### PR TITLE
fix: stabilize tests by managing node lifecycle

### DIFF
--- a/adapter/grpc_test.go
+++ b/adapter/grpc_test.go
@@ -3,7 +3,6 @@ package adapter
 import (
 	"context"
 	"strconv"
-	"strings"
 	"sync"
 	"testing"
 
@@ -164,8 +163,7 @@ func Test_grpc_transaction(t *testing.T) {
 }
 
 func rawKVClient(t *testing.T, hosts []string) pb.RawKVClient {
-	dials := "multi:///" + strings.Join(hosts, ",")
-	conn, err := grpc.NewClient(dials,
+	conn, err := grpc.NewClient(hosts[0],
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 	)
@@ -175,8 +173,7 @@ func rawKVClient(t *testing.T, hosts []string) pb.RawKVClient {
 }
 
 func transactionalKVClient(t *testing.T, hosts []string) pb.TransactionalKVClient {
-	dials := "multi:///" + strings.Join(hosts, ",")
-	conn, err := grpc.NewClient(dials,
+	conn, err := grpc.NewClient(hosts[0],
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 	)

--- a/cmd/server/demo.go
+++ b/cmd/server/demo.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log/slog"
 	"net"
 	"os"
@@ -55,6 +56,8 @@ func main() {
 func run(eg *errgroup.Group) error {
 
 	cfg := raft.Configuration{}
+	ctx := context.Background()
+	var lc net.ListenConfig
 
 	for i := 0; i < 3; i++ {
 		var suffrage raft.ServerSuffrage
@@ -93,7 +96,7 @@ func run(eg *errgroup.Group) error {
 		leaderhealth.Setup(r, s, []string{"RawKV"})
 		raftadmin.Register(s, r)
 
-		grpcSock, err := net.Listen("tcp", grpcAdders[i])
+		grpcSock, err := lc.Listen(ctx, "tcp", grpcAdders[i])
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -102,7 +105,7 @@ func run(eg *errgroup.Group) error {
 			return errors.WithStack(s.Serve(grpcSock))
 		})
 
-		l, err := net.Listen("tcp", redisAdders[i])
+		l, err := lc.Listen(ctx, "tcp", redisAdders[i])
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/main.go
+++ b/main.go
@@ -41,12 +41,14 @@ func main() {
 	}
 
 	ctx := context.Background()
+	var lc net.ListenConfig
+
 	_, port, err := net.SplitHostPort(*myAddr)
 	if err != nil {
 		log.Fatalf("failed to parse local address (%q): %v", *myAddr, err)
 	}
 
-	grpcSock, err := net.Listen("tcp", fmt.Sprintf(":%s", port))
+	grpcSock, err := lc.Listen(ctx, "tcp", fmt.Sprintf(":%s", port))
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}
@@ -72,7 +74,7 @@ func main() {
 	raftadmin.Register(gs, r)
 	reflection.Register(gs)
 
-	redisL, err := net.Listen("tcp", *redisAddr)
+	redisL, err := lc.Listen(ctx, "tcp", *redisAddr)
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}


### PR DESCRIPTION
## Summary
- ensure test nodes shut down raft and transport
- add raft and transport to Node for cleanup
- wait for gRPC/Redis servers and Raft leader before tests run
- replace net.DialTimeout usage with DialContext and Dialer timeout
- use ListenConfig to create gRPC and Redis listeners
- remove redundant ctx redefinition in test helper
- connect test clients to leader node to avoid stale reads
- log transport close errors in test cleanup

## Testing
- `go test ./...` (fails: TestRedis_follower_redirect_node_set_get_deleted)
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6897642fe61c83249418501609499b8d