### PR TITLE
Avoid data race in DynamoDB server

### DIFF
--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -33,18 +33,19 @@ type DynamoDBServer struct {
 }
 
 func NewDynamoDBServer(listen net.Listener, st store.ScanStore, coordinate *kv.Coordinate) *DynamoDBServer {
-	return &DynamoDBServer{
+	d := &DynamoDBServer{
 		listen:           listen,
 		store:            st,
 		coordinator:      coordinate,
 		dynamoTranscoder: newDynamoDBTranscoder(),
 	}
-}
-
-func (d *DynamoDBServer) Run() error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", d.handle)
 	d.httpServer = &http.Server{Handler: mux, ReadHeaderTimeout: time.Second}
+	return d
+}
+
+func (d *DynamoDBServer) Run() error {
 	if err := d.httpServer.Serve(d.listen); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
## Summary
- initialize DynamoDB HTTP server during construction to avoid concurrent read/write
- simplify Run by serving prebuilt HTTP server

## Testing
- `go test ./...`
- `go test -race ./adapter -run Redis_follower_redirect_node_set_get_deleted`
- `go test -race ./adapter` *(fails: consistency check failed in Test_grpc_transaction)*

------
https://chatgpt.com/codex/tasks/task_e_68a488ecca248324939ef2cf1ef6159d