### PR TITLE
Handle Raft apply response errors in transaction manager

### DIFF
--- a/adapter/test_util.go
+++ b/adapter/test_util.go
@@ -243,6 +243,14 @@ func createNode(t *testing.T, n int) ([]Node, []string, []string) {
 		return nodes[0].raft.State() == raft.Leader
 	}, waitTimeout, waitInterval)
 
+	for i := 1; i < len(nodes); i++ {
+		f := nodes[0].raft.AddNonvoter(raft.ServerID(strconv.Itoa(i)), raft.ServerAddress(nodes[i].raftAddress), 0, 0)
+		assert.NoError(t, f.Error())
+		assert.Eventually(t, func() bool {
+			return nodes[i].raft.State() == raft.Follower
+		}, waitTimeout, waitInterval)
+	}
+
 	return nodes, grpcAdders, redisAdders
 }
 


### PR DESCRIPTION
## Summary
- propagate FSM errors from Raft Apply in transaction commits
- surface commit failures instead of proceeding with invalid state
- join nonvoter nodes to the Raft cluster during test setup to ensure nodes are ready

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a48de431b0832497d9256f9c07fd50