### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jepsen-test.yml
+++ b/.github/workflows/jepsen-test.yml
@@ -4,6 +4,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-jepsen-test
 
 name: Jepsen Test
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/bootjp/elastickv/security/code-scanning/10](https://github.com/bootjp/elastickv/security/code-scanning/10)

To fix the problem, add a `permissions` block to the workflow configuration to restrict the default permissions of the GITHUB_TOKEN used in the job. Since the current job (test) does not appear to require write-access to repository contents or other resources, set the permissions to least privilege, e.g., `contents: read`. The best way to implement this is to add the `permissions:` block to the top level of the workflow YAML, just below `name: Jepsen Test` (typically after the `concurrency` block for clarity), or as part of the individual job under `jobs.test`. The standard practice is to add it globally—or per job if more granular control will be necessary in the future.

No methods, imports, or variable definitions are required—just a YAML config edit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
