### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-mod-fix.yaml
+++ b/.github/workflows/go-mod-fix.yaml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   go-mod-fix:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: checkout


### PR DESCRIPTION
Potential fix for [https://github.com/bootjp/elastickv/security/code-scanning/7](https://github.com/bootjp/elastickv/security/code-scanning/7)

To fix the problem, you should add a `permissions` block to the job definition (or at the workflow root) in `.github/workflows/go-mod-fix.yaml`. This block should grant only the minimum required permissions for the job to function. Since the job pushes commits to the repository, it needs `contents: write`. If it does not interact with issues or pull requests, those permissions can be omitted. The best place to add this is directly under the job definition (`go-mod-fix:`), before `runs-on:`. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
