### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,7 @@
 name: Docker Image CI
+permissions:
+  contents: read
+  packages: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/bootjp/elastickv/security/code-scanning/6](https://github.com/bootjp/elastickv/security/code-scanning/6)

The best fix is to add a `permissions` block that grants only the minimum set of required permissions for the job. In this case:

- At a minimum, the job needs `contents: read` for standard repository access.
- Since the workflow logs in and pushes an image to the GitHub Container Registry, it also needs `packages: write`.
- The `permissions` block can be added at the workflow root (to apply to all jobs) or per job (beneath `jobs.build`). Here, both approaches are acceptable; adding it at the root is usually preferable for future clarity and to avoid unintentional privilege escalation in new jobs.
- No external package dependencies are needed; this is a single addition to the YAML configuration.

Add the following block after the workflow `name:` and before `on:`:

```yaml
permissions:
  contents: read
  packages: write
```

No further code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
