### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,6 +11,9 @@ concurrency:
 jobs:
   golangci-lint:
     name: golangci-lint
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory


### PR DESCRIPTION
Potential fix for [https://github.com/bootjp/elastickv/security/code-scanning/4](https://github.com/bootjp/elastickv/security/code-scanning/4)

To fix this problem, we need to add an explicit `permissions` block to the `golangci-lint` job inside the `.github/workflows/golangci-lint.yml` workflow. Based on the nature of the job—which posts PR review annotations via reviewdog—we should grant `contents: read` and `pull-requests: write` permissions, as the workflow posts comments/review results to pull requests. The changes should be applied within the `golangci-lint` job definition (after line 13), specifically before the `steps:` key, so the permissions apply only to this job as recommended.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
