### PR TITLE
test: add property-based coverage for store and adapters

### DIFF
--- a/adapter/dynamodb_property_test.go
+++ b/adapter/dynamodb_property_test.go
@@ -1,0 +1,141 @@
+package adapter
+
+import (
+	"bytes"
+	"encoding/json"
+	"math/rand"
+	"reflect"
+	"testing"
+	"testing/quick"
+
+	"github.com/bootjp/elastickv/kv"
+	"github.com/bootjp/elastickv/store"
+)
+
+type smallString string
+
+type smallStringList []string
+
+func (s smallString) Generate(r *rand.Rand, size int) reflect.Value {
+	length := r.Intn(16)
+	chars := make([]byte, length)
+	for i := range chars {
+		chars[i] = byte('a' + r.Intn(26))
+	}
+	return reflect.ValueOf(smallString(chars))
+}
+
+func (s smallStringList) Generate(r *rand.Rand, size int) reflect.Value {
+	length := r.Intn(6)
+	items := make([]string, 0, length)
+	for i := 0; i < length; i++ {
+		items = append(items, string(smallString("").Generate(r, size).Interface().(smallString)))
+	}
+	return reflect.ValueOf(smallStringList(items))
+}
+
+func TestDynamoDBTranscoderScalarProperty(t *testing.T) {
+	transcoder := newDynamoDBTranscoder()
+
+	property := func(key, value smallString) bool {
+		input := putItemInput{
+			TableName: "table",
+			Item: map[string]attributeValue{
+				"key":   {S: string(key)},
+				"value": {S: string(value)},
+			},
+		}
+		payload, err := json.Marshal(input)
+		if err != nil {
+			return false
+		}
+		group, err := transcoder.PutItemToRequest(payload)
+		if err != nil || group == nil {
+			return false
+		}
+		if group.IsTxn || len(group.Elems) != 1 {
+			return false
+		}
+		elem := group.Elems[0]
+		return elem.Op == kv.Put && bytes.Equal(elem.Key, []byte(key)) && bytes.Equal(elem.Value, []byte(value))
+	}
+
+	if err := quick.Check(property, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDynamoDBTranscoderListProperty(t *testing.T) {
+	transcoder := newDynamoDBTranscoder()
+
+	property := func(key smallString, values smallStringList) bool {
+		if len(values) == 0 {
+			return true
+		}
+		listAttr := make([]attributeValue, 0, len(values))
+		for _, value := range values {
+			listAttr = append(listAttr, attributeValue{S: value})
+		}
+		input := putItemInput{
+			TableName: "table",
+			Item: map[string]attributeValue{
+				"key":   {S: string(key)},
+				"value": {L: listAttr},
+			},
+		}
+		payload, err := json.Marshal(input)
+		if err != nil {
+			return false
+		}
+		group, err := transcoder.PutItemToRequest(payload)
+		if err != nil || group == nil {
+			return false
+		}
+		if !group.IsTxn || len(group.Elems) != len(values)+1 {
+			return false
+		}
+
+		metaKey := store.ListMetaKey([]byte(key))
+		itemValues := make(map[string]string, len(values))
+		for i, value := range values {
+			itemKey := store.ListItemKey([]byte(key), int64(i))
+			itemValues[string(itemKey)] = value
+		}
+
+		var metaFound bool
+		seenItems := 0
+		for _, elem := range group.Elems {
+			switch {
+			case bytes.Equal(elem.Key, metaKey):
+				if elem.Op != kv.Put {
+					return false
+				}
+				meta, err := store.UnmarshalListMeta(elem.Value)
+				if err != nil {
+					return false
+				}
+				if meta.Head != 0 || meta.Tail != int64(len(values)) || meta.Len != int64(len(values)) {
+					return false
+				}
+				metaFound = true
+			case store.IsListItemKey(elem.Key):
+				expected, ok := itemValues[string(elem.Key)]
+				if !ok || elem.Op != kv.Put {
+					return false
+				}
+				if !bytes.Equal(elem.Value, []byte(expected)) {
+					return false
+				}
+				seenItems++
+			default:
+				return false
+			}
+		}
+
+		return metaFound && seenItems == len(values)
+	}
+
+	if err := quick.Check(property, nil); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/adapter/grpc_property_test.go
+++ b/adapter/grpc_property_test.go
@@ -1,0 +1,75 @@
+package adapter
+
+import (
+	"bytes"
+	"testing"
+	"testing/quick"
+
+	"github.com/bootjp/elastickv/kv"
+	pb "github.com/bootjp/elastickv/proto"
+)
+
+func TestGrpcTranscoderProperty(t *testing.T) {
+	transcoder := newGrpcGrpcTranscoder()
+
+	rawPutProperty := func(key, value []byte) bool {
+		group, err := transcoder.RawPutToRequest(&pb.RawPutRequest{Key: key, Value: value})
+		if err != nil || group == nil {
+			return false
+		}
+		if group.IsTxn || len(group.Elems) != 1 {
+			return false
+		}
+		elem := group.Elems[0]
+		return elem.Op == kv.Put && bytes.Equal(elem.Key, key) && bytes.Equal(elem.Value, value)
+	}
+
+	rawDeleteProperty := func(key []byte) bool {
+		group, err := transcoder.RawDeleteToRequest(&pb.RawDeleteRequest{Key: key})
+		if err != nil || group == nil {
+			return false
+		}
+		if group.IsTxn || len(group.Elems) != 1 {
+			return false
+		}
+		elem := group.Elems[0]
+		return elem.Op == kv.Del && bytes.Equal(elem.Key, key)
+	}
+
+	txnPutProperty := func(key, value []byte) bool {
+		group, err := transcoder.TransactionalPutToRequests(&pb.PutRequest{Key: key, Value: value})
+		if err != nil || group == nil {
+			return false
+		}
+		if !group.IsTxn || len(group.Elems) != 1 {
+			return false
+		}
+		elem := group.Elems[0]
+		return elem.Op == kv.Put && bytes.Equal(elem.Key, key) && bytes.Equal(elem.Value, value)
+	}
+
+	txnDeleteProperty := func(key []byte) bool {
+		group, err := transcoder.TransactionalDeleteToRequests(&pb.DeleteRequest{Key: key})
+		if err != nil || group == nil {
+			return false
+		}
+		if !group.IsTxn || len(group.Elems) != 1 {
+			return false
+		}
+		elem := group.Elems[0]
+		return elem.Op == kv.Del && bytes.Equal(elem.Key, key)
+	}
+
+	if err := quick.Check(rawPutProperty, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := quick.Check(rawDeleteProperty, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := quick.Check(txnPutProperty, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := quick.Check(txnDeleteProperty, nil); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/adapter/redis_property_test.go
+++ b/adapter/redis_property_test.go
@@ -1,0 +1,44 @@
+package adapter
+
+import (
+	"bytes"
+	"testing"
+	"testing/quick"
+
+	"github.com/bootjp/elastickv/kv"
+)
+
+func TestRedisTranscoderProperty(t *testing.T) {
+	transcoder := newRedisTranscoder()
+
+	setProperty := func(key, value []byte) bool {
+		group, err := transcoder.SetToRequest(key, value)
+		if err != nil || group == nil {
+			return false
+		}
+		if group.IsTxn || len(group.Elems) != 1 {
+			return false
+		}
+		elem := group.Elems[0]
+		return elem.Op == kv.Put && bytes.Equal(elem.Key, key) && bytes.Equal(elem.Value, value)
+	}
+
+	deleteProperty := func(key []byte) bool {
+		group, err := transcoder.DeleteToRequest(key)
+		if err != nil || group == nil {
+			return false
+		}
+		if group.IsTxn || len(group.Elems) != 1 {
+			return false
+		}
+		elem := group.Elems[0]
+		return elem.Op == kv.Del && bytes.Equal(elem.Key, key)
+	}
+
+	if err := quick.Check(setProperty, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := quick.Check(deleteProperty, nil); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/store/list_helpers_property_test.go
+++ b/store/list_helpers_property_test.go
@@ -1,0 +1,49 @@
+package store
+
+import (
+	"bytes"
+	"math"
+	"testing"
+	"testing/quick"
+)
+
+func TestListMetaRoundTripProperty(t *testing.T) {
+	property := func(head, tail, length uint64) bool {
+		if head > math.MaxInt64 || tail > math.MaxInt64 || length > math.MaxInt64 {
+			return true
+		}
+		meta := ListMeta{Head: int64(head), Tail: int64(tail), Len: int64(length)}
+		encoded, err := MarshalListMeta(meta)
+		if err != nil {
+			return false
+		}
+		decoded, err := UnmarshalListMeta(encoded)
+		if err != nil {
+			return false
+		}
+		return decoded == meta
+	}
+
+	if err := quick.Check(property, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestListKeyExtractionProperty(t *testing.T) {
+	metaProperty := func(userKey []byte) bool {
+		extracted := ExtractListUserKey(ListMetaKey(userKey))
+		return bytes.Equal(extracted, userKey)
+	}
+
+	itemProperty := func(userKey []byte, seq int64) bool {
+		extracted := ExtractListUserKey(ListItemKey(userKey, seq))
+		return bytes.Equal(extracted, userKey)
+	}
+
+	if err := quick.Check(metaProperty, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := quick.Check(itemProperty, nil); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
### Motivation

- Increase randomized coverage for low-level helpers and protocol transcoders by adding property-based tests to catch edge cases in encoding/decoding and request translation.
- Focus on the `store` list helper encodings and adapters for Redis, gRPC, and DynamoDB where small mistakes in transcoders can cause subtle data corruption.

### Description

- Add `store/list_helpers_property_test.go` which property-tests `MarshalListMeta`/`UnmarshalListMeta` round-trips and list key extraction via `ExtractListUserKey`.
- Add `adapter/redis_property_test.go` and `adapter/grpc_property_test.go` which property-test the Redis and gRPC transcoders to validate `OperationGroup` construction for `Put`/`Del` and transactional variants.
- Add `adapter/dynamodb_property_test.go` which property-tests DynamoDB transcoder scalar and list handling using custom `smallString` and `smallStringList` generators and validates list item/meta layout.

### Testing

- No automated tests were executed as part of this change.
- These tests are runnable with `go test ./...` and are designed as property-based checks using the standard `testing/quick` package.
- The changes are test-only and introduce no runtime behavior modifications, minimizing risk.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69660833ce388324b64b8f8c5180708d)