### PR TITLE
jepsen: add S3 linearizable register consistency test

### DIFF
--- a/.github/workflows/jepsen-test.yml
+++ b/.github/workflows/jepsen-test.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Run S3 Jepsen workload against elastickv
         working-directory: jepsen
         run: |
-          ~/lein run -m elastickv.s3-workload --local --time-limit 5 --rate 5 --concurrency 5 --s3-ports 63901,63902,63903 --host 127.0.0.1
+          ~/lein run -m elastickv.s3-workload --local --time-limit 5 --rate 10 --concurrency 10 --s3-ports 63901,63902,63903 --host 127.0.0.1
       - name: Stop demo cluster
         run: |
           if [ -f /tmp/elastickv-demo.pid ]; then

--- a/.github/workflows/jepsen-test.yml
+++ b/.github/workflows/jepsen-test.yml
@@ -46,10 +46,11 @@ jobs:
           nohup go run cmd/server/demo.go > /tmp/elastickv-demo.log 2>&1 &
           echo $! > /tmp/elastickv-demo.pid
 
-          echo "Waiting for redis (63791-63793) and dynamo (63801-63803) listeners..."
+          echo "Waiting for redis (63791-63793), dynamo (63801-63803), and s3 (63901-63903) listeners..."
           for i in {1..90}; do
             if nc -z 127.0.0.1 63791 && nc -z 127.0.0.1 63792 && nc -z 127.0.0.1 63793 \
-              && nc -z 127.0.0.1 63801 && nc -z 127.0.0.1 63802 && nc -z 127.0.0.1 63803; then
+              && nc -z 127.0.0.1 63801 && nc -z 127.0.0.1 63802 && nc -z 127.0.0.1 63803 \
+              && nc -z 127.0.0.1 63901 && nc -z 127.0.0.1 63902 && nc -z 127.0.0.1 63903; then
               echo "Cluster is up"
               exit 0
             fi
@@ -67,6 +68,10 @@ jobs:
         working-directory: jepsen
         run: |
           ~/lein run -m elastickv.dynamodb-workload --local --time-limit 5 --rate 5 --concurrency 5 --dynamo-ports 63801,63802,63803 --host 127.0.0.1
+      - name: Run S3 Jepsen workload against elastickv
+        working-directory: jepsen
+        run: |
+          ~/lein run -m elastickv.s3-workload --local --time-limit 5 --rate 5 --concurrency 5 --s3-ports 63901,63902,63903 --host 127.0.0.1
       - name: Stop demo cluster
         run: |
           if [ -f /tmp/elastickv-demo.pid ]; then

--- a/.github/workflows/jepsen.yml
+++ b/.github/workflows/jepsen.yml
@@ -69,6 +69,21 @@ jobs:
               --faults ${{ github.event.inputs['faults'] || github.event.inputs.faults }} \
               --concurrency 10"
 
+      - name: Run S3 Jepsen workload
+        working-directory: jepsen
+        env:
+          HOME: ${{ github.workspace }}/jepsen/tmp-home
+          LEIN_HOME: ${{ github.workspace }}/jepsen/.lein
+          LEIN_JVM_OPTS: -Duser.home=${{ github.workspace }}/jepsen/tmp-home
+        run: |
+          vagrant ssh ctrl -c "cd ~/elastickv/jepsen && \
+            lein run -m elastickv.s3-workload \
+              --nodes n1,n2,n3,n4,n5 \
+              --time-limit ${{ github.event.inputs['time-limit'] || github.event.inputs.time-limit }} \
+              --rate ${{ github.event.inputs['rate'] || github.event.inputs.rate }} \
+              --faults ${{ github.event.inputs['faults'] || github.event.inputs.faults }} \
+              --concurrency 10"
+
       - name: Collect Jepsen artifacts
         if: always()
         working-directory: jepsen

--- a/jepsen/src/elastickv/db.clj
+++ b/jepsen/src/elastickv/db.clj
@@ -97,7 +97,7 @@
          (clojure.string/join ","))))
 
 (defn- start-node!
-  [test node {:keys [bootstrap-node grpc-port redis-port dynamo-port data-dir raft-groups shard-ranges]}]
+  [test node {:keys [bootstrap-node grpc-port redis-port dynamo-port s3-port data-dir raft-groups shard-ranges]}]
   (when (and (seq raft-groups)
              (> (count raft-groups) 1)
              (nil? shard-ranges))
@@ -108,6 +108,8 @@
         redis (node-addr node (port-for redis-port node))
         dynamo (when dynamo-port
                  (node-addr node (port-for dynamo-port node)))
+        s3 (when s3-port
+             (node-addr node (port-for s3-port node)))
         raft-redis-map (build-raft-redis-map (:nodes test) grpc-port redis-port raft-groups)
         bootstrap? (= node bootstrap-node)
         args (cond-> [server-bin
@@ -117,6 +119,7 @@
                       "--raftDataDir" data-dir
                       "--raftRedisMap" raft-redis-map]
                dynamo (conj "--dynamoAddress" dynamo)
+               s3 (conj "--s3Address" s3)
                (seq raft-groups) (conj "--raftGroups" (build-raft-groups-arg node raft-groups))
                (seq shard-ranges) (conj "--shardRanges" shard-ranges)
                bootstrap? (conj "--raftBootstrap"))]

--- a/jepsen/src/elastickv/jepsen_test.clj
+++ b/jepsen/src/elastickv/jepsen_test.clj
@@ -2,6 +2,7 @@
   (:gen-class)
   (:require [elastickv.redis-workload :as redis-workload]
             [elastickv.dynamodb-workload :as dynamodb-workload]
+            [elastickv.s3-workload :as s3-workload]
             [jepsen.cli :as cli]))
 
 (defn elastickv-test []
@@ -9,6 +10,9 @@
 
 (defn elastickv-dynamodb-test []
   (dynamodb-workload/elastickv-dynamodb-test {}))
+
+(defn elastickv-s3-test []
+  (s3-workload/elastickv-s3-test {}))
 
 (defn -main
   [& args]

--- a/jepsen/src/elastickv/s3_workload.clj
+++ b/jepsen/src/elastickv/s3_workload.clj
@@ -6,7 +6,6 @@
    linearizable history of writes."
   (:gen-class)
   (:require [clojure.string :as str]
-            [clojure.tools.logging :refer [warn]]
             [clj-http.client :as http]
             [elastickv.cli :as cli]
             [elastickv.db :as ekdb]
@@ -29,6 +28,7 @@
 ;; ---------------------------------------------------------------------------
 
 (def ^:private bucket-name "jepsen-test")
+(def ^:private default-s3-port 9000)
 
 ;; ---------------------------------------------------------------------------
 ;; S3 HTTP helpers
@@ -82,28 +82,6 @@
       (throw (ex-info (str "S3 GET error: HTTP " (:status resp))
                       {:status (:status resp) :body (:body resp)})))))
 
-(defn- s3-delete!
-  "DELETE an object. Returns nil."
-  [base-url k]
-  (http/delete (object-url base-url k)
-               {:throw-exceptions false
-                :conn-timeout     5000
-                :socket-timeout   10000})
-  nil)
-
-(defn- s3-list
-  "List object keys in the test bucket. Returns a set of key strings."
-  [base-url]
-  (let [resp (http/get (str base-url "/" bucket-name "?list-type=2&max-keys=1000")
-                       {:throw-exceptions false
-                        :as               :string
-                        :conn-timeout     5000
-                        :socket-timeout   10000})]
-    (when (= 200 (:status resp))
-      (->> (re-seq #"<Key>([^<]+)</Key>" (:body resp))
-           (map second)
-           set))))
-
 ;; ---------------------------------------------------------------------------
 ;; Jepsen client
 ;; ---------------------------------------------------------------------------
@@ -111,7 +89,7 @@
 (defrecord S3Client [node->port url]
   client/Client
   (open! [this test node]
-    (let [port (get node->port node 9000)
+    (let [port (get node->port node default-s3-port)
           host (or (:s3-host test) (name node))]
       (assoc this :url (s3-base-url host port))))
 
@@ -170,7 +148,7 @@
         max-writes      (or (:max-writes-per-key opts) 100)
         threads-per-key (or (:threads-per-key opts) 2)
         client          (->S3Client (or (:node->port opts)
-                                        (zipmap default-nodes (repeat 9000)))
+                                        (zipmap default-nodes (repeat default-s3-port)))
                                     nil)]
     {:client    client
      :generator (independent/concurrent-generator
@@ -178,7 +156,7 @@
                   (range key-count)
                   (fn [_k]
                     (->> (gen/mix [(map (fn [v] {:f :write :value v}) (range))
-                                  (repeat {:f :read})])
+                                  (gen/repeat {:f :read})])
                          (gen/limit max-writes))))
      :checker   (independent/checker
                   (checker/compose
@@ -193,7 +171,7 @@
   ([] (elastickv-s3-test {}))
   ([opts]
    (let [nodes      (or (:nodes opts) default-nodes)
-         s3-ports   (or (:s3-ports opts) (repeat (count nodes) (or (:s3-port opts) 9000)))
+         s3-ports   (or (:s3-ports opts) (repeat (count nodes) (or (:s3-port opts) default-s3-port)))
          node->port (or (:node->port opts) (cli/ports->node-map s3-ports nodes))
          local?     (:local opts)
          db         (if local?
@@ -252,7 +230,7 @@
                      (remove str/blank?)
                      (mapv #(Integer/parseInt %))))]
    [nil "--s3-port PORT" "S3 port (applied to all nodes)."
-    :default 9000
+    :default default-s3-port
     :parse-fn #(Integer/parseInt %)]
    [nil "--redis-port PORT" "Redis port."
     :default 6379

--- a/jepsen/src/elastickv/s3_workload.clj
+++ b/jepsen/src/elastickv/s3_workload.clj
@@ -159,16 +159,22 @@
 (defn s3-register-workload
   "Builds a linearizable-register workload targeting the S3 endpoint.
    Each independent key is an S3 object; the checker verifies linearizability
-   of the write/read history per key."
+   of the write/read history per key.
+
+   threads-per-key controls how many concurrent threads hammer each key
+   simultaneously. The test-level :concurrency divided by threads-per-key
+   determines how many keys are active at once (e.g. concurrency=10,
+   threads-per-key=2 → 5 keys active, each with 2 concurrent threads)."
   [opts]
   (let [key-count       (or (:key-count opts) 10)
         max-writes      (or (:max-writes-per-key opts) 100)
+        threads-per-key (or (:threads-per-key opts) 2)
         client          (->S3Client (or (:node->port opts)
                                         (zipmap default-nodes (repeat 9000)))
                                     nil)]
     {:client    client
      :generator (independent/concurrent-generator
-                  (or (:concurrency opts) 5)
+                  threads-per-key
                   (range key-count)
                   (fn [_k]
                     (->> (gen/mix [(map (fn [v] {:f :write :value v}) (range))
@@ -227,7 +233,7 @@
                                 (:nemesis nemesis-p)
                                 nemesis/noop)
              :final-generator nil
-             :concurrency     (or (:concurrency opts) 5)
+             :concurrency     (or (:concurrency opts) 10)
              :generator       (->> (:generator workload)
                                    (gen/nemesis nemesis-gen)
                                    (gen/stagger (/ rate))
@@ -250,6 +256,9 @@
     :parse-fn #(Integer/parseInt %)]
    [nil "--redis-port PORT" "Redis port."
     :default 6379
+    :parse-fn #(Integer/parseInt %)]
+   [nil "--threads-per-key N" "Concurrent threads per S3 object key."
+    :default 2
     :parse-fn #(Integer/parseInt %)]])
 
 (defn- prepare-s3-opts
@@ -261,10 +270,11 @@
                      (cli/ports->node-map s3-ports (:nodes options))
                      (zipmap (:nodes options) (repeat (:s3-port options))))]
     (assoc options
-      :s3-host    (:host options)
-      :node->port node->port
-      :s3-port    (:s3-port options)
-      :redis-port (:redis-port options))))
+      :s3-host         (:host options)
+      :node->port      node->port
+      :s3-port         (:s3-port options)
+      :redis-port      (:redis-port options)
+      :threads-per-key (:threads-per-key options))))
 
 (defn -main
   [& args]

--- a/jepsen/src/elastickv/s3_workload.clj
+++ b/jepsen/src/elastickv/s3_workload.clj
@@ -1,0 +1,274 @@
+(ns elastickv.s3-workload
+  "Jepsen workload for elastickv's S3-compatible API.
+   Uses a linearizable register model: each S3 object is an independent
+   register.  Writes PUT a value as the object body; reads GET the object
+   body.  The checker verifies that every read is consistent with a
+   linearizable history of writes."
+  (:gen-class)
+  (:require [clojure.string :as str]
+            [clojure.tools.logging :refer [warn]]
+            [clj-http.client :as http]
+            [elastickv.cli :as cli]
+            [elastickv.db :as ekdb]
+            [jepsen [checker :as checker]
+                    [client :as client]
+                    [generator :as gen]
+                    [independent :as independent]
+                    [net :as net]]
+            [jepsen.checker.timeline :as timeline]
+            [jepsen.control :as control]
+            [jepsen.db :as jdb]
+            [jepsen.nemesis :as nemesis]
+            [knossos.model :as model]
+            [jepsen.nemesis.combined :as combined]
+            [jepsen.os :as os]
+            [jepsen.os.debian :as debian]))
+
+;; ---------------------------------------------------------------------------
+;; Constants
+;; ---------------------------------------------------------------------------
+
+(def ^:private bucket-name "jepsen-test")
+
+;; ---------------------------------------------------------------------------
+;; S3 HTTP helpers
+;; ---------------------------------------------------------------------------
+
+(defn- s3-base-url
+  "Returns the base URL for the S3 endpoint on a given node and port."
+  [node port]
+  (str "http://" (name node) ":" port))
+
+(defn- object-url
+  "URL for an individual object in the test bucket."
+  [base-url k]
+  (str base-url "/" bucket-name "/key-" k))
+
+(defn- create-bucket!
+  "Create the test bucket. Ignores BucketAlreadyOwnedByYou (409)."
+  [base-url]
+  (let [resp (http/put (str base-url "/" bucket-name)
+                       {:throw-exceptions false
+                        :conn-timeout     5000
+                        :socket-timeout   10000})]
+    (when (and (>= (:status resp) 400)
+               (not= 409 (:status resp)))
+      (throw (ex-info (str "Failed to create bucket: HTTP " (:status resp))
+                      {:status (:status resp) :body (:body resp)})))))
+
+(defn- s3-put!
+  "PUT an object with the given integer value as the body. Returns nil."
+  [base-url k v]
+  (http/put (object-url base-url k)
+            {:body              (str v)
+             :content-type      "text/plain"
+             :throw-exceptions  true
+             :conn-timeout      5000
+             :socket-timeout    10000})
+  nil)
+
+(defn- s3-get
+  "GET an object and parse the body as a long. Returns nil when the object
+   does not exist (404). Throws on unexpected status codes."
+  [base-url k]
+  (let [resp (http/get (object-url base-url k)
+                       {:throw-exceptions false
+                        :as               :string
+                        :conn-timeout     5000
+                        :socket-timeout   10000})]
+    (case (int (:status resp))
+      200 (Long/parseLong (str/trim (:body resp)))
+      404 nil
+      (throw (ex-info (str "S3 GET error: HTTP " (:status resp))
+                      {:status (:status resp) :body (:body resp)})))))
+
+(defn- s3-delete!
+  "DELETE an object. Returns nil."
+  [base-url k]
+  (http/delete (object-url base-url k)
+               {:throw-exceptions false
+                :conn-timeout     5000
+                :socket-timeout   10000})
+  nil)
+
+(defn- s3-list
+  "List object keys in the test bucket. Returns a set of key strings."
+  [base-url]
+  (let [resp (http/get (str base-url "/" bucket-name "?list-type=2&max-keys=1000")
+                       {:throw-exceptions false
+                        :as               :string
+                        :conn-timeout     5000
+                        :socket-timeout   10000})]
+    (when (= 200 (:status resp))
+      (->> (re-seq #"<Key>([^<]+)</Key>" (:body resp))
+           (map second)
+           set))))
+
+;; ---------------------------------------------------------------------------
+;; Jepsen client
+;; ---------------------------------------------------------------------------
+
+(defrecord S3Client [node->port url]
+  client/Client
+  (open! [this test node]
+    (let [port (get node->port node 9000)
+          host (or (:s3-host test) (name node))]
+      (assoc this :url (s3-base-url host port))))
+
+  (setup! [this _test]
+    (create-bucket! url))
+
+  (teardown! [_this _test])
+
+  (close! [this _test]
+    (assoc this :url nil))
+
+  (invoke! [_this _test op]
+    (try
+      (let [[k v] (:value op)]
+        (case (:f op)
+          :write
+          (do (s3-put! url k v)
+              (assoc op :type :ok))
+
+          :read
+          (let [val (s3-get url k)]
+            (assoc op :type :ok :value (independent/tuple k val)))))
+      (catch java.net.ConnectException _
+        (assoc op :type :info :error :connection-refused))
+      (catch java.net.SocketTimeoutException _
+        (assoc op :type :info :error :socket-timeout))
+      (catch java.net.SocketException e
+        (assoc op :type :info :error (str "socket: " (.getMessage e))))
+      (catch org.apache.http.NoHttpResponseException _
+        (assoc op :type :info :error :no-http-response))
+      (catch clojure.lang.ExceptionInfo e
+        (let [data (ex-data e)]
+          (if (and (:status data) (>= (int (:status data)) 500))
+            (assoc op :type :info :error (str "HTTP " (:status data)))
+            (assoc op :type :info :error (.getMessage e)))))
+      (catch Exception e
+        (assoc op :type :info :error (.getMessage e))))))
+
+;; ---------------------------------------------------------------------------
+;; Workload & Test builders
+;; ---------------------------------------------------------------------------
+
+(def default-nodes ["n1" "n2" "n3" "n4" "n5"])
+
+(defn s3-register-workload
+  "Builds a linearizable-register workload targeting the S3 endpoint.
+   Each independent key is an S3 object; the checker verifies linearizability
+   of the write/read history per key."
+  [opts]
+  (let [key-count       (or (:key-count opts) 10)
+        max-writes      (or (:max-writes-per-key opts) 100)
+        client          (->S3Client (or (:node->port opts)
+                                        (zipmap default-nodes (repeat 9000)))
+                                    nil)]
+    {:client    client
+     :generator (independent/concurrent-generator
+                  (or (:concurrency opts) 5)
+                  (range key-count)
+                  (fn [_k]
+                    (->> (gen/mix [(map (fn [v] {:f :write :value v}) (range))
+                                  (repeat {:f :read})])
+                         (gen/limit max-writes))))
+     :checker   (independent/checker
+                  (checker/compose
+                    {:linear   (checker/linearizable
+                                 {:model     (model/register)
+                                  :algorithm :linear})
+                     :timeline (timeline/html)}))}))
+
+(defn elastickv-s3-test
+  "Builds a Jepsen test map that drives elastickv's S3-compatible API
+   with the linearizable register workload."
+  ([] (elastickv-s3-test {}))
+  ([opts]
+   (let [nodes      (or (:nodes opts) default-nodes)
+         s3-ports   (or (:s3-ports opts) (repeat (count nodes) (or (:s3-port opts) 9000)))
+         node->port (or (:node->port opts) (cli/ports->node-map s3-ports nodes))
+         local?     (:local opts)
+         db         (if local?
+                      jdb/noop
+                      (ekdb/db {:grpc-port    (or (:grpc-port opts) 50051)
+                                :redis-port   (or (:redis-port opts) 6379)
+                                :s3-port      node->port
+                                :raft-groups  (:raft-groups opts)
+                                :shard-ranges (:shard-ranges opts)}))
+         rate       (double (or (:rate opts) 5))
+         time-limit (or (:time-limit opts) 30)
+         faults     (if local?
+                      []
+                      (cli/normalize-faults (or (:faults opts) [:partition :kill])))
+         nemesis-p  (when-not local?
+                      (combined/nemesis-package {:db       db
+                                                 :faults   faults
+                                                 :interval (or (:fault-interval opts) 40)}))
+         nemesis-gen (if nemesis-p
+                       (:generator nemesis-p)
+                       (gen/once {:type :info :f :noop}))
+         workload   (s3-register-workload (assoc opts :node->port node->port))]
+     (merge workload
+            {:name            (or (:name opts) "elastickv-s3-register")
+             :nodes           nodes
+             :db              db
+             :s3-host         (:s3-host opts)
+             :os              (if local? os/noop debian/os)
+             :net             (if local? net/noop net/iptables)
+             :ssh             (merge {:username                  "vagrant"
+                                      :private-key-path          "/home/vagrant/.ssh/id_rsa"
+                                      :strict-host-key-checking  false}
+                                     (when local? {:dummy true})
+                                     (:ssh opts))
+             :remote          control/ssh
+             :nemesis         (if nemesis-p
+                                (:nemesis nemesis-p)
+                                nemesis/noop)
+             :final-generator nil
+             :concurrency     (or (:concurrency opts) 5)
+             :generator       (->> (:generator workload)
+                                   (gen/nemesis nemesis-gen)
+                                   (gen/stagger (/ rate))
+                                   (gen/time-limit time-limit))}))))
+
+;; ---------------------------------------------------------------------------
+;; CLI
+;; ---------------------------------------------------------------------------
+
+(def s3-cli-opts
+  "S3-specific CLI options, appended to common opts."
+  [[nil "--s3-ports PORTS" "Comma separated S3 ports (per node)."
+    :default nil
+    :parse-fn (fn [s]
+                (->> (str/split s #",")
+                     (remove str/blank?)
+                     (mapv #(Integer/parseInt %))))]
+   [nil "--s3-port PORT" "S3 port (applied to all nodes)."
+    :default 9000
+    :parse-fn #(Integer/parseInt %)]
+   [nil "--redis-port PORT" "Redis port."
+    :default 6379
+    :parse-fn #(Integer/parseInt %)]])
+
+(defn- prepare-s3-opts
+  "Transform parsed CLI options into the map expected by elastickv-s3-test."
+  [options]
+  (let [s3-ports (:s3-ports options)
+        options  (cli/parse-common-opts options s3-ports)
+        node->port (if s3-ports
+                     (cli/ports->node-map s3-ports (:nodes options))
+                     (zipmap (:nodes options) (repeat (:s3-port options))))]
+    (assoc options
+      :s3-host    (:host options)
+      :node->port node->port
+      :s3-port    (:s3-port options)
+      :redis-port (:redis-port options))))
+
+(defn -main
+  [& args]
+  (cli/run-workload! args
+                     (into cli/common-cli-opts s3-cli-opts)
+                     prepare-s3-opts
+                     elastickv-s3-test))

--- a/jepsen/test/elastickv/s3_workload_test.clj
+++ b/jepsen/test/elastickv/s3_workload_test.clj
@@ -10,12 +10,16 @@
     (is (= "elastickv-s3-register" (:name test-map)))
     (is (= ["n1" "n2" "n3" "n4" "n5"] (:nodes test-map)))))
 
+(deftest default-concurrency-is-10
+  (let [test-map (workload/elastickv-s3-test {})]
+    (is (= 10 (:concurrency test-map)))))
+
 (deftest custom-options-override-defaults
   (let [test-map (workload/elastickv-s3-test
                    {:time-limit  60
-                    :concurrency 10
+                    :concurrency 20
                     :s3-port     9999})]
-    (is (= 10 (:concurrency test-map)))))
+    (is (= 20 (:concurrency test-map)))))
 
 (deftest host-override-uses-provided-host
   (let [test-map (workload/elastickv-s3-test

--- a/jepsen/test/elastickv/s3_workload_test.clj
+++ b/jepsen/test/elastickv/s3_workload_test.clj
@@ -1,0 +1,26 @@
+(ns elastickv.s3-workload-test
+  (:require [clojure.test :refer :all]
+            [jepsen.client :as client]
+            [elastickv.cli :as cli]
+            [elastickv.s3-workload :as workload]))
+
+(deftest builds-test-spec
+  (let [test-map (workload/elastickv-s3-test {})]
+    (is (map? test-map))
+    (is (= "elastickv-s3-register" (:name test-map)))
+    (is (= ["n1" "n2" "n3" "n4" "n5"] (:nodes test-map)))))
+
+(deftest custom-options-override-defaults
+  (let [test-map (workload/elastickv-s3-test
+                   {:time-limit  60
+                    :concurrency 10
+                    :s3-port     9999})]
+    (is (= 10 (:concurrency test-map)))))
+
+(deftest host-override-uses-provided-host
+  (let [test-map (workload/elastickv-s3-test
+                   {:s3-host "127.0.0.1"
+                    :node->port {"n1" 9000 "n2" 9001}})
+        c        (:client test-map)
+        opened   (client/open! c test-map "n1")]
+    (is (re-find #"http://127\.0\.0\.1:9000" (:url opened)))))


### PR DESCRIPTION
Add Jepsen workload that verifies S3-like strong read-after-write consistency using a linearizable register model. Each S3 object is treated as an independent register; the knossos checker verifies all reads are consistent with a linear ordering of writes under network partitions, process kills, and clock skew.

- s3_workload.clj: S3 client + register workload + CLI
- db.clj: pass --s3Address to server startup
- jepsen_test.clj: expose elastickv-s3-test entry point
- CI: run S3 workload in both jepsen-test and jepsen workflows