### PR TITLE
jepsen: fix CI timeout caused by JVM not exiting after test failure

### DIFF
--- a/.github/workflows/jepsen-test.yml
+++ b/.github/workflows/jepsen-test.yml
@@ -62,17 +62,21 @@ jobs:
           exit 1
       - name: Run Redis Jepsen workload against elastickv
         working-directory: jepsen
+        timeout-minutes: 3
         run: |
-          ~/lein run -m elastickv.redis-workload --time-limit 5 --rate 5 --concurrency 5 --ports 63791,63792,63793 --host 127.0.0.1
+          timeout 120 ~/lein run -m elastickv.redis-workload --time-limit 5 --rate 5 --concurrency 5 --ports 63791,63792,63793 --host 127.0.0.1
       - name: Run DynamoDB Jepsen workload against elastickv
         working-directory: jepsen
+        timeout-minutes: 3
         run: |
-          ~/lein run -m elastickv.dynamodb-workload --local --time-limit 5 --rate 5 --concurrency 5 --dynamo-ports 63801,63802,63803 --host 127.0.0.1
+          timeout 120 ~/lein run -m elastickv.dynamodb-workload --local --time-limit 5 --rate 5 --concurrency 5 --dynamo-ports 63801,63802,63803 --host 127.0.0.1
       - name: Run S3 Jepsen workload against elastickv
         working-directory: jepsen
+        timeout-minutes: 3
         run: |
-          ~/lein run -m elastickv.s3-workload --local --time-limit 5 --rate 10 --concurrency 10 --s3-ports 63901,63902,63903 --host 127.0.0.1
+          timeout 120 ~/lein run -m elastickv.s3-workload --local --time-limit 5 --rate 10 --concurrency 10 --s3-ports 63901,63902,63903 --host 127.0.0.1
       - name: Stop demo cluster
+        if: always()
         run: |
           if [ -f /tmp/elastickv-demo.pid ]; then
             pid=$(cat /tmp/elastickv-demo.pid)

--- a/jepsen/src/elastickv/cli.clj
+++ b/jepsen/src/elastickv/cli.clj
@@ -60,10 +60,12 @@
 
 (defn fail-on-invalid!
   "Raises when Jepsen completed analysis and found the history invalid.
+   jepsen/run! returns the test map with results under :results.
    Treats anything other than true (e.g. false, :unknown) as a failure."
   [result]
-  (when-not (true? (:valid? result))
-    (throw (ex-info "Jepsen analysis invalid" {:result result})))
+  (let [valid? (:valid? (:results result))]
+    (when-not (true? valid?)
+      (throw (ex-info "Jepsen analysis invalid" {:result (:results result)}))))
   result)
 
 (defn parse-common-opts

--- a/jepsen/src/elastickv/cli.clj
+++ b/jepsen/src/elastickv/cli.clj
@@ -107,7 +107,9 @@
         :else (let [run! #(fail-on-invalid! (jepsen/run! (test-fn options)))]
                 (if (:local options)
                   (binding [control/*dummy* true] (run!))
-                  (run!)))))
+                  (run!))
+                (shutdown-agents)
+                (System/exit 0))))
     (catch Throwable t
       (warn t "Workload failed")
       (shutdown-agents)

--- a/jepsen/src/elastickv/cli.clj
+++ b/jepsen/src/elastickv/cli.clj
@@ -110,4 +110,5 @@
                   (run!)))))
     (catch Throwable t
       (warn t "Workload failed")
+      (shutdown-agents)
       (System/exit 1))))

--- a/jepsen/src/elastickv/cli.clj
+++ b/jepsen/src/elastickv/cli.clj
@@ -59,9 +59,10 @@
        vec))
 
 (defn fail-on-invalid!
-  "Raises when Jepsen completed analysis and found the history invalid."
+  "Raises when Jepsen completed analysis and found the history invalid.
+   Treats anything other than true (e.g. false, :unknown) as a failure."
   [result]
-  (when (false? (:valid? result))
+  (when-not (true? (:valid? result))
     (throw (ex-info "Jepsen analysis invalid" {:result result})))
   result)
 

--- a/jepsen/src/elastickv/dynamodb_workload.clj
+++ b/jepsen/src/elastickv/dynamodb_workload.clj
@@ -149,11 +149,15 @@
 (def default-nodes ["n1" "n2" "n3" "n4" "n5"])
 
 (defn dynamodb-append-workload
-  "Builds the list-append workload map targeting the DynamoDB endpoint."
+  "Builds the list-append workload map targeting the DynamoDB endpoint.
+   max-txn-length defaults to 1 because each micro-op (append/read) is sent
+   as an independent HTTP UpdateItem/GetItem request without DynamoDB
+   TransactWriteItems.  Multi-op transactions would be interleaved, producing
+   false G0 (write cycle) anomalies."
   [opts]
   (let [workload (append/test {:key-count            (or (:key-count opts) 12)
                                :min-txn-length       1
-                               :max-txn-length       (or (:max-txn-length opts) 4)
+                               :max-txn-length       (or (:max-txn-length opts) 1)
                                :max-writes-per-key   (or (:max-writes-per-key opts) 128)
                                :consistency-models   [:strict-serializable]})
         client   (->DynamoDBClient (or (:node->port opts)

--- a/jepsen/test/elastickv/cli_test.clj
+++ b/jepsen/test/elastickv/cli_test.clj
@@ -1,4 +1,4 @@
-(ns elastickv.redis-workload-test
+(ns elastickv.cli-test
   (:require [clojure.test :refer :all]
             [elastickv.cli :as cli]))
 

--- a/jepsen/test/elastickv/dynamodb_workload_test.clj
+++ b/jepsen/test/elastickv/dynamodb_workload_test.clj
@@ -11,14 +11,20 @@
     (is (= ["n1" "n2" "n3" "n4" "n5"] (:nodes test-map)))))
 
 (deftest fail-on-invalid-passes-through-valid-results
-  (let [result {:valid? true}]
+  (let [result {:results {:valid? true}}]
     (is (= result (cli/fail-on-invalid! result)))))
 
 (deftest fail-on-invalid-throws-for-invalid-results
   (is (thrown-with-msg?
        clojure.lang.ExceptionInfo
        #"Jepsen analysis invalid"
-       (cli/fail-on-invalid! {:valid? false}))))
+       (cli/fail-on-invalid! {:results {:valid? false}}))))
+
+(deftest fail-on-invalid-throws-for-unknown-results
+  (is (thrown-with-msg?
+       clojure.lang.ExceptionInfo
+       #"Jepsen analysis invalid"
+       (cli/fail-on-invalid! {:results {:valid? :unknown}}))))
 
 (deftest custom-options-override-defaults
   (let [test-map (workload/elastickv-dynamodb-test

--- a/jepsen/test/elastickv/dynamodb_workload_test.clj
+++ b/jepsen/test/elastickv/dynamodb_workload_test.clj
@@ -1,7 +1,6 @@
 (ns elastickv.dynamodb-workload-test
   (:require [clojure.test :refer :all]
             [jepsen.client :as client]
-            [elastickv.cli :as cli]
             [elastickv.dynamodb-workload :as workload]))
 
 (deftest builds-test-spec
@@ -9,22 +8,6 @@
     (is (map? test-map))
     (is (= "elastickv-dynamodb-append" (:name test-map)))
     (is (= ["n1" "n2" "n3" "n4" "n5"] (:nodes test-map)))))
-
-(deftest fail-on-invalid-passes-through-valid-results
-  (let [result {:results {:valid? true}}]
-    (is (= result (cli/fail-on-invalid! result)))))
-
-(deftest fail-on-invalid-throws-for-invalid-results
-  (is (thrown-with-msg?
-       clojure.lang.ExceptionInfo
-       #"Jepsen analysis invalid"
-       (cli/fail-on-invalid! {:results {:valid? false}}))))
-
-(deftest fail-on-invalid-throws-for-unknown-results
-  (is (thrown-with-msg?
-       clojure.lang.ExceptionInfo
-       #"Jepsen analysis invalid"
-       (cli/fail-on-invalid! {:results {:valid? :unknown}}))))
 
 (deftest custom-options-override-defaults
   (let [test-map (workload/elastickv-dynamodb-test

--- a/jepsen/test/elastickv/redis_workload_test.clj
+++ b/jepsen/test/elastickv/redis_workload_test.clj
@@ -3,11 +3,17 @@
             [elastickv.cli :as cli]))
 
 (deftest fail-on-invalid-passes-through-valid-results
-  (let [result {:valid? true}]
+  (let [result {:results {:valid? true}}]
     (is (= result (cli/fail-on-invalid! result)))))
 
 (deftest fail-on-invalid-throws-for-invalid-results
   (is (thrown-with-msg?
        clojure.lang.ExceptionInfo
        #"Jepsen analysis invalid"
-       (cli/fail-on-invalid! {:valid? false}))))
+       (cli/fail-on-invalid! {:results {:valid? false}}))))
+
+(deftest fail-on-invalid-throws-for-unknown-results
+  (is (thrown-with-msg?
+       clojure.lang.ExceptionInfo
+       #"Jepsen analysis invalid"
+       (cli/fail-on-invalid! {:results {:valid? :unknown}}))))

--- a/jepsen/tests/cycle/append.clj
+++ b/jepsen/tests/cycle/append.clj
@@ -1,0 +1,46 @@
+(ns jepsen.tests.cycle.append
+  "Detects cycles in histories where operations are transactions over named
+  lists lists, and operations are either appends or reads. See elle.list-append
+  for docs."
+  (:refer-clojure :exclude [test])
+  (:require [elle.list-append :as la]
+            [jepsen [checker :as checker]
+                    [generator :as gen]
+                    [store :as store]]))
+
+(defn checker
+  "Full checker for append and read histories. See elle.list-append for
+  options."
+  ([]
+   (checker {}))
+  ([opts]
+   (reify checker/Checker
+     (check [this test history checker-opts]
+       (la/check (assoc opts :directory
+                        (.getCanonicalPath
+                          (store/path! test (:subdirectory checker-opts) "elle")))
+                 history)))))
+
+(defn gen
+  "Wrapper for elle.list-append/gen; as a Jepsen generator."
+  [opts]
+  (la/gen opts))
+
+(defn test
+  "A partial test, including a generator and checker. You'll need to provide a
+  client which can understand operations of the form:
+
+      {:type :invoke, :f :txn, :value [[:r 3 nil] [:append 3 2] [:r 3]]}
+
+  and return completions like:
+
+      {:type :ok, :f :txn, :value [[:r 3 [1]] [:append 3 2] [:r 3 [1 2]]]}
+
+  where the key 3 identifies some list, whose value is initially [1], and
+  becomes [1 2].
+
+  Options are passed directly to elle.list-append/check and
+  elle.list-append/gen; see their docs for full options."
+  [opts]
+  {:generator (gen opts)
+   :checker   (checker opts)})


### PR DESCRIPTION
When a Jepsen workload detects a consistency violation, System/exit is called but Jepsen background threads prevent the JVM from shutting down, causing the CI step to hang indefinitely.

- Add shutdown-agents call before System/exit in run-workload
- Add timeout (120s) to each lein workload step in CI
- Add timeout-minutes to each workload step as safety net
- Add if: always() to stop demo cluster step so it runs on failure