### PR TITLE
fix: broadcast DEL_PREFIX to all shard groups in ShardedCoordinator

### DIFF
--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -140,12 +140,13 @@ func (c *ShardedCoordinator) dispatchDelPrefixBroadcast(isTxn bool, elems []*Ele
 		return nil, err
 	}
 
+	ts := c.clock.Next()
 	requests := make([]*pb.Request, 0, len(elems))
 	for _, elem := range elems {
 		requests = append(requests, &pb.Request{
 			IsTxn:     false,
 			Phase:     pb.Phase_NONE,
-			Ts:        c.clock.Next(),
+			Ts:        ts,
 			Mutations: []*pb.Mutation{elemToMutation(elem)},
 		})
 	}

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -72,6 +72,12 @@ func (c *ShardedCoordinator) Dispatch(ctx context.Context, reqs *OperationGroup[
 	// span multiple shards (or be nil, meaning "all keys"). Broadcast the
 	// operation to every shard group so each FSM scans locally.
 	if hasDelPrefixElem(reqs.Elems) {
+		if reqs.IsTxn {
+			return nil, errors.Wrap(ErrInvalidRequest, "DEL_PREFIX not supported in transactions")
+		}
+		if err := validateDelPrefixOnly(reqs.Elems); err != nil {
+			return nil, err
+		}
 		return c.dispatchDelPrefixBroadcast(reqs.Elems)
 	}
 
@@ -114,31 +120,45 @@ func hasDelPrefixElem(elems []*Elem[OP]) bool {
 	return false
 }
 
-// dispatchDelPrefixBroadcast sends the DEL_PREFIX request to every shard group.
-func (c *ShardedCoordinator) dispatchDelPrefixBroadcast(elems []*Elem[OP]) (*CoordinateResponse, error) {
-	muts := make([]*pb.Mutation, 0, len(elems))
-	for _, elem := range elems {
-		muts = append(muts, elemToMutation(elem))
+// validateDelPrefixOnly ensures all elements are DelPrefix operations.
+// Mixing DEL_PREFIX with other operations (PUT, DEL) in a single dispatch is
+// not allowed because the FSM handles DEL_PREFIX exclusively.
+func validateDelPrefixOnly(elems []*Elem[OP]) error {
+	for _, e := range elems {
+		if e != nil && e.Op != DelPrefix {
+			return errors.Wrap(ErrInvalidRequest, "DEL_PREFIX cannot be mixed with other operations")
+		}
 	}
+	return nil
+}
 
+// dispatchDelPrefixBroadcast sends each DEL_PREFIX element as a separate
+// request to every shard group. Each element gets its own request because the
+// FSM's extractDelPrefix processes only the first DEL_PREFIX mutation per
+// request.
+func (c *ShardedCoordinator) dispatchDelPrefixBroadcast(elems []*Elem[OP]) (*CoordinateResponse, error) {
 	var maxIndex uint64
 	var firstErr error
-	for _, g := range c.groups {
-		req := &pb.Request{
-			IsTxn:     false,
-			Phase:     pb.Phase_NONE,
-			Ts:        c.clock.Next(),
-			Mutations: muts,
-		}
-		r, err := g.Txn.Commit([]*pb.Request{req})
-		if err != nil {
-			if firstErr == nil {
-				firstErr = err
+	for _, elem := range elems {
+		mut := elemToMutation(elem)
+		ts := c.clock.Next()
+		for _, g := range c.groups {
+			req := &pb.Request{
+				IsTxn:     false,
+				Phase:     pb.Phase_NONE,
+				Ts:        ts,
+				Mutations: []*pb.Mutation{mut},
 			}
-			continue
-		}
-		if r.CommitIndex > maxIndex {
-			maxIndex = r.CommitIndex
+			r, err := g.Txn.Commit([]*pb.Request{req})
+			if err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+			if r.CommitIndex > maxIndex {
+				maxIndex = r.CommitIndex
+			}
 		}
 	}
 	if firstErr != nil {

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"log/slog"
 	"slices"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/bootjp/elastickv/distribution"
@@ -148,24 +150,47 @@ func (c *ShardedCoordinator) dispatchDelPrefixBroadcast(isTxn bool, elems []*Ele
 		})
 	}
 
-	var maxIndex uint64
-	var firstErr error
+	return c.broadcastToAllGroups(requests)
+}
+
+// broadcastToAllGroups sends the same set of requests to every shard group in
+// parallel and returns the maximum commit index.
+func (c *ShardedCoordinator) broadcastToAllGroups(requests []*pb.Request) (*CoordinateResponse, error) {
+	var (
+		maxIndex atomic.Uint64
+		firstErr error
+		errMu    sync.Mutex
+		wg       sync.WaitGroup
+	)
 	for _, g := range c.groups {
-		r, err := g.Txn.Commit(requests)
-		if err != nil {
-			if firstErr == nil {
-				firstErr = err
+		wg.Add(1)
+		go func(g *ShardGroup) {
+			defer wg.Done()
+			r, err := g.Txn.Commit(requests)
+			if err != nil {
+				errMu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				errMu.Unlock()
+				return
 			}
-			continue
-		}
-		if r != nil && r.CommitIndex > maxIndex {
-			maxIndex = r.CommitIndex
-		}
+			if r != nil {
+				for {
+					cur := maxIndex.Load()
+					if r.CommitIndex <= cur || maxIndex.CompareAndSwap(cur, r.CommitIndex) {
+						break
+					}
+				}
+			}
+		}(g)
 	}
+	wg.Wait()
+
 	if firstErr != nil {
 		return nil, errors.WithStack(firstErr)
 	}
-	return &CoordinateResponse{CommitIndex: maxIndex}, nil
+	return &CoordinateResponse{CommitIndex: maxIndex.Load()}, nil
 }
 
 func (c *ShardedCoordinator) dispatchTxn(startTS uint64, commitTS uint64, elems []*Elem[OP]) (*CoordinateResponse, error) {

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -72,13 +72,7 @@ func (c *ShardedCoordinator) Dispatch(ctx context.Context, reqs *OperationGroup[
 	// span multiple shards (or be nil, meaning "all keys"). Broadcast the
 	// operation to every shard group so each FSM scans locally.
 	if hasDelPrefixElem(reqs.Elems) {
-		if reqs.IsTxn {
-			return nil, errors.Wrap(ErrInvalidRequest, "DEL_PREFIX not supported in transactions")
-		}
-		if err := validateDelPrefixOnly(reqs.Elems); err != nil {
-			return nil, err
-		}
-		return c.dispatchDelPrefixBroadcast(reqs.Elems)
+		return c.dispatchDelPrefixBroadcast(reqs.IsTxn, reqs.Elems)
 	}
 
 	if reqs.IsTxn && reqs.StartTS == 0 {
@@ -132,33 +126,40 @@ func validateDelPrefixOnly(elems []*Elem[OP]) error {
 	return nil
 }
 
-// dispatchDelPrefixBroadcast sends each DEL_PREFIX element as a separate
-// request to every shard group. Each element gets its own request because the
-// FSM's extractDelPrefix processes only the first DEL_PREFIX mutation per
-// request.
-func (c *ShardedCoordinator) dispatchDelPrefixBroadcast(elems []*Elem[OP]) (*CoordinateResponse, error) {
+// dispatchDelPrefixBroadcast validates and broadcasts DEL_PREFIX operations
+// to every shard group. Each element becomes a separate pb.Request (the FSM's
+// extractDelPrefix processes only the first DEL_PREFIX mutation per request).
+// All requests are batched into a single Commit call per shard group.
+func (c *ShardedCoordinator) dispatchDelPrefixBroadcast(isTxn bool, elems []*Elem[OP]) (*CoordinateResponse, error) {
+	if isTxn {
+		return nil, errors.Wrap(ErrInvalidRequest, "DEL_PREFIX not supported in transactions")
+	}
+	if err := validateDelPrefixOnly(elems); err != nil {
+		return nil, err
+	}
+
+	requests := make([]*pb.Request, 0, len(elems))
+	for _, elem := range elems {
+		requests = append(requests, &pb.Request{
+			IsTxn:     false,
+			Phase:     pb.Phase_NONE,
+			Ts:        c.clock.Next(),
+			Mutations: []*pb.Mutation{elemToMutation(elem)},
+		})
+	}
+
 	var maxIndex uint64
 	var firstErr error
-	for _, elem := range elems {
-		mut := elemToMutation(elem)
-		ts := c.clock.Next()
-		for _, g := range c.groups {
-			req := &pb.Request{
-				IsTxn:     false,
-				Phase:     pb.Phase_NONE,
-				Ts:        ts,
-				Mutations: []*pb.Mutation{mut},
+	for _, g := range c.groups {
+		r, err := g.Txn.Commit(requests)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
 			}
-			r, err := g.Txn.Commit([]*pb.Request{req})
-			if err != nil {
-				if firstErr == nil {
-					firstErr = err
-				}
-				continue
-			}
-			if r.CommitIndex > maxIndex {
-				maxIndex = r.CommitIndex
-			}
+			continue
+		}
+		if r != nil && r.CommitIndex > maxIndex {
+			maxIndex = r.CommitIndex
 		}
 	}
 	if firstErr != nil {

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -68,6 +68,13 @@ func (c *ShardedCoordinator) Dispatch(ctx context.Context, reqs *OperationGroup[
 		return nil, err
 	}
 
+	// DEL_PREFIX cannot be routed to a single shard because the prefix may
+	// span multiple shards (or be nil, meaning "all keys"). Broadcast the
+	// operation to every shard group so each FSM scans locally.
+	if hasDelPrefixElem(reqs.Elems) {
+		return c.dispatchDelPrefixBroadcast(reqs.Elems)
+	}
+
 	if reqs.IsTxn && reqs.StartTS == 0 {
 		startTS, err := c.nextStartTS(ctx, reqs.Elems)
 		if err != nil {
@@ -95,6 +102,49 @@ func (c *ShardedCoordinator) Dispatch(ctx context.Context, reqs *OperationGroup[
 		return nil, errors.WithStack(err)
 	}
 	return &CoordinateResponse{CommitIndex: r.CommitIndex}, nil
+}
+
+// hasDelPrefixElem returns true if any element is a DelPrefix operation.
+func hasDelPrefixElem(elems []*Elem[OP]) bool {
+	for _, e := range elems {
+		if e != nil && e.Op == DelPrefix {
+			return true
+		}
+	}
+	return false
+}
+
+// dispatchDelPrefixBroadcast sends the DEL_PREFIX request to every shard group.
+func (c *ShardedCoordinator) dispatchDelPrefixBroadcast(elems []*Elem[OP]) (*CoordinateResponse, error) {
+	muts := make([]*pb.Mutation, 0, len(elems))
+	for _, elem := range elems {
+		muts = append(muts, elemToMutation(elem))
+	}
+
+	var maxIndex uint64
+	var firstErr error
+	for _, g := range c.groups {
+		req := &pb.Request{
+			IsTxn:     false,
+			Phase:     pb.Phase_NONE,
+			Ts:        c.clock.Next(),
+			Mutations: muts,
+		}
+		r, err := g.Txn.Commit([]*pb.Request{req})
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if r.CommitIndex > maxIndex {
+			maxIndex = r.CommitIndex
+		}
+	}
+	if firstErr != nil {
+		return nil, errors.WithStack(firstErr)
+	}
+	return &CoordinateResponse{CommitIndex: maxIndex}, nil
 }
 
 func (c *ShardedCoordinator) dispatchTxn(startTS uint64, commitTS uint64, elems []*Elem[OP]) (*CoordinateResponse, error) {

--- a/kv/sharded_coordinator_del_prefix_test.go
+++ b/kv/sharded_coordinator_del_prefix_test.go
@@ -115,6 +115,54 @@ func TestShardedCoordinator_DelPrefixBroadcastsToAllGroups(t *testing.T) {
 		require.Equal(t, pb.Op_DEL_PREFIX, req.Mutations[0].Op)
 		require.Empty(t, req.Mutations[0].Key, "nil prefix means all keys")
 	}
+
+	// All groups should receive the same timestamp for a single DEL_PREFIX.
+	require.Equal(t, g1Txn.requests[0].Ts, g2Txn.requests[0].Ts,
+		"same DEL_PREFIX element must use the same timestamp across shards")
+}
+
+// TestShardedCoordinator_DelPrefixRejectsTxn verifies that DEL_PREFIX inside
+// a transactional group is rejected.
+func TestShardedCoordinator_DelPrefixRejectsTxn(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	engine.UpdateRoute([]byte(""), nil, 1)
+
+	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{
+		1: {Txn: &recordingTransactional{}},
+	}, 1, NewHLC(), nil)
+
+	_, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
+		IsTxn: true,
+		Elems: []*Elem[OP]{
+			{Op: DelPrefix, Key: nil},
+		},
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrInvalidRequest)
+}
+
+// TestShardedCoordinator_DelPrefixRejectsMixed verifies that mixing DEL_PREFIX
+// with other operations in the same dispatch is rejected.
+func TestShardedCoordinator_DelPrefixRejectsMixed(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	engine.UpdateRoute([]byte(""), nil, 1)
+
+	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{
+		1: {Txn: &recordingTransactional{}},
+	}, 1, NewHLC(), nil)
+
+	_, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
+		Elems: []*Elem[OP]{
+			{Op: DelPrefix, Key: nil},
+			{Op: Put, Key: []byte("k"), Value: []byte("v")},
+		},
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrInvalidRequest)
 }
 
 // TestShardedCoordinator_DelPrefixWithSpecificPrefix verifies broadcasting

--- a/kv/sharded_coordinator_del_prefix_test.go
+++ b/kv/sharded_coordinator_del_prefix_test.go
@@ -58,9 +58,9 @@ func TestHasDelPrefixElem(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "nil element skipped",
+			name:  "nil element skipped",
 			elems: []*Elem[OP]{nil, {Op: DelPrefix}},
-			want: true,
+			want:  true,
 		},
 	}
 

--- a/kv/sharded_coordinator_del_prefix_test.go
+++ b/kv/sharded_coordinator_del_prefix_test.go
@@ -1,0 +1,336 @@
+package kv
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/bootjp/elastickv/distribution"
+	pb "github.com/bootjp/elastickv/proto"
+	"github.com/bootjp/elastickv/store"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasDelPrefixElem(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		elems []*Elem[OP]
+		want  bool
+	}{
+		{
+			name:  "nil slice",
+			elems: nil,
+			want:  false,
+		},
+		{
+			name:  "empty slice",
+			elems: []*Elem[OP]{},
+			want:  false,
+		},
+		{
+			name: "only Put",
+			elems: []*Elem[OP]{
+				{Op: Put, Key: []byte("k"), Value: []byte("v")},
+			},
+			want: false,
+		},
+		{
+			name: "only Del",
+			elems: []*Elem[OP]{
+				{Op: Del, Key: []byte("k")},
+			},
+			want: false,
+		},
+		{
+			name: "DelPrefix with nil key",
+			elems: []*Elem[OP]{
+				{Op: DelPrefix, Key: nil},
+			},
+			want: true,
+		},
+		{
+			name: "DelPrefix with specific prefix",
+			elems: []*Elem[OP]{
+				{Op: DelPrefix, Key: []byte("prefix:")},
+			},
+			want: true,
+		},
+		{
+			name: "nil element skipped",
+			elems: []*Elem[OP]{nil, {Op: DelPrefix}},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, hasDelPrefixElem(tt.elems))
+		})
+	}
+}
+
+// TestShardedCoordinator_DelPrefixBroadcastsToAllGroups verifies that a
+// DEL_PREFIX operation is sent to every shard group, not routed to one.
+func TestShardedCoordinator_DelPrefixBroadcastsToAllGroups(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	engine.UpdateRoute([]byte("a"), []byte("m"), 1)
+	engine.UpdateRoute([]byte("m"), nil, 2)
+
+	g1Txn := &recordingTransactional{
+		responses: []*TransactionResponse{{CommitIndex: 5}},
+	}
+	g2Txn := &recordingTransactional{
+		responses: []*TransactionResponse{{CommitIndex: 12}},
+	}
+
+	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{
+		1: {Txn: g1Txn},
+		2: {Txn: g2Txn},
+	}, 1, NewHLC(), nil)
+
+	resp, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
+		Elems: []*Elem[OP]{
+			{Op: DelPrefix, Key: nil},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, uint64(12), resp.CommitIndex, "should return max commit index")
+
+	// Both groups must have received exactly one request.
+	require.Len(t, g1Txn.requests, 1)
+	require.Len(t, g2Txn.requests, 1)
+
+	for _, txn := range []*recordingTransactional{g1Txn, g2Txn} {
+		req := txn.requests[0]
+		require.False(t, req.IsTxn)
+		require.Equal(t, pb.Phase_NONE, req.Phase)
+		require.NotZero(t, req.Ts)
+		require.Len(t, req.Mutations, 1)
+		require.Equal(t, pb.Op_DEL_PREFIX, req.Mutations[0].Op)
+		require.Empty(t, req.Mutations[0].Key, "nil prefix means all keys")
+	}
+}
+
+// TestShardedCoordinator_DelPrefixWithSpecificPrefix verifies broadcasting
+// with a non-nil prefix.
+func TestShardedCoordinator_DelPrefixWithSpecificPrefix(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	engine.UpdateRoute([]byte("a"), []byte("m"), 1)
+	engine.UpdateRoute([]byte("m"), nil, 2)
+
+	g1Txn := &recordingTransactional{}
+	g2Txn := &recordingTransactional{}
+
+	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{
+		1: {Txn: g1Txn},
+		2: {Txn: g2Txn},
+	}, 1, NewHLC(), nil)
+
+	prefix := []byte("dynamo|items|")
+	_, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
+		Elems: []*Elem[OP]{
+			{Op: DelPrefix, Key: prefix},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, g1Txn.requests, 1)
+	require.Len(t, g2Txn.requests, 1)
+
+	for _, txn := range []*recordingTransactional{g1Txn, g2Txn} {
+		mut := txn.requests[0].Mutations[0]
+		require.Equal(t, pb.Op_DEL_PREFIX, mut.Op)
+		require.Equal(t, prefix, mut.Key)
+	}
+}
+
+// TestShardedCoordinator_DelPrefixPartialFailure verifies that an error is
+// returned when one of the shard groups fails, while the other still executes.
+func TestShardedCoordinator_DelPrefixPartialFailure(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	engine.UpdateRoute([]byte("a"), []byte("m"), 1)
+	engine.UpdateRoute([]byte("m"), nil, 2)
+
+	g1Txn := &recordingTransactional{
+		responses: []*TransactionResponse{{CommitIndex: 5}},
+	}
+	failErr := errors.New("shard2 disk full")
+	g2Txn := &recordingTransactional{
+		errs: []error{failErr},
+	}
+
+	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{
+		1: {Txn: g1Txn},
+		2: {Txn: g2Txn},
+	}, 1, NewHLC(), nil)
+
+	_, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
+		Elems: []*Elem[OP]{
+			{Op: DelPrefix, Key: nil},
+		},
+	})
+	require.Error(t, err)
+	// Both groups should still have been called.
+	require.Len(t, g1Txn.requests, 1)
+	require.Len(t, g2Txn.requests, 1)
+}
+
+// TestShardedCoordinator_DelPrefixSingleShard verifies broadcast works with
+// a single shard group.
+func TestShardedCoordinator_DelPrefixSingleShard(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	engine.UpdateRoute([]byte(""), nil, 1)
+
+	g1Txn := &recordingTransactional{
+		responses: []*TransactionResponse{{CommitIndex: 42}},
+	}
+
+	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{
+		1: {Txn: g1Txn},
+	}, 1, NewHLC(), nil)
+
+	resp, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
+		Elems: []*Elem[OP]{
+			{Op: DelPrefix, Key: nil},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(42), resp.CommitIndex)
+	require.Len(t, g1Txn.requests, 1)
+}
+
+// TestShardedCoordinator_DelPrefixIntegration uses real raft instances to
+// verify that DEL_PREFIX actually deletes data across multiple shards.
+func TestShardedCoordinator_DelPrefixIntegration(t *testing.T) {
+	ctx := context.Background()
+
+	engine := distribution.NewEngine()
+	engine.UpdateRoute([]byte("a"), []byte("m"), 1)
+	engine.UpdateRoute([]byte("m"), nil, 2)
+
+	s1 := store.NewMVCCStore()
+	r1, stop1 := newSingleRaft(t, "dp-g1", NewKvFSM(s1))
+	t.Cleanup(stop1)
+
+	s2 := store.NewMVCCStore()
+	r2, stop2 := newSingleRaft(t, "dp-g2", NewKvFSM(s2))
+	t.Cleanup(stop2)
+
+	groups := map[uint64]*ShardGroup{
+		1: {Raft: r1, Store: s1, Txn: NewLeaderProxy(r1)},
+		2: {Raft: r2, Store: s2, Txn: NewLeaderProxy(r2)},
+	}
+
+	shardStore := NewShardStore(engine, groups)
+	coord := NewShardedCoordinator(engine, groups, 1, NewHLC(), shardStore)
+
+	// Write keys into both shards.
+	_, err := coord.Dispatch(ctx, &OperationGroup[OP]{
+		Elems: []*Elem[OP]{
+			{Op: Put, Key: []byte("b"), Value: []byte("v1")},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = coord.Dispatch(ctx, &OperationGroup[OP]{
+		Elems: []*Elem[OP]{
+			{Op: Put, Key: []byte("x"), Value: []byte("v2")},
+		},
+	})
+	require.NoError(t, err)
+
+	// Confirm both keys are readable.
+	readTS := shardStore.LastCommitTS()
+	v, err := shardStore.GetAt(ctx, []byte("b"), readTS)
+	require.NoError(t, err)
+	require.Equal(t, "v1", string(v))
+
+	v, err = shardStore.GetAt(ctx, []byte("x"), readTS)
+	require.NoError(t, err)
+	require.Equal(t, "v2", string(v))
+
+	// Dispatch DEL_PREFIX with nil key (flush all).
+	_, err = coord.Dispatch(ctx, &OperationGroup[OP]{
+		Elems: []*Elem[OP]{
+			{Op: DelPrefix, Key: nil},
+		},
+	})
+	require.NoError(t, err)
+
+	// Both keys should now be deleted (tombstoned).
+	readTS = shardStore.LastCommitTS()
+	_, err = shardStore.GetAt(ctx, []byte("b"), readTS)
+	require.ErrorIs(t, err, store.ErrKeyNotFound, "key 'b' should be deleted after DEL_PREFIX")
+
+	_, err = shardStore.GetAt(ctx, []byte("x"), readTS)
+	require.ErrorIs(t, err, store.ErrKeyNotFound, "key 'x' should be deleted after DEL_PREFIX")
+}
+
+// TestShardedCoordinator_DelPrefixPreservesTxnKeys verifies that transaction-
+// internal keys (!txn|*) are not deleted by DEL_PREFIX.
+func TestShardedCoordinator_DelPrefixPreservesTxnKeys(t *testing.T) {
+	ctx := context.Background()
+
+	engine := distribution.NewEngine()
+	engine.UpdateRoute([]byte(""), nil, 1)
+
+	s1 := store.NewMVCCStore()
+	r1, stop1 := newSingleRaft(t, "dp-txn-g1", NewKvFSM(s1))
+	t.Cleanup(stop1)
+
+	groups := map[uint64]*ShardGroup{
+		1: {Raft: r1, Store: s1, Txn: NewLeaderProxy(r1)},
+	}
+	shardStore := NewShardStore(engine, groups)
+	coord := NewShardedCoordinator(engine, groups, 1, NewHLC(), shardStore)
+
+	// Write a user key via the coordinator.
+	_, err := coord.Dispatch(ctx, &OperationGroup[OP]{
+		Elems: []*Elem[OP]{
+			{Op: Put, Key: []byte("user-key"), Value: []byte("user-val")},
+		},
+	})
+	require.NoError(t, err)
+
+	// Write a txn-internal key directly into the store to simulate leftover
+	// transaction metadata. PutAt bypasses raft but lets us verify the FSM's
+	// exclude-prefix logic in isolation.
+	txnKey := []byte(TxnKeyPrefix + "cmt|simulated")
+	err = s1.PutAt(ctx, txnKey, []byte("commit-record"), shardStore.LastCommitTS(), 0)
+	require.NoError(t, err)
+
+	readTS := shardStore.LastCommitTS()
+	_, err = shardStore.GetAt(ctx, []byte("user-key"), readTS)
+	require.NoError(t, err)
+	_, err = s1.GetAt(ctx, txnKey, readTS)
+	require.NoError(t, err)
+
+	// DEL_PREFIX (flush all) should delete user keys but not txn-internal keys.
+	_, err = coord.Dispatch(ctx, &OperationGroup[OP]{
+		Elems: []*Elem[OP]{
+			{Op: DelPrefix, Key: nil},
+		},
+	})
+	require.NoError(t, err)
+
+	readTS = shardStore.LastCommitTS()
+	_, err = shardStore.GetAt(ctx, []byte("user-key"), readTS)
+	require.ErrorIs(t, err, store.ErrKeyNotFound, "user key should be deleted")
+
+	// The txn-internal key should still be accessible.
+	v, err := s1.GetAt(ctx, txnKey, readTS)
+	require.NoError(t, err, "txn-internal key should survive DEL_PREFIX")
+	require.Equal(t, "commit-record", string(v))
+}


### PR DESCRIPTION
DEL_PREFIX with a nil key (FLUSHALL) or a prefix spanning multiple shards could not be routed by groupMutations, causing "invalid request" errors in production where ShardedCoordinator is always used.