### PR TITLE
feat: add !redis|str| prefix to Redis string keys and scope FLUSHALL

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1435,13 +1435,23 @@ func (t *txnContext) trackTypeReadKeys(key []byte) {
 }
 
 func (t *txnContext) load(key []byte) (*txnValue, error) {
-	k := string(key)
+	// If the key is already an internal Redis key (e.g., !redis|hash|...),
+	// use it as-is. Otherwise, it's a bare user key for a string value —
+	// prefix it with !redis|str|.
+	storageKey := key
+	userKey := extractRedisInternalUserKey(key)
+	if userKey == nil && !isRedisTTLKey(key) {
+		storageKey = redisStrKey(key)
+		userKey = key
+	}
+	k := string(storageKey)
 	if tv, ok := t.working[k]; ok {
 		return tv, nil
 	}
-	storageKey := redisStrKey(key)
 	t.trackReadKey(storageKey)
-	t.trackReadKey(redisTTLKey(key))
+	if userKey != nil {
+		t.trackReadKey(redisTTLKey(userKey))
+	}
 	tv := &txnValue{}
 	val, err := t.server.readValueAt(storageKey, t.startTS)
 	if err != nil && !errors.Is(err, store.ErrKeyNotFound) {
@@ -1566,7 +1576,7 @@ func (t *txnContext) stagedListType(key string) (redisValueType, bool) {
 }
 
 func (t *txnContext) stagedStringType(key string) (redisValueType, bool) {
-	tv, ok := t.working[key]
+	tv, ok := t.working[string(redisStrKey([]byte(key)))]
 	if !ok {
 		return redisTypeNone, false
 	}
@@ -1909,7 +1919,7 @@ func (t *txnContext) buildKeyElems() []*kv.Elem[kv.OP] {
 		if !tv.dirty {
 			continue
 		}
-		storageKey := redisStrKey([]byte(k))
+		storageKey := []byte(k)
 		if tv.deleted {
 			elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: storageKey})
 			continue

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1428,6 +1428,7 @@ func (t *txnContext) trackTypeReadKeys(key []byte) {
 		redisStreamKey(key),
 		redisHLLKey(key),
 		redisStrKey(key),
+		key, // legacy bare key for fallback reads
 		redisTTLKey(key),
 	} {
 		t.trackReadKey(readKey)
@@ -1449,15 +1450,22 @@ func (t *txnContext) load(key []byte) (*txnValue, error) {
 		return tv, nil
 	}
 	t.trackReadKey(storageKey)
+	if !isKnownInternalKey(key) {
+		// Track the bare key too for conflict detection on legacy fallback reads.
+		t.trackReadKey(key)
+	}
 	if userKey != nil {
 		t.trackReadKey(redisTTLKey(userKey))
 	}
 	tv := &txnValue{}
 	var val []byte
-	isString := !isKnownInternalKey(key) || bytes.HasPrefix(key, []byte(redisStrPrefix))
-	if isString {
-		// For user string keys, use the fallback-aware reader with the bare key.
-		val, _ = t.server.readRedisStringAt(userKey, t.startTS)
+	if !isKnownInternalKey(key) {
+		// For bare user string keys, use the fallback-aware reader.
+		var err error
+		val, err = t.server.readRedisStringAt(key, t.startTS)
+		if err != nil && !errors.Is(err, store.ErrKeyNotFound) {
+			return nil, errors.WithStack(err)
+		}
 	} else {
 		var err error
 		val, err = t.server.readValueAt(storageKey, t.startTS)

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1435,12 +1435,12 @@ func (t *txnContext) trackTypeReadKeys(key []byte) {
 }
 
 func (t *txnContext) load(key []byte) (*txnValue, error) {
-	// If the key is already an internal Redis key (e.g., !redis|hash|...),
-	// use it as-is. Otherwise, it's a bare user key for a string value —
-	// prefix it with !redis|str|.
+	// If the key is already an internal key (e.g., !redis|hash|...,
+	// !lst|..., !txn|..., !ddb|..., !s3|..., !dist|...), use it as-is.
+	// Otherwise, it's a bare user key for a string value — prefix it.
 	storageKey := key
 	userKey := extractRedisInternalUserKey(key)
-	if !bytes.HasPrefix(key, []byte("!")) {
+	if !isKnownInternalKey(key) {
 		storageKey = redisStrKey(key)
 		userKey = key
 	}

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -114,7 +114,7 @@ const (
 const (
 	redisLatestCommitTimeout = 5 * time.Second
 	redisDispatchTimeout     = 10 * time.Second
-	redisFlushLegacyTimeout  = 60 * time.Second
+	redisFlushLegacyTimeout  = 10 * time.Minute
 	redisRelayPublishTimeout = 2 * time.Second
 	redisTraceArgLimit       = 6
 	redisTraceArgMaxLen      = 96

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -696,7 +696,7 @@ func (r *RedisServer) loadRedisSetState(key []byte, readTS uint64, returnOld boo
 		return state, nil
 	}
 
-	oldValue, err := r.readValueAt(redisStrKey(key), readTS)
+	oldValue, err := r.readRedisStringAt(key, readTS)
 	if err != nil && !errors.Is(err, store.ErrKeyNotFound) {
 		return redisSetState{}, err
 	}
@@ -959,7 +959,7 @@ func (r *RedisServer) get(conn redcon.Conn, cmd redcon.Command) {
 		return
 	}
 
-	v, err := r.readValueAt(redisStrKey(key), readTS)
+	v, err := r.readRedisStringAt(key, readTS)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
 			conn.WriteNull()
@@ -1453,9 +1453,16 @@ func (t *txnContext) load(key []byte) (*txnValue, error) {
 		t.trackReadKey(redisTTLKey(userKey))
 	}
 	tv := &txnValue{}
-	val, err := t.server.readValueAt(storageKey, t.startTS)
-	if err != nil && !errors.Is(err, store.ErrKeyNotFound) {
-		return nil, errors.WithStack(err)
+	var val []byte
+	if userKey != nil {
+		// For user string keys, use the fallback-aware reader.
+		val, _ = t.server.readRedisStringAt(key, t.startTS)
+	} else {
+		var err error
+		val, err = t.server.readValueAt(storageKey, t.startTS)
+		if err != nil && !errors.Is(err, store.ErrKeyNotFound) {
+			return nil, errors.WithStack(err)
+		}
 	}
 	tv.raw = val
 	tv.loaded = true

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -39,6 +39,7 @@ const (
 	cmdExpire           = "EXPIRE"
 	cmdFlushAll         = "FLUSHALL"
 	cmdFlushDB          = "FLUSHDB"
+	cmdFlushLegacy      = "FLUSHLEGACY"
 	cmdGet              = "GET"
 	cmdGetDel           = "GETDEL"
 	cmdHDel             = "HDEL"
@@ -113,6 +114,7 @@ const (
 const (
 	redisLatestCommitTimeout = 5 * time.Second
 	redisDispatchTimeout     = 10 * time.Second
+	redisFlushLegacyTimeout  = 60 * time.Second
 	redisRelayPublishTimeout = 2 * time.Second
 	redisTraceArgLimit       = 6
 	redisTraceArgMaxLen      = 96
@@ -170,6 +172,7 @@ var argsLen = map[string]int{
 	cmdExpire:           -3,
 	cmdFlushAll:         1,
 	cmdFlushDB:          1,
+	cmdFlushLegacy:      1,
 	cmdGet:              2,
 	cmdGetDel:           2,
 	cmdHDel:             -3,
@@ -358,6 +361,7 @@ func NewRedisServer(listen net.Listener, redisAddr string, store store.MVCCStore
 		cmdExpire:           r.expire,
 		cmdFlushAll:         r.flushall,
 		cmdFlushDB:          r.flushdb,
+		cmdFlushLegacy:      r.flushlegacy,
 		cmdGet:              r.get,
 		cmdGetDel:           r.getdel,
 		cmdHDel:             r.hdel,
@@ -692,7 +696,7 @@ func (r *RedisServer) loadRedisSetState(key []byte, readTS uint64, returnOld boo
 		return state, nil
 	}
 
-	oldValue, err := r.readValueAt(key, readTS)
+	oldValue, err := r.readValueAt(redisStrKey(key), readTS)
 	if err != nil && !errors.Is(err, store.ErrKeyNotFound) {
 		return redisSetState{}, err
 	}
@@ -709,7 +713,7 @@ func (r *RedisServer) replaceWithStringTxn(ctx context.Context, key, value []byt
 		}
 		elems = append(elems, delElems...)
 	}
-	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: key, Value: bytes.Clone(value)})
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: redisStrKey(key), Value: bytes.Clone(value)})
 	if ttl != nil {
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: redisTTLKey(key), Value: encodeRedisTTL(*ttl)})
 	} else {
@@ -955,7 +959,7 @@ func (r *RedisServer) get(conn redcon.Conn, cmd redcon.Command) {
 		return
 	}
 
-	v, err := r.readValueAt(key, readTS)
+	v, err := r.readValueAt(redisStrKey(key), readTS)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
 			conn.WriteNull()
@@ -1423,7 +1427,7 @@ func (t *txnContext) trackTypeReadKeys(key []byte) {
 		redisZSetKey(key),
 		redisStreamKey(key),
 		redisHLLKey(key),
-		key,
+		redisStrKey(key),
 		redisTTLKey(key),
 	} {
 		t.trackReadKey(readKey)
@@ -1435,14 +1439,11 @@ func (t *txnContext) load(key []byte) (*txnValue, error) {
 	if tv, ok := t.working[k]; ok {
 		return tv, nil
 	}
-	t.trackReadKey(key)
-	if userKey := extractRedisInternalUserKey(key); userKey != nil {
-		t.trackReadKey(redisTTLKey(userKey))
-	} else if !bytes.HasPrefix(key, []byte(redisTTLPrefix)) {
-		t.trackReadKey(redisTTLKey(key))
-	}
+	storageKey := redisStrKey(key)
+	t.trackReadKey(storageKey)
+	t.trackReadKey(redisTTLKey(key))
 	tv := &txnValue{}
-	val, err := t.server.readValueAt(key, t.startTS)
+	val, err := t.server.readValueAt(storageKey, t.startTS)
 	if err != nil && !errors.Is(err, store.ErrKeyNotFound) {
 		return nil, errors.WithStack(err)
 	}
@@ -1908,12 +1909,12 @@ func (t *txnContext) buildKeyElems() []*kv.Elem[kv.OP] {
 		if !tv.dirty {
 			continue
 		}
-		key := []byte(k)
+		storageKey := redisStrKey([]byte(k))
 		if tv.deleted {
-			elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: key})
+			elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: storageKey})
 			continue
 		}
-		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: key, Value: tv.raw})
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: storageKey, Value: tv.raw})
 	}
 	return elems
 }

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1840,6 +1840,8 @@ func (t *txnContext) stageKeyDeletion(key []byte) (redisResult, error) {
 	}
 	// Mark legacy bare string key for deletion. We bypass load() here
 	// because load() auto-prefixes bare keys to !redis|str|.
+	// Track the bare key in the read set for conflict detection.
+	t.trackReadKey(key)
 	bareK := string(key)
 	if _, ok := t.working[bareK]; !ok {
 		t.working[bareK] = &txnValue{}

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1454,9 +1454,10 @@ func (t *txnContext) load(key []byte) (*txnValue, error) {
 	}
 	tv := &txnValue{}
 	var val []byte
-	if userKey != nil {
-		// For user string keys, use the fallback-aware reader.
-		val, _ = t.server.readRedisStringAt(key, t.startTS)
+	isString := !isKnownInternalKey(key) || bytes.HasPrefix(key, []byte(redisStrPrefix))
+	if isString {
+		// For user string keys, use the fallback-aware reader with the bare key.
+		val, _ = t.server.readRedisStringAt(userKey, t.startTS)
 	} else {
 		var err error
 		val, err = t.server.readValueAt(storageKey, t.startTS)

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1838,6 +1838,14 @@ func (t *txnContext) stageKeyDeletion(key []byte) (redisResult, error) {
 		iv.deleted = true
 		iv.dirty = true
 	}
+	// Mark legacy bare string key for deletion. We bypass load() here
+	// because load() auto-prefixes bare keys to !redis|str|.
+	bareK := string(key)
+	if _, ok := t.working[bareK]; !ok {
+		t.working[bareK] = &txnValue{}
+	}
+	t.working[bareK].deleted = true
+	t.working[bareK].dirty = true
 	return redisResult{typ: resultInt, integer: 1}, nil
 }
 

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1440,7 +1440,7 @@ func (t *txnContext) load(key []byte) (*txnValue, error) {
 	// prefix it with !redis|str|.
 	storageKey := key
 	userKey := extractRedisInternalUserKey(key)
-	if userKey == nil && !isRedisTTLKey(key) {
+	if !bytes.HasPrefix(key, []byte("!")) {
 		storageKey = redisStrKey(key)
 		userKey = key
 	}

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -475,12 +475,12 @@ func (r *RedisServer) flushlegacy(conn redcon.Conn, _ redcon.Command) {
 	var totalDeleted int
 	readTS := r.readTS()
 
-	// Scan in batches to avoid unbounded memory usage and oversized Raft
-	// proposals. Internal keys start with "!" (0x21), so scanning [nil, "!")
-	// covers only bare user keys.
+	// Scan the full keyspace in batches and delete keys that do not start
+	// with "!" (the internal key prefix). This covers legacy bare user keys
+	// regardless of their byte range.
 	var cursor []byte
 	for {
-		kvs, err := r.store.ScanAt(ctx, cursor, []byte("!"), batchSize, readTS)
+		kvs, err := r.store.ScanAt(ctx, cursor, nil, batchSize, readTS)
 		if err != nil {
 			conn.WriteError(fmt.Sprintf("ERR scan: %s", err))
 			return
@@ -491,17 +491,20 @@ func (r *RedisServer) flushlegacy(conn redcon.Conn, _ redcon.Command) {
 
 		elems := make([]*kv.Elem[kv.OP], 0, len(kvs))
 		for _, pair := range kvs {
-			elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
+			if len(pair.Key) == 0 || pair.Key[0] != '!' {
+				elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
+			}
 		}
 
-		if err := r.dispatchElems(ctx, false, readTS, elems); err != nil {
-			conn.WriteError(err.Error())
-			return
+		if len(elems) > 0 {
+			if err := r.dispatchElems(ctx, false, readTS, elems); err != nil {
+				conn.WriteError(err.Error())
+				return
+			}
+			totalDeleted += len(elems)
 		}
-		totalDeleted += len(elems)
 
-		// Advance cursor past the last key in this batch by appending a
-		// zero byte to create a key strictly greater than the last one.
+		// Advance cursor past the last key in this batch.
 		lastKey := kvs[len(kvs)-1].Key
 		cursor = make([]byte, len(lastKey)+1)
 		copy(cursor, lastKey)

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"math"
 	"slices"
 	"sort"
 	"strconv"
@@ -472,31 +471,43 @@ func (r *RedisServer) flushlegacy(conn redcon.Conn, _ redcon.Command) {
 	ctx, cancel := context.WithTimeout(context.Background(), redisFlushLegacyTimeout)
 	defer cancel()
 
+	const batchSize = 1000
+	var totalDeleted int
 	readTS := r.readTS()
-	// Scan all keys up to the "!" boundary. Internal keys start with "!"
-	// (0x21), so scanning [nil, "!") covers all bare user keys.
-	kvs, err := r.store.ScanAt(ctx, nil, []byte("!"), math.MaxInt, readTS)
-	if err != nil {
-		conn.WriteError(fmt.Sprintf("ERR scan: %s", err))
-		return
+
+	// Scan in batches to avoid unbounded memory usage and oversized Raft
+	// proposals. Internal keys start with "!" (0x21), so scanning [nil, "!")
+	// covers only bare user keys.
+	var cursor []byte
+	for {
+		kvs, err := r.store.ScanAt(ctx, cursor, []byte("!"), batchSize, readTS)
+		if err != nil {
+			conn.WriteError(fmt.Sprintf("ERR scan: %s", err))
+			return
+		}
+		if len(kvs) == 0 {
+			break
+		}
+
+		elems := make([]*kv.Elem[kv.OP], 0, len(kvs))
+		for _, pair := range kvs {
+			elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
+		}
+
+		if err := r.dispatchElems(ctx, false, readTS, elems); err != nil {
+			conn.WriteError(err.Error())
+			return
+		}
+		totalDeleted += len(elems)
+
+		// Advance cursor past the last key in this batch by appending a
+		// zero byte to create a key strictly greater than the last one.
+		lastKey := kvs[len(kvs)-1].Key
+		cursor = make([]byte, len(lastKey)+1)
+		copy(cursor, lastKey)
 	}
 
-	if len(kvs) == 0 {
-		conn.WriteInt(0)
-		return
-	}
-
-	elems := make([]*kv.Elem[kv.OP], 0, len(kvs))
-	for _, pair := range kvs {
-		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
-	}
-
-	if err := r.dispatchElems(ctx, false, readTS, elems); err != nil {
-		conn.WriteError(err.Error())
-		return
-	}
-
-	conn.WriteInt(len(elems))
+	conn.WriteInt(totalDeleted)
 }
 
 func (r *RedisServer) flushDatabase(conn redcon.Conn, all bool) {

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -491,7 +491,7 @@ func (r *RedisServer) flushlegacy(conn redcon.Conn, _ redcon.Command) {
 
 		elems := make([]*kv.Elem[kv.OP], 0, len(kvs))
 		for _, pair := range kvs {
-			if len(pair.Key) == 0 || pair.Key[0] != '!' {
+			if !isKnownInternalKey(pair.Key) {
 				elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
 			}
 		}

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -460,10 +460,10 @@ func (r *RedisServer) flushall(conn redcon.Conn, _ redcon.Command) {
 
 // deleteLegacyKeys scans the full keyspace and deletes keys that do not belong
 // to any known internal prefix. Returns the number of user-visible legacy keys
-// deleted. If deleteTTL is true, also deletes associated TTL keys for each
-// legacy key (when called standalone); callers that already cleared TTL keys
-// via DEL_PREFIX should pass false.
-func (r *RedisServer) deleteLegacyKeys(ctx context.Context, readTS uint64, deleteTTL bool) (int, error) {
+// deleted. TTL keys are intentionally NOT deleted because the !redis|ttl|
+// namespace is shared across all Redis types — deleting them could strip
+// expiration from already-migrated or newly-created keys.
+func (r *RedisServer) deleteLegacyKeys(ctx context.Context, readTS uint64) (int, error) {
 	const batchSize = 1000
 	var totalDeleted int
 	cursor := make([]byte, 0, batchSize)
@@ -476,19 +476,12 @@ func (r *RedisServer) deleteLegacyKeys(ctx context.Context, readTS uint64, delet
 			break
 		}
 
-		capacity := len(kvs)
-		if deleteTTL {
-			capacity *= 2
-		}
-		elems := make([]*kv.Elem[kv.OP], 0, capacity)
+		elems := make([]*kv.Elem[kv.OP], 0, len(kvs))
 		legacyCount := 0
 		for _, pair := range kvs {
 			if !isKnownInternalKey(pair.Key) {
 				legacyCount++
 				elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
-				if deleteTTL {
-					elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisTTLKey(pair.Key)})
-				}
 			}
 		}
 
@@ -527,7 +520,7 @@ func (r *RedisServer) flushlegacy(conn redcon.Conn, _ redcon.Command) {
 	ctx, cancel := context.WithTimeout(context.Background(), redisFlushLegacyTimeout)
 	defer cancel()
 
-	totalDeleted, err := r.deleteLegacyKeys(ctx, r.readTS(), true)
+	totalDeleted, err := r.deleteLegacyKeys(ctx, r.readTS())
 	if err != nil {
 		conn.WriteError(err.Error())
 		return

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -541,7 +541,7 @@ func (r *RedisServer) flushDatabase(conn redcon.Conn, all bool) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), redisFlushLegacyTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
 	defer cancel()
 
 	if err := r.retryRedisWrite(ctx, func() error {
@@ -552,6 +552,8 @@ func (r *RedisServer) flushDatabase(conn redcon.Conn, all bool) {
 		// Delete only Redis-related keys. Two DEL_PREFIX operations cover
 		// all Redis namespaces: "!redis|" (str, hash, set, zset, hll,
 		// stream, ttl) and "!lst|" (list meta + items).
+		// Legacy bare keys are NOT deleted here to avoid a full keyspace
+		// scan. Run FLUSHLEGACY first to clean up legacy data.
 		_, err := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 			Elems: []*kv.Elem[kv.OP]{
 				{Op: kv.DelPrefix, Key: []byte("!redis|")},
@@ -563,14 +565,6 @@ func (r *RedisServer) flushDatabase(conn redcon.Conn, all bool) {
 		}
 		return nil
 	}); err != nil {
-		conn.WriteError(err.Error())
-		return
-	}
-
-	// Also clean up any legacy bare keys so they don't "reappear" via the
-	// fallback read path. TTL keys are already deleted by the !redis| prefix
-	// delete above, so pass deleteTTL=false.
-	if _, err := r.deleteLegacyKeys(ctx, r.readTS(), false); err != nil {
 		conn.WriteError(err.Error())
 		return
 	}

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -112,7 +112,7 @@ func (r *RedisServer) getdel(conn redcon.Conn, cmd redcon.Command) {
 		if typ != redisTypeString {
 			return wrongTypeError()
 		}
-		raw, err := r.readValueAt(redisStrKey(key), readTS)
+		raw, err := r.readRedisStringAt(key, readTS)
 		if err != nil {
 			// Key may have expired or been deleted between type check and read.
 			v = nil
@@ -493,6 +493,8 @@ func (r *RedisServer) flushlegacy(conn redcon.Conn, _ redcon.Command) {
 		for _, pair := range kvs {
 			if !isKnownInternalKey(pair.Key) {
 				elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
+				// Also delete the associated TTL key to avoid orphaned metadata.
+				elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisTTLKey(pair.Key)})
 			}
 		}
 
@@ -1225,7 +1227,7 @@ func (r *RedisServer) incr(conn redcon.Conn, cmd redcon.Command) {
 
 		current = 0
 		if typ == redisTypeString {
-			raw, err := r.readValueAt(redisStrKey(cmd.Args[1]), readTS)
+			raw, err := r.readRedisStringAt(cmd.Args[1], readTS)
 			if err != nil {
 				return err
 			}

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -546,15 +546,17 @@ func (r *RedisServer) flushDatabase(conn redcon.Conn, all bool) {
 			return fmt.Errorf("verify leader: %w", err)
 		}
 
-		// Delete only Redis-related keys. Two DEL_PREFIX operations cover
+		// Delete only Redis-related keys. Three DEL_PREFIX operations cover
 		// all Redis namespaces: "!redis|" (str, hash, set, zset, hll,
-		// stream, ttl) and "!lst|" (list meta + items).
+		// stream, ttl), "!lst|" (list meta + items), and "!zs|" (zset
+		// wide-column meta/member/score).
 		// Legacy bare keys are NOT deleted here to avoid a full keyspace
 		// scan. Run FLUSHLEGACY first to clean up legacy data.
 		_, err := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 			Elems: []*kv.Elem[kv.OP]{
 				{Op: kv.DelPrefix, Key: []byte("!redis|")},
 				{Op: kv.DelPrefix, Key: []byte("!lst|")},
+				{Op: kv.DelPrefix, Key: []byte("!zs|")},
 			},
 		})
 		if err != nil {

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -511,7 +511,12 @@ func (r *RedisServer) deleteLegacyKeys(ctx context.Context, readTS uint64, delet
 // do not match any known internal prefix. This is a one-time migration operation.
 func (r *RedisServer) flushlegacy(conn redcon.Conn, _ redcon.Command) {
 	if !r.coordinator.IsLeader() {
-		conn.WriteError("ERR FLUSHLEGACY must be run on the leader")
+		n, err := r.proxyFlushLegacy()
+		if err != nil {
+			conn.WriteError(err.Error())
+			return
+		}
+		conn.WriteInt(n)
 		return
 	}
 

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"slices"
 	"sort"
 	"strconv"
@@ -112,7 +113,7 @@ func (r *RedisServer) getdel(conn redcon.Conn, cmd redcon.Command) {
 		if typ != redisTypeString {
 			return wrongTypeError()
 		}
-		raw, err := r.readValueAt(key, readTS)
+		raw, err := r.readValueAt(redisStrKey(key), readTS)
 		if err != nil {
 			// Key may have expired or been deleted between type check and read.
 			v = nil
@@ -458,6 +459,46 @@ func (r *RedisServer) flushall(conn redcon.Conn, _ redcon.Command) {
 	r.flushDatabase(conn, true)
 }
 
+// flushlegacy deletes old unprefixed Redis string keys that were written before
+// the !redis|str| prefix migration. It scans all keys and deletes those that
+// do not start with "!" (the internal key prefix), which are the legacy bare
+// Redis string keys. This is a one-time migration operation.
+func (r *RedisServer) flushlegacy(conn redcon.Conn, _ redcon.Command) {
+	if !r.coordinator.IsLeader() {
+		conn.WriteError("ERR FLUSHLEGACY must be run on the leader")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), redisFlushLegacyTimeout)
+	defer cancel()
+
+	readTS := r.readTS()
+	// Scan all keys up to the "!" boundary. Internal keys start with "!"
+	// (0x21), so scanning [nil, "!") covers all bare user keys.
+	kvs, err := r.store.ScanAt(ctx, nil, []byte("!"), math.MaxInt, readTS)
+	if err != nil {
+		conn.WriteError(fmt.Sprintf("ERR scan: %s", err))
+		return
+	}
+
+	if len(kvs) == 0 {
+		conn.WriteInt(0)
+		return
+	}
+
+	elems := make([]*kv.Elem[kv.OP], 0, len(kvs))
+	for _, pair := range kvs {
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
+	}
+
+	if err := r.dispatchElems(ctx, false, readTS, elems); err != nil {
+		conn.WriteError(err.Error())
+		return
+	}
+
+	conn.WriteInt(len(elems))
+}
+
 func (r *RedisServer) flushDatabase(conn redcon.Conn, all bool) {
 	if !r.coordinator.IsLeader() {
 		if err := r.proxyFlushDatabase(all); err != nil {
@@ -476,12 +517,13 @@ func (r *RedisServer) flushDatabase(conn redcon.Conn, all bool) {
 			return fmt.Errorf("verify leader: %w", err)
 		}
 
-		// Dispatch a single DEL_PREFIX operation. The FSM on each node will
-		// scan locally and write tombstones, avoiding the need to enumerate
-		// all keys here and send them through the Raft log.
+		// Delete only Redis-related keys. Two DEL_PREFIX operations cover
+		// all Redis namespaces: "!redis|" (str, hash, set, zset, hll,
+		// stream, ttl) and "!lst|" (list meta + items).
 		_, err := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 			Elems: []*kv.Elem[kv.OP]{
-				{Op: kv.DelPrefix, Key: nil},
+				{Op: kv.DelPrefix, Key: []byte("!redis|")},
+				{Op: kv.DelPrefix, Key: []byte("!lst|")},
 			},
 		})
 		if err != nil {
@@ -1169,7 +1211,7 @@ func (r *RedisServer) incr(conn redcon.Conn, cmd redcon.Command) {
 
 		current = 0
 		if typ == redisTypeString {
-			raw, err := r.readValueAt(cmd.Args[1], readTS)
+			raw, err := r.readValueAt(redisStrKey(cmd.Args[1]), readTS)
 			if err != nil {
 				return err
 			}
@@ -1181,7 +1223,7 @@ func (r *RedisServer) incr(conn redcon.Conn, cmd redcon.Command) {
 		current++
 
 		return r.dispatchElems(ctx, true, readTS, []*kv.Elem[kv.OP]{
-			{Op: kv.Put, Key: cmd.Args[1], Value: []byte(strconv.FormatInt(current, 10))},
+			{Op: kv.Put, Key: redisStrKey(cmd.Args[1]), Value: []byte(strconv.FormatInt(current, 10))},
 			{Op: kv.Del, Key: redisTTLKey(cmd.Args[1])},
 		})
 	}); err != nil {

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -466,7 +466,7 @@ func (r *RedisServer) flushall(conn redcon.Conn, _ redcon.Command) {
 func (r *RedisServer) deleteLegacyKeys(ctx context.Context, readTS uint64, deleteTTL bool) (int, error) {
 	const batchSize = 1000
 	var totalDeleted int
-	var cursor []byte
+	cursor := make([]byte, 0, batchSize)
 	for {
 		kvs, err := r.store.ScanAt(ctx, cursor, nil, batchSize, readTS)
 		if err != nil {
@@ -476,7 +476,11 @@ func (r *RedisServer) deleteLegacyKeys(ctx context.Context, readTS uint64, delet
 			break
 		}
 
-		elems := make([]*kv.Elem[kv.OP], 0, len(kvs))
+		capacity := len(kvs)
+		if deleteTTL {
+			capacity *= 2
+		}
+		elems := make([]*kv.Elem[kv.OP], 0, capacity)
 		legacyCount := 0
 		for _, pair := range kvs {
 			if !isKnownInternalKey(pair.Key) {

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -490,8 +490,10 @@ func (r *RedisServer) flushlegacy(conn redcon.Conn, _ redcon.Command) {
 		}
 
 		elems := make([]*kv.Elem[kv.OP], 0, len(kvs))
+		legacyCount := 0
 		for _, pair := range kvs {
 			if !isKnownInternalKey(pair.Key) {
+				legacyCount++
 				elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
 				// Also delete the associated TTL key to avoid orphaned metadata.
 				elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisTTLKey(pair.Key)})
@@ -503,7 +505,7 @@ func (r *RedisServer) flushlegacy(conn redcon.Conn, _ redcon.Command) {
 				conn.WriteError(err.Error())
 				return
 			}
-			totalDeleted += len(elems)
+			totalDeleted += legacyCount
 		}
 
 		// Advance cursor past the last key in this batch.

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -458,32 +458,19 @@ func (r *RedisServer) flushall(conn redcon.Conn, _ redcon.Command) {
 	r.flushDatabase(conn, true)
 }
 
-// flushlegacy deletes old unprefixed Redis string keys that were written before
-// the !redis|str| prefix migration. It scans all keys and deletes those that
-// do not start with "!" (the internal key prefix), which are the legacy bare
-// Redis string keys. This is a one-time migration operation.
-func (r *RedisServer) flushlegacy(conn redcon.Conn, _ redcon.Command) {
-	if !r.coordinator.IsLeader() {
-		conn.WriteError("ERR FLUSHLEGACY must be run on the leader")
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), redisFlushLegacyTimeout)
-	defer cancel()
-
+// deleteLegacyKeys scans the full keyspace and deletes keys that do not belong
+// to any known internal prefix. Returns the number of user-visible legacy keys
+// deleted. If deleteTTL is true, also deletes associated TTL keys for each
+// legacy key (when called standalone); callers that already cleared TTL keys
+// via DEL_PREFIX should pass false.
+func (r *RedisServer) deleteLegacyKeys(ctx context.Context, readTS uint64, deleteTTL bool) (int, error) {
 	const batchSize = 1000
 	var totalDeleted int
-	readTS := r.readTS()
-
-	// Scan the full keyspace in batches and delete keys that do not start
-	// with "!" (the internal key prefix). This covers legacy bare user keys
-	// regardless of their byte range.
 	var cursor []byte
 	for {
 		kvs, err := r.store.ScanAt(ctx, cursor, nil, batchSize, readTS)
 		if err != nil {
-			conn.WriteError(fmt.Sprintf("ERR scan: %s", err))
-			return
+			return totalDeleted, fmt.Errorf("scan: %w", err)
 		}
 		if len(kvs) == 0 {
 			break
@@ -495,15 +482,15 @@ func (r *RedisServer) flushlegacy(conn redcon.Conn, _ redcon.Command) {
 			if !isKnownInternalKey(pair.Key) {
 				legacyCount++
 				elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
-				// Also delete the associated TTL key to avoid orphaned metadata.
-				elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisTTLKey(pair.Key)})
+				if deleteTTL {
+					elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisTTLKey(pair.Key)})
+				}
 			}
 		}
 
 		if len(elems) > 0 {
 			if err := r.dispatchElems(ctx, false, readTS, elems); err != nil {
-				conn.WriteError(err.Error())
-				return
+				return totalDeleted, err
 			}
 			totalDeleted += legacyCount
 		}
@@ -512,8 +499,30 @@ func (r *RedisServer) flushlegacy(conn redcon.Conn, _ redcon.Command) {
 		lastKey := kvs[len(kvs)-1].Key
 		cursor = make([]byte, len(lastKey)+1)
 		copy(cursor, lastKey)
+
+		// Yield briefly between batches to avoid saturating the Raft log.
+		time.Sleep(time.Millisecond)
+	}
+	return totalDeleted, nil
+}
+
+// flushlegacy deletes old unprefixed Redis string keys that were written before
+// the !redis|str| prefix migration. It scans all keys and deletes those that
+// do not match any known internal prefix. This is a one-time migration operation.
+func (r *RedisServer) flushlegacy(conn redcon.Conn, _ redcon.Command) {
+	if !r.coordinator.IsLeader() {
+		conn.WriteError("ERR FLUSHLEGACY must be run on the leader")
+		return
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), redisFlushLegacyTimeout)
+	defer cancel()
+
+	totalDeleted, err := r.deleteLegacyKeys(ctx, r.readTS(), true)
+	if err != nil {
+		conn.WriteError(err.Error())
+		return
+	}
 	conn.WriteInt(totalDeleted)
 }
 
@@ -527,7 +536,7 @@ func (r *RedisServer) flushDatabase(conn redcon.Conn, all bool) {
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), redisFlushLegacyTimeout)
 	defer cancel()
 
 	if err := r.retryRedisWrite(ctx, func() error {
@@ -549,6 +558,14 @@ func (r *RedisServer) flushDatabase(conn redcon.Conn, all bool) {
 		}
 		return nil
 	}); err != nil {
+		conn.WriteError(err.Error())
+		return
+	}
+
+	// Also clean up any legacy bare keys so they don't "reappear" via the
+	// fallback read path. TTL keys are already deleted by the !redis| prefix
+	// delete above, so pass deleteTTL=false.
+	if _, err := r.deleteLegacyKeys(ctx, r.readTS(), false); err != nil {
 		conn.WriteError(err.Error())
 		return
 	}

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -29,7 +29,7 @@ func (r *RedisServer) rawKeyTypeAt(ctx context.Context, key []byte, readTS uint6
 		{typ: redisTypeStream, key: redisStreamKey(key)},
 		// HyperLogLog is a Redis string subtype. Treat it as "string" for TYPE.
 		{typ: redisTypeString, key: redisHLLKey(key)},
-		{typ: redisTypeString, key: key},
+		{typ: redisTypeString, key: redisStrKey(key)},
 	}
 	for _, check := range checks {
 		exists, err := r.store.ExistsAt(ctx, check.key, readTS)
@@ -139,7 +139,7 @@ func (r *RedisServer) dispatchElems(ctx context.Context, isTxn bool, startTS uin
 
 func (r *RedisServer) saveString(ctx context.Context, key []byte, value []byte, ttl *time.Time) error {
 	elems := []*kv.Elem[kv.OP]{
-		{Op: kv.Put, Key: key, Value: bytes.Clone(value)},
+		{Op: kv.Put, Key: redisStrKey(key), Value: bytes.Clone(value)},
 	}
 	if ttl == nil {
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisTTLKey(key)})
@@ -157,12 +157,12 @@ func (r *RedisServer) deleteLogicalKeyElems(ctx context.Context, key []byte, rea
 
 	elems := []*kv.Elem[kv.OP]{}
 
-	stringExists, err := r.store.ExistsAt(ctx, key, readTS)
+	stringExists, err := r.store.ExistsAt(ctx, redisStrKey(key), readTS)
 	if err != nil {
 		return nil, false, errors.WithStack(err)
 	}
 	if stringExists {
-		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: key})
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisStrKey(key)})
 	}
 
 	for _, internalKey := range [][]byte{

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -30,6 +30,9 @@ func (r *RedisServer) rawKeyTypeAt(ctx context.Context, key []byte, readTS uint6
 		// HyperLogLog is a Redis string subtype. Treat it as "string" for TYPE.
 		{typ: redisTypeString, key: redisHLLKey(key)},
 		{typ: redisTypeString, key: redisStrKey(key)},
+		// Fallback: check bare key for legacy data written before the
+		// !redis|str| prefix migration.
+		{typ: redisTypeString, key: key},
 	}
 	for _, check := range checks {
 		exists, err := r.store.ExistsAt(ctx, check.key, readTS)
@@ -137,6 +140,20 @@ func (r *RedisServer) dispatchElems(ctx context.Context, isTxn bool, startTS uin
 	return errors.WithStack(err)
 }
 
+// readRedisStringAt reads a Redis string value, trying the prefixed key first
+// and falling back to the bare key for legacy data written before the
+// !redis|str| prefix migration.
+func (r *RedisServer) readRedisStringAt(key []byte, readTS uint64) ([]byte, error) {
+	v, err := r.readValueAt(redisStrKey(key), readTS)
+	if err == nil {
+		return v, nil
+	}
+	if !errors.Is(err, store.ErrKeyNotFound) {
+		return nil, err
+	}
+	return r.readValueAt(key, readTS)
+}
+
 func (r *RedisServer) saveString(ctx context.Context, key []byte, value []byte, ttl *time.Time) error {
 	elems := []*kv.Elem[kv.OP]{
 		{Op: kv.Put, Key: redisStrKey(key), Value: bytes.Clone(value)},
@@ -157,15 +174,9 @@ func (r *RedisServer) deleteLogicalKeyElems(ctx context.Context, key []byte, rea
 
 	elems := []*kv.Elem[kv.OP]{}
 
-	stringExists, err := r.store.ExistsAt(ctx, redisStrKey(key), readTS)
-	if err != nil {
-		return nil, false, errors.WithStack(err)
-	}
-	if stringExists {
-		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisStrKey(key)})
-	}
-
 	for _, internalKey := range [][]byte{
+		redisStrKey(key),
+		key, // legacy bare string key
 		redisHashKey(key),
 		redisSetKey(key),
 		redisHLLKey(key),

--- a/adapter/redis_compat_types.go
+++ b/adapter/redis_compat_types.go
@@ -15,6 +15,7 @@ import (
 )
 
 const (
+	redisStrPrefix    = "!redis|str|"
 	redisHashPrefix   = "!redis|hash|"
 	redisSetPrefix    = "!redis|set|"
 	redisZSetPrefix   = "!redis|zset|"
@@ -24,6 +25,7 @@ const (
 )
 
 var redisInternalPrefixes = []string{
+	redisStrPrefix,
 	redisHashPrefix,
 	redisSetPrefix,
 	redisHLLPrefix,
@@ -79,6 +81,10 @@ type redisStreamID struct {
 	seq uint64
 }
 
+func redisStrKey(userKey []byte) []byte {
+	return append([]byte(redisStrPrefix), userKey...)
+}
+
 func redisHashKey(userKey []byte) []byte {
 	return append([]byte(redisHashPrefix), userKey...)
 }
@@ -120,6 +126,8 @@ func isRedisTTLKey(key []byte) bool {
 
 func extractRedisInternalUserKey(key []byte) []byte {
 	switch {
+	case bytes.HasPrefix(key, []byte(redisStrPrefix)):
+		return bytes.TrimPrefix(key, []byte(redisStrPrefix))
 	case bytes.HasPrefix(key, []byte(redisHashPrefix)):
 		return bytes.TrimPrefix(key, []byte(redisHashPrefix))
 	case bytes.HasPrefix(key, []byte(redisSetPrefix)):

--- a/adapter/redis_compat_types.go
+++ b/adapter/redis_compat_types.go
@@ -134,9 +134,13 @@ var knownInternalPrefixes = [][]byte{
 	[]byte("!ddb|"),
 	[]byte("!s3|"),
 	[]byte("!dist|"),
+	[]byte("!zs|"),
 }
 
 func isKnownInternalKey(key []byte) bool {
+	if len(key) == 0 || key[0] != '!' {
+		return false
+	}
 	for _, prefix := range knownInternalPrefixes {
 		if bytes.HasPrefix(key, prefix) {
 			return true

--- a/adapter/redis_compat_types.go
+++ b/adapter/redis_compat_types.go
@@ -124,6 +124,27 @@ func isRedisTTLKey(key []byte) bool {
 	return bytes.HasPrefix(key, []byte(redisTTLPrefix))
 }
 
+// knownInternalPrefixes lists all key namespace prefixes used by internal
+// subsystems. Keys matching any of these prefixes are never legacy Redis
+// string keys and must be preserved by migration operations.
+var knownInternalPrefixes = [][]byte{
+	[]byte("!redis|"),
+	[]byte("!lst|"),
+	[]byte("!txn|"),
+	[]byte("!ddb|"),
+	[]byte("!s3|"),
+	[]byte("!dist|"),
+}
+
+func isKnownInternalKey(key []byte) bool {
+	for _, prefix := range knownInternalPrefixes {
+		if bytes.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 func extractRedisInternalUserKey(key []byte) []byte {
 	switch {
 	case bytes.HasPrefix(key, []byte(redisStrPrefix)):

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -428,7 +428,7 @@ func (c *luaScriptContext) stringState(key []byte) (*luaStringState, error) {
 		return nil, wrongTypeError()
 	}
 
-	value, err := c.server.readValueAt(key, c.startTS)
+	value, err := c.server.readValueAt(redisStrKey(key), c.startTS)
 	if errors.Is(err, store.ErrKeyNotFound) {
 		st.loaded = true
 		return st, nil
@@ -2510,7 +2510,7 @@ func (c *luaScriptContext) stringCommitElems(key string) ([]*kv.Elem[kv.OP], err
 	if err != nil {
 		return nil, err
 	}
-	return []*kv.Elem[kv.OP]{{Op: kv.Put, Key: []byte(key), Value: append([]byte(nil), st.value...)}}, nil
+	return []*kv.Elem[kv.OP]{{Op: kv.Put, Key: redisStrKey([]byte(key)), Value: append([]byte(nil), st.value...)}}, nil
 }
 
 func (c *luaScriptContext) listCommitPlan(key string) (luaCommitPlan, error) {

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -428,7 +428,7 @@ func (c *luaScriptContext) stringState(key []byte) (*luaStringState, error) {
 		return nil, wrongTypeError()
 	}
 
-	value, err := c.server.readValueAt(redisStrKey(key), c.startTS)
+	value, err := c.server.readRedisStringAt(key, c.startTS)
 	if errors.Is(err, store.ErrKeyNotFound) {
 		st.loaded = true
 		return st, nil

--- a/adapter/redis_proxy.go
+++ b/adapter/redis_proxy.go
@@ -81,3 +81,26 @@ func (r *RedisServer) proxyFlushDatabase(all bool) error {
 	}
 	return errors.WithStack(err)
 }
+
+func (r *RedisServer) proxyFlushLegacy() (int, error) {
+	leader := r.coordinator.RaftLeader()
+	if leader == "" {
+		return 0, ErrLeaderNotFound
+	}
+	leaderAddr, ok := r.leaderRedis[leader]
+	if !ok || leaderAddr == "" {
+		return 0, errors.WithStack(errors.Newf("leader redis address unknown for %s", leader))
+	}
+
+	cli := r.getOrCreateLeaderClient(leaderAddr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), redisFlushLegacyTimeout)
+	defer cancel()
+
+	res := cli.Do(ctx, "FLUSHLEGACY")
+	if res.Err() != nil {
+		return 0, errors.WithStack(res.Err())
+	}
+	n, err := res.Int()
+	return n, errors.WithStack(err)
+}

--- a/adapter/redis_proxy.go
+++ b/adapter/redis_proxy.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/errors"
 )
@@ -94,7 +95,8 @@ func (r *RedisServer) proxyFlushLegacy() (int, error) {
 
 	cli := r.getOrCreateLeaderClient(leaderAddr)
 
-	ctx, cancel := context.WithTimeout(context.Background(), redisFlushLegacyTimeout)
+	// Use a slightly longer timeout than the leader to account for network latency.
+	ctx, cancel := context.WithTimeout(context.Background(), redisFlushLegacyTimeout+30*time.Second)
 	defer cancel()
 
 	res := cli.Do(ctx, "FLUSHLEGACY")

--- a/adapter/redis_retry_test.go
+++ b/adapter/redis_retry_test.go
@@ -154,7 +154,7 @@ func TestRedisDelRetriesWriteConflict(t *testing.T) {
 
 	ctx := context.Background()
 	st := store.NewMVCCStore()
-	require.NoError(t, st.PutAt(ctx, []byte("retry:del"), []byte("v1"), 1, 0))
+	require.NoError(t, st.PutAt(ctx, redisStrKey([]byte("retry:del")), []byte("v1"), 1, 0))
 
 	coord := newRetryOnceCoordinator(st)
 	coord.clock.Observe(1)
@@ -172,7 +172,7 @@ func TestRedisDelRetriesWriteConflict(t *testing.T) {
 	require.Equal(t, int64(1), conn.int)
 	require.Equal(t, 2, coord.dispatches)
 
-	exists, err := st.ExistsAt(ctx, []byte("retry:del"), snapshotTS(coord.clock, st))
+	exists, err := st.ExistsAt(ctx, redisStrKey([]byte("retry:del")), snapshotTS(coord.clock, st))
 	require.NoError(t, err)
 	require.False(t, exists)
 }
@@ -228,7 +228,7 @@ func TestRedisEvalRetriesWriteConflict(t *testing.T) {
 	require.Equal(t, "v1", string(conn.bulk))
 	require.Equal(t, 2, coord.dispatches)
 
-	value, err := srv.readValueAt([]byte("retry:lua"), snapshotTS(coord.clock, st))
+	value, err := srv.readValueAt(redisStrKey([]byte("retry:lua")), snapshotTS(coord.clock, st))
 	require.NoError(t, err)
 	require.Equal(t, []byte("v1"), value)
 }


### PR DESCRIPTION
## Summary
- Add `!redis|str|` prefix to all Redis string key storage paths, making them distinguishable from DynamoDB, S3, and other namespaces
- Scope FLUSHALL to only delete Redis-related keys (`!redis|*` and `!lst|*`), preventing accidental deletion of DynamoDB/S3/distribution data
- Add `FLUSHLEGACY` command to scan and delete old unprefixed string keys written before the migration

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] golangci-lint reports 0 issues
- [ ] Manual test: SET/GET/DEL/INCR with new prefix
- [ ] Manual test: FLUSHALL only clears Redis data
- [ ] Manual test: FLUSHLEGACY clears old bare keys