### PR TITLE
feat: separate scheduled Jepsen stress test with heavier workload parameters

### DIFF
--- a/.github/workflows/jepsen-test-scheduled.yml
+++ b/.github/workflows/jepsen-test-scheduled.yml
@@ -1,11 +1,33 @@
 on:
-  push:
+  schedule:
+    - cron: '0 */6 * * *'
   workflow_dispatch:
+    inputs:
+      time-limit:
+        description: "Workload runtime seconds"
+        required: false
+        default: "600"
+      rate:
+        description: "Ops/sec per worker"
+        required: false
+        default: "50"
+      concurrency:
+        description: "Number of worker threads"
+        required: false
+        default: "20"
+      key-count:
+        description: "Number of distinct keys per workload"
+        required: false
+        default: "50"
+      max-writes-per-key:
+        description: "Maximum writes per key before exhaustion"
+        required: false
+        default: "2000"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-jepsen-test
+  group: ${{ github.workflow }}-${{ github.ref }}-jepsen-scheduled
 
-name: Jepsen Test
+name: Jepsen Scheduled Stress Test
 permissions:
   contents: read
 jobs:
@@ -64,19 +86,45 @@ jobs:
           exit 1
       - name: Run Redis Jepsen workload against elastickv
         working-directory: jepsen
-        timeout-minutes: 3
+        timeout-minutes: 30
         run: |
-          timeout 120 ~/lein run -m elastickv.redis-workload --time-limit 5 --rate 5 --concurrency 5 --ports 63791,63792,63793 --host 127.0.0.1
+          timeout 1800 ~/lein run -m elastickv.redis-workload \
+            --time-limit ${{ inputs.time-limit || '600' }} \
+            --rate ${{ inputs.rate || '50' }} \
+            --concurrency ${{ inputs.concurrency || '20' }} \
+            --key-count ${{ inputs.key-count || '50' }} \
+            --max-writes-per-key ${{ inputs.max-writes-per-key || '2000' }} \
+            --max-txn-length 4 \
+            --ports 63791,63792,63793 \
+            --host 127.0.0.1
       - name: Run DynamoDB Jepsen workload against elastickv
         working-directory: jepsen
-        timeout-minutes: 3
+        timeout-minutes: 30
         run: |
-          timeout 120 ~/lein run -m elastickv.dynamodb-workload --local --time-limit 5 --rate 5 --concurrency 5 --dynamo-ports 63801,63802,63803 --host 127.0.0.1
+          timeout 1800 ~/lein run -m elastickv.dynamodb-workload --local \
+            --time-limit ${{ inputs.time-limit || '600' }} \
+            --rate ${{ inputs.rate || '50' }} \
+            --concurrency ${{ inputs.concurrency || '20' }} \
+            --key-count ${{ inputs.key-count || '50' }} \
+            --max-writes-per-key ${{ inputs.max-writes-per-key || '2000' }} \
+            --dynamo-ports 63801,63802,63803 \
+            --host 127.0.0.1
       - name: Run S3 Jepsen workload against elastickv
         working-directory: jepsen
-        timeout-minutes: 3
+        timeout-minutes: 30
         run: |
-          timeout 120 ~/lein run -m elastickv.s3-workload --local --time-limit 5 --rate 10 --concurrency 10 --s3-ports 63901,63902,63903 --host 127.0.0.1
+          timeout 1800 ~/lein run -m elastickv.s3-workload --local \
+            --time-limit ${{ inputs.time-limit || '600' }} \
+            --rate ${{ inputs.rate || '50' }} \
+            --concurrency ${{ inputs.concurrency || '20' }} \
+            --key-count ${{ inputs.key-count || '50' }} \
+            --max-writes-per-key ${{ inputs.max-writes-per-key || '2000' }} \
+            --threads-per-key 4 \
+            --s3-ports 63901,63902,63903 \
+            --host 127.0.0.1
+      - name: Dump demo cluster log on failure
+        if: failure()
+        run: tail -n 500 /tmp/elastickv-demo.log || true
       - name: Stop demo cluster
         if: always()
         run: |

--- a/jepsen/src/elastickv/cli.clj
+++ b/jepsen/src/elastickv/cli.clj
@@ -47,6 +47,12 @@
    [nil "--concurrency N" "Number of worker threads."
     :default 5
     :parse-fn #(Integer/parseInt %)]
+   [nil "--key-count N" "Number of distinct keys."
+    :default nil
+    :parse-fn #(Integer/parseInt %)]
+   [nil "--max-writes-per-key N" "Maximum writes per key before exhaustion."
+    :default nil
+    :parse-fn #(Integer/parseInt %)]
    ["-h" "--help"]])
 
 (defn ports->node-map

--- a/jepsen/src/elastickv/redis_workload.clj
+++ b/jepsen/src/elastickv/redis_workload.clj
@@ -129,6 +129,9 @@
                      (mapv #(Integer/parseInt %))))]
    [nil "--redis-port PORT" "Redis port (applied to all nodes)."
     :default 6379
+    :parse-fn #(Integer/parseInt %)]
+   [nil "--max-txn-length N" "Maximum number of operations per transaction."
+    :default nil
     :parse-fn #(Integer/parseInt %)]])
 
 (defn- prepare-redis-opts


### PR DESCRIPTION
Split the scheduled (every 6h) Jepsen run into its own workflow with significantly larger workload parameters to improve race condition detection for consistency verification:

- time-limit: 5s -> 600s
- rate: 5-10 -> 50 ops/sec
- concurrency: 5-10 -> 20 threads
- key-count: 10-12 -> 50
- max-writes-per-key: 100-128 -> 2000
- threads-per-key (S3): 2 -> 4

Add CLI options --key-count, --max-writes-per-key, --max-txn-length so workload parameters can be tuned from the command line. Existing jepsen-test.yml (push-triggered) is unaffected as new CLI options default to nil, preserving original fallback values.