### PR TITLE
fix: reduce scheduled Jepsen parameters to fit ubuntu-latest runner

### DIFF
--- a/.github/workflows/jepsen-test-scheduled.yml
+++ b/.github/workflows/jepsen-test-scheduled.yml
@@ -6,23 +6,23 @@ on:
       time-limit:
         description: "Workload runtime seconds"
         required: false
-        default: "600"
+        default: "300"
       rate:
         description: "Ops/sec per worker"
         required: false
-        default: "50"
+        default: "20"
       concurrency:
         description: "Number of worker threads"
         required: false
-        default: "20"
+        default: "10"
       key-count:
         description: "Number of distinct keys per workload"
         required: false
-        default: "50"
+        default: "30"
       max-writes-per-key:
         description: "Maximum writes per key before exhaustion"
         required: false
-        default: "2000"
+        default: "500"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-jepsen-scheduled
@@ -86,39 +86,39 @@ jobs:
           exit 1
       - name: Run Redis Jepsen workload against elastickv
         working-directory: jepsen
-        timeout-minutes: 30
+        timeout-minutes: 20
         run: |
-          timeout 1800 ~/lein run -m elastickv.redis-workload \
-            --time-limit ${{ inputs.time-limit || '600' }} \
-            --rate ${{ inputs.rate || '50' }} \
-            --concurrency ${{ inputs.concurrency || '20' }} \
-            --key-count ${{ inputs.key-count || '50' }} \
-            --max-writes-per-key ${{ inputs.max-writes-per-key || '2000' }} \
+          timeout 900 ~/lein run -m elastickv.redis-workload \
+            --time-limit ${{ inputs.time-limit || '300' }} \
+            --rate ${{ inputs.rate || '20' }} \
+            --concurrency ${{ inputs.concurrency || '10' }} \
+            --key-count ${{ inputs.key-count || '30' }} \
+            --max-writes-per-key ${{ inputs.max-writes-per-key || '500' }} \
             --max-txn-length 4 \
             --ports 63791,63792,63793 \
             --host 127.0.0.1
       - name: Run DynamoDB Jepsen workload against elastickv
         working-directory: jepsen
-        timeout-minutes: 30
+        timeout-minutes: 20
         run: |
-          timeout 1800 ~/lein run -m elastickv.dynamodb-workload --local \
-            --time-limit ${{ inputs.time-limit || '600' }} \
-            --rate ${{ inputs.rate || '50' }} \
-            --concurrency ${{ inputs.concurrency || '20' }} \
-            --key-count ${{ inputs.key-count || '50' }} \
-            --max-writes-per-key ${{ inputs.max-writes-per-key || '2000' }} \
+          timeout 900 ~/lein run -m elastickv.dynamodb-workload --local \
+            --time-limit ${{ inputs.time-limit || '300' }} \
+            --rate ${{ inputs.rate || '20' }} \
+            --concurrency ${{ inputs.concurrency || '10' }} \
+            --key-count ${{ inputs.key-count || '30' }} \
+            --max-writes-per-key ${{ inputs.max-writes-per-key || '500' }} \
             --dynamo-ports 63801,63802,63803 \
             --host 127.0.0.1
       - name: Run S3 Jepsen workload against elastickv
         working-directory: jepsen
-        timeout-minutes: 30
+        timeout-minutes: 20
         run: |
-          timeout 1800 ~/lein run -m elastickv.s3-workload --local \
-            --time-limit ${{ inputs.time-limit || '600' }} \
-            --rate ${{ inputs.rate || '50' }} \
-            --concurrency ${{ inputs.concurrency || '20' }} \
-            --key-count ${{ inputs.key-count || '50' }} \
-            --max-writes-per-key ${{ inputs.max-writes-per-key || '2000' }} \
+          timeout 900 ~/lein run -m elastickv.s3-workload --local \
+            --time-limit ${{ inputs.time-limit || '300' }} \
+            --rate ${{ inputs.rate || '20' }} \
+            --concurrency ${{ inputs.concurrency || '10' }} \
+            --key-count ${{ inputs.key-count || '30' }} \
+            --max-writes-per-key ${{ inputs.max-writes-per-key || '500' }} \
             --threads-per-key 4 \
             --s3-ports 63901,63902,63903 \
             --host 127.0.0.1


### PR DESCRIPTION
ubuntu-latest has 2 vCPU / 7GB RAM. Previous parameters (rate=50, concurrency=20, time-limit=600) were too heavy. Adjusted to:

- time-limit: 600s -> 300s
- rate: 50 -> 20
- concurrency: 20 -> 10
- key-count: 50 -> 30
- max-writes-per-key: 2000 -> 500
- timeout: 1800s -> 900s, timeout-minutes: 30 -> 20

Still ~15x heavier than the CI smoke test (5s/5rate/5concurrency).