### PR TITLE
raftengine: close design doc gaps with shared interfaces, factory pat…

### DIFF
--- a/adapter/distribution_milestone1_e2e_test.go
+++ b/adapter/distribution_milestone1_e2e_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/bootjp/elastickv/distribution"
+	hashicorpraftengine "github.com/bootjp/elastickv/internal/raftengine/hashicorp"
 	"github.com/bootjp/elastickv/kv"
 	pb "github.com/bootjp/elastickv/proto"
 	"github.com/bootjp/elastickv/store"
@@ -31,8 +32,8 @@ func TestMilestone1SplitRange_EndToEndRefreshAndDataPath(t *testing.T) {
 	defer stopGroup2()
 
 	groups := map[uint64]*kv.ShardGroup{
-		1: {Raft: group1Raft, Store: group1Store, Txn: kv.NewLeaderProxy(group1Raft)},
-		2: {Raft: group2Raft, Store: group2Store, Txn: kv.NewLeaderProxy(group2Raft)},
+		1: {Engine: hashicorpraftengine.New(group1Raft), Store: group1Store, Txn: kv.NewLeaderProxyWithEngine(hashicorpraftengine.New(group1Raft))},
+		2: {Engine: hashicorpraftengine.New(group2Raft), Store: group2Store, Txn: kv.NewLeaderProxyWithEngine(hashicorpraftengine.New(group2Raft))},
 	}
 	shardStore := kv.NewShardStore(engine, groups)
 	t.Cleanup(func() {

--- a/adapter/distribution_milestone1_e2e_test.go
+++ b/adapter/distribution_milestone1_e2e_test.go
@@ -31,9 +31,11 @@ func TestMilestone1SplitRange_EndToEndRefreshAndDataPath(t *testing.T) {
 	group2Raft, stopGroup2 := newSingleRaftForDistributionE2E(t, "group-2", kv.NewKvFSM(group2Store))
 	defer stopGroup2()
 
+	group1Engine := hashicorpraftengine.New(group1Raft)
+	group2Engine := hashicorpraftengine.New(group2Raft)
 	groups := map[uint64]*kv.ShardGroup{
-		1: {Engine: hashicorpraftengine.New(group1Raft), Store: group1Store, Txn: kv.NewLeaderProxyWithEngine(hashicorpraftengine.New(group1Raft))},
-		2: {Engine: hashicorpraftengine.New(group2Raft), Store: group2Store, Txn: kv.NewLeaderProxyWithEngine(hashicorpraftengine.New(group2Raft))},
+		1: {Engine: group1Engine, Store: group1Store, Txn: kv.NewLeaderProxyWithEngine(group1Engine)},
+		2: {Engine: group2Engine, Store: group2Store, Txn: kv.NewLeaderProxyWithEngine(group2Engine)},
 	}
 	shardStore := kv.NewShardStore(engine, groups)
 	t.Cleanup(func() {

--- a/adapter/s3_test.go
+++ b/adapter/s3_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/bootjp/elastickv/distribution"
+	hashicorpraftengine "github.com/bootjp/elastickv/internal/raftengine/hashicorp"
 	"github.com/bootjp/elastickv/internal/s3keys"
 	"github.com/bootjp/elastickv/kv"
 	"github.com/bootjp/elastickv/store"
@@ -372,8 +373,8 @@ func TestS3Server_ShardedStoreRoutesBucketAndObjectData(t *testing.T) {
 	defer stop2()
 
 	groups := map[uint64]*kv.ShardGroup{
-		1: {Raft: raft1, Store: store1, Txn: kv.NewLeaderProxy(raft1)},
-		2: {Raft: raft2, Store: store2, Txn: kv.NewLeaderProxy(raft2)},
+		1: {Engine: hashicorpraftengine.New(raft1), Store: store1, Txn: kv.NewLeaderProxyWithEngine(hashicorpraftengine.New(raft1))},
+		2: {Engine: hashicorpraftengine.New(raft2), Store: store2, Txn: kv.NewLeaderProxyWithEngine(hashicorpraftengine.New(raft2))},
 	}
 	shardStore := kv.NewShardStore(engine, groups)
 	coord := kv.NewShardedCoordinator(engine, groups, 1, kv.NewHLC(), shardStore)

--- a/adapter/s3_test.go
+++ b/adapter/s3_test.go
@@ -372,9 +372,11 @@ func TestS3Server_ShardedStoreRoutesBucketAndObjectData(t *testing.T) {
 	raft2, stop2 := newSingleRaftForS3Test(t, "g2", kv.NewKvFSM(store2))
 	defer stop2()
 
+	engine1 := hashicorpraftengine.New(raft1)
+	engine2 := hashicorpraftengine.New(raft2)
 	groups := map[uint64]*kv.ShardGroup{
-		1: {Engine: hashicorpraftengine.New(raft1), Store: store1, Txn: kv.NewLeaderProxyWithEngine(hashicorpraftengine.New(raft1))},
-		2: {Engine: hashicorpraftengine.New(raft2), Store: store2, Txn: kv.NewLeaderProxyWithEngine(hashicorpraftengine.New(raft2))},
+		1: {Engine: engine1, Store: store1, Txn: kv.NewLeaderProxyWithEngine(engine1)},
+		2: {Engine: engine2, Store: store2, Txn: kv.NewLeaderProxyWithEngine(engine2)},
 	}
 	shardStore := kv.NewShardStore(engine, groups)
 	coord := kv.NewShardedCoordinator(engine, groups, 1, kv.NewHLC(), shardStore)

--- a/cmd/etcd-raft-rollback/main.go
+++ b/cmd/etcd-raft-rollback/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+
+	hashicorpraftengine "github.com/bootjp/elastickv/internal/raftengine/hashicorp"
+)
+
+var (
+	sourceFSM = flag.String("fsm-store", "", "Path to the source FSM Pebble store (for example group dir/fsm.db)")
+	destDir   = flag.String("dest", "", "Destination hashicorp raft data dir")
+	peerList  = flag.String("peers", "", "Comma-separated raft peers (id=host:port,...)")
+)
+
+func main() {
+	flag.Parse()
+
+	peers, err := hashicorpraftengine.ParsePeers(*peerList)
+	if err != nil {
+		log.Fatal(err)
+	}
+	stats, err := hashicorpraftengine.MigrateFSMStore(*sourceFSM, *destDir, peers)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("rolled back snapshot_bytes=%d peers=%d\n", stats.SnapshotBytes, stats.Peers)
+}

--- a/internal/raftengine/etcd/conformance_test.go
+++ b/internal/raftengine/etcd/conformance_test.go
@@ -1,0 +1,20 @@
+package etcd_test
+
+import (
+	"testing"
+	"time"
+
+	etcdraftengine "github.com/bootjp/elastickv/internal/raftengine/etcd"
+	"github.com/bootjp/elastickv/internal/raftengine/raftenginetest"
+)
+
+func TestConformance(t *testing.T) {
+	factory := etcdraftengine.NewFactory(etcdraftengine.FactoryConfig{
+		TickInterval:   10 * time.Millisecond,
+		HeartbeatTick:  1,
+		ElectionTick:   10,
+		MaxSizePerMsg:  1 << 20,
+		MaxInflightMsg: 256,
+	})
+	raftenginetest.RunConformanceSuite(t, factory)
+}

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"io"
 	"log/slog"
 	"sort"
 	"strconv"
@@ -56,21 +55,11 @@ var (
 	errTooManyPendingConfigs      = errors.New("etcd raft engine has too many pending config changes")
 )
 
-type Snapshot interface {
-	// Snapshot is an owned export handle from the state machine. Callers are
-	// responsible for closing it after WriteTo completes.
-	WriteTo(w io.Writer) (int64, error)
-	Close() error
-}
+// Snapshot is an alias for the shared raftengine.Snapshot interface.
+type Snapshot = raftengine.Snapshot
 
-type StateMachine interface {
-	Apply(data []byte) any
-	// Snapshot should capture a stable export handle quickly. Expensive snapshot
-	// serialization belongs in Snapshot.WriteTo, which the engine can run off
-	// the main raft loop.
-	Snapshot() (Snapshot, error)
-	Restore(r io.Reader) error
-}
+// StateMachine is an alias for the shared raftengine.StateMachine interface.
+type StateMachine = raftengine.StateMachine
 
 type OpenConfig struct {
 	NodeID         uint64

--- a/internal/raftengine/etcd/factory.go
+++ b/internal/raftengine/etcd/factory.go
@@ -65,10 +65,10 @@ func (f *Factory) Create(cfg raftengine.FactoryConfig) (*raftengine.FactoryResul
 	}
 
 	var register func(grpc.ServiceRegistrar)
-	var closeFunc func()
+	var closeFunc func() error
 	if transport != nil {
 		register = transport.Register
-		closeFunc = func() { _ = transport.Close() }
+		closeFunc = func() error { return errors.WithStack(transport.Close()) }
 	}
 
 	return &raftengine.FactoryResult{

--- a/internal/raftengine/etcd/factory.go
+++ b/internal/raftengine/etcd/factory.go
@@ -60,7 +60,7 @@ func (f *Factory) Create(cfg raftengine.FactoryConfig) (*raftengine.FactoryResul
 	if err != nil {
 		var closeErr error
 		if transport != nil {
-			closeErr = transport.Close()
+			closeErr = errors.WithStack(transport.Close())
 		}
 		return nil, errors.WithStack(errors.CombineErrors(err, closeErr))
 	}

--- a/internal/raftengine/etcd/factory.go
+++ b/internal/raftengine/etcd/factory.go
@@ -1,0 +1,93 @@
+package etcd
+
+import (
+	"context"
+	"time"
+
+	"github.com/bootjp/elastickv/internal/raftengine"
+	"github.com/cockroachdb/errors"
+	"google.golang.org/grpc"
+)
+
+// FactoryConfig holds etcd-specific engine parameters.
+type FactoryConfig struct {
+	TickInterval   time.Duration
+	HeartbeatTick  int
+	ElectionTick   int
+	MaxSizePerMsg  uint64
+	MaxInflightMsg int
+}
+
+// Factory creates etcd raft engine instances.
+type Factory struct {
+	cfg FactoryConfig
+}
+
+// NewFactory returns a Factory with the given etcd-specific settings.
+func NewFactory(cfg FactoryConfig) *Factory {
+	return &Factory{cfg: cfg}
+}
+
+func (f *Factory) EngineType() string { return "etcd" }
+
+func (f *Factory) Create(cfg raftengine.FactoryConfig) (*raftengine.FactoryResult, error) {
+	peers := peersFromServers(cfg.Peers)
+	if persistedPeers, ok, err := LoadPersistedPeers(cfg.DataDir); err != nil {
+		return nil, errors.WithStack(err)
+	} else if ok {
+		peers = persistedPeers
+	}
+
+	var transport *GRPCTransport
+	if len(peers) > 1 {
+		transport = NewGRPCTransport(peers)
+	}
+
+	engine, err := Open(context.Background(), OpenConfig{
+		LocalID:        cfg.LocalID,
+		LocalAddress:   cfg.LocalAddress,
+		DataDir:        cfg.DataDir,
+		Peers:          peers,
+		Bootstrap:      cfg.Bootstrap,
+		Transport:      transport,
+		StateMachine:   cfg.StateMachine,
+		TickInterval:   f.cfg.TickInterval,
+		HeartbeatTick:  f.cfg.HeartbeatTick,
+		ElectionTick:   f.cfg.ElectionTick,
+		MaxSizePerMsg:  f.cfg.MaxSizePerMsg,
+		MaxInflightMsg: f.cfg.MaxInflightMsg,
+	})
+	if err != nil {
+		if transport != nil {
+			_ = transport.Close()
+		}
+		return nil, errors.WithStack(err)
+	}
+
+	var register func(grpc.ServiceRegistrar)
+	var closeFunc func()
+	if transport != nil {
+		register = transport.Register
+		closeFunc = func() { _ = transport.Close() }
+	}
+
+	return &raftengine.FactoryResult{
+		Engine:            engine,
+		RegisterTransport: register,
+		Close:             closeFunc,
+	}, nil
+}
+
+func peersFromServers(servers []raftengine.Server) []Peer {
+	if len(servers) == 0 {
+		return nil
+	}
+	peers := make([]Peer, 0, len(servers))
+	for _, s := range servers {
+		peers = append(peers, Peer{
+			ID:      s.ID,
+			Address: s.Address,
+		})
+	}
+	return peers
+}

--- a/internal/raftengine/etcd/factory.go
+++ b/internal/raftengine/etcd/factory.go
@@ -58,10 +58,11 @@ func (f *Factory) Create(cfg raftengine.FactoryConfig) (*raftengine.FactoryResul
 		MaxInflightMsg: f.cfg.MaxInflightMsg,
 	})
 	if err != nil {
+		var closeErr error
 		if transport != nil {
-			_ = transport.Close()
+			closeErr = transport.Close()
 		}
-		return nil, errors.WithStack(err)
+		return nil, errors.WithStack(errors.CombineErrors(err, closeErr))
 	}
 
 	var register func(grpc.ServiceRegistrar)

--- a/internal/raftengine/factory.go
+++ b/internal/raftengine/factory.go
@@ -19,7 +19,7 @@ type FactoryResult struct {
 	// Close releases engine-specific resources that are not owned by
 	// Engine.Close (e.g. raft log stores, transport managers). Callers
 	// must still call Engine.Close separately.
-	Close func()
+	Close func() error
 }
 
 // Factory creates raft engine instances. Engine-specific configuration

--- a/internal/raftengine/factory.go
+++ b/internal/raftengine/factory.go
@@ -18,7 +18,8 @@ type FactoryResult struct {
 	RegisterTransport func(grpc.ServiceRegistrar)
 	// Close releases engine-specific resources that are not owned by
 	// Engine.Close (e.g. raft log stores, transport managers). Callers
-	// must still call Engine.Close separately.
+	// must call Engine.Close first to ensure the raft instance is fully
+	// shut down before the underlying stores and transports are released.
 	Close func() error
 }
 

--- a/internal/raftengine/factory.go
+++ b/internal/raftengine/factory.go
@@ -1,0 +1,31 @@
+package raftengine
+
+import "google.golang.org/grpc"
+
+// FactoryConfig holds engine-agnostic parameters for creating a raft engine.
+type FactoryConfig struct {
+	LocalID      string
+	LocalAddress string
+	DataDir      string
+	Peers        []Server
+	Bootstrap    bool
+	StateMachine StateMachine
+}
+
+// FactoryResult holds the output of Factory.Create.
+type FactoryResult struct {
+	Engine            Engine
+	RegisterTransport func(grpc.ServiceRegistrar)
+	// Close releases engine-specific resources that are not owned by
+	// Engine.Close (e.g. raft log stores, transport managers). Callers
+	// must still call Engine.Close separately.
+	Close func()
+}
+
+// Factory creates raft engine instances. Engine-specific configuration
+// (timeouts, tick intervals, etc.) is provided at factory construction
+// time; the Create method receives only engine-agnostic parameters.
+type Factory interface {
+	EngineType() string
+	Create(cfg FactoryConfig) (*FactoryResult, error)
+}

--- a/internal/raftengine/hashicorp/engine.go
+++ b/internal/raftengine/hashicorp/engine.go
@@ -32,7 +32,23 @@ func New(r *raft.Raft) *Engine {
 	return &Engine{raft: r}
 }
 
+// RaftInstance returns the underlying hashicorp raft instance. This is
+// provided for backward compatibility during the engine migration; callers
+// should use the Engine interface instead.
+func (e *Engine) RaftInstance() *raft.Raft {
+	if e == nil {
+		return nil
+	}
+	return e.raft
+}
+
 func (e *Engine) Close() error {
+	if e == nil || e.raft == nil {
+		return nil
+	}
+	if err := e.raft.Shutdown().Error(); err != nil {
+		return errors.WithStack(err)
+	}
 	return nil
 }
 

--- a/internal/raftengine/hashicorp/engine_test.go
+++ b/internal/raftengine/hashicorp/engine_test.go
@@ -1,0 +1,20 @@
+package hashicorp_test
+
+import (
+	"testing"
+	"time"
+
+	hashicorpraftengine "github.com/bootjp/elastickv/internal/raftengine/hashicorp"
+	"github.com/bootjp/elastickv/internal/raftengine/raftenginetest"
+)
+
+func TestConformance(t *testing.T) {
+	factory := hashicorpraftengine.NewFactory(hashicorpraftengine.FactoryConfig{
+		CommitTimeout:       50 * time.Millisecond,
+		HeartbeatTimeout:    200 * time.Millisecond,
+		ElectionTimeout:     2000 * time.Millisecond,
+		LeaderLeaseTimeout:  100 * time.Millisecond,
+		SnapshotRetainCount: 3,
+	})
+	raftenginetest.RunConformanceSuite(t, factory)
+}

--- a/internal/raftengine/hashicorp/engine_test.go
+++ b/internal/raftengine/hashicorp/engine_test.go
@@ -1,11 +1,15 @@
 package hashicorp_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/bootjp/elastickv/internal/raftengine"
 	hashicorpraftengine "github.com/bootjp/elastickv/internal/raftengine/hashicorp"
 	"github.com/bootjp/elastickv/internal/raftengine/raftenginetest"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConformance(t *testing.T) {
@@ -17,4 +21,47 @@ func TestConformance(t *testing.T) {
 		SnapshotRetainCount: 3,
 	})
 	raftenginetest.RunConformanceSuite(t, factory)
+}
+
+func TestEngineCloseNilSafe(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil_engine", func(t *testing.T) {
+		var e *hashicorpraftengine.Engine
+		require.NoError(t, e.Close())
+	})
+
+	t.Run("nil_raft_via_New", func(t *testing.T) {
+		e := hashicorpraftengine.New(nil)
+		require.Nil(t, e)
+	})
+}
+
+func TestRejectLegacyBoltDB(t *testing.T) {
+	t.Parallel()
+
+	factory := hashicorpraftengine.NewFactory(hashicorpraftengine.FactoryConfig{
+		CommitTimeout:       50 * time.Millisecond,
+		HeartbeatTimeout:    200 * time.Millisecond,
+		ElectionTimeout:     2000 * time.Millisecond,
+		LeaderLeaseTimeout:  100 * time.Millisecond,
+		SnapshotRetainCount: 3,
+	})
+
+	for _, legacy := range []string{"logs.dat", "stable.dat"} {
+		t.Run(legacy, func(t *testing.T) {
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, legacy), []byte("legacy"), 0o600))
+
+			_, err := factory.Create(raftengine.FactoryConfig{
+				LocalID:      "n1",
+				LocalAddress: "127.0.0.1:0",
+				DataDir:      dir,
+				Bootstrap:    true,
+				StateMachine: &raftenginetest.TestStateMachine{},
+			})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "legacy boltdb")
+		})
+	}
 }

--- a/internal/raftengine/hashicorp/factory.go
+++ b/internal/raftengine/hashicorp/factory.go
@@ -93,8 +93,7 @@ func (f *Factory) createRaft(dir string, cfg raftengine.FactoryConfig) (*raft.Ra
 
 	fss, err := raft.NewFileSnapshotStore(dir, f.cfg.SnapshotRetainCount, os.Stderr)
 	if err != nil {
-		_ = rs.Close()
-		return nil, nil, nil, errors.WithStack(err)
+		return nil, nil, nil, errors.WithStack(errors.CombineErrors(err, rs.Close()))
 	}
 
 	tm := transport.New(raft.ServerAddress(cfg.LocalAddress), internalutil.GRPCDialOptions())
@@ -108,9 +107,7 @@ func (f *Factory) createRaft(dir string, cfg raftengine.FactoryConfig) (*raft.Ra
 
 	r, err := raft.NewRaft(c, adaptStateMachineToFSM(cfg.StateMachine), rs, rs, fss, tm.Transport())
 	if err != nil {
-		_ = tm.Close()
-		_ = rs.Close()
-		return nil, nil, nil, errors.WithStack(err)
+		return nil, nil, nil, errors.WithStack(errors.CombineErrors(err, errors.CombineErrors(tm.Close(), rs.Close())))
 	}
 	return r, rs, tm, nil
 }

--- a/internal/raftengine/hashicorp/factory.go
+++ b/internal/raftengine/hashicorp/factory.go
@@ -62,7 +62,9 @@ func (f *Factory) Create(cfg raftengine.FactoryConfig) (*raftengine.FactoryResul
 
 	if cfg.Bootstrap {
 		if err := bootstrapCluster(r, cfg); err != nil {
-			_ = cleanup()
+			if cleanupErr := cleanup(); cleanupErr != nil {
+				fmt.Fprintf(os.Stderr, "warning: cleanup after bootstrap failure: %v\n", cleanupErr)
+			}
 			return nil, err
 		}
 	}
@@ -117,7 +119,9 @@ func bootstrapCluster(r *raft.Raft, cfg raftengine.FactoryConfig) error {
 	servers := peersToRaftServers(cfg)
 	raftCfg := raft.Configuration{Servers: servers}
 	if err := r.BootstrapCluster(raftCfg).Error(); err != nil {
-		_ = r.Shutdown().Error()
+		if shutdownErr := r.Shutdown().Error(); shutdownErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: raft shutdown after bootstrap failure: %v\n", shutdownErr)
+		}
 		return errors.WithStack(err)
 	}
 	return nil
@@ -188,7 +192,9 @@ func (a *snapshotFSMAdapter) Persist(sink raft.SnapshotSink) error {
 }
 
 func (a *snapshotFSMAdapter) Release() {
-	_ = a.snap.Close()
+	if err := a.snap.Close(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to close snapshot: %v\n", err)
+	}
 }
 
 // closeIfNotNil closes c if it is not nil and returns the error.

--- a/internal/raftengine/hashicorp/factory.go
+++ b/internal/raftengine/hashicorp/factory.go
@@ -1,0 +1,191 @@
+package hashicorp
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	transport "github.com/Jille/raft-grpc-transport"
+	internalutil "github.com/bootjp/elastickv/internal"
+	"github.com/bootjp/elastickv/internal/raftengine"
+	"github.com/bootjp/elastickv/internal/raftstore"
+	"github.com/cockroachdb/errors"
+	"github.com/hashicorp/raft"
+)
+
+const factoryDirPerm = 0o755
+
+// FactoryConfig holds hashicorp-specific engine parameters.
+type FactoryConfig struct {
+	CommitTimeout       time.Duration
+	HeartbeatTimeout    time.Duration
+	ElectionTimeout     time.Duration
+	LeaderLeaseTimeout  time.Duration
+	SnapshotRetainCount int
+}
+
+// Factory creates hashicorp raft engine instances.
+type Factory struct {
+	cfg FactoryConfig
+}
+
+// NewFactory returns a Factory with the given hashicorp-specific settings.
+func NewFactory(cfg FactoryConfig) *Factory {
+	return &Factory{cfg: cfg}
+}
+
+func (f *Factory) EngineType() string { return "hashicorp" }
+
+func (f *Factory) Create(cfg raftengine.FactoryConfig) (*raftengine.FactoryResult, error) {
+	dir := cfg.DataDir
+	if err := os.MkdirAll(dir, factoryDirPerm); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	if err := rejectLegacyBoltDB(dir); err != nil {
+		return nil, err
+	}
+
+	r, rs, tm, err := f.createRaft(dir, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	cleanup := func() {
+		if tm != nil {
+			_ = tm.Close()
+		}
+		if rs != nil {
+			_ = rs.Close()
+		}
+	}
+
+	if cfg.Bootstrap {
+		if err := bootstrapCluster(r, cfg); err != nil {
+			cleanup()
+			return nil, err
+		}
+	}
+
+	return &raftengine.FactoryResult{
+		Engine:            New(r),
+		RegisterTransport: tm.Register,
+		Close:             cleanup,
+	}, nil
+}
+
+func rejectLegacyBoltDB(dir string) error {
+	for _, legacy := range []string{"logs.dat", "stable.dat"} {
+		if _, err := os.Stat(filepath.Join(dir, legacy)); err == nil {
+			return errors.WithStack(errors.Newf(
+				"legacy boltdb Raft storage %q found in %s; manual migration required before using Pebble-backed storage",
+				legacy, dir,
+			))
+		}
+	}
+	return nil
+}
+
+func (f *Factory) createRaft(dir string, cfg raftengine.FactoryConfig) (*raft.Raft, *raftstore.PebbleStore, *transport.Manager, error) {
+	rs, err := raftstore.NewPebbleStore(filepath.Join(dir, "raft.db"))
+	if err != nil {
+		return nil, nil, nil, errors.WithStack(err)
+	}
+
+	fss, err := raft.NewFileSnapshotStore(dir, f.cfg.SnapshotRetainCount, os.Stderr)
+	if err != nil {
+		_ = rs.Close()
+		return nil, nil, nil, errors.WithStack(err)
+	}
+
+	tm := transport.New(raft.ServerAddress(cfg.LocalAddress), internalutil.GRPCDialOptions())
+
+	c := raft.DefaultConfig()
+	c.LocalID = raft.ServerID(cfg.LocalID)
+	c.CommitTimeout = f.cfg.CommitTimeout
+	c.HeartbeatTimeout = f.cfg.HeartbeatTimeout
+	c.ElectionTimeout = f.cfg.ElectionTimeout
+	c.LeaderLeaseTimeout = f.cfg.LeaderLeaseTimeout
+
+	r, err := raft.NewRaft(c, adaptStateMachineToFSM(cfg.StateMachine), rs, rs, fss, tm.Transport())
+	if err != nil {
+		_ = tm.Close()
+		_ = rs.Close()
+		return nil, nil, nil, errors.WithStack(err)
+	}
+	return r, rs, tm, nil
+}
+
+func bootstrapCluster(r *raft.Raft, cfg raftengine.FactoryConfig) error {
+	servers := peersToRaftServers(cfg)
+	raftCfg := raft.Configuration{Servers: servers}
+	if err := r.BootstrapCluster(raftCfg).Error(); err != nil {
+		_ = r.Shutdown().Error()
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func peersToRaftServers(cfg raftengine.FactoryConfig) []raft.Server {
+	if len(cfg.Peers) == 0 {
+		return []raft.Server{
+			{
+				Suffrage: raft.Voter,
+				ID:       raft.ServerID(cfg.LocalID),
+				Address:  raft.ServerAddress(cfg.LocalAddress),
+			},
+		}
+	}
+	servers := make([]raft.Server, 0, len(cfg.Peers))
+	for _, p := range cfg.Peers {
+		servers = append(servers, raft.Server{
+			Suffrage: raft.Voter,
+			ID:       raft.ServerID(p.ID),
+			Address:  raft.ServerAddress(p.Address),
+		})
+	}
+	return servers
+}
+
+// adaptStateMachineToFSM converts an engine-agnostic StateMachine to
+// hashicorp/raft's FSM interface.
+func adaptStateMachineToFSM(sm raftengine.StateMachine) raft.FSM {
+	return &stateMachineFSMAdapter{sm: sm}
+}
+
+type stateMachineFSMAdapter struct {
+	sm raftengine.StateMachine
+}
+
+func (a *stateMachineFSMAdapter) Apply(log *raft.Log) interface{} {
+	return a.sm.Apply(log.Data)
+}
+
+func (a *stateMachineFSMAdapter) Snapshot() (raft.FSMSnapshot, error) {
+	snap, err := a.sm.Snapshot()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return &snapshotFSMAdapter{snap: snap}, nil
+}
+
+func (a *stateMachineFSMAdapter) Restore(r io.ReadCloser) error {
+	return errors.WithStack(a.sm.Restore(r))
+}
+
+type snapshotFSMAdapter struct {
+	snap raftengine.Snapshot
+}
+
+func (a *snapshotFSMAdapter) Persist(sink raft.SnapshotSink) error {
+	if _, err := a.snap.WriteTo(sink); err != nil {
+		_ = sink.Cancel()
+		return errors.WithStack(err)
+	}
+	return errors.WithStack(sink.Close())
+}
+
+func (a *snapshotFSMAdapter) Release() {
+	_ = a.snap.Close()
+}

--- a/internal/raftengine/hashicorp/factory.go
+++ b/internal/raftengine/hashicorp/factory.go
@@ -1,6 +1,7 @@
 package hashicorp
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -166,6 +167,11 @@ func (a *stateMachineFSMAdapter) Snapshot() (raft.FSMSnapshot, error) {
 }
 
 func (a *stateMachineFSMAdapter) Restore(r io.ReadCloser) error {
+	defer func() {
+		if err := r.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to close raft restore stream: %v\n", err)
+		}
+	}()
 	return errors.WithStack(a.sm.Restore(r))
 }
 

--- a/internal/raftengine/hashicorp/factory.go
+++ b/internal/raftengine/hashicorp/factory.go
@@ -52,18 +52,16 @@ func (f *Factory) Create(cfg raftengine.FactoryConfig) (*raftengine.FactoryResul
 		return nil, err
 	}
 
-	cleanup := func() {
-		if tm != nil {
-			_ = tm.Close()
-		}
-		if rs != nil {
-			_ = rs.Close()
-		}
+	cleanup := func() error {
+		return errors.CombineErrors(
+			closeIfNotNil(tm),
+			closeIfNotNil(rs),
+		)
 	}
 
 	if cfg.Bootstrap {
 		if err := bootstrapCluster(r, cfg); err != nil {
-			cleanup()
+			_ = cleanup()
 			return nil, err
 		}
 	}
@@ -188,4 +186,12 @@ func (a *snapshotFSMAdapter) Persist(sink raft.SnapshotSink) error {
 
 func (a *snapshotFSMAdapter) Release() {
 	_ = a.snap.Close()
+}
+
+// closeIfNotNil closes c if it is not nil and returns the error.
+func closeIfNotNil(c io.Closer) error {
+	if c == nil {
+		return nil
+	}
+	return errors.WithStack(c.Close())
 }

--- a/internal/raftengine/hashicorp/migrate.go
+++ b/internal/raftengine/hashicorp/migrate.go
@@ -131,7 +131,11 @@ func seedHashicorpDir(storePath string, tempDir string, peers []MigrationPeer) (
 	if err != nil {
 		return 0, errors.WithStack(err)
 	}
-	defer rs.Close()
+	defer func() {
+		if err := rs.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to close raft store: %v\n", err)
+		}
+	}()
 
 	// Set initial term to 1. Hashicorp raft reads "CurrentTerm" on startup.
 	if err := rs.SetUint64([]byte("CurrentTerm"), 1); err != nil {
@@ -150,6 +154,7 @@ func seedHashicorpDir(storePath string, tempDir string, peers []MigrationPeer) (
 	// Create an in-memory transport (required by FileSnapshotStore.Create but
 	// not used for actual communication during migration).
 	_, transport := raft.NewInmemTransport("")
+	defer transport.Close()
 
 	// Create a snapshot sink at index=1, term=1.
 	sink, err := fss.Create(raft.SnapshotVersionMax, 1, 1, configuration, 1, transport)
@@ -179,7 +184,11 @@ func streamFSMSnapshotToSink(storePath string, w io.Writer) (int64, error) {
 	if err != nil {
 		return 0, errors.WithStack(err)
 	}
-	defer source.Close()
+	defer func() {
+		if err := source.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to close source store: %v\n", err)
+		}
+	}()
 
 	snapshot, err := source.Snapshot()
 	if err != nil {

--- a/internal/raftengine/hashicorp/migrate.go
+++ b/internal/raftengine/hashicorp/migrate.go
@@ -1,0 +1,230 @@
+package hashicorp
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bootjp/elastickv/internal/raftstore"
+	"github.com/bootjp/elastickv/store"
+	"github.com/cockroachdb/errors"
+	"github.com/hashicorp/raft"
+)
+
+const (
+	migrationTempSuffix = ".migrating"
+	peerSpecParts       = 2
+	migrationDirPerm    = 0o755
+)
+
+// MigrationPeer represents a single node in the hashicorp raft cluster.
+type MigrationPeer struct {
+	ID      string
+	Address string
+}
+
+// MigrationStats holds summary info about a completed migration.
+type MigrationStats struct {
+	SnapshotBytes int64
+	Peers         int
+}
+
+// ParsePeers parses a comma-separated "id=host:port" list into MigrationPeer
+// values. The format matches the etcd migration tool for consistency.
+func ParsePeers(raw string) ([]MigrationPeer, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(raw, ",")
+	peers := make([]MigrationPeer, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		idAddr := strings.SplitN(part, "=", peerSpecParts)
+		if len(idAddr) != peerSpecParts {
+			return nil, errors.WithStack(errors.Newf("invalid peer format %q, expected id=host:port", part))
+		}
+		id := strings.TrimSpace(idAddr[0])
+		addr := strings.TrimSpace(idAddr[1])
+		if id == "" || addr == "" {
+			return nil, errors.WithStack(errors.Newf("invalid peer format %q, id and address must be non-empty", part))
+		}
+		peers = append(peers, MigrationPeer{ID: id, Address: addr})
+	}
+	return peers, nil
+}
+
+// MigrateFSMStore performs a reverse migration from etcd/raft to hashicorp
+// raft. It reads an FSM PebbleStore snapshot and creates the directory
+// structure that hashicorp/raft expects: a raft.db PebbleStore for log/stable
+// state and a snapshots/ directory containing the FSM snapshot with peer
+// configuration.
+//
+// The source FSM store (fsm.db) is read-only and shared between both engines;
+// this function only creates the hashicorp-specific artifacts.
+func MigrateFSMStore(storePath string, destDataDir string, peers []MigrationPeer) (*MigrationStats, error) {
+	destDataDir, tempDir, err := prepareMigrationDest(storePath, destDataDir, peers)
+	if err != nil {
+		return nil, err
+	}
+	snapshotData, snapshotBytes, err := readFSMSnapshot(storePath)
+	if err != nil {
+		return nil, err
+	}
+	if err := seedHashicorpDir(tempDir, peers, snapshotData); err != nil {
+		_ = os.RemoveAll(tempDir)
+		return nil, err
+	}
+	if err := finalizeMigrationDir(tempDir, destDataDir); err != nil {
+		return nil, err
+	}
+	return &MigrationStats{
+		SnapshotBytes: snapshotBytes,
+		Peers:         len(peers),
+	}, nil
+}
+
+func prepareMigrationDest(storePath string, destDataDir string, peers []MigrationPeer) (string, string, error) {
+	switch {
+	case storePath == "":
+		return "", "", errors.WithStack(errors.New("source FSM store path is required"))
+	case destDataDir == "":
+		return "", "", errors.WithStack(errors.New("destination data dir is required"))
+	case len(peers) == 0:
+		return "", "", errors.WithStack(errors.New("at least one peer is required"))
+	}
+
+	destDataDir = filepath.Clean(destDataDir)
+	if err := ensureMigrationPathAbsent(destDataDir, "destination"); err != nil {
+		return "", "", err
+	}
+	tempDir := destDataDir + migrationTempSuffix
+	if err := ensureMigrationPathAbsent(tempDir, "temporary destination"); err != nil {
+		return "", "", err
+	}
+	return destDataDir, tempDir, nil
+}
+
+func ensureMigrationPathAbsent(path string, kind string) error {
+	if _, err := os.Stat(path); err == nil {
+		return errors.WithStack(errors.Newf("%s already exists: %s", kind, path))
+	} else if !os.IsNotExist(err) {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func readFSMSnapshot(storePath string) ([]byte, int64, error) {
+	source, err := store.NewPebbleStore(storePath)
+	if err != nil {
+		return nil, 0, errors.WithStack(err)
+	}
+	defer source.Close()
+
+	snapshot, err := source.Snapshot()
+	if err != nil {
+		return nil, 0, errors.WithStack(err)
+	}
+	defer snapshot.Close()
+
+	var buf countingBuffer
+	if _, err := snapshot.WriteTo(&buf); err != nil {
+		return nil, 0, errors.WithStack(err)
+	}
+	return buf.Bytes(), int64(buf.Len()), nil
+}
+
+type countingBuffer struct {
+	data []byte
+}
+
+func (b *countingBuffer) Write(p []byte) (int, error) {
+	b.data = append(b.data, p...)
+	return len(p), nil
+}
+
+func (b *countingBuffer) Bytes() []byte { return b.data }
+func (b *countingBuffer) Len() int      { return len(b.data) }
+
+// seedHashicorpDir creates the hashicorp raft directory structure inside
+// tempDir with a raft.db stable store and a snapshot containing the FSM data.
+func seedHashicorpDir(tempDir string, peers []MigrationPeer, snapshotData []byte) error {
+	if err := os.MkdirAll(tempDir, migrationDirPerm); err != nil {
+		return errors.WithStack(err)
+	}
+
+	// Create the raft.db PebbleStore with initial stable state.
+	rs, err := raftstore.NewPebbleStore(filepath.Join(tempDir, "raft.db"))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer rs.Close()
+
+	// Set initial term to 1. Hashicorp raft reads "CurrentTerm" on startup.
+	if err := rs.SetUint64([]byte("CurrentTerm"), 1); err != nil {
+		return errors.WithStack(err)
+	}
+
+	// Create the FileSnapshotStore to hold the FSM snapshot.
+	fss, err := raft.NewFileSnapshotStore(tempDir, 1, os.Stderr)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	// Build the raft configuration from peers.
+	servers := make([]raft.Server, 0, len(peers))
+	for _, p := range peers {
+		servers = append(servers, raft.Server{
+			Suffrage: raft.Voter,
+			ID:       raft.ServerID(p.ID),
+			Address:  raft.ServerAddress(p.Address),
+		})
+	}
+	configuration := raft.Configuration{Servers: servers}
+
+	// Create an in-memory transport (required by FileSnapshotStore.Create but
+	// not used for actual communication during migration).
+	_, transport := raft.NewInmemTransport("")
+
+	// Create a snapshot at index=1, term=1 with the full FSM data.
+	sink, err := fss.Create(raft.SnapshotVersionMax, 1, 1, configuration, 1, transport)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if _, err := sink.Write(snapshotData); err != nil {
+		_ = sink.Cancel()
+		return errors.WithStack(err)
+	}
+	if err := sink.Close(); err != nil {
+		return errors.WithStack(err)
+	}
+
+	fmt.Fprintf(os.Stderr, "  created snapshot with %d bytes of FSM data\n", len(snapshotData))
+	return nil
+}
+
+func finalizeMigrationDir(tempDir string, destDataDir string) error {
+	if err := os.Rename(tempDir, destDataDir); err != nil {
+		_ = os.RemoveAll(tempDir)
+		return errors.WithStack(err)
+	}
+	if err := syncDir(filepath.Dir(destDataDir)); err != nil {
+		_ = os.RemoveAll(destDataDir)
+		return err
+	}
+	return nil
+}
+
+func syncDir(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer f.Close()
+	return errors.WithStack(f.Sync())
+}

--- a/internal/raftengine/hashicorp/migrate.go
+++ b/internal/raftengine/hashicorp/migrate.go
@@ -68,6 +68,10 @@ func ParsePeers(raw string) ([]MigrationPeer, error) {
 //
 // The source FSM store (fsm.db) is read-only and shared between both engines;
 // this function only creates the hashicorp-specific artifacts.
+//
+// IMPORTANT: The source engine must be fully stopped before running this
+// tool. Running it against a live engine may produce an inconsistent
+// snapshot that is missing recently applied entries.
 func MigrateFSMStore(storePath string, destDataDir string, peers []MigrationPeer) (*MigrationStats, error) {
 	destDataDir, tempDir, err := prepareMigrationDest(storePath, destDataDir, peers)
 	if err != nil {

--- a/internal/raftengine/hashicorp/migrate.go
+++ b/internal/raftengine/hashicorp/migrate.go
@@ -221,7 +221,8 @@ func finalizeMigrationDir(tempDir string, destDataDir string) error {
 		return errors.WithStack(err)
 	}
 	if err := syncDir(filepath.Dir(destDataDir)); err != nil {
-		_ = os.RemoveAll(destDataDir)
+		// Don't remove destDataDir here — the rename succeeded and the data
+		// is already in place. Deleting it would cause total data loss.
 		return err
 	}
 	return nil

--- a/internal/raftengine/hashicorp/migrate.go
+++ b/internal/raftengine/hashicorp/migrate.go
@@ -2,6 +2,7 @@ package hashicorp
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -72,11 +73,8 @@ func MigrateFSMStore(storePath string, destDataDir string, peers []MigrationPeer
 	if err != nil {
 		return nil, err
 	}
-	snapshotData, snapshotBytes, err := readFSMSnapshot(storePath)
+	snapshotBytes, err := seedHashicorpDir(storePath, tempDir, peers)
 	if err != nil {
-		return nil, err
-	}
-	if err := seedHashicorpDir(tempDir, peers, snapshotData); err != nil {
 		_ = os.RemoveAll(tempDir)
 		return nil, err
 	}
@@ -119,64 +117,84 @@ func ensureMigrationPathAbsent(path string, kind string) error {
 	return nil
 }
 
-func readFSMSnapshot(storePath string) ([]byte, int64, error) {
-	source, err := store.NewPebbleStore(storePath)
-	if err != nil {
-		return nil, 0, errors.WithStack(err)
-	}
-	defer source.Close()
-
-	snapshot, err := source.Snapshot()
-	if err != nil {
-		return nil, 0, errors.WithStack(err)
-	}
-	defer snapshot.Close()
-
-	var buf countingBuffer
-	if _, err := snapshot.WriteTo(&buf); err != nil {
-		return nil, 0, errors.WithStack(err)
-	}
-	return buf.Bytes(), int64(buf.Len()), nil
-}
-
-type countingBuffer struct {
-	data []byte
-}
-
-func (b *countingBuffer) Write(p []byte) (int, error) {
-	b.data = append(b.data, p...)
-	return len(p), nil
-}
-
-func (b *countingBuffer) Bytes() []byte { return b.data }
-func (b *countingBuffer) Len() int      { return len(b.data) }
-
 // seedHashicorpDir creates the hashicorp raft directory structure inside
 // tempDir with a raft.db stable store and a snapshot containing the FSM data.
-func seedHashicorpDir(tempDir string, peers []MigrationPeer, snapshotData []byte) error {
+// The snapshot is streamed directly from the source PebbleStore to the
+// raft.SnapshotSink to avoid buffering the entire FSM in memory.
+func seedHashicorpDir(storePath string, tempDir string, peers []MigrationPeer) (int64, error) {
 	if err := os.MkdirAll(tempDir, migrationDirPerm); err != nil {
-		return errors.WithStack(err)
+		return 0, errors.WithStack(err)
 	}
 
 	// Create the raft.db PebbleStore with initial stable state.
 	rs, err := raftstore.NewPebbleStore(filepath.Join(tempDir, "raft.db"))
 	if err != nil {
-		return errors.WithStack(err)
+		return 0, errors.WithStack(err)
 	}
 	defer rs.Close()
 
 	// Set initial term to 1. Hashicorp raft reads "CurrentTerm" on startup.
 	if err := rs.SetUint64([]byte("CurrentTerm"), 1); err != nil {
-		return errors.WithStack(err)
+		return 0, errors.WithStack(err)
 	}
 
 	// Create the FileSnapshotStore to hold the FSM snapshot.
 	fss, err := raft.NewFileSnapshotStore(tempDir, 1, os.Stderr)
 	if err != nil {
-		return errors.WithStack(err)
+		return 0, errors.WithStack(err)
 	}
 
 	// Build the raft configuration from peers.
+	configuration := raft.Configuration{Servers: peersToRaftMigrationServers(peers)}
+
+	// Create an in-memory transport (required by FileSnapshotStore.Create but
+	// not used for actual communication during migration).
+	_, transport := raft.NewInmemTransport("")
+
+	// Create a snapshot sink at index=1, term=1.
+	sink, err := fss.Create(raft.SnapshotVersionMax, 1, 1, configuration, 1, transport)
+	if err != nil {
+		return 0, errors.WithStack(err)
+	}
+
+	// Stream FSM snapshot directly to the sink (no in-memory buffering).
+	snapshotBytes, err := streamFSMSnapshotToSink(storePath, sink)
+	if err != nil {
+		_ = sink.Cancel()
+		return 0, err
+	}
+
+	if err := sink.Close(); err != nil {
+		return 0, errors.WithStack(err)
+	}
+
+	fmt.Fprintf(os.Stderr, "  created snapshot with %d bytes of FSM data\n", snapshotBytes)
+	return snapshotBytes, nil
+}
+
+// streamFSMSnapshotToSink opens the source PebbleStore, takes a snapshot,
+// and streams it directly to the given io.Writer (typically a raft.SnapshotSink).
+func streamFSMSnapshotToSink(storePath string, w io.Writer) (int64, error) {
+	source, err := store.NewPebbleStore(storePath)
+	if err != nil {
+		return 0, errors.WithStack(err)
+	}
+	defer source.Close()
+
+	snapshot, err := source.Snapshot()
+	if err != nil {
+		return 0, errors.WithStack(err)
+	}
+	defer snapshot.Close()
+
+	n, err := snapshot.WriteTo(w)
+	if err != nil {
+		return n, errors.WithStack(err)
+	}
+	return n, nil
+}
+
+func peersToRaftMigrationServers(peers []MigrationPeer) []raft.Server {
 	servers := make([]raft.Server, 0, len(peers))
 	for _, p := range peers {
 		servers = append(servers, raft.Server{
@@ -185,27 +203,7 @@ func seedHashicorpDir(tempDir string, peers []MigrationPeer, snapshotData []byte
 			Address:  raft.ServerAddress(p.Address),
 		})
 	}
-	configuration := raft.Configuration{Servers: servers}
-
-	// Create an in-memory transport (required by FileSnapshotStore.Create but
-	// not used for actual communication during migration).
-	_, transport := raft.NewInmemTransport("")
-
-	// Create a snapshot at index=1, term=1 with the full FSM data.
-	sink, err := fss.Create(raft.SnapshotVersionMax, 1, 1, configuration, 1, transport)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	if _, err := sink.Write(snapshotData); err != nil {
-		_ = sink.Cancel()
-		return errors.WithStack(err)
-	}
-	if err := sink.Close(); err != nil {
-		return errors.WithStack(err)
-	}
-
-	fmt.Fprintf(os.Stderr, "  created snapshot with %d bytes of FSM data\n", len(snapshotData))
-	return nil
+	return servers
 }
 
 func finalizeMigrationDir(tempDir string, destDataDir string) error {

--- a/internal/raftengine/hashicorp/migrate_test.go
+++ b/internal/raftengine/hashicorp/migrate_test.go
@@ -109,7 +109,7 @@ func TestMigrateFSMStoreSeedsHashicorpDataDir(t *testing.T) {
 	t.Cleanup(func() {
 		_ = result.Engine.Close()
 		if result.Close != nil {
-			result.Close()
+			_ = result.Close()
 		}
 	})
 

--- a/internal/raftengine/hashicorp/migrate_test.go
+++ b/internal/raftengine/hashicorp/migrate_test.go
@@ -63,6 +63,14 @@ func TestMigrateFSMStoreValidation(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "at least one peer is required")
 	})
+
+	t.Run("dest_already_exists", func(t *testing.T) {
+		dest := t.TempDir() // already exists
+		peers := []hashicorpraftengine.MigrationPeer{{ID: "n1", Address: "127.0.0.1:7001"}}
+		_, err := hashicorpraftengine.MigrateFSMStore("/some/path", dest, peers)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "already exists")
+	})
 }
 
 func TestMigrateFSMStoreSeedsHashicorpDataDir(t *testing.T) {

--- a/internal/raftengine/hashicorp/migrate_test.go
+++ b/internal/raftengine/hashicorp/migrate_test.go
@@ -1,0 +1,174 @@
+package hashicorp_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bootjp/elastickv/internal/raftengine"
+	hashicorpraftengine "github.com/bootjp/elastickv/internal/raftengine/hashicorp"
+	"github.com/bootjp/elastickv/store"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePeers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		peers, err := hashicorpraftengine.ParsePeers("")
+		require.NoError(t, err)
+		require.Nil(t, peers)
+	})
+
+	t.Run("single", func(t *testing.T) {
+		peers, err := hashicorpraftengine.ParsePeers("n1=127.0.0.1:7001")
+		require.NoError(t, err)
+		require.Len(t, peers, 1)
+		require.Equal(t, "n1", peers[0].ID)
+		require.Equal(t, "127.0.0.1:7001", peers[0].Address)
+	})
+
+	t.Run("multiple", func(t *testing.T) {
+		peers, err := hashicorpraftengine.ParsePeers("n1=127.0.0.1:7001,n2=127.0.0.1:7002,n3=127.0.0.1:7003")
+		require.NoError(t, err)
+		require.Len(t, peers, 3)
+	})
+
+	t.Run("invalid_format", func(t *testing.T) {
+		_, err := hashicorpraftengine.ParsePeers("bad-entry")
+		require.Error(t, err)
+	})
+}
+
+func TestMigrateFSMStoreValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing_source", func(t *testing.T) {
+		_, err := hashicorpraftengine.MigrateFSMStore("", t.TempDir(), []hashicorpraftengine.MigrationPeer{{ID: "n1", Address: "127.0.0.1:7001"}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "source FSM store path is required")
+	})
+
+	t.Run("missing_dest", func(t *testing.T) {
+		_, err := hashicorpraftengine.MigrateFSMStore("/some/path", "", []hashicorpraftengine.MigrationPeer{{ID: "n1", Address: "127.0.0.1:7001"}})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "destination data dir is required")
+	})
+
+	t.Run("missing_peers", func(t *testing.T) {
+		_, err := hashicorpraftengine.MigrateFSMStore("/some/path", t.TempDir()+"/dest", nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "at least one peer is required")
+	})
+}
+
+func TestMigrateFSMStoreSeedsHashicorpDataDir(t *testing.T) {
+	// Write test data to a PebbleStore (the shared FSM store).
+	sourcePath := filepath.Join(t.TempDir(), "fsm.db")
+	source, err := store.NewPebbleStore(sourcePath)
+	require.NoError(t, err)
+	require.NoError(t, source.PutAt(context.Background(), []byte("alpha"), []byte("one"), 10, 0))
+	require.NoError(t, source.PutAt(context.Background(), []byte("beta"), []byte("two"), 11, 0))
+	require.NoError(t, source.Close())
+
+	// Migrate to hashicorp raft format.
+	destDataDir := filepath.Join(t.TempDir(), "raft")
+	peers := []hashicorpraftengine.MigrationPeer{
+		{ID: "n1", Address: "127.0.0.1:7001"},
+	}
+	stats, err := hashicorpraftengine.MigrateFSMStore(sourcePath, destDataDir, peers)
+	require.NoError(t, err)
+	require.Positive(t, stats.SnapshotBytes)
+	require.Equal(t, 1, stats.Peers)
+
+	// Boot a hashicorp raft engine from the migrated directory and verify
+	// the FSM snapshot is restored.
+	destStore, err := store.NewPebbleStore(filepath.Join(t.TempDir(), "dest-fsm.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, destStore.Close()) })
+
+	sm := &storeStateMachine{store: destStore}
+	factory := hashicorpraftengine.NewFactory(hashicorpraftengine.FactoryConfig{
+		CommitTimeout:       50 * time.Millisecond,
+		HeartbeatTimeout:    200 * time.Millisecond,
+		ElectionTimeout:     2000 * time.Millisecond,
+		LeaderLeaseTimeout:  100 * time.Millisecond,
+		SnapshotRetainCount: 3,
+	})
+
+	result, err := factory.Create(raftengine.FactoryConfig{
+		LocalID:      "n1",
+		LocalAddress: "127.0.0.1:0",
+		DataDir:      destDataDir,
+		StateMachine: sm,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = result.Engine.Close()
+		if result.Close != nil {
+			result.Close()
+		}
+	})
+
+	// Wait for leader election.
+	require.Eventually(t, func() bool {
+		return result.Engine.State() == raftengine.StateLeader
+	}, 5*time.Second, 10*time.Millisecond, "engine did not become leader")
+
+	// Verify FSM data survived the migration.
+	v, err := destStore.GetAt(context.Background(), []byte("alpha"), ^uint64(0))
+	require.NoError(t, err)
+	require.Equal(t, []byte("one"), v)
+
+	v, err = destStore.GetAt(context.Background(), []byte("beta"), ^uint64(0))
+	require.NoError(t, err)
+	require.Equal(t, []byte("two"), v)
+}
+
+// storeStateMachine adapts store.MVCCStore to raftengine.StateMachine for
+// migration tests. Only Snapshot/Restore are needed; Apply is unused.
+type storeStateMachine struct {
+	store store.MVCCStore
+}
+
+func (s *storeStateMachine) Apply(_ []byte) any { return nil }
+
+func (s *storeStateMachine) Snapshot() (raftengine.Snapshot, error) {
+	return s.store.Snapshot()
+}
+
+func (s *storeStateMachine) Restore(r io.Reader) error {
+	return s.store.Restore(r)
+}
+
+func TestFSMSnapshotRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// Create source store with data.
+	sourcePath := filepath.Join(t.TempDir(), "src.db")
+	src, err := store.NewPebbleStore(sourcePath)
+	require.NoError(t, err)
+	require.NoError(t, src.PutAt(context.Background(), []byte("k"), []byte("v"), 1, 0))
+
+	snap, err := src.Snapshot()
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	_, err = snap.WriteTo(&buf)
+	require.NoError(t, err)
+	require.NoError(t, snap.Close())
+	require.NoError(t, src.Close())
+
+	// Restore into destination store.
+	dstPath := filepath.Join(t.TempDir(), "dst.db")
+	dst, err := store.NewPebbleStore(dstPath)
+	require.NoError(t, err)
+	require.NoError(t, dst.Restore(&buf))
+
+	v, err := dst.GetAt(context.Background(), []byte("k"), ^uint64(0))
+	require.NoError(t, err)
+	require.Equal(t, []byte("v"), v)
+	require.NoError(t, dst.Close())
+}

--- a/internal/raftengine/hashicorp/migrate_test.go
+++ b/internal/raftengine/hashicorp/migrate_test.go
@@ -41,6 +41,22 @@ func TestParsePeers(t *testing.T) {
 		_, err := hashicorpraftengine.ParsePeers("bad-entry")
 		require.Error(t, err)
 	})
+
+	t.Run("empty_id", func(t *testing.T) {
+		_, err := hashicorpraftengine.ParsePeers("=127.0.0.1:7001")
+		require.Error(t, err)
+	})
+
+	t.Run("empty_address", func(t *testing.T) {
+		_, err := hashicorpraftengine.ParsePeers("n1=")
+		require.Error(t, err)
+	})
+
+	t.Run("trailing_commas_skipped", func(t *testing.T) {
+		peers, err := hashicorpraftengine.ParsePeers("n1=127.0.0.1:7001,,")
+		require.NoError(t, err)
+		require.Len(t, peers, 1)
+	})
 }
 
 func TestMigrateFSMStoreValidation(t *testing.T) {

--- a/internal/raftengine/raftenginetest/conformance.go
+++ b/internal/raftengine/raftenginetest/conformance.go
@@ -138,7 +138,7 @@ func createSingleNode(t *testing.T, factory raftengine.Factory, dir string, sm *
 	t.Cleanup(func() {
 		_ = result.Engine.Close()
 		if result.Close != nil {
-			result.Close()
+			_ = result.Close()
 		}
 	})
 
@@ -229,7 +229,7 @@ func testCloseAndReopen(t *testing.T, factory raftengine.Factory) {
 
 	_ = result1.Engine.Close()
 	if result1.Close != nil {
-		result1.Close()
+		_ = result1.Close()
 	}
 
 	// Second open: verify data persisted
@@ -244,7 +244,7 @@ func testCloseAndReopen(t *testing.T, factory raftengine.Factory) {
 	t.Cleanup(func() {
 		_ = result2.Engine.Close()
 		if result2.Close != nil {
-			result2.Close()
+			_ = result2.Close()
 		}
 	})
 

--- a/internal/raftengine/raftenginetest/conformance.go
+++ b/internal/raftengine/raftenginetest/conformance.go
@@ -1,0 +1,262 @@
+// Package raftenginetest provides a shared conformance test suite for
+// raftengine.Engine implementations. Each engine package should call
+// RunConformanceSuite with its own Factory in a _test.go file.
+package raftenginetest
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bootjp/elastickv/internal/raftengine"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStateMachine is a simple in-memory state machine for testing. It
+// records all applied entries and supports snapshot/restore via a binary
+// encoding.
+type TestStateMachine struct {
+	mu      sync.Mutex
+	applied [][]byte
+}
+
+func (s *TestStateMachine) Apply(data []byte) any {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.applied = append(s.applied, append([]byte(nil), data...))
+	return string(data)
+}
+
+func (s *TestStateMachine) Applied() [][]byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([][]byte, len(s.applied))
+	for i, item := range s.applied {
+		out[i] = append([]byte(nil), item...)
+	}
+	return out
+}
+
+func (s *TestStateMachine) Snapshot() (raftengine.Snapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var buf bytes.Buffer
+	//nolint:gosec // length is bounded by memory
+	if err := binary.Write(&buf, binary.BigEndian, uint32(len(s.applied))); err != nil {
+		return nil, err
+	}
+	for _, item := range s.applied {
+		//nolint:gosec // length is bounded by memory
+		if err := binary.Write(&buf, binary.BigEndian, uint32(len(item))); err != nil {
+			return nil, err
+		}
+		if _, err := buf.Write(item); err != nil {
+			return nil, err
+		}
+	}
+	return &testSnapshot{data: buf.Bytes()}, nil
+}
+
+func (s *TestStateMachine) Restore(r io.Reader) error {
+	var count uint32
+	if err := binary.Read(r, binary.BigEndian, &count); err != nil {
+		return err
+	}
+
+	applied := make([][]byte, 0, count)
+	for range count {
+		var length uint32
+		if err := binary.Read(r, binary.BigEndian, &length); err != nil {
+			return err
+		}
+		item := make([]byte, length)
+		if _, err := io.ReadFull(r, item); err != nil {
+			return err
+		}
+		applied = append(applied, item)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.applied = applied
+	return nil
+}
+
+type testSnapshot struct {
+	data []byte
+}
+
+func (s *testSnapshot) WriteTo(w io.Writer) (int64, error) {
+	n, err := w.Write(s.data)
+	return int64(n), err
+}
+
+func (s *testSnapshot) Close() error {
+	return nil
+}
+
+const (
+	leaderElectionTimeout  = 5 * time.Second
+	leaderElectionInterval = 10 * time.Millisecond
+)
+
+// RunConformanceSuite runs the shared conformance tests against the given
+// factory. The factory should create single-node, self-bootstrapping engines.
+func RunConformanceSuite(t *testing.T, factory raftengine.Factory) {
+	t.Run("SingleNodeProposeAndRead", func(t *testing.T) {
+		testSingleNodeProposeAndRead(t, factory)
+	})
+	t.Run("StatusReporting", func(t *testing.T) {
+		testStatusReporting(t, factory)
+	})
+	t.Run("Configuration", func(t *testing.T) {
+		testConfiguration(t, factory)
+	})
+	t.Run("ProposeContextCancellation", func(t *testing.T) {
+		testProposeContextCancellation(t, factory)
+	})
+	t.Run("CloseAndReopen", func(t *testing.T) {
+		testCloseAndReopen(t, factory)
+	})
+}
+
+func createSingleNode(t *testing.T, factory raftengine.Factory, dir string, sm *TestStateMachine) *raftengine.FactoryResult {
+	t.Helper()
+	result, err := factory.Create(raftengine.FactoryConfig{
+		LocalID:      "n1",
+		LocalAddress: "127.0.0.1:0",
+		DataDir:      dir,
+		Bootstrap:    true,
+		StateMachine: sm,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = result.Engine.Close()
+		if result.Close != nil {
+			result.Close()
+		}
+	})
+
+	// Wait for leader election
+	require.Eventually(t, func() bool {
+		return result.Engine.State() == raftengine.StateLeader
+	}, leaderElectionTimeout, leaderElectionInterval, "engine did not become leader")
+
+	return result
+}
+
+func testSingleNodeProposeAndRead(t *testing.T, factory raftengine.Factory) {
+	sm := &TestStateMachine{}
+	result := createSingleNode(t, factory, t.TempDir(), sm)
+
+	ctx := context.Background()
+	pr, err := result.Engine.Propose(ctx, []byte("hello"))
+	require.NoError(t, err)
+	require.NotNil(t, pr)
+	require.NotZero(t, pr.CommitIndex)
+	require.Equal(t, "hello", pr.Response)
+
+	readIdx, err := result.Engine.LinearizableRead(ctx)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, readIdx, pr.CommitIndex)
+
+	applied := sm.Applied()
+	require.Len(t, applied, 1)
+	require.Equal(t, []byte("hello"), applied[0])
+}
+
+func testStatusReporting(t *testing.T, factory raftengine.Factory) {
+	sm := &TestStateMachine{}
+	result := createSingleNode(t, factory, t.TempDir(), sm)
+
+	ctx := context.Background()
+	_, err := result.Engine.Propose(ctx, []byte("status-test"))
+	require.NoError(t, err)
+
+	status := result.Engine.Status()
+	require.Equal(t, raftengine.StateLeader, status.State)
+	require.NotZero(t, status.CommitIndex)
+	require.NotZero(t, status.AppliedIndex)
+	require.Equal(t, "n1", status.Leader.ID)
+}
+
+func testConfiguration(t *testing.T, factory raftengine.Factory) {
+	sm := &TestStateMachine{}
+	result := createSingleNode(t, factory, t.TempDir(), sm)
+
+	cfg, err := result.Engine.Configuration(context.Background())
+	require.NoError(t, err)
+	require.Len(t, cfg.Servers, 1)
+	require.Equal(t, "n1", cfg.Servers[0].ID)
+}
+
+func testProposeContextCancellation(t *testing.T, factory raftengine.Factory) {
+	sm := &TestStateMachine{}
+	result := createSingleNode(t, factory, t.TempDir(), sm)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err := result.Engine.Propose(ctx, []byte("should-fail"))
+	require.Error(t, err)
+}
+
+func testCloseAndReopen(t *testing.T, factory raftengine.Factory) {
+	sm := &TestStateMachine{}
+	dir := t.TempDir()
+
+	// First open: propose data
+	result1, err := factory.Create(raftengine.FactoryConfig{
+		LocalID:      "n1",
+		LocalAddress: "127.0.0.1:0",
+		DataDir:      dir,
+		Bootstrap:    true,
+		StateMachine: sm,
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return result1.Engine.State() == raftengine.StateLeader
+	}, leaderElectionTimeout, leaderElectionInterval)
+
+	_, err = result1.Engine.Propose(context.Background(), []byte("persist-me"))
+	require.NoError(t, err)
+
+	_ = result1.Engine.Close()
+	if result1.Close != nil {
+		result1.Close()
+	}
+
+	// Second open: verify data persisted
+	sm2 := &TestStateMachine{}
+	result2, err := factory.Create(raftengine.FactoryConfig{
+		LocalID:      "n1",
+		LocalAddress: "127.0.0.1:0",
+		DataDir:      dir,
+		StateMachine: sm2,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = result2.Engine.Close()
+		if result2.Close != nil {
+			result2.Close()
+		}
+	})
+
+	require.Eventually(t, func() bool {
+		return result2.Engine.State() == raftengine.StateLeader
+	}, leaderElectionTimeout, leaderElectionInterval)
+
+	// Wait for the FSM to replay the log
+	require.Eventually(t, func() bool {
+		return len(sm2.Applied()) >= 1
+	}, leaderElectionTimeout, leaderElectionInterval)
+
+	applied := sm2.Applied()
+	require.Equal(t, []byte("persist-me"), applied[len(applied)-1])
+}

--- a/internal/raftengine/statemachine.go
+++ b/internal/raftengine/statemachine.go
@@ -1,0 +1,21 @@
+package raftengine
+
+import "io"
+
+// Snapshot is an owned export handle from the state machine. Callers are
+// responsible for closing it after WriteTo completes.
+type Snapshot interface {
+	WriteTo(w io.Writer) (int64, error)
+	Close() error
+}
+
+// StateMachine is the interface that engine-agnostic state machines must
+// implement. Both the hashicorp and etcd backends use this contract.
+type StateMachine interface {
+	Apply(data []byte) any
+	// Snapshot should capture a stable export handle quickly. Expensive snapshot
+	// serialization belongs in Snapshot.WriteTo, which the engine can run off
+	// the main raft loop.
+	Snapshot() (Snapshot, error)
+	Restore(r io.Reader) error
+}

--- a/kv/coordinator_dispatch_test.go
+++ b/kv/coordinator_dispatch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	hashicorpraftengine "github.com/bootjp/elastickv/internal/raftengine/hashicorp"
 	"github.com/bootjp/elastickv/store"
 	"github.com/stretchr/testify/require"
 )
@@ -134,7 +135,7 @@ func TestCoordinateDispatch_TxnAssignsStartTS(t *testing.T) {
 
 	c := &Coordinate{
 		transactionManager: tx,
-		engine:             engineFromRaft(r),
+		engine:             hashicorpraftengine.New(r),
 		clock:              NewHLC(),
 	}
 
@@ -166,7 +167,7 @@ func TestCoordinateDispatchRaw_CallsTransactionManager(t *testing.T) {
 
 	c := &Coordinate{
 		transactionManager: tx,
-		engine:             engineFromRaft(r),
+		engine:             hashicorpraftengine.New(r),
 		clock:              NewHLC(),
 	}
 

--- a/kv/lock_resolver_test.go
+++ b/kv/lock_resolver_test.go
@@ -26,9 +26,11 @@ func setupLockResolverEnv(t *testing.T) (*LockResolver, *ShardStore, map[uint64]
 	st2 := store.NewMVCCStore()
 	r2, stop2 := newSingleRaft(t, "lr-g2", NewKvFSM(st2))
 
+	e1 := hashicorpraftengine.New(r1)
+	e2 := hashicorpraftengine.New(r2)
 	groups := map[uint64]*ShardGroup{
-		1: {Engine: hashicorpraftengine.New(r1), Store: st1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
-		2: {Engine: hashicorpraftengine.New(r2), Store: st2, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r2))},
+		1: {Engine: e1, Store: st1, Txn: NewLeaderProxyWithEngine(e1)},
+		2: {Engine: e2, Store: st2, Txn: NewLeaderProxyWithEngine(e2)},
 	}
 	ss := NewShardStore(engine, groups)
 	lr := NewLockResolver(ss, groups, nil)

--- a/kv/lock_resolver_test.go
+++ b/kv/lock_resolver_test.go
@@ -209,8 +209,9 @@ func TestLockResolver_LeaderOnlyExecution(t *testing.T) {
 	r, stop := newSingleRaft(t, "lr-leader", NewKvFSM(st))
 	defer stop()
 
+	e := hashicorpraftengine.New(r)
 	groups := map[uint64]*ShardGroup{
-		1: {Engine: hashicorpraftengine.New(r), Store: st, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r))},
+		1: {Engine: e, Store: st, Txn: NewLeaderProxyWithEngine(e)},
 	}
 	ss := NewShardStore(engine, groups)
 	lr := NewLockResolver(ss, groups, nil)
@@ -239,8 +240,9 @@ func TestLockResolver_CloseStopsBackground(t *testing.T) {
 	r, stop := newSingleRaft(t, "lr-close", NewKvFSM(st))
 	defer stop()
 
+	e := hashicorpraftengine.New(r)
 	groups := map[uint64]*ShardGroup{
-		1: {Engine: hashicorpraftengine.New(r), Store: st, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r))},
+		1: {Engine: e, Store: st, Txn: NewLeaderProxyWithEngine(e)},
 	}
 	ss := NewShardStore(engine, groups)
 	lr := NewLockResolver(ss, groups, nil)

--- a/kv/lock_resolver_test.go
+++ b/kv/lock_resolver_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/bootjp/elastickv/distribution"
+	hashicorpraftengine "github.com/bootjp/elastickv/internal/raftengine/hashicorp"
 	pb "github.com/bootjp/elastickv/proto"
 	"github.com/bootjp/elastickv/store"
 	"github.com/stretchr/testify/require"
@@ -26,8 +27,8 @@ func setupLockResolverEnv(t *testing.T) (*LockResolver, *ShardStore, map[uint64]
 	r2, stop2 := newSingleRaft(t, "lr-g2", NewKvFSM(st2))
 
 	groups := map[uint64]*ShardGroup{
-		1: {Raft: r1, Store: st1, Txn: NewLeaderProxy(r1)},
-		2: {Raft: r2, Store: st2, Txn: NewLeaderProxy(r2)},
+		1: {Engine: hashicorpraftengine.New(r1), Store: st1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
+		2: {Engine: hashicorpraftengine.New(r2), Store: st2, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r2))},
 	}
 	ss := NewShardStore(engine, groups)
 	lr := NewLockResolver(ss, groups, nil)
@@ -207,7 +208,7 @@ func TestLockResolver_LeaderOnlyExecution(t *testing.T) {
 	defer stop()
 
 	groups := map[uint64]*ShardGroup{
-		1: {Raft: r, Store: st, Txn: NewLeaderProxy(r)},
+		1: {Engine: hashicorpraftengine.New(r), Store: st, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r))},
 	}
 	ss := NewShardStore(engine, groups)
 	lr := NewLockResolver(ss, groups, nil)
@@ -237,7 +238,7 @@ func TestLockResolver_CloseStopsBackground(t *testing.T) {
 	defer stop()
 
 	groups := map[uint64]*ShardGroup{
-		1: {Raft: r, Store: st, Txn: NewLeaderProxy(r)},
+		1: {Engine: hashicorpraftengine.New(r), Store: st, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r))},
 	}
 	ss := NewShardStore(engine, groups)
 	lr := NewLockResolver(ss, groups, nil)

--- a/kv/raft_engine.go
+++ b/kv/raft_engine.go
@@ -4,26 +4,15 @@ import (
 	"context"
 
 	"github.com/bootjp/elastickv/internal/raftengine"
-	hashicorpraftengine "github.com/bootjp/elastickv/internal/raftengine/hashicorp"
 	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/raft"
 )
-
-func engineFromRaft(r *raft.Raft) raftengine.Engine {
-	if r == nil {
-		return nil
-	}
-	return hashicorpraftengine.New(r)
-}
 
 func engineForGroup(g *ShardGroup) raftengine.Engine {
 	if g == nil {
 		return nil
 	}
-	if g.Engine != nil {
-		return g.Engine
-	}
-	return engineFromRaft(g.Raft)
+	return g.Engine
 }
 
 func isLeaderEngine(engine raftengine.LeaderView) bool {

--- a/kv/shard_store_txn_lock_test.go
+++ b/kv/shard_store_txn_lock_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/bootjp/elastickv/distribution"
+	hashicorpraftengine "github.com/bootjp/elastickv/internal/raftengine/hashicorp"
 	pb "github.com/bootjp/elastickv/proto"
 	"github.com/bootjp/elastickv/store"
 	"github.com/cockroachdb/errors"
@@ -26,8 +27,8 @@ func setupTwoShardStore(t *testing.T) (*ShardStore, map[uint64]*ShardGroup, func
 	r2, stop2 := newSingleRaft(t, "g2", NewKvFSM(st2))
 
 	groups := map[uint64]*ShardGroup{
-		1: {Raft: r1, Store: st1, Txn: NewLeaderProxy(r1)},
-		2: {Raft: r2, Store: st2, Txn: NewLeaderProxy(r2)},
+		1: {Engine: hashicorpraftengine.New(r1), Store: st1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
+		2: {Engine: hashicorpraftengine.New(r2), Store: st2, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r2))},
 	}
 	shardStore := NewShardStore(engine, groups)
 
@@ -95,7 +96,7 @@ func TestShardStoreGetAt_ReturnsTxnLockedForPendingLock(t *testing.T) {
 	defer stop1()
 
 	groups := map[uint64]*ShardGroup{
-		1: {Raft: r1, Store: st1, Txn: NewLeaderProxy(r1)},
+		1: {Engine: hashicorpraftengine.New(r1), Store: st1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
 	}
 	shardStore := NewShardStore(engine, groups)
 
@@ -231,7 +232,7 @@ func TestShardStoreScanAt_ReturnsTxnLockedForPendingLock(t *testing.T) {
 	defer stop1()
 
 	groups := map[uint64]*ShardGroup{
-		1: {Raft: r1, Store: st1, Txn: NewLeaderProxy(r1)},
+		1: {Engine: hashicorpraftengine.New(r1), Store: st1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
 	}
 	shardStore := NewShardStore(engine, groups)
 
@@ -260,7 +261,7 @@ func TestShardStoreScanAt_ReturnsTxnLockedForPendingLockWithoutCommittedValue(t 
 	defer stop1()
 
 	groups := map[uint64]*ShardGroup{
-		1: {Raft: r1, Store: st1, Txn: NewLeaderProxy(r1)},
+		1: {Engine: hashicorpraftengine.New(r1), Store: st1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
 	}
 	shardStore := NewShardStore(engine, groups)
 
@@ -289,7 +290,7 @@ func TestShardStoreScanAt_ReturnsTxnLockedWhenPendingLockExceedsUserLimit(t *tes
 	defer stop1()
 
 	groups := map[uint64]*ShardGroup{
-		1: {Raft: r1, Store: st1, Txn: NewLeaderProxy(r1)},
+		1: {Engine: hashicorpraftengine.New(r1), Store: st1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
 	}
 	shardStore := NewShardStore(engine, groups)
 

--- a/kv/shard_store_txn_lock_test.go
+++ b/kv/shard_store_txn_lock_test.go
@@ -97,8 +97,9 @@ func TestShardStoreGetAt_ReturnsTxnLockedForPendingLock(t *testing.T) {
 	r1, stop1 := newSingleRaft(t, "g1", NewKvFSM(st1))
 	defer stop1()
 
+	e1 := hashicorpraftengine.New(r1)
 	groups := map[uint64]*ShardGroup{
-		1: {Engine: hashicorpraftengine.New(r1), Store: st1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
+		1: {Engine: e1, Store: st1, Txn: NewLeaderProxyWithEngine(e1)},
 	}
 	shardStore := NewShardStore(engine, groups)
 
@@ -233,8 +234,9 @@ func TestShardStoreScanAt_ReturnsTxnLockedForPendingLock(t *testing.T) {
 	r1, stop1 := newSingleRaft(t, "g1", NewKvFSM(st1))
 	defer stop1()
 
+	e1 := hashicorpraftengine.New(r1)
 	groups := map[uint64]*ShardGroup{
-		1: {Engine: hashicorpraftengine.New(r1), Store: st1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
+		1: {Engine: e1, Store: st1, Txn: NewLeaderProxyWithEngine(e1)},
 	}
 	shardStore := NewShardStore(engine, groups)
 
@@ -262,8 +264,9 @@ func TestShardStoreScanAt_ReturnsTxnLockedForPendingLockWithoutCommittedValue(t 
 	r1, stop1 := newSingleRaft(t, "g1", NewKvFSM(st1))
 	defer stop1()
 
+	e1 := hashicorpraftengine.New(r1)
 	groups := map[uint64]*ShardGroup{
-		1: {Engine: hashicorpraftengine.New(r1), Store: st1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
+		1: {Engine: e1, Store: st1, Txn: NewLeaderProxyWithEngine(e1)},
 	}
 	shardStore := NewShardStore(engine, groups)
 
@@ -291,8 +294,9 @@ func TestShardStoreScanAt_ReturnsTxnLockedWhenPendingLockExceedsUserLimit(t *tes
 	r1, stop1 := newSingleRaft(t, "g1", NewKvFSM(st1))
 	defer stop1()
 
+	e1 := hashicorpraftengine.New(r1)
 	groups := map[uint64]*ShardGroup{
-		1: {Engine: hashicorpraftengine.New(r1), Store: st1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
+		1: {Engine: e1, Store: st1, Txn: NewLeaderProxyWithEngine(e1)},
 	}
 	shardStore := NewShardStore(engine, groups)
 

--- a/kv/shard_store_txn_lock_test.go
+++ b/kv/shard_store_txn_lock_test.go
@@ -26,9 +26,11 @@ func setupTwoShardStore(t *testing.T) (*ShardStore, map[uint64]*ShardGroup, func
 	st2 := store.NewMVCCStore()
 	r2, stop2 := newSingleRaft(t, "g2", NewKvFSM(st2))
 
+	e1 := hashicorpraftengine.New(r1)
+	e2 := hashicorpraftengine.New(r2)
 	groups := map[uint64]*ShardGroup{
-		1: {Engine: hashicorpraftengine.New(r1), Store: st1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
-		2: {Engine: hashicorpraftengine.New(r2), Store: st2, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r2))},
+		1: {Engine: e1, Store: st1, Txn: NewLeaderProxyWithEngine(e1)},
+		2: {Engine: e2, Store: st2, Txn: NewLeaderProxyWithEngine(e2)},
 	}
 	shardStore := NewShardStore(engine, groups)
 

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -18,7 +18,6 @@ import (
 )
 
 type ShardGroup struct {
-	Raft   *raft.Raft
 	Engine raftengine.Engine
 	Store  store.MVCCStore
 	Txn    Transactional

--- a/kv/sharded_coordinator_abort_test.go
+++ b/kv/sharded_coordinator_abort_test.go
@@ -48,8 +48,9 @@ func TestShardedAbortRollback_PrepareFailOnShard2_CleansShard1Locks(t *testing.T
 	s2 := store.NewMVCCStore()
 	failTxn := &failingTransactional{err: errors.New("simulated shard2 prepare failure")}
 
+	e1 := hashicorpraftengine.New(r1)
 	groups := map[uint64]*ShardGroup{
-		1: {Engine: hashicorpraftengine.New(r1), Store: s1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
+		1: {Engine: e1, Store: s1, Txn: NewLeaderProxyWithEngine(e1)},
 		2: {Store: s2, Txn: failTxn},
 	}
 

--- a/kv/sharded_coordinator_abort_test.go
+++ b/kv/sharded_coordinator_abort_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/bootjp/elastickv/distribution"
+	hashicorpraftengine "github.com/bootjp/elastickv/internal/raftengine/hashicorp"
 	pb "github.com/bootjp/elastickv/proto"
 	"github.com/bootjp/elastickv/store"
 	"github.com/cockroachdb/errors"
@@ -48,8 +49,8 @@ func TestShardedAbortRollback_PrepareFailOnShard2_CleansShard1Locks(t *testing.T
 	failTxn := &failingTransactional{err: errors.New("simulated shard2 prepare failure")}
 
 	groups := map[uint64]*ShardGroup{
-		1: {Raft: r1, Store: s1, Txn: NewLeaderProxy(r1)},
-		2: {Raft: nil, Store: s2, Txn: failTxn},
+		1: {Engine: hashicorpraftengine.New(r1), Store: s1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
+		2: {Store: s2, Txn: failTxn},
 	}
 
 	shardStore := NewShardStore(engine, groups)

--- a/kv/sharded_coordinator_del_prefix_test.go
+++ b/kv/sharded_coordinator_del_prefix_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/bootjp/elastickv/distribution"
+	hashicorpraftengine "github.com/bootjp/elastickv/internal/raftengine/hashicorp"
 	pb "github.com/bootjp/elastickv/proto"
 	"github.com/bootjp/elastickv/store"
 	"github.com/stretchr/testify/require"
@@ -277,8 +278,8 @@ func TestShardedCoordinator_DelPrefixIntegration(t *testing.T) {
 	t.Cleanup(stop2)
 
 	groups := map[uint64]*ShardGroup{
-		1: {Raft: r1, Store: s1, Txn: NewLeaderProxy(r1)},
-		2: {Raft: r2, Store: s2, Txn: NewLeaderProxy(r2)},
+		1: {Engine: hashicorpraftengine.New(r1), Store: s1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
+		2: {Engine: hashicorpraftengine.New(r2), Store: s2, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r2))},
 	}
 
 	shardStore := NewShardStore(engine, groups)
@@ -339,7 +340,7 @@ func TestShardedCoordinator_DelPrefixPreservesTxnKeys(t *testing.T) {
 	t.Cleanup(stop1)
 
 	groups := map[uint64]*ShardGroup{
-		1: {Raft: r1, Store: s1, Txn: NewLeaderProxy(r1)},
+		1: {Engine: hashicorpraftengine.New(r1), Store: s1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
 	}
 	shardStore := NewShardStore(engine, groups)
 	coord := NewShardedCoordinator(engine, groups, 1, NewHLC(), shardStore)

--- a/kv/sharded_coordinator_del_prefix_test.go
+++ b/kv/sharded_coordinator_del_prefix_test.go
@@ -341,8 +341,9 @@ func TestShardedCoordinator_DelPrefixPreservesTxnKeys(t *testing.T) {
 	r1, stop1 := newSingleRaft(t, "dp-txn-g1", NewKvFSM(s1))
 	t.Cleanup(stop1)
 
+	e1 := hashicorpraftengine.New(r1)
 	groups := map[uint64]*ShardGroup{
-		1: {Engine: hashicorpraftengine.New(r1), Store: s1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
+		1: {Engine: e1, Store: s1, Txn: NewLeaderProxyWithEngine(e1)},
 	}
 	shardStore := NewShardStore(engine, groups)
 	coord := NewShardedCoordinator(engine, groups, 1, NewHLC(), shardStore)

--- a/kv/sharded_coordinator_del_prefix_test.go
+++ b/kv/sharded_coordinator_del_prefix_test.go
@@ -277,9 +277,11 @@ func TestShardedCoordinator_DelPrefixIntegration(t *testing.T) {
 	r2, stop2 := newSingleRaft(t, "dp-g2", NewKvFSM(s2))
 	t.Cleanup(stop2)
 
+	e1 := hashicorpraftengine.New(r1)
+	e2 := hashicorpraftengine.New(r2)
 	groups := map[uint64]*ShardGroup{
-		1: {Engine: hashicorpraftengine.New(r1), Store: s1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
-		2: {Engine: hashicorpraftengine.New(r2), Store: s2, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r2))},
+		1: {Engine: e1, Store: s1, Txn: NewLeaderProxyWithEngine(e1)},
+		2: {Engine: e2, Store: s2, Txn: NewLeaderProxyWithEngine(e2)},
 	}
 
 	shardStore := NewShardStore(engine, groups)

--- a/kv/sharded_coordinator_leader_test.go
+++ b/kv/sharded_coordinator_leader_test.go
@@ -19,11 +19,11 @@ func TestShardedCoordinatorVerifyLeader_LeaderReturnsNil(t *testing.T) {
 	r, stop := newSingleRaft(t, "shard-leader", NewKvFSM(st))
 	t.Cleanup(stop)
 
-	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{
-		1: {Engine: hashicorpraftengine.New(r), Store: st, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r))},
-	}, 1, NewHLC(), NewShardStore(engine, map[uint64]*ShardGroup{
-		1: {Engine: hashicorpraftengine.New(r), Store: st, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r))},
-	}))
+	re := hashicorpraftengine.New(r)
+	groups := map[uint64]*ShardGroup{
+		1: {Engine: re, Store: st, Txn: NewLeaderProxyWithEngine(re)},
+	}
+	coord := NewShardedCoordinator(engine, groups, 1, NewHLC(), NewShardStore(engine, groups))
 
 	require.NoError(t, coord.VerifyLeader())
 	require.NoError(t, coord.VerifyLeaderForKey([]byte("b")))

--- a/kv/sharded_coordinator_leader_test.go
+++ b/kv/sharded_coordinator_leader_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/bootjp/elastickv/distribution"
+	hashicorpraftengine "github.com/bootjp/elastickv/internal/raftengine/hashicorp"
 	"github.com/bootjp/elastickv/store"
 	"github.com/stretchr/testify/require"
 )
@@ -19,9 +20,9 @@ func TestShardedCoordinatorVerifyLeader_LeaderReturnsNil(t *testing.T) {
 	t.Cleanup(stop)
 
 	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{
-		1: {Raft: r, Store: st, Txn: NewLeaderProxy(r)},
+		1: {Engine: hashicorpraftengine.New(r), Store: st, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r))},
 	}, 1, NewHLC(), NewShardStore(engine, map[uint64]*ShardGroup{
-		1: {Raft: r, Store: st, Txn: NewLeaderProxy(r)},
+		1: {Engine: hashicorpraftengine.New(r), Store: st, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r))},
 	}))
 
 	require.NoError(t, coord.VerifyLeader())

--- a/kv/sharded_integration_test.go
+++ b/kv/sharded_integration_test.go
@@ -70,9 +70,11 @@ func TestShardedCoordinatorDispatch(t *testing.T) {
 	r2, stop2 := newSingleRaft(t, "g2", NewKvFSM(s2))
 	defer stop2()
 
+	e1 := hashicorpraftengine.New(r1)
+	e2 := hashicorpraftengine.New(r2)
 	groups := map[uint64]*ShardGroup{
-		1: {Engine: hashicorpraftengine.New(r1), Store: s1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
-		2: {Engine: hashicorpraftengine.New(r2), Store: s2, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r2))},
+		1: {Engine: e1, Store: s1, Txn: NewLeaderProxyWithEngine(e1)},
+		2: {Engine: e2, Store: s2, Txn: NewLeaderProxyWithEngine(e2)},
 	}
 
 	shardStore := NewShardStore(engine, groups)
@@ -122,9 +124,11 @@ func TestShardedCoordinatorDispatch_CrossShardTxnSucceeds(t *testing.T) {
 	r2, stop2 := newSingleRaft(t, "g2", NewKvFSM(s2))
 	defer stop2()
 
+	e1 := hashicorpraftengine.New(r1)
+	e2 := hashicorpraftengine.New(r2)
 	groups := map[uint64]*ShardGroup{
-		1: {Engine: hashicorpraftengine.New(r1), Store: s1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
-		2: {Engine: hashicorpraftengine.New(r2), Store: s2, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r2))},
+		1: {Engine: e1, Store: s1, Txn: NewLeaderProxyWithEngine(e1)},
+		2: {Engine: e2, Store: s2, Txn: NewLeaderProxyWithEngine(e2)},
 	}
 
 	shardStore := NewShardStore(engine, groups)

--- a/kv/sharded_integration_test.go
+++ b/kv/sharded_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/bootjp/elastickv/distribution"
+	hashicorpraftengine "github.com/bootjp/elastickv/internal/raftengine/hashicorp"
 	"github.com/bootjp/elastickv/store"
 	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/raft"
@@ -70,8 +71,8 @@ func TestShardedCoordinatorDispatch(t *testing.T) {
 	defer stop2()
 
 	groups := map[uint64]*ShardGroup{
-		1: {Raft: r1, Store: s1, Txn: NewLeaderProxy(r1)},
-		2: {Raft: r2, Store: s2, Txn: NewLeaderProxy(r2)},
+		1: {Engine: hashicorpraftengine.New(r1), Store: s1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
+		2: {Engine: hashicorpraftengine.New(r2), Store: s2, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r2))},
 	}
 
 	shardStore := NewShardStore(engine, groups)
@@ -122,8 +123,8 @@ func TestShardedCoordinatorDispatch_CrossShardTxnSucceeds(t *testing.T) {
 	defer stop2()
 
 	groups := map[uint64]*ShardGroup{
-		1: {Raft: r1, Store: s1, Txn: NewLeaderProxy(r1)},
-		2: {Raft: r2, Store: s2, Txn: NewLeaderProxy(r2)},
+		1: {Engine: hashicorpraftengine.New(r1), Store: s1, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r1))},
+		2: {Engine: hashicorpraftengine.New(r2), Store: s2, Txn: NewLeaderProxyWithEngine(hashicorpraftengine.New(r2))},
 	}
 
 	shardStore := NewShardStore(engine, groups)

--- a/kv/transaction_batch_test.go
+++ b/kv/transaction_batch_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	etcdraftengine "github.com/bootjp/elastickv/internal/raftengine/etcd"
+	hashicorpraftengine "github.com/bootjp/elastickv/internal/raftengine/hashicorp"
 	pb "github.com/bootjp/elastickv/proto"
 	"github.com/bootjp/elastickv/store"
 	"github.com/hashicorp/raft"
@@ -169,7 +170,7 @@ func TestApplyRequestsCountsProposalFailureOnRaftApplyError(t *testing.T) {
 		},
 	}}
 
-	_, _, err := applyRequests(engineFromRaft(r), reqs, observer)
+	_, _, err := applyRequests(hashicorpraftengine.New(r), reqs, observer)
 	require.Error(t, err)
 	require.Equal(t, 1, observer.FailureCount())
 }
@@ -188,7 +189,7 @@ func TestApplyRequestsDoesNotCountBusinessErrorAsProposalFailure(t *testing.T) {
 		},
 	}}
 
-	_, results, err := applyRequests(engineFromRaft(r), reqs, observer)
+	_, results, err := applyRequests(hashicorpraftengine.New(r), reqs, observer)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	require.ErrorIs(t, results[0], ErrInvalidRequest)

--- a/main.go
+++ b/main.go
@@ -16,6 +16,9 @@ import (
 	"github.com/bootjp/elastickv/distribution"
 	internalutil "github.com/bootjp/elastickv/internal"
 	internalraftadmin "github.com/bootjp/elastickv/internal/raftadmin"
+	"github.com/bootjp/elastickv/internal/raftengine"
+	etcdraftengine "github.com/bootjp/elastickv/internal/raftengine/etcd"
+	hashicorpraftengine "github.com/bootjp/elastickv/internal/raftengine/hashicorp"
 	"github.com/bootjp/elastickv/kv"
 	"github.com/bootjp/elastickv/monitoring"
 	pb "github.com/bootjp/elastickv/proto"
@@ -31,9 +34,55 @@ const (
 	heartbeatTimeout           = 200 * time.Millisecond
 	electionTimeout            = 2000 * time.Millisecond
 	leaderLease                = 100 * time.Millisecond
+	raftCommitTimeout          = 50 * time.Millisecond
 	raftMetricsObserveInterval = 5 * time.Second
 	dirPerm                    = raftDirPerm
+
+	etcdTickInterval      = 10 * time.Millisecond
+	etcdHeartbeatMinTicks = 1
+	etcdElectionMinTicks  = 2
+	etcdMaxSizePerMsg     = 1 << 20
+	etcdMaxInflightMsg    = 256
 )
+
+const snapshotRetainCount = 3
+
+func newRaftFactory(engineType raftEngineType) (raftengine.Factory, error) {
+	switch engineType {
+	case raftEngineHashicorp:
+		return hashicorpraftengine.NewFactory(hashicorpraftengine.FactoryConfig{
+			CommitTimeout:       raftCommitTimeout,
+			HeartbeatTimeout:    heartbeatTimeout,
+			ElectionTimeout:     electionTimeout,
+			LeaderLeaseTimeout:  leaderLease,
+			SnapshotRetainCount: snapshotRetainCount,
+		}), nil
+	case raftEngineEtcd:
+		return etcdraftengine.NewFactory(etcdraftengine.FactoryConfig{
+			TickInterval:   etcdTickInterval,
+			HeartbeatTick:  durationToTicks(heartbeatTimeout, etcdTickInterval, etcdHeartbeatMinTicks),
+			ElectionTick:   durationToTicks(electionTimeout, etcdTickInterval, etcdElectionMinTicks),
+			MaxSizePerMsg:  etcdMaxSizePerMsg,
+			MaxInflightMsg: etcdMaxInflightMsg,
+		}), nil
+	default:
+		return nil, errors.Wrapf(ErrUnsupportedRaftEngine, "%q", engineType)
+	}
+}
+
+func durationToTicks(timeout time.Duration, tick time.Duration, min int) int {
+	if tick <= 0 {
+		return min
+	}
+	ticks := int(timeout / tick)
+	if timeout%tick != 0 {
+		ticks++
+	}
+	if ticks < min {
+		return min
+	}
+	return ticks
+}
 
 var (
 	myAddr               = flag.String("address", "localhost:50051", "TCP host+port for this node")
@@ -72,6 +121,11 @@ func run() error {
 		return err
 	}
 
+	factory, err := newRaftFactory(engineType)
+	if err != nil {
+		return err
+	}
+
 	var lc net.ListenConfig
 
 	metricsRegistry := monitoring.NewRegistry(*raftId, *myAddr)
@@ -83,7 +137,7 @@ func run() error {
 		cfg.multi,
 		bootstrap,
 		bootstrapServers,
-		engineType,
+		factory,
 		func(groupID uint64) kv.ProposalObserver {
 			return metricsRegistry.RaftProposalObserver(groupID)
 		},
@@ -189,8 +243,6 @@ func resolveRuntimeInputs() (runtimeConfig, raftEngineType, []raft.Server, bool,
 
 	return cfg, engineType, bootstrapServers, *raftBootstrap || len(bootstrapServers) > 0, nil
 }
-
-const snapshotRetainCount = 3
 
 type runtimeConfig struct {
 	groups       []groupSpec
@@ -313,7 +365,7 @@ func buildShardGroups(
 	multi bool,
 	bootstrap bool,
 	bootstrapServers []raft.Server,
-	engineType raftEngineType,
+	factory raftengine.Factory,
 	proposalObserverForGroup func(uint64) kv.ProposalObserver,
 ) ([]*raftGroupRuntime, map[uint64]*kv.ShardGroup, error) {
 	runtimes := make([]*raftGroupRuntime, 0, len(groups))
@@ -327,8 +379,8 @@ func buildShardGroups(
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "failed to open pebble fsm store for group %d", g.id)
 		}
-		fsm := kv.NewKvFSM(st)
-		runtime, err := buildRuntimeForGroup(raftID, g, raftDir, multi, bootstrap, bootstrapServers, st, fsm, engineType)
+		sm := etcdraftengine.AdaptHashicorpFSM(kv.NewKvFSM(st))
+		runtime, err := buildRuntimeForGroup(raftID, g, raftDir, multi, bootstrap, bootstrapServers, st, sm, factory)
 		if err != nil {
 			for _, rt := range runtimes {
 				rt.Close()
@@ -338,7 +390,6 @@ func buildShardGroups(
 		}
 		runtimes = append(runtimes, runtime)
 		shardGroups[g.id] = &kv.ShardGroup{
-			Raft:   runtime.raft,
 			Engine: runtime.engine,
 			Store:  st,
 			Txn:    kv.NewLeaderProxyWithEngine(runtime.engine, kv.WithProposalObserver(observerForGroup(proposalObserverForGroup, g.id))),

--- a/main_bootstrap_e2e_test.go
+++ b/main_bootstrap_e2e_test.go
@@ -341,7 +341,11 @@ func startBootstrapE2ENode(
 	}
 	bootstrap = bootstrap || len(bootstrapServers) > 0
 
-	runtimes, shardGroups, err := buildShardGroups(ep.id, baseDir, cfg.groups, cfg.multi, bootstrap, bootstrapServers, engineType, nil)
+	factory, err := newRaftFactory(engineType)
+	if err != nil {
+		return nil, err
+	}
+	runtimes, shardGroups, err := buildShardGroups(ep.id, baseDir, cfg.groups, cfg.multi, bootstrap, bootstrapServers, factory, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/main_bootstrap_test.go
+++ b/main_bootstrap_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/hashicorp/raft"
 	"github.com/stretchr/testify/require"
@@ -65,5 +66,25 @@ func TestResolveBootstrapServers(t *testing.T) {
 	t.Run("only separators are rejected", func(t *testing.T) {
 		_, err := resolveBootstrapServers("n1", []groupSpec{{id: 1, address: "10.0.0.11:50051"}}, " , , ")
 		require.ErrorIs(t, err, ErrNoBootstrapMembersConfigured)
+	})
+}
+
+func TestDurationToTicks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("zero tick returns min", func(t *testing.T) {
+		require.Equal(t, 5, durationToTicks(200*time.Millisecond, 0, 5))
+	})
+
+	t.Run("exact division", func(t *testing.T) {
+		require.Equal(t, 20, durationToTicks(200*time.Millisecond, 10*time.Millisecond, 1))
+	})
+
+	t.Run("remainder rounds up", func(t *testing.T) {
+		require.Equal(t, 21, durationToTicks(205*time.Millisecond, 10*time.Millisecond, 1))
+	})
+
+	t.Run("below min returns min", func(t *testing.T) {
+		require.Equal(t, 10, durationToTicks(50*time.Millisecond, 10*time.Millisecond, 10))
 	})
 }

--- a/main_bootstrap_test.go
+++ b/main_bootstrap_test.go
@@ -88,3 +88,9 @@ func TestDurationToTicks(t *testing.T) {
 		require.Equal(t, 10, durationToTicks(50*time.Millisecond, 10*time.Millisecond, 10))
 	})
 }
+
+func TestNewRaftFactory_UnsupportedEngine(t *testing.T) {
+	t.Parallel()
+	_, err := newRaftFactory(raftEngineType("unknown"))
+	require.ErrorIs(t, err, ErrUnsupportedRaftEngine)
+}

--- a/multiraft_runtime.go
+++ b/multiraft_runtime.go
@@ -19,7 +19,7 @@ type raftGroupRuntime struct {
 	store  store.MVCCStore
 
 	registerTransport func(grpc.ServiceRegistrar)
-	closeFactory      func() // releases factory-created resources (transport, stores)
+	closeFactory      func() error // releases factory-created resources (transport, stores)
 }
 
 const raftEngineMarkerPerm = 0o600
@@ -58,7 +58,7 @@ func (r *raftGroupRuntime) Close() {
 		r.engine = nil
 	}
 	if r.closeFactory != nil {
-		r.closeFactory()
+		_ = r.closeFactory()
 		r.closeFactory = nil
 	}
 	if r.store != nil {

--- a/multiraft_runtime.go
+++ b/multiraft_runtime.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,15 +55,21 @@ func (r *raftGroupRuntime) Close() {
 		return
 	}
 	if r.engine != nil {
-		_ = r.engine.Close()
+		if err := r.engine.Close(); err != nil {
+			slog.Warn("failed to close raft engine", "error", err)
+		}
 		r.engine = nil
 	}
 	if r.closeFactory != nil {
-		_ = r.closeFactory()
+		if err := r.closeFactory(); err != nil {
+			slog.Warn("failed to close factory resources", "error", err)
+		}
 		r.closeFactory = nil
 	}
 	if r.store != nil {
-		_ = r.store.Close()
+		if err := r.store.Close(); err != nil {
+			slog.Warn("failed to close store", "error", err)
+		}
 		r.store = nil
 	}
 }

--- a/multiraft_runtime.go
+++ b/multiraft_runtime.go
@@ -1,19 +1,12 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
-	transport "github.com/Jille/raft-grpc-transport"
-	internalutil "github.com/bootjp/elastickv/internal"
 	"github.com/bootjp/elastickv/internal/raftengine"
-	etcdraftengine "github.com/bootjp/elastickv/internal/raftengine/etcd"
-	hashicorpraftengine "github.com/bootjp/elastickv/internal/raftengine/hashicorp"
-	"github.com/bootjp/elastickv/internal/raftstore"
 	"github.com/bootjp/elastickv/store"
 	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/raft"
@@ -22,29 +15,21 @@ import (
 
 type raftGroupRuntime struct {
 	spec   groupSpec
-	raft   *raft.Raft
 	engine raftengine.Engine
 	store  store.MVCCStore
 
 	registerTransport func(grpc.ServiceRegistrar)
-	closeTransport    func()
-	closeStores       func()
+	closeFactory      func() // releases factory-created resources (transport, stores)
 }
 
-const raftCommitTimeout = 50 * time.Millisecond
 const raftEngineMarkerPerm = 0o600
 
 type raftEngineType string
 
 const (
-	raftEngineHashicorp       raftEngineType = "hashicorp"
-	raftEngineEtcd            raftEngineType = "etcd"
-	raftEngineMarkerFile                     = "raft-engine"
-	etcdTickInterval                         = 10 * time.Millisecond
-	etcdHeartbeatMinTicks                    = 1
-	etcdElectionMinTicks                     = 2
-	etcdRuntimeMaxSizePerMsg                 = 1 << 20
-	etcdRuntimeMaxInflightMsg                = 256
+	raftEngineHashicorp  raftEngineType = "hashicorp"
+	raftEngineEtcd       raftEngineType = "etcd"
+	raftEngineMarkerFile                = "raft-engine"
 )
 
 var (
@@ -68,21 +53,13 @@ func (r *raftGroupRuntime) Close() {
 	if r == nil {
 		return
 	}
-	if r.raft != nil {
-		_ = r.raft.Shutdown().Error()
-		r.raft = nil
-	}
 	if r.engine != nil {
 		_ = r.engine.Close()
 		r.engine = nil
 	}
-	if r.closeTransport != nil {
-		r.closeTransport()
-		r.closeTransport = nil
-	}
-	if r.closeStores != nil {
-		r.closeStores()
-		r.closeStores = nil
+	if r.closeFactory != nil {
+		r.closeFactory()
+		r.closeFactory = nil
 	}
 	if r.store != nil {
 		_ = r.store.Close()
@@ -95,22 +72,6 @@ func (r *raftGroupRuntime) registerGRPC(server grpc.ServiceRegistrar) {
 		return
 	}
 	r.registerTransport(server)
-}
-
-func closeRaftStore(raftStore **raftstore.PebbleStore) {
-	if raftStore == nil || *raftStore == nil {
-		return
-	}
-	_ = (*raftStore).Close()
-	*raftStore = nil
-}
-
-func closeTransportManager(tm **transport.Manager) {
-	if tm == nil || *tm == nil {
-		return
-	}
-	_ = (*tm).Close()
-	*tm = nil
 }
 
 const raftDirPerm = 0o755
@@ -226,152 +187,16 @@ func syncDataDir(path string) error {
 	return nil
 }
 
-func newRaftGroup(raftID string, group groupSpec, baseDir string, multi bool, bootstrap bool, bootstrapServers []raft.Server, fsm raft.FSM) (*raft.Raft, *transport.Manager, func(), error) {
-	c := raft.DefaultConfig()
-	c.LocalID = raft.ServerID(raftID)
-	c.CommitTimeout = raftCommitTimeout
-	c.HeartbeatTimeout = heartbeatTimeout
-	c.ElectionTimeout = electionTimeout
-	c.LeaderLeaseTimeout = leaderLease
-
-	dir := groupDataDir(baseDir, raftID, group.id, multi)
-	if err := os.MkdirAll(dir, raftDirPerm); err != nil {
-		return nil, nil, nil, errors.WithStack(err)
-	}
-
-	var raftStore *raftstore.PebbleStore
-	var tm *transport.Manager
-
-	closeStores := func() { closeRaftStore(&raftStore) }
-	cleanup := func() {
-		closeTransportManager(&tm)
-		closeStores()
-	}
-
-	for _, legacy := range []string{"logs.dat", "stable.dat"} {
-		if _, err := os.Stat(filepath.Join(dir, legacy)); err == nil {
-			cleanup()
-			return nil, nil, nil, errors.WithStack(errors.Newf(
-				"legacy boltdb Raft storage %q found in %s; manual migration required before using Pebble-backed storage",
-				legacy, dir,
-			))
-		}
-	}
-
-	var err error
-	raftStore, err = raftstore.NewPebbleStore(filepath.Join(dir, "raft.db"))
-	if err != nil {
-		return nil, nil, nil, errors.WithStack(err)
-	}
-
-	fss, err := raft.NewFileSnapshotStore(dir, snapshotRetainCount, os.Stderr)
-	if err != nil {
-		cleanup()
-		return nil, nil, nil, errors.WithStack(err)
-	}
-
-	tm = transport.New(raft.ServerAddress(group.address), internalutil.GRPCDialOptions())
-
-	r, err := raft.NewRaft(c, fsm, raftStore, raftStore, fss, tm.Transport())
-	if err != nil {
-		cleanup()
-		return nil, nil, nil, errors.WithStack(err)
-	}
-
-	if bootstrap {
-		servers := bootstrapServers
-		if len(servers) == 0 {
-			servers = []raft.Server{
-				{
-					Suffrage: raft.Voter,
-					ID:       raft.ServerID(raftID),
-					Address:  raft.ServerAddress(group.address),
-				},
-			}
-		}
-		cfg := raft.Configuration{Servers: servers}
-		f := r.BootstrapCluster(cfg)
-		if err := f.Error(); err != nil {
-			_ = r.Shutdown().Error()
-			cleanup()
-			return nil, nil, nil, errors.WithStack(err)
-		}
-	}
-
-	return r, tm, closeStores, nil
-}
-
-func newEtcdGroup(raftID string, group groupSpec, baseDir string, multi bool, bootstrap bool, bootstrapServers []raft.Server, fsm raft.FSM) (raftengine.Engine, func(grpc.ServiceRegistrar), error) {
-	dir := groupDataDir(baseDir, raftID, group.id, multi)
-	if err := os.MkdirAll(dir, raftDirPerm); err != nil {
-		return nil, nil, errors.WithStack(err)
-	}
-
-	peers := etcdPeersFromServers(bootstrapServers)
-	if persistedPeers, ok, err := etcdraftengine.LoadPersistedPeers(dir); err != nil {
-		return nil, nil, errors.WithStack(err)
-	} else if ok {
-		peers = persistedPeers
-	}
-	var transport *etcdraftengine.GRPCTransport
-	if len(peers) > 1 {
-		transport = etcdraftengine.NewGRPCTransport(peers)
-	}
-
-	engine, err := etcdraftengine.Open(context.Background(), etcdraftengine.OpenConfig{
-		LocalID:        raftID,
-		LocalAddress:   group.address,
-		DataDir:        dir,
-		Peers:          peers,
-		Bootstrap:      bootstrap,
-		Transport:      transport,
-		StateMachine:   etcdraftengine.AdaptHashicorpFSM(fsm),
-		TickInterval:   etcdTickInterval,
-		HeartbeatTick:  durationToTicks(heartbeatTimeout, etcdTickInterval, etcdHeartbeatMinTicks),
-		ElectionTick:   durationToTicks(electionTimeout, etcdTickInterval, etcdElectionMinTicks),
-		MaxSizePerMsg:  etcdRuntimeMaxSizePerMsg,
-		MaxInflightMsg: etcdRuntimeMaxInflightMsg,
-	})
-	if err != nil {
-		if transport != nil {
-			_ = transport.Close()
-		}
-		return nil, nil, errors.WithStack(err)
-	}
-
-	var register func(grpc.ServiceRegistrar)
-	if transport != nil {
-		register = transport.Register
-	}
-	return engine, register, nil
-}
-
-func etcdPeersFromServers(servers []raft.Server) []etcdraftengine.Peer {
-	if len(servers) == 0 {
-		return nil
-	}
-	peers := make([]etcdraftengine.Peer, 0, len(servers))
-	for _, server := range servers {
-		peers = append(peers, etcdraftengine.Peer{
-			ID:      string(server.ID),
-			Address: string(server.Address),
+func bootstrapPeersToServers(bootstrapServers []raft.Server) []raftengine.Server {
+	servers := make([]raftengine.Server, 0, len(bootstrapServers))
+	for _, s := range bootstrapServers {
+		servers = append(servers, raftengine.Server{
+			ID:       string(s.ID),
+			Address:  string(s.Address),
+			Suffrage: "voter",
 		})
 	}
-	return peers
-}
-
-func durationToTicks(timeout time.Duration, tick time.Duration, min int) int {
-	if tick <= 0 {
-		return min
-	}
-	ticks := int(timeout / tick)
-	if timeout%tick != 0 {
-		ticks++
-	}
-	if ticks < min {
-		return min
-	}
-	return ticks
+	return servers
 }
 
 func buildRuntimeForGroup(
@@ -382,41 +207,32 @@ func buildRuntimeForGroup(
 	bootstrap bool,
 	bootstrapServers []raft.Server,
 	st store.MVCCStore,
-	fsm raft.FSM,
-	engineType raftEngineType,
+	sm raftengine.StateMachine,
+	factory raftengine.Factory,
 ) (*raftGroupRuntime, error) {
 	dir := groupDataDir(baseDir, raftID, group.id, multi)
+	engineType := raftEngineType(factory.EngineType())
 	if err := ensureRaftEngineDataDir(dir, engineType); err != nil {
 		return nil, err
 	}
 
-	switch engineType {
-	case raftEngineHashicorp:
-		r, tm, closeStores, err := newRaftGroup(raftID, group, baseDir, multi, bootstrap, bootstrapServers, fsm)
-		if err != nil {
-			return nil, err
-		}
-		return &raftGroupRuntime{
-			spec:              group,
-			raft:              r,
-			engine:            hashicorpraftengine.New(r),
-			store:             st,
-			registerTransport: tm.Register,
-			closeTransport:    func() { closeTransportManager(&tm) },
-			closeStores:       closeStores,
-		}, nil
-	case raftEngineEtcd:
-		engine, register, err := newEtcdGroup(raftID, group, baseDir, multi, bootstrap, bootstrapServers, fsm)
-		if err != nil {
-			return nil, err
-		}
-		return &raftGroupRuntime{
-			spec:              group,
-			engine:            engine,
-			store:             st,
-			registerTransport: register,
-		}, nil
-	default:
-		return nil, errors.Wrapf(ErrUnsupportedRaftEngine, "%q", engineType)
+	result, err := factory.Create(raftengine.FactoryConfig{
+		LocalID:      raftID,
+		LocalAddress: group.address,
+		DataDir:      dir,
+		Peers:        bootstrapPeersToServers(bootstrapServers),
+		Bootstrap:    bootstrap,
+		StateMachine: sm,
+	})
+	if err != nil {
+		return nil, errors.WithStack(err)
 	}
+
+	return &raftGroupRuntime{
+		spec:              group,
+		engine:            result.Engine,
+		store:             st,
+		registerTransport: result.RegisterTransport,
+		closeFactory:      result.Close,
+	}, nil
 }

--- a/multiraft_runtime_test.go
+++ b/multiraft_runtime_test.go
@@ -5,12 +5,11 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/bootjp/elastickv/distribution"
+	etcdraftengine "github.com/bootjp/elastickv/internal/raftengine/etcd"
 	"github.com/bootjp/elastickv/kv"
 	"github.com/bootjp/elastickv/store"
-	"github.com/hashicorp/raft"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,31 +26,30 @@ func TestGroupDataDir(t *testing.T) {
 	})
 }
 
-func TestNewRaftGroupBootstrap(t *testing.T) {
+func TestBuildRuntimeForGroupBootstrap(t *testing.T) {
 	baseDir := t.TempDir()
 
-	st := store.NewMVCCStore()
-	fsm := kv.NewKvFSM(st)
+	factory, err := newRaftFactory(raftEngineHashicorp)
+	require.NoError(t, err)
 
-	r, tm, closeStores, err := newRaftGroup(
+	st := store.NewMVCCStore()
+	sm := etcdraftengine.AdaptHashicorpFSM(kv.NewKvFSM(st))
+
+	runtime, err := buildRuntimeForGroup(
 		"n1",
 		groupSpec{id: 1, address: "127.0.0.1:0"},
 		baseDir,
 		true, // multi
 		true, // bootstrap
 		nil,
-		fsm,
+		st,
+		sm,
+		factory,
 	)
 	require.NoError(t, err)
-	require.NotNil(t, r)
-	require.NotNil(t, tm)
-	t.Cleanup(func() {
-		_ = r.Shutdown().Error()
-		_ = tm.Close()
-		if closeStores != nil {
-			closeStores()
-		}
-	})
+	require.NotNil(t, runtime)
+	require.NotNil(t, runtime.engine)
+	t.Cleanup(func() { runtime.Close() })
 
 	dir := groupDataDir(baseDir, "n1", 1, true)
 	_, err = os.Stat(dir)
@@ -59,10 +57,6 @@ func TestNewRaftGroupBootstrap(t *testing.T) {
 
 	_, err = os.Stat(filepath.Join(dir, "raft.db"))
 	require.NoError(t, err)
-
-	require.Eventually(t, func() bool {
-		return r.State() == raft.Leader
-	}, 5*time.Second, 10*time.Millisecond)
 }
 
 func TestParseRaftEngineType(t *testing.T) {
@@ -91,7 +85,9 @@ func TestBuildShardGroupsWithEtcdEngineRoutesAcrossGroups(t *testing.T) {
 		{id: 2, address: "127.0.0.1:15002"},
 	}
 
-	runtimes, shardGroups, err := buildShardGroups("n1", baseDir, groups, true, false, nil, raftEngineEtcd, nil)
+	factory, err := newRaftFactory(raftEngineEtcd)
+	require.NoError(t, err)
+	runtimes, shardGroups, err := buildShardGroups("n1", baseDir, groups, true, false, nil, factory, nil)
 	require.NoError(t, err)
 
 	engine := distribution.NewEngine()
@@ -142,7 +138,9 @@ func TestBuildShardGroupsWithEtcdEngineRestartsAcrossGroups(t *testing.T) {
 	engine.UpdateRoute([]byte("m"), nil, 2)
 
 	openShardStore := func() ([]*raftGroupRuntime, map[uint64]*kv.ShardGroup, *kv.ShardStore) {
-		runtimes, shardGroups, err := buildShardGroups("n1", baseDir, groups, true, false, nil, raftEngineEtcd, nil)
+		factory, err := newRaftFactory(raftEngineEtcd)
+		require.NoError(t, err)
+		runtimes, shardGroups, err := buildShardGroups("n1", baseDir, groups, true, false, nil, factory, nil)
 		require.NoError(t, err)
 		shardStore := kv.NewShardStore(engine, shardGroups)
 		return runtimes, shardGroups, shardStore

--- a/scripts/engine-rollback.sh
+++ b/scripts/engine-rollback.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Engine rollback: etcd/raft → hashicorp
+#
+# This script performs a stop-the-world rollback of all cluster nodes from
+# the etcd/raft engine back to the HashiCorp Raft engine. All nodes must be
+# stopped simultaneously because the two engines are protocol-incompatible
+# and cannot coexist in a running cluster.
+#
+# Usage:
+#   ROLLING_UPDATE_ENV_FILE=/path/to/deploy.env ./scripts/engine-rollback.sh
+#
+# The script reuses the same deploy.env as rolling-update.sh. It will:
+#   1. Build the etcd-raft-rollback tool for remote architectures
+#   2. Stop all containers (stop-the-world)
+#   3. On each node, run the FSM rollback and archive etcd artifacts
+#   4. Start all nodes with --raftEngine hashicorp via rolling-update.sh
+#
+# Required environment: same as rolling-update.sh (NODES, etc.)
+#
+# Safety:
+#   - etcd raft artifacts are archived, not deleted
+#   - Rollback is aborted if any node fails to stop
+#   - The FSM Pebble store (fsm.db) is preserved as-is
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [[ -n "${ROLLING_UPDATE_ENV_FILE:-}" ]]; then
+  if [[ ! -f "$ROLLING_UPDATE_ENV_FILE" ]]; then
+    echo "ROLLING_UPDATE_ENV_FILE not found: $ROLLING_UPDATE_ENV_FILE" >&2
+    exit 1
+  fi
+  # shellcheck disable=SC1090
+  source "$ROLLING_UPDATE_ENV_FILE"
+fi
+
+SSH_USER="${SSH_USER:-${USER:-$(id -un)}}"
+CONTAINER_NAME="${CONTAINER_NAME:-elastickv}"
+DATA_DIR="${DATA_DIR:-/var/lib/elastickv}"
+RAFT_PORT="${RAFT_PORT:-50051}"
+NODES="${NODES:-}"
+SSH_TARGETS="${SSH_TARGETS:-}"
+SSH_CONNECT_TIMEOUT_SECONDS="${SSH_CONNECT_TIMEOUT_SECONDS:-10}"
+SSH_STRICT_HOST_KEY_CHECKING="${SSH_STRICT_HOST_KEY_CHECKING:-accept-new}"
+HEALTH_TIMEOUT_SECONDS="${HEALTH_TIMEOUT_SECONDS:-60}"
+ROLLBACK_REMOTE_BIN="${ROLLBACK_REMOTE_BIN:-/tmp/etcd-raft-rollback}"
+
+if [[ -z "$NODES" ]]; then
+  echo "NODES is required" >&2
+  exit 1
+fi
+
+SSH_BASE_OPTS=(
+  -o BatchMode=yes
+  -o ConnectTimeout="${SSH_CONNECT_TIMEOUT_SECONDS}"
+  -o StrictHostKeyChecking="${SSH_STRICT_HOST_KEY_CHECKING}"
+)
+SCP_BASE_OPTS=(-q "${SSH_BASE_OPTS[@]}")
+
+NODE_IDS=()
+NODE_HOSTS=()
+ROLLBACK_TMP_DIR=""
+
+cleanup() {
+  if [[ -n "$ROLLBACK_TMP_DIR" && -d "$ROLLBACK_TMP_DIR" ]]; then
+    rm -rf "$ROLLBACK_TMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+contains_value() {
+  local needle="$1"
+  shift
+  local v
+  for v in "$@"; do
+    if [[ "$v" == "$needle" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+lookup_mapping() {
+  local key="$1"
+  local mapping="$2"
+  local pair entry_key entry_value
+
+  [[ -n "$mapping" ]] || return 1
+  IFS=',' read -r -a pairs <<< "$mapping"
+  for pair in "${pairs[@]}"; do
+    pair="${pair//[[:space:]]/}"
+    [[ -n "$pair" ]] || continue
+    [[ "$pair" == *=* ]] || continue
+    entry_key="${pair%%=*}"
+    entry_value="${pair#*=}"
+    if [[ "$entry_key" == "$key" ]]; then
+      printf '%s\n' "$entry_value"
+      return 0
+    fi
+  done
+  return 1
+}
+
+parse_nodes() {
+  local pair node_id node_host
+  IFS=',' read -r -a pairs <<< "$NODES"
+  for pair in "${pairs[@]}"; do
+    pair="${pair//[[:space:]]/}"
+    [[ -n "$pair" ]] || continue
+    if [[ "$pair" != *=* ]]; then
+      echo "invalid NODES entry: $pair" >&2
+      exit 1
+    fi
+    node_id="${pair%%=*}"
+    node_host="${pair#*=}"
+    if [[ -z "$node_id" || -z "$node_host" ]]; then
+      echo "invalid NODES entry: $pair" >&2
+      exit 1
+    fi
+    if contains_value "$node_id" "${NODE_IDS[@]+"${NODE_IDS[@]}"}"; then
+      echo "duplicate raft ID in NODES: $node_id" >&2
+      exit 1
+    fi
+    NODE_IDS+=("$node_id")
+    NODE_HOSTS+=("$node_host")
+  done
+  if [[ "${#NODE_IDS[@]}" -eq 0 ]]; then
+    echo "NODES did not contain any nodes" >&2
+    exit 1
+  fi
+}
+
+node_host_by_id() {
+  local wanted_id="$1"
+  local i
+  for i in "${!NODE_IDS[@]}"; do
+    if [[ "${NODE_IDS[$i]}" == "$wanted_id" ]]; then
+      printf '%s\n' "${NODE_HOSTS[$i]}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+ssh_target_by_id() {
+  local node_id="$1"
+  local target
+  target="$(lookup_mapping "$node_id" "$SSH_TARGETS" || true)"
+  if [[ -z "$target" ]]; then
+    target="$(node_host_by_id "$node_id")"
+  fi
+  if [[ "$target" == *@* ]]; then
+    printf '%s\n' "$target"
+    return 0
+  fi
+  printf '%s@%s\n' "$SSH_USER" "$target"
+}
+
+build_peers_string() {
+  local parts=()
+  local i
+  for i in "${!NODE_IDS[@]}"; do
+    parts+=("${NODE_IDS[$i]}=${NODE_HOSTS[$i]}:${RAFT_PORT}")
+  done
+  (IFS=,; printf '%s\n' "${parts[*]}")
+}
+
+build_rollback_variant() {
+  local goos="$1"
+  local goarch="$2"
+  local out="${ROLLBACK_TMP_DIR}/etcd-raft-rollback-${goos}-${goarch}"
+
+  if [[ -x "$out" ]]; then
+    printf '%s\n' "$out"
+    return 0
+  fi
+
+  echo "[engine-rollback] building etcd-raft-rollback for ${goos}/${goarch}" >&2
+  CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
+    go build -C "$REPO_ROOT" -o "$out" ./cmd/etcd-raft-rollback
+  chmod +x "$out"
+  printf '%s\n' "$out"
+}
+
+copy_rollback_tool() {
+  local node_id="$1"
+  local ssh_target="$2"
+
+  scp "${SCP_BASE_OPTS[@]}" "$ROLLBACK_LINUX_AMD64_BIN" "${ssh_target}:${ROLLBACK_REMOTE_BIN}-amd64"
+  scp "${SCP_BASE_OPTS[@]}" "$ROLLBACK_LINUX_ARM64_BIN" "${ssh_target}:${ROLLBACK_REMOTE_BIN}-arm64"
+
+  ssh "${SSH_BASE_OPTS[@]}" "$ssh_target" \
+    ROLLBACK_REMOTE_BIN="$ROLLBACK_REMOTE_BIN" \
+    'bash -s' <<'INSTALL'
+set -euo pipefail
+case "$(uname -m)" in
+  x86_64|amd64)  cp "${ROLLBACK_REMOTE_BIN}-amd64" "$ROLLBACK_REMOTE_BIN" ;;
+  aarch64|arm64)  cp "${ROLLBACK_REMOTE_BIN}-arm64" "$ROLLBACK_REMOTE_BIN" ;;
+  *)
+    echo "unsupported remote architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+chmod +x "$ROLLBACK_REMOTE_BIN"
+rm -f "${ROLLBACK_REMOTE_BIN}-amd64" "${ROLLBACK_REMOTE_BIN}-arm64"
+INSTALL
+}
+
+stop_node() {
+  local node_id="$1"
+  local ssh_target="$2"
+
+  echo "==> [${node_id}] stopping container"
+  ssh "${SSH_BASE_OPTS[@]}" "$ssh_target" \
+    CONTAINER_NAME="$CONTAINER_NAME" \
+    'bash -s' <<'STOP'
+set -euo pipefail
+docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+STOP
+}
+
+verify_node_stopped() {
+  local node_id="$1"
+  local ssh_target="$2"
+
+  local status
+  status="$(ssh "${SSH_BASE_OPTS[@]}" "$ssh_target" \
+    CONTAINER_NAME="$CONTAINER_NAME" \
+    'bash -s' <<'CHECK'
+set -euo pipefail
+docker inspect --format "{{.State.Status}}" "$CONTAINER_NAME" 2>/dev/null || echo "missing"
+CHECK
+  )"
+  if [[ "$status" != "missing" ]]; then
+    echo "error: container on ${node_id} is still ${status} after stop" >&2
+    return 1
+  fi
+}
+
+rollback_node() {
+  local node_id="$1"
+  local ssh_target="$2"
+  local peers_string="$3"
+
+  echo "==> [${node_id}] rolling back etcd → hashicorp"
+
+  ssh "${SSH_BASE_OPTS[@]}" "$ssh_target" \
+    env \
+      ROLLBACK_BIN="$ROLLBACK_REMOTE_BIN" \
+      DATA_DIR="$DATA_DIR" \
+      NODE_ID="$node_id" \
+      PEERS="$peers_string" \
+    bash -s <<'ROLLBACK'
+set -euo pipefail
+
+node_dir="${DATA_DIR%/}/${NODE_ID}"
+fsm_store="${node_dir}/fsm.db"
+ts="$(date -u +%Y%m%dT%H%M%SZ)"
+backup_dir="${node_dir}/etcd-backup-${ts}"
+
+if ! sudo -n true 2>/dev/null; then
+  echo "error: passwordless sudo is required on this host" >&2
+  exit 1
+fi
+
+if sudo -n test -d "${node_dir}/raft.db"; then
+  echo "hashicorp raft data already exists at ${node_dir}/raft.db; skipping rollback"
+  # Still ensure the engine marker is correct
+  echo "hashicorp" | sudo -n tee "${node_dir}/raft-engine" > /dev/null
+  exit 0
+fi
+
+if ! sudo -n test -d "$fsm_store"; then
+  echo "error: FSM store not found at ${fsm_store}" >&2
+  exit 1
+fi
+
+rollback_dest="$(sudo -n mktemp -d "/tmp/hashicorp-rollback-${NODE_ID}-XXXXXX")"
+
+echo "  running etcd-raft-rollback"
+sudo -n "$ROLLBACK_BIN" \
+  -fsm-store "$fsm_store" \
+  -dest "${rollback_dest}/data" \
+  -peers "$PEERS"
+
+echo "  moving hashicorp artifacts into place"
+sudo -n mv "${rollback_dest}/data/raft.db" "${node_dir}/raft.db"
+sudo -n mv "${rollback_dest}/data/snapshots" "${node_dir}/snapshots"
+sudo -n rm -rf "$rollback_dest"
+
+echo "  archiving etcd raft artifacts"
+sudo -n mkdir -p "$backup_dir"
+if sudo -n test -d "${node_dir}/member"; then
+  sudo -n mv "${node_dir}/member" "${backup_dir}/member"
+fi
+
+echo "  updating engine marker"
+echo "hashicorp" | sudo -n tee "${node_dir}/raft-engine" > /dev/null
+
+echo "  rollback complete for ${NODE_ID}"
+ROLLBACK
+}
+
+wait_for_grpc() {
+  local node_host="$1"
+  local ssh_target="$2"
+  local i
+
+  for ((i = 0; i < HEALTH_TIMEOUT_SECONDS; i++)); do
+    if ssh "${SSH_BASE_OPTS[@]}" "$ssh_target" \
+         bash -lc "exec 3<>/dev/tcp/${node_host}/${RAFT_PORT}" 2>/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+# ── Main ──
+
+parse_nodes
+PEERS_STRING="$(build_peers_string)"
+
+echo "[engine-rollback] cluster: ${NODE_IDS[*]}"
+echo "[engine-rollback] peers: ${PEERS_STRING}"
+echo ""
+echo "This will STOP ALL NODES and roll back from etcd/raft to hashicorp."
+echo "There will be cluster downtime during rollback."
+echo ""
+read -r -p "Continue? [y/N] " confirm
+if [[ "$confirm" != [yY] ]]; then
+  echo "aborted"
+  exit 1
+fi
+
+# Step 1: Build rollback tool
+echo ""
+echo "[engine-rollback] building rollback tool"
+ROLLBACK_TMP_DIR="$(mktemp -d)"
+ROLLBACK_LINUX_AMD64_BIN="$(build_rollback_variant linux amd64)"
+ROLLBACK_LINUX_ARM64_BIN="$(build_rollback_variant linux arm64)"
+
+# Step 2: Stop all nodes
+echo ""
+echo "[engine-rollback] stopping all nodes"
+for node_id in "${NODE_IDS[@]}"; do
+  stop_node "$node_id" "$(ssh_target_by_id "$node_id")"
+done
+
+echo "[engine-rollback] verifying all nodes stopped"
+for node_id in "${NODE_IDS[@]}"; do
+  verify_node_stopped "$node_id" "$(ssh_target_by_id "$node_id")"
+done
+echo "[engine-rollback] all nodes stopped"
+
+# Step 3: Copy rollback tool and run rollback on each node
+echo ""
+echo "[engine-rollback] running rollback on each node"
+for node_id in "${NODE_IDS[@]}"; do
+  ssh_target="$(ssh_target_by_id "$node_id")"
+  echo "==> [${node_id}] deploying rollback tool"
+  copy_rollback_tool "$node_id" "$ssh_target"
+  rollback_node "$node_id" "$ssh_target" "$PEERS_STRING"
+done
+
+# Step 4: Start all nodes with hashicorp engine using rolling-update.sh
+echo ""
+echo "[engine-rollback] starting all nodes with hashicorp engine"
+RAFT_ENGINE=hashicorp \
+  ROLLING_UPDATE_ENV_FILE="${ROLLING_UPDATE_ENV_FILE:-}" \
+  exec "${SCRIPT_DIR}/rolling-update.sh"


### PR DESCRIPTION
…tern, and rollback tooling

Implements all non-deferred gaps between docs/etcd_raft_migration_design.md and the actual codebase before production migration:

- Move StateMachine/Snapshot interfaces to shared raftengine package
- Add Factory interface for engine construction, replacing switch-on-string
- Remove vestigial ShardGroup.Raft field; hashicorp Engine.Close() now actually shuts down the raft instance
- Add shared conformance test suite (raftenginetest) exercised by both engines
- Add reverse migration tool (etcd→hashicorp) with CLI, tests, and engine-rollback.sh script mirroring the forward migration workflow