### PR TITLE
fix: halve scheduled Jepsen parameters, keep concurrency multiple of 4

### DIFF
--- a/.github/workflows/jepsen-test-scheduled.yml
+++ b/.github/workflows/jepsen-test-scheduled.yml
@@ -6,23 +6,23 @@ on:
       time-limit:
         description: "Workload runtime seconds"
         required: false
-        default: "300"
+        default: "150"
       rate:
         description: "Ops/sec per worker"
         required: false
-        default: "20"
-      concurrency:
-        description: "Number of worker threads"
-        required: false
         default: "10"
+      concurrency:
+        description: "Number of worker threads (must be multiple of 4 for S3)"
+        required: false
+        default: "8"
       key-count:
         description: "Number of distinct keys per workload"
         required: false
-        default: "30"
+        default: "16"
       max-writes-per-key:
         description: "Maximum writes per key before exhaustion"
         required: false
-        default: "500"
+        default: "250"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-jepsen-scheduled
@@ -86,39 +86,39 @@ jobs:
           exit 1
       - name: Run Redis Jepsen workload against elastickv
         working-directory: jepsen
-        timeout-minutes: 20
+        timeout-minutes: 10
         run: |
-          timeout 900 ~/lein run -m elastickv.redis-workload \
-            --time-limit ${{ inputs.time-limit || '300' }} \
-            --rate ${{ inputs.rate || '20' }} \
-            --concurrency ${{ inputs.concurrency || '10' }} \
-            --key-count ${{ inputs.key-count || '30' }} \
-            --max-writes-per-key ${{ inputs.max-writes-per-key || '500' }} \
+          timeout 480 ~/lein run -m elastickv.redis-workload \
+            --time-limit ${{ inputs.time-limit || '150' }} \
+            --rate ${{ inputs.rate || '10' }} \
+            --concurrency ${{ inputs.concurrency || '8' }} \
+            --key-count ${{ inputs.key-count || '16' }} \
+            --max-writes-per-key ${{ inputs.max-writes-per-key || '250' }} \
             --max-txn-length 4 \
             --ports 63791,63792,63793 \
             --host 127.0.0.1
       - name: Run DynamoDB Jepsen workload against elastickv
         working-directory: jepsen
-        timeout-minutes: 20
+        timeout-minutes: 10
         run: |
-          timeout 900 ~/lein run -m elastickv.dynamodb-workload --local \
-            --time-limit ${{ inputs.time-limit || '300' }} \
-            --rate ${{ inputs.rate || '20' }} \
-            --concurrency ${{ inputs.concurrency || '10' }} \
-            --key-count ${{ inputs.key-count || '30' }} \
-            --max-writes-per-key ${{ inputs.max-writes-per-key || '500' }} \
+          timeout 480 ~/lein run -m elastickv.dynamodb-workload --local \
+            --time-limit ${{ inputs.time-limit || '150' }} \
+            --rate ${{ inputs.rate || '10' }} \
+            --concurrency ${{ inputs.concurrency || '8' }} \
+            --key-count ${{ inputs.key-count || '16' }} \
+            --max-writes-per-key ${{ inputs.max-writes-per-key || '250' }} \
             --dynamo-ports 63801,63802,63803 \
             --host 127.0.0.1
       - name: Run S3 Jepsen workload against elastickv
         working-directory: jepsen
-        timeout-minutes: 20
+        timeout-minutes: 10
         run: |
-          timeout 900 ~/lein run -m elastickv.s3-workload --local \
-            --time-limit ${{ inputs.time-limit || '300' }} \
-            --rate ${{ inputs.rate || '20' }} \
-            --concurrency ${{ inputs.concurrency || '10' }} \
-            --key-count ${{ inputs.key-count || '30' }} \
-            --max-writes-per-key ${{ inputs.max-writes-per-key || '500' }} \
+          timeout 480 ~/lein run -m elastickv.s3-workload --local \
+            --time-limit ${{ inputs.time-limit || '150' }} \
+            --rate ${{ inputs.rate || '10' }} \
+            --concurrency ${{ inputs.concurrency || '8' }} \
+            --key-count ${{ inputs.key-count || '16' }} \
+            --max-writes-per-key ${{ inputs.max-writes-per-key || '250' }} \
             --threads-per-key 4 \
             --s3-ports 63901,63902,63903 \
             --host 127.0.0.1


### PR DESCRIPTION
S3 workload requires concurrency to be a multiple of threads-per-key (4).

- time-limit: 300s -> 150s
- rate: 20 -> 10
- concurrency: 10 -> 8 (multiple of 4)
- key-count: 30 -> 16
- max-writes-per-key: 500 -> 250
- timeout: 900s -> 480s, timeout-minutes: 20 -> 10