### PR TITLE
fix: clarify FSM comment, fix gci formatting, pin golangci-lint version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,6 +22,7 @@ jobs:
         uses: reviewdog/action-golangci-lint@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          golangci_lint_version: "v2.9.0"
           level: warning
           golangci_lint_flags: "--config=.golangci.yaml"
           filter_mode: nofilter

--- a/kv/fsm.go
+++ b/kv/fsm.go
@@ -320,9 +320,11 @@ func (f *kvFSM) handlePrepareRequest(ctx context.Context, r *pb.Request) error {
 }
 
 // handleOnePhaseTxnRequest applies a single-shard transaction atomically.
-// Both write-write and read-write conflicts are checked: the read set carried
-// in r.ReadKeys is validated alongside the mutation keys inside
-// ApplyMutations under the store's apply lock.
+// Write-write conflicts are always checked under the store's apply lock.
+// r.ReadKeys is passed through to ApplyMutations for read-write conflict
+// detection; for single-shard transactions it is typically nil because the
+// adapter validates the read set pre-Raft (see kv/coordinator.go), while
+// multi-shard PREPARE requests carry per-shard read keys.
 func (f *kvFSM) handleOnePhaseTxnRequest(ctx context.Context, r *pb.Request, commitTS uint64) error {
 	meta, muts, err := extractTxnMeta(r.Mutations)
 	if err != nil {

--- a/kv/sharded_coordinator_txn_test.go
+++ b/kv/sharded_coordinator_txn_test.go
@@ -6,13 +6,12 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
-
 	"github.com/bootjp/elastickv/distribution"
 	"github.com/bootjp/elastickv/internal/raftengine"
 	pb "github.com/bootjp/elastickv/proto"
 	"github.com/bootjp/elastickv/store"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 type recordingTransactional struct {
@@ -383,11 +382,11 @@ type noopEngine struct{}
 func (noopEngine) Propose(_ context.Context, _ []byte) (*raftengine.ProposalResult, error) {
 	return &raftengine.ProposalResult{}, nil
 }
-func (noopEngine) State() raftengine.State                                 { return raftengine.StateLeader }
-func (noopEngine) Leader() raftengine.LeaderInfo                           { return raftengine.LeaderInfo{} }
-func (noopEngine) VerifyLeader(_ context.Context) error                    { return nil }
-func (noopEngine) LinearizableRead(_ context.Context) (uint64, error)      { return 0, nil }
-func (noopEngine) Status() raftengine.Status                               { return raftengine.Status{} }
+func (noopEngine) State() raftengine.State                            { return raftengine.StateLeader }
+func (noopEngine) Leader() raftengine.LeaderInfo                      { return raftengine.LeaderInfo{} }
+func (noopEngine) VerifyLeader(_ context.Context) error               { return nil }
+func (noopEngine) LinearizableRead(_ context.Context) (uint64, error) { return 0, nil }
+func (noopEngine) Status() raftengine.Status                          { return raftengine.Status{} }
 func (noopEngine) Configuration(_ context.Context) (raftengine.Configuration, error) {
 	return raftengine.Configuration{}, nil
 }
@@ -498,7 +497,7 @@ func TestShardedCoordinatorDispatchTxn_ReadKeysRoutedToPrepareByShard(t *testing
 
 	engine := distribution.NewEngine()
 	engine.UpdateRoute([]byte("a"), []byte("m"), 1) // shard 1: a-m
-	engine.UpdateRoute([]byte("m"), nil, 2)          // shard 2: m+
+	engine.UpdateRoute([]byte("m"), nil, 2)         // shard 2: m+
 
 	g1Txn := &recordingTransactional{}
 	g2Txn := &recordingTransactional{}


### PR DESCRIPTION
- Update handleOnePhaseTxnRequest comment to clarify that r.ReadKeys is nil for single-shard txns (pre-Raft validation by adapter)
- Auto-fix gci import formatting via golangci-lint --fix
- Pin golangci-lint version to v2.9.0 in GitHub Actions to match local, preventing lint result divergence between pre-commit hook and CI