### PR TITLE
feat: implement collection metadata delta for Hash/Set/ZSet wide-column keys

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -2377,7 +2377,11 @@ func (r *RedisServer) listPushCore(ctx context.Context, key []byte, values [][]b
 			return err
 		}
 
-		// Pre-allocate commitTS so we can embed it in the Delta key.
+		// Pre-allocate startTS and commitTS so the commitTS can be embedded
+		// in the Delta key and the coordinator will not regenerate it.
+		// ensureValidStartTS guarantees startTS > 0 so the coordinator keeps
+		// the caller-provided commitTS instead of assigning a new one.
+		startTS := ensureValidStartTS(readTS, r.coordinator.Clock())
 		commitTS := r.coordinator.Clock().Next()
 		ops, updatedMeta, err := buildFn(meta, key, values, commitTS, 0)
 		if err != nil {
@@ -2391,7 +2395,7 @@ func (r *RedisServer) listPushCore(ctx context.Context, key []byte, values [][]b
 		// Dispatch with the pre-allocated commitTS.
 		_, dispErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 			IsTxn:    true,
-			StartTS:  normalizeStartTS(readTS),
+			StartTS:  startTS,
 			CommitTS: commitTS,
 			Elems:    ops,
 		})

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1317,6 +1317,9 @@ func (r *RedisServer) collectUserKeys(kvs []*store.KVPair, pattern []byte) map[s
 // key, or returns (nil, true) for internal-only keys (meta/delta), and
 // (nil, false) if the key is not a wide-column key at all.
 func wideColumnVisibleUserKey(key []byte) (userKey []byte, isWide bool) {
+	if store.IsListMetaDeltaKey(key) || store.IsListClaimKey(key) {
+		return nil, true
+	}
 	if store.IsHashMetaDeltaKey(key) || store.IsHashMetaKey(key) {
 		return nil, true
 	}

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1185,14 +1185,21 @@ func (r *RedisServer) mergeInternalNamespaces(start []byte, pattern []byte, merg
 	// prefix makes straightforward bounds-based scanning non-trivial.
 	// Use the user-key prefix as the lower bound and scan to the end of each
 	// namespace; collectUserKeys filters false positives by pattern.
-	hashFieldStart := store.HashFieldScanPrefix(start)
-	hashFieldEnd := prefixScanEnd([]byte(store.HashFieldPrefix))
-	if err := mergeScannedKeys(hashFieldStart, hashFieldEnd); err != nil {
-		return err
+	type wideColNS struct {
+		startFn func([]byte) []byte
+		prefix  string
 	}
-	setMemberStart := store.SetMemberScanPrefix(start)
-	setMemberEnd := prefixScanEnd([]byte(store.SetMemberPrefix))
-	return mergeScannedKeys(setMemberStart, setMemberEnd)
+	for _, ns := range []wideColNS{
+		{store.HashFieldScanPrefix, store.HashFieldPrefix},
+		{store.SetMemberScanPrefix, store.SetMemberPrefix},
+	} {
+		nsStart := ns.startFn(start)
+		nsEnd := prefixScanEnd([]byte(ns.prefix))
+		if err := mergeScannedKeys(nsStart, nsEnd); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *RedisServer) localKeysPattern(pattern []byte) ([][]byte, error) {
@@ -1545,6 +1552,9 @@ func (t *txnContext) loadListState(key []byte) (*listTxnState, error) {
 	deltaKVs, err := t.server.store.ScanAt(ctx, deltaPrefix, deltaEnd, store.MaxDeltaScanLimit, t.startTS)
 	if err != nil {
 		return nil, errors.WithStack(err)
+	}
+	if len(deltaKVs) == store.MaxDeltaScanLimit {
+		return nil, errors.WithStack(ErrDeltaScanTruncated)
 	}
 	existingDeltas := make([][]byte, 0, len(deltaKVs))
 	for _, kv := range deltaKVs {
@@ -2036,6 +2046,14 @@ func listDeleteMeta(st *listTxnState) (store.ListMeta, bool) {
 	}
 }
 
+// appendDeltaDeletes appends Del operations for each delta key in deltaKeys.
+func appendDeltaDeletes(elems []*kv.Elem[kv.OP], deltaKeys [][]byte) []*kv.Elem[kv.OP] {
+	for _, dk := range deltaKeys {
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: dk})
+	}
+	return elems
+}
+
 func appendListDeleteOps(elems []*kv.Elem[kv.OP], userKey []byte, meta store.ListMeta) []*kv.Elem[kv.OP] {
 	for seq := meta.Head; seq < meta.Tail; seq++ {
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: listItemKey(userKey, seq)})
@@ -2061,9 +2079,7 @@ func (t *txnContext) buildListElems(commitTS uint64) []*kv.Elem[kv.OP] {
 				elems = appendListDeleteOps(elems, userKey, meta)
 			}
 			// Delete existing delta keys so they don't survive the logical delete.
-			for _, dk := range st.existingDeltas {
-				elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: dk})
-			}
+			elems = appendDeltaDeletes(elems, st.existingDeltas)
 			continue
 		}
 		if len(st.appends) == 0 {
@@ -2072,9 +2088,7 @@ func (t *txnContext) buildListElems(commitTS uint64) []*kv.Elem[kv.OP] {
 		if st.purge {
 			elems = appendListDeleteOps(elems, userKey, st.purgeMeta)
 			// Delete existing delta keys so they don't accumulate after DEL+RPUSH.
-			for _, dk := range st.existingDeltas {
-				elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: dk})
-			}
+			elems = appendDeltaDeletes(elems, st.existingDeltas)
 		}
 
 		startSeq := st.meta.Head + st.meta.Len

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1161,6 +1161,40 @@ func (r *RedisServer) localKeysExact(pattern []byte) ([][]byte, error) {
 	return [][]byte{}, nil
 }
 
+// mergeInternalNamespaces scans all internal key namespaces (list, hash, set, and
+// other internal prefixes) for keys that match pattern and merges them into the
+// caller's keyset via mergeScannedKeys. Called only when the pattern is bounded
+// (start != nil) because unbounded scans already cover the full keyspace.
+func (r *RedisServer) mergeInternalNamespaces(start []byte, pattern []byte, mergeScannedKeys func([]byte, []byte) error) error {
+	metaStart, metaEnd := listPatternScanBounds(store.ListMetaPrefix, pattern)
+	if err := mergeScannedKeys(metaStart, metaEnd); err != nil {
+		return err
+	}
+	itemStart, itemEnd := listPatternScanBounds(store.ListItemPrefix, pattern)
+	if err := mergeScannedKeys(itemStart, itemEnd); err != nil {
+		return err
+	}
+	for _, prefix := range redisInternalPrefixes {
+		internalStart, internalEnd := listPatternScanBounds(prefix, pattern)
+		if err := mergeScannedKeys(internalStart, internalEnd); err != nil {
+			return err
+		}
+	}
+	// Wide-column hash/set keys embed the user-key as
+	// <prefix><4-byte-len><userKey><field|member>, so the binary length
+	// prefix makes straightforward bounds-based scanning non-trivial.
+	// Use the user-key prefix as the lower bound and scan to the end of each
+	// namespace; collectUserKeys filters false positives by pattern.
+	hashFieldStart := store.HashFieldScanPrefix(start)
+	hashFieldEnd := prefixScanEnd([]byte(store.HashFieldPrefix))
+	if err := mergeScannedKeys(hashFieldStart, hashFieldEnd); err != nil {
+		return err
+	}
+	setMemberStart := store.SetMemberScanPrefix(start)
+	setMemberEnd := prefixScanEnd([]byte(store.SetMemberPrefix))
+	return mergeScannedKeys(setMemberStart, setMemberEnd)
+}
+
 func (r *RedisServer) localKeysPattern(pattern []byte) ([][]byte, error) {
 	start, end := patternScanBounds(pattern)
 	keyset := map[string][]byte{}
@@ -1184,21 +1218,8 @@ func (r *RedisServer) localKeysPattern(pattern []byte) ([][]byte, error) {
 	// and map them back to logical user keys.  For unbounded patterns
 	// (e.g. "*"), the full-keyspace scan already covers everything.
 	if start != nil {
-		metaStart, metaEnd := listPatternScanBounds(store.ListMetaPrefix, pattern)
-		if err := mergeScannedKeys(metaStart, metaEnd); err != nil {
+		if err := r.mergeInternalNamespaces(start, pattern, mergeScannedKeys); err != nil {
 			return nil, err
-		}
-
-		itemStart, itemEnd := listPatternScanBounds(store.ListItemPrefix, pattern)
-		if err := mergeScannedKeys(itemStart, itemEnd); err != nil {
-			return nil, err
-		}
-
-		for _, prefix := range redisInternalPrefixes {
-			internalStart, internalEnd := listPatternScanBounds(prefix, pattern)
-			if err := mergeScannedKeys(internalStart, internalEnd); err != nil {
-				return nil, err
-			}
 		}
 	}
 
@@ -1285,12 +1306,35 @@ func (r *RedisServer) collectUserKeys(kvs []*store.KVPair, pattern []byte) map[s
 	return keyset
 }
 
+// wideColumnVisibleUserKey maps a wide-column internal key to its visible user
+// key, or returns (nil, true) for internal-only keys (meta/delta), and
+// (nil, false) if the key is not a wide-column key at all.
+func wideColumnVisibleUserKey(key []byte) (userKey []byte, isWide bool) {
+	// Check delta prefixes before meta prefixes (delta starts with meta prefix).
+	if store.IsHashMetaDeltaKey(key) || store.IsHashMetaKey(key) {
+		return nil, true
+	}
+	if store.IsHashFieldKey(key) {
+		return store.ExtractHashUserKeyFromField(key), true
+	}
+	if store.IsSetMetaDeltaKey(key) || store.IsSetMetaKey(key) {
+		return nil, true
+	}
+	if store.IsSetMemberKey(key) {
+		return store.ExtractSetUserKeyFromMember(key), true
+	}
+	return nil, false
+}
+
 func redisVisibleUserKey(key []byte) []byte {
 	if bytes.HasPrefix(key, redisTxnKeyPrefix) || isRedisTTLKey(key) {
 		return nil
 	}
 	if store.IsListMetaKey(key) || store.IsListItemKey(key) {
 		return store.ExtractListUserKey(key)
+	}
+	if userKey, isWide := wideColumnVisibleUserKey(key); isWide {
+		return userKey
 	}
 	if userKey := extractRedisInternalUserKey(key); userKey != nil {
 		return userKey
@@ -1377,12 +1421,13 @@ type txnContext struct {
 }
 
 type listTxnState struct {
-	meta       store.ListMeta
-	metaExists bool
-	appends    [][]byte
-	deleted    bool
-	purge      bool
-	purgeMeta  store.ListMeta
+	meta           store.ListMeta
+	metaExists     bool
+	appends        [][]byte
+	deleted        bool
+	purge          bool
+	purgeMeta      store.ListMeta
+	existingDeltas [][]byte // delta key bytes present at load time; deleted on purge/delete
 }
 
 type zsetTxnState struct {
@@ -1484,25 +1529,34 @@ func (t *txnContext) loadListState(key []byte) (*listTxnState, error) {
 	if st, ok := t.listStates[k]; ok {
 		return st, nil
 	}
-	// Track listMetaKey (length/tail-pointer) and redisTTLKey as read
-	// dependencies. Individual list element keys (listItemKey) are NOT tracked
-	// because every list write operation (RPUSH, DEL) updates listMetaKey;
-	// a stale element read is therefore always detected via a stale meta read.
-	// A hypothetical LSET (in-place element mutation without touching meta)
-	// would require tracking individual element keys, but LSET is not
-	// currently supported.
-	t.trackReadKey(listMetaKey(key))
+	// With the Delta pattern we no longer read-modify-write the single base
+	// meta key, so there is no OCC conflict to track on it.
 	t.trackReadKey(redisTTLKey(key))
 
-	meta, exists, err := t.server.loadListMetaAt(context.Background(), key, t.startTS)
+	ctx := context.Background()
+	meta, exists, err := t.server.resolveListMeta(ctx, key, t.startTS)
 	if err != nil {
 		return nil, err
 	}
 
+	// Capture existing delta keys so they can be deleted if the list is later
+	// purged or deleted within this transaction.
+	deltaPrefix := store.ListMetaDeltaScanPrefix(key)
+	deltaEnd := store.PrefixScanEnd(deltaPrefix)
+	deltaKVs, err := t.server.store.ScanAt(ctx, deltaPrefix, deltaEnd, store.MaxDeltaScanLimit, t.startTS)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	existingDeltas := make([][]byte, 0, len(deltaKVs))
+	for _, kv := range deltaKVs {
+		existingDeltas = append(existingDeltas, kv.Key)
+	}
+
 	st := &listTxnState{
-		meta:       meta,
-		metaExists: exists,
-		appends:    [][]byte{},
+		meta:           meta,
+		metaExists:     exists,
+		appends:        [][]byte{},
+		existingDeltas: existingDeltas,
 	}
 	t.listStates[k] = st
 	return st, nil
@@ -1913,10 +1967,10 @@ func (t *txnContext) validateReadSet(ctx context.Context) error {
 func (t *txnContext) commit() error {
 	elems := t.buildKeyElems()
 
-	listElems, err := t.buildListElems()
-	if err != nil {
-		return err
-	}
+	// Pre-allocate commitTS so Delta keys can embed it in their bytes before
+	// the coordinator assigns it during Dispatch.
+	commitTS := t.server.coordinator.Clock().Next()
+	listElems := t.buildListElems(commitTS)
 	zsetElems, err := t.buildZSetElems()
 	if err != nil {
 		return err
@@ -1934,7 +1988,13 @@ func (t *txnContext) commit() error {
 	for _, k := range t.readKeys {
 		readKeys = append(readKeys, k)
 	}
-	group := &kv.OperationGroup[kv.OP]{IsTxn: true, Elems: elems, StartTS: t.startTS, ReadKeys: readKeys}
+	group := &kv.OperationGroup[kv.OP]{
+		IsTxn:    true,
+		Elems:    elems,
+		StartTS:  t.startTS,
+		CommitTS: commitTS,
+		ReadKeys: readKeys,
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
 	defer cancel()
 	if _, err := t.server.coordinator.Dispatch(ctx, group); err != nil {
@@ -1984,7 +2044,7 @@ func appendListDeleteOps(elems []*kv.Elem[kv.OP], userKey []byte, meta store.Lis
 	return append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: listMetaKey(userKey)})
 }
 
-func (t *txnContext) buildListElems() ([]*kv.Elem[kv.OP], error) {
+func (t *txnContext) buildListElems(commitTS uint64) []*kv.Elem[kv.OP] {
 	listKeys := make([]string, 0, len(t.listStates))
 	for k := range t.listStates {
 		listKeys = append(listKeys, k)
@@ -1992,6 +2052,7 @@ func (t *txnContext) buildListElems() ([]*kv.Elem[kv.OP], error) {
 	sort.Strings(listKeys)
 
 	var elems []*kv.Elem[kv.OP]
+	var seqInTxn uint32
 	for _, k := range listKeys {
 		st := t.listStates[k]
 		userKey := []byte(k)
@@ -2000,6 +2061,10 @@ func (t *txnContext) buildListElems() ([]*kv.Elem[kv.OP], error) {
 			if meta, ok := listDeleteMeta(st); ok {
 				elems = appendListDeleteOps(elems, userKey, meta)
 			}
+			// Delete existing delta keys so they don't survive the logical delete.
+			for _, dk := range st.existingDeltas {
+				elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: dk})
+			}
 			continue
 		}
 		if len(st.appends) == 0 {
@@ -2007,6 +2072,10 @@ func (t *txnContext) buildListElems() ([]*kv.Elem[kv.OP], error) {
 		}
 		if st.purge {
 			elems = appendListDeleteOps(elems, userKey, st.purgeMeta)
+			// Delete existing delta keys so they don't accumulate after DEL+RPUSH.
+			for _, dk := range st.existingDeltas {
+				elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: dk})
+			}
 		}
 
 		startSeq := st.meta.Head + st.meta.Len
@@ -2018,15 +2087,18 @@ func (t *txnContext) buildListElems() ([]*kv.Elem[kv.OP], error) {
 			})
 		}
 
-		st.meta.Len += int64(len(st.appends))
-		st.meta.Tail = st.meta.Head + st.meta.Len
-		metaBytes, err := store.MarshalListMeta(st.meta)
-		if err != nil {
-			return nil, errors.WithStack(err)
-		}
-		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: listMetaKey(userKey), Value: metaBytes})
+		// Emit a Delta key instead of updating the base metadata key.
+		// Each list key in this transaction gets a unique seqInTxn.
+		n := int64(len(st.appends))
+		deltaVal := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: 0, LenDelta: n})
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.ListMetaDeltaKey(userKey, commitTS, seqInTxn),
+			Value: deltaVal,
+		})
+		seqInTxn++
 	}
-	return elems, nil
+	return elems
 }
 
 func (t *txnContext) buildZSetElems() ([]*kv.Elem[kv.OP], error) {
@@ -2247,7 +2319,12 @@ func (r *RedisServer) isListKeyAt(ctx context.Context, key []byte, readTS uint64
 	return exists, err
 }
 
-func (r *RedisServer) buildRPushOps(meta store.ListMeta, key []byte, values [][]byte) ([]*kv.Elem[kv.OP], store.ListMeta, error) {
+// buildRPushOps creates operations to append values to the tail of a list using
+// the Delta pattern. Instead of writing to the base metadata key (causing OCC
+// conflicts), it emits a single ListMetaDelta key with LenDelta = len(values).
+// commitTS must be pre-allocated via dispatchElemsWithCommitTS; seqInTxn
+// disambiguates multiple push operations in the same transaction.
+func (r *RedisServer) buildRPushOps(meta store.ListMeta, key []byte, values [][]byte, commitTS uint64, seqInTxn uint32) ([]*kv.Elem[kv.OP], store.ListMeta, error) {
 	if len(values) == 0 {
 		return nil, meta, nil
 	}
@@ -2260,40 +2337,65 @@ func (r *RedisServer) buildRPushOps(meta store.ListMeta, key []byte, values [][]
 		seq++
 	}
 
+	// Emit a Delta key instead of writing the base meta key.
+	delta := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: 0, LenDelta: int64(len(values))})
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: store.ListMetaDeltaKey(key, commitTS, seqInTxn), Value: delta})
+
 	meta.Len += int64(len(values))
 	meta.Tail = meta.Head + meta.Len
-
-	b, err := store.MarshalListMeta(meta)
-	if err != nil {
-		return nil, meta, errors.WithStack(err)
-	}
-
-	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: listMetaKey(key), Value: b})
 	return elems, meta, nil
 }
 
-func (r *RedisServer) listRPush(ctx context.Context, key []byte, values [][]byte) (int64, error) {
-	readTS := r.readTS()
-	meta, _, err := r.loadListMetaAt(ctx, key, readTS)
-	if err != nil {
-		return 0, err
-	}
+// listPushBuildFn is the type for functions that build list push operations.
+type listPushBuildFn func(meta store.ListMeta, key []byte, values [][]byte, commitTS uint64, seqInTxn uint32) ([]*kv.Elem[kv.OP], store.ListMeta, error)
 
-	ops, newMeta, err := r.buildRPushOps(meta, key, values)
-	if err != nil {
-		return 0, err
-	}
-	if len(ops) == 0 {
-		return newMeta.Len, nil
-	}
+// listPushCore is the shared retry loop for RPUSH and LPUSH. The caller supplies
+// a buildFn that assembles the specific operations (RPUSH appends to tail, LPUSH
+// prepends to head).
+func (r *RedisServer) listPushCore(ctx context.Context, key []byte, values [][]byte, buildFn listPushBuildFn) (int64, error) {
+	var newLen int64
+	err := r.retryRedisWrite(ctx, func() error {
+		readTS := r.readTS()
+		meta, _, err := r.resolveListMeta(ctx, key, readTS)
+		if err != nil {
+			return err
+		}
 
-	return newMeta.Len, r.dispatchElems(ctx, true, readTS, ops)
+		// Pre-allocate commitTS so we can embed it in the Delta key.
+		commitTS := r.coordinator.Clock().Next()
+		ops, updatedMeta, err := buildFn(meta, key, values, commitTS, 0)
+		if err != nil {
+			return err
+		}
+		if len(ops) == 0 {
+			newLen = updatedMeta.Len
+			return nil
+		}
+
+		// Dispatch with the pre-allocated commitTS.
+		_, dispErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+			IsTxn:    true,
+			StartTS:  normalizeStartTS(readTS),
+			CommitTS: commitTS,
+			Elems:    ops,
+		})
+		if dispErr != nil {
+			return errors.WithStack(dispErr)
+		}
+		newLen = updatedMeta.Len
+		return nil
+	})
+	return newLen, err
 }
 
-// buildLPushOps creates Raft operations to prepend values to the head of a list.
-// This is O(k) where k = len(values), not O(N) where N is the total list length.
-// LPUSH reverses the order of arguments: LPUSH key a b c → [c, b, a, ...existing].
-func (r *RedisServer) buildLPushOps(meta store.ListMeta, key []byte, values [][]byte) ([]*kv.Elem[kv.OP], store.ListMeta, error) {
+func (r *RedisServer) listRPush(ctx context.Context, key []byte, values [][]byte) (int64, error) {
+	return r.listPushCore(ctx, key, values, r.buildRPushOps)
+}
+
+// buildLPushOps creates operations to prepend values to the head of a list using
+// the Delta pattern. LPUSH reverses the order of arguments:
+// LPUSH key a b c → [c, b, a, ...existing].
+func (r *RedisServer) buildLPushOps(meta store.ListMeta, key []byte, values [][]byte, commitTS uint64, seqInTxn uint32) ([]*kv.Elem[kv.OP], store.ListMeta, error) {
 	if len(values) == 0 {
 		return nil, meta, nil
 	}
@@ -2312,35 +2414,17 @@ func (r *RedisServer) buildLPushOps(meta store.ListMeta, key []byte, values [][]
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: listItemKey(key, seq), Value: vCopy})
 	}
 
+	// Emit a Delta key instead of writing the base meta key.
+	delta := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: -n, LenDelta: n})
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: store.ListMetaDeltaKey(key, commitTS, seqInTxn), Value: delta})
+
 	meta.Head = newHead
 	meta.Len += n
-	// Tail stays the same: Tail = oldHead + oldLen = newHead + newLen
-
-	b, err := store.MarshalListMeta(meta)
-	if err != nil {
-		return nil, meta, errors.WithStack(err)
-	}
-
-	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: listMetaKey(key), Value: b})
 	return elems, meta, nil
 }
 
 func (r *RedisServer) listLPush(ctx context.Context, key []byte, values [][]byte) (int64, error) {
-	readTS := r.readTS()
-	meta, _, err := r.loadListMetaAt(ctx, key, readTS)
-	if err != nil {
-		return 0, err
-	}
-
-	ops, newMeta, err := r.buildLPushOps(meta, key, values)
-	if err != nil {
-		return 0, err
-	}
-	if len(ops) == 0 {
-		return newMeta.Len, nil
-	}
-
-	return newMeta.Len, r.dispatchElems(ctx, true, readTS, ops)
+	return r.listPushCore(ctx, key, values, r.buildLPushOps)
 }
 
 func (r *RedisServer) fetchListRange(ctx context.Context, key []byte, meta store.ListMeta, startIdx, endIdx int64, readTS uint64) ([]string, error) {
@@ -2387,7 +2471,7 @@ func (r *RedisServer) rangeList(key []byte, startRaw, endRaw []byte) ([]string, 
 		return nil, errors.WithStack(err)
 	}
 
-	meta, exists, err := r.loadListMetaAt(context.Background(), key, readTS)
+	meta, exists, err := r.resolveListMeta(context.Background(), key, readTS)
 	if err != nil {
 		return nil, err
 	}

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1310,7 +1310,6 @@ func (r *RedisServer) collectUserKeys(kvs []*store.KVPair, pattern []byte) map[s
 // key, or returns (nil, true) for internal-only keys (meta/delta), and
 // (nil, false) if the key is not a wide-column key at all.
 func wideColumnVisibleUserKey(key []byte) (userKey []byte, isWide bool) {
-	// Check delta prefixes before meta prefixes (delta starts with meta prefix).
 	if store.IsHashMetaDeltaKey(key) || store.IsHashMetaKey(key) {
 		return nil, true
 	}

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/bootjp/elastickv/kv"
+	"github.com/bootjp/elastickv/store"
+	cockerrors "github.com/cockroachdb/errors"
 	"github.com/tidwall/redcon"
 )
 
@@ -22,6 +24,11 @@ const (
 	pubsubFirstChannel   = 2
 	redisBusyPollBackoff = 10 * time.Millisecond
 	redisKeywordCount    = "COUNT"
+
+	// setWideColOverhead is the number of extra elements reserved in a set
+	// wide-column mutation slice beyond the per-member elements: one for the
+	// metadata key and one for the legacy-blob deletion tombstone.
+	setWideColOverhead = 2
 )
 
 type xreadRequest struct {
@@ -546,21 +553,33 @@ func (r *RedisServer) flushDatabase(conn redcon.Conn, all bool) {
 			return fmt.Errorf("verify leader: %w", err)
 		}
 
-		// Delete only Redis-related keys. Three DEL_PREFIX operations cover
-		// all Redis namespaces: "!redis|" (str, hash, set, zset, hll,
-		// stream, ttl), "!lst|" (list meta + items), and "!zs|" (zset
-		// wide-column meta/member/score).
+		// Delete only Redis-related keys. Each DEL_PREFIX operation must be
+		// dispatched separately because the FSM processes only one DEL_PREFIX
+		// per request (the first mutation).
+		//
+		// Namespaces covered:
+		//   "!redis|" — str, legacy hash/set/zset/hll/stream, ttl
+		//   "!lst|"   — list meta + items
+		//   "!zs|"    — zset wide-column
+		//   "!hs|"    — hash wide-column meta/field/delta
+		//   "!st|"    — set wide-column meta/member/delta
+		//
 		// Legacy bare keys are NOT deleted here to avoid a full keyspace
 		// scan. Run FLUSHLEGACY first to clean up legacy data.
-		_, err := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
-			Elems: []*kv.Elem[kv.OP]{
-				{Op: kv.DelPrefix, Key: []byte("!redis|")},
-				{Op: kv.DelPrefix, Key: []byte("!lst|")},
-				{Op: kv.DelPrefix, Key: []byte("!zs|")},
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("dispatch del_prefix: %w", err)
+		for _, prefix := range [][]byte{
+			[]byte("!redis|"),
+			[]byte("!lst|"),
+			[]byte("!zs|"),
+			[]byte("!hs|"),
+			[]byte("!st|"),
+		} {
+			if _, err := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+				Elems: []*kv.Elem[kv.OP]{
+					{Op: kv.DelPrefix, Key: prefix},
+				},
+			}); err != nil {
+				return fmt.Errorf("dispatch del_prefix %q: %w", prefix, err)
+			}
 		}
 		return nil
 	}); err != nil {
@@ -625,14 +644,14 @@ func (r *RedisServer) sadd(conn redcon.Conn, cmd redcon.Command) {
 	if r.proxyToLeader(conn, cmd, cmd.Args[1]) {
 		return
 	}
-	r.mutateExactSet(conn, "set", cmd.Args[1], cmd.Args[2:], true)
+	r.mutateExactSet(conn, setKind, cmd.Args[1], cmd.Args[2:], true)
 }
 
 func (r *RedisServer) srem(conn redcon.Conn, cmd redcon.Command) {
 	if r.proxyToLeader(conn, cmd, cmd.Args[1]) {
 		return
 	}
-	r.mutateExactSet(conn, "set", cmd.Args[1], cmd.Args[2:], false)
+	r.mutateExactSet(conn, setKind, cmd.Args[1], cmd.Args[2:], false)
 }
 
 func (r *RedisServer) validateExactSetKind(kind string, key []byte, readTS uint64) error {
@@ -642,9 +661,9 @@ func (r *RedisServer) validateExactSetKind(kind string, key []byte, readTS uint6
 	}
 
 	switch kind {
-	case "set":
+	case setKind:
 		return r.validateExactSetType(typ, key, readTS)
-	case "hll":
+	case hllKind:
 		return r.validateExactHLLType(typ, key, readTS)
 	default:
 		return errors.New("ERR unsupported exact set kind")
@@ -731,6 +750,24 @@ func sortedExactSetMembers(existing map[string]struct{}) []string {
 }
 
 func (r *RedisServer) persistExactSetMembersTxn(ctx context.Context, kind string, key []byte, readTS uint64, members map[string]struct{}) error {
+	if kind != setKind {
+		// HLL and other non-set kinds keep using the legacy blob format.
+		if len(members) == 0 {
+			elems, _, err := r.deleteLogicalKeyElems(ctx, key, readTS)
+			if err != nil {
+				return err
+			}
+			return r.dispatchElems(ctx, true, readTS, elems)
+		}
+		payload, err := marshalSetValue(redisSetValue{Members: sortedExactSetMembers(members)})
+		if err != nil {
+			return err
+		}
+		return r.dispatchElems(ctx, true, readTS, []*kv.Elem[kv.OP]{
+			{Op: kv.Put, Key: redisExactSetStorageKey(kind, key), Value: payload},
+		})
+	}
+	// Wide-column set: full rewrite (used when the whole state is available).
 	if len(members) == 0 {
 		elems, _, err := r.deleteLogicalKeyElems(ctx, key, readTS)
 		if err != nil {
@@ -738,18 +775,38 @@ func (r *RedisServer) persistExactSetMembersTxn(ctx context.Context, kind string
 		}
 		return r.dispatchElems(ctx, true, readTS, elems)
 	}
-	payload, err := marshalSetValue(redisSetValue{Members: sortedExactSetMembers(members)})
-	if err != nil {
-		return err
+	elems := make([]*kv.Elem[kv.OP], 0, len(members)+setWideColOverhead)
+	for member := range members {
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.SetMemberKey(key, []byte(member)),
+			Value: []byte{},
+		})
 	}
-	return r.dispatchElems(ctx, true, readTS, []*kv.Elem[kv.OP]{
-		{Op: kv.Put, Key: redisExactSetStorageKey(kind, key), Value: payload},
+	elems = append(elems, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   store.SetMetaKey(key),
+		Value: store.MarshalSetMeta(store.SetMeta{Len: int64(len(members))}),
 	})
+	// Remove legacy blob if present.
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisSetKey(key)})
+	return r.dispatchElems(ctx, true, readTS, elems)
 }
 
-func (r *RedisServer) mutateExactSet(conn redcon.Conn, kind string, key []byte, members [][]byte, add bool) {
-	ctx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
-	defer cancel()
+// applySetMemberMutation emits a Put or Del for one set member and returns the
+// change count (1) and the signed length delta (+1 or -1), or (0, 0) if no change.
+func applySetMemberMutation(elems []*kv.Elem[kv.OP], memberKey []byte, exists, add bool) ([]*kv.Elem[kv.OP], int, int64) {
+	if add && !exists {
+		return append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: memberKey, Value: []byte{}}), 1, 1
+	}
+	if !add && exists {
+		return append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: memberKey}), 1, -1
+	}
+	return elems, 0, 0
+}
+
+// mutateExactSetLegacy handles SADD/SREM for non-set kinds (e.g. HLL) via the legacy blob path.
+func (r *RedisServer) mutateExactSetLegacy(conn redcon.Conn, ctx context.Context, kind string, key []byte, members [][]byte, add bool) {
 	var changed int
 	if err := r.retryRedisWrite(ctx, func() error {
 		readTS := r.readTS()
@@ -773,6 +830,81 @@ func (r *RedisServer) mutateExactSet(conn redcon.Conn, kind string, key []byte, 
 	conn.WriteInt(changed)
 }
 
+// mutateExactSetWide handles SADD/SREM for the wide-column set path.
+func (r *RedisServer) mutateExactSetWide(conn redcon.Conn, ctx context.Context, key []byte, members [][]byte, add bool) {
+	var changed int
+	if err := r.retryRedisWrite(ctx, func() error {
+		readTS := r.readTS()
+		if err := r.validateExactSetKind(setKind, key, readTS); err != nil {
+			return err
+		}
+
+		commitTS := r.coordinator.Clock().Next()
+		elems := make([]*kv.Elem[kv.OP], 0, len(members)+setWideColOverhead)
+
+		migrationElems, migErr := r.buildSetLegacyMigrationElems(ctx, key, readTS)
+		if migErr != nil {
+			return migErr
+		}
+		elems = append(elems, migrationElems...)
+
+		changed = 0
+		lenDelta := int64(0)
+		for _, member := range members {
+			memberKey := store.SetMemberKey(key, member)
+			exists, existsErr := r.store.ExistsAt(ctx, memberKey, readTS)
+			if existsErr != nil {
+				return cockerrors.WithStack(existsErr)
+			}
+			var c int
+			var d int64
+			elems, c, d = applySetMemberMutation(elems, memberKey, exists, add)
+			changed += c
+			lenDelta += d
+		}
+
+		if changed == 0 && len(migrationElems) == 0 {
+			return nil
+		}
+
+		if lenDelta != 0 {
+			deltaVal := store.MarshalSetMetaDelta(store.SetMetaDelta{LenDelta: lenDelta})
+			elems = append(elems, &kv.Elem[kv.OP]{
+				Op:    kv.Put,
+				Key:   store.SetMetaDeltaKey(key, commitTS, 0),
+				Value: deltaVal,
+			})
+		}
+
+		if len(elems) == 0 {
+			return nil
+		}
+
+		_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+			IsTxn:    true,
+			StartTS:  normalizeStartTS(readTS),
+			CommitTS: commitTS,
+			Elems:    elems,
+		})
+		return cockerrors.WithStack(dispatchErr)
+	}); err != nil {
+		conn.WriteError(err.Error())
+		return
+	}
+	conn.WriteInt(changed)
+}
+
+func (r *RedisServer) mutateExactSet(conn redcon.Conn, kind string, key []byte, members [][]byte, add bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
+	defer cancel()
+
+	if kind != setKind {
+		r.mutateExactSetLegacy(conn, ctx, kind, key, members, add)
+		return
+	}
+	r.mutateExactSetWide(conn, ctx, key, members, add)
+}
+
 func (r *RedisServer) sismember(conn redcon.Conn, cmd redcon.Command) {
 	if r.proxyToLeader(conn, cmd, cmd.Args[1]) {
 		return
@@ -792,7 +924,7 @@ func (r *RedisServer) sismember(conn redcon.Conn, cmd redcon.Command) {
 		return
 	}
 
-	value, err := r.loadSetAt(context.Background(), "set", cmd.Args[1], readTS)
+	value, err := r.loadSetAt(context.Background(), setKind, cmd.Args[1], readTS)
 	if err != nil {
 		conn.WriteError(err.Error())
 		return
@@ -823,7 +955,7 @@ func (r *RedisServer) smembers(conn redcon.Conn, cmd redcon.Command) {
 		return
 	}
 
-	value, err := r.loadSetAt(context.Background(), "set", cmd.Args[1], readTS)
+	value, err := r.loadSetAt(context.Background(), setKind, cmd.Args[1], readTS)
 	if err != nil {
 		conn.WriteError(err.Error())
 		return
@@ -843,11 +975,11 @@ func (r *RedisServer) pfadd(conn redcon.Conn, cmd redcon.Command) {
 	var changed int
 	if err := r.retryRedisWrite(ctx, func() error {
 		readTS := r.readTS()
-		if err := r.validateExactSetKind("hll", cmd.Args[1], readTS); err != nil {
+		if err := r.validateExactSetKind(hllKind, cmd.Args[1], readTS); err != nil {
 			return err
 		}
 
-		value, err := r.loadSetAt(context.Background(), "hll", cmd.Args[1], readTS)
+		value, err := r.loadSetAt(context.Background(), hllKind, cmd.Args[1], readTS)
 		if err != nil {
 			return err
 		}
@@ -857,7 +989,7 @@ func (r *RedisServer) pfadd(conn redcon.Conn, cmd redcon.Command) {
 			return nil
 		}
 
-		return r.persistExactSetMembersTxn(ctx, "hll", cmd.Args[1], readTS, existing)
+		return r.persistExactSetMembersTxn(ctx, hllKind, cmd.Args[1], readTS, existing)
 	}); err != nil {
 		conn.WriteError(err.Error())
 		return
@@ -892,7 +1024,7 @@ func (r *RedisServer) pfcount(conn redcon.Conn, cmd redcon.Command) {
 				return
 			}
 		}
-		value, err := r.loadSetAt(context.Background(), "hll", key, readTS)
+		value, err := r.loadSetAt(context.Background(), hllKind, key, readTS)
 		if err != nil {
 			conn.WriteError(err.Error())
 			return
@@ -927,16 +1059,93 @@ func (r *RedisServer) hmset(conn redcon.Conn, cmd redcon.Command) {
 	conn.WriteString("OK")
 }
 
-func applyHashPairs(value redisHashValue, args [][]byte) int {
-	added := 0
-	for i := 0; i < len(args); i += redisPairWidth {
-		field := string(args[i])
-		if _, ok := value[field]; !ok {
-			added++
-		}
-		value[field] = string(args[i+1])
+// buildHashLegacyMigrationElems returns ops that atomically migrate a legacy
+// !redis|hash| blob to wide-column !hs|fld| keys.  Returns nil if no legacy
+// blob exists.  The base meta key is also written with the migrated count so
+// that resolveHashMeta works correctly after migration.
+func (r *RedisServer) buildHashLegacyMigrationElems(ctx context.Context, key []byte, readTS uint64) ([]*kv.Elem[kv.OP], error) {
+	raw, err := r.store.GetAt(ctx, redisHashKey(key), readTS)
+	if cockerrors.Is(err, store.ErrKeyNotFound) {
+		return nil, nil
 	}
-	return added
+	if err != nil {
+		return nil, cockerrors.WithStack(err)
+	}
+	value, err := unmarshalHashValue(raw)
+	if err != nil {
+		return nil, err
+	}
+	elems := make([]*kv.Elem[kv.OP], 0, len(value)+setWideColOverhead)
+	for field, val := range value {
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.HashFieldKey(key, []byte(field)),
+			Value: []byte(val),
+		})
+	}
+	// Delete the legacy blob.
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisHashKey(key)})
+	// Write a base meta so that resolveHashMeta starts from an accurate count.
+	elems = append(elems, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   store.HashMetaKey(key),
+		Value: store.MarshalHashMeta(store.HashMeta{Len: int64(len(value))}),
+	})
+	return elems, nil
+}
+
+// buildSetLegacyMigrationElems returns ops that atomically migrate a legacy
+// !redis|set| blob to wide-column !st|mem| keys.  Returns nil if no legacy
+// blob exists.
+func (r *RedisServer) buildSetLegacyMigrationElems(ctx context.Context, key []byte, readTS uint64) ([]*kv.Elem[kv.OP], error) {
+	raw, err := r.store.GetAt(ctx, redisSetKey(key), readTS)
+	if cockerrors.Is(err, store.ErrKeyNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, cockerrors.WithStack(err)
+	}
+	value, err := unmarshalSetValue(raw)
+	if err != nil {
+		return nil, err
+	}
+	elems := make([]*kv.Elem[kv.OP], 0, len(value.Members)+setWideColOverhead)
+	for _, member := range value.Members {
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.SetMemberKey(key, []byte(member)),
+			Value: []byte{},
+		})
+	}
+	// Delete the legacy blob.
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisSetKey(key)})
+	// Write a base meta so that resolveSetMeta starts from an accurate count.
+	elems = append(elems, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   store.SetMetaKey(key),
+		Value: store.MarshalSetMeta(store.SetMeta{Len: int64(len(value.Members))}),
+	})
+	return elems, nil
+}
+
+// buildHashFieldElems iterates over field-value pairs in args, records whether each field is
+// new vs. existing, appends Put operations to elems, and returns the updated elems and new-field count.
+func (r *RedisServer) buildHashFieldElems(ctx context.Context, key []byte, args [][]byte, readTS uint64, elems []*kv.Elem[kv.OP]) ([]*kv.Elem[kv.OP], int, error) {
+	newFields := 0
+	for i := 0; i < len(args); i += redisPairWidth {
+		field := args[i]
+		value := args[i+1]
+		fieldKey := store.HashFieldKey(key, field)
+		exists, existsErr := r.store.ExistsAt(ctx, fieldKey, readTS)
+		if existsErr != nil {
+			return nil, 0, cockerrors.WithStack(existsErr)
+		}
+		if !exists {
+			newFields++
+		}
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: fieldKey, Value: value})
+	}
+	return elems, newFields, nil
 }
 
 func (r *RedisServer) applyHashFieldPairs(key []byte, args [][]byte) (int, error) {
@@ -956,18 +1165,45 @@ func (r *RedisServer) applyHashFieldPairs(key []byte, args [][]byte) (int, error
 		if typ != redisTypeNone && typ != redisTypeHash {
 			return wrongTypeError()
 		}
-		value, err := r.loadHashAt(context.Background(), key, readTS)
+
+		commitTS := r.coordinator.Clock().Next()
+		elems := make([]*kv.Elem[kv.OP], 0, len(args)/redisPairWidth+setWideColOverhead)
+
+		// Atomically migrate any legacy blob on first wide-column write.
+		migrationElems, err := r.buildHashLegacyMigrationElems(ctx, key, readTS)
 		if err != nil {
 			return err
 		}
-		added = applyHashPairs(value, args)
-		payload, err := marshalHashValue(value)
+		elems = append(elems, migrationElems...)
+
+		var newFields int
+		elems, newFields, err = r.buildHashFieldElems(ctx, key, args, readTS, elems)
 		if err != nil {
 			return err
 		}
-		return r.dispatchElems(ctx, true, readTS, []*kv.Elem[kv.OP]{
-			{Op: kv.Put, Key: redisHashKey(key), Value: payload},
+		added = newFields
+
+		// Emit a single delta key for all newly-added fields.
+		if newFields != 0 {
+			deltaVal := store.MarshalHashMetaDelta(store.HashMetaDelta{LenDelta: int64(newFields)})
+			elems = append(elems, &kv.Elem[kv.OP]{
+				Op:    kv.Put,
+				Key:   store.HashMetaDeltaKey(key, commitTS, 0),
+				Value: deltaVal,
+			})
+		}
+
+		if len(elems) == 0 {
+			return nil
+		}
+
+		_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+			IsTxn:    true,
+			StartTS:  normalizeStartTS(readTS),
+			CommitTS: commitTS,
+			Elems:    elems,
 		})
+		return cockerrors.WithStack(dispatchErr)
 	})
 	return added, err
 }
@@ -1061,6 +1297,40 @@ func (r *RedisServer) hdel(conn redcon.Conn, cmd redcon.Command) {
 	conn.WriteInt(removed)
 }
 
+// hdelWideColumn deletes the given fields from the wide-column hash and emits a negative delta.
+func (r *RedisServer) hdelWideColumn(ctx context.Context, key []byte, fields [][]byte, readTS uint64) (int, error) {
+	commitTS := r.coordinator.Clock().Next()
+	elems := make([]*kv.Elem[kv.OP], 0, len(fields)+1)
+	removed := 0
+	for _, field := range fields {
+		fieldKey := store.HashFieldKey(key, field)
+		exists, existsErr := r.store.ExistsAt(ctx, fieldKey, readTS)
+		if existsErr != nil {
+			return 0, cockerrors.WithStack(existsErr)
+		}
+		if exists {
+			elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: fieldKey})
+			removed++
+		}
+	}
+	if removed == 0 {
+		return 0, nil
+	}
+	deltaVal := store.MarshalHashMetaDelta(store.HashMetaDelta{LenDelta: int64(-removed)})
+	elems = append(elems, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   store.HashMetaDeltaKey(key, commitTS, 0),
+		Value: deltaVal,
+	})
+	_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+		IsTxn:    true,
+		StartTS:  normalizeStartTS(readTS),
+		CommitTS: commitTS,
+		Elems:    elems,
+	})
+	return removed, cockerrors.WithStack(dispatchErr)
+}
+
 func (r *RedisServer) hdelTxn(ctx context.Context, key []byte, fields [][]byte) (int, error) {
 	readTS := r.readTS()
 	typ, err := r.keyTypeAt(context.Background(), key, readTS)
@@ -1073,6 +1343,19 @@ func (r *RedisServer) hdelTxn(ctx context.Context, key []byte, fields [][]byte) 
 	if typ != redisTypeHash {
 		return 0, wrongTypeError()
 	}
+
+	// Wide-column path: check if any !hs|fld| keys exist for this key.
+	hashFieldPrefix := store.HashFieldScanPrefix(key)
+	hashFieldEnd := store.PrefixScanEnd(hashFieldPrefix)
+	wideKVs, err := r.store.ScanAt(context.Background(), hashFieldPrefix, hashFieldEnd, 1, readTS)
+	if err != nil {
+		return 0, cockerrors.WithStack(err)
+	}
+	if len(wideKVs) > 0 {
+		return r.hdelWideColumn(ctx, key, fields, readTS)
+	}
+
+	// Legacy blob path.
 	value, err := r.loadHashAt(context.Background(), key, readTS)
 	if err != nil {
 		return 0, err
@@ -1103,13 +1386,24 @@ func (r *RedisServer) persistHashTxn(ctx context.Context, key []byte, readTS uin
 		}
 		return r.dispatchElems(ctx, true, readTS, elems)
 	}
-	payload, err := marshalHashValue(value)
-	if err != nil {
-		return err
+	// Wide-column rewrite: write per-field keys and a new base meta.
+	// deleteLogicalKeyElems (called by the caller when needed) clears old keys.
+	elems := make([]*kv.Elem[kv.OP], 0, len(value)+1)
+	for field, val := range value {
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.HashFieldKey(key, []byte(field)),
+			Value: []byte(val),
+		})
 	}
-	return r.dispatchElems(ctx, true, readTS, []*kv.Elem[kv.OP]{
-		{Op: kv.Put, Key: redisHashKey(key), Value: payload},
+	elems = append(elems, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   store.HashMetaKey(key),
+		Value: store.MarshalHashMeta(store.HashMeta{Len: int64(len(value))}),
 	})
+	// Also remove the legacy blob if it was present.
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisHashKey(key)})
+	return r.dispatchElems(ctx, true, readTS, elems)
 }
 
 func (r *RedisServer) hexists(conn redcon.Conn, cmd redcon.Command) {
@@ -1162,6 +1456,17 @@ func (r *RedisServer) hlen(conn redcon.Conn, cmd redcon.Command) {
 		return
 	}
 
+	// Wide-column path: use delta-aggregated metadata for O(1) count.
+	count, exists, err := r.resolveHashMeta(context.Background(), cmd.Args[1], readTS)
+	if err != nil {
+		conn.WriteError(err.Error())
+		return
+	}
+	if exists {
+		conn.WriteInt64(count)
+		return
+	}
+	// Legacy blob fallback: load all fields and count.
 	value, err := r.loadHashAt(context.Background(), cmd.Args[1], readTS)
 	if err != nil {
 		conn.WriteError(err.Error())
@@ -1194,6 +1499,66 @@ func (r *RedisServer) hincrby(conn redcon.Conn, cmd redcon.Command) {
 	conn.WriteInt64(current)
 }
 
+// readHashFieldInt reads the current integer value of a hash field from wide-column or legacy storage.
+// Returns (current, isNewField, legacyHashValue, error). legacyHashValue is non-nil only when
+// the value came from a legacy JSON blob that needs to be migrated on the next write.
+func (r *RedisServer) readHashFieldInt(ctx context.Context, key, field []byte, readTS uint64) (int64, bool, redisHashValue, error) {
+	fieldKey := store.HashFieldKey(key, field)
+	raw, readErr := r.store.GetAt(ctx, fieldKey, readTS)
+	if readErr != nil && !cockerrors.Is(readErr, store.ErrKeyNotFound) {
+		return 0, true, nil, cockerrors.WithStack(readErr)
+	}
+	if readErr == nil {
+		current, parseErr := strconv.ParseInt(string(raw), 10, 64)
+		if parseErr != nil {
+			return 0, false, nil, errors.New("ERR hash value is not an integer")
+		}
+		return current, false, nil, nil
+	}
+	// Not in wide-column – check legacy blob.
+	legacyValue, legacyErr := r.loadHashAt(ctx, key, readTS)
+	if legacyErr != nil {
+		return 0, true, nil, legacyErr
+	}
+	if rawLegacy, ok := legacyValue[string(field)]; ok {
+		current, parseErr := strconv.ParseInt(rawLegacy, 10, 64)
+		if parseErr != nil {
+			return 0, false, nil, errors.New("ERR hash value is not an integer")
+		}
+		return current, false, legacyValue, nil
+	}
+	return 0, true, legacyValue, nil
+}
+
+// hincrbyWithMigration handles the HINCRBY case where a legacy JSON blob must be migrated
+// atomically with the increment operation.
+func (r *RedisServer) hincrbyWithMigration(ctx context.Context, key, fieldKey []byte, readTS, commitTS uint64, current int64, isNewField bool, increment int64) (int64, error) {
+	migrationElems, migErr := r.buildHashLegacyMigrationElems(ctx, key, readTS)
+	if migErr != nil {
+		return 0, migErr
+	}
+	current += increment
+	newVal := strconv.FormatInt(current, 10)
+	elems := make([]*kv.Elem[kv.OP], 0, len(migrationElems)+setWideColOverhead)
+	elems = append(elems, migrationElems...)
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: fieldKey, Value: []byte(newVal)})
+	if isNewField {
+		deltaVal := store.MarshalHashMetaDelta(store.HashMetaDelta{LenDelta: 1})
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.HashMetaDeltaKey(key, commitTS, 0),
+			Value: deltaVal,
+		})
+	}
+	_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+		IsTxn:    true,
+		StartTS:  normalizeStartTS(readTS),
+		CommitTS: commitTS,
+		Elems:    elems,
+	})
+	return current, cockerrors.WithStack(dispatchErr)
+}
+
 func (r *RedisServer) hincrbyTxn(ctx context.Context, key, field []byte, increment int64) (int64, error) {
 	readTS := r.readTS()
 	typ, err := r.keyTypeAt(context.Background(), key, readTS)
@@ -1203,26 +1568,39 @@ func (r *RedisServer) hincrbyTxn(ctx context.Context, key, field []byte, increme
 	if typ != redisTypeNone && typ != redisTypeHash {
 		return 0, wrongTypeError()
 	}
-	value, err := r.loadHashAt(context.Background(), key, readTS)
+
+	commitTS := r.coordinator.Clock().Next()
+	fieldKey := store.HashFieldKey(key, field)
+
+	current, isNewField, legacyValue, err := r.readHashFieldInt(ctx, key, field, readTS)
 	if err != nil {
 		return 0, err
 	}
-	var current int64
-	if raw, ok := value[string(field)]; ok {
-		current, err = strconv.ParseInt(raw, 10, 64)
-		if err != nil {
-			return 0, errors.New("ERR hash value is not an integer")
-		}
+
+	// If a legacy blob exists, migrate it atomically with the increment.
+	if len(legacyValue) > 0 {
+		return r.hincrbyWithMigration(ctx, key, fieldKey, readTS, commitTS, current, isNewField, increment)
 	}
+
 	current += increment
-	value[string(field)] = strconv.FormatInt(current, 10)
-	payload, err := marshalHashValue(value)
-	if err != nil {
-		return 0, err
+	newVal := strconv.FormatInt(current, 10)
+	elems := make([]*kv.Elem[kv.OP], 0, setWideColOverhead)
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: fieldKey, Value: []byte(newVal)})
+	if isNewField {
+		deltaVal := store.MarshalHashMetaDelta(store.HashMetaDelta{LenDelta: 1})
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.HashMetaDeltaKey(key, commitTS, 0),
+			Value: deltaVal,
+		})
 	}
-	return current, r.dispatchElems(ctx, true, readTS, []*kv.Elem[kv.OP]{
-		{Op: kv.Put, Key: redisHashKey(key), Value: payload},
+	_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+		IsTxn:    true,
+		StartTS:  normalizeStartTS(readTS),
+		CommitTS: commitTS,
+		Elems:    elems,
 	})
+	return current, cockerrors.WithStack(dispatchErr)
 }
 
 func (r *RedisServer) incr(conn redcon.Conn, cmd redcon.Command) {

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -830,6 +830,20 @@ func (r *RedisServer) mutateExactSetLegacy(conn redcon.Conn, ctx context.Context
 	conn.WriteInt(changed)
 }
 
+// setMemberExists reports whether a member exists in the set at readTS,
+// checking the wide-column store first and falling back to the legacy member
+// map when a migration is in progress (wide-column keys don't exist yet).
+func (r *RedisServer) setMemberExists(ctx context.Context, memberKey []byte, member []byte, legacyMembers map[string]struct{}, readTS uint64) (bool, error) {
+	exists, err := r.store.ExistsAt(ctx, memberKey, readTS)
+	if err != nil {
+		return false, cockerrors.WithStack(err)
+	}
+	if !exists && legacyMembers != nil {
+		_, exists = legacyMembers[string(member)]
+	}
+	return exists, nil
+}
+
 // mutateExactSetWide handles SADD/SREM for the wide-column set path.
 func (r *RedisServer) mutateExactSetWide(conn redcon.Conn, ctx context.Context, key []byte, members [][]byte, add bool) {
 	var changed int
@@ -843,7 +857,7 @@ func (r *RedisServer) mutateExactSetWide(conn redcon.Conn, ctx context.Context, 
 		commitTS := r.coordinator.Clock().Next()
 		elems := make([]*kv.Elem[kv.OP], 0, len(members)+setWideColOverhead)
 
-		migrationElems, migErr := r.buildSetLegacyMigrationElems(ctx, key, readTS)
+		migrationElems, legacyMembers, migErr := r.buildSetLegacyMigrationElems(ctx, key, readTS)
 		if migErr != nil {
 			return migErr
 		}
@@ -853,9 +867,9 @@ func (r *RedisServer) mutateExactSetWide(conn redcon.Conn, ctx context.Context, 
 		lenDelta := int64(0)
 		for _, member := range members {
 			memberKey := store.SetMemberKey(key, member)
-			exists, existsErr := r.store.ExistsAt(ctx, memberKey, readTS)
+			exists, existsErr := r.setMemberExists(ctx, memberKey, member, legacyMembers, readTS)
 			if existsErr != nil {
-				return cockerrors.WithStack(existsErr)
+				return existsErr
 			}
 			var c int
 			var d int64
@@ -1061,20 +1075,23 @@ func (r *RedisServer) hmset(conn redcon.Conn, cmd redcon.Command) {
 }
 
 // buildHashLegacyMigrationElems returns ops that atomically migrate a legacy
-// !redis|hash| blob to wide-column !hs|fld| keys.  Returns nil if no legacy
-// blob exists.  The base meta key is also written with the migrated count so
-// that resolveHashMeta works correctly after migration.
-func (r *RedisServer) buildHashLegacyMigrationElems(ctx context.Context, key []byte, readTS uint64) ([]*kv.Elem[kv.OP], error) {
+// !redis|hash| blob to wide-column !hs|fld| keys.  Returns nil elems if no
+// legacy blob exists.  The base meta key is also written with the migrated
+// count so that resolveHashMeta works correctly after migration.
+// The returned redisHashValue (may be nil) must be used by the caller to
+// correctly determine field existence — wide-column keys don't exist yet at
+// readTS, so ExistsAt would incorrectly count all legacy fields as new.
+func (r *RedisServer) buildHashLegacyMigrationElems(ctx context.Context, key []byte, readTS uint64) ([]*kv.Elem[kv.OP], redisHashValue, error) {
 	raw, err := r.store.GetAt(ctx, redisHashKey(key), readTS)
 	if cockerrors.Is(err, store.ErrKeyNotFound) {
-		return nil, nil
+		return nil, nil, nil
 	}
 	if err != nil {
-		return nil, cockerrors.WithStack(err)
+		return nil, nil, cockerrors.WithStack(err)
 	}
 	value, err := unmarshalHashValue(raw)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	elems := make([]*kv.Elem[kv.OP], 0, len(value)+setWideColOverhead)
 	for field, val := range value {
@@ -1092,26 +1109,31 @@ func (r *RedisServer) buildHashLegacyMigrationElems(ctx context.Context, key []b
 		Key:   store.HashMetaKey(key),
 		Value: store.MarshalHashMeta(store.HashMeta{Len: int64(len(value))}),
 	})
-	return elems, nil
+	return elems, value, nil
 }
 
 // buildSetLegacyMigrationElems returns ops that atomically migrate a legacy
-// !redis|set| blob to wide-column !st|mem| keys.  Returns nil if no legacy
-// blob exists.
-func (r *RedisServer) buildSetLegacyMigrationElems(ctx context.Context, key []byte, readTS uint64) ([]*kv.Elem[kv.OP], error) {
+// !redis|set| blob to wide-column !st|mem| keys. Returns nil elems if no
+// legacy blob exists.
+// The returned member set (may be nil) must be used by the caller to
+// correctly determine member existence — wide-column keys don't exist yet at
+// readTS, so ExistsAt would incorrectly count all legacy members as new.
+func (r *RedisServer) buildSetLegacyMigrationElems(ctx context.Context, key []byte, readTS uint64) ([]*kv.Elem[kv.OP], map[string]struct{}, error) {
 	raw, err := r.store.GetAt(ctx, redisSetKey(key), readTS)
 	if cockerrors.Is(err, store.ErrKeyNotFound) {
-		return nil, nil
+		return nil, nil, nil
 	}
 	if err != nil {
-		return nil, cockerrors.WithStack(err)
+		return nil, nil, cockerrors.WithStack(err)
 	}
 	value, err := unmarshalSetValue(raw)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+	legacyMembers := make(map[string]struct{}, len(value.Members))
 	elems := make([]*kv.Elem[kv.OP], 0, len(value.Members)+setWideColOverhead)
 	for _, member := range value.Members {
+		legacyMembers[member] = struct{}{}
 		elems = append(elems, &kv.Elem[kv.OP]{
 			Op:    kv.Put,
 			Key:   store.SetMemberKey(key, []byte(member)),
@@ -1126,12 +1148,16 @@ func (r *RedisServer) buildSetLegacyMigrationElems(ctx context.Context, key []by
 		Key:   store.SetMetaKey(key),
 		Value: store.MarshalSetMeta(store.SetMeta{Len: int64(len(value.Members))}),
 	})
-	return elems, nil
+	return elems, legacyMembers, nil
 }
 
-// buildHashFieldElems iterates over field-value pairs in args, records whether each field is
-// new vs. existing, appends Put operations to elems, and returns the updated elems and new-field count.
-func (r *RedisServer) buildHashFieldElems(ctx context.Context, key []byte, args [][]byte, readTS uint64, elems []*kv.Elem[kv.OP]) ([]*kv.Elem[kv.OP], int, error) {
+// buildHashFieldElems iterates over field-value pairs in args, records whether
+// each field is new vs. existing, appends Put operations to elems, and returns
+// the updated elems and the count of newly-added fields.
+// legacyFields must be set when a legacy blob migration is in progress; it is
+// used to detect fields that already existed in the blob (which have no
+// wide-column key yet at readTS, so ExistsAt would otherwise miscount them).
+func (r *RedisServer) buildHashFieldElems(ctx context.Context, key []byte, args [][]byte, readTS uint64, elems []*kv.Elem[kv.OP], legacyFields redisHashValue) ([]*kv.Elem[kv.OP], int, error) {
 	newFields := 0
 	for i := 0; i < len(args); i += redisPairWidth {
 		field := args[i]
@@ -1140,6 +1166,11 @@ func (r *RedisServer) buildHashFieldElems(ctx context.Context, key []byte, args 
 		exists, existsErr := r.store.ExistsAt(ctx, fieldKey, readTS)
 		if existsErr != nil {
 			return nil, 0, cockerrors.WithStack(existsErr)
+		}
+		// During migration the wide-column key doesn't exist yet; fall back to
+		// the legacy blob to avoid inflating the field count.
+		if !exists && legacyFields != nil {
+			_, exists = legacyFields[string(field)]
 		}
 		if !exists {
 			newFields++
@@ -1172,14 +1203,14 @@ func (r *RedisServer) applyHashFieldPairs(key []byte, args [][]byte) (int, error
 		elems := make([]*kv.Elem[kv.OP], 0, len(args)/redisPairWidth+setWideColOverhead)
 
 		// Atomically migrate any legacy blob on first wide-column write.
-		migrationElems, err := r.buildHashLegacyMigrationElems(ctx, key, readTS)
+		migrationElems, legacyFields, err := r.buildHashLegacyMigrationElems(ctx, key, readTS)
 		if err != nil {
 			return err
 		}
 		elems = append(elems, migrationElems...)
 
 		var newFields int
-		elems, newFields, err = r.buildHashFieldElems(ctx, key, args, readTS, elems)
+		elems, newFields, err = r.buildHashFieldElems(ctx, key, args, readTS, elems, legacyFields)
 		if err != nil {
 			return err
 		}
@@ -1536,7 +1567,9 @@ func (r *RedisServer) readHashFieldInt(ctx context.Context, key, field []byte, r
 // hincrbyWithMigration handles the HINCRBY case where a legacy JSON blob must be migrated
 // atomically with the increment operation.
 func (r *RedisServer) hincrbyWithMigration(ctx context.Context, key, fieldKey []byte, readTS, startTS, commitTS uint64, current int64, isNewField bool, increment int64) (int64, error) {
-	migrationElems, migErr := r.buildHashLegacyMigrationElems(ctx, key, readTS)
+	// Legacy value is ignored here — isNewField was already computed from it
+	// before calling this function, so the delta is correct regardless.
+	migrationElems, _, migErr := r.buildHashLegacyMigrationElems(ctx, key, readTS)
 	if migErr != nil {
 		return 0, migErr
 	}

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -839,6 +839,7 @@ func (r *RedisServer) mutateExactSetWide(conn redcon.Conn, ctx context.Context, 
 			return err
 		}
 
+		startTS := ensureValidStartTS(readTS, r.coordinator.Clock())
 		commitTS := r.coordinator.Clock().Next()
 		elems := make([]*kv.Elem[kv.OP], 0, len(members)+setWideColOverhead)
 
@@ -882,7 +883,7 @@ func (r *RedisServer) mutateExactSetWide(conn redcon.Conn, ctx context.Context, 
 
 		_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 			IsTxn:    true,
-			StartTS:  normalizeStartTS(readTS),
+			StartTS:  startTS,
 			CommitTS: commitTS,
 			Elems:    elems,
 		})
@@ -1166,6 +1167,7 @@ func (r *RedisServer) applyHashFieldPairs(key []byte, args [][]byte) (int, error
 			return wrongTypeError()
 		}
 
+		startTS := ensureValidStartTS(readTS, r.coordinator.Clock())
 		commitTS := r.coordinator.Clock().Next()
 		elems := make([]*kv.Elem[kv.OP], 0, len(args)/redisPairWidth+setWideColOverhead)
 
@@ -1199,7 +1201,7 @@ func (r *RedisServer) applyHashFieldPairs(key []byte, args [][]byte) (int, error
 
 		_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 			IsTxn:    true,
-			StartTS:  normalizeStartTS(readTS),
+			StartTS:  startTS,
 			CommitTS: commitTS,
 			Elems:    elems,
 		})
@@ -1299,6 +1301,7 @@ func (r *RedisServer) hdel(conn redcon.Conn, cmd redcon.Command) {
 
 // hdelWideColumn deletes the given fields from the wide-column hash and emits a negative delta.
 func (r *RedisServer) hdelWideColumn(ctx context.Context, key []byte, fields [][]byte, readTS uint64) (int, error) {
+	startTS := ensureValidStartTS(readTS, r.coordinator.Clock())
 	commitTS := r.coordinator.Clock().Next()
 	elems := make([]*kv.Elem[kv.OP], 0, len(fields)+1)
 	removed := 0
@@ -1324,7 +1327,7 @@ func (r *RedisServer) hdelWideColumn(ctx context.Context, key []byte, fields [][
 	})
 	_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 		IsTxn:    true,
-		StartTS:  normalizeStartTS(readTS),
+		StartTS:  startTS,
 		CommitTS: commitTS,
 		Elems:    elems,
 	})
@@ -1532,7 +1535,7 @@ func (r *RedisServer) readHashFieldInt(ctx context.Context, key, field []byte, r
 
 // hincrbyWithMigration handles the HINCRBY case where a legacy JSON blob must be migrated
 // atomically with the increment operation.
-func (r *RedisServer) hincrbyWithMigration(ctx context.Context, key, fieldKey []byte, readTS, commitTS uint64, current int64, isNewField bool, increment int64) (int64, error) {
+func (r *RedisServer) hincrbyWithMigration(ctx context.Context, key, fieldKey []byte, readTS, startTS, commitTS uint64, current int64, isNewField bool, increment int64) (int64, error) {
 	migrationElems, migErr := r.buildHashLegacyMigrationElems(ctx, key, readTS)
 	if migErr != nil {
 		return 0, migErr
@@ -1552,7 +1555,7 @@ func (r *RedisServer) hincrbyWithMigration(ctx context.Context, key, fieldKey []
 	}
 	_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 		IsTxn:    true,
-		StartTS:  normalizeStartTS(readTS),
+		StartTS:  startTS,
 		CommitTS: commitTS,
 		Elems:    elems,
 	})
@@ -1569,6 +1572,7 @@ func (r *RedisServer) hincrbyTxn(ctx context.Context, key, field []byte, increme
 		return 0, wrongTypeError()
 	}
 
+	startTS := ensureValidStartTS(readTS, r.coordinator.Clock())
 	commitTS := r.coordinator.Clock().Next()
 	fieldKey := store.HashFieldKey(key, field)
 
@@ -1579,7 +1583,7 @@ func (r *RedisServer) hincrbyTxn(ctx context.Context, key, field []byte, increme
 
 	// If a legacy blob exists, migrate it atomically with the increment.
 	if len(legacyValue) > 0 {
-		return r.hincrbyWithMigration(ctx, key, fieldKey, readTS, commitTS, current, isNewField, increment)
+		return r.hincrbyWithMigration(ctx, key, fieldKey, readTS, startTS, commitTS, current, isNewField, increment)
 	}
 
 	current += increment
@@ -1596,7 +1600,7 @@ func (r *RedisServer) hincrbyTxn(ctx context.Context, key, field []byte, increme
 	}
 	_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 		IsTxn:    true,
-		StartTS:  normalizeStartTS(readTS),
+		StartTS:  startTS,
 		CommitTS: commitTS,
 		Elems:    elems,
 	})

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -1422,7 +1422,7 @@ func (r *RedisServer) persistHashTxn(ctx context.Context, key []byte, readTS uin
 	}
 	// Wide-column rewrite: write per-field keys and a new base meta.
 	// deleteLogicalKeyElems (called by the caller when needed) clears old keys.
-	elems := make([]*kv.Elem[kv.OP], 0, len(value)+1)
+	elems := make([]*kv.Elem[kv.OP], 0, len(value)+setWideColOverhead)
 	for field, val := range value {
 		elems = append(elems, &kv.Elem[kv.OP]{
 			Op:    kv.Put,

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -55,6 +55,20 @@ func normalizeStartTS(ts uint64) uint64 {
 	return ts
 }
 
+// ensureValidStartTS returns a non-zero start timestamp suitable for Dispatch
+// when a pre-allocated commitTS will be embedded into delta keys. If the
+// snapshot readTS is the uninitialised sentinel (^uint64(0)), normalizeStartTS
+// returns 0, which causes the coordinator to clear the caller-provided
+// commitTS and generate a new one — making the embedded timestamp wrong.
+// Obtaining a fresh startTS from the clock before allocating commitTS ensures
+// startTS > 0 so the coordinator keeps commitTS as-is.
+func ensureValidStartTS(readTS uint64, clk interface{ Next() uint64 }) uint64 {
+	if ts := normalizeStartTS(readTS); ts != 0 {
+		return ts
+	}
+	return clk.Next()
+}
+
 // detectWideColumnType checks for the presence of wide-column hash or set keys
 // and returns the corresponding redis type, or redisTypeNone if neither is found.
 func (r *RedisServer) detectWideColumnType(ctx context.Context, key []byte, readTS uint64) (redisValueType, error) {
@@ -365,13 +379,14 @@ func (r *RedisServer) deleteWideColumnElems(ctx context.Context, readTS uint64, 
 	if len(fieldKVs) > maxWideColumnItems {
 		return nil, errors.Wrapf(ErrCollectionTooLarge, "collection exceeds %d fields/members", maxWideColumnItems)
 	}
-	elems := make([]*kv.Elem[kv.OP], 0, len(fieldKVs))
+	elems := make([]*kv.Elem[kv.OP], 0, len(fieldKVs)+setWideColOverhead)
 	for _, pair := range fieldKVs {
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
 	}
-	if len(fieldKVs) == 0 {
-		return elems, nil
-	}
+	// Always delete the meta key and delta keys even when fieldKVs is empty:
+	// a collection can have zero field/member keys but still hold a base meta
+	// key and uncompacted delta keys (e.g. after all members were removed via
+	// HDEL/SREM). Skipping these would leak internal state.
 	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: metaKey})
 	deltaEnd := store.PrefixScanEnd(deltaPrefix)
 	deltaKVs, scanErr := r.store.ScanAt(ctx, deltaPrefix, deltaEnd, store.MaxDeltaScanLimit, readTS)

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -374,7 +374,7 @@ func (r *RedisServer) deleteListElems(ctx context.Context, key []byte, readTS ui
 	if meta.Len > maxWideColumnItems {
 		return nil, errors.Wrapf(ErrCollectionTooLarge, "list %q exceeds %d items", key, maxWideColumnItems)
 	}
-	elems := make([]*kv.Elem[kv.OP], 0, int(meta.Len)+setWideColOverhead)
+	elems := make([]*kv.Elem[kv.OP], 0, int(meta.Len)+store.MaxDeltaScanLimit+1)
 	for seq := meta.Head; seq < meta.Tail; seq++ {
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: listItemKey(key, seq)})
 	}
@@ -401,7 +401,7 @@ func (r *RedisServer) deleteWideColumnElems(ctx context.Context, readTS uint64, 
 	if len(fieldKVs) > maxWideColumnItems {
 		return nil, errors.Wrapf(ErrCollectionTooLarge, "collection exceeds %d fields/members", maxWideColumnItems)
 	}
-	elems := make([]*kv.Elem[kv.OP], 0, len(fieldKVs)+setWideColOverhead)
+	elems := make([]*kv.Elem[kv.OP], 0, len(fieldKVs)+store.MaxDeltaScanLimit+1)
 	for _, pair := range fieldKVs {
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
 	}

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"log/slog"
-	"math"
 	"sort"
 	"time"
 
@@ -13,10 +12,20 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// maxWideScanLimit is the upper bound used when scanning all fields/members of
-// a wide-column hash or set.  It is intentionally large – wide-column keys are
-// per-field/member so the real cap is the number of items in the collection.
-const maxWideScanLimit = math.MaxInt32
+// maxWideColumnItems is the maximum number of fields/members a single
+// wide-column collection (Hash, Set, ZSet, or List) may contain.
+// Operations that would materialize more than this many items are rejected
+// to prevent unbounded memory growth (OOM).
+const maxWideColumnItems = 100_000
+
+// maxWideScanLimit is passed to ScanAt when loading an entire collection.
+// It is set to maxWideColumnItems+1 so that receiving exactly limit results
+// indicates the collection is over the cap and the caller can return an error
+// instead of silently truncating.
+const maxWideScanLimit = maxWideColumnItems + 1
+
+// ErrCollectionTooLarge is returned when a collection exceeds maxWideColumnItems.
+var ErrCollectionTooLarge = errors.New("collection too large")
 
 const wrongTypeMessage = "WRONGTYPE Operation against a key holding the wrong kind of value"
 
@@ -159,6 +168,9 @@ func (r *RedisServer) loadHashFieldsAt(ctx context.Context, key []byte, readTS u
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	if len(kvs) > maxWideColumnItems {
+		return nil, errors.Wrapf(ErrCollectionTooLarge, "hash %q exceeds %d fields", key, maxWideColumnItems)
+	}
 	result := make(redisHashValue, len(kvs))
 	for _, kv := range kvs {
 		field := store.ExtractHashFieldName(kv.Key, key)
@@ -200,6 +212,9 @@ func (r *RedisServer) loadSetMembersAt(ctx context.Context, key []byte, readTS u
 	kvs, err := r.store.ScanAt(ctx, prefix, end, maxWideScanLimit, readTS)
 	if err != nil {
 		return redisSetValue{}, errors.WithStack(err)
+	}
+	if len(kvs) > maxWideColumnItems {
+		return redisSetValue{}, errors.Wrapf(ErrCollectionTooLarge, "set %q exceeds %d members", key, maxWideColumnItems)
 	}
 	members := make([]string, 0, len(kvs))
 	for _, kv := range kvs {
@@ -315,6 +330,9 @@ func (r *RedisServer) deleteListElems(ctx context.Context, key []byte, readTS ui
 	if !listExists {
 		return nil, nil
 	}
+	if meta.Len > maxWideColumnItems {
+		return nil, errors.Wrapf(ErrCollectionTooLarge, "list %q exceeds %d items", key, maxWideColumnItems)
+	}
 	elems := make([]*kv.Elem[kv.OP], 0, int(meta.Len)+setWideColOverhead)
 	for seq := meta.Head; seq < meta.Tail; seq++ {
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: listItemKey(key, seq)})
@@ -340,6 +358,9 @@ func (r *RedisServer) deleteWideColumnElems(ctx context.Context, readTS uint64, 
 	fieldKVs, err := r.store.ScanAt(ctx, fieldPrefix, fieldEnd, maxWideScanLimit, readTS)
 	if err != nil {
 		return nil, errors.WithStack(err)
+	}
+	if len(fieldKVs) > maxWideColumnItems {
+		return nil, errors.Wrapf(ErrCollectionTooLarge, "collection exceeds %d fields/members", maxWideColumnItems)
 	}
 	elems := make([]*kv.Elem[kv.OP], 0, len(fieldKVs))
 	for _, pair := range fieldKVs {

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -3,6 +3,8 @@ package adapter
 import (
 	"bytes"
 	"context"
+	"log/slog"
+	"math"
 	"sort"
 	"time"
 
@@ -11,18 +13,93 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// maxWideScanLimit is the upper bound used when scanning all fields/members of
+// a wide-column hash or set.  It is intentionally large – wide-column keys are
+// per-field/member so the real cap is the number of items in the collection.
+const maxWideScanLimit = math.MaxInt32
+
 const wrongTypeMessage = "WRONGTYPE Operation against a key holding the wrong kind of value"
+
+// setKind and hllKind are the internal kind discriminators used for Set and
+// HyperLogLog operations. They distinguish code paths within functions that
+// handle both types (e.g. loadSetAt, mutateExactSet).
+const (
+	setKind = "set"
+	hllKind = "hll"
+)
+
+// ErrDeltaScanTruncated is returned when the delta scan result is truncated,
+// indicating that synchronous compaction is required before the operation can proceed.
+var ErrDeltaScanTruncated = errors.New("delta scan truncated: compaction required")
 
 func wrongTypeError() error {
 	return errors.New(wrongTypeMessage)
 }
 
+// normalizeStartTS converts a "fresh read" sentinel (^uint64(0)) to 0.
+// The coordinator's Dispatch requires startTS=0 to mean "no conflict check",
+// while internally we use ^uint64(0) to indicate an uninitialized read timestamp.
+func normalizeStartTS(ts uint64) uint64 {
+	if ts == ^uint64(0) {
+		return 0
+	}
+	return ts
+}
+
+// detectWideColumnType checks for the presence of wide-column hash or set keys
+// and returns the corresponding redis type, or redisTypeNone if neither is found.
+func (r *RedisServer) detectWideColumnType(ctx context.Context, key []byte, readTS uint64) (redisValueType, error) {
+	hashFieldPrefix := store.HashFieldScanPrefix(key)
+	hashFieldEnd := store.PrefixScanEnd(hashFieldPrefix)
+	hashFieldKVs, err := r.store.ScanAt(ctx, hashFieldPrefix, hashFieldEnd, 1, readTS)
+	if err != nil {
+		return redisTypeNone, errors.WithStack(err)
+	}
+	if len(hashFieldKVs) > 0 {
+		return redisTypeHash, nil
+	}
+	setMemberPrefix := store.SetMemberScanPrefix(key)
+	setMemberEnd := store.PrefixScanEnd(setMemberPrefix)
+	setMemberKVs, err := r.store.ScanAt(ctx, setMemberPrefix, setMemberEnd, 1, readTS)
+	if err != nil {
+		return redisTypeNone, errors.WithStack(err)
+	}
+	if len(setMemberKVs) > 0 {
+		return redisTypeSet, nil
+	}
+	return redisTypeNone, nil
+}
+
 func (r *RedisServer) rawKeyTypeAt(ctx context.Context, key []byte, readTS uint64) (redisValueType, error) {
+	// Check list base metadata key first.
+	listMetaExists, err := r.store.ExistsAt(ctx, store.ListMetaKey(key), readTS)
+	if err != nil {
+		return redisTypeNone, errors.WithStack(err)
+	}
+	if listMetaExists {
+		return redisTypeList, nil
+	}
+	// Fallback: detect a delta-only list (base meta not yet written or
+	// already compacted away but deltas still present).
+	deltaPrefix := store.ListMetaDeltaScanPrefix(key)
+	deltaEnd := store.PrefixScanEnd(deltaPrefix)
+	deltaKVs, err := r.store.ScanAt(ctx, deltaPrefix, deltaEnd, 1, readTS)
+	if err != nil {
+		return redisTypeNone, errors.WithStack(err)
+	}
+	if len(deltaKVs) > 0 {
+		return redisTypeList, nil
+	}
+
+	// Check wide-column hash and set types.
+	if typ, wideErr := r.detectWideColumnType(ctx, key, readTS); wideErr != nil || typ != redisTypeNone {
+		return typ, wideErr
+	}
+
 	checks := []struct {
 		typ redisValueType
 		key []byte
 	}{
-		{typ: redisTypeList, key: store.ListMetaKey(key)},
 		{typ: redisTypeHash, key: redisHashKey(key)},
 		{typ: redisTypeSet, key: redisSetKey(key)},
 		{typ: redisTypeZSet, key: redisZSetKey(key)},
@@ -73,7 +150,37 @@ func (r *RedisServer) logicalExistsAt(ctx context.Context, key []byte, readTS ui
 	return typ != redisTypeNone, nil
 }
 
+// loadHashFieldsAt scans all wide-column !hs|fld| keys and returns them as a
+// redisHashValue map.
+func (r *RedisServer) loadHashFieldsAt(ctx context.Context, key []byte, readTS uint64) (redisHashValue, error) {
+	prefix := store.HashFieldScanPrefix(key)
+	end := store.PrefixScanEnd(prefix)
+	kvs, err := r.store.ScanAt(ctx, prefix, end, maxWideScanLimit, readTS)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	result := make(redisHashValue, len(kvs))
+	for _, kv := range kvs {
+		field := store.ExtractHashFieldName(kv.Key, key)
+		if field != nil {
+			result[string(field)] = string(kv.Value)
+		}
+	}
+	return result, nil
+}
+
 func (r *RedisServer) loadHashAt(ctx context.Context, key []byte, readTS uint64) (redisHashValue, error) {
+	// Wide-column path: scan !hs|fld| prefix first.
+	prefix := store.HashFieldScanPrefix(key)
+	end := store.PrefixScanEnd(prefix)
+	kvs, err := r.store.ScanAt(ctx, prefix, end, 1, readTS)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if len(kvs) > 0 {
+		return r.loadHashFieldsAt(ctx, key, readTS)
+	}
+	// Legacy blob fallback.
 	raw, err := r.store.GetAt(ctx, redisHashKey(key), readTS)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
@@ -85,7 +192,40 @@ func (r *RedisServer) loadHashAt(ctx context.Context, key []byte, readTS uint64)
 	return val, err
 }
 
+// loadSetMembersAt scans all wide-column !st|mem| keys and returns them as a
+// redisSetValue.  Only used for kind=="set" (HLL stays as a legacy blob).
+func (r *RedisServer) loadSetMembersAt(ctx context.Context, key []byte, readTS uint64) (redisSetValue, error) {
+	prefix := store.SetMemberScanPrefix(key)
+	end := store.PrefixScanEnd(prefix)
+	kvs, err := r.store.ScanAt(ctx, prefix, end, maxWideScanLimit, readTS)
+	if err != nil {
+		return redisSetValue{}, errors.WithStack(err)
+	}
+	members := make([]string, 0, len(kvs))
+	for _, kv := range kvs {
+		member := store.ExtractSetMemberName(kv.Key, key)
+		if member != nil {
+			members = append(members, string(member))
+		}
+	}
+	sort.Strings(members)
+	return redisSetValue{Members: members}, nil
+}
+
 func (r *RedisServer) loadSetAt(ctx context.Context, kind string, key []byte, readTS uint64) (redisSetValue, error) {
+	if kind == "set" {
+		// Wide-column path: check !st|mem| prefix first.
+		prefix := store.SetMemberScanPrefix(key)
+		end := store.PrefixScanEnd(prefix)
+		kvs, err := r.store.ScanAt(ctx, prefix, end, 1, readTS)
+		if err != nil {
+			return redisSetValue{}, errors.WithStack(err)
+		}
+		if len(kvs) > 0 {
+			return r.loadSetMembersAt(ctx, key, readTS)
+		}
+	}
+	// Legacy blob fallback (also the only path for HLL).
 	storageKey := redisExactSetStorageKey(kind, key)
 	raw, err := r.store.GetAt(ctx, storageKey, readTS)
 	if err != nil {
@@ -166,6 +306,60 @@ func (r *RedisServer) saveString(ctx context.Context, key []byte, value []byte, 
 	return r.dispatchElems(ctx, false, 0, elems)
 }
 
+// deleteListElems returns delete operations for all list keys (items, meta, deltas).
+func (r *RedisServer) deleteListElems(ctx context.Context, key []byte, readTS uint64) ([]*kv.Elem[kv.OP], error) {
+	meta, listExists, err := r.resolveListMeta(ctx, key, readTS)
+	if err != nil {
+		return nil, err
+	}
+	if !listExists {
+		return nil, nil
+	}
+	elems := make([]*kv.Elem[kv.OP], 0, int(meta.Len)+setWideColOverhead)
+	for seq := meta.Head; seq < meta.Tail; seq++ {
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: listItemKey(key, seq)})
+	}
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: listMetaKey(key)})
+	deltaPrefix := store.ListMetaDeltaScanPrefix(key)
+	deltaEnd := store.PrefixScanEnd(deltaPrefix)
+	deltaKVs, scanErr := r.store.ScanAt(ctx, deltaPrefix, deltaEnd, store.MaxDeltaScanLimit, readTS)
+	if scanErr != nil {
+		return nil, errors.WithStack(scanErr)
+	}
+	for _, pair := range deltaKVs {
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
+	}
+	return elems, nil
+}
+
+// deleteWideColumnElems returns delete operations for all wide-column field/member keys,
+// the base meta key, and all delta keys for a collection identified by the given scan prefix,
+// meta key, and delta prefix.
+func (r *RedisServer) deleteWideColumnElems(ctx context.Context, readTS uint64, fieldPrefix, metaKey, deltaPrefix []byte) ([]*kv.Elem[kv.OP], error) {
+	fieldEnd := store.PrefixScanEnd(fieldPrefix)
+	fieldKVs, err := r.store.ScanAt(ctx, fieldPrefix, fieldEnd, maxWideScanLimit, readTS)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	elems := make([]*kv.Elem[kv.OP], 0, len(fieldKVs))
+	for _, pair := range fieldKVs {
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
+	}
+	if len(fieldKVs) == 0 {
+		return elems, nil
+	}
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: metaKey})
+	deltaEnd := store.PrefixScanEnd(deltaPrefix)
+	deltaKVs, scanErr := r.store.ScanAt(ctx, deltaPrefix, deltaEnd, store.MaxDeltaScanLimit, readTS)
+	if scanErr != nil {
+		return nil, errors.WithStack(scanErr)
+	}
+	for _, pair := range deltaKVs {
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
+	}
+	return elems, nil
+}
+
 func (r *RedisServer) deleteLogicalKeyElems(ctx context.Context, key []byte, readTS uint64) ([]*kv.Elem[kv.OP], bool, error) {
 	existed, err := r.logicalExistsAt(ctx, key, readTS)
 	if err != nil {
@@ -193,22 +387,33 @@ func (r *RedisServer) deleteLogicalKeyElems(ctx context.Context, key []byte, rea
 		}
 	}
 
-	meta, listExists, err := r.loadListMetaAt(ctx, key, readTS)
+	listElems, err := r.deleteListElems(ctx, key, readTS)
 	if err != nil {
 		return nil, false, err
 	}
-	if listExists {
-		for seq := meta.Head; seq < meta.Tail; seq++ {
-			elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: listItemKey(key, seq)})
-		}
-		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: listMetaKey(key)})
+	elems = append(elems, listElems...)
+
+	// Wide-column hash cleanup: delete all !hs|fld| keys, meta, and delta keys.
+	hashElems, err := r.deleteWideColumnElems(ctx, readTS,
+		store.HashFieldScanPrefix(key), store.HashMetaKey(key), store.HashMetaDeltaScanPrefix(key))
+	if err != nil {
+		return nil, false, err
 	}
+	elems = append(elems, hashElems...)
+
+	// Wide-column set cleanup: delete all !st|mem| keys, meta, and delta keys.
+	setElems, err := r.deleteWideColumnElems(ctx, readTS,
+		store.SetMemberScanPrefix(key), store.SetMetaKey(key), store.SetMetaDeltaScanPrefix(key))
+	if err != nil {
+		return nil, false, err
+	}
+	elems = append(elems, setElems...)
 
 	return elems, existed, nil
 }
 
 func (r *RedisServer) listValuesAt(ctx context.Context, key []byte, readTS uint64) ([]string, error) {
-	meta, exists, err := r.loadListMetaAt(ctx, key, readTS)
+	meta, exists, err := r.resolveListMeta(ctx, key, readTS)
 	if err != nil {
 		return nil, err
 	}
@@ -232,12 +437,22 @@ func (r *RedisServer) rewriteListTxn(ctx context.Context, key []byte, readTS uin
 	for _, value := range values {
 		rawValues = append(rawValues, []byte(value))
 	}
-	ops, _, err := r.buildRPushOps(store.ListMeta{}, key, rawValues)
+	commitTS := r.coordinator.Clock().Next()
+	ops, _, err := r.buildRPushOps(store.ListMeta{}, key, rawValues, commitTS, 0)
 	if err != nil {
 		return err
 	}
 	elems = append(elems, ops...)
-	return r.dispatchElems(ctx, true, readTS, elems)
+	if readTS == ^uint64(0) {
+		readTS = 0
+	}
+	_, err = r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+		IsTxn:    true,
+		StartTS:  readTS,
+		CommitTS: commitTS,
+		Elems:    elems,
+	})
+	return errors.WithStack(err)
 }
 
 func (r *RedisServer) visibleKeys(pattern []byte) ([][]byte, error) {
@@ -296,4 +511,152 @@ func minRedisInt(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// aggregateLenDeltas scans delta keys under prefix and sums the LenDelta values
+// via unmarshalDelta. Returns (sum, hasDeltas, error).
+// ErrDeltaScanTruncated is returned when the scan hits MaxDeltaScanLimit.
+func (r *RedisServer) aggregateLenDeltas(ctx context.Context, prefix []byte, readTS uint64, unmarshalDelta func([]byte) (int64, error)) (int64, bool, error) {
+	end := store.PrefixScanEnd(prefix)
+	deltas, err := r.store.ScanAt(ctx, prefix, end, store.MaxDeltaScanLimit, readTS)
+	if err != nil {
+		return 0, false, errors.WithStack(err)
+	}
+	if len(deltas) == store.MaxDeltaScanLimit {
+		return 0, false, ErrDeltaScanTruncated
+	}
+	var sum int64
+	for _, d := range deltas {
+		delta, err := unmarshalDelta(d.Value)
+		if err != nil {
+			return 0, false, errors.WithStack(err)
+		}
+		sum += delta
+	}
+	return sum, len(deltas) > 0, nil
+}
+
+// resolveListMeta aggregates the base list metadata with all uncompacted Delta keys
+// visible at readTS. Returns ErrDeltaScanTruncated if > MaxDeltaScanLimit deltas exist.
+func (r *RedisServer) resolveListMeta(ctx context.Context, key []byte, readTS uint64) (store.ListMeta, bool, error) {
+	// 1. Read base metadata.
+	baseMeta, exists, err := r.loadListMetaAt(ctx, key, readTS)
+	if err != nil {
+		return store.ListMeta{}, false, err
+	}
+
+	// 2. Scan and aggregate delta keys.
+	// The closure also captures baseMeta to accumulate the list-specific HeadDelta.
+	prefix := store.ListMetaDeltaScanPrefix(key)
+	lenSum, hasDeltas, err := r.aggregateLenDeltas(ctx, prefix, readTS, func(b []byte) (int64, error) {
+		d, unmarshalErr := store.UnmarshalListMetaDelta(b)
+		baseMeta.Head += d.HeadDelta
+		return d.LenDelta, errors.WithStack(unmarshalErr)
+	})
+	if err != nil {
+		return store.ListMeta{}, false, err
+	}
+	baseMeta.Len += lenSum
+
+	if baseMeta.Len < 0 {
+		slog.Warn("resolveListMeta: clamping negative Len to 0", "key", string(key), "len", baseMeta.Len)
+		baseMeta.Len = 0
+	}
+	baseMeta.Tail = baseMeta.Head + baseMeta.Len
+	return baseMeta, exists || hasDeltas, nil
+}
+
+// resolveCollectionLen reads the base meta key, then aggregates all delta keys
+// into the final length. It is used by resolveHashMeta, resolveSetMeta, and
+// resolveZSetMeta which all follow the same pattern.
+func (r *RedisServer) resolveCollectionLen(
+	ctx context.Context,
+	key []byte,
+	readTS uint64,
+	metaKey []byte,
+	deltaPrefix []byte,
+	unmarshalBase func([]byte) (int64, error),
+	unmarshalDelta func([]byte) (int64, error),
+	clampMsg string,
+) (int64, bool, error) {
+	raw, err := r.store.GetAt(ctx, metaKey, readTS)
+	var baseLen int64
+	exists := true
+	if err != nil {
+		if !errors.Is(err, store.ErrKeyNotFound) {
+			return 0, false, errors.WithStack(err)
+		}
+		exists = false
+	} else {
+		baseLen, err = unmarshalBase(raw)
+		if err != nil {
+			return 0, false, errors.WithStack(err)
+		}
+	}
+
+	deltaSum, hasDeltas, err := r.aggregateLenDeltas(ctx, deltaPrefix, readTS, unmarshalDelta)
+	if err != nil {
+		return 0, false, err
+	}
+
+	length := baseLen + deltaSum
+	if length < 0 {
+		slog.Warn(clampMsg, "key", string(key), "len", length)
+		length = 0
+	}
+	return length, exists || hasDeltas, nil
+}
+
+// resolveHashMeta aggregates the base hash metadata with all uncompacted Delta keys.
+func (r *RedisServer) resolveHashMeta(ctx context.Context, key []byte, readTS uint64) (int64, bool, error) {
+	return r.resolveCollectionLen(
+		ctx, key, readTS,
+		store.HashMetaKey(key),
+		store.HashMetaDeltaScanPrefix(key),
+		func(b []byte) (int64, error) {
+			m, err := store.UnmarshalHashMeta(b)
+			return m.Len, errors.WithStack(err)
+		},
+		func(b []byte) (int64, error) {
+			d, err := store.UnmarshalHashMetaDelta(b)
+			return d.LenDelta, errors.WithStack(err)
+		},
+		"resolveHashMeta: clamping negative Len to 0",
+	)
+}
+
+// resolveSetMeta aggregates the base set metadata with all uncompacted Delta keys.
+func (r *RedisServer) resolveSetMeta(ctx context.Context, key []byte, readTS uint64) (int64, bool, error) {
+	return r.resolveCollectionLen(
+		ctx, key, readTS,
+		store.SetMetaKey(key),
+		store.SetMetaDeltaScanPrefix(key),
+		func(b []byte) (int64, error) {
+			m, err := store.UnmarshalSetMeta(b)
+			return m.Len, errors.WithStack(err)
+		},
+		func(b []byte) (int64, error) {
+			d, err := store.UnmarshalSetMetaDelta(b)
+			return d.LenDelta, errors.WithStack(err)
+		},
+		"resolveSetMeta: clamping negative Len to 0",
+	)
+}
+
+// resolveZSetMeta aggregates the base sorted set metadata with all uncompacted Delta keys.
+func (r *RedisServer) resolveZSetMeta(ctx context.Context, key []byte, readTS uint64) (int64, bool, error) {
+	return r.resolveCollectionLen(
+		ctx, key, readTS,
+		store.ZSetMetaKey(key),
+		store.ZSetMetaDeltaScanPrefix(key),
+		func(b []byte) (int64, error) {
+			m, err := store.UnmarshalZSetMeta(b)
+			return m.Len, errors.WithStack(err)
+		},
+		func(b []byte) (int64, error) {
+			d, err := store.UnmarshalZSetMetaDelta(b)
+			return d.LenDelta, errors.WithStack(err)
+		},
+		"resolveZSetMeta: clamping negative Len to 0",
+	)
 }

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -344,6 +344,9 @@ func (r *RedisServer) deleteListElems(ctx context.Context, key []byte, readTS ui
 	if scanErr != nil {
 		return nil, errors.WithStack(scanErr)
 	}
+	if len(deltaKVs) == store.MaxDeltaScanLimit {
+		return nil, errors.WithStack(ErrDeltaScanTruncated)
+	}
 	for _, pair := range deltaKVs {
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
 	}
@@ -374,6 +377,9 @@ func (r *RedisServer) deleteWideColumnElems(ctx context.Context, readTS uint64, 
 	deltaKVs, scanErr := r.store.ScanAt(ctx, deltaPrefix, deltaEnd, store.MaxDeltaScanLimit, readTS)
 	if scanErr != nil {
 		return nil, errors.WithStack(scanErr)
+	}
+	if len(deltaKVs) == store.MaxDeltaScanLimit {
+		return nil, errors.WithStack(ErrDeltaScanTruncated)
 	}
 	for _, pair := range deltaKVs {
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -18,6 +18,10 @@ import (
 // to prevent unbounded memory growth (OOM).
 const maxWideColumnItems = 100_000
 
+// scanCursorAdvance is appended to the last key of a scan page to advance the
+// cursor past it for the next page fetch.
+const scanCursorAdvance = byte(0x00)
+
 // maxWideScanLimit is passed to ScanAt when loading an entire collection.
 // It is set to maxWideColumnItems+1 so that receiving exactly limit results
 // indicates the collection is over the cap and the caller can return an error
@@ -335,6 +339,29 @@ func (r *RedisServer) saveString(ctx context.Context, key []byte, value []byte, 
 	return r.dispatchElems(ctx, false, 0, elems)
 }
 
+// scanAllDeltaKeys scans every delta key under deltaPrefix using paginated
+// reads, returning the complete set. Unlike a single bounded ScanAt, it never
+// truncates — deletion must be complete to avoid orphaned delta keys.
+// Each page is bounded by MaxDeltaScanLimit; delta keys are key-only (no
+// large values), so total memory is proportional to key count × key size.
+func (r *RedisServer) scanAllDeltaKeys(ctx context.Context, deltaPrefix []byte, readTS uint64) ([]*store.KVPair, error) {
+	cursor := deltaPrefix
+	end := store.PrefixScanEnd(deltaPrefix)
+	var all []*store.KVPair
+	for {
+		page, err := r.store.ScanAt(ctx, cursor, end, store.MaxDeltaScanLimit, readTS)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		all = append(all, page...)
+		if len(page) < store.MaxDeltaScanLimit {
+			break
+		}
+		cursor = append(bytes.Clone(page[len(page)-1].Key), scanCursorAdvance)
+	}
+	return all, nil
+}
+
 // deleteListElems returns delete operations for all list keys (items, meta, deltas).
 func (r *RedisServer) deleteListElems(ctx context.Context, key []byte, readTS uint64) ([]*kv.Elem[kv.OP], error) {
 	meta, listExists, err := r.resolveListMeta(ctx, key, readTS)
@@ -352,14 +379,9 @@ func (r *RedisServer) deleteListElems(ctx context.Context, key []byte, readTS ui
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: listItemKey(key, seq)})
 	}
 	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: listMetaKey(key)})
-	deltaPrefix := store.ListMetaDeltaScanPrefix(key)
-	deltaEnd := store.PrefixScanEnd(deltaPrefix)
-	deltaKVs, scanErr := r.store.ScanAt(ctx, deltaPrefix, deltaEnd, store.MaxDeltaScanLimit, readTS)
+	deltaKVs, scanErr := r.scanAllDeltaKeys(ctx, store.ListMetaDeltaScanPrefix(key), readTS)
 	if scanErr != nil {
-		return nil, errors.WithStack(scanErr)
-	}
-	if len(deltaKVs) == store.MaxDeltaScanLimit {
-		return nil, errors.WithStack(ErrDeltaScanTruncated)
+		return nil, scanErr
 	}
 	for _, pair := range deltaKVs {
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
@@ -388,13 +410,9 @@ func (r *RedisServer) deleteWideColumnElems(ctx context.Context, readTS uint64, 
 	// key and uncompacted delta keys (e.g. after all members were removed via
 	// HDEL/SREM). Skipping these would leak internal state.
 	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: metaKey})
-	deltaEnd := store.PrefixScanEnd(deltaPrefix)
-	deltaKVs, scanErr := r.store.ScanAt(ctx, deltaPrefix, deltaEnd, store.MaxDeltaScanLimit, readTS)
+	deltaKVs, scanErr := r.scanAllDeltaKeys(ctx, deltaPrefix, readTS)
 	if scanErr != nil {
-		return nil, errors.WithStack(scanErr)
-	}
-	if len(deltaKVs) == store.MaxDeltaScanLimit {
-		return nil, errors.WithStack(ErrDeltaScanTruncated)
+		return nil, scanErr
 	}
 	for _, pair := range deltaKVs {
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})

--- a/adapter/redis_compat_types.go
+++ b/adapter/redis_compat_types.go
@@ -135,6 +135,8 @@ var knownInternalPrefixes = [][]byte{
 	[]byte("!s3|"),
 	[]byte("!dist|"),
 	[]byte("!zs|"),
+	[]byte("!hs|"),
+	[]byte("!st|"),
 }
 
 func isKnownInternalKey(key []byte) bool {

--- a/adapter/redis_lua.go
+++ b/adapter/redis_lua.go
@@ -922,18 +922,52 @@ func (r *RedisServer) lset(conn redcon.Conn, cmd redcon.Command) {
 	r.execLuaCompat(conn, cmdLSet, cmd.Args[1:])
 }
 
-func (r *RedisServer) scard(conn redcon.Conn, cmd redcon.Command) {
+// collectionCardinal handles SCARD/ZCARD: checks type, uses the delta-aggregated
+// metadata for wide-column collections (O(1)), and falls back to the Lua
+// compatibility path for legacy blob-encoded collections.
+func (r *RedisServer) collectionCardinal(
+	conn redcon.Conn,
+	cmd redcon.Command,
+	expectedType redisValueType,
+	resolveMeta func(context.Context, []byte, uint64) (int64, bool, error),
+	legacyCmd string,
+) {
 	if r.proxyToLeader(conn, cmd, cmd.Args[1]) {
 		return
 	}
-	r.execLuaCompat(conn, cmdSCard, cmd.Args[1:])
+	readTS := r.readTS()
+	typ, err := r.keyTypeAt(context.Background(), cmd.Args[1], readTS)
+	if err != nil {
+		conn.WriteError(err.Error())
+		return
+	}
+	if typ == redisTypeNone {
+		conn.WriteInt(0)
+		return
+	}
+	if typ != expectedType {
+		conn.WriteError(wrongTypeMessage)
+		return
+	}
+	count, exists, err := resolveMeta(context.Background(), cmd.Args[1], readTS)
+	if err != nil {
+		conn.WriteError(err.Error())
+		return
+	}
+	if exists {
+		conn.WriteInt64(count)
+		return
+	}
+	// Legacy blob fallback.
+	r.execLuaCompat(conn, legacyCmd, cmd.Args[1:])
+}
+
+func (r *RedisServer) scard(conn redcon.Conn, cmd redcon.Command) {
+	r.collectionCardinal(conn, cmd, redisTypeSet, r.resolveSetMeta, cmdSCard)
 }
 
 func (r *RedisServer) zcard(conn redcon.Conn, cmd redcon.Command) {
-	if r.proxyToLeader(conn, cmd, cmd.Args[1]) {
-		return
-	}
-	r.execLuaCompat(conn, cmdZCard, cmd.Args[1:])
+	r.collectionCardinal(conn, cmd, redisTypeZSet, r.resolveZSetMeta, cmdZCard)
 }
 
 func (r *RedisServer) zcount(conn redcon.Conn, cmd redcon.Command) {

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -466,7 +466,7 @@ func (c *luaScriptContext) listState(key []byte) (*luaListState, error) {
 		return nil, wrongTypeError()
 	}
 
-	meta, exists, err := c.server.loadListMetaAt(context.Background(), key, c.startTS)
+	meta, exists, err := c.server.resolveListMeta(context.Background(), key, c.startTS)
 	if err != nil {
 		return nil, err
 	}
@@ -2431,10 +2431,13 @@ func (c *luaScriptContext) commit() error {
 	}
 	sort.Strings(keys)
 
+	// Pre-allocate a commitTS so Delta key bytes can embed it before dispatch.
+	commitTS := c.server.coordinator.Clock().Next()
+
 	elems := make([]*kv.Elem[kv.OP], 0, len(keys)*redisPairWidth)
 	ctx := context.Background()
 	for _, key := range keys {
-		keyElems, err := c.commitElemsForKey(ctx, key)
+		keyElems, err := c.commitElemsForKey(ctx, key, commitTS)
 		if err != nil {
 			return err
 		}
@@ -2446,16 +2449,26 @@ func (c *luaScriptContext) commit() error {
 	}
 	dispatchCtx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
 	defer cancel()
-	return c.server.dispatchElems(dispatchCtx, true, c.startTS, elems)
+	startTS := c.startTS
+	if startTS == ^uint64(0) {
+		startTS = 0
+	}
+	_, err := c.server.coordinator.Dispatch(dispatchCtx, &kv.OperationGroup[kv.OP]{
+		IsTxn:    true,
+		StartTS:  startTS,
+		CommitTS: commitTS,
+		Elems:    elems,
+	})
+	return errors.WithStack(err)
 }
 
-func (c *luaScriptContext) commitElemsForKey(ctx context.Context, key string) ([]*kv.Elem[kv.OP], error) {
+func (c *luaScriptContext) commitElemsForKey(ctx context.Context, key string, commitTS uint64) ([]*kv.Elem[kv.OP], error) {
 	finalType, err := c.finalType([]byte(key))
 	if err != nil {
 		return nil, err
 	}
 
-	valuePlan, err := c.valueCommitPlan(key, finalType)
+	valuePlan, err := c.valueCommitPlan(key, finalType, commitTS)
 	if err != nil {
 		return nil, err
 	}
@@ -2479,7 +2492,7 @@ func (c *luaScriptContext) commitElemsForKey(ctx context.Context, key string) ([
 	return elems, nil
 }
 
-func (c *luaScriptContext) valueCommitPlan(key string, finalType redisValueType) (luaCommitPlan, error) {
+func (c *luaScriptContext) valueCommitPlan(key string, finalType redisValueType, commitTS uint64) (luaCommitPlan, error) {
 	switch finalType {
 	case redisTypeNone:
 		return luaCommitPlan{}, nil
@@ -2487,7 +2500,7 @@ func (c *luaScriptContext) valueCommitPlan(key string, finalType redisValueType)
 		elems, err := c.stringCommitElems(key)
 		return luaCommitPlan{elems: elems}, err
 	case redisTypeList:
-		return c.listCommitPlan(key)
+		return c.listCommitPlan(key, commitTS)
 	case redisTypeHash:
 		elems, err := c.hashCommitElems(key)
 		return luaCommitPlan{elems: elems}, err
@@ -2513,13 +2526,13 @@ func (c *luaScriptContext) stringCommitElems(key string) ([]*kv.Elem[kv.OP], err
 	return []*kv.Elem[kv.OP]{{Op: kv.Put, Key: redisStrKey([]byte(key)), Value: append([]byte(nil), st.value...)}}, nil
 }
 
-func (c *luaScriptContext) listCommitPlan(key string) (luaCommitPlan, error) {
+func (c *luaScriptContext) listCommitPlan(key string, commitTS uint64) (luaCommitPlan, error) {
 	st := c.lists[key]
 	if st == nil || !st.dirty {
 		return luaCommitPlan{preserveExisting: true}, nil
 	}
 	if st.materialized {
-		elems, err := c.listCommitElems(key)
+		elems, err := c.listCommitElems(key, commitTS)
 		return luaCommitPlan{elems: elems}, err
 	}
 	// If the key was deleted earlier in this script and later recreated as a
@@ -2527,14 +2540,14 @@ func (c *luaScriptContext) listCommitPlan(key string) (luaCommitPlan, error) {
 	// deleteLogicalKeyElems is called and any orphaned storage items from the
 	// previous incarnation of the key are cleaned up before writing the delta.
 	if c.everDeleted[key] {
-		elems, err := c.listCommitElems(key)
+		elems, err := c.listCommitElems(key, commitTS)
 		return luaCommitPlan{elems: elems}, err
 	}
-	elems, err := c.listDeltaCommitElems(key, st)
+	elems, err := c.listDeltaCommitElems(key, st, commitTS)
 	return luaCommitPlan{preserveExisting: true, elems: elems}, err
 }
 
-func (c *luaScriptContext) listCommitElems(key string) ([]*kv.Elem[kv.OP], error) {
+func (c *luaScriptContext) listCommitElems(key string, commitTS uint64) ([]*kv.Elem[kv.OP], error) {
 	st, err := c.listState([]byte(key))
 	if err != nil {
 		return nil, err
@@ -2547,14 +2560,14 @@ func (c *luaScriptContext) listCommitElems(key string) ([]*kv.Elem[kv.OP], error
 		values = append(values, []byte(value))
 	}
 
-	listElems, _, err := c.server.buildRPushOps(store.ListMeta{}, []byte(key), values)
+	listElems, _, err := c.server.buildRPushOps(store.ListMeta{}, []byte(key), values, commitTS, 0)
 	if err != nil {
 		return nil, err
 	}
 	return listElems, nil
 }
 
-func (c *luaScriptContext) listDeltaCommitElems(key string, st *luaListState) ([]*kv.Elem[kv.OP], error) {
+func (c *luaScriptContext) listDeltaCommitElems(key string, st *luaListState, commitTS uint64) ([]*kv.Elem[kv.OP], error) {
 	if !st.exists || st.currentLen() == 0 {
 		return nil, nil
 	}
@@ -2563,21 +2576,38 @@ func (c *luaScriptContext) listDeltaCommitElems(key string, st *luaListState) ([
 	if err != nil {
 		return nil, err
 	}
-	newMeta := store.ListMeta{
-		Head: newHead,
-		Len:  st.currentLen(),
-		Tail: newHead + st.currentLen(),
-	}
-	metaBytes, err := store.MarshalListMeta(newMeta)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
 
-	elems := make([]*kv.Elem[kv.OP], 0, int(st.leftTrim+st.rightTrim)+len(st.leftValues)+len(st.rightValues)+1)
+	elems := make([]*kv.Elem[kv.OP], 0, int(st.leftTrim+st.rightTrim)+len(st.leftValues)+len(st.rightValues)+setWideColOverhead)
 	elems = appendListTrimDeletes(elems, []byte(key), st)
 	elems = appendListPuts(elems, []byte(key), st.leftValues, newHead)
 	elems = appendListPuts(elems, []byte(key), st.rightValues, rightStart)
-	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: listMetaKey([]byte(key)), Value: metaBytes})
+
+	// Emit Delta keys for any appended values and trims instead of writing base meta.
+	// Trims are counted separately as negative deltas.
+	var seqInTxn uint32
+	if len(st.rightValues) > 0 {
+		rightDelta := store.MarshalListMetaDelta(store.ListMetaDelta{
+			HeadDelta: 0,
+			LenDelta:  int64(len(st.rightValues)) - st.rightTrim,
+		})
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.ListMetaDeltaKey([]byte(key), commitTS, seqInTxn),
+			Value: rightDelta,
+		})
+		seqInTxn++
+	}
+	if len(st.leftValues) > 0 || st.leftTrim > 0 {
+		leftDelta := store.MarshalListMetaDelta(store.ListMetaDelta{
+			HeadDelta: -int64(len(st.leftValues)) + st.leftTrim,
+			LenDelta:  int64(len(st.leftValues)) - st.leftTrim,
+		})
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.ListMetaDeltaKey([]byte(key), commitTS, seqInTxn),
+			Value: leftDelta,
+		})
+	}
 	return elems, nil
 }
 
@@ -2620,11 +2650,26 @@ func (c *luaScriptContext) hashCommitElems(key string) ([]*kv.Elem[kv.OP], error
 	if err != nil {
 		return nil, err
 	}
-	payload, err := marshalHashValue(st.value)
-	if err != nil {
-		return nil, err
+	if len(st.value) == 0 {
+		// Deletion is handled by deleteLogicalKeyElems called before this.
+		return nil, nil
 	}
-	return []*kv.Elem[kv.OP]{{Op: kv.Put, Key: redisHashKey([]byte(key)), Value: payload}}, nil
+	// Wide-column: write per-field keys and a base meta key with the final count.
+	// deleteLogicalKeyElems (called by the Lua commit flow) clears any old keys.
+	elems := make([]*kv.Elem[kv.OP], 0, len(st.value)+1)
+	for field, val := range st.value {
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.HashFieldKey([]byte(key), []byte(field)),
+			Value: []byte(val),
+		})
+	}
+	elems = append(elems, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   store.HashMetaKey([]byte(key)),
+		Value: store.MarshalHashMeta(store.HashMeta{Len: int64(len(st.value))}),
+	})
+	return elems, nil
 }
 
 func (c *luaScriptContext) setCommitElems(key string) ([]*kv.Elem[kv.OP], error) {
@@ -2632,11 +2677,25 @@ func (c *luaScriptContext) setCommitElems(key string) ([]*kv.Elem[kv.OP], error)
 	if err != nil {
 		return nil, err
 	}
-	payload, err := marshalSetValue(redisSetValue{Members: sortedSetMembers(st.members)})
-	if err != nil {
-		return nil, err
+	if len(st.members) == 0 {
+		// Deletion is handled by deleteLogicalKeyElems called before this.
+		return nil, nil
 	}
-	return []*kv.Elem[kv.OP]{{Op: kv.Put, Key: redisSetKey([]byte(key)), Value: payload}}, nil
+	// Wide-column: write per-member keys and a base meta key with the final count.
+	elems := make([]*kv.Elem[kv.OP], 0, len(st.members)+1)
+	for member := range st.members {
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.SetMemberKey([]byte(key), []byte(member)),
+			Value: []byte{},
+		})
+	}
+	elems = append(elems, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   store.SetMetaKey([]byte(key)),
+		Value: store.MarshalSetMeta(store.SetMeta{Len: int64(len(st.members))}),
+	})
+	return elems, nil
 }
 
 func (c *luaScriptContext) zsetCommitElems(key string) ([]*kv.Elem[kv.OP], error) {

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -2431,7 +2431,11 @@ func (c *luaScriptContext) commit() error {
 	}
 	sort.Strings(keys)
 
-	// Pre-allocate a commitTS so Delta key bytes can embed it before dispatch.
+	// Pre-allocate startTS and commitTS so the commitTS can be embedded in
+	// Delta key bytes before dispatch, and the coordinator will not clear it.
+	// ensureValidStartTS guarantees startTS > 0 so the coordinator keeps the
+	// caller-provided commitTS instead of assigning a new one.
+	startTS := ensureValidStartTS(c.startTS, c.server.coordinator.Clock())
 	commitTS := c.server.coordinator.Clock().Next()
 
 	elems := make([]*kv.Elem[kv.OP], 0, len(keys)*redisPairWidth)
@@ -2449,10 +2453,6 @@ func (c *luaScriptContext) commit() error {
 	}
 	dispatchCtx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
 	defer cancel()
-	startTS := c.startTS
-	if startTS == ^uint64(0) {
-		startTS = 0
-	}
 	_, err := c.server.coordinator.Dispatch(dispatchCtx, &kv.OperationGroup[kv.OP]{
 		IsTxn:    true,
 		StartTS:  startTS,

--- a/adapter/redis_multi_test.go
+++ b/adapter/redis_multi_test.go
@@ -195,11 +195,14 @@ func TestRedis_MultiExec_DelThenRPushRecreatesList(t *testing.T) {
 	require.Equal(t, []any{"new1", "new2"}, rangeRes)
 
 	readTS := nodes[1].redisServer.readTS()
-	metaRaw, err := nodes[1].redisServer.store.GetAt(ctx, store.ListMetaKey([]byte("list-del-rpush")), readTS)
+
+	// With the Delta pattern, RPUSH inside a MULTI/EXEC emits a delta key
+	// rather than updating the base metadata key directly.  Verify the
+	// effective metadata via resolveListMeta which aggregates deltas.
+	resolvedMeta, resolvedExists, err := nodes[1].redisServer.resolveListMeta(ctx, []byte("list-del-rpush"), readTS)
 	require.NoError(t, err)
-	meta, err := store.UnmarshalListMeta(metaRaw)
-	require.NoError(t, err)
-	require.Equal(t, int64(2), meta.Len)
+	require.True(t, resolvedExists)
+	require.Equal(t, int64(2), resolvedMeta.Len)
 
 	kvs, err := nodes[1].redisServer.store.ScanAt(
 		ctx,

--- a/adapter/redis_retry.go
+++ b/adapter/redis_retry.go
@@ -130,6 +130,12 @@ func normalizeRetryableRedisTxnErr(err error) error {
 // Delta prefixes are checked before meta prefixes because delta keys share the
 // meta prefix as a leading substring.
 func normalizeWideColumnKey(key []byte) ([]byte, bool) {
+	if store.IsListMetaDeltaKey(key) {
+		return store.ExtractListUserKeyFromDelta(key), true
+	}
+	if store.IsListClaimKey(key) {
+		return store.ExtractListUserKeyFromClaim(key), true
+	}
 	if store.IsHashMetaDeltaKey(key) {
 		return store.ExtractHashUserKeyFromDelta(key), true
 	}

--- a/adapter/redis_retry.go
+++ b/adapter/redis_retry.go
@@ -124,12 +124,42 @@ func normalizeRetryableRedisTxnErr(err error) error {
 	return err
 }
 
+// normalizeWideColumnKey extracts the logical user key from any wide-column
+// internal key (hash/set meta, delta, or field/member). Returns (key, true) when
+// the input is a recognised wide-column key, (nil, false) otherwise.
+// Delta prefixes are checked before meta prefixes because delta keys share the
+// meta prefix as a leading substring.
+func normalizeWideColumnKey(key []byte) ([]byte, bool) {
+	if store.IsHashMetaDeltaKey(key) {
+		return store.ExtractHashUserKeyFromDelta(key), true
+	}
+	if store.IsHashMetaKey(key) {
+		return store.ExtractHashUserKeyFromMeta(key), true
+	}
+	if store.IsHashFieldKey(key) {
+		return store.ExtractHashUserKeyFromField(key), true
+	}
+	if store.IsSetMetaDeltaKey(key) {
+		return store.ExtractSetUserKeyFromDelta(key), true
+	}
+	if store.IsSetMetaKey(key) {
+		return store.ExtractSetUserKeyFromMeta(key), true
+	}
+	if store.IsSetMemberKey(key) {
+		return store.ExtractSetUserKeyFromMember(key), true
+	}
+	return nil, false
+}
+
 func normalizeRetryableRedisTxnKey(key []byte) []byte {
 	if userKey := kv.ExtractTxnUserKey(key); userKey != nil {
 		key = userKey
 	}
 	if store.IsListMetaKey(key) || store.IsListItemKey(key) {
 		return store.ExtractListUserKey(key)
+	}
+	if wideKey, ok := normalizeWideColumnKey(key); ok {
+		return wideKey
 	}
 	if bytes.HasPrefix(key, []byte(redisTTLPrefix)) {
 		return bytes.TrimPrefix(key, []byte(redisTTLPrefix))

--- a/adapter/redis_storage_migration_test.go
+++ b/adapter/redis_storage_migration_test.go
@@ -64,12 +64,21 @@ func TestRedisHashLegacyJSONReadThenRewriteToProto(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, added)
 
-	rawAfterWrite := mustReadRawValue(t, st, storageKey)
-	require.True(t, hasStoredRedisPrefix(rawAfterWrite, storedRedisHashProtoPrefix))
+	// After migration-on-write the legacy blob is deleted; wide-column field keys are used instead.
+	readTS := server.readTS()
+	_, err = st.GetAt(context.Background(), storageKey, readTS)
+	require.ErrorIs(t, err, store.ErrKeyNotFound, "legacy blob should be deleted after wide-column migration")
 
-	decoded, err := unmarshalHashValue(rawAfterWrite)
+	// loadHashAt should aggregate all wide-column fields including the migrated one.
+	got, err := server.loadHashAt(context.Background(), key, readTS)
 	require.NoError(t, err)
-	require.Equal(t, redisHashValue{"field": "old", "next": "new"}, decoded)
+	require.Equal(t, redisHashValue{"field": "old", "next": "new"}, got)
+
+	// Each field key must be present in the store.
+	for _, field := range []string{"field", "next"} {
+		_, err = st.GetAt(context.Background(), store.HashFieldKey(key, []byte(field)), readTS)
+		require.NoError(t, err, "field key %q should exist after migration", field)
+	}
 }
 
 func TestRedisSetLegacyJSONReadThenRewriteToProto(t *testing.T) {
@@ -95,12 +104,21 @@ func TestRedisSetLegacyJSONReadThenRewriteToProto(t *testing.T) {
 	require.Empty(t, conn.err)
 	require.Equal(t, int64(1), conn.int)
 
-	rawAfterWrite := mustReadRawValue(t, st, storageKey)
-	require.True(t, hasStoredRedisPrefix(rawAfterWrite, storedRedisSetProtoPrefix))
+	// After migration-on-write the legacy blob is deleted; wide-column member keys are used instead.
+	readTS := server.readTS()
+	_, err = st.GetAt(context.Background(), storageKey, readTS)
+	require.ErrorIs(t, err, store.ErrKeyNotFound, "legacy blob should be deleted after wide-column migration")
 
-	decoded, err := unmarshalSetValue(rawAfterWrite)
+	// loadSetAt should aggregate all wide-column members including the migrated ones.
+	got, err := server.loadSetAt(context.Background(), "set", key, readTS)
 	require.NoError(t, err)
-	require.Equal(t, redisSetValue{Members: []string{"a", "b", "c"}}, decoded)
+	require.Equal(t, redisSetValue{Members: []string{"a", "b", "c"}}, got)
+
+	// Each member key must be present in the store.
+	for _, member := range []string{"a", "b", "c"} {
+		_, err = st.GetAt(context.Background(), store.SetMemberKey(key, []byte(member)), readTS)
+		require.NoError(t, err, "member key %q should exist after migration", member)
+	}
 }
 
 func TestRedisHLLLegacyJSONReadThenRewriteToProto(t *testing.T) {

--- a/adapter/redis_txn_test.go
+++ b/adapter/redis_txn_test.go
@@ -9,7 +9,11 @@ import (
 	"github.com/tidwall/redcon"
 )
 
-func TestRedisTxnValidateReadSetDetectsStaleListMeta(t *testing.T) {
+// TestRedisTxnValidateReadSet_ListMetaUpdateNoConflict verifies that updating
+// the base list metadata key (e.g. by a DeltaCompactor) does NOT trigger an
+// OCC conflict for append operations.  With the Delta pattern, appenders never
+// read-modify-write the base meta key, so compaction is invisible to them.
+func TestRedisTxnValidateReadSet_ListMetaUpdateNoConflict(t *testing.T) {
 	t.Parallel()
 
 	server, st := newRedisStorageMigrationTestServer(t)
@@ -32,9 +36,45 @@ func TestRedisTxnValidateReadSetDetectsStaleListMeta(t *testing.T) {
 	_, err = txn.loadListState(key)
 	require.NoError(t, err)
 
+	// Simulate a DeltaCompactor updating the base meta after our read.
 	metaV2, err := store.MarshalListMeta(store.ListMeta{Len: 2})
 	require.NoError(t, err)
 	require.NoError(t, st.PutAt(context.Background(), store.ListMetaKey(key), metaV2, 11, 0))
+
+	// With the Delta pattern the base meta key is NOT in the OCC read set,
+	// so the compaction write must NOT surface as a write conflict.
+	err = txn.validateReadSet(context.Background())
+	require.NoError(t, err)
+}
+
+// TestRedisTxnValidateReadSet_TTLUpdateConflict verifies that updating the TTL
+// key for a list DOES trigger an OCC conflict, because TTL reads are still
+// tracked in the read set.
+func TestRedisTxnValidateReadSet_TTLUpdateConflict(t *testing.T) {
+	t.Parallel()
+
+	server, st := newRedisStorageMigrationTestServer(t)
+	key := []byte("list:ttl-conflict")
+
+	metaBytes, err := store.MarshalListMeta(store.ListMeta{Len: 1})
+	require.NoError(t, err)
+	require.NoError(t, st.PutAt(context.Background(), store.ListMetaKey(key), metaBytes, 10, 0))
+
+	txn := &txnContext{
+		server:     server,
+		working:    map[string]*txnValue{},
+		listStates: map[string]*listTxnState{},
+		zsetStates: map[string]*zsetTxnState{},
+		ttlStates:  map[string]*ttlTxnState{},
+		readKeys:   map[string][]byte{},
+		startTS:    10,
+	}
+
+	_, err = txn.loadListState(key)
+	require.NoError(t, err)
+
+	// A concurrent EXPIRE updates the TTL key after our read.
+	require.NoError(t, st.PutAt(context.Background(), redisTTLKey(key), []byte("dummy"), 11, 0))
 
 	err = txn.validateReadSet(context.Background())
 	require.Error(t, err)

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -240,47 +240,9 @@ const maxReadKeys = 10_000
 
 var ErrLeaderNotFound = errors.New("leader not found")
 
-func (c *Coordinate) redirect(ctx context.Context, reqs *OperationGroup[OP]) (*CoordinateResponse, error) {
-	if len(reqs.Elems) == 0 {
-		return nil, ErrInvalidRequest
-	}
-
-	addr := leaderAddrFromEngine(c.engine)
-	if addr == "" {
-		return nil, errors.WithStack(ErrLeaderNotFound)
-	}
-
-	conn, err := c.connCache.ConnFor(addr)
-	if err != nil {
-		return nil, err
-	}
-
-	cli := pb.NewInternalClient(conn)
-
-	requests, err := c.buildRedirectRequests(reqs)
-	if err != nil {
-		return nil, err
-	}
-
-	fwdCtx, cancel := context.WithTimeout(ctx, redirectForwardTimeout)
-	defer cancel()
-	r, err := cli.Forward(fwdCtx, c.toForwardRequest(requests))
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	if !r.Success {
-		return nil, ErrInvalidRequest
-	}
-
-	return &CoordinateResponse{
-		CommitIndex: r.CommitIndex,
-	}, nil
-}
-
 func (c *Coordinate) buildRedirectRequests(reqs *OperationGroup[OP]) ([]*pb.Request, error) {
 	if !reqs.IsTxn {
-		requests := make([]*pb.Request, 0, len(reqs.Elems))
+		var requests []*pb.Request
 		for _, req := range reqs.Elems {
 			requests = append(requests, c.toRawRequest(req))
 		}
@@ -303,6 +265,43 @@ func (c *Coordinate) buildRedirectRequests(reqs *OperationGroup[OP]) ([]*pb.Requ
 	}
 	return []*pb.Request{
 		onePhaseTxnRequest(reqs.StartTS, commitTS, primary, reqs.Elems, reqs.ReadKeys),
+	}, nil
+}
+
+func (c *Coordinate) redirect(ctx context.Context, reqs *OperationGroup[OP]) (*CoordinateResponse, error) {
+	if len(reqs.Elems) == 0 {
+		return nil, ErrInvalidRequest
+	}
+
+	addr := leaderAddrFromEngine(c.engine)
+	if addr == "" {
+		return nil, errors.WithStack(ErrLeaderNotFound)
+	}
+
+	conn, err := c.connCache.ConnFor(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	requests, err := c.buildRedirectRequests(reqs)
+	if err != nil {
+		return nil, err
+	}
+
+	cli := pb.NewInternalClient(conn)
+	fwdCtx, cancel := context.WithTimeout(ctx, redirectForwardTimeout)
+	defer cancel()
+	r, err := cli.Forward(fwdCtx, c.toForwardRequest(requests))
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	if !r.Success {
+		return nil, ErrInvalidRequest
+	}
+
+	return &CoordinateResponse{
+		CommitIndex: r.CommitIndex,
 	}, nil
 }
 

--- a/kv/leader_routed_store.go
+++ b/kv/leader_routed_store.go
@@ -155,14 +155,21 @@ func (s *LeaderRoutedStore) GetAt(ctx context.Context, key []byte, ts uint64) ([
 }
 
 func (s *LeaderRoutedStore) ExistsAt(ctx context.Context, key []byte, ts uint64) (bool, error) {
-	v, err := s.GetAt(ctx, key, ts)
-	if err != nil {
-		if errors.Is(err, store.ErrKeyNotFound) {
-			return false, nil
-		}
-		return false, err
+	if s == nil || s.local == nil {
+		return false, nil
 	}
-	return v != nil, nil
+	if s.leaderOKForKey(ctx, key) {
+		ok, err := s.local.ExistsAt(ctx, key, ts)
+		return ok, errors.WithStack(err)
+	}
+	// Via proxy path: RawGet returns a nil Value for a key that exists with an
+	// empty value because proto3 strips zero-valued bytes fields on the wire.
+	// Determine existence from the error alone, not from whether Value is non-nil.
+	_, err := s.proxyRawGet(ctx, key, ts)
+	if errors.Is(err, store.ErrKeyNotFound) {
+		return false, nil
+	}
+	return err == nil, errors.WithStack(err)
 }
 
 func (s *LeaderRoutedStore) ScanAt(ctx context.Context, start []byte, end []byte, limit int, ts uint64) ([]*store.KVPair, error) {

--- a/store/hash_helpers.go
+++ b/store/hash_helpers.go
@@ -1,0 +1,189 @@
+//nolint:dupl // Hash and Set helpers are intentionally parallel implementations for distinct types.
+package store
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Hash wide-column key layout:
+//
+//	Base Metadata: !hs|meta|<userKeyLen(4)><userKey>               → [Len(8)]
+//	Field Key:     !hs|fld|<userKeyLen(4)><userKey><fieldName>     → field value bytes
+//	Delta Key:     !hs|meta|d|<userKeyLen(4)><userKey><commitTS(8)><seqInTxn(4)> → [LenDelta(8)]
+const (
+	HashMetaPrefix      = "!hs|meta|"
+	HashFieldPrefix     = "!hs|fld|"
+	HashMetaDeltaPrefix = "!hs|meta|d|"
+
+	// hashMetaSizeBytes is the fixed binary size of a HashMeta or HashMetaDelta (one int64).
+	hashMetaSizeBytes = 8
+)
+
+// HashMeta is the base metadata for a hash collection.
+type HashMeta struct {
+	Len int64
+}
+
+// HashMetaDelta holds a signed change in field count.
+type HashMetaDelta struct {
+	LenDelta int64
+}
+
+// MarshalHashMeta encodes HashMeta into a fixed 8-byte binary format.
+func MarshalHashMeta(m HashMeta) []byte {
+	buf := make([]byte, hashMetaSizeBytes)
+	binary.BigEndian.PutUint64(buf, uint64(m.Len)) //nolint:gosec
+	return buf
+}
+
+// UnmarshalHashMeta decodes HashMeta from the fixed 8-byte binary format.
+func UnmarshalHashMeta(b []byte) (HashMeta, error) {
+	if len(b) != hashMetaSizeBytes {
+		return HashMeta{}, errors.WithStack(errors.Newf("invalid hash meta length: %d", len(b)))
+	}
+	return HashMeta{Len: int64(binary.BigEndian.Uint64(b))}, nil //nolint:gosec
+}
+
+// MarshalHashMetaDelta encodes HashMetaDelta into a fixed 8-byte binary format.
+func MarshalHashMetaDelta(d HashMetaDelta) []byte {
+	buf := make([]byte, hashMetaSizeBytes)
+	binary.BigEndian.PutUint64(buf, uint64(d.LenDelta)) //nolint:gosec
+	return buf
+}
+
+// UnmarshalHashMetaDelta decodes HashMetaDelta from the fixed 8-byte binary format.
+func UnmarshalHashMetaDelta(b []byte) (HashMetaDelta, error) {
+	if len(b) != hashMetaSizeBytes {
+		return HashMetaDelta{}, errors.WithStack(errors.Newf("invalid hash meta delta length: %d", len(b)))
+	}
+	return HashMetaDelta{LenDelta: int64(binary.BigEndian.Uint64(b))}, nil //nolint:gosec
+}
+
+// HashMetaKey builds the metadata key for a hash.
+func HashMetaKey(userKey []byte) []byte {
+	buf := make([]byte, 0, len(HashMetaPrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, HashMetaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// HashFieldKey builds the per-field key for a hash field.
+func HashFieldKey(userKey, fieldName []byte) []byte {
+	buf := make([]byte, 0, len(HashFieldPrefix)+wideColKeyLenSize+len(userKey)+len(fieldName))
+	buf = append(buf, HashFieldPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	buf = append(buf, fieldName...)
+	return buf
+}
+
+// HashFieldScanPrefix returns the prefix to scan all fields of a hash.
+func HashFieldScanPrefix(userKey []byte) []byte {
+	buf := make([]byte, 0, len(HashFieldPrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, HashFieldPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// ExtractHashFieldName extracts the field name from a hash field key.
+func ExtractHashFieldName(key, userKey []byte) []byte {
+	prefix := HashFieldScanPrefix(userKey)
+	if !bytes.HasPrefix(key, prefix) {
+		return nil
+	}
+	return key[len(prefix):]
+}
+
+// HashMetaDeltaKey builds the delta key for a hash metadata change.
+func HashMetaDeltaKey(userKey []byte, commitTS uint64, seqInTxn uint32) []byte {
+	buf := make([]byte, 0, len(HashMetaDeltaPrefix)+wideColKeyLenSize+len(userKey)+deltaKeyTSSize+deltaKeySeqSize)
+	buf = append(buf, HashMetaDeltaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], commitTS)
+	buf = append(buf, ts[:]...)
+	var seq [4]byte
+	binary.BigEndian.PutUint32(seq[:], seqInTxn)
+	buf = append(buf, seq[:]...)
+	return buf
+}
+
+// HashMetaDeltaScanPrefix returns the prefix to scan all delta keys for a hash.
+func HashMetaDeltaScanPrefix(userKey []byte) []byte {
+	buf := make([]byte, 0, len(HashMetaDeltaPrefix)+4+len(userKey))
+	buf = append(buf, HashMetaDeltaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// IsHashMetaKey reports whether the key is a hash metadata key.
+func IsHashMetaKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(HashMetaPrefix))
+}
+
+// IsHashFieldKey reports whether the key is a hash field key.
+func IsHashFieldKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(HashFieldPrefix))
+}
+
+// IsHashMetaDeltaKey reports whether the key is a hash metadata delta key.
+func IsHashMetaDeltaKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(HashMetaDeltaPrefix))
+}
+
+// ExtractHashUserKeyFromMeta extracts the logical user key from a hash meta key.
+func ExtractHashUserKeyFromMeta(key []byte) []byte {
+	trimmed := bytes.TrimPrefix(key, []byte(HashMetaPrefix))
+	if len(trimmed) < wideColKeyLenSize {
+		return nil
+	}
+	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
+	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
+		return nil
+	}
+	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+}
+
+// ExtractHashUserKeyFromField extracts the logical user key from a hash field key.
+func ExtractHashUserKeyFromField(key []byte) []byte {
+	trimmed := bytes.TrimPrefix(key, []byte(HashFieldPrefix))
+	if len(trimmed) < wideColKeyLenSize {
+		return nil
+	}
+	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
+	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
+		return nil
+	}
+	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+}
+
+// ExtractHashUserKeyFromDelta extracts the logical user key from a hash delta key.
+func ExtractHashUserKeyFromDelta(key []byte) []byte {
+	trimmed := bytes.TrimPrefix(key, []byte(HashMetaDeltaPrefix))
+	minLen := wideColKeyLenSize + deltaKeyTSSize + deltaKeySeqSize
+	if len(trimmed) < minLen {
+		return nil
+	}
+	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
+	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen+uint32(deltaKeyTSSize+deltaKeySeqSize) { //nolint:gosec // constants fit in uint32
+		return nil
+	}
+	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+}

--- a/store/hash_helpers.go
+++ b/store/hash_helpers.go
@@ -10,11 +10,15 @@ import (
 
 // Hash wide-column key layout:
 //
-//	Base Metadata: !hs|meta|<userKeyLen(4)><userKey>               → [Len(8)]
-//	Field Key:     !hs|fld|<userKeyLen(4)><userKey><fieldName>     → field value bytes
+//	Base Metadata: !hs|meta|b|<userKeyLen(4)><userKey>               → [Len(8)]
+//	Field Key:     !hs|fld|<userKeyLen(4)><userKey><fieldName>       → field value bytes
 //	Delta Key:     !hs|meta|d|<userKeyLen(4)><userKey><commitTS(8)><seqInTxn(4)> → [LenDelta(8)]
+//
+// Note: the base prefix ("!hs|meta|b|") and delta prefix ("!hs|meta|d|") differ
+// at the trailing discriminator byte ('b' vs 'd') so that IsHashMetaKey and
+// IsHashMetaDeltaKey produce unambiguous results without ordering constraints.
 const (
-	HashMetaPrefix      = "!hs|meta|"
+	HashMetaPrefix      = "!hs|meta|b|"
 	HashFieldPrefix     = "!hs|fld|"
 	HashMetaDeltaPrefix = "!hs|meta|d|"
 

--- a/store/hash_helpers.go
+++ b/store/hash_helpers.go
@@ -159,7 +159,7 @@ func ExtractHashUserKeyFromMeta(key []byte) []byte {
 		return nil
 	}
 	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
+	if ukLen > uint32(len(trimmed)-wideColKeyLenSize) { //nolint:gosec // len check above guarantees non-negative subtraction
 		return nil
 	}
 	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
@@ -172,7 +172,7 @@ func ExtractHashUserKeyFromField(key []byte) []byte {
 		return nil
 	}
 	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
+	if ukLen > uint32(len(trimmed)-wideColKeyLenSize) { //nolint:gosec // len check above guarantees non-negative subtraction
 		return nil
 	}
 	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
@@ -186,7 +186,7 @@ func ExtractHashUserKeyFromDelta(key []byte) []byte {
 		return nil
 	}
 	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen+uint32(deltaKeyTSSize+deltaKeySeqSize) { //nolint:gosec // constants fit in uint32
+	if ukLen > uint32(len(trimmed)-wideColKeyLenSize-deltaKeyTSSize-deltaKeySeqSize) { //nolint:gosec // minLen check above guarantees non-negative subtraction
 		return nil
 	}
 	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]

--- a/store/list_helpers.go
+++ b/store/list_helpers.go
@@ -8,6 +8,167 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// Delta/Claim key constants.
+const (
+	// ListMetaDeltaPrefix is the prefix for all list metadata delta keys.
+	// Layout: !lst|meta|d|<userKeyLen(4)><userKey><commitTS(8)><seqInTxn(4)>
+	ListMetaDeltaPrefix = "!lst|meta|d|"
+
+	// ListClaimPrefix is the prefix for list claim keys used by POP operations.
+	// Layout: !lst|claim|<userKeyLen(4)><userKey><seq(8-byte sortable)>
+	ListClaimPrefix = "!lst|claim|"
+
+	// MaxDeltaScanLimit is the hard limit on delta scan results.
+	// resolveListMeta returns ErrDeltaScanTruncated if this is reached.
+	MaxDeltaScanLimit = 256
+
+	// wideColKeyLenSize is the number of bytes used to encode the user-key
+	// length as a big-endian uint32 in wide-column storage keys.
+	wideColKeyLenSize = 4
+
+	// deltaKeyTSSize is the number of bytes used for the commit-timestamp
+	// field (uint64) in wide-column delta keys.
+	deltaKeyTSSize = 8
+
+	// deltaKeySeqSize is the number of bytes used for the seqInTxn field
+	// (uint32) in wide-column delta keys.
+	deltaKeySeqSize = 4
+
+	// listDeltaSizeBytes is the fixed binary size of a ListMetaDelta (two int64 fields).
+	listDeltaSizeBytes = 16
+)
+
+// ListMetaDelta holds the signed deltas applied by a single PUSH/POP operation.
+type ListMetaDelta struct {
+	HeadDelta int64
+	LenDelta  int64
+}
+
+// MarshalListMetaDelta encodes a ListMetaDelta into a fixed 16-byte binary format.
+func MarshalListMetaDelta(d ListMetaDelta) []byte {
+	buf := make([]byte, listDeltaSizeBytes)
+	binary.BigEndian.PutUint64(buf[0:8], uint64(d.HeadDelta)) //nolint:gosec
+	binary.BigEndian.PutUint64(buf[8:16], uint64(d.LenDelta)) //nolint:gosec
+	return buf
+}
+
+// UnmarshalListMetaDelta decodes a ListMetaDelta from the fixed 16-byte binary format.
+func UnmarshalListMetaDelta(b []byte) (ListMetaDelta, error) {
+	if len(b) != listDeltaSizeBytes {
+		return ListMetaDelta{}, errors.WithStack(errors.Newf("invalid list meta delta length: %d", len(b)))
+	}
+	return ListMetaDelta{
+		HeadDelta: int64(binary.BigEndian.Uint64(b[0:8])),  //nolint:gosec
+		LenDelta:  int64(binary.BigEndian.Uint64(b[8:16])), //nolint:gosec
+	}, nil
+}
+
+// ListMetaDeltaKey builds the delta key for a list: prefix + 4-byte userKeyLen + userKey + 8-byte commitTS + 4-byte seqInTxn.
+func ListMetaDeltaKey(userKey []byte, commitTS uint64, seqInTxn uint32) []byte {
+	buf := make([]byte, 0, len(ListMetaDeltaPrefix)+wideColKeyLenSize+len(userKey)+deltaKeyTSSize+deltaKeySeqSize)
+	buf = append(buf, ListMetaDeltaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], commitTS)
+	buf = append(buf, ts[:]...)
+	var seq [4]byte
+	binary.BigEndian.PutUint32(seq[:], seqInTxn)
+	buf = append(buf, seq[:]...)
+	return buf
+}
+
+// ListMetaDeltaScanPrefix returns the prefix used to scan all delta keys for a userKey.
+func ListMetaDeltaScanPrefix(userKey []byte) []byte {
+	buf := make([]byte, 0, len(ListMetaDeltaPrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, ListMetaDeltaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// ListClaimKey builds the claim key for a list item at the given sequence number.
+func ListClaimKey(userKey []byte, seq int64) []byte {
+	var raw [8]byte
+	encodeSortableInt64(raw[:], seq)
+	buf := make([]byte, 0, len(ListClaimPrefix)+wideColKeyLenSize+len(userKey)+sortableInt64Bytes)
+	buf = append(buf, ListClaimPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	buf = append(buf, raw[:]...)
+	return buf
+}
+
+// ListClaimScanPrefix returns the prefix used to scan all claim keys for a userKey.
+func ListClaimScanPrefix(userKey []byte) []byte {
+	buf := make([]byte, 0, len(ListClaimPrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, ListClaimPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// IsListMetaDeltaKey reports whether the key is a list metadata delta key.
+func IsListMetaDeltaKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(ListMetaDeltaPrefix))
+}
+
+// IsListClaimKey reports whether the key is a list claim key.
+func IsListClaimKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(ListClaimPrefix))
+}
+
+// ExtractListUserKeyFromDelta extracts the logical user key from a list delta key.
+func ExtractListUserKeyFromDelta(key []byte) []byte {
+	trimmed := bytes.TrimPrefix(key, []byte(ListMetaDeltaPrefix))
+	if len(trimmed) < wideColKeyLenSize+deltaKeyTSSize+deltaKeySeqSize {
+		return nil
+	}
+	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
+	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen+uint32(deltaKeyTSSize+deltaKeySeqSize) { //nolint:gosec // constants fit in uint32
+		return nil
+	}
+	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+}
+
+// ExtractListUserKeyFromClaim extracts the logical user key from a list claim key.
+func ExtractListUserKeyFromClaim(key []byte) []byte {
+	trimmed := bytes.TrimPrefix(key, []byte(ListClaimPrefix))
+	if len(trimmed) < wideColKeyLenSize+sortableInt64Bytes {
+		return nil
+	}
+	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
+	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen+uint32(sortableInt64Bytes) { //nolint:gosec // constants fit in uint32
+		return nil
+	}
+	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+}
+
+// PrefixScanEnd returns the exclusive end key for a prefix scan.
+// It increments the last byte of the prefix; if overflow occurs (all 0xFF),
+// it returns a nil slice which callers must interpret as "scan to end of keyspace".
+func PrefixScanEnd(prefix []byte) []byte {
+	if len(prefix) == 0 {
+		return nil
+	}
+	end := bytes.Clone(prefix)
+	for i := len(end) - 1; i >= 0; i-- {
+		end[i]++
+		if end[i] != 0 {
+			return end
+		}
+	}
+	return nil // overflow: all bytes were 0xFF
+}
+
 // Wide-column style list storage using per-element keys.
 // Item keys: !lst|itm|<userKey><seq(8-byte sortable binary)>
 // Meta key : !lst|meta|<userKey> -> [Head(8)][Tail(8)][Len(8)]

--- a/store/list_helpers.go
+++ b/store/list_helpers.go
@@ -133,7 +133,7 @@ func ExtractListUserKeyFromDelta(key []byte) []byte {
 		return nil
 	}
 	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen+uint32(deltaKeyTSSize+deltaKeySeqSize) { //nolint:gosec // constants fit in uint32
+	if ukLen > uint32(len(trimmed)-wideColKeyLenSize-deltaKeyTSSize-deltaKeySeqSize) { //nolint:gosec // len check above guarantees non-negative subtraction
 		return nil
 	}
 	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
@@ -146,7 +146,7 @@ func ExtractListUserKeyFromClaim(key []byte) []byte {
 		return nil
 	}
 	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen+uint32(sortableInt64Bytes) { //nolint:gosec // constants fit in uint32
+	if ukLen > uint32(len(trimmed)-wideColKeyLenSize-sortableInt64Bytes) { //nolint:gosec // len check above guarantees non-negative subtraction
 		return nil
 	}
 	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]

--- a/store/set_helpers.go
+++ b/store/set_helpers.go
@@ -10,11 +10,15 @@ import (
 
 // Set wide-column key layout:
 //
-//	Base Metadata: !st|meta|<userKeyLen(4)><userKey>                 → [Len(8)]
-//	Member Key:    !st|mem|<userKeyLen(4)><userKey><member>           → (empty value)
+//	Base Metadata: !st|meta|b|<userKeyLen(4)><userKey>                 → [Len(8)]
+//	Member Key:    !st|mem|<userKeyLen(4)><userKey><member>             → (empty value)
 //	Delta Key:     !st|meta|d|<userKeyLen(4)><userKey><commitTS(8)><seqInTxn(4)> → [LenDelta(8)]
+//
+// Note: the base prefix ("!st|meta|b|") and delta prefix ("!st|meta|d|") differ
+// at the trailing discriminator byte ('b' vs 'd') so that IsSetMetaKey and
+// IsSetMetaDeltaKey produce unambiguous results without ordering constraints.
 const (
-	SetMetaPrefix      = "!st|meta|"
+	SetMetaPrefix      = "!st|meta|b|"
 	SetMemberPrefix    = "!st|mem|"
 	SetMetaDeltaPrefix = "!st|meta|d|"
 

--- a/store/set_helpers.go
+++ b/store/set_helpers.go
@@ -159,7 +159,7 @@ func ExtractSetUserKeyFromMeta(key []byte) []byte {
 		return nil
 	}
 	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
+	if ukLen > uint32(len(trimmed)-wideColKeyLenSize) { //nolint:gosec // len check above guarantees non-negative subtraction
 		return nil
 	}
 	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
@@ -172,7 +172,7 @@ func ExtractSetUserKeyFromMember(key []byte) []byte {
 		return nil
 	}
 	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
+	if ukLen > uint32(len(trimmed)-wideColKeyLenSize) { //nolint:gosec // len check above guarantees non-negative subtraction
 		return nil
 	}
 	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
@@ -186,7 +186,7 @@ func ExtractSetUserKeyFromDelta(key []byte) []byte {
 		return nil
 	}
 	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen+uint32(deltaKeyTSSize+deltaKeySeqSize) { //nolint:gosec // constants fit in uint32
+	if ukLen > uint32(len(trimmed)-wideColKeyLenSize-deltaKeyTSSize-deltaKeySeqSize) { //nolint:gosec // minLen check above guarantees non-negative subtraction
 		return nil
 	}
 	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]

--- a/store/set_helpers.go
+++ b/store/set_helpers.go
@@ -1,0 +1,189 @@
+//nolint:dupl // Hash and Set helpers are intentionally parallel implementations for distinct types.
+package store
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Set wide-column key layout:
+//
+//	Base Metadata: !st|meta|<userKeyLen(4)><userKey>                 → [Len(8)]
+//	Member Key:    !st|mem|<userKeyLen(4)><userKey><member>           → (empty value)
+//	Delta Key:     !st|meta|d|<userKeyLen(4)><userKey><commitTS(8)><seqInTxn(4)> → [LenDelta(8)]
+const (
+	SetMetaPrefix      = "!st|meta|"
+	SetMemberPrefix    = "!st|mem|"
+	SetMetaDeltaPrefix = "!st|meta|d|"
+
+	// setMetaSizeBytes is the fixed binary size of a SetMeta or SetMetaDelta (one int64).
+	setMetaSizeBytes = 8
+)
+
+// SetMeta is the base metadata for a set collection.
+type SetMeta struct {
+	Len int64
+}
+
+// SetMetaDelta holds a signed change in member count.
+type SetMetaDelta struct {
+	LenDelta int64
+}
+
+// MarshalSetMeta encodes SetMeta into a fixed 8-byte binary format.
+func MarshalSetMeta(m SetMeta) []byte {
+	buf := make([]byte, setMetaSizeBytes)
+	binary.BigEndian.PutUint64(buf, uint64(m.Len)) //nolint:gosec
+	return buf
+}
+
+// UnmarshalSetMeta decodes SetMeta from the fixed 8-byte binary format.
+func UnmarshalSetMeta(b []byte) (SetMeta, error) {
+	if len(b) != setMetaSizeBytes {
+		return SetMeta{}, errors.WithStack(errors.Newf("invalid set meta length: %d", len(b)))
+	}
+	return SetMeta{Len: int64(binary.BigEndian.Uint64(b))}, nil //nolint:gosec
+}
+
+// MarshalSetMetaDelta encodes SetMetaDelta into a fixed 8-byte binary format.
+func MarshalSetMetaDelta(d SetMetaDelta) []byte {
+	buf := make([]byte, setMetaSizeBytes)
+	binary.BigEndian.PutUint64(buf, uint64(d.LenDelta)) //nolint:gosec
+	return buf
+}
+
+// UnmarshalSetMetaDelta decodes SetMetaDelta from the fixed 8-byte binary format.
+func UnmarshalSetMetaDelta(b []byte) (SetMetaDelta, error) {
+	if len(b) != setMetaSizeBytes {
+		return SetMetaDelta{}, errors.WithStack(errors.Newf("invalid set meta delta length: %d", len(b)))
+	}
+	return SetMetaDelta{LenDelta: int64(binary.BigEndian.Uint64(b))}, nil //nolint:gosec
+}
+
+// SetMetaKey builds the metadata key for a set.
+func SetMetaKey(userKey []byte) []byte {
+	buf := make([]byte, 0, len(SetMetaPrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, SetMetaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// SetMemberKey builds the per-member key for a set member.
+func SetMemberKey(userKey, member []byte) []byte {
+	buf := make([]byte, 0, len(SetMemberPrefix)+wideColKeyLenSize+len(userKey)+len(member))
+	buf = append(buf, SetMemberPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	buf = append(buf, member...)
+	return buf
+}
+
+// SetMemberScanPrefix returns the prefix to scan all members of a set.
+func SetMemberScanPrefix(userKey []byte) []byte {
+	buf := make([]byte, 0, len(SetMemberPrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, SetMemberPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// ExtractSetMemberName extracts the member name from a set member key.
+func ExtractSetMemberName(key, userKey []byte) []byte {
+	prefix := SetMemberScanPrefix(userKey)
+	if !bytes.HasPrefix(key, prefix) {
+		return nil
+	}
+	return key[len(prefix):]
+}
+
+// SetMetaDeltaKey builds the delta key for a set metadata change.
+func SetMetaDeltaKey(userKey []byte, commitTS uint64, seqInTxn uint32) []byte {
+	buf := make([]byte, 0, len(SetMetaDeltaPrefix)+wideColKeyLenSize+len(userKey)+deltaKeyTSSize+deltaKeySeqSize)
+	buf = append(buf, SetMetaDeltaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], commitTS)
+	buf = append(buf, ts[:]...)
+	var seq [4]byte
+	binary.BigEndian.PutUint32(seq[:], seqInTxn)
+	buf = append(buf, seq[:]...)
+	return buf
+}
+
+// SetMetaDeltaScanPrefix returns the prefix to scan all delta keys for a set.
+func SetMetaDeltaScanPrefix(userKey []byte) []byte {
+	buf := make([]byte, 0, len(SetMetaDeltaPrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, SetMetaDeltaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// IsSetMetaKey reports whether the key is a set metadata key.
+func IsSetMetaKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(SetMetaPrefix))
+}
+
+// IsSetMemberKey reports whether the key is a set member key.
+func IsSetMemberKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(SetMemberPrefix))
+}
+
+// IsSetMetaDeltaKey reports whether the key is a set metadata delta key.
+func IsSetMetaDeltaKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(SetMetaDeltaPrefix))
+}
+
+// ExtractSetUserKeyFromMeta extracts the logical user key from a set meta key.
+func ExtractSetUserKeyFromMeta(key []byte) []byte {
+	trimmed := bytes.TrimPrefix(key, []byte(SetMetaPrefix))
+	if len(trimmed) < wideColKeyLenSize {
+		return nil
+	}
+	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
+	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
+		return nil
+	}
+	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+}
+
+// ExtractSetUserKeyFromMember extracts the logical user key from a set member key.
+func ExtractSetUserKeyFromMember(key []byte) []byte {
+	trimmed := bytes.TrimPrefix(key, []byte(SetMemberPrefix))
+	if len(trimmed) < wideColKeyLenSize {
+		return nil
+	}
+	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
+	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
+		return nil
+	}
+	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+}
+
+// ExtractSetUserKeyFromDelta extracts the logical user key from a set delta key.
+func ExtractSetUserKeyFromDelta(key []byte) []byte {
+	trimmed := bytes.TrimPrefix(key, []byte(SetMetaDeltaPrefix))
+	minLen := wideColKeyLenSize + deltaKeyTSSize + deltaKeySeqSize
+	if len(trimmed) < minLen {
+		return nil
+	}
+	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
+	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen+uint32(deltaKeyTSSize+deltaKeySeqSize) { //nolint:gosec // constants fit in uint32
+		return nil
+	}
+	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+}

--- a/store/zset_helpers.go
+++ b/store/zset_helpers.go
@@ -269,7 +269,7 @@ func ExtractZSetUserKeyFromDelta(key []byte) []byte {
 		return nil
 	}
 	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen+uint32(deltaKeyTSSize+deltaKeySeqSize) { //nolint:gosec // constants fit in uint32
+	if ukLen > uint32(len(trimmed)-wideColKeyLenSize-deltaKeyTSSize-deltaKeySeqSize) { //nolint:gosec // minLen check above guarantees non-negative subtraction
 		return nil
 	}
 	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]

--- a/store/zset_helpers.go
+++ b/store/zset_helpers.go
@@ -10,12 +10,16 @@ import (
 
 // ZSet wide-column key layout:
 //
-//	Base Metadata: !zs|meta|<userKeyLen(4)><userKey>                               → [Len(8)]
-//	Member Key:    !zs|mem|<userKeyLen(4)><userKey><member>                         → [Score(8)] IEEE 754
-//	Score Index:   !zs|scr|<userKeyLen(4)><userKey><sortableScore(8)><member>       → (empty)
-//	Delta Key:     !zs|meta|d|<userKeyLen(4)><userKey><commitTS(8)><seqInTxn(4)>   → [LenDelta(8)]
+//	Base Metadata: !zs|meta|b|<userKeyLen(4)><userKey>                               → [Len(8)]
+//	Member Key:    !zs|mem|<userKeyLen(4)><userKey><member>                           → [Score(8)] IEEE 754
+//	Score Index:   !zs|scr|<userKeyLen(4)><userKey><sortableScore(8)><member>         → (empty)
+//	Delta Key:     !zs|meta|d|<userKeyLen(4)><userKey><commitTS(8)><seqInTxn(4)>     → [LenDelta(8)]
+//
+// Note: the base prefix ("!zs|meta|b|") and delta prefix ("!zs|meta|d|") differ
+// at the trailing discriminator byte ('b' vs 'd') so that IsZSetMetaKey and
+// IsZSetMetaDeltaKey produce unambiguous results without ordering constraints.
 const (
-	ZSetMetaPrefix      = "!zs|meta|"
+	ZSetMetaPrefix      = "!zs|meta|b|"
 	ZSetMemberPrefix    = "!zs|mem|"
 	ZSetScorePrefix     = "!zs|scr|"
 	ZSetMetaDeltaPrefix = "!zs|meta|d|"

--- a/store/zset_helpers.go
+++ b/store/zset_helpers.go
@@ -1,0 +1,272 @@
+package store
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+
+	"github.com/cockroachdb/errors"
+)
+
+// ZSet wide-column key layout:
+//
+//	Base Metadata: !zs|meta|<userKeyLen(4)><userKey>                               → [Len(8)]
+//	Member Key:    !zs|mem|<userKeyLen(4)><userKey><member>                         → [Score(8)] IEEE 754
+//	Score Index:   !zs|scr|<userKeyLen(4)><userKey><sortableScore(8)><member>       → (empty)
+//	Delta Key:     !zs|meta|d|<userKeyLen(4)><userKey><commitTS(8)><seqInTxn(4)>   → [LenDelta(8)]
+const (
+	ZSetMetaPrefix      = "!zs|meta|"
+	ZSetMemberPrefix    = "!zs|mem|"
+	ZSetScorePrefix     = "!zs|scr|"
+	ZSetMetaDeltaPrefix = "!zs|meta|d|"
+
+	// zsetMetaSizeBytes is the fixed binary size of a ZSetMeta, ZSetMetaDelta, or ZSet score (one int64/float64).
+	zsetMetaSizeBytes = 8
+)
+
+// ZSetMeta is the base metadata for a sorted set collection.
+type ZSetMeta struct {
+	Len int64
+}
+
+// ZSetMetaDelta holds a signed change in member count.
+type ZSetMetaDelta struct {
+	LenDelta int64
+}
+
+// MarshalZSetMeta encodes ZSetMeta into a fixed 8-byte binary format.
+func MarshalZSetMeta(m ZSetMeta) []byte {
+	buf := make([]byte, zsetMetaSizeBytes)
+	binary.BigEndian.PutUint64(buf, uint64(m.Len)) //nolint:gosec
+	return buf
+}
+
+// UnmarshalZSetMeta decodes ZSetMeta from the fixed 8-byte binary format.
+func UnmarshalZSetMeta(b []byte) (ZSetMeta, error) {
+	if len(b) != zsetMetaSizeBytes {
+		return ZSetMeta{}, errors.WithStack(errors.Newf("invalid zset meta length: %d", len(b)))
+	}
+	return ZSetMeta{Len: int64(binary.BigEndian.Uint64(b))}, nil //nolint:gosec
+}
+
+// MarshalZSetMetaDelta encodes ZSetMetaDelta into a fixed 8-byte binary format.
+func MarshalZSetMetaDelta(d ZSetMetaDelta) []byte {
+	buf := make([]byte, zsetMetaSizeBytes)
+	binary.BigEndian.PutUint64(buf, uint64(d.LenDelta)) //nolint:gosec
+	return buf
+}
+
+// UnmarshalZSetMetaDelta decodes ZSetMetaDelta from the fixed 8-byte binary format.
+func UnmarshalZSetMetaDelta(b []byte) (ZSetMetaDelta, error) {
+	if len(b) != zsetMetaSizeBytes {
+		return ZSetMetaDelta{}, errors.WithStack(errors.Newf("invalid zset meta delta length: %d", len(b)))
+	}
+	return ZSetMetaDelta{LenDelta: int64(binary.BigEndian.Uint64(b))}, nil //nolint:gosec
+}
+
+// MarshalZSetScore encodes a float64 score in IEEE 754 big-endian format.
+func MarshalZSetScore(score float64) []byte {
+	buf := make([]byte, zsetMetaSizeBytes)
+	binary.BigEndian.PutUint64(buf, math.Float64bits(score))
+	return buf
+}
+
+// UnmarshalZSetScore decodes a float64 score from IEEE 754 big-endian format.
+func UnmarshalZSetScore(b []byte) (float64, error) {
+	if len(b) != zsetMetaSizeBytes {
+		return 0, errors.WithStack(errors.Newf("invalid zset score length: %d", len(b)))
+	}
+	return math.Float64frombits(binary.BigEndian.Uint64(b)), nil
+}
+
+// EncodeSortableFloat64 encodes a float64 into a sortable 8-byte representation.
+// For positive floats: XOR the sign bit to make them sort above negative.
+// For negative floats: XOR all bits to reverse the order.
+// This produces a byte sequence that sorts correctly with standard byte comparison.
+func EncodeSortableFloat64(f float64) [8]byte {
+	bits := math.Float64bits(f)
+	if bits>>63 == 0 {
+		// Positive (or +0): flip the sign bit
+		bits ^= 0x8000000000000000
+	} else {
+		// Negative (or -0): flip all bits
+		bits ^= 0xFFFFFFFFFFFFFFFF
+	}
+	var b [8]byte
+	binary.BigEndian.PutUint64(b[:], bits)
+	return b
+}
+
+// DecodeSortableFloat64 decodes a sortable 8-byte representation back to float64.
+func DecodeSortableFloat64(b [8]byte) float64 {
+	bits := binary.BigEndian.Uint64(b[:])
+	if bits>>63 == 1 {
+		// Was positive: flip only the sign bit back
+		bits ^= 0x8000000000000000
+	} else {
+		// Was negative: flip all bits back
+		bits ^= 0xFFFFFFFFFFFFFFFF
+	}
+	return math.Float64frombits(bits)
+}
+
+// ZSetMetaKey builds the metadata key for a sorted set.
+func ZSetMetaKey(userKey []byte) []byte {
+	buf := make([]byte, 0, len(ZSetMetaPrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, ZSetMetaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// ZSetMemberKey builds the per-member key storing the score for a sorted set.
+func ZSetMemberKey(userKey, member []byte) []byte {
+	buf := make([]byte, 0, len(ZSetMemberPrefix)+wideColKeyLenSize+len(userKey)+len(member))
+	buf = append(buf, ZSetMemberPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	buf = append(buf, member...)
+	return buf
+}
+
+// ZSetMemberScanPrefix returns the prefix to scan all members of a sorted set.
+func ZSetMemberScanPrefix(userKey []byte) []byte {
+	buf := make([]byte, 0, len(ZSetMemberPrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, ZSetMemberPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// ExtractZSetMemberName extracts the member name from a zset member key.
+func ExtractZSetMemberName(key, userKey []byte) []byte {
+	prefix := ZSetMemberScanPrefix(userKey)
+	if !bytes.HasPrefix(key, prefix) {
+		return nil
+	}
+	return key[len(prefix):]
+}
+
+// ZSetScoreKey builds the score index key for a sorted set entry.
+// Layout: !zs|scr|<userKeyLen(4)><userKey><sortableScore(8)><member>
+func ZSetScoreKey(userKey []byte, score float64, member []byte) []byte {
+	sortable := EncodeSortableFloat64(score)
+	buf := make([]byte, 0, len(ZSetScorePrefix)+wideColKeyLenSize+len(userKey)+zsetMetaSizeBytes+len(member))
+	buf = append(buf, ZSetScorePrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	buf = append(buf, sortable[:]...)
+	buf = append(buf, member...)
+	return buf
+}
+
+// ZSetScoreScanPrefix returns the prefix to scan all score index keys for a sorted set.
+func ZSetScoreScanPrefix(userKey []byte) []byte {
+	buf := make([]byte, 0, len(ZSetScorePrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, ZSetScorePrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// ZSetScoreRangeScanPrefix returns the prefix for scanning scores in [minScore, maxScore].
+func ZSetScoreRangeScanPrefix(userKey []byte, score float64) []byte {
+	sortable := EncodeSortableFloat64(score)
+	buf := make([]byte, 0, len(ZSetScorePrefix)+wideColKeyLenSize+len(userKey)+zsetMetaSizeBytes)
+	buf = append(buf, ZSetScorePrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	buf = append(buf, sortable[:]...)
+	return buf
+}
+
+// ExtractZSetScoreAndMember extracts the score and member name from a zset score index key.
+func ExtractZSetScoreAndMember(key, userKey []byte) (score float64, member []byte, ok bool) {
+	prefix := ZSetScoreScanPrefix(userKey)
+	if !bytes.HasPrefix(key, prefix) {
+		return 0, nil, false
+	}
+	rest := key[len(prefix):]
+	if len(rest) < zsetMetaSizeBytes {
+		return 0, nil, false
+	}
+	var sortable [zsetMetaSizeBytes]byte
+	copy(sortable[:], rest[:zsetMetaSizeBytes])
+	score = DecodeSortableFloat64(sortable)
+	member = rest[zsetMetaSizeBytes:]
+	return score, member, true
+}
+
+// ZSetMetaDeltaKey builds the delta key for a sorted set metadata change.
+func ZSetMetaDeltaKey(userKey []byte, commitTS uint64, seqInTxn uint32) []byte {
+	buf := make([]byte, 0, len(ZSetMetaDeltaPrefix)+wideColKeyLenSize+len(userKey)+deltaKeyTSSize+deltaKeySeqSize)
+	buf = append(buf, ZSetMetaDeltaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], commitTS)
+	buf = append(buf, ts[:]...)
+	var seq [4]byte
+	binary.BigEndian.PutUint32(seq[:], seqInTxn)
+	buf = append(buf, seq[:]...)
+	return buf
+}
+
+// ZSetMetaDeltaScanPrefix returns the prefix to scan all delta keys for a sorted set.
+func ZSetMetaDeltaScanPrefix(userKey []byte) []byte {
+	buf := make([]byte, 0, len(ZSetMetaDeltaPrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, ZSetMetaDeltaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// IsZSetMetaKey reports whether the key is a sorted set metadata key.
+func IsZSetMetaKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(ZSetMetaPrefix))
+}
+
+// IsZSetMemberKey reports whether the key is a sorted set member key.
+func IsZSetMemberKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(ZSetMemberPrefix))
+}
+
+// IsZSetScoreKey reports whether the key is a sorted set score index key.
+func IsZSetScoreKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(ZSetScorePrefix))
+}
+
+// IsZSetMetaDeltaKey reports whether the key is a sorted set metadata delta key.
+func IsZSetMetaDeltaKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(ZSetMetaDeltaPrefix))
+}
+
+// ExtractZSetUserKeyFromDelta extracts the logical user key from a zset delta key.
+func ExtractZSetUserKeyFromDelta(key []byte) []byte {
+	trimmed := bytes.TrimPrefix(key, []byte(ZSetMetaDeltaPrefix))
+	minLen := wideColKeyLenSize + deltaKeyTSSize + deltaKeySeqSize
+	if len(trimmed) < minLen {
+		return nil
+	}
+	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
+	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen+uint32(deltaKeyTSSize+deltaKeySeqSize) { //nolint:gosec // constants fit in uint32
+		return nil
+	}
+	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+}


### PR DESCRIPTION
- Add wide-column key layout helpers for Hash (store/hash_helpers.go), Set (store/set_helpers.go), and ZSet (store/zset_helpers.go) with meta, member/field/score, and delta key builders
- Add shared wide-column constants (wideColKeyLenSize, deltaKeyTSSize, deltaKeySeqSize) in store/list_helpers.go used across all helpers
- Implement delta-aggregated HLEN, SCARD, ZCARD via resolveHashMeta / resolveSetMeta / resolveZSetMeta; fall back to legacy blob for old data
- Extract listPushCore to eliminate dupl between listRPush and listLPush
- Extract normalizeWideColumnKey, wideColumnVisibleUserKey, and mergeInternalNamespaces helpers to reduce cyclop complexity
- Extract collectionCardinal helper to eliminate dupl in scard/zcard
- Wire normalizeStartTS into listPushCore and hincrby dispatch paths
- Update LeaderRoutedStore.ExistsAt to wrap error on local path