### PR TITLE
fix: pass readKeys through Raft log for single-shard txns to close TOCTOU window

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1484,6 +1484,13 @@ func (t *txnContext) loadListState(key []byte) (*listTxnState, error) {
 	if st, ok := t.listStates[k]; ok {
 		return st, nil
 	}
+	// Track listMetaKey (length/tail-pointer) and redisTTLKey as read
+	// dependencies. Individual list element keys (listItemKey) are NOT tracked
+	// because every list write operation (RPUSH, DEL) updates listMetaKey;
+	// a stale element read is therefore always detected via a stale meta read.
+	// A hypothetical LSET (in-place element mutation without touching meta)
+	// would require tracking individual element keys, but LSET is not
+	// currently supported.
 	t.trackReadKey(listMetaKey(key))
 	t.trackReadKey(redisTTLKey(key))
 

--- a/adapter/redis_txn_test.go
+++ b/adapter/redis_txn_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bootjp/elastickv/store"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/redcon"
 )
 
 func TestRedisTxnValidateReadSetDetectsStaleListMeta(t *testing.T) {
@@ -38,4 +39,35 @@ func TestRedisTxnValidateReadSetDetectsStaleListMeta(t *testing.T) {
 	err = txn.validateReadSet(context.Background())
 	require.Error(t, err)
 	require.ErrorIs(t, err, store.ErrWriteConflict)
+}
+
+// TestRedisTxnMULTIEXECRetriesOnCoordinatorConflict verifies that runTransaction
+// retries the full transaction when the coordinator returns ErrWriteConflict,
+// matching the retry behaviour of individual write commands.
+func TestRedisTxnMULTIEXECRetriesOnCoordinatorConflict(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	coord := newRetryOnceCoordinator(st)
+
+	srv := &RedisServer{
+		store:       st,
+		coordinator: coord,
+		scriptCache: map[string]string{},
+	}
+
+	// Simulate a queued MULTI/EXEC with a single SET command.
+	queue := []redcon.Command{
+		{Args: [][]byte{[]byte(cmdSet), []byte("txn:key"), []byte("v1")}},
+	}
+
+	results, err := srv.runTransaction(queue)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, 2, coord.dispatches) // first dispatch fails, second succeeds
+
+	val, err := st.GetAt(ctx, redisStrKey([]byte("txn:key")), snapshotTS(coord.clock, st))
+	require.NoError(t, err)
+	require.Equal(t, []byte("v1"), val)
 }

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -75,7 +75,7 @@ func (c *Coordinate) Dispatch(ctx context.Context, reqs *OperationGroup[OP]) (*C
 	}
 
 	if reqs.IsTxn {
-		return c.dispatchTxn(reqs.Elems, reqs.StartTS, reqs.CommitTS)
+		return c.dispatchTxn(reqs.Elems, reqs.ReadKeys, reqs.StartTS, reqs.CommitTS)
 	}
 
 	return c.dispatchRaw(reqs.Elems)
@@ -122,7 +122,7 @@ func (c *Coordinate) nextStartTS() uint64 {
 	return c.clock.Next()
 }
 
-func (c *Coordinate) dispatchTxn(reqs []*Elem[OP], startTS uint64, commitTS uint64) (*CoordinateResponse, error) {
+func (c *Coordinate) dispatchTxn(reqs []*Elem[OP], readKeys [][]byte, startTS uint64, commitTS uint64) (*CoordinateResponse, error) {
 	primary := primaryKeyForElems(reqs)
 	if len(primary) == 0 {
 		return nil, errors.WithStack(ErrTxnPrimaryKeyRequired)
@@ -143,13 +143,14 @@ func (c *Coordinate) dispatchTxn(reqs []*Elem[OP], startTS uint64, commitTS uint
 		return nil, errors.WithStack(ErrTxnCommitTSRequired)
 	}
 
-	// Read-set validation for single-shard transactions is performed by the
-	// adapter BEFORE Raft submission (validateReadSet). Passing readKeys
-	// into the Raft log would cause the FSM to reject transactions after
-	// they are already committed in the log, forcing retries at a later
-	// timestamp and breaking realtime ordering of appends.
+	// ReadKeys are included in the Raft log entry so the FSM validates
+	// read-write conflicts atomically under applyMu, eliminating the TOCTOU
+	// window that exists between the adapter's pre-Raft validateReadSet call
+	// and FSM application. The adapter's validateReadSet is kept as a fast
+	// path to fail early without a Raft round-trip, but the FSM check is
+	// the authoritative, serializable validation.
 	r, err := c.transactionManager.Commit([]*pb.Request{
-		onePhaseTxnRequest(startTS, commitTS, primary, reqs, nil),
+		onePhaseTxnRequest(startTS, commitTS, primary, reqs, readKeys),
 	})
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -263,7 +264,7 @@ func (c *Coordinate) redirect(ctx context.Context, reqs *OperationGroup[OP]) (*C
 			commitTS = 0
 		}
 		requests = []*pb.Request{
-			onePhaseTxnRequest(reqs.StartTS, commitTS, primary, reqs.Elems, nil),
+			onePhaseTxnRequest(reqs.StartTS, commitTS, primary, reqs.Elems, reqs.ReadKeys),
 		}
 	} else {
 		for _, req := range reqs.Elems {

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -123,6 +123,9 @@ func (c *Coordinate) nextStartTS() uint64 {
 }
 
 func (c *Coordinate) dispatchTxn(reqs []*Elem[OP], readKeys [][]byte, startTS uint64, commitTS uint64) (*CoordinateResponse, error) {
+	if len(readKeys) > maxReadKeys {
+		return nil, errors.WithStack(ErrInvalidRequest)
+	}
 	primary := primaryKeyForElems(reqs)
 	if len(primary) == 0 {
 		return nil, errors.WithStack(ErrTxnPrimaryKeyRequired)
@@ -230,6 +233,10 @@ func (c *Coordinate) toRawRequest(req *Elem[OP]) *pb.Request {
 }
 
 var ErrInvalidRequest = errors.New("invalid request")
+
+// maxReadKeys caps the number of keys that may appear in a transaction's read
+// set. Exceeding this limit is rejected to prevent unbounded memory growth.
+const maxReadKeys = 10_000
 var ErrLeaderNotFound = errors.New("leader not found")
 
 func (c *Coordinate) redirect(ctx context.Context, reqs *OperationGroup[OP]) (*CoordinateResponse, error) {

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -259,6 +259,9 @@ func (c *Coordinate) redirect(ctx context.Context, reqs *OperationGroup[OP]) (*C
 
 	var requests []*pb.Request
 	if reqs.IsTxn {
+		if len(reqs.ReadKeys) > maxReadKeys {
+			return nil, errors.WithStack(ErrInvalidRequest)
+		}
 		primary := primaryKeyForElems(reqs.Elems)
 		if len(primary) == 0 {
 			return nil, errors.WithStack(ErrTxnPrimaryKeyRequired)

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -237,6 +237,7 @@ var ErrInvalidRequest = errors.New("invalid request")
 // maxReadKeys caps the number of keys that may appear in a transaction's read
 // set. Exceeding this limit is rejected to prevent unbounded memory growth.
 const maxReadKeys = 10_000
+
 var ErrLeaderNotFound = errors.New("leader not found")
 
 func (c *Coordinate) redirect(ctx context.Context, reqs *OperationGroup[OP]) (*CoordinateResponse, error) {

--- a/kv/coordinator_txn_test.go
+++ b/kv/coordinator_txn_test.go
@@ -36,7 +36,7 @@ func TestCoordinateDispatchTxn_RejectsNonMonotonicCommitTS(t *testing.T) {
 
 	_, err := c.dispatchTxn([]*Elem[OP]{
 		{Op: Put, Key: []byte("k"), Value: []byte("v")},
-	}, startTS, 0)
+	}, nil, startTS, 0)
 	require.ErrorIs(t, err, ErrTxnCommitTSRequired)
 	require.Equal(t, 0, tx.commits)
 }
@@ -52,7 +52,7 @@ func TestCoordinateDispatchTxn_RejectsMissingPrimaryKey(t *testing.T) {
 
 	_, err := c.dispatchTxn([]*Elem[OP]{
 		{Op: Put, Key: nil, Value: []byte("v")},
-	}, 1, 0)
+	}, nil, 1, 0)
 	require.ErrorIs(t, err, ErrTxnPrimaryKeyRequired)
 	require.Equal(t, 0, tx.commits)
 }
@@ -70,7 +70,7 @@ func TestCoordinateDispatchTxn_UsesOnePhaseRequest(t *testing.T) {
 	_, err := c.dispatchTxn([]*Elem[OP]{
 		{Op: Put, Key: []byte("b"), Value: []byte("v1")},
 		{Op: Del, Key: []byte("x")},
-	}, startTS, 0)
+	}, nil, startTS, 0)
 	require.NoError(t, err)
 	require.Equal(t, 1, tx.commits)
 	require.Len(t, tx.reqs, 1)
@@ -107,7 +107,7 @@ func TestCoordinateDispatchTxn_UsesProvidedCommitTS(t *testing.T) {
 	commitTS := uint64(25)
 	_, err := c.dispatchTxn([]*Elem[OP]{
 		{Op: Put, Key: []byte("k"), Value: []byte("v")},
-	}, startTS, commitTS)
+	}, nil, startTS, commitTS)
 	require.NoError(t, err)
 	require.Len(t, tx.reqs, 1)
 	require.Len(t, tx.reqs[0], 1)
@@ -117,5 +117,5 @@ func TestCoordinateDispatchTxn_UsesProvidedCommitTS(t *testing.T) {
 	require.Equal(t, commitTS, meta.CommitTS)
 }
 
-// ReadKeys omission from single-shard Raft entries is tested in
-// TestShardedCoordinatorDispatchTxn_SingleShardOmitsReadKeysFromRaftEntry.
+// ReadKeys inclusion in single-shard Raft entries is tested in
+// TestShardedCoordinatorDispatchTxn_SingleShardIncludesReadKeysInRaftEntry.

--- a/kv/coordinator_txn_test.go
+++ b/kv/coordinator_txn_test.go
@@ -117,5 +117,24 @@ func TestCoordinateDispatchTxn_UsesProvidedCommitTS(t *testing.T) {
 	require.Equal(t, commitTS, meta.CommitTS)
 }
 
+func TestCoordinateDispatchTxn_PassesReadKeysToRaftEntry(t *testing.T) {
+	t.Parallel()
+
+	tx := &stubTransactional{}
+	c := &Coordinate{
+		transactionManager: tx,
+		clock:              NewHLC(),
+	}
+
+	readKeys := [][]byte{[]byte("rk1"), []byte("rk2")}
+	_, err := c.dispatchTxn([]*Elem[OP]{
+		{Op: Put, Key: []byte("k"), Value: []byte("v")},
+	}, readKeys, 10, 0)
+	require.NoError(t, err)
+	require.Len(t, tx.reqs, 1)
+	require.Len(t, tx.reqs[0], 1)
+	require.Equal(t, readKeys, tx.reqs[0][0].ReadKeys)
+}
+
 // ReadKeys inclusion in single-shard Raft entries is tested in
 // TestShardedCoordinatorDispatchTxn_SingleShardIncludesReadKeysInRaftEntry.

--- a/kv/fsm.go
+++ b/kv/fsm.go
@@ -320,11 +320,11 @@ func (f *kvFSM) handlePrepareRequest(ctx context.Context, r *pb.Request) error {
 }
 
 // handleOnePhaseTxnRequest applies a single-shard transaction atomically.
-// Write-write conflicts are always checked under the store's apply lock.
-// r.ReadKeys is passed through to ApplyMutations for read-write conflict
-// detection; for single-shard transactions it is typically nil because the
-// adapter validates the read set pre-Raft (see kv/coordinator.go), while
-// multi-shard PREPARE requests carry per-shard read keys.
+// Both write-write and read-write conflicts are checked under the store's
+// applyMu lock via ApplyMutations. r.ReadKeys carries the transaction's read
+// set (populated by the coordinator from OperationGroup.ReadKeys), so the
+// FSM validates read-write conflicts atomically with the commit, eliminating
+// the TOCTOU window that existed when validation was only done pre-Raft.
 func (f *kvFSM) handleOnePhaseTxnRequest(ctx context.Context, r *pb.Request, commitTS uint64) error {
 	meta, muts, err := extractTxnMeta(r.Mutations)
 	if err != nil {

--- a/kv/fsm_occ_test.go
+++ b/kv/fsm_occ_test.go
@@ -103,3 +103,167 @@ func TestOnePhaseTxnDetectsWriteConflict(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte("v1"), v)
 }
+
+// TestOnePhaseTxnDetectsReadWriteConflictViaReadKeys verifies that the FSM
+// rejects a one-phase transaction when a key in ReadKeys was committed after
+// the transaction's startTS, closing the TOCTOU window.
+func TestOnePhaseTxnDetectsReadWriteConflictViaReadKeys(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	// Concurrent write: "rk" committed at ts=100, after T_a's startTS=90.
+	require.NoError(t, st.PutAt(ctx, []byte("rk"), []byte("concurrent"), 100, 0))
+
+	fsm, ok := NewKvFSM(st).(*kvFSM)
+	require.True(t, ok)
+
+	// T_a one-phase txn: startTS=90, writes "wk", reads "rk" (stale).
+	req := &pb.Request{
+		IsTxn:    true,
+		Phase:    pb.Phase_NONE,
+		Ts:       90,
+		ReadKeys: [][]byte{[]byte("rk")},
+		Mutations: []*pb.Mutation{
+			{Op: pb.Op_PUT, Key: []byte(txnMetaPrefix), Value: EncodeTxnMeta(TxnMeta{PrimaryKey: []byte("wk"), CommitTS: 110})},
+			{Op: pb.Op_PUT, Key: []byte("wk"), Value: []byte("val")},
+		},
+	}
+	err := applyFSMRequest(t, fsm, req)
+	require.ErrorIs(t, err, store.ErrWriteConflict)
+
+	// The write must not have been applied.
+	_, err = st.GetAt(ctx, []byte("wk"), ^uint64(0))
+	require.ErrorIs(t, err, store.ErrKeyNotFound)
+}
+
+// TestOnePhaseTxnAllowsReadKeyWhenNoConflict verifies that a one-phase
+// transaction succeeds when ReadKeys were not modified after startTS.
+func TestOnePhaseTxnAllowsReadKeyWhenNoConflict(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	// "rk" committed at ts=80, before T_a's startTS=100 — not stale.
+	require.NoError(t, st.PutAt(ctx, []byte("rk"), []byte("old"), 80, 0))
+
+	fsm, ok := NewKvFSM(st).(*kvFSM)
+	require.True(t, ok)
+
+	req := &pb.Request{
+		IsTxn:    true,
+		Phase:    pb.Phase_NONE,
+		Ts:       100,
+		ReadKeys: [][]byte{[]byte("rk")},
+		Mutations: []*pb.Mutation{
+			{Op: pb.Op_PUT, Key: []byte(txnMetaPrefix), Value: EncodeTxnMeta(TxnMeta{PrimaryKey: []byte("wk"), CommitTS: 120})},
+			{Op: pb.Op_PUT, Key: []byte("wk"), Value: []byte("val")},
+		},
+	}
+	require.NoError(t, applyFSMRequest(t, fsm, req))
+
+	v, err := st.GetAt(ctx, []byte("wk"), ^uint64(0))
+	require.NoError(t, err)
+	require.Equal(t, []byte("val"), v)
+}
+
+// TestOnePhaseTxnNilReadKeysSkipsReadWriteValidation verifies that when
+// ReadKeys is nil the FSM skips read-write conflict checks, so a concurrent
+// commit to an untracked key does not block the transaction.
+func TestOnePhaseTxnNilReadKeysSkipsReadWriteValidation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	// "rk" committed at ts=200 — would trigger a conflict if tracked.
+	require.NoError(t, st.PutAt(ctx, []byte("rk"), []byte("newer"), 200, 0))
+
+	fsm, ok := NewKvFSM(st).(*kvFSM)
+	require.True(t, ok)
+
+	// nil ReadKeys: read-write check is skipped entirely.
+	req := &pb.Request{
+		IsTxn:    true,
+		Phase:    pb.Phase_NONE,
+		Ts:       100,
+		ReadKeys: nil,
+		Mutations: []*pb.Mutation{
+			{Op: pb.Op_PUT, Key: []byte(txnMetaPrefix), Value: EncodeTxnMeta(TxnMeta{PrimaryKey: []byte("wk"), CommitTS: 120})},
+			{Op: pb.Op_PUT, Key: []byte("wk"), Value: []byte("val")},
+		},
+	}
+	require.NoError(t, applyFSMRequest(t, fsm, req))
+
+	v, err := st.GetAt(ctx, []byte("wk"), ^uint64(0))
+	require.NoError(t, err)
+	require.Equal(t, []byte("val"), v)
+}
+
+// TestOnePhaseTxnTOCTOUScenario simulates the exact TOCTOU window that the
+// readKeys fix was designed to close: T_a reads a key at startTS=100, then
+// T_b commits a newer version at ts=150 before T_a reaches the FSM. The FSM
+// must reject T_a's one-phase commit because its read set is stale.
+func TestOnePhaseTxnTOCTOUScenario(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	// Initial value seen by T_a.
+	require.NoError(t, st.PutAt(ctx, []byte("balance"), []byte("100"), 50, 0))
+
+	fsm, ok := NewKvFSM(st).(*kvFSM)
+	require.True(t, ok)
+
+	// T_b commits a newer version while T_a is in flight.
+	require.NoError(t, st.PutAt(ctx, []byte("balance"), []byte("50"), 150, 0))
+
+	// T_a commits based on the stale value it read at startTS=100.
+	req := &pb.Request{
+		IsTxn:    true,
+		Phase:    pb.Phase_NONE,
+		Ts:       100,
+		ReadKeys: [][]byte{[]byte("balance")},
+		Mutations: []*pb.Mutation{
+			{Op: pb.Op_PUT, Key: []byte(txnMetaPrefix), Value: EncodeTxnMeta(TxnMeta{PrimaryKey: []byte("result"), CommitTS: 200})},
+			{Op: pb.Op_PUT, Key: []byte("result"), Value: []byte("derived-from-stale-balance")},
+		},
+	}
+	err := applyFSMRequest(t, fsm, req)
+	require.ErrorIs(t, err, store.ErrWriteConflict)
+
+	// "result" must not have been written.
+	_, err = st.GetAt(ctx, []byte("result"), ^uint64(0))
+	require.ErrorIs(t, err, store.ErrKeyNotFound)
+}
+
+// TestPrepareRequestDetectsReadWriteConflictViaReadKeys verifies that the
+// PREPARE phase also rejects transactions whose ReadKeys were committed after
+// startTS, providing the same SSI guarantee as one-phase transactions.
+func TestPrepareRequestDetectsReadWriteConflictViaReadKeys(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	// "rk" committed at ts=100, after T_a's startTS=90.
+	require.NoError(t, st.PutAt(ctx, []byte("rk"), []byte("concurrent"), 100, 0))
+
+	fsm, ok := NewKvFSM(st).(*kvFSM)
+	require.True(t, ok)
+
+	req := &pb.Request{
+		IsTxn:    true,
+		Phase:    pb.Phase_PREPARE,
+		Ts:       90,
+		ReadKeys: [][]byte{[]byte("rk")},
+		Mutations: []*pb.Mutation{
+			{Op: pb.Op_PUT, Key: []byte(txnMetaPrefix), Value: EncodeTxnMeta(TxnMeta{PrimaryKey: []byte("wk"), LockTTLms: 1000})},
+			{Op: pb.Op_PUT, Key: []byte("wk"), Value: []byte("val")},
+		},
+	}
+	err := applyFSMRequest(t, fsm, req)
+	require.ErrorIs(t, err, store.ErrWriteConflict)
+
+	// The lock must not have been written.
+	_, err = st.GetAt(ctx, txnLockKey([]byte("wk")), ^uint64(0))
+	require.ErrorIs(t, err, store.ErrKeyNotFound)
+}

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -209,7 +209,21 @@ func (c *ShardedCoordinator) dispatchTxn(ctx context.Context, startTS uint64, co
 	}
 
 	if len(gids) == 1 {
-		return c.dispatchSingleShardTxn(startTS, commitTS, primaryKey, gids[0], elems, readKeys)
+		// Only use the single-shard (one-phase) path when every read key also
+		// belongs to the same shard as the mutations. If any read key belongs
+		// to a different shard, the 2PC path must be used so that
+		// validateReadOnlyShards validates those shards via a linearizable
+		// read barrier, preserving SSI.
+		canOptimize := true
+		for _, rk := range readKeys {
+			if c.engineGroupIDForKey(rk) != gids[0] {
+				canOptimize = false
+				break
+			}
+		}
+		if canOptimize {
+			return c.dispatchSingleShardTxn(startTS, commitTS, primaryKey, gids[0], elems, readKeys)
+		}
 	}
 
 	prepared, err := c.prewriteTxn(ctx, startTS, commitTS, primaryKey, grouped, gids, readKeys)

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -194,6 +194,9 @@ func (c *ShardedCoordinator) broadcastToAllGroups(requests []*pb.Request) (*Coor
 }
 
 func (c *ShardedCoordinator) dispatchTxn(ctx context.Context, startTS uint64, commitTS uint64, elems []*Elem[OP], readKeys [][]byte) (*CoordinateResponse, error) {
+	if len(readKeys) > maxReadKeys {
+		return nil, errors.WithStack(ErrInvalidRequest)
+	}
 	grouped, gids, err := c.groupMutations(elems)
 	if err != nil {
 		return nil, err

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -209,7 +209,7 @@ func (c *ShardedCoordinator) dispatchTxn(ctx context.Context, startTS uint64, co
 	}
 
 	if len(gids) == 1 {
-		return c.dispatchSingleShardTxn(startTS, commitTS, primaryKey, gids[0], elems)
+		return c.dispatchSingleShardTxn(startTS, commitTS, primaryKey, gids[0], elems, readKeys)
 	}
 
 	prepared, err := c.prewriteTxn(ctx, startTS, commitTS, primaryKey, grouped, gids, readKeys)
@@ -241,14 +241,15 @@ func (c *ShardedCoordinator) resolveTxnCommitTS(startTS, commitTS uint64) (uint6
 	return commitTS, nil
 }
 
-func (c *ShardedCoordinator) dispatchSingleShardTxn(startTS, commitTS uint64, primaryKey []byte, gid uint64, elems []*Elem[OP]) (*CoordinateResponse, error) {
+func (c *ShardedCoordinator) dispatchSingleShardTxn(startTS, commitTS uint64, primaryKey []byte, gid uint64, elems []*Elem[OP], readKeys [][]byte) (*CoordinateResponse, error) {
 	g, err := c.txnGroupForID(gid)
 	if err != nil {
 		return nil, err
 	}
-	// Single-shard: read-set validated pre-Raft by the adapter.
+	// ReadKeys are included in the Raft log entry so the FSM validates
+	// read-write conflicts atomically under applyMu.
 	resp, err := g.Txn.Commit([]*pb.Request{
-		onePhaseTxnRequest(startTS, commitTS, primaryKey, elems, nil),
+		onePhaseTxnRequest(startTS, commitTS, primaryKey, elems, readKeys),
 	})
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/kv/sharded_coordinator_txn_test.go
+++ b/kv/sharded_coordinator_txn_test.go
@@ -531,7 +531,7 @@ func TestShardedCoordinatorDispatchTxn_ReadKeysRoutedToPrepareByShard(t *testing
 	require.Equal(t, [][]byte{[]byte("y")}, g2Prepare.ReadKeys)
 }
 
-func TestShardedCoordinatorDispatchTxn_SingleShardOmitsReadKeysFromRaftEntry(t *testing.T) {
+func TestShardedCoordinatorDispatchTxn_SingleShardIncludesReadKeysInRaftEntry(t *testing.T) {
 	t.Parallel()
 
 	engine := distribution.NewEngine()
@@ -550,7 +550,9 @@ func TestShardedCoordinatorDispatchTxn_SingleShardOmitsReadKeysFromRaftEntry(t *
 	})
 	require.NoError(t, err)
 	require.Len(t, g1Txn.requests, 1)
-	// Single-shard: readKeys are validated pre-Raft by the adapter,
-	// so they must NOT be in the Raft log entry.
-	require.Nil(t, g1Txn.requests[0].ReadKeys)
+	// Single-shard: readKeys must be included in the Raft log entry so the
+	// FSM can validate read-write conflicts atomically under applyMu,
+	// eliminating the TOCTOU window that exists between the adapter's
+	// pre-Raft validateReadSet call and FSM application.
+	require.Equal(t, [][]byte{[]byte("rk1"), []byte("rk2")}, g1Txn.requests[0].ReadKeys)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -136,14 +136,11 @@ type MVCCStore interface {
 	//
 	// Isolation guarantees vary by transaction topology:
 	//
-	//   Single-shard transactions: read-set validation is performed by the
-	//   adapter layer BEFORE Raft submission (pre-Raft). readKeys is nil in
-	//   the Raft log entry so the FSM does not re-validate. This avoids
-	//   post-commit rejections that would break realtime ordering, but
-	//   introduces a TOCTOU window between the adapter check and the FSM
-	//   apply under applyMu. The window is narrow (single Raft round-trip)
-	//   and matches the isolation level of the previous validateReadSet
-	//   design.
+	//   Single-shard transactions: readKeys are included in the Raft log entry
+	//   and validated atomically under the FSM's applyMu lock alongside
+	//   write-write conflict detection. The adapter's pre-Raft validateReadSet
+	//   call is kept as a fast-fail optimization but the FSM check is
+	//   authoritative. No TOCTOU window; full SSI.
 	//
 	//   Multi-shard (2PC) write shards: readKeys are included in the
 	//   PREPARE Raft entry and validated atomically under the FSM's applyMu


### PR DESCRIPTION
Single-shard transactions were passing nil for readKeys in the Raft log entry (introduced in commit 17cbfbd7), relying solely on the adapter pre-Raft validateReadSet call to detect read-write conflicts.

This created a TOCTOU race: another transaction could commit to a key in the read set after validateReadSet passed but before the FSM applied the entry. With readKeys=nil, the FSM ApplyMutations never checked read-write conflicts, allowing stale reads to commit silently. This caused G-single-item and G2-item anomalies (and apparent G0 cycles) detected by the Jepsen test.

Fix: pass readKeys from OperationGroup through dispatchTxn and dispatchSingleShardTxn into onePhaseTxnRequest, so the FSM validates read-write conflicts atomically under applyMu alongside write-write conflict detection. The adapter validateReadSet is kept as a fast-fail optimization but the FSM check is now the authoritative serializable validation with no TOCTOU window.

The original comment claiming this breaks realtime ordering was incorrect: when the FSM rejects an entry due to read-write conflict, the store is unmodified (conflict check runs before any writes), so the adapter retries safely with a fresh timestamp -- correct SSI behavior.

Also update the test that was asserting the buggy behavior (omission of readKeys from Raft entries) to assert the correct behavior (inclusion).