### PR TITLE
docs: add FSM snapshot disk offload design with CRC32C integrity

### DIFF
--- a/docs/etcd_snapshot_disk_offload_design.md
+++ b/docs/etcd_snapshot_disk_offload_design.md
@@ -107,7 +107,7 @@ After:  Data = [magic:4][version:1][index:8][crc32c:4]
 
 | Field   | Size   | Value |
 |---------|--------|-------|
-| magic   | 4 byte | `EKVR` (ElasticKV Reference) |
+| magic   | 4 byte | `EKVT` (ElasticKV Token) |
 | version | 1 byte | `0x01` |
 | index   | 8 byte | applied log index of the snapshot (little-endian uint64) |
 | crc32c  | 4 byte | CRC32C checksum of the entire `.fsm` file (little-endian uint32) |
@@ -115,6 +115,18 @@ After:  Data = [magic:4][version:1][index:8][crc32c:4]
 The magic prefix distinguishes the new format from legacy payloads (see Migration section).
 Embedding the CRC32C in the token allows integrity verification at the metadata level,
 before the file is even opened.
+
+> **Magic allocation note**: The existing persistence layer already uses `EKVR` (state
+> file), `EKVM` (metadata file), and `EKVW` (entries file) as defined in
+> `internal/raftengine/etcd/persistence.go`. `EKVT` is chosen to avoid collision with
+> any of these. The full registry is:
+>
+> | Magic  | File |
+> |--------|------|
+> | `EKVR` | `etcd-raft-state.bin` |
+> | `EKVM` | `etcd-raft-meta.bin` |
+> | `EKVW` | `etcd-raft-entries.bin` |
+> | `EKVT` | `raftpb.Snapshot.Data` token (this design) |
 
 ### `.fsm` File Format
 
@@ -192,7 +204,7 @@ maybePersistLocalSnapshot()
       → os.CreateTemp() → {fsmSnapDir}/{storageIndex}.fsm.tmp
       → crcWriter := newCRC32CWriter(tmpFile)
       → fsmSnap.WriteTo(crcWriter)                              # stream to disk + compute CRC
-      → binary.Write(tmpFile, LittleEndian, crcWriter.Sum32()) # append CRC footer
+      → binary.Write(tmpFile, binary.LittleEndian, crcWriter.Sum32()) # append CRC footer
       → tmpFile.Sync()
       → os.Rename(tmp, final)                                   # atomic commit
       → syncDir(fsmSnapDir)                                     # persist directory entry
@@ -246,8 +258,11 @@ func openAndRestoreFSMSnapshot(fsm StateMachine, path string, tokenCRC uint32) e
     if err != nil {
         return errors.WithStack(err)
     }
-    if info.Size() < 4 {
-        return errors.Wrapf(ErrFSMSnapshotFileCRC, "file too small: %d bytes", info.Size())
+    // Minimum valid .fsm: 8 bytes Pebble magic + 8 bytes lastCommitTS + 4 bytes CRC footer = 20 bytes.
+    const minFSMFileSize = 20
+    if info.Size() < minFSMFileSize {
+        return errors.Wrapf(ErrFSMSnapshotTooSmall,
+            "file too small: %d bytes (minimum %d)", info.Size(), minFSMFileSize)
     }
     f, err := os.Open(path)
     if err != nil {
@@ -461,7 +476,7 @@ var (
 | File | Change |
 |------|--------|
 | `internal/raftengine/etcd/wal_store.go` | Remove `snapshotBytes`; add `writeFSMSnapshotFile`; update `restoreSnapshotState` and `stateMachineSnapshotBytes` (bootstrap) |
-| `internal/raftengine/etcd/engine.go` | Update `persistLocalSnapshot`, `persistConfigSnapshot`, and `persistConfigSnapshotPayload` to use `writeFSMSnapshotFile` + token; add `fsmSnapDir` and `snapReceiveGroup` fields |
+| `internal/raftengine/etcd/engine.go` | Update `persistLocalSnapshot`, `persistConfigSnapshot`, `persistConfigState`, and `persistConfigSnapshotPayload` to use `writeFSMSnapshotFile` + token; add `fsmSnapDir` and `snapReceiveGroup` fields |
 | `internal/raftengine/etcd/grpc_transport.go` | Detect token in `Dispatch` → file-streaming send; update `receiveSnapshotStream` to write chunks to file with `singleflight` serialization and `syncDir` |
 | `internal/raftengine/etcd/snapshot_spool.go` | Remove `snapshotSpool` (Phase 3) |
 
@@ -481,7 +496,7 @@ var (
 writeFSMSnapshotFile():
   1. os.CreateTemp(fsmSnapDir, "*.fsm.tmp")         # write to temp file
   2. snapshot.WriteTo(crcWriter)                     # stream FSM + accumulate CRC
-  3. binary.Write(tmpFile, LE, crcWriter.Sum32())    # append CRC footer
+  3. binary.Write(tmpFile, binary.LittleEndian, crcWriter.Sum32()) # append CRC footer
   4. tmpFile.Sync()                                  # flush to durable storage
   5. os.Rename(tmp, final)                           # atomic commit
   6. syncDir(fsmSnapDir)                             # persist directory entry
@@ -551,7 +566,7 @@ If the first 4 bytes of `raftpb.Snapshot.Data` equal `EKVR`, the payload is trea
 token. Any other prefix is treated as a legacy FSM payload.
 
 ```go
-const snapshotTokenMagic = [4]byte{'E', 'K', 'V', 'R'}
+const snapshotTokenMagic = [4]byte{'E', 'K', 'V', 'T'}
 
 func isSnapshotToken(data []byte) bool {
     if len(data) < 4 {
@@ -574,6 +589,62 @@ If a node begins writing `.fsm` files and then rolls back to the previous binary
 **When a follower receives a legacy-format MsgSnap:**
 - `isSnapshotToken` returns false → restore via `bytes.NewReader` (no CRC check)
 - Compatible with rolling upgrades where not all nodes have been updated yet
+
+---
+
+## Rolling Upgrade and Zero-Downtime Cutover
+
+### Compatibility Matrix
+
+The `isSnapshotToken` magic check provides the compatibility bridge. Because `EKVT` is
+a prefix that can never appear in a valid legacy FSM payload (Pebble snapshots start with
+`EKVPBBL1`; gob-encoded legacy payloads start with gob framing bytes), there is no
+ambiguity when a mixed-version cluster is operating.
+
+| Sender version | Receiver version | Outcome |
+|----------------|-----------------|---------|
+| Legacy (no token) | Legacy | Unchanged — existing path |
+| Legacy (no token) | New | `isSnapshotToken` → false → `bytes.NewReader` fallback |
+| New (token) | Legacy | Legacy node does not understand the token; restores from the 17-byte payload as if it were FSM data → **corrupt FSM** |
+| New (token) | New | Token path → `.fsm` file |
+
+### Rolling Upgrade Strategy
+
+The third case — a new-format leader sending a token to a legacy follower — is the only
+dangerous scenario. To prevent it, the rollout must proceed as follows:
+
+1. **Deploy Phase 1 to all nodes before Phase 2.** Phase 1 changes only local snapshot
+   creation and restore; it does not change what is sent over the wire. A Phase 1 node
+   still sends full `[]byte` payloads in `MsgSnap` and can receive them. Mixed Phase 1 /
+   legacy clusters are safe.
+
+2. **Deploy Phase 2 to all nodes simultaneously, or use the feature flag below.** Once
+   any node begins sending token-format `MsgSnap`, all receivers must be at Phase 2.
+
+3. **Feature flag (recommended)**: add a `DisableFSMSnapshotToken` config field (default
+   `false`). When set to `true`, `Dispatch` falls back to the legacy `sendSnapshot` path
+   even if the local MemoryStorage contains a token. This allows operators to:
+   - Deploy Phase 2 binaries cluster-wide with the flag enabled.
+   - Verify stability, then disable the flag on each node progressively.
+   - Roll back safely by re-enabling the flag without restarting.
+
+### Rollback Safety
+
+If a rollback to the pre-Phase 1 binary is required after Phase 1 has created `.fsm`
+files:
+- The legacy binary reads the `.snap` file and finds `Data` = a 17-byte token starting
+  with `EKVT`.
+- `fsm.Restore` will attempt to interpret 17 bytes as a Pebble snapshot and fail with a
+  decode error (the Pebble magic `EKVPBBL1` is not present).
+- **Mitigation**: Before rolling back, stop the node and manually delete `fsm-snap/`; the
+  legacy binary will then fall back to WAL replay from the compacted snapshot index.
+  Document this procedure in the runbook.
+
+Alternatively, Phase 1 can write a **dual-format** `.snap` file during a configurable
+transition window: `raftpb.Snapshot.Data` = token AND a copy of the full legacy payload
+stored in an auxiliary file. The legacy binary would then decode the full payload
+normally. This dual-write mode is a forward compatibility bridge and can be removed after
+the fleet has been fully upgraded.
 
 ---
 
@@ -621,7 +692,7 @@ config-change, and bootstrap). Follower send/receive is unchanged.
   - `encodeSnapshotToken` / `decodeSnapshotToken` (17-byte token with CRC)
   - Error types: `ErrFSMSnapshotFileCRC`, `ErrFSMSnapshotTokenCRC`, etc.
 - Update `persistLocalSnapshot` → `writeFSMSnapshotFile` + token
-- Update `persistConfigSnapshot` / `persistConfigSnapshotPayload` → same
+- Update `persistConfigSnapshot`, `persistConfigState`, and `persistConfigSnapshotPayload` → same
 - Update `stateMachineSnapshotBytes` (bootstrap) → `writeFSMSnapshotFile` + token
 - Update `restoreSnapshotState` → `openAndRestoreFSMSnapshot`
 - Replace `purgeOldSnapFiles` with `purgeOldSnapshotFiles(snapDir, fsmSnapDir)`

--- a/docs/etcd_snapshot_disk_offload_design.md
+++ b/docs/etcd_snapshot_disk_offload_design.md
@@ -110,7 +110,7 @@ After:  Data = [magic:4][version:1][index:8][crc32c:4]
 | magic   | 4 byte | `EKVT` (ElasticKV Token) |
 | version | 1 byte | `0x01` |
 | index   | 8 byte | applied log index of the snapshot (little-endian uint64) |
-| crc32c  | 4 byte | CRC32C checksum of the entire `.fsm` file (little-endian uint32) |
+| crc32c  | 4 byte | CRC32C checksum of the `.fsm` file payload (all bytes preceding the footer) (little-endian uint32) |
 
 The magic prefix distinguishes the new format from legacy payloads (see Migration section).
 Embedding the CRC32C in the token allows integrity verification at the metadata level,
@@ -274,7 +274,15 @@ func openAndRestoreFSMSnapshot(fsm StateMachine, path string, tokenCRC uint32) e
     h := crc32.New(crc32cTable)
     // Tee: data flows to both the CRC accumulator and fsm.Restore simultaneously.
     tee := io.TeeReader(io.LimitReader(f, payloadSize), h)
-    if err := fsm.Restore(bufio.NewReaderSize(tee, 1<<20)); err != nil {
+    br := bufio.NewReaderSize(tee, 1<<20)
+    if err := fsm.Restore(br); err != nil {
+        return errors.WithStack(err)
+    }
+    // Drain any bytes that fsm.Restore left unread (e.g. if it stopped on an
+    // internal end-of-stream marker before consuming the full payload).
+    // Without this, h would have accumulated fewer bytes than the file contains,
+    // producing a spurious CRC mismatch even for a valid file.
+    if _, err := io.Copy(io.Discard, br); err != nil {
         return errors.WithStack(err)
     }
     var footer uint32
@@ -562,7 +570,7 @@ The existing `purgeOldSnapFiles` function is removed and replaced entirely.
 
 ## Migration (Legacy Format Compatibility)
 
-If the first 4 bytes of `raftpb.Snapshot.Data` equal `EKVR`, the payload is treated as a
+If the first 4 bytes of `raftpb.Snapshot.Data` equal `EKVT`, the payload is treated as a
 token. Any other prefix is treated as a legacy FSM payload.
 
 ```go
@@ -737,7 +745,7 @@ removes three-read-pass anti-pattern on the receive side.
 | Test | What it verifies |
 |------|-----------------|
 | `TestTokenRoundTrip` | `encodeSnapshotToken` / `decodeSnapshotToken` round-trip for boundary values (`0`, `MaxUint64`, `MaxUint32`) |
-| `TestTokenMagicRejection` | `isSnapshotToken` returns false for non-`EKVR` prefixes; `decodeSnapshotToken` returns `ErrFSMSnapshotTokenInvalid` for lengths 0–16 and wrong magic |
+| `TestTokenMagicRejection` | `isSnapshotToken` returns false for non-`EKVT` prefixes; `decodeSnapshotToken` returns `ErrFSMSnapshotTokenInvalid` for lengths 0–16 and wrong magic |
 | `TestCRCWriterMatchesStdlib` | `crc32CWriter.Sum32()` matches `crc32.Checksum` for identical bytes; incremental writes accumulate correctly |
 | `TestOpenAndRestoreFSMSnapshotGoodFile` | Correct file restores FSM state without error |
 | `TestOpenAndRestoreFSMSnapshotBadFooter` | Footer byte flipped → `ErrFSMSnapshotFileCRC` |
@@ -757,7 +765,7 @@ removes three-read-pass anti-pattern on the receive side.
 | `TestReceiveWrongCRCInFooter` | Correct length, corrupted footer → verify rejects before rename |
 | `TestReceiveTokenCRCMismatchesFileCRC` | Token carries wrong CRC, file footer is self-consistent → `ErrFSMSnapshotTokenCRC` in `openAndRestoreFSMSnapshot` |
 | `TestConcurrentReceiveSameIndex` | Two goroutines receiving the same index via `singleflight`; only one `.fsm` committed; no torn file |
-| `TestLegacyFormatFallbackOnRestore` | `snap.Data` without `EKVR` prefix → `bytes.NewReader` path; no `.fsm` file opened |
+| `TestLegacyFormatFallbackOnRestore` | `snap.Data` without `EKVT` prefix → `bytes.NewReader` path; no `.fsm` file opened |
 | `TestLegacyFormatFallbackOnSend` | Non-token `MsgSnap` → old `sendSnapshot` path; no file opened from `fsmSnapDir` |
 | `TestSyncDirCalledAfterRename` | Both `writeFSMSnapshotFile` and `receiveSnapshotStream` call `syncDir` after rename (verified via mock or filesystem hook) |
 | Conformance `SnapshotRestoreAfterRestart` | Propose 10,001 entries, close engine, reopen; assert FSM state recovered from `.fsm` snapshot (not WAL replay) |

--- a/docs/etcd_snapshot_disk_offload_design.md
+++ b/docs/etcd_snapshot_disk_offload_design.md
@@ -366,6 +366,9 @@ receiveSnapshotStream()
 ```
 receiveSnapshotStream()
   → receive header chunk → parse token → extract index, tokenCRC
+  → validate token.Index == snap.Metadata.Index
+    # a mismatch indicates a misrouted or corrupted snapshot; return
+    # ErrFSMSnapshotIndexMismatch immediately before writing any data
   → result, err := snapReceiveGroup.Do(strconv.FormatUint(index, 10), func() {
         → os.CreateTemp() → {fsmSnapDir}/{index}.fsm.tmp
         → stream remaining chunks to tmpFile (with bufio.NewWriterSize)
@@ -531,11 +534,16 @@ The receiver path (`receiveSnapshotStream`) follows the same sequence and also c
 3. Removes any `.fsm` file whose index does not correspond to a live token — this handles
    the case where a `.fsm` was written but the corresponding `.snap` was never saved
    (upgrade crash), as well as files left over after purge ordering bugs in older versions.
-4. For each remaining `.fsm` file, calls `verifyFSMSnapshotFile` and removes files where
-   `ErrFSMSnapshotFileCRC` is returned (corrupt files cannot be used for restore).
 
-This index-based orphan detection is stricter than a CRC-only check: a file with a valid
-CRC but no matching token is still an orphan and must be removed.
+CRC integrity of the retained `.fsm` files is **not** verified at startup. For GiB-scale
+snapshots on slow storage, a full read-pass over every `.fsm` file would unacceptably
+delay engine recovery. Instead, CRC verification happens lazily in
+`openAndRestoreFSMSnapshot` at the moment the snapshot is actually applied. If a file is
+corrupt, the engine detects it at restore time and can request a fresh snapshot from the
+leader.
+
+This index-based orphan detection is stricter than a CRC-only startup scan: a file with
+a valid CRC but no matching token is still an orphan and must be removed.
 
 ---
 
@@ -621,13 +629,37 @@ ambiguity when a mixed-version cluster is operating.
 The third case — a new-format leader sending a token to a legacy follower — is the only
 dangerous scenario. To prevent it, the rollout must proceed as follows:
 
-1. **Deploy Phase 1 to all nodes before Phase 2.** Phase 1 changes only local snapshot
-   creation and restore; it does not change what is sent over the wire. A Phase 1 node
-   still sends full `[]byte` payloads in `MsgSnap` and can receive them. Mixed Phase 1 /
-   legacy clusters are safe.
+1. **Deploy Phase 1 to all nodes before Phase 2.** Phase 1 stores a 17-byte token in
+   `MemoryStorage` instead of the full FSM payload. This means a Phase 1 leader **would**
+   send a token in `MsgSnap` to a lagging follower, which a legacy follower cannot
+   understand. To remain backward-compatible, Phase 1 **must** therefore also include a
+   `Dispatch`-side fallback that reconstructs a full-payload `MsgSnap` when using the
+   legacy send path:
 
-2. **Deploy Phase 2 to all nodes simultaneously, or use the feature flag below.** Once
-   any node begins sending token-format `MsgSnap`, all receivers must be at Phase 2.
+   ```go
+   // Phase 1 Dispatch fallback: token is in MemoryStorage but receiver may be legacy.
+   // Read the .fsm file back to bytes only when a slow follower actually needs a
+   // snapshot — not on every periodic creation — so peak memory is still improved.
+   if isSnapshotToken(msg.Snapshot.Data) {
+       tok, _ := decodeSnapshotToken(msg.Snapshot.Data)
+       path := filepath.Join(fsmSnapDir, strconv.FormatUint(tok.Index, 10)+".fsm")
+       payload, err := readFSMSnapshotPayload(path) // streams file, returns []byte
+       if err != nil {
+           return errors.WithStack(err)
+       }
+       msg.Snapshot.Data = payload // full bytes → safe for legacy receivers
+   }
+   // fall through to legacy sendSnapshot path
+   ```
+
+   With this fallback, mixed Phase 1 / legacy clusters are safe. The memory allocation
+   occurs only when a slow follower needs a snapshot send, not during periodic local
+   snapshot creation, so the worst-case spike is unchanged but the common-case (no
+   lagging followers) is fully eliminated.
+
+2. **Deploy Phase 2 to all nodes simultaneously, or use the feature flag below.** Phase 2
+   replaces the Phase 1 fallback with true file streaming; once any node begins sending
+   token-format `MsgSnap` without reconstructing, all receivers must be at Phase 2.
 
 3. **Feature flag (recommended)**: add a `DisableFSMSnapshotToken` config field (default
    `false`). When set to `true`, `Dispatch` falls back to the legacy `sendSnapshot` path
@@ -688,7 +720,8 @@ the fleet has been fully upgraded.
 ### Phase 1: Local Snapshot Disk Offload
 
 Scope: local creation and local restore for **all three snapshot paths** (periodic,
-config-change, and bootstrap). Follower send/receive is unchanged.
+config-change, and bootstrap) **plus** a `Dispatch`-side fallback for backward
+compatibility with legacy followers.
 
 **Implementation tasks:**
 
@@ -697,12 +730,17 @@ config-change, and bootstrap). Follower send/receive is unchanged.
   - `writeFSMSnapshotFile` (write with CRC footer + syncDir)
   - `openAndRestoreFSMSnapshot` (single-pass verify+restore via TeeReader)
   - `verifyFSMSnapshotFile` (read-only CRC check for orphan detection)
+  - `readFSMSnapshotPayload` (read `.fsm` file back to `[]byte` for legacy send)
   - `encodeSnapshotToken` / `decodeSnapshotToken` (17-byte token with CRC)
-  - Error types: `ErrFSMSnapshotFileCRC`, `ErrFSMSnapshotTokenCRC`, etc.
+  - Error types: `ErrFSMSnapshotFileCRC`, `ErrFSMSnapshotTokenCRC`,
+    `ErrFSMSnapshotIndexMismatch`, etc.
 - Update `persistLocalSnapshot` → `writeFSMSnapshotFile` + token
 - Update `persistConfigSnapshot`, `persistConfigState`, and `persistConfigSnapshotPayload` → same
 - Update `stateMachineSnapshotBytes` (bootstrap) → `writeFSMSnapshotFile` + token
 - Update `restoreSnapshotState` → `openAndRestoreFSMSnapshot`
+- Update `Dispatch`: if `isSnapshotToken(msg.Snapshot.Data)` and using the legacy send
+  path, call `readFSMSnapshotPayload` to reconstruct the full payload before sending
+  (ensures legacy followers receive a valid FSM byte stream)
 - Replace `purgeOldSnapFiles` with `purgeOldSnapshotFiles(snapDir, fsmSnapDir)`
 - Add `cleanupStaleFSMSnaps(snapDir, fsmSnapDir)` (index-based orphan removal)
 - Capture `storageIndex` before `fsm.Snapshot()` in `maybePersistLocalSnapshot`
@@ -710,14 +748,18 @@ config-change, and bootstrap). Follower send/receive is unchanged.
 
 **Effect**: eliminates memory spikes during local snapshot creation; reduces
 `MemoryStorage` resident memory; all snapshot creation paths are consistent.
+Mixed Phase 1 / legacy clusters remain safe because the Dispatch fallback reconstructs
+the full payload on demand (only when a slow follower actually needs a snapshot).
 
 ### Phase 2: Streaming Follower Send/Receive
 
-Scope: update `GRPCTransport` MsgSnap paths to use file streaming.
+Scope: update `GRPCTransport` MsgSnap paths to use file streaming; remove the
+Phase 1 `readFSMSnapshotPayload` fallback from `Dispatch`.
 
 **Implementation tasks:**
 
 - `Dispatch`: detect token → open `.fsm` file → `sendSnapshotFileChunks`
+  (replaces the Phase 1 `readFSMSnapshotPayload` fallback entirely)
 - `receiveSnapshotStream`:
   - Write chunks to temp file (with `bufio.NewWriterSize`)
   - `verifyFSMSnapshotFile` on tmp before rename

--- a/docs/etcd_snapshot_disk_offload_design.md
+++ b/docs/etcd_snapshot_disk_offload_design.md
@@ -492,8 +492,32 @@ var (
 | Error | Meaning | Recovery |
 |-------|---------|---------|
 | `ErrFSMSnapshotFileCRC` | On-disk file is corrupt; footer ≠ computed | Delete file; WAL replay from `FirstIndex` |
-| `ErrFSMSnapshotTokenCRC` | Footer and token disagree (detected before restore) | Log the mismatch; request a fresh snapshot from the leader; do not auto-rewrite the token (the mismatch may indicate the token references the wrong file version) |
+| `ErrFSMSnapshotTokenCRC` | Footer and token disagree (detected before restore) | Delete the corrupt `.fsm` file; request a fresh snapshot from the leader; do not auto-rewrite the token (see note below) |
 | `ErrFSMSnapshotNotFound` | `.fsm` file missing for a valid token | WAL replay from `FirstIndex` |
+
+> **`ErrFSMSnapshotTokenCRC` — infinite-loop and source-of-truth considerations**
+>
+> When the engine encounters `ErrFSMSnapshotTokenCRC` it must:
+>
+> 1. **Delete** the suspect `.fsm` file before requesting a new snapshot. If the file is
+>    not deleted, the same mismatch will recur on every apply attempt.
+> 2. **Request a fresh snapshot from the leader** by calling `ReportSnapshot` with
+>    `SnapshotFailure`, which prompts etcd-raft to ask the leader to send another
+>    snapshot. This is not a free-form "request" — it uses the existing Raft mechanism,
+>    which has built-in backoff and retry limits.
+> 3. **Avoid infinite loops**: if `ErrFSMSnapshotTokenCRC` recurs after N consecutive
+>    fresh snapshots (suggested threshold: 3), the engine should log a critical alert and
+>    stop retrying automatically. Persistent recurrence indicates a leader-side issue
+>    (corrupt `.snap` token in the leader's MemoryStorage) that requires operator
+>    intervention.
+> 4. **Single-node or degraded cluster**: if the leader is the only source of truth and
+>    its `.snap` token is persistently corrupt, no amount of re-requesting will help. The
+>    operator must use the rollback procedure (stop node, delete `fsm-snap/`, restart for
+>    WAL replay) to recover. This is documented in the Zero-Downtime Cutover Runbook.
+>
+> Auto-rewriting the token from the file footer is not implemented because the mismatch
+> could indicate the token references a different snapshot version than the file contains;
+> rewriting would silently accept potentially incorrect state.
 
 ---
 

--- a/docs/etcd_snapshot_disk_offload_design.md
+++ b/docs/etcd_snapshot_disk_offload_design.md
@@ -138,15 +138,38 @@ This is the same algorithm used by etcd's `Snapshotter`
 range of several GB/s with negligible CPU overhead. The Go standard library exposes it as
 `hash/crc32.MakeTable(crc32.Castagnoli)`.
 
+### CRC Authority
+
+The **on-disk footer is the authoritative checksum**. The CRC embedded in the token is a
+*transmission integrity check* — it is derived from the file at write time and travels
+with the raft snapshot metadata. The two values must always agree; a mismatch indicates:
+
+- **footer ≠ computed**: the `.fsm` file is corrupt on disk → delete and attempt WAL
+  replay; do not trust the token.
+- **footer == computed, token ≠ computed**: the `.snap` metadata is corrupt → the file
+  itself is trustworthy; the snap file should be rewritten from the file's actual CRC.
+- **footer ≠ computed AND token ≠ computed**: both are corrupt → WAL replay only.
+
+This distinction is implemented in `verifyFSMSnapshotFile`, which returns typed errors
+(`ErrFSMSnapshotFileCRC`, `ErrFSMSnapshotTokenCRC`) to allow callers to take the correct
+recovery action.
+
 ---
 
 ## Flow Changes
 
 ### 1. Local Snapshot Creation
 
+> **Scope note**: This flow applies to **all three snapshot creation paths**: local
+> periodic snapshots (`persistLocalSnapshot`), config-change snapshots
+> (`persistConfigSnapshot`), and bootstrap (`stateMachineSnapshotBytes`). All three must
+> be migrated in Phase 1; leaving any path on the legacy `snapshotBytesAndClose` route
+> re-introduces the memory problem and breaks the token invariant.
+
 **Before:**
 ```
 maybePersistLocalSnapshot()
+  → storageIndex := storage.Snapshot().Metadata.Index   # record current index
   → fsm.Snapshot()
   → snapshotBytesAndClose()
       → spool.WriteTo()        # write to temp file on disk
@@ -158,18 +181,26 @@ maybePersistLocalSnapshot()
 **After:**
 ```
 maybePersistLocalSnapshot()
-  → fsm.Snapshot()
-  → writeFSMSnapshotFile(snapshot, fsmSnapDir, index)
-      → os.CreateTemp() → {fsmSnapDir}/{index}.fsm.tmp
+  # Capture the MemoryStorage index BEFORE calling fsm.Snapshot() so the
+  # staleness check in persistLocalSnapshotPayload uses the same baseline.
+  # If a follower restore advances storage between Snapshot() and
+  # persistLocalSnapshotPayload, the index <= current.Metadata.Index guard
+  # will correctly discard the stale file.
+  → storageIndex := storage.Snapshot().Metadata.Index
+  → fsmSnap := fsm.Snapshot()
+  → crc32c, err := writeFSMSnapshotFile(fsmSnap, fsmSnapDir, storageIndex)
+      → os.CreateTemp() → {fsmSnapDir}/{storageIndex}.fsm.tmp
       → crcWriter := newCRC32CWriter(tmpFile)
-      → snapshot.WriteTo(crcWriter)                               # stream to disk + compute CRC
-      → binary.Write(tmpFile, LittleEndian, crcWriter.Sum32())   # append CRC footer
-      → tmpFile.Sync() → os.Rename(tmp, final)                   # atomic commit
+      → fsmSnap.WriteTo(crcWriter)                              # stream to disk + compute CRC
+      → binary.Write(tmpFile, LittleEndian, crcWriter.Sum32()) # append CRC footer
+      → tmpFile.Sync()
+      → os.Rename(tmp, final)                                   # atomic commit
+      → syncDir(fsmSnapDir)                                     # persist directory entry
       → return crcWriter.Sum32()
-  → token := encodeSnapshotToken(index, crc32c)  # 17 bytes
-  → persist.SaveSnap(snap{Data: token})          # small snap file
-  → storage.CreateSnapshot(_, _, token)          # MemoryStorage: 17 bytes only
-  → purgeOldFSMSnapFiles(fsmSnapDir)
+  → token := encodeSnapshotToken(storageIndex, crc32c)  # 17 bytes
+  → persist.SaveSnap(snap{Data: token})                 # small snap file
+  → storage.CreateSnapshot(_, _, token)                 # MemoryStorage: 17 bytes only
+  → purgeOldSnapshotFiles(snapDir, fsmSnapDir)          # coordinated purge (see Retention)
 ```
 
 **Memory impact:**
@@ -177,6 +208,11 @@ maybePersistLocalSnapshot()
 - Resident: FSM data size → 17 bytes
 
 ### 2. Restore on Restart
+
+Restore uses a **single-pass** helper `openAndRestoreFSMSnapshot` that opens the file
+once, verifies the CRC while streaming data to the FSM, and never reads the file a second
+time. This eliminates the double-read that would result from a separate verify pass
+followed by a restore pass.
 
 **Before:**
 ```
@@ -192,18 +228,66 @@ loadWalState()
   → snapshotter.LoadNewestAvailable()
   → restoreSnapshotState(fsm, snap, fsmSnapDir)
       → if isSnapshotToken(snap.Data):
-            index, expectedCRC := decodeSnapshotToken(snap.Data)
+            index, tokenCRC := decodeSnapshotToken(snap.Data)
             path := fsmSnapPath(fsmSnapDir, index)
-            verifyFSMSnapshotFile(path, expectedCRC)          # fail fast on corruption
-            f := os.Open(path)
-            fsm.Restore(newCRC32CStripFooterReader(f))        # exclude footer from stream
+            openAndRestoreFSMSnapshot(fsm, path, tokenCRC)
+              # single pass: open fd → stream payload through CRC accumulator
+              #              → call fsm.Restore → compare computed vs footer vs tokenCRC
+              # returns ErrFSMSnapshotFileCRC or ErrFSMSnapshotTokenCRC on mismatch
          else:
-            fsm.Restore(bytes.NewReader(snap.Data))           # legacy format fallback
+            fsm.Restore(bytes.NewReader(snap.Data))  # legacy format fallback
 ```
 
-`verifyFSMSnapshotFile` reads the file sequentially, computes the CRC incrementally, and
-compares it against both the on-disk footer and the `expectedCRC` from the token. A
-mismatch returns `ErrFSMSnapshotCRCMismatch` and aborts startup.
+`openAndRestoreFSMSnapshot` keeps a single open file descriptor for the full operation:
+
+```go
+func openAndRestoreFSMSnapshot(fsm StateMachine, path string, tokenCRC uint32) error {
+    info, err := os.Stat(path)
+    if err != nil {
+        return errors.WithStack(err)
+    }
+    if info.Size() < 4 {
+        return errors.Wrapf(ErrFSMSnapshotFileCRC, "file too small: %d bytes", info.Size())
+    }
+    f, err := os.Open(path)
+    if err != nil {
+        return errors.WithStack(err)
+    }
+    defer f.Close()
+
+    payloadSize := info.Size() - 4
+    h := crc32.New(crc32cTable)
+    // Tee: data flows to both the CRC accumulator and fsm.Restore simultaneously.
+    tee := io.TeeReader(io.LimitReader(f, payloadSize), h)
+    if err := fsm.Restore(bufio.NewReaderSize(tee, 1<<20)); err != nil {
+        return errors.WithStack(err)
+    }
+    var footer uint32
+    if err := binary.Read(f, binary.LittleEndian, &footer); err != nil {
+        return errors.WithStack(err)
+    }
+    computed := h.Sum32()
+    if computed != footer {
+        return errors.Wrapf(ErrFSMSnapshotFileCRC,
+            "path=%s footer=%08x computed=%08x", path, footer, computed)
+    }
+    if computed != tokenCRC {
+        return errors.Wrapf(ErrFSMSnapshotTokenCRC,
+            "path=%s token=%08x computed=%08x", path, tokenCRC, computed)
+    }
+    return nil
+}
+```
+
+Key properties:
+- **Single read pass**: `io.TeeReader` feeds data to both `fsm.Restore` and the CRC hash
+  simultaneously; no second scan.
+- **`bufio.NewReaderSize(tee, 1<<20)`**: the 1 MiB read-ahead buffer amortizes the
+  per-entry small reads that `writePebbleSnapshotEntries` / the restore loop issues,
+  matching the throughput of the former `bytes.Reader` path.
+- **Single open fd**: the file descriptor is held across the full verify+restore
+  operation, eliminating the TOCTOU window between a separate verify and a subsequent
+  restore open.
 
 ### 3. Sending MsgSnap to a Follower
 
@@ -228,10 +312,22 @@ sendMessages()
             sendSnapshot(msg)   # legacy format fallback
 ```
 
-The `.fsm` file is sent including its CRC footer. The receiver stores the full file and
-performs CRC verification after all chunks arrive.
+The `.fsm` file is sent **including its CRC footer** as the final 4 bytes. The receiver
+stores the full file and verifies the CRC before committing.
 
 ### 4. Receiving and Applying MsgSnap on a Follower
+
+Two concurrency concerns are addressed here:
+
+1. **Concurrent receive for the same index**: a leader retry or simultaneous MsgSnap
+   delivery could cause two goroutines to write `{index}.fsm` at the same time. A
+   `singleflight.Group` keyed on the snapshot index serializes receive operations for the
+   same index; only the first completes, the second reuses its result.
+
+2. **TOCTOU between verify and apply**: verify and restore use the same open file
+   descriptor via `openAndRestoreFSMSnapshot` (see §2), eliminating the window where the
+   file could be replaced between a standalone verify call and a subsequent open for
+   restore.
 
 **Before:**
 ```
@@ -246,24 +342,31 @@ receiveSnapshotStream()
 **After:**
 ```
 receiveSnapshotStream()
-  → receive header chunk → parse token → extract index, expectedCRC
-  → os.CreateTemp() → {fsmSnapDir}/{index}.fsm.tmp
-  → stream remaining chunks to tmpFile
-  → tmpFile.Sync()
-  → verifyFSMSnapshotFile(tmpPath, expectedCRC)              # verify before committing
-  → os.Rename(tmpPath, {fsmSnapDir}/{index}.fsm)             # atomic commit on success
+  → receive header chunk → parse token → extract index, tokenCRC
+  → result, err := snapReceiveGroup.Do(strconv.FormatUint(index, 10), func() {
+        → os.CreateTemp() → {fsmSnapDir}/{index}.fsm.tmp
+        → stream remaining chunks to tmpFile (with bufio.NewWriterSize)
+        → tmpFile.Sync()
+        → verify CRC of tmpPath against footer and tokenCRC
+          # footer is authoritative; return ErrFSMSnapshotFileCRC if mismatch
+        → os.Rename(tmpPath, {fsmSnapDir}/{index}.fsm)  # atomic commit on success
+        → syncDir(fsmSnapDir)                           # flush directory entry
+        → return token
+    })
   → raftpb.Message{Snapshot: {Data: token}}
   → handler(msg)
       → applyReadySnapshot(snap)
-          → index, expectedCRC := decodeSnapshotToken(snap.Data)
-          → verifyFSMSnapshotFile(path, expectedCRC)         # second check before apply
-          → fsm.Restore(newCRC32CStripFooterReader(f))
+          → index, tokenCRC := decodeSnapshotToken(snap.Data)
+          → openAndRestoreFSMSnapshot(fsm, path, tokenCRC)
+            # single-pass verify+restore; no second verifyFSMSnapshotFile call needed
+            # the file was already committed atomically by receiveSnapshotStream
 ```
 
-**Why verify immediately after receive:**
-- Detects in-transit bit errors before the file is applied to the FSM
-- Prevents a corrupt file from overwriting a healthy FSM state
-- On failure, report `SnapshotFailure` to prompt the leader to retry
+**Why the second `verifyFSMSnapshotFile` call is removed from `applyReadySnapshot`:**
+After `receiveSnapshotStream` has verified, atomically renamed, and `syncDir`'d the file,
+no other process modifies `.fsm` files between that point and `applyReadySnapshot`. The
+`openAndRestoreFSMSnapshot` call already recomputes the CRC as a by-product of streaming
+data to `fsm.Restore`, so integrity is confirmed without an extra full-file scan.
 
 ---
 
@@ -297,74 +400,51 @@ func (c *crc32CWriter) Sum32() uint32 { return c.h.Sum32() }
 Passing `crc32CWriter` to `snapshot.WriteTo` computes the CRC without any changes to the
 existing `WriteTo` implementation.
 
-### Reading: Streaming Verification
+### Reading: Single-Pass Verify and Restore
 
-`verifyFSMSnapshotFile` uses `stat` to determine the file size, then reads
-`(size - 4)` bytes through a CRC accumulator, and compares the result against the
-4-byte footer and the `expectedCRC` from the token. No second read pass is required.
+Rather than a standalone `verifyFSMSnapshotFile` followed by a separate `fsm.Restore`,
+all read paths use `openAndRestoreFSMSnapshot` (see §2: Restore on Restart). This
+function:
 
-```go
-func verifyFSMSnapshotFile(path string, expectedCRC uint32) error {
-    info, err := os.Stat(path)
-    if err != nil {
-        return errors.WithStack(err)
-    }
-    if info.Size() < 4 {
-        return errors.Wrapf(ErrFSMSnapshotCRCMismatch, "file too small: %d bytes", info.Size())
-    }
-    f, err := os.Open(path)
-    if err != nil {
-        return errors.WithStack(err)
-    }
-    defer f.Close()
+1. Opens the file once and holds the fd for the entire operation.
+2. Uses `io.TeeReader` to feed data simultaneously to the CRC accumulator and
+   `fsm.Restore`.
+3. Reads the 4-byte footer after `fsm.Restore` returns and checks `computed == footer`
+   and `computed == tokenCRC`.
+4. Returns typed errors distinguishing file corruption (`ErrFSMSnapshotFileCRC`) from
+   token corruption (`ErrFSMSnapshotTokenCRC`).
 
-    h := crc32.New(crc32cTable)
-    if _, err := io.Copy(h, io.LimitReader(f, info.Size()-4)); err != nil {
-        return errors.WithStack(err)
-    }
-    var footer uint32
-    if err := binary.Read(f, binary.LittleEndian, &footer); err != nil {
-        return errors.WithStack(err)
-    }
-    computed := h.Sum32()
-    if computed != footer {
-        return errors.Wrapf(ErrFSMSnapshotCRCMismatch,
-            "path=%s footer=%08x computed=%08x", path, footer, computed)
-    }
-    if computed != expectedCRC {
-        return errors.Wrapf(ErrFSMSnapshotCRCMismatch,
-            "path=%s token=%08x computed=%08x", path, expectedCRC, computed)
-    }
-    return nil
-}
-```
-
-`newCRC32CStripFooterReader` wraps the open file and exposes only the first
-`(size - 4)` bytes to the FSM's `Restore` call so the footer is not interpreted as
-key-value data.
+A standalone `verifyFSMSnapshotFile(path, tokenCRC)` is still provided for contexts where
+the FSM must not be modified (e.g., startup cleanup health-checking orphan files), but it
+is **never called in sequence with a subsequent restore**.
 
 ### Verification Points
 
-| When | Location | What is checked |
-|------|----------|-----------------|
-| **On restart** | `restoreSnapshotState` | file CRC ↔ footer ↔ token CRC |
-| **After follower receive** | `receiveSnapshotStream` | file CRC ↔ footer ↔ token CRC |
-| **Before follower apply** | `applyReadySnapshot` | token CRC ↔ file CRC (second check) |
-| **Background health check** *(future)* | background task | periodic re-computation of file CRC |
+| When | Location | Mechanism |
+|------|----------|-----------|
+| **On restart** | `restoreSnapshotState` | `openAndRestoreFSMSnapshot` (single pass) |
+| **After follower receive** | `receiveSnapshotStream` | `verifyFSMSnapshotFile` on tmp before rename |
+| **On follower apply** | `applyReadySnapshot` | `openAndRestoreFSMSnapshot` (single pass; no extra verify) |
+| **Startup orphan check** | `cleanupStaleFSMSnaps` | `verifyFSMSnapshotFile` (read-only, no restore) |
+| **Background health check** *(future)* | background task | `verifyFSMSnapshotFile` |
 
-### Error Handling
+### Error Types and Recovery
 
 ```go
 var (
-    ErrFSMSnapshotCRCMismatch  = errors.New("fsm snapshot: CRC32C mismatch")
-    ErrFSMSnapshotNotFound     = errors.New("fsm snapshot: file not found")
+    ErrFSMSnapshotFileCRC   = errors.New("fsm snapshot: file CRC32C mismatch (file corrupt)")
+    ErrFSMSnapshotTokenCRC  = errors.New("fsm snapshot: token CRC32C mismatch (metadata corrupt)")
+    ErrFSMSnapshotNotFound  = errors.New("fsm snapshot: file not found")
+    ErrFSMSnapshotTooSmall  = errors.New("fsm snapshot: file too small to contain footer")
     ErrFSMSnapshotTokenInvalid = errors.New("fsm snapshot: token format invalid")
 )
 ```
 
-- `ErrFSMSnapshotCRCMismatch`: log `{path, expected, actual}` and abort the operation.
-  - On startup: attempt WAL replay from `FirstIndex` before giving up.
-  - On follower receive: report `SnapshotFailure`; the leader will retry.
+| Error | Meaning | Recovery |
+|-------|---------|---------|
+| `ErrFSMSnapshotFileCRC` | On-disk file is corrupt; footer ≠ computed | Delete file; WAL replay from `FirstIndex` |
+| `ErrFSMSnapshotTokenCRC` | File is intact (footer == computed) but token differs | Rewrite token from file's actual CRC; no WAL replay needed |
+| `ErrFSMSnapshotNotFound` | `.fsm` file missing for a valid token | WAL replay from `FirstIndex` |
 
 ---
 
@@ -374,16 +454,16 @@ var (
 
 | File | Contents |
 |------|----------|
-| `internal/raftengine/etcd/fsm_snapshot_file.go` | FSM snapshot file read/write, CRC32C computation and verification, token encode/decode |
+| `internal/raftengine/etcd/fsm_snapshot_file.go` | `crc32CWriter`, `openAndRestoreFSMSnapshot`, `verifyFSMSnapshotFile`, `writeFSMSnapshotFile`, token encode/decode, error types |
 
 ### Changes to Existing Files
 
 | File | Change |
 |------|--------|
-| `internal/raftengine/etcd/wal_store.go` | Remove `snapshotBytes`; add `writeFSMSnapshotFile`; update `restoreSnapshotState` to handle token format |
-| `internal/raftengine/etcd/engine.go` | Replace payload retrieval in `persistLocalSnapshot` with `writeFSMSnapshotFile`; add `fsmSnapDir` field |
-| `internal/raftengine/etcd/grpc_transport.go` | Detect token in `Dispatch` → route to file-streaming send path; update `receiveSnapshotStream` to write chunks to file |
-| `internal/raftengine/etcd/snapshot_spool.go` | Repurpose or remove `snapshotSpool` |
+| `internal/raftengine/etcd/wal_store.go` | Remove `snapshotBytes`; add `writeFSMSnapshotFile`; update `restoreSnapshotState` and `stateMachineSnapshotBytes` (bootstrap) |
+| `internal/raftengine/etcd/engine.go` | Update `persistLocalSnapshot`, `persistConfigSnapshot`, and `persistConfigSnapshotPayload` to use `writeFSMSnapshotFile` + token; add `fsmSnapDir` and `snapReceiveGroup` fields |
+| `internal/raftengine/etcd/grpc_transport.go` | Detect token in `Dispatch` → file-streaming send; update `receiveSnapshotStream` to write chunks to file with `singleflight` serialization and `syncDir` |
+| `internal/raftengine/etcd/snapshot_spool.go` | Remove `snapshotSpool` (Phase 3) |
 
 ### Code Removed
 
@@ -407,35 +487,61 @@ writeFSMSnapshotFile():
   6. syncDir(fsmSnapDir)                             # persist directory entry
 ```
 
-`persist.SaveSnap(snap{Data: token})` is called only after the rename succeeds.
-Because the `.fsm` file is committed before the token is written to the WAL or snap
-file, the following crash scenarios are all safely recoverable:
+`persist.SaveSnap(snap{Data: token})` is called **only after step 6 succeeds**.
+The receiver path (`receiveSnapshotStream`) follows the same sequence and also calls
+`syncDir(fsmSnapDir)` after rename.
 
 | State at crash | Recovery |
 |----------------|----------|
-| Only `.fsm.tmp` exists | Deleted by startup cleanup (treated as orphan) |
+| Only `.fsm.tmp` exists | Deleted by startup cleanup (orphan) |
 | `.fsm` exists, snap not yet saved | Snap points to previous index; next snapshot overwrites |
-| snap(token) exists, `.fsm` missing | Token dereferences a missing file → error → WAL replay fallback |
-| `.fsm` CRC mismatch | Treated as corrupt orphan; deleted at startup; WAL replay fallback |
+| snap(token) exists, `.fsm` missing | `ErrFSMSnapshotNotFound` → WAL replay from `FirstIndex` |
+| `.fsm` footer CRC mismatch | `ErrFSMSnapshotFileCRC` → delete file; WAL replay |
+| `.fsm` footer ok, token CRC differs | `ErrFSMSnapshotTokenCRC` → rewrite token; restore from file |
 
 ### Startup Cleanup
 
-Similar to `cleanupStaleSnapshotSpools`, a new `cleanupStaleFSMSnaps(fsmSnapDir)` removes
-any `*.fsm.tmp` files left by a previously crashed process. `.fsm` files whose CRC does
-not match any live token are also removed, since WAL replay can reconstruct the FSM
-without them.
+`cleanupStaleFSMSnaps(snapDir, fsmSnapDir)` runs at engine open time and:
+
+1. Removes all `*.fsm.tmp` (orphans from a previous crash).
+2. Enumerates all live snap tokens by reading `*.snap` files in `snapDir`.
+3. Removes any `.fsm` file whose index does not correspond to a live token — this handles
+   the case where a `.fsm` was written but the corresponding `.snap` was never saved
+   (upgrade crash), as well as files left over after purge ordering bugs in older versions.
+4. For each remaining `.fsm` file, calls `verifyFSMSnapshotFile` and removes files where
+   `ErrFSMSnapshotFileCRC` is returned (corrupt files cannot be used for restore).
+
+This index-based orphan detection is stricter than a CRC-only check: a file with a valid
+CRC but no matching token is still an orphan and must be removed.
 
 ---
 
 ## File Retention Policy
 
+### Coordinated Purge
+
+Snap files and FSM files **must always be purged together** in a single function.
+Calling them independently risks deleting a `.fsm` file while its token `.snap` still
+exists, which makes the node unrecoverable if the WAL has already been compacted.
+
+```go
+// purgeOldSnapshotFiles removes old snap and fsm files in tandem, always deleting
+// the snap file BEFORE its corresponding fsm file. This ordering guarantees that
+// no live token can ever reference a deleted fsm file.
+func purgeOldSnapshotFiles(snapDir, fsmSnapDir string) error {
+    // 1. List all snap files sorted oldest-first.
+    // 2. Keep the newest defaultMaxSnapFiles (3); mark the rest for deletion.
+    // 3. For each file to delete:
+    //    a. os.Remove(snapFile)      ← snap first
+    //    b. os.Remove(fsmFile)       ← fsm second
+    //    A crash between a and b leaves a .fsm with no token: treated as orphan on
+    //    next startup and removed by cleanupStaleFSMSnaps.
+    // 4. syncDir(snapDir) and syncDir(fsmSnapDir).
+}
 ```
-purgeOldFSMSnapFiles(fsmSnapDir):
-  - Retain the same count as snap files: defaultMaxSnapFiles = 3
-  - Match .fsm files to snap files by index; delete in tandem
-  - Always delete the snap file before its corresponding .fsm file
-    (reverse order risks leaving a token that points to a deleted file)
-```
+
+`purgeOldSnapshotFiles` is the **only** call site for deleting either type of file.
+The existing `purgeOldSnapFiles` function is removed and replaced entirely.
 
 ---
 
@@ -460,6 +566,11 @@ func isSnapshotToken(data []byte) bool {
 - The next snapshot creation writes a new-format `.fsm` file with CRC
 - No manual migration step is required
 
+**Orphan `.fsm` files during upgrade rollback:**
+If a node begins writing `.fsm` files and then rolls back to the previous binary, the
+`.fsm` files have no corresponding token in the legacy `.snap` files.
+`cleanupStaleFSMSnaps` removes them by walking live tokens, so rollback is safe.
+
 **When a follower receives a legacy-format MsgSnap:**
 - `isSnapshotToken` returns false → restore via `bytes.NewReader` (no CRC check)
 - Compatible with rolling upgrades where not all nodes have been updated yet
@@ -473,6 +584,9 @@ func isSnapshotToken(data []byte) bool {
 - **Peak memory**: spikes caused by snapshot creation drop to near zero
 - **Resident memory**: `MemoryStorage` snapshot footprint reduced to 17 bytes
 - **I/O**: eliminates the spool → Bytes → SaveSnap double-write; total disk I/O decreases
+- **Single-pass restore**: `io.TeeReader` combines CRC verification and FSM restore into
+  one sequential scan, eliminating the double-read present in a naive verify-then-restore
+  design
 - **gRPC send**: existing `sendSnapshotReaderChunks` accepts `io.Reader` as-is
 - **No upstream dependency**: no changes to etcd-raft protobuf or library code
 
@@ -480,9 +594,12 @@ func isSnapshotToken(data []byte) bool {
 
 | Risk | Mitigation |
 |------|-----------|
-| `.fsm` and snap file inconsistency | `persist.SaveSnap` is called only after successful rename; ordering is strict |
-| Disk space increase | `.fsm` files are roughly the same size as the former `.snap` payloads; net usage is unchanged |
-| Increased code complexity | `isSnapshotToken` branch is small; legacy path is preserved intact |
+| `.fsm` and snap file inconsistency | `persist.SaveSnap` only after `syncDir`; single `purgeOldSnapshotFiles` function enforces deletion ordering |
+| Stale local snapshot overwriting newer follower state | `storageIndex` captured before `fsm.Snapshot()`; `persistLocalSnapshotPayload` staleness guard uses the same baseline |
+| Concurrent follower receive for same index | `singleflight.Group` keyed on index in `receiveSnapshotStream` |
+| TOCTOU between verify and restore | `openAndRestoreFSMSnapshot` holds a single fd across the entire verify+restore operation |
+| `Metadata.Index` diverging from `.fsm` content in config snapshots | `persistConfigSnapshot` migrated in Phase 1; FSM snapshot taken with the same index used as the file name and token |
+| Disk space increase | `.fsm` files are the same size as the former `.snap` payloads; net usage unchanged |
 | CRC false negatives | CRC32C has a 1-in-2³² collision rate; adequate for accidental corruption detection |
 
 ---
@@ -491,35 +608,96 @@ func isSnapshotToken(data []byte) bool {
 
 ### Phase 1: Local Snapshot Disk Offload
 
-Scope: local creation and local restore only. Follower send/receive is unchanged.
+Scope: local creation and local restore for **all three snapshot paths** (periodic,
+config-change, and bootstrap). Follower send/receive is unchanged.
+
+**Implementation tasks:**
 
 - Create `fsm_snapshot_file.go`:
-  - `crc32CWriter` (streaming CRC computation)
-  - `writeFSMSnapshotFile` (write with CRC footer)
-  - `verifyFSMSnapshotFile` (CRC verification)
-  - `newCRC32CStripFooterReader` (expose payload without footer)
-  - `encodeSnapshotToken` / `decodeSnapshotToken` (17-byte token including CRC)
-- Update `persistLocalSnapshot` to use `writeFSMSnapshotFile` + token
-- Update `restoreSnapshotState` to handle token format with CRC verification
+  - `crc32CWriter` (streaming CRC writer)
+  - `writeFSMSnapshotFile` (write with CRC footer + syncDir)
+  - `openAndRestoreFSMSnapshot` (single-pass verify+restore via TeeReader)
+  - `verifyFSMSnapshotFile` (read-only CRC check for orphan detection)
+  - `encodeSnapshotToken` / `decodeSnapshotToken` (17-byte token with CRC)
+  - Error types: `ErrFSMSnapshotFileCRC`, `ErrFSMSnapshotTokenCRC`, etc.
+- Update `persistLocalSnapshot` → `writeFSMSnapshotFile` + token
+- Update `persistConfigSnapshot` / `persistConfigSnapshotPayload` → same
+- Update `stateMachineSnapshotBytes` (bootstrap) → `writeFSMSnapshotFile` + token
+- Update `restoreSnapshotState` → `openAndRestoreFSMSnapshot`
+- Replace `purgeOldSnapFiles` with `purgeOldSnapshotFiles(snapDir, fsmSnapDir)`
+- Add `cleanupStaleFSMSnaps(snapDir, fsmSnapDir)` (index-based orphan removal)
+- Capture `storageIndex` before `fsm.Snapshot()` in `maybePersistLocalSnapshot`
 - All existing tests must continue to pass
 
-**Effect**: eliminates memory spikes during local snapshot creation; reduces `MemoryStorage` resident memory
+**Effect**: eliminates memory spikes during local snapshot creation; reduces
+`MemoryStorage` resident memory; all snapshot creation paths are consistent.
 
 ### Phase 2: Streaming Follower Send/Receive
 
 Scope: update `GRPCTransport` MsgSnap paths to use file streaming.
 
-- `Dispatch`: detect token → open file → `sendSnapshotFileChunks`
-- `receiveSnapshotStream`: write chunks to temp file → verify CRC → atomic rename
+**Implementation tasks:**
+
+- `Dispatch`: detect token → open `.fsm` file → `sendSnapshotFileChunks`
+- `receiveSnapshotStream`:
+  - Write chunks to temp file (with `bufio.NewWriterSize`)
+  - `verifyFSMSnapshotFile` on tmp before rename
+  - `syncDir(fsmSnapDir)` after rename
+  - `singleflight.Group` keyed on index to serialize concurrent receives
+- `applyReadySnapshot`: use `openAndRestoreFSMSnapshot` (no extra verify call)
 - Test legacy-format compatibility paths
 
-**Effect**: eliminates memory spikes during large snapshot transfers to followers
+**Effect**: eliminates memory spikes during large snapshot transfers to followers;
+removes three-read-pass anti-pattern on the receive side.
 
 ### Phase 3: Cleanup
 
 - Remove `snapshotBytesAndClose`, `snapshotBytes`, and `snapshotSpool`
+- Remove standalone `purgeOldSnapFiles` (replaced by `purgeOldSnapshotFiles`)
 - Resolve `maxSnapshotPayloadBytes`
 - Update documentation
+
+---
+
+## Required Tests
+
+### P0 — Must have before Phase 1 merge
+
+| Test | What it verifies |
+|------|-----------------|
+| `TestTokenRoundTrip` | `encodeSnapshotToken` / `decodeSnapshotToken` round-trip for boundary values (`0`, `MaxUint64`, `MaxUint32`) |
+| `TestTokenMagicRejection` | `isSnapshotToken` returns false for non-`EKVR` prefixes; `decodeSnapshotToken` returns `ErrFSMSnapshotTokenInvalid` for lengths 0–16 and wrong magic |
+| `TestCRCWriterMatchesStdlib` | `crc32CWriter.Sum32()` matches `crc32.Checksum` for identical bytes; incremental writes accumulate correctly |
+| `TestOpenAndRestoreFSMSnapshotGoodFile` | Correct file restores FSM state without error |
+| `TestOpenAndRestoreFSMSnapshotBadFooter` | Footer byte flipped → `ErrFSMSnapshotFileCRC` |
+| `TestOpenAndRestoreFSMSnapshotTokenMismatch` | File footer ok, wrong `tokenCRC` → `ErrFSMSnapshotTokenCRC` |
+| `TestOpenAndRestoreFSMSnapshotTooSmall` | File shorter than 4 bytes → `ErrFSMSnapshotTooSmall` |
+| `TestStripFooterReaderBoundary` | `io.TeeReader` with `LimitReader(size-4)` exposes exactly the payload; footer bytes not passed to FSM |
+| `TestCrashAfterTmpBeforeRename` | A leftover `*.fsm.tmp` is deleted by `cleanupStaleFSMSnaps`; no `.fsm` is promoted |
+| `TestSnapSavedOnlyAfterRename` | `WriteTo` error → no `.snap` token written, no `.fsm` final file committed |
+| `TestPurgeOldSnapshotFilesOrdering` | `purgeOldSnapshotFiles` always removes `.snap` before `.fsm`; verified by intercepting `os.Remove` calls |
+| `TestCleanupStaleFSMSnapsIndexBased` | Orphan `.fsm` with no matching live token is removed even when its CRC is valid |
+
+### P1 — High value, ship in Phase 2 or immediately after
+
+| Test | What it verifies |
+|------|-----------------|
+| `TestReceiveTruncatedFile` | Stream ending mid-file → `ErrFSMSnapshotFileCRC`; no `.fsm` committed |
+| `TestReceiveWrongCRCInFooter` | Correct length, corrupted footer → verify rejects before rename |
+| `TestReceiveTokenCRCMismatchesFileCRC` | Token carries wrong CRC, file footer is self-consistent → `ErrFSMSnapshotTokenCRC` in `openAndRestoreFSMSnapshot` |
+| `TestConcurrentReceiveSameIndex` | Two goroutines receiving the same index via `singleflight`; only one `.fsm` committed; no torn file |
+| `TestLegacyFormatFallbackOnRestore` | `snap.Data` without `EKVR` prefix → `bytes.NewReader` path; no `.fsm` file opened |
+| `TestLegacyFormatFallbackOnSend` | Non-token `MsgSnap` → old `sendSnapshot` path; no file opened from `fsmSnapDir` |
+| `TestSyncDirCalledAfterRename` | Both `writeFSMSnapshotFile` and `receiveSnapshotStream` call `syncDir` after rename (verified via mock or filesystem hook) |
+| Conformance `SnapshotRestoreAfterRestart` | Propose 10,001 entries, close engine, reopen; assert FSM state recovered from `.fsm` snapshot (not WAL replay) |
+
+### P2 — Nice to have
+
+| Test | What it verifies |
+|------|-----------------|
+| `FuzzTokenEncodeDecode` | `decodeSnapshotToken` never panics on arbitrary 17-byte input; round-trips for valid tokens |
+| `FuzzOpenAndRestoreFSMSnapshot` | Arbitrary file content → only typed errors returned, never panics |
+| `TestConcurrentSnapshotAndEngineClose` | Snapshot worker crash on engine close leaves no torn file |
 
 ---
 

--- a/docs/etcd_snapshot_disk_offload_design.md
+++ b/docs/etcd_snapshot_disk_offload_design.md
@@ -109,8 +109,8 @@ After:  Data = [magic:4][version:1][index:8][crc32c:4]
 |---------|--------|-------|
 | magic   | 4 byte | `EKVT` (ElasticKV Token) |
 | version | 1 byte | `0x01` |
-| index   | 8 byte | applied log index of the snapshot (little-endian uint64) |
-| crc32c  | 4 byte | CRC32C checksum of the `.fsm` file payload (all bytes preceding the footer) (little-endian uint32) |
+| index   | 8 byte | applied log index of the snapshot (big-endian uint64) |
+| crc32c  | 4 byte | CRC32C checksum of the `.fsm` file payload (all bytes preceding the footer) (big-endian uint32) |
 
 The magic prefix distinguishes the new format from legacy payloads (see Migration section).
 Embedding the CRC32C in the token allows integrity verification at the metadata level,
@@ -136,7 +136,7 @@ before the file is even opened.
   ├── lastCommitTS: 8 bytes  (little-endian uint64)
   └── entries:      variable [keyLen:8][key][valLen:8][val] repeated
 [footer]
-  └── crc32c:       4 bytes  CRC32C of all bytes preceding this field (little-endian uint32)
+  └── crc32c:       4 bytes  CRC32C of all bytes preceding this field (big-endian uint32)
 ```
 
 The CRC32C is computed incrementally as data is written, so no second pass over the file
@@ -201,10 +201,10 @@ maybePersistLocalSnapshot()
   → storageIndex := storage.Snapshot().Metadata.Index
   → fsmSnap := fsm.Snapshot()
   → crc32c, err := writeFSMSnapshotFile(fsmSnap, fsmSnapDir, storageIndex)
-      → os.CreateTemp() → {fsmSnapDir}/{storageIndex}.fsm.tmp
+      → os.CreateTemp() → {fsmSnapDir}/{storageIndex:016x}.fsm.tmp
       → crcWriter := newCRC32CWriter(tmpFile)
       → fsmSnap.WriteTo(crcWriter)                              # stream to disk + compute CRC
-      → binary.Write(tmpFile, binary.LittleEndian, crcWriter.Sum32()) # append CRC footer
+      → binary.Write(tmpFile, binary.BigEndian, crcWriter.Sum32()) # append CRC footer
       → tmpFile.Sync()
       → os.Rename(tmp, final)                                   # atomic commit
       → syncDir(fsmSnapDir)                                     # persist directory entry
@@ -286,7 +286,7 @@ func openAndRestoreFSMSnapshot(fsm StateMachine, path string, tokenCRC uint32) e
         return errors.WithStack(err)
     }
     var footer uint32
-    if err := binary.Read(f, binary.LittleEndian, &footer); err != nil {
+    if err := binary.Read(f, binary.BigEndian, &footer); err != nil {
         return errors.WithStack(err)
     }
     computed := h.Sum32()
@@ -369,16 +369,17 @@ receiveSnapshotStream()
   → validate token.Index == snap.Metadata.Index
     # a mismatch indicates a misrouted or corrupted snapshot; return
     # ErrFSMSnapshotIndexMismatch immediately before writing any data
-  → result, err := snapReceiveGroup.Do(strconv.FormatUint(index, 10), func() {
-        → os.CreateTemp() → {fsmSnapDir}/{index}.fsm.tmp
+  → result, err := snapReceiveGroup.Do(fmt.Sprintf("%016x", index), func() {
+        → os.CreateTemp() → {fsmSnapDir}/{index:016x}.fsm.tmp
         → stream remaining chunks to tmpFile (with bufio.NewWriterSize)
         → tmpFile.Sync()
         → verify CRC of tmpPath against footer and tokenCRC
           # footer is authoritative; return ErrFSMSnapshotFileCRC if mismatch
-        → os.Rename(tmpPath, {fsmSnapDir}/{index}.fsm)  # atomic commit on success
-        → syncDir(fsmSnapDir)                           # flush directory entry
-        → return token
+        → os.Rename(tmpPath, {fsmSnapDir}/{index:016x}.fsm)  # atomic commit on success
+        → syncDir(fsmSnapDir)                                # flush directory entry
+        → return token  # []byte — the 17-byte token built from the received header
     })
+  → token := result.([]byte)  # extract from singleflight result
   → raftpb.Message{Snapshot: {Data: token}}
   → handler(msg)
       → applyReadySnapshot(snap)
@@ -440,9 +441,9 @@ function:
 4. Returns typed errors distinguishing file corruption (`ErrFSMSnapshotFileCRC`) from
    token corruption (`ErrFSMSnapshotTokenCRC`).
 
-A standalone `verifyFSMSnapshotFile(path, tokenCRC)` is still provided for contexts where
-the FSM must not be modified (e.g., startup cleanup health-checking orphan files), but it
-is **never called in sequence with a subsequent restore**.
+A standalone `verifyFSMSnapshotFile(path, tokenCRC)` is still provided for use in
+`receiveSnapshotStream` (verify the temp file before atomic rename) and future background
+health-check tasks, but it is **never called in sequence with a subsequent restore**.
 
 ### Verification Points
 
@@ -451,7 +452,7 @@ is **never called in sequence with a subsequent restore**.
 | **On restart** | `restoreSnapshotState` | `openAndRestoreFSMSnapshot` (single pass) |
 | **After follower receive** | `receiveSnapshotStream` | `verifyFSMSnapshotFile` on tmp before rename |
 | **On follower apply** | `applyReadySnapshot` | `openAndRestoreFSMSnapshot` (single pass; no extra verify) |
-| **Startup orphan check** | `cleanupStaleFSMSnaps` | `verifyFSMSnapshotFile` (read-only, no restore) |
+| **Startup orphan check** | `cleanupStaleFSMSnaps` | Index-based only; no CRC scan (deferred to restore time) |
 | **Background health check** *(future)* | background task | `verifyFSMSnapshotFile` |
 
 ### Error Types and Recovery
@@ -469,7 +470,7 @@ var (
 | Error | Meaning | Recovery |
 |-------|---------|---------|
 | `ErrFSMSnapshotFileCRC` | On-disk file is corrupt; footer ≠ computed | Delete file; WAL replay from `FirstIndex` |
-| `ErrFSMSnapshotTokenCRC` | File is intact (footer == computed) but token differs | Rewrite token from file's actual CRC; no WAL replay needed |
+| `ErrFSMSnapshotTokenCRC` | File is intact (footer == computed) but token differs | Read footer CRC from file; call `Snapshotter.SaveSnap` with `encodeSnapshotToken(index, fileCRC)`; restore from the intact file without WAL replay |
 | `ErrFSMSnapshotNotFound` | `.fsm` file missing for a valid token | WAL replay from `FirstIndex` |
 
 ---
@@ -507,7 +508,7 @@ var (
 writeFSMSnapshotFile():
   1. os.CreateTemp(fsmSnapDir, "*.fsm.tmp")         # write to temp file
   2. snapshot.WriteTo(crcWriter)                     # stream FSM + accumulate CRC
-  3. binary.Write(tmpFile, binary.LittleEndian, crcWriter.Sum32()) # append CRC footer
+  3. binary.Write(tmpFile, binary.BigEndian, crcWriter.Sum32()) # append CRC footer
   4. tmpFile.Sync()                                  # flush to durable storage
   5. os.Rename(tmp, final)                           # atomic commit
   6. syncDir(fsmSnapDir)                             # persist directory entry
@@ -523,7 +524,7 @@ The receiver path (`receiveSnapshotStream`) follows the same sequence and also c
 | `.fsm` exists, snap not yet saved | Snap points to previous index; next snapshot overwrites |
 | snap(token) exists, `.fsm` missing | `ErrFSMSnapshotNotFound` → WAL replay from `FirstIndex` |
 | `.fsm` footer CRC mismatch | `ErrFSMSnapshotFileCRC` → delete file; WAL replay |
-| `.fsm` footer ok, token CRC differs | `ErrFSMSnapshotTokenCRC` → rewrite token; restore from file |
+| `.fsm` footer ok, token CRC differs | `ErrFSMSnapshotTokenCRC` → `Snapshotter.SaveSnap` with corrected token; restore from file; no WAL replay |
 
 ### Startup Cleanup
 
@@ -642,7 +643,7 @@ dangerous scenario. To prevent it, the rollout must proceed as follows:
    // snapshot — not on every periodic creation — so peak memory is still improved.
    if isSnapshotToken(msg.Snapshot.Data) {
        tok, _ := decodeSnapshotToken(msg.Snapshot.Data)
-       path := filepath.Join(fsmSnapDir, strconv.FormatUint(tok.Index, 10)+".fsm")
+       path := filepath.Join(fsmSnapDir, fmt.Sprintf("%016x.fsm", tok.Index))
        payload, err := readFSMSnapshotPayload(path) // streams file, returns []byte
        if err != nil {
            return errors.WithStack(err)
@@ -685,6 +686,54 @@ transition window: `raftpb.Snapshot.Data` = token AND a copy of the full legacy 
 stored in an auxiliary file. The legacy binary would then decode the full payload
 normally. This dual-write mode is a forward compatibility bridge and can be removed after
 the fleet has been fully upgraded.
+
+### Zero-Downtime Cutover Runbook
+
+For a Raft cluster, the standard zero-downtime approach is a **rolling upgrade**: replace
+one node at a time, verify health, then proceed to the next. The feature flag provides
+the safety valve at each step. Below is the recommended procedure for a 3-node cluster
+(`nodeA`, `nodeB`, `nodeC`).
+
+**Phase 1 rollout (safe in mixed clusters):**
+
+```
+1. Deploy Phase 1 binary to nodeA; restart.
+   - nodeA starts writing .fsm files locally.
+   - nodeA's Dispatch fallback reads .fsm → bytes for any legacy-receiver MsgSnap.
+   - Verify: cluster healthy, no error logs for ErrFSMSnapshotFileCRC.
+
+2. Repeat for nodeB, then nodeC.
+   - All nodes now write .fsm files. Mixed Phase 1 / legacy is safe throughout.
+
+3. Run for at least one full snapshot cycle per node before proceeding to Phase 2.
+   Confirm: each node's fsm-snap/ directory contains a valid .fsm file.
+```
+
+**Phase 2 rollout (requires all nodes on Phase 1 first):**
+
+```
+4. Deploy Phase 2 binary to all nodes with DisableFSMSnapshotToken=true.
+   - Nodes use file streaming internally but Dispatch still reconstructs full payload
+     (feature flag active). This is a no-op from the wire perspective.
+   - Verify: cluster healthy.
+
+5. Enable token mode on nodeA: set DisableFSMSnapshotToken=false (hot reload or restart).
+   - nodeA now sends token-format MsgSnap; all receivers must be Phase 2 (they are).
+   - Monitor for one snapshot cycle. Verify follower applies succeed.
+
+6. Enable on nodeB, then nodeC.
+   - All nodes now use full token-mode streaming.
+
+7. Remove the DisableFSMSnapshotToken flag from config (it now defaults to false).
+```
+
+**Rollback at any step:**
+
+| Step | Rollback action |
+|------|----------------|
+| During Phase 1 rollout | Redeploy legacy binary; stop node first; delete `fsm-snap/`; restart (WAL replay) |
+| Phase 2 deployed, flag still enabled | Redeploy Phase 1 binary; no fsm-snap cleanup needed |
+| Phase 2 deployed, flag disabled on some nodes | Re-enable `DisableFSMSnapshotToken=true` on flag-disabled nodes first; then redeploy Phase 1 binaries |
 
 ---
 

--- a/docs/etcd_snapshot_disk_offload_design.md
+++ b/docs/etcd_snapshot_disk_offload_design.md
@@ -1,0 +1,531 @@
+# etcd Engine: FSM Snapshot Disk Offload Design
+
+## Background and Problem
+
+### Observed Symptoms
+
+Clusters using the etcd engine exhibit large memory spikes across all nodes at snapshot
+creation intervals (`defaultSnapshotEvery = 10,000` entries). The spike magnitude scales
+with FSM data size, and simultaneous spikes across multiple nodes compound the pressure.
+
+### Root Cause
+
+The current implementation stores the entire FSM state as a `[]byte` in
+`raftpb.Snapshot.Data`. Because the etcd-raft protobuf API requires this type, there are
+three distinct points of excessive memory consumption.
+
+#### Problem 1: Peak allocation during snapshot creation
+
+```
+internal/raftengine/etcd/wal_store.go: snapshotBytes()
+
+FSM.WriteTo(spool)   → write to a temporary file on disk
+spool.Bytes()        → io.ReadAll materializes the entire payload as []byte  ← spike
+persist.SaveSnap()   → write to disk again (redundant copy)
+```
+
+`snapshotSpool` already avoids a second in-memory buffer during serialization, but the
+final `spool.Bytes()` call still materializes the entire dataset at once.
+
+#### Problem 2: Sustained retention in MemoryStorage
+
+```go
+storage.CreateSnapshot(applied, &confState, payload)
+```
+
+`MemoryStorage` holds `raftpb.Snapshot.Data = payload` until the next snapshot is created
+(i.e., until another 10,000 entries are processed), keeping the full FSM export resident
+in memory the entire time.
+
+#### Problem 3: Re-allocation when sending to followers
+
+```go
+// grpc_transport.go: sendSnapshot()
+header, payload, err := splitSnapshotMessage(msg)
+// payload = msg.Snapshot.Data  ← []byte extracted from MemoryStorage
+```
+
+Sending `MsgSnap` to a follower extracts `Data` from `MemoryStorage` and expands it into
+memory again.
+
+### Official etcd Position
+
+In etcd-io/etcd#9000 ("Snapshot splitting"), core contributor @xiang90 explicitly
+recommended the following architecture:
+
+> The suggested way to handle the problem you described is to **always only include
+> metadata into the raft snapshot message, and use a side-channel to supply the actual
+> application snapshot**.
+
+This design follows that recommendation: `raftpb.Snapshot.Data` carries only a small
+reference token, and FSM data is managed entirely on disk.
+
+---
+
+## Design Goals
+
+| Goal | Detail |
+|------|--------|
+| **Eliminate peak memory** | Remove `spool.Bytes()`; never materialize FSM data as `[]byte` |
+| **Eliminate sustained memory** | `MemoryStorage` holds only a 17-byte token, not the full FSM |
+| **No upstream changes** | etcd-raft `raftpb` API is unchanged; no upstream PR needed |
+| **Reuse existing gRPC transport** | `sendSnapshotReaderChunks` already accepts `io.Reader` |
+| **Crash safety** | A node crash during write must never produce a corrupt or partially-applied snapshot |
+| **Corruption detection** | CRC32C on every `.fsm` file; verified at write, restore, and receive |
+
+### Non-Goals
+
+- Changes to etcd-io/raft upstream
+- Any impact on the hashicorp engine
+- Changes to the WAL format
+
+---
+
+## Proposed Architecture
+
+### File Layout
+
+```
+{dataDir}/
+├── wal/                           # unchanged
+│   └── *.wal
+├── snap/                          # unchanged (raft snap metadata)
+│   └── 0000000100000064.snap      # raftpb.Snapshot{Data: token, Metadata: ...}
+└── fsm-snap/                      # new directory
+    ├── 0000000000000064.fsm       # FSM payload (Pebble key-value stream + CRC32C footer)
+    └── 0000000000000064.fsm.tmp   # in-flight write; renamed to .fsm on atomic commit
+```
+
+### `raftpb.Snapshot.Data` Token Format
+
+```
+Before: Data = full FSM payload (variable length, up to 1 GiB)
+
+After:  Data = [magic:4][version:1][index:8][crc32c:4]
+               17 bytes, fixed size
+```
+
+| Field   | Size   | Value |
+|---------|--------|-------|
+| magic   | 4 byte | `EKVR` (ElasticKV Reference) |
+| version | 1 byte | `0x01` |
+| index   | 8 byte | applied log index of the snapshot (little-endian uint64) |
+| crc32c  | 4 byte | CRC32C checksum of the entire `.fsm` file (little-endian uint32) |
+
+The magic prefix distinguishes the new format from legacy payloads (see Migration section).
+Embedding the CRC32C in the token allows integrity verification at the metadata level,
+before the file is even opened.
+
+### `.fsm` File Format
+
+```
+[Pebble snapshot stream (existing format)]
+  ├── magic:        8 bytes  {'E','K','V','P','B','B','L','1'}
+  ├── lastCommitTS: 8 bytes  (little-endian uint64)
+  └── entries:      variable [keyLen:8][key][valLen:8][val] repeated
+[footer]
+  └── crc32c:       4 bytes  CRC32C of all bytes preceding this field (little-endian uint32)
+```
+
+The CRC32C is computed incrementally as data is written, so no second pass over the file
+is needed to finalize the checksum.
+
+**Algorithm choice: CRC32C (Castagnoli)**
+
+This is the same algorithm used by etcd's `Snapshotter`
+(`etcdserver/api/snap/snapshotter.go`). It is hardware-accelerated on both x86
+(SSE4.2 `CRC32` instruction) and ARM64 (ARMv8.1 `CRC32C`), delivering throughput in the
+range of several GB/s with negligible CPU overhead. The Go standard library exposes it as
+`hash/crc32.MakeTable(crc32.Castagnoli)`.
+
+---
+
+## Flow Changes
+
+### 1. Local Snapshot Creation
+
+**Before:**
+```
+maybePersistLocalSnapshot()
+  → fsm.Snapshot()
+  → snapshotBytesAndClose()
+      → spool.WriteTo()        # write to temp file on disk
+      → spool.Bytes()          # ← problem: io.ReadAll materializes full []byte
+  → persist.SaveSnap(snap{Data: payload})  # write to disk again
+  → storage.CreateSnapshot(_, _, payload)  # hold in MemoryStorage
+```
+
+**After:**
+```
+maybePersistLocalSnapshot()
+  → fsm.Snapshot()
+  → writeFSMSnapshotFile(snapshot, fsmSnapDir, index)
+      → os.CreateTemp() → {fsmSnapDir}/{index}.fsm.tmp
+      → crcWriter := newCRC32CWriter(tmpFile)
+      → snapshot.WriteTo(crcWriter)                               # stream to disk + compute CRC
+      → binary.Write(tmpFile, LittleEndian, crcWriter.Sum32())   # append CRC footer
+      → tmpFile.Sync() → os.Rename(tmp, final)                   # atomic commit
+      → return crcWriter.Sum32()
+  → token := encodeSnapshotToken(index, crc32c)  # 17 bytes
+  → persist.SaveSnap(snap{Data: token})          # small snap file
+  → storage.CreateSnapshot(_, _, token)          # MemoryStorage: 17 bytes only
+  → purgeOldFSMSnapFiles(fsmSnapDir)
+```
+
+**Memory impact:**
+- Peak: FSM data size → 0 (direct disk write only)
+- Resident: FSM data size → 17 bytes
+
+### 2. Restore on Restart
+
+**Before:**
+```
+loadWalState()
+  → snapshotter.LoadNewestAvailable()
+  → restoreSnapshotState(fsm, snap)
+      → fsm.Restore(bytes.NewReader(snap.Data))  # snap.Data is the full FSM payload
+```
+
+**After:**
+```
+loadWalState()
+  → snapshotter.LoadNewestAvailable()
+  → restoreSnapshotState(fsm, snap, fsmSnapDir)
+      → if isSnapshotToken(snap.Data):
+            index, expectedCRC := decodeSnapshotToken(snap.Data)
+            path := fsmSnapPath(fsmSnapDir, index)
+            verifyFSMSnapshotFile(path, expectedCRC)          # fail fast on corruption
+            f := os.Open(path)
+            fsm.Restore(newCRC32CStripFooterReader(f))        # exclude footer from stream
+         else:
+            fsm.Restore(bytes.NewReader(snap.Data))           # legacy format fallback
+```
+
+`verifyFSMSnapshotFile` reads the file sequentially, computes the CRC incrementally, and
+compares it against both the on-disk footer and the `expectedCRC` from the token. A
+mismatch returns `ErrFSMSnapshotCRCMismatch` and aborts startup.
+
+### 3. Sending MsgSnap to a Follower
+
+**Before:**
+```
+sendMessages()
+  → Dispatch(msg)
+      → sendSnapshot(msg)
+          → splitSnapshotMessage(msg)   # extracts large msg.Snapshot.Data
+          → sendSnapshotChunks(...)     # sends []byte in chunks
+```
+
+**After:**
+```
+sendMessages()
+  → Dispatch(msg)
+      → if isSnapshotToken(msg.Snapshot.Data):
+            index, _ := decodeSnapshotToken(msg.Snapshot.Data)
+            f := os.Open(fsmSnapPath(fsmSnapDir, index))
+            sendSnapshotFileChunks(stream, header, f)   # stream .fsm file including footer
+         else:
+            sendSnapshot(msg)   # legacy format fallback
+```
+
+The `.fsm` file is sent including its CRC footer. The receiver stores the full file and
+performs CRC verification after all chunks arrive.
+
+### 4. Receiving and Applying MsgSnap on a Follower
+
+**Before:**
+```
+receiveSnapshotStream()
+  → receive all chunks → assemble into []byte
+  → raftpb.Message{Snapshot: {Data: fullBytes}}
+  → handler(msg)
+      → applyReadySnapshot(snap)
+          → fsm.Restore(bytes.NewReader(snap.Data))
+```
+
+**After:**
+```
+receiveSnapshotStream()
+  → receive header chunk → parse token → extract index, expectedCRC
+  → os.CreateTemp() → {fsmSnapDir}/{index}.fsm.tmp
+  → stream remaining chunks to tmpFile
+  → tmpFile.Sync()
+  → verifyFSMSnapshotFile(tmpPath, expectedCRC)              # verify before committing
+  → os.Rename(tmpPath, {fsmSnapDir}/{index}.fsm)             # atomic commit on success
+  → raftpb.Message{Snapshot: {Data: token}}
+  → handler(msg)
+      → applyReadySnapshot(snap)
+          → index, expectedCRC := decodeSnapshotToken(snap.Data)
+          → verifyFSMSnapshotFile(path, expectedCRC)         # second check before apply
+          → fsm.Restore(newCRC32CStripFooterReader(f))
+```
+
+**Why verify immediately after receive:**
+- Detects in-transit bit errors before the file is applied to the FSM
+- Prevents a corrupt file from overwriting a healthy FSM state
+- On failure, report `SnapshotFailure` to prompt the leader to retry
+
+---
+
+## CRC32C Implementation Details
+
+### Writing: Incremental Computation
+
+```go
+var crc32cTable = crc32.MakeTable(crc32.Castagnoli)
+
+// crc32CWriter wraps an io.Writer and computes the CRC32C of all bytes written through
+// it. Call Sum32() after writing is complete to obtain the checksum.
+type crc32CWriter struct {
+    w io.Writer
+    h hash.Hash32
+}
+
+func newCRC32CWriter(w io.Writer) *crc32CWriter {
+    return &crc32CWriter{w: w, h: crc32.New(crc32cTable)}
+}
+
+func (c *crc32CWriter) Write(p []byte) (int, error) {
+    n, err := c.w.Write(p)
+    c.h.Write(p[:n])
+    return n, err
+}
+
+func (c *crc32CWriter) Sum32() uint32 { return c.h.Sum32() }
+```
+
+Passing `crc32CWriter` to `snapshot.WriteTo` computes the CRC without any changes to the
+existing `WriteTo` implementation.
+
+### Reading: Streaming Verification
+
+`verifyFSMSnapshotFile` uses `stat` to determine the file size, then reads
+`(size - 4)` bytes through a CRC accumulator, and compares the result against the
+4-byte footer and the `expectedCRC` from the token. No second read pass is required.
+
+```go
+func verifyFSMSnapshotFile(path string, expectedCRC uint32) error {
+    info, err := os.Stat(path)
+    if err != nil {
+        return errors.WithStack(err)
+    }
+    if info.Size() < 4 {
+        return errors.Wrapf(ErrFSMSnapshotCRCMismatch, "file too small: %d bytes", info.Size())
+    }
+    f, err := os.Open(path)
+    if err != nil {
+        return errors.WithStack(err)
+    }
+    defer f.Close()
+
+    h := crc32.New(crc32cTable)
+    if _, err := io.Copy(h, io.LimitReader(f, info.Size()-4)); err != nil {
+        return errors.WithStack(err)
+    }
+    var footer uint32
+    if err := binary.Read(f, binary.LittleEndian, &footer); err != nil {
+        return errors.WithStack(err)
+    }
+    computed := h.Sum32()
+    if computed != footer {
+        return errors.Wrapf(ErrFSMSnapshotCRCMismatch,
+            "path=%s footer=%08x computed=%08x", path, footer, computed)
+    }
+    if computed != expectedCRC {
+        return errors.Wrapf(ErrFSMSnapshotCRCMismatch,
+            "path=%s token=%08x computed=%08x", path, expectedCRC, computed)
+    }
+    return nil
+}
+```
+
+`newCRC32CStripFooterReader` wraps the open file and exposes only the first
+`(size - 4)` bytes to the FSM's `Restore` call so the footer is not interpreted as
+key-value data.
+
+### Verification Points
+
+| When | Location | What is checked |
+|------|----------|-----------------|
+| **On restart** | `restoreSnapshotState` | file CRC ↔ footer ↔ token CRC |
+| **After follower receive** | `receiveSnapshotStream` | file CRC ↔ footer ↔ token CRC |
+| **Before follower apply** | `applyReadySnapshot` | token CRC ↔ file CRC (second check) |
+| **Background health check** *(future)* | background task | periodic re-computation of file CRC |
+
+### Error Handling
+
+```go
+var (
+    ErrFSMSnapshotCRCMismatch  = errors.New("fsm snapshot: CRC32C mismatch")
+    ErrFSMSnapshotNotFound     = errors.New("fsm snapshot: file not found")
+    ErrFSMSnapshotTokenInvalid = errors.New("fsm snapshot: token format invalid")
+)
+```
+
+- `ErrFSMSnapshotCRCMismatch`: log `{path, expected, actual}` and abort the operation.
+  - On startup: attempt WAL replay from `FirstIndex` before giving up.
+  - On follower receive: report `SnapshotFailure`; the leader will retry.
+
+---
+
+## Key Implementation Changes
+
+### New File
+
+| File | Contents |
+|------|----------|
+| `internal/raftengine/etcd/fsm_snapshot_file.go` | FSM snapshot file read/write, CRC32C computation and verification, token encode/decode |
+
+### Changes to Existing Files
+
+| File | Change |
+|------|--------|
+| `internal/raftengine/etcd/wal_store.go` | Remove `snapshotBytes`; add `writeFSMSnapshotFile`; update `restoreSnapshotState` to handle token format |
+| `internal/raftengine/etcd/engine.go` | Replace payload retrieval in `persistLocalSnapshot` with `writeFSMSnapshotFile`; add `fsmSnapDir` field |
+| `internal/raftengine/etcd/grpc_transport.go` | Detect token in `Dispatch` → route to file-streaming send path; update `receiveSnapshotStream` to write chunks to file |
+| `internal/raftengine/etcd/snapshot_spool.go` | Repurpose or remove `snapshotSpool` |
+
+### Code Removed
+
+- `snapshotBytesAndClose()` — the `[]byte` materialization path is no longer needed
+- `snapshotBytes()` — same
+- `maxSnapshotPayloadBytes` — file size bounds are delegated to the OS / disk quota
+
+---
+
+## Crash Safety
+
+### Write-time Crash Protection
+
+```
+writeFSMSnapshotFile():
+  1. os.CreateTemp(fsmSnapDir, "*.fsm.tmp")         # write to temp file
+  2. snapshot.WriteTo(crcWriter)                     # stream FSM + accumulate CRC
+  3. binary.Write(tmpFile, LE, crcWriter.Sum32())    # append CRC footer
+  4. tmpFile.Sync()                                  # flush to durable storage
+  5. os.Rename(tmp, final)                           # atomic commit
+  6. syncDir(fsmSnapDir)                             # persist directory entry
+```
+
+`persist.SaveSnap(snap{Data: token})` is called only after the rename succeeds.
+Because the `.fsm` file is committed before the token is written to the WAL or snap
+file, the following crash scenarios are all safely recoverable:
+
+| State at crash | Recovery |
+|----------------|----------|
+| Only `.fsm.tmp` exists | Deleted by startup cleanup (treated as orphan) |
+| `.fsm` exists, snap not yet saved | Snap points to previous index; next snapshot overwrites |
+| snap(token) exists, `.fsm` missing | Token dereferences a missing file → error → WAL replay fallback |
+| `.fsm` CRC mismatch | Treated as corrupt orphan; deleted at startup; WAL replay fallback |
+
+### Startup Cleanup
+
+Similar to `cleanupStaleSnapshotSpools`, a new `cleanupStaleFSMSnaps(fsmSnapDir)` removes
+any `*.fsm.tmp` files left by a previously crashed process. `.fsm` files whose CRC does
+not match any live token are also removed, since WAL replay can reconstruct the FSM
+without them.
+
+---
+
+## File Retention Policy
+
+```
+purgeOldFSMSnapFiles(fsmSnapDir):
+  - Retain the same count as snap files: defaultMaxSnapFiles = 3
+  - Match .fsm files to snap files by index; delete in tandem
+  - Always delete the snap file before its corresponding .fsm file
+    (reverse order risks leaving a token that points to a deleted file)
+```
+
+---
+
+## Migration (Legacy Format Compatibility)
+
+If the first 4 bytes of `raftpb.Snapshot.Data` equal `EKVR`, the payload is treated as a
+token. Any other prefix is treated as a legacy FSM payload.
+
+```go
+const snapshotTokenMagic = [4]byte{'E', 'K', 'V', 'R'}
+
+func isSnapshotToken(data []byte) bool {
+    if len(data) < 4 {
+        return false
+    }
+    return [4]byte(data[:4]) == snapshotTokenMagic
+}
+```
+
+**When a legacy snap file is present on startup:**
+- `isSnapshotToken` returns false → restore via `bytes.NewReader(snap.Data)` (no CRC check)
+- The next snapshot creation writes a new-format `.fsm` file with CRC
+- No manual migration step is required
+
+**When a follower receives a legacy-format MsgSnap:**
+- `isSnapshotToken` returns false → restore via `bytes.NewReader` (no CRC check)
+- Compatible with rolling upgrades where not all nodes have been updated yet
+
+---
+
+## Trade-offs
+
+### Benefits
+
+- **Peak memory**: spikes caused by snapshot creation drop to near zero
+- **Resident memory**: `MemoryStorage` snapshot footprint reduced to 17 bytes
+- **I/O**: eliminates the spool → Bytes → SaveSnap double-write; total disk I/O decreases
+- **gRPC send**: existing `sendSnapshotReaderChunks` accepts `io.Reader` as-is
+- **No upstream dependency**: no changes to etcd-raft protobuf or library code
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| `.fsm` and snap file inconsistency | `persist.SaveSnap` is called only after successful rename; ordering is strict |
+| Disk space increase | `.fsm` files are roughly the same size as the former `.snap` payloads; net usage is unchanged |
+| Increased code complexity | `isSnapshotToken` branch is small; legacy path is preserved intact |
+| CRC false negatives | CRC32C has a 1-in-2³² collision rate; adequate for accidental corruption detection |
+
+---
+
+## Implementation Phases
+
+### Phase 1: Local Snapshot Disk Offload
+
+Scope: local creation and local restore only. Follower send/receive is unchanged.
+
+- Create `fsm_snapshot_file.go`:
+  - `crc32CWriter` (streaming CRC computation)
+  - `writeFSMSnapshotFile` (write with CRC footer)
+  - `verifyFSMSnapshotFile` (CRC verification)
+  - `newCRC32CStripFooterReader` (expose payload without footer)
+  - `encodeSnapshotToken` / `decodeSnapshotToken` (17-byte token including CRC)
+- Update `persistLocalSnapshot` to use `writeFSMSnapshotFile` + token
+- Update `restoreSnapshotState` to handle token format with CRC verification
+- All existing tests must continue to pass
+
+**Effect**: eliminates memory spikes during local snapshot creation; reduces `MemoryStorage` resident memory
+
+### Phase 2: Streaming Follower Send/Receive
+
+Scope: update `GRPCTransport` MsgSnap paths to use file streaming.
+
+- `Dispatch`: detect token → open file → `sendSnapshotFileChunks`
+- `receiveSnapshotStream`: write chunks to temp file → verify CRC → atomic rename
+- Test legacy-format compatibility paths
+
+**Effect**: eliminates memory spikes during large snapshot transfers to followers
+
+### Phase 3: Cleanup
+
+- Remove `snapshotBytesAndClose`, `snapshotBytes`, and `snapshotSpool`
+- Resolve `maxSnapshotPayloadBytes`
+- Update documentation
+
+---
+
+## References
+
+- [etcd-io/etcd#9000 - Snapshot splitting](https://github.com/etcd-io/etcd/issues/9000) — basis for the side-channel architecture recommendation
+- [etcd-io/raft#124 - Clean up and improve snapshot handling](https://github.com/etcd-io/raft/issues/124)
+- `internal/raftengine/etcd/snapshot_spool.go`: comment "the prototype cannot stream snapshots end-to-end yet"
+- `internal/raftengine/etcd/grpc_transport.go`: `sendSnapshotReaderChunks` — existing streaming send implementation

--- a/docs/etcd_snapshot_disk_offload_design.md
+++ b/docs/etcd_snapshot_disk_offload_design.md
@@ -110,7 +110,7 @@ After:  Data = [magic:4][version:1][index:8][crc32c:4]
 | magic   | 4 byte | `EKVT` (ElasticKV Token) |
 | version | 1 byte | `0x01` |
 | index   | 8 byte | applied log index of the snapshot (big-endian uint64) |
-| crc32c  | 4 byte | CRC32C checksum of the `.fsm` file payload (all bytes preceding the footer) (big-endian uint32) |
+| crc32c  | 4 byte | CRC32C checksum of the `.fsm` file payload (bytes preceding the footer) (big-endian uint32) |
 
 The magic prefix distinguishes the new format from legacy payloads (see Migration section).
 Embedding the CRC32C in the token allows integrity verification at the metadata level,
@@ -133,7 +133,7 @@ before the file is even opened.
 ```
 [Pebble snapshot stream (existing format)]
   ├── magic:        8 bytes  {'E','K','V','P','B','B','L','1'}
-  ├── lastCommitTS: 8 bytes  (little-endian uint64)
+  ├── lastCommitTS: 8 bytes  (big-endian uint64)
   └── entries:      variable [keyLen:8][key][valLen:8][val] repeated
 [footer]
   └── crc32c:       4 bytes  CRC32C of all bytes preceding this field (big-endian uint32)
@@ -201,7 +201,7 @@ maybePersistLocalSnapshot()
   → storageIndex := storage.Snapshot().Metadata.Index
   → fsmSnap := fsm.Snapshot()
   → crc32c, err := writeFSMSnapshotFile(fsmSnap, fsmSnapDir, storageIndex)
-      → os.CreateTemp() → {fsmSnapDir}/{storageIndex:016x}.fsm.tmp
+      → os.CreateTemp() → {fsmSnapDir}/{storageIndex}.fsm.tmp
       → crcWriter := newCRC32CWriter(tmpFile)
       → fsmSnap.WriteTo(crcWriter)                              # stream to disk + compute CRC
       → binary.Write(tmpFile, binary.BigEndian, crcWriter.Sum32()) # append CRC footer
@@ -278,10 +278,8 @@ func openAndRestoreFSMSnapshot(fsm StateMachine, path string, tokenCRC uint32) e
     if err := fsm.Restore(br); err != nil {
         return errors.WithStack(err)
     }
-    // Drain any bytes that fsm.Restore left unread (e.g. if it stopped on an
-    // internal end-of-stream marker before consuming the full payload).
-    // Without this, h would have accumulated fewer bytes than the file contains,
-    // producing a spurious CRC mismatch even for a valid file.
+    // Drain any bytes not consumed by fsm.Restore so the CRC accumulator h
+    // covers the full payload before we read the footer.
     if _, err := io.Copy(io.Discard, br); err != nil {
         return errors.WithStack(err)
     }
@@ -366,20 +364,20 @@ receiveSnapshotStream()
 ```
 receiveSnapshotStream()
   → receive header chunk → parse token → extract index, tokenCRC
-  → validate token.Index == snap.Metadata.Index
-    # a mismatch indicates a misrouted or corrupted snapshot; return
-    # ErrFSMSnapshotIndexMismatch immediately before writing any data
-  → result, err := snapReceiveGroup.Do(fmt.Sprintf("%016x", index), func() {
-        → os.CreateTemp() → {fsmSnapDir}/{index:016x}.fsm.tmp
+  # Validate that the token index matches raftpb.SnapshotMetadata.Index to
+  # reject corrupted or misrouted messages before any disk I/O.
+  → if index != msg.Snapshot.Metadata.Index: reject with error
+  → result, token, err := snapReceiveGroup.Do(fmt.Sprintf("%016x", index), func() (any, error) {
+        → os.CreateTemp() → {fsmSnapDir}/{fmt.Sprintf("%016x", index)}.fsm.tmp
         → stream remaining chunks to tmpFile (with bufio.NewWriterSize)
         → tmpFile.Sync()
         → verify CRC of tmpPath against footer and tokenCRC
           # footer is authoritative; return ErrFSMSnapshotFileCRC if mismatch
-        → os.Rename(tmpPath, {fsmSnapDir}/{index:016x}.fsm)  # atomic commit on success
-        → syncDir(fsmSnapDir)                                # flush directory entry
-        → return token  # []byte — the 17-byte token built from the received header
+        → os.Rename(tmpPath, {fsmSnapDir}/{fmt.Sprintf("%016x", index)}.fsm)  # atomic commit on success
+        → syncDir(fsmSnapDir)                           # flush directory entry
+        → return token
     })
-  → token := result.([]byte)  # extract from singleflight result
+  → token = result.([]byte)   # extract from singleflight result
   → raftpb.Message{Snapshot: {Data: token}}
   → handler(msg)
       → applyReadySnapshot(snap)
@@ -441,9 +439,9 @@ function:
 4. Returns typed errors distinguishing file corruption (`ErrFSMSnapshotFileCRC`) from
    token corruption (`ErrFSMSnapshotTokenCRC`).
 
-A standalone `verifyFSMSnapshotFile(path, tokenCRC)` is still provided for use in
-`receiveSnapshotStream` (verify the temp file before atomic rename) and future background
-health-check tasks, but it is **never called in sequence with a subsequent restore**.
+A standalone `verifyFSMSnapshotFile(path, tokenCRC)` is still provided for contexts where
+the FSM must not be modified (e.g., startup cleanup health-checking orphan files), but it
+is **never called in sequence with a subsequent restore**.
 
 ### Verification Points
 
@@ -452,7 +450,7 @@ health-check tasks, but it is **never called in sequence with a subsequent resto
 | **On restart** | `restoreSnapshotState` | `openAndRestoreFSMSnapshot` (single pass) |
 | **After follower receive** | `receiveSnapshotStream` | `verifyFSMSnapshotFile` on tmp before rename |
 | **On follower apply** | `applyReadySnapshot` | `openAndRestoreFSMSnapshot` (single pass; no extra verify) |
-| **Startup orphan check** | `cleanupStaleFSMSnaps` | Index-based only; no CRC scan (deferred to restore time) |
+| **Startup orphan check** | `cleanupStaleFSMSnaps` | `verifyFSMSnapshotFile` (read-only, no restore) |
 | **Background health check** *(future)* | background task | `verifyFSMSnapshotFile` |
 
 ### Error Types and Recovery
@@ -470,7 +468,7 @@ var (
 | Error | Meaning | Recovery |
 |-------|---------|---------|
 | `ErrFSMSnapshotFileCRC` | On-disk file is corrupt; footer ≠ computed | Delete file; WAL replay from `FirstIndex` |
-| `ErrFSMSnapshotTokenCRC` | File is intact (footer == computed) but token differs | Read footer CRC from file; call `Snapshotter.SaveSnap` with `encodeSnapshotToken(index, fileCRC)`; restore from the intact file without WAL replay |
+| `ErrFSMSnapshotTokenCRC` | File is intact (footer == computed) but token differs | Rewrite token from file's actual CRC; no WAL replay needed |
 | `ErrFSMSnapshotNotFound` | `.fsm` file missing for a valid token | WAL replay from `FirstIndex` |
 
 ---
@@ -524,7 +522,7 @@ The receiver path (`receiveSnapshotStream`) follows the same sequence and also c
 | `.fsm` exists, snap not yet saved | Snap points to previous index; next snapshot overwrites |
 | snap(token) exists, `.fsm` missing | `ErrFSMSnapshotNotFound` → WAL replay from `FirstIndex` |
 | `.fsm` footer CRC mismatch | `ErrFSMSnapshotFileCRC` → delete file; WAL replay |
-| `.fsm` footer ok, token CRC differs | `ErrFSMSnapshotTokenCRC` → `Snapshotter.SaveSnap` with corrected token; restore from file; no WAL replay |
+| `.fsm` footer ok, token CRC differs | `ErrFSMSnapshotTokenCRC` → rewrite token; restore from file |
 
 ### Startup Cleanup
 
@@ -535,16 +533,18 @@ The receiver path (`receiveSnapshotStream`) follows the same sequence and also c
 3. Removes any `.fsm` file whose index does not correspond to a live token — this handles
    the case where a `.fsm` was written but the corresponding `.snap` was never saved
    (upgrade crash), as well as files left over after purge ordering bugs in older versions.
+4. For each remaining `.fsm` file, calls `verifyFSMSnapshotFile` and removes files where
+   `ErrFSMSnapshotFileCRC` is returned (corrupt files cannot be used for restore).
 
-CRC integrity of the retained `.fsm` files is **not** verified at startup. For GiB-scale
-snapshots on slow storage, a full read-pass over every `.fsm` file would unacceptably
-delay engine recovery. Instead, CRC verification happens lazily in
-`openAndRestoreFSMSnapshot` at the moment the snapshot is actually applied. If a file is
-corrupt, the engine detects it at restore time and can request a fresh snapshot from the
-leader.
+This index-based orphan detection is stricter than a CRC-only check: a file with a valid
+CRC but no matching token is still an orphan and must be removed.
 
-This index-based orphan detection is stricter than a CRC-only startup scan: a file with
-a valid CRC but no matching token is still an orphan and must be removed.
+> **Performance note**: Step 4 performs a full sequential read of every retained `.fsm`
+> file. For large snapshots (e.g., GiB-scale) or slow storage, this may noticeably delay
+> engine startup. An operator-configurable `DisableStartupFSMCRCCheck` flag can skip step
+> 4; the file would still be detected as corrupt at the next restore attempt via
+> `openAndRestoreFSMSnapshot`. Index-based orphan removal (steps 2–3) always runs
+> regardless of the flag.
 
 ---
 
@@ -630,37 +630,16 @@ ambiguity when a mixed-version cluster is operating.
 The third case — a new-format leader sending a token to a legacy follower — is the only
 dangerous scenario. To prevent it, the rollout must proceed as follows:
 
-1. **Deploy Phase 1 to all nodes before Phase 2.** Phase 1 stores a 17-byte token in
-   `MemoryStorage` instead of the full FSM payload. This means a Phase 1 leader **would**
-   send a token in `MsgSnap` to a lagging follower, which a legacy follower cannot
-   understand. To remain backward-compatible, Phase 1 **must** therefore also include a
-   `Dispatch`-side fallback that reconstructs a full-payload `MsgSnap` when using the
-   legacy send path:
+1. **Deploy Phase 1 to all nodes before Phase 2.** Phase 1 changes local snapshot creation
+   and restore, and also updates the `Dispatch` path with a **bridge mode**: when
+   `msg.Snapshot.Data` is a token, `Dispatch` transparently reads the corresponding `.fsm`
+   file from disk and sends the full `[]byte` payload to the follower via the existing
+   `sendSnapshot` path. This preserves wire compatibility — legacy followers receive the
+   same full payload they always have. Mixed Phase 1 / legacy clusters are therefore safe.
+   File streaming (Phase 2) is deferred until all nodes are on Phase 1.
 
-   ```go
-   // Phase 1 Dispatch fallback: token is in MemoryStorage but receiver may be legacy.
-   // Read the .fsm file back to bytes only when a slow follower actually needs a
-   // snapshot — not on every periodic creation — so peak memory is still improved.
-   if isSnapshotToken(msg.Snapshot.Data) {
-       tok, _ := decodeSnapshotToken(msg.Snapshot.Data)
-       path := filepath.Join(fsmSnapDir, fmt.Sprintf("%016x.fsm", tok.Index))
-       payload, err := readFSMSnapshotPayload(path) // streams file, returns []byte
-       if err != nil {
-           return errors.WithStack(err)
-       }
-       msg.Snapshot.Data = payload // full bytes → safe for legacy receivers
-   }
-   // fall through to legacy sendSnapshot path
-   ```
-
-   With this fallback, mixed Phase 1 / legacy clusters are safe. The memory allocation
-   occurs only when a slow follower needs a snapshot send, not during periodic local
-   snapshot creation, so the worst-case spike is unchanged but the common-case (no
-   lagging followers) is fully eliminated.
-
-2. **Deploy Phase 2 to all nodes simultaneously, or use the feature flag below.** Phase 2
-   replaces the Phase 1 fallback with true file streaming; once any node begins sending
-   token-format `MsgSnap` without reconstructing, all receivers must be at Phase 2.
+2. **Deploy Phase 2 to all nodes simultaneously, or use the feature flag below.** Once
+   any node begins sending token-format `MsgSnap`, all receivers must be at Phase 2.
 
 3. **Feature flag (recommended)**: add a `DisableFSMSnapshotToken` config field (default
    `false`). When set to `true`, `Dispatch` falls back to the legacy `sendSnapshot` path
@@ -686,54 +665,6 @@ transition window: `raftpb.Snapshot.Data` = token AND a copy of the full legacy 
 stored in an auxiliary file. The legacy binary would then decode the full payload
 normally. This dual-write mode is a forward compatibility bridge and can be removed after
 the fleet has been fully upgraded.
-
-### Zero-Downtime Cutover Runbook
-
-For a Raft cluster, the standard zero-downtime approach is a **rolling upgrade**: replace
-one node at a time, verify health, then proceed to the next. The feature flag provides
-the safety valve at each step. Below is the recommended procedure for a 3-node cluster
-(`nodeA`, `nodeB`, `nodeC`).
-
-**Phase 1 rollout (safe in mixed clusters):**
-
-```
-1. Deploy Phase 1 binary to nodeA; restart.
-   - nodeA starts writing .fsm files locally.
-   - nodeA's Dispatch fallback reads .fsm → bytes for any legacy-receiver MsgSnap.
-   - Verify: cluster healthy, no error logs for ErrFSMSnapshotFileCRC.
-
-2. Repeat for nodeB, then nodeC.
-   - All nodes now write .fsm files. Mixed Phase 1 / legacy is safe throughout.
-
-3. Run for at least one full snapshot cycle per node before proceeding to Phase 2.
-   Confirm: each node's fsm-snap/ directory contains a valid .fsm file.
-```
-
-**Phase 2 rollout (requires all nodes on Phase 1 first):**
-
-```
-4. Deploy Phase 2 binary to all nodes with DisableFSMSnapshotToken=true.
-   - Nodes use file streaming internally but Dispatch still reconstructs full payload
-     (feature flag active). This is a no-op from the wire perspective.
-   - Verify: cluster healthy.
-
-5. Enable token mode on nodeA: set DisableFSMSnapshotToken=false (hot reload or restart).
-   - nodeA now sends token-format MsgSnap; all receivers must be Phase 2 (they are).
-   - Monitor for one snapshot cycle. Verify follower applies succeed.
-
-6. Enable on nodeB, then nodeC.
-   - All nodes now use full token-mode streaming.
-
-7. Remove the DisableFSMSnapshotToken flag from config (it now defaults to false).
-```
-
-**Rollback at any step:**
-
-| Step | Rollback action |
-|------|----------------|
-| During Phase 1 rollout | Redeploy legacy binary; stop node first; delete `fsm-snap/`; restart (WAL replay) |
-| Phase 2 deployed, flag still enabled | Redeploy Phase 1 binary; no fsm-snap cleanup needed |
-| Phase 2 deployed, flag disabled on some nodes | Re-enable `DisableFSMSnapshotToken=true` on flag-disabled nodes first; then redeploy Phase 1 binaries |
 
 ---
 
@@ -769,8 +700,7 @@ the safety valve at each step. Below is the recommended procedure for a 3-node c
 ### Phase 1: Local Snapshot Disk Offload
 
 Scope: local creation and local restore for **all three snapshot paths** (periodic,
-config-change, and bootstrap) **plus** a `Dispatch`-side fallback for backward
-compatibility with legacy followers.
+config-change, and bootstrap). Follower send/receive is unchanged.
 
 **Implementation tasks:**
 
@@ -779,17 +709,12 @@ compatibility with legacy followers.
   - `writeFSMSnapshotFile` (write with CRC footer + syncDir)
   - `openAndRestoreFSMSnapshot` (single-pass verify+restore via TeeReader)
   - `verifyFSMSnapshotFile` (read-only CRC check for orphan detection)
-  - `readFSMSnapshotPayload` (read `.fsm` file back to `[]byte` for legacy send)
   - `encodeSnapshotToken` / `decodeSnapshotToken` (17-byte token with CRC)
-  - Error types: `ErrFSMSnapshotFileCRC`, `ErrFSMSnapshotTokenCRC`,
-    `ErrFSMSnapshotIndexMismatch`, etc.
+  - Error types: `ErrFSMSnapshotFileCRC`, `ErrFSMSnapshotTokenCRC`, etc.
 - Update `persistLocalSnapshot` → `writeFSMSnapshotFile` + token
 - Update `persistConfigSnapshot`, `persistConfigState`, and `persistConfigSnapshotPayload` → same
 - Update `stateMachineSnapshotBytes` (bootstrap) → `writeFSMSnapshotFile` + token
 - Update `restoreSnapshotState` → `openAndRestoreFSMSnapshot`
-- Update `Dispatch`: if `isSnapshotToken(msg.Snapshot.Data)` and using the legacy send
-  path, call `readFSMSnapshotPayload` to reconstruct the full payload before sending
-  (ensures legacy followers receive a valid FSM byte stream)
 - Replace `purgeOldSnapFiles` with `purgeOldSnapshotFiles(snapDir, fsmSnapDir)`
 - Add `cleanupStaleFSMSnaps(snapDir, fsmSnapDir)` (index-based orphan removal)
 - Capture `storageIndex` before `fsm.Snapshot()` in `maybePersistLocalSnapshot`
@@ -797,18 +722,14 @@ compatibility with legacy followers.
 
 **Effect**: eliminates memory spikes during local snapshot creation; reduces
 `MemoryStorage` resident memory; all snapshot creation paths are consistent.
-Mixed Phase 1 / legacy clusters remain safe because the Dispatch fallback reconstructs
-the full payload on demand (only when a slow follower actually needs a snapshot).
 
 ### Phase 2: Streaming Follower Send/Receive
 
-Scope: update `GRPCTransport` MsgSnap paths to use file streaming; remove the
-Phase 1 `readFSMSnapshotPayload` fallback from `Dispatch`.
+Scope: update `GRPCTransport` MsgSnap paths to use file streaming.
 
 **Implementation tasks:**
 
 - `Dispatch`: detect token → open `.fsm` file → `sendSnapshotFileChunks`
-  (replaces the Phase 1 `readFSMSnapshotPayload` fallback entirely)
 - `receiveSnapshotStream`:
   - Write chunks to temp file (with `bufio.NewWriterSize`)
   - `verifyFSMSnapshotFile` on tmp before rename

--- a/docs/etcd_snapshot_disk_offload_design.md
+++ b/docs/etcd_snapshot_disk_offload_design.md
@@ -391,17 +391,19 @@ receiveSnapshotStream()
   # Validate that the token index matches raftpb.SnapshotMetadata.Index to
   # reject corrupted or misrouted messages before any disk I/O.
   → if index != msg.Snapshot.Metadata.Index: reject with error
-  → result, token, err := snapReceiveGroup.Do(fmt.Sprintf("%016x", index), func() (any, error) {
+  # singleflight.Group.Do signature: Do(key string, fn func() (any, error)) (v any, err error, shared bool)
+  → v, err, _ := snapReceiveGroup.Do(fmt.Sprintf("%016x", index), func() (any, error) {
         → os.CreateTemp() → {fsmSnapDir}/{fmt.Sprintf("%016x", index)}.fsm.tmp
         → stream remaining chunks to tmpFile (with bufio.NewWriterSize)
         → tmpFile.Sync()
         → verify CRC of tmpPath against footer and tokenCRC
-          # footer is authoritative; return ErrFSMSnapshotFileCRC if mismatch
+          # footer is authoritative; return nil, ErrFSMSnapshotFileCRC if mismatch
         → os.Rename(tmpPath, {fsmSnapDir}/{fmt.Sprintf("%016x", index)}.fsm)  # atomic commit on success
         → syncDir(fsmSnapDir)                           # flush directory entry
-        → return token
+        → return encodedToken, nil  # encodedToken is the 17-byte token []byte
     })
-  → token = result.([]byte)   # extract from singleflight result
+  → if err != nil: return err
+  → token := v.([]byte)   # type-assert the singleflight result to []byte
   → raftpb.Message{Snapshot: {Data: token}}
   → handler(msg)
       → applyReadySnapshot(snap)
@@ -670,8 +672,10 @@ ambiguity when a mixed-version cluster is operating.
 |----------------|-----------------|---------|
 | Legacy (no token) | Legacy | Unchanged — existing path |
 | Legacy (no token) | New | `isSnapshotToken` → false → `bytes.NewReader` fallback |
-| New (token) | Legacy | Legacy node does not understand the token; restores from the 17-byte payload as if it were FSM data → **corrupt FSM** |
-| New (token) | New | Token path → `.fsm` file |
+| Phase 1 (bridge mode) | Legacy | `Dispatch` reads `.fsm` → `[]byte` → `sendSnapshot`; legacy receiver sees full payload → safe |
+| Phase 1 (bridge mode) | Phase 1+ | Same as above (bridge mode always uses old wire format) |
+| Phase 2 (token send) | Legacy | Legacy node receives 17-byte token; restore fails → **unsafe; requires all nodes on Phase 2** |
+| Phase 2 (token send) | Phase 2 | Token path → `.fsm` file streaming → safe |
 
 ### Rolling Upgrade Strategy
 
@@ -687,35 +691,34 @@ dangerous scenario. To prevent it, the rollout must proceed as follows:
    File streaming (Phase 2) is deferred until all nodes are on Phase 1.
 
    ```go
-   // Phase 1 Dispatch fallback: token is in MemoryStorage but receiver may be legacy.
-   // Open the .fsm file and stream it directly via sendSnapshotReaderChunks to avoid
-   // materializing the full payload into memory. This requires the receiver to be at
-   // least Phase 1 (i.e., it runs receiveSnapshotStream which handles both formats).
-   // A truly pre-Phase-1 legacy receiver cannot handle this path; see note below.
+   // Phase 1 Dispatch bridge mode: MemoryStorage holds a token, but the receiver
+   // may be a pre-Phase-1 legacy node that expects a full FSM payload in
+   // msg.Snapshot.Data. Read the .fsm file back into []byte and use the
+   // existing sendSnapshot path to preserve wire compatibility.
    if isSnapshotToken(msg.Snapshot.Data) {
        tok, _ := decodeSnapshotToken(msg.Snapshot.Data)
        path := filepath.Join(fsmSnapDir, fmt.Sprintf("%016x.fsm", tok.Index))
-       f, err := os.Open(path)
+       payload, err := readFSMSnapshotPayload(path) // reads file, returns []byte
        if err != nil {
            return errors.WithStack(err)
        }
-       defer f.Close()
-       return sendSnapshotReaderChunks(stream, header, f) // stream without []byte alloc
+       msg.Snapshot.Data = payload // restore full bytes for legacy wire format
    }
-   // fall through to legacy sendSnapshot path (receiver is pre-Phase-1)
+   // sendSnapshot uses the existing chunked send path; all receivers understand it
+   return sendSnapshot(msg)
    ```
 
-   > **Memory trade-off note**: `sendSnapshotReaderChunks` streams the `.fsm` file
-   > directly without materializing it to `[]byte`, preserving the memory benefit. This
-   > path requires the receiver to run `receiveSnapshotStream`. If the cluster contains
-   > genuine pre-Phase-1 nodes that do not have `receiveSnapshotStream`, the operator
-   > must materialize via `readFSMSnapshotPayload` instead — accepting that the memory
-   > spike is re-introduced for that specific send. In practice this case should not
-   > arise when the Phase 1 rollout is done correctly (all nodes updated before Phase 2
-   > is enabled). Phase 2 eliminates the fallback entirely.
+   > **Memory trade-off**: `readFSMSnapshotPayload` materializes the `.fsm` file to
+   > `[]byte`, which re-introduces a memory allocation at send time. However:
+   > - The allocation is **transient** (freed after the send completes) — not permanently
+   >   held in MemoryStorage as it was before this change.
+   > - It occurs only when a **slow follower** needs a snapshot, not on every periodic
+   >   snapshot creation; in a healthy cluster this is rare.
+   > - **Phase 2 eliminates this entirely** by replacing the bridge mode with file
+   >   streaming to all nodes.
 
-   With this fallback, mixed Phase 1 / legacy clusters are safe. Memory allocation
-   during snapshot creation is eliminated; the send path streams from disk.
+   With this bridge, mixed Phase 1 / legacy clusters are fully safe: every receiver
+   always gets a standard full-payload `MsgSnap` regardless of version.
 
 2. **Deploy Phase 2 to all nodes simultaneously, or use the feature flag below.** Phase 2
    replaces the Phase 1 fallback with true file streaming; once any node begins sending
@@ -789,19 +792,27 @@ config-change, and bootstrap). Follower send/receive is unchanged.
   - `writeFSMSnapshotFile` (write with CRC footer + syncDir)
   - `openAndRestoreFSMSnapshot` (single-pass verify+restore via TeeReader)
   - `verifyFSMSnapshotFile` (read-only CRC check for orphan detection)
-- Update `Dispatch`: if `isSnapshotToken(msg.Snapshot.Data)`, open the `.fsm` file and
-  stream via `sendSnapshotReaderChunks` (no `[]byte` allocation); this requires the
-  receiver to run `receiveSnapshotStream` (i.e., be at Phase 1 or newer)
+  - `readFSMSnapshotPayload` (read `.fsm` file back to `[]byte` for bridge-mode send)
+  - `fsmSnapPath(fsmSnapDir string, index uint64) string` (canonical zero-padded hex path helper)
+  - `encodeSnapshotToken` / `decodeSnapshotToken` (17-byte token with CRC)
+  - Error types: `ErrFSMSnapshotFileCRC`, `ErrFSMSnapshotTokenCRC`,
+    `ErrFSMSnapshotIndexMismatch`, etc.
+- Update `persistLocalSnapshot` → `writeFSMSnapshotFile` + token
+- Update `persistConfigSnapshot`, `persistConfigState`, and `persistConfigSnapshotPayload` → same
+- Update `stateMachineSnapshotBytes` (bootstrap) → `writeFSMSnapshotFile` + token
+- Update `restoreSnapshotState` → `openAndRestoreFSMSnapshot`
+- Update `Dispatch` (bridge mode): if `isSnapshotToken(msg.Snapshot.Data)`, call
+  `readFSMSnapshotPayload` to reconstruct `[]byte` payload; use old `sendSnapshot` path
+  so all receivers (including legacy) receive a standard full-payload `MsgSnap`
 - Replace `purgeOldSnapFiles` with `purgeOldSnapshotFiles(snapDir, fsmSnapDir)`
 - Add `cleanupStaleFSMSnaps(snapDir, fsmSnapDir)` (index-based orphan removal)
 - Capture `storageIndex` before `fsm.Snapshot()` in `maybePersistLocalSnapshot`
 - All existing tests must continue to pass
 
-**Effect**: eliminates memory spikes during local snapshot creation; reduces
-`MemoryStorage` resident memory; all snapshot creation paths are consistent.
-Mixed Phase 1 clusters are safe: Dispatch streams from the `.fsm` file via
-`sendSnapshotReaderChunks` without materializing to `[]byte`. Requires all nodes in the
-cluster to be at Phase 1 or newer before any Phase 1 node becomes leader.
+**Effect**: eliminates memory spikes during **local snapshot creation**; reduces
+`MemoryStorage` resident memory. A transient allocation still occurs when a slow follower
+needs a snapshot send (bridge mode), but it is freed after the send and does not persist.
+Phase 2 eliminates this last allocation by switching to file streaming.
 
 ### Phase 2: Streaming Follower Send/Receive
 

--- a/docs/etcd_snapshot_disk_offload_design.md
+++ b/docs/etcd_snapshot_disk_offload_design.md
@@ -159,7 +159,9 @@ with the raft snapshot metadata. The two values must always agree; a mismatch in
 - **footer ≠ computed**: the `.fsm` file is corrupt on disk → delete and attempt WAL
   replay; do not trust the token.
 - **footer == computed, token ≠ computed**: the `.snap` metadata is corrupt → the file
-  itself is trustworthy; the snap file should be rewritten from the file's actual CRC.
+  itself may be trustworthy, but the mismatch could also indicate the token points to the
+  wrong file version; **do not auto-rewrite**; log the discrepancy and request a fresh
+  snapshot from the leader (safe path).
 - **footer ≠ computed AND token ≠ computed**: both are corrupt → WAL replay only.
 
 This distinction is implemented in `verifyFSMSnapshotFile`, which returns typed errors
@@ -270,6 +272,31 @@ func openAndRestoreFSMSnapshot(fsm StateMachine, path string, tokenCRC uint32) e
     }
     defer f.Close()
 
+    // --- Fail fast: read footer before restoring FSM state ---
+    // The tokenCRC (from the .snap metadata) is verified against the on-disk footer
+    // BEFORE fsm.Restore is called. This prevents the FSM from being mutated when
+    // the token is stale or corrupt, avoiding any state-change side-effects.
+    footerOffset := info.Size() - 4
+    if _, err := f.Seek(footerOffset, io.SeekStart); err != nil {
+        return errors.WithStack(err)
+    }
+    var footer uint32
+    if err := binary.Read(f, binary.BigEndian, &footer); err != nil {
+        return errors.WithStack(err)
+    }
+    if footer != tokenCRC {
+        // Footer and token disagree before we even start restoring. We cannot safely
+        // determine which is correct without computing the full CRC (which requires
+        // restoring). Return ErrFSMSnapshotTokenCRC and let the caller request a fresh
+        // snapshot from the leader.
+        return errors.Wrapf(ErrFSMSnapshotTokenCRC,
+            "path=%s footer=%08x token=%08x", path, footer, tokenCRC)
+    }
+    // Seek back to start for the restore + CRC verification pass.
+    if _, err := f.Seek(0, io.SeekStart); err != nil {
+        return errors.WithStack(err)
+    }
+
     payloadSize := info.Size() - 4
     h := crc32.New(crc32cTable)
     // Tee: data flows to both the CRC accumulator and fsm.Restore simultaneously.
@@ -283,24 +310,21 @@ func openAndRestoreFSMSnapshot(fsm StateMachine, path string, tokenCRC uint32) e
     if _, err := io.Copy(io.Discard, br); err != nil {
         return errors.WithStack(err)
     }
-    var footer uint32
-    if err := binary.Read(f, binary.BigEndian, &footer); err != nil {
-        return errors.WithStack(err)
-    }
     computed := h.Sum32()
     if computed != footer {
         return errors.Wrapf(ErrFSMSnapshotFileCRC,
             "path=%s footer=%08x computed=%08x", path, footer, computed)
     }
-    if computed != tokenCRC {
-        return errors.Wrapf(ErrFSMSnapshotTokenCRC,
-            "path=%s token=%08x computed=%08x", path, tokenCRC, computed)
-    }
+    // footer == tokenCRC was already verified above; computed == footer is now also
+    // confirmed, so all three values agree. No second tokenCRC comparison needed.
     return nil
 }
 ```
 
 Key properties:
+- **Token fail-fast before restore**: the footer is read via `Seek` and compared to
+  `tokenCRC` before `fsm.Restore` is called, so a corrupt token never causes FSM
+  mutation.
 - **Single read pass**: `io.TeeReader` feeds data to both `fsm.Restore` and the CRC hash
   simultaneously; no second scan.
 - **`bufio.NewReaderSize(tee, 1<<20)`**: the 1 MiB read-ahead buffer amortizes the
@@ -468,7 +492,7 @@ var (
 | Error | Meaning | Recovery |
 |-------|---------|---------|
 | `ErrFSMSnapshotFileCRC` | On-disk file is corrupt; footer ≠ computed | Delete file; WAL replay from `FirstIndex` |
-| `ErrFSMSnapshotTokenCRC` | File is intact (footer == computed) but token differs | Rewrite token from file's actual CRC; no WAL replay needed |
+| `ErrFSMSnapshotTokenCRC` | Footer and token disagree (detected before restore) | Log the mismatch; request a fresh snapshot from the leader; do not auto-rewrite the token (the mismatch may indicate the token references the wrong file version) |
 | `ErrFSMSnapshotNotFound` | `.fsm` file missing for a valid token | WAL replay from `FirstIndex` |
 
 ---
@@ -522,7 +546,7 @@ The receiver path (`receiveSnapshotStream`) follows the same sequence and also c
 | `.fsm` exists, snap not yet saved | Snap points to previous index; next snapshot overwrites |
 | snap(token) exists, `.fsm` missing | `ErrFSMSnapshotNotFound` → WAL replay from `FirstIndex` |
 | `.fsm` footer CRC mismatch | `ErrFSMSnapshotFileCRC` → delete file; WAL replay |
-| `.fsm` footer ok, token CRC differs | `ErrFSMSnapshotTokenCRC` → rewrite token; restore from file |
+| `.fsm` footer ok, token CRC differs | `ErrFSMSnapshotTokenCRC` → log + request fresh snapshot from leader; no auto-rewrite |
 
 ### Startup Cleanup
 
@@ -638,8 +662,40 @@ dangerous scenario. To prevent it, the rollout must proceed as follows:
    same full payload they always have. Mixed Phase 1 / legacy clusters are therefore safe.
    File streaming (Phase 2) is deferred until all nodes are on Phase 1.
 
-2. **Deploy Phase 2 to all nodes simultaneously, or use the feature flag below.** Once
-   any node begins sending token-format `MsgSnap`, all receivers must be at Phase 2.
+   ```go
+   // Phase 1 Dispatch fallback: token is in MemoryStorage but receiver may be legacy.
+   // Open the .fsm file and stream it directly via sendSnapshotReaderChunks to avoid
+   // materializing the full payload into memory. This requires the receiver to be at
+   // least Phase 1 (i.e., it runs receiveSnapshotStream which handles both formats).
+   // A truly pre-Phase-1 legacy receiver cannot handle this path; see note below.
+   if isSnapshotToken(msg.Snapshot.Data) {
+       tok, _ := decodeSnapshotToken(msg.Snapshot.Data)
+       path := filepath.Join(fsmSnapDir, fmt.Sprintf("%016x.fsm", tok.Index))
+       f, err := os.Open(path)
+       if err != nil {
+           return errors.WithStack(err)
+       }
+       defer f.Close()
+       return sendSnapshotReaderChunks(stream, header, f) // stream without []byte alloc
+   }
+   // fall through to legacy sendSnapshot path (receiver is pre-Phase-1)
+   ```
+
+   > **Memory trade-off note**: `sendSnapshotReaderChunks` streams the `.fsm` file
+   > directly without materializing it to `[]byte`, preserving the memory benefit. This
+   > path requires the receiver to run `receiveSnapshotStream`. If the cluster contains
+   > genuine pre-Phase-1 nodes that do not have `receiveSnapshotStream`, the operator
+   > must materialize via `readFSMSnapshotPayload` instead — accepting that the memory
+   > spike is re-introduced for that specific send. In practice this case should not
+   > arise when the Phase 1 rollout is done correctly (all nodes updated before Phase 2
+   > is enabled). Phase 2 eliminates the fallback entirely.
+
+   With this fallback, mixed Phase 1 / legacy clusters are safe. Memory allocation
+   during snapshot creation is eliminated; the send path streams from disk.
+
+2. **Deploy Phase 2 to all nodes simultaneously, or use the feature flag below.** Phase 2
+   replaces the Phase 1 fallback with true file streaming; once any node begins sending
+   token-format `MsgSnap` without reconstructing, all receivers must be at Phase 2.
 
 3. **Feature flag (recommended)**: add a `DisableFSMSnapshotToken` config field (default
    `false`). When set to `true`, `Dispatch` falls back to the legacy `sendSnapshot` path
@@ -709,12 +765,9 @@ config-change, and bootstrap). Follower send/receive is unchanged.
   - `writeFSMSnapshotFile` (write with CRC footer + syncDir)
   - `openAndRestoreFSMSnapshot` (single-pass verify+restore via TeeReader)
   - `verifyFSMSnapshotFile` (read-only CRC check for orphan detection)
-  - `encodeSnapshotToken` / `decodeSnapshotToken` (17-byte token with CRC)
-  - Error types: `ErrFSMSnapshotFileCRC`, `ErrFSMSnapshotTokenCRC`, etc.
-- Update `persistLocalSnapshot` → `writeFSMSnapshotFile` + token
-- Update `persistConfigSnapshot`, `persistConfigState`, and `persistConfigSnapshotPayload` → same
-- Update `stateMachineSnapshotBytes` (bootstrap) → `writeFSMSnapshotFile` + token
-- Update `restoreSnapshotState` → `openAndRestoreFSMSnapshot`
+- Update `Dispatch`: if `isSnapshotToken(msg.Snapshot.Data)`, open the `.fsm` file and
+  stream via `sendSnapshotReaderChunks` (no `[]byte` allocation); this requires the
+  receiver to run `receiveSnapshotStream` (i.e., be at Phase 1 or newer)
 - Replace `purgeOldSnapFiles` with `purgeOldSnapshotFiles(snapDir, fsmSnapDir)`
 - Add `cleanupStaleFSMSnaps(snapDir, fsmSnapDir)` (index-based orphan removal)
 - Capture `storageIndex` before `fsm.Snapshot()` in `maybePersistLocalSnapshot`
@@ -722,6 +775,9 @@ config-change, and bootstrap). Follower send/receive is unchanged.
 
 **Effect**: eliminates memory spikes during local snapshot creation; reduces
 `MemoryStorage` resident memory; all snapshot creation paths are consistent.
+Mixed Phase 1 clusters are safe: Dispatch streams from the `.fsm` file via
+`sendSnapshotReaderChunks` without materializing to `[]byte`. Requires all nodes in the
+cluster to be at Phase 1 or newer before any Phase 1 node becomes leader.
 
 ### Phase 2: Streaming Follower Send/Receive
 

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -257,30 +257,9 @@ func (c *Coordinate) redirect(ctx context.Context, reqs *OperationGroup[OP]) (*C
 
 	cli := pb.NewInternalClient(conn)
 
-	var requests []*pb.Request
-	if reqs.IsTxn {
-		if len(reqs.ReadKeys) > maxReadKeys {
-			return nil, errors.WithStack(ErrInvalidRequest)
-		}
-		primary := primaryKeyForElems(reqs.Elems)
-		if len(primary) == 0 {
-			return nil, errors.WithStack(ErrTxnPrimaryKeyRequired)
-		}
-		// When StartTS is absent (leader will assign it), also clear CommitTS
-		// so the leader assigns both timestamps consistently. A caller-provided
-		// CommitTS without a StartTS would produce an invalid txn where
-		// CommitTS <= StartTS (because StartTS=0 at the forwarding site).
-		commitTS := reqs.CommitTS
-		if reqs.StartTS == 0 {
-			commitTS = 0
-		}
-		requests = []*pb.Request{
-			onePhaseTxnRequest(reqs.StartTS, commitTS, primary, reqs.Elems, reqs.ReadKeys),
-		}
-	} else {
-		for _, req := range reqs.Elems {
-			requests = append(requests, c.toRawRequest(req))
-		}
+	requests, err := c.buildRedirectRequests(reqs)
+	if err != nil {
+		return nil, err
 	}
 
 	fwdCtx, cancel := context.WithTimeout(ctx, redirectForwardTimeout)
@@ -296,6 +275,34 @@ func (c *Coordinate) redirect(ctx context.Context, reqs *OperationGroup[OP]) (*C
 
 	return &CoordinateResponse{
 		CommitIndex: r.CommitIndex,
+	}, nil
+}
+
+func (c *Coordinate) buildRedirectRequests(reqs *OperationGroup[OP]) ([]*pb.Request, error) {
+	if !reqs.IsTxn {
+		var requests []*pb.Request
+		for _, req := range reqs.Elems {
+			requests = append(requests, c.toRawRequest(req))
+		}
+		return requests, nil
+	}
+	if len(reqs.ReadKeys) > maxReadKeys {
+		return nil, errors.WithStack(ErrInvalidRequest)
+	}
+	primary := primaryKeyForElems(reqs.Elems)
+	if len(primary) == 0 {
+		return nil, errors.WithStack(ErrTxnPrimaryKeyRequired)
+	}
+	// When StartTS is absent (leader will assign it), also clear CommitTS
+	// so the leader assigns both timestamps consistently. A caller-provided
+	// CommitTS without a StartTS would produce an invalid txn where
+	// CommitTS <= StartTS (because StartTS=0 at the forwarding site).
+	commitTS := reqs.CommitTS
+	if reqs.StartTS == 0 {
+		commitTS = 0
+	}
+	return []*pb.Request{
+		onePhaseTxnRequest(reqs.StartTS, commitTS, primary, reqs.Elems, reqs.ReadKeys),
 	}, nil
 }
 

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -280,7 +280,7 @@ func (c *Coordinate) redirect(ctx context.Context, reqs *OperationGroup[OP]) (*C
 
 func (c *Coordinate) buildRedirectRequests(reqs *OperationGroup[OP]) ([]*pb.Request, error) {
 	if !reqs.IsTxn {
-		var requests []*pb.Request
+		requests := make([]*pb.Request, 0, len(reqs.Elems))
 		for _, req := range reqs.Elems {
 			requests = append(requests, c.toRawRequest(req))
 		}

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -211,22 +211,13 @@ func (c *ShardedCoordinator) dispatchTxn(ctx context.Context, startTS uint64, co
 		return nil, err
 	}
 
-	if len(gids) == 1 {
+	if len(gids) == 1 && c.allReadKeysInShard(readKeys, gids[0]) {
 		// Only use the single-shard (one-phase) path when every read key also
 		// belongs to the same shard as the mutations. If any read key belongs
 		// to a different shard, the 2PC path must be used so that
 		// validateReadOnlyShards validates those shards via a linearizable
 		// read barrier, preserving SSI.
-		canOptimize := true
-		for _, rk := range readKeys {
-			if c.engineGroupIDForKey(rk) != gids[0] {
-				canOptimize = false
-				break
-			}
-		}
-		if canOptimize {
-			return c.dispatchSingleShardTxn(startTS, commitTS, primaryKey, gids[0], elems, readKeys)
-		}
+		return c.dispatchSingleShardTxn(startTS, commitTS, primaryKey, gids[0], elems, readKeys)
 	}
 
 	prepared, err := c.prewriteTxn(ctx, startTS, commitTS, primaryKey, grouped, gids, readKeys)
@@ -256,6 +247,16 @@ func (c *ShardedCoordinator) resolveTxnCommitTS(startTS, commitTS uint64) (uint6
 		return 0, errors.WithStack(ErrTxnCommitTSRequired)
 	}
 	return commitTS, nil
+}
+
+// allReadKeysInShard reports whether every key in readKeys belongs to gid.
+func (c *ShardedCoordinator) allReadKeysInShard(readKeys [][]byte, gid uint64) bool {
+	for _, rk := range readKeys {
+		if c.engineGroupIDForKey(rk) != gid {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *ShardedCoordinator) dispatchSingleShardTxn(startTS, commitTS uint64, primaryKey []byte, gid uint64, elems []*Elem[OP], readKeys [][]byte) (*CoordinateResponse, error) {

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -211,7 +211,11 @@ func (c *ShardedCoordinator) dispatchTxn(ctx context.Context, startTS uint64, co
 		return nil, err
 	}
 
-	if len(gids) == 1 && c.allReadKeysInShard(readKeys, gids[0]) {
+	// Group read keys by shard once here so the result can be reused by
+	// prewriteTxn without a second iteration over readKeys.
+	groupedReadKeys := c.groupReadKeysByShardID(readKeys)
+
+	if len(gids) == 1 && allGroupedReadKeysInShard(groupedReadKeys, gids[0]) {
 		// Only use the single-shard (one-phase) path when every read key also
 		// belongs to the same shard as the mutations. If any read key belongs
 		// to a different shard, the 2PC path must be used so that
@@ -220,7 +224,7 @@ func (c *ShardedCoordinator) dispatchTxn(ctx context.Context, startTS uint64, co
 		return c.dispatchSingleShardTxn(startTS, commitTS, primaryKey, gids[0], elems, readKeys)
 	}
 
-	prepared, err := c.prewriteTxn(ctx, startTS, commitTS, primaryKey, grouped, gids, readKeys)
+	prepared, err := c.prewriteTxn(ctx, startTS, commitTS, primaryKey, grouped, gids, groupedReadKeys)
 	if err != nil {
 		return nil, err
 	}
@@ -249,14 +253,15 @@ func (c *ShardedCoordinator) resolveTxnCommitTS(startTS, commitTS uint64) (uint6
 	return commitTS, nil
 }
 
-// allReadKeysInShard reports whether every key in readKeys belongs to gid.
-func (c *ShardedCoordinator) allReadKeysInShard(readKeys [][]byte, gid uint64) bool {
-	for _, rk := range readKeys {
-		if c.engineGroupIDForKey(rk) != gid {
-			return false
-		}
+// allGroupedReadKeysInShard returns true when every read key in groupedReadKeys
+// belongs to gid (i.e. the map is empty or contains only the entry for gid).
+// It operates on the pre-computed groupedReadKeys to avoid a second iteration.
+func allGroupedReadKeysInShard(groupedReadKeys map[uint64][][]byte, gid uint64) bool {
+	if len(groupedReadKeys) == 0 {
+		return true
 	}
-	return true
+	_, ok := groupedReadKeys[gid]
+	return ok && len(groupedReadKeys) == 1
 }
 
 func (c *ShardedCoordinator) dispatchSingleShardTxn(startTS, commitTS uint64, primaryKey []byte, gid uint64, elems []*Elem[OP], readKeys [][]byte) (*CoordinateResponse, error) {
@@ -283,11 +288,9 @@ type preparedGroup struct {
 	keys []*pb.Mutation
 }
 
-func (c *ShardedCoordinator) prewriteTxn(ctx context.Context, startTS, commitTS uint64, primaryKey []byte, grouped map[uint64][]*pb.Mutation, gids []uint64, readKeys [][]byte) ([]preparedGroup, error) {
+func (c *ShardedCoordinator) prewriteTxn(ctx context.Context, startTS, commitTS uint64, primaryKey []byte, grouped map[uint64][]*pb.Mutation, gids []uint64, groupedReadKeys map[uint64][][]byte) ([]preparedGroup, error) {
 	prepareMeta := txnMetaMutation(primaryKey, defaultTxnLockTTLms, 0)
 	prepared := make([]preparedGroup, 0, len(gids))
-
-	groupedReadKeys := c.groupReadKeysByShardID(readKeys)
 
 	for _, gid := range gids {
 		g, err := c.txnGroupForID(gid)

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -211,19 +211,18 @@ func (c *ShardedCoordinator) dispatchTxn(ctx context.Context, startTS uint64, co
 		return nil, err
 	}
 
-	// Group read keys by shard once here so the result can be reused by
-	// prewriteTxn without a second iteration over readKeys.
-	groupedReadKeys := c.groupReadKeysByShardID(readKeys)
-
-	if len(gids) == 1 && allGroupedReadKeysInShard(groupedReadKeys, gids[0]) {
-		// Only use the single-shard (one-phase) path when every read key also
-		// belongs to the same shard as the mutations. If any read key belongs
-		// to a different shard, the 2PC path must be used so that
-		// validateReadOnlyShards validates those shards via a linearizable
-		// read barrier, preserving SSI.
+	if len(gids) == 1 && c.allReadKeysInShard(readKeys, gids[0]) {
+		// Fast path: all mutations and read keys are in a single shard.
+		// Use the one-phase path without allocating a grouped-read-keys map.
+		// If any read key belongs to a different shard the 2PC path is required
+		// so that validateReadOnlyShards can issue a linearizable read barrier,
+		// preserving SSI.
 		return c.dispatchSingleShardTxn(startTS, commitTS, primaryKey, gids[0], elems, readKeys)
 	}
 
+	// Multi-shard path: group read keys by shard now. The result is passed
+	// directly to prewriteTxn to avoid a second iteration inside that function.
+	groupedReadKeys := c.groupReadKeysByShardID(readKeys)
 	prepared, err := c.prewriteTxn(ctx, startTS, commitTS, primaryKey, grouped, gids, groupedReadKeys)
 	if err != nil {
 		return nil, err
@@ -253,15 +252,16 @@ func (c *ShardedCoordinator) resolveTxnCommitTS(startTS, commitTS uint64) (uint6
 	return commitTS, nil
 }
 
-// allGroupedReadKeysInShard returns true when every read key in groupedReadKeys
-// belongs to gid (i.e. the map is empty or contains only the entry for gid).
-// It operates on the pre-computed groupedReadKeys to avoid a second iteration.
-func allGroupedReadKeysInShard(groupedReadKeys map[uint64][][]byte, gid uint64) bool {
-	if len(groupedReadKeys) == 0 {
-		return true
+// allReadKeysInShard returns true when every key in readKeys belongs to gid.
+// It performs a single O(n) pass without allocating a map, making it suitable
+// for the single-shard fast path in dispatchTxn.
+func (c *ShardedCoordinator) allReadKeysInShard(readKeys [][]byte, gid uint64) bool {
+	for _, rk := range readKeys {
+		if c.engineGroupIDForKey(rk) != gid {
+			return false
+		}
 	}
-	_, ok := groupedReadKeys[gid]
-	return ok && len(groupedReadKeys) == 1
+	return true
 }
 
 func (c *ShardedCoordinator) dispatchSingleShardTxn(startTS, commitTS uint64, primaryKey []byte, gid uint64, elems []*Elem[OP], readKeys [][]byte) (*CoordinateResponse, error) {


### PR DESCRIPTION
Design document covering the side-channel approach recommended by etcd maintainers (etcd-io/etcd#9000): store FSM snapshot payload in a dedicated .fsm file on disk rather than in raftpb.Snapshot.Data, and carry only a 17-byte reference token (magic + version + index + CRC32C) in the raft snapshot message.

Key points documented:
- Eliminates peak memory spikes from spool.Bytes() / io.ReadAll
- Reduces MemoryStorage resident footprint from FSM size to 17 bytes
- CRC32C (Castagnoli) footer on every .fsm file; checksum also embedded in the token for pre-open metadata-level verification
- Crash-safe write sequence (tmp -> sync -> rename -> persist.SaveSnap)
- Backward-compatible with existing legacy snapshot format
- Phased implementation plan (local offload, then follower streaming, then cleanup)