### PR TITLE
feat(phase-2): implement Hash/Set/ZSet wide-column write+read paths with delta metadata

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1306,6 +1306,21 @@ func (r *RedisServer) collectUserKeys(kvs []*store.KVPair, pattern []byte) map[s
 	return keyset
 }
 
+// zsetWideColumnVisibleUserKey handles the ZSet-specific part of wide-column key mapping.
+// Returns (nil, true) for internal-only keys and (userKey, true) for visible keys.
+func zsetWideColumnVisibleUserKey(key []byte) (userKey []byte, isWide bool) {
+	if store.IsZSetMetaDeltaKey(key) || store.IsZSetMetaKey(key) {
+		return nil, true
+	}
+	if store.IsZSetMemberKey(key) {
+		return store.ExtractZSetUserKeyFromMember(key), true
+	}
+	if store.IsZSetScoreKey(key) {
+		return store.ExtractZSetUserKeyFromScore(key), true
+	}
+	return nil, false
+}
+
 // wideColumnVisibleUserKey maps a wide-column internal key to its visible user
 // key, or returns (nil, true) for internal-only keys (meta/delta), and
 // (nil, false) if the key is not a wide-column key at all.
@@ -1323,7 +1338,7 @@ func wideColumnVisibleUserKey(key []byte) (userKey []byte, isWide bool) {
 	if store.IsSetMemberKey(key) {
 		return store.ExtractSetUserKeyFromMember(key), true
 	}
-	return nil, false
+	return zsetWideColumnVisibleUserKey(key)
 }
 
 func redisVisibleUserKey(key []byte) []byte {
@@ -1431,9 +1446,11 @@ type listTxnState struct {
 }
 
 type zsetTxnState struct {
-	members map[string]float64
-	exists  bool
-	dirty   bool
+	members     map[string]float64 // current (potentially modified) state
+	origMembers map[string]float64 // original state at load time (for wide-column diff)
+	isWide      bool               // true if loaded from wide-column !zs|mem| storage
+	exists      bool
+	dirty       bool
 }
 
 type ttlTxnState struct {
@@ -1579,19 +1596,38 @@ func (t *txnContext) loadZSetState(key []byte) (*zsetTxnState, error) {
 	}
 	if ttlSt.value != nil && !ttlSt.value.After(time.Now()) {
 		st := &zsetTxnState{
-			members: map[string]float64{},
-			exists:  false,
+			members:     map[string]float64{},
+			origMembers: map[string]float64{},
+			exists:      false,
 		}
 		t.zsetStates[k] = st
 		return st, nil
 	}
+
+	// Detect wide-column storage by probing the !zs|mem| prefix.
+	memberPrefix := store.ZSetMemberScanPrefix(key)
+	memberEnd := store.PrefixScanEnd(memberPrefix)
+	probeKVs, probeErr := t.server.store.ScanAt(context.Background(), memberPrefix, memberEnd, 1, t.startTS)
+	if probeErr != nil {
+		return nil, errors.WithStack(probeErr)
+	}
+	isWide := len(probeKVs) > 0
+
 	value, exists, err := t.server.loadZSetAt(context.Background(), key, t.startTS)
 	if err != nil {
 		return nil, err
 	}
+	members := zsetEntriesToMap(value.Entries)
+	// Snapshot the original members for wide-column diff at commit time.
+	origMembers := make(map[string]float64, len(members))
+	for m, s := range members {
+		origMembers[m] = s
+	}
 	st := &zsetTxnState{
-		members: zsetEntriesToMap(value.Entries),
-		exists:  exists,
+		members:     members,
+		origMembers: origMembers,
+		isWide:      isWide,
+		exists:      exists,
 	}
 	t.zsetStates[k] = st
 	return st, nil
@@ -1971,7 +2007,7 @@ func (t *txnContext) commit() error {
 	// the coordinator assigns it during Dispatch.
 	commitTS := t.server.coordinator.Clock().Next()
 	listElems := t.buildListElems(commitTS)
-	zsetElems, err := t.buildZSetElems()
+	zsetElems, err := t.buildZSetElems(commitTS)
 	if err != nil {
 		return err
 	}
@@ -2101,7 +2137,7 @@ func (t *txnContext) buildListElems(commitTS uint64) []*kv.Elem[kv.OP] {
 	return elems
 }
 
-func (t *txnContext) buildZSetElems() ([]*kv.Elem[kv.OP], error) {
+func (t *txnContext) buildZSetElems(commitTS uint64) ([]*kv.Elem[kv.OP], error) {
 	keys := make([]string, 0, len(t.zsetStates))
 	for k := range t.zsetStates {
 		keys = append(keys, k)
@@ -2109,22 +2145,75 @@ func (t *txnContext) buildZSetElems() ([]*kv.Elem[kv.OP], error) {
 	sort.Strings(keys)
 
 	elems := make([]*kv.Elem[kv.OP], 0, len(keys))
+	seqInTxn := uint32(0)
 	for _, k := range keys {
 		st := t.zsetStates[k]
 		if !st.dirty {
 			continue
 		}
+		key := []byte(k)
+		if st.isWide {
+			wideElems, lenDelta := buildZSetWideElems(key, st)
+			elems = append(elems, wideElems...)
+			if lenDelta != 0 {
+				deltaVal := store.MarshalZSetMetaDelta(store.ZSetMetaDelta{LenDelta: lenDelta})
+				elems = append(elems, &kv.Elem[kv.OP]{
+					Op:    kv.Put,
+					Key:   store.ZSetMetaDeltaKey(key, commitTS, seqInTxn),
+					Value: deltaVal,
+				})
+				seqInTxn++
+			}
+			continue
+		}
+		// Legacy blob path.
 		if len(st.members) == 0 {
-			elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisZSetKey([]byte(k))})
+			elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisZSetKey(key)})
 			continue
 		}
 		payload, err := marshalZSetValue(redisZSetValue{Entries: zsetMapToEntries(st.members)})
 		if err != nil {
 			return nil, err
 		}
-		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: redisZSetKey([]byte(k)), Value: payload})
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: redisZSetKey(key), Value: payload})
 	}
 	return elems, nil
+}
+
+// buildZSetWideElems computes the minimal set of ops to transition from st.origMembers to
+// st.members in wide-column format. Returns the ops and the net length delta.
+func buildZSetWideElems(key []byte, st *zsetTxnState) ([]*kv.Elem[kv.OP], int64) {
+	elems := make([]*kv.Elem[kv.OP], 0, len(st.members)+len(st.origMembers))
+	var lenDelta int64
+
+	// Deletions: members removed or score changed (old score index must be removed).
+	for member, oldScore := range st.origMembers {
+		newScore, inNew := st.members[member]
+		if !inNew {
+			// Fully removed.
+			elems = append(elems,
+				&kv.Elem[kv.OP]{Op: kv.Del, Key: store.ZSetMemberKey(key, []byte(member))},
+				&kv.Elem[kv.OP]{Op: kv.Del, Key: store.ZSetScoreKey(key, oldScore, []byte(member))},
+			)
+			lenDelta--
+		} else if newScore != oldScore {
+			// Score updated: delete old score index.
+			elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: store.ZSetScoreKey(key, oldScore, []byte(member))})
+		}
+	}
+
+	// Insertions / updates.
+	for member, newScore := range st.members {
+		_, wasOrig := st.origMembers[member]
+		elems = append(elems,
+			&kv.Elem[kv.OP]{Op: kv.Put, Key: store.ZSetMemberKey(key, []byte(member)), Value: store.MarshalZSetScore(newScore)},
+			&kv.Elem[kv.OP]{Op: kv.Put, Key: store.ZSetScoreKey(key, newScore, []byte(member)), Value: []byte{}},
+		)
+		if !wasOrig {
+			lenDelta++
+		}
+	}
+	return elems, lenDelta
 }
 
 func (t *txnContext) buildTTLElems() []*kv.Elem[kv.OP] {

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1161,6 +1161,40 @@ func (r *RedisServer) localKeysExact(pattern []byte) ([][]byte, error) {
 	return [][]byte{}, nil
 }
 
+// mergeInternalNamespaces scans all internal key namespaces (list, hash, set, and
+// other internal prefixes) for keys that match pattern and merges them into the
+// caller's keyset via mergeScannedKeys. Called only when the pattern is bounded
+// (start != nil) because unbounded scans already cover the full keyspace.
+func (r *RedisServer) mergeInternalNamespaces(start []byte, pattern []byte, mergeScannedKeys func([]byte, []byte) error) error {
+	metaStart, metaEnd := listPatternScanBounds(store.ListMetaPrefix, pattern)
+	if err := mergeScannedKeys(metaStart, metaEnd); err != nil {
+		return err
+	}
+	itemStart, itemEnd := listPatternScanBounds(store.ListItemPrefix, pattern)
+	if err := mergeScannedKeys(itemStart, itemEnd); err != nil {
+		return err
+	}
+	for _, prefix := range redisInternalPrefixes {
+		internalStart, internalEnd := listPatternScanBounds(prefix, pattern)
+		if err := mergeScannedKeys(internalStart, internalEnd); err != nil {
+			return err
+		}
+	}
+	// Wide-column hash/set keys embed the user-key as
+	// <prefix><4-byte-len><userKey><field|member>, so the binary length
+	// prefix makes straightforward bounds-based scanning non-trivial.
+	// Use the user-key prefix as the lower bound and scan to the end of each
+	// namespace; collectUserKeys filters false positives by pattern.
+	hashFieldStart := store.HashFieldScanPrefix(start)
+	hashFieldEnd := prefixScanEnd([]byte(store.HashFieldPrefix))
+	if err := mergeScannedKeys(hashFieldStart, hashFieldEnd); err != nil {
+		return err
+	}
+	setMemberStart := store.SetMemberScanPrefix(start)
+	setMemberEnd := prefixScanEnd([]byte(store.SetMemberPrefix))
+	return mergeScannedKeys(setMemberStart, setMemberEnd)
+}
+
 func (r *RedisServer) localKeysPattern(pattern []byte) ([][]byte, error) {
 	start, end := patternScanBounds(pattern)
 	keyset := map[string][]byte{}
@@ -1184,21 +1218,8 @@ func (r *RedisServer) localKeysPattern(pattern []byte) ([][]byte, error) {
 	// and map them back to logical user keys.  For unbounded patterns
 	// (e.g. "*"), the full-keyspace scan already covers everything.
 	if start != nil {
-		metaStart, metaEnd := listPatternScanBounds(store.ListMetaPrefix, pattern)
-		if err := mergeScannedKeys(metaStart, metaEnd); err != nil {
+		if err := r.mergeInternalNamespaces(start, pattern, mergeScannedKeys); err != nil {
 			return nil, err
-		}
-
-		itemStart, itemEnd := listPatternScanBounds(store.ListItemPrefix, pattern)
-		if err := mergeScannedKeys(itemStart, itemEnd); err != nil {
-			return nil, err
-		}
-
-		for _, prefix := range redisInternalPrefixes {
-			internalStart, internalEnd := listPatternScanBounds(prefix, pattern)
-			if err := mergeScannedKeys(internalStart, internalEnd); err != nil {
-				return nil, err
-			}
 		}
 	}
 
@@ -1285,12 +1306,35 @@ func (r *RedisServer) collectUserKeys(kvs []*store.KVPair, pattern []byte) map[s
 	return keyset
 }
 
+// wideColumnVisibleUserKey maps a wide-column internal key to its visible user
+// key, or returns (nil, true) for internal-only keys (meta/delta), and
+// (nil, false) if the key is not a wide-column key at all.
+func wideColumnVisibleUserKey(key []byte) (userKey []byte, isWide bool) {
+	// Check delta prefixes before meta prefixes (delta starts with meta prefix).
+	if store.IsHashMetaDeltaKey(key) || store.IsHashMetaKey(key) {
+		return nil, true
+	}
+	if store.IsHashFieldKey(key) {
+		return store.ExtractHashUserKeyFromField(key), true
+	}
+	if store.IsSetMetaDeltaKey(key) || store.IsSetMetaKey(key) {
+		return nil, true
+	}
+	if store.IsSetMemberKey(key) {
+		return store.ExtractSetUserKeyFromMember(key), true
+	}
+	return nil, false
+}
+
 func redisVisibleUserKey(key []byte) []byte {
 	if bytes.HasPrefix(key, redisTxnKeyPrefix) || isRedisTTLKey(key) {
 		return nil
 	}
 	if store.IsListMetaKey(key) || store.IsListItemKey(key) {
 		return store.ExtractListUserKey(key)
+	}
+	if userKey, isWide := wideColumnVisibleUserKey(key); isWide {
+		return userKey
 	}
 	if userKey := extractRedisInternalUserKey(key); userKey != nil {
 		return userKey
@@ -1377,12 +1421,13 @@ type txnContext struct {
 }
 
 type listTxnState struct {
-	meta       store.ListMeta
-	metaExists bool
-	appends    [][]byte
-	deleted    bool
-	purge      bool
-	purgeMeta  store.ListMeta
+	meta           store.ListMeta
+	metaExists     bool
+	appends        [][]byte
+	deleted        bool
+	purge          bool
+	purgeMeta      store.ListMeta
+	existingDeltas [][]byte // delta key bytes present at load time; deleted on purge/delete
 }
 
 type zsetTxnState struct {
@@ -1484,25 +1529,34 @@ func (t *txnContext) loadListState(key []byte) (*listTxnState, error) {
 	if st, ok := t.listStates[k]; ok {
 		return st, nil
 	}
-	// Track listMetaKey (length/tail-pointer) and redisTTLKey as read
-	// dependencies. Individual list element keys (listItemKey) are NOT tracked
-	// because every list write operation (RPUSH, DEL) updates listMetaKey;
-	// a stale element read is therefore always detected via a stale meta read.
-	// A hypothetical LSET (in-place element mutation without touching meta)
-	// would require tracking individual element keys, but LSET is not
-	// currently supported.
-	t.trackReadKey(listMetaKey(key))
+	// With the Delta pattern we no longer read-modify-write the single base
+	// meta key, so there is no OCC conflict to track on it.
 	t.trackReadKey(redisTTLKey(key))
 
-	meta, exists, err := t.server.loadListMetaAt(context.Background(), key, t.startTS)
+	ctx := context.Background()
+	meta, exists, err := t.server.resolveListMeta(ctx, key, t.startTS)
 	if err != nil {
 		return nil, err
 	}
 
+	// Capture existing delta keys so they can be deleted if the list is later
+	// purged or deleted within this transaction.
+	deltaPrefix := store.ListMetaDeltaScanPrefix(key)
+	deltaEnd := store.PrefixScanEnd(deltaPrefix)
+	deltaKVs, err := t.server.store.ScanAt(ctx, deltaPrefix, deltaEnd, store.MaxDeltaScanLimit, t.startTS)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	existingDeltas := make([][]byte, 0, len(deltaKVs))
+	for _, kv := range deltaKVs {
+		existingDeltas = append(existingDeltas, kv.Key)
+	}
+
 	st := &listTxnState{
-		meta:       meta,
-		metaExists: exists,
-		appends:    [][]byte{},
+		meta:           meta,
+		metaExists:     exists,
+		appends:        [][]byte{},
+		existingDeltas: existingDeltas,
 	}
 	t.listStates[k] = st
 	return st, nil
@@ -1913,10 +1967,10 @@ func (t *txnContext) validateReadSet(ctx context.Context) error {
 func (t *txnContext) commit() error {
 	elems := t.buildKeyElems()
 
-	listElems, err := t.buildListElems()
-	if err != nil {
-		return err
-	}
+	// Pre-allocate commitTS so Delta keys can embed it in their bytes before
+	// the coordinator assigns it during Dispatch.
+	commitTS := t.server.coordinator.Clock().Next()
+	listElems := t.buildListElems(commitTS)
 	zsetElems, err := t.buildZSetElems()
 	if err != nil {
 		return err
@@ -1934,7 +1988,13 @@ func (t *txnContext) commit() error {
 	for _, k := range t.readKeys {
 		readKeys = append(readKeys, k)
 	}
-	group := &kv.OperationGroup[kv.OP]{IsTxn: true, Elems: elems, StartTS: t.startTS, ReadKeys: readKeys}
+	group := &kv.OperationGroup[kv.OP]{
+		IsTxn:    true,
+		Elems:    elems,
+		StartTS:  t.startTS,
+		CommitTS: commitTS,
+		ReadKeys: readKeys,
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
 	defer cancel()
 	if _, err := t.server.coordinator.Dispatch(ctx, group); err != nil {
@@ -1984,7 +2044,7 @@ func appendListDeleteOps(elems []*kv.Elem[kv.OP], userKey []byte, meta store.Lis
 	return append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: listMetaKey(userKey)})
 }
 
-func (t *txnContext) buildListElems() ([]*kv.Elem[kv.OP], error) {
+func (t *txnContext) buildListElems(commitTS uint64) []*kv.Elem[kv.OP] {
 	listKeys := make([]string, 0, len(t.listStates))
 	for k := range t.listStates {
 		listKeys = append(listKeys, k)
@@ -1992,6 +2052,7 @@ func (t *txnContext) buildListElems() ([]*kv.Elem[kv.OP], error) {
 	sort.Strings(listKeys)
 
 	var elems []*kv.Elem[kv.OP]
+	var seqInTxn uint32
 	for _, k := range listKeys {
 		st := t.listStates[k]
 		userKey := []byte(k)
@@ -2000,6 +2061,10 @@ func (t *txnContext) buildListElems() ([]*kv.Elem[kv.OP], error) {
 			if meta, ok := listDeleteMeta(st); ok {
 				elems = appendListDeleteOps(elems, userKey, meta)
 			}
+			// Delete existing delta keys so they don't survive the logical delete.
+			for _, dk := range st.existingDeltas {
+				elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: dk})
+			}
 			continue
 		}
 		if len(st.appends) == 0 {
@@ -2007,6 +2072,10 @@ func (t *txnContext) buildListElems() ([]*kv.Elem[kv.OP], error) {
 		}
 		if st.purge {
 			elems = appendListDeleteOps(elems, userKey, st.purgeMeta)
+			// Delete existing delta keys so they don't accumulate after DEL+RPUSH.
+			for _, dk := range st.existingDeltas {
+				elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: dk})
+			}
 		}
 
 		startSeq := st.meta.Head + st.meta.Len
@@ -2018,15 +2087,18 @@ func (t *txnContext) buildListElems() ([]*kv.Elem[kv.OP], error) {
 			})
 		}
 
-		st.meta.Len += int64(len(st.appends))
-		st.meta.Tail = st.meta.Head + st.meta.Len
-		metaBytes, err := store.MarshalListMeta(st.meta)
-		if err != nil {
-			return nil, errors.WithStack(err)
-		}
-		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: listMetaKey(userKey), Value: metaBytes})
+		// Emit a Delta key instead of updating the base metadata key.
+		// Each list key in this transaction gets a unique seqInTxn.
+		n := int64(len(st.appends))
+		deltaVal := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: 0, LenDelta: n})
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.ListMetaDeltaKey(userKey, commitTS, seqInTxn),
+			Value: deltaVal,
+		})
+		seqInTxn++
 	}
-	return elems, nil
+	return elems
 }
 
 func (t *txnContext) buildZSetElems() ([]*kv.Elem[kv.OP], error) {
@@ -2247,7 +2319,12 @@ func (r *RedisServer) isListKeyAt(ctx context.Context, key []byte, readTS uint64
 	return exists, err
 }
 
-func (r *RedisServer) buildRPushOps(meta store.ListMeta, key []byte, values [][]byte) ([]*kv.Elem[kv.OP], store.ListMeta, error) {
+// buildRPushOps creates operations to append values to the tail of a list using
+// the Delta pattern. Instead of writing to the base metadata key (causing OCC
+// conflicts), it emits a single ListMetaDelta key with LenDelta = len(values).
+// commitTS must be pre-allocated via dispatchElemsWithCommitTS; seqInTxn
+// disambiguates multiple push operations in the same transaction.
+func (r *RedisServer) buildRPushOps(meta store.ListMeta, key []byte, values [][]byte, commitTS uint64, seqInTxn uint32) ([]*kv.Elem[kv.OP], store.ListMeta, error) {
 	if len(values) == 0 {
 		return nil, meta, nil
 	}
@@ -2260,40 +2337,65 @@ func (r *RedisServer) buildRPushOps(meta store.ListMeta, key []byte, values [][]
 		seq++
 	}
 
+	// Emit a Delta key instead of writing the base meta key.
+	delta := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: 0, LenDelta: int64(len(values))})
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: store.ListMetaDeltaKey(key, commitTS, seqInTxn), Value: delta})
+
 	meta.Len += int64(len(values))
 	meta.Tail = meta.Head + meta.Len
-
-	b, err := store.MarshalListMeta(meta)
-	if err != nil {
-		return nil, meta, errors.WithStack(err)
-	}
-
-	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: listMetaKey(key), Value: b})
 	return elems, meta, nil
 }
 
-func (r *RedisServer) listRPush(ctx context.Context, key []byte, values [][]byte) (int64, error) {
-	readTS := r.readTS()
-	meta, _, err := r.loadListMetaAt(ctx, key, readTS)
-	if err != nil {
-		return 0, err
-	}
+// listPushBuildFn is the type for functions that build list push operations.
+type listPushBuildFn func(meta store.ListMeta, key []byte, values [][]byte, commitTS uint64, seqInTxn uint32) ([]*kv.Elem[kv.OP], store.ListMeta, error)
 
-	ops, newMeta, err := r.buildRPushOps(meta, key, values)
-	if err != nil {
-		return 0, err
-	}
-	if len(ops) == 0 {
-		return newMeta.Len, nil
-	}
+// listPushCore is the shared retry loop for RPUSH and LPUSH. The caller supplies
+// a buildFn that assembles the specific operations (RPUSH appends to tail, LPUSH
+// prepends to head).
+func (r *RedisServer) listPushCore(ctx context.Context, key []byte, values [][]byte, buildFn listPushBuildFn) (int64, error) {
+	var newLen int64
+	err := r.retryRedisWrite(ctx, func() error {
+		readTS := r.readTS()
+		meta, _, err := r.resolveListMeta(ctx, key, readTS)
+		if err != nil {
+			return err
+		}
 
-	return newMeta.Len, r.dispatchElems(ctx, true, readTS, ops)
+		// Pre-allocate commitTS so we can embed it in the Delta key.
+		commitTS := r.coordinator.Clock().Next()
+		ops, updatedMeta, err := buildFn(meta, key, values, commitTS, 0)
+		if err != nil {
+			return err
+		}
+		if len(ops) == 0 {
+			newLen = updatedMeta.Len
+			return nil
+		}
+
+		// Dispatch with the pre-allocated commitTS.
+		_, dispErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+			IsTxn:    true,
+			StartTS:  normalizeStartTS(readTS),
+			CommitTS: commitTS,
+			Elems:    ops,
+		})
+		if dispErr != nil {
+			return errors.WithStack(dispErr)
+		}
+		newLen = updatedMeta.Len
+		return nil
+	})
+	return newLen, err
 }
 
-// buildLPushOps creates Raft operations to prepend values to the head of a list.
-// This is O(k) where k = len(values), not O(N) where N is the total list length.
-// LPUSH reverses the order of arguments: LPUSH key a b c → [c, b, a, ...existing].
-func (r *RedisServer) buildLPushOps(meta store.ListMeta, key []byte, values [][]byte) ([]*kv.Elem[kv.OP], store.ListMeta, error) {
+func (r *RedisServer) listRPush(ctx context.Context, key []byte, values [][]byte) (int64, error) {
+	return r.listPushCore(ctx, key, values, r.buildRPushOps)
+}
+
+// buildLPushOps creates operations to prepend values to the head of a list using
+// the Delta pattern. LPUSH reverses the order of arguments:
+// LPUSH key a b c → [c, b, a, ...existing].
+func (r *RedisServer) buildLPushOps(meta store.ListMeta, key []byte, values [][]byte, commitTS uint64, seqInTxn uint32) ([]*kv.Elem[kv.OP], store.ListMeta, error) {
 	if len(values) == 0 {
 		return nil, meta, nil
 	}
@@ -2312,35 +2414,17 @@ func (r *RedisServer) buildLPushOps(meta store.ListMeta, key []byte, values [][]
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: listItemKey(key, seq), Value: vCopy})
 	}
 
+	// Emit a Delta key instead of writing the base meta key.
+	delta := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: -n, LenDelta: n})
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: store.ListMetaDeltaKey(key, commitTS, seqInTxn), Value: delta})
+
 	meta.Head = newHead
 	meta.Len += n
-	// Tail stays the same: Tail = oldHead + oldLen = newHead + newLen
-
-	b, err := store.MarshalListMeta(meta)
-	if err != nil {
-		return nil, meta, errors.WithStack(err)
-	}
-
-	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: listMetaKey(key), Value: b})
 	return elems, meta, nil
 }
 
 func (r *RedisServer) listLPush(ctx context.Context, key []byte, values [][]byte) (int64, error) {
-	readTS := r.readTS()
-	meta, _, err := r.loadListMetaAt(ctx, key, readTS)
-	if err != nil {
-		return 0, err
-	}
-
-	ops, newMeta, err := r.buildLPushOps(meta, key, values)
-	if err != nil {
-		return 0, err
-	}
-	if len(ops) == 0 {
-		return newMeta.Len, nil
-	}
-
-	return newMeta.Len, r.dispatchElems(ctx, true, readTS, ops)
+	return r.listPushCore(ctx, key, values, r.buildLPushOps)
 }
 
 func (r *RedisServer) fetchListRange(ctx context.Context, key []byte, meta store.ListMeta, startIdx, endIdx int64, readTS uint64) ([]string, error) {
@@ -2387,7 +2471,7 @@ func (r *RedisServer) rangeList(key []byte, startRaw, endRaw []byte) ([]string, 
 		return nil, errors.WithStack(err)
 	}
 
-	meta, exists, err := r.loadListMetaAt(context.Background(), key, readTS)
+	meta, exists, err := r.resolveListMeta(context.Background(), key, readTS)
 	if err != nil {
 		return nil, err
 	}

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/bootjp/elastickv/kv"
+	"github.com/bootjp/elastickv/store"
+	cockerrors "github.com/cockroachdb/errors"
 	"github.com/tidwall/redcon"
 )
 
@@ -22,6 +24,11 @@ const (
 	pubsubFirstChannel   = 2
 	redisBusyPollBackoff = 10 * time.Millisecond
 	redisKeywordCount    = "COUNT"
+
+	// setWideColOverhead is the number of extra elements reserved in a set
+	// wide-column mutation slice beyond the per-member elements: one for the
+	// metadata key and one for the legacy-blob deletion tombstone.
+	setWideColOverhead = 2
 )
 
 type xreadRequest struct {
@@ -546,21 +553,33 @@ func (r *RedisServer) flushDatabase(conn redcon.Conn, all bool) {
 			return fmt.Errorf("verify leader: %w", err)
 		}
 
-		// Delete only Redis-related keys. Three DEL_PREFIX operations cover
-		// all Redis namespaces: "!redis|" (str, hash, set, zset, hll,
-		// stream, ttl), "!lst|" (list meta + items), and "!zs|" (zset
-		// wide-column meta/member/score).
+		// Delete only Redis-related keys. Each DEL_PREFIX operation must be
+		// dispatched separately because the FSM processes only one DEL_PREFIX
+		// per request (the first mutation).
+		//
+		// Namespaces covered:
+		//   "!redis|" — str, legacy hash/set/zset/hll/stream, ttl
+		//   "!lst|"   — list meta + items
+		//   "!zs|"    — zset wide-column
+		//   "!hs|"    — hash wide-column meta/field/delta
+		//   "!st|"    — set wide-column meta/member/delta
+		//
 		// Legacy bare keys are NOT deleted here to avoid a full keyspace
 		// scan. Run FLUSHLEGACY first to clean up legacy data.
-		_, err := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
-			Elems: []*kv.Elem[kv.OP]{
-				{Op: kv.DelPrefix, Key: []byte("!redis|")},
-				{Op: kv.DelPrefix, Key: []byte("!lst|")},
-				{Op: kv.DelPrefix, Key: []byte("!zs|")},
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("dispatch del_prefix: %w", err)
+		for _, prefix := range [][]byte{
+			[]byte("!redis|"),
+			[]byte("!lst|"),
+			[]byte("!zs|"),
+			[]byte("!hs|"),
+			[]byte("!st|"),
+		} {
+			if _, err := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+				Elems: []*kv.Elem[kv.OP]{
+					{Op: kv.DelPrefix, Key: prefix},
+				},
+			}); err != nil {
+				return fmt.Errorf("dispatch del_prefix %q: %w", prefix, err)
+			}
 		}
 		return nil
 	}); err != nil {
@@ -625,14 +644,14 @@ func (r *RedisServer) sadd(conn redcon.Conn, cmd redcon.Command) {
 	if r.proxyToLeader(conn, cmd, cmd.Args[1]) {
 		return
 	}
-	r.mutateExactSet(conn, "set", cmd.Args[1], cmd.Args[2:], true)
+	r.mutateExactSet(conn, setKind, cmd.Args[1], cmd.Args[2:], true)
 }
 
 func (r *RedisServer) srem(conn redcon.Conn, cmd redcon.Command) {
 	if r.proxyToLeader(conn, cmd, cmd.Args[1]) {
 		return
 	}
-	r.mutateExactSet(conn, "set", cmd.Args[1], cmd.Args[2:], false)
+	r.mutateExactSet(conn, setKind, cmd.Args[1], cmd.Args[2:], false)
 }
 
 func (r *RedisServer) validateExactSetKind(kind string, key []byte, readTS uint64) error {
@@ -642,9 +661,9 @@ func (r *RedisServer) validateExactSetKind(kind string, key []byte, readTS uint6
 	}
 
 	switch kind {
-	case "set":
+	case setKind:
 		return r.validateExactSetType(typ, key, readTS)
-	case "hll":
+	case hllKind:
 		return r.validateExactHLLType(typ, key, readTS)
 	default:
 		return errors.New("ERR unsupported exact set kind")
@@ -731,6 +750,24 @@ func sortedExactSetMembers(existing map[string]struct{}) []string {
 }
 
 func (r *RedisServer) persistExactSetMembersTxn(ctx context.Context, kind string, key []byte, readTS uint64, members map[string]struct{}) error {
+	if kind != setKind {
+		// HLL and other non-set kinds keep using the legacy blob format.
+		if len(members) == 0 {
+			elems, _, err := r.deleteLogicalKeyElems(ctx, key, readTS)
+			if err != nil {
+				return err
+			}
+			return r.dispatchElems(ctx, true, readTS, elems)
+		}
+		payload, err := marshalSetValue(redisSetValue{Members: sortedExactSetMembers(members)})
+		if err != nil {
+			return err
+		}
+		return r.dispatchElems(ctx, true, readTS, []*kv.Elem[kv.OP]{
+			{Op: kv.Put, Key: redisExactSetStorageKey(kind, key), Value: payload},
+		})
+	}
+	// Wide-column set: full rewrite (used when the whole state is available).
 	if len(members) == 0 {
 		elems, _, err := r.deleteLogicalKeyElems(ctx, key, readTS)
 		if err != nil {
@@ -738,18 +775,38 @@ func (r *RedisServer) persistExactSetMembersTxn(ctx context.Context, kind string
 		}
 		return r.dispatchElems(ctx, true, readTS, elems)
 	}
-	payload, err := marshalSetValue(redisSetValue{Members: sortedExactSetMembers(members)})
-	if err != nil {
-		return err
+	elems := make([]*kv.Elem[kv.OP], 0, len(members)+setWideColOverhead)
+	for member := range members {
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.SetMemberKey(key, []byte(member)),
+			Value: []byte{},
+		})
 	}
-	return r.dispatchElems(ctx, true, readTS, []*kv.Elem[kv.OP]{
-		{Op: kv.Put, Key: redisExactSetStorageKey(kind, key), Value: payload},
+	elems = append(elems, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   store.SetMetaKey(key),
+		Value: store.MarshalSetMeta(store.SetMeta{Len: int64(len(members))}),
 	})
+	// Remove legacy blob if present.
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisSetKey(key)})
+	return r.dispatchElems(ctx, true, readTS, elems)
 }
 
-func (r *RedisServer) mutateExactSet(conn redcon.Conn, kind string, key []byte, members [][]byte, add bool) {
-	ctx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
-	defer cancel()
+// applySetMemberMutation emits a Put or Del for one set member and returns the
+// change count (1) and the signed length delta (+1 or -1), or (0, 0) if no change.
+func applySetMemberMutation(elems []*kv.Elem[kv.OP], memberKey []byte, exists, add bool) ([]*kv.Elem[kv.OP], int, int64) {
+	if add && !exists {
+		return append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: memberKey, Value: []byte{}}), 1, 1
+	}
+	if !add && exists {
+		return append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: memberKey}), 1, -1
+	}
+	return elems, 0, 0
+}
+
+// mutateExactSetLegacy handles SADD/SREM for non-set kinds (e.g. HLL) via the legacy blob path.
+func (r *RedisServer) mutateExactSetLegacy(conn redcon.Conn, ctx context.Context, kind string, key []byte, members [][]byte, add bool) {
 	var changed int
 	if err := r.retryRedisWrite(ctx, func() error {
 		readTS := r.readTS()
@@ -773,6 +830,81 @@ func (r *RedisServer) mutateExactSet(conn redcon.Conn, kind string, key []byte, 
 	conn.WriteInt(changed)
 }
 
+// mutateExactSetWide handles SADD/SREM for the wide-column set path.
+func (r *RedisServer) mutateExactSetWide(conn redcon.Conn, ctx context.Context, key []byte, members [][]byte, add bool) {
+	var changed int
+	if err := r.retryRedisWrite(ctx, func() error {
+		readTS := r.readTS()
+		if err := r.validateExactSetKind(setKind, key, readTS); err != nil {
+			return err
+		}
+
+		commitTS := r.coordinator.Clock().Next()
+		elems := make([]*kv.Elem[kv.OP], 0, len(members)+setWideColOverhead)
+
+		migrationElems, migErr := r.buildSetLegacyMigrationElems(ctx, key, readTS)
+		if migErr != nil {
+			return migErr
+		}
+		elems = append(elems, migrationElems...)
+
+		changed = 0
+		lenDelta := int64(0)
+		for _, member := range members {
+			memberKey := store.SetMemberKey(key, member)
+			exists, existsErr := r.store.ExistsAt(ctx, memberKey, readTS)
+			if existsErr != nil {
+				return cockerrors.WithStack(existsErr)
+			}
+			var c int
+			var d int64
+			elems, c, d = applySetMemberMutation(elems, memberKey, exists, add)
+			changed += c
+			lenDelta += d
+		}
+
+		if changed == 0 && len(migrationElems) == 0 {
+			return nil
+		}
+
+		if lenDelta != 0 {
+			deltaVal := store.MarshalSetMetaDelta(store.SetMetaDelta{LenDelta: lenDelta})
+			elems = append(elems, &kv.Elem[kv.OP]{
+				Op:    kv.Put,
+				Key:   store.SetMetaDeltaKey(key, commitTS, 0),
+				Value: deltaVal,
+			})
+		}
+
+		if len(elems) == 0 {
+			return nil
+		}
+
+		_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+			IsTxn:    true,
+			StartTS:  normalizeStartTS(readTS),
+			CommitTS: commitTS,
+			Elems:    elems,
+		})
+		return cockerrors.WithStack(dispatchErr)
+	}); err != nil {
+		conn.WriteError(err.Error())
+		return
+	}
+	conn.WriteInt(changed)
+}
+
+func (r *RedisServer) mutateExactSet(conn redcon.Conn, kind string, key []byte, members [][]byte, add bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
+	defer cancel()
+
+	if kind != setKind {
+		r.mutateExactSetLegacy(conn, ctx, kind, key, members, add)
+		return
+	}
+	r.mutateExactSetWide(conn, ctx, key, members, add)
+}
+
 func (r *RedisServer) sismember(conn redcon.Conn, cmd redcon.Command) {
 	if r.proxyToLeader(conn, cmd, cmd.Args[1]) {
 		return
@@ -792,7 +924,7 @@ func (r *RedisServer) sismember(conn redcon.Conn, cmd redcon.Command) {
 		return
 	}
 
-	value, err := r.loadSetAt(context.Background(), "set", cmd.Args[1], readTS)
+	value, err := r.loadSetAt(context.Background(), setKind, cmd.Args[1], readTS)
 	if err != nil {
 		conn.WriteError(err.Error())
 		return
@@ -823,7 +955,7 @@ func (r *RedisServer) smembers(conn redcon.Conn, cmd redcon.Command) {
 		return
 	}
 
-	value, err := r.loadSetAt(context.Background(), "set", cmd.Args[1], readTS)
+	value, err := r.loadSetAt(context.Background(), setKind, cmd.Args[1], readTS)
 	if err != nil {
 		conn.WriteError(err.Error())
 		return
@@ -843,11 +975,11 @@ func (r *RedisServer) pfadd(conn redcon.Conn, cmd redcon.Command) {
 	var changed int
 	if err := r.retryRedisWrite(ctx, func() error {
 		readTS := r.readTS()
-		if err := r.validateExactSetKind("hll", cmd.Args[1], readTS); err != nil {
+		if err := r.validateExactSetKind(hllKind, cmd.Args[1], readTS); err != nil {
 			return err
 		}
 
-		value, err := r.loadSetAt(context.Background(), "hll", cmd.Args[1], readTS)
+		value, err := r.loadSetAt(context.Background(), hllKind, cmd.Args[1], readTS)
 		if err != nil {
 			return err
 		}
@@ -857,7 +989,7 @@ func (r *RedisServer) pfadd(conn redcon.Conn, cmd redcon.Command) {
 			return nil
 		}
 
-		return r.persistExactSetMembersTxn(ctx, "hll", cmd.Args[1], readTS, existing)
+		return r.persistExactSetMembersTxn(ctx, hllKind, cmd.Args[1], readTS, existing)
 	}); err != nil {
 		conn.WriteError(err.Error())
 		return
@@ -892,7 +1024,7 @@ func (r *RedisServer) pfcount(conn redcon.Conn, cmd redcon.Command) {
 				return
 			}
 		}
-		value, err := r.loadSetAt(context.Background(), "hll", key, readTS)
+		value, err := r.loadSetAt(context.Background(), hllKind, key, readTS)
 		if err != nil {
 			conn.WriteError(err.Error())
 			return
@@ -927,16 +1059,93 @@ func (r *RedisServer) hmset(conn redcon.Conn, cmd redcon.Command) {
 	conn.WriteString("OK")
 }
 
-func applyHashPairs(value redisHashValue, args [][]byte) int {
-	added := 0
-	for i := 0; i < len(args); i += redisPairWidth {
-		field := string(args[i])
-		if _, ok := value[field]; !ok {
-			added++
-		}
-		value[field] = string(args[i+1])
+// buildHashLegacyMigrationElems returns ops that atomically migrate a legacy
+// !redis|hash| blob to wide-column !hs|fld| keys.  Returns nil if no legacy
+// blob exists.  The base meta key is also written with the migrated count so
+// that resolveHashMeta works correctly after migration.
+func (r *RedisServer) buildHashLegacyMigrationElems(ctx context.Context, key []byte, readTS uint64) ([]*kv.Elem[kv.OP], error) {
+	raw, err := r.store.GetAt(ctx, redisHashKey(key), readTS)
+	if cockerrors.Is(err, store.ErrKeyNotFound) {
+		return nil, nil
 	}
-	return added
+	if err != nil {
+		return nil, cockerrors.WithStack(err)
+	}
+	value, err := unmarshalHashValue(raw)
+	if err != nil {
+		return nil, err
+	}
+	elems := make([]*kv.Elem[kv.OP], 0, len(value)+setWideColOverhead)
+	for field, val := range value {
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.HashFieldKey(key, []byte(field)),
+			Value: []byte(val),
+		})
+	}
+	// Delete the legacy blob.
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisHashKey(key)})
+	// Write a base meta so that resolveHashMeta starts from an accurate count.
+	elems = append(elems, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   store.HashMetaKey(key),
+		Value: store.MarshalHashMeta(store.HashMeta{Len: int64(len(value))}),
+	})
+	return elems, nil
+}
+
+// buildSetLegacyMigrationElems returns ops that atomically migrate a legacy
+// !redis|set| blob to wide-column !st|mem| keys.  Returns nil if no legacy
+// blob exists.
+func (r *RedisServer) buildSetLegacyMigrationElems(ctx context.Context, key []byte, readTS uint64) ([]*kv.Elem[kv.OP], error) {
+	raw, err := r.store.GetAt(ctx, redisSetKey(key), readTS)
+	if cockerrors.Is(err, store.ErrKeyNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, cockerrors.WithStack(err)
+	}
+	value, err := unmarshalSetValue(raw)
+	if err != nil {
+		return nil, err
+	}
+	elems := make([]*kv.Elem[kv.OP], 0, len(value.Members)+setWideColOverhead)
+	for _, member := range value.Members {
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.SetMemberKey(key, []byte(member)),
+			Value: []byte{},
+		})
+	}
+	// Delete the legacy blob.
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisSetKey(key)})
+	// Write a base meta so that resolveSetMeta starts from an accurate count.
+	elems = append(elems, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   store.SetMetaKey(key),
+		Value: store.MarshalSetMeta(store.SetMeta{Len: int64(len(value.Members))}),
+	})
+	return elems, nil
+}
+
+// buildHashFieldElems iterates over field-value pairs in args, records whether each field is
+// new vs. existing, appends Put operations to elems, and returns the updated elems and new-field count.
+func (r *RedisServer) buildHashFieldElems(ctx context.Context, key []byte, args [][]byte, readTS uint64, elems []*kv.Elem[kv.OP]) ([]*kv.Elem[kv.OP], int, error) {
+	newFields := 0
+	for i := 0; i < len(args); i += redisPairWidth {
+		field := args[i]
+		value := args[i+1]
+		fieldKey := store.HashFieldKey(key, field)
+		exists, existsErr := r.store.ExistsAt(ctx, fieldKey, readTS)
+		if existsErr != nil {
+			return nil, 0, cockerrors.WithStack(existsErr)
+		}
+		if !exists {
+			newFields++
+		}
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: fieldKey, Value: value})
+	}
+	return elems, newFields, nil
 }
 
 func (r *RedisServer) applyHashFieldPairs(key []byte, args [][]byte) (int, error) {
@@ -956,18 +1165,45 @@ func (r *RedisServer) applyHashFieldPairs(key []byte, args [][]byte) (int, error
 		if typ != redisTypeNone && typ != redisTypeHash {
 			return wrongTypeError()
 		}
-		value, err := r.loadHashAt(context.Background(), key, readTS)
+
+		commitTS := r.coordinator.Clock().Next()
+		elems := make([]*kv.Elem[kv.OP], 0, len(args)/redisPairWidth+setWideColOverhead)
+
+		// Atomically migrate any legacy blob on first wide-column write.
+		migrationElems, err := r.buildHashLegacyMigrationElems(ctx, key, readTS)
 		if err != nil {
 			return err
 		}
-		added = applyHashPairs(value, args)
-		payload, err := marshalHashValue(value)
+		elems = append(elems, migrationElems...)
+
+		var newFields int
+		elems, newFields, err = r.buildHashFieldElems(ctx, key, args, readTS, elems)
 		if err != nil {
 			return err
 		}
-		return r.dispatchElems(ctx, true, readTS, []*kv.Elem[kv.OP]{
-			{Op: kv.Put, Key: redisHashKey(key), Value: payload},
+		added = newFields
+
+		// Emit a single delta key for all newly-added fields.
+		if newFields != 0 {
+			deltaVal := store.MarshalHashMetaDelta(store.HashMetaDelta{LenDelta: int64(newFields)})
+			elems = append(elems, &kv.Elem[kv.OP]{
+				Op:    kv.Put,
+				Key:   store.HashMetaDeltaKey(key, commitTS, 0),
+				Value: deltaVal,
+			})
+		}
+
+		if len(elems) == 0 {
+			return nil
+		}
+
+		_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+			IsTxn:    true,
+			StartTS:  normalizeStartTS(readTS),
+			CommitTS: commitTS,
+			Elems:    elems,
 		})
+		return cockerrors.WithStack(dispatchErr)
 	})
 	return added, err
 }
@@ -1061,6 +1297,40 @@ func (r *RedisServer) hdel(conn redcon.Conn, cmd redcon.Command) {
 	conn.WriteInt(removed)
 }
 
+// hdelWideColumn deletes the given fields from the wide-column hash and emits a negative delta.
+func (r *RedisServer) hdelWideColumn(ctx context.Context, key []byte, fields [][]byte, readTS uint64) (int, error) {
+	commitTS := r.coordinator.Clock().Next()
+	elems := make([]*kv.Elem[kv.OP], 0, len(fields)+1)
+	removed := 0
+	for _, field := range fields {
+		fieldKey := store.HashFieldKey(key, field)
+		exists, existsErr := r.store.ExistsAt(ctx, fieldKey, readTS)
+		if existsErr != nil {
+			return 0, cockerrors.WithStack(existsErr)
+		}
+		if exists {
+			elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: fieldKey})
+			removed++
+		}
+	}
+	if removed == 0 {
+		return 0, nil
+	}
+	deltaVal := store.MarshalHashMetaDelta(store.HashMetaDelta{LenDelta: int64(-removed)})
+	elems = append(elems, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   store.HashMetaDeltaKey(key, commitTS, 0),
+		Value: deltaVal,
+	})
+	_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+		IsTxn:    true,
+		StartTS:  normalizeStartTS(readTS),
+		CommitTS: commitTS,
+		Elems:    elems,
+	})
+	return removed, cockerrors.WithStack(dispatchErr)
+}
+
 func (r *RedisServer) hdelTxn(ctx context.Context, key []byte, fields [][]byte) (int, error) {
 	readTS := r.readTS()
 	typ, err := r.keyTypeAt(context.Background(), key, readTS)
@@ -1073,6 +1343,19 @@ func (r *RedisServer) hdelTxn(ctx context.Context, key []byte, fields [][]byte) 
 	if typ != redisTypeHash {
 		return 0, wrongTypeError()
 	}
+
+	// Wide-column path: check if any !hs|fld| keys exist for this key.
+	hashFieldPrefix := store.HashFieldScanPrefix(key)
+	hashFieldEnd := store.PrefixScanEnd(hashFieldPrefix)
+	wideKVs, err := r.store.ScanAt(context.Background(), hashFieldPrefix, hashFieldEnd, 1, readTS)
+	if err != nil {
+		return 0, cockerrors.WithStack(err)
+	}
+	if len(wideKVs) > 0 {
+		return r.hdelWideColumn(ctx, key, fields, readTS)
+	}
+
+	// Legacy blob path.
 	value, err := r.loadHashAt(context.Background(), key, readTS)
 	if err != nil {
 		return 0, err
@@ -1103,13 +1386,24 @@ func (r *RedisServer) persistHashTxn(ctx context.Context, key []byte, readTS uin
 		}
 		return r.dispatchElems(ctx, true, readTS, elems)
 	}
-	payload, err := marshalHashValue(value)
-	if err != nil {
-		return err
+	// Wide-column rewrite: write per-field keys and a new base meta.
+	// deleteLogicalKeyElems (called by the caller when needed) clears old keys.
+	elems := make([]*kv.Elem[kv.OP], 0, len(value)+1)
+	for field, val := range value {
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.HashFieldKey(key, []byte(field)),
+			Value: []byte(val),
+		})
 	}
-	return r.dispatchElems(ctx, true, readTS, []*kv.Elem[kv.OP]{
-		{Op: kv.Put, Key: redisHashKey(key), Value: payload},
+	elems = append(elems, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   store.HashMetaKey(key),
+		Value: store.MarshalHashMeta(store.HashMeta{Len: int64(len(value))}),
 	})
+	// Also remove the legacy blob if it was present.
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisHashKey(key)})
+	return r.dispatchElems(ctx, true, readTS, elems)
 }
 
 func (r *RedisServer) hexists(conn redcon.Conn, cmd redcon.Command) {
@@ -1162,6 +1456,17 @@ func (r *RedisServer) hlen(conn redcon.Conn, cmd redcon.Command) {
 		return
 	}
 
+	// Wide-column path: use delta-aggregated metadata for O(1) count.
+	count, exists, err := r.resolveHashMeta(context.Background(), cmd.Args[1], readTS)
+	if err != nil {
+		conn.WriteError(err.Error())
+		return
+	}
+	if exists {
+		conn.WriteInt64(count)
+		return
+	}
+	// Legacy blob fallback: load all fields and count.
 	value, err := r.loadHashAt(context.Background(), cmd.Args[1], readTS)
 	if err != nil {
 		conn.WriteError(err.Error())
@@ -1194,6 +1499,66 @@ func (r *RedisServer) hincrby(conn redcon.Conn, cmd redcon.Command) {
 	conn.WriteInt64(current)
 }
 
+// readHashFieldInt reads the current integer value of a hash field from wide-column or legacy storage.
+// Returns (current, isNewField, legacyHashValue, error). legacyHashValue is non-nil only when
+// the value came from a legacy JSON blob that needs to be migrated on the next write.
+func (r *RedisServer) readHashFieldInt(ctx context.Context, key, field []byte, readTS uint64) (int64, bool, redisHashValue, error) {
+	fieldKey := store.HashFieldKey(key, field)
+	raw, readErr := r.store.GetAt(ctx, fieldKey, readTS)
+	if readErr != nil && !cockerrors.Is(readErr, store.ErrKeyNotFound) {
+		return 0, true, nil, cockerrors.WithStack(readErr)
+	}
+	if readErr == nil {
+		current, parseErr := strconv.ParseInt(string(raw), 10, 64)
+		if parseErr != nil {
+			return 0, false, nil, errors.New("ERR hash value is not an integer")
+		}
+		return current, false, nil, nil
+	}
+	// Not in wide-column – check legacy blob.
+	legacyValue, legacyErr := r.loadHashAt(ctx, key, readTS)
+	if legacyErr != nil {
+		return 0, true, nil, legacyErr
+	}
+	if rawLegacy, ok := legacyValue[string(field)]; ok {
+		current, parseErr := strconv.ParseInt(rawLegacy, 10, 64)
+		if parseErr != nil {
+			return 0, false, nil, errors.New("ERR hash value is not an integer")
+		}
+		return current, false, legacyValue, nil
+	}
+	return 0, true, legacyValue, nil
+}
+
+// hincrbyWithMigration handles the HINCRBY case where a legacy JSON blob must be migrated
+// atomically with the increment operation.
+func (r *RedisServer) hincrbyWithMigration(ctx context.Context, key, fieldKey []byte, readTS, commitTS uint64, current int64, isNewField bool, increment int64) (int64, error) {
+	migrationElems, migErr := r.buildHashLegacyMigrationElems(ctx, key, readTS)
+	if migErr != nil {
+		return 0, migErr
+	}
+	current += increment
+	newVal := strconv.FormatInt(current, 10)
+	elems := make([]*kv.Elem[kv.OP], 0, len(migrationElems)+setWideColOverhead)
+	elems = append(elems, migrationElems...)
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: fieldKey, Value: []byte(newVal)})
+	if isNewField {
+		deltaVal := store.MarshalHashMetaDelta(store.HashMetaDelta{LenDelta: 1})
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.HashMetaDeltaKey(key, commitTS, 0),
+			Value: deltaVal,
+		})
+	}
+	_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+		IsTxn:    true,
+		StartTS:  normalizeStartTS(readTS),
+		CommitTS: commitTS,
+		Elems:    elems,
+	})
+	return current, cockerrors.WithStack(dispatchErr)
+}
+
 func (r *RedisServer) hincrbyTxn(ctx context.Context, key, field []byte, increment int64) (int64, error) {
 	readTS := r.readTS()
 	typ, err := r.keyTypeAt(context.Background(), key, readTS)
@@ -1203,26 +1568,39 @@ func (r *RedisServer) hincrbyTxn(ctx context.Context, key, field []byte, increme
 	if typ != redisTypeNone && typ != redisTypeHash {
 		return 0, wrongTypeError()
 	}
-	value, err := r.loadHashAt(context.Background(), key, readTS)
+
+	commitTS := r.coordinator.Clock().Next()
+	fieldKey := store.HashFieldKey(key, field)
+
+	current, isNewField, legacyValue, err := r.readHashFieldInt(ctx, key, field, readTS)
 	if err != nil {
 		return 0, err
 	}
-	var current int64
-	if raw, ok := value[string(field)]; ok {
-		current, err = strconv.ParseInt(raw, 10, 64)
-		if err != nil {
-			return 0, errors.New("ERR hash value is not an integer")
-		}
+
+	// If a legacy blob exists, migrate it atomically with the increment.
+	if len(legacyValue) > 0 {
+		return r.hincrbyWithMigration(ctx, key, fieldKey, readTS, commitTS, current, isNewField, increment)
 	}
+
 	current += increment
-	value[string(field)] = strconv.FormatInt(current, 10)
-	payload, err := marshalHashValue(value)
-	if err != nil {
-		return 0, err
+	newVal := strconv.FormatInt(current, 10)
+	elems := make([]*kv.Elem[kv.OP], 0, setWideColOverhead)
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: fieldKey, Value: []byte(newVal)})
+	if isNewField {
+		deltaVal := store.MarshalHashMetaDelta(store.HashMetaDelta{LenDelta: 1})
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.HashMetaDeltaKey(key, commitTS, 0),
+			Value: deltaVal,
+		})
 	}
-	return current, r.dispatchElems(ctx, true, readTS, []*kv.Elem[kv.OP]{
-		{Op: kv.Put, Key: redisHashKey(key), Value: payload},
+	_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+		IsTxn:    true,
+		StartTS:  normalizeStartTS(readTS),
+		CommitTS: commitTS,
+		Elems:    elems,
 	})
+	return current, cockerrors.WithStack(dispatchErr)
 }
 
 func (r *RedisServer) incr(conn redcon.Conn, cmd redcon.Command) {

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -1128,6 +1128,49 @@ func (r *RedisServer) buildSetLegacyMigrationElems(ctx context.Context, key []by
 	return elems, nil
 }
 
+// buildZSetLegacyMigrationElems returns ops that atomically migrate a legacy
+// !redis|zset| blob to wide-column !zs|mem| + !zs|scr| keys. Returns nil if no legacy
+// blob exists.  The base meta key is also written with the migrated count so
+// that resolveZSetMeta works correctly after migration.
+func (r *RedisServer) buildZSetLegacyMigrationElems(ctx context.Context, key []byte, readTS uint64) ([]*kv.Elem[kv.OP], error) {
+	raw, err := r.store.GetAt(ctx, redisZSetKey(key), readTS)
+	if cockerrors.Is(err, store.ErrKeyNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, cockerrors.WithStack(err)
+	}
+	value, err := unmarshalZSetValue(raw)
+	if err != nil {
+		return nil, err
+	}
+	// Each entry → member key + score index key; plus legacy blob deletion + base meta.
+	elems := make([]*kv.Elem[kv.OP], 0, len(value.Entries)*2+setWideColOverhead) //nolint:mnd // 2 ops per entry (member + score index)
+	for _, entry := range value.Entries {
+		elems = append(elems,
+			&kv.Elem[kv.OP]{
+				Op:    kv.Put,
+				Key:   store.ZSetMemberKey(key, []byte(entry.Member)),
+				Value: store.MarshalZSetScore(entry.Score),
+			},
+			&kv.Elem[kv.OP]{
+				Op:    kv.Put,
+				Key:   store.ZSetScoreKey(key, entry.Score, []byte(entry.Member)),
+				Value: []byte{},
+			},
+		)
+	}
+	// Delete the legacy blob.
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisZSetKey(key)})
+	// Write a base meta so that resolveZSetMeta starts from an accurate count.
+	elems = append(elems, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   store.ZSetMetaKey(key),
+		Value: store.MarshalZSetMeta(store.ZSetMeta{Len: int64(len(value.Entries))}),
+	})
+	return elems, nil
+}
+
 // buildHashFieldElems iterates over field-value pairs in args, records whether each field is
 // new vs. existing, appends Put operations to elems, and returns the updated elems and new-field count.
 func (r *RedisServer) buildHashFieldElems(ctx context.Context, key []byte, args [][]byte, readTS uint64, elems []*kv.Elem[kv.OP]) ([]*kv.Elem[kv.OP], int, error) {
@@ -1796,6 +1839,37 @@ func (r *RedisServer) zadd(conn redcon.Conn, cmd redcon.Command) {
 	conn.WriteInt(added)
 }
 
+// applyZAddPair processes one ZADD pair against the wide-column store: reads the
+// existing member score (if any), checks the ZADD flags, emits del-old-score /
+// put-member / put-score-index ops, and returns the updated elems, the add count
+// (0 or 1), and the length delta (0 or +1).
+func (r *RedisServer) applyZAddPair(ctx context.Context, key []byte, p zaddPair, flags zaddFlags, readTS uint64, elems []*kv.Elem[kv.OP]) ([]*kv.Elem[kv.OP], int, int64, error) {
+	memberKey := store.ZSetMemberKey(key, []byte(p.member))
+	raw, getErr := r.store.GetAt(ctx, memberKey, readTS)
+	var oldScore float64
+	memberExists := false
+	if getErr == nil {
+		memberExists = true
+		oldScore, _ = store.UnmarshalZSetScore(raw)
+	} else if !cockerrors.Is(getErr, store.ErrKeyNotFound) {
+		return nil, 0, 0, cockerrors.WithStack(getErr)
+	}
+	if !flags.allows(memberExists, oldScore, p.score) {
+		return elems, 0, 0, nil
+	}
+	if memberExists {
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: store.ZSetScoreKey(key, oldScore, []byte(p.member))})
+	}
+	elems = append(elems,
+		&kv.Elem[kv.OP]{Op: kv.Put, Key: memberKey, Value: store.MarshalZSetScore(p.score)},
+		&kv.Elem[kv.OP]{Op: kv.Put, Key: store.ZSetScoreKey(key, p.score, []byte(p.member)), Value: []byte{}},
+	)
+	if memberExists {
+		return elems, 0, 0, nil
+	}
+	return elems, 1, 1, nil
+}
+
 func (r *RedisServer) zaddTxn(ctx context.Context, key []byte, flags zaddFlags, pairs []zaddPair) (int, error) {
 	readTS := r.readTS()
 	typ, err := r.keyTypeAt(context.Background(), key, readTS)
@@ -1805,30 +1879,108 @@ func (r *RedisServer) zaddTxn(ctx context.Context, key []byte, flags zaddFlags, 
 	if typ != redisTypeNone && typ != redisTypeZSet {
 		return 0, wrongTypeError()
 	}
-	value, _, err := r.loadZSetAt(context.Background(), key, readTS)
+
+	commitTS := r.coordinator.Clock().Next()
+	// Capacity: each pair may produce 3 ops (del old score + put member + put score index),
+	// plus migration elems and a delta key.
+	elems := make([]*kv.Elem[kv.OP], 0, len(pairs)*3+setWideColOverhead) //nolint:mnd // 3 ops per pair
+
+	migrationElems, err := r.buildZSetLegacyMigrationElems(ctx, key, readTS)
 	if err != nil {
 		return 0, err
 	}
-	members := zsetEntriesToMap(value.Entries)
+	elems = append(elems, migrationElems...)
+
 	added := 0
+	lenDelta := int64(0)
 	for _, p := range pairs {
-		old, exists := members[p.member]
-		if !flags.allows(exists, old, p.score) {
-			continue
+		var c int
+		var d int64
+		elems, c, d, err = r.applyZAddPair(ctx, key, p, flags, readTS, elems)
+		if err != nil {
+			return 0, err
 		}
-		if !exists {
-			added++
-		}
-		members[p.member] = p.score
+		added += c
+		lenDelta += d
 	}
-	value.Entries = zsetMapToEntries(members)
-	payload, err := marshalZSetValue(value)
+
+	if len(elems) == 0 {
+		return 0, nil
+	}
+
+	if lenDelta != 0 {
+		deltaVal := store.MarshalZSetMetaDelta(store.ZSetMetaDelta{LenDelta: lenDelta})
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.ZSetMetaDeltaKey(key, commitTS, 0),
+			Value: deltaVal,
+		})
+	}
+
+	_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+		IsTxn:    true,
+		StartTS:  normalizeStartTS(readTS),
+		CommitTS: commitTS,
+		Elems:    elems,
+	})
+	return added, cockerrors.WithStack(dispatchErr)
+}
+
+// zincrbyTxn performs one attempt of ZINCRBY in wide-column format.
+// Returns the new score after applying increment.
+func (r *RedisServer) zincrbyTxn(ctx context.Context, key []byte, member string, increment float64) (float64, error) {
+	readTS := r.readTS()
+	typ, err := r.keyTypeAt(context.Background(), key, readTS)
 	if err != nil {
 		return 0, err
 	}
-	return added, r.dispatchElems(ctx, true, readTS, []*kv.Elem[kv.OP]{
-		{Op: kv.Put, Key: redisZSetKey(key), Value: payload},
+	if typ != redisTypeNone && typ != redisTypeZSet {
+		return 0, wrongTypeError()
+	}
+
+	memberKey := store.ZSetMemberKey(key, []byte(member))
+	commitTS := r.coordinator.Clock().Next()
+
+	migrationElems, migErr := r.buildZSetLegacyMigrationElems(ctx, key, readTS)
+	if migErr != nil {
+		return 0, migErr
+	}
+
+	raw, getErr := r.store.GetAt(ctx, memberKey, readTS)
+	var oldScore float64
+	memberExists := false
+	if getErr == nil {
+		memberExists = true
+		oldScore, _ = store.UnmarshalZSetScore(raw)
+	} else if !cockerrors.Is(getErr, store.ErrKeyNotFound) {
+		return 0, cockerrors.WithStack(getErr)
+	}
+
+	newScore := oldScore + increment
+	elems := make([]*kv.Elem[kv.OP], 0, len(migrationElems)+3) //nolint:mnd // del old score + put member + put score index
+	elems = append(elems, migrationElems...)
+	if memberExists {
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: store.ZSetScoreKey(key, oldScore, []byte(member))})
+	}
+	elems = append(elems,
+		&kv.Elem[kv.OP]{Op: kv.Put, Key: memberKey, Value: store.MarshalZSetScore(newScore)},
+		&kv.Elem[kv.OP]{Op: kv.Put, Key: store.ZSetScoreKey(key, newScore, []byte(member)), Value: []byte{}},
+	)
+	if !memberExists {
+		deltaVal := store.MarshalZSetMetaDelta(store.ZSetMetaDelta{LenDelta: 1})
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.ZSetMetaDeltaKey(key, commitTS, 0),
+			Value: deltaVal,
+		})
+	}
+	_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+		IsTxn:    true,
+		StartTS:  normalizeStartTS(readTS),
+		CommitTS: commitTS,
+		Elems:    elems,
 	})
+	return newScore, cockerrors.WithStack(dispatchErr)
 }
 
 func (r *RedisServer) zincrby(conn redcon.Conn, cmd redcon.Command) {
@@ -1845,30 +1997,9 @@ func (r *RedisServer) zincrby(conn redcon.Conn, cmd redcon.Command) {
 	defer cancel()
 	var newScore float64
 	if err := r.retryRedisWrite(ctx, func() error {
-		readTS := r.readTS()
-		typ, err := r.keyTypeAt(context.Background(), cmd.Args[1], readTS)
-		if err != nil {
-			return err
-		}
-		if typ != redisTypeNone && typ != redisTypeZSet {
-			return wrongTypeError()
-		}
-		value, _, err := r.loadZSetAt(context.Background(), cmd.Args[1], readTS)
-		if err != nil {
-			return err
-		}
-		members := zsetEntriesToMap(value.Entries)
-		member := string(cmd.Args[3])
-		members[member] += increment
-		newScore = members[member]
-		value.Entries = zsetMapToEntries(members)
-		payload, err := marshalZSetValue(value)
-		if err != nil {
-			return err
-		}
-		return r.dispatchElems(ctx, true, readTS, []*kv.Elem[kv.OP]{
-			{Op: kv.Put, Key: redisZSetKey(cmd.Args[1]), Value: payload},
-		})
+		var txnErr error
+		newScore, txnErr = r.zincrbyTxn(ctx, cmd.Args[1], string(cmd.Args[3]), increment)
+		return txnErr
 	}); err != nil {
 		conn.WriteError(err.Error())
 		return
@@ -2114,7 +2245,17 @@ func (r *RedisServer) tryBZPopMin(key []byte) (*bzpopminResult, error) {
 		}
 		popped := value.Entries[0]
 		remaining := append([]redisZSetEntry(nil), value.Entries[1:]...)
-		if err := r.persistBZPopMinResult(ctx, key, readTS, remaining); err != nil {
+
+		// Detect wide-column storage.
+		memberPrefix := store.ZSetMemberScanPrefix(key)
+		memberEnd := store.PrefixScanEnd(memberPrefix)
+		probeKVs, probeErr := r.store.ScanAt(ctx, memberPrefix, memberEnd, 1, readTS)
+		if probeErr != nil {
+			return cockerrors.WithStack(probeErr)
+		}
+		isWide := len(probeKVs) > 0
+
+		if err := r.persistBZPopMinResult(ctx, key, readTS, popped, remaining, isWide); err != nil {
 			return err
 		}
 		result = &bzpopminResult{key: key, entry: popped}
@@ -2123,7 +2264,7 @@ func (r *RedisServer) tryBZPopMin(key []byte) (*bzpopminResult, error) {
 	return result, err
 }
 
-func (r *RedisServer) persistBZPopMinResult(ctx context.Context, key []byte, readTS uint64, remaining []redisZSetEntry) error {
+func (r *RedisServer) persistBZPopMinResult(ctx context.Context, key []byte, readTS uint64, popped redisZSetEntry, remaining []redisZSetEntry, isWide bool) error {
 	if len(remaining) == 0 {
 		elems, _, err := r.deleteLogicalKeyElems(ctx, key, readTS)
 		if err != nil {
@@ -2131,6 +2272,24 @@ func (r *RedisServer) persistBZPopMinResult(ctx context.Context, key []byte, rea
 		}
 		return r.dispatchElems(ctx, true, readTS, elems)
 	}
+	if isWide {
+		// Wide-column: delete the popped member key + score index, emit delta -1.
+		commitTS := r.coordinator.Clock().Next()
+		deltaVal := store.MarshalZSetMetaDelta(store.ZSetMetaDelta{LenDelta: -1})
+		elems := []*kv.Elem[kv.OP]{
+			{Op: kv.Del, Key: store.ZSetMemberKey(key, []byte(popped.Member))},
+			{Op: kv.Del, Key: store.ZSetScoreKey(key, popped.Score, []byte(popped.Member))},
+			{Op: kv.Put, Key: store.ZSetMetaDeltaKey(key, commitTS, 0), Value: deltaVal},
+		}
+		_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+			IsTxn:    true,
+			StartTS:  normalizeStartTS(readTS),
+			CommitTS: commitTS,
+			Elems:    elems,
+		})
+		return cockerrors.WithStack(dispatchErr)
+	}
+	// Legacy blob: write back all remaining entries.
 	payload, err := marshalZSetValue(redisZSetValue{Entries: remaining})
 	if err != nil {
 		return err

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"slices"
 	"sort"
 	"strconv"
@@ -1957,6 +1958,9 @@ func (r *RedisServer) zincrbyTxn(ctx context.Context, key []byte, member string,
 	}
 
 	newScore := oldScore + increment
+	if math.IsNaN(newScore) {
+		return 0, errors.New("ERR resulting score is not a number (NaN)")
+	}
 	elems := make([]*kv.Elem[kv.OP], 0, len(migrationElems)+3) //nolint:mnd // del old score + put member + put score index
 	elems = append(elems, migrationElems...)
 	if memberExists {

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -46,8 +46,8 @@ func normalizeStartTS(ts uint64) uint64 {
 	return ts
 }
 
-// detectWideColumnType checks for the presence of wide-column hash or set keys
-// and returns the corresponding redis type, or redisTypeNone if neither is found.
+// detectWideColumnType checks for the presence of wide-column hash, set, or zset keys
+// and returns the corresponding redis type, or redisTypeNone if none is found.
 func (r *RedisServer) detectWideColumnType(ctx context.Context, key []byte, readTS uint64) (redisValueType, error) {
 	hashFieldPrefix := store.HashFieldScanPrefix(key)
 	hashFieldEnd := store.PrefixScanEnd(hashFieldPrefix)
@@ -66,6 +66,15 @@ func (r *RedisServer) detectWideColumnType(ctx context.Context, key []byte, read
 	}
 	if len(setMemberKVs) > 0 {
 		return redisTypeSet, nil
+	}
+	zsetMemberPrefix := store.ZSetMemberScanPrefix(key)
+	zsetMemberEnd := store.PrefixScanEnd(zsetMemberPrefix)
+	zsetMemberKVs, err := r.store.ScanAt(ctx, zsetMemberPrefix, zsetMemberEnd, 1, readTS)
+	if err != nil {
+		return redisTypeNone, errors.WithStack(err)
+	}
+	if len(zsetMemberKVs) > 0 {
+		return redisTypeZSet, nil
 	}
 	return redisTypeNone, nil
 }
@@ -238,7 +247,44 @@ func (r *RedisServer) loadSetAt(ctx context.Context, kind string, key []byte, re
 	return val, err
 }
 
+// loadZSetMembersAt scans all wide-column !zs|mem| keys and returns them as a redisZSetValue
+// sorted by (score, member), matching the ordering produced by the legacy blob path.
+func (r *RedisServer) loadZSetMembersAt(ctx context.Context, key []byte, readTS uint64) (redisZSetValue, error) {
+	prefix := store.ZSetMemberScanPrefix(key)
+	end := store.PrefixScanEnd(prefix)
+	kvs, err := r.store.ScanAt(ctx, prefix, end, maxWideScanLimit, readTS)
+	if err != nil {
+		return redisZSetValue{}, errors.WithStack(err)
+	}
+	entries := make([]redisZSetEntry, 0, len(kvs))
+	for _, kv := range kvs {
+		member := store.ExtractZSetMemberName(kv.Key, key)
+		if member == nil {
+			continue
+		}
+		score, scoreErr := store.UnmarshalZSetScore(kv.Value)
+		if scoreErr != nil {
+			return redisZSetValue{}, errors.WithStack(scoreErr)
+		}
+		entries = append(entries, redisZSetEntry{Member: string(member), Score: score})
+	}
+	sortZSetEntries(entries)
+	return redisZSetValue{Entries: entries}, nil
+}
+
 func (r *RedisServer) loadZSetAt(ctx context.Context, key []byte, readTS uint64) (redisZSetValue, bool, error) {
+	// Wide-column path: check !zs|mem| prefix first.
+	prefix := store.ZSetMemberScanPrefix(key)
+	end := store.PrefixScanEnd(prefix)
+	kvs, err := r.store.ScanAt(ctx, prefix, end, 1, readTS)
+	if err != nil {
+		return redisZSetValue{}, false, errors.WithStack(err)
+	}
+	if len(kvs) > 0 {
+		val, loadErr := r.loadZSetMembersAt(ctx, key, readTS)
+		return val, true, loadErr
+	}
+	// Legacy blob fallback.
 	raw, err := r.store.GetAt(ctx, redisZSetKey(key), readTS)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
@@ -409,7 +455,37 @@ func (r *RedisServer) deleteLogicalKeyElems(ctx context.Context, key []byte, rea
 	}
 	elems = append(elems, setElems...)
 
+	// Wide-column zset cleanup: delete all !zs|mem|, !zs|scr|, meta, and delta keys.
+	zsetElems, err := r.deleteZSetWideColumnElems(ctx, key, readTS)
+	if err != nil {
+		return nil, false, err
+	}
+	elems = append(elems, zsetElems...)
+
 	return elems, existed, nil
+}
+
+// deleteZSetWideColumnElems returns delete operations for all ZSet wide-column keys:
+// member keys (!zs|mem|), score index keys (!zs|scr|), the meta key, and all delta keys.
+func (r *RedisServer) deleteZSetWideColumnElems(ctx context.Context, key []byte, readTS uint64) ([]*kv.Elem[kv.OP], error) {
+	memberElems, err := r.deleteWideColumnElems(ctx, readTS,
+		store.ZSetMemberScanPrefix(key), store.ZSetMetaKey(key), store.ZSetMetaDeltaScanPrefix(key))
+	if err != nil {
+		return nil, err
+	}
+	// deleteWideColumnElems covers member + meta + delta. Also scan score index keys.
+	scorePrefix := store.ZSetScoreScanPrefix(key)
+	scoreEnd := store.PrefixScanEnd(scorePrefix)
+	scoreKVs, scanErr := r.store.ScanAt(ctx, scorePrefix, scoreEnd, maxWideScanLimit, readTS)
+	if scanErr != nil {
+		return nil, errors.WithStack(scanErr)
+	}
+	elems := make([]*kv.Elem[kv.OP], 0, len(memberElems)+len(scoreKVs))
+	elems = append(elems, memberElems...)
+	for _, pair := range scoreKVs {
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
+	}
+	return elems, nil
 }
 
 func (r *RedisServer) listValuesAt(ctx context.Context, key []byte, readTS uint64) ([]string, error) {

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -3,6 +3,8 @@ package adapter
 import (
 	"bytes"
 	"context"
+	"log/slog"
+	"math"
 	"sort"
 	"time"
 
@@ -11,18 +13,93 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// maxWideScanLimit is the upper bound used when scanning all fields/members of
+// a wide-column hash or set.  It is intentionally large – wide-column keys are
+// per-field/member so the real cap is the number of items in the collection.
+const maxWideScanLimit = math.MaxInt32
+
 const wrongTypeMessage = "WRONGTYPE Operation against a key holding the wrong kind of value"
+
+// setKind and hllKind are the internal kind discriminators used for Set and
+// HyperLogLog operations. They distinguish code paths within functions that
+// handle both types (e.g. loadSetAt, mutateExactSet).
+const (
+	setKind = "set"
+	hllKind = "hll"
+)
+
+// ErrDeltaScanTruncated is returned when the delta scan result is truncated,
+// indicating that synchronous compaction is required before the operation can proceed.
+var ErrDeltaScanTruncated = errors.New("delta scan truncated: compaction required")
 
 func wrongTypeError() error {
 	return errors.New(wrongTypeMessage)
 }
 
+// normalizeStartTS converts a "fresh read" sentinel (^uint64(0)) to 0.
+// The coordinator's Dispatch requires startTS=0 to mean "no conflict check",
+// while internally we use ^uint64(0) to indicate an uninitialized read timestamp.
+func normalizeStartTS(ts uint64) uint64 {
+	if ts == ^uint64(0) {
+		return 0
+	}
+	return ts
+}
+
+// detectWideColumnType checks for the presence of wide-column hash or set keys
+// and returns the corresponding redis type, or redisTypeNone if neither is found.
+func (r *RedisServer) detectWideColumnType(ctx context.Context, key []byte, readTS uint64) (redisValueType, error) {
+	hashFieldPrefix := store.HashFieldScanPrefix(key)
+	hashFieldEnd := store.PrefixScanEnd(hashFieldPrefix)
+	hashFieldKVs, err := r.store.ScanAt(ctx, hashFieldPrefix, hashFieldEnd, 1, readTS)
+	if err != nil {
+		return redisTypeNone, errors.WithStack(err)
+	}
+	if len(hashFieldKVs) > 0 {
+		return redisTypeHash, nil
+	}
+	setMemberPrefix := store.SetMemberScanPrefix(key)
+	setMemberEnd := store.PrefixScanEnd(setMemberPrefix)
+	setMemberKVs, err := r.store.ScanAt(ctx, setMemberPrefix, setMemberEnd, 1, readTS)
+	if err != nil {
+		return redisTypeNone, errors.WithStack(err)
+	}
+	if len(setMemberKVs) > 0 {
+		return redisTypeSet, nil
+	}
+	return redisTypeNone, nil
+}
+
 func (r *RedisServer) rawKeyTypeAt(ctx context.Context, key []byte, readTS uint64) (redisValueType, error) {
+	// Check list base metadata key first.
+	listMetaExists, err := r.store.ExistsAt(ctx, store.ListMetaKey(key), readTS)
+	if err != nil {
+		return redisTypeNone, errors.WithStack(err)
+	}
+	if listMetaExists {
+		return redisTypeList, nil
+	}
+	// Fallback: detect a delta-only list (base meta not yet written or
+	// already compacted away but deltas still present).
+	deltaPrefix := store.ListMetaDeltaScanPrefix(key)
+	deltaEnd := store.PrefixScanEnd(deltaPrefix)
+	deltaKVs, err := r.store.ScanAt(ctx, deltaPrefix, deltaEnd, 1, readTS)
+	if err != nil {
+		return redisTypeNone, errors.WithStack(err)
+	}
+	if len(deltaKVs) > 0 {
+		return redisTypeList, nil
+	}
+
+	// Check wide-column hash and set types.
+	if typ, wideErr := r.detectWideColumnType(ctx, key, readTS); wideErr != nil || typ != redisTypeNone {
+		return typ, wideErr
+	}
+
 	checks := []struct {
 		typ redisValueType
 		key []byte
 	}{
-		{typ: redisTypeList, key: store.ListMetaKey(key)},
 		{typ: redisTypeHash, key: redisHashKey(key)},
 		{typ: redisTypeSet, key: redisSetKey(key)},
 		{typ: redisTypeZSet, key: redisZSetKey(key)},
@@ -73,7 +150,37 @@ func (r *RedisServer) logicalExistsAt(ctx context.Context, key []byte, readTS ui
 	return typ != redisTypeNone, nil
 }
 
+// loadHashFieldsAt scans all wide-column !hs|fld| keys and returns them as a
+// redisHashValue map.
+func (r *RedisServer) loadHashFieldsAt(ctx context.Context, key []byte, readTS uint64) (redisHashValue, error) {
+	prefix := store.HashFieldScanPrefix(key)
+	end := store.PrefixScanEnd(prefix)
+	kvs, err := r.store.ScanAt(ctx, prefix, end, maxWideScanLimit, readTS)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	result := make(redisHashValue, len(kvs))
+	for _, kv := range kvs {
+		field := store.ExtractHashFieldName(kv.Key, key)
+		if field != nil {
+			result[string(field)] = string(kv.Value)
+		}
+	}
+	return result, nil
+}
+
 func (r *RedisServer) loadHashAt(ctx context.Context, key []byte, readTS uint64) (redisHashValue, error) {
+	// Wide-column path: scan !hs|fld| prefix first.
+	prefix := store.HashFieldScanPrefix(key)
+	end := store.PrefixScanEnd(prefix)
+	kvs, err := r.store.ScanAt(ctx, prefix, end, 1, readTS)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if len(kvs) > 0 {
+		return r.loadHashFieldsAt(ctx, key, readTS)
+	}
+	// Legacy blob fallback.
 	raw, err := r.store.GetAt(ctx, redisHashKey(key), readTS)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
@@ -85,7 +192,40 @@ func (r *RedisServer) loadHashAt(ctx context.Context, key []byte, readTS uint64)
 	return val, err
 }
 
+// loadSetMembersAt scans all wide-column !st|mem| keys and returns them as a
+// redisSetValue.  Only used for kind=="set" (HLL stays as a legacy blob).
+func (r *RedisServer) loadSetMembersAt(ctx context.Context, key []byte, readTS uint64) (redisSetValue, error) {
+	prefix := store.SetMemberScanPrefix(key)
+	end := store.PrefixScanEnd(prefix)
+	kvs, err := r.store.ScanAt(ctx, prefix, end, maxWideScanLimit, readTS)
+	if err != nil {
+		return redisSetValue{}, errors.WithStack(err)
+	}
+	members := make([]string, 0, len(kvs))
+	for _, kv := range kvs {
+		member := store.ExtractSetMemberName(kv.Key, key)
+		if member != nil {
+			members = append(members, string(member))
+		}
+	}
+	sort.Strings(members)
+	return redisSetValue{Members: members}, nil
+}
+
 func (r *RedisServer) loadSetAt(ctx context.Context, kind string, key []byte, readTS uint64) (redisSetValue, error) {
+	if kind == "set" {
+		// Wide-column path: check !st|mem| prefix first.
+		prefix := store.SetMemberScanPrefix(key)
+		end := store.PrefixScanEnd(prefix)
+		kvs, err := r.store.ScanAt(ctx, prefix, end, 1, readTS)
+		if err != nil {
+			return redisSetValue{}, errors.WithStack(err)
+		}
+		if len(kvs) > 0 {
+			return r.loadSetMembersAt(ctx, key, readTS)
+		}
+	}
+	// Legacy blob fallback (also the only path for HLL).
 	storageKey := redisExactSetStorageKey(kind, key)
 	raw, err := r.store.GetAt(ctx, storageKey, readTS)
 	if err != nil {
@@ -166,6 +306,60 @@ func (r *RedisServer) saveString(ctx context.Context, key []byte, value []byte, 
 	return r.dispatchElems(ctx, false, 0, elems)
 }
 
+// deleteListElems returns delete operations for all list keys (items, meta, deltas).
+func (r *RedisServer) deleteListElems(ctx context.Context, key []byte, readTS uint64) ([]*kv.Elem[kv.OP], error) {
+	meta, listExists, err := r.resolveListMeta(ctx, key, readTS)
+	if err != nil {
+		return nil, err
+	}
+	if !listExists {
+		return nil, nil
+	}
+	elems := make([]*kv.Elem[kv.OP], 0, int(meta.Len)+setWideColOverhead)
+	for seq := meta.Head; seq < meta.Tail; seq++ {
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: listItemKey(key, seq)})
+	}
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: listMetaKey(key)})
+	deltaPrefix := store.ListMetaDeltaScanPrefix(key)
+	deltaEnd := store.PrefixScanEnd(deltaPrefix)
+	deltaKVs, scanErr := r.store.ScanAt(ctx, deltaPrefix, deltaEnd, store.MaxDeltaScanLimit, readTS)
+	if scanErr != nil {
+		return nil, errors.WithStack(scanErr)
+	}
+	for _, pair := range deltaKVs {
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
+	}
+	return elems, nil
+}
+
+// deleteWideColumnElems returns delete operations for all wide-column field/member keys,
+// the base meta key, and all delta keys for a collection identified by the given scan prefix,
+// meta key, and delta prefix.
+func (r *RedisServer) deleteWideColumnElems(ctx context.Context, readTS uint64, fieldPrefix, metaKey, deltaPrefix []byte) ([]*kv.Elem[kv.OP], error) {
+	fieldEnd := store.PrefixScanEnd(fieldPrefix)
+	fieldKVs, err := r.store.ScanAt(ctx, fieldPrefix, fieldEnd, maxWideScanLimit, readTS)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	elems := make([]*kv.Elem[kv.OP], 0, len(fieldKVs))
+	for _, pair := range fieldKVs {
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
+	}
+	if len(fieldKVs) == 0 {
+		return elems, nil
+	}
+	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: metaKey})
+	deltaEnd := store.PrefixScanEnd(deltaPrefix)
+	deltaKVs, scanErr := r.store.ScanAt(ctx, deltaPrefix, deltaEnd, store.MaxDeltaScanLimit, readTS)
+	if scanErr != nil {
+		return nil, errors.WithStack(scanErr)
+	}
+	for _, pair := range deltaKVs {
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
+	}
+	return elems, nil
+}
+
 func (r *RedisServer) deleteLogicalKeyElems(ctx context.Context, key []byte, readTS uint64) ([]*kv.Elem[kv.OP], bool, error) {
 	existed, err := r.logicalExistsAt(ctx, key, readTS)
 	if err != nil {
@@ -193,22 +387,33 @@ func (r *RedisServer) deleteLogicalKeyElems(ctx context.Context, key []byte, rea
 		}
 	}
 
-	meta, listExists, err := r.loadListMetaAt(ctx, key, readTS)
+	listElems, err := r.deleteListElems(ctx, key, readTS)
 	if err != nil {
 		return nil, false, err
 	}
-	if listExists {
-		for seq := meta.Head; seq < meta.Tail; seq++ {
-			elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: listItemKey(key, seq)})
-		}
-		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: listMetaKey(key)})
+	elems = append(elems, listElems...)
+
+	// Wide-column hash cleanup: delete all !hs|fld| keys, meta, and delta keys.
+	hashElems, err := r.deleteWideColumnElems(ctx, readTS,
+		store.HashFieldScanPrefix(key), store.HashMetaKey(key), store.HashMetaDeltaScanPrefix(key))
+	if err != nil {
+		return nil, false, err
 	}
+	elems = append(elems, hashElems...)
+
+	// Wide-column set cleanup: delete all !st|mem| keys, meta, and delta keys.
+	setElems, err := r.deleteWideColumnElems(ctx, readTS,
+		store.SetMemberScanPrefix(key), store.SetMetaKey(key), store.SetMetaDeltaScanPrefix(key))
+	if err != nil {
+		return nil, false, err
+	}
+	elems = append(elems, setElems...)
 
 	return elems, existed, nil
 }
 
 func (r *RedisServer) listValuesAt(ctx context.Context, key []byte, readTS uint64) ([]string, error) {
-	meta, exists, err := r.loadListMetaAt(ctx, key, readTS)
+	meta, exists, err := r.resolveListMeta(ctx, key, readTS)
 	if err != nil {
 		return nil, err
 	}
@@ -232,12 +437,22 @@ func (r *RedisServer) rewriteListTxn(ctx context.Context, key []byte, readTS uin
 	for _, value := range values {
 		rawValues = append(rawValues, []byte(value))
 	}
-	ops, _, err := r.buildRPushOps(store.ListMeta{}, key, rawValues)
+	commitTS := r.coordinator.Clock().Next()
+	ops, _, err := r.buildRPushOps(store.ListMeta{}, key, rawValues, commitTS, 0)
 	if err != nil {
 		return err
 	}
 	elems = append(elems, ops...)
-	return r.dispatchElems(ctx, true, readTS, elems)
+	if readTS == ^uint64(0) {
+		readTS = 0
+	}
+	_, err = r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+		IsTxn:    true,
+		StartTS:  readTS,
+		CommitTS: commitTS,
+		Elems:    elems,
+	})
+	return errors.WithStack(err)
 }
 
 func (r *RedisServer) visibleKeys(pattern []byte) ([][]byte, error) {
@@ -296,4 +511,152 @@ func minRedisInt(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// aggregateLenDeltas scans delta keys under prefix and sums the LenDelta values
+// via unmarshalDelta. Returns (sum, hasDeltas, error).
+// ErrDeltaScanTruncated is returned when the scan hits MaxDeltaScanLimit.
+func (r *RedisServer) aggregateLenDeltas(ctx context.Context, prefix []byte, readTS uint64, unmarshalDelta func([]byte) (int64, error)) (int64, bool, error) {
+	end := store.PrefixScanEnd(prefix)
+	deltas, err := r.store.ScanAt(ctx, prefix, end, store.MaxDeltaScanLimit, readTS)
+	if err != nil {
+		return 0, false, errors.WithStack(err)
+	}
+	if len(deltas) == store.MaxDeltaScanLimit {
+		return 0, false, ErrDeltaScanTruncated
+	}
+	var sum int64
+	for _, d := range deltas {
+		delta, err := unmarshalDelta(d.Value)
+		if err != nil {
+			return 0, false, errors.WithStack(err)
+		}
+		sum += delta
+	}
+	return sum, len(deltas) > 0, nil
+}
+
+// resolveListMeta aggregates the base list metadata with all uncompacted Delta keys
+// visible at readTS. Returns ErrDeltaScanTruncated if > MaxDeltaScanLimit deltas exist.
+func (r *RedisServer) resolveListMeta(ctx context.Context, key []byte, readTS uint64) (store.ListMeta, bool, error) {
+	// 1. Read base metadata.
+	baseMeta, exists, err := r.loadListMetaAt(ctx, key, readTS)
+	if err != nil {
+		return store.ListMeta{}, false, err
+	}
+
+	// 2. Scan and aggregate delta keys.
+	// The closure also captures baseMeta to accumulate the list-specific HeadDelta.
+	prefix := store.ListMetaDeltaScanPrefix(key)
+	lenSum, hasDeltas, err := r.aggregateLenDeltas(ctx, prefix, readTS, func(b []byte) (int64, error) {
+		d, unmarshalErr := store.UnmarshalListMetaDelta(b)
+		baseMeta.Head += d.HeadDelta
+		return d.LenDelta, errors.WithStack(unmarshalErr)
+	})
+	if err != nil {
+		return store.ListMeta{}, false, err
+	}
+	baseMeta.Len += lenSum
+
+	if baseMeta.Len < 0 {
+		slog.Warn("resolveListMeta: clamping negative Len to 0", "key", string(key), "len", baseMeta.Len)
+		baseMeta.Len = 0
+	}
+	baseMeta.Tail = baseMeta.Head + baseMeta.Len
+	return baseMeta, exists || hasDeltas, nil
+}
+
+// resolveCollectionLen reads the base meta key, then aggregates all delta keys
+// into the final length. It is used by resolveHashMeta, resolveSetMeta, and
+// resolveZSetMeta which all follow the same pattern.
+func (r *RedisServer) resolveCollectionLen(
+	ctx context.Context,
+	key []byte,
+	readTS uint64,
+	metaKey []byte,
+	deltaPrefix []byte,
+	unmarshalBase func([]byte) (int64, error),
+	unmarshalDelta func([]byte) (int64, error),
+	clampMsg string,
+) (int64, bool, error) {
+	raw, err := r.store.GetAt(ctx, metaKey, readTS)
+	var baseLen int64
+	exists := true
+	if err != nil {
+		if !errors.Is(err, store.ErrKeyNotFound) {
+			return 0, false, errors.WithStack(err)
+		}
+		exists = false
+	} else {
+		baseLen, err = unmarshalBase(raw)
+		if err != nil {
+			return 0, false, errors.WithStack(err)
+		}
+	}
+
+	deltaSum, hasDeltas, err := r.aggregateLenDeltas(ctx, deltaPrefix, readTS, unmarshalDelta)
+	if err != nil {
+		return 0, false, err
+	}
+
+	length := baseLen + deltaSum
+	if length < 0 {
+		slog.Warn(clampMsg, "key", string(key), "len", length)
+		length = 0
+	}
+	return length, exists || hasDeltas, nil
+}
+
+// resolveHashMeta aggregates the base hash metadata with all uncompacted Delta keys.
+func (r *RedisServer) resolveHashMeta(ctx context.Context, key []byte, readTS uint64) (int64, bool, error) {
+	return r.resolveCollectionLen(
+		ctx, key, readTS,
+		store.HashMetaKey(key),
+		store.HashMetaDeltaScanPrefix(key),
+		func(b []byte) (int64, error) {
+			m, err := store.UnmarshalHashMeta(b)
+			return m.Len, errors.WithStack(err)
+		},
+		func(b []byte) (int64, error) {
+			d, err := store.UnmarshalHashMetaDelta(b)
+			return d.LenDelta, errors.WithStack(err)
+		},
+		"resolveHashMeta: clamping negative Len to 0",
+	)
+}
+
+// resolveSetMeta aggregates the base set metadata with all uncompacted Delta keys.
+func (r *RedisServer) resolveSetMeta(ctx context.Context, key []byte, readTS uint64) (int64, bool, error) {
+	return r.resolveCollectionLen(
+		ctx, key, readTS,
+		store.SetMetaKey(key),
+		store.SetMetaDeltaScanPrefix(key),
+		func(b []byte) (int64, error) {
+			m, err := store.UnmarshalSetMeta(b)
+			return m.Len, errors.WithStack(err)
+		},
+		func(b []byte) (int64, error) {
+			d, err := store.UnmarshalSetMetaDelta(b)
+			return d.LenDelta, errors.WithStack(err)
+		},
+		"resolveSetMeta: clamping negative Len to 0",
+	)
+}
+
+// resolveZSetMeta aggregates the base sorted set metadata with all uncompacted Delta keys.
+func (r *RedisServer) resolveZSetMeta(ctx context.Context, key []byte, readTS uint64) (int64, bool, error) {
+	return r.resolveCollectionLen(
+		ctx, key, readTS,
+		store.ZSetMetaKey(key),
+		store.ZSetMetaDeltaScanPrefix(key),
+		func(b []byte) (int64, error) {
+			m, err := store.UnmarshalZSetMeta(b)
+			return m.Len, errors.WithStack(err)
+		},
+		func(b []byte) (int64, error) {
+			d, err := store.UnmarshalZSetMetaDelta(b)
+			return d.LenDelta, errors.WithStack(err)
+		},
+		"resolveZSetMeta: clamping negative Len to 0",
+	)
 }

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"log/slog"
-	"math"
 	"sort"
 	"time"
 
@@ -13,10 +12,20 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// maxWideScanLimit is the upper bound used when scanning all fields/members of
-// a wide-column hash or set.  It is intentionally large – wide-column keys are
-// per-field/member so the real cap is the number of items in the collection.
-const maxWideScanLimit = math.MaxInt32
+// maxWideColumnItems is the maximum number of fields/members a single
+// wide-column collection (Hash, Set, or ZSet) may contain.
+// Operations that would materialize more than this many items are rejected
+// to prevent unbounded memory growth (OOM).
+const maxWideColumnItems = 100_000
+
+// maxWideScanLimit is passed to ScanAt when loading an entire collection.
+// It is set to maxWideColumnItems+1 so that receiving exactly limit results
+// indicates the collection is over the cap and the caller can return an error
+// instead of silently truncating.
+const maxWideScanLimit = maxWideColumnItems + 1
+
+// ErrCollectionTooLarge is returned when a collection exceeds maxWideColumnItems.
+var ErrCollectionTooLarge = errors.New("collection too large")
 
 const wrongTypeMessage = "WRONGTYPE Operation against a key holding the wrong kind of value"
 
@@ -168,6 +177,9 @@ func (r *RedisServer) loadHashFieldsAt(ctx context.Context, key []byte, readTS u
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	if len(kvs) > maxWideColumnItems {
+		return nil, errors.Wrapf(ErrCollectionTooLarge, "hash %q exceeds %d fields", key, maxWideColumnItems)
+	}
 	result := make(redisHashValue, len(kvs))
 	for _, kv := range kvs {
 		field := store.ExtractHashFieldName(kv.Key, key)
@@ -209,6 +221,9 @@ func (r *RedisServer) loadSetMembersAt(ctx context.Context, key []byte, readTS u
 	kvs, err := r.store.ScanAt(ctx, prefix, end, maxWideScanLimit, readTS)
 	if err != nil {
 		return redisSetValue{}, errors.WithStack(err)
+	}
+	if len(kvs) > maxWideColumnItems {
+		return redisSetValue{}, errors.Wrapf(ErrCollectionTooLarge, "set %q exceeds %d members", key, maxWideColumnItems)
 	}
 	members := make([]string, 0, len(kvs))
 	for _, kv := range kvs {

--- a/adapter/redis_compat_types.go
+++ b/adapter/redis_compat_types.go
@@ -135,6 +135,8 @@ var knownInternalPrefixes = [][]byte{
 	[]byte("!s3|"),
 	[]byte("!dist|"),
 	[]byte("!zs|"),
+	[]byte("!hs|"),
+	[]byte("!st|"),
 }
 
 func isKnownInternalKey(key []byte) bool {

--- a/adapter/redis_lua.go
+++ b/adapter/redis_lua.go
@@ -922,18 +922,52 @@ func (r *RedisServer) lset(conn redcon.Conn, cmd redcon.Command) {
 	r.execLuaCompat(conn, cmdLSet, cmd.Args[1:])
 }
 
-func (r *RedisServer) scard(conn redcon.Conn, cmd redcon.Command) {
+// collectionCardinal handles SCARD/ZCARD: checks type, uses the delta-aggregated
+// metadata for wide-column collections (O(1)), and falls back to the Lua
+// compatibility path for legacy blob-encoded collections.
+func (r *RedisServer) collectionCardinal(
+	conn redcon.Conn,
+	cmd redcon.Command,
+	expectedType redisValueType,
+	resolveMeta func(context.Context, []byte, uint64) (int64, bool, error),
+	legacyCmd string,
+) {
 	if r.proxyToLeader(conn, cmd, cmd.Args[1]) {
 		return
 	}
-	r.execLuaCompat(conn, cmdSCard, cmd.Args[1:])
+	readTS := r.readTS()
+	typ, err := r.keyTypeAt(context.Background(), cmd.Args[1], readTS)
+	if err != nil {
+		conn.WriteError(err.Error())
+		return
+	}
+	if typ == redisTypeNone {
+		conn.WriteInt(0)
+		return
+	}
+	if typ != expectedType {
+		conn.WriteError(wrongTypeMessage)
+		return
+	}
+	count, exists, err := resolveMeta(context.Background(), cmd.Args[1], readTS)
+	if err != nil {
+		conn.WriteError(err.Error())
+		return
+	}
+	if exists {
+		conn.WriteInt64(count)
+		return
+	}
+	// Legacy blob fallback.
+	r.execLuaCompat(conn, legacyCmd, cmd.Args[1:])
+}
+
+func (r *RedisServer) scard(conn redcon.Conn, cmd redcon.Command) {
+	r.collectionCardinal(conn, cmd, redisTypeSet, r.resolveSetMeta, cmdSCard)
 }
 
 func (r *RedisServer) zcard(conn redcon.Conn, cmd redcon.Command) {
-	if r.proxyToLeader(conn, cmd, cmd.Args[1]) {
-		return
-	}
-	r.execLuaCompat(conn, cmdZCard, cmd.Args[1:])
+	r.collectionCardinal(conn, cmd, redisTypeZSet, r.resolveZSetMeta, cmdZCard)
 }
 
 func (r *RedisServer) zcount(conn redcon.Conn, cmd redcon.Command) {

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -466,7 +466,7 @@ func (c *luaScriptContext) listState(key []byte) (*luaListState, error) {
 		return nil, wrongTypeError()
 	}
 
-	meta, exists, err := c.server.loadListMetaAt(context.Background(), key, c.startTS)
+	meta, exists, err := c.server.resolveListMeta(context.Background(), key, c.startTS)
 	if err != nil {
 		return nil, err
 	}
@@ -2431,10 +2431,13 @@ func (c *luaScriptContext) commit() error {
 	}
 	sort.Strings(keys)
 
+	// Pre-allocate a commitTS so Delta key bytes can embed it before dispatch.
+	commitTS := c.server.coordinator.Clock().Next()
+
 	elems := make([]*kv.Elem[kv.OP], 0, len(keys)*redisPairWidth)
 	ctx := context.Background()
 	for _, key := range keys {
-		keyElems, err := c.commitElemsForKey(ctx, key)
+		keyElems, err := c.commitElemsForKey(ctx, key, commitTS)
 		if err != nil {
 			return err
 		}
@@ -2446,16 +2449,26 @@ func (c *luaScriptContext) commit() error {
 	}
 	dispatchCtx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
 	defer cancel()
-	return c.server.dispatchElems(dispatchCtx, true, c.startTS, elems)
+	startTS := c.startTS
+	if startTS == ^uint64(0) {
+		startTS = 0
+	}
+	_, err := c.server.coordinator.Dispatch(dispatchCtx, &kv.OperationGroup[kv.OP]{
+		IsTxn:    true,
+		StartTS:  startTS,
+		CommitTS: commitTS,
+		Elems:    elems,
+	})
+	return errors.WithStack(err)
 }
 
-func (c *luaScriptContext) commitElemsForKey(ctx context.Context, key string) ([]*kv.Elem[kv.OP], error) {
+func (c *luaScriptContext) commitElemsForKey(ctx context.Context, key string, commitTS uint64) ([]*kv.Elem[kv.OP], error) {
 	finalType, err := c.finalType([]byte(key))
 	if err != nil {
 		return nil, err
 	}
 
-	valuePlan, err := c.valueCommitPlan(key, finalType)
+	valuePlan, err := c.valueCommitPlan(key, finalType, commitTS)
 	if err != nil {
 		return nil, err
 	}
@@ -2479,7 +2492,7 @@ func (c *luaScriptContext) commitElemsForKey(ctx context.Context, key string) ([
 	return elems, nil
 }
 
-func (c *luaScriptContext) valueCommitPlan(key string, finalType redisValueType) (luaCommitPlan, error) {
+func (c *luaScriptContext) valueCommitPlan(key string, finalType redisValueType, commitTS uint64) (luaCommitPlan, error) {
 	switch finalType {
 	case redisTypeNone:
 		return luaCommitPlan{}, nil
@@ -2487,7 +2500,7 @@ func (c *luaScriptContext) valueCommitPlan(key string, finalType redisValueType)
 		elems, err := c.stringCommitElems(key)
 		return luaCommitPlan{elems: elems}, err
 	case redisTypeList:
-		return c.listCommitPlan(key)
+		return c.listCommitPlan(key, commitTS)
 	case redisTypeHash:
 		elems, err := c.hashCommitElems(key)
 		return luaCommitPlan{elems: elems}, err
@@ -2513,13 +2526,13 @@ func (c *luaScriptContext) stringCommitElems(key string) ([]*kv.Elem[kv.OP], err
 	return []*kv.Elem[kv.OP]{{Op: kv.Put, Key: redisStrKey([]byte(key)), Value: append([]byte(nil), st.value...)}}, nil
 }
 
-func (c *luaScriptContext) listCommitPlan(key string) (luaCommitPlan, error) {
+func (c *luaScriptContext) listCommitPlan(key string, commitTS uint64) (luaCommitPlan, error) {
 	st := c.lists[key]
 	if st == nil || !st.dirty {
 		return luaCommitPlan{preserveExisting: true}, nil
 	}
 	if st.materialized {
-		elems, err := c.listCommitElems(key)
+		elems, err := c.listCommitElems(key, commitTS)
 		return luaCommitPlan{elems: elems}, err
 	}
 	// If the key was deleted earlier in this script and later recreated as a
@@ -2527,14 +2540,14 @@ func (c *luaScriptContext) listCommitPlan(key string) (luaCommitPlan, error) {
 	// deleteLogicalKeyElems is called and any orphaned storage items from the
 	// previous incarnation of the key are cleaned up before writing the delta.
 	if c.everDeleted[key] {
-		elems, err := c.listCommitElems(key)
+		elems, err := c.listCommitElems(key, commitTS)
 		return luaCommitPlan{elems: elems}, err
 	}
-	elems, err := c.listDeltaCommitElems(key, st)
+	elems, err := c.listDeltaCommitElems(key, st, commitTS)
 	return luaCommitPlan{preserveExisting: true, elems: elems}, err
 }
 
-func (c *luaScriptContext) listCommitElems(key string) ([]*kv.Elem[kv.OP], error) {
+func (c *luaScriptContext) listCommitElems(key string, commitTS uint64) ([]*kv.Elem[kv.OP], error) {
 	st, err := c.listState([]byte(key))
 	if err != nil {
 		return nil, err
@@ -2547,14 +2560,14 @@ func (c *luaScriptContext) listCommitElems(key string) ([]*kv.Elem[kv.OP], error
 		values = append(values, []byte(value))
 	}
 
-	listElems, _, err := c.server.buildRPushOps(store.ListMeta{}, []byte(key), values)
+	listElems, _, err := c.server.buildRPushOps(store.ListMeta{}, []byte(key), values, commitTS, 0)
 	if err != nil {
 		return nil, err
 	}
 	return listElems, nil
 }
 
-func (c *luaScriptContext) listDeltaCommitElems(key string, st *luaListState) ([]*kv.Elem[kv.OP], error) {
+func (c *luaScriptContext) listDeltaCommitElems(key string, st *luaListState, commitTS uint64) ([]*kv.Elem[kv.OP], error) {
 	if !st.exists || st.currentLen() == 0 {
 		return nil, nil
 	}
@@ -2563,21 +2576,38 @@ func (c *luaScriptContext) listDeltaCommitElems(key string, st *luaListState) ([
 	if err != nil {
 		return nil, err
 	}
-	newMeta := store.ListMeta{
-		Head: newHead,
-		Len:  st.currentLen(),
-		Tail: newHead + st.currentLen(),
-	}
-	metaBytes, err := store.MarshalListMeta(newMeta)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
 
-	elems := make([]*kv.Elem[kv.OP], 0, int(st.leftTrim+st.rightTrim)+len(st.leftValues)+len(st.rightValues)+1)
+	elems := make([]*kv.Elem[kv.OP], 0, int(st.leftTrim+st.rightTrim)+len(st.leftValues)+len(st.rightValues)+setWideColOverhead)
 	elems = appendListTrimDeletes(elems, []byte(key), st)
 	elems = appendListPuts(elems, []byte(key), st.leftValues, newHead)
 	elems = appendListPuts(elems, []byte(key), st.rightValues, rightStart)
-	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: listMetaKey([]byte(key)), Value: metaBytes})
+
+	// Emit Delta keys for any appended values and trims instead of writing base meta.
+	// Trims are counted separately as negative deltas.
+	var seqInTxn uint32
+	if len(st.rightValues) > 0 {
+		rightDelta := store.MarshalListMetaDelta(store.ListMetaDelta{
+			HeadDelta: 0,
+			LenDelta:  int64(len(st.rightValues)) - st.rightTrim,
+		})
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.ListMetaDeltaKey([]byte(key), commitTS, seqInTxn),
+			Value: rightDelta,
+		})
+		seqInTxn++
+	}
+	if len(st.leftValues) > 0 || st.leftTrim > 0 {
+		leftDelta := store.MarshalListMetaDelta(store.ListMetaDelta{
+			HeadDelta: -int64(len(st.leftValues)) + st.leftTrim,
+			LenDelta:  int64(len(st.leftValues)) - st.leftTrim,
+		})
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.ListMetaDeltaKey([]byte(key), commitTS, seqInTxn),
+			Value: leftDelta,
+		})
+	}
 	return elems, nil
 }
 
@@ -2620,11 +2650,26 @@ func (c *luaScriptContext) hashCommitElems(key string) ([]*kv.Elem[kv.OP], error
 	if err != nil {
 		return nil, err
 	}
-	payload, err := marshalHashValue(st.value)
-	if err != nil {
-		return nil, err
+	if len(st.value) == 0 {
+		// Deletion is handled by deleteLogicalKeyElems called before this.
+		return nil, nil
 	}
-	return []*kv.Elem[kv.OP]{{Op: kv.Put, Key: redisHashKey([]byte(key)), Value: payload}}, nil
+	// Wide-column: write per-field keys and a base meta key with the final count.
+	// deleteLogicalKeyElems (called by the Lua commit flow) clears any old keys.
+	elems := make([]*kv.Elem[kv.OP], 0, len(st.value)+1)
+	for field, val := range st.value {
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.HashFieldKey([]byte(key), []byte(field)),
+			Value: []byte(val),
+		})
+	}
+	elems = append(elems, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   store.HashMetaKey([]byte(key)),
+		Value: store.MarshalHashMeta(store.HashMeta{Len: int64(len(st.value))}),
+	})
+	return elems, nil
 }
 
 func (c *luaScriptContext) setCommitElems(key string) ([]*kv.Elem[kv.OP], error) {
@@ -2632,11 +2677,25 @@ func (c *luaScriptContext) setCommitElems(key string) ([]*kv.Elem[kv.OP], error)
 	if err != nil {
 		return nil, err
 	}
-	payload, err := marshalSetValue(redisSetValue{Members: sortedSetMembers(st.members)})
-	if err != nil {
-		return nil, err
+	if len(st.members) == 0 {
+		// Deletion is handled by deleteLogicalKeyElems called before this.
+		return nil, nil
 	}
-	return []*kv.Elem[kv.OP]{{Op: kv.Put, Key: redisSetKey([]byte(key)), Value: payload}}, nil
+	// Wide-column: write per-member keys and a base meta key with the final count.
+	elems := make([]*kv.Elem[kv.OP], 0, len(st.members)+1)
+	for member := range st.members {
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.SetMemberKey([]byte(key), []byte(member)),
+			Value: []byte{},
+		})
+	}
+	elems = append(elems, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   store.SetMetaKey([]byte(key)),
+		Value: store.MarshalSetMeta(store.SetMeta{Len: int64(len(st.members))}),
+	})
+	return elems, nil
 }
 
 func (c *luaScriptContext) zsetCommitElems(key string) ([]*kv.Elem[kv.OP], error) {

--- a/adapter/redis_multi_test.go
+++ b/adapter/redis_multi_test.go
@@ -195,11 +195,14 @@ func TestRedis_MultiExec_DelThenRPushRecreatesList(t *testing.T) {
 	require.Equal(t, []any{"new1", "new2"}, rangeRes)
 
 	readTS := nodes[1].redisServer.readTS()
-	metaRaw, err := nodes[1].redisServer.store.GetAt(ctx, store.ListMetaKey([]byte("list-del-rpush")), readTS)
+
+	// With the Delta pattern, RPUSH inside a MULTI/EXEC emits a delta key
+	// rather than updating the base metadata key directly.  Verify the
+	// effective metadata via resolveListMeta which aggregates deltas.
+	resolvedMeta, resolvedExists, err := nodes[1].redisServer.resolveListMeta(ctx, []byte("list-del-rpush"), readTS)
 	require.NoError(t, err)
-	meta, err := store.UnmarshalListMeta(metaRaw)
-	require.NoError(t, err)
-	require.Equal(t, int64(2), meta.Len)
+	require.True(t, resolvedExists)
+	require.Equal(t, int64(2), resolvedMeta.Len)
 
 	kvs, err := nodes[1].redisServer.store.ScanAt(
 		ctx,

--- a/adapter/redis_retry.go
+++ b/adapter/redis_retry.go
@@ -124,9 +124,26 @@ func normalizeRetryableRedisTxnErr(err error) error {
 	return err
 }
 
+// normalizeZSetWideColumnKey extracts the logical user key from a ZSet wide-column key.
+func normalizeZSetWideColumnKey(key []byte) ([]byte, bool) {
+	if store.IsZSetMetaDeltaKey(key) {
+		return store.ExtractZSetUserKeyFromDelta(key), true
+	}
+	if store.IsZSetMetaKey(key) {
+		return store.ExtractZSetUserKeyFromMeta(key), true
+	}
+	if store.IsZSetMemberKey(key) {
+		return store.ExtractZSetUserKeyFromMember(key), true
+	}
+	if store.IsZSetScoreKey(key) {
+		return store.ExtractZSetUserKeyFromScore(key), true
+	}
+	return nil, false
+}
+
 // normalizeWideColumnKey extracts the logical user key from any wide-column
-// internal key (hash/set meta, delta, or field/member). Returns (key, true) when
-// the input is a recognised wide-column key, (nil, false) otherwise.
+// internal key (hash/set/zset meta, delta, field, member, or score index).
+// Returns (key, true) when the input is a recognised wide-column key, (nil, false) otherwise.
 // Delta prefixes are checked before meta prefixes because delta keys share the
 // meta prefix as a leading substring.
 func normalizeWideColumnKey(key []byte) ([]byte, bool) {
@@ -148,7 +165,7 @@ func normalizeWideColumnKey(key []byte) ([]byte, bool) {
 	if store.IsSetMemberKey(key) {
 		return store.ExtractSetUserKeyFromMember(key), true
 	}
-	return nil, false
+	return normalizeZSetWideColumnKey(key)
 }
 
 func normalizeRetryableRedisTxnKey(key []byte) []byte {

--- a/adapter/redis_retry.go
+++ b/adapter/redis_retry.go
@@ -124,12 +124,42 @@ func normalizeRetryableRedisTxnErr(err error) error {
 	return err
 }
 
+// normalizeWideColumnKey extracts the logical user key from any wide-column
+// internal key (hash/set meta, delta, or field/member). Returns (key, true) when
+// the input is a recognised wide-column key, (nil, false) otherwise.
+// Delta prefixes are checked before meta prefixes because delta keys share the
+// meta prefix as a leading substring.
+func normalizeWideColumnKey(key []byte) ([]byte, bool) {
+	if store.IsHashMetaDeltaKey(key) {
+		return store.ExtractHashUserKeyFromDelta(key), true
+	}
+	if store.IsHashMetaKey(key) {
+		return store.ExtractHashUserKeyFromMeta(key), true
+	}
+	if store.IsHashFieldKey(key) {
+		return store.ExtractHashUserKeyFromField(key), true
+	}
+	if store.IsSetMetaDeltaKey(key) {
+		return store.ExtractSetUserKeyFromDelta(key), true
+	}
+	if store.IsSetMetaKey(key) {
+		return store.ExtractSetUserKeyFromMeta(key), true
+	}
+	if store.IsSetMemberKey(key) {
+		return store.ExtractSetUserKeyFromMember(key), true
+	}
+	return nil, false
+}
+
 func normalizeRetryableRedisTxnKey(key []byte) []byte {
 	if userKey := kv.ExtractTxnUserKey(key); userKey != nil {
 		key = userKey
 	}
 	if store.IsListMetaKey(key) || store.IsListItemKey(key) {
 		return store.ExtractListUserKey(key)
+	}
+	if wideKey, ok := normalizeWideColumnKey(key); ok {
+		return wideKey
 	}
 	if bytes.HasPrefix(key, []byte(redisTTLPrefix)) {
 		return bytes.TrimPrefix(key, []byte(redisTTLPrefix))

--- a/adapter/redis_storage_migration_test.go
+++ b/adapter/redis_storage_migration_test.go
@@ -185,18 +185,30 @@ func TestRedisZSetLegacyJSONReadThenRewriteToProto(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, added)
 
-	rawAfterWrite := mustReadRawValue(t, st, storageKey)
-	require.True(t, hasStoredRedisPrefix(rawAfterWrite, storedRedisZSetProtoPrefix))
+	// After migration-on-write the legacy blob is deleted; wide-column member + score keys are used instead.
+	readTS := server.readTS()
+	_, err = st.GetAt(context.Background(), storageKey, readTS)
+	require.ErrorIs(t, err, store.ErrKeyNotFound, "legacy blob should be deleted after wide-column migration")
 
-	decoded, err := unmarshalZSetValue(rawAfterWrite)
+	// loadZSetAt should aggregate all wide-column members including the migrated ones.
+	got, gotExists, err := server.loadZSetAt(context.Background(), key, readTS)
 	require.NoError(t, err)
+	require.True(t, gotExists)
 	require.Equal(t, redisZSetValue{
 		Entries: []redisZSetEntry{
 			{Member: "a", Score: 1},
 			{Member: "b", Score: 2},
 			{Member: "c", Score: 3},
 		},
-	}, decoded)
+	}, got)
+
+	// Each member key and score index key must be present in the store.
+	for _, entry := range got.Entries {
+		_, err = st.GetAt(context.Background(), store.ZSetMemberKey(key, []byte(entry.Member)), readTS)
+		require.NoError(t, err, "member key %q should exist after migration", entry.Member)
+		_, err = st.GetAt(context.Background(), store.ZSetScoreKey(key, entry.Score, []byte(entry.Member)), readTS)
+		require.NoError(t, err, "score key %q should exist after migration", entry.Member)
+	}
 }
 
 func TestRedisStreamLegacyJSONReadThenRewriteToProto(t *testing.T) {

--- a/adapter/redis_storage_migration_test.go
+++ b/adapter/redis_storage_migration_test.go
@@ -64,12 +64,21 @@ func TestRedisHashLegacyJSONReadThenRewriteToProto(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, added)
 
-	rawAfterWrite := mustReadRawValue(t, st, storageKey)
-	require.True(t, hasStoredRedisPrefix(rawAfterWrite, storedRedisHashProtoPrefix))
+	// After migration-on-write the legacy blob is deleted; wide-column field keys are used instead.
+	readTS := server.readTS()
+	_, err = st.GetAt(context.Background(), storageKey, readTS)
+	require.ErrorIs(t, err, store.ErrKeyNotFound, "legacy blob should be deleted after wide-column migration")
 
-	decoded, err := unmarshalHashValue(rawAfterWrite)
+	// loadHashAt should aggregate all wide-column fields including the migrated one.
+	got, err := server.loadHashAt(context.Background(), key, readTS)
 	require.NoError(t, err)
-	require.Equal(t, redisHashValue{"field": "old", "next": "new"}, decoded)
+	require.Equal(t, redisHashValue{"field": "old", "next": "new"}, got)
+
+	// Each field key must be present in the store.
+	for _, field := range []string{"field", "next"} {
+		_, err = st.GetAt(context.Background(), store.HashFieldKey(key, []byte(field)), readTS)
+		require.NoError(t, err, "field key %q should exist after migration", field)
+	}
 }
 
 func TestRedisSetLegacyJSONReadThenRewriteToProto(t *testing.T) {
@@ -95,12 +104,21 @@ func TestRedisSetLegacyJSONReadThenRewriteToProto(t *testing.T) {
 	require.Empty(t, conn.err)
 	require.Equal(t, int64(1), conn.int)
 
-	rawAfterWrite := mustReadRawValue(t, st, storageKey)
-	require.True(t, hasStoredRedisPrefix(rawAfterWrite, storedRedisSetProtoPrefix))
+	// After migration-on-write the legacy blob is deleted; wide-column member keys are used instead.
+	readTS := server.readTS()
+	_, err = st.GetAt(context.Background(), storageKey, readTS)
+	require.ErrorIs(t, err, store.ErrKeyNotFound, "legacy blob should be deleted after wide-column migration")
 
-	decoded, err := unmarshalSetValue(rawAfterWrite)
+	// loadSetAt should aggregate all wide-column members including the migrated ones.
+	got, err := server.loadSetAt(context.Background(), "set", key, readTS)
 	require.NoError(t, err)
-	require.Equal(t, redisSetValue{Members: []string{"a", "b", "c"}}, decoded)
+	require.Equal(t, redisSetValue{Members: []string{"a", "b", "c"}}, got)
+
+	// Each member key must be present in the store.
+	for _, member := range []string{"a", "b", "c"} {
+		_, err = st.GetAt(context.Background(), store.SetMemberKey(key, []byte(member)), readTS)
+		require.NoError(t, err, "member key %q should exist after migration", member)
+	}
 }
 
 func TestRedisHLLLegacyJSONReadThenRewriteToProto(t *testing.T) {

--- a/adapter/redis_txn_test.go
+++ b/adapter/redis_txn_test.go
@@ -9,7 +9,11 @@ import (
 	"github.com/tidwall/redcon"
 )
 
-func TestRedisTxnValidateReadSetDetectsStaleListMeta(t *testing.T) {
+// TestRedisTxnValidateReadSet_ListMetaUpdateNoConflict verifies that updating
+// the base list metadata key (e.g. by a DeltaCompactor) does NOT trigger an
+// OCC conflict for append operations.  With the Delta pattern, appenders never
+// read-modify-write the base meta key, so compaction is invisible to them.
+func TestRedisTxnValidateReadSet_ListMetaUpdateNoConflict(t *testing.T) {
 	t.Parallel()
 
 	server, st := newRedisStorageMigrationTestServer(t)
@@ -32,9 +36,45 @@ func TestRedisTxnValidateReadSetDetectsStaleListMeta(t *testing.T) {
 	_, err = txn.loadListState(key)
 	require.NoError(t, err)
 
+	// Simulate a DeltaCompactor updating the base meta after our read.
 	metaV2, err := store.MarshalListMeta(store.ListMeta{Len: 2})
 	require.NoError(t, err)
 	require.NoError(t, st.PutAt(context.Background(), store.ListMetaKey(key), metaV2, 11, 0))
+
+	// With the Delta pattern the base meta key is NOT in the OCC read set,
+	// so the compaction write must NOT surface as a write conflict.
+	err = txn.validateReadSet(context.Background())
+	require.NoError(t, err)
+}
+
+// TestRedisTxnValidateReadSet_TTLUpdateConflict verifies that updating the TTL
+// key for a list DOES trigger an OCC conflict, because TTL reads are still
+// tracked in the read set.
+func TestRedisTxnValidateReadSet_TTLUpdateConflict(t *testing.T) {
+	t.Parallel()
+
+	server, st := newRedisStorageMigrationTestServer(t)
+	key := []byte("list:ttl-conflict")
+
+	metaBytes, err := store.MarshalListMeta(store.ListMeta{Len: 1})
+	require.NoError(t, err)
+	require.NoError(t, st.PutAt(context.Background(), store.ListMetaKey(key), metaBytes, 10, 0))
+
+	txn := &txnContext{
+		server:     server,
+		working:    map[string]*txnValue{},
+		listStates: map[string]*listTxnState{},
+		zsetStates: map[string]*zsetTxnState{},
+		ttlStates:  map[string]*ttlTxnState{},
+		readKeys:   map[string][]byte{},
+		startTS:    10,
+	}
+
+	_, err = txn.loadListState(key)
+	require.NoError(t, err)
+
+	// A concurrent EXPIRE updates the TTL key after our read.
+	require.NoError(t, st.PutAt(context.Background(), redisTTLKey(key), []byte("dummy"), 11, 0))
 
 	err = txn.validateReadSet(context.Background())
 	require.Error(t, err)

--- a/docs/etcd_snapshot_disk_offload_design.md
+++ b/docs/etcd_snapshot_disk_offload_design.md
@@ -107,7 +107,7 @@ After:  Data = [magic:4][version:1][index:8][crc32c:4]
 
 | Field   | Size   | Value |
 |---------|--------|-------|
-| magic   | 4 byte | `EKVR` (ElasticKV Reference) |
+| magic   | 4 byte | `EKVT` (ElasticKV Token) |
 | version | 1 byte | `0x01` |
 | index   | 8 byte | applied log index of the snapshot (little-endian uint64) |
 | crc32c  | 4 byte | CRC32C checksum of the entire `.fsm` file (little-endian uint32) |
@@ -115,6 +115,18 @@ After:  Data = [magic:4][version:1][index:8][crc32c:4]
 The magic prefix distinguishes the new format from legacy payloads (see Migration section).
 Embedding the CRC32C in the token allows integrity verification at the metadata level,
 before the file is even opened.
+
+> **Magic allocation note**: The existing persistence layer already uses `EKVR` (state
+> file), `EKVM` (metadata file), and `EKVW` (entries file) as defined in
+> `internal/raftengine/etcd/persistence.go`. `EKVT` is chosen to avoid collision with
+> any of these. The full registry is:
+>
+> | Magic  | File |
+> |--------|------|
+> | `EKVR` | `etcd-raft-state.bin` |
+> | `EKVM` | `etcd-raft-meta.bin` |
+> | `EKVW` | `etcd-raft-entries.bin` |
+> | `EKVT` | `raftpb.Snapshot.Data` token (this design) |
 
 ### `.fsm` File Format
 
@@ -192,7 +204,7 @@ maybePersistLocalSnapshot()
       → os.CreateTemp() → {fsmSnapDir}/{storageIndex}.fsm.tmp
       → crcWriter := newCRC32CWriter(tmpFile)
       → fsmSnap.WriteTo(crcWriter)                              # stream to disk + compute CRC
-      → binary.Write(tmpFile, LittleEndian, crcWriter.Sum32()) # append CRC footer
+      → binary.Write(tmpFile, binary.LittleEndian, crcWriter.Sum32()) # append CRC footer
       → tmpFile.Sync()
       → os.Rename(tmp, final)                                   # atomic commit
       → syncDir(fsmSnapDir)                                     # persist directory entry
@@ -246,8 +258,11 @@ func openAndRestoreFSMSnapshot(fsm StateMachine, path string, tokenCRC uint32) e
     if err != nil {
         return errors.WithStack(err)
     }
-    if info.Size() < 4 {
-        return errors.Wrapf(ErrFSMSnapshotFileCRC, "file too small: %d bytes", info.Size())
+    // Minimum valid .fsm: 8 bytes Pebble magic + 8 bytes lastCommitTS + 4 bytes CRC footer = 20 bytes.
+    const minFSMFileSize = 20
+    if info.Size() < minFSMFileSize {
+        return errors.Wrapf(ErrFSMSnapshotTooSmall,
+            "file too small: %d bytes (minimum %d)", info.Size(), minFSMFileSize)
     }
     f, err := os.Open(path)
     if err != nil {
@@ -461,7 +476,7 @@ var (
 | File | Change |
 |------|--------|
 | `internal/raftengine/etcd/wal_store.go` | Remove `snapshotBytes`; add `writeFSMSnapshotFile`; update `restoreSnapshotState` and `stateMachineSnapshotBytes` (bootstrap) |
-| `internal/raftengine/etcd/engine.go` | Update `persistLocalSnapshot`, `persistConfigSnapshot`, and `persistConfigSnapshotPayload` to use `writeFSMSnapshotFile` + token; add `fsmSnapDir` and `snapReceiveGroup` fields |
+| `internal/raftengine/etcd/engine.go` | Update `persistLocalSnapshot`, `persistConfigSnapshot`, `persistConfigState`, and `persistConfigSnapshotPayload` to use `writeFSMSnapshotFile` + token; add `fsmSnapDir` and `snapReceiveGroup` fields |
 | `internal/raftengine/etcd/grpc_transport.go` | Detect token in `Dispatch` → file-streaming send; update `receiveSnapshotStream` to write chunks to file with `singleflight` serialization and `syncDir` |
 | `internal/raftengine/etcd/snapshot_spool.go` | Remove `snapshotSpool` (Phase 3) |
 
@@ -481,7 +496,7 @@ var (
 writeFSMSnapshotFile():
   1. os.CreateTemp(fsmSnapDir, "*.fsm.tmp")         # write to temp file
   2. snapshot.WriteTo(crcWriter)                     # stream FSM + accumulate CRC
-  3. binary.Write(tmpFile, LE, crcWriter.Sum32())    # append CRC footer
+  3. binary.Write(tmpFile, binary.LittleEndian, crcWriter.Sum32()) # append CRC footer
   4. tmpFile.Sync()                                  # flush to durable storage
   5. os.Rename(tmp, final)                           # atomic commit
   6. syncDir(fsmSnapDir)                             # persist directory entry
@@ -551,7 +566,7 @@ If the first 4 bytes of `raftpb.Snapshot.Data` equal `EKVR`, the payload is trea
 token. Any other prefix is treated as a legacy FSM payload.
 
 ```go
-const snapshotTokenMagic = [4]byte{'E', 'K', 'V', 'R'}
+const snapshotTokenMagic = [4]byte{'E', 'K', 'V', 'T'}
 
 func isSnapshotToken(data []byte) bool {
     if len(data) < 4 {
@@ -574,6 +589,62 @@ If a node begins writing `.fsm` files and then rolls back to the previous binary
 **When a follower receives a legacy-format MsgSnap:**
 - `isSnapshotToken` returns false → restore via `bytes.NewReader` (no CRC check)
 - Compatible with rolling upgrades where not all nodes have been updated yet
+
+---
+
+## Rolling Upgrade and Zero-Downtime Cutover
+
+### Compatibility Matrix
+
+The `isSnapshotToken` magic check provides the compatibility bridge. Because `EKVT` is
+a prefix that can never appear in a valid legacy FSM payload (Pebble snapshots start with
+`EKVPBBL1`; gob-encoded legacy payloads start with gob framing bytes), there is no
+ambiguity when a mixed-version cluster is operating.
+
+| Sender version | Receiver version | Outcome |
+|----------------|-----------------|---------|
+| Legacy (no token) | Legacy | Unchanged — existing path |
+| Legacy (no token) | New | `isSnapshotToken` → false → `bytes.NewReader` fallback |
+| New (token) | Legacy | Legacy node does not understand the token; restores from the 17-byte payload as if it were FSM data → **corrupt FSM** |
+| New (token) | New | Token path → `.fsm` file |
+
+### Rolling Upgrade Strategy
+
+The third case — a new-format leader sending a token to a legacy follower — is the only
+dangerous scenario. To prevent it, the rollout must proceed as follows:
+
+1. **Deploy Phase 1 to all nodes before Phase 2.** Phase 1 changes only local snapshot
+   creation and restore; it does not change what is sent over the wire. A Phase 1 node
+   still sends full `[]byte` payloads in `MsgSnap` and can receive them. Mixed Phase 1 /
+   legacy clusters are safe.
+
+2. **Deploy Phase 2 to all nodes simultaneously, or use the feature flag below.** Once
+   any node begins sending token-format `MsgSnap`, all receivers must be at Phase 2.
+
+3. **Feature flag (recommended)**: add a `DisableFSMSnapshotToken` config field (default
+   `false`). When set to `true`, `Dispatch` falls back to the legacy `sendSnapshot` path
+   even if the local MemoryStorage contains a token. This allows operators to:
+   - Deploy Phase 2 binaries cluster-wide with the flag enabled.
+   - Verify stability, then disable the flag on each node progressively.
+   - Roll back safely by re-enabling the flag without restarting.
+
+### Rollback Safety
+
+If a rollback to the pre-Phase 1 binary is required after Phase 1 has created `.fsm`
+files:
+- The legacy binary reads the `.snap` file and finds `Data` = a 17-byte token starting
+  with `EKVT`.
+- `fsm.Restore` will attempt to interpret 17 bytes as a Pebble snapshot and fail with a
+  decode error (the Pebble magic `EKVPBBL1` is not present).
+- **Mitigation**: Before rolling back, stop the node and manually delete `fsm-snap/`; the
+  legacy binary will then fall back to WAL replay from the compacted snapshot index.
+  Document this procedure in the runbook.
+
+Alternatively, Phase 1 can write a **dual-format** `.snap` file during a configurable
+transition window: `raftpb.Snapshot.Data` = token AND a copy of the full legacy payload
+stored in an auxiliary file. The legacy binary would then decode the full payload
+normally. This dual-write mode is a forward compatibility bridge and can be removed after
+the fleet has been fully upgraded.
 
 ---
 
@@ -621,7 +692,7 @@ config-change, and bootstrap). Follower send/receive is unchanged.
   - `encodeSnapshotToken` / `decodeSnapshotToken` (17-byte token with CRC)
   - Error types: `ErrFSMSnapshotFileCRC`, `ErrFSMSnapshotTokenCRC`, etc.
 - Update `persistLocalSnapshot` → `writeFSMSnapshotFile` + token
-- Update `persistConfigSnapshot` / `persistConfigSnapshotPayload` → same
+- Update `persistConfigSnapshot`, `persistConfigState`, and `persistConfigSnapshotPayload` → same
 - Update `stateMachineSnapshotBytes` (bootstrap) → `writeFSMSnapshotFile` + token
 - Update `restoreSnapshotState` → `openAndRestoreFSMSnapshot`
 - Replace `purgeOldSnapFiles` with `purgeOldSnapshotFiles(snapDir, fsmSnapDir)`

--- a/docs/etcd_snapshot_disk_offload_design.md
+++ b/docs/etcd_snapshot_disk_offload_design.md
@@ -110,7 +110,7 @@ After:  Data = [magic:4][version:1][index:8][crc32c:4]
 | magic   | 4 byte | `EKVT` (ElasticKV Token) |
 | version | 1 byte | `0x01` |
 | index   | 8 byte | applied log index of the snapshot (little-endian uint64) |
-| crc32c  | 4 byte | CRC32C checksum of the entire `.fsm` file (little-endian uint32) |
+| crc32c  | 4 byte | CRC32C checksum of the `.fsm` file payload (all bytes preceding the footer) (little-endian uint32) |
 
 The magic prefix distinguishes the new format from legacy payloads (see Migration section).
 Embedding the CRC32C in the token allows integrity verification at the metadata level,
@@ -274,7 +274,15 @@ func openAndRestoreFSMSnapshot(fsm StateMachine, path string, tokenCRC uint32) e
     h := crc32.New(crc32cTable)
     // Tee: data flows to both the CRC accumulator and fsm.Restore simultaneously.
     tee := io.TeeReader(io.LimitReader(f, payloadSize), h)
-    if err := fsm.Restore(bufio.NewReaderSize(tee, 1<<20)); err != nil {
+    br := bufio.NewReaderSize(tee, 1<<20)
+    if err := fsm.Restore(br); err != nil {
+        return errors.WithStack(err)
+    }
+    // Drain any bytes that fsm.Restore left unread (e.g. if it stopped on an
+    // internal end-of-stream marker before consuming the full payload).
+    // Without this, h would have accumulated fewer bytes than the file contains,
+    // producing a spurious CRC mismatch even for a valid file.
+    if _, err := io.Copy(io.Discard, br); err != nil {
         return errors.WithStack(err)
     }
     var footer uint32
@@ -562,7 +570,7 @@ The existing `purgeOldSnapFiles` function is removed and replaced entirely.
 
 ## Migration (Legacy Format Compatibility)
 
-If the first 4 bytes of `raftpb.Snapshot.Data` equal `EKVR`, the payload is treated as a
+If the first 4 bytes of `raftpb.Snapshot.Data` equal `EKVT`, the payload is treated as a
 token. Any other prefix is treated as a legacy FSM payload.
 
 ```go
@@ -737,7 +745,7 @@ removes three-read-pass anti-pattern on the receive side.
 | Test | What it verifies |
 |------|-----------------|
 | `TestTokenRoundTrip` | `encodeSnapshotToken` / `decodeSnapshotToken` round-trip for boundary values (`0`, `MaxUint64`, `MaxUint32`) |
-| `TestTokenMagicRejection` | `isSnapshotToken` returns false for non-`EKVR` prefixes; `decodeSnapshotToken` returns `ErrFSMSnapshotTokenInvalid` for lengths 0–16 and wrong magic |
+| `TestTokenMagicRejection` | `isSnapshotToken` returns false for non-`EKVT` prefixes; `decodeSnapshotToken` returns `ErrFSMSnapshotTokenInvalid` for lengths 0–16 and wrong magic |
 | `TestCRCWriterMatchesStdlib` | `crc32CWriter.Sum32()` matches `crc32.Checksum` for identical bytes; incremental writes accumulate correctly |
 | `TestOpenAndRestoreFSMSnapshotGoodFile` | Correct file restores FSM state without error |
 | `TestOpenAndRestoreFSMSnapshotBadFooter` | Footer byte flipped → `ErrFSMSnapshotFileCRC` |
@@ -757,7 +765,7 @@ removes three-read-pass anti-pattern on the receive side.
 | `TestReceiveWrongCRCInFooter` | Correct length, corrupted footer → verify rejects before rename |
 | `TestReceiveTokenCRCMismatchesFileCRC` | Token carries wrong CRC, file footer is self-consistent → `ErrFSMSnapshotTokenCRC` in `openAndRestoreFSMSnapshot` |
 | `TestConcurrentReceiveSameIndex` | Two goroutines receiving the same index via `singleflight`; only one `.fsm` committed; no torn file |
-| `TestLegacyFormatFallbackOnRestore` | `snap.Data` without `EKVR` prefix → `bytes.NewReader` path; no `.fsm` file opened |
+| `TestLegacyFormatFallbackOnRestore` | `snap.Data` without `EKVT` prefix → `bytes.NewReader` path; no `.fsm` file opened |
 | `TestLegacyFormatFallbackOnSend` | Non-token `MsgSnap` → old `sendSnapshot` path; no file opened from `fsmSnapDir` |
 | `TestSyncDirCalledAfterRename` | Both `writeFSMSnapshotFile` and `receiveSnapshotStream` call `syncDir` after rename (verified via mock or filesystem hook) |
 | Conformance `SnapshotRestoreAfterRestart` | Propose 10,001 entries, close engine, reopen; assert FSM state recovered from `.fsm` snapshot (not WAL replay) |

--- a/docs/etcd_snapshot_disk_offload_design.md
+++ b/docs/etcd_snapshot_disk_offload_design.md
@@ -366,6 +366,9 @@ receiveSnapshotStream()
 ```
 receiveSnapshotStream()
   → receive header chunk → parse token → extract index, tokenCRC
+  → validate token.Index == snap.Metadata.Index
+    # a mismatch indicates a misrouted or corrupted snapshot; return
+    # ErrFSMSnapshotIndexMismatch immediately before writing any data
   → result, err := snapReceiveGroup.Do(strconv.FormatUint(index, 10), func() {
         → os.CreateTemp() → {fsmSnapDir}/{index}.fsm.tmp
         → stream remaining chunks to tmpFile (with bufio.NewWriterSize)
@@ -531,11 +534,16 @@ The receiver path (`receiveSnapshotStream`) follows the same sequence and also c
 3. Removes any `.fsm` file whose index does not correspond to a live token — this handles
    the case where a `.fsm` was written but the corresponding `.snap` was never saved
    (upgrade crash), as well as files left over after purge ordering bugs in older versions.
-4. For each remaining `.fsm` file, calls `verifyFSMSnapshotFile` and removes files where
-   `ErrFSMSnapshotFileCRC` is returned (corrupt files cannot be used for restore).
 
-This index-based orphan detection is stricter than a CRC-only check: a file with a valid
-CRC but no matching token is still an orphan and must be removed.
+CRC integrity of the retained `.fsm` files is **not** verified at startup. For GiB-scale
+snapshots on slow storage, a full read-pass over every `.fsm` file would unacceptably
+delay engine recovery. Instead, CRC verification happens lazily in
+`openAndRestoreFSMSnapshot` at the moment the snapshot is actually applied. If a file is
+corrupt, the engine detects it at restore time and can request a fresh snapshot from the
+leader.
+
+This index-based orphan detection is stricter than a CRC-only startup scan: a file with
+a valid CRC but no matching token is still an orphan and must be removed.
 
 ---
 
@@ -621,13 +629,37 @@ ambiguity when a mixed-version cluster is operating.
 The third case — a new-format leader sending a token to a legacy follower — is the only
 dangerous scenario. To prevent it, the rollout must proceed as follows:
 
-1. **Deploy Phase 1 to all nodes before Phase 2.** Phase 1 changes only local snapshot
-   creation and restore; it does not change what is sent over the wire. A Phase 1 node
-   still sends full `[]byte` payloads in `MsgSnap` and can receive them. Mixed Phase 1 /
-   legacy clusters are safe.
+1. **Deploy Phase 1 to all nodes before Phase 2.** Phase 1 stores a 17-byte token in
+   `MemoryStorage` instead of the full FSM payload. This means a Phase 1 leader **would**
+   send a token in `MsgSnap` to a lagging follower, which a legacy follower cannot
+   understand. To remain backward-compatible, Phase 1 **must** therefore also include a
+   `Dispatch`-side fallback that reconstructs a full-payload `MsgSnap` when using the
+   legacy send path:
 
-2. **Deploy Phase 2 to all nodes simultaneously, or use the feature flag below.** Once
-   any node begins sending token-format `MsgSnap`, all receivers must be at Phase 2.
+   ```go
+   // Phase 1 Dispatch fallback: token is in MemoryStorage but receiver may be legacy.
+   // Read the .fsm file back to bytes only when a slow follower actually needs a
+   // snapshot — not on every periodic creation — so peak memory is still improved.
+   if isSnapshotToken(msg.Snapshot.Data) {
+       tok, _ := decodeSnapshotToken(msg.Snapshot.Data)
+       path := filepath.Join(fsmSnapDir, strconv.FormatUint(tok.Index, 10)+".fsm")
+       payload, err := readFSMSnapshotPayload(path) // streams file, returns []byte
+       if err != nil {
+           return errors.WithStack(err)
+       }
+       msg.Snapshot.Data = payload // full bytes → safe for legacy receivers
+   }
+   // fall through to legacy sendSnapshot path
+   ```
+
+   With this fallback, mixed Phase 1 / legacy clusters are safe. The memory allocation
+   occurs only when a slow follower needs a snapshot send, not during periodic local
+   snapshot creation, so the worst-case spike is unchanged but the common-case (no
+   lagging followers) is fully eliminated.
+
+2. **Deploy Phase 2 to all nodes simultaneously, or use the feature flag below.** Phase 2
+   replaces the Phase 1 fallback with true file streaming; once any node begins sending
+   token-format `MsgSnap` without reconstructing, all receivers must be at Phase 2.
 
 3. **Feature flag (recommended)**: add a `DisableFSMSnapshotToken` config field (default
    `false`). When set to `true`, `Dispatch` falls back to the legacy `sendSnapshot` path
@@ -688,7 +720,8 @@ the fleet has been fully upgraded.
 ### Phase 1: Local Snapshot Disk Offload
 
 Scope: local creation and local restore for **all three snapshot paths** (periodic,
-config-change, and bootstrap). Follower send/receive is unchanged.
+config-change, and bootstrap) **plus** a `Dispatch`-side fallback for backward
+compatibility with legacy followers.
 
 **Implementation tasks:**
 
@@ -697,12 +730,17 @@ config-change, and bootstrap). Follower send/receive is unchanged.
   - `writeFSMSnapshotFile` (write with CRC footer + syncDir)
   - `openAndRestoreFSMSnapshot` (single-pass verify+restore via TeeReader)
   - `verifyFSMSnapshotFile` (read-only CRC check for orphan detection)
+  - `readFSMSnapshotPayload` (read `.fsm` file back to `[]byte` for legacy send)
   - `encodeSnapshotToken` / `decodeSnapshotToken` (17-byte token with CRC)
-  - Error types: `ErrFSMSnapshotFileCRC`, `ErrFSMSnapshotTokenCRC`, etc.
+  - Error types: `ErrFSMSnapshotFileCRC`, `ErrFSMSnapshotTokenCRC`,
+    `ErrFSMSnapshotIndexMismatch`, etc.
 - Update `persistLocalSnapshot` → `writeFSMSnapshotFile` + token
 - Update `persistConfigSnapshot`, `persistConfigState`, and `persistConfigSnapshotPayload` → same
 - Update `stateMachineSnapshotBytes` (bootstrap) → `writeFSMSnapshotFile` + token
 - Update `restoreSnapshotState` → `openAndRestoreFSMSnapshot`
+- Update `Dispatch`: if `isSnapshotToken(msg.Snapshot.Data)` and using the legacy send
+  path, call `readFSMSnapshotPayload` to reconstruct the full payload before sending
+  (ensures legacy followers receive a valid FSM byte stream)
 - Replace `purgeOldSnapFiles` with `purgeOldSnapshotFiles(snapDir, fsmSnapDir)`
 - Add `cleanupStaleFSMSnaps(snapDir, fsmSnapDir)` (index-based orphan removal)
 - Capture `storageIndex` before `fsm.Snapshot()` in `maybePersistLocalSnapshot`
@@ -710,14 +748,18 @@ config-change, and bootstrap). Follower send/receive is unchanged.
 
 **Effect**: eliminates memory spikes during local snapshot creation; reduces
 `MemoryStorage` resident memory; all snapshot creation paths are consistent.
+Mixed Phase 1 / legacy clusters remain safe because the Dispatch fallback reconstructs
+the full payload on demand (only when a slow follower actually needs a snapshot).
 
 ### Phase 2: Streaming Follower Send/Receive
 
-Scope: update `GRPCTransport` MsgSnap paths to use file streaming.
+Scope: update `GRPCTransport` MsgSnap paths to use file streaming; remove the
+Phase 1 `readFSMSnapshotPayload` fallback from `Dispatch`.
 
 **Implementation tasks:**
 
 - `Dispatch`: detect token → open `.fsm` file → `sendSnapshotFileChunks`
+  (replaces the Phase 1 `readFSMSnapshotPayload` fallback entirely)
 - `receiveSnapshotStream`:
   - Write chunks to temp file (with `bufio.NewWriterSize`)
   - `verifyFSMSnapshotFile` on tmp before rename

--- a/docs/etcd_snapshot_disk_offload_design.md
+++ b/docs/etcd_snapshot_disk_offload_design.md
@@ -492,8 +492,32 @@ var (
 | Error | Meaning | Recovery |
 |-------|---------|---------|
 | `ErrFSMSnapshotFileCRC` | On-disk file is corrupt; footer ≠ computed | Delete file; WAL replay from `FirstIndex` |
-| `ErrFSMSnapshotTokenCRC` | Footer and token disagree (detected before restore) | Log the mismatch; request a fresh snapshot from the leader; do not auto-rewrite the token (the mismatch may indicate the token references the wrong file version) |
+| `ErrFSMSnapshotTokenCRC` | Footer and token disagree (detected before restore) | Delete the corrupt `.fsm` file; request a fresh snapshot from the leader; do not auto-rewrite the token (see note below) |
 | `ErrFSMSnapshotNotFound` | `.fsm` file missing for a valid token | WAL replay from `FirstIndex` |
+
+> **`ErrFSMSnapshotTokenCRC` — infinite-loop and source-of-truth considerations**
+>
+> When the engine encounters `ErrFSMSnapshotTokenCRC` it must:
+>
+> 1. **Delete** the suspect `.fsm` file before requesting a new snapshot. If the file is
+>    not deleted, the same mismatch will recur on every apply attempt.
+> 2. **Request a fresh snapshot from the leader** by calling `ReportSnapshot` with
+>    `SnapshotFailure`, which prompts etcd-raft to ask the leader to send another
+>    snapshot. This is not a free-form "request" — it uses the existing Raft mechanism,
+>    which has built-in backoff and retry limits.
+> 3. **Avoid infinite loops**: if `ErrFSMSnapshotTokenCRC` recurs after N consecutive
+>    fresh snapshots (suggested threshold: 3), the engine should log a critical alert and
+>    stop retrying automatically. Persistent recurrence indicates a leader-side issue
+>    (corrupt `.snap` token in the leader's MemoryStorage) that requires operator
+>    intervention.
+> 4. **Single-node or degraded cluster**: if the leader is the only source of truth and
+>    its `.snap` token is persistently corrupt, no amount of re-requesting will help. The
+>    operator must use the rollback procedure (stop node, delete `fsm-snap/`, restart for
+>    WAL replay) to recover. This is documented in the Zero-Downtime Cutover Runbook.
+>
+> Auto-rewriting the token from the file footer is not implemented because the mismatch
+> could indicate the token references a different snapshot version than the file contains;
+> rewriting would silently accept potentially incorrect state.
 
 ---
 

--- a/docs/etcd_snapshot_disk_offload_design.md
+++ b/docs/etcd_snapshot_disk_offload_design.md
@@ -138,15 +138,38 @@ This is the same algorithm used by etcd's `Snapshotter`
 range of several GB/s with negligible CPU overhead. The Go standard library exposes it as
 `hash/crc32.MakeTable(crc32.Castagnoli)`.
 
+### CRC Authority
+
+The **on-disk footer is the authoritative checksum**. The CRC embedded in the token is a
+*transmission integrity check* — it is derived from the file at write time and travels
+with the raft snapshot metadata. The two values must always agree; a mismatch indicates:
+
+- **footer ≠ computed**: the `.fsm` file is corrupt on disk → delete and attempt WAL
+  replay; do not trust the token.
+- **footer == computed, token ≠ computed**: the `.snap` metadata is corrupt → the file
+  itself is trustworthy; the snap file should be rewritten from the file's actual CRC.
+- **footer ≠ computed AND token ≠ computed**: both are corrupt → WAL replay only.
+
+This distinction is implemented in `verifyFSMSnapshotFile`, which returns typed errors
+(`ErrFSMSnapshotFileCRC`, `ErrFSMSnapshotTokenCRC`) to allow callers to take the correct
+recovery action.
+
 ---
 
 ## Flow Changes
 
 ### 1. Local Snapshot Creation
 
+> **Scope note**: This flow applies to **all three snapshot creation paths**: local
+> periodic snapshots (`persistLocalSnapshot`), config-change snapshots
+> (`persistConfigSnapshot`), and bootstrap (`stateMachineSnapshotBytes`). All three must
+> be migrated in Phase 1; leaving any path on the legacy `snapshotBytesAndClose` route
+> re-introduces the memory problem and breaks the token invariant.
+
 **Before:**
 ```
 maybePersistLocalSnapshot()
+  → storageIndex := storage.Snapshot().Metadata.Index   # record current index
   → fsm.Snapshot()
   → snapshotBytesAndClose()
       → spool.WriteTo()        # write to temp file on disk
@@ -158,18 +181,26 @@ maybePersistLocalSnapshot()
 **After:**
 ```
 maybePersistLocalSnapshot()
-  → fsm.Snapshot()
-  → writeFSMSnapshotFile(snapshot, fsmSnapDir, index)
-      → os.CreateTemp() → {fsmSnapDir}/{index}.fsm.tmp
+  # Capture the MemoryStorage index BEFORE calling fsm.Snapshot() so the
+  # staleness check in persistLocalSnapshotPayload uses the same baseline.
+  # If a follower restore advances storage between Snapshot() and
+  # persistLocalSnapshotPayload, the index <= current.Metadata.Index guard
+  # will correctly discard the stale file.
+  → storageIndex := storage.Snapshot().Metadata.Index
+  → fsmSnap := fsm.Snapshot()
+  → crc32c, err := writeFSMSnapshotFile(fsmSnap, fsmSnapDir, storageIndex)
+      → os.CreateTemp() → {fsmSnapDir}/{storageIndex}.fsm.tmp
       → crcWriter := newCRC32CWriter(tmpFile)
-      → snapshot.WriteTo(crcWriter)                               # stream to disk + compute CRC
-      → binary.Write(tmpFile, LittleEndian, crcWriter.Sum32())   # append CRC footer
-      → tmpFile.Sync() → os.Rename(tmp, final)                   # atomic commit
+      → fsmSnap.WriteTo(crcWriter)                              # stream to disk + compute CRC
+      → binary.Write(tmpFile, LittleEndian, crcWriter.Sum32()) # append CRC footer
+      → tmpFile.Sync()
+      → os.Rename(tmp, final)                                   # atomic commit
+      → syncDir(fsmSnapDir)                                     # persist directory entry
       → return crcWriter.Sum32()
-  → token := encodeSnapshotToken(index, crc32c)  # 17 bytes
-  → persist.SaveSnap(snap{Data: token})          # small snap file
-  → storage.CreateSnapshot(_, _, token)          # MemoryStorage: 17 bytes only
-  → purgeOldFSMSnapFiles(fsmSnapDir)
+  → token := encodeSnapshotToken(storageIndex, crc32c)  # 17 bytes
+  → persist.SaveSnap(snap{Data: token})                 # small snap file
+  → storage.CreateSnapshot(_, _, token)                 # MemoryStorage: 17 bytes only
+  → purgeOldSnapshotFiles(snapDir, fsmSnapDir)          # coordinated purge (see Retention)
 ```
 
 **Memory impact:**
@@ -177,6 +208,11 @@ maybePersistLocalSnapshot()
 - Resident: FSM data size → 17 bytes
 
 ### 2. Restore on Restart
+
+Restore uses a **single-pass** helper `openAndRestoreFSMSnapshot` that opens the file
+once, verifies the CRC while streaming data to the FSM, and never reads the file a second
+time. This eliminates the double-read that would result from a separate verify pass
+followed by a restore pass.
 
 **Before:**
 ```
@@ -192,18 +228,66 @@ loadWalState()
   → snapshotter.LoadNewestAvailable()
   → restoreSnapshotState(fsm, snap, fsmSnapDir)
       → if isSnapshotToken(snap.Data):
-            index, expectedCRC := decodeSnapshotToken(snap.Data)
+            index, tokenCRC := decodeSnapshotToken(snap.Data)
             path := fsmSnapPath(fsmSnapDir, index)
-            verifyFSMSnapshotFile(path, expectedCRC)          # fail fast on corruption
-            f := os.Open(path)
-            fsm.Restore(newCRC32CStripFooterReader(f))        # exclude footer from stream
+            openAndRestoreFSMSnapshot(fsm, path, tokenCRC)
+              # single pass: open fd → stream payload through CRC accumulator
+              #              → call fsm.Restore → compare computed vs footer vs tokenCRC
+              # returns ErrFSMSnapshotFileCRC or ErrFSMSnapshotTokenCRC on mismatch
          else:
-            fsm.Restore(bytes.NewReader(snap.Data))           # legacy format fallback
+            fsm.Restore(bytes.NewReader(snap.Data))  # legacy format fallback
 ```
 
-`verifyFSMSnapshotFile` reads the file sequentially, computes the CRC incrementally, and
-compares it against both the on-disk footer and the `expectedCRC` from the token. A
-mismatch returns `ErrFSMSnapshotCRCMismatch` and aborts startup.
+`openAndRestoreFSMSnapshot` keeps a single open file descriptor for the full operation:
+
+```go
+func openAndRestoreFSMSnapshot(fsm StateMachine, path string, tokenCRC uint32) error {
+    info, err := os.Stat(path)
+    if err != nil {
+        return errors.WithStack(err)
+    }
+    if info.Size() < 4 {
+        return errors.Wrapf(ErrFSMSnapshotFileCRC, "file too small: %d bytes", info.Size())
+    }
+    f, err := os.Open(path)
+    if err != nil {
+        return errors.WithStack(err)
+    }
+    defer f.Close()
+
+    payloadSize := info.Size() - 4
+    h := crc32.New(crc32cTable)
+    // Tee: data flows to both the CRC accumulator and fsm.Restore simultaneously.
+    tee := io.TeeReader(io.LimitReader(f, payloadSize), h)
+    if err := fsm.Restore(bufio.NewReaderSize(tee, 1<<20)); err != nil {
+        return errors.WithStack(err)
+    }
+    var footer uint32
+    if err := binary.Read(f, binary.LittleEndian, &footer); err != nil {
+        return errors.WithStack(err)
+    }
+    computed := h.Sum32()
+    if computed != footer {
+        return errors.Wrapf(ErrFSMSnapshotFileCRC,
+            "path=%s footer=%08x computed=%08x", path, footer, computed)
+    }
+    if computed != tokenCRC {
+        return errors.Wrapf(ErrFSMSnapshotTokenCRC,
+            "path=%s token=%08x computed=%08x", path, tokenCRC, computed)
+    }
+    return nil
+}
+```
+
+Key properties:
+- **Single read pass**: `io.TeeReader` feeds data to both `fsm.Restore` and the CRC hash
+  simultaneously; no second scan.
+- **`bufio.NewReaderSize(tee, 1<<20)`**: the 1 MiB read-ahead buffer amortizes the
+  per-entry small reads that `writePebbleSnapshotEntries` / the restore loop issues,
+  matching the throughput of the former `bytes.Reader` path.
+- **Single open fd**: the file descriptor is held across the full verify+restore
+  operation, eliminating the TOCTOU window between a separate verify and a subsequent
+  restore open.
 
 ### 3. Sending MsgSnap to a Follower
 
@@ -228,10 +312,22 @@ sendMessages()
             sendSnapshot(msg)   # legacy format fallback
 ```
 
-The `.fsm` file is sent including its CRC footer. The receiver stores the full file and
-performs CRC verification after all chunks arrive.
+The `.fsm` file is sent **including its CRC footer** as the final 4 bytes. The receiver
+stores the full file and verifies the CRC before committing.
 
 ### 4. Receiving and Applying MsgSnap on a Follower
+
+Two concurrency concerns are addressed here:
+
+1. **Concurrent receive for the same index**: a leader retry or simultaneous MsgSnap
+   delivery could cause two goroutines to write `{index}.fsm` at the same time. A
+   `singleflight.Group` keyed on the snapshot index serializes receive operations for the
+   same index; only the first completes, the second reuses its result.
+
+2. **TOCTOU between verify and apply**: verify and restore use the same open file
+   descriptor via `openAndRestoreFSMSnapshot` (see §2), eliminating the window where the
+   file could be replaced between a standalone verify call and a subsequent open for
+   restore.
 
 **Before:**
 ```
@@ -246,24 +342,31 @@ receiveSnapshotStream()
 **After:**
 ```
 receiveSnapshotStream()
-  → receive header chunk → parse token → extract index, expectedCRC
-  → os.CreateTemp() → {fsmSnapDir}/{index}.fsm.tmp
-  → stream remaining chunks to tmpFile
-  → tmpFile.Sync()
-  → verifyFSMSnapshotFile(tmpPath, expectedCRC)              # verify before committing
-  → os.Rename(tmpPath, {fsmSnapDir}/{index}.fsm)             # atomic commit on success
+  → receive header chunk → parse token → extract index, tokenCRC
+  → result, err := snapReceiveGroup.Do(strconv.FormatUint(index, 10), func() {
+        → os.CreateTemp() → {fsmSnapDir}/{index}.fsm.tmp
+        → stream remaining chunks to tmpFile (with bufio.NewWriterSize)
+        → tmpFile.Sync()
+        → verify CRC of tmpPath against footer and tokenCRC
+          # footer is authoritative; return ErrFSMSnapshotFileCRC if mismatch
+        → os.Rename(tmpPath, {fsmSnapDir}/{index}.fsm)  # atomic commit on success
+        → syncDir(fsmSnapDir)                           # flush directory entry
+        → return token
+    })
   → raftpb.Message{Snapshot: {Data: token}}
   → handler(msg)
       → applyReadySnapshot(snap)
-          → index, expectedCRC := decodeSnapshotToken(snap.Data)
-          → verifyFSMSnapshotFile(path, expectedCRC)         # second check before apply
-          → fsm.Restore(newCRC32CStripFooterReader(f))
+          → index, tokenCRC := decodeSnapshotToken(snap.Data)
+          → openAndRestoreFSMSnapshot(fsm, path, tokenCRC)
+            # single-pass verify+restore; no second verifyFSMSnapshotFile call needed
+            # the file was already committed atomically by receiveSnapshotStream
 ```
 
-**Why verify immediately after receive:**
-- Detects in-transit bit errors before the file is applied to the FSM
-- Prevents a corrupt file from overwriting a healthy FSM state
-- On failure, report `SnapshotFailure` to prompt the leader to retry
+**Why the second `verifyFSMSnapshotFile` call is removed from `applyReadySnapshot`:**
+After `receiveSnapshotStream` has verified, atomically renamed, and `syncDir`'d the file,
+no other process modifies `.fsm` files between that point and `applyReadySnapshot`. The
+`openAndRestoreFSMSnapshot` call already recomputes the CRC as a by-product of streaming
+data to `fsm.Restore`, so integrity is confirmed without an extra full-file scan.
 
 ---
 
@@ -297,74 +400,51 @@ func (c *crc32CWriter) Sum32() uint32 { return c.h.Sum32() }
 Passing `crc32CWriter` to `snapshot.WriteTo` computes the CRC without any changes to the
 existing `WriteTo` implementation.
 
-### Reading: Streaming Verification
+### Reading: Single-Pass Verify and Restore
 
-`verifyFSMSnapshotFile` uses `stat` to determine the file size, then reads
-`(size - 4)` bytes through a CRC accumulator, and compares the result against the
-4-byte footer and the `expectedCRC` from the token. No second read pass is required.
+Rather than a standalone `verifyFSMSnapshotFile` followed by a separate `fsm.Restore`,
+all read paths use `openAndRestoreFSMSnapshot` (see §2: Restore on Restart). This
+function:
 
-```go
-func verifyFSMSnapshotFile(path string, expectedCRC uint32) error {
-    info, err := os.Stat(path)
-    if err != nil {
-        return errors.WithStack(err)
-    }
-    if info.Size() < 4 {
-        return errors.Wrapf(ErrFSMSnapshotCRCMismatch, "file too small: %d bytes", info.Size())
-    }
-    f, err := os.Open(path)
-    if err != nil {
-        return errors.WithStack(err)
-    }
-    defer f.Close()
+1. Opens the file once and holds the fd for the entire operation.
+2. Uses `io.TeeReader` to feed data simultaneously to the CRC accumulator and
+   `fsm.Restore`.
+3. Reads the 4-byte footer after `fsm.Restore` returns and checks `computed == footer`
+   and `computed == tokenCRC`.
+4. Returns typed errors distinguishing file corruption (`ErrFSMSnapshotFileCRC`) from
+   token corruption (`ErrFSMSnapshotTokenCRC`).
 
-    h := crc32.New(crc32cTable)
-    if _, err := io.Copy(h, io.LimitReader(f, info.Size()-4)); err != nil {
-        return errors.WithStack(err)
-    }
-    var footer uint32
-    if err := binary.Read(f, binary.LittleEndian, &footer); err != nil {
-        return errors.WithStack(err)
-    }
-    computed := h.Sum32()
-    if computed != footer {
-        return errors.Wrapf(ErrFSMSnapshotCRCMismatch,
-            "path=%s footer=%08x computed=%08x", path, footer, computed)
-    }
-    if computed != expectedCRC {
-        return errors.Wrapf(ErrFSMSnapshotCRCMismatch,
-            "path=%s token=%08x computed=%08x", path, expectedCRC, computed)
-    }
-    return nil
-}
-```
-
-`newCRC32CStripFooterReader` wraps the open file and exposes only the first
-`(size - 4)` bytes to the FSM's `Restore` call so the footer is not interpreted as
-key-value data.
+A standalone `verifyFSMSnapshotFile(path, tokenCRC)` is still provided for contexts where
+the FSM must not be modified (e.g., startup cleanup health-checking orphan files), but it
+is **never called in sequence with a subsequent restore**.
 
 ### Verification Points
 
-| When | Location | What is checked |
-|------|----------|-----------------|
-| **On restart** | `restoreSnapshotState` | file CRC ↔ footer ↔ token CRC |
-| **After follower receive** | `receiveSnapshotStream` | file CRC ↔ footer ↔ token CRC |
-| **Before follower apply** | `applyReadySnapshot` | token CRC ↔ file CRC (second check) |
-| **Background health check** *(future)* | background task | periodic re-computation of file CRC |
+| When | Location | Mechanism |
+|------|----------|-----------|
+| **On restart** | `restoreSnapshotState` | `openAndRestoreFSMSnapshot` (single pass) |
+| **After follower receive** | `receiveSnapshotStream` | `verifyFSMSnapshotFile` on tmp before rename |
+| **On follower apply** | `applyReadySnapshot` | `openAndRestoreFSMSnapshot` (single pass; no extra verify) |
+| **Startup orphan check** | `cleanupStaleFSMSnaps` | `verifyFSMSnapshotFile` (read-only, no restore) |
+| **Background health check** *(future)* | background task | `verifyFSMSnapshotFile` |
 
-### Error Handling
+### Error Types and Recovery
 
 ```go
 var (
-    ErrFSMSnapshotCRCMismatch  = errors.New("fsm snapshot: CRC32C mismatch")
-    ErrFSMSnapshotNotFound     = errors.New("fsm snapshot: file not found")
+    ErrFSMSnapshotFileCRC   = errors.New("fsm snapshot: file CRC32C mismatch (file corrupt)")
+    ErrFSMSnapshotTokenCRC  = errors.New("fsm snapshot: token CRC32C mismatch (metadata corrupt)")
+    ErrFSMSnapshotNotFound  = errors.New("fsm snapshot: file not found")
+    ErrFSMSnapshotTooSmall  = errors.New("fsm snapshot: file too small to contain footer")
     ErrFSMSnapshotTokenInvalid = errors.New("fsm snapshot: token format invalid")
 )
 ```
 
-- `ErrFSMSnapshotCRCMismatch`: log `{path, expected, actual}` and abort the operation.
-  - On startup: attempt WAL replay from `FirstIndex` before giving up.
-  - On follower receive: report `SnapshotFailure`; the leader will retry.
+| Error | Meaning | Recovery |
+|-------|---------|---------|
+| `ErrFSMSnapshotFileCRC` | On-disk file is corrupt; footer ≠ computed | Delete file; WAL replay from `FirstIndex` |
+| `ErrFSMSnapshotTokenCRC` | File is intact (footer == computed) but token differs | Rewrite token from file's actual CRC; no WAL replay needed |
+| `ErrFSMSnapshotNotFound` | `.fsm` file missing for a valid token | WAL replay from `FirstIndex` |
 
 ---
 
@@ -374,16 +454,16 @@ var (
 
 | File | Contents |
 |------|----------|
-| `internal/raftengine/etcd/fsm_snapshot_file.go` | FSM snapshot file read/write, CRC32C computation and verification, token encode/decode |
+| `internal/raftengine/etcd/fsm_snapshot_file.go` | `crc32CWriter`, `openAndRestoreFSMSnapshot`, `verifyFSMSnapshotFile`, `writeFSMSnapshotFile`, token encode/decode, error types |
 
 ### Changes to Existing Files
 
 | File | Change |
 |------|--------|
-| `internal/raftengine/etcd/wal_store.go` | Remove `snapshotBytes`; add `writeFSMSnapshotFile`; update `restoreSnapshotState` to handle token format |
-| `internal/raftengine/etcd/engine.go` | Replace payload retrieval in `persistLocalSnapshot` with `writeFSMSnapshotFile`; add `fsmSnapDir` field |
-| `internal/raftengine/etcd/grpc_transport.go` | Detect token in `Dispatch` → route to file-streaming send path; update `receiveSnapshotStream` to write chunks to file |
-| `internal/raftengine/etcd/snapshot_spool.go` | Repurpose or remove `snapshotSpool` |
+| `internal/raftengine/etcd/wal_store.go` | Remove `snapshotBytes`; add `writeFSMSnapshotFile`; update `restoreSnapshotState` and `stateMachineSnapshotBytes` (bootstrap) |
+| `internal/raftengine/etcd/engine.go` | Update `persistLocalSnapshot`, `persistConfigSnapshot`, and `persistConfigSnapshotPayload` to use `writeFSMSnapshotFile` + token; add `fsmSnapDir` and `snapReceiveGroup` fields |
+| `internal/raftengine/etcd/grpc_transport.go` | Detect token in `Dispatch` → file-streaming send; update `receiveSnapshotStream` to write chunks to file with `singleflight` serialization and `syncDir` |
+| `internal/raftengine/etcd/snapshot_spool.go` | Remove `snapshotSpool` (Phase 3) |
 
 ### Code Removed
 
@@ -407,35 +487,61 @@ writeFSMSnapshotFile():
   6. syncDir(fsmSnapDir)                             # persist directory entry
 ```
 
-`persist.SaveSnap(snap{Data: token})` is called only after the rename succeeds.
-Because the `.fsm` file is committed before the token is written to the WAL or snap
-file, the following crash scenarios are all safely recoverable:
+`persist.SaveSnap(snap{Data: token})` is called **only after step 6 succeeds**.
+The receiver path (`receiveSnapshotStream`) follows the same sequence and also calls
+`syncDir(fsmSnapDir)` after rename.
 
 | State at crash | Recovery |
 |----------------|----------|
-| Only `.fsm.tmp` exists | Deleted by startup cleanup (treated as orphan) |
+| Only `.fsm.tmp` exists | Deleted by startup cleanup (orphan) |
 | `.fsm` exists, snap not yet saved | Snap points to previous index; next snapshot overwrites |
-| snap(token) exists, `.fsm` missing | Token dereferences a missing file → error → WAL replay fallback |
-| `.fsm` CRC mismatch | Treated as corrupt orphan; deleted at startup; WAL replay fallback |
+| snap(token) exists, `.fsm` missing | `ErrFSMSnapshotNotFound` → WAL replay from `FirstIndex` |
+| `.fsm` footer CRC mismatch | `ErrFSMSnapshotFileCRC` → delete file; WAL replay |
+| `.fsm` footer ok, token CRC differs | `ErrFSMSnapshotTokenCRC` → rewrite token; restore from file |
 
 ### Startup Cleanup
 
-Similar to `cleanupStaleSnapshotSpools`, a new `cleanupStaleFSMSnaps(fsmSnapDir)` removes
-any `*.fsm.tmp` files left by a previously crashed process. `.fsm` files whose CRC does
-not match any live token are also removed, since WAL replay can reconstruct the FSM
-without them.
+`cleanupStaleFSMSnaps(snapDir, fsmSnapDir)` runs at engine open time and:
+
+1. Removes all `*.fsm.tmp` (orphans from a previous crash).
+2. Enumerates all live snap tokens by reading `*.snap` files in `snapDir`.
+3. Removes any `.fsm` file whose index does not correspond to a live token — this handles
+   the case where a `.fsm` was written but the corresponding `.snap` was never saved
+   (upgrade crash), as well as files left over after purge ordering bugs in older versions.
+4. For each remaining `.fsm` file, calls `verifyFSMSnapshotFile` and removes files where
+   `ErrFSMSnapshotFileCRC` is returned (corrupt files cannot be used for restore).
+
+This index-based orphan detection is stricter than a CRC-only check: a file with a valid
+CRC but no matching token is still an orphan and must be removed.
 
 ---
 
 ## File Retention Policy
 
+### Coordinated Purge
+
+Snap files and FSM files **must always be purged together** in a single function.
+Calling them independently risks deleting a `.fsm` file while its token `.snap` still
+exists, which makes the node unrecoverable if the WAL has already been compacted.
+
+```go
+// purgeOldSnapshotFiles removes old snap and fsm files in tandem, always deleting
+// the snap file BEFORE its corresponding fsm file. This ordering guarantees that
+// no live token can ever reference a deleted fsm file.
+func purgeOldSnapshotFiles(snapDir, fsmSnapDir string) error {
+    // 1. List all snap files sorted oldest-first.
+    // 2. Keep the newest defaultMaxSnapFiles (3); mark the rest for deletion.
+    // 3. For each file to delete:
+    //    a. os.Remove(snapFile)      ← snap first
+    //    b. os.Remove(fsmFile)       ← fsm second
+    //    A crash between a and b leaves a .fsm with no token: treated as orphan on
+    //    next startup and removed by cleanupStaleFSMSnaps.
+    // 4. syncDir(snapDir) and syncDir(fsmSnapDir).
+}
 ```
-purgeOldFSMSnapFiles(fsmSnapDir):
-  - Retain the same count as snap files: defaultMaxSnapFiles = 3
-  - Match .fsm files to snap files by index; delete in tandem
-  - Always delete the snap file before its corresponding .fsm file
-    (reverse order risks leaving a token that points to a deleted file)
-```
+
+`purgeOldSnapshotFiles` is the **only** call site for deleting either type of file.
+The existing `purgeOldSnapFiles` function is removed and replaced entirely.
 
 ---
 
@@ -460,6 +566,11 @@ func isSnapshotToken(data []byte) bool {
 - The next snapshot creation writes a new-format `.fsm` file with CRC
 - No manual migration step is required
 
+**Orphan `.fsm` files during upgrade rollback:**
+If a node begins writing `.fsm` files and then rolls back to the previous binary, the
+`.fsm` files have no corresponding token in the legacy `.snap` files.
+`cleanupStaleFSMSnaps` removes them by walking live tokens, so rollback is safe.
+
 **When a follower receives a legacy-format MsgSnap:**
 - `isSnapshotToken` returns false → restore via `bytes.NewReader` (no CRC check)
 - Compatible with rolling upgrades where not all nodes have been updated yet
@@ -473,6 +584,9 @@ func isSnapshotToken(data []byte) bool {
 - **Peak memory**: spikes caused by snapshot creation drop to near zero
 - **Resident memory**: `MemoryStorage` snapshot footprint reduced to 17 bytes
 - **I/O**: eliminates the spool → Bytes → SaveSnap double-write; total disk I/O decreases
+- **Single-pass restore**: `io.TeeReader` combines CRC verification and FSM restore into
+  one sequential scan, eliminating the double-read present in a naive verify-then-restore
+  design
 - **gRPC send**: existing `sendSnapshotReaderChunks` accepts `io.Reader` as-is
 - **No upstream dependency**: no changes to etcd-raft protobuf or library code
 
@@ -480,9 +594,12 @@ func isSnapshotToken(data []byte) bool {
 
 | Risk | Mitigation |
 |------|-----------|
-| `.fsm` and snap file inconsistency | `persist.SaveSnap` is called only after successful rename; ordering is strict |
-| Disk space increase | `.fsm` files are roughly the same size as the former `.snap` payloads; net usage is unchanged |
-| Increased code complexity | `isSnapshotToken` branch is small; legacy path is preserved intact |
+| `.fsm` and snap file inconsistency | `persist.SaveSnap` only after `syncDir`; single `purgeOldSnapshotFiles` function enforces deletion ordering |
+| Stale local snapshot overwriting newer follower state | `storageIndex` captured before `fsm.Snapshot()`; `persistLocalSnapshotPayload` staleness guard uses the same baseline |
+| Concurrent follower receive for same index | `singleflight.Group` keyed on index in `receiveSnapshotStream` |
+| TOCTOU between verify and restore | `openAndRestoreFSMSnapshot` holds a single fd across the entire verify+restore operation |
+| `Metadata.Index` diverging from `.fsm` content in config snapshots | `persistConfigSnapshot` migrated in Phase 1; FSM snapshot taken with the same index used as the file name and token |
+| Disk space increase | `.fsm` files are the same size as the former `.snap` payloads; net usage unchanged |
 | CRC false negatives | CRC32C has a 1-in-2³² collision rate; adequate for accidental corruption detection |
 
 ---
@@ -491,35 +608,96 @@ func isSnapshotToken(data []byte) bool {
 
 ### Phase 1: Local Snapshot Disk Offload
 
-Scope: local creation and local restore only. Follower send/receive is unchanged.
+Scope: local creation and local restore for **all three snapshot paths** (periodic,
+config-change, and bootstrap). Follower send/receive is unchanged.
+
+**Implementation tasks:**
 
 - Create `fsm_snapshot_file.go`:
-  - `crc32CWriter` (streaming CRC computation)
-  - `writeFSMSnapshotFile` (write with CRC footer)
-  - `verifyFSMSnapshotFile` (CRC verification)
-  - `newCRC32CStripFooterReader` (expose payload without footer)
-  - `encodeSnapshotToken` / `decodeSnapshotToken` (17-byte token including CRC)
-- Update `persistLocalSnapshot` to use `writeFSMSnapshotFile` + token
-- Update `restoreSnapshotState` to handle token format with CRC verification
+  - `crc32CWriter` (streaming CRC writer)
+  - `writeFSMSnapshotFile` (write with CRC footer + syncDir)
+  - `openAndRestoreFSMSnapshot` (single-pass verify+restore via TeeReader)
+  - `verifyFSMSnapshotFile` (read-only CRC check for orphan detection)
+  - `encodeSnapshotToken` / `decodeSnapshotToken` (17-byte token with CRC)
+  - Error types: `ErrFSMSnapshotFileCRC`, `ErrFSMSnapshotTokenCRC`, etc.
+- Update `persistLocalSnapshot` → `writeFSMSnapshotFile` + token
+- Update `persistConfigSnapshot` / `persistConfigSnapshotPayload` → same
+- Update `stateMachineSnapshotBytes` (bootstrap) → `writeFSMSnapshotFile` + token
+- Update `restoreSnapshotState` → `openAndRestoreFSMSnapshot`
+- Replace `purgeOldSnapFiles` with `purgeOldSnapshotFiles(snapDir, fsmSnapDir)`
+- Add `cleanupStaleFSMSnaps(snapDir, fsmSnapDir)` (index-based orphan removal)
+- Capture `storageIndex` before `fsm.Snapshot()` in `maybePersistLocalSnapshot`
 - All existing tests must continue to pass
 
-**Effect**: eliminates memory spikes during local snapshot creation; reduces `MemoryStorage` resident memory
+**Effect**: eliminates memory spikes during local snapshot creation; reduces
+`MemoryStorage` resident memory; all snapshot creation paths are consistent.
 
 ### Phase 2: Streaming Follower Send/Receive
 
 Scope: update `GRPCTransport` MsgSnap paths to use file streaming.
 
-- `Dispatch`: detect token → open file → `sendSnapshotFileChunks`
-- `receiveSnapshotStream`: write chunks to temp file → verify CRC → atomic rename
+**Implementation tasks:**
+
+- `Dispatch`: detect token → open `.fsm` file → `sendSnapshotFileChunks`
+- `receiveSnapshotStream`:
+  - Write chunks to temp file (with `bufio.NewWriterSize`)
+  - `verifyFSMSnapshotFile` on tmp before rename
+  - `syncDir(fsmSnapDir)` after rename
+  - `singleflight.Group` keyed on index to serialize concurrent receives
+- `applyReadySnapshot`: use `openAndRestoreFSMSnapshot` (no extra verify call)
 - Test legacy-format compatibility paths
 
-**Effect**: eliminates memory spikes during large snapshot transfers to followers
+**Effect**: eliminates memory spikes during large snapshot transfers to followers;
+removes three-read-pass anti-pattern on the receive side.
 
 ### Phase 3: Cleanup
 
 - Remove `snapshotBytesAndClose`, `snapshotBytes`, and `snapshotSpool`
+- Remove standalone `purgeOldSnapFiles` (replaced by `purgeOldSnapshotFiles`)
 - Resolve `maxSnapshotPayloadBytes`
 - Update documentation
+
+---
+
+## Required Tests
+
+### P0 — Must have before Phase 1 merge
+
+| Test | What it verifies |
+|------|-----------------|
+| `TestTokenRoundTrip` | `encodeSnapshotToken` / `decodeSnapshotToken` round-trip for boundary values (`0`, `MaxUint64`, `MaxUint32`) |
+| `TestTokenMagicRejection` | `isSnapshotToken` returns false for non-`EKVR` prefixes; `decodeSnapshotToken` returns `ErrFSMSnapshotTokenInvalid` for lengths 0–16 and wrong magic |
+| `TestCRCWriterMatchesStdlib` | `crc32CWriter.Sum32()` matches `crc32.Checksum` for identical bytes; incremental writes accumulate correctly |
+| `TestOpenAndRestoreFSMSnapshotGoodFile` | Correct file restores FSM state without error |
+| `TestOpenAndRestoreFSMSnapshotBadFooter` | Footer byte flipped → `ErrFSMSnapshotFileCRC` |
+| `TestOpenAndRestoreFSMSnapshotTokenMismatch` | File footer ok, wrong `tokenCRC` → `ErrFSMSnapshotTokenCRC` |
+| `TestOpenAndRestoreFSMSnapshotTooSmall` | File shorter than 4 bytes → `ErrFSMSnapshotTooSmall` |
+| `TestStripFooterReaderBoundary` | `io.TeeReader` with `LimitReader(size-4)` exposes exactly the payload; footer bytes not passed to FSM |
+| `TestCrashAfterTmpBeforeRename` | A leftover `*.fsm.tmp` is deleted by `cleanupStaleFSMSnaps`; no `.fsm` is promoted |
+| `TestSnapSavedOnlyAfterRename` | `WriteTo` error → no `.snap` token written, no `.fsm` final file committed |
+| `TestPurgeOldSnapshotFilesOrdering` | `purgeOldSnapshotFiles` always removes `.snap` before `.fsm`; verified by intercepting `os.Remove` calls |
+| `TestCleanupStaleFSMSnapsIndexBased` | Orphan `.fsm` with no matching live token is removed even when its CRC is valid |
+
+### P1 — High value, ship in Phase 2 or immediately after
+
+| Test | What it verifies |
+|------|-----------------|
+| `TestReceiveTruncatedFile` | Stream ending mid-file → `ErrFSMSnapshotFileCRC`; no `.fsm` committed |
+| `TestReceiveWrongCRCInFooter` | Correct length, corrupted footer → verify rejects before rename |
+| `TestReceiveTokenCRCMismatchesFileCRC` | Token carries wrong CRC, file footer is self-consistent → `ErrFSMSnapshotTokenCRC` in `openAndRestoreFSMSnapshot` |
+| `TestConcurrentReceiveSameIndex` | Two goroutines receiving the same index via `singleflight`; only one `.fsm` committed; no torn file |
+| `TestLegacyFormatFallbackOnRestore` | `snap.Data` without `EKVR` prefix → `bytes.NewReader` path; no `.fsm` file opened |
+| `TestLegacyFormatFallbackOnSend` | Non-token `MsgSnap` → old `sendSnapshot` path; no file opened from `fsmSnapDir` |
+| `TestSyncDirCalledAfterRename` | Both `writeFSMSnapshotFile` and `receiveSnapshotStream` call `syncDir` after rename (verified via mock or filesystem hook) |
+| Conformance `SnapshotRestoreAfterRestart` | Propose 10,001 entries, close engine, reopen; assert FSM state recovered from `.fsm` snapshot (not WAL replay) |
+
+### P2 — Nice to have
+
+| Test | What it verifies |
+|------|-----------------|
+| `FuzzTokenEncodeDecode` | `decodeSnapshotToken` never panics on arbitrary 17-byte input; round-trips for valid tokens |
+| `FuzzOpenAndRestoreFSMSnapshot` | Arbitrary file content → only typed errors returned, never panics |
+| `TestConcurrentSnapshotAndEngineClose` | Snapshot worker crash on engine close leaves no torn file |
 
 ---
 

--- a/docs/etcd_snapshot_disk_offload_design.md
+++ b/docs/etcd_snapshot_disk_offload_design.md
@@ -109,8 +109,8 @@ After:  Data = [magic:4][version:1][index:8][crc32c:4]
 |---------|--------|-------|
 | magic   | 4 byte | `EKVT` (ElasticKV Token) |
 | version | 1 byte | `0x01` |
-| index   | 8 byte | applied log index of the snapshot (little-endian uint64) |
-| crc32c  | 4 byte | CRC32C checksum of the `.fsm` file payload (all bytes preceding the footer) (little-endian uint32) |
+| index   | 8 byte | applied log index of the snapshot (big-endian uint64) |
+| crc32c  | 4 byte | CRC32C checksum of the `.fsm` file payload (all bytes preceding the footer) (big-endian uint32) |
 
 The magic prefix distinguishes the new format from legacy payloads (see Migration section).
 Embedding the CRC32C in the token allows integrity verification at the metadata level,
@@ -136,7 +136,7 @@ before the file is even opened.
   ├── lastCommitTS: 8 bytes  (little-endian uint64)
   └── entries:      variable [keyLen:8][key][valLen:8][val] repeated
 [footer]
-  └── crc32c:       4 bytes  CRC32C of all bytes preceding this field (little-endian uint32)
+  └── crc32c:       4 bytes  CRC32C of all bytes preceding this field (big-endian uint32)
 ```
 
 The CRC32C is computed incrementally as data is written, so no second pass over the file
@@ -201,10 +201,10 @@ maybePersistLocalSnapshot()
   → storageIndex := storage.Snapshot().Metadata.Index
   → fsmSnap := fsm.Snapshot()
   → crc32c, err := writeFSMSnapshotFile(fsmSnap, fsmSnapDir, storageIndex)
-      → os.CreateTemp() → {fsmSnapDir}/{storageIndex}.fsm.tmp
+      → os.CreateTemp() → {fsmSnapDir}/{storageIndex:016x}.fsm.tmp
       → crcWriter := newCRC32CWriter(tmpFile)
       → fsmSnap.WriteTo(crcWriter)                              # stream to disk + compute CRC
-      → binary.Write(tmpFile, binary.LittleEndian, crcWriter.Sum32()) # append CRC footer
+      → binary.Write(tmpFile, binary.BigEndian, crcWriter.Sum32()) # append CRC footer
       → tmpFile.Sync()
       → os.Rename(tmp, final)                                   # atomic commit
       → syncDir(fsmSnapDir)                                     # persist directory entry
@@ -286,7 +286,7 @@ func openAndRestoreFSMSnapshot(fsm StateMachine, path string, tokenCRC uint32) e
         return errors.WithStack(err)
     }
     var footer uint32
-    if err := binary.Read(f, binary.LittleEndian, &footer); err != nil {
+    if err := binary.Read(f, binary.BigEndian, &footer); err != nil {
         return errors.WithStack(err)
     }
     computed := h.Sum32()
@@ -369,16 +369,17 @@ receiveSnapshotStream()
   → validate token.Index == snap.Metadata.Index
     # a mismatch indicates a misrouted or corrupted snapshot; return
     # ErrFSMSnapshotIndexMismatch immediately before writing any data
-  → result, err := snapReceiveGroup.Do(strconv.FormatUint(index, 10), func() {
-        → os.CreateTemp() → {fsmSnapDir}/{index}.fsm.tmp
+  → result, err := snapReceiveGroup.Do(fmt.Sprintf("%016x", index), func() {
+        → os.CreateTemp() → {fsmSnapDir}/{index:016x}.fsm.tmp
         → stream remaining chunks to tmpFile (with bufio.NewWriterSize)
         → tmpFile.Sync()
         → verify CRC of tmpPath against footer and tokenCRC
           # footer is authoritative; return ErrFSMSnapshotFileCRC if mismatch
-        → os.Rename(tmpPath, {fsmSnapDir}/{index}.fsm)  # atomic commit on success
-        → syncDir(fsmSnapDir)                           # flush directory entry
-        → return token
+        → os.Rename(tmpPath, {fsmSnapDir}/{index:016x}.fsm)  # atomic commit on success
+        → syncDir(fsmSnapDir)                                # flush directory entry
+        → return token  # []byte — the 17-byte token built from the received header
     })
+  → token := result.([]byte)  # extract from singleflight result
   → raftpb.Message{Snapshot: {Data: token}}
   → handler(msg)
       → applyReadySnapshot(snap)
@@ -440,9 +441,9 @@ function:
 4. Returns typed errors distinguishing file corruption (`ErrFSMSnapshotFileCRC`) from
    token corruption (`ErrFSMSnapshotTokenCRC`).
 
-A standalone `verifyFSMSnapshotFile(path, tokenCRC)` is still provided for contexts where
-the FSM must not be modified (e.g., startup cleanup health-checking orphan files), but it
-is **never called in sequence with a subsequent restore**.
+A standalone `verifyFSMSnapshotFile(path, tokenCRC)` is still provided for use in
+`receiveSnapshotStream` (verify the temp file before atomic rename) and future background
+health-check tasks, but it is **never called in sequence with a subsequent restore**.
 
 ### Verification Points
 
@@ -451,7 +452,7 @@ is **never called in sequence with a subsequent restore**.
 | **On restart** | `restoreSnapshotState` | `openAndRestoreFSMSnapshot` (single pass) |
 | **After follower receive** | `receiveSnapshotStream` | `verifyFSMSnapshotFile` on tmp before rename |
 | **On follower apply** | `applyReadySnapshot` | `openAndRestoreFSMSnapshot` (single pass; no extra verify) |
-| **Startup orphan check** | `cleanupStaleFSMSnaps` | `verifyFSMSnapshotFile` (read-only, no restore) |
+| **Startup orphan check** | `cleanupStaleFSMSnaps` | Index-based only; no CRC scan (deferred to restore time) |
 | **Background health check** *(future)* | background task | `verifyFSMSnapshotFile` |
 
 ### Error Types and Recovery
@@ -469,7 +470,7 @@ var (
 | Error | Meaning | Recovery |
 |-------|---------|---------|
 | `ErrFSMSnapshotFileCRC` | On-disk file is corrupt; footer ≠ computed | Delete file; WAL replay from `FirstIndex` |
-| `ErrFSMSnapshotTokenCRC` | File is intact (footer == computed) but token differs | Rewrite token from file's actual CRC; no WAL replay needed |
+| `ErrFSMSnapshotTokenCRC` | File is intact (footer == computed) but token differs | Read footer CRC from file; call `Snapshotter.SaveSnap` with `encodeSnapshotToken(index, fileCRC)`; restore from the intact file without WAL replay |
 | `ErrFSMSnapshotNotFound` | `.fsm` file missing for a valid token | WAL replay from `FirstIndex` |
 
 ---
@@ -507,7 +508,7 @@ var (
 writeFSMSnapshotFile():
   1. os.CreateTemp(fsmSnapDir, "*.fsm.tmp")         # write to temp file
   2. snapshot.WriteTo(crcWriter)                     # stream FSM + accumulate CRC
-  3. binary.Write(tmpFile, binary.LittleEndian, crcWriter.Sum32()) # append CRC footer
+  3. binary.Write(tmpFile, binary.BigEndian, crcWriter.Sum32()) # append CRC footer
   4. tmpFile.Sync()                                  # flush to durable storage
   5. os.Rename(tmp, final)                           # atomic commit
   6. syncDir(fsmSnapDir)                             # persist directory entry
@@ -523,7 +524,7 @@ The receiver path (`receiveSnapshotStream`) follows the same sequence and also c
 | `.fsm` exists, snap not yet saved | Snap points to previous index; next snapshot overwrites |
 | snap(token) exists, `.fsm` missing | `ErrFSMSnapshotNotFound` → WAL replay from `FirstIndex` |
 | `.fsm` footer CRC mismatch | `ErrFSMSnapshotFileCRC` → delete file; WAL replay |
-| `.fsm` footer ok, token CRC differs | `ErrFSMSnapshotTokenCRC` → rewrite token; restore from file |
+| `.fsm` footer ok, token CRC differs | `ErrFSMSnapshotTokenCRC` → `Snapshotter.SaveSnap` with corrected token; restore from file; no WAL replay |
 
 ### Startup Cleanup
 
@@ -642,7 +643,7 @@ dangerous scenario. To prevent it, the rollout must proceed as follows:
    // snapshot — not on every periodic creation — so peak memory is still improved.
    if isSnapshotToken(msg.Snapshot.Data) {
        tok, _ := decodeSnapshotToken(msg.Snapshot.Data)
-       path := filepath.Join(fsmSnapDir, strconv.FormatUint(tok.Index, 10)+".fsm")
+       path := filepath.Join(fsmSnapDir, fmt.Sprintf("%016x.fsm", tok.Index))
        payload, err := readFSMSnapshotPayload(path) // streams file, returns []byte
        if err != nil {
            return errors.WithStack(err)
@@ -685,6 +686,54 @@ transition window: `raftpb.Snapshot.Data` = token AND a copy of the full legacy 
 stored in an auxiliary file. The legacy binary would then decode the full payload
 normally. This dual-write mode is a forward compatibility bridge and can be removed after
 the fleet has been fully upgraded.
+
+### Zero-Downtime Cutover Runbook
+
+For a Raft cluster, the standard zero-downtime approach is a **rolling upgrade**: replace
+one node at a time, verify health, then proceed to the next. The feature flag provides
+the safety valve at each step. Below is the recommended procedure for a 3-node cluster
+(`nodeA`, `nodeB`, `nodeC`).
+
+**Phase 1 rollout (safe in mixed clusters):**
+
+```
+1. Deploy Phase 1 binary to nodeA; restart.
+   - nodeA starts writing .fsm files locally.
+   - nodeA's Dispatch fallback reads .fsm → bytes for any legacy-receiver MsgSnap.
+   - Verify: cluster healthy, no error logs for ErrFSMSnapshotFileCRC.
+
+2. Repeat for nodeB, then nodeC.
+   - All nodes now write .fsm files. Mixed Phase 1 / legacy is safe throughout.
+
+3. Run for at least one full snapshot cycle per node before proceeding to Phase 2.
+   Confirm: each node's fsm-snap/ directory contains a valid .fsm file.
+```
+
+**Phase 2 rollout (requires all nodes on Phase 1 first):**
+
+```
+4. Deploy Phase 2 binary to all nodes with DisableFSMSnapshotToken=true.
+   - Nodes use file streaming internally but Dispatch still reconstructs full payload
+     (feature flag active). This is a no-op from the wire perspective.
+   - Verify: cluster healthy.
+
+5. Enable token mode on nodeA: set DisableFSMSnapshotToken=false (hot reload or restart).
+   - nodeA now sends token-format MsgSnap; all receivers must be Phase 2 (they are).
+   - Monitor for one snapshot cycle. Verify follower applies succeed.
+
+6. Enable on nodeB, then nodeC.
+   - All nodes now use full token-mode streaming.
+
+7. Remove the DisableFSMSnapshotToken flag from config (it now defaults to false).
+```
+
+**Rollback at any step:**
+
+| Step | Rollback action |
+|------|----------------|
+| During Phase 1 rollout | Redeploy legacy binary; stop node first; delete `fsm-snap/`; restart (WAL replay) |
+| Phase 2 deployed, flag still enabled | Redeploy Phase 1 binary; no fsm-snap cleanup needed |
+| Phase 2 deployed, flag disabled on some nodes | Re-enable `DisableFSMSnapshotToken=true` on flag-disabled nodes first; then redeploy Phase 1 binaries |
 
 ---
 

--- a/docs/etcd_snapshot_disk_offload_design.md
+++ b/docs/etcd_snapshot_disk_offload_design.md
@@ -1,0 +1,531 @@
+# etcd Engine: FSM Snapshot Disk Offload Design
+
+## Background and Problem
+
+### Observed Symptoms
+
+Clusters using the etcd engine exhibit large memory spikes across all nodes at snapshot
+creation intervals (`defaultSnapshotEvery = 10,000` entries). The spike magnitude scales
+with FSM data size, and simultaneous spikes across multiple nodes compound the pressure.
+
+### Root Cause
+
+The current implementation stores the entire FSM state as a `[]byte` in
+`raftpb.Snapshot.Data`. Because the etcd-raft protobuf API requires this type, there are
+three distinct points of excessive memory consumption.
+
+#### Problem 1: Peak allocation during snapshot creation
+
+```
+internal/raftengine/etcd/wal_store.go: snapshotBytes()
+
+FSM.WriteTo(spool)   → write to a temporary file on disk
+spool.Bytes()        → io.ReadAll materializes the entire payload as []byte  ← spike
+persist.SaveSnap()   → write to disk again (redundant copy)
+```
+
+`snapshotSpool` already avoids a second in-memory buffer during serialization, but the
+final `spool.Bytes()` call still materializes the entire dataset at once.
+
+#### Problem 2: Sustained retention in MemoryStorage
+
+```go
+storage.CreateSnapshot(applied, &confState, payload)
+```
+
+`MemoryStorage` holds `raftpb.Snapshot.Data = payload` until the next snapshot is created
+(i.e., until another 10,000 entries are processed), keeping the full FSM export resident
+in memory the entire time.
+
+#### Problem 3: Re-allocation when sending to followers
+
+```go
+// grpc_transport.go: sendSnapshot()
+header, payload, err := splitSnapshotMessage(msg)
+// payload = msg.Snapshot.Data  ← []byte extracted from MemoryStorage
+```
+
+Sending `MsgSnap` to a follower extracts `Data` from `MemoryStorage` and expands it into
+memory again.
+
+### Official etcd Position
+
+In etcd-io/etcd#9000 ("Snapshot splitting"), core contributor @xiang90 explicitly
+recommended the following architecture:
+
+> The suggested way to handle the problem you described is to **always only include
+> metadata into the raft snapshot message, and use a side-channel to supply the actual
+> application snapshot**.
+
+This design follows that recommendation: `raftpb.Snapshot.Data` carries only a small
+reference token, and FSM data is managed entirely on disk.
+
+---
+
+## Design Goals
+
+| Goal | Detail |
+|------|--------|
+| **Eliminate peak memory** | Remove `spool.Bytes()`; never materialize FSM data as `[]byte` |
+| **Eliminate sustained memory** | `MemoryStorage` holds only a 17-byte token, not the full FSM |
+| **No upstream changes** | etcd-raft `raftpb` API is unchanged; no upstream PR needed |
+| **Reuse existing gRPC transport** | `sendSnapshotReaderChunks` already accepts `io.Reader` |
+| **Crash safety** | A node crash during write must never produce a corrupt or partially-applied snapshot |
+| **Corruption detection** | CRC32C on every `.fsm` file; verified at write, restore, and receive |
+
+### Non-Goals
+
+- Changes to etcd-io/raft upstream
+- Any impact on the hashicorp engine
+- Changes to the WAL format
+
+---
+
+## Proposed Architecture
+
+### File Layout
+
+```
+{dataDir}/
+├── wal/                           # unchanged
+│   └── *.wal
+├── snap/                          # unchanged (raft snap metadata)
+│   └── 0000000100000064.snap      # raftpb.Snapshot{Data: token, Metadata: ...}
+└── fsm-snap/                      # new directory
+    ├── 0000000000000064.fsm       # FSM payload (Pebble key-value stream + CRC32C footer)
+    └── 0000000000000064.fsm.tmp   # in-flight write; renamed to .fsm on atomic commit
+```
+
+### `raftpb.Snapshot.Data` Token Format
+
+```
+Before: Data = full FSM payload (variable length, up to 1 GiB)
+
+After:  Data = [magic:4][version:1][index:8][crc32c:4]
+               17 bytes, fixed size
+```
+
+| Field   | Size   | Value |
+|---------|--------|-------|
+| magic   | 4 byte | `EKVR` (ElasticKV Reference) |
+| version | 1 byte | `0x01` |
+| index   | 8 byte | applied log index of the snapshot (little-endian uint64) |
+| crc32c  | 4 byte | CRC32C checksum of the entire `.fsm` file (little-endian uint32) |
+
+The magic prefix distinguishes the new format from legacy payloads (see Migration section).
+Embedding the CRC32C in the token allows integrity verification at the metadata level,
+before the file is even opened.
+
+### `.fsm` File Format
+
+```
+[Pebble snapshot stream (existing format)]
+  ├── magic:        8 bytes  {'E','K','V','P','B','B','L','1'}
+  ├── lastCommitTS: 8 bytes  (little-endian uint64)
+  └── entries:      variable [keyLen:8][key][valLen:8][val] repeated
+[footer]
+  └── crc32c:       4 bytes  CRC32C of all bytes preceding this field (little-endian uint32)
+```
+
+The CRC32C is computed incrementally as data is written, so no second pass over the file
+is needed to finalize the checksum.
+
+**Algorithm choice: CRC32C (Castagnoli)**
+
+This is the same algorithm used by etcd's `Snapshotter`
+(`etcdserver/api/snap/snapshotter.go`). It is hardware-accelerated on both x86
+(SSE4.2 `CRC32` instruction) and ARM64 (ARMv8.1 `CRC32C`), delivering throughput in the
+range of several GB/s with negligible CPU overhead. The Go standard library exposes it as
+`hash/crc32.MakeTable(crc32.Castagnoli)`.
+
+---
+
+## Flow Changes
+
+### 1. Local Snapshot Creation
+
+**Before:**
+```
+maybePersistLocalSnapshot()
+  → fsm.Snapshot()
+  → snapshotBytesAndClose()
+      → spool.WriteTo()        # write to temp file on disk
+      → spool.Bytes()          # ← problem: io.ReadAll materializes full []byte
+  → persist.SaveSnap(snap{Data: payload})  # write to disk again
+  → storage.CreateSnapshot(_, _, payload)  # hold in MemoryStorage
+```
+
+**After:**
+```
+maybePersistLocalSnapshot()
+  → fsm.Snapshot()
+  → writeFSMSnapshotFile(snapshot, fsmSnapDir, index)
+      → os.CreateTemp() → {fsmSnapDir}/{index}.fsm.tmp
+      → crcWriter := newCRC32CWriter(tmpFile)
+      → snapshot.WriteTo(crcWriter)                               # stream to disk + compute CRC
+      → binary.Write(tmpFile, LittleEndian, crcWriter.Sum32())   # append CRC footer
+      → tmpFile.Sync() → os.Rename(tmp, final)                   # atomic commit
+      → return crcWriter.Sum32()
+  → token := encodeSnapshotToken(index, crc32c)  # 17 bytes
+  → persist.SaveSnap(snap{Data: token})          # small snap file
+  → storage.CreateSnapshot(_, _, token)          # MemoryStorage: 17 bytes only
+  → purgeOldFSMSnapFiles(fsmSnapDir)
+```
+
+**Memory impact:**
+- Peak: FSM data size → 0 (direct disk write only)
+- Resident: FSM data size → 17 bytes
+
+### 2. Restore on Restart
+
+**Before:**
+```
+loadWalState()
+  → snapshotter.LoadNewestAvailable()
+  → restoreSnapshotState(fsm, snap)
+      → fsm.Restore(bytes.NewReader(snap.Data))  # snap.Data is the full FSM payload
+```
+
+**After:**
+```
+loadWalState()
+  → snapshotter.LoadNewestAvailable()
+  → restoreSnapshotState(fsm, snap, fsmSnapDir)
+      → if isSnapshotToken(snap.Data):
+            index, expectedCRC := decodeSnapshotToken(snap.Data)
+            path := fsmSnapPath(fsmSnapDir, index)
+            verifyFSMSnapshotFile(path, expectedCRC)          # fail fast on corruption
+            f := os.Open(path)
+            fsm.Restore(newCRC32CStripFooterReader(f))        # exclude footer from stream
+         else:
+            fsm.Restore(bytes.NewReader(snap.Data))           # legacy format fallback
+```
+
+`verifyFSMSnapshotFile` reads the file sequentially, computes the CRC incrementally, and
+compares it against both the on-disk footer and the `expectedCRC` from the token. A
+mismatch returns `ErrFSMSnapshotCRCMismatch` and aborts startup.
+
+### 3. Sending MsgSnap to a Follower
+
+**Before:**
+```
+sendMessages()
+  → Dispatch(msg)
+      → sendSnapshot(msg)
+          → splitSnapshotMessage(msg)   # extracts large msg.Snapshot.Data
+          → sendSnapshotChunks(...)     # sends []byte in chunks
+```
+
+**After:**
+```
+sendMessages()
+  → Dispatch(msg)
+      → if isSnapshotToken(msg.Snapshot.Data):
+            index, _ := decodeSnapshotToken(msg.Snapshot.Data)
+            f := os.Open(fsmSnapPath(fsmSnapDir, index))
+            sendSnapshotFileChunks(stream, header, f)   # stream .fsm file including footer
+         else:
+            sendSnapshot(msg)   # legacy format fallback
+```
+
+The `.fsm` file is sent including its CRC footer. The receiver stores the full file and
+performs CRC verification after all chunks arrive.
+
+### 4. Receiving and Applying MsgSnap on a Follower
+
+**Before:**
+```
+receiveSnapshotStream()
+  → receive all chunks → assemble into []byte
+  → raftpb.Message{Snapshot: {Data: fullBytes}}
+  → handler(msg)
+      → applyReadySnapshot(snap)
+          → fsm.Restore(bytes.NewReader(snap.Data))
+```
+
+**After:**
+```
+receiveSnapshotStream()
+  → receive header chunk → parse token → extract index, expectedCRC
+  → os.CreateTemp() → {fsmSnapDir}/{index}.fsm.tmp
+  → stream remaining chunks to tmpFile
+  → tmpFile.Sync()
+  → verifyFSMSnapshotFile(tmpPath, expectedCRC)              # verify before committing
+  → os.Rename(tmpPath, {fsmSnapDir}/{index}.fsm)             # atomic commit on success
+  → raftpb.Message{Snapshot: {Data: token}}
+  → handler(msg)
+      → applyReadySnapshot(snap)
+          → index, expectedCRC := decodeSnapshotToken(snap.Data)
+          → verifyFSMSnapshotFile(path, expectedCRC)         # second check before apply
+          → fsm.Restore(newCRC32CStripFooterReader(f))
+```
+
+**Why verify immediately after receive:**
+- Detects in-transit bit errors before the file is applied to the FSM
+- Prevents a corrupt file from overwriting a healthy FSM state
+- On failure, report `SnapshotFailure` to prompt the leader to retry
+
+---
+
+## CRC32C Implementation Details
+
+### Writing: Incremental Computation
+
+```go
+var crc32cTable = crc32.MakeTable(crc32.Castagnoli)
+
+// crc32CWriter wraps an io.Writer and computes the CRC32C of all bytes written through
+// it. Call Sum32() after writing is complete to obtain the checksum.
+type crc32CWriter struct {
+    w io.Writer
+    h hash.Hash32
+}
+
+func newCRC32CWriter(w io.Writer) *crc32CWriter {
+    return &crc32CWriter{w: w, h: crc32.New(crc32cTable)}
+}
+
+func (c *crc32CWriter) Write(p []byte) (int, error) {
+    n, err := c.w.Write(p)
+    c.h.Write(p[:n])
+    return n, err
+}
+
+func (c *crc32CWriter) Sum32() uint32 { return c.h.Sum32() }
+```
+
+Passing `crc32CWriter` to `snapshot.WriteTo` computes the CRC without any changes to the
+existing `WriteTo` implementation.
+
+### Reading: Streaming Verification
+
+`verifyFSMSnapshotFile` uses `stat` to determine the file size, then reads
+`(size - 4)` bytes through a CRC accumulator, and compares the result against the
+4-byte footer and the `expectedCRC` from the token. No second read pass is required.
+
+```go
+func verifyFSMSnapshotFile(path string, expectedCRC uint32) error {
+    info, err := os.Stat(path)
+    if err != nil {
+        return errors.WithStack(err)
+    }
+    if info.Size() < 4 {
+        return errors.Wrapf(ErrFSMSnapshotCRCMismatch, "file too small: %d bytes", info.Size())
+    }
+    f, err := os.Open(path)
+    if err != nil {
+        return errors.WithStack(err)
+    }
+    defer f.Close()
+
+    h := crc32.New(crc32cTable)
+    if _, err := io.Copy(h, io.LimitReader(f, info.Size()-4)); err != nil {
+        return errors.WithStack(err)
+    }
+    var footer uint32
+    if err := binary.Read(f, binary.LittleEndian, &footer); err != nil {
+        return errors.WithStack(err)
+    }
+    computed := h.Sum32()
+    if computed != footer {
+        return errors.Wrapf(ErrFSMSnapshotCRCMismatch,
+            "path=%s footer=%08x computed=%08x", path, footer, computed)
+    }
+    if computed != expectedCRC {
+        return errors.Wrapf(ErrFSMSnapshotCRCMismatch,
+            "path=%s token=%08x computed=%08x", path, expectedCRC, computed)
+    }
+    return nil
+}
+```
+
+`newCRC32CStripFooterReader` wraps the open file and exposes only the first
+`(size - 4)` bytes to the FSM's `Restore` call so the footer is not interpreted as
+key-value data.
+
+### Verification Points
+
+| When | Location | What is checked |
+|------|----------|-----------------|
+| **On restart** | `restoreSnapshotState` | file CRC ↔ footer ↔ token CRC |
+| **After follower receive** | `receiveSnapshotStream` | file CRC ↔ footer ↔ token CRC |
+| **Before follower apply** | `applyReadySnapshot` | token CRC ↔ file CRC (second check) |
+| **Background health check** *(future)* | background task | periodic re-computation of file CRC |
+
+### Error Handling
+
+```go
+var (
+    ErrFSMSnapshotCRCMismatch  = errors.New("fsm snapshot: CRC32C mismatch")
+    ErrFSMSnapshotNotFound     = errors.New("fsm snapshot: file not found")
+    ErrFSMSnapshotTokenInvalid = errors.New("fsm snapshot: token format invalid")
+)
+```
+
+- `ErrFSMSnapshotCRCMismatch`: log `{path, expected, actual}` and abort the operation.
+  - On startup: attempt WAL replay from `FirstIndex` before giving up.
+  - On follower receive: report `SnapshotFailure`; the leader will retry.
+
+---
+
+## Key Implementation Changes
+
+### New File
+
+| File | Contents |
+|------|----------|
+| `internal/raftengine/etcd/fsm_snapshot_file.go` | FSM snapshot file read/write, CRC32C computation and verification, token encode/decode |
+
+### Changes to Existing Files
+
+| File | Change |
+|------|--------|
+| `internal/raftengine/etcd/wal_store.go` | Remove `snapshotBytes`; add `writeFSMSnapshotFile`; update `restoreSnapshotState` to handle token format |
+| `internal/raftengine/etcd/engine.go` | Replace payload retrieval in `persistLocalSnapshot` with `writeFSMSnapshotFile`; add `fsmSnapDir` field |
+| `internal/raftengine/etcd/grpc_transport.go` | Detect token in `Dispatch` → route to file-streaming send path; update `receiveSnapshotStream` to write chunks to file |
+| `internal/raftengine/etcd/snapshot_spool.go` | Repurpose or remove `snapshotSpool` |
+
+### Code Removed
+
+- `snapshotBytesAndClose()` — the `[]byte` materialization path is no longer needed
+- `snapshotBytes()` — same
+- `maxSnapshotPayloadBytes` — file size bounds are delegated to the OS / disk quota
+
+---
+
+## Crash Safety
+
+### Write-time Crash Protection
+
+```
+writeFSMSnapshotFile():
+  1. os.CreateTemp(fsmSnapDir, "*.fsm.tmp")         # write to temp file
+  2. snapshot.WriteTo(crcWriter)                     # stream FSM + accumulate CRC
+  3. binary.Write(tmpFile, LE, crcWriter.Sum32())    # append CRC footer
+  4. tmpFile.Sync()                                  # flush to durable storage
+  5. os.Rename(tmp, final)                           # atomic commit
+  6. syncDir(fsmSnapDir)                             # persist directory entry
+```
+
+`persist.SaveSnap(snap{Data: token})` is called only after the rename succeeds.
+Because the `.fsm` file is committed before the token is written to the WAL or snap
+file, the following crash scenarios are all safely recoverable:
+
+| State at crash | Recovery |
+|----------------|----------|
+| Only `.fsm.tmp` exists | Deleted by startup cleanup (treated as orphan) |
+| `.fsm` exists, snap not yet saved | Snap points to previous index; next snapshot overwrites |
+| snap(token) exists, `.fsm` missing | Token dereferences a missing file → error → WAL replay fallback |
+| `.fsm` CRC mismatch | Treated as corrupt orphan; deleted at startup; WAL replay fallback |
+
+### Startup Cleanup
+
+Similar to `cleanupStaleSnapshotSpools`, a new `cleanupStaleFSMSnaps(fsmSnapDir)` removes
+any `*.fsm.tmp` files left by a previously crashed process. `.fsm` files whose CRC does
+not match any live token are also removed, since WAL replay can reconstruct the FSM
+without them.
+
+---
+
+## File Retention Policy
+
+```
+purgeOldFSMSnapFiles(fsmSnapDir):
+  - Retain the same count as snap files: defaultMaxSnapFiles = 3
+  - Match .fsm files to snap files by index; delete in tandem
+  - Always delete the snap file before its corresponding .fsm file
+    (reverse order risks leaving a token that points to a deleted file)
+```
+
+---
+
+## Migration (Legacy Format Compatibility)
+
+If the first 4 bytes of `raftpb.Snapshot.Data` equal `EKVR`, the payload is treated as a
+token. Any other prefix is treated as a legacy FSM payload.
+
+```go
+const snapshotTokenMagic = [4]byte{'E', 'K', 'V', 'R'}
+
+func isSnapshotToken(data []byte) bool {
+    if len(data) < 4 {
+        return false
+    }
+    return [4]byte(data[:4]) == snapshotTokenMagic
+}
+```
+
+**When a legacy snap file is present on startup:**
+- `isSnapshotToken` returns false → restore via `bytes.NewReader(snap.Data)` (no CRC check)
+- The next snapshot creation writes a new-format `.fsm` file with CRC
+- No manual migration step is required
+
+**When a follower receives a legacy-format MsgSnap:**
+- `isSnapshotToken` returns false → restore via `bytes.NewReader` (no CRC check)
+- Compatible with rolling upgrades where not all nodes have been updated yet
+
+---
+
+## Trade-offs
+
+### Benefits
+
+- **Peak memory**: spikes caused by snapshot creation drop to near zero
+- **Resident memory**: `MemoryStorage` snapshot footprint reduced to 17 bytes
+- **I/O**: eliminates the spool → Bytes → SaveSnap double-write; total disk I/O decreases
+- **gRPC send**: existing `sendSnapshotReaderChunks` accepts `io.Reader` as-is
+- **No upstream dependency**: no changes to etcd-raft protobuf or library code
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| `.fsm` and snap file inconsistency | `persist.SaveSnap` is called only after successful rename; ordering is strict |
+| Disk space increase | `.fsm` files are roughly the same size as the former `.snap` payloads; net usage is unchanged |
+| Increased code complexity | `isSnapshotToken` branch is small; legacy path is preserved intact |
+| CRC false negatives | CRC32C has a 1-in-2³² collision rate; adequate for accidental corruption detection |
+
+---
+
+## Implementation Phases
+
+### Phase 1: Local Snapshot Disk Offload
+
+Scope: local creation and local restore only. Follower send/receive is unchanged.
+
+- Create `fsm_snapshot_file.go`:
+  - `crc32CWriter` (streaming CRC computation)
+  - `writeFSMSnapshotFile` (write with CRC footer)
+  - `verifyFSMSnapshotFile` (CRC verification)
+  - `newCRC32CStripFooterReader` (expose payload without footer)
+  - `encodeSnapshotToken` / `decodeSnapshotToken` (17-byte token including CRC)
+- Update `persistLocalSnapshot` to use `writeFSMSnapshotFile` + token
+- Update `restoreSnapshotState` to handle token format with CRC verification
+- All existing tests must continue to pass
+
+**Effect**: eliminates memory spikes during local snapshot creation; reduces `MemoryStorage` resident memory
+
+### Phase 2: Streaming Follower Send/Receive
+
+Scope: update `GRPCTransport` MsgSnap paths to use file streaming.
+
+- `Dispatch`: detect token → open file → `sendSnapshotFileChunks`
+- `receiveSnapshotStream`: write chunks to temp file → verify CRC → atomic rename
+- Test legacy-format compatibility paths
+
+**Effect**: eliminates memory spikes during large snapshot transfers to followers
+
+### Phase 3: Cleanup
+
+- Remove `snapshotBytesAndClose`, `snapshotBytes`, and `snapshotSpool`
+- Resolve `maxSnapshotPayloadBytes`
+- Update documentation
+
+---
+
+## References
+
+- [etcd-io/etcd#9000 - Snapshot splitting](https://github.com/etcd-io/etcd/issues/9000) — basis for the side-channel architecture recommendation
+- [etcd-io/raft#124 - Clean up and improve snapshot handling](https://github.com/etcd-io/raft/issues/124)
+- `internal/raftengine/etcd/snapshot_spool.go`: comment "the prototype cannot stream snapshots end-to-end yet"
+- `internal/raftengine/etcd/grpc_transport.go`: `sendSnapshotReaderChunks` — existing streaming send implementation

--- a/docs/etcd_snapshot_disk_offload_design.md
+++ b/docs/etcd_snapshot_disk_offload_design.md
@@ -110,7 +110,7 @@ After:  Data = [magic:4][version:1][index:8][crc32c:4]
 | magic   | 4 byte | `EKVT` (ElasticKV Token) |
 | version | 1 byte | `0x01` |
 | index   | 8 byte | applied log index of the snapshot (big-endian uint64) |
-| crc32c  | 4 byte | CRC32C checksum of the `.fsm` file payload (all bytes preceding the footer) (big-endian uint32) |
+| crc32c  | 4 byte | CRC32C checksum of the `.fsm` file payload (bytes preceding the footer) (big-endian uint32) |
 
 The magic prefix distinguishes the new format from legacy payloads (see Migration section).
 Embedding the CRC32C in the token allows integrity verification at the metadata level,
@@ -133,7 +133,7 @@ before the file is even opened.
 ```
 [Pebble snapshot stream (existing format)]
   ├── magic:        8 bytes  {'E','K','V','P','B','B','L','1'}
-  ├── lastCommitTS: 8 bytes  (little-endian uint64)
+  ├── lastCommitTS: 8 bytes  (big-endian uint64)
   └── entries:      variable [keyLen:8][key][valLen:8][val] repeated
 [footer]
   └── crc32c:       4 bytes  CRC32C of all bytes preceding this field (big-endian uint32)
@@ -201,7 +201,7 @@ maybePersistLocalSnapshot()
   → storageIndex := storage.Snapshot().Metadata.Index
   → fsmSnap := fsm.Snapshot()
   → crc32c, err := writeFSMSnapshotFile(fsmSnap, fsmSnapDir, storageIndex)
-      → os.CreateTemp() → {fsmSnapDir}/{storageIndex:016x}.fsm.tmp
+      → os.CreateTemp() → {fsmSnapDir}/{storageIndex}.fsm.tmp
       → crcWriter := newCRC32CWriter(tmpFile)
       → fsmSnap.WriteTo(crcWriter)                              # stream to disk + compute CRC
       → binary.Write(tmpFile, binary.BigEndian, crcWriter.Sum32()) # append CRC footer
@@ -278,10 +278,8 @@ func openAndRestoreFSMSnapshot(fsm StateMachine, path string, tokenCRC uint32) e
     if err := fsm.Restore(br); err != nil {
         return errors.WithStack(err)
     }
-    // Drain any bytes that fsm.Restore left unread (e.g. if it stopped on an
-    // internal end-of-stream marker before consuming the full payload).
-    // Without this, h would have accumulated fewer bytes than the file contains,
-    // producing a spurious CRC mismatch even for a valid file.
+    // Drain any bytes not consumed by fsm.Restore so the CRC accumulator h
+    // covers the full payload before we read the footer.
     if _, err := io.Copy(io.Discard, br); err != nil {
         return errors.WithStack(err)
     }
@@ -366,20 +364,20 @@ receiveSnapshotStream()
 ```
 receiveSnapshotStream()
   → receive header chunk → parse token → extract index, tokenCRC
-  → validate token.Index == snap.Metadata.Index
-    # a mismatch indicates a misrouted or corrupted snapshot; return
-    # ErrFSMSnapshotIndexMismatch immediately before writing any data
-  → result, err := snapReceiveGroup.Do(fmt.Sprintf("%016x", index), func() {
-        → os.CreateTemp() → {fsmSnapDir}/{index:016x}.fsm.tmp
+  # Validate that the token index matches raftpb.SnapshotMetadata.Index to
+  # reject corrupted or misrouted messages before any disk I/O.
+  → if index != msg.Snapshot.Metadata.Index: reject with error
+  → result, token, err := snapReceiveGroup.Do(fmt.Sprintf("%016x", index), func() (any, error) {
+        → os.CreateTemp() → {fsmSnapDir}/{fmt.Sprintf("%016x", index)}.fsm.tmp
         → stream remaining chunks to tmpFile (with bufio.NewWriterSize)
         → tmpFile.Sync()
         → verify CRC of tmpPath against footer and tokenCRC
           # footer is authoritative; return ErrFSMSnapshotFileCRC if mismatch
-        → os.Rename(tmpPath, {fsmSnapDir}/{index:016x}.fsm)  # atomic commit on success
-        → syncDir(fsmSnapDir)                                # flush directory entry
-        → return token  # []byte — the 17-byte token built from the received header
+        → os.Rename(tmpPath, {fsmSnapDir}/{fmt.Sprintf("%016x", index)}.fsm)  # atomic commit on success
+        → syncDir(fsmSnapDir)                           # flush directory entry
+        → return token
     })
-  → token := result.([]byte)  # extract from singleflight result
+  → token = result.([]byte)   # extract from singleflight result
   → raftpb.Message{Snapshot: {Data: token}}
   → handler(msg)
       → applyReadySnapshot(snap)
@@ -441,9 +439,9 @@ function:
 4. Returns typed errors distinguishing file corruption (`ErrFSMSnapshotFileCRC`) from
    token corruption (`ErrFSMSnapshotTokenCRC`).
 
-A standalone `verifyFSMSnapshotFile(path, tokenCRC)` is still provided for use in
-`receiveSnapshotStream` (verify the temp file before atomic rename) and future background
-health-check tasks, but it is **never called in sequence with a subsequent restore**.
+A standalone `verifyFSMSnapshotFile(path, tokenCRC)` is still provided for contexts where
+the FSM must not be modified (e.g., startup cleanup health-checking orphan files), but it
+is **never called in sequence with a subsequent restore**.
 
 ### Verification Points
 
@@ -452,7 +450,7 @@ health-check tasks, but it is **never called in sequence with a subsequent resto
 | **On restart** | `restoreSnapshotState` | `openAndRestoreFSMSnapshot` (single pass) |
 | **After follower receive** | `receiveSnapshotStream` | `verifyFSMSnapshotFile` on tmp before rename |
 | **On follower apply** | `applyReadySnapshot` | `openAndRestoreFSMSnapshot` (single pass; no extra verify) |
-| **Startup orphan check** | `cleanupStaleFSMSnaps` | Index-based only; no CRC scan (deferred to restore time) |
+| **Startup orphan check** | `cleanupStaleFSMSnaps` | `verifyFSMSnapshotFile` (read-only, no restore) |
 | **Background health check** *(future)* | background task | `verifyFSMSnapshotFile` |
 
 ### Error Types and Recovery
@@ -470,7 +468,7 @@ var (
 | Error | Meaning | Recovery |
 |-------|---------|---------|
 | `ErrFSMSnapshotFileCRC` | On-disk file is corrupt; footer ≠ computed | Delete file; WAL replay from `FirstIndex` |
-| `ErrFSMSnapshotTokenCRC` | File is intact (footer == computed) but token differs | Read footer CRC from file; call `Snapshotter.SaveSnap` with `encodeSnapshotToken(index, fileCRC)`; restore from the intact file without WAL replay |
+| `ErrFSMSnapshotTokenCRC` | File is intact (footer == computed) but token differs | Rewrite token from file's actual CRC; no WAL replay needed |
 | `ErrFSMSnapshotNotFound` | `.fsm` file missing for a valid token | WAL replay from `FirstIndex` |
 
 ---
@@ -524,7 +522,7 @@ The receiver path (`receiveSnapshotStream`) follows the same sequence and also c
 | `.fsm` exists, snap not yet saved | Snap points to previous index; next snapshot overwrites |
 | snap(token) exists, `.fsm` missing | `ErrFSMSnapshotNotFound` → WAL replay from `FirstIndex` |
 | `.fsm` footer CRC mismatch | `ErrFSMSnapshotFileCRC` → delete file; WAL replay |
-| `.fsm` footer ok, token CRC differs | `ErrFSMSnapshotTokenCRC` → `Snapshotter.SaveSnap` with corrected token; restore from file; no WAL replay |
+| `.fsm` footer ok, token CRC differs | `ErrFSMSnapshotTokenCRC` → rewrite token; restore from file |
 
 ### Startup Cleanup
 
@@ -535,16 +533,18 @@ The receiver path (`receiveSnapshotStream`) follows the same sequence and also c
 3. Removes any `.fsm` file whose index does not correspond to a live token — this handles
    the case where a `.fsm` was written but the corresponding `.snap` was never saved
    (upgrade crash), as well as files left over after purge ordering bugs in older versions.
+4. For each remaining `.fsm` file, calls `verifyFSMSnapshotFile` and removes files where
+   `ErrFSMSnapshotFileCRC` is returned (corrupt files cannot be used for restore).
 
-CRC integrity of the retained `.fsm` files is **not** verified at startup. For GiB-scale
-snapshots on slow storage, a full read-pass over every `.fsm` file would unacceptably
-delay engine recovery. Instead, CRC verification happens lazily in
-`openAndRestoreFSMSnapshot` at the moment the snapshot is actually applied. If a file is
-corrupt, the engine detects it at restore time and can request a fresh snapshot from the
-leader.
+This index-based orphan detection is stricter than a CRC-only check: a file with a valid
+CRC but no matching token is still an orphan and must be removed.
 
-This index-based orphan detection is stricter than a CRC-only startup scan: a file with
-a valid CRC but no matching token is still an orphan and must be removed.
+> **Performance note**: Step 4 performs a full sequential read of every retained `.fsm`
+> file. For large snapshots (e.g., GiB-scale) or slow storage, this may noticeably delay
+> engine startup. An operator-configurable `DisableStartupFSMCRCCheck` flag can skip step
+> 4; the file would still be detected as corrupt at the next restore attempt via
+> `openAndRestoreFSMSnapshot`. Index-based orphan removal (steps 2–3) always runs
+> regardless of the flag.
 
 ---
 
@@ -630,37 +630,16 @@ ambiguity when a mixed-version cluster is operating.
 The third case — a new-format leader sending a token to a legacy follower — is the only
 dangerous scenario. To prevent it, the rollout must proceed as follows:
 
-1. **Deploy Phase 1 to all nodes before Phase 2.** Phase 1 stores a 17-byte token in
-   `MemoryStorage` instead of the full FSM payload. This means a Phase 1 leader **would**
-   send a token in `MsgSnap` to a lagging follower, which a legacy follower cannot
-   understand. To remain backward-compatible, Phase 1 **must** therefore also include a
-   `Dispatch`-side fallback that reconstructs a full-payload `MsgSnap` when using the
-   legacy send path:
+1. **Deploy Phase 1 to all nodes before Phase 2.** Phase 1 changes local snapshot creation
+   and restore, and also updates the `Dispatch` path with a **bridge mode**: when
+   `msg.Snapshot.Data` is a token, `Dispatch` transparently reads the corresponding `.fsm`
+   file from disk and sends the full `[]byte` payload to the follower via the existing
+   `sendSnapshot` path. This preserves wire compatibility — legacy followers receive the
+   same full payload they always have. Mixed Phase 1 / legacy clusters are therefore safe.
+   File streaming (Phase 2) is deferred until all nodes are on Phase 1.
 
-   ```go
-   // Phase 1 Dispatch fallback: token is in MemoryStorage but receiver may be legacy.
-   // Read the .fsm file back to bytes only when a slow follower actually needs a
-   // snapshot — not on every periodic creation — so peak memory is still improved.
-   if isSnapshotToken(msg.Snapshot.Data) {
-       tok, _ := decodeSnapshotToken(msg.Snapshot.Data)
-       path := filepath.Join(fsmSnapDir, fmt.Sprintf("%016x.fsm", tok.Index))
-       payload, err := readFSMSnapshotPayload(path) // streams file, returns []byte
-       if err != nil {
-           return errors.WithStack(err)
-       }
-       msg.Snapshot.Data = payload // full bytes → safe for legacy receivers
-   }
-   // fall through to legacy sendSnapshot path
-   ```
-
-   With this fallback, mixed Phase 1 / legacy clusters are safe. The memory allocation
-   occurs only when a slow follower needs a snapshot send, not during periodic local
-   snapshot creation, so the worst-case spike is unchanged but the common-case (no
-   lagging followers) is fully eliminated.
-
-2. **Deploy Phase 2 to all nodes simultaneously, or use the feature flag below.** Phase 2
-   replaces the Phase 1 fallback with true file streaming; once any node begins sending
-   token-format `MsgSnap` without reconstructing, all receivers must be at Phase 2.
+2. **Deploy Phase 2 to all nodes simultaneously, or use the feature flag below.** Once
+   any node begins sending token-format `MsgSnap`, all receivers must be at Phase 2.
 
 3. **Feature flag (recommended)**: add a `DisableFSMSnapshotToken` config field (default
    `false`). When set to `true`, `Dispatch` falls back to the legacy `sendSnapshot` path
@@ -686,54 +665,6 @@ transition window: `raftpb.Snapshot.Data` = token AND a copy of the full legacy 
 stored in an auxiliary file. The legacy binary would then decode the full payload
 normally. This dual-write mode is a forward compatibility bridge and can be removed after
 the fleet has been fully upgraded.
-
-### Zero-Downtime Cutover Runbook
-
-For a Raft cluster, the standard zero-downtime approach is a **rolling upgrade**: replace
-one node at a time, verify health, then proceed to the next. The feature flag provides
-the safety valve at each step. Below is the recommended procedure for a 3-node cluster
-(`nodeA`, `nodeB`, `nodeC`).
-
-**Phase 1 rollout (safe in mixed clusters):**
-
-```
-1. Deploy Phase 1 binary to nodeA; restart.
-   - nodeA starts writing .fsm files locally.
-   - nodeA's Dispatch fallback reads .fsm → bytes for any legacy-receiver MsgSnap.
-   - Verify: cluster healthy, no error logs for ErrFSMSnapshotFileCRC.
-
-2. Repeat for nodeB, then nodeC.
-   - All nodes now write .fsm files. Mixed Phase 1 / legacy is safe throughout.
-
-3. Run for at least one full snapshot cycle per node before proceeding to Phase 2.
-   Confirm: each node's fsm-snap/ directory contains a valid .fsm file.
-```
-
-**Phase 2 rollout (requires all nodes on Phase 1 first):**
-
-```
-4. Deploy Phase 2 binary to all nodes with DisableFSMSnapshotToken=true.
-   - Nodes use file streaming internally but Dispatch still reconstructs full payload
-     (feature flag active). This is a no-op from the wire perspective.
-   - Verify: cluster healthy.
-
-5. Enable token mode on nodeA: set DisableFSMSnapshotToken=false (hot reload or restart).
-   - nodeA now sends token-format MsgSnap; all receivers must be Phase 2 (they are).
-   - Monitor for one snapshot cycle. Verify follower applies succeed.
-
-6. Enable on nodeB, then nodeC.
-   - All nodes now use full token-mode streaming.
-
-7. Remove the DisableFSMSnapshotToken flag from config (it now defaults to false).
-```
-
-**Rollback at any step:**
-
-| Step | Rollback action |
-|------|----------------|
-| During Phase 1 rollout | Redeploy legacy binary; stop node first; delete `fsm-snap/`; restart (WAL replay) |
-| Phase 2 deployed, flag still enabled | Redeploy Phase 1 binary; no fsm-snap cleanup needed |
-| Phase 2 deployed, flag disabled on some nodes | Re-enable `DisableFSMSnapshotToken=true` on flag-disabled nodes first; then redeploy Phase 1 binaries |
 
 ---
 
@@ -769,8 +700,7 @@ the safety valve at each step. Below is the recommended procedure for a 3-node c
 ### Phase 1: Local Snapshot Disk Offload
 
 Scope: local creation and local restore for **all three snapshot paths** (periodic,
-config-change, and bootstrap) **plus** a `Dispatch`-side fallback for backward
-compatibility with legacy followers.
+config-change, and bootstrap). Follower send/receive is unchanged.
 
 **Implementation tasks:**
 
@@ -779,17 +709,12 @@ compatibility with legacy followers.
   - `writeFSMSnapshotFile` (write with CRC footer + syncDir)
   - `openAndRestoreFSMSnapshot` (single-pass verify+restore via TeeReader)
   - `verifyFSMSnapshotFile` (read-only CRC check for orphan detection)
-  - `readFSMSnapshotPayload` (read `.fsm` file back to `[]byte` for legacy send)
   - `encodeSnapshotToken` / `decodeSnapshotToken` (17-byte token with CRC)
-  - Error types: `ErrFSMSnapshotFileCRC`, `ErrFSMSnapshotTokenCRC`,
-    `ErrFSMSnapshotIndexMismatch`, etc.
+  - Error types: `ErrFSMSnapshotFileCRC`, `ErrFSMSnapshotTokenCRC`, etc.
 - Update `persistLocalSnapshot` → `writeFSMSnapshotFile` + token
 - Update `persistConfigSnapshot`, `persistConfigState`, and `persistConfigSnapshotPayload` → same
 - Update `stateMachineSnapshotBytes` (bootstrap) → `writeFSMSnapshotFile` + token
 - Update `restoreSnapshotState` → `openAndRestoreFSMSnapshot`
-- Update `Dispatch`: if `isSnapshotToken(msg.Snapshot.Data)` and using the legacy send
-  path, call `readFSMSnapshotPayload` to reconstruct the full payload before sending
-  (ensures legacy followers receive a valid FSM byte stream)
 - Replace `purgeOldSnapFiles` with `purgeOldSnapshotFiles(snapDir, fsmSnapDir)`
 - Add `cleanupStaleFSMSnaps(snapDir, fsmSnapDir)` (index-based orphan removal)
 - Capture `storageIndex` before `fsm.Snapshot()` in `maybePersistLocalSnapshot`
@@ -797,18 +722,14 @@ compatibility with legacy followers.
 
 **Effect**: eliminates memory spikes during local snapshot creation; reduces
 `MemoryStorage` resident memory; all snapshot creation paths are consistent.
-Mixed Phase 1 / legacy clusters remain safe because the Dispatch fallback reconstructs
-the full payload on demand (only when a slow follower actually needs a snapshot).
 
 ### Phase 2: Streaming Follower Send/Receive
 
-Scope: update `GRPCTransport` MsgSnap paths to use file streaming; remove the
-Phase 1 `readFSMSnapshotPayload` fallback from `Dispatch`.
+Scope: update `GRPCTransport` MsgSnap paths to use file streaming.
 
 **Implementation tasks:**
 
 - `Dispatch`: detect token → open `.fsm` file → `sendSnapshotFileChunks`
-  (replaces the Phase 1 `readFSMSnapshotPayload` fallback entirely)
 - `receiveSnapshotStream`:
   - Write chunks to temp file (with `bufio.NewWriterSize`)
   - `verifyFSMSnapshotFile` on tmp before rename

--- a/docs/etcd_snapshot_disk_offload_design.md
+++ b/docs/etcd_snapshot_disk_offload_design.md
@@ -391,17 +391,19 @@ receiveSnapshotStream()
   # Validate that the token index matches raftpb.SnapshotMetadata.Index to
   # reject corrupted or misrouted messages before any disk I/O.
   → if index != msg.Snapshot.Metadata.Index: reject with error
-  → result, token, err := snapReceiveGroup.Do(fmt.Sprintf("%016x", index), func() (any, error) {
+  # singleflight.Group.Do signature: Do(key string, fn func() (any, error)) (v any, err error, shared bool)
+  → v, err, _ := snapReceiveGroup.Do(fmt.Sprintf("%016x", index), func() (any, error) {
         → os.CreateTemp() → {fsmSnapDir}/{fmt.Sprintf("%016x", index)}.fsm.tmp
         → stream remaining chunks to tmpFile (with bufio.NewWriterSize)
         → tmpFile.Sync()
         → verify CRC of tmpPath against footer and tokenCRC
-          # footer is authoritative; return ErrFSMSnapshotFileCRC if mismatch
+          # footer is authoritative; return nil, ErrFSMSnapshotFileCRC if mismatch
         → os.Rename(tmpPath, {fsmSnapDir}/{fmt.Sprintf("%016x", index)}.fsm)  # atomic commit on success
         → syncDir(fsmSnapDir)                           # flush directory entry
-        → return token
+        → return encodedToken, nil  # encodedToken is the 17-byte token []byte
     })
-  → token = result.([]byte)   # extract from singleflight result
+  → if err != nil: return err
+  → token := v.([]byte)   # type-assert the singleflight result to []byte
   → raftpb.Message{Snapshot: {Data: token}}
   → handler(msg)
       → applyReadySnapshot(snap)
@@ -670,8 +672,10 @@ ambiguity when a mixed-version cluster is operating.
 |----------------|-----------------|---------|
 | Legacy (no token) | Legacy | Unchanged — existing path |
 | Legacy (no token) | New | `isSnapshotToken` → false → `bytes.NewReader` fallback |
-| New (token) | Legacy | Legacy node does not understand the token; restores from the 17-byte payload as if it were FSM data → **corrupt FSM** |
-| New (token) | New | Token path → `.fsm` file |
+| Phase 1 (bridge mode) | Legacy | `Dispatch` reads `.fsm` → `[]byte` → `sendSnapshot`; legacy receiver sees full payload → safe |
+| Phase 1 (bridge mode) | Phase 1+ | Same as above (bridge mode always uses old wire format) |
+| Phase 2 (token send) | Legacy | Legacy node receives 17-byte token; restore fails → **unsafe; requires all nodes on Phase 2** |
+| Phase 2 (token send) | Phase 2 | Token path → `.fsm` file streaming → safe |
 
 ### Rolling Upgrade Strategy
 
@@ -687,35 +691,34 @@ dangerous scenario. To prevent it, the rollout must proceed as follows:
    File streaming (Phase 2) is deferred until all nodes are on Phase 1.
 
    ```go
-   // Phase 1 Dispatch fallback: token is in MemoryStorage but receiver may be legacy.
-   // Open the .fsm file and stream it directly via sendSnapshotReaderChunks to avoid
-   // materializing the full payload into memory. This requires the receiver to be at
-   // least Phase 1 (i.e., it runs receiveSnapshotStream which handles both formats).
-   // A truly pre-Phase-1 legacy receiver cannot handle this path; see note below.
+   // Phase 1 Dispatch bridge mode: MemoryStorage holds a token, but the receiver
+   // may be a pre-Phase-1 legacy node that expects a full FSM payload in
+   // msg.Snapshot.Data. Read the .fsm file back into []byte and use the
+   // existing sendSnapshot path to preserve wire compatibility.
    if isSnapshotToken(msg.Snapshot.Data) {
        tok, _ := decodeSnapshotToken(msg.Snapshot.Data)
        path := filepath.Join(fsmSnapDir, fmt.Sprintf("%016x.fsm", tok.Index))
-       f, err := os.Open(path)
+       payload, err := readFSMSnapshotPayload(path) // reads file, returns []byte
        if err != nil {
            return errors.WithStack(err)
        }
-       defer f.Close()
-       return sendSnapshotReaderChunks(stream, header, f) // stream without []byte alloc
+       msg.Snapshot.Data = payload // restore full bytes for legacy wire format
    }
-   // fall through to legacy sendSnapshot path (receiver is pre-Phase-1)
+   // sendSnapshot uses the existing chunked send path; all receivers understand it
+   return sendSnapshot(msg)
    ```
 
-   > **Memory trade-off note**: `sendSnapshotReaderChunks` streams the `.fsm` file
-   > directly without materializing it to `[]byte`, preserving the memory benefit. This
-   > path requires the receiver to run `receiveSnapshotStream`. If the cluster contains
-   > genuine pre-Phase-1 nodes that do not have `receiveSnapshotStream`, the operator
-   > must materialize via `readFSMSnapshotPayload` instead — accepting that the memory
-   > spike is re-introduced for that specific send. In practice this case should not
-   > arise when the Phase 1 rollout is done correctly (all nodes updated before Phase 2
-   > is enabled). Phase 2 eliminates the fallback entirely.
+   > **Memory trade-off**: `readFSMSnapshotPayload` materializes the `.fsm` file to
+   > `[]byte`, which re-introduces a memory allocation at send time. However:
+   > - The allocation is **transient** (freed after the send completes) — not permanently
+   >   held in MemoryStorage as it was before this change.
+   > - It occurs only when a **slow follower** needs a snapshot, not on every periodic
+   >   snapshot creation; in a healthy cluster this is rare.
+   > - **Phase 2 eliminates this entirely** by replacing the bridge mode with file
+   >   streaming to all nodes.
 
-   With this fallback, mixed Phase 1 / legacy clusters are safe. Memory allocation
-   during snapshot creation is eliminated; the send path streams from disk.
+   With this bridge, mixed Phase 1 / legacy clusters are fully safe: every receiver
+   always gets a standard full-payload `MsgSnap` regardless of version.
 
 2. **Deploy Phase 2 to all nodes simultaneously, or use the feature flag below.** Phase 2
    replaces the Phase 1 fallback with true file streaming; once any node begins sending
@@ -789,19 +792,27 @@ config-change, and bootstrap). Follower send/receive is unchanged.
   - `writeFSMSnapshotFile` (write with CRC footer + syncDir)
   - `openAndRestoreFSMSnapshot` (single-pass verify+restore via TeeReader)
   - `verifyFSMSnapshotFile` (read-only CRC check for orphan detection)
-- Update `Dispatch`: if `isSnapshotToken(msg.Snapshot.Data)`, open the `.fsm` file and
-  stream via `sendSnapshotReaderChunks` (no `[]byte` allocation); this requires the
-  receiver to run `receiveSnapshotStream` (i.e., be at Phase 1 or newer)
+  - `readFSMSnapshotPayload` (read `.fsm` file back to `[]byte` for bridge-mode send)
+  - `fsmSnapPath(fsmSnapDir string, index uint64) string` (canonical zero-padded hex path helper)
+  - `encodeSnapshotToken` / `decodeSnapshotToken` (17-byte token with CRC)
+  - Error types: `ErrFSMSnapshotFileCRC`, `ErrFSMSnapshotTokenCRC`,
+    `ErrFSMSnapshotIndexMismatch`, etc.
+- Update `persistLocalSnapshot` → `writeFSMSnapshotFile` + token
+- Update `persistConfigSnapshot`, `persistConfigState`, and `persistConfigSnapshotPayload` → same
+- Update `stateMachineSnapshotBytes` (bootstrap) → `writeFSMSnapshotFile` + token
+- Update `restoreSnapshotState` → `openAndRestoreFSMSnapshot`
+- Update `Dispatch` (bridge mode): if `isSnapshotToken(msg.Snapshot.Data)`, call
+  `readFSMSnapshotPayload` to reconstruct `[]byte` payload; use old `sendSnapshot` path
+  so all receivers (including legacy) receive a standard full-payload `MsgSnap`
 - Replace `purgeOldSnapFiles` with `purgeOldSnapshotFiles(snapDir, fsmSnapDir)`
 - Add `cleanupStaleFSMSnaps(snapDir, fsmSnapDir)` (index-based orphan removal)
 - Capture `storageIndex` before `fsm.Snapshot()` in `maybePersistLocalSnapshot`
 - All existing tests must continue to pass
 
-**Effect**: eliminates memory spikes during local snapshot creation; reduces
-`MemoryStorage` resident memory; all snapshot creation paths are consistent.
-Mixed Phase 1 clusters are safe: Dispatch streams from the `.fsm` file via
-`sendSnapshotReaderChunks` without materializing to `[]byte`. Requires all nodes in the
-cluster to be at Phase 1 or newer before any Phase 1 node becomes leader.
+**Effect**: eliminates memory spikes during **local snapshot creation**; reduces
+`MemoryStorage` resident memory. A transient allocation still occurs when a slow follower
+needs a snapshot send (bridge mode), but it is freed after the send and does not persist.
+Phase 2 eliminates this last allocation by switching to file streaming.
 
 ### Phase 2: Streaming Follower Send/Receive
 

--- a/docs/etcd_snapshot_disk_offload_design.md
+++ b/docs/etcd_snapshot_disk_offload_design.md
@@ -159,7 +159,9 @@ with the raft snapshot metadata. The two values must always agree; a mismatch in
 - **footer ≠ computed**: the `.fsm` file is corrupt on disk → delete and attempt WAL
   replay; do not trust the token.
 - **footer == computed, token ≠ computed**: the `.snap` metadata is corrupt → the file
-  itself is trustworthy; the snap file should be rewritten from the file's actual CRC.
+  itself may be trustworthy, but the mismatch could also indicate the token points to the
+  wrong file version; **do not auto-rewrite**; log the discrepancy and request a fresh
+  snapshot from the leader (safe path).
 - **footer ≠ computed AND token ≠ computed**: both are corrupt → WAL replay only.
 
 This distinction is implemented in `verifyFSMSnapshotFile`, which returns typed errors
@@ -270,6 +272,31 @@ func openAndRestoreFSMSnapshot(fsm StateMachine, path string, tokenCRC uint32) e
     }
     defer f.Close()
 
+    // --- Fail fast: read footer before restoring FSM state ---
+    // The tokenCRC (from the .snap metadata) is verified against the on-disk footer
+    // BEFORE fsm.Restore is called. This prevents the FSM from being mutated when
+    // the token is stale or corrupt, avoiding any state-change side-effects.
+    footerOffset := info.Size() - 4
+    if _, err := f.Seek(footerOffset, io.SeekStart); err != nil {
+        return errors.WithStack(err)
+    }
+    var footer uint32
+    if err := binary.Read(f, binary.BigEndian, &footer); err != nil {
+        return errors.WithStack(err)
+    }
+    if footer != tokenCRC {
+        // Footer and token disagree before we even start restoring. We cannot safely
+        // determine which is correct without computing the full CRC (which requires
+        // restoring). Return ErrFSMSnapshotTokenCRC and let the caller request a fresh
+        // snapshot from the leader.
+        return errors.Wrapf(ErrFSMSnapshotTokenCRC,
+            "path=%s footer=%08x token=%08x", path, footer, tokenCRC)
+    }
+    // Seek back to start for the restore + CRC verification pass.
+    if _, err := f.Seek(0, io.SeekStart); err != nil {
+        return errors.WithStack(err)
+    }
+
     payloadSize := info.Size() - 4
     h := crc32.New(crc32cTable)
     // Tee: data flows to both the CRC accumulator and fsm.Restore simultaneously.
@@ -283,24 +310,21 @@ func openAndRestoreFSMSnapshot(fsm StateMachine, path string, tokenCRC uint32) e
     if _, err := io.Copy(io.Discard, br); err != nil {
         return errors.WithStack(err)
     }
-    var footer uint32
-    if err := binary.Read(f, binary.BigEndian, &footer); err != nil {
-        return errors.WithStack(err)
-    }
     computed := h.Sum32()
     if computed != footer {
         return errors.Wrapf(ErrFSMSnapshotFileCRC,
             "path=%s footer=%08x computed=%08x", path, footer, computed)
     }
-    if computed != tokenCRC {
-        return errors.Wrapf(ErrFSMSnapshotTokenCRC,
-            "path=%s token=%08x computed=%08x", path, tokenCRC, computed)
-    }
+    // footer == tokenCRC was already verified above; computed == footer is now also
+    // confirmed, so all three values agree. No second tokenCRC comparison needed.
     return nil
 }
 ```
 
 Key properties:
+- **Token fail-fast before restore**: the footer is read via `Seek` and compared to
+  `tokenCRC` before `fsm.Restore` is called, so a corrupt token never causes FSM
+  mutation.
 - **Single read pass**: `io.TeeReader` feeds data to both `fsm.Restore` and the CRC hash
   simultaneously; no second scan.
 - **`bufio.NewReaderSize(tee, 1<<20)`**: the 1 MiB read-ahead buffer amortizes the
@@ -468,7 +492,7 @@ var (
 | Error | Meaning | Recovery |
 |-------|---------|---------|
 | `ErrFSMSnapshotFileCRC` | On-disk file is corrupt; footer ≠ computed | Delete file; WAL replay from `FirstIndex` |
-| `ErrFSMSnapshotTokenCRC` | File is intact (footer == computed) but token differs | Rewrite token from file's actual CRC; no WAL replay needed |
+| `ErrFSMSnapshotTokenCRC` | Footer and token disagree (detected before restore) | Log the mismatch; request a fresh snapshot from the leader; do not auto-rewrite the token (the mismatch may indicate the token references the wrong file version) |
 | `ErrFSMSnapshotNotFound` | `.fsm` file missing for a valid token | WAL replay from `FirstIndex` |
 
 ---
@@ -522,7 +546,7 @@ The receiver path (`receiveSnapshotStream`) follows the same sequence and also c
 | `.fsm` exists, snap not yet saved | Snap points to previous index; next snapshot overwrites |
 | snap(token) exists, `.fsm` missing | `ErrFSMSnapshotNotFound` → WAL replay from `FirstIndex` |
 | `.fsm` footer CRC mismatch | `ErrFSMSnapshotFileCRC` → delete file; WAL replay |
-| `.fsm` footer ok, token CRC differs | `ErrFSMSnapshotTokenCRC` → rewrite token; restore from file |
+| `.fsm` footer ok, token CRC differs | `ErrFSMSnapshotTokenCRC` → log + request fresh snapshot from leader; no auto-rewrite |
 
 ### Startup Cleanup
 
@@ -638,8 +662,40 @@ dangerous scenario. To prevent it, the rollout must proceed as follows:
    same full payload they always have. Mixed Phase 1 / legacy clusters are therefore safe.
    File streaming (Phase 2) is deferred until all nodes are on Phase 1.
 
-2. **Deploy Phase 2 to all nodes simultaneously, or use the feature flag below.** Once
-   any node begins sending token-format `MsgSnap`, all receivers must be at Phase 2.
+   ```go
+   // Phase 1 Dispatch fallback: token is in MemoryStorage but receiver may be legacy.
+   // Open the .fsm file and stream it directly via sendSnapshotReaderChunks to avoid
+   // materializing the full payload into memory. This requires the receiver to be at
+   // least Phase 1 (i.e., it runs receiveSnapshotStream which handles both formats).
+   // A truly pre-Phase-1 legacy receiver cannot handle this path; see note below.
+   if isSnapshotToken(msg.Snapshot.Data) {
+       tok, _ := decodeSnapshotToken(msg.Snapshot.Data)
+       path := filepath.Join(fsmSnapDir, fmt.Sprintf("%016x.fsm", tok.Index))
+       f, err := os.Open(path)
+       if err != nil {
+           return errors.WithStack(err)
+       }
+       defer f.Close()
+       return sendSnapshotReaderChunks(stream, header, f) // stream without []byte alloc
+   }
+   // fall through to legacy sendSnapshot path (receiver is pre-Phase-1)
+   ```
+
+   > **Memory trade-off note**: `sendSnapshotReaderChunks` streams the `.fsm` file
+   > directly without materializing it to `[]byte`, preserving the memory benefit. This
+   > path requires the receiver to run `receiveSnapshotStream`. If the cluster contains
+   > genuine pre-Phase-1 nodes that do not have `receiveSnapshotStream`, the operator
+   > must materialize via `readFSMSnapshotPayload` instead — accepting that the memory
+   > spike is re-introduced for that specific send. In practice this case should not
+   > arise when the Phase 1 rollout is done correctly (all nodes updated before Phase 2
+   > is enabled). Phase 2 eliminates the fallback entirely.
+
+   With this fallback, mixed Phase 1 / legacy clusters are safe. Memory allocation
+   during snapshot creation is eliminated; the send path streams from disk.
+
+2. **Deploy Phase 2 to all nodes simultaneously, or use the feature flag below.** Phase 2
+   replaces the Phase 1 fallback with true file streaming; once any node begins sending
+   token-format `MsgSnap` without reconstructing, all receivers must be at Phase 2.
 
 3. **Feature flag (recommended)**: add a `DisableFSMSnapshotToken` config field (default
    `false`). When set to `true`, `Dispatch` falls back to the legacy `sendSnapshot` path
@@ -709,12 +765,9 @@ config-change, and bootstrap). Follower send/receive is unchanged.
   - `writeFSMSnapshotFile` (write with CRC footer + syncDir)
   - `openAndRestoreFSMSnapshot` (single-pass verify+restore via TeeReader)
   - `verifyFSMSnapshotFile` (read-only CRC check for orphan detection)
-  - `encodeSnapshotToken` / `decodeSnapshotToken` (17-byte token with CRC)
-  - Error types: `ErrFSMSnapshotFileCRC`, `ErrFSMSnapshotTokenCRC`, etc.
-- Update `persistLocalSnapshot` → `writeFSMSnapshotFile` + token
-- Update `persistConfigSnapshot`, `persistConfigState`, and `persistConfigSnapshotPayload` → same
-- Update `stateMachineSnapshotBytes` (bootstrap) → `writeFSMSnapshotFile` + token
-- Update `restoreSnapshotState` → `openAndRestoreFSMSnapshot`
+- Update `Dispatch`: if `isSnapshotToken(msg.Snapshot.Data)`, open the `.fsm` file and
+  stream via `sendSnapshotReaderChunks` (no `[]byte` allocation); this requires the
+  receiver to run `receiveSnapshotStream` (i.e., be at Phase 1 or newer)
 - Replace `purgeOldSnapFiles` with `purgeOldSnapshotFiles(snapDir, fsmSnapDir)`
 - Add `cleanupStaleFSMSnaps(snapDir, fsmSnapDir)` (index-based orphan removal)
 - Capture `storageIndex` before `fsm.Snapshot()` in `maybePersistLocalSnapshot`
@@ -722,6 +775,9 @@ config-change, and bootstrap). Follower send/receive is unchanged.
 
 **Effect**: eliminates memory spikes during local snapshot creation; reduces
 `MemoryStorage` resident memory; all snapshot creation paths are consistent.
+Mixed Phase 1 clusters are safe: Dispatch streams from the `.fsm` file via
+`sendSnapshotReaderChunks` without materializing to `[]byte`. Requires all nodes in the
+cluster to be at Phase 1 or newer before any Phase 1 node becomes leader.
 
 ### Phase 2: Streaming Follower Send/Receive
 

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -257,30 +257,9 @@ func (c *Coordinate) redirect(ctx context.Context, reqs *OperationGroup[OP]) (*C
 
 	cli := pb.NewInternalClient(conn)
 
-	var requests []*pb.Request
-	if reqs.IsTxn {
-		if len(reqs.ReadKeys) > maxReadKeys {
-			return nil, errors.WithStack(ErrInvalidRequest)
-		}
-		primary := primaryKeyForElems(reqs.Elems)
-		if len(primary) == 0 {
-			return nil, errors.WithStack(ErrTxnPrimaryKeyRequired)
-		}
-		// When StartTS is absent (leader will assign it), also clear CommitTS
-		// so the leader assigns both timestamps consistently. A caller-provided
-		// CommitTS without a StartTS would produce an invalid txn where
-		// CommitTS <= StartTS (because StartTS=0 at the forwarding site).
-		commitTS := reqs.CommitTS
-		if reqs.StartTS == 0 {
-			commitTS = 0
-		}
-		requests = []*pb.Request{
-			onePhaseTxnRequest(reqs.StartTS, commitTS, primary, reqs.Elems, reqs.ReadKeys),
-		}
-	} else {
-		for _, req := range reqs.Elems {
-			requests = append(requests, c.toRawRequest(req))
-		}
+	requests, err := c.buildRedirectRequests(reqs)
+	if err != nil {
+		return nil, err
 	}
 
 	fwdCtx, cancel := context.WithTimeout(ctx, redirectForwardTimeout)
@@ -296,6 +275,34 @@ func (c *Coordinate) redirect(ctx context.Context, reqs *OperationGroup[OP]) (*C
 
 	return &CoordinateResponse{
 		CommitIndex: r.CommitIndex,
+	}, nil
+}
+
+func (c *Coordinate) buildRedirectRequests(reqs *OperationGroup[OP]) ([]*pb.Request, error) {
+	if !reqs.IsTxn {
+		var requests []*pb.Request
+		for _, req := range reqs.Elems {
+			requests = append(requests, c.toRawRequest(req))
+		}
+		return requests, nil
+	}
+	if len(reqs.ReadKeys) > maxReadKeys {
+		return nil, errors.WithStack(ErrInvalidRequest)
+	}
+	primary := primaryKeyForElems(reqs.Elems)
+	if len(primary) == 0 {
+		return nil, errors.WithStack(ErrTxnPrimaryKeyRequired)
+	}
+	// When StartTS is absent (leader will assign it), also clear CommitTS
+	// so the leader assigns both timestamps consistently. A caller-provided
+	// CommitTS without a StartTS would produce an invalid txn where
+	// CommitTS <= StartTS (because StartTS=0 at the forwarding site).
+	commitTS := reqs.CommitTS
+	if reqs.StartTS == 0 {
+		commitTS = 0
+	}
+	return []*pb.Request{
+		onePhaseTxnRequest(reqs.StartTS, commitTS, primary, reqs.Elems, reqs.ReadKeys),
 	}, nil
 }
 

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -280,7 +280,7 @@ func (c *Coordinate) redirect(ctx context.Context, reqs *OperationGroup[OP]) (*C
 
 func (c *Coordinate) buildRedirectRequests(reqs *OperationGroup[OP]) ([]*pb.Request, error) {
 	if !reqs.IsTxn {
-		var requests []*pb.Request
+		requests := make([]*pb.Request, 0, len(reqs.Elems))
 		for _, req := range reqs.Elems {
 			requests = append(requests, c.toRawRequest(req))
 		}

--- a/kv/leader_routed_store.go
+++ b/kv/leader_routed_store.go
@@ -155,14 +155,21 @@ func (s *LeaderRoutedStore) GetAt(ctx context.Context, key []byte, ts uint64) ([
 }
 
 func (s *LeaderRoutedStore) ExistsAt(ctx context.Context, key []byte, ts uint64) (bool, error) {
-	v, err := s.GetAt(ctx, key, ts)
-	if err != nil {
-		if errors.Is(err, store.ErrKeyNotFound) {
-			return false, nil
-		}
-		return false, err
+	if s == nil || s.local == nil {
+		return false, nil
 	}
-	return v != nil, nil
+	if s.leaderOKForKey(ctx, key) {
+		ok, err := s.local.ExistsAt(ctx, key, ts)
+		return ok, errors.WithStack(err)
+	}
+	// Via proxy path: RawGet returns a nil Value for a key that exists with an
+	// empty value because proto3 strips zero-valued bytes fields on the wire.
+	// Determine existence from the error alone, not from whether Value is non-nil.
+	_, err := s.proxyRawGet(ctx, key, ts)
+	if errors.Is(err, store.ErrKeyNotFound) {
+		return false, nil
+	}
+	return err == nil, errors.WithStack(err)
 }
 
 func (s *LeaderRoutedStore) ScanAt(ctx context.Context, start []byte, end []byte, limit int, ts uint64) ([]*store.KVPair, error) {

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -211,22 +211,13 @@ func (c *ShardedCoordinator) dispatchTxn(ctx context.Context, startTS uint64, co
 		return nil, err
 	}
 
-	if len(gids) == 1 {
+	if len(gids) == 1 && c.allReadKeysInShard(readKeys, gids[0]) {
 		// Only use the single-shard (one-phase) path when every read key also
 		// belongs to the same shard as the mutations. If any read key belongs
 		// to a different shard, the 2PC path must be used so that
 		// validateReadOnlyShards validates those shards via a linearizable
 		// read barrier, preserving SSI.
-		canOptimize := true
-		for _, rk := range readKeys {
-			if c.engineGroupIDForKey(rk) != gids[0] {
-				canOptimize = false
-				break
-			}
-		}
-		if canOptimize {
-			return c.dispatchSingleShardTxn(startTS, commitTS, primaryKey, gids[0], elems, readKeys)
-		}
+		return c.dispatchSingleShardTxn(startTS, commitTS, primaryKey, gids[0], elems, readKeys)
 	}
 
 	prepared, err := c.prewriteTxn(ctx, startTS, commitTS, primaryKey, grouped, gids, readKeys)
@@ -256,6 +247,16 @@ func (c *ShardedCoordinator) resolveTxnCommitTS(startTS, commitTS uint64) (uint6
 		return 0, errors.WithStack(ErrTxnCommitTSRequired)
 	}
 	return commitTS, nil
+}
+
+// allReadKeysInShard reports whether every key in readKeys belongs to gid.
+func (c *ShardedCoordinator) allReadKeysInShard(readKeys [][]byte, gid uint64) bool {
+	for _, rk := range readKeys {
+		if c.engineGroupIDForKey(rk) != gid {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *ShardedCoordinator) dispatchSingleShardTxn(startTS, commitTS uint64, primaryKey []byte, gid uint64, elems []*Elem[OP], readKeys [][]byte) (*CoordinateResponse, error) {

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -211,7 +211,11 @@ func (c *ShardedCoordinator) dispatchTxn(ctx context.Context, startTS uint64, co
 		return nil, err
 	}
 
-	if len(gids) == 1 && c.allReadKeysInShard(readKeys, gids[0]) {
+	// Group read keys by shard once here so the result can be reused by
+	// prewriteTxn without a second iteration over readKeys.
+	groupedReadKeys := c.groupReadKeysByShardID(readKeys)
+
+	if len(gids) == 1 && allGroupedReadKeysInShard(groupedReadKeys, gids[0]) {
 		// Only use the single-shard (one-phase) path when every read key also
 		// belongs to the same shard as the mutations. If any read key belongs
 		// to a different shard, the 2PC path must be used so that
@@ -220,7 +224,7 @@ func (c *ShardedCoordinator) dispatchTxn(ctx context.Context, startTS uint64, co
 		return c.dispatchSingleShardTxn(startTS, commitTS, primaryKey, gids[0], elems, readKeys)
 	}
 
-	prepared, err := c.prewriteTxn(ctx, startTS, commitTS, primaryKey, grouped, gids, readKeys)
+	prepared, err := c.prewriteTxn(ctx, startTS, commitTS, primaryKey, grouped, gids, groupedReadKeys)
 	if err != nil {
 		return nil, err
 	}
@@ -249,14 +253,15 @@ func (c *ShardedCoordinator) resolveTxnCommitTS(startTS, commitTS uint64) (uint6
 	return commitTS, nil
 }
 
-// allReadKeysInShard reports whether every key in readKeys belongs to gid.
-func (c *ShardedCoordinator) allReadKeysInShard(readKeys [][]byte, gid uint64) bool {
-	for _, rk := range readKeys {
-		if c.engineGroupIDForKey(rk) != gid {
-			return false
-		}
+// allGroupedReadKeysInShard returns true when every read key in groupedReadKeys
+// belongs to gid (i.e. the map is empty or contains only the entry for gid).
+// It operates on the pre-computed groupedReadKeys to avoid a second iteration.
+func allGroupedReadKeysInShard(groupedReadKeys map[uint64][][]byte, gid uint64) bool {
+	if len(groupedReadKeys) == 0 {
+		return true
 	}
-	return true
+	_, ok := groupedReadKeys[gid]
+	return ok && len(groupedReadKeys) == 1
 }
 
 func (c *ShardedCoordinator) dispatchSingleShardTxn(startTS, commitTS uint64, primaryKey []byte, gid uint64, elems []*Elem[OP], readKeys [][]byte) (*CoordinateResponse, error) {
@@ -283,11 +288,9 @@ type preparedGroup struct {
 	keys []*pb.Mutation
 }
 
-func (c *ShardedCoordinator) prewriteTxn(ctx context.Context, startTS, commitTS uint64, primaryKey []byte, grouped map[uint64][]*pb.Mutation, gids []uint64, readKeys [][]byte) ([]preparedGroup, error) {
+func (c *ShardedCoordinator) prewriteTxn(ctx context.Context, startTS, commitTS uint64, primaryKey []byte, grouped map[uint64][]*pb.Mutation, gids []uint64, groupedReadKeys map[uint64][][]byte) ([]preparedGroup, error) {
 	prepareMeta := txnMetaMutation(primaryKey, defaultTxnLockTTLms, 0)
 	prepared := make([]preparedGroup, 0, len(gids))
-
-	groupedReadKeys := c.groupReadKeysByShardID(readKeys)
 
 	for _, gid := range gids {
 		g, err := c.txnGroupForID(gid)

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -211,19 +211,18 @@ func (c *ShardedCoordinator) dispatchTxn(ctx context.Context, startTS uint64, co
 		return nil, err
 	}
 
-	// Group read keys by shard once here so the result can be reused by
-	// prewriteTxn without a second iteration over readKeys.
-	groupedReadKeys := c.groupReadKeysByShardID(readKeys)
-
-	if len(gids) == 1 && allGroupedReadKeysInShard(groupedReadKeys, gids[0]) {
-		// Only use the single-shard (one-phase) path when every read key also
-		// belongs to the same shard as the mutations. If any read key belongs
-		// to a different shard, the 2PC path must be used so that
-		// validateReadOnlyShards validates those shards via a linearizable
-		// read barrier, preserving SSI.
+	if len(gids) == 1 && c.allReadKeysInShard(readKeys, gids[0]) {
+		// Fast path: all mutations and read keys are in a single shard.
+		// Use the one-phase path without allocating a grouped-read-keys map.
+		// If any read key belongs to a different shard the 2PC path is required
+		// so that validateReadOnlyShards can issue a linearizable read barrier,
+		// preserving SSI.
 		return c.dispatchSingleShardTxn(startTS, commitTS, primaryKey, gids[0], elems, readKeys)
 	}
 
+	// Multi-shard path: group read keys by shard now. The result is passed
+	// directly to prewriteTxn to avoid a second iteration inside that function.
+	groupedReadKeys := c.groupReadKeysByShardID(readKeys)
 	prepared, err := c.prewriteTxn(ctx, startTS, commitTS, primaryKey, grouped, gids, groupedReadKeys)
 	if err != nil {
 		return nil, err
@@ -253,15 +252,16 @@ func (c *ShardedCoordinator) resolveTxnCommitTS(startTS, commitTS uint64) (uint6
 	return commitTS, nil
 }
 
-// allGroupedReadKeysInShard returns true when every read key in groupedReadKeys
-// belongs to gid (i.e. the map is empty or contains only the entry for gid).
-// It operates on the pre-computed groupedReadKeys to avoid a second iteration.
-func allGroupedReadKeysInShard(groupedReadKeys map[uint64][][]byte, gid uint64) bool {
-	if len(groupedReadKeys) == 0 {
-		return true
+// allReadKeysInShard returns true when every key in readKeys belongs to gid.
+// It performs a single O(n) pass without allocating a map, making it suitable
+// for the single-shard fast path in dispatchTxn.
+func (c *ShardedCoordinator) allReadKeysInShard(readKeys [][]byte, gid uint64) bool {
+	for _, rk := range readKeys {
+		if c.engineGroupIDForKey(rk) != gid {
+			return false
+		}
 	}
-	_, ok := groupedReadKeys[gid]
-	return ok && len(groupedReadKeys) == 1
+	return true
 }
 
 func (c *ShardedCoordinator) dispatchSingleShardTxn(startTS, commitTS uint64, primaryKey []byte, gid uint64, elems []*Elem[OP], readKeys [][]byte) (*CoordinateResponse, error) {

--- a/store/hash_helpers.go
+++ b/store/hash_helpers.go
@@ -1,0 +1,189 @@
+//nolint:dupl // Hash and Set helpers are intentionally parallel implementations for distinct types.
+package store
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Hash wide-column key layout:
+//
+//	Base Metadata: !hs|meta|<userKeyLen(4)><userKey>               → [Len(8)]
+//	Field Key:     !hs|fld|<userKeyLen(4)><userKey><fieldName>     → field value bytes
+//	Delta Key:     !hs|meta|d|<userKeyLen(4)><userKey><commitTS(8)><seqInTxn(4)> → [LenDelta(8)]
+const (
+	HashMetaPrefix      = "!hs|meta|"
+	HashFieldPrefix     = "!hs|fld|"
+	HashMetaDeltaPrefix = "!hs|meta|d|"
+
+	// hashMetaSizeBytes is the fixed binary size of a HashMeta or HashMetaDelta (one int64).
+	hashMetaSizeBytes = 8
+)
+
+// HashMeta is the base metadata for a hash collection.
+type HashMeta struct {
+	Len int64
+}
+
+// HashMetaDelta holds a signed change in field count.
+type HashMetaDelta struct {
+	LenDelta int64
+}
+
+// MarshalHashMeta encodes HashMeta into a fixed 8-byte binary format.
+func MarshalHashMeta(m HashMeta) []byte {
+	buf := make([]byte, hashMetaSizeBytes)
+	binary.BigEndian.PutUint64(buf, uint64(m.Len)) //nolint:gosec
+	return buf
+}
+
+// UnmarshalHashMeta decodes HashMeta from the fixed 8-byte binary format.
+func UnmarshalHashMeta(b []byte) (HashMeta, error) {
+	if len(b) != hashMetaSizeBytes {
+		return HashMeta{}, errors.WithStack(errors.Newf("invalid hash meta length: %d", len(b)))
+	}
+	return HashMeta{Len: int64(binary.BigEndian.Uint64(b))}, nil //nolint:gosec
+}
+
+// MarshalHashMetaDelta encodes HashMetaDelta into a fixed 8-byte binary format.
+func MarshalHashMetaDelta(d HashMetaDelta) []byte {
+	buf := make([]byte, hashMetaSizeBytes)
+	binary.BigEndian.PutUint64(buf, uint64(d.LenDelta)) //nolint:gosec
+	return buf
+}
+
+// UnmarshalHashMetaDelta decodes HashMetaDelta from the fixed 8-byte binary format.
+func UnmarshalHashMetaDelta(b []byte) (HashMetaDelta, error) {
+	if len(b) != hashMetaSizeBytes {
+		return HashMetaDelta{}, errors.WithStack(errors.Newf("invalid hash meta delta length: %d", len(b)))
+	}
+	return HashMetaDelta{LenDelta: int64(binary.BigEndian.Uint64(b))}, nil //nolint:gosec
+}
+
+// HashMetaKey builds the metadata key for a hash.
+func HashMetaKey(userKey []byte) []byte {
+	buf := make([]byte, 0, len(HashMetaPrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, HashMetaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// HashFieldKey builds the per-field key for a hash field.
+func HashFieldKey(userKey, fieldName []byte) []byte {
+	buf := make([]byte, 0, len(HashFieldPrefix)+wideColKeyLenSize+len(userKey)+len(fieldName))
+	buf = append(buf, HashFieldPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	buf = append(buf, fieldName...)
+	return buf
+}
+
+// HashFieldScanPrefix returns the prefix to scan all fields of a hash.
+func HashFieldScanPrefix(userKey []byte) []byte {
+	buf := make([]byte, 0, len(HashFieldPrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, HashFieldPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// ExtractHashFieldName extracts the field name from a hash field key.
+func ExtractHashFieldName(key, userKey []byte) []byte {
+	prefix := HashFieldScanPrefix(userKey)
+	if !bytes.HasPrefix(key, prefix) {
+		return nil
+	}
+	return key[len(prefix):]
+}
+
+// HashMetaDeltaKey builds the delta key for a hash metadata change.
+func HashMetaDeltaKey(userKey []byte, commitTS uint64, seqInTxn uint32) []byte {
+	buf := make([]byte, 0, len(HashMetaDeltaPrefix)+wideColKeyLenSize+len(userKey)+deltaKeyTSSize+deltaKeySeqSize)
+	buf = append(buf, HashMetaDeltaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], commitTS)
+	buf = append(buf, ts[:]...)
+	var seq [4]byte
+	binary.BigEndian.PutUint32(seq[:], seqInTxn)
+	buf = append(buf, seq[:]...)
+	return buf
+}
+
+// HashMetaDeltaScanPrefix returns the prefix to scan all delta keys for a hash.
+func HashMetaDeltaScanPrefix(userKey []byte) []byte {
+	buf := make([]byte, 0, len(HashMetaDeltaPrefix)+4+len(userKey))
+	buf = append(buf, HashMetaDeltaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// IsHashMetaKey reports whether the key is a hash metadata key.
+func IsHashMetaKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(HashMetaPrefix))
+}
+
+// IsHashFieldKey reports whether the key is a hash field key.
+func IsHashFieldKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(HashFieldPrefix))
+}
+
+// IsHashMetaDeltaKey reports whether the key is a hash metadata delta key.
+func IsHashMetaDeltaKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(HashMetaDeltaPrefix))
+}
+
+// ExtractHashUserKeyFromMeta extracts the logical user key from a hash meta key.
+func ExtractHashUserKeyFromMeta(key []byte) []byte {
+	trimmed := bytes.TrimPrefix(key, []byte(HashMetaPrefix))
+	if len(trimmed) < wideColKeyLenSize {
+		return nil
+	}
+	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
+	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
+		return nil
+	}
+	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+}
+
+// ExtractHashUserKeyFromField extracts the logical user key from a hash field key.
+func ExtractHashUserKeyFromField(key []byte) []byte {
+	trimmed := bytes.TrimPrefix(key, []byte(HashFieldPrefix))
+	if len(trimmed) < wideColKeyLenSize {
+		return nil
+	}
+	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
+	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
+		return nil
+	}
+	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+}
+
+// ExtractHashUserKeyFromDelta extracts the logical user key from a hash delta key.
+func ExtractHashUserKeyFromDelta(key []byte) []byte {
+	trimmed := bytes.TrimPrefix(key, []byte(HashMetaDeltaPrefix))
+	minLen := wideColKeyLenSize + deltaKeyTSSize + deltaKeySeqSize
+	if len(trimmed) < minLen {
+		return nil
+	}
+	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
+	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen+uint32(deltaKeyTSSize+deltaKeySeqSize) { //nolint:gosec // constants fit in uint32
+		return nil
+	}
+	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+}

--- a/store/list_helpers.go
+++ b/store/list_helpers.go
@@ -8,6 +8,167 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// Delta/Claim key constants.
+const (
+	// ListMetaDeltaPrefix is the prefix for all list metadata delta keys.
+	// Layout: !lst|meta|d|<userKeyLen(4)><userKey><commitTS(8)><seqInTxn(4)>
+	ListMetaDeltaPrefix = "!lst|meta|d|"
+
+	// ListClaimPrefix is the prefix for list claim keys used by POP operations.
+	// Layout: !lst|claim|<userKeyLen(4)><userKey><seq(8-byte sortable)>
+	ListClaimPrefix = "!lst|claim|"
+
+	// MaxDeltaScanLimit is the hard limit on delta scan results.
+	// resolveListMeta returns ErrDeltaScanTruncated if this is reached.
+	MaxDeltaScanLimit = 256
+
+	// wideColKeyLenSize is the number of bytes used to encode the user-key
+	// length as a big-endian uint32 in wide-column storage keys.
+	wideColKeyLenSize = 4
+
+	// deltaKeyTSSize is the number of bytes used for the commit-timestamp
+	// field (uint64) in wide-column delta keys.
+	deltaKeyTSSize = 8
+
+	// deltaKeySeqSize is the number of bytes used for the seqInTxn field
+	// (uint32) in wide-column delta keys.
+	deltaKeySeqSize = 4
+
+	// listDeltaSizeBytes is the fixed binary size of a ListMetaDelta (two int64 fields).
+	listDeltaSizeBytes = 16
+)
+
+// ListMetaDelta holds the signed deltas applied by a single PUSH/POP operation.
+type ListMetaDelta struct {
+	HeadDelta int64
+	LenDelta  int64
+}
+
+// MarshalListMetaDelta encodes a ListMetaDelta into a fixed 16-byte binary format.
+func MarshalListMetaDelta(d ListMetaDelta) []byte {
+	buf := make([]byte, listDeltaSizeBytes)
+	binary.BigEndian.PutUint64(buf[0:8], uint64(d.HeadDelta)) //nolint:gosec
+	binary.BigEndian.PutUint64(buf[8:16], uint64(d.LenDelta)) //nolint:gosec
+	return buf
+}
+
+// UnmarshalListMetaDelta decodes a ListMetaDelta from the fixed 16-byte binary format.
+func UnmarshalListMetaDelta(b []byte) (ListMetaDelta, error) {
+	if len(b) != listDeltaSizeBytes {
+		return ListMetaDelta{}, errors.WithStack(errors.Newf("invalid list meta delta length: %d", len(b)))
+	}
+	return ListMetaDelta{
+		HeadDelta: int64(binary.BigEndian.Uint64(b[0:8])),  //nolint:gosec
+		LenDelta:  int64(binary.BigEndian.Uint64(b[8:16])), //nolint:gosec
+	}, nil
+}
+
+// ListMetaDeltaKey builds the delta key for a list: prefix + 4-byte userKeyLen + userKey + 8-byte commitTS + 4-byte seqInTxn.
+func ListMetaDeltaKey(userKey []byte, commitTS uint64, seqInTxn uint32) []byte {
+	buf := make([]byte, 0, len(ListMetaDeltaPrefix)+wideColKeyLenSize+len(userKey)+deltaKeyTSSize+deltaKeySeqSize)
+	buf = append(buf, ListMetaDeltaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], commitTS)
+	buf = append(buf, ts[:]...)
+	var seq [4]byte
+	binary.BigEndian.PutUint32(seq[:], seqInTxn)
+	buf = append(buf, seq[:]...)
+	return buf
+}
+
+// ListMetaDeltaScanPrefix returns the prefix used to scan all delta keys for a userKey.
+func ListMetaDeltaScanPrefix(userKey []byte) []byte {
+	buf := make([]byte, 0, len(ListMetaDeltaPrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, ListMetaDeltaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// ListClaimKey builds the claim key for a list item at the given sequence number.
+func ListClaimKey(userKey []byte, seq int64) []byte {
+	var raw [8]byte
+	encodeSortableInt64(raw[:], seq)
+	buf := make([]byte, 0, len(ListClaimPrefix)+wideColKeyLenSize+len(userKey)+sortableInt64Bytes)
+	buf = append(buf, ListClaimPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	buf = append(buf, raw[:]...)
+	return buf
+}
+
+// ListClaimScanPrefix returns the prefix used to scan all claim keys for a userKey.
+func ListClaimScanPrefix(userKey []byte) []byte {
+	buf := make([]byte, 0, len(ListClaimPrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, ListClaimPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// IsListMetaDeltaKey reports whether the key is a list metadata delta key.
+func IsListMetaDeltaKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(ListMetaDeltaPrefix))
+}
+
+// IsListClaimKey reports whether the key is a list claim key.
+func IsListClaimKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(ListClaimPrefix))
+}
+
+// ExtractListUserKeyFromDelta extracts the logical user key from a list delta key.
+func ExtractListUserKeyFromDelta(key []byte) []byte {
+	trimmed := bytes.TrimPrefix(key, []byte(ListMetaDeltaPrefix))
+	if len(trimmed) < wideColKeyLenSize+deltaKeyTSSize+deltaKeySeqSize {
+		return nil
+	}
+	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
+	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen+uint32(deltaKeyTSSize+deltaKeySeqSize) { //nolint:gosec // constants fit in uint32
+		return nil
+	}
+	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+}
+
+// ExtractListUserKeyFromClaim extracts the logical user key from a list claim key.
+func ExtractListUserKeyFromClaim(key []byte) []byte {
+	trimmed := bytes.TrimPrefix(key, []byte(ListClaimPrefix))
+	if len(trimmed) < wideColKeyLenSize+sortableInt64Bytes {
+		return nil
+	}
+	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
+	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen+uint32(sortableInt64Bytes) { //nolint:gosec // constants fit in uint32
+		return nil
+	}
+	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+}
+
+// PrefixScanEnd returns the exclusive end key for a prefix scan.
+// It increments the last byte of the prefix; if overflow occurs (all 0xFF),
+// it returns a nil slice which callers must interpret as "scan to end of keyspace".
+func PrefixScanEnd(prefix []byte) []byte {
+	if len(prefix) == 0 {
+		return nil
+	}
+	end := bytes.Clone(prefix)
+	for i := len(end) - 1; i >= 0; i-- {
+		end[i]++
+		if end[i] != 0 {
+			return end
+		}
+	}
+	return nil // overflow: all bytes were 0xFF
+}
+
 // Wide-column style list storage using per-element keys.
 // Item keys: !lst|itm|<userKey><seq(8-byte sortable binary)>
 // Meta key : !lst|meta|<userKey> -> [Head(8)][Tail(8)][Len(8)]

--- a/store/set_helpers.go
+++ b/store/set_helpers.go
@@ -1,0 +1,189 @@
+//nolint:dupl // Hash and Set helpers are intentionally parallel implementations for distinct types.
+package store
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Set wide-column key layout:
+//
+//	Base Metadata: !st|meta|<userKeyLen(4)><userKey>                 → [Len(8)]
+//	Member Key:    !st|mem|<userKeyLen(4)><userKey><member>           → (empty value)
+//	Delta Key:     !st|meta|d|<userKeyLen(4)><userKey><commitTS(8)><seqInTxn(4)> → [LenDelta(8)]
+const (
+	SetMetaPrefix      = "!st|meta|"
+	SetMemberPrefix    = "!st|mem|"
+	SetMetaDeltaPrefix = "!st|meta|d|"
+
+	// setMetaSizeBytes is the fixed binary size of a SetMeta or SetMetaDelta (one int64).
+	setMetaSizeBytes = 8
+)
+
+// SetMeta is the base metadata for a set collection.
+type SetMeta struct {
+	Len int64
+}
+
+// SetMetaDelta holds a signed change in member count.
+type SetMetaDelta struct {
+	LenDelta int64
+}
+
+// MarshalSetMeta encodes SetMeta into a fixed 8-byte binary format.
+func MarshalSetMeta(m SetMeta) []byte {
+	buf := make([]byte, setMetaSizeBytes)
+	binary.BigEndian.PutUint64(buf, uint64(m.Len)) //nolint:gosec
+	return buf
+}
+
+// UnmarshalSetMeta decodes SetMeta from the fixed 8-byte binary format.
+func UnmarshalSetMeta(b []byte) (SetMeta, error) {
+	if len(b) != setMetaSizeBytes {
+		return SetMeta{}, errors.WithStack(errors.Newf("invalid set meta length: %d", len(b)))
+	}
+	return SetMeta{Len: int64(binary.BigEndian.Uint64(b))}, nil //nolint:gosec
+}
+
+// MarshalSetMetaDelta encodes SetMetaDelta into a fixed 8-byte binary format.
+func MarshalSetMetaDelta(d SetMetaDelta) []byte {
+	buf := make([]byte, setMetaSizeBytes)
+	binary.BigEndian.PutUint64(buf, uint64(d.LenDelta)) //nolint:gosec
+	return buf
+}
+
+// UnmarshalSetMetaDelta decodes SetMetaDelta from the fixed 8-byte binary format.
+func UnmarshalSetMetaDelta(b []byte) (SetMetaDelta, error) {
+	if len(b) != setMetaSizeBytes {
+		return SetMetaDelta{}, errors.WithStack(errors.Newf("invalid set meta delta length: %d", len(b)))
+	}
+	return SetMetaDelta{LenDelta: int64(binary.BigEndian.Uint64(b))}, nil //nolint:gosec
+}
+
+// SetMetaKey builds the metadata key for a set.
+func SetMetaKey(userKey []byte) []byte {
+	buf := make([]byte, 0, len(SetMetaPrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, SetMetaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// SetMemberKey builds the per-member key for a set member.
+func SetMemberKey(userKey, member []byte) []byte {
+	buf := make([]byte, 0, len(SetMemberPrefix)+wideColKeyLenSize+len(userKey)+len(member))
+	buf = append(buf, SetMemberPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	buf = append(buf, member...)
+	return buf
+}
+
+// SetMemberScanPrefix returns the prefix to scan all members of a set.
+func SetMemberScanPrefix(userKey []byte) []byte {
+	buf := make([]byte, 0, len(SetMemberPrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, SetMemberPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// ExtractSetMemberName extracts the member name from a set member key.
+func ExtractSetMemberName(key, userKey []byte) []byte {
+	prefix := SetMemberScanPrefix(userKey)
+	if !bytes.HasPrefix(key, prefix) {
+		return nil
+	}
+	return key[len(prefix):]
+}
+
+// SetMetaDeltaKey builds the delta key for a set metadata change.
+func SetMetaDeltaKey(userKey []byte, commitTS uint64, seqInTxn uint32) []byte {
+	buf := make([]byte, 0, len(SetMetaDeltaPrefix)+wideColKeyLenSize+len(userKey)+deltaKeyTSSize+deltaKeySeqSize)
+	buf = append(buf, SetMetaDeltaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], commitTS)
+	buf = append(buf, ts[:]...)
+	var seq [4]byte
+	binary.BigEndian.PutUint32(seq[:], seqInTxn)
+	buf = append(buf, seq[:]...)
+	return buf
+}
+
+// SetMetaDeltaScanPrefix returns the prefix to scan all delta keys for a set.
+func SetMetaDeltaScanPrefix(userKey []byte) []byte {
+	buf := make([]byte, 0, len(SetMetaDeltaPrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, SetMetaDeltaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// IsSetMetaKey reports whether the key is a set metadata key.
+func IsSetMetaKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(SetMetaPrefix))
+}
+
+// IsSetMemberKey reports whether the key is a set member key.
+func IsSetMemberKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(SetMemberPrefix))
+}
+
+// IsSetMetaDeltaKey reports whether the key is a set metadata delta key.
+func IsSetMetaDeltaKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(SetMetaDeltaPrefix))
+}
+
+// ExtractSetUserKeyFromMeta extracts the logical user key from a set meta key.
+func ExtractSetUserKeyFromMeta(key []byte) []byte {
+	trimmed := bytes.TrimPrefix(key, []byte(SetMetaPrefix))
+	if len(trimmed) < wideColKeyLenSize {
+		return nil
+	}
+	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
+	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
+		return nil
+	}
+	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+}
+
+// ExtractSetUserKeyFromMember extracts the logical user key from a set member key.
+func ExtractSetUserKeyFromMember(key []byte) []byte {
+	trimmed := bytes.TrimPrefix(key, []byte(SetMemberPrefix))
+	if len(trimmed) < wideColKeyLenSize {
+		return nil
+	}
+	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
+	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
+		return nil
+	}
+	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+}
+
+// ExtractSetUserKeyFromDelta extracts the logical user key from a set delta key.
+func ExtractSetUserKeyFromDelta(key []byte) []byte {
+	trimmed := bytes.TrimPrefix(key, []byte(SetMetaDeltaPrefix))
+	minLen := wideColKeyLenSize + deltaKeyTSSize + deltaKeySeqSize
+	if len(trimmed) < minLen {
+		return nil
+	}
+	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
+	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen+uint32(deltaKeyTSSize+deltaKeySeqSize) { //nolint:gosec // constants fit in uint32
+		return nil
+	}
+	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+}

--- a/store/zset_helpers.go
+++ b/store/zset_helpers.go
@@ -1,0 +1,272 @@
+package store
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+
+	"github.com/cockroachdb/errors"
+)
+
+// ZSet wide-column key layout:
+//
+//	Base Metadata: !zs|meta|<userKeyLen(4)><userKey>                               → [Len(8)]
+//	Member Key:    !zs|mem|<userKeyLen(4)><userKey><member>                         → [Score(8)] IEEE 754
+//	Score Index:   !zs|scr|<userKeyLen(4)><userKey><sortableScore(8)><member>       → (empty)
+//	Delta Key:     !zs|meta|d|<userKeyLen(4)><userKey><commitTS(8)><seqInTxn(4)>   → [LenDelta(8)]
+const (
+	ZSetMetaPrefix      = "!zs|meta|"
+	ZSetMemberPrefix    = "!zs|mem|"
+	ZSetScorePrefix     = "!zs|scr|"
+	ZSetMetaDeltaPrefix = "!zs|meta|d|"
+
+	// zsetMetaSizeBytes is the fixed binary size of a ZSetMeta, ZSetMetaDelta, or ZSet score (one int64/float64).
+	zsetMetaSizeBytes = 8
+)
+
+// ZSetMeta is the base metadata for a sorted set collection.
+type ZSetMeta struct {
+	Len int64
+}
+
+// ZSetMetaDelta holds a signed change in member count.
+type ZSetMetaDelta struct {
+	LenDelta int64
+}
+
+// MarshalZSetMeta encodes ZSetMeta into a fixed 8-byte binary format.
+func MarshalZSetMeta(m ZSetMeta) []byte {
+	buf := make([]byte, zsetMetaSizeBytes)
+	binary.BigEndian.PutUint64(buf, uint64(m.Len)) //nolint:gosec
+	return buf
+}
+
+// UnmarshalZSetMeta decodes ZSetMeta from the fixed 8-byte binary format.
+func UnmarshalZSetMeta(b []byte) (ZSetMeta, error) {
+	if len(b) != zsetMetaSizeBytes {
+		return ZSetMeta{}, errors.WithStack(errors.Newf("invalid zset meta length: %d", len(b)))
+	}
+	return ZSetMeta{Len: int64(binary.BigEndian.Uint64(b))}, nil //nolint:gosec
+}
+
+// MarshalZSetMetaDelta encodes ZSetMetaDelta into a fixed 8-byte binary format.
+func MarshalZSetMetaDelta(d ZSetMetaDelta) []byte {
+	buf := make([]byte, zsetMetaSizeBytes)
+	binary.BigEndian.PutUint64(buf, uint64(d.LenDelta)) //nolint:gosec
+	return buf
+}
+
+// UnmarshalZSetMetaDelta decodes ZSetMetaDelta from the fixed 8-byte binary format.
+func UnmarshalZSetMetaDelta(b []byte) (ZSetMetaDelta, error) {
+	if len(b) != zsetMetaSizeBytes {
+		return ZSetMetaDelta{}, errors.WithStack(errors.Newf("invalid zset meta delta length: %d", len(b)))
+	}
+	return ZSetMetaDelta{LenDelta: int64(binary.BigEndian.Uint64(b))}, nil //nolint:gosec
+}
+
+// MarshalZSetScore encodes a float64 score in IEEE 754 big-endian format.
+func MarshalZSetScore(score float64) []byte {
+	buf := make([]byte, zsetMetaSizeBytes)
+	binary.BigEndian.PutUint64(buf, math.Float64bits(score))
+	return buf
+}
+
+// UnmarshalZSetScore decodes a float64 score from IEEE 754 big-endian format.
+func UnmarshalZSetScore(b []byte) (float64, error) {
+	if len(b) != zsetMetaSizeBytes {
+		return 0, errors.WithStack(errors.Newf("invalid zset score length: %d", len(b)))
+	}
+	return math.Float64frombits(binary.BigEndian.Uint64(b)), nil
+}
+
+// EncodeSortableFloat64 encodes a float64 into a sortable 8-byte representation.
+// For positive floats: XOR the sign bit to make them sort above negative.
+// For negative floats: XOR all bits to reverse the order.
+// This produces a byte sequence that sorts correctly with standard byte comparison.
+func EncodeSortableFloat64(f float64) [8]byte {
+	bits := math.Float64bits(f)
+	if bits>>63 == 0 {
+		// Positive (or +0): flip the sign bit
+		bits ^= 0x8000000000000000
+	} else {
+		// Negative (or -0): flip all bits
+		bits ^= 0xFFFFFFFFFFFFFFFF
+	}
+	var b [8]byte
+	binary.BigEndian.PutUint64(b[:], bits)
+	return b
+}
+
+// DecodeSortableFloat64 decodes a sortable 8-byte representation back to float64.
+func DecodeSortableFloat64(b [8]byte) float64 {
+	bits := binary.BigEndian.Uint64(b[:])
+	if bits>>63 == 1 {
+		// Was positive: flip only the sign bit back
+		bits ^= 0x8000000000000000
+	} else {
+		// Was negative: flip all bits back
+		bits ^= 0xFFFFFFFFFFFFFFFF
+	}
+	return math.Float64frombits(bits)
+}
+
+// ZSetMetaKey builds the metadata key for a sorted set.
+func ZSetMetaKey(userKey []byte) []byte {
+	buf := make([]byte, 0, len(ZSetMetaPrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, ZSetMetaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// ZSetMemberKey builds the per-member key storing the score for a sorted set.
+func ZSetMemberKey(userKey, member []byte) []byte {
+	buf := make([]byte, 0, len(ZSetMemberPrefix)+wideColKeyLenSize+len(userKey)+len(member))
+	buf = append(buf, ZSetMemberPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	buf = append(buf, member...)
+	return buf
+}
+
+// ZSetMemberScanPrefix returns the prefix to scan all members of a sorted set.
+func ZSetMemberScanPrefix(userKey []byte) []byte {
+	buf := make([]byte, 0, len(ZSetMemberPrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, ZSetMemberPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// ExtractZSetMemberName extracts the member name from a zset member key.
+func ExtractZSetMemberName(key, userKey []byte) []byte {
+	prefix := ZSetMemberScanPrefix(userKey)
+	if !bytes.HasPrefix(key, prefix) {
+		return nil
+	}
+	return key[len(prefix):]
+}
+
+// ZSetScoreKey builds the score index key for a sorted set entry.
+// Layout: !zs|scr|<userKeyLen(4)><userKey><sortableScore(8)><member>
+func ZSetScoreKey(userKey []byte, score float64, member []byte) []byte {
+	sortable := EncodeSortableFloat64(score)
+	buf := make([]byte, 0, len(ZSetScorePrefix)+wideColKeyLenSize+len(userKey)+zsetMetaSizeBytes+len(member))
+	buf = append(buf, ZSetScorePrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	buf = append(buf, sortable[:]...)
+	buf = append(buf, member...)
+	return buf
+}
+
+// ZSetScoreScanPrefix returns the prefix to scan all score index keys for a sorted set.
+func ZSetScoreScanPrefix(userKey []byte) []byte {
+	buf := make([]byte, 0, len(ZSetScorePrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, ZSetScorePrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// ZSetScoreRangeScanPrefix returns the prefix for scanning scores in [minScore, maxScore].
+func ZSetScoreRangeScanPrefix(userKey []byte, score float64) []byte {
+	sortable := EncodeSortableFloat64(score)
+	buf := make([]byte, 0, len(ZSetScorePrefix)+wideColKeyLenSize+len(userKey)+zsetMetaSizeBytes)
+	buf = append(buf, ZSetScorePrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	buf = append(buf, sortable[:]...)
+	return buf
+}
+
+// ExtractZSetScoreAndMember extracts the score and member name from a zset score index key.
+func ExtractZSetScoreAndMember(key, userKey []byte) (score float64, member []byte, ok bool) {
+	prefix := ZSetScoreScanPrefix(userKey)
+	if !bytes.HasPrefix(key, prefix) {
+		return 0, nil, false
+	}
+	rest := key[len(prefix):]
+	if len(rest) < zsetMetaSizeBytes {
+		return 0, nil, false
+	}
+	var sortable [zsetMetaSizeBytes]byte
+	copy(sortable[:], rest[:zsetMetaSizeBytes])
+	score = DecodeSortableFloat64(sortable)
+	member = rest[zsetMetaSizeBytes:]
+	return score, member, true
+}
+
+// ZSetMetaDeltaKey builds the delta key for a sorted set metadata change.
+func ZSetMetaDeltaKey(userKey []byte, commitTS uint64, seqInTxn uint32) []byte {
+	buf := make([]byte, 0, len(ZSetMetaDeltaPrefix)+wideColKeyLenSize+len(userKey)+deltaKeyTSSize+deltaKeySeqSize)
+	buf = append(buf, ZSetMetaDeltaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], commitTS)
+	buf = append(buf, ts[:]...)
+	var seq [4]byte
+	binary.BigEndian.PutUint32(seq[:], seqInTxn)
+	buf = append(buf, seq[:]...)
+	return buf
+}
+
+// ZSetMetaDeltaScanPrefix returns the prefix to scan all delta keys for a sorted set.
+func ZSetMetaDeltaScanPrefix(userKey []byte) []byte {
+	buf := make([]byte, 0, len(ZSetMetaDeltaPrefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, ZSetMetaDeltaPrefix...)
+	var kl [4]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
+	buf = append(buf, kl[:]...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+// IsZSetMetaKey reports whether the key is a sorted set metadata key.
+func IsZSetMetaKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(ZSetMetaPrefix))
+}
+
+// IsZSetMemberKey reports whether the key is a sorted set member key.
+func IsZSetMemberKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(ZSetMemberPrefix))
+}
+
+// IsZSetScoreKey reports whether the key is a sorted set score index key.
+func IsZSetScoreKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(ZSetScorePrefix))
+}
+
+// IsZSetMetaDeltaKey reports whether the key is a sorted set metadata delta key.
+func IsZSetMetaDeltaKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(ZSetMetaDeltaPrefix))
+}
+
+// ExtractZSetUserKeyFromDelta extracts the logical user key from a zset delta key.
+func ExtractZSetUserKeyFromDelta(key []byte) []byte {
+	trimmed := bytes.TrimPrefix(key, []byte(ZSetMetaDeltaPrefix))
+	minLen := wideColKeyLenSize + deltaKeyTSSize + deltaKeySeqSize
+	if len(trimmed) < minLen {
+		return nil
+	}
+	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
+	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen+uint32(deltaKeyTSSize+deltaKeySeqSize) { //nolint:gosec // constants fit in uint32
+		return nil
+	}
+	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+}

--- a/store/zset_helpers.go
+++ b/store/zset_helpers.go
@@ -84,6 +84,11 @@ func UnmarshalZSetScore(b []byte) (float64, error) {
 // For negative floats: XOR all bits to reverse the order.
 // This produces a byte sequence that sorts correctly with standard byte comparison.
 func EncodeSortableFloat64(f float64) [8]byte {
+	// Normalize -0.0 → +0.0 so both map to the same score key, matching
+	// Redis's treatment of 0 and -0 as equal in sorted sets.
+	if f == 0 {
+		f = 0.0
+	}
 	bits := math.Float64bits(f)
 	if bits>>63 == 0 {
 		// Positive (or +0): flip the sign bit

--- a/store/zset_helpers.go
+++ b/store/zset_helpers.go
@@ -270,3 +270,42 @@ func ExtractZSetUserKeyFromDelta(key []byte) []byte {
 	}
 	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
 }
+
+// ExtractZSetUserKeyFromMeta extracts the logical user key from a zset meta key.
+func ExtractZSetUserKeyFromMeta(key []byte) []byte {
+	trimmed := bytes.TrimPrefix(key, []byte(ZSetMetaPrefix))
+	if len(trimmed) < wideColKeyLenSize {
+		return nil
+	}
+	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
+	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
+		return nil
+	}
+	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+}
+
+// ExtractZSetUserKeyFromMember extracts the logical user key from a zset member key.
+func ExtractZSetUserKeyFromMember(key []byte) []byte {
+	trimmed := bytes.TrimPrefix(key, []byte(ZSetMemberPrefix))
+	if len(trimmed) < wideColKeyLenSize {
+		return nil
+	}
+	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
+	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
+		return nil
+	}
+	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+}
+
+// ExtractZSetUserKeyFromScore extracts the logical user key from a zset score index key.
+func ExtractZSetUserKeyFromScore(key []byte) []byte {
+	trimmed := bytes.TrimPrefix(key, []byte(ZSetScorePrefix))
+	if len(trimmed) < wideColKeyLenSize {
+		return nil
+	}
+	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
+	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
+		return nil
+	}
+	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+}


### PR DESCRIPTION
## Summary

Phase 2 of the `collection-metadata-delta` series. Implements wide-column storage and delta metadata for Hash, Set, and ZSet collection types, following the same pattern established for List in Phase 1.

- **Hash** (`!hs|fld|`, `!hs|meta|`, `!hs|meta|d|`): per-field wide-column keys, migration-on-write from legacy blob, `HSET`/`HGET`/`HGETALL`/`HLEN`/`HDEL` rewritten to wide-column
- **Set** (`!st|mem|`, `!st|meta|`, `!st|meta|d|`): per-member wide-column keys, `SADD`/`SMEMBERS`/`SCARD`/`SREM` rewritten
- **ZSet** (`!zs|mem|`, `!zs|scr|`, `!zs|meta|`, `!zs|meta|d|`): per-member + score-index wide-column keys, `ZADD`/`ZINCRBY`/`ZCARD`/`BZPOPMIN` rewritten
- `store/hash_helpers.go`, `store/set_helpers.go`, `store/zset_helpers.go`: new helper packages with marshal/unmarshal, key builders, and Extract functions
- `normalizeWideColumnKey` / `wideColumnVisibleUserKey`: extended to handle all four collection types
- `deleteLogicalKeyElems`: delegates ZSet cleanup to `deleteZSetWideColumnElems`
- MULTI/EXEC `zsetTxnState`: tracks `origMembers` + `isWide` for minimal diff computation
- Legacy blobs are atomically migrated to wide-column on first write; legacy read path retained for backwards compatibility

## Test plan

- [ ] `go test ./adapter/... -timeout 120s` passes
- [ ] `go test ./store/...` passes
- [ ] `golangci-lint run ./adapter/... ./store/...` returns 0 issues
- [ ] `TestRedisZSetLegacyJSONReadThenRewriteToProto` verifies migration-on-write deletes legacy blob and creates wide-column keys
- [ ] `TestRedis_BullMQDirectCommands` (BZPOPMIN) verifies pop correctly deletes member+score keys