### PR TITLE
feat(phase-3): implement LPOP/RPOP claim mechanism for conflict-free list pops

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1345,8 +1345,12 @@ func redisVisibleUserKey(key []byte) []byte {
 	if bytes.HasPrefix(key, redisTxnKeyPrefix) || isRedisTTLKey(key) {
 		return nil
 	}
-	if store.IsListMetaKey(key) || store.IsListItemKey(key) {
+	// List item keys are visible; meta, delta, and claim keys are internal-only.
+	if store.IsListItemKey(key) {
 		return store.ExtractListUserKey(key)
+	}
+	if store.IsListMetaKey(key) || store.IsListMetaDeltaKey(key) || store.IsListClaimKey(key) {
+		return nil
 	}
 	if userKey, isWide := wideColumnVisibleUserKey(key); isWide {
 		return userKey
@@ -2514,6 +2518,131 @@ func (r *RedisServer) buildLPushOps(meta store.ListMeta, key []byte, values [][]
 
 func (r *RedisServer) listLPush(ctx context.Context, key []byte, values [][]byte) (int64, error) {
 	return r.listPushCore(ctx, key, values, r.buildLPushOps)
+}
+
+// listPopClaim implements LPOP (left=true) or RPOP (left=false) using the
+// Claim pattern to avoid write-write conflicts on the list metadata key.
+// For each item popped it emits:
+//   - Del(listItemKey) — removes the item value
+//   - Put(listClaimKey, empty) — uniqueness guard; conflicts if another txn
+//     claims the same sequence number concurrently
+//
+// A single ListMetaDelta with {HeadDelta, LenDelta} is emitted for the whole batch.
+//
+// Returns the popped values (len ≤ count) or nil if the list does not exist.
+func (r *RedisServer) buildListPopElems(ctx context.Context, key []byte, meta store.ListMeta, n int64, left bool, readTS uint64) ([]string, []*kv.Elem[kv.OP], error) {
+	// Each item: Del(item) + Put(claim); capacity leaves room for the delta key appended by the caller.
+	elems := make([]*kv.Elem[kv.OP], 0, int(n)*2+1) //nolint:mnd // 2 ops per item (del item + put claim)
+	values := make([]string, 0, int(n))
+
+	for i := int64(0); i < n; i++ {
+		var seq int64
+		if left {
+			seq = meta.Head + i
+		} else {
+			seq = meta.Tail - 1 - i
+		}
+		itemKey := listItemKey(key, seq)
+		raw, getErr := r.store.GetAt(ctx, itemKey, readTS)
+		if errors.Is(getErr, store.ErrKeyNotFound) {
+			// Sparse list — stop here.
+			break
+		}
+		if getErr != nil {
+			return nil, nil, errors.WithStack(getErr)
+		}
+		values = append(values, string(raw))
+		elems = append(elems,
+			&kv.Elem[kv.OP]{Op: kv.Del, Key: itemKey},
+			&kv.Elem[kv.OP]{Op: kv.Put, Key: store.ListClaimKey(key, seq), Value: []byte{}},
+		)
+	}
+	return values, elems, nil
+}
+
+// resolveListPopMeta returns the list metadata for a pop operation.
+// Returns (meta, true, nil) when the list exists and is non-empty,
+// (zero, false, nil) when the key does not exist or the list is empty,
+// and (zero, false, err) on error (including wrong-type error).
+func (r *RedisServer) resolveListPopMeta(ctx context.Context, key []byte, readTS uint64) (store.ListMeta, bool, error) {
+	typ, typErr := r.keyTypeAt(context.Background(), key, readTS)
+	if typErr != nil {
+		return store.ListMeta{}, false, typErr
+	}
+	if typ == redisTypeNone {
+		return store.ListMeta{}, false, nil
+	}
+	if typ != redisTypeList {
+		return store.ListMeta{}, false, wrongTypeError()
+	}
+	meta, exists, metaErr := r.resolveListMeta(ctx, key, readTS)
+	if metaErr != nil {
+		return store.ListMeta{}, false, metaErr
+	}
+	if !exists || meta.Len == 0 {
+		return store.ListMeta{}, false, nil
+	}
+	return meta, true, nil
+}
+
+func (r *RedisServer) listPopClaim(ctx context.Context, key []byte, count int, left bool) ([]string, error) {
+	if count <= 0 {
+		return nil, nil
+	}
+
+	var popped []string
+	err := r.retryRedisWrite(ctx, func() error {
+		readTS := r.readTS()
+		meta, ok, metaErr := r.resolveListPopMeta(ctx, key, readTS)
+		if metaErr != nil {
+			return metaErr
+		}
+		if !ok {
+			popped = nil
+			return nil
+		}
+
+		n := int64(count)
+		if n > meta.Len {
+			n = meta.Len
+		}
+
+		values, elems, buildErr := r.buildListPopElems(ctx, key, meta, n, left, readTS)
+		if buildErr != nil {
+			return buildErr
+		}
+
+		n = int64(len(values))
+		if n == 0 {
+			popped = nil
+			return nil
+		}
+
+		commitTS := r.coordinator.Clock().Next()
+		var headDelta int64
+		if left {
+			headDelta = n // head advances by n for LPOP
+		}
+		delta := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: headDelta, LenDelta: -n})
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.ListMetaDeltaKey(key, commitTS, 0),
+			Value: delta,
+		})
+
+		_, dispErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+			IsTxn:    true,
+			StartTS:  normalizeStartTS(readTS),
+			CommitTS: commitTS,
+			Elems:    elems,
+		})
+		if dispErr != nil {
+			return errors.WithStack(dispErr)
+		}
+		popped = values
+		return nil
+	})
+	return popped, err
 }
 
 func (r *RedisServer) fetchListRange(ctx context.Context, key []byte, meta store.ListMeta, startIdx, endIdx int64, readTS uint64) ([]string, error) {

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -2544,18 +2544,16 @@ func (r *RedisServer) buildListPopElems(ctx context.Context, key []byte, meta st
 		}
 		itemKey := listItemKey(key, seq)
 		raw, getErr := r.store.GetAt(ctx, itemKey, readTS)
-		if errors.Is(getErr, store.ErrKeyNotFound) {
-			// Sparse list — stop here.
-			break
-		}
-		if getErr != nil {
+		if getErr != nil && !errors.Is(getErr, store.ErrKeyNotFound) {
 			return nil, nil, errors.WithStack(getErr)
 		}
-		values = append(values, string(raw))
-		elems = append(elems,
-			&kv.Elem[kv.OP]{Op: kv.Del, Key: itemKey},
-			&kv.Elem[kv.OP]{Op: kv.Put, Key: store.ListClaimKey(key, seq), Value: []byte{}},
-		)
+		if getErr == nil {
+			values = append(values, string(raw))
+			elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: itemKey})
+		}
+		// Always claim the sequence number so that Head advances past holes in
+		// sparse lists. Without this, a hole at Head would block all future pops.
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: store.ListClaimKey(key, seq), Value: []byte{}})
 	}
 	return values, elems, nil
 }
@@ -2565,7 +2563,7 @@ func (r *RedisServer) buildListPopElems(ctx context.Context, key []byte, meta st
 // (zero, false, nil) when the key does not exist or the list is empty,
 // and (zero, false, err) on error (including wrong-type error).
 func (r *RedisServer) resolveListPopMeta(ctx context.Context, key []byte, readTS uint64) (store.ListMeta, bool, error) {
-	typ, typErr := r.keyTypeAt(context.Background(), key, readTS)
+	typ, typErr := r.keyTypeAt(ctx, key, readTS)
 	if typErr != nil {
 		return store.ListMeta{}, false, typErr
 	}
@@ -2612,8 +2610,12 @@ func (r *RedisServer) listPopClaim(ctx context.Context, key []byte, count int, l
 			return buildErr
 		}
 
-		n = int64(len(values))
-		if n == 0 {
+		// n is the number of sequence positions claimed (including any holes).
+		// HeadDelta and LenDelta must use n, not len(values), so that Head
+		// advances past holes and the metadata stays consistent with Tail.
+		// The transaction must proceed even when len(values)==0 so that
+		// Head is updated past the hole and future pops are not stuck.
+		if len(elems) == 0 {
 			popped = nil
 			return nil
 		}
@@ -2621,7 +2623,7 @@ func (r *RedisServer) listPopClaim(ctx context.Context, key []byte, count int, l
 		commitTS := r.coordinator.Clock().Next()
 		var headDelta int64
 		if left {
-			headDelta = n // head advances by n for LPOP
+			headDelta = n // head advances by n positions for LPOP
 		}
 		delta := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: headDelta, LenDelta: -n})
 		elems = append(elems, &kv.Elem[kv.OP]{

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -2558,90 +2558,94 @@ func (r *RedisServer) buildListPopElems(ctx context.Context, key []byte, meta st
 	return values, elems, nil
 }
 
-// resolveListPopMeta returns the list metadata for a pop operation.
-// Returns (meta, true, nil) when the list exists and is non-empty,
-// (zero, false, nil) when the key does not exist or the list is empty,
-// and (zero, false, err) on error (including wrong-type error).
-func (r *RedisServer) resolveListPopMeta(ctx context.Context, key []byte, readTS uint64) (store.ListMeta, bool, error) {
+// checkListKeyType verifies the key is a list. Returns (keyFound, error).
+// Writes wrongTypeError if the key exists but is not a list.
+func (r *RedisServer) checkListKeyType(ctx context.Context, key []byte, readTS uint64) (found bool, err error) {
 	typ, typErr := r.keyTypeAt(ctx, key, readTS)
 	if typErr != nil {
-		return store.ListMeta{}, false, typErr
+		return false, typErr
 	}
 	if typ == redisTypeNone {
-		return store.ListMeta{}, false, nil
+		return false, nil
 	}
 	if typ != redisTypeList {
-		return store.ListMeta{}, false, wrongTypeError()
+		return false, wrongTypeError()
 	}
+	return true, nil
+}
+
+// listPopClaimOnce executes one attempt of a pop-with-claim transaction.
+// Returns (nil, nil) for a missing key, ([]string{}, nil) for an empty list,
+// and the popped values otherwise.
+func (r *RedisServer) listPopClaimOnce(ctx context.Context, key []byte, count int, left bool, readTS uint64) ([]string, error) {
+	found, typeErr := r.checkListKeyType(ctx, key, readTS)
+	if typeErr != nil || !found {
+		return nil, typeErr
+	}
+
 	meta, exists, metaErr := r.resolveListMeta(ctx, key, readTS)
 	if metaErr != nil {
-		return store.ListMeta{}, false, metaErr
+		return nil, metaErr
 	}
 	if !exists || meta.Len == 0 {
-		return store.ListMeta{}, false, nil
+		return []string{}, nil
 	}
-	return meta, true, nil
+
+	n := int64(count)
+	if n > meta.Len {
+		n = meta.Len
+	}
+
+	values, elems, buildErr := r.buildListPopElems(ctx, key, meta, n, left, readTS)
+	if buildErr != nil {
+		return nil, buildErr
+	}
+
+	// n is the number of sequence positions claimed (including any holes).
+	// HeadDelta and LenDelta must use n, not len(values), so that Head
+	// advances past holes and the metadata stays consistent with Tail.
+	commitTS := r.coordinator.Clock().Next()
+	var headDelta int64
+	if left {
+		headDelta = n // head advances by n positions for LPOP
+	}
+	delta := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: headDelta, LenDelta: -n})
+	elems = append(elems, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   store.ListMetaDeltaKey(key, commitTS, 0),
+		Value: delta,
+	})
+
+	_, dispErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+		IsTxn:    true,
+		StartTS:  normalizeStartTS(readTS),
+		CommitTS: commitTS,
+		Elems:    elems,
+	})
+	if dispErr != nil {
+		return nil, errors.WithStack(dispErr)
+	}
+	return values, nil
 }
 
 func (r *RedisServer) listPopClaim(ctx context.Context, key []byte, count int, left bool) ([]string, error) {
+	// count=0: Redis returns an empty array if the key exists as a list, nil otherwise.
 	if count <= 0 {
-		return nil, nil
+		readTS := r.readTS()
+		found, err := r.checkListKeyType(ctx, key, readTS)
+		if err != nil || !found {
+			return nil, err
+		}
+		return []string{}, nil
 	}
 
 	var popped []string
 	err := r.retryRedisWrite(ctx, func() error {
-		readTS := r.readTS()
-		meta, ok, metaErr := r.resolveListPopMeta(ctx, key, readTS)
-		if metaErr != nil {
-			return metaErr
+		result, popErr := r.listPopClaimOnce(ctx, key, count, left, r.readTS())
+		if popErr != nil {
+			return popErr
 		}
-		if !ok {
-			popped = nil
-			return nil
-		}
-
-		n := int64(count)
-		if n > meta.Len {
-			n = meta.Len
-		}
-
-		values, elems, buildErr := r.buildListPopElems(ctx, key, meta, n, left, readTS)
-		if buildErr != nil {
-			return buildErr
-		}
-
-		// n is the number of sequence positions claimed (including any holes).
-		// HeadDelta and LenDelta must use n, not len(values), so that Head
-		// advances past holes and the metadata stays consistent with Tail.
-		// The transaction must proceed even when len(values)==0 so that
-		// Head is updated past the hole and future pops are not stuck.
-		if len(elems) == 0 {
-			popped = nil
-			return nil
-		}
-
-		commitTS := r.coordinator.Clock().Next()
-		var headDelta int64
-		if left {
-			headDelta = n // head advances by n positions for LPOP
-		}
-		delta := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: headDelta, LenDelta: -n})
-		elems = append(elems, &kv.Elem[kv.OP]{
-			Op:    kv.Put,
-			Key:   store.ListMetaDeltaKey(key, commitTS, 0),
-			Value: delta,
-		})
-
-		_, dispErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
-			IsTxn:    true,
-			StartTS:  normalizeStartTS(readTS),
-			CommitTS: commitTS,
-			Elems:    elems,
-		})
-		if dispErr != nil {
-			return errors.WithStack(dispErr)
-		}
-		popped = values
+		popped = result
 		return nil
 	})
 	return popped, err

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -367,7 +367,8 @@ func (r *RedisServer) saveString(ctx context.Context, key []byte, value []byte, 
 	return r.dispatchElems(ctx, false, 0, elems)
 }
 
-// deleteListElems returns delete operations for all list keys (items, meta, deltas).
+// deleteListElems returns delete operations for all list keys: item keys, the base
+// meta key, all delta keys, and all claim keys.
 func (r *RedisServer) deleteListElems(ctx context.Context, key []byte, readTS uint64) ([]*kv.Elem[kv.OP], error) {
 	meta, listExists, err := r.resolveListMeta(ctx, key, readTS)
 	if err != nil {
@@ -381,6 +382,7 @@ func (r *RedisServer) deleteListElems(ctx context.Context, key []byte, readTS ui
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: listItemKey(key, seq)})
 	}
 	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: listMetaKey(key)})
+	// Delete all delta keys.
 	deltaPrefix := store.ListMetaDeltaScanPrefix(key)
 	deltaEnd := store.PrefixScanEnd(deltaPrefix)
 	deltaKVs, scanErr := r.store.ScanAt(ctx, deltaPrefix, deltaEnd, store.MaxDeltaScanLimit, readTS)
@@ -388,6 +390,16 @@ func (r *RedisServer) deleteListElems(ctx context.Context, key []byte, readTS ui
 		return nil, errors.WithStack(scanErr)
 	}
 	for _, pair := range deltaKVs {
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
+	}
+	// Delete all claim keys.
+	claimPrefix := store.ListClaimScanPrefix(key)
+	claimEnd := store.PrefixScanEnd(claimPrefix)
+	claimKVs, claimScanErr := r.store.ScanAt(ctx, claimPrefix, claimEnd, maxWideScanLimit, readTS)
+	if claimScanErr != nil {
+		return nil, errors.WithStack(claimScanErr)
+	}
+	for _, pair := range claimKVs {
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
 	}
 	return elems, nil

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -13,7 +13,7 @@ import (
 )
 
 // maxWideColumnItems is the maximum number of fields/members a single
-// wide-column collection (Hash, Set, or ZSet) may contain.
+// wide-column collection (Hash, Set, ZSet, or List) may contain.
 // Operations that would materialize more than this many items are rejected
 // to prevent unbounded memory growth (OOM).
 const maxWideColumnItems = 100_000
@@ -392,12 +392,17 @@ func (r *RedisServer) deleteListElems(ctx context.Context, key []byte, readTS ui
 	for _, pair := range deltaKVs {
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
 	}
-	// Delete all claim keys.
+	// Delete all claim keys. Use maxWideScanLimit to guard against OOM; a list
+	// that has accumulated more claim keys than maxWideColumnItems is too large
+	// to delete atomically and should be rejected.
 	claimPrefix := store.ListClaimScanPrefix(key)
 	claimEnd := store.PrefixScanEnd(claimPrefix)
 	claimKVs, claimScanErr := r.store.ScanAt(ctx, claimPrefix, claimEnd, maxWideScanLimit, readTS)
 	if claimScanErr != nil {
 		return nil, errors.WithStack(claimScanErr)
+	}
+	if len(claimKVs) > maxWideColumnItems {
+		return nil, errors.Wrapf(ErrCollectionTooLarge, "list %q has more than %d claim keys", key, maxWideColumnItems)
 	}
 	for _, pair := range claimKVs {
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})

--- a/adapter/redis_lua.go
+++ b/adapter/redis_lua.go
@@ -891,14 +891,58 @@ func (r *RedisServer) lpop(conn redcon.Conn, cmd redcon.Command) {
 	if r.proxyToLeader(conn, cmd, cmd.Args[1]) {
 		return
 	}
-	r.execLuaCompat(conn, cmdLPop, cmd.Args[1:])
+	r.execListPop(conn, cmd, true)
 }
 
 func (r *RedisServer) rpop(conn redcon.Conn, cmd redcon.Command) {
 	if r.proxyToLeader(conn, cmd, cmd.Args[1]) {
 		return
 	}
-	r.execLuaCompat(conn, cmdRPop, cmd.Args[1:])
+	r.execListPop(conn, cmd, false)
+}
+
+// execListPop executes LPOP (left=true) or RPOP (left=false) using the Claim
+// mechanism for O(1) conflict-free pops. An optional count argument is supported:
+// LPOP key [count] / RPOP key [count].
+func (r *RedisServer) execListPop(conn redcon.Conn, cmd redcon.Command, left bool) {
+	count := 1
+	withCount := len(cmd.Args) > 2 //nolint:mnd // args: [CMD, key, count]
+	if withCount {
+		n, err := strconv.Atoi(string(cmd.Args[2]))
+		if err != nil || n < 0 {
+			conn.WriteError("ERR value is not an integer or out of range")
+			return
+		}
+		count = n
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
+	defer cancel()
+
+	values, err := r.listPopClaim(ctx, cmd.Args[1], count, left)
+	if err != nil {
+		conn.WriteError(err.Error())
+		return
+	}
+
+	if withCount {
+		// Count variant: always returns an array (or nil array if key not found).
+		if values == nil {
+			conn.WriteNull()
+			return
+		}
+		conn.WriteArray(len(values))
+		for _, v := range values {
+			conn.WriteBulkString(v)
+		}
+		return
+	}
+	// Non-count variant: return a single bulk string (or nil).
+	if len(values) == 0 {
+		conn.WriteNull()
+		return
+	}
+	conn.WriteBulkString(values[0])
 }
 
 func (r *RedisServer) rpoplpush(conn redcon.Conn, cmd redcon.Command) {

--- a/adapter/redis_retry.go
+++ b/adapter/redis_retry.go
@@ -175,6 +175,12 @@ func normalizeRetryableRedisTxnKey(key []byte) []byte {
 	if store.IsListMetaKey(key) || store.IsListItemKey(key) {
 		return store.ExtractListUserKey(key)
 	}
+	if store.IsListMetaDeltaKey(key) {
+		return store.ExtractListUserKeyFromDelta(key)
+	}
+	if store.IsListClaimKey(key) {
+		return store.ExtractListUserKeyFromClaim(key)
+	}
 	if wideKey, ok := normalizeWideColumnKey(key); ok {
 		return wideKey
 	}


### PR DESCRIPTION
## Summary

Phase 3 of the `collection-metadata-delta` series. Replaces the `execLuaCompat`-based LPOP/RPOP implementation with a conflict-free Claim pattern that avoids head-pointer write-write conflicts under concurrent pops.

**Depends on**: `feat/collection-metadata-delta-phase-2`

### Claim mechanism design

Each pop of n items emits a single atomic transaction:
```
Del(!lst|itm|<key><seq_0>)    + Put(!lst|claim|<key><seq_0>, empty)
Del(!lst|itm|<key><seq_1>)    + Put(!lst|claim|<key><seq_1>, empty)
...
Put(!lst|meta|d|<key><commitTS><0>, {HeadDelta=n (LPOP) or 0 (RPOP), LenDelta=-n})
```

The claim key at the exact sequence number is the uniqueness guard — two concurrent pops claiming the same `seq` get an OCC write-write conflict; the loser retries and discovers the new head via the delta the winner already committed.

### Changes

- `adapter/redis.go`: `buildListPopElems`, `resolveListPopMeta`, `listPopClaim` — core claim implementation
- `adapter/redis_lua.go`: `lpop`/`rpop` delegate to `execListPop`; handles count variant and array vs bulk-string response
- `adapter/redis_compat_helpers.go`: `deleteListElems` now scans and deletes `!lst|claim|` keys so DEL fully cleans up
- `adapter/redis_retry.go`: `normalizeRetryableRedisTxnKey` maps `ListMetaDeltaKey` and `ListClaimKey` back to their logical user key for retry logging

## Test plan

- [ ] `go test ./adapter/... -timeout 120s` passes
- [ ] `golangci-lint run ./adapter/...` returns 0 issues
- [ ] LPOP/RPOP on non-existent key returns nil
- [ ] LPOP/RPOP on empty list returns nil  
- [ ] LPOP with count returns array; LPOP without count returns bulk string
- [ ] Concurrent LPOP stress (two goroutines popping same list) — no double-pop, no data loss