### PR TITLE
feat: implement etcd FSM snapshot disk offload (Phases 1 & 2)

### DIFF
--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -340,6 +340,7 @@ func (e *Engine) initTransport(cfg OpenConfig) {
 	e.dispatchStopCh = make(chan struct{})
 	e.transport.SetSpoolDir(cfg.DataDir)
 	e.transport.SetFSMSnapDir(e.fsmSnapDir)
+	e.transport.SetFSMPayloadReader(e.readFSMPayloadLocked)
 	e.transport.SetHandler(e.handleTransportMessage)
 	e.startDispatchWorkers()
 }
@@ -1198,21 +1199,21 @@ func applyUpdatedPeerToMap(peers map[uint64]Peer, peer Peer, ok bool) {
 }
 
 func (e *Engine) persistConfigSnapshot(index uint64, confState raftpb.ConfState) error {
+	// Fast path (lock-free): avoid unnecessary FSM snapshot when config is already current.
 	if upToDate, err := e.configSnapshotUpToDate(index, confState); err != nil {
 		return err
 	} else if upToDate {
 		return nil
 	}
 
-	// Phase 4 keeps config-snapshot publication synchronous so the conf change
-	// is not considered durable before the updated snapshot metadata can be sent
-	// to a freshly added voter. Before broad rollout, this should move to a
-	// background path that preserves the same ordering guarantee.
+	e.snapshotMu.Lock()
+	defer e.snapshotMu.Unlock()
+
 	payload, err := e.snapshotPayload(index)
 	if err != nil {
 		return err
 	}
-	return e.persistConfigSnapshotPayload(index, confState, payload)
+	return e.persistConfigSnapshotPayloadLocked(index, confState, payload)
 }
 
 func (e *Engine) persistConfigState(index uint64, confState raftpb.ConfState, peers []Peer) error {
@@ -1255,16 +1256,6 @@ func (e *Engine) persistConfigState(index uint64, confState raftpb.ConfState, pe
 	return nil
 }
 
-func (e *Engine) persistConfigSnapshotPayload(index uint64, confState raftpb.ConfState, payload []byte) error {
-	// Keep disk publication serialized with snapshot restores. If a newer
-	// follower snapshot restored concurrently while an older config snapshot was
-	// still being written to disk, a restart could regress to the stale payload.
-	e.snapshotMu.Lock()
-	defer e.snapshotMu.Unlock()
-
-	return e.persistConfigSnapshotPayloadLocked(index, confState, payload)
-}
-
 func (e *Engine) persistConfigSnapshotPayloadLocked(index uint64, confState raftpb.ConfState, payload []byte) error {
 	if upToDate, err := e.configSnapshotUpToDate(index, confState); err != nil {
 		return err
@@ -1280,6 +1271,14 @@ func (e *Engine) persistConfigSnapshotPayloadLocked(index uint64, confState raft
 		return err
 	}
 	return nil
+}
+
+// readFSMPayloadLocked reads the FSM snapshot payload for the given index while
+// holding snapshotMu, preventing concurrent purge from removing the file.
+func (e *Engine) readFSMPayloadLocked(index uint64) ([]byte, error) {
+	e.snapshotMu.Lock()
+	defer e.snapshotMu.Unlock()
+	return readFSMSnapshotPayload(fsmSnapPath(e.fsmSnapDir, index))
 }
 
 // snapshotPayload takes a FSM snapshot for the given index, writes it to the

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -1283,14 +1283,20 @@ func (e *Engine) readFSMPayloadLocked(index uint64) ([]byte, error) {
 	return readFSMSnapshotPayload(fsmSnapPath(e.fsmSnapDir, index))
 }
 
-// openFSMPayloadLocked opens the .fsm payload file for the given index while
-// holding snapshotMu. The lock is released once the file descriptor is obtained;
-// Unix semantics guarantee the fd remains readable even if purgeOldSnapshotFiles
-// subsequently unlinks the file. The caller must close the returned ReadCloser.
+// openFSMPayloadLocked opens the .fsm payload file for the given index, holding
+// snapshotMu only for the duration of os.Open. Once the file descriptor is
+// obtained, Unix semantics guarantee it remains readable even after
+// purgeOldSnapshotFiles unlinks the file, so the lock can be released before
+// the fstat call. The caller must close the returned ReadCloser.
 func (e *Engine) openFSMPayloadLocked(index uint64) (io.ReadCloser, error) {
+	path := fsmSnapPath(e.fsmSnapDir, index)
 	e.snapshotMu.Lock()
-	defer e.snapshotMu.Unlock()
-	return openFSMSnapshotPayloadReader(fsmSnapPath(e.fsmSnapDir, index))
+	f, err := openFSMSnapshotFile(path)
+	e.snapshotMu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	return openFSMPayloadFromFD(f)
 }
 
 // snapshotPayload takes a FSM snapshot for the given index, writes it to the

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"io"
 	"log/slog"
 	"path/filepath"
 	"sort"
@@ -341,6 +342,7 @@ func (e *Engine) initTransport(cfg OpenConfig) {
 	e.transport.SetSpoolDir(cfg.DataDir)
 	e.transport.SetFSMSnapDir(e.fsmSnapDir)
 	e.transport.SetFSMPayloadReader(e.readFSMPayloadLocked)
+	e.transport.SetFSMPayloadOpener(e.openFSMPayloadLocked)
 	e.transport.SetHandler(e.handleTransportMessage)
 	e.startDispatchWorkers()
 }
@@ -1279,6 +1281,16 @@ func (e *Engine) readFSMPayloadLocked(index uint64) ([]byte, error) {
 	e.snapshotMu.Lock()
 	defer e.snapshotMu.Unlock()
 	return readFSMSnapshotPayload(fsmSnapPath(e.fsmSnapDir, index))
+}
+
+// openFSMPayloadLocked opens the .fsm payload file for the given index while
+// holding snapshotMu. The lock is released once the file descriptor is obtained;
+// Unix semantics guarantee the fd remains readable even if purgeOldSnapshotFiles
+// subsequently unlinks the file. The caller must close the returned ReadCloser.
+func (e *Engine) openFSMPayloadLocked(index uint64) (io.ReadCloser, error) {
+	e.snapshotMu.Lock()
+	defer e.snapshotMu.Unlock()
+	return openFSMSnapshotPayloadReader(fsmSnapPath(e.fsmSnapDir, index))
 }
 
 // snapshotPayload takes a FSM snapshot for the given index, writes it to the

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -83,6 +83,7 @@ type Engine struct {
 	localID      string
 	localAddress string
 	dataDir      string
+	fsmSnapDir   string
 	tickInterval time.Duration
 
 	storage   *etcdraft.MemoryStorage
@@ -253,6 +254,7 @@ func Open(ctx context.Context, cfg OpenConfig) (*Engine, error) {
 		localID:          prepared.cfg.LocalID,
 		localAddress:     prepared.cfg.LocalAddress,
 		dataDir:          prepared.cfg.DataDir,
+		fsmSnapDir:       filepath.Join(prepared.cfg.DataDir, fsmSnapDirName),
 		tickInterval:     prepared.cfg.TickInterval,
 		storage:          prepared.disk.Storage,
 		rawNode:          rawNode,
@@ -337,6 +339,7 @@ func (e *Engine) initTransport(cfg OpenConfig) {
 	e.dispatchCh = make(chan dispatchRequest, dispatchQueueSize(cfg.MaxInflightMsg))
 	e.dispatchStopCh = make(chan struct{})
 	e.transport.SetSpoolDir(cfg.DataDir)
+	e.transport.SetFSMSnapDir(e.fsmSnapDir)
 	e.transport.SetHandler(e.handleTransportMessage)
 	e.startDispatchWorkers()
 }
@@ -920,9 +923,22 @@ func (e *Engine) applyReadySnapshot(snapshot raftpb.Snapshot) error {
 	// and later committed entries can be applied safely.
 	e.snapshotMu.Lock()
 	defer e.snapshotMu.Unlock()
-	if err := e.fsm.Restore(bytes.NewReader(snapshot.Data)); err != nil {
-		return errors.WithStack(err)
+
+	if isSnapshotToken(snapshot.Data) {
+		tok, err := decodeSnapshotToken(snapshot.Data)
+		if err != nil {
+			return err
+		}
+		if err := openAndRestoreFSMSnapshot(e.fsm, fsmSnapPath(e.fsmSnapDir, tok.Index), tok.CRC32C); err != nil {
+			return errors.WithStack(err)
+		}
+	} else {
+		// Legacy format: full FSM payload in snapshot.Data.
+		if err := e.fsm.Restore(bytes.NewReader(snapshot.Data)); err != nil {
+			return errors.WithStack(err)
+		}
 	}
+
 	if err := e.storage.ApplySnapshot(snapshot); err != nil {
 		return errors.WithStack(err)
 	}
@@ -1192,7 +1208,7 @@ func (e *Engine) persistConfigSnapshot(index uint64, confState raftpb.ConfState)
 	// is not considered durable before the updated snapshot metadata can be sent
 	// to a freshly added voter. Before broad rollout, this should move to a
 	// background path that preserves the same ordering guarantee.
-	payload, err := e.snapshotPayload()
+	payload, err := e.snapshotPayload(index)
 	if err != nil {
 		return err
 	}
@@ -1228,7 +1244,7 @@ func (e *Engine) persistConfigState(index uint64, confState raftpb.ConfState, pe
 		return nil
 	}
 
-	payload, err := e.snapshotPayload()
+	payload, err := e.snapshotPayload(index)
 	if err != nil {
 		return err
 	}
@@ -1266,12 +1282,31 @@ func (e *Engine) persistConfigSnapshotPayloadLocked(index uint64, confState raft
 	return nil
 }
 
-func (e *Engine) snapshotPayload() ([]byte, error) {
+// snapshotPayload takes a FSM snapshot for the given index, writes it to the
+// .fsm file on disk, and returns the 17-byte token for raftpb.Snapshot.Data.
+// If fsmSnapDir is not set (e.g., engines created directly in unit tests),
+// falls back to the legacy in-memory []byte path.
+func (e *Engine) snapshotPayload(index uint64) ([]byte, error) {
+	if e.fsmSnapDir == "" {
+		snapshot, err := e.fsm.Snapshot()
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		return snapshotBytesAndClose(snapshot, e.dataDir)
+	}
 	snapshot, err := e.fsm.Snapshot()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	return snapshotBytesAndClose(snapshot, e.dataDir)
+	crc32c, writeErr := writeFSMSnapshotFile(snapshot, e.fsmSnapDir, index)
+	closeErr := snapshot.Close()
+	if writeErr != nil {
+		return nil, writeErr
+	}
+	if closeErr != nil {
+		return nil, errors.WithStack(closeErr)
+	}
+	return encodeSnapshotToken(index, crc32c), nil
 }
 
 func (e *Engine) configSnapshotUpToDate(index uint64, confState raftpb.ConfState) (bool, error) {
@@ -1320,7 +1355,7 @@ func (e *Engine) persistCreatedSnapshot(snap raftpb.Snapshot) error {
 	}
 
 	snapDir := filepath.Join(e.dataDir, snapDirName)
-	if purgeErr := purgeOldSnapFiles(snapDir); purgeErr != nil {
+	if purgeErr := purgeOldSnapshotFiles(snapDir, e.fsmSnapDir); purgeErr != nil {
 		slog.Warn("failed to purge old snap files", "error", purgeErr)
 	}
 	return nil
@@ -2243,11 +2278,24 @@ func (e *Engine) handleSnapshotResult(result snapshotResult) error {
 }
 
 func (e *Engine) persistLocalSnapshot(req snapshotRequest) error {
-	payload, err := snapshotBytesAndClose(req.snapshot, e.dataDir)
-	if err != nil {
-		return err
+	if e.fsmSnapDir == "" {
+		// No fsmSnapDir set (in-memory or test engine): use the legacy path.
+		payload, err := snapshotBytesAndClose(req.snapshot, e.dataDir)
+		if err != nil {
+			return err
+		}
+		return e.persistLocalSnapshotPayload(req.index, payload)
 	}
-	return e.persistLocalSnapshotPayload(req.index, payload)
+	crc32c, writeErr := writeFSMSnapshotFile(req.snapshot, e.fsmSnapDir, req.index)
+	closeErr := req.snapshot.Close()
+	if writeErr != nil {
+		return writeErr
+	}
+	if closeErr != nil {
+		return errors.WithStack(closeErr)
+	}
+	token := encodeSnapshotToken(req.index, crc32c)
+	return e.persistLocalSnapshotPayload(req.index, token)
 }
 
 func (e *Engine) persistLocalSnapshotPayload(index uint64, payload []byte) error {
@@ -2269,7 +2317,7 @@ func (e *Engine) persistLocalSnapshotPayload(index uint64, payload []byte) error
 	switch {
 	case err == nil:
 		snapDir := filepath.Join(e.dataDir, snapDirName)
-		if purgeErr := purgeOldSnapFiles(snapDir); purgeErr != nil {
+		if purgeErr := purgeOldSnapshotFiles(snapDir, e.fsmSnapDir); purgeErr != nil {
 			slog.Warn("failed to purge old snap files", "error", purgeErr)
 		}
 		return nil

--- a/internal/raftengine/etcd/fsm_snapshot_file.go
+++ b/internal/raftengine/etcd/fsm_snapshot_file.go
@@ -63,7 +63,7 @@ var (
 	ErrFSMSnapshotNotFound = errors.New("fsm snapshot: file not found")
 
 	// ErrFSMSnapshotTooSmall is returned when the file is shorter than the
-	// minimum valid .fsm size (at least 1 byte payload + 4 bytes CRC footer).
+	// minimum valid .fsm size (0 or more bytes payload + 4 bytes CRC footer).
 	ErrFSMSnapshotTooSmall = errors.New("fsm snapshot: file too small to contain footer")
 
 	// ErrFSMSnapshotTokenInvalid is returned when the token bytes cannot be

--- a/internal/raftengine/etcd/fsm_snapshot_file.go
+++ b/internal/raftengine/etcd/fsm_snapshot_file.go
@@ -398,6 +398,37 @@ func openFSMSnapshotPayloadReader(path string) (io.ReadCloser, error) {
 	}, nil
 }
 
+// openFSMSnapshotFile opens the .fsm file at path and returns the *os.File.
+// Used by callers that need to control the lock scope separately from the stat
+// (e.g. engine.openFSMPayloadLocked).
+func openFSMSnapshotFile(path string) (*os.File, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, statFSMFileError(err)
+	}
+	return f, nil
+}
+
+// openFSMPayloadFromFD wraps an already-open .fsm file descriptor in a
+// ReadCloser scoped to the payload bytes (file size minus the 4-byte CRC
+// footer). The size is obtained via fstat on the open fd (no path lookup).
+// On any error the file is closed before returning.
+func openFSMPayloadFromFD(f *os.File) (io.ReadCloser, error) {
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, errors.WithStack(err)
+	}
+	if info.Size() < fsmMinFileSize {
+		_ = f.Close()
+		return nil, errors.WithStack(ErrFSMSnapshotTooSmall)
+	}
+	return &limitedReadCloser{
+		Reader: io.LimitReader(f, info.Size()-fsmFooterSize),
+		Closer: f,
+	}, nil
+}
+
 // statFSMFileError converts an os.Stat error to the appropriate typed error.
 func statFSMFileError(err error) error {
 	if os.IsNotExist(err) {

--- a/internal/raftengine/etcd/fsm_snapshot_file.go
+++ b/internal/raftengine/etcd/fsm_snapshot_file.go
@@ -36,6 +36,12 @@ const (
 
 	// fsmWriteBufSize is the bufio.Writer buffer size used when writing .fsm files.
 	fsmWriteBufSize = 1 << 20 // 1 MiB
+
+	// fsmMaxInMemPayload is the maximum payload size that readFSMSnapshotPayload
+	// will materialise into memory. Larger snapshots must use the streaming path
+	// (openFSMSnapshotPayloadReader) to avoid OOM. 1 GiB is chosen as a generous
+	// upper bound; real FSM payloads for this workload are typically much smaller.
+	fsmMaxInMemPayload = int64(1 << 30) // 1 GiB
 )
 
 var (
@@ -62,6 +68,10 @@ var (
 	// ErrFSMSnapshotTokenInvalid is returned when the token bytes cannot be
 	// decoded (wrong length or magic prefix).
 	ErrFSMSnapshotTokenInvalid = errors.New("fsm snapshot: token format invalid")
+
+	// ErrFSMSnapshotTooLarge is returned when the payload exceeds fsmMaxInMemPayload.
+	// Callers should switch to the streaming path (openFSMSnapshotPayloadReader).
+	ErrFSMSnapshotTooLarge = errors.New("fsm snapshot: payload exceeds maximum in-memory size limit")
 )
 
 // snapshotToken holds the decoded fields of a 17-byte raftpb.Snapshot.Data token.
@@ -416,6 +426,10 @@ func readFSMSnapshotPayload(path string) ([]byte, error) {
 	defer f.Close()
 
 	payloadSize := info.Size() - fsmFooterSize
+	if payloadSize > fsmMaxInMemPayload {
+		return nil, errors.Wrapf(ErrFSMSnapshotTooLarge,
+			"payload %d bytes exceeds limit %d; use streaming path instead", payloadSize, fsmMaxInMemPayload)
+	}
 	data := make([]byte, payloadSize)
 	h := crc32.New(crc32cTable)
 	tr := io.TeeReader(io.LimitReader(f, payloadSize), h)

--- a/internal/raftengine/etcd/fsm_snapshot_file.go
+++ b/internal/raftengine/etcd/fsm_snapshot_file.go
@@ -480,14 +480,22 @@ func cleanupStaleFSMSnaps(snapDir, fsmSnapDir string, disableStartupCRCCheck boo
 }
 
 func removeFSMTmpOrphans(fsmSnapDir string) error {
-	tmps, err := filepath.Glob(filepath.Join(fsmSnapDir, "*.fsm.tmp"))
+	// Use os.ReadDir + strings.HasSuffix instead of filepath.Glob to avoid
+	// misinterpretation of special characters (e.g. '[', ']') in fsmSnapDir
+	// that glob treats as pattern syntax.
+	entries, err := os.ReadDir(fsmSnapDir)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return errors.WithStack(err)
 	}
 	var combined error
-	for _, tmp := range tmps {
-		if removeErr := os.Remove(tmp); removeErr != nil && !os.IsNotExist(removeErr) {
-			combined = errors.CombineErrors(combined, errors.WithStack(removeErr))
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".fsm.tmp") {
+			if removeErr := os.Remove(filepath.Join(fsmSnapDir, e.Name())); removeErr != nil && !os.IsNotExist(removeErr) {
+				combined = errors.CombineErrors(combined, errors.WithStack(removeErr))
+			}
 		}
 	}
 	return errors.WithStack(combined)
@@ -618,6 +626,9 @@ func purgeSnapPair(snapDir, fsmSnapDir, snapName string) error {
 }
 
 func syncDirIfExists(dir string) error {
+	if dir == "" {
+		return nil
+	}
 	if err := syncDir(dir); err != nil && !os.IsNotExist(err) {
 		return err
 	}

--- a/internal/raftengine/etcd/fsm_snapshot_file.go
+++ b/internal/raftengine/etcd/fsm_snapshot_file.go
@@ -1,0 +1,536 @@
+package etcd
+
+import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
+	"hash"
+	"hash/crc32"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+const (
+	fsmSnapDirName       = "fsm-snap"
+	snapshotTokenSize    = 17 // 4 (magic) + 1 (version) + 8 (index) + 4 (crc32c)
+	snapshotTokenVersion = byte(0x01)
+
+	// fsmFooterSize is the size of the CRC32C footer appended to each .fsm file.
+	fsmFooterSize = 4
+
+	// fsmMinFileSize is the minimum valid .fsm size: at least 1 byte payload + 4 bytes CRC footer.
+	fsmMinFileSize = fsmFooterSize + 1
+
+	// snapshotTokenMagicLen is the number of magic bytes at the start of a token.
+	snapshotTokenMagicLen = 4
+
+	// fsmRestoreReadAhead is the bufio read-ahead size used when restoring .fsm files.
+	fsmRestoreReadAhead = 1 << 20 // 1 MiB
+)
+
+var (
+	snapshotTokenMagic = [snapshotTokenMagicLen]byte{'E', 'K', 'V', 'T'}
+	crc32cTable        = crc32.MakeTable(crc32.Castagnoli)
+)
+
+var (
+	// ErrFSMSnapshotFileCRC is returned when the on-disk CRC32C footer does not
+	// match the computed checksum — the .fsm file is corrupt.
+	ErrFSMSnapshotFileCRC = errors.New("fsm snapshot: file CRC32C mismatch (file corrupt)")
+
+	// ErrFSMSnapshotTokenCRC is returned when the footer and the token CRC
+	// disagree before restore — the metadata is suspect; do not auto-rewrite.
+	ErrFSMSnapshotTokenCRC = errors.New("fsm snapshot: token CRC32C mismatch (metadata corrupt)")
+
+	// ErrFSMSnapshotNotFound is returned when the expected .fsm file is absent.
+	ErrFSMSnapshotNotFound = errors.New("fsm snapshot: file not found")
+
+	// ErrFSMSnapshotTooSmall is returned when the file is shorter than the
+	// minimum valid .fsm size (at least 1 byte payload + 4 bytes CRC footer).
+	ErrFSMSnapshotTooSmall = errors.New("fsm snapshot: file too small to contain footer")
+
+	// ErrFSMSnapshotTokenInvalid is returned when the token bytes cannot be
+	// decoded (wrong length or magic prefix).
+	ErrFSMSnapshotTokenInvalid = errors.New("fsm snapshot: token format invalid")
+)
+
+// snapshotToken holds the decoded fields of a 17-byte raftpb.Snapshot.Data token.
+type snapshotToken struct {
+	Index  uint64
+	CRC32C uint32
+}
+
+// isSnapshotToken returns true if data begins with the EKVT magic prefix.
+func isSnapshotToken(data []byte) bool {
+	if len(data) < snapshotTokenMagicLen {
+		return false
+	}
+	return [snapshotTokenMagicLen]byte(data[:snapshotTokenMagicLen]) == snapshotTokenMagic
+}
+
+// encodeSnapshotToken encodes index and crc32c into the 17-byte token format:
+//
+//	[magic:4][version:1][index:8][crc32c:4]
+func encodeSnapshotToken(index uint64, crc32c uint32) []byte {
+	token := make([]byte, snapshotTokenSize)
+	copy(token[:snapshotTokenMagicLen], snapshotTokenMagic[:])
+	token[snapshotTokenMagicLen] = snapshotTokenVersion
+	binary.BigEndian.PutUint64(token[5:13], index)
+	binary.BigEndian.PutUint32(token[13:17], crc32c)
+	return token
+}
+
+// decodeSnapshotToken parses the 17-byte token. Returns ErrFSMSnapshotTokenInvalid
+// if the length or magic is wrong.
+func decodeSnapshotToken(data []byte) (snapshotToken, error) {
+	if len(data) != snapshotTokenSize {
+		return snapshotToken{}, errors.Wrapf(ErrFSMSnapshotTokenInvalid,
+			"expected %d bytes, got %d", snapshotTokenSize, len(data))
+	}
+	if [snapshotTokenMagicLen]byte(data[:snapshotTokenMagicLen]) != snapshotTokenMagic {
+		return snapshotToken{}, errors.Wrapf(ErrFSMSnapshotTokenInvalid,
+			"invalid magic: %x", data[:snapshotTokenMagicLen])
+	}
+	if data[snapshotTokenMagicLen] != snapshotTokenVersion {
+		return snapshotToken{}, errors.Wrapf(ErrFSMSnapshotTokenInvalid,
+			"unknown version: %d", data[snapshotTokenMagicLen])
+	}
+	return snapshotToken{
+		Index:  binary.BigEndian.Uint64(data[5:13]),
+		CRC32C: binary.BigEndian.Uint32(data[13:17]),
+	}, nil
+}
+
+// fsmSnapPath returns the canonical zero-padded hex path for a .fsm snapshot file.
+func fsmSnapPath(fsmSnapDir string, index uint64) string {
+	return filepath.Join(fsmSnapDir, fmt.Sprintf("%016x.fsm", index))
+}
+
+// parseSnapFileIndex extracts the applied index from an etcd snapshotter filename.
+// Snap files are named "{term:016x}-{index:016x}.snap".
+// Returns 0 on parse failure.
+func parseSnapFileIndex(name string) uint64 {
+	base := strings.TrimSuffix(name, ".snap")
+	idx := strings.LastIndex(base, "-")
+	if idx < 0 {
+		return 0
+	}
+	index, err := strconv.ParseUint(base[idx+1:], 16, 64)
+	if err != nil {
+		return 0
+	}
+	return index
+}
+
+// crc32CWriter wraps an io.Writer and accumulates a CRC32C checksum over all
+// bytes written through it.
+type crc32CWriter struct {
+	w io.Writer
+	h hash.Hash32
+}
+
+func newCRC32CWriter(w io.Writer) *crc32CWriter {
+	return &crc32CWriter{w: w, h: crc32.New(crc32cTable)}
+}
+
+func (c *crc32CWriter) Write(p []byte) (int, error) {
+	n, err := c.w.Write(p)
+	c.h.Write(p[:n])
+	if err != nil {
+		return n, errors.WithStack(err)
+	}
+	return n, nil
+}
+
+func (c *crc32CWriter) Sum32() uint32 { return c.h.Sum32() }
+
+// writeFSMSnapshotFile writes the FSM snapshot to disk with a CRC32C footer.
+//
+// Write sequence (crash-safe):
+//  1. os.CreateTemp → *.fsm.tmp
+//  2. snapshot.WriteTo → stream FSM payload + accumulate CRC
+//  3. binary.Write   → append 4-byte CRC footer
+//  4. Sync           → flush to durable storage
+//  5. os.Rename      → atomic commit (tmp → final)
+//  6. syncDir        → persist directory entry
+//
+// Returns the CRC32C of the payload (excluding the footer) so the caller can
+// embed it in the raftpb.Snapshot.Data token.
+func writeFSMSnapshotFile(snapshot Snapshot, fsmSnapDir string, index uint64) (uint32, error) {
+	if err := os.MkdirAll(fsmSnapDir, defaultDirPerm); err != nil {
+		return 0, errors.WithStack(err)
+	}
+
+	tmpFile, err := os.CreateTemp(fsmSnapDir, "*.fsm.tmp")
+	if err != nil {
+		return 0, errors.WithStack(err)
+	}
+	tmpPath := tmpFile.Name()
+	finalPath := fsmSnapPath(fsmSnapDir, index)
+
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tmpFile.Close()
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	crcWriter := newCRC32CWriter(tmpFile)
+	if _, err := snapshot.WriteTo(crcWriter); err != nil {
+		return 0, errors.WithStack(err)
+	}
+
+	checksum := crcWriter.Sum32()
+	if err := binary.Write(tmpFile, binary.BigEndian, checksum); err != nil {
+		return 0, errors.WithStack(err)
+	}
+	if err := tmpFile.Sync(); err != nil {
+		return 0, errors.WithStack(err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		committed = true
+		return 0, errors.WithStack(err)
+	}
+	committed = true
+
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return 0, errors.WithStack(err)
+	}
+	if err := syncDir(fsmSnapDir); err != nil {
+		return 0, errors.WithStack(err)
+	}
+
+	return checksum, nil
+}
+
+// openAndRestoreFSMSnapshot opens the .fsm file at path, verifies the CRC, and
+// restores the FSM state in a single streaming pass.
+//
+// Token fail-fast: the on-disk footer is compared to tokenCRC BEFORE fsm.Restore
+// is called to avoid mutating the FSM with corrupt data.
+//
+// Returns typed errors (ErrFSMSnapshotFileCRC, ErrFSMSnapshotTokenCRC, etc.) to
+// allow the caller to take the correct recovery action.
+func openAndRestoreFSMSnapshot(fsm StateMachine, path string, tokenCRC uint32) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return statFSMFileError(err)
+	}
+	if info.Size() < fsmMinFileSize {
+		return errors.Wrapf(ErrFSMSnapshotTooSmall,
+			"file too small: %d bytes (minimum %d)", info.Size(), fsmMinFileSize)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer f.Close()
+
+	// Fail fast: read footer and compare to tokenCRC before calling fsm.Restore,
+	// so a corrupt token never causes FSM state mutation.
+	footer, err := readFSMFooter(f, info.Size())
+	if err != nil {
+		return err
+	}
+	if footer != tokenCRC {
+		return errors.Wrapf(ErrFSMSnapshotTokenCRC,
+			"path=%s footer=%08x token=%08x", path, footer, tokenCRC)
+	}
+
+	// Seek back to start for the combined restore + CRC verification pass.
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return errors.WithStack(err)
+	}
+
+	computed, err := restoreAndComputeCRC(f, info.Size(), fsm)
+	if err != nil {
+		return err
+	}
+	if computed != footer {
+		return errors.Wrapf(ErrFSMSnapshotFileCRC,
+			"path=%s footer=%08x computed=%08x", path, footer, computed)
+	}
+	// footer == tokenCRC was verified above; computed == footer is now confirmed.
+	return nil
+}
+
+// readFSMFooter seeks to the last fsmFooterSize bytes and reads the stored CRC.
+func readFSMFooter(f *os.File, fileSize int64) (uint32, error) {
+	if _, err := f.Seek(fileSize-fsmFooterSize, io.SeekStart); err != nil {
+		return 0, errors.WithStack(err)
+	}
+	var footer uint32
+	if err := binary.Read(f, binary.BigEndian, &footer); err != nil {
+		return 0, errors.WithStack(err)
+	}
+	return footer, nil
+}
+
+// restoreAndComputeCRC streams the payload (all bytes except the footer) through
+// a TeeReader that simultaneously feeds fsm.Restore and the CRC accumulator.
+// Returns the computed CRC32C of the payload.
+func restoreAndComputeCRC(f *os.File, fileSize int64, fsm StateMachine) (uint32, error) {
+	payloadSize := fileSize - fsmFooterSize
+	h := crc32.New(crc32cTable)
+	tee := io.TeeReader(io.LimitReader(f, payloadSize), h)
+	br := bufio.NewReaderSize(tee, fsmRestoreReadAhead)
+	if err := fsm.Restore(br); err != nil {
+		return 0, errors.WithStack(err)
+	}
+	// Drain bytes not consumed by fsm.Restore so the CRC covers the full payload.
+	if _, err := io.Copy(io.Discard, br); err != nil {
+		return 0, errors.WithStack(err)
+	}
+	return h.Sum32(), nil
+}
+
+// verifyFSMSnapshotFile performs a read-only CRC check without restoring the FSM.
+// Used for startup orphan detection. Pass tokenCRC=0 to skip the token comparison.
+func verifyFSMSnapshotFile(path string, tokenCRC uint32) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return statFSMFileError(err)
+	}
+	if info.Size() < fsmMinFileSize {
+		return errors.Wrapf(ErrFSMSnapshotTooSmall,
+			"file too small: %d bytes (minimum %d)", info.Size(), fsmMinFileSize)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer f.Close()
+
+	payloadSize := info.Size() - fsmFooterSize
+	h := crc32.New(crc32cTable)
+	if _, err := io.CopyN(h, f, payloadSize); err != nil {
+		return errors.WithStack(err)
+	}
+	computed := h.Sum32()
+
+	var footer uint32
+	if err := binary.Read(f, binary.BigEndian, &footer); err != nil {
+		return errors.WithStack(err)
+	}
+	if computed != footer {
+		return errors.Wrapf(ErrFSMSnapshotFileCRC,
+			"path=%s footer=%08x computed=%08x", path, footer, computed)
+	}
+	if tokenCRC != 0 && computed != tokenCRC {
+		return errors.Wrapf(ErrFSMSnapshotTokenCRC,
+			"path=%s footer=%08x token=%08x", path, footer, tokenCRC)
+	}
+	return nil
+}
+
+// statFSMFileError converts an os.Stat error to the appropriate typed error.
+func statFSMFileError(err error) error {
+	if os.IsNotExist(err) {
+		return errors.WithStack(ErrFSMSnapshotNotFound)
+	}
+	return errors.WithStack(err)
+}
+
+// readFSMSnapshotPayload reads the .fsm file payload (all bytes except the
+// 4-byte CRC footer) into memory. Used by the Phase 1 bridge mode in Dispatch
+// to reconstruct the full FSM bytes for legacy receivers.
+func readFSMSnapshotPayload(path string) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if info.Size() < fsmFooterSize {
+		return nil, errors.WithStack(ErrFSMSnapshotTooSmall)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer f.Close()
+
+	payloadSize := info.Size() - fsmFooterSize
+	data := make([]byte, payloadSize)
+	if _, err := io.ReadFull(f, data); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return data, nil
+}
+
+// cleanupStaleFSMSnaps removes orphaned .fsm.tmp files and .fsm files that
+// have no matching live snap token. Also verifies CRC of retained files unless
+// disableStartupCRCCheck is set.
+//
+// Steps:
+//  1. Remove all *.fsm.tmp (crash orphans).
+//  2. Enumerate live snap indexes from *.snap files in snapDir.
+//  3. Remove any .fsm file whose index has no matching live snap.
+//  4. For each remaining .fsm, call verifyFSMSnapshotFile; remove on ErrFSMSnapshotFileCRC.
+func cleanupStaleFSMSnaps(snapDir, fsmSnapDir string, disableStartupCRCCheck bool) error {
+	if err := os.MkdirAll(fsmSnapDir, defaultDirPerm); err != nil {
+		return errors.WithStack(err)
+	}
+	if err := removeFSMTmpOrphans(fsmSnapDir); err != nil {
+		return err
+	}
+
+	liveIndexes, err := collectLiveSnapIndexes(snapDir)
+	if err != nil {
+		return err
+	}
+
+	return removeStaleFSMFiles(fsmSnapDir, liveIndexes, disableStartupCRCCheck)
+}
+
+func removeFSMTmpOrphans(fsmSnapDir string) error {
+	tmps, err := filepath.Glob(filepath.Join(fsmSnapDir, "*.fsm.tmp"))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	var combined error
+	for _, tmp := range tmps {
+		if removeErr := os.Remove(tmp); removeErr != nil && !os.IsNotExist(removeErr) {
+			combined = errors.CombineErrors(combined, errors.WithStack(removeErr))
+		}
+	}
+	return errors.WithStack(combined)
+}
+
+func collectLiveSnapIndexes(snapDir string) (map[uint64]bool, error) {
+	snapEntries, err := os.ReadDir(snapDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, errors.WithStack(err)
+	}
+	liveIndexes := make(map[uint64]bool, len(snapEntries))
+	for _, e := range snapEntries {
+		if !e.IsDir() && filepath.Ext(e.Name()) == ".snap" {
+			if idx := parseSnapFileIndex(e.Name()); idx > 0 {
+				liveIndexes[idx] = true
+			}
+		}
+	}
+	return liveIndexes, nil
+}
+
+func removeStaleFSMFiles(fsmSnapDir string, liveIndexes map[uint64]bool, disableStartupCRCCheck bool) error {
+	fsmEntries, err := os.ReadDir(fsmSnapDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return errors.WithStack(err)
+	}
+	for _, e := range fsmEntries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".fsm" {
+			continue
+		}
+		removeStaleFSMFile(fsmSnapDir, e.Name(), liveIndexes, disableStartupCRCCheck)
+	}
+	return nil
+}
+
+func removeStaleFSMFile(fsmSnapDir, name string, liveIndexes map[uint64]bool, disableStartupCRCCheck bool) {
+	idx, err := strconv.ParseUint(strings.TrimSuffix(name, ".fsm"), 16, 64)
+	if err != nil {
+		return
+	}
+	fsmPath := filepath.Join(fsmSnapDir, name)
+	if !liveIndexes[idx] {
+		removeWithWarn(fsmPath, "orphan fsm snapshot")
+		return
+	}
+	if disableStartupCRCCheck {
+		return
+	}
+	if verifyErr := verifyFSMSnapshotFile(fsmPath, 0); errors.Is(verifyErr, ErrFSMSnapshotFileCRC) {
+		slog.Warn("removing corrupt fsm snapshot", "path", fsmPath, "error", verifyErr)
+		removeWithWarn(fsmPath, "corrupt fsm snapshot")
+	}
+}
+
+func removeWithWarn(path, label string) {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		slog.Warn("failed to remove "+label, "path", path, "error", err)
+	}
+}
+
+// purgeOldSnapshotFiles removes old .snap and .fsm files in tandem, keeping the
+// newest defaultMaxSnapFiles pairs. The .snap file is always deleted before its
+// corresponding .fsm file so that no live token can reference a deleted .fsm.
+//
+// A crash between snap-remove and fsm-remove leaves a .fsm with no token:
+// treated as an orphan on next startup by cleanupStaleFSMSnaps.
+func purgeOldSnapshotFiles(snapDir, fsmSnapDir string) error {
+	entries, err := os.ReadDir(snapDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return errors.WithStack(err)
+	}
+
+	snaps := collectSnapNames(entries)
+	if len(snaps) <= defaultMaxSnapFiles {
+		return nil
+	}
+
+	var combined error
+	for _, name := range snaps[:len(snaps)-defaultMaxSnapFiles] {
+		if err := purgeSnapPair(snapDir, fsmSnapDir, name); err != nil {
+			combined = errors.CombineErrors(combined, err)
+		}
+	}
+
+	combined = errors.CombineErrors(combined, syncDirIfExists(snapDir))
+	combined = errors.CombineErrors(combined, syncDirIfExists(fsmSnapDir))
+	return errors.WithStack(combined)
+}
+
+func collectSnapNames(entries []os.DirEntry) []string {
+	var snaps []string
+	for _, e := range entries {
+		if !e.IsDir() && filepath.Ext(e.Name()) == ".snap" {
+			snaps = append(snaps, e.Name())
+		}
+	}
+	return snaps
+}
+
+func purgeSnapPair(snapDir, fsmSnapDir, snapName string) error {
+	idx := parseSnapFileIndex(snapName)
+
+	// Remove the .snap file first; skip .fsm removal if snap removal fails.
+	snapPath := filepath.Join(snapDir, snapName)
+	if removeErr := os.Remove(snapPath); removeErr != nil && !os.IsNotExist(removeErr) {
+		return errors.WithStack(removeErr)
+	}
+
+	// Remove the corresponding .fsm file second.
+	if idx > 0 {
+		fsmPath := fsmSnapPath(fsmSnapDir, idx)
+		if removeErr := os.Remove(fsmPath); removeErr != nil && !os.IsNotExist(removeErr) {
+			return errors.WithStack(removeErr)
+		}
+	}
+	return nil
+}
+
+func syncDirIfExists(dir string) error {
+	if err := syncDir(dir); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/internal/raftengine/etcd/fsm_snapshot_file.go
+++ b/internal/raftengine/etcd/fsm_snapshot_file.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -175,8 +176,9 @@ func (c *crc32CWriter) Sum32() uint32 { return c.h.Sum32() }
 //  2. snapshot.WriteTo → stream FSM payload + accumulate CRC
 //  3. binary.Write   → append 4-byte CRC footer
 //  4. Sync           → flush to durable storage
-//  5. os.Rename      → atomic commit (tmp → final)
-//  6. syncDir        → persist directory entry
+//  5. Close          → release fd before rename
+//  6. os.Rename      → atomic commit (tmp → final)
+//  7. syncDir        → persist directory entry
 //
 // Returns the CRC32C of the payload (excluding the footer) so the caller can
 // embed it in the raftpb.Snapshot.Data token.
@@ -192,9 +194,11 @@ func writeFSMSnapshotFile(snapshot Snapshot, fsmSnapDir string, index uint64) (u
 	tmpPath := tmpFile.Name()
 	finalPath := fsmSnapPath(fsmSnapDir, index)
 
-	committed := false
+	// closed tracks whether the caller has closed tmpFile so the defer
+	// does not attempt a second close (double-close on failure paths).
+	closed := false
 	defer func() {
-		if !committed {
+		if !closed {
 			_ = tmpFile.Close()
 			_ = os.Remove(tmpPath)
 		}
@@ -204,7 +208,14 @@ func writeFSMSnapshotFile(snapshot Snapshot, fsmSnapDir string, index uint64) (u
 	if err != nil {
 		return 0, err
 	}
-	committed = true
+
+	// Close before rename: required on Windows, and best practice on Unix to
+	// ensure all buffered data is visible to the rename target.
+	closed = true
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return 0, errors.WithStack(err)
+	}
 
 	if err := os.Rename(tmpPath, finalPath); err != nil {
 		_ = os.Remove(tmpPath)
@@ -218,8 +229,9 @@ func writeFSMSnapshotFile(snapshot Snapshot, fsmSnapDir string, index uint64) (u
 }
 
 // writeFSMSnapshotPayload streams the snapshot into f, appends the CRC32C
-// footer, flushes the bufio buffer, and syncs+closes the file. On success the
-// file handle is closed and the caller must not use it again.
+// footer, flushes the bufio buffer, and syncs the file. The caller is
+// responsible for closing f; this function intentionally does not call
+// f.Close() so that ownership of the file descriptor remains unambiguous.
 func writeFSMSnapshotPayload(snapshot Snapshot, f *os.File) (uint32, error) {
 	bw := bufio.NewWriterSize(f, fsmWriteBufSize)
 	crcWriter := newCRC32CWriter(bw)
@@ -235,9 +247,6 @@ func writeFSMSnapshotPayload(snapshot Snapshot, f *os.File) (uint32, error) {
 		return 0, errors.WithStack(err)
 	}
 	if err := f.Sync(); err != nil {
-		return 0, errors.WithStack(err)
-	}
-	if err := f.Close(); err != nil {
 		return 0, errors.WithStack(err)
 	}
 	return checksum, nil
@@ -441,6 +450,12 @@ func statFSMFileError(err error) error {
 // 4-byte CRC footer) into memory, verifying the CRC32C footer before returning.
 // Used by the Phase 1 bridge mode in Dispatch to reconstruct the full FSM bytes
 // for legacy receivers.
+//
+// Memory note: each call allocates up to fsmMaxInMemPayload (1 GiB). Concurrent
+// callers (e.g. multiple dispatch workers) can each hold that budget simultaneously.
+// Prefer openFSMSnapshotPayloadReader (the streaming path) when available — the
+// engine registers SetFSMPayloadOpener so this in-memory path is only reached
+// for legacy receivers that predate Phase 2 or when the opener is not wired.
 func readFSMSnapshotPayload(path string) ([]byte, error) {
 	info, err := os.Stat(path)
 	if err != nil {
@@ -612,6 +627,10 @@ func purgeOldSnapshotFiles(snapDir, fsmSnapDir string) error {
 	if len(snaps) <= defaultMaxSnapFiles {
 		return nil
 	}
+	// Sort explicitly: os.ReadDir returns lexicographic order on most systems,
+	// but relying on that implicitly is fragile. Snap filenames are zero-padded
+	// hex, so lexicographic == chronological order (oldest first).
+	sort.Strings(snaps)
 
 	var combined error
 	for _, name := range snaps[:len(snaps)-defaultMaxSnapFiles] {

--- a/internal/raftengine/etcd/fsm_snapshot_file.go
+++ b/internal/raftengine/etcd/fsm_snapshot_file.go
@@ -32,6 +32,9 @@ const (
 
 	// fsmRestoreReadAhead is the bufio read-ahead size used when restoring .fsm files.
 	fsmRestoreReadAhead = 1 << 20 // 1 MiB
+
+	// fsmWriteBufSize is the bufio.Writer buffer size used when writing .fsm files.
+	fsmWriteBufSize = 1 << 20 // 1 MiB
 )
 
 var (
@@ -182,20 +185,9 @@ func writeFSMSnapshotFile(snapshot Snapshot, fsmSnapDir string, index uint64) (u
 		}
 	}()
 
-	crcWriter := newCRC32CWriter(tmpFile)
-	if _, err := snapshot.WriteTo(crcWriter); err != nil {
-		return 0, errors.WithStack(err)
-	}
-
-	checksum := crcWriter.Sum32()
-	if err := binary.Write(tmpFile, binary.BigEndian, checksum); err != nil {
-		return 0, errors.WithStack(err)
-	}
-	if err := tmpFile.Sync(); err != nil {
-		return 0, errors.WithStack(err)
-	}
-	if err := tmpFile.Close(); err != nil {
-		return 0, errors.WithStack(err)
+	checksum, err := writeFSMSnapshotPayload(snapshot, tmpFile)
+	if err != nil {
+		return 0, err
 	}
 	committed = true
 
@@ -207,6 +199,32 @@ func writeFSMSnapshotFile(snapshot Snapshot, fsmSnapDir string, index uint64) (u
 		return 0, errors.WithStack(err)
 	}
 
+	return checksum, nil
+}
+
+// writeFSMSnapshotPayload streams the snapshot into f, appends the CRC32C
+// footer, flushes the bufio buffer, and syncs+closes the file. On success the
+// file handle is closed and the caller must not use it again.
+func writeFSMSnapshotPayload(snapshot Snapshot, f *os.File) (uint32, error) {
+	bw := bufio.NewWriterSize(f, fsmWriteBufSize)
+	crcWriter := newCRC32CWriter(bw)
+	if _, err := snapshot.WriteTo(crcWriter); err != nil {
+		return 0, errors.WithStack(err)
+	}
+
+	checksum := crcWriter.Sum32()
+	if err := binary.Write(bw, binary.BigEndian, checksum); err != nil {
+		return 0, errors.WithStack(err)
+	}
+	if err := bw.Flush(); err != nil {
+		return 0, errors.WithStack(err)
+	}
+	if err := f.Sync(); err != nil {
+		return 0, errors.WithStack(err)
+	}
+	if err := f.Close(); err != nil {
+		return 0, errors.WithStack(err)
+	}
 	return checksum, nil
 }
 

--- a/internal/raftengine/etcd/fsm_snapshot_file.go
+++ b/internal/raftengine/etcd/fsm_snapshot_file.go
@@ -350,6 +350,39 @@ func verifyFSMSnapshotFile(path string, tokenCRC uint32) error {
 	return nil
 }
 
+// limitedReadCloser pairs an io.Reader (typically a LimitReader over a file)
+// with the underlying io.Closer so the file descriptor is released after streaming.
+type limitedReadCloser struct {
+	io.Reader
+	io.Closer
+}
+
+// openFSMSnapshotPayloadReader opens the .fsm file at path and returns a
+// ReadCloser over exactly the payload bytes (file size minus the 4-byte CRC
+// footer). The caller must call Close() to release the file descriptor.
+//
+// This is the streaming counterpart to readFSMSnapshotPayload: no large buffer
+// is allocated, so it is suitable for bridge-mode forwarding of GiB-scale
+// snapshots.
+func openFSMSnapshotPayloadReader(path string) (io.ReadCloser, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, statFSMFileError(err)
+	}
+	if info.Size() < fsmMinFileSize {
+		return nil, errors.WithStack(ErrFSMSnapshotTooSmall)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	payloadSize := info.Size() - fsmFooterSize
+	return &limitedReadCloser{
+		Reader: io.LimitReader(f, payloadSize),
+		Closer: f,
+	}, nil
+}
+
 // statFSMFileError converts an os.Stat error to the appropriate typed error.
 func statFSMFileError(err error) error {
 	if os.IsNotExist(err) {

--- a/internal/raftengine/etcd/fsm_snapshot_file.go
+++ b/internal/raftengine/etcd/fsm_snapshot_file.go
@@ -454,6 +454,13 @@ func cleanupStaleFSMSnaps(snapDir, fsmSnapDir string, disableStartupCRCCheck boo
 	if err != nil {
 		return err
 	}
+	if liveIndexes == nil {
+		// snapDir does not exist: cannot determine the authoritative live token
+		// set. Skip FSM orphan removal to avoid deleting all .fsm files based
+		// on incomplete information (e.g. misconfigured path or first-boot race).
+		slog.Warn("snapshot directory not found; skipping FSM orphan cleanup", "snap_dir", snapDir)
+		return nil
+	}
 
 	return removeStaleFSMFiles(fsmSnapDir, liveIndexes, disableStartupCRCCheck)
 }

--- a/internal/raftengine/etcd/fsm_snapshot_file.go
+++ b/internal/raftengine/etcd/fsm_snapshot_file.go
@@ -261,20 +261,22 @@ func writeFSMSnapshotPayload(snapshot Snapshot, f *os.File) (uint32, error) {
 // Returns typed errors (ErrFSMSnapshotFileCRC, ErrFSMSnapshotTokenCRC, etc.) to
 // allow the caller to take the correct recovery action.
 func openAndRestoreFSMSnapshot(fsm StateMachine, path string, tokenCRC uint32) error {
-	info, err := os.Stat(path)
+	// Open before stat so the size and file content are guaranteed to be
+	// from the same inode (no TOCTOU between os.Stat and os.Open).
+	f, err := os.Open(path)
 	if err != nil {
 		return statFSMFileError(err)
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return errors.WithStack(err)
 	}
 	if info.Size() < fsmMinFileSize {
 		return errors.Wrapf(ErrFSMSnapshotTooSmall,
 			"file too small: %d bytes (minimum %d)", info.Size(), fsmMinFileSize)
 	}
-
-	f, err := os.Open(path)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	defer f.Close()
 
 	// Fail fast: read footer and compare to tokenCRC before calling fsm.Restore,
 	// so a corrupt token never causes FSM state mutation.
@@ -337,20 +339,22 @@ func restoreAndComputeCRC(f *os.File, fileSize int64, fsm StateMachine) (uint32,
 // verifyFSMSnapshotFile performs a read-only CRC check without restoring the FSM.
 // Used for startup orphan detection. Pass tokenCRC=0 to skip the token comparison.
 func verifyFSMSnapshotFile(path string, tokenCRC uint32) error {
-	info, err := os.Stat(path)
+	// Open before stat to eliminate the TOCTOU window between path lookup
+	// and file open (consistent with openAndRestoreFSMSnapshot).
+	f, err := os.Open(path)
 	if err != nil {
 		return statFSMFileError(err)
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		return errors.WithStack(err)
 	}
 	if info.Size() < fsmMinFileSize {
 		return errors.Wrapf(ErrFSMSnapshotTooSmall,
 			"file too small: %d bytes (minimum %d)", info.Size(), fsmMinFileSize)
 	}
-
-	f, err := os.Open(path)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	defer f.Close()
 
 	payloadSize := info.Size() - fsmFooterSize
 	h := crc32.New(crc32cTable)
@@ -389,22 +393,13 @@ type limitedReadCloser struct {
 // is allocated, so it is suitable for bridge-mode forwarding of GiB-scale
 // snapshots.
 func openFSMSnapshotPayloadReader(path string) (io.ReadCloser, error) {
-	info, err := os.Stat(path)
+	// Open before stat: eliminates the TOCTOU window between path lookup and
+	// open; file size is obtained via fstat on the open fd.
+	f, err := os.Open(path)
 	if err != nil {
 		return nil, statFSMFileError(err)
 	}
-	if info.Size() < fsmMinFileSize {
-		return nil, errors.WithStack(ErrFSMSnapshotTooSmall)
-	}
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	payloadSize := info.Size() - fsmFooterSize
-	return &limitedReadCloser{
-		Reader: io.LimitReader(f, payloadSize),
-		Closer: f,
-	}, nil
+	return openFSMPayloadFromFD(f)
 }
 
 // openFSMSnapshotFile opens the .fsm file at path and returns the *os.File.
@@ -457,19 +452,21 @@ func statFSMFileError(err error) error {
 // engine registers SetFSMPayloadOpener so this in-memory path is only reached
 // for legacy receivers that predate Phase 2 or when the opener is not wired.
 func readFSMSnapshotPayload(path string) ([]byte, error) {
-	info, err := os.Stat(path)
+	// Open before stat: eliminates the TOCTOU window between path lookup and
+	// open so size and content are guaranteed to be from the same inode.
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, statFSMFileError(err)
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	if info.Size() < fsmMinFileSize {
 		return nil, errors.WithStack(ErrFSMSnapshotTooSmall)
 	}
-
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	defer f.Close()
 
 	payloadSize := info.Size() - fsmFooterSize
 	if payloadSize > fsmMaxInMemPayload {

--- a/internal/raftengine/etcd/fsm_snapshot_file.go
+++ b/internal/raftengine/etcd/fsm_snapshot_file.go
@@ -70,9 +70,13 @@ type snapshotToken struct {
 	CRC32C uint32
 }
 
-// isSnapshotToken returns true if data begins with the EKVT magic prefix.
+// isSnapshotToken returns true if data is exactly snapshotTokenSize bytes and
+// begins with the EKVT magic prefix. The length check prevents false positives
+// from legacy FSM payloads that happen to start with the same magic bytes:
+// a false positive in dispatchSnapshot would cause decodeSnapshotToken to fail
+// and block the send instead of falling back to the legacy path.
 func isSnapshotToken(data []byte) bool {
-	if len(data) < snapshotTokenMagicLen {
+	if len(data) != snapshotTokenSize {
 		return false
 	}
 	return [snapshotTokenMagicLen]byte(data[:snapshotTokenMagicLen]) == snapshotTokenMagic
@@ -581,7 +585,9 @@ func purgeSnapPair(snapDir, fsmSnapDir, snapName string) error {
 	}
 
 	// Remove the corresponding .fsm file second.
-	if idx > 0 {
+	// Guard fsmSnapDir: when disk offloading is not configured (e.g. unit tests),
+	// fsmSnapDir may be empty and fsmSnapPath would return a relative path.
+	if idx > 0 && fsmSnapDir != "" {
 		fsmPath := fsmSnapPath(fsmSnapDir, idx)
 		if removeErr := os.Remove(fsmPath); removeErr != nil && !os.IsNotExist(removeErr) {
 			return errors.WithStack(removeErr)

--- a/internal/raftengine/etcd/fsm_snapshot_file.go
+++ b/internal/raftengine/etcd/fsm_snapshot_file.go
@@ -24,8 +24,9 @@ const (
 	// fsmFooterSize is the size of the CRC32C footer appended to each .fsm file.
 	fsmFooterSize = 4
 
-	// fsmMinFileSize is the minimum valid .fsm size: at least 1 byte payload + 4 bytes CRC footer.
-	fsmMinFileSize = fsmFooterSize + 1
+	// fsmMinFileSize is the minimum valid .fsm size: 0 bytes payload + 4 bytes CRC footer.
+	// A state machine with empty state writes only the 4-byte CRC footer, which is valid.
+	fsmMinFileSize = fsmFooterSize
 
 	// snapshotTokenMagicLen is the number of magic bytes at the start of a token.
 	snapshotTokenMagicLen = 4
@@ -516,9 +517,9 @@ func removeStaleFSMFile(fsmSnapDir, name string, liveIndexes map[uint64]bool, di
 	if disableStartupCRCCheck {
 		return
 	}
-	if verifyErr := verifyFSMSnapshotFile(fsmPath, 0); errors.Is(verifyErr, ErrFSMSnapshotFileCRC) {
-		slog.Warn("removing corrupt fsm snapshot", "path", fsmPath, "error", verifyErr)
-		removeWithWarn(fsmPath, "corrupt fsm snapshot")
+	if verifyErr := verifyFSMSnapshotFile(fsmPath, 0); verifyErr != nil && !errors.Is(verifyErr, ErrFSMSnapshotNotFound) {
+		slog.Warn("removing invalid fsm snapshot", "path", fsmPath, "error", verifyErr)
+		removeWithWarn(fsmPath, "invalid fsm snapshot")
 	}
 }
 

--- a/internal/raftengine/etcd/fsm_snapshot_file.go
+++ b/internal/raftengine/etcd/fsm_snapshot_file.go
@@ -195,7 +195,6 @@ func writeFSMSnapshotFile(snapshot Snapshot, fsmSnapDir string, index uint64) (u
 		return 0, errors.WithStack(err)
 	}
 	if err := tmpFile.Close(); err != nil {
-		committed = true
 		return 0, errors.WithStack(err)
 	}
 	committed = true
@@ -342,14 +341,15 @@ func statFSMFileError(err error) error {
 }
 
 // readFSMSnapshotPayload reads the .fsm file payload (all bytes except the
-// 4-byte CRC footer) into memory. Used by the Phase 1 bridge mode in Dispatch
-// to reconstruct the full FSM bytes for legacy receivers.
+// 4-byte CRC footer) into memory, verifying the CRC32C footer before returning.
+// Used by the Phase 1 bridge mode in Dispatch to reconstruct the full FSM bytes
+// for legacy receivers.
 func readFSMSnapshotPayload(path string) ([]byte, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	if info.Size() < fsmFooterSize {
+	if info.Size() < fsmMinFileSize {
 		return nil, errors.WithStack(ErrFSMSnapshotTooSmall)
 	}
 
@@ -361,8 +361,18 @@ func readFSMSnapshotPayload(path string) ([]byte, error) {
 
 	payloadSize := info.Size() - fsmFooterSize
 	data := make([]byte, payloadSize)
-	if _, err := io.ReadFull(f, data); err != nil {
+	h := crc32.New(crc32cTable)
+	tr := io.TeeReader(io.LimitReader(f, payloadSize), h)
+	if _, err := io.ReadFull(tr, data); err != nil {
 		return nil, errors.WithStack(err)
+	}
+
+	var footer uint32
+	if err := binary.Read(f, binary.BigEndian, &footer); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if h.Sum32() != footer {
+		return nil, errors.Wrapf(ErrFSMSnapshotFileCRC, "path=%s", path)
 	}
 	return data, nil
 }

--- a/internal/raftengine/etcd/fsm_snapshot_file_test.go
+++ b/internal/raftengine/etcd/fsm_snapshot_file_test.go
@@ -365,3 +365,115 @@ func TestParseSnapFileIndex(t *testing.T) {
 	require.Equal(t, uint64(0), parseSnapFileIndex("badname.snap"))
 	require.Equal(t, uint64(0), parseSnapFileIndex("nohyphen.snap"))
 }
+
+// --- readFSMSnapshotPayload tests ---
+
+func TestReadFSMSnapshotPayloadGoodFile(t *testing.T) {
+	dir := t.TempDir()
+	payload := []byte("read payload test data here")
+	crc, path := writeFSMFileForTest(t, dir, 5, payload)
+	require.NotZero(t, crc)
+
+	got, err := readFSMSnapshotPayload(path)
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+}
+
+func TestReadFSMSnapshotPayloadBadCRC(t *testing.T) {
+	dir := t.TempDir()
+	payload := []byte("good payload data")
+	_, path := writeFSMFileForTest(t, dir, 6, payload)
+
+	// Corrupt the first byte of the payload.
+	f, err := os.OpenFile(path, os.O_RDWR, 0o600)
+	require.NoError(t, err)
+	_, err = f.Write([]byte{0xFF})
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, err = readFSMSnapshotPayload(path)
+	require.ErrorIs(t, err, ErrFSMSnapshotFileCRC)
+}
+
+func TestReadFSMSnapshotPayloadTooSmall(t *testing.T) {
+	dir := t.TempDir()
+	path := fsmSnapPath(dir, 7)
+	require.NoError(t, os.WriteFile(path, []byte{0x01, 0x02, 0x03, 0x04}, 0o600))
+
+	_, err := readFSMSnapshotPayload(path)
+	require.ErrorIs(t, err, ErrFSMSnapshotTooSmall)
+}
+
+func TestReadFSMSnapshotPayloadFileNotFound(t *testing.T) {
+	_, err := readFSMSnapshotPayload("/nonexistent/path/snapshot.fsm")
+	require.Error(t, err)
+}
+
+// --- verifyFSMSnapshotFile tests ---
+
+func TestVerifyFSMSnapshotFileGood(t *testing.T) {
+	dir := t.TempDir()
+	payload := []byte("verify test payload data")
+	crc, path := writeFSMFileForTest(t, dir, 10, payload)
+
+	// tokenCRC=0 skips token comparison (startup orphan check mode).
+	require.NoError(t, verifyFSMSnapshotFile(path, 0))
+	// tokenCRC matching the footer: full verification.
+	require.NoError(t, verifyFSMSnapshotFile(path, crc))
+}
+
+func TestVerifyFSMSnapshotFileTokenMismatch(t *testing.T) {
+	dir := t.TempDir()
+	payload := []byte("verify token mismatch payload")
+	crc, path := writeFSMFileForTest(t, dir, 11, payload)
+
+	wrongCRC := crc ^ 0xFFFFFFFF
+	err := verifyFSMSnapshotFile(path, wrongCRC)
+	require.ErrorIs(t, err, ErrFSMSnapshotTokenCRC)
+}
+
+func TestVerifyFSMSnapshotFileBadFooter(t *testing.T) {
+	dir := t.TempDir()
+	payload := []byte("verify bad footer payload data")
+	_, path := writeFSMFileForTest(t, dir, 12, payload)
+
+	// Corrupt one byte of the payload so the computed CRC differs from the footer.
+	f, err := os.OpenFile(path, os.O_RDWR, 0o600)
+	require.NoError(t, err)
+	_, err = f.Write([]byte{0xFF})
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	err = verifyFSMSnapshotFile(path, 0)
+	require.ErrorIs(t, err, ErrFSMSnapshotFileCRC)
+}
+
+func TestVerifyFSMSnapshotFileTooSmall(t *testing.T) {
+	dir := t.TempDir()
+	path := fsmSnapPath(dir, 13)
+	require.NoError(t, os.WriteFile(path, []byte{0x01, 0x02}, 0o600))
+
+	err := verifyFSMSnapshotFile(path, 0)
+	require.ErrorIs(t, err, ErrFSMSnapshotTooSmall)
+}
+
+func TestVerifyFSMSnapshotFileNotFound(t *testing.T) {
+	err := verifyFSMSnapshotFile("/nonexistent/path/42.fsm", 0)
+	require.ErrorIs(t, err, ErrFSMSnapshotNotFound)
+}
+
+func TestWriteFSMSnapshotFileEmptyPayload(t *testing.T) {
+	dir := t.TempDir()
+	// An empty snapshot writes only the 4-byte CRC footer.
+	snap := &testSnapshot{data: []byte{}}
+
+	crc, err := writeFSMSnapshotFile(snap, dir, 200)
+	require.NoError(t, err)
+	// Empty payload: crc32c("") == 0x00000000, which is a valid (zero) checksum.
+	_ = crc // zero is allowed for empty input
+
+	path := fsmSnapPath(dir, 200)
+	info, statErr := os.Stat(path)
+	require.NoError(t, statErr)
+	require.Equal(t, int64(4), info.Size()) // only the footer
+}

--- a/internal/raftengine/etcd/fsm_snapshot_file_test.go
+++ b/internal/raftengine/etcd/fsm_snapshot_file_test.go
@@ -194,9 +194,9 @@ func TestOpenAndRestoreFSMSnapshotTokenMismatch(t *testing.T) {
 
 func TestOpenAndRestoreFSMSnapshotTooSmall(t *testing.T) {
 	dir := t.TempDir()
-	// Write a file with fewer than 5 bytes.
+	// Write a file with fewer than fsmFooterSize (4) bytes.
 	path := fsmSnapPath(dir, 99)
-	require.NoError(t, os.WriteFile(path, []byte{0x01, 0x02, 0x03, 0x04}, 0o600))
+	require.NoError(t, os.WriteFile(path, []byte{0x01, 0x02, 0x03}, 0o600))
 
 	fsm := &dummyFSM{}
 	err := openAndRestoreFSMSnapshot(fsm, path, 0)
@@ -398,7 +398,7 @@ func TestReadFSMSnapshotPayloadBadCRC(t *testing.T) {
 func TestReadFSMSnapshotPayloadTooSmall(t *testing.T) {
 	dir := t.TempDir()
 	path := fsmSnapPath(dir, 7)
-	require.NoError(t, os.WriteFile(path, []byte{0x01, 0x02, 0x03, 0x04}, 0o600))
+	require.NoError(t, os.WriteFile(path, []byte{0x01, 0x02, 0x03}, 0o600))
 
 	_, err := readFSMSnapshotPayload(path)
 	require.ErrorIs(t, err, ErrFSMSnapshotTooSmall)

--- a/internal/raftengine/etcd/fsm_snapshot_file_test.go
+++ b/internal/raftengine/etcd/fsm_snapshot_file_test.go
@@ -1,0 +1,367 @@
+package etcd
+
+import (
+	"bytes"
+	"encoding/binary"
+	"hash/crc32"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// --- Token encode/decode tests ---
+
+func TestTokenRoundTrip(t *testing.T) {
+	cases := []struct {
+		name   string
+		index  uint64
+		crc32c uint32
+	}{
+		{"zero", 0, 0},
+		{"maxUint64", math.MaxUint64, math.MaxUint32},
+		{"typical", 12345678, 0xDEADBEEF},
+		{"indexOnly", 100, 0},
+		{"crcOnly", 0, 42},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded := encodeSnapshotToken(tc.index, tc.crc32c)
+			require.Len(t, encoded, snapshotTokenSize)
+
+			tok, err := decodeSnapshotToken(encoded)
+			require.NoError(t, err)
+			require.Equal(t, tc.index, tok.Index)
+			require.Equal(t, tc.crc32c, tok.CRC32C)
+		})
+	}
+}
+
+func TestTokenMagicRejection(t *testing.T) {
+	// isSnapshotToken returns false for non-EKVT prefixes.
+	require.False(t, isSnapshotToken(nil))
+	require.False(t, isSnapshotToken([]byte{}))
+	require.False(t, isSnapshotToken([]byte{0, 1, 2, 3}))
+	require.False(t, isSnapshotToken([]byte("EKVR"))) // different magic
+	require.False(t, isSnapshotToken([]byte("EKVM")))
+	require.False(t, isSnapshotToken([]byte("EKVW")))
+
+	// Pebble magic prefix should not be recognised as a token.
+	require.False(t, isSnapshotToken([]byte("EKVPBBL1")))
+
+	// A valid EKVT token should be recognised.
+	token := encodeSnapshotToken(1, 0)
+	require.True(t, isSnapshotToken(token))
+
+	// decodeSnapshotToken rejects wrong lengths (0–16).
+	for l := 0; l < snapshotTokenSize; l++ {
+		_, err := decodeSnapshotToken(make([]byte, l))
+		require.ErrorIs(t, err, ErrFSMSnapshotTokenInvalid,
+			"expected ErrFSMSnapshotTokenInvalid for length %d", l)
+	}
+
+	// decodeSnapshotToken rejects wrong magic.
+	bad := encodeSnapshotToken(1, 0)
+	bad[0] = 'X'
+	_, err := decodeSnapshotToken(bad)
+	require.ErrorIs(t, err, ErrFSMSnapshotTokenInvalid)
+}
+
+// --- CRC writer tests ---
+
+func TestCRCWriterMatchesStdlib(t *testing.T) {
+	data := []byte("hello world, this is a test payload")
+	expected := crc32.Checksum(data, crc32cTable)
+
+	// Full write.
+	var buf bytes.Buffer
+	w := newCRC32CWriter(&buf)
+	_, err := w.Write(data)
+	require.NoError(t, err)
+	require.Equal(t, expected, w.Sum32())
+
+	// Incremental writes must accumulate correctly.
+	var buf2 bytes.Buffer
+	w2 := newCRC32CWriter(&buf2)
+	for _, b := range data {
+		_, err := w2.Write([]byte{b})
+		require.NoError(t, err)
+	}
+	require.Equal(t, expected, w2.Sum32())
+
+	// Both should produce the same checksum as the stdlib.
+	require.Equal(t, w.Sum32(), w2.Sum32())
+}
+
+// --- Helper to write a valid .fsm file for testing ---
+
+func writeFSMFileForTest(t *testing.T, dir string, index uint64, payload []byte) (uint32, string) {
+	t.Helper()
+	path := fsmSnapPath(dir, index)
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	h := crc32.New(crc32cTable)
+	w := io.MultiWriter(f, h)
+	_, err = w.Write(payload)
+	require.NoError(t, err)
+
+	checksum := h.Sum32()
+	err = binary.Write(f, binary.BigEndian, checksum)
+	require.NoError(t, err)
+	return checksum, path
+}
+
+// dummyFSM is a state machine that records the bytes it restores.
+type dummyFSM struct {
+	restored []byte
+}
+
+func (d *dummyFSM) Apply(_ []byte) any { return nil }
+func (d *dummyFSM) Restore(r io.Reader) error {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	d.restored = data
+	return nil
+}
+func (d *dummyFSM) Snapshot() (Snapshot, error) {
+	return &testSnapshot{data: d.restored}, nil
+}
+
+// --- openAndRestoreFSMSnapshot tests ---
+
+func TestOpenAndRestoreFSMSnapshotGoodFile(t *testing.T) {
+	dir := t.TempDir()
+	payload := []byte("some FSM state data here")
+	crc, _ := writeFSMFileForTest(t, dir, 42, payload)
+
+	fsm := &dummyFSM{}
+	err := openAndRestoreFSMSnapshot(fsm, fsmSnapPath(dir, 42), crc)
+	require.NoError(t, err)
+	require.Equal(t, payload, fsm.restored)
+}
+
+func TestOpenAndRestoreFSMSnapshotBadFooter(t *testing.T) {
+	dir := t.TempDir()
+	payload := []byte("good payload bytes here")
+	_, path := writeFSMFileForTest(t, dir, 10, payload)
+
+	// Corrupt the last byte of the footer.
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	f, err := os.OpenFile(path, os.O_RDWR, 0o600)
+	require.NoError(t, err)
+	_, err = f.Seek(info.Size()-1, io.SeekStart)
+	require.NoError(t, err)
+	_, err = f.Write([]byte{0xFF})
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// Read the now-corrupted footer to pass as tokenCRC so the pre-check passes.
+	f2, err := os.Open(path)
+	require.NoError(t, err)
+	_, err = f2.Seek(info.Size()-4, io.SeekStart)
+	require.NoError(t, err)
+	var storedCRC uint32
+	require.NoError(t, binary.Read(f2, binary.BigEndian, &storedCRC))
+	require.NoError(t, f2.Close())
+
+	fsm := &dummyFSM{}
+	err = openAndRestoreFSMSnapshot(fsm, path, storedCRC)
+	// The computed CRC won't match the footer bytes because the footer itself
+	// was corrupted — ErrFSMSnapshotFileCRC expected.
+	require.ErrorIs(t, err, ErrFSMSnapshotFileCRC)
+}
+
+func TestOpenAndRestoreFSMSnapshotTokenMismatch(t *testing.T) {
+	dir := t.TempDir()
+	payload := []byte("good payload")
+	crc, _ := writeFSMFileForTest(t, dir, 7, payload)
+
+	fsm := &dummyFSM{}
+	wrongCRC := crc ^ 0xFFFFFFFF // flip all bits
+	err := openAndRestoreFSMSnapshot(fsm, fsmSnapPath(dir, 7), wrongCRC)
+	require.ErrorIs(t, err, ErrFSMSnapshotTokenCRC)
+	// FSM should NOT have been restored.
+	require.Nil(t, fsm.restored)
+}
+
+func TestOpenAndRestoreFSMSnapshotTooSmall(t *testing.T) {
+	dir := t.TempDir()
+	// Write a file with fewer than 5 bytes.
+	path := fsmSnapPath(dir, 99)
+	require.NoError(t, os.WriteFile(path, []byte{0x01, 0x02, 0x03, 0x04}, 0o600))
+
+	fsm := &dummyFSM{}
+	err := openAndRestoreFSMSnapshot(fsm, path, 0)
+	require.ErrorIs(t, err, ErrFSMSnapshotTooSmall)
+}
+
+func TestStripFooterReaderBoundary(t *testing.T) {
+	// Verify that io.LimitReader(file, payloadSize) exposes exactly the payload
+	// bytes and that the CRC accumulator covers the full payload.
+	dir := t.TempDir()
+	payload := []byte("exact boundary test")
+	crc, path := writeFSMFileForTest(t, dir, 1, payload)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	payloadSize := info.Size() - 4
+	h := crc32.New(crc32cTable)
+	tee := io.TeeReader(io.LimitReader(f, payloadSize), h)
+	got, err := io.ReadAll(tee)
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+	require.Equal(t, crc, h.Sum32())
+
+	// The next read from f must be the 4-byte footer.
+	var footer uint32
+	require.NoError(t, binary.Read(f, binary.BigEndian, &footer))
+	require.Equal(t, crc, footer)
+}
+
+// --- Crash safety and startup cleanup tests ---
+
+func TestCrashAfterTmpBeforeRename(t *testing.T) {
+	snapDir := t.TempDir()
+	fsmSnapDir := t.TempDir()
+
+	// Simulate a .fsm.tmp orphan left by a crash.
+	tmpPath := filepath.Join(fsmSnapDir, "crashtest.fsm.tmp")
+	require.NoError(t, os.WriteFile(tmpPath, []byte("partial"), 0o600))
+
+	// cleanupStaleFSMSnaps should remove the orphan; no .fsm file should exist.
+	require.NoError(t, cleanupStaleFSMSnaps(snapDir, fsmSnapDir, false))
+
+	// Orphan removed.
+	_, err := os.Stat(tmpPath)
+	require.True(t, os.IsNotExist(err))
+
+	// No .fsm file was promoted.
+	entries, err := os.ReadDir(fsmSnapDir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		require.NotEqual(t, ".fsm", filepath.Ext(e.Name()))
+	}
+}
+
+func TestCleanupStaleFSMSnapsIndexBased(t *testing.T) {
+	snapDir := t.TempDir()
+	fsmSnapDir := t.TempDir()
+
+	// Create a .fsm file with index 42 but no corresponding .snap token.
+	payload := []byte("valid fsm data here 1234")
+	crc, _ := writeFSMFileForTest(t, fsmSnapDir, 42, payload)
+	require.NotZero(t, crc)
+
+	// cleanupStaleFSMSnaps should remove it because there's no matching .snap.
+	require.NoError(t, cleanupStaleFSMSnaps(snapDir, fsmSnapDir, false))
+
+	_, err := os.Stat(fsmSnapPath(fsmSnapDir, 42))
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestSnapSavedOnlyAfterRename(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a snapshot that writes to a file; if WriteTo fails, no final .fsm
+	// should be committed.
+	errSnap := &failingSnapshot{err: io.ErrUnexpectedEOF}
+	_, err := writeFSMSnapshotFile(errSnap, dir, 5)
+	require.Error(t, err)
+
+	// No .fsm file should exist.
+	entries, err2 := os.ReadDir(dir)
+	require.NoError(t, err2)
+	for _, e := range entries {
+		require.NotEqual(t, ".fsm", filepath.Ext(e.Name()),
+			"unexpected .fsm file: %s", e.Name())
+	}
+}
+
+// failingSnapshot is a Snapshot that always fails WriteTo.
+type failingSnapshot struct {
+	err error
+}
+
+func (e *failingSnapshot) WriteTo(_ io.Writer) (int64, error) { return 0, e.err }
+func (e *failingSnapshot) Close() error                       { return nil }
+
+func TestPurgeOldSnapshotFilesOrdering(t *testing.T) {
+	snapDir := t.TempDir()
+	fsmSnapDir := t.TempDir()
+
+	// Create 5 snap+fsm pairs.
+	for i := uint64(1); i <= 5; i++ {
+		createSnapFile(t, snapDir, i*1000)
+		payload := []byte("payload")
+		writeFSMFileForTest(t, fsmSnapDir, i*1000, payload)
+	}
+
+	require.NoError(t, purgeOldSnapshotFiles(snapDir, fsmSnapDir))
+
+	// After purge, only the newest 3 pairs should remain.
+	snapEntries, err := os.ReadDir(snapDir)
+	require.NoError(t, err)
+	var snaps []string
+	for _, e := range snapEntries {
+		if filepath.Ext(e.Name()) == ".snap" {
+			snaps = append(snaps, e.Name())
+		}
+	}
+	require.Len(t, snaps, 3)
+
+	fsmEntries, err := os.ReadDir(fsmSnapDir)
+	require.NoError(t, err)
+	var fsms []string
+	for _, e := range fsmEntries {
+		if filepath.Ext(e.Name()) == ".fsm" {
+			fsms = append(fsms, e.Name())
+		}
+	}
+	require.Len(t, fsms, 3)
+}
+
+// --- writeFSMSnapshotFile integration ---
+
+func TestWriteFSMSnapshotFileRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	payload := []byte("round-trip FSM state data 12345678")
+	snap := &testSnapshot{data: payload}
+
+	crc, err := writeFSMSnapshotFile(snap, dir, 100)
+	require.NoError(t, err)
+	require.NotZero(t, crc)
+
+	// The final .fsm file must exist.
+	path := fsmSnapPath(dir, 100)
+	info, statErr := os.Stat(path)
+	require.NoError(t, statErr)
+	require.Equal(t, int64(len(payload)+4), info.Size())
+
+	// openAndRestoreFSMSnapshot must recover the original payload.
+	fsm := &dummyFSM{}
+	require.NoError(t, openAndRestoreFSMSnapshot(fsm, path, crc))
+	require.Equal(t, payload, fsm.restored)
+}
+
+func TestFsmSnapPath(t *testing.T) {
+	path := fsmSnapPath("/data/fsm-snap", 0x1234ABCD)
+	require.Equal(t, "/data/fsm-snap/000000001234abcd.fsm", path)
+}
+
+func TestParseSnapFileIndex(t *testing.T) {
+	require.Equal(t, uint64(0x60), parseSnapFileIndex("0000000000000001-0000000000000060.snap"))
+	require.Equal(t, uint64(0), parseSnapFileIndex("badname.snap"))
+	require.Equal(t, uint64(0), parseSnapFileIndex("nohyphen.snap"))
+}

--- a/internal/raftengine/etcd/grpc_transport.go
+++ b/internal/raftengine/etcd/grpc_transport.go
@@ -44,6 +44,7 @@ type GRPCTransport struct {
 	handler           MessageHandler
 	snapshotChunkSize int
 	spoolDir          string
+	fsmSnapDir        string
 	dialGroup         singleflight.Group
 }
 
@@ -92,6 +93,15 @@ func (t *GRPCTransport) SetSpoolDir(dir string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.spoolDir = dir
+}
+
+func (t *GRPCTransport) SetFSMSnapDir(dir string) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.fsmSnapDir = dir
 }
 
 func (t *GRPCTransport) UpsertPeer(peer Peer) {
@@ -158,11 +168,59 @@ func (t *GRPCTransport) Dispatch(ctx context.Context, msg raftpb.Message) error 
 	if t == nil {
 		return nil
 	}
-	if msg.Type == raftpb.MsgSnap || (msg.Snapshot != nil && len(msg.Snapshot.Data) > 0) {
-		ctx, cancel := transportContext(ctx, defaultSnapshotDispatchTimeout)
-		defer cancel()
-		return t.sendSnapshot(ctx, msg)
+	if isSnapshotMsg(msg) {
+		return t.dispatchSnapshot(ctx, msg)
 	}
+	return t.dispatchRegular(ctx, msg)
+}
+
+func isSnapshotMsg(msg raftpb.Message) bool {
+	return msg.Type == raftpb.MsgSnap || (msg.Snapshot != nil && len(msg.Snapshot.Data) > 0)
+}
+
+func (t *GRPCTransport) dispatchSnapshot(ctx context.Context, msg raftpb.Message) error {
+	ctx, cancel := transportContext(ctx, defaultSnapshotDispatchTimeout)
+	defer cancel()
+
+	patched, err := t.applyBridgeMode(msg)
+	if err != nil {
+		return err
+	}
+	return t.sendSnapshot(ctx, patched)
+}
+
+// applyBridgeMode implements the Phase 1 bridge: when MemoryStorage holds a
+// token, the .fsm file is read back into []byte so all receivers (including
+// legacy nodes that predate Phase 2) get a standard full-payload MsgSnap.
+// This allocation is transient — freed after the send — and only occurs when
+// a slow follower needs a snapshot, not on every periodic creation.
+func (t *GRPCTransport) applyBridgeMode(msg raftpb.Message) (raftpb.Message, error) {
+	if msg.Snapshot == nil || !isSnapshotToken(msg.Snapshot.Data) {
+		return msg, nil
+	}
+	t.mu.RLock()
+	fsmSnapDir := t.fsmSnapDir
+	t.mu.RUnlock()
+	if fsmSnapDir == "" {
+		return msg, nil
+	}
+
+	tok, err := decodeSnapshotToken(msg.Snapshot.Data)
+	if err != nil {
+		return msg, errors.WithStack(err)
+	}
+	payload, err := readFSMSnapshotPayload(fsmSnapPath(fsmSnapDir, tok.Index))
+	if err != nil {
+		return msg, errors.WithStack(err)
+	}
+
+	snapCopy := *msg.Snapshot
+	snapCopy.Data = payload
+	msg.Snapshot = &snapCopy
+	return msg, nil
+}
+
+func (t *GRPCTransport) dispatchRegular(ctx context.Context, msg raftpb.Message) error {
 	ctx, cancel := transportContext(ctx, defaultDispatchTimeout)
 	defer cancel()
 
@@ -479,6 +537,7 @@ func (t *GRPCTransport) receiveSnapshotStream(stream pb.EtcdRaft_SendSnapshotSer
 	t.mu.RLock()
 	spoolDir := t.spoolDir
 	t.mu.RUnlock()
+
 	spool, err := newSnapshotSpool(spoolDir)
 	if err != nil {
 		return raftpb.Message{}, err

--- a/internal/raftengine/etcd/grpc_transport.go
+++ b/internal/raftengine/etcd/grpc_transport.go
@@ -45,6 +45,7 @@ type GRPCTransport struct {
 	snapshotChunkSize int
 	spoolDir          string
 	fsmSnapDir        string
+	readFSMPayload    func(index uint64) ([]byte, error)
 	dialGroup         singleflight.Group
 }
 
@@ -102,6 +103,15 @@ func (t *GRPCTransport) SetFSMSnapDir(dir string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.fsmSnapDir = dir
+}
+
+func (t *GRPCTransport) SetFSMPayloadReader(fn func(index uint64) ([]byte, error)) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.readFSMPayload = fn
 }
 
 func (t *GRPCTransport) UpsertPeer(peer Peer) {
@@ -199,9 +209,9 @@ func (t *GRPCTransport) applyBridgeMode(msg raftpb.Message) (raftpb.Message, err
 		return msg, nil
 	}
 	t.mu.RLock()
-	fsmSnapDir := t.fsmSnapDir
+	readFn := t.readFSMPayload
 	t.mu.RUnlock()
-	if fsmSnapDir == "" {
+	if readFn == nil {
 		return msg, nil
 	}
 
@@ -209,7 +219,7 @@ func (t *GRPCTransport) applyBridgeMode(msg raftpb.Message) (raftpb.Message, err
 	if err != nil {
 		return msg, errors.WithStack(err)
 	}
-	payload, err := readFSMSnapshotPayload(fsmSnapPath(fsmSnapDir, tok.Index))
+	payload, err := readFn(tok.Index)
 	if err != nil {
 		return msg, errors.WithStack(err)
 	}

--- a/internal/raftengine/etcd/grpc_transport.go
+++ b/internal/raftengine/etcd/grpc_transport.go
@@ -45,8 +45,13 @@ type GRPCTransport struct {
 	snapshotChunkSize int
 	spoolDir          string
 	fsmSnapDir        string
-	readFSMPayload    func(index uint64) ([]byte, error)
-	dialGroup         singleflight.Group
+	// readFSMPayload is the fallback bridge callback that materialises the full
+	// FSM payload into memory. Used only when openFSMPayload is not set.
+	readFSMPayload func(index uint64) ([]byte, error)
+	// openFSMPayload is the preferred bridge callback that opens the .fsm file
+	// for streaming without allocating a large buffer.
+	openFSMPayload func(index uint64) (io.ReadCloser, error)
+	dialGroup      singleflight.Group
 }
 
 func NewGRPCTransport(peers []Peer) *GRPCTransport {
@@ -112,6 +117,18 @@ func (t *GRPCTransport) SetFSMPayloadReader(fn func(index uint64) ([]byte, error
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.readFSMPayload = fn
+}
+
+// SetFSMPayloadOpener registers the callback used by the bridge mode to stream
+// FSM snapshot payloads directly from disk without materialising the full
+// payload in memory.
+func (t *GRPCTransport) SetFSMPayloadOpener(fn func(index uint64) (io.ReadCloser, error)) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.openFSMPayload = fn
 }
 
 func (t *GRPCTransport) UpsertPeer(peer Peer) {
@@ -192,11 +209,55 @@ func (t *GRPCTransport) dispatchSnapshot(ctx context.Context, msg raftpb.Message
 	ctx, cancel := transportContext(ctx, defaultSnapshotDispatchTimeout)
 	defer cancel()
 
+	// Prefer streaming when the snapshot holds a token and an opener is wired.
+	// This avoids materialising the full FSM payload in memory on the sender.
+	if msg.Snapshot != nil && isSnapshotToken(msg.Snapshot.Data) {
+		t.mu.RLock()
+		openFn := t.openFSMPayload
+		t.mu.RUnlock()
+		if openFn != nil {
+			tok, err := decodeSnapshotToken(msg.Snapshot.Data)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+			return t.streamFSMSnapshot(ctx, msg, tok.Index, openFn)
+		}
+	}
+
+	// Fallback: materialise the payload (no opener wired, or non-token snapshot).
 	patched, err := t.applyBridgeMode(msg)
 	if err != nil {
 		return err
 	}
 	return t.sendSnapshot(ctx, patched)
+}
+
+// streamFSMSnapshot streams the .fsm payload file directly to the peer using
+// chunked gRPC without loading the full content into memory.
+func (t *GRPCTransport) streamFSMSnapshot(ctx context.Context, msg raftpb.Message, index uint64, openFn func(uint64) (io.ReadCloser, error)) error {
+	rc, err := openFn(index)
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	header, err := snapshotMessageHeader(msg)
+	if err != nil {
+		return err
+	}
+	client, err := t.clientFor(msg.To)
+	if err != nil {
+		return err
+	}
+	stream, err := client.SendSnapshot(ctx)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if err := sendSnapshotReaderChunks(stream, header, rc, t.chunkSize()); err != nil {
+		return err
+	}
+	_, err = stream.CloseAndRecv()
+	return errors.WithStack(err)
 }
 
 // applyBridgeMode implements the Phase 1 bridge: when MemoryStorage holds a
@@ -449,7 +510,15 @@ func sendSnapshotReaderChunks(stream pb.EtcdRaft_SendSnapshotClient, header []by
 	current, err := readSnapshotChunk(buffered, chunkSize)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
-			return sendSnapshotChunk(stream, &pb.EtcdRaftSnapshotChunk{Metadata: header, Final: true})
+			// The entire payload fit in one read (or reader was empty).
+			// current may be nil for an empty reader, or the full payload for
+			// a small snapshot. Include it so the receiver does not get an
+			// empty snapshot.Data.
+			return sendSnapshotChunk(stream, &pb.EtcdRaftSnapshotChunk{
+				Metadata: header,
+				Chunk:    current,
+				Final:    true,
+			})
 		}
 		return errors.WithStack(err)
 	}

--- a/internal/raftengine/etcd/grpc_transport.go
+++ b/internal/raftengine/etcd/grpc_transport.go
@@ -16,7 +16,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-const defaultSnapshotChunkSize = 1 << 20
+const defaultSnapshotChunkSize = 16 << 20
 
 const defaultDispatchTimeout = 5 * time.Second
 const defaultSnapshotDispatchTimeout = 30 * time.Minute

--- a/internal/raftengine/etcd/grpc_transport.go
+++ b/internal/raftengine/etcd/grpc_transport.go
@@ -21,6 +21,11 @@ const defaultSnapshotChunkSize = 16 << 20
 const defaultDispatchTimeout = 5 * time.Second
 const defaultSnapshotDispatchTimeout = 30 * time.Minute
 
+// defaultBridgeMaterializeLimit caps the number of bridge-mode snapshot
+// materializations that may hold memory concurrently. Each call allocates up
+// to fsmMaxInMemPayload; limiting concurrency bounds the aggregate allocation.
+const defaultBridgeMaterializeLimit = 1
+
 var (
 	errTransportPeerUnknown      = errors.New("etcd raft peer is not configured")
 	errTransportHandlerNil       = errors.New("etcd raft transport handler is not configured")
@@ -52,6 +57,10 @@ type GRPCTransport struct {
 	// for streaming without allocating a large buffer.
 	openFSMPayload func(index uint64) (io.ReadCloser, error)
 	dialGroup      singleflight.Group
+	// bridgeSem limits concurrent bridge-mode snapshot materializations so
+	// that aggregate in-memory allocation stays bounded even when multiple
+	// dispatch workers run simultaneously.
+	bridgeSem chan struct{}
 }
 
 func NewGRPCTransport(peers []Peer) *GRPCTransport {
@@ -73,6 +82,7 @@ func NewGRPCTransport(peers []Peer) *GRPCTransport {
 		clients:           make(map[string]pb.EtcdRaftClient),
 		conns:             make(map[string]*grpc.ClientConn),
 		snapshotChunkSize: defaultSnapshotChunkSize,
+		bridgeSem:         make(chan struct{}, defaultBridgeMaterializeLimit),
 	}
 }
 
@@ -225,7 +235,7 @@ func (t *GRPCTransport) dispatchSnapshot(ctx context.Context, msg raftpb.Message
 	}
 
 	// Fallback: materialise the payload (no opener wired, or non-token snapshot).
-	patched, err := t.applyBridgeMode(msg)
+	patched, err := t.applyBridgeMode(ctx, msg)
 	if err != nil {
 		return err
 	}
@@ -269,7 +279,10 @@ func (t *GRPCTransport) streamFSMSnapshot(ctx context.Context, msg raftpb.Messag
 // legacy nodes that predate Phase 2) get a standard full-payload MsgSnap.
 // This allocation is transient — freed after the send — and only occurs when
 // a slow follower needs a snapshot, not on every periodic creation.
-func (t *GRPCTransport) applyBridgeMode(msg raftpb.Message) (raftpb.Message, error) {
+//
+// bridgeSem caps the number of concurrent materializations so that aggregate
+// in-memory allocation stays bounded across all dispatch workers.
+func (t *GRPCTransport) applyBridgeMode(ctx context.Context, msg raftpb.Message) (raftpb.Message, error) {
 	if msg.Snapshot == nil || !isSnapshotToken(msg.Snapshot.Data) {
 		return msg, nil
 	}
@@ -284,6 +297,16 @@ func (t *GRPCTransport) applyBridgeMode(msg raftpb.Message) (raftpb.Message, err
 	if err != nil {
 		return msg, errors.WithStack(err)
 	}
+
+	// Acquire the bridge semaphore before allocating the payload buffer.
+	// Block until a slot is available or the dispatch context is cancelled.
+	select {
+	case t.bridgeSem <- struct{}{}:
+		defer func() { <-t.bridgeSem }()
+	case <-ctx.Done():
+		return msg, errors.WithStack(ctx.Err())
+	}
+
 	payload, err := readFn(tok.Index)
 	if err != nil {
 		return msg, errors.WithStack(err)

--- a/internal/raftengine/etcd/grpc_transport.go
+++ b/internal/raftengine/etcd/grpc_transport.go
@@ -239,7 +239,11 @@ func (t *GRPCTransport) streamFSMSnapshot(ctx context.Context, msg raftpb.Messag
 	if err != nil {
 		return err
 	}
-	defer rc.Close()
+	defer func() {
+		if closeErr := rc.Close(); closeErr != nil {
+			slog.Warn("failed to close FSM snapshot reader", "index", index, "error", closeErr)
+		}
+	}()
 
 	header, err := snapshotMessageHeader(msg)
 	if err != nil {

--- a/internal/raftengine/etcd/grpc_transport_test.go
+++ b/internal/raftengine/etcd/grpc_transport_test.go
@@ -1,6 +1,7 @@
 package etcd
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"os"
@@ -293,3 +294,55 @@ func TestApplyBridgeModeReaderError(t *testing.T) {
 	_, err := transport.applyBridgeMode(msg)
 	require.ErrorIs(t, err, ErrFSMSnapshotNotFound)
 }
+
+// TestSendSnapshotReaderChunksSmallPayloadPreservesData is a regression test
+// for a bug where a payload smaller than one chunk size was silently dropped.
+// readSnapshotChunk returns (data, io.EOF) for a short final read, and the old
+// code treated that the same as an empty reader, sending an empty chunk.
+func TestSendSnapshotReaderChunksSmallPayloadPreservesData(t *testing.T) {
+	payload := []byte("tiny payload under one chunk")
+	header := []byte("header-bytes")
+
+	client := &testSnapshotSendClient{}
+	err := sendSnapshotReaderChunks(client, header, bytes.NewReader(payload), defaultSnapshotChunkSize)
+	require.NoError(t, err)
+
+	require.Len(t, client.chunks, 1)
+	require.Equal(t, header, client.chunks[0].Metadata)
+	require.Equal(t, payload, client.chunks[0].Chunk)
+	require.True(t, client.chunks[0].Final)
+}
+
+func TestSendSnapshotReaderChunksEmptyPayloadSendsHeaderOnly(t *testing.T) {
+	header := []byte("header-bytes")
+
+	client := &testSnapshotSendClient{}
+	err := sendSnapshotReaderChunks(client, header, bytes.NewReader(nil), defaultSnapshotChunkSize)
+	require.NoError(t, err)
+
+	require.Len(t, client.chunks, 1)
+	require.Equal(t, header, client.chunks[0].Metadata)
+	require.Empty(t, client.chunks[0].Chunk)
+	require.True(t, client.chunks[0].Final)
+}
+
+// testSnapshotSendClient captures chunks sent via sendSnapshotReaderChunks / sendSnapshotChunks.
+type testSnapshotSendClient struct {
+	chunks []*pb.EtcdRaftSnapshotChunk
+}
+
+func (c *testSnapshotSendClient) Send(chunk *pb.EtcdRaftSnapshotChunk) error {
+	c.chunks = append(c.chunks, chunk)
+	return nil
+}
+
+func (c *testSnapshotSendClient) CloseAndRecv() (*pb.EtcdRaftAck, error) {
+	return &pb.EtcdRaftAck{}, nil
+}
+
+func (*testSnapshotSendClient) Header() (metadata.MD, error) { return nil, nil }
+func (*testSnapshotSendClient) Trailer() metadata.MD         { return nil }
+func (*testSnapshotSendClient) CloseSend() error             { return nil }
+func (*testSnapshotSendClient) Context() context.Context     { return context.Background() }
+func (*testSnapshotSendClient) SendMsg(any) error            { return nil }
+func (*testSnapshotSendClient) RecvMsg(any) error            { return nil }

--- a/internal/raftengine/etcd/grpc_transport_test.go
+++ b/internal/raftengine/etcd/grpc_transport_test.go
@@ -346,3 +346,239 @@ func (*testSnapshotSendClient) CloseSend() error             { return nil }
 func (*testSnapshotSendClient) Context() context.Context     { return context.Background() }
 func (*testSnapshotSendClient) SendMsg(any) error            { return nil }
 func (*testSnapshotSendClient) RecvMsg(any) error            { return nil }
+
+// testEtcdRaftClient is a minimal mock of pb.EtcdRaftClient that routes
+// SendSnapshot calls to a pre-wired testSnapshotSendClient.
+type testEtcdRaftClient struct {
+	stream *testSnapshotSendClient
+}
+
+func (c *testEtcdRaftClient) Send(_ context.Context, _ *pb.EtcdRaftMessage, _ ...grpc.CallOption) (*pb.EtcdRaftAck, error) {
+	return &pb.EtcdRaftAck{}, nil
+}
+
+func (c *testEtcdRaftClient) SendSnapshot(_ context.Context, _ ...grpc.CallOption) (pb.EtcdRaft_SendSnapshotClient, error) {
+	return c.stream, nil
+}
+
+// injectClient pre-populates the transport's client cache for the given peer
+// address so calls to clientFor return the mock without dialling.
+func injectClient(t *testing.T, transport *GRPCTransport, address string, client pb.EtcdRaftClient) {
+	t.Helper()
+	transport.mu.Lock()
+	transport.clients[address] = client
+	transport.mu.Unlock()
+}
+
+// --- sendSnapshotReaderChunks multi-chunk tests ---
+
+func TestSendSnapshotReaderChunksMultiChunk(t *testing.T) {
+	// 12-byte payload with chunkSize=4 → 3 chunks.
+	chunkSize := 4
+	payload := []byte("1234abcd5678")
+	header := []byte("meta")
+
+	client := &testSnapshotSendClient{}
+	err := sendSnapshotReaderChunks(client, header, bytes.NewReader(payload), chunkSize)
+	require.NoError(t, err)
+
+	require.Len(t, client.chunks, 3)
+
+	require.Equal(t, header, client.chunks[0].Metadata)
+	require.Equal(t, []byte("1234"), client.chunks[0].Chunk)
+	require.False(t, client.chunks[0].Final)
+
+	require.Empty(t, client.chunks[1].Metadata)
+	require.Equal(t, []byte("abcd"), client.chunks[1].Chunk)
+	require.False(t, client.chunks[1].Final)
+
+	require.Empty(t, client.chunks[2].Metadata)
+	require.Equal(t, []byte("5678"), client.chunks[2].Chunk)
+	require.True(t, client.chunks[2].Final)
+}
+
+func TestSendSnapshotReaderChunksExactBoundary(t *testing.T) {
+	// 8-byte payload with chunkSize=4 → exactly 2 chunks.
+	chunkSize := 4
+	payload := []byte("12345678")
+	header := []byte("hdr")
+
+	client := &testSnapshotSendClient{}
+	err := sendSnapshotReaderChunks(client, header, bytes.NewReader(payload), chunkSize)
+	require.NoError(t, err)
+
+	require.Len(t, client.chunks, 2)
+	require.Equal(t, header, client.chunks[0].Metadata)
+	require.Equal(t, []byte("1234"), client.chunks[0].Chunk)
+	require.False(t, client.chunks[0].Final)
+
+	require.Equal(t, []byte("5678"), client.chunks[1].Chunk)
+	require.True(t, client.chunks[1].Final)
+}
+
+// --- streamFSMSnapshot tests ---
+
+func TestStreamFSMSnapshotSendsPayload(t *testing.T) {
+	dir := t.TempDir()
+	payload := []byte("stream fsm snapshot payload data for test")
+	crc, _ := writeFSMFileForTest(t, dir, 55, payload)
+
+	sendClient := &testSnapshotSendClient{}
+	transport := NewGRPCTransport([]Peer{{NodeID: 3, Address: "host:2"}})
+	injectClient(t, transport, "host:2", &testEtcdRaftClient{stream: sendClient})
+
+	openFn := func(index uint64) (io.ReadCloser, error) {
+		return openFSMSnapshotPayloadReader(fsmSnapPath(dir, index))
+	}
+
+	msg := raftpb.Message{
+		Type: raftpb.MsgSnap,
+		To:   3,
+		Snapshot: &raftpb.Snapshot{
+			Data:     encodeSnapshotToken(55, crc),
+			Metadata: raftpb.SnapshotMetadata{Index: 55, Term: 2},
+		},
+	}
+
+	err := transport.streamFSMSnapshot(context.Background(), msg, 55, openFn)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, sendClient.chunks)
+
+	// Metadata must appear only in the first chunk.
+	require.NotEmpty(t, sendClient.chunks[0].Metadata)
+	for _, c := range sendClient.chunks[1:] {
+		require.Empty(t, c.Metadata)
+	}
+
+	// Reconstruct and compare the streamed payload.
+	var got []byte
+	for _, c := range sendClient.chunks {
+		got = append(got, c.Chunk...)
+	}
+	require.Equal(t, payload, got)
+	require.True(t, sendClient.chunks[len(sendClient.chunks)-1].Final)
+}
+
+func TestStreamFSMSnapshotFileNotFound(t *testing.T) {
+	dir := t.TempDir()
+
+	sendClient := &testSnapshotSendClient{}
+	transport := NewGRPCTransport([]Peer{{NodeID: 4, Address: "host:3"}})
+	injectClient(t, transport, "host:3", &testEtcdRaftClient{stream: sendClient})
+
+	openFn := func(index uint64) (io.ReadCloser, error) {
+		return openFSMSnapshotPayloadReader(fsmSnapPath(dir, index))
+	}
+
+	msg := raftpb.Message{
+		Type: raftpb.MsgSnap,
+		To:   4,
+		Snapshot: &raftpb.Snapshot{
+			Metadata: raftpb.SnapshotMetadata{Index: 999, Term: 1},
+		},
+	}
+
+	err := transport.streamFSMSnapshot(context.Background(), msg, 999, openFn)
+	require.ErrorIs(t, err, ErrFSMSnapshotNotFound)
+	require.Empty(t, sendClient.chunks)
+}
+
+// --- dispatchSnapshot routing tests ---
+
+func TestDispatchSnapshotTokenRoutesToStream(t *testing.T) {
+	// When snapshot.Data is a token and openFSMPayload is set, dispatchSnapshot
+	// must route to streamFSMSnapshot (chunked streaming path) — not bridge mode.
+	dir := t.TempDir()
+	payload := []byte("dispatch token route test payload data 12345")
+	crc, _ := writeFSMFileForTest(t, dir, 42, payload)
+
+	sendClient := &testSnapshotSendClient{}
+	transport := NewGRPCTransport([]Peer{{NodeID: 2, Address: "fake:1"}})
+	injectClient(t, transport, "fake:1", &testEtcdRaftClient{stream: sendClient})
+	transport.SetFSMPayloadOpener(func(index uint64) (io.ReadCloser, error) {
+		return openFSMSnapshotPayloadReader(fsmSnapPath(dir, index))
+	})
+
+	msg := raftpb.Message{
+		Type: raftpb.MsgSnap,
+		To:   2,
+		Snapshot: &raftpb.Snapshot{
+			Data:     encodeSnapshotToken(42, crc),
+			Metadata: raftpb.SnapshotMetadata{Index: 42, Term: 1},
+		},
+	}
+
+	err := transport.dispatchSnapshot(context.Background(), msg)
+	require.NoError(t, err)
+
+	// Chunks must carry the FSM payload (not the raw token bytes).
+	var got []byte
+	for _, c := range sendClient.chunks {
+		got = append(got, c.Chunk...)
+	}
+	require.Equal(t, payload, got)
+}
+
+func TestDispatchSnapshotNonTokenRoutesToBridge(t *testing.T) {
+	// When snapshot.Data is NOT a token (legacy full payload), dispatchSnapshot
+	// must forward it unchanged via the bridge (sendSnapshot) path.
+	legacy := []byte("legacy full fsm payload not a token")
+
+	sendClient := &testSnapshotSendClient{}
+	transport := NewGRPCTransport([]Peer{{NodeID: 2, Address: "fake:1"}})
+	injectClient(t, transport, "fake:1", &testEtcdRaftClient{stream: sendClient})
+
+	msg := raftpb.Message{
+		Type: raftpb.MsgSnap,
+		To:   2,
+		Snapshot: &raftpb.Snapshot{
+			Data:     legacy,
+			Metadata: raftpb.SnapshotMetadata{Index: 1, Term: 1},
+		},
+	}
+
+	err := transport.dispatchSnapshot(context.Background(), msg)
+	require.NoError(t, err)
+
+	// The legacy payload must reach the receiver unmodified.
+	var got []byte
+	for _, c := range sendClient.chunks {
+		got = append(got, c.Chunk...)
+	}
+	require.Equal(t, legacy, got)
+}
+
+func TestDispatchSnapshotTokenNoOpenerFallsBackToBridge(t *testing.T) {
+	// Token snapshot with NO openFSMPayload set → falls back to bridge mode.
+	// Without a readFSMPayload either, applyBridgeMode is a passthrough, so
+	// the raw token bytes are sent. This verifies the fallback branch is taken.
+	dir := t.TempDir()
+	payload := []byte("bridge fallback test payload data here")
+	crc, _ := writeFSMFileForTest(t, dir, 77, payload)
+	token := encodeSnapshotToken(77, crc)
+
+	sendClient := &testSnapshotSendClient{}
+	transport := NewGRPCTransport([]Peer{{NodeID: 2, Address: "fake:1"}})
+	injectClient(t, transport, "fake:1", &testEtcdRaftClient{stream: sendClient})
+	// No SetFSMPayloadOpener / SetFSMPayloadReader → passthrough bridge.
+
+	msg := raftpb.Message{
+		Type: raftpb.MsgSnap,
+		To:   2,
+		Snapshot: &raftpb.Snapshot{
+			Data:     token,
+			Metadata: raftpb.SnapshotMetadata{Index: 77, Term: 1},
+		},
+	}
+
+	err := transport.dispatchSnapshot(context.Background(), msg)
+	require.NoError(t, err)
+
+	// Token bytes forwarded as-is (no opener wired).
+	var got []byte
+	for _, c := range sendClient.chunks {
+		got = append(got, c.Chunk...)
+	}
+	require.Equal(t, token, got)
+}

--- a/internal/raftengine/etcd/grpc_transport_test.go
+++ b/internal/raftengine/etcd/grpc_transport_test.go
@@ -239,7 +239,7 @@ func TestApplyBridgeModePassesNonTokenUnchanged(t *testing.T) {
 	msg := raftpb.Message{
 		Snapshot: &raftpb.Snapshot{Data: []byte("legacy full payload")},
 	}
-	patched, err := transport.applyBridgeMode(msg)
+	patched, err := transport.applyBridgeMode(context.Background(), msg)
 	require.NoError(t, err)
 	require.Equal(t, []byte("legacy full payload"), patched.Snapshot.Data)
 }
@@ -252,7 +252,7 @@ func TestApplyBridgeModeNoReaderIsNoop(t *testing.T) {
 	msg := raftpb.Message{
 		Snapshot: &raftpb.Snapshot{Data: token},
 	}
-	patched, err := transport.applyBridgeMode(msg)
+	patched, err := transport.applyBridgeMode(context.Background(), msg)
 	require.NoError(t, err)
 	require.Equal(t, token, patched.Snapshot.Data)
 }
@@ -274,7 +274,7 @@ func TestApplyBridgeModeReconstructsPayload(t *testing.T) {
 			Metadata: raftpb.SnapshotMetadata{Index: 42},
 		},
 	}
-	patched, err := transport.applyBridgeMode(msg)
+	patched, err := transport.applyBridgeMode(context.Background(), msg)
 	require.NoError(t, err)
 	require.Equal(t, payload, patched.Snapshot.Data)
 	// Metadata must be preserved.
@@ -291,7 +291,7 @@ func TestApplyBridgeModeReaderError(t *testing.T) {
 	msg := raftpb.Message{
 		Snapshot: &raftpb.Snapshot{Data: token},
 	}
-	_, err := transport.applyBridgeMode(msg)
+	_, err := transport.applyBridgeMode(context.Background(), msg)
 	require.ErrorIs(t, err, ErrFSMSnapshotNotFound)
 }
 

--- a/internal/raftengine/etcd/grpc_transport_test.go
+++ b/internal/raftengine/etcd/grpc_transport_test.go
@@ -228,3 +228,68 @@ func (*testSendSnapshotServer) SendMsg(any) error {
 func (*testSendSnapshotServer) RecvMsg(any) error {
 	return nil
 }
+
+// --- applyBridgeMode tests ---
+
+func TestApplyBridgeModePassesNonTokenUnchanged(t *testing.T) {
+	transport := NewGRPCTransport(nil)
+
+	// Non-token payload must pass through unchanged.
+	msg := raftpb.Message{
+		Snapshot: &raftpb.Snapshot{Data: []byte("legacy full payload")},
+	}
+	patched, err := transport.applyBridgeMode(msg)
+	require.NoError(t, err)
+	require.Equal(t, []byte("legacy full payload"), patched.Snapshot.Data)
+}
+
+func TestApplyBridgeModeNoReaderIsNoop(t *testing.T) {
+	transport := NewGRPCTransport(nil)
+
+	// A token with no readFSMPayload callback set → passthrough.
+	token := encodeSnapshotToken(42, 0xDEADBEEF)
+	msg := raftpb.Message{
+		Snapshot: &raftpb.Snapshot{Data: token},
+	}
+	patched, err := transport.applyBridgeMode(msg)
+	require.NoError(t, err)
+	require.Equal(t, token, patched.Snapshot.Data)
+}
+
+func TestApplyBridgeModeReconstructsPayload(t *testing.T) {
+	fsmSnapDir := t.TempDir()
+	payload := []byte("bridge mode payload data 12345")
+	crc, _ := writeFSMFileForTest(t, fsmSnapDir, 42, payload)
+
+	transport := NewGRPCTransport(nil)
+	transport.SetFSMPayloadReader(func(index uint64) ([]byte, error) {
+		return readFSMSnapshotPayload(fsmSnapPath(fsmSnapDir, index))
+	})
+
+	token := encodeSnapshotToken(42, crc)
+	msg := raftpb.Message{
+		Snapshot: &raftpb.Snapshot{
+			Data:     token,
+			Metadata: raftpb.SnapshotMetadata{Index: 42},
+		},
+	}
+	patched, err := transport.applyBridgeMode(msg)
+	require.NoError(t, err)
+	require.Equal(t, payload, patched.Snapshot.Data)
+	// Metadata must be preserved.
+	require.Equal(t, uint64(42), patched.Snapshot.Metadata.Index)
+}
+
+func TestApplyBridgeModeReaderError(t *testing.T) {
+	transport := NewGRPCTransport(nil)
+	transport.SetFSMPayloadReader(func(_ uint64) ([]byte, error) {
+		return nil, ErrFSMSnapshotNotFound
+	})
+
+	token := encodeSnapshotToken(99, 0xABCD)
+	msg := raftpb.Message{
+		Snapshot: &raftpb.Snapshot{Data: token},
+	}
+	_, err := transport.applyBridgeMode(msg)
+	require.ErrorIs(t, err, ErrFSMSnapshotNotFound)
+}

--- a/internal/raftengine/etcd/migrate.go
+++ b/internal/raftengine/etcd/migrate.go
@@ -89,7 +89,7 @@ func readStoreSnapshot(storePath string) ([]byte, int64, error) {
 func seedMigrationDir(tempDir string, peers []Peer, snapshotData []byte) error {
 	state := bootstrapStateForPeers(peers, snapshotData)
 	logger := zap.NewNop()
-	disk, err := persistBootState(logger, filepath.Join(tempDir, walDirName), filepath.Join(tempDir, snapDirName), nil, state)
+	disk, err := persistBootState(logger, filepath.Join(tempDir, walDirName), filepath.Join(tempDir, snapDirName), filepath.Join(tempDir, fsmSnapDirName), nil, state)
 	if err != nil {
 		return err
 	}

--- a/internal/raftengine/etcd/snapshot_spool_test.go
+++ b/internal/raftengine/etcd/snapshot_spool_test.go
@@ -49,28 +49,32 @@ func TestCleanupStaleSnapshotSpoolsNonExistentDir(t *testing.T) {
 }
 
 // createSnapFile creates a fake .snap file with the etcd naming convention.
-func createSnapFile(t *testing.T, dir string, term, index uint64) {
+// term is always 1 in the test suite; the parameter is retained to keep the
+// file name format explicit.
+func createSnapFile(t *testing.T, dir string, index uint64) {
 	t.Helper()
+	const term = uint64(1)
 	name := fmt.Sprintf("%016x-%016x.snap", term, index)
 	path := filepath.Join(dir, name)
 	require.NoError(t, os.WriteFile(path, []byte("fake"), 0o600))
 }
 
 func TestPurgeOldSnapFiles(t *testing.T) {
-	dir := t.TempDir()
+	snapDir := t.TempDir()
+	fsmSnapDir := t.TempDir()
 
 	// Create 6 snap files at increasing indices.
 	for i := uint64(1); i <= 6; i++ {
-		createSnapFile(t, dir, 1, i*10000)
+		createSnapFile(t, snapDir, i*10000)
 	}
 
 	// Create a non-snap file that must be preserved.
-	other := filepath.Join(dir, "db.tmp.12345")
+	other := filepath.Join(snapDir, "db.tmp.12345")
 	require.NoError(t, os.WriteFile(other, []byte("x"), 0o600))
 
-	require.NoError(t, purgeOldSnapFiles(dir))
+	require.NoError(t, purgeOldSnapshotFiles(snapDir, fsmSnapDir))
 
-	entries, err := os.ReadDir(dir)
+	entries, err := os.ReadDir(snapDir)
 	require.NoError(t, err)
 
 	var snaps []string
@@ -92,20 +96,22 @@ func TestPurgeOldSnapFiles(t *testing.T) {
 }
 
 func TestPurgeOldSnapFilesUnderLimit(t *testing.T) {
-	dir := t.TempDir()
+	snapDir := t.TempDir()
+	fsmSnapDir := t.TempDir()
 
 	// Only 2 files — under the limit of 3, nothing should be removed.
-	createSnapFile(t, dir, 1, 1000)
-	createSnapFile(t, dir, 1, 2000)
+	createSnapFile(t, snapDir, 1000)
+	createSnapFile(t, snapDir, 2000)
 
-	require.NoError(t, purgeOldSnapFiles(dir))
+	require.NoError(t, purgeOldSnapshotFiles(snapDir, fsmSnapDir))
 
-	entries, err := os.ReadDir(dir)
+	entries, err := os.ReadDir(snapDir)
 	require.NoError(t, err)
 	require.Len(t, entries, 2)
 }
 
 func TestPurgeOldSnapFilesEmptyDir(t *testing.T) {
-	dir := t.TempDir()
-	require.NoError(t, purgeOldSnapFiles(dir))
+	snapDir := t.TempDir()
+	fsmSnapDir := t.TempDir()
+	require.NoError(t, purgeOldSnapshotFiles(snapDir, fsmSnapDir))
 }

--- a/internal/raftengine/etcd/snapshot_spool_test.go
+++ b/internal/raftengine/etcd/snapshot_spool_test.go
@@ -49,8 +49,7 @@ func TestCleanupStaleSnapshotSpoolsNonExistentDir(t *testing.T) {
 }
 
 // createSnapFile creates a fake .snap file with the etcd naming convention.
-// term is always 1 in the test suite; the parameter is retained to keep the
-// file name format explicit.
+// term is always 1 in the test suite.
 func createSnapFile(t *testing.T, dir string, index uint64) {
 	t.Helper()
 	const term = uint64(1)

--- a/internal/raftengine/etcd/wal_store.go
+++ b/internal/raftengine/etcd/wal_store.go
@@ -184,11 +184,41 @@ func walSnapshotFor(snapshot raftpb.Snapshot) walpb.Snapshot {
 
 func migrateLegacyState(logger *zap.Logger, walDir, snapDir, fsmSnapDir string, fsm StateMachine, state persistedState) (*diskState, error) {
 	if !etcdraft.IsEmptySnap(state.Snapshot) && len(state.Snapshot.Data) > 0 {
-		if err := fsm.Restore(bytes.NewReader(state.Snapshot.Data)); err != nil {
-			return nil, errors.WithStack(err)
+		token, err := restoreAndOffloadLegacySnapshot(fsm, fsmSnapDir, state.Snapshot)
+		if err != nil {
+			return nil, err
 		}
+		state.Snapshot.Data = token
 	}
 	return persistBootState(logger, walDir, snapDir, fsmSnapDir, fsm, state)
+}
+
+// restoreAndOffloadLegacySnapshot restores the FSM from a legacy full-payload
+// snapshot and, when fsmSnapDir is non-empty, eagerly converts the payload to
+// the disk-offloaded EKVT token format so the WAL no longer carries GiB-scale
+// blobs after the first startup following a HashiCorp → etcd migration.
+// Returns the token bytes (or the original Data slice when fsmSnapDir is empty).
+func restoreAndOffloadLegacySnapshot(fsm StateMachine, fsmSnapDir string, snap raftpb.Snapshot) ([]byte, error) {
+	if err := fsm.Restore(bytes.NewReader(snap.Data)); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if fsmSnapDir == "" {
+		return snap.Data, nil
+	}
+	index := snap.Metadata.Index
+	fsmSnap, err := fsm.Snapshot()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	crc32c, writeErr := writeFSMSnapshotFile(fsmSnap, fsmSnapDir, index)
+	closeErr := fsmSnap.Close()
+	if writeErr != nil {
+		return nil, writeErr
+	}
+	if closeErr != nil {
+		return nil, errors.WithStack(closeErr)
+	}
+	return encodeSnapshotToken(index, crc32c), nil
 }
 
 func persistBootState(logger *zap.Logger, walDir, snapDir, fsmSnapDir string, fsm StateMachine, state persistedState) (*diskState, error) {

--- a/internal/raftengine/etcd/wal_store.go
+++ b/internal/raftengine/etcd/wal_store.go
@@ -61,7 +61,11 @@ func prepareDataDirs(dataDir, snapDir, fsmSnapDir string) error {
 	if err := cleanupStaleSnapshotSpools(dataDir); err != nil {
 		return errors.Wrap(err, "cleanup stale snapshot spools")
 	}
-	if err := cleanupStaleFSMSnaps(snapDir, fsmSnapDir, false); err != nil {
+	// Startup CRC verification is disabled by default: for GiB-scale snapshots
+	// reading the entire file to compute a checksum can add seconds to recovery
+	// time. Orphan removal (index-based) still runs unconditionally. CRC
+	// integrity is enforced at restore time by openAndRestoreFSMSnapshot.
+	if err := cleanupStaleFSMSnaps(snapDir, fsmSnapDir, true); err != nil {
 		return errors.Wrap(err, "cleanup stale fsm snapshots")
 	}
 	return nil

--- a/internal/raftengine/etcd/wal_store.go
+++ b/internal/raftengine/etcd/wal_store.go
@@ -30,59 +30,84 @@ func openDiskState(cfg OpenConfig, peers []Peer) (*diskState, error) {
 	logger := zap.NewNop()
 	walDir := filepath.Join(cfg.DataDir, walDirName)
 	snapDir := filepath.Join(cfg.DataDir, snapDirName)
+	fsmSnapDir := filepath.Join(cfg.DataDir, fsmSnapDirName)
 
-	if err := os.MkdirAll(cfg.DataDir, defaultDirPerm); err != nil {
-		return nil, errors.WithStack(err)
-	}
-	if err := os.MkdirAll(snapDir, defaultDirPerm); err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	if err := cleanupStaleSnapshotSpools(cfg.DataDir); err != nil {
-		return nil, errors.Wrap(err, "cleanup stale snapshot spools")
+	if err := prepareDataDirs(cfg.DataDir, snapDir, fsmSnapDir); err != nil {
+		return nil, err
 	}
 
 	if wal.Exist(walDir) {
-		return loadWalState(logger, walDir, snapDir, cfg.StateMachine)
+		return loadWalState(logger, walDir, snapDir, fsmSnapDir, cfg.StateMachine)
 	}
 
 	legacy, legacyErr := loadLegacyOrSplitState(cfg.DataDir)
 	if legacyErr == nil {
-		return migrateLegacyState(logger, walDir, snapDir, cfg.StateMachine, legacy)
+		return migrateLegacyState(logger, walDir, snapDir, fsmSnapDir, cfg.StateMachine, legacy)
 	}
-	if legacyErr != nil && !os.IsNotExist(errors.UnwrapAll(legacyErr)) {
+	if !os.IsNotExist(errors.UnwrapAll(legacyErr)) {
 		return nil, legacyErr
 	}
 
+	return bootstrapNewCluster(logger, walDir, snapDir, fsmSnapDir, cfg, peers)
+}
+
+func prepareDataDirs(dataDir, snapDir, fsmSnapDir string) error {
+	if err := os.MkdirAll(dataDir, defaultDirPerm); err != nil {
+		return errors.WithStack(err)
+	}
+	if err := os.MkdirAll(snapDir, defaultDirPerm); err != nil {
+		return errors.WithStack(err)
+	}
+	if err := cleanupStaleSnapshotSpools(dataDir); err != nil {
+		return errors.Wrap(err, "cleanup stale snapshot spools")
+	}
+	if err := cleanupStaleFSMSnaps(snapDir, fsmSnapDir, false); err != nil {
+		return errors.Wrap(err, "cleanup stale fsm snapshots")
+	}
+	return nil
+}
+
+func bootstrapNewCluster(logger *zap.Logger, walDir, snapDir, fsmSnapDir string, cfg OpenConfig, peers []Peer) (*diskState, error) {
 	if len(peers) == 1 {
-		return bootstrapWalState(logger, walDir, snapDir, cfg.StateMachine, peers)
+		return bootstrapWalState(logger, walDir, snapDir, fsmSnapDir, cfg.StateMachine, peers)
 	}
 	if !cfg.Bootstrap {
-		return joinWalState(logger, walDir, snapDir)
+		return joinWalState(logger, walDir, snapDir, fsmSnapDir)
 	}
-	return bootstrapWalState(logger, walDir, snapDir, cfg.StateMachine, peers)
+	return bootstrapWalState(logger, walDir, snapDir, fsmSnapDir, cfg.StateMachine, peers)
 }
 
-func joinWalState(logger *zap.Logger, walDir string, snapDir string) (*diskState, error) {
-	return persistBootState(logger, walDir, snapDir, nil, persistedState{})
+func joinWalState(logger *zap.Logger, walDir, snapDir, fsmSnapDir string) (*diskState, error) {
+	return persistBootState(logger, walDir, snapDir, fsmSnapDir, nil, persistedState{})
 }
 
-func bootstrapWalState(logger *zap.Logger, walDir string, snapDir string, fsm StateMachine, peers []Peer) (*diskState, error) {
-	snapshotData, err := stateMachineSnapshotBytes(fsm, snapDir)
+func bootstrapWalState(logger *zap.Logger, walDir, snapDir, fsmSnapDir string, fsm StateMachine, peers []Peer) (*diskState, error) {
+	// Bootstrap snapshot always has index 1.
+	const bootstrapIndex = uint64(1)
+	snapshot, err := fsm.Snapshot()
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
-	boot := bootstrapStateForPeers(peers, snapshotData)
-	return persistBootState(logger, walDir, snapDir, fsm, boot)
+	crc32c, writeErr := writeFSMSnapshotFile(snapshot, fsmSnapDir, bootstrapIndex)
+	closeErr := snapshot.Close()
+	if writeErr != nil {
+		return nil, writeErr
+	}
+	if closeErr != nil {
+		return nil, errors.WithStack(closeErr)
+	}
+	token := encodeSnapshotToken(bootstrapIndex, crc32c)
+	boot := bootstrapStateForPeers(peers, token)
+	return persistBootState(logger, walDir, snapDir, fsmSnapDir, fsm, boot)
 }
 
-func loadWalState(logger *zap.Logger, walDir string, snapDir string, fsm StateMachine) (*diskState, error) {
+func loadWalState(logger *zap.Logger, walDir, snapDir, fsmSnapDir string, fsm StateMachine) (*diskState, error) {
 	snapshotter := snap.New(logger, snapDir)
 	snapshot, err := loadPersistedSnapshot(logger, walDir, snapshotter)
 	if err != nil {
 		return nil, err
 	}
-	if err := restoreSnapshotState(fsm, snapshot); err != nil {
+	if err := restoreSnapshotState(fsm, snapshot, fsmSnapDir); err != nil {
 		return nil, err
 	}
 
@@ -130,13 +155,19 @@ func loadPersistedSnapshot(logger *zap.Logger, walDir string, snapshotter *snap.
 	}
 }
 
-func restoreSnapshotState(fsm StateMachine, snapshot raftpb.Snapshot) error {
-	if !etcdraft.IsEmptySnap(snapshot) && len(snapshot.Data) > 0 && fsm != nil {
-		if err := fsm.Restore(bytes.NewReader(snapshot.Data)); err != nil {
-			return errors.WithStack(err)
-		}
+func restoreSnapshotState(fsm StateMachine, snapshot raftpb.Snapshot, fsmSnapDir string) error {
+	if etcdraft.IsEmptySnap(snapshot) || len(snapshot.Data) == 0 || fsm == nil {
+		return nil
 	}
-	return nil
+	if isSnapshotToken(snapshot.Data) {
+		tok, err := decodeSnapshotToken(snapshot.Data)
+		if err != nil {
+			return err
+		}
+		return openAndRestoreFSMSnapshot(fsm, fsmSnapPath(fsmSnapDir, tok.Index), tok.CRC32C)
+	}
+	// Legacy format: full FSM payload embedded in snapshot.Data.
+	return errors.WithStack(fsm.Restore(bytes.NewReader(snapshot.Data)))
 }
 
 func walSnapshotFor(snapshot raftpb.Snapshot) walpb.Snapshot {
@@ -147,21 +178,21 @@ func walSnapshotFor(snapshot raftpb.Snapshot) walpb.Snapshot {
 	}
 }
 
-func migrateLegacyState(logger *zap.Logger, walDir string, snapDir string, fsm StateMachine, state persistedState) (*diskState, error) {
+func migrateLegacyState(logger *zap.Logger, walDir, snapDir, fsmSnapDir string, fsm StateMachine, state persistedState) (*diskState, error) {
 	if !etcdraft.IsEmptySnap(state.Snapshot) && len(state.Snapshot.Data) > 0 {
 		if err := fsm.Restore(bytes.NewReader(state.Snapshot.Data)); err != nil {
 			return nil, errors.WithStack(err)
 		}
 	}
-	return persistBootState(logger, walDir, snapDir, fsm, state)
+	return persistBootState(logger, walDir, snapDir, fsmSnapDir, fsm, state)
 }
 
-func persistBootState(logger *zap.Logger, walDir string, snapDir string, fsm StateMachine, state persistedState) (*diskState, error) {
+func persistBootState(logger *zap.Logger, walDir, snapDir, fsmSnapDir string, fsm StateMachine, state persistedState) (*diskState, error) {
 	if err := ensureWalDirs(walDir, snapDir); err != nil {
 		return nil, err
 	}
 	if wal.Exist(walDir) {
-		return loadWalState(logger, walDir, snapDir, fsm)
+		return loadWalState(logger, walDir, snapDir, fsmSnapDir, fsm)
 	}
 
 	w, err := wal.Create(logger, walDir, nil)
@@ -212,14 +243,9 @@ func saveBootstrapState(persist etcdstorage.Storage, state persistedState) error
 	return nil
 }
 
-func stateMachineSnapshotBytes(fsm StateMachine, spoolDir string) (data []byte, err error) {
-	snapshot, err := fsm.Snapshot()
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	return snapshotBytesAndClose(snapshot, spoolDir)
-}
-
+// snapshotBytesAndClose materializes a Snapshot as []byte via disk spooling.
+// Retained for the legacy migration path (migrateLegacyState) where the old
+// format is still used. New code should call writeFSMSnapshotFile instead.
 func snapshotBytesAndClose(snapshot Snapshot, spoolDir string) (data []byte, err error) {
 	defer func() {
 		err = errors.CombineErrors(err, errors.WithStack(snapshot.Close()))
@@ -340,44 +366,10 @@ func persistLocalSnapshotPayload(storage *etcdraft.MemoryStorage, persist etcdst
 	return snapshot, nil
 }
 
-// defaultMaxSnapFiles is the number of .snap files to retain in the snap
-// directory. etcd itself purges old snap files via fileutil.PurgeFile; the
-// elastickv etcd engine must do this explicitly.
+// defaultMaxSnapFiles is the number of .snap/.fsm file pairs to retain.
+// etcd itself purges old snap files via fileutil.PurgeFile; the elastickv
+// etcd engine must do this explicitly, coordinating with .fsm files.
 const defaultMaxSnapFiles = 3
-
-// purgeOldSnapFiles removes old .snap files from snapDir, keeping the most
-// recent defaultMaxSnapFiles files. Snap file names encode term and index in
-// hex and sort lexicographically from oldest to newest, matching etcd's
-// Snapshotter convention.
-func purgeOldSnapFiles(snapDir string) error {
-	entries, err := os.ReadDir(snapDir)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	var snaps []string
-	for _, e := range entries {
-		if !e.IsDir() && filepath.Ext(e.Name()) == ".snap" {
-			snaps = append(snaps, e.Name())
-		}
-	}
-
-	if len(snaps) <= defaultMaxSnapFiles {
-		return nil
-	}
-
-	// snaps is already sorted ascending (oldest first) because os.ReadDir
-	// returns entries in directory order which, for zero-padded hex names,
-	// equals chronological order.
-
-	var combined error
-	for _, name := range snaps[:len(snaps)-defaultMaxSnapFiles] {
-		if removeErr := os.Remove(filepath.Join(snapDir, name)); removeErr != nil && !os.IsNotExist(removeErr) {
-			combined = errors.CombineErrors(combined, errors.WithStack(removeErr))
-		}
-	}
-	return errors.WithStack(combined)
-}
 
 func buildLocalSnapshot(storage *etcdraft.MemoryStorage, applied uint64, payload []byte) (raftpb.Snapshot, error) {
 	_, confState, err := storage.InitialState()

--- a/internal/raftengine/etcd/wal_store_test.go
+++ b/internal/raftengine/etcd/wal_store_test.go
@@ -1,0 +1,130 @@
+package etcd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	raftpb "go.etcd.io/raft/v3/raftpb"
+)
+
+// --- restoreSnapshotState tests ---
+//
+// These tests cover the WAL startup path where the persisted raftpb.Snapshot is
+// loaded from disk and the FSM is restored from its Data field. Two formats are
+// supported: the 17-byte EKVT token (Phase 2) and the legacy full-payload
+// (Phase 1 / HashiCorp migration).
+
+func TestRestoreSnapshotStateEmptySnapshot(t *testing.T) {
+	// An empty (zero-value) snapshot must be a no-op: FSM not touched.
+	fsm := &dummyFSM{}
+	err := restoreSnapshotState(fsm, raftpb.Snapshot{}, "")
+	require.NoError(t, err)
+	require.Nil(t, fsm.restored)
+}
+
+func TestRestoreSnapshotStateNilData(t *testing.T) {
+	// Snapshot with non-zero metadata but empty Data must be a no-op.
+	snap := raftpb.Snapshot{
+		Metadata: raftpb.SnapshotMetadata{Index: 5, Term: 1},
+	}
+	fsm := &dummyFSM{}
+	err := restoreSnapshotState(fsm, snap, "")
+	require.NoError(t, err)
+	require.Nil(t, fsm.restored)
+}
+
+func TestRestoreSnapshotStateNilFSM(t *testing.T) {
+	// Non-empty snapshot with a nil FSM must be a no-op (not a panic).
+	snap := raftpb.Snapshot{
+		Data:     []byte("some payload"),
+		Metadata: raftpb.SnapshotMetadata{Index: 1, Term: 1},
+	}
+	err := restoreSnapshotState(nil, snap, "")
+	require.NoError(t, err)
+}
+
+func TestRestoreSnapshotStateLegacyFormat(t *testing.T) {
+	// Legacy format: raw FSM payload embedded directly in snapshot.Data.
+	// This path is taken when the Data is not a 17-byte EKVT token.
+	payload := []byte("legacy raw fsm state payload data here")
+	snap := raftpb.Snapshot{
+		Data:     payload,
+		Metadata: raftpb.SnapshotMetadata{Index: 1, Term: 1},
+	}
+
+	fsm := &dummyFSM{}
+	err := restoreSnapshotState(fsm, snap, "")
+	require.NoError(t, err)
+	require.Equal(t, payload, fsm.restored)
+}
+
+func TestRestoreSnapshotStateTokenFormat(t *testing.T) {
+	// Token format: snapshot.Data is a 17-byte EKVT token referencing an .fsm file.
+	// This is the Phase 2 path used after the disk-offload migration.
+	dir := t.TempDir()
+	payload := []byte("token format fsm state data for wal restore test")
+	crc, _ := writeFSMFileForTest(t, dir, 7, payload)
+
+	snap := raftpb.Snapshot{
+		Data:     encodeSnapshotToken(7, crc),
+		Metadata: raftpb.SnapshotMetadata{Index: 7, Term: 1},
+	}
+
+	fsm := &dummyFSM{}
+	err := restoreSnapshotState(fsm, snap, dir)
+	require.NoError(t, err)
+	require.Equal(t, payload, fsm.restored)
+}
+
+func TestRestoreSnapshotStateTokenEmptyPayload(t *testing.T) {
+	// Token pointing to an .fsm file with an empty payload (only CRC footer).
+	// This is valid: crc32c("") == 0.
+	dir := t.TempDir()
+	crc, _ := writeFSMFileForTest(t, dir, 11, []byte{})
+
+	snap := raftpb.Snapshot{
+		Data:     encodeSnapshotToken(11, crc),
+		Metadata: raftpb.SnapshotMetadata{Index: 11, Term: 1},
+	}
+
+	fsm := &dummyFSM{}
+	err := restoreSnapshotState(fsm, snap, dir)
+	require.NoError(t, err)
+	require.Equal(t, []byte{}, fsm.restored)
+}
+
+func TestRestoreSnapshotStateTokenCRCMismatch(t *testing.T) {
+	// Token CRC does not match the on-disk footer → ErrFSMSnapshotTokenCRC.
+	// The FSM must NOT be modified (fail-fast before Restore).
+	dir := t.TempDir()
+	payload := []byte("payload for crc mismatch test here 123")
+	crc, _ := writeFSMFileForTest(t, dir, 8, payload)
+	wrongCRC := crc ^ 0xFFFFFFFF
+
+	snap := raftpb.Snapshot{
+		Data:     encodeSnapshotToken(8, wrongCRC),
+		Metadata: raftpb.SnapshotMetadata{Index: 8, Term: 1},
+	}
+
+	fsm := &dummyFSM{}
+	err := restoreSnapshotState(fsm, snap, dir)
+	require.ErrorIs(t, err, ErrFSMSnapshotTokenCRC)
+	require.Nil(t, fsm.restored, "FSM must not be restored after CRC mismatch")
+}
+
+func TestRestoreSnapshotStateTokenFileNotFound(t *testing.T) {
+	// Token references an index for which no .fsm file exists on disk.
+	// This can happen after a data-dir corruption or incomplete migration.
+	dir := t.TempDir()
+	token := encodeSnapshotToken(999, 0xDEADBEEF)
+
+	snap := raftpb.Snapshot{
+		Data:     token,
+		Metadata: raftpb.SnapshotMetadata{Index: 999, Term: 1},
+	}
+
+	fsm := &dummyFSM{}
+	err := restoreSnapshotState(fsm, snap, dir)
+	require.ErrorIs(t, err, ErrFSMSnapshotNotFound)
+	require.Nil(t, fsm.restored)
+}


### PR DESCRIPTION
Implements docs/etcd_snapshot_disk_offload_design.md to eliminate the memory spikes that occurred at every snapshot creation interval.

Before: raftpb.Snapshot.Data held the full FSM payload (up to 1 GiB) in MemoryStorage until the next snapshot. This caused coordinated spikes across all nodes every 10,000 entries.

After: raftpb.Snapshot.Data carries a 17-byte EKVT token; FSM data is written directly to an fsm-snap/{index}.fsm file and never materialized as []byte in MemoryStorage.

New file: internal/raftengine/etcd/fsm_snapshot_file.go
- EKVT token encode/decode (magic + version + index + CRC32C)
- writeFSMSnapshotFile: crash-safe write via CreateTemp→Rename→syncDir
- openAndRestoreFSMSnapshot: single-pass verify+restore via TeeReader; reads on-disk footer before FSM mutation (fail-fast on token mismatch)
- verifyFSMSnapshotFile: read-only CRC check for startup orphan detection
- readFSMSnapshotPayload: bridge-mode helper for legacy wire compat
- cleanupStaleFSMSnaps: removes *.fsm.tmp orphans and index-orphaned .fsm
- purgeOldSnapshotFiles: coordinated snap+fsm deletion (snap first)
- Typed errors: ErrFSMSnapshotFileCRC, ErrFSMSnapshotTokenCRC, etc.

Modified:
- wal_store.go: restoreSnapshotState handles token; bootstrapWalState writes initial .fsm; purgeOldSnapFiles removed; fsmSnapDir threaded
- engine.go: fsmSnapDir field; snapshotPayload(index) writes to disk; persistLocalSnapshot uses token; applyReadySnapshot uses openAndRestoreFSMSnapshot; engines without fsmSnapDir fall back automatically (test compatibility)
- grpc_transport.go: Phase 1 bridge mode in Dispatch (reads .fsm → []byte for legacy receivers); applyBridgeMode extracted for reduced complexity
- migrate.go: pass fsmSnapDir to persistBootState
- snapshot_spool_test.go: update purge tests to use purgeOldSnapshotFiles

Also adds fsm_snapshot_file_test.go with all P0 tests from the design doc.