### PR TITLE
fix: always proxy MULTI/EXEC to leader to eliminate follower stale-read anomalies

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -2193,8 +2193,22 @@ func (r *RedisServer) txnStartTS(queue []redcon.Command) (uint64, error) {
 	}
 	// txnStartTS is only called on the leader (followers proxy MULTI/EXEC via
 	// proxyTransactionToLeader before reaching runTransaction). The leader's
-	// HLC clock is authoritative — Observe the max key timestamp first so the
-	// clock never goes backwards, then take the next monotonic tick.
+	// HLC clock is authoritative — Observe the highest known committed
+	// timestamp before issuing the next tick so the clock never goes backwards.
+	//
+	// store.LastCommitTS() covers the leader-election case: when a new leader
+	// is elected its in-memory HLC starts from wall-clock time (zero logical),
+	// which may be lower than the previous leader's last commit timestamp
+	// (stored in the MVCC layer and applied via FSM). Without this Observe
+	// call the new leader could issue a startTS below already-committed
+	// versions, causing spurious write-conflict retries. The FSM conflict check
+	// would still catch any real violations, but observing LastCommitTS here
+	// avoids the unnecessary retry loop.
+	if r.store != nil {
+		if storeTS := r.store.LastCommitTS(); storeTS > maxTS {
+			maxTS = storeTS
+		}
+	}
 	if r.coordinator != nil && r.coordinator.Clock() != nil && maxTS > 0 {
 		r.coordinator.Clock().Observe(maxTS)
 	}

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -2133,13 +2133,28 @@ func (r *RedisServer) txnStartTS(queue []redcon.Command) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
+
+	// Bound maxTS by the store's global last applied timestamp.
+	// On follower nodes the HLC wall clock can advance beyond the follower's
+	// replicated state: Clock().Next() may return a timestamp higher than the
+	// leader's latest commit for a key, causing the FSM's conflict check
+	// (latestVer.TS > startTS) to pass even when the follower read a stale
+	// version. Including LastCommitTS() ensures startTS reflects what the
+	// follower has actually applied, so any unreplicated leader commits will
+	// still be detected as conflicts.
+	if r.store != nil {
+		if storeTS := r.store.LastCommitTS(); storeTS > maxTS {
+			maxTS = storeTS
+		}
+	}
+
 	if r.coordinator != nil && r.coordinator.Clock() != nil && maxTS > 0 {
 		r.coordinator.Clock().Observe(maxTS)
 	}
-	if r.coordinator == nil || r.coordinator.Clock() == nil {
-		return maxTS + 1, nil
-	}
-	return r.coordinator.Clock().Next(), nil
+	// Return maxTS+1 (bounded by applied store state) rather than
+	// Clock().Next() (wall-clock-based) to prevent startTS from exceeding the
+	// follower's replicated state and masking write-write conflicts in the FSM.
+	return maxTS + 1, nil
 }
 
 func (r *RedisServer) maxLatestCommitTS(ctx context.Context, queue []redcon.Command) (uint64, error) {

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1348,15 +1348,73 @@ func (r *RedisServer) exec(conn redcon.Conn, _ redcon.Command) {
 		return
 	}
 
-	results, err := r.runTransaction(state.queue)
+	queue := state.queue
 	state.inTxn = false
 	state.queue = nil
+
+	// Always execute MULTI/EXEC on the leader so that reads and writes within
+	// the transaction see consistent, up-to-date data. Serving transactions
+	// on followers risks reading stale MVCC state and producing write cycles.
+	if !r.coordinator.IsLeader() {
+		r.proxyTransactionToLeader(conn, queue)
+		return
+	}
+
+	results, err := r.runTransaction(queue)
 	if err != nil {
 		conn.WriteError(err.Error())
 		return
 	}
 
 	r.writeResults(conn, results)
+}
+
+// proxyTransactionToLeader forwards a MULTI/EXEC transaction to the leader
+// node and writes the EXEC response array back to conn.
+func (r *RedisServer) proxyTransactionToLeader(conn redcon.Conn, queue []redcon.Command) {
+	leader := r.coordinator.RaftLeader()
+	if leader == "" {
+		conn.WriteError(ErrLeaderNotFound.Error())
+		return
+	}
+	leaderAddr, ok := r.leaderRedis[leader]
+	if !ok || leaderAddr == "" {
+		conn.WriteError(fmt.Sprintf("leader redis address unknown for raft address %s", leader))
+		return
+	}
+	cli := r.getOrCreateLeaderClient(leaderAddr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
+	defer cancel()
+
+	cmds := make([]*redis.Cmd, 0, len(queue))
+	_, err := cli.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+		for _, cmd := range queue {
+			args := make([]interface{}, len(cmd.Args))
+			for i, a := range cmd.Args {
+				args[i] = a
+			}
+			cmds = append(cmds, pipe.Do(ctx, args...))
+		}
+		return nil
+	})
+	// A non-nil err here means one or more commands within the transaction
+	// returned a Redis-level error. Individual results are still available
+	// on each cmd, which is the correct Redis EXEC semantics (array of
+	// per-command results, some of which may be error replies).
+	// Only bail if we have no per-command results at all (fatal error).
+	if len(cmds) == 0 {
+		if err != nil {
+			conn.WriteError(err.Error())
+		} else {
+			conn.WriteArray(0)
+		}
+		return
+	}
+	conn.WriteArray(len(cmds))
+	for _, cmd := range cmds {
+		writeGoRedisResult(conn, cmd)
+	}
 }
 
 type txnValue struct {

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -2191,28 +2191,17 @@ func (r *RedisServer) txnStartTS(queue []redcon.Command) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-
-	// Bound maxTS by the store's global last applied timestamp.
-	// On follower nodes the HLC wall clock can advance beyond the follower's
-	// replicated state: Clock().Next() may return a timestamp higher than the
-	// leader's latest commit for a key, causing the FSM's conflict check
-	// (latestVer.TS > startTS) to pass even when the follower read a stale
-	// version. Including LastCommitTS() ensures startTS reflects what the
-	// follower has actually applied, so any unreplicated leader commits will
-	// still be detected as conflicts.
-	if r.store != nil {
-		if storeTS := r.store.LastCommitTS(); storeTS > maxTS {
-			maxTS = storeTS
-		}
-	}
-
+	// txnStartTS is only called on the leader (followers proxy MULTI/EXEC via
+	// proxyTransactionToLeader before reaching runTransaction). The leader's
+	// HLC clock is authoritative — Observe the max key timestamp first so the
+	// clock never goes backwards, then take the next monotonic tick.
 	if r.coordinator != nil && r.coordinator.Clock() != nil && maxTS > 0 {
 		r.coordinator.Clock().Observe(maxTS)
 	}
-	// Return maxTS+1 (bounded by applied store state) rather than
-	// Clock().Next() (wall-clock-based) to prevent startTS from exceeding the
-	// follower's replicated state and masking write-write conflicts in the FSM.
-	return maxTS + 1, nil
+	if r.coordinator == nil || r.coordinator.Clock() == nil {
+		return maxTS + 1, nil
+	}
+	return r.coordinator.Clock().Next(), nil
 }
 
 func (r *RedisServer) maxLatestCommitTS(ctx context.Context, queue []redcon.Command) (uint64, error) {

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1398,17 +1398,24 @@ func (r *RedisServer) proxyTransactionToLeader(conn redcon.Conn, queue []redcon.
 		}
 		return nil
 	})
-	// A non-nil err here means one or more commands within the transaction
-	// returned a Redis-level error. Individual results are still available
-	// on each cmd, which is the correct Redis EXEC semantics (array of
-	// per-command results, some of which may be error replies).
-	// Only bail if we have no per-command results at all (fatal error).
+	// Transaction aborted (WATCH conflict or server-side nil EXEC reply):
+	// Redis protocol requires a Null array reply (*-1), not an error array.
+	if errors.Is(err, redis.TxFailedErr) || errors.Is(err, redis.Nil) {
+		conn.WriteNull()
+		return
+	}
+	// Fatal transport error (context timeout, network failure): return a
+	// single error reply. Per-command results are unreliable in this case.
+	if err != nil && (errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)) {
+		conn.WriteError(err.Error())
+		return
+	}
+	// For any other non-nil err (individual command errors within the
+	// transaction), individual results are still available on each cmd,
+	// which is the correct Redis EXEC semantics — an array of per-command
+	// responses where some entries may be error replies.
 	if len(cmds) == 0 {
-		if err != nil {
-			conn.WriteError(err.Error())
-		} else {
-			conn.WriteArray(0)
-		}
+		conn.WriteArray(0)
 		return
 	}
 	conn.WriteArray(len(cmds))


### PR DESCRIPTION
…n followers

On follower nodes, Clock().Next() returns a wall-clock-based HLC timestamp that can exceed the follower's replicated state for specific keys. When this happens, the FSM conflict check (latestVer.TS > startTS) passes even though the follower read a stale version, producing G0 write cycles detected by Jepsen.

Fix: incorporate r.store.LastCommitTS() into maxTS before computing startTS. This ensures startTS is bounded by what the follower has actually applied, so any unreplicated leader commit will have TS_leader > startTS and be correctly rejected by checkConflictsLocked.