### PR TITLE
fix: use safe snapshot timestamp in txnStartTS to prevent lost-write anomaly

### DIFF
--- a/.github/workflows/jepsen-test-scheduled.yml
+++ b/.github/workflows/jepsen-test-scheduled.yml
@@ -23,6 +23,10 @@ on:
         description: "Maximum writes per key before exhaustion"
         required: false
         default: "150"
+      max-txn-length:
+        description: "Maximum micro-ops per transaction"
+        required: false
+        default: "4"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-jepsen-scheduled
@@ -94,7 +98,7 @@ jobs:
             --concurrency ${{ inputs.concurrency || '8' }} \
             --key-count ${{ inputs.key-count || '16' }} \
             --max-writes-per-key ${{ inputs.max-writes-per-key || '250' }} \
-            --max-txn-length 4 \
+            --max-txn-length ${{ inputs.max-txn-length || '4' }} \
             --ports 63791,63792,63793 \
             --host 127.0.0.1
       - name: Run DynamoDB Jepsen workload against elastickv
@@ -107,6 +111,7 @@ jobs:
             --concurrency ${{ inputs.concurrency || '8' }} \
             --key-count ${{ inputs.key-count || '16' }} \
             --max-writes-per-key ${{ inputs.max-writes-per-key || '250' }} \
+            --max-txn-length ${{ inputs.max-txn-length || '4' }} \
             --dynamo-ports 63801,63802,63803 \
             --host 127.0.0.1
       - name: Run S3 Jepsen workload against elastickv

--- a/.github/workflows/jepsen-test.yml
+++ b/.github/workflows/jepsen-test.yml
@@ -48,6 +48,7 @@ jobs:
           BOOTSTRAP_MEMBERS="n1=127.0.0.1:50051,n2=127.0.0.1:50052,n3=127.0.0.1:50053"
           RAFT_REDIS_MAP="127.0.0.1:50051=127.0.0.1:63791,127.0.0.1:50052=127.0.0.1:63792,127.0.0.1:50053=127.0.0.1:63793"
           RAFT_S3_MAP="127.0.0.1:50051=127.0.0.1:63901,127.0.0.1:50052=127.0.0.1:63902,127.0.0.1:50053=127.0.0.1:63903"
+          RAFT_DYNAMO_MAP="127.0.0.1:50051=127.0.0.1:63801,127.0.0.1:50052=127.0.0.1:63802,127.0.0.1:50053=127.0.0.1:63803"
 
           : > /tmp/elastickv-demo.pid
           for node in 1 2 3; do
@@ -63,6 +64,7 @@ jobs:
               --raftBootstrapMembers "$BOOTSTRAP_MEMBERS" \
               --raftRedisMap "$RAFT_REDIS_MAP" \
               --raftS3Map "$RAFT_S3_MAP" \
+              --raftDynamoMap "$RAFT_DYNAMO_MAP" \
               > "/tmp/elastickv-demo-n${node}.log" 2>&1 &
             echo $! >> /tmp/elastickv-demo.pid
           done

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -7506,9 +7506,24 @@ func cloneAttributeValue(in attributeValue) attributeValue {
 	return out
 }
 
+// globalLastCommitTSProvider is the interface satisfied by stores (e.g.
+// LeaderRoutedStore) that can proxy the leader's LastCommitTS.  Defined as a
+// local interface so DynamoDBServer avoids a hard dependency on the concrete
+// kv type.
+type globalLastCommitTSProvider interface {
+	GlobalLastCommitTS(ctx context.Context) uint64
+}
+
 func (d *DynamoDBServer) nextTxnReadTS() uint64 {
+	// On a follower the local store.LastCommitTS() may lag behind the leader.
+	// Use GlobalLastCommitTS so ConsistentRead snapshots and transaction
+	// start timestamps are aligned with the leader's committed watermark,
+	// preventing stale pre-reads that cause false Jepsen anomalies and
+	// unnecessary WriteConflict retries on every follower request.
 	maxTS := uint64(0)
-	if d.store != nil {
+	if p, ok := d.store.(globalLastCommitTSProvider); ok {
+		maxTS = p.GlobalLastCommitTS(context.Background())
+	} else if d.store != nil {
 		maxTS = d.store.LastCommitTS()
 	}
 

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -94,11 +94,12 @@ var dynamoOperationTargets = map[string]string{
 }
 
 const (
-	dynamoErrValidation        = "ValidationException"
-	dynamoErrInternal          = "InternalServerError"
-	dynamoErrConditionalFailed = "ConditionalCheckFailedException"
-	dynamoErrResourceNotFound  = "ResourceNotFoundException"
-	dynamoErrResourceInUse     = "ResourceInUseException"
+	dynamoErrValidation          = "ValidationException"
+	dynamoErrInternal            = "InternalServerError"
+	dynamoErrConditionalFailed   = "ConditionalCheckFailedException"
+	dynamoErrTransactionCanceled = "TransactionCanceledException"
+	dynamoErrResourceNotFound    = "ResourceNotFoundException"
+	dynamoErrResourceInUse       = "ResourceInUseException"
 )
 
 const (
@@ -4040,6 +4041,13 @@ func (d *DynamoDBServer) processTransactWriteItem(
 	seenItemKeys[compositeKey] = struct{}{}
 	plan, err := d.buildTransactWriteItemPlan(ctx, schema, item, readTS)
 	if err != nil {
+		// Real DynamoDB wraps per-item condition failures in
+		// TransactionCanceledException rather than surfacing the raw
+		// ConditionalCheckFailedException to the caller.
+		var apiErr *dynamoAPIError
+		if errors.As(err, &apiErr) && apiErr.errorType == dynamoErrConditionalFailed {
+			return newDynamoAPIError(http.StatusBadRequest, dynamoErrTransactionCanceled, apiErr.message)
+		}
 		return err
 	}
 	reqs.Elems = append(reqs.Elems, plan.elems...)

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -3996,6 +3996,9 @@ func (d *DynamoDBServer) buildTransactWriteItemsRequest(ctx context.Context, in 
 	schemaCache := make(map[string]*dynamoTableSchema)
 	tableGenerations := make(map[string]uint64)
 	cleanup := make([][]byte, 0, len(in.TransactItems))
+	// seenItemKeys tracks (tableName, primaryKey) pairs to detect duplicates.
+	// Real DynamoDB rejects requests with multiple operations on the same item.
+	seenItemKeys := make(map[string]struct{}, len(in.TransactItems))
 	for _, item := range in.TransactItems {
 		tableName, err := transactWriteItemTableName(item)
 		if err != nil {
@@ -4005,6 +4008,17 @@ func (d *DynamoDBServer) buildTransactWriteItemsRequest(ctx context.Context, in 
 		if err != nil {
 			return nil, nil, nil, err
 		}
+		// Reject duplicate item keys to match real DynamoDB behavior.
+		itemKeyStr, err := transactWriteItemPrimaryKeyStr(schema, item)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		compositeKey := tableName + "\x00" + itemKeyStr
+		if _, dup := seenItemKeys[compositeKey]; dup {
+			return nil, nil, nil, newDynamoAPIError(http.StatusBadRequest, dynamoErrValidation,
+				"Transaction request cannot include multiple operations on one item")
+		}
+		seenItemKeys[compositeKey] = struct{}{}
 		plan, err := d.buildTransactWriteItemPlan(ctx, schema, item, readTS)
 		if err != nil {
 			return nil, nil, nil, err
@@ -4017,6 +4031,34 @@ func (d *DynamoDBServer) buildTransactWriteItemsRequest(ctx context.Context, in 
 		cleanup = append(cleanup, plan.cleanup...)
 	}
 	return reqs, tableGenerations, cleanup, nil
+}
+
+// transactWriteItemPrimaryKeyStr returns a canonical JSON string of the item's
+// primary key attributes, used to detect duplicate-item violations in
+// TransactWriteItems (real DynamoDB returns ValidationException for these).
+func transactWriteItemPrimaryKeyStr(schema *dynamoTableSchema, item transactWriteItem) (string, error) {
+	var keyAttrs map[string]attributeValue
+	switch {
+	case item.Update != nil:
+		keyAttrs = item.Update.Key
+	case item.Delete != nil:
+		keyAttrs = item.Delete.Key
+	case item.ConditionCheck != nil:
+		keyAttrs = item.ConditionCheck.Key
+	case item.Put != nil:
+		var err error
+		keyAttrs, err = primaryKeyAttributes(schema.PrimaryKey, item.Put.Item)
+		if err != nil {
+			return "", err
+		}
+	default:
+		return "", newDynamoAPIError(http.StatusBadRequest, dynamoErrValidation, "unsupported transact item")
+	}
+	b, err := json.Marshal(keyAttrs)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to serialize transact item key")
+	}
+	return string(b), nil
 }
 
 type transactWriteItemPlan struct {

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -4315,8 +4315,10 @@ func (d *DynamoDBServer) buildTransactDeletePlan(
 		return nil, newDynamoAPIError(http.StatusBadRequest, dynamoErrConditionalFailed, err.Error())
 	}
 	if !found {
-		// Item does not exist at readTS; still track the key so the FSM can
-		// detect a concurrent write that creates the item after our snapshot.
+		// Item does not exist at readTS. Track the key so a concurrent create
+		// after our snapshot can be detected if the overall transaction
+		// includes write elems and therefore reaches FSM validation. In a
+		// pure no-op transaction, these read keys may not be validated.
 		return &transactWriteItemPlan{readKeys: [][]byte{itemKey}}, nil
 	}
 	req, err := buildItemDeleteRequestWithSource(currentLocation)

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -4024,6 +4024,7 @@ func (d *DynamoDBServer) buildTransactWriteItemsRequest(ctx context.Context, in 
 			return nil, nil, nil, err
 		}
 		reqs.Elems = append(reqs.Elems, plan.elems...)
+		reqs.ReadKeys = append(reqs.ReadKeys, plan.readKeys...)
 		if !plan.writes {
 			continue
 		}
@@ -4062,9 +4063,15 @@ func transactWriteItemPrimaryKeyStr(schema *dynamoTableSchema, item transactWrit
 }
 
 type transactWriteItemPlan struct {
-	elems   []*kv.Elem[kv.OP]
-	cleanup [][]byte
-	writes  bool
+	elems    []*kv.Elem[kv.OP]
+	cleanup  [][]byte
+	writes   bool
+	// readKeys contains the raw storage keys that were read during plan
+	// construction.  They are propagated into OperationGroup.ReadKeys so the
+	// FSM can validate read-write conflicts atomically at commit time,
+	// preventing lost-update and G0 anomalies on concurrent transactions that
+	// read the same item at a stale timestamp.
+	readKeys [][]byte
 }
 
 func (d *DynamoDBServer) buildTransactWriteItemPlan(
@@ -4122,9 +4129,10 @@ func (d *DynamoDBServer) buildTransactPutPlan(
 		return nil, err
 	}
 	return &transactWriteItemPlan{
-		elems:   req.Elems,
-		cleanup: cleanup,
-		writes:  true,
+		elems:    req.Elems,
+		cleanup:  cleanup,
+		writes:   true,
+		readKeys: [][]byte{itemKey},
 	}, nil
 }
 
@@ -4165,9 +4173,10 @@ func (d *DynamoDBServer) buildTransactUpdatePlan(
 		return nil, err
 	}
 	return &transactWriteItemPlan{
-		elems:   req.Elems,
-		cleanup: cleanup,
-		writes:  true,
+		elems:    req.Elems,
+		cleanup:  cleanup,
+		writes:   true,
+		readKeys: [][]byte{itemKey},
 	}, nil
 }
 
@@ -4177,6 +4186,10 @@ func (d *DynamoDBServer) buildTransactDeletePlan(
 	in transactDeleteInput,
 	readTS uint64,
 ) (*transactWriteItemPlan, error) {
+	itemKey, err := schema.itemKeyFromAttributes(in.Key)
+	if err != nil {
+		return nil, newDynamoAPIError(http.StatusBadRequest, dynamoErrValidation, err.Error())
+	}
 	currentLocation, found, err := d.readLogicalItemAt(ctx, schema, in.Key, readTS)
 	if err != nil {
 		return nil, newDynamoAPIError(http.StatusBadRequest, dynamoErrValidation, err.Error())
@@ -4194,15 +4207,18 @@ func (d *DynamoDBServer) buildTransactDeletePlan(
 		return nil, newDynamoAPIError(http.StatusBadRequest, dynamoErrConditionalFailed, err.Error())
 	}
 	if !found {
-		return &transactWriteItemPlan{}, nil
+		// Item does not exist at readTS; still track the key so the FSM can
+		// detect a concurrent write that creates the item after our snapshot.
+		return &transactWriteItemPlan{readKeys: [][]byte{itemKey}}, nil
 	}
 	req, err := buildItemDeleteRequestWithSource(currentLocation)
 	if err != nil {
 		return nil, err
 	}
 	return &transactWriteItemPlan{
-		elems:  req.Elems,
-		writes: true,
+		elems:    req.Elems,
+		writes:   true,
+		readKeys: [][]byte{itemKey},
 	}, nil
 }
 
@@ -4244,9 +4260,10 @@ func (d *DynamoDBServer) buildTransactConditionCheckPlan(
 		return nil, err
 	}
 	return &transactWriteItemPlan{
-		elems:   lockReq.Elems,
-		cleanup: lockCleanup,
-		writes:  true,
+		elems:    lockReq.Elems,
+		cleanup:  lockCleanup,
+		writes:   true,
+		readKeys: [][]byte{itemKey},
 	}, nil
 }
 

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -4407,16 +4407,26 @@ func buildConditionCheckLockRequest(
 	current map[string]attributeValue,
 	found bool,
 ) (*kv.OperationGroup[kv.OP], [][]byte, error) {
-	elems := make([]*kv.Elem[kv.OP], 0, 1)
-	if found {
-		payload, err := encodeStoredDynamoItem(current)
-		if err != nil {
-			return nil, nil, errors.WithStack(err)
-		}
-		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: itemKey, Value: payload})
-	} else {
-		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: itemKey})
+	if !found {
+		// Item does not exist: no write is needed.
+		// Include itemKey in ReadKeys only so OCC conflict detection fires
+		// if a concurrent writer commits to this key between our startTS and commitTS.
+		// Writing a Del tombstone here would shadow any concurrently committed Put
+		// at a higher timestamp, causing G-single-item-realtime anomalies.
+		// Return nil cleanup since nothing was written by this condition check.
+		return &kv.OperationGroup[kv.OP]{
+				IsTxn:   true,
+				StartTS: 0,
+				Elems:   nil,
+			},
+			nil,
+			nil
 	}
+	payload, err := encodeStoredDynamoItem(current)
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+	elems := []*kv.Elem[kv.OP]{{Op: kv.Put, Key: itemKey, Value: payload}}
 	return &kv.OperationGroup[kv.OP]{
 			IsTxn:   true,
 			StartTS: 0,

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -2064,47 +2064,29 @@ func (d *DynamoDBServer) mergeReadItemsFromSourceSchema(
 	return mergeMigratingReadItems(schema.PrimaryKey, orderKey, items, sourceItems)
 }
 
-// consistentReadLatestTS is a read timestamp used by follower nodes for
-// ConsistentRead=true reads.  The value is far above any realistic HLC
-// timestamp (~Unix-nanosecond range, ≪ 10^19), so reading at this TS from
-// the leader's Pebble store returns the most recently committed version of
-// any key.  It avoids the noStartTS sentinel (^uint64(0)) used by the
-// coordinator.
+// consistentReadLatestTS is a read timestamp used for ConsistentRead=true reads.
+// The value is far above any realistic HLC timestamp (~Unix-nanosecond range,
+// ≪ 10^19), so reading at this TS from the leader's Pebble store returns the
+// most recently committed version of any key.  It avoids the noStartTS
+// sentinel (^uint64(0)) used by the coordinator.
+//
+// This sentinel is used on BOTH the leader and followers:
+//   - On a follower, the read is proxied to the leader via proxyRawGet with
+//     ts=consistentReadLatestTS, so the leader reads the absolute latest version.
+//   - On the leader, the LeaderRoutedStore performs a linearizable read fence
+//     (ensuring all committed Raft entries are applied) and then reads locally
+//     at consistentReadLatestTS, returning the latest committed version.
+//
+// Using store.LastCommitTS() instead would introduce a TOCTOU race: the
+// timestamp is captured before the linearizable fence, so a write committed
+// after LastCommitTS() but applied during the fence would be missed.
 const consistentReadLatestTS = ^uint64(0) - 1
 
 func (d *DynamoDBServer) resolveDynamoReadTS(consistentRead *bool) uint64 {
 	if consistentRead != nil && *consistentRead {
-		return d.nextConsistentReadTS()
-	}
-	return snapshotTS(d.coordinator.Clock(), d.store)
-}
-
-// nextConsistentReadTS returns a read timestamp suitable for ConsistentRead=true
-// reads.  On the leader, it returns store.LastCommitTS() — every version at or
-// below that timestamp is guaranteed visible in Pebble.  On a follower, the
-// local LastCommitTS() may lag behind the leader's; since consistent reads are
-// proxied to the leader via proxyRawGet, we use consistentReadLatestTS so the
-// leader reads the most recently committed version rather than the stale
-// follower timestamp.
-func (d *DynamoDBServer) nextConsistentReadTS() uint64 {
-	maxTS := uint64(0)
-	if d.store != nil {
-		maxTS = d.store.LastCommitTS()
-	}
-	clock := d.coordinator.Clock()
-	if clock != nil && maxTS > 0 {
-		clock.Observe(maxTS)
-	}
-	// On a follower, LastCommitTS() is stale relative to the leader.
-	// Return a large sentinel so that proxyRawGet asks the leader for
-	// the absolute latest committed version of the requested key.
-	if d.coordinator != nil && !d.coordinator.IsLeader() {
 		return consistentReadLatestTS
 	}
-	if maxTS == 0 {
-		return 1
-	}
-	return maxTS
+	return snapshotTS(d.coordinator.Clock(), d.store)
 }
 
 func validateGSIReadOptions(

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -7380,17 +7380,23 @@ func (d *DynamoDBServer) nextTxnReadTS() uint64 {
 		maxTS = d.store.LastCommitTS()
 	}
 
+	// Advance the HLC so subsequent commitTS calls produce values > maxTS,
+	// but return maxTS directly as the snapshot — NOT clock.Next().
+	//
+	// clock.Next() can be ahead of store.LastCommitTS() because concurrent
+	// dispatchTxn calls advance the HLC before their Raft entry is applied.
+	// If readTS = clock.Next() = T and a concurrent write obtained
+	// commitTS = T-1 (still in the Raft pipeline), the version at T-1 is
+	// not yet in Pebble.  Reads would see stale data and the FSM conflict
+	// check (latestTS > startTS: T-1 > T → false) would silently pass,
+	// allowing corrupted writes.  Returning maxTS closes this gap: every
+	// version at ≤ maxTS is guaranteed visible, and any concurrent write at
+	// > maxTS triggers a WriteConflict and a retry.
 	clock := d.coordinator.Clock()
-	if clock == nil {
-		if maxTS == ^uint64(0) {
-			return maxTS
-		}
-		return maxTS + 1
-	}
-	if maxTS > 0 {
+	if clock != nil && maxTS > 0 {
 		clock.Observe(maxTS)
 	}
-	return clock.Next()
+	return maxTS
 }
 
 func (d *DynamoDBServer) pinReadTS(ts uint64) *kv.ActiveTimestampToken {

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -2064,11 +2064,47 @@ func (d *DynamoDBServer) mergeReadItemsFromSourceSchema(
 	return mergeMigratingReadItems(schema.PrimaryKey, orderKey, items, sourceItems)
 }
 
+// consistentReadLatestTS is a read timestamp used by follower nodes for
+// ConsistentRead=true reads.  The value is far above any realistic HLC
+// timestamp (~Unix-nanosecond range, ≪ 10^19), so reading at this TS from
+// the leader's Pebble store returns the most recently committed version of
+// any key.  It avoids the noStartTS sentinel (^uint64(0)) used by the
+// coordinator.
+const consistentReadLatestTS = ^uint64(0) - 1
+
 func (d *DynamoDBServer) resolveDynamoReadTS(consistentRead *bool) uint64 {
 	if consistentRead != nil && *consistentRead {
-		return d.nextTxnReadTS()
+		return d.nextConsistentReadTS()
 	}
 	return snapshotTS(d.coordinator.Clock(), d.store)
+}
+
+// nextConsistentReadTS returns a read timestamp suitable for ConsistentRead=true
+// reads.  On the leader, it returns store.LastCommitTS() — every version at or
+// below that timestamp is guaranteed visible in Pebble.  On a follower, the
+// local LastCommitTS() may lag behind the leader's; since consistent reads are
+// proxied to the leader via proxyRawGet, we use consistentReadLatestTS so the
+// leader reads the most recently committed version rather than the stale
+// follower timestamp.
+func (d *DynamoDBServer) nextConsistentReadTS() uint64 {
+	maxTS := uint64(0)
+	if d.store != nil {
+		maxTS = d.store.LastCommitTS()
+	}
+	clock := d.coordinator.Clock()
+	if clock != nil && maxTS > 0 {
+		clock.Observe(maxTS)
+	}
+	// On a follower, LastCommitTS() is stale relative to the leader.
+	// Return a large sentinel so that proxyRawGet asks the leader for
+	// the absolute latest committed version of the requested key.
+	if d.coordinator != nil && !d.coordinator.IsLeader() {
+		return consistentReadLatestTS
+	}
+	if maxTS == 0 {
+		return 1
+	}
+	return maxTS
 }
 
 func validateGSIReadOptions(

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -281,9 +281,10 @@ func (d *DynamoDBServer) Stop() {
 }
 
 // proxyToLeader forwards the HTTP request to the current DynamoDB leader when
-// this node is not the Raft leader.  Returns true if the request was proxied
-// (caller must not write a response), false if the request should be handled
-// locally.
+// this node is not the Raft leader.  Returns true if the request was handled
+// (either proxied or an error response was written), false if the request
+// should be handled locally (i.e. this node is the leader or no leader map is
+// configured).
 func (d *DynamoDBServer) proxyToLeader(w http.ResponseWriter, r *http.Request) bool {
 	if len(d.leaderDynamo) == 0 || d.coordinator == nil {
 		return false
@@ -291,13 +292,18 @@ func (d *DynamoDBServer) proxyToLeader(w http.ResponseWriter, r *http.Request) b
 	if d.coordinator.IsLeader() {
 		return false
 	}
+	// This node is a follower.  All requests must be forwarded to the leader to
+	// preserve linearizability — serving reads or writes locally on a follower
+	// causes stale-read anomalies (G2-item-realtime).
 	leader := d.coordinator.RaftLeader()
 	if leader == "" {
-		return false
+		writeDynamoError(w, http.StatusServiceUnavailable, dynamoErrInternal, "no raft leader currently available")
+		return true
 	}
 	targetAddr, ok := d.leaderDynamo[leader]
 	if !ok || strings.TrimSpace(targetAddr) == "" {
-		return false
+		writeDynamoError(w, http.StatusServiceUnavailable, dynamoErrInternal, "leader dynamo address not found")
+		return true
 	}
 	target := &url.URL{Scheme: "http", Host: targetAddr}
 	proxy := httputil.NewSingleHostReverseProxy(target)

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -4430,7 +4430,11 @@ func nextTransactRetryBackoff(current time.Duration) time.Duration {
 var errTableGenerationChanged = errors.New("table generation changed")
 
 func (d *DynamoDBServer) verifyTableGeneration(ctx context.Context, tableName string, expectedGeneration uint64) error {
-	schema, exists, err := d.loadTableSchema(ctx, tableName)
+	// Use consistentReadLatestTS to always read the latest committed schema.
+	// Using a stale snapshotTS can cause false "table not found" results when
+	// this node's LastCommitTS is behind the table creation timestamp, which
+	// would erroneously trigger cleanupCommittedKeys and delete live item data.
+	schema, exists, err := d.loadTableSchemaAt(ctx, tableName, consistentReadLatestTS)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -7396,6 +7396,9 @@ func (d *DynamoDBServer) nextTxnReadTS() uint64 {
 	if clock != nil && maxTS > 0 {
 		clock.Observe(maxTS)
 	}
+	if maxTS == 0 {
+		return 1
+	}
 	return maxTS
 }
 

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -4000,38 +4000,56 @@ func (d *DynamoDBServer) buildTransactWriteItemsRequest(ctx context.Context, in 
 	// Real DynamoDB rejects requests with multiple operations on the same item.
 	seenItemKeys := make(map[string]struct{}, len(in.TransactItems))
 	for _, item := range in.TransactItems {
-		tableName, err := transactWriteItemTableName(item)
-		if err != nil {
+		if err := d.processTransactWriteItem(ctx, item, readTS, reqs, schemaCache, seenItemKeys, tableGenerations, &cleanup); err != nil {
 			return nil, nil, nil, err
 		}
-		schema, err := d.resolveTransactTableSchema(ctx, schemaCache, tableName, readTS)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		// Reject duplicate item keys to match real DynamoDB behavior.
-		itemKeyStr, err := transactWriteItemPrimaryKeyStr(schema, item)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		compositeKey := tableName + "\x00" + itemKeyStr
-		if _, dup := seenItemKeys[compositeKey]; dup {
-			return nil, nil, nil, newDynamoAPIError(http.StatusBadRequest, dynamoErrValidation,
-				"Transaction request cannot include multiple operations on one item")
-		}
-		seenItemKeys[compositeKey] = struct{}{}
-		plan, err := d.buildTransactWriteItemPlan(ctx, schema, item, readTS)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		reqs.Elems = append(reqs.Elems, plan.elems...)
-		reqs.ReadKeys = append(reqs.ReadKeys, plan.readKeys...)
-		if !plan.writes {
-			continue
-		}
-		tableGenerations[tableName] = schema.Generation
-		cleanup = append(cleanup, plan.cleanup...)
 	}
 	return reqs, tableGenerations, cleanup, nil
+}
+
+// processTransactWriteItem validates and plans a single item within a
+// TransactWriteItems request, appending the resulting ops to reqs and cleanup.
+func (d *DynamoDBServer) processTransactWriteItem(
+	ctx context.Context,
+	item transactWriteItem,
+	readTS uint64,
+	reqs *kv.OperationGroup[kv.OP],
+	schemaCache map[string]*dynamoTableSchema,
+	seenItemKeys map[string]struct{},
+	tableGenerations map[string]uint64,
+	cleanup *[][]byte,
+) error {
+	tableName, err := transactWriteItemTableName(item)
+	if err != nil {
+		return err
+	}
+	schema, err := d.resolveTransactTableSchema(ctx, schemaCache, tableName, readTS)
+	if err != nil {
+		return err
+	}
+	// Reject duplicate item keys to match real DynamoDB behavior.
+	itemKeyStr, err := transactWriteItemPrimaryKeyStr(schema, item)
+	if err != nil {
+		return err
+	}
+	compositeKey := tableName + "\x00" + itemKeyStr
+	if _, dup := seenItemKeys[compositeKey]; dup {
+		return newDynamoAPIError(http.StatusBadRequest, dynamoErrValidation,
+			"Transaction request cannot include multiple operations on one item")
+	}
+	seenItemKeys[compositeKey] = struct{}{}
+	plan, err := d.buildTransactWriteItemPlan(ctx, schema, item, readTS)
+	if err != nil {
+		return err
+	}
+	reqs.Elems = append(reqs.Elems, plan.elems...)
+	reqs.ReadKeys = append(reqs.ReadKeys, plan.readKeys...)
+	if !plan.writes {
+		return nil
+	}
+	tableGenerations[tableName] = schema.Generation
+	*cleanup = append(*cleanup, plan.cleanup...)
+	return nil
 }
 
 // transactWriteItemPrimaryKeyStr returns a canonical JSON string of the item's
@@ -4055,7 +4073,18 @@ func transactWriteItemPrimaryKeyStr(schema *dynamoTableSchema, item transactWrit
 	default:
 		return "", newDynamoAPIError(http.StatusBadRequest, dynamoErrValidation, "unsupported transact item")
 	}
-	b, err := json.Marshal(keyAttrs)
+	// Normalize numeric attribute values so that equivalent numbers (e.g. "10"
+	// and "10.0") produce the same canonical key string and are reliably detected
+	// as duplicates during JSON marshalling.
+	normalized := make(map[string]attributeValue, len(keyAttrs))
+	for k, v := range keyAttrs {
+		if v.N != nil {
+			n := canonicalNumberString(*v.N)
+			v.N = &n
+		}
+		normalized[k] = v
+	}
+	b, err := json.Marshal(normalized)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to serialize transact item key")
 	}
@@ -4063,9 +4092,9 @@ func transactWriteItemPrimaryKeyStr(schema *dynamoTableSchema, item transactWrit
 }
 
 type transactWriteItemPlan struct {
-	elems    []*kv.Elem[kv.OP]
-	cleanup  [][]byte
-	writes   bool
+	elems   []*kv.Elem[kv.OP]
+	cleanup [][]byte
+	writes  bool
 	// readKeys contains the raw storage keys that were read during plan
 	// construction.  They are propagated into OperationGroup.ReadKeys so the
 	// FSM can validate read-write conflicts atomically at commit time,

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -12,6 +12,8 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"slices"
 	"sort"
 	"strconv"
@@ -24,6 +26,7 @@ import (
 	"github.com/bootjp/elastickv/store"
 	"github.com/cockroachdb/errors"
 	json "github.com/goccy/go-json"
+	"github.com/hashicorp/raft"
 )
 
 const (
@@ -123,6 +126,7 @@ type DynamoDBServer struct {
 	requestObserver monitoring.DynamoDBRequestObserver
 	itemUpdateLocks [itemUpdateLockStripeCount]sync.Mutex
 	tableLocks      [tableLockStripeCount]sync.Mutex
+	leaderDynamo    map[raft.ServerAddress]string
 }
 
 // WithDynamoDBRequestObserver enables Prometheus-compatible request metrics.
@@ -135,6 +139,18 @@ func WithDynamoDBRequestObserver(observer monitoring.DynamoDBRequestObserver) Dy
 func WithDynamoDBActiveTimestampTracker(tracker *kv.ActiveTimestampTracker) DynamoDBServerOption {
 	return func(server *DynamoDBServer) {
 		server.readTracker = tracker
+	}
+}
+
+// WithDynamoDBLeaderMap configures the Raft-address-to-DynamoDB-address mapping
+// used to forward requests from followers to the current leader.
+// The format mirrors the raftRedisMap / raftS3Map convention.
+func WithDynamoDBLeaderMap(m map[raft.ServerAddress]string) DynamoDBServerOption {
+	return func(server *DynamoDBServer) {
+		server.leaderDynamo = make(map[raft.ServerAddress]string, len(m))
+		for k, v := range m {
+			server.leaderDynamo[k] = v
+		}
 	}
 }
 
@@ -264,8 +280,39 @@ func (d *DynamoDBServer) Stop() {
 	}
 }
 
+// proxyToLeader forwards the HTTP request to the current DynamoDB leader when
+// this node is not the Raft leader.  Returns true if the request was proxied
+// (caller must not write a response), false if the request should be handled
+// locally.
+func (d *DynamoDBServer) proxyToLeader(w http.ResponseWriter, r *http.Request) bool {
+	if len(d.leaderDynamo) == 0 || d.coordinator == nil {
+		return false
+	}
+	if d.coordinator.IsLeader() {
+		return false
+	}
+	leader := d.coordinator.RaftLeader()
+	if leader == "" {
+		return false
+	}
+	targetAddr, ok := d.leaderDynamo[leader]
+	if !ok || strings.TrimSpace(targetAddr) == "" {
+		return false
+	}
+	target := &url.URL{Scheme: "http", Host: targetAddr}
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy.ErrorHandler = func(rw http.ResponseWriter, _ *http.Request, err error) {
+		writeDynamoError(rw, http.StatusServiceUnavailable, dynamoErrInternal, "leader proxy error: "+err.Error())
+	}
+	proxy.ServeHTTP(w, r)
+	return true
+}
+
 func (d *DynamoDBServer) handle(w http.ResponseWriter, r *http.Request) {
 	if d.serveHealthz(w, r) {
+		return
+	}
+	if d.proxyToLeader(w, r) {
 		return
 	}
 

--- a/adapter/dynamodb_table_compat_test.go
+++ b/adapter/dynamodb_table_compat_test.go
@@ -986,14 +986,26 @@ func TestDynamoDB_TransactWriteItems_MixedActions(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+	// "guard" is a separate sentinel item used only by the ConditionCheck so that
+	// no single item is targeted by two different actions in the same transaction
+	// (which real DynamoDB forbids and our duplicate-key validation enforces).
+	_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(table),
+		Item: map[string]ddbTypes.AttributeValue{
+			"id": &ddbTypes.AttributeValueMemberS{Value: "guard"},
+		},
+	})
+	require.NoError(t, err)
 
 	_, err = client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
 		TransactItems: []ddbTypes.TransactWriteItem{
 			{
+				// Check that the guard item exists — exercises ConditionCheck in a
+				// mixed transaction without colliding with any write target.
 				ConditionCheck: &ddbTypes.ConditionCheck{
 					TableName: aws.String(table),
 					Key: map[string]ddbTypes.AttributeValue{
-						"id": &ddbTypes.AttributeValueMemberS{Value: "2"},
+						"id": &ddbTypes.AttributeValueMemberS{Value: "guard"},
 					},
 					ConditionExpression: aws.String("attribute_exists(#id)"),
 					ExpressionAttributeNames: map[string]string{

--- a/adapter/grpc.go
+++ b/adapter/grpc.go
@@ -108,7 +108,14 @@ func (r *GRPCServer) RawGet(ctx context.Context, req *pb.RawGetRequest) (*pb.Raw
 func (r *GRPCServer) RawLatestCommitTS(ctx context.Context, req *pb.RawLatestCommitTSRequest) (*pb.RawLatestCommitTSResponse, error) {
 	key := req.GetKey()
 	if len(key) == 0 {
-		return nil, errors.WithStack(kv.ErrInvalidRequest)
+		// No key: return the store's global last-committed watermark.
+		// Used by followers to obtain the leader's authoritative LastCommitTS
+		// without per-key overhead, enabling consistent-read snapshot alignment.
+		ts := r.store.LastCommitTS()
+		return &pb.RawLatestCommitTSResponse{
+			Ts:     ts,
+			Exists: ts > 0,
+		}, nil
 	}
 
 	ts, exists, err := r.store.LatestCommitTS(ctx, key)

--- a/adapter/grpc_test.go
+++ b/adapter/grpc_test.go
@@ -10,6 +10,7 @@ import (
 	pb "github.com/bootjp/elastickv/proto"
 	"github.com/bootjp/elastickv/store"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	_ "google.golang.org/grpc/health"
@@ -98,6 +99,27 @@ func Test_grpc_scan(t *testing.T) {
 		assert.Equal(t, key, resp.Kv[i].Key, "Scan RPC failed")
 		assert.Equal(t, want, resp.Kv[i].Value, "Scan RPC failed")
 	}
+}
+
+func TestGRPCServer_RawLatestCommitTS_EmptyKeyReturnsGlobalWatermark(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	require.NoError(t, st.PutAt(ctx, []byte("k"), []byte("v"), 77, 0))
+
+	s := NewGRPCServer(st, nil)
+
+	// Empty key should return global LastCommitTS, not an error.
+	resp, err := s.RawLatestCommitTS(ctx, &pb.RawLatestCommitTSRequest{})
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(77), resp.GetTs())
+	assert.True(t, resp.GetExists())
+
+	// Non-empty key should still work as before.
+	resp, err = s.RawLatestCommitTS(ctx, &pb.RawLatestCommitTSRequest{Key: []byte("k")})
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(77), resp.GetTs())
 }
 
 func TestGRPCServer_RawScanAt_RejectsOversizedLimit(t *testing.T) {

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1372,14 +1372,8 @@ func (r *RedisServer) exec(conn redcon.Conn, _ redcon.Command) {
 // proxyTransactionToLeader forwards a MULTI/EXEC transaction to the leader
 // node and writes the EXEC response array back to conn.
 func (r *RedisServer) proxyTransactionToLeader(conn redcon.Conn, queue []redcon.Command) {
-	leader := r.coordinator.RaftLeader()
-	if leader == "" {
-		conn.WriteError(ErrLeaderNotFound.Error())
-		return
-	}
-	leaderAddr, ok := r.leaderRedis[leader]
-	if !ok || leaderAddr == "" {
-		conn.WriteError(fmt.Sprintf("leader redis address unknown for raft address %s", leader))
+	leaderAddr, ok := r.resolveLeaderRedisAddr(conn)
+	if !ok {
 		return
 	}
 	cli := r.getOrCreateLeaderClient(leaderAddr)
@@ -1387,6 +1381,32 @@ func (r *RedisServer) proxyTransactionToLeader(conn redcon.Conn, queue []redcon.
 	ctx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
 	defer cancel()
 
+	cmds, err := r.execTxPipeline(ctx, cli, queue)
+	if handleProxyTxnError(conn, err) {
+		return
+	}
+	writeProxyCmdsResult(conn, cmds)
+}
+
+// resolveLeaderRedisAddr looks up the Redis address of the current Raft leader,
+// writes an error reply to conn on failure and returns ("", false).
+func (r *RedisServer) resolveLeaderRedisAddr(conn redcon.Conn) (string, bool) {
+	leader := r.coordinator.RaftLeader()
+	if leader == "" {
+		conn.WriteError(ErrLeaderNotFound.Error())
+		return "", false
+	}
+	leaderAddr, ok := r.leaderRedis[leader]
+	if !ok || leaderAddr == "" {
+		conn.WriteError(fmt.Sprintf("leader redis address unknown for raft address %s", leader))
+		return "", false
+	}
+	return leaderAddr, true
+}
+
+// execTxPipeline sends queue as a single TxPipelined batch and returns the
+// per-command result handles together with any pipeline-level error.
+func (r *RedisServer) execTxPipeline(ctx context.Context, cli *redis.Client, queue []redcon.Command) ([]*redis.Cmd, error) {
 	cmds := make([]*redis.Cmd, 0, len(queue))
 	_, err := cli.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
 		for _, cmd := range queue {
@@ -1398,26 +1418,30 @@ func (r *RedisServer) proxyTransactionToLeader(conn redcon.Conn, queue []redcon.
 		}
 		return nil
 	})
+	return cmds, err
+}
+
+// handleProxyTxnError writes the appropriate reply for terminal pipeline errors
+// and returns true when the caller should return early without writing results.
+func handleProxyTxnError(conn redcon.Conn, err error) bool {
 	// Transaction aborted (WATCH conflict or server-side nil EXEC reply):
 	// Redis protocol requires a Null array reply (*-1), not an error array.
 	if errors.Is(err, redis.TxFailedErr) || errors.Is(err, redis.Nil) {
 		conn.WriteNull()
-		return
+		return true
 	}
-	// Fatal transport error (context timeout, network failure): return a
-	// single error reply. Per-command results are unreliable in this case.
+	// Fatal transport error: per-command results are unreliable.
 	if err != nil && (errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)) {
 		conn.WriteError(err.Error())
-		return
+		return true
 	}
-	// For any other non-nil err (individual command errors within the
-	// transaction), individual results are still available on each cmd,
-	// which is the correct Redis EXEC semantics — an array of per-command
-	// responses where some entries may be error replies.
-	if len(cmds) == 0 {
-		conn.WriteArray(0)
-		return
-	}
+	return false
+}
+
+// writeProxyCmdsResult writes an EXEC-style array reply for the given pipeline
+// command handles. For any other non-nil per-command errors, each cmd carries
+// its own result, which is the correct Redis EXEC semantics.
+func writeProxyCmdsResult(conn redcon.Conn, cmds []*redis.Cmd) {
 	conn.WriteArray(len(cmds))
 	for _, cmd := range cmds {
 		writeGoRedisResult(conn, cmd)

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -2228,6 +2228,9 @@ func (r *RedisServer) txnStartTS(queue []redcon.Command) (uint64, error) {
 	if r.coordinator != nil && r.coordinator.Clock() != nil && maxTS > 0 {
 		r.coordinator.Clock().Observe(maxTS)
 	}
+	if maxTS == 0 {
+		return 1, nil
+	}
 	return maxTS, nil
 }
 

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"maps"
 	"math"
@@ -112,8 +113,7 @@ const (
 )
 
 const (
-	redisLatestCommitTimeout = 5 * time.Second
-	redisDispatchTimeout     = 10 * time.Second
+	redisDispatchTimeout = 10 * time.Second
 	redisFlushLegacyTimeout  = 10 * time.Minute
 	redisRelayPublishTimeout = 2 * time.Second
 	redisTraceArgLimit       = 6
@@ -1418,22 +1418,31 @@ func (r *RedisServer) execTxPipeline(ctx context.Context, cli *redis.Client, que
 		}
 		return nil
 	})
-	return cmds, err
+	return cmds, errors.WithStack(err)
 }
 
 // handleProxyTxnError writes the appropriate reply for terminal pipeline errors
 // and returns true when the caller should return early without writing results.
 func handleProxyTxnError(conn redcon.Conn, err error) bool {
-	// Transaction aborted (WATCH conflict or server-side nil EXEC reply):
-	// Redis protocol requires a Null array reply (*-1), not an error array.
-	if errors.Is(err, redis.TxFailedErr) || errors.Is(err, redis.Nil) {
-		conn.WriteNull()
+	// Transaction aborted (WATCH conflict): Redis protocol requires a Null
+	// array reply (*-1\r\n), not a null bulk string or an error.
+	// redis.Nil is a per-command nil response and must NOT be treated as an
+	// EXEC abort — only redis.TxFailedErr signals that.
+	if errors.Is(err, redis.TxFailedErr) {
+		conn.WriteArray(-1)
 		return true
 	}
-	// Fatal transport error: per-command results are unreliable.
-	if err != nil && (errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)) {
-		conn.WriteError(err.Error())
-		return true
+	// Fatal transport / context error: per-command results are unreliable.
+	if err != nil {
+		var netErr net.Error
+		if errors.Is(err, context.DeadlineExceeded) ||
+			errors.Is(err, context.Canceled) ||
+			errors.Is(err, io.EOF) ||
+			errors.Is(err, io.ErrUnexpectedEOF) ||
+			errors.As(err, &netErr) {
+			conn.WriteError(err.Error())
+			return true
+		}
 	}
 	return false
 }
@@ -2172,7 +2181,7 @@ func (r *RedisServer) runTransaction(queue []redcon.Command) ([]redisResult, err
 
 	var results []redisResult
 	err := r.retryRedisWrite(dispatchCtx, func() error {
-		startTS, err := r.txnStartTS(queue)
+		startTS, err := r.txnStartTS()
 		if err != nil {
 			return err
 		}
@@ -2214,14 +2223,7 @@ func (r *RedisServer) runTransaction(queue []redcon.Command) ([]redisResult, err
 	return results, nil
 }
 
-func (r *RedisServer) txnStartTS(queue []redcon.Command) (uint64, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), redisLatestCommitTimeout)
-	defer cancel()
-
-	maxTS, err := r.maxLatestCommitTS(ctx, queue)
-	if err != nil {
-		return 0, err
-	}
+func (r *RedisServer) txnStartTS() (uint64, error) {
 	// store.LastCommitTS() is the authoritative safe-snapshot watermark: it is
 	// updated atomically only AFTER the corresponding Pebble batch commit, so
 	// every version with commitTS ≤ store.LastCommitTS() is guaranteed visible
@@ -2237,17 +2239,14 @@ func (r *RedisServer) txnStartTS(queue []redcon.Command) (uint64, error) {
 	// though we read stale data.  This allows two concurrent RPUSHes to pick the
 	// same sequence number, with the second overwriting the first — a lost write.
 	//
-	// Returning maxTS (= store.LastCommitTS() in practice, or the per-key
-	// Pebble-read value in the narrow window before lastCommitTS is updated)
-	// closes this gap: any concurrent commit at > maxTS triggers a
-	// WriteConflict and a retry via retryRedisWrite.
+	// Using store.LastCommitTS() directly closes this gap: any concurrent commit
+	// at > maxTS triggers a WriteConflict and a retry via retryRedisWrite.
 	//
 	// The Observe call still advances the HLC so that dispatchTxn's clock.Next()
 	// produces a commitTS strictly greater than maxTS (leader-election safety).
+	var maxTS uint64
 	if r.store != nil {
-		if storeTS := r.store.LastCommitTS(); storeTS > maxTS {
-			maxTS = storeTS
-		}
+		maxTS = r.store.LastCommitTS()
 	}
 	if r.coordinator != nil && r.coordinator.Clock() != nil && maxTS > 0 {
 		r.coordinator.Clock().Observe(maxTS)
@@ -2256,39 +2255,6 @@ func (r *RedisServer) txnStartTS(queue []redcon.Command) (uint64, error) {
 		return 1, nil
 	}
 	return maxTS, nil
-}
-
-func (r *RedisServer) maxLatestCommitTS(ctx context.Context, queue []redcon.Command) (uint64, error) {
-	if r.store == nil {
-		return 0, nil
-	}
-
-	// NOTE: This currently calls LatestCommitTS for each (unique) key involved in
-	// the transaction. kv.MaxLatestCommitTS deduplicates keys and performs the
-	// lookups in parallel, but very large transactions can still make this a
-	// latency hot path. If needed, add batching/caching at the storage layer.
-	const txnLatestCommitKeysPerCmd = 4
-	keys := make([][]byte, 0, len(queue)*txnLatestCommitKeysPerCmd)
-	for _, cmd := range queue {
-		if len(cmd.Args) < minKeyedArgs {
-			continue
-		}
-		name := strings.ToUpper(string(cmd.Args[0]))
-		switch name {
-		case cmdSet, cmdGet, cmdDel, cmdExists, cmdRPush, cmdLRange, cmdExpire, cmdPExpire, cmdZIncrBy:
-			key := cmd.Args[1]
-			keys = append(keys, key)
-			// Also account for list metadata keys to avoid stale typing decisions.
-			keys = append(keys, listMetaKey(key))
-			keys = append(keys, redisZSetKey(key))
-			keys = append(keys, redisTTLKey(key))
-		}
-	}
-	ts, err := kv.MaxLatestCommitTS(ctx, r.store, keys)
-	if err != nil {
-		return 0, errors.WithStack(err)
-	}
-	return ts, nil
 }
 
 func (r *RedisServer) writeResults(conn redcon.Conn, results []redisResult) {

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -113,7 +113,7 @@ const (
 )
 
 const (
-	redisDispatchTimeout = 10 * time.Second
+	redisDispatchTimeout     = 10 * time.Second
 	redisFlushLegacyTimeout  = 10 * time.Minute
 	redisRelayPublishTimeout = 2 * time.Second
 	redisTraceArgLimit       = 6
@@ -2181,10 +2181,7 @@ func (r *RedisServer) runTransaction(queue []redcon.Command) ([]redisResult, err
 
 	var results []redisResult
 	err := r.retryRedisWrite(dispatchCtx, func() error {
-		startTS, err := r.txnStartTS()
-		if err != nil {
-			return err
-		}
+		startTS := r.txnStartTS()
 		readPin := r.pinReadTS(startTS)
 		defer readPin.Release()
 
@@ -2223,7 +2220,7 @@ func (r *RedisServer) runTransaction(queue []redcon.Command) ([]redisResult, err
 	return results, nil
 }
 
-func (r *RedisServer) txnStartTS() (uint64, error) {
+func (r *RedisServer) txnStartTS() uint64 {
 	// store.LastCommitTS() is the authoritative safe-snapshot watermark: it is
 	// updated atomically only AFTER the corresponding Pebble batch commit, so
 	// every version with commitTS ≤ store.LastCommitTS() is guaranteed visible
@@ -2244,6 +2241,10 @@ func (r *RedisServer) txnStartTS() (uint64, error) {
 	//
 	// The Observe call still advances the HLC so that dispatchTxn's clock.Next()
 	// produces a commitTS strictly greater than maxTS (leader-election safety).
+	//
+	// When maxTS is 0 (empty store) we return 1 so the coordinator treats this
+	// as a valid startTS and does not override it with clock.Next() — which
+	// could be ahead of unapplied Raft entries and reintroduce the anomaly.
 	var maxTS uint64
 	if r.store != nil {
 		maxTS = r.store.LastCommitTS()
@@ -2252,9 +2253,9 @@ func (r *RedisServer) txnStartTS() (uint64, error) {
 		r.coordinator.Clock().Observe(maxTS)
 	}
 	if maxTS == 0 {
-		return 1, nil
+		return 1
 	}
-	return maxTS, nil
+	return maxTS
 }
 
 func (r *RedisServer) writeResults(conn redcon.Conn, results []redisResult) {

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -2198,19 +2198,28 @@ func (r *RedisServer) txnStartTS(queue []redcon.Command) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	// txnStartTS is only called on the leader (followers proxy MULTI/EXEC via
-	// proxyTransactionToLeader before reaching runTransaction). The leader's
-	// HLC clock is authoritative — Observe the highest known committed
-	// timestamp before issuing the next tick so the clock never goes backwards.
+	// store.LastCommitTS() is the authoritative safe-snapshot watermark: it is
+	// updated atomically only AFTER the corresponding Pebble batch commit, so
+	// every version with commitTS ≤ store.LastCommitTS() is guaranteed visible
+	// in the store when we read.
 	//
-	// store.LastCommitTS() covers the leader-election case: when a new leader
-	// is elected its in-memory HLC starts from wall-clock time (zero logical),
-	// which may be lower than the previous leader's last commit timestamp
-	// (stored in the MVCC layer and applied via FSM). Without this Observe
-	// call the new leader could issue a startTS below already-committed
-	// versions, causing spurious write-conflict retries. The FSM conflict check
-	// would still catch any real violations, but observing LastCommitTS here
-	// avoids the unnecessary retry loop.
+	// We must NOT return clock.Next() here.  clock.Next() can be AHEAD of
+	// store.LastCommitTS() because concurrent dispatchTxn calls advance the HLC
+	// before their Raft entry is applied.  If startTS = clock.Next() = T, a
+	// concurrent transaction that already called clock.Next() to obtain
+	// commitTS = T-1 and is still in the Raft pipeline will satisfy
+	//   latestTS(key) = T-1  ≤  T = startTS
+	// causing the FSM conflict check (latestTS > startTS) to silently pass even
+	// though we read stale data.  This allows two concurrent RPUSHes to pick the
+	// same sequence number, with the second overwriting the first — a lost write.
+	//
+	// Returning maxTS (= store.LastCommitTS() in practice, or the per-key
+	// Pebble-read value in the narrow window before lastCommitTS is updated)
+	// closes this gap: any concurrent commit at > maxTS triggers a
+	// WriteConflict and a retry via retryRedisWrite.
+	//
+	// The Observe call still advances the HLC so that dispatchTxn's clock.Next()
+	// produces a commitTS strictly greater than maxTS (leader-election safety).
 	if r.store != nil {
 		if storeTS := r.store.LastCommitTS(); storeTS > maxTS {
 			maxTS = storeTS
@@ -2219,10 +2228,7 @@ func (r *RedisServer) txnStartTS(queue []redcon.Command) (uint64, error) {
 	if r.coordinator != nil && r.coordinator.Clock() != nil && maxTS > 0 {
 		r.coordinator.Clock().Observe(maxTS)
 	}
-	if r.coordinator == nil || r.coordinator.Clock() == nil {
-		return maxTS + 1, nil
-	}
-	return r.coordinator.Clock().Next(), nil
+	return maxTS, nil
 }
 
 func (r *RedisServer) maxLatestCommitTS(ctx context.Context, queue []redcon.Command) (uint64, error) {

--- a/adapter/redis_txn_test.go
+++ b/adapter/redis_txn_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/bootjp/elastickv/kv"
 	"github.com/bootjp/elastickv/store"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/redcon"
@@ -70,4 +71,43 @@ func TestRedisTxnMULTIEXECRetriesOnCoordinatorConflict(t *testing.T) {
 	val, err := st.GetAt(ctx, redisStrKey([]byte("txn:key")), snapshotTS(coord.clock, st))
 	require.NoError(t, err)
 	require.Equal(t, []byte("v1"), val)
+}
+
+// TestTxnStartTSUsesLastCommitTS verifies that txnStartTS returns
+// store.LastCommitTS() even when the HLC has advanced beyond the last applied
+// commit, preventing the lost-write anomaly described in the PR.
+// If txnStartTS returned clock.Next() instead, a concurrent write that obtained
+// commitTS = lastCommitTS could satisfy latestTS ≤ startTS, silently passing
+// the FSM conflict check and causing a lost write.
+func TestTxnStartTSUsesLastCommitTS(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+
+	// Advance the store's LastCommitTS to a known value.
+	const appliedTS = uint64(5)
+	require.NoError(t, st.PutAt(ctx, []byte("k"), []byte("v"), appliedTS, 0))
+	require.Equal(t, appliedTS, st.LastCommitTS())
+
+	// Advance the HLC well past the applied commit timestamp to simulate
+	// the window where clock.Next() is ahead of unapplied Raft entries.
+	clock := kv.NewHLC()
+	clock.Observe(100)
+	// Verify the clock is ahead of the store watermark.
+	require.Greater(t, clock.Next(), appliedTS)
+
+	coord := newRetryOnceCoordinator(st)
+	coord.clock = clock
+
+	srv := &RedisServer{
+		store:       st,
+		coordinator: coord,
+		scriptCache: map[string]string{},
+	}
+
+	// txnStartTS must return store.LastCommitTS(), not the HLC value.
+	startTS := srv.txnStartTS()
+	require.Equal(t, appliedTS, startTS,
+		"txnStartTS must equal store.LastCommitTS() to prevent lost-write anomaly")
 }

--- a/cmd/server/demo.go
+++ b/cmd/server/demo.go
@@ -49,6 +49,7 @@ var (
 	raftBootstrap  = flag.Bool("raftBootstrap", false, "Bootstrap cluster")
 	raftRedisMap   = flag.String("raftRedisMap", "", "Map of Raft address to Redis address (raftAddr=redisAddr,...)")
 	raftS3Map      = flag.String("raftS3Map", "", "Map of Raft address to S3 address (raftAddr=s3Addr,...)")
+	raftDynamoMap  = flag.String("raftDynamoMap", "", "Map of Raft address to DynamoDB address (raftAddr=dynamoAddr,...)")
 )
 
 const (
@@ -85,6 +86,7 @@ type config struct {
 	raftBootstrap  bool
 	raftRedisMap   string
 	raftS3Map      string
+	raftDynamoMap  string
 }
 
 func main() {
@@ -111,6 +113,7 @@ func main() {
 			raftBootstrap:  *raftBootstrap,
 			raftRedisMap:   *raftRedisMap,
 			raftS3Map:      *raftS3Map,
+			raftDynamoMap:  *raftDynamoMap,
 		}
 		if err := run(runCtx, eg, cfg); err != nil {
 			slog.Error(err.Error())
@@ -169,19 +172,23 @@ func main() {
 			},
 		}
 
-		// Build raftRedisMap/raftS3Map strings.
+		// Build raftRedisMap/raftS3Map/raftDynamoMap strings.
 		var redisMapParts []string
 		var s3MapParts []string
+		var dynamoMapParts []string
 		for _, n := range nodes {
 			redisMapParts = append(redisMapParts, n.address+"="+n.redisAddress)
 			s3MapParts = append(s3MapParts, n.address+"="+n.s3Address)
+			dynamoMapParts = append(dynamoMapParts, n.address+"="+n.dynamoAddress)
 		}
 		raftRedisMapStr := strings.Join(redisMapParts, ",")
 		raftS3MapStr := strings.Join(s3MapParts, ",")
+		raftDynamoMapStr := strings.Join(dynamoMapParts, ",")
 
 		for _, n := range nodes {
 			n.raftRedisMap = raftRedisMapStr
 			n.raftS3Map = raftS3MapStr
+			n.raftDynamoMap = raftDynamoMapStr
 			cfg := n // capture loop variable
 			if err := run(runCtx, eg, cfg); err != nil {
 				slog.Error(err.Error())
@@ -574,12 +581,23 @@ func run(ctx context.Context, eg *errgroup.Group, cfg config) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
+	leaderDynamo := make(map[raft.ServerAddress]string)
+	if cfg.raftDynamoMap != "" {
+		for part := range strings.SplitSeq(cfg.raftDynamoMap, ",") {
+			pair := strings.SplitN(part, "=", kvParts)
+			if len(pair) == kvParts {
+				leaderDynamo[raft.ServerAddress(pair[0])] = pair[1]
+			}
+		}
+	}
+	leaderDynamo[raft.ServerAddress(cfg.address)] = cfg.dynamoAddress
 	dynamoRoutedStore := kv.NewLeaderRoutedStore(st, coordinator)
 	ds := adapter.NewDynamoDBServer(
 		dynamoL,
 		dynamoRoutedStore,
 		coordinator,
 		adapter.WithDynamoDBRequestObserver(metricsRegistry.DynamoDBObserver()),
+		adapter.WithDynamoDBLeaderMap(leaderDynamo),
 	)
 	cleanup.Add(ds.Stop)
 	metricsL, ms, pprofL, ps, err := setupObservabilityServers(ctx, lc, &cleanup, cfg, metricsRegistry.Handler())

--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -9,6 +9,9 @@
                  [slingshot "0.12.2"]
                  [redis.clients/jedis "5.1.0" :exclusions [org.slf4j/slf4j-api]]
                  [clj-http "3.13.1"]
-                 [cheshire "6.2.0"]
+                 ;; cognitect/aws-api — official Clojure AWS SDK used by DynamoDB workload
+                 [com.cognitect.aws/api "0.8.692"]
+                 [com.cognitect.aws/endpoints "1.1.12.626"]
+                 [com.cognitect.aws/dynamodb "847.2.1365.0"]
                  [org.slf4j/slf4j-nop "2.0.9"]]
   :main elastickv.jepsen-test)

--- a/jepsen/src/elastickv/dynamodb_workload.clj
+++ b/jepsen/src/elastickv/dynamodb_workload.clj
@@ -91,6 +91,24 @@
         (when list-val
           (mapv (fn [elem] (Long/parseLong (:N elem))) list-val))))))
 
+(defn- dynamo-transact-write!
+  "Atomically write multiple append operations via a single TransactWriteItems
+   request.  All list_append mutations are applied atomically so that a
+   concurrent reader never observes a partial set of writes from the same
+   transaction (which would produce spurious G0 write-cycle anomalies)."
+  [url writes]
+  (dynamo-request url "DynamoDB_20120810.TransactWriteItems"
+                  {:TransactItems
+                   (mapv (fn [[_ k v]]
+                           {:Update
+                            {:TableName                 table-name
+                             :Key                       {pk-attr {:S (str k)}}
+                             :UpdateExpression          "SET #v = list_append(if_not_exists(#v, :empty), :val)"
+                             :ExpressionAttributeNames  {"#v" val-attr}
+                             :ExpressionAttributeValues {":empty" {:L []}
+                                                         ":val"   {:L [{:N (str v)}]}}}})
+                         writes)}))
+
 (defrecord DynamoDBClient [node->port url]
   client/Client
   (open! [this test node]
@@ -110,13 +128,28 @@
     (try
       (case (:f op)
         :txn
-        (let [value' (mapv (fn [[f k v :as mop]]
-                             (case f
-                               :append (do (dynamo-append! url k v)
-                                           mop)
-                               :r      [f k (dynamo-read url k)]))
-                           (:value op))]
-          (assoc op :type :ok :value value')))
+        (let [mops (:value op)]
+          (if (= 1 (count mops))
+            ;; Single micro-op: send as individual UpdateItem / GetItem.
+            (let [[f k v :as mop] (first mops)]
+              (assoc op :type :ok
+                        :value [(case f
+                                  :append (do (dynamo-append! url k v) mop)
+                                  :r      [f k (dynamo-read url k)])]))
+            ;; Multi-op: reads are individual GetItem (consistent snapshot),
+            ;; writes are batched into one TransactWriteItems for atomicity.
+            ;; Executing reads before writes mirrors snapshot-isolation
+            ;; semantics and prevents G0 write-cycle anomalies.
+            (let [writes (filterv (fn [[f _ _]] (= f :append)) mops)
+                  reads  (filterv (fn [[f _ _]] (= f :r))      mops)
+                  read-results (into {} (map (fn [[_ k _]] [k (dynamo-read url k)]) reads))
+                  _ (when (seq writes) (dynamo-transact-write! url writes))
+                  value' (mapv (fn [[f k v :as mop]]
+                                 (case f
+                                   :append mop
+                                   :r      [f k (get read-results k)]))
+                               mops)]
+              (assoc op :type :ok :value value')))))
       (catch clojure.lang.ExceptionInfo e
         (let [data (ex-data e)
               err-type (:type data)]
@@ -150,14 +183,13 @@
 
 (defn dynamodb-append-workload
   "Builds the list-append workload map targeting the DynamoDB endpoint.
-   max-txn-length defaults to 1 because each micro-op (append/read) is sent
-   as an independent HTTP UpdateItem/GetItem request without DynamoDB
-   TransactWriteItems.  Multi-op transactions would be interleaved, producing
-   false G0 (write cycle) anomalies."
+   Multi-op write transactions are executed atomically via TransactWriteItems
+   to prevent G0 write-cycle anomalies.  Reads within a transaction are sent
+   as individual ConsistentRead GetItem calls before the atomic write batch."
   [opts]
   (let [workload (append/test {:key-count            (or (:key-count opts) 12)
                                :min-txn-length       1
-                               :max-txn-length       (or (:max-txn-length opts) 1)
+                               :max-txn-length       (or (:max-txn-length opts) 4)
                                :max-writes-per-key   (or (:max-writes-per-key opts) 128)
                                :consistency-models   [:strict-serializable]})
         client   (->DynamoDBClient (or (:node->port opts)
@@ -234,6 +266,9 @@
     :parse-fn #(Integer/parseInt %)]
    [nil "--redis-port PORT" "Redis port."
     :default 6379
+    :parse-fn #(Integer/parseInt %)]
+   [nil "--max-txn-length N" "Maximum number of micro-ops per transaction."
+    :default nil
     :parse-fn #(Integer/parseInt %)]])
 
 (defn- prepare-dynamo-opts

--- a/jepsen/src/elastickv/dynamodb_workload.clj
+++ b/jepsen/src/elastickv/dynamodb_workload.clj
@@ -37,11 +37,13 @@
 
 (defn- make-ddb-client
   "Returns a cognitect/aws-api DynamoDB client pointed at http://host:port.
-   Dummy credentials are provided explicitly so the SDK never attempts
-   credential resolution from the environment (which would fail in CI)."
+   Dummy credentials and a fixed region are provided explicitly so the SDK
+   never attempts credential or region resolution from the environment
+   (which would fail in CI or local runs without AWS config)."
   [host port]
   (aws/client
     {:api                  :dynamodb
+     :region               "us-east-1"
      :credentials-provider (creds/basic-credentials-provider
                              {:access-key-id     "dummy"
                               :secret-access-key "dummy"})
@@ -172,8 +174,10 @@
                                   :append (do (dynamo-append! ddb k v) mop)
                                   :r      [f k (dynamo-read ddb k)])]))
 
-            ;; ---- Multi-op: snapshot isolation + read-your-own-writes ----
-            ;; 1. Pre-read a consistent snapshot for every key accessed.
+            ;; ---- Multi-op: pre-read + read-your-own-writes ----
+            ;; 1. Pre-read every key before applying any writes.  Each read is
+            ;;    an independent ConsistentRead GetItem; they do NOT form an
+            ;;    atomic multi-key snapshot (timestamps may differ per key).
             ;; 2. Simulate micro-ops in order; track local appends so that
             ;;    a :r after an :append in the same txn sees the append (RYOW).
             ;; 3. Dispatch all writes atomically via TransactWriteItems,

--- a/jepsen/src/elastickv/dynamodb_workload.clj
+++ b/jepsen/src/elastickv/dynamodb_workload.clj
@@ -1,13 +1,18 @@
 (ns elastickv.dynamodb-workload
   "Jepsen workload for elastickv's DynamoDB-compatible API.
    Uses the list-append consistency model: each key maps to a DynamoDB item
-   whose 'val' attribute is a list of integers. Writes append to the list via
-   UpdateItem; reads fetch the list via GetItem."
+   whose 'val' attribute is a list of integers.
+
+   Writes append to the list via UpdateItem (single-op) or TransactWriteItems
+   (multi-op).  Reads fetch the list via GetItem with ConsistentRead=true.
+
+   Uses cognitect/aws-api as the DynamoDB client so that the full SDK wire
+   protocol (auth headers, error parsing, retry classification) is exercised
+   against elastickv rather than a hand-rolled HTTP layer."
   (:gen-class)
   (:require [clojure.string :as str]
-            [clojure.tools.logging :refer [warn]]
-            [cheshire.core :as json]
-            [clj-http.client :as http]
+            [cognitect.aws.client.api :as aws]
+            [cognitect.aws.credentials :as creds]
             [elastickv.cli :as cli]
             [elastickv.db :as ekdb]
             [jepsen [client :as client]
@@ -23,106 +28,136 @@
             [jepsen.tests.cycle.append :as append]))
 
 (def ^:private table-name "jepsen_append")
-(def ^:private pk-attr "pk")
-(def ^:private val-attr "val")
+(def ^:private pk-attr    "pk")
+(def ^:private val-attr   "val")
 
-(defn- dynamo-url
-  "Returns the base URL for the DynamoDB endpoint on a given node and port."
-  [node port]
-  (str "http://" (name node) ":" port))
+;; ---------------------------------------------------------------------------
+;; Client construction
+;; ---------------------------------------------------------------------------
 
-(defn- dynamo-request
-  "Send a DynamoDB JSON request. Returns the parsed response body or throws."
-  [url target body]
-  (let [resp (http/post url
-               {:headers      {"X-Amz-Target" target
-                               "Content-Type" "application/x-amz-json-1.0"}
-                :body         (json/generate-string body)
-                :as           :string
-                :throw-exceptions false
-                :conn-timeout 5000
-                :socket-timeout 10000})]
-    (if (< (:status resp) 400)
-      (when (and (:body resp) (not (str/blank? (:body resp))))
-        (json/parse-string (:body resp) true))
-      (let [parsed (when (and (:body resp) (not (str/blank? (:body resp))))
-                     (try (json/parse-string (:body resp) true)
-                          (catch Exception _ nil)))
-            err-type (get parsed :__type "UnknownError")
-            message  (get parsed :message (or (:body resp) ""))]
-        (throw (ex-info (str "DynamoDB error: " err-type ": " message)
-                        {:type err-type :status (:status resp) :body parsed}))))))
+(defn- make-ddb-client
+  "Returns a cognitect/aws-api DynamoDB client pointed at http://host:port.
+   Dummy credentials are provided explicitly so the SDK never attempts
+   credential resolution from the environment (which would fail in CI)."
+  [host port]
+  (aws/client
+    {:api                  :dynamodb
+     :credentials-provider (creds/basic-credentials-provider
+                             {:access-key-id     "dummy"
+                              :secret-access-key "dummy"})
+     :endpoint-override    {:protocol :http
+                            :hostname  host
+                            :port      port}}))
+
+;; ---------------------------------------------------------------------------
+;; Low-level DynamoDB helpers
+;; ---------------------------------------------------------------------------
+
+(defn- anomaly? [resp]
+  (contains? resp :cognitect.anomalies/category))
+
+(defn- ddb-invoke!
+  "Invoke op against ddb-client, returning the parsed response map.
+   Throws ex-info on any error (DynamoDB API error or network failure).
+   ex-data keys: :type (DynamoDB __type string or nil), :category (anomaly
+   keyword), :resp (raw cognitect/aws-api response)."
+  [ddb-client op request]
+  (let [resp (aws/invoke ddb-client {:op op :request request})]
+    (if (anomaly? resp)
+      (let [err-type (:__type resp)
+            category (:cognitect.anomalies/category resp)
+            msg      (or (:message resp)
+                         (:Message resp)
+                         (:cognitect.anomalies/message resp)
+                         "")]
+        (throw (ex-info (str "DynamoDB " (or err-type category) ": " msg)
+                        {:type     err-type
+                         :category category
+                         :resp     resp})))
+      resp)))
 
 (defn- create-table!
-  "Create the jepsen_append table if it doesn't exist."
-  [url]
+  "Create the jepsen_append table; ignore ResourceInUseException."
+  [ddb]
   (try
-    (dynamo-request url "DynamoDB_20120810.CreateTable"
-                    {:TableName             table-name
-                     :KeySchema             [{:AttributeName pk-attr :KeyType "HASH"}]
-                     :AttributeDefinitions  [{:AttributeName pk-attr :AttributeType "S"}]
-                     :ProvisionedThroughput {:ReadCapacityUnits 5 :WriteCapacityUnits 5}})
+    (ddb-invoke! ddb :CreateTable
+                 {:TableName             table-name
+                  :KeySchema             [{:AttributeName pk-attr :KeyType "HASH"}]
+                  :AttributeDefinitions  [{:AttributeName pk-attr :AttributeType "S"}]
+                  :ProvisionedThroughput {:ReadCapacityUnits 5 :WriteCapacityUnits 5}})
     (catch clojure.lang.ExceptionInfo e
       (when-not (= "ResourceInUseException" (:type (ex-data e)))
         (throw e)))))
 
 (defn- dynamo-append!
-  "Append a value to the list for the given key. Returns nil."
-  [url k v]
-  (dynamo-request url "DynamoDB_20120810.UpdateItem"
-                  {:TableName                 table-name
-                   :Key                       {pk-attr {:S (str k)}}
-                   :UpdateExpression          "SET #v = list_append(if_not_exists(#v, :empty), :val)"
-                   :ExpressionAttributeNames  {"#v" val-attr}
-                   :ExpressionAttributeValues {":empty" {:L []}
-                                               ":val"   {:L [{:N (str v)}]}}})
+  "Append single value v to the list stored at key k."
+  [ddb k v]
+  (ddb-invoke! ddb :UpdateItem
+               {:TableName                 table-name
+                :Key                       {pk-attr {:S (str k)}}
+                :UpdateExpression          "SET #v = list_append(if_not_exists(#v, :empty), :val)"
+                :ExpressionAttributeNames  {"#v" val-attr}
+                :ExpressionAttributeValues {":empty" {:L []}
+                                            ":val"   {:L [{:N (str v)}]}}})
   nil)
 
 (defn- dynamo-read
-  "Read the list for the given key. Returns a vector of longs, or nil if the
-   item doesn't exist."
-  [url k]
-  (let [resp (dynamo-request url "DynamoDB_20120810.GetItem"
-                             {:TableName      table-name
-                              :Key            {pk-attr {:S (str k)}}
-                              :ConsistentRead true})]
-    (when-let [item (:Item resp)]
-      (let [list-val (get-in item [(keyword val-attr) :L])]
-        (when list-val
-          (mapv (fn [elem] (Long/parseLong (:N elem))) list-val))))))
+  "Read the list stored at key k.  Returns a vector of longs, or nil if the
+   item does not exist.  ConsistentRead ensures we read from the leader."
+  [ddb k]
+  (let [resp (ddb-invoke! ddb :GetItem
+                          {:TableName      table-name
+                           :Key            {pk-attr {:S (str k)}}
+                           :ConsistentRead true})]
+    ;; cognitect/aws-api: Item is map[String,AttributeValue]; member keys
+    ;; of AttributeValue union (S, N, L …) are Clojure keywords.
+    (when-let [lv (get-in resp [:Item val-attr :L])]
+      (mapv #(Long/parseLong (:N %)) lv))))
 
 (defn- dynamo-transact-write!
-  "Atomically write multiple append operations via a single TransactWriteItems
-   request.  All list_append mutations are applied atomically so that a
-   concurrent reader never observes a partial set of writes from the same
-   transaction (which would produce spurious G0 write-cycle anomalies)."
-  [url writes]
-  (dynamo-request url "DynamoDB_20120810.TransactWriteItems"
-                  {:TransactItems
-                   (mapv (fn [[_ k v]]
-                           {:Update
-                            {:TableName                 table-name
-                             :Key                       {pk-attr {:S (str k)}}
-                             :UpdateExpression          "SET #v = list_append(if_not_exists(#v, :empty), :val)"
-                             :ExpressionAttributeNames  {"#v" val-attr}
-                             :ExpressionAttributeValues {":empty" {:L []}
-                                                         ":val"   {:L [{:N (str v)}]}}}})
-                         writes)}))
+  "Atomically write all append micro-ops as a single TransactWriteItems call.
+   Multiple appends to the same key within one transaction are merged into one
+   UpdateItem entry so they are applied atomically — real DynamoDB rejects
+   requests with two operations on the same item (ValidationException), and
+   elastickv enforces the same constraint server-side."
+  [ddb writes]
+  ;; Group values by key, preserving append order within each key.
+  (let [by-key (reduce (fn [acc [_ k v]]
+                         (update acc k (fnil conj []) v))
+                       (array-map)
+                       writes)]
+    (ddb-invoke! ddb :TransactWriteItems
+                 {:TransactItems
+                  (mapv (fn [[k vs]]
+                          {:Update
+                           {:TableName                 table-name
+                            :Key                       {pk-attr {:S (str k)}}
+                            :UpdateExpression          "SET #v = list_append(if_not_exists(#v, :empty), :val)"
+                            :ExpressionAttributeNames  {"#v" val-attr}
+                            :ExpressionAttributeValues {":empty" {:L []}
+                                                        ":val"   {:L (mapv (fn [v] {:N (str v)}) vs)}}}})
+                        by-key)})))
 
-(defrecord DynamoDBClient [node->port url]
+;; ---------------------------------------------------------------------------
+;; Jepsen client
+;; ---------------------------------------------------------------------------
+
+(defrecord DynamoDBClient [node->port ddb]
   client/Client
+
   (open! [this test node]
     (let [port (get node->port node 8000)
           host (or (:dynamo-host test) (name node))]
-      (assoc this :url (dynamo-url host port))))
+      (assoc this :ddb (make-ddb-client host port))))
 
   (setup! [this _test]
-    (create-table! url))
+    (create-table! ddb))
 
   (teardown! [_this _test])
 
   (close! [this _test]
-    (assoc this :url nil))
+    (when ddb (aws/stop ddb))
+    (assoc this :ddb nil))
 
   (invoke! [_this _test op]
     (try
@@ -130,48 +165,63 @@
         :txn
         (let [mops (:value op)]
           (if (= 1 (count mops))
-            ;; Single micro-op: send as individual UpdateItem / GetItem.
+            ;; ---- Single micro-op: individual UpdateItem / GetItem ----
             (let [[f k v :as mop] (first mops)]
               (assoc op :type :ok
                         :value [(case f
-                                  :append (do (dynamo-append! url k v) mop)
-                                  :r      [f k (dynamo-read url k)])]))
-            ;; Multi-op: reads are individual GetItem (consistent snapshot),
-            ;; writes are batched into one TransactWriteItems for atomicity.
-            ;; Executing reads before writes mirrors snapshot-isolation
-            ;; semantics and prevents G0 write-cycle anomalies.
-            (let [writes (filterv (fn [[f _ _]] (= f :append)) mops)
-                  reads  (filterv (fn [[f _ _]] (= f :r))      mops)
-                  read-results (into {} (map (fn [[_ k _]] [k (dynamo-read url k)]) reads))
-                  _ (when (seq writes) (dynamo-transact-write! url writes))
+                                  :append (do (dynamo-append! ddb k v) mop)
+                                  :r      [f k (dynamo-read ddb k)])]))
+
+            ;; ---- Multi-op: snapshot isolation + read-your-own-writes ----
+            ;; 1. Pre-read a consistent snapshot for every key accessed.
+            ;; 2. Simulate micro-ops in order; track local appends so that
+            ;;    a :r after an :append in the same txn sees the append (RYOW).
+            ;; 3. Dispatch all writes atomically via TransactWriteItems,
+            ;;    merging same-key appends into one UpdateItem entry.
+            (let [all-keys      (into #{} (map second mops))
+                  snapshot      (into {} (map (fn [k] [k (dynamo-read ddb k)]) all-keys))
+                  local-appends (volatile! {})
                   value' (mapv (fn [[f k v :as mop]]
                                  (case f
-                                   :append mop
-                                   :r      [f k (get read-results k)]))
-                               mops)]
+                                   :append (do (vswap! local-appends update k (fnil conj []) v)
+                                               mop)
+                                   :r      (let [base    (get snapshot k)
+                                                 pending (get @local-appends k [])]
+                                             [f k (if (and (nil? base) (empty? pending))
+                                                    nil
+                                                    (into (or base []) pending))])))
+                               mops)
+                  writes (filterv (fn [[f _ _]] (= f :append)) mops)]
+              (when (seq writes) (dynamo-transact-write! ddb writes))
               (assoc op :type :ok :value value')))))
+
       (catch clojure.lang.ExceptionInfo e
-        (let [data (ex-data e)
-              err-type (:type data)]
+        (let [data     (ex-data e)
+              err-type (:type data)
+              category (:category data)]
           (cond
-            ;; Condition check failures or internal retryable errors → :info
+            ;; Network / transport error (no DynamoDB __type)
+            (and (nil? err-type)
+                 (#{:cognitect.anomalies/fault
+                    :cognitect.anomalies/unavailable} category))
+            (assoc op :type :info :error :network-error)
+
+            ;; Retryable DynamoDB server-side errors
             (contains? #{"ConditionalCheckFailedException"
                          "InternalServerError"
                          "TransactionCanceledException"} err-type)
             (assoc op :type :info :error (str err-type))
 
-            ;; Validation errors are definite failures
+            ;; Definite API-level failures
             (= "ValidationException" err-type)
-            (assoc op :type :fail :error (str err-type ": " (get-in data [:body :message] "")))
+            (assoc op :type :fail
+                      :error (str err-type ": "
+                                  (get-in data [:resp :message]
+                                    (get-in data [:resp :Message] ""))))
 
             :else
             (assoc op :type :info :error (.getMessage e)))))
-      (catch java.net.ConnectException _
-        (assoc op :type :info :error :connection-refused))
-      (catch java.net.SocketTimeoutException _
-        (assoc op :type :info :error :socket-timeout))
-      (catch java.net.SocketException e
-        (assoc op :type :info :error (str "socket: " (.getMessage e))))
+
       (catch Exception e
         (assoc op :type :info :error (.getMessage e))))))
 
@@ -182,16 +232,16 @@
 (def default-nodes ["n1" "n2" "n3" "n4" "n5"])
 
 (defn dynamodb-append-workload
-  "Builds the list-append workload map targeting the DynamoDB endpoint.
-   Multi-op write transactions are executed atomically via TransactWriteItems
-   to prevent G0 write-cycle anomalies.  Reads within a transaction are sent
-   as individual ConsistentRead GetItem calls before the atomic write batch."
+  "Builds the list-append workload targeting the DynamoDB endpoint.
+   Multi-op write transactions are executed atomically via TransactWriteItems.
+   Reads within a transaction are ConsistentRead GetItem calls; RYOW semantics
+   are implemented client-side for reads that follow a write on the same key."
   [opts]
-  (let [workload (append/test {:key-count            (or (:key-count opts) 12)
-                               :min-txn-length       1
-                               :max-txn-length       (or (:max-txn-length opts) 4)
-                               :max-writes-per-key   (or (:max-writes-per-key opts) 128)
-                               :consistency-models   [:strict-serializable]})
+  (let [workload (append/test {:key-count          (or (:key-count opts) 12)
+                               :min-txn-length     1
+                               :max-txn-length     (or (:max-txn-length opts) 4)
+                               :max-writes-per-key (or (:max-writes-per-key opts) 128)
+                               :consistency-models [:strict-serializable]})
         client   (->DynamoDBClient (or (:node->port opts)
                                        (zipmap default-nodes (repeat 8000)))
                                    nil)]
@@ -202,30 +252,30 @@
    with the list-append workload."
   ([] (elastickv-dynamodb-test {}))
   ([opts]
-   (let [nodes       (or (:nodes opts) default-nodes)
+   (let [nodes        (or (:nodes opts) default-nodes)
          dynamo-ports (or (:dynamo-ports opts) (repeat (count nodes) (or (:dynamo-port opts) 8000)))
-         node->port  (or (:node->port opts) (cli/ports->node-map dynamo-ports nodes))
-         local?      (:local opts)
-         db          (if local?
-                       jdb/noop
-                       (ekdb/db {:grpc-port   (or (:grpc-port opts) 50051)
-                                 :redis-port  (or (:redis-port opts) 6379)
-                                 :dynamo-port node->port
-                                 :raft-groups  (:raft-groups opts)
-                                 :shard-ranges (:shard-ranges opts)}))
-         rate        (double (or (:rate opts) 5))
-         time-limit  (or (:time-limit opts) 30)
-         faults      (if local?
-                       []
-                       (cli/normalize-faults (or (:faults opts) [:partition :kill])))
-         nemesis-p   (when-not local?
-                       (combined/nemesis-package {:db       db
-                                                  :faults   faults
-                                                  :interval (or (:fault-interval opts) 40)}))
-         nemesis-gen (if nemesis-p
-                       (:generator nemesis-p)
-                       (gen/once {:type :info :f :noop}))
-         workload    (dynamodb-append-workload (assoc opts :node->port node->port))]
+         node->port   (or (:node->port opts) (cli/ports->node-map dynamo-ports nodes))
+         local?       (:local opts)
+         db           (if local?
+                        jdb/noop
+                        (ekdb/db {:grpc-port    (or (:grpc-port opts) 50051)
+                                  :redis-port   (or (:redis-port opts) 6379)
+                                  :dynamo-port  node->port
+                                  :raft-groups  (:raft-groups opts)
+                                  :shard-ranges (:shard-ranges opts)}))
+         rate         (double (or (:rate opts) 5))
+         time-limit   (or (:time-limit opts) 30)
+         faults       (if local?
+                        []
+                        (cli/normalize-faults (or (:faults opts) [:partition :kill])))
+         nemesis-p    (when-not local?
+                        (combined/nemesis-package {:db       db
+                                                   :faults   faults
+                                                   :interval (or (:fault-interval opts) 40)}))
+         nemesis-gen  (if nemesis-p
+                        (:generator nemesis-p)
+                        (gen/once {:type :info :f :noop}))
+         workload     (dynamodb-append-workload (assoc opts :node->port node->port))]
      (merge workload
             {:name            (or (:name opts) "elastickv-dynamodb-append")
              :nodes           nodes
@@ -233,15 +283,13 @@
              :dynamo-host     (:dynamo-host opts)
              :os              (if local? os/noop debian/os)
              :net             (if local? net/noop net/iptables)
-             :ssh             (merge {:username              "vagrant"
-                                      :private-key-path      "/home/vagrant/.ssh/id_rsa"
+             :ssh             (merge {:username               "vagrant"
+                                      :private-key-path       "/home/vagrant/.ssh/id_rsa"
                                       :strict-host-key-checking false}
                                      (when local? {:dummy true})
                                      (:ssh opts))
              :remote          control/ssh
-             :nemesis         (if nemesis-p
-                                (:nemesis nemesis-p)
-                                nemesis/noop)
+             :nemesis         (if nemesis-p (:nemesis nemesis-p) nemesis/noop)
              :final-generator nil
              :concurrency     (or (:concurrency opts) 5)
              :generator       (->> (:generator workload)
@@ -255,7 +303,7 @@
 
 (def dynamo-cli-opts
   "DynamoDB-specific CLI options, appended to common opts."
-  [[nil "--dynamo-ports PORTS" "Comma separated DynamoDB ports (per node)."
+  [[nil "--dynamo-ports PORTS" "Comma-separated DynamoDB ports (one per node)."
     :default nil
     :parse-fn (fn [s]
                 (->> (str/split s #",")
@@ -275,15 +323,15 @@
   "Transform parsed CLI options into the map expected by elastickv-dynamodb-test."
   [options]
   (let [dynamo-ports (:dynamo-ports options)
-        options (cli/parse-common-opts options dynamo-ports)
-        node->port (if dynamo-ports
-                     (cli/ports->node-map dynamo-ports (:nodes options))
-                     (zipmap (:nodes options) (repeat (:dynamo-port options))))]
+        options      (cli/parse-common-opts options dynamo-ports)
+        node->port   (if dynamo-ports
+                       (cli/ports->node-map dynamo-ports (:nodes options))
+                       (zipmap (:nodes options) (repeat (:dynamo-port options))))]
     (assoc options
       :dynamo-host (:host options)
-      :node->port node->port
+      :node->port  node->port
       :dynamo-port (:dynamo-port options)
-      :redis-port (:redis-port options))))
+      :redis-port  (:redis-port options))))
 
 (defn -main
   [& args]

--- a/jepsen/src/elastickv/dynamodb_workload.clj
+++ b/jepsen/src/elastickv/dynamodb_workload.clj
@@ -111,9 +111,10 @@
                           {:TableName      table-name
                            :Key            {pk-attr {:S (str k)}}
                            :ConsistentRead true})]
-    ;; cognitect/aws-api: Item is map[String,AttributeValue]; member keys
-    ;; of AttributeValue union (S, N, L …) are Clojure keywords.
-    (when-let [lv (get-in resp [:Item val-attr :L])]
+    ;; cognitect/aws-api uses (json/read-str … :key-fn keyword), so ALL JSON
+    ;; object keys — including DynamoDB attribute names inside Item — are
+    ;; keywordised.  Use (keyword val-attr) to look up :val, not the string "val".
+    (when-let [lv (get-in resp [:Item (keyword val-attr) :L])]
       (mapv #(Long/parseLong (:N %)) lv))))
 
 (defn- list-attr

--- a/jepsen/src/elastickv/dynamodb_workload.clj
+++ b/jepsen/src/elastickv/dynamodb_workload.clj
@@ -116,29 +116,69 @@
     (when-let [lv (get-in resp [:Item val-attr :L])]
       (mapv #(Long/parseLong (:N %)) lv))))
 
+(defn- list-attr
+  "Convert a Clojure vector of longs to a DynamoDB {:L [...]} attribute."
+  [vs]
+  {:L (mapv (fn [n] {:N (str n)}) vs)})
+
 (defn- dynamo-transact-write!
-  "Atomically write all append micro-ops as a single TransactWriteItems call.
-   Multiple appends to the same key within one transaction are merged into one
-   UpdateItem entry so they are applied atomically — real DynamoDB rejects
-   requests with two operations on the same item (ValidationException), and
-   elastickv enforces the same constraint server-side."
-  [ddb writes]
+  "Atomically write all append micro-ops as a single TransactWriteItems call,
+   with optimistic concurrency control based on the pre-read snapshot.
+
+   For each key k that was written:
+   - Adds a ConditionExpression asserting the current DynamoDB value matches
+     snapshot[k] (nil → attribute_not_exists; list → #v = :cv).
+   If any pre-read value has changed since the snapshot was taken, the server
+   returns TransactionCanceledException and the caller returns :fail to Jepsen.
+
+   For each key k that was read but NOT written:
+   - Adds a ConditionCheck entry asserting the same invariant.
+
+   Multiple appends to the same key are merged into one UpdateItem (real
+   DynamoDB rejects two operations on the same item)."
+  [ddb writes snapshot]
   ;; Group values by key, preserving append order within each key.
-  (let [by-key (reduce (fn [acc [_ k v]]
-                         (update acc k (fnil conj []) v))
-                       (array-map)
-                       writes)]
+  (let [by-key     (reduce (fn [acc [_ k v]]
+                             (update acc k (fnil conj []) v))
+                           (array-map)
+                           writes)
+        write-keys (set (keys by-key))
+        ;; Keys that appear in snapshot but are not written — need ConditionCheck.
+        read-only  (remove write-keys (keys snapshot))
+        ;; Build ConditionCheck items for read-only keys.
+        checks
+        (mapv (fn [k]
+                (let [v (get snapshot k)]
+                  {:ConditionCheck
+                   (merge {:TableName table-name
+                           :Key       {pk-attr {:S (str k)}}}
+                          (if (nil? v)
+                            {:ConditionExpression      "attribute_not_exists(#pk)"
+                             :ExpressionAttributeNames {"#pk" pk-attr}}
+                            {:ConditionExpression       "#v = :cv"
+                             :ExpressionAttributeNames  {"#v" val-attr}
+                             :ExpressionAttributeValues {":cv" (list-attr v)}}))}))
+              read-only)
+        ;; Build UpdateItem items for written keys with a snapshot condition.
+        updates
+        (mapv (fn [[k vs]]
+                (let [v (get snapshot k)
+                      ;; Base attribute values shared by all update variants.
+                      attr-vals (merge {":empty" {:L []}
+                                        ":val"   (list-attr vs)}
+                                       (when-not (nil? v) {":cv" (list-attr v)}))]
+                  {:Update
+                   (merge {:TableName                 table-name
+                           :Key                       {pk-attr {:S (str k)}}
+                           :UpdateExpression          "SET #v = list_append(if_not_exists(#v, :empty), :val)"
+                           :ExpressionAttributeNames  {"#v" val-attr}
+                           :ExpressionAttributeValues attr-vals}
+                          (if (nil? v)
+                            {:ConditionExpression "attribute_not_exists(#v)"}
+                            {:ConditionExpression "#v = :cv"}))}))
+              by-key)]
     (ddb-invoke! ddb :TransactWriteItems
-                 {:TransactItems
-                  (mapv (fn [[k vs]]
-                          {:Update
-                           {:TableName                 table-name
-                            :Key                       {pk-attr {:S (str k)}}
-                            :UpdateExpression          "SET #v = list_append(if_not_exists(#v, :empty), :val)"
-                            :ExpressionAttributeNames  {"#v" val-attr}
-                            :ExpressionAttributeValues {":empty" {:L []}
-                                                        ":val"   {:L (mapv (fn [v] {:N (str v)}) vs)}}}})
-                        by-key)})))
+                 {:TransactItems (into checks updates)})))
 
 ;; ---------------------------------------------------------------------------
 ;; Jepsen client
@@ -196,7 +236,7 @@
                                                     (into (or base []) pending))])))
                                mops)
                   writes (filterv (fn [[f _ _]] (= f :append)) mops)]
-              (when (seq writes) (dynamo-transact-write! ddb writes))
+              (when (seq writes) (dynamo-transact-write! ddb writes snapshot))
               (assoc op :type :ok :value value')))))
 
       (catch clojure.lang.ExceptionInfo e
@@ -210,11 +250,18 @@
                     :cognitect.anomalies/unavailable} category))
             (assoc op :type :info :error :network-error)
 
-            ;; Retryable DynamoDB server-side errors
+            ;; Retryable DynamoDB server-side errors.
             (contains? #{"ConditionalCheckFailedException"
-                         "InternalServerError"
-                         "TransactionCanceledException"} err-type)
+                         "InternalServerError"} err-type)
             (assoc op :type :info :error (str err-type))
+
+            ;; OCC snapshot conflict: transaction definitely was not committed.
+            ;; We added ConditionExpressions to TransactWriteItems; if a
+            ;; concurrent write changed a pre-read key, the server returns
+            ;; TransactionCanceledException.  The operation is a definite
+            ;; abort — return :fail so Jepsen excludes it from the history.
+            (= "TransactionCanceledException" err-type)
+            (assoc op :type :fail :error (str err-type))
 
             ;; Definite API-level failures
             (= "ValidationException" err-type)

--- a/jepsen/test/elastickv/dynamodb_workload_test.clj
+++ b/jepsen/test/elastickv/dynamodb_workload_test.clj
@@ -16,10 +16,12 @@
                     :dynamo-port 9000})]
     (is (= 10 (:concurrency test-map)))))
 
-(deftest host-override-uses-provided-host
+(deftest host-override-creates-client
+  ;; Verify that open! produces a DynamoDBClient with a live cognitect/aws-api
+  ;; client object (not nil) when a host/port override is supplied.
   (let [test-map (workload/elastickv-dynamodb-test
                    {:dynamo-host "127.0.0.1"
-                    :node->port {"n1" 8000 "n2" 8001}})
+                    :node->port  {"n1" 8000 "n2" 8001}})
         c        (:client test-map)
         opened   (client/open! c test-map "n1")]
-    (is (re-find #"http://127\.0\.0\.1:8000" (:url opened)))))
+    (is (some? (:ddb opened)))))

--- a/kv/leader_routed_store.go
+++ b/kv/leader_routed_store.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"time"
 
 	pb "github.com/bootjp/elastickv/proto"
 	"github.com/bootjp/elastickv/store"
@@ -251,6 +252,39 @@ func (s *LeaderRoutedStore) LastCommitTS() uint64 {
 		return 0
 	}
 	return s.local.LastCommitTS()
+}
+
+const globalLastCommitTSTimeout = 200 * time.Millisecond
+
+// GlobalLastCommitTS returns the most recently committed HLC timestamp from
+// the authoritative leader.  On the leader this is the local LastCommitTS.
+// On a follower the method issues a lightweight RPC (RawLatestCommitTS with
+// an empty key) so callers obtain a non-stale snapshot — critical for
+// ConsistentRead semantics where followers must not serve reads at a stale
+// local watermark.  Falls back to the local LastCommitTS on any error.
+func (s *LeaderRoutedStore) GlobalLastCommitTS(ctx context.Context) uint64 {
+	if s == nil || s.local == nil {
+		return 0
+	}
+	if s.coordinator == nil || s.coordinator.IsLeader() {
+		return s.local.LastCommitTS()
+	}
+	addr := s.coordinator.RaftLeader()
+	if addr == "" {
+		return s.local.LastCommitTS()
+	}
+	conn, err := s.connCache.ConnFor(addr)
+	if err != nil {
+		return s.local.LastCommitTS()
+	}
+	proxyCtx, cancel := context.WithTimeout(ctx, globalLastCommitTSTimeout)
+	defer cancel()
+	cli := pb.NewRawKVClient(conn)
+	resp, err := cli.RawLatestCommitTS(proxyCtx, &pb.RawLatestCommitTSRequest{})
+	if err != nil || resp.GetTs() == 0 {
+		return s.local.LastCommitTS()
+	}
+	return resp.GetTs()
 }
 
 func (s *LeaderRoutedStore) Compact(ctx context.Context, minTS uint64) error {

--- a/kv/leader_routed_store_test.go
+++ b/kv/leader_routed_store_test.go
@@ -261,3 +261,55 @@ func TestLeaderRoutedStore_ReturnsLeaderNotFoundWhenNoLeaderAddr(t *testing.T) {
 	_, _, err = s.LatestCommitTS(ctx, []byte("k"))
 	require.ErrorIs(t, err, ErrLeaderNotFound)
 }
+
+func TestLeaderRoutedStore_GlobalLastCommitTS_OnLeader(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	local := store.NewMVCCStore()
+	require.NoError(t, local.PutAt(ctx, []byte("k"), []byte("v"), 42, 0))
+
+	coord := &stubLeaderCoordinator{isLeader: true, clock: NewHLC()}
+	s := NewLeaderRoutedStore(local, coord)
+	t.Cleanup(func() { _ = s.Close() })
+
+	ts := s.GlobalLastCommitTS(ctx)
+	require.Equal(t, uint64(42), ts)
+}
+
+func TestLeaderRoutedStore_GlobalLastCommitTS_ProxiesToLeader(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeRawKVServer{
+		latestResp: &pb.RawLatestCommitTSResponse{Ts: 99, Exists: true},
+	}
+	addr, stop := startRawKVServer(t, fake)
+	t.Cleanup(stop)
+
+	coord := &stubLeaderCoordinator{isLeader: false, leader: addr, clock: NewHLC()}
+	s := NewLeaderRoutedStore(store.NewMVCCStore(), coord)
+	t.Cleanup(func() { _ = s.Close() })
+
+	ts := s.GlobalLastCommitTS(context.Background())
+	require.Equal(t, uint64(99), ts)
+
+	fake.mu.Lock()
+	require.Equal(t, 1, fake.latestCalls)
+	fake.mu.Unlock()
+}
+
+func TestLeaderRoutedStore_GlobalLastCommitTS_FallsBackWhenNoLeader(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	local := store.NewMVCCStore()
+	require.NoError(t, local.PutAt(ctx, []byte("k"), []byte("v"), 7, 0))
+
+	coord := &stubLeaderCoordinator{isLeader: false, leader: "", clock: NewHLC()}
+	s := NewLeaderRoutedStore(local, coord)
+	t.Cleanup(func() { _ = s.Close() })
+
+	// No leader address available → falls back to local LastCommitTS.
+	ts := s.GlobalLastCommitTS(ctx)
+	require.Equal(t, uint64(7), ts)
+}

--- a/main.go
+++ b/main.go
@@ -105,6 +105,7 @@ var (
 	shardRanges          = flag.String("shardRanges", "", "Comma-separated shard ranges (start:end=groupID,...)")
 	raftRedisMap         = flag.String("raftRedisMap", "", "Map of Raft address to Redis address (raftAddr=redisAddr,...)")
 	raftS3Map            = flag.String("raftS3Map", "", "Map of Raft address to S3 address (raftAddr=s3Addr,...)")
+	raftDynamoMap        = flag.String("raftDynamoMap", "", "Map of Raft address to DynamoDB address (raftAddr=dynamoAddr,...)")
 )
 
 func main() {
@@ -200,6 +201,7 @@ func run() error {
 		pubsubRelay:     adapter.NewRedisPubSubRelay(),
 		readTracker:     readTracker,
 		dynamoAddress:   *dynamoAddr,
+		leaderDynamo:    cfg.leaderDynamo,
 		s3Address:       *s3Addr,
 		leaderS3:        cfg.leaderS3,
 		s3Region:        *s3Region,
@@ -231,7 +233,7 @@ func resolveRuntimeInputs() (runtimeConfig, raftEngineType, []raft.Server, bool,
 		return runtimeConfig{}, "", nil, false, err
 	}
 
-	cfg, err := parseRuntimeConfig(*myAddr, *redisAddr, *s3Addr, *raftGroups, *shardRanges, *raftRedisMap, *raftS3Map)
+	cfg, err := parseRuntimeConfig(*myAddr, *redisAddr, *s3Addr, *dynamoAddr, *raftGroups, *shardRanges, *raftRedisMap, *raftS3Map, *raftDynamoMap)
 	if err != nil {
 		return runtimeConfig{}, "", nil, false, err
 	}
@@ -250,10 +252,11 @@ type runtimeConfig struct {
 	engine       *distribution.Engine
 	leaderRedis  map[raft.ServerAddress]string
 	leaderS3     map[raft.ServerAddress]string
+	leaderDynamo map[raft.ServerAddress]string
 	multi        bool
 }
 
-func parseRuntimeConfig(myAddr, redisAddr, s3Addr, raftGroups, shardRanges, raftRedisMap, raftS3Map string) (runtimeConfig, error) {
+func parseRuntimeConfig(myAddr, redisAddr, s3Addr, dynamoAddr, raftGroups, shardRanges, raftRedisMap, raftS3Map, raftDynamoMap string) (runtimeConfig, error) {
 	groups, err := parseRaftGroups(raftGroups, myAddr)
 	if err != nil {
 		return runtimeConfig{}, errors.Wrapf(err, "failed to parse raft groups")
@@ -276,6 +279,10 @@ func parseRuntimeConfig(myAddr, redisAddr, s3Addr, raftGroups, shardRanges, raft
 	if err != nil {
 		return runtimeConfig{}, errors.Wrapf(err, "failed to parse raft s3 map")
 	}
+	leaderDynamo, err := buildLeaderDynamo(groups, dynamoAddr, raftDynamoMap)
+	if err != nil {
+		return runtimeConfig{}, errors.Wrapf(err, "failed to parse raft dynamo map")
+	}
 
 	return runtimeConfig{
 		groups:       groups,
@@ -283,6 +290,7 @@ func parseRuntimeConfig(myAddr, redisAddr, s3Addr, raftGroups, shardRanges, raft
 		engine:       engine,
 		leaderRedis:  leaderRedis,
 		leaderS3:     leaderS3,
+		leaderDynamo: leaderDynamo,
 		multi:        len(groups) > 1,
 	}, nil
 }
@@ -301,6 +309,10 @@ func buildLeaderRedis(groups []groupSpec, redisAddr string, raftRedisMap string)
 
 func buildLeaderS3(groups []groupSpec, s3Addr string, raftS3Map string) (map[raft.ServerAddress]string, error) {
 	return buildLeaderAddrMap(groups, s3Addr, raftS3Map, parseRaftS3Map)
+}
+
+func buildLeaderDynamo(groups []groupSpec, dynamoAddr string, raftDynamoMap string) (map[raft.ServerAddress]string, error) {
+	return buildLeaderAddrMap(groups, dynamoAddr, raftDynamoMap, parseRaftDynamoMap)
 }
 
 func buildLeaderAddrMap(
@@ -518,7 +530,7 @@ func startRedisServer(ctx context.Context, lc *net.ListenConfig, eg *errgroup.Gr
 	return nil
 }
 
-func startDynamoDBServer(ctx context.Context, lc *net.ListenConfig, eg *errgroup.Group, dynamoAddr string, shardStore *kv.ShardStore, coordinate kv.Coordinator, metricsRegistry *monitoring.Registry, readTracker *kv.ActiveTimestampTracker) error {
+func startDynamoDBServer(ctx context.Context, lc *net.ListenConfig, eg *errgroup.Group, dynamoAddr string, shardStore *kv.ShardStore, coordinate kv.Coordinator, leaderDynamo map[raft.ServerAddress]string, metricsRegistry *monitoring.Registry, readTracker *kv.ActiveTimestampTracker) error {
 	dynamoL, err := lc.Listen(ctx, "tcp", dynamoAddr)
 	if err != nil {
 		return errors.Wrapf(err, "failed to listen on %s", dynamoAddr)
@@ -529,6 +541,7 @@ func startDynamoDBServer(ctx context.Context, lc *net.ListenConfig, eg *errgroup
 		coordinate,
 		adapter.WithDynamoDBActiveTimestampTracker(readTracker),
 		adapter.WithDynamoDBRequestObserver(metricsRegistry.DynamoDBObserver()),
+		adapter.WithDynamoDBLeaderMap(leaderDynamo),
 	)
 	eg.Go(func() error {
 		defer dynamoServer.Stop()
@@ -670,6 +683,7 @@ type runtimeServerRunner struct {
 	pubsubRelay     *adapter.RedisPubSubRelay
 	readTracker     *kv.ActiveTimestampTracker
 	dynamoAddress   string
+	leaderDynamo    map[raft.ServerAddress]string
 	s3Address       string
 	leaderS3        map[raft.ServerAddress]string
 	s3Region        string
@@ -701,7 +715,7 @@ func (r runtimeServerRunner) start() error {
 	); err != nil {
 		return waitErrgroupAfterStartupFailure(r.cancel, r.eg, err)
 	}
-	if err := startDynamoDBServer(r.ctx, r.lc, r.eg, r.dynamoAddress, r.shardStore, r.coordinate, r.metricsRegistry, r.readTracker); err != nil {
+	if err := startDynamoDBServer(r.ctx, r.lc, r.eg, r.dynamoAddress, r.shardStore, r.coordinate, r.leaderDynamo, r.metricsRegistry, r.readTracker); err != nil {
 		return waitErrgroupAfterStartupFailure(r.cancel, r.eg, err)
 	}
 	if err := startS3Server(r.ctx, r.lc, r.eg, r.s3Address, r.shardStore, r.coordinate, r.leaderS3, r.s3Region, r.s3CredsFile, r.s3PathStyleOnly, r.readTracker); err != nil {

--- a/main_bootstrap_e2e_test.go
+++ b/main_bootstrap_e2e_test.go
@@ -330,7 +330,7 @@ func startBootstrapE2ENode(
 	bootstrapMembers string,
 	engineType raftEngineType,
 ) (*bootstrapE2ENode, error) {
-	cfg, err := parseRuntimeConfig(ep.raftAddr, ep.redisAddr, "", "", "", "", "")
+	cfg, err := parseRuntimeConfig(ep.raftAddr, ep.redisAddr, "", "", "", "", "", "", "")
 	if err != nil {
 		return nil, err
 	}

--- a/scripts/run-jepsen-local.sh
+++ b/scripts/run-jepsen-local.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Run the DynamoDB Jepsen workload locally against a 3-node elastickv cluster.
+# Usage:
+#   ./scripts/run-jepsen-local.sh               # build + start cluster + test
+#   ./scripts/run-jepsen-local.sh --no-rebuild   # skip go build (reuse binary)
+#   ./scripts/run-jepsen-local.sh --no-cluster   # skip cluster start (reuse running one)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BINARY=/tmp/elastickv4-binary
+DATA_DIR=/tmp/elastickv-test-run
+PID_FILE=/tmp/elastickv-test-run.pid
+
+BOOTSTRAP_MEMBERS="n1=127.0.0.1:50051,n2=127.0.0.1:50052,n3=127.0.0.1:50053"
+RAFT_REDIS_MAP="127.0.0.1:50051=127.0.0.1:63791,127.0.0.1:50052=127.0.0.1:63792,127.0.0.1:50053=127.0.0.1:63793"
+RAFT_S3_MAP="127.0.0.1:50051=127.0.0.1:63901,127.0.0.1:50052=127.0.0.1:63902,127.0.0.1:50053=127.0.0.1:63903"
+RAFT_DYNAMO_MAP="127.0.0.1:50051=127.0.0.1:63801,127.0.0.1:50052=127.0.0.1:63802,127.0.0.1:50053=127.0.0.1:63803"
+
+NO_REBUILD=false
+NO_CLUSTER=false
+for arg in "$@"; do
+  case "$arg" in
+    --no-rebuild) NO_REBUILD=true ;;
+    --no-cluster) NO_CLUSTER=true ;;
+  esac
+done
+
+# ---- stop any previously managed cluster ----
+stop_cluster() {
+  if [ -f "$PID_FILE" ]; then
+    echo "[cluster] stopping previous cluster..."
+    while IFS= read -r pid; do
+      kill "$pid" 2>/dev/null || true
+    done < "$PID_FILE"
+    rm -f "$PID_FILE"
+  fi
+}
+
+# ---- build ----
+if ! $NO_REBUILD; then
+  echo "[build] compiling elastickv..."
+  cd "$REPO_ROOT"
+  go build -o "$BINARY" .
+  echo "[build] done -> $BINARY"
+fi
+
+# ---- start cluster ----
+if ! $NO_CLUSTER; then
+  stop_cluster
+  rm -rf "$DATA_DIR"
+  mkdir -p "$DATA_DIR"
+  : > "$PID_FILE"
+
+  echo "[cluster] starting 3-node cluster..."
+  for node in 1 2 3; do
+    nohup "$BINARY" \
+      --address      "127.0.0.1:5005${node}" \
+      --redisAddress "127.0.0.1:6379${node}" \
+      --dynamoAddress "127.0.0.1:6380${node}" \
+      --s3Address    "127.0.0.1:6390${node}" \
+      --metricsAddress "" \
+      --pprofAddress "" \
+      --raftId       "n${node}" \
+      --raftDataDir  "${DATA_DIR}/n${node}" \
+      --raftBootstrapMembers "$BOOTSTRAP_MEMBERS" \
+      --raftRedisMap "$RAFT_REDIS_MAP" \
+      --raftS3Map    "$RAFT_S3_MAP" \
+      --raftDynamoMap "$RAFT_DYNAMO_MAP" \
+      > "${DATA_DIR}/n${node}.log" 2>&1 &
+    echo $! >> "$PID_FILE"
+  done
+
+  echo "[cluster] waiting for all ports (redis 63791-3, dynamo 63801-3, s3 63901-3)..."
+  for i in $(seq 1 90); do
+    if nc -z 127.0.0.1 63791 && nc -z 127.0.0.1 63792 && nc -z 127.0.0.1 63793 \
+      && nc -z 127.0.0.1 63801 && nc -z 127.0.0.1 63802 && nc -z 127.0.0.1 63803 \
+      && nc -z 127.0.0.1 63901 && nc -z 127.0.0.1 63902 && nc -z 127.0.0.1 63903; then
+      echo "[cluster] up after ${i}s"
+      break
+    fi
+    sleep 1
+    if [ "$i" -eq 90 ]; then
+      echo "[cluster] FAILED to start - dumping logs:"
+      for n in 1 2 3; do tail -n 50 "${DATA_DIR}/n${n}.log" || true; done
+      exit 1
+    fi
+  done
+fi
+
+# ---- run Jepsen DynamoDB workload ----
+echo "[jepsen] running DynamoDB workload..."
+cd "$REPO_ROOT/jepsen"
+set +e
+lein run -m elastickv.dynamodb-workload \
+  --local \
+  --time-limit 30 \
+  --rate 5 \
+  --concurrency 5 \
+  --dynamo-ports 63801,63802,63803 \
+  --host 127.0.0.1
+EXIT_CODE=$?
+set -e
+
+if [ $EXIT_CODE -eq 0 ]; then
+  echo "[jepsen] PASSED"
+else
+  echo "[jepsen] FAILED (exit $EXIT_CODE)"
+fi
+exit $EXIT_CODE

--- a/shard_config.go
+++ b/shard_config.go
@@ -31,6 +31,7 @@ var (
 	ErrInvalidShardRangesEntry          = errors.New("invalid shardRanges entry")
 	ErrInvalidRaftRedisMapEntry         = errors.New("invalid raftRedisMap entry")
 	ErrInvalidRaftS3MapEntry            = errors.New("invalid raftS3Map entry")
+	ErrInvalidRaftDynamoMapEntry        = errors.New("invalid raftDynamoMap entry")
 	ErrInvalidRaftBootstrapMembersEntry = errors.New("invalid raftBootstrapMembers entry")
 )
 
@@ -121,6 +122,10 @@ func parseRaftRedisMap(raw string) (map[raft.ServerAddress]string, error) {
 
 func parseRaftS3Map(raw string) (map[raft.ServerAddress]string, error) {
 	return parseRaftAddressMap(raw, ErrInvalidRaftS3MapEntry)
+}
+
+func parseRaftDynamoMap(raw string) (map[raft.ServerAddress]string, error) {
+	return parseRaftAddressMap(raw, ErrInvalidRaftDynamoMapEntry)
 }
 
 func parseRaftAddressMap(raw string, invalidEntry error) (map[raft.ServerAddress]string, error) {


### PR DESCRIPTION
clock.Next() can be ahead of store.LastCommitTS() because concurrent dispatchTxn calls advance the HLC before their Raft entry is applied to Pebble. When txnStartTS returned clock.Next() = T, a concurrent RPUSH that had obtained commitTS = T-1 could still be in the Raft pipeline. The transaction would read stale list metadata, pick the same sequence number, and overwrite the concurrent value — a lost write. The FSM conflict check (latestTS > startTS) silently passed because T-1 < T.

Fix: return maxTS (= store.LastCommitTS()) as the startTS directly. store.LastCommitTS() is only advanced after the Pebble batch commit, so every version at <= maxTS is guaranteed visible. Any concurrent write at
> maxTS triggers WriteConflict and a retry via retryRedisWrite.
The Observe(maxTS) call is preserved so dispatchTxn clock.Next() still produces a valid commitTS > maxTS.

This closes the root cause of the Jepsen G1c / lost-write anomalies observed in list-append workloads under concurrent MULTI/EXEC and direct RPUSH operations.