### PR TITLE
feat: trigger urgent single-key compaction on ErrDeltaScanTruncated

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -2703,7 +2703,8 @@ func (r *RedisServer) buildListPopElems(ctx context.Context, key []byte, meta st
 		claimEnd = meta.Tail
 	}
 	// Capacity: n claim keys + n Del(item) for found items + 1 for the delta key appended by caller.
-	elems := make([]*kv.Elem[kv.OP], 0, n+int64(len(kvps))+listPopDeltaOverhead)
+	// n is bounded by maxWideColumnItems (100_000) so the int conversion is safe.
+	elems := make([]*kv.Elem[kv.OP], 0, int(n)+len(kvps)+listPopDeltaOverhead)
 	for seq := claimStart; seq < claimEnd; seq++ {
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: store.ListClaimKey(key, seq), Value: []byte{}})
 	}

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -271,6 +271,11 @@ type RedisServer struct {
 	leaderClientsMu sync.RWMutex
 	leaderClients   map[string]*redis.Client
 
+	// compactor is the background DeltaCompactor for this node. When set,
+	// urgent compaction is triggered on ErrDeltaScanTruncated to unblock
+	// reads on hot keys faster than the regular compaction interval.
+	compactor *DeltaCompactor
+
 	route map[string]func(conn redcon.Conn, cmd redcon.Command)
 }
 
@@ -279,6 +284,14 @@ type RedisServerOption func(*RedisServer)
 func WithRedisActiveTimestampTracker(tracker *kv.ActiveTimestampTracker) RedisServerOption {
 	return func(r *RedisServer) {
 		r.readTracker = tracker
+	}
+}
+
+// WithRedisCompactor wires a DeltaCompactor to the RedisServer so that urgent
+// single-key compaction can be triggered when ErrDeltaScanTruncated is hit.
+func WithRedisCompactor(c *DeltaCompactor) RedisServerOption {
+	return func(r *RedisServer) {
+		r.compactor = c
 	}
 }
 
@@ -465,6 +478,14 @@ func (r *RedisServer) pinReadTS(ts uint64) *kv.ActiveTimestampToken {
 		return nil
 	}
 	return r.readTracker.Pin(ts)
+}
+
+// triggerUrgentCompaction signals the DeltaCompactor to immediately compact
+// the given key, bypassing the regular interval. No-op when no compactor is wired.
+func (r *RedisServer) triggerUrgentCompaction(typeName string, key []byte) {
+	if r.compactor != nil {
+		r.compactor.TriggerUrgentCompaction(typeName, key)
+	}
 }
 
 func (r *RedisServer) dispatchCommand(conn redcon.Conn, name string, handler func(redcon.Conn, redcon.Command), cmd redcon.Command, start time.Time) {

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -742,6 +742,9 @@ func (r *RedisServer) resolveListMeta(ctx context.Context, key []byte, readTS ui
 		return d.LenDelta, errors.WithStack(unmarshalErr)
 	})
 	if err != nil {
+		if errors.Is(err, ErrDeltaScanTruncated) {
+			r.triggerUrgentCompaction("list", key)
+		}
 		return store.ListMeta{}, false, err
 	}
 	baseMeta.Len += lenSum
@@ -797,7 +800,7 @@ func (r *RedisServer) resolveCollectionLen(
 
 // resolveHashMeta aggregates the base hash metadata with all uncompacted Delta keys.
 func (r *RedisServer) resolveHashMeta(ctx context.Context, key []byte, readTS uint64) (int64, bool, error) {
-	return r.resolveCollectionLen(
+	n, exists, err := r.resolveCollectionLen(
 		ctx, key, readTS,
 		store.HashMetaKey(key),
 		store.HashMetaDeltaScanPrefix(key),
@@ -811,11 +814,15 @@ func (r *RedisServer) resolveHashMeta(ctx context.Context, key []byte, readTS ui
 		},
 		"resolveHashMeta: clamping negative Len to 0",
 	)
+	if errors.Is(err, ErrDeltaScanTruncated) {
+		r.triggerUrgentCompaction("hash", key)
+	}
+	return n, exists, err
 }
 
 // resolveSetMeta aggregates the base set metadata with all uncompacted Delta keys.
 func (r *RedisServer) resolveSetMeta(ctx context.Context, key []byte, readTS uint64) (int64, bool, error) {
-	return r.resolveCollectionLen(
+	n, exists, err := r.resolveCollectionLen(
 		ctx, key, readTS,
 		store.SetMetaKey(key),
 		store.SetMetaDeltaScanPrefix(key),
@@ -829,11 +836,15 @@ func (r *RedisServer) resolveSetMeta(ctx context.Context, key []byte, readTS uin
 		},
 		"resolveSetMeta: clamping negative Len to 0",
 	)
+	if errors.Is(err, ErrDeltaScanTruncated) {
+		r.triggerUrgentCompaction("set", key)
+	}
+	return n, exists, err
 }
 
 // resolveZSetMeta aggregates the base sorted set metadata with all uncompacted Delta keys.
 func (r *RedisServer) resolveZSetMeta(ctx context.Context, key []byte, readTS uint64) (int64, bool, error) {
-	return r.resolveCollectionLen(
+	n, exists, err := r.resolveCollectionLen(
 		ctx, key, readTS,
 		store.ZSetMetaKey(key),
 		store.ZSetMetaDeltaScanPrefix(key),
@@ -847,4 +858,8 @@ func (r *RedisServer) resolveZSetMeta(ctx context.Context, key []byte, readTS ui
 		},
 		"resolveZSetMeta: clamping negative Len to 0",
 	)
+	if errors.Is(err, ErrDeltaScanTruncated) {
+		r.triggerUrgentCompaction("zset", key)
+	}
+	return n, exists, err
 }

--- a/adapter/redis_delta_compactor.go
+++ b/adapter/redis_delta_compactor.go
@@ -257,14 +257,19 @@ func (c *DeltaCompactor) compactUrgentKeyBatch(ctx context.Context, req urgentCo
 	return len(kvs), len(kvs) <= store.MaxDeltaScanLimit
 }
 
-// SyncOnce runs one compaction pass. Keys for shards this node does not lead
-// are skipped individually inside buildBatchElems via IsLeaderForKey, so the
-// scan proceeds on all nodes but only the shard leader dispatches each batch.
+// SyncOnce runs one compaction pass. The IsLeader() guard avoids the
+// full-prefix delta scan on followers, which would proxy cross-node on
+// ShardStore backends. For sharded deployments where this node is the
+// leader for a non-default shard group, the regular tick is skipped; those
+// keys are still handled by the urgent compaction path (compactUrgentKey)
+// which uses IsLeaderForKey for per-key routing. buildBatchElems adds an
+// additional per-key IsLeaderForKey filter so a default-group leader never
+// dispatches mutations for shards it does not own.
 // Each collection-type handler runs in its own goroutine so that a slow
 // handler (e.g. one with many list deltas) does not delay Hash/Set/ZSet
 // compaction. All goroutines share the same per-tick timeout context.
 func (c *DeltaCompactor) SyncOnce(ctx context.Context) error {
-	if c.coord == nil {
+	if c.coord == nil || !c.coord.IsLeader() {
 		return nil
 	}
 	readTS := snapshotTS(c.coord.Clock(), c.st)

--- a/adapter/redis_delta_compactor.go
+++ b/adapter/redis_delta_compactor.go
@@ -192,7 +192,9 @@ func (c *DeltaCompactor) compactUrgentKey(ctx context.Context, req urgentCompact
 				slog.Any("panic", rec))
 		}
 	}()
-	if !c.coord.IsLeader() {
+	// Use per-key leadership so that in sharded deployments this node compacts
+	// keys for the shards it leads, not just those of the default Raft group.
+	if !c.coord.IsLeaderForKey(req.userKey) {
 		return
 	}
 	h := c.handlerByTypeName(req.typeName)
@@ -255,12 +257,14 @@ func (c *DeltaCompactor) compactUrgentKeyBatch(ctx context.Context, req urgentCo
 	return len(kvs), len(kvs) <= store.MaxDeltaScanLimit
 }
 
-// SyncOnce runs one compaction pass. Non-leaders return immediately.
+// SyncOnce runs one compaction pass. Keys for shards this node does not lead
+// are skipped individually inside buildBatchElems via IsLeaderForKey, so the
+// scan proceeds on all nodes but only the shard leader dispatches each batch.
 // Each collection-type handler runs in its own goroutine so that a slow
 // handler (e.g. one with many list deltas) does not delay Hash/Set/ZSet
 // compaction. All goroutines share the same per-tick timeout context.
 func (c *DeltaCompactor) SyncOnce(ctx context.Context) error {
-	if c.coord == nil || !c.coord.IsLeader() {
+	if c.coord == nil {
 		return nil
 	}
 	readTS := snapshotTS(c.coord.Clock(), c.st)
@@ -456,6 +460,12 @@ func (c *DeltaCompactor) buildBatchElems(ctx context.Context, h collectionDeltaH
 			continue
 		}
 		userKey := []byte(ukStr)
+		// In sharded deployments IsLeaderForKey returns false for keys whose
+		// shard this node does not lead. Skip those to avoid dispatching a
+		// transaction that the responsible leader will reject.
+		if !c.coord.IsLeaderForKey(userKey) {
+			continue
+		}
 		elems, buildErr := h.buildElems(ctx, userKey, deltaKVs, readTS)
 		if buildErr != nil {
 			c.logger.WarnContext(ctx, "delta compactor: failed to build elems",

--- a/adapter/redis_delta_compactor.go
+++ b/adapter/redis_delta_compactor.go
@@ -180,7 +180,16 @@ func (c *DeltaCompactor) handlerByTypeName(typeName string) *collectionDeltaHand
 // compactUrgentKey performs an immediate targeted compaction for a single user key
 // whose delta count exceeded MaxDeltaScanLimit. It scans all delta keys for the
 // key, builds compaction elems, and dispatches them as an OCC transaction.
+// A recover guard prevents a panic inside a handler from crashing the Run loop.
 func (c *DeltaCompactor) compactUrgentKey(ctx context.Context, req urgentCompactionRequest) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			c.logger.Error("DeltaCompactor: panic in urgent compaction",
+				slog.String("type", req.typeName),
+				slog.String("key", string(req.userKey)),
+				slog.Any("panic", rec))
+		}
+	}()
 	if !c.coord.IsLeader() {
 		return
 	}

--- a/adapter/redis_delta_compactor.go
+++ b/adapter/redis_delta_compactor.go
@@ -25,7 +25,17 @@ const (
 	// cursorNextByte is appended to the last-scanned key to produce an
 	// exclusive lower bound that skips past it on the next tick.
 	cursorNextByte = byte(0x00)
+
+	// urgentCompactionChanSize is the buffer size for the urgent compaction
+	// channel. Excess signals are dropped (the regular tick will catch them).
+	urgentCompactionChanSize = 64
 )
+
+// urgentCompactionRequest is a request to immediately compact a single key.
+type urgentCompactionRequest struct {
+	typeName string
+	userKey  []byte
+}
 
 // DeltaCompactor folds accumulated delta keys into their corresponding base
 // metadata keys for all wide-column collection types (List, Hash, Set, ZSet).
@@ -50,6 +60,12 @@ type DeltaCompactor struct {
 	// called from a test while Run is active).
 	cursorMu sync.Mutex
 	cursors  map[string][]byte
+
+	// urgentCh receives requests to immediately compact a single key whose
+	// delta count has exceeded MaxDeltaScanLimit, making reads fail. The Run
+	// loop drains this channel between regular ticks so hot keys are unblocked
+	// quickly without waiting for the next scheduled pass.
+	urgentCh chan urgentCompactionRequest
 }
 
 // DeltaCompactorOption configures a DeltaCompactor.
@@ -103,6 +119,7 @@ func NewDeltaCompactor(st store.MVCCStore, coord kv.Coordinator, opts ...DeltaCo
 		interval: defaultDeltaCompactorScanInterval,
 		timeout:  defaultDeltaCompactorTimeout,
 		cursors:  make(map[string][]byte),
+		urgentCh: make(chan urgentCompactionRequest, urgentCompactionChanSize),
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -123,6 +140,8 @@ func (c *DeltaCompactor) Run(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return nil
+		case req := <-c.urgentCh:
+			c.compactUrgentKey(ctx, req)
 		case <-timer.C:
 			if err := c.SyncOnce(ctx); err != nil && !errors.Is(err, context.Canceled) {
 				c.logger.WarnContext(ctx, "delta compactor pass failed", "error", err)
@@ -130,6 +149,76 @@ func (c *DeltaCompactor) Run(ctx context.Context) error {
 			timer.Reset(c.interval)
 		}
 	}
+}
+
+// TriggerUrgentCompaction queues an immediate single-key compaction for a key
+// whose delta count has exceeded MaxDeltaScanLimit. The request is dropped
+// silently when the channel is full (the regular tick will catch it).
+func (c *DeltaCompactor) TriggerUrgentCompaction(typeName string, userKey []byte) {
+	if c == nil {
+		return
+	}
+	req := urgentCompactionRequest{typeName: typeName, userKey: bytes.Clone(userKey)}
+	select {
+	case c.urgentCh <- req:
+	default: // channel full; the regular tick will catch it
+	}
+}
+
+// handlerByTypeName returns the collectionDeltaHandler for the given typeName,
+// or nil if not found.
+func (c *DeltaCompactor) handlerByTypeName(typeName string) *collectionDeltaHandler {
+	for _, h := range c.allHandlers() {
+		if h.typeName == typeName {
+			h := h
+			return &h
+		}
+	}
+	return nil
+}
+
+// compactUrgentKey performs an immediate targeted compaction for a single user key
+// whose delta count exceeded MaxDeltaScanLimit. It scans all delta keys for the
+// key, builds compaction elems, and dispatches them as an OCC transaction.
+func (c *DeltaCompactor) compactUrgentKey(ctx context.Context, req urgentCompactionRequest) {
+	if !c.coord.IsLeader() {
+		return
+	}
+	h := c.handlerByTypeName(req.typeName)
+	if h == nil {
+		return
+	}
+	readTS := snapshotTS(c.coord.Clock(), c.st)
+	tickCtx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	// Scan all delta keys for this specific user key.
+	prefix := h.deltaKeyPrefixFn(req.userKey)
+	end := store.PrefixScanEnd(prefix)
+	// Scan one extra beyond MaxDeltaScanLimit to collect all accumulated deltas.
+	kvs, err := c.st.ScanAt(tickCtx, prefix, end, store.MaxDeltaScanLimit+1, readTS)
+	if err != nil {
+		c.logger.WarnContext(tickCtx, "delta compactor urgent: scan failed",
+			"type", req.typeName, "key", string(req.userKey), "error", err)
+		return
+	}
+	if len(kvs) == 0 {
+		return
+	}
+
+	elems, err := h.buildElems(tickCtx, req.userKey, kvs, readTS)
+	if err != nil {
+		c.logger.WarnContext(tickCtx, "delta compactor urgent: buildElems failed",
+			"type", req.typeName, "key", string(req.userKey), "error", err)
+		return
+	}
+	if err := c.dispatchCompaction(tickCtx, readTS, elems); err != nil {
+		c.logger.WarnContext(tickCtx, "delta compactor urgent: dispatch failed",
+			"type", req.typeName, "key", string(req.userKey), "error", err)
+		return
+	}
+	c.logger.InfoContext(tickCtx, "delta compactor urgent: compacted key",
+		"type", req.typeName, "key", string(req.userKey), "delta_count", len(kvs))
 }
 
 // SyncOnce runs one compaction pass. Non-leaders return immediately.
@@ -178,7 +267,10 @@ type collectionDeltaHandler struct {
 	typeName       string
 	prefix         []byte
 	extractUserKey func(key []byte) []byte
-	buildElems     func(ctx context.Context, userKey []byte, deltaKVs []*store.KVPair, readTS uint64) ([]*kv.Elem[kv.OP], error)
+	// deltaKeyPrefixFn returns the prefix that covers all delta keys for a single
+	// user key. Used by compactUrgentKey to perform a targeted single-key scan.
+	deltaKeyPrefixFn func(userKey []byte) []byte
+	buildElems       func(ctx context.Context, userKey []byte, deltaKVs []*store.KVPair, readTS uint64) ([]*kv.Elem[kv.OP], error)
 }
 
 // allHandlers returns the compaction handlers for all wide-column collection types.
@@ -389,10 +481,11 @@ func sumListMetaDeltas(deltaKVs []*store.KVPair) (headDelta, lenDelta int64, err
 
 func (c *DeltaCompactor) listHandler() collectionDeltaHandler {
 	return collectionDeltaHandler{
-		typeName:       "list",
-		prefix:         []byte(store.ListMetaDeltaPrefix),
-		extractUserKey: store.ExtractListUserKeyFromDelta,
-		buildElems:     c.buildListCompactElems,
+		typeName:         "list",
+		prefix:           []byte(store.ListMetaDeltaPrefix),
+		extractUserKey:   store.ExtractListUserKeyFromDelta,
+		deltaKeyPrefixFn: store.ListMetaDeltaScanPrefix,
+		buildElems:       c.buildListCompactElems,
 	}
 }
 
@@ -494,20 +587,22 @@ func listMetaElemForLen(metaKey []byte, meta store.ListMeta) (*kv.Elem[kv.OP], e
 // Hash/Set/ZSet compaction handler. All three types carry only a LenDelta,
 // so a single factory (makeSimpleLenHandler) produces all three handlers.
 type simpleLenHandlerParams struct {
-	typeName       string
-	deltaPrefix    string
-	extractUserKey func(key []byte) []byte
-	metaKeyFn      func(userKey []byte) []byte
-	unmarshalBase  func([]byte) (int64, error)
-	unmarshalDelta func([]byte) (int64, error)
-	marshalBase    func(int64) []byte
+	typeName         string
+	deltaPrefix      string
+	extractUserKey   func(key []byte) []byte
+	deltaKeyPrefixFn func(userKey []byte) []byte
+	metaKeyFn        func(userKey []byte) []byte
+	unmarshalBase    func([]byte) (int64, error)
+	unmarshalDelta   func([]byte) (int64, error)
+	marshalBase      func(int64) []byte
 }
 
 func (c *DeltaCompactor) makeSimpleLenHandler(p simpleLenHandlerParams) collectionDeltaHandler {
 	return collectionDeltaHandler{
-		typeName:       p.typeName,
-		prefix:         []byte(p.deltaPrefix),
-		extractUserKey: p.extractUserKey,
+		typeName:         p.typeName,
+		prefix:           []byte(p.deltaPrefix),
+		extractUserKey:   p.extractUserKey,
+		deltaKeyPrefixFn: p.deltaKeyPrefixFn,
 		buildElems: func(ctx context.Context, userKey []byte, deltaKVs []*store.KVPair, readTS uint64) ([]*kv.Elem[kv.OP], error) {
 			return c.buildSimpleCompactElems(ctx, userKey, deltaKVs, readTS,
 				p.metaKeyFn(userKey),
@@ -521,10 +616,11 @@ func (c *DeltaCompactor) makeSimpleLenHandler(p simpleLenHandlerParams) collecti
 
 func (c *DeltaCompactor) hashHandler() collectionDeltaHandler {
 	return c.makeSimpleLenHandler(simpleLenHandlerParams{
-		typeName:       "hash",
-		deltaPrefix:    store.HashMetaDeltaPrefix,
-		extractUserKey: store.ExtractHashUserKeyFromDelta,
-		metaKeyFn:      store.HashMetaKey,
+		typeName:         "hash",
+		deltaPrefix:      store.HashMetaDeltaPrefix,
+		extractUserKey:   store.ExtractHashUserKeyFromDelta,
+		deltaKeyPrefixFn: store.HashMetaDeltaScanPrefix,
+		metaKeyFn:        store.HashMetaKey,
 		unmarshalBase: func(b []byte) (int64, error) {
 			m, err := store.UnmarshalHashMeta(b)
 			return m.Len, errors.WithStack(err)
@@ -539,10 +635,11 @@ func (c *DeltaCompactor) hashHandler() collectionDeltaHandler {
 
 func (c *DeltaCompactor) setHandler() collectionDeltaHandler {
 	return c.makeSimpleLenHandler(simpleLenHandlerParams{
-		typeName:       "set",
-		deltaPrefix:    store.SetMetaDeltaPrefix,
-		extractUserKey: store.ExtractSetUserKeyFromDelta,
-		metaKeyFn:      store.SetMetaKey,
+		typeName:         "set",
+		deltaPrefix:      store.SetMetaDeltaPrefix,
+		extractUserKey:   store.ExtractSetUserKeyFromDelta,
+		deltaKeyPrefixFn: store.SetMetaDeltaScanPrefix,
+		metaKeyFn:        store.SetMetaKey,
 		unmarshalBase: func(b []byte) (int64, error) {
 			m, err := store.UnmarshalSetMeta(b)
 			return m.Len, errors.WithStack(err)
@@ -557,10 +654,11 @@ func (c *DeltaCompactor) setHandler() collectionDeltaHandler {
 
 func (c *DeltaCompactor) zsetHandler() collectionDeltaHandler {
 	return c.makeSimpleLenHandler(simpleLenHandlerParams{
-		typeName:       "zset",
-		deltaPrefix:    store.ZSetMetaDeltaPrefix,
-		extractUserKey: store.ExtractZSetUserKeyFromDelta,
-		metaKeyFn:      store.ZSetMetaKey,
+		typeName:         "zset",
+		deltaPrefix:      store.ZSetMetaDeltaPrefix,
+		extractUserKey:   store.ExtractZSetUserKeyFromDelta,
+		deltaKeyPrefixFn: store.ZSetMetaDeltaScanPrefix,
+		metaKeyFn:        store.ZSetMetaKey,
 		unmarshalBase: func(b []byte) (int64, error) {
 			m, err := store.UnmarshalZSetMeta(b)
 			return m.Len, errors.WithStack(err)

--- a/adapter/redis_delta_compactor.go
+++ b/adapter/redis_delta_compactor.go
@@ -178,8 +178,10 @@ func (c *DeltaCompactor) handlerByTypeName(typeName string) *collectionDeltaHand
 }
 
 // compactUrgentKey performs an immediate targeted compaction for a single user key
-// whose delta count exceeded MaxDeltaScanLimit. It scans all delta keys for the
-// key, builds compaction elems, and dispatches them as an OCC transaction.
+// whose delta count exceeded MaxDeltaScanLimit. It repeatedly scans and dispatches
+// compaction batches until the delta count drops to or below MaxDeltaScanLimit,
+// restoring readability for the key. Each iteration uses a fresh readTS so that
+// it observes the committed result of the previous batch.
 // A recover guard prevents a panic inside a handler from crashing the Run loop.
 func (c *DeltaCompactor) compactUrgentKey(ctx context.Context, req urgentCompactionRequest) {
 	defer func() {
@@ -197,37 +199,60 @@ func (c *DeltaCompactor) compactUrgentKey(ctx context.Context, req urgentCompact
 	if h == nil {
 		return
 	}
-	readTS := snapshotTS(c.coord.Clock(), c.st)
 	tickCtx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 
-	// Scan all delta keys for this specific user key.
 	prefix := h.deltaKeyPrefixFn(req.userKey)
 	end := store.PrefixScanEnd(prefix)
-	// Scan one extra beyond MaxDeltaScanLimit to collect all accumulated deltas.
-	kvs, err := c.st.ScanAt(tickCtx, prefix, end, store.MaxDeltaScanLimit+1, readTS)
+	totalCompacted, done := 0, false
+	for !done {
+		var n int
+		n, done = c.compactUrgentKeyBatch(tickCtx, req, h, prefix, end)
+		totalCompacted += n
+		if n == 0 {
+			break
+		}
+	}
+	if totalCompacted > 0 {
+		c.logger.InfoContext(tickCtx, "delta compactor urgent: compacted key",
+			"type", req.typeName, "key", string(req.userKey), "total_delta_count", totalCompacted)
+	}
+}
+
+// compactUrgentKeyBatch scans one window of delta keys for req.userKey, builds
+// compaction elems, and dispatches the OCC transaction.
+// Returns (n, done): n is the number of delta keys processed in this batch;
+// done is true when the remaining delta count is at or below MaxDeltaScanLimit
+// (the key is now readable).
+func (c *DeltaCompactor) compactUrgentKeyBatch(ctx context.Context, req urgentCompactionRequest, h *collectionDeltaHandler, prefix, end []byte) (int, bool) {
+	// Use a fresh readTS each iteration so we observe the committed state from
+	// the previous compaction pass and do not re-scan already-deleted delta keys.
+	readTS := snapshotTS(c.coord.Clock(), c.st)
+
+	// Scan one extra beyond MaxDeltaScanLimit to detect whether more remain.
+	kvs, err := c.st.ScanAt(ctx, prefix, end, store.MaxDeltaScanLimit+1, readTS)
 	if err != nil {
-		c.logger.WarnContext(tickCtx, "delta compactor urgent: scan failed",
+		c.logger.WarnContext(ctx, "delta compactor urgent: scan failed",
 			"type", req.typeName, "key", string(req.userKey), "error", err)
-		return
+		return 0, true
 	}
 	if len(kvs) == 0 {
-		return
+		return 0, true
 	}
 
-	elems, err := h.buildElems(tickCtx, req.userKey, kvs, readTS)
+	elems, err := h.buildElems(ctx, req.userKey, kvs, readTS)
 	if err != nil {
-		c.logger.WarnContext(tickCtx, "delta compactor urgent: buildElems failed",
+		c.logger.WarnContext(ctx, "delta compactor urgent: buildElems failed",
 			"type", req.typeName, "key", string(req.userKey), "error", err)
-		return
+		return 0, true
 	}
-	if err := c.dispatchCompaction(tickCtx, readTS, elems); err != nil {
-		c.logger.WarnContext(tickCtx, "delta compactor urgent: dispatch failed",
+	if err := c.dispatchCompaction(ctx, readTS, elems); err != nil {
+		c.logger.WarnContext(ctx, "delta compactor urgent: dispatch failed",
 			"type", req.typeName, "key", string(req.userKey), "error", err)
-		return
+		return 0, true
 	}
-	c.logger.InfoContext(tickCtx, "delta compactor urgent: compacted key",
-		"type", req.typeName, "key", string(req.userKey), "delta_count", len(kvs))
+	// Fewer than MaxDeltaScanLimit+1 results means no more deltas remain; key is readable.
+	return len(kvs), len(kvs) <= store.MaxDeltaScanLimit
 }
 
 // SyncOnce runs one compaction pass. Non-leaders return immediately.

--- a/adapter/redis_delta_compactor_test.go
+++ b/adapter/redis_delta_compactor_test.go
@@ -192,8 +192,13 @@ func TestDeltaCompactor_ZSetDeltaFoldedIntoBaseMeta(t *testing.T) {
 func TestDeltaCompactor_NonLeaderSkips(t *testing.T) {
 	t.Parallel()
 
+	// Use a real (writing) coordinator so that if compaction were incorrectly
+	// dispatched the delta keys would actually be deleted, making the assertion
+	// meaningful. The stub's IsLeaderForKey returns false to simulate a follower.
 	st := store.NewMVCCStore()
-	coord := &stubAdapterCoordinator{leaderSet: true, leader: false}
+	coord := newLocalAdapterCoordinator(st)
+	coord.leaderSet = true
+	coord.leader = false
 	c := NewDeltaCompactor(st, coord, WithDeltaCompactorMaxDeltaCount(1))
 	ctx := context.Background()
 
@@ -207,7 +212,7 @@ func TestDeltaCompactor_NonLeaderSkips(t *testing.T) {
 	require.NoError(t, c.SyncOnce(ctx))
 
 	readTS := st.LastCommitTS()
-	// Delta keys must NOT be touched since this node is not the leader.
+	// Delta keys must NOT be touched since this node is not the per-key leader.
 	_, getErr := st.GetAt(ctx, d1Key, readTS)
 	require.NoError(t, getErr, "non-leader should not compact delta keys")
 }

--- a/adapter/redis_delta_compactor_test.go
+++ b/adapter/redis_delta_compactor_test.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/bootjp/elastickv/store"
 	"github.com/stretchr/testify/require"
@@ -240,4 +241,108 @@ func TestDeltaCompactor_ListNoBaseMeta(t *testing.T) {
 	require.ErrorIs(t, err, store.ErrKeyNotFound)
 	_, err = st.GetAt(ctx, d2Key, readTS)
 	require.ErrorIs(t, err, store.ErrKeyNotFound)
+}
+
+// TestDeltaCompactor_UrgentCompactionTriggeredByChannel verifies that a request
+// queued via TriggerUrgentCompaction is processed by the Run loop, compacting
+// the targeted key without waiting for the next regular tick.
+//
+// maxCount is set high so the regular SyncOnce pass skips the key, ensuring it
+// is the urgent path that performs the actual compaction.
+func TestDeltaCompactor_UrgentCompactionTriggeredByChannel(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	coord := newLocalAdapterCoordinator(st)
+	// High maxCount ensures SyncOnce does not compact our key; only the urgent path will.
+	const hugeMaxCount = 1<<31 - 1
+	c := NewDeltaCompactor(st, coord, WithDeltaCompactorMaxDeltaCount(hugeMaxCount))
+	ctx := context.Background()
+	userKey := []byte("urgent-hash-key")
+
+	// Write base meta: Len=5.
+	require.NoError(t, st.PutAt(ctx, store.HashMetaKey(userKey), store.MarshalHashMeta(store.HashMeta{Len: 5}), 1, 0))
+
+	// Write 3 delta keys (LenDelta=+1 each). These are below hugeMaxCount so SyncOnce
+	// skips them; TriggerUrgentCompaction must be what kicks off compaction.
+	delta := store.MarshalHashMetaDelta(store.HashMetaDelta{LenDelta: 1})
+	for i := uint64(0); i < 3; i++ {
+		dKey := store.HashMetaDeltaKey(userKey, 10+i, 0)
+		require.NoError(t, st.PutAt(ctx, dKey, delta, 10+i, 0))
+	}
+
+	// Queue the urgent compaction request.
+	c.TriggerUrgentCompaction("hash", userKey)
+
+	// Start the Run loop; it runs SyncOnce (skips the key) then drains the urgent channel.
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() { _ = c.Run(runCtx) }()
+
+	// Wait until the base meta reflects the compacted value (5 + 3 = 8).
+	require.Eventually(t, func() bool {
+		readTS := st.LastCommitTS()
+		raw, err := st.GetAt(ctx, store.HashMetaKey(userKey), readTS)
+		if err != nil {
+			return false
+		}
+		got, err := store.UnmarshalHashMeta(raw)
+		return err == nil && got.Len == 8
+	}, 2*time.Second, 10*time.Millisecond, "urgent compaction should have updated the hash meta to Len=8")
+}
+
+// TestDeltaCompactor_UrgentCompactionPagination verifies that when a key has
+// more than MaxDeltaScanLimit delta keys, compactUrgentKey loops until all
+// batches are compacted, leaving the key readable.
+//
+// maxCount is set to MaxInt so the regular SyncOnce pass skips the key
+// (threshold not met), ensuring only the urgent path exercises the pagination loop.
+func TestDeltaCompactor_UrgentCompactionPagination(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	coord := newLocalAdapterCoordinator(st)
+	// Use a very high maxCount so SyncOnce never compacts our test key, forcing
+	// the urgent path to handle all batches via the pagination loop.
+	const hugeMaxCount = 1<<31 - 1
+	c := NewDeltaCompactor(st, coord, WithDeltaCompactorMaxDeltaCount(hugeMaxCount))
+	ctx := context.Background()
+	userKey := []byte("overflow-hash-key")
+
+	// Write more than MaxDeltaScanLimit delta keys so that a single-pass scan
+	// (capped at MaxDeltaScanLimit+1) leaves some unconsumed, requiring pagination.
+	// Use a typed constant to avoid int->uint64 overflow warnings.
+	const totalDeltasU64 = uint64(store.MaxDeltaScanLimit + 10) // 1034
+	delta := store.MarshalHashMetaDelta(store.HashMetaDelta{LenDelta: 1})
+	for i := uint64(0); i < totalDeltasU64; i++ {
+		dKey := store.HashMetaDeltaKey(userKey, i+1, 0)
+		require.NoError(t, st.PutAt(ctx, dKey, delta, i+1, 0))
+	}
+
+	// Queue and process the urgent compaction.
+	c.TriggerUrgentCompaction("hash", userKey)
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() { _ = c.Run(runCtx) }()
+
+	// Wait until the base meta holds the accumulated total.
+	// The pagination loop should take two passes: first 1025, then 9.
+	require.Eventually(t, func() bool {
+		readTS := st.LastCommitTS()
+		raw, err := st.GetAt(ctx, store.HashMetaKey(userKey), readTS)
+		if err != nil {
+			return false
+		}
+		got, err := store.UnmarshalHashMeta(raw)
+		return err == nil && got.Len == int64(totalDeltasU64)
+	}, 5*time.Second, 20*time.Millisecond, "all %d delta keys should be compacted into base meta", totalDeltasU64)
+
+	// No delta keys should remain after pagination compaction.
+	readTS := st.LastCommitTS()
+	prefix := store.HashMetaDeltaScanPrefix(userKey)
+	end := store.PrefixScanEnd(prefix)
+	remaining, err := st.ScanAt(ctx, prefix, end, int(totalDeltasU64)+1, readTS)
+	require.NoError(t, err)
+	require.Empty(t, remaining, "all delta keys must be deleted after urgent compaction")
 }

--- a/adapter/redis_keys_pattern_test.go
+++ b/adapter/redis_keys_pattern_test.go
@@ -40,6 +40,9 @@ func (s *stubAdapterCoordinator) RaftLeader() raft.ServerAddress {
 }
 
 func (s *stubAdapterCoordinator) IsLeaderForKey([]byte) bool {
+	if s.leaderSet {
+		return s.leader
+	}
 	return true
 }
 

--- a/adapter/test_util.go
+++ b/adapter/test_util.go
@@ -379,7 +379,11 @@ func setupNodes(t *testing.T, ctx context.Context, n int, ports []portsAdress) (
 			assert.NoError(t, srv.Serve(lis))
 		}(s, grpcSock)
 
-		rd := NewRedisServer(redisSock, port.redisAddress, routedStore, coordinator, leaderRedisMap, relay)
+		dc := NewDeltaCompactor(st, coordinator)
+		go func() { _ = dc.Run(opsCtx) }()
+		rd := NewRedisServer(redisSock, port.redisAddress, routedStore, coordinator, leaderRedisMap, relay,
+			WithRedisCompactor(dc),
+		)
 		go func(server *RedisServer) {
 			assert.NoError(t, server.Run())
 		}(rd)

--- a/cmd/server/demo.go
+++ b/cmd/server/demo.go
@@ -411,7 +411,7 @@ func setupGRPC(ctx context.Context, r *raft.Raft, st store.MVCCStore, tm *transp
 	return s, gs
 }
 
-func setupRedis(ctx context.Context, lc net.ListenConfig, st store.MVCCStore, coordinator *kv.Coordinate, addr, redisAddr, raftRedisMapStr string, relay *adapter.RedisPubSubRelay, readTracker *kv.ActiveTimestampTracker) (*adapter.RedisServer, error) {
+func setupRedis(ctx context.Context, lc net.ListenConfig, st store.MVCCStore, coordinator *kv.Coordinate, addr, redisAddr, raftRedisMapStr string, relay *adapter.RedisPubSubRelay, readTracker *kv.ActiveTimestampTracker, deltaCompactor *adapter.DeltaCompactor) (*adapter.RedisServer, error) {
 	leaderRedis := make(map[raft.ServerAddress]string)
 	if raftRedisMapStr != "" {
 		parts := strings.SplitSeq(raftRedisMapStr, ",")
@@ -430,7 +430,10 @@ func setupRedis(ctx context.Context, lc net.ListenConfig, st store.MVCCStore, co
 		return nil, errors.WithStack(err)
 	}
 	routedStore := kv.NewLeaderRoutedStore(st, coordinator)
-	return adapter.NewRedisServer(l, redisAddr, routedStore, coordinator, leaderRedis, relay, adapter.WithRedisActiveTimestampTracker(readTracker)), nil
+	return adapter.NewRedisServer(l, redisAddr, routedStore, coordinator, leaderRedis, relay,
+		adapter.WithRedisActiveTimestampTracker(readTracker),
+		adapter.WithRedisCompactor(deltaCompactor),
+	), nil
 }
 
 func setupS3(
@@ -590,7 +593,9 @@ func run(ctx context.Context, eg *errgroup.Group, cfg config) error {
 		_ = grpcSock.Close()
 	})
 
-	rd, err := setupRedis(ctx, lc, st, coordinator, cfg.address, cfg.redisAddress, cfg.raftRedisMap, relay, readTracker)
+	deltaCompactor := adapter.NewDeltaCompactor(st, coordinator)
+
+	rd, err := setupRedis(ctx, lc, st, coordinator, cfg.address, cfg.redisAddress, cfg.raftRedisMap, relay, readTracker, deltaCompactor)
 	if err != nil {
 		return err
 	}
@@ -609,8 +614,6 @@ func run(ctx context.Context, eg *errgroup.Group, cfg config) error {
 	if err != nil {
 		return err
 	}
-
-	deltaCompactor := adapter.NewDeltaCompactor(st, coordinator)
 
 	eg.Go(func() error { coordinator.RunHLCLeaseRenewal(ctx); return nil })
 	eg.Go(catalogWatcherTask(ctx, distCatalog, distEngine))

--- a/main.go
+++ b/main.go
@@ -520,7 +520,13 @@ func startRedisServer(ctx context.Context, lc *net.ListenConfig, eg *errgroup.Gr
 	if err != nil {
 		return errors.Wrapf(err, "failed to listen on %s", redisAddr)
 	}
-	redisServer := adapter.NewRedisServer(redisL, redisAddr, shardStore, coordinate, leaderRedis, relay, adapter.WithRedisActiveTimestampTracker(readTracker), adapter.WithRedisRequestObserver(metricsRegistry.RedisObserver()))
+	deltaCompactor := adapter.NewDeltaCompactor(shardStore, coordinate)
+	eg.Go(func() error { return deltaCompactor.Run(ctx) })
+	redisServer := adapter.NewRedisServer(redisL, redisAddr, shardStore, coordinate, leaderRedis, relay,
+		adapter.WithRedisActiveTimestampTracker(readTracker),
+		adapter.WithRedisRequestObserver(metricsRegistry.RedisObserver()),
+		adapter.WithRedisCompactor(deltaCompactor),
+	)
 	eg.Go(func() error {
 		defer redisServer.Stop()
 		stop := make(chan struct{})


### PR DESCRIPTION
When a hot key accumulates more than MaxDeltaScanLimit (1024) delta keys, reads like HLEN/SCARD/ZCARD/LLEN fail with ErrDeltaScanTruncated. Previously the only remedy was to wait for the next 30s compaction tick.

Now:
- DeltaCompactor gains an urgentCh (buffered 64) and TriggerUrgentCompaction.
- Run() selects on urgentCh between regular ticks; compactUrgentKey performs a targeted single-key scan+compact without waiting for the full keyspace pass.
- Each collectionDeltaHandler carries a deltaKeyPrefixFn for per-key scans.
- resolveHashMeta/resolveSetMeta/resolveZSetMeta/resolveListMeta call triggerUrgentCompaction when ErrDeltaScanTruncated is returned.
- RedisServer gains a compactor field wired via WithRedisCompactor option.

Excess urgent signals (channel full) are dropped silently; the regular tick acts as the fallback. This bounds latency for hot keys under high write load.