### PR TITLE
feat(redis): eliminate TTL write conflicts via in-memory buffer with batch Raft flush

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -273,7 +273,8 @@ type RedisServer struct {
 
 	// ttlBuffer holds pending TTL writes that are flushed to Raft in batches.
 	// It eliminates TTL write conflicts from concurrent Lua script executions.
-	ttlBuffer *TTLBuffer
+	ttlBuffer        *TTLBuffer
+	ttlFlushInterval time.Duration
 
 	route map[string]func(conn redcon.Conn, cmd redcon.Command)
 }
@@ -290,6 +291,17 @@ func WithRedisActiveTimestampTracker(tracker *kv.ActiveTimestampTracker) RedisSe
 func WithRedisRequestObserver(observer monitoring.RedisRequestObserver) RedisServerOption {
 	return func(r *RedisServer) {
 		r.requestObserver = observer
+	}
+}
+
+// WithTTLFlushInterval overrides the default TTL buffer flush interval (100 ms).
+// Smaller values reduce the window for TTL loss on crash; larger values lower
+// Raft write amplification. Values ≤ 0 are ignored.
+func WithTTLFlushInterval(d time.Duration) RedisServerOption {
+	return func(r *RedisServer) {
+		if d > 0 {
+			r.ttlFlushInterval = d
+		}
 	}
 }
 
@@ -343,18 +355,19 @@ func NewRedisServer(listen net.Listener, redisAddr string, store store.MVCCStore
 		relay = NewRedisPubSubRelay()
 	}
 	r := &RedisServer{
-		listen:          listen,
-		store:           store,
-		coordinator:     coordinate,
-		redisTranscoder: newRedisTranscoder(),
-		redisAddr:       redisAddr,
-		relay:           relay,
-		leaderRedis:     leaderRedis,
-		leaderClients:   make(map[string]*redis.Client),
-		pubsub:          newRedisPubSub(),
-		scriptCache:     map[string]string{},
-		traceCommands:   os.Getenv("ELASTICKV_REDIS_TRACE") == "1",
-		ttlBuffer:       newTTLBuffer(),
+		listen:           listen,
+		store:            store,
+		coordinator:      coordinate,
+		redisTranscoder:  newRedisTranscoder(),
+		redisAddr:        redisAddr,
+		relay:            relay,
+		leaderRedis:      leaderRedis,
+		leaderClients:    make(map[string]*redis.Client),
+		pubsub:           newRedisPubSub(),
+		scriptCache:      map[string]string{},
+		traceCommands:    os.Getenv("ELASTICKV_REDIS_TRACE") == "1",
+		ttlBuffer:        newTTLBuffer(),
+		ttlFlushInterval: defaultTTLFlushInterval,
 	}
 	r.relay.Bind(r.publishLocal)
 

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1916,7 +1916,7 @@ func (t *txnContext) applySet(cmd redcon.Command) (redisResult, error) {
 	}
 
 	var oldValue []byte
-	if opts.returnOld {
+	if opts.returnOld && !tv.deleted {
 		oldValue = tv.raw
 	}
 

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1030,12 +1030,6 @@ func (r *RedisServer) get(conn redcon.Conn, cmd redcon.Command) {
 
 // isLeaderKeyExpired checks whether the key has an expired TTL on the leader.
 func (r *RedisServer) isLeaderKeyExpired(key []byte) bool {
-	if expireAt, found := r.ttlBuffer.Get(key); found {
-		if expireAt == nil {
-			return false
-		}
-		return !expireAt.After(time.Now())
-	}
 	raw, err := r.tryLeaderGetAt(redisTTLKey(key), 0)
 	if err != nil {
 		return false
@@ -1052,11 +1046,7 @@ func (r *RedisServer) isLeaderKeyExpired(key []byte) bool {
 // key has an expired TTL.
 func (r *RedisServer) tryLeaderNonStringExists(key []byte) bool {
 	// Check TTL first: if expired, the key is logically gone.
-	if expireAt, found := r.ttlBuffer.Get(key); found {
-		if expireAt != nil && !expireAt.After(time.Now()) {
-			return false
-		}
-	} else if raw, err := r.tryLeaderGetAt(redisTTLKey(key), 0); err == nil {
+	if raw, err := r.tryLeaderGetAt(redisTTLKey(key), 0); err == nil {
 		if ttl, decErr := decodeRedisTTL(raw); decErr == nil && !ttl.After(time.Now()) {
 			return false
 		}

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1901,11 +1901,10 @@ func (t *txnContext) applySet(cmd redcon.Command) (redisResult, error) {
 	tv.deleted = false
 	tv.dirty = true
 
-	// EX/PX: store the TTL so it is flushed to the TTLBuffer after commit.
-	if opts.ttl != nil {
-		if err := t.applySetTTL(cmd.Args[1], opts.ttl); err != nil {
-			return redisResult{}, err
-		}
+	// Always update TTL state: EX/PX sets a new expiry; a plain SET clears it
+	// (opts.ttl == nil → nil stored → PERSIST semantics, matching Redis behaviour).
+	if err := t.applySetTTL(cmd.Args[1], opts.ttl); err != nil {
+		return redisResult{}, err
 	}
 
 	return applySetResult(opts, oldValue), nil

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1070,6 +1070,17 @@ func (r *RedisServer) tryLeaderNonStringExists(key []byte) bool {
 
 // tryLeaderLogicalExists checks whether the key exists as any type on the leader.
 func (r *RedisServer) tryLeaderLogicalExists(key []byte) bool {
+	// Prefer asking the leader's Redis command path directly: it evaluates
+	// existence with ttlAt() semantics (including the in-memory TTL buffer).
+	if cli, err := r.leaderClientForKey(key); err == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
+		defer cancel()
+		if count, existsErr := cli.Exists(ctx, string(key)).Result(); existsErr == nil {
+			return count > 0
+		}
+	}
+
+	// Fallback to raw KV probing if Redis command proxying is unavailable.
 	if r.isLeaderKeyExpired(key) {
 		return false
 	}

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1860,14 +1860,83 @@ func (t *txnContext) applySet(cmd redcon.Command) (redisResult, error) {
 		return redisResult{typ: resultError, err: errors.New("WRONGTYPE Operation against a key holding the wrong kind of value")}, nil
 	}
 
+	opts, err := parseRedisSetOptions(cmd.Args[3:], time.Now())
+	if err != nil {
+		return redisResult{}, err
+	}
+
+	// NX/XX: skip the write if the key-existence condition is not met.
+	blocked, res, err := t.applySetCondition(cmd.Args[1], opts)
+	if err != nil {
+		return redisResult{}, err
+	}
+	if blocked {
+		return res, nil
+	}
+
 	tv, err := t.load(cmd.Args[1])
 	if err != nil {
 		return redisResult{}, err
 	}
+
+	var oldValue []byte
+	if opts.returnOld {
+		oldValue = tv.raw
+	}
+
 	tv.raw = cmd.Args[2]
 	tv.deleted = false
 	tv.dirty = true
-	return redisResult{typ: resultString, str: "OK"}, nil
+
+	// EX/PX: store the TTL so it is flushed to the TTLBuffer after commit.
+	if opts.ttl != nil {
+		if err := t.applySetTTL(cmd.Args[1], opts.ttl); err != nil {
+			return redisResult{}, err
+		}
+	}
+
+	return applySetResult(opts, oldValue), nil
+}
+
+// applySetCondition checks NX/XX conditions.  Returns (blocked, result, err).
+// blocked=true means the condition prevented the write; callers should return result.
+// Returns (false, _, nil) immediately when no condition is set.
+func (t *txnContext) applySetCondition(key []byte, opts redisSetOptions) (bool, redisResult, error) {
+	if !opts.existsCond && !opts.missingCond {
+		return false, redisResult{}, nil
+	}
+	typ, err := t.stagedKeyType(key)
+	if err != nil {
+		return false, redisResult{}, err
+	}
+	exists := typ != redisTypeNone
+	if (opts.missingCond && exists) || (opts.existsCond && !exists) {
+		return true, redisResult{typ: resultNil}, nil
+	}
+	return false, redisResult{}, nil
+}
+
+// applySetTTL stores the expiry in ttlStates so flushTTLToBuffer sends it to
+// the TTLBuffer after a successful commit.
+func (t *txnContext) applySetTTL(key []byte, expireAt *time.Time) error {
+	ttlSt, err := t.loadTTLState(key)
+	if err != nil {
+		return err
+	}
+	ttlSt.value = expireAt
+	ttlSt.dirty = true
+	return nil
+}
+
+// applySetResult returns the appropriate redisResult for a completed SET.
+func applySetResult(opts redisSetOptions, oldValue []byte) redisResult {
+	if !opts.returnOld {
+		return redisResult{typ: resultString, str: "OK"}
+	}
+	if oldValue == nil {
+		return redisResult{typ: resultNil}
+	}
+	return redisResult{typ: resultBulk, bulk: oldValue}
 }
 
 func (t *txnContext) applyDel(cmd redcon.Command) (redisResult, error) {

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1072,6 +1072,8 @@ func (r *RedisServer) tryLeaderNonStringExists(key []byte) bool {
 func (r *RedisServer) tryLeaderLogicalExists(key []byte) bool {
 	// Prefer asking the leader's Redis command path directly: it evaluates
 	// existence with ttlAt() semantics (including the in-memory TTL buffer).
+	// If this path is unavailable we fall back to raw-KV probing, which is
+	// best-effort and may lag unflushed buffer-only TTL updates.
 	if cli, err := r.leaderClientForKey(key); err == nil {
 		ctx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
 		defer cancel()

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -271,6 +271,10 @@ type RedisServer struct {
 	leaderClientsMu sync.RWMutex
 	leaderClients   map[string]*redis.Client
 
+	// ttlBuffer holds pending TTL writes that are flushed to Raft in batches.
+	// It eliminates TTL write conflicts from concurrent Lua script executions.
+	ttlBuffer *TTLBuffer
+
 	route map[string]func(conn redcon.Conn, cmd redcon.Command)
 }
 
@@ -350,6 +354,7 @@ func NewRedisServer(listen net.Listener, redisAddr string, store store.MVCCStore
 		pubsub:          newRedisPubSub(),
 		scriptCache:     map[string]string{},
 		traceCommands:   os.Getenv("ELASTICKV_REDIS_TRACE") == "1",
+		ttlBuffer:       newTTLBuffer(),
 	}
 	r.relay.Bind(r.publishLocal)
 
@@ -499,6 +504,16 @@ func (r *RedisServer) dispatchCommand(conn redcon.Conn, name string, handler fun
 }
 
 func (r *RedisServer) Run() error {
+	// Start the TTL buffer flush goroutine. It runs until the listener closes,
+	// then performs one final flush before returning.
+	flushCtx, cancelFlush := context.WithCancel(context.Background())
+	var flushWG sync.WaitGroup
+	flushWG.Add(1)
+	go func() {
+		defer flushWG.Done()
+		r.runTTLFlusher(flushCtx)
+	}()
+
 	err := redcon.Serve(r.listen,
 		func(conn redcon.Conn, cmd redcon.Command) {
 			needsTiming := r.requestObserver != nil || r.traceCommands
@@ -545,6 +560,8 @@ func (r *RedisServer) Run() error {
 			// PubSub connections clean up their own subscriptions via bgrunner.
 		})
 
+	cancelFlush()
+	flushWG.Wait()
 	return errors.WithStack(err)
 }
 
@@ -719,12 +736,13 @@ func (r *RedisServer) replaceWithStringTxn(ctx context.Context, key, value []byt
 		elems = append(elems, delElems...)
 	}
 	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: redisStrKey(key), Value: bytes.Clone(value)})
-	if ttl != nil {
-		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: redisTTLKey(key), Value: encodeRedisTTL(*ttl)})
-	} else {
-		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisTTLKey(key)})
+	// TTL is no longer part of the Raft transaction; it is written to the
+	// in-memory buffer after a successful data commit (see flushTTLToBuffer).
+	if err := r.dispatchElems(ctx, true, readTS, elems); err != nil {
+		return err
 	}
-	return r.dispatchElems(ctx, true, readTS, elems)
+	r.ttlBuffer.Set(key, ttl)
+	return nil
 }
 
 func (r *RedisServer) executeSet(ctx context.Context, key, value []byte, opts redisSetOptions) (redisSetExecution, error) {
@@ -979,6 +997,12 @@ func (r *RedisServer) get(conn redcon.Conn, cmd redcon.Command) {
 
 // isLeaderKeyExpired checks whether the key has an expired TTL on the leader.
 func (r *RedisServer) isLeaderKeyExpired(key []byte) bool {
+	if expireAt, found := r.ttlBuffer.Get(key); found {
+		if expireAt == nil {
+			return false
+		}
+		return !expireAt.After(time.Now())
+	}
 	raw, err := r.tryLeaderGetAt(redisTTLKey(key), 0)
 	if err != nil {
 		return false
@@ -995,7 +1019,11 @@ func (r *RedisServer) isLeaderKeyExpired(key []byte) bool {
 // key has an expired TTL.
 func (r *RedisServer) tryLeaderNonStringExists(key []byte) bool {
 	// Check TTL first: if expired, the key is logically gone.
-	if raw, err := r.tryLeaderGetAt(redisTTLKey(key), 0); err == nil {
+	if expireAt, found := r.ttlBuffer.Get(key); found {
+		if expireAt != nil && !expireAt.After(time.Now()) {
+			return false
+		}
+	} else if raw, err := r.tryLeaderGetAt(redisTTLKey(key), 0); err == nil {
 		if ttl, decErr := decodeRedisTTL(raw); decErr == nil && !ttl.After(time.Now()) {
 			return false
 		}
@@ -1606,7 +1634,6 @@ func (t *txnContext) trackTypeReadKeys(key []byte) {
 		redisHLLKey(key),
 		redisStrKey(key),
 		key, // legacy bare key for fallback reads
-		redisTTLKey(key),
 	} {
 		t.trackReadKey(readKey)
 	}
@@ -1617,10 +1644,8 @@ func (t *txnContext) load(key []byte) (*txnValue, error) {
 	// !lst|..., !txn|..., !ddb|..., !s3|..., !dist|...), use it as-is.
 	// Otherwise, it's a bare user key for a string value — prefix it.
 	storageKey := key
-	userKey := extractRedisInternalUserKey(key)
 	if !isKnownInternalKey(key) {
 		storageKey = redisStrKey(key)
-		userKey = key
 	}
 	k := string(storageKey)
 	if tv, ok := t.working[k]; ok {
@@ -1630,9 +1655,6 @@ func (t *txnContext) load(key []byte) (*txnValue, error) {
 	if !isKnownInternalKey(key) {
 		// Track the bare key too for conflict detection on legacy fallback reads.
 		t.trackReadKey(key)
-	}
-	if userKey != nil {
-		t.trackReadKey(redisTTLKey(userKey))
 	}
 	tv := &txnValue{}
 	var val []byte
@@ -1661,10 +1683,6 @@ func (t *txnContext) loadListState(key []byte) (*listTxnState, error) {
 	if st, ok := t.listStates[k]; ok {
 		return st, nil
 	}
-	// With the Delta pattern we no longer read-modify-write the single base
-	// meta key, so there is no OCC conflict to track on it.
-	t.trackReadKey(redisTTLKey(key))
-
 	ctx := context.Background()
 	meta, exists, err := t.server.resolveListMeta(ctx, key, t.startTS)
 	if err != nil {
@@ -1759,7 +1777,6 @@ func (t *txnContext) loadTTLState(key []byte) (*ttlTxnState, error) {
 	if st, ok := t.ttlStates[k]; ok {
 		return st, nil
 	}
-	t.trackReadKey(redisTTLKey(key))
 	value, err := t.server.ttlAt(context.Background(), key, t.startTS)
 	if err != nil {
 		return nil, err
@@ -2132,31 +2149,36 @@ func (t *txnContext) commit() error {
 	if err != nil {
 		return err
 	}
-	ttlElems := t.buildTTLElems()
 
+	// TTL is no longer included in the IsTxn=true transaction; it is written to
+	// the in-memory buffer after a successful data commit to eliminate write
+	// conflicts on redisTTLKey from concurrent EXPIRE/SETEX operations.
 	elems = append(elems, listElems...)
 	elems = append(elems, zsetElems...)
-	elems = append(elems, ttlElems...)
-	if len(elems) == 0 {
+	if len(elems) == 0 && !t.hasDirtyTTLStates() {
 		return nil
 	}
 
-	readKeys := make([][]byte, 0, len(t.readKeys))
-	for _, k := range t.readKeys {
-		readKeys = append(readKeys, k)
+	if len(elems) > 0 {
+		readKeys := make([][]byte, 0, len(t.readKeys))
+		for _, k := range t.readKeys {
+			readKeys = append(readKeys, k)
+		}
+		group := &kv.OperationGroup[kv.OP]{
+			IsTxn:    true,
+			Elems:    elems,
+			StartTS:  t.startTS,
+			CommitTS: commitTS,
+			ReadKeys: readKeys,
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
+		defer cancel()
+		if _, err := t.server.coordinator.Dispatch(ctx, group); err != nil {
+			return errors.WithStack(err)
+		}
 	}
-	group := &kv.OperationGroup[kv.OP]{
-		IsTxn:    true,
-		Elems:    elems,
-		StartTS:  t.startTS,
-		CommitTS: commitTS,
-		ReadKeys: readKeys,
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
-	defer cancel()
-	if _, err := t.server.coordinator.Dispatch(ctx, group); err != nil {
-		return errors.WithStack(err)
-	}
+
+	t.flushTTLToBuffer()
 	return nil
 }
 
@@ -2337,26 +2359,26 @@ func buildZSetWideElems(key []byte, st *zsetTxnState) ([]*kv.Elem[kv.OP], int64)
 	return elems, lenDelta
 }
 
-func (t *txnContext) buildTTLElems() []*kv.Elem[kv.OP] {
-	keys := make([]string, 0, len(t.ttlStates))
-	for k := range t.ttlStates {
-		keys = append(keys, k)
+// hasDirtyTTLStates returns true if any TTL state has been modified.
+func (t *txnContext) hasDirtyTTLStates() bool {
+	for _, st := range t.ttlStates {
+		if st.dirty {
+			return true
+		}
 	}
-	sort.Strings(keys)
+	return false
+}
 
-	elems := make([]*kv.Elem[kv.OP], 0, len(keys))
-	for _, k := range keys {
-		st := t.ttlStates[k]
+// flushTTLToBuffer writes all dirty TTL states to the server's TTLBuffer.
+// It is called after a successful Raft data commit so TTL never reaches the
+// buffer if the data commit fails.
+func (t *txnContext) flushTTLToBuffer() {
+	for k, st := range t.ttlStates {
 		if !st.dirty {
 			continue
 		}
-		if st.value == nil {
-			elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisTTLKey([]byte(k))})
-			continue
-		}
-		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: redisTTLKey([]byte(k)), Value: encodeRedisTTL(*st.value)})
+		t.server.ttlBuffer.Set([]byte(k), st.value)
 	}
-	return elems
 }
 
 func (r *RedisServer) runTransaction(queue []redcon.Command) ([]redisResult, error) {

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -355,9 +355,10 @@ func (r *RedisServer) setExpire(conn redcon.Conn, cmd redcon.Command, unit time.
 		}
 		expireAt := time.Now().Add(time.Duration(ttl) * unit)
 		result = 1
-		return r.dispatchElems(ctx, true, readTS, []*kv.Elem[kv.OP]{
-			{Op: kv.Put, Key: redisTTLKey(cmd.Args[1]), Value: encodeRedisTTL(expireAt)},
-		})
+		// TTL is written to the in-memory buffer; the background flusher
+		// batches it to Raft without conflict detection (IsTxn=false).
+		r.ttlBuffer.Set(cmd.Args[1], &expireAt)
+		return nil
 	}); err != nil {
 		conn.WriteError(err.Error())
 		return
@@ -1935,10 +1936,14 @@ func (r *RedisServer) incr(conn redcon.Conn, cmd redcon.Command) {
 		}
 		current++
 
-		return r.dispatchElems(ctx, true, readTS, []*kv.Elem[kv.OP]{
+		if err := r.dispatchElems(ctx, true, readTS, []*kv.Elem[kv.OP]{
 			{Op: kv.Put, Key: redisStrKey(cmd.Args[1]), Value: []byte(strconv.FormatInt(current, 10))},
-			{Op: kv.Del, Key: redisTTLKey(cmd.Args[1])},
-		})
+		}); err != nil {
+			return err
+		}
+		// INCR clears any TTL; write nil to buffer (PERSIST semantics).
+		r.ttlBuffer.Set(cmd.Args[1], nil)
+		return nil
 	}); err != nil {
 		conn.WriteError(err.Error())
 		return

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -384,12 +384,13 @@ func (r *RedisServer) saveString(ctx context.Context, key []byte, value []byte, 
 	elems := []*kv.Elem[kv.OP]{
 		{Op: kv.Put, Key: redisStrKey(key), Value: bytes.Clone(value)},
 	}
-	if ttl == nil {
-		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisTTLKey(key)})
-	} else {
-		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: redisTTLKey(key), Value: encodeRedisTTL(*ttl)})
+	if err := r.dispatchElems(ctx, false, 0, elems); err != nil {
+		return err
 	}
-	return r.dispatchElems(ctx, false, 0, elems)
+	// TTL is written to the buffer after a successful data commit; the
+	// background flusher batches it to Raft without conflict detection.
+	r.ttlBuffer.Set(key, ttl)
+	return nil
 }
 
 // deleteListElems returns delete operations for all list keys: item keys, the base

--- a/adapter/redis_compat_types.go
+++ b/adapter/redis_compat_types.go
@@ -211,6 +211,10 @@ func decodeRedisTTL(raw []byte) (time.Time, error) {
 }
 
 func (r *RedisServer) ttlAt(ctx context.Context, userKey []byte, readTS uint64) (*time.Time, error) {
+	// The buffer holds the most recent TTL write regardless of Raft flush state.
+	if expireAt, found := r.ttlBuffer.Get(userKey); found {
+		return expireAt, nil
+	}
 	raw, err := r.store.GetAt(ctx, redisTTLKey(userKey), readTS)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"context"
+	"log/slog"
 	"maps"
 	"math"
 	"sort"
@@ -2523,12 +2524,16 @@ func (c *luaScriptContext) flushTTLForKeyToBuffer(key string, finalType redisVal
 	}
 	ttl, err := c.finalTTL([]byte(key))
 	if err != nil {
+		// Data was already committed to Raft; log and leave the stale TTL as-is
+		// rather than silently losing the TTL state.
+		slog.Warn("lua TTL flush: failed to read finalTTL, TTL update skipped", "key_len", len(key), "err", err)
 		return
 	}
 	if ttl == nil {
-		if preserveExisting {
-			c.server.ttlBuffer.Set([]byte(key), nil)
-		}
+		// Write nil unconditionally: for read-modify-write paths (preserveExisting=true)
+		// this is an explicit TTL removal (PERSIST); for rewrite paths
+		// (preserveExisting=false) it clears any stale buffered TTL for this key.
+		c.server.ttlBuffer.Set([]byte(key), nil)
 		return
 	}
 	c.server.ttlBuffer.Set([]byte(key), ttl)

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -2424,6 +2424,13 @@ type luaCommitPlan struct {
 	elems            []*kv.Elem[kv.OP]
 }
 
+// luaKeyPlan carries the data elements and TTL metadata for a single key commit.
+type luaKeyPlan struct {
+	elems           []*kv.Elem[kv.OP]
+	finalType       redisValueType
+	preserveExisting bool
+}
+
 func (c *luaScriptContext) commit() error {
 	keys := make([]string, 0, len(c.touched))
 	for key := range c.touched {
@@ -2434,62 +2441,97 @@ func (c *luaScriptContext) commit() error {
 	// Pre-allocate a commitTS so Delta key bytes can embed it before dispatch.
 	commitTS := c.server.coordinator.Clock().Next()
 
+	keyPlans := make([]luaKeyPlan, 0, len(keys))
 	elems := make([]*kv.Elem[kv.OP], 0, len(keys)*redisPairWidth)
 	ctx := context.Background()
 	for _, key := range keys {
-		keyElems, err := c.commitElemsForKey(ctx, key, commitTS)
+		plan, err := c.commitPlanForKey(ctx, key, commitTS)
 		if err != nil {
 			return err
 		}
-		elems = append(elems, keyElems...)
+		elems = append(elems, plan.elems...)
+		keyPlans = append(keyPlans, plan)
 	}
 
-	if len(elems) == 0 {
-		return nil
+	if len(elems) > 0 {
+		dispatchCtx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
+		defer cancel()
+		startTS := c.startTS
+		if startTS == ^uint64(0) {
+			startTS = 0
+		}
+		if _, err := c.server.coordinator.Dispatch(dispatchCtx, &kv.OperationGroup[kv.OP]{
+			IsTxn:    true,
+			StartTS:  startTS,
+			CommitTS: commitTS,
+			Elems:    elems,
+		}); err != nil {
+			return errors.WithStack(err)
+		}
 	}
-	dispatchCtx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
-	defer cancel()
-	startTS := c.startTS
-	if startTS == ^uint64(0) {
-		startTS = 0
+
+	// Flush TTL to the in-memory buffer after a successful data commit.
+	// TTL is excluded from the IsTxn=true transaction to eliminate write
+	// conflicts on redisTTLKey from concurrent EXPIRE/EVALSHA operations.
+	for i, key := range keys {
+		c.flushTTLForKeyToBuffer(key, keyPlans[i].finalType, keyPlans[i].preserveExisting)
 	}
-	_, err := c.server.coordinator.Dispatch(dispatchCtx, &kv.OperationGroup[kv.OP]{
-		IsTxn:    true,
-		StartTS:  startTS,
-		CommitTS: commitTS,
-		Elems:    elems,
-	})
-	return errors.WithStack(err)
+	return nil
 }
 
-func (c *luaScriptContext) commitElemsForKey(ctx context.Context, key string, commitTS uint64) ([]*kv.Elem[kv.OP], error) {
+// commitPlanForKey builds the data Raft elements for a single key (TTL excluded).
+func (c *luaScriptContext) commitPlanForKey(ctx context.Context, key string, commitTS uint64) (luaKeyPlan, error) {
 	finalType, err := c.finalType([]byte(key))
 	if err != nil {
-		return nil, err
+		return luaKeyPlan{}, err
 	}
 
 	valuePlan, err := c.valueCommitPlan(key, finalType, commitTS)
 	if err != nil {
-		return nil, err
+		return luaKeyPlan{}, err
 	}
 
 	var deleteElems []*kv.Elem[kv.OP]
 	if !valuePlan.preserveExisting {
 		deleteElems, _, err = c.server.deleteLogicalKeyElems(ctx, []byte(key), c.startTS)
 		if err != nil {
-			return nil, err
+			return luaKeyPlan{}, err
 		}
 	}
-	ttlElems, err := c.ttlCommitElems(key, finalType, valuePlan.preserveExisting)
-	if err != nil {
-		return nil, err
-	}
 
-	elems := make([]*kv.Elem[kv.OP], 0, len(deleteElems)+len(valuePlan.elems)+len(ttlElems))
-	elems = append(elems, deleteElems...)
-	elems = append(elems, valuePlan.elems...)
-	elems = append(elems, ttlElems...)
-	return elems, nil
+	dataElems := make([]*kv.Elem[kv.OP], 0, len(deleteElems)+len(valuePlan.elems))
+	dataElems = append(dataElems, deleteElems...)
+	dataElems = append(dataElems, valuePlan.elems...)
+	return luaKeyPlan{
+		elems:            dataElems,
+		finalType:        finalType,
+		preserveExisting: valuePlan.preserveExisting,
+	}, nil
+}
+
+// flushTTLForKeyToBuffer writes the TTL for a single key to the server's
+// TTLBuffer. Only keys with a non-None final type and a dirty TTL state
+// (or an unconditionally-set TTL) are written.
+func (c *luaScriptContext) flushTTLForKeyToBuffer(key string, finalType redisValueType, preserveExisting bool) {
+	if finalType == redisTypeNone {
+		return
+	}
+	if preserveExisting {
+		if st := c.ttls[key]; st == nil || !st.dirty {
+			return
+		}
+	}
+	ttl, err := c.finalTTL([]byte(key))
+	if err != nil {
+		return
+	}
+	if ttl == nil {
+		if preserveExisting {
+			c.server.ttlBuffer.Set([]byte(key), nil)
+		}
+		return
+	}
+	c.server.ttlBuffer.Set([]byte(key), ttl)
 }
 
 func (c *luaScriptContext) valueCommitPlan(key string, finalType redisValueType, commitTS uint64) (luaCommitPlan, error) {
@@ -2720,30 +2762,6 @@ func (c *luaScriptContext) streamCommitElems(key string) ([]*kv.Elem[kv.OP], err
 		return nil, err
 	}
 	return []*kv.Elem[kv.OP]{{Op: kv.Put, Key: redisStreamKey([]byte(key)), Value: payload}}, nil
-}
-
-func (c *luaScriptContext) ttlCommitElems(key string, finalType redisValueType, preserveExisting bool) ([]*kv.Elem[kv.OP], error) {
-	if finalType == redisTypeNone {
-		return nil, nil
-	}
-	if preserveExisting {
-		if st := c.ttls[key]; st == nil || !st.dirty {
-			return nil, nil
-		}
-	}
-
-	ttl, err := c.finalTTL([]byte(key))
-	if err != nil {
-		return nil, err
-	}
-	if ttl == nil {
-		if preserveExisting {
-			return []*kv.Elem[kv.OP]{{Op: kv.Del, Key: redisTTLKey([]byte(key))}}, nil
-		}
-		return nil, nil
-	}
-
-	return []*kv.Elem[kv.OP]{{Op: kv.Put, Key: redisTTLKey([]byte(key)), Value: encodeRedisTTL(*ttl)}}, nil
 }
 
 func (c *luaScriptContext) finalType(key []byte) (redisValueType, error) {

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -2511,10 +2511,14 @@ func (c *luaScriptContext) commitPlanForKey(ctx context.Context, key string, com
 }
 
 // flushTTLForKeyToBuffer writes the TTL for a single key to the server's
-// TTLBuffer. Only keys with a non-None final type and a dirty TTL state
-// (or an unconditionally-set TTL) are written.
+// TTLBuffer. Keys deleted by the script (finalType==None) write a nil TTL when
+// the Lua TTL state is dirty to clear pending/persisted expiry. For non-None
+// keys, only dirty TTL state (or unconditionally-set TTL) is written.
 func (c *luaScriptContext) flushTTLForKeyToBuffer(key string, finalType redisValueType, preserveExisting bool) {
 	if finalType == redisTypeNone {
+		if st := c.ttls[key]; st != nil && st.dirty {
+			c.server.ttlBuffer.Set([]byte(key), nil)
+		}
 		return
 	}
 	if preserveExisting {

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -2426,8 +2426,8 @@ type luaCommitPlan struct {
 
 // luaKeyPlan carries the data elements and TTL metadata for a single key commit.
 type luaKeyPlan struct {
-	elems           []*kv.Elem[kv.OP]
-	finalType       redisValueType
+	elems            []*kv.Elem[kv.OP]
+	finalType        redisValueType
 	preserveExisting bool
 }
 

--- a/adapter/redis_lua_context_test.go
+++ b/adapter/redis_lua_context_test.go
@@ -1,0 +1,44 @@
+package adapter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLuaFlushTTLForDeletedKey_DirtyStateClearsBufferedTTL(t *testing.T) {
+	t.Parallel()
+	b := newTTLBufferWithMaxSize(8)
+	expireAt := time.Now().Add(time.Minute)
+	b.Set([]byte("k"), &expireAt)
+
+	c := &luaScriptContext{
+		server: &RedisServer{ttlBuffer: b},
+		ttls: map[string]*luaTTLState{
+			"k": {dirty: true},
+		},
+	}
+
+	c.flushTTLForKeyToBuffer("k", redisTypeNone, false)
+
+	got, found := b.Get([]byte("k"))
+	require.True(t, found)
+	require.Nil(t, got)
+}
+
+func TestLuaFlushTTLForDeletedKey_CleanStateDoesNotWriteBuffer(t *testing.T) {
+	t.Parallel()
+	b := newTTLBufferWithMaxSize(8)
+	c := &luaScriptContext{
+		server: &RedisServer{ttlBuffer: b},
+		ttls: map[string]*luaTTLState{
+			"k": {dirty: false},
+		},
+	}
+
+	c.flushTTLForKeyToBuffer("k", redisTypeNone, false)
+
+	_, found := b.Get([]byte("k"))
+	require.False(t, found)
+}

--- a/adapter/redis_multi_test.go
+++ b/adapter/redis_multi_test.go
@@ -220,3 +220,29 @@ func TestRedis_MultiExec_DelThenRPushRecreatesList(t *testing.T) {
 	}
 	require.Equal(t, []string{"new1", "new2"}, got)
 }
+
+func TestRedis_MultiExec_SetGetAfterDeleteReturnsNilOldValue(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	ctx := context.Background()
+
+	require.NoError(t, rdb.Set(ctx, "sg:del", "v1", 0).Err())
+	require.Equal(t, "OK", rdb.Do(ctx, "MULTI").Val())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "DEL", "sg:del").Val())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "SET", "sg:del", "v2", "GET").Val())
+
+	execRes, err := rdb.Do(ctx, "EXEC").Result()
+	require.NoError(t, err)
+	vals, ok := execRes.([]any)
+	require.True(t, ok)
+	require.Len(t, vals, 2)
+	require.Equal(t, int64(1), vals[0])
+	require.Nil(t, vals[1], "SET GET should see key as missing after staged DEL")
+
+	got, err := rdb.Get(ctx, "sg:del").Result()
+	require.NoError(t, err)
+	require.Equal(t, "v2", got)
+}

--- a/adapter/redis_ttl_buffer.go
+++ b/adapter/redis_ttl_buffer.go
@@ -33,11 +33,20 @@ type TTLBuffer struct {
 	mu      sync.RWMutex
 	entries map[string]ttlBufferEntry
 	counter atomic.Uint64
+	maxSize int
 }
 
 func newTTLBuffer() *TTLBuffer {
+	return newTTLBufferWithMaxSize(ttlBufferMaxSize)
+}
+
+func newTTLBufferWithMaxSize(maxSize int) *TTLBuffer {
+	if maxSize <= 0 {
+		maxSize = ttlBufferMaxSize
+	}
 	return &TTLBuffer{
 		entries: make(map[string]ttlBufferEntry),
+		maxSize: maxSize,
 	}
 }
 
@@ -59,7 +68,7 @@ func (b *TTLBuffer) Set(key []byte, expireAt *time.Time) {
 	if e, ok := b.entries[k]; ok && e.seq > s {
 		return
 	}
-	if _, exists := b.entries[k]; !exists && len(b.entries) >= ttlBufferMaxSize {
+	if _, exists := b.entries[k]; !exists && len(b.entries) >= b.maxSize {
 		slog.Warn("ttl buffer full, dropping entry", "size", len(b.entries), "key_len", len(k))
 		return
 	}
@@ -112,7 +121,7 @@ func (b *TTLBuffer) MergeBack(entries map[string]ttlBufferEntry) {
 			if e.seq > entry.seq {
 				continue // a newer write supersedes the failed entry
 			}
-		} else if len(b.entries) >= ttlBufferMaxSize {
+		} else if len(b.entries) >= b.maxSize {
 			continue // buffer full; drop the restored entry rather than growing unbounded
 		}
 		b.entries[key] = entry

--- a/adapter/redis_ttl_buffer.go
+++ b/adapter/redis_ttl_buffer.go
@@ -15,6 +15,8 @@ const (
 	defaultTTLFlushInterval = 100 * time.Millisecond
 	ttlShutdownFlushAttempts = 3
 	ttlShutdownFlushBackoff  = 100 * time.Millisecond
+	// Rate-limit buffer-drop logs to the first drop and then each Nth drop.
+	ttlBufferDropLogEvery = 1024
 	// ttlBufferMaxSize is the maximum number of entries retained in the buffer.
 	// Entries beyond this limit are dropped with a warning; the Raft store still
 	// holds the last flushed value so the impact is limited to a missed update.
@@ -86,10 +88,7 @@ func (b *TTLBuffer) Set(key []byte, expireAt *time.Time) {
 logDrop:
 	// Log outside the mutex and rate-limit to avoid lock contention/log spam under overload.
 	dropCount := b.dropped.Add(1)
-	if dropCount == ^uint64(0) {
-		b.dropped.Store(0)
-	}
-	if dropCount == 1 || dropCount%1024 == 0 {
+	if dropCount == 1 || dropCount%ttlBufferDropLogEvery == 0 {
 		slog.Warn("ttl buffer full, dropping entry", "size", size, "key_len", keyLen, "dropped", dropCount)
 	}
 }
@@ -128,22 +127,41 @@ func (b *TTLBuffer) Drain() map[string]ttlBufferEntry {
 // MergeBack re-inserts entries from a failed flush attempt.
 // For each key, the entry is only restored if the buffer does not already hold
 // a newer write (higher seq) for that key. Keys that are new to the current
-// buffer are skipped once the buffer is full (same policy as Set).
+// buffer are skipped once the buffer is full (same policy as Set), and dropped
+// entries are counted/logged to make recovery-path loss observable.
 func (b *TTLBuffer) MergeBack(entries map[string]ttlBufferEntry) {
 	if len(entries) == 0 {
 		return
 	}
 	b.mu.Lock()
-	defer b.mu.Unlock()
+	dropped := 0
+	size := 0
 	for key, entry := range entries {
 		if e, ok := b.entries[key]; ok {
 			if e.seq > entry.seq {
 				continue // a newer write supersedes the failed entry
 			}
 		} else if len(b.entries) >= b.maxSize {
+			dropped++
 			continue // buffer full; drop the restored entry rather than growing unbounded
 		}
 		b.entries[key] = entry
+	}
+	size = len(b.entries)
+	b.mu.Unlock()
+
+	if dropped == 0 {
+		return
+	}
+	dropCount := b.dropped.Add(uint64(dropped))
+	prevDropCount := dropCount - uint64(dropped)
+	if prevDropCount == 0 || prevDropCount/ttlBufferDropLogEvery != dropCount/ttlBufferDropLogEvery {
+		slog.Warn(
+			"ttl buffer merge-back dropped entries",
+			"size", size,
+			"dropped", dropped,
+			"total_dropped", dropCount,
+		)
 	}
 }
 

--- a/adapter/redis_ttl_buffer.go
+++ b/adapter/redis_ttl_buffer.go
@@ -40,6 +40,8 @@ func newTTLBuffer() *TTLBuffer {
 	return newTTLBufferWithMaxSize(ttlBufferMaxSize)
 }
 
+// newTTLBufferWithMaxSize exists for tests that need a smaller buffer limit.
+// Non-positive maxSize falls back to ttlBufferMaxSize.
 func newTTLBufferWithMaxSize(maxSize int) *TTLBuffer {
 	if maxSize <= 0 {
 		maxSize = ttlBufferMaxSize

--- a/adapter/redis_ttl_buffer.go
+++ b/adapter/redis_ttl_buffer.go
@@ -61,7 +61,7 @@ func (b *TTLBuffer) Set(key []byte, expireAt *time.Time) {
 		return
 	}
 	if _, exists := b.entries[k]; !exists && len(b.entries) >= ttlBufferMaxSize {
-		slog.Warn("ttl buffer full, dropping entry", "size", len(b.entries), "key", k)
+		slog.Warn("ttl buffer full, dropping entry", "size", len(b.entries), "key_len", len(k))
 		return
 	}
 	b.entries[k] = ttlBufferEntry{expireAt: expireAt, seq: s}
@@ -100,7 +100,8 @@ func (b *TTLBuffer) Drain() map[string]ttlBufferEntry {
 
 // MergeBack re-inserts entries from a failed flush attempt.
 // For each key, the entry is only restored if the buffer does not already hold
-// a newer write (higher seq) for that key.
+// a newer write (higher seq) for that key. Keys that are new to the current
+// buffer are skipped once the buffer is full (same policy as Set).
 func (b *TTLBuffer) MergeBack(entries map[string]ttlBufferEntry) {
 	if len(entries) == 0 {
 		return
@@ -108,8 +109,12 @@ func (b *TTLBuffer) MergeBack(entries map[string]ttlBufferEntry) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	for key, entry := range entries {
-		if e, ok := b.entries[key]; ok && e.seq > entry.seq {
-			continue // a newer write supersedes the failed entry
+		if e, ok := b.entries[key]; ok {
+			if e.seq > entry.seq {
+				continue // a newer write supersedes the failed entry
+			}
+		} else if len(b.entries) >= ttlBufferMaxSize {
+			continue // buffer full; drop the restored entry rather than growing unbounded
 		}
 		b.entries[key] = entry
 	}
@@ -150,7 +155,7 @@ func buildTTLFlushElems(entries map[string]ttlBufferEntry) []*kv.Elem[kv.OP] {
 // runTTLFlusher periodically flushes the TTL buffer to Raft until ctx is cancelled.
 // On cancellation it performs one final flush to minimise TTL loss during shutdown.
 func (r *RedisServer) runTTLFlusher(ctx context.Context) {
-	ticker := time.NewTicker(defaultTTLFlushInterval)
+	ticker := time.NewTicker(r.ttlFlushInterval)
 	defer ticker.Stop()
 	for {
 		select {

--- a/adapter/redis_ttl_buffer.go
+++ b/adapter/redis_ttl_buffer.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/bootjp/elastickv/kv"
-	"github.com/cockroachdb/errors"
 )
 
 const (
@@ -184,7 +183,11 @@ func (r *RedisServer) flushTTLBuffer(ctx context.Context) {
 		IsTxn: false, // no conflict detection; last writer wins
 		Elems: elems,
 	})
-	if err != nil && !errors.Is(err, context.Canceled) {
+	if err != nil {
+		// MergeBack on any error, including context.Canceled.
+		// If a ticker tick races with shutdown (ctx already canceled), MergeBack
+		// ensures those entries are not lost: the final shutdown flush uses
+		// context.Background() and will retry them successfully.
 		r.ttlBuffer.MergeBack(entries)
 		slog.Warn("ttl buffer flush failed, will retry", "err", err, "entries", len(entries))
 	}

--- a/adapter/redis_ttl_buffer.go
+++ b/adapter/redis_ttl_buffer.go
@@ -1,0 +1,186 @@
+package adapter
+
+import (
+	"context"
+	"log/slog"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/bootjp/elastickv/kv"
+	"github.com/cockroachdb/errors"
+)
+
+const (
+	defaultTTLFlushInterval = 100 * time.Millisecond
+	// ttlBufferMaxSize is the maximum number of entries retained in the buffer.
+	// Entries beyond this limit are dropped with a warning; the Raft store still
+	// holds the last flushed value so the impact is limited to a missed update.
+	ttlBufferMaxSize = 1_000_000
+)
+
+// ttlBufferEntry holds a pending TTL update for a single user key.
+// expireAt == nil represents a TTL deletion (PERSIST semantics).
+type ttlBufferEntry struct {
+	expireAt *time.Time
+	seq      uint64 // monotonically increasing; later writes win on the same key
+}
+
+// TTLBuffer is a thread-safe in-memory buffer for pending TTL writes.
+// Entries are flushed to Raft in batches by a background goroutine, which
+// eliminates TTL write conflicts from concurrent Lua script executions.
+type TTLBuffer struct {
+	mu      sync.RWMutex
+	entries map[string]ttlBufferEntry
+	counter atomic.Uint64
+}
+
+func newTTLBuffer() *TTLBuffer {
+	return &TTLBuffer{
+		entries: make(map[string]ttlBufferEntry),
+	}
+}
+
+// Set writes a TTL entry for key into the buffer.
+// expireAt == nil marks the TTL for deletion (PERSIST).
+// Concurrent calls for the same key are resolved by keeping the latest seq.
+// Set is a no-op on a nil *TTLBuffer.
+// If the buffer already holds ttlBufferMaxSize distinct keys and key is new,
+// the entry is dropped with a warning; the Raft store retains the last flushed
+// value so the impact is limited to a missed in-flight update.
+func (b *TTLBuffer) Set(key []byte, expireAt *time.Time) {
+	if b == nil {
+		return
+	}
+	s := b.counter.Add(1)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	k := string(key)
+	if e, ok := b.entries[k]; ok && e.seq > s {
+		return
+	}
+	if _, exists := b.entries[k]; !exists && len(b.entries) >= ttlBufferMaxSize {
+		slog.Warn("ttl buffer full, dropping entry", "size", len(b.entries), "key", k)
+		return
+	}
+	b.entries[k] = ttlBufferEntry{expireAt: expireAt, seq: s}
+}
+
+// Get returns the buffered TTL for key.
+// found=false means no buffered entry; callers should fall back to the Raft store.
+// A nil expireAt with found=true means TTL was explicitly deleted (PERSIST).
+// Get is safe to call on a nil *TTLBuffer and always returns (nil, false).
+func (b *TTLBuffer) Get(key []byte) (expireAt *time.Time, found bool) {
+	if b == nil {
+		return nil, false
+	}
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	e, ok := b.entries[string(key)]
+	if !ok {
+		return nil, false
+	}
+	return e.expireAt, true
+}
+
+// Drain atomically snapshots all buffer entries and resets the buffer.
+// The returned map is owned by the caller. The buffer may accept new writes
+// concurrently after this call returns.
+func (b *TTLBuffer) Drain() map[string]ttlBufferEntry {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.entries) == 0 {
+		return nil
+	}
+	snapshot := b.entries
+	b.entries = make(map[string]ttlBufferEntry, len(snapshot))
+	return snapshot
+}
+
+// MergeBack re-inserts entries from a failed flush attempt.
+// For each key, the entry is only restored if the buffer does not already hold
+// a newer write (higher seq) for that key.
+func (b *TTLBuffer) MergeBack(entries map[string]ttlBufferEntry) {
+	if len(entries) == 0 {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for key, entry := range entries {
+		if e, ok := b.entries[key]; ok && e.seq > entry.seq {
+			continue // a newer write supersedes the failed entry
+		}
+		b.entries[key] = entry
+	}
+}
+
+// Len returns the number of buffered entries.
+func (b *TTLBuffer) Len() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.entries)
+}
+
+// buildTTLFlushElems converts a drained snapshot into Raft kv elements.
+// Keys are sorted for deterministic Raft log ordering.
+func buildTTLFlushElems(entries map[string]ttlBufferEntry) []*kv.Elem[kv.OP] {
+	keys := make([]string, 0, len(entries))
+	for k := range entries {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	elems := make([]*kv.Elem[kv.OP], 0, len(entries))
+	for _, key := range keys {
+		entry := entries[key]
+		if entry.expireAt == nil {
+			elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisTTLKey([]byte(key))})
+		} else {
+			elems = append(elems, &kv.Elem[kv.OP]{
+				Op:    kv.Put,
+				Key:   redisTTLKey([]byte(key)),
+				Value: encodeRedisTTL(*entry.expireAt),
+			})
+		}
+	}
+	return elems
+}
+
+// runTTLFlusher periodically flushes the TTL buffer to Raft until ctx is cancelled.
+// On cancellation it performs one final flush to minimise TTL loss during shutdown.
+func (r *RedisServer) runTTLFlusher(ctx context.Context) {
+	ticker := time.NewTicker(defaultTTLFlushInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			r.flushTTLBuffer(ctx)
+		case <-ctx.Done():
+			r.flushTTLBuffer(context.Background())
+			return
+		}
+	}
+}
+
+// flushTTLBuffer drains the buffer and dispatches the entries to Raft as a
+// non-transactional (last-writer-wins) operation group.
+// On failure the entries are merged back into the buffer for retry on the next tick.
+func (r *RedisServer) flushTTLBuffer(ctx context.Context) {
+	entries := r.ttlBuffer.Drain()
+	if len(entries) == 0 {
+		return
+	}
+
+	elems := buildTTLFlushElems(entries)
+	flushCtx, cancel := context.WithTimeout(ctx, redisDispatchTimeout)
+	defer cancel()
+	_, err := r.coordinator.Dispatch(flushCtx, &kv.OperationGroup[kv.OP]{
+		IsTxn: false, // no conflict detection; last writer wins
+		Elems: elems,
+	})
+	if err != nil && !errors.Is(err, context.Canceled) {
+		r.ttlBuffer.MergeBack(entries)
+		slog.Warn("ttl buffer flush failed, will retry", "err", err, "entries", len(entries))
+	}
+}

--- a/adapter/redis_ttl_buffer.go
+++ b/adapter/redis_ttl_buffer.go
@@ -12,9 +12,11 @@ import (
 )
 
 const (
-	defaultTTLFlushInterval = 100 * time.Millisecond
+	defaultTTLFlushInterval  = 100 * time.Millisecond
 	ttlShutdownFlushAttempts = 3
 	ttlShutdownFlushBackoff  = 100 * time.Millisecond
+	// Flush at most this many TTL updates per dispatch to avoid oversized raft ops.
+	ttlFlushBatchMax = 4096
 	// Rate-limit buffer-drop logs to the first drop and then each Nth drop.
 	ttlBufferDropLogEvery = 1024
 	// ttlBufferMaxSize is the maximum number of entries retained in the buffer.
@@ -124,6 +126,32 @@ func (b *TTLBuffer) Drain() map[string]ttlBufferEntry {
 	return snapshot
 }
 
+// DrainN atomically snapshots up to limit entries and removes them from
+// the buffer. If limit <= 0, all entries are drained.
+func (b *TTLBuffer) DrainN(limit int) map[string]ttlBufferEntry {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.entries) == 0 {
+		return nil
+	}
+	if limit <= 0 || limit >= len(b.entries) {
+		snapshot := b.entries
+		b.entries = make(map[string]ttlBufferEntry)
+		return snapshot
+	}
+	snapshot := make(map[string]ttlBufferEntry, limit)
+	count := 0
+	for key, entry := range b.entries {
+		snapshot[key] = entry
+		delete(b.entries, key)
+		count++
+		if count >= limit {
+			break
+		}
+	}
+	return snapshot
+}
+
 // MergeBack re-inserts entries from a failed flush attempt.
 // For each key, the entry is only restored if the buffer does not already hold
 // a newer write (higher seq) for that key. Keys that are new to the current
@@ -135,7 +163,7 @@ func (b *TTLBuffer) MergeBack(entries map[string]ttlBufferEntry) {
 	}
 	b.mu.Lock()
 	dropped := 0
-	size := 0
+	var size int
 	for key, entry := range entries {
 		if e, ok := b.entries[key]; ok {
 			if e.seq > entry.seq {
@@ -232,11 +260,10 @@ func (r *RedisServer) runTTLFlusher(ctx context.Context) {
 // non-transactional (last-writer-wins) operation group.
 // On failure the entries are merged back into the buffer for retry on the next tick.
 func (r *RedisServer) flushTTLBuffer(ctx context.Context, shutdown bool) bool {
-	entries := r.ttlBuffer.Drain()
+	entries := r.ttlBuffer.DrainN(ttlFlushBatchMax)
 	if len(entries) == 0 {
 		return true
 	}
-
 	elems := buildTTLFlushElems(entries)
 	flushCtx, cancel := context.WithTimeout(ctx, redisDispatchTimeout)
 	defer cancel()
@@ -257,5 +284,5 @@ func (r *RedisServer) flushTTLBuffer(ctx context.Context, shutdown bool) bool {
 		}
 		return false
 	}
-	return true
+	return r.ttlBuffer.Len() == 0
 }

--- a/adapter/redis_ttl_buffer.go
+++ b/adapter/redis_ttl_buffer.go
@@ -33,6 +33,7 @@ type TTLBuffer struct {
 	mu      sync.RWMutex
 	entries map[string]ttlBufferEntry
 	counter atomic.Uint64
+	dropped atomic.Uint64
 	maxSize int
 }
 
@@ -63,18 +64,36 @@ func (b *TTLBuffer) Set(key []byte, expireAt *time.Time) {
 	if b == nil {
 		return
 	}
+	var (
+		size   int
+		keyLen int
+	)
 	s := b.counter.Add(1)
 	b.mu.Lock()
-	defer b.mu.Unlock()
 	k := string(key)
 	if e, ok := b.entries[k]; ok && e.seq > s {
+		b.mu.Unlock()
 		return
 	}
 	if _, exists := b.entries[k]; !exists && len(b.entries) >= b.maxSize {
-		slog.Warn("ttl buffer full, dropping entry", "size", len(b.entries), "key_len", len(k))
-		return
+		size = len(b.entries)
+		keyLen = len(k)
+		b.mu.Unlock()
+		goto logDrop
 	}
 	b.entries[k] = ttlBufferEntry{expireAt: expireAt, seq: s}
+	b.mu.Unlock()
+	return
+
+logDrop:
+	// Log outside the mutex and rate-limit to avoid lock contention/log spam under overload.
+	dropCount := b.dropped.Add(1)
+	if dropCount == ^uint64(0) {
+		b.dropped.Store(0)
+	}
+	if dropCount == 1 || dropCount%1024 == 0 {
+		slog.Warn("ttl buffer full, dropping entry", "size", size, "key_len", keyLen, "dropped", dropCount)
+	}
 }
 
 // Get returns the buffered TTL for key.
@@ -104,7 +123,7 @@ func (b *TTLBuffer) Drain() map[string]ttlBufferEntry {
 		return nil
 	}
 	snapshot := b.entries
-	b.entries = make(map[string]ttlBufferEntry, len(snapshot))
+	b.entries = make(map[string]ttlBufferEntry)
 	return snapshot
 }
 

--- a/adapter/redis_ttl_buffer.go
+++ b/adapter/redis_ttl_buffer.go
@@ -59,7 +59,7 @@ func newTTLBufferWithMaxSize(maxSize int) *TTLBuffer {
 // expireAt == nil marks the TTL for deletion (PERSIST).
 // Concurrent calls for the same key are resolved by keeping the latest seq.
 // Set is a no-op on a nil *TTLBuffer.
-// If the buffer already holds ttlBufferMaxSize distinct keys and key is new,
+// If the buffer already holds b.maxSize distinct keys and key is new,
 // the entry is dropped with a warning; the Raft store retains the last flushed
 // value so the impact is limited to a missed in-flight update.
 func (b *TTLBuffer) Set(key []byte, expireAt *time.Time) {
@@ -73,10 +73,6 @@ func (b *TTLBuffer) Set(key []byte, expireAt *time.Time) {
 	s := b.counter.Add(1)
 	b.mu.Lock()
 	k := string(key)
-	if e, ok := b.entries[k]; ok && e.seq > s {
-		b.mu.Unlock()
-		return
-	}
 	if _, exists := b.entries[k]; !exists && len(b.entries) >= b.maxSize {
 		size = len(b.entries)
 		keyLen = len(k)

--- a/adapter/redis_ttl_buffer.go
+++ b/adapter/redis_ttl_buffer.go
@@ -13,6 +13,8 @@ import (
 
 const (
 	defaultTTLFlushInterval = 100 * time.Millisecond
+	ttlShutdownFlushAttempts = 3
+	ttlShutdownFlushBackoff  = 100 * time.Millisecond
 	// ttlBufferMaxSize is the maximum number of entries retained in the buffer.
 	// Entries beyond this limit are dropped with a warning; the Raft store still
 	// holds the last flushed value so the impact is limited to a missed update.
@@ -182,16 +184,31 @@ func buildTTLFlushElems(entries map[string]ttlBufferEntry) []*kv.Elem[kv.OP] {
 }
 
 // runTTLFlusher periodically flushes the TTL buffer to Raft until ctx is cancelled.
-// On cancellation it performs one final flush to minimise TTL loss during shutdown.
+// On cancellation it performs bounded final-flush retries to minimise TTL loss
+// during shutdown and logs if entries remain unflushed.
 func (r *RedisServer) runTTLFlusher(ctx context.Context) {
 	ticker := time.NewTicker(r.ttlFlushInterval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
-			r.flushTTLBuffer(ctx)
+			r.flushTTLBuffer(ctx, false)
 		case <-ctx.Done():
-			r.flushTTLBuffer(context.Background())
+			for attempt := 1; attempt <= ttlShutdownFlushAttempts; attempt++ {
+				if r.flushTTLBuffer(context.Background(), true) {
+					return
+				}
+				if attempt < ttlShutdownFlushAttempts {
+					time.Sleep(ttlShutdownFlushBackoff)
+				}
+			}
+			if remaining := r.ttlBuffer.Len(); remaining > 0 {
+				slog.Warn(
+					"ttl buffer shutdown flush incomplete",
+					"remaining_entries", remaining,
+					"attempts", ttlShutdownFlushAttempts,
+				)
+			}
 			return
 		}
 	}
@@ -200,10 +217,10 @@ func (r *RedisServer) runTTLFlusher(ctx context.Context) {
 // flushTTLBuffer drains the buffer and dispatches the entries to Raft as a
 // non-transactional (last-writer-wins) operation group.
 // On failure the entries are merged back into the buffer for retry on the next tick.
-func (r *RedisServer) flushTTLBuffer(ctx context.Context) {
+func (r *RedisServer) flushTTLBuffer(ctx context.Context, shutdown bool) bool {
 	entries := r.ttlBuffer.Drain()
 	if len(entries) == 0 {
-		return
+		return true
 	}
 
 	elems := buildTTLFlushElems(entries)
@@ -219,6 +236,12 @@ func (r *RedisServer) flushTTLBuffer(ctx context.Context) {
 		// ensures those entries are not lost: the final shutdown flush uses
 		// context.Background() and will retry them successfully.
 		r.ttlBuffer.MergeBack(entries)
-		slog.Warn("ttl buffer flush failed, will retry", "err", err, "entries", len(entries))
+		if shutdown {
+			slog.Warn("ttl buffer shutdown flush attempt failed", "err", err, "entries", len(entries))
+		} else {
+			slog.Warn("ttl buffer flush failed, will retry on next tick", "err", err, "entries", len(entries))
+		}
+		return false
 	}
+	return true
 }

--- a/adapter/redis_ttl_buffer_test.go
+++ b/adapter/redis_ttl_buffer_test.go
@@ -151,19 +151,20 @@ func TestTTLBuffer_NilReceiver_SetIsNoop(t *testing.T) {
 // Existing keys must still be updatable.
 func TestTTLBuffer_Full_DropsNewKey(t *testing.T) {
 	t.Parallel()
-	b := newTTLBuffer()
+	const testMaxSize = 8
+	b := newTTLBufferWithMaxSize(testMaxSize)
 
 	// Fill the map to exactly ttlBufferMaxSize via direct struct access so the
 	// test runs in O(N) map writes without going through the seq machinery.
 	b.mu.Lock()
 	var seq uint64
-	for i := range ttlBufferMaxSize {
+	for i := range testMaxSize {
 		seq++
 		b.entries[fmt.Sprintf("slot:%d", i)] = ttlBufferEntry{seq: seq}
 	}
 	b.mu.Unlock()
 
-	require.Equal(t, ttlBufferMaxSize, b.Len())
+	require.Equal(t, testMaxSize, b.Len())
 
 	// A brand-new key must be dropped.
 	expireAt := time.Now().Add(time.Minute)

--- a/adapter/redis_ttl_buffer_test.go
+++ b/adapter/redis_ttl_buffer_test.go
@@ -1,0 +1,366 @@
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bootjp/elastickv/kv"
+	"github.com/bootjp/elastickv/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ────────────────────────────────────────────────────────────────
+// TTLBuffer — unit tests
+// ────────────────────────────────────────────────────────────────
+
+func TestTTLBuffer_SetAndGet(t *testing.T) {
+	t.Parallel()
+	b := newTTLBuffer()
+	expireAt := time.Now().Add(time.Minute)
+
+	b.Set([]byte("k"), &expireAt)
+
+	got, found := b.Get([]byte("k"))
+	require.True(t, found)
+	require.NotNil(t, got)
+	require.Equal(t, expireAt.UnixNano(), got.UnixNano())
+}
+
+func TestTTLBuffer_GetMissReturnsFalse(t *testing.T) {
+	t.Parallel()
+	b := newTTLBuffer()
+
+	got, found := b.Get([]byte("missing"))
+	require.False(t, found)
+	require.Nil(t, got)
+}
+
+// Set(key, nil) represents PERSIST semantics: the TTL was explicitly removed.
+// Get must return (nil, true) — "found but no expiry".
+func TestTTLBuffer_SetNilIsPersistFound(t *testing.T) {
+	t.Parallel()
+	b := newTTLBuffer()
+
+	b.Set([]byte("k"), nil)
+
+	got, found := b.Get([]byte("k"))
+	require.True(t, found, "PERSIST entry must be found in buffer")
+	require.Nil(t, got, "PERSIST entry must have nil expireAt")
+}
+
+// A second Set with a higher seq must overwrite a previous Set.
+func TestTTLBuffer_LaterSetWins(t *testing.T) {
+	t.Parallel()
+	b := newTTLBuffer()
+	t1 := time.Now().Add(10 * time.Second)
+	t2 := time.Now().Add(20 * time.Second)
+
+	b.Set([]byte("k"), &t1)
+	b.Set([]byte("k"), &t2)
+
+	got, found := b.Get([]byte("k"))
+	require.True(t, found)
+	require.Equal(t, t2.UnixNano(), got.UnixNano())
+}
+
+func TestTTLBuffer_Drain_ReturnsSnapshotAndClearsBuffer(t *testing.T) {
+	t.Parallel()
+	b := newTTLBuffer()
+	expireAt := time.Now().Add(time.Minute)
+	b.Set([]byte("a"), &expireAt)
+	b.Set([]byte("b"), nil)
+
+	snapshot := b.Drain()
+
+	require.Len(t, snapshot, 2)
+	require.Contains(t, snapshot, "a")
+	require.Contains(t, snapshot, "b")
+	require.Equal(t, 0, b.Len(), "buffer must be empty after Drain")
+}
+
+func TestTTLBuffer_Drain_EmptyReturnsNil(t *testing.T) {
+	t.Parallel()
+	b := newTTLBuffer()
+
+	snapshot := b.Drain()
+	require.Nil(t, snapshot)
+}
+
+// MergeBack must NOT restore a failed entry if a newer write already exists.
+func TestTTLBuffer_MergeBack_NewerWriteWins(t *testing.T) {
+	t.Parallel()
+	b := newTTLBuffer()
+
+	// First write — goes into the buffer.
+	old := time.Now().Add(10 * time.Second)
+	b.Set([]byte("k"), &old)
+	snapshot := b.Drain() // grab the entry (seq == 1)
+
+	// New write arrives while the flush (using snapshot) was in-flight.
+	newer := time.Now().Add(60 * time.Second)
+	b.Set([]byte("k"), &newer) // seq == 2
+
+	// Simulate flush failure: merge the old snapshot back.
+	b.MergeBack(snapshot)
+
+	// The buffer must keep the newer value (seq=2), not the merged-back one (seq=1).
+	got, found := b.Get([]byte("k"))
+	require.True(t, found)
+	require.Equal(t, newer.UnixNano(), got.UnixNano(),
+		"MergeBack must not overwrite a newer in-buffer write")
+}
+
+// MergeBack must restore an entry when no concurrent write occurred.
+func TestTTLBuffer_MergeBack_RestoresWhenNoNewerWrite(t *testing.T) {
+	t.Parallel()
+	b := newTTLBuffer()
+	expireAt := time.Now().Add(time.Minute)
+	b.Set([]byte("k"), &expireAt)
+	snapshot := b.Drain()
+
+	// No new Set — buffer is now empty.
+	b.MergeBack(snapshot)
+
+	got, found := b.Get([]byte("k"))
+	require.True(t, found)
+	require.Equal(t, expireAt.UnixNano(), got.UnixNano())
+}
+
+// A nil *TTLBuffer must not panic on Get.
+func TestTTLBuffer_NilReceiver_GetIsNoop(t *testing.T) {
+	t.Parallel()
+	var b *TTLBuffer
+	got, found := b.Get([]byte("k"))
+	require.False(t, found)
+	require.Nil(t, got)
+}
+
+// A nil *TTLBuffer must not panic on Set.
+func TestTTLBuffer_NilReceiver_SetIsNoop(t *testing.T) {
+	t.Parallel()
+	var b *TTLBuffer
+	expireAt := time.Now().Add(time.Minute)
+	require.NotPanics(t, func() { b.Set([]byte("k"), &expireAt) })
+}
+
+// When the buffer is full, new (unseen) keys must be silently dropped.
+// Existing keys must still be updatable.
+func TestTTLBuffer_Full_DropsNewKey(t *testing.T) {
+	t.Parallel()
+	b := newTTLBuffer()
+
+	// Fill the map to exactly ttlBufferMaxSize via direct struct access so the
+	// test runs in O(N) map writes without going through the seq machinery.
+	b.mu.Lock()
+	var seq uint64
+	for i := range ttlBufferMaxSize {
+		seq++
+		b.entries[fmt.Sprintf("slot:%d", i)] = ttlBufferEntry{seq: seq}
+	}
+	b.mu.Unlock()
+
+	require.Equal(t, ttlBufferMaxSize, b.Len())
+
+	// A brand-new key must be dropped.
+	expireAt := time.Now().Add(time.Minute)
+	b.Set([]byte("brand-new"), &expireAt)
+	_, found := b.Get([]byte("brand-new"))
+	require.False(t, found, "new key must be dropped when the buffer is full")
+
+	// An existing key must still accept updates.
+	b.Set([]byte("slot:0"), &expireAt)
+	got, found := b.Get([]byte("slot:0"))
+	require.True(t, found, "existing key must be updatable even when buffer is full")
+	require.NotNil(t, got)
+}
+
+// Concurrent Set/Get/Drain/MergeBack must not data-race.
+// Run with `go test -race` to exercise the race detector.
+func TestTTLBuffer_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+	b := newTTLBuffer()
+	const goroutines = 50
+	const opsPerGoroutine = 100
+
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			key := []byte(fmt.Sprintf("key:%d", id%10))
+			expireAt := time.Now().Add(time.Duration(id) * time.Second)
+			for range opsPerGoroutine {
+				b.Set(key, &expireAt)
+				_, _ = b.Get(key)
+				if id%5 == 0 {
+					drained := b.Drain()
+					b.MergeBack(drained)
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+
+// ────────────────────────────────────────────────────────────────
+// buildTTLFlushElems — unit tests
+// ────────────────────────────────────────────────────────────────
+
+func TestBuildTTLFlushElems_Empty(t *testing.T) {
+	t.Parallel()
+	elems := buildTTLFlushElems(nil)
+	require.Empty(t, elems)
+}
+
+// nil expireAt (PERSIST) must produce a Del operation on the TTL key.
+func TestBuildTTLFlushElems_NilExpireGeneratesDel(t *testing.T) {
+	t.Parallel()
+	entries := map[string]ttlBufferEntry{
+		"mykey": {expireAt: nil, seq: 1},
+	}
+
+	elems := buildTTLFlushElems(entries)
+
+	require.Len(t, elems, 1)
+	assert.Equal(t, kv.Del, elems[0].Op)
+	assert.Equal(t, redisTTLKey([]byte("mykey")), elems[0].Key)
+	assert.Nil(t, elems[0].Value)
+}
+
+// non-nil expireAt must produce a Put with the encoded TTL.
+func TestBuildTTLFlushElems_NonNilExpireGeneratesPut(t *testing.T) {
+	t.Parallel()
+	expireAt := time.UnixMilli(9_000_000_000_000) // far future
+	entries := map[string]ttlBufferEntry{
+		"mykey": {expireAt: &expireAt, seq: 1},
+	}
+
+	elems := buildTTLFlushElems(entries)
+
+	require.Len(t, elems, 1)
+	assert.Equal(t, kv.Put, elems[0].Op)
+	assert.Equal(t, redisTTLKey([]byte("mykey")), elems[0].Key)
+	require.NotNil(t, elems[0].Value)
+
+	// Round-trip: decoded value must match the original expiry.
+	decoded, err := decodeRedisTTL(elems[0].Value)
+	require.NoError(t, err)
+	assert.Equal(t, expireAt.UnixMilli(), decoded.UnixMilli())
+}
+
+// Keys must appear in lexicographic order for deterministic Raft log entries.
+func TestBuildTTLFlushElems_KeysAreSorted(t *testing.T) {
+	t.Parallel()
+	exp := time.Now().Add(time.Minute)
+	entries := map[string]ttlBufferEntry{
+		"zzz": {expireAt: &exp, seq: 3},
+		"aaa": {expireAt: &exp, seq: 1},
+		"mmm": {expireAt: &exp, seq: 2},
+	}
+
+	elems := buildTTLFlushElems(entries)
+
+	require.Len(t, elems, 3)
+	// TTL key has the !redis|ttl| prefix; strip it to compare user keys.
+	prefix := len(redisTTLKey(nil))
+	userKeys := make([]string, len(elems))
+	for i, e := range elems {
+		userKeys[i] = string(e.Key[prefix:])
+	}
+	assert.Equal(t, []string{"aaa", "mmm", "zzz"}, userKeys)
+}
+
+// Mixed nil / non-nil in one batch.
+func TestBuildTTLFlushElems_MixedDelAndPut(t *testing.T) {
+	t.Parallel()
+	exp := time.Now().Add(time.Minute)
+	entries := map[string]ttlBufferEntry{
+		"persist": {expireAt: nil, seq: 1},
+		"expire":  {expireAt: &exp, seq: 2},
+	}
+
+	elems := buildTTLFlushElems(entries)
+	require.Len(t, elems, 2)
+
+	ops := map[string]kv.OP{}
+	prefix := len(redisTTLKey(nil))
+	for _, e := range elems {
+		ops[string(e.Key[prefix:])] = e.Op
+	}
+	assert.Equal(t, kv.Del, ops["persist"])
+	assert.Equal(t, kv.Put, ops["expire"])
+}
+
+// ────────────────────────────────────────────────────────────────
+// ttlAt — buffer-first read path (unit)
+// ────────────────────────────────────────────────────────────────
+
+// When the buffer holds a TTL entry, ttlAt must return it without
+// touching the Raft/MVCCStore.
+func TestTTLAt_BufferHit_SkipsStore(t *testing.T) {
+	t.Parallel()
+	server, st := newRedisStorageMigrationTestServer(t)
+	ctx := context.Background()
+	key := []byte("bufhit:key")
+
+	// Write a TTL into the buffer only — the Raft store has no entry.
+	expireAt := time.Now().Add(time.Hour)
+	server.ttlBuffer.Set(key, &expireAt)
+
+	// Verify the store is indeed empty.
+	_, err := st.GetAt(ctx, redisTTLKey(key), server.readTS())
+	require.ErrorIs(t, err, store.ErrKeyNotFound, "store must not have a TTL entry yet")
+
+	// ttlAt must return the buffer value.
+	got, err := server.ttlAt(ctx, key, server.readTS())
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, expireAt.UnixMilli(), got.UnixMilli())
+}
+
+// When the buffer is empty, ttlAt must fall back to the Raft store.
+func TestTTLAt_BufferMiss_FallsBackToStore(t *testing.T) {
+	t.Parallel()
+	server, st := newRedisStorageMigrationTestServer(t)
+	ctx := context.Background()
+	key := []byte("bufmiss:key")
+
+	// Write TTL directly to the store, bypassing the buffer.
+	expireAt := time.Now().Add(time.Hour)
+	ts := server.readTS() + 1
+	require.NoError(t, st.PutAt(ctx, redisTTLKey(key), encodeRedisTTL(expireAt), ts, 0))
+
+	// Buffer is empty.
+	_, found := server.ttlBuffer.Get(key)
+	require.False(t, found)
+
+	got, err := server.ttlAt(ctx, key, ts)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, expireAt.UnixMilli(), got.UnixMilli())
+}
+
+// A PERSIST entry in the buffer (nil expireAt, found=true) must return nil
+// without falling back to the store, even when the store has a stale TTL.
+func TestTTLAt_BufferPersist_ReturnsNil(t *testing.T) {
+	t.Parallel()
+	server, st := newRedisStorageMigrationTestServer(t)
+	ctx := context.Background()
+	key := []byte("persist:key")
+
+	// Store has an old TTL.
+	oldExpiry := time.Now().Add(time.Hour)
+	ts := server.readTS() + 1
+	require.NoError(t, st.PutAt(ctx, redisTTLKey(key), encodeRedisTTL(oldExpiry), ts, 0))
+
+	// Buffer says "TTL was removed".
+	server.ttlBuffer.Set(key, nil)
+
+	got, err := server.ttlAt(ctx, key, ts)
+	require.NoError(t, err)
+	require.Nil(t, got, "buffer PERSIST entry must shadow the stale store TTL")
+}

--- a/adapter/redis_ttl_buffer_test.go
+++ b/adapter/redis_ttl_buffer_test.go
@@ -2,8 +2,10 @@ package adapter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -12,6 +14,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type shutdownFlushCoordinator struct {
+	stubAdapterCoordinator
+	failUntil int32
+	calls     atomic.Int32
+}
+
+func (c *shutdownFlushCoordinator) Dispatch(context.Context, *kv.OperationGroup[kv.OP]) (*kv.CoordinateResponse, error) {
+	call := c.calls.Add(1)
+	if call <= c.failUntil {
+		return nil, errors.New("dispatch failed")
+	}
+	return &kv.CoordinateResponse{}, nil
+}
 
 // ────────────────────────────────────────────────────────────────
 // TTLBuffer — unit tests
@@ -205,6 +221,44 @@ func TestTTLBuffer_ConcurrentAccess(t *testing.T) {
 		}(g)
 	}
 	wg.Wait()
+}
+
+func TestRunTTLFlusher_ShutdownRetriesUntilSuccess(t *testing.T) {
+	t.Parallel()
+	coord := &shutdownFlushCoordinator{failUntil: 2}
+	server := &RedisServer{
+		coordinator:      coord,
+		ttlBuffer:        newTTLBufferWithMaxSize(8),
+		ttlFlushInterval: time.Hour,
+	}
+	expireAt := time.Now().Add(time.Minute)
+	server.ttlBuffer.Set([]byte("k"), &expireAt)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	server.runTTLFlusher(ctx)
+
+	require.Equal(t, int32(3), coord.calls.Load())
+	require.Equal(t, 0, server.ttlBuffer.Len())
+}
+
+func TestRunTTLFlusher_ShutdownStopsAfterBoundedRetries(t *testing.T) {
+	t.Parallel()
+	coord := &shutdownFlushCoordinator{failUntil: 100}
+	server := &RedisServer{
+		coordinator:      coord,
+		ttlBuffer:        newTTLBufferWithMaxSize(8),
+		ttlFlushInterval: time.Hour,
+	}
+	expireAt := time.Now().Add(time.Minute)
+	server.ttlBuffer.Set([]byte("k"), &expireAt)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	server.runTTLFlusher(ctx)
+
+	require.Equal(t, int32(ttlShutdownFlushAttempts), coord.calls.Load())
+	require.Equal(t, 1, server.ttlBuffer.Len())
 }
 
 // ────────────────────────────────────────────────────────────────

--- a/adapter/redis_ttl_buffer_test.go
+++ b/adapter/redis_ttl_buffer_test.go
@@ -29,6 +29,33 @@ func (c *shutdownFlushCoordinator) Dispatch(context.Context, *kv.OperationGroup[
 	return &kv.CoordinateResponse{}, nil
 }
 
+type chunkingFlushCoordinator struct {
+	stubAdapterCoordinator
+	err   error
+	calls atomic.Int32
+	mu    sync.Mutex
+	sizes []int
+	keys  map[string]struct{}
+}
+
+func (c *chunkingFlushCoordinator) Dispatch(_ context.Context, opg *kv.OperationGroup[kv.OP]) (*kv.CoordinateResponse, error) {
+	c.calls.Add(1)
+	c.mu.Lock()
+	if c.keys == nil {
+		c.keys = make(map[string]struct{})
+	}
+	c.sizes = append(c.sizes, len(opg.Elems))
+	prefix := len(redisTTLKey(nil))
+	for _, elem := range opg.Elems {
+		c.keys[string(elem.Key[prefix:])] = struct{}{}
+	}
+	c.mu.Unlock()
+	if c.err != nil {
+		return nil, c.err
+	}
+	return &kv.CoordinateResponse{}, nil
+}
+
 // ────────────────────────────────────────────────────────────────
 // TTLBuffer — unit tests
 // ────────────────────────────────────────────────────────────────
@@ -279,6 +306,59 @@ func TestRunTTLFlusher_ShutdownStopsAfterBoundedRetries(t *testing.T) {
 
 	require.Equal(t, int32(ttlShutdownFlushAttempts), coord.calls.Load())
 	require.Equal(t, 1, server.ttlBuffer.Len())
+}
+
+func TestFlushTTLBuffer_ChunksLargeBuffer(t *testing.T) {
+	t.Parallel()
+	coord := &chunkingFlushCoordinator{}
+	server := &RedisServer{
+		coordinator:      coord,
+		ttlBuffer:        newTTLBufferWithMaxSize(ttlFlushBatchMax + 64),
+		ttlFlushInterval: time.Hour,
+	}
+	expireAt := time.Now().Add(time.Minute)
+	total := ttlFlushBatchMax + 17
+	for i := range total {
+		server.ttlBuffer.Set([]byte(fmt.Sprintf("k:%d", i)), &expireAt)
+	}
+
+	drainedAll := server.flushTTLBuffer(context.Background(), false)
+	require.False(t, drainedAll, "first flush should leave remainder")
+	require.Equal(t, total-ttlFlushBatchMax, server.ttlBuffer.Len())
+
+	drainedAll = server.flushTTLBuffer(context.Background(), false)
+	require.True(t, drainedAll, "second flush should empty remaining entries")
+	require.Equal(t, 0, server.ttlBuffer.Len())
+	require.Equal(t, int32(2), coord.calls.Load())
+
+	coord.mu.Lock()
+	defer coord.mu.Unlock()
+	require.Equal(t, []int{ttlFlushBatchMax, total - ttlFlushBatchMax}, coord.sizes)
+	require.Len(t, coord.keys, total, "all original keys must be flushed across chunks")
+}
+
+func TestFlushTTLBuffer_ChunkDispatchError_RequeuesAll(t *testing.T) {
+	t.Parallel()
+	coord := &chunkingFlushCoordinator{err: errors.New("dispatch failed")}
+	server := &RedisServer{
+		coordinator:      coord,
+		ttlBuffer:        newTTLBufferWithMaxSize(ttlFlushBatchMax + 64),
+		ttlFlushInterval: time.Hour,
+	}
+	expireAt := time.Now().Add(time.Minute)
+	total := ttlFlushBatchMax + 5
+	for i := range total {
+		server.ttlBuffer.Set([]byte(fmt.Sprintf("k:%d", i)), &expireAt)
+	}
+
+	drainedAll := server.flushTTLBuffer(context.Background(), false)
+	require.False(t, drainedAll)
+	require.Equal(t, total, server.ttlBuffer.Len(), "failed chunk must be merged back and remainder preserved")
+	require.Equal(t, int32(1), coord.calls.Load())
+
+	coord.mu.Lock()
+	require.Equal(t, []int{ttlFlushBatchMax}, coord.sizes)
+	coord.mu.Unlock()
 }
 
 // ────────────────────────────────────────────────────────────────

--- a/adapter/redis_ttl_buffer_test.go
+++ b/adapter/redis_ttl_buffer_test.go
@@ -146,6 +146,26 @@ func TestTTLBuffer_MergeBack_RestoresWhenNoNewerWrite(t *testing.T) {
 	require.Equal(t, expireAt.UnixNano(), got.UnixNano())
 }
 
+func TestTTLBuffer_MergeBack_Full_DropsAndCounts(t *testing.T) {
+	t.Parallel()
+	b := newTTLBufferWithMaxSize(1)
+	expireAt := time.Now().Add(time.Minute)
+	b.Set([]byte("live"), &expireAt)
+
+	snapshot := map[string]ttlBufferEntry{
+		"a": {expireAt: &expireAt, seq: 1},
+		"b": {expireAt: nil, seq: 2},
+	}
+	b.MergeBack(snapshot)
+
+	require.Equal(t, uint64(2), b.dropped.Load())
+	require.Equal(t, 1, b.Len())
+	_, found := b.Get([]byte("a"))
+	require.False(t, found)
+	_, found = b.Get([]byte("b"))
+	require.False(t, found)
+}
+
 // A nil *TTLBuffer must not panic on Get.
 func TestTTLBuffer_NilReceiver_GetIsNoop(t *testing.T) {
 	t.Parallel()

--- a/adapter/redis_ttl_compat_test.go
+++ b/adapter/redis_ttl_compat_test.go
@@ -120,27 +120,6 @@ func TestRedis_INCR_NoTTL_StaysNegativeOne(t *testing.T) {
 }
 
 // ────────────────────────────────────────────────────────────────
-// PERSIST — must remove an existing TTL
-// ────────────────────────────────────────────────────────────────
-
-func TestRedis_PERSIST_ClearsTTL(t *testing.T) {
-	t.Parallel()
-	nodes, _, _ := createNode(t, 3)
-	defer shutdown(nodes)
-
-	ctx := context.Background()
-	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
-	defer func() { _ = rdb.Close() }()
-
-	require.NoError(t, rdb.Do(ctx, "SET", "persist:key", "v", "EX", "100").Err())
-	require.NoError(t, rdb.Persist(ctx, "persist:key").Err())
-
-	ttl, err := rdb.TTL(ctx, "persist:key").Result()
-	require.NoError(t, err)
-	require.Equal(t, time.Duration(-1), ttl, "PERSIST must remove the TTL")
-}
-
-// ────────────────────────────────────────────────────────────────
 // MULTI/EXEC with EXPIRE
 // ────────────────────────────────────────────────────────────────
 
@@ -215,49 +194,4 @@ func TestRedis_ExpiredKey_BecomesInvisible(t *testing.T) {
 
 	_, err = rdb.Get(ctx, "expiry:short").Result()
 	require.ErrorIs(t, err, redis.Nil, "key must be gone after expiry")
-}
-
-// ────────────────────────────────────────────────────────────────
-// GETEX — must update TTL immediately
-// ────────────────────────────────────────────────────────────────
-
-func TestRedis_GETEX_UpdatesTTLImmediately(t *testing.T) {
-	t.Parallel()
-	nodes, _, _ := createNode(t, 3)
-	defer shutdown(nodes)
-
-	ctx := context.Background()
-	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
-	defer func() { _ = rdb.Close() }()
-
-	require.NoError(t, rdb.Set(ctx, "getex:key", "hello", 0).Err())
-
-	// GETEX with EX must set a TTL and return the value.
-	val, err := rdb.Do(ctx, "GETEX", "getex:key", "EX", "80").Text()
-	require.NoError(t, err)
-	require.Equal(t, "hello", val)
-
-	ttl, err := rdb.TTL(ctx, "getex:key").Result()
-	require.NoError(t, err)
-	require.Greater(t, ttl, time.Duration(0))
-	require.LessOrEqual(t, ttl, 80*time.Second)
-}
-
-// GETEX PERSIST must remove an existing TTL.
-func TestRedis_GETEX_PERSIST_ClearsTTL(t *testing.T) {
-	t.Parallel()
-	nodes, _, _ := createNode(t, 3)
-	defer shutdown(nodes)
-
-	ctx := context.Background()
-	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
-	defer func() { _ = rdb.Close() }()
-
-	require.NoError(t, rdb.Do(ctx, "SET", "getex:persist", "v", "EX", "100").Err())
-	_, err := rdb.Do(ctx, "GETEX", "getex:persist", "PERSIST").Text()
-	require.NoError(t, err)
-
-	ttl, err := rdb.TTL(ctx, "getex:persist").Result()
-	require.NoError(t, err)
-	require.Equal(t, time.Duration(-1), ttl, "GETEX PERSIST must clear the TTL")
 }

--- a/adapter/redis_ttl_compat_test.go
+++ b/adapter/redis_ttl_compat_test.go
@@ -1,0 +1,263 @@
+package adapter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+// ────────────────────────────────────────────────────────────────
+// EXPIRE / PEXPIRE — TTL is read immediately from the buffer
+// ────────────────────────────────────────────────────────────────
+
+// EXPIRE must set a TTL that is immediately visible via the TTL command,
+// even before the background flush has run.
+func TestRedis_EXPIRE_ImmediatelyVisibleViaTTL(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.Set(ctx, "expire:key", "value", 0).Err())
+	require.NoError(t, rdb.Expire(ctx, "expire:key", 100*time.Second).Err())
+
+	ttl, err := rdb.TTL(ctx, "expire:key").Result()
+	require.NoError(t, err)
+	require.Greater(t, ttl, time.Duration(0), "TTL must be > 0 immediately after EXPIRE")
+	require.LessOrEqual(t, ttl, 100*time.Second)
+}
+
+// PEXPIRE must set a millisecond-precision TTL immediately visible via PTTL.
+func TestRedis_PEXPIRE_ImmediatelyVisibleViaPTTL(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.Set(ctx, "pexpire:key", "v", 0).Err())
+	require.NoError(t, rdb.Do(ctx, "PEXPIRE", "pexpire:key", "50000").Err())
+
+	pttl, err := rdb.PTTL(ctx, "pexpire:key").Result()
+	require.NoError(t, err)
+	require.Greater(t, pttl, time.Duration(0))
+	require.LessOrEqual(t, pttl, 50*time.Second)
+}
+
+// SET EX stores a TTL that must be visible immediately.
+func TestRedis_SET_EX_ImmediatelyVisibleViaTTL(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.Do(ctx, "SET", "setex:key", "v", "EX", "90").Err())
+
+	ttl, err := rdb.TTL(ctx, "setex:key").Result()
+	require.NoError(t, err)
+	require.Greater(t, ttl, time.Duration(0))
+	require.LessOrEqual(t, ttl, 90*time.Second)
+}
+
+// ────────────────────────────────────────────────────────────────
+// INCR — must clear any existing TTL (PERSIST semantics)
+// ────────────────────────────────────────────────────────────────
+
+func TestRedis_INCR_ClearsTTL(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	// Store an integer with an expiry.
+	require.NoError(t, rdb.Do(ctx, "SET", "incr:key", "10", "EX", "100").Err())
+	ttlBefore, err := rdb.TTL(ctx, "incr:key").Result()
+	require.NoError(t, err)
+	require.Greater(t, ttlBefore, time.Duration(0), "key must have a TTL before INCR")
+
+	// INCR must clear the TTL.
+	val, err := rdb.Do(ctx, "INCR", "incr:key").Int64()
+	require.NoError(t, err)
+	require.Equal(t, int64(11), val)
+
+	ttlAfter, err := rdb.TTL(ctx, "incr:key").Result()
+	require.NoError(t, err)
+	require.Equal(t, time.Duration(-1), ttlAfter,
+		"INCR must clear the TTL (PERSIST); TTL must be -1 after INCR")
+}
+
+// INCR on a key without TTL must keep TTL as -1.
+func TestRedis_INCR_NoTTL_StaysNegativeOne(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.Set(ctx, "incr:notl", "5", 0).Err())
+	_, err := rdb.Do(ctx, "INCR", "incr:notl").Int64()
+	require.NoError(t, err)
+
+	ttl, err := rdb.TTL(ctx, "incr:notl").Result()
+	require.NoError(t, err)
+	require.Equal(t, time.Duration(-1), ttl)
+}
+
+// ────────────────────────────────────────────────────────────────
+// PERSIST — must remove an existing TTL
+// ────────────────────────────────────────────────────────────────
+
+func TestRedis_PERSIST_ClearsTTL(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.Do(ctx, "SET", "persist:key", "v", "EX", "100").Err())
+	require.NoError(t, rdb.Persist(ctx, "persist:key").Err())
+
+	ttl, err := rdb.TTL(ctx, "persist:key").Result()
+	require.NoError(t, err)
+	require.Equal(t, time.Duration(-1), ttl, "PERSIST must remove the TTL")
+}
+
+// ────────────────────────────────────────────────────────────────
+// MULTI/EXEC with EXPIRE
+// ────────────────────────────────────────────────────────────────
+
+// EXPIRE inside MULTI/EXEC must set a TTL that is visible after EXEC.
+func TestRedis_MultiExec_ExpireSetsVisibleTTL(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.Set(ctx, "multi:key", "v", 0).Err())
+
+	require.NoError(t, rdb.Do(ctx, "MULTI").Err())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "EXPIRE", "multi:key", "60").Val())
+	_, err := rdb.Do(ctx, "EXEC").Result()
+	require.NoError(t, err)
+
+	ttl, err := rdb.TTL(ctx, "multi:key").Result()
+	require.NoError(t, err)
+	require.Greater(t, ttl, time.Duration(0))
+	require.LessOrEqual(t, ttl, 60*time.Second)
+}
+
+// SET with EX inside MULTI/EXEC must store both value and TTL.
+func TestRedis_MultiExec_SetEXStoresTTL(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.Do(ctx, "MULTI").Err())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "SET", "multi:setex", "hello", "EX", "30").Val())
+	_, err := rdb.Do(ctx, "EXEC").Result()
+	require.NoError(t, err)
+
+	val, err := rdb.Get(ctx, "multi:setex").Result()
+	require.NoError(t, err)
+	require.Equal(t, "hello", val)
+
+	ttl, err := rdb.TTL(ctx, "multi:setex").Result()
+	require.NoError(t, err)
+	require.Greater(t, ttl, time.Duration(0))
+}
+
+// ────────────────────────────────────────────────────────────────
+// Key expiration — expired keys must become invisible
+// ────────────────────────────────────────────────────────────────
+
+func TestRedis_ExpiredKey_BecomesInvisible(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	// Set a key with a very short TTL.
+	require.NoError(t, rdb.Do(ctx, "SET", "expiry:short", "v", "PX", "200").Err())
+
+	got, err := rdb.Get(ctx, "expiry:short").Result()
+	require.NoError(t, err)
+	require.Equal(t, "v", got, "key must be visible before expiry")
+
+	time.Sleep(400 * time.Millisecond)
+
+	_, err = rdb.Get(ctx, "expiry:short").Result()
+	require.ErrorIs(t, err, redis.Nil, "key must be gone after expiry")
+}
+
+// ────────────────────────────────────────────────────────────────
+// GETEX — must update TTL immediately
+// ────────────────────────────────────────────────────────────────
+
+func TestRedis_GETEX_UpdatesTTLImmediately(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.Set(ctx, "getex:key", "hello", 0).Err())
+
+	// GETEX with EX must set a TTL and return the value.
+	val, err := rdb.Do(ctx, "GETEX", "getex:key", "EX", "80").Text()
+	require.NoError(t, err)
+	require.Equal(t, "hello", val)
+
+	ttl, err := rdb.TTL(ctx, "getex:key").Result()
+	require.NoError(t, err)
+	require.Greater(t, ttl, time.Duration(0))
+	require.LessOrEqual(t, ttl, 80*time.Second)
+}
+
+// GETEX PERSIST must remove an existing TTL.
+func TestRedis_GETEX_PERSIST_ClearsTTL(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.Do(ctx, "SET", "getex:persist", "v", "EX", "100").Err())
+	_, err := rdb.Do(ctx, "GETEX", "getex:persist", "PERSIST").Text()
+	require.NoError(t, err)
+
+	ttl, err := rdb.TTL(ctx, "getex:persist").Result()
+	require.NoError(t, err)
+	require.Equal(t, time.Duration(-1), ttl, "GETEX PERSIST must clear the TTL")
+}

--- a/adapter/redis_ttl_compat_test.go
+++ b/adapter/redis_ttl_compat_test.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -190,8 +191,8 @@ func TestRedis_ExpiredKey_BecomesInvisible(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "v", got, "key must be visible before expiry")
 
-	time.Sleep(400 * time.Millisecond)
-
-	_, err = rdb.Get(ctx, "expiry:short").Result()
-	require.ErrorIs(t, err, redis.Nil, "key must be gone after expiry")
+	require.Eventually(t, func() bool {
+		_, e := rdb.Get(ctx, "expiry:short").Result()
+		return errors.Is(e, redis.Nil)
+	}, time.Second, 25*time.Millisecond, "key must be gone after expiry")
 }

--- a/adapter/redis_txn_test.go
+++ b/adapter/redis_txn_test.go
@@ -48,14 +48,15 @@ func TestRedisTxnValidateReadSet_ListMetaUpdateNoConflict(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestRedisTxnValidateReadSet_TTLUpdateConflict verifies that updating the TTL
-// key for a list DOES trigger an OCC conflict, because TTL reads are still
-// tracked in the read set.
-func TestRedisTxnValidateReadSet_TTLUpdateConflict(t *testing.T) {
+// TestRedisTxnValidateReadSet_TTLUpdateNoConflict verifies that a concurrent TTL
+// update does NOT trigger an OCC conflict for list append operations. TTL is now
+// written via IsTxn=false batch flushes and is excluded from the read set, so
+// concurrent EXPIRE/SETEX writes are invisible to data transactions.
+func TestRedisTxnValidateReadSet_TTLUpdateNoConflict(t *testing.T) {
 	t.Parallel()
 
 	server, st := newRedisStorageMigrationTestServer(t)
-	key := []byte("list:ttl-conflict")
+	key := []byte("list:ttl-no-conflict")
 
 	metaBytes, err := store.MarshalListMeta(store.ListMeta{Len: 1})
 	require.NoError(t, err)
@@ -75,11 +76,12 @@ func TestRedisTxnValidateReadSet_TTLUpdateConflict(t *testing.T) {
 	require.NoError(t, err)
 
 	// A concurrent EXPIRE updates the TTL key after our read.
+	// Because TTL is no longer tracked in the OCC read set, this must NOT
+	// surface as a write conflict.
 	require.NoError(t, st.PutAt(context.Background(), redisTTLKey(key), []byte("dummy"), 11, 0))
 
 	err = txn.validateReadSet(context.Background())
-	require.Error(t, err)
-	require.ErrorIs(t, err, store.ErrWriteConflict)
+	require.NoError(t, err)
 }
 
 // TestRedisTxnMULTIEXECRetriesOnCoordinatorConflict verifies that runTransaction

--- a/docs/design/ttl-memory-buffer.md
+++ b/docs/design/ttl-memory-buffer.md
@@ -177,6 +177,28 @@ external TTL writes trigger write-conflict detection.  Since TTL is now written 
 `IsTxn=false` flushes (which do not participate in conflict detection), this tracking
 is no longer useful.  All `trackReadKey(redisTTLKey(...))` call sites are removed.
 
+### MULTI/EXEC — TTL snapshot isolation is not guaranteed
+
+With TTL removed from OCC read sets, a concurrent `EXPIRE` executed between a
+client's `MULTI` and `EXEC` will **not** surface as `ErrWriteConflict` for data
+operations.  Concretely:
+
+```
+Client A:  MULTI
+Client A:  SET   key value  ← queued
+Client B:  EXPIRE key 5     ← writes TTL buffer, IsTxn=false
+Client A:  EXEC             ← commits data, then flushes TTL from A's own state
+```
+
+After `EXEC`, Client A's buffered TTL (if any) will overwrite Client B's `EXPIRE`
+via last-writer-wins, because both take the `IsTxn=false` path.
+
+**Impact**: workloads that rely on TTL changes being detected as OCC conflicts
+inside `MULTI/EXEC` will no longer see that behaviour.  For rate-limiting keys
+(the primary use-case of this change) this is harmless — the TTL difference is
+at most one flush interval (100 ms) and the final committed value is always the
+most recent write as determined by `seq`.
+
 ---
 
 ## 6. Write-path changes

--- a/docs/design/ttl-memory-buffer.md
+++ b/docs/design/ttl-memory-buffer.md
@@ -1,0 +1,356 @@
+# Design: TTL In-Memory Buffer with Batch Raft Flush
+
+## 1. Background and motivation
+
+### Problem
+
+When redis-proxy proxies Misskey requests, EVALSHA secondary writes time out en masse
+with `context deadline exceeded`.
+
+Root-cause analysis:
+
+1. Misskey rate-limit Lua scripts follow the pattern `INCR key` + `EXPIRE key window`.
+2. When elastickv4 executes the EVALSHA secondary write, `runLuaScript` →
+   `retryRedisWrite` attempts to commit a Raft transaction.
+3. `luaScriptContext.commit()` packs **data changes (INCR) and TTL changes (EXPIRE)
+   into the same `IsTxn=true` transaction**.
+4. Concurrent `EXPIRE` calls on the same rate-limit key produce **write conflicts on
+   `!redis|ttl|<key>`**.
+5. Data write conflicts are eliminated for list/hash/set/zset by the Delta
+   compaction scheme, but TTL has no equivalent.
+6. `retryRedisWrite` allows up to 50 retries with up to 50 ms backoff each, plus
+   Raft round-trip overhead, totalling ≈ 5 s — exceeding `SecondaryTimeout`.
+
+### Why TTL is hard to Delta-ize
+
+Delta keys use a unique timestamp-embedded key per write to enable conflict-free
+merges.  TTL is a single scalar (`uint64` milliseconds); there is no natural merge
+semantic to apply.
+
+### Proposed approach
+
+**Buffer all TTL writes in memory and flush them to Raft in batches on a background
+goroutine.**
+
+Benefits:
+- TTL elements are removed from `IsTxn=true` Raft transactions → TTL write
+  conflicts eliminated.
+- Multiple TTL updates for distinct keys are coalesced into one Raft entry →
+  lower Raft write amplification.
+
+---
+
+## 2. Goals / non-goals
+
+### Goals
+
+- Eliminate TTL write conflicts in EVALSHA to remove secondary-write timeouts.
+- Apply the same buffering to `EXPIRE`/`PEXPIRE`, `SET EX`/`SETEX`/`GETEX`, and
+  `MULTI`/`EXEC` transactions uniformly.
+- Reads (`ttlAt`) consult the buffer first so the accurate TTL is returned even
+  before a flush.
+- Flush failures re-queue entries for the next flush interval; no silent TTL loss.
+
+### Non-goals
+
+- Buffering data values (string/list/hash/set/zset): out of scope.
+- Strict atomicity of data + TTL under process crash: the window where data is
+  committed but TTL has not yet been flushed is accepted (see §8).
+- Full MVCC snapshot isolation for TTL inside `MULTI`/`EXEC`: approximate model
+  is preserved.
+
+---
+
+## 3. Design overview
+
+```
+Write (EXPIRE / SET EX / Lua EVALSHA / MULTI-EXEC)
+     │
+     ▼
+┌──────────────────────────────┐
+│  TTLBuffer  (per RedisServer) │
+│  map[userKey] → entry         │
+│  { expireAt *time.Time,       │
+│    seq      uint64 }          │
+└──────────────────────────────┘
+     │  background goroutine (100 ms default)
+     ▼
+┌──────────────────────────────┐
+│  coordinator.Dispatch         │
+│  IsTxn = false                │  ← no conflict detection, last-writer-wins
+│  batch: N TTL elements        │
+└──────────────────────────────┘
+     │
+     ▼
+  Raft / MVCCStore
+
+Read (ttlAt / hasExpiredTTLAt)
+  1. check TTLBuffer        ← buffer-first (always most recent)
+  2. fallback: MVCCStore.GetAt(redisTTLKey, readTS)
+```
+
+### Components
+
+| Component | Role | File |
+|---|---|---|
+| `TTLBuffer` | Thread-safe TTL write buffer | `adapter/redis_ttl_buffer.go` (new) |
+| `RedisServer.ttlBuffer` | Server-level embedding | `adapter/redis.go` |
+| TTL flush goroutine | Periodic background flush | `adapter/redis.go` `Run()` |
+| `ttlAt()` | Buffer-first TTL read | `adapter/redis_compat_types.go` |
+| Lua write path | Remove TTL from data commit, write to buffer after | `adapter/redis_lua_context.go` |
+| Direct TTL write paths | `EXPIRE`, `saveString`, `txnContext` | multiple files |
+
+---
+
+## 4. TTLBuffer detailed design
+
+```go
+// ttlBufferEntry holds a pending TTL update for one user key.
+// expireAt == nil represents a TTL deletion (PERSIST).
+type ttlBufferEntry struct {
+    expireAt *time.Time
+    seq      uint64  // monotonic; later writes win on same key
+}
+
+// TTLBuffer is a thread-safe in-memory TTL write buffer.
+type TTLBuffer struct {
+    mu      sync.RWMutex
+    entries map[string]ttlBufferEntry
+    counter atomic.Uint64
+}
+```
+
+### Key operations
+
+```go
+// Set writes a TTL entry for key. expireAt==nil means delete TTL (PERSIST).
+func (b *TTLBuffer) Set(key []byte, expireAt *time.Time)
+
+// Get returns the buffered TTL for key.
+// found=false → no entry; caller should fall back to the store.
+// nil expireAt with found=true → TTL was explicitly removed.
+func (b *TTLBuffer) Get(key []byte) (expireAt *time.Time, found bool)
+
+// Drain atomically snapshots the buffer and resets it for new writes.
+func (b *TTLBuffer) Drain() map[string]ttlBufferEntry
+
+// MergeBack re-inserts entries from a failed flush, skipping keys
+// that already have a newer write in the live buffer.
+func (b *TTLBuffer) MergeBack(entries map[string]ttlBufferEntry)
+```
+
+### `seq` field
+
+A monotonically increasing counter ensures the latest call to `Set` wins when
+`MergeBack` races with concurrent writes.
+
+---
+
+## 5. Read-path changes
+
+### `ttlAt()` — `adapter/redis_compat_types.go`
+
+```go
+func (r *RedisServer) ttlAt(ctx context.Context, userKey []byte, readTS uint64) (*time.Time, error) {
+    // Buffer holds the most recent write regardless of Raft flush state.
+    if expireAt, found := r.ttlBuffer.Get(userKey); found {
+        return expireAt, nil
+    }
+    // Fall back to Raft store at readTS.
+    raw, err := r.store.GetAt(ctx, redisTTLKey(userKey), readTS)
+    // ... unchanged
+}
+```
+
+All callers of `ttlAt` (`hasExpiredTTLAt`, `keyTypeAt`, `TTL`/`PTTL` commands,
+`luaScriptContext.finalTTL`) automatically gain buffer-first semantics.
+
+### `isLeaderKeyExpired` / `tryLeaderNonStringExists` — `adapter/redis.go`
+
+These read TTL directly via `tryLeaderGetAt(redisTTLKey, 0)`.  Both are updated to
+check the buffer before the Raft store.
+
+### MVCC TTL read tracking removal — `adapter/redis.go`
+
+`txnContext` currently registers `redisTTLKey` reads via `trackReadKey` so that
+external TTL writes trigger write-conflict detection.  Since TTL is now written via
+`IsTxn=false` flushes (which do not participate in conflict detection), this tracking
+is no longer useful.  All `trackReadKey(redisTTLKey(...))` call sites are removed.
+
+---
+
+## 6. Write-path changes
+
+### Change sites
+
+| Location | File | Change |
+|---|---|---|
+| `luaScriptContext.commit()` | `redis_lua_context.go` | Remove TTL elems from Raft group; call `flushTTLToBuffer()` after successful dispatch |
+| `commitElemsForKey()` | `redis_lua_context.go` | Drop `ttlCommitElems` call |
+| `setExpire()` positive TTL branch | `redis_compat_commands.go` | Replace `dispatchElems` with `ttlBuffer.Set` |
+| `incr()` TTL-clear | `redis_compat_commands.go` | Remove `Del redisTTLKey` from Raft dispatch; add `ttlBuffer.Set(key, nil)` |
+| `saveString()` | `redis_compat_helpers.go` | Remove TTL elems from dispatch; add `ttlBuffer.Set` after |
+| `replaceWithStringTxn()` | `redis.go` | Remove TTL elems from dispatch; add `ttlBuffer.Set` after |
+| `txnContext.commit()` | `redis.go` | Drop `buildTTLElems`; call `flushTTLToBuffer()` after Raft dispatch |
+
+### Lua script commit — key change
+
+```go
+// Before: TTL inside IsTxn=true (causes write conflicts)
+func (c *luaScriptContext) commit() error {
+    elems := buildDataAndTTLElems(...)
+    coordinator.Dispatch(&kv.OperationGroup{IsTxn: true, Elems: elems})
+}
+
+// After: data and TTL separated; TTL written to buffer post-commit
+func (c *luaScriptContext) commit() error {
+    dataElems := buildDataElems(...)   // no TTL
+    if len(dataElems) > 0 {
+        coordinator.Dispatch(&kv.OperationGroup{IsTxn: true, Elems: dataElems})
+        // returns on error without writing TTL
+    }
+    c.flushTTLToBuffer()   // only reached on success (or pure-TTL scripts)
+    return nil
+}
+```
+
+This guarantees TTL reaches the buffer only after the data commit succeeds.  If the
+data commit is retried by `retryRedisWrite`, TTL is written to buffer only on the
+successful attempt.
+
+---
+
+## 7. Background flush
+
+### Goroutine lifecycle
+
+`Run()` starts a flush goroutine and ensures a final flush on shutdown:
+
+```go
+func (r *RedisServer) Run() error {
+    ctx, cancel := context.WithCancel(context.Background())
+    var wg sync.WaitGroup
+    wg.Add(1)
+    go func() {
+        defer wg.Done()
+        r.runTTLFlusher(ctx)
+    }()
+    err := redcon.Serve(r.listen, ...)
+    cancel()
+    wg.Wait()   // drain buffer before returning
+    return errors.WithStack(err)
+}
+```
+
+### Flush logic
+
+```go
+func (r *RedisServer) flushTTLBuffer(ctx context.Context) {
+    entries := r.ttlBuffer.Drain()
+    if len(entries) == 0 { return }
+
+    elems := buildTTLFlushElems(entries)   // Put or Del per entry
+    _, err := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+        IsTxn: false,   // last-writer-wins, no conflict detection
+        Elems: elems,
+    })
+    if err != nil {
+        r.ttlBuffer.MergeBack(entries)  // retry on next tick
+        // log warning
+    }
+}
+```
+
+### Flush interval trade-offs
+
+| Interval | Batch size | Raft load | Max TTL loss on crash |
+|---|---|---|---|
+| 10 ms | small | higher | minimal |
+| **100 ms** (default) | medium | low | < 100 ms |
+| 1 s | large | minimal | < 1 s |
+
+Default: 100 ms, configurable via `RedisServerOption`.
+
+---
+
+## 8. Consistency model and trade-offs
+
+### Buffer as the authoritative TTL source
+
+Entries in the buffer represent writes newer than the latest Raft flush.  Reading
+the buffer before the Raft store ensures callers always see the most recent TTL
+without waiting for a flush.
+
+### Crash: data committed, TTL not yet flushed
+
+If the process crashes after a successful Raft data commit but before the TTL flush:
+- Data key exists in Raft.
+- TTL entry exists only in the (now-lost) buffer.
+- Effect: the key has no expiry until the next write sets it again.
+
+**Accepted trade-off**: for rate-limiting keys, a temporarily non-expiring key is
+harmless.  In the worst case, the rate-limit window resets on the next write.
+
+### MVCC snapshot isolation for TTL
+
+`ttlAt(key, readTS)` ignores `readTS` once a buffer entry exists.  This breaks
+strict TTL snapshot isolation but aligns with the existing approximate TTL model.
+The impact is limited to a very short window between a concurrent EXPIRE and commit.
+
+### Follower reads
+
+Each `RedisServer` instance maintains its own buffer.  Followers that handle read
+requests will have an empty buffer and fall back to the Raft store.  TTL precision
+on follower reads is already approximate; this does not change that property.
+
+### Stale TTL keys after DEL
+
+When a key is deleted (`DEL`, type-change replace), `deleteLogicalKeyElems` emits a
+Raft `Del` for `redisTTLKey` if it exists in the store.  Any concurrent buffer entry
+for the deleted key will be flushed later, creating a short-lived "zombie" TTL key in
+Raft.  This is harmless because `keyTypeAt` only checks TTL after confirming the data
+key exists; a zombie TTL for a non-existent data key is never observed.
+
+---
+
+## 9. Failure handling
+
+| Scenario | Behaviour |
+|---|---|
+| Flush fails (Raft unavailable) | `MergeBack` restores drained entries; retried on next tick |
+| Process crash | Buffer lost; keys exist without TTL until next write |
+| Concurrent Set + Drain | Protected by `sync.RWMutex` |
+| Buffer overflow (> 1 M entries) | Oldest entries dropped with a warning log |
+
+---
+
+## 10. Implementation steps
+
+1. **`adapter/redis_ttl_buffer.go`** (new) — `TTLBuffer`, `buildTTLFlushElems`
+2. **`adapter/redis.go`** — add field, init, `Run()` goroutine, flush helpers,
+   `replaceWithStringTxn`, `isLeaderKeyExpired`, `tryLeaderNonStringExists`,
+   remove TTL `trackReadKey` calls, replace `buildTTLElems` with
+   `hasDirtyTTLStates` + `flushTTLToBuffer` in `txnContext`
+3. **`adapter/redis_compat_types.go`** — `ttlAt()` buffer-first
+4. **`adapter/redis_compat_helpers.go`** — `saveString()` TTL to buffer
+5. **`adapter/redis_compat_commands.go`** — `setExpire()` and `incr()` TTL to buffer
+6. **`adapter/redis_lua_context.go`** — `commit()` separation, `commitElemsForKey`
+   drops TTL, add `flushTTLToBuffer()`
+
+---
+
+## 11. Affected files summary
+
+```
+adapter/redis_ttl_buffer.go        new
+adapter/redis.go                   RedisServer struct, Run(), replaceWithStringTxn,
+                                   isLeaderKeyExpired, tryLeaderNonStringExists,
+                                   txnContext.commit, trackReadKey cleanup
+adapter/redis_compat_types.go      ttlAt()
+adapter/redis_compat_helpers.go    saveString()
+adapter/redis_compat_commands.go   setExpire(), incr()
+adapter/redis_lua_context.go       commit(), commitElemsForKey()
+```
+
+No changes to Raft commit paths for string/list/hash/set/zset data.
+TTL keys are simply excluded from `IsTxn=true` transactions.

--- a/docs/design/ttl-memory-buffer.md
+++ b/docs/design/ttl-memory-buffer.md
@@ -342,7 +342,7 @@ key exists; a zombie TTL for a non-existent data key is never observed.
 | Flush fails (Raft unavailable) | `MergeBack` restores drained entries; retried on next tick |
 | Process crash | Buffer lost; keys exist without TTL until next write |
 | Concurrent Set + Drain | Protected by `sync.RWMutex` |
-| Buffer overflow (> 1 M entries) | Oldest entries dropped with a warning log |
+| Buffer overflow (> 1 M entries) | New keys are dropped with a warning log; updates to already-buffered keys are still accepted |
 
 ---
 

--- a/proxy/dualwrite.go
+++ b/proxy/dualwrite.go
@@ -17,6 +17,13 @@ const (
 	// maxShadowGoroutines limits concurrent shadow read goroutines separately
 	// so that secondary write failures cannot starve shadow reads.
 	maxShadowGoroutines = 1024
+	// maxScriptWriteGoroutines limits concurrent secondary Lua-script write goroutines
+	// (EVAL / EVALSHA). Lua scripts under high load cause write conflicts in the Raft
+	// layer, and each conflict triggers a full script re-execution. Capping the
+	// concurrency reduces contention so individual scripts complete within
+	// SecondaryTimeout. Excess scripts are dropped (acceptable in dual-write mode
+	// where Redis remains the authoritative store).
+	maxScriptWriteGoroutines = 64
 )
 
 // DualWriter routes commands to primary and secondary backends based on mode.
@@ -31,6 +38,7 @@ type DualWriter struct {
 
 	writeSem  chan struct{} // bounds concurrent secondary write goroutines
 	shadowSem chan struct{} // bounds concurrent shadow read goroutines
+	scriptSem chan struct{} // bounds concurrent secondary Lua-script write goroutines
 
 	wg       sync.WaitGroup
 	mu       sync.Mutex // protects closed; held briefly to make wg.Add atomic with close check
@@ -52,6 +60,7 @@ func NewDualWriter(primary, secondary Backend, cfg ProxyConfig, metrics *ProxyMe
 		logger:    logger,
 		writeSem:  make(chan struct{}, maxWriteGoroutines),
 		shadowSem: make(chan struct{}, maxShadowGoroutines),
+		scriptSem: make(chan struct{}, maxScriptWriteGoroutines),
 		scripts:   make(map[string]string),
 	}
 
@@ -204,7 +213,7 @@ func (d *DualWriter) Script(ctx context.Context, cmd string, args [][]byte) (any
 	d.rememberScript(cmd, args)
 
 	if d.hasSecondaryWrite() {
-		d.goWrite(func() { d.writeSecondary(cmd, iArgs) })
+		d.goScript(func() { d.writeSecondary(cmd, iArgs) })
 	}
 
 	return resp, err //nolint:wrapcheck // redis.Nil must pass through unwrapped for callers to detect nil replies
@@ -241,6 +250,13 @@ func (d *DualWriter) writeSecondary(cmd string, iArgs []any) {
 // goWrite launches fn in a bounded write goroutine.
 func (d *DualWriter) goWrite(fn func()) {
 	d.goAsyncWithSem(d.writeSem, fn)
+}
+
+// goScript launches fn in a bounded Lua-script write goroutine.
+// It uses a smaller semaphore than goWrite to cap the number of concurrent
+// EVAL/EVALSHA secondary writes. When the cap is reached the write is dropped.
+func (d *DualWriter) goScript(fn func()) {
+	d.goAsyncWithSem(d.scriptSem, fn)
 }
 
 // goShadow launches fn in a bounded shadow-read goroutine.

--- a/proxy/dualwrite.go
+++ b/proxy/dualwrite.go
@@ -21,8 +21,9 @@ const (
 	// (EVAL / EVALSHA). Lua scripts under high load cause write conflicts in the Raft
 	// layer, and each conflict triggers a full script re-execution. Capping the
 	// concurrency reduces contention so individual scripts complete within
-	// SecondaryTimeout. Excess scripts are dropped (acceptable in dual-write mode
-	// where Redis remains the authoritative store).
+	// SecondaryTimeout. Excess secondary script writes may be dropped to keep
+	// contention bounded; this is only tolerable in modes where the script write
+	// is targeting the non-authoritative backend.
 	maxScriptWriteGoroutines = 64
 )
 

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -625,6 +625,49 @@ func TestDualWriter_GoAsync_Bounded(t *testing.T) {
 	d.Close()      // wait for all goroutines to finish
 }
 
+func TestDualWriter_Script_DropsWhenScriptSemFull(t *testing.T) {
+	primary := newMockBackend("primary")
+	primary.doFunc = makeCmd("OK", nil)
+	secondary := newMockBackend("secondary")
+	secondary.doFunc = makeCmd("OK", nil)
+
+	metrics := newTestMetrics()
+	cfg := ProxyConfig{Mode: ModeDualWrite, SecondaryTimeout: 10 * time.Second}
+	d := NewDualWriter(primary, secondary, cfg, metrics, newTestSentry(), testLogger)
+
+	// Fill the script semaphore with blocking goroutines.
+	blocker := make(chan struct{})
+	for range maxScriptWriteGoroutines {
+		d.goScript(func() {
+			<-blocker
+		})
+	}
+
+	// Script should return promptly even when scriptSem is full.
+	done := make(chan struct{})
+	go func() {
+		_, err := d.Script(context.Background(), "EVALSHA", [][]byte{
+			[]byte("EVALSHA"), []byte("deadbeef"), []byte("0"),
+		})
+		assert.NoError(t, err)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// good — Script returned without blocking on a full scriptSem
+	case <-time.After(time.Second):
+		t.Fatal("Script blocked when script semaphore was full")
+	}
+
+	// The async replay to secondary must be dropped.
+	assert.Equal(t, 0, secondary.CallCount())
+	assert.InDelta(t, 1, testutil.ToFloat64(metrics.AsyncDrops), 0.001)
+
+	close(blocker)
+	d.Close()
+}
+
 // TestDualWriter_Close_NoWaitGroupRace verifies that concurrent calls to
 // goAsync and Close do not trigger a "WaitGroup misuse: Add called
 // concurrently with Wait" panic under the race detector.

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -636,6 +636,7 @@ func TestDualWriter_Script_DropsWhenScriptSemFull(t *testing.T) {
 	d := NewDualWriter(primary, secondary, cfg, metrics, newTestSentry(), testLogger)
 
 	// Fill the script semaphore with blocking goroutines.
+	// Keep this tied to maxScriptWriteGoroutines so the test tracks the runtime cap.
 	blocker := make(chan struct{})
 	for range maxScriptWriteGoroutines {
 		d.goScript(func() {


### PR DESCRIPTION
EVALSHA secondary writes to elastickv timed out (context deadline exceeded) because Misskey rate-limit Lua scripts (INCR + EXPIRE) produced concurrent write conflicts on redisTTLKey in IsTxn=true Raft transactions. retryRedisWrite allows up to 50 retries x ~100ms each, exceeding SecondaryTimeout.

Root fix: buffer all TTL writes in memory (TTLBuffer) and flush them to Raft every 100ms via a background goroutine using IsTxn=false (last-writer-wins, no conflict detection). This removes TTL entirely from OCC transactions.

Changes:
- adapter/redis_ttl_buffer.go: new TTLBuffer with seq-based ordering, buildTTLFlushElems, runTTLFlusher, flushTTLBuffer; enforces ttlBufferMaxSize cap with drop-and-warn on overflow
- adapter/redis.go: embed ttlBuffer in RedisServer, wire flush goroutine in Run(), update isLeaderKeyExpired/tryLeaderNonStringExists to check buffer first, remove redisTTLKey from OCC read sets, refactor txnContext.commit() to exclude TTL from IsTxn=true dispatch
- adapter/redis_compat_types.go: ttlAt() reads buffer before Raft store
- adapter/redis_compat_helpers.go: saveString() writes TTL to buffer post-commit
- adapter/redis_compat_commands.go: setExpire() and incr() write TTL to buffer
- adapter/redis_lua_context.go: commit() separates data dispatch from TTL; add flushTTLForKeyToBuffer() called after successful Raft dispatch
- proxy/dualwrite.go: add scriptSem (cap 64) to limit concurrent EVALSHA secondary writes as a complementary mitigation
- adapter/redis_txn_test.go: update TTL conflict test to reflect new semantics (TTL updates no longer trigger OCC conflicts)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Immediate TTL visibility after EXPIRE, PEXPIRE, and SET with EX options
  * Proper INCR semantics—now clears TTL when incrementing keys
  * Improved TTL handling in transactions (MULTI/EXEC)

* **Bug Fixes**
  * Fixed TTL consistency and expiration visibility issues
  * Enhanced Redis TTL compatibility across multiple command types

* **Performance**
  * Optimized Lua script execution with independent concurrency control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->