### PR TITLE
fix(redis): track list boundary keys in MULTI read set to prevent G2-item anomaly

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1752,14 +1752,20 @@ func (t *txnContext) loadListState(key []byte) (*listTxnState, error) {
 	}
 	t.listStates[k] = st
 
+	// Track the list meta key so that concurrent structural changes (DEL,
+	// compaction that rewrites the base meta) create a read-write conflict.
+	t.trackReadKey(listMetaKey(key))
 	// Track the list-item key at the current tail (and the position before the
 	// head) so that concurrent RPUSH/LPUSH operations—which write to exactly
 	// these positions—trigger a read-write conflict and force a retry.
 	// Without this, a MULTI transaction that reads a list via LRANGE can commit
 	// with a stale snapshot while a concurrent RPUSH commits a new item,
 	// forming an anti-dependency (G2-item) cycle.
+	// We intentionally track only the list-specific keys (not trackTypeReadKeys)
+	// to avoid registering irrelevant type keys (hash/set/zset/str) that would
+	// add unnecessary FSM LatestCommitTS lookups for every LRANGE in a MULTI.
 	t.trackReadKey(listItemKey(key, meta.Head+meta.Len)) // next RPUSH target
-	t.trackReadKey(listItemKey(key, meta.Head-1))        // next LPUSH target
+	t.trackReadKey(listItemKey(key, meta.Head-1))         // next LPUSH target
 
 	return st, nil
 }

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1752,20 +1752,19 @@ func (t *txnContext) loadListState(key []byte) (*listTxnState, error) {
 	}
 	t.listStates[k] = st
 
-	// Track the list meta key so that concurrent structural changes (DEL,
-	// compaction that rewrites the base meta) create a read-write conflict.
-	t.trackReadKey(listMetaKey(key))
 	// Track the list-item key at the current tail (and the position before the
 	// head) so that concurrent RPUSH/LPUSH operations—which write to exactly
 	// these positions—trigger a read-write conflict and force a retry.
 	// Without this, a MULTI transaction that reads a list via LRANGE can commit
 	// with a stale snapshot while a concurrent RPUSH commits a new item,
 	// forming an anti-dependency (G2-item) cycle.
-	// We intentionally track only the list-specific keys (not trackTypeReadKeys)
-	// to avoid registering irrelevant type keys (hash/set/zset/str) that would
-	// add unnecessary FSM LatestCommitTS lookups for every LRANGE in a MULTI.
+	// The base meta key (listMetaKey) is intentionally NOT tracked here: the
+	// Delta scheme allows the DeltaCompactor to rewrite it without conflicting
+	// with ongoing push/read transactions (see TestRedisTxnValidateReadSet_ListMetaUpdateNoConflict).
 	t.trackReadKey(listItemKey(key, meta.Head+meta.Len)) // next RPUSH target
-	t.trackReadKey(listItemKey(key, meta.Head-1))         // next LPUSH target
+	if meta.Head > math.MinInt64 {
+		t.trackReadKey(listItemKey(key, meta.Head-1)) // next LPUSH target
+	}
 
 	return st, nil
 }

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1751,6 +1751,16 @@ func (t *txnContext) loadListState(key []byte) (*listTxnState, error) {
 		existingDeltas: existingDeltas,
 	}
 	t.listStates[k] = st
+
+	// Track the list-item key at the current tail (and the position before the
+	// head) so that concurrent RPUSH/LPUSH operations—which write to exactly
+	// these positions—trigger a read-write conflict and force a retry.
+	// Without this, a MULTI transaction that reads a list via LRANGE can commit
+	// with a stale snapshot while a concurrent RPUSH commits a new item,
+	// forming an anti-dependency (G2-item) cycle.
+	t.trackReadKey(listItemKey(key, meta.Head+meta.Len)) // next RPUSH target
+	t.trackReadKey(listItemKey(key, meta.Head-1))        // next LPUSH target
+
 	return st, nil
 }
 

--- a/adapter/redis_ttl_buffer.go
+++ b/adapter/redis_ttl_buffer.go
@@ -181,8 +181,8 @@ func (b *TTLBuffer) MergeBack(entries map[string]ttlBufferEntry) {
 	if dropped == 0 {
 		return
 	}
-	dropCount := b.dropped.Add(uint64(dropped))
-	prevDropCount := dropCount - uint64(dropped)
+	dropCount := b.dropped.Add(uint64(dropped))  //#nosec G115 -- dropped is always non-negative, bounded by map size
+	prevDropCount := dropCount - uint64(dropped) //#nosec G115 -- same bound
 	if prevDropCount == 0 || prevDropCount/ttlBufferDropLogEvery != dropCount/ttlBufferDropLogEvery {
 		slog.Warn(
 			"ttl buffer merge-back dropped entries",

--- a/adapter/redis_ttl_buffer.go
+++ b/adapter/redis_ttl_buffer.go
@@ -162,7 +162,7 @@ func (b *TTLBuffer) MergeBack(entries map[string]ttlBufferEntry) {
 		return
 	}
 	b.mu.Lock()
-	dropped := 0
+	var dropped uint64
 	var size int
 	for key, entry := range entries {
 		if e, ok := b.entries[key]; ok {
@@ -181,8 +181,8 @@ func (b *TTLBuffer) MergeBack(entries map[string]ttlBufferEntry) {
 	if dropped == 0 {
 		return
 	}
-	dropCount := b.dropped.Add(uint64(dropped))  //#nosec G115 -- dropped is always non-negative, bounded by map size
-	prevDropCount := dropCount - uint64(dropped) //#nosec G115 -- same bound
+	dropCount := b.dropped.Add(dropped)
+	prevDropCount := dropCount - dropped
 	if prevDropCount == 0 || prevDropCount/ttlBufferDropLogEvery != dropCount/ttlBufferDropLogEvery {
 		slog.Warn(
 			"ttl buffer merge-back dropped entries",

--- a/adapter/redis_txn_test.go
+++ b/adapter/redis_txn_test.go
@@ -10,6 +10,80 @@ import (
 	"github.com/tidwall/redcon"
 )
 
+// TestRedisTxnValidateReadSet_ConcurrentRPushTriggersConflict verifies that a
+// concurrent RPUSH to a list triggers an OCC read-write conflict for a MULTI
+// transaction that read the list via LRANGE.  Without the boundary key tracking
+// added to loadListState the validateReadSet call would report no conflict,
+// allowing a G2-item anti-dependency cycle to commit undetected.
+func TestRedisTxnValidateReadSet_ConcurrentRPushTriggersConflict(t *testing.T) {
+	t.Parallel()
+
+	server, st := newRedisStorageMigrationTestServer(t)
+	key := []byte("list:concurrent-rpush")
+
+	// Write a list with Head=0, Len=5 at ts=10.
+	metaBytes, err := store.MarshalListMeta(store.ListMeta{Len: 5})
+	require.NoError(t, err)
+	require.NoError(t, st.PutAt(context.Background(), store.ListMetaKey(key), metaBytes, 10, 0))
+
+	// T1: begin a MULTI/EXEC that reads the list (LRANGE) at startTS=10.
+	txn := &txnContext{
+		server:     server,
+		working:    map[string]*txnValue{},
+		listStates: map[string]*listTxnState{},
+		zsetStates: map[string]*zsetTxnState{},
+		ttlStates:  map[string]*ttlTxnState{},
+		readKeys:   map[string][]byte{},
+		startTS:    10,
+	}
+	_, err = txn.loadListState(key)
+	require.NoError(t, err)
+
+	// T2: a concurrent RPUSH commits a new item at the tail position (seq=5) at ts=11.
+	require.NoError(t, st.PutAt(context.Background(), store.ListItemKey(key, 5), []byte("new"), 11, 0))
+
+	// T1's validateReadSet must detect the read-write conflict via the tracked tail key.
+	err = txn.validateReadSet(context.Background())
+	require.ErrorIs(t, err, store.ErrWriteConflict,
+		"LRANGE in MULTI must conflict with a concurrent RPUSH on the same key (G2-item prevention)")
+}
+
+// TestRedisTxnValidateReadSet_ConcurrentLPushTriggersConflict verifies that a
+// concurrent LPUSH to a list triggers an OCC read-write conflict for a MULTI
+// transaction that read the list via LRANGE.
+func TestRedisTxnValidateReadSet_ConcurrentLPushTriggersConflict(t *testing.T) {
+	t.Parallel()
+
+	server, st := newRedisStorageMigrationTestServer(t)
+	key := []byte("list:concurrent-lpush")
+
+	// Write a list with Head=0, Len=5 at ts=10.
+	metaBytes, err := store.MarshalListMeta(store.ListMeta{Len: 5})
+	require.NoError(t, err)
+	require.NoError(t, st.PutAt(context.Background(), store.ListMetaKey(key), metaBytes, 10, 0))
+
+	// T1: begin a MULTI/EXEC that reads the list at startTS=10.
+	txn := &txnContext{
+		server:     server,
+		working:    map[string]*txnValue{},
+		listStates: map[string]*listTxnState{},
+		zsetStates: map[string]*zsetTxnState{},
+		ttlStates:  map[string]*ttlTxnState{},
+		readKeys:   map[string][]byte{},
+		startTS:    10,
+	}
+	_, err = txn.loadListState(key)
+	require.NoError(t, err)
+
+	// T2: a concurrent LPUSH commits a new item at head-1 (seq=-1) at ts=11.
+	require.NoError(t, st.PutAt(context.Background(), store.ListItemKey(key, -1), []byte("new"), 11, 0))
+
+	// T1's validateReadSet must detect the read-write conflict via the tracked head-adjacent key.
+	err = txn.validateReadSet(context.Background())
+	require.ErrorIs(t, err, store.ErrWriteConflict,
+		"LRANGE in MULTI must conflict with a concurrent LPUSH on the same key (G2-item prevention)")
+}
+
 // TestRedisTxnValidateReadSet_ListMetaUpdateNoConflict verifies that updating
 // the base list metadata key (e.g. by a DeltaCompactor) does NOT trigger an
 // OCC conflict for append operations.  With the Delta pattern, appenders never


### PR DESCRIPTION
loadListState never called trackReadKey, so LRANGE inside MULTI did not register any read-set entries for the list. A concurrent RPUSH on the same key committed a new delta key (a brand-new key unknown to the reader), so neither validateReadSet nor the FSM checkReadConflicts detected the conflict. Both transactions could commit, producing an anti-dependency (rw) cycle that Jepsen elle checker flags as G2-item.

Fix: after resolving list metadata, track the list-item key at the current tail (meta.Head+meta.Len) and the position just before the head (meta.Head-1). A concurrent RPUSH writes exactly the tail position and a concurrent LPUSH writes exactly the head-1 position, so either operation now creates a read-write conflict that forces a retry.

Also suppress two gosec G115 false-positives in redis_ttl_buffer.go that were blocking the pre-commit hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transaction conflict detection to properly handle concurrent list append operations, ensuring reliable retry behavior and preventing potential data consistency issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->