### PR TITLE
perf(raft): replace shared dispatch channel with per-peer channels to eliminate head-of-line blocking

### DIFF
--- a/docs/design/raft-grpc-streaming-transport.md
+++ b/docs/design/raft-grpc-streaming-transport.md
@@ -136,9 +136,11 @@ pick up the next message from the per-peer channel.
 > `stream.Send` with a `sync.Mutex` per peer. Simpler to implement but adds
 > a lock on the hot path.
 >
-> Option A is preferred: it eliminates the lock, and within-peer ordering is already
-> guaranteed by the two independent channels. `getOrOpenStream` is protected by
-> `mu` only for map access and must not be called from multiple workers simultaneously.
+> Option A is preferred: it eliminates the lock on the hot path, and within-peer
+> ordering is already guaranteed by the single multiplexing worker. `getOrOpenStream`
+> uses `mu` only to serialize map access; the per-peer stream itself is then written
+> by exactly one goroutine (the multiplexing worker), satisfying gRPC's
+> single-writer requirement.
 
 ### 3.3 Receiver side (`GRPCTransport`)
 

--- a/docs/design/raft-grpc-streaming-transport.md
+++ b/docs/design/raft-grpc-streaming-transport.md
@@ -211,21 +211,32 @@ for {
     // Drain the priority channel before accepting normal messages.
     select {
     case req := <-pd.heartbeat:
-        stream.Send(req)
+        if err := stream.Send(req); err != nil {
+            return err // triggers teardown + reconnect (§3.4)
+        }
         continue
     default:
     }
     // No priority message pending; wait on either.
     select {
     case req := <-pd.heartbeat:
-        stream.Send(req)
+        if err := stream.Send(req); err != nil {
+            return err
+        }
     case req := <-pd.normal:
-        stream.Send(req)
+        if err := stream.Send(req); err != nil {
+            return err
+        }
     case <-ctx.Done():
-        return
+        return nil
     }
 }
 ```
+
+`stream.Send` errors (broken stream, lost connection) are returned immediately,
+triggering the stream teardown and reconnect path described in §3.4. Raft's
+built-in retransmission handles any messages dropped during the reconnect window
+— identical to the behaviour of the existing unary `Send` drop path.
 
 This guarantees heartbeats are flushed before the next log entry is written
 to the stream, bounding heartbeat delay to one normal-message send time.

--- a/docs/design/raft-grpc-streaming-transport.md
+++ b/docs/design/raft-grpc-streaming-transport.md
@@ -67,7 +67,7 @@ Snapshot messages already use client streaming (`SendSnapshot`); regular message
 
 ### 3.1 Protocol change
 
-Add a bidirectional streaming RPC to `etcd_raft.proto`:
+Add a client-streaming RPC to `etcd_raft.proto`:
 
 ```protobuf
 service EtcdRaft {
@@ -122,11 +122,23 @@ err = stream.Send(&pb.EtcdRaftMessage{Message: raw})
 pick up the next message from the per-peer channel.
 
 > **Concurrency constraint**: gRPC-go's `stream.Send` / `SendMsg` is **not**
-> goroutine-safe. Each per-peer stream must be accessed by exactly one goroutine
-> at a time. This is satisfied by the existing architecture: each peer has a
-> single dispatch worker goroutine that owns the stream and is the only caller
-> of `stream.Send`. `getOrOpenStream` is protected by `mu` only for map
-> access; stream sends must remain confined to the owning dispatch worker.
+> goroutine-safe. Each per-peer stream must be written by exactly one goroutine.
+>
+> PR #522 runs **two** dispatch workers per peer (one for normal messages, one for
+> heartbeats). When streaming is introduced, these two workers cannot share a
+> single `SendStream` stream without external synchronization. Two approaches:
+>
+> **Option A — single multiplexing worker**: merge both channels into one goroutine
+> that reads from either channel via `select` and writes to the stream. Preserves
+> stream ownership with no locking.
+>
+> **Option B — stream-level mutex**: keep the two-worker model and protect
+> `stream.Send` with a `sync.Mutex` per peer. Simpler to implement but adds
+> a lock on the hot path.
+>
+> Option A is preferred: it eliminates the lock, and within-peer ordering is already
+> guaranteed by the two independent channels. `getOrOpenStream` is protected by
+> `mu` only for map access and must not be called from multiple workers simultaneously.
 
 ### 3.3 Receiver side (`GRPCTransport`)
 

--- a/docs/design/raft-grpc-streaming-transport.md
+++ b/docs/design/raft-grpc-streaming-transport.md
@@ -209,7 +209,11 @@ to either channel:
 ```go
 for {
     // Drain the priority channel before accepting normal messages.
+    // ctx.Done() is checked here too so a sustained heartbeat burst
+    // cannot prevent a prompt shutdown.
     select {
+    case <-ctx.Done():
+        return nil
     case req := <-pd.heartbeat:
         if err := stream.Send(req); err != nil {
             return err // triggers teardown + reconnect (§3.4)

--- a/docs/design/raft-grpc-streaming-transport.md
+++ b/docs/design/raft-grpc-streaming-transport.md
@@ -1,0 +1,187 @@
+# Design: gRPC Streaming Transport for Raft Messages
+
+## 1. Background and motivation
+
+### Problem
+
+The current Raft transport uses a unary gRPC RPC (`Send`) for every outbound message:
+
+```
+dispatchRegular:
+  msg.Marshal() → client.Send(ctx, req) → wait ACK → return
+```
+
+Each call pays a full network round-trip before the next message can be sent.
+With `defaultMaxInflightMsg = 1024`, the leader can generate up to 1024 MsgApp
+messages per follower before receiving ACK. A single dispatch worker serialises
+those 1024 sends: at 1 ms RTT, throughput is capped at ~1 000 msg/s per peer
+regardless of bandwidth.
+
+PR #522 introduced per-peer dispatch channels and `defaultDispatchWorkersPerPeer = 1`
+to eliminate cross-peer head-of-line blocking. The remaining bottleneck is the
+per-message RTT of unary gRPC.
+
+### Goal
+
+Replace per-message unary RPCs with a **long-lived bidirectional gRPC stream per peer**
+so that the sender does not block waiting for an individual ACK between messages.
+Expected outcome: throughput per peer scales with available bandwidth rather than
+being RTT-limited.
+
+---
+
+## 2. Current architecture
+
+```
+Engine run loop
+  └─ sendMessages()
+       └─ enqueueDispatchMessage()  → peerDispatchers[nodeID] (chan, cap 512)
+                                          ↓
+                                   runDispatchWorker (1 goroutine/peer)
+                                          ↓
+                                   GRPCTransport.dispatchRegular()
+                                          ↓
+                                   client.Send(ctx, EtcdRaftMessage)   ← unary, blocks on RTT
+                                          ↓
+                                   receive EtcdRaftAck
+```
+
+Snapshot messages already use client streaming (`SendSnapshot`); regular messages do not.
+
+---
+
+## 3. Proposed design
+
+### 3.1 Protocol change
+
+Add a bidirectional streaming RPC to `etcd_raft.proto`:
+
+```protobuf
+service EtcdRaft {
+  rpc Send(EtcdRaftMessage)              returns (EtcdRaftAck) {}          // kept for compat
+  rpc SendStream(stream EtcdRaftMessage) returns (stream EtcdRaftAck) {}   // new
+  rpc SendSnapshot(stream EtcdRaftSnapshotChunk) returns (EtcdRaftAck) {}
+}
+```
+
+`EtcdRaftAck` is reused as the per-stream ACK (sent once when the server closes
+the stream or on explicit flush). Per-message ACKs are intentionally omitted:
+Raft's own MsgAppResp / MsgHeartbeatResp handle application-level
+acknowledgement; the transport only needs delivery confirmation at stream
+granularity.
+
+### 3.2 Sender side (`GRPCTransport`)
+
+Add a `peerStream` map protected by `mu`:
+
+```go
+type peerStream struct {
+    stream pb.EtcdRaft_SendStreamClient
+    cancel context.CancelFunc
+}
+
+type GRPCTransport struct {
+    // existing fields ...
+    streams map[uint64]*peerStream   // nodeID → active stream
+}
+```
+
+`getOrOpenStream(nodeID)` returns the existing stream or opens a new one.
+On error (network drop, server restart), the stream is torn down and a new
+one is opened on the next send attempt.
+
+`dispatchRegular` changes from:
+
+```go
+_, err = client.Send(ctx, &pb.EtcdRaftMessage{Message: raw})
+```
+
+to:
+
+```go
+stream, err := t.getOrOpenStream(msg.To)
+if err != nil { return err }
+err = stream.Send(&pb.EtcdRaftMessage{Message: raw})
+```
+
+`stream.Send()` returns as soon as the message enters the gRPC send buffer
+(non-blocking under normal conditions). The dispatch worker can immediately
+pick up the next message from the per-peer channel.
+
+### 3.3 Receiver side (`GRPCTransport`)
+
+Add a `SendStream` server handler:
+
+```go
+func (t *GRPCTransport) SendStream(stream pb.EtcdRaft_SendStreamServer) error {
+    for {
+        req, err := stream.Recv()
+        if err == io.EOF {
+            return stream.SendAndClose(&pb.EtcdRaftAck{})
+        }
+        if err != nil {
+            return err
+        }
+        var msg raftpb.Message
+        if err := msg.Unmarshal(req.Message); err != nil {
+            return err
+        }
+        if err := t.handle(stream.Context(), msg); err != nil {
+            return err
+        }
+    }
+}
+```
+
+### 3.4 Stream lifecycle
+
+| Event | Action |
+|---|---|
+| First message to peer | Open stream, store in `streams[nodeID]` |
+| `stream.Send()` error | Close and delete stream; caller retries via `getOrOpenStream` |
+| `removePeer(nodeID)` | Cancel stream context, delete from `streams` |
+| `GRPCTransport.Close()` | Cancel all stream contexts, close all streams |
+| Peer restart / network partition | Server closes stream → sender gets error on next `Send()` → reconnect |
+
+### 3.5 Backward compatibility
+
+Nodes that have not yet upgraded only register `Send()`. The sender detects
+`codes.Unimplemented` on `SendStream` and falls back to the existing unary
+`Send()` path. A version negotiation flag (e.g., a field in peer metadata) can
+be used to skip the probe after the first successful stream is established.
+
+---
+
+## 4. Trade-offs and risks
+
+| Factor | Notes |
+|---|---|
+| **Throughput** | Removes per-message RTT; limited by bandwidth and gRPC flow control window |
+| **Latency** | Messages reach the receiver faster (no ACK wait) |
+| **Head-of-line blocking** | Still present within a single stream; mitigated by per-peer isolation from PR #522 |
+| **Stream reconnect gap** | During reconnect, messages are dropped and Raft retransmits — identical to current drop behaviour |
+| **Memory** | gRPC stream send buffer (typically 32 KB) replaces per-peer channel as primary buffer; channel can be reduced |
+| **Complexity** | Stream state machine in `GRPCTransport`; backward-compat fallback path |
+| **Ordering** | Single stream per peer preserves FIFO — safe for Raft |
+
+---
+
+## 5. Implementation plan
+
+| Step | Scope | Estimate |
+|---|---|---|
+| 1. Proto: add `SendStream` RPC | `proto/etcd_raft.proto` + regenerate | 0.5 day |
+| 2. Receiver handler | `GRPCTransport.SendStream` | 0.5 day |
+| 3. Stream open/close/reconnect | `getOrOpenStream`, `peerStream` lifecycle | 1 day |
+| 4. Sender: swap unary → stream in `dispatchRegular` | `GRPCTransport.dispatchRegular` | 0.5 day |
+| 5. Backward-compat fallback | Unimplemented detection, version flag | 1 day |
+| 6. Tests | Unit + conformance | 1 day |
+| **Total** | | **~4.5 days** |
+
+---
+
+## 6. Out of scope
+
+- Batch encoding (multiple `EtcdRaftMessage` payloads in one proto message) — independent optimisation.
+- Priority queuing for heartbeats vs log entries — orthogonal to transport protocol.
+- Snapshot streaming changes — already implemented.

--- a/docs/design/raft-grpc-streaming-transport.md
+++ b/docs/design/raft-grpc-streaming-transport.md
@@ -37,7 +37,7 @@ being RTT-limited.
 Engine run loop
   └─ sendMessages()
        └─ enqueueDispatchMessage()
-            ├─ regular messages   → peerDispatchers[nodeID].normal    (chan, cap 512)
+            ├─ regular messages   → peerDispatchers[nodeID].normal    (chan, cap MaxInflightMsg)
             │                           ↓
             │                    runDispatchWorker (1 goroutine/peer)
             │                           ↓
@@ -47,7 +47,7 @@ Engine run loop
             │                           ↓
             │                    receive EtcdRaftAck
             │
-            └─ heartbeat messages → peerDispatchers[nodeID].heartbeat (chan, cap 512)
+            └─ heartbeat messages → peerDispatchers[nodeID].heartbeat (chan, cap MaxInflightMsg)
                                         ↓
                                  runDispatchWorker (1 goroutine/peer, dedicated)
                                         ↓

--- a/docs/design/raft-grpc-streaming-transport.md
+++ b/docs/design/raft-grpc-streaming-transport.md
@@ -1,5 +1,10 @@
 # Design: gRPC Streaming Transport for Raft Messages
 
+> **Status: proposed — not yet implemented.**
+> PR #522 delivers the per-peer dispatch channel foundation described in §2.
+> This document specifies the next step: replacing per-message unary RPCs with
+> a long-lived client-streaming gRPC connection per peer.
+
 ## 1. Background and motivation
 
 ### Problem
@@ -188,7 +193,22 @@ be used to skip the probe after the first successful stream is established.
 
 ---
 
-## 6. Out of scope
+## 6. Rollout and migration strategy
+
+Because `SendStream` is additive, the rollout is zero-downtime by design:
+
+| Phase | Action |
+|---|---|
+| **Deploy new server binary** | All nodes register both `Send` (unary) and `SendStream`. Existing peers that have not yet upgraded continue to use `Send` — no behaviour change. |
+| **Gradual upgrade** | As each peer is upgraded, the sender detects `SendStream` availability (no `codes.Unimplemented`) and opens a stream. Unary `Send` remains the fallback for un-upgraded peers. |
+| **Full cutover** | Once all peers run the new binary, every peer-to-peer path uses streaming. The unary `Send` handler is kept indefinitely for backward compatibility. |
+
+No dual-write or blue/green deployment is required: the `codes.Unimplemented` probe
+(§3.5) makes the switch per-peer and per-connection atomically.
+
+---
+
+## 7. Out of scope
 
 - Batch encoding (multiple `EtcdRaftMessage` payloads in one proto message) — independent optimisation.
 - Priority queuing for heartbeats vs log entries — orthogonal to transport protocol.

--- a/docs/design/raft-grpc-streaming-transport.md
+++ b/docs/design/raft-grpc-streaming-transport.md
@@ -11,7 +11,7 @@
 
 The current Raft transport uses a unary gRPC RPC (`Send`) for every outbound message:
 
-```
+```text
 dispatchRegular:
   msg.Marshal() → client.Send(ctx, req) → wait ACK → return
 ```
@@ -38,7 +38,7 @@ being RTT-limited.
 
 ## 2. Current architecture
 
-```
+```text
 Engine run loop
   └─ sendMessages()
        └─ enqueueDispatchMessage()
@@ -120,6 +120,13 @@ err = stream.Send(&pb.EtcdRaftMessage{Message: raw})
 `stream.Send()` returns as soon as the message enters the gRPC send buffer
 (non-blocking under normal conditions). The dispatch worker can immediately
 pick up the next message from the per-peer channel.
+
+> **Concurrency constraint**: gRPC-go's `stream.Send` / `SendMsg` is **not**
+> goroutine-safe. Each per-peer stream must be accessed by exactly one goroutine
+> at a time. This is satisfied by the existing architecture: each peer has a
+> single dispatch worker goroutine that owns the stream and is the only caller
+> of `stream.Send`. `getOrOpenStream` is protected by `mu` only for map
+> access; stream sends must remain confined to the owning dispatch worker.
 
 ### 3.3 Receiver side (`GRPCTransport`)
 

--- a/docs/design/raft-grpc-streaming-transport.md
+++ b/docs/design/raft-grpc-streaming-transport.md
@@ -17,8 +17,9 @@ messages per follower before receiving ACK. A single dispatch worker serialises
 those 1024 sends: at 1 ms RTT, throughput is capped at ~1 000 msg/s per peer
 regardless of bandwidth.
 
-PR #522 introduced per-peer dispatch channels and `defaultDispatchWorkersPerPeer = 1`
-to eliminate cross-peer head-of-line blocking. The remaining bottleneck is the
+PR #522 introduced per-peer dispatch channels and `defaultDispatchWorkersPerPeer = 2`
+(one goroutine for normal messages, one dedicated to heartbeats) to eliminate
+cross-peer head-of-line blocking. The remaining bottleneck is the
 per-message RTT of unary gRPC.
 
 ### Goal
@@ -35,15 +36,22 @@ being RTT-limited.
 ```
 Engine run loop
   └─ sendMessages()
-       └─ enqueueDispatchMessage()  → peerDispatchers[nodeID] (chan, cap 512)
-                                          ↓
-                                   runDispatchWorker (1 goroutine/peer)
-                                          ↓
-                                   GRPCTransport.dispatchRegular()
-                                          ↓
-                                   client.Send(ctx, EtcdRaftMessage)   ← unary, blocks on RTT
-                                          ↓
-                                   receive EtcdRaftAck
+       └─ enqueueDispatchMessage()
+            ├─ regular messages   → peerDispatchers[nodeID].normal    (chan, cap 512)
+            │                           ↓
+            │                    runDispatchWorker (1 goroutine/peer)
+            │                           ↓
+            │                    GRPCTransport.dispatchRegular()
+            │                           ↓
+            │                    client.Send(ctx, EtcdRaftMessage)   ← unary, blocks on RTT
+            │                           ↓
+            │                    receive EtcdRaftAck
+            │
+            └─ heartbeat messages → peerDispatchers[nodeID].heartbeat (chan, cap 512)
+                                        ↓
+                                 runDispatchWorker (1 goroutine/peer, dedicated)
+                                        ↓
+                                 GRPCTransport.dispatchRegular()
 ```
 
 Snapshot messages already use client streaming (`SendSnapshot`); regular messages do not.
@@ -58,17 +66,17 @@ Add a bidirectional streaming RPC to `etcd_raft.proto`:
 
 ```protobuf
 service EtcdRaft {
-  rpc Send(EtcdRaftMessage)              returns (EtcdRaftAck) {}          // kept for compat
-  rpc SendStream(stream EtcdRaftMessage) returns (stream EtcdRaftAck) {}   // new
+  rpc Send(EtcdRaftMessage)              returns (EtcdRaftAck) {}        // kept for compat
+  rpc SendStream(stream EtcdRaftMessage) returns (EtcdRaftAck) {}        // new: client-streaming
   rpc SendSnapshot(stream EtcdRaftSnapshotChunk) returns (EtcdRaftAck) {}
 }
 ```
 
-`EtcdRaftAck` is reused as the per-stream ACK (sent once when the server closes
-the stream or on explicit flush). Per-message ACKs are intentionally omitted:
-Raft's own MsgAppResp / MsgHeartbeatResp handle application-level
-acknowledgement; the transport only needs delivery confirmation at stream
-granularity.
+`SendStream` is **client-streaming**: the client sends a sequence of messages and
+the server replies with a single `EtcdRaftAck` when the stream closes or on error.
+Per-message ACKs are intentionally omitted: Raft's own MsgAppResp / MsgHeartbeatResp
+handle application-level acknowledgement; the transport only needs delivery
+confirmation at stream granularity.
 
 ### 3.2 Sender side (`GRPCTransport`)
 

--- a/docs/design/raft-grpc-streaming-transport.md
+++ b/docs/design/raft-grpc-streaming-transport.md
@@ -29,7 +29,7 @@ per-message RTT of unary gRPC.
 
 ### Goal
 
-Replace per-message unary RPCs with a **long-lived bidirectional gRPC stream per peer**
+Replace per-message unary RPCs with a **long-lived client-streaming gRPC stream per peer**
 so that the sender does not block waiting for an individual ACK between messages.
 Expected outcome: throughput per peer scales with available bandwidth rather than
 being RTT-limited.

--- a/docs/design/raft-grpc-streaming-transport.md
+++ b/docs/design/raft-grpc-streaming-transport.md
@@ -22,7 +22,7 @@ messages per follower before receiving ACK. A single dispatch worker serialises
 those 256 sends: at 1 ms RTT, throughput is capped at ~1 000 msg/s per peer
 regardless of bandwidth.
 
-PR #522 introduced per-peer dispatch channels and `defaultDispatchWorkersPerPeer = 2`
+PR #522 introduced per-peer dispatch channels and two dispatch workers per peer
 (one goroutine for normal messages, one dedicated to heartbeats) to eliminate
 cross-peer head-of-line blocking. The remaining bottleneck is the
 per-message RTT of unary gRPC.

--- a/docs/design/raft-grpc-streaming-transport.md
+++ b/docs/design/raft-grpc-streaming-transport.md
@@ -17,9 +17,9 @@ dispatchRegular:
 ```
 
 Each call pays a full network round-trip before the next message can be sent.
-With `defaultMaxInflightMsg = 1024`, the leader can generate up to 1024 MsgApp
+With `defaultMaxInflightMsg = 256`, the leader can generate up to 256 MsgApp
 messages per follower before receiving ACK. A single dispatch worker serialises
-those 1024 sends: at 1 ms RTT, throughput is capped at ~1 000 msg/s per peer
+those 256 sends: at 1 ms RTT, throughput is capped at ~1 000 msg/s per peer
 regardless of bandwidth.
 
 PR #522 introduced per-peer dispatch channels and `defaultDispatchWorkersPerPeer = 2`
@@ -195,6 +195,38 @@ be used to skip the probe after the first successful stream is established.
 | **Memory** | gRPC stream send buffer (typically 32 KB) replaces per-peer channel as primary buffer; channel can be reduced |
 | **Complexity** | Stream state machine in `GRPCTransport`; backward-compat fallback path |
 | **Ordering** | Single stream per peer preserves FIFO — safe for Raft |
+| **Heartbeat starvation** | Under a burst of log entries, heartbeats could be delayed in the send buffer. Mitigated via biased-select (see below). |
+
+### 3.6 Heartbeat starvation mitigation — biased select
+
+When the multiplexing dispatch worker (Option A from §3.2) reads from both
+channels, a sustained `MsgApp` burst can delay heartbeats. The mitigation is
+a **biased select**: check the priority channel non-blocking first, fall back
+to either channel:
+
+```go
+for {
+    // Drain the priority channel before accepting normal messages.
+    select {
+    case req := <-pd.heartbeat:
+        stream.Send(req)
+        continue
+    default:
+    }
+    // No priority message pending; wait on either.
+    select {
+    case req := <-pd.heartbeat:
+        stream.Send(req)
+    case req := <-pd.normal:
+        stream.Send(req)
+    case <-ctx.Done():
+        return
+    }
+}
+```
+
+This guarantees heartbeats are flushed before the next log entry is written
+to the stream, bounding heartbeat delay to one normal-message send time.
 
 ---
 

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -24,7 +24,7 @@ const (
 	defaultTickInterval           = 10 * time.Millisecond
 	defaultHeartbeatTick          = 1
 	defaultElectionTick           = 10
-	defaultMaxInflightMsg         = 256
+	defaultMaxInflightMsg         = 1024
 	defaultMaxSizePerMsg          = 1 << 20
 	defaultDispatchWorkersPerPeer = 1
 	defaultSnapshotEvery          = 10_000

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -21,11 +21,11 @@ import (
 )
 
 const (
-	defaultTickInterval           = 10 * time.Millisecond
-	defaultHeartbeatTick          = 1
-	defaultElectionTick           = 10
-	defaultMaxInflightMsg         = 1024
-	defaultMaxSizePerMsg          = 1 << 20
+	defaultTickInterval   = 10 * time.Millisecond
+	defaultHeartbeatTick  = 1
+	defaultElectionTick   = 10
+	defaultMaxInflightMsg = 1024
+	defaultMaxSizePerMsg  = 1 << 20
 	// defaultDispatchWorkersPerPeer is the number of goroutines started per peer:
 	// one for normal messages (MsgApp, etc.) and one dedicated to heartbeats.
 	defaultDispatchWorkersPerPeer = 2

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -2042,25 +2042,32 @@ func (e *Engine) runDispatchWorker(ctx context.Context, ch chan dispatchRequest)
 			if !ok {
 				return
 			}
-			if ctx.Err() != nil {
-				_ = req.Close()
-				continue
-			}
-			if err := e.dispatchTransport(ctx, req); err != nil {
-				count := e.dispatchErrorCount.Add(1)
-				if shouldLogDispatchEvent(count) {
-					slog.Warn("etcd raft outbound dispatch failed",
-						"node_id", e.nodeID,
-						"to", req.msg.To,
-						"type", req.msg.Type.String(),
-						"dispatch_error_count", count,
-						"err", err,
-					)
-				}
-				_ = req.Close()
-				continue
-			}
-			_ = req.Close()
+			e.handleDispatchRequest(ctx, req)
+		}
+	}
+}
+
+func (e *Engine) handleDispatchRequest(ctx context.Context, req dispatchRequest) {
+	if ctx.Err() != nil {
+		if err := req.Close(); err != nil {
+			slog.Error("etcd raft dispatch: failed to close request", "err", err)
+		}
+		return
+	}
+	dispatchErr := e.dispatchTransport(ctx, req)
+	if err := req.Close(); err != nil {
+		slog.Error("etcd raft dispatch: failed to close request", "err", err)
+	}
+	if dispatchErr != nil {
+		count := e.dispatchErrorCount.Add(1)
+		if shouldLogDispatchEvent(count) {
+			slog.Warn("etcd raft outbound dispatch failed",
+				"node_id", e.nodeID,
+				"to", req.msg.To,
+				"type", req.msg.Type.String(),
+				"dispatch_error_count", count,
+				"err", dispatchErr,
+			)
 		}
 	}
 }

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -2058,7 +2058,7 @@ func (e *Engine) handleDispatchRequest(ctx context.Context, req dispatchRequest)
 	if err := req.Close(); err != nil {
 		slog.Error("etcd raft dispatch: failed to close request", "err", err)
 	}
-	if dispatchErr != nil {
+	if dispatchErr != nil && !errors.Is(dispatchErr, ctx.Err()) {
 		count := e.dispatchErrorCount.Add(1)
 		if shouldLogDispatchEvent(count) {
 			slog.Warn("etcd raft outbound dispatch failed",

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -951,12 +951,14 @@ func (e *Engine) enqueueDispatchMessage(msg raftpb.Message) error {
 // Election messages (MsgVote/MsgPreVote) are included because delays can
 // trigger unnecessary election timeouts. MsgReadIndex/Resp affects linearizable
 // read latency. MsgAppResp lets the leader advance the commit index promptly.
+// MsgTimeoutNow triggers an immediate election on the target follower for
+// leadership transfer; delaying it stalls the transfer.
 func isPriorityMsg(t raftpb.MessageType) bool {
 	return t == raftpb.MsgHeartbeat || t == raftpb.MsgHeartbeatResp ||
 		t == raftpb.MsgReadIndex || t == raftpb.MsgReadIndexResp ||
 		t == raftpb.MsgVote || t == raftpb.MsgVoteResp ||
 		t == raftpb.MsgPreVote || t == raftpb.MsgPreVoteResp ||
-		t == raftpb.MsgAppResp
+		t == raftpb.MsgAppResp || t == raftpb.MsgTimeoutNow
 }
 
 func (e *Engine) applyReadySnapshot(snapshot raftpb.Snapshot) error {

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -33,10 +33,12 @@ const (
 	defaultMaxInflightMsg = 256
 	defaultMaxSizePerMsg  = 1 << 20
 	// defaultHeartbeatBufPerPeer is the capacity of the priority dispatch channel.
-	// It carries only truly low-frequency control messages (heartbeats, votes,
-	// read-index, leader-transfer). MsgAppResp is intentionally kept in the
-	// normal channel: followers — the only senders of MsgAppResp — do not send
-	// MsgApp, so there is no head-of-line blocking risk there.
+	// It carries low-frequency control traffic: heartbeats, votes, read-index,
+	// leader-transfer, and their corresponding response messages
+	// (MsgHeartbeatResp, MsgReadIndexResp, MsgVoteResp, MsgPreVoteResp).
+	// MsgAppResp is intentionally kept in the normal channel: followers — the
+	// only senders of MsgAppResp — do not send MsgApp, so there is no
+	// head-of-line blocking risk there.
 	defaultHeartbeatBufPerPeer = 64
 	defaultSnapshotEvery       = 10_000
 	defaultSnapshotQueueSize   = 1

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -933,8 +933,12 @@ func (e *Engine) enqueueDispatchMessage(msg raftpb.Message) error {
 	}
 }
 
+// isHeartbeatMsg returns true for small, latency-sensitive control messages
+// that must not be queued behind large MsgApp payloads. MsgReadIndex and
+// MsgReadIndexResp are included because delays hurt linearizable read latency.
 func isHeartbeatMsg(t raftpb.MessageType) bool {
-	return t == raftpb.MsgHeartbeat || t == raftpb.MsgHeartbeatResp
+	return t == raftpb.MsgHeartbeat || t == raftpb.MsgHeartbeatResp ||
+		t == raftpb.MsgReadIndex || t == raftpb.MsgReadIndexResp
 }
 
 func (e *Engine) applyReadySnapshot(snapshot raftpb.Snapshot) error {

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -1968,7 +1968,10 @@ func (e *Engine) runDispatchWorker(ch chan dispatchRequest) {
 		select {
 		case <-e.dispatchStopCh:
 			return
-		case req := <-ch:
+		case req, ok := <-ch:
+			if !ok {
+				return
+			}
 			if err := e.dispatchTransport(req); err != nil {
 				count := e.dispatchErrorCount.Add(1)
 				if shouldLogDispatchEvent(count) {
@@ -2198,7 +2201,10 @@ func (e *Engine) removePeer(nodeID uint64) {
 		e.transport.RemovePeer(nodeID)
 	}
 	if e.peerDispatchers != nil {
-		delete(e.peerDispatchers, nodeID)
+		if ch, ok := e.peerDispatchers[nodeID]; ok {
+			delete(e.peerDispatchers, nodeID)
+			close(ch)
+		}
 	}
 }
 

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -91,7 +91,8 @@ type OpenConfig struct {
 	// per peer before waiting for an acknowledgement (Raft-level flow control).
 	// It also sets the per-peer dispatch channel capacity, so total buffered
 	// memory is bounded by O(numPeers * MaxInflightMsg * avgMsgSize).
-	// Default: 1024. Lower this value in memory-constrained clusters.
+	// Default: 256. Increase for deeper pipelining on high-bandwidth links;
+	// lower in memory-constrained clusters.
 	MaxInflightMsg int
 }
 

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -32,17 +32,11 @@ const (
 	// defaultDispatchWorkersPerPeer is the number of goroutines started per peer:
 	// one for normal messages (MsgApp, etc.) and one dedicated to heartbeats.
 	defaultDispatchWorkersPerPeer = 2
-	// defaultDispatchBufPerPeer is the per-peer dispatch channel capacity.
-	// It is intentionally decoupled from defaultMaxInflightMsg: MaxInflightMsg
-	// is a Raft-level flow-control knob, while this controls how many serialised
-	// messages the dispatch goroutine can buffer before dropping. 512 is chosen
-	// to keep memory overhead modest while still absorbing bursts.
-	defaultDispatchBufPerPeer = 512
-	defaultSnapshotEvery      = 10_000
-	defaultSnapshotQueueSize  = 1
-	defaultAdminPollInterval  = 10 * time.Millisecond
-	defaultMaxPendingConfigs  = 64
-	unknownLastContact        = time.Duration(-1)
+	defaultSnapshotEvery          = 10_000
+	defaultSnapshotQueueSize      = 1
+	defaultAdminPollInterval      = 10 * time.Millisecond
+	defaultMaxPendingConfigs      = 64
+	unknownLastContact            = time.Duration(-1)
 
 	proposalEnvelopeVersion  = byte(0x01)
 	readContextVersion       = byte(0x02)
@@ -357,7 +351,9 @@ func (e *Engine) initTransport(cfg OpenConfig) {
 	// Gate inbound delivery on startedCh so messages are not enqueued until the
 	// local run loop has completed startup.
 	e.peerDispatchers = make(map[uint64]*peerQueues, len(e.peers))
-	e.perPeerQueueSize = defaultDispatchBufPerPeer
+	// Size the per-peer dispatch buffer to match the Raft inflight limit so that
+	// the channel never drops messages that Raft's flow-control would permit.
+	e.perPeerQueueSize = cfg.MaxInflightMsg
 	e.dispatchStopCh = make(chan struct{})
 	e.transport.SetSpoolDir(cfg.DataDir)
 	e.transport.SetFSMSnapDir(e.fsmSnapDir)
@@ -1978,7 +1974,7 @@ func (e *Engine) startPeerDispatcher(nodeID uint64) {
 	}
 	size := e.perPeerQueueSize
 	if size <= 0 {
-		size = defaultDispatchBufPerPeer
+		size = defaultMaxInflightMsg
 	}
 	pd := &peerQueues{
 		normal:    make(chan dispatchRequest, size),

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -27,17 +27,13 @@ const (
 	// defaultMaxInflightMsg controls how many in-flight MsgApp messages Raft
 	// allows per peer before it must wait for an ACK. Increasing this from the
 	// etcd/raft default of 256 enables deeper pipelining on high-bandwidth links.
-	defaultMaxInflightMsg = 1024
-	defaultMaxSizePerMsg  = 1 << 20
-	// defaultHeartbeatBufPerPeer is the capacity of the dedicated heartbeat
-	// dispatch channel. Heartbeats are low-frequency (one per heartbeatTick
-	// interval), so a small buffer is sufficient and avoids wasting memory.
-	defaultHeartbeatBufPerPeer = 64
-	defaultSnapshotEvery       = 10_000
-	defaultSnapshotQueueSize   = 1
-	defaultAdminPollInterval   = 10 * time.Millisecond
-	defaultMaxPendingConfigs   = 64
-	unknownLastContact         = time.Duration(-1)
+	defaultMaxInflightMsg    = 1024
+	defaultMaxSizePerMsg     = 1 << 20
+	defaultSnapshotEvery     = 10_000
+	defaultSnapshotQueueSize = 1
+	defaultAdminPollInterval = 10 * time.Millisecond
+	defaultMaxPendingConfigs = 64
+	unknownLastContact       = time.Duration(-1)
 
 	proposalEnvelopeVersion  = byte(0x01)
 	readContextVersion       = byte(0x02)
@@ -2004,7 +2000,7 @@ func (e *Engine) startPeerDispatcher(nodeID uint64) {
 	ctx, cancel := context.WithCancel(baseCtx)
 	pd := &peerQueues{
 		normal:    make(chan dispatchRequest, size),
-		heartbeat: make(chan dispatchRequest, defaultHeartbeatBufPerPeer),
+		heartbeat: make(chan dispatchRequest, size),
 		ctx:       ctx,
 		cancel:    cancel,
 	}

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -27,16 +27,13 @@ const (
 	// defaultMaxInflightMsg controls how many in-flight MsgApp messages Raft
 	// allows per peer before it must wait for an ACK. Increasing this from the
 	// etcd/raft default of 256 enables deeper pipelining on high-bandwidth links.
-	defaultMaxInflightMsg = 1024
-	defaultMaxSizePerMsg  = 1 << 20
-	// defaultDispatchWorkersPerPeer is the number of goroutines started per peer:
-	// one for normal messages (MsgApp, etc.) and one dedicated to heartbeats.
-	defaultDispatchWorkersPerPeer = 2
-	defaultSnapshotEvery          = 10_000
-	defaultSnapshotQueueSize      = 1
-	defaultAdminPollInterval      = 10 * time.Millisecond
-	defaultMaxPendingConfigs      = 64
-	unknownLastContact            = time.Duration(-1)
+	defaultMaxInflightMsg    = 1024
+	defaultMaxSizePerMsg     = 1 << 20
+	defaultSnapshotEvery     = 10_000
+	defaultSnapshotQueueSize = 1
+	defaultAdminPollInterval = 10 * time.Millisecond
+	defaultMaxPendingConfigs = 64
+	unknownLastContact       = time.Duration(-1)
 
 	proposalEnvelopeVersion  = byte(0x01)
 	readContextVersion       = byte(0x02)
@@ -1981,9 +1978,11 @@ func (e *Engine) startPeerDispatcher(nodeID uint64) {
 		heartbeat: make(chan dispatchRequest, size),
 	}
 	e.peerDispatchers[nodeID] = pd
-	e.dispatchWG.Add(defaultDispatchWorkersPerPeer)
-	go e.runDispatchWorker(pd.normal)
-	go e.runDispatchWorker(pd.heartbeat)
+	workers := []chan dispatchRequest{pd.normal, pd.heartbeat}
+	e.dispatchWG.Add(len(workers))
+	for _, w := range workers {
+		go e.runDispatchWorker(w)
+	}
 }
 
 func (e *Engine) runDispatchWorker(ch chan dispatchRequest) {

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -25,13 +25,12 @@ const (
 	defaultHeartbeatTick = 1
 	defaultElectionTick  = 10
 	// defaultMaxInflightMsg controls how many in-flight MsgApp messages Raft
-	// allows per peer before waiting for an ACK. Increasing this from the
-	// etcd/raft default of 256 enables deeper pipelining on high-bandwidth links.
-	// Memory note: worst-case is defaultMaxInflightMsg × defaultMaxSizePerMsg per
-	// peer, but in practice Raft batches many small entries per MsgApp and typical
-	// message sizes are <<1 MB. Lower this via OpenConfig.MaxInflightMsg in
-	// memory-constrained clusters.
-	defaultMaxInflightMsg = 1024
+	// allows per peer before waiting for an ACK (etcd/raft default: 256).
+	// It also sets the per-peer dispatch channel capacity; total buffered memory
+	// is bounded by O(numPeers × MaxInflightMsg × avgMsgSize).
+	// Increase via OpenConfig.MaxInflightMsg for deeper pipelining on
+	// high-bandwidth links; reduce it in memory-constrained clusters.
+	defaultMaxInflightMsg = 256
 	defaultMaxSizePerMsg  = 1 << 20
 	// defaultHeartbeatBufPerPeer is the capacity of the priority dispatch channel.
 	// It carries only truly low-frequency control messages (heartbeats, votes,
@@ -2026,11 +2025,17 @@ func (e *Engine) startPeerDispatcher(nodeID uint64) {
 	}
 }
 
+// runDispatchWorker drains ch until the channel is closed, the engine stops,
+// or the per-peer context is cancelled (e.g. by removePeer). The ctx.Done()
+// arm ensures old workers exit promptly when a peer is removed and
+// immediately re-added, preventing stale goroutines from shadowing new ones.
 func (e *Engine) runDispatchWorker(ctx context.Context, ch chan dispatchRequest) {
 	defer e.dispatchWG.Done()
 	for {
 		select {
 		case <-e.dispatchStopCh:
+			return
+		case <-ctx.Done():
 			return
 		case req, ok := <-ch:
 			if !ok {

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -25,8 +25,12 @@ const (
 	defaultHeartbeatTick = 1
 	defaultElectionTick  = 10
 	// defaultMaxInflightMsg controls how many in-flight MsgApp messages Raft
-	// allows per peer before it must wait for an ACK. Increasing this from the
+	// allows per peer before waiting for an ACK. Increasing this from the
 	// etcd/raft default of 256 enables deeper pipelining on high-bandwidth links.
+	// Memory note: worst-case is defaultMaxInflightMsg × defaultMaxSizePerMsg per
+	// peer, but in practice Raft batches many small entries per MsgApp and typical
+	// message sizes are <<1 MB. Lower this via OpenConfig.MaxInflightMsg in
+	// memory-constrained clusters.
 	defaultMaxInflightMsg = 1024
 	defaultMaxSizePerMsg  = 1 << 20
 	// defaultHeartbeatBufPerPeer is the capacity of the priority dispatch channel.

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -96,20 +96,21 @@ type Engine struct {
 
 	nextRequestID atomic.Uint64
 
-	proposeCh      chan proposalRequest
-	readCh         chan readRequest
-	adminCh        chan adminRequest
-	stepCh         chan raftpb.Message
-	dispatchCh     chan dispatchRequest
-	dispatchStopCh chan struct{}
-	dispatchCtx    context.Context
-	dispatchCancel context.CancelFunc
-	snapshotReqCh  chan snapshotRequest
-	snapshotResCh  chan snapshotResult
-	snapshotStopCh chan struct{}
-	closeCh        chan struct{}
-	doneCh         chan struct{}
-	startedCh      chan struct{}
+	proposeCh        chan proposalRequest
+	readCh           chan readRequest
+	adminCh          chan adminRequest
+	stepCh           chan raftpb.Message
+	peerDispatchers  map[uint64]chan dispatchRequest
+	perPeerQueueSize int
+	dispatchStopCh   chan struct{}
+	dispatchCtx      context.Context
+	dispatchCancel   context.CancelFunc
+	snapshotReqCh    chan snapshotRequest
+	snapshotResCh    chan snapshotResult
+	snapshotStopCh   chan struct{}
+	closeCh          chan struct{}
+	doneCh           chan struct{}
+	startedCh        chan struct{}
 
 	leaderReady  chan struct{}
 	leaderOnce   sync.Once
@@ -337,7 +338,8 @@ func (e *Engine) initTransport(cfg OpenConfig) {
 	// Transport listeners may already be accepting RPCs when Open is called.
 	// Gate inbound delivery on startedCh so messages are not enqueued until the
 	// local run loop has completed startup.
-	e.dispatchCh = make(chan dispatchRequest, dispatchQueueSize(cfg.MaxInflightMsg))
+	e.peerDispatchers = make(map[uint64]chan dispatchRequest, len(e.peers))
+	e.perPeerQueueSize = cfg.MaxInflightMsg
 	e.dispatchStopCh = make(chan struct{})
 	e.transport.SetSpoolDir(cfg.DataDir)
 	e.transport.SetFSMSnapDir(e.fsmSnapDir)
@@ -892,17 +894,22 @@ func (e *Engine) skipDispatchMessage(msg raftpb.Message) bool {
 	if msg.To == 0 || msg.To == e.nodeID || etcdraft.IsLocalMsg(msg.Type) {
 		return true
 	}
-	return e.transport == nil || e.dispatchCh == nil
+	return e.transport == nil || e.peerDispatchers == nil
 }
 
 func (e *Engine) enqueueDispatchMessage(msg raftpb.Message) error {
-	if len(e.dispatchCh) >= cap(e.dispatchCh) {
+	ch, ok := e.peerDispatchers[msg.To]
+	if !ok {
+		e.recordDroppedDispatch(msg)
+		return nil
+	}
+	if len(ch) >= cap(ch) {
 		e.recordDroppedDispatch(msg)
 		return nil
 	}
 	dispatchReq := prepareDispatchRequest(msg)
 	select {
-	case e.dispatchCh <- dispatchReq:
+	case ch <- dispatchReq:
 		return nil
 	default:
 		_ = dispatchReq.Close()
@@ -1928,22 +1935,40 @@ func isLeaderContactMessage(msgType raftpb.MessageType) bool {
 }
 
 func (e *Engine) startDispatchWorkers() {
-	if e.dispatchCh == nil {
+	if e.peerDispatchers == nil {
 		return
 	}
-	for range defaultDispatchWorkers {
-		e.dispatchWG.Add(1)
-		go e.runDispatchWorker()
+	for nodeID := range e.peers {
+		if nodeID == e.nodeID {
+			continue
+		}
+		e.startPeerDispatcher(nodeID)
 	}
 }
 
-func (e *Engine) runDispatchWorker() {
+func (e *Engine) startPeerDispatcher(nodeID uint64) {
+	if _, exists := e.peerDispatchers[nodeID]; exists {
+		return
+	}
+	size := e.perPeerQueueSize
+	if size <= 0 {
+		size = defaultMaxInflightMsg
+	}
+	ch := make(chan dispatchRequest, size)
+	e.peerDispatchers[nodeID] = ch
+	for range defaultDispatchWorkers {
+		e.dispatchWG.Add(1)
+		go e.runDispatchWorker(ch)
+	}
+}
+
+func (e *Engine) runDispatchWorker(ch chan dispatchRequest) {
 	defer e.dispatchWG.Done()
 	for {
 		select {
 		case <-e.dispatchStopCh:
 			return
-		case req := <-e.dispatchCh:
+		case req := <-ch:
 			if err := e.dispatchTransport(req); err != nil {
 				count := e.dispatchErrorCount.Add(1)
 				if shouldLogDispatchEvent(count) {
@@ -2133,6 +2158,9 @@ func (e *Engine) upsertPeer(peer Peer) {
 	if e.transport != nil {
 		e.transport.UpsertPeer(peer)
 	}
+	if e.peerDispatchers != nil && peer.NodeID != e.nodeID {
+		e.startPeerDispatcher(peer.NodeID)
+	}
 }
 
 func (e *Engine) nextPeersAfterConfigChange(changeType raftpb.ConfChangeType, nodeID uint64, context []byte, _ raftpb.ConfState) []Peer {
@@ -2169,6 +2197,9 @@ func (e *Engine) removePeer(nodeID uint64) {
 	if e.transport != nil {
 		e.transport.RemovePeer(nodeID)
 	}
+	if e.peerDispatchers != nil {
+		delete(e.peerDispatchers, nodeID)
+	}
 }
 
 func (e *Engine) hasPeer(nodeID uint64) bool {
@@ -2193,13 +2224,6 @@ func decodeProposalEnvelope(data []byte) (uint64, []byte, bool) {
 	return binary.BigEndian.Uint64(data[1:envelopeHeaderSize]), data[envelopeHeaderSize:], true
 }
 
-func dispatchQueueSize(maxInflight int) int {
-	size := maxInflight
-	if size <= 0 {
-		size = defaultMaxInflightMsg
-	}
-	return size * defaultDispatchWorkers
-}
 
 func shouldLogDispatchEvent(count uint64) bool {
 	return count == 1 || count%128 == 0

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -2224,7 +2224,6 @@ func decodeProposalEnvelope(data []byte) (uint64, []byte, bool) {
 	return binary.BigEndian.Uint64(data[1:envelopeHeaderSize]), data[envelopeHeaderSize:], true
 }
 
-
 func shouldLogDispatchEvent(count uint64) bool {
 	return count == 1 || count%128 == 0
 }

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -2032,6 +2032,10 @@ func (e *Engine) runDispatchWorker(ctx context.Context, ch chan dispatchRequest)
 			if !ok {
 				return
 			}
+			if ctx.Err() != nil {
+				_ = req.Close()
+				continue
+			}
 			if err := e.dispatchTransport(ctx, req); err != nil {
 				count := e.dispatchErrorCount.Add(1)
 				if shouldLogDispatchEvent(count) {

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -27,6 +27,7 @@ const (
 	defaultMaxInflightMsg         = 1024
 	defaultMaxSizePerMsg          = 1 << 20
 	defaultDispatchWorkersPerPeer = 1
+	defaultDispatchBufPerPeer     = 512
 	defaultSnapshotEvery          = 10_000
 	defaultSnapshotQueueSize      = 1
 	defaultAdminPollInterval      = 10 * time.Millisecond
@@ -339,7 +340,7 @@ func (e *Engine) initTransport(cfg OpenConfig) {
 	// Gate inbound delivery on startedCh so messages are not enqueued until the
 	// local run loop has completed startup.
 	e.peerDispatchers = make(map[uint64]chan dispatchRequest, len(e.peers))
-	e.perPeerQueueSize = cfg.MaxInflightMsg
+	e.perPeerQueueSize = defaultDispatchBufPerPeer
 	e.dispatchStopCh = make(chan struct{})
 	e.transport.SetSpoolDir(cfg.DataDir)
 	e.transport.SetFSMSnapDir(e.fsmSnapDir)
@@ -1952,7 +1953,7 @@ func (e *Engine) startPeerDispatcher(nodeID uint64) {
 	}
 	size := e.perPeerQueueSize
 	if size <= 0 {
-		size = defaultMaxInflightMsg
+		size = defaultDispatchBufPerPeer
 	}
 	ch := make(chan dispatchRequest, size)
 	e.peerDispatchers[nodeID] = ch

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -21,20 +21,28 @@ import (
 )
 
 const (
-	defaultTickInterval   = 10 * time.Millisecond
-	defaultHeartbeatTick  = 1
-	defaultElectionTick   = 10
+	defaultTickInterval  = 10 * time.Millisecond
+	defaultHeartbeatTick = 1
+	defaultElectionTick  = 10
+	// defaultMaxInflightMsg controls how many in-flight MsgApp messages Raft
+	// allows per peer before it must wait for an ACK. Increasing this from the
+	// etcd/raft default of 256 enables deeper pipelining on high-bandwidth links.
 	defaultMaxInflightMsg = 1024
 	defaultMaxSizePerMsg  = 1 << 20
 	// defaultDispatchWorkersPerPeer is the number of goroutines started per peer:
 	// one for normal messages (MsgApp, etc.) and one dedicated to heartbeats.
 	defaultDispatchWorkersPerPeer = 2
-	defaultDispatchBufPerPeer     = 512
-	defaultSnapshotEvery          = 10_000
-	defaultSnapshotQueueSize      = 1
-	defaultAdminPollInterval      = 10 * time.Millisecond
-	defaultMaxPendingConfigs      = 64
-	unknownLastContact            = time.Duration(-1)
+	// defaultDispatchBufPerPeer is the per-peer dispatch channel capacity.
+	// It is intentionally decoupled from defaultMaxInflightMsg: MaxInflightMsg
+	// is a Raft-level flow-control knob, while this controls how many serialised
+	// messages the dispatch goroutine can buffer before dropping. 512 is chosen
+	// to keep memory overhead modest while still absorbing bursts.
+	defaultDispatchBufPerPeer = 512
+	defaultSnapshotEvery      = 10_000
+	defaultSnapshotQueueSize  = 1
+	defaultAdminPollInterval  = 10 * time.Millisecond
+	defaultMaxPendingConfigs  = 64
+	unknownLastContact        = time.Duration(-1)
 
 	proposalEnvelopeVersion  = byte(0x01)
 	readContextVersion       = byte(0x02)

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -27,13 +27,19 @@ const (
 	// defaultMaxInflightMsg controls how many in-flight MsgApp messages Raft
 	// allows per peer before it must wait for an ACK. Increasing this from the
 	// etcd/raft default of 256 enables deeper pipelining on high-bandwidth links.
-	defaultMaxInflightMsg    = 1024
-	defaultMaxSizePerMsg     = 1 << 20
-	defaultSnapshotEvery     = 10_000
-	defaultSnapshotQueueSize = 1
-	defaultAdminPollInterval = 10 * time.Millisecond
-	defaultMaxPendingConfigs = 64
-	unknownLastContact       = time.Duration(-1)
+	defaultMaxInflightMsg = 1024
+	defaultMaxSizePerMsg  = 1 << 20
+	// defaultHeartbeatBufPerPeer is the capacity of the priority dispatch channel.
+	// It carries only truly low-frequency control messages (heartbeats, votes,
+	// read-index, leader-transfer). MsgAppResp is intentionally kept in the
+	// normal channel: followers — the only senders of MsgAppResp — do not send
+	// MsgApp, so there is no head-of-line blocking risk there.
+	defaultHeartbeatBufPerPeer = 64
+	defaultSnapshotEvery       = 10_000
+	defaultSnapshotQueueSize   = 1
+	defaultAdminPollInterval   = 10 * time.Millisecond
+	defaultMaxPendingConfigs   = 64
+	unknownLastContact         = time.Duration(-1)
 
 	proposalEnvelopeVersion  = byte(0x01)
 	readContextVersion       = byte(0x02)
@@ -942,19 +948,18 @@ func (e *Engine) enqueueDispatchMessage(msg raftpb.Message) error {
 	}
 }
 
-// isPriorityMsg returns true for small, latency-sensitive control messages
-// that must not be queued behind large MsgApp payloads in the normal channel.
-// Election messages (MsgVote/MsgPreVote) are included because delays can
-// trigger unnecessary election timeouts. MsgReadIndex/Resp affects linearizable
-// read latency. MsgAppResp lets the leader advance the commit index promptly.
-// MsgTimeoutNow triggers an immediate election on the target follower for
-// leadership transfer; delaying it stalls the transfer.
+// isPriorityMsg returns true for small, low-frequency control messages that
+// must not be queued behind large MsgApp payloads in the normal channel.
+// MsgAppResp is intentionally excluded: it is sent by followers, which never
+// send MsgApp, so it faces no head-of-line blocking in the normal channel.
+// Keeping it out of the priority queue preserves the low-frequency invariant
+// that justifies defaultHeartbeatBufPerPeer = 64.
 func isPriorityMsg(t raftpb.MessageType) bool {
 	return t == raftpb.MsgHeartbeat || t == raftpb.MsgHeartbeatResp ||
 		t == raftpb.MsgReadIndex || t == raftpb.MsgReadIndexResp ||
 		t == raftpb.MsgVote || t == raftpb.MsgVoteResp ||
 		t == raftpb.MsgPreVote || t == raftpb.MsgPreVoteResp ||
-		t == raftpb.MsgAppResp || t == raftpb.MsgTimeoutNow
+		t == raftpb.MsgTimeoutNow
 }
 
 func (e *Engine) applyReadySnapshot(snapshot raftpb.Snapshot) error {
@@ -2000,7 +2005,7 @@ func (e *Engine) startPeerDispatcher(nodeID uint64) {
 	ctx, cancel := context.WithCancel(baseCtx)
 	pd := &peerQueues{
 		normal:    make(chan dispatchRequest, size),
-		heartbeat: make(chan dispatchRequest, size),
+		heartbeat: make(chan dispatchRequest, defaultHeartbeatBufPerPeer),
 		ctx:       ctx,
 		cancel:    cancel,
 	}

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -26,7 +26,7 @@ const (
 	defaultElectionTick           = 10
 	defaultMaxInflightMsg         = 1024
 	defaultMaxSizePerMsg          = 1 << 20
-	defaultDispatchWorkersPerPeer = 1
+	defaultDispatchWorkersPerPeer = 2
 	defaultDispatchBufPerPeer     = 512
 	defaultSnapshotEvery          = 10_000
 	defaultSnapshotQueueSize      = 1

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -26,7 +26,7 @@ const (
 	defaultElectionTick      = 10
 	defaultMaxInflightMsg    = 256
 	defaultMaxSizePerMsg     = 1 << 20
-	defaultDispatchWorkers   = 4
+	defaultDispatchWorkersPerPeer = 2
 	defaultSnapshotEvery     = 10_000
 	defaultSnapshotQueueSize = 1
 	defaultAdminPollInterval = 10 * time.Millisecond
@@ -1956,7 +1956,7 @@ func (e *Engine) startPeerDispatcher(nodeID uint64) {
 	}
 	ch := make(chan dispatchRequest, size)
 	e.peerDispatchers[nodeID] = ch
-	for range defaultDispatchWorkers {
+	for range defaultDispatchWorkersPerPeer {
 		e.dispatchWG.Add(1)
 		go e.runDispatchWorker(ch)
 	}

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -72,18 +72,23 @@ type Snapshot = raftengine.Snapshot
 type StateMachine = raftengine.StateMachine
 
 type OpenConfig struct {
-	NodeID         uint64
-	LocalID        string
-	LocalAddress   string
-	DataDir        string
-	Peers          []Peer
-	Bootstrap      bool
-	Transport      *GRPCTransport
-	TickInterval   time.Duration
-	ElectionTick   int
-	HeartbeatTick  int
-	StateMachine   StateMachine
-	MaxSizePerMsg  uint64
+	NodeID        uint64
+	LocalID       string
+	LocalAddress  string
+	DataDir       string
+	Peers         []Peer
+	Bootstrap     bool
+	Transport     *GRPCTransport
+	TickInterval  time.Duration
+	ElectionTick  int
+	HeartbeatTick int
+	StateMachine  StateMachine
+	MaxSizePerMsg uint64
+	// MaxInflightMsg controls how many MsgApp messages Raft may have in-flight
+	// per peer before waiting for an acknowledgement (Raft-level flow control).
+	// It also sets the per-peer dispatch channel capacity, so total buffered
+	// memory is bounded by O(numPeers * MaxInflightMsg * avgMsgSize).
+	// Default: 1024. Lower this value in memory-constrained clusters.
 	MaxInflightMsg int
 }
 

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -222,6 +222,8 @@ type dispatchRequest struct {
 type peerQueues struct {
 	normal    chan dispatchRequest
 	heartbeat chan dispatchRequest
+	ctx       context.Context
+	cancel    context.CancelFunc
 }
 
 type preparedOpenState struct {
@@ -923,7 +925,7 @@ func (e *Engine) enqueueDispatchMessage(msg raftpb.Message) error {
 		return nil
 	}
 	ch := pd.normal
-	if isHeartbeatMsg(msg.Type) {
+	if isPriorityMsg(msg.Type) {
 		ch = pd.heartbeat
 	}
 	// Avoid the expensive deep-clone in prepareDispatchRequest when the channel
@@ -944,12 +946,17 @@ func (e *Engine) enqueueDispatchMessage(msg raftpb.Message) error {
 	}
 }
 
-// isHeartbeatMsg returns true for small, latency-sensitive control messages
-// that must not be queued behind large MsgApp payloads. MsgReadIndex and
-// MsgReadIndexResp are included because delays hurt linearizable read latency.
-func isHeartbeatMsg(t raftpb.MessageType) bool {
+// isPriorityMsg returns true for small, latency-sensitive control messages
+// that must not be queued behind large MsgApp payloads in the normal channel.
+// Election messages (MsgVote/MsgPreVote) are included because delays can
+// trigger unnecessary election timeouts. MsgReadIndex/Resp affects linearizable
+// read latency. MsgAppResp lets the leader advance the commit index promptly.
+func isPriorityMsg(t raftpb.MessageType) bool {
 	return t == raftpb.MsgHeartbeat || t == raftpb.MsgHeartbeatResp ||
-		t == raftpb.MsgReadIndex || t == raftpb.MsgReadIndexResp
+		t == raftpb.MsgReadIndex || t == raftpb.MsgReadIndexResp ||
+		t == raftpb.MsgVote || t == raftpb.MsgVoteResp ||
+		t == raftpb.MsgPreVote || t == raftpb.MsgPreVoteResp ||
+		t == raftpb.MsgAppResp
 }
 
 func (e *Engine) applyReadySnapshot(snapshot raftpb.Snapshot) error {
@@ -1988,19 +1995,26 @@ func (e *Engine) startPeerDispatcher(nodeID uint64) {
 	if size <= 0 {
 		size = defaultMaxInflightMsg
 	}
+	baseCtx := e.dispatchCtx
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+	ctx, cancel := context.WithCancel(baseCtx)
 	pd := &peerQueues{
 		normal:    make(chan dispatchRequest, size),
 		heartbeat: make(chan dispatchRequest, defaultHeartbeatBufPerPeer),
+		ctx:       ctx,
+		cancel:    cancel,
 	}
 	e.peerDispatchers[nodeID] = pd
 	workers := []chan dispatchRequest{pd.normal, pd.heartbeat}
 	e.dispatchWG.Add(len(workers))
 	for _, w := range workers {
-		go e.runDispatchWorker(w)
+		go e.runDispatchWorker(ctx, w)
 	}
 }
 
-func (e *Engine) runDispatchWorker(ch chan dispatchRequest) {
+func (e *Engine) runDispatchWorker(ctx context.Context, ch chan dispatchRequest) {
 	defer e.dispatchWG.Done()
 	for {
 		select {
@@ -2010,7 +2024,7 @@ func (e *Engine) runDispatchWorker(ch chan dispatchRequest) {
 			if !ok {
 				return
 			}
-			if err := e.dispatchTransport(req); err != nil {
+			if err := e.dispatchTransport(ctx, req); err != nil {
 				count := e.dispatchErrorCount.Add(1)
 				if shouldLogDispatchEvent(count) {
 					slog.Warn("etcd raft outbound dispatch failed",
@@ -2241,6 +2255,7 @@ func (e *Engine) removePeer(nodeID uint64) {
 	if e.peerDispatchers != nil {
 		if pd, ok := e.peerDispatchers[nodeID]; ok {
 			delete(e.peerDispatchers, nodeID)
+			pd.cancel() // cancel any in-flight RPC for this peer immediately
 			close(pd.normal)
 			close(pd.heartbeat)
 		}
@@ -2285,11 +2300,7 @@ func (e *Engine) recordDroppedDispatch(msg raftpb.Message) {
 	}
 }
 
-func (e *Engine) dispatchTransport(req dispatchRequest) error {
-	ctx := e.dispatchCtx
-	if ctx == nil {
-		ctx = context.Background()
-	}
+func (e *Engine) dispatchTransport(ctx context.Context, req dispatchRequest) error {
 	if e.dispatchFn != nil {
 		return e.dispatchFn(ctx, req)
 	}

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -27,13 +27,17 @@ const (
 	// defaultMaxInflightMsg controls how many in-flight MsgApp messages Raft
 	// allows per peer before it must wait for an ACK. Increasing this from the
 	// etcd/raft default of 256 enables deeper pipelining on high-bandwidth links.
-	defaultMaxInflightMsg    = 1024
-	defaultMaxSizePerMsg     = 1 << 20
-	defaultSnapshotEvery     = 10_000
-	defaultSnapshotQueueSize = 1
-	defaultAdminPollInterval = 10 * time.Millisecond
-	defaultMaxPendingConfigs = 64
-	unknownLastContact       = time.Duration(-1)
+	defaultMaxInflightMsg = 1024
+	defaultMaxSizePerMsg  = 1 << 20
+	// defaultHeartbeatBufPerPeer is the capacity of the dedicated heartbeat
+	// dispatch channel. Heartbeats are low-frequency (one per heartbeatTick
+	// interval), so a small buffer is sufficient and avoids wasting memory.
+	defaultHeartbeatBufPerPeer = 64
+	defaultSnapshotEvery       = 10_000
+	defaultSnapshotQueueSize   = 1
+	defaultAdminPollInterval   = 10 * time.Millisecond
+	defaultMaxPendingConfigs   = 64
+	unknownLastContact         = time.Duration(-1)
 
 	proposalEnvelopeVersion  = byte(0x01)
 	readContextVersion       = byte(0x02)
@@ -921,6 +925,13 @@ func (e *Engine) enqueueDispatchMessage(msg raftpb.Message) error {
 	ch := pd.normal
 	if isHeartbeatMsg(msg.Type) {
 		ch = pd.heartbeat
+	}
+	// Avoid the expensive deep-clone in prepareDispatchRequest when the channel
+	// is already full. The len/cap check is safe here because this function is
+	// only ever called from the single engine event-loop goroutine.
+	if len(ch) >= cap(ch) {
+		e.recordDroppedDispatch(msg)
+		return nil
 	}
 	dispatchReq := prepareDispatchRequest(msg)
 	select {
@@ -1979,7 +1990,7 @@ func (e *Engine) startPeerDispatcher(nodeID uint64) {
 	}
 	pd := &peerQueues{
 		normal:    make(chan dispatchRequest, size),
-		heartbeat: make(chan dispatchRequest, size),
+		heartbeat: make(chan dispatchRequest, defaultHeartbeatBufPerPeer),
 	}
 	e.peerDispatchers[nodeID] = pd
 	workers := []chan dispatchRequest{pd.normal, pd.heartbeat}

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -21,17 +21,17 @@ import (
 )
 
 const (
-	defaultTickInterval      = 10 * time.Millisecond
-	defaultHeartbeatTick     = 1
-	defaultElectionTick      = 10
-	defaultMaxInflightMsg    = 256
-	defaultMaxSizePerMsg     = 1 << 20
-	defaultDispatchWorkersPerPeer = 2
-	defaultSnapshotEvery     = 10_000
-	defaultSnapshotQueueSize = 1
-	defaultAdminPollInterval = 10 * time.Millisecond
-	defaultMaxPendingConfigs = 64
-	unknownLastContact       = time.Duration(-1)
+	defaultTickInterval           = 10 * time.Millisecond
+	defaultHeartbeatTick          = 1
+	defaultElectionTick           = 10
+	defaultMaxInflightMsg         = 256
+	defaultMaxSizePerMsg          = 1 << 20
+	defaultDispatchWorkersPerPeer = 1
+	defaultSnapshotEvery          = 10_000
+	defaultSnapshotQueueSize      = 1
+	defaultAdminPollInterval      = 10 * time.Millisecond
+	defaultMaxPendingConfigs      = 64
+	unknownLastContact            = time.Duration(-1)
 
 	proposalEnvelopeVersion  = byte(0x01)
 	readContextVersion       = byte(0x02)

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -26,6 +26,8 @@ const (
 	defaultElectionTick           = 10
 	defaultMaxInflightMsg         = 1024
 	defaultMaxSizePerMsg          = 1 << 20
+	// defaultDispatchWorkersPerPeer is the number of goroutines started per peer:
+	// one for normal messages (MsgApp, etc.) and one dedicated to heartbeats.
 	defaultDispatchWorkersPerPeer = 2
 	defaultDispatchBufPerPeer     = 512
 	defaultSnapshotEvery          = 10_000
@@ -101,7 +103,7 @@ type Engine struct {
 	readCh           chan readRequest
 	adminCh          chan adminRequest
 	stepCh           chan raftpb.Message
-	peerDispatchers  map[uint64]chan dispatchRequest
+	peerDispatchers  map[uint64]*peerQueues
 	perPeerQueueSize int
 	dispatchStopCh   chan struct{}
 	dispatchCtx      context.Context
@@ -210,6 +212,13 @@ type snapshotResult struct {
 
 type dispatchRequest struct {
 	msg raftpb.Message
+}
+
+// peerQueues holds separate dispatch channels per peer so that heartbeats
+// are never blocked behind large log-entry RPCs.
+type peerQueues struct {
+	normal    chan dispatchRequest
+	heartbeat chan dispatchRequest
 }
 
 type preparedOpenState struct {
@@ -339,7 +348,7 @@ func (e *Engine) initTransport(cfg OpenConfig) {
 	// Transport listeners may already be accepting RPCs when Open is called.
 	// Gate inbound delivery on startedCh so messages are not enqueued until the
 	// local run loop has completed startup.
-	e.peerDispatchers = make(map[uint64]chan dispatchRequest, len(e.peers))
+	e.peerDispatchers = make(map[uint64]*peerQueues, len(e.peers))
 	e.perPeerQueueSize = defaultDispatchBufPerPeer
 	e.dispatchStopCh = make(chan struct{})
 	e.transport.SetSpoolDir(cfg.DataDir)
@@ -899,10 +908,14 @@ func (e *Engine) skipDispatchMessage(msg raftpb.Message) bool {
 }
 
 func (e *Engine) enqueueDispatchMessage(msg raftpb.Message) error {
-	ch, ok := e.peerDispatchers[msg.To]
+	pd, ok := e.peerDispatchers[msg.To]
 	if !ok {
 		e.recordDroppedDispatch(msg)
 		return nil
+	}
+	ch := pd.normal
+	if isHeartbeatMsg(msg.Type) {
+		ch = pd.heartbeat
 	}
 	if len(ch) >= cap(ch) {
 		e.recordDroppedDispatch(msg)
@@ -917,6 +930,10 @@ func (e *Engine) enqueueDispatchMessage(msg raftpb.Message) error {
 		e.recordDroppedDispatch(msg)
 		return nil
 	}
+}
+
+func isHeartbeatMsg(t raftpb.MessageType) bool {
+	return t == raftpb.MsgHeartbeat || t == raftpb.MsgHeartbeatResp
 }
 
 func (e *Engine) applyReadySnapshot(snapshot raftpb.Snapshot) error {
@@ -1955,12 +1972,14 @@ func (e *Engine) startPeerDispatcher(nodeID uint64) {
 	if size <= 0 {
 		size = defaultDispatchBufPerPeer
 	}
-	ch := make(chan dispatchRequest, size)
-	e.peerDispatchers[nodeID] = ch
-	for range defaultDispatchWorkersPerPeer {
-		e.dispatchWG.Add(1)
-		go e.runDispatchWorker(ch)
+	pd := &peerQueues{
+		normal:    make(chan dispatchRequest, size),
+		heartbeat: make(chan dispatchRequest, size),
 	}
+	e.peerDispatchers[nodeID] = pd
+	e.dispatchWG.Add(defaultDispatchWorkersPerPeer)
+	go e.runDispatchWorker(pd.normal)
+	go e.runDispatchWorker(pd.heartbeat)
 }
 
 func (e *Engine) runDispatchWorker(ch chan dispatchRequest) {
@@ -2202,9 +2221,10 @@ func (e *Engine) removePeer(nodeID uint64) {
 		e.transport.RemovePeer(nodeID)
 	}
 	if e.peerDispatchers != nil {
-		if ch, ok := e.peerDispatchers[nodeID]; ok {
+		if pd, ok := e.peerDispatchers[nodeID]; ok {
 			delete(e.peerDispatchers, nodeID)
-			close(ch)
+			close(pd.normal)
+			close(pd.heartbeat)
 		}
 	}
 }

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -2042,18 +2042,18 @@ func (e *Engine) runDispatchWorker(ctx context.Context, ch chan dispatchRequest)
 			if !ok {
 				return
 			}
+			if ctx.Err() != nil {
+				if err := req.Close(); err != nil {
+					slog.Error("etcd raft dispatch: failed to close request", "err", err)
+				}
+				return
+			}
 			e.handleDispatchRequest(ctx, req)
 		}
 	}
 }
 
 func (e *Engine) handleDispatchRequest(ctx context.Context, req dispatchRequest) {
-	if ctx.Err() != nil {
-		if err := req.Close(); err != nil {
-			slog.Error("etcd raft dispatch: failed to close request", "err", err)
-		}
-		return
-	}
 	dispatchErr := e.dispatchTransport(ctx, req)
 	if err := req.Close(); err != nil {
 		slog.Error("etcd raft dispatch: failed to close request", "err", err)

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -908,6 +908,10 @@ func (e *Engine) skipDispatchMessage(msg raftpb.Message) bool {
 	return e.transport == nil || e.peerDispatchers == nil
 }
 
+// enqueueDispatchMessage routes msg to the per-peer channel. It is called
+// exclusively from the engine event-loop goroutine, which is the same goroutine
+// that calls removePeer. The delete-then-close ordering in removePeer therefore
+// guarantees that no send can race with a channel close.
 func (e *Engine) enqueueDispatchMessage(msg raftpb.Message) error {
 	pd, ok := e.peerDispatchers[msg.To]
 	if !ok {
@@ -917,10 +921,6 @@ func (e *Engine) enqueueDispatchMessage(msg raftpb.Message) error {
 	ch := pd.normal
 	if isHeartbeatMsg(msg.Type) {
 		ch = pd.heartbeat
-	}
-	if len(ch) >= cap(ch) {
-		e.recordDroppedDispatch(msg)
-		return nil
 	}
 	dispatchReq := prepareDispatchRequest(msg)
 	select {

--- a/internal/raftengine/etcd/engine_test.go
+++ b/internal/raftengine/etcd/engine_test.go
@@ -590,7 +590,7 @@ func TestUpsertPeerStartsDispatcherAndAcceptsMessages(t *testing.T) {
 
 	pd, ok := engine.peerDispatchers[2]
 	require.True(t, ok, "dispatcher must be created on upsert")
-	require.Equal(t, 4, cap(pd.heartbeat))
+	require.Equal(t, defaultHeartbeatBufPerPeer, cap(pd.heartbeat))
 	require.Equal(t, 4, cap(pd.normal))
 
 	require.NoError(t, engine.enqueueDispatchMessage(raftpb.Message{Type: raftpb.MsgHeartbeat, To: 2}))

--- a/internal/raftengine/etcd/engine_test.go
+++ b/internal/raftengine/etcd/engine_test.go
@@ -501,12 +501,14 @@ func TestApplyReadySnapshotAdvancesAppliedIndex(t *testing.T) {
 }
 
 func TestSendMessagesDoesNotBlockWhenDispatchQueueIsFull(t *testing.T) {
-	ch := make(chan dispatchRequest, 1)
-	ch <- dispatchRequest{msg: raftpb.Message{Type: raftpb.MsgHeartbeat, To: 2}}
+	hbCh := make(chan dispatchRequest, 1)
+	hbCh <- dispatchRequest{msg: raftpb.Message{Type: raftpb.MsgHeartbeat, To: 2}}
 	engine := &Engine{
-		nodeID:          1,
-		transport:       &GRPCTransport{},
-		peerDispatchers: map[uint64]chan dispatchRequest{2: ch},
+		nodeID:    1,
+		transport: &GRPCTransport{},
+		peerDispatchers: map[uint64]*peerQueues{
+			2: {normal: make(chan dispatchRequest, 1), heartbeat: hbCh},
+		},
 	}
 
 	done := make(chan struct{})
@@ -533,7 +535,7 @@ func TestStopDispatchWorkersCancelsInflightDispatch(t *testing.T) {
 		peers: map[uint64]Peer{
 			2: {NodeID: 2},
 		},
-		peerDispatchers:  make(map[uint64]chan dispatchRequest),
+		peerDispatchers:  make(map[uint64]*peerQueues),
 		perPeerQueueSize: 1,
 		dispatchStopCh:   make(chan struct{}),
 		dispatchCtx:      ctx,
@@ -546,7 +548,7 @@ func TestStopDispatchWorkersCancelsInflightDispatch(t *testing.T) {
 		return ctx.Err()
 	}
 	engine.startDispatchWorkers()
-	engine.peerDispatchers[2] <- dispatchRequest{msg: raftpb.Message{Type: raftpb.MsgHeartbeat, To: 2}}
+	engine.peerDispatchers[2].heartbeat <- dispatchRequest{msg: raftpb.Message{Type: raftpb.MsgHeartbeat, To: 2}}
 
 	select {
 	case <-started:
@@ -573,7 +575,7 @@ func TestUpsertPeerStartsDispatcherAndAcceptsMessages(t *testing.T) {
 	dispatched := make(chan raftpb.Message, 1)
 	engine := &Engine{
 		nodeID:           1,
-		peerDispatchers:  make(map[uint64]chan dispatchRequest),
+		peerDispatchers:  make(map[uint64]*peerQueues),
 		perPeerQueueSize: 4,
 		dispatchStopCh:   make(chan struct{}),
 		dispatchCtx:      ctx,
@@ -586,9 +588,10 @@ func TestUpsertPeerStartsDispatcherAndAcceptsMessages(t *testing.T) {
 
 	engine.upsertPeer(Peer{NodeID: 2, ID: "peer2", Address: "localhost:2"})
 
-	ch, ok := engine.peerDispatchers[2]
-	require.True(t, ok, "dispatcher channel must be created on upsert")
-	require.Equal(t, 4, cap(ch))
+	pd, ok := engine.peerDispatchers[2]
+	require.True(t, ok, "dispatcher must be created on upsert")
+	require.Equal(t, 4, cap(pd.heartbeat))
+	require.Equal(t, 4, cap(pd.normal))
 
 	require.NoError(t, engine.enqueueDispatchMessage(raftpb.Message{Type: raftpb.MsgHeartbeat, To: 2}))
 
@@ -605,15 +608,19 @@ func TestUpsertPeerStartsDispatcherAndAcceptsMessages(t *testing.T) {
 
 func TestRemovePeerClosesDispatcherAndDropsSubsequentMessages(t *testing.T) {
 	stopCh := make(chan struct{})
-	ch := make(chan dispatchRequest, 4)
+	pd := &peerQueues{
+		normal:    make(chan dispatchRequest, 4),
+		heartbeat: make(chan dispatchRequest, 4),
+	}
 	engine := &Engine{
 		nodeID:          1,
 		peers:           map[uint64]Peer{2: {NodeID: 2, ID: "peer2"}},
-		peerDispatchers: map[uint64]chan dispatchRequest{2: ch},
+		peerDispatchers: map[uint64]*peerQueues{2: pd},
 		dispatchStopCh:  stopCh,
 	}
-	engine.dispatchWG.Add(1)
-	go engine.runDispatchWorker(ch)
+	engine.dispatchWG.Add(2)
+	go engine.runDispatchWorker(pd.normal)
+	go engine.runDispatchWorker(pd.heartbeat)
 
 	engine.removePeer(2)
 
@@ -628,7 +635,7 @@ func TestRemovePeerClosesDispatcherAndDropsSubsequentMessages(t *testing.T) {
 	select {
 	case <-workerDone:
 	case <-time.After(time.Second):
-		t.Fatal("dispatch worker did not exit after channel close")
+		t.Fatal("dispatch workers did not exit after channel close")
 	}
 
 	// Subsequent messages to the removed peer must be dropped without panic.

--- a/internal/raftengine/etcd/engine_test.go
+++ b/internal/raftengine/etcd/engine_test.go
@@ -501,12 +501,13 @@ func TestApplyReadySnapshotAdvancesAppliedIndex(t *testing.T) {
 }
 
 func TestSendMessagesDoesNotBlockWhenDispatchQueueIsFull(t *testing.T) {
+	ch := make(chan dispatchRequest, 1)
+	ch <- dispatchRequest{msg: raftpb.Message{Type: raftpb.MsgHeartbeat, To: 2}}
 	engine := &Engine{
-		nodeID:     1,
-		transport:  &GRPCTransport{},
-		dispatchCh: make(chan dispatchRequest, 1),
+		nodeID:          1,
+		transport:       &GRPCTransport{},
+		peerDispatchers: map[uint64]chan dispatchRequest{2: ch},
 	}
-	engine.dispatchCh <- dispatchRequest{msg: raftpb.Message{Type: raftpb.MsgHeartbeat, To: 2}}
 
 	done := make(chan struct{})
 	go func() {
@@ -528,10 +529,15 @@ func TestStopDispatchWorkersCancelsInflightDispatch(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	engine := &Engine{
-		dispatchCh:     make(chan dispatchRequest, 1),
-		dispatchStopCh: make(chan struct{}),
-		dispatchCtx:    ctx,
-		dispatchCancel: cancel,
+		nodeID: 1,
+		peers: map[uint64]Peer{
+			2: {NodeID: 2},
+		},
+		peerDispatchers:  make(map[uint64]chan dispatchRequest),
+		perPeerQueueSize: 1,
+		dispatchStopCh:   make(chan struct{}),
+		dispatchCtx:      ctx,
+		dispatchCancel:   cancel,
 	}
 	started := make(chan struct{})
 	engine.dispatchFn = func(ctx context.Context, _ dispatchRequest) error {
@@ -540,7 +546,7 @@ func TestStopDispatchWorkersCancelsInflightDispatch(t *testing.T) {
 		return ctx.Err()
 	}
 	engine.startDispatchWorkers()
-	engine.dispatchCh <- dispatchRequest{msg: raftpb.Message{Type: raftpb.MsgHeartbeat, To: 2}}
+	engine.peerDispatchers[2] <- dispatchRequest{msg: raftpb.Message{Type: raftpb.MsgHeartbeat, To: 2}}
 
 	select {
 	case <-started:

--- a/internal/raftengine/etcd/engine_test.go
+++ b/internal/raftengine/etcd/engine_test.go
@@ -608,9 +608,12 @@ func TestUpsertPeerStartsDispatcherAndAcceptsMessages(t *testing.T) {
 
 func TestRemovePeerClosesDispatcherAndDropsSubsequentMessages(t *testing.T) {
 	stopCh := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
 	pd := &peerQueues{
 		normal:    make(chan dispatchRequest, 4),
 		heartbeat: make(chan dispatchRequest, 4),
+		ctx:       ctx,
+		cancel:    cancel,
 	}
 	engine := &Engine{
 		nodeID:          1,
@@ -619,8 +622,8 @@ func TestRemovePeerClosesDispatcherAndDropsSubsequentMessages(t *testing.T) {
 		dispatchStopCh:  stopCh,
 	}
 	engine.dispatchWG.Add(2)
-	go engine.runDispatchWorker(pd.normal)
-	go engine.runDispatchWorker(pd.heartbeat)
+	go engine.runDispatchWorker(ctx, pd.normal)
+	go engine.runDispatchWorker(ctx, pd.heartbeat)
 
 	engine.removePeer(2)
 

--- a/internal/raftengine/etcd/engine_test.go
+++ b/internal/raftengine/etcd/engine_test.go
@@ -567,6 +567,74 @@ func TestStopDispatchWorkersCancelsInflightDispatch(t *testing.T) {
 	}
 }
 
+func TestUpsertPeerStartsDispatcherAndAcceptsMessages(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	dispatched := make(chan raftpb.Message, 1)
+	engine := &Engine{
+		nodeID:           1,
+		peerDispatchers:  make(map[uint64]chan dispatchRequest),
+		perPeerQueueSize: 4,
+		dispatchStopCh:   make(chan struct{}),
+		dispatchCtx:      ctx,
+		dispatchCancel:   cancel,
+	}
+	engine.dispatchFn = func(_ context.Context, req dispatchRequest) error {
+		dispatched <- req.msg
+		return nil
+	}
+
+	engine.upsertPeer(Peer{NodeID: 2, ID: "peer2", Address: "localhost:2"})
+
+	ch, ok := engine.peerDispatchers[2]
+	require.True(t, ok, "dispatcher channel must be created on upsert")
+	require.Equal(t, 4, cap(ch))
+
+	require.NoError(t, engine.enqueueDispatchMessage(raftpb.Message{Type: raftpb.MsgHeartbeat, To: 2}))
+
+	select {
+	case msg := <-dispatched:
+		require.Equal(t, uint64(2), msg.To)
+	case <-time.After(time.Second):
+		t.Fatal("message was not dispatched to peer 2")
+	}
+
+	close(engine.dispatchStopCh)
+	engine.dispatchWG.Wait()
+}
+
+func TestRemovePeerClosesDispatcherAndDropsSubsequentMessages(t *testing.T) {
+	stopCh := make(chan struct{})
+	ch := make(chan dispatchRequest, 4)
+	engine := &Engine{
+		nodeID:          1,
+		peers:           map[uint64]Peer{2: {NodeID: 2, ID: "peer2"}},
+		peerDispatchers: map[uint64]chan dispatchRequest{2: ch},
+		dispatchStopCh:  stopCh,
+	}
+	engine.dispatchWG.Add(1)
+	go engine.runDispatchWorker(ch)
+
+	engine.removePeer(2)
+
+	_, ok := engine.peerDispatchers[2]
+	require.False(t, ok, "dispatcher must be removed from map")
+
+	workerDone := make(chan struct{})
+	go func() {
+		engine.dispatchWG.Wait()
+		close(workerDone)
+	}()
+	select {
+	case <-workerDone:
+	case <-time.After(time.Second):
+		t.Fatal("dispatch worker did not exit after channel close")
+	}
+
+	// Subsequent messages to the removed peer must be dropped without panic.
+	require.NoError(t, engine.enqueueDispatchMessage(raftpb.Message{Type: raftpb.MsgHeartbeat, To: 2}))
+}
+
 func TestMaybePersistLocalSnapshotSkipsSmallAdvance(t *testing.T) {
 	storage := etcdraft.NewMemoryStorage()
 	require.NoError(t, storage.ApplySnapshot(raftpb.Snapshot{

--- a/internal/raftengine/etcd/engine_test.go
+++ b/internal/raftengine/etcd/engine_test.go
@@ -590,7 +590,7 @@ func TestUpsertPeerStartsDispatcherAndAcceptsMessages(t *testing.T) {
 
 	pd, ok := engine.peerDispatchers[2]
 	require.True(t, ok, "dispatcher must be created on upsert")
-	require.Equal(t, defaultHeartbeatBufPerPeer, cap(pd.heartbeat))
+	require.Equal(t, 4, cap(pd.heartbeat))
 	require.Equal(t, 4, cap(pd.normal))
 
 	require.NoError(t, engine.enqueueDispatchMessage(raftpb.Message{Type: raftpb.MsgHeartbeat, To: 2}))


### PR DESCRIPTION
Each peer now gets an isolated channel (capacity MaxInflightMsg) and dedicated dispatch workers (defaultDispatchWorkers per peer) instead of all peers competing for a single shared channel. A slow gRPC call to one peer no longer starves heartbeats and log entries destined for others.

Dynamic peer membership (AddVoter/RemoveVoter) is handled: startPeerDispatcher is called on upsert and the channel entry is removed on peer removal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched to per-peer outbound dispatch queues with separate normal and priority/control channels, per-peer sizing, and per-peer start/stop lifecycles; messages to removed peers are dropped gracefully.
* **Tests**
  * Added/updated tests for per-peer dispatcher lifecycle, priority queueing, non-blocking enqueueing, shutdown behavior, and dropped-message handling.
* **Documentation**
  * Added a design proposal for long-lived per-peer streaming transport with backward-compatible fallback and rollout guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->