### PR TITLE
fix(proxy): retry secondary writes on "read timestamp has been compacted"

### DIFF
--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -73,13 +73,43 @@ type bzpopminResult struct {
 }
 
 func (r *RedisServer) info(conn redcon.Conn, _ redcon.Command) {
+	role := "slave"
+	if r.coordinator != nil && r.coordinator.IsLeader() {
+		role = "master"
+	}
+
+	leaderRedis := r.raftLeaderRedisAddr()
+
 	conn.WriteBulkString(strings.Join([]string{
 		"# Server",
 		"redis_version:7.2.0",
 		"loading:0",
-		"role:master",
+		"role:" + role,
+		"",
+		"# Replication",
+		"role:" + role,
+		"raft_leader_redis:" + leaderRedis,
 		"",
 	}, "\r\n"))
+}
+
+// raftLeaderRedisAddr returns the Redis-protocol address of the current Raft
+// leader as known by this node. When this node is itself the leader the
+// server's own listen address is returned. An empty string is returned when
+// the leader is not yet known or when the leader's Redis address is not
+// configured in the leaderRedis map.
+func (r *RedisServer) raftLeaderRedisAddr() string {
+	if r.coordinator == nil {
+		return ""
+	}
+	if r.coordinator.IsLeader() {
+		return r.redisAddr
+	}
+	leader := r.coordinator.RaftLeader()
+	if leader == "" {
+		return ""
+	}
+	return r.leaderRedis[leader]
 }
 
 // SETEX key seconds value — equivalent to SET key value EX seconds

--- a/adapter/redis_info_test.go
+++ b/adapter/redis_info_test.go
@@ -1,0 +1,94 @@
+package adapter
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/bootjp/elastickv/kv"
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/redcon"
+)
+
+type infoTestCoordinator struct {
+	isLeader   bool
+	raftLeader raft.ServerAddress
+	clock      *kv.HLC
+}
+
+func (c *infoTestCoordinator) Dispatch(context.Context, *kv.OperationGroup[kv.OP]) (*kv.CoordinateResponse, error) {
+	return &kv.CoordinateResponse{}, nil
+}
+func (c *infoTestCoordinator) IsLeader() bool                              { return c.isLeader }
+func (c *infoTestCoordinator) VerifyLeader() error                         { return nil }
+func (c *infoTestCoordinator) RaftLeader() raft.ServerAddress              { return c.raftLeader }
+func (c *infoTestCoordinator) IsLeaderForKey([]byte) bool                  { return c.isLeader }
+func (c *infoTestCoordinator) VerifyLeaderForKey([]byte) error             { return nil }
+func (c *infoTestCoordinator) RaftLeaderForKey([]byte) raft.ServerAddress  { return c.raftLeader }
+func (c *infoTestCoordinator) Clock() *kv.HLC {
+	if c.clock == nil {
+		c.clock = kv.NewHLC()
+	}
+	return c.clock
+}
+
+func TestRedisServer_Info_LeaderRole(t *testing.T) {
+	r := &RedisServer{
+		redisAddr:   "10.0.0.1:6379",
+		leaderRedis: map[raft.ServerAddress]string{"raft-1": "10.0.0.1:6379"},
+		coordinator: &infoTestCoordinator{isLeader: true, raftLeader: "raft-1"},
+	}
+
+	conn := &recordingConn{}
+	r.info(conn, redcon.Command{})
+
+	out := string(conn.bulk)
+	assert.Contains(t, out, "# Server", "INFO reply must keep the Server section")
+	assert.Contains(t, out, "# Replication", "INFO reply must expose a Replication section")
+	assert.Contains(t, out, "role:master", "leader must advertise role:master")
+	assert.Contains(t, out, "raft_leader_redis:10.0.0.1:6379",
+		"leader must point raft_leader_redis at itself")
+}
+
+func TestRedisServer_Info_FollowerRole(t *testing.T) {
+	r := &RedisServer{
+		redisAddr: "10.0.0.2:6379",
+		leaderRedis: map[raft.ServerAddress]string{
+			"raft-1": "10.0.0.1:6379",
+			"raft-2": "10.0.0.2:6379",
+		},
+		coordinator: &infoTestCoordinator{isLeader: false, raftLeader: "raft-1"},
+	}
+
+	conn := &recordingConn{}
+	r.info(conn, redcon.Command{})
+
+	out := string(conn.bulk)
+	assert.Contains(t, out, "role:slave", "follower must advertise role:slave")
+	assert.Contains(t, out, "raft_leader_redis:10.0.0.1:6379",
+		"follower must point raft_leader_redis at the actual leader")
+	// The role must appear in the Replication section so clients that only
+	// scan that section still see the right value.
+	idx := strings.Index(out, "# Replication")
+	require.GreaterOrEqual(t, idx, 0)
+	assert.Contains(t, out[idx:], "role:slave")
+	assert.Contains(t, out[idx:], "raft_leader_redis:10.0.0.1:6379")
+}
+
+func TestRedisServer_Info_UnknownLeader(t *testing.T) {
+	r := &RedisServer{
+		redisAddr:   "10.0.0.3:6379",
+		leaderRedis: map[raft.ServerAddress]string{},
+		coordinator: &infoTestCoordinator{isLeader: false, raftLeader: ""},
+	}
+
+	conn := &recordingConn{}
+	r.info(conn, redcon.Command{})
+
+	out := string(conn.bulk)
+	assert.Contains(t, out, "role:slave")
+	assert.Contains(t, out, "raft_leader_redis:\r\n",
+		"when the leader is unknown the field must be empty so clients know to keep probing")
+}

--- a/adapter/redis_info_test.go
+++ b/adapter/redis_info_test.go
@@ -21,12 +21,12 @@ type infoTestCoordinator struct {
 func (c *infoTestCoordinator) Dispatch(context.Context, *kv.OperationGroup[kv.OP]) (*kv.CoordinateResponse, error) {
 	return &kv.CoordinateResponse{}, nil
 }
-func (c *infoTestCoordinator) IsLeader() bool                              { return c.isLeader }
-func (c *infoTestCoordinator) VerifyLeader() error                         { return nil }
-func (c *infoTestCoordinator) RaftLeader() raft.ServerAddress              { return c.raftLeader }
-func (c *infoTestCoordinator) IsLeaderForKey([]byte) bool                  { return c.isLeader }
-func (c *infoTestCoordinator) VerifyLeaderForKey([]byte) error             { return nil }
-func (c *infoTestCoordinator) RaftLeaderForKey([]byte) raft.ServerAddress  { return c.raftLeader }
+func (c *infoTestCoordinator) IsLeader() bool                             { return c.isLeader }
+func (c *infoTestCoordinator) VerifyLeader() error                        { return nil }
+func (c *infoTestCoordinator) RaftLeader() raft.ServerAddress             { return c.raftLeader }
+func (c *infoTestCoordinator) IsLeaderForKey([]byte) bool                 { return c.isLeader }
+func (c *infoTestCoordinator) VerifyLeaderForKey([]byte) error            { return nil }
+func (c *infoTestCoordinator) RaftLeaderForKey([]byte) raft.ServerAddress { return c.raftLeader }
 func (c *infoTestCoordinator) Clock() *kv.HLC {
 	if c.clock == nil {
 		c.clock = kv.NewHLC()

--- a/cmd/redis-proxy/main.go
+++ b/cmd/redis-proxy/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -37,7 +38,7 @@ func run() error {
 	flag.StringVar(&cfg.PrimaryAddr, "primary", cfg.PrimaryAddr, "Primary (Redis) address")
 	flag.IntVar(&cfg.PrimaryDB, "primary-db", cfg.PrimaryDB, "Primary Redis DB number")
 	flag.StringVar(&cfg.PrimaryPassword, "primary-password", cfg.PrimaryPassword, "Primary Redis password")
-	flag.StringVar(&cfg.SecondaryAddr, "secondary", cfg.SecondaryAddr, "Secondary (ElasticKV) address")
+	flag.StringVar(&cfg.SecondaryAddr, "secondary", cfg.SecondaryAddr, "Secondary (ElasticKV) address. Comma-separated list of seeds is supported; the proxy discovers the current Raft leader via INFO replication.")
 	flag.IntVar(&cfg.SecondaryDB, "secondary-db", cfg.SecondaryDB, "Secondary Redis DB number")
 	flag.StringVar(&cfg.SecondaryPassword, "secondary-password", cfg.SecondaryPassword, "Secondary Redis password")
 	flag.StringVar(&modeStr, "mode", "dual-write", "Proxy mode: redis-only, dual-write, dual-write-shadow, elastickv-primary, elastickv-only")
@@ -73,14 +74,19 @@ func run() error {
 	secondaryOpts.DB = cfg.SecondaryDB
 	secondaryOpts.Password = cfg.SecondaryPassword
 
+	secondarySeeds := parseAddrList(cfg.SecondaryAddr)
+	if len(secondarySeeds) == 0 {
+		return fmt.Errorf("at least one secondary address is required")
+	}
+
 	var primary, secondary proxy.Backend
 	switch cfg.Mode {
 	case proxy.ModeElasticKVPrimary, proxy.ModeElasticKVOnly:
-		primary = proxy.NewRedisBackendWithOptions(cfg.SecondaryAddr, "elastickv", secondaryOpts)
+		primary = proxy.NewLeaderAwareRedisBackend(secondarySeeds, "elastickv", secondaryOpts, logger)
 		secondary = proxy.NewRedisBackendWithOptions(cfg.PrimaryAddr, "redis", primaryOpts)
 	case proxy.ModeRedisOnly, proxy.ModeDualWrite, proxy.ModeDualWriteShadow:
 		primary = proxy.NewRedisBackendWithOptions(cfg.PrimaryAddr, "redis", primaryOpts)
-		secondary = proxy.NewRedisBackendWithOptions(cfg.SecondaryAddr, "elastickv", secondaryOpts)
+		secondary = proxy.NewLeaderAwareRedisBackend(secondarySeeds, "elastickv", secondaryOpts, logger)
 	}
 	defer primary.Close()
 	defer secondary.Close()
@@ -123,4 +129,15 @@ func run() error {
 		return fmt.Errorf("proxy server: %w", err)
 	}
 	return nil
+}
+
+func parseAddrList(raw string) []string {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }

--- a/proxy/dualwrite.go
+++ b/proxy/dualwrite.go
@@ -2,10 +2,11 @@ package proxy
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"log/slog"
-	"math/rand/v2"
+	"math/big"
 	"strings"
 	"sync"
 	"time"
@@ -254,12 +255,53 @@ func (d *DualWriter) Script(ctx context.Context, cmd string, args [][]byte) (any
 	return resp, err //nolint:wrapcheck // redis.Nil must pass through unwrapped for callers to detect nil replies
 }
 
+// writeSecondary sends the command to the secondary, handling the NOSCRIPT
+// → EVAL fallback and transparently retrying when the secondary reports that
+// the read snapshot has been compacted. A re-sent command causes the backend
+// to re-select a fresh read timestamp, which is the only way to recover once
+// the original startTS has fallen behind MinRetainedTS on a peer node.
+//
+// The secondary's raw redis error is kept in sErr (not wrapped) so that
+// writeSecondary can classify it via errors.Is(sErr, redis.Nil), attach the
+// original message to Sentry and the structured log, and so the retry
+// predicate isReadTSCompactedError matches the exact substring coming back
+// from gRPC.
 func (d *DualWriter) writeSecondary(cmd string, iArgs []any) {
 	sCtx, cancel := context.WithTimeout(context.Background(), d.cfg.SecondaryTimeout)
 	defer cancel()
 
 	start := time.Now()
-	sErr := d.executeSecondary(sCtx, cmd, iArgs)
+
+	backoff := compactedRetryInitialBackoff
+	var sErr error
+	args := iArgs
+	for attempt := 0; ; attempt++ {
+		result := d.secondary.Do(sCtx, args...)
+		_, sErr = result.Result()
+		if isNoScriptError(sErr) {
+			// After a successful NOSCRIPT→EVAL resolution, retries reuse the
+			// resolved EVAL args so we don't waste a round-trip on the
+			// known-missing EVALSHA every iteration.
+			if fallbackArgs, ok := d.evalFallbackArgs(cmd, args); ok {
+				args = fallbackArgs
+				result = d.secondary.Do(sCtx, args...)
+				_, sErr = result.Result()
+			}
+		}
+		if !isReadTSCompactedError(sErr) {
+			break
+		}
+		if attempt >= maxCompactedRetries {
+			break
+		}
+		d.logger.Debug("retrying secondary write on compacted snapshot",
+			"cmd", cmd, "attempt", attempt+1, "backoff", backoff, "err", sErr)
+		if !waitCompactedRetryBackoff(sCtx, backoff) {
+			break
+		}
+		backoff = nextCompactedRetryBackoff(backoff)
+	}
+
 	d.metrics.CommandDuration.WithLabelValues(cmd, d.secondary.Name()).Observe(time.Since(start).Seconds())
 
 	if sErr != nil && !errors.Is(sErr, redis.Nil) {
@@ -275,52 +317,6 @@ func (d *DualWriter) writeSecondary(cmd string, iArgs []any) {
 	d.metrics.CommandTotal.WithLabelValues(cmd, d.secondary.Name(), "ok").Inc()
 }
 
-// executeSecondary sends the command to the secondary, handling the NOSCRIPT
-// → EVAL fallback and transparently retrying when the secondary reports that
-// the read snapshot has been compacted. A re-sent command causes the backend
-// to re-select a fresh read timestamp, which is the only way to recover once
-// the original startTS has fallen behind MinRetainedTS on a peer node.
-//
-// If the first attempt triggers a NOSCRIPT fallback, subsequent retry
-// attempts use the resolved EVAL args directly so we don't waste a
-// round-trip on the known-missing EVALSHA every iteration.
-func (d *DualWriter) executeSecondary(sCtx context.Context, cmd string, iArgs []any) error {
-	backoff := compactedRetryInitialBackoff
-	var sErr error
-	args := iArgs
-	for attempt := 0; ; attempt++ {
-		result := d.secondary.Do(sCtx, args...)
-		_, sErr = result.Result()
-		if isNoScriptError(sErr) {
-			if fallbackArgs, ok := d.evalFallbackArgs(cmd, args); ok {
-				args = fallbackArgs
-				result = d.secondary.Do(sCtx, args...)
-				_, sErr = result.Result()
-			}
-		}
-		if !isReadTSCompactedError(sErr) {
-			return wrapSecondaryError(sErr)
-		}
-		if attempt >= maxCompactedRetries {
-			return wrapSecondaryError(sErr)
-		}
-		if !waitCompactedRetryBackoff(sCtx, backoff) {
-			return wrapSecondaryError(sErr)
-		}
-		backoff = nextCompactedRetryBackoff(backoff)
-	}
-}
-
-// wrapSecondaryError forwards the secondary's error with a %w wrapper so
-// wrapcheck is satisfied while preserving errors.Is classification for
-// redis.Nil and redis.Error. Returns nil unchanged.
-func wrapSecondaryError(err error) error {
-	if err == nil {
-		return nil
-	}
-	return fmt.Errorf("secondary: %w", err)
-}
-
 // waitCompactedRetryBackoff sleeps for a jittered interval or returns early
 // when the context is cancelled. Returns false if the caller should abort
 // the retry loop (context done).
@@ -334,11 +330,7 @@ func waitCompactedRetryBackoff(ctx context.Context, backoff time.Duration) bool 
 	if backoff <= 0 {
 		return ctx.Err() == nil
 	}
-	jitter := time.Duration(0)
-	if jitterWindow := int64(backoff / compactedRetryJitterDivisor); jitterWindow > 0 {
-		jitter = time.Duration(rand.Int64N(jitterWindow)) //nolint:gosec // jitter for retry backoff, not security sensitive
-	}
-	timer := time.NewTimer(backoff + jitter)
+	timer := time.NewTimer(backoff + jitterFor(backoff))
 	defer timer.Stop()
 
 	select {
@@ -347,6 +339,22 @@ func waitCompactedRetryBackoff(ctx context.Context, backoff time.Duration) bool 
 	case <-timer.C:
 		return true
 	}
+}
+
+// jitterFor returns a random additive jitter in [0, backoff/compactedRetryJitterDivisor).
+// crypto/rand is used so the code does not trip the gosec G404 rule that
+// flags math/rand for randomness; the security grade does not matter for a
+// retry spread but this avoids a blanket lint suppression.
+func jitterFor(backoff time.Duration) time.Duration {
+	window := int64(backoff / compactedRetryJitterDivisor)
+	if window <= 0 {
+		return 0
+	}
+	n, err := rand.Int(rand.Reader, big.NewInt(window))
+	if err != nil {
+		return 0
+	}
+	return time.Duration(n.Int64())
 }
 
 func nextCompactedRetryBackoff(current time.Duration) time.Duration {

--- a/proxy/dualwrite.go
+++ b/proxy/dualwrite.go
@@ -40,6 +40,12 @@ const (
 	// stays well within SecondaryTimeout even if the retry policy is ever
 	// widened.
 	compactedRetryMaxBackoff = 100 * time.Millisecond
+	// compactedRetryBackoffFactor is the multiplier applied to the backoff
+	// between retries; 2 gives a conventional exponential schedule.
+	compactedRetryBackoffFactor = 2
+	// compactedRetryJitterDivisor bounds the jitter to backoff/divisor so
+	// jitter stays small relative to the base delay.
+	compactedRetryJitterDivisor = 2
 )
 
 // readTSCompactedMarker is the substring produced by
@@ -278,10 +284,6 @@ func (d *DualWriter) writeSecondary(cmd string, iArgs []any) {
 // If the first attempt triggers a NOSCRIPT fallback, subsequent retry
 // attempts use the resolved EVAL args directly so we don't waste a
 // round-trip on the known-missing EVALSHA every iteration.
-// The nolint:wrapcheck annotations on each return mirror the other
-// writeSecondary-family handlers above: the secondary error must flow back
-// unwrapped so writeSecondary can classify redis.Nil / redis.Error, fingerprint
-// it for Sentry, and attach the original message in the structured log.
 func (d *DualWriter) executeSecondary(sCtx context.Context, cmd string, iArgs []any) error {
 	backoff := compactedRetryInitialBackoff
 	var sErr error
@@ -297,16 +299,26 @@ func (d *DualWriter) executeSecondary(sCtx context.Context, cmd string, iArgs []
 			}
 		}
 		if !isReadTSCompactedError(sErr) {
-			return sErr //nolint:wrapcheck // secondary error must pass through unwrapped for redis.Nil / redis.Error classification
+			return wrapSecondaryError(sErr)
 		}
 		if attempt >= maxCompactedRetries {
-			return sErr //nolint:wrapcheck // secondary error must pass through unwrapped for redis.Nil / redis.Error classification
+			return wrapSecondaryError(sErr)
 		}
 		if !waitCompactedRetryBackoff(sCtx, backoff) {
-			return sErr //nolint:wrapcheck // secondary error must pass through unwrapped for redis.Nil / redis.Error classification
+			return wrapSecondaryError(sErr)
 		}
 		backoff = nextCompactedRetryBackoff(backoff)
 	}
+}
+
+// wrapSecondaryError forwards the secondary's error with a %w wrapper so
+// wrapcheck is satisfied while preserving errors.Is classification for
+// redis.Nil and redis.Error. Returns nil unchanged.
+func wrapSecondaryError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("secondary: %w", err)
 }
 
 // waitCompactedRetryBackoff sleeps for a jittered interval or returns early
@@ -323,8 +335,8 @@ func waitCompactedRetryBackoff(ctx context.Context, backoff time.Duration) bool 
 		return ctx.Err() == nil
 	}
 	jitter := time.Duration(0)
-	if half := int64(backoff / 2); half > 0 {
-		jitter = time.Duration(rand.Int64N(half)) //nolint:gosec // jitter for retry backoff, not security sensitive
+	if jitterWindow := int64(backoff / compactedRetryJitterDivisor); jitterWindow > 0 {
+		jitter = time.Duration(rand.Int64N(jitterWindow)) //nolint:gosec // jitter for retry backoff, not security sensitive
 	}
 	timer := time.NewTimer(backoff + jitter)
 	defer timer.Stop()
@@ -338,7 +350,7 @@ func waitCompactedRetryBackoff(ctx context.Context, backoff time.Duration) bool 
 }
 
 func nextCompactedRetryBackoff(current time.Duration) time.Duration {
-	next := current * 2
+	next := current * compactedRetryBackoffFactor
 	if next > compactedRetryMaxBackoff {
 		return compactedRetryMaxBackoff
 	}

--- a/proxy/dualwrite.go
+++ b/proxy/dualwrite.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -25,7 +26,29 @@ const (
 	// contention bounded; this is only tolerable in modes where the script write
 	// is targeting the non-authoritative backend.
 	maxScriptWriteGoroutines = 64
+
+	// maxCompactedRetries caps retries when the secondary returns
+	// "read timestamp has been compacted". Each attempt re-sends the command so
+	// the secondary re-selects a fresh read snapshot; a small bound is enough
+	// because the compaction waterline advances slowly relative to SecondaryTimeout.
+	maxCompactedRetries = 3
+	// compactedRetryInitialBackoff is the first delay before retrying a secondary
+	// command that failed with a compacted-read error.
+	compactedRetryInitialBackoff = 10 * time.Millisecond
 )
+
+// readTSCompactedMarker is the substring produced by
+// store.ErrReadTSCompacted as it flows through gRPC (wrapped as
+// FailedPrecondition) and Lua PCall. Matching on substring is necessary
+// because both layers erase the typed error.
+const readTSCompactedMarker = "read timestamp has been compacted"
+
+func isReadTSCompactedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), readTSCompactedMarker)
+}
 
 // DualWriter routes commands to primary and secondary backends based on mode.
 type DualWriter struct {
@@ -225,14 +248,7 @@ func (d *DualWriter) writeSecondary(cmd string, iArgs []any) {
 	defer cancel()
 
 	start := time.Now()
-	result := d.secondary.Do(sCtx, iArgs...)
-	_, sErr := result.Result()
-	if isNoScriptError(sErr) {
-		if fallbackArgs, ok := d.evalFallbackArgs(cmd, iArgs); ok {
-			result = d.secondary.Do(sCtx, fallbackArgs...)
-			_, sErr = result.Result()
-		}
-	}
+	sErr := d.executeSecondary(sCtx, cmd, iArgs)
 	d.metrics.CommandDuration.WithLabelValues(cmd, d.secondary.Name()).Observe(time.Since(start).Seconds())
 
 	if sErr != nil && !errors.Is(sErr, redis.Nil) {
@@ -246,6 +262,38 @@ func (d *DualWriter) writeSecondary(cmd string, iArgs []any) {
 		return
 	}
 	d.metrics.CommandTotal.WithLabelValues(cmd, d.secondary.Name(), "ok").Inc()
+}
+
+// executeSecondary sends the command to the secondary, handling the NOSCRIPT
+// → EVAL fallback and transparently retrying when the secondary reports that
+// the read snapshot has been compacted. A re-sent command causes the backend
+// to re-select a fresh read timestamp, which is the only way to recover once
+// the original startTS has fallen behind MinRetainedTS on a peer node.
+func (d *DualWriter) executeSecondary(sCtx context.Context, cmd string, iArgs []any) error {
+	backoff := compactedRetryInitialBackoff
+	var sErr error
+	for attempt := 0; ; attempt++ {
+		result := d.secondary.Do(sCtx, iArgs...)
+		_, sErr = result.Result()
+		if isNoScriptError(sErr) {
+			if fallbackArgs, ok := d.evalFallbackArgs(cmd, iArgs); ok {
+				result = d.secondary.Do(sCtx, fallbackArgs...)
+				_, sErr = result.Result()
+			}
+		}
+		if !isReadTSCompactedError(sErr) {
+			return sErr
+		}
+		if attempt >= maxCompactedRetries {
+			return sErr
+		}
+		select {
+		case <-sCtx.Done():
+			return sErr
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+	}
 }
 
 // goWrite launches fn in a bounded write goroutine.

--- a/proxy/dualwrite.go
+++ b/proxy/dualwrite.go
@@ -278,28 +278,32 @@ func (d *DualWriter) writeSecondary(cmd string, iArgs []any) {
 // If the first attempt triggers a NOSCRIPT fallback, subsequent retry
 // attempts use the resolved EVAL args directly so we don't waste a
 // round-trip on the known-missing EVALSHA every iteration.
+// The nolint:wrapcheck annotations on each return mirror the other
+// writeSecondary-family handlers above: the secondary error must flow back
+// unwrapped so writeSecondary can classify redis.Nil / redis.Error, fingerprint
+// it for Sentry, and attach the original message in the structured log.
 func (d *DualWriter) executeSecondary(sCtx context.Context, cmd string, iArgs []any) error {
 	backoff := compactedRetryInitialBackoff
 	var sErr error
 	args := iArgs
 	for attempt := 0; ; attempt++ {
 		result := d.secondary.Do(sCtx, args...)
-		_, sErr = result.Result() //nolint:wrapcheck // classification/error propagation preserves redis.Error types
+		_, sErr = result.Result()
 		if isNoScriptError(sErr) {
 			if fallbackArgs, ok := d.evalFallbackArgs(cmd, args); ok {
 				args = fallbackArgs
 				result = d.secondary.Do(sCtx, args...)
-				_, sErr = result.Result() //nolint:wrapcheck // classification/error propagation preserves redis.Error types
+				_, sErr = result.Result()
 			}
 		}
 		if !isReadTSCompactedError(sErr) {
-			return sErr
+			return sErr //nolint:wrapcheck // secondary error must pass through unwrapped for redis.Nil / redis.Error classification
 		}
 		if attempt >= maxCompactedRetries {
-			return sErr
+			return sErr //nolint:wrapcheck // secondary error must pass through unwrapped for redis.Nil / redis.Error classification
 		}
 		if !waitCompactedRetryBackoff(sCtx, backoff) {
-			return sErr
+			return sErr //nolint:wrapcheck // secondary error must pass through unwrapped for redis.Nil / redis.Error classification
 		}
 		backoff = nextCompactedRetryBackoff(backoff)
 	}

--- a/proxy/dualwrite.go
+++ b/proxy/dualwrite.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math/rand/v2"
 	"strings"
 	"sync"
 	"time"
@@ -35,6 +36,10 @@ const (
 	// compactedRetryInitialBackoff is the first delay before retrying a secondary
 	// command that failed with a compacted-read error.
 	compactedRetryInitialBackoff = 10 * time.Millisecond
+	// compactedRetryMaxBackoff caps the jittered exponential backoff so it
+	// stays well within SecondaryTimeout even if the retry policy is ever
+	// widened.
+	compactedRetryMaxBackoff = 100 * time.Millisecond
 )
 
 // readTSCompactedMarker is the substring produced by
@@ -269,16 +274,22 @@ func (d *DualWriter) writeSecondary(cmd string, iArgs []any) {
 // the read snapshot has been compacted. A re-sent command causes the backend
 // to re-select a fresh read timestamp, which is the only way to recover once
 // the original startTS has fallen behind MinRetainedTS on a peer node.
+//
+// If the first attempt triggers a NOSCRIPT fallback, subsequent retry
+// attempts use the resolved EVAL args directly so we don't waste a
+// round-trip on the known-missing EVALSHA every iteration.
 func (d *DualWriter) executeSecondary(sCtx context.Context, cmd string, iArgs []any) error {
 	backoff := compactedRetryInitialBackoff
 	var sErr error
+	args := iArgs
 	for attempt := 0; ; attempt++ {
-		result := d.secondary.Do(sCtx, iArgs...)
-		_, sErr = result.Result()
+		result := d.secondary.Do(sCtx, args...)
+		_, sErr = result.Result() //nolint:wrapcheck // classification/error propagation preserves redis.Error types
 		if isNoScriptError(sErr) {
-			if fallbackArgs, ok := d.evalFallbackArgs(cmd, iArgs); ok {
-				result = d.secondary.Do(sCtx, fallbackArgs...)
-				_, sErr = result.Result()
+			if fallbackArgs, ok := d.evalFallbackArgs(cmd, args); ok {
+				args = fallbackArgs
+				result = d.secondary.Do(sCtx, args...)
+				_, sErr = result.Result() //nolint:wrapcheck // classification/error propagation preserves redis.Error types
 			}
 		}
 		if !isReadTSCompactedError(sErr) {
@@ -287,13 +298,47 @@ func (d *DualWriter) executeSecondary(sCtx context.Context, cmd string, iArgs []
 		if attempt >= maxCompactedRetries {
 			return sErr
 		}
-		select {
-		case <-sCtx.Done():
+		if !waitCompactedRetryBackoff(sCtx, backoff) {
 			return sErr
-		case <-time.After(backoff):
 		}
-		backoff *= 2
+		backoff = nextCompactedRetryBackoff(backoff)
 	}
+}
+
+// waitCompactedRetryBackoff sleeps for a jittered interval or returns early
+// when the context is cancelled. Returns false if the caller should abort
+// the retry loop (context done).
+//
+// Jitter is in [backoff, backoff + backoff/2) so that concurrent retries
+// caused by a single compaction waterline advancement do not re-hit the
+// secondary in lockstep. A NewTimer is used instead of time.After so the
+// timer is released promptly on ctx cancellation (avoiding a leak until
+// expiry when the async goroutine is shutting down).
+func waitCompactedRetryBackoff(ctx context.Context, backoff time.Duration) bool {
+	if backoff <= 0 {
+		return ctx.Err() == nil
+	}
+	jitter := time.Duration(0)
+	if half := int64(backoff / 2); half > 0 {
+		jitter = time.Duration(rand.Int64N(half)) //nolint:gosec // jitter for retry backoff, not security sensitive
+	}
+	timer := time.NewTimer(backoff + jitter)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func nextCompactedRetryBackoff(current time.Duration) time.Duration {
+	next := current * 2
+	if next > compactedRetryMaxBackoff {
+		return compactedRetryMaxBackoff
+	}
+	return next
 }
 
 // goWrite launches fn in a bounded write goroutine.

--- a/proxy/leader_aware_backend.go
+++ b/proxy/leader_aware_backend.go
@@ -24,6 +24,14 @@ const (
 
 	raftLeaderRedisField = "raft_leader_redis:"
 	infoReplicationArg   = "replication"
+
+	// maxLeaderAwareClients caps the number of cached redis.Client pools so
+	// that a long-running process cannot accumulate pools indefinitely as
+	// leaders churn (e.g. rolling restarts changing addresses). This is well
+	// above a realistic Raft cluster size; when the cap is reached we evict
+	// the oldest non-protected entry (FIFO, skipping seeds and the current
+	// leader) before inserting a new one.
+	maxLeaderAwareClients = 16
 )
 
 // ErrNoLeaderBackend is returned when LeaderAwareRedisBackend has no usable
@@ -45,10 +53,12 @@ type LeaderAwareRedisBackend struct {
 
 	logger *slog.Logger
 
-	mu      sync.RWMutex
-	clients map[string]*redis.Client
-	leader  string
-	closed  bool
+	mu           sync.RWMutex
+	clients      map[string]*redis.Client
+	clientOrder  []string // FIFO insertion order for bounded eviction
+	leader       string
+	closed       bool
+	seedProtect  map[string]struct{}
 
 	stopCh    chan struct{}
 	done      chan struct{}
@@ -72,6 +82,10 @@ func NewLeaderAwareRedisBackendWithInterval(seeds []string, name string, opts Ba
 	if logger == nil {
 		logger = slog.Default()
 	}
+	seedProtect := make(map[string]struct{}, len(normalized))
+	for _, s := range normalized {
+		seedProtect[s] = struct{}{}
+	}
 	b := &LeaderAwareRedisBackend{
 		name:            name,
 		opts:            opts,
@@ -80,6 +94,8 @@ func NewLeaderAwareRedisBackendWithInterval(seeds []string, name string, opts Ba
 		refreshTimeout:  refreshTimeout,
 		logger:          logger,
 		clients:         make(map[string]*redis.Client, len(normalized)),
+		clientOrder:     make([]string, 0, len(normalized)),
+		seedProtect:     seedProtect,
 		leader:          normalized[0],
 		stopCh:          make(chan struct{}),
 		done:            make(chan struct{}),
@@ -275,6 +291,15 @@ func (b *LeaderAwareRedisBackend) ensureClientLocked(addr string) *redis.Client 
 	if b.closed {
 		return nil
 	}
+	// Evict the oldest non-protected client (FIFO, skipping seeds and the
+	// current leader) so long-running leader churn cannot leak pools.
+	if len(b.clients) >= maxLeaderAwareClients {
+		if !b.evictOneLocked() {
+			b.logger.Warn("leader-aware client cache at cap with no evictable entries",
+				"backend", b.name, "cap", maxLeaderAwareClients, "rejected", addr)
+			return nil
+		}
+	}
 	cli := redis.NewClient(&redis.Options{
 		Addr:         addr,
 		DB:           b.opts.DB,
@@ -286,7 +311,33 @@ func (b *LeaderAwareRedisBackend) ensureClientLocked(addr string) *redis.Client 
 		WriteTimeout: b.opts.WriteTimeout,
 	})
 	b.clients[addr] = cli
+	b.clientOrder = append(b.clientOrder, addr)
 	return cli
+}
+
+// evictOneLocked removes the oldest client that is neither a seed nor the
+// current leader and closes its pool. Returns true when an entry was evicted.
+// Must be called with b.mu held for writing.
+func (b *LeaderAwareRedisBackend) evictOneLocked() bool {
+	for i, addr := range b.clientOrder {
+		if _, protected := b.seedProtect[addr]; protected {
+			continue
+		}
+		if addr == b.leader {
+			continue
+		}
+		cli := b.clients[addr]
+		delete(b.clients, addr)
+		b.clientOrder = append(b.clientOrder[:i], b.clientOrder[i+1:]...)
+		if cli != nil {
+			if err := cli.Close(); err != nil {
+				b.logger.Warn("close evicted leader-aware client failed",
+					"backend", b.name, "addr", addr, "err", err)
+			}
+		}
+		return true
+	}
+	return false
 }
 
 // currentClient returns the client for the current leader. The whole
@@ -386,6 +437,7 @@ func (b *LeaderAwareRedisBackend) Close() error {
 		snapshot[addr] = cli
 	}
 	b.clients = map[string]*redis.Client{}
+	b.clientOrder = b.clientOrder[:0]
 	b.mu.Unlock()
 
 	var firstErr error

--- a/proxy/leader_aware_backend.go
+++ b/proxy/leader_aware_backend.go
@@ -124,17 +124,31 @@ func (b *LeaderAwareRedisBackend) refreshLoop() {
 
 	b.refreshLeader(ctx)
 
-	t := time.NewTicker(b.refreshInterval)
-	defer t.Stop()
+	// Use a NewTimer that is reset after each probe completes rather than a
+	// Ticker so that when a probe takes longer than refreshInterval (e.g. a
+	// dead seed with a 1s probe timeout and a 50ms interval) we don't
+	// immediately re-fire a second probe the instant the first returns.
+	// This guarantees at least refreshInterval of quiet time between probes.
+	timer := time.NewTimer(b.refreshInterval)
+	defer timer.Stop()
 	for {
 		select {
 		case <-b.stopCh:
 			return
-		case <-t.C:
+		case <-timer.C:
 			b.refreshLeader(ctx)
 		case <-b.refreshCh:
+			if !timer.Stop() {
+				// Drain the channel if the timer had already fired so the
+				// subsequent Reset doesn't race a pending tick.
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
 			b.refreshLeader(ctx)
 		}
+		timer.Reset(b.refreshInterval)
 	}
 }
 
@@ -154,7 +168,8 @@ func (b *LeaderAwareRedisBackend) TriggerRefresh() {
 // leader's Redis address is returned by the leader node itself when it's
 // healthy, so this converges in one probe during steady state.
 func (b *LeaderAwareRedisBackend) refreshLeader(ctx context.Context) {
-	for _, addr := range b.candidateAddrs() {
+	candidates := b.candidateAddrs()
+	for _, addr := range candidates {
 		if ctx.Err() != nil {
 			return
 		}
@@ -168,6 +183,12 @@ func (b *LeaderAwareRedisBackend) refreshLeader(ctx context.Context) {
 		}
 		b.setLeader(leader)
 		return
+	}
+	// Only warn when the context is still alive; an interrupted probe during
+	// shutdown is expected and not a cluster-health signal.
+	if ctx.Err() == nil {
+		b.logger.Warn("leader discovery could not find an advertised leader",
+			"backend", b.name, "candidates", candidates)
 	}
 }
 

--- a/proxy/leader_aware_backend.go
+++ b/proxy/leader_aware_backend.go
@@ -1,0 +1,347 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	// defaultLeaderRefreshInterval is how often the leader-aware backend
+	// re-polls the ElasticKV cluster for its current Raft leader. The
+	// interval is short enough that a leader election settles quickly but
+	// long enough to avoid meaningful INFO traffic overhead.
+	defaultLeaderRefreshInterval = 2 * time.Second
+	// defaultLeaderRefreshTimeout caps a single INFO replication probe so
+	// that one dead node cannot stall the refresh loop for every seed.
+	defaultLeaderRefreshTimeout = 1 * time.Second
+
+	raftLeaderRedisField = "raft_leader_redis:"
+	infoReplicationArg   = "replication"
+)
+
+// ErrNoLeaderBackend is returned when LeaderAwareRedisBackend has no usable
+// client (no seed and no discovered leader). It should never happen in
+// practice because the backend always falls back to a seed address.
+var ErrNoLeaderBackend = errors.New("leader-aware backend has no upstream")
+
+// LeaderAwareRedisBackend routes commands to whichever ElasticKV node is
+// currently the Raft leader, discovering the leader via `INFO replication`.
+// Seed addresses are used for the initial probe and as fallbacks when the
+// current leader becomes unreachable.
+type LeaderAwareRedisBackend struct {
+	name  string
+	opts  BackendOptions
+	seeds []string
+
+	refreshInterval time.Duration
+	refreshTimeout  time.Duration
+
+	logger *slog.Logger
+
+	mu      sync.RWMutex
+	clients map[string]*redis.Client
+	leader  string
+	closed  bool
+
+	stopCh    chan struct{}
+	done      chan struct{}
+	refreshCh chan struct{}
+}
+
+// NewLeaderAwareRedisBackend creates a LeaderAwareRedisBackend with the given
+// seed addresses. The first seed is used as the initial target until the
+// first refresh completes. At least one seed is required.
+func NewLeaderAwareRedisBackend(seeds []string, name string, opts BackendOptions, logger *slog.Logger) *LeaderAwareRedisBackend {
+	return NewLeaderAwareRedisBackendWithInterval(seeds, name, opts, defaultLeaderRefreshInterval, defaultLeaderRefreshTimeout, logger)
+}
+
+// NewLeaderAwareRedisBackendWithInterval is the fully-parameterised constructor
+// used by tests that need a shorter poll period.
+func NewLeaderAwareRedisBackendWithInterval(seeds []string, name string, opts BackendOptions, refreshInterval, refreshTimeout time.Duration, logger *slog.Logger) *LeaderAwareRedisBackend {
+	normalized := normalizeSeeds(seeds)
+	if len(normalized) == 0 {
+		panic("proxy: LeaderAwareRedisBackend requires at least one seed address")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	b := &LeaderAwareRedisBackend{
+		name:            name,
+		opts:            opts,
+		seeds:           normalized,
+		refreshInterval: refreshInterval,
+		refreshTimeout:  refreshTimeout,
+		logger:          logger,
+		clients:         make(map[string]*redis.Client, len(normalized)),
+		leader:          normalized[0],
+		stopCh:          make(chan struct{}),
+		done:            make(chan struct{}),
+		refreshCh:       make(chan struct{}, 1),
+	}
+	for _, addr := range normalized {
+		b.ensureClientLocked(addr)
+	}
+	go b.refreshLoop()
+	return b
+}
+
+func normalizeSeeds(seeds []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(seeds))
+	for _, s := range seeds {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+func (b *LeaderAwareRedisBackend) refreshLoop() {
+	defer close(b.done)
+
+	b.refreshLeader(context.Background())
+
+	t := time.NewTicker(b.refreshInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-b.stopCh:
+			return
+		case <-t.C:
+			b.refreshLeader(context.Background())
+		case <-b.refreshCh:
+			b.refreshLeader(context.Background())
+		}
+	}
+}
+
+// TriggerRefresh asks the background loop to re-probe the current leader
+// immediately. Useful after a command fails in a way that suggests the
+// leader has changed. Multiple concurrent calls coalesce into at most one
+// extra probe.
+func (b *LeaderAwareRedisBackend) TriggerRefresh() {
+	select {
+	case b.refreshCh <- struct{}{}:
+	default:
+	}
+}
+
+// refreshLeader probes INFO replication on the current leader first, then on
+// each seed, and adopts the first advertised leader address. The current
+// leader's Redis address is returned by the leader node itself when it's
+// healthy, so this converges in one probe during steady state.
+func (b *LeaderAwareRedisBackend) refreshLeader(ctx context.Context) {
+	for _, addr := range b.candidateAddrs() {
+		leader, err := b.probeLeader(ctx, addr)
+		if err != nil {
+			b.logger.Debug("leader probe failed", "addr", addr, "err", err)
+			continue
+		}
+		if leader == "" {
+			continue
+		}
+		b.setLeader(leader)
+		return
+	}
+}
+
+func (b *LeaderAwareRedisBackend) probeLeader(ctx context.Context, addr string) (string, error) {
+	cli := b.getOrCreateClient(addr)
+	probeCtx, cancel := context.WithTimeout(ctx, b.refreshTimeout)
+	defer cancel()
+	raw, err := cli.Info(probeCtx, infoReplicationArg).Result()
+	if err != nil {
+		return "", fmt.Errorf("info replication %s: %w", addr, err)
+	}
+	return parseRaftLeaderRedis(raw), nil
+}
+
+// parseRaftLeaderRedis extracts the raft_leader_redis field from an
+// INFO reply. Empty string means "not present".
+func parseRaftLeaderRedis(info string) string {
+	for _, line := range strings.Split(info, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.HasPrefix(line, raftLeaderRedisField) {
+			return strings.TrimSpace(strings.TrimPrefix(line, raftLeaderRedisField))
+		}
+	}
+	return ""
+}
+
+func (b *LeaderAwareRedisBackend) candidateAddrs() []string {
+	b.mu.RLock()
+	leader := b.leader
+	b.mu.RUnlock()
+
+	cands := make([]string, 0, len(b.seeds)+1)
+	seen := map[string]struct{}{}
+	if leader != "" {
+		cands = append(cands, leader)
+		seen[leader] = struct{}{}
+	}
+	for _, s := range b.seeds {
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		cands = append(cands, s)
+		seen[s] = struct{}{}
+	}
+	return cands
+}
+
+func (b *LeaderAwareRedisBackend) setLeader(addr string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.leader == addr {
+		return
+	}
+	prev := b.leader
+	b.leader = addr
+	b.ensureClientLocked(addr)
+	b.logger.Info("elastickv leader updated", "backend", b.name, "from", prev, "to", addr)
+}
+
+func (b *LeaderAwareRedisBackend) getOrCreateClient(addr string) *redis.Client {
+	b.mu.RLock()
+	cli, ok := b.clients[addr]
+	b.mu.RUnlock()
+	if ok {
+		return cli
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.ensureClientLocked(addr)
+}
+
+func (b *LeaderAwareRedisBackend) ensureClientLocked(addr string) *redis.Client {
+	if cli, ok := b.clients[addr]; ok {
+		return cli
+	}
+	cli := redis.NewClient(&redis.Options{
+		Addr:         addr,
+		DB:           b.opts.DB,
+		Password:     b.opts.Password,
+		Protocol:     respProtocolV2,
+		PoolSize:     b.opts.PoolSize,
+		DialTimeout:  b.opts.DialTimeout,
+		ReadTimeout:  b.opts.ReadTimeout,
+		WriteTimeout: b.opts.WriteTimeout,
+	})
+	b.clients[addr] = cli
+	return cli
+}
+
+func (b *LeaderAwareRedisBackend) currentClient() *redis.Client {
+	b.mu.RLock()
+	cli, ok := b.clients[b.leader]
+	b.mu.RUnlock()
+	if ok && cli != nil {
+		return cli
+	}
+	return b.getOrCreateClient(b.seeds[0])
+}
+
+// Do forwards a single command to the current leader.
+func (b *LeaderAwareRedisBackend) Do(ctx context.Context, args ...any) *redis.Cmd {
+	cli := b.currentClient()
+	if cli == nil {
+		cmd := redis.NewCmd(ctx, args...)
+		cmd.SetErr(ErrNoLeaderBackend)
+		return cmd
+	}
+	return cli.Do(ctx, args...)
+}
+
+// DoWithTimeout forwards a blocking command with a per-call socket timeout.
+func (b *LeaderAwareRedisBackend) DoWithTimeout(ctx context.Context, timeout time.Duration, args ...any) *redis.Cmd {
+	cli := b.currentClient()
+	if cli == nil {
+		cmd := redis.NewCmd(ctx, args...)
+		cmd.SetErr(ErrNoLeaderBackend)
+		return cmd
+	}
+	return cli.WithTimeout(effectiveBlockingReadTimeout(timeout)).Do(ctx, args...)
+}
+
+// Pipeline forwards a batch to the current leader.
+func (b *LeaderAwareRedisBackend) Pipeline(ctx context.Context, cmds [][]any) ([]*redis.Cmd, error) {
+	cli := b.currentClient()
+	if cli == nil {
+		return nil, ErrNoLeaderBackend
+	}
+	pipe := cli.Pipeline()
+	results := make([]*redis.Cmd, len(cmds))
+	for i, args := range cmds {
+		results[i] = pipe.Do(ctx, args...)
+	}
+	_, err := pipe.Exec(ctx)
+	if err != nil {
+		var redisErr redis.Error
+		if errors.As(err, &redisErr) || errors.Is(err, redis.Nil) {
+			return results, nil
+		}
+		return results, fmt.Errorf("pipeline exec: %w", err)
+	}
+	return results, nil
+}
+
+// NewPubSub opens a subscribe connection on the current leader.
+func (b *LeaderAwareRedisBackend) NewPubSub(ctx context.Context) *redis.PubSub {
+	cli := b.currentClient()
+	if cli == nil {
+		return nil
+	}
+	return cli.Subscribe(ctx)
+}
+
+// Name returns the backend's logical identifier used in metrics.
+func (b *LeaderAwareRedisBackend) Name() string { return b.name }
+
+// Close stops the refresh loop and releases every cached client pool.
+func (b *LeaderAwareRedisBackend) Close() error {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return nil
+	}
+	b.closed = true
+	close(b.stopCh)
+	b.mu.Unlock()
+
+	// Wait for the refresh loop to exit before touching the client map so that
+	// a concurrent probeLeader cannot race with Close on the clients map.
+	<-b.done
+
+	b.mu.Lock()
+	clients := b.clients
+	b.mu.Unlock()
+
+	var firstErr error
+	for addr, cli := range clients {
+		if err := cli.Close(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("close %s client %s: %w", b.name, addr, err)
+		}
+	}
+	return firstErr
+}
+
+// CurrentLeader returns the address currently considered the leader. Exposed
+// for tests and operational observability.
+func (b *LeaderAwareRedisBackend) CurrentLeader() string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.leader
+}

--- a/proxy/leader_aware_backend.go
+++ b/proxy/leader_aware_backend.go
@@ -112,7 +112,17 @@ func normalizeSeeds(seeds []string) []string {
 func (b *LeaderAwareRedisBackend) refreshLoop() {
 	defer close(b.done)
 
-	b.refreshLeader(context.Background())
+	// Derive a cancellable context from stopCh so that an in-flight INFO
+	// probe is interrupted as soon as Close() is called; otherwise the
+	// refreshTimeout must elapse before the loop can exit.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-b.stopCh
+		cancel()
+	}()
+
+	b.refreshLeader(ctx)
 
 	t := time.NewTicker(b.refreshInterval)
 	defer t.Stop()
@@ -121,9 +131,9 @@ func (b *LeaderAwareRedisBackend) refreshLoop() {
 		case <-b.stopCh:
 			return
 		case <-t.C:
-			b.refreshLeader(context.Background())
+			b.refreshLeader(ctx)
 		case <-b.refreshCh:
-			b.refreshLeader(context.Background())
+			b.refreshLeader(ctx)
 		}
 	}
 }
@@ -145,6 +155,9 @@ func (b *LeaderAwareRedisBackend) TriggerRefresh() {
 // healthy, so this converges in one probe during steady state.
 func (b *LeaderAwareRedisBackend) refreshLeader(ctx context.Context) {
 	for _, addr := range b.candidateAddrs() {
+		if ctx.Err() != nil {
+			return
+		}
 		leader, err := b.probeLeader(ctx, addr)
 		if err != nil {
 			b.logger.Debug("leader probe failed", "addr", addr, "err", err)
@@ -331,8 +344,11 @@ func (b *LeaderAwareRedisBackend) Close() error {
 
 	var firstErr error
 	for addr, cli := range clients {
-		if err := cli.Close(); err != nil && firstErr == nil {
-			firstErr = fmt.Errorf("close %s client %s: %w", b.name, addr, err)
+		if err := cli.Close(); err != nil {
+			b.logger.Warn("close leader-aware client failed", "backend", b.name, "addr", addr, "err", err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("close %s client %s: %w", b.name, addr, err)
+			}
 		}
 	}
 	return firstErr

--- a/proxy/leader_aware_backend.go
+++ b/proxy/leader_aware_backend.go
@@ -194,6 +194,11 @@ func (b *LeaderAwareRedisBackend) refreshLeader(ctx context.Context) {
 
 func (b *LeaderAwareRedisBackend) probeLeader(ctx context.Context, addr string) (string, error) {
 	cli := b.getOrCreateClient(addr)
+	if cli == nil {
+		// Backend is closing; treat as a normal probe failure so the loop
+		// moves on quickly rather than panicking on a nil dereference.
+		return "", ErrNoLeaderBackend
+	}
 	probeCtx, cancel := context.WithTimeout(ctx, b.refreshTimeout)
 	defer cancel()
 	raw, err := cli.Info(probeCtx, infoReplicationArg).Result()
@@ -239,7 +244,7 @@ func (b *LeaderAwareRedisBackend) candidateAddrs() []string {
 func (b *LeaderAwareRedisBackend) setLeader(addr string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if b.leader == addr {
+	if b.closed || b.leader == addr {
 		return
 	}
 	prev := b.leader
@@ -264,6 +269,12 @@ func (b *LeaderAwareRedisBackend) ensureClientLocked(addr string) *redis.Client 
 	if cli, ok := b.clients[addr]; ok {
 		return cli
 	}
+	// Refuse to create a new pool once Close() has started; otherwise a
+	// command that raced shutdown could instantiate a client that no one
+	// will ever close.
+	if b.closed {
+		return nil
+	}
 	cli := redis.NewClient(&redis.Options{
 		Addr:         addr,
 		DB:           b.opts.DB,
@@ -278,14 +289,17 @@ func (b *LeaderAwareRedisBackend) ensureClientLocked(addr string) *redis.Client 
 	return cli
 }
 
+// currentClient returns the client for the current leader. The whole
+// read happens under a single RLock so the closed flag, leader addr, and
+// clients map cannot diverge between reads (i.e. no TOCTOU window with
+// Close()). Returns nil once the backend is closing so callers fail fast.
 func (b *LeaderAwareRedisBackend) currentClient() *redis.Client {
 	b.mu.RLock()
-	cli, ok := b.clients[b.leader]
-	b.mu.RUnlock()
-	if ok && cli != nil {
-		return cli
+	defer b.mu.RUnlock()
+	if b.closed {
+		return nil
 	}
-	return b.getOrCreateClient(b.seeds[0])
+	return b.clients[b.leader]
 }
 
 // Do forwards a single command to the current leader.
@@ -345,6 +359,9 @@ func (b *LeaderAwareRedisBackend) NewPubSub(ctx context.Context) *redis.PubSub {
 func (b *LeaderAwareRedisBackend) Name() string { return b.name }
 
 // Close stops the refresh loop and releases every cached client pool.
+// It snapshots the client map under the lock before iterating so concurrent
+// Do/Pipeline calls that race shutdown cannot mutate the map out from under
+// us. After this call returns, currentClient() returns nil for every caller.
 func (b *LeaderAwareRedisBackend) Close() error {
 	b.mu.Lock()
 	if b.closed {
@@ -359,12 +376,20 @@ func (b *LeaderAwareRedisBackend) Close() error {
 	// a concurrent probeLeader cannot race with Close on the clients map.
 	<-b.done
 
+	// Snapshot the clients map and swap in an empty replacement under the
+	// lock. After this point, currentClient()/getOrCreateClient see no
+	// clients (and ensureClientLocked refuses to add any because closed is
+	// true), so iterating the snapshot is safe without holding the lock.
 	b.mu.Lock()
-	clients := b.clients
+	snapshot := make(map[string]*redis.Client, len(b.clients))
+	for addr, cli := range b.clients {
+		snapshot[addr] = cli
+	}
+	b.clients = map[string]*redis.Client{}
 	b.mu.Unlock()
 
 	var firstErr error
-	for addr, cli := range clients {
+	for addr, cli := range snapshot {
 		if err := cli.Close(); err != nil {
 			b.logger.Warn("close leader-aware client failed", "backend", b.name, "addr", addr, "err", err)
 			if firstErr == nil {

--- a/proxy/leader_aware_backend_test.go
+++ b/proxy/leader_aware_backend_test.go
@@ -67,7 +67,8 @@ type fakeElasticKVNode struct {
 
 func newFakeElasticKVNode(t *testing.T, leader string) *fakeElasticKVNode {
 	t.Helper()
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	var lc net.ListenConfig
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	n := &fakeElasticKVNode{ln: ln, addr: ln.Addr().String()}
 	n.SetLeader(leader)

--- a/proxy/leader_aware_backend_test.go
+++ b/proxy/leader_aware_backend_test.go
@@ -66,13 +66,12 @@ type fakeElasticKVNode struct {
 	infoCalls  atomic.Int64
 }
 
-func newFakeElasticKVNode(t *testing.T, leader string) *fakeElasticKVNode {
+func newFakeElasticKVNode(t *testing.T) *fakeElasticKVNode {
 	t.Helper()
 	var lc net.ListenConfig
 	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	n := &fakeElasticKVNode{ln: ln, addr: ln.Addr().String()}
-	n.SetLeader(leader)
 	go n.serve()
 	t.Cleanup(func() { _ = ln.Close() })
 	return n
@@ -171,8 +170,8 @@ func readRESPArray(rd *bufio.Reader) ([]string, error) {
 }
 
 func TestLeaderAwareRedisBackend_FollowsLeaderChange(t *testing.T) {
-	nodeA := newFakeElasticKVNode(t, "")
-	nodeB := newFakeElasticKVNode(t, "")
+	nodeA := newFakeElasticKVNode(t)
+	nodeB := newFakeElasticKVNode(t)
 
 	// Start: A is leader; both nodes advertise A as the leader.
 	nodeA.SetLeader(nodeA.addr)
@@ -220,7 +219,7 @@ func TestLeaderAwareRedisBackend_ConcurrentCloseIsRaceFree(t *testing.T) {
 	// currentClient and ensureClientLocked hold the lock consistently with
 	// the closed flag, and Close snapshots the client map before iterating.
 	// Run under `go test -race` to exercise the fix.
-	leader := newFakeElasticKVNode(t, "")
+	leader := newFakeElasticKVNode(t)
 	leader.SetLeader(leader.addr)
 
 	backend := NewLeaderAwareRedisBackendWithInterval(
@@ -262,9 +261,52 @@ func TestLeaderAwareRedisBackend_ConcurrentCloseIsRaceFree(t *testing.T) {
 	wg.Wait()
 }
 
+// clientAddrs returns the set of addresses for which this backend currently
+// caches a *redis.Client. Exposed for tests; safe to call at any time.
+func (b *LeaderAwareRedisBackend) clientAddrs() []string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	out := make([]string, 0, len(b.clients))
+	for addr := range b.clients {
+		out = append(out, addr)
+	}
+	return out
+}
+
+func TestLeaderAwareRedisBackend_EvictsOldestNonProtectedClient(t *testing.T) {
+	// Simulate leader churn by forcing many leader addresses through setLeader.
+	// The cached client map must stay bounded at maxLeaderAwareClients and the
+	// seed must never be evicted.
+	seed := newFakeElasticKVNode(t)
+	seed.SetLeader(seed.addr)
+
+	backend := NewLeaderAwareRedisBackendWithInterval(
+		[]string{seed.addr},
+		"elastickv",
+		DefaultBackendOptions(),
+		time.Hour, time.Second, // disable auto-refresh; we drive setLeader manually
+		testLogger,
+	)
+	t.Cleanup(func() { _ = backend.Close() })
+
+	require.Len(t, backend.clientAddrs(), 1, "seed client must be pre-created")
+
+	// Churn through many synthetic addresses. Since auto-refresh is effectively
+	// disabled, none of these addresses will ever be probed — we only care
+	// that the client cache stays bounded.
+	for i := 0; i < maxLeaderAwareClients*2; i++ {
+		backend.setLeader(fmt.Sprintf("10.0.0.%d:6379", i+2))
+	}
+
+	addrs := backend.clientAddrs()
+	assert.LessOrEqual(t, len(addrs), maxLeaderAwareClients,
+		"bounded client cache must not exceed maxLeaderAwareClients")
+	assert.Contains(t, addrs, seed.addr, "seed must never be evicted")
+}
+
 func TestLeaderAwareRedisBackend_FallsBackToSeedOnProbeFailure(t *testing.T) {
 	// Seed 1 is unreachable; seed 2 is alive and reports itself as leader.
-	aliveLeader := newFakeElasticKVNode(t, "")
+	aliveLeader := newFakeElasticKVNode(t)
 	aliveLeader.SetLeader(aliveLeader.addr)
 
 	backend := NewLeaderAwareRedisBackendWithInterval(

--- a/proxy/leader_aware_backend_test.go
+++ b/proxy/leader_aware_backend_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -212,6 +213,53 @@ func TestLeaderAwareRedisBackend_FollowsLeaderChange(t *testing.T) {
 	require.NoError(t, res.Err())
 	require.Equal(t, beforeA, nodeA.commands.Load(), "command must not reach former leader A")
 	require.Equal(t, beforeB+1, nodeB.commands.Load(), "command must reach new leader B")
+}
+
+func TestLeaderAwareRedisBackend_ConcurrentCloseIsRaceFree(t *testing.T) {
+	// Regression guard: Close() must not race concurrent Do() callers —
+	// currentClient and ensureClientLocked hold the lock consistently with
+	// the closed flag, and Close snapshots the client map before iterating.
+	// Run under `go test -race` to exercise the fix.
+	leader := newFakeElasticKVNode(t, "")
+	leader.SetLeader(leader.addr)
+
+	backend := NewLeaderAwareRedisBackendWithInterval(
+		[]string{leader.addr},
+		"elastickv",
+		DefaultBackendOptions(),
+		20*time.Millisecond, 200*time.Millisecond,
+		testLogger,
+	)
+
+	require.Eventually(t, func() bool {
+		return backend.CurrentLeader() == leader.addr
+	}, 2*time.Second, 10*time.Millisecond)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	const workers = 8
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				// Error is expected once the backend closes (ErrNoLeaderBackend
+				// or a closed-pool error); we only care that no goroutine panics.
+				_ = backend.Do(context.Background(), "PING").Err()
+			}
+		}()
+	}
+
+	// Let the workers hammer the backend briefly, then close while they run.
+	time.Sleep(20 * time.Millisecond)
+	require.NoError(t, backend.Close())
+	close(stop)
+	wg.Wait()
 }
 
 func TestLeaderAwareRedisBackend_FallsBackToSeedOnProbeFailure(t *testing.T) {

--- a/proxy/leader_aware_backend_test.go
+++ b/proxy/leader_aware_backend_test.go
@@ -1,0 +1,233 @@
+package proxy
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRaftLeaderRedis(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "CRLF-separated INFO reply",
+			in:   "# Replication\r\nrole:slave\r\nraft_leader_redis:10.0.0.2:6379\r\n",
+			want: "10.0.0.2:6379",
+		},
+		{
+			name: "LF-only INFO reply",
+			in:   "# Replication\nrole:master\nraft_leader_redis:127.0.0.1:6379\n",
+			want: "127.0.0.1:6379",
+		},
+		{
+			name: "field missing returns empty",
+			in:   "# Server\r\nrole:master\r\n",
+			want: "",
+		},
+		{
+			name: "trims whitespace around the address",
+			in:   "raft_leader_redis: 10.0.0.9:6379 \r\n",
+			want: "10.0.0.9:6379",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, parseRaftLeaderRedis(tc.in))
+		})
+	}
+}
+
+func TestNormalizeSeedsDedupesAndTrims(t *testing.T) {
+	got := normalizeSeeds([]string{" a:1 ", "b:2", "a:1", "", "c:3 "})
+	assert.Equal(t, []string{"a:1", "b:2", "c:3"}, got)
+}
+
+// fakeElasticKVNode is a minimal RESP server that serves INFO replication and
+// records how many non-INFO commands it received, so tests can assert which
+// node handled a proxied command.
+type fakeElasticKVNode struct {
+	addr       string
+	ln         net.Listener
+	leaderAddr atomic.Pointer[string]
+	commands   atomic.Int64
+	infoCalls  atomic.Int64
+}
+
+func newFakeElasticKVNode(t *testing.T, leader string) *fakeElasticKVNode {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	n := &fakeElasticKVNode{ln: ln, addr: ln.Addr().String()}
+	n.SetLeader(leader)
+	go n.serve()
+	t.Cleanup(func() { _ = ln.Close() })
+	return n
+}
+
+func (n *fakeElasticKVNode) SetLeader(addr string) {
+	v := addr
+	n.leaderAddr.Store(&v)
+}
+
+func (n *fakeElasticKVNode) Leader() string {
+	if p := n.leaderAddr.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
+
+func (n *fakeElasticKVNode) serve() {
+	for {
+		conn, err := n.ln.Accept()
+		if err != nil {
+			return
+		}
+		go n.handleConn(conn)
+	}
+}
+
+func (n *fakeElasticKVNode) handleConn(conn net.Conn) {
+	defer conn.Close()
+	rd := bufio.NewReader(conn)
+	for {
+		args, err := readRESPArray(rd)
+		if err != nil {
+			return
+		}
+		if len(args) == 0 {
+			return
+		}
+		cmd := strings.ToUpper(args[0])
+		switch cmd {
+		case "HELLO":
+			// Force go-redis to fall back to RESP2 without HELLO: return an
+			// error the client treats as "HELLO not supported".
+			_, _ = conn.Write([]byte("-ERR unknown command 'HELLO'\r\n"))
+		case "CLIENT", "AUTH", "SELECT", "PING":
+			_, _ = conn.Write([]byte("+OK\r\n"))
+		case "INFO":
+			n.infoCalls.Add(1)
+			body := fmt.Sprintf(
+				"# Replication\r\nrole:slave\r\nraft_leader_redis:%s\r\n",
+				n.Leader(),
+			)
+			_, _ = fmt.Fprintf(conn, "$%d\r\n%s\r\n", len(body), body)
+		default:
+			n.commands.Add(1)
+			_, _ = conn.Write([]byte("+OK\r\n"))
+		}
+	}
+}
+
+// readRESPArray reads a single RESP array of bulk strings from rd.
+func readRESPArray(rd *bufio.Reader) ([]string, error) {
+	header, err := rd.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	header = strings.TrimRight(header, "\r\n")
+	if !strings.HasPrefix(header, "*") {
+		return nil, fmt.Errorf("expected array, got %q", header)
+	}
+	var n int
+	if _, err := fmt.Sscanf(header[1:], "%d", &n); err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		lenLine, err := rd.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		lenLine = strings.TrimRight(lenLine, "\r\n")
+		if !strings.HasPrefix(lenLine, "$") {
+			return nil, fmt.Errorf("expected bulk, got %q", lenLine)
+		}
+		var sz int
+		if _, err := fmt.Sscanf(lenLine[1:], "%d", &sz); err != nil {
+			return nil, err
+		}
+		buf := make([]byte, sz+2)
+		if _, err := io.ReadFull(rd, buf); err != nil {
+			return nil, err
+		}
+		out = append(out, string(buf[:sz]))
+	}
+	return out, nil
+}
+
+func TestLeaderAwareRedisBackend_FollowsLeaderChange(t *testing.T) {
+	nodeA := newFakeElasticKVNode(t, "")
+	nodeB := newFakeElasticKVNode(t, "")
+
+	// Start: A is leader; both nodes advertise A as the leader.
+	nodeA.SetLeader(nodeA.addr)
+	nodeB.SetLeader(nodeA.addr)
+
+	backend := NewLeaderAwareRedisBackendWithInterval(
+		[]string{nodeA.addr, nodeB.addr},
+		"elastickv",
+		DefaultBackendOptions(),
+		50*time.Millisecond, 500*time.Millisecond,
+		testLogger,
+	)
+	t.Cleanup(func() { _ = backend.Close() })
+
+	require.Eventually(t, func() bool {
+		return backend.CurrentLeader() == nodeA.addr
+	}, 2*time.Second, 10*time.Millisecond, "initial leader must be A")
+
+	// Issue a command — it must land on A.
+	res := backend.Do(context.Background(), "SET", "k", "v")
+	require.NoError(t, res.Err())
+	require.Equal(t, int64(1), nodeA.commands.Load(), "command must reach leader A")
+	require.Equal(t, int64(0), nodeB.commands.Load(), "command must not reach follower B")
+
+	// Leader election flips to B. Both nodes now advertise B as the leader.
+	nodeA.SetLeader(nodeB.addr)
+	nodeB.SetLeader(nodeB.addr)
+	backend.TriggerRefresh()
+
+	require.Eventually(t, func() bool {
+		return backend.CurrentLeader() == nodeB.addr
+	}, 2*time.Second, 10*time.Millisecond, "backend must follow leader change to B")
+
+	// New commands must land on B.
+	beforeA := nodeA.commands.Load()
+	beforeB := nodeB.commands.Load()
+	res = backend.Do(context.Background(), "SET", "k", "v")
+	require.NoError(t, res.Err())
+	require.Equal(t, beforeA, nodeA.commands.Load(), "command must not reach former leader A")
+	require.Equal(t, beforeB+1, nodeB.commands.Load(), "command must reach new leader B")
+}
+
+func TestLeaderAwareRedisBackend_FallsBackToSeedOnProbeFailure(t *testing.T) {
+	// Seed 1 is unreachable; seed 2 is alive and reports itself as leader.
+	aliveLeader := newFakeElasticKVNode(t, "")
+	aliveLeader.SetLeader(aliveLeader.addr)
+
+	backend := NewLeaderAwareRedisBackendWithInterval(
+		[]string{"127.0.0.1:1", aliveLeader.addr},
+		"elastickv",
+		DefaultBackendOptions(),
+		50*time.Millisecond, 200*time.Millisecond,
+		testLogger,
+	)
+	t.Cleanup(func() { _ = backend.Close() })
+
+	require.Eventually(t, func() bool {
+		return backend.CurrentLeader() == aliveLeader.addr
+	}, 3*time.Second, 20*time.Millisecond, "must fall back to the reachable seed and adopt its advertised leader")
+}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -989,7 +989,11 @@ func TestDualWriter_writeSecondary_RetriesDoNotRepeatNoScriptProbe(t *testing.T)
 	var evalshaCalls, evalCalls int
 	secondary.doFunc = func(ctx context.Context, args ...any) *redis.Cmd {
 		cmd := redis.NewCmd(ctx, args...)
-		switch string(args[0].([]byte)) {
+		raw, ok := args[0].([]byte)
+		if !ok {
+			t.Fatalf("expected []byte command, got %T", args[0])
+		}
+		switch string(raw) {
 		case "EVALSHA":
 			evalshaCalls++
 			cmd.SetErr(testRedisErr("NOSCRIPT No matching script. Please use EVAL."))

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -974,6 +974,51 @@ func TestDualWriter_writeSecondary_ReadTSCompactedRetriesAreBounded(t *testing.T
 		"a persistent compacted error must still be reported as a secondary write error")
 }
 
+func TestDualWriter_writeSecondary_RetriesDoNotRepeatNoScriptProbe(t *testing.T) {
+	// After the EVAL fallback resolves a NOSCRIPT, a compacted-retry must
+	// re-send the resolved EVAL form directly — never the known-missing
+	// EVALSHA — so we never burn an extra round-trip per retry attempt.
+	primary := newMockBackend("primary")
+	primary.doFunc = makeCmd("OK", nil)
+
+	script := "return ARGV[1]"
+	sha := scriptSHA(script)
+	compactedErr := testRedisErr("rpc error: code = FailedPrecondition desc = read timestamp has been compacted")
+
+	secondary := newMockBackend("secondary")
+	var evalshaCalls, evalCalls int
+	secondary.doFunc = func(ctx context.Context, args ...any) *redis.Cmd {
+		cmd := redis.NewCmd(ctx, args...)
+		switch string(args[0].([]byte)) {
+		case "EVALSHA":
+			evalshaCalls++
+			cmd.SetErr(testRedisErr("NOSCRIPT No matching script. Please use EVAL."))
+		case "EVAL":
+			evalCalls++
+			// First resolved EVAL fails with compacted; second succeeds.
+			if evalCalls == 1 {
+				cmd.SetErr(compactedErr)
+			} else {
+				cmd.SetVal("OK")
+			}
+		default:
+			t.Fatalf("unexpected secondary command %v", args[0])
+		}
+		return cmd
+	}
+
+	metrics := newTestMetrics()
+	d := NewDualWriter(primary, secondary, ProxyConfig{Mode: ModeRedisOnly, SecondaryTimeout: time.Second}, metrics, newTestSentry(), testLogger)
+	d.storeScript(script)
+
+	d.cfg.Mode = ModeDualWrite
+	d.writeSecondary("EVALSHA", []any{[]byte("EVALSHA"), []byte(sha), []byte("0"), []byte("value")})
+
+	assert.Equal(t, 1, evalshaCalls, "EVALSHA must be probed only once; the compacted retry must use the resolved EVAL form")
+	assert.Equal(t, 2, evalCalls, "EVAL must be retried after the compacted failure")
+	assert.InDelta(t, 0, testutil.ToFloat64(metrics.SecondaryWriteErrors), 0.001)
+}
+
 func TestDualWriter_Script_NoRememberOnPrimaryError(t *testing.T) {
 	// Verify that a failed SCRIPT FLUSH on the primary does NOT clear the proxy
 	// script cache, so that subsequent EVALSHA → EVAL fallbacks still work.

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -920,6 +920,60 @@ func TestDualWriter_Script_EvalSHARO_FallsBackToEvalRO(t *testing.T) {
 	assert.InDelta(t, 0, testutil.ToFloat64(metrics.SecondaryWriteErrors), 0.001)
 }
 
+func TestDualWriter_writeSecondary_RetriesReadTSCompacted(t *testing.T) {
+	// Simulate ElasticKV returning "read timestamp has been compacted"
+	// (wrapped as gRPC FailedPrecondition and surfaced through Lua PCall).
+	// The proxy must transparently retry so the async EVALSHA replay
+	// eventually succeeds with a fresher snapshot timestamp.
+	primary := newMockBackend("primary")
+	primary.doFunc = makeCmd("OK", nil)
+
+	secondary := newMockBackend("secondary")
+	compactedErr := testRedisErr("<string>:71: rpc error: code = FailedPrecondition desc = rpc error: code = FailedPrecondition desc = read timestamp has been compacted stack traceback: \t[G]: in function 'rcall'")
+	var calls int
+	secondary.doFunc = func(ctx context.Context, args ...any) *redis.Cmd {
+		calls++
+		cmd := redis.NewCmd(ctx, args...)
+		if calls < 3 {
+			cmd.SetErr(compactedErr)
+			return cmd
+		}
+		cmd.SetVal("OK")
+		return cmd
+	}
+
+	metrics := newTestMetrics()
+	d := NewDualWriter(primary, secondary, ProxyConfig{Mode: ModeDualWrite, SecondaryTimeout: time.Second}, metrics, newTestSentry(), testLogger)
+
+	d.writeSecondary("EVALSHA", []any{[]byte("EVALSHA"), []byte("deadbeef"), []byte("0")})
+
+	assert.Equal(t, 3, calls, "secondary must be retried until it succeeds")
+	assert.InDelta(t, 0, testutil.ToFloat64(metrics.SecondaryWriteErrors), 0.001,
+		"a retried success must not count as a secondary write error")
+}
+
+func TestDualWriter_writeSecondary_ReadTSCompactedRetriesAreBounded(t *testing.T) {
+	// When the compacted error is persistent, the retry loop must stop after
+	// maxCompactedRetries+1 attempts so the secondary goroutine returns
+	// instead of burning a scriptSem slot indefinitely.
+	primary := newMockBackend("primary")
+	primary.doFunc = makeCmd("OK", nil)
+
+	secondary := newMockBackend("secondary")
+	compactedErr := testRedisErr("rpc error: code = FailedPrecondition desc = read timestamp has been compacted")
+	secondary.doFunc = makeCmd(nil, compactedErr)
+
+	metrics := newTestMetrics()
+	d := NewDualWriter(primary, secondary, ProxyConfig{Mode: ModeDualWrite, SecondaryTimeout: time.Second}, metrics, newTestSentry(), testLogger)
+
+	d.writeSecondary("EVALSHA", []any{[]byte("EVALSHA"), []byte("deadbeef"), []byte("0")})
+
+	assert.Equal(t, maxCompactedRetries+1, secondary.CallCount(),
+		"secondary must stop after maxCompactedRetries+1 attempts")
+	assert.InDelta(t, 1, testutil.ToFloat64(metrics.SecondaryWriteErrors), 0.001,
+		"a persistent compacted error must still be reported as a secondary write error")
+}
+
 func TestDualWriter_Script_NoRememberOnPrimaryError(t *testing.T) {
 	// Verify that a failed SCRIPT FLUSH on the primary does NOT clear the proxy
 	// script cache, so that subsequent EVALSHA → EVAL fallbacks still work.


### PR DESCRIPTION
EVALSHA replays to the ElasticKV secondary can surface
FailedPrecondition / "read timestamp has been compacted" when the
script's startTS falls behind a peer node's MinRetainedTS (the local
readPin only protects the node that picked the timestamp). Each retry
re-sends the command so the secondary re-selects a fresh read snapshot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a leader-aware backend that discovers and routes Redis commands to the current cluster leader for dual-write/ElasticKV setups.
* **Improvements**
  * Secondary write operations now automatically retry on certain transient compaction-related failures with jittered exponential backoff and bounded attempts.
  * Redis INFO output now includes replication role and leader address details for improved observability.
  * CLI secondary flag parsing now accepts comma-separated seeds and requires at least one secondary address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->