### PR TITLE
fix(raft): surface etcd engine fail reasons instead of failing silently

### DIFF
--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -1031,7 +1031,7 @@ func (e *Engine) applyReadySnapshot(snapshot raftpb.Snapshot) error {
 	if isSnapshotToken(snapshot.Data) {
 		tok, err := decodeSnapshotToken(snapshot.Data)
 		if err != nil {
-			return errors.Wrapf(err, "decode snapshot token for index %d", snapshot.Metadata.Index)
+			return errors.Wrapf(err, "decode snapshot token index=%d", snapshot.Metadata.Index)
 		}
 		if err := openAndRestoreFSMSnapshot(e.fsm, fsmSnapPath(e.fsmSnapDir, tok.Index), tok.CRC32C); err != nil {
 			return errors.Wrapf(err, "restore fsm snapshot file index=%d crc=%08x", tok.Index, tok.CRC32C)
@@ -1575,6 +1575,21 @@ func (e *Engine) shutdown() {
 }
 
 func (e *Engine) fail(err error) {
+	// Idempotency guard: fail can be invoked from handleStep, which runs inside
+	// the main run loop and does not return on error. Without this guard a
+	// persistent step error would re-enter fail on every loop iteration,
+	// producing a log storm and redundant teardown calls.
+	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
+		// Make sure the run loop still observes the shutdown signal even if a
+		// previous fail path did not reach requestShutdown (e.g. concurrent
+		// invocation racing on the closed flag).
+		e.requestShutdown()
+		return
+	}
+	e.mu.Unlock()
+
 	// Log before mutating state so observability is preserved even if the
 	// downstream stopDispatch/closePersist calls themselves block or panic.
 	// Without this, the engine quietly transitions to StateShutdown and the
@@ -1595,6 +1610,9 @@ func (e *Engine) fail(err error) {
 	e.closed = true
 	e.status.State = raftengine.StateShutdown
 	e.mu.Unlock()
+	// Signal the run loop so that callers which invoke fail without returning
+	// from run themselves (notably handleStep) still exit on the next select.
+	e.requestShutdown()
 	e.stopDispatchWorkers()
 	e.stopSnapshotWorker()
 	_ = closePersist(e.persist)

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -1031,20 +1031,21 @@ func (e *Engine) applyReadySnapshot(snapshot raftpb.Snapshot) error {
 	if isSnapshotToken(snapshot.Data) {
 		tok, err := decodeSnapshotToken(snapshot.Data)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "decode snapshot token for index %d", snapshot.Metadata.Index)
 		}
 		if err := openAndRestoreFSMSnapshot(e.fsm, fsmSnapPath(e.fsmSnapDir, tok.Index), tok.CRC32C); err != nil {
-			return errors.WithStack(err)
+			return errors.Wrapf(err, "restore fsm snapshot file index=%d crc=%08x", tok.Index, tok.CRC32C)
 		}
 	} else {
 		// Legacy format: full FSM payload in snapshot.Data.
 		if err := e.fsm.Restore(bytes.NewReader(snapshot.Data)); err != nil {
-			return errors.WithStack(err)
+			return errors.Wrapf(err, "restore fsm from legacy snapshot payload index=%d", snapshot.Metadata.Index)
 		}
 	}
 
 	if err := e.storage.ApplySnapshot(snapshot); err != nil {
-		return errors.WithStack(err)
+		return errors.Wrapf(err, "apply snapshot to raft storage index=%d term=%d",
+			snapshot.Metadata.Index, snapshot.Metadata.Term)
 	}
 	e.applied = snapshot.Metadata.Index
 	e.setConfigurationFromConfState(snapshot.Metadata.ConfState, snapshot.Metadata.Index)
@@ -1574,6 +1575,19 @@ func (e *Engine) shutdown() {
 }
 
 func (e *Engine) fail(err error) {
+	// Log before mutating state so observability is preserved even if the
+	// downstream stopDispatch/closePersist calls themselves block or panic.
+	// Without this, the engine quietly transitions to StateShutdown and the
+	// only signal to the operator is a "shutdown" gauge — which is what
+	// happened in the production rolling-update incident where a snapshot
+	// restore failed silently and left the process running but unusable.
+	if err != nil {
+		slog.Error("etcd raft engine shutting down due to error",
+			slog.String("node_id", e.localID),
+			slog.Uint64("raft_node_id", e.nodeID),
+			slog.Any("err", err),
+		)
+	}
 	e.mu.Lock()
 	if err != nil {
 		e.runErr = err


### PR DESCRIPTION
An operator debugging a production rolling-update incident found a node whose process was still running but whose raft engine was in StateShutdown. The only external signal was the elastickv_raft_local_state gauge flipping to shutdown=1 — no stderr line, no metric, no log. Internally the engine had called fail(err), stored the error in runErr, and torn down background workers, but the error was never exported.

Two changes:

1. fail(err) now emits a single slog.Error before mutating state, carrying localID, raft node id, and the wrapped error chain. The log fires for every terminating error path in the run loop (startup failure, drainReady failure, handleEvent failure, and the defensive fail in applyCommitted).

2. applyReadySnapshot wraps each sub-step error with a message identifying which stage failed (decode snapshot token, restore fsm snapshot file, restore fsm legacy payload, apply snapshot to raft storage), so the single shutdown log line is enough to localize a restore failure without attaching a debugger.