### PR TITLE
chore(pebble): pin FormatMajorVersion to ratchet DBs for pebble v2

### DIFF
--- a/internal/raftstore/pebble.go
+++ b/internal/raftstore/pebble.go
@@ -42,9 +42,11 @@ func NewPebbleStore(dir string) (*PebbleStore, error) {
 // Pinned so existing v1-era DBs are ratcheted above pebble v2's
 // FormatMinSupported (FormatFlushableIngest) before the v2 upgrade lands.
 func pebbleOptions() *pebble.Options {
-	return &pebble.Options{
+	opts := &pebble.Options{
 		FormatMajorVersion: pebble.FormatVirtualSSTables,
 	}
+	opts.EnsureDefaults()
+	return opts
 }
 
 func (s *PebbleStore) FirstIndex() (uint64, error) {

--- a/internal/raftstore/pebble.go
+++ b/internal/raftstore/pebble.go
@@ -32,11 +32,19 @@ func NewPebbleStore(dir string) (*PebbleStore, error) {
 		return nil, errors.WithStack(err)
 	}
 
-	db, err := pebble.Open(dir, &pebble.Options{})
+	db, err := pebble.Open(dir, pebbleOptions())
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	return &PebbleStore{db: db}, nil
+}
+
+// Pinned so existing v1-era DBs are ratcheted above pebble v2's
+// FormatMinSupported (FormatFlushableIngest) before the v2 upgrade lands.
+func pebbleOptions() *pebble.Options {
+	return &pebble.Options{
+		FormatMajorVersion: pebble.FormatVirtualSSTables,
+	}
 }
 
 func (s *PebbleStore) FirstIndex() (uint64, error) {

--- a/internal/raftstore/pebble_test.go
+++ b/internal/raftstore/pebble_test.go
@@ -15,7 +15,7 @@ func TestPebbleStore_FormatRatchetedForV2(t *testing.T) {
 
 	s, err := NewPebbleStore(dir)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = s.Close() })
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
 
 	require.GreaterOrEqual(t, s.db.FormatMajorVersion(), pebble.FormatFlushableIngest)
 }
@@ -38,7 +38,7 @@ func TestPebbleStore_RatchetsExistingDB(t *testing.T) {
 	// Reopen through the production path.
 	s, err := NewPebbleStore(dir)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = s.Close() })
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
 
 	require.GreaterOrEqual(t, s.db.FormatMajorVersion(), pebble.FormatFlushableIngest)
 }
@@ -58,7 +58,7 @@ func TestPebbleStore_PreservesLogsAcrossRatchet(t *testing.T) {
 
 	s, err := NewPebbleStore(dir)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = s.Close() })
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
 
 	var got raft.Log
 	require.NoError(t, s.GetLog(1, &got))

--- a/internal/raftstore/pebble_test.go
+++ b/internal/raftstore/pebble_test.go
@@ -1,0 +1,72 @@
+package raftstore
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/require"
+)
+
+// Guards the pebble v1 → v2 migration: v2 refuses to open DBs below
+// FormatFlushableIngest.
+func TestPebbleStore_FormatRatchetedForV2(t *testing.T) {
+	dir := t.TempDir()
+
+	s, err := NewPebbleStore(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	require.GreaterOrEqual(t, s.db.FormatMajorVersion(), pebble.FormatFlushableIngest)
+}
+
+// Existing on-disk DBs from pre-migration binaries must be ratcheted up on
+// reopen — this is the migration path for clusters that already have raft.db.
+func TestPebbleStore_RatchetsExistingDB(t *testing.T) {
+	dir := t.TempDir()
+
+	// Simulate an existing on-disk DB created by a pre-migration binary,
+	// which left FormatMajorVersion unset (== FormatMostCompatible after
+	// EnsureDefaults in pebble v1).
+	old, err := pebble.Open(dir, &pebble.Options{
+		FormatMajorVersion: pebble.FormatMostCompatible,
+	})
+	require.NoError(t, err)
+	require.Equal(t, pebble.FormatMostCompatible, old.FormatMajorVersion())
+	require.NoError(t, old.Close())
+
+	// Reopen through the production path.
+	s, err := NewPebbleStore(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	require.GreaterOrEqual(t, s.db.FormatMajorVersion(), pebble.FormatFlushableIngest)
+}
+
+// The format ratchet runs during DB open; committed Raft entries must survive it.
+func TestPebbleStore_PreservesLogsAcrossRatchet(t *testing.T) {
+	dir := t.TempDir()
+
+	old, err := pebble.Open(dir, &pebble.Options{
+		FormatMajorVersion: pebble.FormatMostCompatible,
+	})
+	require.NoError(t, err)
+	pre := &PebbleStore{db: old}
+	require.NoError(t, pre.StoreLog(&raft.Log{Index: 1, Term: 1, Data: []byte("hello")}))
+	require.NoError(t, pre.StoreLog(&raft.Log{Index: 2, Term: 1, Data: []byte("world")}))
+	require.NoError(t, old.Close())
+
+	s, err := NewPebbleStore(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	var got raft.Log
+	require.NoError(t, s.GetLog(1, &got))
+	require.Equal(t, []byte("hello"), got.Data)
+	require.NoError(t, s.GetLog(2, &got))
+	require.Equal(t, []byte("world"), got.Data)
+
+	last, err := s.LastIndex()
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), last)
+}

--- a/store/lsm_store.go
+++ b/store/lsm_store.go
@@ -82,8 +82,14 @@ func WithPebbleLogger(l *slog.Logger) PebbleStoreOption {
 // defaultPebbleOptions returns the standard Pebble options used throughout
 // the store (including restores) to ensure consistent behaviour between a
 // freshly opened and a restored/swapped-in database.
+//
+// FormatMajorVersion is pinned to ratchet v1-era DBs above pebble v2's
+// FormatMinSupported (FormatFlushableIngest) before the v2 upgrade lands.
 func defaultPebbleOptions() *pebble.Options {
-	opts := &pebble.Options{FS: vfs.Default}
+	opts := &pebble.Options{
+		FS:                 vfs.Default,
+		FormatMajorVersion: pebble.FormatVirtualSSTables,
+	}
 	// Enable automatic compactions and apply all other Pebble defaults.
 	opts.EnsureDefaults()
 	return opts


### PR DESCRIPTION
## Summary

Prep step for #289 (pebble v1.1.5 → v2.1.4 bump).

Pebble v2 sets `FormatMinSupported = FormatFlushableIngest` and refuses to open DBs below that. Today both pebble instances in this repo open with defaults:

- `internal/raftstore/pebble.go` — Raft log / stable store (`raft.db`)
- `store/lsm_store.go` — MVCC FSM store

Pebble v1 treats an unset `FormatMajorVersion` as `FormatMostCompatible`, so any DB written by current binaries is **unreadable by pebble v2**. Merging #289 as-is would brick existing clusters on restart.

This PR pins `FormatMajorVersion` to `pebble.FormatVirtualSSTables` in both opens. That is the newest format pebble v1.1.5 supports and is well above v2's minimum, so:

- Fresh DBs are created at a v2-compatible format.
- Existing DBs are auto-ratcheted by pebble on open.

`FormatVirtualSSTables` was picked as an explicit, stable constant rather than `FormatNewest` so the intent is auditable and doesn't drift with future pebble patch releases.

## Rollout order

1. **Ship this PR on pebble v1.1.5** to every node (rolling restart is fine).
2. Verify that each node has successfully opened its DB at least once after running this build — the format ratchet happens during `pebble.Open`.
3. Only then merge #289 to bump pebble to v2.

If step 2 is skipped on even one node, that node will fail to start after the v2 bump.

## Test plan

- [x] `go test ./internal/raftstore/... ./store/...` — passes
- [x] `go test ./...` — passes
- [x] `golangci-lint run ./internal/raftstore/... ./store/...` — clean
- New regression tests in `internal/raftstore/pebble_test.go`:
  - `TestPebbleStore_FormatRatchetedForV2` — fresh DB opens ≥ `FormatFlushableIngest`
  - `TestPebbleStore_RatchetsExistingDB` — reopening a DB created at `FormatMostCompatible` ratchets it up
  - `TestPebbleStore_PreservesLogsAcrossRatchet` — committed Raft log entries survive the ratchet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced database initialization with stricter format version configuration to ensure consistent and predictable behavior during database format transitions and version updates.

* **Tests**
  * Added test coverage validating that data persists correctly across database format version changes, including verification that existing data remains intact and accessible following format version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->