### PR TITLE
feat(s3): expose /healthz/leader for leader-only routing

### DIFF
--- a/adapter/s3.go
+++ b/adapter/s3.go
@@ -31,16 +31,17 @@ import (
 )
 
 const (
-	s3HealthPath             = "/healthz"
-	s3LeaderHealthPath       = "/healthz/leader"
-	s3ChunkSize              = 1 << 20
-	s3ChunkBatchOps          = 16
-	s3XMLNamespace           = "http://s3.amazonaws.com/doc/2006-03-01/"
-	s3DefaultRegion          = "us-east-1"
-	s3MaxKeys                = 1000
-	s3ListPageSize           = 256
-	s3ManifestCleanupTimeout = 2 * time.Minute
-	s3MaxObjectSizeBytes     = 5 * 1024 * 1024 * 1024 // 5 GiB, matching AWS S3 single PUT limit.
+	s3HealthPath                = "/healthz"
+	s3LeaderHealthPath          = "/healthz/leader"
+	s3HealthMaxRequestBodyBytes = 1024
+	s3ChunkSize                 = 1 << 20
+	s3ChunkBatchOps             = 16
+	s3XMLNamespace              = "http://s3.amazonaws.com/doc/2006-03-01/"
+	s3DefaultRegion             = "us-east-1"
+	s3MaxKeys                   = 1000
+	s3ListPageSize              = 256
+	s3ManifestCleanupTimeout    = 2 * time.Minute
+	s3MaxObjectSizeBytes        = 5 * 1024 * 1024 * 1024 // 5 GiB, matching AWS S3 single PUT limit.
 
 	s3TxnRetryInitialBackoff = 2 * time.Millisecond
 	s3TxnRetryMaxBackoff     = 32 * time.Millisecond
@@ -2338,7 +2339,11 @@ func (s *S3Server) serveS3LeaderHealthz(w http.ResponseWriter, r *http.Request) 
 	if r == nil || r.URL == nil || r.URL.Path != s3LeaderHealthPath {
 		return false
 	}
+	if r.Body != nil {
+		r.Body = http.MaxBytesReader(w, r.Body, s3HealthMaxRequestBodyBytes)
+	}
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return true
 	}

--- a/adapter/s3.go
+++ b/adapter/s3.go
@@ -2347,9 +2347,9 @@ func (s *S3Server) serveS3LeaderHealthz(w http.ResponseWriter, r *http.Request) 
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return true
 	}
-	status, body := http.StatusOK, "ok\n"
+	status, body := http.StatusOK, "ok"
 	if !s.isVerifiedS3Leader() {
-		status, body = http.StatusServiceUnavailable, "not leader\n"
+		status, body = http.StatusServiceUnavailable, "not leader"
 	}
 	w.WriteHeader(status)
 	if r.Method != http.MethodHead {
@@ -2359,10 +2359,7 @@ func (s *S3Server) serveS3LeaderHealthz(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *S3Server) isVerifiedS3Leader() bool {
-	if s == nil || s.coordinator == nil {
-		return false
-	}
-	if !s.coordinator.IsLeader() {
+	if s.coordinator == nil || !s.coordinator.IsLeader() {
 		return false
 	}
 	return s.coordinator.VerifyLeader() == nil

--- a/adapter/s3.go
+++ b/adapter/s3.go
@@ -32,6 +32,7 @@ import (
 
 const (
 	s3HealthPath             = "/healthz"
+	s3LeaderHealthPath       = "/healthz/leader"
 	s3ChunkSize              = 1 << 20
 	s3ChunkBatchOps          = 16
 	s3XMLNamespace           = "http://s3.amazonaws.com/doc/2006-03-01/"
@@ -331,6 +332,9 @@ func (s *S3Server) Stop() {
 
 func (s *S3Server) handle(w http.ResponseWriter, r *http.Request) {
 	if serveS3Healthz(w, r) {
+		return
+	}
+	if s.serveS3LeaderHealthz(w, r) {
 		return
 	}
 	if s.maybeProxyToLeader(w, r) {
@@ -2324,6 +2328,39 @@ func serveS3Healthz(w http.ResponseWriter, r *http.Request) bool {
 		_, _ = io.WriteString(w, "ok")
 	}
 	return true
+}
+
+// serveS3LeaderHealthz returns 200 only when this node is the verified raft
+// leader. It mirrors the DynamoDB server's /healthz/leader so that an
+// upstream load balancer can route S3 traffic to the current leader without
+// hitting the (currently broken) follower-proxy SigV4 path.
+func (s *S3Server) serveS3LeaderHealthz(w http.ResponseWriter, r *http.Request) bool {
+	if r == nil || r.URL == nil || r.URL.Path != s3LeaderHealthPath {
+		return false
+	}
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return true
+	}
+	status, body := http.StatusOK, "ok\n"
+	if !s.isVerifiedS3Leader() {
+		status, body = http.StatusServiceUnavailable, "not leader\n"
+	}
+	w.WriteHeader(status)
+	if r.Method != http.MethodHead {
+		_, _ = io.WriteString(w, body)
+	}
+	return true
+}
+
+func (s *S3Server) isVerifiedS3Leader() bool {
+	if s == nil || s.coordinator == nil {
+		return false
+	}
+	if !s.coordinator.IsLeader() {
+		return false
+	}
+	return s.coordinator.VerifyLeader() == nil
 }
 
 func encodeS3BucketMeta(meta *s3BucketMeta) ([]byte, error) {

--- a/adapter/s3_test.go
+++ b/adapter/s3_test.go
@@ -213,6 +213,38 @@ func TestS3Server_RejectsSigV4RequestWithExcessiveClockSkew(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "<Code>RequestTimeTooSkewed</Code>")
 }
 
+func TestS3Server_LeaderHealthz(t *testing.T) {
+	t.Parallel()
+
+	leaderSrv := NewS3Server(nil, "", store.NewMVCCStore(), newLocalAdapterCoordinator(store.NewMVCCStore()), nil)
+	followerSrv := NewS3Server(nil, "", store.NewMVCCStore(), &followerS3Coordinator{}, nil)
+
+	cases := []struct {
+		name   string
+		server *S3Server
+		status int
+		body   string
+	}{
+		{name: "leader", server: leaderSrv, status: http.StatusOK, body: "ok\n"},
+		{name: "follower", server: followerSrv, status: http.StatusServiceUnavailable, body: "not leader\n"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			tc.server.handle(rec, newS3TestRequest(http.MethodGet, s3LeaderHealthPath, nil))
+			require.Equal(t, tc.status, rec.Code)
+			require.Equal(t, tc.body, rec.Body.String())
+
+			// HEAD must match status but carry no body.
+			rec = httptest.NewRecorder()
+			tc.server.handle(rec, newS3TestRequest(http.MethodHead, s3LeaderHealthPath, nil))
+			require.Equal(t, tc.status, rec.Code)
+			require.Empty(t, rec.Body.String())
+		})
+	}
+}
+
 func TestS3Server_ProxiesFollowerRequestsBeforeAuth(t *testing.T) {
 	t.Parallel()
 

--- a/adapter/s3_test.go
+++ b/adapter/s3_test.go
@@ -225,8 +225,8 @@ func TestS3Server_LeaderHealthz(t *testing.T) {
 		status int
 		body   string
 	}{
-		{name: "leader", server: leaderSrv, status: http.StatusOK, body: "ok\n"},
-		{name: "follower", server: followerSrv, status: http.StatusServiceUnavailable, body: "not leader\n"},
+		{name: "leader", server: leaderSrv, status: http.StatusOK, body: "ok"},
+		{name: "follower", server: followerSrv, status: http.StatusServiceUnavailable, body: "not leader"},
 	}
 
 	for _, tc := range cases {

--- a/adapter/s3_test.go
+++ b/adapter/s3_test.go
@@ -243,6 +243,12 @@ func TestS3Server_LeaderHealthz(t *testing.T) {
 			require.Empty(t, rec.Body.String())
 		})
 	}
+
+	// Disallowed methods must get 405 with an Allow header per RFC 7231.
+	rec := httptest.NewRecorder()
+	leaderSrv.handle(rec, newS3TestRequest(http.MethodPost, s3LeaderHealthPath, nil))
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	require.Equal(t, "GET, HEAD", rec.Header().Get("Allow"))
 }
 
 func TestS3Server_ProxiesFollowerRequestsBeforeAuth(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `/healthz/leader` to the S3 server so an upstream load balancer can route port-9000 traffic to the current raft leader, mirroring the existing DynamoDB endpoint.

## Why
The S3 follower-proxy re-signs requests with the original Host header but the signature validation fails at the leader (separate bug); until that's fixed, pointing all traffic at the leader via an LB is the safest workaround. The leader check has to live on port 9000 because LB active health check uses the upstream port -- it can't split health-check port from proxy port.

## Test plan
- [x] `go test ./adapter/ -run TestS3Server_LeaderHealthz`
- [x] `golangci-lint run ./adapter/...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added S3 leader health check endpoint (`/healthz/leader`) supporting GET and HEAD requests that returns 200 when verified as a cluster leader, 503 otherwise. Unsupported methods receive a 405 response with appropriate headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->