### PR TITLE
feat(metrics): separate redis.call() time from Lua PCall duration

### DIFF
--- a/adapter/redis_lua.go
+++ b/adapter/redis_lua.go
@@ -120,7 +120,7 @@ func (r *RedisServer) runLuaScript(conn redcon.Conn, script string, evalArgs [][
 
 	start := time.Now()
 	var attempts int
-	var totalLuaExec, totalCommit time.Duration
+	var totalLuaExec, totalCommit, totalRedisCall time.Duration
 	var reply luaReply
 	err = r.retryRedisWrite(ctx, func() error {
 		attempts++
@@ -142,6 +142,7 @@ func (r *RedisServer) runLuaScript(conn redcon.Conn, script string, evalArgs [][
 			return errors.WithStack(err)
 		}
 		totalLuaExec += time.Since(luaStart)
+		totalRedisCall += scriptCtx.redisCallDuration
 
 		result := state.Get(-1)
 		defer state.Pop(1)
@@ -163,10 +164,11 @@ func (r *RedisServer) runLuaScript(conn redcon.Conn, script string, evalArgs [][
 	elapsed := time.Since(start)
 	if r.luaObserver != nil {
 		r.luaObserver.ObserveLuaScript(monitoring.LuaScriptReport{
-			LuaExecDuration: totalLuaExec,
-			CommitDuration:  totalCommit,
-			ConflictRetries: attempts - 1,
-			IsError:         err != nil,
+			LuaExecDuration:  totalLuaExec,
+			RedisCallDuration: totalRedisCall,
+			CommitDuration:   totalCommit,
+			ConflictRetries:  attempts - 1,
+			IsError:          err != nil,
 		})
 	}
 	if err != nil {

--- a/adapter/redis_lua.go
+++ b/adapter/redis_lua.go
@@ -138,11 +138,12 @@ func (r *RedisServer) runLuaScript(conn redcon.Conn, script string, evalArgs [][
 		state.Push(chunk)
 
 		luaStart := time.Now()
-		if err := state.PCall(0, 1, nil); err != nil {
-			return errors.WithStack(err)
-		}
+		pcallErr := state.PCall(0, 1, nil)
 		totalLuaExec += time.Since(luaStart)
 		totalRedisCall += scriptCtx.redisCallDuration
+		if pcallErr != nil {
+			return errors.WithStack(pcallErr)
+		}
 
 		result := state.Get(-1)
 		defer state.Pop(1)
@@ -164,11 +165,11 @@ func (r *RedisServer) runLuaScript(conn redcon.Conn, script string, evalArgs [][
 	elapsed := time.Since(start)
 	if r.luaObserver != nil {
 		r.luaObserver.ObserveLuaScript(monitoring.LuaScriptReport{
-			LuaExecDuration:  totalLuaExec,
+			LuaExecDuration:   totalLuaExec,
 			RedisCallDuration: totalRedisCall,
-			CommitDuration:   totalCommit,
-			ConflictRetries:  attempts - 1,
-			IsError:          err != nil,
+			CommitDuration:    totalCommit,
+			ConflictRetries:   attempts - 1,
+			IsError:           err != nil,
 		})
 	}
 	if err != nil {

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -19,6 +19,8 @@ type luaScriptContext struct {
 	startTS uint64
 	readPin *kv.ActiveTimestampToken
 
+	redisCallDuration time.Duration
+
 	touched     map[string]struct{}
 	deleted     map[string]bool
 	everDeleted map[string]bool
@@ -214,11 +216,16 @@ func (c *luaScriptContext) Close() {
 }
 
 func (c *luaScriptContext) exec(command string, args []string) (luaReply, error) {
+	execStart := time.Now()
+	var reply luaReply
+	var err error
 	if handler, ok := luaCommandHandlers[command]; ok {
-		return handler(c, args)
+		reply, err = handler(c, args)
+	} else {
+		err = errors.WithStack(errors.Newf("ERR unsupported command '%s'", command))
 	}
-
-	return luaReply{}, errors.WithStack(errors.Newf("ERR unsupported command '%s'", command))
+	c.redisCallDuration += time.Since(execStart)
+	return reply, err
 }
 
 func (c *luaScriptContext) markTouched(key []byte) {

--- a/monitoring/grafana/dashboards/elastickv-redis-summary.json
+++ b/monitoring/grafana/dashboards/elastickv-redis-summary.json
@@ -704,7 +704,7 @@
     },
     {
       "datasource": "$datasource",
-      "description": "Time spent purely in the Lua VM (state.PCall) per script invocation, summed across write-conflict retries. High p99 here means the Lua script itself is the bottleneck, not Raft or storage.",
+      "description": "Total time inside state.PCall per script invocation (includes redis.call() handler time). Compare with 'redis.call() Time' panel to separate pure VM overhead from distributed read latency.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -896,6 +896,130 @@
         }
       ],
       "title": "Write-Conflict Retries per Script (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "Time spent inside redis.call()/pcall() handlers per script invocation (Raft reads + in-memory state updates). Pure Lua VM time = 'Lua VM Execution Time' minus this value. High values here indicate distributed read latency is the bottleneck, not the Lua VM itself.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "auto"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 46
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(elastickv_lua_redis_call_duration_seconds_bucket{job=\"elastickv\", outcome=\"success\"}[5m])))",
+          "legendFormat": "p50 redis.call()",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(elastickv_lua_redis_call_duration_seconds_bucket{job=\"elastickv\", outcome=\"success\"}[5m])))",
+          "legendFormat": "p95 redis.call()",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(elastickv_lua_redis_call_duration_seconds_bucket{job=\"elastickv\", outcome=\"success\"}[5m])))",
+          "legendFormat": "p99 redis.call()",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "redis.call() Time inside Lua Script (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "Fraction of PCall time consumed by redis.call() handlers. Values near 100% confirm the bottleneck is distributed read latency, not the Lua VM.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "auto"
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 46
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(elastickv_lua_redis_call_duration_seconds_bucket{job=\"elastickv\", outcome=\"success\"}[5m]))) / histogram_quantile(0.50, sum by (le) (rate(elastickv_lua_exec_duration_seconds_bucket{job=\"elastickv\", outcome=\"success\"}[5m])))",
+          "legendFormat": "p50 redis.call() fraction",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(elastickv_lua_redis_call_duration_seconds_bucket{job=\"elastickv\", outcome=\"success\"}[5m]))) / histogram_quantile(0.99, sum by (le) (rate(elastickv_lua_exec_duration_seconds_bucket{job=\"elastickv\", outcome=\"success\"}[5m])))",
+          "legendFormat": "p99 redis.call() fraction",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "redis.call() Time as Fraction of Lua PCall Time",
       "type": "timeseries"
     }
   ],

--- a/monitoring/lua.go
+++ b/monitoring/lua.go
@@ -10,8 +10,12 @@ import (
 // covering all retryRedisWrite attempts.
 type LuaScriptReport struct {
 	// LuaExecDuration is the cumulative time spent inside state.PCall across
-	// all retry attempts (pure Lua VM execution, no I/O).
+	// all retry attempts. This includes RedisCallDuration.
 	LuaExecDuration time.Duration
+	// RedisCallDuration is the cumulative time spent inside redis.call() /
+	// redis.pcall() handlers (scriptCtx.exec) — Raft reads and in-memory
+	// state updates. Pure VM time = LuaExecDuration - RedisCallDuration.
+	RedisCallDuration time.Duration
 	// CommitDuration is the cumulative time spent in scriptCtx.commit()
 	// (coordinator.Dispatch → Raft consensus + storage write).
 	CommitDuration time.Duration
@@ -32,9 +36,10 @@ type LuaScriptObserver interface {
 // a Lua script execution so that Lua VM slowness, Raft latency, and write
 // conflict retries can be distinguished in dashboards.
 type LuaMetrics struct {
-	luaExecDuration *prometheus.HistogramVec
-	commitDuration  *prometheus.HistogramVec
-	conflictRetries prometheus.Histogram
+	luaExecDuration   *prometheus.HistogramVec
+	redisCallDuration *prometheus.HistogramVec
+	commitDuration    *prometheus.HistogramVec
+	conflictRetries   prometheus.Histogram
 }
 
 var luaDurationBuckets = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10}
@@ -45,7 +50,15 @@ func newLuaMetrics(registerer prometheus.Registerer) *LuaMetrics {
 		luaExecDuration: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Name:    "elastickv_lua_exec_duration_seconds",
-				Help:    "Cumulative time spent in the Lua VM (PCall) per script invocation, summed across retries.",
+				Help:    "Cumulative time inside state.PCall per invocation (includes redis.call() time). Use with redis_call_duration to isolate pure VM time.",
+				Buckets: luaDurationBuckets,
+			},
+			[]string{"outcome"},
+		),
+		redisCallDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "elastickv_lua_redis_call_duration_seconds",
+				Help:    "Cumulative time spent in redis.call()/pcall() handlers (Raft reads + in-memory state) per invocation. Pure VM time = exec_duration - redis_call_duration.",
 				Buckets: luaDurationBuckets,
 			},
 			[]string{"outcome"},
@@ -69,6 +82,7 @@ func newLuaMetrics(registerer prometheus.Registerer) *LuaMetrics {
 
 	registerer.MustRegister(
 		m.luaExecDuration,
+		m.redisCallDuration,
 		m.commitDuration,
 		m.conflictRetries,
 	)
@@ -86,6 +100,7 @@ func (m *LuaMetrics) ObserveLuaScript(report LuaScriptReport) {
 		outcome = redisOutcomeError
 	}
 	m.luaExecDuration.WithLabelValues(outcome).Observe(report.LuaExecDuration.Seconds())
+	m.redisCallDuration.WithLabelValues(outcome).Observe(report.RedisCallDuration.Seconds())
 	m.commitDuration.WithLabelValues(outcome).Observe(report.CommitDuration.Seconds())
 	m.conflictRetries.Observe(float64(report.ConflictRetries))
 }


### PR DESCRIPTION
Previously elastickv_lua_exec_duration_seconds included both the Lua VM and all redis.call() handler time (Raft reads), making it impossible to tell whether the bottleneck was the VM or distributed I/O.

- luaScriptContext.exec() now accumulates redisCallDuration per attempt
- runLuaScript sums it across retries and reports via LuaScriptReport
- New metric: elastickv_lua_redis_call_duration_seconds
- New Grafana panels: redis.call() absolute time and fraction-of-PCall ratio