### PR TITLE
Potential fix for code scanning alert no. 20: Size computation for allocation may overflow

### DIFF
--- a/kv/transaction.go
+++ b/kv/transaction.go
@@ -2,6 +2,7 @@ package kv
 
 import (
 	"context"
+	"math"
 	"sync"
 	"time"
 
@@ -130,6 +131,9 @@ func marshalRaftCommand(reqs []*pb.Request) ([]byte, error) {
 
 // prependByte returns a new slice with prefix followed by data.
 func prependByte(prefix byte, data []byte) []byte {
+	if len(data) >= math.MaxInt {
+		panic("prependByte: data too large")
+	}
 	out := make([]byte, len(data)+1)
 	out[0] = prefix
 	copy(out[1:], data)

--- a/kv/transaction.go
+++ b/kv/transaction.go
@@ -114,7 +114,7 @@ func marshalRaftCommand(reqs []*pb.Request) ([]byte, error) {
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
-		if len(b)+1 > maxMarshaledCommandSize {
+		if len(b) >= maxMarshaledCommandSize {
 			return nil, errors.New("marshaled request too large")
 		}
 		return prependByte(raftEncodeSingle, b), nil
@@ -123,7 +123,7 @@ func marshalRaftCommand(reqs []*pb.Request) ([]byte, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	if len(b)+1 > maxMarshaledCommandSize {
+	if len(b) >= maxMarshaledCommandSize {
 		return nil, errors.New("marshaled request batch too large")
 	}
 	return prependByte(raftEncodeBatch, b), nil


### PR DESCRIPTION
Potential fix for [https://github.com/bootjp/elastickv/security/code-scanning/20](https://github.com/bootjp/elastickv/security/code-scanning/20)

The best fix is to harden `prependByte` with an explicit overflow guard before computing allocation length, while preserving existing behavior for valid inputs.

In `kv/transaction.go`, update `prependByte` to:
- import `math` (standard library),
- check `if len(data) >= math.MaxInt { panic("prependByte: data too large") }` before `make`.

This ensures `len(data)+1` cannot overflow. Using a panic here keeps function signature and existing call pattern unchanged (no new error return path), so functionality remains the same for normal inputs while failing safely on impossible/extreme inputs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
