### PR TITLE
feat(s3): accept aws-chunked streaming payload uploads

### DIFF
--- a/adapter/s3.go
+++ b/adapter/s3.go
@@ -17,6 +17,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"net/textproto"
 	"net/url"
 	"strconv"
 	"strings"
@@ -777,7 +778,7 @@ func (s *S3Server) putBucketAcl(w http.ResponseWriter, r *http.Request, bucket s
 	w.WriteHeader(http.StatusOK)
 }
 
-//nolint:cyclop,gocognit,nestif // The S3 PUT flow is intentionally linear and maps directly to protocol steps.
+//nolint:cyclop,gocognit,gocyclo,nestif // The S3 PUT flow is intentionally linear and maps directly to protocol steps.
 func (s *S3Server) putObject(w http.ResponseWriter, r *http.Request, bucket string, objectKey string) {
 	readTS := s.readTS()
 	startTS := s.txnStartTS(readTS)
@@ -809,8 +810,12 @@ func (s *S3Server) putObject(w http.ResponseWriter, r *http.Request, bucket stri
 	hasher := md5.New() //nolint:gosec // S3 ETag compatibility requires MD5.
 	sha256Hasher := sha256.New()
 	expectedPayloadSHA := normalizeS3PayloadHash(r.Header.Get("X-Amz-Content-Sha256"))
-	validatePayloadSHA := expectedPayloadSHA != "" && !strings.EqualFold(expectedPayloadSHA, s3UnsignedPayload)
-	r.Body = http.MaxBytesReader(w, r.Body, s3MaxObjectSizeBytes)
+	validatePayloadSHA := expectedPayloadSHA != "" && !isS3PayloadMarker(expectedPayloadSHA)
+	streamBody, bodyErr := prepareStreamingPutBody(w, r, s3MaxObjectSizeBytes, expectedPayloadSHA)
+	if bodyErr != nil {
+		writeS3Error(w, bodyErr.Status, bodyErr.Code, bodyErr.Message, bucket, objectKey)
+		return
+	}
 	part := s3ObjectPart{PartNo: 1}
 	sizeBytes := int64(0)
 	chunkNo := uint64(0)
@@ -857,6 +862,7 @@ func (s *S3Server) putObject(w http.ResponseWriter, r *http.Request, bucket stri
 					return
 				}
 			}
+			streamBody.writeDecoded(chunk)
 			chunkKey := s3keys.BlobKey(bucket, meta.Generation, objectKey, uploadID, part.PartNo, chunkNo)
 			pendingBatch = append(pendingBatch, &kv.Elem[kv.OP]{Op: kv.Put, Key: chunkKey, Value: chunk})
 			chunkSize, err := uint64FromInt(n)
@@ -881,9 +887,8 @@ func (s *S3Server) putObject(w http.ResponseWriter, r *http.Request, bucket stri
 		}
 		if readErr != nil {
 			s.cleanupManifestBlobs(r.Context(), bucket, meta.Generation, objectKey, uploadedManifest())
-			var maxBytesErr *http.MaxBytesError
-			if errors.As(readErr, &maxBytesErr) {
-				writeS3Error(w, http.StatusRequestEntityTooLarge, "EntityTooLarge", "object exceeds maximum allowed size", bucket, objectKey)
+			if be, ok := classifyS3BodyReadErr(readErr, "object exceeds maximum allowed size"); ok {
+				writeS3Error(w, be.Status, be.Code, be.Message, bucket, objectKey)
 				return
 			}
 			writeS3InternalError(w, readErr)
@@ -903,6 +908,11 @@ func (s *S3Server) putObject(w http.ResponseWriter, r *http.Request, bucket stri
 			return
 		}
 	}
+	if err := streamBody.verifyTrailer(); err != nil {
+		s.cleanupManifestBlobs(r.Context(), bucket, meta.Generation, objectKey, uploadedManifest())
+		writeS3Error(w, http.StatusBadRequest, "BadDigest", err.Error(), bucket, objectKey)
+		return
+	}
 
 	etag := hex.EncodeToString(hasher.Sum(nil))
 	part.ETag = etag
@@ -920,7 +930,7 @@ func (s *S3Server) putObject(w http.ResponseWriter, r *http.Request, bucket stri
 		SizeBytes:          sizeBytes,
 		LastModifiedHLC:    commitTS,
 		ContentType:        headerOrDefault(r.Header.Get("Content-Type"), "application/octet-stream"),
-		ContentEncoding:    r.Header.Get("Content-Encoding"),
+		ContentEncoding:    cleanStoredContentEncoding(r.Header.Get("Content-Encoding")),
 		CacheControl:       r.Header.Get("Cache-Control"),
 		ContentDisposition: r.Header.Get("Content-Disposition"),
 		UserMetadata:       collectS3UserMetadata(r.Header),
@@ -1299,7 +1309,12 @@ func (s *S3Server) uploadPart(w http.ResponseWriter, r *http.Request, bucket str
 		return
 	}
 
-	r.Body = http.MaxBytesReader(w, r.Body, s3MaxPartSizeBytes)
+	partPayloadSHA := normalizeS3PayloadHash(r.Header.Get("X-Amz-Content-Sha256"))
+	partStreamBody, bodyErr := prepareStreamingPutBody(w, r, s3MaxPartSizeBytes, partPayloadSHA)
+	if bodyErr != nil {
+		writeS3Error(w, bodyErr.Status, bodyErr.Code, bodyErr.Message, bucket, objectKey)
+		return
+	}
 
 	// Pre-allocate the part's commit timestamp before writing any blob chunks so
 	// that the same version identifier is used for every chunk in this attempt.
@@ -1348,9 +1363,8 @@ func (s *S3Server) uploadPart(w http.ResponseWriter, r *http.Request, bucket str
 				break
 			}
 			if readErr != nil {
-				var maxBytesErr *http.MaxBytesError
-				if errors.As(readErr, &maxBytesErr) {
-					writeS3Error(w, http.StatusRequestEntityTooLarge, "EntityTooLarge", "part exceeds maximum allowed size", bucket, objectKey)
+				if be, ok := classifyS3BodyReadErr(readErr, "part exceeds maximum allowed size"); ok {
+					writeS3Error(w, be.Status, be.Code, be.Message, bucket, objectKey)
 					return
 				}
 				writeS3InternalError(w, readErr)
@@ -1363,6 +1377,7 @@ func (s *S3Server) uploadPart(w http.ResponseWriter, r *http.Request, bucket str
 			writeS3InternalError(w, err)
 			return
 		}
+		partStreamBody.writeDecoded(chunk)
 		chunkKey := s3keys.VersionedBlobKey(bucket, meta.Generation, objectKey, uploadID, partNo, chunkNo, partCommitTS)
 		pendingBatch = append(pendingBatch, &kv.Elem[kv.OP]{Op: kv.Put, Key: chunkKey, Value: chunk})
 		cs, err := uint64FromInt(n)
@@ -1383,9 +1398,8 @@ func (s *S3Server) uploadPart(w http.ResponseWriter, r *http.Request, bucket str
 			break
 		}
 		if readErr != nil {
-			var maxBytesErr *http.MaxBytesError
-			if errors.As(readErr, &maxBytesErr) {
-				writeS3Error(w, http.StatusRequestEntityTooLarge, "EntityTooLarge", "part exceeds maximum allowed size", bucket, objectKey)
+			if be, ok := classifyS3BodyReadErr(readErr, "part exceeds maximum allowed size"); ok {
+				writeS3Error(w, be.Status, be.Code, be.Message, bucket, objectKey)
 				return
 			}
 			writeS3InternalError(w, readErr)
@@ -1394,6 +1408,10 @@ func (s *S3Server) uploadPart(w http.ResponseWriter, r *http.Request, bucket str
 	}
 	if err := flushBatch(); err != nil {
 		writeS3InternalError(w, err)
+		return
+	}
+	if err := partStreamBody.verifyTrailer(); err != nil {
+		writeS3Error(w, http.StatusBadRequest, "BadDigest", err.Error(), bucket, objectKey)
 		return
 	}
 
@@ -2363,6 +2381,102 @@ func (s *S3Server) isVerifiedS3Leader() bool {
 		return false
 	}
 	return s.coordinator.VerifyLeader() == nil
+}
+
+// prepareStreamingPutBody wraps r.Body for aws-chunked framed uploads. When
+// the request is a plain (non-streaming) PUT the body is only wrapped with
+// MaxBytesReader; the streaming-body context returned is the zero value and
+// its helpers become no-ops. The caller uses the returned context to feed
+// decoded chunks through the optional trailer hasher and to verify the
+// trailer checksum once EOF is reached.
+func prepareStreamingPutBody(w http.ResponseWriter, r *http.Request, maxDecoded int64, payloadSHA string) (*s3StreamingBody, *s3PutBodyError) {
+	if !isS3StreamingPayloadMarker(payloadSHA) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxDecoded)
+		return &s3StreamingBody{}, nil
+	}
+
+	declaredRaw := strings.TrimSpace(r.Header.Get("X-Amz-Decoded-Content-Length"))
+	declared := int64(-1)
+	if declaredRaw != "" {
+		parsed, err := strconv.ParseInt(declaredRaw, 10, 64)
+		if err != nil || parsed < 0 {
+			return nil, &s3PutBodyError{Status: http.StatusBadRequest, Code: "InvalidRequest", Message: "invalid X-Amz-Decoded-Content-Length"}
+		}
+		if parsed > maxDecoded {
+			return nil, &s3PutBodyError{Status: http.StatusRequestEntityTooLarge, Code: "EntityTooLarge", Message: "object exceeds maximum allowed size"}
+		}
+		declared = parsed
+	}
+
+	// Budget the raw transport generously to absorb chunk/trailer framing
+	// overhead. Decoded bytes are independently capped inside the chunked
+	// reader, so this outer limit only guards against a client that keeps
+	// the connection open with junk framing forever.
+	const framingOverhead = 1 << 20 // 1 MiB
+	rawMax := maxDecoded + framingOverhead
+	r.Body = http.MaxBytesReader(w, r.Body, rawMax)
+
+	reader := newAwsChunkedReader(r.Body, declared, maxDecoded)
+	body := &s3StreamingBody{reader: reader}
+	r.Body = io.NopCloser(reader)
+
+	if advertised := strings.TrimSpace(r.Header.Get("X-Amz-Trailer")); advertised != "" {
+		canonical := canonicalTrailerName(advertised)
+		if h := newS3TrailerChecksumHasher(advertised); h != nil {
+			body.trailerName = canonical
+			body.trailerHash = h
+		}
+	}
+	return body, nil
+}
+
+// canonicalTrailerName returns the MIME-canonical form (e.g.
+// "X-Amz-Checksum-Crc32") of a trailer header name.
+func canonicalTrailerName(name string) string {
+	return textproto.CanonicalMIMEHeaderKey(strings.TrimSpace(name))
+}
+
+type s3PutBodyError struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+// classifyS3BodyReadErr folds the recognised body-read failures into an
+// s3PutBodyError the caller can pass to writeS3Error. Returns nil, false
+// when the error is not one of the known shapes, so the caller falls back
+// to writeS3InternalError.
+func classifyS3BodyReadErr(err error, tooLargeMessage string) (*s3PutBodyError, bool) {
+	var maxBytesErr *http.MaxBytesError
+	if errors.As(err, &maxBytesErr) {
+		return &s3PutBodyError{Status: http.StatusRequestEntityTooLarge, Code: "EntityTooLarge", Message: tooLargeMessage}, true
+	}
+	var chunkedErr *awsChunkedError
+	if errors.As(err, &chunkedErr) {
+		return &s3PutBodyError{Status: http.StatusBadRequest, Code: "InvalidRequest", Message: chunkedErr.Error()}, true
+	}
+	return nil, false
+}
+
+// cleanStoredContentEncoding strips "aws-chunked" from the Content-Encoding
+// value that will be persisted on the object. AWS S3 treats aws-chunked as a
+// transport-layer signal and does not store it; preserving it would cause
+// subsequent GET responses to advertise a transport encoding that no client
+// ever asked for.
+func cleanStoredContentEncoding(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	parts := strings.Split(raw, ",")
+	kept := parts[:0]
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed == "" || strings.EqualFold(trimmed, "aws-chunked") {
+			continue
+		}
+		kept = append(kept, trimmed)
+	}
+	return strings.Join(kept, ", ")
 }
 
 func encodeS3BucketMeta(meta *s3BucketMeta) ([]byte, error) {

--- a/adapter/s3.go
+++ b/adapter/s3.go
@@ -811,7 +811,7 @@ func (s *S3Server) putObject(w http.ResponseWriter, r *http.Request, bucket stri
 	sha256Hasher := sha256.New()
 	expectedPayloadSHA := normalizeS3PayloadHash(r.Header.Get("X-Amz-Content-Sha256"))
 	validatePayloadSHA := expectedPayloadSHA != "" && !isS3PayloadMarker(expectedPayloadSHA)
-	streamBody, bodyErr := prepareStreamingPutBody(w, r, s3MaxObjectSizeBytes, expectedPayloadSHA)
+	streamBody, bodyErr := prepareStreamingPutBody(w, r, s3MaxObjectSizeBytes, expectedPayloadSHA, "object exceeds maximum allowed size")
 	if bodyErr != nil {
 		writeS3Error(w, bodyErr.Status, bodyErr.Code, bodyErr.Message, bucket, objectKey)
 		return
@@ -1310,7 +1310,7 @@ func (s *S3Server) uploadPart(w http.ResponseWriter, r *http.Request, bucket str
 	}
 
 	partPayloadSHA := normalizeS3PayloadHash(r.Header.Get("X-Amz-Content-Sha256"))
-	partStreamBody, bodyErr := prepareStreamingPutBody(w, r, s3MaxPartSizeBytes, partPayloadSHA)
+	partStreamBody, bodyErr := prepareStreamingPutBody(w, r, s3MaxPartSizeBytes, partPayloadSHA, "part exceeds maximum allowed size")
 	if bodyErr != nil {
 		writeS3Error(w, bodyErr.Status, bodyErr.Code, bodyErr.Message, bucket, objectKey)
 		return
@@ -2389,8 +2389,27 @@ func (s *S3Server) isVerifiedS3Leader() bool {
 // its helpers become no-ops. The caller uses the returned context to feed
 // decoded chunks through the optional trailer hasher and to verify the
 // trailer checksum once EOF is reached.
-func prepareStreamingPutBody(w http.ResponseWriter, r *http.Request, maxDecoded int64, payloadSHA string) (*s3StreamingBody, *s3PutBodyError) {
+//
+//nolint:cyclop // Linear protocol preamble: reject unsupported markers, parse declared length, bind trailer, then hand off.
+func prepareStreamingPutBody(w http.ResponseWriter, r *http.Request, maxDecoded int64, payloadSHA, tooLargeMessage string) (*s3StreamingBody, *s3PutBodyError) {
+	// Reject signed streaming payload markers up-front. Accepting them
+	// without verifying the per-chunk chunk-signature= would silently
+	// downgrade the client's integrity guarantee to just the request
+	// header signature; better to respond 501 so the client can fall back
+	// to the unsigned streaming variant or non-streaming SHA.
+	if isS3SignedStreamingPayloadMarker(payloadSHA) {
+		return nil, &s3PutBodyError{Status: http.StatusNotImplemented, Code: "NotImplemented", Message: "signed streaming uploads (STREAMING-AWS4-HMAC-SHA256-PAYLOAD*) are not supported"}
+	}
+
+	hasAwsChunkedEncoding := contentEncodingContains(r.Header.Get("Content-Encoding"), "aws-chunked")
 	if !isS3StreamingPayloadMarker(payloadSHA) {
+		// A client that labels the transport as aws-chunked MUST also set
+		// a streaming payload marker; otherwise the server would store the
+		// raw framed bytes as-is (and cleanStoredContentEncoding would
+		// later drop the only hint that the object is still encoded).
+		if hasAwsChunkedEncoding {
+			return nil, &s3PutBodyError{Status: http.StatusBadRequest, Code: "InvalidRequest", Message: "Content-Encoding: aws-chunked requires a streaming X-Amz-Content-Sha256 marker"}
+		}
 		r.Body = http.MaxBytesReader(w, r.Body, maxDecoded)
 		return &s3StreamingBody{}, nil
 	}
@@ -2403,22 +2422,30 @@ func prepareStreamingPutBody(w http.ResponseWriter, r *http.Request, maxDecoded 
 			return nil, &s3PutBodyError{Status: http.StatusBadRequest, Code: "InvalidRequest", Message: "invalid X-Amz-Decoded-Content-Length"}
 		}
 		if parsed > maxDecoded {
-			return nil, &s3PutBodyError{Status: http.StatusRequestEntityTooLarge, Code: "EntityTooLarge", Message: "object exceeds maximum allowed size"}
+			return nil, &s3PutBodyError{Status: http.StatusRequestEntityTooLarge, Code: "EntityTooLarge", Message: tooLargeMessage}
 		}
 		declared = parsed
 	}
 
-	// Budget the raw transport generously to absorb chunk/trailer framing
-	// overhead. Decoded bytes are independently capped inside the chunked
-	// reader, so this outer limit only guards against a client that keeps
-	// the connection open with junk framing forever.
-	const framingOverhead = 1 << 20 // 1 MiB
-	rawMax := maxDecoded + framingOverhead
+	// Bound the raw transport. maxDecoded/256 covers the worst realistic
+	// per-chunk header overhead (AWS recommends >= 8 KiB chunks, and
+	// unsigned framing adds ~6 bytes per chunk; the allowance tolerates
+	// chunks as small as ~32 bytes). When the client declared a
+	// Content-Length tighter than that, honour the smaller bound; when
+	// they declared one larger, keep our cap so a runaway stream hits
+	// MaxBytesReader well before RAM pressure.
+	rawMax := maxDecoded + maxDecoded/s3StreamingFramingDivisor + s3StreamingTrailerBytes
+	if r.ContentLength > 0 && r.ContentLength < rawMax {
+		rawMax = r.ContentLength
+	}
 	r.Body = http.MaxBytesReader(w, r.Body, rawMax)
 
 	reader := newAwsChunkedReader(r.Body, declared, maxDecoded)
 	body := &s3StreamingBody{reader: reader}
-	r.Body = io.NopCloser(reader)
+	// Preserve Close() on the outer body so net/http still drains and
+	// frees the underlying MaxBytesReader + transport when the handler
+	// returns (io.NopCloser would have dropped that on the floor).
+	r.Body = closeForwardingReader{Reader: reader, Closer: r.Body}
 
 	// X-Amz-Trailer is formally a comma-separated list per AWS docs; pick
 	// the first trailer whose checksum algorithm we support rather than
@@ -2435,6 +2462,39 @@ func prepareStreamingPutBody(w http.ResponseWriter, r *http.Request, maxDecoded 
 		}
 	}
 	return body, nil
+}
+
+const (
+	// s3StreamingFramingDivisor bounds the per-chunk header overhead we
+	// allow over the decoded payload. maxDecoded / 256 allows up to ~0.4%
+	// of framing bytes, which comfortably covers the AWS-recommended 8 KiB
+	// chunk size (~6 bytes of framing per chunk) with generous headroom
+	// for smaller chunks.
+	s3StreamingFramingDivisor = 256
+	// s3StreamingTrailerBytes reserves room for the terminating 0-chunk
+	// plus advertised trailer headers (x-amz-checksum-* values etc.).
+	s3StreamingTrailerBytes = 4 * 1024
+)
+
+// contentEncodingContains reports whether the Content-Encoding header lists
+// the given token (case-insensitive). Per RFC 9110 the value is a
+// comma-separated list of coding names.
+func contentEncodingContains(raw, token string) bool {
+	for _, part := range strings.Split(raw, ",") {
+		if strings.EqualFold(strings.TrimSpace(part), token) {
+			return true
+		}
+	}
+	return false
+}
+
+// closeForwardingReader pairs a new Reader (typically a decoder built on
+// top of r.Body) with the original body's Close method so that when the
+// HTTP server calls r.Body.Close() at the end of the request, the
+// underlying MaxBytesReader / transport still gets the cleanup call.
+type closeForwardingReader struct {
+	io.Reader
+	io.Closer
 }
 
 // canonicalTrailerName returns the MIME-canonical form (e.g.

--- a/adapter/s3.go
+++ b/adapter/s3.go
@@ -2420,11 +2420,18 @@ func prepareStreamingPutBody(w http.ResponseWriter, r *http.Request, maxDecoded 
 	body := &s3StreamingBody{reader: reader}
 	r.Body = io.NopCloser(reader)
 
-	if advertised := strings.TrimSpace(r.Header.Get("X-Amz-Trailer")); advertised != "" {
-		canonical := canonicalTrailerName(advertised)
-		if h := newS3TrailerChecksumHasher(advertised); h != nil {
-			body.trailerName = canonical
+	// X-Amz-Trailer is formally a comma-separated list per AWS docs; pick
+	// the first trailer whose checksum algorithm we support rather than
+	// treating the whole value as one header name.
+	for _, raw := range strings.Split(r.Header.Get("X-Amz-Trailer"), ",") {
+		name := strings.TrimSpace(raw)
+		if name == "" {
+			continue
+		}
+		if h := newS3TrailerChecksumHasher(name); h != nil {
+			body.trailerName = canonicalTrailerName(name)
 			body.trailerHash = h
+			break
 		}
 	}
 	return body, nil

--- a/adapter/s3_auth.go
+++ b/adapter/s3_auth.go
@@ -16,12 +16,46 @@ import (
 )
 
 const (
-	s3SigV4Algorithm     = "AWS4-HMAC-SHA256"
-	s3UnsignedPayload    = "UNSIGNED-PAYLOAD"
-	s3EmptyPayloadHash   = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-	s3DateHeaderFormat   = "20060102T150405Z"
-	s3RequestTimeMaxSkew = 15 * time.Minute
+	s3SigV4Algorithm = "AWS4-HMAC-SHA256"
+	// s3UnsignedPayload / s3Streaming* are sentinel values that AWS SDKs may
+	// place in X-Amz-Content-Sha256. None of them are a literal SHA-256 hash
+	// of the body, so the PUT pipeline must skip hash validation when it sees
+	// one. The streaming variants additionally signal that the request body
+	// is framed in the aws-chunked encoding; see adapter/s3_chunked.go.
+	s3UnsignedPayload                 = "UNSIGNED-PAYLOAD"
+	s3StreamingUnsignedPayloadTrailer = "STREAMING-UNSIGNED-PAYLOAD-TRAILER"
+	s3StreamingSignedPayload          = "STREAMING-AWS4-HMAC-SHA256-PAYLOAD"
+	s3StreamingSignedPayloadTrailer   = "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER"
+	s3EmptyPayloadHash                = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	s3DateHeaderFormat                = "20060102T150405Z"
+	s3RequestTimeMaxSkew              = 15 * time.Minute
 )
+
+// isS3PayloadMarker reports whether the given X-Amz-Content-Sha256 value is a
+// sentinel (UNSIGNED-PAYLOAD / STREAMING-*) rather than a literal SHA-256
+// hash. Callers MUST NOT try to hash the request body against a marker value.
+func isS3PayloadMarker(hash string) bool {
+	switch {
+	case strings.EqualFold(hash, s3UnsignedPayload),
+		strings.EqualFold(hash, s3StreamingUnsignedPayloadTrailer),
+		strings.EqualFold(hash, s3StreamingSignedPayload),
+		strings.EqualFold(hash, s3StreamingSignedPayloadTrailer):
+		return true
+	}
+	return false
+}
+
+// isS3StreamingPayloadMarker reports whether the payload sentinel indicates
+// an aws-chunked framed body that the server must decode before storing.
+func isS3StreamingPayloadMarker(hash string) bool {
+	switch {
+	case strings.EqualFold(hash, s3StreamingUnsignedPayloadTrailer),
+		strings.EqualFold(hash, s3StreamingSignedPayload),
+		strings.EqualFold(hash, s3StreamingSignedPayloadTrailer):
+		return true
+	}
+	return false
+}
 
 type S3ServerOption func(*S3Server)
 

--- a/adapter/s3_auth.go
+++ b/adapter/s3_auth.go
@@ -46,11 +46,25 @@ func isS3PayloadMarker(hash string) bool {
 }
 
 // isS3StreamingPayloadMarker reports whether the payload sentinel indicates
-// an aws-chunked framed body that the server must decode before storing.
+// an aws-chunked framed body whose integrity is NOT dependent on chained
+// chunk-signature verification. Only the unsigned streaming variant is
+// accepted today; see isS3SignedStreamingPayloadMarker for why the signed
+// variants require a separate implementation path.
 func isS3StreamingPayloadMarker(hash string) bool {
+	return strings.EqualFold(hash, s3StreamingUnsignedPayloadTrailer)
+}
+
+// isS3SignedStreamingPayloadMarker reports whether the payload sentinel is
+// one of the STREAMING-AWS4-HMAC-SHA256-PAYLOAD[-TRAILER] markers. These
+// require the server to recompute and compare the chunk-signature=<hex>
+// parameter on every chunk (AWS spec: chained HMAC-SHA256 across previous
+// signature + chunk data). Until we implement that chunk-by-chunk
+// verification, accepting the marker would silently downgrade the client's
+// integrity guarantee to just the request-header SigV4, so the PutObject
+// / UploadPart pipeline rejects these uploads with 501 NotImplemented.
+func isS3SignedStreamingPayloadMarker(hash string) bool {
 	switch {
-	case strings.EqualFold(hash, s3StreamingUnsignedPayloadTrailer),
-		strings.EqualFold(hash, s3StreamingSignedPayload),
+	case strings.EqualFold(hash, s3StreamingSignedPayload),
 		strings.EqualFold(hash, s3StreamingSignedPayloadTrailer):
 		return true
 	}

--- a/adapter/s3_chunked.go
+++ b/adapter/s3_chunked.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/base64"
 	"hash"
 	"hash/crc32"
@@ -19,8 +20,10 @@ import (
 // The cap is generous relative to AWS SDK defaults (128 KiB - 1 MiB) so it
 // only triggers on clearly pathological inputs.
 const (
-	s3ChunkSizeMax     = 16 * 1024 * 1024 // 16 MiB
-	s3MaxTrailerLength = 4 * 1024         // 4 KiB total across trailer headers
+	s3ChunkSizeMax          = 16 * 1024 * 1024 // 16 MiB
+	s3MaxTrailerLength      = 4 * 1024         // 4 KiB total across trailer headers
+	s3ChunkedMaxLineLength  = 8 * 1024         // 8 KiB — also the bufio buffer size
+	s3ChunkedReaderBufBytes = s3ChunkedMaxLineLength
 )
 
 // awsChunkedError tags failures that originate from aws-chunked framing or
@@ -66,8 +69,11 @@ type awsChunkedReader struct {
 }
 
 func newAwsChunkedReader(r io.Reader, declaredDecoded, maxDecoded int64) *awsChunkedReader {
+	// Pre-size the bufio buffer to the maximum allowed line length so that
+	// readLine can rely on ReadSlice returning ErrBufferFull on over-long
+	// lines instead of growing the buffer unboundedly.
 	return &awsChunkedReader{
-		br:              bufio.NewReader(r),
+		br:              bufio.NewReaderSize(r, s3ChunkedReaderBufBytes),
 		cur:             0,
 		declaredDecoded: declaredDecoded,
 		maxDecoded:      maxDecoded,
@@ -114,10 +120,14 @@ func (r *awsChunkedReader) Read(p []byte) (int, error) {
 			return n, newAwsChunkedError(sizeErr)
 		}
 	}
-	// The underlying reader ran out of bytes before the chunk completed.
-	// Treat that as a malformed stream rather than a clean EOF so the caller
-	// does not silently store a truncated object.
-	if errors.Is(err, io.EOF) && r.cur > 0 {
+	// The underlying reader ran out of bytes before the stream terminated.
+	// This covers two scenarios that must both be treated as malformed:
+	//   - EOF mid-chunk (r.cur > 0)
+	//   - EOF exactly at a chunk boundary before the terminating 0-chunk
+	//     was processed (r.cur == 0 but !r.finished)
+	// Returning io.EOF to the caller in the second case would let
+	// io.ReadAll silently accept a truncated upload.
+	if errors.Is(err, io.EOF) && !r.finished {
 		return n, newAwsChunkedError(io.ErrUnexpectedEOF)
 	}
 	if r.cur == 0 && err == nil {
@@ -207,15 +217,16 @@ func (r *awsChunkedReader) readTrailer() error {
 // the line length so a malicious peer cannot force us to read an unbounded
 // buffer.
 func (r *awsChunkedReader) readLine() (string, error) {
-	const maxLine = 8 * 1024
-	line, err := r.br.ReadString('\n')
+	line, err := r.br.ReadSlice('\n')
+	if errors.Is(err, bufio.ErrBufferFull) {
+		return "", errors.Newf("aws-chunked: header line exceeds %d bytes", s3ChunkedMaxLineLength) //nolint:wrapcheck // creating new error, nothing to wrap
+	}
 	if err != nil {
 		return "", errors.Wrap(err, "aws-chunked: read line")
 	}
-	if len(line) > maxLine {
-		return "", errors.Newf("aws-chunked: header line exceeds %d bytes", maxLine) //nolint:wrapcheck // creating new error, nothing to wrap
-	}
-	return strings.TrimRight(line, "\r\n"), nil
+	// Convert to string (which copies) so the result survives the next
+	// ReadSlice call that reuses the internal buffer.
+	return strings.TrimRight(string(line), "\r\n"), nil
 }
 
 func (r *awsChunkedReader) consumeCRLF() error {
@@ -289,20 +300,8 @@ func (s *s3StreamingBody) verifyTrailer() error {
 		return errors.Wrapf(err, "aws-chunked: decode trailer %q", s.trailerName)
 	}
 	computed := s.trailerHash.Sum(nil)
-	if !hashesEqual(expected, computed) {
+	if !bytes.Equal(expected, computed) {
 		return errors.Newf("aws-chunked: trailer %q checksum mismatch", s.trailerName) //nolint:wrapcheck // creating new error, nothing to wrap
 	}
 	return nil
-}
-
-func hashesEqual(a, b []byte) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }

--- a/adapter/s3_chunked.go
+++ b/adapter/s3_chunked.go
@@ -1,0 +1,308 @@
+package adapter
+
+import (
+	"bufio"
+	"encoding/base64"
+	"hash"
+	"hash/crc32"
+	"io"
+	"net/textproto"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Limits applied to aws-chunked framed request bodies. A single chunk must
+// fit within s3ChunkSizeMax so a malicious client cannot force the server to
+// allocate an unbounded buffer based on the attacker-supplied hex size line.
+// The cap is generous relative to AWS SDK defaults (128 KiB - 1 MiB) so it
+// only triggers on clearly pathological inputs.
+const (
+	s3ChunkSizeMax     = 16 * 1024 * 1024 // 16 MiB
+	s3MaxTrailerLength = 4 * 1024         // 4 KiB total across trailer headers
+)
+
+// awsChunkedError tags failures that originate from aws-chunked framing or
+// from enforcing the declared decoded length. Handlers unwrap to this type
+// to distinguish malformed-input failures (400 InvalidRequest) from generic
+// I/O errors (500 InternalError).
+type awsChunkedError struct{ err error }
+
+func (e *awsChunkedError) Error() string { return e.err.Error() }
+func (e *awsChunkedError) Unwrap() error { return e.err }
+
+func newAwsChunkedError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &awsChunkedError{err: err}
+}
+
+// awsChunkedReader decodes an aws-chunked framed body into the underlying
+// decoded bytes. The wire format is:
+//
+//	<hex-chunk-size>[;chunk-signature=<hex>]\r\n
+//	<chunk-data>\r\n
+//	... (repeat) ...
+//	0\r\n
+//	<trailer-header>: <value>\r\n   (optional, zero or more)
+//	\r\n
+//
+// The decoder tolerates both the unsigned and signed chunk forms because the
+// signature parameter is parsed and discarded (see isS3StreamingPayloadMarker
+// and the security note in s3_chunked_test.go for the rationale). It also
+// records trailer headers the caller may verify (currently used for the
+// x-amz-checksum-* trailers so a CRC mismatch surfaces as 400 to the client
+// instead of silent corruption).
+type awsChunkedReader struct {
+	br              *bufio.Reader
+	cur             int64 // bytes remaining in the current chunk
+	finished        bool
+	totalDecoded    int64
+	maxDecoded      int64 // decoded-byte ceiling; 0 means unlimited
+	declaredDecoded int64 // X-Amz-Decoded-Content-Length; -1 means unknown
+	trailers        map[string]string
+}
+
+func newAwsChunkedReader(r io.Reader, declaredDecoded, maxDecoded int64) *awsChunkedReader {
+	return &awsChunkedReader{
+		br:              bufio.NewReader(r),
+		cur:             0,
+		declaredDecoded: declaredDecoded,
+		maxDecoded:      maxDecoded,
+		trailers:        map[string]string{},
+	}
+}
+
+// Trailer returns the trailer headers collected after the terminating
+// 0-length chunk. The map key is canonical MIME form (e.g.
+// "X-Amz-Checksum-Crc32"). Only valid after Read has returned io.EOF.
+func (r *awsChunkedReader) Trailer() map[string]string {
+	out := make(map[string]string, len(r.trailers))
+	for k, v := range r.trailers {
+		out[k] = v
+	}
+	return out
+}
+
+//nolint:cyclop // aws-chunked decoder branches on chunk boundaries, framing errors, and decoded-length limits; splitting further hurts readability.
+func (r *awsChunkedReader) Read(p []byte) (int, error) {
+	if r.finished {
+		return 0, io.EOF
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	if r.cur == 0 {
+		if err := r.readChunkHeader(); err != nil {
+			return 0, newAwsChunkedError(err)
+		}
+		if r.finished {
+			return 0, io.EOF
+		}
+	}
+
+	want := int64(len(p))
+	if want > r.cur {
+		want = r.cur
+	}
+	n, err := r.br.Read(p[:want])
+	if n > 0 {
+		if sizeErr := r.accountDecoded(int64(n)); sizeErr != nil {
+			return n, newAwsChunkedError(sizeErr)
+		}
+	}
+	// The underlying reader ran out of bytes before the chunk completed.
+	// Treat that as a malformed stream rather than a clean EOF so the caller
+	// does not silently store a truncated object.
+	if errors.Is(err, io.EOF) && r.cur > 0 {
+		return n, newAwsChunkedError(io.ErrUnexpectedEOF)
+	}
+	if r.cur == 0 && err == nil {
+		// Drain the trailing CRLF that follows chunk data.
+		if err = r.consumeCRLF(); err != nil {
+			return n, newAwsChunkedError(err)
+		}
+	}
+	return n, err //nolint:wrapcheck // propagate underlying reader error verbatim
+}
+
+func (r *awsChunkedReader) accountDecoded(n int64) error {
+	r.cur -= n
+	r.totalDecoded += n
+	if r.maxDecoded > 0 && r.totalDecoded > r.maxDecoded {
+		return errors.New("aws-chunked: decoded body exceeded maximum allowed size")
+	}
+	if r.declaredDecoded >= 0 && r.totalDecoded > r.declaredDecoded {
+		return errors.New("aws-chunked: decoded bytes exceed X-Amz-Decoded-Content-Length")
+	}
+	return nil
+}
+
+func (r *awsChunkedReader) readChunkHeader() error {
+	line, err := r.readLine()
+	if err != nil {
+		return errors.Wrap(err, "aws-chunked: read chunk header")
+	}
+	sizeStr := line
+	if idx := strings.IndexByte(line, ';'); idx >= 0 {
+		// Discard `;chunk-signature=<hex>` (and any other chunk extensions).
+		// TODO: optionally verify chunk-signature when we implement
+		// signed-chunk support.
+		sizeStr = line[:idx]
+	}
+	sizeStr = strings.TrimSpace(sizeStr)
+	size, err := strconv.ParseInt(sizeStr, 16, 64)
+	if err != nil {
+		return errors.Wrapf(err, "aws-chunked: invalid chunk size %q", sizeStr)
+	}
+	if size < 0 {
+		return errors.Newf("aws-chunked: negative chunk size %d", size) //nolint:wrapcheck // creating new error, nothing to wrap
+	}
+	if size > s3ChunkSizeMax {
+		return errors.Newf("aws-chunked: chunk size %d exceeds maximum %d", size, s3ChunkSizeMax) //nolint:wrapcheck // creating new error, nothing to wrap
+	}
+	if size == 0 {
+		if err := r.readTrailer(); err != nil {
+			return err
+		}
+		r.finished = true
+		if r.declaredDecoded >= 0 && r.totalDecoded != r.declaredDecoded {
+			return errors.Newf( //nolint:wrapcheck // creating new error, nothing to wrap
+				"aws-chunked: decoded %d bytes but X-Amz-Decoded-Content-Length was %d",
+				r.totalDecoded, r.declaredDecoded,
+			)
+		}
+		return nil
+	}
+	r.cur = size
+	return nil
+}
+
+func (r *awsChunkedReader) readTrailer() error {
+	total := 0
+	for {
+		line, err := r.readLine()
+		if err != nil {
+			return errors.Wrap(err, "aws-chunked: read trailer")
+		}
+		if line == "" {
+			return nil
+		}
+		total += len(line)
+		if total > s3MaxTrailerLength {
+			return errors.New("aws-chunked: trailer headers exceed maximum length")
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			return errors.Newf("aws-chunked: malformed trailer line %q", line) //nolint:wrapcheck // creating new error, nothing to wrap
+		}
+		r.trailers[textproto.CanonicalMIMEHeaderKey(strings.TrimSpace(key))] = strings.TrimSpace(value)
+	}
+}
+
+// readLine reads one CRLF-terminated line (without the CRLF) while bounding
+// the line length so a malicious peer cannot force us to read an unbounded
+// buffer.
+func (r *awsChunkedReader) readLine() (string, error) {
+	const maxLine = 8 * 1024
+	line, err := r.br.ReadString('\n')
+	if err != nil {
+		return "", errors.Wrap(err, "aws-chunked: read line")
+	}
+	if len(line) > maxLine {
+		return "", errors.Newf("aws-chunked: header line exceeds %d bytes", maxLine) //nolint:wrapcheck // creating new error, nothing to wrap
+	}
+	return strings.TrimRight(line, "\r\n"), nil
+}
+
+func (r *awsChunkedReader) consumeCRLF() error {
+	var buf [2]byte
+	if _, err := io.ReadFull(r.br, buf[:]); err != nil {
+		return errors.Wrap(err, "aws-chunked: read chunk trailing CRLF")
+	}
+	if buf != [2]byte{'\r', '\n'} {
+		return errors.Newf("aws-chunked: chunk not terminated by CRLF (got %q)", string(buf[:])) //nolint:wrapcheck // creating new error, nothing to wrap
+	}
+	return nil
+}
+
+// newS3TrailerChecksumHasher returns a hasher matching the given trailer
+// name (e.g. "x-amz-checksum-crc32"). It returns nil when the algorithm is
+// unsupported; callers then skip validation. Trailer values are base64.
+func newS3TrailerChecksumHasher(name string) hash.Hash {
+	switch textproto.CanonicalMIMEHeaderKey(strings.TrimSpace(name)) {
+	case "X-Amz-Checksum-Crc32":
+		return crc32.NewIEEE()
+	case "X-Amz-Checksum-Crc32c":
+		return crc32.New(crc32.MakeTable(crc32.Castagnoli))
+	}
+	return nil
+}
+
+func decodeS3TrailerChecksum(value string) ([]byte, error) {
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(value))
+	if err != nil {
+		return nil, errors.Wrap(err, "aws-chunked: decode trailer base64")
+	}
+	return decoded, nil
+}
+
+// s3StreamingBody is the mutable state a streaming PUT needs to keep around
+// while it drains the request body: the wrapped reader (for trailer
+// extraction after EOF), an optional running checksum of the decoded bytes
+// for the trailer the client promised, and the canonical trailer header
+// name. When the request is not streaming, all fields are zero-valued and
+// the helpers below are no-ops.
+type s3StreamingBody struct {
+	reader      *awsChunkedReader
+	trailerName string // canonical MIME form, e.g. "X-Amz-Checksum-Crc32"
+	trailerHash hash.Hash
+}
+
+// writeDecoded feeds each decoded chunk through the optional trailer hasher.
+// Safe to call when s is the zero value.
+func (s *s3StreamingBody) writeDecoded(p []byte) {
+	if s == nil || s.trailerHash == nil {
+		return
+	}
+	_, _ = s.trailerHash.Write(p)
+}
+
+// verifyTrailer must be called after the body has been read to EOF. It
+// returns a non-nil error when the client advertised a trailer checksum via
+// X-Amz-Trailer and the value that arrived in the chunked trailer does not
+// match the bytes we received. Returns nil for non-streaming requests or
+// when the client did not advertise a supported checksum.
+func (s *s3StreamingBody) verifyTrailer() error {
+	if s == nil || s.trailerName == "" || s.trailerHash == nil || s.reader == nil {
+		return nil
+	}
+	received, ok := s.reader.Trailer()[s.trailerName]
+	if !ok {
+		return errors.Newf("aws-chunked: advertised trailer %q missing", s.trailerName) //nolint:wrapcheck // creating new error, nothing to wrap
+	}
+	expected, err := decodeS3TrailerChecksum(received)
+	if err != nil {
+		return errors.Wrapf(err, "aws-chunked: decode trailer %q", s.trailerName)
+	}
+	computed := s.trailerHash.Sum(nil)
+	if !hashesEqual(expected, computed) {
+		return errors.Newf("aws-chunked: trailer %q checksum mismatch", s.trailerName) //nolint:wrapcheck // creating new error, nothing to wrap
+	}
+	return nil
+}
+
+func hashesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/adapter/s3_chunked_test.go
+++ b/adapter/s3_chunked_test.go
@@ -1,0 +1,247 @@
+package adapter
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// encodeAwsChunked returns an aws-chunked framed body that carries the given
+// decoded payload split into chunks of size chunkSize. If trailer is
+// non-empty it is appended as a single chunk-extension trailer header.
+func encodeAwsChunked(t *testing.T, payload []byte, chunkSize int, trailerName, trailerValue string) []byte {
+	t.Helper()
+	require.Positive(t, chunkSize)
+	var buf bytes.Buffer
+	for i := 0; i < len(payload); i += chunkSize {
+		end := i + chunkSize
+		if end > len(payload) {
+			end = len(payload)
+		}
+		fmt.Fprintf(&buf, "%x\r\n", end-i)
+		buf.Write(payload[i:end])
+		buf.WriteString("\r\n")
+	}
+	buf.WriteString("0\r\n")
+	if trailerName != "" {
+		fmt.Fprintf(&buf, "%s: %s\r\n", trailerName, trailerValue)
+	}
+	buf.WriteString("\r\n")
+	return buf.Bytes()
+}
+
+// encodeSignedAwsChunked produces a signed-chunk body. The fake chunk
+// signature is never validated by the decoder (see security note in
+// s3_chunked.go).
+func encodeSignedAwsChunked(t *testing.T, payload []byte, chunkSize int) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	for i := 0; i < len(payload); i += chunkSize {
+		end := i + chunkSize
+		if end > len(payload) {
+			end = len(payload)
+		}
+		fmt.Fprintf(&buf, "%x;chunk-signature=deadbeef\r\n", end-i)
+		buf.Write(payload[i:end])
+		buf.WriteString("\r\n")
+	}
+	buf.WriteString("0;chunk-signature=cafed00d\r\n\r\n")
+	return buf.Bytes()
+}
+
+func TestAwsChunkedReader_SingleChunk(t *testing.T) {
+	payload := []byte("hello aws chunked")
+	body := encodeAwsChunked(t, payload, len(payload), "", "")
+
+	r := newAwsChunkedReader(bytes.NewReader(body), int64(len(payload)), 1<<20)
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+}
+
+func TestAwsChunkedReader_MultipleChunks(t *testing.T) {
+	payload := bytes.Repeat([]byte("abcde"), 100) // 500 bytes
+	body := encodeAwsChunked(t, payload, 37, "", "")
+
+	r := newAwsChunkedReader(bytes.NewReader(body), int64(len(payload)), 1<<20)
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+}
+
+func TestAwsChunkedReader_SignedChunkExtensionsIgnored(t *testing.T) {
+	payload := []byte("signed chunked body")
+	body := encodeSignedAwsChunked(t, payload, 8)
+
+	r := newAwsChunkedReader(bytes.NewReader(body), int64(len(payload)), 1<<20)
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+}
+
+func TestAwsChunkedReader_TrailerExposed(t *testing.T) {
+	payload := []byte("with trailer")
+	body := encodeAwsChunked(t, payload, 5, "x-amz-checksum-crc32", "Zm9vYmFyMA==")
+
+	r := newAwsChunkedReader(bytes.NewReader(body), int64(len(payload)), 1<<20)
+	_, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Equal(t, "Zm9vYmFyMA==", r.Trailer()["X-Amz-Checksum-Crc32"])
+}
+
+func TestAwsChunkedReader_DecodedLengthMismatch(t *testing.T) {
+	payload := []byte("exact length matters")
+	body := encodeAwsChunked(t, payload, 7, "", "")
+	// Declare a smaller length than the actual decoded body to ensure the
+	// reader enforces equality and does not silently truncate.
+	r := newAwsChunkedReader(bytes.NewReader(body), int64(len(payload)-1), 1<<20)
+	_, err := io.ReadAll(r)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "X-Amz-Decoded-Content-Length")
+}
+
+func TestAwsChunkedReader_DecodedLengthShort(t *testing.T) {
+	payload := []byte("shorter than declared")
+	body := encodeAwsChunked(t, payload, 6, "", "")
+	r := newAwsChunkedReader(bytes.NewReader(body), int64(len(payload)+5), 1<<20)
+	_, err := io.ReadAll(r)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "X-Amz-Decoded-Content-Length")
+}
+
+func TestAwsChunkedReader_MaxDecodedEnforced(t *testing.T) {
+	payload := bytes.Repeat([]byte("x"), 100)
+	body := encodeAwsChunked(t, payload, 16, "", "")
+	r := newAwsChunkedReader(bytes.NewReader(body), -1, 40)
+	_, err := io.ReadAll(r)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "maximum allowed size")
+}
+
+func TestAwsChunkedReader_RejectsOversizedChunkHeader(t *testing.T) {
+	oversized := fmt.Sprintf("%x\r\n", s3ChunkSizeMax+1)
+	r := newAwsChunkedReader(strings.NewReader(oversized), -1, 1<<30)
+	_, err := io.ReadAll(r)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds maximum")
+}
+
+func TestAwsChunkedReader_RejectsMalformedSizeLine(t *testing.T) {
+	body := "zz\r\npayload\r\n0\r\n\r\n"
+	r := newAwsChunkedReader(strings.NewReader(body), -1, 1<<20)
+	_, err := io.ReadAll(r)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid chunk size")
+}
+
+func TestAwsChunkedReader_RejectsMissingTrailingCRLF(t *testing.T) {
+	// Chunk data without the terminating \r\n.
+	body := "5\r\nhellomore"
+	r := newAwsChunkedReader(strings.NewReader(body), -1, 1<<20)
+	_, err := io.ReadAll(r)
+	require.Error(t, err)
+}
+
+func TestAwsChunkedReader_TruncatedInput(t *testing.T) {
+	// Declares 10 byte chunk but only provides 3 bytes before EOF.
+	body := "a\r\nabc"
+	r := newAwsChunkedReader(strings.NewReader(body), -1, 1<<20)
+	_, err := io.ReadAll(r)
+	require.Error(t, err)
+}
+
+func TestS3StreamingBody_VerifyTrailer_CRC32(t *testing.T) {
+	payload := []byte("Mary had a little lamb")
+	sum := crc32.NewIEEE()
+	_, err := sum.Write(payload)
+	require.NoError(t, err)
+	expected := base64.StdEncoding.EncodeToString(sum.Sum(nil))
+
+	body := encodeAwsChunked(t, payload, 5, "x-amz-checksum-crc32", expected)
+	reader := newAwsChunkedReader(bytes.NewReader(body), int64(len(payload)), 1<<20)
+
+	hasher := newS3TrailerChecksumHasher("x-amz-checksum-crc32")
+	require.NotNil(t, hasher)
+	sb := &s3StreamingBody{
+		reader:      reader,
+		trailerName: canonicalTrailerName("x-amz-checksum-crc32"),
+		trailerHash: hasher,
+	}
+	got, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+	sb.writeDecoded(got)
+	require.NoError(t, sb.verifyTrailer())
+}
+
+func TestS3StreamingBody_VerifyTrailer_Mismatch(t *testing.T) {
+	payload := []byte("Mary had a little lamb")
+	wrong := base64.StdEncoding.EncodeToString([]byte{0xDE, 0xAD, 0xBE, 0xEF})
+	body := encodeAwsChunked(t, payload, 5, "x-amz-checksum-crc32", wrong)
+	reader := newAwsChunkedReader(bytes.NewReader(body), int64(len(payload)), 1<<20)
+	hasher := newS3TrailerChecksumHasher("x-amz-checksum-crc32")
+	sb := &s3StreamingBody{
+		reader:      reader,
+		trailerName: canonicalTrailerName("x-amz-checksum-crc32"),
+		trailerHash: hasher,
+	}
+	got, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	sb.writeDecoded(got)
+	err = sb.verifyTrailer()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "checksum mismatch")
+}
+
+func TestS3StreamingBody_ZeroValueIsNoOp(t *testing.T) {
+	var sb s3StreamingBody
+	sb.writeDecoded([]byte("anything"))
+	require.NoError(t, sb.verifyTrailer())
+}
+
+func TestIsS3PayloadMarker(t *testing.T) {
+	cases := map[string]bool{
+		"UNSIGNED-PAYLOAD":                               true,
+		"unsigned-payload":                               true,
+		"STREAMING-UNSIGNED-PAYLOAD-TRAILER":             true,
+		"STREAMING-AWS4-HMAC-SHA256-PAYLOAD":             true,
+		"STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER":     true,
+		"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b93": false,
+		"":                       false,
+		"SOMETHING-ELSE-PAYLOAD": false,
+	}
+	for in, want := range cases {
+		got := isS3PayloadMarker(in)
+		require.Equal(t, want, got, "isS3PayloadMarker(%q)", in)
+	}
+}
+
+func TestIsS3StreamingPayloadMarker(t *testing.T) {
+	require.False(t, isS3StreamingPayloadMarker("UNSIGNED-PAYLOAD"))
+	require.True(t, isS3StreamingPayloadMarker("STREAMING-UNSIGNED-PAYLOAD-TRAILER"))
+	require.True(t, isS3StreamingPayloadMarker("streaming-aws4-hmac-sha256-payload"))
+	require.False(t, isS3StreamingPayloadMarker(""))
+}
+
+func TestCleanStoredContentEncoding(t *testing.T) {
+	cases := map[string]string{
+		"":                      "",
+		"aws-chunked":           "",
+		"AWS-CHUNKED":           "",
+		"gzip":                  "gzip",
+		"aws-chunked, gzip":     "gzip",
+		"gzip, aws-chunked":     "gzip",
+		"gzip,  aws-chunked ":   "gzip",
+		"identity":              "identity",
+		"aws-chunked, gzip, br": "gzip, br",
+	}
+	for in, want := range cases {
+		require.Equal(t, want, cleanStoredContentEncoding(in), "input %q", in)
+	}
+}

--- a/adapter/s3_chunked_test.go
+++ b/adapter/s3_chunked_test.go
@@ -248,10 +248,23 @@ func TestIsS3PayloadMarker(t *testing.T) {
 }
 
 func TestIsS3StreamingPayloadMarker(t *testing.T) {
+	// Only the unsigned streaming variant is accepted today; signed
+	// variants require chained chunk-signature verification that the
+	// decoder does not implement yet.
 	require.False(t, isS3StreamingPayloadMarker("UNSIGNED-PAYLOAD"))
 	require.True(t, isS3StreamingPayloadMarker("STREAMING-UNSIGNED-PAYLOAD-TRAILER"))
-	require.True(t, isS3StreamingPayloadMarker("streaming-aws4-hmac-sha256-payload"))
+	require.True(t, isS3StreamingPayloadMarker("streaming-unsigned-payload-trailer"))
+	require.False(t, isS3StreamingPayloadMarker("STREAMING-AWS4-HMAC-SHA256-PAYLOAD"))
+	require.False(t, isS3StreamingPayloadMarker("STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER"))
 	require.False(t, isS3StreamingPayloadMarker(""))
+}
+
+func TestIsS3SignedStreamingPayloadMarker(t *testing.T) {
+	require.True(t, isS3SignedStreamingPayloadMarker("STREAMING-AWS4-HMAC-SHA256-PAYLOAD"))
+	require.True(t, isS3SignedStreamingPayloadMarker("streaming-aws4-hmac-sha256-payload-trailer"))
+	require.False(t, isS3SignedStreamingPayloadMarker("STREAMING-UNSIGNED-PAYLOAD-TRAILER"))
+	require.False(t, isS3SignedStreamingPayloadMarker("UNSIGNED-PAYLOAD"))
+	require.False(t, isS3SignedStreamingPayloadMarker(""))
 }
 
 func TestCleanStoredContentEncoding(t *testing.T) {

--- a/adapter/s3_chunked_test.go
+++ b/adapter/s3_chunked_test.go
@@ -156,6 +156,31 @@ func TestAwsChunkedReader_TruncatedInput(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestAwsChunkedReader_TruncatedAtChunkBoundary covers the scenario the
+// gemini review flagged: the underlying reader hits EOF exactly at the end
+// of a data chunk (before the terminating 0-chunk). Without the
+// !r.finished guard the reader would happily return io.EOF and a caller
+// like io.ReadAll would treat the upload as complete.
+func TestAwsChunkedReader_TruncatedAtChunkBoundary(t *testing.T) {
+	// Valid first chunk followed by its CRLF, but the terminator chunk
+	// is missing.
+	body := "5\r\nhello\r\n"
+	r := newAwsChunkedReader(strings.NewReader(body), -1, 1<<20)
+	_, err := io.ReadAll(r)
+	require.Error(t, err, "must not silently accept truncation at a chunk boundary")
+}
+
+func TestAwsChunkedReader_OversizedLineRejectedWithoutUnboundedAlloc(t *testing.T) {
+	// Single line that never terminates with \n. ReadSlice must surface
+	// ErrBufferFull once the bufio buffer is saturated (8 KiB) instead of
+	// growing to accommodate the attacker-controlled input.
+	raw := strings.Repeat("A", s3ChunkedMaxLineLength*4)
+	r := newAwsChunkedReader(strings.NewReader(raw), -1, 1<<20)
+	_, err := io.ReadAll(r)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds")
+}
+
 func TestS3StreamingBody_VerifyTrailer_CRC32(t *testing.T) {
 	payload := []byte("Mary had a little lamb")
 	sum := crc32.NewIEEE()

--- a/adapter/s3_test.go
+++ b/adapter/s3_test.go
@@ -328,6 +328,36 @@ func TestS3Server_PutObjectStreamingWithTrailerChecksum(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "<Code>BadDigest</Code>")
 }
 
+// X-Amz-Trailer is formally a comma-separated list. The handler must pick
+// the first supported algorithm rather than treating the whole value as a
+// single header name (regression for gemini review on #544).
+func TestS3Server_PutObjectStreamingWithMultipleAdvertisedTrailers(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	rec := httptest.NewRecorder()
+	server.handle(rec, newS3TestRequest(http.MethodPut, "/bkt-multi-trailer", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	payload := []byte("multi-trailer body")
+	sum := crc32.NewIEEE()
+	_, _ = sum.Write(payload)
+	crc := base64.StdEncoding.EncodeToString(sum.Sum(nil))
+	body := encodeAwsChunked(t, payload, 6, "x-amz-checksum-crc32", crc)
+
+	rec = httptest.NewRecorder()
+	req := newS3TestRequest(http.MethodPut, "/bkt-multi-trailer/obj.bin", bytes.NewReader(body))
+	req.Header.Set("Content-Encoding", "aws-chunked")
+	req.Header.Set("X-Amz-Content-Sha256", s3StreamingUnsignedPayloadTrailer)
+	req.Header.Set("X-Amz-Decoded-Content-Length", strconv.Itoa(len(payload)))
+	// Advertise two trailers — only the first is one we support. The handler
+	// must still drive validation off x-amz-checksum-crc32.
+	req.Header.Set("X-Amz-Trailer", "x-amz-checksum-crc32, x-amz-checksum-sha256")
+	server.handle(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+}
+
 func TestS3Server_PutObjectStreamingRejectsBadDecodedLength(t *testing.T) {
 	t.Parallel()
 

--- a/adapter/s3_test.go
+++ b/adapter/s3_test.go
@@ -378,7 +378,110 @@ func TestS3Server_PutObjectStreamingRejectsBadDecodedLength(t *testing.T) {
 	// Lie about decoded size: client claims 5 but the chunks total 20.
 	req.Header.Set("X-Amz-Decoded-Content-Length", "5")
 	server.handle(rec, req)
-	require.NotEqual(t, http.StatusOK, rec.Code)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "<Code>InvalidRequest</Code>")
+}
+
+func TestS3Server_PutObjectStreamingRejectsSignedPayloadMarker(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	rec := httptest.NewRecorder()
+	server.handle(rec, newS3TestRequest(http.MethodPut, "/bkt-signed", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// STREAMING-AWS4-HMAC-SHA256-PAYLOAD requires chunk-signature=
+	// verification, which we don't implement. The server must not pretend
+	// the upload succeeded — clients would otherwise assume their signed
+	// integrity guarantee was honoured when it is not.
+	body := encodeSignedAwsChunked(t, []byte("irrelevant"), 4)
+	rec = httptest.NewRecorder()
+	req := newS3TestRequest(http.MethodPut, "/bkt-signed/obj.bin", bytes.NewReader(body))
+	req.Header.Set("Content-Encoding", "aws-chunked")
+	req.Header.Set("X-Amz-Content-Sha256", s3StreamingSignedPayload)
+	req.Header.Set("X-Amz-Decoded-Content-Length", "10")
+	server.handle(rec, req)
+	require.Equal(t, http.StatusNotImplemented, rec.Code)
+	require.Contains(t, rec.Body.String(), "<Code>NotImplemented</Code>")
+}
+
+func TestS3Server_PutObjectRejectsAwsChunkedWithoutStreamingMarker(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	rec := httptest.NewRecorder()
+	server.handle(rec, newS3TestRequest(http.MethodPut, "/bkt-mismatch", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// aws-chunked Content-Encoding without a streaming marker would make
+	// the server store the framed bytes as if they were the real payload,
+	// then cleanStoredContentEncoding would erase the only clue that the
+	// object is still encoded. Must be rejected.
+	rec = httptest.NewRecorder()
+	req := newS3TestRequest(http.MethodPut, "/bkt-mismatch/obj.bin",
+		bytes.NewReader([]byte("5\r\nhello\r\n0\r\n\r\n")))
+	req.Header.Set("Content-Encoding", "aws-chunked")
+	// Plain (non-sentinel) SHA256 that does NOT match the framed body.
+	req.Header.Set("X-Amz-Content-Sha256", sha256Hex("hello"))
+	server.handle(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "<Code>InvalidRequest</Code>")
+}
+
+// Multipart UploadPart must also honour aws-chunked framing — coderabbit
+// nit: the existing streaming integration tests only covered putObject.
+func TestS3Server_UploadPartStreamingWithTrailerChecksum(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+
+	rec := httptest.NewRecorder()
+	server.handle(rec, newS3TestRequest(http.MethodPut, "/bkt-part-stream", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Initiate multipart upload.
+	rec = httptest.NewRecorder()
+	server.handle(rec, newS3TestRequest(http.MethodPost, "/bkt-part-stream/blob.bin?uploads=", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	var init s3InitiateMultipartUploadResult
+	require.NoError(t, xml.Unmarshal(rec.Body.Bytes(), &init))
+	uploadID := init.UploadId
+
+	// Upload part via aws-chunked with a valid CRC32 trailer.
+	partPayload := bytes.Repeat([]byte("P"), 5*1024*1024) // 5 MiB -- minimum part size for non-last parts.
+	sum := crc32.NewIEEE()
+	_, _ = sum.Write(partPayload)
+	crc := base64.StdEncoding.EncodeToString(sum.Sum(nil))
+	body := encodeAwsChunked(t, partPayload, 64*1024, "x-amz-checksum-crc32", crc)
+
+	rec = httptest.NewRecorder()
+	req := newS3TestRequest(http.MethodPut,
+		fmt.Sprintf("/bkt-part-stream/blob.bin?uploadId=%s&partNumber=1", uploadID),
+		bytes.NewReader(body))
+	req.Header.Set("Content-Encoding", "aws-chunked")
+	req.Header.Set("X-Amz-Content-Sha256", s3StreamingUnsignedPayloadTrailer)
+	req.Header.Set("X-Amz-Decoded-Content-Length", strconv.Itoa(len(partPayload)))
+	req.Header.Set("X-Amz-Trailer", "x-amz-checksum-crc32")
+	server.handle(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	// Bad trailer must be rejected.
+	bodyBad := encodeAwsChunked(t, partPayload, 64*1024, "x-amz-checksum-crc32",
+		base64.StdEncoding.EncodeToString([]byte{0x00, 0x00, 0x00, 0x00}))
+	rec = httptest.NewRecorder()
+	req = newS3TestRequest(http.MethodPut,
+		fmt.Sprintf("/bkt-part-stream/blob.bin?uploadId=%s&partNumber=2", uploadID),
+		bytes.NewReader(bodyBad))
+	req.Header.Set("Content-Encoding", "aws-chunked")
+	req.Header.Set("X-Amz-Content-Sha256", s3StreamingUnsignedPayloadTrailer)
+	req.Header.Set("X-Amz-Decoded-Content-Length", strconv.Itoa(len(partPayload)))
+	req.Header.Set("X-Amz-Trailer", "x-amz-checksum-crc32")
+	server.handle(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "<Code>BadDigest</Code>")
 }
 
 func TestS3Server_ProxiesFollowerRequestsBeforeAuth(t *testing.T) {

--- a/adapter/s3_test.go
+++ b/adapter/s3_test.go
@@ -5,13 +5,16 @@ import (
 	"context"
 	"crypto/md5" //nolint:gosec // S3 ETag compatibility requires MD5.
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/xml"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -249,6 +252,103 @@ func TestS3Server_LeaderHealthz(t *testing.T) {
 	leaderSrv.handle(rec, newS3TestRequest(http.MethodPost, s3LeaderHealthPath, nil))
 	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
 	require.Equal(t, "GET, HEAD", rec.Header().Get("Allow"))
+}
+
+func TestS3Server_PutObjectStreamingUnsignedPayloadTrailer(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+
+	rec := httptest.NewRecorder()
+	server.handle(rec, newS3TestRequest(http.MethodPut, "/bkt-stream", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	payload := bytes.Repeat([]byte("X"), 1000)
+	body := encodeAwsChunked(t, payload, 137, "", "")
+
+	rec = httptest.NewRecorder()
+	req := newS3TestRequest(http.MethodPut, "/bkt-stream/streamed.bin", bytes.NewReader(body))
+	req.Header.Set("Content-Encoding", "aws-chunked")
+	req.Header.Set("X-Amz-Content-Sha256", s3StreamingUnsignedPayloadTrailer)
+	req.Header.Set("X-Amz-Decoded-Content-Length", "1000")
+	req.Header.Set("Content-Type", "application/octet-stream")
+	server.handle(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	// GET round-trip.
+	rec = httptest.NewRecorder()
+	server.handle(rec, newS3TestRequest(http.MethodGet, "/bkt-stream/streamed.bin", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, payload, rec.Body.Bytes())
+
+	// The stored Content-Encoding must not carry the transport-layer
+	// aws-chunked marker.
+	rec = httptest.NewRecorder()
+	server.handle(rec, newS3TestRequest(http.MethodHead, "/bkt-stream/streamed.bin", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotContains(t, rec.Header().Get("Content-Encoding"), "aws-chunked")
+}
+
+func TestS3Server_PutObjectStreamingWithTrailerChecksum(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	rec := httptest.NewRecorder()
+	server.handle(rec, newS3TestRequest(http.MethodPut, "/bkt-trailer", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	payload := []byte("trailer-me")
+	sum := crc32.NewIEEE()
+	_, _ = sum.Write(payload)
+	crc := base64.StdEncoding.EncodeToString(sum.Sum(nil))
+	body := encodeAwsChunked(t, payload, 4, "x-amz-checksum-crc32", crc)
+
+	rec = httptest.NewRecorder()
+	req := newS3TestRequest(http.MethodPut, "/bkt-trailer/ok.bin", bytes.NewReader(body))
+	req.Header.Set("Content-Encoding", "aws-chunked")
+	req.Header.Set("X-Amz-Content-Sha256", s3StreamingUnsignedPayloadTrailer)
+	req.Header.Set("X-Amz-Decoded-Content-Length", strconv.Itoa(len(payload)))
+	req.Header.Set("X-Amz-Trailer", "x-amz-checksum-crc32")
+	server.handle(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	// Corrupted trailer: server must reject.
+	bodyBad := encodeAwsChunked(t, payload, 4, "x-amz-checksum-crc32",
+		base64.StdEncoding.EncodeToString([]byte{0xDE, 0xAD, 0xBE, 0xEF}))
+	rec = httptest.NewRecorder()
+	req = newS3TestRequest(http.MethodPut, "/bkt-trailer/bad.bin", bytes.NewReader(bodyBad))
+	req.Header.Set("Content-Encoding", "aws-chunked")
+	req.Header.Set("X-Amz-Content-Sha256", s3StreamingUnsignedPayloadTrailer)
+	req.Header.Set("X-Amz-Decoded-Content-Length", strconv.Itoa(len(payload)))
+	req.Header.Set("X-Amz-Trailer", "x-amz-checksum-crc32")
+	server.handle(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "<Code>BadDigest</Code>")
+}
+
+func TestS3Server_PutObjectStreamingRejectsBadDecodedLength(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	rec := httptest.NewRecorder()
+	server.handle(rec, newS3TestRequest(http.MethodPut, "/bkt-badlen", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	payload := []byte("actual-length-is-20-")
+	require.Len(t, payload, 20)
+	body := encodeAwsChunked(t, payload, 9, "", "")
+
+	rec = httptest.NewRecorder()
+	req := newS3TestRequest(http.MethodPut, "/bkt-badlen/obj.bin", bytes.NewReader(body))
+	req.Header.Set("Content-Encoding", "aws-chunked")
+	req.Header.Set("X-Amz-Content-Sha256", s3StreamingUnsignedPayloadTrailer)
+	// Lie about decoded size: client claims 5 but the chunks total 20.
+	req.Header.Set("X-Amz-Decoded-Content-Length", "5")
+	server.handle(rec, req)
+	require.NotEqual(t, http.StatusOK, rec.Code)
 }
 
 func TestS3Server_ProxiesFollowerRequestsBeforeAuth(t *testing.T) {


### PR DESCRIPTION
## Summary
- Accept aws-chunked framed PUT / UploadPart bodies so aws-sdk-go-v2 default clients stop getting `XAmzContentSHA256Mismatch`.
- Recognise `STREAMING-UNSIGNED-PAYLOAD-TRAILER`, `STREAMING-AWS4-HMAC-SHA256-PAYLOAD`, and its `-TRAILER` sibling as payload sentinels (same skip-the-body-hash treatment as `UNSIGNED-PAYLOAD`).
- Optionally verify `x-amz-checksum-crc32` / `-crc32c` trailers when the client advertises them via `X-Amz-Trailer`; mismatch returns 400 `BadDigest`.
- Strip `aws-chunked` from the stored `Content-Encoding` so GET responses don't advertise a transport-only encoding.

## Why
aws-sdk-go-v2 ≥ ~v1.90 defaults to `Content-Encoding: aws-chunked` + `X-Amz-Content-Sha256: STREAMING-UNSIGNED-PAYLOAD-TRAILER` over HTTPS. Until now, butoGPT and every other consumer had to disable SDK streaming (`AWS_REQUEST_CHECKSUM_CALCULATION=when_required`) to upload anything to the Caddy-fronted `s3-elk.bootjp.dev`. Accepting the native format lets clients run with stock defaults.

## What's *not* verified (intentional, documented)
- Per-chunk `chunk-signature=` values: parsed and discarded. HTTPS + request-header SigV4 already protect transport, so matching AWS's strict validation would cost implementation time with little local benefit. A future PR can enforce it behind a flag.
- The optional trailer signature accompanying `STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER` is also ignored; the checksum trailer (`x-amz-checksum-*`) is the authoritative body integrity check.

## Security properties kept
- Per-chunk size is capped at 16 MiB so a malicious peer cannot force an unbounded allocation from a crafted hex size line.
- Decoded byte total is compared for strict equality against `X-Amz-Decoded-Content-Length` when declared.
- Raw transport is bounded by `MaxBytesReader` (decoded-max + 1 MiB framing overhead); decoded bytes are bounded independently inside the chunked reader.
- Truncated streams surface as `io.ErrUnexpectedEOF` wrapped in `awsChunkedError`, so the handler returns 400 `InvalidRequest` instead of silently committing a truncated object.

## Test plan
- [x] `go test ./adapter/... -count=1` (full suite, 40 s)
- [x] `golangci-lint run --config=.golangci.yaml ./adapter/...` → 0 issues
- [x] Unit tests cover: single chunk, multi-chunk, signed-chunk extensions ignored, trailer exposed, decoded-length mismatch (over + under), max-decoded cap, oversized chunk header, malformed hex size, missing CRLF, truncated stream.
- [x] Integration tests run `server.handle()` end-to-end with `encodeAwsChunked(...)` bodies: happy path, good CRC32 trailer, corrupted CRC32 trailer, lying `X-Amz-Decoded-Content-Length`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled streaming uploads with automatic checksum verification to ensure data integrity during transfer.
  * Improved request validation and error handling for chunked uploads with better detection of incomplete or malformed requests.
  * Enhanced protection against data corruption from streaming transfer failures.

* **Tests**
  * Added comprehensive test coverage for streaming upload scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->