### PR TITLE
perf(lua): incremental delta writes for ZSet in Lua scripts

### DIFF
--- a/adapter/redis_delta_compactor.go
+++ b/adapter/redis_delta_compactor.go
@@ -720,6 +720,38 @@ func (c *DeltaCompactor) zsetHandler() collectionDeltaHandler {
 	})
 }
 
+// foldSimpleLenDeltas folds deltaKVs and additionalDelta into a new base meta
+// element plus DEL operations for each consumed delta key. It is the shared core
+// used by both the background DeltaCompactor and the inline Lua compaction path.
+func foldSimpleLenDeltas(
+	deltaKVs []*store.KVPair,
+	additionalDelta int64,
+	baseLen int64,
+	metaKey []byte,
+	unmarshalDelta func([]byte) (int64, error),
+	marshalBase func(int64) []byte,
+) ([]*kv.Elem[kv.OP], error) {
+	var deltaSum int64
+	for _, d := range deltaKVs {
+		v, err := unmarshalDelta(d.Value)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		deltaSum += v
+	}
+	newLen := baseLen + deltaSum + additionalDelta
+	if newLen < 0 {
+		newLen = 0
+	}
+	metaElem := simpleMetaElemForLen(metaKey, newLen, marshalBase)
+	elems := make([]*kv.Elem[kv.OP], 0, 1+len(deltaKVs))
+	elems = append(elems, metaElem)
+	for _, d := range deltaKVs {
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: bytes.Clone(d.Key)})
+	}
+	return elems, nil
+}
+
 // buildSimpleCompactElems folds deltaKVs into a single base-meta update.
 // It is used by Hash, Set, and ZSet compaction, which all carry only a LenDelta.
 func (c *DeltaCompactor) buildSimpleCompactElems(
@@ -743,28 +775,54 @@ func (c *DeltaCompactor) buildSimpleCompactElems(
 			return nil, errors.WithStack(err)
 		}
 	}
+	return foldSimpleLenDeltas(deltaKVs, 0, baseLen, metaKey, unmarshalDelta, marshalBase)
+}
 
-	var deltaSum int64
-	for _, d := range deltaKVs {
-		v, unmarshalErr := unmarshalDelta(d.Value)
+// zsetInlineMetaCompactionThreshold is the number of existing ZSetMetaDeltaKey
+// entries at which an inline compaction is triggered during a Lua ZSet delta commit.
+// Aligned with defaultDeltaCompactorMaxDeltaCount so both paths compact at the same rate.
+const zsetInlineMetaCompactionThreshold = defaultDeltaCompactorMaxDeltaCount
+
+// zsetInlineMetaCompactionElems checks whether ZSetMetaDeltaKeys for key have
+// accumulated past the inline threshold. When they have, it returns elems that
+// fold them (together with additionalDelta) into a single base ZSetMetaKey and
+// deletes the old delta keys. Returns (nil, false, nil) when the threshold is not
+// met; the caller should write a new ZSetMetaDeltaKey instead.
+func (r *RedisServer) zsetInlineMetaCompactionElems(
+	ctx context.Context, key []byte, readTS uint64, additionalDelta int64,
+) ([]*kv.Elem[kv.OP], bool, error) {
+	prefix := store.ZSetMetaDeltaScanPrefix(key)
+	end := store.PrefixScanEnd(prefix)
+	// Scan threshold+1 to distinguish "exactly threshold" from "below threshold".
+	deltaKVs, err := r.store.ScanAt(ctx, prefix, end, zsetInlineMetaCompactionThreshold+1, readTS)
+	if err != nil {
+		return nil, false, errors.WithStack(err)
+	}
+	if len(deltaKVs) < zsetInlineMetaCompactionThreshold {
+		return nil, false, nil
+	}
+	raw, err := r.store.GetAt(ctx, store.ZSetMetaKey(key), readTS)
+	var baseLen int64
+	if err != nil && !errors.Is(err, store.ErrKeyNotFound) {
+		return nil, false, errors.WithStack(err)
+	}
+	if err == nil {
+		m, unmarshalErr := store.UnmarshalZSetMeta(raw)
 		if unmarshalErr != nil {
-			return nil, errors.WithStack(unmarshalErr)
+			return nil, false, errors.WithStack(unmarshalErr)
 		}
-		deltaSum += v
+		baseLen = m.Len
 	}
-
-	newLen := baseLen + deltaSum
-	if newLen < 0 {
-		newLen = 0
-	}
-
-	metaElem := simpleMetaElemForLen(metaKey, newLen, marshalBase)
-	elems := make([]*kv.Elem[kv.OP], 0, 1+len(deltaKVs))
-	elems = append(elems, metaElem)
-	for _, d := range deltaKVs {
-		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: bytes.Clone(d.Key)})
-	}
-	return elems, nil
+	elems, err := foldSimpleLenDeltas(
+		deltaKVs, additionalDelta, baseLen,
+		store.ZSetMetaKey(key),
+		func(b []byte) (int64, error) {
+			d, unmarshalErr := store.UnmarshalZSetMetaDelta(b)
+			return d.LenDelta, errors.WithStack(unmarshalErr)
+		},
+		func(n int64) []byte { return store.MarshalZSetMeta(store.ZSetMeta{Len: n}) },
+	)
+	return elems, true, err
 }
 
 // simpleMetaElemForLen returns a Put or Del elem for a Hash/Set/ZSet metadata key.

--- a/adapter/redis_delta_compactor.go
+++ b/adapter/redis_delta_compactor.go
@@ -780,8 +780,8 @@ func (c *DeltaCompactor) buildSimpleCompactElems(
 
 // zsetInlineMetaCompactionThreshold is the number of existing ZSetMetaDeltaKey
 // entries at which an inline compaction is triggered during a Lua ZSet delta commit.
-// Aligned with defaultDeltaCompactorMaxDeltaCount so both paths compact at the same rate.
-const zsetInlineMetaCompactionThreshold = defaultDeltaCompactorMaxDeltaCount
+// Set to MaxDeltaScanLimit so compaction fires just before reads would fail.
+const zsetInlineMetaCompactionThreshold = store.MaxDeltaScanLimit
 
 // zsetInlineMetaCompactionElems checks whether ZSetMetaDeltaKeys for key have
 // accumulated past the inline threshold. When they have, it returns elems that

--- a/adapter/redis_delta_compactor_test.go
+++ b/adapter/redis_delta_compactor_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bootjp/elastickv/kv"
 	"github.com/bootjp/elastickv/store"
 	"github.com/stretchr/testify/require"
 )
@@ -350,4 +351,71 @@ func TestDeltaCompactor_UrgentCompactionPagination(t *testing.T) {
 	remaining, err := st.ScanAt(ctx, prefix, end, int(totalDeltasU64)+1, readTS)
 	require.NoError(t, err)
 	require.Empty(t, remaining, "all delta keys must be deleted after urgent compaction")
+}
+
+// TestZSetInlineMetaCompaction verifies that zsetInlineMetaCompactionElems
+// returns nil when below the threshold, and folds delta keys into the base
+// ZSetMetaKey (deleting all scanned delta keys) when at or above the threshold.
+func TestZSetInlineMetaCompaction(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	coord := newLocalAdapterCoordinator(st)
+	r := &RedisServer{store: st, coordinator: coord}
+	userKey := []byte("inline:zset")
+
+	// Write a base meta key with Len=10.
+	require.NoError(t, st.PutAt(ctx, store.ZSetMetaKey(userKey),
+		store.MarshalZSetMeta(store.ZSetMeta{Len: 10}), 1, 0))
+
+	// Write (threshold - 1) delta keys: should NOT trigger compaction.
+	const threshold = zsetInlineMetaCompactionThreshold
+	delta := store.MarshalZSetMetaDelta(store.ZSetMetaDelta{LenDelta: 1})
+	for i := range threshold - 1 {
+		ts := uint64(10 + i) //nolint:gosec // i is bounded by threshold (1024)
+		require.NoError(t, st.PutAt(ctx, store.ZSetMetaDeltaKey(userKey, ts, 0), delta, ts, 0))
+	}
+
+	readTS := st.LastCommitTS()
+	elems, compacted, err := r.zsetInlineMetaCompactionElems(ctx, userKey, readTS, 0)
+	require.NoError(t, err)
+	require.False(t, compacted, "below threshold: should not compact")
+	require.Nil(t, elems)
+
+	// Write one more delta key to reach the threshold.
+	const lastTS = uint64(10 + threshold - 1)
+	require.NoError(t, st.PutAt(ctx, store.ZSetMetaDeltaKey(userKey, lastTS, 0), delta, lastTS, 0))
+
+	readTS = st.LastCommitTS()
+	elems, compacted, err = r.zsetInlineMetaCompactionElems(ctx, userKey, readTS, 2)
+	require.NoError(t, err)
+	require.True(t, compacted, "at threshold: should compact")
+	// Expected new Len = base(10) + threshold deltas(each +1) + additionalDelta(2)
+	expectedLen := int64(10+threshold) + 2
+
+	// Dispatch the compaction elems.
+	commitTS := coord.Clock().Next()
+	_, dispatchErr := coord.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+		IsTxn:    true,
+		StartTS:  0,
+		CommitTS: commitTS,
+		Elems:    elems,
+	})
+	require.NoError(t, dispatchErr)
+
+	// Verify base meta holds the folded total.
+	afterTS := st.LastCommitTS()
+	raw, err := st.GetAt(ctx, store.ZSetMetaKey(userKey), afterTS)
+	require.NoError(t, err)
+	got, err := store.UnmarshalZSetMeta(raw)
+	require.NoError(t, err)
+	require.Equal(t, expectedLen, got.Len)
+
+	// All delta keys must be deleted.
+	prefix := store.ZSetMetaDeltaScanPrefix(userKey)
+	scanEnd := store.PrefixScanEnd(prefix)
+	remaining, err := st.ScanAt(ctx, prefix, scanEnd, threshold+1, afterTS)
+	require.NoError(t, err)
+	require.Empty(t, remaining, "all delta keys must be removed after inline compaction")
 }

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -80,6 +80,11 @@ type luaZSetState struct {
 	storageScores  map[string]*float64 // original scores from Pebble (nil ptr = absent)
 	removed        map[string]struct{} // members explicitly removed in this script
 	lenDelta       int64               // net cardinality change (for delta commit)
+
+	// resolvedBaseCard caches the result of resolveZSetMeta (storage-level cardinality)
+	// so ZCARD does not re-scan delta keys on every call within the same script.
+	resolvedBaseCard       int64
+	resolvedBaseCardCached bool
 }
 
 type luaStreamState struct {
@@ -127,6 +132,12 @@ const (
 	zsetWithScoresArgIndex = 3
 	xAddMinArgs            = 3
 	xTrimMinArgs           = 4
+
+	// Element counts for ZSet commit slice pre-allocation.
+	zsetElemsPerMember  = 2 // PUT member key + PUT score index key
+	zsetMetaBaseElems   = 1 // PUT or DEL ZSetMetaKey
+	zsetElemsPerAdded   = 3 // optional DEL stale score key + PUT member key + PUT score key
+	zsetElemsPerRemoved = 2 // DEL member key + DEL score key
 )
 
 type luaCommandHandler func(*luaScriptContext, []string) (luaReply, error)
@@ -760,7 +771,8 @@ func (c *luaScriptContext) memberScoreFromPebble(st *luaZSetState, key []byte, m
 
 // zsetCard returns the ZSet cardinality. When members are fully loaded it uses
 // len(st.members); otherwise it reads the base metadata from storage and adds
-// the in-script lenDelta, which is O(log N).
+// the in-script lenDelta, which is O(log N). The storage-level result is cached
+// in st so repeated ZCARD calls within the same script do not re-scan delta keys.
 func (c *luaScriptContext) zsetCard(st *luaZSetState, key []byte) (int64, error) {
 	if st.membersLoaded {
 		return int64(len(st.members)), nil
@@ -768,11 +780,15 @@ func (c *luaScriptContext) zsetCard(st *luaZSetState, key []byte) (int64, error)
 	if !st.exists {
 		return 0, nil
 	}
-	baseLen, _, err := c.server.resolveZSetMeta(context.Background(), key, c.startTS)
-	if err != nil {
-		return 0, err
+	if !st.resolvedBaseCardCached {
+		baseLen, _, err := c.server.resolveZSetMeta(context.Background(), key, c.startTS)
+		if err != nil {
+			return 0, err
+		}
+		st.resolvedBaseCard = baseLen
+		st.resolvedBaseCardCached = true
 	}
-	return baseLen + st.lenDelta, nil
+	return st.resolvedBaseCard + st.lenDelta, nil
 }
 
 // zsetStateForRead returns a fully-loaded ZSet state for commands that need the
@@ -2049,39 +2065,47 @@ func (c *luaScriptContext) cmdZAdd(args []string) (luaReply, error) {
 	if err != nil {
 		return luaReply{}, err
 	}
-	if !st.exists {
-		st.exists = true
-	}
 	added := 0
+	changed := false
 	for j := 0; j < len(pairs); j += 2 {
 		score, err := strconv.ParseFloat(pairs[j], 64)
 		if err != nil {
 			return luaReply{}, errors.WithStack(err)
 		}
-		isNew, err := c.applyZAddMember(st, key, flags, pairs[j+1], score)
+		isNew, mutated, err := c.applyZAddMember(st, key, flags, pairs[j+1], score)
 		if err != nil {
 			return luaReply{}, err
 		}
 		if isNew {
 			added++
 		}
+		if mutated {
+			changed = true
+		}
 	}
-	st.loaded = true
-	st.dirty = true
-	c.markTouched(key)
-	c.deleted[args[0]] = false
+	if changed {
+		if !st.exists {
+			st.exists = true
+		}
+		st.loaded = true
+		st.dirty = true
+		c.markTouched(key)
+		c.deleted[args[0]] = false
+	}
 	return luaIntReply(int64(added)), nil
 }
 
 // applyZAddMember applies a single ZADD member/score pair, updating the delta or
-// the full members map depending on load state. Returns true if the member is new.
-func (c *luaScriptContext) applyZAddMember(st *luaZSetState, key []byte, flags zaddFlags, member string, score float64) (bool, error) {
+// the full members map depending on load state. Returns (isNew, mutated, err):
+// isNew is true when the member did not previously exist; mutated is true when
+// any write was performed (false when flags like NX/XX prevented the operation).
+func (c *luaScriptContext) applyZAddMember(st *luaZSetState, key []byte, flags zaddFlags, member string, score float64) (bool, bool, error) {
 	oldScore, exists, err := c.memberScore(st, key, member)
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 	if !flags.allows(exists, oldScore, score) {
-		return false, nil
+		return false, false, nil
 	}
 	isNew := !exists
 	if isNew && !st.membersLoaded {
@@ -2095,7 +2119,7 @@ func (c *luaScriptContext) applyZAddMember(st *luaZSetState, key []byte, flags z
 	} else {
 		st.added[member] = score
 	}
-	return isNew, nil
+	return isNew, true, nil
 }
 
 func (c *luaScriptContext) cmdZCard(args []string) (luaReply, error) {
@@ -2970,7 +2994,7 @@ func (c *luaScriptContext) zsetCommitPlan(key string, commitTS uint64) (luaCommi
 		return luaCommitPlan{preserveExisting: true}, nil
 	}
 	if c.everDeleted[key] || st.membersLoaded {
-		return luaCommitPlan{elems: c.zsetFullCommitElems(key)}, nil // preserveExisting=false → deleteLogicalKeyElems called
+		return c.zsetFullCommitWithMerge(key, st), nil
 	}
 	if st.legacyBlobBase {
 		// One-time migration: load legacy blob, write wide-column, let deleteLogicalKeyElems clean up.
@@ -2983,6 +3007,23 @@ func (c *luaScriptContext) zsetCommitPlan(key string, commitTS uint64) (luaCommi
 	return luaCommitPlan{preserveExisting: true, elems: c.zsetDeltaCommitElems(key, st, commitTS)}, nil
 }
 
+// zsetFullCommitWithMerge returns a full wide-column commit plan for key. When
+// the key was deleted during the script but delta members were added afterwards
+// (membersLoaded=false), st.added is merged into st.members so that
+// zsetFullCommitElems does not silently drop the newly added entries.
+func (c *luaScriptContext) zsetFullCommitWithMerge(key string, st *luaZSetState) luaCommitPlan {
+	if !st.membersLoaded && len(st.added) > 0 {
+		if st.members == nil {
+			st.members = make(map[string]float64, len(st.added))
+		}
+		for m, s := range st.added {
+			st.members[m] = s
+		}
+		st.added = map[string]float64{}
+	}
+	return luaCommitPlan{elems: c.zsetFullCommitElems(key)} // preserveExisting=false → deleteLogicalKeyElems called
+}
+
 // zsetFullCommitElems writes all members in wide-column format (member keys,
 // score index keys, and a base meta key). deleteLogicalKeyElems is responsible
 // for cleaning up any previous storage before these ops are applied.
@@ -2991,7 +3032,7 @@ func (c *luaScriptContext) zsetFullCommitElems(key string) []*kv.Elem[kv.OP] {
 	if st == nil || len(st.members) == 0 {
 		return nil
 	}
-	elems := make([]*kv.Elem[kv.OP], 0, len(st.members)*2+1) //nolint:mnd // 2 per member (member+score key) + 1 meta
+	elems := make([]*kv.Elem[kv.OP], 0, len(st.members)*zsetElemsPerMember+zsetMetaBaseElems)
 	for member, score := range st.members {
 		elems = append(elems,
 			&kv.Elem[kv.OP]{
@@ -3024,7 +3065,7 @@ func (c *luaScriptContext) zsetDeltaCommitElems(key string, st *luaZSetState, co
 	// Each added member: optionally DEL old score key + PUT member key + PUT score key.
 	// Each removed member: DEL member key + DEL score key.
 	// Plus one optional ZSetMetaDeltaKey.
-	elems := make([]*kv.Elem[kv.OP], 0, len(st.added)*3+len(st.removed)*2+1) //nolint:mnd
+	elems := make([]*kv.Elem[kv.OP], 0, len(st.added)*zsetElemsPerAdded+len(st.removed)*zsetElemsPerRemoved+zsetMetaBaseElems)
 	for member, score := range st.added {
 		if storageScore, ok := st.storageScores[member]; ok && storageScore != nil {
 			// Remove stale score index from storage.
@@ -3056,14 +3097,27 @@ func (c *luaScriptContext) zsetDeltaCommitElems(key string, st *luaZSetState, co
 			&kv.Elem[kv.OP]{Op: kv.Del, Key: store.ZSetScoreKey([]byte(key), *storageScore, []byte(member))},
 		)
 	}
-	if st.lenDelta != 0 {
-		elems = append(elems, &kv.Elem[kv.OP]{
-			Op:    kv.Put,
-			Key:   store.ZSetMetaDeltaKey([]byte(key), commitTS, 0),
-			Value: store.MarshalZSetMetaDelta(store.ZSetMetaDelta{LenDelta: st.lenDelta}),
-		})
-	}
+	elems = append(elems, c.zsetDeltaMetaElems([]byte(key), st, commitTS)...)
 	return elems
+}
+
+// zsetDeltaMetaElems returns the metadata element(s) for a delta commit.
+// It tries to fold existing delta keys inline (compaction); on error or when
+// below the threshold it falls back to writing a single new ZSetMetaDeltaKey.
+func (c *luaScriptContext) zsetDeltaMetaElems(key []byte, st *luaZSetState, commitTS uint64) []*kv.Elem[kv.OP] {
+	compactElems, compacted, err := c.server.zsetInlineMetaCompactionElems(
+		context.Background(), key, c.startTS, st.lenDelta)
+	if err == nil && compacted {
+		return compactElems
+	}
+	if st.lenDelta == 0 {
+		return nil
+	}
+	return []*kv.Elem[kv.OP]{{
+		Op:    kv.Put,
+		Key:   store.ZSetMetaDeltaKey(key, commitTS, 0),
+		Value: store.MarshalZSetMetaDelta(store.ZSetMetaDelta{LenDelta: st.lenDelta}),
+	}}
 }
 
 func (c *luaScriptContext) streamCommitElems(key string) ([]*kv.Elem[kv.OP], error) {

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -676,7 +676,17 @@ func (c *luaScriptContext) zsetState(key []byte) (*luaZSetState, error) {
 	}
 	st.loaded = true
 	st.exists = true
-	st.legacyBlobBase = len(kvs) == 0
+	if len(kvs) > 0 {
+		return st, nil
+	}
+	// No !zs|mem| rows does not imply legacy-blob: a wide-column ZSet that had
+	// all members deleted leaves only meta/delta keys behind. Probe the legacy
+	// blob key directly to distinguish these cases.
+	blobExists, err := c.server.store.ExistsAt(context.Background(), redisZSetKey(key), c.startTS)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	st.legacyBlobBase = blobExists
 	return st, nil
 }
 

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -773,12 +773,20 @@ func (c *luaScriptContext) memberScoreFromPebble(st *luaZSetState, key []byte, m
 // len(st.members); otherwise it reads the base metadata from storage and adds
 // the in-script lenDelta, which is O(log N). The storage-level result is cached
 // in st so repeated ZCARD calls within the same script do not re-scan delta keys.
+// For legacy-blob ZSets there is no wide-column ZSetMetaKey, so resolveZSetMeta
+// would return 0; ensureZSetLoaded is used instead to get the real count.
 func (c *luaScriptContext) zsetCard(st *luaZSetState, key []byte) (int64, error) {
 	if st.membersLoaded {
 		return int64(len(st.members)), nil
 	}
 	if !st.exists {
 		return 0, nil
+	}
+	if st.legacyBlobBase {
+		if err := c.ensureZSetLoaded(st, key); err != nil {
+			return 0, err
+		}
+		return int64(len(st.members)), nil
 	}
 	if !st.resolvedBaseCardCached {
 		baseLen, _, err := c.server.resolveZSetMeta(context.Background(), key, c.startTS)

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -70,10 +70,16 @@ type luaSetState struct {
 }
 
 type luaZSetState struct {
-	loaded  bool
-	exists  bool
-	dirty   bool
-	members map[string]float64
+	loaded         bool
+	exists         bool
+	dirty          bool
+	membersLoaded  bool                // all members loaded into st.members
+	legacyBlobBase bool                // existing data is in legacy blob format
+	members        map[string]float64  // full member map (only when membersLoaded=true)
+	added          map[string]float64  // members added/updated in this script (delta)
+	storageScores  map[string]*float64 // original scores from Pebble (nil ptr = absent)
+	removed        map[string]struct{} // members explicitly removed in this script
+	lenDelta       int64               // net cardinality change (for delta commit)
 }
 
 type luaStreamState struct {
@@ -320,7 +326,12 @@ func (c *luaScriptContext) deleteLogical(key []byte) {
 		st.loaded = true
 		st.exists = false
 		st.dirty = true
+		st.membersLoaded = true
 		st.members = map[string]float64{}
+		st.added = map[string]float64{}
+		st.removed = map[string]struct{}{}
+		st.storageScores = map[string]*float64{}
+		st.lenDelta = 0
 	}
 	if st, ok := c.streams[k]; ok {
 		st.loaded = true
@@ -623,13 +634,16 @@ func (c *luaScriptContext) zsetState(key []byte) (*luaZSetState, error) {
 	if st, ok := c.zsets[k]; ok {
 		return st, nil
 	}
-	st := &luaZSetState{}
+	st := &luaZSetState{
+		added:         map[string]float64{},
+		removed:       map[string]struct{}{},
+		storageScores: map[string]*float64{},
+	}
 	c.zsets[k] = st
 
 	typ, err := c.keyType(key)
 	if errors.Is(err, store.ErrKeyNotFound) {
 		st.loaded = true
-		st.members = map[string]float64{}
 		return st, nil
 	}
 	if err != nil {
@@ -637,21 +651,148 @@ func (c *luaScriptContext) zsetState(key []byte) (*luaZSetState, error) {
 	}
 	if typ == redisTypeNone {
 		st.loaded = true
-		st.members = map[string]float64{}
 		return st, nil
 	}
 	if typ != redisTypeZSet {
 		return nil, wrongTypeError()
 	}
 
-	value, _, err := c.server.loadZSetAt(context.Background(), key, c.startTS)
+	// Probe for wide-column format with a single seek instead of a full scan.
+	prefix := store.ZSetMemberScanPrefix(key)
+	kvs, err := c.server.store.ScanAt(context.Background(), prefix, store.PrefixScanEnd(prefix), 1, c.startTS)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	st.loaded = true
 	st.exists = true
-	st.members = zsetEntriesToMap(value.Entries)
+	st.legacyBlobBase = len(kvs) == 0
 	return st, nil
+}
+
+// ensureZSetLoaded loads all ZSet members from storage if not already loaded,
+// merging any in-script delta (added/removed) into st.members.
+func (c *luaScriptContext) ensureZSetLoaded(st *luaZSetState, key []byte) error {
+	if st.membersLoaded {
+		return nil
+	}
+	members := map[string]float64{}
+	if st.exists {
+		value, _, err := c.server.loadZSetAt(context.Background(), key, c.startTS)
+		if err != nil {
+			return err
+		}
+		members = zsetEntriesToMap(value.Entries)
+	}
+	for member := range st.removed {
+		delete(members, member)
+	}
+	for member, score := range st.added {
+		members[member] = score
+	}
+	st.members = members
+	st.membersLoaded = true
+	return nil
+}
+
+// memberScore returns the current score of a ZSet member, preferring in-script
+// state over Pebble. For wide-column ZSets it performs an O(log N) point lookup
+// instead of loading the entire collection.
+func (c *luaScriptContext) memberScore(st *luaZSetState, key []byte, member string) (float64, bool, error) {
+	if st.membersLoaded {
+		score, ok := st.members[member]
+		return score, ok, nil
+	}
+	if score, ok, handled := zsetDeltaScore(st, member); handled {
+		return score, ok, nil
+	}
+	return c.memberScoreFromPebble(st, key, member)
+}
+
+// zsetDeltaScore checks the in-script delta state (removed/added/storageScores cache)
+// for a member. Returns (score, exists, handled); handled=false means the caller
+// must fall through to a Pebble point lookup.
+func zsetDeltaScore(st *luaZSetState, member string) (float64, bool, bool) {
+	if _, removed := st.removed[member]; removed {
+		return 0, false, true
+	}
+	if score, ok := st.added[member]; ok {
+		return score, true, true
+	}
+	if cached, ok := st.storageScores[member]; ok {
+		if cached == nil {
+			return 0, false, true
+		}
+		return *cached, true, true
+	}
+	return 0, false, false
+}
+
+// memberScoreFromPebble resolves a member score from Pebble storage.
+// For legacy-blob ZSets it triggers a full load; for wide-column it does an
+// O(log N) point lookup and caches the result in st.storageScores.
+func (c *luaScriptContext) memberScoreFromPebble(st *luaZSetState, key []byte, member string) (float64, bool, error) {
+	if !st.exists {
+		st.storageScores[member] = nil
+		return 0, false, nil
+	}
+	if st.legacyBlobBase {
+		if err := c.ensureZSetLoaded(st, key); err != nil {
+			return 0, false, err
+		}
+		score, ok := st.members[member]
+		return score, ok, nil
+	}
+	raw, err := c.server.store.GetAt(context.Background(), store.ZSetMemberKey(key, []byte(member)), c.startTS)
+	if errors.Is(err, store.ErrKeyNotFound) {
+		st.storageScores[member] = nil
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, errors.WithStack(err)
+	}
+	score, err := store.UnmarshalZSetScore(raw)
+	if err != nil {
+		return 0, false, errors.WithStack(err)
+	}
+	st.storageScores[member] = &score
+	return score, true, nil
+}
+
+// zsetCard returns the ZSet cardinality. When members are fully loaded it uses
+// len(st.members); otherwise it reads the base metadata from storage and adds
+// the in-script lenDelta, which is O(log N).
+func (c *luaScriptContext) zsetCard(st *luaZSetState, key []byte) (int64, error) {
+	if st.membersLoaded {
+		return int64(len(st.members)), nil
+	}
+	if !st.exists {
+		return 0, nil
+	}
+	baseLen, _, err := c.server.resolveZSetMeta(context.Background(), key, c.startTS)
+	if err != nil {
+		return 0, err
+	}
+	return baseLen + st.lenDelta, nil
+}
+
+// zsetStateForRead returns a fully-loaded ZSet state for commands that need the
+// complete member set (ZRANGE, ZCOUNT, ZPOPMIN, etc.). Returns (nil, false, nil)
+// when the key does not exist.
+func (c *luaScriptContext) zsetStateForRead(key []byte) (*luaZSetState, bool, error) {
+	st, err := c.zsetState(key)
+	if err != nil {
+		if errors.Is(err, store.ErrKeyNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	if !st.exists {
+		return st, false, nil
+	}
+	if err := c.ensureZSetLoaded(st, key); err != nil {
+		return nil, false, err
+	}
+	return st, true, nil
 }
 
 func (c *luaScriptContext) streamState(key []byte) (*luaStreamState, error) {
@@ -760,7 +901,12 @@ func (c *luaScriptContext) markZSetValue(key []byte, members map[string]float64)
 	st.loaded = true
 	st.exists = true
 	st.dirty = true
+	st.membersLoaded = true
 	st.members = maps.Clone(members)
+	st.added = map[string]float64{}
+	st.removed = map[string]struct{}{}
+	st.storageScores = map[string]*float64{}
+	st.lenDelta = 0
 	c.markTouched(key)
 	c.deleted[string(key)] = false
 	return nil
@@ -1131,6 +1277,9 @@ func (c *luaScriptContext) renameSetValue(src, dst []byte) error {
 func (c *luaScriptContext) renameZSetValue(src, dst []byte) error {
 	st, err := c.zsetState(src)
 	if err != nil {
+		return err
+	}
+	if err := c.ensureZSetLoaded(st, src); err != nil {
 		return err
 	}
 	c.deleteLogical(dst)
@@ -1895,13 +2044,13 @@ func (c *luaScriptContext) cmdZAdd(args []string) (luaReply, error) {
 	if err != nil {
 		return luaReply{}, err
 	}
-	st, err := c.zsetState([]byte(args[0]))
+	key := []byte(args[0])
+	st, err := c.zsetState(key)
 	if err != nil {
 		return luaReply{}, err
 	}
 	if !st.exists {
 		st.exists = true
-		st.members = map[string]float64{}
 	}
 	added := 0
 	for j := 0; j < len(pairs); j += 2 {
@@ -1909,25 +2058,49 @@ func (c *luaScriptContext) cmdZAdd(args []string) (luaReply, error) {
 		if err != nil {
 			return luaReply{}, errors.WithStack(err)
 		}
-		member := pairs[j+1]
-		oldScore, exists := st.members[member]
-		if !flags.allows(exists, oldScore, score) {
-			continue
+		isNew, err := c.applyZAddMember(st, key, flags, pairs[j+1], score)
+		if err != nil {
+			return luaReply{}, err
 		}
-		if !exists {
+		if isNew {
 			added++
 		}
-		st.members[member] = score
 	}
 	st.loaded = true
 	st.dirty = true
-	c.markTouched([]byte(args[0]))
+	c.markTouched(key)
 	c.deleted[args[0]] = false
 	return luaIntReply(int64(added)), nil
 }
 
+// applyZAddMember applies a single ZADD member/score pair, updating the delta or
+// the full members map depending on load state. Returns true if the member is new.
+func (c *luaScriptContext) applyZAddMember(st *luaZSetState, key []byte, flags zaddFlags, member string, score float64) (bool, error) {
+	oldScore, exists, err := c.memberScore(st, key, member)
+	if err != nil {
+		return false, err
+	}
+	if !flags.allows(exists, oldScore, score) {
+		return false, nil
+	}
+	isNew := !exists
+	if isNew && !st.membersLoaded {
+		st.lenDelta++
+	}
+	if st.membersLoaded {
+		if st.members == nil {
+			st.members = map[string]float64{}
+		}
+		st.members[member] = score
+	} else {
+		st.added[member] = score
+	}
+	return isNew, nil
+}
+
 func (c *luaScriptContext) cmdZCard(args []string) (luaReply, error) {
-	st, err := c.zsetState([]byte(args[0]))
+	key := []byte(args[0])
+	st, err := c.zsetState(key)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
 			return luaIntReply(0), nil
@@ -1937,11 +2110,16 @@ func (c *luaScriptContext) cmdZCard(args []string) (luaReply, error) {
 	if !st.exists {
 		return luaIntReply(0), nil
 	}
-	return luaIntReply(int64(len(st.members))), nil
+	n, err := c.zsetCard(st, key)
+	if err != nil {
+		return luaReply{}, err
+	}
+	return luaIntReply(n), nil
 }
 
 func (c *luaScriptContext) cmdZCount(args []string) (luaReply, error) {
-	st, err := c.zsetState([]byte(args[0]))
+	key := []byte(args[0])
+	st, err := c.zsetState(key)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
 			return luaIntReply(0), nil
@@ -1950,6 +2128,9 @@ func (c *luaScriptContext) cmdZCount(args []string) (luaReply, error) {
 	}
 	if !st.exists {
 		return luaIntReply(0), nil
+	}
+	if err := c.ensureZSetLoaded(st, key); err != nil {
+		return luaReply{}, err
 	}
 	minBound, err := parseZScoreBound(args[1])
 	if err != nil {
@@ -1985,7 +2166,8 @@ func (c *luaScriptContext) cmdZRevRangeByScore(args []string) (luaReply, error) 
 }
 
 func (c *luaScriptContext) rangeByRank(args []string, reverse bool) (luaReply, error) {
-	st, err := c.zsetState([]byte(args[0]))
+	key := []byte(args[0])
+	st, err := c.zsetState(key)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
 			return luaArrayReply(), nil
@@ -1994,6 +2176,9 @@ func (c *luaScriptContext) rangeByRank(args []string, reverse bool) (luaReply, e
 	}
 	if !st.exists {
 		return luaArrayReply(), nil
+	}
+	if err := c.ensureZSetLoaded(st, key); err != nil {
+		return luaReply{}, err
 	}
 	start, err := strconv.Atoi(args[1])
 	if err != nil {
@@ -2016,7 +2201,8 @@ func (c *luaScriptContext) rangeByRank(args []string, reverse bool) (luaReply, e
 }
 
 func (c *luaScriptContext) cmdZRangeByScore(args []string, reverse bool) (luaReply, error) {
-	st, err := c.zsetState([]byte(args[0]))
+	key := []byte(args[0])
+	st, err := c.zsetState(key)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
 			return luaArrayReply(), nil
@@ -2025,6 +2211,9 @@ func (c *luaScriptContext) cmdZRangeByScore(args []string, reverse bool) (luaRep
 	}
 	if !st.exists {
 		return luaArrayReply(), nil
+	}
+	if err := c.ensureZSetLoaded(st, key); err != nil {
+		return luaReply{}, err
 	}
 
 	options, err := parseZRangeByScoreOptions(args, reverse)
@@ -2136,7 +2325,8 @@ func applyZRangeLimit(entries []redisZSetEntry, offset, limit int) []redisZSetEn
 }
 
 func (c *luaScriptContext) cmdZScore(args []string) (luaReply, error) {
-	st, err := c.zsetState([]byte(args[0]))
+	key := []byte(args[0])
+	st, err := c.zsetState(key)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
 			return luaNilReply(), nil
@@ -2146,7 +2336,10 @@ func (c *luaScriptContext) cmdZScore(args []string) (luaReply, error) {
 	if !st.exists {
 		return luaNilReply(), nil
 	}
-	score, ok := st.members[args[1]]
+	score, ok, err := c.memberScore(st, key, args[1])
+	if err != nil {
+		return luaReply{}, err
+	}
 	if !ok {
 		return luaNilReply(), nil
 	}
@@ -2154,7 +2347,8 @@ func (c *luaScriptContext) cmdZScore(args []string) (luaReply, error) {
 }
 
 func (c *luaScriptContext) cmdZRem(args []string) (luaReply, error) {
-	st, err := c.zsetState([]byte(args[0]))
+	key := []byte(args[0])
+	st, err := c.zsetState(key)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
 			return luaIntReply(0), nil
@@ -2163,6 +2357,9 @@ func (c *luaScriptContext) cmdZRem(args []string) (luaReply, error) {
 	}
 	if !st.exists {
 		return luaIntReply(0), nil
+	}
+	if err := c.ensureZSetLoaded(st, key); err != nil {
+		return luaReply{}, err
 	}
 	removed := removeMembers(st.members, args[1:])
 	finalizeSetLikeRemoval(c, args[0], removed, len(st.members) == 0, func() {
@@ -2174,14 +2371,12 @@ func (c *luaScriptContext) cmdZRem(args []string) (luaReply, error) {
 }
 
 func (c *luaScriptContext) cmdZPopMin(args []string) (luaReply, error) {
-	st, err := c.zsetState([]byte(args[0]))
+	key := []byte(args[0])
+	st, exists, err := c.zsetStateForRead(key)
 	if err != nil {
-		if errors.Is(err, store.ErrKeyNotFound) {
-			return luaArrayReply(), nil
-		}
-		return luaReply{}, err
+		return luaArrayReply(), err
 	}
-	if !st.exists {
+	if !exists {
 		return luaArrayReply(), nil
 	}
 	count := 1
@@ -2215,7 +2410,8 @@ func (c *luaScriptContext) cmdZPopMin(args []string) (luaReply, error) {
 }
 
 func (c *luaScriptContext) cmdZRemRangeByRank(args []string) (luaReply, error) {
-	st, err := c.zsetState([]byte(args[0]))
+	key := []byte(args[0])
+	st, err := c.zsetState(key)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
 			return luaIntReply(0), nil
@@ -2224,6 +2420,9 @@ func (c *luaScriptContext) cmdZRemRangeByRank(args []string) (luaReply, error) {
 	}
 	if !st.exists {
 		return luaIntReply(0), nil
+	}
+	if err := c.ensureZSetLoaded(st, key); err != nil {
+		return luaReply{}, err
 	}
 	start, err := strconv.Atoi(args[1])
 	if err != nil {
@@ -2255,14 +2454,12 @@ func (c *luaScriptContext) cmdZRemRangeByRank(args []string) (luaReply, error) {
 }
 
 func (c *luaScriptContext) cmdZRemRangeByScore(args []string) (luaReply, error) {
-	st, err := c.zsetState([]byte(args[0]))
+	key := []byte(args[0])
+	st, exists, err := c.zsetStateForRead(key)
 	if err != nil {
-		if errors.Is(err, store.ErrKeyNotFound) {
-			return luaIntReply(0), nil
-		}
-		return luaReply{}, err
+		return luaIntReply(0), err
 	}
-	if !st.exists {
+	if !exists {
 		return luaIntReply(0), nil
 	}
 	minBound, err := parseZScoreBound(args[1])
@@ -2560,8 +2757,7 @@ func (c *luaScriptContext) valueCommitPlan(key string, finalType redisValueType,
 		elems, err := c.setCommitElems(key)
 		return luaCommitPlan{elems: elems}, err
 	case redisTypeZSet:
-		elems, err := c.zsetCommitElems(key)
-		return luaCommitPlan{elems: elems}, err
+		return c.zsetCommitPlan(key, commitTS)
 	case redisTypeStream:
 		elems, err := c.streamCommitElems(key)
 		return luaCommitPlan{elems: elems}, err
@@ -2763,16 +2959,111 @@ func (c *luaScriptContext) setCommitElems(key string) ([]*kv.Elem[kv.OP], error)
 	return elems, nil
 }
 
-func (c *luaScriptContext) zsetCommitElems(key string) ([]*kv.Elem[kv.OP], error) {
-	st, err := c.zsetState([]byte(key))
-	if err != nil {
-		return nil, err
+// zsetCommitPlan decides between a full wide-column rewrite and an incremental
+// delta commit. Full rewrite is used when the key was ever deleted, when members
+// are fully loaded (triggered by any read command), or when the base data was in
+// legacy blob format (one-time migration). Delta commit is used for write-only
+// scripts (typically ZADD without prior reads) on an already-wide-column ZSet.
+func (c *luaScriptContext) zsetCommitPlan(key string, commitTS uint64) (luaCommitPlan, error) {
+	st := c.zsets[key]
+	if st == nil || !st.dirty {
+		return luaCommitPlan{preserveExisting: true}, nil
 	}
-	payload, err := marshalZSetValue(redisZSetValue{Entries: zsetMapToEntries(st.members)})
-	if err != nil {
-		return nil, err
+	if c.everDeleted[key] || st.membersLoaded {
+		return luaCommitPlan{elems: c.zsetFullCommitElems(key)}, nil // preserveExisting=false → deleteLogicalKeyElems called
 	}
-	return []*kv.Elem[kv.OP]{{Op: kv.Put, Key: redisZSetKey([]byte(key)), Value: payload}}, nil
+	if st.legacyBlobBase {
+		// One-time migration: load legacy blob, write wide-column, let deleteLogicalKeyElems clean up.
+		if err := c.ensureZSetLoaded(st, []byte(key)); err != nil {
+			return luaCommitPlan{}, err
+		}
+		return luaCommitPlan{elems: c.zsetFullCommitElems(key)}, nil
+	}
+	// Delta path: write only changed members + score index + metadata delta.
+	return luaCommitPlan{preserveExisting: true, elems: c.zsetDeltaCommitElems(key, st, commitTS)}, nil
+}
+
+// zsetFullCommitElems writes all members in wide-column format (member keys,
+// score index keys, and a base meta key). deleteLogicalKeyElems is responsible
+// for cleaning up any previous storage before these ops are applied.
+func (c *luaScriptContext) zsetFullCommitElems(key string) []*kv.Elem[kv.OP] {
+	st := c.zsets[key]
+	if st == nil || len(st.members) == 0 {
+		return nil
+	}
+	elems := make([]*kv.Elem[kv.OP], 0, len(st.members)*2+1) //nolint:mnd // 2 per member (member+score key) + 1 meta
+	for member, score := range st.members {
+		elems = append(elems,
+			&kv.Elem[kv.OP]{
+				Op:    kv.Put,
+				Key:   store.ZSetMemberKey([]byte(key), []byte(member)),
+				Value: store.MarshalZSetScore(score),
+			},
+			&kv.Elem[kv.OP]{
+				Op:    kv.Put,
+				Key:   store.ZSetScoreKey([]byte(key), score, []byte(member)),
+				Value: []byte{},
+			},
+		)
+	}
+	elems = append(elems, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   store.ZSetMetaKey([]byte(key)),
+		Value: store.MarshalZSetMeta(store.ZSetMeta{Len: int64(len(st.members))}),
+	})
+	return elems
+}
+
+// zsetDeltaCommitElems writes only the members that changed (added/updated/removed)
+// together with their score index entries and a cardinality delta key.
+// preserveExisting=true so deleteLogicalKeyElems is NOT called.
+func (c *luaScriptContext) zsetDeltaCommitElems(key string, st *luaZSetState, commitTS uint64) []*kv.Elem[kv.OP] {
+	if len(st.added) == 0 && len(st.removed) == 0 {
+		return nil
+	}
+	// Each added member: optionally DEL old score key + PUT member key + PUT score key.
+	// Each removed member: DEL member key + DEL score key.
+	// Plus one optional ZSetMetaDeltaKey.
+	elems := make([]*kv.Elem[kv.OP], 0, len(st.added)*3+len(st.removed)*2+1) //nolint:mnd
+	for member, score := range st.added {
+		if storageScore, ok := st.storageScores[member]; ok && storageScore != nil {
+			// Remove stale score index from storage.
+			elems = append(elems, &kv.Elem[kv.OP]{
+				Op:  kv.Del,
+				Key: store.ZSetScoreKey([]byte(key), *storageScore, []byte(member)),
+			})
+		}
+		elems = append(elems,
+			&kv.Elem[kv.OP]{
+				Op:    kv.Put,
+				Key:   store.ZSetMemberKey([]byte(key), []byte(member)),
+				Value: store.MarshalZSetScore(score),
+			},
+			&kv.Elem[kv.OP]{
+				Op:    kv.Put,
+				Key:   store.ZSetScoreKey([]byte(key), score, []byte(member)),
+				Value: []byte{},
+			},
+		)
+	}
+	for member := range st.removed {
+		storageScore, ok := st.storageScores[member]
+		if !ok || storageScore == nil {
+			continue
+		}
+		elems = append(elems,
+			&kv.Elem[kv.OP]{Op: kv.Del, Key: store.ZSetMemberKey([]byte(key), []byte(member))},
+			&kv.Elem[kv.OP]{Op: kv.Del, Key: store.ZSetScoreKey([]byte(key), *storageScore, []byte(member))},
+		)
+	}
+	if st.lenDelta != 0 {
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.ZSetMetaDeltaKey([]byte(key), commitTS, 0),
+			Value: store.MarshalZSetMetaDelta(store.ZSetMetaDelta{LenDelta: st.lenDelta}),
+		})
+	}
+	return elems
 }
 
 func (c *luaScriptContext) streamCommitElems(key string) ([]*kv.Elem[kv.OP], error) {

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -73,8 +73,8 @@ type luaZSetState struct {
 	loaded         bool
 	exists         bool
 	dirty          bool
-	membersLoaded  bool                // all members loaded into st.members
-	legacyBlobBase bool                // existing data is in legacy blob format
+	membersLoaded  bool // all members loaded into st.members
+	legacyBlobBase bool // existing data is in legacy blob format
 	// physicallyExistsAtStart is true when the key had physical ZSet data in
 	// storage at script-start time, even if logically absent due to TTL expiry.
 	// It is used by zsetCommitPlan to force a full commit (and thus cleanup of

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -75,11 +75,16 @@ type luaZSetState struct {
 	dirty          bool
 	membersLoaded  bool                // all members loaded into st.members
 	legacyBlobBase bool                // existing data is in legacy blob format
-	members        map[string]float64  // full member map (only when membersLoaded=true)
-	added          map[string]float64  // members added/updated in this script (delta)
-	storageScores  map[string]*float64 // original scores from Pebble (nil ptr = absent)
-	removed        map[string]struct{} // members explicitly removed in this script
-	lenDelta       int64               // net cardinality change (for delta commit)
+	// physicallyExistsAtStart is true when the key had physical ZSet data in
+	// storage at script-start time, even if logically absent due to TTL expiry.
+	// It is used by zsetCommitPlan to force a full commit (and thus cleanup of
+	// stale wide-column rows) when recreating a TTL-expired ZSet.
+	physicallyExistsAtStart bool
+	members                 map[string]float64  // full member map (only when membersLoaded=true)
+	added                   map[string]float64  // members added/updated in this script (delta)
+	storageScores           map[string]*float64 // original scores from Pebble (nil ptr = absent)
+	removed                 map[string]struct{} // members explicitly removed in this script
+	lenDelta                int64               // net cardinality change (for delta commit)
 
 	// resolvedBaseCard caches the result of resolveZSetMeta (storage-level cardinality)
 	// so ZCARD does not re-scan delta keys on every call within the same script.
@@ -661,6 +666,14 @@ func (c *luaScriptContext) zsetState(key []byte) (*luaZSetState, error) {
 		return nil, err
 	}
 	if typ == redisTypeNone {
+		// Check whether physical ZSet data exists despite the key being logically
+		// absent (TTL-expired). If so, mark physicallyExistsAtStart so that
+		// zsetCommitPlan can force a full commit to clean up stale storage rows.
+		rawTyp, rawErr := c.server.rawKeyTypeAt(context.Background(), key, c.startTS)
+		if rawErr != nil {
+			return nil, rawErr
+		}
+		st.physicallyExistsAtStart = rawTyp == redisTypeZSet
 		st.loaded = true
 		return st, nil
 	}
@@ -3011,7 +3024,11 @@ func (c *luaScriptContext) zsetCommitPlan(key string, commitTS uint64) (luaCommi
 	if st == nil || !st.dirty {
 		return luaCommitPlan{preserveExisting: true}, nil
 	}
-	if c.everDeleted[key] || st.membersLoaded {
+	// physicallyExistsAtStart is true when the key had physical ZSet data in
+	// storage at script start but was TTL-expired (logically absent). Force a
+	// full commit so deleteLogicalKeyElems removes stale wide-column rows
+	// (members, score-index, meta, TTL) that were left by the expired ZSet.
+	if st.physicallyExistsAtStart || c.everDeleted[key] || st.membersLoaded {
 		return c.zsetFullCommitWithMerge(key, st), nil
 	}
 	if st.legacyBlobBase {
@@ -3162,7 +3179,16 @@ func (c *luaScriptContext) finalTTL(key []byte) (*time.Time, error) {
 	if st != nil && st.loaded {
 		return st.value, nil
 	}
-	return c.server.ttlAt(context.Background(), key, c.startTS)
+	ttl, err := c.server.ttlAt(context.Background(), key, c.startTS)
+	if err != nil {
+		return nil, err
+	}
+	// Treat an already-expired TTL as absent so a recreated key does not
+	// inherit the old expired timestamp (which would leave a stale TTL key).
+	if ttl != nil && !ttl.After(time.Now()) {
+		return nil, nil
+	}
+	return ttl, nil
 }
 
 func reverseStrings(values []string) {

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -800,8 +800,8 @@ func (c *luaScriptContext) zsetCard(st *luaZSetState, key []byte) (int64, error)
 }
 
 // zsetStateForRead returns a fully-loaded ZSet state for commands that need the
-// complete member set (ZRANGE, ZCOUNT, ZPOPMIN, etc.). Returns (nil, false, nil)
-// when the key does not exist.
+// complete member set (ZRANGE, ZCOUNT, ZPOPMIN, etc.). Returns (st, false, nil)
+// when the key does not exist; callers must check the bool before using st.
 func (c *luaScriptContext) zsetStateForRead(key []byte) (*luaZSetState, bool, error) {
 	st, err := c.zsetState(key)
 	if err != nil {

--- a/adapter/redis_retry_test.go
+++ b/adapter/redis_retry_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/bootjp/elastickv/kv"
 	"github.com/bootjp/elastickv/store"
@@ -348,4 +349,102 @@ func TestZAdd_XX_MissingKey_NoPhantom(t *testing.T) {
 
 	require.Empty(t, conn.err)
 	require.Equal(t, int64(0), conn.int, "ZADD XX on missing key must not create a phantom key")
+}
+
+// TestZSetTTLExpiredRecreation verifies that when a ZSet expires via TTL and is
+// recreated by Lua ZADD, stale wide-column data (members, score-index, meta, TTL)
+// from the expired ZSet is removed. Before the fix, zsetCommitPlan took the delta
+// path (preserveExisting=true) because st.exists==false and everDeleted was never
+// set, leaving old members and the expired TTL key in storage.
+func TestZSetTTLExpiredRecreation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+
+	// Write a wide-column ZSet with member "old-member" at ts=1.
+	require.NoError(t, st.PutAt(ctx, store.ZSetMemberKey([]byte("expired:zset"), []byte("old-member")), store.MarshalZSetScore(9.0), 1, 0))
+	require.NoError(t, st.PutAt(ctx, store.ZSetScoreKey([]byte("expired:zset"), 9.0, []byte("old-member")), []byte{}, 1, 0))
+	require.NoError(t, st.PutAt(ctx, store.ZSetMetaKey([]byte("expired:zset")), store.MarshalZSetMeta(store.ZSetMeta{Len: 1}), 1, 0))
+	// Set a TTL that is already in the past so the key appears expired.
+	require.NoError(t, st.PutAt(ctx, redisTTLKey([]byte("expired:zset")), encodeRedisTTL(time.Unix(0, 0)), 2, 0))
+
+	coord := newRetryOnceCoordinator(st)
+	coord.clock.Observe(2)
+
+	srv := &RedisServer{
+		store:       st,
+		coordinator: coord,
+		scriptCache: map[string]string{},
+	}
+	conn := &recordingConn{}
+	// Recreate the expired ZSet by adding "new-member".
+	srv.runLuaScript(conn, `return redis.call("ZADD", KEYS[1], 1, "new-member")`, [][]byte{
+		[]byte("1"),
+		[]byte("expired:zset"),
+	})
+
+	require.Empty(t, conn.err)
+	require.Equal(t, int64(1), conn.int, "ZADD should add new-member")
+
+	// Old member key must be gone.
+	oldMemberExists, err := st.ExistsAt(ctx, store.ZSetMemberKey([]byte("expired:zset"), []byte("old-member")), snapshotTS(coord.clock, st))
+	require.NoError(t, err)
+	require.False(t, oldMemberExists, "old-member from expired ZSet must not survive recreation")
+
+	// Old TTL key must be gone.
+	ttlExists, err := st.ExistsAt(ctx, redisTTLKey([]byte("expired:zset")), snapshotTS(coord.clock, st))
+	require.NoError(t, err)
+	require.False(t, ttlExists, "expired TTL key must not survive ZSet recreation")
+
+	// New member must exist.
+	newMemberExists, err := st.ExistsAt(ctx, store.ZSetMemberKey([]byte("expired:zset"), []byte("new-member")), snapshotTS(coord.clock, st))
+	require.NoError(t, err)
+	require.True(t, newMemberExists, "new-member must be present after recreation")
+}
+
+// TestZSetDeltaCommitOnExistingWideColumn verifies that the delta commit path
+// (write-only Lua script on a pre-existing wide-column ZSet) correctly adds new
+// members without dropping untouched existing ones, and that ZCARD reflects the
+// updated count inside the script.
+func TestZSetDeltaCommitOnExistingWideColumn(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+
+	// Pre-populate wide-column ZSet with member "a" at ts=1.
+	require.NoError(t, st.PutAt(ctx, store.ZSetMemberKey([]byte("delta:zset"), []byte("a")), store.MarshalZSetScore(1.0), 1, 0))
+	require.NoError(t, st.PutAt(ctx, store.ZSetScoreKey([]byte("delta:zset"), 1.0, []byte("a")), []byte{}, 1, 0))
+	require.NoError(t, st.PutAt(ctx, store.ZSetMetaKey([]byte("delta:zset")), store.MarshalZSetMeta(store.ZSetMeta{Len: 1}), 1, 0))
+
+	coord := newRetryOnceCoordinator(st)
+	coord.clock.Observe(1)
+
+	srv := &RedisServer{
+		store:       st,
+		coordinator: coord,
+		scriptCache: map[string]string{},
+	}
+	conn := &recordingConn{}
+	// Add "b" and return ZCARD; ZCARD must account for both "a" (existing) and "b" (added).
+	srv.runLuaScript(conn, `redis.call("ZADD", KEYS[1], 2, "b"); return redis.call("ZCARD", KEYS[1])`, [][]byte{
+		[]byte("1"),
+		[]byte("delta:zset"),
+	})
+
+	require.Empty(t, conn.err)
+	require.Equal(t, int64(2), conn.int, "ZCARD must reflect both existing and newly added member")
+
+	readTS := snapshotTS(coord.clock, st)
+
+	// "a" must still exist after delta commit.
+	aExists, err := st.ExistsAt(ctx, store.ZSetMemberKey([]byte("delta:zset"), []byte("a")), readTS)
+	require.NoError(t, err)
+	require.True(t, aExists, "existing member 'a' must survive delta commit")
+
+	// "b" must have been written.
+	bExists, err := st.ExistsAt(ctx, store.ZSetMemberKey([]byte("delta:zset"), []byte("b")), readTS)
+	require.NoError(t, err)
+	require.True(t, bExists, "new member 'b' must be written by delta commit")
 }

--- a/adapter/redis_retry_test.go
+++ b/adapter/redis_retry_test.go
@@ -287,3 +287,65 @@ func TestRetryPolicyForRedisTxnErr(t *testing.T) {
 	require.Equal(t, redisWriteConflictRetryPolicy, retryPolicyForRedisTxnErr(store.ErrWriteConflict))
 	require.Equal(t, redisTxnLockedRetryPolicy, retryPolicyForRedisTxnErr(kv.ErrTxnLocked))
 }
+
+// TestZCard_LegacyBlobZSet verifies that ZCARD inside a Lua script returns the
+// correct member count for a ZSet stored in the legacy single-blob format.
+// Before the fix, zsetCard fell through to resolveZSetMeta which found no
+// wide-column ZSetMetaKey and returned 0 for legacy-blob ZSets.
+func TestZCard_LegacyBlobZSet(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+
+	payload, err := marshalZSetValue(redisZSetValue{
+		Entries: []redisZSetEntry{
+			{Member: "a", Score: 1.0},
+			{Member: "b", Score: 2.0},
+			{Member: "c", Score: 3.0},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, st.PutAt(ctx, redisZSetKey([]byte("legacy:zset")), payload, 1, 0))
+
+	srv := &RedisServer{
+		store:       st,
+		coordinator: &stubAdapterCoordinator{clock: kv.NewHLC()},
+		scriptCache: map[string]string{},
+	}
+	conn := &recordingConn{}
+	srv.runLuaScript(conn, `return redis.call("ZCARD", KEYS[1])`, [][]byte{
+		[]byte("1"),
+		[]byte("legacy:zset"),
+	})
+
+	require.Empty(t, conn.err)
+	require.Equal(t, int64(3), conn.int)
+}
+
+// TestZAdd_XX_MissingKey_NoPhantom verifies that ZADD with the XX flag on a
+// key that does not exist does not create a phantom key visible to subsequent
+// EXISTS/TYPE calls within the same script.
+func TestZAdd_XX_MissingKey_NoPhantom(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	coord := &stubAdapterCoordinator{clock: kv.NewHLC()}
+	srv := &RedisServer{
+		store:       st,
+		coordinator: coord,
+		scriptCache: map[string]string{},
+	}
+	conn := &recordingConn{}
+	// ZADD XX on a non-existent key must not create the key; EXISTS must return 0.
+	srv.runLuaScript(conn, `
+		redis.call("ZADD", KEYS[1], "XX", 1, "member")
+		return redis.call("EXISTS", KEYS[1])
+	`, [][]byte{
+		[]byte("1"),
+		[]byte("phantom:zset"),
+	})
+
+	require.Empty(t, conn.err)
+	require.Equal(t, int64(0), conn.int, "ZADD XX on missing key must not create a phantom key")
+}


### PR DESCRIPTION
Each ZSet write in a Lua script previously triggered loadZSetAt (ScanAt of up to 100,001 member keys) even for pure-write scripts. With BullMQ delayed queues at 10k+ members this caused 700-800ms per redis.call().

- zsetState: single ScanAt(limit=1) probe instead of full member load
- ensureZSetLoaded: lazy full-load called only by read commands
- memberScore/zsetDeltaScore/memberScoreFromPebble: O(log N) GetAt point lookup with per-script cache, used by ZADD flags and ZSCORE
- applyZAddMember: extracted helper to keep cmdZAdd complexity in bounds
- cmdZAdd: delta tracking (st.added/lenDelta) with no full collection scan
- cmdZCard: resolveZSetMeta+lenDelta (O(log N)) instead of len(members)
- cmdZScore: uses memberScore for O(log N) instead of full load
- zsetStateForRead: shared helper that loads on demand for read commands
- zsetCommitPlan: selects full wide-column rewrite vs incremental delta
- zsetFullCommitElems: wide-column format, fixing existing legacy-blob bug
- zsetDeltaCommitElems: writes only changed members + score index + meta delta

ZADD-only Lua scripts on large ZSets now avoid the O(N) collection scan. Legacy-blob ZSets are migrated to wide-column on first write.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized sorted-set storage to load members lazily, reduce unnecessary writes, and improve score/cardinality resolution for faster reads and commits.
* **Bug Fixes**
  * Fixed correctness for cardinality and conditional add semantics to avoid phantom keys and incorrect counts on legacy-backed sets.
* **Tests**
  * Added unit and integration tests validating inline meta compaction and ZSET read/write behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->