### PR TITLE
perf(redis): fast-path GET to avoid ~17-seek type probe

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1085,6 +1085,15 @@ func (r *RedisServer) get(conn redcon.Conn, cmd redcon.Command) {
 		conn.WriteNull()
 		return
 	}
+	// If keyTypeAt disagrees with the fast path and classifies the key
+	// as a live string (e.g. a rare TTL-filter discrepancy between
+	// decodePrefixedStringWith/readBareLegacyStringWith and
+	// hasExpiredTTLAt), match the pre-optimisation behaviour and
+	// return nil rather than WRONGTYPE.
+	if typ == redisTypeString {
+		conn.WriteNull()
+		return
+	}
 	conn.WriteError(wrongTypeMessage)
 }
 

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1048,6 +1048,30 @@ func (r *RedisServer) get(conn redcon.Conn, cmd redcon.Command) {
 		return
 	}
 	readTS := r.readTS()
+
+	// Fast path: attempt the string read directly instead of probing
+	// every possible Redis encoding first. rawKeyTypeAt issues up to
+	// ~17 pebble seeks (list meta + list delta + 3×wide-column probes
+	// each doing 3 seeks + hash/set/zset/stream/HLL/str/bare); that
+	// overhead dominated every GET on a hot cluster (see
+	// docs/lease_read_design.md). A live string key resolves in 1-2
+	// seeks here, and we only fall back to keyTypeAt when the string
+	// path returns ErrKeyNotFound (meaning either missing, expired,
+	// or a non-string type is present under this user-key).
+	v, _, err := r.readRedisStringAt(key, readTS)
+	if err == nil {
+		conn.WriteBulk(v)
+		return
+	}
+	if !errors.Is(err, store.ErrKeyNotFound) {
+		conn.WriteError(err.Error())
+		return
+	}
+
+	// Slow path: disambiguate "missing / expired" from WRONGTYPE.
+	// keyTypeAt applies the TTL filter, so an expired string reports
+	// as redisTypeNone here and we return nil -- matching the
+	// pre-optimisation behaviour.
 	typ, err := r.keyTypeAt(ctx, key, readTS)
 	if err != nil {
 		conn.WriteError(err.Error())
@@ -1057,22 +1081,7 @@ func (r *RedisServer) get(conn redcon.Conn, cmd redcon.Command) {
 		conn.WriteNull()
 		return
 	}
-	if typ != redisTypeString {
-		conn.WriteError(wrongTypeMessage)
-		return
-	}
-
-	v, _, err := r.readRedisStringAt(key, readTS)
-	if err != nil {
-		if errors.Is(err, store.ErrKeyNotFound) {
-			conn.WriteNull()
-		} else {
-			conn.WriteError(err.Error())
-		}
-		return
-	}
-
-	conn.WriteBulk(v)
+	conn.WriteError(wrongTypeMessage)
 }
 
 // leaderEmbeddedTTLExpired looks at !redis|str|<key> on the leader and, if the

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1058,7 +1058,11 @@ func (r *RedisServer) get(conn redcon.Conn, cmd redcon.Command) {
 	// seeks here, and we only fall back to keyTypeAt when the string
 	// path returns ErrKeyNotFound (meaning either missing, expired,
 	// or a non-string type is present under this user-key).
-	v, _, err := r.readRedisStringAt(key, readTS)
+	//
+	// Use the snapshot variant: LeaseReadForKeyThrough above already
+	// established the ReadIndex fence, so a per-call VerifyLeaderForKey
+	// (inside leaderAwareGetAt) would duplicate the quorum work.
+	v, _, err := r.readRedisStringAtSnapshot(key, readTS)
 	if err == nil {
 		conn.WriteBulk(v)
 		return


### PR DESCRIPTION
## Summary
Every GET was calling `keyTypeAt` → `rawKeyTypeAt`, which issues up to ~17 pebble seeks just to classify the encoding (list meta + list delta + 3×wide-column×3 + hash/set/zset/stream/HLL/str/bare). On a string-dominated workload this dwarfs the actual read.

**pprof from production (6 CPUs pinned, 577% over 30s):**
- 22% cum in `rawKeyTypeAt` → pebble SeekGE
- 61 goroutines simultaneously in `rawKeyTypeAt`
- 65 goroutines blocked in `LinearizableRead`

The seek storm also starves the Raft event loop, filling stepCh on both leader and followers and causing MsgHeartbeat drops. Fixing the GET hot path frees CPU for the event loop and reduces read latency directly.

**Fix**: try `readRedisStringAt` first (1-2 seeks). Only fall back to `keyTypeAt` when the string read returns `ErrKeyNotFound`, to disambiguate nil vs WRONGTYPE. `keyTypeAt` already applies TTL filtering, so an expired string reports `redisTypeNone` and we return nil, matching the pre-change behaviour.

## Test plan
- [x] `go test -race ./adapter/... -short` passes
- [x] Existing GET tests cover: live string, nil key, wrong type (returns WRONGTYPE), expired string
- [x] Deploy to hot-fix environment and verify GET latency drops from ~1s to <100ms