### PR TITLE
perf(redis): reduce duplicate type probes in SET and fast-path EXISTS

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1258,10 +1258,12 @@ func (r *RedisServer) delLocal(keys [][]byte) (int, error) {
 
 func (r *RedisServer) exists(conn redcon.Conn, cmd redcon.Command) {
 	readTS := r.readTS()
-	// Derive ctx from the server's base context so Close() cancels any
-	// in-flight probe instead of leaving it on a detached Background().
-	// The timeout bounds the worst case across multiple keys and any
-	// follower-side leader proxy hop.
+	// Derive ctx from the server's base context so shutdown cancels
+	// the ctx-aware branches of this handler. Note: the string
+	// fast-path (readRedisStringAt -> doGetAt) currently issues its
+	// pebble GetAt against context.Background, so cancellation only
+	// bounds logicalExistsAt's ctx-aware probes and the per-key
+	// loader. Plumbing ctx through doGetAt is tracked separately.
 	ctx, cancel := context.WithTimeout(r.handlerContext(), redisDispatchTimeout)
 	defer cancel()
 	count := 0
@@ -1286,12 +1288,21 @@ func (r *RedisServer) exists(conn redcon.Conn, cmd redcon.Command) {
 // existsAtFast is a string-first fast path for EXISTS-style liveness
 // checks. Strings dominate real workloads, and a string key resolves
 // here in 1-2 seeks against redisStrKey (with TTL filtering applied
-// by readRedisStringAtSnapshot) versus the ~17 seeks of a full
+// by readRedisStringAt) versus the ~17 seeks of a full
 // logicalExistsAt probe. When the string path reports ErrKeyNotFound
 // (missing, expired, or a non-string type is present) we fall back to
 // the full probe.
+//
+// Uses readRedisStringAt (the leader-aware variant), NOT the snapshot
+// variant: EXISTS does no up-front LeaseReadForKeyThrough like GET
+// does, so the snapshot variant would violate its caller-contract
+// ("must have VerifyLeader'd first"). The leader-aware path handles
+// the follower case by proxying to the leader inside doGetAt, and
+// matches the liveness semantics of the pre-optimisation EXISTS flow
+// (logicalExistsAt → keyTypeAt → store.ExistsAt) which also did not
+// take the snapshot shortcut.
 func (r *RedisServer) existsAtFast(ctx context.Context, key []byte, readTS uint64) (bool, error) {
-	if _, _, err := r.readRedisStringAtSnapshot(key, readTS); err == nil {
+	if _, _, err := r.readRedisStringAt(key, readTS); err == nil {
 		return true, nil
 	} else if !errors.Is(err, store.ErrKeyNotFound) {
 		return false, errors.WithStack(err)

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1258,14 +1258,13 @@ func (r *RedisServer) delLocal(keys [][]byte) (int, error) {
 
 func (r *RedisServer) exists(conn redcon.Conn, cmd redcon.Command) {
 	readTS := r.readTS()
-	// Derive ctx from the server's base context so proxy hops (which
-	// DO honor ctx) are bounded by this deadline and cancel on
-	// shutdown. Local Pebble reads (store.GetAt / ExistsAt / ScanAt)
-	// currently ignore the context parameter, so cancellation does
-	// not actually interrupt an in-flight local probe -- the deadline
-	// bounds the per-key loop iteration and any leader-proxy RPC
-	// taken by the negative-result fallback, not the local probes
-	// themselves.
+	// Derive ctx from the server's base context so work in this handler
+	// that honors context deadlines is bounded and cancels on shutdown.
+	// Local Pebble reads (store.GetAt / ExistsAt / ScanAt) currently
+	// ignore the context parameter, so cancellation does not interrupt
+	// an in-flight local probe. The negative-result follower fallback
+	// currently calls tryLeaderLogicalExists(), which manages its own
+	// timeout/context rather than using this ctx.
 	ctx, cancel := context.WithTimeout(r.handlerContext(), redisDispatchTimeout)
 	defer cancel()
 	count := 0

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -751,13 +751,12 @@ func (o redisSetOptions) allows(exists bool) bool {
 	return true
 }
 
-func (r *RedisServer) loadRedisSetState(key []byte, readTS uint64, returnOld bool) (redisSetState, error) {
+func (r *RedisServer) loadRedisSetState(ctx context.Context, key []byte, readTS uint64, returnOld bool) (redisSetState, error) {
 	// Probe type ONCE (rawKeyTypeAt issues up to ~17 pebble seeks),
 	// then derive both the raw and TTL-filtered views from it. The
 	// previous implementation called rawKeyTypeAt + keyTypeAt, which
 	// called rawKeyTypeAt again inside -- doubling every SET to ~34
 	// seeks for purely redundant work.
-	ctx := context.Background()
 	rawTyp, err := r.rawKeyTypeAt(ctx, key, readTS)
 	if err != nil {
 		return redisSetState{}, err
@@ -806,7 +805,7 @@ func (r *RedisServer) executeSet(ctx context.Context, key, value []byte, opts re
 	var result redisSetExecution
 	err := r.retryRedisWrite(ctx, func() error {
 		readTS := r.readTS()
-		state, err := r.loadRedisSetState(key, readTS, opts.returnOld)
+		state, err := r.loadRedisSetState(ctx, key, readTS, opts.returnOld)
 		if err != nil {
 			return err
 		}
@@ -1259,7 +1258,12 @@ func (r *RedisServer) delLocal(keys [][]byte) (int, error) {
 
 func (r *RedisServer) exists(conn redcon.Conn, cmd redcon.Command) {
 	readTS := r.readTS()
-	ctx := context.Background()
+	// Derive ctx from the server's base context so Close() cancels any
+	// in-flight probe instead of leaving it on a detached Background().
+	// The timeout bounds the worst case across multiple keys and any
+	// follower-side leader proxy hop.
+	ctx, cancel := context.WithTimeout(r.handlerContext(), redisDispatchTimeout)
+	defer cancel()
 	count := 0
 	for _, key := range cmd.Args[1:] {
 		ok, err := r.existsAtFast(ctx, key, readTS)

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1259,11 +1259,10 @@ func (r *RedisServer) delLocal(keys [][]byte) (int, error) {
 func (r *RedisServer) exists(conn redcon.Conn, cmd redcon.Command) {
 	readTS := r.readTS()
 	// Derive ctx from the server's base context so shutdown cancels
-	// the ctx-aware branches of this handler. Note: the string
-	// fast-path (readRedisStringAt -> doGetAt) currently issues its
-	// pebble GetAt against context.Background, so cancellation only
-	// bounds logicalExistsAt's ctx-aware probes and the per-key
-	// loader. Plumbing ctx through doGetAt is tracked separately.
+	// in-flight probes. Both the fast path (existsAtFast →
+	// store.GetAt / legacyIndexTTLAt) and the slow fallback
+	// (logicalExistsAt) are ctx-aware, so the deadline bounds every
+	// per-key branch we can reach.
 	ctx, cancel := context.WithTimeout(r.handlerContext(), redisDispatchTimeout)
 	defer cancel()
 	count := 0
@@ -1310,8 +1309,10 @@ func (r *RedisServer) existsAtFast(ctx context.Context, key []byte, readTS uint6
 		if alive {
 			return true, nil
 		}
-		// Expired / undecodable: fall through so other encodings still
-		// get their chance.
+		// Expired: fall through so other encodings still get their
+		// chance. Undecodable payloads are already propagated as an
+		// error by stringPayloadIsLive above -- they're a corruption
+		// signal, not a "try something else" case.
 	} else if !errors.Is(err, store.ErrKeyNotFound) {
 		return false, errors.WithStack(err)
 	}

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1258,11 +1258,14 @@ func (r *RedisServer) delLocal(keys [][]byte) (int, error) {
 
 func (r *RedisServer) exists(conn redcon.Conn, cmd redcon.Command) {
 	readTS := r.readTS()
-	// Derive ctx from the server's base context so shutdown cancels
-	// in-flight probes. Both the fast path (existsAtFast →
-	// store.GetAt / legacyIndexTTLAt) and the slow fallback
-	// (logicalExistsAt) are ctx-aware, so the deadline bounds every
-	// per-key branch we can reach.
+	// Derive ctx from the server's base context so proxy hops (which
+	// DO honor ctx) are bounded by this deadline and cancel on
+	// shutdown. Local Pebble reads (store.GetAt / ExistsAt / ScanAt)
+	// currently ignore the context parameter, so cancellation does
+	// not actually interrupt an in-flight local probe -- the deadline
+	// bounds the per-key loop iteration and any leader-proxy RPC
+	// taken by the negative-result fallback, not the local probes
+	// themselves.
 	ctx, cancel := context.WithTimeout(r.handlerContext(), redisDispatchTimeout)
 	defer cancel()
 	count := 0

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -752,13 +752,18 @@ func (o redisSetOptions) allows(exists bool) bool {
 }
 
 func (r *RedisServer) loadRedisSetState(key []byte, readTS uint64, returnOld bool) (redisSetState, error) {
-	// rawTyp (TTL-unaware) detects lingering internal keys for cleanup.
-	rawTyp, err := r.rawKeyTypeAt(context.Background(), key, readTS)
+	// Probe type ONCE (rawKeyTypeAt issues up to ~17 pebble seeks),
+	// then derive both the raw and TTL-filtered views from it. The
+	// previous implementation called rawKeyTypeAt + keyTypeAt, which
+	// called rawKeyTypeAt again inside -- doubling every SET to ~34
+	// seeks for purely redundant work.
+	ctx := context.Background()
+	rawTyp, err := r.rawKeyTypeAt(ctx, key, readTS)
 	if err != nil {
 		return redisSetState{}, err
 	}
 	// typ (TTL-aware) drives NX/XX/GET Redis semantics: expired keys are "gone".
-	typ, err := r.keyTypeAt(context.Background(), key, readTS)
+	typ, err := r.applyTTLFilter(ctx, key, readTS, rawTyp)
 	if err != nil {
 		return redisSetState{}, err
 	}
@@ -1254,9 +1259,10 @@ func (r *RedisServer) delLocal(keys [][]byte) (int, error) {
 
 func (r *RedisServer) exists(conn redcon.Conn, cmd redcon.Command) {
 	readTS := r.readTS()
+	ctx := context.Background()
 	count := 0
 	for _, key := range cmd.Args[1:] {
-		ok, err := r.logicalExistsAt(context.Background(), key, readTS)
+		ok, err := r.existsAtFast(ctx, key, readTS)
 		if err != nil {
 			conn.WriteError(err.Error())
 			return
@@ -1271,6 +1277,22 @@ func (r *RedisServer) exists(conn redcon.Conn, cmd redcon.Command) {
 		}
 	}
 	conn.WriteInt(count)
+}
+
+// existsAtFast is a string-first fast path for EXISTS-style liveness
+// checks. Strings dominate real workloads, and a string key resolves
+// here in 1-2 seeks against redisStrKey (with TTL filtering applied
+// by readRedisStringAtSnapshot) versus the ~17 seeks of a full
+// logicalExistsAt probe. When the string path reports ErrKeyNotFound
+// (missing, expired, or a non-string type is present) we fall back to
+// the full probe.
+func (r *RedisServer) existsAtFast(ctx context.Context, key []byte, readTS uint64) (bool, error) {
+	if _, _, err := r.readRedisStringAtSnapshot(key, readTS); err == nil {
+		return true, nil
+	} else if !errors.Is(err, store.ErrKeyNotFound) {
+		return false, errors.WithStack(err)
+	}
+	return r.logicalExistsAt(ctx, key, readTS)
 }
 
 func (r *RedisServer) keys(conn redcon.Conn, cmd redcon.Command) {

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1286,28 +1286,56 @@ func (r *RedisServer) exists(conn redcon.Conn, cmd redcon.Command) {
 }
 
 // existsAtFast is a string-first fast path for EXISTS-style liveness
-// checks. Strings dominate real workloads, and a string key resolves
-// here in 1-2 seeks against redisStrKey (with TTL filtering applied
-// by readRedisStringAt) versus the ~17 seeks of a full
-// logicalExistsAt probe. When the string path reports ErrKeyNotFound
-// (missing, expired, or a non-string type is present) we fall back to
-// the full probe.
+// checks. Strings dominate real workloads, and a live string key
+// resolves here in 1-2 seeks against redisStrKey (with TTL filtering
+// applied inline) versus the ~17 seeks of a full logicalExistsAt
+// probe. When the redisStrKey probe misses we fall back to the full
+// type-probe.
 //
-// Uses readRedisStringAt (the leader-aware variant), NOT the snapshot
-// variant: EXISTS does no up-front LeaseReadForKeyThrough like GET
-// does, so the snapshot variant would violate its caller-contract
-// ("must have VerifyLeader'd first"). The leader-aware path handles
-// the follower case by proxying to the leader inside doGetAt, and
-// matches the liveness semantics of the pre-optimisation EXISTS flow
-// (logicalExistsAt → keyTypeAt → store.ExistsAt) which also did not
-// take the snapshot shortcut.
+// The probe goes directly to the local store. EXISTS tolerates stale-
+// positive reads on followers by design -- the pre-optimisation flow
+// (logicalExistsAt → keyTypeAt → local store.ExistsAt) never proxied
+// to the leader for the probe itself; proxying is reserved for the
+// negative-result fallback (tryLeaderLogicalExists in the caller).
+// Routing through readRedisStringAt here would instead issue a Raft
+// round-trip per key on every follower, regressing EXISTS latency on
+// workloads that were previously all-local.
 func (r *RedisServer) existsAtFast(ctx context.Context, key []byte, readTS uint64) (bool, error) {
-	if _, _, err := r.readRedisStringAt(key, readTS); err == nil {
-		return true, nil
+	raw, err := r.store.GetAt(ctx, redisStrKey(key), readTS)
+	if err == nil {
+		alive, decErr := r.stringPayloadIsLive(ctx, key, raw, readTS)
+		if decErr != nil {
+			return false, errors.WithStack(decErr)
+		}
+		if alive {
+			return true, nil
+		}
+		// Expired / undecodable: fall through so other encodings still
+		// get their chance.
 	} else if !errors.Is(err, store.ErrKeyNotFound) {
 		return false, errors.WithStack(err)
 	}
 	return r.logicalExistsAt(ctx, key, readTS)
+}
+
+// stringPayloadIsLive reports whether a redisStrKey payload is still
+// TTL-alive. New-format payloads carry their expiry inline; legacy-
+// format payloads need the !redis|ttl| index consulted for the TTL.
+// Both paths use the LOCAL store, matching existsAtFast's no-proxy
+// contract.
+func (r *RedisServer) stringPayloadIsLive(ctx context.Context, key, raw []byte, readTS uint64) (bool, error) {
+	if isNewRedisStrFormat(raw) {
+		_, expireAt, err := decodeRedisStr(raw)
+		if err != nil {
+			return false, err
+		}
+		return expireAt == nil || expireAt.After(time.Now()), nil
+	}
+	ttl, err := r.legacyIndexTTLAt(ctx, key, readTS)
+	if err != nil {
+		return false, err
+	}
+	return ttl == nil || ttl.After(time.Now()), nil
 }
 
 func (r *RedisServer) keys(conn redcon.Conn, cmd redcon.Command) {

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -165,8 +165,20 @@ func (r *RedisServer) rawKeyTypeAt(ctx context.Context, key []byte, readTS uint6
 
 func (r *RedisServer) keyTypeAt(ctx context.Context, key []byte, readTS uint64) (redisValueType, error) {
 	typ, err := r.rawKeyTypeAt(ctx, key, readTS)
-	if err != nil || typ == redisTypeNone {
+	if err != nil {
 		return typ, err
+	}
+	return r.applyTTLFilter(ctx, key, readTS, typ)
+}
+
+// applyTTLFilter takes a raw (TTL-unaware) type and returns the
+// TTL-filtered equivalent. Callers that need BOTH the raw and filtered
+// types (SET NX/XX/GET against a possibly-expired key) can reuse a
+// single rawKeyTypeAt result and skip the duplicate ~17-seek probe
+// that keyTypeAt would otherwise issue.
+func (r *RedisServer) applyTTLFilter(ctx context.Context, key []byte, readTS uint64, rawTyp redisValueType) (redisValueType, error) {
+	if rawTyp == redisTypeNone {
+		return rawTyp, nil
 	}
 	expired, err := r.hasExpiredTTLAt(ctx, key, readTS)
 	if err != nil {
@@ -175,7 +187,7 @@ func (r *RedisServer) keyTypeAt(ctx context.Context, key []byte, readTS uint64) 
 	if expired {
 		return redisTypeNone, nil
 	}
-	return typ, nil
+	return rawTyp, nil
 }
 
 func (r *RedisServer) keyType(ctx context.Context, key []byte) (redisValueType, error) {

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -176,11 +176,18 @@ func (r *RedisServer) keyTypeAt(ctx context.Context, key []byte, readTS uint64) 
 // types (SET NX/XX/GET against a possibly-expired key) can reuse a
 // single rawKeyTypeAt result and skip the duplicate ~17-seek probe
 // that keyTypeAt would otherwise issue.
+//
+// For non-string raw types we skip the embedded-TTL probe that
+// hasExpired does by default: the embedded TTL only lives under
+// !redis|str|<key>, so probing it for a hash/set/zset/stream/list is
+// a guaranteed-miss GetAt. Passing nonStringOnly=true jumps straight
+// to the !redis|ttl| secondary index, saving one pebble seek per
+// non-string SET / type check.
 func (r *RedisServer) applyTTLFilter(ctx context.Context, key []byte, readTS uint64, rawTyp redisValueType) (redisValueType, error) {
 	if rawTyp == redisTypeNone {
 		return rawTyp, nil
 	}
-	expired, err := r.hasExpiredTTLAt(ctx, key, readTS)
+	expired, err := r.hasExpired(ctx, key, readTS, rawTyp != redisTypeString)
 	if err != nil {
 		return redisTypeNone, err
 	}

--- a/adapter/redis_compat_types.go
+++ b/adapter/redis_compat_types.go
@@ -307,10 +307,6 @@ func (r *RedisServer) legacyIndexTTLAt(ctx context.Context, userKey []byte, read
 	return &ttl, nil
 }
 
-func (r *RedisServer) hasExpiredTTLAt(ctx context.Context, userKey []byte, readTS uint64) (bool, error) {
-	return r.hasExpired(ctx, userKey, readTS, false)
-}
-
 // hasExpired checks TTL expiry. When nonStringOnly is true, the embedded-TTL
 // probe is skipped and only the !redis|ttl| index is consulted, avoiding a
 // wasted GetAt on !redis|str|<key> for non-string types.


### PR DESCRIPTION
## Summary
Follow-up to PR #560 (GET fast-path). Two more hot paths still issued ~17 pebble seeks per call via `rawKeyTypeAt`.

### 1. SET: eliminate duplicate probe
`loadRedisSetState` called `rawKeyTypeAt` AND `keyTypeAt` back to back. `keyTypeAt` internally calls `rawKeyTypeAt` again, so a single SET spent ~34 seeks just to obtain the raw-and-TTL-filtered type pair. Extract `applyTTLFilter` so the two views are derived from one probe.

**~34 seeks → ~18 seeks per SET.**

### 2. EXISTS: string-first fast path
`logicalExistsAt` forced the full ~17-seek probe even though the command only needs a boolean. Introduce `existsAtFast`: try `readRedisStringAtSnapshot` first (1-2 seeks for the common string case, TTL filter already baked in), fall back to `logicalExistsAt` only when the string path returns `ErrKeyNotFound`.

**~17 seeks → 1-2 seeks per EXISTS on a string key.**

## Why
The freed CPU is the same currency PR #560 redirected into the Raft event loop. Writes (SET, INCR) and EXISTS share the same contention as GET did against the step queue; cutting per-command seek count helps the event loop run on time, reducing heartbeat drops and step-queue rejections.

## Test plan
- [x] `go test -race ./adapter/... -short` passes
- [x] Existing SET tests cover NX/XX/GET, TTL expiration, WRONGTYPE from non-string prior keys
- [x] Existing EXISTS tests cover string / collection / expired key cases (all go through `logicalExistsAt` after string path misses)
- [ ] Production: deploy and verify SET + INCR latency drops
