### PR TITLE
obs(redis): add hot-path dashboard and metrics to verify PR #560

### DIFF
--- a/docs/redis_hotpath_dashboard.md
+++ b/docs/redis_hotpath_dashboard.md
@@ -10,11 +10,11 @@ probe") landed cleanly in production.
 Three panels together answer the question. All other panels on the
 dashboard are supporting context.
 
-| Panel                                 | Expected direction post-deploy                                                                 |
-| ------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| **LinearizableRead Rate (lease miss)**| Falls sharply as each node rolls. A steady GET workload used to push every GET through this.   |
-| **GET p99 (success)**                 | Flat or down. The fast path removes ~15 pebble seeks per GET, shaving the head of the tail.    |
-| **Lease Fast-Path Hit Ratio**         | Climbs toward 1.0. Leases stay warm because GETs no longer force slow-path ReadIndex traffic.  |
+| Panel                                  | Expected direction post-deploy                                                                |
+| -------------------------------------- | --------------------------------------------------------------------------------------------- |
+| **LinearizableRead Rate (lease miss)** | Falls sharply as each node rolls. A steady GET workload used to push every GET through this.  |
+| **GET p99 (success)**                  | Flat or down. The fast path removes ~15 pebble seeks per GET, shaving the head of the tail.   |
+| **Lease Fast-Path Hit Ratio**          | Climbs toward 1.0. Leases stay warm because GETs no longer force slow-path ReadIndex traffic. |
 
 If LinearizableRead rate drops but p99 worsens, something on the
 lease-read path is regressing (look at Raft Queue Saturation). If p99

--- a/docs/redis_hotpath_dashboard.md
+++ b/docs/redis_hotpath_dashboard.md
@@ -25,9 +25,12 @@ which usually means the adapter wiring was not updated on that node.
 
 Added in this PR:
 
-- `elastickv_lease_read_total{outcome="hit|miss"}` -- counter on
-  `kv.Coordinate.LeaseRead` / `kv.ShardedCoordinator.groupLeaseRead`.
-  Wired via `kv.WithLeaseReadObserver` (single-group) and
+- `elastickv_lease_read_total{outcome="hit|miss"}` -- counter
+  incremented at the lease-read call sites in `kv/coordinator.go`
+  (`Coordinate.LeaseRead`, `Coordinate.LeaseReadForKey`) and the
+  shared `kv.groupLeaseRead` helper used by
+  `ShardedCoordinator.LeaseRead` / `LeaseReadForKey`. Wired via the
+  `kv.WithLeaseReadObserver` option on `Coordinate` and
   `ShardedCoordinator.WithLeaseReadObserver`.
 - `elastickv_raft_dispatch_dropped_total{group}` -- mirrors the etcd
   raft engine's `dispatchDropCount`.

--- a/docs/redis_hotpath_dashboard.md
+++ b/docs/redis_hotpath_dashboard.md
@@ -1,0 +1,64 @@
+# Redis Hot Path Dashboard (PR #560 verification)
+
+`monitoring/grafana/dashboards/elastickv-redis-hotpath.json` is the
+operator view for the Redis GET hot path. It was added to confirm that
+PR #560 (`a45ca291` "perf(redis): fast-path GET to avoid ~17-seek type
+probe") landed cleanly in production.
+
+## How to confirm #560 worked
+
+Three panels together answer the question. All other panels on the
+dashboard are supporting context.
+
+| Panel                                 | Expected direction post-deploy                                                                 |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| **LinearizableRead Rate (lease miss)**| Falls sharply as each node rolls. A steady GET workload used to push every GET through this.   |
+| **GET p99 (success)**                 | Flat or down. The fast path removes ~15 pebble seeks per GET, shaving the head of the tail.    |
+| **Lease Fast-Path Hit Ratio**         | Climbs toward 1.0. Leases stay warm because GETs no longer force slow-path ReadIndex traffic.  |
+
+If LinearizableRead rate drops but p99 worsens, something on the
+lease-read path is regressing (look at Raft Queue Saturation). If p99
+drops but the miss rate does not, GETs are still taking the old path,
+which usually means the adapter wiring was not updated on that node.
+
+## Metrics surfaced for this dashboard
+
+Added in this PR:
+
+- `elastickv_lease_read_total{outcome="hit|miss"}` -- counter on
+  `kv.Coordinate.LeaseRead` / `kv.ShardedCoordinator.groupLeaseRead`.
+  Wired via `kv.WithLeaseReadObserver` (single-group) and
+  `ShardedCoordinator.WithLeaseReadObserver`.
+- `elastickv_raft_dispatch_dropped_total{group}` -- mirrors the etcd
+  raft engine's `dispatchDropCount`.
+- `elastickv_raft_dispatch_errors_total{group}` -- mirrors
+  `dispatchErrorCount`.
+- `elastickv_raft_step_queue_full_total{group}` -- new counter that
+  increments every time `enqueueStep` rejects an inbound raft message
+  because `stepCh` was at capacity (the "etcd raft inbound step queue
+  is full" signal).
+
+Already present and reused:
+
+- `elastickv_redis_request_duration_seconds_bucket` for p50/p95/p99.
+- `elastickv_redis_requests_total` / `elastickv_redis_errors_total` for
+  throughput and error ratio.
+
+The dispatch counters are polled, not incremented inline. The etcd
+Engine exposes `DispatchDropCount() / DispatchErrorCount() /
+StepQueueFullCount()` accessors (atomic.Uint64 reads) and
+`monitoring.DispatchCollector` samples them on a 5s tick that matches
+`RaftObserver`. Polling avoids taking an extra interface call on the
+hot raft dispatch path.
+
+## What this dashboard deliberately does NOT show
+
+- Pebble SeekGE rate per command. Pebble's built-in metrics are not
+  yet wired into the Prometheus registry; when they are, add a panel
+  alongside "GET vs SET vs TYPE vs EXISTS Rate" using
+  `pebble_seek_ge_total` (or equivalent) so operators can graph real
+  seek amplification rather than inferring it.
+- goroutine counts in `rawKeyTypeAt` stacks. Go's pprof already
+  covers this; surfacing it as a Prometheus metric would require a
+  custom collector that walks `runtime.Stack()`, which is too
+  expensive to run continuously.

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -180,6 +180,12 @@ type Engine struct {
 
 	dispatchDropCount  atomic.Uint64
 	dispatchErrorCount atomic.Uint64
+	// stepQueueFullCount tracks the number of inbound raft messages
+	// (from remote peers and local handlers) that were dropped because
+	// stepCh was full. Surfaced to Prometheus as
+	// elastickv_raft_step_queue_full_total so operators can correlate
+	// seek-storm goroutine spikes with raft backpressure.
+	stepQueueFullCount atomic.Uint64
 
 	// leaderLossCbsMu guards the slice of callbacks invoked when the node
 	// transitions out of the leader role (graceful transfer, partition
@@ -602,6 +608,42 @@ func (e *Engine) AppliedIndex() uint64 {
 		return 0
 	}
 	return e.appliedIndex.Load()
+}
+
+// DispatchDropCount returns the total number of outbound raft messages
+// dropped before hitting the transport because the per-peer normal or
+// heartbeat channel was full. Monotonic across the life of the engine.
+// Surfaced to Prometheus via the monitoring package so the hot-path
+// dashboard can graph stepCh saturation alongside LinearizableRead
+// rate (see monitoring/grafana/dashboards/elastickv-redis-hotpath.json).
+func (e *Engine) DispatchDropCount() uint64 {
+	if e == nil {
+		return 0
+	}
+	return e.dispatchDropCount.Load()
+}
+
+// DispatchErrorCount returns the total number of outbound raft
+// dispatches that reached the transport but failed (network errors,
+// remote shutdown, etc.). Monotonic across the life of the engine.
+func (e *Engine) DispatchErrorCount() uint64 {
+	if e == nil {
+		return 0
+	}
+	return e.dispatchErrorCount.Load()
+}
+
+// StepQueueFullCount returns the total number of inbound raft messages
+// that could not be enqueued into stepCh because the channel was at
+// capacity. This is the "etcd raft inbound step queue is full" signal
+// from the task description: a spike indicates the local raft loop
+// is starved, usually by something blocking the apply path such as
+// the pre-#560 rawKeyTypeAt seek storm.
+func (e *Engine) StepQueueFullCount() uint64 {
+	if e == nil {
+		return 0
+	}
+	return e.stepQueueFullCount.Load()
 }
 
 // RegisterLeaderLossCallback registers fn to fire every time the local
@@ -2367,6 +2409,7 @@ func (e *Engine) enqueueStep(ctx context.Context, msg raftpb.Message) error {
 	case e.stepCh <- msg:
 		return nil
 	default:
+		e.stepQueueFullCount.Add(1)
 		return errors.WithStack(errStepQueueFull)
 	}
 }

--- a/internal/raftengine/etcd/engine_test.go
+++ b/internal/raftengine/etcd/engine_test.go
@@ -458,9 +458,20 @@ func TestEnqueueStepReturnsQueueFull(t *testing.T) {
 	}
 	engine.stepCh <- raftpb.Message{Type: raftpb.MsgHeartbeat}
 
+	require.Equal(t, uint64(0), engine.StepQueueFullCount())
+
 	err := engine.enqueueStep(context.Background(), raftpb.Message{Type: raftpb.MsgApp})
 	require.Error(t, err)
 	require.True(t, errors.Is(err, errStepQueueFull))
+
+	// The Prometheus hot-path dashboard relies on StepQueueFullCount
+	// advancing exactly once per rejected enqueue so the scraped rate
+	// equals the true drop rate, not a multiple of it.
+	require.Equal(t, uint64(1), engine.StepQueueFullCount())
+
+	err = engine.enqueueStep(context.Background(), raftpb.Message{Type: raftpb.MsgApp})
+	require.Error(t, err)
+	require.Equal(t, uint64(2), engine.StepQueueFullCount())
 }
 
 func TestHandleStepIgnoresPeerNotFoundResponses(t *testing.T) {

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -72,14 +72,14 @@ type LeaseReadObserver interface {
 // stays a single branch on a real nil interface.
 func WithLeaseReadObserver(observer LeaseReadObserver) CoordinatorOption {
 	return func(c *Coordinate) {
-		c.leaseObserver = normaliseLeaseObserver(observer)
+		c.leaseObserver = normalizeLeaseObserver(observer)
 	}
 }
 
-// normaliseLeaseObserver flattens a typed-nil LeaseReadObserver to an
+// normalizeLeaseObserver flattens a typed-nil LeaseReadObserver to an
 // untyped nil interface so downstream `observer != nil` checks behave
 // as expected.
-func normaliseLeaseObserver(observer LeaseReadObserver) LeaseReadObserver {
+func normalizeLeaseObserver(observer LeaseReadObserver) LeaseReadObserver {
 	if observer == nil {
 		return nil
 	}

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"log/slog"
+	"reflect"
 	"time"
 
 	"github.com/bootjp/elastickv/internal/raftengine"
@@ -62,10 +63,34 @@ type LeaseReadObserver interface {
 // This is the mechanism monitoring uses to surface the lease-hit ratio
 // panel on the Redis hot-path dashboard (see
 // monitoring/grafana/dashboards/elastickv-redis-hotpath.json).
+//
+// Typed-nil guard: a caller passing a typed-nil pointer
+// (e.g. `var o *myObserver; WithLeaseReadObserver(o)`) produces an
+// interface value that is NOT equal to nil under the normal `!= nil`
+// check, yet invoking ObserveLeaseRead would panic. Normalise here
+// with reflect.Value.IsNil so the hot-path nil check in LeaseRead
+// stays a single branch on a real nil interface.
 func WithLeaseReadObserver(observer LeaseReadObserver) CoordinatorOption {
 	return func(c *Coordinate) {
-		c.leaseObserver = observer
+		c.leaseObserver = normaliseLeaseObserver(observer)
 	}
+}
+
+// normaliseLeaseObserver flattens a typed-nil LeaseReadObserver to an
+// untyped nil interface so downstream `observer != nil` checks behave
+// as expected.
+func normaliseLeaseObserver(observer LeaseReadObserver) LeaseReadObserver {
+	if observer == nil {
+		return nil
+	}
+	v := reflect.ValueOf(observer)
+	switch v.Kind() { //nolint:exhaustive
+	case reflect.Ptr, reflect.Interface, reflect.Func, reflect.Chan, reflect.Map, reflect.Slice:
+		if v.IsNil() {
+			return nil
+		}
+	}
+	return observer
 }
 
 func NewCoordinator(txm Transactional, r *raft.Raft, opts ...CoordinatorOption) *Coordinate {

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -41,6 +41,33 @@ func WithHLC(hlc *HLC) CoordinatorOption {
 	}
 }
 
+// LeaseReadObserver records lease-read fast-path vs slow-path outcomes
+// without coupling kv to a concrete monitoring backend. It is called once
+// per LeaseRead invocation that actually evaluates the lease (the initial
+// type-assertion/LeaseDuration==0 short-circuits are NOT counted because
+// they indicate the engine does not participate in lease reads at all).
+//
+// Implementations MUST be safe for concurrent use and MUST NOT block; the
+// observer is invoked on the Redis GET hot path.
+type LeaseReadObserver interface {
+	// ObserveLeaseRead is called with hit=true when the lease fast path
+	// served the read from local AppliedIndex, or hit=false when the
+	// coordinator fell back to a full LinearizableRead (expired lease,
+	// engine reported non-leader, or leader-loss callback raced with
+	// the request).
+	ObserveLeaseRead(hit bool)
+}
+
+// WithLeaseReadObserver wires a LeaseReadObserver onto a Coordinate.
+// This is the mechanism monitoring uses to surface the lease-hit ratio
+// panel on the Redis hot-path dashboard (see
+// monitoring/grafana/dashboards/elastickv-redis-hotpath.json).
+func WithLeaseReadObserver(observer LeaseReadObserver) CoordinatorOption {
+	return func(c *Coordinate) {
+		c.leaseObserver = observer
+	}
+}
+
 func NewCoordinator(txm Transactional, r *raft.Raft, opts ...CoordinatorOption) *Coordinate {
 	return NewCoordinatorWithEngine(txm, hashicorpraftengine.New(r), opts...)
 }
@@ -114,6 +141,11 @@ type Coordinate struct {
 	// short-lived test coordinators sharing an engine MUST invoke
 	// Close() to release the callback slot.
 	deregisterLeaseCb func()
+	// leaseObserver records lease-read hit/miss outcomes for metrics
+	// (nil when no observer is attached; LeaseRead short-circuits the
+	// nil check so production does not pay an interface call when
+	// monitoring is disabled).
+	leaseObserver LeaseReadObserver
 }
 
 var _ Coordinator = (*Coordinate)(nil)
@@ -374,7 +406,13 @@ func (c *Coordinate) LeaseRead(ctx context.Context) (uint64, error) {
 	// knows it's not leader, force the slow path (which will fail
 	// fast via LinearizableRead and invalidate the lease).
 	if c.lease.valid(now) && c.engine.State() == raftengine.StateLeader {
+		if c.leaseObserver != nil {
+			c.leaseObserver.ObserveLeaseRead(true)
+		}
 		return lp.AppliedIndex(), nil
+	}
+	if c.leaseObserver != nil {
+		c.leaseObserver.ObserveLeaseRead(false)
 	}
 	idx, err := c.LinearizableRead(ctx)
 	if err != nil {

--- a/kv/lease_read_test.go
+++ b/kv/lease_read_test.go
@@ -347,4 +347,3 @@ func TestCoordinate_LeaseRead_ObserverSeparatesHitsFromMisses(t *testing.T) {
 	require.Equal(t, int32(5), obs.hits.Load())
 	require.Equal(t, int32(1), obs.misses.Load())
 }
-

--- a/kv/lease_read_test.go
+++ b/kv/lease_read_test.go
@@ -312,3 +312,39 @@ func TestCoordinate_LeaseRead_AmortizesLinearizableRead(t *testing.T) {
 	require.Equal(t, int32(1), eng.linearizableCalls.Load(),
 		"100 LeaseRead calls inside the lease window should trigger exactly 1 LinearizableRead")
 }
+
+// countingLeaseObserver records hits and misses for assertion purposes.
+type countingLeaseObserver struct {
+	hits   atomic.Int32
+	misses atomic.Int32
+}
+
+func (o *countingLeaseObserver) ObserveLeaseRead(hit bool) {
+	if hit {
+		o.hits.Add(1)
+		return
+	}
+	o.misses.Add(1)
+}
+
+func TestCoordinate_LeaseRead_ObserverSeparatesHitsFromMisses(t *testing.T) {
+	t.Parallel()
+	eng := &fakeLeaseEngine{applied: 77, leaseDur: time.Hour}
+	obs := &countingLeaseObserver{}
+	c := NewCoordinatorWithEngine(nil, eng, WithLeaseReadObserver(obs))
+
+	// First call: lease not yet extended → slow path, MISS.
+	_, err := c.LeaseRead(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int32(0), obs.hits.Load())
+	require.Equal(t, int32(1), obs.misses.Load())
+
+	// The slow path refreshed the lease; the next N calls must all be hits.
+	for i := 0; i < 5; i++ {
+		_, err := c.LeaseRead(context.Background())
+		require.NoError(t, err)
+	}
+	require.Equal(t, int32(5), obs.hits.Load())
+	require.Equal(t, int32(1), obs.misses.Load())
+}
+

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -132,6 +132,19 @@ type ShardedCoordinator struct {
 	// registered at construction. See Coordinate.Close for the
 	// rationale.
 	deregisterLeaseCbs []func()
+	// leaseObserver records lease-read hit/miss for every shard the
+	// coordinator owns. Nil-safe; see Coordinate.leaseObserver.
+	leaseObserver LeaseReadObserver
+}
+
+// WithShardedLeaseReadObserver wires a LeaseReadObserver onto a
+// ShardedCoordinator. Applied after construction because the
+// NewShardedCoordinator signature is already heavily overloaded;
+// see Coordinate.WithLeaseReadObserver for the equivalent option on
+// the single-group coordinator.
+func (c *ShardedCoordinator) WithLeaseReadObserver(observer LeaseReadObserver) *ShardedCoordinator {
+	c.leaseObserver = observer
+	return c
 }
 
 // NewShardedCoordinator builds a coordinator for the provided shard groups.
@@ -727,7 +740,7 @@ func (c *ShardedCoordinator) LeaseRead(ctx context.Context) (uint64, error) {
 	if !ok {
 		return 0, errors.WithStack(ErrLeaderNotFound)
 	}
-	return groupLeaseRead(ctx, g)
+	return groupLeaseRead(ctx, g, c.leaseObserver)
 }
 
 // LeaseReadForKey performs the lease check on the shard group that owns key.
@@ -738,10 +751,10 @@ func (c *ShardedCoordinator) LeaseReadForKey(ctx context.Context, key []byte) (u
 	if !ok {
 		return 0, errors.WithStack(ErrLeaderNotFound)
 	}
-	return groupLeaseRead(ctx, g)
+	return groupLeaseRead(ctx, g, c.leaseObserver)
 }
 
-func groupLeaseRead(ctx context.Context, g *ShardGroup) (uint64, error) {
+func groupLeaseRead(ctx context.Context, g *ShardGroup, observer LeaseReadObserver) (uint64, error) {
 	engine := engineForGroup(g)
 	lp, ok := engine.(raftengine.LeaseProvider)
 	if !ok {
@@ -763,7 +776,13 @@ func groupLeaseRead(ctx context.Context, g *ShardGroup) (uint64, error) {
 	// State() is refreshed every tick and catches transitions
 	// sooner. See Coordinate.LeaseRead for details.
 	if g.lease.valid(now) && engine.State() == raftengine.StateLeader {
+		if observer != nil {
+			observer.ObserveLeaseRead(true)
+		}
 		return lp.AppliedIndex(), nil
+	}
+	if observer != nil {
+		observer.ObserveLeaseRead(false)
 	}
 	idx, err := linearizableReadEngineCtx(ctx, engine)
 	if err != nil {

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -137,7 +137,7 @@ type ShardedCoordinator struct {
 	leaseObserver LeaseReadObserver
 }
 
-// WithShardedLeaseReadObserver wires a LeaseReadObserver onto a
+// WithLeaseReadObserver wires a LeaseReadObserver onto a
 // ShardedCoordinator. Applied after construction because the
 // NewShardedCoordinator signature is already heavily overloaded;
 // see Coordinate.WithLeaseReadObserver for the equivalent option on

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -141,9 +141,10 @@ type ShardedCoordinator struct {
 // ShardedCoordinator. Applied after construction because the
 // NewShardedCoordinator signature is already heavily overloaded;
 // see Coordinate.WithLeaseReadObserver for the equivalent option on
-// the single-group coordinator.
+// the single-group coordinator, including the typed-nil guard
+// rationale.
 func (c *ShardedCoordinator) WithLeaseReadObserver(observer LeaseReadObserver) *ShardedCoordinator {
-	c.leaseObserver = observer
+	c.leaseObserver = normaliseLeaseObserver(observer)
 	return c
 }
 

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -144,7 +144,7 @@ type ShardedCoordinator struct {
 // the single-group coordinator, including the typed-nil guard
 // rationale.
 func (c *ShardedCoordinator) WithLeaseReadObserver(observer LeaseReadObserver) *ShardedCoordinator {
-	c.leaseObserver = normaliseLeaseObserver(observer)
+	c.leaseObserver = normalizeLeaseObserver(observer)
 	return c
 }
 

--- a/main.go
+++ b/main.go
@@ -167,7 +167,8 @@ func run() error {
 	cleanup.Add(cancel)
 	lockResolver := kv.NewLockResolver(shardStore, shardGroups, nil)
 	cleanup.Add(func() { lockResolver.Close() })
-	coordinate := kv.NewShardedCoordinator(cfg.engine, shardGroups, cfg.defaultGroup, clock, shardStore)
+	coordinate := kv.NewShardedCoordinator(cfg.engine, shardGroups, cfg.defaultGroup, clock, shardStore).
+		WithLeaseReadObserver(metricsRegistry.LeaseReadObserver())
 	distCatalog, err := setupDistributionCatalog(ctx, runtimes, cfg.engine)
 	if err != nil {
 		return err
@@ -183,6 +184,9 @@ func run() error {
 		adapter.WithDistributionActiveTimestampTracker(readTracker),
 	)
 	metricsRegistry.RaftObserver().Start(runCtx, raftMonitorRuntimes(runtimes), raftMetricsObserveInterval)
+	if collector := metricsRegistry.DispatchCollector(); collector != nil {
+		collector.Start(runCtx, dispatchMonitorSources(runtimes), raftMetricsObserveInterval)
+	}
 	compactor := kv.NewFSMCompactor(
 		fsmCompactionRuntimes(runtimes),
 		kv.WithFSMCompactorActiveTimestampTracker(readTracker),
@@ -438,6 +442,29 @@ func raftMonitorRuntimes(runtimes []*raftGroupRuntime) []monitoring.RaftRuntime 
 			GroupID:      runtime.spec.id,
 			StatusReader: runtime.engine,
 			ConfigReader: runtime.engine,
+		})
+	}
+	return out
+}
+
+// dispatchMonitorSources extracts the raft engines that expose etcd
+// dispatch counters so monitoring can poll them for the hot-path
+// dashboard. Engines that do not satisfy the interface (hashicorp
+// backend today) are skipped silently; their groups simply won't
+// contribute to elastickv_raft_dispatch_* metrics.
+func dispatchMonitorSources(runtimes []*raftGroupRuntime) []monitoring.DispatchSource {
+	out := make([]monitoring.DispatchSource, 0, len(runtimes))
+	for _, runtime := range runtimes {
+		if runtime == nil || runtime.engine == nil {
+			continue
+		}
+		src, ok := runtime.engine.(monitoring.DispatchCounterSource)
+		if !ok {
+			continue
+		}
+		out = append(out, monitoring.DispatchSource{
+			GroupID: runtime.spec.id,
+			Source:  src,
 		})
 	}
 	return out

--- a/monitoring/grafana/dashboards/elastickv-redis-hotpath.json
+++ b/monitoring/grafana/dashboards/elastickv-redis-hotpath.json
@@ -74,7 +74,7 @@
         {
           "datasource": "$datasource",
           "editorMode": "code",
-          "expr": "sum(rate(elastickv_lease_read_total{job=\"$job\",node_id=~\"$node_id\",outcome=\"hit\"}[5m])) / sum(rate(elastickv_lease_read_total{job=\"$job\",node_id=~\"$node_id\"}[5m]))",
+          "expr": "sum(rate(elastickv_lease_read_total{job=\"$job\",node_id=~\"$node_id\",outcome=\"hit\"}[5m])) / clamp_min(sum(rate(elastickv_lease_read_total{job=\"$job\",node_id=~\"$node_id\"}[5m])), 1e-9)",
           "legendFormat": "hit ratio",
           "refId": "A",
           "instant": true

--- a/monitoring/grafana/dashboards/elastickv-redis-hotpath.json
+++ b/monitoring/grafana/dashboards/elastickv-redis-hotpath.json
@@ -1,0 +1,648 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Redis GET hot-path health for elastickv. Built to verify PR #560 (GET fast-path skipping rawKeyTypeAt). The three panels that answer 'did #560 work?' are LinearizableRead Rate, GET Latency (p50/p95/p99), and Lease Fast-Path Hit Ratio: a successful rollout shows LinearizableRead rate collapsing, GET p99 holding or improving, and the hit ratio climbing toward 1.0.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "orange",
+                "value": 0.9
+              },
+              {
+                "color": "green",
+                "value": 0.99
+              }
+            ]
+          },
+          "min": 0,
+          "max": 1,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "sum(rate(elastickv_lease_read_total{job=\"$job\",node_id=~\"$node_id\",outcome=\"hit\"}[5m])) / sum(rate(elastickv_lease_read_total{job=\"$job\",node_id=~\"$node_id\"}[5m]))",
+          "legendFormat": "hit ratio",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "Lease Fast-Path Hit Ratio",
+      "type": "stat",
+      "description": "Fraction of Coordinator.LeaseRead calls served from the local AppliedIndex instead of a full LinearizableRead. Steady-state should be >= 0.99 on a hot workload; a drop indicates leader flaps, clock-skew-driven lease expiry, or a regression on the fast path. This is one of the three #560-verification panels: if #560 landed, GET traffic should flow through LeaseRead and push this toward 1.0."
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "orange",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.25
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(elastickv_redis_request_duration_seconds_bucket{job=\"$job\",node_id=~\"$node_id\",command=\"GET\",outcome=\"success\"}[5m])))",
+          "legendFormat": "GET p99",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "GET p99 (success)",
+      "type": "stat",
+      "description": "Current p99 latency for successful GET commands over the last 5 minutes. One of the three #560-verification panels: the fast path halved pebble seek count, so this should be FLAT or DOWN across the rollout, never up."
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "sum(rate(elastickv_lease_read_total{job=\"$job\",node_id=~\"$node_id\",outcome=\"miss\"}[5m]))",
+          "legendFormat": "lease misses/s",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "LinearizableRead Rate (lease miss)",
+      "type": "stat",
+      "description": "Rate of Coordinator.LeaseRead calls that FELL BACK to LinearizableRead. Every miss corresponds to one slow-path raft ReadIndex round-trip, the exact behaviour #560 eliminates for GETs on steady leaders. This is the third #560-verification panel: watch it collapse as the rollout reaches each node."
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "orange",
+                "value": 0.001
+              },
+              {
+                "color": "red",
+                "value": 0.01
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "sum(rate(elastickv_redis_errors_total{job=\"$job\",node_id=~\"$node_id\",command=\"GET\"}[5m])) / clamp_min(sum(rate(elastickv_redis_requests_total{job=\"$job\",node_id=~\"$node_id\",command=\"GET\"}[5m])), 1e-9)",
+          "legendFormat": "GET error ratio",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "GET Error Ratio",
+      "type": "stat",
+      "description": "Fraction of GET requests returning an error. Paired with the GET p99 stat so operators can tell latency wins from quietly-shed traffic: a fast-path bug that mis-classifies a key could turn latency wins into NIL responses, which would light up this tile but not the latency one."
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "auto"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(elastickv_redis_request_duration_seconds_bucket{job=\"$job\",node_id=~\"$node_id\",command=\"GET\",outcome=\"success\"}[5m])))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(elastickv_redis_request_duration_seconds_bucket{job=\"$job\",node_id=~\"$node_id\",command=\"GET\",outcome=\"success\"}[5m])))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(elastickv_redis_request_duration_seconds_bucket{job=\"$job\",node_id=~\"$node_id\",command=\"GET\",outcome=\"success\"}[5m])))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "GET Latency (p50 / p95 / p99)",
+      "type": "timeseries",
+      "description": "Per-quantile GET latency taken from elastickv_redis_request_duration_seconds. #560 reduces string-GET pebble SeekGE calls from ~17 to 1-2, so the p50 should barely move (it was already fast) while p95 and especially p99 tighten on the head of the distribution. Overlay with the deploy annotation to see the step change."
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "auto"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "sum by (node_id) (rate(elastickv_redis_requests_total{job=\"$job\",node_id=~\"$node_id\",command=\"GET\",outcome=\"success\"}[5m]))",
+          "legendFormat": "{{node_id}} success",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "sum by (node_id) (rate(elastickv_redis_requests_total{job=\"$job\",node_id=~\"$node_id\",command=\"GET\",outcome=\"error\"}[5m]))",
+          "legendFormat": "{{node_id}} error",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "GET Throughput and Errors (per node)",
+      "type": "timeseries",
+      "description": "Per-node GET request rate split by outcome. Shows whether the rollout affects traffic distribution: if one node's GET rate collapses post-deploy without a matching rise elsewhere, clients are likely disconnecting instead of fast-pathing, which invalidates the latency-win interpretation."
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "sum(rate(elastickv_lease_read_total{job=\"$job\",node_id=~\"$node_id\",outcome=\"hit\"}[5m]))",
+          "legendFormat": "hits",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "sum(rate(elastickv_lease_read_total{job=\"$job\",node_id=~\"$node_id\",outcome=\"miss\"}[5m]))",
+          "legendFormat": "misses (= LinearizableRead)",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Lease Hit vs LinearizableRead Rate Over Time",
+      "type": "timeseries",
+      "description": "Hit and miss rates as time series so operators can correlate miss spikes with leader elections (see the Raft dashboard's leader_changes counter) or lease clock-skew events. The miss series IS the raft engine's slow-path read rate; a clean #560 rollout should show this line fall sharply while hits rise."
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "auto"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "sum by (group) (rate(elastickv_raft_step_queue_full_total{job=\"$job\",node_id=~\"$node_id\"}[5m]))",
+          "legendFormat": "stepCh full (group {{group}})",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "sum by (group) (rate(elastickv_raft_dispatch_dropped_total{job=\"$job\",node_id=~\"$node_id\"}[5m]))",
+          "legendFormat": "dispatch dropped (group {{group}})",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "sum by (group) (rate(elastickv_raft_dispatch_errors_total{job=\"$job\",node_id=~\"$node_id\"}[5m]))",
+          "legendFormat": "dispatch errors (group {{group}})",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Raft Queue Saturation (stepCh full / outbound drops / errors)",
+      "type": "timeseries",
+      "description": "Counter rates from the etcd raft engine. stepCh-full means inbound messages from remote peers were dropped because the local raft loop was too slow to consume them (the 'etcd raft inbound step queue is full' log line). dispatch-dropped means outbound messages were discarded before transport because the per-peer channel was full. dispatch-errors means transport delivery failed. The pre-#560 seek storm caused all three to spike together; watch for them to fall after the rollout and stay flat."
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "auto"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "sum by (command) (rate(elastickv_redis_requests_total{job=\"$job\",node_id=~\"$node_id\",command=~\"GET|SET|TYPE|EXISTS\"}[5m]))",
+          "legendFormat": "{{command}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GET vs SET vs TYPE vs EXISTS Rate",
+      "type": "timeseries",
+      "description": "Proxy for seek amplification: before #560, every GET internally issued a TYPE probe, so the ratio of TYPE-like rawKeyTypeAt work to GETs was ~1:1. We do not currently export pebble SeekGE directly; this panel lets operators sanity-check that GET's external rate hasn't shifted relative to SET/TYPE/EXISTS in a way that would explain latency changes. If pebble SeekGE telemetry is exposed later, a dedicated panel should be added here."
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 41,
+  "tags": [
+    "elastickv",
+    "redis",
+    "hot-path",
+    "pr-560"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "elastickv",
+          "value": "elastickv"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Job",
+        "multi": false,
+        "name": "job",
+        "options": [
+          {
+            "selected": true,
+            "text": "elastickv",
+            "value": "elastickv"
+          }
+        ],
+        "query": "elastickv",
+        "type": "custom"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": "$datasource",
+        "definition": "label_values(elastickv_redis_requests_total{job=\"$job\"}, node_id)",
+        "includeAll": true,
+        "label": "Node ID",
+        "multi": true,
+        "name": "node_id",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(elastickv_redis_requests_total{job=\"$job\"}, node_id)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Elastickv Redis Hot Path (PR #560)",
+  "uid": "elastickv-redis-hotpath",
+  "version": 1
+}

--- a/monitoring/hotpath.go
+++ b/monitoring/hotpath.go
@@ -16,8 +16,8 @@ import (
 // string-dominated workload while GET p99 stays flat or improves, and
 // the lease-hit ratio approaches 1.0 once leases are steady.
 //
-// Names follow the existing elastickv_* prefix convention. All
-// counters are monotonic; gauges are set directly.
+// Names follow the existing elastickv_* prefix convention. The
+// metrics defined in this file are all monotonic counters.
 
 const (
 	leaseReadOutcomeHit  = "hit"

--- a/monitoring/hotpath.go
+++ b/monitoring/hotpath.go
@@ -1,0 +1,209 @@
+package monitoring
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Hot-path metrics support the "Redis Hot Path" dashboard
+// (monitoring/grafana/dashboards/elastickv-redis-hotpath.json). They
+// were added to confirm PR #560 (GET fast-path) landed in production:
+// the LinearizableRead call rate should drop sharply on a
+// string-dominated workload while GET p99 stays flat or improves, and
+// the lease-hit ratio approaches 1.0 once leases are steady.
+//
+// Names follow the existing elastickv_* prefix convention. All
+// counters are monotonic; gauges are set directly.
+
+const (
+	leaseReadOutcomeHit  = "hit"
+	leaseReadOutcomeMiss = "miss"
+
+	defaultDispatchPollInterval = 5 * time.Second
+)
+
+// HotPathMetrics owns the Prometheus vectors introduced for the Redis
+// GET hot-path dashboard. Kept in its own type so the Registry can hold
+// a single instance and hand out scoped observer/collector objects.
+type HotPathMetrics struct {
+	leaseReadsTotal      *prometheus.CounterVec
+	dispatchDroppedTotal *prometheus.CounterVec
+	dispatchErrorsTotal  *prometheus.CounterVec
+	stepQueueFullTotal   *prometheus.CounterVec
+}
+
+func newHotPathMetrics(registerer prometheus.Registerer) *HotPathMetrics {
+	m := &HotPathMetrics{
+		leaseReadsTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "elastickv_lease_read_total",
+				Help: "Lease-read outcomes from the kv Coordinator (hit = served from local AppliedIndex, miss = fell back to LinearizableRead).",
+			},
+			[]string{"outcome"},
+		),
+		dispatchDroppedTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "elastickv_raft_dispatch_dropped_total",
+				Help: "Outbound raft messages dropped before transport because the per-peer channel was full. Mirrors etcd raft Engine.dispatchDropCount.",
+			},
+			[]string{"group"},
+		),
+		dispatchErrorsTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "elastickv_raft_dispatch_errors_total",
+				Help: "Outbound raft dispatches that reached the transport but failed. Mirrors etcd raft Engine.dispatchErrorCount.",
+			},
+			[]string{"group"},
+		),
+		stepQueueFullTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "elastickv_raft_step_queue_full_total",
+				Help: "Inbound raft messages that could not be enqueued because stepCh was full; indicates the raft loop is starved (classic pre-#560 seek-storm symptom).",
+			},
+			[]string{"group"},
+		),
+	}
+
+	registerer.MustRegister(
+		m.leaseReadsTotal,
+		m.dispatchDroppedTotal,
+		m.dispatchErrorsTotal,
+		m.stepQueueFullTotal,
+	)
+	return m
+}
+
+// LeaseReadObserver implements kv.LeaseReadObserver by incrementing the
+// elastickv_lease_read_total counter vector. Callers grab an instance
+// via Registry.LeaseReadObserver(); the zero value is safe and silently
+// drops samples, so tests can pass LeaseReadObserver{} as a stub.
+type LeaseReadObserver struct {
+	metrics *HotPathMetrics
+}
+
+// ObserveLeaseRead records a single lease-read outcome.
+func (o LeaseReadObserver) ObserveLeaseRead(hit bool) {
+	if o.metrics == nil {
+		return
+	}
+	outcome := leaseReadOutcomeMiss
+	if hit {
+		outcome = leaseReadOutcomeHit
+	}
+	o.metrics.leaseReadsTotal.WithLabelValues(outcome).Inc()
+}
+
+// DispatchCounterSource abstracts the etcd raft Engine's monotonic
+// dispatch counters so monitoring can scrape them without importing
+// the etcd package. The concrete etcd Engine satisfies this interface
+// via its DispatchDropCount / DispatchErrorCount / StepQueueFullCount
+// accessors.
+type DispatchCounterSource interface {
+	DispatchDropCount() uint64
+	DispatchErrorCount() uint64
+	StepQueueFullCount() uint64
+}
+
+// DispatchSource binds a raft group ID to its counter source. Multiple
+// groups can be polled by a single collector on a sharded node.
+type DispatchSource struct {
+	GroupID uint64
+	Source  DispatchCounterSource
+}
+
+// DispatchCollector polls the etcd raft Engine's atomic dispatch
+// counters on a fixed interval and mirrors them into monotonic
+// Prometheus counters. We poll rather than calling Add() inline in the
+// raft path because those code paths are already hot and must not take
+// any additional interface call; the counters are atomic.Uint64 in the
+// engine and polling is cheap (O(groups) reads every 5s).
+type DispatchCollector struct {
+	metrics *HotPathMetrics
+
+	mu       sync.Mutex
+	previous map[uint64]dispatchSnapshot
+}
+
+type dispatchSnapshot struct {
+	drops     uint64
+	errors    uint64
+	stepFulls uint64
+}
+
+func newDispatchCollector(metrics *HotPathMetrics) *DispatchCollector {
+	return &DispatchCollector{
+		metrics:  metrics,
+		previous: map[uint64]dispatchSnapshot{},
+	}
+}
+
+// Start polls sources on the given interval until ctx is canceled.
+// Passing interval <= 0 uses defaultDispatchPollInterval (5 s), which
+// matches the cadence of RaftObserver so operators see consistent
+// refresh rates across dashboards.
+func (c *DispatchCollector) Start(ctx context.Context, sources []DispatchSource, interval time.Duration) {
+	if c == nil || c.metrics == nil || len(sources) == 0 {
+		return
+	}
+	if interval <= 0 {
+		interval = defaultDispatchPollInterval
+	}
+	c.observeOnce(sources)
+	ticker := time.NewTicker(interval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				c.observeOnce(sources)
+			}
+		}
+	}()
+}
+
+// ObserveOnce is exposed for tests and single-shot callers.
+func (c *DispatchCollector) ObserveOnce(sources []DispatchSource) {
+	c.observeOnce(sources)
+}
+
+func (c *DispatchCollector) observeOnce(sources []DispatchSource) {
+	if c == nil || c.metrics == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, src := range sources {
+		if src.Source == nil {
+			continue
+		}
+		curr := dispatchSnapshot{
+			drops:     src.Source.DispatchDropCount(),
+			errors:    src.Source.DispatchErrorCount(),
+			stepFulls: src.Source.StepQueueFullCount(),
+		}
+		prev := c.previous[src.GroupID]
+		group := strconv.FormatUint(src.GroupID, 10)
+		// The engine's counters are monotonic; still, guard against
+		// wraparound / replacement of the underlying engine (e.g. a
+		// test reopens it) by only advancing the Prometheus counter
+		// when the current value is strictly greater than the last
+		// snapshot. A smaller value means the source was reset and
+		// we restart the delta baseline without emitting negative.
+		if curr.drops > prev.drops {
+			c.metrics.dispatchDroppedTotal.WithLabelValues(group).Add(float64(curr.drops - prev.drops))
+		}
+		if curr.errors > prev.errors {
+			c.metrics.dispatchErrorsTotal.WithLabelValues(group).Add(float64(curr.errors - prev.errors))
+		}
+		if curr.stepFulls > prev.stepFulls {
+			c.metrics.stepQueueFullTotal.WithLabelValues(group).Add(float64(curr.stepFulls - prev.stepFulls))
+		}
+		c.previous[src.GroupID] = curr
+	}
+}

--- a/monitoring/hotpath_test.go
+++ b/monitoring/hotpath_test.go
@@ -1,0 +1,126 @@
+package monitoring
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeaseReadObserverHitsAndMisses(t *testing.T) {
+	registry := NewRegistry("n1", "10.0.0.1:50051")
+	observer := registry.LeaseReadObserver()
+
+	observer.ObserveLeaseRead(true)
+	observer.ObserveLeaseRead(true)
+	observer.ObserveLeaseRead(false)
+
+	err := testutil.GatherAndCompare(
+		registry.Gatherer(),
+		strings.NewReader(`
+# HELP elastickv_lease_read_total Lease-read outcomes from the kv Coordinator (hit = served from local AppliedIndex, miss = fell back to LinearizableRead).
+# TYPE elastickv_lease_read_total counter
+elastickv_lease_read_total{node_address="10.0.0.1:50051",node_id="n1",outcome="hit"} 2
+elastickv_lease_read_total{node_address="10.0.0.1:50051",node_id="n1",outcome="miss"} 1
+`),
+		"elastickv_lease_read_total",
+	)
+	require.NoError(t, err)
+}
+
+func TestLeaseReadObserverZeroValueIsNoop(t *testing.T) {
+	// LeaseReadObserver{} is documented as safe; the Coordinator
+	// falls back to this when monitoring is disabled. Calling
+	// ObserveLeaseRead must not panic.
+	var observer LeaseReadObserver
+	require.NotPanics(t, func() {
+		observer.ObserveLeaseRead(true)
+		observer.ObserveLeaseRead(false)
+	})
+}
+
+// fakeDispatchSource implements DispatchCounterSource on atomic
+// uint64s so tests can advance counters without touching the etcd
+// engine directly.
+type fakeDispatchSource struct {
+	drops     atomic.Uint64
+	errors    atomic.Uint64
+	stepFulls atomic.Uint64
+}
+
+func (f *fakeDispatchSource) DispatchDropCount() uint64  { return f.drops.Load() }
+func (f *fakeDispatchSource) DispatchErrorCount() uint64 { return f.errors.Load() }
+func (f *fakeDispatchSource) StepQueueFullCount() uint64 { return f.stepFulls.Load() }
+
+func TestDispatchCollectorMirrorsDeltas(t *testing.T) {
+	registry := NewRegistry("n1", "10.0.0.1:50051")
+	collector := registry.DispatchCollector()
+	require.NotNil(t, collector)
+
+	src := &fakeDispatchSource{}
+	sources := []DispatchSource{{GroupID: 1, Source: src}}
+
+	// First pass initialises the delta baseline.
+	collector.ObserveOnce(sources)
+
+	src.drops.Store(3)
+	src.errors.Store(2)
+	src.stepFulls.Store(1)
+	collector.ObserveOnce(sources)
+
+	// A second pass with no change must NOT double-count.
+	collector.ObserveOnce(sources)
+
+	err := testutil.GatherAndCompare(
+		registry.Gatherer(),
+		strings.NewReader(`
+# HELP elastickv_raft_dispatch_dropped_total Outbound raft messages dropped before transport because the per-peer channel was full. Mirrors etcd raft Engine.dispatchDropCount.
+# TYPE elastickv_raft_dispatch_dropped_total counter
+elastickv_raft_dispatch_dropped_total{group="1",node_address="10.0.0.1:50051",node_id="n1"} 3
+# HELP elastickv_raft_dispatch_errors_total Outbound raft dispatches that reached the transport but failed. Mirrors etcd raft Engine.dispatchErrorCount.
+# TYPE elastickv_raft_dispatch_errors_total counter
+elastickv_raft_dispatch_errors_total{group="1",node_address="10.0.0.1:50051",node_id="n1"} 2
+# HELP elastickv_raft_step_queue_full_total Inbound raft messages that could not be enqueued because stepCh was full; indicates the raft loop is starved (classic pre-#560 seek-storm symptom).
+# TYPE elastickv_raft_step_queue_full_total counter
+elastickv_raft_step_queue_full_total{group="1",node_address="10.0.0.1:50051",node_id="n1"} 1
+`),
+		"elastickv_raft_dispatch_dropped_total",
+		"elastickv_raft_dispatch_errors_total",
+		"elastickv_raft_step_queue_full_total",
+	)
+	require.NoError(t, err)
+}
+
+func TestDispatchCollectorHandlesSourceReset(t *testing.T) {
+	// If the engine's counter is replaced (e.g. a test reopens it)
+	// the snapshot may go DOWN. The collector must not emit negative
+	// deltas; instead, it rebases silently.
+	registry := NewRegistry("n1", "10.0.0.1:50051")
+	collector := registry.DispatchCollector()
+
+	src := &fakeDispatchSource{}
+	sources := []DispatchSource{{GroupID: 7, Source: src}}
+
+	src.drops.Store(10)
+	collector.ObserveOnce(sources) // mirrors initial 10
+
+	src.drops.Store(4) // simulated reset: MUST NOT emit -6
+	collector.ObserveOnce(sources)
+
+	src.drops.Store(6) // +2 from the post-reset baseline
+	collector.ObserveOnce(sources)
+
+	// Expected: 10 (initial) + 0 (no negative) + 2 (post-reset delta) = 12.
+	err := testutil.GatherAndCompare(
+		registry.Gatherer(),
+		strings.NewReader(`
+# HELP elastickv_raft_dispatch_dropped_total Outbound raft messages dropped before transport because the per-peer channel was full. Mirrors etcd raft Engine.dispatchDropCount.
+# TYPE elastickv_raft_dispatch_dropped_total counter
+elastickv_raft_dispatch_dropped_total{group="7",node_address="10.0.0.1:50051",node_id="n1"} 12
+`),
+		"elastickv_raft_dispatch_dropped_total",
+	)
+	require.NoError(t, err)
+}

--- a/monitoring/registry.go
+++ b/monitoring/registry.go
@@ -14,10 +14,11 @@ type Registry struct {
 	registerer   prometheus.Registerer
 	gatherer     prometheus.Gatherer
 
-	dynamo *DynamoDBMetrics
-	redis  *RedisMetrics
-	raft   *RaftMetrics
-	lua    *LuaMetrics
+	dynamo  *DynamoDBMetrics
+	redis   *RedisMetrics
+	raft    *RaftMetrics
+	lua     *LuaMetrics
+	hotPath *HotPathMetrics
 }
 
 // NewRegistry builds a registry with constant labels that identify the local node.
@@ -37,6 +38,7 @@ func NewRegistry(nodeID string, nodeAddress string) *Registry {
 	r.redis = newRedisMetrics(registerer)
 	r.raft = newRaftMetrics(registerer)
 	r.lua = newLuaMetrics(registerer)
+	r.hotPath = newHotPathMetrics(registerer)
 	return r
 }
 
@@ -97,4 +99,25 @@ func (r *Registry) RaftProposalObserver(groupID uint64) *raftProposalObserver {
 		metrics: r.raft,
 		group:   strconv.FormatUint(groupID, 10),
 	}
+}
+
+// LeaseReadObserver returns an observer for the kv coordinator's
+// LeaseRead fast-path counter. Returns a zero-value observer when the
+// registry is nil so callers can pass the result through without
+// checking; the zero value silently drops samples.
+func (r *Registry) LeaseReadObserver() LeaseReadObserver {
+	if r == nil {
+		return LeaseReadObserver{}
+	}
+	return LeaseReadObserver{metrics: r.hotPath}
+}
+
+// DispatchCollector returns a collector that polls the etcd raft
+// engine's dispatch counters and exports them to Prometheus. Start it
+// with the node's raft sources after engine Open() completes.
+func (r *Registry) DispatchCollector() *DispatchCollector {
+	if r == nil || r.hotPath == nil {
+		return nil
+	}
+	return newDispatchCollector(r.hotPath)
 }


### PR DESCRIPTION
## Summary
- Adds `monitoring/grafana/dashboards/elastickv-redis-hotpath.json` and wires the three Prometheus counters it needs (`elastickv_lease_read_total`, `elastickv_raft_dispatch_dropped_total` + `_errors_total`, `elastickv_raft_step_queue_full_total`) so the production team can confirm PR #560 (merged at `a45ca291`) landed cleanly.
- The three panels that answer "did #560 work?" are the LinearizableRead Rate, GET p99, and Lease Fast-Path Hit Ratio stats at the top of the dashboard. Expected direction post-deploy is called out in the panel descriptions and in `docs/redis_hotpath_dashboard.md`.
- The dispatch counters mirror the etcd raft engine's existing atomic `dispatchDropCount` / `dispatchErrorCount`; a new `stepQueueFullCount` was added alongside them. A new `monitoring.DispatchCollector` polls all three on a 5s tick so no additional interface call is added to the hot raft dispatch path.

## What was already there vs. new
Already exported and reused for the new dashboard:
- `elastickv_redis_request_duration_seconds_bucket` (GET p50/p95/p99)
- `elastickv_redis_requests_total`, `elastickv_redis_errors_total` (throughput, error ratio)

New in this PR:
- `elastickv_lease_read_total{outcome="hit|miss"}` -- wired via a new `kv.LeaseReadObserver` interface plus `WithLeaseReadObserver` / `ShardedCoordinator.WithLeaseReadObserver` options, following the existing `ProposalObserver` pattern.
- `elastickv_raft_dispatch_dropped_total{group}` / `elastickv_raft_dispatch_errors_total{group}` -- polled from new `Engine.DispatchDropCount` / `Engine.DispatchErrorCount` accessors.
- `elastickv_raft_step_queue_full_total{group}` -- polled from new `Engine.StepQueueFullCount` backed by an atomic increment inside `enqueueStep`.

## Caveats
- The hashicorp raft backend does not satisfy `monitoring.DispatchCounterSource`; its groups simply won't contribute to `elastickv_raft_dispatch_*` metrics. This is deliberate: #560 only matters on the etcd engine path.
- Pebble SeekGE rate is not exported yet. The "GET vs SET vs TYPE vs EXISTS Rate" panel is the best available proxy; a dedicated seek panel should be added when pebble metrics get wired up.
- The dashboard's `$job` template defaults to `elastickv`; adjust if your scrape job is named differently.

## Test plan
- [x] `go test ./monitoring/... ./kv/... ./internal/raftengine/etcd/...` passes (new tests: `TestLeaseReadObserverHitsAndMisses`, `TestLeaseReadObserverZeroValueIsNoop`, `TestDispatchCollectorMirrorsDeltas`, `TestDispatchCollectorHandlesSourceReset`, `TestCoordinate_LeaseRead_ObserverSeparatesHitsFromMisses`, extended `TestEnqueueStepReturnsQueueFull`).
- [x] `go test ./adapter/...` passes.
- [x] `go test .` passes.
- [x] `go build ./... && go vet ./...` clean.
- [x] Dashboard JSON parses (`json.load`).
- [ ] Import dashboard into a Grafana instance wired to a real elastickv cluster and confirm all PromQL expressions resolve.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Grafana dashboard for monitoring Redis hot-path behavior, displaying lease fast-path hit ratios, GET latency percentiles, and raft queue saturation metrics.
  * Introduced new metrics tracking lease read outcomes, raft dispatch operations, and step queue capacity events.

* **Documentation**
  * Added comprehensive guide for validating Redis hot-path metrics after deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->