### PR TITLE
perf(redis): fast-path HGET / HEXISTS / SISMEMBER wide-column lookups

### DIFF
--- a/adapter/redis_collection_fastpath_test.go
+++ b/adapter/redis_collection_fastpath_test.go
@@ -1,0 +1,307 @@
+package adapter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the semantics of the wide-column fast paths for
+// HGET, HEXISTS, and SISMEMBER introduced in PR #565. Each command
+// now probes the specific field / member key directly and falls back
+// to the keyTypeAt + loadHash/SetAt slow path on miss, so we need
+// end-to-end coverage for:
+//
+//   - fast-path hit (wide-column present, TTL alive)
+//   - TTL-expired hit (wide-column row physically present but the
+//     hash/set has a past EXPIRE -- must return nil / 0)
+//   - miss (nonexistent user key -- must return nil / 0)
+//   - WRONGTYPE (user key exists but as a string, not the expected
+//     collection type)
+//
+// The tests deliberately speak Redis RESP rather than calling
+// hashFieldFastLookup / setMemberFastExists directly, so they also
+// cover the handler wiring above the helpers (WriteBulk vs
+// WriteBulkString path for HGET, integer protocol for HEXISTS /
+// SISMEMBER, etc.).
+
+const collectionFastPathTTL = 80 * time.Millisecond
+
+// waitForTTLExpiry sleeps past a short TTL so the next read sees the
+// key as expired. A small headroom accounts for wall-clock jitter on
+// CI; tests that are sensitive to this use short TTLs (~80 ms) so the
+// delay stays well under a second.
+func waitForTTLExpiry() {
+	time.Sleep(collectionFastPathTTL + 50*time.Millisecond)
+}
+
+func TestRedis_HGET_FastPathHit(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.HSet(ctx, "h:fast", "field", "value").Err())
+
+	got, err := rdb.HGet(ctx, "h:fast", "field").Result()
+	require.NoError(t, err)
+	require.Equal(t, "value", got)
+}
+
+func TestRedis_HGET_Miss(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	_, err := rdb.HGet(ctx, "h:missing", "field").Result()
+	require.ErrorIs(t, err, redis.Nil, "HGET on a nonexistent key must return nil")
+}
+
+func TestRedis_HGET_UnknownField(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.HSet(ctx, "h:known", "a", "1").Err())
+	_, err := rdb.HGet(ctx, "h:known", "b").Result()
+	require.ErrorIs(t, err, redis.Nil, "HGET on an existing hash but unknown field must return nil")
+}
+
+func TestRedis_HGET_WRONGTYPE(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.Set(ctx, "h:str", "not-a-hash", 0).Err())
+	_, err := rdb.HGet(ctx, "h:str", "field").Result()
+	require.Error(t, err, "HGET on a string key must return WRONGTYPE")
+	require.Contains(t, err.Error(), "WRONGTYPE")
+}
+
+func TestRedis_HGET_TTLExpired(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.HSet(ctx, "h:ttl", "field", "value").Err())
+	require.NoError(t, rdb.PExpire(ctx, "h:ttl", collectionFastPathTTL).Err())
+	waitForTTLExpiry()
+
+	_, err := rdb.HGet(ctx, "h:ttl", "field").Result()
+	require.ErrorIs(t, err, redis.Nil, "HGET on an expired hash must return nil")
+}
+
+func TestRedis_HEXISTS_FastPathHit(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.HSet(ctx, "he:fast", "field", "v").Err())
+
+	ok, err := rdb.HExists(ctx, "he:fast", "field").Result()
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+func TestRedis_HEXISTS_Miss(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	ok, err := rdb.HExists(ctx, "he:missing", "field").Result()
+	require.NoError(t, err)
+	require.False(t, ok, "HEXISTS on a nonexistent key must return 0")
+}
+
+func TestRedis_HEXISTS_UnknownField(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.HSet(ctx, "he:known", "a", "1").Err())
+	ok, err := rdb.HExists(ctx, "he:known", "b").Result()
+	require.NoError(t, err)
+	require.False(t, ok, "HEXISTS on an existing hash but unknown field must return 0")
+}
+
+func TestRedis_HEXISTS_WRONGTYPE(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.Set(ctx, "he:str", "x", 0).Err())
+	_, err := rdb.HExists(ctx, "he:str", "field").Result()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WRONGTYPE")
+}
+
+func TestRedis_HEXISTS_TTLExpired(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.HSet(ctx, "he:ttl", "field", "v").Err())
+	require.NoError(t, rdb.PExpire(ctx, "he:ttl", collectionFastPathTTL).Err())
+	waitForTTLExpiry()
+
+	ok, err := rdb.HExists(ctx, "he:ttl", "field").Result()
+	require.NoError(t, err)
+	require.False(t, ok, "HEXISTS on an expired hash must return 0")
+}
+
+func TestRedis_SISMEMBER_FastPathHit(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.SAdd(ctx, "s:fast", "member").Err())
+
+	ok, err := rdb.SIsMember(ctx, "s:fast", "member").Result()
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+func TestRedis_SISMEMBER_Miss(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	ok, err := rdb.SIsMember(ctx, "s:missing", "member").Result()
+	require.NoError(t, err)
+	require.False(t, ok, "SISMEMBER on a nonexistent set must return 0")
+}
+
+func TestRedis_SISMEMBER_UnknownMember(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.SAdd(ctx, "s:known", "a").Err())
+	ok, err := rdb.SIsMember(ctx, "s:known", "b").Result()
+	require.NoError(t, err)
+	require.False(t, ok, "SISMEMBER on an existing set but unknown member must return 0")
+}
+
+func TestRedis_SISMEMBER_WRONGTYPE(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.Set(ctx, "s:str", "x", 0).Err())
+	_, err := rdb.SIsMember(ctx, "s:str", "member").Result()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WRONGTYPE")
+}
+
+func TestRedis_SISMEMBER_TTLExpired(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.SAdd(ctx, "s:ttl", "member").Err())
+	require.NoError(t, rdb.PExpire(ctx, "s:ttl", collectionFastPathTTL).Err())
+	waitForTTLExpiry()
+
+	ok, err := rdb.SIsMember(ctx, "s:ttl", "member").Result()
+	require.NoError(t, err)
+	require.False(t, ok, "SISMEMBER on an expired set must return 0")
+}
+
+// TestRedis_HGET_FastPathGuardDualEncoding exercises the string-
+// priority guard (hasHigherPriorityStringEncoding) at the HGET
+// wire-protocol level: a key holding both a hash wide-column row AND
+// a string must report WRONGTYPE, not the hash value.
+//
+// The scenario is only reachable under data-corruption recovery; we
+// drive it here by overwriting a pre-existing hash with a SET, which
+// replaceWithStringTxn normally cleans the hash keys for, but by the
+// time SET commits the hash field row may still be observable at the
+// readTS for this HGET. The test tolerates either "WRONGTYPE" or the
+// old hash value being returned, since the exact race window is tiny,
+// but it must NOT panic or silently leak wide-column data as a string
+// hit: the guard is what keeps that outcome consistent with
+// keyTypeAt semantics.
+func TestRedis_HGET_FastPathGuardDualEncodingSmoke(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.HSet(ctx, "dual:key", "field", "hashVal").Err())
+	require.NoError(t, rdb.Set(ctx, "dual:key", "stringVal", 0).Err())
+
+	// After the SET, HGET must either see WRONGTYPE (string-priority
+	// guard fires, slow path reports the key as string) or nil (the
+	// hash keys were cleaned up). It must NOT return "hashVal".
+	got, err := rdb.HGet(ctx, "dual:key", "field").Result()
+	if err != nil {
+		require.Contains(t, err.Error(), "WRONGTYPE")
+		return
+	}
+	require.NotEqual(t, "hashVal", got, "fast path must not leak collection data when a string has taken over the key")
+}

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -1675,18 +1675,22 @@ func (r *RedisServer) hget(conn redcon.Conn, cmd redcon.Command) {
 
 // hashFieldFastLookup probes the wide-column field entry directly and
 // reports whether it is present and TTL-alive. Returns hit=false when
-// the wide-column key is absent OR when a higher-priority encoding
-// (string / list) exists on the same user key, so the caller falls
-// through to hgetSlow and ends up with the keyTypeAt-consistent
-// WRONGTYPE / nil response.
+// the wide-column key is absent, or when the narrow string-encoding
+// guard in hasHigherPriorityStringEncoding fires, so the caller
+// falls through to hgetSlow.
 //
-// The priority guard costs a single ExistsAt on redisStrKey, covering
-// the most common dual-encoding corruption (SET on a key that
-// previously held a hash, where cleanup did not run). Rarer legacy
-// corruption mixing hash with HLL / bare-key / list encodings will
-// still let this fast-path hit; those workloads should take the slow
-// path too, but in normal operation at most one encoding exists per
-// user key and the guard is a guaranteed miss.
+// Priority-alignment scope: this fast path does NOT fully mirror
+// rawKeyTypeAt / keyTypeAt's priority checks. The guard only probes
+// redisStrKey (the common SET-over-previous-hash corruption case);
+// rarer dual-encoding corruption involving HLL, legacy bare keys, or
+// list meta / delta entries is NOT caught here and will surface the
+// wide-column hash answer instead of the WRONGTYPE / nil response
+// keyTypeAt would produce. In normal operation at most one encoding
+// exists per user key, so the guard is a guaranteed miss and the
+// priority-alignment gap is invisible; pre-existing writers already
+// clean up the old encoding before switching types. A full check
+// would cost ~3-5 extra seeks per fast-path hit, which would negate
+// most of the gain over the ~17-seek keyTypeAt slow path.
 func (r *RedisServer) hashFieldFastLookup(ctx context.Context, key, field []byte, readTS uint64) (raw []byte, hit, alive bool, err error) {
 	if higher, hErr := r.hasHigherPriorityStringEncoding(ctx, key, readTS); hErr != nil {
 		return nil, false, false, hErr

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -1235,6 +1235,12 @@ func (r *RedisServer) sismember(conn redcon.Conn, cmd redcon.Command) {
 }
 
 func (r *RedisServer) setMemberFastExists(ctx context.Context, key, member []byte, readTS uint64) (hit, alive bool, err error) {
+	// String-priority guard; see hashFieldFastLookup for rationale.
+	if higher, hErr := r.hasHigherPriorityStringEncoding(ctx, key, readTS); hErr != nil {
+		return false, false, hErr
+	} else if higher {
+		return false, false, nil
+	}
 	exists, err := r.store.ExistsAt(ctx, store.SetMemberKey(key, member), readTS)
 	if err != nil {
 		return false, false, cockerrors.WithStack(err)
@@ -1658,7 +1664,10 @@ func (r *RedisServer) hget(conn redcon.Conn, cmd redcon.Command) {
 			conn.WriteNull()
 			return
 		}
-		conn.WriteBulkString(string(raw))
+		// WriteBulk sends the payload directly from the []byte backing
+		// store; WriteBulkString(string(raw)) would force a []byte →
+		// string copy on every fast-path hit.
+		conn.WriteBulk(raw)
 		return
 	}
 	r.hgetSlow(conn, ctx, key, field, readTS)
@@ -1666,11 +1675,27 @@ func (r *RedisServer) hget(conn redcon.Conn, cmd redcon.Command) {
 
 // hashFieldFastLookup probes the wide-column field entry directly and
 // reports whether it is present and TTL-alive. Returns hit=false when
-// the wide-column key is absent (caller must take the slow path).
+// the wide-column key is absent OR when a higher-priority encoding
+// (string / list) exists on the same user key, so the caller falls
+// through to hgetSlow and ends up with the keyTypeAt-consistent
+// WRONGTYPE / nil response.
+//
+// The priority guard costs a single ExistsAt on redisStrKey, covering
+// the most common dual-encoding corruption (SET on a key that
+// previously held a hash, where cleanup did not run). Rarer legacy
+// corruption mixing hash with HLL / bare-key / list encodings will
+// still let this fast-path hit; those workloads should take the slow
+// path too, but in normal operation at most one encoding exists per
+// user key and the guard is a guaranteed miss.
 func (r *RedisServer) hashFieldFastLookup(ctx context.Context, key, field []byte, readTS uint64) (raw []byte, hit, alive bool, err error) {
+	if higher, hErr := r.hasHigherPriorityStringEncoding(ctx, key, readTS); hErr != nil {
+		return nil, false, false, hErr
+	} else if higher {
+		return nil, false, false, nil
+	}
 	raw, err = r.store.GetAt(ctx, store.HashFieldKey(key, field), readTS)
 	if err != nil {
-		if errors.Is(err, store.ErrKeyNotFound) {
+		if cockerrors.Is(err, store.ErrKeyNotFound) {
 			return nil, false, false, nil
 		}
 		return nil, false, false, cockerrors.WithStack(err)
@@ -1680,6 +1705,20 @@ func (r *RedisServer) hashFieldFastLookup(ctx context.Context, key, field []byte
 		return nil, false, false, cockerrors.WithStack(expErr)
 	}
 	return raw, true, !expired, nil
+}
+
+// hasHigherPriorityStringEncoding returns true iff a string-encoded
+// entry exists for key. Matches the "string wins" tiebreaker in
+// rawKeyTypeAt (see adapter/redis_compat_helpers.go), so a corrupt
+// dual-encoded key where both a string and a collection row are
+// present will take the slow path and return WRONGTYPE / nil from
+// keyTypeAt rather than the collection-specific fast-path answer.
+func (r *RedisServer) hasHigherPriorityStringEncoding(ctx context.Context, key []byte, readTS uint64) (bool, error) {
+	exists, err := r.store.ExistsAt(ctx, redisStrKey(key), readTS)
+	if err != nil {
+		return false, cockerrors.WithStack(err)
+	}
+	return exists, nil
 }
 
 // hgetSlow falls back to the type-probing path when hashFieldFastLookup
@@ -1931,6 +1970,12 @@ func (r *RedisServer) hexists(conn redcon.Conn, cmd redcon.Command) {
 }
 
 func (r *RedisServer) hashFieldFastExists(ctx context.Context, key, field []byte, readTS uint64) (hit, alive bool, err error) {
+	// String-priority guard; see hashFieldFastLookup for rationale.
+	if higher, hErr := r.hasHigherPriorityStringEncoding(ctx, key, readTS); hErr != nil {
+		return false, false, hErr
+	} else if higher {
+		return false, false, nil
+	}
 	exists, err := r.store.ExistsAt(ctx, store.HashFieldKey(key, field), readTS)
 	if err != nil {
 		return false, false, cockerrors.WithStack(err)

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -1242,7 +1242,7 @@ func (r *RedisServer) setMemberFastExists(ctx context.Context, key, member []byt
 	if !exists {
 		return false, false, nil
 	}
-	expired, expErr := r.hasExpiredTTLAt(ctx, key, readTS)
+	expired, expErr := r.hasExpired(ctx, key, readTS, true)
 	if expErr != nil {
 		return false, false, cockerrors.WithStack(expErr)
 	}
@@ -1675,7 +1675,7 @@ func (r *RedisServer) hashFieldFastLookup(ctx context.Context, key, field []byte
 		}
 		return nil, false, false, cockerrors.WithStack(err)
 	}
-	expired, expErr := r.hasExpiredTTLAt(ctx, key, readTS)
+	expired, expErr := r.hasExpired(ctx, key, readTS, true)
 	if expErr != nil {
 		return nil, false, false, cockerrors.WithStack(expErr)
 	}
@@ -1938,7 +1938,7 @@ func (r *RedisServer) hashFieldFastExists(ctx context.Context, key, field []byte
 	if !exists {
 		return false, false, nil
 	}
-	expired, expErr := r.hasExpiredTTLAt(ctx, key, readTS)
+	expired, expErr := r.hasExpired(ctx, key, readTS, true)
 	if expErr != nil {
 		return false, false, cockerrors.WithStack(expErr)
 	}

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -1235,17 +1235,18 @@ func (r *RedisServer) sismember(conn redcon.Conn, cmd redcon.Command) {
 }
 
 func (r *RedisServer) setMemberFastExists(ctx context.Context, key, member []byte, readTS uint64) (hit, alive bool, err error) {
-	// String-priority guard; see hashFieldFastLookup for rationale.
-	if higher, hErr := r.hasHigherPriorityStringEncoding(ctx, key, readTS); hErr != nil {
-		return false, false, hErr
-	} else if higher {
-		return false, false, nil
-	}
+	// Probe FIRST; guard only on hit. See hashFieldFastLookup for the
+	// regression rationale.
 	exists, err := r.store.ExistsAt(ctx, store.SetMemberKey(key, member), readTS)
 	if err != nil {
 		return false, false, cockerrors.WithStack(err)
 	}
 	if !exists {
+		return false, false, nil
+	}
+	if higher, hErr := r.hasHigherPriorityStringEncoding(ctx, key, readTS); hErr != nil {
+		return false, false, hErr
+	} else if higher {
 		return false, false, nil
 	}
 	expired, expErr := r.hasExpired(ctx, key, readTS, true)
@@ -1692,17 +1693,25 @@ func (r *RedisServer) hget(conn redcon.Conn, cmd redcon.Command) {
 // would cost ~3-5 extra seeks per fast-path hit, which would negate
 // most of the gain over the ~17-seek keyTypeAt slow path.
 func (r *RedisServer) hashFieldFastLookup(ctx context.Context, key, field []byte, readTS uint64) (raw []byte, hit, alive bool, err error) {
-	if higher, hErr := r.hasHigherPriorityStringEncoding(ctx, key, readTS); hErr != nil {
-		return nil, false, false, hErr
-	} else if higher {
-		return nil, false, false, nil
-	}
+	// Probe the wide-column field FIRST so the priority guard only
+	// runs on a hit. Placing the guard before the probe made every
+	// miss (nonexistent key, legacy-blob hash, or wrong-type) pay an
+	// unnecessary ExistsAt on redisStrKey -- pure overhead for the
+	// common negative-lookup case and for any workload that still
+	// carries legacy-blob encodings. See the PR #565 independent
+	// review for the Medium-severity regression this addresses.
 	raw, err = r.store.GetAt(ctx, store.HashFieldKey(key, field), readTS)
 	if err != nil {
 		if cockerrors.Is(err, store.ErrKeyNotFound) {
 			return nil, false, false, nil
 		}
 		return nil, false, false, cockerrors.WithStack(err)
+	}
+	// Only pay the guard seek when we actually have a hit to defer.
+	if higher, hErr := r.hasHigherPriorityStringEncoding(ctx, key, readTS); hErr != nil {
+		return nil, false, false, hErr
+	} else if higher {
+		return nil, false, false, nil
 	}
 	expired, expErr := r.hasExpired(ctx, key, readTS, true)
 	if expErr != nil {
@@ -1974,17 +1983,18 @@ func (r *RedisServer) hexists(conn redcon.Conn, cmd redcon.Command) {
 }
 
 func (r *RedisServer) hashFieldFastExists(ctx context.Context, key, field []byte, readTS uint64) (hit, alive bool, err error) {
-	// String-priority guard; see hashFieldFastLookup for rationale.
-	if higher, hErr := r.hasHigherPriorityStringEncoding(ctx, key, readTS); hErr != nil {
-		return false, false, hErr
-	} else if higher {
-		return false, false, nil
-	}
+	// Probe FIRST; guard only on hit. See hashFieldFastLookup for the
+	// regression rationale.
 	exists, err := r.store.ExistsAt(ctx, store.HashFieldKey(key, field), readTS)
 	if err != nil {
 		return false, false, cockerrors.WithStack(err)
 	}
 	if !exists {
+		return false, false, nil
+	}
+	if higher, hErr := r.hasHigherPriorityStringEncoding(ctx, key, readTS); hErr != nil {
+		return false, false, hErr
+	} else if higher {
 		return false, false, nil
 	}
 	expired, expErr := r.hasExpired(ctx, key, readTS, true)

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -1720,12 +1720,21 @@ func (r *RedisServer) hashFieldFastLookup(ctx context.Context, key, field []byte
 	return raw, true, !expired, nil
 }
 
-// hasHigherPriorityStringEncoding returns true iff a string-encoded
-// entry exists for key. Matches the "string wins" tiebreaker in
-// rawKeyTypeAt (see adapter/redis_compat_helpers.go), so a corrupt
-// dual-encoded key where both a string and a collection row are
-// present will take the slow path and return WRONGTYPE / nil from
-// keyTypeAt rather than the collection-specific fast-path answer.
+// hasHigherPriorityStringEncoding returns true iff the new-format
+// string encoding (redisStrKey) exists for key. This is NARROWER
+// than rawKeyTypeAt's full string-wins tiebreaker, which also covers
+// HyperLogLog (redisHLLKey) and the legacy bare key: those rarer
+// dual-encoding corruption cases still reach the wide-column fast
+// path and may return the collection-specific answer instead of
+// WRONGTYPE / nil.
+//
+// The narrow scope is deliberate -- expanding the guard to every
+// string-priority candidate (3 ExistsAt calls + the list-meta probe)
+// would cost ~4-5 extra seeks per fast-path hit, regressing the
+// negative case further than the ordering tweak in
+// hashFieldFastLookup / setMemberFastExists / hashFieldFastExists
+// already saved. Callers that require complete priority alignment
+// must take the keyTypeAt slow path explicitly.
 func (r *RedisServer) hasHigherPriorityStringEncoding(ctx context.Context, key []byte, readTS uint64) (bool, error) {
 	exists, err := r.store.ExistsAt(ctx, redisStrKey(key), readTS)
 	if err != nil {

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -1213,8 +1213,44 @@ func (r *RedisServer) sismember(conn redcon.Conn, cmd redcon.Command) {
 	if r.proxyToLeader(conn, cmd, cmd.Args[1]) {
 		return
 	}
+	key := cmd.Args[1]
+	member := cmd.Args[2]
 	readTS := r.readTS()
-	typ, err := r.keyTypeAt(context.Background(), cmd.Args[1], readTS)
+	ctx := context.Background()
+
+	hit, alive, err := r.setMemberFastExists(ctx, key, member, readTS)
+	if err != nil {
+		conn.WriteError(err.Error())
+		return
+	}
+	if hit {
+		if alive {
+			conn.WriteInt(1)
+		} else {
+			conn.WriteInt(0)
+		}
+		return
+	}
+	r.sismemberSlow(conn, ctx, key, member, readTS)
+}
+
+func (r *RedisServer) setMemberFastExists(ctx context.Context, key, member []byte, readTS uint64) (hit, alive bool, err error) {
+	exists, err := r.store.ExistsAt(ctx, store.SetMemberKey(key, member), readTS)
+	if err != nil {
+		return false, false, cockerrors.WithStack(err)
+	}
+	if !exists {
+		return false, false, nil
+	}
+	expired, expErr := r.hasExpiredTTLAt(ctx, key, readTS)
+	if expErr != nil {
+		return false, false, cockerrors.WithStack(expErr)
+	}
+	return true, !expired, nil
+}
+
+func (r *RedisServer) sismemberSlow(conn redcon.Conn, ctx context.Context, key, member []byte, readTS uint64) {
+	typ, err := r.keyTypeAt(ctx, key, readTS)
 	if err != nil {
 		conn.WriteError(err.Error())
 		return
@@ -1227,13 +1263,12 @@ func (r *RedisServer) sismember(conn redcon.Conn, cmd redcon.Command) {
 		conn.WriteError(wrongTypeMessage)
 		return
 	}
-
-	value, err := r.loadSetAt(context.Background(), setKind, cmd.Args[1], readTS)
+	value, err := r.loadSetAt(ctx, setKind, key, readTS)
 	if err != nil {
 		conn.WriteError(err.Error())
 		return
 	}
-	if slices.Contains(value.Members, string(cmd.Args[2])) {
+	if slices.Contains(value.Members, string(member)) {
 		conn.WriteInt(1)
 		return
 	}
@@ -1604,8 +1639,53 @@ func (r *RedisServer) hget(conn redcon.Conn, cmd redcon.Command) {
 	if r.proxyToLeader(conn, cmd, cmd.Args[1]) {
 		return
 	}
+	key := cmd.Args[1]
+	field := cmd.Args[2]
 	readTS := r.readTS()
-	typ, err := r.keyTypeAt(context.Background(), cmd.Args[1], readTS)
+	ctx := context.Background()
+
+	// Fast path: look the wide-column field up directly. Live
+	// wide-column hashes resolve here in 1 seek + TTL probe versus
+	// the ~17 seeks rawKeyTypeAt issues through keyTypeAt. Legacy-
+	// blob hashes miss the wide-column key and fall through.
+	raw, hit, alive, err := r.hashFieldFastLookup(ctx, key, field, readTS)
+	if err != nil {
+		conn.WriteError(err.Error())
+		return
+	}
+	if hit {
+		if !alive {
+			conn.WriteNull()
+			return
+		}
+		conn.WriteBulkString(string(raw))
+		return
+	}
+	r.hgetSlow(conn, ctx, key, field, readTS)
+}
+
+// hashFieldFastLookup probes the wide-column field entry directly and
+// reports whether it is present and TTL-alive. Returns hit=false when
+// the wide-column key is absent (caller must take the slow path).
+func (r *RedisServer) hashFieldFastLookup(ctx context.Context, key, field []byte, readTS uint64) (raw []byte, hit, alive bool, err error) {
+	raw, err = r.store.GetAt(ctx, store.HashFieldKey(key, field), readTS)
+	if err != nil {
+		if errors.Is(err, store.ErrKeyNotFound) {
+			return nil, false, false, nil
+		}
+		return nil, false, false, cockerrors.WithStack(err)
+	}
+	expired, expErr := r.hasExpiredTTLAt(ctx, key, readTS)
+	if expErr != nil {
+		return nil, false, false, cockerrors.WithStack(expErr)
+	}
+	return raw, true, !expired, nil
+}
+
+// hgetSlow falls back to the type-probing path when hashFieldFastLookup
+// misses. Handles legacy-blob hashes and nil / WRONGTYPE disambiguation.
+func (r *RedisServer) hgetSlow(conn redcon.Conn, ctx context.Context, key, field []byte, readTS uint64) {
+	typ, err := r.keyTypeAt(ctx, key, readTS)
 	if err != nil {
 		conn.WriteError(err.Error())
 		return
@@ -1618,13 +1698,12 @@ func (r *RedisServer) hget(conn redcon.Conn, cmd redcon.Command) {
 		conn.WriteError(wrongTypeMessage)
 		return
 	}
-
-	value, err := r.loadHashAt(context.Background(), cmd.Args[1], readTS)
+	value, err := r.loadHashAt(ctx, key, readTS)
 	if err != nil {
 		conn.WriteError(err.Error())
 		return
 	}
-	fieldValue, ok := value[string(cmd.Args[2])]
+	fieldValue, ok := value[string(field)]
 	if !ok {
 		conn.WriteNull()
 		return
@@ -1828,8 +1907,46 @@ func (r *RedisServer) hexists(conn redcon.Conn, cmd redcon.Command) {
 	if r.proxyToLeader(conn, cmd, cmd.Args[1]) {
 		return
 	}
+	key := cmd.Args[1]
+	field := cmd.Args[2]
 	readTS := r.readTS()
-	typ, err := r.keyTypeAt(context.Background(), cmd.Args[1], readTS)
+	ctx := context.Background()
+
+	// Fast path: direct wide-column field existence check. ExistsAt
+	// is cheaper than GetAt since we don't need the value payload.
+	hit, alive, err := r.hashFieldFastExists(ctx, key, field, readTS)
+	if err != nil {
+		conn.WriteError(err.Error())
+		return
+	}
+	if hit {
+		if alive {
+			conn.WriteInt(1)
+		} else {
+			conn.WriteInt(0)
+		}
+		return
+	}
+	r.hexistsSlow(conn, ctx, key, field, readTS)
+}
+
+func (r *RedisServer) hashFieldFastExists(ctx context.Context, key, field []byte, readTS uint64) (hit, alive bool, err error) {
+	exists, err := r.store.ExistsAt(ctx, store.HashFieldKey(key, field), readTS)
+	if err != nil {
+		return false, false, cockerrors.WithStack(err)
+	}
+	if !exists {
+		return false, false, nil
+	}
+	expired, expErr := r.hasExpiredTTLAt(ctx, key, readTS)
+	if expErr != nil {
+		return false, false, cockerrors.WithStack(expErr)
+	}
+	return true, !expired, nil
+}
+
+func (r *RedisServer) hexistsSlow(conn redcon.Conn, ctx context.Context, key, field []byte, readTS uint64) {
+	typ, err := r.keyTypeAt(ctx, key, readTS)
 	if err != nil {
 		conn.WriteError(err.Error())
 		return
@@ -1842,13 +1959,12 @@ func (r *RedisServer) hexists(conn redcon.Conn, cmd redcon.Command) {
 		conn.WriteError(wrongTypeMessage)
 		return
 	}
-
-	value, err := r.loadHashAt(context.Background(), cmd.Args[1], readTS)
+	value, err := r.loadHashAt(ctx, key, readTS)
 	if err != nil {
 		conn.WriteError(err.Error())
 		return
 	}
-	if _, ok := value[string(cmd.Args[2])]; ok {
+	if _, ok := value[string(field)]; ok {
 		conn.WriteInt(1)
 		return
 	}


### PR DESCRIPTION
## Summary
Extends the GET / EXISTS / SET fast-path work (PRs #560, #562, #563) to three more hot type-specific reads.

Before, every HGET / HEXISTS / SISMEMBER paid the full ~17-seek `rawKeyTypeAt` probe before even calling `loadHashAt` / `loadSetAt`, even though the specific wide-column entry for the requested field / member is addressable in a single seek.

### New flow per command
1. Probe the wide-column entry directly:
   - `HGET` → `store.GetAt(store.HashFieldKey(key, field))`
   - `HEXISTS` → `store.ExistsAt(store.HashFieldKey(key, field))`
   - `SISMEMBER` → `store.ExistsAt(store.SetMemberKey(key, member))`
2. On hit, apply `hasExpiredTTLAt(key)` and return the appropriate Redis response. Expired → nil / 0, matching the pre-optimisation `keyTypeAt` semantics.
3. On miss, delegate to a per-command slow helper (`hgetSlow` / `hexistsSlow` / `sismemberSlow`) that preserves the exact legacy `keyTypeAt` + `loadHashAt` / `loadSetAt` path. Legacy-blob encodings and nil / WRONGTYPE disambiguation retain their prior behaviour.

### Per-command effect on a live wide-column key

| Command   | Before   | After    |
|-----------|---------:|---------:|
| HGET      | ~17 seeks| 2–3 seeks|
| HEXISTS   | ~17 seeks| 2–3 seeks|
| SISMEMBER | ~17 seeks| 2–3 seeks|

Legacy-blob-encoded hashes/sets go through the slow path (miss on the wide-column key → fallback) so behaviour there is unchanged.

## Test plan
- [x] `go test -race ./adapter/... -short` passes
- [x] Existing HGET / HEXISTS / SISMEMBER tests cover: hit / miss / WRONGTYPE / nil-key / TTL-expired / legacy-blob
- [ ] Production: deploy and verify per-command GetAt counters (once Grafana dashboard in #564 lands) show HGET/HEXISTS/SISMEMBER drop into the same latency band as GET


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved performance and responsiveness for HGET, HEXISTS, and SISMEMBER commands via faster lookup paths and more efficient handling of type/TTL conditions.

* **Tests**
  * Added extensive end-to-end tests covering fast-path hits, TTL-expired cases, misses, and type-mismatch behavior to ensure correctness and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->