### PR TITLE
perf(redis-lua): fast-path HGET / HEXISTS / SISMEMBER inside Lua scripts

### DIFF
--- a/adapter/redis_lua_collection_fastpath_test.go
+++ b/adapter/redis_lua_collection_fastpath_test.go
@@ -419,3 +419,34 @@ func TestLua_SISMEMBER_WRONGTYPE(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "WRONGTYPE")
 }
+
+// TestLua_HGET_RepeatedMissReusesLoadedState pins the optimisation
+// that a missing hash loaded once should NOT re-run the wide-column
+// probe on every subsequent HGET in the same Eval. The script does
+// N HGETs on the same missing key; if the fast-path guard correctly
+// honors an already-loaded luaHashState (even with exists=false),
+// only the first call reaches Pebble.
+func TestLua_HGET_RepeatedMissReusesLoadedState(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	// 4 HGETs on the same missing key; the script must return nil for
+	// each and complete without divergent results. Correctness check
+	// only -- the optimisation itself is a seek-count saving that
+	// needs pprof to verify; this test guards against the guard
+	// regressing into returning wrong answers.
+	got, err := rdb.Eval(ctx, `
+local a = redis.call("HGET", KEYS[1], "f") or "nil"
+local b = redis.call("HGET", KEYS[1], "f") or "nil"
+local c = redis.call("HGET", KEYS[1], "f") or "nil"
+local d = redis.call("HGET", KEYS[1], "f") or "nil"
+return a .. "|" .. b .. "|" .. c .. "|" .. d
+`, []string{"lua:h:repeatedmiss"}).Result()
+	require.NoError(t, err)
+	require.Equal(t, "nil|nil|nil|nil", got)
+}

--- a/adapter/redis_lua_collection_fastpath_test.go
+++ b/adapter/redis_lua_collection_fastpath_test.go
@@ -251,6 +251,157 @@ func TestLua_SISMEMBER_Miss(t *testing.T) {
 	require.Equal(t, int64(0), got)
 }
 
+// --- Regression tests for the cachedType defer-to-slow-path guard ---
+//
+// These pin down the High-severity findings from the PR #567 review:
+// a script that mutates the logical type (DEL / SET / RENAME / HDEL
+// of an entire hash) within the same Eval must NOT see the fast path
+// read pre-script pebble state and return stale collection data.
+
+func TestLua_HGET_SetThenHGetReturnsWrongType(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	// Seed a hash with a field in pebble.
+	require.NoError(t, rdb.HSet(ctx, "lua:h:typechange", "f", "hashval").Err())
+
+	// Script: SET string over the same key, then HGET. Pre-script
+	// pebble still has the wide-column row, but the in-script type
+	// is now String -> HGET MUST return WRONGTYPE, NOT "hashval".
+	_, err := rdb.Eval(ctx, `
+redis.call("SET", KEYS[1], "stringval")
+return redis.call("HGET", KEYS[1], "f")
+`, []string{"lua:h:typechange"}).Result()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WRONGTYPE",
+		"fast path must defer to cachedType when a prior SET changes the logical type")
+}
+
+func TestLua_HGET_DelThenHGetReturnsNil(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.HSet(ctx, "lua:h:delthenget", "f", "v").Err())
+
+	_, err := rdb.Eval(ctx, `
+redis.call("DEL", KEYS[1])
+return redis.call("HGET", KEYS[1], "f")
+`, []string{"lua:h:delthenget"}).Result()
+	require.ErrorIs(t, err, redis.Nil,
+		"fast path must defer to cachedType / deleted flag when a prior DEL tombstones the key")
+}
+
+func TestLua_HEXISTS_SetThenHExistsReturnsWrongType(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.HSet(ctx, "lua:he:typechange", "f", "v").Err())
+	_, err := rdb.Eval(ctx, `
+redis.call("SET", KEYS[1], "x")
+return redis.call("HEXISTS", KEYS[1], "f")
+`, []string{"lua:he:typechange"}).Result()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WRONGTYPE")
+}
+
+func TestLua_HEXISTS_DelThenHExistsReturnsZero(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.HSet(ctx, "lua:he:delthenexists", "f", "v").Err())
+	got, err := rdb.Eval(ctx, `
+redis.call("DEL", KEYS[1])
+return redis.call("HEXISTS", KEYS[1], "f")
+`, []string{"lua:he:delthenexists"}).Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(0), got)
+}
+
+func TestLua_SISMEMBER_SetThenSIsMemberReturnsWrongType(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.SAdd(ctx, "lua:s:typechange", "m").Err())
+	_, err := rdb.Eval(ctx, `
+redis.call("SET", KEYS[1], "x")
+return redis.call("SISMEMBER", KEYS[1], "m")
+`, []string{"lua:s:typechange"}).Result()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WRONGTYPE")
+}
+
+func TestLua_SISMEMBER_DelThenSIsMemberReturnsZero(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.SAdd(ctx, "lua:s:delthenexists", "m").Err())
+	got, err := rdb.Eval(ctx, `
+redis.call("DEL", KEYS[1])
+return redis.call("SISMEMBER", KEYS[1], "m")
+`, []string{"lua:s:delthenexists"}).Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(0), got)
+}
+
+// Additional coverage: in-script HSET then HGET on a DIFFERENT field
+// must see the cached state (nil for unset field), not fall through
+// to the fast path which would miss the unflushed HSET.
+func TestLua_HGET_AnotherFieldAfterHSet(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	// Seed pebble with field "seeded".
+	require.NoError(t, rdb.HSet(ctx, "lua:h:twofield", "seeded", "old").Err())
+
+	// Script writes "newf" then reads "seeded" and "newf" and
+	// "unknownf". Must see the unflushed write, the seeded value,
+	// and nil for unknown.
+	got, err := rdb.Eval(ctx, `
+redis.call("HSET", KEYS[1], "newf", "newval")
+local a = redis.call("HGET", KEYS[1], "seeded") or "nil"
+local b = redis.call("HGET", KEYS[1], "newf") or "nil"
+local c = redis.call("HGET", KEYS[1], "unknownf") or "nil"
+return a .. "|" .. b .. "|" .. c
+`, []string{"lua:h:twofield"}).Result()
+	require.NoError(t, err)
+	require.Equal(t, "old|newval|nil", got)
+}
+
 func TestLua_SISMEMBER_WRONGTYPE(t *testing.T) {
 	t.Parallel()
 	nodes, _, _ := createNode(t, 3)

--- a/adapter/redis_lua_collection_fastpath_test.go
+++ b/adapter/redis_lua_collection_fastpath_test.go
@@ -1,0 +1,270 @@
+package adapter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the wire-level behaviour of the Lua-context fast
+// paths added alongside PR #565's top-level equivalents. Each
+// redis.call("HGET" / "HEXISTS" / "SISMEMBER", ...) inside a Lua
+// script now takes the direct wide-column lookup path bypassing
+// keyTypeAt's ~8-seek type probe, and must preserve identical
+// semantics to the legacy hashState / setState flow:
+//
+//   - hit on a live wide-column key returns the value / 1
+//   - in-script writes (HSET / SADD) done earlier in the same Eval
+//     must be visible to subsequent HGET / SISMEMBER calls (the
+//     fast path checks c.hashes / c.sets first)
+//   - missing key / unknown field returns nil / 0 via the slow-path
+//     fallback
+//   - TTL-expired key is reported as missing
+//   - WRONGTYPE propagates as a script error
+
+const luaFastPathTTL = 80 * time.Millisecond
+
+func waitForLuaTTL() {
+	time.Sleep(luaFastPathTTL + 50*time.Millisecond)
+}
+
+func TestLua_HGET_FastPathHit(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.HSet(ctx, "lua:h:fast", "field", "value").Err())
+
+	got, err := rdb.Eval(ctx,
+		`return redis.call("HGET", KEYS[1], ARGV[1])`,
+		[]string{"lua:h:fast"}, "field",
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, "value", got)
+}
+
+func TestLua_HGET_HonorsInScriptHSet(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	// HSET then HGET in the same script. The fast path must NOT bypass
+	// the unflushed in-script mutation -- it must honor c.hashes[key]
+	// and return the pending value.
+	got, err := rdb.Eval(ctx, `
+redis.call("HSET", KEYS[1], "field", ARGV[1])
+return redis.call("HGET", KEYS[1], "field")
+`, []string{"lua:h:rw"}, "scripted-value").Result()
+	require.NoError(t, err)
+	require.Equal(t, "scripted-value", got)
+}
+
+func TestLua_HGET_Miss(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	_, err := rdb.Eval(ctx,
+		`return redis.call("HGET", KEYS[1], ARGV[1])`,
+		[]string{"lua:h:missing"}, "field",
+	).Result()
+	require.ErrorIs(t, err, redis.Nil, "HGET on nonexistent key from Lua must surface as nil")
+}
+
+func TestLua_HGET_WRONGTYPE(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.Set(ctx, "lua:h:str", "x", 0).Err())
+	_, err := rdb.Eval(ctx,
+		`return redis.call("HGET", KEYS[1], ARGV[1])`,
+		[]string{"lua:h:str"}, "field",
+	).Result()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WRONGTYPE")
+}
+
+func TestLua_HGET_TTLExpired(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.HSet(ctx, "lua:h:ttl", "field", "v").Err())
+	require.NoError(t, rdb.PExpire(ctx, "lua:h:ttl", luaFastPathTTL).Err())
+	waitForLuaTTL()
+
+	_, err := rdb.Eval(ctx,
+		`return redis.call("HGET", KEYS[1], "field")`,
+		[]string{"lua:h:ttl"},
+	).Result()
+	require.ErrorIs(t, err, redis.Nil, "HGET on an expired hash from Lua must surface as nil")
+}
+
+func TestLua_HEXISTS_FastPathHit(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.HSet(ctx, "lua:he:fast", "field", "v").Err())
+
+	got, err := rdb.Eval(ctx,
+		`return redis.call("HEXISTS", KEYS[1], ARGV[1])`,
+		[]string{"lua:he:fast"}, "field",
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), got)
+}
+
+func TestLua_HEXISTS_HonorsInScriptHSet(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	got, err := rdb.Eval(ctx, `
+redis.call("HSET", KEYS[1], "f", "v")
+return redis.call("HEXISTS", KEYS[1], "f")
+`, []string{"lua:he:rw"}).Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), got)
+}
+
+func TestLua_HEXISTS_Miss(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	got, err := rdb.Eval(ctx,
+		`return redis.call("HEXISTS", KEYS[1], ARGV[1])`,
+		[]string{"lua:he:missing"}, "field",
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(0), got)
+}
+
+func TestLua_HEXISTS_TTLExpired(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.HSet(ctx, "lua:he:ttl", "f", "v").Err())
+	require.NoError(t, rdb.PExpire(ctx, "lua:he:ttl", luaFastPathTTL).Err())
+	waitForLuaTTL()
+
+	got, err := rdb.Eval(ctx,
+		`return redis.call("HEXISTS", KEYS[1], "f")`,
+		[]string{"lua:he:ttl"},
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(0), got)
+}
+
+func TestLua_SISMEMBER_FastPathHit(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.SAdd(ctx, "lua:s:fast", "member").Err())
+
+	got, err := rdb.Eval(ctx,
+		`return redis.call("SISMEMBER", KEYS[1], ARGV[1])`,
+		[]string{"lua:s:fast"}, "member",
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), got)
+}
+
+func TestLua_SISMEMBER_HonorsInScriptSAdd(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	got, err := rdb.Eval(ctx, `
+redis.call("SADD", KEYS[1], "m")
+return redis.call("SISMEMBER", KEYS[1], "m")
+`, []string{"lua:s:rw"}).Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), got)
+}
+
+func TestLua_SISMEMBER_Miss(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	got, err := rdb.Eval(ctx,
+		`return redis.call("SISMEMBER", KEYS[1], ARGV[1])`,
+		[]string{"lua:s:missing"}, "member",
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(0), got)
+}
+
+func TestLua_SISMEMBER_WRONGTYPE(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.Set(ctx, "lua:s:str", "x", 0).Err())
+	_, err := rdb.Eval(ctx,
+		`return redis.call("SISMEMBER", KEYS[1], "member")`,
+		[]string{"lua:s:str"},
+	).Result()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WRONGTYPE")
+}

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -1346,13 +1346,18 @@ func (c *luaScriptContext) renameStreamValue(src, dst []byte) error {
 func (c *luaScriptContext) cmdHGet(args []string) (luaReply, error) {
 	key := []byte(args[0])
 	field := args[1]
-	// Honor in-script writes first: if a prior HSET / HINCRBY / HDEL on
-	// this key within this script run already loaded the hash into
-	// c.hashes, the fast path would miss those unflushed mutations.
-	// This also covers callers that pre-loaded the state (e.g. HGETALL
-	// before HGET).
-	if st, ok := c.hashes[string(key)]; ok {
-		return hgetFromHashState(st, field), nil
+	// Fast path is only safe when cachedType has NO authoritative
+	// script-local answer. A cached entry (loaded hash / string / list
+	// / etc. OR an explicit c.deleted entry from a prior DEL / RENAME)
+	// means another command in this Eval has either (a) mutated the
+	// hash so c.hashes[key] holds the unflushed view, (b) changed the
+	// logical type so hashState() must produce WRONGTYPE, or (c)
+	// deleted the key so the correct answer is nil. In all three cases
+	// the slow path's hashState -> keyType -> cachedType chain produces
+	// the right answer; bypassing it would silently read pre-script
+	// pebble state and leak stale data.
+	if _, cached := c.cachedType(key); cached {
+		return hgetFromSlowPath(c, key, field)
 	}
 	// Fast path: direct wide-column field lookup, bypassing the ~8-seek
 	// keyTypeAt probe inside hashState. This is the same pattern that
@@ -1369,9 +1374,14 @@ func (c *luaScriptContext) cmdHGet(args []string) (luaReply, error) {
 		}
 		return luaStringReply(string(raw)), nil
 	}
-	// Miss: fall back to the full hashState path so legacy-blob hashes,
-	// nil / WRONGTYPE disambiguation, and the script-local cache all
-	// behave exactly as before.
+	// Miss: fall back to the full hashState path so legacy-blob hashes
+	// and nil / WRONGTYPE disambiguation behave exactly as before.
+	return hgetFromSlowPath(c, key, field)
+}
+
+// hgetFromSlowPath runs the legacy hashState-based HGET, preserving
+// the script-local cache and WRONGTYPE / nil behaviour unchanged.
+func hgetFromSlowPath(c *luaScriptContext, key []byte, field string) (luaReply, error) {
 	st, err := c.hashState(key)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
@@ -1546,9 +1556,11 @@ func (c *luaScriptContext) cmdHDel(args []string) (luaReply, error) {
 func (c *luaScriptContext) cmdHExists(args []string) (luaReply, error) {
 	key := []byte(args[0])
 	field := args[1]
-	// In-script cache first; same rationale as cmdHGet.
-	if st, ok := c.hashes[string(key)]; ok {
-		return hexistsFromHashState(st, field), nil
+	// See cmdHGet: defer to the slow path whenever cachedType has an
+	// authoritative answer, so prior DEL / RENAME / SET / HSET within
+	// this Eval is honored before the pebble probe fires.
+	if _, cached := c.cachedType(key); cached {
+		return hexistsFromSlowPath(c, key, field)
 	}
 	hit, alive, err := c.server.hashFieldFastExists(context.Background(), key, []byte(field), c.startTS)
 	if err != nil {
@@ -1560,6 +1572,10 @@ func (c *luaScriptContext) cmdHExists(args []string) (luaReply, error) {
 		}
 		return luaIntReply(0), nil
 	}
+	return hexistsFromSlowPath(c, key, field)
+}
+
+func hexistsFromSlowPath(c *luaScriptContext, key []byte, field string) (luaReply, error) {
 	st, err := c.hashState(key)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
@@ -2109,9 +2125,10 @@ func finalizeSetLikeRemoval(c *luaScriptContext, key string, removed int, empty 
 func (c *luaScriptContext) cmdSIsMember(args []string) (luaReply, error) {
 	key := []byte(args[0])
 	member := args[1]
-	// In-script cache first; same rationale as cmdHGet.
-	if st, ok := c.sets[string(key)]; ok {
-		return sismemberFromSetState(st, member), nil
+	// See cmdHGet: defer to the slow path whenever cachedType has an
+	// authoritative answer.
+	if _, cached := c.cachedType(key); cached {
+		return sismemberFromSlowPath(c, key, member)
 	}
 	hit, alive, err := c.server.setMemberFastExists(context.Background(), key, []byte(member), c.startTS)
 	if err != nil {
@@ -2123,6 +2140,10 @@ func (c *luaScriptContext) cmdSIsMember(args []string) (luaReply, error) {
 		}
 		return luaIntReply(0), nil
 	}
+	return sismemberFromSlowPath(c, key, member)
+}
+
+func sismemberFromSlowPath(c *luaScriptContext, key []byte, member string) (luaReply, error) {
 	st, err := c.setState(key)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -1346,16 +1346,21 @@ func (c *luaScriptContext) renameStreamValue(src, dst []byte) error {
 func (c *luaScriptContext) cmdHGet(args []string) (luaReply, error) {
 	key := []byte(args[0])
 	field := args[1]
-	// Fast path is only safe when cachedType has NO authoritative
-	// script-local answer. A cached entry (loaded hash / string / list
-	// / etc. OR an explicit c.deleted entry from a prior DEL / RENAME)
-	// means another command in this Eval has either (a) mutated the
-	// hash so c.hashes[key] holds the unflushed view, (b) changed the
-	// logical type so hashState() must produce WRONGTYPE, or (c)
-	// deleted the key so the correct answer is nil. In all three cases
-	// the slow path's hashState -> keyType -> cachedType chain produces
-	// the right answer; bypassing it would silently read pre-script
-	// pebble state and leak stale data.
+	// Fast path is only safe when there is NO authoritative
+	// script-local answer. Two separate signals to check:
+	//
+	//   (a) cachedType() covers loaded state for OTHER types (string /
+	//       list / ...) AND the explicit c.deleted entry from a prior
+	//       DEL / RENAME. Bypassing would leak pre-script pebble state.
+	//   (b) c.hashes[key] already loaded (even with exists=false for
+	//       a confirmed miss) means a prior command already paid the
+	//       type-probe tax. Re-running the fast path would just do
+	//       another wide-column probe for the same negative answer.
+	//       Reuse the loaded state via the slow path, which returns
+	//       immediately when c.hashes[key] is present.
+	if luaHashAlreadyLoaded(c, key) {
+		return hgetFromSlowPath(c, key, field)
+	}
 	if _, cached := c.cachedType(key); cached {
 		return hgetFromSlowPath(c, key, field)
 	}
@@ -1377,6 +1382,22 @@ func (c *luaScriptContext) cmdHGet(args []string) (luaReply, error) {
 	// Miss: fall back to the full hashState path so legacy-blob hashes
 	// and nil / WRONGTYPE disambiguation behave exactly as before.
 	return hgetFromSlowPath(c, key, field)
+}
+
+// luaHashAlreadyLoaded reports whether a prior command in this Eval
+// already populated c.hashes[key] and resolved its exists/loaded
+// flags. A loaded state -- even one representing a known miss --
+// makes the fast path redundant: the slow path returns immediately
+// by reading the cached luaHashState, skipping a wide-column probe.
+func luaHashAlreadyLoaded(c *luaScriptContext, key []byte) bool {
+	st, ok := c.hashes[string(key)]
+	return ok && st != nil && st.loaded
+}
+
+// luaSetAlreadyLoaded mirrors luaHashAlreadyLoaded for c.sets.
+func luaSetAlreadyLoaded(c *luaScriptContext, key []byte) bool {
+	st, ok := c.sets[string(key)]
+	return ok && st != nil && st.loaded
 }
 
 // hgetFromSlowPath runs the legacy hashState-based HGET, preserving
@@ -1556,9 +1577,14 @@ func (c *luaScriptContext) cmdHDel(args []string) (luaReply, error) {
 func (c *luaScriptContext) cmdHExists(args []string) (luaReply, error) {
 	key := []byte(args[0])
 	field := args[1]
-	// See cmdHGet: defer to the slow path whenever cachedType has an
-	// authoritative answer, so prior DEL / RENAME / SET / HSET within
-	// this Eval is honored before the pebble probe fires.
+	// See cmdHGet: defer to the slow path whenever the key already has
+	// an authoritative answer locally, so prior DEL / RENAME / SET /
+	// HSET within this Eval is honored, AND so a confirmed-missing
+	// hash loaded earlier in the script does not re-run the
+	// wide-column probe on every subsequent HEXISTS.
+	if luaHashAlreadyLoaded(c, key) {
+		return hexistsFromSlowPath(c, key, field)
+	}
 	if _, cached := c.cachedType(key); cached {
 		return hexistsFromSlowPath(c, key, field)
 	}
@@ -2125,8 +2151,12 @@ func finalizeSetLikeRemoval(c *luaScriptContext, key string, removed int, empty 
 func (c *luaScriptContext) cmdSIsMember(args []string) (luaReply, error) {
 	key := []byte(args[0])
 	member := args[1]
-	// See cmdHGet: defer to the slow path whenever cachedType has an
-	// authoritative answer.
+	// See cmdHGet: defer to the slow path whenever the set has an
+	// authoritative script-local answer (loaded state incl. miss, or
+	// cachedType reporting a different-type / deleted key).
+	if luaSetAlreadyLoaded(c, key) {
+		return sismemberFromSlowPath(c, key, member)
+	}
 	if _, cached := c.cachedType(key); cached {
 		return sismemberFromSlowPath(c, key, member)
 	}

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -1344,21 +1344,55 @@ func (c *luaScriptContext) renameStreamValue(src, dst []byte) error {
 }
 
 func (c *luaScriptContext) cmdHGet(args []string) (luaReply, error) {
-	st, err := c.hashState([]byte(args[0]))
+	key := []byte(args[0])
+	field := args[1]
+	// Honor in-script writes first: if a prior HSET / HINCRBY / HDEL on
+	// this key within this script run already loaded the hash into
+	// c.hashes, the fast path would miss those unflushed mutations.
+	// This also covers callers that pre-loaded the state (e.g. HGETALL
+	// before HGET).
+	if st, ok := c.hashes[string(key)]; ok {
+		return hgetFromHashState(st, field), nil
+	}
+	// Fast path: direct wide-column field lookup, bypassing the ~8-seek
+	// keyTypeAt probe inside hashState. This is the same pattern that
+	// the top-level HGET handler uses (see adapter/redis_compat_commands.go),
+	// reused verbatim here so BullMQ-style scripts that touch many
+	// hash keys stop paying the type-probe tax per redis.call.
+	raw, hit, alive, err := c.server.hashFieldFastLookup(context.Background(), key, []byte(field), c.startTS)
+	if err != nil {
+		return luaReply{}, err
+	}
+	if hit {
+		if !alive {
+			return luaNilReply(), nil
+		}
+		return luaStringReply(string(raw)), nil
+	}
+	// Miss: fall back to the full hashState path so legacy-blob hashes,
+	// nil / WRONGTYPE disambiguation, and the script-local cache all
+	// behave exactly as before.
+	st, err := c.hashState(key)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
 			return luaNilReply(), nil
 		}
 		return luaReply{}, err
 	}
+	return hgetFromHashState(st, field), nil
+}
+
+// hgetFromHashState reads field out of a loaded luaHashState in the
+// same way the legacy cmdHGet did.
+func hgetFromHashState(st *luaHashState, field string) luaReply {
 	if !st.exists {
-		return luaNilReply(), nil
+		return luaNilReply()
 	}
-	value, ok := st.value[args[1]]
+	value, ok := st.value[field]
 	if !ok {
-		return luaNilReply(), nil
+		return luaNilReply()
 	}
-	return luaStringReply(value), nil
+	return luaStringReply(value)
 }
 
 func (c *luaScriptContext) cmdHSet(args []string) (luaReply, error) {
@@ -1510,21 +1544,42 @@ func (c *luaScriptContext) cmdHDel(args []string) (luaReply, error) {
 }
 
 func (c *luaScriptContext) cmdHExists(args []string) (luaReply, error) {
-	st, err := c.hashState([]byte(args[0]))
+	key := []byte(args[0])
+	field := args[1]
+	// In-script cache first; same rationale as cmdHGet.
+	if st, ok := c.hashes[string(key)]; ok {
+		return hexistsFromHashState(st, field), nil
+	}
+	hit, alive, err := c.server.hashFieldFastExists(context.Background(), key, []byte(field), c.startTS)
+	if err != nil {
+		return luaReply{}, err
+	}
+	if hit {
+		if alive {
+			return luaIntReply(1), nil
+		}
+		return luaIntReply(0), nil
+	}
+	st, err := c.hashState(key)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
 			return luaIntReply(0), nil
 		}
 		return luaReply{}, err
 	}
+	return hexistsFromHashState(st, field), nil
+}
+
+// hexistsFromHashState reports whether field is present in a loaded
+// luaHashState, matching the legacy cmdHExists semantics.
+func hexistsFromHashState(st *luaHashState, field string) luaReply {
 	if !st.exists {
-		return luaIntReply(0), nil
+		return luaIntReply(0)
 	}
-	_, ok := st.value[args[1]]
-	if ok {
-		return luaIntReply(1), nil
+	if _, ok := st.value[field]; ok {
+		return luaIntReply(1)
 	}
-	return luaIntReply(0), nil
+	return luaIntReply(0)
 }
 
 func (c *luaScriptContext) cmdHLen(args []string) (luaReply, error) {
@@ -2052,20 +2107,43 @@ func finalizeSetLikeRemoval(c *luaScriptContext, key string, removed int, empty 
 }
 
 func (c *luaScriptContext) cmdSIsMember(args []string) (luaReply, error) {
-	st, err := c.setState([]byte(args[0]))
+	key := []byte(args[0])
+	member := args[1]
+	// In-script cache first; same rationale as cmdHGet.
+	if st, ok := c.sets[string(key)]; ok {
+		return sismemberFromSetState(st, member), nil
+	}
+	hit, alive, err := c.server.setMemberFastExists(context.Background(), key, []byte(member), c.startTS)
+	if err != nil {
+		return luaReply{}, err
+	}
+	if hit {
+		if alive {
+			return luaIntReply(1), nil
+		}
+		return luaIntReply(0), nil
+	}
+	st, err := c.setState(key)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
 			return luaIntReply(0), nil
 		}
 		return luaReply{}, err
 	}
+	return sismemberFromSetState(st, member), nil
+}
+
+// sismemberFromSetState returns the Redis integer reply for SISMEMBER
+// against a loaded luaSetState, matching the legacy cmdSIsMember
+// semantics.
+func sismemberFromSetState(st *luaSetState, member string) luaReply {
 	if !st.exists {
-		return luaIntReply(0), nil
+		return luaIntReply(0)
 	}
-	if _, ok := st.members[args[1]]; ok {
-		return luaIntReply(1), nil
+	if _, ok := st.members[member]; ok {
+		return luaIntReply(1)
 	}
-	return luaIntReply(0), nil
+	return luaIntReply(0)
 }
 
 func parseLuaZAddArgs(args []string) (zaddFlags, []string, error) {


### PR DESCRIPTION
## Summary
Follow-up to PR #565 (top-level HGET / HEXISTS / SISMEMBER fast-paths). BullMQ and similar Lua-heavy workloads never saw the benefit because `luaScriptContext.cmdHGet` etc. still went through `hashState` / `setState`, which paid the full `keyTypeAt` probe (~8 seeks post-#563) before loading the value.

### Effect on BullMQ-style scripts
A typical BullMQ script (`moveToActive`, `moveToCompleted`, etc.) touches 5–10 keys. Before this PR, each key cost ~8 seeks just for type classification, i.e. **40–80 wasted seeks per script invocation**. After: 1–2 seeks per fast-path hit.

### Changes
Port #565's pattern verbatim into the Lua command handlers:

| Lua cmd       | Fast-path helper reused from #565 |
|---------------|-----------------------------------|
| `cmdHGet`     | `hashFieldFastLookup`             |
| `cmdHExists`  | `hashFieldFastExists`             |
| `cmdSIsMember`| `setMemberFastExists`             |

Each handler still consults `c.hashes` / `c.sets` **first**, so in-script mutations (`HSET` followed by `HGET` in the same `Eval`) stay visible — the fast path only fires when the key has not yet been loaded into the script-local cache. Misses fall through to the legacy `hashState` / `setState` loader so legacy-blob encodings, `WRONGTYPE`, and TTL-expired keys behave identically to before.

Small helpers factored out (`hgetFromHashState`, `hexistsFromHashState`, `sismemberFromSetState`) to keep each command body under the cyclomatic-complexity cap.

## Test plan
- [x] `go test -race -short ./adapter/...` passes
- [x] `adapter/redis_lua_collection_fastpath_test.go` drives each command through a real `redis.Eval`:
  - fast-path hit returns the value / 1
  - in-script write (HSET / SADD) is visible to a subsequent HGET / SISMEMBER
  - miss / unknown field / member → nil / 0 via slow-path fallback
  - TTL-expired key → nil / 0
  - WRONGTYPE propagates as script error

## Depends on
- PR #565 (not yet merged) — provides `hashFieldFastLookup`, `hashFieldFastExists`, `setMemberFastExists`. This branch is based on #565; once #565 merges, rebase to main will be clean.
