### PR TITLE
perf(redis-lua): fast-path ZSCORE wide-column lookup

### DIFF
--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -1725,6 +1725,36 @@ func (r *RedisServer) hasHigherPriorityStringEncoding(ctx context.Context, key [
 	return exists, nil
 }
 
+// zsetMemberFastScore probes the wide-column score entry for (key,
+// member) directly and reports whether it is present and TTL-alive.
+// The priority-alignment scope mirrors hashFieldFastLookup: only the
+// redisStrKey dual-encoding case is guarded. Callers must fall back
+// to the full zsetState loader on hit=false to cover legacy-blob
+// zsets and nil / WRONGTYPE disambiguation.
+func (r *RedisServer) zsetMemberFastScore(ctx context.Context, key, member []byte, readTS uint64) (score float64, hit, alive bool, err error) {
+	if higher, hErr := r.hasHigherPriorityStringEncoding(ctx, key, readTS); hErr != nil {
+		return 0, false, false, hErr
+	} else if higher {
+		return 0, false, false, nil
+	}
+	raw, err := r.store.GetAt(ctx, store.ZSetMemberKey(key, member), readTS)
+	if err != nil {
+		if cockerrors.Is(err, store.ErrKeyNotFound) {
+			return 0, false, false, nil
+		}
+		return 0, false, false, cockerrors.WithStack(err)
+	}
+	score, err = store.UnmarshalZSetScore(raw)
+	if err != nil {
+		return 0, false, false, cockerrors.WithStack(err)
+	}
+	expired, expErr := r.hasExpired(ctx, key, readTS, true)
+	if expErr != nil {
+		return 0, false, false, cockerrors.WithStack(expErr)
+	}
+	return score, true, !expired, nil
+}
+
 // hgetSlow falls back to the type-probing path when hashFieldFastLookup
 // misses. Handles legacy-blob hashes and nil / WRONGTYPE disambiguation.
 func (r *RedisServer) hgetSlow(conn redcon.Conn, ctx context.Context, key, field []byte, readTS uint64) {

--- a/adapter/redis_lua_collection_fastpath_test.go
+++ b/adapter/redis_lua_collection_fastpath_test.go
@@ -251,6 +251,115 @@ func TestLua_SISMEMBER_Miss(t *testing.T) {
 	require.Equal(t, int64(0), got)
 }
 
+func TestLua_ZSCORE_FastPathHit(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.ZAdd(ctx, "lua:z:fast", redis.Z{Score: 42, Member: "m"}).Err())
+
+	got, err := rdb.Eval(ctx,
+		`return redis.call("ZSCORE", KEYS[1], ARGV[1])`,
+		[]string{"lua:z:fast"}, "m",
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, "42", got)
+}
+
+func TestLua_ZSCORE_HonorsInScriptZAdd(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	// ZADD followed by ZSCORE in the same Eval: the fast path must NOT
+	// bypass the unflushed mutation, it must read through c.zsets.
+	got, err := rdb.Eval(ctx, `
+redis.call("ZADD", KEYS[1], ARGV[1], ARGV[2])
+return redis.call("ZSCORE", KEYS[1], ARGV[2])
+`, []string{"lua:z:rw"}, "7", "m").Result()
+	require.NoError(t, err)
+	require.Equal(t, "7", got)
+}
+
+func TestLua_ZSCORE_Miss(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	_, err := rdb.Eval(ctx,
+		`return redis.call("ZSCORE", KEYS[1], ARGV[1])`,
+		[]string{"lua:z:missing"}, "m",
+	).Result()
+	require.ErrorIs(t, err, redis.Nil, "ZSCORE on nonexistent zset from Lua must surface as nil")
+}
+
+func TestLua_ZSCORE_UnknownMember(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.ZAdd(ctx, "lua:z:known", redis.Z{Score: 1, Member: "a"}).Err())
+	_, err := rdb.Eval(ctx,
+		`return redis.call("ZSCORE", KEYS[1], ARGV[1])`,
+		[]string{"lua:z:known"}, "b",
+	).Result()
+	require.ErrorIs(t, err, redis.Nil, "ZSCORE on an existing zset but unknown member must surface as nil")
+}
+
+func TestLua_ZSCORE_WRONGTYPE(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.Set(ctx, "lua:z:str", "x", 0).Err())
+	_, err := rdb.Eval(ctx,
+		`return redis.call("ZSCORE", KEYS[1], "m")`,
+		[]string{"lua:z:str"},
+	).Result()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WRONGTYPE")
+}
+
+func TestLua_ZSCORE_TTLExpired(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.ZAdd(ctx, "lua:z:ttl", redis.Z{Score: 1, Member: "m"}).Err())
+	require.NoError(t, rdb.PExpire(ctx, "lua:z:ttl", luaFastPathTTL).Err())
+	waitForLuaTTL()
+
+	_, err := rdb.Eval(ctx,
+		`return redis.call("ZSCORE", KEYS[1], "m")`,
+		[]string{"lua:z:ttl"},
+	).Result()
+	require.ErrorIs(t, err, redis.Nil, "ZSCORE on an expired zset from Lua must surface as nil")
+}
+
 func TestLua_SISMEMBER_WRONGTYPE(t *testing.T) {
 	t.Parallel()
 	nodes, _, _ := createNode(t, 3)

--- a/adapter/redis_lua_collection_fastpath_test.go
+++ b/adapter/redis_lua_collection_fastpath_test.go
@@ -377,3 +377,198 @@ func TestLua_SISMEMBER_WRONGTYPE(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "WRONGTYPE")
 }
+
+// --- Regression tests for the cachedType defer-to-slow-path guard ---
+//
+// A script that mutates the logical type (DEL / SET / RENAME / HDEL
+// of an entire hash) within the same Eval must NOT see the fast path
+// read pre-script pebble state and return stale collection data.
+
+func TestLua_HGET_SetThenHGetReturnsWrongType(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.HSet(ctx, "lua:h:typechange", "f", "hashval").Err())
+	_, err := rdb.Eval(ctx, `
+redis.call("SET", KEYS[1], "stringval")
+return redis.call("HGET", KEYS[1], "f")
+`, []string{"lua:h:typechange"}).Result()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WRONGTYPE",
+		"fast path must defer to cachedType when a prior SET changes the logical type")
+}
+
+func TestLua_HGET_DelThenHGetReturnsNil(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.HSet(ctx, "lua:h:delthenget", "f", "v").Err())
+	_, err := rdb.Eval(ctx, `
+redis.call("DEL", KEYS[1])
+return redis.call("HGET", KEYS[1], "f")
+`, []string{"lua:h:delthenget"}).Result()
+	require.ErrorIs(t, err, redis.Nil,
+		"fast path must defer to cachedType / deleted flag when a prior DEL tombstones the key")
+}
+
+func TestLua_HEXISTS_SetThenHExistsReturnsWrongType(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.HSet(ctx, "lua:he:typechange", "f", "v").Err())
+	_, err := rdb.Eval(ctx, `
+redis.call("SET", KEYS[1], "x")
+return redis.call("HEXISTS", KEYS[1], "f")
+`, []string{"lua:he:typechange"}).Result()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WRONGTYPE")
+}
+
+func TestLua_HEXISTS_DelThenHExistsReturnsZero(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.HSet(ctx, "lua:he:delthenexists", "f", "v").Err())
+	got, err := rdb.Eval(ctx, `
+redis.call("DEL", KEYS[1])
+return redis.call("HEXISTS", KEYS[1], "f")
+`, []string{"lua:he:delthenexists"}).Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(0), got)
+}
+
+func TestLua_SISMEMBER_SetThenSIsMemberReturnsWrongType(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.SAdd(ctx, "lua:s:typechange", "m").Err())
+	_, err := rdb.Eval(ctx, `
+redis.call("SET", KEYS[1], "x")
+return redis.call("SISMEMBER", KEYS[1], "m")
+`, []string{"lua:s:typechange"}).Result()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WRONGTYPE")
+}
+
+func TestLua_SISMEMBER_DelThenSIsMemberReturnsZero(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.SAdd(ctx, "lua:s:delthenexists", "m").Err())
+	got, err := rdb.Eval(ctx, `
+redis.call("DEL", KEYS[1])
+return redis.call("SISMEMBER", KEYS[1], "m")
+`, []string{"lua:s:delthenexists"}).Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(0), got)
+}
+
+func TestLua_ZSCORE_SetThenZScoreReturnsWrongType(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.ZAdd(ctx, "lua:z:typechange", redis.Z{Score: 7, Member: "m"}).Err())
+	_, err := rdb.Eval(ctx, `
+redis.call("SET", KEYS[1], "x")
+return redis.call("ZSCORE", KEYS[1], "m")
+`, []string{"lua:z:typechange"}).Result()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WRONGTYPE")
+}
+
+func TestLua_ZSCORE_DelThenZScoreReturnsNil(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.ZAdd(ctx, "lua:z:delthen", redis.Z{Score: 7, Member: "m"}).Err())
+	_, err := rdb.Eval(ctx, `
+redis.call("DEL", KEYS[1])
+return redis.call("ZSCORE", KEYS[1], "m")
+`, []string{"lua:z:delthen"}).Result()
+	require.ErrorIs(t, err, redis.Nil)
+}
+
+// ZSCORE arity: the legacy handler returned nil when only the key was
+// given because the missing-key check fired first. The fast path
+// indexed args[1] unconditionally, which would panic on a 1-arg call.
+// Guard explicitly.
+func TestLua_ZSCORE_ArityTooFew(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	_, err := rdb.Eval(ctx,
+		`return redis.call("ZSCORE", KEYS[1])`,
+		[]string{"lua:z:arity"},
+	).Result()
+	require.Error(t, err, "ZSCORE without a member argument must return an error, not panic")
+	require.Contains(t, err.Error(), "wrong number of arguments")
+}
+
+// HSET on a new field while a seeded field already exists in pebble:
+// the script must see the unflushed field AND the seeded field, and
+// nil for any unrelated field.
+func TestLua_HGET_AnotherFieldAfterHSet(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.HSet(ctx, "lua:h:twofield", "seeded", "old").Err())
+	got, err := rdb.Eval(ctx, `
+redis.call("HSET", KEYS[1], "newf", "newval")
+local a = redis.call("HGET", KEYS[1], "seeded") or "nil"
+local b = redis.call("HGET", KEYS[1], "newf") or "nil"
+local c = redis.call("HGET", KEYS[1], "unknownf") or "nil"
+return a .. "|" .. b .. "|" .. c
+`, []string{"lua:h:twofield"}).Result()
+	require.NoError(t, err)
+	require.Equal(t, "old|newval|nil", got)
+}

--- a/adapter/redis_lua_collection_fastpath_test.go
+++ b/adapter/redis_lua_collection_fastpath_test.go
@@ -528,6 +528,26 @@ return redis.call("ZSCORE", KEYS[1], "m")
 	require.ErrorIs(t, err, redis.Nil)
 }
 
+// TestLua_ZSCORE_ArityTooMany rejects a ZSCORE invocation with
+// trailing extra arguments. Real Redis enforces arity == 3 (command +
+// 2 args); silently ignoring extras hides bugs in caller scripts.
+func TestLua_ZSCORE_ArityTooMany(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	_, err := rdb.Eval(ctx,
+		`return redis.call("ZSCORE", KEYS[1], "m", "extra")`,
+		[]string{"lua:z:aritymany"},
+	).Result()
+	require.Error(t, err, "ZSCORE with extra arguments must be rejected, not silently ignored")
+	require.Contains(t, err.Error(), "wrong number of arguments")
+}
+
 // ZSCORE arity: the legacy handler returned nil when only the key was
 // given because the missing-key check fired first. The fast path
 // indexed args[1] unconditionally, which would panic on a 1-arg call.
@@ -571,4 +591,35 @@ return a .. "|" .. b .. "|" .. c
 `, []string{"lua:h:twofield"}).Result()
 	require.NoError(t, err)
 	require.Equal(t, "old|newval|nil", got)
+}
+
+// TestLua_HGET_RepeatedMissReusesLoadedState pins the optimisation
+// that a missing hash loaded once should NOT re-run the wide-column
+// probe on every subsequent HGET in the same Eval. The script does
+// N HGETs on the same missing key; if the fast-path guard correctly
+// honors an already-loaded luaHashState (even with exists=false),
+// only the first call reaches Pebble.
+func TestLua_HGET_RepeatedMissReusesLoadedState(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	// 4 HGETs on the same missing key; the script must return nil for
+	// each and complete without divergent results. Correctness check
+	// only -- the optimisation itself is a seek-count saving that
+	// needs pprof to verify; this test guards against the guard
+	// regressing into returning wrong answers.
+	got, err := rdb.Eval(ctx, `
+local a = redis.call("HGET", KEYS[1], "f") or "nil"
+local b = redis.call("HGET", KEYS[1], "f") or "nil"
+local c = redis.call("HGET", KEYS[1], "f") or "nil"
+local d = redis.call("HGET", KEYS[1], "f") or "nil"
+return a .. "|" .. b .. "|" .. c .. "|" .. d
+`, []string{"lua:h:repeatedmiss"}).Result()
+	require.NoError(t, err)
+	require.Equal(t, "nil|nil|nil|nil", got)
 }

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -2460,6 +2460,28 @@ func applyZRangeLimit(entries []redisZSetEntry, offset, limit int) []redisZSetEn
 
 func (c *luaScriptContext) cmdZScore(args []string) (luaReply, error) {
 	key := []byte(args[0])
+	member := args[1]
+	// In-script cache first: a prior ZADD / ZINCRBY / ZREM in this
+	// Eval already loaded the zset into c.zsets and may carry
+	// unflushed score mutations the fast path would miss. Matches the
+	// HGET / HEXISTS / SISMEMBER pattern added in PR #567.
+	if st, ok := c.zsets[string(key)]; ok {
+		return c.zscoreFromZSetState(st, key, member)
+	}
+	// Fast path: direct wide-column score lookup, bypassing the
+	// ~8-seek keyTypeAt probe inside zsetState.
+	score, hit, alive, err := c.server.zsetMemberFastScore(context.Background(), key, []byte(member), c.startTS)
+	if err != nil {
+		return luaReply{}, err
+	}
+	if hit {
+		if !alive {
+			return luaNilReply(), nil
+		}
+		return luaStringReply(formatRedisFloat(score)), nil
+	}
+	// Miss: fall back to the full zsetState path so legacy-blob zsets
+	// and nil / WRONGTYPE disambiguation behave exactly as before.
 	st, err := c.zsetState(key)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
@@ -2467,10 +2489,16 @@ func (c *luaScriptContext) cmdZScore(args []string) (luaReply, error) {
 		}
 		return luaReply{}, err
 	}
+	return c.zscoreFromZSetState(st, key, member)
+}
+
+// zscoreFromZSetState returns the Redis reply for ZSCORE against a
+// loaded luaZSetState, matching the legacy cmdZScore semantics.
+func (c *luaScriptContext) zscoreFromZSetState(st *luaZSetState, key []byte, member string) (luaReply, error) {
 	if !st.exists {
 		return luaNilReply(), nil
 	}
-	score, ok, err := c.memberScore(st, key, args[1])
+	score, ok, err := c.memberScore(st, key, member)
 	if err != nil {
 		return luaReply{}, err
 	}

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -1346,13 +1346,18 @@ func (c *luaScriptContext) renameStreamValue(src, dst []byte) error {
 func (c *luaScriptContext) cmdHGet(args []string) (luaReply, error) {
 	key := []byte(args[0])
 	field := args[1]
-	// Honor in-script writes first: if a prior HSET / HINCRBY / HDEL on
-	// this key within this script run already loaded the hash into
-	// c.hashes, the fast path would miss those unflushed mutations.
-	// This also covers callers that pre-loaded the state (e.g. HGETALL
-	// before HGET).
-	if st, ok := c.hashes[string(key)]; ok {
-		return hgetFromHashState(st, field), nil
+	// Fast path is only safe when cachedType has NO authoritative
+	// script-local answer. A cached entry (loaded hash / string / list
+	// / etc. OR an explicit c.deleted entry from a prior DEL / RENAME)
+	// means another command in this Eval has either (a) mutated the
+	// hash so c.hashes[key] holds the unflushed view, (b) changed the
+	// logical type so hashState() must produce WRONGTYPE, or (c)
+	// deleted the key so the correct answer is nil. In all three cases
+	// the slow path's hashState -> keyType -> cachedType chain produces
+	// the right answer; bypassing it would silently read pre-script
+	// pebble state and leak stale data.
+	if _, cached := c.cachedType(key); cached {
+		return hgetFromSlowPath(c, key, field)
 	}
 	// Fast path: direct wide-column field lookup, bypassing the ~8-seek
 	// keyTypeAt probe inside hashState. This is the same pattern that
@@ -1369,9 +1374,14 @@ func (c *luaScriptContext) cmdHGet(args []string) (luaReply, error) {
 		}
 		return luaStringReply(string(raw)), nil
 	}
-	// Miss: fall back to the full hashState path so legacy-blob hashes,
-	// nil / WRONGTYPE disambiguation, and the script-local cache all
-	// behave exactly as before.
+	// Miss: fall back to the full hashState path so legacy-blob hashes
+	// and nil / WRONGTYPE disambiguation behave exactly as before.
+	return hgetFromSlowPath(c, key, field)
+}
+
+// hgetFromSlowPath runs the legacy hashState-based HGET, preserving
+// the script-local cache and WRONGTYPE / nil behaviour unchanged.
+func hgetFromSlowPath(c *luaScriptContext, key []byte, field string) (luaReply, error) {
 	st, err := c.hashState(key)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
@@ -1546,9 +1556,11 @@ func (c *luaScriptContext) cmdHDel(args []string) (luaReply, error) {
 func (c *luaScriptContext) cmdHExists(args []string) (luaReply, error) {
 	key := []byte(args[0])
 	field := args[1]
-	// In-script cache first; same rationale as cmdHGet.
-	if st, ok := c.hashes[string(key)]; ok {
-		return hexistsFromHashState(st, field), nil
+	// See cmdHGet: defer to the slow path whenever cachedType has an
+	// authoritative answer, so prior DEL / RENAME / SET / HSET within
+	// this Eval is honored before the pebble probe fires.
+	if _, cached := c.cachedType(key); cached {
+		return hexistsFromSlowPath(c, key, field)
 	}
 	hit, alive, err := c.server.hashFieldFastExists(context.Background(), key, []byte(field), c.startTS)
 	if err != nil {
@@ -1560,6 +1572,10 @@ func (c *luaScriptContext) cmdHExists(args []string) (luaReply, error) {
 		}
 		return luaIntReply(0), nil
 	}
+	return hexistsFromSlowPath(c, key, field)
+}
+
+func hexistsFromSlowPath(c *luaScriptContext, key []byte, field string) (luaReply, error) {
 	st, err := c.hashState(key)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
@@ -2109,9 +2125,10 @@ func finalizeSetLikeRemoval(c *luaScriptContext, key string, removed int, empty 
 func (c *luaScriptContext) cmdSIsMember(args []string) (luaReply, error) {
 	key := []byte(args[0])
 	member := args[1]
-	// In-script cache first; same rationale as cmdHGet.
-	if st, ok := c.sets[string(key)]; ok {
-		return sismemberFromSetState(st, member), nil
+	// See cmdHGet: defer to the slow path whenever cachedType has an
+	// authoritative answer.
+	if _, cached := c.cachedType(key); cached {
+		return sismemberFromSlowPath(c, key, member)
 	}
 	hit, alive, err := c.server.setMemberFastExists(context.Background(), key, []byte(member), c.startTS)
 	if err != nil {
@@ -2123,6 +2140,10 @@ func (c *luaScriptContext) cmdSIsMember(args []string) (luaReply, error) {
 		}
 		return luaIntReply(0), nil
 	}
+	return sismemberFromSlowPath(c, key, member)
+}
+
+func sismemberFromSlowPath(c *luaScriptContext, key []byte, member string) (luaReply, error) {
 	st, err := c.setState(key)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -1346,16 +1346,21 @@ func (c *luaScriptContext) renameStreamValue(src, dst []byte) error {
 func (c *luaScriptContext) cmdHGet(args []string) (luaReply, error) {
 	key := []byte(args[0])
 	field := args[1]
-	// Fast path is only safe when cachedType has NO authoritative
-	// script-local answer. A cached entry (loaded hash / string / list
-	// / etc. OR an explicit c.deleted entry from a prior DEL / RENAME)
-	// means another command in this Eval has either (a) mutated the
-	// hash so c.hashes[key] holds the unflushed view, (b) changed the
-	// logical type so hashState() must produce WRONGTYPE, or (c)
-	// deleted the key so the correct answer is nil. In all three cases
-	// the slow path's hashState -> keyType -> cachedType chain produces
-	// the right answer; bypassing it would silently read pre-script
-	// pebble state and leak stale data.
+	// Fast path is only safe when there is NO authoritative
+	// script-local answer. Two separate signals to check:
+	//
+	//   (a) cachedType() covers loaded state for OTHER types (string /
+	//       list / ...) AND the explicit c.deleted entry from a prior
+	//       DEL / RENAME. Bypassing would leak pre-script pebble state.
+	//   (b) c.hashes[key] already loaded (even with exists=false for
+	//       a confirmed miss) means a prior command already paid the
+	//       type-probe tax. Re-running the fast path would just do
+	//       another wide-column probe for the same negative answer.
+	//       Reuse the loaded state via the slow path, which returns
+	//       immediately when c.hashes[key] is present.
+	if luaHashAlreadyLoaded(c, key) {
+		return hgetFromSlowPath(c, key, field)
+	}
 	if _, cached := c.cachedType(key); cached {
 		return hgetFromSlowPath(c, key, field)
 	}
@@ -1377,6 +1382,22 @@ func (c *luaScriptContext) cmdHGet(args []string) (luaReply, error) {
 	// Miss: fall back to the full hashState path so legacy-blob hashes
 	// and nil / WRONGTYPE disambiguation behave exactly as before.
 	return hgetFromSlowPath(c, key, field)
+}
+
+// luaHashAlreadyLoaded reports whether a prior command in this Eval
+// already populated c.hashes[key] and resolved its exists/loaded
+// flags. A loaded state -- even one representing a known miss --
+// makes the fast path redundant: the slow path returns immediately
+// by reading the cached luaHashState, skipping a wide-column probe.
+func luaHashAlreadyLoaded(c *luaScriptContext, key []byte) bool {
+	st, ok := c.hashes[string(key)]
+	return ok && st != nil && st.loaded
+}
+
+// luaSetAlreadyLoaded mirrors luaHashAlreadyLoaded for c.sets.
+func luaSetAlreadyLoaded(c *luaScriptContext, key []byte) bool {
+	st, ok := c.sets[string(key)]
+	return ok && st != nil && st.loaded
 }
 
 // hgetFromSlowPath runs the legacy hashState-based HGET, preserving
@@ -1556,9 +1577,14 @@ func (c *luaScriptContext) cmdHDel(args []string) (luaReply, error) {
 func (c *luaScriptContext) cmdHExists(args []string) (luaReply, error) {
 	key := []byte(args[0])
 	field := args[1]
-	// See cmdHGet: defer to the slow path whenever cachedType has an
-	// authoritative answer, so prior DEL / RENAME / SET / HSET within
-	// this Eval is honored before the pebble probe fires.
+	// See cmdHGet: defer to the slow path whenever the key already has
+	// an authoritative answer locally, so prior DEL / RENAME / SET /
+	// HSET within this Eval is honored, AND so a confirmed-missing
+	// hash loaded earlier in the script does not re-run the
+	// wide-column probe on every subsequent HEXISTS.
+	if luaHashAlreadyLoaded(c, key) {
+		return hexistsFromSlowPath(c, key, field)
+	}
 	if _, cached := c.cachedType(key); cached {
 		return hexistsFromSlowPath(c, key, field)
 	}
@@ -2125,8 +2151,12 @@ func finalizeSetLikeRemoval(c *luaScriptContext, key string, removed int, empty 
 func (c *luaScriptContext) cmdSIsMember(args []string) (luaReply, error) {
 	key := []byte(args[0])
 	member := args[1]
-	// See cmdHGet: defer to the slow path whenever cachedType has an
-	// authoritative answer.
+	// See cmdHGet: defer to the slow path whenever the set has an
+	// authoritative script-local answer (loaded state incl. miss, or
+	// cachedType reporting a different-type / deleted key).
+	if luaSetAlreadyLoaded(c, key) {
+		return sismemberFromSlowPath(c, key, member)
+	}
 	if _, cached := c.cachedType(key); cached {
 		return sismemberFromSlowPath(c, key, member)
 	}

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -2480,17 +2480,19 @@ func applyZRangeLimit(entries []redisZSetEntry, offset, limit int) []redisZSetEn
 }
 
 func (c *luaScriptContext) cmdZScore(args []string) (luaReply, error) {
+	if len(args) < 2 { //nolint:mnd
+		return luaReply{}, errors.New("ERR wrong number of arguments for 'zscore' command")
+	}
 	key := []byte(args[0])
 	member := args[1]
-	// In-script cache first: a prior ZADD / ZINCRBY / ZREM in this
-	// Eval already loaded the zset into c.zsets and may carry
-	// unflushed score mutations the fast path would miss. Matches the
-	// HGET / HEXISTS / SISMEMBER pattern added in PR #567.
-	if st, ok := c.zsets[string(key)]; ok {
-		return c.zscoreFromZSetState(st, key, member)
+	// See cmdHGet: defer to the slow path whenever cachedType has an
+	// authoritative answer (loaded zset from a prior ZADD / ZREM in
+	// this Eval, explicit DEL tombstone, or a different type from a
+	// prior SET on the same key). Only "unknown" cachedType proceeds
+	// to the pebble fast-path.
+	if _, cached := c.cachedType(key); cached {
+		return zscoreFromSlowPath(c, key, member)
 	}
-	// Fast path: direct wide-column score lookup, bypassing the
-	// ~8-seek keyTypeAt probe inside zsetState.
 	score, hit, alive, err := c.server.zsetMemberFastScore(context.Background(), key, []byte(member), c.startTS)
 	if err != nil {
 		return luaReply{}, err
@@ -2501,8 +2503,14 @@ func (c *luaScriptContext) cmdZScore(args []string) (luaReply, error) {
 		}
 		return luaStringReply(formatRedisFloat(score)), nil
 	}
-	// Miss: fall back to the full zsetState path so legacy-blob zsets
-	// and nil / WRONGTYPE disambiguation behave exactly as before.
+	return zscoreFromSlowPath(c, key, member)
+}
+
+// zscoreFromSlowPath runs the legacy zsetState-based ZSCORE,
+// preserving the script-local cache and WRONGTYPE / nil behaviour
+// unchanged. Handles legacy-blob zsets via ensureZSetLoaded inside
+// memberScore.
+func zscoreFromSlowPath(c *luaScriptContext, key []byte, member string) (luaReply, error) {
 	st, err := c.zsetState(key)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -1400,6 +1400,12 @@ func luaSetAlreadyLoaded(c *luaScriptContext, key []byte) bool {
 	return ok && st != nil && st.loaded
 }
 
+// luaZSetAlreadyLoaded mirrors luaHashAlreadyLoaded for c.zsets.
+func luaZSetAlreadyLoaded(c *luaScriptContext, key []byte) bool {
+	st, ok := c.zsets[string(key)]
+	return ok && st != nil && st.loaded
+}
+
 // hgetFromSlowPath runs the legacy hashState-based HGET, preserving
 // the script-local cache and WRONGTYPE / nil behaviour unchanged.
 func hgetFromSlowPath(c *luaScriptContext, key []byte, field string) (luaReply, error) {
@@ -2509,17 +2515,32 @@ func applyZRangeLimit(entries []redisZSetEntry, offset, limit int) []redisZSetEn
 	return trimmed
 }
 
+// zscoreArgCount pins the expected argument count for ZSCORE at the
+// Lua-context dispatch boundary. Using a named constant satisfies
+// the linter without a //nolint:mnd on the arity check and documents
+// that the command requires EXACTLY two arguments (any extras must
+// be rejected, matching Redis server semantics).
+const zscoreArgCount = 2
+
 func (c *luaScriptContext) cmdZScore(args []string) (luaReply, error) {
-	if len(args) < 2 { //nolint:mnd
+	if len(args) != zscoreArgCount {
 		return luaReply{}, errors.New("ERR wrong number of arguments for 'zscore' command")
 	}
 	key := []byte(args[0])
 	member := args[1]
-	// See cmdHGet: defer to the slow path whenever cachedType has an
-	// authoritative answer (loaded zset from a prior ZADD / ZREM in
-	// this Eval, explicit DEL tombstone, or a different type from a
-	// prior SET on the same key). Only "unknown" cachedType proceeds
-	// to the pebble fast-path.
+	// See cmdHGet: defer to the slow path whenever the zset has an
+	// authoritative script-local answer. Two separate signals:
+	//
+	//   (a) luaZSetAlreadyLoaded: a prior cmdZScore / cmdZRange etc.
+	//       fully resolved the zset, even to a confirmed miss
+	//       (loaded=true, exists=false). Re-running the fast path
+	//       would do a redundant wide-column probe.
+	//   (b) cachedType: a prior ZADD / ZREM in this Eval OR a prior
+	//       DEL / type-change via SET. Without this guard the fast
+	//       path would leak pre-script pebble state.
+	if luaZSetAlreadyLoaded(c, key) {
+		return zscoreFromSlowPath(c, key, member)
+	}
 	if _, cached := c.cachedType(key); cached {
 		return zscoreFromSlowPath(c, key, member)
 	}


### PR DESCRIPTION
## Summary
Phase A of the ZSET fast-path plan discussed alongside PR #567. BullMQ and other Lua-heavy workloads call ZSCORE for delay-queue position checks and job-existence checks; the legacy path went through `zsetState` (~8-seek `keyTypeAt` + full zset state init) before a direct `GetAt` on `ZSetMemberKey`.

### Change
Reuse PR #565's pattern for the single-member ZSET case:

- `adapter/redis_compat_commands.go` — new `zsetMemberFastScore(ctx, key, member, readTS)` helper. Single `GetAt` on `ZSetMemberKey`, returns `(score, hit, alive)`. Priority-alignment scope identical to `hashFieldFastLookup`: only the `redisStrKey` dual-encoding case is guarded; legacy / HLL / list corner cases fall through to the slow path.
- `adapter/redis_lua_context.go` — `cmdZScore` consults `c.zsets[key]` first (so `ZADD` → `ZSCORE` inside the same `Eval` honors unflushed mutations), otherwise calls `zsetMemberFastScore`, then falls back to `zsetState` on miss. `zscoreFromZSetState` helper factored out to keep the function body under the cyclomatic-complexity cap.

### What this does *not* do
Phase B / C (`ZRANGEBYSCORE` streaming, `ZADD` / `ZREM` fast-path) need production profiling before we commit to the deeper refactor. See #567's discussion for the staging rationale.

## Per-call effect on BullMQ position checks
- Before: ~8 seeks (keyTypeAt) + 1 scan / GetAt inside `zsetState` + 1 GetAt on `ZSetMemberKey` inside `memberScore`.
- After (fast-path hit): **2 seeks** — 1 string-priority guard + 1 `ZSetMemberKey` GetAt + 1 TTL probe.

Falls back to the legacy flow on miss so legacy-blob zsets and WRONGTYPE paths retain their prior behaviour.

## Test plan
- [x] `go test -race -short ./adapter/...` passes
- [x] New test cases in `redis_lua_collection_fastpath_test.go`:
  - fast-path hit
  - in-script `ZADD` visible to subsequent `ZSCORE`
  - miss on nonexistent zset
  - unknown member on existing zset
  - WRONGTYPE when key is a string
  - TTL-expired zset

## Depends on
- PR #567 (not yet merged) — adds the in-script-cache-first wiring pattern this PR follows. Once #567 merges, rebase to main will be clean.
