### PR TITLE
perf(redis-lua): fast-path ZSCORE wide-column lookup

### DIFF
--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -1743,6 +1743,42 @@ func (r *RedisServer) hasHigherPriorityStringEncoding(ctx context.Context, key [
 	return exists, nil
 }
 
+// zsetMemberFastScore probes the wide-column score entry for (key,
+// member) directly and reports whether it is present and TTL-alive.
+// Priority-alignment scope mirrors hashFieldFastLookup: only the
+// redisStrKey dual-encoding case is guarded (see
+// hasHigherPriorityStringEncoding's narrow-scope caveats). Callers
+// must fall back to the full zsetState loader on hit=false to cover
+// legacy-blob zsets and nil / WRONGTYPE disambiguation.
+//
+// Probe ORDER matches hashFieldFastLookup / setMemberFastExists /
+// hashFieldFastExists post-PR #565: hit the wide-column score key
+// first so the negative case (missing, legacy-blob, wrong-type) does
+// not pay the priority-guard seek.
+func (r *RedisServer) zsetMemberFastScore(ctx context.Context, key, member []byte, readTS uint64) (score float64, hit, alive bool, err error) {
+	raw, err := r.store.GetAt(ctx, store.ZSetMemberKey(key, member), readTS)
+	if err != nil {
+		if cockerrors.Is(err, store.ErrKeyNotFound) {
+			return 0, false, false, nil
+		}
+		return 0, false, false, cockerrors.WithStack(err)
+	}
+	score, err = store.UnmarshalZSetScore(raw)
+	if err != nil {
+		return 0, false, false, cockerrors.WithStack(err)
+	}
+	if higher, hErr := r.hasHigherPriorityStringEncoding(ctx, key, readTS); hErr != nil {
+		return 0, false, false, hErr
+	} else if higher {
+		return 0, false, false, nil
+	}
+	expired, expErr := r.hasExpired(ctx, key, readTS, true)
+	if expErr != nil {
+		return 0, false, false, cockerrors.WithStack(expErr)
+	}
+	return score, true, !expired, nil
+}
+
 // hgetSlow falls back to the type-probing path when hashFieldFastLookup
 // misses. Handles legacy-blob hashes and nil / WRONGTYPE disambiguation.
 func (r *RedisServer) hgetSlow(conn redcon.Conn, ctx context.Context, key, field []byte, readTS uint64) {

--- a/adapter/redis_lua_collection_fastpath_test.go
+++ b/adapter/redis_lua_collection_fastpath_test.go
@@ -450,3 +450,183 @@ return a .. "|" .. b .. "|" .. c .. "|" .. d
 	require.NoError(t, err)
 	require.Equal(t, "nil|nil|nil|nil", got)
 }
+
+// --- ZSCORE fast-path (#568) ---
+
+func TestLua_ZSCORE_FastPathHit(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.ZAdd(ctx, "lua:z:fast", redis.Z{Score: 42, Member: "m"}).Err())
+
+	got, err := rdb.Eval(ctx,
+		`return redis.call("ZSCORE", KEYS[1], ARGV[1])`,
+		[]string{"lua:z:fast"}, "m",
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, "42", got)
+}
+
+func TestLua_ZSCORE_HonorsInScriptZAdd(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	got, err := rdb.Eval(ctx, `
+redis.call("ZADD", KEYS[1], ARGV[1], ARGV[2])
+return redis.call("ZSCORE", KEYS[1], ARGV[2])
+`, []string{"lua:z:rw"}, "7", "m").Result()
+	require.NoError(t, err)
+	require.Equal(t, "7", got)
+}
+
+func TestLua_ZSCORE_Miss(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	_, err := rdb.Eval(ctx,
+		`return redis.call("ZSCORE", KEYS[1], ARGV[1])`,
+		[]string{"lua:z:missing"}, "m",
+	).Result()
+	require.ErrorIs(t, err, redis.Nil)
+}
+
+func TestLua_ZSCORE_UnknownMember(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.ZAdd(ctx, "lua:z:known", redis.Z{Score: 1, Member: "a"}).Err())
+	_, err := rdb.Eval(ctx,
+		`return redis.call("ZSCORE", KEYS[1], ARGV[1])`,
+		[]string{"lua:z:known"}, "b",
+	).Result()
+	require.ErrorIs(t, err, redis.Nil)
+}
+
+func TestLua_ZSCORE_WRONGTYPE(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.Set(ctx, "lua:z:str", "x", 0).Err())
+	_, err := rdb.Eval(ctx,
+		`return redis.call("ZSCORE", KEYS[1], "m")`,
+		[]string{"lua:z:str"},
+	).Result()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WRONGTYPE")
+}
+
+func TestLua_ZSCORE_TTLExpired(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.ZAdd(ctx, "lua:z:ttl", redis.Z{Score: 1, Member: "m"}).Err())
+	require.NoError(t, rdb.PExpire(ctx, "lua:z:ttl", luaFastPathTTL).Err())
+	waitForLuaTTL()
+
+	_, err := rdb.Eval(ctx,
+		`return redis.call("ZSCORE", KEYS[1], "m")`,
+		[]string{"lua:z:ttl"},
+	).Result()
+	require.ErrorIs(t, err, redis.Nil)
+}
+
+func TestLua_ZSCORE_SetThenZScoreReturnsWrongType(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.ZAdd(ctx, "lua:z:typechange", redis.Z{Score: 7, Member: "m"}).Err())
+	_, err := rdb.Eval(ctx, `
+redis.call("SET", KEYS[1], "x")
+return redis.call("ZSCORE", KEYS[1], "m")
+`, []string{"lua:z:typechange"}).Result()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WRONGTYPE")
+}
+
+func TestLua_ZSCORE_DelThenZScoreReturnsNil(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.ZAdd(ctx, "lua:z:delthen", redis.Z{Score: 7, Member: "m"}).Err())
+	_, err := rdb.Eval(ctx, `
+redis.call("DEL", KEYS[1])
+return redis.call("ZSCORE", KEYS[1], "m")
+`, []string{"lua:z:delthen"}).Result()
+	require.ErrorIs(t, err, redis.Nil)
+}
+
+// ZSCORE arity: exactly 2 arguments (command + key + member). Extra
+// arguments must be rejected, matching Redis server semantics.
+func TestLua_ZSCORE_ArityTooFew(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	_, err := rdb.Eval(ctx,
+		`return redis.call("ZSCORE", KEYS[1])`,
+		[]string{"lua:z:arityfew"},
+	).Result()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "wrong number of arguments")
+}
+
+func TestLua_ZSCORE_ArityTooMany(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	_, err := rdb.Eval(ctx,
+		`return redis.call("ZSCORE", KEYS[1], "m", "extra")`,
+		[]string{"lua:z:aritymany"},
+	).Result()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "wrong number of arguments")
+}

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -1400,6 +1400,12 @@ func luaSetAlreadyLoaded(c *luaScriptContext, key []byte) bool {
 	return ok && st != nil && st.loaded
 }
 
+// luaZSetAlreadyLoaded mirrors luaHashAlreadyLoaded for c.zsets.
+func luaZSetAlreadyLoaded(c *luaScriptContext, key []byte) bool {
+	st, ok := c.zsets[string(key)]
+	return ok && st != nil && st.loaded
+}
+
 // hgetFromSlowPath runs the legacy hashState-based HGET, preserving
 // the script-local cache and WRONGTYPE / nil behaviour unchanged.
 func hgetFromSlowPath(c *luaScriptContext, key []byte, field string) (luaReply, error) {
@@ -2509,8 +2515,53 @@ func applyZRangeLimit(entries []redisZSetEntry, offset, limit int) []redisZSetEn
 	return trimmed
 }
 
+// zscoreArgCount pins the expected argument count for ZSCORE at the
+// Lua-context dispatch boundary. Using a named constant satisfies
+// the linter without a //nolint:mnd on the arity check and documents
+// that the command requires EXACTLY two arguments (any extras must
+// be rejected, matching Redis server semantics).
+const zscoreArgCount = 2
+
 func (c *luaScriptContext) cmdZScore(args []string) (luaReply, error) {
+	if len(args) != zscoreArgCount {
+		return luaReply{}, errors.New("ERR wrong number of arguments for 'zscore' command")
+	}
 	key := []byte(args[0])
+	member := args[1]
+	// See cmdHGet: defer to the slow path whenever the zset has an
+	// authoritative script-local answer. Two separate signals:
+	//
+	//   (a) luaZSetAlreadyLoaded: a prior cmdZScore / cmdZRange etc.
+	//       fully resolved the zset, even to a confirmed miss
+	//       (loaded=true, exists=false). Re-running the fast path
+	//       would do a redundant wide-column probe.
+	//   (b) cachedType: a prior ZADD / ZREM in this Eval OR a prior
+	//       DEL / type-change via SET. Without this guard the fast
+	//       path would leak pre-script pebble state.
+	if luaZSetAlreadyLoaded(c, key) {
+		return zscoreFromSlowPath(c, key, member)
+	}
+	if _, cached := c.cachedType(key); cached {
+		return zscoreFromSlowPath(c, key, member)
+	}
+	score, hit, alive, err := c.server.zsetMemberFastScore(context.Background(), key, []byte(member), c.startTS)
+	if err != nil {
+		return luaReply{}, err
+	}
+	if hit {
+		if !alive {
+			return luaNilReply(), nil
+		}
+		return luaStringReply(formatRedisFloat(score)), nil
+	}
+	return zscoreFromSlowPath(c, key, member)
+}
+
+// zscoreFromSlowPath runs the legacy zsetState-based ZSCORE,
+// preserving the script-local cache and WRONGTYPE / nil behaviour
+// unchanged. Handles legacy-blob zsets via ensureZSetLoaded inside
+// memberScore.
+func zscoreFromSlowPath(c *luaScriptContext, key []byte, member string) (luaReply, error) {
 	st, err := c.zsetState(key)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
@@ -2518,10 +2569,16 @@ func (c *luaScriptContext) cmdZScore(args []string) (luaReply, error) {
 		}
 		return luaReply{}, err
 	}
+	return c.zscoreFromZSetState(st, key, member)
+}
+
+// zscoreFromZSetState returns the Redis reply for ZSCORE against a
+// loaded luaZSetState, matching the legacy cmdZScore semantics.
+func (c *luaScriptContext) zscoreFromZSetState(st *luaZSetState, key []byte, member string) (luaReply, error) {
 	if !st.exists {
 		return luaNilReply(), nil
 	}
-	score, ok, err := c.memberScore(st, key, args[1])
+	score, ok, err := c.memberScore(st, key, member)
 	if err != nil {
 		return luaReply{}, err
 	}


### PR DESCRIPTION
BullMQ and similar Lua-heavy workloads call ZSCORE for delay-queue position checks and job-existence checks; the legacy path went through zsetState (~8-seek keyTypeAt + full zset state init) before a direct GetAt on ZSetMemberKey.

Reuse PR #565 / #567's pattern for the single-member ZSET case:

- adapter/redis_compat_commands.go: new zsetMemberFastScore helper. Probes store.ZSetMemberKey directly. Probe-first-then-guard ordering matches the post-PR #565 helpers so missing / legacy- blob / wrong-type workloads do not pay the priority-guard seek. Narrow-scope priority guard covers the redisStrKey dual-encoding corruption case only, same scope as hashFieldFastLookup.
- adapter/redis_lua_context.go: cmdZScore rewrite.
  * Enforce exact arity (zscoreArgCount = 2) -- extras rejected, not silently ignored.
  * luaZSetAlreadyLoaded helper mirrors luaHashAlreadyLoaded / luaSetAlreadyLoaded (from PR #567 follow-up): a loaded zset state (even exists=false) short-circuits to the slow path so repeated ZSCORE on the same missing key does not re-probe.
  * cachedType defer: prior ZADD / ZREM in this Eval, explicit DEL tombstone, or type change via SET all go through the slow path so zsetState -> keyType -> cachedType produces the correct WRONGTYPE / nil / cached-score answer.
  * Fast path via zsetMemberFastScore when both guards pass.
  * zscoreFromSlowPath helper factored out to keep the function body under the cyclomatic-complexity cap.

Per-call effect on BullMQ position checks:
  Before: ~8 seeks (keyTypeAt) + scan / GetAt inside zsetState +
          GetAt inside memberScore
  After (fast-path hit): 3 seeks -- ZSetMemberKey GetAt +
          redisStrKey ExistsAt guard + TTL probe

Falls back to the legacy flow on miss so legacy-blob zsets and WRONGTYPE paths retain their prior behaviour.

Tests: 10 new ZSCORE cases in redis_lua_collection_fastpath_test.go: fast-path hit / in-script ZADD visible / miss / unknown member / WRONGTYPE / TTL-expired / SET-then-ZSCORE (WRONGTYPE via cachedType guard) / DEL-then-ZSCORE (nil via cachedType guard) / arity too few (1 arg rejected) / arity too many (3 args rejected).