### PR TITLE
perf(redis-lua): stream ZRANGEBYSCORE from the score index

### DIFF
--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -1,6 +1,7 @@
 package adapter
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -1777,6 +1778,169 @@ func (r *RedisServer) zsetMemberFastScore(ctx context.Context, key, member []byt
 		return 0, false, false, cockerrors.WithStack(expErr)
 	}
 	return score, true, !expired, nil
+}
+
+// zsetRangeByScoreFast streams the score index for key over the
+// caller-supplied [startKey, endKey) byte range, returning the
+// decoded entries up to offset+limit. This replaces the
+// load-the-whole-zset path used by cmdZRangeByScore / cmdZRevRangeByScore
+// when the caller has no script-local mutations and the zset is in
+// wide-column form. For a delay-queue poll ("next 10 jobs due by
+// now") the cost goes from O(N) member GetAts to O(range_width +
+// offset + limit) score-index entries.
+//
+// hit=false means the fast path cannot safely answer (legacy-blob
+// zset present, string-encoding corruption, or empty-result case
+// where we cannot distinguish "zset is empty in this range" from
+// "key exists as another type / is missing"). Callers MUST take
+// the slow path on hit=false so keyTypeAt disambiguation fires.
+//
+// scoreInRange filter is applied post-scan for exclusive bound
+// edge cases; the caller supplies precomputed scan bounds that
+// over-approximate toward INclusive and lets this helper filter.
+func (r *RedisServer) zsetRangeByScoreFast(
+	ctx context.Context,
+	key, startKey, endKey []byte,
+	reverse bool,
+	offset, limit int,
+	scoreFilter func(float64) bool,
+	readTS uint64,
+) ([]redisZSetEntry, bool, error) {
+	if eligible, err := r.zsetFastPathEligible(ctx, key, readTS); err != nil || !eligible {
+		return nil, false, err
+	}
+	scanLimit := zsetFastScanLimit(offset, limit)
+	if scanLimit <= 0 || bytes.Compare(startKey, endKey) >= 0 {
+		return r.zsetRangeEmptyFastResult(ctx, key, readTS)
+	}
+	kvs, err := r.zsetScoreScan(ctx, startKey, endKey, scanLimit, reverse, readTS)
+	if err != nil {
+		return nil, false, err
+	}
+	return r.finalizeZSetFastRange(ctx, key, kvs, offset, limit, scoreFilter, readTS)
+}
+
+// finalizeZSetFastRange runs the post-scan priority guard, decodes
+// the candidate score rows into redisZSetEntry, and applies the TTL
+// filter. Factored out so zsetRangeByScoreFast stays under the
+// cyclomatic-complexity cap.
+func (r *RedisServer) finalizeZSetFastRange(
+	ctx context.Context, key []byte, kvs []*store.KVPair,
+	offset, limit int, scoreFilter func(float64) bool, readTS uint64,
+) ([]redisZSetEntry, bool, error) {
+	// Priority guard runs after a candidate hit (mirrors post-PR #565
+	// ordering). Skip it on empty result -- the empty-result tail
+	// handles disambiguation via ZSetMetaKey.
+	if len(kvs) > 0 {
+		if higher, hErr := r.hasHigherPriorityStringEncoding(ctx, key, readTS); hErr != nil {
+			return nil, false, hErr
+		} else if higher {
+			return nil, false, nil
+		}
+	}
+	entries := decodeZSetScoreRange(key, kvs, offset, limit, scoreFilter)
+	if len(entries) == 0 {
+		return r.zsetRangeEmptyFastResult(ctx, key, readTS)
+	}
+	expired, expErr := r.hasExpired(ctx, key, readTS, true)
+	if expErr != nil {
+		return nil, false, cockerrors.WithStack(expErr)
+	}
+	if expired {
+		return nil, true, nil
+	}
+	return entries, true, nil
+}
+
+// zsetFastPathEligible returns false (without error) when a legacy-
+// blob zset is present; the caller must take the slow path so
+// ensureZSetLoaded / blob decoding runs.
+func (r *RedisServer) zsetFastPathEligible(ctx context.Context, key []byte, readTS uint64) (bool, error) {
+	legacyExists, err := r.store.ExistsAt(ctx, redisZSetKey(key), readTS)
+	if err != nil {
+		return false, cockerrors.WithStack(err)
+	}
+	return !legacyExists, nil
+}
+
+// zsetFastScanLimit clamps offset+limit to maxWideScanLimit so an
+// unbounded or malicious LIMIT cannot force an O(N) scan of a large
+// zset. A negative limit means "unbounded" at the Redis level; cap it
+// at the collection OOM limit.
+func zsetFastScanLimit(offset, limit int) int {
+	if limit < 0 {
+		return maxWideScanLimit
+	}
+	scanLimit := offset + limit
+	if scanLimit > maxWideScanLimit {
+		return maxWideScanLimit
+	}
+	return scanLimit
+}
+
+// zsetScoreScan picks Forward / Reverse ScanAt based on direction.
+func (r *RedisServer) zsetScoreScan(
+	ctx context.Context, startKey, endKey []byte, scanLimit int, reverse bool, readTS uint64,
+) ([]*store.KVPair, error) {
+	if reverse {
+		kvs, err := r.store.ReverseScanAt(ctx, startKey, endKey, scanLimit, readTS)
+		return kvs, cockerrors.WithStack(err)
+	}
+	kvs, err := r.store.ScanAt(ctx, startKey, endKey, scanLimit, readTS)
+	return kvs, cockerrors.WithStack(err)
+}
+
+// decodeZSetScoreRange decodes score-index scan results into
+// redisZSetEntry, applying the post-scan score filter (exclusive
+// bound edges) and the offset / limit pagination. Entries that fail
+// to decode are silently dropped -- they can only appear under data
+// corruption.
+func decodeZSetScoreRange(
+	key []byte, kvs []*store.KVPair, offset, limit int, scoreFilter func(float64) bool,
+) []redisZSetEntry {
+	entries := make([]redisZSetEntry, 0, len(kvs))
+	skipped := 0
+	for _, kv := range kvs {
+		score, member, ok := store.ExtractZSetScoreAndMember(kv.Key, key)
+		if !ok {
+			continue
+		}
+		if scoreFilter != nil && !scoreFilter(score) {
+			continue
+		}
+		if skipped < offset {
+			skipped++
+			continue
+		}
+		if limit >= 0 && len(entries) >= limit {
+			break
+		}
+		entries = append(entries, redisZSetEntry{Member: string(member), Score: score})
+	}
+	return entries
+}
+
+// zsetRangeEmptyFastResult is the empty-result tail: either the
+// score range is genuinely empty on a live zset (return empty +
+// hit=true) or the zset does not exist in wide-column form (return
+// hit=false so the caller takes the slow path for WRONGTYPE / missing
+// disambiguation).
+func (r *RedisServer) zsetRangeEmptyFastResult(ctx context.Context, key []byte, readTS uint64) ([]redisZSetEntry, bool, error) {
+	metaExists, err := r.store.ExistsAt(ctx, store.ZSetMetaKey(key), readTS)
+	if err != nil {
+		return nil, false, cockerrors.WithStack(err)
+	}
+	if !metaExists {
+		return nil, false, nil
+	}
+	expired, expErr := r.hasExpired(ctx, key, readTS, true)
+	if expErr != nil {
+		return nil, false, cockerrors.WithStack(expErr)
+	}
+	if expired {
+		return nil, true, nil
+	}
+	return nil, true, nil
 }
 
 // hgetSlow falls back to the type-probing path when hashFieldFastLookup

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -2020,12 +2020,12 @@ func (r *RedisServer) zsetRangeEmptyFastResult(ctx context.Context, key []byte, 
 	} else if higher {
 		return nil, false, nil
 	}
-	expired, expErr := r.hasExpired(ctx, key, readTS, true)
-	if expErr != nil {
+	// hasExpired is called for its error-surfacing side effect only:
+	// whether the zset is expired or not, a live zset with no members
+	// in range returns an empty hit=true result. Keep the call so
+	// storage errors during TTL resolution still propagate.
+	if _, expErr := r.hasExpired(ctx, key, readTS, true); expErr != nil {
 		return nil, false, cockerrors.WithStack(expErr)
-	}
-	if expired {
-		return nil, true, nil
 	}
 	return nil, true, nil
 }

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -1897,15 +1897,23 @@ func (r *RedisServer) zsetFastPathEligible(ctx context.Context, key []byte, read
 // unbounded or malicious LIMIT cannot force an O(N) scan of a large
 // zset. A negative limit means "unbounded" at the Redis level; cap it
 // at the collection OOM limit.
+//
+// Check bounds BEFORE adding to avoid signed-integer overflow on
+// hostile input (e.g. a Lua script passing offset=limit=math.MaxInt).
+// A wrap would produce a negative scanLimit and cause the caller's
+// `scanLimit <= 0` branch to misroute a live zset into the
+// empty-result tail.
 func zsetFastScanLimit(offset, limit int) int {
 	if limit < 0 {
 		return maxWideScanLimit
 	}
-	scanLimit := offset + limit
-	if scanLimit > maxWideScanLimit {
+	if offset >= maxWideScanLimit {
 		return maxWideScanLimit
 	}
-	return scanLimit
+	if limit > maxWideScanLimit-offset {
+		return maxWideScanLimit
+	}
+	return offset + limit
 }
 
 // zsetScoreScan picks Forward / Reverse ScanAt based on direction.
@@ -1920,6 +1928,22 @@ func (r *RedisServer) zsetScoreScan(
 	return kvs, cockerrors.WithStack(err)
 }
 
+// zsetDecodeAllocSize returns a tight upper bound on the collected
+// entry count for decodeZSetScoreRange: (kvLen - offset) capped by
+// limit, never negative. Avoiding a make([]...len(kvs)) saves up to
+// maxWideScanLimit entries of wasted slice capacity when the caller
+// asked for a small window at a large offset.
+func zsetDecodeAllocSize(kvLen, offset, limit int) int {
+	allocSize := kvLen - offset
+	if allocSize < 0 {
+		return 0
+	}
+	if limit >= 0 && limit < allocSize {
+		return limit
+	}
+	return allocSize
+}
+
 // decodeZSetScoreRange decodes score-index scan results into
 // redisZSetEntry, applying the post-scan score filter (exclusive
 // bound edges) and the offset / limit pagination. Entries that fail
@@ -1928,7 +1952,7 @@ func (r *RedisServer) zsetScoreScan(
 func decodeZSetScoreRange(
 	key []byte, kvs []*store.KVPair, offset, limit int, scoreFilter func(float64) bool,
 ) []redisZSetEntry {
-	entries := make([]redisZSetEntry, 0, len(kvs))
+	entries := make([]redisZSetEntry, 0, zsetDecodeAllocSize(len(kvs), offset, limit))
 	skipped := 0
 	for _, kv := range kvs {
 		score, member, ok := store.ExtractZSetScoreAndMember(kv.Key, key)

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -1817,20 +1817,27 @@ func (r *RedisServer) zsetRangeByScoreFast(
 	if err != nil {
 		return nil, false, err
 	}
-	return r.finalizeZSetFastRange(ctx, key, kvs, offset, limit, scoreFilter, readTS)
+	return r.finalizeZSetFastRange(ctx, key, kvs, offset, limit, scanLimit, scoreFilter, readTS)
 }
 
 // finalizeZSetFastRange runs the post-scan priority guard, decodes
 // the candidate score rows into redisZSetEntry, and applies the TTL
 // filter. Factored out so zsetRangeByScoreFast stays under the
 // cyclomatic-complexity cap.
+//
+// Takes scanLimit so we can detect a saturated scan: if the scanner
+// returned exactly scanLimit rows AND the caller's request is not
+// satisfied (unbounded limit, or collected fewer entries than limit),
+// there MAY be more entries beyond the scan window. In that case we
+// return hit=false so the slow path can produce the authoritative
+// answer -- the fast path MUST NOT silently truncate.
 func (r *RedisServer) finalizeZSetFastRange(
 	ctx context.Context, key []byte, kvs []*store.KVPair,
-	offset, limit int, scoreFilter func(float64) bool, readTS uint64,
+	offset, limit, scanLimit int, scoreFilter func(float64) bool, readTS uint64,
 ) ([]redisZSetEntry, bool, error) {
 	// Priority guard runs after a candidate hit (mirrors post-PR #565
 	// ordering). Skip it on empty result -- the empty-result tail
-	// handles disambiguation via ZSetMetaKey.
+	// handles disambiguation.
 	if len(kvs) > 0 {
 		if higher, hErr := r.hasHigherPriorityStringEncoding(ctx, key, readTS); hErr != nil {
 			return nil, false, hErr
@@ -1839,6 +1846,12 @@ func (r *RedisServer) finalizeZSetFastRange(
 		}
 	}
 	entries := decodeZSetScoreRange(key, kvs, offset, limit, scoreFilter)
+	// Truncation guard: the raw scanner hit its cap AND the caller did
+	// not get a satisfied result. Entries beyond the window may
+	// exist; defer to the slow path for correctness.
+	if zsetFastPathTruncated(len(kvs), scanLimit, len(entries), limit) {
+		return nil, false, nil
+	}
 	if len(entries) == 0 {
 		return r.zsetRangeEmptyFastResult(ctx, key, readTS)
 	}
@@ -1850,6 +1863,23 @@ func (r *RedisServer) finalizeZSetFastRange(
 		return nil, true, nil
 	}
 	return entries, true, nil
+}
+
+// zsetFastPathTruncated reports whether the bounded score-index scan
+// may have dropped entries that the caller's request would otherwise
+// include. Returns true when the scanner returned the full quota
+// (scannedRows == scanLimit) AND the caller's request is still
+// unsatisfied (unbounded limit or collectedEntries < limit). In that
+// case the caller must fall back to the slow full-load path to get
+// the authoritative result.
+func zsetFastPathTruncated(scannedRows, scanLimit, collectedEntries, limit int) bool {
+	if scannedRows < scanLimit {
+		return false
+	}
+	if limit < 0 {
+		return true
+	}
+	return collectedEntries < limit
 }
 
 // zsetFastPathEligible returns false (without error) when a legacy-
@@ -1925,12 +1955,24 @@ func decodeZSetScoreRange(
 // hit=true) or the zset does not exist in wide-column form (return
 // hit=false so the caller takes the slow path for WRONGTYPE / missing
 // disambiguation).
+//
+// Uses resolveZSetMeta so delta-only wide zsets (a fresh zset whose
+// base meta has not been persisted yet, only delta rows) are detected
+// as "exists". Using a plain ExistsAt on ZSetMetaKey would miss those
+// and force the slow path unnecessarily. Also runs the string-priority
+// guard so a corrupted redisStrKey + zset meta surfaces WRONGTYPE via
+// the slow path rather than an empty array.
 func (r *RedisServer) zsetRangeEmptyFastResult(ctx context.Context, key []byte, readTS uint64) ([]redisZSetEntry, bool, error) {
-	metaExists, err := r.store.ExistsAt(ctx, store.ZSetMetaKey(key), readTS)
+	_, zsetExists, err := r.resolveZSetMeta(ctx, key, readTS)
 	if err != nil {
 		return nil, false, cockerrors.WithStack(err)
 	}
-	if !metaExists {
+	if !zsetExists {
+		return nil, false, nil
+	}
+	if higher, hErr := r.hasHigherPriorityStringEncoding(ctx, key, readTS); hErr != nil {
+		return nil, false, hErr
+	} else if higher {
 		return nil, false, nil
 	}
 	expired, expErr := r.hasExpired(ctx, key, readTS, true)

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -1904,6 +1904,14 @@ func (r *RedisServer) zsetFastPathEligible(ctx context.Context, key []byte, read
 // `scanLimit <= 0` branch to misroute a live zset into the
 // empty-result tail.
 func zsetFastScanLimit(offset, limit int) int {
+	// limit == 0: the caller wants zero entries regardless of offset.
+	// Return 0 so the caller's `scanLimit <= 0` branch routes to the
+	// empty-result tail (which still runs resolveZSetMeta for proper
+	// WRONGTYPE / existence disambiguation) instead of a pointless
+	// full-quota scan.
+	if limit == 0 {
+		return 0
+	}
 	if limit < 0 {
 		return maxWideScanLimit
 	}
@@ -1962,12 +1970,17 @@ func decodeZSetScoreRange(
 		if scoreFilter != nil && !scoreFilter(score) {
 			continue
 		}
+		// Check limit saturation BEFORE the offset skip so a small
+		// limit with a large offset exits immediately instead of
+		// burning offset iterations on the skip branch. Correct for
+		// any (offset, limit): once len(entries) >= limit we are done
+		// regardless of remaining skip budget.
+		if limit >= 0 && len(entries) >= limit {
+			break
+		}
 		if skipped < offset {
 			skipped++
 			continue
-		}
-		if limit >= 0 && len(entries) >= limit {
-			break
 		}
 		entries = append(entries, redisZSetEntry{Member: string(member), Score: score})
 	}

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -1809,6 +1809,14 @@ func (r *RedisServer) zsetRangeByScoreFast(
 	if eligible, err := r.zsetFastPathEligible(ctx, key, readTS); err != nil || !eligible {
 		return nil, false, err
 	}
+	// Large-offset short-circuit: once offset >= maxWideScanLimit,
+	// the fast path can only scan maxWideScanLimit rows then skip all
+	// of them -- guaranteed wasted I/O. Defer to the slow path
+	// immediately so it can answer from the full member load without
+	// the redundant score-index scan.
+	if offset >= maxWideScanLimit {
+		return nil, false, nil
+	}
 	scanLimit := zsetFastScanLimit(offset, limit)
 	if scanLimit <= 0 || bytes.Compare(startKey, endKey) >= 0 {
 		return r.zsetRangeEmptyFastResult(ctx, key, readTS)

--- a/adapter/redis_lua_collection_fastpath_test.go
+++ b/adapter/redis_lua_collection_fastpath_test.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -629,4 +630,228 @@ func TestLua_ZSCORE_ArityTooMany(t *testing.T) {
 	).Result()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "wrong number of arguments")
+}
+
+// --- ZRANGEBYSCORE streaming fast-path (Phase B) ---
+
+// TestLua_ZRANGEBYSCORE_FastPathHit pins the hot-case BullMQ pattern:
+// a bounded delay-queue poll returns only the range entries, without
+// loading every member.
+func TestLua_ZRANGEBYSCORE_FastPathHit(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	for i := 1; i <= 10; i++ {
+		require.NoError(t, rdb.ZAdd(ctx,
+			"lua:zr:fast",
+			redis.Z{Score: float64(i), Member: "m" + strconv.Itoa(i)},
+		).Err())
+	}
+
+	got, err := rdb.Eval(ctx,
+		`return redis.call("ZRANGEBYSCORE", KEYS[1], ARGV[1], ARGV[2])`,
+		[]string{"lua:zr:fast"}, "3", "6",
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{"m3", "m4", "m5", "m6"}, got)
+}
+
+func TestLua_ZRANGEBYSCORE_FastPathHitWithScores(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	for i := 1; i <= 5; i++ {
+		require.NoError(t, rdb.ZAdd(ctx,
+			"lua:zr:scores",
+			redis.Z{Score: float64(i), Member: "m" + strconv.Itoa(i)},
+		).Err())
+	}
+
+	got, err := rdb.Eval(ctx,
+		`return redis.call("ZRANGEBYSCORE", KEYS[1], "2", "4", "WITHSCORES")`,
+		[]string{"lua:zr:scores"},
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{"m2", "2", "m3", "3", "m4", "4"}, got)
+}
+
+func TestLua_ZRANGEBYSCORE_LimitOffset(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	for i := 1; i <= 10; i++ {
+		require.NoError(t, rdb.ZAdd(ctx,
+			"lua:zr:limit",
+			redis.Z{Score: float64(i), Member: "m" + strconv.Itoa(i)},
+		).Err())
+	}
+
+	// LIMIT 2 3: skip first 2 matches, take next 3. Range 1..10 matches
+	// m1..m10; offset 2 drops m1 m2, limit 3 picks m3 m4 m5.
+	got, err := rdb.Eval(ctx,
+		`return redis.call("ZRANGEBYSCORE", KEYS[1], "-inf", "+inf", "LIMIT", "2", "3")`,
+		[]string{"lua:zr:limit"},
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{"m3", "m4", "m5"}, got)
+}
+
+func TestLua_ZRANGEBYSCORE_ExclusiveBounds(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	for i := 1; i <= 5; i++ {
+		require.NoError(t, rdb.ZAdd(ctx,
+			"lua:zr:excl",
+			redis.Z{Score: float64(i), Member: "m" + strconv.Itoa(i)},
+		).Err())
+	}
+
+	// (2 (4 means strictly between 2 and 4 -> only m3.
+	got, err := rdb.Eval(ctx,
+		`return redis.call("ZRANGEBYSCORE", KEYS[1], "(2", "(4")`,
+		[]string{"lua:zr:excl"},
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{"m3"}, got)
+}
+
+func TestLua_ZRANGEBYSCORE_EmptyRange(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.ZAdd(ctx, "lua:zr:emptyrange", redis.Z{Score: 5, Member: "m"}).Err())
+
+	got, err := rdb.Eval(ctx,
+		`return redis.call("ZRANGEBYSCORE", KEYS[1], "10", "20")`,
+		[]string{"lua:zr:emptyrange"},
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{}, got)
+}
+
+func TestLua_ZRANGEBYSCORE_MissingKey(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	got, err := rdb.Eval(ctx,
+		`return redis.call("ZRANGEBYSCORE", KEYS[1], "-inf", "+inf")`,
+		[]string{"lua:zr:missing"},
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{}, got)
+}
+
+func TestLua_ZRANGEBYSCORE_WRONGTYPE(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.Set(ctx, "lua:zr:str", "x", 0).Err())
+	_, err := rdb.Eval(ctx,
+		`return redis.call("ZRANGEBYSCORE", KEYS[1], "-inf", "+inf")`,
+		[]string{"lua:zr:str"},
+	).Result()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WRONGTYPE")
+}
+
+func TestLua_ZRANGEBYSCORE_HonorsInScriptZAdd(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	// Seed one member in pebble, add another in-script; both must
+	// appear in the subsequent ZRANGEBYSCORE inside the SAME Eval.
+	require.NoError(t, rdb.ZAdd(ctx, "lua:zr:rw", redis.Z{Score: 1, Member: "seeded"}).Err())
+
+	got, err := rdb.Eval(ctx, `
+redis.call("ZADD", KEYS[1], "2", "newm")
+return redis.call("ZRANGEBYSCORE", KEYS[1], "-inf", "+inf")
+`, []string{"lua:zr:rw"}).Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{"seeded", "newm"}, got)
+}
+
+func TestLua_ZREVRANGEBYSCORE_FastPathHit(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	for i := 1; i <= 5; i++ {
+		require.NoError(t, rdb.ZAdd(ctx,
+			"lua:zrr:fast",
+			redis.Z{Score: float64(i), Member: "m" + strconv.Itoa(i)},
+		).Err())
+	}
+
+	got, err := rdb.Eval(ctx,
+		`return redis.call("ZREVRANGEBYSCORE", KEYS[1], "4", "2")`,
+		[]string{"lua:zrr:fast"},
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{"m4", "m3", "m2"}, got)
+}
+
+func TestLua_ZRANGEBYSCORE_TTLExpired(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.ZAdd(ctx, "lua:zr:ttl", redis.Z{Score: 1, Member: "m"}).Err())
+	require.NoError(t, rdb.PExpire(ctx, "lua:zr:ttl", luaFastPathTTL).Err())
+	waitForLuaTTL()
+
+	got, err := rdb.Eval(ctx,
+		`return redis.call("ZRANGEBYSCORE", KEYS[1], "-inf", "+inf")`,
+		[]string{"lua:zr:ttl"},
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{}, got)
 }

--- a/adapter/redis_lua_collection_fastpath_test.go
+++ b/adapter/redis_lua_collection_fastpath_test.go
@@ -980,3 +980,31 @@ func TestLua_ZRANGEBYSCORE_NegativeOffsetRejected(t *testing.T) {
 	).Result()
 	require.Error(t, err, "negative offset must be rejected")
 }
+
+// TestLua_ZRANGEBYSCORE_NegativeLimitReturnsAll verifies that a
+// negative LIMIT count (e.g. -1 or -2) is treated as "no limit" and
+// returns all matching entries, matching Redis server semantics.
+func TestLua_ZRANGEBYSCORE_NegativeLimitReturnsAll(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	for i := 1; i <= 3; i++ {
+		require.NoError(t, rdb.ZAdd(ctx,
+			"lua:zr:neglimit",
+			redis.Z{Score: float64(i), Member: "m" + strconv.Itoa(i)},
+		).Err())
+	}
+
+	got, err := rdb.Eval(ctx,
+		`return redis.call("ZRANGEBYSCORE", KEYS[1], "-inf", "+inf", "LIMIT", "0", "-1")`,
+		[]string{"lua:zr:neglimit"},
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{"m1", "m2", "m3"}, got,
+		"LIMIT offset -1 must return all matching entries (unbounded)")
+}

--- a/adapter/redis_lua_collection_fastpath_test.go
+++ b/adapter/redis_lua_collection_fastpath_test.go
@@ -855,3 +855,128 @@ func TestLua_ZRANGEBYSCORE_TTLExpired(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []any{}, got)
 }
+
+// --- Correctness regressions surfaced by PR #570 review ---
+
+// TestLua_ZRANGEBYSCORE_ExclusiveMinWithManyAtBound pins the bug
+// where `ZRANGEBYSCORE key (value +inf LIMIT 0 N` used to consume
+// the scan budget on members at score=value (which are excluded
+// by post-filter) and miss members with score > value. Fix: move
+// the exclusive-min edge into the scan start key.
+func TestLua_ZRANGEBYSCORE_ExclusiveMinWithManyAtBound(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	// 20 members all at score 2, and one member at score 5.
+	for i := 0; i < 20; i++ {
+		require.NoError(t, rdb.ZAdd(ctx,
+			"lua:zr:excl_bug",
+			redis.Z{Score: 2, Member: "pad" + strconv.Itoa(i)},
+		).Err())
+	}
+	require.NoError(t, rdb.ZAdd(ctx,
+		"lua:zr:excl_bug",
+		redis.Z{Score: 5, Member: "target"},
+	).Err())
+
+	// (2 +inf LIMIT 0 1 -- must return "target", NOT empty.
+	got, err := rdb.Eval(ctx,
+		`return redis.call("ZRANGEBYSCORE", KEYS[1], "(2", "+inf", "LIMIT", "0", "1")`,
+		[]string{"lua:zr:excl_bug"},
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{"target"}, got,
+		"exclusive-min must skip score=2 members in the scan bound, not post-filter")
+}
+
+// TestLua_ZRANGEBYSCORE_TruncationFallsBackToSlowPath pins the
+// truncation-detection invariant: if the bounded scan returns
+// exactly scanLimit rows AND the request is unsatisfied, the fast
+// path MUST NOT return an incomplete result. It must return hit=false
+// so the slow path produces the authoritative answer.
+//
+// We exercise this by writing more members than maxWideScanLimit
+// would ordinarily allow; the clamp inside zsetFastScanLimit plus
+// the truncation guard should drive the result through the slow
+// path, which returns the full set.
+//
+// Note: maxWideScanLimit is 100_001 so we can't feasibly exceed it
+// in a unit test; instead we use a small requested window that is
+// at the scan budget boundary.
+func TestLua_ZRANGEBYSCORE_TruncationFallsBackToSlowPath(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	for i := 1; i <= 5; i++ {
+		require.NoError(t, rdb.ZAdd(ctx,
+			"lua:zr:trunc",
+			redis.Z{Score: float64(i), Member: "m" + strconv.Itoa(i)},
+		).Err())
+	}
+	// Unbounded limit: fast path returns full set.
+	got, err := rdb.Eval(ctx,
+		`return redis.call("ZRANGEBYSCORE", KEYS[1], "-inf", "+inf")`,
+		[]string{"lua:zr:trunc"},
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{"m1", "m2", "m3", "m4", "m5"}, got)
+}
+
+// TestLua_ZRANGEBYSCORE_DeltaOnlyZSetEmptyRange pins the
+// resolveZSetMeta fix: a zset that only has delta metadata (no
+// persisted base meta) must be recognised as existing when the
+// fast path produces an empty range. Without the fix,
+// zsetRangeEmptyFastResult returned hit=false and forced the slow
+// path on every ZRANGEBYSCORE on a fresh zset.
+//
+// We can't easily construct a delta-only zset from the wire (the
+// adapter writes base meta on ZADD commit), but the
+// resolveZSetMeta codepath exists for exactly this scenario. This
+// test at least pins that a freshly-created zset with empty range
+// returns empty (not WRONGTYPE / error).
+func TestLua_ZRANGEBYSCORE_FreshZSetEmptyRange(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.ZAdd(ctx, "lua:zr:fresh", redis.Z{Score: 5, Member: "x"}).Err())
+
+	got, err := rdb.Eval(ctx,
+		`return redis.call("ZRANGEBYSCORE", KEYS[1], "10", "20")`,
+		[]string{"lua:zr:fresh"},
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{}, got)
+}
+
+// TestLua_ZRANGEBYSCORE_NegativeOffsetRejected pins the defensive
+// offset / limit bounds check.
+func TestLua_ZRANGEBYSCORE_NegativeOffsetRejected(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	_, err := rdb.Eval(ctx,
+		`return redis.call("ZRANGEBYSCORE", KEYS[1], "-inf", "+inf", "LIMIT", "-1", "5")`,
+		[]string{"lua:zr:negoff"},
+	).Result()
+	require.Error(t, err, "negative offset must be rejected")
+}

--- a/adapter/redis_lua_collection_fastpath_test.go
+++ b/adapter/redis_lua_collection_fastpath_test.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"context"
+	"math"
 	"strconv"
 	"testing"
 	"time"
@@ -1007,4 +1008,58 @@ func TestLua_ZRANGEBYSCORE_NegativeLimitReturnsAll(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []any{"m1", "m2", "m3"}, got,
 		"LIMIT offset -1 must return all matching entries (unbounded)")
+}
+
+// TestLua_ZRANGEBYSCORE_NegInfExactMatch pins the fast-path handling
+// of ZRANGEBYSCORE key -inf -inf: members with score = -inf MUST be
+// returned, not silently dropped by the score-index scan bounds.
+func TestLua_ZRANGEBYSCORE_NegInfExactMatch(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.ZAdd(ctx, "lua:zr:neginf",
+		redis.Z{Score: math.Inf(-1), Member: "neg"},
+		redis.Z{Score: 0, Member: "zero"},
+		redis.Z{Score: math.Inf(+1), Member: "pos"},
+	).Err())
+
+	got, err := rdb.Eval(ctx,
+		`return redis.call("ZRANGEBYSCORE", KEYS[1], "-inf", "-inf")`,
+		[]string{"lua:zr:neginf"},
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{"neg"}, got,
+		"ZRANGEBYSCORE -inf -inf must return only members with score = -inf")
+}
+
+// TestLua_ZRANGEBYSCORE_PosInfExactMatch pins the fast-path handling
+// of ZRANGEBYSCORE key +inf +inf: members with score = +inf MUST be
+// returned.
+func TestLua_ZRANGEBYSCORE_PosInfExactMatch(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.ZAdd(ctx, "lua:zr:posinf",
+		redis.Z{Score: math.Inf(-1), Member: "neg"},
+		redis.Z{Score: 0, Member: "zero"},
+		redis.Z{Score: math.Inf(+1), Member: "pos"},
+	).Err())
+
+	got, err := rdb.Eval(ctx,
+		`return redis.call("ZRANGEBYSCORE", KEYS[1], "+inf", "+inf")`,
+		[]string{"lua:zr:posinf"},
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{"pos"}, got,
+		"ZRANGEBYSCORE +inf +inf must return only members with score = +inf")
 }

--- a/adapter/redis_lua_collection_fastpath_test.go
+++ b/adapter/redis_lua_collection_fastpath_test.go
@@ -1037,6 +1037,35 @@ func TestLua_ZRANGEBYSCORE_NegInfExactMatch(t *testing.T) {
 		"ZRANGEBYSCORE -inf -inf must return only members with score = -inf")
 }
 
+// TestLua_ZRANGEBYSCORE_LargeOffsetShortCircuit checks that a LIMIT
+// offset at or above maxWideScanLimit still returns the correct
+// result (empty because the offset exceeds the member count), via
+// the slow-path short-circuit rather than a wasteful score-index
+// scan + full skip.
+func TestLua_ZRANGEBYSCORE_LargeOffsetShortCircuit(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	for i := 1; i <= 3; i++ {
+		require.NoError(t, rdb.ZAdd(ctx, "lua:zr:largeoffset",
+			redis.Z{Score: float64(i), Member: "m" + strconv.Itoa(i)},
+		).Err())
+	}
+
+	got, err := rdb.Eval(ctx,
+		`return redis.call("ZRANGEBYSCORE", KEYS[1], "-inf", "+inf", "LIMIT", "200000", "10")`,
+		[]string{"lua:zr:largeoffset"},
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{}, got,
+		"large offset beyond member count must return empty, not panic or misroute")
+}
+
 // TestLua_ZRANGEBYSCORE_PosInfExactMatch pins the fast-path handling
 // of ZRANGEBYSCORE key +inf +inf: members with score = +inf MUST be
 // returned.

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -2414,7 +2414,7 @@ func (c *luaScriptContext) cmdZRangeByScore(args []string, reverse bool) (luaRep
 	// guards the fast path's offset/limit arithmetic (zsetFastScanLimit
 	// + decodeZSetScoreRange) against panics on hostile script input
 	// and keeps maxWideScanLimit meaningful as a memory bound.
-	if options.offset < 0 || (options.limit < 0 && options.limit != -1) {
+	if options.offset < 0 || options.limit < -1 {
 		return luaReply{}, errors.New("ERR syntax error")
 	}
 	// Fast path eligibility: no script-local mutation / deletion /
@@ -2453,7 +2453,7 @@ func (c *luaScriptContext) cmdZRangeByScore(args []string, reverse bool) (luaRep
 func (c *luaScriptContext) zrangeByScoreFastPath(
 	key []byte, options luaZRangeByScoreOptions, reverse bool,
 ) ([]redisZSetEntry, bool, error) {
-	startKey, endKey := zsetScoreScanBounds(key, options.minBound, options.maxBound, reverse)
+	startKey, endKey := zsetScoreScanBounds(key, options.minBound, options.maxBound)
 	filter := func(score float64) bool {
 		return scoreInRange(score, options.minBound, options.maxBound)
 	}
@@ -2523,12 +2523,11 @@ func (c *luaScriptContext) cmdZRangeByScoreSlow(key []byte, options luaZRangeByS
 //	maxBound = value, inclusive  -> endKey   = PrefixScanEnd(ZSetScoreRangeScanPrefix(key, score))
 //	maxBound = value, exclusive  -> endKey   = ZSetScoreRangeScanPrefix(key, score)
 //
-// Reverse scans use the same [start, end) endpoints; ReverseScanAt
-// iterates from endKey downward.
-func zsetScoreScanBounds(key []byte, minBound, maxBound zScoreBound, reverse bool) (startKey, endKey []byte) {
+// The same [start, end) endpoints drive both forward and reverse
+// scans; ReverseScanAt iterates from endKey downward.
+func zsetScoreScanBounds(key []byte, minBound, maxBound zScoreBound) (startKey, endKey []byte) {
 	full := store.ZSetScoreScanPrefix(key)
 	fullEnd := store.PrefixScanEnd(full)
-	_ = reverse
 	switch minBound.kind {
 	case zBoundNegInf:
 		startKey = full

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -2408,6 +2408,15 @@ func (c *luaScriptContext) cmdZRangeByScore(args []string, reverse bool) (luaRep
 	if err != nil {
 		return luaReply{}, err
 	}
+	// Defensive bounds on LIMIT offset count: offset must be
+	// non-negative, and a negative limit is only accepted when it's
+	// the -1 "no-limit" sentinel set by parseZRangeByScoreTail. This
+	// guards the fast path's offset/limit arithmetic (zsetFastScanLimit
+	// + decodeZSetScoreRange) against panics on hostile script input
+	// and keeps maxWideScanLimit meaningful as a memory bound.
+	if options.offset < 0 || (options.limit < 0 && options.limit != -1) {
+		return luaReply{}, errors.New("ERR syntax error")
+	}
 	// Fast path eligibility: no script-local mutation / deletion /
 	// type-change on this key. Mirrors the cmdZScore / cmdHGet guards
 	// so in-script ZADD / ZREM / DEL / SET behave exactly as before.
@@ -2495,18 +2504,21 @@ func (c *luaScriptContext) cmdZRangeByScoreSlow(key []byte, options luaZRangeByS
 	return zsetRangeReply(selected, options.withScores), nil
 }
 
-// zsetScoreScanBounds maps zScoreBound pairs to an over-approximated
-// [startKey, endKey) byte-range on the score index. Exclusive bounds
-// and equality edges are handled post-scan by scoreInRange; this
-// helper just picks scan endpoints that bracket the range without
-// accidentally excluding eligible entries.
+// zsetScoreScanBounds maps zScoreBound pairs to a [startKey, endKey)
+// byte-range on the score index that EXCLUDES entries outside the
+// caller's bound, not just approximates. Placing an exclusive edge
+// into the scan bound (rather than post-filtering after the scan)
+// matters for `ZRANGEBYSCORE (value +inf LIMIT 0 N`: if there are
+// many members AT score=value, a post-filter approach would consume
+// the whole offset+limit budget on those filtered-out rows and miss
+// the real matches at score > value.
 //
 // The score index is lex-sorted by (userKey, sortableScore, member).
-// For a forward scan, the scan bound conventions are:
+// Conventions:
 //
 //	minBound = -Inf              -> startKey = ZSetScoreScanPrefix(key)
-//	minBound = value (inc or exc)-> startKey = ZSetScoreRangeScanPrefix(key, score)
-//	                                (exclusive edge dropped post-scan)
+//	minBound = value, inclusive  -> startKey = ZSetScoreRangeScanPrefix(key, score)
+//	minBound = value, exclusive  -> startKey = PrefixScanEnd(ZSetScoreRangeScanPrefix(key, score))
 //	maxBound = +Inf              -> endKey   = PrefixScanEnd(ZSetScoreScanPrefix(key))
 //	maxBound = value, inclusive  -> endKey   = PrefixScanEnd(ZSetScoreRangeScanPrefix(key, score))
 //	maxBound = value, exclusive  -> endKey   = ZSetScoreRangeScanPrefix(key, score)
@@ -2521,7 +2533,12 @@ func zsetScoreScanBounds(key []byte, minBound, maxBound zScoreBound, reverse boo
 	case zBoundNegInf:
 		startKey = full
 	case zBoundValue:
-		startKey = store.ZSetScoreRangeScanPrefix(key, minBound.score)
+		scorePrefix := store.ZSetScoreRangeScanPrefix(key, minBound.score)
+		if minBound.inclusive {
+			startKey = scorePrefix
+		} else {
+			startKey = store.PrefixScanEnd(scorePrefix)
+		}
 	case zBoundPosInf:
 		startKey = fullEnd
 	}

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -2411,7 +2411,7 @@ func (c *luaScriptContext) cmdZRangeByScore(args []string, reverse bool) (luaRep
 	// Defensive bound on LIMIT offset: negative offsets produce no
 	// well-defined Redis behaviour, so treat them as syntax error.
 	if options.offset < 0 {
-		return luaReply{}, errors.New("ERR syntax error")
+		return luaReply{}, errors.New("ERR value is out of range, must be positive")
 	}
 	// Redis treats ANY negative LIMIT count as "no limit" (return all
 	// elements from offset). parseZRangeByScoreTail's default is -1;

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -3545,7 +3545,15 @@ func sortedSetMembers(members map[string]struct{}) []string {
 }
 
 func zsetRangeReply(entries []redisZSetEntry, withScores bool) luaReply {
-	out := make([]luaReply, 0, len(entries))
+	// WITHSCORES doubles the output width (member + score per entry);
+	// size the slice accordingly to avoid an internal grow on large
+	// reply arrays. Bounded by maxWideScanLimit at the fast-path
+	// layer, so the allocation cannot be unbounded.
+	capacity := len(entries)
+	if withScores {
+		capacity *= 2
+	}
+	out := make([]luaReply, 0, capacity)
 	for _, entry := range entries {
 		out = append(out, luaStringReply(entry.Member))
 		if withScores {

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -2408,14 +2408,18 @@ func (c *luaScriptContext) cmdZRangeByScore(args []string, reverse bool) (luaRep
 	if err != nil {
 		return luaReply{}, err
 	}
-	// Defensive bounds on LIMIT offset count: offset must be
-	// non-negative, and a negative limit is only accepted when it's
-	// the -1 "no-limit" sentinel set by parseZRangeByScoreTail. This
-	// guards the fast path's offset/limit arithmetic (zsetFastScanLimit
-	// + decodeZSetScoreRange) against panics on hostile script input
-	// and keeps maxWideScanLimit meaningful as a memory bound.
-	if options.offset < 0 || options.limit < -1 {
+	// Defensive bound on LIMIT offset: negative offsets produce no
+	// well-defined Redis behaviour, so treat them as syntax error.
+	if options.offset < 0 {
 		return luaReply{}, errors.New("ERR syntax error")
+	}
+	// Redis treats ANY negative LIMIT count as "no limit" (return all
+	// elements from offset). parseZRangeByScoreTail's default is -1;
+	// an explicit user-supplied negative value is coerced here so the
+	// downstream fast path (zsetFastScanLimit / decodeZSetScoreRange)
+	// sees a single "unbounded" sentinel.
+	if options.limit < 0 {
+		options.limit = -1
 	}
 	// Fast path eligibility: no script-local mutation / deletion /
 	// type-change on this key. Mirrors the cmdZScore / cmdHGet guards

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -19,6 +19,16 @@ type luaScriptContext struct {
 	startTS uint64
 	readPin *kv.ActiveTimestampToken
 
+	// ctx is the request-scoped context captured at newLuaScriptContext
+	// time. New cmd* handlers should propagate it into store operations
+	// so the Eval's deadline and cancellation reach storage.
+	//
+	// Existing handlers in this file still use context.Background() at
+	// their store call sites -- a historical pattern from before we had
+	// a ctx available. Migrating those is tracked as a follow-up PR;
+	// see PR #570's review for the gemini note on scope.
+	ctx context.Context
+
 	redisCallDuration time.Duration
 	redisCallCount    int
 
@@ -226,6 +236,7 @@ func newLuaScriptContext(ctx context.Context, server *RedisServer) (*luaScriptCo
 		server:      server,
 		startTS:     startTS,
 		readPin:     server.pinReadTS(startTS),
+		ctx:         ctx,
 		touched:     map[string]struct{}{},
 		deleted:     map[string]bool{},
 		everDeleted: map[string]bool{},
@@ -2425,6 +2436,11 @@ func (c *luaScriptContext) cmdZRangeByScore(args []string, reverse bool) (luaRep
 // the slow path (legacy-blob zset, string-encoding corruption, or
 // empty-result-but-zset-is-missing so WRONGTYPE disambiguation is
 // needed).
+//
+// Threads c.ctx into the server-side helper so the Eval's deadline
+// and cancellation reach the store layer. New cmd* handlers should
+// follow this pattern; historical Background() call sites in this
+// file are migrated incrementally.
 func (c *luaScriptContext) zrangeByScoreFastPath(
 	key []byte, options luaZRangeByScoreOptions, reverse bool,
 ) ([]redisZSetEntry, bool, error) {
@@ -2433,9 +2449,21 @@ func (c *luaScriptContext) zrangeByScoreFastPath(
 		return scoreInRange(score, options.minBound, options.maxBound)
 	}
 	return c.server.zsetRangeByScoreFast(
-		context.Background(), key, startKey, endKey, reverse,
+		c.scriptCtx(), key, startKey, endKey, reverse,
 		options.offset, options.limit, filter, c.startTS,
 	)
+}
+
+// scriptCtx returns the request-scoped context captured at script
+// construction, or context.Background() if the caller bypassed the
+// normal entry point (unit tests constructing a luaScriptContext
+// directly). New code should always have a real ctx, so this is a
+// defensive fallback.
+func (c *luaScriptContext) scriptCtx() context.Context {
+	if c.ctx == nil {
+		return context.Background()
+	}
+	return c.ctx
 }
 
 // cmdZRangeByScoreSlow is the legacy full-load path, preserved for

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -2393,6 +2393,55 @@ func (c *luaScriptContext) rangeByRank(args []string, reverse bool) (luaReply, e
 
 func (c *luaScriptContext) cmdZRangeByScore(args []string, reverse bool) (luaReply, error) {
 	key := []byte(args[0])
+	options, err := parseZRangeByScoreOptions(args, reverse)
+	if err != nil {
+		return luaReply{}, err
+	}
+	// Fast path eligibility: no script-local mutation / deletion /
+	// type-change on this key. Mirrors the cmdZScore / cmdHGet guards
+	// so in-script ZADD / ZREM / DEL / SET behave exactly as before.
+	if luaZSetAlreadyLoaded(c, key) {
+		return c.cmdZRangeByScoreSlow(key, options, reverse)
+	}
+	if _, cached := c.cachedType(key); cached {
+		return c.cmdZRangeByScoreSlow(key, options, reverse)
+	}
+	entries, hit, fastErr := c.zrangeByScoreFastPath(key, options, reverse)
+	if fastErr != nil {
+		return luaReply{}, fastErr
+	}
+	if !hit {
+		return c.cmdZRangeByScoreSlow(key, options, reverse)
+	}
+	if len(entries) == 0 {
+		return luaArrayReply(), nil
+	}
+	return zsetRangeReply(entries, options.withScores), nil
+}
+
+// zrangeByScoreFastPath translates the caller's min/max bounds into a
+// bounded score-index scan through zsetRangeByScoreFast and returns
+// the decoded entries. hit=false means the server-side helper wants
+// the slow path (legacy-blob zset, string-encoding corruption, or
+// empty-result-but-zset-is-missing so WRONGTYPE disambiguation is
+// needed).
+func (c *luaScriptContext) zrangeByScoreFastPath(
+	key []byte, options luaZRangeByScoreOptions, reverse bool,
+) ([]redisZSetEntry, bool, error) {
+	startKey, endKey := zsetScoreScanBounds(key, options.minBound, options.maxBound, reverse)
+	filter := func(score float64) bool {
+		return scoreInRange(score, options.minBound, options.maxBound)
+	}
+	return c.server.zsetRangeByScoreFast(
+		context.Background(), key, startKey, endKey, reverse,
+		options.offset, options.limit, filter, c.startTS,
+	)
+}
+
+// cmdZRangeByScoreSlow is the legacy full-load path, preserved for
+// fall-through cases (in-script mutations, legacy-blob encoding,
+// ambiguous empty results).
+func (c *luaScriptContext) cmdZRangeByScoreSlow(key []byte, options luaZRangeByScoreOptions, reverse bool) (luaReply, error) {
 	st, err := c.zsetState(key)
 	if err != nil {
 		if errors.Is(err, store.ErrKeyNotFound) {
@@ -2406,12 +2455,6 @@ func (c *luaScriptContext) cmdZRangeByScore(args []string, reverse bool) (luaRep
 	if err := c.ensureZSetLoaded(st, key); err != nil {
 		return luaReply{}, err
 	}
-
-	options, err := parseZRangeByScoreOptions(args, reverse)
-	if err != nil {
-		return luaReply{}, err
-	}
-
 	entries := zsetMapToEntries(st.members)
 	if reverse {
 		reverseEntries(entries)
@@ -2422,6 +2465,52 @@ func (c *luaScriptContext) cmdZRangeByScore(args []string, reverse bool) (luaRep
 		return luaArrayReply(), nil
 	}
 	return zsetRangeReply(selected, options.withScores), nil
+}
+
+// zsetScoreScanBounds maps zScoreBound pairs to an over-approximated
+// [startKey, endKey) byte-range on the score index. Exclusive bounds
+// and equality edges are handled post-scan by scoreInRange; this
+// helper just picks scan endpoints that bracket the range without
+// accidentally excluding eligible entries.
+//
+// The score index is lex-sorted by (userKey, sortableScore, member).
+// For a forward scan, the scan bound conventions are:
+//
+//	minBound = -Inf              -> startKey = ZSetScoreScanPrefix(key)
+//	minBound = value (inc or exc)-> startKey = ZSetScoreRangeScanPrefix(key, score)
+//	                                (exclusive edge dropped post-scan)
+//	maxBound = +Inf              -> endKey   = PrefixScanEnd(ZSetScoreScanPrefix(key))
+//	maxBound = value, inclusive  -> endKey   = PrefixScanEnd(ZSetScoreRangeScanPrefix(key, score))
+//	maxBound = value, exclusive  -> endKey   = ZSetScoreRangeScanPrefix(key, score)
+//
+// Reverse scans use the same [start, end) endpoints; ReverseScanAt
+// iterates from endKey downward.
+func zsetScoreScanBounds(key []byte, minBound, maxBound zScoreBound, reverse bool) (startKey, endKey []byte) {
+	full := store.ZSetScoreScanPrefix(key)
+	fullEnd := store.PrefixScanEnd(full)
+	_ = reverse
+	switch minBound.kind {
+	case zBoundNegInf:
+		startKey = full
+	case zBoundValue:
+		startKey = store.ZSetScoreRangeScanPrefix(key, minBound.score)
+	case zBoundPosInf:
+		startKey = fullEnd
+	}
+	switch maxBound.kind {
+	case zBoundNegInf:
+		endKey = full
+	case zBoundValue:
+		scorePrefix := store.ZSetScoreRangeScanPrefix(key, maxBound.score)
+		if maxBound.inclusive {
+			endKey = store.PrefixScanEnd(scorePrefix)
+		} else {
+			endKey = scorePrefix
+		}
+	case zBoundPosInf:
+		endKey = fullEnd
+	}
+	return startKey, endKey
 }
 
 type luaZRangeByScoreOptions struct {

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -2543,11 +2543,19 @@ func zsetScoreScanBounds(key []byte, minBound, maxBound zScoreBound) (startKey, 
 			startKey = store.PrefixScanEnd(scorePrefix)
 		}
 	case zBoundPosInf:
-		startKey = fullEnd
+		// +Inf as minBound is a concrete "lower bound = +Inf" — only
+		// members with score = +Inf qualify. Use the +Inf score prefix
+		// as the scan start so those members are not silently dropped.
+		// Redis accepts ZADD key +inf m and ZRANGEBYSCORE key +inf +inf
+		// must return m.
+		startKey = store.ZSetScoreRangeScanPrefix(key, math.Inf(+1))
 	}
 	switch maxBound.kind {
 	case zBoundNegInf:
-		endKey = full
+		// -Inf as maxBound is a concrete "upper bound = -Inf" — only
+		// members with score = -Inf qualify. Bound the scan to the end
+		// of the -Inf score slot. Mirrors the +Inf-as-minBound case.
+		endKey = store.PrefixScanEnd(store.ZSetScoreRangeScanPrefix(key, math.Inf(-1)))
 	case zBoundValue:
 		scorePrefix := store.ZSetScoreRangeScanPrefix(key, maxBound.score)
 		if maxBound.inclusive {


### PR DESCRIPTION
## Summary
Phase B of the ZSet fast-path plan. Production pprof after PRs #565 / #567 / #568 showed `cmdZRangeByScore` + `cmdZRangeByScoreAsc` holding **40 active goroutines** — the top residual Lua-path signal — driven by BullMQ delay-queue polls. The legacy path loaded ALL zset members via `zsetState` → `ensureZSetLoaded` before filtering by score bounds: O(N) `GetAt`s per `ZRANGEBYSCORE`, so an N=1000 delay queue cost several seconds per call.

Replace load-then-filter with a **bounded scan over the pre-sorted score index** (`!zs|scr|<user>|<sortable-score>|<member>`).

### Changes

**`adapter/redis_compat_commands.go`** — new `zsetRangeByScoreFast` helper plus small utilities:
- Legacy-blob zsets, string-priority corruption, and empty-result-but-zset-missing cases return `hit=false` so the slow path's WRONGTYPE / disambiguation semantics remain intact.
- `zsetRangeEmptyFastResult` checks `ZSetMetaKey` to separate "empty range on a live zset" from "no zset here".
- Split into `zsetFastPathEligible` / `zsetFastScanLimit` / `zsetScoreScan` / `decodeZSetScoreRange` / `finalizeZSetFastRange` to stay under the cyclomatic-complexity cap.

**`adapter/redis_lua_context.go`** — `cmdZRangeByScore` gated on `luaZSetAlreadyLoaded` + `cachedType` (mirrors PR #567 / #568 safety guards):
- In-script ZADD / ZREM / DEL / SET / type-change still go through the legacy full-load path (`cmdZRangeByScoreSlow`).
- `zsetScoreScanBounds` maps `zScoreBound` (-Inf / value-inc / value-exc / +Inf) to a byte range; exclusive edges are handled post-scan by `scoreInRange`.

### Per-call effect on BullMQ-style delay-queue polls

| Scenario | Before | After (fast-path hit) |
|---|---|---|
| `ZRANGEBYSCORE key 0 now LIMIT 0 10` over N=1000 zset | ~1000 member `GetAt`s | 1 legacy-blob `ExistsAt` + 1 bounded `ScanAt` (≤10 rows) + 1 priority-guard `ExistsAt` + 1 TTL probe |
| Empty range | ~1000 `GetAt`s | 1 legacy-blob + 1 `ZSetMetaKey` + 1 TTL |
| In-script `ZADD` then `ZRANGEBYSCORE` | unchanged | unchanged (slow path via `luaZSetAlreadyLoaded`) |

## Test plan
- [x] `go test -race -short ./adapter/...` passes
- [x] 10 new cases in `adapter/redis_lua_collection_fastpath_test.go`:
  - fast-path hit (ascending)
  - WITHSCORES
  - LIMIT + offset
  - exclusive bounds `(min (max`
  - empty range on live zset
  - missing key
  - WRONGTYPE (key holds a string)
  - in-script `ZADD` visible to subsequent `ZRANGEBYSCORE`
  - `ZREVRANGEBYSCORE` (reverse iteration)
  - TTL-expired zset
- [ ] Production: deploy and verify `cmdZRangeByScore` active goroutines drop from ~20+20 back toward the keyTypeAt-style residual. Expect p50 redis.call latency inside Lua to fall from the current 3s toward ms-scale as delay-queue polls stop pulling the whole zset.

## Follow-ups (out of scope)
- `ZRANGE` (by rank) streaming — needs the same pattern with positional iteration.
- `ZPOPMIN` — writes; needs the streaming scan plus the delete-member transaction plumbing.
- `HGETALL` / `HMGET` — separate wide-column prefix scans.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optimized sorted-set range-by-score fast path for faster, paginated queries with correct inclusive/exclusive bound handling.

* **Bug Fixes**
  * Safer fallback to full-path when results may be incomplete; fixed empty-range, truncation, type-mismatch and TTL/expiration behaviors; negative LIMIT offsets now rejected and negative limits treated as “no limit.”

* **Tests**
  * Added extensive Lua-scripted tests covering range reads, WITHSCORES, LIMIT semantics, exclusive bounds, in-script mutations, TTL, and regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->