### PR TITLE
obs(redis-lua): per-cmd fast-path outcome counter

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -266,6 +266,11 @@ type RedisServer struct {
 	requestObserver     monitoring.RedisRequestObserver
 	luaObserver         monitoring.LuaScriptObserver
 	luaFastPathObserver monitoring.LuaFastPathObserver
+	// luaFastPathZRange is the pre-resolved counter bundle for the
+	// ZRANGEBYSCORE / ZREVRANGEBYSCORE Lua fast path. Resolved once in
+	// WithLuaFastPathObserver so the hot path does not pay for
+	// CounterVec.WithLabelValues on every redis.call().
+	luaFastPathZRange monitoring.LuaFastPathCmd
 	// baseCtx is the parent context for per-request handlers.
 	// NewRedisServer creates a cancelable context here; Stop() cancels
 	// it so in-flight handlers abort promptly instead of running
@@ -324,11 +329,21 @@ func WithLuaObserver(observer monitoring.LuaScriptObserver) RedisServerOption {
 // WithLuaFastPathObserver enables per-redis.call() fast-path outcome
 // metrics inside Lua scripts. Used to diagnose fast-path hit ratios
 // for commands like ZRANGEBYSCORE / ZSCORE / HGET.
+//
+// Resolves per-command counter handles up front so the hot path
+// avoids CounterVec.WithLabelValues on every redis.call().
 func WithLuaFastPathObserver(observer monitoring.LuaFastPathObserver) RedisServerOption {
 	return func(r *RedisServer) {
 		r.luaFastPathObserver = observer
+		r.luaFastPathZRange = observer.ForCommand(luaFastPathCmdZRangeByScore)
 	}
 }
+
+// luaFastPathCmdZRangeByScore is the shared label for ZRANGEBYSCORE
+// and ZREVRANGEBYSCORE fast-path outcomes. Both directions take the
+// same branch through zsetRangeByScoreFast so sharing one label
+// keeps the counter cardinality bounded.
+const luaFastPathCmdZRangeByScore = "zrangebyscore"
 
 // redisMetricsConn wraps a redcon.Conn to detect whether WriteError was called.
 type redisMetricsConn struct {

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -250,21 +250,22 @@ var argsLen = map[string]int{
 }
 
 type RedisServer struct {
-	listen          net.Listener
-	store           store.MVCCStore
-	coordinator     kv.Coordinator
-	readTracker     *kv.ActiveTimestampTracker
-	redisTranscoder *redisTranscoder
-	pubsub          *redisPubSub
-	scriptMu        sync.RWMutex
-	scriptCache     map[string]string
-	traceCommands   bool
-	traceSeq        atomic.Uint64
-	redisAddr       string
-	relay           *RedisPubSubRelay
-	relayConnCache  kv.GRPCConnCache
-	requestObserver monitoring.RedisRequestObserver
-	luaObserver     monitoring.LuaScriptObserver
+	listen              net.Listener
+	store               store.MVCCStore
+	coordinator         kv.Coordinator
+	readTracker         *kv.ActiveTimestampTracker
+	redisTranscoder     *redisTranscoder
+	pubsub              *redisPubSub
+	scriptMu            sync.RWMutex
+	scriptCache         map[string]string
+	traceCommands       bool
+	traceSeq            atomic.Uint64
+	redisAddr           string
+	relay               *RedisPubSubRelay
+	relayConnCache      kv.GRPCConnCache
+	requestObserver     monitoring.RedisRequestObserver
+	luaObserver         monitoring.LuaScriptObserver
+	luaFastPathObserver monitoring.LuaFastPathObserver
 	// baseCtx is the parent context for per-request handlers.
 	// NewRedisServer creates a cancelable context here; Stop() cancels
 	// it so in-flight handlers abort promptly instead of running
@@ -317,6 +318,15 @@ func WithRedisRequestObserver(observer monitoring.RedisRequestObserver) RedisSer
 func WithLuaObserver(observer monitoring.LuaScriptObserver) RedisServerOption {
 	return func(r *RedisServer) {
 		r.luaObserver = observer
+	}
+}
+
+// WithLuaFastPathObserver enables per-redis.call() fast-path outcome
+// metrics inside Lua scripts. Used to diagnose fast-path hit ratios
+// for commands like ZRANGEBYSCORE / ZSCORE / HGET.
+func WithLuaFastPathObserver(observer monitoring.LuaFastPathObserver) RedisServerOption {
+	return func(r *RedisServer) {
+		r.luaFastPathObserver = observer
 	}
 }
 

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/bootjp/elastickv/kv"
+	"github.com/bootjp/elastickv/monitoring"
 	"github.com/bootjp/elastickv/store"
 	"github.com/cockroachdb/errors"
 )
@@ -2425,9 +2426,11 @@ func (c *luaScriptContext) cmdZRangeByScore(args []string, reverse bool) (luaRep
 	// type-change on this key. Mirrors the cmdZScore / cmdHGet guards
 	// so in-script ZADD / ZREM / DEL / SET behave exactly as before.
 	if luaZSetAlreadyLoaded(c, key) {
+		c.observeFastPathOutcome(luaCmdZRangeByScore, monitoring.LuaFastPathOutcomeSkipAlreadyLoad)
 		return c.cmdZRangeByScoreSlow(key, options, reverse)
 	}
 	if _, cached := c.cachedType(key); cached {
+		c.observeFastPathOutcome(luaCmdZRangeByScore, monitoring.LuaFastPathOutcomeSkipCachedType)
 		return c.cmdZRangeByScoreSlow(key, options, reverse)
 	}
 	entries, hit, fastErr := c.zrangeByScoreFastPath(key, options, reverse)
@@ -2435,12 +2438,36 @@ func (c *luaScriptContext) cmdZRangeByScore(args []string, reverse bool) (luaRep
 		return luaReply{}, fastErr
 	}
 	if !hit {
+		c.observeFastPathOutcome(luaCmdZRangeByScore, monitoring.LuaFastPathOutcomeFallback)
 		return c.cmdZRangeByScoreSlow(key, options, reverse)
 	}
+	c.observeFastPathOutcome(luaCmdZRangeByScore, monitoring.LuaFastPathOutcomeHit)
 	if len(entries) == 0 {
 		return luaArrayReply(), nil
 	}
 	return zsetRangeReply(entries, options.withScores), nil
+}
+
+// luaCmdZRangeByScore is the metric label for ZRANGEBYSCORE /
+// ZREVRANGEBYSCORE fast-path outcomes. Both directions share one
+// label because the fast-path implementation is identical except for
+// scan direction.
+const luaCmdZRangeByScore = "zrangebyscore"
+
+// observeFastPathOutcome records one fast-path decision via the
+// server's observer. No-op when no observer is wired (tests, or a
+// scriptCtx constructed without a RedisServer).
+//
+// cmd is accepted as a parameter (rather than hard-coded) so the
+// next wave of fast-path commands (ZSCORE, HGET, HEXISTS, SISMEMBER)
+// can plug in without widening the helper signature.
+//
+//nolint:unparam // cmd will gain additional values in follow-up commits.
+func (c *luaScriptContext) observeFastPathOutcome(cmd, outcome string) {
+	if c.server == nil {
+		return
+	}
+	c.server.luaFastPathObserver.ObserveLuaFastPath(cmd, outcome)
 }
 
 // zrangeByScoreFastPath translates the caller's min/max bounds into a

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/bootjp/elastickv/kv"
-	"github.com/bootjp/elastickv/monitoring"
 	"github.com/bootjp/elastickv/store"
 	"github.com/cockroachdb/errors"
 )
@@ -2425,12 +2424,18 @@ func (c *luaScriptContext) cmdZRangeByScore(args []string, reverse bool) (luaRep
 	// Fast path eligibility: no script-local mutation / deletion /
 	// type-change on this key. Mirrors the cmdZScore / cmdHGet guards
 	// so in-script ZADD / ZREM / DEL / SET behave exactly as before.
+	//
+	// zrangeMetrics is a zero-value LuaFastPathCmd when no observer is
+	// wired (tests); Observe* methods on it are no-ops. When wired,
+	// each Observe* is a single atomic increment on a pre-resolved
+	// Counter (see WithLuaFastPathObserver).
+	zrangeMetrics := c.server.luaFastPathZRange
 	if luaZSetAlreadyLoaded(c, key) {
-		c.observeFastPathOutcome(luaCmdZRangeByScore, monitoring.LuaFastPathOutcomeSkipAlreadyLoad)
+		zrangeMetrics.ObserveSkipAlreadyLoaded()
 		return c.cmdZRangeByScoreSlow(key, options, reverse)
 	}
 	if _, cached := c.cachedType(key); cached {
-		c.observeFastPathOutcome(luaCmdZRangeByScore, monitoring.LuaFastPathOutcomeSkipCachedType)
+		zrangeMetrics.ObserveSkipCachedType()
 		return c.cmdZRangeByScoreSlow(key, options, reverse)
 	}
 	entries, hit, fastErr := c.zrangeByScoreFastPath(key, options, reverse)
@@ -2438,36 +2443,14 @@ func (c *luaScriptContext) cmdZRangeByScore(args []string, reverse bool) (luaRep
 		return luaReply{}, fastErr
 	}
 	if !hit {
-		c.observeFastPathOutcome(luaCmdZRangeByScore, monitoring.LuaFastPathOutcomeFallback)
+		zrangeMetrics.ObserveFallback()
 		return c.cmdZRangeByScoreSlow(key, options, reverse)
 	}
-	c.observeFastPathOutcome(luaCmdZRangeByScore, monitoring.LuaFastPathOutcomeHit)
+	zrangeMetrics.ObserveHit()
 	if len(entries) == 0 {
 		return luaArrayReply(), nil
 	}
 	return zsetRangeReply(entries, options.withScores), nil
-}
-
-// luaCmdZRangeByScore is the metric label for ZRANGEBYSCORE /
-// ZREVRANGEBYSCORE fast-path outcomes. Both directions share one
-// label because the fast-path implementation is identical except for
-// scan direction.
-const luaCmdZRangeByScore = "zrangebyscore"
-
-// observeFastPathOutcome records one fast-path decision via the
-// server's observer. No-op when no observer is wired (tests, or a
-// scriptCtx constructed without a RedisServer).
-//
-// cmd is accepted as a parameter (rather than hard-coded) so the
-// next wave of fast-path commands (ZSCORE, HGET, HEXISTS, SISMEMBER)
-// can plug in without widening the helper signature.
-//
-//nolint:unparam // cmd will gain additional values in follow-up commits.
-func (c *luaScriptContext) observeFastPathOutcome(cmd, outcome string) {
-	if c.server == nil {
-		return
-	}
-	c.server.luaFastPathObserver.ObserveLuaFastPath(cmd, outcome)
 }
 
 // zrangeByScoreFastPath translates the caller's min/max bounds into a

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -2431,7 +2431,7 @@ func (c *luaScriptContext) cmdZRangeByScore(args []string, reverse bool) (luaRep
 	// Counter (see WithLuaFastPathObserver).
 	zrangeMetrics := c.server.luaFastPathZRange
 	if luaZSetAlreadyLoaded(c, key) {
-		zrangeMetrics.ObserveSkipAlreadyLoaded()
+		zrangeMetrics.ObserveSkipLoaded()
 		return c.cmdZRangeByScoreSlow(key, options, reverse)
 	}
 	if _, cached := c.cachedType(key); cached {

--- a/main.go
+++ b/main.go
@@ -553,6 +553,7 @@ func startRedisServer(ctx context.Context, lc *net.ListenConfig, eg *errgroup.Gr
 		adapter.WithRedisActiveTimestampTracker(readTracker),
 		adapter.WithRedisRequestObserver(metricsRegistry.RedisObserver()),
 		adapter.WithLuaObserver(metricsRegistry.LuaObserver()),
+		adapter.WithLuaFastPathObserver(metricsRegistry.LuaFastPathObserver()),
 		adapter.WithRedisCompactor(deltaCompactor),
 	)
 	eg.Go(func() error {

--- a/monitoring/hotpath.go
+++ b/monitoring/hotpath.go
@@ -42,7 +42,7 @@ type HotPathMetrics struct {
 // ZSCORE, HGET, etc.) actually takes the fast path vs falls back.
 const (
 	LuaFastPathOutcomeHit             = "hit"
-	LuaFastPathOutcomeSkipAlreadyLoad = "skip_loaded"
+	LuaFastPathOutcomeSkipLoaded = "skip_loaded"
 	LuaFastPathOutcomeSkipCachedType  = "skip_cached_type"
 	LuaFastPathOutcomeFallback        = "fallback"
 )
@@ -100,11 +100,13 @@ func newHotPathMetrics(registerer prometheus.Registerer) *HotPathMetrics {
 // inside Lua scripts. The zero value is safe and silently drops
 // samples so tests can pass LuaFastPathObserver{} as a stub.
 //
-// Hot-path shape: each ObserveLuaFastPath-on-handle call is a single
-// atomic increment on a pre-resolved prometheus.Counter. Callers
-// resolve one LuaFastPathCmd per command at server construction to
-// avoid CounterVec.WithLabelValues (mutex-guarded map lookup) on the
-// hot path.
+// Hot-path shape: each Observe* call on a LuaFastPathCmd handle is a
+// single non-blocking atomic increment on a pre-resolved
+// prometheus.Counter (client_golang's default Counter uses
+// sync/atomic internally). Callers resolve one LuaFastPathCmd per
+// command at server construction to avoid
+// CounterVec.WithLabelValues (mutex-guarded map lookup) on the hot
+// path.
 type LuaFastPathObserver struct {
 	metrics *HotPathMetrics
 }
@@ -115,7 +117,7 @@ type LuaFastPathObserver struct {
 // Observe* methods per redis.call(). Safe to copy.
 type LuaFastPathCmd struct {
 	hit             prometheus.Counter
-	skipAlreadyLoad prometheus.Counter
+	skipLoaded prometheus.Counter
 	skipCachedType  prometheus.Counter
 	fallback        prometheus.Counter
 }
@@ -130,13 +132,13 @@ func (o LuaFastPathObserver) ForCommand(cmd string) LuaFastPathCmd {
 	vec := o.metrics.luaFastPathTotal
 	return LuaFastPathCmd{
 		hit:             vec.WithLabelValues(cmd, LuaFastPathOutcomeHit),
-		skipAlreadyLoad: vec.WithLabelValues(cmd, LuaFastPathOutcomeSkipAlreadyLoad),
+		skipLoaded: vec.WithLabelValues(cmd, LuaFastPathOutcomeSkipLoaded),
 		skipCachedType:  vec.WithLabelValues(cmd, LuaFastPathOutcomeSkipCachedType),
 		fallback:        vec.WithLabelValues(cmd, LuaFastPathOutcomeFallback),
 	}
 }
 
-// ObserveHit / ObserveSkipAlreadyLoaded / ObserveSkipCachedType /
+// ObserveHit / ObserveSkipLoaded / ObserveSkipCachedType /
 // ObserveFallback record one outcome. Each is a single atomic
 // increment when the counter is wired; a no-op on the zero value.
 func (c LuaFastPathCmd) ObserveHit() {
@@ -145,9 +147,9 @@ func (c LuaFastPathCmd) ObserveHit() {
 	}
 }
 
-func (c LuaFastPathCmd) ObserveSkipAlreadyLoaded() {
-	if c.skipAlreadyLoad != nil {
-		c.skipAlreadyLoad.Inc()
+func (c LuaFastPathCmd) ObserveSkipLoaded() {
+	if c.skipLoaded != nil {
+		c.skipLoaded.Inc()
 	}
 }
 

--- a/monitoring/hotpath.go
+++ b/monitoring/hotpath.go
@@ -41,10 +41,10 @@ type HotPathMetrics struct {
 // so operators can see how often a given command (ZRANGEBYSCORE,
 // ZSCORE, HGET, etc.) actually takes the fast path vs falls back.
 const (
-	LuaFastPathOutcomeHit             = "hit"
-	LuaFastPathOutcomeSkipLoaded = "skip_loaded"
-	LuaFastPathOutcomeSkipCachedType  = "skip_cached_type"
-	LuaFastPathOutcomeFallback        = "fallback"
+	LuaFastPathOutcomeHit            = "hit"
+	LuaFastPathOutcomeSkipLoaded     = "skip_loaded"
+	LuaFastPathOutcomeSkipCachedType = "skip_cached_type"
+	LuaFastPathOutcomeFallback       = "fallback"
 )
 
 func newHotPathMetrics(registerer prometheus.Registerer) *HotPathMetrics {
@@ -116,10 +116,10 @@ type LuaFastPathObserver struct {
 // LuaFastPathObserver.ForCommand(cmd) at server startup; call the
 // Observe* methods per redis.call(). Safe to copy.
 type LuaFastPathCmd struct {
-	hit             prometheus.Counter
-	skipLoaded prometheus.Counter
-	skipCachedType  prometheus.Counter
-	fallback        prometheus.Counter
+	hit            prometheus.Counter
+	skipLoaded     prometheus.Counter
+	skipCachedType prometheus.Counter
+	fallback       prometheus.Counter
 }
 
 // ForCommand pre-resolves the counter handles for cmd. Returns a
@@ -131,10 +131,10 @@ func (o LuaFastPathObserver) ForCommand(cmd string) LuaFastPathCmd {
 	}
 	vec := o.metrics.luaFastPathTotal
 	return LuaFastPathCmd{
-		hit:             vec.WithLabelValues(cmd, LuaFastPathOutcomeHit),
-		skipLoaded: vec.WithLabelValues(cmd, LuaFastPathOutcomeSkipLoaded),
-		skipCachedType:  vec.WithLabelValues(cmd, LuaFastPathOutcomeSkipCachedType),
-		fallback:        vec.WithLabelValues(cmd, LuaFastPathOutcomeFallback),
+		hit:            vec.WithLabelValues(cmd, LuaFastPathOutcomeHit),
+		skipLoaded:     vec.WithLabelValues(cmd, LuaFastPathOutcomeSkipLoaded),
+		skipCachedType: vec.WithLabelValues(cmd, LuaFastPathOutcomeSkipCachedType),
+		fallback:       vec.WithLabelValues(cmd, LuaFastPathOutcomeFallback),
 	}
 }
 

--- a/monitoring/hotpath.go
+++ b/monitoring/hotpath.go
@@ -34,7 +34,18 @@ type HotPathMetrics struct {
 	dispatchDroppedTotal *prometheus.CounterVec
 	dispatchErrorsTotal  *prometheus.CounterVec
 	stepQueueFullTotal   *prometheus.CounterVec
+	luaFastPathTotal     *prometheus.CounterVec
 }
+
+// LuaFastPathOutcome labels tag each Lua-side read fast-path decision
+// so operators can see how often a given command (ZRANGEBYSCORE,
+// ZSCORE, HGET, etc.) actually takes the fast path vs falls back.
+const (
+	LuaFastPathOutcomeHit             = "hit"
+	LuaFastPathOutcomeSkipAlreadyLoad = "skip_loaded"
+	LuaFastPathOutcomeSkipCachedType  = "skip_cached_type"
+	LuaFastPathOutcomeFallback        = "fallback"
+)
 
 func newHotPathMetrics(registerer prometheus.Registerer) *HotPathMetrics {
 	m := &HotPathMetrics{
@@ -66,6 +77,13 @@ func newHotPathMetrics(registerer prometheus.Registerer) *HotPathMetrics {
 			},
 			[]string{"group"},
 		),
+		luaFastPathTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "elastickv_lua_cmd_fastpath_total",
+				Help: "Per-redis.call() fast-path outcome inside Lua scripts. cmd identifies the command (zrangebyscore, zscore, ...); outcome is hit, skip_loaded, skip_cached_type, or fallback.",
+			},
+			[]string{"cmd", "outcome"},
+		),
 	}
 
 	registerer.MustRegister(
@@ -73,8 +91,27 @@ func newHotPathMetrics(registerer prometheus.Registerer) *HotPathMetrics {
 		m.dispatchDroppedTotal,
 		m.dispatchErrorsTotal,
 		m.stepQueueFullTotal,
+		m.luaFastPathTotal,
 	)
 	return m
+}
+
+// LuaFastPathObserver records a fast-path outcome for a single
+// redis.call() inside a Lua script. The zero value is safe and
+// silently drops samples so tests can pass LuaFastPathObserver{} as a
+// stub.
+type LuaFastPathObserver struct {
+	metrics *HotPathMetrics
+}
+
+// ObserveLuaFastPath records (cmd, outcome). cmd should be the
+// lowercase command name (e.g. "zrangebyscore"); outcome should be
+// one of LuaFastPathOutcome*.
+func (o LuaFastPathObserver) ObserveLuaFastPath(cmd, outcome string) {
+	if o.metrics == nil {
+		return
+	}
+	o.metrics.luaFastPathTotal.WithLabelValues(cmd, outcome).Inc()
 }
 
 // LeaseReadObserver implements kv.LeaseReadObserver by incrementing the

--- a/monitoring/hotpath.go
+++ b/monitoring/hotpath.go
@@ -96,22 +96,71 @@ func newHotPathMetrics(registerer prometheus.Registerer) *HotPathMetrics {
 	return m
 }
 
-// LuaFastPathObserver records a fast-path outcome for a single
-// redis.call() inside a Lua script. The zero value is safe and
-// silently drops samples so tests can pass LuaFastPathObserver{} as a
-// stub.
+// LuaFastPathObserver records fast-path outcomes for redis.call()
+// inside Lua scripts. The zero value is safe and silently drops
+// samples so tests can pass LuaFastPathObserver{} as a stub.
+//
+// Hot-path shape: each ObserveLuaFastPath-on-handle call is a single
+// atomic increment on a pre-resolved prometheus.Counter. Callers
+// resolve one LuaFastPathCmd per command at server construction to
+// avoid CounterVec.WithLabelValues (mutex-guarded map lookup) on the
+// hot path.
 type LuaFastPathObserver struct {
 	metrics *HotPathMetrics
 }
 
-// ObserveLuaFastPath records (cmd, outcome). cmd should be the
-// lowercase command name (e.g. "zrangebyscore"); outcome should be
-// one of LuaFastPathOutcome*.
-func (o LuaFastPathObserver) ObserveLuaFastPath(cmd, outcome string) {
+// LuaFastPathCmd is a pre-resolved bundle of fast-path outcome
+// counters for a single Lua command. Construct once via
+// LuaFastPathObserver.ForCommand(cmd) at server startup; call the
+// Observe* methods per redis.call(). Safe to copy.
+type LuaFastPathCmd struct {
+	hit             prometheus.Counter
+	skipAlreadyLoad prometheus.Counter
+	skipCachedType  prometheus.Counter
+	fallback        prometheus.Counter
+}
+
+// ForCommand pre-resolves the counter handles for cmd. Returns a
+// zero-value LuaFastPathCmd when the observer is empty (tests),
+// which silently drops all Observe* calls.
+func (o LuaFastPathObserver) ForCommand(cmd string) LuaFastPathCmd {
 	if o.metrics == nil {
-		return
+		return LuaFastPathCmd{}
 	}
-	o.metrics.luaFastPathTotal.WithLabelValues(cmd, outcome).Inc()
+	vec := o.metrics.luaFastPathTotal
+	return LuaFastPathCmd{
+		hit:             vec.WithLabelValues(cmd, LuaFastPathOutcomeHit),
+		skipAlreadyLoad: vec.WithLabelValues(cmd, LuaFastPathOutcomeSkipAlreadyLoad),
+		skipCachedType:  vec.WithLabelValues(cmd, LuaFastPathOutcomeSkipCachedType),
+		fallback:        vec.WithLabelValues(cmd, LuaFastPathOutcomeFallback),
+	}
+}
+
+// ObserveHit / ObserveSkipAlreadyLoaded / ObserveSkipCachedType /
+// ObserveFallback record one outcome. Each is a single atomic
+// increment when the counter is wired; a no-op on the zero value.
+func (c LuaFastPathCmd) ObserveHit() {
+	if c.hit != nil {
+		c.hit.Inc()
+	}
+}
+
+func (c LuaFastPathCmd) ObserveSkipAlreadyLoaded() {
+	if c.skipAlreadyLoad != nil {
+		c.skipAlreadyLoad.Inc()
+	}
+}
+
+func (c LuaFastPathCmd) ObserveSkipCachedType() {
+	if c.skipCachedType != nil {
+		c.skipCachedType.Inc()
+	}
+}
+
+func (c LuaFastPathCmd) ObserveFallback() {
+	if c.fallback != nil {
+		c.fallback.Inc()
+	}
 }
 
 // LeaseReadObserver implements kv.LeaseReadObserver by incrementing the

--- a/monitoring/hotpath_test.go
+++ b/monitoring/hotpath_test.go
@@ -36,7 +36,7 @@ func TestLuaFastPathObserverCountsByCmdAndOutcome(t *testing.T) {
 
 	cmd.ObserveHit()
 	cmd.ObserveHit()
-	cmd.ObserveSkipAlreadyLoaded()
+	cmd.ObserveSkipLoaded()
 	cmd.ObserveFallback()
 
 	err := testutil.GatherAndCompare(
@@ -59,7 +59,7 @@ func TestLuaFastPathObserverZeroValueIsNoop(t *testing.T) {
 	cmd := observer.ForCommand("zrangebyscore")
 	require.NotPanics(t, func() {
 		cmd.ObserveHit()
-		cmd.ObserveSkipAlreadyLoaded()
+		cmd.ObserveSkipLoaded()
 		cmd.ObserveSkipCachedType()
 		cmd.ObserveFallback()
 	})

--- a/monitoring/hotpath_test.go
+++ b/monitoring/hotpath_test.go
@@ -32,12 +32,12 @@ elastickv_lease_read_total{node_address="10.0.0.1:50051",node_id="n1",outcome="m
 
 func TestLuaFastPathObserverCountsByCmdAndOutcome(t *testing.T) {
 	registry := NewRegistry("n1", "10.0.0.1:50051")
-	observer := registry.LuaFastPathObserver()
+	cmd := registry.LuaFastPathObserver().ForCommand("zrangebyscore")
 
-	observer.ObserveLuaFastPath("zrangebyscore", LuaFastPathOutcomeHit)
-	observer.ObserveLuaFastPath("zrangebyscore", LuaFastPathOutcomeHit)
-	observer.ObserveLuaFastPath("zrangebyscore", LuaFastPathOutcomeSkipAlreadyLoad)
-	observer.ObserveLuaFastPath("zrangebyscore", LuaFastPathOutcomeFallback)
+	cmd.ObserveHit()
+	cmd.ObserveHit()
+	cmd.ObserveSkipAlreadyLoaded()
+	cmd.ObserveFallback()
 
 	err := testutil.GatherAndCompare(
 		registry.Gatherer(),
@@ -46,6 +46,7 @@ func TestLuaFastPathObserverCountsByCmdAndOutcome(t *testing.T) {
 # TYPE elastickv_lua_cmd_fastpath_total counter
 elastickv_lua_cmd_fastpath_total{cmd="zrangebyscore",node_address="10.0.0.1:50051",node_id="n1",outcome="fallback"} 1
 elastickv_lua_cmd_fastpath_total{cmd="zrangebyscore",node_address="10.0.0.1:50051",node_id="n1",outcome="hit"} 2
+elastickv_lua_cmd_fastpath_total{cmd="zrangebyscore",node_address="10.0.0.1:50051",node_id="n1",outcome="skip_cached_type"} 0
 elastickv_lua_cmd_fastpath_total{cmd="zrangebyscore",node_address="10.0.0.1:50051",node_id="n1",outcome="skip_loaded"} 1
 `),
 		"elastickv_lua_cmd_fastpath_total",
@@ -55,8 +56,12 @@ elastickv_lua_cmd_fastpath_total{cmd="zrangebyscore",node_address="10.0.0.1:5005
 
 func TestLuaFastPathObserverZeroValueIsNoop(t *testing.T) {
 	var observer LuaFastPathObserver
+	cmd := observer.ForCommand("zrangebyscore")
 	require.NotPanics(t, func() {
-		observer.ObserveLuaFastPath("zrangebyscore", LuaFastPathOutcomeHit)
+		cmd.ObserveHit()
+		cmd.ObserveSkipAlreadyLoaded()
+		cmd.ObserveSkipCachedType()
+		cmd.ObserveFallback()
 	})
 }
 

--- a/monitoring/hotpath_test.go
+++ b/monitoring/hotpath_test.go
@@ -30,6 +30,36 @@ elastickv_lease_read_total{node_address="10.0.0.1:50051",node_id="n1",outcome="m
 	require.NoError(t, err)
 }
 
+func TestLuaFastPathObserverCountsByCmdAndOutcome(t *testing.T) {
+	registry := NewRegistry("n1", "10.0.0.1:50051")
+	observer := registry.LuaFastPathObserver()
+
+	observer.ObserveLuaFastPath("zrangebyscore", LuaFastPathOutcomeHit)
+	observer.ObserveLuaFastPath("zrangebyscore", LuaFastPathOutcomeHit)
+	observer.ObserveLuaFastPath("zrangebyscore", LuaFastPathOutcomeSkipAlreadyLoad)
+	observer.ObserveLuaFastPath("zrangebyscore", LuaFastPathOutcomeFallback)
+
+	err := testutil.GatherAndCompare(
+		registry.Gatherer(),
+		strings.NewReader(`
+# HELP elastickv_lua_cmd_fastpath_total Per-redis.call() fast-path outcome inside Lua scripts. cmd identifies the command (zrangebyscore, zscore, ...); outcome is hit, skip_loaded, skip_cached_type, or fallback.
+# TYPE elastickv_lua_cmd_fastpath_total counter
+elastickv_lua_cmd_fastpath_total{cmd="zrangebyscore",node_address="10.0.0.1:50051",node_id="n1",outcome="fallback"} 1
+elastickv_lua_cmd_fastpath_total{cmd="zrangebyscore",node_address="10.0.0.1:50051",node_id="n1",outcome="hit"} 2
+elastickv_lua_cmd_fastpath_total{cmd="zrangebyscore",node_address="10.0.0.1:50051",node_id="n1",outcome="skip_loaded"} 1
+`),
+		"elastickv_lua_cmd_fastpath_total",
+	)
+	require.NoError(t, err)
+}
+
+func TestLuaFastPathObserverZeroValueIsNoop(t *testing.T) {
+	var observer LuaFastPathObserver
+	require.NotPanics(t, func() {
+		observer.ObserveLuaFastPath("zrangebyscore", LuaFastPathOutcomeHit)
+	})
+}
+
 func TestLeaseReadObserverZeroValueIsNoop(t *testing.T) {
 	// LeaseReadObserver{} is documented as safe; the Coordinator
 	// falls back to this when monitoring is disabled. Calling

--- a/monitoring/registry.go
+++ b/monitoring/registry.go
@@ -112,6 +112,16 @@ func (r *Registry) LeaseReadObserver() LeaseReadObserver {
 	return LeaseReadObserver{metrics: r.hotPath}
 }
 
+// LuaFastPathObserver returns an observer for Lua-side redis.call()
+// fast-path outcomes (hit / skip / fallback per command). Zero-value
+// safe for tests and tools that do not wire a registry.
+func (r *Registry) LuaFastPathObserver() LuaFastPathObserver {
+	if r == nil {
+		return LuaFastPathObserver{}
+	}
+	return LuaFastPathObserver{metrics: r.hotPath}
+}
+
 // DispatchCollector returns a collector that polls the etcd raft
 // engine's dispatch counters and exports them to Prometheus. Start it
 // with the node's raft sources after engine Open() completes.


### PR DESCRIPTION
## Summary
- Add `elastickv_lua_cmd_fastpath_total{cmd,outcome}` counter to measure how often Lua-side fast paths actually take the fast path vs fall back (hit / skip_loaded / skip_cached_type / fallback).
- Wire `LuaFastPathObserver` through Registry → RedisServer option → `luaScriptContext.observeFastPathOutcome`.
- Instrument `cmdZRangeByScore` as the first caller.

## Motivation
Post-deploy CPU profile on a BullMQ-style workload shows `cmdZRangeByScoreSlow` consuming ~14x the CPU of `zsetRangeByScoreFast` (860ms vs 60ms in a 30 s profile), despite the fast path being eligible on paper. Without per-outcome instrumentation it is not possible to tell whether scripts are hitting `luaZSetAlreadyLoaded` (a prior ZCARD/ZCOUNT on the same key), `cachedType` (SET/DEL earlier in the script), or the server-side `hit=false` fallback (legacy-blob zset, truncation, large-offset short-circuit).

Shipping this counter first so we can decide whether the follow-up should loosen the `luaZSetAlreadyLoaded` guard, or target a different cause.

## Test plan
- [x] `go test ./adapter/... ./monitoring/...` green
- [x] New `TestLuaFastPathObserver*` in monitoring/hotpath_test.go
- [x] Zero-value observer safe (already used by tests that do not wire a registry)
- [ ] Deploy to prod, watch `rate(elastickv_lua_cmd_fastpath_total{cmd=zrangebyscore}[5m])` by outcome for ~5 minutes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics to monitor Lua script fast-path execution performance, tracking per-command outcomes including successful hits, skipped operations from cached data, and fallback scenarios.

* **Tests**
  * Added tests validating Lua fast-path metrics accuracy and zero-value safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->