### PR TITLE
obs(redis-lua): subdivide ZRANGEBYSCORE fast-path fallback by reason

### DIFF
--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -1808,9 +1808,9 @@ func (r *RedisServer) zsetRangeByScoreFast(
 	offset, limit int,
 	scoreFilter func(float64) bool,
 	readTS uint64,
-) ([]redisZSetEntry, bool, string, error) {
+) ([]redisZSetEntry, bool, monitoring.LuaFastPathFallbackReason, error) {
 	if eligible, err := r.zsetFastPathEligible(ctx, key, readTS); err != nil || !eligible {
-		return nil, false, monitoring.LuaFastPathOutcomeFallbackIneligible, err
+		return nil, false, monitoring.LuaFastPathFallbackIneligible, err
 	}
 	// Large-offset short-circuit: once offset >= maxWideScanLimit,
 	// the fast path can only scan maxWideScanLimit rows then skip all
@@ -1818,7 +1818,7 @@ func (r *RedisServer) zsetRangeByScoreFast(
 	// immediately so it can answer from the full member load without
 	// the redundant score-index scan.
 	if offset >= maxWideScanLimit {
-		return nil, false, monitoring.LuaFastPathOutcomeFallbackLargeOffset, nil
+		return nil, false, monitoring.LuaFastPathFallbackLargeOffset, nil
 	}
 	scanLimit := zsetFastScanLimit(offset, limit)
 	if scanLimit <= 0 || bytes.Compare(startKey, endKey) >= 0 {
@@ -1827,7 +1827,7 @@ func (r *RedisServer) zsetRangeByScoreFast(
 	}
 	kvs, err := r.zsetScoreScan(ctx, startKey, endKey, scanLimit, reverse, readTS)
 	if err != nil {
-		return nil, false, monitoring.LuaFastPathOutcomeFallbackOther, err
+		return nil, false, monitoring.LuaFastPathFallbackOther, err
 	}
 	return r.finalizeZSetFastRange(ctx, key, kvs, offset, limit, scanLimit, scoreFilter, readTS)
 }
@@ -1846,15 +1846,15 @@ func (r *RedisServer) zsetRangeByScoreFast(
 func (r *RedisServer) finalizeZSetFastRange(
 	ctx context.Context, key []byte, kvs []*store.KVPair,
 	offset, limit, scanLimit int, scoreFilter func(float64) bool, readTS uint64,
-) ([]redisZSetEntry, bool, string, error) {
+) ([]redisZSetEntry, bool, monitoring.LuaFastPathFallbackReason, error) {
 	// Priority guard runs after a candidate hit (mirrors post-PR #565
 	// ordering). Skip it on empty result -- the empty-result tail
 	// handles disambiguation.
 	if len(kvs) > 0 {
 		if higher, hErr := r.hasHigherPriorityStringEncoding(ctx, key, readTS); hErr != nil {
-			return nil, false, monitoring.LuaFastPathOutcomeFallbackOther, hErr
+			return nil, false, monitoring.LuaFastPathFallbackOther, hErr
 		} else if higher {
-			return nil, false, monitoring.LuaFastPathOutcomeFallbackWrongType, nil
+			return nil, false, monitoring.LuaFastPathFallbackWrongType, nil
 		}
 	}
 	entries := decodeZSetScoreRange(key, kvs, offset, limit, scoreFilter)
@@ -1862,7 +1862,7 @@ func (r *RedisServer) finalizeZSetFastRange(
 	// not get a satisfied result. Entries beyond the window may
 	// exist; defer to the slow path for correctness.
 	if zsetFastPathTruncated(len(kvs), scanLimit, len(entries), limit) {
-		return nil, false, monitoring.LuaFastPathOutcomeFallbackTruncated, nil
+		return nil, false, monitoring.LuaFastPathFallbackTruncated, nil
 	}
 	if len(entries) == 0 {
 		hit, reason, err := r.zsetRangeEmptyFastResult(ctx, key, readTS)
@@ -1870,7 +1870,7 @@ func (r *RedisServer) finalizeZSetFastRange(
 	}
 	expired, expErr := r.hasExpired(ctx, key, readTS, true)
 	if expErr != nil {
-		return nil, false, monitoring.LuaFastPathOutcomeFallbackOther, cockerrors.WithStack(expErr)
+		return nil, false, monitoring.LuaFastPathFallbackOther, cockerrors.WithStack(expErr)
 	}
 	if expired {
 		return nil, true, "", nil
@@ -2017,25 +2017,25 @@ func decodeZSetScoreRange(
 // range is simply empty (callers return an empty array and no
 // fallback); hit=false carries a specific fallback reason so the
 // caller can route its slow-path observation accordingly.
-func (r *RedisServer) zsetRangeEmptyFastResult(ctx context.Context, key []byte, readTS uint64) (bool, string, error) {
+func (r *RedisServer) zsetRangeEmptyFastResult(ctx context.Context, key []byte, readTS uint64) (bool, monitoring.LuaFastPathFallbackReason, error) {
 	_, zsetExists, err := r.resolveZSetMeta(ctx, key, readTS)
 	if err != nil {
-		return false, monitoring.LuaFastPathOutcomeFallbackOther, cockerrors.WithStack(err)
+		return false, monitoring.LuaFastPathFallbackOther, cockerrors.WithStack(err)
 	}
 	if !zsetExists {
-		return false, monitoring.LuaFastPathOutcomeFallbackMissingKey, nil
+		return false, monitoring.LuaFastPathFallbackMissingKey, nil
 	}
 	if higher, hErr := r.hasHigherPriorityStringEncoding(ctx, key, readTS); hErr != nil {
-		return false, monitoring.LuaFastPathOutcomeFallbackOther, hErr
+		return false, monitoring.LuaFastPathFallbackOther, hErr
 	} else if higher {
-		return false, monitoring.LuaFastPathOutcomeFallbackWrongType, nil
+		return false, monitoring.LuaFastPathFallbackWrongType, nil
 	}
 	// hasExpired is called for its error-surfacing side effect only:
 	// whether the zset is expired or not, a live zset with no members
 	// in range returns an empty hit=true result. Keep the call so
 	// storage errors during TTL resolution still propagate.
 	if _, expErr := r.hasExpired(ctx, key, readTS, true); expErr != nil {
-		return false, monitoring.LuaFastPathOutcomeFallbackOther, cockerrors.WithStack(expErr)
+		return false, monitoring.LuaFastPathFallbackOther, cockerrors.WithStack(expErr)
 	}
 	return true, "", nil
 }

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/bootjp/elastickv/kv"
+	"github.com/bootjp/elastickv/monitoring"
 	"github.com/bootjp/elastickv/store"
 	cockerrors "github.com/cockroachdb/errors"
 	"github.com/tidwall/redcon"
@@ -1794,6 +1795,8 @@ func (r *RedisServer) zsetMemberFastScore(ctx context.Context, key, member []byt
 // where we cannot distinguish "zset is empty in this range" from
 // "key exists as another type / is missing"). Callers MUST take
 // the slow path on hit=false so keyTypeAt disambiguation fires.
+// reason carries the specific hit=false branch so observers can
+// subdivide fallback rates for dashboarding; "" when hit=true.
 //
 // scoreInRange filter is applied post-scan for exclusive bound
 // edge cases; the caller supplies precomputed scan bounds that
@@ -1805,9 +1808,9 @@ func (r *RedisServer) zsetRangeByScoreFast(
 	offset, limit int,
 	scoreFilter func(float64) bool,
 	readTS uint64,
-) ([]redisZSetEntry, bool, error) {
+) ([]redisZSetEntry, bool, string, error) {
 	if eligible, err := r.zsetFastPathEligible(ctx, key, readTS); err != nil || !eligible {
-		return nil, false, err
+		return nil, false, monitoring.LuaFastPathOutcomeFallbackIneligible, err
 	}
 	// Large-offset short-circuit: once offset >= maxWideScanLimit,
 	// the fast path can only scan maxWideScanLimit rows then skip all
@@ -1815,15 +1818,16 @@ func (r *RedisServer) zsetRangeByScoreFast(
 	// immediately so it can answer from the full member load without
 	// the redundant score-index scan.
 	if offset >= maxWideScanLimit {
-		return nil, false, nil
+		return nil, false, monitoring.LuaFastPathOutcomeFallbackLargeOffset, nil
 	}
 	scanLimit := zsetFastScanLimit(offset, limit)
 	if scanLimit <= 0 || bytes.Compare(startKey, endKey) >= 0 {
-		return r.zsetRangeEmptyFastResult(ctx, key, readTS)
+		hit, reason, err := r.zsetRangeEmptyFastResult(ctx, key, readTS)
+		return nil, hit, reason, err
 	}
 	kvs, err := r.zsetScoreScan(ctx, startKey, endKey, scanLimit, reverse, readTS)
 	if err != nil {
-		return nil, false, err
+		return nil, false, monitoring.LuaFastPathOutcomeFallbackOther, err
 	}
 	return r.finalizeZSetFastRange(ctx, key, kvs, offset, limit, scanLimit, scoreFilter, readTS)
 }
@@ -1842,15 +1846,15 @@ func (r *RedisServer) zsetRangeByScoreFast(
 func (r *RedisServer) finalizeZSetFastRange(
 	ctx context.Context, key []byte, kvs []*store.KVPair,
 	offset, limit, scanLimit int, scoreFilter func(float64) bool, readTS uint64,
-) ([]redisZSetEntry, bool, error) {
+) ([]redisZSetEntry, bool, string, error) {
 	// Priority guard runs after a candidate hit (mirrors post-PR #565
 	// ordering). Skip it on empty result -- the empty-result tail
 	// handles disambiguation.
 	if len(kvs) > 0 {
 		if higher, hErr := r.hasHigherPriorityStringEncoding(ctx, key, readTS); hErr != nil {
-			return nil, false, hErr
+			return nil, false, monitoring.LuaFastPathOutcomeFallbackOther, hErr
 		} else if higher {
-			return nil, false, nil
+			return nil, false, monitoring.LuaFastPathOutcomeFallbackWrongType, nil
 		}
 	}
 	entries := decodeZSetScoreRange(key, kvs, offset, limit, scoreFilter)
@@ -1858,19 +1862,20 @@ func (r *RedisServer) finalizeZSetFastRange(
 	// not get a satisfied result. Entries beyond the window may
 	// exist; defer to the slow path for correctness.
 	if zsetFastPathTruncated(len(kvs), scanLimit, len(entries), limit) {
-		return nil, false, nil
+		return nil, false, monitoring.LuaFastPathOutcomeFallbackTruncated, nil
 	}
 	if len(entries) == 0 {
-		return r.zsetRangeEmptyFastResult(ctx, key, readTS)
+		hit, reason, err := r.zsetRangeEmptyFastResult(ctx, key, readTS)
+		return nil, hit, reason, err
 	}
 	expired, expErr := r.hasExpired(ctx, key, readTS, true)
 	if expErr != nil {
-		return nil, false, cockerrors.WithStack(expErr)
+		return nil, false, monitoring.LuaFastPathOutcomeFallbackOther, cockerrors.WithStack(expErr)
 	}
 	if expired {
-		return nil, true, nil
+		return nil, true, "", nil
 	}
-	return entries, true, nil
+	return entries, true, "", nil
 }
 
 // zsetFastPathTruncated reports whether the bounded score-index scan
@@ -2007,27 +2012,32 @@ func decodeZSetScoreRange(
 // and force the slow path unnecessarily. Also runs the string-priority
 // guard so a corrupted redisStrKey + zset meta surfaces WRONGTYPE via
 // the slow path rather than an empty array.
-func (r *RedisServer) zsetRangeEmptyFastResult(ctx context.Context, key []byte, readTS uint64) ([]redisZSetEntry, bool, error) {
+// zsetRangeEmptyFastResult returns (hit, reason, err) for the empty-
+// result tail. hit=true means the key is a live zset whose score
+// range is simply empty (callers return an empty array and no
+// fallback); hit=false carries a specific fallback reason so the
+// caller can route its slow-path observation accordingly.
+func (r *RedisServer) zsetRangeEmptyFastResult(ctx context.Context, key []byte, readTS uint64) (bool, string, error) {
 	_, zsetExists, err := r.resolveZSetMeta(ctx, key, readTS)
 	if err != nil {
-		return nil, false, cockerrors.WithStack(err)
+		return false, monitoring.LuaFastPathOutcomeFallbackOther, cockerrors.WithStack(err)
 	}
 	if !zsetExists {
-		return nil, false, nil
+		return false, monitoring.LuaFastPathOutcomeFallbackMissingKey, nil
 	}
 	if higher, hErr := r.hasHigherPriorityStringEncoding(ctx, key, readTS); hErr != nil {
-		return nil, false, hErr
+		return false, monitoring.LuaFastPathOutcomeFallbackOther, hErr
 	} else if higher {
-		return nil, false, nil
+		return false, monitoring.LuaFastPathOutcomeFallbackWrongType, nil
 	}
 	// hasExpired is called for its error-surfacing side effect only:
 	// whether the zset is expired or not, a live zset with no members
 	// in range returns an empty hit=true result. Keep the call so
 	// storage errors during TTL resolution still propagate.
 	if _, expErr := r.hasExpired(ctx, key, readTS, true); expErr != nil {
-		return nil, false, cockerrors.WithStack(expErr)
+		return false, monitoring.LuaFastPathOutcomeFallbackOther, cockerrors.WithStack(expErr)
 	}
-	return nil, true, nil
+	return true, "", nil
 }
 
 // hgetSlow falls back to the type-probing path when hashFieldFastLookup

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/bootjp/elastickv/kv"
+	"github.com/bootjp/elastickv/monitoring"
 	"github.com/bootjp/elastickv/store"
 	"github.com/cockroachdb/errors"
 )
@@ -2466,7 +2467,7 @@ func (c *luaScriptContext) cmdZRangeByScore(args []string, reverse bool) (luaRep
 // file are migrated incrementally.
 func (c *luaScriptContext) zrangeByScoreFastPath(
 	key []byte, options luaZRangeByScoreOptions, reverse bool,
-) ([]redisZSetEntry, bool, string, error) {
+) ([]redisZSetEntry, bool, monitoring.LuaFastPathFallbackReason, error) {
 	startKey, endKey := zsetScoreScanBounds(key, options.minBound, options.maxBound)
 	filter := func(score float64) bool {
 		return scoreInRange(score, options.minBound, options.maxBound)

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -2438,12 +2438,12 @@ func (c *luaScriptContext) cmdZRangeByScore(args []string, reverse bool) (luaRep
 		zrangeMetrics.ObserveSkipCachedType()
 		return c.cmdZRangeByScoreSlow(key, options, reverse)
 	}
-	entries, hit, fastErr := c.zrangeByScoreFastPath(key, options, reverse)
+	entries, hit, fallbackReason, fastErr := c.zrangeByScoreFastPath(key, options, reverse)
 	if fastErr != nil {
 		return luaReply{}, fastErr
 	}
 	if !hit {
-		zrangeMetrics.ObserveFallback()
+		zrangeMetrics.ObserveFallback(fallbackReason)
 		return c.cmdZRangeByScoreSlow(key, options, reverse)
 	}
 	zrangeMetrics.ObserveHit()
@@ -2466,7 +2466,7 @@ func (c *luaScriptContext) cmdZRangeByScore(args []string, reverse bool) (luaRep
 // file are migrated incrementally.
 func (c *luaScriptContext) zrangeByScoreFastPath(
 	key []byte, options luaZRangeByScoreOptions, reverse bool,
-) ([]redisZSetEntry, bool, error) {
+) ([]redisZSetEntry, bool, string, error) {
 	startKey, endKey := zsetScoreScanBounds(key, options.minBound, options.maxBound)
 	filter := func(score float64) bool {
 		return scoreInRange(score, options.minBound, options.maxBound)

--- a/monitoring/hotpath.go
+++ b/monitoring/hotpath.go
@@ -44,15 +44,30 @@ const (
 	LuaFastPathOutcomeHit            = "hit"
 	LuaFastPathOutcomeSkipLoaded     = "skip_loaded"
 	LuaFastPathOutcomeSkipCachedType = "skip_cached_type"
-	// Server-side hit=false reasons. Subdivide "fallback" so operators
-	// can tell why the fast path gave up and route the fix accordingly
-	// (eligibility check, truncation, empty-key short-circuit, etc.).
-	LuaFastPathOutcomeFallbackIneligible  = "fallback_ineligible"
-	LuaFastPathOutcomeFallbackMissingKey  = "fallback_missing_key"
-	LuaFastPathOutcomeFallbackWrongType   = "fallback_wrong_type"
-	LuaFastPathOutcomeFallbackTruncated   = "fallback_truncated"
-	LuaFastPathOutcomeFallbackLargeOffset = "fallback_large_offset"
-	LuaFastPathOutcomeFallbackOther       = "fallback_other"
+)
+
+// LuaFastPathFallbackReason is the typed label for server-side
+// hit=false branches. A dedicated type (instead of a bare string)
+// lets Go catch typos in call sites — producers in adapter/ and the
+// switch in ObserveFallback stay in lockstep with the constants
+// below, and the Prometheus label value is derived directly from the
+// underlying string via string(reason).
+type LuaFastPathFallbackReason string
+
+// Known fallback reasons. Subdivides the generic "fallback" outcome
+// so operators can tell WHY the fast path gave up and route the fix
+// accordingly (eligibility check, truncation, empty-key
+// short-circuit, etc.).
+const (
+	LuaFastPathFallbackIneligible  LuaFastPathFallbackReason = "fallback_ineligible"
+	LuaFastPathFallbackMissingKey  LuaFastPathFallbackReason = "fallback_missing_key"
+	LuaFastPathFallbackWrongType   LuaFastPathFallbackReason = "fallback_wrong_type"
+	LuaFastPathFallbackTruncated   LuaFastPathFallbackReason = "fallback_truncated"
+	LuaFastPathFallbackLargeOffset LuaFastPathFallbackReason = "fallback_large_offset"
+	LuaFastPathFallbackOther       LuaFastPathFallbackReason = "fallback_other"
+	// LuaFastPathFallbackNone is the sentinel returned alongside
+	// hit=true; callers must not record it.
+	LuaFastPathFallbackNone LuaFastPathFallbackReason = ""
 )
 
 func newHotPathMetrics(registerer prometheus.Registerer) *HotPathMetrics {
@@ -147,12 +162,12 @@ func (o LuaFastPathObserver) ForCommand(cmd string) LuaFastPathCmd {
 		hit:                 vec.WithLabelValues(cmd, LuaFastPathOutcomeHit),
 		skipLoaded:          vec.WithLabelValues(cmd, LuaFastPathOutcomeSkipLoaded),
 		skipCachedType:      vec.WithLabelValues(cmd, LuaFastPathOutcomeSkipCachedType),
-		fallbackIneligible:  vec.WithLabelValues(cmd, LuaFastPathOutcomeFallbackIneligible),
-		fallbackMissingKey:  vec.WithLabelValues(cmd, LuaFastPathOutcomeFallbackMissingKey),
-		fallbackWrongType:   vec.WithLabelValues(cmd, LuaFastPathOutcomeFallbackWrongType),
-		fallbackTruncated:   vec.WithLabelValues(cmd, LuaFastPathOutcomeFallbackTruncated),
-		fallbackLargeOffset: vec.WithLabelValues(cmd, LuaFastPathOutcomeFallbackLargeOffset),
-		fallbackOther:       vec.WithLabelValues(cmd, LuaFastPathOutcomeFallbackOther),
+		fallbackIneligible:  vec.WithLabelValues(cmd, string(LuaFastPathFallbackIneligible)),
+		fallbackMissingKey:  vec.WithLabelValues(cmd, string(LuaFastPathFallbackMissingKey)),
+		fallbackWrongType:   vec.WithLabelValues(cmd, string(LuaFastPathFallbackWrongType)),
+		fallbackTruncated:   vec.WithLabelValues(cmd, string(LuaFastPathFallbackTruncated)),
+		fallbackLargeOffset: vec.WithLabelValues(cmd, string(LuaFastPathFallbackLargeOffset)),
+		fallbackOther:       vec.WithLabelValues(cmd, string(LuaFastPathFallbackOther)),
 	}
 }
 
@@ -177,21 +192,24 @@ func (c LuaFastPathCmd) ObserveSkipCachedType() {
 }
 
 // ObserveFallback routes to the counter for the given reason. Use
-// LuaFastPathOutcomeFallback* constants; unknown values land on the
-// "other" bucket so cardinality stays bounded.
-func (c LuaFastPathCmd) ObserveFallback(reason string) {
+// the LuaFastPathFallback* constants; unknown values (including the
+// zero value LuaFastPathFallbackNone, which should never reach here)
+// land on the "other" bucket so cardinality stays bounded.
+func (c LuaFastPathCmd) ObserveFallback(reason LuaFastPathFallbackReason) {
 	var counter prometheus.Counter
 	switch reason {
-	case LuaFastPathOutcomeFallbackIneligible:
+	case LuaFastPathFallbackIneligible:
 		counter = c.fallbackIneligible
-	case LuaFastPathOutcomeFallbackMissingKey:
+	case LuaFastPathFallbackMissingKey:
 		counter = c.fallbackMissingKey
-	case LuaFastPathOutcomeFallbackWrongType:
+	case LuaFastPathFallbackWrongType:
 		counter = c.fallbackWrongType
-	case LuaFastPathOutcomeFallbackTruncated:
+	case LuaFastPathFallbackTruncated:
 		counter = c.fallbackTruncated
-	case LuaFastPathOutcomeFallbackLargeOffset:
+	case LuaFastPathFallbackLargeOffset:
 		counter = c.fallbackLargeOffset
+	case LuaFastPathFallbackOther, LuaFastPathFallbackNone:
+		counter = c.fallbackOther
 	default:
 		counter = c.fallbackOther
 	}

--- a/monitoring/hotpath.go
+++ b/monitoring/hotpath.go
@@ -44,7 +44,15 @@ const (
 	LuaFastPathOutcomeHit            = "hit"
 	LuaFastPathOutcomeSkipLoaded     = "skip_loaded"
 	LuaFastPathOutcomeSkipCachedType = "skip_cached_type"
-	LuaFastPathOutcomeFallback       = "fallback"
+	// Server-side hit=false reasons. Subdivide "fallback" so operators
+	// can tell why the fast path gave up and route the fix accordingly
+	// (eligibility check, truncation, empty-key short-circuit, etc.).
+	LuaFastPathOutcomeFallbackIneligible  = "fallback_ineligible"
+	LuaFastPathOutcomeFallbackMissingKey  = "fallback_missing_key"
+	LuaFastPathOutcomeFallbackWrongType   = "fallback_wrong_type"
+	LuaFastPathOutcomeFallbackTruncated   = "fallback_truncated"
+	LuaFastPathOutcomeFallbackLargeOffset = "fallback_large_offset"
+	LuaFastPathOutcomeFallbackOther       = "fallback_other"
 )
 
 func newHotPathMetrics(registerer prometheus.Registerer) *HotPathMetrics {
@@ -80,7 +88,7 @@ func newHotPathMetrics(registerer prometheus.Registerer) *HotPathMetrics {
 		luaFastPathTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "elastickv_lua_cmd_fastpath_total",
-				Help: "Per-redis.call() fast-path outcome inside Lua scripts. cmd identifies the command (zrangebyscore, zscore, ...); outcome is hit, skip_loaded, skip_cached_type, or fallback.",
+				Help: "Per-redis.call() fast-path outcome inside Lua scripts. cmd identifies the command (zrangebyscore, zscore, ...); outcome is hit, skip_loaded, skip_cached_type, or fallback_* (subdivided by reason: ineligible, missing_key, wrong_type, truncated, large_offset, other).",
 			},
 			[]string{"cmd", "outcome"},
 		),
@@ -116,10 +124,15 @@ type LuaFastPathObserver struct {
 // LuaFastPathObserver.ForCommand(cmd) at server startup; call the
 // Observe* methods per redis.call(). Safe to copy.
 type LuaFastPathCmd struct {
-	hit            prometheus.Counter
-	skipLoaded     prometheus.Counter
-	skipCachedType prometheus.Counter
-	fallback       prometheus.Counter
+	hit                 prometheus.Counter
+	skipLoaded          prometheus.Counter
+	skipCachedType      prometheus.Counter
+	fallbackIneligible  prometheus.Counter
+	fallbackMissingKey  prometheus.Counter
+	fallbackWrongType   prometheus.Counter
+	fallbackTruncated   prometheus.Counter
+	fallbackLargeOffset prometheus.Counter
+	fallbackOther       prometheus.Counter
 }
 
 // ForCommand pre-resolves the counter handles for cmd. Returns a
@@ -131,15 +144,19 @@ func (o LuaFastPathObserver) ForCommand(cmd string) LuaFastPathCmd {
 	}
 	vec := o.metrics.luaFastPathTotal
 	return LuaFastPathCmd{
-		hit:            vec.WithLabelValues(cmd, LuaFastPathOutcomeHit),
-		skipLoaded:     vec.WithLabelValues(cmd, LuaFastPathOutcomeSkipLoaded),
-		skipCachedType: vec.WithLabelValues(cmd, LuaFastPathOutcomeSkipCachedType),
-		fallback:       vec.WithLabelValues(cmd, LuaFastPathOutcomeFallback),
+		hit:                 vec.WithLabelValues(cmd, LuaFastPathOutcomeHit),
+		skipLoaded:          vec.WithLabelValues(cmd, LuaFastPathOutcomeSkipLoaded),
+		skipCachedType:      vec.WithLabelValues(cmd, LuaFastPathOutcomeSkipCachedType),
+		fallbackIneligible:  vec.WithLabelValues(cmd, LuaFastPathOutcomeFallbackIneligible),
+		fallbackMissingKey:  vec.WithLabelValues(cmd, LuaFastPathOutcomeFallbackMissingKey),
+		fallbackWrongType:   vec.WithLabelValues(cmd, LuaFastPathOutcomeFallbackWrongType),
+		fallbackTruncated:   vec.WithLabelValues(cmd, LuaFastPathOutcomeFallbackTruncated),
+		fallbackLargeOffset: vec.WithLabelValues(cmd, LuaFastPathOutcomeFallbackLargeOffset),
+		fallbackOther:       vec.WithLabelValues(cmd, LuaFastPathOutcomeFallbackOther),
 	}
 }
 
-// ObserveHit / ObserveSkipLoaded / ObserveSkipCachedType /
-// ObserveFallback record one outcome. Each is a single atomic
+// Observe* methods record one outcome. Each is a single atomic
 // increment when the counter is wired; a no-op on the zero value.
 func (c LuaFastPathCmd) ObserveHit() {
 	if c.hit != nil {
@@ -159,9 +176,27 @@ func (c LuaFastPathCmd) ObserveSkipCachedType() {
 	}
 }
 
-func (c LuaFastPathCmd) ObserveFallback() {
-	if c.fallback != nil {
-		c.fallback.Inc()
+// ObserveFallback routes to the counter for the given reason. Use
+// LuaFastPathOutcomeFallback* constants; unknown values land on the
+// "other" bucket so cardinality stays bounded.
+func (c LuaFastPathCmd) ObserveFallback(reason string) {
+	var counter prometheus.Counter
+	switch reason {
+	case LuaFastPathOutcomeFallbackIneligible:
+		counter = c.fallbackIneligible
+	case LuaFastPathOutcomeFallbackMissingKey:
+		counter = c.fallbackMissingKey
+	case LuaFastPathOutcomeFallbackWrongType:
+		counter = c.fallbackWrongType
+	case LuaFastPathOutcomeFallbackTruncated:
+		counter = c.fallbackTruncated
+	case LuaFastPathOutcomeFallbackLargeOffset:
+		counter = c.fallbackLargeOffset
+	default:
+		counter = c.fallbackOther
+	}
+	if counter != nil {
+		counter.Inc()
 	}
 }
 

--- a/monitoring/hotpath_test.go
+++ b/monitoring/hotpath_test.go
@@ -37,14 +37,21 @@ func TestLuaFastPathObserverCountsByCmdAndOutcome(t *testing.T) {
 	cmd.ObserveHit()
 	cmd.ObserveHit()
 	cmd.ObserveSkipLoaded()
-	cmd.ObserveFallback()
+	cmd.ObserveFallback(LuaFastPathOutcomeFallbackMissingKey)
+	cmd.ObserveFallback(LuaFastPathOutcomeFallbackTruncated)
+	cmd.ObserveFallback("bogus-reason") // routes to fallback_other
 
 	err := testutil.GatherAndCompare(
 		registry.Gatherer(),
 		strings.NewReader(`
-# HELP elastickv_lua_cmd_fastpath_total Per-redis.call() fast-path outcome inside Lua scripts. cmd identifies the command (zrangebyscore, zscore, ...); outcome is hit, skip_loaded, skip_cached_type, or fallback.
+# HELP elastickv_lua_cmd_fastpath_total Per-redis.call() fast-path outcome inside Lua scripts. cmd identifies the command (zrangebyscore, zscore, ...); outcome is hit, skip_loaded, skip_cached_type, or fallback_* (subdivided by reason: ineligible, missing_key, wrong_type, truncated, large_offset, other).
 # TYPE elastickv_lua_cmd_fastpath_total counter
-elastickv_lua_cmd_fastpath_total{cmd="zrangebyscore",node_address="10.0.0.1:50051",node_id="n1",outcome="fallback"} 1
+elastickv_lua_cmd_fastpath_total{cmd="zrangebyscore",node_address="10.0.0.1:50051",node_id="n1",outcome="fallback_ineligible"} 0
+elastickv_lua_cmd_fastpath_total{cmd="zrangebyscore",node_address="10.0.0.1:50051",node_id="n1",outcome="fallback_large_offset"} 0
+elastickv_lua_cmd_fastpath_total{cmd="zrangebyscore",node_address="10.0.0.1:50051",node_id="n1",outcome="fallback_missing_key"} 1
+elastickv_lua_cmd_fastpath_total{cmd="zrangebyscore",node_address="10.0.0.1:50051",node_id="n1",outcome="fallback_other"} 1
+elastickv_lua_cmd_fastpath_total{cmd="zrangebyscore",node_address="10.0.0.1:50051",node_id="n1",outcome="fallback_truncated"} 1
+elastickv_lua_cmd_fastpath_total{cmd="zrangebyscore",node_address="10.0.0.1:50051",node_id="n1",outcome="fallback_wrong_type"} 0
 elastickv_lua_cmd_fastpath_total{cmd="zrangebyscore",node_address="10.0.0.1:50051",node_id="n1",outcome="hit"} 2
 elastickv_lua_cmd_fastpath_total{cmd="zrangebyscore",node_address="10.0.0.1:50051",node_id="n1",outcome="skip_cached_type"} 0
 elastickv_lua_cmd_fastpath_total{cmd="zrangebyscore",node_address="10.0.0.1:50051",node_id="n1",outcome="skip_loaded"} 1
@@ -61,7 +68,8 @@ func TestLuaFastPathObserverZeroValueIsNoop(t *testing.T) {
 		cmd.ObserveHit()
 		cmd.ObserveSkipLoaded()
 		cmd.ObserveSkipCachedType()
-		cmd.ObserveFallback()
+		cmd.ObserveFallback(LuaFastPathOutcomeFallbackMissingKey)
+		cmd.ObserveFallback("")
 	})
 }
 

--- a/monitoring/hotpath_test.go
+++ b/monitoring/hotpath_test.go
@@ -37,8 +37,8 @@ func TestLuaFastPathObserverCountsByCmdAndOutcome(t *testing.T) {
 	cmd.ObserveHit()
 	cmd.ObserveHit()
 	cmd.ObserveSkipLoaded()
-	cmd.ObserveFallback(LuaFastPathOutcomeFallbackMissingKey)
-	cmd.ObserveFallback(LuaFastPathOutcomeFallbackTruncated)
+	cmd.ObserveFallback(LuaFastPathFallbackMissingKey)
+	cmd.ObserveFallback(LuaFastPathFallbackTruncated)
 	cmd.ObserveFallback("bogus-reason") // routes to fallback_other
 
 	err := testutil.GatherAndCompare(
@@ -68,7 +68,7 @@ func TestLuaFastPathObserverZeroValueIsNoop(t *testing.T) {
 		cmd.ObserveHit()
 		cmd.ObserveSkipLoaded()
 		cmd.ObserveSkipCachedType()
-		cmd.ObserveFallback(LuaFastPathOutcomeFallbackMissingKey)
+		cmd.ObserveFallback(LuaFastPathFallbackMissingKey)
 		cmd.ObserveFallback("")
 	})
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #571. The counter it added showed (on n1 / leader, 15 min of BullMQ traffic):

```
fallback         1463  (96.4%)
hit                54  (3.6%)
skip_loaded         0
skip_cached_type    0
```

The Lua-layer guards are not the issue; the fast path is being rejected server-side. The current single `fallback` bucket is too coarse to tell *why*: legacy-blob eligibility, large-offset short-circuit, truncation, empty-key missing-zset, or wrong-type guard.

This PR subdivides the `fallback` outcome label so the real cause is visible in 5 minutes of prod scrapes.

## Changes

- New outcome labels (replacing single `fallback`):
  - `fallback_ineligible` — `zsetFastPathEligible` rejected (legacy-blob zset)
  - `fallback_large_offset` — `offset >= maxWideScanLimit` short-circuit
  - `fallback_truncated` — scan hit `scanLimit` with request unsatisfied
  - `fallback_missing_key` — `zsetRangeEmptyFastResult` saw `zsetExists=false`
  - `fallback_wrong_type` — `hasHigherPriorityStringEncoding=true`
  - `fallback_other` — error / unclassified
- `zsetRangeByScoreFast` grows a `reason string` return (empty when `hit=true`); all `hit=false` sites populate a specific reason.
- `zsetRangeEmptyFastResult` now returns `(hit, reason, err)`; the old `[]redisZSetEntry` return was always `nil`.
- `LuaFastPathCmd` pre-resolves 6 new counters (same hot-path shape as #571: one atomic `Inc` per redis.call()).
- `ObserveFallback(reason)` dispatches via a small switch; unknown reasons land on `fallback_other`.

## Motivation

Pre-deploy hypothesis: most fallbacks are `fallback_missing_key` (BullMQ polling empty delayed queues). Ship this first, measure in prod, then write the actual fix accordingly.

## Test plan

- [x] `go test -race -short ./adapter/...` (53s) green
- [x] `go test -race ./monitoring/...` green
- [x] `TestLuaFastPathObserverCountsByCmdAndOutcome` updated for new labels + unknown-reason dispatch
- [ ] Deploy to prod; watch `sum by (outcome) (rate(elastickv_lua_cmd_fastpath_total{cmd="zrangebyscore"}[5m]))`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved query performance monitoring with categorized fallback reasons for sorted set operations, providing enhanced visibility into query optimization effectiveness and performance diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->