### PR TITLE
perf(redis-lua): short-circuit missing-key ZRANGEBYSCORE in fast path

### DIFF
--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -2023,7 +2023,29 @@ func (r *RedisServer) zsetRangeEmptyFastResult(ctx context.Context, key []byte, 
 		return false, monitoring.LuaFastPathFallbackOther, cockerrors.WithStack(err)
 	}
 	if !zsetExists {
-		return false, monitoring.LuaFastPathFallbackMissingKey, nil
+		// The key has no ZSet encoding at readTS. Redis semantics:
+		//   - key truly absent  → ZRANGEBYSCORE returns empty
+		//   - key is another type → ZRANGEBYSCORE returns WRONGTYPE
+		// Production metric (PR #572) showed this branch is the
+		// hot-path dominant outcome (~96% of ZRANGEBYSCORE calls on
+		// BullMQ-style workloads that poll an empty delayed queue).
+		// Punting every such call to the slow path repeats the same
+		// 3-probe member/meta/delta scan we just did and then
+		// re-probes all other types anyway -- pure duplicate I/O.
+		//
+		// Short-circuit: use keyTypeAt (logical type after TTL check)
+		// to distinguish "truly absent" from "wrong type". If None,
+		// return hit=true with an empty result -- that is the correct
+		// Redis answer and saves the slow-path round-trip. Otherwise
+		// fall back so the slow path can produce WRONGTYPE.
+		typ, typErr := r.keyTypeAt(ctx, key, readTS)
+		if typErr != nil {
+			return false, monitoring.LuaFastPathFallbackOther, cockerrors.WithStack(typErr)
+		}
+		if typ == redisTypeNone {
+			return true, "", nil
+		}
+		return false, monitoring.LuaFastPathFallbackWrongType, nil
 	}
 	if higher, hErr := r.hasHigherPriorityStringEncoding(ctx, key, readTS); hErr != nil {
 		return false, monitoring.LuaFastPathFallbackOther, hErr

--- a/adapter/redis_lua_collection_fastpath_test.go
+++ b/adapter/redis_lua_collection_fastpath_test.go
@@ -1092,3 +1092,75 @@ func TestLua_ZRANGEBYSCORE_PosInfExactMatch(t *testing.T) {
 	require.Equal(t, []any{"pos"}, got,
 		"ZRANGEBYSCORE +inf +inf must return only members with score = +inf")
 }
+
+// TestLua_ZRANGEBYSCORE_MissingKeyReturnsEmptyViaFastPath pins the
+// empty-result short-circuit for a key that does not exist at all.
+// Redis returns an empty array for ZRANGEBYSCORE on a missing key;
+// the fast path must serve that directly instead of punting to the
+// slow path, which was the dominant call pattern on BullMQ-style
+// workloads polling empty delayed queues.
+func TestLua_ZRANGEBYSCORE_MissingKeyReturnsEmptyViaFastPath(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	got, err := rdb.Eval(ctx,
+		`return redis.call("ZRANGEBYSCORE", KEYS[1], "-inf", "+inf")`,
+		[]string{"lua:zr:absent"},
+	).Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{}, got,
+		"ZRANGEBYSCORE on a missing key must return empty array")
+}
+
+// TestLua_ZRANGEBYSCORE_StringKeyReturnsWrongType verifies that when
+// the key exists as a string (not a zset), ZRANGEBYSCORE still yields
+// WRONGTYPE. The fast-path short-circuit must only short-circuit when
+// the key is truly absent; a wrong-type existence must surface the
+// error via the slow path.
+func TestLua_ZRANGEBYSCORE_StringKeyReturnsWrongType(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.Set(ctx, "lua:zr:wrongtype", "notzset", 0).Err())
+
+	_, err := rdb.Eval(ctx,
+		`return redis.call("ZRANGEBYSCORE", KEYS[1], "-inf", "+inf")`,
+		[]string{"lua:zr:wrongtype"},
+	).Result()
+	require.Error(t, err, "ZRANGEBYSCORE on a string key must return an error")
+	require.Contains(t, err.Error(), "WRONGTYPE",
+		"error must be WRONGTYPE, not the fast-path empty-array short-circuit")
+}
+
+// TestLua_ZRANGEBYSCORE_ListKeyReturnsWrongType mirrors the string
+// test for list-typed keys, covering the non-string collection arm
+// of keyTypeAt in the wrong-type short-circuit.
+func TestLua_ZRANGEBYSCORE_ListKeyReturnsWrongType(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.RPush(ctx, "lua:zr:wronglist", "a", "b").Err())
+
+	_, err := rdb.Eval(ctx,
+		`return redis.call("ZRANGEBYSCORE", KEYS[1], "-inf", "+inf")`,
+		[]string{"lua:zr:wronglist"},
+	).Result()
+	require.Error(t, err, "ZRANGEBYSCORE on a list key must return an error")
+	require.Contains(t, err.Error(), "WRONGTYPE",
+		"error must be WRONGTYPE for list-encoded key")
+}


### PR DESCRIPTION
## Summary

Fix the top source of slow-path fallbacks on BullMQ-style workloads.

Production metric from PR #572 after 8 minutes of traffic on n1 (leader):

```
fallback_missing_key  3288  (96.25%)
hit                    128  ( 3.75%)
fallback_ineligible     0
fallback_large_offset   0
fallback_truncated      0
fallback_wrong_type     0
fallback_other          0
skip_loaded             0
skip_cached_type        0
```

Every ZRANGEBYSCORE that hit an absent zset key was punting to the slow path *purely* to distinguish "missing" from "wrong type" — then the slow path re-probed the same member / meta / delta rows and the same string / list / hash / set prefixes, only to return an empty array. Pure duplicate I/O on a poll loop that is empty most of the time.

## Change

In `zsetRangeEmptyFastResult`'s `!zsetExists` branch, classify the key via `keyTypeAt`:

- `redisTypeNone` → return `hit=true` with empty result (the correct Redis answer; saves the slow-path round-trip).
- Any other type → keep `hit=false` with `fallback_wrong_type` so the slow path still surfaces `WRONGTYPE`.

`keyTypeAt` (post-TTL) is used so a TTL-expired string is treated as logically absent, matching Redis semantics. `rawKeyTypeAt` would incorrectly surface `WRONGTYPE` for that case.

## Expected prod impact

- `fallback_missing_key` → ~0
- `hit` → ~96%
- Slow-path dispatch rate for ZRANGEBYSCORE drops by ~20x
- Per-call I/O on the missing-key hot path: ~13–16 → ~11

## Test plan

- [x] `go test -race -short ./adapter/...` (59 s) green
- [x] New `TestLua_ZRANGEBYSCORE_MissingKeyReturnsEmptyViaFastPath` pins the short-circuit
- [x] `TestLua_ZRANGEBYSCORE_StringKeyReturnsWrongType` and `...ListKeyReturnsWrongType` verify WRONGTYPE is preserved for non-zset encodings
- [ ] Deploy; watch `sum by (outcome) (rate(elastickv_lua_cmd_fastpath_total{cmd="zrangebyscore"}[5m]))` and `elastickv_lua_redis_call_duration_seconds` p50/p95
