### PR TITLE
obs(raft): subdivide dispatch errors by grpc status code

### DIFF
--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -19,6 +19,7 @@ import (
 	etcdstorage "go.etcd.io/etcd/server/v3/storage"
 	etcdraft "go.etcd.io/raft/v3"
 	raftpb "go.etcd.io/raft/v3/raftpb"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -198,6 +199,14 @@ type Engine struct {
 
 	dispatchDropCount  atomic.Uint64
 	dispatchErrorCount atomic.Uint64
+	// dispatchErrorByCode subdivides dispatchErrorCount by the grpc
+	// status code returned from the transport (e.g. "Unavailable",
+	// "DeadlineExceeded"). Used to tell whether dispatch failures are
+	// network / backpressure / follower apply stalls. Surfaced to
+	// Prometheus via DispatchErrorCountsByCode() and the
+	// DispatchCollector poll loop.
+	dispatchErrorByCodeMu sync.Mutex
+	dispatchErrorByCode   map[string]uint64
 	// stepQueueFullCount tracks the number of inbound raft messages
 	// (from remote peers and local handlers) that were dropped because
 	// stepCh was full. Surfaced to Prometheus as
@@ -698,6 +707,45 @@ func (e *Engine) DispatchErrorCount() uint64 {
 		return 0
 	}
 	return e.dispatchErrorCount.Load()
+}
+
+// DispatchErrorCountsByCode returns a snapshot of dispatch-error
+// counts keyed by grpc status code ("Unavailable",
+// "DeadlineExceeded", "ResourceExhausted", ...). Sum of values
+// equals DispatchErrorCount(). A separate breakdown is needed to
+// tell whether failures are peer-down (Unavailable), leader under
+// load (DeadlineExceeded), or flow-control (ResourceExhausted).
+// Returns an empty map when e is nil. Safe for concurrent callers;
+// the returned map is a copy.
+func (e *Engine) DispatchErrorCountsByCode() map[string]uint64 {
+	if e == nil {
+		return map[string]uint64{}
+	}
+	e.dispatchErrorByCodeMu.Lock()
+	defer e.dispatchErrorByCodeMu.Unlock()
+	if len(e.dispatchErrorByCode) == 0 {
+		return map[string]uint64{}
+	}
+	out := make(map[string]uint64, len(e.dispatchErrorByCode))
+	for k, v := range e.dispatchErrorByCode {
+		out[k] = v
+	}
+	return out
+}
+
+// recordDispatchErrorCode atomically increments both the aggregate
+// dispatchErrorCount and the per-code bucket. code should be the
+// grpc status code string from the error; callers that cannot
+// extract one pass "Unknown".
+func (e *Engine) recordDispatchErrorCode(code string) uint64 {
+	count := e.dispatchErrorCount.Add(1)
+	e.dispatchErrorByCodeMu.Lock()
+	if e.dispatchErrorByCode == nil {
+		e.dispatchErrorByCode = map[string]uint64{}
+	}
+	e.dispatchErrorByCode[code]++
+	e.dispatchErrorByCodeMu.Unlock()
+	return count
 }
 
 // StepQueueFullCount returns the total number of inbound raft messages
@@ -2672,13 +2720,15 @@ func (e *Engine) handleDispatchRequest(ctx context.Context, req dispatchRequest)
 	if dispatchErr == nil || errors.Is(dispatchErr, ctx.Err()) {
 		return
 	}
-	count := e.dispatchErrorCount.Add(1)
+	code := dispatchErrorCodeOf(dispatchErr)
+	count := e.recordDispatchErrorCode(code)
 	if shouldLogDispatchEvent(count) {
 		slog.Warn("etcd raft outbound dispatch failed",
 			"node_id", e.nodeID,
 			"to", req.msg.To,
 			"type", req.msg.Type.String(),
 			"dispatch_error_count", count,
+			"code", code,
 			"err", dispatchErr,
 		)
 	}
@@ -2959,6 +3009,26 @@ func (e *Engine) recordDroppedDispatch(msg raftpb.Message) {
 			"drop_count", count,
 		)
 	}
+}
+
+// dispatchErrorCodeOf extracts the grpc status code name from err, or
+// returns a synthetic bucket ("Canceled" / "DeadlineExceeded" when the
+// Go stdlib error matches, "Unknown" otherwise). Keeps the label set
+// bounded to grpc's ~15 canonical codes + 1 fallback.
+func dispatchErrorCodeOf(err error) string {
+	if err == nil {
+		return "OK"
+	}
+	if s, ok := status.FromError(err); ok {
+		return s.Code().String()
+	}
+	if errors.Is(err, context.Canceled) {
+		return "Canceled"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "DeadlineExceeded"
+	}
+	return "Unknown"
 }
 
 func (e *Engine) dispatchTransport(ctx context.Context, req dispatchRequest) error {

--- a/monitoring/hotpath.go
+++ b/monitoring/hotpath.go
@@ -30,11 +30,12 @@ const (
 // GET hot-path dashboard. Kept in its own type so the Registry can hold
 // a single instance and hand out scoped observer/collector objects.
 type HotPathMetrics struct {
-	leaseReadsTotal      *prometheus.CounterVec
-	dispatchDroppedTotal *prometheus.CounterVec
-	dispatchErrorsTotal  *prometheus.CounterVec
-	stepQueueFullTotal   *prometheus.CounterVec
-	luaFastPathTotal     *prometheus.CounterVec
+	leaseReadsTotal           *prometheus.CounterVec
+	dispatchDroppedTotal      *prometheus.CounterVec
+	dispatchErrorsTotal       *prometheus.CounterVec
+	dispatchErrorsByCodeTotal *prometheus.CounterVec
+	stepQueueFullTotal        *prometheus.CounterVec
+	luaFastPathTotal          *prometheus.CounterVec
 }
 
 // LuaFastPathOutcome labels tag each Lua-side read fast-path decision
@@ -100,6 +101,13 @@ func newHotPathMetrics(registerer prometheus.Registerer) *HotPathMetrics {
 			},
 			[]string{"group"},
 		),
+		dispatchErrorsByCodeTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "elastickv_raft_dispatch_errors_by_code_total",
+				Help: "elastickv_raft_dispatch_errors_total subdivided by grpc status code so operators can tell whether the transport is failing because peers are unreachable (Unavailable), slow (DeadlineExceeded), or flow-controlled (ResourceExhausted).",
+			},
+			[]string{"group", "code"},
+		),
 		luaFastPathTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "elastickv_lua_cmd_fastpath_total",
@@ -113,6 +121,7 @@ func newHotPathMetrics(registerer prometheus.Registerer) *HotPathMetrics {
 		m.leaseReadsTotal,
 		m.dispatchDroppedTotal,
 		m.dispatchErrorsTotal,
+		m.dispatchErrorsByCodeTotal,
 		m.stepQueueFullTotal,
 		m.luaFastPathTotal,
 	)
@@ -247,6 +256,12 @@ type DispatchCounterSource interface {
 	DispatchDropCount() uint64
 	DispatchErrorCount() uint64
 	StepQueueFullCount() uint64
+	// DispatchErrorCountsByCode returns a snapshot of dispatch error
+	// counts keyed by grpc status code ("Unavailable",
+	// "DeadlineExceeded", ...). Sum of values equals
+	// DispatchErrorCount(). Implementations that do not break out by
+	// code may return an empty map.
+	DispatchErrorCountsByCode() map[string]uint64
 }
 
 // DispatchSource binds a raft group ID to its counter source. Multiple
@@ -273,6 +288,10 @@ type dispatchSnapshot struct {
 	drops     uint64
 	errors    uint64
 	stepFulls uint64
+	// byCode keeps the last-seen per-grpc-code error totals so the
+	// collector can emit monotonic deltas per code on each poll. nil
+	// until the first observation.
+	byCode map[string]uint64
 }
 
 func newDispatchCollector(metrics *HotPathMetrics) *DispatchCollector {
@@ -327,6 +346,7 @@ func (c *DispatchCollector) observeOnce(sources []DispatchSource) {
 			drops:     src.Source.DispatchDropCount(),
 			errors:    src.Source.DispatchErrorCount(),
 			stepFulls: src.Source.StepQueueFullCount(),
+			byCode:    src.Source.DispatchErrorCountsByCode(),
 		}
 		prev := c.previous[src.GroupID]
 		group := strconv.FormatUint(src.GroupID, 10)
@@ -344,6 +364,11 @@ func (c *DispatchCollector) observeOnce(sources []DispatchSource) {
 		}
 		if curr.stepFulls > prev.stepFulls {
 			c.metrics.stepQueueFullTotal.WithLabelValues(group).Add(float64(curr.stepFulls - prev.stepFulls))
+		}
+		for code, count := range curr.byCode {
+			if prevCount := prev.byCode[code]; count > prevCount {
+				c.metrics.dispatchErrorsByCodeTotal.WithLabelValues(group, code).Add(float64(count - prevCount))
+			}
 		}
 		c.previous[src.GroupID] = curr
 	}

--- a/monitoring/hotpath_test.go
+++ b/monitoring/hotpath_test.go
@@ -2,6 +2,7 @@ package monitoring
 
 import (
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -88,14 +89,35 @@ func TestLeaseReadObserverZeroValueIsNoop(t *testing.T) {
 // uint64s so tests can advance counters without touching the etcd
 // engine directly.
 type fakeDispatchSource struct {
-	drops     atomic.Uint64
-	errors    atomic.Uint64
-	stepFulls atomic.Uint64
+	drops      atomic.Uint64
+	errors     atomic.Uint64
+	stepFulls  atomic.Uint64
+	byCodeMu   sync.Mutex
+	byCodeVals map[string]uint64
 }
 
 func (f *fakeDispatchSource) DispatchDropCount() uint64  { return f.drops.Load() }
 func (f *fakeDispatchSource) DispatchErrorCount() uint64 { return f.errors.Load() }
 func (f *fakeDispatchSource) StepQueueFullCount() uint64 { return f.stepFulls.Load() }
+
+func (f *fakeDispatchSource) DispatchErrorCountsByCode() map[string]uint64 {
+	f.byCodeMu.Lock()
+	defer f.byCodeMu.Unlock()
+	if len(f.byCodeVals) == 0 {
+		return map[string]uint64{}
+	}
+	out := make(map[string]uint64, len(f.byCodeVals))
+	for k, v := range f.byCodeVals {
+		out[k] = v
+	}
+	return out
+}
+
+func (f *fakeDispatchSource) setByCode(m map[string]uint64) {
+	f.byCodeMu.Lock()
+	defer f.byCodeMu.Unlock()
+	f.byCodeVals = m
+}
 
 func TestDispatchCollectorMirrorsDeltas(t *testing.T) {
 	registry := NewRegistry("n1", "10.0.0.1:50051")
@@ -132,6 +154,46 @@ elastickv_raft_step_queue_full_total{group="1",node_address="10.0.0.1:50051",nod
 		"elastickv_raft_dispatch_dropped_total",
 		"elastickv_raft_dispatch_errors_total",
 		"elastickv_raft_step_queue_full_total",
+	)
+	require.NoError(t, err)
+}
+
+func TestDispatchCollectorEmitsPerCodeDeltas(t *testing.T) {
+	registry := NewRegistry("n1", "10.0.0.1:50051")
+	collector := registry.DispatchCollector()
+	require.NotNil(t, collector)
+
+	src := &fakeDispatchSource{}
+	sources := []DispatchSource{{GroupID: 1, Source: src}}
+
+	// First pass initialises the delta baseline.
+	collector.ObserveOnce(sources)
+
+	// Advance aggregate + per-code counters in sync.
+	src.errors.Store(5)
+	src.setByCode(map[string]uint64{
+		"Unavailable":      3,
+		"DeadlineExceeded": 2,
+	})
+	collector.ObserveOnce(sources)
+
+	// Second delta: only Unavailable grows.
+	src.errors.Store(7)
+	src.setByCode(map[string]uint64{
+		"Unavailable":      5,
+		"DeadlineExceeded": 2,
+	})
+	collector.ObserveOnce(sources)
+
+	err := testutil.GatherAndCompare(
+		registry.Gatherer(),
+		strings.NewReader(`
+# HELP elastickv_raft_dispatch_errors_by_code_total elastickv_raft_dispatch_errors_total subdivided by grpc status code so operators can tell whether the transport is failing because peers are unreachable (Unavailable), slow (DeadlineExceeded), or flow-controlled (ResourceExhausted).
+# TYPE elastickv_raft_dispatch_errors_by_code_total counter
+elastickv_raft_dispatch_errors_by_code_total{code="DeadlineExceeded",group="1",node_address="10.0.0.1:50051",node_id="n1"} 2
+elastickv_raft_dispatch_errors_by_code_total{code="Unavailable",group="1",node_address="10.0.0.1:50051",node_id="n1"} 5
+`),
+		"elastickv_raft_dispatch_errors_by_code_total",
 	)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary

Add `elastickv_raft_dispatch_errors_by_code_total{group,code}` so `elastickv_raft_dispatch_errors_total` can be subdivided by grpc status code.

## Motivation

Post-#573 production metric showed `dispatch_errors_total` climbing to ~1500/s but the aggregate counter alone couldn't tell us *why*:

- `Unavailable` → peer unreachable / process down
- `DeadlineExceeded` → peer is slow to ACK (the likely case here; leader pprof shows 282/401 goroutines parked in `submitRead` — single-dispatcher saturation)
- `ResourceExhausted` → grpc flow-control / server-side backpressure
- `Canceled` → request aborted (normal shutdown noise)

Without the breakdown, choosing between "restart a follower", "tune dispatcher concurrency", or "raise MaxConcurrentStreams" is guesswork.

## Change

- `Engine.dispatchErrorByCode`: mutex-protected `map[string]uint64`, incremented alongside the existing atomic `dispatchErrorCount`. Hot-path cost: one `Mutex.Lock/Unlock` per error (dispatch errors are rare relative to successful dispatches; a mutex is acceptable and keeps the map flexible for future codes).
- `dispatchErrorCodeOf` pulls the grpc `Code` string out of the error; falls through to `Canceled` / `DeadlineExceeded` sentinels for non-grpc errors; everything else → `Unknown`. Cardinality bounded at grpc's ~15 codes + 1.
- `DispatchCounterSource` grows `DispatchErrorCountsByCode() map[string]uint64`. `DispatchCollector.observeOnce` caches the last-seen per-code map and emits monotonic deltas on each 5s poll (same pattern the existing aggregate counters use).
- `fakeDispatchSource` in tests implements the new accessor and gains a `setByCode` helper.

Sum of per-code counters equals `dispatch_errors_total` so dashboards can cross-check.

## Test plan

- [x] `go test -race ./monitoring/... ./internal/raftengine/etcd/...` green
- [x] `TestDispatchCollectorEmitsPerCodeDeltas` pins the delta behaviour (baseline → first observation → only-one-code-grows)
- [ ] Deploy; watch `sum by (code) (rate(elastickv_raft_dispatch_errors_by_code_total[5m]))` for ~5 min to classify the current 1500/s failure stream


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added gRPC status code-based dispatch error tracking in metrics, enabling detailed visibility into error distributions by failure type for improved troubleshooting and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->