### PR TITLE
perf(kv): serve ShardStore.GetAt reads via lease, not read-index

### DIFF
--- a/kv/lease_read_test.go
+++ b/kv/lease_read_test.go
@@ -434,3 +434,79 @@ func TestCoordinate_LeaseRead_ObserverSeparatesHitsFromMisses(t *testing.T) {
 	require.Equal(t, int32(5), obs.hits.Load())
 	require.Equal(t, int32(1), obs.misses.Load())
 }
+
+// --- leaseReadEngineCtx -------------------------------------------------
+
+// TestLeaseReadEngineCtx_FastPath_SkipsLinearizableRead covers the
+// core invariant for ShardStore.GetAt: a fresh LastQuorumAck with
+// Leader state must return AppliedIndex directly, without calling
+// engine.LinearizableRead. This is the fix for the post-#573
+// read-index dispatcher saturation (each in-script redis.call was
+// going through LinearizableRead every time).
+func TestLeaseReadEngineCtx_FastPath_SkipsLinearizableRead(t *testing.T) {
+	t.Parallel()
+	eng := &fakeLeaseEngine{applied: 42, leaseDur: time.Hour}
+	eng.setQuorumAck(time.Now())
+
+	idx, err := leaseReadEngineCtx(context.Background(), eng)
+	require.NoError(t, err)
+	require.Equal(t, uint64(42), idx)
+	require.Equal(t, int32(0), eng.linearizableCalls.Load(),
+		"fresh engine-driven lease must skip the LinearizableRead round-trip")
+}
+
+// TestLeaseReadEngineCtx_StaleAck_FallsThroughToLinearizable makes
+// sure the fast path isn't taken when the engine's last quorum ack
+// has aged past LeaseDuration.
+func TestLeaseReadEngineCtx_StaleAck_FallsThroughToLinearizable(t *testing.T) {
+	t.Parallel()
+	eng := &fakeLeaseEngine{applied: 7, leaseDur: 50 * time.Millisecond}
+	eng.setQuorumAck(time.Now().Add(-time.Hour))
+
+	idx, err := leaseReadEngineCtx(context.Background(), eng)
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), idx)
+	require.Equal(t, int32(1), eng.linearizableCalls.Load(),
+		"stale ack must take the slow path exactly once")
+}
+
+// TestLeaseReadEngineCtx_NotLeader_FallsThrough verifies that a
+// fresh ack alone is not sufficient — the engine must currently be
+// Leader. Mirrors engineLeaseAckValid's state guard.
+func TestLeaseReadEngineCtx_NotLeader_FallsThrough(t *testing.T) {
+	t.Parallel()
+	eng := &fakeLeaseEngine{applied: 99, leaseDur: time.Hour}
+	eng.setQuorumAck(time.Now())
+	eng.state.Store(raftengine.StateFollower)
+	// On a non-leader the fake honours the LeaseProvider contract and
+	// returns zero ack, so the engineLeaseAckValid state guard also
+	// fires — both layers must fail closed.
+	eng.linearizableErr = errors.New("not leader")
+
+	_, err := leaseReadEngineCtx(context.Background(), eng)
+	require.Error(t, err)
+	require.Equal(t, int32(1), eng.linearizableCalls.Load(),
+		"non-leader must take the slow path; leader-only fast path must NOT serve")
+}
+
+// TestLeaseReadEngineCtx_NoLeaseProvider_FallsThrough covers engines
+// that do not implement LeaseProvider. The helper must still work by
+// routing every call through LinearizableRead.
+func TestLeaseReadEngineCtx_NoLeaseProvider_FallsThrough(t *testing.T) {
+	t.Parallel()
+	eng := &nonLeaseEngine{}
+
+	idx, err := leaseReadEngineCtx(context.Background(), eng)
+	require.NoError(t, err)
+	require.Equal(t, uint64(42), idx)
+}
+
+// TestLeaseReadEngineCtx_NilEngine returns ErrLeaderNotFound without
+// panicking. Protects against a regression where the nil guard is
+// removed.
+func TestLeaseReadEngineCtx_NilEngine(t *testing.T) {
+	t.Parallel()
+	_, err := leaseReadEngineCtx(context.Background(), nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrLeaderNotFound)
+}

--- a/kv/raft_engine.go
+++ b/kv/raft_engine.go
@@ -2,6 +2,7 @@ package kv
 
 import (
 	"context"
+	"time"
 
 	"github.com/bootjp/elastickv/internal/raftengine"
 	"github.com/cockroachdb/errors"
@@ -47,6 +48,42 @@ func verifyLeaderEngine(engine raftengine.LeaderView) error {
 func linearizableReadEngineCtx(ctx context.Context, engine raftengine.LeaderView) (uint64, error) {
 	if engine == nil {
 		return 0, errors.WithStack(ErrLeaderNotFound)
+	}
+	index, err := engine.LinearizableRead(ctx)
+	if err != nil {
+		return 0, errors.WithStack(err)
+	}
+	return index, nil
+}
+
+// leaseReadEngineCtx is the lease-aware sibling of
+// linearizableReadEngineCtx. When the engine exposes LeaseProvider
+// and the engine-driven lease anchor (LastQuorumAck) is fresh, it
+// returns the current AppliedIndex WITHOUT dispatching a new
+// read-index request. Only when the lease is unavailable / expired
+// does it fall through to the full LinearizableRead round-trip.
+//
+// Used by ShardStore.GetAt and friends so the per-redis.call read
+// path no longer funnels every read through the single raft
+// dispatch worker — the fast-path goal PR #560 shipped for the
+// top-level Redis GET, now extended to all internal
+// storage-read callers.
+//
+// Safety mirrors Coordinator.LeaseRead (see engineLeaseAckValid):
+// the returned AppliedIndex is only served when the local node is
+// Leader AND LastQuorumAck is within LeaseDuration of a single
+// time.Now() sample.
+func leaseReadEngineCtx(ctx context.Context, engine raftengine.LeaderView) (uint64, error) {
+	if engine == nil {
+		return 0, errors.WithStack(ErrLeaderNotFound)
+	}
+	if lp, ok := engine.(raftengine.LeaseProvider); ok {
+		if leaseDur := lp.LeaseDuration(); leaseDur > 0 {
+			now := time.Now()
+			if engineLeaseAckValid(engine.State(), lp.LastQuorumAck(), now, leaseDur) {
+				return lp.AppliedIndex(), nil
+			}
+		}
 	}
 	index, err := engine.LinearizableRead(ctx)
 	if err != nil {

--- a/kv/shard_store.go
+++ b/kv/shard_store.go
@@ -57,7 +57,16 @@ func isLinearizableRaftLeader(ctx context.Context, engine raftengine.LeaderView)
 	if !isLeaderEngine(engine) {
 		return false
 	}
-	_, err := linearizableReadEngineCtx(ctx, engine)
+	// Lease-aware fence: when the engine's quorum-ack lease is fresh,
+	// leaseReadEngineCtx returns the current AppliedIndex without
+	// issuing a new read-index request. Previously this path always
+	// called LinearizableRead per GetAt, which funnelled every
+	// in-script redis.call through the single raft dispatch worker
+	// and starved heartbeats under sustained Lua load. The lease
+	// guarantees no concurrent leader exists within LeaseDuration,
+	// so the local applied index is still safe to serve; the slow
+	// read-index is only paid on lease miss.
+	_, err := leaseReadEngineCtx(ctx, engine)
 	return err == nil
 }
 
@@ -491,9 +500,10 @@ func (s *ShardStore) LatestCommitTS(ctx context.Context, key []byte) (uint64, bo
 	}
 
 	// Avoid returning a stale watermark when our local raft instance is a
-	// deposed leader.
+	// deposed leader. Lease-aware: on lease hit we skip the read-index
+	// round-trip (same rationale as isLinearizableRaftLeader).
 	if engine := engineForGroup(g); isLeaderEngine(engine) {
-		if _, err := linearizableReadEngineCtx(ctx, engine); err == nil {
+		if _, err := leaseReadEngineCtx(ctx, engine); err == nil {
 			ts, exists, err := g.Store.LatestCommitTS(ctx, key)
 			if err != nil {
 				return 0, false, errors.WithStack(err)


### PR DESCRIPTION
## Summary

Serve `ShardStore.GetAt` / `ScanAt` / `LatestCommitTS` from the leader-local lease when the engine-driven `LastQuorumAck` is fresh, instead of dispatching a fresh read-index round-trip per call.

## Root cause (from PR #573's post-deploy telemetry)

- `elastickv_raft_dispatch_errors_total` → 1500/s
- `MsgHeartbeat drop_count` → 324,864 in 10 min
- Leader pprof: **282 of 401 goroutines parked in `Engine.submitRead`**
- `elastickv_lease_read_total{outcome="hit"}=99.7%` — the Coordinator-level LeaseRead at script start IS hitting

The asymmetry: `luaScriptContext` runs `LeaseReadThrough` once at start and uses `startTS` afterwards, but each in-script `redis.call` → `ShardStore.GetAt(ctx, key, startTS)` called `isLinearizableRaftLeader` → `linearizableReadEngineCtx` → `engine.LinearizableRead` → `submitRead`. **Every storage-layer read submitted its own read-index** through the single dispatch worker. At 7 scripts/s × 5-7 redis.call/script × 1-7 GetAts/call, the dispatcher was swamped and heartbeats couldn't get through.

## Change

New `kv.leaseReadEngineCtx(ctx, engine)` — lease-aware sibling of `linearizableReadEngineCtx`:

- If engine exposes `LeaseProvider` AND `engineLeaseAckValid(state, LastQuorumAck, time.Now(), LeaseDuration)` holds, return `AppliedIndex()` directly.
- Otherwise fall through to the existing `LinearizableRead` round-trip.

Two call sites switched:
- `isLinearizableRaftLeader` (the fence inside `ShardStore.GetAt` / `ScanAt`)
- the leader-liveness guard inside `LatestCommitTS`

Safety is identical to `Coordinator.LeaseRead` — `engineLeaseAckValid` already enforces `state == Leader && !ack.IsZero() && !ack.After(now) && now.Sub(ack) < LeaseDuration`. The lease guarantees no concurrent leader within the window, so local `AppliedIndex` is safe.

## Expected prod impact

- `Engine.submitRead` call rate: ~N× lower, where N = number of storage reads per script (5+ in BullMQ workloads post-#573).
- `elastickv_raft_dispatch_errors_total` should stop climbing.
- `Heartbeat drop_count` should plateau.
- Raft Commit p99 should drop back toward the pre-incident 5s baseline once reads stop hogging the dispatcher.

## Test plan

- [x] `go test -race ./kv/...` (3.6s) green
- [x] `go test -race -short ./adapter/...` (56s) green
- [x] New `TestLeaseReadEngineCtx_*` cover: fast path, stale-ack fallback, non-leader fallback, missing LeaseProvider, nil-engine
- [ ] Deploy; watch `rate(elastickv_lua_cmd_fastpath_total{cmd="zrangebyscore",outcome="hit"}[1m])` for throughput, `elastickv_raft_dispatch_errors_total`, and the leader's goroutine count via pprof
