### PR TITLE
perf(redis-lua): cache keyTypeAt=None results in Eval scope

### DIFF
--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -43,6 +43,11 @@ type luaScriptContext struct {
 	// populate the concrete-type state (c.strings/c.zsets/... with
 	// exists=true), which cachedType() returns first, so the negative
 	// cache is shadowed without needing explicit invalidation.
+	//
+	// Bounded by maxNegativeTypeCacheEntries to prevent a malicious or
+	// buggy script from probing unbounded unique non-existent keys and
+	// blowing up memory. Once full, further misses fall back to the
+	// server-side probe (still correct, just not cached).
 	negativeType map[string]bool
 
 	// keyTypeProbeCount counts how many times the server-side keyTypeAt
@@ -444,6 +449,13 @@ func hasLoadedStreamValue(st *luaStreamState) bool {
 	return st != nil && st.loaded && st.exists
 }
 
+// maxNegativeTypeCacheEntries caps the size of luaScriptContext.negativeType
+// so a malicious or buggy script probing unbounded unique non-existent keys
+// cannot balloon memory. Matches the magnitude of kv.maxReadKeys (10_000),
+// which already bounds the read-set of a single transaction; once the cache
+// is full, further keyTypeAt misses are correctly returned but not memoized.
+const maxNegativeTypeCacheEntries = 10_000
+
 func (c *luaScriptContext) keyType(key []byte) (redisValueType, error) {
 	if typ, ok := c.cachedType(key); ok {
 		if typ != redisTypeNone {
@@ -453,15 +465,19 @@ func (c *luaScriptContext) keyType(key []byte) (redisValueType, error) {
 	}
 
 	c.keyTypeProbeCount++
-	typ, err := c.server.keyTypeAt(context.Background(), key, c.startTS)
+	typ, err := c.server.keyTypeAt(c.scriptCtx(), key, c.startTS)
 	if err != nil {
 		return redisTypeNone, err
 	}
-	if typ == redisTypeNone {
+	if typ == redisTypeNone && len(c.negativeType) < maxNegativeTypeCacheEntries {
 		// Pin the absence result for the rest of this Eval so repeated
 		// BullMQ-style polling of a missing key (e.g. a "delayed" zset)
 		// does not re-run the ~8-seek rawKeyTypeAt probe on every
 		// redis.call.
+		//
+		// Bounded to keep adversarial scripts from growing the map
+		// unboundedly; once full, subsequent misses correctly fall
+		// through to the server probe without caching.
 		c.negativeType[string(key)] = true
 	}
 	return typ, nil

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -36,6 +36,19 @@ type luaScriptContext struct {
 	touched     map[string]struct{}
 	deleted     map[string]bool
 	everDeleted map[string]bool
+	// negativeType caches keys for which server.keyTypeAt() has already
+	// returned redisTypeNone during this Eval. Since startTS is pinned,
+	// MVCC guarantees the absence-at-startTS result is stable for the
+	// script's duration; in-script mutations that re-create the key
+	// populate the concrete-type state (c.strings/c.zsets/... with
+	// exists=true), which cachedType() returns first, so the negative
+	// cache is shadowed without needing explicit invalidation.
+	negativeType map[string]bool
+
+	// keyTypeProbeCount counts how many times the server-side keyTypeAt
+	// helper was invoked during this Eval. Only read by tests via
+	// luaScriptContext methods; ordinary production code never reads it.
+	keyTypeProbeCount int
 
 	strings map[string]*luaStringState
 	lists   map[string]*luaListState
@@ -234,20 +247,21 @@ func newLuaScriptContext(ctx context.Context, server *RedisServer) (*luaScriptCo
 	}
 	startTS := server.readTS()
 	return &luaScriptContext{
-		server:      server,
-		startTS:     startTS,
-		readPin:     server.pinReadTS(startTS),
-		ctx:         ctx,
-		touched:     map[string]struct{}{},
-		deleted:     map[string]bool{},
-		everDeleted: map[string]bool{},
-		strings:     map[string]*luaStringState{},
-		lists:       map[string]*luaListState{},
-		hashes:      map[string]*luaHashState{},
-		sets:        map[string]*luaSetState{},
-		zsets:       map[string]*luaZSetState{},
-		streams:     map[string]*luaStreamState{},
-		ttls:        map[string]*luaTTLState{},
+		server:       server,
+		startTS:      startTS,
+		readPin:      server.pinReadTS(startTS),
+		ctx:          ctx,
+		touched:      map[string]struct{}{},
+		deleted:      map[string]bool{},
+		everDeleted:  map[string]bool{},
+		negativeType: map[string]bool{},
+		strings:      map[string]*luaStringState{},
+		lists:        map[string]*luaListState{},
+		hashes:       map[string]*luaHashState{},
+		sets:         map[string]*luaSetState{},
+		zsets:        map[string]*luaZSetState{},
+		streams:      map[string]*luaStreamState{},
+		ttls:         map[string]*luaTTLState{},
 	}, nil
 }
 
@@ -380,6 +394,13 @@ func (c *luaScriptContext) cachedType(key []byte) (redisValueType, bool) {
 	if c.deleted[k] {
 		return redisTypeNone, true
 	}
+	// Negative (absent-at-startTS) probe result from a prior keyType call
+	// in this Eval. Consulted last so loaded-type and in-script DEL tombstones
+	// win; safe because in-script writes set cachedLoadedTypes[...].exists
+	// which short-circuits above, shadowing the stale negative entry.
+	if c.negativeType[k] {
+		return redisTypeNone, true
+	}
 	return redisTypeNone, false
 }
 
@@ -431,9 +452,17 @@ func (c *luaScriptContext) keyType(key []byte) (redisValueType, error) {
 		return typ, nil
 	}
 
+	c.keyTypeProbeCount++
 	typ, err := c.server.keyTypeAt(context.Background(), key, c.startTS)
 	if err != nil {
 		return redisTypeNone, err
+	}
+	if typ == redisTypeNone {
+		// Pin the absence result for the rest of this Eval so repeated
+		// BullMQ-style polling of a missing key (e.g. a "delayed" zset)
+		// does not re-run the ~8-seek rawKeyTypeAt probe on every
+		// redis.call.
+		c.negativeType[string(key)] = true
 	}
 	return typ, nil
 }
@@ -1373,7 +1402,14 @@ func (c *luaScriptContext) cmdHGet(args []string) (luaReply, error) {
 	if luaHashAlreadyLoaded(c, key) {
 		return hgetFromSlowPath(c, key, field)
 	}
-	if _, cached := c.cachedType(key); cached {
+	if typ, cached := c.cachedType(key); cached {
+		// Short-circuit for a cached-absent key: the slow path would just
+		// re-derive nil after allocating an empty luaHashState. Returning
+		// nil directly skips that work and keeps the BullMQ poll loop on
+		// the cheapest possible code path.
+		if typ == redisTypeNone {
+			return luaNilReply(), nil
+		}
 		return hgetFromSlowPath(c, key, field)
 	}
 	// Fast path: direct wide-column field lookup, bypassing the ~8-seek
@@ -1603,7 +1639,13 @@ func (c *luaScriptContext) cmdHExists(args []string) (luaReply, error) {
 	if luaHashAlreadyLoaded(c, key) {
 		return hexistsFromSlowPath(c, key, field)
 	}
-	if _, cached := c.cachedType(key); cached {
+	if typ, cached := c.cachedType(key); cached {
+		// Short-circuit for a cached-absent key: HEXISTS on a missing
+		// hash is defined to return 0, matching the slow-path result
+		// without allocating an empty luaHashState.
+		if typ == redisTypeNone {
+			return luaIntReply(0), nil
+		}
 		return hexistsFromSlowPath(c, key, field)
 	}
 	hit, alive, err := c.server.hashFieldFastExists(context.Background(), key, []byte(field), c.startTS)
@@ -2175,7 +2217,12 @@ func (c *luaScriptContext) cmdSIsMember(args []string) (luaReply, error) {
 	if luaSetAlreadyLoaded(c, key) {
 		return sismemberFromSlowPath(c, key, member)
 	}
-	if _, cached := c.cachedType(key); cached {
+	if typ, cached := c.cachedType(key); cached {
+		// SISMEMBER on a missing set returns 0; skip the slow path to
+		// avoid an empty luaSetState allocation on repeated misses.
+		if typ == redisTypeNone {
+			return luaIntReply(0), nil
+		}
 		return sismemberFromSlowPath(c, key, member)
 	}
 	hit, alive, err := c.server.setMemberFastExists(context.Background(), key, []byte(member), c.startTS)
@@ -2435,8 +2482,14 @@ func (c *luaScriptContext) cmdZRangeByScore(args []string, reverse bool) (luaRep
 		zrangeMetrics.ObserveSkipLoaded()
 		return c.cmdZRangeByScoreSlow(key, options, reverse)
 	}
-	if _, cached := c.cachedType(key); cached {
+	if typ, cached := c.cachedType(key); cached {
 		zrangeMetrics.ObserveSkipCachedType()
+		// Negative-cache / in-script DEL / RENAME: returning an empty
+		// array directly matches the slow-path result without a second
+		// rawKeyTypeAt probe inside zsetState.
+		if typ == redisTypeNone {
+			return luaArrayReply(), nil
+		}
 		return c.cmdZRangeByScoreSlow(key, options, reverse)
 	}
 	entries, hit, fallbackReason, fastErr := c.zrangeByScoreFastPath(key, options, reverse)
@@ -2697,7 +2750,14 @@ func (c *luaScriptContext) cmdZScore(args []string) (luaReply, error) {
 	if luaZSetAlreadyLoaded(c, key) {
 		return zscoreFromSlowPath(c, key, member)
 	}
-	if _, cached := c.cachedType(key); cached {
+	if typ, cached := c.cachedType(key); cached {
+		// Cached-absent key (incl. negative-cache hit from a prior probe):
+		// skip the slow path entirely and return nil directly. Mirrors the
+		// "missing zset" branch of zscoreFromSlowPath without paying for
+		// an empty luaZSetState allocation.
+		if typ == redisTypeNone {
+			return luaNilReply(), nil
+		}
 		return zscoreFromSlowPath(c, key, member)
 	}
 	score, hit, alive, err := c.server.zsetMemberFastScore(context.Background(), key, []byte(member), c.startTS)

--- a/adapter/redis_lua_negative_type_cache_test.go
+++ b/adapter/redis_lua_negative_type_cache_test.go
@@ -1,0 +1,141 @@
+package adapter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the BullMQ-style "poll a missing delayed zset" path
+// that the negative-type cache targets. See `perf(redis-lua): cache
+// keyTypeAt=None results in Eval scope`.
+//
+// Wire-level tests cover correctness invariants (WRONGTYPE after
+// create-over-negative, nil across repeated misses). A dedicated
+// in-process test uses luaScriptContext.keyTypeProbeCount to pin the
+// "only ONE storage probe per key per Eval" property without relying
+// on brittle production metric assertions.
+
+// TestLua_ZSCORE_MissingThenMissingStillReturnsNil covers the hot-case
+// invariant: two ZSCORE calls on a key that is absent at script start
+// must both return nil. The negative-type cache short-circuits the
+// second call; this test merely ensures the short-circuit produces the
+// same reply shape as the slow path.
+func TestLua_ZSCORE_MissingThenMissingStillReturnsNil(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	// Key is NOT created in pebble. Two ZSCOREs in the same Eval
+	// exercise cold-probe then negative-cache-hit paths.
+	got, err := rdb.Eval(ctx, `
+local a = redis.call("ZSCORE", KEYS[1], "m")
+local b = redis.call("ZSCORE", KEYS[1], "m")
+if a == false and b == false then return "both-nil" end
+return "unexpected"
+`, []string{"lua:neg:zscore"}).Result()
+	require.NoError(t, err)
+	require.Equal(t, "both-nil", got)
+}
+
+// TestLua_ZRANGEBYSCORE_MissingReturnsEmptyArray pins the empty-array
+// reply when the negative-type cache short-circuits the ZRANGEBYSCORE
+// fast-path guard. Matches the slow-path behaviour for a missing key.
+func TestLua_ZRANGEBYSCORE_MissingReturnsEmptyArray(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	got, err := rdb.Eval(ctx, `
+redis.call("ZRANGEBYSCORE", KEYS[1], "-inf", "+inf")
+local r = redis.call("ZRANGEBYSCORE", KEYS[1], "-inf", "+inf")
+return #r
+`, []string{"lua:neg:zrange"}).Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(0), got)
+}
+
+// TestLua_HGET_MissingThenSetReturnsWrongType pins the critical
+// correctness invariant from the task spec: after an EXISTS-style probe
+// loads a negative cache entry, a subsequent SET that transitions the
+// key to String must cause HGET to return WRONGTYPE -- NOT the stale
+// "cached as None" nil reply. The cachedLoadedTypes lookup inside
+// cachedType() shadows the negative entry because SET populates
+// c.strings[k] with exists=true.
+func TestLua_HGET_MissingThenSetReturnsWrongType(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	_, err := rdb.Eval(ctx, `
+redis.call("EXISTS", KEYS[1])
+redis.call("SET", KEYS[1], "v")
+return redis.call("HGET", KEYS[1], "f")
+`, []string{"lua:neg:hget-wt"}).Result()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "WRONGTYPE",
+		"negative cache must NOT shadow an in-script SET that changes the logical type")
+}
+
+// TestLua_ZSCORE_MissingThenZAddReturnsScore pins the companion
+// invariant for zsets: after a probe observes None, a subsequent ZADD
+// in the same script must update c.zsets[k].exists, so ZSCORE returns
+// the newly-added member's score -- not a cached nil.
+func TestLua_ZSCORE_MissingThenZAddReturnsScore(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	got, err := rdb.Eval(ctx, `
+redis.call("ZSCORE", KEYS[1], "m")
+redis.call("ZADD", KEYS[1], 7, "m")
+return redis.call("ZSCORE", KEYS[1], "m")
+`, []string{"lua:neg:zscore-recreate"}).Result()
+	require.NoError(t, err)
+	require.Equal(t, "7", got)
+}
+
+// TestLuaNegativeTypeCache_SingleProbePerKey pins the probe-count
+// property that motivates the negative cache. Uses the in-process
+// luaScriptContext.keyTypeProbeCount counter rather than a brittle
+// Prometheus metric scrape: this guarantees that N repeated reads of a
+// missing key incur exactly ONE server.keyTypeAt() call.
+func TestLuaNegativeTypeCache_SingleProbePerKey(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	sc, err := newLuaScriptContext(ctx, nodes[0].redisServer)
+	require.NoError(t, err)
+	defer sc.Close()
+
+	// The FIRST keyType call triggers a server probe; the cache must
+	// absorb every subsequent call on the same key.
+	key := []byte("lua:neg:probe-count")
+	for i := 0; i < 5; i++ {
+		typ, kerr := sc.keyType(key)
+		require.NoError(t, kerr)
+		require.Equal(t, redisTypeNone, typ)
+	}
+	require.Equal(t, 1, sc.keyTypeProbeCount,
+		"repeated keyType() on a missing key must issue exactly one server probe")
+}

--- a/adapter/redis_lua_negative_type_cache_test.go
+++ b/adapter/redis_lua_negative_type_cache_test.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/redis/go-redis/v9"
@@ -138,4 +139,54 @@ func TestLuaNegativeTypeCache_SingleProbePerKey(t *testing.T) {
 	}
 	require.Equal(t, 1, sc.keyTypeProbeCount,
 		"repeated keyType() on a missing key must issue exactly one server probe")
+}
+
+// TestLuaNegativeTypeCache_BoundedSize pins the memory-safety invariant:
+// a script that probes more than maxNegativeTypeCacheEntries unique
+// missing keys must NOT grow the map beyond the cap. The first `cap`
+// keys are still cached (single probe each on repeat); keys probed after
+// the cap is reached fall through to the server every time but the map
+// itself stays bounded.
+func TestLuaNegativeTypeCache_BoundedSize(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	sc, err := newLuaScriptContext(ctx, nodes[0].redisServer)
+	require.NoError(t, err)
+	defer sc.Close()
+
+	// Probe cap+overflow unique missing keys. Each probe is a miss
+	// (redisTypeNone); only the first `cap` should be memoized.
+	const overflow = 50
+	total := maxNegativeTypeCacheEntries + overflow
+	for i := 0; i < total; i++ {
+		typ, kerr := sc.keyType([]byte(fmt.Sprintf("lua:neg:cap:%d", i)))
+		require.NoError(t, kerr)
+		require.Equal(t, redisTypeNone, typ)
+	}
+	require.Equal(t, maxNegativeTypeCacheEntries, len(sc.negativeType),
+		"negativeType map must be capped at maxNegativeTypeCacheEntries")
+
+	// Each unique key above required exactly one probe on first access.
+	require.Equal(t, total, sc.keyTypeProbeCount,
+		"each unique key must have triggered exactly one server probe")
+
+	// Re-probing one of the first `cap` keys must hit the cache
+	// (no additional server probe). Re-probing an overflow key must
+	// miss the cache and issue another server probe.
+	cachedKey := []byte("lua:neg:cap:0")
+	_, kerr := sc.keyType(cachedKey)
+	require.NoError(t, kerr)
+	require.Equal(t, total, sc.keyTypeProbeCount,
+		"a key inserted before the cap must remain cached")
+
+	overflowKey := []byte(fmt.Sprintf("lua:neg:cap:%d", maxNegativeTypeCacheEntries+1))
+	_, kerr = sc.keyType(overflowKey)
+	require.NoError(t, kerr)
+	require.Equal(t, total+1, sc.keyTypeProbeCount,
+		"a key probed after the cap was reached must fall back to the server probe")
+	require.Equal(t, maxNegativeTypeCacheEntries, len(sc.negativeType),
+		"fallback probe must NOT grow the bounded cache")
 }


### PR DESCRIPTION
## Summary
- Extend `luaScriptContext.cachedType` with a per-Eval `negativeType` map populated when `server.keyTypeAt()` returns `redisTypeNone`. MVCC at the pinned `startTS` guarantees the absence result is stable for the script's duration.
- Short-circuit `cmdZScore` / `cmdZRangeByScore` / `cmdHGet` / `cmdHExists` / `cmdSIsMember` to their empty-reply shape on a cached-None type instead of punting to the slow path, eliminating the remaining `rawKeyTypeAt` probes that `zsetState` / `hashState` / `setState` would otherwise issue for a missing key.
- No explicit invalidation needed: in-script writes populate `cachedLoadedTypes[...].exists=true`, which `cachedType()` consults first and thus shadows the negative entry automatically.

Motivation: post-#573/575 pprof still showed `rawKeyTypeAt` net write 14% CPU cum on the BullMQ "poll a missing delayed zset" loop because the negative result was not cached; every subsequent `redis.call` re-paid the ~8-seek type probe.

## Test plan
- [x] `go test -race -short ./adapter/...` passes (63.58s)
- [x] `TestLua_ZSCORE_DelThenZScoreReturnsNil` still green (DEL-then-ZSCORE path unchanged)
- [x] `TestLua_HGET_SetThenHGetReturnsWrongType` / `TestLua_ZSCORE_SetThenZScoreReturnsWrongType` still green (SET-over-hash/zset invariant preserved)
- [x] New `TestLuaNegativeTypeCache_SingleProbePerKey` pins "repeated `keyType()` on missing key = exactly 1 server probe" via in-process `keyTypeProbeCount` counter
- [x] New `TestLua_HGET_MissingThenSetReturnsWrongType` / `TestLua_ZSCORE_MissingThenZAddReturnsScore` pin the correctness invariants called out in the task spec
- [x] New `TestLua_ZSCORE_MissingThenMissingStillReturnsNil` / `TestLua_ZRANGEBYSCORE_MissingReturnsEmptyArray` cover the hot-case wire reply shape
