### PR TITLE
test(redis-lua): drop flaky pool.Hits() assertion in VMReuse leak test

### DIFF
--- a/adapter/redis_lua_pool_test.go
+++ b/adapter/redis_lua_pool_test.go
@@ -108,8 +108,14 @@ func TestLua_VMReuseDoesNotLeakGlobals(t *testing.T) {
 	require.NoError(t, stateB.DoString(`assert(string.upper("ok") == "OK")`))
 	pool.put(plsB)
 
-	// Pool should have registered at least one hit by now.
-	require.GreaterOrEqual(t, pool.Hits(), uint64(1), "pool never reported a hit")
+	// NOTE: we intentionally do NOT assert pool.Hits() >= 1 here.
+	// sync.Pool may evict items between Put and Get under GC pressure
+	// (same non-determinism acknowledged in the comment above line
+	// 80), so the Script-B Get may be a fresh allocation even though
+	// Script A's plsA was just Put. CI on GitHub Actions has
+	// reproduced this as a flake. Pool effectiveness is covered
+	// deterministically by TestLua_PoolRecordsReuseVsAllocation,
+	// which asserts hits + misses rather than hits alone.
 }
 
 // TestLua_VMReuseRestoresRebindsWhitelistedGlobals guards against a

--- a/adapter/redis_lua_pool_test.go
+++ b/adapter/redis_lua_pool_test.go
@@ -109,13 +109,10 @@ func TestLua_VMReuseDoesNotLeakGlobals(t *testing.T) {
 	pool.put(plsB)
 
 	// NOTE: we intentionally do NOT assert pool.Hits() >= 1 here.
-	// sync.Pool may evict items between Put and Get under GC pressure
-	// (same non-determinism acknowledged in the comment above line
-	// 80), so the Script-B Get may be a fresh allocation even though
-	// Script A's plsA was just Put. CI on GitHub Actions has
-	// reproduced this as a flake. Pool effectiveness is covered
-	// deterministically by TestLua_PoolRecordsReuseVsAllocation,
-	// which asserts hits + misses rather than hits alone.
+	// As noted at line 81, sync.Pool may evict items under GC pressure,
+	// making a single-iteration hit assertion non-deterministic.
+	// Pool effectiveness is covered by TestLua_PoolRecordsReuseVsAllocation,
+	// which uses a loop to ensure reuse occurs.
 }
 
 // TestLua_VMReuseRestoresRebindsWhitelistedGlobals guards against a


### PR DESCRIPTION
## Summary

Drop the `require.GreaterOrEqual(t, pool.Hits(), uint64(1))` line from `TestLua_VMReuseDoesNotLeakGlobals`. It was flaking on CI (PR #582 run `24781704678`), and the assertion is inherently racy on `sync.Pool`.

## Root cause

The assertion required the Script-B `pool.get(nil)` to return exactly the `pooledLuaState` that Script-A put back moments earlier. But `sync.Pool` is documented to discard pooled items under GC pressure, which can easily fire between a Put and a Get on the race runtime. The test's own comment above line 80 already acknowledges this non-determinism — but then the Hits assertion at line 112 reintroduces the same source of flake.

```
--- FAIL: TestLua_VMReuseDoesNotLeakGlobals (0.00s)
    Error: "0" is not greater than or equal to "1"
    redis_lua_pool_test.go:112
```

## Change

- Remove the flaky Hits assertion from `TestLua_VMReuseDoesNotLeakGlobals`.
- Keep the test's actual purpose intact (no leak of `GLOBAL_LEAK`, `LEAKY_TABLE` across pooled states; whitelisted globals still intact).
- Comment points at `TestLua_PoolRecordsReuseVsAllocation` which asserts `hits + misses` deterministically across a controlled loop.

## Verification

- `go test -race -count=20 -run TestLua_VMReuseDoesNotLeakGlobals ./adapter/` → 20/20 pass
- `go test -race -count=1 -short ./adapter/...` → ok in 63s
- `make lint` clean

Pair with PR #582 (multi-exec flake) to unblock the CI pipeline on `perf/raft-dispatcher-lanes` and `fix/idempotent-rollback-marker`.
