### PR TITLE
docs: add HLC to architecture/README and drop stale BoltDB migration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Elastickv is an experimental project undertaking the challenge of creating a dis
 
 **THIS PROJECT IS CURRENTLY UNDER DEVELOPMENT AND IS NOT READY FOR PRODUCTION USE.**
 
-## Implemented Features (Verified)
+## Implemented Features
 - **Raft-based Data Replication**: KV state replication is implemented on Raft, with leader-based commit and follower forwarding paths.
 - **Shard-aware Data Plane**: Static shard ranges across multiple Raft groups with shard routing/coordinator are implemented.
 - **Durable Route Control Plane (Milestone 1)**: Durable route catalog, versioned route snapshot apply, watcher-based route refresh, and manual `ListRoutes`/`SplitRange` (same-group split) are implemented.
@@ -14,6 +14,7 @@ Elastickv is an experimental project undertaking the challenge of creating a dis
 - **DynamoDB Compatibility Scope**: `CreateTable`/`DeleteTable`/`DescribeTable`/`ListTables`/`PutItem`/`GetItem`/`DeleteItem`/`UpdateItem`/`Query`/`Scan`/`BatchWriteItem`/`TransactWriteItems` are implemented.
 - **S3 Compatibility Scope**: `ListBuckets`, `CreateBucket`, `HeadBucket`, `DeleteBucket`, `PutObject`, `GetObject`, `HeadObject`, `DeleteObject`, and `ListObjectsV2` (path-style) are implemented. AWS Signature Version 4 authentication with static credentials is supported. The server exposes an S3-compatible HTTP endpoint via `--s3Address`.
 - **Basic Consistency Behaviors**: Write-after-read checks, leader redirection/forwarding paths, and OCC conflict detection for transactional writes are covered by tests.
+- **Hybrid Logical Clock (HLC)**: Transactions are ordered by a 64-bit HLC split into an upper 48-bit physical component (Unix milliseconds) and a lower 16-bit logical counter. The logical half advances in memory with atomic CAS on every `Next()` call — no Raft round-trip per timestamp — so timestamp issuance stays in the nanosecond range. The physical half is bounded by a leader-lease style ceiling: the leader periodically commits a lease entry (`hlcRenewalInterval ≈ 1s`, window `hlcPhysicalWindowMs = 3s`) so that a newly elected leader inherits a safe lower bound and never issues timestamps overlapping the previous leader's window, without blocking per-request on consensus. See `docs/architecture_overview.md` §4 for details.
 
 ## Planned Features
 - **Dynamic Node Scaling**: Automatic node/range scaling based on load is not yet implemented (current sharding operations are configuration/manual driven).
@@ -97,32 +98,6 @@ go run . \
   --raftId "n1" \
   --raftBootstrap
 ```
-
-### Migrating Legacy BoltDB Raft Storage
-
-Recent versions store Raft logs and stable state in Pebble (`raft.db`) instead of
-the legacy BoltDB files (`logs.dat` and `stable.dat`). If startup fails with:
-
-```text
-legacy boltdb Raft storage "logs.dat" found in ...
-```
-
-stop the node and run the offline migrator against the directory shown in the
-error:
-
-```bash
-go run ./cmd/raft-migrate --dir /var/lib/elastickv/n1
-mv /var/lib/elastickv/n1/logs.dat /var/lib/elastickv/n1/logs.dat.bak
-mv /var/lib/elastickv/n1/stable.dat /var/lib/elastickv/n1/stable.dat.bak
-```
-
-For multi-group layouts, pass the exact group directory from the error message
-(for example `/var/lib/elastickv/n1/group-1`).
-
-After that, start Elastickv normally. The migrator leaves the legacy files in
-place as a backup, but they must be moved or removed before startup because the
-server intentionally refuses to run while `logs.dat` or `stable.dat` are still
-present.
 
 To expose metrics on a dedicated port:
 ```bash

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -41,6 +41,10 @@ flowchart TB
       FSM["KV FSM (kv/fsm.go)"]
       MV["MVCC Store (store/mvcc_store.go or store/lsm_store.go)"]
     end
+
+    subgraph Clock["Timestamp Oracle"]
+      HLC["HLC (kv/hlc.go)"]
+    end
   end
 
   RC --> RS
@@ -71,6 +75,10 @@ flowchart TB
   CS --> MV
   CW --> CS
   CW --> DE
+
+  SCC -- "Next() timestamps" --> HLC
+  FSM -- "apply HLC lease: SetPhysicalCeiling" --> HLC
+  SCC -- "propose HLC lease (leader)" --> RG
 ```
 
 ## 2. Overall Runtime Architecture
@@ -146,8 +154,37 @@ sequenceDiagram
   DS-->>Op: "SplitRangeResponse(left,right,catalogVersion)"
 ```
 
-## 4. Notes
+## 4. Hybrid Logical Clock (HLC)
+
+Transactional reads and writes are ordered by a Hybrid Logical Clock (`kv/hlc.go`).
+A 64-bit timestamp packs a 48-bit physical component (Unix milliseconds) and a
+16-bit in-memory logical counter. The physical component is bounded by a
+Raft-agreed ceiling so that a newly elected leader never issues timestamps that
+overlap the previous leader's window.
+
+```mermaid
+sequenceDiagram
+  participant L as "Leader Coordinator"
+  participant RG as "Default Raft Group"
+  participant F as "KV FSM (all nodes)"
+  participant H as "HLC (all nodes)"
+  participant Tx as "Txn / MVCC read-write path"
+
+  loop "every hlcRenewalInterval (<3s)"
+    L->>RG: "Propose HLC lease (now + hlcPhysicalWindowMs)"
+    RG-->>F: "Apply HLC lease entry"
+    F->>H: "SetPhysicalCeiling(ms)"
+  end
+
+  Tx->>H: "Next()"
+  H-->>Tx: "ts = max(wall, ceiling)<<16 | logical++"
+```
+
+## 5. Notes
 
 1. Route catalog is persisted in reserved internal keys in the default Raft group.
 2. `distribution.Engine` is an in-memory read path cache and is refreshed by watcher.
 3. Milestone 1 split is same-group only. Cross-group migration is out of scope.
+4. HLC physical ceiling is replicated via the default Raft group; the logical
+   counter advances in memory with no Raft round-trip. Coordinator and FSM share
+   the same `*HLC` instance (wired via `WithHLC` / `NewKvFSMWithHLC`).

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -177,7 +177,7 @@ sequenceDiagram
   end
 
   Tx->>H: "Next()"
-  H-->>Tx: "ts = max(wall, ceiling)<<16 | logical++"
+  H-->>Tx: "ts = max(wall, ceiling)<<16 | logical_counter"
 ```
 
 ## 5. Notes


### PR DESCRIPTION
- Add HLC component + edges and a lease-renewal sequence diagram to docs/architecture_overview.md (upper 48-bit physical / lower 16-bit logical split, leader-lease style physical ceiling).
- Add an "Implemented Features" bullet for HLC in README covering the physical/logical split, in-memory logical counter, and leader-lease ceiling for low-latency timestamp issuance.
- Drop the "Migrating Legacy BoltDB Raft Storage" README section; the cmd/raft-migrate tool no longer exists and BoltDB is kept only as a startup-time legacy-file detector.