### PR TITLE
obs(store): track MVCC write conflicts by key-prefix class

### DIFF
--- a/kv/leader_routed_store.go
+++ b/kv/leader_routed_store.go
@@ -279,6 +279,16 @@ func (s *LeaderRoutedStore) LastCommitTS() uint64 {
 	return s.local.LastCommitTS()
 }
 
+// WriteConflictCountsByPrefix delegates to the local MVCC store. The
+// leader-routed wrapper does not add cross-group conflict detection of
+// its own, so the node-local view IS the authoritative view.
+func (s *LeaderRoutedStore) WriteConflictCountsByPrefix() map[string]uint64 {
+	if s == nil || s.local == nil {
+		return map[string]uint64{}
+	}
+	return s.local.WriteConflictCountsByPrefix()
+}
+
 const globalLastCommitTSTimeout = 200 * time.Millisecond
 
 // GlobalLastCommitTS returns the most recently committed HLC timestamp from

--- a/kv/shard_store.go
+++ b/kv/shard_store.go
@@ -1174,6 +1174,23 @@ func (s *ShardStore) LastCommitTS() uint64 {
 	return max
 }
 
+// WriteConflictCountsByPrefix aggregates OCC conflict counts across
+// every shard group owned by this ShardStore. Per-shard counts share
+// the same "<kind>|<key_prefix>" label schema, so a simple sum gives
+// the node-wide view. The result is always non-nil.
+func (s *ShardStore) WriteConflictCountsByPrefix() map[string]uint64 {
+	out := map[string]uint64{}
+	for _, g := range s.groups {
+		if g == nil || g.Store == nil {
+			continue
+		}
+		for label, count := range g.Store.WriteConflictCountsByPrefix() {
+			out[label] += count
+		}
+	}
+	return out
+}
+
 func (s *ShardStore) Compact(ctx context.Context, minTS uint64) error {
 	for _, g := range s.groups {
 		if g == nil || g.Store == nil {

--- a/main.go
+++ b/main.go
@@ -184,13 +184,7 @@ func run() error {
 		adapter.WithDistributionCoordinator(coordinate),
 		adapter.WithDistributionActiveTimestampTracker(readTracker),
 	)
-	metricsRegistry.RaftObserver().Start(runCtx, raftMonitorRuntimes(runtimes), raftMetricsObserveInterval)
-	if collector := metricsRegistry.DispatchCollector(); collector != nil {
-		collector.Start(runCtx, dispatchMonitorSources(runtimes), raftMetricsObserveInterval)
-	}
-	if collector := metricsRegistry.PebbleCollector(); collector != nil {
-		collector.Start(runCtx, pebbleMonitorSources(runtimes), raftMetricsObserveInterval)
-	}
+	startMonitoringCollectors(runCtx, metricsRegistry, runtimes)
 	compactor := kv.NewFSMCompactor(
 		fsmCompactionRuntimes(runtimes),
 		kv.WithFSMCompactorActiveTimestampTracker(readTracker),
@@ -494,6 +488,49 @@ func dispatchMonitorSources(runtimes []*raftGroupRuntime) []monitoring.DispatchS
 		out = append(out, monitoring.DispatchSource{
 			GroupID: runtime.spec.id,
 			Source:  src,
+		})
+	}
+	return out
+}
+
+// startMonitoringCollectors wires up the per-tick Prometheus
+// collectors (raft dispatch, Pebble LSM, store-layer OCC conflicts)
+// on top of the running raft runtimes. Kept separate from run() so
+// the latter stays under the cyclop complexity budget and so new
+// collectors can be added without widening run() further.
+func startMonitoringCollectors(ctx context.Context, reg *monitoring.Registry, runtimes []*raftGroupRuntime) {
+	reg.RaftObserver().Start(ctx, raftMonitorRuntimes(runtimes), raftMetricsObserveInterval)
+	if collector := reg.DispatchCollector(); collector != nil {
+		collector.Start(ctx, dispatchMonitorSources(runtimes), raftMetricsObserveInterval)
+	}
+	if collector := reg.PebbleCollector(); collector != nil {
+		collector.Start(ctx, pebbleMonitorSources(runtimes), raftMetricsObserveInterval)
+	}
+	if collector := reg.WriteConflictCollector(); collector != nil {
+		collector.Start(ctx, writeConflictMonitorSources(runtimes), raftMetricsObserveInterval)
+	}
+}
+
+// writeConflictMonitorSources extracts the MVCC stores that expose
+// per-(kind, key_prefix) OCC conflict counters so monitoring can poll
+// them for the elastickv_store_write_conflict_total metric. Every
+// store.MVCCStore implements WriteConflictCountsByPrefix(); stores
+// that do not track conflicts return an empty map and simply do not
+// contribute series.
+func writeConflictMonitorSources(runtimes []*raftGroupRuntime) []monitoring.WriteConflictSource {
+	out := make([]monitoring.WriteConflictSource, 0, len(runtimes))
+	for _, runtime := range runtimes {
+		if runtime == nil || runtime.store == nil {
+			continue
+		}
+		src, ok := runtime.store.(monitoring.WriteConflictCounterSource)
+		if !ok {
+			continue
+		}
+		out = append(out, monitoring.WriteConflictSource{
+			GroupID:    runtime.spec.id,
+			GroupIDStr: strconv.FormatUint(runtime.spec.id, 10),
+			Source:     src,
 		})
 	}
 	return out

--- a/monitoring/registry.go
+++ b/monitoring/registry.go
@@ -14,12 +14,13 @@ type Registry struct {
 	registerer   prometheus.Registerer
 	gatherer     prometheus.Gatherer
 
-	dynamo  *DynamoDBMetrics
-	redis   *RedisMetrics
-	raft    *RaftMetrics
-	lua     *LuaMetrics
-	hotPath *HotPathMetrics
-	pebble  *PebbleMetrics
+	dynamo        *DynamoDBMetrics
+	redis         *RedisMetrics
+	raft          *RaftMetrics
+	lua           *LuaMetrics
+	hotPath       *HotPathMetrics
+	pebble        *PebbleMetrics
+	writeConflict *WriteConflictMetrics
 }
 
 // NewRegistry builds a registry with constant labels that identify the local node.
@@ -41,6 +42,7 @@ func NewRegistry(nodeID string, nodeAddress string) *Registry {
 	r.lua = newLuaMetrics(registerer)
 	r.hotPath = newHotPathMetrics(registerer)
 	r.pebble = newPebbleMetrics(registerer)
+	r.writeConflict = newWriteConflictMetrics(registerer)
 	return r
 }
 
@@ -144,4 +146,16 @@ func (r *Registry) PebbleCollector() *PebbleCollector {
 		return nil
 	}
 	return newPebbleCollector(r.pebble)
+}
+
+// WriteConflictCollector returns a collector that polls each MVCC
+// store's per-(kind, key_prefix) OCC conflict counters and mirrors
+// them into the elastickv_store_write_conflict_total Prometheus
+// counter vector. Start it with the node's MVCC sources after the
+// stores have been opened.
+func (r *Registry) WriteConflictCollector() *WriteConflictCollector {
+	if r == nil || r.writeConflict == nil {
+		return nil
+	}
+	return newWriteConflictCollector(r.writeConflict)
 }

--- a/monitoring/write_conflict.go
+++ b/monitoring/write_conflict.go
@@ -1,0 +1,168 @@
+package monitoring
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Write-conflict metrics expose the MVCC store layer's OCC conflict
+// signal. Conflicts are detected inside the store's ApplyMutations —
+// both write-write (mutation vs newer committed version) and
+// read-write (read set vs newer committed version) — and attributed
+// by a bounded key-prefix classification (txn_lock, redis_string,
+// zset, ...). The metric is protocol-independent: whether the
+// consumer is Redis, DynamoDB, or raw KV, a conflict landing here is
+// the same underlying event.
+//
+// This complements the proxy-side view added in #585: the proxy
+// counter tells you how many client requests observed a conflict,
+// but a single client request can map to many Raft proposals (e.g.
+// a DynamoDB TransactWriteItems across several items). The store
+// counter is the authoritative per-proposal count and the right
+// signal for capacity/alerting.
+
+const defaultWriteConflictPollInterval = 5 * time.Second
+
+// WriteConflictMetrics owns the per-(group, kind, key_prefix) counter
+// vector used by the write-conflict dashboard. Registered once per
+// Registry.
+type WriteConflictMetrics struct {
+	writeConflictTotal *prometheus.CounterVec
+}
+
+func newWriteConflictMetrics(registerer prometheus.Registerer) *WriteConflictMetrics {
+	m := &WriteConflictMetrics{
+		writeConflictTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "elastickv_store_write_conflict_total",
+				Help: "OCC write conflicts detected at the MVCC store layer, bucketed by conflicting key-prefix class and conflict kind (read=read-write, write=write-write). Rate shows cluster-wide conflict pressure; sharp increases on specific prefixes point at hot keys or lock-resolver races (e.g. txn_rollback for the PR #581 incident pattern).",
+			},
+			[]string{"group", "kind", "key_prefix"},
+		),
+	}
+	registerer.MustRegister(m.writeConflictTotal)
+	return m
+}
+
+// WriteConflictCounterSource abstracts per-group access to the MVCC
+// store's OCC conflict counters. The concrete store implementations
+// (pebbleStore, mvccStore, ShardStore, LeaderRoutedStore) satisfy
+// this via WriteConflictCountsByPrefix(); keys in the returned map
+// follow the "<kind>|<key_prefix>" encoding from the store package.
+type WriteConflictCounterSource interface {
+	WriteConflictCountsByPrefix() map[string]uint64
+}
+
+// WriteConflictSource binds a raft group ID to a counter source.
+// Multiple groups can be polled by a single collector on a sharded
+// node. GroupIDStr is the pre-formatted decimal form of GroupID used
+// as the "group" Prometheus label; pre-computing it avoids a
+// per-tick strconv allocation.
+type WriteConflictSource struct {
+	GroupID    uint64
+	GroupIDStr string
+	Source     WriteConflictCounterSource
+}
+
+// WriteConflictCollector polls each registered store on a fixed
+// interval and mirrors the snapshot into the Prometheus counter
+// vector. Store-side counts are monotonic for the lifetime of a
+// single store instance; counters advance by the positive delta
+// against the last snapshot so a store reopen (Restore swap) does
+// not produce negative values.
+type WriteConflictCollector struct {
+	metrics *WriteConflictMetrics
+
+	mu       sync.Mutex
+	previous map[uint64]map[string]uint64
+}
+
+func newWriteConflictCollector(metrics *WriteConflictMetrics) *WriteConflictCollector {
+	return &WriteConflictCollector{
+		metrics:  metrics,
+		previous: map[uint64]map[string]uint64{},
+	}
+}
+
+// Start polls sources on the given interval until ctx is canceled.
+// Passing interval <= 0 uses defaultWriteConflictPollInterval (5 s),
+// matching the DispatchCollector / PebbleCollector cadence.
+func (c *WriteConflictCollector) Start(ctx context.Context, sources []WriteConflictSource, interval time.Duration) {
+	if c == nil || c.metrics == nil || len(sources) == 0 {
+		return
+	}
+	if interval <= 0 {
+		interval = defaultWriteConflictPollInterval
+	}
+	c.observeOnce(sources)
+	ticker := time.NewTicker(interval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				c.observeOnce(sources)
+			}
+		}
+	}()
+}
+
+// ObserveOnce is exposed for tests and single-shot callers.
+func (c *WriteConflictCollector) ObserveOnce(sources []WriteConflictSource) {
+	c.observeOnce(sources)
+}
+
+func (c *WriteConflictCollector) observeOnce(sources []WriteConflictSource) {
+	if c == nil || c.metrics == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, src := range sources {
+		if src.Source == nil {
+			continue
+		}
+		curr := src.Source.WriteConflictCountsByPrefix()
+		prev := c.previous[src.GroupID]
+		for label, count := range curr {
+			prevCount := prev[label]
+			if count <= prevCount {
+				// Counter reset (store reopen) or no change:
+				// do not emit. prev is replaced below, which
+				// rebases the delta baseline silently.
+				continue
+			}
+			kind, keyPrefix, ok := splitWriteConflictLabel(label)
+			if !ok {
+				continue
+			}
+			c.metrics.writeConflictTotal.
+				WithLabelValues(src.GroupIDStr, kind, keyPrefix).
+				Add(float64(count - prevCount))
+		}
+		// Copy curr into previous so future ticks use the latest
+		// snapshot as baseline even if the source happens to reset.
+		snap := make(map[string]uint64, len(curr))
+		for k, v := range curr {
+			snap[k] = v
+		}
+		c.previous[src.GroupID] = snap
+	}
+}
+
+// splitWriteConflictLabel mirrors store.DecodeWriteConflictLabel
+// without importing the store package (which would pull pebble into
+// monitoring). The encoding is stable: "<kind>|<key_prefix>".
+func splitWriteConflictLabel(label string) (kind, keyPrefix string, ok bool) {
+	idx := strings.IndexByte(label, '|')
+	if idx < 0 {
+		return "", "", false
+	}
+	return label[:idx], label[idx+1:], true
+}

--- a/monitoring/write_conflict_test.go
+++ b/monitoring/write_conflict_test.go
@@ -1,0 +1,151 @@
+package monitoring
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeWriteConflictSource implements WriteConflictCounterSource with
+// canned snapshots so collector tests need not open a real store.
+type fakeWriteConflictSource struct {
+	mu    sync.Mutex
+	snap  map[string]uint64
+	nilOK bool
+}
+
+func (f *fakeWriteConflictSource) set(s map[string]uint64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.snap = s
+}
+
+func (f *fakeWriteConflictSource) WriteConflictCountsByPrefix() map[string]uint64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.snap == nil && !f.nilOK {
+		return map[string]uint64{}
+	}
+	out := make(map[string]uint64, len(f.snap))
+	for k, v := range f.snap {
+		out[k] = v
+	}
+	return out
+}
+
+func TestWriteConflictCollectorEmitsPositiveDeltas(t *testing.T) {
+	registry := NewRegistry("n1", "10.0.0.1:50051")
+	collector := registry.WriteConflictCollector()
+	require.NotNil(t, collector)
+
+	src := &fakeWriteConflictSource{}
+	sources := []WriteConflictSource{{GroupID: 1, GroupIDStr: "1", Source: src}}
+
+	// Baseline: establishes the delta reference. No series emitted
+	// yet because every count equals its previous zero, so the
+	// collector skips strict-greater checks — but once the snapshot
+	// grows on the next tick, those buckets appear.
+	src.set(map[string]uint64{
+		"write|txn_rollback": 3,
+		"read|redis_string":  1,
+	})
+	collector.ObserveOnce(sources)
+
+	// Advance: +2 rollback write conflicts, +4 redis_string reads.
+	src.set(map[string]uint64{
+		"write|txn_rollback": 5,
+		"read|redis_string":  5,
+		"write|zset":         7, // brand-new bucket; whole count emits.
+	})
+	collector.ObserveOnce(sources)
+
+	// Idempotent: same snapshot → zero delta → no double-counting.
+	collector.ObserveOnce(sources)
+
+	err := testutil.GatherAndCompare(
+		registry.Gatherer(),
+		strings.NewReader(`
+# HELP elastickv_store_write_conflict_total OCC write conflicts detected at the MVCC store layer, bucketed by conflicting key-prefix class and conflict kind (read=read-write, write=write-write). Rate shows cluster-wide conflict pressure; sharp increases on specific prefixes point at hot keys or lock-resolver races (e.g. txn_rollback for the PR #581 incident pattern).
+# TYPE elastickv_store_write_conflict_total counter
+elastickv_store_write_conflict_total{group="1",key_prefix="redis_string",kind="read",node_address="10.0.0.1:50051",node_id="n1"} 5
+elastickv_store_write_conflict_total{group="1",key_prefix="txn_rollback",kind="write",node_address="10.0.0.1:50051",node_id="n1"} 5
+elastickv_store_write_conflict_total{group="1",key_prefix="zset",kind="write",node_address="10.0.0.1:50051",node_id="n1"} 7
+`),
+		"elastickv_store_write_conflict_total",
+	)
+	require.NoError(t, err)
+}
+
+func TestWriteConflictCollectorHandlesSourceReset(t *testing.T) {
+	// A store reopen resets the underlying counters. The collector
+	// must not emit a negative delta; it rebases silently.
+	registry := NewRegistry("n2", "10.0.0.2:50051")
+	collector := registry.WriteConflictCollector()
+	require.NotNil(t, collector)
+
+	src := &fakeWriteConflictSource{}
+	sources := []WriteConflictSource{{GroupID: 7, GroupIDStr: "7", Source: src}}
+
+	src.set(map[string]uint64{"write|txn_lock": 10})
+	collector.ObserveOnce(sources)
+
+	src.set(map[string]uint64{"write|txn_lock": 2}) // reopen / reset
+	collector.ObserveOnce(sources)
+
+	src.set(map[string]uint64{"write|txn_lock": 5}) // +3 from the post-reset baseline
+	collector.ObserveOnce(sources)
+
+	err := testutil.GatherAndCompare(
+		registry.Gatherer(),
+		strings.NewReader(`
+# HELP elastickv_store_write_conflict_total OCC write conflicts detected at the MVCC store layer, bucketed by conflicting key-prefix class and conflict kind (read=read-write, write=write-write). Rate shows cluster-wide conflict pressure; sharp increases on specific prefixes point at hot keys or lock-resolver races (e.g. txn_rollback for the PR #581 incident pattern).
+# TYPE elastickv_store_write_conflict_total counter
+elastickv_store_write_conflict_total{group="7",key_prefix="txn_lock",kind="write",node_address="10.0.0.2:50051",node_id="n2"} 13
+`),
+		"elastickv_store_write_conflict_total",
+	)
+	require.NoError(t, err)
+}
+
+func TestWriteConflictCollectorSkipsNilSourceAndMalformedLabels(t *testing.T) {
+	registry := NewRegistry("n3", "10.0.0.3:50051")
+	collector := registry.WriteConflictCollector()
+	require.NotNil(t, collector)
+
+	// Nil source must be skipped without panic.
+	require.NotPanics(t, func() {
+		collector.ObserveOnce([]WriteConflictSource{{GroupID: 1, GroupIDStr: "1", Source: nil}})
+	})
+
+	// Malformed label (missing the "|" separator) must be skipped;
+	// the well-formed neighbour must still be emitted.
+	src := &fakeWriteConflictSource{}
+	src.set(map[string]uint64{
+		"malformed_no_pipe": 5,
+		"write|hash":        2,
+	})
+	collector.ObserveOnce([]WriteConflictSource{{GroupID: 42, GroupIDStr: "42", Source: src}})
+
+	err := testutil.GatherAndCompare(
+		registry.Gatherer(),
+		strings.NewReader(`
+# HELP elastickv_store_write_conflict_total OCC write conflicts detected at the MVCC store layer, bucketed by conflicting key-prefix class and conflict kind (read=read-write, write=write-write). Rate shows cluster-wide conflict pressure; sharp increases on specific prefixes point at hot keys or lock-resolver races (e.g. txn_rollback for the PR #581 incident pattern).
+# TYPE elastickv_store_write_conflict_total counter
+elastickv_store_write_conflict_total{group="42",key_prefix="hash",kind="write",node_address="10.0.0.3:50051",node_id="n3"} 2
+`),
+		"elastickv_store_write_conflict_total",
+	)
+	require.NoError(t, err)
+}
+
+func TestWriteConflictCollectorZeroRegistryIsSafe(t *testing.T) {
+	var c *WriteConflictCollector
+	require.NotPanics(t, func() { c.ObserveOnce(nil) })
+
+	registry := NewRegistry("n1", "10.0.0.1:50051")
+	collector := registry.WriteConflictCollector()
+	require.NotPanics(t, func() { collector.ObserveOnce(nil) })
+}

--- a/monitoring/write_conflict_test.go
+++ b/monitoring/write_conflict_test.go
@@ -44,10 +44,10 @@ func TestWriteConflictCollectorEmitsPositiveDeltas(t *testing.T) {
 	src := &fakeWriteConflictSource{}
 	sources := []WriteConflictSource{{GroupID: 1, GroupIDStr: "1", Source: src}}
 
-	// Baseline: establishes the delta reference. No series emitted
-	// yet because every count equals its previous zero, so the
-	// collector skips strict-greater checks — but once the snapshot
-	// grows on the next tick, those buckets appear.
+	// Baseline: on the first observation, prevCount is implicitly zero,
+	// so any bucket with a non-zero count is emitted immediately.
+	// Subsequent observations only emit positive deltas relative to
+	// this snapshot, while brand-new buckets emit their whole count.
 	src.set(map[string]uint64{
 		"write|txn_rollback": 3,
 		"read|redis_string":  1,

--- a/store/lsm_store.go
+++ b/store/lsm_store.go
@@ -63,6 +63,10 @@ type pebbleStore struct {
 	applyMu              sync.Mutex // serializes ApplyMutations: conflict check → commit
 	maintenanceMu        sync.Mutex
 	dir                  string
+	// writeConflicts tracks per-(kind, key_prefix) OCC conflict counts
+	// detected inside ApplyMutations. Polled by the monitoring
+	// WriteConflictCollector; not part of the authoritative OCC path.
+	writeConflicts *writeConflictCounter
 }
 
 // Ensure pebbleStore implements MVCCStore and RetentionController.
@@ -102,6 +106,7 @@ func NewPebbleStore(dir string, opts ...PebbleStoreOption) (MVCCStore, error) {
 		log: slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 			Level: slog.LevelWarn,
 		})),
+		writeConflicts: newWriteConflictCounter(),
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -860,6 +865,11 @@ func (s *pebbleStore) checkConflicts(ctx context.Context, mutations []*KVPairMut
 			return err
 		}
 		if exists && ts > startTS {
+			// Record the first conflicting key's bucket only — a single
+			// failing ApplyMutations corresponds to one OCC conflict
+			// regardless of how many subsequent mutations would also
+			// collide, which matches the Prometheus rate semantics.
+			s.writeConflicts.record(WriteConflictKindWrite, classifyWriteConflictKey(mut.Key))
 			return NewWriteConflictError(mut.Key)
 		}
 	}
@@ -873,10 +883,28 @@ func (s *pebbleStore) checkReadConflicts(ctx context.Context, readKeys [][]byte,
 			return err
 		}
 		if exists && ts > startTS {
+			s.writeConflicts.record(WriteConflictKindRead, classifyWriteConflictKey(key))
 			return NewWriteConflictError(key)
 		}
 	}
 	return nil
+}
+
+// WriteConflictCountsByPrefix returns a snapshot of the OCC conflict
+// counts keyed by "<kind>|<key_prefix>" (see EncodeWriteConflictLabel).
+// Counts are monotonic for the lifetime of this *pebbleStore; a store
+// reopen starts them back at zero, which the monitoring collector
+// absorbs by rebasing its delta baseline.
+func (s *pebbleStore) WriteConflictCountsByPrefix() map[string]uint64 {
+	return s.writeConflicts.snapshot()
+}
+
+// WriteConflictCount is the aggregate across every (kind, key_prefix)
+// bucket. Primarily useful for tests and for quick single-number
+// sanity checks; Prometheus exports the per-bucket view via
+// WriteConflictCountsByPrefix.
+func (s *pebbleStore) WriteConflictCount() uint64 {
+	return s.writeConflicts.total()
 }
 
 func (s *pebbleStore) applyMutationsBatch(b *pebble.Batch, mutations []*KVPairMutation, commitTS uint64) error {

--- a/store/mvcc_store.go
+++ b/store/mvcc_store.go
@@ -65,6 +65,11 @@ type mvccStore struct {
 	log           *slog.Logger
 	lastCommitTS  uint64
 	minRetainedTS uint64
+	// writeConflicts mirrors the per-(kind, key_prefix) counter from
+	// the pebble-backed store so the in-memory implementation shows up
+	// in the same Prometheus series (even if the counts are usually
+	// zero because tests rarely race ApplyMutations).
+	writeConflicts *writeConflictCounter
 }
 
 // LastCommitTS exposes the latest commit timestamp for read snapshot selection.
@@ -106,6 +111,7 @@ func NewMVCCStore(opts ...MVCCStoreOption) MVCCStore {
 		log: slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 			Level: slog.LevelWarn,
 		})),
+		writeConflicts: newWriteConflictCounter(),
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -493,15 +499,29 @@ func (s *mvccStore) ApplyMutations(ctx context.Context, mutations []*KVPairMutat
 func (s *mvccStore) checkConflictsLocked(mutations []*KVPairMutation, readKeys [][]byte, startTS uint64) error {
 	for _, mut := range mutations {
 		if latestVer, ok := s.latestVersionLocked(mut.Key); ok && latestVer.TS > startTS {
+			s.writeConflicts.record(WriteConflictKindWrite, classifyWriteConflictKey(mut.Key))
 			return NewWriteConflictError(mut.Key)
 		}
 	}
 	for _, key := range readKeys {
 		if latestVer, ok := s.latestVersionLocked(key); ok && latestVer.TS > startTS {
+			s.writeConflicts.record(WriteConflictKindRead, classifyWriteConflictKey(key))
 			return NewWriteConflictError(key)
 		}
 	}
 	return nil
+}
+
+// WriteConflictCountsByPrefix returns a snapshot of OCC conflicts
+// observed by this in-memory store. See pebbleStore for semantics.
+func (s *mvccStore) WriteConflictCountsByPrefix() map[string]uint64 {
+	return s.writeConflicts.snapshot()
+}
+
+// WriteConflictCount returns the aggregate OCC conflict count across
+// all (kind, key_prefix) buckets.
+func (s *mvccStore) WriteConflictCount() uint64 {
+	return s.writeConflicts.total()
 }
 
 // DeletePrefixAt deletes all visible keys matching prefix by writing tombstones

--- a/store/store.go
+++ b/store/store.go
@@ -158,6 +158,13 @@ type MVCCStore interface {
 	DeletePrefixAt(ctx context.Context, prefix []byte, excludePrefix []byte, commitTS uint64) error
 	// LastCommitTS returns the highest commit timestamp applied on this node.
 	LastCommitTS() uint64
+	// WriteConflictCountsByPrefix returns a snapshot of the MVCC
+	// write-conflict counters keyed by "<kind>|<key_prefix>" where
+	// kind is "read" or "write" and key_prefix is a bounded
+	// classification of the conflicting key. The map is a copy; the
+	// caller may mutate it freely. Implementations that do not track
+	// conflicts may return an empty (non-nil) map.
+	WriteConflictCountsByPrefix() map[string]uint64
 	// Compact removes versions older than minTS that are no longer needed.
 	Compact(ctx context.Context, minTS uint64) error
 	Snapshot() (Snapshot, error)

--- a/store/write_conflict_counter.go
+++ b/store/write_conflict_counter.go
@@ -1,0 +1,200 @@
+package store
+
+import (
+	"bytes"
+	"sync"
+)
+
+// Write-conflict classification labels. These are emitted as the
+// "key_prefix" Prometheus label on elastickv_store_write_conflict_total
+// so operators can tell WHICH namespace is producing OCC conflicts.
+// The label set is deliberately bounded and stable — adding a new
+// bucket is a conscious schema change, not a cardinality surprise.
+//
+// Buckets are aligned with the internal key prefixes declared across
+// the codebase:
+//
+//	!txn|lock|, !txn|int|, !txn|cmt|, !txn|rb|  (kv/txn_keys.go)
+//	!redis|str|, !redis|ttl|, !redis|hll|       (adapter/redis_compat_types.go)
+//	!hs|, !st|, !zs|, !lst|                     (store/*_helpers.go)
+//	!ddb|                                       (kv/shard_key.go)
+const (
+	WriteConflictKindWrite = "write"
+	WriteConflictKindRead  = "read"
+
+	writeConflictClassTxnLock     = "txn_lock"
+	writeConflictClassTxnIntent   = "txn_intent"
+	writeConflictClassTxnCommit   = "txn_commit"
+	writeConflictClassTxnRollback = "txn_rollback"
+	writeConflictClassTxnMeta     = "txn_meta"
+	writeConflictClassTxnOther    = "txn_other"
+	writeConflictClassRedisString = "redis_string"
+	writeConflictClassRedisTTL    = "redis_ttl"
+	writeConflictClassRedisHLL    = "redis_hll"
+	writeConflictClassRedisOther  = "redis_other"
+	writeConflictClassHash        = "hash"
+	writeConflictClassSet         = "set"
+	writeConflictClassZSet        = "zset"
+	writeConflictClassList        = "list"
+	writeConflictClassStream      = "stream"
+	writeConflictClassDynamoDB    = "dynamodb"
+	writeConflictClassOther       = "other"
+)
+
+var (
+	// Txn-internal prefixes (from kv/txn_keys.go; duplicated here to
+	// avoid the store→kv import cycle).
+	wcPrefixTxnLock     = []byte("!txn|lock|")
+	wcPrefixTxnIntent   = []byte("!txn|int|")
+	wcPrefixTxnCommit   = []byte("!txn|cmt|")
+	wcPrefixTxnRollback = []byte("!txn|rb|")
+	wcPrefixTxnMeta     = []byte("!txn|meta|")
+	wcPrefixTxn         = []byte("!txn|")
+
+	// Redis-adapter prefixes (from adapter/redis_compat_types.go).
+	wcPrefixRedisString = []byte("!redis|str|")
+	wcPrefixRedisTTL    = []byte("!redis|ttl|")
+	wcPrefixRedisHLL    = []byte("!redis|hll|")
+	wcPrefixRedisStream = []byte("!redis|stream|")
+	wcPrefixRedisHash   = []byte("!redis|hash|")
+	wcPrefixRedisSet    = []byte("!redis|set|")
+	wcPrefixRedisZSet   = []byte("!redis|zset|")
+	wcPrefixRedis       = []byte("!redis|")
+
+	// Composite-type helper prefixes (store/*_helpers.go).
+	wcPrefixHash = []byte("!hs|")
+	wcPrefixSet  = []byte("!st|")
+	wcPrefixZSet = []byte("!zs|")
+	wcPrefixList = []byte("!lst|")
+
+	// DynamoDB-adapter prefix (kv/shard_key.go).
+	wcPrefixDynamoDB = []byte("!ddb|")
+)
+
+// writeConflictPrefixMatcher pairs a literal byte prefix with the
+// bucket label it maps to. Evaluated in order against the candidate
+// key; the first match wins, so more-specific prefixes (e.g.
+// "!txn|lock|") must be listed before the namespace umbrella
+// ("!txn|") that would otherwise shadow them.
+type writeConflictPrefixMatcher struct {
+	prefix []byte
+	label  string
+}
+
+var writeConflictPrefixTable = []writeConflictPrefixMatcher{
+	// Txn-internal namespaces first (most specific), then the
+	// umbrella "!txn|" fallback bucket for future additions.
+	{wcPrefixTxnLock, writeConflictClassTxnLock},
+	{wcPrefixTxnIntent, writeConflictClassTxnIntent},
+	{wcPrefixTxnCommit, writeConflictClassTxnCommit},
+	{wcPrefixTxnRollback, writeConflictClassTxnRollback},
+	{wcPrefixTxnMeta, writeConflictClassTxnMeta},
+	{wcPrefixTxn, writeConflictClassTxnOther},
+	// Redis-adapter namespaces, specific-first.
+	{wcPrefixRedisString, writeConflictClassRedisString},
+	{wcPrefixRedisTTL, writeConflictClassRedisTTL},
+	{wcPrefixRedisHLL, writeConflictClassRedisHLL},
+	{wcPrefixRedisStream, writeConflictClassStream},
+	{wcPrefixRedisHash, writeConflictClassHash},
+	{wcPrefixRedisSet, writeConflictClassSet},
+	{wcPrefixRedisZSet, writeConflictClassZSet},
+	{wcPrefixRedis, writeConflictClassRedisOther},
+	// Composite-type helpers (server-internal naming).
+	{wcPrefixHash, writeConflictClassHash},
+	{wcPrefixSet, writeConflictClassSet},
+	{wcPrefixZSet, writeConflictClassZSet},
+	{wcPrefixList, writeConflictClassList},
+	// DynamoDB-adapter namespace.
+	{wcPrefixDynamoDB, writeConflictClassDynamoDB},
+}
+
+// classifyWriteConflictKey returns a bounded, stable label identifying
+// the conflicting key's namespace. Unknown shapes fall back to "other"
+// so the label set cannot grow unbounded with user-supplied keys.
+func classifyWriteConflictKey(key []byte) string {
+	for _, m := range writeConflictPrefixTable {
+		if bytes.HasPrefix(key, m.prefix) {
+			return m.label
+		}
+	}
+	return writeConflictClassOther
+}
+
+// writeConflictCounter is a small, lock-protected set of per-bucket
+// counters. Conflicts are rare — at most one increment per failing
+// ApplyMutations call — so a mutex is cheaper than a shard map. The
+// (kind, key_prefix) tuple is flattened into a single string key with
+// "|" as separator; this keeps the snapshot map dense and avoids a
+// nested map allocation per tick.
+type writeConflictCounter struct {
+	mu     sync.Mutex
+	counts map[string]uint64
+}
+
+func newWriteConflictCounter() *writeConflictCounter {
+	return &writeConflictCounter{counts: map[string]uint64{}}
+}
+
+// record increments the counter for (kind, keyClass) where kind is one
+// of WriteConflictKindWrite / WriteConflictKindRead and keyClass is a
+// classifyWriteConflictKey result.
+func (c *writeConflictCounter) record(kind string, keyClass string) {
+	if c == nil {
+		return
+	}
+	label := kind + "|" + keyClass
+	c.mu.Lock()
+	c.counts[label]++
+	c.mu.Unlock()
+}
+
+// snapshot returns a copy of the counter map suitable for handing to
+// the monitoring collector without callers holding the counter lock.
+func (c *writeConflictCounter) snapshot() map[string]uint64 {
+	if c == nil {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[string]uint64, len(c.counts))
+	for k, v := range c.counts {
+		out[k] = v
+	}
+	return out
+}
+
+// total returns the sum across all (kind, keyClass) buckets. Useful
+// for an aggregate accessor and for tests that just want to assert
+// "some conflict was recorded".
+func (c *writeConflictCounter) total() uint64 {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var sum uint64
+	for _, v := range c.counts {
+		sum += v
+	}
+	return sum
+}
+
+// EncodeWriteConflictLabel joins a (kind, keyClass) tuple into the
+// flat map key used by WriteConflictCountsByPrefix snapshots. Exposed
+// so the monitoring collector can build the same string without
+// re-implementing the convention.
+func EncodeWriteConflictLabel(kind, keyClass string) string {
+	return kind + "|" + keyClass
+}
+
+// DecodeWriteConflictLabel splits a flat label back into (kind,
+// keyClass). Returns ok=false for malformed input so collector code
+// can skip rather than emit bogus series.
+func DecodeWriteConflictLabel(label string) (kind, keyClass string, ok bool) {
+	for i := 0; i < len(label); i++ {
+		if label[i] == '|' {
+			return label[:i], label[i+1:], true
+		}
+	}
+	return "", "", false
+}

--- a/store/write_conflict_counter_test.go
+++ b/store/write_conflict_counter_test.go
@@ -1,0 +1,82 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyWriteConflictKey(t *testing.T) {
+	// Table test covering every bucket in classifyWriteConflictKey. A
+	// new bucket without a test row here is intentional dead code.
+	cases := []struct {
+		name string
+		key  []byte
+		want string
+	}{
+		{"txn_lock", []byte("!txn|lock|user/42"), writeConflictClassTxnLock},
+		{"txn_intent", []byte("!txn|int|user/42"), writeConflictClassTxnIntent},
+		{"txn_commit", []byte("!txn|cmt|user/42\x00\x00\x00\x00\x00\x00\x00\x01"), writeConflictClassTxnCommit},
+		{"txn_rollback", []byte("!txn|rb|user/42\x00\x00\x00\x00\x00\x00\x00\x01"), writeConflictClassTxnRollback},
+		{"txn_meta", []byte("!txn|meta|primary"), writeConflictClassTxnMeta},
+		{"txn_other", []byte("!txn|unknown|x"), writeConflictClassTxnOther},
+		{"redis_string", []byte("!redis|str|foo"), writeConflictClassRedisString},
+		{"redis_ttl", []byte("!redis|ttl|foo"), writeConflictClassRedisTTL},
+		{"redis_hll", []byte("!redis|hll|foo"), writeConflictClassRedisHLL},
+		{"redis_stream_routes_to_stream", []byte("!redis|stream|foo"), writeConflictClassStream},
+		{"redis_hash_routes_to_hash", []byte("!redis|hash|foo"), writeConflictClassHash},
+		{"redis_set_routes_to_set", []byte("!redis|set|foo"), writeConflictClassSet},
+		{"redis_zset_routes_to_zset", []byte("!redis|zset|foo"), writeConflictClassZSet},
+		{"redis_other", []byte("!redis|weird|foo"), writeConflictClassRedisOther},
+		{"hash_prefix", []byte("!hs|meta|foo"), writeConflictClassHash},
+		{"set_prefix", []byte("!st|mem|foo"), writeConflictClassSet},
+		{"zset_prefix", []byte("!zs|scr|foo"), writeConflictClassZSet},
+		{"list_prefix", []byte("!lst|itm|foo"), writeConflictClassList},
+		{"dynamodb_prefix", []byte("!ddb|item|users/42"), writeConflictClassDynamoDB},
+		{"other_fallback", []byte("user/42"), writeConflictClassOther},
+		{"empty_key", []byte(""), writeConflictClassOther},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, classifyWriteConflictKey(tc.key))
+		})
+	}
+}
+
+func TestWriteConflictCounterRecordAndSnapshot(t *testing.T) {
+	c := newWriteConflictCounter()
+	require.Zero(t, c.total())
+
+	c.record(WriteConflictKindWrite, writeConflictClassTxnRollback)
+	c.record(WriteConflictKindWrite, writeConflictClassTxnRollback)
+	c.record(WriteConflictKindRead, writeConflictClassRedisString)
+
+	assert.EqualValues(t, 3, c.total())
+
+	snap := c.snapshot()
+	assert.EqualValues(t, 2, snap[EncodeWriteConflictLabel(WriteConflictKindWrite, writeConflictClassTxnRollback)])
+	assert.EqualValues(t, 1, snap[EncodeWriteConflictLabel(WriteConflictKindRead, writeConflictClassRedisString)])
+
+	// Snapshot is a copy: mutating it must not affect the counter.
+	snap["bogus"] = 999
+	assert.EqualValues(t, 3, c.total())
+}
+
+func TestDecodeWriteConflictLabel(t *testing.T) {
+	kind, class, ok := DecodeWriteConflictLabel(EncodeWriteConflictLabel(WriteConflictKindWrite, writeConflictClassTxnLock))
+	require.True(t, ok)
+	assert.Equal(t, WriteConflictKindWrite, kind)
+	assert.Equal(t, writeConflictClassTxnLock, class)
+
+	_, _, ok = DecodeWriteConflictLabel("malformed")
+	assert.False(t, ok)
+}
+
+func TestWriteConflictCounterNilSafe(t *testing.T) {
+	var c *writeConflictCounter
+	require.NotPanics(t, func() { c.record(WriteConflictKindWrite, writeConflictClassOther) })
+	assert.Nil(t, c.snapshot())
+	assert.Zero(t, c.total())
+}

--- a/store/write_conflict_store_test.go
+++ b/store/write_conflict_store_test.go
@@ -1,0 +1,119 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPebbleStoreApplyMutations_RecordsWriteConflict verifies that a
+// write-write conflict inside ApplyMutations increments the
+// (kind=write, key_prefix=<bucket>) counter. Mirrors the real lost-
+// update scenario: a txn reads at startTS=5, another commits a new
+// version at commitTS=10, then the first txn tries to commit with
+// startTS=5 — must fail and be counted.
+func TestPebbleStoreApplyMutations_RecordsWriteConflict(t *testing.T) {
+	dir, err := os.MkdirTemp("", "pebble-writeconflict-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	s, err := NewPebbleStore(dir)
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, s.Close()) }()
+
+	ctx := context.Background()
+	key := []byte("!redis|str|hotkey")
+
+	// Commit v1 at ts=10.
+	require.NoError(t, s.ApplyMutations(ctx, []*KVPairMutation{
+		{Op: OpTypePut, Key: key, Value: []byte("v1")},
+	}, nil, 0, 10))
+
+	// Another txn tries to commit with startTS=5 (older than the committed v1).
+	err = s.ApplyMutations(ctx, []*KVPairMutation{
+		{Op: OpTypePut, Key: key, Value: []byte("v2")},
+	}, nil, 5, 11)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrWriteConflict))
+
+	ps, ok := s.(*pebbleStore)
+	require.True(t, ok)
+	require.EqualValues(t, 1, ps.WriteConflictCount())
+	snap := ps.WriteConflictCountsByPrefix()
+	assert.EqualValues(t, 1, snap[EncodeWriteConflictLabel(WriteConflictKindWrite, writeConflictClassRedisString)])
+	assert.Zero(t, snap[EncodeWriteConflictLabel(WriteConflictKindRead, writeConflictClassRedisString)])
+}
+
+// TestPebbleStoreApplyMutations_RecordsReadConflict covers the RW
+// conflict path: a txn's read set sees a newer committed version.
+// Same metric, different kind label.
+func TestPebbleStoreApplyMutations_RecordsReadConflict(t *testing.T) {
+	dir, err := os.MkdirTemp("", "pebble-readconflict-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	s, err := NewPebbleStore(dir)
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, s.Close()) }()
+
+	ctx := context.Background()
+	readKey := []byte("!txn|rb|primary\x00\x00\x00\x00\x00\x00\x00\x01")
+	writeKey := []byte("!redis|str|other")
+
+	// Commit a newer version at the read key so the next txn's
+	// readKeys check observes ts > startTS.
+	require.NoError(t, s.ApplyMutations(ctx, []*KVPairMutation{
+		{Op: OpTypePut, Key: readKey, Value: []byte("rollback_record")},
+	}, nil, 0, 20))
+
+	err = s.ApplyMutations(ctx, []*KVPairMutation{
+		{Op: OpTypePut, Key: writeKey, Value: []byte("v1")},
+	}, [][]byte{readKey}, 10, 21)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrWriteConflict))
+
+	ps, ok := s.(*pebbleStore)
+	require.True(t, ok)
+	require.EqualValues(t, 1, ps.WriteConflictCount())
+	snap := ps.WriteConflictCountsByPrefix()
+	assert.EqualValues(t, 1, snap[EncodeWriteConflictLabel(WriteConflictKindRead, writeConflictClassTxnRollback)])
+}
+
+// TestMVCCStoreApplyMutations_RecordsConflicts verifies the in-memory
+// implementation records conflicts identically to the pebble-backed
+// one so both show up in the same Prometheus series.
+func TestMVCCStoreApplyMutations_RecordsConflicts(t *testing.T) {
+	s := NewMVCCStore()
+	defer s.Close()
+	ctx := context.Background()
+
+	writeKey := []byte("!zs|scr|leaderboard")
+	require.NoError(t, s.ApplyMutations(ctx, []*KVPairMutation{
+		{Op: OpTypePut, Key: writeKey, Value: []byte("v1")},
+	}, nil, 0, 10))
+
+	err := s.ApplyMutations(ctx, []*KVPairMutation{
+		{Op: OpTypePut, Key: writeKey, Value: []byte("v2")},
+	}, nil, 5, 11)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrWriteConflict))
+
+	snap := s.WriteConflictCountsByPrefix()
+	assert.EqualValues(t, 1, snap[EncodeWriteConflictLabel(WriteConflictKindWrite, writeConflictClassZSet)])
+}
+
+// TestMVCCStoreWriteConflictCountsByPrefix_EmptyByDefault guards the
+// invariant that a freshly-constructed store returns a non-nil,
+// empty map (so the monitoring collector does not have to nil-check).
+func TestMVCCStoreWriteConflictCountsByPrefix_EmptyByDefault(t *testing.T) {
+	s := NewMVCCStore()
+	defer s.Close()
+
+	snap := s.WriteConflictCountsByPrefix()
+	require.NotNil(t, snap)
+	assert.Empty(t, snap)
+}


### PR DESCRIPTION
## Summary

- Adds a protocol-independent OCC write-conflict metric at the MVCC store layer. Both `checkConflicts` (write-write) and `checkReadConflicts` (read-write) in `store/lsm_store.go` / `store/mvcc_store.go` now increment a bounded per-(kind, key_prefix) counter immediately before returning `NewWriteConflictError`; a new `monitoring.WriteConflictCollector` polls the stores every 5 s (matching the existing `DispatchCollector` / `PebbleCollector` cadence) and mirrors deltas into `elastickv_store_write_conflict_total{group, kind, key_prefix}`.
- `kind` splits `read` (RW conflict via read set) from `write` (WW conflict via mutation set) since ops implications differ. `key_prefix` uses a bounded classification aligned with existing prefix constants (`!txn|lock|`, `!txn|rb|`, `!redis|str|`, `!hs|`, `!zs|`, `!lst|`, `!ddb|`, ...) with an `other` fallback so user-supplied keys cannot grow cardinality.

## Motivation

`#585` adds the proxy-side view (per client request). This PR adds the underlying store-side view (per Raft-applied proposal), so the signal is visible regardless of protocol adapter (Redis, DynamoDB, raw KV). In the `!txn|rb|` production incident the proxy counter spiked per user request but a single request fanned out to many Raft proposals; the store-side metric would have surfaced the real pressure (txn_rollback bucket) directly.

## Sample Grafana query

```
sum by (key_prefix) (rate(elastickv_store_write_conflict_total[5m]))
```

Split by conflict kind:

```
sum by (kind, key_prefix) (rate(elastickv_store_write_conflict_total[5m]))
```

## Test plan

- [x] `go test -race -count=1 ./store/... ./monitoring/... ./adapter/... ./kv/...`
- [x] `make lint`
- [x] New unit tests:
  - `store/write_conflict_counter_test.go`: table test for `classifyWriteConflictKey` covering every bucket; counter record / snapshot / nil-safety.
  - `store/write_conflict_store_test.go`: integration tests for both pebble-backed and in-memory MVCC stores exercising the WW and RW conflict paths and asserting the right bucket increments.
  - `monitoring/write_conflict_test.go`: collector delta behaviour, source-reset (counter-down) rebasing, malformed-label skip, nil-safety.
