### PR TITLE
perf(pebble): set explicit 256 MiB block cache with env override

### DIFF
--- a/monitoring/pebble.go
+++ b/monitoring/pebble.go
@@ -47,9 +47,10 @@ type PebbleMetrics struct {
 	memtableZombieCount *prometheus.GaugeVec
 
 	// Block cache.
-	blockCacheSizeBytes   *prometheus.GaugeVec
-	blockCacheHitsTotal   *prometheus.CounterVec
-	blockCacheMissesTotal *prometheus.CounterVec
+	blockCacheSizeBytes     *prometheus.GaugeVec
+	blockCacheCapacityBytes *prometheus.GaugeVec
+	blockCacheHitsTotal     *prometheus.CounterVec
+	blockCacheMissesTotal   *prometheus.CounterVec
 }
 
 func newPebbleMetrics(registerer prometheus.Registerer) *PebbleMetrics {
@@ -117,6 +118,13 @@ func newPebbleMetrics(registerer prometheus.Registerer) *PebbleMetrics {
 			},
 			[]string{"group"},
 		),
+		blockCacheCapacityBytes: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "elastickv_pebble_block_cache_capacity_bytes",
+				Help: "Configured maximum size of Pebble's block cache in bytes. Paired with elastickv_pebble_block_cache_size_bytes so operators can see usage relative to capacity and with the hit/miss counters so they can reason about whether a low hit rate reflects a cold cache or an undersized one.",
+			},
+			[]string{"group"},
+		),
 		blockCacheHitsTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "elastickv_pebble_block_cache_hits_total",
@@ -143,6 +151,7 @@ func newPebbleMetrics(registerer prometheus.Registerer) *PebbleMetrics {
 		m.memtableSizeBytes,
 		m.memtableZombieCount,
 		m.blockCacheSizeBytes,
+		m.blockCacheCapacityBytes,
 		m.blockCacheHitsTotal,
 		m.blockCacheMissesTotal,
 	)
@@ -155,6 +164,17 @@ func newPebbleMetrics(registerer prometheus.Registerer) *PebbleMetrics {
 // allowed; the collector will skip that group for the tick.
 type PebbleMetricsSource interface {
 	Metrics() *pebble.Metrics
+}
+
+// PebbleCacheCapacitySource is an optional companion to PebbleMetricsSource:
+// sources that expose the configured block-cache capacity (in bytes) are
+// queried by the collector to populate
+// elastickv_pebble_block_cache_capacity_bytes. Implementations return 0 to
+// indicate "not known / store closed"; the collector then leaves the gauge
+// at its last observed value for that tick. The concrete *store pebbleStore
+// satisfies this via BlockCacheCapacityBytes(); tests can omit it.
+type PebbleCacheCapacitySource interface {
+	BlockCacheCapacityBytes() int64
 }
 
 // PebbleSource binds a raft group ID to its Pebble store. Multiple
@@ -238,42 +258,58 @@ func (c *PebbleCollector) observeOnce(sources []PebbleSource) {
 		if snap == nil {
 			continue
 		}
-		group := src.GroupIDStr
-
-		// L0 pressure: gauges, overwritten each tick.
-		c.metrics.l0Sublevels.WithLabelValues(group).Set(float64(snap.Levels[0].Sublevels))
-		c.metrics.l0NumFiles.WithLabelValues(group).Set(float64(snap.Levels[0].TablesCount))
-
-		// Compaction.
-		c.metrics.compactEstimatedDebt.WithLabelValues(group).Set(float64(snap.Compact.EstimatedDebt))
-		c.metrics.compactInProgress.WithLabelValues(group).Set(float64(snap.Compact.NumInProgress))
-
-		// Memtable.
-		c.metrics.memtableCount.WithLabelValues(group).Set(float64(snap.MemTable.Count))
-		c.metrics.memtableSizeBytes.WithLabelValues(group).Set(float64(snap.MemTable.Size))
-		c.metrics.memtableZombieCount.WithLabelValues(group).Set(float64(snap.MemTable.ZombieCount))
-
-		// Block cache gauge.
-		c.metrics.blockCacheSizeBytes.WithLabelValues(group).Set(float64(snap.BlockCache.Size))
-
-		// Monotonic counters: emit only the positive delta. A smaller
-		// value means the source was reset (store reopened); rebase
-		// silently without emitting negative.
-		prev := c.previous[src.GroupID]
-		curr := pebbleSnapshot{
-			compactCount:     snap.Compact.Count,
-			blockCacheHits:   snap.BlockCache.Hits,
-			blockCacheMisses: snap.BlockCache.Misses,
-		}
-		if curr.compactCount > prev.compactCount {
-			c.metrics.compactCountTotal.WithLabelValues(group).Add(float64(curr.compactCount - prev.compactCount))
-		}
-		if curr.blockCacheHits > prev.blockCacheHits {
-			c.metrics.blockCacheHitsTotal.WithLabelValues(group).Add(float64(curr.blockCacheHits - prev.blockCacheHits))
-		}
-		if curr.blockCacheMisses > prev.blockCacheMisses {
-			c.metrics.blockCacheMissesTotal.WithLabelValues(group).Add(float64(curr.blockCacheMisses - prev.blockCacheMisses))
-		}
-		c.previous[src.GroupID] = curr
+		c.observeSource(src, snap)
 	}
+}
+
+// observeSource publishes a single source's snapshot into the Prometheus
+// vectors. Split out of observeOnce to keep that function's control flow
+// (nil-guards + source loop) below the cyclomatic-complexity budget.
+func (c *PebbleCollector) observeSource(src PebbleSource, snap *pebble.Metrics) {
+	group := src.GroupIDStr
+
+	// L0 pressure: gauges, overwritten each tick.
+	c.metrics.l0Sublevels.WithLabelValues(group).Set(float64(snap.Levels[0].Sublevels))
+	c.metrics.l0NumFiles.WithLabelValues(group).Set(float64(snap.Levels[0].TablesCount))
+
+	// Compaction.
+	c.metrics.compactEstimatedDebt.WithLabelValues(group).Set(float64(snap.Compact.EstimatedDebt))
+	c.metrics.compactInProgress.WithLabelValues(group).Set(float64(snap.Compact.NumInProgress))
+
+	// Memtable.
+	c.metrics.memtableCount.WithLabelValues(group).Set(float64(snap.MemTable.Count))
+	c.metrics.memtableSizeBytes.WithLabelValues(group).Set(float64(snap.MemTable.Size))
+	c.metrics.memtableZombieCount.WithLabelValues(group).Set(float64(snap.MemTable.ZombieCount))
+
+	// Block cache gauges: current usage (always) + configured capacity
+	// (when the source exposes it). Capacity is static for the lifetime
+	// of a DB in practice, but we re-read each tick so operators observe
+	// the new value immediately after a restart with a different
+	// ELASTICKV_PEBBLE_CACHE_MB.
+	c.metrics.blockCacheSizeBytes.WithLabelValues(group).Set(float64(snap.BlockCache.Size))
+	if capSrc, ok := src.Source.(PebbleCacheCapacitySource); ok {
+		if capBytes := capSrc.BlockCacheCapacityBytes(); capBytes > 0 {
+			c.metrics.blockCacheCapacityBytes.WithLabelValues(group).Set(float64(capBytes))
+		}
+	}
+
+	// Monotonic counters: emit only the positive delta. A smaller value
+	// means the source was reset (store reopened); rebase silently
+	// without emitting negative.
+	prev := c.previous[src.GroupID]
+	curr := pebbleSnapshot{
+		compactCount:     snap.Compact.Count,
+		blockCacheHits:   snap.BlockCache.Hits,
+		blockCacheMisses: snap.BlockCache.Misses,
+	}
+	if curr.compactCount > prev.compactCount {
+		c.metrics.compactCountTotal.WithLabelValues(group).Add(float64(curr.compactCount - prev.compactCount))
+	}
+	if curr.blockCacheHits > prev.blockCacheHits {
+		c.metrics.blockCacheHitsTotal.WithLabelValues(group).Add(float64(curr.blockCacheHits - prev.blockCacheHits))
+	}
+	if curr.blockCacheMisses > prev.blockCacheMisses {
+		c.metrics.blockCacheMissesTotal.WithLabelValues(group).Add(float64(curr.blockCacheMisses - prev.blockCacheMisses))
+	}
+	c.previous[src.GroupID] = curr
 }

--- a/monitoring/pebble_test.go
+++ b/monitoring/pebble_test.go
@@ -31,6 +31,19 @@ func (f *fakePebbleSource) Metrics() *pebble.Metrics {
 	return f.metrics
 }
 
+// fakePebbleCapacitySource additionally implements PebbleCacheCapacitySource
+// so the collector emits elastickv_pebble_block_cache_capacity_bytes.
+type fakePebbleCapacitySource struct {
+	fakePebbleSource
+	capacity int64
+}
+
+func (f *fakePebbleCapacitySource) BlockCacheCapacityBytes() int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.capacity
+}
+
 // newFakeMetrics builds a *pebble.Metrics populated only with the
 // fields the collector reads. Other fields stay at their zero value.
 func newFakeMetrics(l0Sub int32, l0Files int64, debt uint64, inProg int64, compactCount int64,
@@ -188,6 +201,58 @@ func TestPebbleCollectorSkipsNilSnapshot(t *testing.T) {
 	// No gauges or counters should exist yet.
 	require.Equal(t, 0, testutil.CollectAndCount(registry.pebble.l0Sublevels))
 	require.Equal(t, 0, testutil.CollectAndCount(registry.pebble.compactCountTotal))
+}
+
+func TestPebbleCollectorEmitsBlockCacheCapacity(t *testing.T) {
+	// When the source implements PebbleCacheCapacitySource, the
+	// collector mirrors the configured capacity into
+	// elastickv_pebble_block_cache_capacity_bytes alongside the current
+	// usage gauge. This lets operators see a low hit rate and
+	// immediately tell whether the cache is undersized vs simply cold.
+	registry := NewRegistry("n1", "10.0.0.1:50051")
+	collector := registry.PebbleCollector()
+	require.NotNil(t, collector)
+
+	src := &fakePebbleCapacitySource{capacity: 256 << 20}
+	src.set(newFakeMetrics(
+		0, 0, 0, 0, 0,
+		0, 0, 0,
+		4096, 0, 0,
+	))
+	sources := []PebbleSource{{GroupID: 3, GroupIDStr: "3", Source: src}}
+	collector.ObserveOnce(sources)
+
+	err := testutil.GatherAndCompare(
+		registry.Gatherer(),
+		strings.NewReader(`
+# HELP elastickv_pebble_block_cache_capacity_bytes Configured maximum size of Pebble's block cache in bytes. Paired with elastickv_pebble_block_cache_size_bytes so operators can see usage relative to capacity and with the hit/miss counters so they can reason about whether a low hit rate reflects a cold cache or an undersized one.
+# TYPE elastickv_pebble_block_cache_capacity_bytes gauge
+elastickv_pebble_block_cache_capacity_bytes{group="3",node_address="10.0.0.1:50051",node_id="n1"} 2.68435456e+08
+# HELP elastickv_pebble_block_cache_size_bytes Current bytes in use by Pebble's block cache.
+# TYPE elastickv_pebble_block_cache_size_bytes gauge
+elastickv_pebble_block_cache_size_bytes{group="3",node_address="10.0.0.1:50051",node_id="n1"} 4096
+`),
+		"elastickv_pebble_block_cache_capacity_bytes",
+		"elastickv_pebble_block_cache_size_bytes",
+	)
+	require.NoError(t, err)
+}
+
+func TestPebbleCollectorSkipsCapacityWhenUnsupported(t *testing.T) {
+	// A PebbleMetricsSource that does NOT additionally implement
+	// PebbleCacheCapacitySource must not cause the capacity gauge to be
+	// populated for its group. This preserves backward compatibility
+	// with sources that pre-date the capacity interface.
+	registry := NewRegistry("n1", "10.0.0.1:50051")
+	collector := registry.PebbleCollector()
+	require.NotNil(t, collector)
+
+	src := &fakePebbleSource{}
+	src.set(newFakeMetrics(0, 0, 0, 0, 0, 0, 0, 0, 1024, 0, 0))
+	collector.ObserveOnce([]PebbleSource{{GroupID: 4, GroupIDStr: "4", Source: src}})
+
+	// The capacity vector should remain empty (no label sets observed).
+	require.Equal(t, 0, testutil.CollectAndCount(registry.pebble.blockCacheCapacityBytes))
 }
 
 func TestPebbleCollectorZeroRegistryIsSafe(t *testing.T) {

--- a/store/lsm_store.go
+++ b/store/lsm_store.go
@@ -51,9 +51,10 @@ const (
 	// out-of-range values fall back to the default.
 	pebbleCacheMBEnv = "ELASTICKV_PEBBLE_CACHE_MB"
 
-	// pebbleCacheMBMin / pebbleCacheMBMax clamp the env override. The 8 MiB
-	// floor preserves pebble's sanity baseline; the 64 GiB ceiling guards
-	// against typos ("65536" instead of "6553").
+	// pebbleCacheMBMin / pebbleCacheMBMax define the accepted range for the
+	// env override. Values below the 8 MiB floor or above the 64 GiB ceiling
+	// are rejected and fall back to the default; the ceiling guards against
+	// typos ("65536" instead of "6553").
 	pebbleCacheMBMin = 8
 	pebbleCacheMBMax = 65536
 
@@ -78,9 +79,10 @@ func init() {
 }
 
 // resolvePebbleCacheBytes parses an ELASTICKV_PEBBLE_CACHE_MB value and
-// returns the clamped cache size in bytes. Empty, malformed, or
-// out-of-range values fall back to the default. "0" is treated as
-// out-of-range (below the 8 MiB floor) and also falls back to the default.
+// returns the resolved cache size in bytes. Empty, malformed, or
+// out-of-range values are rejected and fall back to the default rather
+// than being clamped to the nearest bound. "0" is below the 8 MiB floor
+// and therefore also falls back to the default.
 func resolvePebbleCacheBytes(envVal string) int64 {
 	if envVal == "" {
 		return defaultPebbleCacheBytes
@@ -137,29 +139,21 @@ func WithPebbleLogger(l *slog.Logger) PebbleStoreOption {
 	}
 }
 
-// defaultPebbleOptions returns the standard Pebble options used throughout
-// the store (including restores) to ensure consistent behaviour between a
-// freshly opened and a restored/swapped-in database.
+// defaultPebbleOptionsWithCache returns the standard Pebble options used
+// throughout the store (including restores) to ensure consistent behaviour
+// between a freshly opened and a restored/swapped-in database, along with
+// the owned *pebble.Cache handle.
 //
 // FormatMajorVersion is pinned to ratchet v1-era DBs above pebble v2's
 // FormatMinSupported (FormatFlushableIngest) before the v2 upgrade lands.
 //
 // The returned options carry a freshly-allocated block cache sized from
 // pebbleCacheBytes. pebble.NewCache hands back a refcounted Cache with
-// ref=1; pebble.Open adds one reference, so the caller must Unref the
-// returned cache after the DB is closed to fully release the memory. Use
-// defaultPebbleOptionsWithCache when you need that handle explicitly; this
-// wrapper is kept for callers that only want *pebble.Options and are
-// content to let the cache live for the process lifetime.
-func defaultPebbleOptions() *pebble.Options {
-	opts, _ := defaultPebbleOptionsWithCache()
-	return opts
-}
-
-// defaultPebbleOptionsWithCache is like defaultPebbleOptions but also
-// returns the owned *pebble.Cache reference so the caller can Unref it
-// after the DB is closed to avoid accumulating caches across repeated
-// Open/Close cycles.
+// ref=1; pebble.Open adds one reference, so the caller MUST Unref the
+// returned cache after the DB is closed (or after pebble.Open fails) to
+// fully release the memory. Callers that only need *pebble.Options should
+// still take the cache handle and defer its Unref to avoid leaking a
+// 256 MiB (default) allocation per call.
 func defaultPebbleOptionsWithCache() (*pebble.Options, *pebble.Cache) {
 	cache := pebble.NewCache(pebbleCacheBytes)
 	opts := &pebble.Options{
@@ -194,22 +188,34 @@ func NewPebbleStore(dir string, opts ...PebbleStoreOption) (MVCCStore, error) {
 	s.db = db
 	s.cache = cache
 
+	// cleanupOnInitFail closes the just-opened DB and releases our creator
+	// reference on the cache so that a partially corrupt store (where the
+	// metadata scans below fail) does not leak the ~256 MiB cache
+	// allocation. Also nil's out the store pointers so a zero-valued
+	// pebbleStore does not linger with stale refs.
+	cleanupOnInitFail := func() {
+		_ = db.Close()
+		cache.Unref()
+		s.db = nil
+		s.cache = nil
+	}
+
 	// Initialize lastCommitTS by scanning specifically or persisting it separately.
 	// For simplicity, we scan on startup to find the max TS.
 	// In a production system, this should be stored in a separate meta key.
 	maxTS, err := s.findMaxCommitTS()
 	if err != nil {
-		_ = db.Close()
+		cleanupOnInitFail()
 		return nil, err
 	}
 	minRetainedTS, err := s.findMinRetainedTS()
 	if err != nil {
-		_ = db.Close()
+		cleanupOnInitFail()
 		return nil, err
 	}
 	pendingMinRetainedTS, err := s.findPendingMinRetainedTS()
 	if err != nil {
-		_ = db.Close()
+		cleanupOnInitFail()
 		return nil, err
 	}
 	s.lastCommitTS = maxTS
@@ -1864,22 +1870,28 @@ func (s *pebbleStore) swapInTempDB(tmpDir string) error {
 	}
 	s.db = newDB
 	s.cache = cache
+	// cleanupOnSwapFail mirrors the cleanup in NewPebbleStore: release the
+	// creator ref on the freshly-opened cache so a failed metadata read
+	// does not pin a ~256 MiB cache on the store across restore retries.
+	cleanupOnSwapFail := func() {
+		_ = newDB.Close()
+		cache.Unref()
+		s.db = nil
+		s.cache = nil
+	}
 	lastCommitTS, err := s.findMaxCommitTS()
 	if err != nil {
-		_ = newDB.Close()
-		s.db = nil
+		cleanupOnSwapFail()
 		return err
 	}
 	minRetainedTS, err := s.findMinRetainedTS()
 	if err != nil {
-		_ = newDB.Close()
-		s.db = nil
+		cleanupOnSwapFail()
 		return err
 	}
 	pendingMinRetainedTS, err := s.findPendingMinRetainedTS()
 	if err != nil {
-		_ = newDB.Close()
-		s.db = nil
+		cleanupOnSwapFail()
 		return err
 	}
 	s.lastCommitTS = lastCommitTS

--- a/store/lsm_store.go
+++ b/store/lsm_store.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 
 	"github.com/cockroachdb/errors"
@@ -36,7 +37,63 @@ const (
 	// avoids rejecting keys that are valid at the user-key level but slightly
 	// exceed maxSnapshotKeySize once the timestamp suffix is appended.
 	maxPebbleEncodedKeySize = maxSnapshotKeySize + timestampSize
+
+	// defaultPebbleCacheBytes is the default Pebble block-cache capacity per
+	// store. Pebble's built-in EnsureDefaults() supplies only 8 MiB, which
+	// is far too small for our workloads: production observed a block-cache
+	// hit rate of 0.003% (1.8B misses vs 58k hits) because the working set
+	// evicted faster than it filled. 256 MiB is a conservative baseline per
+	// shard; operators can override via ELASTICKV_PEBBLE_CACHE_MB.
+	defaultPebbleCacheBytes int64 = 256 << 20
+
+	// pebbleCacheMBEnv is the env var operators use to override the per-store
+	// Pebble block-cache capacity. Units are MiB, integer only. Malformed or
+	// out-of-range values fall back to the default.
+	pebbleCacheMBEnv = "ELASTICKV_PEBBLE_CACHE_MB"
+
+	// pebbleCacheMBMin / pebbleCacheMBMax clamp the env override. The 8 MiB
+	// floor preserves pebble's sanity baseline; the 64 GiB ceiling guards
+	// against typos ("65536" instead of "6553").
+	pebbleCacheMBMin = 8
+	pebbleCacheMBMax = 65536
+
+	// mebibyteShift converts MiB to bytes via x << mebibyteShift. Named to
+	// avoid a magic-number lint violation on the shift amount.
+	mebibyteShift = 20
 )
+
+// pebbleCacheBytes is the effective per-store Pebble block-cache capacity,
+// resolved once at process start. Exposed as a package variable so tests can
+// swap it via setPebbleCacheBytesForTest; production code treats it as
+// read-only after init().
+//
+// TODO(perf/pebble): introduce a process-wide shared cache plumbed through
+// NewPebbleStore so all shards on a node share one LRU eviction pool rather
+// than each carrying an independent 256 MiB budget. That requires changing
+// NewPebbleStore's signature and is deferred to a follow-up PR.
+var pebbleCacheBytes = defaultPebbleCacheBytes
+
+func init() {
+	pebbleCacheBytes = resolvePebbleCacheBytes(os.Getenv(pebbleCacheMBEnv))
+}
+
+// resolvePebbleCacheBytes parses an ELASTICKV_PEBBLE_CACHE_MB value and
+// returns the clamped cache size in bytes. Empty, malformed, or
+// out-of-range values fall back to the default. "0" is treated as
+// out-of-range (below the 8 MiB floor) and also falls back to the default.
+func resolvePebbleCacheBytes(envVal string) int64 {
+	if envVal == "" {
+		return defaultPebbleCacheBytes
+	}
+	mb, err := strconv.Atoi(envVal)
+	if err != nil {
+		return defaultPebbleCacheBytes
+	}
+	if mb < pebbleCacheMBMin || mb > pebbleCacheMBMax {
+		return defaultPebbleCacheBytes
+	}
+	return int64(mb) << mebibyteShift
+}
 
 var metaLastCommitTSBytes = []byte(metaLastCommitTS)
 var metaMinRetainedTSBytes = []byte(metaMinRetainedTS)
@@ -54,7 +111,8 @@ var metaPendingMinRetainedTSBytes = []byte(metaPendingMinRetainedTS)
 //     (lastCommitTS, minRetainedTS, pendingMinRetainedTS).
 type pebbleStore struct {
 	db                   *pebble.DB
-	dbMu                 sync.RWMutex // guards s.db pointer – see lock ordering above
+	cache                *pebble.Cache // owns one ref; Unref on Close / reopen.
+	dbMu                 sync.RWMutex  // guards s.db pointer – see lock ordering above
 	log                  *slog.Logger
 	lastCommitTS         uint64
 	minRetainedTS        uint64
@@ -85,14 +143,34 @@ func WithPebbleLogger(l *slog.Logger) PebbleStoreOption {
 //
 // FormatMajorVersion is pinned to ratchet v1-era DBs above pebble v2's
 // FormatMinSupported (FormatFlushableIngest) before the v2 upgrade lands.
+//
+// The returned options carry a freshly-allocated block cache sized from
+// pebbleCacheBytes. pebble.NewCache hands back a refcounted Cache with
+// ref=1; pebble.Open adds one reference, so the caller must Unref the
+// returned cache after the DB is closed to fully release the memory. Use
+// defaultPebbleOptionsWithCache when you need that handle explicitly; this
+// wrapper is kept for callers that only want *pebble.Options and are
+// content to let the cache live for the process lifetime.
 func defaultPebbleOptions() *pebble.Options {
+	opts, _ := defaultPebbleOptionsWithCache()
+	return opts
+}
+
+// defaultPebbleOptionsWithCache is like defaultPebbleOptions but also
+// returns the owned *pebble.Cache reference so the caller can Unref it
+// after the DB is closed to avoid accumulating caches across repeated
+// Open/Close cycles.
+func defaultPebbleOptionsWithCache() (*pebble.Options, *pebble.Cache) {
+	cache := pebble.NewCache(pebbleCacheBytes)
 	opts := &pebble.Options{
 		FS:                 vfs.Default,
 		FormatMajorVersion: pebble.FormatVirtualSSTables,
+		Cache:              cache,
 	}
 	// Enable automatic compactions and apply all other Pebble defaults.
+	// EnsureDefaults leaves Cache alone because we already set it.
 	opts.EnsureDefaults()
-	return opts
+	return opts, cache
 }
 
 // NewPebbleStore creates a new Pebble-backed MVCC store.
@@ -107,11 +185,14 @@ func NewPebbleStore(dir string, opts ...PebbleStoreOption) (MVCCStore, error) {
 		opt(s)
 	}
 
-	db, err := pebble.Open(dir, defaultPebbleOptions())
+	pebbleOpts, cache := defaultPebbleOptionsWithCache()
+	db, err := pebble.Open(dir, pebbleOpts)
 	if err != nil {
+		cache.Unref()
 		return nil, errors.WithStack(err)
 	}
 	s.db = db
+	s.cache = cache
 
 	// Initialize lastCommitTS by scanning specifically or persisting it separately.
 	// For simplicity, we scan on startup to find the max TS.
@@ -1504,6 +1585,10 @@ func (s *pebbleStore) reopenFreshDB() error {
 		if err := s.db.Close(); err != nil {
 			return errors.WithStack(err)
 		}
+		if s.cache != nil {
+			s.cache.Unref()
+			s.cache = nil
+		}
 	}
 	if err := os.RemoveAll(s.dir); err != nil {
 		return errors.WithStack(err)
@@ -1511,11 +1596,14 @@ func (s *pebbleStore) reopenFreshDB() error {
 	if err := os.MkdirAll(s.dir, dirPerms); err != nil {
 		return errors.WithStack(err)
 	}
-	db, err := pebble.Open(s.dir, defaultPebbleOptions())
+	opts, cache := defaultPebbleOptionsWithCache()
+	db, err := pebble.Open(s.dir, opts)
 	if err != nil {
+		cache.Unref()
 		return errors.WithStack(err)
 	}
 	s.db = db
+	s.cache = cache
 	return nil
 }
 
@@ -1622,10 +1710,16 @@ func makeSiblingTempDir(dir, tag string) (string, error) {
 // Pebble database at tmpDir, persists ts as the lastCommitTS meta-key, then
 // closes the database.
 func writeNativeSnapshotToTempDir(r io.Reader, tmpDir string, ts uint64) error {
-	tmpDB, err := pebble.Open(tmpDir, defaultPebbleOptions())
+	opts, cache := defaultPebbleOptionsWithCache()
+	tmpDB, err := pebble.Open(tmpDir, opts)
 	if err != nil {
+		cache.Unref()
 		return errors.WithStack(err)
 	}
+	// The tmpDB is discarded once swapInTempDB renames its directory over
+	// s.dir (which reopens with a fresh cache), so release our creator ref
+	// as soon as we're done writing to avoid leaking per-snapshot caches.
+	defer cache.Unref()
 
 	if err := restoreBatchLoopInto(r, tmpDB); err != nil {
 		_ = tmpDB.Close()
@@ -1667,10 +1761,16 @@ func writeStreamingMVCCRestoreTempDB(dir string, body io.Reader, hash hash.Hash3
 	if err := os.RemoveAll(tmpDir); err != nil {
 		return "", errors.WithStack(err)
 	}
-	tmpDB, err := pebble.Open(tmpDir, defaultPebbleOptions())
+	opts, cache := defaultPebbleOptionsWithCache()
+	tmpDB, err := pebble.Open(tmpDir, opts)
 	if err != nil {
+		cache.Unref()
 		return "", errors.WithStack(err)
 	}
+	// As in writeNativeSnapshotToTempDir, the tmpDB is discarded once the
+	// directory is renamed, so drop our creator ref when this helper
+	// returns. swapInTempDB reopens with a fresh cache.
+	defer cache.Unref()
 	cleanupTmp := func() {
 		_ = tmpDB.Close()
 		_ = os.RemoveAll(tmpDir)
@@ -1744,6 +1844,10 @@ func (s *pebbleStore) swapInTempDB(tmpDir string) error {
 		_ = os.RemoveAll(tmpDir)
 		return errors.WithStack(err)
 	}
+	if s.cache != nil {
+		s.cache.Unref()
+		s.cache = nil
+	}
 	if err := os.RemoveAll(s.dir); err != nil {
 		_ = os.RemoveAll(tmpDir)
 		return errors.WithStack(err)
@@ -1752,11 +1856,14 @@ func (s *pebbleStore) swapInTempDB(tmpDir string) error {
 		_ = os.RemoveAll(tmpDir)
 		return errors.WithStack(err)
 	}
-	newDB, err := pebble.Open(s.dir, defaultPebbleOptions())
+	opts, cache := defaultPebbleOptionsWithCache()
+	newDB, err := pebble.Open(s.dir, opts)
 	if err != nil {
+		cache.Unref()
 		return errors.WithStack(err)
 	}
 	s.db = newDB
+	s.cache = cache
 	lastCommitTS, err := s.findMaxCommitTS()
 	if err != nil {
 		_ = newDB.Close()
@@ -1788,7 +1895,30 @@ func (s *pebbleStore) Close() error {
 	// before we close the database.  Lock ordering: dbMu before mtx.
 	s.dbMu.Lock()
 	defer s.dbMu.Unlock()
-	return errors.WithStack(s.db.Close())
+	err := s.db.Close()
+	// Release our creator reference on the block cache so the memory is
+	// freed once pebble has also dropped its internal reference (which
+	// Close does). Safe to call after a Close error: Unref is
+	// idempotent-friendly in that s.cache is only nilled out here, and
+	// Close() is not expected to be called twice.
+	if s.cache != nil {
+		s.cache.Unref()
+		s.cache = nil
+	}
+	return errors.WithStack(err)
+}
+
+// BlockCacheCapacityBytes returns the configured maximum size of the
+// underlying Pebble block cache in bytes, or 0 if the store is closed /
+// mid-restore. Exported for the monitoring collector so operators can graph
+// configured capacity alongside current usage.
+func (s *pebbleStore) BlockCacheCapacityBytes() int64 {
+	s.dbMu.RLock()
+	defer s.dbMu.RUnlock()
+	if s.cache == nil {
+		return 0
+	}
+	return s.cache.MaxSize()
 }
 
 // Metrics returns a snapshot of the underlying Pebble DB's operational

--- a/store/lsm_store_env_test.go
+++ b/store/lsm_store_env_test.go
@@ -1,0 +1,90 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// setPebbleCacheBytesForTest swaps the package-level pebbleCacheBytes value
+// for the duration of a single test and restores it during t.Cleanup. The
+// real override happens in init() from ELASTICKV_PEBBLE_CACHE_MB; tests use
+// this helper to exercise specific cache sizes without relying on process
+// env state.
+func setPebbleCacheBytesForTest(t *testing.T, n int64) {
+	t.Helper()
+	prev := pebbleCacheBytes
+	pebbleCacheBytes = n
+	t.Cleanup(func() { pebbleCacheBytes = prev })
+}
+
+// TestPebbleCacheEnvOverride covers the ELASTICKV_PEBBLE_CACHE_MB parsing
+// contract directly against resolvePebbleCacheBytes, which is what init()
+// calls. We deliberately avoid mutating os.Environ here so parallel test
+// binaries remain isolated.
+func TestPebbleCacheEnvOverride(t *testing.T) {
+	t.Run("valid value is parsed and converted to bytes", func(t *testing.T) {
+		got := resolvePebbleCacheBytes("64")
+		require.Equal(t, int64(64)<<20, got)
+	})
+
+	t.Run("empty string falls back to default", func(t *testing.T) {
+		require.Equal(t, defaultPebbleCacheBytes, resolvePebbleCacheBytes(""))
+	})
+
+	t.Run("garbage input falls back to default", func(t *testing.T) {
+		require.Equal(t, defaultPebbleCacheBytes, resolvePebbleCacheBytes("garbage"))
+	})
+
+	t.Run("zero is rejected and default is applied", func(t *testing.T) {
+		// "0" is below the 8 MiB floor, so we fall back to the default
+		// rather than silently clamping. Documented behaviour: only
+		// values inside [8, 65536] MiB are accepted; everything else
+		// falls back.
+		require.Equal(t, defaultPebbleCacheBytes, resolvePebbleCacheBytes("0"))
+	})
+
+	t.Run("below floor falls back to default", func(t *testing.T) {
+		require.Equal(t, defaultPebbleCacheBytes, resolvePebbleCacheBytes("4"))
+	})
+
+	t.Run("at floor is accepted", func(t *testing.T) {
+		require.Equal(t, int64(8)<<20, resolvePebbleCacheBytes("8"))
+	})
+
+	t.Run("at ceiling is accepted", func(t *testing.T) {
+		require.Equal(t, int64(65536)<<20, resolvePebbleCacheBytes("65536"))
+	})
+
+	t.Run("above ceiling falls back to default", func(t *testing.T) {
+		require.Equal(t, defaultPebbleCacheBytes, resolvePebbleCacheBytes("65537"))
+	})
+
+	t.Run("negative falls back to default", func(t *testing.T) {
+		require.Equal(t, defaultPebbleCacheBytes, resolvePebbleCacheBytes("-1"))
+	})
+}
+
+// TestSetPebbleCacheBytesForTestRestores verifies the helper reinstates the
+// previous value via t.Cleanup so tests that tweak pebbleCacheBytes do not
+// leak state to later tests in the package.
+func TestSetPebbleCacheBytesForTestRestores(t *testing.T) {
+	before := pebbleCacheBytes
+	t.Run("inner", func(t *testing.T) {
+		setPebbleCacheBytesForTest(t, 16<<20)
+		require.Equal(t, int64(16)<<20, pebbleCacheBytes)
+	})
+	require.Equal(t, before, pebbleCacheBytes)
+}
+
+// TestDefaultPebbleOptionsCarriesCache sanity-checks that the options
+// constructor wires a cache through at the configured size and that Unref
+// is safe to call after closing the DB (the primary lifecycle path).
+func TestDefaultPebbleOptionsCarriesCache(t *testing.T) {
+	setPebbleCacheBytesForTest(t, 16<<20)
+	opts, cache := defaultPebbleOptionsWithCache()
+	require.NotNil(t, cache)
+	require.Same(t, cache, opts.Cache)
+	require.Equal(t, int64(16)<<20, cache.MaxSize())
+	cache.Unref()
+}

--- a/store/lsm_store_test.go
+++ b/store/lsm_store_test.go
@@ -509,9 +509,13 @@ func TestSnapshotBatchShouldFlushOnByteLimit(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	db, err := pebble.Open(dir, defaultPebbleOptions())
+	opts, cache := defaultPebbleOptionsWithCache()
+	db, err := pebble.Open(dir, opts)
 	require.NoError(t, err)
-	defer func() { assert.NoError(t, db.Close()) }()
+	defer func() {
+		assert.NoError(t, db.Close())
+		cache.Unref()
+	}()
 
 	batch := db.NewBatch()
 	defer func() { assert.NoError(t, batch.Close()) }()


### PR DESCRIPTION
## Summary

- Production Pebble block-cache hit rate was 0.003% (1.8B misses vs 58k hits, `block_cache_size_bytes=0`) because `defaultPebbleOptions` never set `Cache` and `EnsureDefaults` supplied pebble's built-in 8 MiB baseline, which churned immediately against the working set.
- Populate `Cache: pebble.NewCache(pebbleCacheBytes)` with a 256 MiB per-store default. Override contract: `ELASTICKV_PEBBLE_CACHE_MB` (integer MiB, clamped to `[8, 65536]`; empty / malformed / out-of-range values fall back to the default, including `"0"` which is below the floor).
- Track the cache ref on `pebbleStore` and `Unref` it in `Close`, `reopenFreshDB`, and `swapInTempDB`; transient tmpDB opens (snapshot restore) Unref their cache on the way out so a restore cycle no longer leaks a 256 MiB cache.
- Add `elastickv_pebble_block_cache_capacity_bytes` gauge in `monitoring/pebble.go`, sourced from a new optional `PebbleCacheCapacitySource` interface (`*pebbleStore.BlockCacheCapacityBytes()` returns `Cache.MaxSize()`). Operators can now see configured capacity alongside current usage.

A process-wide shared cache plumbed through `NewPebbleStore` is deferred to a follow-up PR (marked with a `TODO(perf/pebble)` comment) because it requires changing the constructor signature and all call sites.

## Test plan

- [x] `go test -race -count=1 ./store/... ./monitoring/...`
- [x] `make lint`
- [x] `TestPebbleCacheEnvOverride` covers empty / garbage / 0 / below floor / at both bounds / above ceiling / negative
- [x] `TestDefaultPebbleOptionsCarriesCache` verifies the cache is wired at the configured size
- [x] `TestPebbleCollectorEmitsBlockCacheCapacity` and `TestPebbleCollectorSkipsCapacityWhenUnsupported` cover the new capacity gauge
- [ ] Observe production `elastickv_pebble_block_cache_capacity_bytes == 268435456` and hit rate climbing after rollout
