### PR TITLE
fix(raft): retention GC for fsm snapshots + tunable snapshot trigger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/tidwall/redcon v1.6.2
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	github.com/yuin/gopher-lua v1.1.2
+	go.etcd.io/etcd/client/pkg/v3 v3.6.10
 	go.etcd.io/etcd/server/v3 v3.6.10
 	go.etcd.io/raft/v3 v3.6.0
 	go.uber.org/zap v1.27.1
@@ -100,7 +101,6 @@ require (
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	go.etcd.io/bbolt v1.4.3 // indirect
 	go.etcd.io/etcd/api/v3 v3.6.10 // indirect
-	go.etcd.io/etcd/client/pkg/v3 v3.6.10 // indirect
 	go.etcd.io/etcd/client/v3 v3.6.10 // indirect
 	go.etcd.io/etcd/pkg/v3 v3.6.10 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -181,15 +181,26 @@ type Engine struct {
 	// once at Open from ELASTICKV_RAFT_DISPATCHER_LANES so the run-time code
 	// path is branch-free per message and does not need to re-read env vars.
 	dispatcherLanesEnabled bool
-	dispatchStopCh         chan struct{}
-	dispatchCtx            context.Context
-	dispatchCancel         context.CancelFunc
-	snapshotReqCh          chan snapshotRequest
-	snapshotResCh          chan snapshotResult
-	snapshotStopCh         chan struct{}
-	closeCh                chan struct{}
-	doneCh                 chan struct{}
-	startedCh              chan struct{}
+	// snapshotEvery is the FSM-snapshot trigger threshold captured once at
+	// Open from ELASTICKV_RAFT_SNAPSHOT_COUNT. maybePersistLocalSnapshot
+	// runs on every Ready-drain pass, so re-parsing the env var (and
+	// potentially emitting a warning on malformed input) on every call
+	// would flood logs and burn CPU on the raft hot path. Cache it once.
+	snapshotEvery uint64
+	// maxWALFiles is the WAL retention cap captured once at Open from
+	// ELASTICKV_RAFT_MAX_WAL_FILES. Purges are relatively rare (only after
+	// snapshot release) but caching avoids a second warning-per-invalid
+	// call site and keeps the knob consistent across the engine lifetime.
+	maxWALFiles    int
+	dispatchStopCh chan struct{}
+	dispatchCtx    context.Context
+	dispatchCancel context.CancelFunc
+	snapshotReqCh  chan snapshotRequest
+	snapshotResCh  chan snapshotResult
+	snapshotStopCh chan struct{}
+	closeCh        chan struct{}
+	doneCh         chan struct{}
+	startedCh      chan struct{}
 
 	leaderReady  chan struct{}
 	leaderOnce   sync.Once
@@ -437,6 +448,13 @@ func Open(ctx context.Context, cfg OpenConfig) (*Engine, error) {
 		pendingProposals: map[uint64]proposalRequest{},
 		pendingReads:     map[uint64]readRequest{},
 		pendingConfigs:   map[uint64]adminRequest{},
+		// Parse env-tunable retention/snapshot knobs once at Open. Both
+		// are consulted on hot paths (maybePersistLocalSnapshot runs per
+		// Ready-drain; purge runs after each snapshot persist) and the
+		// underlying env parsers emit warnings on malformed input, so
+		// re-reading them would flood logs under a misconfiguration.
+		snapshotEvery: snapshotEveryFromEnv(),
+		maxWALFiles:   maxWALFilesFromEnv(),
 	}
 	engine.configIndex.Store(maxAppliedIndex(prepared.disk.LocalSnap))
 	engine.appliedIndex.Store(maxAppliedIndex(prepared.disk.LocalSnap))
@@ -1668,7 +1686,7 @@ func (e *Engine) maybePersistLocalSnapshot() error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	if e.applied <= current.Metadata.Index || e.applied-current.Metadata.Index < snapshotEveryFromEnv() {
+	if e.applied <= current.Metadata.Index || e.applied-current.Metadata.Index < e.snapshotThreshold() {
 		return nil
 	}
 	snapshot, err := e.fsm.Snapshot()
@@ -2779,6 +2797,31 @@ func (e *Engine) startPeerDispatcher(nodeID uint64) {
 	}
 }
 
+// walRetention returns the WAL segment retention cap for this engine. As
+// with snapshotThreshold, the value is cached at Open so the purge path
+// does not re-parse ELASTICKV_RAFT_MAX_WAL_FILES on every snapshot release.
+// A zero cache (tests that bypass Open) falls back to defaultMaxWALFiles.
+func (e *Engine) walRetention() int {
+	if e.maxWALFiles == 0 {
+		return defaultMaxWALFiles
+	}
+	return e.maxWALFiles
+}
+
+// snapshotThreshold returns the FSM-snapshot trigger threshold for this
+// engine. The value is cached once at Open via snapshotEveryFromEnv so the
+// hot path (maybePersistLocalSnapshot runs per Ready-drain) does not re-parse
+// the env var or re-emit warnings on every loop iteration. When the engine is
+// constructed directly (e.g. in unit tests that bypass Open) snapshotEvery is
+// zero; fall back to defaultSnapshotEvery rather than treating zero as "never
+// snapshot", which would silently break those tests.
+func (e *Engine) snapshotThreshold() uint64 {
+	if e.snapshotEvery == 0 {
+		return defaultSnapshotEvery
+	}
+	return e.snapshotEvery
+}
+
 // snapshotEveryFromEnv returns the FSM-snapshot trigger threshold (in applied
 // raft entries past the last snapshot). Operators can override via
 // ELASTICKV_RAFT_SNAPSHOT_COUNT; invalid or missing values fall back to
@@ -3289,7 +3332,7 @@ func (e *Engine) persistLocalSnapshotPayload(index uint64, payload []byte) error
 			slog.Warn("failed to purge old snap files", "error", purgeErr)
 		}
 		walDir := filepath.Join(e.dataDir, walDirName)
-		if purgeErr := purgeOldWALFiles(walDir, maxWALFilesFromEnv()); purgeErr != nil {
+		if purgeErr := purgeOldWALFiles(walDir, e.walRetention()); purgeErr != nil {
 			slog.Warn("failed to purge old wal files", "error", purgeErr)
 		}
 		return nil

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -2093,7 +2093,7 @@ func (e *Engine) persistCreatedSnapshot(snap raftpb.Snapshot) error {
 		slog.Warn("failed to purge old snap files", "error", purgeErr)
 	}
 	walDir := filepath.Join(e.dataDir, walDirName)
-	if purgeErr := purgeOldWALFiles(walDir, maxWALFilesFromEnv()); purgeErr != nil {
+	if purgeErr := purgeOldWALFiles(walDir, e.walRetention()); purgeErr != nil {
 		slog.Warn("failed to purge old wal files", "error", purgeErr)
 	}
 	return nil

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -82,8 +82,15 @@ const (
 	// 2-lane layout (heartbeat + normal) is used. Opt-in by design: the
 	// raft hot path is high blast radius and a regression here can cause
 	// cluster-wide elections.
-	dispatcherLanesEnvVar    = "ELASTICKV_RAFT_DISPATCHER_LANES"
+	dispatcherLanesEnvVar = "ELASTICKV_RAFT_DISPATCHER_LANES"
+	// defaultSnapshotEvery is the fallback trigger threshold: take an FSM
+	// snapshot once the applied index has advanced this many entries past
+	// the last snapshot's index. etcd/raft itself uses 10_000 as a default,
+	// but with fat proposal payloads (e.g. Lua scripts) this can produce a
+	// multi-GiB WAL between snapshots. Operators can lower via
+	// ELASTICKV_RAFT_SNAPSHOT_COUNT without a rebuild.
 	defaultSnapshotEvery     = 10_000
+	snapshotEveryEnvVar      = "ELASTICKV_RAFT_SNAPSHOT_COUNT"
 	defaultSnapshotQueueSize = 1
 	defaultAdminPollInterval = 10 * time.Millisecond
 	defaultMaxPendingConfigs = 64
@@ -1661,7 +1668,7 @@ func (e *Engine) maybePersistLocalSnapshot() error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	if e.applied <= current.Metadata.Index || e.applied-current.Metadata.Index < defaultSnapshotEvery {
+	if e.applied <= current.Metadata.Index || e.applied-current.Metadata.Index < snapshotEveryFromEnv() {
 		return nil
 	}
 	snapshot, err := e.fsm.Snapshot()
@@ -2066,6 +2073,10 @@ func (e *Engine) persistCreatedSnapshot(snap raftpb.Snapshot) error {
 	snapDir := filepath.Join(e.dataDir, snapDirName)
 	if purgeErr := purgeOldSnapshotFiles(snapDir, e.fsmSnapDir); purgeErr != nil {
 		slog.Warn("failed to purge old snap files", "error", purgeErr)
+	}
+	walDir := filepath.Join(e.dataDir, walDirName)
+	if purgeErr := purgeOldWALFiles(walDir, maxWALFilesFromEnv()); purgeErr != nil {
+		slog.Warn("failed to purge old wal files", "error", purgeErr)
 	}
 	return nil
 }
@@ -2768,6 +2779,29 @@ func (e *Engine) startPeerDispatcher(nodeID uint64) {
 	}
 }
 
+// snapshotEveryFromEnv returns the FSM-snapshot trigger threshold (in applied
+// raft entries past the last snapshot). Operators can override via
+// ELASTICKV_RAFT_SNAPSHOT_COUNT; invalid or missing values fall back to
+// defaultSnapshotEvery. Values < 1 are clamped to 1 rather than rejected so a
+// misconfiguration errs on the side of MORE-frequent snapshots (smaller WAL
+// footprint) instead of disabling snapshotting entirely.
+func snapshotEveryFromEnv() uint64 {
+	v := strings.TrimSpace(os.Getenv(snapshotEveryEnvVar))
+	if v == "" {
+		return defaultSnapshotEvery
+	}
+	n, err := strconv.ParseUint(v, 10, 64)
+	if err != nil {
+		slog.Warn("invalid ELASTICKV_RAFT_SNAPSHOT_COUNT; using default",
+			"value", v, "default", defaultSnapshotEvery)
+		return defaultSnapshotEvery
+	}
+	if n < 1 {
+		return 1
+	}
+	return n
+}
+
 // dispatcherLanesEnabledFromEnv returns true when the 4-lane dispatcher has
 // been explicitly opted into via ELASTICKV_RAFT_DISPATCHER_LANES. The value
 // is parsed with strconv.ParseBool, which accepts the standard tokens
@@ -3253,6 +3287,10 @@ func (e *Engine) persistLocalSnapshotPayload(index uint64, payload []byte) error
 		snapDir := filepath.Join(e.dataDir, snapDirName)
 		if purgeErr := purgeOldSnapshotFiles(snapDir, e.fsmSnapDir); purgeErr != nil {
 			slog.Warn("failed to purge old snap files", "error", purgeErr)
+		}
+		walDir := filepath.Join(e.dataDir, walDirName)
+		if purgeErr := purgeOldWALFiles(walDir, maxWALFilesFromEnv()); purgeErr != nil {
+			slog.Warn("failed to purge old wal files", "error", purgeErr)
 		}
 		return nil
 	case errors.Is(err, etcdraft.ErrCompacted):

--- a/internal/raftengine/etcd/wal_purge.go
+++ b/internal/raftengine/etcd/wal_purge.go
@@ -1,0 +1,132 @@
+package etcd
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"go.etcd.io/etcd/client/pkg/v3/fileutil"
+)
+
+// defaultMaxWALFiles is the number of .wal segment files to retain after a
+// successful snapshot. etcd's wal package allocates segments of 64 MiB each;
+// keeping the most recent N segments bounds WAL disk usage at ~N * 64 MiB.
+//
+// Rationale for keeping more than 1:
+//   - The tail segment (currently being written) must always remain.
+//   - A slow follower that hasn't applied the latest snapshot can still catch
+//     up via log replication from a previous segment, avoiding an expensive
+//     full snapshot transfer.
+//   - etcd's own defaults keep max=5 segments via fileutil.PurgeFile.
+const defaultMaxWALFiles = 5
+
+// maxWALFilesEnvVar lets operators tune the WAL retention cap without a
+// rebuild. Value must parse as an integer >= 1; invalid or unset values
+// fall back to defaultMaxWALFiles.
+const maxWALFilesEnvVar = "ELASTICKV_RAFT_MAX_WAL_FILES"
+
+// walLockMode is the file mode passed to fileutil.TryLockFile when probing
+// whether a .wal segment is still held by the active writer. 0o600 matches
+// etcd's own PurgeFile behaviour (owner read/write only): the file already
+// exists so the mode is only consulted on create, but we pin it here to
+// avoid an mnd lint exception at the call site.
+const walLockMode = 0o600
+
+// maxWALFilesFromEnv returns the effective WAL retention cap. Operators can
+// override via ELASTICKV_RAFT_MAX_WAL_FILES; invalid values are ignored and
+// the default is used instead (retention is safety-critical, so we prefer a
+// conservative fallback over failing open).
+func maxWALFilesFromEnv() int {
+	v := strings.TrimSpace(os.Getenv(maxWALFilesEnvVar))
+	if v == "" {
+		return defaultMaxWALFiles
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 1 {
+		slog.Warn("invalid ELASTICKV_RAFT_MAX_WAL_FILES; using default",
+			"value", v, "default", defaultMaxWALFiles)
+		return defaultMaxWALFiles
+	}
+	return n
+}
+
+// purgeOldWALFiles removes .wal segment files beyond the keep most recent.
+//
+// Safety:
+//   - Segments still held under a flock by the active WAL writer (tail and
+//     any segments whose lock the wal package has NOT yet released via
+//     ReleaseLockTo) will refuse the TryLockFile acquire and are skipped.
+//   - Filenames are sorted lexicographically; .wal names are
+//     %016x-%016x.wal (seq-index), so lex order == chronological order.
+//   - We never delete more than (N - keep) files, so when segments are held
+//     the active tail is naturally preserved.
+//
+// This function must be called only AFTER persist.Release(snap) has run so
+// that the wal package has closed the flocks on segments strictly older
+// than the snapshot. Calling it earlier is a no-op (TryLockFile will fail
+// on every segment) rather than a safety violation.
+func purgeOldWALFiles(walDir string, keep int) error {
+	if keep < 1 {
+		keep = 1
+	}
+	entries, err := os.ReadDir(walDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return errors.WithStack(err)
+	}
+
+	names := collectWALNames(entries)
+	if len(names) <= keep {
+		return nil
+	}
+	sort.Strings(names)
+
+	victims := names[:len(names)-keep]
+	var combined error
+	for _, name := range victims {
+		full := filepath.Join(walDir, name)
+		// Try-lock so we never delete a segment the wal package still owns.
+		// If the lock fails (segment is active), skip it and continue: the
+		// next snapshot's purge pass will pick it up once Release advances.
+		l, lockErr := fileutil.TryLockFile(full, os.O_WRONLY, walLockMode)
+		if lockErr != nil {
+			slog.Debug("skipping locked wal segment", "path", full, "error", lockErr)
+			continue
+		}
+		if rmErr := os.Remove(full); rmErr != nil && !os.IsNotExist(rmErr) {
+			combined = errors.CombineErrors(combined, errors.WithStack(rmErr))
+			_ = l.Close()
+			continue
+		}
+		if closeErr := l.Close(); closeErr != nil {
+			combined = errors.CombineErrors(combined, errors.WithStack(closeErr))
+		}
+	}
+	combined = errors.CombineErrors(combined, syncDirIfExists(walDir))
+	return errors.WithStack(combined)
+}
+
+// collectWALNames returns the subset of entries that look like WAL segment
+// files. We filter by extension rather than regex-matching the full hex
+// format so that we remain forward-compatible with any future wal naming
+// tweaks — the worst case is that an unrecognised .wal file is treated as
+// an older segment, which is exactly what we want.
+func collectWALNames(entries []os.DirEntry) []string {
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if filepath.Ext(e.Name()) != ".wal" {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	return names
+}

--- a/internal/raftengine/etcd/wal_purge.go
+++ b/internal/raftengine/etcd/wal_purge.go
@@ -90,26 +90,40 @@ func purgeOldWALFiles(walDir string, keep int) error {
 	victims := names[:len(names)-keep]
 	var combined error
 	for _, name := range victims {
-		full := filepath.Join(walDir, name)
-		// Try-lock so we never delete a segment the wal package still owns.
-		// If the lock fails (segment is active), skip it and continue: the
-		// next snapshot's purge pass will pick it up once Release advances.
-		l, lockErr := fileutil.TryLockFile(full, os.O_WRONLY, walLockMode)
-		if lockErr != nil {
-			slog.Debug("skipping locked wal segment", "path", full, "error", lockErr)
-			continue
-		}
-		if rmErr := os.Remove(full); rmErr != nil && !os.IsNotExist(rmErr) {
-			combined = errors.CombineErrors(combined, errors.WithStack(rmErr))
-			_ = l.Close()
-			continue
-		}
-		if closeErr := l.Close(); closeErr != nil {
-			combined = errors.CombineErrors(combined, errors.WithStack(closeErr))
+		if err := tryPurgeWALSegment(filepath.Join(walDir, name)); err != nil {
+			combined = errors.CombineErrors(combined, err)
 		}
 	}
 	combined = errors.CombineErrors(combined, syncDirIfExists(walDir))
 	return errors.WithStack(combined)
+}
+
+// tryPurgeWALSegment attempts to delete a single .wal segment, taking a
+// flock first so we never race the active writer. Returns nil on success
+// OR when the segment is skipped because it's still locked by the wal
+// package (a transient condition that the next purge pass will clear).
+// Non-lock errors (open/permission/I/O, rm, flock-close) are returned so
+// the caller can surface them; silently swallowing them would effectively
+// disable WAL retention under filesystem faults.
+func tryPurgeWALSegment(path string) error {
+	l, lockErr := fileutil.TryLockFile(path, os.O_WRONLY, walLockMode)
+	if lockErr != nil {
+		if errors.Is(lockErr, fileutil.ErrLocked) {
+			slog.Debug("skipping locked wal segment", "path", path)
+			return nil
+		}
+		slog.Warn("wal purge: TryLockFile failed with non-lock error",
+			"path", path, "error", lockErr)
+		return errors.WithStack(lockErr)
+	}
+	if rmErr := os.Remove(path); rmErr != nil && !os.IsNotExist(rmErr) {
+		_ = l.Close()
+		return errors.WithStack(rmErr)
+	}
+	if closeErr := l.Close(); closeErr != nil {
+		return errors.WithStack(closeErr)
+	}
+	return nil
 }
 
 // collectWALNames returns the subset of entries that look like WAL segment

--- a/internal/raftengine/etcd/wal_purge_test.go
+++ b/internal/raftengine/etcd/wal_purge_test.go
@@ -1,0 +1,166 @@
+package etcd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// writeDummyWALSegment creates a plausible-looking WAL filename in dir so
+// purgeOldWALFiles has something to pick up. The wal package's naming format
+// is %016x-%016x.wal; we only need the suffix and lexicographic ordering to
+// match production so we can exercise the purge logic without standing up a
+// full wal.WAL.
+func writeDummyWALSegment(t *testing.T, dir string, seq, index uint64) string {
+	t.Helper()
+	name := fmt.Sprintf("%016x-%016x.wal", seq, index)
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte("dummy"), 0o600))
+	return name
+}
+
+// listWALFiles returns the sorted set of .wal filenames currently in dir.
+func listWALFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() && filepath.Ext(e.Name()) == ".wal" {
+			out = append(out, e.Name())
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestPurgeOldWALFiles_NoOpWhenBelowLimit(t *testing.T) {
+	dir := t.TempDir()
+	writeDummyWALSegment(t, dir, 0, 0)
+	writeDummyWALSegment(t, dir, 1, 100)
+
+	require.NoError(t, purgeOldWALFiles(dir, 5))
+
+	got := listWALFiles(t, dir)
+	require.Len(t, got, 2)
+}
+
+func TestPurgeOldWALFiles_KeepsMostRecentN(t *testing.T) {
+	dir := t.TempDir()
+	for i := uint64(0); i < 10; i++ {
+		writeDummyWALSegment(t, dir, i, i*100)
+	}
+
+	require.NoError(t, purgeOldWALFiles(dir, 3))
+
+	got := listWALFiles(t, dir)
+	// Must keep exactly the 3 newest; names are lexicographic == chronological.
+	require.Len(t, got, 3)
+	require.Equal(t, []string{
+		fmt.Sprintf("%016x-%016x.wal", 7, 700),
+		fmt.Sprintf("%016x-%016x.wal", 8, 800),
+		fmt.Sprintf("%016x-%016x.wal", 9, 900),
+	}, got)
+}
+
+func TestPurgeOldWALFiles_NeverDeletesActiveTail(t *testing.T) {
+	dir := t.TempDir()
+	// Create 5 segments; then hold an OS-level file lock on the newest one
+	// to simulate the wal package's flock on the active tail. keep=1 means
+	// the purger would WANT to delete the other 4, but the tail must remain
+	// under all circumstances.
+	var names []string
+	for i := uint64(0); i < 5; i++ {
+		names = append(names, writeDummyWALSegment(t, dir, i, i*100))
+	}
+	// keep=1 asks the purger to delete the 4 older segments; the newest is
+	// already excluded by the keep cutoff, not by locking. This verifies
+	// the "keep at least 1" invariant even with an aggressive cap.
+	require.NoError(t, purgeOldWALFiles(dir, 1))
+
+	got := listWALFiles(t, dir)
+	require.Len(t, got, 1)
+	require.Equal(t, names[len(names)-1], got[0])
+}
+
+func TestPurgeOldWALFiles_MissingDirIsNoOp(t *testing.T) {
+	// Directory that doesn't exist -> nil error, not a failure.
+	require.NoError(t, purgeOldWALFiles(filepath.Join(t.TempDir(), "no-such-dir"), 3))
+}
+
+func TestPurgeOldWALFiles_ClampsKeepToOne(t *testing.T) {
+	dir := t.TempDir()
+	for i := uint64(0); i < 4; i++ {
+		writeDummyWALSegment(t, dir, i, i*100)
+	}
+	// keep=0 is an invalid configuration; the function must clamp to 1
+	// rather than delete every segment (which would destroy the WAL).
+	require.NoError(t, purgeOldWALFiles(dir, 0))
+
+	got := listWALFiles(t, dir)
+	require.Len(t, got, 1)
+}
+
+func TestPurgeOldWALFiles_IgnoresNonWALEntries(t *testing.T) {
+	dir := t.TempDir()
+	writeDummyWALSegment(t, dir, 0, 0)
+	writeDummyWALSegment(t, dir, 1, 100)
+	writeDummyWALSegment(t, dir, 2, 200)
+	// Non-.wal files must be left untouched: operators sometimes drop
+	// hand-crafted recovery artefacts here.
+	otherPath := filepath.Join(dir, "NOTES.txt")
+	require.NoError(t, os.WriteFile(otherPath, []byte("hello"), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "subdir"), 0o700))
+
+	require.NoError(t, purgeOldWALFiles(dir, 1))
+
+	got := listWALFiles(t, dir)
+	require.Len(t, got, 1)
+	_, statErr := os.Stat(otherPath)
+	require.NoError(t, statErr, "non-wal file must not be deleted")
+}
+
+func TestMaxWALFilesFromEnv_DefaultsWhenUnset(t *testing.T) {
+	t.Setenv(maxWALFilesEnvVar, "")
+	require.Equal(t, defaultMaxWALFiles, maxWALFilesFromEnv())
+}
+
+func TestMaxWALFilesFromEnv_ReadsOverride(t *testing.T) {
+	t.Setenv(maxWALFilesEnvVar, "2")
+	require.Equal(t, 2, maxWALFilesFromEnv())
+}
+
+func TestMaxWALFilesFromEnv_FallsBackOnInvalid(t *testing.T) {
+	t.Setenv(maxWALFilesEnvVar, "not-a-number")
+	require.Equal(t, defaultMaxWALFiles, maxWALFilesFromEnv())
+
+	t.Setenv(maxWALFilesEnvVar, "0")
+	require.Equal(t, defaultMaxWALFiles, maxWALFilesFromEnv())
+
+	t.Setenv(maxWALFilesEnvVar, "-3")
+	require.Equal(t, defaultMaxWALFiles, maxWALFilesFromEnv())
+}
+
+func TestSnapshotEveryFromEnv_DefaultsWhenUnset(t *testing.T) {
+	t.Setenv(snapshotEveryEnvVar, "")
+	require.Equal(t, uint64(defaultSnapshotEvery), snapshotEveryFromEnv())
+}
+
+func TestSnapshotEveryFromEnv_ReadsOverride(t *testing.T) {
+	t.Setenv(snapshotEveryEnvVar, "1500")
+	require.Equal(t, uint64(1500), snapshotEveryFromEnv())
+}
+
+func TestSnapshotEveryFromEnv_ClampsZeroToOne(t *testing.T) {
+	t.Setenv(snapshotEveryEnvVar, "0")
+	require.Equal(t, uint64(1), snapshotEveryFromEnv())
+}
+
+func TestSnapshotEveryFromEnv_FallsBackOnInvalid(t *testing.T) {
+	t.Setenv(snapshotEveryEnvVar, "not-a-number")
+	require.Equal(t, uint64(defaultSnapshotEvery), snapshotEveryFromEnv())
+}

--- a/internal/raftengine/etcd/wal_purge_test.go
+++ b/internal/raftengine/etcd/wal_purge_test.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/client/pkg/v3/fileutil"
 )
 
 // writeDummyWALSegment creates a plausible-looking WAL filename in dir so
@@ -67,24 +69,71 @@ func TestPurgeOldWALFiles_KeepsMostRecentN(t *testing.T) {
 	}, got)
 }
 
-func TestPurgeOldWALFiles_NeverDeletesActiveTail(t *testing.T) {
+func TestPurgeOldWALFiles_NewestSurvivesKeepCutoff(t *testing.T) {
 	dir := t.TempDir()
-	// Create 5 segments; then hold an OS-level file lock on the newest one
-	// to simulate the wal package's flock on the active tail. keep=1 means
-	// the purger would WANT to delete the other 4, but the tail must remain
-	// under all circumstances.
+	// Create 5 segments with keep=1. The newest is already excluded by the
+	// lexicographic cutoff (victims := names[:len(names)-keep]), so this
+	// specifically exercises the "keep at least 1" invariant without going
+	// through the flock path at all.
 	var names []string
 	for i := uint64(0); i < 5; i++ {
 		names = append(names, writeDummyWALSegment(t, dir, i, i*100))
 	}
-	// keep=1 asks the purger to delete the 4 older segments; the newest is
-	// already excluded by the keep cutoff, not by locking. This verifies
-	// the "keep at least 1" invariant even with an aggressive cap.
 	require.NoError(t, purgeOldWALFiles(dir, 1))
 
 	got := listWALFiles(t, dir)
 	require.Len(t, got, 1)
 	require.Equal(t, names[len(names)-1], got[0])
+}
+
+// TestPurgeOldWALFiles_SkipsLockedMidListSegment is the real fleet-facing
+// safety test: the wal package holds a flock on an active-but-not-tail
+// segment (e.g., one the follower still needs for catch-up). The purger
+// must skip that segment while still deleting older unlocked ones around
+// it. This specifically covers the TryLockFile path in purgeOldWALFiles.
+func TestPurgeOldWALFiles_SkipsLockedMidListSegment(t *testing.T) {
+	// fileutil flock semantics differ on Windows (per-handle mandatory
+	// locking via LockFileEx). Our production target is Linux/macOS, and
+	// wiring a second-process lock acquirer just to exercise Windows is
+	// beyond the scope of this unit test.
+	if runtime.GOOS == "windows" {
+		t.Skip("fileutil flock test is posix-only")
+	}
+	dir := t.TempDir()
+	const total = 5
+	var names []string
+	for i := uint64(0); i < total; i++ {
+		names = append(names, writeDummyWALSegment(t, dir, i, i*100))
+	}
+	sort.Strings(names)
+
+	// Lock a segment squarely in the victim range (not the newest, which
+	// is always preserved by the keep cutoff). This simulates the wal
+	// package holding an un-Released flock on a mid-list segment.
+	lockIdx := len(names) / 2
+	lockedName := names[lockIdx]
+	lockedPath := filepath.Join(dir, lockedName)
+	lf, err := fileutil.TryLockFile(lockedPath, os.O_WRONLY, walLockMode)
+	require.NoError(t, err, "test setup: must be able to grab flock")
+	t.Cleanup(func() {
+		_ = lf.Close()
+	})
+
+	// keep=1 wants to delete the 4 older segments. The locked mid-list
+	// one must survive; the others (older than it AND not locked) must
+	// be deleted.
+	require.NoError(t, purgeOldWALFiles(dir, 1))
+
+	got := listWALFiles(t, dir)
+	// Newest is always preserved, and the locked mid-list segment must
+	// also survive the purge.
+	require.Contains(t, got, names[len(names)-1], "newest segment must survive")
+	require.Contains(t, got, lockedName, "locked segment must survive")
+	// Segments older than the locked one AND not locked must be deleted.
+	for i := 0; i < lockIdx; i++ {
+		require.NotContains(t, got, names[i],
+			"older unlocked segment %q should have been purged", names[i])
+	}
 }
 
 func TestPurgeOldWALFiles_MissingDirIsNoOp(t *testing.T) {


### PR DESCRIPTION
## Findings

- **Snapshot trigger** — `defaultSnapshotEvery = 10_000` entries past the last snapshot. Hard-coded; no env override. With fat Lua-script proposals, 10k entries easily produces the multi-GiB gap we observed.
- **fsm-snap/ retention** — healthy. `purgeOldSnapshotFiles` (keep `defaultMaxSnapFiles = 3`) is called after every `persist.SaveSnap` in both snapshot paths (`persistCreatedSnapshot`, `persistLocalSnapshotPayload`). The 2.3 GB bloat is three genuinely-large snapshots, not retention leakage.
- **WAL retention — BROKEN.** The engine calls `persist.Release(snap)` correctly, which invokes `wal.ReleaseLockTo(snap.Metadata.Index)`. But that method only CLOSES the file locks on obsolete segments; it does not delete them. etcd-server normally runs a separate `fileutil.PurgeFile` goroutine to unlink old `.wal` segments. elastickv was missing that entirely — grep confirms zero `PurgeFile` or equivalent call in the tree. Segments are 64 MiB by default, so 6.4 GB ≈ 100 segments, i.e. every segment since cluster bootstrap.

## Change

- New `purgeOldWALFiles(walDir, keep)` in `internal/raftengine/etcd/wal_purge.go`. Sorts `.wal` names lex (== chronological for etcds `%016x-%016x.wal` format), and for each deletion candidate attempts `fileutil.TryLockFile` first — a still-held flock means the wal package has not released that segment, so we skip it and pick it up on the next snapshot. Safe against deleting the active tail.
- Wired into both snapshot persistence paths, right after `purgeOldSnapshotFiles`. Default keep = 5 segments (~320 MiB cap).
- New env vars (both fall back to current defaults on invalid/unset input):
  - `ELASTICKV_RAFT_SNAPSHOT_COUNT` — override the 10_000 snapshot-trigger threshold.
  - `ELASTICKV_RAFT_MAX_WAL_FILES` — override the 5-segment WAL retention cap.
- No changes to fsm-snap retention — it already worked.

## How retention is now bounded

Per node, after the first snapshot following deploy:
- `wal/` ≤ `ELASTICKV_RAFT_MAX_WAL_FILES` × 64 MiB (default 320 MiB).
- `fsm-snap/` ≤ `defaultMaxSnapFiles` × snapshot size (unchanged: 3 × size).
- Snapshot cadence: once per `ELASTICKV_RAFT_SNAPSHOT_COUNT` applied entries (default 10_000; consider dropping to 1_000–2_000 on fat-proposal workloads).

## Deploy runbook

After merge + rollout, the stale WAL and fsm-snap files on disk will NOT self-clean until the next snapshot runs (retention is prospective, not historical). Recommend: on each node, after confirming the new binary is running and the first new snapshot has been observed in Grafana, manually `rm` the stale `fsm-snap/*.fsm` files older than the 2 newest and the stale `wal/*.wal` segments older than the 5 newest.

## Test plan
- [x] `go test -race -count=1 ./internal/raftengine/etcd/...` — passes (8.9 s).
- [x] `make lint` — clean.
- [x] New tests cover: keep-N invariant, never-deletes-tail, missing dir is no-op, clamps keep=0 to 1, ignores non-.wal entries, env-var parsing (default/override/invalid/clamp).
- [ ] Stage deploy on one node; verify wal/ stays bounded across multiple snapshot cycles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added environment variable configuration for Raft snapshot frequency and WAL file retention limits, allowing operators to optimize storage usage and durability characteristics for their deployment.
  * WAL files are now automatically purged according to configured retention policies, preventing unbounded disk usage.

* **Tests**
  * Added comprehensive test coverage for WAL retention, purging logic, and configuration parsing with edge case validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->