### PR TITLE
obs(redis): expose unsupported-command names via bounded metric

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -606,7 +606,12 @@ func (r *RedisServer) Run() error {
 			if !ok {
 				r.traceCommandError(conn, name, cmd.Args[1:], "unsupported")
 				conn.WriteError("ERR unsupported command '" + string(cmd.Args[0]) + "'")
-				r.observeRedisUnsupported(name, time.Since(start))
+				// Pass the RAW command bytes (not the already-uppercased `name`)
+				// so that the unsupported-command observer can detect invalid
+				// UTF-8 before strings.ToUpper silently rewrites the bytes to
+				// the U+FFFD replacement character. See observeUnsupportedCommand
+				// in monitoring/redis.go.
+				r.observeRedisUnsupported(string(cmd.Args[0]), time.Since(start))
 				return
 			}
 
@@ -871,6 +876,11 @@ func (r *RedisServer) observeRedisError(command string, dur time.Duration) {
 // counters (which bucket the name into "unknown"), this flags the
 // report so the monitoring layer can record the real command name in
 // its bounded-cardinality unsupported-commands counter.
+//
+// IMPORTANT: `command` must be the RAW bytes the client sent (not an
+// already-uppercased value). The monitoring layer relies on seeing the
+// raw bytes to detect invalid UTF-8 before strings.ToUpper silently
+// replaces invalid bytes with the Unicode replacement character.
 func (r *RedisServer) observeRedisUnsupported(command string, dur time.Duration) {
 	if r.requestObserver == nil {
 		return

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -606,7 +606,7 @@ func (r *RedisServer) Run() error {
 			if !ok {
 				r.traceCommandError(conn, name, cmd.Args[1:], "unsupported")
 				conn.WriteError("ERR unsupported command '" + string(cmd.Args[0]) + "'")
-				r.observeRedisError(name, time.Since(start))
+				r.observeRedisUnsupported(name, time.Since(start))
 				return
 			}
 
@@ -863,6 +863,23 @@ func (r *RedisServer) observeRedisError(command string, dur time.Duration) {
 		Command:  command,
 		IsError:  true,
 		Duration: dur,
+	})
+}
+
+// observeRedisUnsupported records a command that was rejected because
+// the adapter has no route for it. In addition to the usual error
+// counters (which bucket the name into "unknown"), this flags the
+// report so the monitoring layer can record the real command name in
+// its bounded-cardinality unsupported-commands counter.
+func (r *RedisServer) observeRedisUnsupported(command string, dur time.Duration) {
+	if r.requestObserver == nil {
+		return
+	}
+	r.requestObserver.ObserveRedisRequest(monitoring.RedisRequestReport{
+		Command:     command,
+		IsError:     true,
+		Duration:    dur,
+		Unsupported: true,
 	})
 }
 

--- a/adapter/redis_metrics_test.go
+++ b/adapter/redis_metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/bootjp/elastickv/monitoring"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -363,7 +364,9 @@ func TestRedisMetricsUnsupportedCommandTruncatesLongName(t *testing.T) {
 					continue
 				}
 				require.LessOrEqual(t, len(lbl.GetValue()), 64,
-					"label value must be length-capped")
+					"label value must be length-capped (byte count)")
+				require.True(t, utf8.ValidString(lbl.GetValue()),
+					"label value must be valid UTF-8")
 				if lbl.GetValue() == strings.Repeat("A", 64) {
 					found = true
 				}
@@ -371,6 +374,96 @@ func TestRedisMetricsUnsupportedCommandTruncatesLongName(t *testing.T) {
 		}
 	}
 	require.True(t, found, "expected truncated 64-char label value")
+}
+
+// TestRedisMetricsUnsupportedCommandTruncatesOnRuneBoundary verifies that
+// truncating a long command name that contains multibyte UTF-8 runes does
+// not split a rune, which would produce an invalid UTF-8 label and cause
+// prometheus.WithLabelValues to panic. The input is 63 ASCII 'A' bytes
+// followed by a 2-byte rune 'é' repeated enough times to exceed the 64-byte
+// cap; a byte-boundary truncate would split the first 'é'.
+func TestRedisMetricsUnsupportedCommandTruncatesOnRuneBoundary(t *testing.T) {
+	registry := monitoring.NewRegistry("n1", "10.0.0.1:50051")
+	observer := registry.RedisObserver()
+
+	// 63 bytes of 'A' + a sequence of 'é' (2 bytes each, uppercases to 'É'
+	// which is also 2 bytes). Total byte length well over 64.
+	payload := strings.Repeat("A", 63) + strings.Repeat("é", 20)
+	require.Greater(t, len(payload), 64)
+
+	require.NotPanics(t, func() {
+		observer.ObserveRedisRequest(monitoring.RedisRequestReport{
+			Command:     payload,
+			IsError:     true,
+			Duration:    time.Millisecond,
+			Unsupported: true,
+		})
+	})
+
+	mf, err := registry.Gatherer().Gather()
+	require.NoError(t, err)
+
+	var checked bool
+	for _, family := range mf {
+		if family.GetName() != "elastickv_redis_unsupported_commands_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			for _, lbl := range metric.GetLabel() {
+				if lbl.GetName() != "command" {
+					continue
+				}
+				v := lbl.GetValue()
+				require.LessOrEqual(t, len(v), 64,
+					"byte-length cap must be preserved")
+				require.True(t, utf8.ValidString(v),
+					"truncation must not split a rune (invalid UTF-8 would panic prometheus)")
+				checked = true
+			}
+		}
+	}
+	require.True(t, checked, "expected an unsupported-commands metric to be emitted")
+}
+
+// TestRedisMetricsUnsupportedCommandRejectsInvalidUTF8 verifies that an
+// ingress command name that is already invalid UTF-8 (e.g. a binary blob
+// from a misbehaving or hostile client) does not crash the observer and is
+// folded into a fixed "invalid_utf8" sentinel label.
+func TestRedisMetricsUnsupportedCommandRejectsInvalidUTF8(t *testing.T) {
+	registry := monitoring.NewRegistry("n1", "10.0.0.1:50051")
+	observer := registry.RedisObserver()
+
+	// 0xff 0xfe 0xfd are never valid UTF-8 start bytes.
+	invalid := string([]byte{0xff, 0xfe, 0xfd, 0xc3, 0x28})
+	require.False(t, utf8.ValidString(invalid))
+
+	require.NotPanics(t, func() {
+		observer.ObserveRedisRequest(monitoring.RedisRequestReport{
+			Command:     invalid,
+			IsError:     true,
+			Duration:    time.Millisecond,
+			Unsupported: true,
+		})
+	})
+
+	mf, err := registry.Gatherer().Gather()
+	require.NoError(t, err)
+
+	var sentinelCount float64
+	for _, family := range mf {
+		if family.GetName() != "elastickv_redis_unsupported_commands_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			for _, lbl := range metric.GetLabel() {
+				if lbl.GetName() == "command" && lbl.GetValue() == "invalid_utf8" {
+					sentinelCount += metric.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+	require.Equal(t, float64(1), sentinelCount,
+		"invalid-UTF-8 input must be folded into the 'invalid_utf8' sentinel")
 }
 
 func TestRedisMetricsUnsupportedCommandConcurrentObservers(t *testing.T) {

--- a/adapter/redis_metrics_test.go
+++ b/adapter/redis_metrics_test.go
@@ -506,15 +506,15 @@ func TestRedisMetricsUnsupportedCommandConcurrentObservers(t *testing.T) {
 	require.Equal(t, float64(workers*perWorks), total)
 }
 
-// TestRedisMetricsUnsupportedCommandRawInvalidUTF8Bytes covers the
-// regression this commit fixes: the adapter's Run() loop must pass RAW
-// command bytes (not strings.ToUpper'd bytes) to the unsupported-command
-// observer. ToUpper silently rewrites invalid UTF-8 into the U+FFFD
-// replacement character, so if the raw path is not preserved the
-// invalid_utf8 sentinel is never reached and a hostile client can burn
-// through the distinct-name slots with replacement-char garbage. Feeding
-// the observer directly with three invalid bytes must produce the
-// sentinel, not a synthetic "valid UTF-8" label.
+// TestRedisMetricsUnsupportedCommandRawInvalidUTF8FromAdapterPath covers
+// the regression fixed alongside this commit: the adapter's Run() loop
+// must pass RAW command bytes (not strings.ToUpper'd bytes) to the
+// unsupported-command observer. ToUpper silently rewrites invalid UTF-8
+// into the U+FFFD replacement character, so if the raw path is not
+// preserved the invalid_utf8 sentinel is never reached and a hostile
+// client can burn through the distinct-name slots with replacement-char
+// garbage. Feeding the observer directly with three invalid bytes must
+// produce the sentinel, not a synthetic "valid UTF-8" label.
 func TestRedisMetricsUnsupportedCommandRawInvalidUTF8Bytes(t *testing.T) {
 	registry := monitoring.NewRegistry("n1", "10.0.0.1:50051")
 	observer := registry.RedisObserver()
@@ -549,6 +549,119 @@ func TestRedisMetricsUnsupportedCommandRawInvalidUTF8Bytes(t *testing.T) {
 	}
 	require.Equal(t, float64(1), sentinel,
 		"raw invalid-UTF-8 bytes must land in the 'invalid_utf8' sentinel")
+}
+
+// TestRedisMetricsUnsupportedCommandRejectsPathologicalLength defends
+// against CPU-exhaustion input: a hostile client sending a multi-megabyte
+// first argument must not cause strings.ToUpper / utf8.ValidString /
+// []rune iteration to process the full payload. The observer caps the raw
+// input length before any O(n) string operation runs; this test just
+// asserts the call returns quickly and does not panic under the default
+// `go test -timeout` budget.
+func TestRedisMetricsUnsupportedCommandRejectsPathologicalLength(t *testing.T) {
+	registry := monitoring.NewRegistry("n1", "10.0.0.1:50051")
+	observer := registry.RedisObserver()
+
+	// 1 MiB of 'A'. Well above any reasonable Redis command name.
+	huge := strings.Repeat("A", 1<<20)
+
+	require.NotPanics(t, func() {
+		observer.ObserveRedisRequest(monitoring.RedisRequestReport{
+			Command:     huge,
+			IsError:     true,
+			Duration:    time.Millisecond,
+			Unsupported: true,
+		})
+	})
+
+	mf, err := registry.Gatherer().Gather()
+	require.NoError(t, err)
+
+	var checked bool
+	for _, family := range mf {
+		if family.GetName() != "elastickv_redis_unsupported_commands_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			for _, lbl := range metric.GetLabel() {
+				if lbl.GetName() != "command" {
+					continue
+				}
+				require.LessOrEqual(t, len(lbl.GetValue()), 64,
+					"even pathologically long inputs must respect the 64-byte label cap")
+				require.True(t, utf8.ValidString(lbl.GetValue()),
+					"label value must remain valid UTF-8")
+				checked = true
+			}
+		}
+	}
+	require.True(t, checked, "expected a metric to be emitted for the huge input")
+}
+
+// TestRedisMetricsUnsupportedCommandRWMutexFastPath exercises the
+// read-locked fast path in observeUnsupportedCommand under concurrent
+// observers hitting a mix of already-admitted names (fast path) and brand
+// new names (slow path). It is designed to run under `go test -race`.
+func TestRedisMetricsUnsupportedCommandRWMutexFastPath(t *testing.T) {
+	registry := monitoring.NewRegistry("n1", "10.0.0.1:50051")
+	observer := registry.RedisObserver()
+
+	// Pre-seed a handful of names so the vast majority of concurrent
+	// observations take the read-only fast path.
+	seeds := []string{"ALPHA", "BRAVO", "CHARLIE", "DELTA", "ECHO"}
+	for _, s := range seeds {
+		observer.ObserveRedisRequest(monitoring.RedisRequestReport{
+			Command:     s,
+			IsError:     true,
+			Duration:    time.Microsecond,
+			Unsupported: true,
+		})
+	}
+
+	const (
+		workers = 32
+		iters   = 500
+	)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				var cmd string
+				// ~80% fast path, ~20% slow path (new names) to stress
+				// both RLock and Lock branches concurrently.
+				if i%5 == 0 {
+					cmd = fmt.Sprintf("NEW_W%03d_I%03d", w, i)
+				} else {
+					cmd = seeds[i%len(seeds)]
+				}
+				observer.ObserveRedisRequest(monitoring.RedisRequestReport{
+					Command:     cmd,
+					IsError:     true,
+					Duration:    time.Microsecond,
+					Unsupported: true,
+				})
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Sanity: the total across all label buckets must equal the total
+	// number of observations performed (including seeds).
+	mf, err := registry.Gatherer().Gather()
+	require.NoError(t, err)
+
+	var total float64
+	for _, family := range mf {
+		if family.GetName() != "elastickv_redis_unsupported_commands_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			total += metric.GetCounter().GetValue()
+		}
+	}
+	require.Equal(t, float64(len(seeds)+workers*iters), total)
 }
 
 // stubRedisConn is a minimal redcon.Conn implementation for unit tests.

--- a/adapter/redis_metrics_test.go
+++ b/adapter/redis_metrics_test.go
@@ -1,8 +1,10 @@
 package adapter
 
 import (
+	"fmt"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -88,9 +90,10 @@ func TestRedisMetricsNormalizesUnknownCommand(t *testing.T) {
 	observer := registry.RedisObserver()
 
 	observer.ObserveRedisRequest(monitoring.RedisRequestReport{
-		Command:  "NOTACOMMAND",
-		IsError:  true,
-		Duration: time.Millisecond,
+		Command:     "NOTACOMMAND",
+		IsError:     true,
+		Duration:    time.Millisecond,
+		Unsupported: true,
 	})
 
 	err := testutil.GatherAndCompare(
@@ -99,8 +102,12 @@ func TestRedisMetricsNormalizesUnknownCommand(t *testing.T) {
 # HELP elastickv_redis_requests_total Total number of Redis API requests by command and outcome.
 # TYPE elastickv_redis_requests_total counter
 elastickv_redis_requests_total{command="unknown",node_address="10.0.0.1:50051",node_id="n1",outcome="error"} 1
+# HELP elastickv_redis_unsupported_commands_total Count of Redis commands rejected as unsupported, labelled with the actual command name (bounded cardinality).
+# TYPE elastickv_redis_unsupported_commands_total counter
+elastickv_redis_unsupported_commands_total{command="NOTACOMMAND",node_address="10.0.0.1:50051",node_id="n1"} 1
 `),
 		"elastickv_redis_requests_total",
+		"elastickv_redis_unsupported_commands_total",
 	)
 	require.NoError(t, err)
 }
@@ -203,6 +210,207 @@ elastickv_redis_requests_total{command="GET",node_address="10.0.0.1:50051",node_
 		"elastickv_redis_requests_total",
 	)
 	require.NoError(t, err)
+}
+
+func TestRedisMetricsUnsupportedCommandRecordsRealName(t *testing.T) {
+	registry := monitoring.NewRegistry("n1", "10.0.0.1:50051")
+	observer := registry.RedisObserver()
+
+	observer.ObserveRedisRequest(monitoring.RedisRequestReport{
+		Command:     "proxy",
+		IsError:     true,
+		Duration:    time.Millisecond,
+		Unsupported: true,
+	})
+
+	err := testutil.GatherAndCompare(
+		registry.Gatherer(),
+		strings.NewReader(`
+# HELP elastickv_redis_unsupported_commands_total Count of Redis commands rejected as unsupported, labelled with the actual command name (bounded cardinality).
+# TYPE elastickv_redis_unsupported_commands_total counter
+elastickv_redis_unsupported_commands_total{command="PROXY",node_address="10.0.0.1:50051",node_id="n1"} 1
+`),
+		"elastickv_redis_unsupported_commands_total",
+	)
+	require.NoError(t, err)
+}
+
+func TestRedisMetricsUnsupportedCommandTwoDistinctNames(t *testing.T) {
+	registry := monitoring.NewRegistry("n1", "10.0.0.1:50051")
+	observer := registry.RedisObserver()
+
+	observer.ObserveRedisRequest(monitoring.RedisRequestReport{
+		Command: "FOO", IsError: true, Duration: time.Millisecond, Unsupported: true,
+	})
+	observer.ObserveRedisRequest(monitoring.RedisRequestReport{
+		Command: "BAR", IsError: true, Duration: time.Millisecond, Unsupported: true,
+	})
+	observer.ObserveRedisRequest(monitoring.RedisRequestReport{
+		Command: "FOO", IsError: true, Duration: time.Millisecond, Unsupported: true,
+	})
+
+	err := testutil.GatherAndCompare(
+		registry.Gatherer(),
+		strings.NewReader(`
+# HELP elastickv_redis_unsupported_commands_total Count of Redis commands rejected as unsupported, labelled with the actual command name (bounded cardinality).
+# TYPE elastickv_redis_unsupported_commands_total counter
+elastickv_redis_unsupported_commands_total{command="BAR",node_address="10.0.0.1:50051",node_id="n1"} 1
+elastickv_redis_unsupported_commands_total{command="FOO",node_address="10.0.0.1:50051",node_id="n1"} 2
+`),
+		"elastickv_redis_unsupported_commands_total",
+	)
+	require.NoError(t, err)
+}
+
+func TestRedisMetricsUnsupportedCommandCapSpillsToOther(t *testing.T) {
+	registry := monitoring.NewRegistry("n1", "10.0.0.1:50051")
+	observer := registry.RedisObserver()
+
+	// Observe 32 distinct names (the cap).
+	for i := 0; i < 32; i++ {
+		observer.ObserveRedisRequest(monitoring.RedisRequestReport{
+			Command:     fmt.Sprintf("CMD%02d", i),
+			IsError:     true,
+			Duration:    time.Millisecond,
+			Unsupported: true,
+		})
+	}
+	// The 33rd distinct name must fold into "other".
+	observer.ObserveRedisRequest(monitoring.RedisRequestReport{
+		Command:     "OVERFLOW33",
+		IsError:     true,
+		Duration:    time.Millisecond,
+		Unsupported: true,
+	})
+	// Same overflow name comes in again: still "other" because it never
+	// got admitted into the distinct-name set.
+	observer.ObserveRedisRequest(monitoring.RedisRequestReport{
+		Command:     "OVERFLOW33",
+		IsError:     true,
+		Duration:    time.Millisecond,
+		Unsupported: true,
+	})
+	// An already-seen name (under cap) must still record with its real
+	// name, not "other".
+	observer.ObserveRedisRequest(monitoring.RedisRequestReport{
+		Command:     "CMD00",
+		IsError:     true,
+		Duration:    time.Millisecond,
+		Unsupported: true,
+	})
+
+	mf, err := registry.Gatherer().Gather()
+	require.NoError(t, err)
+
+	var (
+		otherCount    float64
+		cmd00Count    float64
+		distinctNames = map[string]float64{}
+	)
+	for _, family := range mf {
+		if family.GetName() != "elastickv_redis_unsupported_commands_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			var name string
+			for _, lbl := range metric.GetLabel() {
+				if lbl.GetName() == "command" {
+					name = lbl.GetValue()
+					break
+				}
+			}
+			val := metric.GetCounter().GetValue()
+			distinctNames[name] = val
+			switch name {
+			case "other":
+				otherCount = val
+			case "CMD00":
+				cmd00Count = val
+			}
+		}
+	}
+
+	// 32 real names + "other" = 33 distinct label values.
+	require.Len(t, distinctNames, 33, "expected exactly 32 real names plus 'other'")
+	require.NotContains(t, distinctNames, "OVERFLOW33", "overflow name must not appear as its own label")
+	require.Equal(t, float64(2), otherCount, "overflow increments must accumulate in 'other'")
+	require.Equal(t, float64(2), cmd00Count, "already-seen name must still record with real label")
+}
+
+func TestRedisMetricsUnsupportedCommandTruncatesLongName(t *testing.T) {
+	registry := monitoring.NewRegistry("n1", "10.0.0.1:50051")
+	observer := registry.RedisObserver()
+
+	long := strings.Repeat("A", 200)
+	observer.ObserveRedisRequest(monitoring.RedisRequestReport{
+		Command:     long,
+		IsError:     true,
+		Duration:    time.Millisecond,
+		Unsupported: true,
+	})
+
+	mf, err := registry.Gatherer().Gather()
+	require.NoError(t, err)
+
+	var found bool
+	for _, family := range mf {
+		if family.GetName() != "elastickv_redis_unsupported_commands_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			for _, lbl := range metric.GetLabel() {
+				if lbl.GetName() != "command" {
+					continue
+				}
+				require.LessOrEqual(t, len(lbl.GetValue()), 64,
+					"label value must be length-capped")
+				if lbl.GetValue() == strings.Repeat("A", 64) {
+					found = true
+				}
+			}
+		}
+	}
+	require.True(t, found, "expected truncated 64-char label value")
+}
+
+func TestRedisMetricsUnsupportedCommandConcurrentObservers(t *testing.T) {
+	registry := monitoring.NewRegistry("n1", "10.0.0.1:50051")
+	observer := registry.RedisObserver()
+
+	const (
+		workers  = 16
+		perWorks = 200
+	)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perWorks; i++ {
+				observer.ObserveRedisRequest(monitoring.RedisRequestReport{
+					Command:     fmt.Sprintf("WCMD%02d", (w+i)%40),
+					IsError:     true,
+					Duration:    time.Microsecond,
+					Unsupported: true,
+				})
+			}
+		}()
+	}
+	wg.Wait()
+
+	mf, err := registry.Gatherer().Gather()
+	require.NoError(t, err)
+
+	var total float64
+	for _, family := range mf {
+		if family.GetName() != "elastickv_redis_unsupported_commands_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			total += metric.GetCounter().GetValue()
+		}
+	}
+	require.Equal(t, float64(workers*perWorks), total)
 }
 
 // stubRedisConn is a minimal redcon.Conn implementation for unit tests.

--- a/adapter/redis_metrics_test.go
+++ b/adapter/redis_metrics_test.go
@@ -506,6 +506,51 @@ func TestRedisMetricsUnsupportedCommandConcurrentObservers(t *testing.T) {
 	require.Equal(t, float64(workers*perWorks), total)
 }
 
+// TestRedisMetricsUnsupportedCommandRawInvalidUTF8Bytes covers the
+// regression this commit fixes: the adapter's Run() loop must pass RAW
+// command bytes (not strings.ToUpper'd bytes) to the unsupported-command
+// observer. ToUpper silently rewrites invalid UTF-8 into the U+FFFD
+// replacement character, so if the raw path is not preserved the
+// invalid_utf8 sentinel is never reached and a hostile client can burn
+// through the distinct-name slots with replacement-char garbage. Feeding
+// the observer directly with three invalid bytes must produce the
+// sentinel, not a synthetic "valid UTF-8" label.
+func TestRedisMetricsUnsupportedCommandRawInvalidUTF8Bytes(t *testing.T) {
+	registry := monitoring.NewRegistry("n1", "10.0.0.1:50051")
+	observer := registry.RedisObserver()
+
+	raw := string([]byte{0xff, 0xff, 0xff})
+	require.False(t, utf8.ValidString(raw), "precondition: bytes must be invalid UTF-8")
+
+	require.NotPanics(t, func() {
+		observer.ObserveRedisRequest(monitoring.RedisRequestReport{
+			Command:     raw,
+			IsError:     true,
+			Duration:    time.Millisecond,
+			Unsupported: true,
+		})
+	})
+
+	mf, err := registry.Gatherer().Gather()
+	require.NoError(t, err)
+
+	var sentinel float64
+	for _, family := range mf {
+		if family.GetName() != "elastickv_redis_unsupported_commands_total" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			for _, lbl := range metric.GetLabel() {
+				if lbl.GetName() == "command" && lbl.GetValue() == "invalid_utf8" {
+					sentinel += metric.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+	require.Equal(t, float64(1), sentinel,
+		"raw invalid-UTF-8 bytes must land in the 'invalid_utf8' sentinel")
+}
+
 // stubRedisConn is a minimal redcon.Conn implementation for unit tests.
 type stubRedisConn struct {
 	lastError  string

--- a/monitoring/redis.go
+++ b/monitoring/redis.go
@@ -36,6 +36,15 @@ const (
 	// fixed sentinel avoids ever passing invalid UTF-8 to
 	// prometheus.WithLabelValues, which would panic.
 	redisUnsupportedCommandInvalidUTF8 = "invalid_utf8"
+
+	// maxUnsupportedCommandRawLen defensively caps the raw input length
+	// before any O(n) string operations (strings.ToUpper, utf8.ValidString,
+	// rune iteration) run. Redis command names are always short, so a
+	// multi-megabyte first argument is abusive input; processing the full
+	// payload would let a hostile client burn CPU. The cap is loose enough
+	// to cover any plausible command name plus a margin of whitespace; the
+	// later rune-aware truncation produces the final label.
+	maxUnsupportedCommandRawLen = 256
 )
 
 var redisCommandSet = map[string]struct{}{
@@ -146,7 +155,7 @@ type RedisMetrics struct {
 	errorsTotal         *prometheus.CounterVec
 	unsupportedCommands *prometheus.CounterVec
 
-	unsupportedMu    sync.Mutex
+	unsupportedMu    sync.RWMutex
 	unsupportedNames map[string]struct{}
 }
 
@@ -229,10 +238,20 @@ func (m *RedisMetrics) ObserveRedisRequest(report RedisRequestReport) {
 // with synthetic "valid" garbage. Keep ToUpper/TrimSpace inside this
 // function, AFTER the UTF-8 validity check.
 func (m *RedisMetrics) observeUnsupportedCommand(raw string) {
+	// Defensive cap on raw input length BEFORE any O(n) string operations
+	// (utf8.ValidString, strings.ToUpper, rune iteration). A hostile
+	// client sending a multi-megabyte first argument would otherwise burn
+	// CPU on every call. Cutting mid-rune is acceptable here because the
+	// UTF-8 validity check below rejects the result or the rune-aware
+	// truncation further down trims to a clean boundary.
+	if len(raw) > maxUnsupportedCommandRawLen {
+		raw = raw[:maxUnsupportedCommandRawLen]
+	}
+
 	// Guard against raw inputs that are already invalid UTF-8 at ingress
 	// (e.g. a binary blob sent as a command name). Passing invalid UTF-8
 	// to prometheus.WithLabelValues would panic and crash the calling
-	// goroutine. Check the raw string before strings.ToUpper, which would
+	// goroutine. Check the raw string BEFORE strings.ToUpper, which would
 	// otherwise silently rewrite invalid bytes to the Unicode replacement
 	// character and mask the problem.
 	var name string
@@ -247,33 +266,41 @@ func (m *RedisMetrics) observeUnsupportedCommand(raw string) {
 	if len(name) > maxUnsupportedCommandLabelLen {
 		// Truncate by UTF-8 rune boundary, not byte boundary, so we never
 		// split a multibyte rune and produce invalid UTF-8 (which would
-		// make prometheus.WithLabelValues panic). We keep the cap as a
-		// byte limit to preserve the existing cardinality/size semantics.
-		b := 0
+		// make prometheus.WithLabelValues panic). The range-loop index `i`
+		// is itself the byte offset of rune `r`; because the upstream
+		// UTF-8 validity check guarantees `name` is valid UTF-8 here,
+		// utf8.RuneLen(r) is always positive.
 		cut := len(name)
 		for i, r := range name {
-			size := utf8.RuneLen(r)
-			if size < 0 {
-				size = 1
-			}
-			if b+size > maxUnsupportedCommandLabelLen {
+			if i+utf8.RuneLen(r) > maxUnsupportedCommandLabelLen {
 				cut = i
 				break
 			}
-			b += size
 		}
 		name = name[:cut]
 	}
 
+	// Fast path: if the name has already been admitted, only a read lock
+	// is needed so concurrent observers do not serialise on the same
+	// mutex.
 	label := redisUnsupportedCommandOther
-	m.unsupportedMu.Lock()
-	if _, seen := m.unsupportedNames[name]; seen {
+	m.unsupportedMu.RLock()
+	_, seen := m.unsupportedNames[name]
+	m.unsupportedMu.RUnlock()
+	if seen {
 		label = name
-	} else if len(m.unsupportedNames) < maxUnsupportedCommandLabels {
-		m.unsupportedNames[name] = struct{}{}
-		label = name
+	} else {
+		m.unsupportedMu.Lock()
+		// Double-check under the write lock: another goroutine may have
+		// admitted this name between our RUnlock and Lock.
+		if _, seen := m.unsupportedNames[name]; seen {
+			label = name
+		} else if len(m.unsupportedNames) < maxUnsupportedCommandLabels {
+			m.unsupportedNames[name] = struct{}{}
+			label = name
+		}
+		m.unsupportedMu.Unlock()
 	}
-	m.unsupportedMu.Unlock()
 
 	m.unsupportedCommands.WithLabelValues(label).Inc()
 }

--- a/monitoring/redis.go
+++ b/monitoring/redis.go
@@ -221,6 +221,13 @@ func (m *RedisMetrics) ObserveRedisRequest(report RedisRequestReport) {
 // command name, falling back to "other" when the distinct-name cap has
 // been reached. The input is uppercased, trimmed, and length-capped to
 // avoid pathological label values.
+//
+// `raw` MUST be the raw bytes received from the client (NOT already
+// uppercased). strings.ToUpper silently rewrites invalid UTF-8 bytes
+// into the U+FFFD replacement character, which would mask the invalid-
+// UTF-8 sentinel path and let a hostile client consume real label slots
+// with synthetic "valid" garbage. Keep ToUpper/TrimSpace inside this
+// function, AFTER the UTF-8 validity check.
 func (m *RedisMetrics) observeUnsupportedCommand(raw string) {
 	// Guard against raw inputs that are already invalid UTF-8 at ingress
 	// (e.g. a binary blob sent as a command name). Passing invalid UTF-8

--- a/monitoring/redis.go
+++ b/monitoring/redis.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -29,6 +30,12 @@ const (
 	// redisUnsupportedCommandOther is the overflow bucket used when the
 	// observed name is novel and the distinct-name cap is full.
 	redisUnsupportedCommandOther = "other"
+
+	// redisUnsupportedCommandInvalidUTF8 is the sentinel label applied when
+	// the raw command name contains bytes that are not valid UTF-8. Using a
+	// fixed sentinel avoids ever passing invalid UTF-8 to
+	// prometheus.WithLabelValues, which would panic.
+	redisUnsupportedCommandInvalidUTF8 = "invalid_utf8"
 )
 
 var redisCommandSet = map[string]struct{}{
@@ -215,12 +222,40 @@ func (m *RedisMetrics) ObserveRedisRequest(report RedisRequestReport) {
 // been reached. The input is uppercased, trimmed, and length-capped to
 // avoid pathological label values.
 func (m *RedisMetrics) observeUnsupportedCommand(raw string) {
-	name := strings.ToUpper(strings.TrimSpace(raw))
+	// Guard against raw inputs that are already invalid UTF-8 at ingress
+	// (e.g. a binary blob sent as a command name). Passing invalid UTF-8
+	// to prometheus.WithLabelValues would panic and crash the calling
+	// goroutine. Check the raw string before strings.ToUpper, which would
+	// otherwise silently rewrite invalid bytes to the Unicode replacement
+	// character and mask the problem.
+	var name string
+	if !utf8.ValidString(raw) {
+		name = redisUnsupportedCommandInvalidUTF8
+	} else {
+		name = strings.ToUpper(strings.TrimSpace(raw))
+	}
 	if name == "" {
 		name = redisCommandUnknown
 	}
 	if len(name) > maxUnsupportedCommandLabelLen {
-		name = name[:maxUnsupportedCommandLabelLen]
+		// Truncate by UTF-8 rune boundary, not byte boundary, so we never
+		// split a multibyte rune and produce invalid UTF-8 (which would
+		// make prometheus.WithLabelValues panic). We keep the cap as a
+		// byte limit to preserve the existing cardinality/size semantics.
+		b := 0
+		cut := len(name)
+		for i, r := range name {
+			size := utf8.RuneLen(r)
+			if size < 0 {
+				size = 1
+			}
+			if b+size > maxUnsupportedCommandLabelLen {
+				cut = i
+				break
+			}
+			b += size
+		}
+		name = name[:cut]
 	}
 
 	label := redisUnsupportedCommandOther

--- a/monitoring/redis.go
+++ b/monitoring/redis.go
@@ -2,6 +2,7 @@ package monitoring
 
 import (
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -11,6 +12,23 @@ const (
 	redisOutcomeSuccess = "success"
 	redisOutcomeError   = "error"
 	redisCommandUnknown = "unknown"
+
+	// maxUnsupportedCommandLabels caps the cardinality of the
+	// elastickv_redis_unsupported_commands_total{command} label set. Once
+	// this many distinct names have been seen, further novel names are
+	// collapsed into the "other" bucket so a hostile or buggy client
+	// cannot explode metric cardinality via protocol abuse.
+	maxUnsupportedCommandLabels = 32
+
+	// maxUnsupportedCommandLabelLen defensively caps the length of the
+	// actual command-name label value. Redis command names are short; a
+	// client sending a pathologically long first argument should not be
+	// able to pollute label values with the entire payload.
+	maxUnsupportedCommandLabelLen = 64
+
+	// redisUnsupportedCommandOther is the overflow bucket used when the
+	// observed name is novel and the distinct-name cap is full.
+	redisUnsupportedCommandOther = "other"
 )
 
 var redisCommandSet = map[string]struct{}{
@@ -106,13 +124,23 @@ type RedisRequestReport struct {
 	Command  string
 	IsError  bool
 	Duration time.Duration
+	// Unsupported indicates the command was rejected because the adapter
+	// has no route for it. When true, ObserveRedisRequest additionally
+	// records the real (bounded) command name in
+	// elastickv_redis_unsupported_commands_total alongside the existing
+	// "unknown"-bucketed counters, which are preserved unchanged.
+	Unsupported bool
 }
 
 // RedisMetrics holds all Prometheus metric vectors for the Redis adapter.
 type RedisMetrics struct {
-	requestsTotal   *prometheus.CounterVec
-	requestDuration *prometheus.HistogramVec
-	errorsTotal     *prometheus.CounterVec
+	requestsTotal       *prometheus.CounterVec
+	requestDuration     *prometheus.HistogramVec
+	errorsTotal         *prometheus.CounterVec
+	unsupportedCommands *prometheus.CounterVec
+
+	unsupportedMu    sync.Mutex
+	unsupportedNames map[string]struct{}
 }
 
 func newRedisMetrics(registerer prometheus.Registerer) *RedisMetrics {
@@ -139,12 +167,21 @@ func newRedisMetrics(registerer prometheus.Registerer) *RedisMetrics {
 			},
 			[]string{"command"},
 		),
+		unsupportedCommands: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "elastickv_redis_unsupported_commands_total",
+				Help: "Count of Redis commands rejected as unsupported, labelled with the actual command name (bounded cardinality).",
+			},
+			[]string{"command"},
+		),
+		unsupportedNames: make(map[string]struct{}, maxUnsupportedCommandLabels),
 	}
 
 	registerer.MustRegister(
 		m.requestsTotal,
 		m.requestDuration,
 		m.errorsTotal,
+		m.unsupportedCommands,
 	)
 
 	return m
@@ -167,6 +204,36 @@ func (m *RedisMetrics) ObserveRedisRequest(report RedisRequestReport) {
 	if report.IsError {
 		m.errorsTotal.WithLabelValues(command).Inc()
 	}
+	if report.Unsupported {
+		m.observeUnsupportedCommand(report.Command)
+	}
+}
+
+// observeUnsupportedCommand increments the bounded-cardinality
+// elastickv_redis_unsupported_commands_total counter with the real
+// command name, falling back to "other" when the distinct-name cap has
+// been reached. The input is uppercased, trimmed, and length-capped to
+// avoid pathological label values.
+func (m *RedisMetrics) observeUnsupportedCommand(raw string) {
+	name := strings.ToUpper(strings.TrimSpace(raw))
+	if name == "" {
+		name = redisCommandUnknown
+	}
+	if len(name) > maxUnsupportedCommandLabelLen {
+		name = name[:maxUnsupportedCommandLabelLen]
+	}
+
+	label := redisUnsupportedCommandOther
+	m.unsupportedMu.Lock()
+	if _, seen := m.unsupportedNames[name]; seen {
+		label = name
+	} else if len(m.unsupportedNames) < maxUnsupportedCommandLabels {
+		m.unsupportedNames[name] = struct{}{}
+		label = name
+	}
+	m.unsupportedMu.Unlock()
+
+	m.unsupportedCommands.WithLabelValues(label).Inc()
 }
 
 func normalizeRedisCommand(command string) string {


### PR DESCRIPTION
## Summary

- Add a new Prometheus counter `elastickv_redis_unsupported_commands_total{command}` that records the **actual** name of Redis commands the adapter rejects at the route-miss path (`adapter/redis.go`). Today those are all collapsed into `command="unknown"`, which leaves a large unnamed bar in Grafana's "Errors by Command".
- The new metric is **additive**: the existing `elastickv_redis_requests_total{command="unknown",outcome="error"}` and `elastickv_redis_errors_total{command="unknown"}` counters are unchanged, so existing dashboards and alerts keep working.

## Cardinality guarantee

- Hard cap of **32 distinct** command-name label values (`maxUnsupportedCommandLabels = 32`), guarded by a `sync.Mutex` on an in-memory seen-set in `RedisMetrics`.
- Once the cap is reached, any further novel name folds into `command="other"`. Already-seen names still record with their real label even after the cap is full.
- Label values are uppercased, trimmed, and **truncated to 64 chars** (`maxUnsupportedCommandLabelLen = 64`) before use, so a pathological client cannot pollute label values via protocol abuse (e.g. sending a huge first argument).

## Wiring

- `monitoring.RedisRequestReport` gains an `Unsupported bool` field. The adapter sets it to `true` only at the route-miss path via a new helper `observeRedisUnsupported`; all other call sites are unchanged.
- `RedisMetrics.ObserveRedisRequest` still runs the existing "unknown"-bucket path for unsupported commands, then *additionally* increments the new bounded counter when `Unsupported` is set.

## Test plan

- [x] `go test -race ./monitoring/...`
- [x] `go test -race ./adapter/...`
- [x] `golangci-lint run ./monitoring/... ./adapter/...`
- [x] Unsupported command records its real (uppercased) name.
- [x] Two different unsupported commands produce two label values.
- [x] The 33rd distinct name folds into `command="other"` and further overflow increments accumulate there.
- [x] An already-seen name (after cap reached) still records with its real label, not `"other"`.
- [x] Extreme-long (200-char) name is truncated to 64 chars.
- [x] Concurrent observers do not race (checked with `-race`).
- [x] Existing `NOTACOMMAND` test now asserts the new counter carries `NOTACOMMAND` alongside the unchanged `unknown` bucket.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated monitoring for unsupported Redis commands with a new metric tracking command names and frequency, enabling clearer visibility into command rejections.

* **Tests**
  * Expanded test coverage for unsupported command tracking, including label cardinality management and concurrent operation validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->