### PR TITLE
test(helper): event-driven leader-readiness with 300ms stability window

### DIFF
--- a/.github/workflows/jepsen-test-scheduled.yml
+++ b/.github/workflows/jepsen-test-scheduled.yml
@@ -101,6 +101,16 @@ jobs:
             --max-txn-length ${{ inputs.max-txn-length || '4' }} \
             --ports 63791,63792,63793 \
             --host 127.0.0.1
+      - name: Run Redis ZSet safety Jepsen workload against elastickv
+        working-directory: jepsen
+        timeout-minutes: 10
+        run: |
+          timeout 480 ~/lein run -m elastickv.redis-zset-safety-workload \
+            --time-limit ${{ inputs.time-limit || '150' }} \
+            --rate ${{ inputs.rate || '10' }} \
+            --concurrency ${{ inputs.concurrency || '8' }} \
+            --ports 63791,63792,63793 \
+            --host 127.0.0.1
       - name: Run DynamoDB Jepsen workload against elastickv
         working-directory: jepsen
         timeout-minutes: 10

--- a/.github/workflows/jepsen-test.yml
+++ b/.github/workflows/jepsen-test.yml
@@ -90,6 +90,11 @@ jobs:
         timeout-minutes: 3
         run: |
           timeout 120 ~/lein run -m elastickv.redis-workload --time-limit 5 --rate 5 --concurrency 5 --ports 63791,63792,63793 --host 127.0.0.1
+      - name: Run Redis ZSet safety Jepsen workload against elastickv
+        working-directory: jepsen
+        timeout-minutes: 3
+        run: |
+          timeout 120 ~/lein run -m elastickv.redis-zset-safety-workload --time-limit 5 --rate 5 --concurrency 5 --ports 63791,63792,63793 --host 127.0.0.1
       - name: Run DynamoDB Jepsen workload against elastickv
         working-directory: jepsen
         timeout-minutes: 3

--- a/adapter/test_util.go
+++ b/adapter/test_util.go
@@ -139,8 +139,9 @@ func newNode(grpcAddress, raftAddress, redisAddress, dynamoAddress string, r *ra
 //nolint:unparam
 func createNode(t *testing.T, n int) ([]Node, []string, []string) {
 	const (
-		waitTimeout  = 5 * time.Second
-		waitInterval = 100 * time.Millisecond
+		waitTimeout           = 5 * time.Second
+		waitInterval          = 100 * time.Millisecond
+		leaderReadinessWindow = 10 * time.Second
 	)
 
 	t.Helper()
@@ -152,7 +153,7 @@ func createNode(t *testing.T, n int) ([]Node, []string, []string) {
 
 	waitForNodeListeners(t, ctx, nodes, waitTimeout, waitInterval)
 	waitForConfigReplication(t, cfg, nodes, waitTimeout, waitInterval)
-	waitForRaftReadiness(t, nodes, waitTimeout, waitInterval)
+	waitForRaftReadiness(t, nodes, leaderReadinessWindow, waitInterval)
 
 	return nodes, grpcAdders, redisAdders
 }
@@ -218,28 +219,124 @@ func waitForNodeListeners(t *testing.T, ctx context.Context, nodes []Node, waitT
 	}
 }
 
+// leaderStabilityWindow is the duration a node must continuously report itself
+// as leader (and peers as followers pointing at it) before we treat the cluster
+// as ready. This absorbs the "elected then immediately stepped down" race
+// observed on slow CI, where quorum-active-timeout briefly flips the leader
+// back to follower moments after it wins an election.
+const leaderStabilityWindow = 300 * time.Millisecond
+
+// defaultStabilityPoll is the sampling interval used during the stability
+// window when the caller-supplied waitInterval is unsuitable (zero or larger
+// than the window itself).
+const defaultStabilityPoll = 25 * time.Millisecond
+
+// waitForRaftReadiness blocks until the bootstrap leader (nodes[0]) has been
+// elected AND has remained leader for leaderStabilityWindow, with all other
+// nodes acknowledging it as leader. It relies on raft.LeaderCh() for the
+// initial election event rather than polling, and then verifies stability to
+// filter out transient leadership flaps during CI congestion.
+//
+// waitInterval is the polling interval used during the stability window. The
+// parameter is preserved for backwards compatibility with existing call sites.
 func waitForRaftReadiness(t *testing.T, nodes []Node, waitTimeout, waitInterval time.Duration) {
 	t.Helper()
 
-	expectedLeader := raft.ServerAddress(nodes[0].raftAddress)
-	assert.Eventually(t, func() bool {
-		for i, n := range nodes {
-			state := n.raft.State()
-			if i == 0 {
-				if state != raft.Leader {
-					return false
-				}
-			} else if state != raft.Follower {
+	if len(nodes) == 0 {
+		return
+	}
+
+	leader := nodes[0]
+	followers := nodes[1:]
+	expectedLeader := raft.ServerAddress(leader.raftAddress)
+
+	stabilityPoll := waitInterval
+	if stabilityPoll <= 0 || stabilityPoll > leaderStabilityWindow {
+		stabilityPoll = defaultStabilityPoll
+	}
+
+	deadline := time.Now().Add(waitTimeout)
+	leaderCh := leader.raft.LeaderCh()
+
+	// Drain any stale notifications so we only observe this run's transitions.
+	drainLeaderCh(leaderCh)
+
+	var lastState raft.RaftState
+	for time.Now().Before(deadline) {
+		if !awaitLeaderElected(t, leader, leaderCh, deadline, waitTimeout) {
+			// Residual `false` on the channel; loop and keep waiting.
+			continue
+		}
+		if leaderHoldsStable(leader, followers, expectedLeader, stabilityPoll, &lastState) {
+			return
+		}
+		// Flipped during the window; go back to waiting for another `true`
+		// event from LeaderCh.
+	}
+
+	t.Fatalf("leader never stabilised within %s (last state: %s)", waitTimeout, lastState)
+}
+
+// awaitLeaderElected returns true once `leader` is in raft.Leader state. If
+// the node is not yet leader it blocks on leaderCh until a `true` notification
+// arrives or the deadline expires (t.Fatalf on timeout / channel close). It
+// returns false when a stale `false` is observed, asking the caller to retry.
+func awaitLeaderElected(t *testing.T, leader Node, leaderCh <-chan bool, deadline time.Time, waitTimeout time.Duration) bool {
+	t.Helper()
+	if leader.raft.State() == raft.Leader {
+		return true
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		t.Fatalf("no leader elected within %s (last state: %s)", waitTimeout, leader.raft.State())
+	}
+	select {
+	case became, ok := <-leaderCh:
+		if !ok {
+			t.Fatalf("leader channel closed before leadership acquired")
+		}
+		return became
+	case <-time.After(remaining):
+		t.Fatalf("no leader elected within %s (last state: %s)", waitTimeout, leader.raft.State())
+	}
+	return false
+}
+
+// drainLeaderCh consumes any buffered notifications on the leader channel so
+// that subsequent receives only observe post-drain events.
+func drainLeaderCh(ch <-chan bool) {
+	for {
+		select {
+		case <-ch:
+		default:
+			return
+		}
+	}
+}
+
+// leaderHoldsStable verifies the leader stays in raft.Leader state, and all
+// followers stay in raft.Follower pointing at expectedLeader, for the full
+// leaderStabilityWindow. Returns true on success, false if anything flips.
+func leaderHoldsStable(leader Node, followers []Node, expectedLeader raft.ServerAddress, poll time.Duration, lastState *raft.RaftState) bool {
+	stableUntil := time.Now().Add(leaderStabilityWindow)
+	for time.Now().Before(stableUntil) {
+		state := leader.raft.State()
+		*lastState = state
+		if state != raft.Leader {
+			return false
+		}
+		for _, f := range followers {
+			if f.raft.State() != raft.Follower {
 				return false
 			}
-
-			addr, _ := n.raft.LeaderWithID()
+			addr, _ := f.raft.LeaderWithID()
 			if addr != expectedLeader {
 				return false
 			}
 		}
-		return true
-	}, waitTimeout, waitInterval)
+		time.Sleep(poll)
+	}
+	return true
 }
 
 func waitForConfigReplication(t *testing.T, cfg raft.Configuration, nodes []Node, waitTimeout, waitInterval time.Duration) {

--- a/jepsen/src/elastickv/jepsen_test.clj
+++ b/jepsen/src/elastickv/jepsen_test.clj
@@ -18,6 +18,40 @@
 (defn elastickv-zset-safety-test []
   (zset-safety-workload/elastickv-zset-safety-test {}))
 
+(def ^:private test-fns
+  "Map of user-facing test names to their constructor fns. The first
+  positional CLI arg selects which workload runs; if absent or unknown,
+  we default to `elastickv-test` for backward compatibility with
+  pre-existing invocations."
+  {"elastickv-test"             elastickv-test
+   "elastickv-zset-safety-test" elastickv-zset-safety-test
+   "elastickv-dynamodb-test"    elastickv-dynamodb-test
+   "elastickv-s3-test"          elastickv-s3-test})
+
 (defn -main
+  "Dispatch to a named workload. Usage:
+
+    lein run -m elastickv.jepsen-test <test-name> [jepsen-subcmd] [jepsen-opts ...]
+
+  Supported <test-name>s: elastickv-test, elastickv-zset-safety-test,
+  elastickv-dynamodb-test, elastickv-s3-test. When the first positional
+  arg is not a known test name, we default to `elastickv-test` for
+  backward compatibility and forward ALL args to jepsen.cli/run!.
+
+  The jepsen subcommand (`test` or `analyze`) is auto-prepended when
+  missing, so `lein run elastickv-zset-safety-test --nodes n1,n2` works
+  without the user repeating `test`."
   [& args]
-  (cli/run! (cli/single-test-cmd {:test-fn elastickv-test}) args))
+  (let [[head & tail] args
+        [selected-fn remaining-args] (if-let [f (get test-fns head)]
+                                       [f tail]
+                                       [elastickv-test args])
+        ;; jepsen.cli/run! requires a subcommand ("test" or "analyze")
+        ;; as the first arg. Insert "test" if absent so users don't
+        ;; have to type it twice.
+        [next-head & _] remaining-args
+        final-args (if (#{"test" "analyze"} next-head)
+                     remaining-args
+                     (cons "test" remaining-args))]
+    (cli/run! (cli/single-test-cmd {:test-fn selected-fn})
+              final-args)))

--- a/jepsen/src/elastickv/jepsen_test.clj
+++ b/jepsen/src/elastickv/jepsen_test.clj
@@ -47,11 +47,21 @@
                                        [f tail]
                                        [elastickv-test args])
         ;; jepsen.cli/run! requires a subcommand ("test" or "analyze")
-        ;; as the first arg. Insert "test" if absent so users don't
-        ;; have to type it twice.
+        ;; as the first arg. Insert "test" only when the user clearly
+        ;; did NOT supply a subcommand:
+        ;;   - remaining-args is empty, OR
+        ;;   - the first token is an option (starts with "-")
+        ;; If the first token looks like a subcommand (any non-option
+        ;; word, e.g. "test", "analyze", "serve", or a future jepsen.cli
+        ;; subcommand we don't hard-code), leave it alone and let
+        ;; jepsen.cli/run! handle it (including producing a better
+        ;; error message for unknown subcommands than we could here).
         [next-head & _] remaining-args
-        final-args (if (#{"test" "analyze"} next-head)
-                     remaining-args
-                     (cons "test" remaining-args))]
+        prepend-test? (or (empty? remaining-args)
+                          (and (string? next-head)
+                               (.startsWith ^String next-head "-")))
+        final-args (if prepend-test?
+                     (cons "test" remaining-args)
+                     remaining-args)]
     (cli/run! (cli/single-test-cmd {:test-fn selected-fn})
               final-args)))

--- a/jepsen/src/elastickv/jepsen_test.clj
+++ b/jepsen/src/elastickv/jepsen_test.clj
@@ -1,6 +1,7 @@
 (ns elastickv.jepsen-test
   (:gen-class)
   (:require [elastickv.redis-workload :as redis-workload]
+            [elastickv.redis-zset-safety-workload :as zset-safety-workload]
             [elastickv.dynamodb-workload :as dynamodb-workload]
             [elastickv.s3-workload :as s3-workload]
             [jepsen.cli :as cli]))
@@ -13,6 +14,9 @@
 
 (defn elastickv-s3-test []
   (s3-workload/elastickv-s3-test {}))
+
+(defn elastickv-zset-safety-test []
+  (zset-safety-workload/elastickv-zset-safety-test {}))
 
 (defn -main
   [& args]

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -223,10 +223,18 @@
 
 (defn- completed-mutation-window
   "For each completed mutation, produce
-  {:member m :score s :zrem? bool? :invoke-idx i :complete-idx j :type t}.
-  For :zadd and :zincrby, :score is the final (committed) score. For :zrem,
-  :score is nil and :zrem? is true. :info (indeterminate) ops are kept as
-  possibly-applied with :type :info."
+  {:member m :score s :zrem? bool? :unknown-score? bool? :invoke-idx i
+   :complete-idx j :type t}.
+  - :zadd: :score is the requested score (always known).
+  - :zincrby: when :ok, :score is the server-returned final score. When
+    :info or pending, the resulting score is unknown (depends on which
+    other ops were applied first); :unknown-score? is set so allowed-
+    scores-for-member can short-circuit the strict score check.
+  - :zrem: :removed? is the boolean returned by ZREM (true iff the
+    member existed). A no-op ZREM (returns 0) does NOT mutate state, so
+    the model must not treat it as a deletion.
+  :info / :pending mutations are still emitted so concurrent windows
+  account for their possible effect."
   [pairs]
   (keep
     (fn [{:keys [invoke complete]}]
@@ -243,14 +251,30 @@
 
             :zincrby
             (let [[m _delta] (:value invoke)
-                  s (when (and (= :ok t) (vector? (:value complete)))
+                  ;; ZINCRBY's resulting score is only knowable from the
+                  ;; server reply. For :info/:pending we don't have it.
+                  ok? (= :ok t)
+                  s (when (and ok? (vector? (:value complete)))
                       (second (:value complete)))]
               {:f :zincrby :member m :score (some-> s double)
+               :unknown-score? (not (and ok? (some? s)))
                :type t :invoke-idx inv-idx :complete-idx cmp-idx})
 
             :zrem
-            (let [m (:value invoke)]
-              {:f :zrem :member m :score nil :zrem? true
+            (let [m (:value invoke)
+                  ;; invoke! returns [member removed?]. For :info we don't
+                  ;; know whether the member was removed.
+                  removed? (cond
+                             (and (= :ok t)
+                                  (vector? (:value complete)))
+                             (boolean (second (:value complete)))
+                             ;; pending / info: assume removal could have
+                             ;; happened; the checker treats it as a
+                             ;; possibly-concurrent deletion via the
+                             ;; concurrent window.
+                             :else true)]
+              {:f :zrem :member m :score nil
+               :zrem? true :removed? removed?
                :type t :invoke-idx inv-idx :complete-idx cmp-idx})))))
     pairs))
 
@@ -266,12 +290,23 @@
        (or (nil? (:complete-idx m))
            (>= (:complete-idx m) read-inv-idx))))
 
+(defn- apply-mutation-to-state
+  "Fold one mutation into a per-member state {:present? bool :score s}.
+  A no-op ZREM (member did not exist; :removed? false) leaves state
+  unchanged so the checker doesn't falsely conclude the member is gone."
+  [st m]
+  (case (:f m)
+    :zadd    {:present? true :score (:score m)}
+    :zincrby {:present? true :score (:score m)}
+    :zrem    (if (:removed? m)
+               {:present? false :score nil}
+               st)))
+
 (defn- model-before
-  "Construct model state from the set of mutations whose completions
-  strictly precede `read-inv-idx`. Model maps member -> {:score s} or
-  marks member as :deleted. Returns {:members map :ok-members set}.
-  Only considers :ok mutations for the authoritative model; :info
-  mutations are treated as uncertain (neither strictly applied nor not)."
+  "Construct authoritative per-member state from mutations whose
+  completions strictly precede read-inv-idx. Returns
+  {member -> {:present? bool :score s}}. Only :ok mutations contribute;
+  :info / :pending are deferred to the concurrent-window check."
   [mutations-by-m read-inv-idx]
   (reduce-kv
     (fn [model member muts]
@@ -280,14 +315,7 @@
                                        (some? (:complete-idx %))
                                        (< (:complete-idx %) read-inv-idx)))
                          (sort-by :complete-idx))
-            state (reduce
-                    (fn [st m]
-                      (case (:f m)
-                        :zadd    {:present? true :score (:score m)}
-                        :zincrby {:present? true :score (:score m)}
-                        :zrem    {:present? false :score nil}))
-                    nil
-                    applied)]
+            state (reduce apply-mutation-to-state nil applied)]
         (if state
           (assoc model member state)
           model)))
@@ -302,7 +330,18 @@
 (defn- allowed-scores-for-member
   "Compute the set of scores considered valid for `member` by a read
   whose window is [read-inv-idx, read-cmp-idx], based on committed state
-  and any concurrent mutations."
+  and any concurrent mutations.
+
+  Returns:
+    :scores            - set of acceptable scores (committed + concurrent
+                         :zadd / :ok :zincrby).
+    :unknown-score?    - true iff any concurrent ZINCRBY's resulting score
+                         is unknown (in-flight or :info). When set, the
+                         caller MUST skip the strict score-membership
+                         check to stay sound.
+    :must-be-present?  - committed state says present and no concurrent
+                         mutation could have removed/changed it.
+    :any-known?        - some op claims to have touched this member."
   [mutations-by-m member read-inv-idx read-cmp-idx]
   (let [muts (get mutations-by-m member [])
         committed (->> muts
@@ -310,13 +349,7 @@
                                      (some? (:complete-idx %))
                                      (< (:complete-idx %) read-inv-idx)))
                        (sort-by :complete-idx))
-        committed-state (reduce
-                          (fn [st m]
-                            (case (:f m)
-                              (:zadd :zincrby) {:present? true :score (:score m)}
-                              :zrem            {:present? false :score nil}))
-                          nil
-                          committed)
+        committed-state (reduce apply-mutation-to-state nil committed)
         concurrent (concurrent-mutations-for-member muts read-inv-idx read-cmp-idx)
         scores (cond-> #{}
                  (and committed-state (:present? committed-state))
@@ -328,8 +361,12 @@
                      :zincrby (cond-> acc (some? (:score m)) (conj (:score m)))
                      :zrem    acc))
                  scores
-                 concurrent)]
+                 concurrent)
+        unknown-score? (some #(and (= :zincrby (:f %))
+                                   (:unknown-score? %))
+                             concurrent)]
       {:scores scores
+       :unknown-score? (boolean unknown-score?)
        :must-be-present? (boolean (and committed-state (:present? committed-state)
                                        (empty? concurrent)))
        :any-known? (or (boolean committed-state) (seq concurrent))}))
@@ -347,7 +384,7 @@
                           :entries entries}))
     ;; 2. For each observed (member,score): validate score and non-phantom
     (doseq [[member score] entries]
-      (let [{:keys [scores any-known?]}
+      (let [{:keys [scores any-known? unknown-score?]}
             (allowed-scores-for-member mutations-by-m member inv-idx cmp-idx)]
         (cond
           (not any-known?)
@@ -355,6 +392,10 @@
                               :index cmp-idx
                               :member member
                               :score score})
+          ;; Skip the strict score check when any concurrent ZINCRBY's
+          ;; resulting score is unknown: the read could legitimately
+          ;; observe any value the in-flight increment produces.
+          unknown-score? nil
           (not (contains? scores score))
           (swap! errors conj {:kind :score-mismatch
                               :index cmp-idx
@@ -394,7 +435,7 @@
                             :bounds bounds
                             :member member
                             :score score}))
-      (let [{:keys [scores any-known?]}
+      (let [{:keys [scores any-known? unknown-score?]}
             (allowed-scores-for-member mutations-by-m member inv-idx cmp-idx)]
         (cond
           (not any-known?)
@@ -402,6 +443,7 @@
                               :index cmp-idx
                               :member member
                               :score score})
+          unknown-score? nil
           (not (contains? scores score))
           (swap! errors conj {:kind :score-mismatch-range
                               :index cmp-idx

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -421,16 +421,6 @@
   [m]
   (#{:zadd :zincrby} (:f m)))
 
-(defn- existence-evidence?
-  "A mutation proves that the member existed at some point iff it is a
-  write-op, or a ZREM whose :removed? flag is true. No-op ZREMs
-  (:removed? false) do NOT prove existence."
-  [m]
-  (case (:f m)
-    (:zadd :zincrby) true
-    :zrem            (boolean (:removed? m))
-    false))
-
 (defn- allowed-scores-for-member
   "Compute the set of scores considered valid for `member` by a read
   whose window is [read-inv-idx, read-cmp-idx], based on committed state
@@ -561,13 +551,16 @@
 
         ;; can-be-present?: at least one admissible linearization
         ;; (candidates + uncertain) ends with the member present.
-        ;; An uncertain write (or an uncertain :zrem combined with
-        ;; existence evidence) can flip an otherwise-absent candidate
-        ;; outcome to present by reordering after a write.
+        ;; Presence REQUIRES a write-op (ZADD / ZINCRBY) somewhere in
+        ;; the admissible set -- either a candidate committed write or
+        ;; an uncertain concurrent/pre-read :info write. ZREM never
+        ;; contributes existence evidence: since `setup!` clears the
+        ;; key at test start, an observed member that never had a ZADD
+        ;; or ZINCRBY touch it must be a phantom regardless of any
+        ;; ZREM's :removed? flag (which may be defaulted to true on
+        ;; :info for uncertainty accounting only).
         can-be-present? (or candidate-can-be-present?
-                            any-uncertain-write?
-                            (and any-uncertain-zrem?
-                                 (some existence-evidence? uncertain)))
+                            any-uncertain-write?)
 
         ;; must-be-present?: EVERY admissible linearization ends with
         ;; the member present. Requires the candidate outcome to be

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -116,7 +116,7 @@
     ;; Carmine surfaces Redis error replies as exceptions by default,
     ;; but some codepaths wrap them in an ex-info / Throwable value.
     (instance? Throwable response)
-    [:error (.getMessage ^Throwable response)]
+    [:error (or (.getMessage ^Throwable response) (str response))]
 
     :else
     [:unexpected response]))
@@ -184,7 +184,7 @@
           (warn t "ZSet safety setup! DEL failed -- aborting to avoid stale data")
           (throw (ex-info
                    (str "ZSet safety setup! failed to clear prior state at "
-                        zset-key ": " (.getMessage t)
+                        zset-key ": " (or (.getMessage t) (str t))
                         ". Refusing to run against potentially stale data.")
                    {:type ::cleanup-failed
                     :zset-key zset-key}
@@ -245,7 +245,7 @@
                                         :members (parse-withscores flat)})))
         (catch Exception e
           (warn e (str "ZSet safety op failed: " (:f op)))
-          (assoc op :type :info :error (.getMessage e)))))))
+          (assoc op :type :info :error (or (.getMessage e) (str e))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Generator

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -129,7 +129,7 @@
   (->> flat
        (partition 2)
        (mapv (fn [[m s]]
-               [(if (bytes? m) (String. ^bytes m) (str m))
+               [(if (bytes? m) (String. ^bytes m "UTF-8") (str m))
                 (parse-double-safe s)]))))
 
 (defn- zincrby!

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -68,6 +68,24 @@
 ;; Client
 ;; ---------------------------------------------------------------------------
 
+(defn- parse-double-safe
+  "Parse a Redis score string into a Double. Redis serializes infinite
+  scores as \"inf\" / \"+inf\" / \"-inf\", which Java's Double/parseDouble
+  does not accept (it expects \"Infinity\" / \"-Infinity\"). Handle both
+  encodings so the checker doesn't throw on infinite ZSET scores."
+  [s]
+  (let [raw   (str s)
+        lower (str/lower-case raw)]
+    (cond
+      (or (= lower "inf") (= lower "+inf") (= lower "infinity") (= lower "+infinity"))
+      Double/POSITIVE_INFINITY
+
+      (or (= lower "-inf") (= lower "-infinity"))
+      Double/NEGATIVE_INFINITY
+
+      :else
+      (Double/parseDouble raw))))
+
 (defn- parse-withscores
   "Carmine returns a flat [member score member score ...] vector for
   ZRANGE WITHSCORES. Convert to a sorted vector of [member (double score)]
@@ -77,7 +95,7 @@
        (partition 2)
        (mapv (fn [[m s]]
                [(if (bytes? m) (String. ^bytes m) (str m))
-                (Double/parseDouble (str s))]))))
+                (parse-double-safe s)]))))
 
 (defrecord ElastickvRedisZSetSafetyClient [node->port conn-spec]
   client/Client
@@ -113,7 +131,7 @@
           (let [[member delta] (:value op)
                 new-score (car/wcar cs (car/zincrby zset-key (double delta) member))]
             (assoc op :type :ok
-                   :value [member (Double/parseDouble (str new-score))]))
+                   :value [member (parse-double-safe new-score)]))
 
           :zrem
           (let [member (:value op)
@@ -327,33 +345,65 @@
   [muts read-inv-idx read-cmp-idx]
   (filter #(concurrent? % read-inv-idx read-cmp-idx) muts))
 
+(defn- write-op?
+  "True iff the mutation adds/updates the member's score (i.e. would
+  make the member present). :zrem is NOT a write-op here."
+  [m]
+  (#{:zadd :zincrby} (:f m)))
+
+(defn- existence-evidence?
+  "A mutation proves that the member existed at some point iff it is a
+  write-op, or a ZREM whose :removed? flag is true. No-op ZREMs
+  (:removed? false) do NOT prove existence."
+  [m]
+  (case (:f m)
+    (:zadd :zincrby) true
+    :zrem            (boolean (:removed? m))
+    false))
+
 (defn- allowed-scores-for-member
   "Compute the set of scores considered valid for `member` by a read
   whose window is [read-inv-idx, read-cmp-idx], based on committed state
-  and any concurrent mutations.
+  and any concurrent/uncertain mutations.
+
+  Linearizability demands a read observes either (a) the latest committed
+  state in real-time order, or (b) the effect of a write still concurrent
+  with the read. We therefore restrict the committed score set to
+  'candidates' — committed mutations NOT strictly followed in real time
+  by another committed mutation (i.e. no other committed op's invoke
+  comes after this op's completion). Scores from strictly superseded
+  committed mutations are NOT admissible.
 
   Returns:
-    :scores            - set of acceptable scores (committed + concurrent
-                         :zadd / :ok :zincrby).
-    :unknown-score?    - true iff any concurrent ZINCRBY's resulting score
-                         is unknown (in-flight or :info). When set, the
-                         caller MUST skip the strict score-membership
+    :scores            - set of acceptable scores (from candidate
+                         committed ops + pre-read :info + concurrent
+                         writes with a known score).
+    :unknown-score?    - true iff any concurrent / pre-read :info
+                         ZINCRBY's resulting score is unknown. When set,
+                         the caller MUST skip the strict score-membership
                          check to stay sound.
-    :must-be-present?  - committed state says present and no concurrent
-                         mutation could have removed/changed it.
-    :any-known?        - some op claims to have touched this member."
+    :can-be-present?   - true iff the member may legitimately appear in
+                         the read (some candidate/concurrent/pre-read
+                         :info op is a write, OR a concurrent/pre-read
+                         :info ZREM leaves presence uncertain).
+    :must-be-present?  - true iff a candidate committed state says
+                         present and nothing concurrent/pre-read :info
+                         could have removed it."
   [mutations-by-m member read-inv-idx read-cmp-idx]
   (let [muts (get mutations-by-m member [])
-        ;; :ok mutations that completed strictly before the read. They
-        ;; may have overlapped with each other in wall-clock time, so
-        ;; the serialization order among them is ambiguous.
-        committed (->> muts
+        ;; :ok mutations that completed strictly before the read.
+        preceding (->> muts
                        (filter #(and (= :ok (:type %))
                                      (some? (:complete-idx %))
                                      (< (:complete-idx %) read-inv-idx))))
+        ;; Real-time "last-wins" candidate filter: a preceding mutation
+        ;; m is admissible iff no OTHER preceding mutation m' has
+        ;; m'.invoke-idx > m.complete-idx (i.e. m' strictly follows m).
+        ;; Equivalent: m.complete-idx >= max(invoke-idx) over preceding.
+        max-inv (reduce max -1 (map :invoke-idx preceding))
+        candidates (filterv #(>= (:complete-idx %) max-inv) preceding)
         ;; :info mutations that completed before the read: they may or
-        ;; may not have taken effect server-side. We must account for
-        ;; their possible scores just like concurrent ones.
+        ;; may not have taken effect server-side.
         pre-read-info (->> muts
                            (filter #(and (= :info (:type %))
                                          (some? (:complete-idx %))
@@ -361,61 +411,55 @@
         ;; Concurrent mutations: windows overlap the read. Include both
         ;; :ok and :info since either may have taken effect.
         concurrent (concurrent-mutations-for-member muts read-inv-idx read-cmp-idx)
-        ;; A conservative last-wins linearization for the must-be-present?
-        ;; check only. Ambiguous when committed writes overlap each other.
-        committed-sorted (sort-by :complete-idx committed)
-        committed-state (reduce apply-mutation-to-state nil committed-sorted)
-        committed-overlap? (boolean
-                             (some (fn [[a b]]
-                                     (and (not (identical? a b))
-                                          (<= (:invoke-idx a) (:complete-idx b))
-                                          (<= (:invoke-idx b) (:complete-idx a))))
-                                   (for [a committed, b committed] [a b])))
-        ;; Union of every score that any committed / pre-read :info /
-        ;; concurrent op could have produced. This over-approximates the
-        ;; legitimate post-state set when writes overlap, keeping the
-        ;; checker sound at the cost of being slightly less strict on
-        ;; overlapping concurrent writers.
+
         add-scores (fn [acc m]
                      (case (:f m)
                        :zadd    (conj acc (:score m))
                        :zincrby (cond-> acc (some? (:score m)) (conj (:score m)))
                        :zrem    acc))
+        ;; Admissible scores: candidate committed + pre-read :info +
+        ;; concurrent writes (with a known score).
         scores (as-> #{} s
-                 (reduce add-scores s committed)
+                 (reduce add-scores s candidates)
                  (reduce add-scores s pre-read-info)
                  (reduce add-scores s concurrent))
-        unknown-score? (or
-                         (some #(and (= :zincrby (:f %)) (:unknown-score? %))
-                               concurrent)
-                         (some #(and (= :zincrby (:f %)) (:unknown-score? %))
-                               pre-read-info))
-        ;; any-known? must only be true when something provides evidence
-        ;; the member actually existed at some point. A no-op ZREM
-        ;; (:removed? false) does NOT prove existence.
-        existence-evidence? (or (some #(case (:f %)
-                                         (:zadd :zincrby) true
-                                         :zrem            (:removed? %))
-                                      committed)
-                                (some #(case (:f %)
-                                         (:zadd :zincrby) true
-                                         :zrem            (:removed? %))
-                                      pre-read-info)
-                                (some #(case (:f %)
-                                         (:zadd :zincrby) true
-                                         :zrem            (:removed? %))
-                                      concurrent))]
-      {:scores scores
-       :unknown-score? (boolean unknown-score?)
-       ;; must-be-present? is relaxed when committed writes overlap
-       ;; among themselves or when any :info / concurrent mutation could
-       ;; have removed the member before the read.
-       :must-be-present? (boolean (and committed-state
-                                       (:present? committed-state)
-                                       (not committed-overlap?)
+
+        has-unknown-incr? (fn [coll]
+                            (some #(and (= :zincrby (:f %))
+                                        (:unknown-score? %))
+                                  coll))
+        unknown-score? (or (has-unknown-incr? concurrent)
+                           (has-unknown-incr? pre-read-info))
+
+        ;; Did any candidate commit establish presence (write, or
+        ;; ZREM with :removed? -- either way the member existed)?
+        candidate-state (reduce apply-mutation-to-state nil
+                                (sort-by :complete-idx candidates))
+        candidate-present? (boolean (:present? candidate-state))
+
+        any-concurrent-could-write? (or (some write-op? concurrent)
+                                        (some write-op? pre-read-info))
+        any-concurrent-could-remove? (or (some #(= :zrem (:f %)) concurrent)
+                                         (some #(= :zrem (:f %)) pre-read-info))
+
+        can-be-present? (or candidate-present?
+                            any-concurrent-could-write?
+                            ;; A :zrem with :removed? true still proves
+                            ;; existence; if a concurrent ZREM raced
+                            ;; with an earlier write whose window is
+                            ;; not captured as a candidate, presence is
+                            ;; uncertain rather than forbidden.
+                            (and (some existence-evidence? (concat concurrent
+                                                                   pre-read-info))
+                                 any-concurrent-could-remove?))
+
+        must-be-present? (boolean (and candidate-present?
                                        (empty? pre-read-info)
-                                       (empty? concurrent)))
-       :any-known? (boolean existence-evidence?)}))
+                                       (empty? concurrent)))]
+    {:scores           scores
+     :unknown-score?   (boolean unknown-score?)
+     :can-be-present?  (boolean can-be-present?)
+     :must-be-present? must-be-present?}))
 
 (defn- duplicate-members
   "Return the set of members that appear more than once in entries."
@@ -445,13 +489,16 @@
         (swap! errors conj {:kind :duplicate-members
                             :index cmp-idx
                             :members dupes})))
-    ;; 2. For each observed (member,score): validate score and non-phantom
+    ;; 2. For each observed (member,score): validate presence + score.
+    ;;    can-be-present? catches both phantoms (member never existed)
+    ;;    and stale reads (member committed-removed before the read
+    ;;    with no concurrent re-add).
     (doseq [[member score] entries]
-      (let [{:keys [scores any-known? unknown-score?]}
+      (let [{:keys [scores can-be-present? unknown-score?]}
             (allowed-scores-for-member mutations-by-m member inv-idx cmp-idx)]
         (cond
-          (not any-known?)
-          (swap! errors conj {:kind :phantom
+          (not can-be-present?)
+          (swap! errors conj {:kind :unexpected-presence
                               :index cmp-idx
                               :member member
                               :score score})
@@ -504,11 +551,11 @@
                             :bounds bounds
                             :member member
                             :score score}))
-      (let [{:keys [scores any-known? unknown-score?]}
+      (let [{:keys [scores can-be-present? unknown-score?]}
             (allowed-scores-for-member mutations-by-m member inv-idx cmp-idx)]
         (cond
-          (not any-known?)
-          (swap! errors conj {:kind :phantom-range
+          (not can-be-present?)
+          (swap! errors conj {:kind :unexpected-presence-range
                               :index cmp-idx
                               :member member
                               :score score})

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -177,7 +177,7 @@
       ;; run survives under zset-key and can produce false-positive
       ;; safety verdicts in the checker. Log loudly AND re-throw so
       ;; Jepsen aborts the run instead of silently running against
-      ;; dirty state. (gemini MEDIUM)
+      ;; dirty state.
       (try
         (car/wcar cs (car/del zset-key))
         (catch Throwable t
@@ -769,7 +769,7 @@
                          []
                          read-pairs)
             by-kind (group-by :kind all-errors)
-            ;; Vacuous-pass guard (codex P1): if the run produced zero
+            ;; Vacuous-pass guard: if the run produced zero
             ;; successful reads, we have no evidence that the system
             ;; under test actually satisfies ZSet safety -- every op
             ;; may have been downgraded to :info because Redis was

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -1,0 +1,555 @@
+(ns elastickv.redis-zset-safety-workload
+  "Jepsen workload verifying stronger safety properties of elastickv's
+  Redis ZSet (sorted set) implementation under faults.
+
+  Beyond the simple visibility check in redis-zset-workload, this workload
+  exercises score correctness, ordering, range queries, phantom-member
+  freedom, and atomicity of compound ZSet mutations by using a custom,
+  model-based Checker.
+
+  Operations (all target a single well-known key):
+
+    {:f :zadd          :value [member score]}   ZADD key score member
+    {:f :zincrby       :value [member delta]}   ZINCRBY key delta member
+    {:f :zrem          :value member}           ZREM key member
+    {:f :zrange-all}                            ZRANGE key 0 -1 WITHSCORES
+    {:f :zrangebyscore :value [lo hi]}          ZRANGEBYSCORE key lo hi WITHSCORES
+
+  Semantics checked (see `zset-safety-checker`):
+
+  1. Score correctness: the score of any member observed by a :zrange-all
+     read must match the model's latest committed score for that member,
+     OR must match a score written by an operation that is concurrent with
+     the read (we cannot linearize concurrent writes to the same member,
+     so any such \"in-flight\" value is permitted).
+  2. Order preservation: the result of :zrange-all must be sorted by
+     (score ascending, member lexicographically ascending).
+  3. ZRANGEBYSCORE correctness: every member in a score-range read must
+     have a latest committed (or concurrent) score within [lo, hi]; and
+     every model member with a score in [lo, hi] must either be present
+     or be subject to a concurrent mutation.
+  4. No phantom members: every member observed by a read must have been
+     introduced by some successful (or in-flight) operation.
+  5. Atomicity: there is no explicit \"partial\" state to probe from the
+     client, but the checker treats every :ok operation as atomic — any
+     visible inconsistency (member present with no matching op, score
+     disagreeing with any known write, etc.) is reported."
+  (:require [clojure.string :as str]
+            [clojure.tools.logging :refer [warn]]
+            [elastickv.cli :as cli]
+            [elastickv.db :as ekdb]
+            [jepsen.db :as jdb]
+            [jepsen [checker :as checker]
+                    [client :as client]
+                    [generator :as gen]
+                    [net :as net]]
+            [jepsen.checker.timeline :as timeline]
+            [jepsen.control :as control]
+            [jepsen.nemesis :as nemesis]
+            [jepsen.nemesis.combined :as combined]
+            [jepsen.os :as os]
+            [jepsen.os.debian :as debian]
+            [taoensso.carmine :as car]))
+
+;; ---------------------------------------------------------------------------
+;; Constants
+;; ---------------------------------------------------------------------------
+
+(def ^:private zset-key "jepsen-zset-safety")
+
+(def default-nodes ["n1" "n2" "n3" "n4" "n5"])
+
+;; A small, fixed universe of members keeps contention high and makes the
+;; model's state small enough to enumerate.
+(def ^:private members
+  (mapv #(str "m" %) (range 16)))
+
+;; ---------------------------------------------------------------------------
+;; Client
+;; ---------------------------------------------------------------------------
+
+(defn- parse-withscores
+  "Carmine returns a flat [member score member score ...] vector for
+  ZRANGE WITHSCORES. Convert to a sorted vector of [member (double score)]
+  preserving server-returned order (score ascending, then member)."
+  [flat]
+  (->> flat
+       (partition 2)
+       (mapv (fn [[m s]]
+               [(if (bytes? m) (String. ^bytes m) (str m))
+                (Double/parseDouble (str s))]))))
+
+(defrecord ElastickvRedisZSetSafetyClient [node->port conn-spec]
+  client/Client
+
+  (open! [this test node]
+    (let [port (get node->port node 6379)
+          host (or (:redis-host test) (name node))]
+      (assoc this :conn-spec {:pool {} :spec {:host host
+                                              :port port
+                                              :timeout-ms 10000}})))
+
+  (close! [this _test] this)
+
+  (setup! [this _test]
+    (when-let [cs (:conn-spec this)]
+      (try (car/wcar cs (car/del zset-key))
+           (catch Exception e
+             (warn "ZSet safety setup DEL failed:" (.getMessage e)))))
+    this)
+
+  (teardown! [this _test] this)
+
+  (invoke! [_ _test op]
+    (let [cs conn-spec]
+      (try
+        (case (:f op)
+          :zadd
+          (let [[member score] (:value op)]
+            (car/wcar cs (car/zadd zset-key (double score) member))
+            (assoc op :type :ok))
+
+          :zincrby
+          (let [[member delta] (:value op)
+                new-score (car/wcar cs (car/zincrby zset-key (double delta) member))]
+            (assoc op :type :ok
+                   :value [member (Double/parseDouble (str new-score))]))
+
+          :zrem
+          (let [member (:value op)
+                removed (car/wcar cs (car/zrem zset-key member))]
+            (assoc op :type :ok :value [member (pos? (long removed))]))
+
+          :zrange-all
+          (let [flat (car/wcar cs (car/zrange zset-key 0 -1 "WITHSCORES"))]
+            (assoc op :type :ok :value (parse-withscores flat)))
+
+          :zrangebyscore
+          (let [[lo hi] (:value op)
+                flat (car/wcar cs (car/zrangebyscore zset-key
+                                                     (double lo)
+                                                     (double hi)
+                                                     "WITHSCORES"))]
+            (assoc op :type :ok :value {:bounds [lo hi]
+                                        :members (parse-withscores flat)})))
+        (catch Exception e
+          (warn "ZSet safety op failed:" (:f op) (.getMessage e))
+          (assoc op :type :info :error (.getMessage e)))))))
+
+;; ---------------------------------------------------------------------------
+;; Generator
+;; ---------------------------------------------------------------------------
+
+(defn- rand-member [] (rand-nth members))
+
+(defn- gen-op []
+  (let [roll (rand)]
+    (cond
+      (< roll 0.35)
+      {:f :zadd :value [(rand-member) (double (- (rand-int 200) 100))]}
+
+      (< roll 0.55)
+      {:f :zincrby :value [(rand-member)
+                           (double (- (rand-int 20) 10))]}
+
+      (< roll 0.65)
+      {:f :zrem :value (rand-member)}
+
+      (< roll 0.90)
+      {:f :zrange-all}
+
+      :else
+      (let [a (- (rand-int 200) 100)
+            b (- (rand-int 200) 100)]
+        {:f :zrangebyscore :value [(double (min a b)) (double (max a b))]}))))
+
+(defn- op-generator []
+  (reify gen/Generator
+    (op [this test ctx]
+      [(gen/fill-in-op (gen-op) ctx) this])
+    (update [this _ _ _] this)))
+
+;; ---------------------------------------------------------------------------
+;; Checker
+;; ---------------------------------------------------------------------------
+
+(defn- sorted-by-score-then-member?
+  "Validates the zset invariant: (score, member) ascending, strict."
+  [entries]
+  (loop [prev nil
+         es entries]
+    (cond
+      (empty? es) true
+      (nil? prev) (recur (first es) (rest es))
+      :else
+      (let [[pm ps] prev
+            [cm cs] (first es)]
+        (cond
+          (< ps cs) (recur (first es) (rest es))
+          (> ps cs) false
+          ;; equal score: members must be strictly lexicographically ordered
+          (neg? (compare pm cm)) (recur (first es) (rest es))
+          :else false)))))
+
+(defn- index-by-time
+  "Return a vector of ops sorted by :index."
+  [ops]
+  (vec (sort-by :index ops)))
+
+(defn- pair-invokes-with-completions
+  "Returns a sequence of {:invoke inv :complete cmp} pairs for each
+  completed op (ok/fail/info). Invokes without a matching completion are
+  paired with nil (still in flight at history end)."
+  [history]
+  (let [by-process (group-by :process history)]
+    (mapcat
+      (fn [[_p ops]]
+        (let [ops (index-by-time ops)]
+          (loop [ops ops acc []]
+            (if (empty? ops) acc
+              (let [[o & rest-ops] ops]
+                (cond
+                  (= :invoke (:type o))
+                  (let [c (first rest-ops)]
+                    (if (and c (#{:ok :fail :info} (:type c)))
+                      (recur (drop 1 rest-ops) (conj acc {:invoke o :complete c}))
+                      (recur rest-ops (conj acc {:invoke o :complete nil}))))
+                  :else (recur rest-ops acc)))))))
+      by-process)))
+
+(defn- mutation?
+  [op]
+  (#{:zadd :zincrby :zrem} (:f op)))
+
+(defn- completed-mutation-window
+  "For each completed mutation, produce
+  {:member m :score s :zrem? bool? :invoke-idx i :complete-idx j :type t}.
+  For :zadd and :zincrby, :score is the final (committed) score. For :zrem,
+  :score is nil and :zrem? is true. :info (indeterminate) ops are kept as
+  possibly-applied with :type :info."
+  [pairs]
+  (keep
+    (fn [{:keys [invoke complete]}]
+      (when (and invoke (mutation? invoke))
+        (let [f (:f invoke)
+              t (if complete (:type complete) :pending)
+              inv-idx (:index invoke)
+              cmp-idx (when complete (:index complete))]
+          (case f
+            :zadd
+            (let [[m s] (:value invoke)]
+              {:f :zadd :member m :score (double s)
+               :type t :invoke-idx inv-idx :complete-idx cmp-idx})
+
+            :zincrby
+            (let [[m _delta] (:value invoke)
+                  s (when (and (= :ok t) (vector? (:value complete)))
+                      (second (:value complete)))]
+              {:f :zincrby :member m :score (some-> s double)
+               :type t :invoke-idx inv-idx :complete-idx cmp-idx})
+
+            :zrem
+            (let [m (:value invoke)]
+              {:f :zrem :member m :score nil :zrem? true
+               :type t :invoke-idx inv-idx :complete-idx cmp-idx})))))
+    pairs))
+
+(defn- mutations-by-member
+  [mutations]
+  (group-by :member mutations))
+
+(defn- concurrent?
+  "A mutation m is concurrent with a read r iff m's invoke precedes r's
+  completion AND m's completion (or end-of-history) follows r's invoke."
+  [m read-inv-idx read-cmp-idx]
+  (and (<= (:invoke-idx m) read-cmp-idx)
+       (or (nil? (:complete-idx m))
+           (>= (:complete-idx m) read-inv-idx))))
+
+(defn- model-before
+  "Construct model state from the set of mutations whose completions
+  strictly precede `read-inv-idx`. Model maps member -> {:score s} or
+  marks member as :deleted. Returns {:members map :ok-members set}.
+  Only considers :ok mutations for the authoritative model; :info
+  mutations are treated as uncertain (neither strictly applied nor not)."
+  [mutations-by-m read-inv-idx]
+  (reduce-kv
+    (fn [model member muts]
+      (let [applied (->> muts
+                         (filter #(and (= :ok (:type %))
+                                       (some? (:complete-idx %))
+                                       (< (:complete-idx %) read-inv-idx)))
+                         (sort-by :complete-idx))
+            state (reduce
+                    (fn [st m]
+                      (case (:f m)
+                        :zadd    {:present? true :score (:score m)}
+                        :zincrby {:present? true :score (:score m)}
+                        :zrem    {:present? false :score nil}))
+                    nil
+                    applied)]
+        (if state
+          (assoc model member state)
+          model)))
+    {}
+    mutations-by-m))
+
+(defn- concurrent-mutations-for-member
+  "All mutations (ok or info) that are concurrent with the read window."
+  [muts read-inv-idx read-cmp-idx]
+  (filter #(concurrent? % read-inv-idx read-cmp-idx) muts))
+
+(defn- allowed-scores-for-member
+  "Compute the set of scores considered valid for `member` by a read
+  whose window is [read-inv-idx, read-cmp-idx], based on committed state
+  and any concurrent mutations."
+  [mutations-by-m member read-inv-idx read-cmp-idx]
+  (let [muts (get mutations-by-m member [])
+        committed (->> muts
+                       (filter #(and (= :ok (:type %))
+                                     (some? (:complete-idx %))
+                                     (< (:complete-idx %) read-inv-idx)))
+                       (sort-by :complete-idx))
+        committed-state (reduce
+                          (fn [st m]
+                            (case (:f m)
+                              (:zadd :zincrby) {:present? true :score (:score m)}
+                              :zrem            {:present? false :score nil}))
+                          nil
+                          committed)
+        concurrent (concurrent-mutations-for-member muts read-inv-idx read-cmp-idx)
+        scores (cond-> #{}
+                 (and committed-state (:present? committed-state))
+                 (conj (:score committed-state)))
+        scores (reduce
+                 (fn [acc m]
+                   (case (:f m)
+                     :zadd    (conj acc (:score m))
+                     :zincrby (cond-> acc (some? (:score m)) (conj (:score m)))
+                     :zrem    acc))
+                 scores
+                 concurrent)]
+      {:scores scores
+       :must-be-present? (boolean (and committed-state (:present? committed-state)
+                                       (empty? concurrent)))
+       :any-known? (or (boolean committed-state) (seq concurrent))}))
+
+(defn- check-zrange-all
+  [mutations-by-m {:keys [invoke complete] :as _pair}]
+  (let [entries (:value complete)
+        inv-idx (:index invoke)
+        cmp-idx (:index complete)
+        errors (atom [])]
+    ;; 1. Ordering
+    (when-not (sorted-by-score-then-member? entries)
+      (swap! errors conj {:kind :unsorted
+                          :index cmp-idx
+                          :entries entries}))
+    ;; 2. For each observed (member,score): validate score and non-phantom
+    (doseq [[member score] entries]
+      (let [{:keys [scores any-known?]}
+            (allowed-scores-for-member mutations-by-m member inv-idx cmp-idx)]
+        (cond
+          (not any-known?)
+          (swap! errors conj {:kind :phantom
+                              :index cmp-idx
+                              :member member
+                              :score score})
+          (not (contains? scores score))
+          (swap! errors conj {:kind :score-mismatch
+                              :index cmp-idx
+                              :member member
+                              :observed score
+                              :allowed scores}))))
+    ;; 3. Completeness: model-required members must appear.
+    (let [model (model-before mutations-by-m inv-idx)
+          observed-members (into #{} (map first) entries)]
+      (doseq [[member {:keys [present?]}] model]
+        (when (and present? (not (contains? observed-members member)))
+          (let [muts (get mutations-by-m member [])
+                concurrent (concurrent-mutations-for-member muts inv-idx cmp-idx)]
+            (when (empty? concurrent)
+              (swap! errors conj {:kind :missing-member
+                                  :index cmp-idx
+                                  :member member}))))))
+    @errors))
+
+(defn- check-zrangebyscore
+  [mutations-by-m {:keys [invoke complete] :as _pair}]
+  (let [{:keys [bounds members]} (:value complete)
+        [lo hi] bounds
+        inv-idx (:index invoke)
+        cmp-idx (:index complete)
+        errors (atom [])]
+    (when-not (sorted-by-score-then-member? members)
+      (swap! errors conj {:kind :unsorted-range
+                          :index cmp-idx
+                          :bounds bounds
+                          :members members}))
+    ;; Observed members must be within bounds AND have a known allowed score.
+    (doseq [[member score] members]
+      (when (or (< score lo) (> score hi))
+        (swap! errors conj {:kind :out-of-range
+                            :index cmp-idx
+                            :bounds bounds
+                            :member member
+                            :score score}))
+      (let [{:keys [scores any-known?]}
+            (allowed-scores-for-member mutations-by-m member inv-idx cmp-idx)]
+        (cond
+          (not any-known?)
+          (swap! errors conj {:kind :phantom-range
+                              :index cmp-idx
+                              :member member
+                              :score score})
+          (not (contains? scores score))
+          (swap! errors conj {:kind :score-mismatch-range
+                              :index cmp-idx
+                              :member member
+                              :observed score
+                              :allowed scores}))))
+    ;; Completeness within bounds: any model member whose committed score
+    ;; is in [lo,hi] with no concurrent mutation must appear.
+    (let [model (model-before mutations-by-m inv-idx)
+          observed-members (into #{} (map first) members)]
+      (doseq [[member {:keys [present? score]}] model]
+        (when (and present?
+                   (<= lo score hi)
+                   (not (contains? observed-members member)))
+          (let [muts (get mutations-by-m member [])
+                concurrent (concurrent-mutations-for-member muts inv-idx cmp-idx)]
+            (when (empty? concurrent)
+              (swap! errors conj {:kind :missing-member-range
+                                  :index cmp-idx
+                                  :bounds bounds
+                                  :member member
+                                  :expected-score score}))))))
+    @errors))
+
+(defn zset-safety-checker
+  "Custom Jepsen checker: validates ZSet safety properties using a
+  last-writer model combined with a concurrent-write relaxation."
+  []
+  (reify checker/Checker
+    (check [_ _test history _opts]
+      (let [pairs (pair-invokes-with-completions history)
+            mutations (completed-mutation-window pairs)
+            mutations-by-m (mutations-by-member mutations)
+            read-pairs (filter (fn [{:keys [invoke complete]}]
+                                 (and invoke complete
+                                      (= :ok (:type complete))
+                                      (#{:zrange-all :zrangebyscore}
+                                       (:f invoke))))
+                               pairs)
+            all-errors (reduce
+                         (fn [acc {:keys [invoke] :as pair}]
+                           (into acc
+                                 (case (:f invoke)
+                                   :zrange-all    (check-zrange-all mutations-by-m pair)
+                                   :zrangebyscore (check-zrangebyscore mutations-by-m pair))))
+                         []
+                         read-pairs)
+            by-kind (group-by :kind all-errors)]
+        {:valid? (empty? all-errors)
+         :reads  (count read-pairs)
+         :mutations (count mutations)
+         :error-count (count all-errors)
+         :errors-by-kind (into {} (map (fn [[k v]] [k (count v)]) by-kind))
+         :first-errors (take 20 all-errors)}))))
+
+;; ---------------------------------------------------------------------------
+;; Workload
+;; ---------------------------------------------------------------------------
+
+(defn elastickv-zset-safety-workload
+  [opts]
+  (let [node->port (or (:node->port opts)
+                       (zipmap default-nodes (repeat 6379)))
+        client (->ElastickvRedisZSetSafetyClient node->port nil)]
+    {:client    client
+     :checker   (checker/compose
+                  {:zset-safety (zset-safety-checker)
+                   :timeline    (timeline/html)})
+     :generator (op-generator)
+     :final-generator (gen/once {:f :zrange-all})}))
+
+(defn elastickv-zset-safety-test
+  "Builds a Jepsen test map that drives elastickv's Redis ZSet safety
+  workload."
+  ([] (elastickv-zset-safety-test {}))
+  ([opts]
+   (let [nodes       (or (:nodes opts) default-nodes)
+         redis-ports (or (:redis-ports opts)
+                         (repeat (count nodes) (or (:redis-port opts) 6379)))
+         node->port  (or (:node->port opts)
+                         (cli/ports->node-map redis-ports nodes))
+         local?      (:local opts)
+         db          (if local?
+                       jdb/noop
+                       (ekdb/db {:grpc-port  (or (:grpc-port opts) 50051)
+                                 :redis-port node->port
+                                 :raft-groups (:raft-groups opts)
+                                 :shard-ranges (:shard-ranges opts)}))
+         rate        (double (or (:rate opts) 10))
+         time-limit  (or (:time-limit opts) 60)
+         faults      (if local?
+                       []
+                       (cli/normalize-faults (or (:faults opts) [:partition :kill])))
+         nemesis-p   (when-not local?
+                       (combined/nemesis-package {:db       db
+                                                  :faults   faults
+                                                  :interval (or (:fault-interval opts) 40)}))
+         nemesis-gen (if nemesis-p
+                       (:generator nemesis-p)
+                       (gen/once {:type :info :f :noop}))
+         workload    (elastickv-zset-safety-workload
+                       (assoc opts :node->port node->port))]
+     (merge workload
+            {:name        (or (:name opts) "elastickv-redis-zset-safety")
+             :nodes       nodes
+             :db          db
+             :redis-host  (:redis-host opts)
+             :os          (if local? os/noop debian/os)
+             :net         (if local? net/noop net/iptables)
+             :ssh         (merge {:username             "vagrant"
+                                  :private-key-path     "/home/vagrant/.ssh/id_rsa"
+                                  :strict-host-key-checking false}
+                                 (when local? {:dummy true})
+                                 (:ssh opts))
+             :remote      control/ssh
+             :nemesis     (if nemesis-p (:nemesis nemesis-p) nemesis/noop)
+             :final-generator nil
+             :concurrency (or (:concurrency opts) 5)
+             :generator   (->> (:generator workload)
+                               (gen/nemesis nemesis-gen)
+                               (gen/stagger (/ rate))
+                               (gen/time-limit time-limit))}))))
+
+;; ---------------------------------------------------------------------------
+;; CLI
+;; ---------------------------------------------------------------------------
+
+(def zset-safety-cli-opts
+  [[nil "--ports PORTS" "Comma-separated Redis ports (per node)."
+    :default nil
+    :parse-fn (fn [s]
+                (->> (str/split s #",")
+                     (remove str/blank?)
+                     (mapv #(Integer/parseInt %))))]
+   [nil "--redis-port PORT" "Redis port applied to all nodes."
+    :default 6379
+    :parse-fn #(Integer/parseInt %)]])
+
+(defn- prepare-zset-safety-opts [options]
+  (let [ports (or (:ports options) nil)
+        options (cli/parse-common-opts options ports)]
+    (assoc options
+      :redis-host  (:host options)
+      :redis-ports ports
+      :redis-port  (:redis-port options))))
+
+(defn -main [& args]
+  (cli/run-workload! args
+                     (into cli/common-cli-opts zset-safety-cli-opts)
+                     prepare-zset-safety-opts
+                     elastickv-zset-safety-test))

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -374,6 +374,12 @@
   comes after this op's completion). Scores from strictly superseded
   committed mutations are NOT admissible.
 
+  When multiple candidates remain (their windows overlap), they can
+  serialize in any real-time-consistent order: the read may legitimately
+  observe the outcome of any of them. Thus presence is required only
+  when EVERY admissible serialization leaves the member present; presence
+  is forbidden only when EVERY admissible serialization leaves it absent.
+
   Returns:
     :scores            - set of acceptable scores (from candidate
                          committed ops + pre-read :info + concurrent
@@ -382,13 +388,12 @@
                          ZINCRBY's resulting score is unknown. When set,
                          the caller MUST skip the strict score-membership
                          check to stay sound.
-    :can-be-present?   - true iff the member may legitimately appear in
-                         the read (some candidate/concurrent/pre-read
-                         :info op is a write, OR a concurrent/pre-read
-                         :info ZREM leaves presence uncertain).
-    :must-be-present?  - true iff a candidate committed state says
-                         present and nothing concurrent/pre-read :info
-                         could have removed it."
+    :can-be-present?   - true iff SOME admissible linearization leaves
+                         the member present.
+    :must-be-present?  - true iff EVERY admissible linearization leaves
+                         the member present (i.e. some candidate is a
+                         write, no candidate is a ZREM, and no uncertain
+                         ZREM could have applied before the read)."
   [mutations-by-m member read-inv-idx read-cmp-idx]
   (let [muts (get mutations-by-m member [])
         ;; :ok mutations that completed strictly before the read.
@@ -400,6 +405,8 @@
         ;; m is admissible iff no OTHER preceding mutation m' has
         ;; m'.invoke-idx > m.complete-idx (i.e. m' strictly follows m).
         ;; Equivalent: m.complete-idx >= max(invoke-idx) over preceding.
+        ;; When multiple candidates remain, they have overlapping
+        ;; windows and may serialize in any real-time-consistent order.
         max-inv (reduce max -1 (map :invoke-idx preceding))
         candidates (filterv #(>= (:complete-idx %) max-inv) preceding)
         ;; :info mutations that completed before the read: they may or
@@ -411,6 +418,9 @@
         ;; Concurrent mutations: windows overlap the read. Include both
         ;; :ok and :info since either may have taken effect.
         concurrent (concurrent-mutations-for-member muts read-inv-idx read-cmp-idx)
+        ;; Uncertain mutations: anything whose effect on the read is not
+        ;; fully determined by committed real-time order alone.
+        uncertain (concat pre-read-info concurrent)
 
         add-scores (fn [acc m]
                      (case (:f m)
@@ -421,45 +431,64 @@
         ;; concurrent writes (with a known score).
         scores (as-> #{} s
                  (reduce add-scores s candidates)
-                 (reduce add-scores s pre-read-info)
-                 (reduce add-scores s concurrent))
+                 (reduce add-scores s uncertain))
 
         has-unknown-incr? (fn [coll]
                             (some #(and (= :zincrby (:f %))
                                         (:unknown-score? %))
                                   coll))
-        unknown-score? (or (has-unknown-incr? concurrent)
-                           (has-unknown-incr? pre-read-info))
+        ;; Uncertain score set when any ZINCRBY is concurrent/uncertain
+        ;; (its resulting score is unknown), OR when multiple concurrent
+        ;; increments could yield intermediate prefix-sum scores that
+        ;; are not in :scores.
+        unknown-score? (or (has-unknown-incr? uncertain)
+                           (some #(= :zincrby (:f %)) uncertain))
 
-        ;; Did any candidate commit establish presence (write, or
-        ;; ZREM with :removed? -- either way the member existed)?
-        candidate-state (reduce apply-mutation-to-state nil
-                                (sort-by :complete-idx candidates))
-        candidate-present? (boolean (:present? candidate-state))
+        any-candidate-write? (some write-op? candidates)
+        any-candidate-zrem? (some #(= :zrem (:f %)) candidates)
+        any-uncertain-write? (some write-op? uncertain)
+        any-uncertain-zrem? (some #(= :zrem (:f %)) uncertain)
 
-        any-concurrent-could-write? (or (some write-op? concurrent)
-                                        (some write-op? pre-read-info))
-        any-concurrent-could-remove? (or (some #(= :zrem (:f %)) concurrent)
-                                         (some #(= :zrem (:f %)) pre-read-info))
+        ;; Some linearization of candidates ends with the member
+        ;; present. Because candidates have overlapping windows (they
+        ;; all share the same max-inv), any of them can serialize last.
+        ;; So presence is allowed iff at least one candidate is a write.
+        candidate-can-be-present? (boolean any-candidate-write?)
+        ;; Some linearization of candidates ends with the member absent.
+        candidate-can-be-absent? (or (empty? candidates)
+                                     (boolean any-candidate-zrem?))
 
-        can-be-present? (or candidate-present?
-                            any-concurrent-could-write?
-                            ;; A :zrem with :removed? true still proves
-                            ;; existence; if a concurrent ZREM raced
-                            ;; with an earlier write whose window is
-                            ;; not captured as a candidate, presence is
-                            ;; uncertain rather than forbidden.
-                            (and (some existence-evidence? (concat concurrent
-                                                                   pre-read-info))
-                                 any-concurrent-could-remove?))
+        ;; can-be-present?: at least one admissible linearization
+        ;; (candidates + uncertain) ends with the member present.
+        ;; An uncertain write (or an uncertain :zrem combined with
+        ;; existence evidence) can flip an otherwise-absent candidate
+        ;; outcome to present by reordering after a write.
+        can-be-present? (or candidate-can-be-present?
+                            any-uncertain-write?
+                            (and any-uncertain-zrem?
+                                 (some existence-evidence? uncertain)))
 
-        must-be-present? (boolean (and candidate-present?
-                                       (empty? pre-read-info)
-                                       (empty? concurrent)))]
+        ;; must-be-present?: EVERY admissible linearization ends with
+        ;; the member present. Requires the candidate outcome to be
+        ;; always-present (candidate write, no candidate zrem) AND no
+        ;; uncertain zrem that could reorder last to remove it.
+        must-be-present? (boolean (and any-candidate-write?
+                                       (not candidate-can-be-absent?)
+                                       (not any-uncertain-zrem?)))]
     {:scores           scores
      :unknown-score?   (boolean unknown-score?)
      :can-be-present?  (boolean can-be-present?)
      :must-be-present? must-be-present?}))
+
+(defn- score-definitely-in-range?
+  "True iff the member's committed score is definitively in [lo, hi]
+  for the purposes of completeness: every candidate score is inside the
+  range AND no uncertain/concurrent mutation could have produced an
+  unknown or out-of-range score. Used by ZRANGEBYSCORE completeness."
+  [scores unknown-score? lo hi]
+  (boolean (and (not unknown-score?)
+                (seq scores)
+                (every? #(<= lo % hi) scores))))
 
 (defn- duplicate-members
   "Return the set of members that appear more than once in entries."
@@ -513,16 +542,20 @@
                               :observed score
                               :allowed scores}))))
     ;; 3. Completeness: model-required members must appear.
+    ;;    A member is required-present only if every admissible
+    ;;    linearization leaves it present (must-be-present?). This
+    ;;    correctly skips members that an :info or concurrent ZREM
+    ;;    might have removed before the read.
     (let [model (model-before mutations-by-m inv-idx)
           observed-members (into #{} (map first) entries)]
-      (doseq [[member {:keys [present?]}] model]
-        (when (and present? (not (contains? observed-members member)))
-          (let [muts (get mutations-by-m member [])
-                concurrent (concurrent-mutations-for-member muts inv-idx cmp-idx)]
-            (when (empty? concurrent)
-              (swap! errors conj {:kind :missing-member
-                                  :index cmp-idx
-                                  :member member}))))))
+      (doseq [[member _] model]
+        (let [{:keys [must-be-present?]}
+              (allowed-scores-for-member mutations-by-m member inv-idx cmp-idx)]
+          (when (and must-be-present?
+                     (not (contains? observed-members member)))
+            (swap! errors conj {:kind :missing-member
+                                :index cmp-idx
+                                :member member})))))
     @errors))
 
 (defn- check-zrangebyscore
@@ -566,22 +599,27 @@
                               :member member
                               :observed score
                               :allowed scores}))))
-    ;; Completeness within bounds: any model member whose committed score
-    ;; is in [lo,hi] with no concurrent mutation must appear.
+    ;; Completeness within bounds: a model member must appear only when
+    ;; (a) every admissible linearization leaves it present
+    ;;     (must-be-present?), AND
+    ;; (b) its score is definitively within [lo, hi] across all
+    ;;     admissible linearizations (no uncertain ZINCRBY, every
+    ;;     candidate score inside the bounds).
+    ;; Uncertain scores (concurrent/:info ZINCRBY) must NOT cause
+    ;; completeness failures when the resulting score is unknown.
     (let [model (model-before mutations-by-m inv-idx)
           observed-members (into #{} (map first) members)]
-      (doseq [[member {:keys [present? score]}] model]
-        (when (and present?
-                   (<= lo score hi)
-                   (not (contains? observed-members member)))
-          (let [muts (get mutations-by-m member [])
-                concurrent (concurrent-mutations-for-member muts inv-idx cmp-idx)]
-            (when (empty? concurrent)
-              (swap! errors conj {:kind :missing-member-range
-                                  :index cmp-idx
-                                  :bounds bounds
-                                  :member member
-                                  :expected-score score}))))))
+      (doseq [[member _] model]
+        (let [{:keys [must-be-present? scores unknown-score?]}
+              (allowed-scores-for-member mutations-by-m member inv-idx cmp-idx)]
+          (when (and must-be-present?
+                     (score-definitely-in-range? scores unknown-score? lo hi)
+                     (not (contains? observed-members member)))
+            (swap! errors conj {:kind :missing-member-range
+                                :index cmp-idx
+                                :bounds bounds
+                                :member member
+                                :expected-score (first scores)})))))
     @errors))
 
 (defn zset-safety-checker

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -152,7 +152,19 @@
   (close! [this _test] this)
 
   (setup! [this _test]
-    (if-let [cs (:conn-spec this)]
+    ;; Hard-fail when :conn-spec is missing after open!. Silently (or
+    ;; even loudly) proceeding would leave stale data from a previous
+    ;; run under zset-key and risk false-positive checker results from
+    ;; that dirty state. Better to abort the run and surface the
+    ;; configuration problem.
+    (let [cs (or (:conn-spec this)
+                 (throw (ex-info
+                          (str "ZSet safety setup! cannot clear prior state:"
+                               " :conn-spec is missing on client (open! did"
+                               " not populate it). Aborting to avoid running"
+                               " against stale data under " zset-key ".")
+                          {:type ::missing-conn-spec
+                           :zset-key zset-key})))]
       (try
         (car/wcar cs (car/del zset-key))
         (catch Throwable t
@@ -161,11 +173,7 @@
           ;; produce false-positive safety failures. Log loudly so
           ;; operators notice. clojure.tools.logging/warn expects
           ;; (warn msg) or (warn throwable msg) -- NOT multiple strings.
-          (warn t "ZSet safety setup! DEL failed -- stale data may survive into this run")))
-      ;; open! failed to populate :conn-spec (e.g. unresolvable host);
-      ;; flag it rather than silently proceeding with a no-op setup.
-      (warn (str "ZSet safety setup! skipped: missing :conn-spec on client;"
-                 " prior state under " zset-key " may survive into this run")))
+          (warn t "ZSet safety setup! DEL failed -- stale data may survive into this run"))))
     this)
 
   (teardown! [this _test] this)

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -341,9 +341,15 @@
     mutations-by-m))
 
 (defn- concurrent-mutations-for-member
-  "All mutations (ok or info) that are concurrent with the read window."
+  "All mutations concurrent with the read window that could have taken
+  effect. :fail completions are excluded: in Jepsen, :fail means the op
+  definitively did NOT execute, so it contributes neither an allowed
+  score nor uncertainty about presence. :ok and :info/:pending are
+  included (either may be visible to the read)."
   [muts read-inv-idx read-cmp-idx]
-  (filter #(concurrent? % read-inv-idx read-cmp-idx) muts))
+  (filter #(and (not= :fail (:type %))
+                (concurrent? % read-inv-idx read-cmp-idx))
+          muts))
 
 (defn- write-op?
   "True iff the mutation adds/updates the member's score (i.e. would

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -86,6 +86,41 @@
       :else
       (Double/parseDouble raw))))
 
+(defn- coerce-zincrby-score
+  "Carmine's ZINCRBY reply is normally a score string, but under error /
+  timeout / protocol edge cases it may be nil, a numeric value, or
+  something else entirely. Stringifying nil produces \"nil\", which
+  parse-double-safe would then hand to Double/parseDouble and throw.
+  Explicitly classify the response so the invoke! path can record
+  :unknown-response as :info instead of masking it in a catch-all.
+
+  Returns one of:
+    [:ok   (double score)]
+    [:nil]                    ; nil response
+    [:error <string>]         ; Carmine error reply
+    [:unexpected <value>]     ; anything else"
+  [response]
+  (cond
+    (nil? response)
+    [:nil]
+
+    (number? response)
+    [:ok (double response)]
+
+    (string? response)
+    (try
+      [:ok (parse-double-safe response)]
+      (catch NumberFormatException _
+        [:unexpected response]))
+
+    ;; Carmine surfaces Redis error replies as exceptions by default,
+    ;; but some codepaths wrap them in an ex-info / Throwable value.
+    (instance? Throwable response)
+    [:error (.getMessage ^Throwable response)]
+
+    :else
+    [:unexpected response]))
+
 (defn- parse-withscores
   "Carmine returns a flat [member score member score ...] vector for
   ZRANGE WITHSCORES. Convert to a sorted vector of [member (double score)]
@@ -96,6 +131,13 @@
        (mapv (fn [[m s]]
                [(if (bytes? m) (String. ^bytes m) (str m))
                 (parse-double-safe s)]))))
+
+(defn- zincrby!
+  "Executes a ZINCRBY against conn-spec and returns Carmine's raw reply
+  (normally a score string). Extracted so tests can stub the Redis call
+  without going through the `car/wcar` macro."
+  [conn-spec key delta member]
+  (car/wcar conn-spec (car/zincrby key (double delta) member)))
 
 (defrecord ElastickvRedisZSetSafetyClient [node->port conn-spec]
   client/Client
@@ -110,10 +152,20 @@
   (close! [this _test] this)
 
   (setup! [this _test]
-    (when-let [cs (:conn-spec this)]
-      (try (car/wcar cs (car/del zset-key))
-           (catch Exception e
-             (warn "ZSet safety setup DEL failed:" (.getMessage e)))))
+    (if-let [cs (:conn-spec this)]
+      (try
+        (car/wcar cs (car/del zset-key))
+        (catch Throwable t
+          ;; Do NOT swallow silently: repeated setup! failures across
+          ;; runs would leave stale data under zset-key and could
+          ;; produce false-positive safety failures. Log loudly so
+          ;; operators notice.
+          (warn "ZSet safety setup! DEL failed -- stale data may survive"
+                "into this run:" (.getMessage t))))
+      ;; open! failed to populate :conn-spec (e.g. unresolvable host);
+      ;; flag it rather than silently proceeding with a no-op setup.
+      (warn "ZSet safety setup! skipped: missing :conn-spec on client;"
+            "prior state under" zset-key "may survive into this run"))
     this)
 
   (teardown! [this _test] this)
@@ -129,9 +181,21 @@
 
           :zincrby
           (let [[member delta] (:value op)
-                new-score (car/wcar cs (car/zincrby zset-key (double delta) member))]
-            (assoc op :type :ok
-                   :value [member (parse-double-safe new-score)]))
+                new-score (zincrby! cs zset-key delta member)
+                [tag v]   (coerce-zincrby-score new-score)]
+            (case tag
+              :ok         (assoc op :type :ok :value [member v])
+              :nil        (do (warn "ZSet safety ZINCRBY returned nil for" member)
+                              (assoc op :type :info
+                                        :error :nil-response))
+              :error      (do (warn "ZSet safety ZINCRBY returned error reply:" v)
+                              (assoc op :type :info
+                                        :error {:kind :error-response
+                                                :message v}))
+              :unexpected (do (warn "ZSet safety ZINCRBY returned unexpected reply:" (pr-str v))
+                              (assoc op :type :info
+                                        :error {:kind :unexpected-response
+                                                :value (pr-str v)}))))
 
           :zrem
           (let [member (:value op)

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -139,6 +139,13 @@
   [conn-spec key delta member]
   (car/wcar conn-spec (car/zincrby key (double delta) member)))
 
+(defn- zrem!
+  "Executes a ZREM against conn-spec and returns Carmine's raw reply
+  (normally an integer count of removed members). Extracted so tests
+  can stub the Redis call without going through the `car/wcar` macro."
+  [conn-spec key member]
+  (car/wcar conn-spec (car/zrem key member)))
+
 (defrecord ElastickvRedisZSetSafetyClient [node->port conn-spec]
   client/Client
 
@@ -207,8 +214,14 @@
 
           :zrem
           (let [member (:value op)
-                removed (car/wcar cs (car/zrem zset-key member))]
-            (assoc op :type :ok :value [member (pos? (long removed))]))
+                ;; Carmine normally returns an integer count. Guard
+                ;; against nil / missing reply (protocol edge, closed
+                ;; connection, etc.) so `(long removed)` doesn't throw
+                ;; NPE -- that would otherwise fall through to the
+                ;; general Exception handler and be logged as a generic
+                ;; op failure, obscuring the actual signal.
+                removed (zrem! cs zset-key member)]
+            (assoc op :type :ok :value [member (pos? (long (or removed 0)))]))
 
           :zrange-all
           (let [flat (car/wcar cs (car/zrange zset-key 0 -1 "WITHSCORES"))]

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -407,12 +407,26 @@
                        (filter #(and (= :ok (:type %))
                                      (some? (:complete-idx %))
                                      (< (:complete-idx %) read-inv-idx))))
-        ;; Real-time "last-wins" candidate filter: a preceding mutation
-        ;; m is admissible iff no OTHER preceding mutation m' has
-        ;; m'.invoke-idx > m.complete-idx (i.e. m' strictly follows m).
-        ;; Equivalent: m.complete-idx >= max(invoke-idx) over preceding.
-        ;; When multiple candidates remain, they have overlapping
-        ;; windows and may serialize in any real-time-consistent order.
+        ;; Real-time "last-wins" / chain-tail candidate filter: a
+        ;; preceding mutation m is admissible iff no OTHER preceding
+        ;; mutation m' has m'.invoke-idx > m.complete-idx (i.e. m'
+        ;; strictly follows m in real time). Equivalent:
+        ;; m.complete-idx >= max(invoke-idx) over preceding.
+        ;;
+        ;; Importantly this applies to :zincrby as well: a sequentially
+        ;; committed ZINCRBY chain has a forced linearization (each
+        ;; :ok :zincrby pins the pre-op and post-op states), so only
+        ;; the latest chain tail's return value is a valid final score
+        ;; for a post-chain read. An intermediate ZINCRBY's return
+        ;; value is NOT admissible once another mutation strictly
+        ;; follows it and commits before the read. A ZADD that strictly
+        ;; follows a ZINCRBY likewise resets the chain (the ZADD's
+        ;; absolute score becomes the only candidate).
+        ;;
+        ;; When multiple candidates remain (their invoke/complete
+        ;; windows overlap), they may serialize in any real-time-
+        ;; consistent order and any of their return values is a valid
+        ;; final state.
         max-inv (reduce max -1 (map :invoke-idx preceding))
         candidates (filterv #(>= (:complete-idx %) max-inv) preceding)
         ;; :info mutations that completed before the read: they may or

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -760,13 +760,33 @@
                                    :zrangebyscore (check-zrangebyscore mutations-by-m pair))))
                          []
                          read-pairs)
-            by-kind (group-by :kind all-errors)]
-        {:valid? (empty? all-errors)
-         :reads  (count read-pairs)
-         :mutations (count mutations)
-         :error-count (count all-errors)
-         :errors-by-kind (into {} (map (fn [[k v]] [k (count v)]) by-kind))
-         :first-errors (take 20 all-errors)}))))
+            by-kind (group-by :kind all-errors)
+            ;; Vacuous-pass guard (codex P1): if the run produced zero
+            ;; successful reads, we have no evidence that the system
+            ;; under test actually satisfies ZSet safety -- every op
+            ;; may have been downgraded to :info because Redis was
+            ;; unreachable or every read timed out. Returning
+            ;; `:valid? true` in that case would be a false-green.
+            ;; Emit `:valid? :unknown` with a diagnostic reason; the
+            ;; cli's `fail-on-invalid!` treats anything other than
+            ;; `true` as a failure (see elastickv.cli/fail-on-invalid!).
+            no-successful-reads? (zero? (count read-pairs))
+            valid? (cond
+                     (seq all-errors)      false
+                     no-successful-reads?  :unknown
+                     :else                 true)]
+        (cond-> {:valid? valid?
+                 :reads  (count read-pairs)
+                 :mutations (count mutations)
+                 :error-count (count all-errors)
+                 :errors-by-kind (into {} (map (fn [[k v]] [k (count v)]) by-kind))
+                 :first-errors (take 20 all-errors)}
+          no-successful-reads?
+          (assoc :reason
+                 (str "No successful :zrange-all / :zrangebyscore reads"
+                      " completed -- cannot assert ZSet safety. Likely"
+                      " Redis was unreachable or every read timed out;"
+                      " re-run against a healthy cluster.")))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Workload

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -344,44 +344,87 @@
     :any-known?        - some op claims to have touched this member."
   [mutations-by-m member read-inv-idx read-cmp-idx]
   (let [muts (get mutations-by-m member [])
+        ;; :ok mutations that completed strictly before the read. They
+        ;; may have overlapped with each other in wall-clock time, so
+        ;; the serialization order among them is ambiguous.
         committed (->> muts
                        (filter #(and (= :ok (:type %))
                                      (some? (:complete-idx %))
-                                     (< (:complete-idx %) read-inv-idx)))
-                       (sort-by :complete-idx))
-        committed-state (reduce apply-mutation-to-state nil committed)
+                                     (< (:complete-idx %) read-inv-idx))))
+        ;; :info mutations that completed before the read: they may or
+        ;; may not have taken effect server-side. We must account for
+        ;; their possible scores just like concurrent ones.
+        pre-read-info (->> muts
+                           (filter #(and (= :info (:type %))
+                                         (some? (:complete-idx %))
+                                         (< (:complete-idx %) read-inv-idx))))
+        ;; Concurrent mutations: windows overlap the read. Include both
+        ;; :ok and :info since either may have taken effect.
         concurrent (concurrent-mutations-for-member muts read-inv-idx read-cmp-idx)
-        scores (cond-> #{}
-                 (and committed-state (:present? committed-state))
-                 (conj (:score committed-state)))
-        scores (reduce
-                 (fn [acc m]
-                   (case (:f m)
-                     :zadd    (conj acc (:score m))
-                     :zincrby (cond-> acc (some? (:score m)) (conj (:score m)))
-                     :zrem    acc))
-                 scores
-                 concurrent)
-        unknown-score? (some #(and (= :zincrby (:f %))
-                                   (:unknown-score? %))
-                             concurrent)
+        ;; A conservative last-wins linearization for the must-be-present?
+        ;; check only. Ambiguous when committed writes overlap each other.
+        committed-sorted (sort-by :complete-idx committed)
+        committed-state (reduce apply-mutation-to-state nil committed-sorted)
+        committed-overlap? (boolean
+                             (some (fn [[a b]]
+                                     (and (not (identical? a b))
+                                          (<= (:invoke-idx a) (:complete-idx b))
+                                          (<= (:invoke-idx b) (:complete-idx a))))
+                                   (for [a committed, b committed] [a b])))
+        ;; Union of every score that any committed / pre-read :info /
+        ;; concurrent op could have produced. This over-approximates the
+        ;; legitimate post-state set when writes overlap, keeping the
+        ;; checker sound at the cost of being slightly less strict on
+        ;; overlapping concurrent writers.
+        add-scores (fn [acc m]
+                     (case (:f m)
+                       :zadd    (conj acc (:score m))
+                       :zincrby (cond-> acc (some? (:score m)) (conj (:score m)))
+                       :zrem    acc))
+        scores (as-> #{} s
+                 (reduce add-scores s committed)
+                 (reduce add-scores s pre-read-info)
+                 (reduce add-scores s concurrent))
+        unknown-score? (or
+                         (some #(and (= :zincrby (:f %)) (:unknown-score? %))
+                               concurrent)
+                         (some #(and (= :zincrby (:f %)) (:unknown-score? %))
+                               pre-read-info))
         ;; any-known? must only be true when something provides evidence
         ;; the member actually existed at some point. A no-op ZREM
-        ;; (:removed? false) does NOT prove existence -- it explicitly
-        ;; says the member wasn't there. Without this guard, reads of a
-        ;; never-added member that happened to race with a no-op ZREM
-        ;; would flip from :phantom to :score-mismatch with an empty
-        ;; :allowed set, producing a false positive.
-        existence-evidence? (or (boolean committed-state)
+        ;; (:removed? false) does NOT prove existence.
+        existence-evidence? (or (some #(case (:f %)
+                                         (:zadd :zincrby) true
+                                         :zrem            (:removed? %))
+                                      committed)
+                                (some #(case (:f %)
+                                         (:zadd :zincrby) true
+                                         :zrem            (:removed? %))
+                                      pre-read-info)
                                 (some #(case (:f %)
                                          (:zadd :zincrby) true
                                          :zrem            (:removed? %))
                                       concurrent))]
       {:scores scores
        :unknown-score? (boolean unknown-score?)
-       :must-be-present? (boolean (and committed-state (:present? committed-state)
+       ;; must-be-present? is relaxed when committed writes overlap
+       ;; among themselves or when any :info / concurrent mutation could
+       ;; have removed the member before the read.
+       :must-be-present? (boolean (and committed-state
+                                       (:present? committed-state)
+                                       (not committed-overlap?)
+                                       (empty? pre-read-info)
                                        (empty? concurrent)))
        :any-known? (boolean existence-evidence?)}))
+
+(defn- duplicate-members
+  "Return the set of members that appear more than once in entries."
+  [entries]
+  (->> entries
+       (map first)
+       frequencies
+       (keep (fn [[m n]] (when (> n 1) m)))
+       set))
 
 (defn- check-zrange-all
   [mutations-by-m {:keys [invoke complete] :as _pair}]
@@ -394,6 +437,14 @@
       (swap! errors conj {:kind :unsorted
                           :index cmp-idx
                           :entries entries}))
+    ;; 1b. No duplicate members: a ZSet read must return each member at
+    ;; most once. A duplicate-member result could otherwise satisfy
+    ;; ordering and score-membership checks while hiding a real bug.
+    (let [dupes (duplicate-members entries)]
+      (when (seq dupes)
+        (swap! errors conj {:kind :duplicate-members
+                            :index cmp-idx
+                            :members dupes})))
     ;; 2. For each observed (member,score): validate score and non-phantom
     (doseq [[member score] entries]
       (let [{:keys [scores any-known? unknown-score?]}
@@ -439,6 +490,12 @@
                           :index cmp-idx
                           :bounds bounds
                           :members members}))
+    (let [dupes (duplicate-members members)]
+      (when (seq dupes)
+        (swap! errors conj {:kind :duplicate-members-range
+                            :index cmp-idx
+                            :bounds bounds
+                            :members dupes})))
     ;; Observed members must be within bounds AND have a known allowed score.
     (doseq [[member score] members]
       (when (or (< score lo) (> score hi))

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -364,12 +364,24 @@
                  concurrent)
         unknown-score? (some #(and (= :zincrby (:f %))
                                    (:unknown-score? %))
-                             concurrent)]
+                             concurrent)
+        ;; any-known? must only be true when something provides evidence
+        ;; the member actually existed at some point. A no-op ZREM
+        ;; (:removed? false) does NOT prove existence -- it explicitly
+        ;; says the member wasn't there. Without this guard, reads of a
+        ;; never-added member that happened to race with a no-op ZREM
+        ;; would flip from :phantom to :score-mismatch with an empty
+        ;; :allowed set, producing a false positive.
+        existence-evidence? (or (boolean committed-state)
+                                (some #(case (:f %)
+                                         (:zadd :zincrby) true
+                                         :zrem            (:removed? %))
+                                      concurrent))]
       {:scores scores
        :unknown-score? (boolean unknown-score?)
        :must-be-present? (boolean (and committed-state (:present? committed-state)
                                        (empty? concurrent)))
-       :any-known? (or (boolean committed-state) (seq concurrent))}))
+       :any-known? (boolean existence-evidence?)}))
 
 (defn- check-zrange-all
   [mutations-by-m {:keys [invoke complete] :as _pair}]

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -159,13 +159,13 @@
           ;; Do NOT swallow silently: repeated setup! failures across
           ;; runs would leave stale data under zset-key and could
           ;; produce false-positive safety failures. Log loudly so
-          ;; operators notice.
-          (warn "ZSet safety setup! DEL failed -- stale data may survive"
-                "into this run:" (.getMessage t))))
+          ;; operators notice. clojure.tools.logging/warn expects
+          ;; (warn msg) or (warn throwable msg) -- NOT multiple strings.
+          (warn t "ZSet safety setup! DEL failed -- stale data may survive into this run")))
       ;; open! failed to populate :conn-spec (e.g. unresolvable host);
       ;; flag it rather than silently proceeding with a no-op setup.
-      (warn "ZSet safety setup! skipped: missing :conn-spec on client;"
-            "prior state under" zset-key "may survive into this run"))
+      (warn (str "ZSet safety setup! skipped: missing :conn-spec on client;"
+                 " prior state under " zset-key " may survive into this run")))
     this)
 
   (teardown! [this _test] this)
@@ -185,14 +185,14 @@
                 [tag v]   (coerce-zincrby-score new-score)]
             (case tag
               :ok         (assoc op :type :ok :value [member v])
-              :nil        (do (warn "ZSet safety ZINCRBY returned nil for" member)
+              :nil        (do (warn (str "ZSet safety ZINCRBY returned nil for " member))
                               (assoc op :type :info
                                         :error :nil-response))
-              :error      (do (warn "ZSet safety ZINCRBY returned error reply:" v)
+              :error      (do (warn (str "ZSet safety ZINCRBY returned error reply: " v))
                               (assoc op :type :info
                                         :error {:kind :error-response
                                                 :message v}))
-              :unexpected (do (warn "ZSet safety ZINCRBY returned unexpected reply:" (pr-str v))
+              :unexpected (do (warn (str "ZSet safety ZINCRBY returned unexpected reply: " (pr-str v)))
                               (assoc op :type :info
                                         :error {:kind :unexpected-response
                                                 :value (pr-str v)}))))
@@ -215,7 +215,7 @@
             (assoc op :type :ok :value {:bounds [lo hi]
                                         :members (parse-withscores flat)})))
         (catch Exception e
-          (warn "ZSet safety op failed:" (:f op) (.getMessage e))
+          (warn e (str "ZSet safety op failed: " (:f op)))
           (assoc op :type :info :error (.getMessage e)))))))
 
 ;; ---------------------------------------------------------------------------

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -857,8 +857,11 @@
                                  (:ssh opts))
              :remote      control/ssh
              :nemesis     (if nemesis-p (:nemesis nemesis-p) nemesis/noop)
-             ;; Jepsen 0.3.x can't fressian-serialize some combined final gens; skip.
-             :final-generator nil
+             ;; The inner workload's :final-generator is the trivially-
+             ;; serializable (gen/once {:f :zrange-all}) -- a single
+             ;; Limit defrecord wrapping a plain map. It round-trips
+             ;; through Jepsen 0.3.x's Fressian store cleanly
+             ;; (verified at 86 bytes), so we don't override it here.
              :concurrency (or (:concurrency opts) 5)
              :generator   (->> (:generator workload)
                                (gen/nemesis nemesis-gen)

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -816,6 +816,7 @@
                                  (:ssh opts))
              :remote      control/ssh
              :nemesis     (if nemesis-p (:nemesis nemesis-p) nemesis/noop)
+             ;; Jepsen 0.3.x can't fressian-serialize some combined final gens; skip.
              :final-generator nil
              :concurrency (or (:concurrency opts) 5)
              :generator   (->> (:generator workload)

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -457,24 +457,29 @@
                             (some #(and (= :zincrby (:f %))
                                         (:unknown-score? %))
                                   coll))
-        ;; Count concurrent/uncertain ZINCRBYs. The resulting score of a
-        ;; read relative to ZINCRBYs depends on how many of them took
-        ;; effect before the read observed state.
-        ;;   * 0 uncertain ZINCRBYs: :scores is authoritative.
-        ;;   * 1 uncertain ZINCRBY whose final score is KNOWN (:ok):
-        ;;     the read can observe either the pre-op state (already in
-        ;;     :scores from candidates) or the post-op state (its known
-        ;;     final score, also added to :scores). :scores is complete.
-        ;;   * 1 uncertain ZINCRBY with UNKNOWN score (:info/:pending):
-        ;;     the post-op score is not recoverable from the history.
-        ;;     We must relax the strict score check.
-        ;;   * >=2 uncertain ZINCRBYs: their relative serialization
-        ;;     order produces prefix-sum intermediates that are not in
-        ;;     :scores (e.g. pre + delta1 before pre + delta1 + delta2).
-        ;;     Relax the strict score check.
-        uncertain-incrs (filter #(= :zincrby (:f %)) uncertain)
-        unknown-score? (or (has-unknown-incr? uncertain)
-                           (> (count uncertain-incrs) 1))
+        ;; Classify uncertain ZINCRBYs by whether their resulting score
+        ;; is known. The resulting score of a read relative to ZINCRBYs
+        ;; depends only on which of them took effect before the read
+        ;; observed state AND whether each such ZINCRBY's return value
+        ;; is recorded.
+        ;;   * Any uncertain ZINCRBY with UNKNOWN score (:info/:pending):
+        ;;     the post-op score is not recoverable from the history, so
+        ;;     we must relax the strict score check -- any numeric score
+        ;;     is admissible.
+        ;;   * All uncertain ZINCRBYs :ok with known return values:
+        ;;     every recorded return pins the ZINCRBY's post-op state
+        ;;     and (because ZINCRBY reads-then-writes atomically) its
+        ;;     pre-op state. Any real-time consistent linearization
+        ;;     therefore ends on one of those known return values (or
+        ;;     on a candidate's score). :scores already contains all
+        ;;     of them via the add-scores reduction over `uncertain`,
+        ;;     so the strict score check is sound. Intermediate
+        ;;     "prefix-sum" values (pre + delta_i for just one of
+        ;;     several concurrent zincrbys) are NOT admissible final
+        ;;     states: the return values constrain the serialization
+        ;;     order, and no legitimate read can observe a partial sum
+        ;;     that doesn't match any recorded post-op score.
+        unknown-score? (has-unknown-incr? uncertain)
 
         any-candidate-write? (some write-op? candidates)
         any-candidate-zrem? (some #(= :zrem (:f %)) candidates)

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -437,12 +437,24 @@
                             (some #(and (= :zincrby (:f %))
                                         (:unknown-score? %))
                                   coll))
-        ;; Uncertain score set when any ZINCRBY is concurrent/uncertain
-        ;; (its resulting score is unknown), OR when multiple concurrent
-        ;; increments could yield intermediate prefix-sum scores that
-        ;; are not in :scores.
+        ;; Count concurrent/uncertain ZINCRBYs. The resulting score of a
+        ;; read relative to ZINCRBYs depends on how many of them took
+        ;; effect before the read observed state.
+        ;;   * 0 uncertain ZINCRBYs: :scores is authoritative.
+        ;;   * 1 uncertain ZINCRBY whose final score is KNOWN (:ok):
+        ;;     the read can observe either the pre-op state (already in
+        ;;     :scores from candidates) or the post-op state (its known
+        ;;     final score, also added to :scores). :scores is complete.
+        ;;   * 1 uncertain ZINCRBY with UNKNOWN score (:info/:pending):
+        ;;     the post-op score is not recoverable from the history.
+        ;;     We must relax the strict score check.
+        ;;   * >=2 uncertain ZINCRBYs: their relative serialization
+        ;;     order produces prefix-sum intermediates that are not in
+        ;;     :scores (e.g. pre + delta1 before pre + delta1 + delta2).
+        ;;     Relax the strict score check.
+        uncertain-incrs (filter #(= :zincrby (:f %)) uncertain)
         unknown-score? (or (has-unknown-incr? uncertain)
-                           (some #(= :zincrby (:f %)) uncertain))
+                           (> (count uncertain-incrs) 1))
 
         any-candidate-write? (some write-op? candidates)
         any-candidate-zrem? (some #(= :zrem (:f %)) candidates)

--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -172,15 +172,23 @@
                                " against stale data under " zset-key ".")
                           {:type ::missing-conn-spec
                            :zset-key zset-key})))]
+      ;; The cleanup DEL MUST succeed. If it fails (connection refused,
+      ;; Redis error reply, timeout, whatever), stale data from a prior
+      ;; run survives under zset-key and can produce false-positive
+      ;; safety verdicts in the checker. Log loudly AND re-throw so
+      ;; Jepsen aborts the run instead of silently running against
+      ;; dirty state. (gemini MEDIUM)
       (try
         (car/wcar cs (car/del zset-key))
         (catch Throwable t
-          ;; Do NOT swallow silently: repeated setup! failures across
-          ;; runs would leave stale data under zset-key and could
-          ;; produce false-positive safety failures. Log loudly so
-          ;; operators notice. clojure.tools.logging/warn expects
-          ;; (warn msg) or (warn throwable msg) -- NOT multiple strings.
-          (warn t "ZSet safety setup! DEL failed -- stale data may survive into this run"))))
+          (warn t "ZSet safety setup! DEL failed -- aborting to avoid stale data")
+          (throw (ex-info
+                   (str "ZSet safety setup! failed to clear prior state at "
+                        zset-key ": " (.getMessage t)
+                        ". Refusing to run against potentially stale data.")
+                   {:type ::cleanup-failed
+                    :zset-key zset-key}
+                   t)))))
     this)
 
   (teardown! [this _test] this)

--- a/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
+++ b/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
@@ -200,6 +200,102 @@
 ;; Infinity score parsing
 ;; ---------------------------------------------------------------------------
 
+;; ---------------------------------------------------------------------------
+;; Linearization of concurrent ops / uncertain mutations (gemini HIGH batch 2)
+;; ---------------------------------------------------------------------------
+
+(deftest concurrent-zadd-zrem-both-completed-accepts-either-outcome
+  ;; gemini HIGH: ZADD and ZREM for the same member whose invoke/complete
+  ;; windows overlap (both commit before the read) have ambiguous
+  ;; linearization. A linearizable store may serialize either one last,
+  ;; so the read legitimately observes EITHER [["m1" 1.0]] OR [].
+  ;; Windows: ZADD=[inv=0, cmp=3], ZREM=[inv=1, cmp=2] — overlap.
+  (let [base [{:type :invoke :process 0 :f :zadd :value ["m1" 1] :index 0}
+              {:type :invoke :process 1 :f :zrem :value "m1" :index 1}
+              {:type :ok     :process 1 :f :zrem :value ["m1" true] :index 2}
+              {:type :ok     :process 0 :f :zadd :value ["m1" 1] :index 3}]
+        hist-present (conj base
+                        {:type :invoke :process 2 :f :zrange-all :index 4}
+                        {:type :ok     :process 2 :f :zrange-all
+                         :value [["m1" 1.0]] :index 5})
+        hist-absent (conj base
+                       {:type :invoke :process 2 :f :zrange-all :index 4}
+                       {:type :ok     :process 2 :f :zrange-all
+                        :value [] :index 5})]
+    (is (:valid? (run-checker hist-present))
+        "expected read observing ZADD's outcome to be accepted")
+    (is (:valid? (run-checker hist-absent))
+        "expected read observing ZREM's outcome (absent) to be accepted")))
+
+(deftest info-zrem-concurrent-with-read-allows-missing-member
+  ;; gemini HIGH: an :info ZREM that might have applied before a read
+  ;; leaves the member's presence uncertain. A ZRANGE that omits the
+  ;; member must NOT be flagged as a completeness failure.
+  (let [history [;; ZADD m1 committed before the read.
+                 {:type :invoke :process 0 :f :zadd :value ["m1" 1] :index 0}
+                 {:type :ok     :process 0 :f :zadd :value ["m1" 1] :index 1}
+                 ;; ZREM m1 is invoked, then the read runs, then the
+                 ;; ZREM response is lost (:info). The ZREM may or may
+                 ;; not have applied server-side.
+                 {:type :invoke :process 1 :f :zrem :value "m1" :index 2}
+                 {:type :invoke :process 0 :f :zrange-all :index 3}
+                 {:type :ok     :process 0 :f :zrange-all :value [] :index 4}
+                 {:type :info   :process 1 :f :zrem :value "m1" :index 5}]
+        result  (run-checker history)]
+    (is (:valid? result)
+        (str "expected :info ZREM to make absence acceptable, got: " result))))
+
+(deftest info-zincrby-does-not-flag-zrangebyscore-completeness
+  ;; gemini HIGH: a pre-read :info / concurrent ZINCRBY leaves the
+  ;; resulting score unknown. ZRANGEBYSCORE filtering on a specific
+  ;; range must not flag the member as missing, because its score may
+  ;; have moved outside [lo, hi].
+  (let [history [;; ZADD m1 at score 1 (committed well before read).
+                 {:type :invoke :process 0 :f :zadd :value ["m1" 1] :index 0}
+                 {:type :ok     :process 0 :f :zadd :value ["m1" 1] :index 1}
+                 ;; ZINCRBY m1 +100 — response lost (:info) BEFORE read.
+                 {:type :invoke :process 1 :f :zincrby :value ["m1" 100] :index 2}
+                 {:type :info   :process 1 :f :zincrby :value ["m1" 100] :index 3}
+                 ;; ZRANGEBYSCORE [0, 10] — m1's score is uncertain; it
+                 ;; may now be 101 (outside range) or still 1. The
+                 ;; checker must not complain about m1's absence.
+                 {:type :invoke :process 2 :f :zrangebyscore :value [0.0 10.0] :index 4}
+                 {:type :ok     :process 2 :f :zrangebyscore
+                  :value {:bounds [0.0 10.0] :members []} :index 5}]
+        result  (run-checker history)]
+    (is (:valid? result)
+        (str "expected :info ZINCRBY to skip completeness, got: " result))))
+
+(deftest zrangebyscore-completeness-still-detects-truly-missing-member
+  ;; Sanity: when NO uncertainty exists and a model member's committed
+  ;; score is definitively inside [lo, hi], its absence IS flagged.
+  (let [history [{:type :invoke :process 0 :f :zadd :value ["m1" 5] :index 0}
+                 {:type :ok     :process 0 :f :zadd :value ["m1" 5] :index 1}
+                 {:type :invoke :process 0 :f :zrangebyscore :value [0.0 10.0] :index 2}
+                 {:type :ok     :process 0 :f :zrangebyscore
+                  :value {:bounds [0.0 10.0] :members []} :index 3}]
+        result  (run-checker history)
+        kinds   (set (map :kind (:first-errors result)))]
+    (is (not (:valid? result)) (str "expected missing-member-range, got: " result))
+    (is (contains? kinds :missing-member-range)
+        (str "expected :missing-member-range, got kinds=" kinds))))
+
+(deftest zrange-completeness-still-detects-truly-missing-member
+  ;; Sanity: no uncertainty, member committed-present. Absence flagged.
+  (let [history [{:type :invoke :process 0 :f :zadd :value ["m1" 5] :index 0}
+                 {:type :ok     :process 0 :f :zadd :value ["m1" 5] :index 1}
+                 {:type :invoke :process 0 :f :zrange-all :index 2}
+                 {:type :ok     :process 0 :f :zrange-all :value [] :index 3}]
+        result  (run-checker history)
+        kinds   (set (map :kind (:first-errors result)))]
+    (is (not (:valid? result)) (str "expected missing-member, got: " result))
+    (is (contains? kinds :missing-member)
+        (str "expected :missing-member, got kinds=" kinds))))
+
+;; ---------------------------------------------------------------------------
+;; Infinity score parsing
+;; ---------------------------------------------------------------------------
+
 (deftest parse-withscores-handles-inf-strings
   ;; gemini HIGH: Redis returns "inf" / "+inf" / "-inf" for infinite
   ;; ZSET scores. Double/parseDouble expects "Infinity"; the workload's

--- a/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
+++ b/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
@@ -74,3 +74,16 @@
                  {:type :ok     :process 0 :f :zrange-all :value [["m1" 999.0]] :index 3}]
         result  (run-checker history)]
     (is (not (:valid? result)) (str "expected mismatch, got: " result))))
+
+(deftest no-op-zrem-alone-does-not-false-positive
+  ;; CI-observed false positive: a member whose only prior ops are no-op
+  ;; ZREMs was classified as :score-mismatch with :allowed #{} instead
+  ;; of treated as never-existed (:phantom candidate, empty read -> OK).
+  ;; After the existence-evidence? fix, a read that observes NO such
+  ;; member must be accepted as valid.
+  (let [history [{:type :invoke :process 0 :f :zrem :value "never-added" :index 0}
+                 {:type :invoke :process 1 :f :zrange-all :index 1}
+                 {:type :ok     :process 1 :f :zrange-all :value [] :index 2}
+                 {:type :ok     :process 0 :f :zrem :value ["never-added" false] :index 3}]
+        result  (run-checker history)]
+    (is (:valid? result) (str "expected valid, got: " result))))

--- a/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
+++ b/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
@@ -77,12 +77,12 @@
     (is (not (:valid? result)) (str "expected mismatch, got: " result))))
 
 (deftest single-ok-concurrent-zincrby-still-validates-scores
-  ;; Codex P1: :unknown-score? must NOT be set when exactly one
-  ;; concurrent ZINCRBY is :ok (and therefore has a known resulting
-  ;; score). The read may observe either the pre-op score or the
-  ;; post-op score, both of which are in :scores. An arbitrary
-  ;; impossible score (e.g. 999.0) must still be flagged as a
-  ;; :score-mismatch, not waved through by `:unknown-score?`.
+  ;; :unknown-score? must NOT be set when exactly one concurrent
+  ;; ZINCRBY is :ok (and therefore has a known resulting score). The
+  ;; read may observe either the pre-op score or the post-op score,
+  ;; both of which are in :scores. An arbitrary impossible score
+  ;; (e.g. 999.0) must still be flagged as a :score-mismatch, not
+  ;; waved through by `:unknown-score?`.
   (let [history [{:type :invoke :process 0 :f :zadd    :value ["m1" 1]   :index 0}
                  {:type :ok     :process 0 :f :zadd    :value ["m1" 1]   :index 1}
                  {:type :invoke :process 1 :f :zincrby :value ["m1" 5]   :index 2}
@@ -130,7 +130,7 @@
     (is (:valid? result) (str "expected valid, got: " result))))
 
 (deftest duplicate-members-are-flagged
-  ;; CodeRabbit finding: ZRANGE must not return the same member twice.
+  ;; ZRANGE must not return the same member twice.
   ;; With a hypothetical committed + concurrent score for the same
   ;; member, a duplicate could sneak past sort + score-membership
   ;; checks. Enforce distinctness explicitly.
@@ -143,7 +143,7 @@
     (is (not (:valid? result)) (str "expected duplicate-members error, got: " result))))
 
 (deftest overlapping-committed-zadds-allow-either-score
-  ;; CodeRabbit finding: two :ok ZADDs for the same member whose
+  ;; Two :ok ZADDs for the same member whose
   ;; invoke/complete windows overlap have ambiguous serialization
   ;; order. Either's resulting score is a valid post-state; the checker
   ;; must not pin to the higher :complete-idx value only.
@@ -163,7 +163,7 @@
         (str "expected valid under overlapping-writes relaxation, got: " result))))
 
 (deftest info-before-read-is-considered-uncertain
-  ;; CodeRabbit finding: an :info mutation that completed before a
+  ;; An :info mutation that completed before a
   ;; later read may have taken effect. It must be considered a possible
   ;; source of state for that read, rather than being ignored by both
   ;; model-before and the concurrent window.
@@ -183,11 +183,11 @@
         (str "expected :info-before-read to skip strict score check, got: " result))))
 
 ;; ---------------------------------------------------------------------------
-;; Stale-read / phantom / superseded-committed checks (gemini HIGH)
+;; Stale-read / phantom / superseded-committed checks
 ;; ---------------------------------------------------------------------------
 
 (deftest phantom-member-is-flagged
-  ;; gemini HIGH: a read that observes a member which was never added
+  ;; A read that observes a member which was never added
   ;; (no ZADD/ZINCRBY/true-ZREM anywhere) must be rejected.
   (let [history [{:type :invoke :process 0 :f :zrange-all :index 0}
                  {:type :ok     :process 0 :f :zrange-all
@@ -199,7 +199,7 @@
         (str "expected :unexpected-presence, got kinds=" kinds))))
 
 (deftest phantom-from-info-zrem-still-flagged
-  ;; gemini HIGH (round 2): an :info ZREM is the ONLY history contact
+  ;; An :info ZREM is the ONLY history contact
   ;; with a member (no ZADD/ZINCRBY ever). Because completed-mutation-
   ;; window defaults :removed? to true on :info ZREMs (for uncertainty
   ;; accounting), the checker must NOT treat ZREM as proof the member
@@ -224,7 +224,7 @@
         (str "expected :unexpected-presence, got kinds=" kinds))))
 
 (deftest stale-read-after-committed-zrem-is-flagged
-  ;; gemini HIGH: once a ZADD and a subsequent real (:removed? true) ZREM
+  ;; Once a ZADD and a subsequent real (:removed? true) ZREM
   ;; have BOTH committed (with no concurrent re-add), a later read that
   ;; still sees the member must be rejected as a stale read.
   (let [history [;; Add then remove m1 — both committed before any read.
@@ -243,7 +243,7 @@
         (str "expected :unexpected-presence, got kinds=" kinds))))
 
 (deftest superseded-committed-score-is-not-allowed
-  ;; gemini HIGH: a ZADD committed BEFORE another ZADD for the same
+  ;; A ZADD committed BEFORE another ZADD for the same
   ;; member whose invoke strictly followed it should not be treated as
   ;; a valid post-state score. Only the latest committed score (plus
   ;; concurrent in-flight) may be observed.
@@ -267,11 +267,11 @@
 ;; ---------------------------------------------------------------------------
 
 ;; ---------------------------------------------------------------------------
-;; Linearization of concurrent ops / uncertain mutations (gemini HIGH batch 2)
+;; Linearization of concurrent ops / uncertain mutations
 ;; ---------------------------------------------------------------------------
 
 (deftest concurrent-zadd-zrem-both-completed-accepts-either-outcome
-  ;; gemini HIGH: ZADD and ZREM for the same member whose invoke/complete
+  ;; ZADD and ZREM for the same member whose invoke/complete
   ;; windows overlap (both commit before the read) have ambiguous
   ;; linearization. A linearizable store may serialize either one last,
   ;; so the read legitimately observes EITHER [["m1" 1.0]] OR [].
@@ -294,7 +294,7 @@
         "expected read observing ZREM's outcome (absent) to be accepted")))
 
 (deftest info-zrem-concurrent-with-read-allows-missing-member
-  ;; gemini HIGH: an :info ZREM that might have applied before a read
+  ;; An :info ZREM that might have applied before a read
   ;; leaves the member's presence uncertain. A ZRANGE that omits the
   ;; member must NOT be flagged as a completeness failure.
   (let [history [;; ZADD m1 committed before the read.
@@ -312,7 +312,7 @@
         (str "expected :info ZREM to make absence acceptable, got: " result))))
 
 (deftest info-zincrby-does-not-flag-zrangebyscore-completeness
-  ;; gemini HIGH: a pre-read :info / concurrent ZINCRBY leaves the
+  ;; A pre-read :info / concurrent ZINCRBY leaves the
   ;; resulting score unknown. ZRANGEBYSCORE filtering on a specific
   ;; range must not flag the member as missing, because its score may
   ;; have moved outside [lo, hi].
@@ -359,11 +359,11 @@
         (str "expected :missing-member, got kinds=" kinds))))
 
 ;; ---------------------------------------------------------------------------
-;; Failed-concurrent mutations must not contribute to uncertainty (codex P1)
+;; Failed-concurrent mutations must not contribute to uncertainty
 ;; ---------------------------------------------------------------------------
 
 (deftest failed-concurrent-zrem-does-not-relax-must-be-present
-  ;; codex P1: a concurrent ZREM that completes with :fail did NOT take
+  ;; A concurrent ZREM that completes with :fail did NOT take
   ;; effect. Its window must NOT make the member's presence uncertain,
   ;; so a read that omits the member (which was ZADDed and committed
   ;; beforehand) must be flagged as :missing-member.
@@ -386,7 +386,7 @@
         (str "expected :missing-member, got kinds=" kinds))))
 
 (deftest failed-concurrent-zadd-does-not-contribute-allowed-score
-  ;; codex P1: a concurrent ZADD that completes with :fail did NOT take
+  ;; A concurrent ZADD that completes with :fail did NOT take
   ;; effect. Its score must NOT be added to the allowed set. A read
   ;; observing that score must be flagged as :score-mismatch rather than
   ;; being waved through by the failed ZADD's ghost contribution.
@@ -410,11 +410,11 @@
 
 ;; ---------------------------------------------------------------------------
 ;; Chained committed ZINCRBYs: only the linearization-chain tail is a
-;; valid final score. Earlier intermediate return values are stale. (codex P1)
+;; valid final score. Earlier intermediate return values are stale.
 ;; ---------------------------------------------------------------------------
 
 (deftest chained-committed-zincrby-rejects-stale-intermediate
-  ;; codex P1: sequential committed ZINCRBYs form a forced linearization
+  ;; Sequential committed ZINCRBYs form a forced linearization
   ;; chain. The first ZINCRBY's return value is an intermediate that no
   ;; post-chain read may observe. Expect :score-mismatch on the stale
   ;; intermediate.
@@ -442,7 +442,7 @@
         (str "expected :score-mismatch, got kinds=" kinds))))
 
 (deftest chained-committed-zincrby-accepts-latest
-  ;; codex P1: same history but the read observes the LATEST chain tail
+  ;; Same history but the read observes the LATEST chain tail
   ;; (6.0) -- accept as valid.
   (let [history [{:type :invoke :process 0 :f :zadd    :value ["m1" 1]    :index 0}
                  {:type :ok     :process 0 :f :zadd    :value ["m1" 1]    :index 1}
@@ -458,7 +458,7 @@
         (str "expected chain-tail score to be accepted, got: " result))))
 
 (deftest concurrent-zincrby-both-admissible
-  ;; codex P1: two overlapping-in-real-time ZINCRBYs whose returned
+  ;; Two overlapping-in-real-time ZINCRBYs whose returned
   ;; scores are BOTH candidate final states under some linearization.
   ;; Read observing either value must be accepted.
   ;; Overlap: A=[inv=2, cmp=5], B=[inv=3, cmp=4].
@@ -484,7 +484,7 @@
         "expected A's return value (6.0) admissible under overlap")))
 
 (deftest zadd-resets-zincrby-chain
-  ;; codex P1: a committed ZADD between ZINCRBYs resets the chain --
+  ;; A committed ZADD between ZINCRBYs resets the chain --
   ;; subsequent ZINCRBYs operate on the new ZADD'd value. The pre-reset
   ;; ZINCRBY score is NOT a valid read after the chain completes.
   (let [base [;; ZADD m1 1
@@ -517,11 +517,11 @@
 ;; :ok ZINCRBYs with known return values do NOT make the score check
 ;; unknown -- their return values pin the linearization and the
 ;; admissible score set is constrained by :scores (candidates + uncertain
-;; ok return values). (codex P1)
+;; ok return values).
 ;; ---------------------------------------------------------------------------
 
 (deftest two-ok-concurrent-zincrbys-reject-impossible-score
-  ;; codex P1: two overlapping :ok ZINCRBYs with known return values
+  ;; Two overlapping :ok ZINCRBYs with known return values
   ;; (3 and 6) constrain the admissible post-chain read set to {1,3,6}.
   ;; A read of 999 is impossible under any linearization; the checker
   ;; must flag it as :score-mismatch (no longer swallowed by the old
@@ -545,7 +545,7 @@
         (str "expected :score-mismatch, got kinds=" kinds))))
 
 (deftest two-ok-concurrent-zincrbys-accept-known-chain-tail
-  ;; codex P1: same concurrent :ok ZINCRBY history, but the read
+  ;; Same concurrent :ok ZINCRBY history, but the read
   ;; observes one of the recorded return values. Both 3.0 (linearization
   ;; where +3 ran first, then +2) and 6.0 (the other order) must be
   ;; accepted as valid.
@@ -569,7 +569,7 @@
         "expected 3.0 (other linearization) to be accepted")))
 
 (deftest info-plus-ok-concurrent-zincrby-stays-unknown
-  ;; codex P1: when at least one concurrent ZINCRBY is :info (unknown
+  ;; When at least one concurrent ZINCRBY is :info (unknown
   ;; post-op score), the strict score check must be relaxed regardless
   ;; of how many other :ok ZINCRBYs are concurrent. Any numeric score
   ;; must be accepted for this read.
@@ -596,11 +596,11 @@
 ;; ---------------------------------------------------------------------------
 
 ;; ---------------------------------------------------------------------------
-;; Client setup! / invoke! robustness (gemini MEDIUM)
+;; Client setup! / invoke! robustness
 ;; ---------------------------------------------------------------------------
 
 (deftest setup-bang-hard-fails-when-conn-spec-missing
-  ;; gemini HIGH: if open! failed to populate :conn-spec (unresolvable
+  ;; If open! failed to populate :conn-spec (unresolvable
   ;; host, etc.), setup! MUST throw rather than silently proceed.
   ;; Continuing with a no-op setup would leave stale data from a prior
   ;; run under zset-key and risk false-positive checker verdicts from
@@ -612,7 +612,7 @@
         "setup! must throw ex-info when :conn-spec is nil")))
 
 (deftest setup-bang-hard-fails-when-cleanup-del-errors
-  ;; gemini MEDIUM: even when :conn-spec is populated, if the actual
+  ;; Even when :conn-spec is populated, if the actual
   ;; cleanup (DEL zset-key) fails or errors, setup! must NOT silently
   ;; proceed. Stale data surviving from a prior run under zset-key
   ;; would cause false-positive safety verdicts. Propagate the
@@ -626,7 +626,7 @@
         "setup! must propagate cleanup failures, not swallow them")))
 
 (deftest zincrby-invoke-handles-nil-response
-  ;; gemini MEDIUM: if car/wcar for ZINCRBY returns nil (error reply
+  ;; If car/wcar for ZINCRBY returns nil (error reply
   ;; coerced, unexpected protocol edge), the op must complete as :info
   ;; with a structured :error, not throw NumberFormatException from
   ;; parse-double-safe swallowing (str nil) -> "nil".
@@ -642,7 +642,7 @@
             (str "expected :error to be populated, got: " result))))))
 
 (deftest zincrby-invoke-handles-unexpected-response
-  ;; gemini MEDIUM: same guard, but for a non-string / non-number reply.
+  ;; Same guard, but for a non-string / non-number reply.
   ;; Must complete :info rather than propagate a parse failure.
   (let [client (workload/->ElastickvRedisZSetSafetyClient
                  {} {:pool {} :spec {:host "localhost" :port 6379
@@ -667,11 +667,11 @@
         (is (= ["m1" 7.0] (:value result)))))))
 
 ;; ---------------------------------------------------------------------------
-;; Vacuous-pass guard (codex P1)
+;; Vacuous-pass guard
 ;; ---------------------------------------------------------------------------
 
 (deftest empty-history-is-unknown-not-valid
-  ;; codex P1: an empty history (e.g. Redis unreachable, all ops
+  ;; An empty history (e.g. Redis unreachable, all ops
   ;; downgraded to :info) produces zero successful reads. The checker
   ;; MUST NOT return :valid? true in that case -- that would be a
   ;; false-green. Expect :valid? :unknown plus a diagnostic :reason.
@@ -683,7 +683,7 @@
     (is (zero? (:reads result)))))
 
 (deftest all-info-history-is-unknown-not-valid
-  ;; codex P1: a run where every operation was downgraded to :info
+  ;; A run where every operation was downgraded to :info
   ;; (Redis unreachable / every read timed out) still has read-pairs
   ;; filtered down to zero :ok reads. Must surface as :valid? :unknown.
   (let [history [{:type :invoke :process 0 :f :zadd       :value ["m1" 1] :index 0}
@@ -708,7 +708,7 @@
         (str "expected :valid? true with one :ok read, got: " result))))
 
 (deftest zrem-invoke-handles-nil-response
-  ;; gemini MEDIUM: if car/wcar for ZREM returns nil (protocol edge,
+  ;; If car/wcar for ZREM returns nil (protocol edge,
   ;; closed connection, etc.), `(long nil)` would throw NPE and the
   ;; op would be logged as a generic failure via the general Exception
   ;; handler. Guard with `(or removed 0)` so the op resolves cleanly
@@ -736,7 +736,7 @@
         (is (= ["m1" true] (:value result)))))))
 
 (deftest parse-withscores-handles-inf-strings
-  ;; gemini HIGH: Redis returns "inf" / "+inf" / "-inf" for infinite
+  ;; Redis returns "inf" / "+inf" / "-inf" for infinite
   ;; ZSET scores. Double/parseDouble expects "Infinity"; the workload's
   ;; parser must normalize both encodings instead of throwing.
   (let [flat ["m-pos"  "inf"

--- a/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
+++ b/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
@@ -334,6 +334,56 @@
         (str "expected :missing-member, got kinds=" kinds))))
 
 ;; ---------------------------------------------------------------------------
+;; Failed-concurrent mutations must not contribute to uncertainty (codex P1)
+;; ---------------------------------------------------------------------------
+
+(deftest failed-concurrent-zrem-does-not-relax-must-be-present
+  ;; codex P1: a concurrent ZREM that completes with :fail did NOT take
+  ;; effect. Its window must NOT make the member's presence uncertain,
+  ;; so a read that omits the member (which was ZADDed and committed
+  ;; beforehand) must be flagged as :missing-member.
+  (let [history [;; ZADD m1 committed before the read.
+                 {:type :invoke :process 0 :f :zadd :value ["m1" 1] :index 0}
+                 {:type :ok     :process 0 :f :zadd :value ["m1" 1] :index 1}
+                 ;; ZREM m1 is invoked concurrently with the read but
+                 ;; ultimately :fails -- the op definitively did NOT run.
+                 {:type :invoke :process 1 :f :zrem :value "m1" :index 2}
+                 {:type :invoke :process 0 :f :zrange-all :index 3}
+                 ;; Read observes m1 ABSENT -- without the fix, the
+                 ;; failed ZREM would admit this as "possibly removed".
+                 {:type :ok     :process 0 :f :zrange-all :value [] :index 4}
+                 {:type :fail   :process 1 :f :zrem :value "m1" :index 5}]
+        result  (run-checker history)
+        kinds   (set (map :kind (:first-errors result)))]
+    (is (not (:valid? result))
+        (str "expected :missing-member despite failed ZREM, got: " result))
+    (is (contains? kinds :missing-member)
+        (str "expected :missing-member, got kinds=" kinds))))
+
+(deftest failed-concurrent-zadd-does-not-contribute-allowed-score
+  ;; codex P1: a concurrent ZADD that completes with :fail did NOT take
+  ;; effect. Its score must NOT be added to the allowed set. A read
+  ;; observing that score must be flagged as :score-mismatch rather than
+  ;; being waved through by the failed ZADD's ghost contribution.
+  (let [history [;; ZADD m1 at score 1 committed before the read.
+                 {:type :invoke :process 0 :f :zadd :value ["m1" 1] :index 0}
+                 {:type :ok     :process 0 :f :zadd :value ["m1" 1] :index 1}
+                 ;; Concurrent ZADD m1 at score 42 ultimately :fails.
+                 {:type :invoke :process 1 :f :zadd :value ["m1" 42] :index 2}
+                 {:type :invoke :process 0 :f :zrange-all :index 3}
+                 ;; Read observes score 42 -- only valid if the failed
+                 ;; ZADD is (incorrectly) admitted as a possible write.
+                 {:type :ok     :process 0 :f :zrange-all
+                  :value [["m1" 42.0]] :index 4}
+                 {:type :fail   :process 1 :f :zadd :value ["m1" 42] :index 5}]
+        result  (run-checker history)
+        kinds   (set (map :kind (:first-errors result)))]
+    (is (not (:valid? result))
+        (str "expected :score-mismatch ignoring failed ZADD, got: " result))
+    (is (contains? kinds :score-mismatch)
+        (str "expected :score-mismatch, got kinds=" kinds))))
+
+;; ---------------------------------------------------------------------------
 ;; Infinity score parsing
 ;; ---------------------------------------------------------------------------
 

--- a/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
+++ b/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
@@ -75,6 +75,47 @@
         result  (run-checker history)]
     (is (not (:valid? result)) (str "expected mismatch, got: " result))))
 
+(deftest single-ok-concurrent-zincrby-still-validates-scores
+  ;; Codex P1: :unknown-score? must NOT be set when exactly one
+  ;; concurrent ZINCRBY is :ok (and therefore has a known resulting
+  ;; score). The read may observe either the pre-op score or the
+  ;; post-op score, both of which are in :scores. An arbitrary
+  ;; impossible score (e.g. 999.0) must still be flagged as a
+  ;; :score-mismatch, not waved through by `:unknown-score?`.
+  (let [history [{:type :invoke :process 0 :f :zadd    :value ["m1" 1]   :index 0}
+                 {:type :ok     :process 0 :f :zadd    :value ["m1" 1]   :index 1}
+                 {:type :invoke :process 1 :f :zincrby :value ["m1" 5]   :index 2}
+                 {:type :invoke :process 0 :f :zrange-all                :index 3}
+                 ;; Read observes 999.0 — not 1.0 (pre) or 6.0 (post).
+                 {:type :ok     :process 0 :f :zrange-all
+                  :value [["m1" 999.0]] :index 4}
+                 ;; ZINCRBY eventually completes :ok with known score 6.
+                 {:type :ok     :process 1 :f :zincrby :value ["m1" 6.0] :index 5}]
+        result  (run-checker history)
+        kinds   (set (map :kind (:first-errors result)))]
+    (is (not (:valid? result))
+        (str "expected score-mismatch to still fire, got: " result))
+    (is (contains? kinds :score-mismatch)
+        (str "expected :score-mismatch, got kinds=" kinds))))
+
+(deftest two-concurrent-zincrbys-relax-score-check
+  ;; Prefix-sum ordering matters: with two concurrent ZINCRBYs, the
+  ;; intermediate score (pre + one delta) is reachable and need not be
+  ;; in :scores. The checker must relax the strict score check.
+  (let [history [{:type :invoke :process 0 :f :zadd    :value ["m1" 1]   :index 0}
+                 {:type :ok     :process 0 :f :zadd    :value ["m1" 1]   :index 1}
+                 {:type :invoke :process 1 :f :zincrby :value ["m1" 2]   :index 2}
+                 {:type :invoke :process 2 :f :zincrby :value ["m1" 3]   :index 3}
+                 {:type :invoke :process 0 :f :zrange-all                :index 4}
+                 ;; Intermediate 3.0 = 1 + 2 (before +3 applied).
+                 {:type :ok     :process 0 :f :zrange-all
+                  :value [["m1" 3.0]] :index 5}
+                 {:type :ok     :process 1 :f :zincrby :value ["m1" 3.0] :index 6}
+                 {:type :ok     :process 2 :f :zincrby :value ["m1" 6.0] :index 7}]
+        result  (run-checker history)]
+    (is (:valid? result)
+        (str "expected relaxation for >=2 concurrent ZINCRBYs, got: " result))))
+
 (deftest no-op-zrem-alone-does-not-false-positive
   ;; CI-observed false positive: a member whose only prior ops are no-op
   ;; ZREMs was classified as :score-mismatch with :allowed #{} instead

--- a/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
+++ b/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
@@ -663,6 +663,34 @@
             (str "expected :ok on numeric reply, got: " result))
         (is (= ["m1" 7.0] (:value result)))))))
 
+(deftest zrem-invoke-handles-nil-response
+  ;; gemini MEDIUM: if car/wcar for ZREM returns nil (protocol edge,
+  ;; closed connection, etc.), `(long nil)` would throw NPE and the
+  ;; op would be logged as a generic failure via the general Exception
+  ;; handler. Guard with `(or removed 0)` so the op resolves cleanly
+  ;; as :ok [member false].
+  (let [client (workload/->ElastickvRedisZSetSafetyClient
+                 {} {:pool {} :spec {:host "localhost" :port 6379
+                                     :timeout-ms 100}})
+        op     {:type :invoke :f :zrem :value "ghost" :process 0 :index 0}]
+    (with-redefs [workload/zrem! (fn [& _] nil)]
+      (let [result (client/invoke! client {} op)]
+        (is (= :ok (:type result))
+            (str "expected :ok on nil ZREM reply, got: " result))
+        (is (= ["ghost" false] (:value result))
+            (str "expected removed? false on nil reply, got: " result))))))
+
+(deftest zrem-invoke-handles-numeric-response
+  ;; Sanity: ZREM's normal reply is an integer count.
+  (let [client (workload/->ElastickvRedisZSetSafetyClient
+                 {} {:pool {} :spec {:host "localhost" :port 6379
+                                     :timeout-ms 100}})
+        op     {:type :invoke :f :zrem :value "m1" :process 0 :index 0}]
+    (with-redefs [workload/zrem! (fn [& _] 1)]
+      (let [result (client/invoke! client {} op)]
+        (is (= :ok (:type result)))
+        (is (= ["m1" true] (:value result)))))))
+
 (deftest parse-withscores-handles-inf-strings
   ;; gemini HIGH: Redis returns "inf" / "+inf" / "-inf" for infinite
   ;; ZSET scores. Double/parseDouble expects "Infinity"; the workload's

--- a/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
+++ b/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
@@ -663,6 +663,47 @@
             (str "expected :ok on numeric reply, got: " result))
         (is (= ["m1" 7.0] (:value result)))))))
 
+;; ---------------------------------------------------------------------------
+;; Vacuous-pass guard (codex P1)
+;; ---------------------------------------------------------------------------
+
+(deftest empty-history-is-unknown-not-valid
+  ;; codex P1: an empty history (e.g. Redis unreachable, all ops
+  ;; downgraded to :info) produces zero successful reads. The checker
+  ;; MUST NOT return :valid? true in that case -- that would be a
+  ;; false-green. Expect :valid? :unknown plus a diagnostic :reason.
+  (let [result (run-checker [])]
+    (is (= :unknown (:valid? result))
+        (str "expected :unknown on empty history, got: " result))
+    (is (string? (:reason result))
+        (str "expected :reason to be populated, got: " result))
+    (is (zero? (:reads result)))))
+
+(deftest all-info-history-is-unknown-not-valid
+  ;; codex P1: a run where every operation was downgraded to :info
+  ;; (Redis unreachable / every read timed out) still has read-pairs
+  ;; filtered down to zero :ok reads. Must surface as :valid? :unknown.
+  (let [history [{:type :invoke :process 0 :f :zadd       :value ["m1" 1] :index 0}
+                 {:type :info   :process 0 :f :zadd       :value ["m1" 1] :index 1
+                  :error "conn refused"}
+                 {:type :invoke :process 0 :f :zrange-all                 :index 2}
+                 {:type :info   :process 0 :f :zrange-all                 :index 3
+                  :error "conn refused"}]
+        result  (run-checker history)]
+    (is (= :unknown (:valid? result))
+        (str "expected :unknown when all ops are :info, got: " result))
+    (is (string? (:reason result)))))
+
+(deftest one-successful-read-is-enough-to-validate
+  ;; Sanity: the vacuous-pass guard must only kick in when there are
+  ;; ZERO successful reads. A single :ok read with no errors is a
+  ;; legitimate :valid? true.
+  (let [history [{:type :invoke :process 0 :f :zrange-all :index 0}
+                 {:type :ok     :process 0 :f :zrange-all :value [] :index 1}]
+        result  (run-checker history)]
+    (is (true? (:valid? result))
+        (str "expected :valid? true with one :ok read, got: " result))))
+
 (deftest zrem-invoke-handles-nil-response
   ;; gemini MEDIUM: if car/wcar for ZREM returns nil (protocol edge,
   ;; closed connection, etc.), `(long nil)` would throw NPE and the

--- a/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
+++ b/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
@@ -87,3 +87,56 @@
                  {:type :ok     :process 0 :f :zrem :value ["never-added" false] :index 3}]
         result  (run-checker history)]
     (is (:valid? result) (str "expected valid, got: " result))))
+
+(deftest duplicate-members-are-flagged
+  ;; CodeRabbit finding: ZRANGE must not return the same member twice.
+  ;; With a hypothetical committed + concurrent score for the same
+  ;; member, a duplicate could sneak past sort + score-membership
+  ;; checks. Enforce distinctness explicitly.
+  (let [history [{:type :invoke :process 0 :f :zadd :value ["m1" 1] :index 0}
+                 {:type :ok     :process 0 :f :zadd :value ["m1" 1] :index 1}
+                 {:type :invoke :process 0 :f :zrange-all :index 2}
+                 {:type :ok     :process 0 :f :zrange-all
+                  :value [["m1" 1.0] ["m1" 1.0]] :index 3}]
+        result  (run-checker history)]
+    (is (not (:valid? result)) (str "expected duplicate-members error, got: " result))))
+
+(deftest overlapping-committed-zadds-allow-either-score
+  ;; CodeRabbit finding: two :ok ZADDs for the same member whose
+  ;; invoke/complete windows overlap have ambiguous serialization
+  ;; order. Either's resulting score is a valid post-state; the checker
+  ;; must not pin to the higher :complete-idx value only.
+  ;; Timeline (overlap between A's [invoke=0, complete=3] and
+  ;; B's [invoke=1, complete=2]):
+  (let [history [{:type :invoke :process 0 :f :zadd :value ["m1" 5] :index 0}
+                 {:type :invoke :process 1 :f :zadd :value ["m1" 9] :index 1}
+                 {:type :ok     :process 1 :f :zadd :value ["m1" 9] :index 2}
+                 {:type :ok     :process 0 :f :zadd :value ["m1" 5] :index 3}
+                 ;; Post-commit: either 5 or 9 is a valid final score.
+                 ;; A read observing 5 must NOT be flagged as mismatch.
+                 {:type :invoke :process 2 :f :zrange-all :index 4}
+                 {:type :ok     :process 2 :f :zrange-all
+                  :value [["m1" 5.0]] :index 5}]
+        result  (run-checker history)]
+    (is (:valid? result)
+        (str "expected valid under overlapping-writes relaxation, got: " result))))
+
+(deftest info-before-read-is-considered-uncertain
+  ;; CodeRabbit finding: an :info mutation that completed before a
+  ;; later read may have taken effect. It must be considered a possible
+  ;; source of state for that read, rather than being ignored by both
+  ;; model-before and the concurrent window.
+  (let [history [;; Add m1 with score 1.
+                 {:type :invoke :process 0 :f :zadd :value ["m1" 1] :index 0}
+                 {:type :ok     :process 0 :f :zadd :value ["m1" 1] :index 1}
+                 ;; ZINCRBY m1 by 5 -- response lost, recorded :info.
+                 {:type :invoke :process 1 :f :zincrby :value ["m1" 5] :index 2}
+                 {:type :info   :process 1 :f :zincrby :value ["m1" 5] :index 3}
+                 ;; Later read observes m1 at score 6 (increment applied
+                 ;; server-side before the response was lost). Valid.
+                 {:type :invoke :process 2 :f :zrange-all :index 4}
+                 {:type :ok     :process 2 :f :zrange-all
+                  :value [["m1" 6.0]] :index 5}]
+        result  (run-checker history)]
+    (is (:valid? result)
+        (str "expected :info-before-read to skip strict score check, got: " result))))

--- a/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
+++ b/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
@@ -488,6 +488,85 @@
         "expected pre-reset intermediate (3.0) to be flagged")))
 
 ;; ---------------------------------------------------------------------------
+;; unknown-score? gate: restricted to :info ZINCRBYs only. Two concurrent
+;; :ok ZINCRBYs with known return values do NOT make the score check
+;; unknown -- their return values pin the linearization and the
+;; admissible score set is constrained by :scores (candidates + uncertain
+;; ok return values). (codex P1)
+;; ---------------------------------------------------------------------------
+
+(deftest two-ok-concurrent-zincrbys-reject-impossible-score
+  ;; codex P1: two overlapping :ok ZINCRBYs with known return values
+  ;; (3 and 6) constrain the admissible post-chain read set to {1,3,6}.
+  ;; A read of 999 is impossible under any linearization; the checker
+  ;; must flag it as :score-mismatch (no longer swallowed by the old
+  ;; "2+ uncertain zincrbys -> unknown-score?" shortcut).
+  (let [history [{:type :invoke :process 0 :f :zadd    :value ["m1" 1]    :index 0}
+                 {:type :ok     :process 0 :f :zadd    :value ["m1" 1]    :index 1}
+                 ;; Two concurrent ZINCRBYs. Windows overlap the read.
+                 {:type :invoke :process 1 :f :zincrby :value ["m1" 2]    :index 2}
+                 {:type :invoke :process 2 :f :zincrby :value ["m1" 3]    :index 3}
+                 {:type :ok     :process 1 :f :zincrby :value ["m1" 3.0]  :index 4}
+                 {:type :ok     :process 2 :f :zincrby :value ["m1" 6.0]  :index 5}
+                 ;; Read observes an impossible score.
+                 {:type :invoke :process 3 :f :zrange-all                 :index 6}
+                 {:type :ok     :process 3 :f :zrange-all
+                  :value [["m1" 999.0]] :index 7}]
+        result  (run-checker history)
+        kinds   (set (map :kind (:first-errors result)))]
+    (is (not (:valid? result))
+        (str "expected impossible score to be flagged, got: " result))
+    (is (contains? kinds :score-mismatch)
+        (str "expected :score-mismatch, got kinds=" kinds))))
+
+(deftest two-ok-concurrent-zincrbys-accept-known-chain-tail
+  ;; codex P1: same concurrent :ok ZINCRBY history, but the read
+  ;; observes one of the recorded return values. Both 3.0 (linearization
+  ;; where +3 ran first, then +2) and 6.0 (the other order) must be
+  ;; accepted as valid.
+  (let [base [{:type :invoke :process 0 :f :zadd    :value ["m1" 1]    :index 0}
+              {:type :ok     :process 0 :f :zadd    :value ["m1" 1]    :index 1}
+              {:type :invoke :process 1 :f :zincrby :value ["m1" 2]    :index 2}
+              {:type :invoke :process 2 :f :zincrby :value ["m1" 3]    :index 3}
+              {:type :ok     :process 1 :f :zincrby :value ["m1" 3.0]  :index 4}
+              {:type :ok     :process 2 :f :zincrby :value ["m1" 6.0]  :index 5}]
+        read-6 (conj base
+                 {:type :invoke :process 3 :f :zrange-all :index 6}
+                 {:type :ok     :process 3 :f :zrange-all
+                  :value [["m1" 6.0]] :index 7})
+        read-3 (conj base
+                 {:type :invoke :process 3 :f :zrange-all :index 6}
+                 {:type :ok     :process 3 :f :zrange-all
+                  :value [["m1" 3.0]] :index 7})]
+    (is (:valid? (run-checker read-6))
+        "expected 6.0 (one linearization) to be accepted")
+    (is (:valid? (run-checker read-3))
+        "expected 3.0 (other linearization) to be accepted")))
+
+(deftest info-plus-ok-concurrent-zincrby-stays-unknown
+  ;; codex P1: when at least one concurrent ZINCRBY is :info (unknown
+  ;; post-op score), the strict score check must be relaxed regardless
+  ;; of how many other :ok ZINCRBYs are concurrent. Any numeric score
+  ;; must be accepted for this read.
+  (let [history [{:type :invoke :process 0 :f :zadd    :value ["m1" 1]    :index 0}
+                 {:type :ok     :process 0 :f :zadd    :value ["m1" 1]    :index 1}
+                 ;; One :info ZINCRBY (unknown outcome).
+                 {:type :invoke :process 1 :f :zincrby :value ["m1" 2]    :index 2}
+                 ;; One :ok ZINCRBY with known return value.
+                 {:type :invoke :process 2 :f :zincrby :value ["m1" 3]    :index 3}
+                 {:type :ok     :process 2 :f :zincrby :value ["m1" 4.0]  :index 4}
+                 {:type :info   :process 1 :f :zincrby :value ["m1" 2]
+                  :error "conn reset" :index 5}
+                 ;; Read observes an "arbitrary" score -- admissible
+                 ;; because the :info ZINCRBY could have produced any
+                 ;; post-op state visible to the read.
+                 {:type :invoke :process 3 :f :zrange-all                 :index 6}
+                 {:type :ok     :process 3 :f :zrange-all
+                  :value [["m1" 42.0]] :index 7}]]
+    (is (:valid? (run-checker history))
+        "expected any score accepted when :info ZINCRBY is concurrent")))
+
+;; ---------------------------------------------------------------------------
 ;; Infinity score parsing
 ;; ---------------------------------------------------------------------------
 

--- a/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
+++ b/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
@@ -611,16 +611,19 @@
                           (client/setup! client {}))
         "setup! must throw ex-info when :conn-spec is nil")))
 
-(deftest setup-bang-tolerates-unreachable-redis
-  ;; gemini MEDIUM: a Redis that can't be reached must surface as a
-  ;; logged warn, not an uncaught throw that aborts the whole run. The
-  ;; fix catches Throwable in setup!.
+(deftest setup-bang-hard-fails-when-cleanup-del-errors
+  ;; gemini MEDIUM: even when :conn-spec is populated, if the actual
+  ;; cleanup (DEL zset-key) fails or errors, setup! must NOT silently
+  ;; proceed. Stale data surviving from a prior run under zset-key
+  ;; would cause false-positive safety verdicts. Propagate the
+  ;; exception so Jepsen aborts the run.
   (let [client (workload/->ElastickvRedisZSetSafetyClient
                  {} {:pool {} :spec {:host "127.0.0.1"
                                      :port 1   ; guaranteed unreachable
                                      :timeout-ms 100}})]
-    (is (= client (client/setup! client {}))
-        "setup! must swallow connection errors and keep the run going")))
+    (is (thrown? Throwable
+                 (client/setup! client {}))
+        "setup! must propagate cleanup failures, not swallow them")))
 
 (deftest zincrby-invoke-handles-nil-response
   ;; gemini MEDIUM: if car/wcar for ZINCRBY returns nil (error reply

--- a/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
+++ b/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
@@ -121,8 +121,7 @@
   ;; CI-observed false positive: a member whose only prior ops are no-op
   ;; ZREMs was classified as :score-mismatch with :allowed #{} instead
   ;; of treated as never-existed (:phantom candidate, empty read -> OK).
-  ;; After the existence-evidence? fix, a read that observes NO such
-  ;; member must be accepted as valid.
+  ;; A read that observes NO such member must be accepted as valid.
   (let [history [{:type :invoke :process 0 :f :zrem :value "never-added" :index 0}
                  {:type :invoke :process 1 :f :zrange-all :index 1}
                  {:type :ok     :process 1 :f :zrange-all :value [] :index 2}
@@ -196,6 +195,31 @@
         result  (run-checker history)
         kinds   (set (map :kind (:first-errors result)))]
     (is (not (:valid? result)) (str "expected phantom error, got: " result))
+    (is (contains? kinds :unexpected-presence)
+        (str "expected :unexpected-presence, got kinds=" kinds))))
+
+(deftest phantom-from-info-zrem-still-flagged
+  ;; gemini HIGH (round 2): an :info ZREM is the ONLY history contact
+  ;; with a member (no ZADD/ZINCRBY ever). Because completed-mutation-
+  ;; window defaults :removed? to true on :info ZREMs (for uncertainty
+  ;; accounting), the checker must NOT treat ZREM as proof the member
+  ;; ever existed. A read observing the member present must be flagged
+  ;; as :unexpected-presence. Since setup! clears the key at test
+  ;; start, every observed member must trace back to a successful (or
+  ;; in-flight) ZADD/ZINCRBY -- never to a ZREM.
+  (let [history [;; ZREM of a member that was never added. Invoked
+                 ;; concurrently with the read, response eventually
+                 ;; lost (:info). No ZADD/ZINCRBY anywhere in history.
+                 {:type :invoke :process 0 :f :zrem  :value "phantom" :index 0}
+                 {:type :invoke :process 1 :f :zrange-all :index 1}
+                 ;; Read observes the phantom present at some score.
+                 {:type :ok     :process 1 :f :zrange-all
+                  :value [["phantom" 7.0]] :index 2}
+                 {:type :info   :process 0 :f :zrem  :value "phantom" :index 3}]
+        result  (run-checker history)
+        kinds   (set (map :kind (:first-errors result)))]
+    (is (not (:valid? result))
+        (str "expected :unexpected-presence for phantom, got: " result))
     (is (contains? kinds :unexpected-presence)
         (str "expected :unexpected-presence, got kinds=" kinds))))
 

--- a/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
+++ b/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
@@ -3,6 +3,7 @@
   the model-based checker's edge cases (no-op ZREM, :info ZINCRBY)."
   (:require [clojure.test :refer :all]
             [jepsen.checker :as checker]
+            [jepsen.client :as client]
             [elastickv.redis-zset-safety-workload :as workload]))
 
 ;; ---------------------------------------------------------------------------
@@ -569,6 +570,71 @@
 ;; ---------------------------------------------------------------------------
 ;; Infinity score parsing
 ;; ---------------------------------------------------------------------------
+
+;; ---------------------------------------------------------------------------
+;; Client setup! / invoke! robustness (gemini MEDIUM)
+;; ---------------------------------------------------------------------------
+
+(deftest setup-bang-tolerates-missing-conn-spec
+  ;; gemini MEDIUM: if open! failed to populate :conn-spec (unresolvable
+  ;; host, etc.), setup! must NOT throw. Otherwise stale data from a
+  ;; prior run stays under zset-key and produces false-positive safety
+  ;; failures. The fix logs the skip loudly but returns normally.
+  (let [client (workload/->ElastickvRedisZSetSafetyClient {} nil)]
+    (is (= client (client/setup! client {}))
+        "setup! must return the client (not throw) when :conn-spec is nil")))
+
+(deftest setup-bang-tolerates-unreachable-redis
+  ;; gemini MEDIUM: a Redis that can't be reached must surface as a
+  ;; logged warn, not an uncaught throw that aborts the whole run. The
+  ;; fix catches Throwable in setup!.
+  (let [client (workload/->ElastickvRedisZSetSafetyClient
+                 {} {:pool {} :spec {:host "127.0.0.1"
+                                     :port 1   ; guaranteed unreachable
+                                     :timeout-ms 100}})]
+    (is (= client (client/setup! client {}))
+        "setup! must swallow connection errors and keep the run going")))
+
+(deftest zincrby-invoke-handles-nil-response
+  ;; gemini MEDIUM: if car/wcar for ZINCRBY returns nil (error reply
+  ;; coerced, unexpected protocol edge), the op must complete as :info
+  ;; with a structured :error, not throw NumberFormatException from
+  ;; parse-double-safe swallowing (str nil) -> "nil".
+  (let [client (workload/->ElastickvRedisZSetSafetyClient
+                 {} {:pool {} :spec {:host "localhost" :port 6379
+                                     :timeout-ms 100}})
+        op     {:type :invoke :f :zincrby :value ["m1" 1.0] :process 0 :index 0}]
+    (with-redefs [workload/zincrby! (fn [& _] nil)]
+      (let [result (client/invoke! client {} op)]
+        (is (= :info (:type result))
+            (str "expected :info on nil ZINCRBY reply, got: " result))
+        (is (some? (:error result))
+            (str "expected :error to be populated, got: " result))))))
+
+(deftest zincrby-invoke-handles-unexpected-response
+  ;; gemini MEDIUM: same guard, but for a non-string / non-number reply.
+  ;; Must complete :info rather than propagate a parse failure.
+  (let [client (workload/->ElastickvRedisZSetSafetyClient
+                 {} {:pool {} :spec {:host "localhost" :port 6379
+                                     :timeout-ms 100}})
+        op     {:type :invoke :f :zincrby :value ["m1" 1.0] :process 0 :index 0}]
+    (with-redefs [workload/zincrby! (fn [& _] {:unexpected :map})]
+      (let [result (client/invoke! client {} op)]
+        (is (= :info (:type result))
+            (str "expected :info on unexpected ZINCRBY reply, got: " result))))))
+
+(deftest zincrby-invoke-accepts-numeric-response
+  ;; Sanity: some Carmine versions coerce integer scores to longs.
+  ;; Must parse cleanly to a Double and complete :ok.
+  (let [client (workload/->ElastickvRedisZSetSafetyClient
+                 {} {:pool {} :spec {:host "localhost" :port 6379
+                                     :timeout-ms 100}})
+        op     {:type :invoke :f :zincrby :value ["m1" 1.0] :process 0 :index 0}]
+    (with-redefs [workload/zincrby! (fn [& _] 7)]
+      (let [result (client/invoke! client {} op)]
+        (is (= :ok (:type result))
+            (str "expected :ok on numeric reply, got: " result))
+        (is (= ["m1" 7.0] (:value result)))))))
 
 (deftest parse-withscores-handles-inf-strings
   ;; gemini HIGH: Redis returns "inf" / "+inf" / "-inf" for infinite

--- a/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
+++ b/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
@@ -1,0 +1,76 @@
+(ns elastickv.redis-zset-safety-workload-test
+  "Unit tests for the ZSet safety workload's test-spec construction and
+  the model-based checker's edge cases (no-op ZREM, :info ZINCRBY)."
+  (:require [clojure.test :refer :all]
+            [jepsen.checker :as checker]
+            [elastickv.redis-zset-safety-workload :as workload]))
+
+;; ---------------------------------------------------------------------------
+;; Test-spec construction
+;; ---------------------------------------------------------------------------
+
+(deftest builds-test-spec
+  (let [t (workload/elastickv-zset-safety-test {})]
+    (is (map? t))
+    (is (= "elastickv-redis-zset-safety" (:name t)))
+    (is (= ["n1" "n2" "n3" "n4" "n5"] (:nodes t)))
+    (is (some? (:client t)))
+    (is (some? (:checker t)))
+    (is (some? (:generator t)))))
+
+(deftest custom-options-override-defaults
+  (let [t (workload/elastickv-zset-safety-test
+            {:time-limit 30
+             :concurrency 8
+             :rate 4})]
+    (is (= 8 (:concurrency t)))))
+
+;; ---------------------------------------------------------------------------
+;; Checker edge cases
+;; ---------------------------------------------------------------------------
+
+(defn- run-checker
+  "Run the workload's safety checker against an in-memory history.
+  Bypasses the composed timeline.html checker (which writes files to
+  the test store) so tests stay hermetic."
+  [history]
+  (checker/check (workload/zset-safety-checker)
+                 (workload/elastickv-zset-safety-test {})
+                 history
+                 nil))
+
+(deftest noop-zrem-does-not-flag-correct-read
+  ;; ZREM of a member that was never added returns 0 (no-op). The model
+  ;; must not treat it as a deletion. A subsequent read showing the
+  ;; absence of that member is correct.
+  (let [history [{:type :invoke :process 0 :f :zrem  :value "ghost" :index 0}
+                 {:type :ok     :process 0 :f :zrem  :value ["ghost" false] :index 1}
+                 {:type :invoke :process 0 :f :zadd  :value ["m1" 1] :index 2}
+                 {:type :ok     :process 0 :f :zadd  :value ["m1" 1] :index 3}
+                 {:type :invoke :process 0 :f :zrange-all :index 4}
+                 {:type :ok     :process 0 :f :zrange-all :value [["m1" 1.0]] :index 5}]
+        result  (run-checker history)]
+    (is (:valid? result) (str "expected valid, got: " result))))
+
+(deftest info-zincrby-skips-strict-score-check
+  ;; ZINCRBY whose response was lost (:info) leaves the resulting score
+  ;; unknown. A read concurrent with such an op observing some derived
+  ;; score must NOT be flagged as a score mismatch.
+  (let [history [{:type :invoke :process 0 :f :zadd    :value ["m1" 1] :index 0}
+                 {:type :ok     :process 0 :f :zadd    :value ["m1" 1] :index 1}
+                 {:type :invoke :process 1 :f :zincrby :value ["m1" 5] :index 2}
+                 {:type :invoke :process 0 :f :zrange-all :index 3}
+                 {:type :ok     :process 0 :f :zrange-all :value [["m1" 6.0]] :index 4}
+                 {:type :info   :process 1 :f :zincrby :value ["m1" 5] :index 5}]
+        result  (run-checker history)]
+    (is (:valid? result) (str "expected valid, got: " result))))
+
+(deftest score-mismatch-is-detected-when-no-uncertainty
+  ;; Sanity check: with all ops :ok and no concurrency, an obviously
+  ;; wrong observed score IS flagged.
+  (let [history [{:type :invoke :process 0 :f :zadd :value ["m1" 1] :index 0}
+                 {:type :ok     :process 0 :f :zadd :value ["m1" 1] :index 1}
+                 {:type :invoke :process 0 :f :zrange-all :index 2}
+                 {:type :ok     :process 0 :f :zrange-all :value [["m1" 999.0]] :index 3}]
+        result  (run-checker history)]
+    (is (not (:valid? result)) (str "expected mismatch, got: " result))))

--- a/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
+++ b/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
@@ -140,3 +140,79 @@
         result  (run-checker history)]
     (is (:valid? result)
         (str "expected :info-before-read to skip strict score check, got: " result))))
+
+;; ---------------------------------------------------------------------------
+;; Stale-read / phantom / superseded-committed checks (gemini HIGH)
+;; ---------------------------------------------------------------------------
+
+(deftest phantom-member-is-flagged
+  ;; gemini HIGH: a read that observes a member which was never added
+  ;; (no ZADD/ZINCRBY/true-ZREM anywhere) must be rejected.
+  (let [history [{:type :invoke :process 0 :f :zrange-all :index 0}
+                 {:type :ok     :process 0 :f :zrange-all
+                  :value [["never-added" 42.0]] :index 1}]
+        result  (run-checker history)
+        kinds   (set (map :kind (:first-errors result)))]
+    (is (not (:valid? result)) (str "expected phantom error, got: " result))
+    (is (contains? kinds :unexpected-presence)
+        (str "expected :unexpected-presence, got kinds=" kinds))))
+
+(deftest stale-read-after-committed-zrem-is-flagged
+  ;; gemini HIGH: once a ZADD and a subsequent real (:removed? true) ZREM
+  ;; have BOTH committed (with no concurrent re-add), a later read that
+  ;; still sees the member must be rejected as a stale read.
+  (let [history [;; Add then remove m1 — both committed before any read.
+                 {:type :invoke :process 0 :f :zadd :value ["m1" 1] :index 0}
+                 {:type :ok     :process 0 :f :zadd :value ["m1" 1] :index 1}
+                 {:type :invoke :process 0 :f :zrem :value "m1" :index 2}
+                 {:type :ok     :process 0 :f :zrem :value ["m1" true] :index 3}
+                 ;; Stale read: m1 somehow still appears.
+                 {:type :invoke :process 1 :f :zrange-all :index 4}
+                 {:type :ok     :process 1 :f :zrange-all
+                  :value [["m1" 1.0]] :index 5}]
+        result  (run-checker history)
+        kinds   (set (map :kind (:first-errors result)))]
+    (is (not (:valid? result)) (str "expected stale-read error, got: " result))
+    (is (contains? kinds :unexpected-presence)
+        (str "expected :unexpected-presence, got kinds=" kinds))))
+
+(deftest superseded-committed-score-is-not-allowed
+  ;; gemini HIGH: a ZADD committed BEFORE another ZADD for the same
+  ;; member whose invoke strictly followed it should not be treated as
+  ;; a valid post-state score. Only the latest committed score (plus
+  ;; concurrent in-flight) may be observed.
+  (let [history [;; ZADD m1 1 commits first ...
+                 {:type :invoke :process 0 :f :zadd :value ["m1" 1] :index 0}
+                 {:type :ok     :process 0 :f :zadd :value ["m1" 1] :index 1}
+                 ;; ... then ZADD m1 2 is invoked strictly after, and
+                 ;; also commits before the read.
+                 {:type :invoke :process 0 :f :zadd :value ["m1" 2] :index 2}
+                 {:type :ok     :process 0 :f :zadd :value ["m1" 2] :index 3}
+                 ;; Read observing the SUPERSEDED score 1.0 — invalid.
+                 {:type :invoke :process 1 :f :zrange-all :index 4}
+                 {:type :ok     :process 1 :f :zrange-all
+                  :value [["m1" 1.0]] :index 5}]
+        result  (run-checker history)]
+    (is (not (:valid? result))
+        (str "expected superseded-score mismatch, got: " result))))
+
+;; ---------------------------------------------------------------------------
+;; Infinity score parsing
+;; ---------------------------------------------------------------------------
+
+(deftest parse-withscores-handles-inf-strings
+  ;; gemini HIGH: Redis returns "inf" / "+inf" / "-inf" for infinite
+  ;; ZSET scores. Double/parseDouble expects "Infinity"; the workload's
+  ;; parser must normalize both encodings instead of throwing.
+  (let [flat ["m-pos"  "inf"
+              "m-pos2" "+inf"
+              "m-neg"  "-inf"
+              "m-jvm"  "Infinity"
+              "m-num"  "3.5"]
+        parsed (#'workload/parse-withscores flat)]
+    (is (= [["m-pos"  Double/POSITIVE_INFINITY]
+            ["m-pos2" Double/POSITIVE_INFINITY]
+            ["m-neg"  Double/NEGATIVE_INFINITY]
+            ["m-jvm"  Double/POSITIVE_INFINITY]
+            ["m-num"  3.5]]
+           parsed))))

--- a/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
+++ b/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
@@ -599,14 +599,17 @@
 ;; Client setup! / invoke! robustness (gemini MEDIUM)
 ;; ---------------------------------------------------------------------------
 
-(deftest setup-bang-tolerates-missing-conn-spec
-  ;; gemini MEDIUM: if open! failed to populate :conn-spec (unresolvable
-  ;; host, etc.), setup! must NOT throw. Otherwise stale data from a
-  ;; prior run stays under zset-key and produces false-positive safety
-  ;; failures. The fix logs the skip loudly but returns normally.
+(deftest setup-bang-hard-fails-when-conn-spec-missing
+  ;; gemini HIGH: if open! failed to populate :conn-spec (unresolvable
+  ;; host, etc.), setup! MUST throw rather than silently proceed.
+  ;; Continuing with a no-op setup would leave stale data from a prior
+  ;; run under zset-key and risk false-positive checker verdicts from
+  ;; that dirty state. We want Jepsen to surface the failure.
   (let [client (workload/->ElastickvRedisZSetSafetyClient {} nil)]
-    (is (= client (client/setup! client {}))
-        "setup! must return the client (not throw) when :conn-spec is nil")))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #":conn-spec is missing"
+                          (client/setup! client {}))
+        "setup! must throw ex-info when :conn-spec is nil")))
 
 (deftest setup-bang-tolerates-unreachable-redis
   ;; gemini MEDIUM: a Redis that can't be reached must surface as a

--- a/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
+++ b/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
@@ -384,6 +384,110 @@
         (str "expected :score-mismatch, got kinds=" kinds))))
 
 ;; ---------------------------------------------------------------------------
+;; Chained committed ZINCRBYs: only the linearization-chain tail is a
+;; valid final score. Earlier intermediate return values are stale. (codex P1)
+;; ---------------------------------------------------------------------------
+
+(deftest chained-committed-zincrby-rejects-stale-intermediate
+  ;; codex P1: sequential committed ZINCRBYs form a forced linearization
+  ;; chain. The first ZINCRBY's return value is an intermediate that no
+  ;; post-chain read may observe. Expect :score-mismatch on the stale
+  ;; intermediate.
+  (let [history [;; Start with score 1.
+                 {:type :invoke :process 0 :f :zadd    :value ["m1" 1]    :index 0}
+                 {:type :ok     :process 0 :f :zadd    :value ["m1" 1]    :index 1}
+                 ;; ZINCRBY +2 -> ok=3 (committed).
+                 {:type :invoke :process 0 :f :zincrby :value ["m1" 2]    :index 2}
+                 {:type :ok     :process 0 :f :zincrby :value ["m1" 3.0]  :index 3}
+                 ;; ZINCRBY +3 -> ok=6 (committed). Strictly follows the
+                 ;; previous ZINCRBY in real time (invoke 4 > complete 3).
+                 {:type :invoke :process 0 :f :zincrby :value ["m1" 3]    :index 4}
+                 {:type :ok     :process 0 :f :zincrby :value ["m1" 6.0]  :index 5}
+                 ;; Read AFTER the whole chain observes the stale
+                 ;; intermediate 3.0 -- not admissible under any
+                 ;; linearization.
+                 {:type :invoke :process 1 :f :zrange-all                 :index 6}
+                 {:type :ok     :process 1 :f :zrange-all
+                  :value [["m1" 3.0]] :index 7}]
+        result  (run-checker history)
+        kinds   (set (map :kind (:first-errors result)))]
+    (is (not (:valid? result))
+        (str "expected stale-intermediate to be flagged, got: " result))
+    (is (contains? kinds :score-mismatch)
+        (str "expected :score-mismatch, got kinds=" kinds))))
+
+(deftest chained-committed-zincrby-accepts-latest
+  ;; codex P1: same history but the read observes the LATEST chain tail
+  ;; (6.0) -- accept as valid.
+  (let [history [{:type :invoke :process 0 :f :zadd    :value ["m1" 1]    :index 0}
+                 {:type :ok     :process 0 :f :zadd    :value ["m1" 1]    :index 1}
+                 {:type :invoke :process 0 :f :zincrby :value ["m1" 2]    :index 2}
+                 {:type :ok     :process 0 :f :zincrby :value ["m1" 3.0]  :index 3}
+                 {:type :invoke :process 0 :f :zincrby :value ["m1" 3]    :index 4}
+                 {:type :ok     :process 0 :f :zincrby :value ["m1" 6.0]  :index 5}
+                 {:type :invoke :process 1 :f :zrange-all                 :index 6}
+                 {:type :ok     :process 1 :f :zrange-all
+                  :value [["m1" 6.0]] :index 7}]
+        result  (run-checker history)]
+    (is (:valid? result)
+        (str "expected chain-tail score to be accepted, got: " result))))
+
+(deftest concurrent-zincrby-both-admissible
+  ;; codex P1: two overlapping-in-real-time ZINCRBYs whose returned
+  ;; scores are BOTH candidate final states under some linearization.
+  ;; Read observing either value must be accepted.
+  ;; Overlap: A=[inv=2, cmp=5], B=[inv=3, cmp=4].
+  (let [base [{:type :invoke :process 0 :f :zadd    :value ["m1" 1]    :index 0}
+              {:type :ok     :process 0 :f :zadd    :value ["m1" 1]    :index 1}
+              {:type :invoke :process 1 :f :zincrby :value ["m1" 2]    :index 2}
+              {:type :invoke :process 2 :f :zincrby :value ["m1" 3]    :index 3}
+              ;; B completes first with ok=4 (delta applied to score 1).
+              {:type :ok     :process 2 :f :zincrby :value ["m1" 4.0]  :index 4}
+              ;; A completes with ok=6 (delta applied after B).
+              {:type :ok     :process 1 :f :zincrby :value ["m1" 6.0]  :index 5}]
+        read-a (conj base
+                 {:type :invoke :process 3 :f :zrange-all :index 6}
+                 {:type :ok     :process 3 :f :zrange-all
+                  :value [["m1" 4.0]] :index 7})
+        read-b (conj base
+                 {:type :invoke :process 3 :f :zrange-all :index 6}
+                 {:type :ok     :process 3 :f :zrange-all
+                  :value [["m1" 6.0]] :index 7})]
+    (is (:valid? (run-checker read-a))
+        "expected B's return value (4.0) admissible under overlap")
+    (is (:valid? (run-checker read-b))
+        "expected A's return value (6.0) admissible under overlap")))
+
+(deftest zadd-resets-zincrby-chain
+  ;; codex P1: a committed ZADD between ZINCRBYs resets the chain --
+  ;; subsequent ZINCRBYs operate on the new ZADD'd value. The pre-reset
+  ;; ZINCRBY score is NOT a valid read after the chain completes.
+  (let [base [;; ZADD m1 1
+              {:type :invoke :process 0 :f :zadd    :value ["m1" 1]    :index 0}
+              {:type :ok     :process 0 :f :zadd    :value ["m1" 1]    :index 1}
+              ;; ZINCRBY +2 -> 3
+              {:type :invoke :process 0 :f :zincrby :value ["m1" 2]    :index 2}
+              {:type :ok     :process 0 :f :zincrby :value ["m1" 3.0]  :index 3}
+              ;; ZADD m1 10 -- chain reset to absolute value.
+              {:type :invoke :process 0 :f :zadd    :value ["m1" 10]   :index 4}
+              {:type :ok     :process 0 :f :zadd    :value ["m1" 10]   :index 5}
+              ;; ZINCRBY +1 -> 11
+              {:type :invoke :process 0 :f :zincrby :value ["m1" 1]    :index 6}
+              {:type :ok     :process 0 :f :zincrby :value ["m1" 11.0] :index 7}]
+        read-ok (conj base
+                  {:type :invoke :process 1 :f :zrange-all :index 8}
+                  {:type :ok     :process 1 :f :zrange-all
+                   :value [["m1" 11.0]] :index 9})
+        read-bad (conj base
+                   {:type :invoke :process 1 :f :zrange-all :index 8}
+                   {:type :ok     :process 1 :f :zrange-all
+                    :value [["m1" 3.0]] :index 9})]
+    (is (:valid? (run-checker read-ok))
+        "expected post-reset chain tail (11.0) to be accepted")
+    (is (not (:valid? (run-checker read-bad)))
+        "expected pre-reset intermediate (3.0) to be flagged")))
+
+;; ---------------------------------------------------------------------------
 ;; Infinity score parsing
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Replace the polling-based `waitForRaftReadiness` in `adapter/test_util.go` with an event-driven helper that also enforces a 300ms leader-stability window.

### Why

PR #596's CI log showed this race:

```
15:04:52 became leader at term 2
15:04:53 stepped down to follower since quorum is not active
15:04:54 (first test write) -> "not leader" error
```

The previous `assert.Eventually(... n.raft.State() == raft.Leader ...)` helper returned between the `became leader` line and the subsequent `stepped down` line, so the test's first write raced into the brief non-leader window and failed.

### What changes

- Subscribe to `raft.LeaderCh()` (hashicorp/raft's buffered-1 bool channel that emits `true` on leader, `false` on step-down) instead of polling.
- Drain any pre-existing notifications before we start so we only observe this run's transitions.
- After we see the `true` event, require the leader to hold `raft.Leader` (and all followers to hold `raft.Follower` pointing at the leader's address) for a **300ms stability window**, sampled every ~25ms. If anything flips during the window, go back to waiting for the next `true` event.
- Bump the overall readiness timeout from 5s to 10s at the call site in `createNode` to give headroom for the stability window plus real election delay.
- `nodes[0]` is the bootstrap leader (it's the only `Voter` at bootstrap and is the one that calls `BootstrapCluster`), so observing only `nodes[0].raft.LeaderCh()` is correct.

Complementary to PR #596's mid-test `rpushEventually`/`lpushEventually` retry helper: this patch fixes the **setup-side** race so most tests don't need the retry at all. The in-test retry still covers genuine mid-test churn (e.g. leader transfer triggered by the workload), so both should stay.

## Test plan

- [x] `go test -race -run '^TestRedis_LuaRPopLPushBullMQLikeLists$' ./adapter/ -count=10` — 0 failures, 20.8s
- [x] `go test -race -run '^TestRedis_' ./adapter/ -count=1` — all pass, 23.8s
- [x] `go test -race ./adapter/... -timeout 900s` — all pass, 65.5s (no pre-existing flakes observed in this run)
- [x] `golangci-lint run ./adapter/...` — 0 issues
