### PR TITLE
deploy(redis-proxy): nginx TCP proxy + 2 replicas for HA

### DIFF
--- a/deploy/redis-proxy/docker-compose.ha.yml
+++ b/deploy/redis-proxy/docker-compose.ha.yml
@@ -1,0 +1,71 @@
+# docker-compose.ha.yml -- high-availability redis-proxy topology.
+#
+# Two redis-proxy replicas sit behind an nginx TCP (stream module)
+# load balancer so operators can redeploy one replica at a time
+# without dropping client traffic. See docs/redis-proxy-deployment.md
+# for the rolling-deploy runbook.
+#
+# Client-facing endpoint: host :6379 -> nginx -> redis-proxy-{a,b}:6379.
+# The single-instance deploy in docs/redis-proxy-deployment.md still
+# works; this file is an additive HA option.
+
+services:
+  redis-proxy-a:
+    build:
+      context: ../..
+      dockerfile: Dockerfile.redis-proxy
+    image: ghcr.io/bootjp/elastickv/redis-proxy:latest
+    container_name: redis-proxy-a
+    restart: unless-stopped
+    # No host port exposure -- only nginx is client-facing. Other
+    # replicas in the compose network reach this one by service name.
+    expose:
+      - "6379"
+      - "9191"
+    command:
+      - -listen=:6379
+      - -primary=${REDIS_PROXY_PRIMARY:-redis:6379}
+      - -secondary=${REDIS_PROXY_SECONDARY:-elastickv:6380}
+      - -mode=${REDIS_PROXY_MODE:-dual-write-shadow}
+      - -metrics=:9191
+    networks:
+      - redis-proxy-ha
+
+  redis-proxy-b:
+    build:
+      context: ../..
+      dockerfile: Dockerfile.redis-proxy
+    image: ghcr.io/bootjp/elastickv/redis-proxy:latest
+    container_name: redis-proxy-b
+    restart: unless-stopped
+    expose:
+      - "6379"
+      - "9191"
+    command:
+      - -listen=:6379
+      - -primary=${REDIS_PROXY_PRIMARY:-redis:6379}
+      - -secondary=${REDIS_PROXY_SECONDARY:-elastickv:6380}
+      - -mode=${REDIS_PROXY_MODE:-dual-write-shadow}
+      - -metrics=:9191
+    networks:
+      - redis-proxy-ha
+
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: redis-proxy-nginx
+    restart: unless-stopped
+    depends_on:
+      - redis-proxy-a
+      - redis-proxy-b
+    ports:
+      # Stable client-facing endpoint. Applications connect here and
+      # stay connected across rolling redis-proxy upgrades.
+      - "6379:6379"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    networks:
+      - redis-proxy-ha
+
+networks:
+  redis-proxy-ha:
+    driver: bridge

--- a/deploy/redis-proxy/nginx.conf
+++ b/deploy/redis-proxy/nginx.conf
@@ -1,0 +1,39 @@
+# nginx.conf -- TCP load balancer for elastickv redis-proxy HA.
+# Two backends; passive health via max_fails + fail_timeout.
+# Stream-module only; no http context.
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+events {
+    worker_connections 4096;
+}
+
+stream {
+    log_format proxy_log '$remote_addr [$time_local] '
+                         '$protocol $status $bytes_sent $bytes_received '
+                         'upstream=$upstream_addr session_time=$session_time';
+    access_log /var/log/nginx/redis-proxy-access.log proxy_log;
+
+    upstream elastickv_redis_proxy {
+        # Hash by client IP so a single client's MULTI/EXEC/WATCH
+        # session lands on the same backend. Redis MULTI state is
+        # per-connection, not shared across replicas.
+        hash $remote_addr consistent;
+
+        # Retry the same connection against the next backend only
+        # if the TCP handshake itself failed -- do NOT retry after
+        # bytes have been exchanged to avoid double-executing
+        # non-idempotent commands.
+        server redis-proxy-a:6379 max_fails=3 fail_timeout=10s;
+        server redis-proxy-b:6379 max_fails=3 fail_timeout=10s;
+    }
+
+    server {
+        listen 6379;
+        proxy_pass elastickv_redis_proxy;
+        proxy_connect_timeout 1s;
+        proxy_timeout 5m;
+        proxy_next_upstream on;          # only pre-bytes failover
+        proxy_next_upstream_tries 2;
+        proxy_next_upstream_timeout 3s;
+    }
+}

--- a/docs/redis-proxy-deployment.md
+++ b/docs/redis-proxy-deployment.md
@@ -126,6 +126,144 @@ services:
       - "6380"
 ```
 
+### High-availability redis-proxy (nginx TCP LB + 2 replicas)
+
+The single-container deploy above causes a brief connection blip when the
+container restarts (image upgrade, config change, etc.). For operator-driven
+redeploys without dropping clients, put nginx's stream module in front of two
+redis-proxy replicas and drain them one at a time.
+
+Assets live under `deploy/redis-proxy/`:
+
+- `deploy/redis-proxy/nginx.conf` -- stream-module TCP LB config.
+- `deploy/redis-proxy/docker-compose.ha.yml` -- two redis-proxy replicas
+  (`redis-proxy-a`, `redis-proxy-b`) plus an `nginx:1.27-alpine` frontend.
+
+#### Architecture
+
+```
+           client (redis-cli, app)
+                     |
+                     v  :6379 (stable)
+              +---------------+
+              |     nginx     |   stream {} -- hash $remote_addr consistent
+              |  (stream TCP) |   passive health: max_fails=3 fail_timeout=10s
+              +-------+-------+
+                      |
+           +----------+----------+
+           v                     v
+   redis-proxy-a:6379    redis-proxy-b:6379
+           |                     |
+           +----------+----------+
+                      |
+                      v
+                elastickv cluster
+                  (+ Redis, in
+                  dual-write modes)
+```
+
+Nginx only exposes the client-facing port; the redis-proxy replicas are
+reachable only from within the compose network by service name.
+
+#### Session affinity
+
+The upstream uses `hash $remote_addr consistent`. This pins a given client's
+**new** connections to the same backend so that per-connection state
+(MULTI/EXEC, WATCH, SUBSCRIBE, Lua `SELECT`, etc.) lands on one replica that
+can actually observe it. Consistent hashing also minimises reshuffles when a
+backend is drained.
+
+nginx retries the connection against the next upstream **only** when the TCP
+handshake fails (`proxy_next_upstream on` + `proxy_next_upstream_tries 2`).
+Once bytes have been exchanged, nginx does **not** replay the command on
+another backend -- double-executing non-idempotent Redis commands would be
+worse than a reconnect.
+
+Trade-off: a client whose backend is taken offline sees its **existing**
+connection broken and must reconnect. Only new TCP sessions are steered
+away. This is the correct behaviour vs. silently double-sending an
+in-flight command.
+
+#### Bring up
+
+```bash
+cd deploy/redis-proxy
+# Build + start both backends and nginx.
+docker compose -f docker-compose.ha.yml up -d --build
+
+# Point the client at the nginx endpoint.
+redis-cli -p 6379 PING
+# PONG
+```
+
+Override backend wiring via env vars before `docker compose up`:
+
+```bash
+REDIS_PROXY_PRIMARY=redis.prod.internal:6379 \
+REDIS_PROXY_SECONDARY=elastickv-1.prod.internal:6380,elastickv-2.prod.internal:6380,elastickv-3.prod.internal:6380 \
+REDIS_PROXY_MODE=dual-write-shadow \
+  docker compose -f docker-compose.ha.yml up -d
+```
+
+#### Rolling redeploy procedure
+
+Do one backend at a time; wait for nginx passive health to mark it down
+before restarting, and wait for it to come back up before touching the
+other replica.
+
+```bash
+cd deploy/redis-proxy
+
+# 1. Pull the new image into the compose project.
+docker compose -f docker-compose.ha.yml pull redis-proxy-a
+
+# 2. Stop backend a. Passive health on nginx will observe max_fails
+#    within ~10s (fail_timeout) on the first few failed new-connection
+#    attempts and will stop sending traffic to redis-proxy-a.
+#    Existing nginx->a TCP sessions terminate; clients must reconnect
+#    and will land on redis-proxy-b.
+docker compose -f docker-compose.ha.yml stop redis-proxy-a
+
+# 3. Recreate with the new image.
+docker compose -f docker-compose.ha.yml up -d redis-proxy-a
+
+# 4. Verify it is serving before touching the other replica.
+docker compose -f docker-compose.ha.yml exec redis-proxy-a \
+    /redis-proxy --help >/dev/null    # smoke
+# Or, from a host with network access to the compose network:
+# redis-cli -h <redis-proxy-a-ip> -p 6379 PING
+
+# 5. Repeat for redis-proxy-b.
+docker compose -f docker-compose.ha.yml pull redis-proxy-b
+docker compose -f docker-compose.ha.yml stop redis-proxy-b
+docker compose -f docker-compose.ha.yml up -d redis-proxy-b
+```
+
+The existing `scripts/rolling-update.sh` is for the elastickv raft
+cluster, not the redis-proxy front-end; it is not involved in this
+sequence.
+
+#### Observability
+
+nginx writes one line per client session to
+`/var/log/nginx/redis-proxy-access.log` with this format (defined in
+`nginx.conf`):
+
+```
+$remote_addr [$time_local] $protocol $status $bytes_sent $bytes_received upstream=$upstream_addr session_time=$session_time
+```
+
+Tail it while redeploying to confirm traffic has shifted:
+
+```bash
+docker compose -f docker-compose.ha.yml exec nginx \
+    tail -f /var/log/nginx/redis-proxy-access.log
+```
+
+Per-backend redis-proxy metrics remain on `:9191` of each replica as
+before; scrape them individually (see the Prometheus Metrics section
+below).
+
 ### Kubernetes
 
 ```yaml


### PR DESCRIPTION
## Summary

- Adds `deploy/redis-proxy/nginx.conf` -- stream-module TCP LB that fronts two redis-proxy replicas, with passive health (`max_fails=3 fail_timeout=10s`) and `hash $remote_addr consistent` session affinity.
- Adds `deploy/redis-proxy/docker-compose.ha.yml` -- two `redis-proxy` services (`redis-proxy-a`, `redis-proxy-b`) built from `Dockerfile.redis-proxy` plus `nginx:1.27-alpine` on `:6379` as the stable client-facing endpoint. Shared `redis-proxy-ha` bridge network so nginx resolves backends by service name; no hardcoded IPs.
- Extends `docs/redis-proxy-deployment.md` with an "High-availability redis-proxy" section covering architecture, session affinity + failover trade-offs, bring-up, rolling redeploy sequence, and observability.

The existing single-container Docker / Kubernetes examples in the deployment doc are left in place; this is an additive HA option.

## Architecture

```
client -> nginx :6379 (stream, hash $remote_addr consistent)
         |-> redis-proxy-a:6379 -         |                        +-> elastickv cluster (+ Redis in dual-write modes)
         \-> redis-proxy-b:6379 -/
```

## Session affinity

`hash $remote_addr consistent` so per-connection state (MULTI/EXEC, WATCH, SUBSCRIBE, Lua SELECT) lands on one backend. Failover is pre-bytes only (`proxy_next_upstream on` + `tries 2`) -- nginx never replays an in-flight Redis command against the other backend. A client whose backend is drained sees its existing connection drop and must reconnect; new connections go to the healthy backend. This is intentional vs. silent double-sends of non-idempotent commands.

## Rolling redeploy (full runbook in docs)

```bash
cd deploy/redis-proxy
docker compose -f docker-compose.ha.yml pull redis-proxy-a
docker compose -f docker-compose.ha.yml stop redis-proxy-a   # nginx observes max_fails within ~10s
docker compose -f docker-compose.ha.yml up -d redis-proxy-a
# verify healthy, then repeat for redis-proxy-b
```

No existing `scripts/rolling-update.sh` redis-proxy path to update -- that script targets the elastickv raft cluster; the sequence for the redis-proxy front-end is documented instead.

## Test plan

- [x] `nginx -t -c /etc/nginx/nginx.conf` against `nginx:1.27-alpine` prints `syntax is ok` / `test is successful` (validated locally with `--add-host` aliases since nginx resolves upstream service names at startup).
- [x] `docker compose -f deploy/redis-proxy/docker-compose.ha.yml config` parses without error.
- [ ] End-to-end: `docker compose -f docker-compose.ha.yml up -d --build`, `redis-cli -p 6379 PING`, then `docker compose stop redis-proxy-a` and confirm new PINGs are served by `redis-proxy-b` (access log `upstream=` field).
- [ ] Confirm a drained backend is marked back in rotation within `fail_timeout` after restart.