### PR TITLE
admin: AdminForward follower-side client + handler integration (P1, partial)

### DIFF
--- a/internal/admin/dynamo_handler.go
+++ b/internal/admin/dynamo_handler.go
@@ -168,15 +168,22 @@ func (e *ValidationError) Error() string {
 // — the JWT freezes the role at login time, and tokens last one
 // hour. Codex P1 on PR #635 flagged the gap on the HTTP path;
 // the forward server already does this re-evaluation on its side.
+//
+// When the source returns ErrTablesNotLeader and a LeaderForwarder
+// is configured, write requests are forwarded to the leader
+// transparently — the SPA sees a leader-direct response shape
+// regardless of which node it hit (design Section 3.3 criterion 2).
 type DynamoHandler struct {
-	source TablesSource
-	roles  RoleStore
-	logger *slog.Logger
+	source    TablesSource
+	roles     RoleStore
+	forwarder LeaderForwarder
+	logger    *slog.Logger
 }
 
 // NewDynamoHandler binds the source and seeds logging with
-// slog.Default(). Use WithLogger to attach a tagged logger and
-// WithRoleStore to plug in the live access-key role lookup.
+// slog.Default(). Use WithLogger to attach a tagged logger,
+// WithRoleStore to plug in the live access-key role lookup, and
+// WithLeaderForwarder to plug in the follower→leader forwarder.
 func NewDynamoHandler(source TablesSource) *DynamoHandler {
 	return &DynamoHandler{source: source, logger: slog.Default()}
 }
@@ -198,6 +205,16 @@ func (h *DynamoHandler) WithLogger(l *slog.Logger) *DynamoHandler {
 // production wiring in main_admin.go always sets this.
 func (h *DynamoHandler) WithRoleStore(r RoleStore) *DynamoHandler {
 	h.roles = r
+	return h
+}
+
+// WithLeaderForwarder enables transparent follower→leader
+// forwarding. Without it, write requests on a follower fall back
+// to the standard 503 leader_unavailable response. Production
+// wires this to the gRPCForwardClient in main_admin.go; tests
+// inject a stub.
+func (h *DynamoHandler) WithLeaderForwarder(f LeaderForwarder) *DynamoHandler {
+	h.forwarder = f
 	return h
 }
 
@@ -313,10 +330,46 @@ func (h *DynamoHandler) handleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 	summary, err := h.source.AdminCreateTable(r.Context(), principal, body)
 	if err != nil {
+		// On a follower, the source returns ErrTablesNotLeader. If
+		// a forwarder is wired, dispatch to the leader and re-emit
+		// the leader's response verbatim — the SPA cannot tell the
+		// difference between a leader-direct call and a forwarded
+		// one. Without a forwarder, fall through to the standard
+		// 503 leader_unavailable response.
+		if h.tryForwardCreate(w, r, principal, body, err) {
+			return
+		}
 		h.writeTablesError(w, r, "create", err)
 		return
 	}
 	writeAdminJSONStatus(w, r.Context(), h.logger, http.StatusCreated, summary)
+}
+
+// tryForwardCreate handles the follower→leader forwarding path
+// for POST /tables. Returns true when the response has been
+// written (regardless of forward success/failure); the caller
+// should then return without further processing.
+//
+// The "fall through to 503" path runs only when:
+//   - the source error is something other than ErrTablesNotLeader,
+//   - or no LeaderForwarder was configured,
+//   - or the forwarder itself returned ErrLeaderUnavailable
+//     (election in progress on the leader, criterion 3).
+//
+// Any other forwarder failure (gRPC transport error, etc.) is
+// also surfaced as 503 + Retry-After: 1 so the SPA can re-issue.
+// We log the raw error for operators and never echo it to clients.
+func (h *DynamoHandler) tryForwardCreate(w http.ResponseWriter, r *http.Request, principal AuthPrincipal, body CreateTableRequest, sourceErr error) bool {
+	if !errors.Is(sourceErr, ErrTablesNotLeader) || h.forwarder == nil {
+		return false
+	}
+	res, err := h.forwarder.ForwardCreateTable(r.Context(), principal, body)
+	if err != nil {
+		h.writeForwardFailure(w, r, "create", err)
+		return true
+	}
+	h.writeForwardResult(w, r, res)
+	return true
 }
 
 // handleDelete is the DELETE /tables/{name} handler. Success is
@@ -332,6 +385,9 @@ func (h *DynamoHandler) handleDelete(w http.ResponseWriter, r *http.Request, nam
 		return
 	}
 	if err := h.source.AdminDeleteTable(r.Context(), principal, name); err != nil {
+		if h.tryForwardDelete(w, r, principal, name, err) {
+			return
+		}
 		h.writeTablesError(w, r, "delete", err)
 		return
 	}
@@ -388,6 +444,66 @@ func (h *DynamoHandler) principalForWrite(w http.ResponseWriter, r *http.Request
 		principal.Role = liveRole
 	}
 	return principal, true
+}
+
+// tryForwardDelete is the DELETE counterpart of tryForwardCreate.
+// Same semantics: only the ErrTablesNotLeader source error
+// triggers forwarding, and only when a forwarder is configured.
+func (h *DynamoHandler) tryForwardDelete(w http.ResponseWriter, r *http.Request, principal AuthPrincipal, name string, sourceErr error) bool {
+	if !errors.Is(sourceErr, ErrTablesNotLeader) || h.forwarder == nil {
+		return false
+	}
+	res, err := h.forwarder.ForwardDeleteTable(r.Context(), principal, name)
+	if err != nil {
+		h.writeForwardFailure(w, r, "delete", err)
+		return true
+	}
+	h.writeForwardResult(w, r, res)
+	return true
+}
+
+// writeForwardResult re-emits the leader's structured response
+// verbatim. Status, payload, and content-type all come from the
+// gRPC response so a forwarded request looks identical to a
+// leader-direct call from the SPA's point of view.
+func (h *DynamoHandler) writeForwardResult(w http.ResponseWriter, r *http.Request, res *ForwardResult) {
+	w.Header().Set("Content-Type", res.ContentType)
+	w.Header().Set("Cache-Control", "no-store")
+	// 503 from the leader (e.g. it stepped down mid-request) must
+	// carry Retry-After so the client retries; preserve the
+	// criterion-3 contract on the wire whether the 503 originated
+	// here or at the leader.
+	if res.StatusCode == http.StatusServiceUnavailable {
+		w.Header().Set("Retry-After", "1")
+	}
+	w.WriteHeader(res.StatusCode)
+	if len(res.Payload) > 0 {
+		if _, err := w.Write(res.Payload); err != nil {
+			h.logger.LogAttrs(r.Context(), slog.LevelWarn, "admin forward response write failed",
+				slog.String("error", err.Error()),
+			)
+		}
+	}
+}
+
+// writeForwardFailure handles forwarder errors that did not
+// produce a structured leader response: ErrLeaderUnavailable
+// (election in flight) and gRPC transport errors. Both surface as
+// 503 + Retry-After: 1 — the SPA's retry contract is identical
+// regardless of whether the leader is briefly absent or the
+// network hiccupped.
+func (h *DynamoHandler) writeForwardFailure(w http.ResponseWriter, r *http.Request, op string, err error) {
+	if !errors.Is(err, ErrLeaderUnavailable) {
+		// Not the "no leader known" case — log the raw error so
+		// operators can investigate. Client still sees the same
+		// 503 + Retry-After so they retry uniformly.
+		h.logger.LogAttrs(r.Context(), slog.LevelError, "admin dynamo "+op+" forward failed",
+			slog.String("error", err.Error()),
+		)
+	}
+	w.Header().Set("Retry-After", "1")
+	writeJSONError(w, http.StatusServiceUnavailable, "leader_unavailable",
+		"raft leader currently unavailable; retry shortly")
 }
 
 // writeTablesError translates a TablesSource error into the

--- a/internal/admin/dynamo_handler.go
+++ b/internal/admin/dynamo_handler.go
@@ -213,6 +213,12 @@ func (h *DynamoHandler) WithRoleStore(r RoleStore) *DynamoHandler {
 // to the standard 503 leader_unavailable response. Production
 // wires this to the gRPCForwardClient in main_admin.go; tests
 // inject a stub.
+//
+// Asymmetric vs WithLogger by design: WithLogger no-ops on nil to
+// preserve the slog.Default() seeded by NewDynamoHandler, but a
+// nil forwarder here is a meaningful "disable forwarding" state
+// (the gate in tryForwardCreate / tryForwardDelete checks for
+// nil and falls back to the leader-only 503 path).
 func (h *DynamoHandler) WithLeaderForwarder(f LeaderForwarder) *DynamoHandler {
 	h.forwarder = f
 	return h
@@ -468,6 +474,12 @@ func (h *DynamoHandler) tryForwardDelete(w http.ResponseWriter, r *http.Request,
 // leader-direct call from the SPA's point of view.
 func (h *DynamoHandler) writeForwardResult(w http.ResponseWriter, r *http.Request, res *ForwardResult) {
 	w.Header().Set("Content-Type", res.ContentType)
+	// Match writeAdminJSONStatus's hardening on the leader-direct
+	// path: forwarded responses must also carry nosniff so a SPA
+	// request that happened to traverse a follower does not
+	// silently lose the MIME-sniff protection. Claude review on
+	// PR #644 caught the parity gap.
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Cache-Control", "no-store")
 	// 503 from the leader (e.g. it stepped down mid-request) must
 	// carry Retry-After so the client retries; preserve the

--- a/internal/admin/dynamo_handler.go
+++ b/internal/admin/dynamo_handler.go
@@ -119,8 +119,10 @@ var (
 	// role required for the operation. Maps to 403.
 	ErrTablesForbidden = errors.New("admin tables: principal lacks required role")
 	// ErrTablesNotLeader is returned when the local node is not the
-	// Raft leader. Maps to 503 + Retry-After: 1 today; the future
-	// AdminForward RPC catches this as the trigger to forward.
+	// Raft leader. When a LeaderForwarder is configured,
+	// tryForwardCreate / tryForwardDelete catch this before it reaches
+	// writeTablesError and forward the request to the leader
+	// transparently. Without a forwarder, maps to 503 + Retry-After: 1.
 	ErrTablesNotLeader = errors.New("admin tables: local node is not the raft leader")
 	// ErrTablesNotFound is returned when DELETE / DESCRIBE / a
 	// follow-up read targets a table that does not exist. Maps to

--- a/internal/admin/dynamo_handler.go
+++ b/internal/admin/dynamo_handler.go
@@ -528,9 +528,10 @@ func (h *DynamoHandler) writeTablesError(w http.ResponseWriter, r *http.Request,
 		writeJSONError(w, http.StatusForbidden, "forbidden",
 			"this endpoint requires a full-access role")
 	case errors.Is(err, ErrTablesNotLeader):
-		// The follower→leader forwarding RPC (design 3.3) will
-		// catch this case in a follow-up PR. Until then, surface
-		// 503 + Retry-After: 1 so the SPA / curl can re-issue.
+		// Reached only when no LeaderForwarder is configured (single-
+		// node or leader-only deployments). When a forwarder is wired,
+		// tryForwardCreate / tryForwardDelete intercept ErrTablesNotLeader
+		// before writeTablesError is called.
 		w.Header().Set("Retry-After", "1")
 		writeJSONError(w, http.StatusServiceUnavailable, "leader_unavailable",
 			"this admin node is not the raft leader")

--- a/internal/admin/forward_client.go
+++ b/internal/admin/forward_client.go
@@ -8,6 +8,7 @@ import (
 	pb "github.com/bootjp/elastickv/proto"
 	pkgerrors "github.com/cockroachdb/errors"
 	"github.com/goccy/go-json"
+	"google.golang.org/grpc"
 )
 
 // LeaderForwarder is the contract the admin HTTP handler invokes
@@ -71,13 +72,16 @@ type GRPCConnFactory interface {
 // PBAdminForwardClient narrows pb.AdminForwardClient to just the
 // methods this package uses. The narrower interface keeps the test
 // stub implementation small.
+//
+// The opts parameter must use grpc.CallOption (not interface{}) so
+// the proto-generated *adminForwardClient satisfies this interface
+// directly — Go interface satisfaction requires exact method-
+// signature match, including variadic element types. Claude review
+// on PR #644 caught the mismatch before the bridge tried to assign
+// pb.NewAdminForwardClient(conn) and the build broke.
 type PBAdminForwardClient interface {
-	Forward(ctx context.Context, in *pb.AdminForwardRequest, opts ...grpcCallOption) (*pb.AdminForwardResponse, error)
+	Forward(ctx context.Context, in *pb.AdminForwardRequest, opts ...grpc.CallOption) (*pb.AdminForwardResponse, error)
 }
-
-// grpcCallOption is a re-export of google.golang.org/grpc.CallOption
-// kept private so callers do not import proto's grpc dep directly.
-type grpcCallOption = interface{}
 
 // gRPCForwardClient is the production LeaderForwarder. Construct
 // one with NewGRPCForwardClient. Two collaborators are required:

--- a/internal/admin/forward_client.go
+++ b/internal/admin/forward_client.go
@@ -1,0 +1,181 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	pb "github.com/bootjp/elastickv/proto"
+	pkgerrors "github.com/cockroachdb/errors"
+	"github.com/goccy/go-json"
+)
+
+// LeaderForwarder is the contract the admin HTTP handler invokes
+// when the local node is a follower (the source returned
+// ErrTablesNotLeader). Implementations dial the current leader
+// over the AdminForward gRPC service and return the leader's
+// response in a transport-neutral shape so the handler can re-emit
+// it verbatim.
+//
+// Defining this interface in the admin package — rather than wiring
+// pb.AdminForwardClient directly into the handler — keeps the
+// admin HTTP layer free of any proto-level coupling and lets tests
+// substitute a deterministic stub. The bridge in main_admin.go
+// provides the production implementation that uses
+// kv.GRPCConnCache + the raft engine's leader address.
+type LeaderForwarder interface {
+	// ForwardCreateTable issues a forwarded CreateTable on the
+	// leader's behalf. The response is the leader's structured
+	// AdminForwardResponse re-shaped into ForwardResult so the
+	// handler does not need to import proto.
+	ForwardCreateTable(ctx context.Context, principal AuthPrincipal, in CreateTableRequest) (*ForwardResult, error)
+	// ForwardDeleteTable is the delete-side counterpart.
+	ForwardDeleteTable(ctx context.Context, principal AuthPrincipal, name string) (*ForwardResult, error)
+}
+
+// ForwardResult is the leader's response replayed for the SPA. The
+// handler writes Payload verbatim with the given status code and
+// content type, so a forwarded request is indistinguishable from a
+// leader-direct call.
+type ForwardResult struct {
+	StatusCode  int
+	Payload     []byte
+	ContentType string
+}
+
+// ErrLeaderUnavailable is returned when the forwarder cannot reach
+// any leader — typically during a Raft election or a cluster split.
+// The handler maps it to 503 + Retry-After: 1 so the SPA / client
+// re-issues the request after a short delay (acceptance criterion 3).
+var ErrLeaderUnavailable = errors.New("admin: raft leader currently unavailable")
+
+// LeaderAddressResolver returns the current Raft leader's address
+// for the local node's group, or "" if no leader is known. The
+// production wiring uses raftengine.Engine.LeaderAddr / the
+// cluster's address map; tests inject a fixed string.
+type LeaderAddressResolver func() string
+
+// GRPCConnFactory is the small surface AdminForwardClient needs
+// from kv.GRPCConnCache. Pulling out an interface lets tests
+// substitute an in-memory dialer without spinning up a TCP
+// listener and lets the bridge use the existing connection cache
+// without copy-paste.
+type GRPCConnFactory interface {
+	// ConnFor returns a gRPC client connection to addr, reusing
+	// the cached entry if one exists. addr "" is a programming
+	// error and may panic; callers must check leader-empty before
+	// dialling.
+	ConnFor(addr string) (PBAdminForwardClient, error)
+}
+
+// PBAdminForwardClient narrows pb.AdminForwardClient to just the
+// methods this package uses. The narrower interface keeps the test
+// stub implementation small.
+type PBAdminForwardClient interface {
+	Forward(ctx context.Context, in *pb.AdminForwardRequest, opts ...grpcCallOption) (*pb.AdminForwardResponse, error)
+}
+
+// grpcCallOption is a re-export of google.golang.org/grpc.CallOption
+// kept private so callers do not import proto's grpc dep directly.
+type grpcCallOption = interface{}
+
+// gRPCForwardClient is the production LeaderForwarder. Construct
+// one with NewGRPCForwardClient. Two collaborators are required:
+//   - resolver: returns the current leader address, or "" if absent
+//   - dial:     turns an address into a PBAdminForwardClient (the
+//     bridge wraps kv.GRPCConnCache to satisfy this)
+//
+// nodeID is echoed into the leader's audit log via
+// AdminForwardRequest.forwarded_from (acceptance criterion 6).
+type gRPCForwardClient struct {
+	resolver LeaderAddressResolver
+	dial     GRPCConnFactory
+	nodeID   string
+}
+
+// NewGRPCForwardClient constructs the production LeaderForwarder.
+// All three parameters must be non-nil / non-empty; otherwise the
+// constructor returns nil and a wiring-error so a misconfigured
+// build refuses to start rather than producing 500s at runtime.
+func NewGRPCForwardClient(resolver LeaderAddressResolver, dial GRPCConnFactory, nodeID string) (LeaderForwarder, error) {
+	if resolver == nil {
+		return nil, errors.New("admin forwarder: leader address resolver is required")
+	}
+	if dial == nil {
+		return nil, errors.New("admin forwarder: gRPC connection factory is required")
+	}
+	if nodeID == "" {
+		return nil, errors.New("admin forwarder: node id is required for audit log enrichment")
+	}
+	return &gRPCForwardClient{resolver: resolver, dial: dial, nodeID: nodeID}, nil
+}
+
+// ForwardCreateTable serialises `in` as JSON and dispatches the
+// CreateTable operation to the leader. Returns ErrLeaderUnavailable
+// when no leader address is known; gRPC-level errors are wrapped
+// and surfaced unchanged so the handler can decide whether to
+// retry, log, or 500.
+func (c *gRPCForwardClient) ForwardCreateTable(ctx context.Context, principal AuthPrincipal, in CreateTableRequest) (*ForwardResult, error) {
+	payload, err := json.Marshal(in)
+	if err != nil {
+		// CreateTableRequest is plain string fields; Marshal
+		// cannot fail in practice. Surface the error rather than
+		// silently dropping the request.
+		return nil, pkgerrors.Wrap(err, "admin forward: marshal create-table request")
+	}
+	return c.forward(ctx, pb.AdminOperation_ADMIN_OP_CREATE_TABLE, principal, payload)
+}
+
+// ForwardDeleteTable serialises the table name as `{"name":"..."}`
+// to match the leader-side handleDelete contract.
+func (c *gRPCForwardClient) ForwardDeleteTable(ctx context.Context, principal AuthPrincipal, name string) (*ForwardResult, error) {
+	payload, err := json.Marshal(struct {
+		Name string `json:"name"`
+	}{Name: name})
+	if err != nil {
+		return nil, pkgerrors.Wrap(err, "admin forward: marshal delete-table request")
+	}
+	return c.forward(ctx, pb.AdminOperation_ADMIN_OP_DELETE_TABLE, principal, payload)
+}
+
+func (c *gRPCForwardClient) forward(ctx context.Context, op pb.AdminOperation, principal AuthPrincipal, payload []byte) (*ForwardResult, error) {
+	addr := c.resolver()
+	if addr == "" {
+		return nil, ErrLeaderUnavailable
+	}
+	cli, err := c.dial.ConnFor(addr)
+	if err != nil {
+		return nil, pkgerrors.Wrap(err, "admin forward: dial leader")
+	}
+	resp, err := cli.Forward(ctx, &pb.AdminForwardRequest{
+		Principal: &pb.AdminPrincipal{
+			AccessKey: principal.AccessKey,
+			Role:      string(principal.Role),
+		},
+		Operation:     op,
+		Payload:       payload,
+		ForwardedFrom: c.nodeID,
+	})
+	if err != nil {
+		return nil, pkgerrors.Wrap(err, "admin forward: rpc")
+	}
+	out := &ForwardResult{
+		StatusCode:  int(resp.GetStatusCode()),
+		Payload:     resp.GetPayload(),
+		ContentType: resp.GetContentType(),
+	}
+	if out.ContentType == "" {
+		// The leader server always sets a content type, but be
+		// defensive: a future change that drops it must not
+		// produce a SPA response with no Content-Type header.
+		out.ContentType = "application/json; charset=utf-8"
+	}
+	if out.StatusCode == 0 {
+		// status_code 0 is the proto's zero value, which the
+		// leader server never emits intentionally. Treat it as a
+		// transport bug rather than a 200, since 0 is not a valid
+		// HTTP status.
+		out.StatusCode = http.StatusBadGateway
+	}
+	return out, nil
+}

--- a/internal/admin/forward_client_test.go
+++ b/internal/admin/forward_client_test.go
@@ -1,0 +1,183 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	pb "github.com/bootjp/elastickv/proto"
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/require"
+)
+
+// stubForwardConn is the in-memory PBAdminForwardClient the
+// follower-side tests use. It captures the last request and
+// returns whatever response/error the test prepared.
+type stubForwardConn struct {
+	resp    *pb.AdminForwardResponse
+	err     error
+	lastReq *pb.AdminForwardRequest
+}
+
+func (s *stubForwardConn) Forward(_ context.Context, in *pb.AdminForwardRequest, _ ...grpcCallOption) (*pb.AdminForwardResponse, error) {
+	s.lastReq = in
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.resp, nil
+}
+
+// stubConnFactory wraps stubForwardConn so the gRPCForwardClient
+// can resolve an address to a client. The captured `addr` lets
+// tests prove the resolver round-tripped correctly.
+type stubConnFactory struct {
+	conn     *stubForwardConn
+	dialErr  error
+	lastAddr string
+}
+
+func (s *stubConnFactory) ConnFor(addr string) (PBAdminForwardClient, error) {
+	s.lastAddr = addr
+	if s.dialErr != nil {
+		return nil, s.dialErr
+	}
+	return s.conn, nil
+}
+
+// fixedResolver returns a closure that always resolves to addr.
+// Pulling this into a helper keeps the per-test setup compact.
+func fixedResolver(addr string) LeaderAddressResolver {
+	return func() string { return addr }
+}
+
+func TestNewGRPCForwardClient_RejectsMissingDeps(t *testing.T) {
+	cases := []struct {
+		name     string
+		resolver LeaderAddressResolver
+		dial     GRPCConnFactory
+		nodeID   string
+		expect   string
+	}{
+		{"nil resolver", nil, &stubConnFactory{}, "n1", "leader address resolver"},
+		{"nil dial", fixedResolver(""), nil, "n1", "gRPC connection factory"},
+		{"empty node id", fixedResolver(""), &stubConnFactory{}, "", "node id is required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fwd, err := NewGRPCForwardClient(tc.resolver, tc.dial, tc.nodeID)
+			require.Error(t, err)
+			require.Nil(t, fwd)
+			require.Contains(t, err.Error(), tc.expect)
+		})
+	}
+}
+
+func TestGRPCForwardClient_ForwardCreateTable_HappyPath(t *testing.T) {
+	conn := &stubForwardConn{resp: &pb.AdminForwardResponse{
+		StatusCode:  http.StatusCreated,
+		Payload:     []byte(`{"name":"users"}`),
+		ContentType: "application/json; charset=utf-8",
+	}}
+	dial := &stubConnFactory{conn: conn}
+	fwd, err := NewGRPCForwardClient(fixedResolver("leader.local:7000"), dial, "follower-2")
+	require.NoError(t, err)
+
+	in := CreateTableRequest{TableName: "users", PartitionKey: CreateTableAttribute{Name: "id", Type: "S"}}
+	res, err := fwd.ForwardCreateTable(context.Background(), AuthPrincipal{AccessKey: "AKIA_F", Role: RoleFull}, in)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Equal(t, http.StatusCreated, res.StatusCode)
+	require.JSONEq(t, `{"name":"users"}`, string(res.Payload))
+	require.Equal(t, "application/json; charset=utf-8", res.ContentType)
+
+	// The captured request must carry the principal, the canonical
+	// op enum, the JSON-encoded body, and the follower node id.
+	require.Equal(t, "leader.local:7000", dial.lastAddr)
+	require.NotNil(t, conn.lastReq)
+	require.Equal(t, pb.AdminOperation_ADMIN_OP_CREATE_TABLE, conn.lastReq.GetOperation())
+	require.Equal(t, "AKIA_F", conn.lastReq.GetPrincipal().GetAccessKey())
+	require.Equal(t, "full", conn.lastReq.GetPrincipal().GetRole())
+	require.Equal(t, "follower-2", conn.lastReq.GetForwardedFrom())
+	var roundtripped CreateTableRequest
+	require.NoError(t, json.Unmarshal(conn.lastReq.GetPayload(), &roundtripped))
+	require.Equal(t, in, roundtripped)
+}
+
+func TestGRPCForwardClient_ForwardDeleteTable_HappyPath(t *testing.T) {
+	conn := &stubForwardConn{resp: &pb.AdminForwardResponse{
+		StatusCode:  http.StatusNoContent,
+		ContentType: "application/json; charset=utf-8",
+	}}
+	dial := &stubConnFactory{conn: conn}
+	fwd, _ := NewGRPCForwardClient(fixedResolver("leader.local:7000"), dial, "follower-3")
+
+	res, err := fwd.ForwardDeleteTable(context.Background(), AuthPrincipal{AccessKey: "AKIA_F", Role: RoleFull}, "users")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, res.StatusCode)
+	require.Empty(t, res.Payload)
+	require.Equal(t, pb.AdminOperation_ADMIN_OP_DELETE_TABLE, conn.lastReq.GetOperation())
+	require.JSONEq(t, `{"name":"users"}`, string(conn.lastReq.GetPayload()))
+	require.Equal(t, "follower-3", conn.lastReq.GetForwardedFrom())
+}
+
+func TestGRPCForwardClient_NoLeaderReturnsErrLeaderUnavailable(t *testing.T) {
+	dial := &stubConnFactory{conn: &stubForwardConn{}}
+	fwd, _ := NewGRPCForwardClient(fixedResolver(""), dial, "f")
+
+	_, err := fwd.ForwardCreateTable(context.Background(), AuthPrincipal{Role: RoleFull},
+		CreateTableRequest{TableName: "t", PartitionKey: CreateTableAttribute{Name: "id", Type: "S"}})
+	require.ErrorIs(t, err, ErrLeaderUnavailable)
+	// Connection must not have been dialled when no leader is known.
+	require.Empty(t, dial.lastAddr)
+}
+
+func TestGRPCForwardClient_DialErrorPropagated(t *testing.T) {
+	dial := &stubConnFactory{dialErr: errors.New("network unreachable")}
+	fwd, _ := NewGRPCForwardClient(fixedResolver("leader:1"), dial, "f")
+
+	_, err := fwd.ForwardCreateTable(context.Background(), AuthPrincipal{Role: RoleFull},
+		CreateTableRequest{TableName: "t", PartitionKey: CreateTableAttribute{Name: "id", Type: "S"}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "network unreachable")
+}
+
+func TestGRPCForwardClient_GRPCErrorPropagated(t *testing.T) {
+	conn := &stubForwardConn{err: errors.New("rpc deadline exceeded")}
+	dial := &stubConnFactory{conn: conn}
+	fwd, _ := NewGRPCForwardClient(fixedResolver("leader:1"), dial, "f")
+
+	_, err := fwd.ForwardDeleteTable(context.Background(), AuthPrincipal{Role: RoleFull}, "x")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "rpc deadline exceeded")
+}
+
+func TestGRPCForwardClient_ZeroStatusUpgradesTo502(t *testing.T) {
+	// status_code 0 is the proto zero value — never emitted
+	// intentionally by the leader. The forwarder must not treat
+	// that as 200; mapping it to 502 surfaces the transport bug.
+	conn := &stubForwardConn{resp: &pb.AdminForwardResponse{StatusCode: 0}}
+	dial := &stubConnFactory{conn: conn}
+	fwd, _ := NewGRPCForwardClient(fixedResolver("leader:1"), dial, "f")
+
+	res, err := fwd.ForwardCreateTable(context.Background(), AuthPrincipal{Role: RoleFull},
+		CreateTableRequest{TableName: "t", PartitionKey: CreateTableAttribute{Name: "id", Type: "S"}})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadGateway, res.StatusCode)
+}
+
+func TestGRPCForwardClient_FillsMissingContentType(t *testing.T) {
+	// A future leader-server change that omits ContentType must
+	// still produce a SPA-readable response. The forwarder fills
+	// in the default JSON content type defensively.
+	conn := &stubForwardConn{resp: &pb.AdminForwardResponse{
+		StatusCode: http.StatusCreated,
+		Payload:    []byte(`{"name":"u"}`),
+	}}
+	dial := &stubConnFactory{conn: conn}
+	fwd, _ := NewGRPCForwardClient(fixedResolver("leader:1"), dial, "f")
+
+	res, _ := fwd.ForwardCreateTable(context.Background(), AuthPrincipal{Role: RoleFull},
+		CreateTableRequest{TableName: "t", PartitionKey: CreateTableAttribute{Name: "id", Type: "S"}})
+	require.Equal(t, "application/json; charset=utf-8", res.ContentType)
+}

--- a/internal/admin/forward_client_test.go
+++ b/internal/admin/forward_client_test.go
@@ -9,6 +9,7 @@ import (
 	pb "github.com/bootjp/elastickv/proto"
 	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
 
 // stubForwardConn is the in-memory PBAdminForwardClient the
@@ -20,7 +21,7 @@ type stubForwardConn struct {
 	lastReq *pb.AdminForwardRequest
 }
 
-func (s *stubForwardConn) Forward(_ context.Context, in *pb.AdminForwardRequest, _ ...grpcCallOption) (*pb.AdminForwardResponse, error) {
+func (s *stubForwardConn) Forward(_ context.Context, in *pb.AdminForwardRequest, _ ...grpc.CallOption) (*pb.AdminForwardResponse, error) {
 	s.lastReq = in
 	if s.err != nil {
 		return nil, s.err

--- a/internal/admin/forward_integration_test.go
+++ b/internal/admin/forward_integration_test.go
@@ -169,8 +169,13 @@ func TestDynamoHandler_ForwarderTransportErrorReturns503(t *testing.T) {
 // be silently re-applied at the leader. Claude review on PR #644
 // noted the test gap; locking it down protects against a future
 // change accidentally removing the !errors.Is guard.
+//
+// Both create and delete paths share the same gate logic, so we
+// sweep both surfaces together — a typo-class change to either
+// tryForwardCreate or tryForwardDelete will fail one of the
+// sub-tests.
 func TestDynamoHandler_ForwarderNotInvokedForNonNotLeaderError(t *testing.T) {
-	cases := []struct {
+	createCases := []struct {
 		name     string
 		err      error
 		wantCode int
@@ -179,8 +184,8 @@ func TestDynamoHandler_ForwarderNotInvokedForNonNotLeaderError(t *testing.T) {
 		{"validation", &ValidationError{Message: "bad input"}, http.StatusBadRequest},
 		{"generic", errors.New("opaque storage failure"), http.StatusInternalServerError},
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
+	for _, tc := range createCases {
+		t.Run("create/"+tc.name, func(t *testing.T) {
 			fwd := &stubLeaderForwarder{}
 			src := &stubTablesSource{createErr: tc.err}
 			h := NewDynamoHandler(src).WithLeaderForwarder(fwd)
@@ -191,9 +196,84 @@ func TestDynamoHandler_ForwarderNotInvokedForNonNotLeaderError(t *testing.T) {
 
 			require.Equal(t, tc.wantCode, rec.Code)
 			require.Empty(t, fwd.lastCreateInput.TableName,
-				"forwarder must not be invoked for source error: %s", tc.name)
+				"forwarder must not be invoked for create source error: %s", tc.name)
 		})
 	}
+	deleteCases := []struct {
+		name     string
+		err      error
+		wantCode int
+	}{
+		// not_found is the realistic delete-path counterpart to
+		// already_exists on create.
+		{"not_found", ErrTablesNotFound, http.StatusNotFound},
+		{"forbidden", ErrTablesForbidden, http.StatusForbidden},
+		{"generic", errors.New("opaque storage failure"), http.StatusInternalServerError},
+	}
+	for _, tc := range deleteCases {
+		t.Run("delete/"+tc.name, func(t *testing.T) {
+			fwd := &stubLeaderForwarder{}
+			src := &stubTablesSource{
+				tables:    map[string]*DynamoTableSummary{"users": {Name: "users"}},
+				deleteErr: tc.err,
+			}
+			h := NewDynamoHandler(src).WithLeaderForwarder(fwd)
+			req := httptest.NewRequest(http.MethodDelete, pathDynamoTables+"/users", nil)
+			req = withWritePrincipal(req)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			require.Equal(t, tc.wantCode, rec.Code)
+			require.Empty(t, fwd.lastDeleteName,
+				"forwarder must not be invoked for delete source error: %s", tc.name)
+		})
+	}
+}
+
+// TestDynamoHandler_ForwarderLeaderUnavailableReturns503_Delete
+// mirrors the create-side ErrLeaderUnavailable path — election in
+// flight on the leader must surface as 503 + Retry-After: 1 from
+// the delete endpoint too. ErrLeaderUnavailable is the
+// "no leader known" sentinel from the forwarder layer; tryForwardDelete
+// catches it and routes through writeForwardFailure.
+func TestDynamoHandler_ForwarderLeaderUnavailableReturns503_Delete(t *testing.T) {
+	fwd := &stubLeaderForwarder{deleteErr: ErrLeaderUnavailable}
+	src := &notLeaderSource{stubTablesSource: stubTablesSource{
+		tables: map[string]*DynamoTableSummary{"users": {Name: "users"}},
+	}}
+	h := NewDynamoHandler(src).WithLeaderForwarder(fwd)
+	req := httptest.NewRequest(http.MethodDelete, pathDynamoTables+"/users", nil)
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Equal(t, "1", rec.Header().Get("Retry-After"))
+	require.Contains(t, rec.Body.String(), "leader_unavailable")
+}
+
+// TestDynamoHandler_ForwarderTransportErrorReturns503_Delete is
+// the delete-side counterpart of the create transport-error test:
+// a generic gRPC failure from the forwarder must produce 503 +
+// Retry-After: 1 with no internal error detail leaking to the SPA.
+// The raw error is logged on the server (covered by inspection of
+// slog output in the create-side test); the assertion here is
+// strictly on the wire shape.
+func TestDynamoHandler_ForwarderTransportErrorReturns503_Delete(t *testing.T) {
+	fwd := &stubLeaderForwarder{deleteErr: errors.New("gRPC transport sentinel DEL-TX-1")}
+	src := &notLeaderSource{stubTablesSource: stubTablesSource{
+		tables: map[string]*DynamoTableSummary{"users": {Name: "users"}},
+	}}
+	h := NewDynamoHandler(src).WithLeaderForwarder(fwd)
+	req := httptest.NewRequest(http.MethodDelete, pathDynamoTables+"/users", nil)
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Equal(t, "1", rec.Header().Get("Retry-After"))
+	require.NotContains(t, rec.Body.String(), "DEL-TX-1")
+	require.NotContains(t, rec.Body.String(), "transport sentinel")
 }
 
 // TestDynamoHandler_ForwarderForwardsLeaderResponseSetsNosniff

--- a/internal/admin/forward_integration_test.go
+++ b/internal/admin/forward_integration_test.go
@@ -156,6 +156,7 @@ func TestDynamoHandler_ForwarderTransportErrorReturns503(t *testing.T) {
 	h.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Equal(t, "1", rec.Header().Get("Retry-After"))
 	require.NotContains(t, rec.Body.String(), "TX-1")
 	require.NotContains(t, rec.Body.String(), "transport sentinel")
 }
@@ -238,9 +239,10 @@ func TestDynamoHandler_ForwarderNotInvokedForNonNotLeaderError(t *testing.T) {
 // catches it and routes through writeForwardFailure.
 func TestDynamoHandler_ForwarderLeaderUnavailableReturns503_Delete(t *testing.T) {
 	fwd := &stubLeaderForwarder{deleteErr: ErrLeaderUnavailable}
-	src := &notLeaderSource{stubTablesSource: stubTablesSource{
-		tables: map[string]*DynamoTableSummary{"users": {Name: "users"}},
-	}}
+	// notLeaderSource.AdminDeleteTable unconditionally returns
+	// ErrTablesNotLeader, so the embedded stubTablesSource.tables
+	// map is never consulted — keep the construction minimal.
+	src := &notLeaderSource{}
 	h := NewDynamoHandler(src).WithLeaderForwarder(fwd)
 	req := httptest.NewRequest(http.MethodDelete, pathDynamoTables+"/users", nil)
 	req = withWritePrincipal(req)
@@ -261,9 +263,7 @@ func TestDynamoHandler_ForwarderLeaderUnavailableReturns503_Delete(t *testing.T)
 // strictly on the wire shape.
 func TestDynamoHandler_ForwarderTransportErrorReturns503_Delete(t *testing.T) {
 	fwd := &stubLeaderForwarder{deleteErr: errors.New("gRPC transport sentinel DEL-TX-1")}
-	src := &notLeaderSource{stubTablesSource: stubTablesSource{
-		tables: map[string]*DynamoTableSummary{"users": {Name: "users"}},
-	}}
+	src := &notLeaderSource{}
 	h := NewDynamoHandler(src).WithLeaderForwarder(fwd)
 	req := httptest.NewRequest(http.MethodDelete, pathDynamoTables+"/users", nil)
 	req = withWritePrincipal(req)

--- a/internal/admin/forward_integration_test.go
+++ b/internal/admin/forward_integration_test.go
@@ -160,6 +160,64 @@ func TestDynamoHandler_ForwarderTransportErrorReturns503(t *testing.T) {
 	require.NotContains(t, rec.Body.String(), "transport sentinel")
 }
 
+// TestDynamoHandler_ForwarderNotInvokedForNonNotLeaderError pins
+// the gate in tryForwardCreate / tryForwardDelete: the forward
+// path must run ONLY when the source returned ErrTablesNotLeader.
+// Other source errors (already-exists, validation, generic) must
+// fall through to writeTablesError and never reach the forwarder
+// — otherwise a leader-direct rejection like 409 Conflict would
+// be silently re-applied at the leader. Claude review on PR #644
+// noted the test gap; locking it down protects against a future
+// change accidentally removing the !errors.Is guard.
+func TestDynamoHandler_ForwarderNotInvokedForNonNotLeaderError(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		wantCode int
+	}{
+		{"already_exists", ErrTablesAlreadyExists, http.StatusConflict},
+		{"validation", &ValidationError{Message: "bad input"}, http.StatusBadRequest},
+		{"generic", errors.New("opaque storage failure"), http.StatusInternalServerError},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fwd := &stubLeaderForwarder{}
+			src := &stubTablesSource{createErr: tc.err}
+			h := NewDynamoHandler(src).WithLeaderForwarder(fwd)
+			req := httptest.NewRequest(http.MethodPost, pathDynamoTables, strings.NewReader(validCreateBody()))
+			req = withWritePrincipal(req)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			require.Equal(t, tc.wantCode, rec.Code)
+			require.Empty(t, fwd.lastCreateInput.TableName,
+				"forwarder must not be invoked for source error: %s", tc.name)
+		})
+	}
+}
+
+// TestDynamoHandler_ForwarderForwardsLeaderResponseSetsNosniff
+// confirms the security parity Claude flagged: writeForwardResult
+// must emit X-Content-Type-Options: nosniff just like the leader-
+// direct path's writeAdminJSONStatus, otherwise a SPA hitting a
+// follower would silently lose MIME-sniff protection on
+// forwarded responses.
+func TestDynamoHandler_ForwarderForwardsLeaderResponseSetsNosniff(t *testing.T) {
+	fwd := &stubLeaderForwarder{createRes: &ForwardResult{
+		StatusCode:  http.StatusCreated,
+		Payload:     []byte(`{"name":"users"}`),
+		ContentType: "application/json; charset=utf-8",
+	}}
+	h := newFollowerHandler(t, fwd)
+	req := httptest.NewRequest(http.MethodPost, pathDynamoTables, strings.NewReader(validCreateBody()))
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusCreated, rec.Code)
+	require.Equal(t, "nosniff", rec.Header().Get("X-Content-Type-Options"))
+}
+
 func TestDynamoHandler_ForwarderForwardsLeaderConflictResponse(t *testing.T) {
 	// 409 Conflict from the leader (table already exists) must
 	// be relayed verbatim to the SPA, not re-classified as 503.

--- a/internal/admin/forward_integration_test.go
+++ b/internal/admin/forward_integration_test.go
@@ -217,10 +217,11 @@ func TestDynamoHandler_ForwarderNotInvokedForNonNotLeaderError(t *testing.T) {
 	for _, tc := range deleteCases {
 		t.Run("delete/"+tc.name, func(t *testing.T) {
 			fwd := &stubLeaderForwarder{}
-			src := &stubTablesSource{
-				tables:    map[string]*DynamoTableSummary{"users": {Name: "users"}},
-				deleteErr: tc.err,
-			}
+			// stubTablesSource.AdminDeleteTable returns early on
+			// deleteErr != nil before consulting the tables map, so
+			// the map is unreachable here — drop it for symmetry
+			// with the create-path cases above.
+			src := &stubTablesSource{deleteErr: tc.err}
 			h := NewDynamoHandler(src).WithLeaderForwarder(fwd)
 			req := httptest.NewRequest(http.MethodDelete, pathDynamoTables+"/users", nil)
 			req = withWritePrincipal(req)

--- a/internal/admin/forward_integration_test.go
+++ b/internal/admin/forward_integration_test.go
@@ -1,0 +1,233 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// stubLeaderForwarder is the in-memory test double the integration
+// tests use to simulate the follower→leader forwarding path. It
+// records the last principal/payload it saw and returns whatever
+// canned response/error the test prepared.
+type stubLeaderForwarder struct {
+	createRes *ForwardResult
+	createErr error
+	deleteRes *ForwardResult
+	deleteErr error
+
+	lastCreatePrincipal AuthPrincipal
+	lastCreateInput     CreateTableRequest
+	lastDeletePrincipal AuthPrincipal
+	lastDeleteName      string
+}
+
+func (s *stubLeaderForwarder) ForwardCreateTable(_ context.Context, principal AuthPrincipal, in CreateTableRequest) (*ForwardResult, error) {
+	s.lastCreatePrincipal = principal
+	s.lastCreateInput = in
+	if s.createErr != nil {
+		return nil, s.createErr
+	}
+	return s.createRes, nil
+}
+
+func (s *stubLeaderForwarder) ForwardDeleteTable(_ context.Context, principal AuthPrincipal, name string) (*ForwardResult, error) {
+	s.lastDeletePrincipal = principal
+	s.lastDeleteName = name
+	if s.deleteErr != nil {
+		return nil, s.deleteErr
+	}
+	return s.deleteRes, nil
+}
+
+// notLeaderSource is a TablesSource that always returns
+// ErrTablesNotLeader on writes — i.e., it simulates the local
+// node being a follower. Used to exercise the forwarder path
+// without spinning up a real Raft cluster.
+type notLeaderSource struct {
+	stubTablesSource
+}
+
+func (s *notLeaderSource) AdminCreateTable(_ context.Context, _ AuthPrincipal, _ CreateTableRequest) (*DynamoTableSummary, error) {
+	return nil, ErrTablesNotLeader
+}
+
+func (s *notLeaderSource) AdminDeleteTable(_ context.Context, _ AuthPrincipal, _ string) error {
+	return ErrTablesNotLeader
+}
+
+func newFollowerHandler(t *testing.T, fwd LeaderForwarder) *DynamoHandler {
+	t.Helper()
+	src := &notLeaderSource{stubTablesSource: stubTablesSource{tables: map[string]*DynamoTableSummary{}}}
+	h := NewDynamoHandler(src)
+	if fwd != nil {
+		h = h.WithLeaderForwarder(fwd)
+	}
+	return h
+}
+
+func TestDynamoHandler_FollowerForwardsCreateTable_HappyPath(t *testing.T) {
+	// Acceptance criterion 2: a write hitting a follower is
+	// transparently forwarded; the SPA sees the same 201 + body
+	// shape it would have seen from a leader-direct call.
+	fwd := &stubLeaderForwarder{createRes: &ForwardResult{
+		StatusCode:  http.StatusCreated,
+		Payload:     []byte(`{"name":"users","partition_key":"id","generation":1}`),
+		ContentType: "application/json; charset=utf-8",
+	}}
+	h := newFollowerHandler(t, fwd)
+	req := httptest.NewRequest(http.MethodPost, pathDynamoTables, strings.NewReader(validCreateBody()))
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusCreated, rec.Code)
+	require.Equal(t, "application/json; charset=utf-8", rec.Header().Get("Content-Type"))
+	require.JSONEq(t, `{"name":"users","partition_key":"id","generation":1}`, rec.Body.String())
+	require.Equal(t, RoleFull, fwd.lastCreatePrincipal.Role)
+	require.Equal(t, "users", fwd.lastCreateInput.TableName)
+}
+
+func TestDynamoHandler_FollowerForwardsDeleteTable_HappyPath(t *testing.T) {
+	fwd := &stubLeaderForwarder{deleteRes: &ForwardResult{
+		StatusCode:  http.StatusNoContent,
+		ContentType: "application/json; charset=utf-8",
+	}}
+	h := newFollowerHandler(t, fwd)
+	req := httptest.NewRequest(http.MethodDelete, pathDynamoTables+"/users", nil)
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Empty(t, rec.Body.Bytes())
+	require.Equal(t, "users", fwd.lastDeleteName)
+	require.Equal(t, RoleFull, fwd.lastDeletePrincipal.Role)
+}
+
+func TestDynamoHandler_NoForwarder_FallsBackTo503(t *testing.T) {
+	// Without a forwarder configured, a follower handler still
+	// produces the original 503 leader_unavailable + Retry-After
+	// — preserves the leader-only deployment story from PR #634.
+	h := newFollowerHandler(t, nil)
+	req := httptest.NewRequest(http.MethodPost, pathDynamoTables, strings.NewReader(validCreateBody()))
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Equal(t, "1", rec.Header().Get("Retry-After"))
+	require.Contains(t, rec.Body.String(), "leader_unavailable")
+}
+
+func TestDynamoHandler_ForwarderLeaderUnavailableReturns503(t *testing.T) {
+	// Acceptance criterion 3: when the forwarder cannot find a
+	// leader (election in progress), the handler must surface
+	// 503 + Retry-After: 1 so the client retries instead of
+	// failing hard. ErrLeaderUnavailable specifically must NOT
+	// be logged as an error — that path is expected during
+	// elections and would otherwise spam the audit log.
+	fwd := &stubLeaderForwarder{createErr: ErrLeaderUnavailable}
+	h := newFollowerHandler(t, fwd)
+	req := httptest.NewRequest(http.MethodPost, pathDynamoTables, strings.NewReader(validCreateBody()))
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Equal(t, "1", rec.Header().Get("Retry-After"))
+	require.Contains(t, rec.Body.String(), "leader_unavailable")
+}
+
+func TestDynamoHandler_ForwarderTransportErrorReturns503(t *testing.T) {
+	// Generic gRPC error from the forwarder also produces 503 +
+	// Retry-After. The error is logged on the server (covered by
+	// inspection of slog output) but never surfaces to the SPA.
+	fwd := &stubLeaderForwarder{createErr: errors.New("gRPC transport sentinel TX-1")}
+	h := newFollowerHandler(t, fwd)
+	req := httptest.NewRequest(http.MethodPost, pathDynamoTables, strings.NewReader(validCreateBody()))
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.NotContains(t, rec.Body.String(), "TX-1")
+	require.NotContains(t, rec.Body.String(), "transport sentinel")
+}
+
+func TestDynamoHandler_ForwarderForwardsLeaderConflictResponse(t *testing.T) {
+	// 409 Conflict from the leader (table already exists) must
+	// be relayed verbatim to the SPA, not re-classified as 503.
+	// The forwarder's transport succeeded; the leader's
+	// structured response is the authoritative answer.
+	fwd := &stubLeaderForwarder{createRes: &ForwardResult{
+		StatusCode:  http.StatusConflict,
+		Payload:     []byte(`{"error":"already_exists","message":"table already exists"}`),
+		ContentType: "application/json; charset=utf-8",
+	}}
+	h := newFollowerHandler(t, fwd)
+	req := httptest.NewRequest(http.MethodPost, pathDynamoTables, strings.NewReader(validCreateBody()))
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusConflict, rec.Code)
+	require.Contains(t, rec.Body.String(), "already_exists")
+}
+
+func TestDynamoHandler_ForwarderForwardsLeader503WithRetryAfter(t *testing.T) {
+	// If the leader stepped down mid-request and returned 503
+	// itself, the forwarder relays the body but the handler must
+	// also set Retry-After: 1 so the SPA's retry policy works
+	// uniformly regardless of where in the chain the 503 came
+	// from.
+	fwd := &stubLeaderForwarder{createRes: &ForwardResult{
+		StatusCode:  http.StatusServiceUnavailable,
+		Payload:     []byte(`{"error":"leader_unavailable"}`),
+		ContentType: "application/json; charset=utf-8",
+	}}
+	h := newFollowerHandler(t, fwd)
+	req := httptest.NewRequest(http.MethodPost, pathDynamoTables, strings.NewReader(validCreateBody()))
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Equal(t, "1", rec.Header().Get("Retry-After"))
+}
+
+func TestDynamoHandler_ForwarderNotInvokedForReadOnlyPrincipal(t *testing.T) {
+	// The role check fires before the forward path — a read-only
+	// principal must NEVER reach the forwarder. Defence in depth:
+	// even if a malicious follower could fabricate the principal,
+	// the leader re-validates (covered by forward_server_test).
+	fwd := &stubLeaderForwarder{}
+	h := newFollowerHandler(t, fwd)
+	req := httptest.NewRequest(http.MethodPost, pathDynamoTables, strings.NewReader(validCreateBody()))
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Empty(t, fwd.lastCreateInput.TableName, "forwarder must not be reached on role rejection")
+}
+
+func TestDynamoHandler_ForwarderNotInvokedForBadJSON(t *testing.T) {
+	// Body validation runs before the source call — invalid JSON
+	// must fail at the handler with 400 and never produce a
+	// forward attempt.
+	fwd := &stubLeaderForwarder{}
+	h := newFollowerHandler(t, fwd)
+	req := httptest.NewRequest(http.MethodPost, pathDynamoTables, strings.NewReader("{not json"))
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Empty(t, fwd.lastCreateInput.TableName)
+}

--- a/internal/admin/forward_integration_test.go
+++ b/internal/admin/forward_integration_test.go
@@ -63,7 +63,10 @@ func (s *notLeaderSource) AdminDeleteTable(_ context.Context, _ AuthPrincipal, _
 
 func newFollowerHandler(t *testing.T, fwd LeaderForwarder) *DynamoHandler {
 	t.Helper()
-	src := &notLeaderSource{stubTablesSource: stubTablesSource{tables: map[string]*DynamoTableSummary{}}}
+	// notLeaderSource overrides the write methods to unconditionally
+	// return ErrTablesNotLeader, so the embedded stubTablesSource
+	// never reads its tables map.
+	src := &notLeaderSource{}
 	h := NewDynamoHandler(src)
 	if fwd != nil {
 		h = h.WithLeaderForwarder(fwd)


### PR DESCRIPTION
Phase 1 + 2 of Task #26: the follower-side `LeaderForwarder` client and its integration into the dynamo HTTP handler. Builds on the AdminForward leader-side dispatcher landed via #635.

## Summary

- New `LeaderForwarder` interface (`internal/admin/forward_client.go`) decouples the dynamo HTTP handler from `pb.AdminForwardClient`. The handler stays proto-free; the bridge in `main_admin.go` (next phase) plugs in the gRPC-backed implementation.
- `gRPCForwardClient` translates a `CreateTableRequest` / table-name into an `AdminForwardRequest`, dials via a `GRPCConnFactory` (production wraps `kv.GRPCConnCache`), and re-shapes the response into `ForwardResult` (status, payload, content-type).
- `forwarded_from = nodeID` is populated so the leader's audit log carries the trace (criterion 6, leader-side already shipped in #635).
- Defensive: `status_code == 0` upgrades to `502 Bad Gateway`; missing `ContentType` fills the JSON default. Both surface transport bugs rather than producing silently-malformed SPA responses.
- `ErrLeaderUnavailable` sentinel signals the "no leader known" case so the handler can map to 503 + `Retry-After: 1` (criterion 3).
- `DynamoHandler` gains a `forwarder` field and `WithLeaderForwarder` option. When set, `handleCreate` / `handleDelete` catch `ErrTablesNotLeader` from the source and forward to the leader transparently — the SPA cannot tell forwarded from leader-direct.
- `writeForwardResult` re-emits the leader's structured response verbatim (status + payload + content-type), so a forwarded `409 Conflict` from the leader stays `409` on the wire — no re-classification.
- `writeForwardFailure` maps `ErrLeaderUnavailable` (election in flight) and gRPC transport errors to 503 + `Retry-After: 1`. `ErrLeaderUnavailable` is intentionally NOT logged at error level (elections are routine); transport errors are logged at LevelError so operators can investigate.

## What is NOT in this PR

- gRPC server registration in `main.go` (production wiring of the `ForwardServer` from #635) — comes in the next phase.
- The bridge that wraps `kv.GRPCConnCache` and supplies `LeaderAddressResolver` — same phase.
- Election-period retry-loop on the client side (criterion 3 partial: this PR returns 503 + Retry-After; the SPA / client retries the request; criterion 3 fully needs the production bridge to dial actual leader-discovery).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run` (admin package: 0 issues)
- [x] `go test ./internal/admin/ -count=1 -race`
  - 8 forward-client unit tests: constructor input validation, both Forward operations including principal/payload/op-enum/`forwarded_from` round-trip, `ErrLeaderUnavailable`, dial/RPC errors propagated with `cockroachdb/errors` wrapping, zero status code upgrade, missing content type fallback
  - 9 handler integration tests: transparent forward for create + delete, no-forwarder fallback to 503, `ErrLeaderUnavailable` → 503 + Retry-After, transport error → 503 + log, leader 409 pass-through, leader 503 + Retry-After preserved, role check short-circuits before forward, body validation short-circuits before forward
- [ ] Wire production bridge + register `pb.RegisterAdminForwardServer` in `main.go` and exercise an end-to-end follower → leader call against a real cluster (next PR).

## Acceptance criteria coverage

| # | Criterion | This PR |
|---|---|---|
| 1 | Leader direct write | ✓ (in main since #634) |
| 2 | Follower forwards transparently | ✓ wiring done; needs main.go gRPC registration to take effect |
| 3 | Election-period 503 + retry | ✓ partial — handler returns 503 + Retry-After; full transparency needs the bridge |
| 4 | Leader demotes stale full role | ✓ (in main since #635) |
| 5 | Rolling-upgrade compat flag | ⏳ deferred (cluster-version bump) |
| 6 | `forwarded_from` in audit log | ✓ (in main since #635) |
