### PR TITLE
feat(adapter): expose keyviz heatmap via AdminServer.GetKeyVizMatrix

### DIFF
--- a/adapter/admin_grpc.go
+++ b/adapter/admin_grpc.go
@@ -1,14 +1,17 @@
 package adapter
 
 import (
+	"bytes"
 	"context"
 	"crypto/subtle"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/bootjp/elastickv/internal/raftengine"
+	"github.com/bootjp/elastickv/keyviz"
 	pb "github.com/bootjp/elastickv/proto"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
@@ -16,6 +19,19 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
+
+// KeyVizSampler is the read-side abstraction the Admin service needs
+// from the keyviz package: a time-bounded matrix snapshot. Defined
+// here (not in keyviz) so tests can pass an in-memory fake without
+// constructing a full *keyviz.MemSampler. *keyviz.MemSampler
+// satisfies this interface.
+type KeyVizSampler interface {
+	// Snapshot returns the matrix columns in [from, to). Either
+	// bound may be the zero time meaning unbounded on that side.
+	// Implementations must return rows the caller can mutate freely
+	// (a deep copy) — see keyviz.MemSampler.Snapshot.
+	Snapshot(from, to time.Time) []keyviz.MatrixColumn
+}
 
 // AdminGroup exposes per-Raft-group state to the Admin service. It is a narrow
 // subset of raftengine.Engine so tests can supply an in-memory fake without
@@ -56,6 +72,12 @@ type AdminServer struct {
 	// instance cannot contend with concurrent RPCs on another instance.
 	now func() time.Time
 
+	// sampler exposes the keyviz heatmap matrix to GetKeyVizMatrix.
+	// Nil means keyviz is disabled — the RPC returns Unavailable.
+	// Guarded by groupsMu (same lock as groups/now) so RegisterSampler
+	// pairs atomically with concurrent RPC reads.
+	sampler KeyVizSampler
+
 	pb.UnimplementedAdminServer
 }
 
@@ -94,6 +116,16 @@ func (s *AdminServer) RegisterGroup(groupID uint64, g AdminGroup) {
 	}
 	s.groupsMu.Lock()
 	s.groups[groupID] = g
+	s.groupsMu.Unlock()
+}
+
+// RegisterSampler wires the keyviz sampler used by GetKeyVizMatrix.
+// Without this call (or with a nil sampler) the RPC returns
+// codes.Unavailable so callers can distinguish "keyviz disabled"
+// from "no data yet".
+func (s *AdminServer) RegisterSampler(sampler KeyVizSampler) {
+	s.groupsMu.Lock()
+	s.sampler = sampler
 	s.groupsMu.Unlock()
 }
 
@@ -477,3 +509,125 @@ func AdminTokenAuth(token string) (grpc.UnaryServerInterceptor, grpc.StreamServe
 // ErrAdminTokenRequired is returned by NewAdminServer helpers when the operator
 // failed to supply a token and also did not opt into insecure mode.
 var ErrAdminTokenRequired = errors.New("admin token file required; pass --adminInsecureNoAuth to run without")
+
+// GetKeyVizMatrix renders the keyviz heatmap matrix for the [from, to)
+// range supplied by the request, returning one KeyVizRow per tracked
+// route or virtual bucket and a parallel column-timestamp slice.
+//
+// Series selection (Reads / Writes / ReadBytes / WriteBytes) maps from
+// the request's KeyVizSeries enum to the matching keyviz.MatrixRow
+// counter; KEYVIZ_SERIES_UNSPECIFIED defaults to Reads.
+//
+// Returns codes.Unavailable when no sampler is registered (keyviz
+// disabled) so callers can distinguish that from "no data yet"
+// (which yields a successful empty response).
+func (s *AdminServer) GetKeyVizMatrix(
+	_ context.Context,
+	req *pb.GetKeyVizMatrixRequest,
+) (*pb.GetKeyVizMatrixResponse, error) {
+	s.groupsMu.RLock()
+	sampler := s.sampler
+	s.groupsMu.RUnlock()
+	if sampler == nil {
+		return nil, errors.WithStack(status.Error(codes.Unavailable, "keyviz sampler not configured on this node"))
+	}
+	from := unixMsToTime(req.GetFromUnixMs())
+	to := unixMsToTime(req.GetToUnixMs())
+	cols := sampler.Snapshot(from, to)
+	pickValue := matrixSeriesPicker(req.GetSeries())
+	return matrixToProto(cols, pickValue), nil
+}
+
+// unixMsToTime converts a Unix-millisecond timestamp into a time.Time,
+// returning the zero Time when the input is zero so the sampler reads
+// an unbounded range on that side.
+func unixMsToTime(ms int64) time.Time {
+	if ms == 0 {
+		return time.Time{}
+	}
+	return time.UnixMilli(ms)
+}
+
+// matrixSeriesPicker returns a callback that extracts the requested
+// counter from a MatrixRow. KEYVIZ_SERIES_UNSPECIFIED (and READS)
+// fall through to Reads so a default-valued request still returns
+// something useful.
+func matrixSeriesPicker(series pb.KeyVizSeries) func(keyviz.MatrixRow) uint64 {
+	switch series {
+	case pb.KeyVizSeries_KEYVIZ_SERIES_WRITES:
+		return func(r keyviz.MatrixRow) uint64 { return r.Writes }
+	case pb.KeyVizSeries_KEYVIZ_SERIES_READ_BYTES:
+		return func(r keyviz.MatrixRow) uint64 { return r.ReadBytes }
+	case pb.KeyVizSeries_KEYVIZ_SERIES_WRITE_BYTES:
+		return func(r keyviz.MatrixRow) uint64 { return r.WriteBytes }
+	case pb.KeyVizSeries_KEYVIZ_SERIES_UNSPECIFIED, pb.KeyVizSeries_KEYVIZ_SERIES_READS:
+		return func(r keyviz.MatrixRow) uint64 { return r.Reads }
+	default:
+		return func(r keyviz.MatrixRow) uint64 { return r.Reads }
+	}
+}
+
+// matrixToProto pivots the column-major MatrixColumn slice into the
+// row-major proto layout: one KeyVizRow per distinct RouteID with a
+// values slice aligned to the column_unix_ms parallel slice. Idle
+// routes (zero in every column) are not emitted by the sampler, so
+// the row set already reflects observed activity in [from, to).
+func matrixToProto(cols []keyviz.MatrixColumn, pick func(keyviz.MatrixRow) uint64) *pb.GetKeyVizMatrixResponse {
+	resp := &pb.GetKeyVizMatrixResponse{
+		ColumnUnixMs: make([]int64, len(cols)),
+	}
+	rowsByID := make(map[uint64]*pb.KeyVizRow)
+	order := make([]uint64, 0)
+	for j, col := range cols {
+		resp.ColumnUnixMs[j] = col.At.UnixMilli()
+		for _, mr := range col.Rows {
+			pr, ok := rowsByID[mr.RouteID]
+			if !ok {
+				pr = newKeyVizRowFrom(mr, len(cols))
+				rowsByID[mr.RouteID] = pr
+				order = append(order, mr.RouteID)
+			}
+			pr.Values[j] = pick(mr)
+		}
+	}
+	resp.Rows = make([]*pb.KeyVizRow, len(order))
+	for i, id := range order {
+		resp.Rows[i] = rowsByID[id]
+	}
+	sortKeyVizRowsByStart(resp.Rows)
+	return resp
+}
+
+// newKeyVizRowFrom seeds a proto row from the first MatrixRow seen
+// for a given RouteID. Values is allocated with len == numCols so
+// every column gets a deterministic slot (zero-valued by default).
+func newKeyVizRowFrom(mr keyviz.MatrixRow, numCols int) *pb.KeyVizRow {
+	row := &pb.KeyVizRow{
+		BucketId:   bucketIDFor(mr),
+		Start:      append([]byte(nil), mr.Start...),
+		End:        append([]byte(nil), mr.End...),
+		Aggregate:  mr.Aggregate,
+		RouteCount: uint64(len(mr.MemberRoutes)),
+		Values:     make([]uint64, numCols),
+	}
+	if mr.Aggregate {
+		row.RouteIds = append([]uint64(nil), mr.MemberRoutes...)
+	}
+	return row
+}
+
+func bucketIDFor(mr keyviz.MatrixRow) string {
+	if mr.Aggregate {
+		return "virtual:" + strconv.FormatUint(mr.RouteID, 10)
+	}
+	return "route:" + strconv.FormatUint(mr.RouteID, 10)
+}
+
+func sortKeyVizRowsByStart(rows []*pb.KeyVizRow) {
+	sort.Slice(rows, func(i, j int) bool {
+		if c := bytes.Compare(rows[i].Start, rows[j].Start); c != 0 {
+			return c < 0
+		}
+		return rows[i].BucketId < rows[j].BucketId
+	})
+}

--- a/adapter/admin_grpc.go
+++ b/adapter/admin_grpc.go
@@ -535,7 +535,7 @@ func (s *AdminServer) GetKeyVizMatrix(
 	to := unixMsToTime(req.GetToUnixMs())
 	cols := sampler.Snapshot(from, to)
 	pickValue := matrixSeriesPicker(req.GetSeries())
-	return matrixToProto(cols, pickValue), nil
+	return matrixToProto(cols, pickValue, int(req.GetRows())), nil
 }
 
 // unixMsToTime converts a Unix-millisecond timestamp into a time.Time,
@@ -572,7 +572,13 @@ func matrixSeriesPicker(series pb.KeyVizSeries) func(keyviz.MatrixRow) uint64 {
 // values slice aligned to the column_unix_ms parallel slice. Idle
 // routes (zero in every column) are not emitted by the sampler, so
 // the row set already reflects observed activity in [from, to).
-func matrixToProto(cols []keyviz.MatrixColumn, pick func(keyviz.MatrixRow) uint64) *pb.GetKeyVizMatrixResponse {
+//
+// rowBudget caps how many rows the response carries — passing
+// 0 means "no cap." When the budget would be exceeded, rows are
+// sorted by total activity across the requested series and the
+// top-N retained, so callers asking for a compact matrix do not
+// receive a payload that scales with the route count.
+func matrixToProto(cols []keyviz.MatrixColumn, pick func(keyviz.MatrixRow) uint64, rowBudget int) *pb.GetKeyVizMatrixResponse {
 	resp := &pb.GetKeyVizMatrixResponse{
 		ColumnUnixMs: make([]int64, len(cols)),
 	}
@@ -594,21 +600,56 @@ func matrixToProto(cols []keyviz.MatrixColumn, pick func(keyviz.MatrixRow) uint6
 	for i, id := range order {
 		resp.Rows[i] = rowsByID[id]
 	}
+	resp.Rows = applyKeyVizRowBudget(resp.Rows, rowBudget)
 	sortKeyVizRowsByStart(resp.Rows)
 	return resp
+}
+
+// applyKeyVizRowBudget caps rows to budget by total activity per row
+// (sum of per-column values), preserving the top-N rows. budget <= 0
+// means "no cap."
+func applyKeyVizRowBudget(rows []*pb.KeyVizRow, budget int) []*pb.KeyVizRow {
+	if budget <= 0 || len(rows) <= budget {
+		return rows
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return rowActivityTotal(rows[i]) > rowActivityTotal(rows[j])
+	})
+	return rows[:budget]
+}
+
+func rowActivityTotal(r *pb.KeyVizRow) uint64 {
+	var sum uint64
+	for _, v := range r.Values {
+		sum += v
+	}
+	return sum
 }
 
 // newKeyVizRowFrom seeds a proto row from the first MatrixRow seen
 // for a given RouteID. Values is allocated with len == numCols so
 // every column gets a deterministic slot (zero-valued by default).
+//
+// route_count surfaces MemberRoutesTotal (the true number of routes
+// folded into the bucket) — not just len(MemberRoutes), which the
+// sampler caps at MaxMemberRoutesPerSlot. When the visible list is
+// shorter than the total, route_ids_truncated lets consumers know
+// to trust route_count for drill-down decisions.
 func newKeyVizRowFrom(mr keyviz.MatrixRow, numCols int) *pb.KeyVizRow {
+	total := mr.MemberRoutesTotal
+	if !mr.Aggregate && total == 0 {
+		// Individual slots fall through to RouteCount=1 when the
+		// sampler predates MemberRoutesTotal or never set it.
+		total = 1
+	}
 	row := &pb.KeyVizRow{
-		BucketId:   bucketIDFor(mr),
-		Start:      append([]byte(nil), mr.Start...),
-		End:        append([]byte(nil), mr.End...),
-		Aggregate:  mr.Aggregate,
-		RouteCount: uint64(len(mr.MemberRoutes)),
-		Values:     make([]uint64, numCols),
+		BucketId:          bucketIDFor(mr),
+		Start:             append([]byte(nil), mr.Start...),
+		End:               append([]byte(nil), mr.End...),
+		Aggregate:         mr.Aggregate,
+		RouteCount:        total,
+		RouteIdsTruncated: mr.Aggregate && total > uint64(len(mr.MemberRoutes)),
+		Values:            make([]uint64, numCols),
 	}
 	if mr.Aggregate {
 		row.RouteIds = append([]uint64(nil), mr.MemberRoutes...)

--- a/adapter/admin_grpc.go
+++ b/adapter/admin_grpc.go
@@ -535,7 +535,24 @@ func (s *AdminServer) GetKeyVizMatrix(
 	to := unixMsToTime(req.GetToUnixMs())
 	cols := sampler.Snapshot(from, to)
 	pickValue := matrixSeriesPicker(req.GetSeries())
-	return matrixToProto(cols, pickValue, int(req.GetRows())), nil
+	return matrixToProto(cols, pickValue, clampRowBudget(int(req.GetRows()))), nil
+}
+
+// keyVizRowBudgetCap is the upper bound on the per-request rows
+// budget — design doc §4.1 caps rows at 1024 to bound server work
+// (sort + payload) for adversarial / over-large requests.
+const keyVizRowBudgetCap = 1024
+
+// clampRowBudget enforces design §4.1's upper bound. A request of 0
+// (or negative) means "no cap" and is preserved; anything past the
+// cap is silently clamped — clients asking for more rows than the
+// server is willing to render get the most rows the server will
+// render, not an error.
+func clampRowBudget(requested int) int {
+	if requested > keyVizRowBudgetCap {
+		return keyVizRowBudgetCap
+	}
+	return requested
 }
 
 // unixMsToTime converts a Unix-millisecond timestamp into a time.Time,
@@ -549,21 +566,22 @@ func unixMsToTime(ms int64) time.Time {
 }
 
 // matrixSeriesPicker returns a callback that extracts the requested
-// counter from a MatrixRow. KEYVIZ_SERIES_UNSPECIFIED (and READS)
-// fall through to Reads so a default-valued request still returns
-// something useful.
+// counter from a MatrixRow. KEYVIZ_SERIES_UNSPECIFIED falls through
+// to Writes per design doc §4.1 — write traffic is the primary
+// signal the heatmap is built around, and the read path is wired in
+// a follow-up phase.
 func matrixSeriesPicker(series pb.KeyVizSeries) func(keyviz.MatrixRow) uint64 {
 	switch series {
-	case pb.KeyVizSeries_KEYVIZ_SERIES_WRITES:
-		return func(r keyviz.MatrixRow) uint64 { return r.Writes }
+	case pb.KeyVizSeries_KEYVIZ_SERIES_READS:
+		return func(r keyviz.MatrixRow) uint64 { return r.Reads }
 	case pb.KeyVizSeries_KEYVIZ_SERIES_READ_BYTES:
 		return func(r keyviz.MatrixRow) uint64 { return r.ReadBytes }
 	case pb.KeyVizSeries_KEYVIZ_SERIES_WRITE_BYTES:
 		return func(r keyviz.MatrixRow) uint64 { return r.WriteBytes }
-	case pb.KeyVizSeries_KEYVIZ_SERIES_UNSPECIFIED, pb.KeyVizSeries_KEYVIZ_SERIES_READS:
-		return func(r keyviz.MatrixRow) uint64 { return r.Reads }
+	case pb.KeyVizSeries_KEYVIZ_SERIES_UNSPECIFIED, pb.KeyVizSeries_KEYVIZ_SERIES_WRITES:
+		return func(r keyviz.MatrixRow) uint64 { return r.Writes }
 	default:
-		return func(r keyviz.MatrixRow) uint64 { return r.Reads }
+		return func(r keyviz.MatrixRow) uint64 { return r.Writes }
 	}
 }
 
@@ -608,6 +626,14 @@ func matrixToProto(cols []keyviz.MatrixColumn, pick func(keyviz.MatrixRow) uint6
 // applyKeyVizRowBudget caps rows to budget by total activity per row
 // (sum of per-column values), preserving the top-N rows. budget <= 0
 // means "no cap."
+//
+// NOTE: design doc §5.5 specifies a "lexicographic walk + greedy
+// merge of low-activity adjacent ranges" algorithm — we simplify to
+// activity-descending truncation for Phase 1 because it covers the
+// common UI need (highlight hotspots) without needing the synthetic
+// virtual-bucket plumbing the merge requires. Phase 2 should swap
+// this for the spec'd merge so low-activity ranges become coarse
+// aggregates instead of being silently dropped.
 func applyKeyVizRowBudget(rows []*pb.KeyVizRow, budget int) []*pb.KeyVizRow {
 	if budget <= 0 || len(rows) <= budget {
 		return rows

--- a/adapter/admin_grpc_keyviz_test.go
+++ b/adapter/admin_grpc_keyviz_test.go
@@ -143,7 +143,10 @@ func TestGetKeyVizMatrixSeriesSelection(t *testing.T) {
 
 // TestGetKeyVizMatrixEncodesAggregateBucket pins the proto layout
 // for virtual buckets: bucket_id prefixed "virtual:", aggregate=true,
-// route_ids carries the MemberRoutes list, and route_count matches.
+// route_ids carries the visible MemberRoutes list, and route_count
+// reports the TRUE total (MemberRoutesTotal) — including past-cap
+// folded routes — so consumers always know how many routes
+// contributed.
 func TestGetKeyVizMatrixEncodesAggregateBucket(t *testing.T) {
 	t.Parallel()
 	srv := newAdminServerWithFakeSampler(t, []keyviz.MatrixColumn{
@@ -151,12 +154,13 @@ func TestGetKeyVizMatrixEncodesAggregateBucket(t *testing.T) {
 			At: time.Unix(1_700_000_000, 0),
 			Rows: []keyviz.MatrixRow{
 				{
-					RouteID:      ^uint64(0), // synthetic virtual-bucket ID
-					Start:        []byte("c"),
-					End:          []byte("d"),
-					Aggregate:    true,
-					MemberRoutes: []uint64{2, 3, 4},
-					Reads:        50,
+					RouteID:           ^uint64(0), // synthetic virtual-bucket ID
+					Start:             []byte("c"),
+					End:               []byte("d"),
+					Aggregate:         true,
+					MemberRoutes:      []uint64{2, 3, 4},
+					MemberRoutesTotal: 3,
+					Reads:             50,
 				},
 			},
 		},
@@ -171,5 +175,72 @@ func TestGetKeyVizMatrixEncodesAggregateBucket(t *testing.T) {
 	require.True(t, r.Aggregate)
 	require.Equal(t, "virtual:18446744073709551615", r.BucketId)
 	require.Equal(t, uint64(3), r.RouteCount)
+	require.False(t, r.RouteIdsTruncated)
 	require.Equal(t, []uint64{2, 3, 4}, r.RouteIds)
+}
+
+// TestGetKeyVizMatrixSurfacesRouteCountTruncation pins Codex round-1
+// P2 on PR #646: when the sampler caps MemberRoutes at
+// MaxMemberRoutesPerSlot, route_count must still report the TRUE
+// total (MemberRoutesTotal) and route_ids_truncated must flip true so
+// consumers know the visible list is a prefix.
+func TestGetKeyVizMatrixSurfacesRouteCountTruncation(t *testing.T) {
+	t.Parallel()
+	srv := newAdminServerWithFakeSampler(t, []keyviz.MatrixColumn{
+		{
+			At: time.Unix(1_700_000_000, 0),
+			Rows: []keyviz.MatrixRow{
+				{
+					RouteID:           ^uint64(0),
+					Start:             []byte("c"),
+					End:               []byte("d"),
+					Aggregate:         true,
+					MemberRoutes:      []uint64{2, 3}, // visible cap=2
+					MemberRoutesTotal: 9,              // 7 more folded past the cap
+					Reads:             100,
+				},
+			},
+		},
+	})
+
+	resp, err := srv.GetKeyVizMatrix(context.Background(), &pb.GetKeyVizMatrixRequest{
+		Series: pb.KeyVizSeries_KEYVIZ_SERIES_READS,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Rows, 1)
+	r := resp.Rows[0]
+	require.Equal(t, uint64(9), r.RouteCount, "route_count must reflect MemberRoutesTotal")
+	require.True(t, r.RouteIdsTruncated, "route_ids_truncated must signal capped membership")
+	require.Equal(t, []uint64{2, 3}, r.RouteIds)
+}
+
+// TestGetKeyVizMatrixHonorsRowsBudget pins Codex round-1 P1 on
+// PR #646: a request with rows=N must return at most N rows. We
+// stage 4 routes with distinct activity totals and request rows=2;
+// the response must contain only the two highest-activity routes,
+// sorted by Start.
+func TestGetKeyVizMatrixHonorsRowsBudget(t *testing.T) {
+	t.Parallel()
+	srv := newAdminServerWithFakeSampler(t, []keyviz.MatrixColumn{
+		{
+			At: time.Unix(1_700_000_000, 0),
+			Rows: []keyviz.MatrixRow{
+				{RouteID: 1, Start: []byte("a"), End: []byte("b"), Reads: 1},
+				{RouteID: 2, Start: []byte("b"), End: []byte("c"), Reads: 100},
+				{RouteID: 3, Start: []byte("c"), End: []byte("d"), Reads: 5},
+				{RouteID: 4, Start: []byte("d"), End: []byte("e"), Reads: 50},
+			},
+		},
+	})
+
+	resp, err := srv.GetKeyVizMatrix(context.Background(), &pb.GetKeyVizMatrixRequest{
+		Series: pb.KeyVizSeries_KEYVIZ_SERIES_READS,
+		Rows:   2,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Rows, 2, "rows budget must cap response size")
+	// Top 2 by activity = routes 2 (100) and 4 (50); sorted by Start
+	// gives "b" then "d".
+	require.Equal(t, "route:2", resp.Rows[0].BucketId)
+	require.Equal(t, "route:4", resp.Rows[1].BucketId)
 }

--- a/adapter/admin_grpc_keyviz_test.go
+++ b/adapter/admin_grpc_keyviz_test.go
@@ -1,0 +1,175 @@
+package adapter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bootjp/elastickv/keyviz"
+	pb "github.com/bootjp/elastickv/proto"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// fakeKeyVizSampler is a deterministic in-memory KeyVizSampler so
+// AdminServer tests don't need to drive a real keyviz.MemSampler with
+// goroutines and time. Snapshot returns a fresh deep copy of the
+// configured columns so the test mirrors the real sampler's contract.
+type fakeKeyVizSampler struct {
+	cols []keyviz.MatrixColumn
+}
+
+func (f *fakeKeyVizSampler) Snapshot(_, _ time.Time) []keyviz.MatrixColumn {
+	out := make([]keyviz.MatrixColumn, len(f.cols))
+	for i, c := range f.cols {
+		rows := make([]keyviz.MatrixRow, len(c.Rows))
+		for j, r := range c.Rows {
+			rows[j] = r
+			rows[j].Start = append([]byte(nil), r.Start...)
+			rows[j].End = append([]byte(nil), r.End...)
+			if len(r.MemberRoutes) > 0 {
+				rows[j].MemberRoutes = append([]uint64(nil), r.MemberRoutes...)
+			}
+		}
+		out[i] = keyviz.MatrixColumn{At: c.At, Rows: rows}
+	}
+	return out
+}
+
+// TestGetKeyVizMatrixReturnsUnavailableWhenSamplerNotRegistered pins
+// the failure mode operators should see when keyviz is disabled on
+// a node — Unavailable rather than a successful empty response.
+func TestGetKeyVizMatrixReturnsUnavailableWhenSamplerNotRegistered(t *testing.T) {
+	t.Parallel()
+	srv := NewAdminServer(NodeIdentity{NodeID: "node-a"}, nil)
+	_, err := srv.GetKeyVizMatrix(context.Background(), &pb.GetKeyVizMatrixRequest{})
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.Unavailable {
+		t.Fatalf("expected Unavailable, got %v", err)
+	}
+}
+
+// TestGetKeyVizMatrixPivotsColumnsToRows pins the row-major proto
+// layout: one KeyVizRow per RouteID with values aligned to the
+// parallel column_unix_ms slice. Drives a fake sampler with two
+// columns and two routes (one of which reports zero in column 1).
+func TestGetKeyVizMatrixPivotsColumnsToRows(t *testing.T) {
+	t.Parallel()
+	t0 := time.Unix(1_700_000_000, 0)
+	t1 := t0.Add(time.Minute)
+	srv := newAdminServerWithFakeSampler(t, twoColumnTwoRouteCols(t0, t1))
+
+	resp, err := srv.GetKeyVizMatrix(context.Background(), &pb.GetKeyVizMatrixRequest{
+		Series: pb.KeyVizSeries_KEYVIZ_SERIES_READS,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []int64{t0.UnixMilli(), t1.UnixMilli()}, resp.ColumnUnixMs)
+	require.Len(t, resp.Rows, 2)
+	// Sorted by Start: route 1 ("a") then route 2 ("m").
+	r1, r2 := resp.Rows[0], resp.Rows[1]
+	require.Equal(t, "route:1", r1.BucketId)
+	require.Equal(t, "route:2", r2.BucketId)
+	require.Equal(t, []byte("a"), r1.Start)
+	require.Equal(t, []byte("m"), r1.End)
+	require.False(t, r1.Aggregate)
+	require.False(t, r2.Aggregate)
+	require.Equal(t, []uint64{4, 9}, r1.Values)
+	// Route 2 is absent in column 1 — zero by default.
+	require.Equal(t, []uint64{7, 0}, r2.Values)
+}
+
+func twoColumnTwoRouteCols(t0, t1 time.Time) []keyviz.MatrixColumn {
+	return []keyviz.MatrixColumn{
+		{
+			At: t0,
+			Rows: []keyviz.MatrixRow{
+				{RouteID: 1, Start: []byte("a"), End: []byte("m"), Reads: 4, Writes: 1},
+				{RouteID: 2, Start: []byte("m"), End: []byte("z"), Reads: 7, Writes: 0},
+			},
+		},
+		{
+			At: t1,
+			Rows: []keyviz.MatrixRow{
+				{RouteID: 1, Start: []byte("a"), End: []byte("m"), Reads: 9, Writes: 3},
+			},
+		},
+	}
+}
+
+func newAdminServerWithFakeSampler(t *testing.T, cols []keyviz.MatrixColumn) *AdminServer {
+	t.Helper()
+	srv := NewAdminServer(NodeIdentity{NodeID: "node-a"}, nil)
+	srv.RegisterSampler(&fakeKeyVizSampler{cols: cols})
+	return srv
+}
+
+// TestGetKeyVizMatrixSeriesSelection pins the request.Series →
+// MatrixRow counter mapping including the UNSPECIFIED → Reads default.
+func TestGetKeyVizMatrixSeriesSelection(t *testing.T) {
+	t.Parallel()
+	row := keyviz.MatrixRow{
+		RouteID:    1,
+		Start:      []byte("a"),
+		End:        []byte("z"),
+		Reads:      11,
+		Writes:     22,
+		ReadBytes:  333,
+		WriteBytes: 4444,
+	}
+	srv := newAdminServerWithFakeSampler(t, []keyviz.MatrixColumn{
+		{At: time.Unix(1_700_000_000, 0), Rows: []keyviz.MatrixRow{row}},
+	})
+
+	for _, tc := range []struct {
+		name   string
+		series pb.KeyVizSeries
+		want   uint64
+	}{
+		{"unspecified defaults to reads", pb.KeyVizSeries_KEYVIZ_SERIES_UNSPECIFIED, 11},
+		{"reads", pb.KeyVizSeries_KEYVIZ_SERIES_READS, 11},
+		{"writes", pb.KeyVizSeries_KEYVIZ_SERIES_WRITES, 22},
+		{"read_bytes", pb.KeyVizSeries_KEYVIZ_SERIES_READ_BYTES, 333},
+		{"write_bytes", pb.KeyVizSeries_KEYVIZ_SERIES_WRITE_BYTES, 4444},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := srv.GetKeyVizMatrix(context.Background(), &pb.GetKeyVizMatrixRequest{Series: tc.series})
+			require.NoError(t, err)
+			require.Len(t, resp.Rows, 1)
+			require.Equal(t, []uint64{tc.want}, resp.Rows[0].Values)
+		})
+	}
+}
+
+// TestGetKeyVizMatrixEncodesAggregateBucket pins the proto layout
+// for virtual buckets: bucket_id prefixed "virtual:", aggregate=true,
+// route_ids carries the MemberRoutes list, and route_count matches.
+func TestGetKeyVizMatrixEncodesAggregateBucket(t *testing.T) {
+	t.Parallel()
+	srv := newAdminServerWithFakeSampler(t, []keyviz.MatrixColumn{
+		{
+			At: time.Unix(1_700_000_000, 0),
+			Rows: []keyviz.MatrixRow{
+				{
+					RouteID:      ^uint64(0), // synthetic virtual-bucket ID
+					Start:        []byte("c"),
+					End:          []byte("d"),
+					Aggregate:    true,
+					MemberRoutes: []uint64{2, 3, 4},
+					Reads:        50,
+				},
+			},
+		},
+	})
+
+	resp, err := srv.GetKeyVizMatrix(context.Background(), &pb.GetKeyVizMatrixRequest{
+		Series: pb.KeyVizSeries_KEYVIZ_SERIES_READS,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Rows, 1)
+	r := resp.Rows[0]
+	require.True(t, r.Aggregate)
+	require.Equal(t, "virtual:18446744073709551615", r.BucketId)
+	require.Equal(t, uint64(3), r.RouteCount)
+	require.Equal(t, []uint64{2, 3, 4}, r.RouteIds)
+}

--- a/adapter/admin_grpc_keyviz_test.go
+++ b/adapter/admin_grpc_keyviz_test.go
@@ -126,7 +126,7 @@ func TestGetKeyVizMatrixSeriesSelection(t *testing.T) {
 		series pb.KeyVizSeries
 		want   uint64
 	}{
-		{"unspecified defaults to reads", pb.KeyVizSeries_KEYVIZ_SERIES_UNSPECIFIED, 11},
+		{"unspecified defaults to writes", pb.KeyVizSeries_KEYVIZ_SERIES_UNSPECIFIED, 22},
 		{"reads", pb.KeyVizSeries_KEYVIZ_SERIES_READS, 11},
 		{"writes", pb.KeyVizSeries_KEYVIZ_SERIES_WRITES, 22},
 		{"read_bytes", pb.KeyVizSeries_KEYVIZ_SERIES_READ_BYTES, 333},
@@ -212,6 +212,35 @@ func TestGetKeyVizMatrixSurfacesRouteCountTruncation(t *testing.T) {
 	require.Equal(t, uint64(9), r.RouteCount, "route_count must reflect MemberRoutesTotal")
 	require.True(t, r.RouteIdsTruncated, "route_ids_truncated must signal capped membership")
 	require.Equal(t, []uint64{2, 3}, r.RouteIds)
+}
+
+// TestGetKeyVizMatrixClampsRowsBudgetToCap pins design §4.1's
+// upper-bound: rows requests above the keyVizRowBudgetCap are
+// silently clamped down to the cap so a pathological client cannot
+// force the server to materialise an unbounded payload.
+func TestGetKeyVizMatrixClampsRowsBudgetToCap(t *testing.T) {
+	t.Parallel()
+	rows := make([]keyviz.MatrixRow, keyVizRowBudgetCap+5)
+	for i := range rows {
+		idx := uint64(i + 1) //nolint:gosec // i is bounded by keyVizRowBudgetCap+5
+		rows[i] = keyviz.MatrixRow{
+			RouteID: idx,
+			Start:   []byte{byte(i / 256), byte(i % 256)},
+			End:     []byte{byte((i + 1) / 256), byte((i + 1) % 256)},
+			Writes:  idx,
+		}
+	}
+	srv := newAdminServerWithFakeSampler(t, []keyviz.MatrixColumn{{
+		At:   time.Unix(1_700_000_000, 0),
+		Rows: rows,
+	}})
+
+	resp, err := srv.GetKeyVizMatrix(context.Background(), &pb.GetKeyVizMatrixRequest{
+		Series: pb.KeyVizSeries_KEYVIZ_SERIES_WRITES,
+		Rows:   uint32(keyVizRowBudgetCap + 1000),
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Rows, keyVizRowBudgetCap, "rows must be clamped to keyVizRowBudgetCap")
 }
 
 // TestGetKeyVizMatrixHonorsRowsBudget pins Codex round-1 P1 on

--- a/keyviz/sampler.go
+++ b/keyviz/sampler.go
@@ -226,11 +226,16 @@ type routeSlot struct {
 	// routes together (Snapshot surfaces this in MatrixRow).
 	Aggregate    bool
 	MemberRoutes []uint64
-	// MemberRoutesTotal counts every distinct routeID that has folded
-	// into this bucket, including ones beyond MaxMemberRoutesPerSlot
-	// (which still contribute to the counters but are not appended to
-	// MemberRoutes). Always equals len(MemberRoutes) for individual
-	// (non-Aggregate) slots.
+	// hiddenMembers stores routeIDs folded past
+	// MaxMemberRoutesPerSlot. Used to dedup re-folds (so
+	// MemberRoutesTotal doesn't drift on remove+re-register churn for
+	// past-cap routes) and to drive accurate decrements in
+	// pruneMemberRoute. nil for individual slots.
+	hiddenMembers map[uint64]struct{}
+	// MemberRoutesTotal is len(MemberRoutes) + len(hiddenMembers) — the
+	// authoritative count of distinct routes folded into this bucket.
+	// Always equals len(MemberRoutes) for individual (non-Aggregate)
+	// slots.
 	MemberRoutesTotal uint64
 
 	reads      atomic.Uint64
@@ -455,16 +460,12 @@ func (s *MemSampler) RegisterRoute(routeID uint64, start, end []byte) bool {
 // to preserve Flush's key-order contract.
 //
 // MemberRoutes growth is capped by MaxMemberRoutesPerSlot — beyond
-// that cap the bucket counters still absorb the route's traffic, but
-// the routeID is not added to the visible member list.
+// that cap the bucket counters still absorb the route's traffic and
+// the routeID is recorded in hiddenMembers (so dedup is correct on
+// rejoin) but not appended to the visible MemberRoutes list.
 func (s *MemSampler) foldIntoBucket(next *routeTable, bucket *routeSlot, routeID uint64, start, end []byte) {
 	bucket.metaMu.Lock()
-	if !memberRoutesContains(bucket.MemberRoutes, routeID) {
-		bucket.MemberRoutesTotal++
-		if len(bucket.MemberRoutes) < s.opts.MaxMemberRoutesPerSlot {
-			bucket.MemberRoutes = append(bucket.MemberRoutes, routeID)
-		}
-	}
+	addMemberToBucket(bucket, routeID, s.opts.MaxMemberRoutesPerSlot)
 	if len(end) == 0 || (len(bucket.End) != 0 && bytesGT(end, bucket.End)) {
 		bucket.End = cloneBytes(end)
 	}
@@ -476,6 +477,31 @@ func (s *MemSampler) foldIntoBucket(next *routeTable, bucket *routeSlot, routeID
 	if startLowered {
 		next.sortedSlots = rebuildSorted(next)
 	}
+}
+
+// addMemberToBucket records routeID against bucket, choosing the
+// visible MemberRoutes list when there's room and falling back to
+// the hiddenMembers set past the cap. Both lists are deduped so a
+// rejoin during the prune grace doesn't inflate MemberRoutesTotal.
+// Caller holds bucket.metaMu.
+func addMemberToBucket(bucket *routeSlot, routeID uint64, visibleCap int) {
+	if memberRoutesContains(bucket.MemberRoutes, routeID) {
+		return
+	}
+	if bucket.hiddenMembers != nil {
+		if _, ok := bucket.hiddenMembers[routeID]; ok {
+			return
+		}
+	}
+	if len(bucket.MemberRoutes) < visibleCap {
+		bucket.MemberRoutes = append(bucket.MemberRoutes, routeID)
+	} else {
+		if bucket.hiddenMembers == nil {
+			bucket.hiddenMembers = make(map[uint64]struct{})
+		}
+		bucket.hiddenMembers[routeID] = struct{}{}
+	}
+	bucket.MemberRoutesTotal++
 }
 
 // RemoveRoute drops a RouteID from tracking. Counts accumulated since
@@ -719,12 +745,13 @@ func bucketStillReferenced(virtualForRoute map[uint64]*routeSlot, bucket *routeS
 	return false
 }
 
-// pruneMemberRoute removes routeID from bucket.MemberRoutes under the
-// bucket's metaMu so a concurrent snapshotMeta reader sees a
-// consistent view. MemberRoutesTotal is decremented when the routeID
-// was visible in MemberRoutes (the only case we can confidently
-// account for) — routes pruned past the visible cap stay in the
-// total because we don't track individual past-cap members.
+// pruneMemberRoute removes routeID from bucket.MemberRoutes (or
+// hiddenMembers) under the bucket's metaMu so a concurrent
+// snapshotMeta reader sees a consistent view. MemberRoutesTotal is
+// decremented whenever the routeID was actually present in either
+// list — including past-cap members in hiddenMembers — so the
+// reported route_count stays truthful across remove/re-register
+// churn.
 func pruneMemberRoute(bucket *routeSlot, routeID uint64) {
 	bucket.metaMu.Lock()
 	defer bucket.metaMu.Unlock()
@@ -738,6 +765,15 @@ func pruneMemberRoute(bucket *routeSlot, routeID uint64) {
 		filtered = append(filtered, m)
 	}
 	bucket.MemberRoutes = filtered
+	if !removed && bucket.hiddenMembers != nil {
+		if _, ok := bucket.hiddenMembers[routeID]; ok {
+			delete(bucket.hiddenMembers, routeID)
+			if len(bucket.hiddenMembers) == 0 {
+				bucket.hiddenMembers = nil
+			}
+			removed = true
+		}
+	}
 	if removed && bucket.MemberRoutesTotal > 0 {
 		bucket.MemberRoutesTotal--
 	}

--- a/keyviz/sampler.go
+++ b/keyviz/sampler.go
@@ -226,6 +226,12 @@ type routeSlot struct {
 	// routes together (Snapshot surfaces this in MatrixRow).
 	Aggregate    bool
 	MemberRoutes []uint64
+	// MemberRoutesTotal counts every distinct routeID that has folded
+	// into this bucket, including ones beyond MaxMemberRoutesPerSlot
+	// (which still contribute to the counters but are not appended to
+	// MemberRoutes). Always equals len(MemberRoutes) for individual
+	// (non-Aggregate) slots.
+	MemberRoutesTotal uint64
 
 	reads      atomic.Uint64
 	writes     atomic.Uint64
@@ -238,7 +244,7 @@ type routeSlot struct {
 // Start/End/MemberRoutes with the live slot (which a later
 // RegisterRoute may extend, and which the snapshot API exports to
 // external consumers that may mutate the bounds).
-func (s *routeSlot) snapshotMeta() (start, end []byte, aggregate bool, members []uint64) {
+func (s *routeSlot) snapshotMeta() (start, end []byte, aggregate bool, members []uint64, membersTotal uint64) {
 	s.metaMu.RLock()
 	defer s.metaMu.RUnlock()
 	start = cloneBytes(s.Start)
@@ -247,6 +253,7 @@ func (s *routeSlot) snapshotMeta() (start, end []byte, aggregate bool, members [
 	if len(s.MemberRoutes) > 0 {
 		members = append([]uint64(nil), s.MemberRoutes...)
 	}
+	membersTotal = s.MemberRoutesTotal
 	return
 }
 
@@ -263,6 +270,12 @@ type MatrixRow struct {
 	Start, End   []byte
 	Aggregate    bool
 	MemberRoutes []uint64
+	// MemberRoutesTotal is how many distinct route IDs contributed to
+	// this row's counters, including ones that exceeded
+	// MaxMemberRoutesPerSlot and so are NOT listed in MemberRoutes.
+	// Snapshot consumers should treat MemberRoutes as the visible
+	// prefix of this list when MemberRoutesTotal > len(MemberRoutes).
+	MemberRoutesTotal uint64
 
 	Reads      uint64
 	Writes     uint64
@@ -379,9 +392,10 @@ func (s *MemSampler) RegisterRoute(routeID uint64, start, end []byte) bool {
 		slot := s.reclaimRetiredSlot(routeID)
 		if slot == nil {
 			slot = &routeSlot{
-				RouteID: routeID,
-				Start:   cloneBytes(start),
-				End:     cloneBytes(end),
+				RouteID:           routeID,
+				Start:             cloneBytes(start),
+				End:               cloneBytes(end),
+				MemberRoutesTotal: 1,
 			}
 		} else {
 			// Re-registering the same routeID inside the grace window:
@@ -394,6 +408,7 @@ func (s *MemSampler) RegisterRoute(routeID uint64, start, end []byte) bool {
 			slot.metaMu.Lock()
 			slot.Start = cloneBytes(start)
 			slot.End = cloneBytes(end)
+			slot.MemberRoutesTotal = 1
 			slot.metaMu.Unlock()
 		}
 		next.slots[routeID] = slot
@@ -410,11 +425,12 @@ func (s *MemSampler) RegisterRoute(routeID uint64, start, end []byte) bool {
 	bucket := findVirtualBucket(next.sortedSlots, start)
 	if bucket == nil {
 		bucket = &routeSlot{
-			RouteID:      s.nextVirtualBucketID(),
-			Start:        cloneBytes(start),
-			End:          cloneBytes(end),
-			Aggregate:    true,
-			MemberRoutes: []uint64{routeID},
+			RouteID:           s.nextVirtualBucketID(),
+			Start:             cloneBytes(start),
+			End:               cloneBytes(end),
+			Aggregate:         true,
+			MemberRoutes:      []uint64{routeID},
+			MemberRoutesTotal: 1,
 		}
 		next.sortedSlots = appendSorted(next.sortedSlots, bucket)
 	} else {
@@ -443,9 +459,11 @@ func (s *MemSampler) RegisterRoute(routeID uint64, start, end []byte) bool {
 // the routeID is not added to the visible member list.
 func (s *MemSampler) foldIntoBucket(next *routeTable, bucket *routeSlot, routeID uint64, start, end []byte) {
 	bucket.metaMu.Lock()
-	if !memberRoutesContains(bucket.MemberRoutes, routeID) &&
-		len(bucket.MemberRoutes) < s.opts.MaxMemberRoutesPerSlot {
-		bucket.MemberRoutes = append(bucket.MemberRoutes, routeID)
+	if !memberRoutesContains(bucket.MemberRoutes, routeID) {
+		bucket.MemberRoutesTotal++
+		if len(bucket.MemberRoutes) < s.opts.MaxMemberRoutesPerSlot {
+			bucket.MemberRoutes = append(bucket.MemberRoutes, routeID)
+		}
 	}
 	if len(end) == 0 || (len(bucket.End) != 0 && bytesGT(end, bucket.End)) {
 		bucket.End = cloneBytes(end)
@@ -703,17 +721,26 @@ func bucketStillReferenced(virtualForRoute map[uint64]*routeSlot, bucket *routeS
 
 // pruneMemberRoute removes routeID from bucket.MemberRoutes under the
 // bucket's metaMu so a concurrent snapshotMeta reader sees a
-// consistent view.
+// consistent view. MemberRoutesTotal is decremented when the routeID
+// was visible in MemberRoutes (the only case we can confidently
+// account for) — routes pruned past the visible cap stay in the
+// total because we don't track individual past-cap members.
 func pruneMemberRoute(bucket *routeSlot, routeID uint64) {
 	bucket.metaMu.Lock()
 	defer bucket.metaMu.Unlock()
 	filtered := bucket.MemberRoutes[:0]
+	removed := false
 	for _, m := range bucket.MemberRoutes {
-		if m != routeID {
-			filtered = append(filtered, m)
+		if m == routeID {
+			removed = true
+			continue
 		}
+		filtered = append(filtered, m)
 	}
 	bucket.MemberRoutes = filtered
+	if removed && bucket.MemberRoutesTotal > 0 {
+		bucket.MemberRoutesTotal--
+	}
 }
 
 // Step returns the configured flush interval after applying default
@@ -739,17 +766,18 @@ func appendDrainedRow(rows []MatrixRow, slot *routeSlot) []MatrixRow {
 	if reads == 0 && writes == 0 && readBytes == 0 && writeBytes == 0 {
 		return rows
 	}
-	start, end, aggregate, members := slot.snapshotMeta()
+	start, end, aggregate, members, membersTotal := slot.snapshotMeta()
 	return append(rows, MatrixRow{
-		RouteID:      slot.RouteID,
-		Start:        start,
-		End:          end,
-		Aggregate:    aggregate,
-		MemberRoutes: members,
-		Reads:        reads,
-		Writes:       writes,
-		ReadBytes:    readBytes,
-		WriteBytes:   writeBytes,
+		RouteID:           slot.RouteID,
+		Start:             start,
+		End:               end,
+		Aggregate:         aggregate,
+		MemberRoutes:      members,
+		MemberRoutesTotal: membersTotal,
+		Reads:             reads,
+		Writes:            writes,
+		ReadBytes:         readBytes,
+		WriteBytes:        writeBytes,
 	})
 }
 

--- a/keyviz/sampler_test.go
+++ b/keyviz/sampler_test.go
@@ -916,6 +916,94 @@ func TestMemberRoutesCappedAtConfiguredCap(t *testing.T) {
 	if agg.Reads != 8 {
 		t.Fatalf("bucket Reads = %d, want 8 (counters must absorb traffic past cap)", agg.Reads)
 	}
+	if agg.MemberRoutesTotal != 8 {
+		t.Fatalf("MemberRoutesTotal = %d, want 8 (true count of contributors past cap)", agg.MemberRoutesTotal)
+	}
+}
+
+// TestPastCapMemberRejoinDoesNotInflateTotal pins Codex round-2 P2
+// on PR #646: re-registering a hidden (past-cap) routeID inside the
+// prune grace must not double-count MemberRoutesTotal. The hidden
+// member set serves as dedup so route_count stays truthful across
+// remove/re-register churn for routes the visible MemberRoutes list
+// never carried.
+func TestPastCapMemberRejoinDoesNotInflateTotal(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestSampler(t, MemSamplerOptions{
+		Step:                   time.Second,
+		HistoryColumns:         4,
+		MaxTrackedRoutes:       1,
+		MaxMemberRoutesPerSlot: 1, // visible cap=1; routes 3+4 land in hidden set
+	})
+	mustRegister(t, s, 1, "a", "b")
+	if s.RegisterRoute(2, []byte("c"), []byte("d")) {
+		t.Fatal("route 2 should fold (visible)")
+	}
+	if s.RegisterRoute(3, []byte("e"), []byte("f")) {
+		t.Fatal("route 3 should fold (hidden — past cap)")
+	}
+	if s.RegisterRoute(4, []byte("g"), []byte("h")) {
+		t.Fatal("route 4 should fold (hidden — past cap)")
+	}
+	s.Observe(2, OpRead, 0, 0)
+	s.Flush()
+	beforeTotal := findAggregateRow(t, lastSnapshotColumn(t, s).Rows).MemberRoutesTotal
+	if beforeTotal != 3 {
+		t.Fatalf("baseline MemberRoutesTotal = %d, want 3", beforeTotal)
+	}
+	// Remove the past-cap route 3 and re-register it inside the prune
+	// grace. Without the hidden-member dedup foldIntoBucket would
+	// increment MemberRoutesTotal again, drifting route_count up.
+	s.RemoveRoute(3)
+	if s.RegisterRoute(3, []byte("e"), []byte("f")) {
+		t.Fatal("route 3 should fold again")
+	}
+	s.Observe(2, OpRead, 0, 0)
+	s.Flush()
+	afterTotal := findAggregateRow(t, lastSnapshotColumn(t, s).Rows).MemberRoutesTotal
+	if afterTotal != 3 {
+		t.Fatalf("after remove+re-register, MemberRoutesTotal = %d, want 3 (no drift)", afterTotal)
+	}
+}
+
+// TestPastCapMemberPruneDecrementsTotal pins the other half of Codex
+// round-2 P2: when grace expires for a hidden (past-cap) member, the
+// prune must decrement MemberRoutesTotal — otherwise route_count
+// stays inflated even after the route is fully retired.
+func TestPastCapMemberPruneDecrementsTotal(t *testing.T) {
+	t.Parallel()
+	s, clk := newTestSampler(t, MemSamplerOptions{
+		Step:                   time.Second,
+		HistoryColumns:         8,
+		MaxTrackedRoutes:       1,
+		MaxMemberRoutesPerSlot: 1,
+	})
+	mustRegister(t, s, 1, "a", "b")
+	if s.RegisterRoute(2, []byte("c"), []byte("d")) {
+		t.Fatal("route 2 should fold (visible)")
+	}
+	if s.RegisterRoute(3, []byte("e"), []byte("f")) {
+		t.Fatal("route 3 should fold (hidden — past cap)")
+	}
+	s.Observe(2, OpRead, 0, 0)
+	s.Flush()
+	require := func(want uint64, ctx string) {
+		t.Helper()
+		s.Observe(2, OpRead, 0, 0)
+		s.Flush()
+		got := findAggregateRow(t, lastSnapshotColumn(t, s).Rows).MemberRoutesTotal
+		if got != want {
+			t.Fatalf("%s: MemberRoutesTotal = %d, want %d", ctx, got, want)
+		}
+	}
+	require(2, "baseline")
+	s.RemoveRoute(3) // hidden member — pendingPrune queued
+	clk.Advance(s.graceWindow() + time.Second)
+	// First flush past grace: drains the bucket (snapshot still
+	// shows Total=2) THEN fires the pending prune. The next flush is
+	// the first one whose drain reflects the post-prune state.
+	require(2, "drain runs before prune fires")
+	require(1, "after past-cap prune fires")
 }
 
 // TestRetiredTailClearedAfterDrop pins Codex round-7 P2: after a


### PR DESCRIPTION
## Summary

- Implements `AdminServer.GetKeyVizMatrix` against the proto declared in `proto/admin.proto` (already generated; no proto edits).
- New narrow `KeyVizSampler` interface in the adapter package (just `Snapshot(from, to time.Time) []keyviz.MatrixColumn`), so production wires `*keyviz.MemSampler` while tests pass an in-memory fake.
- `AdminServer.RegisterSampler` mirrors `RegisterGroup`. Without it, `GetKeyVizMatrix` returns `codes.Unavailable` so callers can distinguish "keyviz disabled on this node" from "no data yet" (which is a successful empty response).
- Pivots the column-major `MatrixColumn` slice into the row-major proto layout: one `KeyVizRow` per `RouteID` with values aligned to a parallel `column_unix_ms` slice. `KeyVizSeries` selection picks the matching per-row counter; `UNSPECIFIED` defaults to `Reads`.
- `bucket_id` encodes `route:<id>` for individual slots and `virtual:<syntheticID>` for aggregate buckets. Aggregate rows carry `MemberRoutes` verbatim through `route_ids` and `route_count`.

Implements the read-side half of `docs/admin_ui_key_visualizer_design.md` §5.2 / §6. The dispatch-side `Observe` wiring is in #645.

## Test plan

- [x] `TestGetKeyVizMatrixReturnsUnavailableWhenSamplerNotRegistered` — verifies `codes.Unavailable` when no sampler registered.
- [x] `TestGetKeyVizMatrixPivotsColumnsToRows` — two-column / two-route fixture, verifies the missing-row-becomes-zero contract.
- [x] `TestGetKeyVizMatrixSeriesSelection` — table-driven across all five enum values including `UNSPECIFIED` defaulting to `Reads`.
- [x] `TestGetKeyVizMatrixEncodesAggregateBucket` — virtual bucket layout (`bucket_id` prefix, `aggregate=true`, `route_ids`, `route_count`).
- [x] `go test -race -count=1 -run TestGetKeyVizMatrix ./adapter/...` clean.
- [x] `golangci-lint run ./adapter/...` clean.
