### PR TITLE
feat(kv): observe lease + linearizable reads via keyviz Sampler

### DIFF
--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -750,11 +750,11 @@ func (c *ShardedCoordinator) RaftLeaderForKey(key []byte) string {
 }
 
 func (c *ShardedCoordinator) LinearizableReadForKey(ctx context.Context, key []byte) (uint64, error) {
-	g, ok := c.groupForKey(key)
+	routeID, g, ok := c.routeAndGroupForKey(key)
 	if !ok {
 		return 0, errors.WithStack(ErrLeaderNotFound)
 	}
-	c.observeReadKey(key)
+	c.observeRead(routeID, len(key))
 	return linearizableReadEngineCtx(ctx, engineForGroup(g))
 }
 
@@ -772,11 +772,11 @@ func (c *ShardedCoordinator) LeaseRead(ctx context.Context) (uint64, error) {
 // Each group maintains its own lease since each group has independent
 // leadership and term.
 func (c *ShardedCoordinator) LeaseReadForKey(ctx context.Context, key []byte) (uint64, error) {
-	g, ok := c.groupForKey(key)
+	routeID, g, ok := c.routeAndGroupForKey(key)
 	if !ok {
 		return 0, errors.WithStack(ErrLeaderNotFound)
 	}
-	c.observeReadKey(key)
+	c.observeRead(routeID, len(key))
 	return groupLeaseRead(ctx, g, c.leaseObserver)
 }
 
@@ -836,6 +836,24 @@ func (c *ShardedCoordinator) groupForKey(key []byte) (*ShardGroup, bool) {
 	}
 	g, ok := c.groups[route.GroupID]
 	return g, ok
+}
+
+// routeAndGroupForKey is groupForKey + the resolved RouteID. Read
+// entry points that observe into keyviz call this so the GetRoute
+// lookup runs once instead of twice (Gemini round-1 nit on PR #661).
+// Leadership-only callers (IsLeaderForKey / VerifyLeaderForKey /
+// RaftLeaderForKey) keep using groupForKey because they don't need
+// the route ID.
+func (c *ShardedCoordinator) routeAndGroupForKey(key []byte) (uint64, *ShardGroup, bool) {
+	route, ok := c.engine.GetRoute(routeKey(key))
+	if !ok {
+		return 0, nil, false
+	}
+	g, ok := c.groups[route.GroupID]
+	if !ok {
+		return 0, nil, false
+	}
+	return route.RouteID, g, true
 }
 
 func (c *ShardedCoordinator) engineGroupIDForKey(key []byte) uint64 {
@@ -990,29 +1008,26 @@ func (c *ShardedCoordinator) observeMutation(routeID uint64, mut *pb.Mutation) {
 	c.sampler.Observe(routeID, keyviz.OpWrite, len(mut.Key), len(mut.Value))
 }
 
-// observeReadKey records a single linearizable / lease read against
-// the route that owns key. valueLen is always 0 here — the consistency
-// check at this layer doesn't fetch data; the actual GetAt on the
-// store happens further down the stack and isn't observed yet.
+// observeRead records a single linearizable / lease read against the
+// route. valueLen is always 0 here — the consistency check at this
+// layer doesn't fetch data; the actual GetAt on the store happens
+// further down the stack and isn't observed yet.
 //
-// Caller must have already passed groupForKey(key) so the GetRoute
-// lookup almost always hits in the table — keeping it inside this
-// helper keeps observeReadKey nil-safe at the lookup level too:
-// keyviz disabled → single branch, no map lookup.
+// Callers MUST pass an already-resolved routeID (via
+// routeAndGroupForKey) so the GetRoute lookup runs once across the
+// dispatch path — repeating it here just to compute routeID would
+// double the per-read overhead when sampling is enabled
+// (Gemini round-1 nit on PR #661).
 //
 // Adapter-direct read paths (Redis / DynamoDB / S3 hitting
 // MVCCStore.GetAt without going through the coordinator) still
 // bypass keyviz; sampling those is task B in the design's Phase 2
 // follow-up.
-func (c *ShardedCoordinator) observeReadKey(key []byte) {
+func (c *ShardedCoordinator) observeRead(routeID uint64, keyLen int) {
 	if c.sampler == nil {
 		return
 	}
-	route, ok := c.engine.GetRoute(routeKey(key))
-	if !ok {
-		return
-	}
-	c.sampler.Observe(route.RouteID, keyviz.OpRead, len(key), 0)
+	c.sampler.Observe(routeID, keyviz.OpRead, keyLen, 0)
 }
 
 func (c *ShardedCoordinator) groupMutations(reqs []*Elem[OP]) (map[uint64][]*pb.Mutation, []uint64, error) {

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -754,6 +754,7 @@ func (c *ShardedCoordinator) LinearizableReadForKey(ctx context.Context, key []b
 	if !ok {
 		return 0, errors.WithStack(ErrLeaderNotFound)
 	}
+	c.observeReadKey(key)
 	return linearizableReadEngineCtx(ctx, engineForGroup(g))
 }
 
@@ -775,6 +776,7 @@ func (c *ShardedCoordinator) LeaseReadForKey(ctx context.Context, key []byte) (u
 	if !ok {
 		return 0, errors.WithStack(ErrLeaderNotFound)
 	}
+	c.observeReadKey(key)
 	return groupLeaseRead(ctx, g, c.leaseObserver)
 }
 
@@ -975,23 +977,42 @@ func (c *ShardedCoordinator) txnLogs(reqs *OperationGroup[OP]) ([]*pb.Request, e
 	return buildTxnLogs(reqs.StartTS, commitTS, grouped, gids)
 }
 
-// observeMutation: reads never reach this path; the early return
-// keeps the disabled-keyviz hot path allocation-free. Counted
-// pre-commit, so a mutation that subsequently fails its Raft
-// proposal is still recorded — the heatmap reflects offered load,
-// not just committed writes (intentional for traffic visualisation).
-//
-// TODO(keyviz Phase 2): the design (§5.1, §10) calls for read
-// sampling on the node that serves the read (LeaseRead /
-// LinearizableRead / follower reads). Until that wiring lands the
-// matrix's Reads / ReadBytes series stay zero. Tracked as a Phase-2
-// milestone in docs/admin_ui_key_visualizer_design.md — not a
-// regression for the writes-first slice this method covers.
+// observeMutation: counted pre-commit, so a mutation that subsequently
+// fails its Raft proposal is still recorded — the heatmap reflects
+// offered load, not just committed writes (intentional for traffic
+// visualisation). The early return keeps the disabled-keyviz hot
+// path allocation-free. Reads have their own observeReadKey helper
+// (LinearizableReadForKey / LeaseReadForKey).
 func (c *ShardedCoordinator) observeMutation(routeID uint64, mut *pb.Mutation) {
 	if c.sampler == nil {
 		return
 	}
 	c.sampler.Observe(routeID, keyviz.OpWrite, len(mut.Key), len(mut.Value))
+}
+
+// observeReadKey records a single linearizable / lease read against
+// the route that owns key. valueLen is always 0 here — the consistency
+// check at this layer doesn't fetch data; the actual GetAt on the
+// store happens further down the stack and isn't observed yet.
+//
+// Caller must have already passed groupForKey(key) so the GetRoute
+// lookup almost always hits in the table — keeping it inside this
+// helper keeps observeReadKey nil-safe at the lookup level too:
+// keyviz disabled → single branch, no map lookup.
+//
+// Adapter-direct read paths (Redis / DynamoDB / S3 hitting
+// MVCCStore.GetAt without going through the coordinator) still
+// bypass keyviz; sampling those is task B in the design's Phase 2
+// follow-up.
+func (c *ShardedCoordinator) observeReadKey(key []byte) {
+	if c.sampler == nil {
+		return
+	}
+	route, ok := c.engine.GetRoute(routeKey(key))
+	if !ok {
+		return
+	}
+	c.sampler.Observe(route.RouteID, keyviz.OpRead, len(key), 0)
 }
 
 func (c *ShardedCoordinator) groupMutations(reqs []*Elem[OP]) (map[uint64][]*pb.Mutation, []uint64, error) {

--- a/kv/sharded_coordinator_sampler_test.go
+++ b/kv/sharded_coordinator_sampler_test.go
@@ -151,3 +151,73 @@ func TestShardedCoordinatorWithoutSamplerStaysSafe(t *testing.T) {
 		})
 	}
 }
+
+// TestShardedCoordinatorObservesLeaseAndLinearizableReads pins the
+// read-side wiring: LeaseReadForKey and LinearizableReadForKey each
+// produce one Observe(routeID, OpRead, len(key), 0) call. valueLen
+// is always zero at this layer because the consistency check doesn't
+// fetch data — the actual GetAt happens further down the stack and
+// is sampled separately (Phase 2 follow-up for adapter direct reads).
+func TestShardedCoordinatorObservesLeaseAndLinearizableReads(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	engine := distribution.NewEngine()
+	engine.UpdateRoute([]byte("a"), nil, 1)
+
+	s1 := store.NewMVCCStore()
+	r1, stop1 := newSingleRaft(t, "kv-sampler-read", NewKvFSMWithHLC(s1, NewHLC()))
+	t.Cleanup(stop1)
+	groups := map[uint64]*ShardGroup{
+		1: {Engine: r1, Store: s1, Txn: NewLeaderProxyWithEngine(r1)},
+	}
+	rec := &recordingSampler{}
+	coord := NewShardedCoordinator(engine, groups, 1, NewHLC(), NewShardStore(engine, groups)).WithSampler(rec)
+
+	key := []byte("hot-key")
+	_, err := coord.LinearizableReadForKey(ctx, key)
+	require.NoError(t, err)
+	_, err = coord.LeaseReadForKey(ctx, key)
+	require.NoError(t, err)
+
+	calls := rec.snapshot()
+	require.Len(t, calls, 2, "expected one Observe per read entry")
+	route, ok := engine.GetRoute(routeKey(key))
+	require.True(t, ok)
+	want := sampleCall{
+		routeID:  route.RouteID,
+		op:       keyviz.OpRead,
+		keyLen:   len(key),
+		valueLen: 0,
+	}
+	require.Equal(t, want, calls[0])
+	require.Equal(t, want, calls[1])
+}
+
+// TestShardedCoordinatorSkipsObserveForLeadershipChecks pins the
+// negative contract: leadership-only entries (IsLeaderForKey,
+// VerifyLeaderForKey, RaftLeaderForKey) MUST NOT produce read
+// observations — they don't represent user-facing data reads, just
+// internal routing checks.
+func TestShardedCoordinatorSkipsObserveForLeadershipChecks(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	engine.UpdateRoute([]byte("a"), nil, 1)
+
+	s1 := store.NewMVCCStore()
+	r1, stop1 := newSingleRaft(t, "kv-sampler-leadership", NewKvFSMWithHLC(s1, NewHLC()))
+	t.Cleanup(stop1)
+	groups := map[uint64]*ShardGroup{
+		1: {Engine: r1, Store: s1, Txn: NewLeaderProxyWithEngine(r1)},
+	}
+	rec := &recordingSampler{}
+	coord := NewShardedCoordinator(engine, groups, 1, NewHLC(), NewShardStore(engine, groups)).WithSampler(rec)
+
+	key := []byte("k")
+	_ = coord.IsLeaderForKey(key)
+	_ = coord.VerifyLeaderForKey(key)
+	_ = coord.RaftLeaderForKey(key)
+
+	require.Empty(t, rec.snapshot(), "leadership checks must not produce read samples")
+}


### PR DESCRIPTION
## Summary

Wires read sampling into the shard coordinator's two key-routed read entry points so the heatmap's `Reads` / `ReadBytes` series get populated (design §5.1: "Reads are sampled by the node that actually serves the read"). Mirrors the write-side `observeMutation` wiring; both feed the same `keyviz.Sampler` the coordinator already holds.

- New `observeReadKey` helper, called from `LinearizableReadForKey` and `LeaseReadForKey` after the route is resolved.
- `valueLen` is always 0 at this layer — the consistency check doesn't fetch data; the actual `MVCCStore.GetAt` happens further down the stack and is sampled separately. Adapter direct-read paths (Redis / DynamoDB / S3 hitting `MVCCStore.GetAt` without going through the coordinator) still bypass keyviz; sampling those is a future slice — see the `observeReadKey` doc comment.
- Leadership-check entries (`IsLeaderForKey`, `VerifyLeaderForKey`, `RaftLeaderForKey`) intentionally do NOT call `observeReadKey` — they're internal routing checks, not user-facing data reads.

Closes the read-side gap noted on the `observeMutation` Phase-2 TODO. The matrix's `Reads` and `ReadBytes` series are no longer permanently zero.

## Test plan

- [x] `TestShardedCoordinatorObservesLeaseAndLinearizableReads` — drives one of each through a real raft + store, asserts exactly one `Observe(routeID, OpRead, len(key), 0)` per call.
- [x] `TestShardedCoordinatorSkipsObserveForLeadershipChecks` — pins the negative contract that the three leadership checks stay silent.
- [x] `go test -race -count=1 -run TestShardedCoordinator ./kv/...` clean.
- [x] `golangci-lint run ./kv/...` clean.
