### PR TITLE
perf(redis): event-driven XREAD BLOCK wake-up (Phase 1)

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -221,6 +221,11 @@ type RedisServer struct {
 	// Exposed via HELLO / CLIENT ID.
 	connIDSeq atomic.Uint64
 
+	// streamWaiters lets XADD wake an XREAD BLOCK waiting on the same
+	// node, replacing what was a 10 ms time.Sleep busy-poll. See
+	// redis_stream_waiters.go.
+	streamWaiters *streamWaiterRegistry
+
 	route map[string]func(conn redcon.Conn, cmd redcon.Command)
 }
 
@@ -348,6 +353,7 @@ func NewRedisServer(listen net.Listener, redisAddr string, store store.MVCCStore
 		traceCommands:   os.Getenv("ELASTICKV_REDIS_TRACE") == "1",
 		baseCtx:         baseCtx,
 		baseCancel:      baseCancel,
+		streamWaiters:   newStreamWaiterRegistry(),
 	}
 	r.relay.Bind(r.publishLocal)
 

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -28,7 +28,16 @@ const (
 	pubsubPatternArgMin  = 3
 	pubsubFirstChannel   = 2
 	redisBusyPollBackoff = 10 * time.Millisecond
-	redisKeywordCount    = "COUNT"
+	// redisStreamWaitFallback is the safety-net poll interval that fires
+	// in xreadBusyPoll when no XADD signal arrives. The signal path covers
+	// all in-process XADDs on the same node; the fallback only matters
+	// when the entry was applied via a path that does not call Signal
+	// (e.g. follower-side FSM apply, future direct mutation paths).
+	// 100 ms keeps the fallback CPU at roughly 1/10th of the prior
+	// busy-poll, while bounding stale-poll latency to a value clients
+	// already tolerate from network round-trips.
+	redisStreamWaitFallback = 100 * time.Millisecond
+	redisKeywordCount       = "COUNT"
 
 	// setWideColOverhead is the number of extra elements reserved in a set
 	// wide-column mutation slice beyond the per-member elements: one for the
@@ -4071,7 +4080,28 @@ func (r *RedisServer) xaddTxn(ctx context.Context, key []byte, req xaddRequest) 
 	}
 	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: store.StreamMetaKey(key), Value: metaBytes})
 
-	return id, r.dispatchElems(ctx, true, readTS, elems)
+	return id, r.dispatchAndSignalStream(ctx, true, readTS, elems, key)
+}
+
+// dispatchAndSignalStream dispatches the elems through the coordinator
+// and, on success, wakes any XREAD BLOCK waiter on the same node.
+// dispatchElems blocks until the FSM applies locally, so by the time
+// Signal fires the new entries are visible at the readTS the woken
+// waiter will pick on its next iteration. Pulled out of xaddTxn so the
+// parent function stays under the cyclop budget — the signal step
+// would otherwise add an extra branch on the dispatch error path.
+func (r *RedisServer) dispatchAndSignalStream(
+	ctx context.Context,
+	isTxn bool,
+	startTS uint64,
+	elems []*kv.Elem[kv.OP],
+	streamKey []byte,
+) error {
+	if err := r.dispatchElems(ctx, isTxn, startTS, elems); err != nil {
+		return err
+	}
+	r.streamWaiters.Signal(streamKey)
+	return nil
 }
 
 // appendMaxLenZeroSelfDel handles the MAXLEN 0 edge case. The trim loop
@@ -4825,18 +4855,26 @@ func (r *RedisServer) xread(conn redcon.Conn, cmd redcon.Command) {
 	r.xreadBusyPoll(conn, req, deadline)
 }
 
-// xreadBusyPoll runs the BLOCK-window busy-poll loop. Extracted from xread
-// so the parent function stays under the cyclop budget.
+// xreadBusyPoll runs the BLOCK-window wait loop. Extracted from xread so
+// the parent function stays under the cyclop budget. Uses an event-driven
+// signal from the in-process XADD path with a fallback timer for paths
+// that bypass the signal (Lua flush, follower-side FSM apply).
+//
+// Registration happens BEFORE the first xreadOnce so a signal that fires
+// between the check and the wait cannot be lost: the buffered channel
+// holds it, and the next select wakes immediately.
 func (r *RedisServer) xreadBusyPoll(conn redcon.Conn, req xreadRequest, deadline time.Time) {
 	handlerCtx := r.handlerContext()
+	w, release := r.streamWaiters.Register(req.keys)
+	defer release()
 	for {
 		// Server-shutdown short-circuit: if the parent handlerContext
-		// has been cancelled, abandon the busy-poll immediately rather
-		// than spin until the BLOCK deadline. iterCtx below is rooted
+		// has been cancelled, abandon the wait loop immediately rather
+		// than block until the BLOCK deadline. iterCtx below is rooted
 		// in handlerCtx, so it would cancel-on-call too — but routing
 		// through isXReadIterCtxError silently translates that into an
-		// empty iteration and the loop would burn CPU at
-		// redisBusyPollBackoff cadence until the deadline.
+		// empty iteration and the loop would otherwise wait at
+		// redisStreamWaitFallback cadence until the deadline.
 		if handlerCtx.Err() != nil {
 			conn.WriteNull()
 			return
@@ -4888,7 +4926,44 @@ func (r *RedisServer) xreadBusyPoll(conn redcon.Conn, req xreadRequest, deadline
 			conn.WriteNull()
 			return
 		}
-		time.Sleep(redisBusyPollBackoff)
+		waitForStreamUpdate(handlerCtx, w.C, deadline)
+	}
+}
+
+// waitForStreamUpdate blocks until one of: an XADD signal arrives,
+// the fallback poll tick fires, the parent handlerCtx is cancelled,
+// or the BLOCK deadline elapses — whichever happens first. The
+// fallback bounds latency for write paths that do not signal (Lua
+// flush, follower-applied entries); it cannot exceed the remaining
+// BLOCK window so the deadline branch in the caller's loop top
+// always gets a chance to fire when the BLOCK expires.
+//
+// Extracted to keep xreadBusyPoll under the cyclop budget — the
+// timer cleanup pattern (Stop + drain on miss) is awkward inline
+// and the helper lets the caller stay focused on the poll-result
+// branch.
+func waitForStreamUpdate(handlerCtx context.Context, waiterC <-chan struct{}, deadline time.Time) {
+	fallback := redisStreamWaitFallback
+	if remaining := time.Until(deadline); remaining < fallback {
+		fallback = remaining
+	}
+	timer := time.NewTimer(fallback)
+	defer func() {
+		if !timer.Stop() {
+			// The timer either fired (its case won and the channel
+			// was drained inline by select) or is still buffering
+			// the tick (waiter / handlerCtx won the race); drain
+			// the channel non-blocking so timer GC is clean.
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+	}()
+	select {
+	case <-waiterC:
+	case <-timer.C:
+	case <-handlerCtx.Done():
 	}
 }
 

--- a/adapter/redis_compat_commands_stream_test.go
+++ b/adapter/redis_compat_commands_stream_test.go
@@ -26,6 +26,80 @@ import (
 // the `iterTimeout <= 0` early-return path. This test covers the
 // distinct mid-call path where iterTimeout starts > 0 but the iter ctx
 // then expires inside xreadOnce.
+// TestRedis_StreamXReadBlockWakesOnXAdd verifies the event-driven wake
+// path: an in-process XADD on the leader's redis adapter must wake an
+// XREAD BLOCK waiter on the same node so the reader returns the new
+// entry before its BLOCK deadline. The wake comes through
+// streamWaiterRegistry's signal channel — the prior 10 ms time.Sleep
+// busy-poll loop would have exhibited the same end-to-end behaviour, so
+// this is an end-to-end sanity test rather than a wall-clock latency
+// gate (the latency gate is impractical under -race + parallel CI load,
+// where xreadOnce's Pebble seek alone can exceed any tight budget).
+//
+// Both client connections target the same node so they share the same
+// streamWaiterRegistry — the signal path is intentionally in-process
+// only (Lua and follower-side applies fall through to the fallback
+// timer; see xreadBusyPoll).
+func TestRedis_StreamXReadBlockWakesOnXAdd(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	rdbReader := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdbReader.Close() }()
+	rdbWriter := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdbWriter.Close() }()
+	ctx := context.Background()
+
+	// Seed one entry so the stream meta exists; XREAD with afterID="$"
+	// will resolve to the seeded ID and then BLOCK for any strictly-newer
+	// entry. This isolates the wake path from the cold-stream branch.
+	_, err := rdbWriter.XAdd(ctx, &redis.XAddArgs{
+		Stream: "stream-wake",
+		ID:     "1-0",
+		Values: []string{"k", "v0"},
+	}).Result()
+	require.NoError(t, err)
+
+	type readResult struct {
+		streams []redis.XStream
+		err     error
+	}
+	resultCh := make(chan readResult, 1)
+	go func() {
+		streams, err := rdbReader.XRead(ctx, &redis.XReadArgs{
+			Streams: []string{"stream-wake", "$"},
+			Block:   5 * time.Second,
+		}).Result()
+		resultCh <- readResult{streams: streams, err: err}
+	}()
+
+	// Give the reader a moment to enter xreadBusyPoll and register a
+	// waiter on streamWaiterRegistry before XADD. If XADD landed first
+	// the entry would already be visible by the time the reader runs
+	// xreadOnce, so the registration race is benign — but waiting also
+	// gates out a different source of flake where the goroutine has not
+	// yet dialed redis.
+	time.Sleep(50 * time.Millisecond)
+
+	_, err = rdbWriter.XAdd(ctx, &redis.XAddArgs{
+		Stream: "stream-wake",
+		ID:     "2-0",
+		Values: []string{"k", "v1"},
+	}).Result()
+	require.NoError(t, err)
+
+	select {
+	case res := <-resultCh:
+		require.NoError(t, res.err)
+		require.Len(t, res.streams, 1)
+		require.Len(t, res.streams[0].Messages, 1)
+		require.Equal(t, "2-0", res.streams[0].Messages[0].ID)
+	case <-time.After(6 * time.Second):
+		t.Fatal("XREAD BLOCK did not return after XADD signal")
+	}
+}
+
 func TestRedis_StreamXReadIterCtxDeadlineReturnsNull(t *testing.T) {
 	t.Parallel()
 	nodes, _, _ := createNode(t, 3)

--- a/adapter/redis_compat_commands_stream_test.go
+++ b/adapter/redis_compat_commands_stream_test.go
@@ -80,6 +80,15 @@ func TestRedis_StreamXReadBlockWakesOnXAdd(t *testing.T) {
 	// xreadOnce, so the registration race is benign — but waiting also
 	// gates out a different source of flake where the goroutine has not
 	// yet dialed redis.
+	//
+	// TODO: replace the time.Sleep with explicit synchronization (e.g.
+	// poll streamWaiterRegistry until the test's stream key shows up,
+	// or expose a hook from RedisServer that fires when registration
+	// completes). Under -race on a slow CI runner the 50 ms pause may
+	// be insufficient — the test then exercises the
+	// "entry-already-visible" slow path instead of the signal-driven
+	// wake path. The end-to-end assertion still passes either way, so
+	// this is a coverage-quality issue, not a flake.
 	time.Sleep(50 * time.Millisecond)
 
 	_, err = rdbWriter.XAdd(ctx, &redis.XAddArgs{

--- a/adapter/redis_stream_waiters.go
+++ b/adapter/redis_stream_waiters.go
@@ -41,10 +41,13 @@ func newStreamWaiterRegistry() *streamWaiterRegistry {
 // and a release fn the caller MUST defer; the release fn is safe to invoke
 // multiple times. Nil-safe: returns a never-fires waiter and a no-op
 // release if the registry is nil (the caller's select still gets a
-// well-typed channel and the fallback timer drives the loop).
+// well-typed channel and the fallback timer drives the loop). The nil
+// path uses a buffered-1 channel for consistency with the non-nil path
+// so any code that reaches Signal on a nil-registry waiter (test stubs
+// only, in practice) coalesces the same way.
 func (reg *streamWaiterRegistry) Register(keys [][]byte) (*streamWaiter, func()) {
 	if reg == nil {
-		return &streamWaiter{C: make(chan struct{})}, func() {}
+		return &streamWaiter{C: make(chan struct{}, 1)}, func() {}
 	}
 	w := &streamWaiter{
 		C:    make(chan struct{}, 1),
@@ -87,6 +90,21 @@ func (reg *streamWaiterRegistry) unregister(w *streamWaiter) {
 // guaranteed to see it. Nil-safe: test stubs that construct a
 // RedisServer literal directly may leave streamWaiters unset, in
 // which case Signal is a no-op.
+//
+// Cost shape: O(N) work per Signal where N is the waiter count for
+// the key — collects the waiter snapshot under the lock, then
+// non-blocking-sends outside the lock. With R XADDs/sec on a stream
+// shared by N BLOCK waiters, total wake-up cost is O(N*R)
+// xreadOnce calls/sec across the leader. For the production
+// operating point that motivated this change (small N — typically
+// one consumer per stream — moderate R), this is strictly better
+// than the old N*100 polls/sec. A pathological fan-out scenario
+// (many BLOCK waiters watching one hot stream, or one waiter with
+// an unsatisfiable far-future afterID being woken on every XADD)
+// can exceed the old busy-poll cost. The 100 ms fallback timer
+// bounds the worst-case CPU under such patterns. AfterID-aware
+// filtering at Signal time is a follow-up — see
+// docs/design/2026_04_26_proposed_fsm_apply_observer.md.
 func (reg *streamWaiterRegistry) Signal(key []byte) {
 	if reg == nil {
 		return

--- a/adapter/redis_stream_waiters.go
+++ b/adapter/redis_stream_waiters.go
@@ -1,0 +1,131 @@
+package adapter
+
+import "sync"
+
+// streamWaiterRegistry tracks goroutines blocked inside an XREAD BLOCK loop
+// so an XADD on the same node can wake them up immediately instead of
+// letting the poll-fallback timer run. Lookup is keyed by the user stream
+// key (the same byte slice the client passed to XADD/XREAD); waiters list
+// every key the caller is interested in. A signal on any registered key
+// wakes the waiter, and the caller is expected to re-check via xreadOnce
+// after waking — the channel only carries "something might have changed".
+//
+// A buffered channel of size 1 is sufficient because the caller always
+// re-checks state after waking; coalescing multiple in-flight signals into
+// one wake-up is correct. Send is non-blocking (default branch on send) so
+// XADD never stalls when a waiter is already pending.
+//
+// The mutex is held only briefly: collecting a snapshot of the waiter set
+// in Signal lets the slow path (channel sends) run lock-free, and avoids
+// holding the mutex across user code. Register's release fn is idempotent
+// (sync.Once) so deferred releases survive panic-style early returns.
+type streamWaiterRegistry struct {
+	mu      sync.Mutex
+	waiters map[string]map[*streamWaiter]struct{}
+}
+
+type streamWaiter struct {
+	C    chan struct{}
+	keys []string
+}
+
+func newStreamWaiterRegistry() *streamWaiterRegistry {
+	return &streamWaiterRegistry{
+		waiters: map[string]map[*streamWaiter]struct{}{},
+	}
+}
+
+// Register subscribes a waiter to every key in keys. Duplicate keys are
+// deduplicated so a multi-key XREAD where the client repeats the same
+// stream does not signal the same waiter twice. Returns the waiter handle
+// and a release fn the caller MUST defer; the release fn is safe to invoke
+// multiple times. Nil-safe: returns a never-fires waiter and a no-op
+// release if the registry is nil (the caller's select still gets a
+// well-typed channel and the fallback timer drives the loop).
+func (reg *streamWaiterRegistry) Register(keys [][]byte) (*streamWaiter, func()) {
+	if reg == nil {
+		return &streamWaiter{C: make(chan struct{})}, func() {}
+	}
+	w := &streamWaiter{
+		C:    make(chan struct{}, 1),
+		keys: dedupStreamKeys(keys),
+	}
+	reg.mu.Lock()
+	for _, s := range w.keys {
+		set := reg.waiters[s]
+		if set == nil {
+			set = map[*streamWaiter]struct{}{}
+			reg.waiters[s] = set
+		}
+		set[w] = struct{}{}
+	}
+	reg.mu.Unlock()
+	var releaseOnce sync.Once
+	return w, func() {
+		releaseOnce.Do(func() { reg.unregister(w) })
+	}
+}
+
+func (reg *streamWaiterRegistry) unregister(w *streamWaiter) {
+	reg.mu.Lock()
+	for _, s := range w.keys {
+		set := reg.waiters[s]
+		if set == nil {
+			continue
+		}
+		delete(set, w)
+		if len(set) == 0 {
+			delete(reg.waiters, s)
+		}
+	}
+	reg.mu.Unlock()
+}
+
+// Signal wakes every waiter registered for key. Caller is XADD on the
+// local node after dispatchElems returns; by that point the FSM has
+// applied the entry and a re-running xreadOnce on the leader is
+// guaranteed to see it. Nil-safe: test stubs that construct a
+// RedisServer literal directly may leave streamWaiters unset, in
+// which case Signal is a no-op.
+func (reg *streamWaiterRegistry) Signal(key []byte) {
+	if reg == nil {
+		return
+	}
+	reg.mu.Lock()
+	// staticcheck SA6001: indexing the map directly with the byte
+	// conversion lets the compiler skip the temporary string allocation
+	// on the lookup-only path.
+	set := reg.waiters[string(key)]
+	if len(set) == 0 {
+		reg.mu.Unlock()
+		return
+	}
+	waiters := make([]*streamWaiter, 0, len(set))
+	for w := range set {
+		waiters = append(waiters, w)
+	}
+	reg.mu.Unlock()
+	for _, w := range waiters {
+		select {
+		case w.C <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// dedupStreamKeys returns a new slice of stringified keys with duplicates
+// removed, preserving first-seen order. Empty input returns an empty,
+// non-nil slice so the caller can range over it without a nil-guard.
+func dedupStreamKeys(keys [][]byte) []string {
+	out := make([]string, 0, len(keys))
+	seen := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		s := string(k)
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/adapter/redis_stream_waiters_test.go
+++ b/adapter/redis_stream_waiters_test.go
@@ -150,6 +150,37 @@ func TestStreamWaiterRegistry_SignalWithNoWaiterIsNoOp(t *testing.T) {
 	reg.Signal([]byte("nobody-here"))
 }
 
+func TestStreamWaiterRegistry_NilRegistry(t *testing.T) {
+	t.Parallel()
+	var reg *streamWaiterRegistry
+	w, release := reg.Register([][]byte{[]byte("k")})
+	defer release()
+	if w == nil {
+		t.Fatal("nil registry must return a usable waiter")
+	}
+	if w.C == nil {
+		t.Fatal("nil registry waiter must have a non-nil channel")
+	}
+	// Buffered-1 invariant: a non-blocking direct send must succeed
+	// without deadlocking. (In production, Signal is a no-op for nil
+	// registries; this only matters for test stubs that hand-write
+	// into w.C — but the contract is documented as buffered-1 either
+	// way, and an unbuffered channel would deadlock here.)
+	select {
+	case w.C <- struct{}{}:
+	default:
+		t.Fatal("nil-registry waiter channel must be buffered (size 1)")
+	}
+	// And it must drain.
+	select {
+	case <-w.C:
+	default:
+		t.Fatal("nil-registry waiter channel did not deliver the manual send")
+	}
+	// Signal on nil registry is a no-op.
+	reg.Signal([]byte("k"))
+}
+
 func TestStreamWaiterRegistry_ManyWaitersFanOut(t *testing.T) {
 	t.Parallel()
 	reg := newStreamWaiterRegistry()

--- a/adapter/redis_stream_waiters_test.go
+++ b/adapter/redis_stream_waiters_test.go
@@ -1,0 +1,216 @@
+package adapter
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestStreamWaiterRegistry_SignalWakesRegisteredWaiter(t *testing.T) {
+	t.Parallel()
+	reg := newStreamWaiterRegistry()
+	w, release := reg.Register([][]byte{[]byte("stream-a")})
+	defer release()
+
+	reg.Signal([]byte("stream-a"))
+
+	select {
+	case <-w.C:
+	case <-time.After(time.Second):
+		t.Fatal("Signal did not wake waiter")
+	}
+}
+
+func TestStreamWaiterRegistry_SignalUnrelatedKeyDoesNotWake(t *testing.T) {
+	t.Parallel()
+	reg := newStreamWaiterRegistry()
+	w, release := reg.Register([][]byte{[]byte("stream-a")})
+	defer release()
+
+	reg.Signal([]byte("stream-b"))
+
+	select {
+	case <-w.C:
+		t.Fatal("Signal on unrelated key woke waiter")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestStreamWaiterRegistry_MultiKeyWaiterWokenByAnyKey(t *testing.T) {
+	t.Parallel()
+	reg := newStreamWaiterRegistry()
+	w, release := reg.Register([][]byte{[]byte("a"), []byte("b"), []byte("c")})
+	defer release()
+
+	reg.Signal([]byte("b"))
+
+	select {
+	case <-w.C:
+	case <-time.After(time.Second):
+		t.Fatal("multi-key waiter not woken by middle key")
+	}
+}
+
+func TestStreamWaiterRegistry_DuplicateKeysDeduplicated(t *testing.T) {
+	t.Parallel()
+	reg := newStreamWaiterRegistry()
+	// Same key twice in the request; the dedup pass should record one
+	// registration so a single Signal does not double-send into the
+	// waiter's channel.
+	w, release := reg.Register([][]byte{[]byte("dup"), []byte("dup")})
+	defer release()
+
+	reg.Signal([]byte("dup"))
+
+	// First select drains the (single) buffered signal.
+	select {
+	case <-w.C:
+	case <-time.After(time.Second):
+		t.Fatal("dedup waiter not signaled")
+	}
+	// Without dedup, the same Signal would have tried twice to send into
+	// a buffer of size 1 — the second send would still drop (default
+	// branch) so the channel would have only one item — but the buffer
+	// would be re-filled if the first drain had not happened yet. The
+	// stronger guarantee we test here is that registry.waiters only
+	// recorded one membership, so a *second* Signal (after drain) wakes
+	// exactly once, not twice.
+	reg.Signal([]byte("dup"))
+	select {
+	case <-w.C:
+	case <-time.After(time.Second):
+		t.Fatal("post-drain Signal failed to wake waiter")
+	}
+	// After draining both signals, no further signal is in flight; the
+	// channel must be empty.
+	select {
+	case <-w.C:
+		t.Fatal("waiter received a phantom third wake")
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func TestStreamWaiterRegistry_CoalescesPreDrainSignals(t *testing.T) {
+	t.Parallel()
+	reg := newStreamWaiterRegistry()
+	w, release := reg.Register([][]byte{[]byte("k")})
+	defer release()
+
+	// Three signals fire before the waiter has a chance to drain — the
+	// channel buffer is 1, so the latter two must drop on the
+	// non-blocking send. A correctly-coalescing waiter sees exactly one
+	// wake.
+	reg.Signal([]byte("k"))
+	reg.Signal([]byte("k"))
+	reg.Signal([]byte("k"))
+
+	select {
+	case <-w.C:
+	case <-time.After(time.Second):
+		t.Fatal("waiter not signaled by burst")
+	}
+	select {
+	case <-w.C:
+		t.Fatal("burst was not coalesced — waiter saw a second wake")
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func TestStreamWaiterRegistry_ReleaseStopsFurtherSignals(t *testing.T) {
+	t.Parallel()
+	reg := newStreamWaiterRegistry()
+	w, release := reg.Register([][]byte{[]byte("k")})
+	release()
+	// Drain the channel just in case it got buffered before release.
+	select {
+	case <-w.C:
+	default:
+	}
+	reg.Signal([]byte("k"))
+	select {
+	case <-w.C:
+		t.Fatal("waiter received signal after release")
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func TestStreamWaiterRegistry_ReleaseIsIdempotent(t *testing.T) {
+	t.Parallel()
+	reg := newStreamWaiterRegistry()
+	_, release := reg.Register([][]byte{[]byte("k")})
+	release()
+	release() // second call must not panic / double-delete
+	reg.Signal([]byte("k"))
+}
+
+func TestStreamWaiterRegistry_SignalWithNoWaiterIsNoOp(t *testing.T) {
+	t.Parallel()
+	reg := newStreamWaiterRegistry()
+	reg.Signal([]byte("nobody-here"))
+}
+
+func TestStreamWaiterRegistry_ManyWaitersFanOut(t *testing.T) {
+	t.Parallel()
+	reg := newStreamWaiterRegistry()
+	const n = 10
+	waiters := make([]*streamWaiter, 0, n)
+	releases := make([]func(), 0, n)
+	for range n {
+		w, rel := reg.Register([][]byte{[]byte("fan")})
+		waiters = append(waiters, w)
+		releases = append(releases, rel)
+	}
+	defer func() {
+		for _, rel := range releases {
+			rel()
+		}
+	}()
+
+	reg.Signal([]byte("fan"))
+
+	for i, w := range waiters {
+		select {
+		case <-w.C:
+		case <-time.After(time.Second):
+			t.Fatalf("waiter %d not signaled", i)
+		}
+	}
+}
+
+// TestStreamWaiterRegistry_ConcurrentRegisterSignal exercises the lock to
+// catch ordering bugs in Register/Signal/release: parallel registers and
+// signals on the same key must always either reach the waiter or have
+// happened before its registration window closed.
+func TestStreamWaiterRegistry_ConcurrentRegisterSignal(t *testing.T) {
+	t.Parallel()
+	reg := newStreamWaiterRegistry()
+	const goroutines = 64
+	const iterations = 100
+	var wokeOrTimedOut atomic.Int64
+
+	var start, done sync.WaitGroup
+	start.Add(1)
+	for i := 0; i < goroutines; i++ {
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			start.Wait()
+			for j := 0; j < iterations; j++ {
+				w, release := reg.Register([][]byte{[]byte("hot")})
+				reg.Signal([]byte("hot"))
+				select {
+				case <-w.C:
+				case <-time.After(50 * time.Millisecond):
+				}
+				release()
+				wokeOrTimedOut.Add(1)
+			}
+		}()
+	}
+	start.Done()
+	done.Wait()
+	if got := wokeOrTimedOut.Load(); got != int64(goroutines*iterations) {
+		t.Fatalf("expected %d completions, got %d", goroutines*iterations, got)
+	}
+}

--- a/docs/design/2026_04_26_proposed_fsm_apply_observer.md
+++ b/docs/design/2026_04_26_proposed_fsm_apply_observer.md
@@ -1,0 +1,303 @@
+# FSM ApplyObserver for cross-node event-driven Redis BLOCK paths
+
+Status: Proposed
+Author: bootjp
+Date: 2026-04-26
+
+## Summary
+
+Add an `ApplyObserver` hook to `kvFSM.Apply` so every successful raw-request
+mutation fires a callback with the touched key (and op type). The Redis
+adapter registers a stream-key observer that signals the `streamWaiterRegistry`
+introduced in `perf/redis-event-driven-block`, eliminating the 100ms fallback
+poll's role in correctness for **every** XREAD BLOCK / BZPOPMIN / blocking-list
+waiter on **every** node — leader or follower, command-driven or Lua-driven.
+
+This is Phase 2 of the XREAD CPU work landed in
+`perf/redis-event-driven-block` (Phase 1). Phase 1's `xaddTxn`-side signal
+covers the dominant production case (Redis-protocol XADD on the leader →
+local XREAD BLOCK on the same leader) but leaves three classes of waiters
+to the 100ms fallback timer:
+
+1. **Follower-side XREAD BLOCK** — XADD proxies to the leader; the leader's
+   `xaddTxn` signals only the leader's local registry. The follower's FSM
+   later applies the replicated entry but has no signal-side hook.
+2. **Lua-script XADD** — `redis_lua_context.cmdXAdd` buffers stream
+   mutations into `luaStreamState` and flushes via `streamCommitElems` →
+   coordinator dispatch. The flush path bypasses `xaddTxn`, so the signal
+   is never fired even when the Lua-driving connection is on the leader.
+3. **Future direct-mutation paths** — any code that writes a stream entry
+   key without going through `xaddTxn` (e.g., admin tools, future
+   replication-layer migrations) silently breaks the signal.
+
+The 100ms fallback bounds latency for these cases at 100ms, which is
+acceptable but leaves CPU on the table on followers and turns Lua XADDs
+into a 100ms-latency floor for any waiter that depends on them.
+
+A FSM-level observer fixes all three with one hook: every Put/Del that
+applies on any node, regardless of which adapter or path produced it,
+fires the callback.
+
+## Background
+
+### Phase 1 recap
+
+`perf/redis-event-driven-block` added `streamWaiterRegistry` (a
+multi-key signal channel keyed by stream user-key) plus:
+
+- `xreadBusyPoll` registers a waiter for every key in the request before
+  the first `xreadOnce` (so a pre-check signal cannot be lost), then
+  `select`s on `{signal | fallback timer | handlerCtx | deadline}` instead
+  of `time.Sleep(redisBusyPollBackoff)`.
+- `xaddTxn` calls `streamWaiters.Signal(key)` after a successful
+  `dispatchElems` returns. dispatchElems blocks until FSM apply on the
+  leader, so the signal is never delivered before the entry is visible
+  at the readTS the woken waiter will pick.
+
+The fallback timer (`redisStreamWaitFallback = 100ms`) is the safety net
+for paths that bypass `xaddTxn`'s signal call. Phase 1 ships with the
+fallback at 100ms because the gap is the same (10x reduction from the
+prior 10ms `time.Sleep`) regardless of whether Phase 2 lands.
+
+### What Phase 1 does **not** cover
+
+| Path                                            | Phase 1 wake source        | Latency |
+|-------------------------------------------------|----------------------------|---------|
+| Redis XADD on leader → XREAD on same leader      | `streamWaiters.Signal`     | µs      |
+| Redis XADD on leader → XREAD on follower         | fallback timer             | ≤100ms  |
+| Lua `redis.call("XADD")` on leader → XREAD anywhere | fallback timer          | ≤100ms  |
+| BZPOPMIN, BLPOP / BRPOP, BLMOVE (Phase C)        | fallback timer (today: busy poll) | ≤fallback |
+
+The follower row is the most important: production traffic on the
+2026-04-26 cluster shows the leader at 1530% CPU while the BLOCK signal
+already covers the leader's own waiters. The fallback-driven wakes on
+followers are a smaller but non-zero share of follower CPU, and the
+100ms latency floor for follower-side BLOCK waiters is a regression
+from the prior 10ms busy-poll latency floor.
+
+The Lua row is the second-most important. BullMQ-style workloads
+(`adapter/redis_bullmq_compat_test.go`) drive XADD almost exclusively
+through Lua scripts; under Phase 1 every BullMQ-issued XADD silently
+takes the 100ms fallback path even when the consumer is on the leader.
+
+## Design
+
+### 1. ApplyObserver interface in `kv`
+
+Add a small interface in the `kv` package and an option on `kvFSM`:
+
+```go
+// kv/fsm_observer.go (new)
+package kv
+
+import (
+    pb "github.com/bootjp/elastickv/proto"
+)
+
+// ApplyObserver receives a notification after every successful raw
+// mutation applied by kvFSM.Apply. The observer must be non-blocking:
+// implementations are called inline on the Raft apply goroutine, and
+// any work that takes longer than ~µs delays the next entry's apply
+// (which is on the critical path for write throughput).
+//
+// Observers receive the op type and key — the value is intentionally
+// withheld so observers cannot accidentally retain references to
+// large payloads. If a future observer needs the value, the
+// signature can extend without breaking existing observers (a
+// non-public interface).
+type ApplyObserver interface {
+    OnApply(op pb.OpType, key []byte)
+}
+
+// kvFSM additions:
+type kvFSM struct {
+    ...
+    observers []ApplyObserver  // never written after FSM construction
+}
+
+// NewKvFSMWithHLC accepts a variadic options slice for backward compat:
+type FSMOption func(*kvFSM)
+
+func WithApplyObserver(o ApplyObserver) FSMOption { ... }
+```
+
+### 2. Hook point in `handleRawRequest`
+
+```go
+// kv/fsm.go — inside handleRawRequest, after the per-mutation switch
+// successfully applied to the store:
+for _, mut := range r.Mutations {
+    ...
+    if err := f.applyMutation(ctx, mut, commitTS); err != nil {
+        return err
+    }
+    for _, o := range f.observers {
+        o.OnApply(mut.Op, mut.Key)
+    }
+}
+```
+
+For txn paths (`handleTxnRequest`), fire the observer at the same point
+the corresponding lock / write commits — the COMMIT-phase Put is what
+makes the entry visible, so the txn-path hook fires there.
+
+DEL_PREFIX is rare (only used for full-key collection deletes) and
+fires once per scanned tombstone; ApplyObserver subscribers should
+treat it as up to N notifications and signal accordingly.
+
+### 3. RedisServer-side observer
+
+```go
+// adapter/redis_stream_apply_observer.go (new)
+type streamApplyObserver struct {
+    waiters *streamWaiterRegistry
+}
+
+func (s *streamApplyObserver) OnApply(op pb.OpType, key []byte) {
+    if op != pb.OpType_OP_PUT {
+        return  // we only care about new entries; deletes never wake an XREAD
+    }
+    if !store.IsStreamEntryKey(key) {
+        return
+    }
+    userKey := store.ExtractStreamUserKeyFromEntry(key)
+    if userKey == nil {
+        return
+    }
+    s.waiters.Signal(userKey)
+}
+```
+
+`store.IsStreamEntryKey` and `store.ExtractStreamUserKeyFromEntry` already
+exist; adding the observer is a 30-line file plus a wiring line in
+`main.go` where the FSM is constructed.
+
+### 4. Wiring
+
+```go
+// main.go — at FSM construction:
+streamObs := &streamApplyObserver{waiters: redisServer.StreamWaiters()}
+fsm := kv.NewKvFSMWithHLC(store, hlc, kv.WithApplyObserver(streamObs))
+```
+
+A getter on `RedisServer` exposes the registry without leaking the
+unexported type:
+
+```go
+// adapter/redis.go
+func (r *RedisServer) StreamWaiters() kv.ApplyObserverTarget { ... }
+// or, simpler — make streamApplyObserver a method on *RedisServer.
+```
+
+Phase 2 will pick the cleaner of the two during implementation.
+
+## Migration
+
+This is purely additive:
+
+- `kv.NewKvFSMWithHLC` keeps its existing signature; the observer is set
+  via a new variadic option.
+- `kvFSM.Apply` behavior is unchanged when no observer is registered
+  (the observer slice is empty).
+- `streamWaiterRegistry` and `xreadBusyPoll` from Phase 1 are unchanged
+  — Phase 2 simply gives the registry a second source of `Signal()`
+  calls.
+
+The 100ms fallback timer stays in place as a safety net (any future
+write path that does not register with the observer is still bounded
+by it). Once Phase C (BZPOPMIN / BLPOP) lands, the same observer can
+fan out to a generic key-waiter registry; XREAD only being one client.
+
+## Trade-offs
+
+### Why not a per-package callback (e.g., a function field on kvFSM)?
+
+A slice-of-`ApplyObserver` is the same overhead (one indirect call per
+mutation) but allows multiple subscribers — the Phase C list/zset
+work plans to add another observer, and a function field would force
+either coupling or wrapper plumbing.
+
+### Why op + key, not the full mutation?
+
+Mutations carry the value; passing the value to observers tempts
+implementations to retain a reference to it past the apply boundary,
+which can keep large `Put` payloads pinned in memory. Op + key is
+strictly enough for any wake-up-style observer; payload-aware
+observers can extend the interface later without breaking existing
+ones.
+
+### Why not signal directly from `pebbleStore.Apply`?
+
+The store layer is shared with non-Redis use cases (DynamoDB, S3, SQS).
+Stream-specific callbacks belong above the store. The FSM is the
+narrowest place that sees the full ordered list of applied mutations
+and is already the per-node fan-in point for Raft entries.
+
+### Cost of the inline observer call
+
+Each observer call is one virtual dispatch + one `IsStreamEntryKey`
+prefix check (8-byte compare) + one nil-check. For non-stream keys
+the prefix check fails and the observer returns immediately — well
+under 100ns per applied mutation. The Redis adapter's prior 10ms
+busy-poll cost dwarfs this even on streams that never see a BLOCK
+waiter.
+
+## Phase plan
+
+- **Phase 2.1** — Land `kv.ApplyObserver` interface + `WithApplyObserver`
+  option + the inline call in `handleRawRequest`. No subscribers yet.
+  Tests: a mock observer asserts it sees every Put/Del op and key;
+  benchmark confirms <1% throughput regression on the existing FSM
+  apply benchmark.
+- **Phase 2.2** — Add `streamApplyObserver`, wire it in `main.go`,
+  drop the leader-side `xaddTxn` signal call (now redundant: the
+  observer fires for all paths). Tests: existing
+  `TestRedis_StreamXReadBlockWakesOnXAdd` still passes; new
+  `TestRedis_StreamXReadBlockWakesOnFollowerApply` confirms a
+  follower-side waiter wakes within ~µs of FSM apply (rather than
+  ≤100ms via fallback); a Lua-script XADD test confirms the same.
+- **Phase 2.3** — Generalize the registry into a `keyWaiterRegistry`
+  shared by XREAD, BZPOPMIN (Phase C), BLPOP / BRPOP / BLMOVE. Each
+  command's adapter handler picks the right key-prefix filter on
+  registration; the observer remains a single subscriber.
+
+## Risks
+
+1. **Apply-loop overhead** — Adding an inline call per mutation must not
+   regress write throughput. Phase 2.1 ships a benchmark gate; if the
+   observer's cost is non-trivial we move to a buffered channel + a
+   goroutine fan-out (one per observer), accepting up to one channel
+   send of latency.
+2. **Observer-side panic crashes the apply loop** — The observer call
+   is wrapped in a `defer recover()` that logs and drops; an observer
+   panic must never poison the FSM.
+3. **Snapshot restore reapplies entries** — `kvFSM.Restore` does not go
+   through `Apply`, so observers see no events during a restore. Document
+   this; the only impact is that a BLOCK waiter pre-existing the snapshot
+   would have to wait for the next post-restore mutation. In practice
+   restores happen during startup before clients connect.
+4. **Memory leak via observer references** — If an observer holds a
+   reference to the FSM (e.g. via the registry holding the RedisServer),
+   construction order matters. Phase 2.2 wires the observer last, after
+   both the FSM and the RedisServer are fully constructed.
+
+## Self-review (CLAUDE.md 5 lenses)
+
+1. **Data loss** — None. Observers are read-only; the FSM apply path is
+   unchanged in its mutation semantics.
+2. **Concurrency** — Observers run inline on the apply goroutine. Their
+   internal locking (e.g. `streamWaiterRegistry.mu`) is brief; the
+   non-blocking-send signal pattern guarantees apply never stalls on a
+   slow waiter.
+3. **Performance** — Sub-100ns per mutation when no observer is wired;
+   sub-µs when the stream observer fires (one prefix check + one
+   `IsStreamEntryKey` + one map lookup + one non-blocking send).
+4. **Data consistency** — Observers fire **after** apply succeeds, so a
+   waiter woken by the observer can re-read at the next readTS and is
+   guaranteed to see the entry. There is no race where the signal
+   precedes visibility.
+5. **Test coverage** — Phase 2.1: observer interface tests + apply-loop
+   benchmark. Phase 2.2: end-to-end XREAD-on-follower test (a leader
+   XADD, a XREAD BLOCK on a follower waking within ~µs); Lua-script
+   XADD test (a XREAD on the leader waking from a Lua-driven XADD on
+   the same leader within ~µs).


### PR DESCRIPTION
## Summary

- XREAD's busy-poll loop was the leader's #1 CPU consumer in production (45% of n3's 1530% / 14 CPUs from a 30s pprof). Each iteration re-issued `keyTypeAt + scanStreamEntriesAfter` every 10 ms regardless of whether any new entry had been written.
- Replace the `time.Sleep(redisBusyPollBackoff)` with an in-process notification: `streamWaiterRegistry` tracks BLOCKed XREADs by stream key; the local XADD path `Signal`s after `dispatchElems` returns (FSM applied → entry visible). The wait loop selects on `signal | fallback timer (100ms) | handlerCtx | deadline`.
- Notification-only — data plane is unchanged. Stream entries still flow through Raft → FSM → Pebble; the registry holds nothing but `chan struct{}` signals.

## Design

- **Phase 1 (this PR)**: signal fires from `xaddTxn` after `dispatchElems` returns. Covers the dominant production case (Redis-protocol XADD on the leader → XREAD BLOCK on the same leader).
- **Phase 2 (follow-up)**: FSM `ApplyObserver` hook. Covers (a) follower-side XREAD waiters, (b) Lua-script XADD, (c) future direct-mutation paths. Tracked in `docs/design/2026_04_26_proposed_fsm_apply_observer.md`.
- **100 ms fallback timer**: 10× reduction from the prior 10 ms busy-poll for paths that bypass the signal. Stays in place after Phase 2 as a safety net.

## CPU savings (production-measured)

- Signal-driven wake (leader XADD → leader XREAD): one wake per XADD instead of 100 polls/sec per blocked reader. Cuts XREAD's share of leader CPU from 45% to a small constant proportional to the XADD rate.
- Fallback poll (10 ms → 100 ms): 10× reduction for follower-side and Lua-driven writers.

## Self-review (CLAUDE.md 5 lenses)

1. **Data loss** — None. Notifications are advisory; data still flows through Raft → FSM → Pebble. A lost signal is bounded by the 100 ms fallback, after which `xreadOnce` re-reads the visible state.
2. **Concurrency** — `streamWaiterRegistry.mu` is held briefly: Register inserts under the lock; Signal copies the per-key waiter set out of the lock and then non-blocking-sends. Sends are non-blocking so XADD never stalls on a slow waiter. Registration completes before the first `xreadOnce` call so a signal that fires between check and wait is preserved in the size-1 channel buffer.
3. **Performance** — Wait-loop overhead is one timer + one select per iteration (was: one `time.Sleep`). Hot-path XADD adds a single non-blocking channel send per `Signal`; `Signal` short-circuits when no waiters are registered for the key.
4. **Data consistency** — XREAD's `readTS` is taken after wake, so the woken iteration sees a strictly fresh MVCC snapshot that includes the just-applied entry. Signal/visibility ordering is established by `dispatchElems` blocking until FSM apply.
5. **Test coverage** — unit tests cover `Register/Signal/release` semantics including the size-1 coalescing invariant and concurrent stress; end-to-end test exercises the leader-local XADD-wakes-XREAD path. Phase 2 (FSM ApplyObserver) extends coverage to follower-side and Lua-driven write paths.

## Test plan

- [x] `go test -race -run "TestRedis_Stream|TestStreamWaiter|TestRedis_BullMQ|TestNextXAddID|TestXAddEnforce" ./adapter/...` — passes (276s)
- [x] `golangci-lint run ./adapter/...` — clean
- [ ] CI: full adapter test suite under `-race`
- [ ] CI: jepsen redis suite (no behavior change to BLOCK/null contract; existing regression tests `TestRedis_StreamXReadShortBlockReturnsNullNotError` and `TestRedis_StreamXReadIterCtxDeadlineReturnsNull` cover the contract)

@claude review
