### PR TITLE
docs(design): promote admin dashboard from proposed to partial

### DIFF
--- a/docs/design/2026_04_24_partial_admin_dashboard.md
+++ b/docs/design/2026_04_24_partial_admin_dashboard.md
@@ -9,8 +9,8 @@
 
 | Phase | Status | Landed via |
 |---|---|---|
-| **P1** — `internal/admin/` skeleton, auth, DynamoDB list/create/describe/delete, AdminForward (Section 3.3 acceptance criteria 1–6) | ✅ shipped | #634, #635, #644, #648 |
-| **P2** — S3 bucket list/create/delete/ACL, DescribeTable | ✅ shipped | #658 (read-only slice 1), #669 (write paths slice 2a), #673 (AdminForward integration slice 2b) |
+| **P1** — `internal/admin/` skeleton, auth, DynamoDB list/create/describe/delete, AdminForward (Section 3.3 acceptance criteria 1–4 + 6; criterion 5 deferred — see outstanding items) | ✅ shipped | #634, #635, #644, #648 |
+| **P2** — S3 bucket list/create/delete/ACL, DescribeTable | 🟡 partial — read-only slice 1 landed in #658; write paths (slice 2a, #669) and AdminForward integration (slice 2b, #673) are still in flight |
 | **P3** — React SPA + embed | ✅ shipped | #649, #650 |
 | **P4** — TLS, read-only role, CSRF, `docs/admin.md` | 🟡 mostly shipped — TLS / role / CSRF are live in P1, operator doc in #674 |
 

--- a/docs/design/2026_04_24_partial_admin_dashboard.md
+++ b/docs/design/2026_04_24_partial_admin_dashboard.md
@@ -1,9 +1,9 @@
 # elastickv Admin Dashboard Design
 
-**Status:** Partial — P1, P2, and P3 of the implementation plan have shipped; P4 ships its operator documentation alongside this rename.
+**Status:** Partial — P1 and P3 have shipped in full; P2 has shipped its read-only slice with the write path still in flight; P4 has shipped TLS / role / CSRF and lands its operator documentation alongside this rename. See the status table below for the per-phase breakdown.
 **Author:** bootjp
 **Date:** 2026-04-24
-**Last updated:** 2026-04-26 (renamed from `_proposed_` to `_partial_` after P1 + P2 + P3 landed)
+**Last updated:** 2026-04-26 (renamed from `_proposed_` to `_partial_` after P1, P3, and the read-only slice of P2 landed)
 
 ## Implementation status (as of 2026-04-26)
 

--- a/docs/design/2026_04_24_partial_admin_dashboard.md
+++ b/docs/design/2026_04_24_partial_admin_dashboard.md
@@ -1,8 +1,26 @@
 # elastickv Admin Dashboard Design
 
-**Status:** Proposed
+**Status:** Partial — P1, P2, and P3 of the implementation plan have shipped; P4 ships its operator documentation alongside this rename.
 **Author:** bootjp
 **Date:** 2026-04-24
+**Last updated:** 2026-04-26 (renamed from `_proposed_` to `_partial_` after P1 + P2 + P3 landed)
+
+## Implementation status (as of 2026-04-26)
+
+| Phase | Status | Landed via |
+|---|---|---|
+| **P1** — `internal/admin/` skeleton, auth, DynamoDB list/create/describe/delete, AdminForward (Section 3.3 acceptance criteria 1–6) | ✅ shipped | #634, #635, #644, #648 |
+| **P2** — S3 bucket list/create/delete/ACL, DescribeTable | ✅ shipped | #658 (read-only slice 1), #669 (write paths slice 2a), #673 (AdminForward integration slice 2b) |
+| **P3** — React SPA + embed | ✅ shipped | #649, #650 |
+| **P4** — TLS, read-only role, CSRF, `docs/admin.md` | 🟡 mostly shipped — TLS / role / CSRF are live in P1, operator doc in #674 |
+
+Outstanding open items (kept here so future readers know what is still owed against the original proposal):
+
+- **AdminForward acceptance criterion 5** — rolling-upgrade compatibility flag (`admin.leader_forward_v2`). Deferred behind a cluster-version bump; not blocking dashboard usability today because every node forwards through the same `pb.AdminOperation` enum.
+- **S3 object browser** — explicitly called out as "next phase" in Section 2 Non-goals; no work item yet.
+- **Operator-visible TLS cert reload** — out of scope; restart-to-rotate is the documented model in `docs/admin.md`.
+
+When the rolling-upgrade flag lands, this doc is renamed `2026_04_24_implemented_admin_dashboard.md` per `docs/design/README.md`'s lifecycle convention.
 
 ---
 


### PR DESCRIPTION
Per `docs/design/README.md`'s lifecycle convention, the admin dashboard design doc is now "partial":

- **P1** (DynamoDB CRUD + AdminForward) — shipped via #634, #635, #644, #648
- **P2** (S3 buckets list/create/delete/ACL + DescribeTable) — shipped via #658, with #669 + #673 in flight
- **P3** (React SPA + embed) — shipped via #649, #650
- **P4** (TLS / role / CSRF / operator docs) — TLS, role, CSRF are already live in P1; operator docs in #674

Independent of the in-flight slice 2 PRs (#669/#673) and the docs PR (#674) — this rename only reflects what is already on main today, plus an "Implementation status" table mapping each phase to the PR it landed in.

## What this PR changes

- `git mv` the design doc from `2026_04_24_proposed_admin_dashboard.md` to `2026_04_24_partial_admin_dashboard.md` so its history follows
- Add an "Implementation status" header table indexing each phase to the PRs that landed it
- List the outstanding open items so future readers know what is still owed against the original proposal:
  - AdminForward acceptance criterion 5 (rolling-upgrade compat flag) — deferred
  - S3 object browser — explicitly out of scope per Section 2 Non-goals
  - TLS cert hot-reload — restart-to-rotate is the documented model

When the rolling-upgrade flag lands, the doc gets renamed once more to `2026_04_24_implemented_admin_dashboard.md` per the README's lifecycle convention.