### PR TITLE
feat(raft): learner / non-voter membership (M1 engine + M2 operator surface)

### DIFF
--- a/cmd/raftadmin/main.go
+++ b/cmd/raftadmin/main.go
@@ -23,8 +23,13 @@ const (
 	defaultRPCTimeoutSeconds = 5
 	minCommandArgs           = 2
 	addVoterArgCount         = 2
+	addLearnerArgCount       = 2
+	promoteLearnerArgCount   = 1
 	transferArgCount         = 2
 	addVoterPrevIndex        = 2
+	addLearnerPrevIndex      = 2
+	promoteLearnerPrevIndex  = 1
+	promoteLearnerMinApplied = 2
 	removePrevIndex          = 1
 	timeoutEnv               = "RAFTADMIN_RPC_TIMEOUT_SECONDS"
 	allowInsecureEnv         = "RAFTADMIN_ALLOW_INSECURE"
@@ -179,16 +184,26 @@ func isLoopbackHost(host string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
+func readOnlyCommands() map[string]func(context.Context, pb.RaftAdminClient) error {
+	return map[string]func(context.Context, pb.RaftAdminClient) error{
+		"leader":        printLeader,
+		"state":         printState,
+		"configuration": printConfiguration,
+		"config":        printConfiguration,
+	}
+}
+
 func executeCommand(ctx context.Context, client pb.RaftAdminClient, command string, commandArgs []string) error {
+	if handler, ok := readOnlyCommands()[command]; ok {
+		return handler(ctx, client)
+	}
 	switch command {
-	case "leader":
-		return printLeader(ctx, client)
-	case "state":
-		return printState(ctx, client)
-	case "configuration", "config":
-		return printConfiguration(ctx, client)
 	case "add_voter":
 		return addVoter(ctx, client, commandArgs)
+	case "add_learner":
+		return addLearner(ctx, client, commandArgs)
+	case "promote_learner":
+		return promoteLearner(ctx, client, commandArgs)
 	case "remove_server":
 		return removeServer(ctx, client, commandArgs)
 	case "leadership_transfer":
@@ -253,6 +268,50 @@ func addVoter(ctx context.Context, client pb.RaftAdminClient, args []string) err
 	})
 	if err != nil {
 		return errors.Wrap(err, "add voter")
+	}
+	fmt.Printf("index: %d\n", resp.Index)
+	return nil
+}
+
+func addLearner(ctx context.Context, client pb.RaftAdminClient, args []string) error {
+	if len(args) < addLearnerArgCount || len(args) > addLearnerArgCount+1 {
+		return usageError("add_learner")
+	}
+	prevIndex, err := parseOptionalUint64(args, addLearnerPrevIndex)
+	if err != nil {
+		return err
+	}
+	resp, err := client.AddLearner(ctx, &pb.RaftAdminAddLearnerRequest{
+		Id:            args[0],
+		Address:       args[1],
+		PreviousIndex: prevIndex,
+	})
+	if err != nil {
+		return errors.Wrap(err, "add learner")
+	}
+	fmt.Printf("index: %d\n", resp.Index)
+	return nil
+}
+
+func promoteLearner(ctx context.Context, client pb.RaftAdminClient, args []string) error {
+	if len(args) < promoteLearnerArgCount || len(args) > promoteLearnerArgCount+2 {
+		return usageError("promote_learner")
+	}
+	prevIndex, err := parseOptionalUint64(args, promoteLearnerPrevIndex)
+	if err != nil {
+		return err
+	}
+	minApplied, err := parseOptionalUint64(args, promoteLearnerMinApplied)
+	if err != nil {
+		return err
+	}
+	resp, err := client.PromoteLearner(ctx, &pb.RaftAdminPromoteLearnerRequest{
+		Id:              args[0],
+		PreviousIndex:   prevIndex,
+		MinAppliedIndex: minApplied,
+	})
+	if err != nil {
+		return errors.Wrap(err, "promote learner")
 	}
 	fmt.Printf("index: %d\n", resp.Index)
 	return nil
@@ -336,23 +395,24 @@ func usageError(command string) error {
 	return fmt.Errorf("usage: %s", usage(command))
 }
 
+var usageStrings = map[string]string{
+	"leader":                        "raftadmin <addr> leader",
+	"state":                         "raftadmin <addr> state",
+	"configuration":                 "raftadmin <addr> configuration",
+	"config":                        "raftadmin <addr> configuration",
+	"add_voter":                     "raftadmin <addr> add_voter <id> <address> [previous_index]",
+	"add_learner":                   "raftadmin <addr> add_learner <id> <address> [previous_index]",
+	"promote_learner":               "raftadmin <addr> promote_learner <id> [previous_index] [min_applied_index]",
+	"remove_server":                 "raftadmin <addr> remove_server <id> [previous_index]",
+	"leadership_transfer":           "raftadmin <addr> leadership_transfer",
+	"leadership_transfer_to_server": "raftadmin <addr> leadership_transfer_to_server <id> <address>",
+}
+
+const usageFallback = "raftadmin <addr> <leader|state|configuration|add_voter|add_learner|promote_learner|remove_server|leadership_transfer|leadership_transfer_to_server> [args]"
+
 func usage(command string) string {
-	switch command {
-	case "leader":
-		return "raftadmin <addr> leader"
-	case "state":
-		return "raftadmin <addr> state"
-	case "configuration", "config":
-		return "raftadmin <addr> configuration"
-	case "add_voter":
-		return "raftadmin <addr> add_voter <id> <address> [previous_index]"
-	case "remove_server":
-		return "raftadmin <addr> remove_server <id> [previous_index]"
-	case "leadership_transfer":
-		return "raftadmin <addr> leadership_transfer"
-	case "leadership_transfer_to_server":
-		return "raftadmin <addr> leadership_transfer_to_server <id> <address>"
-	default:
-		return "raftadmin <addr> <leader|state|configuration|add_voter|remove_server|leadership_transfer|leadership_transfer_to_server> [args]"
+	if u, ok := usageStrings[command]; ok {
+		return u
 	}
+	return usageFallback
 }

--- a/cmd/raftadmin/main.go
+++ b/cmd/raftadmin/main.go
@@ -20,21 +20,22 @@ import (
 )
 
 const (
-	defaultRPCTimeoutSeconds = 5
-	minCommandArgs           = 2
-	addVoterArgCount         = 2
-	addLearnerArgCount       = 2
-	promoteLearnerArgCount   = 1
-	transferArgCount         = 2
-	addVoterPrevIndex        = 2
-	addLearnerPrevIndex      = 2
-	promoteLearnerPrevIndex  = 1
-	promoteLearnerMinApplied = 2
-	removePrevIndex          = 1
-	timeoutEnv               = "RAFTADMIN_RPC_TIMEOUT_SECONDS"
-	allowInsecureEnv         = "RAFTADMIN_ALLOW_INSECURE"
-	tlsEnv                   = "RAFTADMIN_TLS"
-	tlsCACertEnv             = "RAFTADMIN_TLS_CA_CERT"
+	defaultRPCTimeoutSeconds   = 5
+	minCommandArgs             = 2
+	addVoterArgCount           = 2
+	addLearnerArgCount         = 2
+	promoteLearnerArgCount     = 1
+	transferArgCount           = 2
+	addVoterPrevIndex          = 2
+	addLearnerPrevIndex        = 2
+	promoteLearnerPrevIndex    = 1
+	promoteLearnerMinApplied   = 2
+	promoteLearnerSkipCheckArg = 3
+	removePrevIndex            = 1
+	timeoutEnv                 = "RAFTADMIN_RPC_TIMEOUT_SECONDS"
+	allowInsecureEnv           = "RAFTADMIN_ALLOW_INSECURE"
+	tlsEnv                     = "RAFTADMIN_TLS"
+	tlsCACertEnv               = "RAFTADMIN_TLS_CA_CERT"
 )
 
 func main() {
@@ -294,7 +295,7 @@ func addLearner(ctx context.Context, client pb.RaftAdminClient, args []string) e
 }
 
 func promoteLearner(ctx context.Context, client pb.RaftAdminClient, args []string) error {
-	if len(args) < promoteLearnerArgCount || len(args) > promoteLearnerArgCount+2 {
+	if len(args) < promoteLearnerArgCount || len(args) > promoteLearnerArgCount+3 {
 		return usageError("promote_learner")
 	}
 	prevIndex, err := parseOptionalUint64(args, promoteLearnerPrevIndex)
@@ -305,16 +306,35 @@ func promoteLearner(ctx context.Context, client pb.RaftAdminClient, args []strin
 	if err != nil {
 		return err
 	}
+	skipMinApplied, err := parseOptionalBool(args, promoteLearnerSkipCheckArg)
+	if err != nil {
+		return err
+	}
 	resp, err := client.PromoteLearner(ctx, &pb.RaftAdminPromoteLearnerRequest{
-		Id:              args[0],
-		PreviousIndex:   prevIndex,
-		MinAppliedIndex: minApplied,
+		Id:                  args[0],
+		PreviousIndex:       prevIndex,
+		MinAppliedIndex:     minApplied,
+		SkipMinAppliedCheck: skipMinApplied,
 	})
 	if err != nil {
 		return errors.Wrap(err, "promote learner")
 	}
 	fmt.Printf("index: %d\n", resp.Index)
 	return nil
+}
+
+func parseOptionalBool(args []string, index int) (bool, error) {
+	if len(args) <= index {
+		return false, nil
+	}
+	switch args[index] {
+	case "true", "1", "yes":
+		return true, nil
+	case "false", "0", "no", "":
+		return false, nil
+	default:
+		return false, errors.Errorf("invalid bool argument %q (want true/false)", args[index])
+	}
 }
 
 func removeServer(ctx context.Context, client pb.RaftAdminClient, args []string) error {
@@ -402,7 +422,7 @@ var usageStrings = map[string]string{
 	"config":                        "raftadmin <addr> configuration",
 	"add_voter":                     "raftadmin <addr> add_voter <id> <address> [previous_index]",
 	"add_learner":                   "raftadmin <addr> add_learner <id> <address> [previous_index]",
-	"promote_learner":               "raftadmin <addr> promote_learner <id> [previous_index] [min_applied_index]",
+	"promote_learner":               "raftadmin <addr> promote_learner <id> [previous_index] [min_applied_index] [skip_min_applied_check]",
 	"remove_server":                 "raftadmin <addr> remove_server <id> [previous_index]",
 	"leadership_transfer":           "raftadmin <addr> leadership_transfer",
 	"leadership_transfer_to_server": "raftadmin <addr> leadership_transfer_to_server <id> <address>",

--- a/cmd/raftadmin/main_test.go
+++ b/cmd/raftadmin/main_test.go
@@ -35,6 +35,14 @@ func (fakeRaftAdminClient) AddVoter(context.Context, *pb.RaftAdminAddVoterReques
 	return &pb.RaftAdminConfigurationChangeResponse{Index: 1}, nil
 }
 
+func (fakeRaftAdminClient) AddLearner(context.Context, *pb.RaftAdminAddLearnerRequest, ...grpc.CallOption) (*pb.RaftAdminConfigurationChangeResponse, error) {
+	return &pb.RaftAdminConfigurationChangeResponse{Index: 2}, nil
+}
+
+func (fakeRaftAdminClient) PromoteLearner(context.Context, *pb.RaftAdminPromoteLearnerRequest, ...grpc.CallOption) (*pb.RaftAdminConfigurationChangeResponse, error) {
+	return &pb.RaftAdminConfigurationChangeResponse{Index: 3}, nil
+}
+
 func (fakeRaftAdminClient) RemoveServer(context.Context, *pb.RaftAdminRemoveServerRequest, ...grpc.CallOption) (*pb.RaftAdminConfigurationChangeResponse, error) {
 	return &pb.RaftAdminConfigurationChangeResponse{Index: 1}, nil
 }
@@ -79,13 +87,32 @@ func TestRPCTimeoutRejectsInvalidEnv(t *testing.T) {
 
 func TestUsageErrorForCommand(t *testing.T) {
 	require.EqualError(t, usageError("add_voter"), "usage: raftadmin <addr> add_voter <id> <address> [previous_index]")
+	require.EqualError(t, usageError("add_learner"), "usage: raftadmin <addr> add_learner <id> <address> [previous_index]")
+	require.EqualError(t, usageError("promote_learner"), "usage: raftadmin <addr> promote_learner <id> [previous_index] [min_applied_index]")
 	require.EqualError(t, usageError("remove_server"), "usage: raftadmin <addr> remove_server <id> [previous_index]")
 	require.EqualError(t, usageError("leadership_transfer_to_server"), "usage: raftadmin <addr> leadership_transfer_to_server <id> <address>")
 }
 
 func TestUsageErrorFallback(t *testing.T) {
-	require.EqualError(t, usageError(""), "usage: raftadmin <addr> <leader|state|configuration|add_voter|remove_server|leadership_transfer|leadership_transfer_to_server> [args]")
-	require.EqualError(t, usageError("unknown"), "usage: raftadmin <addr> <leader|state|configuration|add_voter|remove_server|leadership_transfer|leadership_transfer_to_server> [args]")
+	want := "usage: raftadmin <addr> <leader|state|configuration|add_voter|add_learner|promote_learner|remove_server|leadership_transfer|leadership_transfer_to_server> [args]"
+	require.EqualError(t, usageError(""), want)
+	require.EqualError(t, usageError("unknown"), want)
+}
+
+func TestExecuteCommandAddLearnerPrintsIndex(t *testing.T) {
+	client := fakeRaftAdminClient{}
+	out := captureStdout(t, func() {
+		require.NoError(t, executeCommand(context.Background(), client, "add_learner", []string{"node-X", "127.0.0.1:50099", "5"}))
+	})
+	require.Equal(t, "index: 2\n", out)
+}
+
+func TestExecuteCommandPromoteLearnerPrintsIndex(t *testing.T) {
+	client := fakeRaftAdminClient{}
+	out := captureStdout(t, func() {
+		require.NoError(t, executeCommand(context.Background(), client, "promote_learner", []string{"node-X", "5", "100"}))
+	})
+	require.Equal(t, "index: 3\n", out)
 }
 
 func TestAllowInsecurePlaintextLoopbackByDefault(t *testing.T) {

--- a/cmd/raftadmin/main_test.go
+++ b/cmd/raftadmin/main_test.go
@@ -88,7 +88,7 @@ func TestRPCTimeoutRejectsInvalidEnv(t *testing.T) {
 func TestUsageErrorForCommand(t *testing.T) {
 	require.EqualError(t, usageError("add_voter"), "usage: raftadmin <addr> add_voter <id> <address> [previous_index]")
 	require.EqualError(t, usageError("add_learner"), "usage: raftadmin <addr> add_learner <id> <address> [previous_index]")
-	require.EqualError(t, usageError("promote_learner"), "usage: raftadmin <addr> promote_learner <id> [previous_index] [min_applied_index]")
+	require.EqualError(t, usageError("promote_learner"), "usage: raftadmin <addr> promote_learner <id> [previous_index] [min_applied_index] [skip_min_applied_check]")
 	require.EqualError(t, usageError("remove_server"), "usage: raftadmin <addr> remove_server <id> [previous_index]")
 	require.EqualError(t, usageError("leadership_transfer_to_server"), "usage: raftadmin <addr> leadership_transfer_to_server <id> <address>")
 }

--- a/docs/design/2026_04_26_proposed_raft_learner.md
+++ b/docs/design/2026_04_26_proposed_raft_learner.md
@@ -250,8 +250,16 @@ flagged as a structural prerequisite.
 
    - **(a) Filter at the comparison.** `validateConfState` builds its
      own `expected` voter set from `peers` filtered by
-     `Suffrage != "learner"`, and compares both `Voters` and
-     `Learners` element-wise against the snapshot's `ConfState`.
+     `Suffrage != "learner"`. The voter check stays element-wise
+     (matching the existing pattern, which depends on the
+     well-established voter ordering invariant: `persistConfigState`
+     writes voters in `ConfState.Voters` order and `normalizePeers`
+     preserves it). The **learner check is set-based**:
+     `len(conf.Learners) != filteredLearnerCount && allLearnersPresent(conf.Learners, learnerSet)`.
+     A set comparison avoids pinning a new ordering contract on the
+     v2 writer for learners — there is no prior convention since
+     learners have never been persisted before, and the set form is
+     strictly more robust against future writer reordering.
    - **(b) Add a sibling helper.** Introduce
      `confStateWithLearners(peers []Peer) raftpb.ConfState` used only
      by `validateConfState`; leave `confStateForPeers` voters-only as
@@ -265,15 +273,35 @@ flagged as a structural prerequisite.
    `raftengine.Server{Suffrage: "voter"}` into `e.config.Servers`. Once
    learners exist, the second job is wrong — `upsertPeer` has no
    `ConfState` at call time, so it cannot decide the correct suffrage.
-   The fix: `upsertPeer` keeps `e.peers` only. `e.config.Servers` is
-   recomputed from the post-change `ConfState` by a single call to
-   `configurationFromConfState` inside `applyConfigChange` /
-   `applyConfigChangeV2`. That function already runs on the
-   single-threaded apply loop and already sees the new `ConfState` from
-   `rawNode.ApplyConfChange(...)`, so there is no extra synchronization
-   cost. Symmetric change in `removePeer`: it stops splicing
-   `e.config.Servers` directly and lets the apply loop rebuild it from
-   `ConfState`.
+   The fix: `upsertPeer` keeps `e.peers` only. `e.config.Servers`,
+   `e.voterCount`, and `e.isLearnerNode` are all recomputed from the
+   post-change `ConfState` inside `applyConfigChange` /
+   `applyConfigChangeV2`. Symmetric change in `removePeer`: it stops
+   splicing `e.config.Servers` directly.
+
+   To make the post-change `ConfState` reachable from those functions,
+   **extend their signatures** to accept `confState raftpb.ConfState`:
+
+   ```go
+   func (e *Engine) applyConfigChange(changeType raftpb.ConfChangeType,
+                                       nodeID uint64, context []byte,
+                                       index uint64,
+                                       confState raftpb.ConfState)
+
+   func (e *Engine) applyConfigChangeV2(cc raftpb.ConfChangeV2,
+                                         index uint64,
+                                         confState raftpb.ConfState)
+   ```
+
+   This mirrors `nextPeersAfterConfigChange(_, _, _, conf raftpb.ConfState)`
+   which already takes `ConfState` for the same reason. The call sites
+   in the apply loop already capture the return value of
+   `rawNode.ApplyConfChange(...)`, so wiring the parameter is a
+   one-line change at each call site (no new mutex, no new state).
+   Inside the body, suffrage-aware updates run **after** the existing
+   per-peer cleanup helpers (`upsertPeer` / `removePeer`) so address
+   cache mutations and voter-count rebuilds happen in a deterministic
+   order on the single-threaded apply loop (cf. §5.2 ordering note).
 
 `nextPeersAfterConfigChange` already routes `ConfChangeAddLearnerNode`
 via `applyAddedPeerToMap`, so the snapshot/restart code path is correct
@@ -848,13 +876,13 @@ After Milestone 3, rename
    `bool skip_min_applied_check` field with a default of `false`,
    forcing operators to opt in explicitly. Tracked here so it is not
    discovered post-implementation.
-3. Do we want a `--raftBootstrapMembers` syntax extension to mark
+4. Do we want a `--raftBootstrapMembers` syntax extension to mark
    bootstrap members as learners? Current proposal: **no**. Cold
    bootstrap is voter-only; learners enter exclusively via
    `AddLearner` against an existing leader. This keeps the bootstrap
    path narrow and avoids a footgun where someone bootstraps a
    learner-majority cluster.
-4. Future work: should `LinearizableRead` on a learner be served
+5. Future work: should `LinearizableRead` on a learner be served
    locally with `ReadIndex` + apply-wait, instead of forwarded? That
    is the follower-served-reads question and explicitly out of scope
    here.

--- a/docs/design/2026_04_26_proposed_raft_learner.md
+++ b/docs/design/2026_04_26_proposed_raft_learner.md
@@ -1,0 +1,607 @@
+# Raft Learner support
+
+> **Status: Proposed**
+> Author: bootjp
+> Date: 2026-04-26
+>
+> Builds on the etcd/raft migration (`2026_04_05_implemented_etcd_raft_migration.md`).
+> Phase 3 of that doc deliberately deferred learner / non-voter membership;
+> this proposal closes that gap. It is independent of — but compatible with —
+> the future follower-served-read effort, which would consume learners as a
+> read replica primitive.
+
+---
+
+## 1. Problem
+
+Today every member of an Elastickv Raft group is a voter. The only membership
+mutations exposed by the engine are `AddVoter` and `RemoveServer`
+(`internal/raftengine/engine.go:174`). That has three concrete consequences:
+
+1. **Membership change is unsafe under load.** Adding a fresh node directly as a
+   voter shrinks the effective fault tolerance of the group during catch-up:
+   the new voter counts toward the denominator immediately but cannot vote
+   intelligently until it has caught up on the log. A leader that loses
+   contact with one healthy follower while the new voter is still receiving
+   the snapshot can stall writes — the classic "fourth-voter pause" problem.
+   Operators today work around this by pre-seeding data dirs out of band,
+   which defeats the abstraction.
+
+2. **Replica catch-up has no first-class story.** The etcd backend already
+   knows how to send a snapshot and stream log entries to a peer
+   (`snapshot_spool.go`, the snapshot dispatch lane in `engine.go`), but the
+   only way to attach a peer to that pipeline is to make it a voter.
+
+3. **The roadmap requires it.** Hotspot shard split
+   (`2026_02_18_partial_hotspot_shard_split.md`), workload isolation
+   (`2026_04_24_proposed_workload_isolation.md`), and any future
+   follower-served read mode all need a way to attach a *non-voting* replica
+   that pulls log entries without joining the quorum. Hand-rolling that
+   per-feature is the wrong shape.
+
+The etcd/raft library already supports learners natively
+(`raftpb.ConfChangeAddLearnerNode`, `ConfState.Learners`). The codebase has
+even partly anticipated this — `applyConfigPeerChangeToMap` keeps learner
+metadata when replaying logs, and `nextPeersAfterConfigChangeKeepsLearnerMetadata`
+is a regression test for that — but the live engine path explicitly drops
+learner conf changes and the persistence layer rejects any `ConfState` with
+non-empty `Learners` as "joint consensus". This doc proposes turning that
+dormant support on.
+
+## 2. Goals & non-goals
+
+**Goals**
+
+- Add `AddLearner` and `PromoteLearner` to the `raftengine.Admin` interface,
+  the etcd backend, the `RaftAdmin` gRPC service, and the `cmd/raftadmin`
+  CLI.
+- Report learner suffrage end-to-end. `Configuration.Servers[i].Suffrage`
+  must be `"learner"` for learners and `"voter"` for voters; today it is
+  hard-coded to `"voter"` in two places (`engine.go:2656`, `engine.go:3096`).
+- Persist learner membership across restarts. The
+  `etcd-raft-peers.bin` peer-metadata file must round-trip suffrage so that
+  a node restarting from disk does not silently re-promote itself or
+  forget that it is a learner.
+- Allow a node to **start as a learner** when joining an existing cluster,
+  without ever being a voter first. Cold-bootstrap a cluster with
+  learner-only members must remain rejected.
+- Make sure learners do **not** affect liveness. The lease-read fast path
+  (`LeaseProvider`) must not require a learner ack. The `quorumAckTracker`
+  denominator must exclude learners.
+- Accept a `min_applied_index` precondition on promotion so an operator who
+  promotes a learner that has not actually caught up gets a clean
+  precondition error from the engine, not a silent quorum stall.
+
+**Non-goals**
+
+- Follower-served reads (`LinearizableRead` answered locally on a follower
+  or learner). That is a separate proposal that consumes this primitive;
+  it requires its own treatment of staleness bounds, lease invalidation,
+  and adapter routing changes. Until that lands, learners forward
+  `LinearizableRead` to the leader's `ReadIndex` like any other follower
+  would.
+- Joint consensus / atomic multi-member reconfig. `validateConfState`
+  continues to reject `VotersOutgoing`, `LearnersNext`, and `AutoLeave`.
+  Learner add/promote uses the simple V1 single-step `ConfChange` path that
+  the engine already takes for `AddVoter` / `RemoveServer`.
+- Witness / weighted voter / arbiter roles.
+- Cross-engine portability. The HashiCorp backend was deleted in `a35245a`;
+  the etcd backend is the only target.
+- Auto-promotion. The engine never decides on its own to turn a learner into
+  a voter. Promotion is always an explicit operator (or higher-layer
+  orchestration) action through `PromoteLearner`.
+- Adapter / KV semantics changes. `ShardedCoordinator`, `LeaderProxy`,
+  `LeaseProvider`, and `LinearizableRead` already gate on
+  `state == StateLeader` for the fast path; a learner naturally falls
+  through to the slow path. No KV-layer change is required.
+
+## 3. Background
+
+### 3.1 etcd/raft semantics
+
+In etcd/raft, a learner is a node that:
+
+1. Receives `MsgApp` and `MsgSnap` like any follower.
+2. Persists log entries and applies them to its local state machine.
+3. Does **not** vote. `MsgVote` / `MsgPreVote` from a learner is dropped at
+   the leader's progress tracker, and a learner cannot become candidate.
+4. Is **not** counted toward majority. `Progress.IsLearner == true` excludes
+   it from the quorum denominator on writes and on `ReadIndex`.
+5. Is **not** a valid leadership-transfer target. The library drops
+   `MsgTransferLeader` aimed at a learner. The engine already documents
+   this in `handleTransferLeadership` (`engine.go:1384`); it gives us the
+   "learner cannot be promoted by accident via TransferLeader" property
+   for free.
+
+The two membership operations relevant to this doc are:
+
+| etcd/raft conf change       | Effect                                                                                                 |
+|-----------------------------|--------------------------------------------------------------------------------------------------------|
+| `ConfChangeAddLearnerNode`  | Add a peer as a learner. No quorum impact.                                                             |
+| `ConfChangeAddNode` for an existing learner | **Promote** the learner to voter. The library expects the node to be caught up before this lands. |
+
+Neither operation enters joint consensus.
+
+### 3.2 Today's behaviour in the elastickv etcd backend
+
+The engine *partially* handles learners and *fully* refuses to expose them:
+
+| File                                              | Behaviour                                                                                                                                                                                |
+|---------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `internal/raftengine/engine.go`                    | `Admin` interface has no `AddLearner` or `PromoteLearner`. `Server.Suffrage` field exists but no caller produces `"learner"`.                                                            |
+| `internal/raftengine/etcd/engine.go:1817-1830`     | Live `applyConfigPeerChange` ignores `ConfChangeAddLearnerNode`. Comment: "Phase 3 only exposes voter membership changes."                                                               |
+| `internal/raftengine/etcd/engine.go:1869-1884`     | Map-form `applyConfigPeerChangeToMap` does keep learner peer metadata in the in-memory snapshot — necessary for log replay round-trip — but the live engine's `peers` map does not. |
+| `internal/raftengine/etcd/engine.go:2644-2667`     | `configurationFromConfState` only walks `ConfState.Voters`; it never emits a server with `Suffrage: "learner"`.                                                                          |
+| `internal/raftengine/etcd/engine.go:3080-3106`     | `upsertPeer` hard-codes `Suffrage: "voter"`.                                                                                                                                              |
+| `internal/raftengine/etcd/wal_store.go:419-421`    | `validateConfState` rejects any `ConfState` with non-empty `Learners` / `LearnersNext` / `VotersOutgoing` as "joint consensus state is not supported".                                  |
+| `internal/raftengine/etcd/peers.go:216-222`        | `confStateForPeers` only emits `Voters`. There is no per-peer suffrage on the `Peer` struct.                                                                                              |
+| `internal/raftengine/etcd/peer_metadata.go`        | Persisted peers file (`etcd-raft-peers.bin`, version 1) stores `(NodeID, ID, Address)`. No suffrage byte.                                                                                  |
+| `proto/service.proto`                              | `RaftAdmin` exposes `AddVoter`, `RemoveServer`, `TransferLeadership`. No `AddLearner` or `PromoteLearner`. `RaftAdminMember.suffrage` exists in the response message.                    |
+| `cmd/raftadmin/main.go`                            | Subcommands: `add_voter`, `remove_server`, `leadership_transfer`, `leadership_transfer_to_server`. No learner subcommands.                                                                |
+
+The dormant pieces (`applyConfigPeerChangeToMap`, the `Suffrage` field on
+`Server`, the `suffrage` field on `RaftAdminMember`, the regression test for
+preserved learner metadata) all suggest the original etcd-migration design
+expected this exact follow-up.
+
+## 4. Design
+
+### 4.1 Engine API
+
+Add two methods to `raftengine.Admin`. Both are leader-only. Both use the
+same `prevIndex` precondition pattern as the existing membership RPCs.
+
+```go
+type Admin interface {
+    LeaderView
+    StatusReader
+    ConfigReader
+
+    AddVoter(ctx context.Context, id, address string, prevIndex uint64) (uint64, error)
+    AddLearner(ctx context.Context, id, address string, prevIndex uint64) (uint64, error)
+    PromoteLearner(ctx context.Context, id string, prevIndex uint64, minAppliedIndex uint64) (uint64, error)
+    RemoveServer(ctx context.Context, id string, prevIndex uint64) (uint64, error)
+
+    TransferLeadership(ctx context.Context) error
+    TransferLeadershipToServer(ctx context.Context, id, address string) error
+}
+```
+
+Notes on the new methods:
+
+- `AddLearner` is the symmetric counterpart of `AddVoter`. It proposes a
+  V1 `ConfChangeAddLearnerNode` with the same encoded peer-context the
+  voter path already uses (`encodeConfChangeContext`). Address resolution
+  uses the same `resolveAdminPeer` helper.
+- `PromoteLearner` proposes a V1 `ConfChangeAddNode` for an existing
+  learner. The engine asserts on the leader, on the single-threaded admin
+  loop, that:
+  1. The peer exists in `ConfState.Learners` (not in `Voters`). Otherwise
+     return a `FailedPrecondition` so callers do not silently no-op.
+  2. The leader's `Progress[nodeID].Match >= minAppliedIndex`. The leader
+     is the authority on follower progress; an operator who reads
+     `Status.AppliedIndex` from the learner itself sees a slightly stale
+     view, so the engine re-checks against the leader's tracker before
+     proposing. `minAppliedIndex == 0` skips the precondition (matches the
+     existing "0 means don't care" convention used by `prevIndex`).
+- `RemoveServer` is unchanged. etcd/raft handles `ConfChangeRemoveNode` for
+  a learner correctly, and the existing path already calls `peerForID` /
+  `removePeer`.
+
+### 4.2 etcd backend internals
+
+Three concrete edits, each tightly scoped:
+
+1. `applyConfigPeerChange` (engine.go:1817) stops dropping
+   `ConfChangeAddLearnerNode`. The handler routes to `applyAddedPeer`
+   (same as `ConfChangeAddNode`), and the *suffrage* of the peer is no
+   longer carried in the engine's `peers` map but inferred at read time
+   from `ConfState`. The `peers` map remains a (nodeID → addr) cache
+   keyed by node identity. Promotion does not change the peer entry —
+   only `ConfState.Voters` / `ConfState.Learners` changes.
+2. `configurationFromConfState` walks both `conf.Voters` and
+   `conf.Learners` and emits the right `Suffrage` string for each. This
+   becomes the single source of truth for suffrage; `upsertPeer` stops
+   stamping a hard-coded `Suffrage: "voter"`.
+3. `validateConfState` (wal_store.go:406) accepts learner-only entries:
+   `len(conf.Learners) > 0` is no longer rejected. Joint-consensus markers
+   (`VotersOutgoing`, `LearnersNext`, `AutoLeave`) stay rejected — learner
+   add/promote uses the simple V1 path which never sets them.
+
+`nextPeersAfterConfigChange` already routes `ConfChangeAddLearnerNode` via
+`applyAddedPeerToMap`, so the snapshot/restart code path is correct
+once the live `applyConfigPeerChange` matches it.
+
+### 4.3 Persisted peers file
+
+The existing `etcd-raft-peers.bin` is version 1 and encodes
+`(NodeID, ID, Address)` per peer. Suffrage is not stored. The authoritative
+suffrage view lives in the raft snapshot's `ConfState`, which is already
+persisted via `persistConfigSnapshot`, so in principle we could leave the
+peers file unchanged. However:
+
+- The peers file is consulted on `Open` to resolve addresses for peers that
+  appear in `ConfState` but not in the operator-supplied peer list.
+- A learner that restarts before its first snapshot lands would see a
+  `ConfState` from the bootstrap snapshot that lists it as voter (in the
+  cold-bootstrap case) or as learner (in the join-as-learner case). In the
+  join case there is no in-memory hint about its own role until the
+  snapshot is replayed.
+- Future tooling — `raftadmin configuration` printing local node state,
+  monitoring labels — will want a single read of "what am I" that does
+  not require synthesizing it from `ConfState` plus the local node ID.
+
+Therefore: bump the peers file format to **version 2**. Layout:
+
+```text
+magic   : "EKVP"
+version : u32 = 2
+index   : u64               // unchanged
+count   : u32               // unchanged
+peers   : count × {
+    nodeID   : u64
+    suffrage : u8           // 0 = voter, 1 = learner. NEW.
+    id       : len-prefixed string
+    address  : len-prefixed string
+}
+```
+
+Compatibility:
+
+- `readPersistedPeersFile` keeps the v1 reader. A v1 file is treated as
+  all-voter, which is exactly the current world. Upgrades therefore do not
+  require a migration step.
+- Writers always emit v2. A downgrade to a build that only knows v1 reads
+  the v2 file as a header-version mismatch and rejects it; that is
+  acceptable because we already require explicit offline migration tooling
+  for engine downgrades (Phase 5 of the etcd-migration doc).
+
+The `ConfState` carried inside the local raft snapshot remains the
+*authoritative* source of suffrage. The peers file is a cache plus an
+operator-readable summary; on conflict, the snapshot's `ConfState` wins,
+and `persistConfigState` overwrites the peers file accordingly.
+
+### 4.4 RPC and CLI surface
+
+Proto additions (`proto/service.proto`):
+
+```protobuf
+service RaftAdmin {
+  // ... existing RPCs ...
+  rpc AddLearner(RaftAdminAddLearnerRequest) returns (RaftAdminConfigurationChangeResponse) {}
+  rpc PromoteLearner(RaftAdminPromoteLearnerRequest) returns (RaftAdminConfigurationChangeResponse) {}
+}
+
+message RaftAdminAddLearnerRequest {
+  string id = 1;
+  string address = 2;
+  uint64 previous_index = 3;
+}
+
+message RaftAdminPromoteLearnerRequest {
+  string id = 1;
+  uint64 previous_index = 2;
+  uint64 min_applied_index = 3; // 0 = skip precondition
+}
+```
+
+`internal/raftadmin/server.go` wires them through `s.admin`. The two
+existing wiring helpers (`adminError`, the `Unimplemented` guard for
+`s.admin == nil`) are reused unchanged.
+
+`cmd/raftadmin` subcommands:
+
+```text
+raftadmin <addr> add_learner <id> <address> [previous_index]
+raftadmin <addr> promote_learner <id> [previous_index] [min_applied_index]
+```
+
+The existing `configuration` subcommand already prints the per-server
+`suffrage` field (`cmd/raftadmin/main.go:235`), so once the engine emits
+`"learner"` for learners the operator-visible output is correct without
+further changes.
+
+### 4.5 Bootstrap and join-as-learner
+
+Cold bootstrap (`--raftBootstrap` plus optionally `--raftBootstrapMembers`):
+
+- The bootstrap member list is voters-only. A learner cannot start an
+  election, and the cold-bootstrap flow expects the local node to win an
+  uncontested election to commit the first config snapshot. We reject
+  attempts to bootstrap with a learner-only member list with
+  `errNoVotersConfigured` — symmetric to `errNoPeersConfigured` for the
+  empty case.
+
+Joining an existing cluster as a learner:
+
+- New CLI flag (per group): `--raftJoinAsLearner` (default `false`). When
+  set, the local node refuses to self-bootstrap and refuses to be added
+  with `AddVoter` from outside; it expects an operator to call
+  `AddLearner` against the existing leader before it appears in
+  `ConfState`.
+- Operationally:
+  1. Operator brings up the joiner with `--raftJoinAsLearner` and the
+     peer list it knows about (existing voters; the joiner's own
+     `--raftId` is the local node).
+  2. The joiner starts but stays in follower-no-config until the leader
+     fans out the new `ConfState` via `MsgApp` / `MsgSnap`.
+  3. Operator calls `raftadmin <leader> add_learner <id> <address>`.
+  4. Once the joiner is caught up (operator polls `Status.AppliedIndex`
+     against the leader's `CommitIndex`), operator calls
+     `promote_learner` with `min_applied_index` set to a recent leader
+     commit index. The engine re-verifies against
+     `Progress[nodeID].Match` before proposing.
+- This flow does **not** require a new `--raftBootstrapMembers` syntax.
+  The joiner does not appear in any cold-bootstrap member list; it only
+  enters the cluster's `ConfState` via the explicit `add_learner` RPC.
+
+### 4.6 Quorum, lease reads, and the ack tracker
+
+The lease-read fast path
+(`LeaseProvider` / `LastQuorumAck` / `quorumAckTracker`) must not require
+acknowledgement from learners. Specifically:
+
+- `followerQuorumForClusterSize` currently takes the total *cluster size*
+  (`len(e.peers)`) to compute a follower-quorum denominator. After this
+  change, that count includes learners, which would inflate the
+  denominator and stall lease reads whenever a learner is slow.
+- The engine must compute the lease-read denominator from
+  `len(ConfState.Voters)` (excluding self if leader), not `len(e.peers)`.
+  `recordQuorumAck` already gates on `isLeader`; we additionally drop
+  responses from peers whose `nodeID` is in `ConfState.Learners` so a
+  learner heartbeat ack cannot count toward voter majority.
+
+This is the **highest-risk** area of this proposal and gets its own
+behaviour test (see §5.2). The wrong fix here would silently regress
+lease-read latency the moment any cluster has a single learner attached.
+
+### 4.7 What does *not* change
+
+To keep the milestones reviewable, the following surfaces stay exactly
+where they are:
+
+- KV / adapter code (`kv/`, `adapter/`). `LeaderProxy`, `LeaseProvider`,
+  `LinearizableRead`, and `ShardedCoordinator` already gate fast paths on
+  `state == StateLeader`. A learner falls through to slow paths
+  automatically.
+- Route catalog (`distribution/`). Routing decisions are independent of
+  raft suffrage; the route catalog points at a Raft group, and the group
+  internally decides leadership.
+- Snapshot send/receive (`snapshot_spool.go`, the snapshot dispatch
+  lane). Snapshot sending to a slow joiner already works for voters; a
+  learner consumes the same code path.
+- WAL purge (`wal_purge.go`). Already bounded by per-peer `Match` indexes
+  in the leader's progress tracker; the tracker includes learners by
+  construction in etcd/raft.
+- HLC issuance. Learners do not issue persistence timestamps (they cannot
+  — they are never leader). No change to `kv/hlc.go` is required.
+
+## 5. Self-review of the design (five passes)
+
+Per CLAUDE.md §"Self-review of code changes", spelled out at design time
+because each of these passes informs the milestone breakdown.
+
+### 5.1 Data loss
+
+- A learner cannot lose committed data because it never *commits*: it
+  only replays the leader's committed entries. Its FSM lags or matches
+  the leader, never diverges.
+- Promotion does **not** decrement the voter count at any point. It is a
+  V1 `ConfChangeAddNode` that increments `Voters` by one in the resulting
+  `ConfState`. Quorum size after promotion is `floor((N+1)/2)+1`, which
+  is at least the pre-promotion quorum, so there is no transient window
+  where a single voter failure can stall the cluster on the promote
+  step.
+- WAL purge: the leader's `Progress` map already includes learners
+  (they receive `MsgApp`), so the existing per-peer `Match` floor that
+  bounds purge cannot truncate entries the learner still needs.
+  Verification: a unit test that forces a snapshot + purge while a
+  learner is mid-catch-up.
+- Persisted peers file forward-compat: writers always emit v2; readers
+  accept v1 (treat as all-voter) and v2. A v1→v2 upgrade is therefore a
+  read-once-write-once transition; we do not silently "migrate" until
+  the next conf change forces a `persistConfigState` write.
+
+### 5.2 Concurrency / distributed failures
+
+- Add and promote run on the engine's single-threaded admin loop, the
+  same loop as `AddVoter` / `RemoveServer`. The same `prevIndex`
+  precondition prevents a stale operator from racing two reconfigurations.
+- Promote-during-leader-change: the new leader's `Progress` map starts
+  fresh. The `min_applied_index` precondition will reject promotion until
+  the new leader has observed enough catch-up traffic from the learner;
+  this is the desired behaviour, not a bug.
+- Quorum-ack tracker race: `recordQuorumAck` is gated by `isLeader`; the
+  step-down path (`leaderLossCbs`) already invalidates the tracker. The
+  new gate ("drop responses from learner peers") reads `ConfState`
+  through the same lock as the existing `peers` map, so it does not
+  introduce a new race.
+- Removing a learner mid-promote: etcd/raft processes conf changes
+  serially — the second proposal stays in the log behind the first and
+  is applied or rejected deterministically. `pendingConfigs` already
+  tracks one outstanding change at a time per request ID.
+- Partition + heal: a learner that is partitioned from the leader simply
+  falls behind. On heal, the leader resumes `MsgApp` / `MsgSnap`; no
+  divergence is possible because the learner cannot have been the
+  authority on any committed entry.
+
+### 5.3 Performance
+
+- Adding a learner adds outbound replication traffic (one extra peer)
+  but no extra Raft round-trips on the write path: the learner does not
+  vote, and after §4.6 it does not gate the lease-read denominator
+  either. Hot-path cost on the write path: O(1) extra `MsgApp` per
+  Ready iteration, dispatched on the existing per-peer queue.
+- Snapshot-on-join: identical to the existing voter-snapshot path. Same
+  4-lane dispatcher behaviour, same throttling.
+- The `quorumAckTracker` denominator change is O(voters), recomputed
+  only on conf change, not on each ack — same cadence as today.
+- Persisted peers file v2 is one extra byte per peer; the file is
+  bounded at `maxPersistedPeers = 1024`, so the cost is negligible.
+- No new metric-cardinality blow-up. The `suffrage` label appears on
+  per-peer monitoring labels (`monitoring/raft.go:355`) which is already
+  bounded by cluster size.
+
+### 5.4 Data consistency
+
+- A learner's local FSM may lag. It MUST NOT serve linearizable reads
+  via the lease fast path. This proposal does not change adapter
+  routing; the existing `state == StateLeader` gate already enforces
+  this. We add an explicit unit test on `LeaseProvider`:
+  `LastQuorumAck()` returns the zero `Instant` on a learner regardless
+  of cluster ack traffic.
+- `LinearizableRead` on a learner: the current implementation forwards
+  to the leader's `ReadIndex` and waits for local apply. Behaviour on a
+  learner is identical to behaviour on a slow follower — local apply
+  may take longer, but staleness bound is the same. We add a behaviour
+  test that exercises this.
+- HLC: learners never issue persistence timestamps. The
+  `Coordinator.HLC().Next()` call site is leader-gated already; a
+  learner that somehow got asked for a timestamp would be rejected by
+  `VerifyLeader` upstream.
+- OCC: irrelevant. Learners do not commit transactions.
+- MVCC visibility: a learner's local snapshot reads at HLC ts T are
+  consistent with the leader-issued `T` only after the learner has
+  applied up to the index that committed `T`. Today's `LinearizableRead`
+  fence enforces that already; we just inherit it.
+
+### 5.5 Test coverage
+
+- Unit tests for `AddLearner`, `PromoteLearner`, including:
+  - happy path (add → catch up → promote → vote)
+  - promote without prior add → `FailedPrecondition`
+  - promote with `min_applied_index` ahead of `Progress.Match` →
+    `FailedPrecondition`
+  - leader change between add and promote
+  - remove a learner directly via `RemoveServer`
+- Conformance test (`internal/raftengine/etcd/conformance_test.go`):
+  `Configuration().Servers[i].Suffrage` reports `"learner"` for
+  learners and `"voter"` for voters, including after restart.
+- Persisted peers v1→v2 round-trip test.
+- `quorumAckTracker` regression test: lease reads must not block on
+  learner ack.
+- `WAL purge` test with a learner mid-catch-up (data-loss pass §5.1).
+- Behaviour test: `LinearizableRead` on a learner forwards to leader's
+  `ReadIndex` and returns once local apply catches up.
+- Property test for the conf-change context codec is unchanged
+  (`encodeConfChangeContext` already round-trips peer metadata for the
+  V1 conf-change types we use).
+
+A multi-node Jepsen-style test that exercises learner attach + promote
+during partition is deferred to Milestone 3 because it requires a
+parameterised cluster harness in the existing Jepsen workloads.
+
+## 6. Milestones
+
+### Milestone 1 — Engine-level learner support (no operator surface yet)
+
+- `Admin` interface: add `AddLearner`, `PromoteLearner`.
+- etcd backend: live `applyConfigPeerChange` accepts
+  `ConfChangeAddLearnerNode`; `configurationFromConfState` reports
+  `"learner"`; `upsertPeer` stops hard-coding `"voter"`.
+- `validateConfState` accepts learner-only entries (joint-consensus
+  markers stay rejected).
+- `quorumAckTracker` denominator + admission audit (§4.6).
+- Persisted peers file v2.
+- Unit + conformance tests (§5.5 first three bullets).
+- No proto / CLI / flag changes yet. Promote / add are reachable via
+  the engine API and engine tests only.
+
+Exit criteria: a unit test that adds a learner to a 3-node cluster,
+sees suffrage reported correctly across restarts, and promotes it.
+
+### Milestone 2 — Operator surface
+
+- Proto: `AddLearner`, `PromoteLearner` RPCs and request messages.
+- `internal/raftadmin/server.go` wiring.
+- `cmd/raftadmin` subcommands.
+- `--raftJoinAsLearner` flag in `main.go`.
+- Operator runbook update in `docs/etcd_raft_migration_operations.md`
+  (or a sibling runbook) covering attach-as-learner / promote / verify
+  via `raftadmin configuration`.
+- Behaviour test: `LinearizableRead` on a learner forwards correctly.
+
+Exit criteria: a manual operator workflow that brings up a
+single-process 3-node demo cluster, attaches a learner via
+`raftadmin add_learner`, and promotes it.
+
+### Milestone 3 — Hardening
+
+- Jepsen workload that exercises learner attach during partition and
+  promote after heal.
+- Monitoring: `suffrage` label on per-peer Prometheus labels (already
+  exists in `monitoring/raft.go:355`; verify it survives the engine
+  changes).
+- Promote precondition: surface `Progress[nodeID].Match` in
+  `Status.PerPeer` so an operator can choose `min_applied_index`
+  without guessing.
+- Decision gate for follower-served reads: write a separate proposal,
+  do not extend this one.
+
+After Milestone 3, rename
+`docs/design/2026_04_26_proposed_raft_learner.md` →
+`docs/design/2026_04_26_implemented_raft_learner.md` (or
+`*_partial_*` if Milestone 3 slips behind Milestone 2 shipping).
+
+## 7. Risks
+
+1. **`quorumAckTracker` denominator regression.** If the
+   voter/learner gate in §4.6 is wrong, lease reads silently stall when
+   a learner is slow. Mitigation: explicit unit test, then an
+   integration test that injects learner-side `MsgHeartbeatResp` delay
+   and asserts lease-read latency is unaffected.
+2. **Persisted peers v1→v2 mis-handling on downgrade.** A v2 file read
+   by a v1 reader fails closed (header version mismatch), which is the
+   safe outcome but breaks rollback. Mitigation: document this in the
+   Phase-5 rollout playbook of the etcd-migration doc; require explicit
+   offline tooling for downgrade, same as the existing engine-marker
+   policy in `multiraft_runtime.go`.
+3. **Operator promotes a not-yet-caught-up learner.** Mitigation:
+   `min_applied_index` precondition checked against
+   `Progress[nodeID].Match` on the leader. Default `0` skips the check
+   for compatibility with scripts that don't set it; the runbook
+   strongly recommends a non-zero value.
+4. **Learner cannot become leader by accident.** etcd/raft already
+   enforces this; we inherit the property. The rejection path in
+   `handleTransferLeadership` (`engine.go:1387`) already documents it.
+5. **Cold bootstrap with a learner-only member list.** Reject explicitly
+   with a typed error rather than relying on the underlying library to
+   refuse. Otherwise an operator who specifies a learner-only bootstrap
+   list could see the cluster wedge waiting for a leader that can never
+   be elected.
+
+## 8. Open questions
+
+1. Should `RemoveServer` distinguish between removing a voter and
+   removing a learner at the API layer, or is the existing single
+   method enough? Current proposal: single method, since etcd/raft uses
+   `ConfChangeRemoveNode` for both. (Operators reading
+   `raftadmin configuration` already see the suffrage of the target.)
+2. Should `min_applied_index` be expressed as an absolute index or as a
+   tolerance behind the leader's commit index ("within N entries")? The
+   absolute form is simpler to validate; the tolerance form is easier
+   for an operator to choose. Current proposal: absolute, with a
+   helper in the runbook that computes "current leader commit minus N".
+3. Do we want a `--raftBootstrapMembers` syntax extension to mark
+   bootstrap members as learners? Current proposal: **no**. Cold
+   bootstrap is voter-only; learners enter exclusively via
+   `AddLearner` against an existing leader. This keeps the bootstrap
+   path narrow and avoids a footgun where someone bootstraps a
+   learner-majority cluster.
+4. Future work: should `LinearizableRead` on a learner be served
+   locally with `ReadIndex` + apply-wait, instead of forwarded? That
+   is the follower-served-reads question and explicitly out of scope
+   here.
+
+## 9. Decision criteria
+
+Proceed with Milestone 1 if at least one of the following is true:
+
+- An operator workflow needs to attach a catch-up replica without
+  shrinking voter fault tolerance during catch-up. (Always true for
+  any production-shaped use of elastickv.)
+- A planned subsystem — hotspot shard split, workload isolation,
+  follower-served reads — needs a non-voting replica primitive.
+
+Otherwise the cost of carrying the persisted-peers v2 format change
+without a consumer is non-trivial and we should defer.

--- a/docs/design/2026_04_26_proposed_raft_learner.md
+++ b/docs/design/2026_04_26_proposed_raft_learner.md
@@ -237,6 +237,29 @@ flagged as a structural prerequisite.
    `len(conf.Learners) > 0` is no longer rejected. Joint-consensus
    markers (`VotersOutgoing`, `LearnersNext`, `AutoLeave`) stay rejected
    — learner add/promote uses the simple V1 path which never sets them.
+
+   The voter-count comparison inside `validateConfState`
+   (`len(conf.Voters) != len(expected.Voters)`) currently builds
+   `expected` via `confStateForPeers(peers)`, which emits **every**
+   `Peer` as a voter. Once a learner has been persisted to the v2 peers
+   file, the peers slice passed in by `validateOpenPeers` is mixed
+   voter + learner. Without a fix, `expected.Voters` would be longer
+   than `conf.Voters` and the node would refuse to restart with
+   `errClusterMismatch`. Two valid resolutions, both kept inside
+   `wal_store.go`:
+
+   - **(a) Filter at the comparison.** `validateConfState` builds its
+     own `expected` voter set from `peers` filtered by
+     `Suffrage != "learner"`, and compares both `Voters` and
+     `Learners` element-wise against the snapshot's `ConfState`.
+   - **(b) Add a sibling helper.** Introduce
+     `confStateWithLearners(peers []Peer) raftpb.ConfState` used only
+     by `validateConfState`; leave `confStateForPeers` voters-only as
+     §4.3 documents.
+
+   Resolution (a) is preferred: it keeps the cold-bootstrap helper
+   minimal and isolates the validation-time peer-filtering logic next
+   to the comparison that needs it.
 4. **`upsertPeer` stops owning `e.config.Servers`.** Today it does two
    jobs: refresh the address cache `e.peers`, and stamp a
    `raftengine.Server{Suffrage: "voter"}` into `e.config.Servers`. Once
@@ -477,15 +500,40 @@ moment any cluster has a single learner attached.
 #### Voter-count cache
 
 Introduce a single event-loop-owned field `e.voterCount int` (and a
-companion `e.isLearnerNode map[uint64]bool` keyed by node ID). Both are
-**only written from the apply loop** in `applyConfigChange` /
-`applyConfigChangeV2`, **after** `rawNode.ApplyConfChange(...)` returns
-the new `ConfState`. They are derived directly from
-`conf.Voters` / `conf.Learners`. This piggybacks on the existing
-single-writer invariant for the apply loop: no extra mutex needed, no
-type-assertion contortion. Readers on the lease hot path read these
-fields under the same `e.mu` they already take for `e.peers`, so the
-critical section grows by one int load.
+companion `e.isLearnerNode map[uint64]bool` keyed by node ID).
+
+**Initialization at Open time.** `refreshStatus()` runs once during
+`Open` before the apply loop processes any entry, so the cache must
+have a correct value before that call. Wire it up adjacent to the
+existing `e.config` initialization that already reads
+`prepared.disk.LocalSnap.Metadata.ConfState`:
+
+```go
+// existing
+config: configurationFromConfState(peerMap, prepared.disk.LocalSnap.Metadata.ConfState),
+// added
+voterCount:    len(prepared.disk.LocalSnap.Metadata.ConfState.Voters),
+isLearnerNode: learnerSetFromConfState(prepared.disk.LocalSnap.Metadata.ConfState),
+```
+
+Without this, a 3-voter cluster boots with `voterCount == 0`, which
+would falsely activate the single-node fast path in `refreshStatus`
+on the very first tick.
+
+**Steady-state writes.** After Open, both fields are **only written
+from the apply loop** in `applyConfigChange` /
+`applyConfigChangeV2`, **after** `rawNode.ApplyConfChange(...)`
+returns the new `ConfState`. They are derived directly from
+`conf.Voters` / `conf.Learners` and **rebuilt from scratch** on each
+conf change — not incrementally patched. A patched form
+(`e.isLearnerNode[nodeID] = true`) would leak stale `true` entries
+after a learner is promoted; a full rebuild from `conf.Learners` is
+the only safe form. This piggybacks on the existing single-writer
+invariant for the apply loop: no extra mutex needed.
+
+Readers on the lease hot path read these fields under the same
+`e.mu` they already take for `e.peers`, so the critical section
+grows by one int load and one map lookup.
 
 #### Call-site fixes (all four `len(e.peers)` overloads)
 
@@ -791,7 +839,7 @@ After Milestone 3, rename
    absolute form is simpler to validate; the tolerance form is easier
    for an operator to choose. Current proposal: absolute, with a
    helper in the runbook that computes "current leader commit minus N".
-2a. **`min_applied_index = 0` footgun.** The proposal accepts `0` as
+3. **`min_applied_index = 0` footgun.** The proposal accepts `0` as
    "skip the precondition" to stay symmetric with `prevIndex` on the
    same RPC family. But `prevIndex == 0` is a common no-op skip
    pattern, while `min_applied_index == 0` semantically *removes the

--- a/docs/design/2026_04_26_proposed_raft_learner.md
+++ b/docs/design/2026_04_26_proposed_raft_learner.md
@@ -124,25 +124,42 @@ Neither operation enters joint consensus.
 
 ### 3.2 Today's behaviour in the elastickv etcd backend
 
-The engine *partially* handles learners and *fully* refuses to expose them:
+The engine *partially* handles learners and *fully* refuses to expose them.
+Line numbers below reflect `main` at the propose date and will drift; the
+function names and the small excerpts are the stable references.
 
-| File                                              | Behaviour                                                                                                                                                                                |
-|---------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `internal/raftengine/engine.go`                    | `Admin` interface has no `AddLearner` or `PromoteLearner`. `Server.Suffrage` field exists but no caller produces `"learner"`.                                                            |
-| `internal/raftengine/etcd/engine.go:1817-1830`     | Live `applyConfigPeerChange` ignores `ConfChangeAddLearnerNode`. Comment: "Phase 3 only exposes voter membership changes."                                                               |
-| `internal/raftengine/etcd/engine.go:1869-1884`     | Map-form `applyConfigPeerChangeToMap` does keep learner peer metadata in the in-memory snapshot — necessary for log replay round-trip — but the live engine's `peers` map does not. |
-| `internal/raftengine/etcd/engine.go:2644-2667`     | `configurationFromConfState` only walks `ConfState.Voters`; it never emits a server with `Suffrage: "learner"`.                                                                          |
-| `internal/raftengine/etcd/engine.go:3080-3106`     | `upsertPeer` hard-codes `Suffrage: "voter"`.                                                                                                                                              |
-| `internal/raftengine/etcd/wal_store.go:419-421`    | `validateConfState` rejects any `ConfState` with non-empty `Learners` / `LearnersNext` / `VotersOutgoing` as "joint consensus state is not supported".                                  |
-| `internal/raftengine/etcd/peers.go:216-222`        | `confStateForPeers` only emits `Voters`. There is no per-peer suffrage on the `Peer` struct.                                                                                              |
-| `internal/raftengine/etcd/peer_metadata.go`        | Persisted peers file (`etcd-raft-peers.bin`, version 1) stores `(NodeID, ID, Address)`. No suffrage byte.                                                                                  |
-| `proto/service.proto`                              | `RaftAdmin` exposes `AddVoter`, `RemoveServer`, `TransferLeadership`. No `AddLearner` or `PromoteLearner`. `RaftAdminMember.suffrage` exists in the response message.                    |
-| `cmd/raftadmin/main.go`                            | Subcommands: `add_voter`, `remove_server`, `leadership_transfer`, `leadership_transfer_to_server`. No learner subcommands.                                                                |
+| Location                                               | Behaviour                                                                                                                                                                              |
+|--------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `raftengine.Admin` (`internal/raftengine/engine.go`)   | No `AddLearner` or `PromoteLearner`. `Server.Suffrage` exists but no caller produces `"learner"`.                                                                                       |
+| `Engine.applyConfigPeerChange` (etcd backend)          | Live path ignores `ConfChangeAddLearnerNode`. Comment: "Phase 3 only exposes voter membership changes."                                                                                  |
+| `applyConfigPeerChangeToMap` (etcd backend)            | Map-form path *does* keep learner peer metadata for log-replay round-trip; live engine map does not.                                                                                     |
+| `configurationFromConfState` (etcd backend)            | Only walks `ConfState.Voters`; never emits a server with `Suffrage: "learner"`.                                                                                                          |
+| `Engine.upsertPeer` (etcd backend)                     | Hard-codes `raftengine.Server{..., Suffrage: "voter"}` for `e.config.Servers`.                                                                                                            |
+| `validateConfState` (`wal_store.go`)                   | Rejects any `ConfState` with non-empty `Learners` / `LearnersNext` / `VotersOutgoing` as "joint consensus state is not supported".                                                       |
+| `confStateForPeers` (`peers.go`)                       | Emits every `Peer` as a voter; no per-peer suffrage on the `Peer` struct.                                                                                                                 |
+| `peer_metadata.go`                                     | Persisted peers file (`etcd-raft-peers.bin`, version 1) stores `(NodeID, ID, Address)`. No suffrage byte.                                                                                  |
+| `proto/service.proto`                                  | `RaftAdmin` exposes `AddVoter`, `RemoveServer`, `TransferLeadership`. No `AddLearner` or `PromoteLearner`. `RaftAdminMember.suffrage` exists.                                            |
+| `cmd/raftadmin/main.go`                                | Subcommands: `add_voter`, `remove_server`, `leadership_transfer`, `leadership_transfer_to_server`.                                                                                       |
 
 The dormant pieces (`applyConfigPeerChangeToMap`, the `Suffrage` field on
-`Server`, the `suffrage` field on `RaftAdminMember`, the regression test for
-preserved learner metadata) all suggest the original etcd-migration design
-expected this exact follow-up.
+`Server`, the `suffrage` field on `RaftAdminMember`, the regression test
+`TestNextPeersAfterConfigChangeKeepsLearnerMetadata`) all suggest the original
+etcd-migration design expected this exact follow-up.
+
+### 3.3 `len(e.peers)` is overloaded as "voter count"
+
+A grep of the etcd backend reveals four hot-path call sites where
+`len(e.peers)` is currently used as a proxy for the voter denominator. Each
+breaks the moment a learner is added to `e.peers`:
+
+| Call site                            | What `len(e.peers)` means today                          | What it should mean post-learner |
+|--------------------------------------|----------------------------------------------------------|-----------------------------------|
+| `recordQuorumAck`                    | Total cluster size (incl. self) for `followerQuorumForClusterSize`. | Number of **voters** (incl. self). |
+| `refreshStatus` single-node fast path | `clusterSize <= 1` → leader-of-1 → instant lease ack.   | Voter-count `<= 1` → leader-of-1-voter → instant lease ack. |
+| `removePeer` post-removal cluster size | Used to recompute `followerQuorum` after a removal.    | Post-removal voter count.         |
+| `nextPeersAfterConfigChange*` sizing | Address-cache fan-out only — already correct, included for completeness. | Unchanged. |
+
+§4.6 enumerates the fix and §5.2 audits each site for races.
 
 ## 4. Design
 
@@ -174,42 +191,69 @@ Notes on the new methods:
   voter path already uses (`encodeConfChangeContext`). Address resolution
   uses the same `resolveAdminPeer` helper.
 - `PromoteLearner` proposes a V1 `ConfChangeAddNode` for an existing
-  learner. The engine asserts on the leader, on the single-threaded admin
-  loop, that:
+  learner. Both preconditions below run on the leader, on the
+  single-threaded admin loop (`handleAdmin`), **before** calling
+  `rawNode.ProposeConfChange`. The check intentionally cannot be lazy:
+  if the propose is queued first and the precondition then fails, the
+  conf-change entry has already entered the log and a `RemoveServer`
+  rollback would be required. So:
   1. The peer exists in `ConfState.Learners` (not in `Voters`). Otherwise
      return a `FailedPrecondition` so callers do not silently no-op.
   2. The leader's `Progress[nodeID].Match >= minAppliedIndex`. The leader
      is the authority on follower progress; an operator who reads
      `Status.AppliedIndex` from the learner itself sees a slightly stale
      view, so the engine re-checks against the leader's tracker before
-     proposing. `minAppliedIndex == 0` skips the precondition (matches the
-     existing "0 means don't care" convention used by `prevIndex`).
+     proposing. The `Progress` map is read directly from `rawNode.Status()`
+     inside the admin handler — same goroutine that owns the rawNode —
+     so no lock or clone is required.
+  3. `minAppliedIndex == 0` is **discouraged**: it skips the
+     precondition. We accept the convention to stay consistent with the
+     existing `prevIndex` ("0 means don't check the config index") on
+     the same RPC family, but the runbook calls it out as a footgun and
+     §8 lists "should we use a separate `skip_min_applied_check` boolean
+     instead" as an open question.
 - `RemoveServer` is unchanged. etcd/raft handles `ConfChangeRemoveNode` for
   a learner correctly, and the existing path already calls `peerForID` /
   `removePeer`.
 
 ### 4.2 etcd backend internals
 
-Three concrete edits, each tightly scoped:
+Four concrete edits, each tightly scoped. Edits 1–3 are the "turn on
+learner support" core; edit 4 is the ownership cleanup the reviewer
+flagged as a structural prerequisite.
 
-1. `applyConfigPeerChange` (engine.go:1817) stops dropping
-   `ConfChangeAddLearnerNode`. The handler routes to `applyAddedPeer`
-   (same as `ConfChangeAddNode`), and the *suffrage* of the peer is no
-   longer carried in the engine's `peers` map but inferred at read time
-   from `ConfState`. The `peers` map remains a (nodeID → addr) cache
-   keyed by node identity. Promotion does not change the peer entry —
-   only `ConfState.Voters` / `ConfState.Learners` changes.
+1. `applyConfigPeerChange` stops dropping `ConfChangeAddLearnerNode`.
+   The handler routes to `applyAddedPeer` (same as `ConfChangeAddNode`),
+   and the *suffrage* of the peer is no longer carried in the engine's
+   `peers` map but inferred at read time from `ConfState`. The `peers`
+   map remains a (nodeID → addr) address cache keyed by node identity.
+   Promotion does not change the peer entry — only `ConfState.Voters` /
+   `ConfState.Learners` changes.
 2. `configurationFromConfState` walks both `conf.Voters` and
    `conf.Learners` and emits the right `Suffrage` string for each. This
-   becomes the single source of truth for suffrage; `upsertPeer` stops
-   stamping a hard-coded `Suffrage: "voter"`.
-3. `validateConfState` (wal_store.go:406) accepts learner-only entries:
-   `len(conf.Learners) > 0` is no longer rejected. Joint-consensus markers
-   (`VotersOutgoing`, `LearnersNext`, `AutoLeave`) stay rejected — learner
-   add/promote uses the simple V1 path which never sets them.
+   becomes the single source of truth for suffrage that gets surfaced
+   to callers (`Configuration()`, monitoring labels).
+3. `validateConfState` (`wal_store.go`) accepts learner-only entries:
+   `len(conf.Learners) > 0` is no longer rejected. Joint-consensus
+   markers (`VotersOutgoing`, `LearnersNext`, `AutoLeave`) stay rejected
+   — learner add/promote uses the simple V1 path which never sets them.
+4. **`upsertPeer` stops owning `e.config.Servers`.** Today it does two
+   jobs: refresh the address cache `e.peers`, and stamp a
+   `raftengine.Server{Suffrage: "voter"}` into `e.config.Servers`. Once
+   learners exist, the second job is wrong — `upsertPeer` has no
+   `ConfState` at call time, so it cannot decide the correct suffrage.
+   The fix: `upsertPeer` keeps `e.peers` only. `e.config.Servers` is
+   recomputed from the post-change `ConfState` by a single call to
+   `configurationFromConfState` inside `applyConfigChange` /
+   `applyConfigChangeV2`. That function already runs on the
+   single-threaded apply loop and already sees the new `ConfState` from
+   `rawNode.ApplyConfChange(...)`, so there is no extra synchronization
+   cost. Symmetric change in `removePeer`: it stops splicing
+   `e.config.Servers` directly and lets the apply loop rebuild it from
+   `ConfState`.
 
-`nextPeersAfterConfigChange` already routes `ConfChangeAddLearnerNode` via
-`applyAddedPeerToMap`, so the snapshot/restart code path is correct
+`nextPeersAfterConfigChange` already routes `ConfChangeAddLearnerNode`
+via `applyAddedPeerToMap`, so the snapshot/restart code path is correct
 once the live `applyConfigPeerChange` matches it.
 
 ### 4.3 Persisted peers file
@@ -256,10 +300,79 @@ Compatibility:
   acceptable because we already require explicit offline migration tooling
   for engine downgrades (Phase 5 of the etcd-migration doc).
 
-The `ConfState` carried inside the local raft snapshot remains the
-*authoritative* source of suffrage. The peers file is a cache plus an
-operator-readable summary; on conflict, the snapshot's `ConfState` wins,
-and `persistConfigState` overwrites the peers file accordingly.
+#### Authoritative source of suffrage during recovery
+
+The `ConfState` carried inside the local raft snapshot, plus any
+`ConfChange` entries replayed from the WAL on top of that snapshot, is
+the **authoritative** source of suffrage. The peers file is an address
+cache plus an operator-readable summary, with one important asymmetry:
+`validateOpenPeers` already short-circuits when
+`persisted.Index > snapshot.Metadata.Index` because the persisted file
+can be more current than the local snapshot. That asymmetry is fine for
+addresses but not for suffrage, because between the snapshot and the
+persisted-peers index there may be `ConfChangeAddLearnerNode` and
+`ConfChangeAddNode`-as-promote entries that change a peer's role.
+
+Recovery is therefore explicitly two-phase:
+
+1. **Open phase** — load addresses from the v2 peers file (or the v1
+   file, treated as all-voter). The engine boots with that as the
+   address cache. The suffrage byte from the file is used only for the
+   bootstrap-time `confStateForPeers` call (see next bullet).
+2. **WAL-replay phase** — after `rawNode.Ready()` drains the snapshot
+   and replays log entries up to the persisted commit index, the engine
+   re-derives the peer-set view from the resulting `ConfState`:
+   `e.config.Servers` is rebuilt by `configurationFromConfState`
+   (edit 4 of §4.2). The peers-file suffrage byte is **not** read
+   again after this point. The next `persistConfigState` call writes
+   the post-replay state back to the v2 file.
+
+Concretely: after open, the rule is "snapshot+log wins, the peers file
+catches up". The reviewer's concern that an in-flight learner-add could
+look inconsistent during the gap between snapshot read and WAL replay
+is addressed by never *acting* on the peers-file suffrage during that
+gap — `validateConfState` runs against the snapshot's `ConfState`
+(which always represents a consistent committed state), and the
+in-memory `e.config.Servers` is the post-replay view, not the
+post-open-phase view.
+
+#### `confStateForPeers` and the `Peer.Suffrage` field
+
+`confStateForPeers` is called only on cold bootstrap, before any
+`ConfState` exists, to mint the very first conf state from the operator's
+`--raftBootstrapMembers` list. Cold bootstrap is voters-only (§4.5), so
+the simplest correct implementation is:
+
+```go
+func confStateForPeers(peers []Peer) raftpb.ConfState {
+    voters := make([]uint64, 0, len(peers))
+    for _, peer := range peers {
+        voters = append(voters, peer.NodeID)
+    }
+    return raftpb.ConfState{Voters: voters}
+}
+```
+
+— i.e., unchanged. Cold bootstrap with a learner is rejected upstream in
+`prepareOpenState` with a typed error (§4.5 / risk #5).
+
+For the **persisted-peers v2 read** path, we still add a
+`Peer.Suffrage` field to the in-memory struct so v2 payloads round-trip
+cleanly through tests and through the operator-visible
+`raftadmin configuration` output during the open phase. But that
+field is *not* consulted by `confStateForPeers`. The two writers stay
+distinct:
+
+- `confStateForPeers(peers []Peer) raftpb.ConfState` — cold bootstrap,
+  voters only, ignores `Peer.Suffrage`.
+- `configurationFromConfState(peers map[uint64]Peer, conf raftpb.ConfState) raftengine.Configuration` —
+  hot path, reads suffrage from `conf.Voters` / `conf.Learners`,
+  ignores `Peer.Suffrage`.
+
+`Peer.Suffrage` is therefore a v2-file artifact only. This keeps the
+`ConfState` as the single source of suffrage truth and avoids the
+"peers file says learner, ConfState says voter" divergence the reviewer
+flagged.
 
 ### 4.4 RPC and CLI surface
 
@@ -314,11 +427,29 @@ Cold bootstrap (`--raftBootstrap` plus optionally `--raftBootstrapMembers`):
 
 Joining an existing cluster as a learner:
 
-- New CLI flag (per group): `--raftJoinAsLearner` (default `false`). When
-  set, the local node refuses to self-bootstrap and refuses to be added
-  with `AddVoter` from outside; it expects an operator to call
-  `AddLearner` against the existing leader before it appears in
-  `ConfState`.
+- New CLI flag (per group): `--raftJoinAsLearner` (default `false`).
+- **Enforcement is local and post-apply, not pre-propose.** The flag
+  does *not* attempt to block the leader from issuing a
+  `ConfChangeAddNode` for this node. Doing so would either require a
+  network-level vetoing protocol (no such mechanism exists in the
+  codebase) or rejecting an `Apply` mid-stream (catastrophic — diverges
+  the log). Instead, after each conf-change `Apply`, the joining node
+  inspects the resulting `ConfState`:
+  1. If `--raftJoinAsLearner=true` and the local node ID appears in
+     `ConfState.Voters` (and not in `ConfState.Learners`), the engine
+     emits an ERROR-level structured log
+     (`elastickv_raft_join_role_violation_total`) **and the node
+     continues running** as a voter. We do not shut down: by the time
+     the conf change has applied, the local node already counts toward
+     quorum, and an unilateral shutdown would shrink fault tolerance.
+     The operator is responsible for either (a) calling
+     `RemoveServer` against the leader followed by re-adding via
+     `AddLearner`, or (b) acknowledging the deviation and clearing the
+     flag.
+  2. If `--raftJoinAsLearner=true` and the local node ID is in
+     `ConfState.Learners`, normal operation continues.
+  3. The flag is therefore primarily an **operator alarm**, not a
+     consensus-level enforcement. The runbook makes this explicit.
 - Operationally:
   1. Operator brings up the joiner with `--raftJoinAsLearner` and the
      peer list it knows about (existing voters; the joiner's own
@@ -339,21 +470,67 @@ Joining an existing cluster as a learner:
 
 The lease-read fast path
 (`LeaseProvider` / `LastQuorumAck` / `quorumAckTracker`) must not require
-acknowledgement from learners. Specifically:
+acknowledgement from learners. This is the **highest-risk** area of the
+proposal — the wrong fix silently regresses lease-read latency the
+moment any cluster has a single learner attached.
 
-- `followerQuorumForClusterSize` currently takes the total *cluster size*
-  (`len(e.peers)`) to compute a follower-quorum denominator. After this
-  change, that count includes learners, which would inflate the
-  denominator and stall lease reads whenever a learner is slow.
-- The engine must compute the lease-read denominator from
-  `len(ConfState.Voters)` (excluding self if leader), not `len(e.peers)`.
-  `recordQuorumAck` already gates on `isLeader`; we additionally drop
-  responses from peers whose `nodeID` is in `ConfState.Learners` so a
-  learner heartbeat ack cannot count toward voter majority.
+#### Voter-count cache
 
-This is the **highest-risk** area of this proposal and gets its own
-behaviour test (see §5.2). The wrong fix here would silently regress
-lease-read latency the moment any cluster has a single learner attached.
+Introduce a single event-loop-owned field `e.voterCount int` (and a
+companion `e.isLearnerNode map[uint64]bool` keyed by node ID). Both are
+**only written from the apply loop** in `applyConfigChange` /
+`applyConfigChangeV2`, **after** `rawNode.ApplyConfChange(...)` returns
+the new `ConfState`. They are derived directly from
+`conf.Voters` / `conf.Learners`. This piggybacks on the existing
+single-writer invariant for the apply loop: no extra mutex needed, no
+type-assertion contortion. Readers on the lease hot path read these
+fields under the same `e.mu` they already take for `e.peers`, so the
+critical section grows by one int load.
+
+#### Call-site fixes (all four `len(e.peers)` overloads)
+
+1. **`recordQuorumAck`** (event-loop goroutine, single writer):
+   - Replace `clusterSize := len(e.peers)` with
+     `clusterSize := e.voterCount`.
+   - Reject the ack early when `e.isLearnerNode[msg.From]` is true.
+     This is in addition to the existing `e.peers[msg.From]` membership
+     check; a learner peer is in `e.peers` but must not contribute to
+     the voter ack tracker.
+   - The early `clusterSize <= 1` short-circuit stays — it now
+     correctly means "no other voter to ack from" rather than "no
+     other peer at all".
+
+2. **`refreshStatus` single-node fast path**:
+   - Replace `clusterSize := len(e.peers)` with the cached
+     `e.voterCount`. The leader-of-1 fast path
+     (`singleNodeLeaderAckMonoNs`) now triggers when the leader is the
+     **only voter** regardless of how many learners are attached. This
+     is the single critical fix for the 1-voter+1-learner stall the
+     reviewer flagged.
+
+3. **`removePeer` post-removal cluster size**:
+   - Today it computes `postRemovalClusterSize := len(e.peers)` after
+     deleting the peer and feeds that into
+     `followerQuorumForClusterSize`. After the fix, the apply loop
+     updates `e.voterCount` from the post-change `ConfState` *before*
+     `removePeer` is called for any address-cache cleanup, so
+     `removePeer` simply reads `e.voterCount`. (Removing a learner
+     does not change `e.voterCount`; removing a voter decrements it
+     by one.)
+
+4. **`nextPeersAfterConfigChange*`** — already correct (it walks
+   addresses, not voters). Listed only to confirm we audited it.
+
+#### Why an event-loop-owned cache instead of "read `ConfState` on each call"
+
+The lease-read fast path is intentionally lock-free up to a single
+`e.mu` acquisition. Re-deriving voter count from `rawNode.Status()` on
+each ack would either (a) require acquiring the rawNode-internal mutex
+on a hot path, or (b) clone the `Progress` map per call. Caching the
+scalar voter count and the per-peer learner bitset keeps both hot paths
+(`recordQuorumAck`, `refreshStatus`) at O(1) cost and ties the cache
+update to the natural sequencing point — the apply loop, where the new
+`ConfState` is unambiguously known.
 
 ### 4.7 What does *not* change
 
@@ -413,9 +590,15 @@ because each of these passes informs the milestone breakdown.
   this is the desired behaviour, not a bug.
 - Quorum-ack tracker race: `recordQuorumAck` is gated by `isLeader`; the
   step-down path (`leaderLossCbs`) already invalidates the tracker. The
-  new gate ("drop responses from learner peers") reads `ConfState`
-  through the same lock as the existing `peers` map, so it does not
-  introduce a new race.
+  new gate ("drop responses from learner peers") reads
+  `e.isLearnerNode` (§4.6 voter-count cache), which is written only on
+  the single-threaded apply loop and read under the same `e.mu` already
+  held for the `e.peers` membership check. No new race.
+- `e.voterCount` ordering: the apply loop updates `e.voterCount` and
+  `e.isLearnerNode` *before* invoking the per-peer cleanup helpers
+  (`upsertPeer`, `removePeer`), so any subsequent `recordQuorumAck` on
+  the same loop iteration sees the post-change view. `refreshStatus`
+  runs after `drainReady` and likewise sees the post-change view.
 - Removing a learner mid-promote: etcd/raft processes conf changes
   serially — the second proposal stays in the log behind the first and
   is applied or rejected deterministically. `pendingConfigs` already
@@ -479,8 +662,16 @@ because each of these passes informs the milestone breakdown.
   learners and `"voter"` for voters, including after restart.
 - Persisted peers v1→v2 round-trip test.
 - `quorumAckTracker` regression test: lease reads must not block on
-  learner ack.
+  learner ack. Specific cases: (a) 1-voter + 1-learner cluster lease
+  reads stay on the single-node fast path; (b) 3-voter + 1-learner
+  cluster lease reads use a 3-voter denominator, not 4.
 - `WAL purge` test with a learner mid-catch-up (data-loss pass §5.1).
+- Snapshot-during-learner-catch-up test: trigger a new FSM snapshot
+  while a learner is still receiving the previous snapshot. Verifies
+  `snapshot_spool.go`'s dedup/cancel logic does the right thing for a
+  slow learner — the catch-up replica is exactly the slow consumer the
+  spool was designed to handle, and it is the most likely place for a
+  regression to land.
 - Behaviour test: `LinearizableRead` on a learner forwards to leader's
   `ReadIndex` and returns once local apply catches up.
 - Property test for the conf-change context codec is unchanged
@@ -496,19 +687,37 @@ parameterised cluster harness in the existing Jepsen workloads.
 ### Milestone 1 — Engine-level learner support (no operator surface yet)
 
 - `Admin` interface: add `AddLearner`, `PromoteLearner`.
-- etcd backend: live `applyConfigPeerChange` accepts
-  `ConfChangeAddLearnerNode`; `configurationFromConfState` reports
-  `"learner"`; `upsertPeer` stops hard-coding `"voter"`.
-- `validateConfState` accepts learner-only entries (joint-consensus
-  markers stay rejected).
-- `quorumAckTracker` denominator + admission audit (§4.6).
-- Persisted peers file v2.
-- Unit + conformance tests (§5.5 first three bullets).
+- etcd backend:
+  - Live `applyConfigPeerChange` accepts `ConfChangeAddLearnerNode`.
+  - `configurationFromConfState` reports `"learner"`.
+  - `upsertPeer` no longer writes to `e.config.Servers`; the apply
+    loop rebuilds `e.config.Servers` from the post-change `ConfState`
+    (§4.2 edit 4).
+  - `validateConfState` accepts learner-only entries (joint-consensus
+    markers stay rejected).
+- **All four `len(e.peers)` overloads from §4.6 fixed in one PR**
+  (`recordQuorumAck`, `refreshStatus`, `removePeer`, plus the audit
+  pass on `nextPeersAfterConfigChange*`). Voter-count cache
+  (`e.voterCount`, `e.isLearnerNode`) wired through the apply loop.
+- Persisted peers file v2 with the `Peer.Suffrage` field; v1 reader
+  preserved for upgrades. `confStateForPeers` stays voters-only;
+  `Peer.Suffrage` is a v2-file artifact only (§4.3).
+- Two-phase recovery documented in code comments matching §4.3:
+  open-phase reads addresses from peers file; WAL-replay phase
+  rebuilds `e.config.Servers` and `e.voterCount` from `ConfState`.
+- Unit + conformance tests (§5.5 first four bullets, including both
+  lease-read regression cases — 1-voter+1-learner and 3-voter+1-learner).
 - No proto / CLI / flag changes yet. Promote / add are reachable via
   the engine API and engine tests only.
 
-Exit criteria: a unit test that adds a learner to a 3-node cluster,
-sees suffrage reported correctly across restarts, and promotes it.
+Exit criteria:
+1. Unit test that adds a learner to a 3-node cluster, sees suffrage
+   reported correctly across restarts, and promotes it.
+2. Lease-read regression test passes: a 1-voter+1-learner cluster
+   serves lease reads at the same latency as a 1-voter cluster
+   (the single-node fast path is retained).
+3. Lease-read regression test passes: a 3-voter+1-learner cluster
+   does not stall lease reads when the learner is partitioned.
 
 ### Milestone 2 — Operator surface
 
@@ -582,6 +791,15 @@ After Milestone 3, rename
    absolute form is simpler to validate; the tolerance form is easier
    for an operator to choose. Current proposal: absolute, with a
    helper in the runbook that computes "current leader commit minus N".
+2a. **`min_applied_index = 0` footgun.** The proposal accepts `0` as
+   "skip the precondition" to stay symmetric with `prevIndex` on the
+   same RPC family. But `prevIndex == 0` is a common no-op skip
+   pattern, while `min_applied_index == 0` semantically *removes the
+   primary safety check* of the promote operation. If a future
+   reviewer wants the safer ergonomics, the alternative is a separate
+   `bool skip_min_applied_check` field with a default of `false`,
+   forcing operators to opt in explicitly. Tracked here so it is not
+   discovered post-implementation.
 3. Do we want a `--raftBootstrapMembers` syntax extension to mark
    bootstrap members as learners? Current proposal: **no**. Cold
    bootstrap is voter-only; learners enter exclusively via

--- a/docs/design/2026_04_26_proposed_raft_learner.md
+++ b/docs/design/2026_04_26_proposed_raft_learner.md
@@ -16,7 +16,7 @@
 
 Today every member of an Elastickv Raft group is a voter. The only membership
 mutations exposed by the engine are `AddVoter` and `RemoveServer`
-(`internal/raftengine/engine.go:174`). That has three concrete consequences:
+(the `Admin` interface in `internal/raftengine/engine.go`). That has three concrete consequences:
 
 1. **Membership change is unsafe under load.** Adding a fresh node directly as a
    voter shrinks the effective fault tolerance of the group during catch-up:
@@ -57,7 +57,9 @@ dormant support on.
   CLI.
 - Report learner suffrage end-to-end. `Configuration.Servers[i].Suffrage`
   must be `"learner"` for learners and `"voter"` for voters; today it is
-  hard-coded to `"voter"` in two places (`engine.go:2656`, `engine.go:3096`).
+  hard-coded to `"voter"` in two places (`configurationFromConfState` and
+  `upsertPeer` in `internal/raftengine/etcd/engine.go`, where the helper
+  emits `Suffrage: "voter"` for every server).
 - Persist learner membership across restarts. The
   `etcd-raft-peers.bin` peer-metadata file must round-trip suffrage so that
   a node restarting from disk does not silently re-promote itself or
@@ -887,7 +889,8 @@ After Milestone 3, rename
    strongly recommends a non-zero value.
 4. **Learner cannot become leader by accident.** etcd/raft already
    enforces this; we inherit the property. The rejection path in
-   `handleTransferLeadership` (`engine.go:1387`) already documents it.
+   `handleTransferLeadership` already documents it (rejects transfer to
+   a learner via `errLeadershipTransferRejected`).
 5. **Cold bootstrap with a learner-only member list.** Reject explicitly
    with a typed error rather than relying on the underlying library to
    refuse. Otherwise an operator who specifies a learner-only bootstrap
@@ -906,15 +909,16 @@ After Milestone 3, rename
    absolute form is simpler to validate; the tolerance form is easier
    for an operator to choose. Current proposal: absolute, with a
    helper in the runbook that computes "current leader commit minus N".
-3. **`min_applied_index = 0` footgun.** The proposal accepts `0` as
-   "skip the precondition" to stay symmetric with `prevIndex` on the
-   same RPC family. But `prevIndex == 0` is a common no-op skip
-   pattern, while `min_applied_index == 0` semantically *removes the
-   primary safety check* of the promote operation. If a future
-   reviewer wants the safer ergonomics, the alternative is a separate
-   `bool skip_min_applied_check` field with a default of `false`,
-   forcing operators to opt in explicitly. Tracked here so it is not
-   discovered post-implementation.
+3. ~~**`min_applied_index = 0` footgun.**~~ **Resolved in M2.** The
+   `RaftAdminPromoteLearnerRequest` and the `Admin.PromoteLearner`
+   engine API both carry an explicit `skip_min_applied_check`
+   boolean. The engine rejects `min_applied_index == 0` with
+   `errPromoteLearnerMinAppliedZero` unless the skip flag is also
+   set, so a script that omits the catch-up bound gets a clean
+   `FailedPrecondition` instead of silently disabling the safety
+   check. The `prevIndex == 0` symmetry is preserved (it remains a
+   no-op skip — which is benign since `prevIndex` is just a
+   sequencing guard, not a safety check).
 4. Do we want a `--raftBootstrapMembers` syntax extension to mark
    bootstrap members as learners? Current proposal: **no**. Cold
    bootstrap is voter-only; learners enter exclusively via

--- a/docs/design/2026_04_26_proposed_raft_learner.md
+++ b/docs/design/2026_04_26_proposed_raft_learner.md
@@ -254,12 +254,29 @@ flagged as a structural prerequisite.
      (matching the existing pattern, which depends on the
      well-established voter ordering invariant: `persistConfigState`
      writes voters in `ConfState.Voters` order and `normalizePeers`
-     preserves it). The **learner check is set-based**:
-     `len(conf.Learners) != filteredLearnerCount && allLearnersPresent(conf.Learners, learnerSet)`.
+     preserves it). The **learner check is set-based**. As an error
+     condition (return `errClusterMismatch` when true):
+
+     ```go
+     len(conf.Learners) != filteredLearnerCount ||
+         !allLearnersPresent(conf.Learners, learnerSet)
+     ```
+
+     Equivalently, the valid condition:
+
+     ```go
+     len(conf.Learners) == filteredLearnerCount &&
+         allLearnersPresent(conf.Learners, learnerSet)
+     ```
+
      A set comparison avoids pinning a new ordering contract on the
      v2 writer for learners — there is no prior convention since
      learners have never been persisted before, and the set form is
-     strictly more robust against future writer reordering.
+     strictly more robust against future writer reordering. Use `||`
+     (not `&&`) so that **same-count member divergence** (e.g.
+     `conf.Learners = [A, B]` vs peers `[A, C]`) and **conf-learner
+     missing from peers** are both rejected; an `&&` would silently
+     accept them.
    - **(b) Add a sibling helper.** Introduce
      `confStateWithLearners(peers []Peer) raftpb.ConfState` used only
      by `validateConfState`; leave `confStateForPeers` voters-only as
@@ -298,10 +315,32 @@ flagged as a structural prerequisite.
    in the apply loop already capture the return value of
    `rawNode.ApplyConfChange(...)`, so wiring the parameter is a
    one-line change at each call site (no new mutex, no new state).
-   Inside the body, suffrage-aware updates run **after** the existing
-   per-peer cleanup helpers (`upsertPeer` / `removePeer`) so address
-   cache mutations and voter-count rebuilds happen in a deterministic
-   order on the single-threaded apply loop (cf. §5.2 ordering note).
+
+   The two suffrage-aware updates inside the body have **different
+   ordering relative to the per-peer cleanup helpers**:
+
+   1. **`e.voterCount` and `e.isLearnerNode` are updated *before*
+      `upsertPeer` / `removePeer`.** This is what §4.6 and §5.2
+      require: `removePeer` reads `e.voterCount` to compute the
+      post-removal ack-tracker threshold, so it must see the
+      post-change count, not the pre-change count.
+   2. **`e.config.Servers` is rebuilt *after* `upsertPeer` /
+      `removePeer`** via `configurationFromConfState(e.peers, confState)`.
+      This rebuild reads the address cache `e.peers`, so it has to
+      observe the post-cleanup map.
+
+   The full sequence inside `applyConfigChange` /
+   `applyConfigChangeV2` is therefore:
+
+   ```text
+   1. recompute e.voterCount, e.isLearnerNode from confState
+   2. upsertPeer / removePeer  (mutates e.peers, may read e.voterCount)
+   3. rebuild e.config.Servers via configurationFromConfState(e.peers, confState)
+   4. resolveConfigChange / configIndex bookkeeping (existing)
+   ```
+
+   All four steps run on the single-threaded apply loop, so no extra
+   synchronization is needed.
 
 `nextPeersAfterConfigChange` already routes `ConfChangeAddLearnerNode`
 via `applyAddedPeerToMap`, so the snapshot/restart code path is correct

--- a/docs/raft_learner_operations.md
+++ b/docs/raft_learner_operations.md
@@ -1,0 +1,220 @@
+# Raft Learner operations
+
+Runbook for attaching a Raft learner replica and promoting it to voter.
+Companion to the design doc `docs/design/2026_04_26_proposed_raft_learner.md`.
+
+The learner primitive lets you attach a fresh node, let it catch up
+on the log, and then promote it to voter — without ever shrinking the
+cluster's effective fault tolerance during catch-up. The voter quorum
+denominator stays at the existing voter count for the entire catch-up
+window because the learner does not vote and is not part of the
+ack-tracker majority.
+
+## When to use
+
+- Adding a new replica to an existing cluster.
+- Replacing a removed voter with a fresh data dir.
+- Bringing up a follower-served-read replica (future work; the learner
+  is the storage primitive, the read path is a separate effort).
+
+## Prerequisites
+
+- The new node has a clean Raft data dir (`--raftDataDir`). If the dir
+  contains an old engine marker that disagrees with the cluster's
+  engine, refuse to reuse it — see `docs/etcd_raft_migration_operations.md`.
+- The `raftadmin` CLI binary is available on a host that can reach the
+  leader's gRPC port. Either build it (`go build ./cmd/raftadmin`) or
+  use the binary shipped with the deployment.
+- You know the cluster's leader (e.g. via `raftadmin <leader-addr> leader`).
+
+## Workflow
+
+### 1. Bring up the joining node
+
+Start the node with `--raftJoinAsLearner` set. The flag is an
+**operator alarm**, not a consensus-level enforcement:
+
+```sh
+go run . \
+  --raftId          n4 \
+  --address         127.0.0.1:50054 \
+  --redisAddress    127.0.0.1:63794 \
+  --raftDataDir     /var/lib/elastickv/n4 \
+  --raftJoinAsLearner
+```
+
+The joiner will start, register with the gRPC transport, and wait for
+the leader to fan out the cluster's `ConfState` — it has no
+peer membership of its own yet.
+
+`--raftJoinAsLearner` does *not* prevent the leader from issuing an
+`AddVoter` for this node. If that happens (operator typo, runaway
+script), the joiner's apply loop detects the role mismatch
+post-apply, emits an `ERROR`-level structured log
+(`etcd raft join-as-learner alarm: local node was added as voter`)
+and bumps `JoinRoleViolationCount`. The node keeps running — by the
+time the conf change has applied, it already counts toward the voter
+quorum, and shutting down would shrink fault tolerance. The operator
+remediation is to remove and re-add the node correctly.
+
+### 2. Attach as learner against the leader
+
+From the operator host:
+
+```sh
+raftadmin <leader-addr> add_learner <id> <address> [previous_index]
+```
+
+Concrete example:
+
+```sh
+raftadmin 127.0.0.1:50051 add_learner n4 127.0.0.1:50054
+```
+
+The leader proposes a `ConfChangeAddLearnerNode`. The learner enters
+`ConfState.Learners`, the existing voters' quorum size is **unchanged**,
+and the leader starts replicating log entries (and snapshots, if the
+joiner is far behind) over the existing gRPC raft transport.
+
+The optional `previous_index` is the leader's expected current
+configuration index. Pass it when scripting back-to-back conf changes
+to fail fast on stale plans; pass `0` (or omit) to skip the check.
+
+### 3. Verify the learner is attached
+
+```sh
+raftadmin <leader-addr> configuration
+```
+
+The output now lists the learner with `suffrage: "learner"`:
+
+```text
+servers {
+  id: "n1"
+  address: "127.0.0.1:50051"
+  suffrage: "voter"
+}
+servers {
+  id: "n2"
+  address: "127.0.0.1:50052"
+  suffrage: "voter"
+}
+servers {
+  id: "n3"
+  address: "127.0.0.1:50053"
+  suffrage: "voter"
+}
+servers {
+  id: "n4"
+  address: "127.0.0.1:50054"
+  suffrage: "learner"
+}
+```
+
+The learner does not appear in `Status.NumPeers` calculations as a
+voter; it does appear in `Configuration().Servers`.
+
+### 4. Wait for the learner to catch up
+
+Poll the leader's `Status` and the learner's own `Status` until the
+learner's `applied_index` is close to the leader's `commit_index`:
+
+```sh
+LEADER_COMMIT=$(raftadmin <leader-addr> state | awk '/CommitIndex/{print $2}')
+LEARNER_APPLIED=$(raftadmin <learner-addr> state | awk '/AppliedIndex/{print $2}')
+```
+
+(Adjust to your `raftadmin state` output format.)
+
+A reasonable rule of thumb is "applied within N entries of leader
+commit" — choose N based on how aggressively new writes are landing.
+For a quiet cluster, applied == commit is achievable in seconds; for
+a busy cluster, allow more slack.
+
+### 5. Promote the learner to voter
+
+```sh
+raftadmin <leader-addr> promote_learner <id> [previous_index] [min_applied_index]
+```
+
+The recommended invocation **always** passes `min_applied_index`:
+
+```sh
+LEADER_COMMIT=$(...)              # latest leader commit_index
+raftadmin 127.0.0.1:50051 promote_learner n4 0 ${LEADER_COMMIT}
+```
+
+The leader runs both preconditions on the single-threaded admin loop
+**before** proposing:
+
+1. The target peer must currently be a learner. Promoting a node that
+   is already a voter (or that doesn't exist) returns
+   `FailedPrecondition: etcd raft promote-learner target is not a learner`.
+2. The leader's `Progress[nodeID].Match` must be `>= min_applied_index`.
+   If the learner has not caught up, the leader returns
+   `FailedPrecondition: ... target has not caught up to min_applied_index`.
+
+`min_applied_index = 0` skips the catch-up check. **Do not use 0 in
+production.** It is accepted for symmetry with `previous_index` on
+the same RPC family but it removes the primary safety check of
+promote (see design §8 open question 3).
+
+After a successful promote, `raftadmin configuration` shows the peer
+with `suffrage: "voter"` and the cluster's voter count has grown by
+one.
+
+### 6. Sanity checks after promotion
+
+- `raftadmin configuration` lists the new voter.
+- `raftadmin state` on the new voter reports `state: FOLLOWER` (or
+  `LEADER` if it later wins an election).
+- A `Propose` against the leader still commits — write traffic is
+  uninterrupted by the membership change.
+
+## Removing a learner
+
+If a learner needs to be detached (e.g., the operator decided not to
+promote, or the node is being decommissioned), use the existing
+`remove_server` command. There is no learner-specific RemoveLearner
+RPC; etcd/raft uses `ConfChangeRemoveNode` for both voters and
+learners.
+
+```sh
+raftadmin <leader-addr> remove_server <id>
+```
+
+The voter quorum is unchanged because the removed peer was never a
+voter.
+
+## Common errors
+
+| Error | Cause | Remediation |
+|-------|-------|-------------|
+| `add learner: rpc error: ... not leader` | The address is not currently leader. | Re-issue against `raftadmin leader`. |
+| `promote learner: rpc error: ... target is not a learner` | The peer is already a voter, or the ID is wrong. | Verify with `raftadmin configuration`. |
+| `promote learner: rpc error: ... target has not caught up to min_applied_index` | Learner is still replicating. | Wait and retry; lower `min_applied_index` only if you understand the safety implication. |
+| `promote learner: rpc error: ... target has no leader-side progress entry` | The learner is not in the leader's `Progress` map (e.g., raft has not yet processed the AddLearner). | Confirm the prior `add_learner` was committed via `configuration` before issuing `promote_learner`. |
+| `add learner: rpc error: ... has too many pending config changes` | A previous conf change is still in flight. | Wait for it to commit; retry. |
+
+## Observability
+
+- `JoinRoleViolationCount` (process-wide counter): bumped each time
+  the post-apply alarm fires for a node booted with
+  `--raftJoinAsLearner` that finds itself in `ConfState.Voters`.
+  Surfaced via `internal/raftengine/etcd.JoinRoleViolationCount()`.
+- `raftadmin configuration` is the operator-readable view of suffrage
+  for every member of the cluster.
+
+## What this workflow does **not** do
+
+- **Cold-bootstrap a learner-only cluster.** Bootstrap requires at
+  least one voter to win an uncontested first election. A learner-only
+  bootstrap configuration is rejected at startup.
+- **Auto-promotion.** The engine never promotes a learner on its own.
+  Promotion is always an explicit operator action via
+  `promote_learner`.
+- **Serve linearizable reads from the learner.** Today
+  `LinearizableRead` on a learner returns `ErrNotLeader` and the
+  caller must forward to the leader. Follower-served reads are an
+  explicit non-goal of this milestone and will be addressed in a
+  separate proposal.

--- a/docs/raft_learner_operations.md
+++ b/docs/raft_learner_operations.md
@@ -134,10 +134,11 @@ a busy cluster, allow more slack.
 ### 5. Promote the learner to voter
 
 ```sh
-raftadmin <leader-addr> promote_learner <id> [previous_index] [min_applied_index]
+raftadmin <leader-addr> promote_learner <id> [previous_index] [min_applied_index] [skip_min_applied_check]
 ```
 
-The recommended invocation **always** passes `min_applied_index`:
+The recommended invocation **always** passes a non-zero
+`min_applied_index`:
 
 ```sh
 LEADER_COMMIT=$(...)              # latest leader commit_index
@@ -154,10 +155,19 @@ The leader runs both preconditions on the single-threaded admin loop
    If the learner has not caught up, the leader returns
    `FailedPrecondition: ... target has not caught up to min_applied_index`.
 
-`min_applied_index = 0` skips the catch-up check. **Do not use 0 in
-production.** It is accepted for symmetry with `previous_index` on
-the same RPC family but it removes the primary safety check of
-promote (see design §8 open question 3).
+If `min_applied_index = 0` and `skip_min_applied_check` is not set,
+the engine rejects the request with
+`FailedPrecondition: ... requires min_applied_index>0 unless skip_min_applied_check is set`.
+This is intentional: it forces an operator who copy-pastes a script
+that forgets the catch-up bound to make an explicit decision, rather
+than silently disabling the primary safety check of the promote
+operation.
+
+The `skip_min_applied_check=true` escape hatch exists for bootstrap-
+time scaffolding where the operator has confirmed catch-up
+out-of-band (e.g., by inspecting `raftadmin <learner-addr> state`).
+**Do not use it in normal production runs** — pass a real
+`min_applied_index` instead.
 
 After a successful promote, `raftadmin configuration` shows the peer
 with `suffrage: "voter"` and the cluster's voter count has grown by

--- a/internal/raftadmin/server.go
+++ b/internal/raftadmin/server.go
@@ -101,7 +101,7 @@ func (s *Server) PromoteLearner(ctx context.Context, req *pb.RaftAdminPromoteLea
 	if req == nil || req.Id == "" {
 		return nil, grpcStatus(codes.InvalidArgument, "id is required")
 	}
-	index, err := s.admin.PromoteLearner(ctx, req.Id, req.PreviousIndex, req.MinAppliedIndex)
+	index, err := s.admin.PromoteLearner(ctx, req.Id, req.PreviousIndex, req.MinAppliedIndex, req.SkipMinAppliedCheck)
 	if err != nil {
 		return nil, adminError(err)
 	}

--- a/internal/raftadmin/server.go
+++ b/internal/raftadmin/server.go
@@ -80,6 +80,34 @@ func (s *Server) AddVoter(ctx context.Context, req *pb.RaftAdminAddVoterRequest)
 	return &pb.RaftAdminConfigurationChangeResponse{Index: index}, nil
 }
 
+func (s *Server) AddLearner(ctx context.Context, req *pb.RaftAdminAddLearnerRequest) (*pb.RaftAdminConfigurationChangeResponse, error) {
+	if s == nil || s.admin == nil {
+		return nil, grpcStatus(codes.Unimplemented, "add learner is not supported by this raft engine")
+	}
+	if req == nil || req.Id == "" || req.Address == "" {
+		return nil, grpcStatus(codes.InvalidArgument, "id and address are required")
+	}
+	index, err := s.admin.AddLearner(ctx, req.Id, req.Address, req.PreviousIndex)
+	if err != nil {
+		return nil, adminError(err)
+	}
+	return &pb.RaftAdminConfigurationChangeResponse{Index: index}, nil
+}
+
+func (s *Server) PromoteLearner(ctx context.Context, req *pb.RaftAdminPromoteLearnerRequest) (*pb.RaftAdminConfigurationChangeResponse, error) {
+	if s == nil || s.admin == nil {
+		return nil, grpcStatus(codes.Unimplemented, "promote learner is not supported by this raft engine")
+	}
+	if req == nil || req.Id == "" {
+		return nil, grpcStatus(codes.InvalidArgument, "id is required")
+	}
+	index, err := s.admin.PromoteLearner(ctx, req.Id, req.PreviousIndex, req.MinAppliedIndex)
+	if err != nil {
+		return nil, adminError(err)
+	}
+	return &pb.RaftAdminConfigurationChangeResponse{Index: index}, nil
+}
+
 func (s *Server) RemoveServer(ctx context.Context, req *pb.RaftAdminRemoveServerRequest) (*pb.RaftAdminConfigurationChangeResponse, error) {
 	if s == nil || s.admin == nil {
 		return nil, grpcStatus(codes.Unimplemented, "remove server is not supported by this raft engine")

--- a/internal/raftadmin/server_test.go
+++ b/internal/raftadmin/server_test.go
@@ -185,6 +185,22 @@ func TestServerMapsEngineAdminMethods(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(11), addResp.Index)
 
+	addLearnerResp, err := server.AddLearner(context.Background(), &pb.RaftAdminAddLearnerRequest{
+		Id:            "node-4",
+		Address:       "127.0.0.1:50054",
+		PreviousIndex: 6,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(33), addLearnerResp.Index)
+
+	promoteResp, err := server.PromoteLearner(context.Background(), &pb.RaftAdminPromoteLearnerRequest{
+		Id:              "node-4",
+		PreviousIndex:   7,
+		MinAppliedIndex: 99,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(44), promoteResp.Index)
+
 	removeResp, err := server.RemoveServer(context.Background(), &pb.RaftAdminRemoveServerRequest{
 		Id:            "node-2",
 		PreviousIndex: 5,
@@ -203,6 +219,8 @@ func TestServerMapsEngineAdminMethods(t *testing.T) {
 	engine.mu.Lock()
 	defer engine.mu.Unlock()
 	require.Equal(t, []fakeAddVoterCall{{id: "node-3", address: "127.0.0.1:50053", prevIndex: 4}}, engine.addVoterCalls)
+	require.Equal(t, []fakeAddVoterCall{{id: "node-4", address: "127.0.0.1:50054", prevIndex: 6}}, engine.addLearnerCalls)
+	require.Equal(t, []fakePromoteLearnerCall{{id: "node-4", prevIndex: 7, minAppliedIndex: 99}}, engine.promoteLearnerCalls)
 	require.Equal(t, []fakeRemoveServerCall{{id: "node-2", prevIndex: 5}}, engine.removeServerCalls)
 	require.Equal(t, 1, engine.transferCalls)
 	require.Equal(t, []fakeTransferCall{{id: "node-2", address: "127.0.0.1:50052"}}, engine.targetTransferCalls)

--- a/internal/raftadmin/server_test.go
+++ b/internal/raftadmin/server_test.go
@@ -24,6 +24,8 @@ type fakeEngine struct {
 	serving bool
 
 	addVoterCalls       []fakeAddVoterCall
+	addLearnerCalls     []fakeAddVoterCall
+	promoteLearnerCalls []fakePromoteLearnerCall
 	removeServerCalls   []fakeRemoveServerCall
 	transferCalls       int
 	targetTransferCalls []fakeTransferCall
@@ -33,6 +35,12 @@ type fakeAddVoterCall struct {
 	id        string
 	address   string
 	prevIndex uint64
+}
+
+type fakePromoteLearnerCall struct {
+	id              string
+	prevIndex       uint64
+	minAppliedIndex uint64
 }
 
 type fakeRemoveServerCall struct {
@@ -93,6 +101,20 @@ func (f *fakeEngine) AddVoter(_ context.Context, id string, address string, prev
 	defer f.mu.Unlock()
 	f.addVoterCalls = append(f.addVoterCalls, fakeAddVoterCall{id: id, address: address, prevIndex: prevIndex})
 	return 11, nil
+}
+
+func (f *fakeEngine) AddLearner(_ context.Context, id string, address string, prevIndex uint64) (uint64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.addLearnerCalls = append(f.addLearnerCalls, fakeAddVoterCall{id: id, address: address, prevIndex: prevIndex})
+	return 33, nil
+}
+
+func (f *fakeEngine) PromoteLearner(_ context.Context, id string, prevIndex uint64, minAppliedIndex uint64) (uint64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.promoteLearnerCalls = append(f.promoteLearnerCalls, fakePromoteLearnerCall{id: id, prevIndex: prevIndex, minAppliedIndex: minAppliedIndex})
+	return 44, nil
 }
 
 func (f *fakeEngine) RemoveServer(_ context.Context, id string, prevIndex uint64) (uint64, error) {

--- a/internal/raftadmin/server_test.go
+++ b/internal/raftadmin/server_test.go
@@ -38,9 +38,10 @@ type fakeAddVoterCall struct {
 }
 
 type fakePromoteLearnerCall struct {
-	id              string
-	prevIndex       uint64
-	minAppliedIndex uint64
+	id                  string
+	prevIndex           uint64
+	minAppliedIndex     uint64
+	skipMinAppliedCheck bool
 }
 
 type fakeRemoveServerCall struct {
@@ -110,10 +111,15 @@ func (f *fakeEngine) AddLearner(_ context.Context, id string, address string, pr
 	return 33, nil
 }
 
-func (f *fakeEngine) PromoteLearner(_ context.Context, id string, prevIndex uint64, minAppliedIndex uint64) (uint64, error) {
+func (f *fakeEngine) PromoteLearner(_ context.Context, id string, prevIndex uint64, minAppliedIndex uint64, skipMinAppliedCheck bool) (uint64, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.promoteLearnerCalls = append(f.promoteLearnerCalls, fakePromoteLearnerCall{id: id, prevIndex: prevIndex, minAppliedIndex: minAppliedIndex})
+	f.promoteLearnerCalls = append(f.promoteLearnerCalls, fakePromoteLearnerCall{
+		id:                  id,
+		prevIndex:           prevIndex,
+		minAppliedIndex:     minAppliedIndex,
+		skipMinAppliedCheck: skipMinAppliedCheck,
+	})
 	return 44, nil
 }
 

--- a/internal/raftengine/engine.go
+++ b/internal/raftengine/engine.go
@@ -183,12 +183,15 @@ type Admin interface {
 	// PromoteLearner promotes an existing learner to voter. The
 	// minAppliedIndex precondition is enforced against the leader's
 	// Progress[nodeID].Match before the conf change is proposed: if
-	// non-zero and the learner has not yet caught up to that index,
-	// the call returns FailedPrecondition. minAppliedIndex == 0 skips
-	// the precondition (kept for symmetry with prevIndex on this RPC
-	// family but is a footgun — operators should pass a recent leader
-	// commit index in normal use).
-	PromoteLearner(ctx context.Context, id string, prevIndex uint64, minAppliedIndex uint64) (uint64, error)
+	// the learner has not yet caught up to that index, the call
+	// returns FailedPrecondition.
+	//
+	// minAppliedIndex == 0 is REJECTED unless skipMinAppliedCheck is
+	// also true, so an operator running a copy-pasted script that
+	// omits the catch-up check gets a clean FailedPrecondition
+	// instead of a silent quorum stall. Set skipMinAppliedCheck only
+	// when the catch-up has been confirmed out-of-band.
+	PromoteLearner(ctx context.Context, id string, prevIndex uint64, minAppliedIndex uint64, skipMinAppliedCheck bool) (uint64, error)
 	RemoveServer(ctx context.Context, id string, prevIndex uint64) (uint64, error)
 	TransferLeadership(ctx context.Context) error
 	TransferLeadershipToServer(ctx context.Context, id string, address string) error

--- a/internal/raftengine/engine.go
+++ b/internal/raftengine/engine.go
@@ -172,6 +172,23 @@ type Admin interface {
 	StatusReader
 	ConfigReader
 	AddVoter(ctx context.Context, id string, address string, prevIndex uint64) (uint64, error)
+	// AddLearner attaches a non-voting replica that receives MsgApp /
+	// MsgSnap and applies log entries locally but does not contribute
+	// to the voter quorum. Use this instead of AddVoter when joining
+	// a fresh node so the cluster's effective fault tolerance is not
+	// reduced during catch-up. Promote with PromoteLearner once the
+	// learner has caught up. See
+	// docs/design/2026_04_26_proposed_raft_learner.md.
+	AddLearner(ctx context.Context, id string, address string, prevIndex uint64) (uint64, error)
+	// PromoteLearner promotes an existing learner to voter. The
+	// minAppliedIndex precondition is enforced against the leader's
+	// Progress[nodeID].Match before the conf change is proposed: if
+	// non-zero and the learner has not yet caught up to that index,
+	// the call returns FailedPrecondition. minAppliedIndex == 0 skips
+	// the precondition (kept for symmetry with prevIndex on this RPC
+	// family but is a footgun — operators should pass a recent leader
+	// commit index in normal use).
+	PromoteLearner(ctx context.Context, id string, prevIndex uint64, minAppliedIndex uint64) (uint64, error)
 	RemoveServer(ctx context.Context, id string, prevIndex uint64) (uint64, error)
 	TransferLeadership(ctx context.Context) error
 	TransferLeadershipToServer(ctx context.Context, id string, address string) error

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -122,6 +122,9 @@ var (
 	errLeadershipTransferNotLeader  = errors.Mark(errors.New("etcd raft leadership transfer requires the local node to be leader"), raftengine.ErrNotLeader)
 	errLeadershipTransferInProgress = errors.Mark(errors.New("etcd raft leadership transfer is in progress"), raftengine.ErrLeadershipTransferInProgress)
 	errTooManyPendingConfigs        = errors.New("etcd raft engine has too many pending config changes")
+	errPromoteLearnerNotLearner     = errors.New("etcd raft promote-learner target is not a learner")
+	errPromoteLearnerNoProgress     = errors.New("etcd raft promote-learner target has no leader-side progress entry")
+	errPromoteLearnerNotCaughtUp    = errors.New("etcd raft promote-learner target has not caught up to min_applied_index")
 )
 
 // Snapshot is an alias for the shared raftengine.Snapshot interface.
@@ -317,15 +320,21 @@ const (
 	adminActionAddVoter adminAction = iota + 1
 	adminActionRemoveServer
 	adminActionTransferLeadership
+	adminActionAddLearner
+	adminActionPromoteLearner
 )
 
 type adminRequest struct {
-	ctx       context.Context
-	id        uint64
-	action    adminAction
-	peer      Peer
-	prevIndex uint64
-	done      chan adminResult
+	ctx context.Context
+	id  uint64
+	// minAppliedIndex is the PromoteLearner precondition: the learner's
+	// Progress.Match on the leader must reach this index before the
+	// promotion proposal is submitted. Zero means skip the check.
+	minAppliedIndex uint64
+	action          adminAction
+	peer            Peer
+	prevIndex       uint64
+	done            chan adminResult
 }
 
 type adminResult struct {
@@ -1018,6 +1027,44 @@ func (e *Engine) AddVoter(ctx context.Context, id string, address string, prevIn
 	return result.index, nil
 }
 
+// AddLearner attaches a non-voting replica. The learner is added via
+// V1 ConfChangeAddLearnerNode and starts receiving log entries
+// immediately, but does not contribute to the voter quorum until
+// promoted with PromoteLearner.
+func (e *Engine) AddLearner(ctx context.Context, id string, address string, prevIndex uint64) (uint64, error) {
+	peer, err := e.resolveAdminPeer(id, address)
+	if err != nil {
+		return 0, err
+	}
+	result, err := e.submitAdmin(ctx, adminActionAddLearner, peer, prevIndex)
+	if err != nil {
+		return 0, err
+	}
+	return result.index, nil
+}
+
+// PromoteLearner promotes an existing learner to voter via V1
+// ConfChangeAddNode. The minAppliedIndex precondition (when non-zero)
+// rejects the call if the learner's leader-side Progress.Match has
+// not reached that index yet, so an operator who promotes too eagerly
+// gets a clean FailedPrecondition error instead of a silent quorum
+// stall.
+func (e *Engine) PromoteLearner(ctx context.Context, id string, prevIndex uint64, minAppliedIndex uint64) (uint64, error) {
+	if id == "" {
+		return 0, errors.WithStack(errPeerIDRequired)
+	}
+	result, err := e.submitAdminEx(ctx, adminRequest{
+		action:          adminActionPromoteLearner,
+		peer:            Peer{ID: id},
+		prevIndex:       prevIndex,
+		minAppliedIndex: minAppliedIndex,
+	})
+	if err != nil {
+		return 0, err
+	}
+	return result.index, nil
+}
+
 func (e *Engine) RemoveServer(ctx context.Context, id string, prevIndex uint64) (uint64, error) {
 	result, err := e.submitAdmin(ctx, adminActionRemoveServer, Peer{ID: id}, prevIndex)
 	if err != nil {
@@ -1043,20 +1090,28 @@ func (e *Engine) TransferLeadershipToServer(ctx context.Context, id string, addr
 }
 
 func (e *Engine) submitAdmin(ctx context.Context, action adminAction, peer Peer, prevIndex uint64) (adminResult, error) {
+	return e.submitAdminEx(ctx, adminRequest{
+		action:    action,
+		peer:      peer,
+		prevIndex: prevIndex,
+	})
+}
+
+// submitAdminEx is the underlying admin submit path. The caller
+// populates action, peer, prevIndex, and (for PromoteLearner)
+// minAppliedIndex; ctx, id, and done are filled in here so the
+// request integrates with the engine event loop the same way the
+// existing AddVoter / RemoveServer paths do.
+func (e *Engine) submitAdminEx(ctx context.Context, req adminRequest) (adminResult, error) {
 	if err := contextErr(ctx); err != nil {
 		return adminResult{}, err
 	}
 	if e == nil {
 		return adminResult{}, errors.WithStack(errNilEngine)
 	}
-	req := adminRequest{
-		ctx:       ctx,
-		id:        e.nextID(),
-		action:    action,
-		peer:      peer,
-		prevIndex: prevIndex,
-		done:      make(chan adminResult, 1),
-	}
+	req.ctx = ctx
+	req.id = e.nextID()
+	req.done = make(chan adminResult, 1)
 
 	select {
 	case <-ctx.Done():
@@ -1317,9 +1372,17 @@ func (e *Engine) handleAdmin(req adminRequest) {
 		return
 	}
 
+	e.dispatchAdminAction(req)
+}
+
+func (e *Engine) dispatchAdminAction(req adminRequest) {
 	switch req.action {
 	case adminActionAddVoter:
 		e.handleAddVoter(req)
+	case adminActionAddLearner:
+		e.handleAddLearner(req)
+	case adminActionPromoteLearner:
+		e.handlePromoteLearner(req)
 	case adminActionRemoveServer:
 		e.handleRemoveServer(req)
 	case adminActionTransferLeadership:
@@ -1330,14 +1393,67 @@ func (e *Engine) handleAdmin(req adminRequest) {
 }
 
 func (e *Engine) handleAddVoter(req adminRequest) {
-	contextBytes, err := encodeConfChangeContext(req.id, req.peer)
+	e.proposeMembershipChange(req, raftpb.ConfChangeAddNode, req.peer)
+}
+
+// handleAddLearner submits a ConfChangeAddLearnerNode for a fresh
+// non-voting peer. It runs on the single-threaded admin loop.
+func (e *Engine) handleAddLearner(req adminRequest) {
+	e.proposeMembershipChange(req, raftpb.ConfChangeAddLearnerNode, req.peer)
+}
+
+// handlePromoteLearner promotes an existing learner to voter via
+// ConfChangeAddNode. The two preconditions both run synchronously
+// here, before the propose, so a failed precondition does not enter
+// the log:
+//  1. the peer must currently be a learner (in ConfState.Learners,
+//     not in ConfState.Voters);
+//  2. when minAppliedIndex is non-zero, the leader-side
+//     Progress[nodeID].Match must already be >= minAppliedIndex.
+func (e *Engine) handlePromoteLearner(req adminRequest) {
+	peer, ok := e.peerForID(req.peer.ID)
+	if !ok {
+		req.done <- adminResult{err: errors.Wrapf(errTransportPeerUnknown, "id=%q", req.peer.ID)}
+		return
+	}
+	e.mu.RLock()
+	isLearner := e.isLearnerNode[peer.NodeID]
+	e.mu.RUnlock()
+	if !isLearner {
+		req.done <- adminResult{err: errors.Wrapf(errPromoteLearnerNotLearner, "id=%q", req.peer.ID)}
+		return
+	}
+	if req.minAppliedIndex != 0 {
+		// rawNode.Status() is safe here: handlePromoteLearner runs on
+		// the same goroutine that owns rawNode, so no clone or lock
+		// is required.
+		status := e.rawNode.Status()
+		progress, ok := status.Progress[peer.NodeID]
+		if !ok {
+			req.done <- adminResult{err: errors.Wrapf(errPromoteLearnerNoProgress, "id=%q node=%d", peer.ID, peer.NodeID)}
+			return
+		}
+		if progress.Match < req.minAppliedIndex {
+			req.done <- adminResult{err: errors.Wrapf(errPromoteLearnerNotCaughtUp, "id=%q match=%d want>=%d", peer.ID, progress.Match, req.minAppliedIndex)}
+			return
+		}
+	}
+	e.proposeMembershipChange(req, raftpb.ConfChangeAddNode, peer)
+}
+
+// proposeMembershipChange wraps the encode + storePendingConfig +
+// ProposeConfChange dance shared by AddVoter / AddLearner /
+// PromoteLearner. The caller has already validated the leader and
+// prevIndex preconditions in handleAdmin.
+func (e *Engine) proposeMembershipChange(req adminRequest, changeType raftpb.ConfChangeType, peer Peer) {
+	contextBytes, err := encodeConfChangeContext(req.id, peer)
 	if err != nil {
 		req.done <- adminResult{err: err}
 		return
 	}
 	cc := raftpb.ConfChange{
-		Type:    raftpb.ConfChangeAddNode,
-		NodeID:  req.peer.NodeID,
+		Type:    changeType,
+		NodeID:  peer.NodeID,
 		Context: contextBytes,
 	}
 	if err := e.storePendingConfig(req); err != nil {
@@ -3221,9 +3337,7 @@ func (e *Engine) removePeer(nodeID uint64) {
 	}
 
 	e.mu.Lock()
-	if _, ok := e.peers[nodeID]; ok {
-		delete(e.peers, nodeID)
-	}
+	delete(e.peers, nodeID)
 	// e.voterCount has already been refreshed for the post-change
 	// ConfState by refreshVoterCache earlier in the apply iteration
 	// (see applyConfigChange / applyConfigChangeV2). The ack tracker

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -125,6 +125,7 @@ var (
 	errPromoteLearnerNotLearner     = errors.New("etcd raft promote-learner target is not a learner")
 	errPromoteLearnerNoProgress     = errors.New("etcd raft promote-learner target has no leader-side progress entry")
 	errPromoteLearnerNotCaughtUp    = errors.New("etcd raft promote-learner target has not caught up to min_applied_index")
+	errPromoteLearnerMinAppliedZero = errors.New("etcd raft promote-learner requires min_applied_index>0 unless skip_min_applied_check is set")
 )
 
 // joinRoleViolationCount counts the number of times the join-as-learner
@@ -360,12 +361,17 @@ type adminRequest struct {
 	id  uint64
 	// minAppliedIndex is the PromoteLearner precondition: the learner's
 	// Progress.Match on the leader must reach this index before the
-	// promotion proposal is submitted. Zero means skip the check.
+	// promotion proposal is submitted.
 	minAppliedIndex uint64
-	action          adminAction
-	peer            Peer
-	prevIndex       uint64
-	done            chan adminResult
+	// skipMinAppliedCheck explicitly opts out of the precondition.
+	// Required when minAppliedIndex == 0; otherwise the engine
+	// rejects the request with errPromoteLearnerMinAppliedZero so a
+	// missing argument cannot silently disable the safety check.
+	skipMinAppliedCheck bool
+	action              adminAction
+	peer                Peer
+	prevIndex           uint64
+	done                chan adminResult
 }
 
 type adminResult struct {
@@ -1076,20 +1082,27 @@ func (e *Engine) AddLearner(ctx context.Context, id string, address string, prev
 }
 
 // PromoteLearner promotes an existing learner to voter via V1
-// ConfChangeAddNode. The minAppliedIndex precondition (when non-zero)
-// rejects the call if the learner's leader-side Progress.Match has
-// not reached that index yet, so an operator who promotes too eagerly
-// gets a clean FailedPrecondition error instead of a silent quorum
-// stall.
-func (e *Engine) PromoteLearner(ctx context.Context, id string, prevIndex uint64, minAppliedIndex uint64) (uint64, error) {
+// ConfChangeAddNode. The minAppliedIndex precondition rejects the
+// call if the learner's leader-side Progress.Match has not reached
+// that index yet, so an operator who promotes too eagerly gets a
+// clean FailedPrecondition error instead of a silent quorum stall.
+//
+// minAppliedIndex == 0 is rejected unless skipMinAppliedCheck is
+// also true. Set skipMinAppliedCheck only when the catch-up has
+// been confirmed out-of-band.
+func (e *Engine) PromoteLearner(ctx context.Context, id string, prevIndex uint64, minAppliedIndex uint64, skipMinAppliedCheck bool) (uint64, error) {
 	if id == "" {
 		return 0, errors.WithStack(errPeerIDRequired)
 	}
+	if minAppliedIndex == 0 && !skipMinAppliedCheck {
+		return 0, errors.WithStack(errPromoteLearnerMinAppliedZero)
+	}
 	result, err := e.submitAdminEx(ctx, adminRequest{
-		action:          adminActionPromoteLearner,
-		peer:            Peer{ID: id},
-		prevIndex:       prevIndex,
-		minAppliedIndex: minAppliedIndex,
+		action:              adminActionPromoteLearner,
+		peer:                Peer{ID: id},
+		prevIndex:           prevIndex,
+		minAppliedIndex:     minAppliedIndex,
+		skipMinAppliedCheck: skipMinAppliedCheck,
 	})
 	if err != nil {
 		return 0, err
@@ -1455,7 +1468,14 @@ func (e *Engine) handlePromoteLearner(req adminRequest) {
 		req.done <- adminResult{err: errors.Wrapf(errPromoteLearnerNotLearner, "id=%q", req.peer.ID)}
 		return
 	}
-	if req.minAppliedIndex != 0 {
+	// PromoteLearner gates on a minAppliedIndex catch-up check by
+	// default; only an explicit skipMinAppliedCheck disables it. The
+	// engine-side guard in PromoteLearner already rejects
+	// minAppliedIndex == 0 without skipMinAppliedCheck, so by the
+	// time we reach the apply-loop handler one of these is true:
+	//   * minAppliedIndex > 0  -> verify against Progress.Match
+	//   * skipMinAppliedCheck  -> caller has confirmed out-of-band
+	if !req.skipMinAppliedCheck {
 		// rawNode.Status() is safe here: handlePromoteLearner runs on
 		// the same goroutine that owns rawNode, so no clone or lock
 		// is required.
@@ -2730,8 +2750,25 @@ func (e *Engine) currentConfigIndex() uint64 {
 }
 
 func (e *Engine) shouldCampaignSingleNode() bool {
+	// Count VOTERS in the current configuration, not all servers --
+	// a learner does not vote and must not block the single-voter
+	// fast-path Campaign(). After learner support landed,
+	// len(cfg.Servers) includes learners, so the previous check
+	// would skip Campaign() in a 1-voter + N-learner cluster on
+	// restart and incur a full electionTimeout latency for no
+	// reason. See docs/design/2026_04_26_proposed_raft_learner.md
+	// §4.6 / §3.3 (the audit of len(e.peers) overloads).
 	cfg := e.currentConfiguration()
-	return len(cfg.Servers) == 1 && cfg.Servers[0].ID == e.localID
+	var soleVoter raftengine.Server
+	voterCount := 0
+	for _, s := range cfg.Servers {
+		if s.Suffrage != SuffrageVoter {
+			continue
+		}
+		voterCount++
+		soleVoter = s
+	}
+	return voterCount == 1 && soleVoter.ID == e.localID
 }
 
 func (e *Engine) resolveAdminPeer(id string, address string) (Peer, error) {

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -127,6 +127,21 @@ var (
 	errPromoteLearnerNotCaughtUp    = errors.New("etcd raft promote-learner target has not caught up to min_applied_index")
 )
 
+// joinRoleViolationCount counts the number of times the join-as-learner
+// alarm has fired across all engine instances in this process. Surfaced
+// via JoinRoleViolationCount() so callers (monitoring) can read it
+// without holding any engine lock; the latch on Engine.joinAlarmFired
+// keeps each individual engine from contributing more than once per
+// process lifetime.
+var joinRoleViolationCount atomic.Uint64
+
+// JoinRoleViolationCount returns the cumulative count of
+// --raftJoinAsLearner alarms that have fired since process start. See
+// docs/design/2026_04_26_proposed_raft_learner.md §4.5.
+func JoinRoleViolationCount() uint64 {
+	return joinRoleViolationCount.Load()
+}
+
 // Snapshot is an alias for the shared raftengine.Snapshot interface.
 type Snapshot = raftengine.Snapshot
 
@@ -134,12 +149,18 @@ type Snapshot = raftengine.Snapshot
 type StateMachine = raftengine.StateMachine
 
 type OpenConfig struct {
-	NodeID        uint64
-	LocalID       string
-	LocalAddress  string
-	DataDir       string
-	Peers         []Peer
-	Bootstrap     bool
+	NodeID       uint64
+	LocalID      string
+	LocalAddress string
+	DataDir      string
+	Peers        []Peer
+	Bootstrap    bool
+	// JoinAsLearner mirrors raftengine.FactoryConfig.JoinAsLearner. The
+	// engine watches every post-apply ConfState and emits an
+	// ERROR-level alarm whenever the local node is in Voters while
+	// JoinAsLearner is true. The check is post-apply only; the node
+	// continues running.
+	JoinAsLearner bool
 	Transport     *GRPCTransport
 	TickInterval  time.Duration
 	ElectionTick  int
@@ -163,6 +184,16 @@ type Engine struct {
 	fsmSnapDir   string
 	tickInterval time.Duration
 	electionTick int
+	// joinAsLearner is captured from OpenConfig; consulted by
+	// alarmIfJoinedAsVoter on every post-apply ConfState. See §4.5 of
+	// the learner design doc.
+	joinAsLearner bool
+	// joinAlarmFired latches the join-as-learner alarm so the
+	// structured ERROR log fires once per process lifetime. Without
+	// the latch, every conf change after the misbehaving join would
+	// re-emit the log even though the operator has already been
+	// alerted by the metric counter. Stored as int32 for atomic CAS.
+	joinAlarmFired atomic.Bool
 
 	storage   *etcdraft.MemoryStorage
 	rawNode   *etcdraft.RawNode
@@ -451,6 +482,7 @@ func Open(ctx context.Context, cfg OpenConfig) (*Engine, error) {
 		fsmSnapDir:       filepath.Join(prepared.cfg.DataDir, fsmSnapDirName),
 		tickInterval:     prepared.cfg.TickInterval,
 		electionTick:     prepared.cfg.ElectionTick,
+		joinAsLearner:    prepared.cfg.JoinAsLearner,
 		storage:          prepared.disk.Storage,
 		rawNode:          rawNode,
 		persist:          prepared.disk.Persist,
@@ -1800,7 +1832,15 @@ func (e *Engine) applyReadySnapshot(snapshot raftpb.Snapshot) error {
 	}
 	e.applied = snapshot.Metadata.Index
 	e.appliedIndex.Store(snapshot.Metadata.Index)
+	// Refresh the voter-cache from the snapshot's ConfState so
+	// downstream apply-loop reads (recordQuorumAck, refreshStatus,
+	// removePeer) see the post-snapshot voter set even before any
+	// further conf-change entries arrive. Mirrors the apply-loop
+	// sequence in applyConfigChange. The order matches §4.6:
+	// voterCache first, then config.Servers.
+	e.refreshVoterCache(snapshot.Metadata.ConfState)
 	e.setConfigurationFromConfState(snapshot.Metadata.ConfState, snapshot.Metadata.Index)
+	e.alarmIfJoinedAsVoter(snapshot.Metadata.ConfState)
 	return nil
 }
 
@@ -1955,6 +1995,7 @@ func (e *Engine) applyConfigChange(changeType raftpb.ConfChangeType, nodeID uint
 	e.refreshConfigServers(confState)
 	e.setConfigIndex(index)
 	e.resolveConfigChange(index, context)
+	e.alarmIfJoinedAsVoter(confState)
 }
 
 func (e *Engine) applyConfigChangeV2(cc raftpb.ConfChangeV2, index uint64, confState raftpb.ConfState) {
@@ -1965,6 +2006,43 @@ func (e *Engine) applyConfigChangeV2(cc raftpb.ConfChangeV2, index uint64, confS
 	e.refreshConfigServers(confState)
 	e.setConfigIndex(index)
 	e.resolveConfigChange(index, cc.Context)
+	e.alarmIfJoinedAsVoter(confState)
+}
+
+// alarmIfJoinedAsVoter implements the operator-alarm semantics from
+// docs/design/2026_04_26_proposed_raft_learner.md §4.5: when the
+// operator passed --raftJoinAsLearner but a post-apply ConfState
+// lists this node as a voter, surface a one-shot ERROR-level
+// structured log and bump a metric. The node continues running --
+// shutting down would shrink the cluster's effective fault tolerance
+// since by the time the conf change has applied, the local node
+// already counts toward the voter quorum.
+func (e *Engine) alarmIfJoinedAsVoter(confState raftpb.ConfState) {
+	if !e.joinAsLearner {
+		return
+	}
+	if !nodeInVoters(confState, e.nodeID) {
+		return
+	}
+	if !e.joinAlarmFired.CompareAndSwap(false, true) {
+		return
+	}
+	joinRoleViolationCount.Add(1)
+	slog.Error("etcd raft join-as-learner alarm: local node was added as voter, expected learner",
+		slog.String("local_id", e.localID),
+		slog.Uint64("node_id", e.nodeID),
+		slog.Any("voters", confState.Voters),
+		slog.Any("learners", confState.Learners),
+	)
+}
+
+func nodeInVoters(confState raftpb.ConfState, nodeID uint64) bool {
+	for _, id := range confState.Voters {
+		if id == nodeID {
+			return true
+		}
+	}
+	return false
 }
 
 // refreshVoterCache rebuilds the voterCount / isLearnerNode cache

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -219,6 +218,19 @@ type Engine struct {
 	runErr  error
 	closed  bool
 	applied uint64
+	// voterCount is the count of nodes in the latest applied
+	// ConfState.Voters (including self if voter). isLearnerNode is the
+	// matching set membership lookup keyed by node ID. Both are written
+	// only from the apply loop after rawNode.ApplyConfChange returns
+	// the new ConfState; both are read under e.mu on the lease-read /
+	// quorum-ack hot path. The cache exists to keep
+	// followerQuorumForClusterSize and the singleNodeLeaderAckMonoNs
+	// fast path from inflating the denominator with learners. See
+	// docs/design/2026_04_26_proposed_raft_learner.md §4.6. Rebuilt
+	// from scratch on each conf change — never patched — so promotion
+	// of a learner cannot leak a stale isLearnerNode[id]==true entry.
+	voterCount    int
+	isLearnerNode map[uint64]bool
 	// appliedIndex mirrors the current applied-entry index for
 	// lock-free readers on the lease-read fast path. Writers inside
 	// the Raft run loop update both `applied` (protected by the run
@@ -446,6 +458,8 @@ func Open(ctx context.Context, cfg OpenConfig) (*Engine, error) {
 		startedCh:        make(chan struct{}),
 		leaderReady:      make(chan struct{}),
 		config:           configurationFromConfState(peerMap, prepared.disk.LocalSnap.Metadata.ConfState),
+		voterCount:       len(prepared.disk.LocalSnap.Metadata.ConfState.Voters),
+		isLearnerNode:    learnerSetFromConfState(prepared.disk.LocalSnap.Metadata.ConfState),
 		applied:          maxAppliedIndex(prepared.disk.LocalSnap),
 		dispatchCtx:      dispatchCtx,
 		dispatchCancel:   dispatchCancel,
@@ -1487,11 +1501,21 @@ func (e *Engine) recordQuorumAck(msg raftpb.Message) {
 	if _, ok := e.peers[msg.From]; !ok {
 		return
 	}
-	clusterSize := len(e.peers)
-	if clusterSize <= 1 {
+	// Reject acks from learners. A learner does not vote and must not
+	// contribute to the voter-majority denominator on the lease-read
+	// fast path. See docs/design/2026_04_26_proposed_raft_learner.md
+	// §4.6. Both e.peers and e.isLearnerNode are written from the
+	// apply loop (single writer for both), so reading here under the
+	// run-loop goroutine is race-free for the same reason as e.peers
+	// above.
+	if e.isLearnerNode[msg.From] {
 		return
 	}
-	e.ackTracker.recordAck(msg.From, followerQuorumForClusterSize(clusterSize))
+	voterCount := e.voterCount
+	if voterCount <= 1 {
+		return
+	}
+	e.ackTracker.recordAck(msg.From, followerQuorumForClusterSize(voterCount))
 }
 
 // followerQuorumForClusterSize returns the number of non-self peer
@@ -1742,7 +1766,7 @@ func (e *Engine) applyCommitted(entries []raftpb.Entry) error {
 			if err := e.persistConfigState(entry.Index, *confState, nextPeers); err != nil {
 				return err
 			}
-			e.applyConfigChange(cc.Type, cc.NodeID, cc.Context, entry.Index)
+			e.applyConfigChange(cc.Type, cc.NodeID, cc.Context, entry.Index, *confState)
 			e.setApplied(entry.Index)
 		case raftpb.EntryConfChangeV2:
 			var cc raftpb.ConfChangeV2
@@ -1754,7 +1778,7 @@ func (e *Engine) applyCommitted(entries []raftpb.Entry) error {
 			if err := e.persistConfigState(entry.Index, *confState, nextPeers); err != nil {
 				return err
 			}
-			e.applyConfigChangeV2(cc, entry.Index)
+			e.applyConfigChangeV2(cc, entry.Index, *confState)
 			e.setApplied(entry.Index)
 		default:
 			e.setApplied(entry.Index)
@@ -1800,33 +1824,76 @@ func (e *Engine) resolveProposal(commitIndex uint64, data []byte, response any) 
 	}
 }
 
-func (e *Engine) applyConfigChange(changeType raftpb.ConfChangeType, nodeID uint64, context []byte, index uint64) {
+// applyConfigChange runs the four-step apply-loop sequence from
+// docs/design/2026_04_26_proposed_raft_learner.md §4.2 edit 4:
+//  1. recompute e.voterCount, e.isLearnerNode from confState
+//  2. upsertPeer / removePeer (mutates e.peers; may read e.voterCount)
+//  3. rebuild e.config.Servers via configurationFromConfState(e.peers, confState)
+//  4. configIndex / pending-config bookkeeping
+//
+// All four steps run on the single-threaded apply loop, so no extra
+// synchronization is needed.
+func (e *Engine) applyConfigChange(changeType raftpb.ConfChangeType, nodeID uint64, context []byte, index uint64, confState raftpb.ConfState) {
+	e.refreshVoterCache(confState)
 	e.applyConfigPeerChange(changeType, nodeID, context)
+	e.refreshConfigServers(confState)
 	e.setConfigIndex(index)
 	e.resolveConfigChange(index, context)
 }
 
-func (e *Engine) applyConfigChangeV2(cc raftpb.ConfChangeV2, index uint64) {
+func (e *Engine) applyConfigChangeV2(cc raftpb.ConfChangeV2, index uint64, confState raftpb.ConfState) {
+	e.refreshVoterCache(confState)
 	for _, change := range cc.Changes {
 		e.applyConfigPeerChange(change.Type, change.NodeID, cc.Context)
 	}
+	e.refreshConfigServers(confState)
 	e.setConfigIndex(index)
 	e.resolveConfigChange(index, cc.Context)
+}
+
+// refreshVoterCache rebuilds the voterCount / isLearnerNode cache
+// from the post-change ConfState. Called from the apply loop only.
+// The map is rebuilt from scratch — never patched — so promotion of a
+// learner cannot leak a stale isLearnerNode[id]==true entry. See
+// docs/design/2026_04_26_proposed_raft_learner.md §4.6.
+func (e *Engine) refreshVoterCache(confState raftpb.ConfState) {
+	e.mu.Lock()
+	e.voterCount = len(confState.Voters)
+	e.isLearnerNode = learnerSetFromConfState(confState)
+	e.mu.Unlock()
+}
+
+// refreshConfigServers rebuilds e.config.Servers from the post-change
+// ConfState and the current address-cache map. Called after the
+// per-peer cleanup helpers (upsertPeer / removePeer) so that
+// configurationFromConfState observes the post-cleanup e.peers map.
+func (e *Engine) refreshConfigServers(confState raftpb.ConfState) {
+	e.mu.Lock()
+	e.config = configurationFromConfState(e.peers, confState)
+	e.mu.Unlock()
 }
 
 func (e *Engine) applyConfigPeerChange(changeType raftpb.ConfChangeType, nodeID uint64, context []byte) {
 	peer, ok := decodeConfChangePeerContext(nodeID, context)
 	switch changeType {
 	case raftpb.ConfChangeAddNode:
+		// Promotion of an existing learner also lands here as
+		// ConfChangeAddNode for a node already in e.peers; the upsert
+		// is idempotent on (nodeID -> addr) so it is safe to take
+		// the same path. The voter / learner role swap is reflected
+		// in the post-change ConfState, which the apply loop has
+		// already used to refresh the voter cache and which it will
+		// use to rebuild e.config.Servers.
 		e.applyAddedPeer(nodeID, peer, ok)
 	case raftpb.ConfChangeRemoveNode:
 		e.applyRemovedPeer(nodeID, peer, ok)
 	case raftpb.ConfChangeUpdateNode:
 		e.applyUpdatedPeer(peer, ok)
 	case raftpb.ConfChangeAddLearnerNode:
-		// Phase 3 only exposes voter membership changes. Ignore learner metadata
-		// if it appears in a replayed log; startup validation still rejects joint
-		// consensus snapshots and learner-only cluster states for now.
+		// A learner joins the address cache the same way a voter does;
+		// suffrage is an attribute of ConfState, not of e.peers. See
+		// docs/design/2026_04_26_proposed_raft_learner.md §4.2.
+		e.applyAddedPeer(nodeID, peer, ok)
 	}
 }
 
@@ -2160,7 +2227,11 @@ func (e *Engine) refreshStatus() {
 	if e.closed {
 		e.status.State = raftengine.StateShutdown
 	}
-	clusterSize := len(e.peers)
+	// Use the voter count, NOT len(e.peers), so a 1-voter + N-learner
+	// cluster correctly hits the leader-of-1 fast path: a learner does
+	// not vote and is not part of the lease-read denominator. See
+	// docs/design/2026_04_26_proposed_raft_learner.md §4.6.
+	voterCount := e.voterCount
 	e.mu.Unlock()
 
 	// Keep the lock-free single-node fast path in sync with the current
@@ -2173,7 +2244,7 @@ func (e *Engine) refreshStatus() {
 	// could publish a ack instant while isLeader is still false.
 	e.isLeader.Store(status.State == raftengine.StateLeader)
 
-	if status.State == raftengine.StateLeader && clusterSize <= 1 {
+	if status.State == raftengine.StateLeader && voterCount <= 1 {
 		e.singleNodeLeaderAckMonoNs.Store(monoclock.Now().Nanos())
 	} else {
 		e.singleNodeLeaderAckMonoNs.Store(0)
@@ -2642,28 +2713,47 @@ func maxUint64(left uint64, right uint64) uint64 {
 }
 
 func configurationFromConfState(peers map[uint64]Peer, conf raftpb.ConfState) raftengine.Configuration {
-	if len(conf.Voters) == 0 {
+	if len(conf.Voters) == 0 && len(conf.Learners) == 0 {
 		return raftengine.Configuration{}
 	}
 
-	servers := make([]raftengine.Server, 0, len(conf.Voters))
+	servers := make([]raftengine.Server, 0, len(conf.Voters)+len(conf.Learners))
 	for _, nodeID := range conf.Voters {
-		peer, ok := peers[nodeID]
-		if ok {
-			servers = append(servers, raftengine.Server{
-				ID:       peer.ID,
-				Address:  peer.Address,
-				Suffrage: "voter",
-			})
-			continue
-		}
-		servers = append(servers, raftengine.Server{
-			ID:       strconv.FormatUint(nodeID, 10),
-			Address:  "",
-			Suffrage: "voter",
-		})
+		servers = append(servers, configServerForNode(peers, nodeID, SuffrageVoter))
+	}
+	for _, nodeID := range conf.Learners {
+		servers = append(servers, configServerForNode(peers, nodeID, SuffrageLearner))
 	}
 	return raftengine.Configuration{Servers: servers}
+}
+
+func configServerForNode(peers map[uint64]Peer, nodeID uint64, suffrage string) raftengine.Server {
+	if peer, ok := peers[nodeID]; ok {
+		return raftengine.Server{
+			ID:       peer.ID,
+			Address:  peer.Address,
+			Suffrage: suffrage,
+		}
+	}
+	return raftengine.Server{
+		ID:       strconv.FormatUint(nodeID, 10),
+		Address:  "",
+		Suffrage: suffrage,
+	}
+}
+
+// learnerSetFromConfState builds the apply-loop-owned isLearnerNode
+// cache from a ConfState. Returns nil for an empty / voter-only conf
+// state (callers treat nil as "no learners").
+func learnerSetFromConfState(conf raftpb.ConfState) map[uint64]bool {
+	if len(conf.Learners) == 0 {
+		return nil
+	}
+	out := make(map[uint64]bool, len(conf.Learners))
+	for _, nodeID := range conf.Learners {
+		out[nodeID] = true
+	}
+	return out
 }
 
 func numRemoteServers(servers []raftengine.Server, localID string) uint64 {
@@ -3077,6 +3167,13 @@ func (e *Engine) namedTransferTargetLocked(target Peer) (Peer, error) {
 	return Peer{}, errors.Wrapf(errTransportPeerUnknown, "address=%q", target.Address)
 }
 
+// upsertPeer updates the address cache for a peer. It deliberately
+// does NOT touch e.config.Servers — suffrage is determined by the
+// post-change ConfState which the apply loop threads through
+// refreshConfigServers. Today's call sites are the apply-loop helpers
+// applyAddedPeer / applyUpdatedPeer (both reached from
+// applyConfigPeerChange) which run before refreshConfigServers within
+// the same apply iteration.
 func (e *Engine) upsertPeer(peer Peer) {
 	if peer.NodeID == 0 {
 		peer.NodeID = DeriveNodeID(peer.ID)
@@ -3090,11 +3187,6 @@ func (e *Engine) upsertPeer(peer Peer) {
 		e.peers = make(map[uint64]Peer)
 	}
 	e.peers[peer.NodeID] = peer
-	e.config.Servers = upsertConfigServer(e.peers, e.config.Servers, raftengine.Server{
-		ID:       peer.ID,
-		Address:  peer.Address,
-		Suffrage: "voter",
-	})
 	e.mu.Unlock()
 
 	if e.transport != nil {
@@ -3129,26 +3221,31 @@ func (e *Engine) removePeer(nodeID uint64) {
 	}
 
 	e.mu.Lock()
-	peer, ok := e.peers[nodeID]
-	if ok {
+	if _, ok := e.peers[nodeID]; ok {
 		delete(e.peers, nodeID)
 	}
-	e.config.Servers = removeConfigServer(e.peers, e.config.Servers, nodeID, peer.ID)
-	postRemovalClusterSize := len(e.peers)
+	// e.voterCount has already been refreshed for the post-change
+	// ConfState by refreshVoterCache earlier in the apply iteration
+	// (see applyConfigChange / applyConfigChangeV2). The ack tracker
+	// quorum threshold below uses the voter count, not the address
+	// cache size, because a learner ack must not contribute to the
+	// voter-majority denominator. See
+	// docs/design/2026_04_26_proposed_raft_learner.md §4.6.
+	postRemovalVoterCount := e.voterCount
 	e.mu.Unlock()
 
 	// Drop the peer's recorded ack so a reconfiguration cannot leave a
 	// stale entry that falsely satisfies the new cluster's majority.
-	// followerQuorum is computed against the POST-removal cluster; a
+	// followerQuorum is computed against the POST-removal voter count; a
 	// shrink to <=1 would otherwise pass 0 here, which
 	// quorumAckTracker.removePeer treats as "keep the current instant"
 	// and would surface stale liveness to LastQuorumAck if the cluster
 	// subsequently grew back. Clear the tracker explicitly in that
 	// case so any future multi-node membership starts fresh.
-	if postRemovalClusterSize <= 1 {
+	if postRemovalVoterCount <= 1 {
 		e.ackTracker.reset()
 	} else {
-		e.ackTracker.removePeer(nodeID, followerQuorumForClusterSize(postRemovalClusterSize))
+		e.ackTracker.removePeer(nodeID, followerQuorumForClusterSize(postRemovalVoterCount))
 	}
 
 	if e.transport != nil {
@@ -3433,57 +3530,6 @@ func peerFromServer(peers map[uint64]Peer, server raftengine.Server) Peer {
 		ID:      server.ID,
 		Address: server.Address,
 	}
-}
-
-func upsertConfigServer(peers map[uint64]Peer, servers []raftengine.Server, server raftengine.Server) []raftengine.Server {
-	out := append([]raftengine.Server(nil), servers...)
-	for i := range out {
-		if out[i].ID != server.ID {
-			continue
-		}
-		out[i] = server
-		sortConfigServers(peers, out)
-		return out
-	}
-	out = append(out, server)
-	sortConfigServers(peers, out)
-	return out
-}
-
-func removeConfigServer(peers map[uint64]Peer, servers []raftengine.Server, nodeID uint64, serverID string) []raftengine.Server {
-	if len(servers) == 0 {
-		return nil
-	}
-	out := make([]raftengine.Server, 0, len(servers))
-	for _, server := range servers {
-		if serverID != "" && server.ID == serverID {
-			continue
-		}
-		if nodeID != 0 && serverNodeID(peers, server) == nodeID {
-			continue
-		}
-		out = append(out, server)
-	}
-	sortConfigServers(peers, out)
-	return out
-}
-
-func sortConfigServers(peers map[uint64]Peer, servers []raftengine.Server) {
-	sort.Slice(servers, func(i, j int) bool {
-		left := serverNodeID(peers, servers[i])
-		right := serverNodeID(peers, servers[j])
-		if left == right {
-			return servers[i].ID < servers[j].ID
-		}
-		return left < right
-	})
-}
-
-func serverNodeID(peers map[uint64]Peer, server raftengine.Server) uint64 {
-	if nodeID, ok := configServerNodeID(peers, server); ok {
-		return nodeID
-	}
-	return DeriveNodeID(server.ID)
 }
 
 func configServerNodeID(peers map[uint64]Peer, server raftengine.Server) (uint64, bool) {

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -574,6 +574,13 @@ func prepareOpenState(cfg OpenConfig) (preparedOpenState, error) {
 		_ = closePersist(disk.Persist)
 		return preparedOpenState{}, err
 	}
+	// Annotate suffrage from the persisted snapshot's ConfState before
+	// saving the peers file. The operator-supplied peer list has no
+	// suffrage info; without this, savePersistedPeers would write
+	// every peer as a voter, then a learner's restart would land on
+	// a peers file that contradicts the snapshot's ConfState.Learners
+	// and validateConfState would reject the cluster on next open.
+	annotatePeerSuffrageInSlice(peers, disk.LocalSnap.Metadata.ConfState)
 	if err := savePersistedPeers(cfg.DataDir, maxUint64(maxAppliedIndex(disk.LocalSnap), persistedPeers.Index), peers); err != nil {
 		_ = closePersist(disk.Persist)
 		return preparedOpenState{}, err
@@ -1860,7 +1867,34 @@ func (e *Engine) applyReadySnapshot(snapshot raftpb.Snapshot) error {
 	// voterCache first, then config.Servers.
 	e.refreshVoterCache(snapshot.Metadata.ConfState)
 	e.setConfigurationFromConfState(snapshot.Metadata.ConfState, snapshot.Metadata.Index)
+	// Persist the post-snapshot peers file with suffrage drawn from
+	// the snapshot's ConfState so a learner that received catch-up
+	// state via snapshot (the common case for fresh joiners) writes
+	// a peers file that round-trips correctly across restart. The
+	// snapshot path bypasses the apply-loop's nextPeersAfterConfigChange
+	// hook, so without this the joiner's peers file would carry the
+	// pre-AddLearner suffrage forever. See learner design doc §4.3.
+	if err := e.savePeersFileForSnapshot(snapshot); err != nil {
+		return err
+	}
 	e.alarmIfJoinedAsVoter(snapshot.Metadata.ConfState)
+	return nil
+}
+
+// savePeersFileForSnapshot writes the v2 peers file with suffrage
+// drawn from the snapshot's ConfState. Idempotent: savePersistedPeers
+// short-circuits when the on-disk index already covers `index`.
+func (e *Engine) savePeersFileForSnapshot(snapshot raftpb.Snapshot) error {
+	e.mu.RLock()
+	peers := sortedPeerList(e.peers)
+	e.mu.RUnlock()
+	if len(peers) == 0 {
+		return nil
+	}
+	annotatePeerSuffrageInSlice(peers, snapshot.Metadata.ConfState)
+	if err := savePersistedPeers(e.dataDir, snapshot.Metadata.Index, peers); err != nil {
+		return errors.Wrapf(err, "save peers file from snapshot index=%d", snapshot.Metadata.Index)
+	}
 	return nil
 }
 
@@ -3428,22 +3462,90 @@ func (e *Engine) upsertPeer(peer Peer) {
 	}
 }
 
-func (e *Engine) nextPeersAfterConfigChange(changeType raftpb.ConfChangeType, nodeID uint64, context []byte, _ raftpb.ConfState) []Peer {
+func (e *Engine) nextPeersAfterConfigChange(changeType raftpb.ConfChangeType, nodeID uint64, context []byte, confState raftpb.ConfState) []Peer {
 	e.mu.RLock()
 	next := clonePeerMap(e.peers)
 	e.mu.RUnlock()
 	applyConfigPeerChangeToMap(next, changeType, nodeID, context)
+	annotatePeerSuffrageFromConfState(next, confState)
 	return sortedPeerList(next)
 }
 
-func (e *Engine) nextPeersAfterConfigChangeV2(cc raftpb.ConfChangeV2, _ raftpb.ConfState) []Peer {
+func (e *Engine) nextPeersAfterConfigChangeV2(cc raftpb.ConfChangeV2, confState raftpb.ConfState) []Peer {
 	e.mu.RLock()
 	next := clonePeerMap(e.peers)
 	e.mu.RUnlock()
 	for _, change := range cc.Changes {
 		applyConfigPeerChangeToMap(next, change.Type, change.NodeID, cc.Context)
 	}
+	annotatePeerSuffrageFromConfState(next, confState)
 	return sortedPeerList(next)
+}
+
+// annotatePeerSuffrageInSlice is the slice form of
+// annotatePeerSuffrageFromConfState used at bootstrap-time, where
+// `peers` is a sorted operator-provided slice rather than the apply
+// loop's clone of e.peers.
+func annotatePeerSuffrageInSlice(peers []Peer, conf raftpb.ConfState) {
+	if len(peers) == 0 {
+		return
+	}
+	learners := make(map[uint64]bool, len(conf.Learners))
+	for _, id := range conf.Learners {
+		learners[id] = true
+	}
+	voters := make(map[uint64]bool, len(conf.Voters))
+	for _, id := range conf.Voters {
+		voters[id] = true
+	}
+	for i := range peers {
+		switch {
+		case learners[peers[i].NodeID]:
+			peers[i].Suffrage = SuffrageLearner
+		case voters[peers[i].NodeID]:
+			peers[i].Suffrage = SuffrageVoter
+		}
+	}
+}
+
+// annotatePeerSuffrageFromConfState stamps each peer's Suffrage from
+// the post-change ConfState so the v2 peers file written by
+// persistConfigState round-trips suffrage across restarts. Without
+// this, every Peer in the persist path carries Suffrage="" (the
+// ConfChange context bytes do not encode suffrage; e.peers
+// deliberately stores only nodeID/ID/address), and
+// persistedSuffrageByte("") writes voter — which on restart causes
+// validateConfState to see a learner-as-voter peer list and reject
+// startup with errClusterMismatch. See learner design doc §4.3
+// "Authoritative source of suffrage during recovery".
+//
+// The map is mutated in place. Peers not present in either
+// confState.Voters or confState.Learners (transient state during a
+// removal) keep whatever Suffrage they had — they will fall out of
+// the persisted peers list on the next conf change anyway.
+func annotatePeerSuffrageFromConfState(peers map[uint64]Peer, conf raftpb.ConfState) {
+	if len(peers) == 0 {
+		return
+	}
+	learners := make(map[uint64]bool, len(conf.Learners))
+	for _, id := range conf.Learners {
+		learners[id] = true
+	}
+	voters := make(map[uint64]bool, len(conf.Voters))
+	for _, id := range conf.Voters {
+		voters[id] = true
+	}
+	for id, peer := range peers {
+		switch {
+		case learners[id]:
+			peer.Suffrage = SuffrageLearner
+		case voters[id]:
+			peer.Suffrage = SuffrageVoter
+		default:
+			continue
+		}
+		peers[id] = peer
+	}
 }
 
 func (e *Engine) removePeer(nodeID uint64) {

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -526,6 +526,17 @@ func Open(ctx context.Context, cfg OpenConfig) (*Engine, error) {
 	engine.initTransport(prepared.cfg)
 	engine.initSnapshotWorker()
 	engine.refreshStatus()
+	// Fire the join-as-learner alarm against the persisted snapshot's
+	// ConfState. Without this, a node that mis-joined as voter and is
+	// then restarted with --raftJoinAsLearner=true would never emit
+	// the alarm: applyConfigChange / applyConfigChangeV2 /
+	// applyReadySnapshot are the only other call sites and a clean
+	// open path bypasses all three (the snapshot is loaded from disk,
+	// not replayed). The alarm latch
+	// (joinAlarmFired.CompareAndSwap) guarantees it fires at most
+	// once per process even if a later snapshot or conf change
+	// reapplies the same role assignment. See learner design doc §4.5.
+	engine.alarmIfJoinedAsVoter(prepared.disk.LocalSnap.Metadata.ConfState)
 	// Surface a misconfiguration where the tick settings produce a
 	// non-positive lease window: lease reads would never hit the fast
 	// path. Don't fail Open -- the engine is still functional via the

--- a/internal/raftengine/etcd/engine_test.go
+++ b/internal/raftengine/etcd/engine_test.go
@@ -328,7 +328,11 @@ func TestOpenRestoresPeersFromPersistedMetadata(t *testing.T) {
 	persisted, ok, err := LoadPersistedPeers(dir)
 	require.NoError(t, err)
 	require.True(t, ok)
-	require.Equal(t, peers, persisted)
+	expected := append([]Peer(nil), peers...)
+	for i := range expected {
+		expected[i].Suffrage = SuffrageVoter
+	}
+	require.Equal(t, expected, persisted)
 
 	restarted, err := Open(context.Background(), OpenConfig{
 		NodeID:       1,

--- a/internal/raftengine/etcd/engine_test.go
+++ b/internal/raftengine/etcd/engine_test.go
@@ -1069,9 +1069,13 @@ func TestNextPeersAfterConfigChangeKeepsLearnerMetadata(t *testing.T) {
 		},
 	)
 
+	// nextPeersAfterConfigChange now annotates Suffrage from the
+	// post-change ConfState so persistConfigState can write a v2
+	// peers file that round-trips correctly across restarts. See
+	// learner design doc §4.3.
 	require.Equal(t, []Peer{
-		{NodeID: 1, ID: "n1", Address: "127.0.0.1:7001"},
-		{NodeID: 2, ID: "n2", Address: "127.0.0.1:7002"},
+		{NodeID: 1, ID: "n1", Address: "127.0.0.1:7001", Suffrage: SuffrageVoter},
+		{NodeID: 2, ID: "n2", Address: "127.0.0.1:7002", Suffrage: SuffrageLearner},
 	}, next)
 }
 
@@ -1094,9 +1098,9 @@ func TestNextPeersAfterConfigChangeV2IgnoresMismatchedPeerContext(t *testing.T) 
 	}, raftpb.ConfState{Voters: []uint64{1, 2, 3}})
 
 	require.Equal(t, []Peer{
-		{NodeID: 1, ID: "n1", Address: "127.0.0.1:7001"},
-		{NodeID: 2, ID: "n2", Address: "127.0.0.1:7002"},
-		{NodeID: 3, ID: "3", Address: ""},
+		{NodeID: 1, ID: "n1", Address: "127.0.0.1:7001", Suffrage: SuffrageVoter},
+		{NodeID: 2, ID: "n2", Address: "127.0.0.1:7002", Suffrage: SuffrageVoter},
+		{NodeID: 3, ID: "3", Address: "", Suffrage: SuffrageVoter},
 	}, next)
 }
 
@@ -1115,8 +1119,8 @@ func TestNextPeersAfterConfigChangeV2PreservesExistingPeerWithoutContext(t *test
 	}, raftpb.ConfState{Voters: []uint64{1, 2}})
 
 	require.Equal(t, []Peer{
-		{NodeID: 1, ID: "n1", Address: "127.0.0.1:7001"},
-		{NodeID: 2, ID: "n2", Address: "127.0.0.1:7002"},
+		{NodeID: 1, ID: "n1", Address: "127.0.0.1:7001", Suffrage: SuffrageVoter},
+		{NodeID: 2, ID: "n2", Address: "127.0.0.1:7002", Suffrage: SuffrageVoter},
 	}, next)
 }
 

--- a/internal/raftengine/etcd/engine_test.go
+++ b/internal/raftengine/etcd/engine_test.go
@@ -118,13 +118,14 @@ type countingSnapshotStateMachine struct {
 }
 
 type transportTestNode struct {
-	peer      Peer
-	lis       net.Listener
-	server    *grpc.Server
-	transport *GRPCTransport
-	fsm       *testStateMachine
-	engine    *Engine
-	dir       string
+	peer          Peer
+	lis           net.Listener
+	server        *grpc.Server
+	transport     *GRPCTransport
+	fsm           *testStateMachine
+	engine        *Engine
+	dir           string
+	joinAsLearner bool
 }
 
 func (s *testSnapshot) WriteTo(w io.Writer) (int64, error) {
@@ -1508,14 +1509,15 @@ func cleanupTransportTestNodes(t *testing.T, nodes []*transportTestNode) {
 
 func openTransportTestNode(ctx context.Context, node *transportTestNode, peers []Peer, bootstrap bool) error {
 	engine, err := Open(ctx, OpenConfig{
-		NodeID:       node.peer.NodeID,
-		LocalID:      node.peer.ID,
-		LocalAddress: node.peer.Address,
-		DataDir:      node.dir,
-		Peers:        peers,
-		Bootstrap:    bootstrap,
-		Transport:    node.transport,
-		StateMachine: node.fsm,
+		NodeID:        node.peer.NodeID,
+		LocalID:       node.peer.ID,
+		LocalAddress:  node.peer.Address,
+		DataDir:       node.dir,
+		Peers:         peers,
+		Bootstrap:     bootstrap,
+		JoinAsLearner: node.joinAsLearner,
+		Transport:     node.transport,
+		StateMachine:  node.fsm,
 	})
 	if err != nil {
 		return err

--- a/internal/raftengine/etcd/factory.go
+++ b/internal/raftengine/etcd/factory.go
@@ -49,6 +49,7 @@ func (f *Factory) Create(cfg raftengine.FactoryConfig) (*raftengine.FactoryResul
 		DataDir:        cfg.DataDir,
 		Peers:          peers,
 		Bootstrap:      cfg.Bootstrap,
+		JoinAsLearner:  cfg.JoinAsLearner,
 		Transport:      transport,
 		StateMachine:   cfg.StateMachine,
 		TickInterval:   f.cfg.TickInterval,

--- a/internal/raftengine/etcd/learner_test.go
+++ b/internal/raftengine/etcd/learner_test.go
@@ -1,0 +1,209 @@
+package etcd
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/bootjp/elastickv/internal/raftengine"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAddLearnerReplicatesWithoutCountingAsVoter is the headline M1
+// test from docs/design/2026_04_26_proposed_raft_learner.md exit
+// criterion 1: a learner attached to a 1-voter cluster receives log
+// entries, but does not count toward the voter quorum.
+func TestAddLearnerReplicatesWithoutCountingAsVoter(t *testing.T) {
+	nodes, peers := newTransportTestNodes(t, 2)
+	startTransportTestServers(nodes, peers)
+	t.Cleanup(func() { cleanupTransportTestNodes(t, nodes) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, openTransportTestNode(ctx, nodes[0], peers[:1], true))
+	leader := waitForLeaderNode(t, nodes[:1])
+	require.NoError(t, openTransportTestNode(ctx, nodes[1], peers, false))
+
+	index, err := leader.engine.AddLearner(ctx, nodes[1].peer.ID, nodes[1].peer.Address, 0)
+	require.NoError(t, err)
+	require.Greater(t, index, uint64(0))
+
+	waitForConfigSize(t, leader.engine, 2)
+	waitForConfigSize(t, nodes[1].engine, 2)
+
+	// Suffrage is reported correctly for both peers via Configuration().
+	cfg, err := leader.engine.Configuration(ctx)
+	require.NoError(t, err)
+	require.Len(t, cfg.Servers, 2)
+	suffrageByID := map[string]string{}
+	for _, s := range cfg.Servers {
+		suffrageByID[s.ID] = s.Suffrage
+	}
+	require.Equal(t, SuffrageVoter, suffrageByID[nodes[0].peer.ID])
+	require.Equal(t, SuffrageLearner, suffrageByID[nodes[1].peer.ID])
+
+	// Re-confirm leadership before proposing.
+	require.Eventually(t, func() bool {
+		return leader.engine.State() == raftengine.StateLeader
+	}, 5*time.Second, 20*time.Millisecond)
+
+	// Writes commit on the leader (1 voter is its own quorum) and
+	// replicate to the learner.
+	result, err := leader.engine.Propose(context.Background(), []byte("alpha"))
+	require.NoError(t, err)
+	require.NotZero(t, result.CommitIndex)
+	require.Eventually(t, func() bool {
+		return len(nodes[1].fsm.Applied()) == 1 && string(nodes[1].fsm.Applied()[0]) == "alpha"
+	}, 5*time.Second, 20*time.Millisecond)
+
+	// The learner reports learner suffrage in its own configuration view too.
+	cfg, err = nodes[1].engine.Configuration(ctx)
+	require.NoError(t, err)
+	require.Len(t, cfg.Servers, 2)
+	for _, s := range cfg.Servers {
+		if s.ID == nodes[1].peer.ID {
+			require.Equal(t, SuffrageLearner, s.Suffrage)
+		}
+	}
+}
+
+// TestPromoteLearnerSwapsRoleToVoter exercises the engine's promote
+// path: AddLearner → wait for catch-up → PromoteLearner → suffrage
+// flips to "voter".
+func TestPromoteLearnerSwapsRoleToVoter(t *testing.T) {
+	nodes, peers := newTransportTestNodes(t, 2)
+	startTransportTestServers(nodes, peers)
+	t.Cleanup(func() { cleanupTransportTestNodes(t, nodes) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, openTransportTestNode(ctx, nodes[0], peers[:1], true))
+	leader := waitForLeaderNode(t, nodes[:1])
+	require.NoError(t, openTransportTestNode(ctx, nodes[1], peers, false))
+
+	addIndex, err := leader.engine.AddLearner(ctx, nodes[1].peer.ID, nodes[1].peer.Address, 0)
+	require.NoError(t, err)
+	waitForConfigSize(t, leader.engine, 2)
+	waitForConfigSize(t, nodes[1].engine, 2)
+
+	require.Eventually(t, func() bool {
+		return leader.engine.State() == raftengine.StateLeader
+	}, 5*time.Second, 20*time.Millisecond)
+
+	// Drive a write through so the learner has caught up to a known
+	// commit index before promotion.
+	_, err = leader.engine.Propose(context.Background(), []byte("warm"))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return len(nodes[1].fsm.Applied()) == 1
+	}, 5*time.Second, 20*time.Millisecond)
+
+	promoteIndex, err := leader.engine.PromoteLearner(ctx, nodes[1].peer.ID, addIndex, 0)
+	require.NoError(t, err)
+	require.Greater(t, promoteIndex, addIndex)
+
+	// Both peers should report two voters and zero learners after promotion.
+	require.Eventually(t, func() bool {
+		cfg, err := leader.engine.Configuration(context.Background())
+		if err != nil {
+			return false
+		}
+		voters := 0
+		for _, s := range cfg.Servers {
+			if s.Suffrage == SuffrageVoter {
+				voters++
+			}
+		}
+		return voters == 2
+	}, 5*time.Second, 20*time.Millisecond)
+}
+
+// TestPromoteLearnerRejectsNonLearner ensures the precondition
+// (target must be in ConfState.Learners) is enforced before propose.
+func TestPromoteLearnerRejectsNonLearner(t *testing.T) {
+	nodes, peers := newTransportTestNodes(t, 2)
+	startTransportTestServers(nodes, peers)
+	t.Cleanup(func() { cleanupTransportTestNodes(t, nodes) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, openTransportTestNode(ctx, nodes[0], peers[:1], true))
+	leader := waitForLeaderNode(t, nodes[:1])
+	require.NoError(t, openTransportTestNode(ctx, nodes[1], peers, false))
+
+	// Add as a regular voter, then attempt to promote — should fail.
+	_, err := leader.engine.AddVoter(ctx, nodes[1].peer.ID, nodes[1].peer.Address, 0)
+	require.NoError(t, err)
+	waitForConfigSize(t, leader.engine, 2)
+
+	_, err = leader.engine.PromoteLearner(ctx, nodes[1].peer.ID, 0, 0)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errPromoteLearnerNotLearner), "expected errPromoteLearnerNotLearner, got %v", err)
+}
+
+// TestPromoteLearnerRejectsNotCaughtUp ensures the
+// minAppliedIndex precondition is enforced pre-propose.
+func TestPromoteLearnerRejectsNotCaughtUp(t *testing.T) {
+	nodes, peers := newTransportTestNodes(t, 2)
+	startTransportTestServers(nodes, peers)
+	t.Cleanup(func() { cleanupTransportTestNodes(t, nodes) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, openTransportTestNode(ctx, nodes[0], peers[:1], true))
+	leader := waitForLeaderNode(t, nodes[:1])
+	require.NoError(t, openTransportTestNode(ctx, nodes[1], peers, false))
+
+	addIndex, err := leader.engine.AddLearner(ctx, nodes[1].peer.ID, nodes[1].peer.Address, 0)
+	require.NoError(t, err)
+	waitForConfigSize(t, leader.engine, 2)
+
+	// Demand catch-up to a future index that has not been committed.
+	const unreachableIndex = uint64(1 << 60)
+	_, err = leader.engine.PromoteLearner(ctx, nodes[1].peer.ID, addIndex, unreachableIndex)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errPromoteLearnerNotCaughtUp), "expected errPromoteLearnerNotCaughtUp, got %v", err)
+}
+
+// TestRemovePeerLearnerKeepsSingleNodeFastPath is the §4.6 lease-read
+// regression: with 1 voter + 1 learner, removing the learner must
+// leave the leader on the single-node fast path. The complementary
+// case (lease-read works WHILE the learner exists) is covered
+// implicitly by the AddLearner test above succeeding without a
+// quorum-ack timeout.
+func TestRemovePeerLearnerKeepsSingleNodeFastPath(t *testing.T) {
+	nodes, peers := newTransportTestNodes(t, 2)
+	startTransportTestServers(nodes, peers)
+	t.Cleanup(func() { cleanupTransportTestNodes(t, nodes) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, openTransportTestNode(ctx, nodes[0], peers[:1], true))
+	leader := waitForLeaderNode(t, nodes[:1])
+	require.NoError(t, openTransportTestNode(ctx, nodes[1], peers, false))
+
+	addIndex, err := leader.engine.AddLearner(ctx, nodes[1].peer.ID, nodes[1].peer.Address, 0)
+	require.NoError(t, err)
+	waitForConfigSize(t, leader.engine, 2)
+
+	// While the learner is attached, the leader's voter count is still
+	// 1, so the single-node fast path stays warm.
+	require.Eventually(t, func() bool {
+		return !leader.engine.LastQuorumAck().IsZero()
+	}, 2*time.Second, 20*time.Millisecond)
+
+	_, err = leader.engine.RemoveServer(ctx, nodes[1].peer.ID, addIndex)
+	require.NoError(t, err)
+	waitForConfigSize(t, leader.engine, 1)
+
+	// After removal, the fast path is still warm — voter count stayed at 1.
+	require.Eventually(t, func() bool {
+		return !leader.engine.LastQuorumAck().IsZero()
+	}, 2*time.Second, 20*time.Millisecond)
+}

--- a/internal/raftengine/etcd/learner_test.go
+++ b/internal/raftengine/etcd/learner_test.go
@@ -368,6 +368,63 @@ func TestLinearizableReadOnLearnerForwardsToLeader(t *testing.T) {
 	require.True(t, errors.Is(err, raftengine.ErrNotLeader), "expected ErrNotLeader, got %v", err)
 }
 
+// TestJoinAsLearnerAlarmFiresAtStartupForPersistedVoterRole is the
+// regression for the codex Round 4 finding: when a node previously
+// mis-joined as voter, then restarts with --raftJoinAsLearner=true,
+// the alarm needs to fire even though no apply event happens — Open
+// loads the post-mis-join ConfState from disk and never replays it.
+// Verifies that JoinRoleViolationCount increments on the second
+// Open and that the joiner stays running.
+func TestJoinAsLearnerAlarmFiresAtStartupForPersistedVoterRole(t *testing.T) {
+	nodes, peers := newTransportTestNodes(t, 2)
+	startTransportTestServers(nodes, peers)
+	t.Cleanup(func() { cleanupTransportTestNodes(t, nodes) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, openTransportTestNode(ctx, nodes[0], peers[:1], true))
+	leader := waitForLeaderNode(t, nodes[:1])
+
+	// First open with joinAsLearner=false (the misuse): leader
+	// AddVoter the joiner, conf change persists to disk.
+	require.NoError(t, openTransportTestNode(ctx, nodes[1], peers, false))
+	_, err := leader.engine.AddVoter(ctx, nodes[1].peer.ID, nodes[1].peer.Address, 0)
+	require.NoError(t, err)
+	waitForConfigSize(t, leader.engine, 2)
+	waitForConfigSize(t, nodes[1].engine, 2)
+
+	// Drive a write so the conf change snapshot lands on the joiner's
+	// disk before we close it.
+	require.Eventually(t, func() bool {
+		return leader.engine.State() == raftengine.StateLeader
+	}, 5*time.Second, 20*time.Millisecond)
+	_, err = leader.engine.Propose(context.Background(), []byte("warm"))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return len(nodes[1].fsm.Applied()) >= 1
+	}, 5*time.Second, 20*time.Millisecond)
+
+	// Close the joiner, then reopen with joinAsLearner=true. The
+	// persisted snapshot encodes the local node in ConfState.Voters.
+	require.NoError(t, nodes[1].engine.Close())
+
+	before := JoinRoleViolationCount()
+	engine, err := Open(ctx, OpenConfig{
+		NodeID:        nodes[1].peer.NodeID,
+		LocalID:       nodes[1].peer.ID,
+		LocalAddress:  nodes[1].peer.Address,
+		DataDir:       nodes[1].dir,
+		JoinAsLearner: true,
+		Transport:     nodes[1].transport,
+		StateMachine:  nodes[1].fsm,
+	})
+	require.NoError(t, err)
+	nodes[1].engine = engine
+	require.Greater(t, JoinRoleViolationCount(), before, "expected join-as-learner alarm to fire on startup")
+	require.NotEqual(t, raftengine.StateShutdown, engine.State())
+}
+
 // TestRemovePeerLearnerKeepsSingleNodeFastPath is the §4.6 lease-read
 // regression: with 1 voter + 1 learner, removing the learner must
 // leave the leader on the single-node fast path. The complementary

--- a/internal/raftengine/etcd/learner_test.go
+++ b/internal/raftengine/etcd/learner_test.go
@@ -2,11 +2,11 @@ package etcd
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
 	"github.com/bootjp/elastickv/internal/raftengine"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -168,6 +168,93 @@ func TestPromoteLearnerRejectsNotCaughtUp(t *testing.T) {
 	_, err = leader.engine.PromoteLearner(ctx, nodes[1].peer.ID, addIndex, unreachableIndex)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, errPromoteLearnerNotCaughtUp), "expected errPromoteLearnerNotCaughtUp, got %v", err)
+}
+
+// TestJoinAsLearnerAlarmFiresWhenAddedAsVoter exercises the §4.5
+// post-apply local alarm: a node booted with JoinAsLearner=true that
+// then sees itself in ConfState.Voters logs an ERROR and bumps the
+// process-wide JoinRoleViolationCount counter, but keeps running.
+func TestJoinAsLearnerAlarmFiresWhenAddedAsVoter(t *testing.T) {
+	nodes, peers := newTransportTestNodes(t, 2)
+	startTransportTestServers(nodes, peers)
+	t.Cleanup(func() { cleanupTransportTestNodes(t, nodes) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, openTransportTestNode(ctx, nodes[0], peers[:1], true))
+	leader := waitForLeaderNode(t, nodes[:1])
+
+	// Boot the joiner with the alarm flag set, then add it as a VOTER
+	// (not a learner) — that's the misuse the alarm catches.
+	nodes[1].joinAsLearner = true
+	require.NoError(t, openTransportTestNode(ctx, nodes[1], peers, false))
+
+	before := JoinRoleViolationCount()
+	_, err := leader.engine.AddVoter(ctx, nodes[1].peer.ID, nodes[1].peer.Address, 0)
+	require.NoError(t, err)
+	waitForConfigSize(t, leader.engine, 2)
+	waitForConfigSize(t, nodes[1].engine, 2)
+
+	require.Eventually(t, func() bool {
+		return JoinRoleViolationCount() > before
+	}, 5*time.Second, 20*time.Millisecond, "expected join-as-learner alarm to fire")
+
+	// Joiner stays running -- §4.5: shutdown is explicitly rejected.
+	require.NotEqual(t, raftengine.StateShutdown, nodes[1].engine.State())
+}
+
+// TestLinearizableReadOnLearnerForwardsToLeader is the §4.6 / §5.5
+// behaviour test: LinearizableRead on a learner forwards to the
+// leader's ReadIndex and returns once local apply catches up. A
+// learner must NOT serve LinearizableRead from a leader-local fast
+// path (it isn't leader; LeaderView guards return errNotLeader).
+// Until follower-served reads land in a separate proposal,
+// "learner LinearizableRead" is the same code path as a voter
+// follower's: it forwards to the leader.
+func TestLinearizableReadOnLearnerForwardsToLeader(t *testing.T) {
+	nodes, peers := newTransportTestNodes(t, 2)
+	startTransportTestServers(nodes, peers)
+	t.Cleanup(func() { cleanupTransportTestNodes(t, nodes) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, openTransportTestNode(ctx, nodes[0], peers[:1], true))
+	leader := waitForLeaderNode(t, nodes[:1])
+	require.NoError(t, openTransportTestNode(ctx, nodes[1], peers, false))
+
+	_, err := leader.engine.AddLearner(ctx, nodes[1].peer.ID, nodes[1].peer.Address, 0)
+	require.NoError(t, err)
+	waitForConfigSize(t, leader.engine, 2)
+	waitForConfigSize(t, nodes[1].engine, 2)
+
+	require.Eventually(t, func() bool {
+		return leader.engine.State() == raftengine.StateLeader
+	}, 5*time.Second, 20*time.Millisecond)
+
+	// Drive a write through the leader. This commits at the leader's
+	// next index; the learner replicates and applies.
+	_, err = leader.engine.Propose(context.Background(), []byte("payload"))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return len(nodes[1].fsm.Applied()) >= 1
+	}, 5*time.Second, 20*time.Millisecond)
+
+	// LinearizableRead on the leader returns the latest commit index.
+	leaderIdx, err := leader.engine.LinearizableRead(ctx)
+	require.NoError(t, err)
+	require.NotZero(t, leaderIdx)
+
+	// LinearizableRead on the learner: today we return errNotLeader
+	// (the learner is a follower, and follower-served reads are an
+	// explicit non-goal of this milestone). Guarantee that surface
+	// with a typed error so any future regression that lets the
+	// learner accidentally answer LinearizableRead from local FSM
+	// gets caught here.
+	_, err = nodes[1].engine.LinearizableRead(ctx)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, raftengine.ErrNotLeader), "expected ErrNotLeader, got %v", err)
 }
 
 // TestRemovePeerLearnerKeepsSingleNodeFastPath is the §4.6 lease-read

--- a/internal/raftengine/etcd/learner_test.go
+++ b/internal/raftengine/etcd/learner_test.go
@@ -101,7 +101,11 @@ func TestPromoteLearnerSwapsRoleToVoter(t *testing.T) {
 		return len(nodes[1].fsm.Applied()) == 1
 	}, 5*time.Second, 20*time.Millisecond)
 
-	promoteIndex, err := leader.engine.PromoteLearner(ctx, nodes[1].peer.ID, addIndex, 0)
+	// We just propagated "warm" to the learner; use that committed
+	// commit index as the catch-up bar so promotion is gated on the
+	// learner having actually applied something.
+	leaderStatus := leader.engine.Status()
+	promoteIndex, err := leader.engine.PromoteLearner(ctx, nodes[1].peer.ID, addIndex, leaderStatus.CommitIndex, false)
 	require.NoError(t, err)
 	require.Greater(t, promoteIndex, addIndex)
 
@@ -140,9 +144,36 @@ func TestPromoteLearnerRejectsNonLearner(t *testing.T) {
 	require.NoError(t, err)
 	waitForConfigSize(t, leader.engine, 2)
 
-	_, err = leader.engine.PromoteLearner(ctx, nodes[1].peer.ID, 0, 0)
+	_, err = leader.engine.PromoteLearner(ctx, nodes[1].peer.ID, 0, 0, true)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, errPromoteLearnerNotLearner), "expected errPromoteLearnerNotLearner, got %v", err)
+}
+
+// TestPromoteLearnerRejectsZeroMinAppliedWithoutSkip is the §8 open
+// question 3 fix: passing min_applied_index=0 without
+// skip_min_applied_check returns a clean FailedPrecondition rather
+// than silently disabling the catch-up safety check.
+func TestPromoteLearnerRejectsZeroMinAppliedWithoutSkip(t *testing.T) {
+	nodes, peers := newTransportTestNodes(t, 2)
+	startTransportTestServers(nodes, peers)
+	t.Cleanup(func() { cleanupTransportTestNodes(t, nodes) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, openTransportTestNode(ctx, nodes[0], peers[:1], true))
+	leader := waitForLeaderNode(t, nodes[:1])
+	require.NoError(t, openTransportTestNode(ctx, nodes[1], peers, false))
+
+	addIndex, err := leader.engine.AddLearner(ctx, nodes[1].peer.ID, nodes[1].peer.Address, 0)
+	require.NoError(t, err)
+	waitForConfigSize(t, leader.engine, 2)
+
+	// minApplied=0, skip=false  ->  rejected up-front before any
+	// rawNode interaction.
+	_, err = leader.engine.PromoteLearner(ctx, nodes[1].peer.ID, addIndex, 0, false)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errPromoteLearnerMinAppliedZero), "expected errPromoteLearnerMinAppliedZero, got %v", err)
 }
 
 // TestPromoteLearnerRejectsNotCaughtUp ensures the
@@ -165,7 +196,7 @@ func TestPromoteLearnerRejectsNotCaughtUp(t *testing.T) {
 
 	// Demand catch-up to a future index that has not been committed.
 	const unreachableIndex = uint64(1 << 60)
-	_, err = leader.engine.PromoteLearner(ctx, nodes[1].peer.ID, addIndex, unreachableIndex)
+	_, err = leader.engine.PromoteLearner(ctx, nodes[1].peer.ID, addIndex, unreachableIndex, false)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, errPromoteLearnerNotCaughtUp), "expected errPromoteLearnerNotCaughtUp, got %v", err)
 }

--- a/internal/raftengine/etcd/learner_test.go
+++ b/internal/raftengine/etcd/learner_test.go
@@ -149,6 +149,86 @@ func TestPromoteLearnerRejectsNonLearner(t *testing.T) {
 	require.True(t, errors.Is(err, errPromoteLearnerNotLearner), "expected errPromoteLearnerNotLearner, got %v", err)
 }
 
+// TestLearnerPeersFilePersistsSuffrageAcrossRestart locks down the
+// design doc §4.3 contract that the v2 peers file round-trips
+// suffrage across restarts. Without this, AddLearner writes the
+// learner peer with Suffrage="" (the ConfChange context bytes do
+// not carry suffrage and e.peers stores only nodeID/ID/address);
+// persistedSuffrageByte("") writes voter; on restart
+// validateConfState sees a learner-as-voter peers list and rejects
+// startup with errClusterMismatch. The fix is that
+// nextPeersAfterConfigChange annotates Peer.Suffrage from the
+// post-change ConfState before persistConfigState writes the file.
+func TestLearnerPeersFilePersistsSuffrageAcrossRestart(t *testing.T) {
+	nodes, peers := newTransportTestNodes(t, 2)
+	startTransportTestServers(nodes, peers)
+	t.Cleanup(func() { cleanupTransportTestNodes(t, nodes) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, openTransportTestNode(ctx, nodes[0], peers[:1], true))
+	leader := waitForLeaderNode(t, nodes[:1])
+	require.NoError(t, openTransportTestNode(ctx, nodes[1], peers, false))
+
+	_, err := leader.engine.AddLearner(ctx, nodes[1].peer.ID, nodes[1].peer.Address, 0)
+	require.NoError(t, err)
+	waitForConfigSize(t, leader.engine, 2)
+	waitForConfigSize(t, nodes[1].engine, 2)
+
+	// Drive a write so the learner has applied something — without
+	// this the engines may race close vs. apply on the bootstrap
+	// snapshot and surface unrelated errors.
+	require.Eventually(t, func() bool {
+		return leader.engine.State() == raftengine.StateLeader
+	}, 5*time.Second, 20*time.Millisecond)
+	_, err = leader.engine.Propose(context.Background(), []byte("warm"))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return len(nodes[1].fsm.Applied()) >= 1
+	}, 5*time.Second, 20*time.Millisecond)
+
+	// Verify the v2 peers file actually carries the learner's suffrage.
+	// Both nodes must have flushed the post-AddLearner config, so check
+	// each persisted file directly.
+	for _, n := range nodes {
+		persisted, ok, err := LoadPersistedPeers(n.dir)
+		require.NoError(t, err, "load persisted peers for %s", n.peer.ID)
+		require.True(t, ok, "persisted peers exist for %s", n.peer.ID)
+		var sawLearner bool
+		for _, p := range persisted {
+			if p.NodeID == nodes[1].peer.NodeID {
+				require.Equal(t, SuffrageLearner, p.Suffrage,
+					"learner persisted as %q in %s", p.Suffrage, n.peer.ID)
+				sawLearner = true
+			}
+		}
+		require.True(t, sawLearner, "learner peer missing from %s peers file", n.peer.ID)
+	}
+
+	// Close both engines and reopen them. Without the suffrage
+	// round-trip, validateConfState would reject startup because
+	// the persisted peers file would list the learner as a voter
+	// while the snapshot ConfState lists it as a learner.
+	require.NoError(t, leader.engine.Close())
+	require.NoError(t, nodes[1].engine.Close())
+
+	for _, n := range nodes {
+		// Stale fsm state from the earlier run does not matter; we
+		// only care that Open() does not fail with errClusterMismatch.
+		engine, err := Open(ctx, OpenConfig{
+			NodeID:       n.peer.NodeID,
+			LocalID:      n.peer.ID,
+			LocalAddress: n.peer.Address,
+			DataDir:      n.dir,
+			Transport:    n.transport,
+			StateMachine: n.fsm,
+		})
+		require.NoError(t, err, "reopen failed for %s", n.peer.ID)
+		n.engine = engine
+	}
+}
+
 // TestPromoteLearnerRejectsZeroMinAppliedWithoutSkip is the §8 open
 // question 3 fix: passing min_applied_index=0 without
 // skip_min_applied_check returns a clean FailedPrecondition rather

--- a/internal/raftengine/etcd/peer_metadata.go
+++ b/internal/raftengine/etcd/peer_metadata.go
@@ -13,9 +13,17 @@ import (
 
 const (
 	peersFileName       = "etcd-raft-peers.bin"
-	peersFileVersion    = uint32(1)
+	peersFileVersionV1  = uint32(1)
+	peersFileVersionV2  = uint32(2) // adds per-peer suffrage byte
+	peersFileVersion    = peersFileVersionV2
 	maxPersistedPeers   = uint32(1 << 10)
 	maxPersistedPeerStr = uint32(1 << 20)
+)
+
+// Per-peer suffrage byte values used in v2 of the peers file.
+const (
+	persistedSuffrageVoter   uint8 = 0
+	persistedSuffrageLearner uint8 = 1
 )
 
 var peersFileMagic = [4]byte{'E', 'K', 'V', 'P'}
@@ -100,7 +108,8 @@ func readPersistedPeersFile(path string) (persistedPeers, error) {
 	}()
 
 	reader := bufio.NewReader(file)
-	if err := readVersionedHeader(reader, fileFormat{magic: peersFileMagic, version: peersFileVersion}, "etcd raft peers"); err != nil {
+	version, err := readPeersFileHeader(reader)
+	if err != nil {
 		return persistedPeers{}, err
 	}
 
@@ -118,7 +127,7 @@ func readPersistedPeersFile(path string) (persistedPeers, error) {
 
 	peers := make([]Peer, 0, count)
 	for range count {
-		peer, err := readPersistedPeer(reader)
+		peer, err := readPersistedPeer(reader, version)
 		if err != nil {
 			return persistedPeers{}, err
 		}
@@ -127,10 +136,51 @@ func readPersistedPeersFile(path string) (persistedPeers, error) {
 	return persistedPeers{Index: index, Peers: peers}, nil
 }
 
-func readPersistedPeer(reader io.Reader) (Peer, error) {
+// readPeersFileHeader validates the magic and returns the file's
+// version. v1 (legacy: no per-peer suffrage byte; all peers are voters)
+// and v2 (current: per-peer suffrage byte) are accepted; any other
+// value is rejected. The split from the shared readVersionedHeader
+// helper is intentional — that helper accepts a single hardcoded
+// version and we need to dispatch.
+func readPeersFileHeader(r io.Reader) (uint32, error) {
+	var actual [4]byte
+	if _, err := io.ReadFull(r, actual[:]); err != nil {
+		return 0, errors.WithStack(err)
+	}
+	if actual != peersFileMagic {
+		return 0, errors.WithStack(errors.New("invalid etcd raft peers magic"))
+	}
+	version, err := readU32(r)
+	if err != nil {
+		return 0, err
+	}
+	switch version {
+	case peersFileVersionV1, peersFileVersionV2:
+		return version, nil
+	default:
+		return 0, errors.WithStack(errors.Newf("unsupported etcd raft peers version %d", version))
+	}
+}
+
+func readPersistedPeer(reader io.Reader, version uint32) (Peer, error) {
 	nodeID, err := readU64(reader)
 	if err != nil {
 		return Peer{}, err
+	}
+	suffrage := SuffrageVoter
+	if version >= peersFileVersionV2 {
+		raw, err := readU8(reader)
+		if err != nil {
+			return Peer{}, err
+		}
+		switch raw {
+		case persistedSuffrageVoter:
+			suffrage = SuffrageVoter
+		case persistedSuffrageLearner:
+			suffrage = SuffrageLearner
+		default:
+			return Peer{}, errors.WithStack(errors.Newf("unknown peer suffrage byte %d", raw))
+		}
 	}
 	id, err := readString(reader, maxPersistedPeerStr, "peer id")
 	if err != nil {
@@ -140,11 +190,16 @@ func readPersistedPeer(reader io.Reader) (Peer, error) {
 	if err != nil {
 		return Peer{}, err
 	}
-	return normalizePersistedPeer(Peer{
+	peer, err := normalizePersistedPeer(Peer{
 		NodeID:  nodeID,
 		ID:      id,
 		Address: address,
 	})
+	if err != nil {
+		return Peer{}, err
+	}
+	peer.Suffrage = suffrage
+	return peer, nil
 }
 
 func writePersistedPeersFile(path string, state persistedPeers) error {
@@ -164,13 +219,7 @@ func writePersistedPeersFile(path string, state persistedPeers) error {
 			return err
 		}
 		for _, peer := range state.Peers {
-			if err := writeU64(writer, peer.NodeID); err != nil {
-				return err
-			}
-			if err := writeString(writer, peer.ID); err != nil {
-				return err
-			}
-			if err := writeString(writer, peer.Address); err != nil {
+			if err := writePersistedPeerEntry(writer, peer); err != nil {
 				return err
 			}
 		}
@@ -179,6 +228,26 @@ func writePersistedPeersFile(path string, state persistedPeers) error {
 		}
 		return nil
 	})
+}
+
+func writePersistedPeerEntry(w io.Writer, peer Peer) error {
+	if err := writeU64(w, peer.NodeID); err != nil {
+		return err
+	}
+	if err := writeU8(w, persistedSuffrageByte(peer.Suffrage)); err != nil {
+		return err
+	}
+	if err := writeString(w, peer.ID); err != nil {
+		return err
+	}
+	return writeString(w, peer.Address)
+}
+
+func persistedSuffrageByte(suffrage string) uint8 {
+	if suffrage == SuffrageLearner {
+		return persistedSuffrageLearner
+	}
+	return persistedSuffrageVoter
 }
 
 func readString(r io.Reader, maxSize uint32, kind string) (string, error) {

--- a/internal/raftengine/etcd/peer_metadata_test.go
+++ b/internal/raftengine/etcd/peer_metadata_test.go
@@ -1,0 +1,121 @@
+package etcd
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPersistedPeersV2RoundTripMixedSuffrage(t *testing.T) {
+	dir := t.TempDir()
+	peers := []Peer{
+		{NodeID: 1, ID: "n1", Address: "127.0.0.1:7001", Suffrage: SuffrageVoter},
+		{NodeID: 2, ID: "n2", Address: "127.0.0.1:7002", Suffrage: SuffrageLearner},
+		{NodeID: 3, ID: "n3", Address: "127.0.0.1:7003", Suffrage: SuffrageVoter},
+	}
+
+	require.NoError(t, savePersistedPeers(dir, 42, peers))
+
+	loaded, ok, err := LoadPersistedPeers(dir)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, peers, loaded)
+}
+
+func TestPersistedPeersV1FileReadsAsAllVoter(t *testing.T) {
+	dir := t.TempDir()
+	path := peersFilePath(dir)
+
+	// Hand-craft a v1 file: magic + version=1 + index + count + per-peer
+	// (nodeID, id, address) without the v2 suffrage byte.
+	require.NoError(t, replaceFile(path, func(w io.Writer) error {
+		return writeV1PeersFile(w, 7, []Peer{
+			{NodeID: 1, ID: "n1", Address: "127.0.0.1:7001"},
+			{NodeID: 2, ID: "n2", Address: "127.0.0.1:7002"},
+		})
+	}))
+
+	loaded, ok, err := LoadPersistedPeers(dir)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, []Peer{
+		{NodeID: 1, ID: "n1", Address: "127.0.0.1:7001", Suffrage: SuffrageVoter},
+		{NodeID: 2, ID: "n2", Address: "127.0.0.1:7002", Suffrage: SuffrageVoter},
+	}, loaded)
+}
+
+func writeV1PeersFile(w io.Writer, index uint64, peers []Peer) error {
+	writer := bufio.NewWriter(w)
+	if _, err := writer.Write(peersFileMagic[:]); err != nil {
+		return err
+	}
+	if err := writeU32(writer, peersFileVersionV1); err != nil {
+		return err
+	}
+	if err := writeU64(writer, index); err != nil {
+		return err
+	}
+	count, err := uint32Len(len(peers))
+	if err != nil {
+		return err
+	}
+	if err := writeU32(writer, count); err != nil {
+		return err
+	}
+	for _, peer := range peers {
+		if err := writeV1PeerEntry(writer, peer); err != nil {
+			return err
+		}
+	}
+	return writer.Flush()
+}
+
+func writeV1PeerEntry(w io.Writer, peer Peer) error {
+	if err := writeU64(w, peer.NodeID); err != nil {
+		return err
+	}
+	if err := writeString(w, peer.ID); err != nil {
+		return err
+	}
+	return writeString(w, peer.Address)
+}
+
+func TestPersistedPeersV2RewritesAfterV1Read(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, savePersistedPeers(dir, 1, []Peer{
+		{NodeID: 1, ID: "n1", Address: "127.0.0.1:7001"},
+	}))
+
+	// First saved file is already v2 because the writer always emits v2.
+	// Verify by reading the version field directly.
+	file, err := os.Open(filepath.Join(dir, peersFileName))
+	require.NoError(t, err)
+	defer func() { _ = file.Close() }()
+
+	reader := bufio.NewReader(file)
+	version, err := readPeersFileHeader(reader)
+	require.NoError(t, err)
+	require.Equal(t, peersFileVersionV2, version)
+}
+
+func TestPersistedPeersUnknownVersionRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := peersFilePath(dir)
+	require.NoError(t, replaceFile(path, func(w io.Writer) error {
+		writer := bufio.NewWriter(w)
+		if _, err := writer.Write(peersFileMagic[:]); err != nil {
+			return err
+		}
+		if err := writeU32(writer, 99); err != nil {
+			return err
+		}
+		return writer.Flush()
+	}))
+
+	_, _, err := LoadPersistedPeers(dir)
+	require.Error(t, err)
+}

--- a/internal/raftengine/etcd/peer_metadata_test.go
+++ b/internal/raftengine/etcd/peer_metadata_test.go
@@ -84,14 +84,17 @@ func writeV1PeerEntry(w io.Writer, peer Peer) error {
 	return writeString(w, peer.Address)
 }
 
-func TestPersistedPeersV2RewritesAfterV1Read(t *testing.T) {
+// TestPersistedPeersWriterAlwaysEmitsV2 pins the writer-side
+// invariant that savePersistedPeers writes the v2 header and per-peer
+// suffrage byte even when the input peers carry no explicit
+// Suffrage. There is no v1->v2 read-side migration step in this
+// path; the writer is unconditionally v2.
+func TestPersistedPeersWriterAlwaysEmitsV2(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, savePersistedPeers(dir, 1, []Peer{
 		{NodeID: 1, ID: "n1", Address: "127.0.0.1:7001"},
 	}))
 
-	// First saved file is already v2 because the writer always emits v2.
-	// Verify by reading the version field directly.
 	file, err := os.Open(filepath.Join(dir, peersFileName))
 	require.NoError(t, err)
 	defer func() { _ = file.Close() }()
@@ -100,6 +103,50 @@ func TestPersistedPeersV2RewritesAfterV1Read(t *testing.T) {
 	version, err := readPeersFileHeader(reader)
 	require.NoError(t, err)
 	require.Equal(t, peersFileVersionV2, version)
+}
+
+// TestPersistedPeersV2UnknownSuffrageRejected pins the validation in
+// readPersistedPeer that rejects suffrage bytes outside the known
+// (0=voter, 1=learner) set, so a future binary that introduces a new
+// suffrage variant cannot silently coerce its peers to voter on a
+// build that does not understand the new value.
+func TestPersistedPeersV2UnknownSuffrageRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := peersFilePath(dir)
+
+	require.NoError(t, replaceFile(path, func(w io.Writer) error {
+		writer := bufio.NewWriter(w)
+		if _, err := writer.Write(peersFileMagic[:]); err != nil {
+			return err
+		}
+		if err := writeU32(writer, peersFileVersionV2); err != nil {
+			return err
+		}
+		if err := writeU64(writer, 1); err != nil {
+			return err
+		}
+		if err := writeU32(writer, 1); err != nil {
+			return err
+		}
+		// peer entry with an unknown suffrage byte.
+		if err := writeU64(writer, 1); err != nil {
+			return err
+		}
+		if err := writeU8(writer, 0xFF); err != nil {
+			return err
+		}
+		if err := writeString(writer, "n1"); err != nil {
+			return err
+		}
+		if err := writeString(writer, "127.0.0.1:7001"); err != nil {
+			return err
+		}
+		return writer.Flush()
+	}))
+
+	_, _, err := LoadPersistedPeers(dir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown peer suffrage byte")
 }
 
 func TestPersistedPeersUnknownVersionRejected(t *testing.T) {

--- a/internal/raftengine/etcd/peers.go
+++ b/internal/raftengine/etcd/peers.go
@@ -21,10 +21,26 @@ var (
 
 const peerSpecParts = 2
 
+// Suffrage values match the strings emitted by configurationFromConfState
+// and surfaced by raftengine.Server.Suffrage / pb.RaftAdminMember.suffrage.
+const (
+	SuffrageVoter   = "voter"
+	SuffrageLearner = "learner"
+)
+
 type Peer struct {
 	NodeID  uint64
 	ID      string
 	Address string
+	// Suffrage is a v2-peers-file artifact only. It is NOT consulted by
+	// confStateForPeers (cold bootstrap is voter-only), and it is NOT
+	// consulted by configurationFromConfState (hot path reads
+	// ConfState.Voters / ConfState.Learners directly). Its sole role is
+	// to round-trip the v2 peers file across restarts so the operator
+	// view of the peers file is consistent with the eventual ConfState
+	// view after WAL replay. The empty string and SuffrageVoter are
+	// equivalent. See docs/design/2026_04_26_proposed_raft_learner.md §4.3.
+	Suffrage string
 }
 
 func DeriveNodeID(id string) uint64 {

--- a/internal/raftengine/etcd/persistence.go
+++ b/internal/raftengine/etcd/persistence.go
@@ -385,6 +385,18 @@ func readU32(r io.Reader) (uint32, error) {
 	return v, nil
 }
 
+func writeU8(w io.Writer, v uint8) error {
+	return errors.WithStack(binary.Write(w, binary.BigEndian, v))
+}
+
+func readU8(r io.Reader) (uint8, error) {
+	var v uint8
+	if err := binary.Read(r, binary.BigEndian, &v); err != nil {
+		return 0, errors.WithStack(err)
+	}
+	return v, nil
+}
+
 func readU64(r io.Reader) (uint64, error) {
 	var v uint64
 	if err := binary.Read(r, binary.BigEndian, &v); err != nil {

--- a/internal/raftengine/etcd/wal_store.go
+++ b/internal/raftengine/etcd/wal_store.go
@@ -407,19 +407,71 @@ func validateConfState(conf raftpb.ConfState, peers []Peer) error {
 	if len(peers) == 0 {
 		return nil
 	}
-	expected := confStateForPeers(peers)
-	if len(conf.Voters) != len(expected.Voters) {
-		return errors.Wrapf(errClusterMismatch, "expected %d voters got %d", len(expected.Voters), len(conf.Voters))
-	}
-	for i, voter := range conf.Voters {
-		if voter != expected.Voters[i] {
-			return errors.Wrapf(errClusterMismatch, "voter[%d]=%d expected %d", i, voter, expected.Voters[i])
-		}
-	}
-	if len(conf.VotersOutgoing) > 0 || len(conf.Learners) > 0 || len(conf.LearnersNext) > 0 || conf.AutoLeave {
+	// Joint consensus markers are still rejected: learner add/promote
+	// uses the simple V1 single-step ConfChange path which never sets
+	// these. See docs/design/2026_04_26_proposed_raft_learner.md §4.2.
+	if len(conf.VotersOutgoing) > 0 || len(conf.LearnersNext) > 0 || conf.AutoLeave {
 		return errors.Wrap(errClusterMismatch, "joint consensus state is not supported")
 	}
+	expectedVoters, learnerSet := splitPeersBySuffrage(peers)
+	if err := validateConfStateVoters(conf, expectedVoters); err != nil {
+		return err
+	}
+	return validateConfStateLearners(conf, learnerSet)
+}
+
+// validateConfStateVoters checks that conf.Voters matches the voter
+// peers element-wise. The element-wise comparison relies on the
+// well-established voter ordering invariant: persistConfigState
+// writes voters in ConfState.Voters order and normalizePeers
+// preserves it.
+func validateConfStateVoters(conf raftpb.ConfState, expectedVoters []uint64) error {
+	if len(conf.Voters) != len(expectedVoters) {
+		return errors.Wrapf(errClusterMismatch, "expected %d voters got %d", len(expectedVoters), len(conf.Voters))
+	}
+	for i, voter := range conf.Voters {
+		if voter != expectedVoters[i] {
+			return errors.Wrapf(errClusterMismatch, "voter[%d]=%d expected %d", i, voter, expectedVoters[i])
+		}
+	}
 	return nil
+}
+
+// validateConfStateLearners is set-based, not element-wise. There is
+// no prior writer-side ordering invariant for learners, so we do not
+// pin one in the reader. A set comparison rejects both
+// same-count-member-divergence and conf-learner-not-in-peers cases —
+// see docs/design/2026_04_26_proposed_raft_learner.md §4.2 edit 3.
+func validateConfStateLearners(conf raftpb.ConfState, expected map[uint64]struct{}) error {
+	if len(conf.Learners) != len(expected) {
+		return errors.Wrapf(errClusterMismatch, "expected %d learners got %d", len(expected), len(conf.Learners))
+	}
+	for _, nodeID := range conf.Learners {
+		if _, ok := expected[nodeID]; !ok {
+			return errors.Wrapf(errClusterMismatch, "learner %d not present in peers", nodeID)
+		}
+	}
+	return nil
+}
+
+// splitPeersBySuffrage partitions a peers list into the ordered voter
+// node-ID slice (preserving input order, which encodes the
+// well-established voter ordering invariant) and a learner set
+// (unordered).
+func splitPeersBySuffrage(peers []Peer) ([]uint64, map[uint64]struct{}) {
+	voters := make([]uint64, 0, len(peers))
+	var learners map[uint64]struct{}
+	for _, peer := range peers {
+		if peer.Suffrage == SuffrageLearner {
+			if learners == nil {
+				learners = make(map[uint64]struct{})
+			}
+			learners[peer.NodeID] = struct{}{}
+			continue
+		}
+		voters = append(voters, peer.NodeID)
+	}
+	return voters, learners
 }
 
 func loadLegacyOrSplitState(dataDir string) (persistedState, error) {

--- a/internal/raftengine/factory.go
+++ b/internal/raftengine/factory.go
@@ -10,6 +10,16 @@ type FactoryConfig struct {
 	Peers        []Server
 	Bootstrap    bool
 	StateMachine StateMachine
+	// JoinAsLearner records the operator-stated expectation that the
+	// local node will be added to the cluster via AddLearner, never
+	// AddVoter. The flag is purely an alarm: if a post-apply ConfState
+	// lists this node as a voter instead of a learner, the engine
+	// emits an ERROR-level structured log and increments a metric.
+	// The node keeps running -- by the time the conf change has
+	// applied, the node already counts toward quorum and an unilateral
+	// shutdown would shrink the cluster's effective fault tolerance.
+	// See docs/design/2026_04_26_proposed_raft_learner.md §4.5.
+	JoinAsLearner bool
 }
 
 // FactoryResult holds the output of Factory.Create.

--- a/main.go
+++ b/main.go
@@ -97,6 +97,7 @@ var (
 	raftDir              = flag.String("raftDataDir", "data/", "Raft data dir")
 	raftBootstrap        = flag.Bool("raftBootstrap", false, "Whether to bootstrap the Raft cluster")
 	raftBootstrapMembers = flag.String("raftBootstrapMembers", "", "Comma-separated bootstrap raft members (raftID=host:port,...)")
+	raftJoinAsLearner    = flag.Bool("raftJoinAsLearner", false, "Local node expects to join an existing cluster as a learner; if a post-apply ConfState lists this node as a voter instead, an ERROR-level alarm fires (the node keeps running -- the flag is an operator alarm, not a consensus veto). See docs/design/2026_04_26_proposed_raft_learner.md §4.5.")
 	raftGroups           = flag.String("raftGroups", "", "Comma-separated raft groups (groupID=host:port,...)")
 	shardRanges          = flag.String("shardRanges", "", "Comma-separated shard ranges (start:end=groupID,...)")
 	raftRedisMap         = flag.String("raftRedisMap", "", "Map of Raft address to Redis address (raftAddr=redisAddr,...)")
@@ -528,7 +529,7 @@ func buildShardGroups(
 		// Each shard FSM shares the same HLC so any shard's lease renewal advances
 		// the global physicalCeiling. The logical counter remains in-memory only.
 		sm := kv.NewKvFSMWithHLC(st, clock)
-		runtime, err := buildRuntimeForGroup(raftID, g, raftDir, multi, bootstrap, bootstrapServers, st, sm, factory)
+		runtime, err := buildRuntimeForGroup(raftID, g, raftDir, multi, bootstrap, bootstrapServers, st, sm, factory, *raftJoinAsLearner)
 		if err != nil {
 			for _, rt := range runtimes {
 				rt.Close()

--- a/multiraft_runtime.go
+++ b/multiraft_runtime.go
@@ -207,6 +207,7 @@ func buildRuntimeForGroup(
 	st store.MVCCStore,
 	sm raftengine.StateMachine,
 	factory raftengine.Factory,
+	joinAsLearner bool,
 ) (*raftGroupRuntime, error) {
 	dir := groupDataDir(baseDir, raftID, group.id, multi)
 	engineType := raftEngineType(factory.EngineType())
@@ -215,12 +216,13 @@ func buildRuntimeForGroup(
 	}
 
 	result, err := factory.Create(raftengine.FactoryConfig{
-		LocalID:      raftID,
-		LocalAddress: group.address,
-		DataDir:      dir,
-		Peers:        bootstrapServers,
-		Bootstrap:    bootstrap,
-		StateMachine: sm,
+		LocalID:       raftID,
+		LocalAddress:  group.address,
+		DataDir:       dir,
+		Peers:         bootstrapServers,
+		Bootstrap:     bootstrap,
+		StateMachine:  sm,
+		JoinAsLearner: joinAsLearner,
 	})
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/proto/service.pb.go
+++ b/proto/service.pb.go
@@ -1836,6 +1836,131 @@ func (x *RaftAdminAddVoterRequest) GetPreviousIndex() uint64 {
 	return 0
 }
 
+type RaftAdminAddLearnerRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Address       string                 `protobuf:"bytes,2,opt,name=address,proto3" json:"address,omitempty"`
+	PreviousIndex uint64                 `protobuf:"varint,3,opt,name=previous_index,json=previousIndex,proto3" json:"previous_index,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RaftAdminAddLearnerRequest) Reset() {
+	*x = RaftAdminAddLearnerRequest{}
+	mi := &file_service_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RaftAdminAddLearnerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RaftAdminAddLearnerRequest) ProtoMessage() {}
+
+func (x *RaftAdminAddLearnerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_service_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RaftAdminAddLearnerRequest.ProtoReflect.Descriptor instead.
+func (*RaftAdminAddLearnerRequest) Descriptor() ([]byte, []int) {
+	return file_service_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *RaftAdminAddLearnerRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *RaftAdminAddLearnerRequest) GetAddress() string {
+	if x != nil {
+		return x.Address
+	}
+	return ""
+}
+
+func (x *RaftAdminAddLearnerRequest) GetPreviousIndex() uint64 {
+	if x != nil {
+		return x.PreviousIndex
+	}
+	return 0
+}
+
+type RaftAdminPromoteLearnerRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	PreviousIndex uint64                 `protobuf:"varint,2,opt,name=previous_index,json=previousIndex,proto3" json:"previous_index,omitempty"`
+	// min_applied_index is the catch-up precondition: the learner's
+	// leader-side Progress.Match must be >= min_applied_index for the
+	// promote conf change to be proposed. 0 skips the check (kept for
+	// symmetry with previous_index but discouraged in production -- the
+	// operator runbook recommends passing a recent leader commit index).
+	MinAppliedIndex uint64 `protobuf:"varint,3,opt,name=min_applied_index,json=minAppliedIndex,proto3" json:"min_applied_index,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *RaftAdminPromoteLearnerRequest) Reset() {
+	*x = RaftAdminPromoteLearnerRequest{}
+	mi := &file_service_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RaftAdminPromoteLearnerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RaftAdminPromoteLearnerRequest) ProtoMessage() {}
+
+func (x *RaftAdminPromoteLearnerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_service_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RaftAdminPromoteLearnerRequest.ProtoReflect.Descriptor instead.
+func (*RaftAdminPromoteLearnerRequest) Descriptor() ([]byte, []int) {
+	return file_service_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *RaftAdminPromoteLearnerRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *RaftAdminPromoteLearnerRequest) GetPreviousIndex() uint64 {
+	if x != nil {
+		return x.PreviousIndex
+	}
+	return 0
+}
+
+func (x *RaftAdminPromoteLearnerRequest) GetMinAppliedIndex() uint64 {
+	if x != nil {
+		return x.MinAppliedIndex
+	}
+	return 0
+}
+
 type RaftAdminRemoveServerRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -1846,7 +1971,7 @@ type RaftAdminRemoveServerRequest struct {
 
 func (x *RaftAdminRemoveServerRequest) Reset() {
 	*x = RaftAdminRemoveServerRequest{}
-	mi := &file_service_proto_msgTypes[33]
+	mi := &file_service_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1858,7 +1983,7 @@ func (x *RaftAdminRemoveServerRequest) String() string {
 func (*RaftAdminRemoveServerRequest) ProtoMessage() {}
 
 func (x *RaftAdminRemoveServerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_service_proto_msgTypes[33]
+	mi := &file_service_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1871,7 +1996,7 @@ func (x *RaftAdminRemoveServerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RaftAdminRemoveServerRequest.ProtoReflect.Descriptor instead.
 func (*RaftAdminRemoveServerRequest) Descriptor() ([]byte, []int) {
-	return file_service_proto_rawDescGZIP(), []int{33}
+	return file_service_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *RaftAdminRemoveServerRequest) GetId() string {
@@ -1897,7 +2022,7 @@ type RaftAdminConfigurationChangeResponse struct {
 
 func (x *RaftAdminConfigurationChangeResponse) Reset() {
 	*x = RaftAdminConfigurationChangeResponse{}
-	mi := &file_service_proto_msgTypes[34]
+	mi := &file_service_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1909,7 +2034,7 @@ func (x *RaftAdminConfigurationChangeResponse) String() string {
 func (*RaftAdminConfigurationChangeResponse) ProtoMessage() {}
 
 func (x *RaftAdminConfigurationChangeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_service_proto_msgTypes[34]
+	mi := &file_service_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1922,7 +2047,7 @@ func (x *RaftAdminConfigurationChangeResponse) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use RaftAdminConfigurationChangeResponse.ProtoReflect.Descriptor instead.
 func (*RaftAdminConfigurationChangeResponse) Descriptor() ([]byte, []int) {
-	return file_service_proto_rawDescGZIP(), []int{34}
+	return file_service_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *RaftAdminConfigurationChangeResponse) GetIndex() uint64 {
@@ -1942,7 +2067,7 @@ type RaftAdminTransferLeadershipRequest struct {
 
 func (x *RaftAdminTransferLeadershipRequest) Reset() {
 	*x = RaftAdminTransferLeadershipRequest{}
-	mi := &file_service_proto_msgTypes[35]
+	mi := &file_service_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1954,7 +2079,7 @@ func (x *RaftAdminTransferLeadershipRequest) String() string {
 func (*RaftAdminTransferLeadershipRequest) ProtoMessage() {}
 
 func (x *RaftAdminTransferLeadershipRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_service_proto_msgTypes[35]
+	mi := &file_service_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1967,7 +2092,7 @@ func (x *RaftAdminTransferLeadershipRequest) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use RaftAdminTransferLeadershipRequest.ProtoReflect.Descriptor instead.
 func (*RaftAdminTransferLeadershipRequest) Descriptor() ([]byte, []int) {
-	return file_service_proto_rawDescGZIP(), []int{35}
+	return file_service_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *RaftAdminTransferLeadershipRequest) GetTargetId() string {
@@ -1992,7 +2117,7 @@ type RaftAdminTransferLeadershipResponse struct {
 
 func (x *RaftAdminTransferLeadershipResponse) Reset() {
 	*x = RaftAdminTransferLeadershipResponse{}
-	mi := &file_service_proto_msgTypes[36]
+	mi := &file_service_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2004,7 +2129,7 @@ func (x *RaftAdminTransferLeadershipResponse) String() string {
 func (*RaftAdminTransferLeadershipResponse) ProtoMessage() {}
 
 func (x *RaftAdminTransferLeadershipResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_service_proto_msgTypes[36]
+	mi := &file_service_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2017,7 +2142,7 @@ func (x *RaftAdminTransferLeadershipResponse) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use RaftAdminTransferLeadershipResponse.ProtoReflect.Descriptor instead.
 func (*RaftAdminTransferLeadershipResponse) Descriptor() ([]byte, []int) {
-	return file_service_proto_rawDescGZIP(), []int{36}
+	return file_service_proto_rawDescGZIP(), []int{38}
 }
 
 var File_service_proto protoreflect.FileDescriptor
@@ -2133,7 +2258,15 @@ const file_service_proto_rawDesc = "" +
 	"\x18RaftAdminAddVoterRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
 	"\aaddress\x18\x02 \x01(\tR\aaddress\x12%\n" +
-	"\x0eprevious_index\x18\x03 \x01(\x04R\rpreviousIndex\"U\n" +
+	"\x0eprevious_index\x18\x03 \x01(\x04R\rpreviousIndex\"m\n" +
+	"\x1aRaftAdminAddLearnerRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
+	"\aaddress\x18\x02 \x01(\tR\aaddress\x12%\n" +
+	"\x0eprevious_index\x18\x03 \x01(\x04R\rpreviousIndex\"\x83\x01\n" +
+	"\x1eRaftAdminPromoteLearnerRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12%\n" +
+	"\x0eprevious_index\x18\x02 \x01(\x04R\rpreviousIndex\x12*\n" +
+	"\x11min_applied_index\x18\x03 \x01(\x04R\x0fminAppliedIndex\"U\n" +
 	"\x1cRaftAdminRemoveServerRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12%\n" +
 	"\x0eprevious_index\x18\x02 \x01(\x04R\rpreviousIndex\"<\n" +
@@ -2162,11 +2295,14 @@ const file_service_proto_rawDesc = "" +
 	"\x04Scan\x12\f.ScanRequest\x1a\r.ScanResponse\"\x00\x122\n" +
 	"\bPreWrite\x12\x10.PreWriteRequest\x1a\x12.PreCommitResponse\"\x00\x12+\n" +
 	"\x06Commit\x12\x0e.CommitRequest\x1a\x0f.CommitResponse\"\x00\x121\n" +
-	"\bRollback\x12\x10.RollbackRequest\x1a\x11.RollbackResponse\"\x002\xa9\x03\n" +
+	"\bRollback\x12\x10.RollbackRequest\x1a\x11.RollbackResponse\"\x002\xd9\x04\n" +
 	"\tRaftAdmin\x12=\n" +
 	"\x06Status\x12\x17.RaftAdminStatusRequest\x1a\x18.RaftAdminStatusResponse\"\x00\x12R\n" +
 	"\rConfiguration\x12\x1e.RaftAdminConfigurationRequest\x1a\x1f.RaftAdminConfigurationResponse\"\x00\x12N\n" +
-	"\bAddVoter\x12\x19.RaftAdminAddVoterRequest\x1a%.RaftAdminConfigurationChangeResponse\"\x00\x12V\n" +
+	"\bAddVoter\x12\x19.RaftAdminAddVoterRequest\x1a%.RaftAdminConfigurationChangeResponse\"\x00\x12R\n" +
+	"\n" +
+	"AddLearner\x12\x1b.RaftAdminAddLearnerRequest\x1a%.RaftAdminConfigurationChangeResponse\"\x00\x12Z\n" +
+	"\x0ePromoteLearner\x12\x1f.RaftAdminPromoteLearnerRequest\x1a%.RaftAdminConfigurationChangeResponse\"\x00\x12V\n" +
 	"\fRemoveServer\x12\x1d.RaftAdminRemoveServerRequest\x1a%.RaftAdminConfigurationChangeResponse\"\x00\x12a\n" +
 	"\x12TransferLeadership\x12#.RaftAdminTransferLeadershipRequest\x1a$.RaftAdminTransferLeadershipResponse\"\x00B#Z!github.com/bootjp/elastickv/protob\x06proto3"
 
@@ -2183,7 +2319,7 @@ func file_service_proto_rawDescGZIP() []byte {
 }
 
 var file_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_service_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
+var file_service_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
 var file_service_proto_goTypes = []any{
 	(RaftAdminState)(0),                          // 0: RaftAdminState
 	(*RawPutRequest)(nil),                        // 1: RawPutRequest
@@ -2219,10 +2355,12 @@ var file_service_proto_goTypes = []any{
 	(*RaftAdminMember)(nil),                      // 31: RaftAdminMember
 	(*RaftAdminConfigurationResponse)(nil),       // 32: RaftAdminConfigurationResponse
 	(*RaftAdminAddVoterRequest)(nil),             // 33: RaftAdminAddVoterRequest
-	(*RaftAdminRemoveServerRequest)(nil),         // 34: RaftAdminRemoveServerRequest
-	(*RaftAdminConfigurationChangeResponse)(nil), // 35: RaftAdminConfigurationChangeResponse
-	(*RaftAdminTransferLeadershipRequest)(nil),   // 36: RaftAdminTransferLeadershipRequest
-	(*RaftAdminTransferLeadershipResponse)(nil),  // 37: RaftAdminTransferLeadershipResponse
+	(*RaftAdminAddLearnerRequest)(nil),           // 34: RaftAdminAddLearnerRequest
+	(*RaftAdminPromoteLearnerRequest)(nil),       // 35: RaftAdminPromoteLearnerRequest
+	(*RaftAdminRemoveServerRequest)(nil),         // 36: RaftAdminRemoveServerRequest
+	(*RaftAdminConfigurationChangeResponse)(nil), // 37: RaftAdminConfigurationChangeResponse
+	(*RaftAdminTransferLeadershipRequest)(nil),   // 38: RaftAdminTransferLeadershipRequest
+	(*RaftAdminTransferLeadershipResponse)(nil),  // 39: RaftAdminTransferLeadershipResponse
 }
 var file_service_proto_depIdxs = []int32{
 	10, // 0: RawScanAtResponse.kv:type_name -> RawKVPair
@@ -2248,27 +2386,31 @@ var file_service_proto_depIdxs = []int32{
 	28, // 20: RaftAdmin.Status:input_type -> RaftAdminStatusRequest
 	30, // 21: RaftAdmin.Configuration:input_type -> RaftAdminConfigurationRequest
 	33, // 22: RaftAdmin.AddVoter:input_type -> RaftAdminAddVoterRequest
-	34, // 23: RaftAdmin.RemoveServer:input_type -> RaftAdminRemoveServerRequest
-	36, // 24: RaftAdmin.TransferLeadership:input_type -> RaftAdminTransferLeadershipRequest
-	2,  // 25: RawKV.RawPut:output_type -> RawPutResponse
-	4,  // 26: RawKV.RawGet:output_type -> RawGetResponse
-	6,  // 27: RawKV.RawDelete:output_type -> RawDeleteResponse
-	8,  // 28: RawKV.RawLatestCommitTS:output_type -> RawLatestCommitTSResponse
-	11, // 29: RawKV.RawScanAt:output_type -> RawScanAtResponse
-	13, // 30: TransactionalKV.Put:output_type -> PutResponse
-	17, // 31: TransactionalKV.Get:output_type -> GetResponse
-	15, // 32: TransactionalKV.Delete:output_type -> DeleteResponse
-	21, // 33: TransactionalKV.Scan:output_type -> ScanResponse
-	23, // 34: TransactionalKV.PreWrite:output_type -> PreCommitResponse
-	25, // 35: TransactionalKV.Commit:output_type -> CommitResponse
-	27, // 36: TransactionalKV.Rollback:output_type -> RollbackResponse
-	29, // 37: RaftAdmin.Status:output_type -> RaftAdminStatusResponse
-	32, // 38: RaftAdmin.Configuration:output_type -> RaftAdminConfigurationResponse
-	35, // 39: RaftAdmin.AddVoter:output_type -> RaftAdminConfigurationChangeResponse
-	35, // 40: RaftAdmin.RemoveServer:output_type -> RaftAdminConfigurationChangeResponse
-	37, // 41: RaftAdmin.TransferLeadership:output_type -> RaftAdminTransferLeadershipResponse
-	25, // [25:42] is the sub-list for method output_type
-	8,  // [8:25] is the sub-list for method input_type
+	34, // 23: RaftAdmin.AddLearner:input_type -> RaftAdminAddLearnerRequest
+	35, // 24: RaftAdmin.PromoteLearner:input_type -> RaftAdminPromoteLearnerRequest
+	36, // 25: RaftAdmin.RemoveServer:input_type -> RaftAdminRemoveServerRequest
+	38, // 26: RaftAdmin.TransferLeadership:input_type -> RaftAdminTransferLeadershipRequest
+	2,  // 27: RawKV.RawPut:output_type -> RawPutResponse
+	4,  // 28: RawKV.RawGet:output_type -> RawGetResponse
+	6,  // 29: RawKV.RawDelete:output_type -> RawDeleteResponse
+	8,  // 30: RawKV.RawLatestCommitTS:output_type -> RawLatestCommitTSResponse
+	11, // 31: RawKV.RawScanAt:output_type -> RawScanAtResponse
+	13, // 32: TransactionalKV.Put:output_type -> PutResponse
+	17, // 33: TransactionalKV.Get:output_type -> GetResponse
+	15, // 34: TransactionalKV.Delete:output_type -> DeleteResponse
+	21, // 35: TransactionalKV.Scan:output_type -> ScanResponse
+	23, // 36: TransactionalKV.PreWrite:output_type -> PreCommitResponse
+	25, // 37: TransactionalKV.Commit:output_type -> CommitResponse
+	27, // 38: TransactionalKV.Rollback:output_type -> RollbackResponse
+	29, // 39: RaftAdmin.Status:output_type -> RaftAdminStatusResponse
+	32, // 40: RaftAdmin.Configuration:output_type -> RaftAdminConfigurationResponse
+	37, // 41: RaftAdmin.AddVoter:output_type -> RaftAdminConfigurationChangeResponse
+	37, // 42: RaftAdmin.AddLearner:output_type -> RaftAdminConfigurationChangeResponse
+	37, // 43: RaftAdmin.PromoteLearner:output_type -> RaftAdminConfigurationChangeResponse
+	37, // 44: RaftAdmin.RemoveServer:output_type -> RaftAdminConfigurationChangeResponse
+	39, // 45: RaftAdmin.TransferLeadership:output_type -> RaftAdminTransferLeadershipResponse
+	27, // [27:46] is the sub-list for method output_type
+	8,  // [8:27] is the sub-list for method input_type
 	8,  // [8:8] is the sub-list for extension type_name
 	8,  // [8:8] is the sub-list for extension extendee
 	0,  // [0:8] is the sub-list for field type_name
@@ -2285,7 +2427,7 @@ func file_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_service_proto_rawDesc), len(file_service_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   37,
+			NumMessages:   39,
 			NumExtensions: 0,
 			NumServices:   3,
 		},

--- a/proto/service.pb.go
+++ b/proto/service.pb.go
@@ -1902,12 +1902,19 @@ type RaftAdminPromoteLearnerRequest struct {
 	PreviousIndex uint64                 `protobuf:"varint,2,opt,name=previous_index,json=previousIndex,proto3" json:"previous_index,omitempty"`
 	// min_applied_index is the catch-up precondition: the learner's
 	// leader-side Progress.Match must be >= min_applied_index for the
-	// promote conf change to be proposed. 0 skips the check (kept for
-	// symmetry with previous_index but discouraged in production -- the
-	// operator runbook recommends passing a recent leader commit index).
+	// promote conf change to be proposed. The server REJECTS
+	// min_applied_index == 0 unless skip_min_applied_check is also
+	// set, so an operator who copy-pastes a script that omits the
+	// catch-up check gets a clean FailedPrecondition instead of a
+	// silent quorum stall. See learner runbook step 5.
 	MinAppliedIndex uint64 `protobuf:"varint,3,opt,name=min_applied_index,json=minAppliedIndex,proto3" json:"min_applied_index,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// skip_min_applied_check explicitly opts out of the catch-up
+	// precondition. Strongly discouraged in production -- only set
+	// when promoting a learner that the operator has independently
+	// confirmed is up to date (e.g., bootstrap-time scaffolding).
+	SkipMinAppliedCheck bool `protobuf:"varint,4,opt,name=skip_min_applied_check,json=skipMinAppliedCheck,proto3" json:"skip_min_applied_check,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *RaftAdminPromoteLearnerRequest) Reset() {
@@ -1959,6 +1966,13 @@ func (x *RaftAdminPromoteLearnerRequest) GetMinAppliedIndex() uint64 {
 		return x.MinAppliedIndex
 	}
 	return 0
+}
+
+func (x *RaftAdminPromoteLearnerRequest) GetSkipMinAppliedCheck() bool {
+	if x != nil {
+		return x.SkipMinAppliedCheck
+	}
+	return false
 }
 
 type RaftAdminRemoveServerRequest struct {
@@ -2262,11 +2276,12 @@ const file_service_proto_rawDesc = "" +
 	"\x1aRaftAdminAddLearnerRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
 	"\aaddress\x18\x02 \x01(\tR\aaddress\x12%\n" +
-	"\x0eprevious_index\x18\x03 \x01(\x04R\rpreviousIndex\"\x83\x01\n" +
+	"\x0eprevious_index\x18\x03 \x01(\x04R\rpreviousIndex\"\xb8\x01\n" +
 	"\x1eRaftAdminPromoteLearnerRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12%\n" +
 	"\x0eprevious_index\x18\x02 \x01(\x04R\rpreviousIndex\x12*\n" +
-	"\x11min_applied_index\x18\x03 \x01(\x04R\x0fminAppliedIndex\"U\n" +
+	"\x11min_applied_index\x18\x03 \x01(\x04R\x0fminAppliedIndex\x123\n" +
+	"\x16skip_min_applied_check\x18\x04 \x01(\bR\x13skipMinAppliedCheck\"U\n" +
 	"\x1cRaftAdminRemoveServerRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12%\n" +
 	"\x0eprevious_index\x18\x02 \x01(\x04R\rpreviousIndex\"<\n" +

--- a/proto/service.proto
+++ b/proto/service.proto
@@ -25,6 +25,8 @@ service RaftAdmin {
   rpc Status(RaftAdminStatusRequest) returns (RaftAdminStatusResponse) {}
   rpc Configuration(RaftAdminConfigurationRequest) returns (RaftAdminConfigurationResponse) {}
   rpc AddVoter(RaftAdminAddVoterRequest) returns (RaftAdminConfigurationChangeResponse) {}
+  rpc AddLearner(RaftAdminAddLearnerRequest) returns (RaftAdminConfigurationChangeResponse) {}
+  rpc PromoteLearner(RaftAdminPromoteLearnerRequest) returns (RaftAdminConfigurationChangeResponse) {}
   rpc RemoveServer(RaftAdminRemoveServerRequest) returns (RaftAdminConfigurationChangeResponse) {}
   rpc TransferLeadership(RaftAdminTransferLeadershipRequest) returns (RaftAdminTransferLeadershipResponse) {}
 }
@@ -208,6 +210,23 @@ message RaftAdminAddVoterRequest {
   string id = 1;
   string address = 2;
   uint64 previous_index = 3;
+}
+
+message RaftAdminAddLearnerRequest {
+  string id = 1;
+  string address = 2;
+  uint64 previous_index = 3;
+}
+
+message RaftAdminPromoteLearnerRequest {
+  string id = 1;
+  uint64 previous_index = 2;
+  // min_applied_index is the catch-up precondition: the learner's
+  // leader-side Progress.Match must be >= min_applied_index for the
+  // promote conf change to be proposed. 0 skips the check (kept for
+  // symmetry with previous_index but discouraged in production -- the
+  // operator runbook recommends passing a recent leader commit index).
+  uint64 min_applied_index = 3;
 }
 
 message RaftAdminRemoveServerRequest {

--- a/proto/service.proto
+++ b/proto/service.proto
@@ -223,10 +223,17 @@ message RaftAdminPromoteLearnerRequest {
   uint64 previous_index = 2;
   // min_applied_index is the catch-up precondition: the learner's
   // leader-side Progress.Match must be >= min_applied_index for the
-  // promote conf change to be proposed. 0 skips the check (kept for
-  // symmetry with previous_index but discouraged in production -- the
-  // operator runbook recommends passing a recent leader commit index).
+  // promote conf change to be proposed. The server REJECTS
+  // min_applied_index == 0 unless skip_min_applied_check is also
+  // set, so an operator who copy-pastes a script that omits the
+  // catch-up check gets a clean FailedPrecondition instead of a
+  // silent quorum stall. See learner runbook step 5.
   uint64 min_applied_index = 3;
+  // skip_min_applied_check explicitly opts out of the catch-up
+  // precondition. Strongly discouraged in production -- only set
+  // when promoting a learner that the operator has independently
+  // confirmed is up to date (e.g., bootstrap-time scaffolding).
+  bool skip_min_applied_check = 4;
 }
 
 message RaftAdminRemoveServerRequest {

--- a/proto/service_grpc.pb.go
+++ b/proto/service_grpc.pb.go
@@ -606,6 +606,8 @@ const (
 	RaftAdmin_Status_FullMethodName             = "/RaftAdmin/Status"
 	RaftAdmin_Configuration_FullMethodName      = "/RaftAdmin/Configuration"
 	RaftAdmin_AddVoter_FullMethodName           = "/RaftAdmin/AddVoter"
+	RaftAdmin_AddLearner_FullMethodName         = "/RaftAdmin/AddLearner"
+	RaftAdmin_PromoteLearner_FullMethodName     = "/RaftAdmin/PromoteLearner"
 	RaftAdmin_RemoveServer_FullMethodName       = "/RaftAdmin/RemoveServer"
 	RaftAdmin_TransferLeadership_FullMethodName = "/RaftAdmin/TransferLeadership"
 )
@@ -617,6 +619,8 @@ type RaftAdminClient interface {
 	Status(ctx context.Context, in *RaftAdminStatusRequest, opts ...grpc.CallOption) (*RaftAdminStatusResponse, error)
 	Configuration(ctx context.Context, in *RaftAdminConfigurationRequest, opts ...grpc.CallOption) (*RaftAdminConfigurationResponse, error)
 	AddVoter(ctx context.Context, in *RaftAdminAddVoterRequest, opts ...grpc.CallOption) (*RaftAdminConfigurationChangeResponse, error)
+	AddLearner(ctx context.Context, in *RaftAdminAddLearnerRequest, opts ...grpc.CallOption) (*RaftAdminConfigurationChangeResponse, error)
+	PromoteLearner(ctx context.Context, in *RaftAdminPromoteLearnerRequest, opts ...grpc.CallOption) (*RaftAdminConfigurationChangeResponse, error)
 	RemoveServer(ctx context.Context, in *RaftAdminRemoveServerRequest, opts ...grpc.CallOption) (*RaftAdminConfigurationChangeResponse, error)
 	TransferLeadership(ctx context.Context, in *RaftAdminTransferLeadershipRequest, opts ...grpc.CallOption) (*RaftAdminTransferLeadershipResponse, error)
 }
@@ -659,6 +663,26 @@ func (c *raftAdminClient) AddVoter(ctx context.Context, in *RaftAdminAddVoterReq
 	return out, nil
 }
 
+func (c *raftAdminClient) AddLearner(ctx context.Context, in *RaftAdminAddLearnerRequest, opts ...grpc.CallOption) (*RaftAdminConfigurationChangeResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RaftAdminConfigurationChangeResponse)
+	err := c.cc.Invoke(ctx, RaftAdmin_AddLearner_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *raftAdminClient) PromoteLearner(ctx context.Context, in *RaftAdminPromoteLearnerRequest, opts ...grpc.CallOption) (*RaftAdminConfigurationChangeResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RaftAdminConfigurationChangeResponse)
+	err := c.cc.Invoke(ctx, RaftAdmin_PromoteLearner_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *raftAdminClient) RemoveServer(ctx context.Context, in *RaftAdminRemoveServerRequest, opts ...grpc.CallOption) (*RaftAdminConfigurationChangeResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(RaftAdminConfigurationChangeResponse)
@@ -686,6 +710,8 @@ type RaftAdminServer interface {
 	Status(context.Context, *RaftAdminStatusRequest) (*RaftAdminStatusResponse, error)
 	Configuration(context.Context, *RaftAdminConfigurationRequest) (*RaftAdminConfigurationResponse, error)
 	AddVoter(context.Context, *RaftAdminAddVoterRequest) (*RaftAdminConfigurationChangeResponse, error)
+	AddLearner(context.Context, *RaftAdminAddLearnerRequest) (*RaftAdminConfigurationChangeResponse, error)
+	PromoteLearner(context.Context, *RaftAdminPromoteLearnerRequest) (*RaftAdminConfigurationChangeResponse, error)
 	RemoveServer(context.Context, *RaftAdminRemoveServerRequest) (*RaftAdminConfigurationChangeResponse, error)
 	TransferLeadership(context.Context, *RaftAdminTransferLeadershipRequest) (*RaftAdminTransferLeadershipResponse, error)
 	mustEmbedUnimplementedRaftAdminServer()
@@ -706,6 +732,12 @@ func (UnimplementedRaftAdminServer) Configuration(context.Context, *RaftAdminCon
 }
 func (UnimplementedRaftAdminServer) AddVoter(context.Context, *RaftAdminAddVoterRequest) (*RaftAdminConfigurationChangeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AddVoter not implemented")
+}
+func (UnimplementedRaftAdminServer) AddLearner(context.Context, *RaftAdminAddLearnerRequest) (*RaftAdminConfigurationChangeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method AddLearner not implemented")
+}
+func (UnimplementedRaftAdminServer) PromoteLearner(context.Context, *RaftAdminPromoteLearnerRequest) (*RaftAdminConfigurationChangeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method PromoteLearner not implemented")
 }
 func (UnimplementedRaftAdminServer) RemoveServer(context.Context, *RaftAdminRemoveServerRequest) (*RaftAdminConfigurationChangeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RemoveServer not implemented")
@@ -788,6 +820,42 @@ func _RaftAdmin_AddVoter_Handler(srv interface{}, ctx context.Context, dec func(
 	return interceptor(ctx, in, info, handler)
 }
 
+func _RaftAdmin_AddLearner_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RaftAdminAddLearnerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RaftAdminServer).AddLearner(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RaftAdmin_AddLearner_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RaftAdminServer).AddLearner(ctx, req.(*RaftAdminAddLearnerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RaftAdmin_PromoteLearner_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RaftAdminPromoteLearnerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RaftAdminServer).PromoteLearner(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RaftAdmin_PromoteLearner_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RaftAdminServer).PromoteLearner(ctx, req.(*RaftAdminPromoteLearnerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _RaftAdmin_RemoveServer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(RaftAdminRemoveServerRequest)
 	if err := dec(in); err != nil {
@@ -842,6 +910,14 @@ var RaftAdmin_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "AddVoter",
 			Handler:    _RaftAdmin_AddVoter_Handler,
+		},
+		{
+			MethodName: "AddLearner",
+			Handler:    _RaftAdmin_AddLearner_Handler,
+		},
+		{
+			MethodName: "PromoteLearner",
+			Handler:    _RaftAdmin_PromoteLearner_Handler,
 		},
 		{
 			MethodName: "RemoveServer",


### PR DESCRIPTION
Add Raft learner / non-voter membership to elastickv. Operators can now attach a fresh node as a non-voting replica, let it catch up on the log, and then promote it to voter — without ever shrinking the cluster's effective fault tolerance during catch-up.

The codebase already had partial scaffolding (`Server.Suffrage`, `RaftAdminMember.suffrage`, `applyConfigPeerChangeToMap` keeping learner metadata) waiting for a consumer; this PR turns it on end-to-end.

## Scope

### Design doc (`docs/design/2026_04_26_proposed_raft_learner.md`)
Five rounds of review. Approved on Round 5: "ready to proceed to Milestone 1 implementation."

### Milestone 1 — engine-level learner support
- `Admin.AddLearner` and `Admin.PromoteLearner` on `internal/raftengine`.
- Persisted peers file bumped to v2 with per-peer suffrage byte; v1 reader preserved for upgrade compat.
- New apply-loop-owned `voterCount` + `isLearnerNode` cache (initialized at Open from snapshot ConfState; rebuilt from scratch — never patched — on every conf change).
- All four `len(e.peers)` overloads switched to `voterCount` (`recordQuorumAck`, `refreshStatus` single-node fast path, `removePeer` post-removal, plus the no-op audit on `nextPeersAfterConfigChange`). Closes the 1-voter+1-learner lease-read stall the design flagged.
- `applyConfigChange` / `applyConfigChangeV2` extended with `confState raftpb.ConfState`. Four-step apply-loop sequence: refresh voter cache → per-peer cleanup → rebuild `e.config.Servers` → bookkeeping.
- `validateConfState` accepts learner-only entries; voter check stays element-wise, learner check is set-based.
- `upsertPeer` no longer owns `e.config.Servers`; the apply loop rebuilds it via `configurationFromConfState`.
- `PromoteLearner` preconditions checked synchronously on the admin loop **before** propose: target must be a learner; leader's `Progress.Match >= minAppliedIndex`.

### Milestone 2 — operator surface
- gRPC `RaftAdmin.AddLearner` and `RaftAdmin.PromoteLearner` RPCs.
- `cmd/raftadmin add_learner <id> <address> [previous_index]` and `cmd/raftadmin promote_learner <id> [previous_index] [min_applied_index]`.
- `--raftJoinAsLearner` flag — operator alarm (not consensus veto): when a node booted with the flag finds itself in `ConfState.Voters`, an `ERROR`-level structured log fires once and `JoinRoleViolationCount` increments. The node keeps running.
- `docs/raft_learner_operations.md` runbook: prerequisites, attach/promote/verify, `remove_server` for learners, common errors.

## Out of scope (deferred to M3 / separate proposal)
- Follower-served reads (separate proposal needed for staleness bounds and adapter routing).
- Joint consensus / atomic multi-member reconfig.
- Jepsen workload exercising attach during partition.
- `Status.PerPeer` exposing `Progress.Match` for `min_applied_index` selection.
- Auto-promotion (engine never decides on its own to promote).

## Test evidence
- `internal/raftengine/etcd/learner_test.go` — 6 new tests:
  - `TestAddLearnerReplicatesWithoutCountingAsVoter`
  - `TestPromoteLearnerSwapsRoleToVoter`
  - `TestPromoteLearnerRejectsNonLearner`
  - `TestPromoteLearnerRejectsNotCaughtUp`
  - `TestRemovePeerLearnerKeepsSingleNodeFastPath` (the headline 1-voter+1-learner lease-read regression)
  - `TestJoinAsLearnerAlarmFiresWhenAddedAsVoter`
  - `TestLinearizableReadOnLearnerForwardsToLeader`
- `internal/raftengine/etcd/peer_metadata_test.go` — 4 new tests covering v2 round-trip with mixed suffrage, v1 forward-compat, v2 always-write, unknown-version rejection.
- `internal/raftadmin/server_test.go` — `TestServerMapsEngineAdminMethods` extended for the two new RPCs.
- `cmd/raftadmin/main_test.go` — `add_learner` / `promote_learner` happy-path subcommand tests + extended usage assertions.
- All other suites (`internal/...`, `kv/...`, `store/...`, `monitoring/...`, `distribution/...`, `proxy/...`, `cmd/...`) pass.
- `golangci-lint`: 0 issues.

## Self-review (per CLAUDE.md)
1. **Data loss** — Promotion never decrements voter count; quorum size after promote is `floor((N+1)/2)+1`, ≥ pre-promote. WAL purge tracker includes learners by construction. v2 peers file forward-compat is read-once-write-once.
2. **Concurrency** — Add/promote run on the single-threaded admin loop. `voterCount` / `isLearnerNode` cache is single-writer (apply loop) under existing `e.mu`. `recordQuorumAck` learner-ack reject reads `isLearnerNode` under the same lock as `e.peers`. Promote-during-leader-change handled via `min_applied_index` precondition.
3. **Performance** — Adding a learner adds outbound replication traffic but no extra Raft round-trips on the write path; no extra per-call cost on the lease-read fast path. v2 peers file overhead: 1 byte per peer (bounded at 1024 peers).
4. **Data consistency** — Learner does not serve `LinearizableRead` from local FSM (returns `ErrNotLeader`). Voter / learner suffrage is sourced from `ConfState`, not `e.peers`. Snapshot-restore path also refreshes `voterCount` / `isLearnerNode` and runs the alarm hook.
5. **Test coverage** — New / changed branches each have a unit test as listed above; conformance test confirms suffrage round-trips across restart; lease-read regression test pins the 1-voter+1-learner fast path.

## Caveats
- `proto/Makefile` pins `libprotoc 29.3`; this branch was regenerated with `libprotoc 34.0` (host) + `protoc-gen-go v1.36.11` + `protoc-gen-go-grpc 1.6.1` (matching). The diff is the standard "two new messages + msgTypes index shift" — re-run `make gen` with the pinned toolchain if byte-identical generation matters.
- Branch is **64 commits behind `origin/main`** as of writing. Rebase before merge.
