### PR TITLE
build(docker): build admin SPA bundle and embed it in the image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Host-only artefacts that must not leak into the build context.
+#
+# web/admin/node_modules: the SPA build stage runs `npm ci` to install
+# Linux-correct deps; if a developer ran `npm install` locally
+# (macOS/Windows), the host node_modules would otherwise overwrite the
+# in-container deps when web/admin/ is COPY'd, silently mixing host
+# binaries (Rollup native extensions etc.) into the Linux image.
+web/admin/node_modules
+
+# Build output: regenerated inside the SPA stage; including it would
+# bloat the build context with stale assets.
+web/admin/dist
+
+# Go test caches / local build artefacts.
+.cache
+.golangci-cache
+
+# Local control-plane artefacts that have no business in any image.
+.claude
+.git
+**/.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,14 @@ WORKDIR /spa
 COPY web/admin/package.json web/admin/package-lock.json ./
 RUN npm ci --no-audit --no-fund
 COPY web/admin/ ./
-# vite.config.ts targets `../../internal/admin/dist` relative to
-# web/admin, but inside this stage we flatten the layout: emit
-# straight to /spa/dist and copy it across to the Go build stage.
-RUN npx vite build --outDir /spa/dist --emptyOutDir
+# Use `npm run build` (not `npx vite build`) so the package.json
+# script's `tsc -b && vite build` chain runs in full -- a TypeScript
+# error that would fail a local build must also fail the image build,
+# not silently slip through. vite.config.ts already sets
+# emptyOutDir=true, so only --outDir is forwarded here.
+RUN npm run build -- --outDir /spa/dist
 
-FROM golang:latest AS build
+FROM golang:1.25 AS build
 WORKDIR $GOPATH/src/app
 COPY . .
 # Replace the placeholder dist/ with the real Vite bundle BEFORE the

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,28 @@
-FROM golang:latest AS build
+# Build the admin SPA bundle first so the Go build stage's
+# `//go:embed all:dist` (internal/admin/embed.go) picks up the real
+# Vite output instead of the "(bundle missing)" placeholder. The
+# placeholder index.html is committed for the embed pragma to find
+# during local `go build`/test runs that haven't run npm; the real
+# bundle replaces it inside the image.
+FROM node:22-alpine AS spa-build
+WORKDIR /spa
+# Bring just the package manifests first so the npm cache survives
+# unrelated source changes; the layer rebuilds only when deps shift.
+COPY web/admin/package.json web/admin/package-lock.json ./
+RUN npm ci --no-audit --no-fund
+COPY web/admin/ ./
+# vite.config.ts targets `../../internal/admin/dist` relative to
+# web/admin, but inside this stage we flatten the layout: emit
+# straight to /spa/dist and copy it across to the Go build stage.
+RUN npx vite build --outDir /spa/dist --emptyOutDir
 
+FROM golang:latest AS build
 WORKDIR $GOPATH/src/app
 COPY . .
-
+# Replace the placeholder dist/ with the real Vite bundle BEFORE the
+# Go build so `//go:embed all:dist` picks up the SPA assets.
+RUN rm -rf internal/admin/dist
+COPY --from=spa-build /spa/dist internal/admin/dist
 RUN CGO_ENABLED=0 go build -o /app .
 
 FROM gcr.io/distroless/static:latest


### PR DESCRIPTION
## Summary

The Go-side embed pragma at `internal/admin/embed.go:19` says `//go:embed all:dist`, so what ends up inside `ghcr.io/bootjp/elastickv` is whatever sits at `internal/admin/dist/` when `go build` runs. The repo commits a placeholder `index.html` there so plain `go build` / `go test` (which never run npm) still resolve the embed; the placeholder intentionally renders as `<title>elastickv admin (bundle missing)</title>` so a deploy that skipped the SPA build is loud about it.

Until now the `Dockerfile` only ran `go build`, so every image shipped the placeholder. Live admin dashboards on the cluster therefore resolved to the "bundle missing" page, even though the API surface behind `/admin/api/v1` was fully functional.

Add a `node:22-alpine` SPA stage that runs `npm ci` + `npx vite build`, then in the Go stage replace `internal/admin/dist` with the real Vite output before `go build`.

## Verification

```sh
docker build -t elastickv-test:spa .
docker run --rm --entrypoint /app -p 6789:8080 \
  -v $(pwd)/test-creds.json:/etc/creds.json:ro elastickv-test:spa \
  --address 127.0.0.1:50051 --redisAddress 127.0.0.1:6379 \
  --raftId n1 --raftEngine etcd --raftDataDir /tmp/raft --raftBootstrap \
  --adminEnabled --adminListen 0.0.0.0:8080 \
  --adminFullAccessKeys AKIA-TEST --adminAllowPlaintextNonLoopback \
  --adminSessionSigningKey "$(openssl rand 64 | base64 | tr -d '\n')" \
  --s3CredentialsFile /etc/creds.json
$ curl -s http://localhost:6789/admin/ | grep title
    <title>elastickv admin</title>           # was <title>elastickv admin (bundle missing)</title>
```

## Self-review (CLAUDE.md 5 lenses)

1. **Data loss** — None. Build-only change; no Raft, FSM, or storage semantics touched.
2. **Concurrency** — None.
3. **Performance** — One extra Docker stage (~30s of `npm ci` + ~10s of `vite build` on cold cache; ~3s warm when only Go sources change). The Go layer cache is unaffected.
4. **Data consistency** — None.
5. **Test coverage** — The placeholder fallback path stays intact: a plain `go build` outside Docker still works because `internal/admin/dist/index.html` is committed. The Docker build verifies via the local smoke test above.

## Test plan

- [x] `docker build` — succeeds
- [x] Smoke run — `<title>elastickv admin</title>` (was "bundle missing")
- [ ] CI: full Docker build under linux/amd64 (workflow `Docker Image CI`)

@claude review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build process to ensure admin resources are properly compiled and packaged with the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->