### PR TITLE
build(docker): pin distroless to a digest + drop root privileges

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,29 @@ RUN rm -rf internal/admin/dist
 COPY --from=spa-build /spa/dist internal/admin/dist
 RUN CGO_ENABLED=0 go build -o /app .
 
-FROM gcr.io/distroless/static:latest
+# Pinned to a multi-arch index digest of `gcr.io/distroless/static:nonroot`
+# captured 2026-04-28. The `:latest` (or even `:nonroot`) tag floats with
+# upstream rebuilds; pinning a digest makes intermediate-image
+# reproducibility match the explicit golang:1.25 / node:22-alpine pins
+# above and prevents a silent base-image swap from changing the image
+# layout under us.
+#
+# `:nonroot` resolves to the same OS layer as `:latest` but with `USER
+# nonroot` baked in (UID 65532). Combined with the explicit USER line
+# below (defence-in-depth — the upstream USER directive could change),
+# the Go binary runs unprivileged inside the container, addressing
+# Trivy DS-0002 (root container) without changing what the binary
+# itself does. The Go binary is statically linked CGO_ENABLED=0 and
+# does not bind privileged ports, so unprivileged execution has no
+# functional cost.
+#
+# Operational note: bind-mounted secrets on the host (e.g.
+# /etc/elastickv/admin-hs256.b64) must be readable by UID 65532 inside
+# the container. Either chown them to 65532:65532 or relax permissions
+# to mode 0444 on the host. The host's bootjp group is no longer
+# sufficient because UID 65532 is in no host group by default.
+FROM gcr.io/distroless/static@sha256:e3f945647ffb95b5839c07038d64f9811adf17308b9121d8a2b87b6a22a80a39
+USER nonroot:nonroot
 COPY --from=build /app /app
 
 CMD ["/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,18 @@ RUN CGO_ENABLED=0 go build -o /app .
 # the container. Either chown them to 65532:65532 or relax permissions
 # to mode 0444 on the host. The host's bootjp group is no longer
 # sufficient because UID 65532 is in no host group by default.
-FROM gcr.io/distroless/static@sha256:e3f945647ffb95b5839c07038d64f9811adf17308b9121d8a2b87b6a22a80a39
-USER nonroot:nonroot
+# Tag + digest combo: the digest pin is the reproducibility guard,
+# the :nonroot tag in front is human-readable so a glance at the
+# Dockerfile says which variant we're on without cross-referencing
+# the digest or reading the comment block above.
+FROM gcr.io/distroless/static:nonroot@sha256:e3f945647ffb95b5839c07038d64f9811adf17308b9121d8a2b87b6a22a80a39
+# Numeric UID/GID: 65532 is the canonical distroless nonroot user.
+# K8s Pod Security Standards (`runAsNonRoot: true`) and admission
+# controllers like Gatekeeper validate the runtime user by integer,
+# without parsing /etc/passwd — using the name instead would force
+# them to consult image internals to decide if the container counts
+# as non-root.
+USER 65532:65532
 COPY --from=build /app /app
 
 CMD ["/app"]


### PR DESCRIPTION
## Summary

Address claude bot's two non-blocker findings on PR #690:

- Pin the distroless base to the multi-arch index digest of `gcr.io/distroless/static:nonroot` captured 2026-04-28 (`sha256:e3f9...80a39`). The previous `:latest` tag floats with each upstream rebuild.
- Drop root privileges by switching to the `:nonroot` variant and adding an explicit `USER nonroot:nonroot` line as defence-in-depth. Trivy DS-0002 (root container) is no longer flagged.

The Go binary is built `CGO_ENABLED=0` and binds non-privileged ports (50051, 6379, 8000, 9000, 8080), so unprivileged execution has no functional cost.

## Operational impact ⚠

Bind-mounted secrets on the host (in particular `/etc/elastickv/admin-hs256.b64` and `/etc/elastickv/s3-creds.json`) must now be readable by **UID 65532**. The previous setup chowned these to `root:bootjp` at mode `0440`; after this PR the deploy must either:

- `chown 65532:65532 /etc/elastickv/admin-hs256.b64 /etc/elastickv/s3-creds.json`, or
- `chmod 0444 /etc/elastickv/admin-hs256.b64 /etc/elastickv/s3-creds.json`

The first option keeps the secret unreadable by other host users. The requirement is documented in the Dockerfile so the next operator hits a clear error rather than a mysterious "admin listener failed to start" message.

## Verification

```sh
$ docker build -t elastickv-test:nonroot .
$ docker run --rm --entrypoint /app -p 6791:8080 \
    -v $(pwd)/test-creds.json:/etc/creds.json:ro elastickv-test:nonroot \
    --address 127.0.0.1:50051 --redisAddress 127.0.0.1:6379 \
    --raftId n1 --raftEngine etcd --raftDataDir /tmp/raft --raftBootstrap \
    --adminEnabled --adminListen 0.0.0.0:8080 \
    --adminFullAccessKeys AKIA-TEST --adminAllowPlaintextNonLoopback \
    --adminSessionSigningKey "$(openssl rand 64 | base64 | tr -d '\n')" \
    --s3CredentialsFile /etc/creds.json
$ curl -s http://localhost:6791/admin/ | grep title
    <title>elastickv admin</title>
$ curl -sf http://localhost:6791/admin/healthz
ok
```

(Test-credentials file was `chmod 0444` so the in-container UID 65532 could read it.)

## Self-review (CLAUDE.md 5 lenses)

1. **Data loss** — None. Build-only change.
2. **Concurrency** — None.
3. **Performance** — None. Same final image layer set.
4. **Data consistency** — None.
5. **Test coverage** — The smoke test (`docker run` + `curl`) is the integration check; CI's `Docker Image CI` workflow exercises the multi-stage build end-to-end on every PR push.

## Test plan

- [x] `docker build` — succeeds
- [x] Smoke run as `nonroot` — `<title>elastickv admin</title>` + healthz `ok`
- [ ] CI: full Docker build under linux/amd64

## Deploy follow-up

After merge + image rebuild:

```sh
# On each node, before redeploying:
sudo chmod 0444 /etc/elastickv/admin-hs256.b64
sudo chmod 0444 /etc/elastickv/s3-creds.json
# Then docker rm -f elastickv && rolling-update.sh
```

@claude review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container build consistency and reliability through deterministic base image configuration.
  * Enhanced container security by enforcing unprivileged execution context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->