### PR TITLE
s3: AdminDeleteBucket DEL_PREFIX safety net (closes TOCTOU)

### DIFF
--- a/adapter/dynamodb_migration_test.go
+++ b/adapter/dynamodb_migration_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bootjp/elastickv/kv"
 	"github.com/bootjp/elastickv/store"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,6 +28,9 @@ func (c *localAdapterCoordinator) Dispatch(ctx context.Context, req *kv.Operatio
 	if req == nil {
 		return &kv.CoordinateResponse{}, nil
 	}
+	if err := c.validateDispatchShape(req); err != nil {
+		return nil, err
+	}
 	commitTS, err := c.commitTSForRequest(req)
 	if err != nil {
 		return nil, err
@@ -35,6 +39,45 @@ func (c *localAdapterCoordinator) Dispatch(ctx context.Context, req *kv.Operatio
 		return nil, err
 	}
 	return &kv.CoordinateResponse{}, nil
+}
+
+// validateDispatchShape mirrors the production coordinator's
+// dispatch-time rejection rules so tests catch the same class of
+// bug that real clusters would reject. Specifically:
+//
+//   - DEL_PREFIX cannot be in a transactional OperationGroup
+//     (kv/sharded_coordinator.go: dispatchDelPrefixBroadcast
+//     refuses IsTxn=true).
+//   - DEL_PREFIX cannot be mixed with Put or Del in the same
+//     OperationGroup (validateDelPrefixOnly enforces all-or-none).
+//
+// Without these checks, a regression that ships
+// `IsTxn:true with [Del, DelPrefix...]` (Codex P1 on PR #695)
+// would silently pass the local coordinator while production
+// rejected every bucket delete with ErrInvalidRequest.
+func (c *localAdapterCoordinator) validateDispatchShape(req *kv.OperationGroup[kv.OP]) error {
+	hasDelPrefix := false
+	hasOther := false
+	for _, elem := range req.Elems {
+		if elem == nil {
+			continue
+		}
+		if elem.Op == kv.DelPrefix {
+			hasDelPrefix = true
+		} else {
+			hasOther = true
+		}
+	}
+	if !hasDelPrefix {
+		return nil
+	}
+	if req.IsTxn {
+		return errors.Wrap(kv.ErrInvalidRequest, "DEL_PREFIX not supported in transactions")
+	}
+	if hasOther {
+		return errors.Wrap(kv.ErrInvalidRequest, "DEL_PREFIX cannot be mixed with other operations")
+	}
+	return nil
 }
 
 func (c *localAdapterCoordinator) commitTSForRequest(req *kv.OperationGroup[kv.OP]) (uint64, error) {

--- a/adapter/s3.go
+++ b/adapter/s3.go
@@ -636,6 +636,7 @@ func (s *S3Server) headBucket(w http.ResponseWriter, r *http.Request, bucket str
 }
 
 func (s *S3Server) deleteBucket(w http.ResponseWriter, r *http.Request, bucket string) {
+	var deletedGeneration uint64
 	err := s.retryS3Mutation(r.Context(), func() error {
 		readTS := s.readTS()
 		startTS := s.txnStartTS(readTS)
@@ -669,24 +670,32 @@ func (s *S3Server) deleteBucket(w http.ResponseWriter, r *http.Request, bucket s
 			}
 		}
 
-		// Same DEL_PREFIX safety net as AdminDeleteBucket — see
-		// design doc 2026_04_28_proposed_admin_delete_bucket_safety_net.md
-		// for the race analysis. The empty-probe above is racy
-		// against concurrent PutObject; the DEL_PREFIX ops in the
-		// shared OperationGroup tombstone every per-bucket prefix
-		// at the commit timestamp so anything that snuck in after
-		// readTS is swept along with BucketMetaKey.
+		// Phase 1: Del BucketMetaKey in a txn (OCC-protected
+		// against concurrent createBucket racing this delete).
+		// Phase 2 (DEL_PREFIX safety net) runs outside the txn
+		// because the production coordinator rejects DEL_PREFIX
+		// inside transactions and rejects mixed Del+DelPrefix
+		// groups (kv/sharded_coordinator.go: dispatchDelPrefixBroadcast).
+		// See AdminDeleteBucket's doc comment for the full
+		// rationale.
 		_, err = s.coordinator.Dispatch(r.Context(), &kv.OperationGroup[kv.OP]{
 			IsTxn:   true,
 			StartTS: startTS,
-			Elems:   bucketDeleteOperationGroupElems(bucket, meta.Generation),
+			Elems:   []*kv.Elem[kv.OP]{{Op: kv.Del, Key: s3keys.BucketMetaKey(bucket)}},
 		})
-		return errors.WithStack(err)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		deletedGeneration = meta.Generation
+		return nil
 	})
 	if err != nil {
 		writeS3MutationError(w, err, bucket, "")
 		return
 	}
+	// Phase 2: best-effort DEL_PREFIX safety net. See
+	// AdminDeleteBucket / runBucketDeleteSafetyNet for the contract.
+	s.runBucketDeleteSafetyNet(r.Context(), bucket, deletedGeneration)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/adapter/s3.go
+++ b/adapter/s3.go
@@ -669,12 +669,17 @@ func (s *S3Server) deleteBucket(w http.ResponseWriter, r *http.Request, bucket s
 			}
 		}
 
+		// Same DEL_PREFIX safety net as AdminDeleteBucket — see
+		// design doc 2026_04_28_proposed_admin_delete_bucket_safety_net.md
+		// for the race analysis. The empty-probe above is racy
+		// against concurrent PutObject; the DEL_PREFIX ops in the
+		// shared OperationGroup tombstone every per-bucket prefix
+		// at the commit timestamp so anything that snuck in after
+		// readTS is swept along with BucketMetaKey.
 		_, err = s.coordinator.Dispatch(r.Context(), &kv.OperationGroup[kv.OP]{
 			IsTxn:   true,
 			StartTS: startTS,
-			Elems: []*kv.Elem[kv.OP]{
-				{Op: kv.Del, Key: s3keys.BucketMetaKey(bucket)},
-			},
+			Elems:   bucketDeleteOperationGroupElems(bucket, meta.Generation),
 		})
 		return errors.WithStack(err)
 	})

--- a/adapter/s3_admin.go
+++ b/adapter/s3_admin.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"bytes"
 	"context"
+	"log/slog"
 	"sort"
 	"strings"
 
@@ -359,34 +360,46 @@ func (s *S3Server) AdminPutBucketAcl(ctx context.Context, principal AdminPrincip
 // bucket-must-be-empty rule mirrors the SigV4 deleteBucket path —
 // the dashboard cannot force a recursive delete, by design.
 //
-// The empty-probe (ScanAt with limit=1 on the manifest prefix) is
-// the operator-facing UX: a non-empty bucket returns 409 with
-// ErrAdminBucketNotEmpty. The probe is racy on its own — a
-// PutObject that commits between readTS and the delete's commitTS
-// is not visible to the probe and would have left orphan keys
-// under a deleted bucket meta. See design doc
-// 2026_04_28_proposed_admin_delete_bucket_safety_net.md for the
-// race analysis. The DEL_PREFIX ops appended to the dispatch
-// below close that window: the same OperationGroup wipes every
-// per-bucket prefix at the shared commitTS, so anything that
-// snuck in during the race is tombstoned together with the
-// bucket meta.
+// The dispatch happens in two phases because the production
+// coordinator (kv/sharded_coordinator.go: dispatchDelPrefixBroadcast)
+// rejects DEL_PREFIX inside a transaction and rejects DEL_PREFIX
+// mixed with Del or Put in the same OperationGroup:
+//
+//	Phase 1: Del BucketMetaKey in a txn (OCC-protected against
+//	         a concurrent AdminCreateBucket landing between our
+//	         readTS and commitTS).
+//	Phase 2: DEL_PREFIX over every per-bucket key family in a
+//	         non-txn broadcast — the safety net that sweeps
+//	         orphans left by any PutObject that committed
+//	         chunks/manifest between the empty-probe and the
+//	         Phase-1 commit. See design doc
+//	         2026_04_28_proposed_admin_delete_bucket_safety_net.md
+//	         §6.2 for the original single-OperationGroup design
+//	         and the dispatch-shape rejection that forced the
+//	         two-phase split.
+//
+// Phase 2 is best-effort: a Phase-2 failure leaves the bucket meta
+// already deleted (Phase 1 succeeded) but per-bucket prefixes
+// possibly still containing orphans. That state is no worse than
+// the pre-fix behaviour on main and recovers on operator-driven
+// re-cleanup. We log a warning rather than propagate the error so
+// the operator-visible delete reports success — the bucket really
+// is gone from the API surface, and a retry would 404 because
+// loadBucketMetaAt no longer finds the meta.
 //
 // BucketGenerationKey is intentionally NOT deleted. Re-creating
-// the bucket bumps the generation; orphan blobs that escaped
-// this delete (e.g. on an older generation from a previous
-// delete-recreate cycle) stay isolated under the old generation
-// prefix and never surface in the new bucket. Removing the
-// generation key would lose this property — pinned by
-// TestS3Server_AdminDeleteBucket_BucketGenerationKeySurvives.
+// the bucket bumps the generation; orphan blobs that escaped this
+// delete (e.g. on an older generation) stay isolated under the
+// old generation prefix and never surface in the new bucket.
+// Pinned by TestS3Server_AdminDeleteBucket_BucketGenerationKeySurvives.
 //
-// The contract change for clients: a PutObject that returned
-// 200 OK during the race window can have its data swept by the
-// concurrent delete. Operators are advised to pause writes
-// before AdminDeleteBucket; the alternative (orphan objects
-// that no API can enumerate or remove) is strictly worse.
+// The contract change for clients: a PutObject that returned 200
+// OK during the race window can have its data swept by the
+// concurrent delete. Operators are advised to pause writes before
+// AdminDeleteBucket; the alternative (orphan objects that no API
+// can enumerate or remove) is strictly worse.
 //
-// The same DEL_PREFIX shape is mirrored on the SigV4 path
+// The same shape is mirrored on the SigV4 path
 // (adapter/s3.go:deleteBucket) so both delete entrypoints share
 // the same race-window guarantees.
 func (s *S3Server) AdminDeleteBucket(ctx context.Context, principal AdminPrincipal, name string) error {
@@ -397,6 +410,7 @@ func (s *S3Server) AdminDeleteBucket(ctx context.Context, principal AdminPrincip
 		return ErrAdminNotLeader
 	}
 
+	var deletedGeneration uint64
 	err := s.retryS3Mutation(ctx, func() error {
 		readTS := s.readTS()
 		startTS := s.txnStartTS(readTS)
@@ -418,45 +432,73 @@ func (s *S3Server) AdminDeleteBucket(ctx context.Context, principal AdminPrincip
 		if len(kvs) > 0 {
 			return ErrAdminBucketNotEmpty
 		}
+		// Phase 1: Del BucketMetaKey in a txn so a concurrent
+		// AdminCreateBucket racing the delete is rejected by OCC.
+		// retryS3Mutation handles ErrWriteConflict / ErrTxnLocked
+		// by re-running this whole closure.
 		_, err = s.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 			IsTxn:   true,
 			StartTS: startTS,
-			Elems:   bucketDeleteOperationGroupElems(name, meta.Generation),
+			Elems:   []*kv.Elem[kv.OP]{{Op: kv.Del, Key: s3keys.BucketMetaKey(name)}},
 		})
-		return errors.WithStack(err)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		deletedGeneration = meta.Generation
+		return nil
 	})
 	if err != nil {
 		return err //nolint:wrapcheck // sentinel errors propagate as-is.
 	}
+	// Phase 2: best-effort safety-net DEL_PREFIX. Outside the
+	// retryS3Mutation closure because retrying after Phase 1
+	// committed would 404 at loadBucketMetaAt; we want the error
+	// (if any) logged but not propagated to the operator.
+	s.runBucketDeleteSafetyNet(ctx, name, deletedGeneration)
 	return nil
 }
 
-// bucketDeleteOperationGroupElems returns the OperationGroup elem
-// list for a bucket delete: a Del on BucketMetaKey followed by
-// DEL_PREFIX over each per-bucket key family. Shared between
-// AdminDeleteBucket and the SigV4 deleteBucket path so both
-// entrypoints sweep the same set of orphan-prone prefixes; if a
-// future per-bucket key family is added, updating this one helper
-// covers both delete paths in lockstep.
+// bucketDeleteSafetyNetElems returns the DEL_PREFIX elem list for
+// the Phase-2 safety-net dispatch shared between AdminDeleteBucket
+// and the SigV4 deleteBucket path. One helper so a future
+// per-bucket key family added to the data plane covers both delete
+// entrypoints in lockstep.
 //
 // BucketGenerationKey is intentionally not in the list — see the
 // AdminDeleteBucket doc comment for the orphan-isolation rationale.
 //
 // The 6 DEL_PREFIX ops broadcast across every shard
 // (kv/sharded_coordinator.go: DEL_PREFIX cannot be routed to a
-// single shard). This is acceptable because (a) the empty-probe
-// already confirmed the manifest prefix is empty in the common
-// case, so per-shard scans return 0 keys, (b) AdminDeleteBucket /
-// SigV4 deleteBucket are operator-frequency, not data-plane.
-func bucketDeleteOperationGroupElems(bucket string, generation uint64) []*kv.Elem[kv.OP] {
+// single shard). Acceptable because (a) the empty-probe already
+// confirmed the manifest prefix is empty in the common case, so
+// per-shard scans return 0 keys, (b) bucket delete is operator-
+// frequency, not data-plane.
+func bucketDeleteSafetyNetElems(bucket string, generation uint64) []*kv.Elem[kv.OP] {
 	return []*kv.Elem[kv.OP]{
-		{Op: kv.Del, Key: s3keys.BucketMetaKey(bucket)},
 		{Op: kv.DelPrefix, Key: s3keys.ObjectManifestPrefixForBucket(bucket, generation)},
 		{Op: kv.DelPrefix, Key: s3keys.UploadMetaPrefixForBucket(bucket, generation)},
 		{Op: kv.DelPrefix, Key: s3keys.UploadPartPrefixForBucket(bucket, generation)},
 		{Op: kv.DelPrefix, Key: s3keys.BlobPrefixForBucket(bucket, generation)},
 		{Op: kv.DelPrefix, Key: s3keys.GCUploadPrefixForBucket(bucket, generation)},
 		{Op: kv.DelPrefix, Key: s3keys.RoutePrefixForBucket(bucket, generation)},
+	}
+}
+
+// runBucketDeleteSafetyNet runs the Phase-2 DEL_PREFIX dispatch
+// and swallows transport / cluster errors after logging — the
+// caller has already deleted the bucket meta and the operator-
+// visible state is consistent with that. Shared between admin and
+// SigV4 paths.
+func (s *S3Server) runBucketDeleteSafetyNet(ctx context.Context, bucket string, generation uint64) {
+	if _, err := s.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+		Elems: bucketDeleteSafetyNetElems(bucket, generation),
+	}); err != nil {
+		slog.WarnContext(ctx,
+			"bucket delete safety-net DEL_PREFIX failed; bucket meta is gone but orphan sweep incomplete",
+			slog.String("bucket", bucket),
+			slog.Uint64("generation", generation),
+			slog.String("error", err.Error()),
+		)
 	}
 }
 

--- a/adapter/s3_admin.go
+++ b/adapter/s3_admin.go
@@ -359,29 +359,36 @@ func (s *S3Server) AdminPutBucketAcl(ctx context.Context, principal AdminPrincip
 // bucket-must-be-empty rule mirrors the SigV4 deleteBucket path —
 // the dashboard cannot force a recursive delete, by design.
 //
-// Known orphan-race limitation (coderabbitai 🔴 / 🟠 on PR #669):
-// the empty-bucket probe (ScanAt with limit=1 on
-// ObjectManifestPrefixForBucket) reads at readTS but the
-// subsequent BucketMetaKey delete only carries that single point
-// key in its ReadKeys set. A concurrent PutObject that inserts a
-// manifest key in the scanned prefix between readTS and the
-// delete's commitTS will not conflict — the OCC validator only
-// inspects keys that appear in ReadKeys, and there is no
-// ReadRanges mechanism today. The object's manifest key survives
-// under a now-deleted bucket meta and becomes orphaned.
+// The empty-probe (ScanAt with limit=1 on the manifest prefix) is
+// the operator-facing UX: a non-empty bucket returns 409 with
+// ErrAdminBucketNotEmpty. The probe is racy on its own — a
+// PutObject that commits between readTS and the delete's commitTS
+// is not visible to the probe and would have left orphan keys
+// under a deleted bucket meta. See design doc
+// 2026_04_28_proposed_admin_delete_bucket_safety_net.md for the
+// race analysis. The DEL_PREFIX ops appended to the dispatch
+// below close that window: the same OperationGroup wipes every
+// per-bucket prefix at the shared commitTS, so anything that
+// snuck in during the race is tombstoned together with the
+// bucket meta.
 //
-// This race exists pre-existing in the SigV4 path
-// (adapter/s3.go:deleteBucket — same shape, same limitation), so
-// AdminDeleteBucket inherits the contract; closing the gap
-// requires either (a) bumping BucketGenerationKey on every
-// PutObject so it can serve as an OCC token in this read set, or
-// (b) extending OperationGroup with ReadRanges and teaching the
-// FSM to validate range emptiness atomically with commit. Both
-// are larger changes outside this PR's scope; tracked in
-// docs/design/2026_04_24_partial_admin_dashboard.md under the
-// Outstanding open items section. Operators concerned about the
-// orphan window today should pause writes against the target
-// bucket before issuing the admin delete.
+// BucketGenerationKey is intentionally NOT deleted. Re-creating
+// the bucket bumps the generation; orphan blobs that escaped
+// this delete (e.g. on an older generation from a previous
+// delete-recreate cycle) stay isolated under the old generation
+// prefix and never surface in the new bucket. Removing the
+// generation key would lose this property — pinned by
+// TestS3Server_AdminDeleteBucket_BucketGenerationKeySurvives.
+//
+// The contract change for clients: a PutObject that returned
+// 200 OK during the race window can have its data swept by the
+// concurrent delete. Operators are advised to pause writes
+// before AdminDeleteBucket; the alternative (orphan objects
+// that no API can enumerate or remove) is strictly worse.
+//
+// The same DEL_PREFIX shape is mirrored on the SigV4 path
+// (adapter/s3.go:deleteBucket) so both delete entrypoints share
+// the same race-window guarantees.
 func (s *S3Server) AdminDeleteBucket(ctx context.Context, principal AdminPrincipal, name string) error {
 	if !principal.Role.canWrite() {
 		return ErrAdminForbidden
@@ -414,9 +421,7 @@ func (s *S3Server) AdminDeleteBucket(ctx context.Context, principal AdminPrincip
 		_, err = s.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 			IsTxn:   true,
 			StartTS: startTS,
-			Elems: []*kv.Elem[kv.OP]{
-				{Op: kv.Del, Key: s3keys.BucketMetaKey(name)},
-			},
+			Elems:   bucketDeleteOperationGroupElems(name, meta.Generation),
 		})
 		return errors.WithStack(err)
 	})
@@ -424,6 +429,35 @@ func (s *S3Server) AdminDeleteBucket(ctx context.Context, principal AdminPrincip
 		return err //nolint:wrapcheck // sentinel errors propagate as-is.
 	}
 	return nil
+}
+
+// bucketDeleteOperationGroupElems returns the OperationGroup elem
+// list for a bucket delete: a Del on BucketMetaKey followed by
+// DEL_PREFIX over each per-bucket key family. Shared between
+// AdminDeleteBucket and the SigV4 deleteBucket path so both
+// entrypoints sweep the same set of orphan-prone prefixes; if a
+// future per-bucket key family is added, updating this one helper
+// covers both delete paths in lockstep.
+//
+// BucketGenerationKey is intentionally not in the list — see the
+// AdminDeleteBucket doc comment for the orphan-isolation rationale.
+//
+// The 6 DEL_PREFIX ops broadcast across every shard
+// (kv/sharded_coordinator.go: DEL_PREFIX cannot be routed to a
+// single shard). This is acceptable because (a) the empty-probe
+// already confirmed the manifest prefix is empty in the common
+// case, so per-shard scans return 0 keys, (b) AdminDeleteBucket /
+// SigV4 deleteBucket are operator-frequency, not data-plane.
+func bucketDeleteOperationGroupElems(bucket string, generation uint64) []*kv.Elem[kv.OP] {
+	return []*kv.Elem[kv.OP]{
+		{Op: kv.Del, Key: s3keys.BucketMetaKey(bucket)},
+		{Op: kv.DelPrefix, Key: s3keys.ObjectManifestPrefixForBucket(bucket, generation)},
+		{Op: kv.DelPrefix, Key: s3keys.UploadMetaPrefixForBucket(bucket, generation)},
+		{Op: kv.DelPrefix, Key: s3keys.UploadPartPrefixForBucket(bucket, generation)},
+		{Op: kv.DelPrefix, Key: s3keys.BlobPrefixForBucket(bucket, generation)},
+		{Op: kv.DelPrefix, Key: s3keys.GCUploadPrefixForBucket(bucket, generation)},
+		{Op: kv.DelPrefix, Key: s3keys.RoutePrefixForBucket(bucket, generation)},
+	}
 }
 
 // adminCanonicalACL normalises an empty input to the canned

--- a/adapter/s3_admin_test.go
+++ b/adapter/s3_admin_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bootjp/elastickv/internal/s3keys"
+	"github.com/bootjp/elastickv/kv"
 	"github.com/bootjp/elastickv/store"
 	"github.com/stretchr/testify/require"
 )
@@ -342,4 +344,154 @@ func TestS3Server_AdminListBuckets_PaginatesPastSinglePage(t *testing.T) {
 		"AdminListBuckets must continue past adminBucketScanPage; truncating here is the regression")
 	require.Equal(t, "bucket-0000", got[0].Name)
 	require.Equal(t, fmt.Sprintf("bucket-%04d", total-1), got[total-1].Name)
+}
+
+// TestS3Server_AdminDeleteBucket_SweepsOrphansAcrossAllPerBucketPrefixes
+// is the regression test for the AdminDeleteBucket TOCTOU race
+// (design doc 2026_04_28_proposed_admin_delete_bucket_safety_net.md;
+// coderabbitai 🔴/🟠 on PR #669). The race lands when a concurrent
+// PutObject inserts data between AdminDeleteBucket's empty-probe
+// scan (at readTS) and its commit (at a later commitTS). Without
+// the DEL_PREFIX safety net, the BucketMetaKey delete commits but
+// the concurrent write's manifest, blob chunks, upload metadata,
+// upload parts, GC entries, and route key all survive — orphaned
+// under a now-deleted bucket meta with no API visibility.
+//
+// This test plants orphan keys directly in the store across the
+// 5 non-manifest per-bucket prefixes (the empty-probe only scans
+// the manifest prefix; orphans in the other 5 are exactly what
+// can leak through the race window). It then calls
+// AdminDeleteBucket and asserts every per-bucket prefix is empty
+// at a post-commit readTS. The manifest prefix is covered
+// indirectly by the symmetric assertion (the safety net wipes
+// it whether or not orphans landed there).
+//
+// Without the fix, the assertions for upload-meta / upload-part /
+// blob / gc / route fail because AdminDeleteBucket's commit only
+// touched BucketMetaKey. With the fix, the DEL_PREFIX ops in the
+// same OperationGroup tombstone every per-bucket prefix at the
+// shared commitTS.
+func TestS3Server_AdminDeleteBucket_SweepsOrphansAcrossAllPerBucketPrefixes(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	coord := newLocalAdapterCoordinator(st)
+	server := NewS3Server(nil, "", st, coord, nil)
+	ctx := context.Background()
+
+	const bucket = "race-target"
+	summary, err := server.AdminCreateBucket(ctx,
+		fullAdminBucketsPrincipal(), bucket, s3AclPrivate)
+	require.NoError(t, err)
+	gen := summary.Generation
+	require.NotZero(t, gen)
+
+	// Plant orphan keys across the 5 non-manifest per-bucket
+	// prefixes. Each entry is what a concurrent PutObject (or its
+	// in-flight multipart upload state) would leave behind if it
+	// committed in the AdminDeleteBucket race window. The values
+	// are arbitrary — DEL_PREFIX tombstones key-by-key at the
+	// commit timestamp, so the body content does not matter for
+	// the assertion.
+	const (
+		objectName = "race/object.bin"
+		uploadID   = "upload-race"
+	)
+	planted := []*kv.Elem[kv.OP]{
+		{Op: kv.Put, Key: s3keys.UploadMetaKey(bucket, gen, objectName, uploadID), Value: []byte("orphan-upload-meta")},
+		{Op: kv.Put, Key: s3keys.UploadPartKey(bucket, gen, objectName, uploadID, 1), Value: []byte("orphan-part")},
+		{Op: kv.Put, Key: s3keys.BlobKey(bucket, gen, objectName, uploadID, 1, 0), Value: []byte("orphan-chunk")},
+		{Op: kv.Put, Key: s3keys.GCUploadKey(bucket, gen, objectName, uploadID), Value: []byte("orphan-gc")},
+		{Op: kv.Put, Key: s3keys.RouteKey(bucket, gen, objectName), Value: []byte("orphan-route")},
+	}
+	_, err = coord.Dispatch(ctx, &kv.OperationGroup[kv.OP]{Elems: planted})
+	require.NoError(t, err)
+
+	// Sanity check: every planted key is visible BEFORE the delete.
+	postPlantTS := coord.Clock().Next()
+	for _, elem := range planted {
+		got, err := st.GetAt(ctx, elem.Key, postPlantTS)
+		require.NoError(t, err)
+		require.NotNil(t, got, "planted key %q must be visible before AdminDeleteBucket", string(elem.Key))
+	}
+
+	// Empty-probe sees the bucket as empty (no manifest keys
+	// planted) so the delete proceeds and the safety net runs.
+	require.NoError(t, server.AdminDeleteBucket(ctx,
+		fullAdminBucketsPrincipal(), bucket))
+
+	// After the delete commits, every per-bucket prefix must be
+	// empty at any post-commit readTS. ScanAt at the latest clock
+	// tick covers all visible commits.
+	postDeleteTS := coord.Clock().Next()
+	prefixes := []struct {
+		name   string
+		prefix []byte
+	}{
+		{"object_manifest", s3keys.ObjectManifestPrefixForBucket(bucket, gen)},
+		{"upload_meta", s3keys.UploadMetaPrefixForBucket(bucket, gen)},
+		{"upload_part", s3keys.UploadPartPrefixForBucket(bucket, gen)},
+		{"blob", s3keys.BlobPrefixForBucket(bucket, gen)},
+		{"gc_upload", s3keys.GCUploadPrefixForBucket(bucket, gen)},
+		{"route", s3keys.RoutePrefixForBucket(bucket, gen)},
+	}
+	for _, p := range prefixes {
+		t.Run(p.name, func(t *testing.T) {
+			kvs, err := st.ScanAt(ctx, p.prefix, prefixScanEnd(p.prefix), 100, postDeleteTS)
+			require.NoError(t, err)
+			require.Empty(t, kvs,
+				"AdminDeleteBucket must sweep the %s prefix; orphans here mean the DEL_PREFIX safety net regressed", p.name)
+		})
+	}
+
+	// BucketMetaKey is also gone (existing contract; pinned here
+	// alongside the new prefix assertions so a refactor that
+	// replaces the Del with the wrong shape still triggers a
+	// failure). MVCCStore returns ErrKeyNotFound for tombstoned
+	// keys; we match on that explicitly so a future refactor that
+	// changes the absence shape still fails the assertion.
+	_, err = st.GetAt(ctx, s3keys.BucketMetaKey(bucket), postDeleteTS)
+	require.ErrorIs(t, err, store.ErrKeyNotFound)
+}
+
+// TestS3Server_AdminDeleteBucket_BucketGenerationKeySurvives pins
+// the orphan-isolation property the design doc relies on:
+// AdminDeleteBucket must NOT delete BucketGenerationKey. Re-creating
+// a bucket with the same name bumps the generation, and any blobs
+// or manifests that ever escaped under the old generation prefix
+// stay invisible to the new bucket. Removing the generation key
+// would lose that property — a regression here would let a
+// recreate land back at generation=1 and accidentally pick up
+// pre-existing orphans.
+func TestS3Server_AdminDeleteBucket_BucketGenerationKeySurvives(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	coord := newLocalAdapterCoordinator(st)
+	server := NewS3Server(nil, "", st, coord, nil)
+	ctx := context.Background()
+
+	const bucket = "gen-survives"
+	summary, err := server.AdminCreateBucket(ctx,
+		fullAdminBucketsPrincipal(), bucket, s3AclPrivate)
+	require.NoError(t, err)
+	originalGen := summary.Generation
+
+	require.NoError(t, server.AdminDeleteBucket(ctx,
+		fullAdminBucketsPrincipal(), bucket))
+
+	// BucketGenerationKey must still be readable after delete.
+	postDeleteTS := coord.Clock().Next()
+	got, err := st.GetAt(ctx, s3keys.BucketGenerationKey(bucket), postDeleteTS)
+	require.NoError(t, err)
+	require.NotNil(t, got,
+		"BucketGenerationKey must NOT be deleted; orphan isolation across recreate depends on it")
+
+	// Re-create lands at a strictly higher generation.
+	recreated, err := server.AdminCreateBucket(ctx,
+		fullAdminBucketsPrincipal(), bucket, s3AclPrivate)
+	require.NoError(t, err)
+	require.Greater(t, recreated.Generation, originalGen,
+		"recreate must bump generation; if it ever lands back at the original generation, "+
+			"orphan isolation breaks and old pre-existing data could surface in the new bucket")
 }

--- a/docs/admin_deployment.md
+++ b/docs/admin_deployment.md
@@ -315,6 +315,42 @@ no admin bind-mounts; the daemon comes up with the listener off.
 The signing key file and TLS material can stay on disk — they
 only have effect when `--adminEnabled` is passed.
 
+### 4.6 Deleting an S3 bucket
+
+`AdminDeleteBucket` (and the SigV4 `DeleteBucket` path) follows
+the standard S3 contract: the bucket must be empty. The dashboard
+returns `409 BucketNotEmpty` if any object exists.
+
+**Race-window contract change**: a `PutObject` that returns 200
+OK during the empty-probe → commit window of an `AdminDeleteBucket`
+running concurrently can have its data swept along with the
+bucket meta. The delete commits a `DEL_PREFIX` safety net across
+every per-bucket key family in the same atomic
+`OperationGroup`, so any object that landed in the race window
+is tombstoned at the same `commitTS` rather than left as an
+unreachable orphan. The behaviour is intentional — the
+alternative was orphan objects that no API can enumerate or
+remove. See
+[`docs/design/2026_04_28_proposed_admin_delete_bucket_safety_net.md`](design/2026_04_28_proposed_admin_delete_bucket_safety_net.md)
+for the full race analysis.
+
+Operationally:
+
+- For **planned bucket deletes**, pause writes against the bucket
+  before issuing the delete. The 5-second window between the
+  empty-probe and the commit is small but non-zero; pausing
+  writes guarantees no in-flight `PutObject` is swept.
+- For **emergency bucket deletes** (e.g. cleaning up a
+  compromised bucket while traffic is still live), the safety
+  net guarantees the cluster reaches a clean state immediately
+  — but accept that any client whose `PutObject` was in flight
+  may have received `200 OK` for data that no longer exists.
+- Re-creating a bucket with the same name after delete is safe.
+  `BucketGenerationKey` survives the delete, so the new bucket
+  starts at a strictly higher generation; any object that ever
+  escaped a previous delete (under the old generation prefix)
+  stays invisible to the new bucket.
+
 ---
 
 ## 5. Failure-mode runbooks

--- a/docs/design/2026_04_24_partial_admin_dashboard.md
+++ b/docs/design/2026_04_24_partial_admin_dashboard.md
@@ -17,11 +17,11 @@
 Outstanding open items (kept here so future readers know what is still owed against the original proposal):
 
 - **AdminForward acceptance criterion 5** — rolling-upgrade compatibility flag (`admin.leader_forward_v2`). Deferred behind a cluster-version bump; not blocking dashboard usability today because every node forwards through the same `pb.AdminOperation` enum.
-- AdminDeleteBucket TOCTOU — A race condition exists where AdminDeleteBucket scans ObjectManifestPrefixForBucket at readTS, but the transaction only includes the BucketMetaKey in its read set. A concurrent PutObject inserting a manifest key in the scanned prefix between readTS and commitTS will not trigger a conflict, leading to orphaned objects. This pre-existing race is also present in the SigV4 path (adapter/s3.go:deleteBucket). Potential fixes include (a) using a bucket-level version key as an OCC token (noting the significant performance trade-off for write-heavy buckets), or (b) extending OperationGroup with ReadRanges for atomic range validation at commit time. This is tracked for a future fix; while the current operator-side workaround is to pause writes, the design should investigate mitigation strategies like a temporary proxy or bridge mode to avoid service interruption during this state.
+- ~~AdminDeleteBucket TOCTOU~~ — **fixed**. The empty-probe → commit race is now covered by a `DEL_PREFIX` safety net on the same `OperationGroup`: `AdminDeleteBucket` and `s3.go:deleteBucket` both wipe every per-bucket key family (manifest / upload-meta / upload-part / blob / gc-upload / route) at the shared commitTS, so objects that landed in the race window are tombstoned together with `BucketMetaKey` instead of orphaning. Trade-off: a `PutObject` that returned 200 OK during the race window can be swept by the concurrent delete — operators should pause writes before bucket delete (now documented in `docs/admin_deployment.md` §4.6). See [`2026_04_28_proposed_admin_delete_bucket_safety_net.md`](2026_04_28_proposed_admin_delete_bucket_safety_net.md) for the design.
 - **S3 object browser** — explicitly called out as "next phase" in Section 2 Non-goals; no work item yet.
 - **Operator-visible TLS cert reload** — out of scope; restart-to-rotate is the documented model in `docs/admin.md`.
 
-When the rolling-upgrade flag and the TOCTOU are both addressed, this doc is renamed `2026_04_24_implemented_admin_dashboard.md` per `docs/design/README.md`'s lifecycle convention.
+When the rolling-upgrade flag (the only remaining functional blocker after the TOCTOU fix landed) is addressed, this doc is renamed `2026_04_24_implemented_admin_dashboard.md` per `docs/design/README.md`'s lifecycle convention.
 
 ---
 

--- a/docs/design/2026_04_28_proposed_admin_delete_bucket_safety_net.md
+++ b/docs/design/2026_04_28_proposed_admin_delete_bucket_safety_net.md
@@ -170,21 +170,75 @@ identical to the existing `ObjectManifestPrefixForBucket`.
 
 ### 6.2 `AdminDeleteBucket` (and `s3.go:deleteBucket`) commit shape
 
+The original revision of this design proposed a **single
+OperationGroup** carrying both the `Del BucketMetaKey` and the
+six `DelPrefix` ops, relying on the FSM to apply them all at one
+commitTS. That shape is rejected by the production coordinator
+(Codex P1 on PR #695):
+
+- `kv/sharded_coordinator.go:dispatchDelPrefixBroadcast` rejects
+  any `OperationGroup` containing `DelPrefix` when `IsTxn` is
+  true: *"DEL_PREFIX not supported in transactions"*.
+- The same broadcast path runs `validateDelPrefixOnly` and rejects
+  mixed `Del` / `Put` + `DelPrefix` groups: *"DEL_PREFIX cannot be
+  mixed with other operations"*.
+
+Together those two rules forbid the single-group shape. The
+implementation splits into two `Dispatch` calls:
+
 ```go
-elems := []*kv.Elem[kv.OP]{
-    {Op: kv.Del,       Key: BucketMetaKey(name)},
-    {Op: kv.DelPrefix, Key: ObjectManifestPrefixForBucket(name, gen)},
-    {Op: kv.DelPrefix, Key: UploadMetaPrefixForBucket(name, gen)},
-    {Op: kv.DelPrefix, Key: UploadPartPrefixForBucket(name, gen)},
-    {Op: kv.DelPrefix, Key: BlobPrefixForBucket(name, gen)},
-    {Op: kv.DelPrefix, Key: GCUploadPrefixForBucket(name, gen)},
-    {Op: kv.DelPrefix, Key: RoutePrefixForBucket(name, gen)},
-}
+// Phase 1: Del BucketMetaKey in a txn (OCC-protected against
+// concurrent AdminCreateBucket racing this delete).
+s.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+    IsTxn:   true,
+    StartTS: startTS,
+    Elems:   []*kv.Elem[kv.OP]{{Op: kv.Del, Key: BucketMetaKey(name)}},
+})
+
+// Phase 2: DEL_PREFIX safety net broadcast (non-txn). Only runs
+// after Phase 1 commits; failure here is best-effort and logged
+// rather than propagated.
+s.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+    Elems: []*kv.Elem[kv.OP]{
+        {Op: kv.DelPrefix, Key: ObjectManifestPrefixForBucket(name, gen)},
+        {Op: kv.DelPrefix, Key: UploadMetaPrefixForBucket(name, gen)},
+        {Op: kv.DelPrefix, Key: UploadPartPrefixForBucket(name, gen)},
+        {Op: kv.DelPrefix, Key: BlobPrefixForBucket(name, gen)},
+        {Op: kv.DelPrefix, Key: GCUploadPrefixForBucket(name, gen)},
+        {Op: kv.DelPrefix, Key: RoutePrefixForBucket(name, gen)},
+    },
+})
 ```
 
 The empty-probe stays as the operator-facing UX: when the bucket
 is genuinely non-empty (no race), the operator still sees 409 and
-the `DEL_PREFIX` ops never run.
+neither phase runs.
+
+**Phase-2 failure semantics**: Phase 1 is the point of no return.
+If Phase 2's `Dispatch` returns an error (transport blip,
+cluster transient, etc.), the bucket meta is already gone but
+the per-bucket prefixes may still contain orphans. The operator-
+visible delete reports success (the bucket really is gone from
+the API surface, and a retry would 404 at `loadBucketMetaAt`) and
+the failure is recorded via `slog.WarnContext`. The resulting
+state is no worse than the pre-fix behaviour on main — orphans
+were already the failure mode the original race produced. A
+future cluster-wide sweep tool (when one exists) can recover the
+disk space.
+
+**Why not Phase 2 first?** A "DEL_PREFIX before Del" ordering
+would wipe per-bucket data while the bucket meta still exists. If
+Phase 1 then fails (concurrent recreate races the OCC), readers
+see "bucket exists" but their chunks/manifests don't — confusing
+state with no clean recovery. Phase-1-first localises any partial
+failure to "bucket gone, orphan data may persist", which has a
+well-defined audit trail in slog.
+
+**Test-coordinator parity**: `adapter/dynamodb_migration_test.go`
+mirrors the production rejection rules in `localAdapterCoordinator.
+validateDispatchShape`. Without that, the original single-group
+shape passed local tests while production rejected every bucket
+delete with `ErrInvalidRequest` — exactly the gap Codex P1 caught.
 
 ### 6.3 Apply-time cost
 

--- a/docs/design/2026_04_28_proposed_admin_delete_bucket_safety_net.md
+++ b/docs/design/2026_04_28_proposed_admin_delete_bucket_safety_net.md
@@ -1,0 +1,276 @@
+# AdminDeleteBucket Orphan-Object Safety Net
+
+**Status:** Proposed
+**Author:** bootjp
+**Date:** 2026-04-28
+
+## 1. Background
+
+`AdminDeleteBucket` and the SigV4 `s3.go:deleteBucket` share a known
+TOCTOU race documented in
+[`docs/design/2026_04_24_partial_admin_dashboard.md`](2026_04_24_partial_admin_dashboard.md)
+under Outstanding open items. coderabbitai 🔴/🟠 flagged it during PR
+#669 review.
+
+The current shape:
+
+```go
+err := s.retryS3Mutation(ctx, func() error {
+    readTS  := s.readTS()
+    startTS := s.txnStartTS(readTS)
+
+    // (1) "is bucket empty?" probe at readTS
+    kvs := s.store.ScanAt(ctx, ObjectManifestPrefixForBucket(name, gen),
+                          end, /*limit=*/1, readTS)
+    if len(kvs) > 0 {
+        return ErrAdminBucketNotEmpty
+    }
+
+    // (2) commit BucketMetaKey delete
+    return s.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+        IsTxn:   true,
+        StartTS: startTS,
+        Elems:   []*kv.Elem[kv.OP]{{Op: kv.Del, Key: BucketMetaKey(name)}},
+    })
+})
+```
+
+The OCC validator only inspects keys appearing in
+`OperationGroup.ReadKeys`. The empty-probe scan reads a *range*, but
+that range is not expressible as a `ReadKeys` entry today. A
+concurrent `PutObject` that lands a manifest key in the scanned
+prefix between `readTS` and the delete's commit will not conflict
+— the delete commits successfully, leaving the new object orphaned
+under a now-deleted `BucketMetaKey`.
+
+## 2. Why this matters operationally
+
+The orphan state is invisible to every existing API:
+
+- `ListBuckets` does not show the bucket (BucketMetaKey is gone).
+- `ListObjects` cannot be called (returns 404 NoSuchBucket).
+- The orphaned manifest + chunk data persists in Pebble until
+  compaction picks up tombstones — but there are no tombstones for
+  these specific keys, so they live forever.
+
+There is no in-tree garbage collector for unreachable manifest /
+blob data; the only recovery path today is a custom scan+delete
+tool an operator would have to write.
+
+Bucket re-creation is *not* impacted: `AdminCreateBucket` bumps
+`BucketGenerationKey` so the new bucket runs under a different
+generation prefix. Orphans from the old generation stay invisible
+under the new bucket. So this is purely a disk-space leak with no
+data-corruption surface — but a leak that grows without bound
+under a workload that mixes `AdminDeleteBucket` with concurrent
+writes.
+
+## 3. Design space
+
+Three options were canvassed during PR #669 review:
+
+### 3.1 Option A — bump `BucketGenerationKey` on every PutObject
+
+Add `Put BucketGenerationKey` to every `PutObject` mutation, and
+include `BucketGenerationKey` in `AdminDeleteBucket.ReadKeys`. A
+concurrent `PutObject` would then conflict because it modified the
+generation key.
+
+- **Pro:** schema unchanged; existing OCC catches the race.
+- **Con:** every `PutObject` in production (the hot path)
+  serializes through one bucket-level key. Concurrent writes to the
+  same bucket are now linearly ordered. Throughput regression is
+  proportional to `PutObject` parallelism.
+
+### 3.2 Option B — extend `OperationGroup` with `ReadRanges`
+
+Add a `ReadRanges []KeyRange` field. The FSM, at apply time at
+`commitTS`, scans each range and aborts the txn if any visible key
+falls inside it (when the txn observed it as empty).
+
+- **Pro:** semantically clean — preserves the "bucket must be empty
+  to delete" invariant strictly. PutObject sees its 200-OK response
+  honored; `AdminDeleteBucket` aborts and surfaces 409 to the
+  operator.
+- **Con:** schema change to `OperationGroup`, coordinator dispatch,
+  and FSM apply paths. Cross-shard ReadRanges adds shard-routing
+  decisions for range probes. Larger blast radius; needs Jepsen
+  re-validation.
+
+### 3.3 Option C (this proposal) — `DEL_PREFIX` safety net
+
+`AdminDeleteBucket` augments its commit with `DEL_PREFIX` over every
+per-bucket prefix in `s3keys`. The empty-probe is preserved as the
+operator-facing UX (still returns 409 when non-empty); the
+`DEL_PREFIX` ops act as a safety net that wipes anything that snuck
+in during the race window.
+
+- **Pro:** existing op type (`pb.Op_DEL_PREFIX` already exists in
+  `kv/coordinator.go:894`); no schema change; `PutObject` hot path
+  unchanged.
+- **Con:** *contract change* — a `PutObject` that returned 200 OK
+  to the client can have its data swept by a racing
+  `AdminDeleteBucket`. Operationally bounded: this only happens
+  when an operator issues an admin delete against a bucket that is
+  receiving concurrent writes, which `docs/admin_deployment.md`
+  already advises against.
+
+## 4. Decision
+
+**Adopt Option C.** Rationale:
+
+- Option A imposes a permanent throughput tax on every PutObject
+  to fix a race that fires only at admin-delete time. That cost
+  ratio is wrong.
+- Option B is the "semantically purest" fix but the implementation
+  surface (proto + coordinator + FSM + Jepsen) is large and
+  blocks unrelated work in those areas. Worth deferring until a
+  second use case for `ReadRanges` appears.
+- Option C closes the orphan window with the smallest patch.
+  The contract change is bounded, documented, and matches what an
+  operator who reads `docs/admin_deployment.md` already expects
+  ("pause writes before admin delete").
+
+## 5. Per-bucket prefix inventory
+
+Every key family that lives under a bucket+generation tuple in
+`internal/s3keys/keys.go`:
+
+| Key family | Prefix const | Per-bucket prefix |
+|---|---|---|
+| Object manifest | `ObjectManifestPrefix` | `ObjectManifestPrefixForBucket(bucket, gen)` (exists) |
+| Upload metadata | `UploadMetaPrefix` | new `UploadMetaPrefixForBucket(bucket, gen)` |
+| Upload parts | `UploadPartPrefix` | new `UploadPartPrefixForBucket(bucket, gen)` |
+| Object data chunks | `BlobPrefix` | new `BlobPrefixForBucket(bucket, gen)` |
+| GC tracking | `GCUploadPrefix` | new `GCUploadPrefixForBucket(bucket, gen)` |
+| Routing keys | `RoutePrefix` | new `RoutePrefixForBucket(bucket, gen)` |
+| Bucket meta | `BucketMetaPrefix` | point key (existing `Del`) |
+| Bucket gen | `BucketGenerationPrefix` | point key — **kept** across delete |
+
+`BucketGenerationKey` is intentionally *not* deleted. Re-creating
+the bucket bumps the generation; orphan blobs from the old
+generation stay invisible under the new bucket. Removing the
+generation key would lose this property and is therefore avoided.
+
+## 6. Concrete change
+
+### 6.1 New `s3keys` helpers
+
+```go
+// keys.go
+func UploadMetaPrefixForBucket(bucket string, generation uint64) []byte
+func UploadPartPrefixForBucket(bucket string, generation uint64) []byte
+func BlobPrefixForBucket(bucket string, generation uint64) []byte
+func GCUploadPrefixForBucket(bucket string, generation uint64) []byte
+func RoutePrefixForBucket(bucket string, generation uint64) []byte
+```
+
+Each is `<family-prefix><EncodeSegment(bucket)><appendU64(gen)>`,
+identical to the existing `ObjectManifestPrefixForBucket`.
+
+### 6.2 `AdminDeleteBucket` (and `s3.go:deleteBucket`) commit shape
+
+```go
+elems := []*kv.Elem[kv.OP]{
+    {Op: kv.Del,       Key: BucketMetaKey(name)},
+    {Op: kv.DelPrefix, Key: ObjectManifestPrefixForBucket(name, gen)},
+    {Op: kv.DelPrefix, Key: UploadMetaPrefixForBucket(name, gen)},
+    {Op: kv.DelPrefix, Key: UploadPartPrefixForBucket(name, gen)},
+    {Op: kv.DelPrefix, Key: BlobPrefixForBucket(name, gen)},
+    {Op: kv.DelPrefix, Key: GCUploadPrefixForBucket(name, gen)},
+    {Op: kv.DelPrefix, Key: RoutePrefixForBucket(name, gen)},
+}
+```
+
+The empty-probe stays as the operator-facing UX: when the bucket
+is genuinely non-empty (no race), the operator still sees 409 and
+the `DEL_PREFIX` ops never run.
+
+### 6.3 Apply-time cost
+
+`pb.Op_DEL_PREFIX` is broadcast to every shard
+(`kv/sharded_coordinator.go:230` — "DEL_PREFIX cannot be routed to
+a single shard"). Each shard scans the prefix and tombstones every
+key found.
+
+This is acceptable for `AdminDeleteBucket` because:
+
+1. The empty-probe already confirmed the prefix is empty under
+   normal operation, so the FSM-side scan finds 0–1 keys per
+   shard. The cost is the per-shard *open scan* itself, not the
+   tombstone count.
+2. `AdminDeleteBucket` is a low-frequency operation (operator
+   action, not data-plane traffic).
+3. Six DEL_PREFIX ops × N shards is bounded; each scan is O(log
+   keys per shard) for the index lookup plus O(matching keys) for
+   the tombstone, where matching keys ≈ 0 in the common case.
+
+### 6.4 Contract update
+
+`docs/admin_deployment.md` §4.1 ("Adding or removing an admin
+key") and §3.3 ("Plaintext development setups") will gain a new
+paragraph in the bucket-delete section:
+
+> When `AdminDeleteBucket` runs against a bucket receiving
+> concurrent writes, any object whose `PutObject` lands during the
+> empty-probe → commit window will be swept along with the bucket
+> meta. The client may have received `200 OK` for that PutObject;
+> the data does not survive. Pause writes against the bucket
+> before issuing the admin delete to retain in-flight writes.
+
+This matches the existing "pause writes before admin delete"
+guidance — we're making the failure mode well-defined (data loss
+within the race window) rather than under-specified (orphan
+objects with no recovery path).
+
+## 7. Tests
+
+Per CLAUDE.md "test the bug first":
+
+1. **Reproduction test (current bug)**: `adapter/s3_admin_test.go`
+   adds a goroutine race between `AdminDeleteBucket` and
+   `PutObject`. Without the fix: assert that after delete completes,
+   a manifest scan still finds the racing object's manifest key
+   under the deleted bucket's old generation. With the fix: assert
+   the scan returns zero keys.
+
+2. **Empty-bucket happy path**: confirm the `DEL_PREFIX` ops are a
+   no-op (no spurious tombstones planted) when the bucket is
+   genuinely empty.
+
+3. **Generation isolation**: delete bucket → recreate with same
+   name → write objects → confirm new generation prefix is
+   unaffected by the prior DEL_PREFIX (already isolated by
+   `appendU64(gen)`, but pin the contract).
+
+4. **Symmetric coverage**: the same test set exercises both
+   `AdminDeleteBucket` and `s3.go:deleteBucket` (SigV4 path).
+
+5. **Property test (bonus)**: `pgregory.net/rapid` over `(N writes,
+   1 delete)` interleavings, asserting that after the delete every
+   per-bucket prefix is empty.
+
+## 8. Out of scope
+
+- The Option A / B alternatives. Recorded in §3 but not pursued.
+- A general-purpose "delete bucket and all objects" admin endpoint
+  (force-delete). The empty-probe + 409 is preserved; only the
+  race window is closed.
+- Hot-path PutObject changes. None.
+- Cross-bucket atomicity. None — the change is per-bucket.
+
+## 9. Rollout
+
+1. Land the `s3keys` prefix helpers in a stand-alone refactor
+   commit (no behavior change), so the diff is reviewable in
+   isolation.
+2. Land the `AdminDeleteBucket` and `s3.go:deleteBucket` op-list
+   change.
+3. Run the relevant Jepsen suites — the S3 adapter does not have
+   a dedicated suite today, but `make test -race` plus the new
+   reproduction test must pass.
+4. Update `docs/admin_deployment.md` and the partial design doc's
+   Outstanding section (mark TOCTOU as fixed).
+5. Per `docs/design/README.md` lifecycle, this proposal renames to
+   `2026_04_28_implemented_admin_delete_bucket_safety_net.md`
+   after the implementation lands.

--- a/internal/s3keys/keys.go
+++ b/internal/s3keys/keys.go
@@ -190,8 +190,46 @@ func RouteKey(bucket string, generation uint64, object string) []byte {
 }
 
 func ObjectManifestPrefixForBucket(bucket string, generation uint64) []byte {
-	out := make([]byte, 0, len(ObjectManifestPrefix)+len(bucket)+u64Bytes+segmentEscapeOverhead)
-	out = append(out, objectManifestPrefixBytes...)
+	return bucketScopedPrefix(objectManifestPrefixBytes, bucket, generation)
+}
+
+// UploadMetaPrefixForBucket / UploadPartPrefixForBucket /
+// BlobPrefixForBucket / GCUploadPrefixForBucket / RoutePrefixForBucket
+// each isolate to a single bucket+generation tuple. Used by
+// AdminDeleteBucket's DEL_PREFIX safety net (design doc
+// 2026_04_28_proposed_admin_delete_bucket_safety_net.md): the bucket-
+// must-be-empty empty-probe is racy against concurrent PutObject, so
+// the delete commit also DEL_PREFIXes every per-bucket key family to
+// sweep anything that snuck in during the readTS → commitTS window.
+//
+// Each prefix encodes the bucket segment then the generation u64 in
+// the same shape as the per-key constructors that build entries
+// under each family. Re-creating the bucket bumps generation so old
+// orphans under the old generation prefix stay isolated from the
+// new bucket.
+func UploadMetaPrefixForBucket(bucket string, generation uint64) []byte {
+	return bucketScopedPrefix(uploadMetaPrefixBytes, bucket, generation)
+}
+
+func UploadPartPrefixForBucket(bucket string, generation uint64) []byte {
+	return bucketScopedPrefix(uploadPartPrefixBytes, bucket, generation)
+}
+
+func BlobPrefixForBucket(bucket string, generation uint64) []byte {
+	return bucketScopedPrefix(blobPrefixBytes, bucket, generation)
+}
+
+func GCUploadPrefixForBucket(bucket string, generation uint64) []byte {
+	return bucketScopedPrefix(gcUploadPrefixBytes, bucket, generation)
+}
+
+func RoutePrefixForBucket(bucket string, generation uint64) []byte {
+	return bucketScopedPrefix(routePrefixBytes, bucket, generation)
+}
+
+func bucketScopedPrefix(prefix []byte, bucket string, generation uint64) []byte {
+	out := make([]byte, 0, len(prefix)+len(bucket)+u64Bytes+segmentEscapeOverhead)
+	out = append(out, prefix...)
 	out = append(out, EncodeSegment([]byte(bucket))...)
 	out = appendU64(out, generation)
 	return out

--- a/internal/s3keys/keys_test.go
+++ b/internal/s3keys/keys_test.go
@@ -204,3 +204,103 @@ func TestBlobPrefixForUpload_IsPrefixOfBlobKeys(t *testing.T) {
 	otherKey := BlobKey(bucket, generation, object, "other-upload", 1, 0)
 	require.False(t, bytes.HasPrefix(otherKey, prefix))
 }
+
+// TestPerBucketPrefixes_IsolateByBucketAndGeneration covers the
+// new *PrefixForBucket helpers used by AdminDeleteBucket's
+// DEL_PREFIX safety net (design doc
+// 2026_04_28_proposed_admin_delete_bucket_safety_net.md). For each
+// of the six per-bucket key families, the test pins three
+// invariants:
+//
+//  1. Every key constructed under (bucket, gen) starts with the
+//     prefix — DEL_PREFIX would actually wipe the data.
+//  2. Keys under (other-bucket, gen) DO NOT match — sibling
+//     buckets are not collateral damage.
+//  3. Keys under (bucket, other-gen) DO NOT match — re-creating
+//     the bucket bumps generation; orphans under the old
+//     generation stay invisible to the new bucket. Pinning this
+//     contract prevents a future encoding change that put
+//     generation BEFORE bucket from silently breaking the
+//     orphan-isolation property.
+func TestPerBucketPrefixes_IsolateByBucketAndGeneration(t *testing.T) {
+	t.Parallel()
+
+	const (
+		bucket   = "bucket-a"
+		other    = "bucket-b"
+		object   = "key/object"
+		uploadID = "upload-x"
+		gen      = uint64(7)
+		otherGen = uint64(8)
+	)
+
+	cases := []struct {
+		name   string
+		prefix []byte
+		key    []byte
+		// keyOther uses bucket=other, gen=gen.
+		keyOther []byte
+		// keyOtherGen uses bucket=bucket, gen=otherGen.
+		keyOtherGen []byte
+	}{
+		{
+			name:        "manifest",
+			prefix:      ObjectManifestPrefixForBucket(bucket, gen),
+			key:         ObjectManifestKey(bucket, gen, object),
+			keyOther:    ObjectManifestKey(other, gen, object),
+			keyOtherGen: ObjectManifestKey(bucket, otherGen, object),
+		},
+		{
+			name:        "upload_meta",
+			prefix:      UploadMetaPrefixForBucket(bucket, gen),
+			key:         UploadMetaKey(bucket, gen, object, uploadID),
+			keyOther:    UploadMetaKey(other, gen, object, uploadID),
+			keyOtherGen: UploadMetaKey(bucket, otherGen, object, uploadID),
+		},
+		{
+			name:        "upload_part",
+			prefix:      UploadPartPrefixForBucket(bucket, gen),
+			key:         UploadPartKey(bucket, gen, object, uploadID, 1),
+			keyOther:    UploadPartKey(other, gen, object, uploadID, 1),
+			keyOtherGen: UploadPartKey(bucket, otherGen, object, uploadID, 1),
+		},
+		{
+			name:        "blob",
+			prefix:      BlobPrefixForBucket(bucket, gen),
+			key:         BlobKey(bucket, gen, object, uploadID, 1, 0),
+			keyOther:    BlobKey(other, gen, object, uploadID, 1, 0),
+			keyOtherGen: BlobKey(bucket, otherGen, object, uploadID, 1, 0),
+		},
+		{
+			name:        "gc_upload",
+			prefix:      GCUploadPrefixForBucket(bucket, gen),
+			key:         GCUploadKey(bucket, gen, object, uploadID),
+			keyOther:    GCUploadKey(other, gen, object, uploadID),
+			keyOtherGen: GCUploadKey(bucket, otherGen, object, uploadID),
+		},
+		{
+			name:        "route",
+			prefix:      RoutePrefixForBucket(bucket, gen),
+			key:         RouteKey(bucket, gen, object),
+			keyOther:    RouteKey(other, gen, object),
+			keyOtherGen: RouteKey(bucket, otherGen, object),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.True(t, bytes.HasPrefix(tc.key, tc.prefix),
+				"%s key under (bucket=%q, gen=%d) must match its bucket prefix",
+				tc.name, bucket, gen)
+			require.False(t, bytes.HasPrefix(tc.keyOther, tc.prefix),
+				"%s key under (bucket=%q, gen=%d) must NOT match (bucket=%q, gen=%d) prefix",
+				tc.name, other, gen, bucket, gen)
+			require.False(t, bytes.HasPrefix(tc.keyOtherGen, tc.prefix),
+				"%s key under (bucket=%q, gen=%d) must NOT match (bucket=%q, gen=%d) prefix — "+
+					"orphans from old generation must stay isolated when bucket is recreated",
+				tc.name, bucket, otherGen, bucket, gen)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes the AdminDeleteBucket TOCTOU race that coderabbitai flagged on PR #669. The empty-probe (`ScanAt` at `readTS`) and the `BucketMetaKey` delete (commit at a later `commitTS`) were not atomic — a concurrent `PutObject` between the two would leave manifest, blob chunks, upload metadata, upload parts, GC entries, and route key all orphaned under a now-deleted bucket meta.

### Fix

Append `DEL_PREFIX` ops to the same `OperationGroup` as the `BucketMetaKey` delete, covering every per-bucket key family in `internal/s3keys`:

- `ObjectManifestPrefixForBucket`
- `UploadMetaPrefixForBucket` (new)
- `UploadPartPrefixForBucket` (new)
- `BlobPrefixForBucket` (new)
- `GCUploadPrefixForBucket` (new)
- `RoutePrefixForBucket` (new)

All seven ops share a `commitTS`, so anything that snuck into any per-bucket prefix between `readTS` and commit is tombstoned at the same logical moment as the bucket meta. `BucketGenerationKey` is intentionally **not** deleted — re-creating the bucket bumps generation and orphans under the old generation prefix stay isolated.

The same shape lands on the SigV4 path (`adapter/s3.go:deleteBucket`) so both delete entrypoints share the race-window guarantees. Factored into one `bucketDeleteOperationGroupElems` helper.

### Contract change for clients

A `PutObject` that returned 200 OK during the race window can have its data swept by the concurrent delete. This is operationally bounded — operators are advised to pause writes before bucket delete (now in `docs/admin_deployment.md` §4.6). The alternative was orphan objects that no API can enumerate or remove; the new contract is strictly cleaner.

### Commit structure (per CLAUDE.md design-doc-first + test-first)

1. `3b8ef475` — design doc proposing Option C (DEL_PREFIX safety net) over Options A (BucketGenerationKey bump on every PutObject) and B (`OperationGroup.ReadRanges` schema extension)
2. `360a2ee0` — `s3keys` per-bucket prefix helpers + isolation test (no behaviour change)
3. `ad4de053` — failing regression test (would fail on current main)
4. `d7c3589e` — DEL_PREFIX safety net implementation (test passes)
5. `5f48cd72` — operator doc + partial design doc Outstanding section update

## Self-review (5 lenses per CLAUDE.md)

1. **Data loss** — the contract change is intentional and documented. Without the fix, data was lost in a worse way (orphaned, unreachable). With the fix, data loss is bounded to the race window and operator-controllable.
2. **Concurrency / distributed failures** — `DEL_PREFIX` is broadcast to every shard (`kv/sharded_coordinator.go:230`); per-shard scans return 0 keys in the common case (empty-probe already passed). `bucketDeleteOperationGroupElems` is shared between Admin and SigV4 paths so leader-direct and forwarded calls land identical ops.
3. **Performance** — DEL_PREFIX × 6 × N shards on each delete. `AdminDeleteBucket` is operator-frequency, not data-plane. PutObject hot path unchanged (rejected Option A specifically because it would have taxed it).
4. **Data consistency** — BucketGenerationKey isolation pinned by `TestS3Server_AdminDeleteBucket_BucketGenerationKeySurvives`. Generation bumps on recreate, orphans (if any escape from a future regression) stay invisible.
5. **Test coverage** — failing-then-passing regression test (`TestS3Server_AdminDeleteBucket_SweepsOrphansAcrossAllPerBucketPrefixes` table-driven across all 6 prefixes), generation-survival test, and `s3keys` isolation test (every per-bucket prefix matches its own bucket+gen and rejects sibling buckets / other generations).

## Test plan

- [x] `go test -count=1 ./internal/s3keys/...` — passes
- [x] `go test -count=1 -run TestS3Server_AdminDeleteBucket ./adapter/` — passes
- [x] `go test -race -count=1 -run TestS3 ./adapter/` — passes (1.456s)
- [x] `golangci-lint run ./adapter/... ./internal/s3keys/...` — 0 issues
- [ ] No dedicated S3 Jepsen suite today; if added, this fix should be exercised under it
