### PR TITLE
ci: also pass CLAUDE_CODE_OAUTH_TOKEN via step env

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,12 +32,16 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        # Pinned to v1.0.107 because v1.0.108 (auto-pulled via the `v1` rolling
-        # tag on 2026-04-28) regressed OAuth-token auth: the agent SDK throws
-        # `Could not resolve [authentication]` from validateHeaders before any
-        # work runs. Refreshing CLAUDE_CODE_OAUTH_TOKEN does not help. Bump back
-        # to `@v1` once upstream ships a fix.
+        # Pinned to v1.0.107 + explicit env. As of 2026-04-28, the OAuth token
+        # passed only via the `with:` input is not reaching the Claude Code
+        # child process spawned by the agent SDK's query() — the SDK throws
+        # `Could not resolve [authentication]` even though the same token
+        # works locally with `claude --print`. Setting CLAUDE_CODE_OAUTH_TOKEN
+        # in the step's env: forces it onto process.env so parse-sdk-options
+        # forwards it to the child. Revisit once upstream ships a fix.
         uses: anthropics/claude-code-action@7eab1296cc65117d50ac2a2fa5f00a30ec84d3d5 # v1.0.107
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
## Summary

Follow-up to #696. ピンだけでは不十分だった。ステップ `env:` に `CLAUDE_CODE_OAUTH_TOKEN` を明示的に置くことで、`@claude` トリガー時の `Could not resolve [authentication]` 失敗を直す。

## なぜピンだけでは効かなかったか — 切り分け結果

| ケース | バージョン | 結果 |
| --- | --- | --- |
| 04-28 00:28 GitHub Action | claude-code-action v1.0.107 / agent-sdk 0.2.120 / cli 2.1.119 | ✅ |
| 04-28 07:42 GitHub Action (#696 マージ後の v1.0.107 ピン状態) | 同上 | ❌ `Could not resolve [authentication]` |
| ローカル `claude --print`、`HOME` クリーン、`CLAUDE_CODE_OAUTH_TOKEN` のみ env | cli 2.1.119 | ✅ |

つまり:

- **トークン文字列は生きている** (ローカルの clean HOME で env だけ渡せば通る)
- **Anthropic アカウントも生きている** (Max 20x、weekly 77% 残)
- **action / agent SDK のバージョン由来でもない** (同一バージョンで成功も失敗もしている)

ローカルで通って CI で通らない差分は env forwarding しかなく、`parse-sdk-options.ts@v1.0.107` を読むと子プロセスに渡る env は `{ ...process.env }` で組み立てている。なので **ステップの `env:` に置けば確実に `process.env` 経由で子に乗る**。`with:` の input 値は念のため残してあるので、上流が直っても rollback 不要。

失敗ラン: <https://github.com/bootjp/elastickv/actions/runs/25040351028>

スタック末尾 (失敗共通):

```
SDK execution error: 54 | new Anthropic({ apiKey, dangerouslyAllowBrowser: true });
... validateHeaders({values, nulls}){ ... throw Error('Could not resolve [authentication]')
##[error]Action failed with error: SDK execution error: Error: Claude Code process exited with code 1
```

## 試したが効かなかったこと (記録)

- OAuth トークンの再発行 (Secret 更新) — 同じエラー
- `@v1` → v1.0.107 SHA ピン (PR #696 単独) — 同じエラー
- 直接 `/v1/messages` への curl で 401 が出た件 — `sk-ant-oat01-...` は refresh token 寄りの位置付けで、直接エンドポイントに当てるテストとしては不適切だった (本件の判断材料にはしない)

## Test plan

- [ ] マージ後、任意の PR で `@claude review` を投げて `Run Claude Code` ステップが緑になることを確認
- [ ] 上流が OAuth env forwarding を直した時点で、`env:` ブロックを削除して `with:` 単独に戻す follow-up を出す

## Self-review

CI ワークフロー単独の変更。5-lens は崩して: data-loss / concurrency / consistency 影響なし、性能影響なし、テスト追加対象なし (CI 構成そのもの)。`with:` を残しているので、上流修正後の rollback 経路も保持。
