### PR TITLE
ci(diag): isolate OAuth failure to agent SDK vs runner

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,10 +39,12 @@ jobs:
       # Split into two steps so the OAuth token is never present in the env
       # of `curl | bash` or its subprocesses (Codex P2): the installer runs
       # without the secret; only the verify step has it, and only for the
-      # single claude invocation. The verify step is `continue-on-error: true`
-      # so a runner-side OAuth failure does not skip `Run Claude Code` —
+      # single claude invocation. Both diagnostic steps are
+      # `continue-on-error: true` so neither a transient install failure nor
+      # a runner-side OAuth failure can short-circuit `Run Claude Code` —
       # both step results need to be observed for the isolation logic to
-      # work (Codex P1).
+      # work, and temporary diagnostic infrastructure must not block normal
+      # `@claude` handling (Codex P1, both rounds).
       #
       # Token-leak hardening:
       #   - secret is scoped to the verify step only
@@ -56,6 +58,7 @@ jobs:
       # Remove these two steps (and rotate CLAUDE_CODE_OAUTH_TOKEN) once the
       # diagnostic question is answered.
       - name: Install Claude CLI for diag (no secrets in env)
+        continue-on-error: true
         run: |
           set -euo pipefail
           set +x

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,30 +30,44 @@ jobs:
         with:
           fetch-depth: 1
 
-      # TEMPORARY diagnostic step. Verifies whether the OAuth token works
-      # against `claude --print` directly on the runner (i.e., bypassing the
-      # action / agent SDK entirely). If this step succeeds but `Run Claude
-      # Code` still fails, the bug is isolated to how the agent SDK forwards
-      # auth to its spawned child process.
+      # TEMPORARY diagnostic. Verifies whether the OAuth token works against
+      # `claude --print` directly on the runner (i.e., bypassing the action /
+      # agent SDK entirely), so we can localize the failure to either:
+      #   - SDK auth-forwarding (diag passes, main fails), or
+      #   - runner ↔ Anthropic OAuth backend (diag fails, main fails).
+      #
+      # Split into two steps so the OAuth token is never present in the env
+      # of `curl | bash` or its subprocesses (Codex P2): the installer runs
+      # without the secret; only the verify step has it, and only for the
+      # single claude invocation. The verify step is `continue-on-error: true`
+      # so a runner-side OAuth failure does not skip `Run Claude Code` —
+      # both step results need to be observed for the isolation logic to
+      # work (Codex P1).
       #
       # Token-leak hardening:
+      #   - secret is scoped to the verify step only
       #   - never enables `set -x`; explicit `set +x` defends against
       #     ACTIONS_STEP_DEBUG also enabling xtrace
-      #   - token is only referenced via env, never expanded into a command line
-      #   - install.sh stdout/stderr are dropped; no --debug / --verbose on claude
-      #   - HOME is a fresh tmp dir so cached creds are out of scope and gone
-      #     when the runner is destroyed
+      #   - token reaches `claude` only via env, never as a command-line arg
+      #   - no --debug / --verbose on `claude`
+      #   - HOME is an ephemeral tmp dir; runner is destroyed after the job
       #   - GitHub Actions secret-masking covers any literal occurrence anyway
       #
-      # Remove this step (and rotate CLAUDE_CODE_OAUTH_TOKEN) once the
+      # Remove these two steps (and rotate CLAUDE_CODE_OAUTH_TOKEN) once the
       # diagnostic question is answered.
-      - name: Sanity-check OAuth on the runner (diag only)
+      - name: Install Claude CLI for diag (no secrets in env)
+        run: |
+          set -euo pipefail
+          set +x
+          curl -fsSL https://claude.ai/install.sh | bash -s -- 2.1.119 >/dev/null 2>&1
+
+      - name: Verify OAuth on the runner (diag only)
+        continue-on-error: true
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           set -euo pipefail
           set +x
-          curl -fsSL https://claude.ai/install.sh | bash -s -- 2.1.119 >/dev/null 2>&1
           export PATH="$HOME/.local/bin:$PATH"
           TMPHOME="$(mktemp -d)"
           HOME="$TMPHOME" ANTHROPIC_API_KEY="" claude --print "ok"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,34 @@ jobs:
         with:
           fetch-depth: 1
 
+      # TEMPORARY diagnostic step. Verifies whether the OAuth token works
+      # against `claude --print` directly on the runner (i.e., bypassing the
+      # action / agent SDK entirely). If this step succeeds but `Run Claude
+      # Code` still fails, the bug is isolated to how the agent SDK forwards
+      # auth to its spawned child process.
+      #
+      # Token-leak hardening:
+      #   - never enables `set -x`; explicit `set +x` defends against
+      #     ACTIONS_STEP_DEBUG also enabling xtrace
+      #   - token is only referenced via env, never expanded into a command line
+      #   - install.sh stdout/stderr are dropped; no --debug / --verbose on claude
+      #   - HOME is a fresh tmp dir so cached creds are out of scope and gone
+      #     when the runner is destroyed
+      #   - GitHub Actions secret-masking covers any literal occurrence anyway
+      #
+      # Remove this step (and rotate CLAUDE_CODE_OAUTH_TOKEN) once the
+      # diagnostic question is answered.
+      - name: Sanity-check OAuth on the runner (diag only)
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+          set +x
+          curl -fsSL https://claude.ai/install.sh | bash -s -- 2.1.119 >/dev/null 2>&1
+          export PATH="$HOME/.local/bin:$PATH"
+          TMPHOME="$(mktemp -d)"
+          HOME="$TMPHOME" ANTHROPIC_API_KEY="" claude --print "ok"
+
       - name: Run Claude Code
         id: claude
         # Pinned to v1.0.107 + explicit env. As of 2026-04-28, the OAuth token


### PR DESCRIPTION
## Purpose (temporary diagnostic)

Insert a step that runs `claude --print` **directly on the runner** with the OAuth token from the secret, bypassing `anthropics/claude-code-action` and the agent SDK entirely. The same invocation is known-good locally (clean HOME, only `CLAUDE_CODE_OAUTH_TOKEN` in env), so the result of this step in CI tells us where the bug lives:

| Diag step | `Run Claude Code` step | Conclusion |
| --- | --- | --- |
| ✅ pass | ❌ fail (`Could not resolve [authentication]`) | bug is in the action / agent SDK's auth forwarding to its child claude process — minimal upstream repro |
| ❌ fail | ❌ fail | environmental: GitHub-hosted runner ↔ Anthropic OAuth backend (network, region, IP) |

## Scope

- Adds **one step before** the existing `Run Claude Code` step.
- Does NOT touch the `Run Claude Code` step (still v1.0.107 pinned + env).
- Step is marked TEMPORARY in comments. Will be removed in a follow-up once the question is answered.

## Token-leak hardening (inline rationale)

- `set -euo pipefail` only — never `set -x`; explicit `set +x` defends against `ACTIONS_STEP_DEBUG=true` also enabling xtrace.
- The token is only referenced via env (`CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets... }}`) and is never expanded into a command line. `claude` inherits it via fork, not via `argv`.
- `install.sh` stdout/stderr are dropped (`>/dev/null 2>&1`).
- No `--debug` or `--verbose` on `claude`.
- `HOME=$(mktemp -d)` is a fresh tmp dir, so cached creds and `~/.claude/.credentials.json` go to an ephemeral location that is destroyed with the runner.
- GitHub Actions' secret-masking covers any literal occurrence in stdout/stderr regardless.

**Operational note.** As an additional safety net, after the diag PR runs once we plan to rotate `CLAUDE_CODE_OAUTH_TOKEN` (re-issue via `claude setup-token`, update the secret, revoke the old session at claude.ai). Even in the unlikely event the diag step's logs leaked the token in some unmasked form, rotation makes the leaked value useless.

## Test plan

- [ ] Run the workflow once by `@claude review`-ing this PR (or any PR).
- [ ] Read both step results:
  - `Sanity-check OAuth on the runner (diag only)` — pass/fail
  - `Run Claude Code` — pass/fail
- [ ] Decide next move from the conclusion table above.
- [ ] Rotate `CLAUDE_CODE_OAUTH_TOKEN`.
- [ ] Open a follow-up PR that removes the diag step.

## Self-review

CI workflow change only — single new step. 5-lens collapses to: no data-loss / concurrency / consistency surface, no perf impact (one extra ~10s step on `@claude` runs only), no test coverage applicable.

The risk surface is "could leak the token in logs"; mitigations are documented inline and in this body, plus the rotation step in the test plan keeps a safety margin even against unknown-unknowns.
