### PR TITLE
ci: remove Claude Code OAuth diagnostic steps

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,60 +30,30 @@ jobs:
         with:
           fetch-depth: 1
 
-      # TEMPORARY diagnostic. Verifies whether the OAuth token works against
-      # `claude --print` directly on the runner (i.e., bypassing the action /
-      # agent SDK entirely), so we can localize the failure to either:
-      #   - SDK auth-forwarding (diag passes, main fails), or
-      #   - runner ↔ Anthropic OAuth backend (diag fails, main fails).
-      #
-      # Split into two steps so the OAuth token is never present in the env
-      # of `curl | bash` or its subprocesses (Codex P2): the installer runs
-      # without the secret; only the verify step has it, and only for the
-      # single claude invocation. Both diagnostic steps are
-      # `continue-on-error: true` so neither a transient install failure nor
-      # a runner-side OAuth failure can short-circuit `Run Claude Code` —
-      # both step results need to be observed for the isolation logic to
-      # work, and temporary diagnostic infrastructure must not block normal
-      # `@claude` handling (Codex P1, both rounds).
-      #
-      # Token-leak hardening:
-      #   - secret is scoped to the verify step only
-      #   - never enables `set -x`; explicit `set +x` defends against
-      #     ACTIONS_STEP_DEBUG also enabling xtrace
-      #   - token reaches `claude` only via env, never as a command-line arg
-      #   - no --debug / --verbose on `claude`
-      #   - HOME is an ephemeral tmp dir; runner is destroyed after the job
-      #   - GitHub Actions secret-masking covers any literal occurrence anyway
-      #
-      # Remove these two steps (and rotate CLAUDE_CODE_OAUTH_TOKEN) once the
-      # diagnostic question is answered.
-      - name: Install Claude CLI for diag (no secrets in env)
-        continue-on-error: true
-        run: |
-          set -euo pipefail
-          set +x
-          curl -fsSL https://claude.ai/install.sh | bash -s -- 2.1.119 >/dev/null 2>&1
-
-      - name: Verify OAuth on the runner (diag only)
-        continue-on-error: true
-        env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-        run: |
-          set -euo pipefail
-          set +x
-          export PATH="$HOME/.local/bin:$PATH"
-          TMPHOME="$(mktemp -d)"
-          HOME="$TMPHOME" ANTHROPIC_API_KEY="" claude --print "ok"
-
       - name: Run Claude Code
         id: claude
-        # Pinned to v1.0.107 + explicit env. As of 2026-04-28, the OAuth token
-        # passed only via the `with:` input is not reaching the Claude Code
-        # child process spawned by the agent SDK's query() — the SDK throws
-        # `Could not resolve [authentication]` even though the same token
-        # works locally with `claude --print`. Setting CLAUDE_CODE_OAUTH_TOKEN
-        # in the step's env: forces it onto process.env so parse-sdk-options
-        # forwards it to the child. Revisit once upstream ships a fix.
+        # Pinned to v1.0.107 + explicit env, awaiting upstream fix.
+        # As of 2026-04-28 this step fails with `Could not resolve
+        # [authentication]` from the agent SDK on every @claude run.
+        #
+        # The temporary diagnostic in run 25057882769 isolated the bug:
+        # on the same runner, in the same job, with the same OAuth token,
+        # `claude --print` (CLI direct) authenticated successfully and got
+        # a normal response, while the action's agent-SDK-mediated child
+        # claude process threw the auth error. So the token, the Anthropic
+        # OAuth backend, the runner network, and the env-forwarding to the
+        # step are all healthy — only `anthropics/claude-code-action` /
+        # `@anthropic-ai/claude-agent-sdk` fails to forward auth to the
+        # spawned child.
+        #
+        # Workaround attempts that did NOT help:
+        #   - rotating CLAUDE_CODE_OAUTH_TOKEN
+        #   - pinning the action SHA (v1.0.107)
+        #   - duplicating the secret onto the step's env: in addition to
+        #     `with:` (kept anyway because it does no harm)
+        #
+        # Lift the pin and the env: duplication once upstream ships a fix,
+        # or switch to ANTHROPIC_API_KEY auth if recovery is urgent.
         uses: anthropics/claude-code-action@7eab1296cc65117d50ac2a2fa5f00a30ec84d3d5 # v1.0.107
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Remove the temporary OAuth diagnostic steps added in #698. They isolated the failure as intended — the `Run Claude Code` step is fine on this side and the bug is upstream.

## Diagnostic outcome (run [25057882769](https://github.com/bootjp/elastickv/actions/runs/25057882769))

| Step | Result | Meaning |
| --- | --- | --- |
| Install Claude CLI for diag | ✅ | runner can fetch / install the CLI |
| Verify OAuth on the runner | ✅ | on the same runner, with the same token via env, `claude --print "ok"` returns a normal Claude response |
| Run Claude Code (action / agent SDK) | ❌ | same token, same env, throws `Could not resolve [authentication]` |

So the failing path is **only** through `anthropics/claude-code-action` → `@anthropic-ai/claude-agent-sdk`'s child-process auth forwarding. The token, the Anthropic OAuth backend, the runner network, and step-level env propagation are all healthy.

## Changes

- Drop both diag steps (`Install Claude CLI for diag` + `Verify OAuth on the runner`).
- Replace the comment block on `Run Claude Code` to record the diagnostic conclusion and the workarounds that did NOT help, so the next person doesn't redo the same investigation.

## Kept as-is (deliberately)

- `uses: ...@<v1.0.107 SHA>` pin
- duplicated `env: CLAUDE_CODE_OAUTH_TOKEN` on the step

Neither fixes the issue, but reverting them now is churn we would undo again when upstream ships a fix. Lift both in a single follow-up at that point.

## Operational follow-ups (out of scope for this PR)

- Rotate `CLAUDE_CODE_OAUTH_TOKEN` (insurance, since the diag step did briefly carry the token through `pbpaste | docker stdin` in local testing too — the run logs themselves did not leak it).
- File an upstream issue against `anthropics/claude-code-action` with run 25057882769 as the minimal repro. Not done in this PR; can be a separate task.
- If `@claude review` recovery is urgent before upstream fixes things, switch to `ANTHROPIC_API_KEY` auth (separate billing). Also out of scope here.

## Test plan

- [ ] After merge, `@claude` on a PR will continue to fail until upstream fixes the SDK auth forwarding. That is the expected state — the workflow file is back to its pre-diagnostic shape and waiting.

## Self-review

CI workflow only. 5-lens collapses to: no data-loss / concurrency / consistency / perf surface. Test coverage N/A (this is the workflow that runs review tooling, not code). Reverts a known-good prior state (apart from the comment refresh).
