### PR TITLE
ci: rename Claude OAuth secret to CC_OAUTH_TOKEN

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CC_OAUTH_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary

- Switch `.github/workflows/claude.yml` to read the OAuth credential from `secrets.CC_OAUTH_TOKEN` instead of `secrets.CLAUDE_CODE_OAUTH_TOKEN`. Same token; new secret name.
- The action input name (`claude_code_oauth_token`) is unchanged.

## Why

Same workflow file, same `claude-code-action` SHA (`11a9dadd` = v1.0.108), same agent SDK (`0.2.121`), and an unchanged secret value produced **6 consecutive successful `@claude` runs (15:27–15:55 UTC)** and then **4 consecutive failures (16:00–16:13 UTC)** on 2026-04-28, all with the SDK error `Could not resolve [authentication]` thrown from `validateHeaders`. Failing run for reference: https://github.com/bootjp/elastickv/actions/runs/25063998905.

Successful and failing runs both reach `App token successfully obtained` in the OIDC → GitHub App exchange, and both download the same action SHA + same SDK version. The crash is in the agent SDK's `Anthropic` client constructor: neither `apiKey` nor `authToken` resolves. Workflow-side variables are exhausted, so the remaining moving parts are the secret name itself and the OAuth token behind it.

The previous name `CLAUDE_CODE_OAUTH_TOKEN` collides with the env var that Claude Code itself recognizes as a credential, so any process in the pipeline that touches its own login state (the action's child `claude` process, the runner-side `claude` install, or developer-machine tooling that shares the same env can clobber, mask, or otherwise interact with that env. Renaming the GitHub Actions secret avoids the magic-name interaction.

## Behavior change

- Active only when  is mentioned. Other workflows are untouched.
- Token has been re-registered under  with a freshly issued OAuth token; the old  secret remains in place but is no longer referenced.

## Risk

- If the new secret is missing or empty,  invocations will fail at the same point as today's failures (no regression versus the failing baseline).
- No code path / data-plane / replication / consistency surface — CI workflow only.

## Test plan

- [ ] After merge, comment  on this PR (or any open PR) and observe a successful run.
- [ ] If still failing with the same  error, the next step is to re-add the explicit  forwarding (the  workaround) and/or pin to v1.0.107 () until upstream fixes the auth-forwarding regression. That follow-up is intentionally out of scope here so this PR cleanly tests the magic-name hypothesis in isolation.

## Self-review

5-lens collapses to no-op: CI workflow change only, no data-loss / concurrency / performance / consistency surface, no test-coverage applicable.
PR_EOF
)