### PR TITLE
docs(design): propose per-adapter logical backup format

### DIFF
--- a/docs/design/2026_04_29_proposed_logical_backup.md
+++ b/docs/design/2026_04_29_proposed_logical_backup.md
@@ -312,9 +312,10 @@ item table emits 50 million inodes. On most modern filesystems
 slow for live filesystem operations.
 
 For tables where the inode count is the binding constraint, the
-producer accepts an opt-in `--dynamodb-bundle-mode jsonl[:size=64MiB]`
-that emits items as `items/data-<part-id>.jsonl` instead, packed up
-to a configurable per-file size budget:
+producer accepts an opt-in `--dynamodb-bundle-mode jsonl` (paired
+with `--dynamodb-bundle-size 64MiB`, defaulting to that value) that
+emits items as `items/data-<part-id>.jsonl` instead, packed up to the
+configurable per-file size budget:
 
 ```
 dynamodb/orders/
@@ -435,8 +436,10 @@ redis/
     │   └── tags%3Apost1.json
     ├── zsets/
     │   └── leaderboard.json
-    └── streams/
-        └── events.jsonl
+    ├── streams/
+    │   └── events.jsonl
+    └── hll/
+        └── pfcount%3Auniques.bin
 ```
 
 Redis values are encoded so that `redis-cli --pipe` (or the equivalent in
@@ -611,7 +614,7 @@ the proposal does add is a thin **iterator wrapper** so a multi-million
 key range does not need to be materialized in one call:
 
 ```go
-// kv/backup_scan.go (new)
+// kv/shard_store.go (new method on *ShardStore — same file as ScanAt)
 type BackupScanner interface {
     // Next advances the iterator. Returns (nil, false, nil) at end-of-range.
     // The returned KVPair is owned by the caller until the next call to Next.
@@ -620,11 +623,35 @@ type BackupScanner interface {
 }
 
 // NewBackupScanner returns a forward iterator over [start, end) at ts.
-// Internally calls ShardStore.ScanAt in pages of pageSize, chaining
+// Internally calls ScanAt in pages of pageSize, chaining
 // `start = lastReturnedKey + \x00` between pages so no lock is held
 // across pages and the compactor's MVCC retention budget is bounded.
-func (c *ShardedCoordinator) NewBackupScanner(start, end []byte, ts uint64, pageSize int) BackupScanner
+func (s *ShardStore) NewBackupScanner(start, end []byte, ts uint64, pageSize int) BackupScanner
 ```
+
+`NewBackupScanner` lives on `*ShardStore` (its natural home, sharing a
+file with `ScanAt`) rather than `*ShardedCoordinator`. The coordinator
+type today (`kv/sharded_coordinator.go:124`) has no `*ShardStore`
+field — only `engine`, `router`, `groups`, `clock`, and a raw
+`store.MVCCStore` — so placing the scanner on the coordinator would
+force either an awkward extra field plus `main.go` wiring or a
+roundabout coordinator → router → ShardStore lookup. Putting it on
+`*ShardStore` keeps the scan primitive cohesive with `ScanAt` and
+lets the admin server reach it directly via the existing
+`AdminServer` → `ShardStore` wiring used by `GetRaftGroups`.
+
+> **Phase 1 also updates `ScanAt`'s doc comment**
+> (`kv/shard_store.go:101–105`) which today warns _"this method is
+> NOT a globally consistent snapshot; the caller must implement a
+> cross-shard snapshot fence"_. Under the backup contract the caller
+> *is* fencing — `BeginBackup` waits for `applied_index ≥ f(ts)` on
+> every group before any `Next` call. The new comment must say
+> something like: _"consistent across groups when the caller has
+> fenced `applied_index ≥ f(ts)` cluster-wide before calling, as
+> `BeginBackup` does. Without that fence, results are eventually-
+> consistent across groups."_ Without this comment update, code
+> review of the Phase 1 producer will flag the `ScanAt` use as
+> contradicting the warning.
 
 `pageSize` is the same `ScanAt` `limit` parameter; the producer's
 default is 1024 and is exposed as a `--scan-page-size` CLI flag.
@@ -660,17 +687,29 @@ message BeginBackupResponse {
 // dump calls this every ttl_ms/3 (producer default) so a multi-hour
 // scan never relies on a single TTL window. The read_ts is preserved
 // across renewals; only the deadline shifts.
-message RenewBackupRequest  { bytes pin_token = 1; uint64 ttl_ms = 2; }
+message RenewBackupRequest {
+  bytes  pin_token = 1;
+  // Same range constraint as BeginBackupRequest.ttl_ms:
+  // 60s–24h, bounded above by backup_max_ttl_ms. Out-of-range values
+  // are rejected with InvalidArgument.
+  uint64 ttl_ms    = 2;
+}
 message RenewBackupResponse { uint64 ttl_ms_effective = 1; }
 
 message EndBackupRequest  { bytes pin_token = 1; }
 message EndBackupResponse {}
 
+// ListAdaptersAndScopes runs the per-adapter metadata-prefix scan at
+// the read_ts associated with pin_token, so the returned scope list
+// is a precise match for what BackupScanner will surface. A new scope
+// created by a concurrent client between BeginBackup and this call is
+// invisible at the pinned read_ts and therefore not listed.
+message ListAdaptersAndScopesRequest  { bytes pin_token = 1; }
 message ListAdaptersAndScopesResponse {
-  repeated string dynamodb_tables = 1;  // from !ddb|meta|table| scan
-  repeated string s3_buckets       = 2;  // from !s3|bucket|meta| scan
+  repeated string dynamodb_tables = 1;  // from !ddb|meta|table| scan at read_ts
+  repeated string s3_buckets       = 2;  // from !s3|bucket|meta| scan at read_ts
   repeated uint32 redis_databases  = 3;  // {0} until multi-db lands
-  repeated string sqs_queues       = 4;  // from !sqs|queue|meta| scan
+  repeated string sqs_queues       = 4;  // from !sqs|queue|meta| scan at read_ts
 }
 ```
 
@@ -833,7 +872,10 @@ elastickv-restore apply \
   [--adapter dynamodb,s3,redis,sqs] \
   [--scope    dynamodb=orders] \
   [--mode replace|merge|skip-existing] \
-  [--rate-limit 5000ops/s]
+  [--rate-limit 5000ops/s] \
+  [--preserve-ttl] \
+  [--preserve-visibility] \
+  [--stream-merge-strategy reject|auto-id]
 ```
 
 `replace` deletes the target scope before re-importing; `merge`
@@ -1031,6 +1073,8 @@ Scope: out of this proposal; mentioned only to draw the boundary.
 | `TestS3PathFileVsDirectoryCollision` | Bucket holds both `path/to` (object) and `path/to/obj`; producer renames the shorter key to `path/to.elastickv-leaf-data` and records it in `KEYMAP.jsonl`; restore tool reverses it via `MANIFEST.s3_collision_strategy` |
 | `TestBeginBackupTooManyActiveBackups` | Reaching `max_active_backup_pins` returns `ResourceExhausted`; releasing one pin frees a slot for the next request |
 | `TestRenewBackupExtendsDeadline` | `RenewBackup` shifts the deadline; producer's failed-renewal path aborts the dump with a critical log line rather than continuing past the TTL |
+| `TestRenewBackupTTLRangeValidation` | `RenewBackup` with `ttl_ms < 60s` or `ttl_ms > backup_max_ttl_ms` returns `InvalidArgument`; in-range values succeed |
+| `TestListAdaptersAndScopesAtPinTS` | A scope created (e.g. CreateTable) after `BeginBackup` is not surfaced by `ListAdaptersAndScopes(pin_token)`; pre-existing scopes are |
 
 ### P1
 

--- a/docs/design/2026_04_29_proposed_logical_backup.md
+++ b/docs/design/2026_04_29_proposed_logical_backup.md
@@ -121,7 +121,7 @@ or migrate the data **without elastickv being part of the recovery path**.
 ```
 backup-<utc-timestamp>-<cluster-id>-<commit-ts>/
 ├── MANIFEST.json
-├── CHECKSUMS                         # SHA-256 of every regular file under the root
+├── CHECKSUMS                         # sha256sum(1)-compatible: "<64-hex>  <relative-path>" per line
 ├── dynamodb/
 │   └── <table-name>/
 │       ├── _schema.json
@@ -130,20 +130,34 @@ backup-<utc-timestamp>-<cluster-id>-<commit-ts>/
 ├── s3/
 │   └── <bucket-name>/
 │       ├── _bucket.json
-│       └── <object-key-path>          # original object bytes, original hierarchy
+│       ├── <object-key-path>                       # original object bytes
+│       └── <object-key-path>.elastickv-meta.json   # sidecar (reserved suffix)
 ├── redis/
 │   └── db_<n>/
 │       ├── strings/<key>.bin
+│       ├── strings_ttl.json
 │       ├── hashes/<key>.json
 │       ├── lists/<key>.json
 │       ├── sets/<key>.json
 │       ├── zsets/<key>.json
-│       └── streams/<key>.jsonl
+│       ├── streams/<key>.jsonl
+│       └── hll/<key>.bin                           # HyperLogLog opaque sketch (!redis|hll|<key>)
 └── sqs/
     └── <queue-name>/
         ├── _queue.json
         └── messages.jsonl
 ```
+
+`CHECKSUMS` is exact `sha256sum(1)` output so verification works without
+elastickv: `sha256sum -c CHECKSUMS` from the dump root succeeds on a
+clean dump and fails (with file-level diagnostics) on tampering.
+
+The `.elastickv-meta.json` suffix is **reserved**: a user S3 object
+whose key happens to end in `.elastickv-meta.json` is rejected at dump
+time with a typed error rather than silently colliding with its own
+sidecar. Operators who hold such keys pass `--rename-collisions` to have
+them emitted as `<obj>.elastickv-meta.json.user-data` (the rename is
+recorded in `KEYMAP`).
 
 The directory **is** the index. There is no other side-table that must be
 parsed before the user can find a record.
@@ -190,15 +204,21 @@ convenience, not a correctness dependency.
 
 ```
 dynamodb/
-└── orders/
+└── orders/                                        # composite-key table (hash + range)
     ├── _schema.json
     └── items/
-        ├── customer-7421/
-        │   ├── 2026-04-29T12:00:00Z.json
+        ├── customer-7421/                          # <pk>/
+        │   ├── 2026-04-29T12:00:00Z.json           # <sk>.json
         │   └── 2026-04-29T13:15:42Z.json
         ├── customer-7422/
         │   └── 2026-04-29T09:00:00Z.json
-        └── b64.AAECAw../single.json     # binary partition key
+        └── b64.AAECAw../                           # binary partition key (B attribute)
+            └── 2026-04-29T10:00:00Z.json
+└── sessions/                                      # hash-only table
+    ├── _schema.json
+    └── items/
+        ├── sess-abc123.json                        # <pk>.json directly under items/
+        └── sess-def456.json
 ```
 
 `_schema.json`:
@@ -272,22 +292,26 @@ s3/
     │   └── 04/
     │       └── 29/
     │           ├── img.jpg
-    │           ├── img.jpg.metadata.json
+    │           ├── img.jpg.elastickv-meta.json
     │           ├── thumbnails/
-    │           │   └── img-128x128.jpg
-    │           └── thumbnails/img-128x128.jpg.metadata.json
+    │           │   ├── img-128x128.jpg
+    │           │   └── img-128x128.jpg.elastickv-meta.json
     └── archive/
-        └── manifest.csv
+        ├── manifest.csv
+        └── manifest.csv.elastickv-meta.json
 ```
 
 The S3 object body sits at its natural path — every byte that the
 elastickv S3 adapter would have streamed through `streamObjectChunks` for a
 GET is reassembled in order and written out as a single regular file.
 
-A sidecar `<object>.metadata.json` carries the parts of `s3ObjectManifest`
-that S3 itself exposes via headers (`Content-Type`, `Content-Encoding`,
-`Cache-Control`, `Content-Disposition`, user-defined `x-amz-meta-*`,
-`ETag`, `LastModified`):
+A sidecar `<object>.elastickv-meta.json` carries the parts of
+`s3ObjectManifest` that S3 itself exposes via headers (`Content-Type`,
+`Content-Encoding`, `Cache-Control`, `Content-Disposition`, user-defined
+`x-amz-meta-*`, `ETag`, `LastModified`). The suffix is reserved (see
+"Top-Level Layout" above): a user S3 object whose key ends in
+`.elastickv-meta.json` is rejected at dump time unless
+`--rename-collisions` is passed.
 
 ```json
 {
@@ -477,8 +501,11 @@ emits an `_internals/` subdirectory of newline-delimited records.
     "include_sqs_side_records":   false
   },
   "checksum_algorithm": "sha256",
+  "checksum_format":    "sha256sum",
   "encoded_filename_charset": "rfc3986-unreserved-plus-percent",
-  "key_segment_max_bytes": 240
+  "key_segment_max_bytes": 240,
+  "backup_ts_ttl_ms":   1800000,
+  "s3_meta_suffix":     ".elastickv-meta.json"
 }
 ```
 
@@ -498,39 +525,134 @@ The dump must capture state at a single cluster-wide commit-ts so that:
 - An SQS message's `data` row and its `vis`/`byage` index entries
   (when included) reflect the same FIFO sequence number.
 
-Implementation:
+### Scan primitive
 
-1. The backup tool calls a new admin RPC `Admin.BeginBackup` that returns
-   a cluster-wide `read_ts` chosen by the same path that lease reads use
-   (`kv/lease_state.go`, see also
-   `2026_04_20_implemented_lease_read.md`). The `read_ts` is held open
-   for the duration of the dump by registering it with the **active
-   timestamp tracker** (`kv/active_timestamp_tracker.go`) so
-   `kv/compactor.go` cannot retire MVCC versions the dump still depends
-   on.
-2. Every per-adapter scan (`kv.ShardedCoordinator.ScanRange`) is issued
-   `at_ts = read_ts`. This is exactly the path
-   lease reads already use; no new code path through MVCC is introduced.
-3. `Admin.EndBackup` releases the tracker registration. A
-   tool-side crash leaves the tracker entry behind for at most
-   `backup_ts_ttl` (default 30 minutes, configurable via the same admin
-   RPC), after which the registration auto-expires so the compactor is
-   not blocked indefinitely.
+`ShardStore.ScanAt(ctx, start, end, limit, ts)` already exists today
+(`kv/shard_store.go:106`, returning `[]*store.KVPair`); it shards the
+range across `RouteEngine` routes and runs `MVCCStore.ScanAt`
+(`store/store.go:117`) on the resulting per-group sub-ranges. The
+backup producer reuses it as-is — there is no new MVCC code path. What
+the proposal does add is a thin **iterator wrapper** so a multi-million
+key range does not need to be materialized in one call:
+
+```go
+// kv/backup_scan.go (new)
+type BackupScanner interface {
+    // Next advances the iterator. Returns (nil, false, nil) at end-of-range.
+    // The returned KVPair is owned by the caller until the next call to Next.
+    Next(ctx context.Context) (*store.KVPair, bool, error)
+    Close() error
+}
+
+// NewBackupScanner returns a forward iterator over [start, end) at ts.
+// Internally calls ShardStore.ScanAt in pages of pageSize, chaining
+// `start = lastReturnedKey + \x00` between pages so no lock is held
+// across pages and the compactor's MVCC retention budget is bounded.
+func (c *ShardedCoordinator) NewBackupScanner(start, end []byte, ts uint64, pageSize int) BackupScanner
+```
+
+`pageSize` is the same `ScanAt` `limit` parameter; the producer's
+default is 1024 and is exposed as a `--scan-page-size` CLI flag.
+Per-adapter encoders consume `BackupScanner` and emit one record per
+`Next` (or batch records into the same JSONL file for SQS / streams).
+
+### BeginBackup / EndBackup RPCs
+
+```protobuf
+// proto/admin.proto additions
+service Admin {
+  rpc BeginBackup(BeginBackupRequest) returns (BeginBackupResponse) {}
+  rpc EndBackup(EndBackupRequest) returns (EndBackupResponse) {}
+  rpc ListAdaptersAndScopes(ListAdaptersAndScopesRequest)
+      returns (ListAdaptersAndScopesResponse) {}
+}
+
+message BeginBackupRequest {
+  // Time-to-live for the read_ts pin on the active timestamp tracker.
+  // If EndBackup is not called within this window the pin is auto-released.
+  // Range: 60s–24h. Default: 30m.
+  uint64 ttl_ms = 1;
+}
+message BeginBackupResponse {
+  uint64 read_ts            = 1;
+  bytes  pin_token          = 2;  // opaque, must be passed back to EndBackup
+  uint64 ttl_ms_effective   = 3;
+  repeated ShardApplied shards = 4;  // group_id, applied_index at pin time
+}
+
+message EndBackupRequest  { bytes pin_token = 1; }
+message EndBackupResponse {}
+
+message ListAdaptersAndScopesResponse {
+  repeated string dynamodb_tables = 1;  // from !ddb|meta|table| scan
+  repeated string s3_buckets       = 2;  // from !s3|bucket|meta| scan
+  repeated uint32 redis_databases  = 3;  // {0} until multi-db lands
+  repeated string sqs_queues       = 4;  // from !sqs|queue|meta| scan
+}
+```
+
+`ListAdaptersAndScopes` is a thin wrapper over per-adapter metadata
+prefix scans run at `read_ts`; it has no new state of its own.
+
+### TTL on the active timestamp tracker
+
+`kv/active_timestamp_tracker.go` today exposes only `Pin(ts) → token`
+and `token.Release()`. To support BeginBackup's deadline, this design
+extends the tracker:
+
+```go
+// kv/active_timestamp_tracker.go (extended)
+func (t *ActiveTimestampTracker) PinWithDeadline(ts uint64, deadline time.Time) *ActiveTimestampToken
+```
+
+`PinWithDeadline` records `(id → ts, deadline)`. A single sweeper
+goroutine started by `NewActiveTimestampTracker` wakes once per second
+(or when notified by `PinWithDeadline`) and drops entries whose deadline
+has passed. `Pin(ts)` keeps its current zero-deadline behavior (no
+expiry) and is unaffected; only `BeginBackup` uses the deadline path.
+The sweeper logs a structured warning (`backup_pin_expired`) when it
+drops a stuck registration so operators see crashed-producer cases in
+their existing log pipeline.
+
+### BeginBackup → EndBackup flow
+
+1. **Pick `read_ts`**: `BeginBackup` reads the lease-read timestamp
+   pipeline (`kv/lease_state.go`, see
+   `2026_04_20_implemented_lease_read.md`) and snapshots
+   `applied_index` per Raft group.
+2. **Wait for shards to catch up**: every group is required to report
+   `applied_index ≥ commit_index_at_pin` for the default group's HLC
+   ceiling proposal that produced `read_ts`. `BeginBackup` polls each
+   group's `Status.AppliedIndex` (already exposed via the existing
+   raftengine status interface used by `AdminServer.GetRaftGroups`)
+   with a 500 ms tick and a configurable deadline (default 5 s; surfaced
+   as `--begin-backup-deadline` on the CLI). If any group fails to
+   reach the threshold within the deadline, `BeginBackup` returns
+   `FailedPrecondition` and the producer aborts — the dump is
+   not started until every group can serve `read_ts` consistently.
+3. **Pin `read_ts`** with `PinWithDeadline(read_ts, now+ttl_ms)`; return
+   the resulting `pin_token` to the producer.
+4. **Producer scans** all configured adapter scopes via
+   `BackupScanner.Next(at_ts=read_ts)`.
+5. **Renew on long dumps**: the producer calls `BeginBackup` again with
+   the same `read_ts` (carrying the existing token) every `ttl_ms / 3`
+   to extend the deadline. A multi-hour dump never relies on a single
+   30-minute pin.
+6. **`EndBackup(pin_token)`** releases the tracker entry. A producer
+   crash before EndBackup leaves the entry to be reaped by the sweeper.
 
 The dump is therefore a **point-in-time snapshot** of the user-visible
 keyspace, not a streaming tail.
 
 ### Cross-shard consistency
 
-A multi-shard deployment serves different key ranges from different Raft
-groups. `BeginBackup` propagates the same `read_ts` to every group;
-`ScanRange` at `read_ts` is the same OCC visibility check on every group.
-Because HLC physical ceilings are coordinated through the default group
-(`kv/hlc.go`), the chosen `read_ts` is admissible on every group as long
-as it is below each group's last-applied commit-ts at the moment of the
-call — which `BeginBackup` enforces by re-reading
-`max(group_commit_ts)` and adding a small skew buffer (default 50 ms)
-matching the existing TSO buffer.
+Step 2 above is the mechanism. Without it, picking `read_ts` from
+`max(group_commit_ts) + 50 ms` is only a *liveness* assertion: a
+lagging shard might not yet have applied through `read_ts`, and
+`ScanAt(at_ts=read_ts)` on that shard would either block forever or
+return a partial view. The `applied_index` poll-and-wait in
+`BeginBackup` makes the constraint explicit and bounded — every shard
+provably has the data at `read_ts` before any scan begins.
 
 ## Internal-State Handling
 
@@ -572,9 +694,11 @@ elastickv-backup dump \
 Internally it runs:
 
 ```
-BeginBackup → ListAdaptersAndScopes → ScanRange (per scope, at read_ts)
-            → encode-and-write per adapter → CHECKSUMS → MANIFEST.json
-            → EndBackup
+BeginBackup(ttl_ms=1800000) → ListAdaptersAndScopes
+                            → BackupScanner.Next* (per scope, at read_ts)
+                            → encode-and-write per adapter
+                            → CHECKSUMS → MANIFEST.json
+                            → EndBackup(pin_token)
 ```
 
 The producer **does not need access to the leader** — it issues lease
@@ -609,9 +733,11 @@ The format is designed to be extractable without elastickv:
 
 - DynamoDB: `aws dynamodb create-table --cli-input-json _schema.json` and
   then `aws dynamodb put-item --item @items/<pk>/<sk>.json` per file.
-- S3: `aws s3 sync s3/<bucket>/ s3://target-bucket/`. The metadata
-  sidecars are reapplied with a one-pass script that maps
-  `<obj>.metadata.json` to `--metadata` / `--content-type` / etc.
+- S3: `aws s3 sync --exclude '*.elastickv-meta.json' s3/<bucket>/ s3://target-bucket/`.
+  The metadata sidecars are reapplied with a one-pass script that maps
+  `<obj>.elastickv-meta.json` to `--metadata` / `--content-type` / etc.
+  The `--exclude` is mandatory — without it, `aws s3 sync` would upload
+  every sidecar as if it were a user object.
 - Redis: a 100-line shell script over `find redis/db_0/strings -name '*.bin' -exec redis-cli -x SET …`,
   with similar one-liners per type.
 - SQS: `jq -c . messages.jsonl | xargs -n1 aws sqs send-message --message-body …`.
@@ -658,6 +784,42 @@ parser, the format has failed its goal.
   containing percent-signs has its filename percent-encoded twice. The
   `KEYMAP` file mitigates, and JSONL/JSON record contents always carry
   the original key bytes.
+- **SQS FIFO deduplication window resets on restore.** Side records
+  (`!sqs|msg|dedup|`) are intentionally not dumped, so a queue restored
+  on a fresh cluster will accept message-deduplication-IDs that were
+  previously suppressed by the live queue's dedup window. For
+  `ContentBasedDeduplication=true` this reset is harmless on a clean
+  restore (the body hash drives dedup; replaying the dump produces the
+  same hashes). For ID-based dedup, callers replaying messages from
+  the dump *and* from a still-live source concurrently can produce
+  duplicates. Operators who depend on exact dedup state across a
+  restore use `--include-sqs-side-records` to opt in to the
+  `_internals/dedup.jsonl` artifact, then replay it through a
+  follow-up tool that re-seeds the dedup keys.
+- **Redis TTL keys may already be expired by the time of restore.**
+  TTLs are dumped as absolute Unix-millis (`expire_at_ms`). The
+  default restore behavior is **skip-expired**: keys whose
+  `expire_at_ms` is in the past at restore time are not re-applied
+  (they would be deleted by the TTL reaper on the next pass anyway).
+  `--preserve-ttl` forces re-application with the original epoch,
+  which makes sense when the goal is auditability (verifying the
+  exact TTL state at backup time) rather than getting a working
+  cache back.
+- **Redis stream restore in `--mode merge`** can collide on entry IDs.
+  `XADD <id>` fails when an entry with a higher ID already exists.
+  The restore tool's stream behavior:
+  - `--mode replace` — `DEL` the stream, then `XADD` every entry with
+    the original ID (matches the dump's `_meta` line).
+  - `--mode skip-existing` — `XADD NOMKSTREAM` only entries whose ID
+    is not already present.
+  - `--mode merge` — refuses to operate on streams unless the target
+    is empty; emits an error pointing at the conflict. There is no
+    sound way to splice mid-stream without losing the original IDs.
+    Operators who need merge-into-non-empty pass
+    `--stream-merge-strategy=auto-id`, which falls back to `XADD *`
+    and records the original-to-new ID mapping in a
+    `_id_remap.jsonl` log so referential integrity can be patched
+    out-of-band.
 
 ### Risks and Mitigations
 
@@ -678,11 +840,20 @@ Scope: backup-side only. No restore. Targeted at giving operators a
 trustworthy off-cluster artifact even before the restore tool is fully
 written.
 
-- New admin RPC pair `BeginBackup` / `EndBackup` on `proto/admin.proto`
-  registering with `kv/active_timestamp_tracker.go`.
-- New tool `cmd/elastickv-backup/` performing `BeginBackup` →
-  per-adapter `ScanRange(at_ts)` → encode → write directory tree → emit
-  `MANIFEST.json` and `CHECKSUMS` last → `EndBackup`.
+- New admin RPCs on `proto/admin.proto`: `BeginBackup` (with `ttl_ms`),
+  `EndBackup`, `ListAdaptersAndScopes` (signatures in "Read-Side
+  Consistency").
+- Extend `kv/active_timestamp_tracker.go` with `PinWithDeadline` plus
+  the per-second sweeper goroutine that reaps expired pins and emits
+  the `backup_pin_expired` structured warning.
+- New `kv/backup_scan.go` — `BackupScanner` iterator wrapping the
+  existing `ShardStore.ScanAt` (`kv/shard_store.go:106`) so multi-
+  million-key ranges page through `ScanAt` calls of `--scan-page-size`
+  rather than materializing in one call.
+- New tool `cmd/elastickv-backup/` performing
+  `BeginBackup → ListAdaptersAndScopes → BackupScanner.Next* (per scope)
+  → encode → write directory tree → CHECKSUMS → MANIFEST.json
+  → EndBackup`.
 - Per-adapter encoders:
   - `internal/backup/dynamodb.go` — items + `_schema.json`.
   - `internal/backup/s3.go` — manifest reassembly into single object
@@ -734,6 +905,10 @@ Scope: out of this proposal; mentioned only to draw the boundary.
 | `TestSQSDumpFifoOrderPreserved` | Messages with interleaved `MessageGroupId` are emitted in `(send_ts, sequence_number, message_id)` order; visibility-state fields zeroed by default |
 | `TestManifestVersionGate` | Restore with `format_version > current` fails fast with a typed error; same-major-newer-minor allowed; older-major refused with a clear message |
 | `TestBeginBackupBlocksCompactor` | Open a `BeginBackup`, force a compaction round, confirm MVCC versions for the registered `read_ts` are retained |
+| `TestPinWithDeadlineExpiry` | `PinWithDeadline(ts, now+100ms)` is auto-released by the sweeper after the deadline; compactor unblocked; `backup_pin_expired` log emitted |
+| `TestBeginBackupWaitsForLaggingShard` | Force shard B's `applied_index` to lag; `BeginBackup` polls until it catches up or times out with `FailedPrecondition`; no scan starts in the timeout case |
+| `TestBackupScannerPaging` | A range with > pageSize keys is returned across multiple `ScanAt` pages with no overlap, no gaps; iteration tolerates concurrent writes by completing at the pinned `read_ts` |
+| `TestS3SidecarSuffixCollision` | A user S3 object key ending in `.elastickv-meta.json` is rejected without `--rename-collisions`; with the flag, the rename is recorded in `KEYMAP` |
 
 ### P1
 
@@ -745,6 +920,8 @@ Scope: out of this proposal; mentioned only to draw the boundary.
 | `TestExternalToolReplay` | Generated `aws s3 sync` / `aws dynamodb put-item` / `redis-cli --pipe` scripts (run in CI against MinIO / a local DynamoDB / a real Redis) reproduce the dumped state on a non-elastickv target |
 | `TestLongKeySHA256Fallback` | A 1 KiB key encodes to `<sha256-prefix-32>__<truncated>`; `KEYMAP` records the original; round-trip restore still hits the right key |
 | `TestSQSPreserveVisibilityFlag` | Default leaves messages immediately visible on restore; `--preserve-visibility` retains in-flight receipts |
+| `TestRedisTTLExpiredKeySkippedByDefault` | A key whose `expire_at_ms` is in the past at restore time is not re-applied without `--preserve-ttl`; with the flag it is re-applied with the original epoch |
+| `TestRedisStreamMergeRejectsNonEmpty` | `--mode merge` on a non-empty target stream errors out; `--stream-merge-strategy=auto-id` falls back to `XADD *` and writes `_id_remap.jsonl` |
 
 ### P2
 

--- a/docs/design/2026_04_29_proposed_logical_backup.md
+++ b/docs/design/2026_04_29_proposed_logical_backup.md
@@ -777,6 +777,55 @@ fan-out: it submits the per-group entry through the existing
 `ShardGroup.Propose` path and waits for commit before returning to the
 producer.
 
+**Snapshot installation invalidates a replica's pin set.**
+`kvFSM.Restore` (`kv/fsm.go:264-287`) installs a Raft snapshot by
+rebuilding the Pebble store from the snapshot stream — and then *only*
+the Pebble store. The in-memory `ActiveTimestampTracker` is not part
+of the snapshot, so a replica that installs a snapshot during a
+backup window loses every `BackupPin` that was recorded before the
+snapshot's `Metadata.Index`. Once the leader has compacted the log
+past the original `BackupPin` entry index, that entry is gone — a
+follower catching up via snapshot will never replay it. The replica's
+compactor (now bounded only by other live pins, or unbounded) becomes
+free to retire MVCC versions at `read_ts`.
+
+This bounds when the design is safe:
+
+> **Safe-bound invariant**:
+> `backup_duration + worst_case_compaction_lag < mvcc_retention_horizon`.
+
+Concretely, with a 1-hour MVCC retention and a 10-minute Raft
+snapshot interval, the design tolerates dumps up to ~50 minutes
+without hitting the corner case. Beyond that, a snapshot triggered
+by a freshly-restarted follower can quietly unprotect a replica.
+
+`BeginBackup` enforces a soft form of this invariant: it reads each
+group's `Status.AppliedIndex` and `firstIndex` (the oldest log entry
+still on the leader), and refuses to start if any group's
+`appliedIndex - firstIndex` is below a configurable margin
+(`--snapshot-headroom-entries`, default 10000). Operators dumping a
+cluster running close to its snapshot threshold receive
+`FailedPrecondition` rather than a silent corruption, and either
+retry once the headroom widens or extend `mvcc_retention_horizon`
+upstream of the dump.
+
+The failure mode for replicas that go through `Restore` mid-backup is
+documented explicitly: the replica's `ScanAt(at_ts=read_ts)` results
+become eventually-consistent (versions at `read_ts` may already have
+been compacted on that replica), and the producer surfaces the
+inconsistency as a `ScanAt` returning fewer keys than the
+`applied_index` baseline implied. The producer's per-scope
+`expected_keys` heuristic — already needed for
+`TestBeginBackupPinSurvivesLeaderChange` — catches it and fails the
+dump rather than emitting a corrupted artifact.
+
+A heavier mitigation that would let dumps run longer than the
+retention horizon — snapshotting the tracker state alongside the
+Pebble snapshot, or having `Restore` query siblings for active pins
+— is intentionally **out of scope for Phase 1**. The Phase 1 contract
+is "your dump completes within the retention horizon"; longer dumps
+are a Phase 3 problem (see Incremental Backups).
+
 **Bound on concurrent active backup pins.** To prevent a misbehaving
 or malicious caller from issuing unbounded `BeginBackup` requests and
 holding the compactor open across the whole MVCC retention horizon,
@@ -813,10 +862,15 @@ dumps with retention pressure.
    group's `Status.AppliedIndex` (already exposed via the existing
    raftengine status interface used by `AdminServer.GetRaftGroups`)
    with a 500 ms tick and a configurable deadline (default 5 s; surfaced
-   as `--begin-backup-deadline` on the CLI). If any group fails to
-   reach the threshold within the deadline, `BeginBackup` returns
-   `FailedPrecondition` and the producer aborts — the dump is
-   not started until every group can serve `read_ts` consistently.
+   as `--begin-backup-deadline` on the CLI). **This is the binding wait
+   in practice** — a healthy group commits a Raft entry in <100 ms,
+   while a lagging shard recovering from a leader change or restart
+   can take seconds. Operators tuning `--begin-backup-deadline` are
+   adjusting tolerance for shard lag; it does not need to scale with
+   pin-fan-out latency. If any group fails to reach the threshold
+   within the deadline, `BeginBackup` returns `FailedPrecondition`
+   and the producer aborts — the dump is not started until every
+   group can serve `read_ts` consistently.
 3. **Pin `read_ts` cluster-wide**, not just on the node that received
    the RPC. `kv/active_timestamp_tracker.go` is per-process
    (`main.go:294` constructs one tracker per node and wires it
@@ -847,14 +901,20 @@ dumps with retention pressure.
    renewals; only the deadline shifts. A multi-hour dump never relies
    on a single 30-minute pin. Renewals are cheap (one Raft entry per
    group per renewal — at `ttl_ms/3 = 10 min`, that is 6 entries per
-   hour per group, negligible alongside production traffic). The
-   producer's renewal goroutine logs a critical alert and aborts the
-   dump if a renewal call fails — letting the dump continue past the
-   TTL would silently produce a corrupted artifact (the compactor
-   would have already retired versions the in-flight scan still
-   depends on). If renewal succeeds on some groups but fails on
-   others, the producer aborts and issues `EndBackup` (which itself
-   tolerates partial state — see step 6).
+   hour per group, negligible alongside production traffic).
+
+   **Per-group renewal retry**: `BackupExtend` proposes through
+   `ShardGroup.Propose`, which fails transiently during a leader
+   election (typically <1 s under etcd/raft defaults). The admin
+   server retries each per-group proposal **up to 3 times with 500 ms
+   backoff** before declaring that group's renewal failed. Only after
+   the retry budget is exhausted does the producer's renewal goroutine
+   log a critical alert and abort the dump — letting the dump continue
+   past the TTL would silently produce a corrupted artifact (the
+   compactor would have already retired versions the in-flight scan
+   still depends on). If renewal succeeds on some groups but fails on
+   others after retries, the producer aborts and issues `EndBackup`
+   (which itself tolerates partial state — see step 6).
 6. **`EndBackup(pin_token)`** proposes `BackupRelease{pin_id}` on
    every group recorded in `pin_token`. The release is idempotent: a
    group that has already swept the pin via deadline expiry treats
@@ -913,6 +973,7 @@ elastickv-backup dump \
   [--checksums sha256] \
   [--ttl-ms 1800000] \
   [--begin-backup-deadline 5s] \
+  [--snapshot-headroom-entries 10000] \
   [--scan-page-size 1024] \
   [--dynamodb-bundle-mode per-item|jsonl] \
   [--dynamodb-bundle-size 64MiB] \
@@ -1083,11 +1144,41 @@ trustworthy off-cluster artifact even before the restore tool is fully
 written.
 
 - New admin RPCs on `proto/admin.proto`: `BeginBackup` (with `ttl_ms`),
-  `EndBackup`, `ListAdaptersAndScopes` (signatures in "Read-Side
-  Consistency").
-- Extend `kv/active_timestamp_tracker.go` with `PinWithDeadline` plus
-  the per-second sweeper goroutine that reaps expired pins and emits
-  the `backup_pin_expired` structured warning.
+  `EndBackup`, `RenewBackup`, `ListAdaptersAndScopes` (signatures in
+  "Read-Side Consistency").
+- Extend `kv/active_timestamp_tracker.go` with `PinWithDeadline`,
+  `Extend`, and the per-second sweeper goroutine that reaps expired
+  pins and emits the `backup_pin_expired` structured warning.
+- **FSM plumbing for cluster-wide pins** (the propagation described
+  in "Cluster-wide propagation" only works if these land):
+  - New byte tag constants in `kv/fsm.go` alongside the existing
+    `raftEncodeHLCLease = 0x02` (`kv/fsm.go:116`):
+    `raftEncodeBackupPin = 0x03`, `raftEncodeBackupExtend = 0x04`,
+    `raftEncodeBackupRelease = 0x05`. New
+    `applyBackupPin` / `applyBackupExtend` / `applyBackupRelease`
+    handlers on `kvFSM`, dispatched from `kvFSM.Apply`
+    (`kv/fsm.go:60`) in the same shape as `applyHLCLease`.
+  - New `*ActiveTimestampTracker` field on `kvFSM` (`kv/fsm.go:26`),
+    wired via a new `NewKvFSMWithHLCAndTracker(store, hlc, tracker)`
+    constructor — analogous to how `*HLC` is shared today via
+    `NewKvFSMWithHLC`. The coordinator and the FSM must share the
+    same tracker instance so `applyBackupPin` and the local
+    compactor consult the same map. This invariant goes alongside
+    the HLC-sharing invariant in `CLAUDE.md`.
+  - New `kv/backup_codec.go` — wire encoding for the three entry
+    types. Hand-coded fixed-layout binary (matching the HLC lease
+    style):
+    ```
+    BackupPin     : [tag:1][pin_id:16][read_ts:8][deadline_ms:8]   = 33 bytes
+    BackupExtend  : [tag:1][pin_id:16][deadline_ms:8]              = 25 bytes
+    BackupRelease : [tag:1][pin_id:16]                             = 17 bytes
+    ```
+    `pin_id` is a UUIDv4 generated by the admin server at
+    `BeginBackup` time and echoed in every subsequent `BackupExtend`
+    / `BackupRelease` so the FSM can target the right tracker entry.
+    Hand-coded binary (vs. proto) keeps the entry small enough to
+    stay within the existing `MaxEntryBytes` budget and avoids
+    pulling proto codegen into the FSM apply hot path.
 - New `kv/backup_scan.go` — `BackupScanner` iterator wrapping the
   existing `ShardStore.ScanAt` (`kv/shard_store.go:106`) so multi-
   million-key ranges page through `ScanAt` calls of `--scan-page-size`
@@ -1150,6 +1241,10 @@ Scope: out of this proposal; mentioned only to draw the boundary.
 | `TestBeginBackupPinFanOutAllNodes` | A 3-node cluster: `BeginBackup` issued to node A; verify nodes B and C have applied the `BackupPin` Raft entry and their compactors retain MVCC versions at `read_ts`. Compactor on B forced to run mid-dump must not retire pinned versions |
 | `TestBeginBackupPinSurvivesLeaderChange` | After `BeginBackup` on node A, force a leadership change on a group; the new leader still honors the pin (its FSM applied the same entry); subsequent `BackupScanner.Next` calls succeed |
 | `TestBeginBackupGroupUnreachable` | If one group cannot commit `BackupPin` within `--begin-backup-deadline`, `BeginBackup` returns `Unavailable` and proposes `BackupRelease` on every group that did commit; no stranded pins remain |
+| `TestBackupPinFSMCodecRoundTrip` | `BackupPin` / `BackupExtend` / `BackupRelease` byte layouts (33 / 25 / 17 bytes) round-trip through the FSM apply path; unknown tag bytes return `ErrUnknownRequestType` rather than panicking |
+| `TestRestoreWipesLocalPins` | A replica that installs a Raft snapshot during a backup loses its `BackupPin`; the producer's per-scope `expected_keys` heuristic detects the resulting `ScanAt` shortfall and fails the dump rather than emitting a corrupted artifact |
+| `TestBeginBackupRefusesNearSnapshotThreshold` | When any group's `appliedIndex - firstIndex < snapshot_headroom_entries`, `BeginBackup` returns `FailedPrecondition` rather than starting a dump that risks the snapshot-installation path |
+| `TestRenewBackupRetriesLeaderElection` | Force a leader election mid-`RenewBackup`; the admin server retries `BackupExtend` up to 3 times with 500ms backoff and succeeds once the new leader is established, without aborting the dump |
 | `TestPinWithDeadlineExpiry` | `PinWithDeadline(ts, now+100ms)` is auto-released by the sweeper after the deadline; compactor unblocked; `backup_pin_expired` log emitted |
 | `TestBeginBackupWaitsForLaggingShard` | Force shard B's `applied_index` to lag; `BeginBackup` polls until it catches up or times out with `FailedPrecondition`; no scan starts in the timeout case |
 | `TestBackupScannerPaging` | A range with > pageSize keys is returned across multiple `ScanAt` pages with no overlap, no gaps; iteration tolerates concurrent writes by completing at the pinned `read_ts` |

--- a/docs/design/2026_04_29_proposed_logical_backup.md
+++ b/docs/design/2026_04_29_proposed_logical_backup.md
@@ -125,15 +125,18 @@ backup-<utc-timestamp>-<cluster-id>-<commit-ts>/
 ├── dynamodb/
 │   └── <table-name>/
 │       ├── _schema.json
+│       ├── KEYMAP.jsonl                            # per-scope (omitted when empty)
 │       └── items/
 │           └── <pk-segment>/[<sk-segment>.]json
 ├── s3/
 │   └── <bucket-name>/
 │       ├── _bucket.json
+│       ├── KEYMAP.jsonl                            # per-scope (omitted when empty)
 │       ├── <object-key-path>                       # original object bytes
 │       └── <object-key-path>.elastickv-meta.json   # sidecar (reserved suffix)
 ├── redis/
 │   └── db_<n>/
+│       ├── KEYMAP.jsonl                            # per-scope (omitted when empty)
 │       ├── strings/<key>.bin
 │       ├── strings_ttl.jsonl
 │       ├── hashes/<key>.json
@@ -146,6 +149,7 @@ backup-<utc-timestamp>-<cluster-id>-<commit-ts>/
 └── sqs/
     └── <queue-name>/
         ├── _queue.json
+        ├── KEYMAP.jsonl                            # per-scope (omitted when empty)
         └── messages.jsonl
 ```
 
@@ -754,6 +758,25 @@ The sweeper logs a structured warning (`backup_pin_expired`) when it
 drops a stuck registration so operators see crashed-producer cases in
 their existing log pipeline.
 
+**Cluster-wide propagation.** Each elastickv node owns its own
+`ActiveTimestampTracker` (`main.go:294`) and its compactor only
+consults the local instance (`main.go:335`). For a multi-node
+deployment, a pin recorded on the node receiving the admin RPC is not
+sufficient — the producer's `BackupScanner` reads from group leaders
+that may live on different nodes whose compactors are oblivious to the
+local pin. Pins are therefore **propagated through each Raft group's
+log** as `BackupPin{pin_id, read_ts, deadline}` / `BackupExtend` /
+`BackupRelease` FSM commands. Every replica applies these to its
+local tracker on log apply, so the pin set is replicated and durable
+across leader changes (a newly-elected leader inherits the pin from
+the same log it just applied). Compaction on each replica continues to
+consult only the local tracker; the only new ingredient is the FSM
+plumbing that keeps every replica's tracker in sync. The backup
+admin server (the node receiving `BeginBackup`) is responsible for
+fan-out: it submits the per-group entry through the existing
+`ShardGroup.Propose` path and waits for commit before returning to the
+producer.
+
 **Bound on concurrent active backup pins.** To prevent a misbehaving
 or malicious caller from issuing unbounded `BeginBackup` requests and
 holding the compactor open across the whole MVCC retention horizon,
@@ -794,22 +817,51 @@ dumps with retention pressure.
    reach the threshold within the deadline, `BeginBackup` returns
    `FailedPrecondition` and the producer aborts — the dump is
    not started until every group can serve `read_ts` consistently.
-3. **Pin `read_ts`** with `PinWithDeadline(read_ts, now+ttl_ms)`; return
-   the resulting `pin_token` to the producer.
+3. **Pin `read_ts` cluster-wide**, not just on the node that received
+   the RPC. `kv/active_timestamp_tracker.go` is per-process
+   (`main.go:294` constructs one tracker per node and wires it
+   exclusively to that node's compactor at `main.go:335`). A pin
+   recorded on the receiving node would gate only its own compactor;
+   compactors on other nodes — including any group leader serving the
+   producer's `BackupScanner` — would be free to retire MVCC versions
+   at `read_ts`. The pin therefore fans out to **every replica that
+   could compact**, propagated via the Raft log of each group:
+   `BeginBackup` proposes a `BackupPin{pin_id, read_ts, deadline}`
+   entry through every group involved in the dump; each replica's
+   FSM, on apply, calls `PinWithDeadline(read_ts, deadline)` on its
+   local tracker. The pin is therefore replicated and durable across
+   leader changes — a new leader applies the same entry from the log
+   and inherits the pin. `BeginBackup` returns the resulting
+   `pin_token = (pin_id, []group_id)` to the producer only after every
+   group has committed the entry; if any group's leader is unreachable
+   or fails to commit within `--begin-backup-deadline`, `BeginBackup`
+   proposes a matching `BackupRelease{pin_id}` to every group that
+   *did* commit and returns `Unavailable` so the operator retries
+   cleanly without leaving stranded pins.
 4. **Producer scans** all configured adapter scopes via
    `BackupScanner.Next(at_ts=read_ts)`.
 5. **Renew on long dumps**: the producer calls
-   `RenewBackup(pin_token, ttl_ms)` every `ttl_ms / 3` to extend the
-   deadline. The `read_ts` is preserved across renewals; only the
-   deadline shifts. A multi-hour dump never relies on a single
-   30-minute pin. Renewals are cheap (in-memory map update), and the
+   `RenewBackup(pin_token, ttl_ms)` every `ttl_ms / 3`. The admin
+   server proposes `BackupExtend{pin_id, deadline}` on every group
+   recorded in `pin_token`. The `read_ts` is preserved across
+   renewals; only the deadline shifts. A multi-hour dump never relies
+   on a single 30-minute pin. Renewals are cheap (one Raft entry per
+   group per renewal — at `ttl_ms/3 = 10 min`, that is 6 entries per
+   hour per group, negligible alongside production traffic). The
    producer's renewal goroutine logs a critical alert and aborts the
    dump if a renewal call fails — letting the dump continue past the
    TTL would silently produce a corrupted artifact (the compactor
    would have already retired versions the in-flight scan still
-   depends on).
-6. **`EndBackup(pin_token)`** releases the tracker entry. A producer
-   crash before EndBackup leaves the entry to be reaped by the sweeper.
+   depends on). If renewal succeeds on some groups but fails on
+   others, the producer aborts and issues `EndBackup` (which itself
+   tolerates partial state — see step 6).
+6. **`EndBackup(pin_token)`** proposes `BackupRelease{pin_id}` on
+   every group recorded in `pin_token`. The release is idempotent: a
+   group that has already swept the pin via deadline expiry treats
+   the release as a no-op. A producer crash before EndBackup leaves
+   the pin to be reaped by each replica's sweeper goroutine
+   independently — the per-replica deadline ensures liveness even if
+   no group ever sees a `BackupRelease`.
 
 The dump is therefore a **point-in-time snapshot** of the user-visible
 keyspace, not a streaming tail.
@@ -1005,9 +1057,11 @@ parser, the format has failed its goal.
     sound way to splice mid-stream without losing the original IDs.
     Operators who need merge-into-non-empty pass
     `--stream-merge-strategy=auto-id`, which falls back to `XADD *`
-    and records the original-to-new ID mapping in a
-    `_id_remap.jsonl` log so referential integrity can be patched
-    out-of-band.
+    and records the original-to-new ID mapping next to the source
+    file at `redis/db_<n>/streams/<key>._id_remap.jsonl` (one
+    `{"original_id":"…","new_id":"…"}` line per entry) so referential
+    integrity can be patched out-of-band by tools that find the dump
+    on disk.
 
 ### Risks and Mitigations
 
@@ -1093,6 +1147,9 @@ Scope: out of this proposal; mentioned only to draw the boundary.
 | `TestSQSDumpFifoOrderPreserved` | Messages with interleaved `MessageGroupId` are emitted in `(send_ts, sequence_number, message_id)` order; visibility-state fields zeroed by default |
 | `TestManifestVersionGate` | Restore with `format_version > current` fails fast with a typed error; same-major-newer-minor allowed; older-major refused with a clear message |
 | `TestBeginBackupBlocksCompactor` | Open a `BeginBackup`, force a compaction round, confirm MVCC versions for the registered `read_ts` are retained |
+| `TestBeginBackupPinFanOutAllNodes` | A 3-node cluster: `BeginBackup` issued to node A; verify nodes B and C have applied the `BackupPin` Raft entry and their compactors retain MVCC versions at `read_ts`. Compactor on B forced to run mid-dump must not retire pinned versions |
+| `TestBeginBackupPinSurvivesLeaderChange` | After `BeginBackup` on node A, force a leadership change on a group; the new leader still honors the pin (its FSM applied the same entry); subsequent `BackupScanner.Next` calls succeed |
+| `TestBeginBackupGroupUnreachable` | If one group cannot commit `BackupPin` within `--begin-backup-deadline`, `BeginBackup` returns `Unavailable` and proposes `BackupRelease` on every group that did commit; no stranded pins remain |
 | `TestPinWithDeadlineExpiry` | `PinWithDeadline(ts, now+100ms)` is auto-released by the sweeper after the deadline; compactor unblocked; `backup_pin_expired` log emitted |
 | `TestBeginBackupWaitsForLaggingShard` | Force shard B's `applied_index` to lag; `BeginBackup` polls until it catches up or times out with `FailedPrecondition`; no scan starts in the timeout case |
 | `TestBackupScannerPaging` | A range with > pageSize keys is returned across multiple `ScanAt` pages with no overlap, no gaps; iteration tolerates concurrent writes by completing at the pinned `read_ts` |
@@ -1117,7 +1174,7 @@ Scope: out of this proposal; mentioned only to draw the boundary.
 | `TestRedisStreamMergeRejectsNonEmpty` | `--mode merge` on a non-empty target stream errors out; `--stream-merge-strategy=auto-id` falls back to `XADD *` and writes `_id_remap.jsonl` |
 | `TestRedisStreamTTLRoundTrip` | A stream with `PEXPIREAT` round-trips through dump and restore: `expire_at_ms` is captured in the `_meta` line and re-applied so the restored stream expires at the original epoch |
 | `TestRedisHLLTTLRoundTrip` | A TTL'd HLL key surfaces in `hll_ttl.jsonl` and is re-applied on restore via the same `EXPIREAT` path used for strings; no-TTL HLLs leave `hll_ttl.jsonl` absent |
-| `TestRedisStreamSkipExistingHandlesERR` | The restore tool's `skip-existing` path tolerates `ERR The ID specified in XADD is equal or smaller` without aborting the dump; entries with non-conflicting IDs are still applied |
+| `TestRedisStreamSkipExistingHandlesERR` | The restore tool's `skip-existing` path tolerates `ERR The ID specified in XADD is equal or smaller` without aborting the restore; entries with non-conflicting IDs are still applied |
 
 ### P2
 

--- a/docs/design/2026_04_29_proposed_logical_backup.md
+++ b/docs/design/2026_04_29_proposed_logical_backup.md
@@ -1283,13 +1283,18 @@ written.
     leader change), while the admin cache is keyed on node identity
     (`NodeIdentity.GRPCAddress` from `snapshotMembers`); mixing the
     two would conflate moving and stable address spaces.
-  - `versionCache map[string]struct{ version string; fetchedAt time.Time }`
-    (or `sync.Map` equivalent) protecting the 10 s
-    `leader_node_version` cache used by `GetRaftGroups`'s async
-    leader probes. Populated by the same async dials; read by
-    `GetRaftGroups` synchronously when fresh, returning empty
-    string on cache-miss-or-dial-still-in-flight to keep the RPC
-    latency contract intact.
+  - `versionCache sync.Map` (key `string` node-id, value
+    `versionCacheEntry{ version string; fetchedAt time.Time }`)
+    backing the 10 s `leader_node_version` cache used by
+    `GetRaftGroups`'s async leader probes. `sync.Map` is chosen
+    over `map + RWMutex` so the cache's lock is independent of
+    `groupsMu`; mixing them would force the async write goroutine
+    to wait on every `GetRaftGroups` reader holding `groupsMu.RLock`,
+    or — worse — produce a data race if the implementor reuses
+    `groupsMu.RLock` for writes. The cache is populated by the
+    async dials; read by `GetRaftGroups` synchronously, returning
+    `""` when the entry is missing-or-expired so the RPC latency
+    contract stays intact regardless of dial state.
 - Extend `AdminGroup` interface (`adapter/admin_grpc.go:41`) with a
   `SnapshotEvery() uint64` method matching the `StatusReader`
   addition. Without this, the `BeginBackup` handler on
@@ -1384,6 +1389,29 @@ written.
        responds with its compiled-in version constant. The handler
        refuses `BeginBackup` if any peer returns a version below N
        or fails to respond within the deadline.
+
+       **Auth metadata propagation.** The `Admin` service is
+       gated by `AdminTokenAuth` (`adapter/admin_grpc.go:455-505`)
+       on every method, including `GetNodeVersion`. Since
+       `GetNodeVersion` is itself an `Admin` method, the outbound
+       fan-out from `BeginBackup` must carry the same bearer token
+       that authenticated the inbound call — otherwise every peer
+       returns `Unauthenticated` and the gate misreports the
+       failure as "node X did not respond" on every auth-enabled
+       cluster. The `BeginBackup` handler propagates the inbound
+       metadata to outbound calls explicitly:
+
+       ```go
+       inMD, _ := metadata.FromIncomingContext(ctx)
+       outCtx := metadata.NewOutgoingContext(context.Background(), inMD)
+       // every per-peer GetNodeVersion dial uses outCtx
+       ```
+
+       This pattern is also used by the async `GetNodeVersion(leader)`
+       probes in `GetRaftGroups`. The forwarded token must be the
+       inbound caller's, not a server-stored value, so the
+       authorization decision remains the operator's bearer token,
+       not a privilege escalation by the admin server.
 
        The two failure cases — "old version" and "unreachable" —
        both block backups, but the error message must
@@ -1532,6 +1560,8 @@ Scope: out of this proposal; mentioned only to draw the boundary.
 | `TestBeginBackupGatesIncludesDynamicallyAddedNodes` | Start a 3-node cluster, add a 4th node at `v(N-1)` via `AddVoter` after `AdminServer` startup (so it is NOT in the bootstrap `members` seed), then call `BeginBackup`; the gate fails with the new node identified in the error. The previous seed-only design would have falsely passed |
 | `TestGetRaftGroupsLeaderVersionAsync` | `GetRaftGroups` returns within local-snapshot latency even when a leader is unreachable; `leader_node_version` is empty string in that case. Verify the 500 ms per-leader timeout and the 10 s response cache prevent repeated fan-outs across rapid polls |
 | `TestAdminGRPCConnCacheReuse` | Two consecutive `BeginBackup` calls dialing the same peer share one underlying `*grpc.ClientConn` (verified via the cache size); shutdown of a peer evicts only that entry, not the whole cache; admin cache is independent of `ShardStore.connCache` (no cross-cache eviction) |
+| `TestBeginBackupPropagatesAdminAuthToken` | A cluster booted with `--adminToken` accepts a `BeginBackup` call carrying `authorization: Bearer <token>`; the handler propagates the same metadata via `metadata.NewOutgoingContext` to every `GetNodeVersion` fan-out dial, so peers return their version (not `Unauthenticated`). A `BeginBackup` call without the token is itself rejected before any fan-out happens |
+| `TestVersionCacheRaceUnderLoad` | `go test -race` with 50 concurrent `GetRaftGroups` callers and async `GetNodeVersion` probe goroutines writing the cache simultaneously emits no data-race report; the `sync.Map` choice is enforced by the lack of a separate `versionCacheMu` field on `AdminServer` |
 | `TestSnapshotEveryReadsFromEngine` | A node started with `ELASTICKV_RAFT_SNAPSHOT_COUNT=5000` reports `Engine.SnapshotEvery() == 5000`; `BeginBackup` uses 5000 (not the default 10000) when computing remaining headroom |
 | `TestRenewBackupRetriesLeaderElection` | Force a leader election mid-`RenewBackup`; the admin server retries `BackupExtend` up to 3 times with 500ms backoff and succeeds once the new leader is established, without aborting the dump |
 | `TestPinWithDeadlineExpiry` | `PinWithDeadline(ts, now+100ms)` is auto-released by the sweeper after the deadline; compactor unblocked; `backup_pin_expired` log emitted |

--- a/docs/design/2026_04_29_proposed_logical_backup.md
+++ b/docs/design/2026_04_29_proposed_logical_backup.md
@@ -1,0 +1,770 @@
+# Logical Backup: Per-Adapter Decomposed Snapshot Format
+
+Status: Proposed
+Author: bootjp
+Date: 2026-04-29
+
+## Background and Problem
+
+### What we have today
+
+The FSM snapshot path (`store/snapshot_pebble.go`, see
+`2026_04_14_implemented_etcd_snapshot_disk_offload.md`) writes the entire
+keyspace as a single opaque stream:
+
+```
+[magic "EKVPBBL1" :8]
+[lastCommitTS    :8]
+([keyLen:8][key][valLen:8][val])*
+[CRC32C footer  :4]
+```
+
+That format is fine for Raft log compaction and follower catch-up — it is
+loaded back by `kvFSM.Restore` into the same Pebble store that produced it —
+but it is **fundamentally a one-way artifact**:
+
+- Keys are raw byte slices in elastickv's internal layout
+  (`!ddb|item|<table>|<gen>|<orderedKey>`, `!s3|blob|<bucket><gen><obj>...`,
+  `!hs|fld|<keyLen><key><field>`, `!sqs|msg|data|<queue><gen><msgID>`, …).
+- Values are protobuf or JSON envelopes wrapped with internal magic prefixes
+  (`0x00 'D' 'I' 0x01` for DynamoDB items in `adapter/dynamodb_storage_codec.go`,
+  `0x00 'S' 'M' 0x01` for SQS records in `adapter/sqs_messages.go`, etc.).
+- S3 objects are split into per-chunk blob keys keyed by `(bucket, generation,
+  object, uploadID, partNo, chunkNo, partVersion)` (see
+  `internal/s3keys/keys.go`); the original byte stream only exists as a sequence
+  reassembled by `streamObjectChunks` at GET time.
+- Internal control-plane keys (route catalog, txn keys, HLC ceiling, write
+  conflict counter prefixes) are intermixed with user data with no separation
+  marker.
+
+If the user takes that snapshot off-cluster — to S3, tape, a sidecar disk,
+another cluster — they have a backup that **only this elastickv binary, on
+exactly the version that wrote it, can read**.
+
+### Why that is unsafe
+
+Backups are an insurance policy. The condition under which a user reaches for
+a backup is by definition the worst case: corrupted store, lost cluster,
+botched migration, rolled-back schema, or a vendor-side failure that leaves
+elastickv itself unusable. A backup format that requires the same vendor's
+binary to extract is not insurance — it is a single point of failure
+collocated with the thing it is supposed to protect against.
+
+Concrete failure modes the current snapshot format does not survive:
+
+1. **The cluster is gone and the binary cannot be rebuilt** (lost source,
+   broken toolchain, vendor end-of-life). The user holds bytes they cannot
+   read.
+2. **Format drift between versions.** Internal magic prefixes
+   (`storedDynamoItemProtoPrefix`, `storedSQSMsgPrefix`, the Redis stream
+   entry envelope, the `!hs|fld|<keyLen>...` wide-column layout) have already
+   changed twice in this codebase (Redis hash/set/zset legacy → wide-column
+   migrations, see `redis_compat_commands.go:1881-1950`). A snapshot from an
+   older format cannot be restored into a newer binary without running the
+   in-tree migration code paths first.
+3. **Cross-system migration.** The user wants to leave elastickv and feed
+   DynamoDB tables into real DynamoDB, Redis keys into a real Redis, S3
+   objects into MinIO/AWS, SQS messages into AWS SQS. Today they would have
+   to write a custom snapshot-stream parser per adapter, including reverse-
+   engineering all the wide-column layouts.
+4. **Partial or selective restore.** "I just want to recover the
+   `users` DynamoDB table" or "I just want this one S3 bucket back". The
+   current snapshot is monolithic.
+
+### What we want instead
+
+A backup whose physical layout *is* the logical structure of the data, in
+formats every operating system, scripting language, and competing storage
+product already understands:
+
+- Directory hierarchy by adapter, then by user-visible scope (table /
+  bucket / queue / db).
+- Records in self-describing formats (JSON for keyed records, JSONL for
+  ordered streams, raw bytes for blobs).
+- Filenames that match the user's primary key — so `find`, `ls`, `grep`,
+  `aws s3 sync`, `redis-cli --pipe` can operate on the dump directly.
+- A versioned manifest at the root so future tools can round-trip if they
+  want to, without that being a precondition for reading.
+
+This is what is meant by "not a one-way ticket": the user can recover, audit,
+or migrate the data **without elastickv being part of the recovery path**.
+
+## Design Goals
+
+| Goal | Detail |
+|------|--------|
+| **Vendor-independent restore** | `cat`, `jq`, `find`, `aws s3 cp`, `redis-cli` are sufficient to reconstruct any single record without running elastickv |
+| **Adapter-shaped layout** | Top level partitions by `dynamodb/`, `s3/`, `redis/`, `sqs/`; each adapter's subtree mirrors how that protocol exposes data |
+| **Self-describing per record** | A `dynamodb/<table>/items/<pk>.json` file is a complete DynamoDB item, decodable in isolation; an `s3/<bucket>/<key>` file is the original object body byte-for-byte |
+| **Crash-consistent across adapters** | All records in a single backup come from one cluster-wide read timestamp, so cross-adapter invariants (e.g., DynamoDB conditional write outcomes) are preserved |
+| **Selective backup and restore** | The dump and restore tools can be scoped to one adapter, one table, one bucket, or one queue without reading or rewriting unrelated data |
+| **Format stability across elastickv versions** | The on-disk record format does not embed elastickv's internal magic prefixes or wide-column key encoding; format changes are versioned in `MANIFEST.json` |
+| **Forward-compatible restore** | Older dumps remain restorable on newer binaries; per-adapter restore handles dropped/added optional fields |
+| **No change to the in-cluster snapshot path** | This is a separate output produced by a backup tool, not a replacement for the FSM snapshot used by Raft compaction |
+
+### Non-Goals
+
+- Replacing the FSM/Raft snapshot pipeline. The on-the-wire and on-disk
+  snapshot format described in `2026_04_14_implemented_etcd_snapshot_disk_offload.md`
+  is unaffected.
+- Continuous/incremental backup or PITR. This proposal is the full-snapshot
+  baseline; incremental/CDC is left for a follow-up.
+- Encryption-at-rest or signed manifests. Both are valuable but are layered
+  on top — the format described here is the payload for them.
+- Backing up internal control-plane state (route catalog, HLC ceiling,
+  Raft term/index, txn intent keys, GSI projections). These are
+  re-derivable from user data plus configuration (see "Internal-State
+  Handling" below).
+
+## Top-Level Layout
+
+```
+backup-<utc-timestamp>-<cluster-id>-<commit-ts>/
+├── MANIFEST.json
+├── CHECKSUMS                         # SHA-256 of every regular file under the root
+├── dynamodb/
+│   └── <table-name>/
+│       ├── _schema.json
+│       └── items/
+│           └── <pk-segment>/[<sk-segment>.]json
+├── s3/
+│   └── <bucket-name>/
+│       ├── _bucket.json
+│       └── <object-key-path>          # original object bytes, original hierarchy
+├── redis/
+│   └── db_<n>/
+│       ├── strings/<key>.bin
+│       ├── hashes/<key>.json
+│       ├── lists/<key>.json
+│       ├── sets/<key>.json
+│       ├── zsets/<key>.json
+│       └── streams/<key>.jsonl
+└── sqs/
+    └── <queue-name>/
+        ├── _queue.json
+        └── messages.jsonl
+```
+
+The directory **is** the index. There is no other side-table that must be
+parsed before the user can find a record.
+
+### Filename Encoding
+
+User keys (table names, bucket names, S3 object keys, Redis keys, SQS
+message IDs) can contain bytes that are illegal or ambiguous on common
+filesystems: `/`, NUL, `\`, control characters, names ending in `.`, names
+that case-collide on Windows/HFS+, names longer than `NAME_MAX`.
+
+Rules:
+
+- **S3 object keys preserve their `/` separators** as filesystem path
+  separators. `s3://photos/2026/04/29/img.jpg` becomes
+  `s3/photos/2026/04/29/img.jpg`. This is the whole point — `aws s3 sync`
+  on the dump directory works.
+- **All other key segments** (DynamoDB partition/sort key bytes, Redis keys,
+  SQS queue names and message IDs) are encoded with the following scheme,
+  which is unambiguous and reversible:
+  - Bytes in `[A-Za-z0-9._-]` pass through.
+  - Every other byte is rendered as `%HH` (uppercase hex), like
+    `application/x-www-form-urlencoded` but applied to every non-allowlisted
+    byte.
+  - If the resulting segment exceeds 240 bytes, the segment is replaced with
+    `<sha256-hex-prefix-32>__<truncated-original>` and the full original
+    bytes are recorded in `<adapter>/<scope>/_long_keys.jsonl`.
+- **DynamoDB binary partition / sort keys** (the `B` attribute type) are
+  rendered as `b64.<base64url>` so a binary key never collides with a
+  string key whose hex encoding happens to look like base64.
+- **Stream messages** within an SQS queue are not represented by file
+  per message (would be millions of small files); they live in a single
+  `messages.jsonl`. Same rationale for Redis stream entries.
+
+A single `KEYMAP` file at each adapter scope root translates the encoded
+filename back to the exact original bytes, in case the user needs to feed
+the data into a system that requires the verbatim key. The translation is
+also losslessly recoverable from the encoded filename alone — `KEYMAP` is a
+convenience, not a correctness dependency.
+
+## Per-Adapter Format
+
+### DynamoDB
+
+```
+dynamodb/
+└── orders/
+    ├── _schema.json
+    └── items/
+        ├── customer-7421/
+        │   ├── 2026-04-29T12:00:00Z.json
+        │   └── 2026-04-29T13:15:42Z.json
+        ├── customer-7422/
+        │   └── 2026-04-29T09:00:00Z.json
+        └── b64.AAECAw../single.json     # binary partition key
+```
+
+`_schema.json`:
+
+```json
+{
+  "format_version": 1,
+  "table_name": "orders",
+  "creation_time_iso": "2026-03-12T08:14:00Z",
+  "primary_key": {
+    "hash_key": {"name": "customer_id", "type": "S"},
+    "range_key": {"name": "order_ts", "type": "S"}
+  },
+  "global_secondary_indexes": [
+    {
+      "name": "by_status",
+      "key_schema": [
+        {"name": "status", "type": "S"},
+        {"name": "order_ts", "type": "S"}
+      ],
+      "projection": {"type": "INCLUDE", "non_key_attributes": ["total_amount"]}
+    }
+  ],
+  "attribute_definitions": [
+    {"name": "customer_id", "type": "S"},
+    {"name": "order_ts",   "type": "S"},
+    {"name": "status",     "type": "S"},
+    {"name": "total_amount", "type": "N"}
+  ],
+  "billing_mode": "PAY_PER_REQUEST"
+}
+```
+
+This is structurally identical to what `DescribeTable` returns; tools that
+already speak DynamoDB JSON ingest it without translation.
+
+`items/<pk>/<sk>.json`:
+
+```json
+{
+  "customer_id": {"S": "customer-7421"},
+  "order_ts":    {"S": "2026-04-29T12:00:00Z"},
+  "total_amount": {"N": "129.50"},
+  "status":       {"S": "shipped"},
+  "items":        {"L": [
+    {"M": {"sku": {"S": "abc"}, "qty": {"N": "2"}}}
+  ]}
+}
+```
+
+This is the **wire-format DynamoDB item** — the same shape `GetItem` returns
+to a real DynamoDB SDK. Restoring into AWS DynamoDB is a literal
+`PutItem` per file. A failed table can be partially recovered by hand-
+editing one item and re-feeding it.
+
+GSIs are **not materialized** under the dump because they are derivable
+from `_schema.json` plus the base item set. Re-creating the table from
+`_schema.json` and replaying the items rebuilds the GSI; this is what AWS
+itself does on table import. (Materializing GSIs would also create
+consistency hazards: the dump's GSI rows would be at the same read TS as
+the base rows but rewriting them on restore could conflict with the
+restore-side OCC, see "Read-Side Consistency".)
+
+### S3
+
+```
+s3/
+└── photos/
+    ├── _bucket.json
+    ├── 2026/
+    │   └── 04/
+    │       └── 29/
+    │           ├── img.jpg
+    │           ├── img.jpg.metadata.json
+    │           ├── thumbnails/
+    │           │   └── img-128x128.jpg
+    │           └── thumbnails/img-128x128.jpg.metadata.json
+    └── archive/
+        └── manifest.csv
+```
+
+The S3 object body sits at its natural path — every byte that the
+elastickv S3 adapter would have streamed through `streamObjectChunks` for a
+GET is reassembled in order and written out as a single regular file.
+
+A sidecar `<object>.metadata.json` carries the parts of `s3ObjectManifest`
+that S3 itself exposes via headers (`Content-Type`, `Content-Encoding`,
+`Cache-Control`, `Content-Disposition`, user-defined `x-amz-meta-*`,
+`ETag`, `LastModified`):
+
+```json
+{
+  "format_version": 1,
+  "etag":             "\"d41d8cd98f00b204e9800998ecf8427e\"",
+  "size_bytes":       1024576,
+  "last_modified":    "2026-04-29T12:34:56.789Z",
+  "content_type":     "image/jpeg",
+  "content_encoding": "",
+  "cache_control":    "max-age=3600",
+  "user_metadata":    {"camera": "fx30"}
+}
+```
+
+Multipart parts are **flattened on dump**: the user gets the assembled
+object, not the per-part fragments. Tools like `aws s3 cp --recursive`
+work on the dump directory tree directly. In-flight multipart uploads
+(`!s3|upload|meta|`, `!s3|upload|part|`, blob chunks not yet committed by
+`CompleteMultipartUpload`) are excluded by default; an
+`--include-incomplete-uploads` dump flag emits them under
+`s3/<bucket>/_incomplete_uploads/<uploadID>/`.
+
+`_bucket.json`:
+
+```json
+{
+  "format_version": 1,
+  "name": "photos",
+  "creation_time_iso": "2026-01-15T10:00:00Z",
+  "policy_json": null,
+  "acl": "private",
+  "versioning": "Disabled"
+}
+```
+
+Generation handling: only the live (latest) generation per bucket is
+included. Pre-generation orphans (objects under
+`!s3|blob|<bucket>|<oldGen>|...`) are deliberately omitted — they exist on
+disk only because GC has not run yet, and replaying them into a fresh
+elastickv would resurrect deleted state. They land under
+`_orphans/<oldGen>/` only when `--include-orphans` is passed.
+
+### Redis
+
+```
+redis/
+└── db_0/
+    ├── strings/
+    │   ├── session%3Aabc123.bin             # SET session:abc123 …
+    │   └── counter%3Aglobal.bin             # SET counter:global "42"
+    ├── strings_ttl.json                     # { "session%3Aabc123": 1735689600000, ... }
+    ├── hashes/
+    │   └── user%3A1.json
+    ├── lists/
+    │   └── queue%3Ajobs.json
+    ├── sets/
+    │   └── tags%3Apost1.json
+    ├── zsets/
+    │   └── leaderboard.json
+    └── streams/
+        └── events.jsonl
+```
+
+Redis values are encoded so that `redis-cli --pipe` (or the equivalent in
+any client library) can replay them without elastickv.
+
+- `strings/<key>.bin` is the **raw value bytes** — Redis strings are
+  binary-safe, so JSON wrapping would force base64 and lose the property
+  that `cat strings/<key>.bin` produces the original payload. TTL is in
+  the sidecar `strings_ttl.json` keyed by the same encoded filename;
+  values are absolute Unix-millis expirations to avoid clock skew on
+  restore.
+- `hashes/<key>.json`:
+  ```json
+  {"format_version": 1, "fields": {"name": "alice", "age": "30"}, "expire_at_ms": null}
+  ```
+- `lists/<key>.json`:
+  ```json
+  {"format_version": 1, "items": ["job-1", "job-2", "job-3"], "expire_at_ms": null}
+  ```
+  Order is left-to-right (LPUSH `[3,2,1]` produces `["3","2","1"]`).
+- `sets/<key>.json`:
+  ```json
+  {"format_version": 1, "members": ["red", "green", "blue"], "expire_at_ms": null}
+  ```
+- `zsets/<key>.json`:
+  ```json
+  {"format_version": 1, "members": [
+    {"member": "alice", "score": 100.0},
+    {"member": "bob",   "score":  85.5}
+  ], "expire_at_ms": null}
+  ```
+- `streams/<key>.jsonl`: one entry per line, in stream order:
+  ```
+  {"id": "1714400000000-0", "fields": {"event": "login",  "user": "alice"}}
+  {"id": "1714400000001-0", "fields": {"event": "logout", "user": "alice"}}
+  ```
+  followed (optionally) by a trailing meta line:
+  ```
+  {"_meta": true, "length": 2, "last_ms": 1714400000001, "last_seq": 0}
+  ```
+  The meta line lets a restore tool seed `XADD` IDs without re-deriving
+  them from the entries.
+- HyperLogLog (`!redis|hll|<key>`) is a binary opaque sketch; written under
+  `hll/<key>.bin` byte-for-byte. A non-elastickv consumer that does not
+  know HLL can still copy the bytes; a restore back into elastickv (or a
+  Redis-compatible HLL implementation) reads them as-is.
+
+Bitmaps and binary strings flow through the `strings/` path and remain
+raw bytes.
+
+### SQS
+
+```
+sqs/
+└── orders-fifo.fifo/
+    ├── _queue.json
+    └── messages.jsonl
+```
+
+`_queue.json`:
+
+```json
+{
+  "format_version":            1,
+  "name":                      "orders-fifo.fifo",
+  "fifo":                      true,
+  "content_based_deduplication": false,
+  "visibility_timeout_seconds": 30,
+  "message_retention_seconds": 345600,
+  "delay_seconds":             0,
+  "redrive_policy":            null
+}
+```
+
+`messages.jsonl` — one record per line, ordered by `(SendTimestampMillis,
+SequenceNumber, MessageId)`:
+
+```
+{"message_id":"abc-1","body":"hello","md5_of_body":"…","sender_id":"…","send_timestamp_millis":1714400000000,"available_at_millis":1714400000000,"visible_at_millis":0,"receive_count":0,"first_receive_millis":0,"current_receipt_token":null,"queue_generation":7,"message_group_id":"orders","message_deduplication_id":"abc-1","sequence_number":42,"dead_letter_source_arn":null,"message_attributes":{}}
+```
+
+The schema is the dump-time projection of `sqsMessageRecord`
+(`adapter/sqs_messages.go:80`) with **all visibility-state fields present
+but zeroed**. A restored queue starts with every message visible — which
+matches what AWS SQS does when a queue is rehydrated from a backup. If the
+operator explicitly requests `--preserve-visibility`, the live
+`visible_at_millis` / `current_receipt_token` are kept, but this is opt-in
+because resuming with a stale receipt token mid-flight is almost never
+the right behavior.
+
+JSONL was chosen over per-message files for two reasons: (1) production
+queues commonly hold tens of thousands of messages, and one file per
+message inflates inode pressure and `tar` time; (2) message order is
+intrinsic to the queue's semantics (especially FIFO), and a single
+ordered file makes that order explicit and trivially preservable.
+
+In-flight side records (`!sqs|msg|dedup|`, `!sqs|msg|group|`,
+`!sqs|msg|byage|`, `!sqs|msg|vis|`, `!sqs|queue|tombstone|`) are derivable
+from the queue config + message records and are not dumped. The dedup
+window will reset on restore; this is documented as expected behavior.
+Operators who need exactness pass `--include-sqs-side-records`, which
+emits an `_internals/` subdirectory of newline-delimited records.
+
+## MANIFEST.json
+
+```json
+{
+  "format_version":   1,
+  "elastickv_version": "v1.7.3",
+  "cluster_id":       "ek-prod-us-east-1",
+  "commit_ts":        4517352099840000,
+  "wall_time_iso":    "2026-04-29T15:42:11.094Z",
+  "shards": [
+    {"group_id": "default", "raft_leader_at_dump": "n2", "applied_index": 18432021}
+  ],
+  "adapters": {
+    "dynamodb": {"tables":  ["orders", "users", "audit"]},
+    "s3":       {"buckets": ["photos", "logs"]},
+    "redis":    {"databases": [0, 1]},
+    "sqs":      {"queues":  ["orders-fifo.fifo", "notifications"]}
+  },
+  "exclusions": {
+    "include_incomplete_uploads": false,
+    "include_orphans":            false,
+    "preserve_sqs_visibility":    false,
+    "include_sqs_side_records":   false
+  },
+  "checksum_algorithm": "sha256",
+  "encoded_filename_charset": "rfc3986-unreserved-plus-percent",
+  "key_segment_max_bytes": 240
+}
+```
+
+`MANIFEST.json` is **the only file a restore tool must read first**.
+Everything else is decoded from its on-disk path and contents.
+
+## Read-Side Consistency
+
+The dump must capture state at a single cluster-wide commit-ts so that:
+
+- A DynamoDB item and the GSI row it would produce, if both were dumped,
+  would agree.
+- An S3 object's manifest at `!s3|obj|head|` and its blob chunks at
+  `!s3|blob|...` correspond to the same upload generation.
+- A Redis transaction's writes (multiple keys committed together) all
+  appear or all do not appear.
+- An SQS message's `data` row and its `vis`/`byage` index entries
+  (when included) reflect the same FIFO sequence number.
+
+Implementation:
+
+1. The backup tool calls a new admin RPC `Admin.BeginBackup` that returns
+   a cluster-wide `read_ts` chosen by the same path that lease reads use
+   (`kv/lease_state.go`, see also
+   `2026_04_20_implemented_lease_read.md`). The `read_ts` is held open
+   for the duration of the dump by registering it with the **active
+   timestamp tracker** (`kv/active_timestamp_tracker.go`) so
+   `kv/compactor.go` cannot retire MVCC versions the dump still depends
+   on.
+2. Every per-adapter scan (`kv.ShardedCoordinator.ScanRange`) is issued
+   `at_ts = read_ts`. This is exactly the path
+   lease reads already use; no new code path through MVCC is introduced.
+3. `Admin.EndBackup` releases the tracker registration. A
+   tool-side crash leaves the tracker entry behind for at most
+   `backup_ts_ttl` (default 30 minutes, configurable via the same admin
+   RPC), after which the registration auto-expires so the compactor is
+   not blocked indefinitely.
+
+The dump is therefore a **point-in-time snapshot** of the user-visible
+keyspace, not a streaming tail.
+
+### Cross-shard consistency
+
+A multi-shard deployment serves different key ranges from different Raft
+groups. `BeginBackup` propagates the same `read_ts` to every group;
+`ScanRange` at `read_ts` is the same OCC visibility check on every group.
+Because HLC physical ceilings are coordinated through the default group
+(`kv/hlc.go`), the chosen `read_ts` is admissible on every group as long
+as it is below each group's last-applied commit-ts at the moment of the
+call — which `BeginBackup` enforces by re-reading
+`max(group_commit_ts)` and adding a small skew buffer (default 50 ms)
+matching the existing TSO buffer.
+
+## Internal-State Handling
+
+Internal keys are partitioned into three classes:
+
+| Class | Examples | Backup behavior |
+|---|---|---|
+| **Re-derivable from user data + config** | DynamoDB GSI rows; S3 route catalog (`!s3route|`); Redis TTL scan index (`!redis|ttl|`); SQS visibility / age / dedup / group / tombstone indexes; route catalog under default group | Excluded by default. Restore re-builds them as user data is replayed. |
+| **Per-cluster operational state** | HLC physical ceiling; Raft term/index/conf state; FSM marker files (`raft-engine`, `EKVR`/`EKVM`/`EKVW` magic files in `internal/raftengine/etcd/persistence.go`); write conflict counter | Never dumped. They belong to the cluster, not the data. A restore initializes them fresh. |
+| **In-flight transactional state** | `!txn|` intent / lock / resolver records (`kv/txn_keys.go`, `kv/txn_codec.go`); pending S3 multipart uploads | Excluded by default. Optionally dumped under `_internals/` for forensics, but never re-applied by the restore path — replaying intents from a stale read_ts can resurrect aborted transactions. |
+
+This split is what makes the backup safe across versions: the only thing
+encoded in the dump is information the user could in principle have
+reconstructed from API responses (DescribeTable, GetObject, KEYS *, etc.).
+Anything that depends on elastickv's internal physics stays in elastickv.
+
+## Tooling
+
+### Producer: `cmd/elastickv-backup`
+
+A new CLI under `cmd/elastickv-backup/`. Streams the dump out as a
+directory tree on local disk, or as `tar` / `tar+zstd` to stdout for
+piping straight to S3 / GCS / a tape device.
+
+```
+elastickv-backup dump \
+  --address     127.0.0.1:50051 \
+  --output-dir  /backups/2026-04-29 \
+  [--adapter dynamodb,s3,redis,sqs] \
+  [--scope    dynamodb=orders,users] \
+  [--scope    s3=photos] \
+  [--include-incomplete-uploads] \
+  [--include-orphans] \
+  [--preserve-sqs-visibility] \
+  [--include-sqs-side-records] \
+  [--checksums sha256]
+```
+
+Internally it runs:
+
+```
+BeginBackup → ListAdaptersAndScopes → ScanRange (per scope, at read_ts)
+            → encode-and-write per adapter → CHECKSUMS → MANIFEST.json
+            → EndBackup
+```
+
+The producer **does not need access to the leader** — it issues lease
+reads. It does need network reach to every Raft group; for multi-shard
+deployments it scans groups in parallel.
+
+### Consumer: `cmd/elastickv-restore`
+
+```
+elastickv-restore apply \
+  --address    127.0.0.1:50051 \
+  --input-dir  /backups/2026-04-29 \
+  [--adapter dynamodb,s3,redis,sqs] \
+  [--scope    dynamodb=orders] \
+  [--mode replace|merge|skip-existing] \
+  [--rate-limit 5000ops/s]
+```
+
+`replace` deletes the target scope before re-importing; `merge`
+upserts; `skip-existing` only writes keys not already present.
+
+The consumer talks to the same public adapter endpoints (PutItem,
+PutObject, SET / HSET / RPUSH / SADD / ZADD / XADD, SendMessage). It does
+**not** write internal keys directly. This is what guarantees that a
+restore exercises the same code paths a real client would, and that any
+future change to internal layout does not break old backups: as long as
+the public protocol still accepts the operation, the restore still works.
+
+### External tools
+
+The format is designed to be extractable without elastickv:
+
+- DynamoDB: `aws dynamodb create-table --cli-input-json _schema.json` and
+  then `aws dynamodb put-item --item @items/<pk>/<sk>.json` per file.
+- S3: `aws s3 sync s3/<bucket>/ s3://target-bucket/`. The metadata
+  sidecars are reapplied with a one-pass script that maps
+  `<obj>.metadata.json` to `--metadata` / `--content-type` / etc.
+- Redis: a 100-line shell script over `find redis/db_0/strings -name '*.bin' -exec redis-cli -x SET …`,
+  with similar one-liners per type.
+- SQS: `jq -c . messages.jsonl | xargs -n1 aws sqs send-message --message-body …`.
+
+These are intentionally one-liners. If they require a 500-line bespoke
+parser, the format has failed its goal.
+
+## Trade-offs
+
+### Benefits
+
+- **Vendor-independent recovery**. The cluster could be permanently
+  unavailable and the user can still get their data back.
+- **Format auditability**. A regulator or operator can `find | jq` over a
+  dump and verify what is there, in human-readable form.
+- **Cross-system migration**. Migrating off elastickv (or onto it from
+  AWS-shaped sources) is now a per-adapter sync, not a custom rewrite.
+- **Selective restore**. Recovering one DynamoDB item is editing one
+  file and running one PutItem.
+- **Stable across elastickv versions**. The dump format is decoupled
+  from internal magic prefixes and wide-column key layouts, which have
+  changed before and will change again.
+
+### Costs
+
+- **Decoded dumps are larger than the FSM stream.** JSON wrapping,
+  per-record sidecars, percent-encoded filenames, and one-file-per-record
+  for DynamoDB items all bloat on-disk size relative to the Pebble
+  snapshot. Expected overhead: 1.5×–3× depending on adapter and average
+  record size. Acceptable: backups are written rarely and often compress
+  well (tar+zstd on JSON is dense).
+- **Dump time is longer than copying the FSM file.** A logical dump must
+  scan the live keyspace at `read_ts` and re-encode every record, vs. a
+  physical snapshot which is essentially `cp`. Mitigations: per-adapter
+  parallel scans, configurable concurrency, no-op if nothing changed
+  since the last dump (Phase 2).
+- **Restore exercises the public adapter API rather than direct FSM
+  apply.** Slower than restoring an FSM snapshot, but correct under
+  schema/version drift in a way that direct FSM apply is not.
+- **GSIs and side indexes are recomputed on restore.** A correctness win,
+  not a regression — but operators should expect restore to take longer
+  than dump for large secondary-index footprints.
+- **Encoded filenames are not always recognizable.** A SQS message ID
+  containing percent-signs has its filename percent-encoded twice. The
+  `KEYMAP` file mitigates, and JSONL/JSON record contents always carry
+  the original key bytes.
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Dump duration exceeds MVCC retention horizon | `read_ts` registered with `active_timestamp_tracker`; compactor cannot retire its versions; producer exits with a typed error if registration is rejected |
+| Filesystem path collisions between distinct keys | Per-adapter encoding rule documented; SHA-256 prefix fallback for very long segments; `KEYMAP` records the original bytes |
+| Restore writes conflict with live traffic on the target cluster | Restore tool defaults to refusing if the target scope is not empty; `--mode replace` requires explicit confirmation; rate limiter caps OCC pressure |
+| Format drift in the dump format itself | `format_version` on every record schema; restore tool reads `MANIFEST.json` first and refuses to operate on unknown major versions |
+| Sensitive data in dumps | Out of scope; layered with at-rest encryption / signing on top of the dump tarball, not inside record format |
+| Partial dumps from producer crash | Producer writes `MANIFEST.json` **last**; restore refuses dumps without a manifest; a partial directory tree is recognizable as such and ignored by tooling |
+
+## Implementation Phases
+
+### Phase 1 — Dump producer for read paths
+
+Scope: backup-side only. No restore. Targeted at giving operators a
+trustworthy off-cluster artifact even before the restore tool is fully
+written.
+
+- New admin RPC pair `BeginBackup` / `EndBackup` on `proto/admin.proto`
+  registering with `kv/active_timestamp_tracker.go`.
+- New tool `cmd/elastickv-backup/` performing `BeginBackup` →
+  per-adapter `ScanRange(at_ts)` → encode → write directory tree → emit
+  `MANIFEST.json` and `CHECKSUMS` last → `EndBackup`.
+- Per-adapter encoders:
+  - `internal/backup/dynamodb.go` — items + `_schema.json`.
+  - `internal/backup/s3.go` — manifest reassembly into single object
+    files, sidecar metadata.
+  - `internal/backup/redis.go` — strings/hashes/lists/sets/zsets/streams
+    with the layout above.
+  - `internal/backup/sqs.go` — `_queue.json` + `messages.jsonl`.
+- Filename encoding lives in `internal/backup/filename.go` with shared
+  unit tests for round-trip safety.
+- Documentation: `docs/operations/backup_restore.md` runbook (separate
+  PR after this design lands).
+
+### Phase 2 — Restore consumer
+
+Scope: re-apply a Phase 1 dump into a running cluster.
+
+- `cmd/elastickv-restore/` driving public adapter endpoints.
+- Mode flags `replace` / `merge` / `skip-existing`.
+- Per-adapter restore drivers reuse the existing client SDKs
+  (`cmd/client/`, the AWS SDK for DynamoDB/S3/SQS, `redis-cli`-style
+  pipelined writer for Redis).
+- Idempotence under retry — restore is a stream of public mutations,
+  each of which the adapter already protects with OCC; producer-side
+  ordering of operations within a single record (e.g., `XADD` order
+  within a stream) is preserved by the dump format.
+
+### Phase 3 — Incremental / scoped backups
+
+Scope: out of this proposal; mentioned only to draw the boundary.
+
+- CDC-style incremental backup: a follow-up design that records mutations
+  between two `read_ts` values and dumps the delta in the same
+  per-adapter format under a `delta/<from-ts>-<to-ts>/` subtree.
+- Concurrent multi-cluster fan-out (one logical backup spanning shards
+  on different physical clusters) — depends on the `Distribution`
+  control plane being fan-out-aware (see
+  `2026_04_27_proposed_keyviz_cluster_fanout.md`).
+
+## Required Tests
+
+### P0
+
+| Test | Verifies |
+|---|---|
+| `TestFilenameEncodingRoundTrip` | Random bytes → encode → decode → original; long segments overflow into SHA-256 fallback; binary keys take the `b64.` path |
+| `TestDynamoDumpItemMatchesGetItem` | An item dumped to `items/<pk>/<sk>.json` matches what the DynamoDB adapter would return for `GetItem` at the same `read_ts` |
+| `TestS3DumpReassemblesObject` | Multipart object stored across N parts and M chunks per part round-trips bytewise to a single dump file; metadata sidecar matches manifest |
+| `TestRedisDumpAllTypes` | One key per type (string, hash, list, set, zset, stream, hll) round-trips through dump + the Phase 2 restore back to a live store |
+| `TestSQSDumpFifoOrderPreserved` | Messages with interleaved `MessageGroupId` are emitted in `(send_ts, sequence_number, message_id)` order; visibility-state fields zeroed by default |
+| `TestManifestVersionGate` | Restore with `format_version > current` fails fast with a typed error; same-major-newer-minor allowed; older-major refused with a clear message |
+| `TestBeginBackupBlocksCompactor` | Open a `BeginBackup`, force a compaction round, confirm MVCC versions for the registered `read_ts` are retained |
+
+### P1
+
+| Test | Verifies |
+|---|---|
+| `TestProducerCrashLeavesNoManifest` | Killing the producer mid-dump leaves the partial tree without `MANIFEST.json`; restore refuses; `EndBackup` TTL releases the tracker |
+| `TestRestoreReplaceMode` | `replace` empties the target scope before re-importing; live traffic is rejected during the replace window |
+| `TestCrossAdapterConsistency` | Dump captures a DynamoDB write and an S3 PutObject committed in the same transaction at TS T; both appear in the dump or neither does |
+| `TestExternalToolReplay` | Generated `aws s3 sync` / `aws dynamodb put-item` / `redis-cli --pipe` scripts (run in CI against MinIO / a local DynamoDB / a real Redis) reproduce the dumped state on a non-elastickv target |
+| `TestLongKeySHA256Fallback` | A 1 KiB key encodes to `<sha256-prefix-32>__<truncated>`; `KEYMAP` records the original; round-trip restore still hits the right key |
+| `TestSQSPreserveVisibilityFlag` | Default leaves messages immediately visible on restore; `--preserve-visibility` retains in-flight receipts |
+
+### P2
+
+| Test | Verifies |
+|---|---|
+| `FuzzFilenameEncoding` | Filename encoder/decoder never panics and is bijective on arbitrary byte input |
+| `BenchmarkDumpThroughputPerAdapter` | Establishes baselines so the Phase 3 incremental design has a regression target |
+
+## References
+
+- `2026_04_14_implemented_etcd_snapshot_disk_offload.md` — the FSM
+  snapshot path this proposal *does not* touch.
+- `2026_04_20_implemented_lease_read.md` — the consistent read primitive
+  used to pin `read_ts`.
+- `kv/active_timestamp_tracker.go` — the mechanism that prevents the
+  compactor from retiring versions an in-flight backup depends on.
+- `internal/s3keys/keys.go`, `kv/shard_key.go`, `adapter/sqs_keys.go`,
+  `store/{hash,list,set,zset,stream}_helpers.go` — the internal key
+  layouts that this format intentionally hides from the backup consumer.
+- `adapter/dynamodb_storage_codec.go`, `adapter/sqs_messages.go`,
+  `adapter/redis_storage_codec.go` — the internal value envelopes
+  (magic-prefixed protobuf/JSON) that the dump format strips before
+  emitting records.

--- a/docs/design/2026_04_29_proposed_logical_backup.md
+++ b/docs/design/2026_04_29_proposed_logical_backup.md
@@ -1342,10 +1342,40 @@ written.
        message GetNodeVersionResponse { string node_version = 1; }
        ```
        The admin server handling `BeginBackup` issues `GetNodeVersion`
-       to every peer in `AdminServer.members` (and to itself); each
-       peer responds with its compiled-in version constant. The
-       handler refuses `BeginBackup` if any peer returns a version
-       below N or fails to respond within `--begin-backup-deadline`.
+       to **the live cluster member set, not the static
+       `AdminServer.members` bootstrap seed**. `AdminServer.members`
+       (`adapter/admin_grpc.go:64`) is set once at construction
+       (`NewAdminServer(self, members)` at line 89) and never updated
+       — a node added later via `AddVoter` would not appear in it,
+       so a fan-out limited to the seed silently misses
+       dynamically-added nodes (which during a rolling upgrade are
+       exactly the ones likely to be running an older version).
+
+       `BeginBackup` instead reuses the existing `snapshotMembers`
+       helper (`adapter/admin_grpc.go:158`) — the same path
+       `GetClusterOverview` uses today — which unions the seed with
+       members discovered from each group's `Configuration()`. The
+       fan-out target is therefore the live cluster, not the
+       startup snapshot.
+
+       Each `GetNodeVersion` dial uses `--begin-backup-deadline` as
+       a **per-peer** budget (the fan-out is concurrent, one
+       goroutine per peer), so a 100-node cluster with one slow peer
+       delays by one deadline period, not N × deadline. Each peer
+       responds with its compiled-in version constant. The handler
+       refuses `BeginBackup` if any peer returns a version below N
+       or fails to respond within the deadline.
+
+       The two failure cases — "old version" and "unreachable" —
+       both block backups, but the error message must
+       **distinguish** them in its detail string so operators can
+       diagnose without out-of-band investigation:
+
+       - `FailedPrecondition: node X reports version v0.9.0; minimum is v1.0.0`
+         (gate triggered by an old version)
+       - `FailedPrecondition: node X did not respond within 5s`
+         (gate triggered by unreachability)
+
        This avoids restructuring `GetRaftGroups` (which today returns
        one row per *group* keyed by local engine, not per *member*),
        while still giving `BeginBackup` a fleet-wide view.
@@ -1355,12 +1385,16 @@ written.
        `GetNodeVersion(leader)` so the admin UI can surface mixed-
        version groups directly. This field is informational and not
        used for the gate decision (the gate uses the dedicated fan-
-       out so it covers followers too).
-
-       If any member reports a version older than N or is
-       unreachable, `BeginBackup` returns `FailedPrecondition` with a
-       clear message ("upgrade node X to vN before backups can be
-       taken").
+       out so it covers followers too). To keep `GetRaftGroups`
+       responsive — it is a synchronous local-state read today
+       (`adapter/admin_grpc.go:382-416`) — the per-leader
+       `GetNodeVersion` dial is made **asynchronously** with a
+       500 ms timeout per leader; failures (unreachable leader,
+       deadline hit) populate `leader_node_version = ""` rather than
+       blocking the response. The version is also cached locally
+       on the admin server with a short TTL (default 10 s) so
+       repeated `GetRaftGroups` calls within a polling window do not
+       fan out repeatedly.
 
     Releases N and N+1 may be the same calendar release if the
     operator is willing to enforce a fleet-wide upgrade window
@@ -1475,7 +1509,9 @@ Scope: out of this proposal; mentioned only to draw the boundary.
 | `TestExpectedKeysBaselineCountOnlyScan` | The baseline pass uses the new `ShardStore.ScanKeysAt`; verify per-key allocation is bounded (no value materialization) on a 1M-key scope and that existing `ScanAt` callers are bytewise-unchanged |
 | `TestExpectedKeysBaselineRunsAfterShardCatchup` | Force shard B to lag at `BeginBackup` time; verify the baseline scan blocks until step 2 (catch-up) completes for B, so B's `expected_keys[i].key_count` is the true count at `read_ts` rather than the partial-pre-catch-up count |
 | `TestForwardCompatUnknownFSMTag` | A release-N FSM receiving a synthetic `0x03`-tagged entry (representing a future `BackupPin` from a release-N+1 leader) returns nil from `Apply` and emits an `unknown_fsm_tag` warning, with no apply-loop stall and no FSM mutation. Tags `0x10+` (outside the reserved range) still error so the forward-compat door is bounded |
-| `TestBeginBackupGatesOnMinVersion` | The `BeginBackup` handler fans out `GetNodeVersion` to every peer in `AdminServer.members`. If any peer returns `node_version < N` (or is unreachable within `--begin-backup-deadline`), the call returns `FailedPrecondition` and proposes no `BackupPin` entries on any group; once every peer reports `node_version ≥ N`, the same call succeeds. A 3-node cluster where node B is at v(N-1) while A and C are at vN is the canonical fixture |
+| `TestBeginBackupGatesOnMinVersion` | The `BeginBackup` handler derives its fan-out target from `snapshotMembers` (live `Configuration()` union, not the static `AdminServer.members` seed) and issues `GetNodeVersion` per peer concurrently. If any peer returns `node_version < N` or is unreachable within `--begin-backup-deadline`, the call returns `FailedPrecondition` with an error message that distinguishes the two cases ("reports version vX" vs. "did not respond within Ns") and proposes no `BackupPin` entries on any group; once every live member reports `node_version ≥ N`, the same call succeeds |
+| `TestBeginBackupGatesIncludesDynamicallyAddedNodes` | Start a 3-node cluster, add a 4th node at `v(N-1)` via `AddVoter` after `AdminServer` startup (so it is NOT in the bootstrap `members` seed), then call `BeginBackup`; the gate fails with the new node identified in the error. The previous seed-only design would have falsely passed |
+| `TestGetRaftGroupsLeaderVersionAsync` | `GetRaftGroups` returns within local-snapshot latency even when a leader is unreachable; `leader_node_version` is empty string in that case. Verify the 500 ms per-leader timeout and the 10 s response cache prevent repeated fan-outs across rapid polls |
 | `TestSnapshotEveryReadsFromEngine` | A node started with `ELASTICKV_RAFT_SNAPSHOT_COUNT=5000` reports `Engine.SnapshotEvery() == 5000`; `BeginBackup` uses 5000 (not the default 10000) when computing remaining headroom |
 | `TestRenewBackupRetriesLeaderElection` | Force a leader election mid-`RenewBackup`; the admin server retries `BackupExtend` up to 3 times with 500ms backoff and succeeds once the new leader is established, without aborting the dump |
 | `TestPinWithDeadlineExpiry` | `PinWithDeadline(ts, now+100ms)` is auto-released by the sweeper after the deadline; compactor unblocked; `backup_pin_expired` log emitted |

--- a/docs/design/2026_04_29_proposed_logical_backup.md
+++ b/docs/design/2026_04_29_proposed_logical_backup.md
@@ -135,7 +135,7 @@ backup-<utc-timestamp>-<cluster-id>-<commit-ts>/
 ├── redis/
 │   └── db_<n>/
 │       ├── strings/<key>.bin
-│       ├── strings_ttl.json
+│       ├── strings_ttl.jsonl
 │       ├── hashes/<key>.json
 │       ├── lists/<key>.json
 │       ├── sets/<key>.json
@@ -192,11 +192,37 @@ Rules:
   per message (would be millions of small files); they live in a single
   `messages.jsonl`. Same rationale for Redis stream entries.
 
-A single `KEYMAP` file at each adapter scope root translates the encoded
-filename back to the exact original bytes, in case the user needs to feed
-the data into a system that requires the verbatim key. The translation is
-also losslessly recoverable from the encoded filename alone — `KEYMAP` is a
-convenience, not a correctness dependency.
+`KEYMAP.jsonl` at each adapter scope root translates the encoded
+filename back to the exact original bytes, in case the user needs to
+feed the data into a system that requires the verbatim key. JSONL
+(one mapping per line, never loaded fully) is used so the file scales
+to millions of keys without becoming a memory bottleneck on either the
+producer or a downstream consumer. The translation is also losslessly
+recoverable from the encoded filename alone — `KEYMAP.jsonl` is a
+convenience, not a correctness dependency. A consumer that does not
+need it can ignore it entirely.
+
+### S3 path collisions (file vs. directory)
+
+S3 permits two objects whose keys are `path/to` and `path/to/obj`
+simultaneously. POSIX filesystems cannot represent both — `path/to`
+cannot be both a regular file and a directory. The dump producer
+detects this case at scan time:
+
+- **Pure-leaf case** (the more common case): the key without `/obj`
+  suffix is the only object → write at the natural path, no collision.
+- **Collision case**: both `path/to` and `path/to/obj` exist in the
+  same bucket at the same generation. The shorter key (the one that
+  would force a regular file on a path that must also be a directory)
+  is renamed to `path/to.elastickv-leaf-data`, with the rename
+  recorded in `s3/<bucket>/KEYMAP.jsonl`. The sidecar follows the
+  same renamed base: `path/to.elastickv-leaf-data.elastickv-meta.json`.
+- The collision-handling rule is documented at dump time in
+  `MANIFEST.json` (`s3_collision_strategy: "leaf-data-suffix"`) so a
+  restore tool reverses it without guessing.
+
+The producer emits a structured warning per collision so operators
+can spot dataset shapes that benefit from object-key normalization.
 
 ## Per-Adapter Format
 
@@ -273,6 +299,44 @@ This is the **wire-format DynamoDB item** — the same shape `GetItem` returns
 to a real DynamoDB SDK. Restoring into AWS DynamoDB is a literal
 `PutItem` per file. A failed table can be partially recovered by hand-
 editing one item and re-feeding it.
+
+#### One-file-per-item vs. bundle mode
+
+The default — one item per file under `items/<pk>/<sk>.json` — is a
+**deliberate, requirement-driven choice**, not an oversight. It is
+what makes "recover one row by editing one file and running one
+PutItem" trivially true, which is the whole point of a
+vendor-independent dump. The cost is filesystem overhead: a 50-million-
+item table emits 50 million inodes. On most modern filesystems
+(ext4/xfs/zfs/apfs) this is fine for write-once-and-tar dumps but
+slow for live filesystem operations.
+
+For tables where the inode count is the binding constraint, the
+producer accepts an opt-in `--dynamodb-bundle-mode jsonl[:size=64MiB]`
+that emits items as `items/data-<part-id>.jsonl` instead, packed up
+to a configurable per-file size budget:
+
+```
+dynamodb/orders/
+├── _schema.json
+└── items/
+    ├── data-00001.jsonl   # one item per line, items/data-00001.jsonl ≤ 64 MiB
+    ├── data-00002.jsonl
+    └── data-00003.jsonl
+```
+
+`MANIFEST.json` records the choice (`dynamodb_layout: "per-item" |
+"jsonl"`) so a restore tool dispatches the right reader. The bundle
+mode is an explicit operational decision; the default stays per-file
+because that is the layout the user asked for and the layout that
+makes one-line recovery scripts trivial. Operators are also free to
+post-process a per-item dump into bundles (`find … | xargs cat`)
+without losing any information, so the choice is not load-bearing on
+the format itself.
+
+The producer emits a structured warning when an unbundled scope
+exceeds 1 million items so operators can decide whether to switch
+modes for that table.
 
 GSIs are **not materialized** under the dump because they are derivable
 from `_schema.json` plus the base item set. Re-creating the table from
@@ -362,7 +426,7 @@ redis/
     ├── strings/
     │   ├── session%3Aabc123.bin             # SET session:abc123 …
     │   └── counter%3Aglobal.bin             # SET counter:global "42"
-    ├── strings_ttl.json                     # { "session%3Aabc123": 1735689600000, ... }
+    ├── strings_ttl.jsonl                     # one line per TTL'd key
     ├── hashes/
     │   └── user%3A1.json
     ├── lists/
@@ -381,9 +445,17 @@ any client library) can replay them without elastickv.
 - `strings/<key>.bin` is the **raw value bytes** — Redis strings are
   binary-safe, so JSON wrapping would force base64 and lose the property
   that `cat strings/<key>.bin` produces the original payload. TTL is in
-  the sidecar `strings_ttl.json` keyed by the same encoded filename;
-  values are absolute Unix-millis expirations to avoid clock skew on
-  restore.
+  the sidecar `strings_ttl.jsonl`, one record per line:
+  ```
+  {"key":"session%3Aabc123","expire_at_ms":1735689600000}
+  {"key":"cache%3Akv99","expire_at_ms":1735689610500}
+  ```
+  Values are absolute Unix-millis expirations to avoid clock skew on
+  restore. JSONL (not a single JSON object) is used so producers and
+  consumers stream the file line-by-line; a Redis instance with tens
+  of millions of TTL'd strings would exceed practical memory limits
+  for a single-object form, and Redis itself has no upper bound on
+  the number of TTL'd keys.
 - `hashes/<key>.json`:
   ```json
   {"format_version": 1, "fields": {"name": "alice", "age": "30"}, "expire_at_ms": null}
@@ -505,7 +577,10 @@ emits an `_internals/` subdirectory of newline-delimited records.
   "encoded_filename_charset": "rfc3986-unreserved-plus-percent",
   "key_segment_max_bytes": 240,
   "backup_ts_ttl_ms":   1800000,
-  "s3_meta_suffix":     ".elastickv-meta.json"
+  "s3_meta_suffix":     ".elastickv-meta.json",
+  "s3_collision_strategy": "leaf-data-suffix",
+  "dynamodb_layout":    "per-item",
+  "max_active_backup_pins": 4
 }
 ```
 
@@ -563,22 +638,30 @@ Per-adapter encoders consume `BackupScanner` and emit one record per
 service Admin {
   rpc BeginBackup(BeginBackupRequest) returns (BeginBackupResponse) {}
   rpc EndBackup(EndBackupRequest) returns (EndBackupResponse) {}
+  rpc RenewBackup(RenewBackupRequest) returns (RenewBackupResponse) {}
   rpc ListAdaptersAndScopes(ListAdaptersAndScopesRequest)
       returns (ListAdaptersAndScopesResponse) {}
 }
 
 message BeginBackupRequest {
   // Time-to-live for the read_ts pin on the active timestamp tracker.
-  // If EndBackup is not called within this window the pin is auto-released.
-  // Range: 60s–24h. Default: 30m.
+  // If neither EndBackup nor RenewBackup is called within this window
+  // the pin is auto-released. Range: 60s–24h. Default: 30m.
   uint64 ttl_ms = 1;
 }
 message BeginBackupResponse {
   uint64 read_ts            = 1;
-  bytes  pin_token          = 2;  // opaque, must be passed back to EndBackup
+  bytes  pin_token          = 2;  // opaque, must be passed back to RenewBackup / EndBackup
   uint64 ttl_ms_effective   = 3;
   repeated ShardApplied shards = 4;  // group_id, applied_index at pin time
 }
+
+// RenewBackup extends the deadline for an existing pin. A long-running
+// dump calls this every ttl_ms/3 (producer default) so a multi-hour
+// scan never relies on a single TTL window. The read_ts is preserved
+// across renewals; only the deadline shifts.
+message RenewBackupRequest  { bytes pin_token = 1; uint64 ttl_ms = 2; }
+message RenewBackupResponse { uint64 ttl_ms_effective = 1; }
 
 message EndBackupRequest  { bytes pin_token = 1; }
 message EndBackupResponse {}
@@ -602,7 +685,8 @@ extends the tracker:
 
 ```go
 // kv/active_timestamp_tracker.go (extended)
-func (t *ActiveTimestampTracker) PinWithDeadline(ts uint64, deadline time.Time) *ActiveTimestampToken
+func (t *ActiveTimestampTracker) PinWithDeadline(ts uint64, deadline time.Time) (*ActiveTimestampToken, error)
+func (t *ActiveTimestampToken) Extend(newDeadline time.Time) error
 ```
 
 `PinWithDeadline` records `(id → ts, deadline)`. A single sweeper
@@ -613,6 +697,30 @@ expiry) and is unaffected; only `BeginBackup` uses the deadline path.
 The sweeper logs a structured warning (`backup_pin_expired`) when it
 drops a stuck registration so operators see crashed-producer cases in
 their existing log pipeline.
+
+**Bound on concurrent active backup pins.** To prevent a misbehaving
+or malicious caller from issuing unbounded `BeginBackup` requests and
+holding the compactor open across the whole MVCC retention horizon,
+the tracker carries a hard cap (default `max_active_backup_pins = 4`,
+configurable). When the cap is reached, `PinWithDeadline` returns
+`ErrTooManyActiveBackups` and the admin RPC surfaces it as
+`ResourceExhausted`. Operators raising this cap should size it
+against the GC/compaction headroom — each held pin clamps the
+compactor's `Oldest()` timestamp until released. The cap is
+intentionally small because backups are an operator action, not
+end-user traffic; if four are not enough, something is wrong with
+the orchestration layer and adding pins compounds the underlying
+problem rather than fixing it.
+
+**TTL ceiling and back-pressure.** `ttl_ms` is bounded above by
+`backup_max_ttl_ms` (default 1 h) — a single pin cannot block
+compaction beyond that window even if a buggy caller asks for it.
+For dumps that legitimately need to run longer (e.g. a 50 TiB
+warehouse), the producer renews via `RenewBackup` every `ttl_ms/3`,
+so total dump duration is bounded only by overall MVCC retention
+budget, not by any single TTL choice. The producer surfaces a
+`pin_renewals_total` metric so operators can correlate long-running
+dumps with retention pressure.
 
 ### BeginBackup → EndBackup flow
 
@@ -634,10 +742,16 @@ their existing log pipeline.
    the resulting `pin_token` to the producer.
 4. **Producer scans** all configured adapter scopes via
    `BackupScanner.Next(at_ts=read_ts)`.
-5. **Renew on long dumps**: the producer calls `BeginBackup` again with
-   the same `read_ts` (carrying the existing token) every `ttl_ms / 3`
-   to extend the deadline. A multi-hour dump never relies on a single
-   30-minute pin.
+5. **Renew on long dumps**: the producer calls
+   `RenewBackup(pin_token, ttl_ms)` every `ttl_ms / 3` to extend the
+   deadline. The `read_ts` is preserved across renewals; only the
+   deadline shifts. A multi-hour dump never relies on a single
+   30-minute pin. Renewals are cheap (in-memory map update), and the
+   producer's renewal goroutine logs a critical alert and aborts the
+   dump if a renewal call fails — letting the dump continue past the
+   TTL would silently produce a corrupted artifact (the compactor
+   would have already retired versions the in-flight scan still
+   depends on).
 6. **`EndBackup(pin_token)`** releases the tracker entry. A producer
    crash before EndBackup leaves the entry to be reaped by the sweeper.
 
@@ -688,7 +802,12 @@ elastickv-backup dump \
   [--include-orphans] \
   [--preserve-sqs-visibility] \
   [--include-sqs-side-records] \
-  [--checksums sha256]
+  [--checksums sha256] \
+  [--ttl-ms 1800000] \
+  [--scan-page-size 1024] \
+  [--dynamodb-bundle-mode per-item|jsonl] \
+  [--dynamodb-bundle-size 64MiB] \
+  [--rename-collisions]
 ```
 
 Internally it runs:
@@ -908,7 +1027,10 @@ Scope: out of this proposal; mentioned only to draw the boundary.
 | `TestPinWithDeadlineExpiry` | `PinWithDeadline(ts, now+100ms)` is auto-released by the sweeper after the deadline; compactor unblocked; `backup_pin_expired` log emitted |
 | `TestBeginBackupWaitsForLaggingShard` | Force shard B's `applied_index` to lag; `BeginBackup` polls until it catches up or times out with `FailedPrecondition`; no scan starts in the timeout case |
 | `TestBackupScannerPaging` | A range with > pageSize keys is returned across multiple `ScanAt` pages with no overlap, no gaps; iteration tolerates concurrent writes by completing at the pinned `read_ts` |
-| `TestS3SidecarSuffixCollision` | A user S3 object key ending in `.elastickv-meta.json` is rejected without `--rename-collisions`; with the flag, the rename is recorded in `KEYMAP` |
+| `TestS3SidecarSuffixCollision` | A user S3 object key ending in `.elastickv-meta.json` is rejected without `--rename-collisions`; with the flag, the rename is recorded in `KEYMAP.jsonl` |
+| `TestS3PathFileVsDirectoryCollision` | Bucket holds both `path/to` (object) and `path/to/obj`; producer renames the shorter key to `path/to.elastickv-leaf-data` and records it in `KEYMAP.jsonl`; restore tool reverses it via `MANIFEST.s3_collision_strategy` |
+| `TestBeginBackupTooManyActiveBackups` | Reaching `max_active_backup_pins` returns `ResourceExhausted`; releasing one pin frees a slot for the next request |
+| `TestRenewBackupExtendsDeadline` | `RenewBackup` shifts the deadline; producer's failed-renewal path aborts the dump with a critical log line rather than continuing past the TTL |
 
 ### P1
 

--- a/docs/design/2026_04_29_proposed_logical_backup.md
+++ b/docs/design/2026_04_29_proposed_logical_backup.md
@@ -1,8 +1,35 @@
-# Logical Backup: Per-Adapter Decomposed Snapshot Format
+# Logical Backup: Live Cluster, PIT-Consistent Extraction (Phase 1)
 
 Status: Proposed
 Author: bootjp
 Date: 2026-04-29
+
+## Phasing
+
+This proposal is split into two phases. Each phase has its own
+design doc; both produce dumps in the **same on-disk format** so
+restorers and external tools do not care which phase produced a
+given dump.
+
+| Phase | Doc | Scope |
+|-------|-----|-------|
+| **Phase 0** | [`2026_04_29_proposed_snapshot_logical_decoder.md`](./2026_04_29_proposed_snapshot_logical_decoder.md) | Offline `.fsm` ↔ logical-format directory tree converter. No live cluster, no admin RPCs, no FSM/Raft changes. **Owns the format definition.** Sufficient for single-shard clusters, one-time exports off elastickv, and any use case where the latest available snapshot is a good-enough recovery point. |
+| **Phase 1 (this doc)** | This file | Live, running-cluster extraction with cluster-wide point-in-time consistency across multiple Raft groups. Adds `BeginBackup` / `RenewBackup` / `EndBackup` admin RPCs, replicated `BackupPin` / `Extend` / `Release` Raft FSM commands, version-gated rolling-upgrade safety, expected-keys baseline. Required only when cross-shard PIT consistency or "snapshot now" cadence is needed. |
+
+The format details (per-adapter directory layout, filename encoding,
+`MANIFEST.json` schema, per-adapter record shapes) are defined in the
+Phase 0 doc and **referenced** here. Phase 1 produces the same
+records into the same tree — the only difference is the source of
+the data (a live cluster pinned at a chosen `read_ts`, vs. a
+historical snapshot file) and the `MANIFEST.phase` discriminator
+(`"phase1-live-pinned"` vs. `"phase0-snapshot-decode"`).
+
+This doc focuses on the **live-cluster machinery** unique to
+Phase 1: the read_ts pinning protocol, cross-shard catch-up,
+expected-keys baseline, fan-out version gate, and the FSM-level pin
+propagation that keeps every replica's compactor honest. Format
+content sections are kept here for reviewer convenience but are
+authoritative only as cross-references — Phase 0 owns the format.
 
 ## Background and Problem
 

--- a/docs/design/2026_04_29_proposed_logical_backup.md
+++ b/docs/design/2026_04_29_proposed_logical_backup.md
@@ -660,8 +660,13 @@ field — only `engine`, `router`, `groups`, `clock`, and a raw
 force either an awkward extra field plus `main.go` wiring or a
 roundabout coordinator → router → ShardStore lookup. Putting it on
 `*ShardStore` keeps the scan primitive cohesive with `ScanAt` and
-lets the admin server reach it directly via the existing
-`AdminServer` → `ShardStore` wiring used by `GetRaftGroups`.
+lets the admin server reach it directly. There is **no existing**
+`AdminServer → ShardStore` wiring today — `AdminServer`
+(`adapter/admin_grpc.go:62-82`) holds `self`, `members`, `groups`,
+`now`, and `sampler`, with no `*kv.ShardStore` field; `GetRaftGroups`
+calls `AdminGroup.Status()` and `Configuration()`, never `ShardStore`.
+Phase 1 adds a `*kv.ShardStore` field to `AdminServer` and wires it
+in `main.go` (listed in Phase 1 scope below).
 
 > **Phase 1 also updates `ScanAt`'s doc comment**
 > (`kv/shard_store.go:101–105`) which today warns _"this method is
@@ -1249,12 +1254,31 @@ trustworthy off-cluster artifact even before the restore tool is fully
 written.
 
 - New admin RPCs on `proto/admin.proto`: `BeginBackup` (with `ttl_ms`),
-  `EndBackup`, `RenewBackup`, `ListAdaptersAndScopes` (signatures in
-  "Read-Side Consistency"). Plus a one-field extension to the existing
-  `RaftGroupState` message (`proto/admin.proto:38`): add
-  `string node_version = 7;` populated by each admin handler from the
-  build-time version constant. The `BeginBackup` rolling-upgrade gate
-  reads this field; without it the gate cannot be implemented.
+  `EndBackup`, `RenewBackup`, `ListAdaptersAndScopes`,
+  `GetNodeVersion` (signatures in "Read-Side Consistency" and the
+  "Two-version rolling-upgrade plan" subsection). Plus a one-field
+  extension to the existing `RaftGroupState` message
+  (`proto/admin.proto:38`): add `string leader_node_version = 7;`
+  populated by the admin handler via `GetNodeVersion(leader)` for
+  UI-side visibility (not used for the rolling-upgrade gate, which
+  fans out `GetNodeVersion` to every member directly).
+- New field on `AdminServer` (`adapter/admin_grpc.go:62`): a
+  `*kv.ShardStore` reference, wired in `main.go` so the
+  `BeginBackup` / `BackupScanner` plumbing can reach `ScanAt` and
+  `ScanKeysAt`. There is no existing `AdminServer → ShardStore`
+  connection — the prior round-2 statement that
+  `NewBackupScanner` is reachable "via the existing wiring used by
+  `GetRaftGroups`" was wrong; `GetRaftGroups` only calls
+  `AdminGroup.Status()` and `AdminGroup.Configuration()`, never
+  `ShardStore`.
+- Extend `AdminGroup` interface (`adapter/admin_grpc.go:41`) with a
+  `SnapshotEvery() uint64` method matching the `StatusReader`
+  addition. Without this, the `BeginBackup` handler on
+  `AdminServer` cannot reach `SnapshotEvery()` through the
+  `s.groups[id]` map without a typed assertion fallback. Tests
+  that mock `AdminGroup` (e.g. `adapter/admin_grpc_test.go`) gain
+  one extra method to implement; they can return
+  `defaultSnapshotEvery = 10000` for parity with production.
 - Extend `kv/active_timestamp_tracker.go` with `PinWithDeadline`,
   `Extend`, and the per-second sweeper goroutine that reaps expired
   pins and emits the `backup_pin_expired` structured warning.
@@ -1296,30 +1320,47 @@ written.
        release N before the next step is enabled.
     2. **Release N+1 (BackupPin enabled).** The actual `applyBackupPin`
        / `Extend` / `Release` handlers ship and the admin RPCs are
-       activated. `BeginBackup` itself **gates on every group member
-       reporting `node_version ≥ N`** via `Admin.GetRaftGroups`. The
-       version field does not exist today: `RaftGroupState` in
-       `proto/admin.proto:38-49` carries only `raft_group_id`,
-       `leader_node_id`, `leader_term`, `commit_index`,
-       `applied_index`, and `last_contact_unix_ms`. Phase 1 therefore
-       adds:
+       activated. `BeginBackup` itself **gates on every cluster
+       member reporting `node_version ≥ N`**. The naïve approach of
+       reading versions from `Admin.GetRaftGroups` does **not** work:
+       `GetRaftGroups` (`adapter/admin_grpc.go:382-416`) iterates the
+       *local* `AdminServer`'s registered groups and populates each
+       row from the local engine's `Status()`. A `node_version` field
+       added to `RaftGroupState` would therefore only ever report the
+       admin server's own version — followers on other nodes would
+       not be reflected, and the gate would falsely pass on a
+       partially-upgraded cluster.
+
+       Phase 1 adds a small dedicated RPC that fans out:
        ```protobuf
-       message RaftGroupState {
-         // ... existing fields 1-6 unchanged ...
-         // node_version is the semver of the binary running on this
-         // member, populated from the build-time version stamp.
-         // Empty string on members reporting from a release older
-         // than the field was introduced (treated as "below N" by
-         // the BeginBackup gate so old members force a refusal).
-         string node_version = 7;
+       service Admin {
+         // ... existing RPCs ...
+         rpc GetNodeVersion(GetNodeVersionRequest)
+             returns (GetNodeVersionResponse) {}
        }
+       message GetNodeVersionRequest  {}
+       message GetNodeVersionResponse { string node_version = 1; }
        ```
-       The admin handler populates `node_version` from the local
-       binary's compiled-in version constant; follower versions are
-       surfaced via the existing membership-state propagation path
-       used by `GetRaftGroups`. If any member reports a version older
-       than N, `BeginBackup` returns `FailedPrecondition` with a clear
-       message ("upgrade node X to vN before backups can be taken").
+       The admin server handling `BeginBackup` issues `GetNodeVersion`
+       to every peer in `AdminServer.members` (and to itself); each
+       peer responds with its compiled-in version constant. The
+       handler refuses `BeginBackup` if any peer returns a version
+       below N or fails to respond within `--begin-backup-deadline`.
+       This avoids restructuring `GetRaftGroups` (which today returns
+       one row per *group* keyed by local engine, not per *member*),
+       while still giving `BeginBackup` a fleet-wide view.
+
+       For visibility, `RaftGroupState` is also extended with a
+       `string leader_node_version = 7;` field populated from
+       `GetNodeVersion(leader)` so the admin UI can surface mixed-
+       version groups directly. This field is informational and not
+       used for the gate decision (the gate uses the dedicated fan-
+       out so it covers followers too).
+
+       If any member reports a version older than N or is
+       unreachable, `BeginBackup` returns `FailedPrecondition` with a
+       clear message ("upgrade node X to vN before backups can be
+       taken").
 
     Releases N and N+1 may be the same calendar release if the
     operator is willing to enforce a fleet-wide upgrade window
@@ -1434,7 +1475,7 @@ Scope: out of this proposal; mentioned only to draw the boundary.
 | `TestExpectedKeysBaselineCountOnlyScan` | The baseline pass uses the new `ShardStore.ScanKeysAt`; verify per-key allocation is bounded (no value materialization) on a 1M-key scope and that existing `ScanAt` callers are bytewise-unchanged |
 | `TestExpectedKeysBaselineRunsAfterShardCatchup` | Force shard B to lag at `BeginBackup` time; verify the baseline scan blocks until step 2 (catch-up) completes for B, so B's `expected_keys[i].key_count` is the true count at `read_ts` rather than the partial-pre-catch-up count |
 | `TestForwardCompatUnknownFSMTag` | A release-N FSM receiving a synthetic `0x03`-tagged entry (representing a future `BackupPin` from a release-N+1 leader) returns nil from `Apply` and emits an `unknown_fsm_tag` warning, with no apply-loop stall and no FSM mutation. Tags `0x10+` (outside the reserved range) still error so the forward-compat door is bounded |
-| `TestBeginBackupGatesOnMinVersion` | If any group member's `RaftGroupState.node_version` is `< N` (or empty), `BeginBackup` returns `FailedPrecondition` and proposes no `BackupPin` entries on any group; once all members report `node_version ≥ N`, the same call succeeds. Verify the `proto/admin.proto` `node_version = 7` field is populated from the build-time version constant on every node |
+| `TestBeginBackupGatesOnMinVersion` | The `BeginBackup` handler fans out `GetNodeVersion` to every peer in `AdminServer.members`. If any peer returns `node_version < N` (or is unreachable within `--begin-backup-deadline`), the call returns `FailedPrecondition` and proposes no `BackupPin` entries on any group; once every peer reports `node_version ≥ N`, the same call succeeds. A 3-node cluster where node B is at v(N-1) while A and C are at vN is the canonical fixture |
 | `TestSnapshotEveryReadsFromEngine` | A node started with `ELASTICKV_RAFT_SNAPSHOT_COUNT=5000` reports `Engine.SnapshotEvery() == 5000`; `BeginBackup` uses 5000 (not the default 10000) when computing remaining headroom |
 | `TestRenewBackupRetriesLeaderElection` | Force a leader election mid-`RenewBackup`; the admin server retries `BackupExtend` up to 3 times with 500ms backoff and succeeds once the new leader is established, without aborting the dump |
 | `TestPinWithDeadlineExpiry` | `PinWithDeadline(ts, now+100ms)` is auto-released by the sweeper after the deadline; compactor unblocked; `backup_pin_expired` log emitted |

--- a/docs/design/2026_04_29_proposed_logical_backup.md
+++ b/docs/design/2026_04_29_proposed_logical_backup.md
@@ -141,7 +141,8 @@ backup-<utc-timestamp>-<cluster-id>-<commit-ts>/
 │       ├── sets/<key>.json
 │       ├── zsets/<key>.json
 │       ├── streams/<key>.jsonl
-│       └── hll/<key>.bin                           # HyperLogLog opaque sketch (!redis|hll|<key>)
+│       ├── hll/<key>.bin                           # HyperLogLog opaque sketch (!redis|hll|<key>)
+│       └── hll_ttl.jsonl                           # HLL TTL sidecar (omitted when empty)
 └── sqs/
     └── <queue-name>/
         ├── _queue.json
@@ -438,8 +439,9 @@ redis/
     │   └── leaderboard.json
     ├── streams/
     │   └── events.jsonl
-    └── hll/
-        └── pfcount%3Auniques.bin
+    ├── hll/
+    │   └── pfcount%3Auniques.bin
+    └── hll_ttl.jsonl                         # one line per TTL'd HLL key
 ```
 
 Redis values are encoded so that `redis-cli --pipe` (or the equivalent in
@@ -486,14 +488,29 @@ any client library) can replay them without elastickv.
   ```
   followed (optionally) by a trailing meta line:
   ```
-  {"_meta": true, "length": 2, "last_ms": 1714400000001, "last_seq": 0}
+  {"_meta": true, "length": 2, "last_ms": 1714400000001, "last_seq": 0, "expire_at_ms": null}
   ```
   The meta line lets a restore tool seed `XADD` IDs without re-deriving
-  them from the entries.
+  them from the entries. `expire_at_ms` is null when the stream has no
+  TTL and is the absolute Unix-millis expiry otherwise — Redis streams
+  can have TTLs set with `EXPIRE` / `PEXPIRE` / `PEXPIREAT`, kept in the
+  `!redis|ttl|` scan index by `buildTTLElems` (`adapter/redis.go:2471`).
+  Without `expire_at_ms` here, restoring a TTL'd stream would silently
+  produce a permanent stream.
 - HyperLogLog (`!redis|hll|<key>`) is a binary opaque sketch; written under
   `hll/<key>.bin` byte-for-byte. A non-elastickv consumer that does not
   know HLL can still copy the bytes; a restore back into elastickv (or a
-  Redis-compatible HLL implementation) reads them as-is.
+  Redis-compatible HLL implementation) reads them as-is. HLL keys can
+  also carry a TTL — the adapter reports HLL as `redisTypeString` but
+  stores the TTL in `!redis|ttl|` rather than inline (see comment at
+  `adapter/redis.go:2319-2320`). The TTL therefore lives in a
+  `hll_ttl.jsonl` sidecar at the `db_<n>` root, in the same shape as
+  `strings_ttl.jsonl`:
+  ```
+  {"key":"pfcount%3Auniques","expire_at_ms":1735689600000}
+  ```
+  A key with no TTL has no entry in the sidecar; the sidecar file is
+  absent entirely when no HLL key in the database has a TTL.
 
 Bitmaps and binary strings flow through the `strings/` path and remain
 raw bytes.
@@ -843,6 +860,7 @@ elastickv-backup dump \
   [--include-sqs-side-records] \
   [--checksums sha256] \
   [--ttl-ms 1800000] \
+  [--begin-backup-deadline 5s] \
   [--scan-page-size 1024] \
   [--dynamodb-bundle-mode per-item|jsonl] \
   [--dynamodb-bundle-size 64MiB] \
@@ -971,8 +989,17 @@ parser, the format has failed its goal.
   The restore tool's stream behavior:
   - `--mode replace` — `DEL` the stream, then `XADD` every entry with
     the original ID (matches the dump's `_meta` line).
-  - `--mode skip-existing` — `XADD NOMKSTREAM` only entries whose ID
-    is not already present.
+  - `--mode skip-existing` — for each entry, attempt
+    `XADD <key> <id> ...` and treat the
+    `ERR The ID specified in XADD is equal or smaller than the target
+    stream top item` response as "already present, skip." `NOMKSTREAM`
+    is **not** a skip-existing mechanism — it only suppresses stream
+    creation; it does not skip entries by ID. A `XRANGE <key> <id>
+    <id> COUNT 1` probe per entry is an alternative implementation,
+    but is the same number of round-trips for the worst case (full
+    overlap) and is slower for the common case (small overlap), so
+    the `XADD`-and-handle-error form is preferred. The cost is O(N)
+    in the entry count regardless.
   - `--mode merge` — refuses to operate on streams unless the target
     is empty; emits an error pointing at the conflict. There is no
     sound way to splice mid-stream without losing the original IDs.
@@ -1088,6 +1115,9 @@ Scope: out of this proposal; mentioned only to draw the boundary.
 | `TestSQSPreserveVisibilityFlag` | Default leaves messages immediately visible on restore; `--preserve-visibility` retains in-flight receipts |
 | `TestRedisTTLExpiredKeySkippedByDefault` | A key whose `expire_at_ms` is in the past at restore time is not re-applied without `--preserve-ttl`; with the flag it is re-applied with the original epoch |
 | `TestRedisStreamMergeRejectsNonEmpty` | `--mode merge` on a non-empty target stream errors out; `--stream-merge-strategy=auto-id` falls back to `XADD *` and writes `_id_remap.jsonl` |
+| `TestRedisStreamTTLRoundTrip` | A stream with `PEXPIREAT` round-trips through dump and restore: `expire_at_ms` is captured in the `_meta` line and re-applied so the restored stream expires at the original epoch |
+| `TestRedisHLLTTLRoundTrip` | A TTL'd HLL key surfaces in `hll_ttl.jsonl` and is re-applied on restore via the same `EXPIREAT` path used for strings; no-TTL HLLs leave `hll_ttl.jsonl` absent |
+| `TestRedisStreamSkipExistingHandlesERR` | The restore tool's `skip-existing` path tolerates `ERR The ID specified in XADD is equal or smaller` without aborting the dump; entries with non-conflicting IDs are still applied |
 
 ### P2
 

--- a/docs/design/2026_04_29_proposed_logical_backup.md
+++ b/docs/design/2026_04_29_proposed_logical_backup.md
@@ -39,7 +39,7 @@ The FSM snapshot path (`store/snapshot_pebble.go`, see
 `2026_04_14_implemented_etcd_snapshot_disk_offload.md`) writes the entire
 keyspace as a single opaque stream:
 
-```
+```text
 [magic "EKVPBBL1" :8]
 [lastCommitTS    :8]
 ([keyLen:8][key][valLen:8][val])*
@@ -145,7 +145,7 @@ or migrate the data **without elastickv being part of the recovery path**.
 
 ## Top-Level Layout
 
-```
+```text
 backup-<utc-timestamp>-<cluster-id>-<commit-ts>/
 ├── MANIFEST.json
 ├── CHECKSUMS                         # sha256sum(1)-compatible: "<64-hex>  <relative-path>" per line
@@ -227,14 +227,26 @@ Rules:
   `messages.jsonl`. Same rationale for Redis stream entries.
 
 `KEYMAP.jsonl` at each adapter scope root translates the encoded
-filename back to the exact original bytes, in case the user needs to
+filename back to the exact original bytes when the user needs to
 feed the data into a system that requires the verbatim key. JSONL
-(one mapping per line, never loaded fully) is used so the file scales
-to millions of keys without becoming a memory bottleneck on either the
-producer or a downstream consumer. The translation is also losslessly
-recoverable from the encoded filename alone — `KEYMAP.jsonl` is a
-convenience, not a correctness dependency. A consumer that does not
-need it can ignore it entirely.
+(one mapping per line, never loaded fully) is used so the file
+scales to millions of keys without becoming a memory bottleneck.
+Reversibility depends on the encoding path (Phase 1 follows the
+same rules Phase 0 defines):
+
+- **`%HH` percent-encoded segments and `b64.<base64url>` segments**
+  are losslessly reversible from the filename alone — `KEYMAP.jsonl`
+  is **convenience only** for these.
+- **SHA-fallback segments** (`<sha256-prefix-32>__<truncated-original>`
+  for keys exceeding 240 bytes) and **S3 path-collision renames**
+  (`<obj>.elastickv-leaf-data`) carry insufficient information in
+  the filename alone. For those entries `KEYMAP.jsonl` is a
+  **correctness dependency** — exact-byte recovery is impossible
+  without it.
+
+A consumer that does not need original-byte recovery on SHA-
+fallback or collision-renamed entries can ignore `KEYMAP.jsonl`
+entirely.
 
 ### S3 path collisions (file vs. directory)
 
@@ -262,7 +274,7 @@ can spot dataset shapes that benefit from object-key normalization.
 
 ### DynamoDB
 
-```
+```text
 dynamodb/
 └── orders/                                        # composite-key table (hash + range)
     ├── _schema.json
@@ -351,7 +363,7 @@ with `--dynamodb-bundle-size 64MiB`, defaulting to that value) that
 emits items as `items/data-<part-id>.jsonl` instead, packed up to the
 configurable per-file size budget:
 
-```
+```text
 dynamodb/orders/
 ├── _schema.json
 └── items/
@@ -383,7 +395,7 @@ restore-side OCC, see "Read-Side Consistency".)
 
 ### S3
 
-```
+```text
 s3/
 └── photos/
     ├── _bucket.json
@@ -455,7 +467,7 @@ elastickv would resurrect deleted state. They land under
 
 ### Redis
 
-```
+```text
 redis/
 └── db_0/
     ├── strings/
@@ -550,7 +562,7 @@ raw bytes.
 
 ### SQS
 
-```
+```text
 sqs/
 └── orders-fifo.fifo/
     ├── _queue.json
@@ -575,7 +587,7 @@ sqs/
 `messages.jsonl` — one record per line, ordered by `(SendTimestampMillis,
 SequenceNumber, MessageId)`:
 
-```
+```text
 {"message_id":"abc-1","body":"hello","md5_of_body":"…","sender_id":"…","send_timestamp_millis":1714400000000,"available_at_millis":1714400000000,"visible_at_millis":0,"receive_count":0,"first_receive_millis":0,"current_receipt_token":null,"queue_generation":7,"message_group_id":"orders","message_deduplication_id":"abc-1","sequence_number":42,"dead_letter_source_arn":null,"message_attributes":{}}
 ```
 
@@ -865,7 +877,7 @@ field; `firstIndex == LastSnapshotIndex + 1`) and refuses to start if
 any group's *remaining headroom before the next snapshot* is below a
 configurable margin:
 
-```
+```text
 entries_since_last_snapshot = AppliedIndex - LastSnapshotIndex
 remaining_headroom          = SnapshotEvery - entries_since_last_snapshot
 refuse if: remaining_headroom < --snapshot-headroom-entries
@@ -1079,9 +1091,9 @@ Internal keys are partitioned into three classes:
 
 | Class | Examples | Backup behavior |
 |---|---|---|
-| **Re-derivable from user data + config** | DynamoDB GSI rows; S3 route catalog (`!s3route|`); Redis TTL scan index (`!redis|ttl|`); SQS visibility / age / dedup / group / tombstone indexes; route catalog under default group | Excluded by default. Restore re-builds them as user data is replayed. |
+| **Re-derivable from user data + config** | DynamoDB GSI rows; S3 route catalog (`!s3route\|`); Redis TTL scan index (`!redis\|ttl\|`); SQS visibility / age / dedup / group / tombstone indexes; route catalog under default group | Excluded by default. Restore re-builds them as user data is replayed. |
 | **Per-cluster operational state** | HLC physical ceiling; Raft term/index/conf state; FSM marker files (`raft-engine`, `EKVR`/`EKVM`/`EKVW` magic files in `internal/raftengine/etcd/persistence.go`); write conflict counter | Never dumped. They belong to the cluster, not the data. A restore initializes them fresh. |
-| **In-flight transactional state** | `!txn|` intent / lock / resolver records (`kv/txn_keys.go`, `kv/txn_codec.go`); pending S3 multipart uploads | Excluded by default. Optionally dumped under `_internals/` for forensics, but never re-applied by the restore path — replaying intents from a stale read_ts can resurrect aborted transactions. |
+| **In-flight transactional state** | `!txn\|` intent / lock / resolver records (`kv/txn_keys.go`, `kv/txn_codec.go`); pending S3 multipart uploads | Excluded by default. Optionally dumped under `_internals/` for forensics, but never re-applied by the restore path — replaying intents from a stale read_ts can resurrect aborted transactions. |
 
 This split is what makes the backup safe across versions: the only thing
 encoded in the dump is information the user could in principle have
@@ -1096,7 +1108,7 @@ A new CLI under `cmd/elastickv-backup/`. Streams the dump out as a
 directory tree on local disk, or as `tar` / `tar+zstd` to stdout for
 piping straight to S3 / GCS / a tape device.
 
-```
+```text
 elastickv-backup dump \
   --address     127.0.0.1:50051 \
   --output-dir  /backups/2026-04-29 \
@@ -1119,7 +1131,7 @@ elastickv-backup dump \
 
 Internally it runs:
 
-```
+```text
 BeginBackup(ttl_ms=1800000) → ListAdaptersAndScopes
                             → BackupScanner.Next* (per scope, at read_ts)
                             → encode-and-write per adapter
@@ -1133,7 +1145,7 @@ deployments it scans groups in parallel.
 
 ### Consumer: `cmd/elastickv-restore`
 
-```
+```text
 elastickv-restore apply \
   --address    127.0.0.1:50051 \
   --input-dir  /backups/2026-04-29 \

--- a/docs/design/2026_04_29_proposed_logical_backup.md
+++ b/docs/design/2026_04_29_proposed_logical_backup.md
@@ -1262,15 +1262,34 @@ written.
   populated by the admin handler via `GetNodeVersion(leader)` for
   UI-side visibility (not used for the rolling-upgrade gate, which
   fans out `GetNodeVersion` to every member directly).
-- New field on `AdminServer` (`adapter/admin_grpc.go:62`): a
-  `*kv.ShardStore` reference, wired in `main.go` so the
-  `BeginBackup` / `BackupScanner` plumbing can reach `ScanAt` and
-  `ScanKeysAt`. There is no existing `AdminServer → ShardStore`
-  connection — the prior round-2 statement that
-  `NewBackupScanner` is reachable "via the existing wiring used by
-  `GetRaftGroups`" was wrong; `GetRaftGroups` only calls
-  `AdminGroup.Status()` and `AdminGroup.Configuration()`, never
-  `ShardStore`.
+- New fields on `AdminServer` (`adapter/admin_grpc.go:62`):
+  - `*kv.ShardStore` reference, wired in `main.go` so the
+    `BeginBackup` / `BackupScanner` plumbing can reach `ScanAt` and
+    `ScanKeysAt`. There is no existing `AdminServer → ShardStore`
+    connection — the prior round-2 statement that
+    `NewBackupScanner` is reachable "via the existing wiring used by
+    `GetRaftGroups`" was wrong; `GetRaftGroups` only calls
+    `AdminGroup.Status()` and `AdminGroup.Configuration()`, never
+    `ShardStore`.
+  - `*kv.GRPCConnCache` for outbound admin-to-admin peer dials
+    (`GetNodeVersion` fan-out from `BeginBackup`, `GetNodeVersion`
+    leader probes from `GetRaftGroups`). Reuses
+    `kv/grpc_conn_cache.go` and dials with `internal.GRPCDialOptions()`,
+    matching how `kv.ShardStore` and the etcd-raft gRPC transport
+    obtain peer connections today (`internal/raftengine/etcd/grpc_transport.go:469`).
+    Keeping it in a **separate cache from** `ShardStore.connCache`
+    is intentional: the data-plane cache is keyed on
+    Raft-group-leader addresses (which can move between nodes on
+    leader change), while the admin cache is keyed on node identity
+    (`NodeIdentity.GRPCAddress` from `snapshotMembers`); mixing the
+    two would conflate moving and stable address spaces.
+  - `versionCache map[string]struct{ version string; fetchedAt time.Time }`
+    (or `sync.Map` equivalent) protecting the 10 s
+    `leader_node_version` cache used by `GetRaftGroups`'s async
+    leader probes. Populated by the same async dials; read by
+    `GetRaftGroups` synchronously when fresh, returning empty
+    string on cache-miss-or-dial-still-in-flight to keep the RPC
+    latency contract intact.
 - Extend `AdminGroup` interface (`adapter/admin_grpc.go:41`) with a
   `SnapshotEvery() uint64` method matching the `StatusReader`
   addition. Without this, the `BeginBackup` handler on
@@ -1512,6 +1531,7 @@ Scope: out of this proposal; mentioned only to draw the boundary.
 | `TestBeginBackupGatesOnMinVersion` | The `BeginBackup` handler derives its fan-out target from `snapshotMembers` (live `Configuration()` union, not the static `AdminServer.members` seed) and issues `GetNodeVersion` per peer concurrently. If any peer returns `node_version < N` or is unreachable within `--begin-backup-deadline`, the call returns `FailedPrecondition` with an error message that distinguishes the two cases ("reports version vX" vs. "did not respond within Ns") and proposes no `BackupPin` entries on any group; once every live member reports `node_version ≥ N`, the same call succeeds |
 | `TestBeginBackupGatesIncludesDynamicallyAddedNodes` | Start a 3-node cluster, add a 4th node at `v(N-1)` via `AddVoter` after `AdminServer` startup (so it is NOT in the bootstrap `members` seed), then call `BeginBackup`; the gate fails with the new node identified in the error. The previous seed-only design would have falsely passed |
 | `TestGetRaftGroupsLeaderVersionAsync` | `GetRaftGroups` returns within local-snapshot latency even when a leader is unreachable; `leader_node_version` is empty string in that case. Verify the 500 ms per-leader timeout and the 10 s response cache prevent repeated fan-outs across rapid polls |
+| `TestAdminGRPCConnCacheReuse` | Two consecutive `BeginBackup` calls dialing the same peer share one underlying `*grpc.ClientConn` (verified via the cache size); shutdown of a peer evicts only that entry, not the whole cache; admin cache is independent of `ShardStore.connCache` (no cross-cache eviction) |
 | `TestSnapshotEveryReadsFromEngine` | A node started with `ELASTICKV_RAFT_SNAPSHOT_COUNT=5000` reports `Engine.SnapshotEvery() == 5000`; `BeginBackup` uses 5000 (not the default 10000) when computing remaining headroom |
 | `TestRenewBackupRetriesLeaderElection` | Force a leader election mid-`RenewBackup`; the admin server retries `BackupExtend` up to 3 times with 500ms backoff and succeeds once the new leader is established, without aborting the dump |
 | `TestPinWithDeadlineExpiry` | `PinWithDeadline(ts, now+100ms)` is auto-released by the sweeper after the deadline; compactor unblocked; `backup_pin_expired` log emitted |

--- a/docs/design/2026_04_29_proposed_logical_backup.md
+++ b/docs/design/2026_04_29_proposed_logical_backup.md
@@ -189,7 +189,9 @@ Rules:
     byte.
   - If the resulting segment exceeds 240 bytes, the segment is replaced with
     `<sha256-hex-prefix-32>__<truncated-original>` and the full original
-    bytes are recorded in `<adapter>/<scope>/_long_keys.jsonl`.
+    bytes are recorded in `<adapter>/<scope>/KEYMAP.jsonl` (the same
+    KEYMAP file used for filename round-trip — long-key fallback and
+    encoded-name reverse-lookup share one append-only stream).
 - **DynamoDB binary partition / sort keys** (the `B` attribute type) are
   rendered as `b64.<base64url>` so a binary key never collides with a
   string key whose hex encoding happens to look like base64.
@@ -800,24 +802,69 @@ without hitting the corner case. Beyond that, a snapshot triggered
 by a freshly-restarted follower can quietly unprotect a replica.
 
 `BeginBackup` enforces a soft form of this invariant: it reads each
-group's `Status.AppliedIndex` and `firstIndex` (the oldest log entry
-still on the leader), and refuses to start if any group's
-`appliedIndex - firstIndex` is below a configurable margin
-(`--snapshot-headroom-entries`, default 10000). Operators dumping a
-cluster running close to its snapshot threshold receive
-`FailedPrecondition` rather than a silent corruption, and either
-retry once the headroom widens or extend `mvcc_retention_horizon`
-upstream of the dump.
+group's `Status.AppliedIndex` and `Status.LastSnapshotIndex`
+(`internal/raftengine/engine.go:53-69` — there is no `FirstIndex`
+field; `firstIndex == LastSnapshotIndex + 1`) and refuses to start if
+any group's *remaining headroom before the next snapshot* is below a
+configurable margin:
+
+```
+entries_since_last_snapshot = AppliedIndex - LastSnapshotIndex
+remaining_headroom          = SnapshotEvery - entries_since_last_snapshot
+refuse if: remaining_headroom < --snapshot-headroom-entries
+```
+
+`SnapshotEvery` is the per-engine snapshot trigger (default
+`defaultSnapshotEvery = 10000` from `internal/raftengine/etcd/engine.go:92`).
+`BeginBackup` reads it from each group's engine config rather than
+hardcoding the default, so an operator who tuned `--raftSnapshotEvery`
+sees consistent behavior. With `SnapshotEvery = 10000` and
+`--snapshot-headroom-entries = 1000` (default; one-tenth of
+SnapshotEvery), the check refuses backups when fewer than 1000 entries
+remain before the next snapshot fires — i.e. when an in-flight backup
+is at risk of triggering the snapshot-installation corner case. A
+freshly-snapshotted cluster has the *largest* remaining headroom and
+is the *safest* moment to start a backup; the check correctly allows
+it. Operators receiving `FailedPrecondition` either retry once the
+group has snapshotted (their headroom resets to `SnapshotEvery`) or
+extend `mvcc_retention_horizon` upstream of the dump.
 
 The failure mode for replicas that go through `Restore` mid-backup is
 documented explicitly: the replica's `ScanAt(at_ts=read_ts)` results
 become eventually-consistent (versions at `read_ts` may already have
 been compacted on that replica), and the producer surfaces the
-inconsistency as a `ScanAt` returning fewer keys than the
-`applied_index` baseline implied. The producer's per-scope
-`expected_keys` heuristic — already needed for
-`TestBeginBackupPinSurvivesLeaderChange` — catches it and fails the
-dump rather than emitting a corrupted artifact.
+inconsistency via a per-scope **expected-keys baseline**:
+
+> **Expected-keys baseline.** During step 1 of `BeginBackup`, before
+> the pin is installed, the admin server runs a *count-only* scan of
+> each adapter scope at `read_ts` (`ShardStore.ScanAt` with
+> `keys_only=true`, returning per-scope `(scope_id, key_count,
+> applied_index_at_count)`). The result is returned in
+> `BeginBackupResponse` and used as the contractual lower bound for
+> the producer's subsequent `BackupScanner.Next` traversal of the
+> same scope.
+>
+> The cost is one full forward scan per scope at backup time, but
+> count-only mode skips value materialization (`*store.KVPair` with
+> `Value == nil`); on Pebble this is a SST iterator with payload
+> trimmed at the block layer, so the additional pass is roughly 10×
+> cheaper than the data-bearing scan that follows. For a 100M-key
+> scope the baseline pass adds seconds, not minutes.
+>
+> If the producer's actual key count for a scope is `< 99% × baseline
+> ± sqrt(baseline)` (binomial-noise tolerance for legitimate
+> compaction of TTL'd keys between baseline and dump), the dump fails
+> with `ErrCompactionDuringDump` and the partial directory tree is
+> rejected by the restore tool (no `MANIFEST.json` is written). The
+> 1% threshold is large enough to absorb routine TTL expiry and small
+> enough to catch the "snapshot wiped pins on one replica" failure
+> mode, which would typically produce shortfalls of 5–50% on the
+> affected key range.
+>
+> Sparse legitimate ranges are not a false positive because the
+> baseline measures the *same scope at the same `read_ts`* — there
+> is no comparison against a structural expectation, only against the
+> producer's own count from a few seconds prior.
 
 A heavier mitigation that would let dumps run longer than the
 retention horizon — snapshotting the tracker state alongside the
@@ -872,7 +919,13 @@ dumps with retention pressure.
    and the producer aborts — the dump is not started until every
    group can serve `read_ts` consistently.
 3. **Pin `read_ts` cluster-wide**, not just on the node that received
-   the RPC. `kv/active_timestamp_tracker.go` is per-process
+   the RPC. **Per-group `BackupPin` proposals are issued concurrently**
+   — one goroutine per group — so a 100-shard cluster does not pay
+   100× serial Raft round-trips at the start of every backup. The
+   handler blocks until every goroutine has reported commit (or the
+   deadline fires); on error it cancels siblings and proceeds to the
+   compensating-release path described below.
+   `kv/active_timestamp_tracker.go` is per-process
    (`main.go:294` constructs one tracker per node and wires it
    exclusively to that node's compactor at `main.go:335`). A pin
    recorded on the receiving node would gate only its own compactor;
@@ -1182,7 +1235,15 @@ written.
 - New `kv/backup_scan.go` — `BackupScanner` iterator wrapping the
   existing `ShardStore.ScanAt` (`kv/shard_store.go:106`) so multi-
   million-key ranges page through `ScanAt` calls of `--scan-page-size`
-  rather than materializing in one call.
+  rather than materializing in one call. Phase 1 also extends
+  `MVCCStore.ScanAt` / `ShardStore.ScanAt` with a `keys_only bool`
+  parameter so the expected-keys baseline pass can iterate without
+  materializing values (Pebble iterator with payload trimmed at the
+  block layer; ~10× cheaper than a value-bearing scan).
+- Add `BeginBackupResponse.expected_keys` per scope (the count
+  produced by the baseline pass at `read_ts` before the pin is
+  installed) and `ErrCompactionDuringDump` in the producer when the
+  actual count falls below `99% × baseline ± sqrt(baseline)`.
 - New tool `cmd/elastickv-backup/` performing
   `BeginBackup → ListAdaptersAndScopes → BackupScanner.Next* (per scope)
   → encode → write directory tree → CHECKSUMS → MANIFEST.json
@@ -1242,8 +1303,10 @@ Scope: out of this proposal; mentioned only to draw the boundary.
 | `TestBeginBackupPinSurvivesLeaderChange` | After `BeginBackup` on node A, force a leadership change on a group; the new leader still honors the pin (its FSM applied the same entry); subsequent `BackupScanner.Next` calls succeed |
 | `TestBeginBackupGroupUnreachable` | If one group cannot commit `BackupPin` within `--begin-backup-deadline`, `BeginBackup` returns `Unavailable` and proposes `BackupRelease` on every group that did commit; no stranded pins remain |
 | `TestBackupPinFSMCodecRoundTrip` | `BackupPin` / `BackupExtend` / `BackupRelease` byte layouts (33 / 25 / 17 bytes) round-trip through the FSM apply path; unknown tag bytes return `ErrUnknownRequestType` rather than panicking |
-| `TestRestoreWipesLocalPins` | A replica that installs a Raft snapshot during a backup loses its `BackupPin`; the producer's per-scope `expected_keys` heuristic detects the resulting `ScanAt` shortfall and fails the dump rather than emitting a corrupted artifact |
-| `TestBeginBackupRefusesNearSnapshotThreshold` | When any group's `appliedIndex - firstIndex < snapshot_headroom_entries`, `BeginBackup` returns `FailedPrecondition` rather than starting a dump that risks the snapshot-installation path |
+| `TestRestoreWipesLocalPins` | A replica that installs a Raft snapshot during a backup loses its `BackupPin`; the producer's per-scope expected-keys baseline detects the resulting `ScanAt` shortfall (count below `99% × baseline ± sqrt(baseline)`) and fails the dump with `ErrCompactionDuringDump` rather than emitting a corrupted artifact |
+| `TestBeginBackupRefusesNearSnapshotThreshold` | When any group's `SnapshotEvery - (AppliedIndex - LastSnapshotIndex) < --snapshot-headroom-entries`, `BeginBackup` returns `FailedPrecondition` rather than starting a dump that risks the snapshot-installation path. Verify a freshly-snapshotted cluster (largest remaining headroom) is allowed |
+| `TestExpectedKeysBaselineToleratesTTLExpiry` | Routine TTL expiry between baseline and dump (1% of keys gone) does NOT trigger `ErrCompactionDuringDump`; a 5% drop DOES |
+| `TestExpectedKeysBaselineCountOnlyScan` | The baseline pass uses `ScanAt` with `keys_only=true`; verify per-key allocation is bounded (no value materialization) on a 1M-key scope |
 | `TestRenewBackupRetriesLeaderElection` | Force a leader election mid-`RenewBackup`; the admin server retries `BackupExtend` up to 3 times with 500ms backoff and succeeds once the new leader is established, without aborting the dump |
 | `TestPinWithDeadlineExpiry` | `PinWithDeadline(ts, now+100ms)` is auto-released by the sweeper after the deadline; compactor unblocked; `backup_pin_expired` log emitted |
 | `TestBeginBackupWaitsForLaggingShard` | Force shard B's `applied_index` to lag; `BeginBackup` polls until it catches up or times out with `FailedPrecondition`; no scan starts in the timeout case |

--- a/docs/design/2026_04_29_proposed_logical_backup.md
+++ b/docs/design/2026_04_29_proposed_logical_backup.md
@@ -1250,7 +1250,11 @@ written.
 
 - New admin RPCs on `proto/admin.proto`: `BeginBackup` (with `ttl_ms`),
   `EndBackup`, `RenewBackup`, `ListAdaptersAndScopes` (signatures in
-  "Read-Side Consistency").
+  "Read-Side Consistency"). Plus a one-field extension to the existing
+  `RaftGroupState` message (`proto/admin.proto:38`): add
+  `string node_version = 7;` populated by each admin handler from the
+  build-time version constant. The `BeginBackup` rolling-upgrade gate
+  reads this field; without it the gate cannot be implemented.
 - Extend `kv/active_timestamp_tracker.go` with `PinWithDeadline`,
   `Extend`, and the per-second sweeper goroutine that reaps expired
   pins and emits the `backup_pin_expired` structured warning.
@@ -1279,19 +1283,43 @@ written.
     1. **Release N (forward-compat handler only).** `kvFSM.Apply` is
        extended so unknown tags in the reserved range
        `[0x03, 0x0F]` are treated as no-ops with a structured
-       `unknown_fsm_tag` warning — no error returned. No new admin
-       RPCs, no producer, no `BackupPin` entries are ever written
-       at this version. Operators upgrade their clusters fleet-wide
-       to release N before the next step is enabled.
+       `unknown_fsm_tag` warning — no error returned. The new check
+       is added in `kvFSM.Apply` (`kv/fsm.go:60`) **immediately after
+       the `raftEncodeHLCLease` guard and before the call to
+       `decodeRaftRequests`**, so all leading-byte dispatch lives in
+       one place rather than splitting the table between `Apply` and
+       `decodeRaftRequests`'s `default:` case. Tags `0x10` and above
+       still fall through to `decodeRaftRequests` and error as
+       before, bounding the forward-compat door. No new admin RPCs,
+       no producer, no `BackupPin` entries are ever written at this
+       version. Operators upgrade their clusters fleet-wide to
+       release N before the next step is enabled.
     2. **Release N+1 (BackupPin enabled).** The actual `applyBackupPin`
        / `Extend` / `Release` handlers ship and the admin RPCs are
        activated. `BeginBackup` itself **gates on every group member
-       reporting `min_backup_version ≥ N`** — verified through the
-       existing `Admin.GetRaftGroups` membership view, which already
-       carries per-node version metadata. If any member reports a
-       version older than N, `BeginBackup` returns
-       `FailedPrecondition` with a clear message ("upgrade
-       node X to vN before backups can be taken").
+       reporting `node_version ≥ N`** via `Admin.GetRaftGroups`. The
+       version field does not exist today: `RaftGroupState` in
+       `proto/admin.proto:38-49` carries only `raft_group_id`,
+       `leader_node_id`, `leader_term`, `commit_index`,
+       `applied_index`, and `last_contact_unix_ms`. Phase 1 therefore
+       adds:
+       ```protobuf
+       message RaftGroupState {
+         // ... existing fields 1-6 unchanged ...
+         // node_version is the semver of the binary running on this
+         // member, populated from the build-time version stamp.
+         // Empty string on members reporting from a release older
+         // than the field was introduced (treated as "below N" by
+         // the BeginBackup gate so old members force a refusal).
+         string node_version = 7;
+       }
+       ```
+       The admin handler populates `node_version` from the local
+       binary's compiled-in version constant; follower versions are
+       surfaced via the existing membership-state propagation path
+       used by `GetRaftGroups`. If any member reports a version older
+       than N, `BeginBackup` returns `FailedPrecondition` with a clear
+       message ("upgrade node X to vN before backups can be taken").
 
     Releases N and N+1 may be the same calendar release if the
     operator is willing to enforce a fleet-wide upgrade window
@@ -1319,7 +1347,8 @@ written.
     `BeginBackup` time and echoed in every subsequent `BackupExtend`
     / `BackupRelease` so the FSM can target the right tracker entry.
     Hand-coded binary (vs. proto) keeps the entry small enough to
-    stay within the existing `MaxEntryBytes` budget and avoids
+    stay well within the `MaxSizePerMsg` limit (default 1 MiB,
+    `internal/raftengine/etcd/engine.go:55`) and avoids
     pulling proto codegen into the FSM apply hot path.
 - New `kv/backup_scan.go` — `BackupScanner` iterator wrapping the
   existing `ShardStore.ScanAt` (`kv/shard_store.go:106`) so multi-
@@ -1405,7 +1434,7 @@ Scope: out of this proposal; mentioned only to draw the boundary.
 | `TestExpectedKeysBaselineCountOnlyScan` | The baseline pass uses the new `ShardStore.ScanKeysAt`; verify per-key allocation is bounded (no value materialization) on a 1M-key scope and that existing `ScanAt` callers are bytewise-unchanged |
 | `TestExpectedKeysBaselineRunsAfterShardCatchup` | Force shard B to lag at `BeginBackup` time; verify the baseline scan blocks until step 2 (catch-up) completes for B, so B's `expected_keys[i].key_count` is the true count at `read_ts` rather than the partial-pre-catch-up count |
 | `TestForwardCompatUnknownFSMTag` | A release-N FSM receiving a synthetic `0x03`-tagged entry (representing a future `BackupPin` from a release-N+1 leader) returns nil from `Apply` and emits an `unknown_fsm_tag` warning, with no apply-loop stall and no FSM mutation. Tags `0x10+` (outside the reserved range) still error so the forward-compat door is bounded |
-| `TestBeginBackupGatesOnMinVersion` | If any group member reports `version < N`, `BeginBackup` returns `FailedPrecondition` and proposes no `BackupPin` entries on any group; once all members report `version ≥ N`, the same call succeeds |
+| `TestBeginBackupGatesOnMinVersion` | If any group member's `RaftGroupState.node_version` is `< N` (or empty), `BeginBackup` returns `FailedPrecondition` and proposes no `BackupPin` entries on any group; once all members report `node_version ≥ N`, the same call succeeds. Verify the `proto/admin.proto` `node_version = 7` field is populated from the build-time version constant on every node |
 | `TestSnapshotEveryReadsFromEngine` | A node started with `ELASTICKV_RAFT_SNAPSHOT_COUNT=5000` reports `Engine.SnapshotEvery() == 5000`; `BeginBackup` uses 5000 (not the default 10000) when computing remaining headroom |
 | `TestRenewBackupRetriesLeaderElection` | Force a leader election mid-`RenewBackup`; the admin server retries `BackupExtend` up to 3 times with 500ms backoff and succeeds once the new leader is established, without aborting the dump |
 | `TestPinWithDeadlineExpiry` | `PinWithDeadline(ts, now+100ms)` is auto-released by the sweeper after the deadline; compactor unblocked; `backup_pin_expired` log emitted |

--- a/docs/design/2026_04_29_proposed_logical_backup.md
+++ b/docs/design/2026_04_29_proposed_logical_backup.md
@@ -717,9 +717,15 @@ message ShardApplied {
 }
 
 message ScopeKeyCount {
-  // scope_id is "<adapter>/<scope-name>" e.g. "dynamodb/orders" or
-  // "s3/photos". Producer matches it against the directory it is
-  // about to write into.
+  // scope_id is the canonical "<adapter>/<scope-name>" string, used
+  // by the producer to match each baseline against the directory it
+  // is about to write. Mapping per adapter:
+  //   - DynamoDB: "dynamodb/<table>"        e.g. "dynamodb/orders"
+  //   - S3      : "s3/<bucket>"             e.g. "s3/photos"
+  //   - Redis   : "redis/db_<n>"            e.g. "redis/db_0"
+  //                (n is the uint32 from
+  //                 ListAdaptersAndScopesResponse.redis_databases)
+  //   - SQS     : "sqs/<queue-name>"        e.g. "sqs/orders-fifo.fifo"
   string scope_id                = 1;
   uint64 key_count               = 2;
   uint64 applied_index_at_count  = 3;
@@ -834,10 +840,29 @@ refuse if: remaining_headroom < --snapshot-headroom-entries
 ```
 
 `SnapshotEvery` is the per-engine snapshot trigger (default
-`defaultSnapshotEvery = 10000` from `internal/raftengine/etcd/engine.go:92`).
-`BeginBackup` reads it from each group's engine config rather than
-hardcoding the default, so an operator who tuned `--raftSnapshotEvery`
-sees consistent behavior. With `SnapshotEvery = 10000` and
+`defaultSnapshotEvery = 10000` from `internal/raftengine/etcd/engine.go:92`,
+overridden via the `ELASTICKV_RAFT_SNAPSHOT_COUNT` env var — there is
+no `--raftSnapshotEvery` CLI flag). The value is currently a private
+field on the etcd `Engine` struct (`internal/raftengine/etcd/engine.go:224`)
+with no accessor on the `raftengine.Engine` interface
+(`internal/raftengine/engine.go:200`, composing `Proposer` /
+`LeaderView` / `StatusReader` / `ConfigReader`). Phase 1 therefore
+adds a new accessor:
+
+```go
+// internal/raftengine/engine.go (extended)
+type StatusReader interface {
+    Status() Status
+    SnapshotEvery() uint64  // new in Phase 1
+}
+```
+
+implemented on the etcd backend by returning the
+`snapshotEveryFromEnv()` value cached at `Open` time. With this in
+place, `BeginBackup` reads each group's `SnapshotEvery` rather than
+hardcoding `defaultSnapshotEvery`, so an operator who tuned
+`ELASTICKV_RAFT_SNAPSHOT_COUNT` sees consistent behavior. With
+`SnapshotEvery = 10000` and
 `--snapshot-headroom-entries = 1000` (default; one-tenth of
 SnapshotEvery), the check refuses backups when fewer than 1000 entries
 remain before the next snapshot fires — i.e. when an in-flight backup
@@ -1238,6 +1263,43 @@ written.
     `applyBackupPin` / `applyBackupExtend` / `applyBackupRelease`
     handlers on `kvFSM`, dispatched from `kvFSM.Apply`
     (`kv/fsm.go:60`) in the same shape as `applyHLCLease`.
+
+  - **Two-version rolling-upgrade plan.** Today, an unknown leading
+    tag falls through `decodeRaftRequests` (`kv/fsm.go:140`) into
+    `decodeLegacyRaftRequest` (`kv/fsm.go:145`), which calls
+    `proto.Unmarshal` on the raw bytes. A `BackupPin` entry with
+    leading byte `0x03` would fail the unmarshal and surface as an
+    error from `Apply`, stalling the apply loop on any node that
+    hasn't been upgraded. Introducing the new tags in a single
+    release would therefore corrupt apply on old replicas the moment
+    the first `BeginBackup` lands during a rolling upgrade.
+
+    Phase 1 ships in **two releases** to avoid this:
+
+    1. **Release N (forward-compat handler only).** `kvFSM.Apply` is
+       extended so unknown tags in the reserved range
+       `[0x03, 0x0F]` are treated as no-ops with a structured
+       `unknown_fsm_tag` warning — no error returned. No new admin
+       RPCs, no producer, no `BackupPin` entries are ever written
+       at this version. Operators upgrade their clusters fleet-wide
+       to release N before the next step is enabled.
+    2. **Release N+1 (BackupPin enabled).** The actual `applyBackupPin`
+       / `Extend` / `Release` handlers ship and the admin RPCs are
+       activated. `BeginBackup` itself **gates on every group member
+       reporting `min_backup_version ≥ N`** — verified through the
+       existing `Admin.GetRaftGroups` membership view, which already
+       carries per-node version metadata. If any member reports a
+       version older than N, `BeginBackup` returns
+       `FailedPrecondition` with a clear message ("upgrade
+       node X to vN before backups can be taken").
+
+    Releases N and N+1 may be the same calendar release if the
+    operator is willing to enforce a fleet-wide upgrade window
+    before the first backup; the gate check still runs and
+    short-circuits if upgrade is incomplete. The reserved tag range
+    `[0x03, 0x0F]` lets future entry types (e.g. CDC tags for the
+    Phase 3 incremental backup) follow the same forward-compat
+    path without re-running the full upgrade dance.
   - New `*ActiveTimestampTracker` field on `kvFSM` (`kv/fsm.go:26`),
     wired via a new `NewKvFSMWithHLCAndTracker(store, hlc, tracker)`
     constructor — analogous to how `*HLC` is shared today via
@@ -1342,6 +1404,9 @@ Scope: out of this proposal; mentioned only to draw the boundary.
 | `TestExpectedKeysBaselineToleratesTTLExpiry` | Routine TTL expiry between baseline and dump (1% of keys gone) does NOT trigger `ErrCompactionDuringDump`; a 5% drop DOES |
 | `TestExpectedKeysBaselineCountOnlyScan` | The baseline pass uses the new `ShardStore.ScanKeysAt`; verify per-key allocation is bounded (no value materialization) on a 1M-key scope and that existing `ScanAt` callers are bytewise-unchanged |
 | `TestExpectedKeysBaselineRunsAfterShardCatchup` | Force shard B to lag at `BeginBackup` time; verify the baseline scan blocks until step 2 (catch-up) completes for B, so B's `expected_keys[i].key_count` is the true count at `read_ts` rather than the partial-pre-catch-up count |
+| `TestForwardCompatUnknownFSMTag` | A release-N FSM receiving a synthetic `0x03`-tagged entry (representing a future `BackupPin` from a release-N+1 leader) returns nil from `Apply` and emits an `unknown_fsm_tag` warning, with no apply-loop stall and no FSM mutation. Tags `0x10+` (outside the reserved range) still error so the forward-compat door is bounded |
+| `TestBeginBackupGatesOnMinVersion` | If any group member reports `version < N`, `BeginBackup` returns `FailedPrecondition` and proposes no `BackupPin` entries on any group; once all members report `version ≥ N`, the same call succeeds |
+| `TestSnapshotEveryReadsFromEngine` | A node started with `ELASTICKV_RAFT_SNAPSHOT_COUNT=5000` reports `Engine.SnapshotEvery() == 5000`; `BeginBackup` uses 5000 (not the default 10000) when computing remaining headroom |
 | `TestRenewBackupRetriesLeaderElection` | Force a leader election mid-`RenewBackup`; the admin server retries `BackupExtend` up to 3 times with 500ms backoff and succeeds once the new leader is established, without aborting the dump |
 | `TestPinWithDeadlineExpiry` | `PinWithDeadline(ts, now+100ms)` is auto-released by the sweeper after the deadline; compactor unblocked; `backup_pin_expired` log emitted |
 | `TestBeginBackupWaitsForLaggingShard` | Force shard B's `applied_index` to lag; `BeginBackup` polls until it catches up or times out with `FailedPrecondition`; no scan starts in the timeout case |

--- a/docs/design/2026_04_29_proposed_logical_backup.md
+++ b/docs/design/2026_04_29_proposed_logical_backup.md
@@ -703,7 +703,26 @@ message BeginBackupResponse {
   uint64 read_ts            = 1;
   bytes  pin_token          = 2;  // opaque, must be passed back to RenewBackup / EndBackup
   uint64 ttl_ms_effective   = 3;
-  repeated ShardApplied shards = 4;  // group_id, applied_index at pin time
+  repeated ShardApplied shards = 4;  // applied_index per group at pin time
+  // Per-scope count produced by the count-only baseline scan at read_ts
+  // (see "Expected-keys baseline" below). The producer compares its
+  // own scope-level traversal count against expected_keys[i].key_count
+  // and aborts with ErrCompactionDuringDump on shortfall.
+  repeated ScopeKeyCount expected_keys = 5;
+}
+
+message ShardApplied {
+  string group_id      = 1;  // distribution.GroupID stringified
+  uint64 applied_index = 2;
+}
+
+message ScopeKeyCount {
+  // scope_id is "<adapter>/<scope-name>" e.g. "dynamodb/orders" or
+  // "s3/photos". Producer matches it against the directory it is
+  // about to write into.
+  string scope_id                = 1;
+  uint64 key_count               = 2;
+  uint64 applied_index_at_count  = 3;
 }
 
 // RenewBackup extends the deadline for an existing pin. A long-running
@@ -835,14 +854,22 @@ become eventually-consistent (versions at `read_ts` may already have
 been compacted on that replica), and the producer surfaces the
 inconsistency via a per-scope **expected-keys baseline**:
 
-> **Expected-keys baseline.** During step 1 of `BeginBackup`, before
-> the pin is installed, the admin server runs a *count-only* scan of
-> each adapter scope at `read_ts` (`ShardStore.ScanAt` with
-> `keys_only=true`, returning per-scope `(scope_id, key_count,
-> applied_index_at_count)`). The result is returned in
-> `BeginBackupResponse` and used as the contractual lower bound for
-> the producer's subsequent `BackupScanner.Next` traversal of the
-> same scope.
+> **Expected-keys baseline.** **After step 2 (every shard has applied
+> through `read_ts`) and before step 3 (the pin is installed)**, the
+> admin server runs a *count-only* scan of each adapter scope at
+> `read_ts` (`ShardStore.ScanKeysAt`, returning
+> per-scope `(scope_id, key_count, applied_index_at_count)`). The
+> ordering matters: a count-only scan run before step 2 would return
+> 0 (or a partial count) for any shard still lagging through
+> `read_ts`, producing an undercount on exactly the shards most at
+> risk of the snapshot-pin-loss corner case — and silently disabling
+> `ErrCompactionDuringDump` on those shards. Running after step 2
+> guarantees every shard has the data at `read_ts` and the count is
+> a true lower bound.
+>
+> The result is returned in `BeginBackupResponse.expected_keys` and
+> used as the contractual lower bound for the producer's subsequent
+> `BackupScanner.Next` traversal of the same scope.
 >
 > The cost is one full forward scan per scope at backup time, but
 > count-only mode skips value materialization (`*store.KVPair` with
@@ -1026,7 +1053,7 @@ elastickv-backup dump \
   [--checksums sha256] \
   [--ttl-ms 1800000] \
   [--begin-backup-deadline 5s] \
-  [--snapshot-headroom-entries 10000] \
+  [--snapshot-headroom-entries 1000] \
   [--scan-page-size 1024] \
   [--dynamodb-bundle-mode per-item|jsonl] \
   [--dynamodb-bundle-size 64MiB] \
@@ -1235,11 +1262,18 @@ written.
 - New `kv/backup_scan.go` — `BackupScanner` iterator wrapping the
   existing `ShardStore.ScanAt` (`kv/shard_store.go:106`) so multi-
   million-key ranges page through `ScanAt` calls of `--scan-page-size`
-  rather than materializing in one call. Phase 1 also extends
-  `MVCCStore.ScanAt` / `ShardStore.ScanAt` with a `keys_only bool`
-  parameter so the expected-keys baseline pass can iterate without
-  materializing values (Pebble iterator with payload trimmed at the
-  block layer; ~10× cheaper than a value-bearing scan).
+  rather than materializing in one call.
+- New `MVCCStore.ScanKeysAt` / `ShardStore.ScanKeysAt` overload
+  (returning `[][]byte` rather than `[]*KVPair`) so the expected-keys
+  baseline pass can iterate without materializing values. **Adding a
+  `keys_only bool` to the existing `ScanAt` signature would be a
+  source-incompatible Go change touching every caller** —
+  `kv/shard_store.go` alone has ~10 sites (e.g. lines 308, 326, 855)
+  plus call sites across adapters. The overload approach leaves every
+  existing caller untouched and keeps the new path obviously named
+  for what it does. Internally `ScanKeysAt` delegates to a private
+  helper that takes a `keysOnly` flag, sharing the route-resolution
+  and merge logic with the existing path.
 - Add `BeginBackupResponse.expected_keys` per scope (the count
   produced by the baseline pass at `read_ts` before the pin is
   installed) and `ErrCompactionDuringDump` in the producer when the
@@ -1306,7 +1340,8 @@ Scope: out of this proposal; mentioned only to draw the boundary.
 | `TestRestoreWipesLocalPins` | A replica that installs a Raft snapshot during a backup loses its `BackupPin`; the producer's per-scope expected-keys baseline detects the resulting `ScanAt` shortfall (count below `99% × baseline ± sqrt(baseline)`) and fails the dump with `ErrCompactionDuringDump` rather than emitting a corrupted artifact |
 | `TestBeginBackupRefusesNearSnapshotThreshold` | When any group's `SnapshotEvery - (AppliedIndex - LastSnapshotIndex) < --snapshot-headroom-entries`, `BeginBackup` returns `FailedPrecondition` rather than starting a dump that risks the snapshot-installation path. Verify a freshly-snapshotted cluster (largest remaining headroom) is allowed |
 | `TestExpectedKeysBaselineToleratesTTLExpiry` | Routine TTL expiry between baseline and dump (1% of keys gone) does NOT trigger `ErrCompactionDuringDump`; a 5% drop DOES |
-| `TestExpectedKeysBaselineCountOnlyScan` | The baseline pass uses `ScanAt` with `keys_only=true`; verify per-key allocation is bounded (no value materialization) on a 1M-key scope |
+| `TestExpectedKeysBaselineCountOnlyScan` | The baseline pass uses the new `ShardStore.ScanKeysAt`; verify per-key allocation is bounded (no value materialization) on a 1M-key scope and that existing `ScanAt` callers are bytewise-unchanged |
+| `TestExpectedKeysBaselineRunsAfterShardCatchup` | Force shard B to lag at `BeginBackup` time; verify the baseline scan blocks until step 2 (catch-up) completes for B, so B's `expected_keys[i].key_count` is the true count at `read_ts` rather than the partial-pre-catch-up count |
 | `TestRenewBackupRetriesLeaderElection` | Force a leader election mid-`RenewBackup`; the admin server retries `BackupExtend` up to 3 times with 500ms backoff and succeeds once the new leader is established, without aborting the dump |
 | `TestPinWithDeadlineExpiry` | `PinWithDeadline(ts, now+100ms)` is auto-released by the sweeper after the deadline; compactor unblocked; `backup_pin_expired` log emitted |
 | `TestBeginBackupWaitsForLaggingShard` | Force shard B's `applied_index` to lag; `BeginBackup` polls until it catches up or times out with `FailedPrecondition`; no scan starts in the timeout case |

--- a/docs/design/2026_04_29_proposed_snapshot_logical_decoder.md
+++ b/docs/design/2026_04_29_proposed_snapshot_logical_decoder.md
@@ -10,7 +10,7 @@ The existing FSM snapshot path (`store/snapshot_pebble.go`, see
 `2026_04_14_implemented_etcd_snapshot_disk_offload.md`) writes the
 entire keyspace as a single opaque stream:
 
-```
+```text
 [magic "EKVPBBL1" :8]
 [lastCommitTS    :8]
 ([keyLen:8][key][valLen:8][val])*
@@ -105,7 +105,7 @@ record schemas, and `MANIFEST.json` are all defined here.
 
 ### Top-level layout
 
-```
+```text
 backup-<utc-timestamp>-<cluster-id>-<applied-index>/
 ├── MANIFEST.json
 ├── CHECKSUMS                         # sha256sum(1)-compatible
@@ -176,10 +176,32 @@ Rules:
 `KEYMAP.jsonl` at each adapter scope root translates encoded
 filenames back to original bytes when needed. JSONL (one mapping per
 line) so the file scales to millions of keys without becoming a
-memory bottleneck. The translation is also losslessly recoverable
-from the encoded filename alone — `KEYMAP.jsonl` is a convenience,
-not a correctness dependency. A consumer that does not need it can
-ignore it entirely.
+memory bottleneck.
+
+Reversibility depends on the encoding path:
+
+- **`%HH` percent-encoded segments and `b64.<base64url>` segments**
+  (DynamoDB binary keys) are losslessly reversible from the filename
+  alone. `KEYMAP.jsonl` is **convenience only** for these — a
+  consumer that operates on encoded keys, or that needs only the
+  human-recognizable subset, can ignore it.
+- **SHA-fallback segments** (`<sha256-prefix-32>__<truncated-original>`,
+  used when a key segment exceeds 240 bytes) carry only the truncated
+  prefix and a hash. The full original bytes are recoverable only via
+  `KEYMAP.jsonl`. For these entries `KEYMAP.jsonl` is a
+  **correctness dependency** — without it, a consumer can identify
+  *which* record a file came from but cannot reproduce the exact
+  original key bytes.
+- **S3 path-collision renames** (`<obj>.elastickv-leaf-data` for the
+  shorter key when both `path/to` and `path/to/obj` exist) similarly
+  require `KEYMAP.jsonl` to reverse — the renamed filename does not
+  by itself encode that the original key was the un-suffixed form.
+
+A consumer that does not need original-byte recovery for SHA-
+fallback or collision-renamed entries (e.g., a migration tool that
+preserves keys as-encoded into the destination system) can ignore
+`KEYMAP.jsonl` entirely. A consumer that needs exact round-trip on
+arbitrary inputs must consult it.
 
 #### S3 path collisions (file vs. directory)
 
@@ -206,7 +228,7 @@ this case at scan time:
 
 #### DynamoDB
 
-```
+```text
 dynamodb/
 └── orders/                                        # composite-key table (hash + range)
     ├── _schema.json
@@ -417,7 +439,7 @@ depending on elastickv's internal physics stays in elastickv.
 
 ### Decoder: `cmd/elastickv-snapshot-decode`
 
-```
+```text
 elastickv-snapshot-decode \
   --input  <fsm-file>          # or --input-snap-dir <data-dir>/fsm-snap/
   --output <directory-root> \
@@ -435,7 +457,7 @@ elastickv-snapshot-decode \
 
 Pipeline:
 
-```
+```text
 open .fsm                                       # verifies CRC32C footer
 parse EKVPBBL1 magic + lastCommitTS
 stream ([keyLen:8][key][valLen:8][val])* entries:
@@ -469,7 +491,7 @@ current.
 
 ### Encoder: `cmd/elastickv-snapshot-encode`
 
-```
+```text
 elastickv-snapshot-encode \
   --input  <directory-root> \
   --output <fsm-file> \
@@ -478,7 +500,7 @@ elastickv-snapshot-encode \
 
 Pipeline:
 
-```
+```text
 read MANIFEST.json (refuse on unknown major format_version)
 walk per-adapter subtrees:
   DynamoDB → emit !ddb|meta|table| then !ddb|item| KV pairs

--- a/docs/design/2026_04_29_proposed_snapshot_logical_decoder.md
+++ b/docs/design/2026_04_29_proposed_snapshot_logical_decoder.md
@@ -1,0 +1,696 @@
+# Snapshot ↔ Logical-Format Decoder (Phase 0)
+
+Status: Proposed
+Author: bootjp
+Date: 2026-04-29
+
+## Background
+
+The existing FSM snapshot path (`store/snapshot_pebble.go`, see
+`2026_04_14_implemented_etcd_snapshot_disk_offload.md`) writes the
+entire keyspace as a single opaque stream:
+
+```
+[magic "EKVPBBL1" :8]
+[lastCommitTS    :8]
+([keyLen:8][key][valLen:8][val])*
+[CRC32C footer  :4]
+```
+
+Snapshots are taken automatically every `defaultSnapshotEvery = 10000`
+log entries (`internal/raftengine/etcd/engine.go:92`) and stored under
+`{dataDir}/fsm-snap/<index>.fsm`. They are crash-consistent by
+construction — the writer takes a Pebble snapshot at the FSM's
+applied index and serializes it.
+
+These files are excellent for what Raft uses them for (log compaction,
+follower catch-up). They are useless as a **user-readable backup**:
+keys are raw internal-format bytes (`!ddb|item|<table>|<gen>|...`,
+`!s3|blob|...`, `!hs|fld|<keyLen>...`, `!sqs|msg|data|...`), values
+are protobuf or JSON wrapped with internal magic prefixes
+(`0x00 'D' 'I' 0x01`, `0x00 'S' 'M' 0x01`, …), and S3 object bodies
+are split into per-chunk blob keys keyed by `(bucket, generation,
+object, uploadID, partNo, chunkNo, partVersion)`.
+
+The user holding such a `.fsm` file has bytes only the same elastickv
+binary on the same version can read. A cluster failure that destroys
+the binary, or a vendor end-of-life, leaves them with unreadable
+bytes — this violates the basic property an operator expects of a
+backup: **vendor-independent recovery**.
+
+## Why Phase 0
+
+The full live-cluster, point-in-time-consistent extraction pipeline
+described in
+`2026_04_29_proposed_logical_backup.md` (the Phase 1 design)
+introduces non-trivial machinery: replicated `BackupPin` Raft FSM
+commands, version-gated RPC fan-outs, expected-keys baselines,
+admin-side connection caches, etc. That machinery exists to chase a
+specific consistency property: a single cluster-wide `read_ts` across
+all Raft groups while the cluster is running.
+
+Many users do not need that property:
+
+- A single-shard or single-Raft-group deployment.
+- A deployment where "the most recent crash-consistent snapshot" is a
+  good-enough recovery point (the gap between the last snapshot and
+  "now" is bounded by `SnapshotEvery × write_rate`).
+- A use case where the cluster has been shut down or destroyed and
+  the only remaining artifact is the snapshot files on a sidecar
+  disk — there is no live cluster to query.
+- An operator who wants to perform a one-time format migration off
+  elastickv: read the snapshots, convert to logical form, replay
+  into the destination system. No live elastickv needed.
+
+For those use cases, **a purely offline `.fsm` ↔ logical-format
+converter delivers the vendor-independent-recovery property at a
+fraction of the complexity** of the Phase 1 pipeline. Phase 0 is
+that converter.
+
+Phase 1 layers on top by producing the *same* logical format (defined
+here) from a running cluster with cross-shard PIT consistency.
+
+## Design Goals
+
+| Goal | Detail |
+|------|--------|
+| **Vendor-independent recovery** | The output directory tree can be inspected and recovered from with `cat`, `jq`, `find`, `aws s3 sync`, `redis-cli` alone — no elastickv binary involved |
+| **Pure offline operation** | No live cluster, no admin RPCs, no Raft, no FSM changes. Reads `.fsm` files; writes a directory tree (and the inverse) |
+| **Bidirectional** | Decode (`.fsm` → directory tree) and encode (directory tree → `.fsm`) are both in scope. Encode lets an operator restore by stop-replace-restart on a node |
+| **Format ownership** | Phase 0 *defines* the per-adapter directory format. Phase 1 produces the same format from a live cluster |
+| **No coupling to elastickv internals** | The decoder reads the snapshot's wire format and the public adapter envelopes (DynamoDB proto, SQS JSON, …); no in-process FSM, no MVCC, no OCC paths are exercised |
+
+### Non-Goals
+
+- Cross-shard / cross-Raft-group point-in-time consistency. Each
+  group's snapshot is independent; a Phase 0 dump that includes
+  multiple groups will reflect different commit-ts per group. Phase 1
+  exists to fix this.
+- The Raft log tail beyond the last snapshot. Whatever has happened
+  between the snapshot's `applied_index` and "now" is not in the
+  snapshot, so it is not in a Phase 0 dump. Phase 1 (which scans the
+  live store) does see it.
+- Online backup of a running cluster as a regular operation. Phase 0
+  is "snapshot exists already; convert it." Repeated dumps require
+  repeated snapshots, which is a Raft-driven cadence, not a
+  user-driven one.
+- A new admin RPC, FSM tag, or proto change. Phase 0 is purely a
+  command-line tool reading and writing files.
+
+## Output Format (per-adapter directory tree)
+
+This is the canonical format for both Phase 0 and Phase 1 dumps. The
+shape of the tree, the filename-encoding rules, the per-adapter
+record schemas, and `MANIFEST.json` are all defined here.
+
+### Top-level layout
+
+```
+backup-<utc-timestamp>-<cluster-id>-<applied-index>/
+├── MANIFEST.json
+├── CHECKSUMS                         # sha256sum(1)-compatible
+├── dynamodb/
+│   └── <table-name>/
+│       ├── _schema.json
+│       ├── KEYMAP.jsonl                            # per-scope (omitted when empty)
+│       └── items/
+│           └── <pk-segment>/[<sk-segment>.]json
+├── s3/
+│   └── <bucket-name>/
+│       ├── _bucket.json
+│       ├── KEYMAP.jsonl
+│       ├── <object-key-path>                       # original object bytes
+│       └── <object-key-path>.elastickv-meta.json   # sidecar (reserved suffix)
+├── redis/
+│   └── db_<n>/
+│       ├── KEYMAP.jsonl
+│       ├── strings/<key>.bin
+│       ├── strings_ttl.jsonl
+│       ├── hashes/<key>.json
+│       ├── lists/<key>.json
+│       ├── sets/<key>.json
+│       ├── zsets/<key>.json
+│       ├── streams/<key>.jsonl
+│       ├── hll/<key>.bin
+│       └── hll_ttl.jsonl
+└── sqs/
+    └── <queue-name>/
+        ├── _queue.json
+        ├── KEYMAP.jsonl
+        └── messages.jsonl
+```
+
+`CHECKSUMS` is exact `sha256sum(1)` output so verification works
+without elastickv: `sha256sum -c CHECKSUMS` from the dump root
+succeeds on a clean dump and fails (with file-level diagnostics) on
+tampering.
+
+### Filename encoding
+
+User keys (table names, bucket names, S3 object keys, Redis keys,
+SQS message IDs) can contain bytes illegal or ambiguous on common
+filesystems: `/`, NUL, `\`, control characters, names ending in `.`,
+case-collision pairs, names longer than `NAME_MAX`.
+
+Rules:
+
+- **S3 object keys preserve their `/` separators** as filesystem
+  path separators. `s3://photos/2026/04/29/img.jpg` becomes
+  `s3/photos/2026/04/29/img.jpg`. This is the whole point — `aws s3
+  sync` on the dump directory works.
+- **All other key segments** are encoded with RFC3986 unreserved
+  characters (`[A-Za-z0-9._-]`) passed through; every other byte
+  becomes `%HH` (uppercase hex).
+- **DynamoDB binary partition / sort keys** (the `B` attribute type)
+  are rendered as `b64.<base64url>` so a binary key never collides
+  with a string key whose hex encoding happens to look like base64.
+- If the resulting segment exceeds 240 bytes, it becomes
+  `<sha256-prefix-32>__<truncated-original>` and the full original
+  bytes are recorded in `<adapter>/<scope>/KEYMAP.jsonl` — same file
+  used for filename round-trip and S3 path-collision rename
+  bookkeeping.
+- **Stream messages** within an SQS queue are not represented by file
+  per message (millions of small files); they live in a single
+  `messages.jsonl`. Same rationale for Redis stream entries.
+
+`KEYMAP.jsonl` at each adapter scope root translates encoded
+filenames back to original bytes when needed. JSONL (one mapping per
+line) so the file scales to millions of keys without becoming a
+memory bottleneck. The translation is also losslessly recoverable
+from the encoded filename alone — `KEYMAP.jsonl` is a convenience,
+not a correctness dependency. A consumer that does not need it can
+ignore it entirely.
+
+#### S3 path collisions (file vs. directory)
+
+S3 permits two objects whose keys are `path/to` and `path/to/obj`
+simultaneously. POSIX filesystems cannot represent both — `path/to`
+cannot be both a regular file and a directory. The decoder detects
+this case at scan time:
+
+- **Pure-leaf case** (the more common case): the key without `/obj`
+  suffix is the only object → write at the natural path, no
+  collision.
+- **Collision case**: both `path/to` and `path/to/obj` exist in the
+  same bucket at the same generation. The shorter key (the one that
+  would force a regular file on a path that must also be a
+  directory) is renamed to `path/to.elastickv-leaf-data`, with the
+  rename recorded in `s3/<bucket>/KEYMAP.jsonl`. The sidecar follows
+  the renamed base:
+  `path/to.elastickv-leaf-data.elastickv-meta.json`.
+- The collision-handling rule is documented at dump time in
+  `MANIFEST.json` (`s3_collision_strategy: "leaf-data-suffix"`) so
+  an encoder reverses it without guessing.
+
+### Per-adapter format
+
+#### DynamoDB
+
+```
+dynamodb/
+└── orders/                                        # composite-key table (hash + range)
+    ├── _schema.json
+    └── items/
+        ├── customer-7421/                          # <pk>/
+        │   ├── 2026-04-29T12:00:00Z.json           # <sk>.json
+        │   └── 2026-04-29T13:15:42Z.json
+        ├── customer-7422/
+        │   └── 2026-04-29T09:00:00Z.json
+        └── b64.AAECAw../                           # binary partition key (B attribute)
+            └── 2026-04-29T10:00:00Z.json
+└── sessions/                                      # hash-only table
+    ├── _schema.json
+    └── items/
+        ├── sess-abc123.json                        # <pk>.json directly under items/
+        └── sess-def456.json
+```
+
+`_schema.json` is structurally identical to a `DescribeTable` JSON
+response — tools that already speak DynamoDB JSON ingest it without
+translation.
+
+`items/<pk>/<sk>.json` is the wire-format DynamoDB item (the same
+shape `GetItem` returns). Restoring into AWS DynamoDB is a literal
+`PutItem` per file. A failed table can be partially recovered by
+hand-editing one item and re-feeding it.
+
+GSIs are **not materialized** in the dump because they are derivable
+from `_schema.json` plus the base item set. Re-creating the table
+from `_schema.json` and replaying the items rebuilds the GSI; this
+is what AWS itself does on table import.
+
+**Bundle mode for very large tables.** The default — one item per
+file under `items/<pk>/<sk>.json` — is what makes "recover one row
+by editing one file" trivially true. For tables where inode count
+is the binding constraint (50M+ items), the decoder accepts an
+opt-in `--dynamodb-bundle-mode jsonl` (paired with
+`--dynamodb-bundle-size 64MiB`, defaulting to that value) that
+emits items as `items/data-<part-id>.jsonl` instead. `MANIFEST.json`
+records the choice (`dynamodb_layout: "per-item" | "jsonl"`) so an
+encoder dispatches the right reader.
+
+#### S3
+
+The S3 object body sits at its natural path — every byte that the
+elastickv S3 adapter would have streamed through `streamObjectChunks`
+for a GET is reassembled in order and written out as a single
+regular file.
+
+A sidecar `<object>.elastickv-meta.json` carries the parts of
+`s3ObjectManifest` that S3 itself exposes via headers
+(`Content-Type`, `Content-Encoding`, `Cache-Control`,
+`Content-Disposition`, user-defined `x-amz-meta-*`, `ETag`,
+`LastModified`):
+
+```json
+{
+  "format_version":   1,
+  "etag":             "\"d41d8cd98f00b204e9800998ecf8427e\"",
+  "size_bytes":       1024576,
+  "last_modified":    "2026-04-29T12:34:56.789Z",
+  "content_type":     "image/jpeg",
+  "content_encoding": "",
+  "cache_control":    "max-age=3600",
+  "user_metadata":    {"camera": "fx30"}
+}
+```
+
+The `.elastickv-meta.json` suffix is **reserved**: a user S3 object
+whose key ends in `.elastickv-meta.json` is rejected at decode time
+unless `--rename-collisions` is passed.
+
+Multipart parts are flattened on decode: the user gets the assembled
+object, not the per-part fragments. In-flight multipart uploads
+(`!s3|upload|meta|`, `!s3|upload|part|`, blob chunks not yet committed
+by `CompleteMultipartUpload`) are excluded by default; an
+`--include-incomplete-uploads` flag emits them under
+`s3/<bucket>/_incomplete_uploads/<uploadID>/`.
+
+Generation handling: only the live (latest) generation per bucket
+is included. Pre-generation orphans land under `_orphans/<oldGen>/`
+only when `--include-orphans` is passed.
+
+#### Redis
+
+- `strings/<key>.bin` is the **raw value bytes** — Redis strings are
+  binary-safe. TTL is in the sidecar `strings_ttl.jsonl`, one record
+  per line:
+  ```
+  {"key":"session%3Aabc123","expire_at_ms":1735689600000}
+  {"key":"cache%3Akv99","expire_at_ms":1735689610500}
+  ```
+  Values are absolute Unix-millis expirations. JSONL (not a single
+  JSON object) is used so producers and consumers stream the file
+  line-by-line.
+- `hashes/<key>.json`:
+  `{"format_version": 1, "fields": {"name": "alice"}, "expire_at_ms": null}`
+- `lists/<key>.json`:
+  `{"format_version": 1, "items": ["job-1", "job-2"], "expire_at_ms": null}`
+  Order is left-to-right (LPUSH `[3,2,1]` produces `["3","2","1"]`).
+- `sets/<key>.json`:
+  `{"format_version": 1, "members": ["red", "green"], "expire_at_ms": null}`
+- `zsets/<key>.json`:
+  `{"format_version": 1, "members": [{"member":"alice","score":100}], "expire_at_ms": null}`
+- `streams/<key>.jsonl`: one entry per line, in stream order:
+  ```
+  {"id": "1714400000000-0", "fields": {"event": "login", "user": "alice"}}
+  {"_meta": true, "length": 2, "last_ms": 1714400000001, "last_seq": 0, "expire_at_ms": null}
+  ```
+  `expire_at_ms` is non-null when the stream has TTL set via
+  `EXPIRE`/`PEXPIRE`/`PEXPIREAT` (kept in `!redis|ttl|` by
+  `buildTTLElems` — `adapter/redis.go:2471`). Without this field, a
+  TTL'd stream would be silently restored as permanent.
+- `hll/<key>.bin` is the binary opaque HLL sketch. HLL TTLs go in a
+  `hll_ttl.jsonl` sidecar (same shape as `strings_ttl.jsonl`) at the
+  `db_<n>` root because HLL is reported as `redisTypeString` but
+  stores its TTL in the legacy scan index (`adapter/redis.go:2319`).
+
+#### SQS
+
+`_queue.json` has the queue configuration that AWS SQS exposes
+(name, FIFO, content-based-dedup, visibility-timeout, retention,
+delay-seconds, redrive-policy).
+
+`messages.jsonl` is one record per line, ordered by
+`(SendTimestampMillis, SequenceNumber, MessageId)`. The schema is
+the dump-time projection of `sqsMessageRecord`
+(`adapter/sqs_messages.go:80`) with **all visibility-state fields
+present but zeroed**. A restored queue starts with every message
+visible — which matches what AWS SQS does when a queue is rehydrated
+from a backup. `--preserve-visibility` keeps the live values for
+operators who need exactness.
+
+JSONL was chosen over per-message files for two reasons: production
+queues commonly hold tens of thousands of messages (one file per
+message inflates inode pressure and `tar` time), and message order
+is intrinsic to FIFO semantics.
+
+In-flight side records (`!sqs|msg|dedup|`, `!sqs|msg|group|`,
+`!sqs|msg|byage|`, `!sqs|msg|vis|`, `!sqs|queue|tombstone|`) are
+derivable from the queue config + message records and are not
+dumped by default. Operators who need exactness pass
+`--include-sqs-side-records` to opt in to the
+`_internals/dedup.jsonl` artifact.
+
+### MANIFEST.json
+
+```json
+{
+  "format_version":   1,
+  "phase":            "phase0-snapshot-decode",
+  "elastickv_version": "v1.7.3",
+  "cluster_id":       "ek-prod-us-east-1",
+  "snapshot_index":   18432021,
+  "last_commit_ts":   4517352099840000,
+  "wall_time_iso":    "2026-04-29T15:42:11.094Z",
+  "source": {
+    "fsm_path":       "/data/fsm-snap/0000000000000064.fsm",
+    "fsm_crc32c":     "deadbeef"
+  },
+  "adapters": {
+    "dynamodb": {"tables":  ["orders", "users"]},
+    "s3":       {"buckets": ["photos"]},
+    "redis":    {"databases": [0]},
+    "sqs":      {"queues":  ["orders-fifo.fifo"]}
+  },
+  "exclusions": {
+    "include_incomplete_uploads": false,
+    "include_orphans":            false,
+    "preserve_sqs_visibility":    false,
+    "include_sqs_side_records":   false
+  },
+  "checksum_algorithm": "sha256",
+  "checksum_format":    "sha256sum",
+  "encoded_filename_charset": "rfc3986-unreserved-plus-percent",
+  "key_segment_max_bytes": 240,
+  "s3_meta_suffix":     ".elastickv-meta.json",
+  "s3_collision_strategy": "leaf-data-suffix",
+  "dynamodb_layout":    "per-item"
+}
+```
+
+`phase` is `"phase0-snapshot-decode"` for offline-decoded dumps and
+`"phase1-live-pinned"` for Phase 1 live-extracted dumps. Restorers
+that care about cross-shard PIT consistency check this field and
+warn (or refuse) on Phase 0 inputs.
+
+`snapshot_index` is the FSM `applied_index` that produced the source
+snapshot; `last_commit_ts` is the HLC commit-ts at that index. Phase 1
+dumps use a `read_ts` field instead.
+
+## Internal-State Handling
+
+Internal keys are partitioned into three classes:
+
+| Class | Examples | Decode behavior |
+|---|---|---|
+| **Re-derivable from user data + config** | DynamoDB GSI rows; S3 route catalog (`!s3route\|`); Redis TTL scan index (`!redis\|ttl\|`); SQS visibility / age / dedup / group / tombstone indexes | Excluded by default. Restore re-builds them by replaying user data through the public adapter API. |
+| **Per-cluster operational state** | HLC physical ceiling; Raft term/index/conf state; FSM marker files; write conflict counter | Never decoded. Belong to the cluster, not the data. |
+| **In-flight transactional state** | `!txn\|` intent / lock / resolver records (`kv/txn_keys.go`, `kv/txn_codec.go`); pending S3 multipart uploads | Excluded by default. Optionally dumped under `_internals/` for forensics, but never re-applied — replaying intents from a stale snapshot can resurrect aborted transactions. |
+
+This is what makes Phase 0 backups safe across versions: only
+information the user could have reconstructed from API responses
+(DescribeTable, GetObject, KEYS *, etc.) is encoded. Anything
+depending on elastickv's internal physics stays in elastickv.
+
+## Tooling
+
+### Decoder: `cmd/elastickv-snapshot-decode`
+
+```
+elastickv-snapshot-decode \
+  --input  <fsm-file>          # or --input-snap-dir <data-dir>/fsm-snap/
+  --output <directory-root> \
+  [--adapter dynamodb,s3,redis,sqs] \
+  [--scope dynamodb=orders,users] \
+  [--include-incomplete-uploads] \
+  [--include-orphans] \
+  [--preserve-sqs-visibility] \
+  [--include-sqs-side-records] \
+  [--dynamodb-bundle-mode per-item|jsonl] \
+  [--dynamodb-bundle-size 64MiB] \
+  [--rename-collisions] \
+  [--checksums sha256]
+```
+
+Pipeline:
+
+```
+open .fsm                                       # verifies CRC32C footer
+parse EKVPBBL1 magic + lastCommitTS
+stream ([keyLen:8][key][valLen:8][val])* entries:
+  dispatch by leading prefix:
+    "!ddb|item|"  → DynamoDB item encoder
+    "!ddb|meta|"  → DynamoDB schema encoder
+    "!s3|obj|"    → S3 manifest encoder (buffer; emit when blob seen)
+    "!s3|blob|"   → S3 blob writer (append to assembled object body)
+    "!redis|str|" → Redis string encoder
+    "!hs|"        → Redis hash encoder
+    "!lst|"       → Redis list encoder
+    "!st|"        → Redis set encoder
+    "!zs|"        → Redis zset encoder
+    "!stream|"    → Redis stream encoder
+    "!sqs|queue|" → SQS queue meta encoder
+    "!sqs|msg|"   → SQS message encoder
+    "!txn|"       → drop (or emit to _internals/ if requested)
+    other "!..."  → drop (internal state)
+emit MANIFEST.json + CHECKSUMS last
+```
+
+Memory: streaming. The decoder holds at most one assembled S3
+object's manifest entries in memory at a time (one per active
+bucket × generation; bounded by the number of in-flight objects in
+the snapshot). Other adapters emit per-record without buffering.
+
+`--input-snap-dir` mode points at a `fsm-snap/` directory and
+processes the newest `.fsm` (or every `.fsm` in chronological order
+with `--all`) so an operator does not need to know which file is
+current.
+
+### Encoder: `cmd/elastickv-snapshot-encode`
+
+```
+elastickv-snapshot-encode \
+  --input  <directory-root> \
+  --output <fsm-file> \
+  [--last-commit-ts <unix-ms>]
+```
+
+Pipeline:
+
+```
+read MANIFEST.json (refuse on unknown major format_version)
+walk per-adapter subtrees:
+  DynamoDB → emit !ddb|meta|table| then !ddb|item| KV pairs
+  S3       → emit !s3|bucket|meta| then !s3|obj|head| then !s3|blob| pairs
+              (split assembled bodies into chunks at the same chunk-size
+              the live cluster uses; chunk_size from MANIFEST.json)
+  Redis    → emit per-type wide-column or simple keys
+  SQS      → emit !sqs|queue|meta| then !sqs|msg|data| pairs
+verify the resulting key-set has no duplicates
+write EKVPBBL1 header + lastCommitTS + sorted KV stream + CRC32C footer
+```
+
+Output is a valid `.fsm` file in the same wire format the live FSM
+emits.
+
+### Restore via stop-replace-restart
+
+Phase 0 does not include a "live load this snapshot" RPC — that is
+non-trivial (would need pause/resume Apply, install snapshot at the
+right index, etc.). Operators restore by:
+
+1. Stop the target node.
+2. Generate the matching `.snap` token file (see
+   `2026_04_14_implemented_etcd_snapshot_disk_offload.md` for the
+   17-byte EKVT format) using a small `cmd/elastickv-snap-token`
+   helper that takes the `.fsm` path and emits the token file.
+3. Place the new `.fsm` in `{dataDir}/fsm-snap/<index>.fsm` and the
+   token in `{dataDir}/snap/<index>.snap` (atomic rename of both,
+   then `syncDir` of both directories).
+4. Start the node. It loads the snapshot at startup as if it had
+   just installed it from a leader.
+
+For multi-node clusters: do this on one node first, then re-add the
+others as fresh members so they snapshot-install from the seeded
+node.
+
+For a *fresh cluster* (zero state, just-bootstrapped), the encoder
+output can be placed directly under `fsm-snap/` and the cluster
+opens to it as its initial state. This is the cleanest restore
+path.
+
+The runbook for both is documented in
+`docs/operations/snapshot_restore.md` (separate PR after this
+design lands).
+
+### External tools
+
+- DynamoDB: `aws dynamodb create-table --cli-input-json _schema.json` and
+  then `aws dynamodb put-item --item @items/<pk>/<sk>.json` per file.
+- S3: `aws s3 sync --exclude '*.elastickv-meta.json' s3/<bucket>/ s3://target-bucket/`,
+  followed by a one-pass script that maps
+  `<obj>.elastickv-meta.json` to `--metadata` / `--content-type`.
+- Redis: a 100-line shell script over
+  `find redis/db_0/strings -name '*.bin' -exec redis-cli -x SET …`,
+  with similar one-liners per type.
+- SQS: `jq -c . messages.jsonl | xargs -n1 aws sqs send-message --message-body …`.
+
+These are intentionally one-liners. If they require a 500-line
+bespoke parser, the format has failed its goal.
+
+## Trade-offs
+
+### Benefits
+
+- **Minimal surface area.** Two CLI tools, one shared internal package,
+  no proto changes, no FSM changes, no admin RPCs, no Raft involvement.
+- **Works without a running cluster.** A `.fsm` file pulled from S3 /
+  tape / a sidecar disk is all the input the decoder needs.
+- **Deterministic and offline-testable.** A unit test feeds a
+  synthetic snapshot and asserts the resulting directory tree.
+- **Format owner.** Phase 1 produces the same format; the format
+  itself is defined here, in one place, decoupled from the
+  live-cluster machinery.
+
+### Costs
+
+- **Multi-shard inconsistency.** Each Raft group's snapshot is at an
+  independent `applied_index` and therefore an independent
+  `commit_ts`. A multi-shard dump produced by running the decoder
+  over each group's `.fsm` shows shard-A's state at one ts and
+  shard-B's at another — cross-shard transactions can split.
+- **Staleness.** Whatever was written between the snapshot's
+  `applied_index` and "now" is not in the snapshot, so it is not in
+  the decoded output. The gap is bounded by `SnapshotEvery × write_rate`
+  (default 10000 entries; for a write-heavy cluster, seconds; for a
+  quiet one, hours).
+- **Cadence is not user-controlled.** "Snapshot now" requires a Raft
+  trigger; the decoder cannot create a fresh snapshot, only consume
+  existing ones. Phase 1 takes a fresh PIT on demand.
+- **The encoder must reproduce internal layouts.** Encoding a
+  decoded directory tree back into a `.fsm` requires re-emitting the
+  exact internal key encodings (`!ddb|item|<table>|<gen>|<orderedKey>`
+  with the right `generation` value, `!s3|blob|<bucket><gen><obj>...`
+  with the right chunk boundaries). This means the encoder has a
+  hard dependency on the live key-format version: encoding a v1
+  dump as a v2 `.fsm` requires per-version logic. The decoded
+  directory tree itself is version-stable; only the encoder side
+  takes on this coupling.
+
+### When Phase 0 is sufficient
+
+| Need | Phase 0 enough? |
+|---|---|
+| Vendor-independent recovery format on disk | ✓ |
+| One-time export off elastickv (migration) | ✓ |
+| Single-shard cluster backup | ✓ |
+| Per-shard backup of long-lived data | ✓ |
+| Recovering one DynamoDB row by hand | ✓ |
+| Multi-shard cross-group point-in-time consistency | ✗ — Phase 1 |
+| "Take a backup right now" with bounded staleness | ✗ — Phase 1 |
+| Online running-cluster backup | ✗ — Phase 1 |
+| Cross-cluster live replication | ✗ — Phase 1 / Phase 3 |
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Stale `.fsm` (old snapshot, much newer cluster state) | Decoder records `snapshot_index` and `wall_time_iso` in `MANIFEST.json`; operators reading the dump know how stale it is |
+| Encoder produces a `.fsm` the running cluster cannot load | Encoder runs `cmd/elastickv-snapshot-decode` on its own output and asserts a byte-identical round-trip before emitting the final `.fsm` |
+| Format drift between Phase 0 dumps from different elastickv versions | `format_version` major-version gate on `MANIFEST.json`; decoder refuses unknown major versions; minor-version drift handled through optional fields |
+| In-flight S3 multipart uploads referenced by the snapshot but not committed | Excluded by default; `--include-incomplete-uploads` opts in and emits them under a clearly-marked `_incomplete_uploads/` subtree |
+| Restoring an encoded `.fsm` onto a node with mismatched cluster_id | Encoder emits `cluster_id` in `MANIFEST.json`; the restore-runbook step checks it matches the target node before placing the file |
+
+## Implementation Phases
+
+### Phase 0a — Decoder
+
+- New binary `cmd/elastickv-snapshot-decode/`.
+- `internal/backup/` package (filename encoding, per-adapter
+  encoders, `MANIFEST.json` writer, CHECKSUMS writer). Shared with
+  Phase 1 — Phase 1 imports the same package and produces the same
+  format.
+- Per-adapter encoders:
+  - `internal/backup/dynamodb.go` — items + `_schema.json`.
+  - `internal/backup/s3.go` — manifest reassembly into single object
+    files, sidecar metadata, multipart flattening.
+  - `internal/backup/redis.go` — strings/hashes/lists/sets/zsets/streams/hll
+    with TTL sidecars.
+  - `internal/backup/sqs.go` — `_queue.json` + `messages.jsonl`.
+- Filename encoding lives in `internal/backup/filename.go` with
+  shared unit tests for round-trip safety.
+- `cmd/elastickv-snap-token` helper for synthesizing the matching
+  `.snap` EKVT token file from a `.fsm`.
+- Documentation: `docs/operations/snapshot_restore.md` runbook
+  (separate PR after this design lands).
+
+### Phase 0b — Encoder
+
+- New binary `cmd/elastickv-snapshot-encode/`.
+- Reverse-direction encoders mirroring the Phase 0a code path.
+- Self-test: encode → decode round-trip asserts byte-identical
+  output for the user-visible directory tree (modulo wall-time and
+  encoder version metadata).
+- End-to-end test: encode a synthetic dump, place output in a
+  fresh single-node cluster's `fsm-snap/` + `snap/`, start the
+  cluster, verify reads return the original data via the
+  DynamoDB / S3 / Redis / SQS adapters.
+
+### Phase 0c — Operator integration
+
+- Stop-replace-restart runbook in `docs/operations/`.
+- Cluster-id and version-compatibility guards.
+- Tar / tar+zstd helpers for shipping decoded directory trees off
+  the host.
+
+## Required Tests
+
+### P0
+
+| Test | Verifies |
+|------|---|
+| `TestFilenameEncodingRoundTrip` | Random bytes → encode → decode → original; long segments overflow into SHA-256 fallback; binary keys take the `b64.` path |
+| `TestSnapshotDecodeAllAdapters` | A synthetic `.fsm` containing one record per adapter (DynamoDB, S3, Redis × all types, SQS) decodes to the documented directory shape; record contents match the inputs |
+| `TestS3DecodeReassemblesObject` | Multipart object stored across N parts and M chunks per part round-trips bytewise to a single decoded file; `.elastickv-meta.json` matches manifest |
+| `TestRedisDecodeAllTypes` | One key per type round-trips through decode + the Phase 0b encode back to a `.fsm` whose Pebble image matches the original |
+| `TestSQSDecodeFifoOrderPreserved` | Messages with interleaved `MessageGroupId` are emitted in `(send_ts, sequence_number, message_id)` order; visibility-state fields zeroed by default |
+| `TestStreamTTLPreserved` | A stream with `PEXPIREAT` round-trips: `expire_at_ms` is captured in the `_meta` line and re-applied by the encoder |
+| `TestHLLTTLPreserved` | TTL'd HLL key surfaces in `hll_ttl.jsonl` and is re-applied by the encoder; no-TTL HLLs leave `hll_ttl.jsonl` absent |
+| `TestS3PathFileVsDirectoryCollision` | Bucket holds both `path/to` (object) and `path/to/obj`; decoder renames the shorter to `path/to.elastickv-leaf-data` and records it in `KEYMAP.jsonl`; `MANIFEST.s3_collision_strategy` set |
+| `TestS3SidecarSuffixCollision` | A user S3 object key ending in `.elastickv-meta.json` is rejected without `--rename-collisions`; with the flag the rename is recorded |
+| `TestEncodeDecodeRoundTrip` | Encoded `.fsm` decodes back to a directory tree byte-identical to the original (wall-time fields excluded) |
+| `TestManifestVersionGate` | Decoder refuses inputs with `format_version > current_major`; same-major-newer-minor allowed; older-major refused with a clear message |
+| `TestDecoderRejectsTruncatedFSM` | A `.fsm` whose CRC32C footer fails verification is rejected with a typed error before any record is emitted |
+
+### P1
+
+| Test | Verifies |
+|------|---|
+| `TestEncoderProducesLoadableSnapshot` | Encoder output placed under a fresh node's `fsm-snap/` + `snap/` is loaded successfully on `Open`; the resulting cluster serves the original data via every adapter |
+| `TestLongKeySHA256Fallback` | A 1 KiB key encodes to `<sha256-prefix-32>__<truncated>`; `KEYMAP.jsonl` records the original; encoder reverses correctly |
+| `TestExternalToolReplay` | Generated `aws s3 sync` / `aws dynamodb put-item` / `redis-cli --pipe` scripts (run in CI against MinIO / a local DynamoDB / a real Redis) reproduce the decoded state on a non-elastickv target |
+| `TestEncoderClusterIDGuard` | Encoder writes `cluster_id` in `MANIFEST.json`; the restore runbook step refuses to place the file if the target node's `cluster_id` differs |
+| `TestPhaseFieldDistinguishesPhase0And1` | A Phase 1 dump and a Phase 0 dump containing the same logical state both pass the decoder's structural validation but `MANIFEST.phase` distinguishes them |
+
+### P2
+
+| Test | Verifies |
+|------|---|
+| `FuzzFilenameEncoding` | Encoder/decoder never panics and is bijective on arbitrary byte input |
+| `BenchmarkSnapshotDecodeThroughput` | Establishes baseline throughput per adapter so Phase 1 has a regression target |
+
+## References
+
+- `2026_04_14_implemented_etcd_snapshot_disk_offload.md` — the
+  `.fsm` file format Phase 0 reads and writes.
+- `2026_04_29_proposed_logical_backup.md` — Phase 1 (live PIT
+  extraction). Phase 1 produces dumps in the same format defined
+  here.
+- `internal/s3keys/keys.go`, `kv/shard_key.go`, `adapter/sqs_keys.go`,
+  `store/{hash,list,set,zset,stream}_helpers.go` — the internal key
+  layouts the decoder dispatches on and the encoder reproduces.
+- `adapter/dynamodb_storage_codec.go`, `adapter/sqs_messages.go`,
+  `adapter/redis_storage_codec.go` — internal value envelopes
+  (magic-prefixed protobuf/JSON) that the decoder unwraps and the
+  encoder re-wraps.


### PR DESCRIPTION
Per-adapter directory hierarchy (dynamodb/<table>/items/<pk>.json, s3/<bucket>/<original/path>, redis/db_<n>/<type>/<key>.{bin,json,jsonl}, sqs/<queue>/messages.jsonl) so a backup is recoverable without elastickv — cat / jq / find / aws s3 sync / redis-cli are sufficient. Strips internal magic prefixes and wide-column key encodings; pins read_ts via the lease- read path and the active timestamp tracker so the dump is consistent and the compactor cannot retire its versions mid-dump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added design documentation for Phase 0 snapshot converter, specifying offline conversion between snapshot files and vendor-independent logical format with encoding rules and restore procedures.
* Added design documentation for Phase 1 logical backup system, outlining cluster-wide point-in-time consistent backup lifecycle management and forward-compatibility approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->