### PR TITLE
feat(keyviz): sampler GroupID + LeaderTerm stamping (Phase 2-C+ PR-3a)

### DIFF
--- a/keyviz/flusher_test.go
+++ b/keyviz/flusher_test.go
@@ -9,7 +9,7 @@ import (
 func TestRunFlusherTicksUntilCancel(t *testing.T) {
 	t.Parallel()
 	s := NewMemSampler(MemSamplerOptions{Step: 5 * time.Millisecond, HistoryColumns: 16})
-	if !s.RegisterRoute(1, []byte("a"), []byte("b")) {
+	if !s.RegisterRoute(1, []byte("a"), []byte("b"), 0) {
 		t.Fatal("Register failed")
 	}
 	ctx, cancel := context.WithCancel(context.Background())

--- a/keyviz/sampler.go
+++ b/keyviz/sampler.go
@@ -160,6 +160,13 @@ type MemSampler struct {
 	// twice in the same column — once as an aggregate row, once as
 	// an individual row — even under register/remove churn.
 	virtualIDCounter atomic.Uint64
+
+	// groupTermsMu guards groupTerms. SetLeaderTerm and Flush both
+	// touch the map; Observe never does. The lock is fine-grained
+	// enough that contention is bounded by leader-term flips, which
+	// happen at most a few times per second across the whole cluster.
+	groupTermsMu sync.RWMutex
+	groupTerms   map[uint64]uint64
 }
 
 // retiredSlot tracks a removed slot through its post-removal grace
@@ -237,6 +244,14 @@ type routeTable struct {
 type routeSlot struct {
 	metaMu  sync.RWMutex
 	RouteID uint64
+	// GroupID is the Raft group this route belongs to. Phase 2-C+
+	// stamps this on every emitted MatrixRow so the cluster fan-out
+	// aggregator can dedupe write samples by (raftGroupID,
+	// leaderTerm) instead of the conservative max-merge that may
+	// undercount during a leadership flip. 0 means "no group
+	// attached" (legacy single-group deployments and the synthetic
+	// virtual-bucket slots both use 0).
+	GroupID uint64
 	Start   []byte
 	End     []byte
 	// Aggregate marks virtual buckets that fold multiple coarsened
@@ -266,7 +281,7 @@ type routeSlot struct {
 // Start/End/MemberRoutes with the live slot (which a later
 // RegisterRoute may extend, and which the snapshot API exports to
 // external consumers that may mutate the bounds).
-func (s *routeSlot) snapshotMeta() (start, end []byte, aggregate bool, members []uint64, membersTotal uint64) {
+func (s *routeSlot) snapshotMeta() (start, end []byte, aggregate bool, members []uint64, membersTotal, groupID uint64) {
 	s.metaMu.RLock()
 	defer s.metaMu.RUnlock()
 	start = cloneBytes(s.Start)
@@ -276,6 +291,7 @@ func (s *routeSlot) snapshotMeta() (start, end []byte, aggregate bool, members [
 		members = append([]uint64(nil), s.MemberRoutes...)
 	}
 	membersTotal = s.MemberRoutesTotal
+	groupID = s.GroupID
 	return
 }
 
@@ -298,6 +314,16 @@ type MatrixRow struct {
 	// Snapshot consumers should treat MemberRoutes as the visible
 	// prefix of this list when MemberRoutesTotal > len(MemberRoutes).
 	MemberRoutesTotal uint64
+
+	// RaftGroupID + LeaderTerm carry the route's Raft identity at the
+	// time the column was flushed. Stamped from the per-group term
+	// snapshot SetLeaderTerm publishes (Phase 2-C+ fan-out merge
+	// uses (RouteID/BucketID, RaftGroupID, LeaderTerm, columnAt) as
+	// the dedupe key). Zero values mean "term not tracked" — emitted
+	// when no SetLeaderTerm call has been made for the group yet, or
+	// for synthetic virtual-bucket slots that span groups.
+	RaftGroupID uint64
+	LeaderTerm  uint64
 
 	Reads      uint64
 	Writes     uint64
@@ -331,12 +357,47 @@ func NewMemSampler(opts MemSamplerOptions) *MemSampler {
 		now = time.Now
 	}
 	s := &MemSampler{
-		opts:    opts,
-		now:     now,
-		history: newRingBuffer(opts.HistoryColumns),
+		opts:       opts,
+		now:        now,
+		history:    newRingBuffer(opts.HistoryColumns),
+		groupTerms: map[uint64]uint64{},
 	}
 	s.table.Store(newEmptyRouteTable())
 	return s
+}
+
+// SetLeaderTerm publishes the current Raft leader term for the given
+// group. Called by main.go on a periodic ticker that polls the engine
+// Status, and on every term-change observed via the engine. Phase 2-C+
+// stamps each MatrixRow's LeaderTerm from this snapshot at Flush time.
+//
+// Calling with term == 0 is allowed but treated as "term unknown"
+// during merge — the canonical (groupID, term) dedupe key collapses
+// to the legacy max-merge for cells whose LeaderTerm is 0. This lets
+// nodes that have not finished engine startup contribute partial data
+// without poisoning the merge.
+//
+// nil-receiver-safe.
+func (s *MemSampler) SetLeaderTerm(groupID, term uint64) {
+	if s == nil {
+		return
+	}
+	s.groupTermsMu.Lock()
+	defer s.groupTermsMu.Unlock()
+	s.groupTerms[groupID] = term
+}
+
+// snapshotGroupTerms returns a copy of the per-group term map. Called
+// at the top of Flush so the column built below sees a stable view
+// of the term mapping even if SetLeaderTerm fires concurrently.
+func (s *MemSampler) snapshotGroupTerms() map[uint64]uint64 {
+	s.groupTermsMu.RLock()
+	defer s.groupTermsMu.RUnlock()
+	out := make(map[uint64]uint64, len(s.groupTerms))
+	for g, t := range s.groupTerms {
+		out[g] = t
+	}
+	return out
 }
 
 func newEmptyRouteTable() *routeTable {
@@ -385,10 +446,18 @@ func (s *MemSampler) Observe(routeID uint64, op Op, keyLen, valueLen int) {
 }
 
 // RegisterRoute adds a (RouteID, [Start, End)) pair to the tracking
-// set. Returns true when the route gets its own slot, false when the
+// set. groupID is the Raft group the route belongs to; it is stamped
+// onto every MatrixRow this slot eventually emits so the Phase 2-C+
+// fan-out merge can dedupe write samples by (groupID, leaderTerm).
+// Pass 0 when the deployment doesn't use multiple groups (legacy /
+// single-group setups); the legacy max-merge fallback handles those.
+//
+// Returns true when the route gets its own slot, false when the
 // MaxTrackedRoutes cap was hit and the route was folded into a
 // virtual aggregate bucket. Idempotent: calling twice with the same
-// RouteID is a no-op (the original slot stays in place).
+// RouteID is a no-op (the original slot stays in place; a different
+// groupID on the second call is silently ignored — RegisterRoute is
+// not the right API to retag a slot, RemoveRoute + RegisterRoute is).
 //
 // If a previous RemoveRoute(routeID) queued a deferred member-prune
 // and the route is now re-registered into the SAME bucket inside the
@@ -397,7 +466,7 @@ func (s *MemSampler) Observe(routeID uint64, op Op, keyLen, valueLen int) {
 // attributing fresh traffic to it. Prunes for different buckets (or
 // when the route rejoins as an individual slot) are left alone so
 // the old bucket's MemberRoutes is correctly cleaned up.
-func (s *MemSampler) RegisterRoute(routeID uint64, start, end []byte) bool {
+func (s *MemSampler) RegisterRoute(routeID uint64, start, end []byte, groupID uint64) bool {
 	if s == nil {
 		return false
 	}
@@ -418,6 +487,7 @@ func (s *MemSampler) RegisterRoute(routeID uint64, start, end []byte) bool {
 		if slot == nil {
 			slot = &routeSlot{
 				RouteID:           routeID,
+				GroupID:           groupID,
 				Start:             cloneBytes(start),
 				End:               cloneBytes(end),
 				MemberRoutesTotal: 1,
@@ -431,6 +501,7 @@ func (s *MemSampler) RegisterRoute(routeID uint64, start, end []byte) bool {
 			// counts split across them. Refresh the metadata fields to
 			// match the new registration; counters are preserved.
 			slot.metaMu.Lock()
+			slot.GroupID = groupID
 			slot.Start = cloneBytes(start)
 			slot.End = cloneBytes(end)
 			slot.MemberRoutesTotal = 1
@@ -601,14 +672,21 @@ func (s *MemSampler) Flush() {
 		return
 	}
 	col := MatrixColumn{At: s.now()}
+	// Snapshot the per-group leader-term map once at the top of
+	// Flush so every row in this column sees a consistent view, even
+	// if SetLeaderTerm fires concurrently. Later rows can never
+	// observe a *newer* term than earlier rows in the same column,
+	// which preserves the merge-side invariant that all rows in a
+	// (groupID, columnAt) tuple share a single leaderTerm value.
+	terms := s.snapshotGroupTerms()
 	tbl := s.table.Load()
 	for _, slot := range tbl.sortedSlots {
-		col.Rows = appendDrainedRow(col.Rows, slot)
+		col.Rows = appendDrainedRow(col.Rows, slot, terms)
 	}
 
 	grace := s.graceWindow()
 	s.retiredMu.Lock()
-	s.retiredSlots = drainRetiredSlots(s.retiredSlots, &col.Rows, col.At, grace)
+	s.retiredSlots = drainRetiredSlots(s.retiredSlots, &col.Rows, col.At, grace, terms)
 	s.pendingPrunes = advancePendingPrunes(s.pendingPrunes, col.At, grace)
 	s.retiredMu.Unlock()
 
@@ -628,10 +706,10 @@ func (s *MemSampler) Flush() {
 // this final drain. The dropped tail of the backing array is zeroed
 // so released *routeSlot pointers do not stay GC-reachable through
 // the reused capacity.
-func drainRetiredSlots(retired []retiredSlot, rows *[]MatrixRow, now time.Time, grace time.Duration) []retiredSlot {
+func drainRetiredSlots(retired []retiredSlot, rows *[]MatrixRow, now time.Time, grace time.Duration, terms map[uint64]uint64) []retiredSlot {
 	keep := retired[:0]
 	for _, r := range retired {
-		*rows = appendDrainedRow(*rows, r.slot)
+		*rows = appendDrainedRow(*rows, r.slot, terms)
 		if now.Sub(r.retiredAt) < grace {
 			keep = append(keep, r)
 		}
@@ -825,7 +903,7 @@ func (s *MemSampler) HistoryColumns() int {
 // MatrixRow when any counter was non-zero. Idle slots are skipped.
 // Metadata is read under the slot's metaMu so a concurrent
 // RegisterRoute fold cannot race with the row materialisation.
-func appendDrainedRow(rows []MatrixRow, slot *routeSlot) []MatrixRow {
+func appendDrainedRow(rows []MatrixRow, slot *routeSlot, terms map[uint64]uint64) []MatrixRow {
 	reads := slot.reads.Swap(0)
 	writes := slot.writes.Swap(0)
 	readBytes := slot.readBytes.Swap(0)
@@ -833,9 +911,11 @@ func appendDrainedRow(rows []MatrixRow, slot *routeSlot) []MatrixRow {
 	if reads == 0 && writes == 0 && readBytes == 0 && writeBytes == 0 {
 		return rows
 	}
-	start, end, aggregate, members, membersTotal := slot.snapshotMeta()
+	start, end, aggregate, members, membersTotal, groupID := slot.snapshotMeta()
 	return append(rows, MatrixRow{
 		RouteID:           slot.RouteID,
+		RaftGroupID:       groupID,
+		LeaderTerm:        terms[groupID],
 		Start:             start,
 		End:               end,
 		Aggregate:         aggregate,

--- a/keyviz/sampler.go
+++ b/keyviz/sampler.go
@@ -377,9 +377,15 @@ func NewMemSampler(opts MemSamplerOptions) *MemSampler {
 // nodes that have not finished engine startup contribute partial data
 // without poisoning the merge.
 //
+// groupID == 0 is reserved for virtual aggregate buckets (which span
+// multiple real groups). Calls with groupID == 0 are silently ignored
+// so a future caller cannot accidentally stamp a non-zero term on
+// aggregate rows — they must remain LeaderTerm == 0 so the fan-out
+// merge falls back to max-merge for cross-group cells.
+//
 // nil-receiver-safe.
 func (s *MemSampler) SetLeaderTerm(groupID, term uint64) {
-	if s == nil {
+	if s == nil || groupID == 0 {
 		return
 	}
 	s.groupTermsMu.Lock()
@@ -390,9 +396,15 @@ func (s *MemSampler) SetLeaderTerm(groupID, term uint64) {
 // snapshotGroupTerms returns a copy of the per-group term map. Called
 // at the top of Flush so the column built below sees a stable view
 // of the term mapping even if SetLeaderTerm fires concurrently.
+// Returns nil when no terms have been published yet — `nil[k]` returns
+// the zero value in Go, so the row-builder hot path needs no nil guard
+// and avoids one allocation per Flush before SetLeaderTerm is wired.
 func (s *MemSampler) snapshotGroupTerms() map[uint64]uint64 {
 	s.groupTermsMu.RLock()
 	defer s.groupTermsMu.RUnlock()
+	if len(s.groupTerms) == 0 {
+		return nil
+	}
 	out := make(map[uint64]uint64, len(s.groupTerms))
 	for g, t := range s.groupTerms {
 		out[g] = t

--- a/keyviz/sampler_test.go
+++ b/keyviz/sampler_test.go
@@ -37,7 +37,7 @@ func TestNilSamplerObserveSafe(t *testing.T) {
 	t.Parallel()
 	var s *MemSampler // nil
 	s.Observe(1, OpRead, 10, 20)
-	if s.RegisterRoute(1, []byte("a"), []byte("b")) {
+	if s.RegisterRoute(1, []byte("a"), []byte("b"), 0) {
 		t.Fatal("nil RegisterRoute should return false")
 	}
 	s.RemoveRoute(1)
@@ -50,7 +50,7 @@ func TestNilSamplerObserveSafe(t *testing.T) {
 func TestObserveAndFlushBasic(t *testing.T) {
 	t.Parallel()
 	s, clk := newTestSampler(t, MemSamplerOptions{Step: time.Second, HistoryColumns: 4})
-	if !s.RegisterRoute(1, []byte("a"), []byte("c")) {
+	if !s.RegisterRoute(1, []byte("a"), []byte("c"), 0) {
 		t.Fatal("RegisterRoute(1) returned false")
 	}
 	s.Observe(1, OpRead, 5, 10)
@@ -90,7 +90,7 @@ func TestNoCountsLostAcrossFlush(t *testing.T) {
 		flushes   = 20
 	)
 	s, _ := newTestSampler(t, MemSamplerOptions{Step: time.Millisecond, HistoryColumns: 1024})
-	if !s.RegisterRoute(1, []byte("a"), []byte("b")) {
+	if !s.RegisterRoute(1, []byte("a"), []byte("b"), 0) {
 		t.Fatal("Register failed")
 	}
 
@@ -159,13 +159,13 @@ func budgetSetup(t *testing.T) *MemSampler {
 		HistoryColumns:   4,
 		MaxTrackedRoutes: 2,
 	})
-	if !s.RegisterRoute(1, []byte("a"), []byte("c")) {
+	if !s.RegisterRoute(1, []byte("a"), []byte("c"), 0) {
 		t.Fatal("route 1 should fit")
 	}
-	if !s.RegisterRoute(2, []byte("c"), []byte("e")) {
+	if !s.RegisterRoute(2, []byte("c"), []byte("e"), 0) {
 		t.Fatal("route 2 should fit")
 	}
-	if s.RegisterRoute(3, []byte("e"), []byte("g")) {
+	if s.RegisterRoute(3, []byte("e"), []byte("g"), 0) {
 		t.Fatal("route 3 over budget should return false (folded into virtual bucket)")
 	}
 	return s
@@ -198,7 +198,7 @@ func findAggregateRow(t *testing.T, rows []MatrixRow) MatrixRow {
 func TestSnapshotRangeFilters(t *testing.T) {
 	t.Parallel()
 	s, clk := newTestSampler(t, MemSamplerOptions{Step: time.Second, HistoryColumns: 8})
-	s.RegisterRoute(1, []byte("a"), []byte("b"))
+	s.RegisterRoute(1, []byte("a"), []byte("b"), 0)
 	for i := 0; i < 5; i++ {
 		s.Observe(1, OpRead, 0, 0)
 		s.Flush()
@@ -222,7 +222,7 @@ func TestSnapshotRangeFilters(t *testing.T) {
 func TestRingBufferDropsOldest(t *testing.T) {
 	t.Parallel()
 	s, clk := newTestSampler(t, MemSamplerOptions{Step: time.Second, HistoryColumns: 3})
-	s.RegisterRoute(1, []byte("a"), []byte("b"))
+	s.RegisterRoute(1, []byte("a"), []byte("b"), 0)
 	for i := 0; i < 5; i++ {
 		s.Observe(1, OpRead, 0, 0)
 		s.Flush()
@@ -243,7 +243,7 @@ func TestRingBufferDropsOldest(t *testing.T) {
 func TestRemoveRouteSilencesObserve(t *testing.T) {
 	t.Parallel()
 	s, _ := newTestSampler(t, MemSamplerOptions{Step: time.Second, HistoryColumns: 4})
-	s.RegisterRoute(1, []byte("a"), []byte("b"))
+	s.RegisterRoute(1, []byte("a"), []byte("b"), 0)
 	s.Observe(1, OpRead, 0, 0)
 	s.RemoveRoute(1)
 	s.Observe(1, OpRead, 0, 0) // silently dropped
@@ -264,7 +264,7 @@ func TestRemoveRouteSilencesObserve(t *testing.T) {
 func TestRemoveRouteHarvestsPendingCounts(t *testing.T) {
 	t.Parallel()
 	s, _ := newTestSampler(t, MemSamplerOptions{Step: time.Second, HistoryColumns: 4})
-	s.RegisterRoute(1, []byte("a"), []byte("b"))
+	s.RegisterRoute(1, []byte("a"), []byte("b"), 0)
 	for i := 0; i < 7; i++ {
 		s.Observe(1, OpRead, 1, 0)
 	}
@@ -360,13 +360,13 @@ func setupOneIndividualPlusVirtualBucket(t *testing.T) (*MemSampler, *fakeClock)
 		HistoryColumns:   4,
 		MaxTrackedRoutes: 1,
 	})
-	if !s.RegisterRoute(1, []byte("a"), []byte("c")) {
+	if !s.RegisterRoute(1, []byte("a"), []byte("c"), 0) {
 		t.Fatal("route 1 should fit")
 	}
-	if s.RegisterRoute(2, []byte("c"), []byte("e")) {
+	if s.RegisterRoute(2, []byte("c"), []byte("e"), 0) {
 		t.Fatal("route 2 should fold (over budget)")
 	}
-	if s.RegisterRoute(3, []byte("e"), []byte("g")) {
+	if s.RegisterRoute(3, []byte("e"), []byte("g"), 0) {
 		t.Fatal("route 3 should fold (over budget)")
 	}
 	return s, clk
@@ -383,11 +383,11 @@ func TestRegisterDoesNotRaceFlushOnVirtualBucket(t *testing.T) {
 		HistoryColumns:   1024,
 		MaxTrackedRoutes: 1,
 	})
-	if !s.RegisterRoute(1, []byte("a"), []byte("b")) {
+	if !s.RegisterRoute(1, []byte("a"), []byte("b"), 0) {
 		t.Fatal("route 1 should fit")
 	}
 	// Seed a virtual bucket so subsequent Registers fold into it.
-	if s.RegisterRoute(2, []byte("c"), []byte("d")) {
+	if s.RegisterRoute(2, []byte("c"), []byte("d"), 0) {
 		t.Fatal("route 2 should fold")
 	}
 
@@ -402,7 +402,7 @@ func TestRegisterDoesNotRaceFlushOnVirtualBucket(t *testing.T) {
 				return
 			default:
 			}
-			s.RegisterRoute(uint64(n), []byte{byte(n)}, []byte{byte(n + 1)}) //nolint:gosec // bounded test loop.
+			s.RegisterRoute(uint64(n), []byte{byte(n)}, []byte{byte(n + 1)}, 0) //nolint:gosec // bounded test loop.
 		}
 	}()
 	wg.Add(1)
@@ -452,7 +452,7 @@ func TestConcurrentRegisterAndObserveRace(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := uint64(1); i <= routes; i++ {
-			s.RegisterRoute(i, []byte{byte('a' + i%26)}, []byte{byte('a' + (i+1)%26)})
+			s.RegisterRoute(i, []byte{byte('a' + i%26)}, []byte{byte('a' + (i+1)%26)}, 0)
 			time.Sleep(time.Microsecond)
 		}
 	}()
@@ -504,7 +504,7 @@ func TestRemoveLastVirtualMemberHarvestsBucket(t *testing.T) {
 		MaxTrackedRoutes: 1,
 	})
 	mustRegister(t, s, 1, "a", "b")
-	if s.RegisterRoute(2, []byte("c"), []byte("d")) {
+	if s.RegisterRoute(2, []byte("c"), []byte("d"), 0) {
 		t.Fatal("route 2 over budget should fold into virtual bucket")
 	}
 	s.Observe(2, OpRead, 5, 7)
@@ -548,7 +548,7 @@ func TestFlushSortsMixedLiveAndRetiredRows(t *testing.T) {
 func TestRetiredSlotGracePeriod(t *testing.T) {
 	t.Parallel()
 	s, clk := newTestSampler(t, MemSamplerOptions{Step: time.Second, HistoryColumns: 8})
-	if !s.RegisterRoute(1, []byte("a"), []byte("b")) {
+	if !s.RegisterRoute(1, []byte("a"), []byte("b"), 0) {
 		t.Fatal("RegisterRoute(1) returned false")
 	}
 	s.Observe(1, OpRead, 1, 2)
@@ -610,13 +610,13 @@ func TestRegisterFoldLowerStartReorders(t *testing.T) {
 	mustRegister(t, s, 1, "m", "n")
 	mustRegister(t, s, 2, "p", "q")
 	// Route 3 is over budget — creates a virtual bucket at Start=r.
-	if s.RegisterRoute(3, []byte("r"), []byte("s")) {
+	if s.RegisterRoute(3, []byte("r"), []byte("s"), 0) {
 		t.Fatal("route 3 over budget should fold into virtual bucket")
 	}
 	// Route 4 is over budget AND has a Start ("a") below the bucket's
 	// existing Start ("r"). The fold must lower bucket.Start to "a"
 	// AND reposition the bucket within sortedSlots.
-	if s.RegisterRoute(4, []byte("a"), []byte("b")) {
+	if s.RegisterRoute(4, []byte("a"), []byte("b"), 0) {
 		t.Fatal("route 4 over budget should fold into virtual bucket")
 	}
 	s.Observe(1, OpRead, 0, 0)
@@ -634,7 +634,7 @@ func TestRegisterFoldLowerStartReorders(t *testing.T) {
 
 func mustRegister(t *testing.T, s *MemSampler, routeID uint64, start, end string) {
 	t.Helper()
-	if !s.RegisterRoute(routeID, []byte(start), []byte(end)) {
+	if !s.RegisterRoute(routeID, []byte(start), []byte(end), 0) {
 		t.Fatalf("RegisterRoute(%d) returned false", routeID)
 	}
 }
@@ -662,7 +662,7 @@ func flushedRowsSorted(t *testing.T, s *MemSampler) []MatrixRow {
 func TestSnapshotReturnsDeepCopy(t *testing.T) {
 	t.Parallel()
 	s, _ := newTestSampler(t, MemSamplerOptions{Step: time.Second, HistoryColumns: 4})
-	if !s.RegisterRoute(1, []byte("aaaa"), []byte("bbbb")) {
+	if !s.RegisterRoute(1, []byte("aaaa"), []byte("bbbb"), 0) {
 		t.Fatal("RegisterRoute(1) returned false")
 	}
 	s.Observe(1, OpRead, 1, 2)
@@ -699,7 +699,7 @@ func TestVirtualBucketRouteIDIsSynthetic(t *testing.T) {
 		MaxTrackedRoutes: 1,
 	})
 	mustRegister(t, s, 1, "a", "b")
-	if s.RegisterRoute(2, []byte("c"), []byte("d")) {
+	if s.RegisterRoute(2, []byte("c"), []byte("d"), 0) {
 		t.Fatal("route 2 should fold into a fresh virtual bucket")
 	}
 	s.Observe(2, OpRead, 0, 0)
@@ -733,10 +733,10 @@ func TestRejoinAsIndividualLetsBucketPruneFire(t *testing.T) {
 		MaxTrackedRoutes: 1,
 	})
 	mustRegister(t, s, 1, "a", "b")
-	if s.RegisterRoute(2, []byte("m"), []byte("n")) {
+	if s.RegisterRoute(2, []byte("m"), []byte("n"), 0) {
 		t.Fatal("route 2 should fold")
 	}
-	if s.RegisterRoute(3, []byte("y"), []byte("z")) {
+	if s.RegisterRoute(3, []byte("y"), []byte("z"), 0) {
 		t.Fatal("route 3 should fold (same bucket)")
 	}
 	s.Observe(2, OpRead, 0, 0)
@@ -746,7 +746,7 @@ func TestRejoinAsIndividualLetsBucketPruneFire(t *testing.T) {
 	// bucket alive in virtualForRoute.
 	s.RemoveRoute(1)
 	s.RemoveRoute(3)
-	if !s.RegisterRoute(3, []byte("y"), []byte("z")) {
+	if !s.RegisterRoute(3, []byte("y"), []byte("z"), 0) {
 		t.Fatal("route 3 should fit individually now")
 	}
 
@@ -815,11 +815,11 @@ func TestReRegisterDuringPruneGraceCancelsPrune(t *testing.T) {
 		MaxTrackedRoutes: 1,
 	})
 	mustRegister(t, s, 1, "a", "b")
-	if s.RegisterRoute(2, []byte("c"), []byte("d")) {
+	if s.RegisterRoute(2, []byte("c"), []byte("d"), 0) {
 		t.Fatal("route 2 should fold into virtual bucket")
 	}
 	s.RemoveRoute(2)
-	if s.RegisterRoute(2, []byte("c"), []byte("d")) {
+	if s.RegisterRoute(2, []byte("c"), []byte("d"), 0) {
 		t.Fatal("route 2 should still fold (over budget)")
 	}
 
@@ -844,6 +844,70 @@ func TestReRegisterDuringPruneGraceCancelsPrune(t *testing.T) {
 }
 
 // TestNonPositiveOptionsFallBackToDefaults pins Codex round-8 P2: a
+// TestRegisterRouteCarriesGroupID pins the Phase 2-C+ contract that
+// MatrixRow.RaftGroupID echoes the groupID supplied at RegisterRoute,
+// independent of leader-term tracking. A route registered with
+// groupID=42 must surface in every flushed row with RaftGroupID=42
+// so the fan-out aggregator's (groupID, leaderTerm) dedupe key is
+// well-defined.
+func TestRegisterRouteCarriesGroupID(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestSampler(t, MemSamplerOptions{Step: time.Second, HistoryColumns: 4})
+	if !s.RegisterRoute(1, []byte("a"), []byte("b"), 42) {
+		t.Fatal("RegisterRoute returned false")
+	}
+	s.Observe(1, OpWrite, 16, 64)
+	s.Flush()
+	cols := s.Snapshot(time.Time{}, time.Time{})
+	if len(cols) != 1 || len(cols[0].Rows) != 1 {
+		t.Fatalf("unexpected snapshot: %+v", cols)
+	}
+	if got := cols[0].Rows[0].RaftGroupID; got != 42 {
+		t.Errorf("RaftGroupID = %d, want 42", got)
+	}
+}
+
+// TestSetLeaderTermStampsRows pins that SetLeaderTerm published before
+// Flush stamps the column's rows with the term, and that subsequent
+// SetLeaderTerm publications are visible to the next Flush only —
+// the per-flush term snapshot is taken at the top of Flush so
+// concurrent term flips do not mid-flush change the stamp.
+func TestSetLeaderTermStampsRows(t *testing.T) {
+	t.Parallel()
+	s, clk := newTestSampler(t, MemSamplerOptions{Step: time.Second, HistoryColumns: 4})
+	if !s.RegisterRoute(1, []byte("a"), []byte("b"), 7) {
+		t.Fatal("RegisterRoute returned false")
+	}
+	s.SetLeaderTerm(7, 100)
+	s.Observe(1, OpWrite, 16, 64)
+	s.Flush()
+	clk.Advance(time.Second)
+
+	s.SetLeaderTerm(7, 101)
+	s.Observe(1, OpWrite, 16, 64)
+	s.Flush()
+
+	cols := s.Snapshot(time.Time{}, time.Time{})
+	if len(cols) != 2 {
+		t.Fatalf("expected 2 columns, got %d", len(cols))
+	}
+	if got := cols[0].Rows[0].LeaderTerm; got != 100 {
+		t.Errorf("col0 LeaderTerm = %d, want 100", got)
+	}
+	if got := cols[1].Rows[0].LeaderTerm; got != 101 {
+		t.Errorf("col1 LeaderTerm = %d, want 101", got)
+	}
+}
+
+// TestSetLeaderTermNilSafe asserts the typed-nil receiver contract
+// extends to SetLeaderTerm — main.go can wire the call before the
+// sampler is constructed and not panic.
+func TestSetLeaderTermNilSafe(t *testing.T) {
+	t.Parallel()
+	var s *MemSampler
+	s.SetLeaderTerm(1, 42) // must not panic
+}
+
 // negative MaxTrackedRoutes used to bypass the zero-check and force
 // every route into a virtual bucket. Confirm both zero and negative
 // inputs land on the documented defaults so a bad CLI/env value
@@ -925,7 +989,7 @@ func TestMemberRoutesCappedAtConfiguredCap(t *testing.T) {
 	mustRegister(t, s, 1, "a", "b")
 	for i := uint64(2); i < 10; i++ {
 		key := []byte{byte('a' + i)}
-		if s.RegisterRoute(i, key, append(key, 'z')) {
+		if s.RegisterRoute(i, key, append(key, 'z'), 0) {
 			t.Fatalf("route %d should fold (over budget)", i)
 		}
 		s.Observe(i, OpRead, 1, 0)
@@ -961,13 +1025,13 @@ func TestPastCapMemberRejoinDoesNotInflateTotal(t *testing.T) {
 		MaxMemberRoutesPerSlot: 1, // visible cap=1; routes 3+4 land in hidden set
 	})
 	mustRegister(t, s, 1, "a", "b")
-	if s.RegisterRoute(2, []byte("c"), []byte("d")) {
+	if s.RegisterRoute(2, []byte("c"), []byte("d"), 0) {
 		t.Fatal("route 2 should fold (visible)")
 	}
-	if s.RegisterRoute(3, []byte("e"), []byte("f")) {
+	if s.RegisterRoute(3, []byte("e"), []byte("f"), 0) {
 		t.Fatal("route 3 should fold (hidden — past cap)")
 	}
-	if s.RegisterRoute(4, []byte("g"), []byte("h")) {
+	if s.RegisterRoute(4, []byte("g"), []byte("h"), 0) {
 		t.Fatal("route 4 should fold (hidden — past cap)")
 	}
 	s.Observe(2, OpRead, 0, 0)
@@ -980,7 +1044,7 @@ func TestPastCapMemberRejoinDoesNotInflateTotal(t *testing.T) {
 	// grace. Without the hidden-member dedup foldIntoBucket would
 	// increment MemberRoutesTotal again, drifting route_count up.
 	s.RemoveRoute(3)
-	if s.RegisterRoute(3, []byte("e"), []byte("f")) {
+	if s.RegisterRoute(3, []byte("e"), []byte("f"), 0) {
 		t.Fatal("route 3 should fold again")
 	}
 	s.Observe(2, OpRead, 0, 0)
@@ -1004,10 +1068,10 @@ func TestPastCapMemberPruneDecrementsTotal(t *testing.T) {
 		MaxMemberRoutesPerSlot: 1,
 	})
 	mustRegister(t, s, 1, "a", "b")
-	if s.RegisterRoute(2, []byte("c"), []byte("d")) {
+	if s.RegisterRoute(2, []byte("c"), []byte("d"), 0) {
 		t.Fatal("route 2 should fold (visible)")
 	}
-	if s.RegisterRoute(3, []byte("e"), []byte("f")) {
+	if s.RegisterRoute(3, []byte("e"), []byte("f"), 0) {
 		t.Fatal("route 3 should fold (hidden — past cap)")
 	}
 	s.Observe(2, OpRead, 0, 0)
@@ -1072,7 +1136,7 @@ func TestRetiredTailClearedAfterDrop(t *testing.T) {
 // catch regressions before they reach the coordinator wiring PR.
 func BenchmarkObserveHit(b *testing.B) {
 	s := NewMemSampler(MemSamplerOptions{Step: time.Second, HistoryColumns: 4})
-	if !s.RegisterRoute(1, []byte("a"), []byte("b")) {
+	if !s.RegisterRoute(1, []byte("a"), []byte("b"), 0) {
 		b.Fatal("RegisterRoute(1) returned false")
 	}
 	b.ReportAllocs()
@@ -1116,7 +1180,7 @@ func BenchmarkObserveParallel(b *testing.B) {
 	)
 	s := NewMemSampler(MemSamplerOptions{Step: time.Second, HistoryColumns: 4, MaxTrackedRoutes: numRoutes})
 	for r := uint64(1); r <= numRoutes; r++ {
-		if !s.RegisterRoute(r, []byte{byte(r >> 8), byte(r)}, []byte{byte((r + 1) >> 8), byte(r + 1)}) {
+		if !s.RegisterRoute(r, []byte{byte(r >> 8), byte(r)}, []byte{byte((r + 1) >> 8), byte(r + 1)}, 0) {
 			b.Fatalf("RegisterRoute(%d) returned false", r)
 		}
 	}
@@ -1152,7 +1216,7 @@ func BenchmarkRegisterRoute(b *testing.B) {
 		MaxTrackedRoutes: registerBenchTableSize + 1,
 	})
 	for r := uint64(1); r <= registerBenchTableSize; r++ {
-		if !s.RegisterRoute(r, []byte{byte(r >> 8), byte(r)}, []byte{byte((r + 1) >> 8), byte(r + 1)}) {
+		if !s.RegisterRoute(r, []byte{byte(r >> 8), byte(r)}, []byte{byte((r + 1) >> 8), byte(r + 1)}, 0) {
 			b.Fatalf("seed RegisterRoute(%d) returned false", r)
 		}
 	}
@@ -1163,7 +1227,7 @@ func BenchmarkRegisterRoute(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		s.RemoveRoute(churnID)
-		if !s.RegisterRoute(churnID, startKey, endKey) {
+		if !s.RegisterRoute(churnID, startKey, endKey, 0) {
 			b.Fatalf("RegisterRoute(%d) returned false at i=%d", churnID, i)
 		}
 	}
@@ -1191,7 +1255,7 @@ func BenchmarkFlush(b *testing.B) {
 		Now:              clk.Now,
 	})
 	for r := uint64(1); r <= numRoutes; r++ {
-		if !s.RegisterRoute(r, []byte{byte(r >> 8), byte(r)}, []byte{byte((r + 1) >> 8), byte(r + 1)}) {
+		if !s.RegisterRoute(r, []byte{byte(r >> 8), byte(r)}, []byte{byte((r + 1) >> 8), byte(r + 1)}, 0) {
 			b.Fatalf("RegisterRoute(%d) returned false", r)
 		}
 		// Pre-seed every slot with traffic so the first Flush has work to swap.
@@ -1229,7 +1293,7 @@ func BenchmarkSnapshot(b *testing.B) {
 		Now:              clk.Now,
 	})
 	for r := uint64(1); r <= numRoutes; r++ {
-		if !s.RegisterRoute(r, []byte{byte(r >> 8), byte(r)}, []byte{byte((r + 1) >> 8), byte(r + 1)}) {
+		if !s.RegisterRoute(r, []byte{byte(r >> 8), byte(r)}, []byte{byte((r + 1) >> 8), byte(r + 1)}, 0) {
 			b.Fatalf("RegisterRoute(%d) returned false", r)
 		}
 	}
@@ -1270,7 +1334,7 @@ func TestObserveExactCountUnderConcurrentBurst(t *testing.T) {
 		MaxTrackedRoutes: numRoutes,
 	})
 	for r := uint64(1); r <= numRoutes; r++ {
-		if !s.RegisterRoute(r, []byte{byte(r)}, []byte{byte(r) + 1}) {
+		if !s.RegisterRoute(r, []byte{byte(r)}, []byte{byte(r) + 1}, 0) {
 			t.Fatalf("RegisterRoute(%d) returned false", r)
 		}
 	}

--- a/keyviz/sampler_test.go
+++ b/keyviz/sampler_test.go
@@ -843,7 +843,6 @@ func TestReRegisterDuringPruneGraceCancelsPrune(t *testing.T) {
 	}
 }
 
-// TestNonPositiveOptionsFallBackToDefaults pins Codex round-8 P2: a
 // TestRegisterRouteCarriesGroupID pins the Phase 2-C+ contract that
 // MatrixRow.RaftGroupID echoes the groupID supplied at RegisterRoute,
 // independent of leader-term tracking. A route registered with
@@ -906,6 +905,109 @@ func TestSetLeaderTermNilSafe(t *testing.T) {
 	t.Parallel()
 	var s *MemSampler
 	s.SetLeaderTerm(1, 42) // must not panic
+}
+
+// TestSetLeaderTermZeroGroupIDDoesNotPolluteVirtualBucket pins the
+// invariant that virtual aggregate buckets (which span multiple real
+// groups and stamp RaftGroupID=0) must always emit LeaderTerm=0.
+// Without the SetLeaderTerm groupID==0 guard, a caller that mistakenly
+// publishes a term for groupID=0 would cause appendDrainedRow's
+// `terms[groupID]` lookup to stamp the virtual bucket with that
+// non-zero term, breaking the fan-out merge's max-merge fallback for
+// cross-group cells.
+func TestSetLeaderTermZeroGroupIDDoesNotPolluteVirtualBucket(t *testing.T) {
+	t.Parallel()
+	s, _ := setupOneIndividualPlusVirtualBucket(t)
+	s.SetLeaderTerm(0, 999) // bug case: caller passes the reserved groupID
+	s.Observe(2, OpWrite, 16, 64)
+	s.Flush()
+	cols := s.Snapshot(time.Time{}, time.Time{})
+	if len(cols) == 0 {
+		t.Fatalf("expected at least one column")
+	}
+	var virtualRow *MatrixRow
+	for i := range cols[0].Rows {
+		if cols[0].Rows[i].Aggregate {
+			virtualRow = &cols[0].Rows[i]
+			break
+		}
+	}
+	if virtualRow == nil {
+		t.Fatalf("expected an aggregate row in column 0; rows=%+v", cols[0].Rows)
+	}
+	if virtualRow.RaftGroupID != 0 {
+		t.Errorf("virtual bucket RaftGroupID = %d, want 0", virtualRow.RaftGroupID)
+	}
+	if virtualRow.LeaderTerm != 0 {
+		t.Errorf("virtual bucket LeaderTerm = %d, want 0 (groupID=0 is reserved for aggregate buckets)", virtualRow.LeaderTerm)
+	}
+}
+
+// TestVirtualBucketRaftGroupIDIsZero pins that an over-budget route
+// folded into a virtual aggregate bucket emits RaftGroupID=0 even
+// when the member routes themselves were registered with non-zero
+// groupIDs. The fan-out aggregator relies on this to fall back to
+// max-merge for aggregate rows; without it, propagating a member's
+// groupID into the bucket would silently re-engage per-term dedupe
+// on rows that span multiple Raft groups.
+func TestVirtualBucketRaftGroupIDIsZero(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestSampler(t, MemSamplerOptions{
+		Step:             time.Second,
+		HistoryColumns:   4,
+		MaxTrackedRoutes: 1,
+	})
+	if !s.RegisterRoute(1, []byte("a"), []byte("b"), 42) {
+		t.Fatal("route 1 should fit (group 42)")
+	}
+	if s.RegisterRoute(2, []byte("c"), []byte("d"), 42) {
+		t.Fatal("route 2 should fold into virtual bucket (group 42, over budget)")
+	}
+	s.Observe(2, OpWrite, 16, 64)
+	s.Flush()
+	cols := s.Snapshot(time.Time{}, time.Time{})
+	if len(cols) == 0 {
+		t.Fatalf("expected at least one column")
+	}
+	var virtualRow *MatrixRow
+	for i := range cols[0].Rows {
+		if cols[0].Rows[i].Aggregate {
+			virtualRow = &cols[0].Rows[i]
+			break
+		}
+	}
+	if virtualRow == nil {
+		t.Fatalf("expected an aggregate row in column 0; rows=%+v", cols[0].Rows)
+	}
+	if virtualRow.RaftGroupID != 0 {
+		t.Errorf("virtual bucket RaftGroupID = %d, want 0 (member groupID=42 must not propagate)", virtualRow.RaftGroupID)
+	}
+}
+
+// TestRegisterRouteSecondCallIgnoresGroupID pins the live-slot
+// idempotency contract documented on RegisterRoute: when the slot is
+// already live, a second RegisterRoute call returns true without
+// updating the slot's metadata, including GroupID. Callers that need
+// to change a live slot's GroupID must RemoveRoute + RegisterRoute,
+// not call RegisterRoute again with a different groupID.
+func TestRegisterRouteSecondCallIgnoresGroupID(t *testing.T) {
+	t.Parallel()
+	s, _ := newTestSampler(t, MemSamplerOptions{Step: time.Second, HistoryColumns: 4})
+	if !s.RegisterRoute(1, []byte("a"), []byte("b"), 10) {
+		t.Fatal("first RegisterRoute returned false")
+	}
+	if !s.RegisterRoute(1, []byte("a"), []byte("b"), 99) {
+		t.Fatal("second RegisterRoute should be a no-op returning true")
+	}
+	s.Observe(1, OpWrite, 16, 64)
+	s.Flush()
+	cols := s.Snapshot(time.Time{}, time.Time{})
+	if len(cols) != 1 || len(cols[0].Rows) != 1 {
+		t.Fatalf("unexpected snapshot: %+v", cols)
+	}
+	if got := cols[0].Rows[0].RaftGroupID; got != 10 {
+		t.Errorf("RaftGroupID = %d, want 10 (second call's groupID=99 must be ignored)", got)
+	}
 }
 
 // negative MaxTrackedRoutes used to bypass the zero-check and force

--- a/main.go
+++ b/main.go
@@ -1482,7 +1482,7 @@ func seedKeyVizRoutes(s *keyviz.MemSampler, engine *distribution.Engine) {
 		return
 	}
 	for _, r := range engine.Stats() {
-		s.RegisterRoute(r.RouteID, r.Start, r.End)
+		s.RegisterRoute(r.RouteID, r.Start, r.End, r.GroupID)
 	}
 }
 

--- a/main_keyviz_test.go
+++ b/main_keyviz_test.go
@@ -73,7 +73,7 @@ func TestSeedKeyVizRoutesNoOpOnNilSampler(t *testing.T) {
 func TestStartKeyVizFlusherReturnsAfterCancel(t *testing.T) {
 	t.Parallel()
 	s := keyviz.NewMemSampler(keyviz.MemSamplerOptions{Step: time.Millisecond, HistoryColumns: 4})
-	require.True(t, s.RegisterRoute(1, []byte("a"), []byte("b")))
+	require.True(t, s.RegisterRoute(1, []byte("a"), []byte("b"), 0))
 	s.Observe(1, keyviz.OpRead, 0, 0)
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary

- Add `GroupID` field to `routeSlot` and `RaftGroupID + LeaderTerm` to `MatrixRow` (Phase 2-C+ §9.1 dedupe key)
- Add `MemSampler.SetLeaderTerm(groupID, term)` API and `groupTerms` snapshot at Flush time
- Extend `RegisterRoute` with a `groupID uint64` parameter; update all call sites (`main.go` reads `r.GroupID` from `distribution.Engine.Stats()`)

## Why

Per `docs/design/2026_04_27_proposed_keyviz_cluster_fanout.md` §9.1, the cluster fan-out aggregator dedupes write samples by `(routeID, raftGroupID, leaderTerm, columnAt)` instead of the conservative max-merge. Max-merge undercounts during a leadership flip when the new leader observes a window the old leader was halfway through. Carrying `RaftGroupID + LeaderTerm` on every row gives the merge enough information to dedupe per-term and sum across terms.

## Scope (PR-3a — sampler API only)

This PR ships the sampler-side API. Wiring lands in follow-up PRs:

- **PR-3a (this)**: `routeSlot.GroupID`, `MatrixRow.RaftGroupID + LeaderTerm`, `SetLeaderTerm` API, `RegisterRoute` signature, `Flush` term snapshot.
- **PR-3b (follow-up)**: periodic ticker in `main.go` that polls engine Status and calls `SetLeaderTerm`; proto + JSON wire-format additions.
- **PR-3c (follow-up)**: aggregator-side `(group, term)`-keyed dedupe in `internal/admin/keyviz_fanout.go`.

With `SetLeaderTerm` never called (this PR alone), every row emits `LeaderTerm=0` and the fan-out merge falls back to today's max-merge → no behavior change for legacy deployments.

## Test plan

- [x] `go test -race -count=1 ./keyviz/...` — passes
- [x] `go test -race -count=1 ./internal/admin/...` — passes (uses MemSampler)
- [x] `go test -race -count=1 .` (root, `main_keyviz_test.go`) — passes
- [x] `go build ./...` — clean
- [x] `golangci-lint run` — 0 issues
- [ ] Jepsen — N/A (sampler-internal change, no replication/MVCC impact)

## Five-lens self-review

1. **Data loss** — no on-disk format change; legacy max-merge fallback preserves today's behavior when `SetLeaderTerm` is never called.
2. **Concurrency** — `groupTermsMu` is a fine-grained `RWMutex`; `Observe` never touches it; `snapshotGroupTerms` clones at the top of `Flush` so every row in a column observes a stable view, even if `SetLeaderTerm` fires concurrently.
3. **Performance** — `Observe` hot path is unchanged (no new map lookup, no new lock); `Flush` gains one `RLock` + map clone per column, bounded by `len(groupTerms)` (typically ≤ a few groups).
4. **Data consistency** — `(routeID, raftGroupID, leaderTerm)` is a strict superset of today's `routeID` dedupe key; rows with `LeaderTerm=0` collapse to the legacy max-merge.
5. **Test coverage** — new `SetLeaderTerm` publishing + `Flush` snapshot tests under `keyviz/sampler_test.go`; existing `RegisterRoute` test signatures updated; race detector clean.
