### PR TITLE
Revert "build(docker): pin distroless to a digest + drop root privileges"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,39 +27,7 @@ RUN rm -rf internal/admin/dist
 COPY --from=spa-build /spa/dist internal/admin/dist
 RUN CGO_ENABLED=0 go build -o /app .
 
-# Pinned to a multi-arch index digest of `gcr.io/distroless/static:nonroot`
-# captured 2026-04-28. The `:latest` (or even `:nonroot`) tag floats with
-# upstream rebuilds; pinning a digest makes intermediate-image
-# reproducibility match the explicit golang:1.25 / node:22-alpine pins
-# above and prevents a silent base-image swap from changing the image
-# layout under us.
-#
-# `:nonroot` resolves to the same OS layer as `:latest` but with `USER
-# nonroot` baked in (UID 65532). Combined with the explicit USER line
-# below (defence-in-depth — the upstream USER directive could change),
-# the Go binary runs unprivileged inside the container, addressing
-# Trivy DS-0002 (root container) without changing what the binary
-# itself does. The Go binary is statically linked CGO_ENABLED=0 and
-# does not bind privileged ports, so unprivileged execution has no
-# functional cost.
-#
-# Operational note: bind-mounted secrets on the host (e.g.
-# /etc/elastickv/admin-hs256.b64) must be readable by UID 65532 inside
-# the container. Either chown them to 65532:65532 or relax permissions
-# to mode 0444 on the host. The host's bootjp group is no longer
-# sufficient because UID 65532 is in no host group by default.
-# Tag + digest combo: the digest pin is the reproducibility guard,
-# the :nonroot tag in front is human-readable so a glance at the
-# Dockerfile says which variant we're on without cross-referencing
-# the digest or reading the comment block above.
-FROM gcr.io/distroless/static:nonroot@sha256:e3f945647ffb95b5839c07038d64f9811adf17308b9121d8a2b87b6a22a80a39
-# Numeric UID/GID: 65532 is the canonical distroless nonroot user.
-# K8s Pod Security Standards (`runAsNonRoot: true`) and admission
-# controllers like Gatekeeper validate the runtime user by integer,
-# without parsing /etc/passwd — using the name instead would force
-# them to consult image internals to decide if the container counts
-# as non-root.
-USER 65532:65532
+FROM gcr.io/distroless/static:latest
 COPY --from=build /app /app
 
 CMD ["/app"]


### PR DESCRIPTION
Reverts bootjp/elastickv#691