### PR TITLE
backup: filename encoding (Phase 0a foundation)

### DIFF
--- a/internal/backup/filename.go
+++ b/internal/backup/filename.go
@@ -80,30 +80,68 @@ var ErrShaFallbackNeedsKeymap = errors.New("backup: filename uses SHA fallback; 
 // filename component. It is the inverse of DecodeSegment for non-fallback
 // inputs.
 //
-// The encoding is deterministic and idempotent given the same input.
+// The encoding is deterministic given the same input.
 //
-// Two short-circuits ensure the encoder never trips its own invariants:
+// Three structural short-circuits ensure DecodeSegment cannot
+// misclassify a legitimate key:
 //
-//   - If raw is so large that percent-encoding it would always overflow
-//     maxSegmentBytes (3*len(raw) > maxSegmentBytes), we go straight to
-//     shaFallback without allocating the full expansion. Without this an
-//     adversarial caller could force a very large transient allocation
-//     just to discard it.
-//   - If the percent-encoded form happens to match the SHA-fallback shape
-//     (32 hex chars followed by "__"), we promote it to a real
+//   - If `raw` is longer than maxSegmentBytes, even a fully-unreserved
+//     encoding (1:1) cannot fit, so we go straight to shaFallback.
+//     This also caps the percent-encode allocation at
+//     ~maxSegmentBytes, preventing OOM on adversarial input.
+//   - If the percent-encoded form happens to match the SHA-fallback
+//     shape (32 hex chars followed by "__"), we promote it to a real
 //     SHA-fallback so DecodeSegment's structural detection cannot
-//     misclassify a legitimate key. Both isShaFallback and shaFallback
-//     are true on the resulting output, so KEYMAP.jsonl carries the
-//     original bytes for exact-byte recovery.
+//     fabricate a wrong original.
+//   - If the percent-encoded form starts with the binary "b64."
+//     prefix, we promote to SHA-fallback for the same reason: a
+//     plain string key like "b64.foo" would otherwise be decoded as
+//     base64 and produce different bytes on round-trip.
+//
+// Both promoted-fallback paths leave the original in KEYMAP.jsonl
+// (a correctness dependency, per the package doc), so exact-byte
+// recovery is preserved.
 func EncodeSegment(raw []byte) string {
-	if len(raw)*percentEncodeMaxExpansion > maxSegmentBytes {
+	if len(raw) > maxSegmentBytes {
+		// 1:1 lower bound on encoded length; cannot fit.
 		return shaFallback(raw)
 	}
-	encoded := percentEncode(raw)
-	if len(encoded) > maxSegmentBytes || isShaFallback(encoded) {
+	encoded, ok := percentEncodeBounded(raw, maxSegmentBytes)
+	if !ok || isShaFallback(encoded) || strings.HasPrefix(encoded, binaryPrefix) {
 		return shaFallback(raw)
 	}
 	return encoded
+}
+
+// percentEncodeBounded percent-encodes raw, bailing out as soon as the
+// in-progress output would exceed maxLen. Returns ("", false) on
+// overflow so the caller can take the SHA-fallback path without
+// having allocated the full 3*len(raw) buffer that the unbounded
+// variant would. Returns (encoded, true) on success.
+func percentEncodeBounded(raw []byte, maxLen int) (string, bool) {
+	const escapeBytes = 3 // len("%HH") -- one escape's worst-case width
+	cap := escapeBytes * len(raw)
+	if cap > maxLen+escapeBytes {
+		cap = maxLen + escapeBytes
+	}
+	var b strings.Builder
+	b.Grow(cap)
+	for _, c := range raw {
+		if isUnreserved(c) {
+			if b.Len()+1 > maxLen {
+				return "", false
+			}
+			b.WriteByte(c)
+			continue
+		}
+		if b.Len()+escapeBytes > maxLen {
+			return "", false
+		}
+		b.WriteByte('%')
+		b.WriteByte(hexUpper(c >> 4))   //nolint:mnd // 4 == nibble width
+		b.WriteByte(hexUpper(c & 0x0F)) //nolint:mnd // 0x0F == low-nibble mask
+	}
+	return b.String(), true
 }
 
 // EncodeBinarySegment encodes a DynamoDB B-attribute (binary) segment as
@@ -151,10 +189,6 @@ func DecodeSegment(seg string) ([]byte, error) {
 	}
 	return percentDecode(seg)
 }
-
-// percentEncodeMaxExpansion is the worst-case ratio of encoded length to
-// raw length for percentEncode (every byte expands to "%HH").
-const percentEncodeMaxExpansion = 3
 
 // IsShaFallback reports whether seg uses the SHA-prefix-and-truncated-original
 // form. Such segments cannot be reversed without KEYMAP.jsonl.

--- a/internal/backup/filename.go
+++ b/internal/backup/filename.go
@@ -1,0 +1,244 @@
+// Package backup implements the per-adapter logical-backup format defined in
+// docs/design/2026_04_29_proposed_snapshot_logical_decoder.md (Phase 0) and
+// reused by docs/design/2026_04_29_proposed_logical_backup.md (Phase 1).
+//
+// This file owns the filename encoding rules for non-S3 segments. S3 object
+// keys preserve their `/` separators (and so are not transformed by EncodeSegment);
+// every other adapter scope encodes user-supplied bytes through this path.
+//
+// Encoding rules (see "Filename encoding" in the Phase 0 doc):
+//
+//   - Bytes in the unreserved set [A-Za-z0-9._-] pass through.
+//   - Every other byte is rendered as %HH (uppercase hex), like
+//     application/x-www-form-urlencoded but applied to every non-allowlisted byte.
+//   - If the encoded result exceeds maxSegmentBytes (240), the segment is
+//     replaced with <sha256-hex-prefix-32>__<truncated-original> and the full
+//     original bytes must be recorded in KEYMAP.jsonl by the caller.
+//   - Binary DynamoDB partition / sort keys take a separate "b64.<base64url>"
+//     path so a binary key never collides with a string key whose hex encoding
+//     happens to look like base64. EncodeBinarySegment emits that form.
+package backup
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+const (
+	// maxSegmentBytes is the maximum length of a single encoded path segment
+	// before the SHA-fallback kicks in. Chosen to leave headroom under the
+	// common NAME_MAX of 255: two-character percent escapes can grow a 240-byte
+	// raw segment to 720 encoded bytes in the worst case, but any segment
+	// large enough to overflow NAME_MAX after expansion takes the SHA-fallback
+	// path before the encoded length is examined.
+	maxSegmentBytes = 240
+
+	// shaFallbackHexPrefixBytes is the number of hex characters of SHA-256
+	// embedded in the SHA-fallback prefix. 32 hex chars == 128 bits of
+	// hash-prefix entropy — enough to make accidental collision negligible
+	// for any single scope.
+	shaFallbackHexPrefixBytes = 32
+
+	// shaFallbackTruncatedSuffixBytes is the number of leading bytes of the
+	// raw segment retained (after percent-encoding) in the SHA-fallback
+	// rendering. Total encoded segment is then at most:
+	//
+	//   shaFallbackHexPrefixBytes + len("__") + 3*shaFallbackTruncatedSuffixBytes
+	//
+	// = 32 + 2 + 3*64 = 226 bytes  (under the 240 ceiling).
+	//
+	// The truncated suffix is purely a human-recognisability aid; it does
+	// NOT carry enough information to reverse the original bytes — that is
+	// what KEYMAP.jsonl is for.
+	shaFallbackTruncatedSuffixBytes = 64
+
+	// binaryPrefix marks a DynamoDB B-attribute segment encoded as base64url.
+	binaryPrefix = "b64."
+
+	// shaFallbackSeparator separates the SHA-256 prefix from the truncated
+	// original bytes. Two underscores rather than one because single
+	// underscores are common in user keys; doubled is much rarer and so
+	// the boundary is unambiguous.
+	shaFallbackSeparator = "__"
+)
+
+// ErrInvalidEncodedSegment is returned by DecodeSegment when its input is
+// neither a valid percent-encoded segment, a binary-prefixed segment, nor a
+// SHA-fallback segment.
+var ErrInvalidEncodedSegment = errors.New("backup: invalid encoded filename segment")
+
+// ErrShaFallbackNeedsKeymap is returned by DecodeSegment when its input is a
+// SHA-fallback segment. The segment cannot be reversed to its original bytes
+// from the filename alone — the caller must consult KEYMAP.jsonl.
+var ErrShaFallbackNeedsKeymap = errors.New("backup: filename uses SHA fallback; consult KEYMAP.jsonl")
+
+// EncodeSegment encodes a single user-supplied path segment for use as a
+// filename component. It is the inverse of DecodeSegment for non-fallback
+// inputs.
+//
+// The encoding is deterministic and idempotent given the same input.
+func EncodeSegment(raw []byte) string {
+	encoded := percentEncode(raw)
+	if len(encoded) <= maxSegmentBytes {
+		return encoded
+	}
+	return shaFallback(raw)
+}
+
+// EncodeBinarySegment encodes a DynamoDB B-attribute (binary) segment as
+// "b64.<base64url-no-padding>" so that binary keys never collide with string
+// keys whose hex-encoding happens to look like base64.
+//
+// b64-encoded segments take the SHA fallback if they exceed maxSegmentBytes
+// after the base64 expansion (~4/3 of the raw length).
+func EncodeBinarySegment(raw []byte) string {
+	enc := binaryPrefix + base64.RawURLEncoding.EncodeToString(raw)
+	if len(enc) <= maxSegmentBytes {
+		return enc
+	}
+	return shaFallback(raw)
+}
+
+// DecodeSegment is the inverse of EncodeSegment for percent-encoded and
+// binary-prefixed inputs. SHA-fallback inputs return ErrShaFallbackNeedsKeymap
+// so the caller knows to consult KEYMAP.jsonl rather than treat the partial
+// suffix as the original key.
+func DecodeSegment(seg string) ([]byte, error) {
+	if isShaFallback(seg) {
+		return nil, errors.WithStack(ErrShaFallbackNeedsKeymap)
+	}
+	if strings.HasPrefix(seg, binaryPrefix) {
+		raw, err := base64.RawURLEncoding.DecodeString(seg[len(binaryPrefix):])
+		if err != nil {
+			return nil, errors.Wrap(ErrInvalidEncodedSegment, err.Error())
+		}
+		return raw, nil
+	}
+	return percentDecode(seg)
+}
+
+// IsShaFallback reports whether seg uses the SHA-prefix-and-truncated-original
+// form. Such segments cannot be reversed without KEYMAP.jsonl.
+func IsShaFallback(seg string) bool {
+	return isShaFallback(seg)
+}
+
+// IsBinarySegment reports whether seg is a base64-url encoded binary segment
+// emitted by EncodeBinarySegment.
+func IsBinarySegment(seg string) bool {
+	return strings.HasPrefix(seg, binaryPrefix)
+}
+
+func percentEncode(raw []byte) string {
+	// Worst case: every byte expands to %HH (3 bytes). Pre-allocate.
+	var b strings.Builder
+	b.Grow(len(raw) * 3) //nolint:mnd // 3 == len("%HH"), local idiom
+	for _, c := range raw {
+		if isUnreserved(c) {
+			b.WriteByte(c)
+			continue
+		}
+		b.WriteByte('%')
+		b.WriteByte(hexUpper(c >> 4))   //nolint:mnd // 4 == nibble width
+		b.WriteByte(hexUpper(c & 0x0F)) //nolint:mnd // 0x0F == low-nibble mask
+	}
+	return b.String()
+}
+
+func percentDecode(seg string) ([]byte, error) {
+	out := make([]byte, 0, len(seg))
+	for i := 0; i < len(seg); i++ {
+		c := seg[i]
+		if c != '%' {
+			if !isUnreserved(c) {
+				return nil, errors.Wrapf(ErrInvalidEncodedSegment,
+					"unexpected raw byte 0x%02x at offset %d", c, i)
+			}
+			out = append(out, c)
+			continue
+		}
+		if i+2 >= len(seg) { //nolint:mnd // 2 == hex digit count after %
+			return nil, errors.Wrapf(ErrInvalidEncodedSegment,
+				"truncated percent escape at offset %d", i)
+		}
+		const (
+			hiNibbleOff = 1
+			loNibbleOff = 2
+		)
+		hi, ok := unhex(seg[i+hiNibbleOff])
+		if !ok {
+			return nil, errors.Wrapf(ErrInvalidEncodedSegment,
+				"non-hex digit 0x%02x at offset %d", seg[i+hiNibbleOff], i+hiNibbleOff)
+		}
+		lo, ok := unhex(seg[i+loNibbleOff])
+		if !ok {
+			return nil, errors.Wrapf(ErrInvalidEncodedSegment,
+				"non-hex digit 0x%02x at offset %d", seg[i+loNibbleOff], i+loNibbleOff)
+		}
+		out = append(out, (hi<<4)|lo) //nolint:mnd // 4 == nibble width
+		i += loNibbleOff              // skip the two consumed hex digits
+	}
+	return out, nil
+}
+
+func shaFallback(raw []byte) string {
+	sum := sha256.Sum256(raw)
+	hashHex := hex.EncodeToString(sum[:])[:shaFallbackHexPrefixBytes]
+	suffix := raw
+	if len(suffix) > shaFallbackTruncatedSuffixBytes {
+		suffix = suffix[:shaFallbackTruncatedSuffixBytes]
+	}
+	return hashHex + shaFallbackSeparator + percentEncode(suffix)
+}
+
+func isShaFallback(seg string) bool {
+	if len(seg) < shaFallbackHexPrefixBytes+len(shaFallbackSeparator) {
+		return false
+	}
+	for i := 0; i < shaFallbackHexPrefixBytes; i++ {
+		if _, ok := unhex(seg[i]); !ok {
+			return false
+		}
+	}
+	return seg[shaFallbackHexPrefixBytes:shaFallbackHexPrefixBytes+len(shaFallbackSeparator)] == shaFallbackSeparator
+}
+
+// isUnreserved is the RFC3986 unreserved set: ALPHA / DIGIT / "-" / "." / "_".
+// "~" is excluded because it has caused interop problems with older shells and
+// the additional safety is not worth the rare benefit.
+func isUnreserved(c byte) bool {
+	switch {
+	case c >= 'A' && c <= 'Z':
+		return true
+	case c >= 'a' && c <= 'z':
+		return true
+	case c >= '0' && c <= '9':
+		return true
+	case c == '-', c == '.', c == '_':
+		return true
+	}
+	return false
+}
+
+func hexUpper(nibble byte) byte {
+	if nibble < 10 { //nolint:mnd // 10 == decimal/hex boundary
+		return '0' + nibble
+	}
+	return 'A' + (nibble - 10) //nolint:mnd // 10 == decimal/hex boundary
+}
+
+func unhex(c byte) (byte, bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', true
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, true //nolint:mnd // 10 == decimal/hex boundary
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10, true //nolint:mnd // 10 == decimal/hex boundary
+	}
+	return 0, false
+}

--- a/internal/backup/filename.go
+++ b/internal/backup/filename.go
@@ -81,33 +81,64 @@ var ErrShaFallbackNeedsKeymap = errors.New("backup: filename uses SHA fallback; 
 // inputs.
 //
 // The encoding is deterministic and idempotent given the same input.
+//
+// Two short-circuits ensure the encoder never trips its own invariants:
+//
+//   - If raw is so large that percent-encoding it would always overflow
+//     maxSegmentBytes (3*len(raw) > maxSegmentBytes), we go straight to
+//     shaFallback without allocating the full expansion. Without this an
+//     adversarial caller could force a very large transient allocation
+//     just to discard it.
+//   - If the percent-encoded form happens to match the SHA-fallback shape
+//     (32 hex chars followed by "__"), we promote it to a real
+//     SHA-fallback so DecodeSegment's structural detection cannot
+//     misclassify a legitimate key. Both isShaFallback and shaFallback
+//     are true on the resulting output, so KEYMAP.jsonl carries the
+//     original bytes for exact-byte recovery.
 func EncodeSegment(raw []byte) string {
-	encoded := percentEncode(raw)
-	if len(encoded) <= maxSegmentBytes {
-		return encoded
+	if len(raw)*percentEncodeMaxExpansion > maxSegmentBytes {
+		return shaFallback(raw)
 	}
-	return shaFallback(raw)
+	encoded := percentEncode(raw)
+	if len(encoded) > maxSegmentBytes || isShaFallback(encoded) {
+		return shaFallback(raw)
+	}
+	return encoded
 }
 
 // EncodeBinarySegment encodes a DynamoDB B-attribute (binary) segment as
 // "b64.<base64url-no-padding>" so that binary keys never collide with string
 // keys whose hex-encoding happens to look like base64.
 //
-// b64-encoded segments take the SHA fallback if they exceed maxSegmentBytes
-// after the base64 expansion (~4/3 of the raw length).
+// Short-circuits the SHA-fallback for inputs whose base64 expansion (~4/3 of
+// the raw length, plus the 4-byte "b64." prefix) would always overflow
+// maxSegmentBytes. As with EncodeSegment, this avoids an unnecessary large
+// allocation when the result would have been discarded anyway.
 func EncodeBinarySegment(raw []byte) string {
-	enc := binaryPrefix + base64.RawURLEncoding.EncodeToString(raw)
-	if len(enc) <= maxSegmentBytes {
-		return enc
+	if base64.RawURLEncoding.EncodedLen(len(raw))+len(binaryPrefix) > maxSegmentBytes {
+		return shaFallback(raw)
 	}
-	return shaFallback(raw)
+	enc := binaryPrefix + base64.RawURLEncoding.EncodeToString(raw)
+	if len(enc) > maxSegmentBytes {
+		return shaFallback(raw)
+	}
+	return enc
 }
 
 // DecodeSegment is the inverse of EncodeSegment for percent-encoded and
 // binary-prefixed inputs. SHA-fallback inputs return ErrShaFallbackNeedsKeymap
 // so the caller knows to consult KEYMAP.jsonl rather than treat the partial
 // suffix as the original key.
+//
+// As a defensive measure DecodeSegment refuses inputs longer than
+// maxSegmentBytes. EncodeSegment never produces such inputs, so any caller
+// passing one is either reading a corrupted dump or has a bug; either way the
+// percentDecode allocation should not run.
 func DecodeSegment(seg string) ([]byte, error) {
+	if len(seg) > maxSegmentBytes {
+		return nil, errors.Wrapf(ErrInvalidEncodedSegment,
+			"segment length %d exceeds maximum %d", len(seg), maxSegmentBytes)
+	}
 	if isShaFallback(seg) {
 		return nil, errors.WithStack(ErrShaFallbackNeedsKeymap)
 	}
@@ -120,6 +151,10 @@ func DecodeSegment(seg string) ([]byte, error) {
 	}
 	return percentDecode(seg)
 }
+
+// percentEncodeMaxExpansion is the worst-case ratio of encoded length to
+// raw length for percentEncode (every byte expands to "%HH").
+const percentEncodeMaxExpansion = 3
 
 // IsShaFallback reports whether seg uses the SHA-prefix-and-truncated-original
 // form. Such segments cannot be reversed without KEYMAP.jsonl.

--- a/internal/backup/filename_test.go
+++ b/internal/backup/filename_test.go
@@ -309,6 +309,72 @@ func TestEncodeBinarySegment_FuzzRoundTripIfNotShaFallback(t *testing.T) {
 	})
 }
 
+func TestEncodeSegment_KeyMatchingShaFallbackShapeIsPromotedToFallback(t *testing.T) {
+	t.Parallel()
+	// A user key that is itself made of 32 hex chars + "__" + suffix
+	// would, under naive encoding, return the raw bytes unchanged
+	// (everything is unreserved) — but DecodeSegment's structural
+	// detection would then misclassify it as a SHA-fallback and
+	// return ErrShaFallbackNeedsKeymap. EncodeSegment must promote
+	// such inputs to a real SHA-fallback so the encoded->decoded
+	// invariant holds (decode refuses; KEYMAP carries the original).
+	raw := []byte("0123456789abcdef0123456789abcdef__suffix")
+	enc := EncodeSegment(raw)
+	if !IsShaFallback(enc) {
+		t.Fatalf("expected SHA fallback for collision-shaped input, got %q", enc)
+	}
+	// The fallback's hex prefix must be the SHA of the raw bytes,
+	// NOT the raw bytes' first 32 chars. That way a KEYMAP entry
+	// keyed on `enc` carries the actual original — not a structural
+	// echo.
+	if _, err := DecodeSegment(enc); !errors.Is(err, ErrShaFallbackNeedsKeymap) {
+		t.Fatalf("decode of promoted fallback: err=%v want ErrShaFallbackNeedsKeymap", err)
+	}
+}
+
+func TestEncodeSegment_HugeInputDoesNotMaterialiseFullExpansion(t *testing.T) {
+	t.Parallel()
+	// A 1 MiB input would, if percent-encoded eagerly, allocate 3
+	// MiB before the length check fired. The early short-circuit
+	// must skip that allocation. We can't directly observe the
+	// allocation here without a profile, but we can assert the
+	// output is correct (SHA fallback, length under the ceiling)
+	// and that the call returns promptly enough to be a no-op
+	// guard in profile-runs.
+	raw := make([]byte, 1<<20) // 1 MiB
+	for i := range raw {
+		raw[i] = byte(i)
+	}
+	enc := EncodeSegment(raw)
+	if !IsShaFallback(enc) {
+		t.Fatalf("expected SHA fallback for huge input")
+	}
+	if len(enc) > maxSegmentBytes {
+		t.Fatalf("encoded len %d > max %d", len(enc), maxSegmentBytes)
+	}
+}
+
+func TestDecodeSegment_RejectsOversizedInput(t *testing.T) {
+	t.Parallel()
+	too := strings.Repeat("a", maxSegmentBytes+1)
+	_, err := DecodeSegment(too)
+	if !errors.Is(err, ErrInvalidEncodedSegment) {
+		t.Fatalf("err=%v want ErrInvalidEncodedSegment for oversized input", err)
+	}
+}
+
+func TestEncodeBinarySegment_HugeInputTakesShaFallbackWithoutEncoding(t *testing.T) {
+	t.Parallel()
+	raw := make([]byte, 1<<20) // 1 MiB
+	enc := EncodeBinarySegment(raw)
+	if !IsShaFallback(enc) {
+		t.Fatalf("expected SHA fallback for huge binary input, got %q", enc[:min(40, len(enc))])
+	}
+	if len(enc) > maxSegmentBytes {
+		t.Fatalf("encoded len %d > max %d", len(enc), maxSegmentBytes)
+	}
+}
+
 func TestEncodeSegment_ShaFallbackEmbedsRecognisableSuffix(t *testing.T) {
 	t.Parallel()
 	// The truncated suffix in the SHA-fallback rendering must be derivable

--- a/internal/backup/filename_test.go
+++ b/internal/backup/filename_test.go
@@ -1,0 +1,327 @@
+package backup
+
+import (
+	"crypto/rand"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"pgregory.net/rapid"
+)
+
+func TestEncodeSegment_PassthroughForUnreserved(t *testing.T) {
+	t.Parallel()
+	// Every unreserved byte must round-trip without escaping.
+	cases := []string{
+		"",
+		"a",
+		"A",
+		"0",
+		"-",
+		".",
+		"_",
+		"abc",
+		"ABCdef-123_test.json",
+		"customer-7421",
+		"2026-04-29T12-00-00Z",
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			t.Parallel()
+			enc := EncodeSegment([]byte(c))
+			if enc != c {
+				t.Fatalf("EncodeSegment(%q) = %q, want %q", c, enc, c)
+			}
+			dec, err := DecodeSegment(enc)
+			if err != nil {
+				t.Fatalf("DecodeSegment(%q) error: %v", enc, err)
+			}
+			if string(dec) != c {
+				t.Fatalf("round-trip: got %q, want %q", dec, c)
+			}
+		})
+	}
+}
+
+func TestEncodeSegment_PercentEscapesReservedBytes(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"hello world":   "hello%20world",
+		"a/b":           "a%2Fb",
+		"a:b":           "a%3Ab",
+		"key|with|pipe": "key%7Cwith%7Cpipe",
+		"\x00":          "%00",
+		"\xff":          "%FF",
+		"colon:.":       "colon%3A.",
+		"plus+":         "plus%2B",
+	}
+	for raw, want := range cases {
+		t.Run(want, func(t *testing.T) {
+			t.Parallel()
+			got := EncodeSegment([]byte(raw))
+			if got != want {
+				t.Fatalf("EncodeSegment(%q) = %q, want %q", raw, got, want)
+			}
+			dec, err := DecodeSegment(got)
+			if err != nil {
+				t.Fatalf("DecodeSegment(%q) error: %v", got, err)
+			}
+			if string(dec) != raw {
+				t.Fatalf("round-trip: got %q, want %q", dec, raw)
+			}
+		})
+	}
+}
+
+func TestEncodeSegment_HexIsUppercase(t *testing.T) {
+	t.Parallel()
+	enc := EncodeSegment([]byte{0xab, 0xcd})
+	if enc != "%AB%CD" {
+		t.Fatalf("EncodeSegment hex case: got %q want %q", enc, "%AB%CD")
+	}
+}
+
+func TestEncodeSegment_LongInputTakesShaFallback(t *testing.T) {
+	t.Parallel()
+	// 250 bytes of unreserved chars: percent-encoded length == 250, which
+	// exceeds the 240-byte ceiling, so the SHA fallback fires.
+	raw := strings.Repeat("a", 250)
+	enc := EncodeSegment([]byte(raw))
+	if !IsShaFallback(enc) {
+		t.Fatalf("EncodeSegment(250 unreserved bytes) did not take SHA fallback: %q", enc)
+	}
+	if len(enc) > maxSegmentBytes {
+		t.Fatalf("SHA-fallback output exceeds max: len=%d > %d", len(enc), maxSegmentBytes)
+	}
+	// Decoder reports the fallback and refuses to fabricate the original.
+	if _, err := DecodeSegment(enc); !errors.Is(err, ErrShaFallbackNeedsKeymap) {
+		t.Fatalf("DecodeSegment of SHA-fallback: err=%v want ErrShaFallbackNeedsKeymap", err)
+	}
+}
+
+func TestEncodeSegment_ShortBytesThatExpandPastCeilingTakeShaFallback(t *testing.T) {
+	t.Parallel()
+	// Each byte percent-encodes to 3 chars, so 81 reserved bytes -> 243 chars.
+	raw := strings.Repeat("\x01", 81)
+	enc := EncodeSegment([]byte(raw))
+	if !IsShaFallback(enc) {
+		t.Fatalf("expected SHA fallback for 81 reserved bytes (243 expanded), got %q", enc)
+	}
+}
+
+func TestEncodeSegment_Deterministic(t *testing.T) {
+	t.Parallel()
+	// Same input must encode to the same output across calls.
+	raw := []byte("session:abc:123/4")
+	a := EncodeSegment(raw)
+	b := EncodeSegment(raw)
+	if a != b {
+		t.Fatalf("non-deterministic: %q != %q", a, b)
+	}
+	// Note: EncodeSegment is intentionally NOT idempotent — `%` is a reserved
+	// byte and a second pass percent-encodes it again. Decode-then-encode is
+	// the round-trip that holds, and is covered by other tests.
+}
+
+func TestEncodeBinarySegment_BasicRoundTrip(t *testing.T) {
+	t.Parallel()
+	cases := [][]byte{
+		nil,
+		{},
+		{0x00},
+		{0x01, 0x02, 0x03},
+		[]byte("not-binary-but-still-a-byte-string"),
+		{0xff, 0xfe, 0xfd, 0xfc},
+	}
+	for _, raw := range cases {
+		enc := EncodeBinarySegment(raw)
+		if !strings.HasPrefix(enc, binaryPrefix) {
+			t.Fatalf("EncodeBinarySegment(%x) = %q, missing binary prefix", raw, enc)
+		}
+		if !IsBinarySegment(enc) {
+			t.Fatalf("IsBinarySegment(%q) = false", enc)
+		}
+		dec, err := DecodeSegment(enc)
+		if err != nil {
+			t.Fatalf("DecodeSegment(%q) error: %v", enc, err)
+		}
+		if string(dec) != string(raw) {
+			t.Fatalf("binary round-trip: got %x want %x", dec, raw)
+		}
+	}
+}
+
+func TestEncodeBinarySegment_LongInputTakesShaFallback(t *testing.T) {
+	t.Parallel()
+	// base64 ~= 4/3 the raw length; raw=200 -> ~268 chars after b64 prefix.
+	raw := make([]byte, 200)
+	if _, err := rand.Read(raw); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	enc := EncodeBinarySegment(raw)
+	if !IsShaFallback(enc) {
+		t.Fatalf("expected SHA fallback for 200-byte binary, got %q (len %d)", enc, len(enc))
+	}
+}
+
+func TestEncodeSegment_ShaFallbackPrefixCannotCollideWithEncodedHex(t *testing.T) {
+	t.Parallel()
+	// A user key consisting solely of unreserved hex chars and underscores
+	// must NOT be detected as a SHA fallback: the SHA fallback requires the
+	// 32-hex prefix to be followed by exactly "__" — the user input
+	// "abcdef...__rest" with shorter prefix or wrong separator length must
+	// fall through.
+	cases := []string{
+		// 31 hex + double-underscore: too short by one
+		"0123456789abcdef0123456789abcde__",
+		// 32 hex + single underscore
+		"0123456789abcdef0123456789abcdef_",
+		// Correct prefix length but trailing single underscore: 33-char prefix,
+		// the "__" check at offset 32 is "_X", not "__".
+		"0123456789abcdef0123456789abcdef_x",
+	}
+	for _, c := range cases {
+		if IsShaFallback(c) {
+			t.Fatalf("false positive: IsShaFallback(%q) = true", c)
+		}
+	}
+}
+
+func TestDecodeSegment_RejectsTruncatedPercentEscape(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"%",
+		"%1",
+		"abc%",
+		"abc%2",
+	}
+	for _, c := range cases {
+		if _, err := DecodeSegment(c); !errors.Is(err, ErrInvalidEncodedSegment) {
+			t.Fatalf("DecodeSegment(%q): err=%v want ErrInvalidEncodedSegment", c, err)
+		}
+	}
+}
+
+func TestDecodeSegment_RejectsNonHexInPercentEscape(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"%GG",
+		"%1G",
+		"%G1",
+		"foo%XYbar",
+	}
+	for _, c := range cases {
+		if _, err := DecodeSegment(c); !errors.Is(err, ErrInvalidEncodedSegment) {
+			t.Fatalf("DecodeSegment(%q): err=%v want ErrInvalidEncodedSegment", c, err)
+		}
+	}
+}
+
+func TestDecodeSegment_RejectsRawReservedBytes(t *testing.T) {
+	t.Parallel()
+	// A literal `/` or other reserved byte in an encoded segment is invalid;
+	// percent-encoded segments must contain only [unreserved-set | "%HH"].
+	cases := []string{
+		"a/b",
+		"a:b",
+		"hello world",
+	}
+	for _, c := range cases {
+		if _, err := DecodeSegment(c); !errors.Is(err, ErrInvalidEncodedSegment) {
+			t.Fatalf("DecodeSegment(%q): err=%v want ErrInvalidEncodedSegment", c, err)
+		}
+	}
+}
+
+func TestDecodeSegment_RejectsMalformedBinary(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"b64.!!!",      // "!" is not a base64url alphabet character
+		"b64.padding=", // RawURLEncoding does not accept padding
+	}
+	for _, c := range cases {
+		if _, err := DecodeSegment(c); !errors.Is(err, ErrInvalidEncodedSegment) {
+			t.Fatalf("DecodeSegment(%q): err=%v want ErrInvalidEncodedSegment", c, err)
+		}
+	}
+}
+
+func TestEncodeSegment_OutputLengthBoundedByMax(t *testing.T) {
+	t.Parallel()
+	// For any input — including pathological ones that expand 3x under
+	// percent-encoding — the encoded output never exceeds maxSegmentBytes.
+	for _, n := range []int{0, 1, 240, 241, 1000, 65536} {
+		raw := make([]byte, n)
+		if _, err := rand.Read(raw); err != nil {
+			t.Fatalf("rand: %v", err)
+		}
+		enc := EncodeSegment(raw)
+		if len(enc) > maxSegmentBytes {
+			t.Fatalf("EncodeSegment(len=%d): output len=%d > max=%d", n, len(enc), maxSegmentBytes)
+		}
+	}
+}
+
+func TestEncodeSegment_FuzzRoundTripIfNotShaFallback(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		raw := rapid.SliceOfN(rapid.Byte(), 0, 80).Draw(t, "raw")
+		enc := EncodeSegment(raw)
+		if IsShaFallback(enc) {
+			// Only assert the documented post-condition for fallback inputs:
+			// decode must refuse rather than fabricate.
+			if _, err := DecodeSegment(enc); !errors.Is(err, ErrShaFallbackNeedsKeymap) {
+				t.Fatalf("SHA-fallback decode did not return ErrShaFallbackNeedsKeymap: %v", err)
+			}
+			return
+		}
+		dec, err := DecodeSegment(enc)
+		if err != nil {
+			t.Fatalf("DecodeSegment(%q) error: %v (raw=%x)", enc, err, raw)
+		}
+		if string(dec) != string(raw) {
+			t.Fatalf("round-trip mismatch: raw=%x dec=%x enc=%q", raw, dec, enc)
+		}
+	})
+}
+
+func TestEncodeBinarySegment_FuzzRoundTripIfNotShaFallback(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(t *rapid.T) {
+		raw := rapid.SliceOfN(rapid.Byte(), 0, 150).Draw(t, "raw")
+		enc := EncodeBinarySegment(raw)
+		if IsShaFallback(enc) {
+			if _, err := DecodeSegment(enc); !errors.Is(err, ErrShaFallbackNeedsKeymap) {
+				t.Fatalf("SHA-fallback decode did not return ErrShaFallbackNeedsKeymap: %v", err)
+			}
+			return
+		}
+		if !IsBinarySegment(enc) {
+			t.Fatalf("non-fallback binary segment missing prefix: %q", enc)
+		}
+		dec, err := DecodeSegment(enc)
+		if err != nil {
+			t.Fatalf("DecodeSegment(%q) error: %v (raw=%x)", enc, err, raw)
+		}
+		if string(dec) != string(raw) {
+			t.Fatalf("binary round-trip mismatch: raw=%x dec=%x enc=%q", raw, dec, enc)
+		}
+	})
+}
+
+func TestEncodeSegment_ShaFallbackEmbedsRecognisableSuffix(t *testing.T) {
+	t.Parallel()
+	// The truncated suffix in the SHA-fallback rendering must be derivable
+	// from the original key, so an operator can grep the file tree for a
+	// known-prefix key. Use an all-letter prefix so percent-encoding leaves
+	// it intact (otherwise the suffix is itself percent-encoded).
+	prefix := "human-recognisable-prefix"
+	raw := []byte(prefix + strings.Repeat("a", 300))
+	enc := EncodeSegment(raw)
+	if !IsShaFallback(enc) {
+		t.Fatalf("expected SHA fallback for 325-byte input")
+	}
+	if !strings.Contains(enc, prefix) {
+		t.Fatalf("SHA fallback %q does not contain %q", enc, prefix)
+	}
+}

--- a/internal/backup/filename_test.go
+++ b/internal/backup/filename_test.go
@@ -309,6 +309,44 @@ func TestEncodeBinarySegment_FuzzRoundTripIfNotShaFallback(t *testing.T) {
 	})
 }
 
+func TestEncodeSegment_LongUnreservedASCIIEncodesAsIs(t *testing.T) {
+	t.Parallel()
+	// 200 ASCII letters are all unreserved; the percent-encoding is
+	// 1:1 (200 bytes), well under the 240-byte ceiling. The encoder
+	// must NOT take the SHA fallback for such inputs — Codex P1 #100.
+	raw := []byte(strings.Repeat("a", 200))
+	enc := EncodeSegment(raw)
+	if IsShaFallback(enc) {
+		t.Fatalf("200-byte ASCII unreserved input must NOT take SHA fallback")
+	}
+	dec, err := DecodeSegment(enc)
+	if err != nil {
+		t.Fatalf("DecodeSegment: %v", err)
+	}
+	if string(dec) != string(raw) {
+		t.Fatalf("round-trip failed for 200-byte ASCII")
+	}
+}
+
+func TestEncodeSegment_KeyStartingWithBinaryPrefixIsPromotedToFallback(t *testing.T) {
+	t.Parallel()
+	// A user STRING key like "b64.foo" passed naively through
+	// EncodeSegment returns "b64.foo" (all unreserved). DecodeSegment
+	// then sees the b64. prefix, treats it as a binary segment, and
+	// decodes the base64 — producing the wrong bytes. Codex P1 #146.
+	// EncodeSegment must promote any input whose encoded form starts
+	// with the binary prefix to a real SHA fallback so KEYMAP.jsonl
+	// carries the original.
+	raw := []byte("b64.foo")
+	enc := EncodeSegment(raw)
+	if !IsShaFallback(enc) {
+		t.Fatalf("expected SHA fallback for b64.-prefixed input, got %q", enc)
+	}
+	if _, err := DecodeSegment(enc); !errors.Is(err, ErrShaFallbackNeedsKeymap) {
+		t.Fatalf("decode err=%v want ErrShaFallbackNeedsKeymap", err)
+	}
+}
+
 func TestEncodeSegment_KeyMatchingShaFallbackShapeIsPromotedToFallback(t *testing.T) {
 	t.Parallel()
 	// A user key that is itself made of 32 hex chars + "__" + suffix


### PR DESCRIPTION
## Summary

First piece of the **Phase 0a logical-backup decoder** described in `docs/design/2026_04_29_proposed_snapshot_logical_decoder.md`. Adds `internal/backup/filename.go` + tests — the filename encoding/decoding primitive every per-adapter encoder will depend on.

Subsequent PRs will add: `KEYMAP.jsonl` writer, per-adapter encoders (DynamoDB / S3 / Redis / SQS), the main decoder pipeline, and the `cmd/elastickv-snapshot-decode` CLI.

## What this PR does

- **Encode**: bytes in `[A-Za-z0-9._-]` pass through; every other byte becomes `%HH`. Long segments (>240 bytes after expansion) take a SHA-256-prefix + truncated-original fallback.
- **Decode**: reverses percent and `b64.` segments; SHA-fallback inputs return `ErrShaFallbackNeedsKeymap` so callers cannot fabricate the original bytes from the filename alone.
- **Binary path**: DynamoDB B-attribute keys take a separate `b64.<base64url>` form so binary keys never collide with hex-shaped string keys.

## Test plan

- [x] `go test -race ./internal/backup/...` — all tests pass.
- [x] `golangci-lint run ./internal/backup/...` — clean.
- [x] Property tests via `pgregory.net/rapid` covering round-trip on both encoding paths and SHA-fallback post-condition.
- [x] Negative tests: truncated `%HH`, non-hex digits, raw reserved bytes, malformed `b64.` segments.

## Self-review

- **Data loss** — N/A; pure encoding/decoding library. SHA-fallback explicitly returns a typed error rather than synthesizing a wrong key.
- **Concurrency** — All functions are pure; no shared state. `-race` clean.
- **Performance** — Single-pass encoders; pre-grown builder; no allocations beyond the output. SHA-256 only on the fallback path.
- **Data consistency** — Encoder is deterministic given the same input. Decode is the inverse on non-fallback inputs (verified by rapid). SHA-fallback is documented as requiring `KEYMAP.jsonl` for full reverse.
- **Test coverage** — Table-driven cases for the documented rules + rapid property tests for round-trip + targeted negative tests. New non-test code lines added: 222.