### PR TITLE
backup: Redis simple-type encoders (strings, HLL, TTL routing)

### DIFF
--- a/internal/backup/disk_full_other.go
+++ b/internal/backup/disk_full_other.go
@@ -1,0 +1,15 @@
+//go:build !unix && !windows
+
+package backup
+
+// isDiskFullError is the fallback for non-unix/non-windows targets
+// (js, wasip1, plan9). Those runtimes either do not surface a
+// disk-full errno through Go's syscall package or do not have a
+// meaningful disk concept (wasm with no host filesystem, plan9 with
+// its own error vocabulary). Returning false matches the documented
+// helper contract: callers treat unrecognised errors as
+// non-retriable, which is the safe default. Codex P2 round 10.
+func isDiskFullError(err error) bool {
+	_ = err
+	return false
+}

--- a/internal/backup/disk_full_unix.go
+++ b/internal/backup/disk_full_unix.go
@@ -1,0 +1,15 @@
+//go:build unix
+
+package backup
+
+import (
+	"errors"
+	"syscall"
+)
+
+// isDiskFullError reports whether err is a POSIX ENOSPC anywhere in
+// the wrap chain. os.File.Write surfaces ENOSPC inside an
+// os.PathError which errors.Is unwraps natively.
+func isDiskFullError(err error) bool {
+	return errors.Is(err, syscall.ENOSPC)
+}

--- a/internal/backup/disk_full_windows.go
+++ b/internal/backup/disk_full_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package backup
+
+import (
+	"errors"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// isDiskFullError reports whether err is a Windows disk-full failure.
+// We accept both ERROR_DISK_FULL (Win32 errno 112) and
+// ERROR_HANDLE_DISK_FULL (39): the kernel returns 112 for write
+// failures driven by free-space exhaustion and 39 for the legacy
+// handle-level variant some FS drivers still surface. We also keep
+// syscall.ENOSPC in the chain because Go's os package occasionally
+// translates platform errors into the POSIX value before returning.
+func isDiskFullError(err error) bool {
+	switch {
+	case errors.Is(err, windows.ERROR_DISK_FULL),
+		errors.Is(err, windows.ERROR_HANDLE_DISK_FULL),
+		errors.Is(err, syscall.ENOSPC):
+		return true
+	}
+	return false
+}

--- a/internal/backup/open_nofollow_other.go
+++ b/internal/backup/open_nofollow_other.go
@@ -21,5 +21,9 @@ func openSidecarFile(path string) (*os.File, error) {
 		return nil, cockroachdberr.WithStack(cockroachdberr.Newf(
 			"backup: refusing to overwrite symlink at %s", path))
 	}
-	return os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec,mnd // path is composed from output-root + fixed file name; 0600 is the standard owner-only mode
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec,mnd // path is composed from output-root + fixed file name; 0600 is the standard owner-only mode
+	if err != nil {
+		return nil, cockroachdberr.WithStack(err)
+	}
+	return f, nil
 }

--- a/internal/backup/open_nofollow_other.go
+++ b/internal/backup/open_nofollow_other.go
@@ -1,0 +1,25 @@
+//go:build !unix && !windows
+
+package backup
+
+import (
+	"os"
+
+	cockroachdberr "github.com/cockroachdb/errors"
+)
+
+// openSidecarFile is the fallback for non-unix/non-windows targets
+// (js, wasip1, plan9). syscall.O_NOFOLLOW and the unix nlink-check
+// path are unavailable; we keep a Lstat-then-OpenFile guard to at
+// least refuse pre-existing symlinks. The remaining TOCTOU window
+// is acceptable here because dump tooling on those targets is
+// offline / sandboxed and the threat model that motivated the unix
+// hardening (a local adversary swapping the path between syscalls)
+// does not apply. Codex P2 round 10.
+func openSidecarFile(path string) (*os.File, error) {
+	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return nil, cockroachdberr.WithStack(cockroachdberr.Newf(
+			"backup: refusing to overwrite symlink at %s", path))
+	}
+	return os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec,mnd // path is composed from output-root + fixed file name; 0600 is the standard owner-only mode
+}

--- a/internal/backup/open_nofollow_unix.go
+++ b/internal/backup/open_nofollow_unix.go
@@ -10,20 +10,47 @@ import (
 	cockroachdberr "github.com/cockroachdb/errors"
 )
 
-// openSidecarFile opens path for write with truncate+create semantics
-// and atomically refuses symlinks. The unix build leans on
-// syscall.O_NOFOLLOW so the kernel returns ELOOP if path is a
-// symlink, eliminating the TOCTOU race a separate Lstat-then-Create
-// pattern would have. The Windows build (open_nofollow_windows.go)
-// implements this with the best alternative available there.
+// openSidecarFile opens path for write while refusing both symlink and
+// hard-link clobber attacks.
+//
+//   - O_NOFOLLOW makes the kernel return ELOOP atomically if the path
+//     is a symbolic link — closing the TOCTOU race a separate
+//     Lstat-then-Create pattern would have.
+//   - To also refuse hard links to files outside the dump tree, we
+//     open WITHOUT O_TRUNC, fstat() the descriptor to check the
+//     link count, and only call Truncate(0) if Nlink == 1. An
+//     adversary that pre-created strings_ttl.jsonl as a hard link
+//     to /etc/passwd (or any other writable file outside the dump
+//     tree) would otherwise see the inode truncated on
+//     openSidecarFile despite the symlink guard. Codex P2 round 9.
+//
+// The Windows build (open_nofollow_windows.go) keeps the simpler
+// Lstat-then-OpenFile guard because Windows's
+// SeCreateSymbolicLinkPrivilege already raises the bar for the
+// equivalent attack.
 func openSidecarFile(path string) (*os.File, error) {
-	const flag = os.O_WRONLY | os.O_CREATE | os.O_TRUNC | syscall.O_NOFOLLOW
+	// Note: NO O_TRUNC here — we truncate after the link-count check.
+	const flag = os.O_WRONLY | os.O_CREATE | syscall.O_NOFOLLOW
 	f, err := os.OpenFile(path, flag, 0o600) //nolint:gosec,mnd // path is composed from output-root + fixed file name; 0600 is the standard owner-only mode
 	if err != nil {
 		if errors.Is(err, syscall.ELOOP) {
 			return nil, cockroachdberr.WithStack(cockroachdberr.Wrapf(err,
 				"backup: refusing to overwrite symlink at %s", path))
 		}
+		return nil, cockroachdberr.WithStack(err)
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, cockroachdberr.WithStack(err)
+	}
+	if sysStat, ok := info.Sys().(*syscall.Stat_t); ok && sysStat.Nlink > 1 {
+		_ = f.Close()
+		return nil, cockroachdberr.WithStack(cockroachdberr.Newf(
+			"backup: refusing to overwrite hard-linked file at %s (nlink=%d)", path, sysStat.Nlink))
+	}
+	if err := f.Truncate(0); err != nil {
+		_ = f.Close()
 		return nil, cockroachdberr.WithStack(err)
 	}
 	return f, nil

--- a/internal/backup/open_nofollow_unix.go
+++ b/internal/backup/open_nofollow_unix.go
@@ -1,0 +1,30 @@
+//go:build unix
+
+package backup
+
+import (
+	"errors"
+	"os"
+	"syscall"
+
+	cockroachdberr "github.com/cockroachdb/errors"
+)
+
+// openSidecarFile opens path for write with truncate+create semantics
+// and atomically refuses symlinks. The unix build leans on
+// syscall.O_NOFOLLOW so the kernel returns ELOOP if path is a
+// symlink, eliminating the TOCTOU race a separate Lstat-then-Create
+// pattern would have. The Windows build (open_nofollow_windows.go)
+// implements this with the best alternative available there.
+func openSidecarFile(path string) (*os.File, error) {
+	const flag = os.O_WRONLY | os.O_CREATE | os.O_TRUNC | syscall.O_NOFOLLOW
+	f, err := os.OpenFile(path, flag, 0o600) //nolint:gosec,mnd // path is composed from output-root + fixed file name; 0600 is the standard owner-only mode
+	if err != nil {
+		if errors.Is(err, syscall.ELOOP) {
+			return nil, cockroachdberr.WithStack(cockroachdberr.Wrapf(err,
+				"backup: refusing to overwrite symlink at %s", path))
+		}
+		return nil, cockroachdberr.WithStack(err)
+	}
+	return f, nil
+}

--- a/internal/backup/open_nofollow_unix.go
+++ b/internal/backup/open_nofollow_unix.go
@@ -10,32 +10,49 @@ import (
 	cockroachdberr "github.com/cockroachdb/errors"
 )
 
-// openSidecarFile opens path for write while refusing both symlink and
-// hard-link clobber attacks.
+// openSidecarFile opens path for write while refusing symlink,
+// hard-link, and non-regular-file (FIFO / socket / device) clobber
+// attacks.
 //
 //   - O_NOFOLLOW makes the kernel return ELOOP atomically if the path
 //     is a symbolic link — closing the TOCTOU race a separate
 //     Lstat-then-Create pattern would have.
+//   - O_NONBLOCK guarantees the open does not hang on a pre-existing
+//     FIFO that has no reader (POSIX: O_WRONLY|O_NONBLOCK on a
+//     reader-less FIFO returns ENXIO immediately). Without this, a
+//     stale or adversarial mkfifo at strings_ttl.jsonl would block
+//     the first TTL write indefinitely; the symlink and hard-link
+//     guards do not catch this case (`mkfifo` produces nlink=1 and
+//     is not a symlink). Codex P2 round 11.
 //   - To also refuse hard links to files outside the dump tree, we
 //     open WITHOUT O_TRUNC, fstat() the descriptor to check the
-//     link count, and only call Truncate(0) if Nlink == 1. An
-//     adversary that pre-created strings_ttl.jsonl as a hard link
-//     to /etc/passwd (or any other writable file outside the dump
-//     tree) would otherwise see the inode truncated on
-//     openSidecarFile despite the symlink guard. Codex P2 round 9.
+//     link count, and only call Truncate(0) if Nlink == 1 AND the
+//     file is a regular file. An adversary that pre-created
+//     strings_ttl.jsonl as a hard link to /etc/passwd (or any other
+//     writable file outside the dump tree) would otherwise see the
+//     inode truncated on openSidecarFile despite the symlink guard.
+//     Codex P2 round 9.
 //
 // The Windows build (open_nofollow_windows.go) keeps the simpler
 // Lstat-then-OpenFile guard because Windows's
 // SeCreateSymbolicLinkPrivilege already raises the bar for the
-// equivalent attack.
+// equivalent attack and Windows has no FIFO concept.
 func openSidecarFile(path string) (*os.File, error) {
 	// Note: NO O_TRUNC here — we truncate after the link-count check.
-	const flag = os.O_WRONLY | os.O_CREATE | syscall.O_NOFOLLOW
+	const flag = os.O_WRONLY | os.O_CREATE | syscall.O_NOFOLLOW | syscall.O_NONBLOCK
 	f, err := os.OpenFile(path, flag, 0o600) //nolint:gosec,mnd // path is composed from output-root + fixed file name; 0600 is the standard owner-only mode
 	if err != nil {
 		if errors.Is(err, syscall.ELOOP) {
 			return nil, cockroachdberr.WithStack(cockroachdberr.Wrapf(err,
 				"backup: refusing to overwrite symlink at %s", path))
+		}
+		// ENXIO surfaces when the path is a FIFO with no reader;
+		// because O_NONBLOCK turned the would-be hang into an
+		// immediate error, surface it with a stable message
+		// rather than letting the bare syscall errno leak out.
+		if errors.Is(err, syscall.ENXIO) {
+			return nil, cockroachdberr.WithStack(cockroachdberr.Wrapf(err,
+				"backup: refusing to write to FIFO at %s", path))
 		}
 		return nil, cockroachdberr.WithStack(err)
 	}
@@ -43,6 +60,16 @@ func openSidecarFile(path string) (*os.File, error) {
 	if err != nil {
 		_ = f.Close()
 		return nil, cockroachdberr.WithStack(err)
+	}
+	// Refuse non-regular files. A reader-attached FIFO (where the
+	// O_NONBLOCK open succeeded), a socket, or a character/block
+	// device would all otherwise be silently written into and
+	// `f.Truncate(0)` would be a no-op or fail in a confusing way.
+	// Codex P2 round 11.
+	if !info.Mode().IsRegular() {
+		_ = f.Close()
+		return nil, cockroachdberr.WithStack(cockroachdberr.Newf(
+			"backup: refusing to write to non-regular file at %s (mode=%s)", path, info.Mode()))
 	}
 	if sysStat, ok := info.Sys().(*syscall.Stat_t); ok && sysStat.Nlink > 1 {
 		_ = f.Close()

--- a/internal/backup/open_nofollow_windows.go
+++ b/internal/backup/open_nofollow_windows.go
@@ -22,5 +22,9 @@ func openSidecarFile(path string) (*os.File, error) {
 		return nil, cockroachdberr.WithStack(cockroachdberr.Newf(
 			"backup: refusing to overwrite symlink at %s", path))
 	}
-	return os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec,mnd // path is composed from output-root + fixed file name; 0600 is the standard owner-only mode
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec,mnd // path is composed from output-root + fixed file name; 0600 is the standard owner-only mode
+	if err != nil {
+		return nil, cockroachdberr.WithStack(err)
+	}
+	return f, nil
 }

--- a/internal/backup/open_nofollow_windows.go
+++ b/internal/backup/open_nofollow_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package backup
+
+import (
+	"os"
+
+	cockroachdberr "github.com/cockroachdb/errors"
+)
+
+// openSidecarFile is the Windows counterpart to the unix
+// open_nofollow_unix.go variant. syscall.O_NOFOLLOW is not defined on
+// Windows and the platform's symlink/permission model is materially
+// different (junction points, ACLs, SeCreateSymbolicLinkPrivilege),
+// so we keep the simpler Lstat-then-OpenFile guard. The remaining
+// TOCTOU window is acceptable here because mounting a successful
+// attack on the dump tree on Windows already requires the attacker to
+// hold write access to the output directory plus the symlink-create
+// privilege, which is a much higher bar than the unix case.
+func openSidecarFile(path string) (*os.File, error) {
+	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return nil, cockroachdberr.WithStack(cockroachdberr.Newf(
+			"backup: refusing to overwrite symlink at %s", path))
+	}
+	return os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec,mnd // path is composed from output-root + fixed file name; 0600 is the standard owner-only mode
+}

--- a/internal/backup/redis_string.go
+++ b/internal/backup/redis_string.go
@@ -2,7 +2,6 @@ package backup
 
 import (
 	"bufio"
-	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -104,16 +103,16 @@ type RedisDB struct {
 	stringsTTL *jsonlFile
 	hllTTL     *jsonlFile
 
-	// pendingWideColumnTTL accumulates !redis|ttl| records whose user key
-	// has not been claimed by HandleString / HandleHLL. These are
-	// candidates for hashes/lists/sets/zsets/streams (handled in a
-	// follow-up PR) — for now Finalize logs them via the warning hook
-	// rather than dropping silently. Bounded by maxPendingWideColumnTTL
-	// so a malformed snapshot with millions of orphan TTL records cannot
-	// drive the encoder OOM; the bound is high enough that real
-	// production state (where wide-column type encoders eventually
-	// claim every TTL) is never affected.
-	pendingWideColumnTTL []redisTTLPending
+	// orphanTTLCount counts !redis|ttl| records whose user key has not
+	// been claimed by HandleString / HandleHLL. These are candidates
+	// for hashes/lists/sets/zsets/streams (handled in a follow-up PR)
+	// — for now Finalize logs the count via the warning hook rather
+	// than dropping silently. We deliberately track only the count
+	// (not the keys themselves) because the keys are unused before
+	// the wide-column encoders land; buffering full keys would
+	// allocate proportional to user-key size (up to 1 MiB per key),
+	// and the warning sink only ever reads len(). Codex P2 round 6.
+	orphanTTLCount int
 
 	// dirsCreated caches the per-encoder directories writeBlob and
 	// appendTTL have already MkdirAll'd. Avoids the per-record syscalls
@@ -138,19 +137,6 @@ type RedisDB struct {
 	// care about warnings.
 	warn func(event string, fields ...any)
 }
-
-type redisTTLPending struct {
-	UserKey    []byte
-	ExpireAtMs uint64
-}
-
-// maxPendingWideColumnTTL caps the orphan-TTL buffer. 1M entries is well
-// past anything a real Redis instance produces under normal operation
-// (each entry is ~50 bytes, so the cap is ~50 MiB) but small enough that
-// a snapshot loaded with a billion synthetic !redis|ttl| records cannot
-// drive the encoder OOM. When the cap is hit, HandleTTL drops further
-// orphans and surfaces a structured warning at Finalize.
-const maxPendingWideColumnTTL = 1_000_000
 
 // NewRedisDB constructs a RedisDB rooted at <outRoot>/redis/db_<n>/.
 // dbIndex selects <n>; today the producer always passes 0, but accepting
@@ -214,8 +200,8 @@ func (r *RedisDB) HandleHLL(userKey, value []byte) error {
 //   - redisKindHLL    -> hll_ttl.jsonl
 //   - redisKindString -> strings_ttl.jsonl (legacy strings, whose TTL
 //     lives in !redis|ttl| rather than the inline magic-prefix header)
-//   - redisKindUnknown -> buffered as pendingWideColumnTTL; reported via
-//     the warn sink on Finalize because Phase 0a's wide-column encoders
+//   - redisKindUnknown -> counted in orphanTTLCount; reported via the
+//     warn sink on Finalize because Phase 0a's wide-column encoders
 //     have not landed yet.
 func (r *RedisDB) HandleTTL(userKey, value []byte) error {
 	expireAtMs, err := decodeRedisTTLValue(value)
@@ -237,17 +223,11 @@ func (r *RedisDB) HandleTTL(userKey, value []byte) error {
 		}
 		return r.appendTTL(&r.stringsTTL, redisStringsTTLFile, userKey, expireAtMs)
 	case redisKindUnknown:
-		// Bounded to prevent OOM on a snapshot that contains a
-		// runaway number of orphan TTL records (e.g., many wide-
-		// column types whose meta records were dropped). After the
-		// cap, additional records are tracked only as a counter via
-		// the warning sink at Finalize.
-		if len(r.pendingWideColumnTTL) < maxPendingWideColumnTTL {
-			r.pendingWideColumnTTL = append(r.pendingWideColumnTTL, redisTTLPending{
-				UserKey:    bytes.Clone(userKey),
-				ExpireAtMs: expireAtMs,
-			})
-		}
+		// Track orphan TTL counts only — keys are unused before the
+		// wide-column encoders land, and buffering them allocates
+		// proportional to user-key size (up to 1 MiB per key) for
+		// no benefit. Codex P2 round 6.
+		r.orphanTTLCount++
 		return nil
 	}
 	return nil
@@ -265,9 +245,9 @@ func (r *RedisDB) Finalize() error {
 	if err := closeJSONL(r.hllTTL); err != nil && firstErr == nil {
 		firstErr = err
 	}
-	if r.warn != nil && len(r.pendingWideColumnTTL) > 0 {
+	if r.warn != nil && r.orphanTTLCount > 0 {
 		r.warn("redis_orphan_ttl",
-			"count", len(r.pendingWideColumnTTL),
+			"count", r.orphanTTLCount,
 			"hint", "wide-column type encoders (hash/list/set/zset/stream) have not landed yet")
 	}
 	return firstErr
@@ -408,16 +388,26 @@ func openJSONL(path string) (*jsonlFile, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil { //nolint:mnd // 0755 == standard dir mode
 		return nil, cockroachdberr.WithStack(err)
 	}
-	// Refuse to clobber a symlink at the sidecar path. os.Create
-	// follows symlinks and would truncate the target outside the
-	// dump tree. writeFileAtomic already defends blob writes the
-	// same way; sidecar creation must mirror that boundary. Codex P2
-	// round 5.
-	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
-		return nil, cockroachdberr.WithStack(cockroachdberr.Newf("backup: refusing to overwrite symlink at %s", path))
-	}
-	f, err := os.Create(path) //nolint:gosec // path is composed from output-root + fixed file name
+	// Refuse to clobber a symlink at the sidecar path. The earlier
+	// Lstat-then-Create pattern was a TOCTOU race: a process that
+	// could write the output directory could swap the path to a
+	// symlink between the two syscalls and still get the target
+	// truncated (Codex P1 round 6, follow-up to round 5). Use
+	// O_NOFOLLOW so the open syscall itself refuses symlinks
+	// atomically — no race window exists. On platforms where the
+	// kernel supports it (Linux, macOS, BSD) this returns ELOOP for
+	// a symlink path. On Windows syscall.O_NOFOLLOW is 0 (no-op),
+	// matching Windows's different filesystem-permission model.
+	const flag = os.O_WRONLY | os.O_CREATE | os.O_TRUNC | syscall.O_NOFOLLOW
+	f, err := os.OpenFile(path, flag, 0o600) //nolint:gosec,mnd // path is composed from output-root + fixed file name; 0600 is the standard owner-only mode for sidecar files
 	if err != nil {
+		// errors.Is(err, syscall.ELOOP) catches symlink rejection
+		// on Linux/macOS/BSD; wrap rather than replace so the
+		// caller can still inspect the underlying syscall error.
+		if errors.Is(err, syscall.ELOOP) {
+			return nil, cockroachdberr.WithStack(cockroachdberr.Wrapf(err,
+				"backup: refusing to overwrite symlink at %s", path))
+		}
 		return nil, cockroachdberr.WithStack(err)
 	}
 	bw := bufio.NewWriterSize(f, redisJSONLBufSize)

--- a/internal/backup/redis_string.go
+++ b/internal/backup/redis_string.go
@@ -404,7 +404,19 @@ func (r *RedisDB) writeBlob(subdir string, userKey, value []byte) error {
 
 func (r *RedisDB) appendTTL(slot **jsonlFile, baseName string, userKey []byte, expireAtMs uint64) error {
 	if *slot == nil {
-		f, err := openJSONL(filepath.Join(r.dbDir(), baseName))
+		// Route the parent directory through ensureDir so the
+		// shared assertNoSymlinkAncestors guard fires before we
+		// open the sidecar. openJSONL alone only protects the
+		// final path element via openSidecarFile; without this
+		// a symlinked ancestor (e.g.
+		// `<outRoot>/redis/db_0 -> /tmp/outside`) would still
+		// redirect strings_ttl.jsonl / hll_ttl.jsonl writes
+		// outside the dump root. Codex P1 round 13 (PR #713).
+		dir := r.dbDir()
+		if err := r.ensureDir(dir); err != nil {
+			return err
+		}
+		f, err := openJSONL(filepath.Join(dir, baseName))
 		if err != nil {
 			return err
 		}

--- a/internal/backup/redis_string.go
+++ b/internal/backup/redis_string.go
@@ -136,6 +136,17 @@ type RedisDB struct {
 	// (fed by the decoder driver); nil in tests if the test does not
 	// care about warnings.
 	warn func(event string, fields ...any)
+
+	// keymap / keymapFile / keymapDir are lazily set on the first
+	// SHA-fallback (or other non-reversible) encoded segment. Without
+	// these records, the decoder cannot recover the original Redis
+	// user key from a fallback-encoded `*.bin` filename or from an
+	// `appendTTL` JSONL row keyed by the encoded form. Codex P1
+	// round 7. KeymapWriter.Close only flushes its bufio buffer, so
+	// the *os.File is tracked separately to be closed at Finalize.
+	keymap     *KeymapWriter
+	keymapFile *os.File
+	keymapDir  string
 }
 
 // NewRedisDB constructs a RedisDB rooted at <outRoot>/redis/db_<n>/.
@@ -245,6 +256,9 @@ func (r *RedisDB) Finalize() error {
 	if err := closeJSONL(r.hllTTL); err != nil && firstErr == nil {
 		firstErr = err
 	}
+	if err := r.closeKeymap(); err != nil && firstErr == nil {
+		firstErr = err
+	}
 	if r.warn != nil && r.orphanTTLCount > 0 {
 		r.warn("redis_orphan_ttl",
 			"count", r.orphanTTLCount,
@@ -300,6 +314,9 @@ func (r *RedisDB) ensureDir(dir string) error {
 
 func (r *RedisDB) writeBlob(subdir string, userKey, value []byte) error {
 	encoded := EncodeSegment(userKey)
+	if err := r.recordIfFallback(encoded, userKey); err != nil {
+		return err
+	}
 	dir := filepath.Join(r.dbDir(), subdir)
 	if err := r.ensureDir(dir); err != nil {
 		return err
@@ -319,17 +336,73 @@ func (r *RedisDB) appendTTL(slot **jsonlFile, baseName string, userKey []byte, e
 		}
 		*slot = f
 	}
+	encoded := EncodeSegment(userKey)
+	if err := r.recordIfFallback(encoded, userKey); err != nil {
+		return err
+	}
 	rec := struct {
 		Key        string `json:"key"`
 		ExpireAtMs uint64 `json:"expire_at_ms"`
 	}{
-		Key:        EncodeSegment(userKey),
+		Key:        encoded,
 		ExpireAtMs: expireAtMs,
 	}
 	if err := (*slot).enc.Encode(rec); err != nil {
 		return cockroachdberr.WithStack(err)
 	}
 	return nil
+}
+
+// recordIfFallback writes a KEYMAP.jsonl entry when EncodeSegment took
+// the SHA-fallback path for userKey. Without this, the encoded
+// filename / JSONL key is non-reversible and the decoder cannot
+// recover the original Redis user key bytes. The keymap writer is
+// lazily opened on first use; an empty KEYMAP file is removed at
+// Finalize so dumps without any fallback keys carry no spurious file.
+// Idempotent: a duplicate (encoded, original) pair is harmless because
+// LoadKeymap's "last record wins" behaviour leaves the same mapping.
+func (r *RedisDB) recordIfFallback(encoded string, userKey []byte) error {
+	if !IsShaFallback(encoded) {
+		return nil
+	}
+	if r.keymap == nil {
+		dir := r.dbDir()
+		if err := r.ensureDir(dir); err != nil {
+			return err
+		}
+		const flag = os.O_WRONLY | os.O_CREATE | os.O_TRUNC | syscall.O_NOFOLLOW
+		f, err := os.OpenFile(filepath.Join(dir, "KEYMAP.jsonl"), flag, 0o600) //nolint:gosec,mnd // path is composed from output-root + fixed file name; 0600 is the standard owner-only mode
+		if err != nil {
+			if errors.Is(err, syscall.ELOOP) {
+				return cockroachdberr.WithStack(cockroachdberr.Wrapf(err,
+					"backup: refusing to overwrite symlink at KEYMAP.jsonl"))
+			}
+			return cockroachdberr.WithStack(err)
+		}
+		r.keymap = NewKeymapWriter(f)
+		r.keymapFile = f
+		r.keymapDir = dir
+	}
+	return r.keymap.WriteOriginal(encoded, userKey, KindSHAFallback)
+}
+
+// closeKeymap flushes and closes the per-encoder KEYMAP.jsonl writer
+// if it was opened. When no SHA-fallback records were emitted the
+// file is removed so dumps without any non-reversible keys carry no
+// spurious empty file (matches the s3 encoder's keymap policy).
+func (r *RedisDB) closeKeymap() error {
+	if r.keymap == nil {
+		return nil
+	}
+	flushErr := r.keymap.Close()
+	closeErr := r.keymapFile.Close()
+	if flushErr == nil && closeErr != nil {
+		flushErr = cockroachdberr.WithStack(closeErr)
+	}
+	if r.keymap.Count() == 0 && r.keymapDir != "" {
+		_ = os.Remove(filepath.Join(r.keymapDir, "KEYMAP.jsonl"))
+	}
+	return flushErr
 }
 
 // decodeRedisStringValue strips the redis-string magic-prefix TTL header

--- a/internal/backup/redis_string.go
+++ b/internal/backup/redis_string.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"syscall"
 
 	cockroachdberr "github.com/cockroachdb/errors"
 )
@@ -75,11 +76,12 @@ const (
 // RedisDB encodes one logical Redis database (`redis/db_<n>/`). All
 // operations are scoped to its outRoot; the caller wires per-database
 // instances when the producer supports multiple databases (today only
-// db_0 is meaningful).
+// db_0 is meaningful, but the encoder is wired to take any non-negative
+// index so a future multi-db dump does not silently collide on db_0).
 //
 // Lifecycle:
 //
-//	r := NewRedisDB(outRoot)
+//	r := NewRedisDB(outRoot, dbIndex)
 //	for each snapshot record matching a redis prefix: r.Handle*(...)
 //	r.Finalize()
 //
@@ -87,6 +89,7 @@ const (
 // inherently sequential per scope, so a mutex would only add cost.
 type RedisDB struct {
 	outRoot string
+	dbIndex int
 
 	// kindByKey records the Redis type each user key was first seen as.
 	// Populated by HandleString and HandleHLL; consulted by HandleTTL.
@@ -105,8 +108,18 @@ type RedisDB struct {
 	// has not been claimed by HandleString / HandleHLL. These are
 	// candidates for hashes/lists/sets/zsets/streams (handled in a
 	// follow-up PR) — for now Finalize logs them via the warning hook
-	// rather than dropping silently.
+	// rather than dropping silently. Bounded by maxPendingWideColumnTTL
+	// so a malformed snapshot with millions of orphan TTL records cannot
+	// drive the encoder OOM; the bound is high enough that real
+	// production state (where wide-column type encoders eventually
+	// claim every TTL) is never affected.
 	pendingWideColumnTTL []redisTTLPending
+
+	// dirsCreated caches the per-encoder directories writeBlob and
+	// appendTTL have already MkdirAll'd. Avoids the per-record syscalls
+	// flagged by Gemini #218; for a 10M-key dump this saves ~10M
+	// stat+mkdir(EEXIST) round-trips.
+	dirsCreated map[string]struct{}
 
 	// warn is the structured-warning sink. Non-nil in production
 	// (fed by the decoder driver); nil in tests if the test does not
@@ -119,12 +132,27 @@ type redisTTLPending struct {
 	ExpireAtMs uint64
 }
 
-// NewRedisDB constructs a RedisDB rooted at <outRoot>/redis/db_<n>/. The
-// caller is responsible for choosing <n>; today only 0 is meaningful.
-func NewRedisDB(outRoot string) *RedisDB {
+// maxPendingWideColumnTTL caps the orphan-TTL buffer. 1M entries is well
+// past anything a real Redis instance produces under normal operation
+// (each entry is ~50 bytes, so the cap is ~50 MiB) but small enough that
+// a snapshot loaded with a billion synthetic !redis|ttl| records cannot
+// drive the encoder OOM. When the cap is hit, HandleTTL drops further
+// orphans and surfaces a structured warning at Finalize.
+const maxPendingWideColumnTTL = 1_000_000
+
+// NewRedisDB constructs a RedisDB rooted at <outRoot>/redis/db_<n>/.
+// dbIndex selects <n>; today the producer always passes 0, but accepting
+// the index as a parameter prevents a future multi-db dump from silently
+// colliding on db_0.
+func NewRedisDB(outRoot string, dbIndex int) *RedisDB {
+	if dbIndex < 0 {
+		dbIndex = 0
+	}
 	return &RedisDB{
-		outRoot:   outRoot,
-		kindByKey: make(map[string]redisKeyKind),
+		outRoot:     outRoot,
+		dbIndex:     dbIndex,
+		kindByKey:   make(map[string]redisKeyKind),
+		dirsCreated: make(map[string]struct{}),
 	}
 }
 
@@ -183,10 +211,17 @@ func (r *RedisDB) HandleTTL(userKey, value []byte) error {
 	case redisKindString:
 		return r.appendTTL(&r.stringsTTL, redisStringsTTLFile, userKey, expireAtMs)
 	case redisKindUnknown:
-		r.pendingWideColumnTTL = append(r.pendingWideColumnTTL, redisTTLPending{
-			UserKey:    bytes.Clone(userKey),
-			ExpireAtMs: expireAtMs,
-		})
+		// Bounded to prevent OOM on a snapshot that contains a
+		// runaway number of orphan TTL records (e.g., many wide-
+		// column types whose meta records were dropped). After the
+		// cap, additional records are tracked only as a counter via
+		// the warning sink at Finalize.
+		if len(r.pendingWideColumnTTL) < maxPendingWideColumnTTL {
+			r.pendingWideColumnTTL = append(r.pendingWideColumnTTL, redisTTLPending{
+				UserKey:    bytes.Clone(userKey),
+				ExpireAtMs: expireAtMs,
+			})
+		}
 		return nil
 	}
 	return nil
@@ -212,11 +247,56 @@ func (r *RedisDB) Finalize() error {
 	return firstErr
 }
 
-func (r *RedisDB) writeBlob(subdir string, userKey, value []byte) error {
-	encoded := EncodeSegment(userKey)
-	dir := filepath.Join(r.outRoot, "redis", "db_0", subdir)
+// dbDir returns the per-encoder root, e.g. "<outRoot>/redis/db_0/".
+// Computed once per call rather than at construction so the encoder's
+// outRoot remains a plain field — easier to reason about in tests.
+func (r *RedisDB) dbDir() string {
+	return filepath.Join(r.outRoot, "redis", redisDBSegment(r.dbIndex))
+}
+
+func redisDBSegment(idx int) string {
+	if idx < 0 {
+		idx = 0
+	}
+	return "db_" + intToDecimal(idx)
+}
+
+// intToDecimal is a tiny zero-allocation helper for non-negative ints.
+// Avoids the strconv import here just to format dbIndex.
+func intToDecimal(v int) string {
+	if v == 0 {
+		return "0"
+	}
+	const maxIntDecimalDigits = 20 // covers MaxInt64
+	var buf [maxIntDecimalDigits]byte
+	pos := len(buf)
+	for v > 0 {
+		pos--
+		buf[pos] = '0' + byte(v%10) //nolint:mnd // 10 == decimal radix
+		v /= 10                     //nolint:mnd // 10 == decimal radix
+	}
+	return string(buf[pos:])
+}
+
+// ensureDir runs MkdirAll once per directory and remembers the result
+// in r.dirsCreated, so repeated calls on the hot path (one per blob
+// record) collapse to a map lookup.
+func (r *RedisDB) ensureDir(dir string) error {
+	if _, ok := r.dirsCreated[dir]; ok {
+		return nil
+	}
 	if err := os.MkdirAll(dir, 0o755); err != nil { //nolint:mnd // 0755 == standard dir mode
 		return cockroachdberr.WithStack(err)
+	}
+	r.dirsCreated[dir] = struct{}{}
+	return nil
+}
+
+func (r *RedisDB) writeBlob(subdir string, userKey, value []byte) error {
+	encoded := EncodeSegment(userKey)
+	dir := filepath.Join(r.dbDir(), subdir)
+	if err := r.ensureDir(dir); err != nil {
+		return err
 	}
 	path := filepath.Join(dir, encoded+".bin")
 	if err := writeFileAtomic(path, value); err != nil {
@@ -227,7 +307,7 @@ func (r *RedisDB) writeBlob(subdir string, userKey, value []byte) error {
 
 func (r *RedisDB) appendTTL(slot **jsonlFile, baseName string, userKey []byte, expireAtMs uint64) error {
 	if *slot == nil {
-		f, err := openJSONL(filepath.Join(r.outRoot, "redis", "db_0", baseName))
+		f, err := openJSONL(filepath.Join(r.dbDir(), baseName))
 		if err != nil {
 			return err
 		}
@@ -369,15 +449,27 @@ func HasInlineTTL(value []byte) bool {
 	return value[2]&redisStrHasTTL != 0
 }
 
-// IsBlobAtomicWriteRetriable reports whether err from writeFileAtomic is
-// a retriable I/O failure (no-space, transient FS error). Today this is a
-// stub that returns false for any error; exposed so the master decoder
-// loop can decide whether to abort the whole dump on encountering one.
+// IsBlobAtomicWriteRetriable reports whether err from writeFileAtomic
+// is a retriable I/O failure. Today the only retriable signal is
+// io.ErrShortWrite. ENOSPC (disk full) is intentionally NOT retriable
+// here — the master pipeline must surface it to the operator rather
+// than spin: a backup against a full disk has no business retrying.
+// IsBlobAtomicWriteOutOfSpace is the explicit out-of-space probe so
+// the pipeline can choose the right alarm wording.
 func IsBlobAtomicWriteRetriable(err error) bool {
 	if err == nil {
 		return false
 	}
-	// errors.Is handles wrapped paths; both sentinel checks are stable
-	// for now because we never wrap them ourselves.
 	return errors.Is(err, io.ErrShortWrite)
+}
+
+// IsBlobAtomicWriteOutOfSpace reports whether err from writeFileAtomic
+// (or any os.File write the master pipeline issues) was driven by a
+// full disk. Tested via syscall.ENOSPC + os.PathError unwrap, which
+// matches what os.File.Write returns on POSIX and Windows.
+func IsBlobAtomicWriteOutOfSpace(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, syscall.ENOSPC)
 }

--- a/internal/backup/redis_string.go
+++ b/internal/backup/redis_string.go
@@ -9,7 +9,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"syscall"
+	"strings"
 
 	cockroachdberr "github.com/cockroachdb/errors"
 )
@@ -300,7 +300,19 @@ func intToDecimal(v int) string {
 
 // ensureDir runs MkdirAll once per directory and remembers the result
 // in r.dirsCreated, so repeated calls on the hot path (one per blob
-// record) collapse to a map lookup.
+// record) collapse to a map lookup. After MkdirAll succeeds, every
+// path component under outRoot is Lstat-checked: a pre-existing
+// directory symlink at e.g. `<outRoot>/redis/db_0/strings` would
+// otherwise let `os.MkdirAll` succeed without creating anything,
+// then steer subsequent writes outside outRoot. Codex P1 round 9.
+//
+// This guard is best-effort against TOCTOU (an adversary that can
+// swap a directory for a symlink between this check and the open
+// races us either way); it closes the much more common case of a
+// stale symlink left in the output tree from a prior run or
+// configuration mistake. Hardening to fully race-free traversal
+// would require os.Root / openat-style traversal, which is a
+// larger refactor for marginal benefit at this layer.
 func (r *RedisDB) ensureDir(dir string) error {
 	if _, ok := r.dirsCreated[dir]; ok {
 		return nil
@@ -308,7 +320,69 @@ func (r *RedisDB) ensureDir(dir string) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil { //nolint:mnd // 0755 == standard dir mode
 		return cockroachdberr.WithStack(err)
 	}
+	if err := assertNoSymlinkAncestors(r.outRoot, dir); err != nil {
+		return err
+	}
 	r.dirsCreated[dir] = struct{}{}
+	return nil
+}
+
+// assertNoSymlinkAncestors walks every path component from rootDir up
+// to (and including) target, Lstat'ing each. Returns ErrSymlinkInPath
+// if any component is a symbolic link. rootDir itself is also
+// Lstat'd: if the dump root is a symlink to somewhere else, all bets
+// are off.
+func assertNoSymlinkAncestors(rootDir, target string) error {
+	cleanRoot := filepath.Clean(rootDir)
+	cleanTarget := filepath.Clean(target)
+	rel, err := filepath.Rel(cleanRoot, cleanTarget)
+	if err != nil {
+		return cockroachdberr.WithStack(err)
+	}
+	// Defensive: if target escapes rootDir (which the callers' path
+	// construction already prevents), refuse rather than silently
+	// validate an unrelated path.
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return cockroachdberr.WithStack(cockroachdberr.Newf(
+			"backup: target %s escapes root %s", target, rootDir))
+	}
+	if err := lstatRefuseSymlink(cleanRoot); err != nil {
+		return err
+	}
+	cur := cleanRoot
+	if rel == "." {
+		return nil
+	}
+	for _, seg := range strings.Split(rel, string(filepath.Separator)) {
+		if seg == "" {
+			continue
+		}
+		cur = filepath.Join(cur, seg)
+		if err := lstatRefuseSymlink(cur); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// lstatRefuseSymlink returns an error wrapped over the underlying
+// stat call when path is a symbolic link. A non-existent path is
+// treated as fine: the caller has just MkdirAll'd it, so a missing
+// component is impossible — but if it were, the symlink-check
+// contract is "if it exists, it must not be a symlink", and we
+// return nil rather than synthesize a false positive.
+func lstatRefuseSymlink(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return cockroachdberr.WithStack(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return cockroachdberr.WithStack(cockroachdberr.Newf(
+			"backup: refusing to traverse symlinked ancestor at %s", path))
+	}
 	return nil
 }
 
@@ -546,11 +620,14 @@ func IsBlobAtomicWriteRetriable(err error) bool {
 
 // IsBlobAtomicWriteOutOfSpace reports whether err from writeFileAtomic
 // (or any os.File write the master pipeline issues) was driven by a
-// full disk. Tested via syscall.ENOSPC + os.PathError unwrap, which
-// matches what os.File.Write returns on POSIX and Windows.
+// full disk. The platform-specific error codes (POSIX ENOSPC vs.
+// Windows ERROR_DISK_FULL / ERROR_HANDLE_DISK_FULL) live in
+// disk_full_{unix,windows}.go so retry/alarm logic in callers
+// classifies disk-full uniformly across operating systems
+// (Codex P2 round 9).
 func IsBlobAtomicWriteOutOfSpace(err error) bool {
 	if err == nil {
 		return false
 	}
-	return errors.Is(err, syscall.ENOSPC)
+	return isDiskFullError(err)
 }

--- a/internal/backup/redis_string.go
+++ b/internal/backup/redis_string.go
@@ -300,11 +300,13 @@ func intToDecimal(v int) string {
 
 // ensureDir runs MkdirAll once per directory and remembers the result
 // in r.dirsCreated, so repeated calls on the hot path (one per blob
-// record) collapse to a map lookup. After MkdirAll succeeds, every
-// path component under outRoot is Lstat-checked: a pre-existing
-// directory symlink at e.g. `<outRoot>/redis/db_0/strings` would
-// otherwise let `os.MkdirAll` succeed without creating anything,
-// then steer subsequent writes outside outRoot. Codex P1 round 9.
+// record) collapse to one syscall instead of N. The
+// `assertNoSymlinkAncestors` check, however, runs on EVERY call —
+// not just the first — because a directory that was safe at first
+// write can later be replaced with a symlink and subsequent writes
+// would bypass the check, reintroducing the path-escape vector
+// (Codex P1 round 13 follow-up). The cache only short-circuits
+// MkdirAll, not the security check.
 //
 // This guard is best-effort against TOCTOU (an adversary that can
 // swap a directory for a symlink between this check and the open
@@ -314,14 +316,15 @@ func intToDecimal(v int) string {
 // would require os.Root / openat-style traversal, which is a
 // larger refactor for marginal benefit at this layer.
 func (r *RedisDB) ensureDir(dir string) error {
+	// Always re-run the ancestor check; never skip on cache hit.
+	if err := assertNoSymlinkAncestors(r.outRoot, dir); err != nil {
+		return err
+	}
 	if _, ok := r.dirsCreated[dir]; ok {
 		return nil
 	}
 	if err := os.MkdirAll(dir, 0o755); err != nil { //nolint:mnd // 0755 == standard dir mode
 		return cockroachdberr.WithStack(err)
-	}
-	if err := assertNoSymlinkAncestors(r.outRoot, dir); err != nil {
-		return err
 	}
 	r.dirsCreated[dir] = struct{}{}
 	return nil

--- a/internal/backup/redis_string.go
+++ b/internal/backup/redis_string.go
@@ -121,6 +121,18 @@ type RedisDB struct {
 	// stat+mkdir(EEXIST) round-trips.
 	dirsCreated map[string]struct{}
 
+	// inlineTTLEmitted tracks string keys whose TTL was already
+	// extracted from the inline magic-prefix header by HandleString and
+	// written to strings_ttl.jsonl. The live Redis encoder emits BOTH
+	// `!redis|str|<k>` (with inline TTL) and `!redis|ttl|<k>` (the
+	// scan-index entry the sweeper consumes) for an expiring string
+	// (see adapter/redis_lua_context.go stringCommitElems). Without
+	// this set, HandleTTL would route the redundant `!redis|ttl|`
+	// record back into the same sidecar, duplicating the entry and
+	// violating the one-record-per-key contract sidecar consumers
+	// rely on. Codex P1 round 5.
+	inlineTTLEmitted map[string]struct{}
+
 	// warn is the structured-warning sink. Non-nil in production
 	// (fed by the decoder driver); nil in tests if the test does not
 	// care about warnings.
@@ -149,10 +161,11 @@ func NewRedisDB(outRoot string, dbIndex int) *RedisDB {
 		dbIndex = 0
 	}
 	return &RedisDB{
-		outRoot:     outRoot,
-		dbIndex:     dbIndex,
-		kindByKey:   make(map[string]redisKeyKind),
-		dirsCreated: make(map[string]struct{}),
+		outRoot:          outRoot,
+		dbIndex:          dbIndex,
+		kindByKey:        make(map[string]redisKeyKind),
+		dirsCreated:      make(map[string]struct{}),
+		inlineTTLEmitted: make(map[string]struct{}),
 	}
 }
 
@@ -179,6 +192,10 @@ func (r *RedisDB) HandleString(userKey, value []byte) error {
 	if expireAtMs == 0 {
 		return nil
 	}
+	// Mark the key as already emitted inline so HandleTTL can drop the
+	// redundant !redis|ttl| scan-index record; otherwise the same
+	// expiring string would be written to strings_ttl.jsonl twice.
+	r.inlineTTLEmitted[string(userKey)] = struct{}{}
 	return r.appendTTL(&r.stringsTTL, redisStringsTTLFile, userKey, expireAtMs)
 }
 
@@ -209,6 +226,15 @@ func (r *RedisDB) HandleTTL(userKey, value []byte) error {
 	case redisKindHLL:
 		return r.appendTTL(&r.hllTTL, redisHLLTTLFile, userKey, expireAtMs)
 	case redisKindString:
+		// New-format strings carry TTL inline in the magic-prefix
+		// header; HandleString already wrote the entry to
+		// strings_ttl.jsonl. The `!redis|ttl|` scan-index record
+		// the sweeper consumes is redundant for backup output. Only
+		// legacy strings (no inline TTL) reach the appendTTL call.
+		// Codex P1 round 5.
+		if _, ok := r.inlineTTLEmitted[string(userKey)]; ok {
+			return nil
+		}
 		return r.appendTTL(&r.stringsTTL, redisStringsTTLFile, userKey, expireAtMs)
 	case redisKindUnknown:
 		// Bounded to prevent OOM on a snapshot that contains a
@@ -381,6 +407,14 @@ type jsonlFile struct {
 func openJSONL(path string) (*jsonlFile, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil { //nolint:mnd // 0755 == standard dir mode
 		return nil, cockroachdberr.WithStack(err)
+	}
+	// Refuse to clobber a symlink at the sidecar path. os.Create
+	// follows symlinks and would truncate the target outside the
+	// dump tree. writeFileAtomic already defends blob writes the
+	// same way; sidecar creation must mirror that boundary. Codex P2
+	// round 5.
+	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return nil, cockroachdberr.WithStack(cockroachdberr.Newf("backup: refusing to overwrite symlink at %s", path))
 	}
 	f, err := os.Create(path) //nolint:gosec // path is composed from output-root + fixed file name
 	if err != nil {

--- a/internal/backup/redis_string.go
+++ b/internal/backup/redis_string.go
@@ -1,0 +1,383 @@
+package backup
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+
+	cockroachdberr "github.com/cockroachdb/errors"
+)
+
+// Redis simple-type encoders translate raw snapshot key/value records into
+// the per-adapter directory tree defined by Phase 0
+// (docs/design/2026_04_29_proposed_snapshot_logical_decoder.md). This file
+// covers the three "simple" Redis prefixes — strings, HLLs, and TTL scan
+// index entries — that always map to ONE snapshot record per user key and
+// therefore need no cross-record assembly.
+//
+// Hash / list / set / zset / stream prefixes carry user keys spread across
+// multiple wide-column rows and ship in a follow-up PR.
+
+// Snapshot key prefixes the encoder dispatches on. Kept in sync with
+// adapter/redis_compat_types.go so a renamed prefix in the live code is
+// caught here at compile time via the corresponding tests.
+const (
+	RedisStringPrefix = "!redis|str|"
+	RedisHLLPrefix    = "!redis|hll|"
+	RedisTTLPrefix    = "!redis|ttl|"
+
+	// redisStrMagic / redisStrVersion / redisStrHasTTL / redisStrBaseHeader
+	// mirror adapter/redis_compat_types.go:20-24. Re-defined here rather
+	// than imported because the backup package is intentionally adapter-
+	// independent (it must run as an offline tool with no live cluster).
+	redisStrMagic      byte = 0xFF
+	redisStrVersion    byte = 0x01
+	redisStrHasTTL     byte = 0x01
+	redisStrBaseHeader      = 3
+	redisUint64Bytes        = 8
+
+	redisStringsTTLFile = "strings_ttl.jsonl"
+	redisHLLTTLFile     = "hll_ttl.jsonl"
+
+	// redisJSONLBufSize is the bufio.Writer buffer for the per-database
+	// TTL sidecar files. The same 64 KiB tuning as KeymapWriter — large
+	// enough to amortise per-syscall cost across thousands of TTL records.
+	redisJSONLBufSize = 64 << 10
+)
+
+// ErrRedisInvalidStringValue is returned when a !redis|str| value uses the
+// new magic-prefix format but its declared TTL section is truncated. Legacy
+// (no-magic) values are accepted as opaque raw bytes.
+var ErrRedisInvalidStringValue = cockroachdberr.New("backup: invalid !redis|str| value")
+
+// ErrRedisInvalidTTLValue is returned when a !redis|ttl| value is not the
+// expected 8-byte big-endian uint64 millisecond expiry.
+var ErrRedisInvalidTTLValue = cockroachdberr.New("backup: invalid !redis|ttl| value")
+
+// redisKeyKind tracks which Redis-type prefix introduced a user key, so that
+// when a later !redis|ttl|<K> record arrives we know whether to write its
+// expiry into strings_ttl.jsonl, hll_ttl.jsonl, or buffer it for a wide-
+// column type (hash/list/set/zset/stream).
+type redisKeyKind uint8
+
+const (
+	redisKindUnknown redisKeyKind = iota
+	redisKindString
+	redisKindHLL
+)
+
+// RedisDB encodes one logical Redis database (`redis/db_<n>/`). All
+// operations are scoped to its outRoot; the caller wires per-database
+// instances when the producer supports multiple databases (today only
+// db_0 is meaningful).
+//
+// Lifecycle:
+//
+//	r := NewRedisDB(outRoot)
+//	for each snapshot record matching a redis prefix: r.Handle*(...)
+//	r.Finalize()
+//
+// Handle* methods are NOT goroutine-safe; the decoder pipeline is
+// inherently sequential per scope, so a mutex would only add cost.
+type RedisDB struct {
+	outRoot string
+
+	// kindByKey records the Redis type each user key was first seen as.
+	// Populated by HandleString and HandleHLL; consulted by HandleTTL.
+	// Sized for typical clusters (millions of keys × ~50 bytes each is
+	// affordable on the dump host); a follow-up PR introducing the
+	// wide-column types may switch to a streamed approach if profiling
+	// shows this is the binding cost.
+	kindByKey map[string]redisKeyKind
+
+	// stringsTTL / hllTTL are lazily opened on first write. Per the spec,
+	// empty sidecar files are omitted from the dump.
+	stringsTTL *jsonlFile
+	hllTTL     *jsonlFile
+
+	// pendingWideColumnTTL accumulates !redis|ttl| records whose user key
+	// has not been claimed by HandleString / HandleHLL. These are
+	// candidates for hashes/lists/sets/zsets/streams (handled in a
+	// follow-up PR) — for now Finalize logs them via the warning hook
+	// rather than dropping silently.
+	pendingWideColumnTTL []redisTTLPending
+
+	// warn is the structured-warning sink. Non-nil in production
+	// (fed by the decoder driver); nil in tests if the test does not
+	// care about warnings.
+	warn func(event string, fields ...any)
+}
+
+type redisTTLPending struct {
+	UserKey    []byte
+	ExpireAtMs uint64
+}
+
+// NewRedisDB constructs a RedisDB rooted at <outRoot>/redis/db_<n>/. The
+// caller is responsible for choosing <n>; today only 0 is meaningful.
+func NewRedisDB(outRoot string) *RedisDB {
+	return &RedisDB{
+		outRoot:   outRoot,
+		kindByKey: make(map[string]redisKeyKind),
+	}
+}
+
+// WithWarnSink wires a structured-warning sink. The sink is called with
+// stable event names ("redis_orphan_ttl", etc.) and key=value pairs.
+func (r *RedisDB) WithWarnSink(fn func(event string, fields ...any)) *RedisDB {
+	r.warn = fn
+	return r
+}
+
+// HandleString processes one !redis|str|<userKey> record. The value is the
+// raw stored bytes; HandleString peels the magic-prefix TTL header (if
+// present) and writes the user-visible value to strings/<encoded>.bin and
+// the TTL — if any — to strings_ttl.jsonl.
+func (r *RedisDB) HandleString(userKey, value []byte) error {
+	r.kindByKey[string(userKey)] = redisKindString
+	userValue, expireAtMs, err := decodeRedisStringValue(value)
+	if err != nil {
+		return err
+	}
+	if err := r.writeBlob("strings", userKey, userValue); err != nil {
+		return err
+	}
+	if expireAtMs == 0 {
+		return nil
+	}
+	return r.appendTTL(&r.stringsTTL, redisStringsTTLFile, userKey, expireAtMs)
+}
+
+// HandleHLL processes one !redis|hll|<userKey> record. The value is the
+// raw HLL sketch bytes, written byte-for-byte to hll/<encoded>.bin. TTL
+// for HLL keys lives in !redis|ttl|<userKey> and is consumed by
+// HandleTTL.
+func (r *RedisDB) HandleHLL(userKey, value []byte) error {
+	r.kindByKey[string(userKey)] = redisKindHLL
+	return r.writeBlob("hll", userKey, value)
+}
+
+// HandleTTL processes one !redis|ttl|<userKey> record. Routing depends on
+// what HandleString/HandleHLL recorded for the same userKey:
+//
+//   - redisKindHLL    -> hll_ttl.jsonl
+//   - redisKindString -> strings_ttl.jsonl (legacy strings, whose TTL
+//     lives in !redis|ttl| rather than the inline magic-prefix header)
+//   - redisKindUnknown -> buffered as pendingWideColumnTTL; reported via
+//     the warn sink on Finalize because Phase 0a's wide-column encoders
+//     have not landed yet.
+func (r *RedisDB) HandleTTL(userKey, value []byte) error {
+	expireAtMs, err := decodeRedisTTLValue(value)
+	if err != nil {
+		return err
+	}
+	switch r.kindByKey[string(userKey)] {
+	case redisKindHLL:
+		return r.appendTTL(&r.hllTTL, redisHLLTTLFile, userKey, expireAtMs)
+	case redisKindString:
+		return r.appendTTL(&r.stringsTTL, redisStringsTTLFile, userKey, expireAtMs)
+	case redisKindUnknown:
+		r.pendingWideColumnTTL = append(r.pendingWideColumnTTL, redisTTLPending{
+			UserKey:    bytes.Clone(userKey),
+			ExpireAtMs: expireAtMs,
+		})
+		return nil
+	}
+	return nil
+}
+
+// Finalize flushes all open sidecar writers and emits warnings for any
+// pending TTL records whose user key was never claimed by the wide-column
+// encoders. Call exactly once after every snapshot record has been
+// dispatched.
+func (r *RedisDB) Finalize() error {
+	var firstErr error
+	if err := closeJSONL(r.stringsTTL); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	if err := closeJSONL(r.hllTTL); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	if r.warn != nil && len(r.pendingWideColumnTTL) > 0 {
+		r.warn("redis_orphan_ttl",
+			"count", len(r.pendingWideColumnTTL),
+			"hint", "wide-column type encoders (hash/list/set/zset/stream) have not landed yet")
+	}
+	return firstErr
+}
+
+func (r *RedisDB) writeBlob(subdir string, userKey, value []byte) error {
+	encoded := EncodeSegment(userKey)
+	dir := filepath.Join(r.outRoot, "redis", "db_0", subdir)
+	if err := os.MkdirAll(dir, 0o755); err != nil { //nolint:mnd // 0755 == standard dir mode
+		return cockroachdberr.WithStack(err)
+	}
+	path := filepath.Join(dir, encoded+".bin")
+	if err := writeFileAtomic(path, value); err != nil {
+		return cockroachdberr.WithStack(err)
+	}
+	return nil
+}
+
+func (r *RedisDB) appendTTL(slot **jsonlFile, baseName string, userKey []byte, expireAtMs uint64) error {
+	if *slot == nil {
+		f, err := openJSONL(filepath.Join(r.outRoot, "redis", "db_0", baseName))
+		if err != nil {
+			return err
+		}
+		*slot = f
+	}
+	rec := struct {
+		Key        string `json:"key"`
+		ExpireAtMs uint64 `json:"expire_at_ms"`
+	}{
+		Key:        EncodeSegment(userKey),
+		ExpireAtMs: expireAtMs,
+	}
+	if err := (*slot).enc.Encode(rec); err != nil {
+		return cockroachdberr.WithStack(err)
+	}
+	return nil
+}
+
+// decodeRedisStringValue strips the redis-string magic-prefix TTL header
+// (if present) from a !redis|str| value and returns (userValue,
+// expireAtMs). expireAtMs == 0 means "no inline TTL"; legacy values
+// always return 0 here because their TTL lives in !redis|ttl|.
+func decodeRedisStringValue(value []byte) ([]byte, uint64, error) {
+	if !isNewRedisStrFormat(value) {
+		return value, 0, nil
+	}
+	if len(value) < redisStrBaseHeader {
+		return nil, 0, cockroachdberr.Wrap(ErrRedisInvalidStringValue, "header truncated")
+	}
+	flags := value[2]
+	rest := value[redisStrBaseHeader:]
+	if flags&redisStrHasTTL == 0 {
+		return rest, 0, nil
+	}
+	if len(rest) < redisUint64Bytes {
+		return nil, 0, cockroachdberr.Wrap(ErrRedisInvalidStringValue, "ttl section truncated")
+	}
+	rawMs := binary.BigEndian.Uint64(rest[:redisUint64Bytes])
+	expireAtMs := rawMs
+	if expireAtMs > math.MaxInt64 {
+		expireAtMs = math.MaxInt64 // mirror live decoder's clamp
+	}
+	return rest[redisUint64Bytes:], expireAtMs, nil
+}
+
+func isNewRedisStrFormat(raw []byte) bool {
+	return len(raw) >= 2 && //nolint:mnd // 2 == magic + version length
+		raw[0] == redisStrMagic && raw[1] == redisStrVersion
+}
+
+func decodeRedisTTLValue(raw []byte) (uint64, error) {
+	if len(raw) != redisUint64Bytes {
+		return 0, cockroachdberr.Wrapf(ErrRedisInvalidTTLValue,
+			"length %d != %d", len(raw), redisUint64Bytes)
+	}
+	v := binary.BigEndian.Uint64(raw)
+	if v > math.MaxInt64 {
+		v = math.MaxInt64
+	}
+	return v, nil
+}
+
+// jsonlFile bundles a file handle and its bufio writer so callers can
+// `f.enc.Encode(rec)` without re-creating the encoder per write.
+type jsonlFile struct {
+	f   *os.File
+	bw  *bufio.Writer
+	enc *json.Encoder
+}
+
+func openJSONL(path string) (*jsonlFile, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil { //nolint:mnd // 0755 == standard dir mode
+		return nil, cockroachdberr.WithStack(err)
+	}
+	f, err := os.Create(path) //nolint:gosec // path is composed from output-root + fixed file name
+	if err != nil {
+		return nil, cockroachdberr.WithStack(err)
+	}
+	bw := bufio.NewWriterSize(f, redisJSONLBufSize)
+	enc := json.NewEncoder(bw)
+	enc.SetEscapeHTML(false)
+	return &jsonlFile{f: f, bw: bw, enc: enc}, nil
+}
+
+func closeJSONL(jl *jsonlFile) error {
+	if jl == nil {
+		return nil
+	}
+	flushErr := jl.bw.Flush()
+	closeErr := jl.f.Close()
+	switch {
+	case flushErr != nil:
+		return cockroachdberr.WithStack(flushErr)
+	case closeErr != nil:
+		return cockroachdberr.WithStack(closeErr)
+	}
+	return nil
+}
+
+// writeFileAtomic writes data to path via a tmp+rename so a crash
+// mid-write never leaves a partial file. Symbolic links are not followed
+// (os.Create truncates a symlink target rather than the link itself; we
+// reject symlinks explicitly).
+func writeFileAtomic(path string, data []byte) error {
+	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return cockroachdberr.WithStack(cockroachdberr.Newf("backup: refusing to overwrite symlink at %s", path))
+	}
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".bin.tmp-*")
+	if err != nil {
+		return cockroachdberr.WithStack(err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		// Best-effort cleanup if Rename did not consume tmpPath.
+		if _, statErr := os.Stat(tmpPath); statErr == nil {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return cockroachdberr.WithStack(err)
+	}
+	if err := tmp.Close(); err != nil {
+		return cockroachdberr.WithStack(err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return cockroachdberr.WithStack(err)
+	}
+	return nil
+}
+
+// HasInlineTTL reports whether a !redis|str| value carries the new-format
+// inline TTL header. Useful for tests asserting the producer's choice.
+func HasInlineTTL(value []byte) bool {
+	if !isNewRedisStrFormat(value) || len(value) < redisStrBaseHeader {
+		return false
+	}
+	return value[2]&redisStrHasTTL != 0
+}
+
+// IsBlobAtomicWriteRetriable reports whether err from writeFileAtomic is
+// a retriable I/O failure (no-space, transient FS error). Today this is a
+// stub that returns false for any error; exposed so the master decoder
+// loop can decide whether to abort the whole dump on encountering one.
+func IsBlobAtomicWriteRetriable(err error) bool {
+	if err == nil {
+		return false
+	}
+	// errors.Is handles wrapped paths; both sentinel checks are stable
+	// for now because we never wrap them ourselves.
+	return errors.Is(err, io.ErrShortWrite)
+}

--- a/internal/backup/redis_string.go
+++ b/internal/backup/redis_string.go
@@ -370,14 +370,9 @@ func (r *RedisDB) recordIfFallback(encoded string, userKey []byte) error {
 		if err := r.ensureDir(dir); err != nil {
 			return err
 		}
-		const flag = os.O_WRONLY | os.O_CREATE | os.O_TRUNC | syscall.O_NOFOLLOW
-		f, err := os.OpenFile(filepath.Join(dir, "KEYMAP.jsonl"), flag, 0o600) //nolint:gosec,mnd // path is composed from output-root + fixed file name; 0600 is the standard owner-only mode
+		f, err := openSidecarFile(filepath.Join(dir, "KEYMAP.jsonl"))
 		if err != nil {
-			if errors.Is(err, syscall.ELOOP) {
-				return cockroachdberr.WithStack(cockroachdberr.Wrapf(err,
-					"backup: refusing to overwrite symlink at KEYMAP.jsonl"))
-			}
-			return cockroachdberr.WithStack(err)
+			return err
 		}
 		r.keymap = NewKeymapWriter(f)
 		r.keymapFile = f
@@ -461,27 +456,16 @@ func openJSONL(path string) (*jsonlFile, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil { //nolint:mnd // 0755 == standard dir mode
 		return nil, cockroachdberr.WithStack(err)
 	}
-	// Refuse to clobber a symlink at the sidecar path. The earlier
-	// Lstat-then-Create pattern was a TOCTOU race: a process that
-	// could write the output directory could swap the path to a
-	// symlink between the two syscalls and still get the target
-	// truncated (Codex P1 round 6, follow-up to round 5). Use
-	// O_NOFOLLOW so the open syscall itself refuses symlinks
-	// atomically — no race window exists. On platforms where the
-	// kernel supports it (Linux, macOS, BSD) this returns ELOOP for
-	// a symlink path. On Windows syscall.O_NOFOLLOW is 0 (no-op),
-	// matching Windows's different filesystem-permission model.
-	const flag = os.O_WRONLY | os.O_CREATE | os.O_TRUNC | syscall.O_NOFOLLOW
-	f, err := os.OpenFile(path, flag, 0o600) //nolint:gosec,mnd // path is composed from output-root + fixed file name; 0600 is the standard owner-only mode for sidecar files
+	// openSidecarFile encapsulates the per-platform symlink-refusal
+	// strategy: Linux/macOS/BSD use O_NOFOLLOW so the open syscall
+	// itself returns ELOOP atomically (no TOCTOU window); Windows
+	// uses Lstat-then-OpenFile, accepting the residual race because
+	// mounting a successful attack on the dump tree there already
+	// requires write access plus SeCreateSymbolicLinkPrivilege.
+	// Codex P1 round 6 (atomic open) + P2 round 7 (Windows build).
+	f, err := openSidecarFile(path)
 	if err != nil {
-		// errors.Is(err, syscall.ELOOP) catches symlink rejection
-		// on Linux/macOS/BSD; wrap rather than replace so the
-		// caller can still inspect the underlying syscall error.
-		if errors.Is(err, syscall.ELOOP) {
-			return nil, cockroachdberr.WithStack(cockroachdberr.Wrapf(err,
-				"backup: refusing to overwrite symlink at %s", path))
-		}
-		return nil, cockroachdberr.WithStack(err)
+		return nil, err
 	}
 	bw := bufio.NewWriterSize(f, redisJSONLBufSize)
 	enc := json.NewEncoder(bw)

--- a/internal/backup/redis_string_test.go
+++ b/internal/backup/redis_string_test.go
@@ -199,6 +199,37 @@ func TestRedisDB_NewFormatStringTTLNotDuplicatedByScanIndex(t *testing.T) {
 	assertTTLSidecar(t, filepath.Join(root, "redis", "db_0", "strings_ttl.jsonl"), "expiring", fixedExpireMs)
 }
 
+// TestRedisDB_OpenJSONLRefusesHardLinkClobber is the regression for
+// Codex P2 round 9: O_NOFOLLOW only blocks symlinks; an adversary
+// who can write the output directory could pre-create
+// strings_ttl.jsonl as a hard link to a file outside the dump tree
+// (e.g. /etc/passwd) and the open's O_TRUNC would clobber that
+// inode. openSidecarFile now opens WITHOUT O_TRUNC, fstat()s the
+// descriptor, refuses if Nlink > 1, and only calls Truncate(0) on
+// the verified-single-link case.
+func TestRedisDB_OpenJSONLRefusesHardLinkClobber(t *testing.T) {
+	t.Parallel()
+	db, root := newRedisDB(t)
+	dir := filepath.Join(root, "redis", "db_0")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bait := filepath.Join(root, "bait-hardlink")
+	if err := os.WriteFile(bait, []byte("stay-out"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(bait, filepath.Join(dir, redisStringsTTLFile)); err != nil {
+		t.Fatal(err)
+	}
+	err := db.HandleString([]byte("k"), encodeNewStringValue(t, []byte("v"), fixedExpireMs))
+	if err == nil || !strings.Contains(err.Error(), "refusing to overwrite hard-linked file") {
+		t.Fatalf("expected hard-link refusal error from openSidecarFile, got %v", err)
+	}
+	if got, _ := os.ReadFile(bait); string(got) != "stay-out" { //nolint:gosec // test path
+		t.Fatalf("bait file written through hard link: %q", got)
+	}
+}
+
 // TestRedisDB_OpenJSONLRefusesSymlinkOverwrite is the regression for Codex
 // P2 round 5 + P1 round 6: openJSONL must atomically refuse to follow
 // symlinks. The earlier Lstat-then-Create variant left a TOCTOU window

--- a/internal/backup/redis_string_test.go
+++ b/internal/backup/redis_string_test.go
@@ -1,0 +1,293 @@
+package backup
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+)
+
+// fixedExpireMs is a 2026-04-29 00:00:00Z epoch-ms used in fixtures so the
+// asserted values do not drift with wall time.
+const fixedExpireMs uint64 = 1788_998_400_000
+
+func newRedisDB(t *testing.T) (*RedisDB, string) {
+	t.Helper()
+	root := t.TempDir()
+	return NewRedisDB(root), root
+}
+
+func encodeNewStringValue(t *testing.T, value []byte, expireAtMs uint64) []byte {
+	t.Helper()
+	flags := byte(0)
+	header := []byte{redisStrMagic, redisStrVersion, flags}
+	body := value
+	if expireAtMs > 0 {
+		flags = redisStrHasTTL
+		header[2] = flags
+		var ttl [redisUint64Bytes]byte
+		binary.BigEndian.PutUint64(ttl[:], expireAtMs)
+		header = append(header, ttl[:]...)
+	}
+	return append(header, body...)
+}
+
+func encodeTTLValue(expireAtMs uint64) []byte {
+	var b [redisUint64Bytes]byte
+	binary.BigEndian.PutUint64(b[:], expireAtMs)
+	return b[:]
+}
+
+func readBlob(t *testing.T, path string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(path) //nolint:gosec // test path
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return b
+}
+
+type ttlRecord struct {
+	Key        string `json:"key"`
+	ExpireAtMs uint64 `json:"expire_at_ms"`
+}
+
+func readTTLJSONL(t *testing.T, path string) []ttlRecord {
+	t.Helper()
+	f, err := os.Open(path) //nolint:gosec // test path
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+	var out []ttlRecord
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var r ttlRecord
+		if err := json.Unmarshal(sc.Bytes(), &r); err != nil {
+			t.Fatalf("unmarshal %q: %v", sc.Text(), err)
+		}
+		out = append(out, r)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	return out
+}
+
+func TestRedisDB_HandleString_NewFormatNoTTL(t *testing.T) {
+	t.Parallel()
+	db, root := newRedisDB(t)
+	val := encodeNewStringValue(t, []byte("hello"), 0)
+	if err := db.HandleString([]byte("greeting"), val); err != nil {
+		t.Fatalf("HandleString: %v", err)
+	}
+	if err := db.Finalize(); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	body := readBlob(t, filepath.Join(root, "redis", "db_0", "strings", "greeting.bin"))
+	if string(body) != "hello" {
+		t.Fatalf("blob = %q want %q", body, "hello")
+	}
+	// No TTL → strings_ttl.jsonl must not exist (omit empty).
+	if _, err := os.Stat(filepath.Join(root, "redis", "db_0", "strings_ttl.jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("expected no strings_ttl.jsonl, stat err=%v", err)
+	}
+}
+
+func TestRedisDB_HandleString_NewFormatWithInlineTTL(t *testing.T) {
+	t.Parallel()
+	db, root := newRedisDB(t)
+	val := encodeNewStringValue(t, []byte("expiring"), fixedExpireMs)
+	if err := db.HandleString([]byte("session:abc"), val); err != nil {
+		t.Fatalf("HandleString: %v", err)
+	}
+	if err := db.Finalize(); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	body := readBlob(t, filepath.Join(root, "redis", "db_0", "strings", "session%3Aabc.bin"))
+	if string(body) != "expiring" {
+		t.Fatalf("blob = %q want %q", body, "expiring")
+	}
+	recs := readTTLJSONL(t, filepath.Join(root, "redis", "db_0", "strings_ttl.jsonl"))
+	if len(recs) != 1 {
+		t.Fatalf("ttl records = %d, want 1", len(recs))
+	}
+	if recs[0].Key != "session%3Aabc" {
+		t.Fatalf("ttl key = %q", recs[0].Key)
+	}
+	if recs[0].ExpireAtMs != fixedExpireMs {
+		t.Fatalf("ttl ms = %d want %d", recs[0].ExpireAtMs, fixedExpireMs)
+	}
+}
+
+func TestRedisDB_HandleString_LegacyFormatTreatedAsRawValue(t *testing.T) {
+	t.Parallel()
+	db, root := newRedisDB(t)
+	// Legacy (no magic prefix): bytes are the user value verbatim.
+	if err := db.HandleString([]byte("legacy"), []byte("\x00\xff\x01raw")); err != nil {
+		t.Fatalf("HandleString: %v", err)
+	}
+	if err := db.Finalize(); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	body := readBlob(t, filepath.Join(root, "redis", "db_0", "strings", "legacy.bin"))
+	if string(body) != "\x00\xff\x01raw" {
+		t.Fatalf("blob bytes = %x", body)
+	}
+}
+
+func TestRedisDB_HandleHLL_WritesRawSketch(t *testing.T) {
+	t.Parallel()
+	db, root := newRedisDB(t)
+	sketch := []byte{0xde, 0xad, 0xbe, 0xef}
+	if err := db.HandleHLL([]byte("uniques"), sketch); err != nil {
+		t.Fatalf("HandleHLL: %v", err)
+	}
+	if err := db.Finalize(); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	body := readBlob(t, filepath.Join(root, "redis", "db_0", "hll", "uniques.bin"))
+	if string(body) != string(sketch) {
+		t.Fatalf("hll blob = %x want %x", body, sketch)
+	}
+}
+
+func assertTTLSidecar(t *testing.T, path string, wantKey string, wantMs uint64) {
+	t.Helper()
+	recs := readTTLJSONL(t, path)
+	if len(recs) != 1 {
+		t.Fatalf("%s: %d records, want 1", path, len(recs))
+	}
+	if recs[0].Key != wantKey {
+		t.Fatalf("%s: key %q want %q", path, recs[0].Key, wantKey)
+	}
+	if recs[0].ExpireAtMs != wantMs {
+		t.Fatalf("%s: ms %d want %d", path, recs[0].ExpireAtMs, wantMs)
+	}
+}
+
+func TestRedisDB_HandleTTL_RoutesByPriorTypeObservation(t *testing.T) {
+	t.Parallel()
+	db, root := newRedisDB(t)
+	mustNoErr := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	// HLL key first, then string key, then TTL records (lex order in
+	// snapshot: hll < str < ttl).
+	mustNoErr(db.HandleHLL([]byte("hll-key"), []byte{0x01}))
+	mustNoErr(db.HandleString([]byte("legacy-str"), []byte("legacy-raw")))
+	mustNoErr(db.HandleTTL([]byte("hll-key"), encodeTTLValue(fixedExpireMs)))
+	mustNoErr(db.HandleTTL([]byte("legacy-str"), encodeTTLValue(fixedExpireMs+1)))
+	mustNoErr(db.Finalize())
+
+	assertTTLSidecar(t, filepath.Join(root, "redis", "db_0", "hll_ttl.jsonl"), "hll-key", fixedExpireMs)
+	assertTTLSidecar(t, filepath.Join(root, "redis", "db_0", "strings_ttl.jsonl"), "legacy-str", fixedExpireMs+1)
+}
+
+func TestRedisDB_HandleTTL_OrphanWarnsOnFinalize(t *testing.T) {
+	t.Parallel()
+	db, _ := newRedisDB(t)
+	var events []string
+	db.WithWarnSink(func(event string, fields ...any) {
+		events = append(events, event)
+	})
+	// TTL for a key never claimed by HandleString or HandleHLL — likely
+	// belongs to a wide-column type (hash/list/set/zset/stream) whose
+	// encoder has not landed yet. Must not crash.
+	if err := db.HandleTTL([]byte("orphan"), encodeTTLValue(fixedExpireMs)); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0] != "redis_orphan_ttl" {
+		t.Fatalf("events = %v want [redis_orphan_ttl]", events)
+	}
+}
+
+func TestRedisDB_RejectsTruncatedNewFormat(t *testing.T) {
+	t.Parallel()
+	cases := [][]byte{
+		{redisStrMagic, redisStrVersion},                                   // header truncated (missing flags)
+		{redisStrMagic, redisStrVersion, redisStrHasTTL, 0x00, 0x00, 0x00}, // ttl section truncated
+	}
+	for _, raw := range cases {
+		db, _ := newRedisDB(t)
+		err := db.HandleString([]byte("k"), raw)
+		if !errors.Is(err, ErrRedisInvalidStringValue) {
+			t.Fatalf("err=%v want ErrRedisInvalidStringValue (input %x)", err, raw)
+		}
+	}
+}
+
+func TestRedisDB_HandleTTL_RejectsBadLength(t *testing.T) {
+	t.Parallel()
+	db, _ := newRedisDB(t)
+	err := db.HandleTTL([]byte("k"), []byte{0x01, 0x02})
+	if !errors.Is(err, ErrRedisInvalidTTLValue) {
+		t.Fatalf("err=%v want ErrRedisInvalidTTLValue", err)
+	}
+}
+
+func TestRedisDB_FilenamesGoThroughEncodeSegment(t *testing.T) {
+	t.Parallel()
+	db, root := newRedisDB(t)
+	// User key with reserved bytes. Filename encoding must match the
+	// EncodeSegment contract (verified by filename_test.go).
+	if err := db.HandleString([]byte("a/b:c"), encodeNewStringValue(t, []byte("v"), 0)); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(root, "redis", "db_0", "strings", "a%2Fb%3Ac.bin")
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("expected file %s, stat err=%v", want, err)
+	}
+}
+
+func TestRedisDB_AtomicWriteRefusesSymlinkOverwrite(t *testing.T) {
+	t.Parallel()
+	db, root := newRedisDB(t)
+	dir := filepath.Join(root, "redis", "db_0", "strings")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(dir, "victim.bin")
+	bait := filepath.Join(root, "bait")
+	if err := os.WriteFile(bait, []byte("stay-out"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(bait, target); err != nil {
+		t.Fatal(err)
+	}
+	err := db.HandleString([]byte("victim"), encodeNewStringValue(t, []byte("attack"), 0))
+	if err == nil || !strings.Contains(err.Error(), "refusing to overwrite symlink") {
+		t.Fatalf("expected symlink-refusal error, got %v", err)
+	}
+	// Bait file must be untouched.
+	if got, _ := os.ReadFile(bait); string(got) != "stay-out" { //nolint:gosec // test path
+		t.Fatalf("bait file written through symlink: %q", got)
+	}
+}
+
+func TestRedisDB_HasInlineTTL(t *testing.T) {
+	t.Parallel()
+	if !HasInlineTTL(encodeNewStringValue(t, []byte("v"), fixedExpireMs)) {
+		t.Fatalf("HasInlineTTL = false on inline-TTL value")
+	}
+	if HasInlineTTL(encodeNewStringValue(t, []byte("v"), 0)) {
+		t.Fatalf("HasInlineTTL = true on no-TTL value")
+	}
+	if HasInlineTTL([]byte("legacy-raw")) {
+		t.Fatalf("HasInlineTTL = true on legacy value")
+	}
+}

--- a/internal/backup/redis_string_test.go
+++ b/internal/backup/redis_string_test.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"io"
@@ -363,6 +364,74 @@ func TestRedisDB_PerDBIndexRoutesIntoOwnDirectory(t *testing.T) {
 	}
 	if got := readBlob(t, filepath.Join(root, "redis", "db_3", "strings", "k.bin")); string(got) != "v3" {
 		t.Fatalf("db_3 blob = %q want %q", got, "v3")
+	}
+}
+
+// TestRedisDB_SHAFallbackKeymapped is the regression for Codex P1
+// round 7: when a Redis user key is long enough that EncodeSegment
+// takes its SHA-fallback path, the encoder must record a KEYMAP.jsonl
+// entry for it. Otherwise the encoded `*.bin` filename and the JSONL
+// TTL row's `key` are non-reversible and the original Redis user key
+// bytes are irrecoverable from a backup.
+func TestRedisDB_SHAFallbackKeymapped(t *testing.T) {
+	t.Parallel()
+	db, root := newRedisDB(t)
+	// Drive a key whose length forces the fallback. EncodeSegment's
+	// length cap is 240 bytes; pad past it with characters that
+	// would percent-encode to 3× their length so we cannot
+	// accidentally fit even with all-unreserved bytes.
+	longKey := bytes.Repeat([]byte{'%'}, 300)
+	encoded := EncodeSegment(longKey)
+	if !IsShaFallback(encoded) {
+		t.Fatalf("test premise broken: encoded %q is not a SHA fallback", encoded)
+	}
+	if err := db.HandleString(longKey, encodeNewStringValue(t, []byte("v"), fixedExpireMs)); err != nil {
+		t.Fatalf("HandleString: %v", err)
+	}
+	if err := db.Finalize(); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	keymapPath := filepath.Join(root, "redis", "db_0", "KEYMAP.jsonl")
+	f, err := os.Open(keymapPath) //nolint:gosec // test-controlled path
+	if err != nil {
+		t.Fatalf("KEYMAP.jsonl missing for SHA-fallback key: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	got, err := LoadKeymap(f)
+	if err != nil {
+		t.Fatalf("LoadKeymap: %v", err)
+	}
+	rec, ok := got[encoded]
+	if !ok {
+		t.Fatalf("no keymap record for encoded %q; have %v", encoded, got)
+	}
+	if rec.Kind != KindSHAFallback {
+		t.Fatalf("kind = %q, want %q", rec.Kind, KindSHAFallback)
+	}
+	orig, err := rec.Original()
+	if err != nil {
+		t.Fatalf("Original: %v", err)
+	}
+	if !bytes.Equal(orig, longKey) {
+		t.Fatalf("Original mismatch: len got=%d want=%d", len(orig), len(longKey))
+	}
+}
+
+// TestRedisDB_NoKeymapWhenAllReversible asserts the converse: a dump
+// with only short keys produces no KEYMAP.jsonl. The empty-file
+// removal in closeKeymap matches the s3 encoder's policy.
+func TestRedisDB_NoKeymapWhenAllReversible(t *testing.T) {
+	t.Parallel()
+	db, root := newRedisDB(t)
+	if err := db.HandleString([]byte("short"), encodeNewStringValue(t, []byte("v"), 0)); err != nil {
+		t.Fatalf("HandleString: %v", err)
+	}
+	if err := db.Finalize(); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	keymapPath := filepath.Join(root, "redis", "db_0", "KEYMAP.jsonl")
+	if _, err := os.Stat(keymapPath); !os.IsNotExist(err) {
+		t.Fatalf("KEYMAP.jsonl present without any fallback keys: stat err=%v", err)
 	}
 }
 

--- a/internal/backup/redis_string_test.go
+++ b/internal/backup/redis_string_test.go
@@ -4,9 +4,11 @@ import (
 	"bufio"
 	"encoding/binary"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/cockroachdb/errors"
@@ -19,7 +21,7 @@ const fixedExpireMs uint64 = 1788_998_400_000
 func newRedisDB(t *testing.T) (*RedisDB, string) {
 	t.Helper()
 	root := t.TempDir()
-	return NewRedisDB(root), root
+	return NewRedisDB(root, 0), root
 }
 
 func encodeNewStringValue(t *testing.T, value []byte, expireAtMs uint64) []byte {
@@ -277,6 +279,109 @@ func TestRedisDB_AtomicWriteRefusesSymlinkOverwrite(t *testing.T) {
 	if got, _ := os.ReadFile(bait); string(got) != "stay-out" { //nolint:gosec // test path
 		t.Fatalf("bait file written through symlink: %q", got)
 	}
+}
+
+func TestRedisDB_PerDBIndexRoutesIntoOwnDirectory(t *testing.T) {
+	t.Parallel()
+	// Two encoders with the same outRoot but different db indices
+	// must not collide. The previous hardcoded "db_0" path would
+	// have routed both to the same blob file.
+	root := t.TempDir()
+	db0 := NewRedisDB(root, 0)
+	db3 := NewRedisDB(root, 3)
+	if err := db0.HandleString([]byte("k"), encodeNewStringValue(t, []byte("v0"), 0)); err != nil {
+		t.Fatal(err)
+	}
+	if err := db3.HandleString([]byte("k"), encodeNewStringValue(t, []byte("v3"), 0)); err != nil {
+		t.Fatal(err)
+	}
+	if err := db0.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+	if err := db3.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+	if got := readBlob(t, filepath.Join(root, "redis", "db_0", "strings", "k.bin")); string(got) != "v0" {
+		t.Fatalf("db_0 blob = %q want %q", got, "v0")
+	}
+	if got := readBlob(t, filepath.Join(root, "redis", "db_3", "strings", "k.bin")); string(got) != "v3" {
+		t.Fatalf("db_3 blob = %q want %q", got, "v3")
+	}
+}
+
+func TestRedisDB_PendingWideColumnTTLBounded(t *testing.T) {
+	t.Parallel()
+	// Stub the cap small enough to exercise it without burning seconds
+	// on the test. We can't override the package constant; instead
+	// drive the RedisDB to the public bound and assert we don't crash
+	// or grow without limit. The cap is 1M; the test verifies a few
+	// past it are dropped silently (no error, no crash) and the
+	// observed slice length matches the cap.
+	if maxPendingWideColumnTTL > 1_000_000 {
+		t.Skipf("cap too high for this fast test: %d", maxPendingWideColumnTTL)
+	}
+	db, _ := newRedisDB(t)
+	// Drive a small sample (10000) of orphan TTL records through
+	// HandleTTL — well under the cap — and confirm they all land.
+	for i := 0; i < 10_000; i++ {
+		key := []byte("orphan-" + intToDecimal(i))
+		ms := uint64(i) + 1 //nolint:gosec // i bounded to 10_000, never negative
+		if err := db.HandleTTL(key, encodeTTLValue(ms)); err != nil {
+			t.Fatalf("HandleTTL[%d]: %v", i, err)
+		}
+	}
+	if len(db.pendingWideColumnTTL) != 10_000 {
+		t.Fatalf("pending len = %d", len(db.pendingWideColumnTTL))
+	}
+	// The bound itself is asserted in package-level review notes; a
+	// 1M-record stress test in CI would be wasteful for a constant
+	// the linter and the implementation already guarantee.
+}
+
+func TestRedisDB_DirsCreatedCachesMkdirAll(t *testing.T) {
+	t.Parallel()
+	// Two HandleString calls in a row should populate dirsCreated
+	// once for the strings/ subdir and skip MkdirAll on the second
+	// call. Black-box: assert the dirsCreated map contains the
+	// strings/ entry exactly once after two writes.
+	db, _ := newRedisDB(t)
+	if err := db.HandleString([]byte("a"), encodeNewStringValue(t, []byte("v"), 0)); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.HandleString([]byte("b"), encodeNewStringValue(t, []byte("v"), 0)); err != nil {
+		t.Fatal(err)
+	}
+	wantSubstr := filepath.Join("redis", "db_0", "strings")
+	count := 0
+	for k := range db.dirsCreated {
+		if strings.Contains(k, wantSubstr) {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("strings/ dir entries = %d want 1; map=%v", count, db.dirsCreated)
+	}
+}
+
+func TestRedisDB_IsBlobAtomicWriteOutOfSpace(t *testing.T) {
+	t.Parallel()
+	if !IsBlobAtomicWriteOutOfSpace(syscall.ENOSPC) {
+		t.Fatalf("ENOSPC must be reported as out-of-space")
+	}
+	if !IsBlobAtomicWriteOutOfSpace(cockroachdbErrorsWrap(syscall.ENOSPC)) {
+		t.Fatalf("wrapped ENOSPC must round-trip via errors.Is")
+	}
+	if IsBlobAtomicWriteOutOfSpace(io.ErrShortWrite) {
+		t.Fatalf("ErrShortWrite must NOT be reported as out-of-space")
+	}
+	// Conversely IsBlobAtomicWriteRetriable must NOT report ENOSPC.
+	if IsBlobAtomicWriteRetriable(syscall.ENOSPC) {
+		t.Fatalf("ENOSPC must NOT be retriable")
+	}
+}
+
+func cockroachdbErrorsWrap(err error) error {
+	return errors.Join(errors.New("wrapped"), err)
 }
 
 func TestRedisDB_HasInlineTTL(t *testing.T) {

--- a/internal/backup/redis_string_test.go
+++ b/internal/backup/redis_string_test.go
@@ -199,6 +199,43 @@ func TestRedisDB_NewFormatStringTTLNotDuplicatedByScanIndex(t *testing.T) {
 	assertTTLSidecar(t, filepath.Join(root, "redis", "db_0", "strings_ttl.jsonl"), "expiring", fixedExpireMs)
 }
 
+// TestRedisDB_RefusesSymlinkedAncestorOnTTLSidecar is the regression
+// for Codex P1 round 13 (PR #713): writeBlob already routed through
+// ensureDir/assertNoSymlinkAncestors, but TTL sidecars (appendTTL ->
+// openJSONL) bypassed that guard because openJSONL only protected
+// the final path element via openSidecarFile. A symlinked ancestor
+// like `<outRoot>/redis/db_0 -> /tmp/outside` would then redirect
+// strings_ttl.jsonl writes outside the dump root. appendTTL now
+// calls ensureDir on the parent directory before opening the
+// sidecar.
+func TestRedisDB_RefusesSymlinkedAncestorOnTTLSidecar(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	bait := filepath.Join(root, "bait-tree")
+	if err := os.MkdirAll(bait, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	parent := filepath.Join(root, "redis")
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Symlink `<outRoot>/redis/db_0` to a directory outside the
+	// dump root. Without the ancestor guard, the first appendTTL
+	// would happily write strings_ttl.jsonl into <bait>/.
+	if err := os.Symlink(bait, filepath.Join(parent, "db_0")); err != nil {
+		t.Fatal(err)
+	}
+	db := NewRedisDB(root, 0)
+	// HandleString with a TTL-bearing value drives appendTTL.
+	err := db.HandleString([]byte("k"), encodeNewStringValue(t, []byte("v"), fixedExpireMs))
+	if err == nil || !strings.Contains(err.Error(), "refusing to traverse symlinked ancestor") {
+		t.Fatalf("expected symlinked-ancestor refusal, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(bait, "strings_ttl.jsonl")); !os.IsNotExist(statErr) {
+		t.Fatalf("TTL sidecar written through ancestor symlink: stat err=%v", statErr)
+	}
+}
+
 // TestRedisDB_RefusesSymlinkedAncestor is the regression for Codex P1
 // round 9: O_NOFOLLOW only blocks the final-component symlink. A
 // pre-existing directory symlink anywhere up the path (e.g.

--- a/internal/backup/redis_string_test.go
+++ b/internal/backup/redis_string_test.go
@@ -199,6 +199,45 @@ func TestRedisDB_NewFormatStringTTLNotDuplicatedByScanIndex(t *testing.T) {
 	assertTTLSidecar(t, filepath.Join(root, "redis", "db_0", "strings_ttl.jsonl"), "expiring", fixedExpireMs)
 }
 
+// TestRedisDB_EnsureDirRevalidatesAfterCachedSuccess is the regression
+// for Codex P1 round 13 follow-up (PR #713 review #11): ensureDir's
+// dirsCreated cache used to skip assertNoSymlinkAncestors on cache
+// hits, so a directory that was safe on the first write could be
+// swapped to a symlink between writes and subsequent HandleString
+// calls would silently traverse it, redirecting blobs outside
+// outRoot. The cache now short-circuits only MkdirAll; the ancestor
+// check runs on every call.
+func TestRedisDB_EnsureDirRevalidatesAfterCachedSuccess(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	bait := filepath.Join(root, "bait-tree")
+	if err := os.MkdirAll(bait, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	db := NewRedisDB(root, 0)
+	// First write seeds dirsCreated for <root>/redis/db_0/strings.
+	if err := db.HandleString([]byte("k1"), encodeNewStringValue(t, []byte("v1"), 0)); err != nil {
+		t.Fatalf("first HandleString: %v", err)
+	}
+	// Adversary swaps the cached real dir for a symlink to outside
+	// outRoot. Without re-validation, the next write would follow
+	// it and land in <bait>/.
+	stringsDir := filepath.Join(root, "redis", "db_0", "strings")
+	if err := os.RemoveAll(stringsDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(bait, stringsDir); err != nil {
+		t.Fatal(err)
+	}
+	err := db.HandleString([]byte("k2"), encodeNewStringValue(t, []byte("v2"), 0))
+	if err == nil || !strings.Contains(err.Error(), "refusing to traverse symlinked ancestor") {
+		t.Fatalf("expected post-cache symlink refusal, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(bait, "k2.bin")); !os.IsNotExist(statErr) {
+		t.Fatalf("blob written through swapped-in symlink: stat err=%v", statErr)
+	}
+}
+
 // TestRedisDB_RefusesSymlinkedAncestorOnTTLSidecar is the regression
 // for Codex P1 round 13 (PR #713): writeBlob already routed through
 // ensureDir/assertNoSymlinkAncestors, but TTL sidecars (appendTTL ->

--- a/internal/backup/redis_string_test.go
+++ b/internal/backup/redis_string_test.go
@@ -199,6 +199,41 @@ func TestRedisDB_NewFormatStringTTLNotDuplicatedByScanIndex(t *testing.T) {
 	assertTTLSidecar(t, filepath.Join(root, "redis", "db_0", "strings_ttl.jsonl"), "expiring", fixedExpireMs)
 }
 
+// TestRedisDB_RefusesSymlinkedAncestor is the regression for Codex P1
+// round 9: O_NOFOLLOW only blocks the final-component symlink. A
+// pre-existing directory symlink anywhere up the path (e.g.
+// `<outRoot>/redis/db_0/strings -> /tmp/outside`) lets MkdirAll
+// silently honor it and steers writeFileAtomic / openSidecarFile
+// outside outRoot. ensureDir now Lstat-walks each ancestor under
+// outRoot and refuses if any is a symlink.
+func TestRedisDB_RefusesSymlinkedAncestor(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	// Pre-place the symlink trap before constructing the encoder so
+	// the directory tree contains a poisoned ancestor at
+	// <root>/redis/db_0/strings.
+	bait := filepath.Join(root, "bait-tree")
+	if err := os.MkdirAll(bait, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	parent := filepath.Join(root, "redis", "db_0")
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(bait, filepath.Join(parent, "strings")); err != nil {
+		t.Fatal(err)
+	}
+	db := NewRedisDB(root, 0)
+	err := db.HandleString([]byte("k"), encodeNewStringValue(t, []byte("v"), 0))
+	if err == nil || !strings.Contains(err.Error(), "refusing to traverse symlinked ancestor") {
+		t.Fatalf("expected symlinked-ancestor refusal, got %v", err)
+	}
+	// The symlink target must be untouched: no `k.bin` written.
+	if _, statErr := os.Stat(filepath.Join(bait, "k.bin")); !os.IsNotExist(statErr) {
+		t.Fatalf("blob written through ancestor symlink: stat err=%v", statErr)
+	}
+}
+
 // TestRedisDB_OpenJSONLRefusesHardLinkClobber is the regression for
 // Codex P2 round 9: O_NOFOLLOW only blocks symlinks; an adversary
 // who can write the output directory could pre-create

--- a/internal/backup/redis_string_test.go
+++ b/internal/backup/redis_string_test.go
@@ -199,10 +199,11 @@ func TestRedisDB_NewFormatStringTTLNotDuplicatedByScanIndex(t *testing.T) {
 }
 
 // TestRedisDB_OpenJSONLRefusesSymlinkOverwrite is the regression for Codex
-// P2 round 5: openJSONL must mirror writeFileAtomic's symlink defence —
-// a `strings_ttl.jsonl` (or `hll_ttl.jsonl`) symlink in the output tree
-// would otherwise be followed by os.Create and the target outside the
-// dump tree truncated.
+// P2 round 5 + P1 round 6: openJSONL must atomically refuse to follow
+// symlinks. The earlier Lstat-then-Create variant left a TOCTOU window
+// where a process that could write the output directory could swap the
+// path to a symlink between the two syscalls; the round-6 fix uses
+// O_NOFOLLOW on the open itself so the kernel returns ELOOP atomically.
 func TestRedisDB_OpenJSONLRefusesSymlinkOverwrite(t *testing.T) {
 	t.Parallel()
 	db, root := newRedisDB(t)
@@ -365,33 +366,25 @@ func TestRedisDB_PerDBIndexRoutesIntoOwnDirectory(t *testing.T) {
 	}
 }
 
-func TestRedisDB_PendingWideColumnTTLBounded(t *testing.T) {
+func TestRedisDB_OrphanTTLCountedNotBuffered(t *testing.T) {
 	t.Parallel()
-	// Stub the cap small enough to exercise it without burning seconds
-	// on the test. We can't override the package constant; instead
-	// drive the RedisDB to the public bound and assert we don't crash
-	// or grow without limit. The cap is 1M; the test verifies a few
-	// past it are dropped silently (no error, no crash) and the
-	// observed slice length matches the cap.
-	if maxPendingWideColumnTTL > 1_000_000 {
-		t.Skipf("cap too high for this fast test: %d", maxPendingWideColumnTTL)
-	}
+	// Codex P2 round 6: orphan TTL records (those with no prior
+	// HandleString/HandleHLL claim) must be counted only — the
+	// per-key payload would allocate proportional to user-key size
+	// and is unused before the wide-column encoders land. Drive a
+	// sample of orphan records and assert the count, not a buffer.
 	db, _ := newRedisDB(t)
-	// Drive a small sample (10000) of orphan TTL records through
-	// HandleTTL — well under the cap — and confirm they all land.
-	for i := 0; i < 10_000; i++ {
+	const n = 10_000
+	for i := 0; i < n; i++ {
 		key := []byte("orphan-" + intToDecimal(i))
-		ms := uint64(i) + 1 //nolint:gosec // i bounded to 10_000, never negative
+		ms := uint64(i) + 1 //nolint:gosec // i bounded to n, never negative
 		if err := db.HandleTTL(key, encodeTTLValue(ms)); err != nil {
 			t.Fatalf("HandleTTL[%d]: %v", i, err)
 		}
 	}
-	if len(db.pendingWideColumnTTL) != 10_000 {
-		t.Fatalf("pending len = %d", len(db.pendingWideColumnTTL))
+	if db.orphanTTLCount != n {
+		t.Fatalf("orphanTTLCount = %d, want %d", db.orphanTTLCount, n)
 	}
-	// The bound itself is asserted in package-level review notes; a
-	// 1M-record stress test in CI would be wasteful for a constant
-	// the linter and the implementation already guarantee.
 }
 
 func TestRedisDB_DirsCreatedCachesMkdirAll(t *testing.T) {

--- a/internal/backup/redis_string_test.go
+++ b/internal/backup/redis_string_test.go
@@ -173,6 +173,62 @@ func assertTTLSidecar(t *testing.T, path string, wantKey string, wantMs uint64) 
 	}
 }
 
+// TestRedisDB_NewFormatStringTTLNotDuplicatedByScanIndex is the regression
+// for Codex P1 round 5: the live Redis encoder emits both `!redis|str|<k>`
+// (with TTL embedded inline in the magic-prefix header) and the scan-index
+// `!redis|ttl|<k>` for every expiring string. The backup decoder must
+// recognise that HandleString already wrote the strings_ttl.jsonl record
+// and drop the redundant !redis|ttl| record. Otherwise the same expiring
+// string is duplicated in the sidecar, breaking the one-record-per-key
+// contract.
+func TestRedisDB_NewFormatStringTTLNotDuplicatedByScanIndex(t *testing.T) {
+	t.Parallel()
+	db, root := newRedisDB(t)
+	mustNoErr := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Snapshot lex order: !redis|str|<k> comes before !redis|ttl|<k>
+	// (because 's' < 't'). Mirror that sequence here.
+	mustNoErr(db.HandleString([]byte("expiring"), encodeNewStringValue(t, []byte("v"), fixedExpireMs)))
+	mustNoErr(db.HandleTTL([]byte("expiring"), encodeTTLValue(fixedExpireMs)))
+	mustNoErr(db.Finalize())
+	assertTTLSidecar(t, filepath.Join(root, "redis", "db_0", "strings_ttl.jsonl"), "expiring", fixedExpireMs)
+}
+
+// TestRedisDB_OpenJSONLRefusesSymlinkOverwrite is the regression for Codex
+// P2 round 5: openJSONL must mirror writeFileAtomic's symlink defence —
+// a `strings_ttl.jsonl` (or `hll_ttl.jsonl`) symlink in the output tree
+// would otherwise be followed by os.Create and the target outside the
+// dump tree truncated.
+func TestRedisDB_OpenJSONLRefusesSymlinkOverwrite(t *testing.T) {
+	t.Parallel()
+	db, root := newRedisDB(t)
+	dir := filepath.Join(root, "redis", "db_0")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bait := filepath.Join(root, "bait-jsonl")
+	if err := os.WriteFile(bait, []byte("stay-out"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(bait, filepath.Join(dir, redisStringsTTLFile)); err != nil {
+		t.Fatal(err)
+	}
+	// HandleString with TTL triggers the first openJSONL on
+	// strings_ttl.jsonl, which must refuse the symlink rather than
+	// truncate the bait target.
+	err := db.HandleString([]byte("k"), encodeNewStringValue(t, []byte("v"), fixedExpireMs))
+	if err == nil || !strings.Contains(err.Error(), "refusing to overwrite symlink") {
+		t.Fatalf("expected symlink-refusal error from openJSONL, got %v", err)
+	}
+	if got, _ := os.ReadFile(bait); string(got) != "stay-out" { //nolint:gosec // test path
+		t.Fatalf("bait file written through symlink: %q", got)
+	}
+}
+
 func TestRedisDB_HandleTTL_RoutesByPriorTypeObservation(t *testing.T) {
 	t.Parallel()
 	db, root := newRedisDB(t)

--- a/internal/backup/redis_string_unix_test.go
+++ b/internal/backup/redis_string_unix_test.go
@@ -1,0 +1,48 @@
+//go:build unix
+
+package backup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// TestRedisDB_OpenJSONLRefusesFIFO is the regression for Codex P2
+// round 11: a pre-existing FIFO at strings_ttl.jsonl / hll_ttl.jsonl
+// would block the first TTL write indefinitely (POSIX: opening a
+// reader-less FIFO with O_WRONLY blocks until a reader attaches).
+// O_NONBLOCK turns that into an immediate ENXIO; the post-open
+// Stat() check then refuses any non-regular file (FIFO with reader,
+// socket, device). The symlink and hard-link guards alone do not
+// catch this — mkfifo produces nlink=1 and is not a symlink.
+//
+// Lives in a unix-only test file because syscall.Mkfifo is undefined
+// on Windows and js/wasm.
+func TestRedisDB_OpenJSONLRefusesFIFO(t *testing.T) {
+	t.Parallel()
+	db, root := newRedisDB(t)
+	dir := filepath.Join(root, "redis", "db_0")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fifoPath := filepath.Join(dir, redisStringsTTLFile)
+	if err := syscall.Mkfifo(fifoPath, 0o600); err != nil {
+		t.Skipf("mkfifo not supported on this platform: %v", err)
+	}
+	err := db.HandleString([]byte("k"), encodeNewStringValue(t, []byte("v"), fixedExpireMs))
+	if err == nil {
+		t.Fatalf("expected refusal of FIFO sidecar, got nil")
+	}
+	// Either ENXIO ("FIFO at <path>") on platforms that surface it
+	// at open, or "non-regular file" if a (rare) reader is around
+	// to make the open succeed. Both are acceptable as long as the
+	// open does not hang and the encoder refuses to truncate the
+	// pipe target.
+	msg := err.Error()
+	if !strings.Contains(msg, "FIFO at") && !strings.Contains(msg, "non-regular file") {
+		t.Fatalf("expected FIFO refusal message, got %v", err)
+	}
+}

--- a/internal/backup/redis_string_unix_test.go
+++ b/internal/backup/redis_string_unix_test.go
@@ -6,8 +6,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 // TestRedisDB_OpenJSONLRefusesFIFO is the regression for Codex P2
@@ -19,8 +20,13 @@ import (
 // socket, device). The symlink and hard-link guards alone do not
 // catch this — mkfifo produces nlink=1 and is not a symlink.
 //
-// Lives in a unix-only test file because syscall.Mkfifo is undefined
-// on Windows and js/wasm.
+// Lives in a unix-only test file because POSIX mkfifo is not
+// defined on Windows or js/wasm. We use golang.org/x/sys/unix.Mkfifo
+// rather than syscall.Mkfifo because the standard library's syscall
+// package does not define Mkfifo on every `unix`-tagged target
+// (notably Solaris); the x/sys/unix wrapper is consistent across
+// every platform the `unix` build tag covers. Codex P2 round 14
+// (PR #713 #12) caught the Solaris cross-compile failure.
 func TestRedisDB_OpenJSONLRefusesFIFO(t *testing.T) {
 	t.Parallel()
 	db, root := newRedisDB(t)
@@ -29,7 +35,7 @@ func TestRedisDB_OpenJSONLRefusesFIFO(t *testing.T) {
 		t.Fatal(err)
 	}
 	fifoPath := filepath.Join(dir, redisStringsTTLFile)
-	if err := syscall.Mkfifo(fifoPath, 0o600); err != nil {
+	if err := unix.Mkfifo(fifoPath, 0o600); err != nil {
 		t.Skipf("mkfifo not supported on this platform: %v", err)
 	}
 	err := db.HandleString([]byte("k"), encodeNewStringValue(t, []byte("v"), fixedExpireMs))


### PR DESCRIPTION
## Summary

Stacked on top of #712. Adds the first per-adapter encoder of the Phase 0 logical-backup decoder — covers the three Redis prefixes that always map ONE snapshot record to one user key:

- `!redis|str|<userKey>` → `strings/<encoded>.bin` (+ inline-TTL stripped into `strings_ttl.jsonl`). Both new magic-prefix format and legacy raw bytes accepted.
- `!redis|hll|<userKey>` → `hll/<encoded>.bin` (raw HLL sketch).
- `!redis|ttl|<userKey>` → routed by prior type observation:
  - `redisKindString` → `strings_ttl.jsonl` (legacy strings)
  - `redisKindHLL` → `hll_ttl.jsonl`
  - `redisKindUnknown` → buffered for wide-column types; orphan warning at `Finalize`.

Wide-column types (hash / list / set / zset / stream) ship in follow-up PRs.

## How TTL routing works

Pebble lex order guarantees `!redis|hll|*` < `!redis|str|*` < `!redis|ttl|*` (h < s < t). So when `HandleTTL` is called, the type tracker already knows what kind of key the user-key belongs to. No two-pass needed.

## Safety

- Filenames go through `EncodeSegment` (the encoding contract from #711).
- Blob writes are atomic (tmp + rename); `writeFileAtomic` refuses to overwrite a symlink so a malicious or accidental link cannot redirect output bytes.
- Truncated magic-prefix headers and bad-length TTL records surface typed errors (`ErrRedisInvalidStringValue`, `ErrRedisInvalidTTLValue`) rather than silent data loss.
- The package keeps the `0xFF 0x01` magic constants local (not imported from `adapter/redis_compat_types.go`) because the decoder is intentionally adapter-independent — must run as an offline tool with no live cluster. A doc comment points back to the live source so a future renamer updates both.

## Test plan

- [x] `go test -race ./internal/backup/...` — pass.
- [x] `golangci-lint run ./internal/backup/...` — clean.
- [x] 11 tests covering new/legacy/inline-TTL strings, HLL raw round-trip, TTL routing for both kinds, orphan-TTL warning, truncated header/TTL rejection, EncodeSegment integration, symlink-overwrite refusal, `HasInlineTTL` helper.

## Stacking

Base: `feat/backup-phase0a-keymap-manifest` (PR #712).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-Redis-database output routing so backups are written into per-DB locations.
  * TTL handling improved: inline TTL deduplication and orphan TTL counting reported at finalize.

* **Bug Fixes**
  * Stronger protections when creating sidecar files: refuses symlinks, hardlink clobbering, and non-regular files (e.g., FIFOs).
  * More reliable disk-full detection across platforms.

* **Tests**
  * Added extensive regression tests covering safety, routing, TTL, and out-of-space scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->