### PR TITLE
backup: SQS encoder for queue meta and messages.jsonl (Phase 0a)

### DIFF
--- a/internal/backup/sqs.go
+++ b/internal/backup/sqs.go
@@ -281,23 +281,28 @@ func (s *SQSEncoder) flushQueue(st *sqsQueueState) error {
 	if err := writeFileAtomic(filepath.Join(dir, "_queue.json"), mustMarshalIndent(st.meta)); err != nil {
 		return err
 	}
-	if len(st.messages) == 0 {
-		return nil
-	}
-	sortMessagesForEmit(st.messages)
-	jl, err := openJSONL(filepath.Join(dir, "messages.jsonl"))
-	if err != nil {
-		return err
-	}
-	for i := range st.messages {
-		if err := jl.enc.Encode(st.messages[i]); err != nil {
-			_ = closeJSONL(jl)
-			return errors.WithStack(err)
+	if len(st.messages) > 0 {
+		sortMessagesForEmit(st.messages)
+		jl, err := openJSONL(filepath.Join(dir, "messages.jsonl"))
+		if err != nil {
+			return err
+		}
+		for i := range st.messages {
+			if err := jl.enc.Encode(st.messages[i]); err != nil {
+				_ = closeJSONL(jl)
+				return errors.WithStack(err)
+			}
+		}
+		if err := closeJSONL(jl); err != nil {
+			return err
 		}
 	}
-	if err := closeJSONL(jl); err != nil {
-		return err
-	}
+	// Side records ("--include-sqs-side-records") flush regardless of
+	// whether the queue has any current messages. A purged or
+	// metadata-only queue can legitimately have side records (e.g.,
+	// dedup window history, vis/byage entries from in-flight reaper
+	// state) and dropping them when messages == 0 silently weakens
+	// the --include-sqs-side-records contract — flagged as Codex P2.
 	if len(st.internalBuf) > 0 {
 		if err := s.flushInternals(dir, st.internalBuf); err != nil {
 			return err
@@ -366,9 +371,13 @@ func parseSQSMessageDataKey(key []byte) (string, error) {
 		return "", err
 	}
 	idx := scanBase64URLBoundary(rest)
-	if idx == 0 || idx+genBytes > len(rest) {
+	// idx == 0 -> no queue segment; idx+genBytes >= len(rest) -> no
+	// room for any msg-id segment after the gen. Both are malformed.
+	// AWS SQS message IDs are non-empty by construction, so an empty
+	// msg-id segment can never be a legitimate snapshot record.
+	if idx == 0 || idx+genBytes >= len(rest) {
 		return "", errors.Wrapf(ErrSQSMalformedKey,
-			"queue segment boundary not found in %q", key)
+			"queue segment or message-id segment not found in %q", key)
 	}
 	encQueue := rest[:idx]
 	if _, err := base64.RawURLEncoding.DecodeString(encQueue); err != nil {
@@ -395,7 +404,12 @@ func parseSQSGenericKey(key []byte, prefix string) (string, error) {
 		return "", err
 	}
 	idx := scanBase64URLBoundary(rest)
-	if idx == 0 {
+	// All side-record key shapes (vis / byage / dedup / group /
+	// tombstone) terminate the encoded queue segment with at least
+	// one binary trailer (the gen u64), so idx must be strictly less
+	// than len(rest). idx == len(rest) means the trailer is missing —
+	// either a truncated key or the wrong prefix.
+	if idx == 0 || idx == len(rest) {
 		return "", errors.Wrapf(ErrSQSMalformedKey,
 			"queue segment not found after prefix %q", prefix)
 	}

--- a/internal/backup/sqs.go
+++ b/internal/backup/sqs.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/cockroachdb/errors"
 )
@@ -136,6 +137,37 @@ type sqsQueueMetaPublic struct {
 	RedrivePolicy             string `json:"redrive_policy,omitempty"`
 }
 
+// sqsMessageBody is the dump-format projection's body field. It marshals
+// as a JSON string when the bytes are valid UTF-8 (the AWS SQS contract
+// — body is XML-text), so restorers can pipe each `body` straight into
+// SendMessage. For non-UTF-8 bytes the encoder falls back to a
+// `{"base64":"..."}` envelope so binary payloads still round-trip
+// without lossy replacement-character rewrites. Codex P1 round 9.
+type sqsMessageBody []byte
+
+// MarshalJSON implements json.Marshaler.
+func (b sqsMessageBody) MarshalJSON() ([]byte, error) {
+	if utf8.Valid(b) {
+		// Emit as a plain JSON string. json.Marshal handles
+		// escaping (`"`, `\`, control chars) — the bytes that
+		// reach this path are valid UTF-8, so no information is
+		// lost.
+		out, err := json.Marshal(string(b))
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		return out, nil
+	}
+	envelope := struct {
+		Base64 string `json:"base64"`
+	}{Base64: base64.RawURLEncoding.EncodeToString(b)}
+	out, err := json.Marshal(envelope)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return out, nil
+}
+
 // sqsMessageRecord is the dump-format projection. Mirrors the live
 // adapter/sqs_messages.go:80 record one-to-one — JSON tag names match so
 // a restorer can call SendMessage with each line as the input. Visibility
@@ -143,7 +175,7 @@ type sqsQueueMetaPublic struct {
 // round-trip; the encoder zeroes the visibility-state fields by default.
 type sqsMessageRecord struct {
 	MessageID              string                     `json:"message_id"`
-	Body                   []byte                     `json:"body"`
+	Body                   sqsMessageBody             `json:"body"`
 	MD5OfBody              string                     `json:"md5_of_body,omitempty"`
 	MD5OfMessageAttributes string                     `json:"md5_of_message_attributes,omitempty"`
 	MessageAttributes      map[string]json.RawMessage `json:"message_attributes,omitempty"`

--- a/internal/backup/sqs.go
+++ b/internal/backup/sqs.go
@@ -252,18 +252,23 @@ func (s *SQSEncoder) HandleSideRecord(prefix string, key, value []byte) error {
 }
 
 // Finalize flushes every queue's _queue.json and messages.jsonl. Queues
-// with buffered messages but no meta record (orphans) emit a warning and
-// are skipped — restoring orphan messages without a queue config would
-// silently create a queue with default settings, which is rarely what
-// the operator wants.
+// with buffered messages but no meta record (orphans) emit a warning
+// and have their messages dropped — restoring orphan messages without
+// a queue config would silently create a queue with default settings,
+// which is rarely what the operator wants. However, if
+// --include-sqs-side-records is on and this orphan queue has buffered
+// side records (vis/byage/dedup/group/tombstone), those are still
+// flushed under the encoded-prefix directory: the most common reason
+// for a missing meta is a DeleteQueue that left tombstones, and
+// dropping exactly those records is the opposite of what the operator
+// asked for. Codex P2 round 8.
 func (s *SQSEncoder) Finalize() error {
 	var firstErr error
 	for _, st := range s.queues {
 		if st.meta == nil {
-			s.emitWarn("sqs_orphan_messages",
-				"encoded_queue", st.encoded,
-				"buffered_messages", len(st.messages),
-				"hint", "no !sqs|queue|meta record matched this encoded prefix; messages dropped from the dump")
+			if err := s.flushOrphanQueueSideRecords(st); err != nil && firstErr == nil {
+				firstErr = err
+			}
 			continue
 		}
 		if err := s.flushQueue(st); err != nil && firstErr == nil {
@@ -271,6 +276,30 @@ func (s *SQSEncoder) Finalize() error {
 		}
 	}
 	return firstErr
+}
+
+// flushOrphanQueueSideRecords emits buffered side records for a queue
+// whose !sqs|queue|meta row never arrived. Without this branch,
+// --include-sqs-side-records silently drops the post-DeleteQueue
+// tombstones and dedup-window history operators most often opt in
+// for. The orphan dir is named by the encoded prefix because no
+// decoded queue name is available; restore tools can join it with
+// the messages-dropped warning to reconstruct context.
+func (s *SQSEncoder) flushOrphanQueueSideRecords(st *sqsQueueState) error {
+	s.emitWarn("sqs_orphan_messages",
+		"encoded_queue", st.encoded,
+		"buffered_messages", len(st.messages),
+		"buffered_side_records", len(st.internalBuf),
+		"hint", "no !sqs|queue|meta record matched this encoded prefix; messages dropped from the dump")
+	if !s.includeSideRecords || len(st.internalBuf) == 0 {
+		return nil
+	}
+	// Use the encoded prefix as the directory name — it's the only
+	// stable identifier available when meta is missing. Suffix it
+	// with `.orphan` so a restore tool cannot mistake it for a real
+	// queue dir produced from a successful meta flush.
+	dir := filepath.Join(s.outRoot, "sqs", st.encoded+".orphan")
+	return s.flushInternals(dir, st.internalBuf)
 }
 
 func (s *SQSEncoder) flushQueue(st *sqsQueueState) error {

--- a/internal/backup/sqs.go
+++ b/internal/backup/sqs.go
@@ -1,0 +1,595 @@
+package backup
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Snapshot key prefixes the SQS encoder dispatches on. Kept in sync with
+// adapter/sqs_keys.go and adapter/sqs_messages.go (see SqsQueueMetaPrefix /
+// SqsMsgDataPrefix); a renamed prefix in the live code is caught here at
+// dispatch time by the corresponding tests that synthesise records with
+// these literal byte strings.
+const (
+	SQSQueueMetaPrefix      = "!sqs|queue|meta|"
+	SQSQueueGenPrefix       = "!sqs|queue|gen|"
+	SQSQueueSeqPrefix       = "!sqs|queue|seq|"
+	SQSQueueTombstonePrefix = "!sqs|queue|tombstone|"
+	SQSMsgDataPrefix        = "!sqs|msg|data|"
+	SQSMsgVisPrefix         = "!sqs|msg|vis|"
+	SQSMsgByAgePrefix       = "!sqs|msg|byage|"
+	SQSMsgDedupPrefix       = "!sqs|msg|dedup|"
+	SQSMsgGroupPrefix       = "!sqs|msg|group|"
+)
+
+// Stored value magic prefixes (mirrors adapter/sqs_catalog.go and
+// adapter/sqs_messages.go). Values that don't carry the right magic are
+// rejected — they are either from a future schema version or genuinely
+// corrupt, both of which warrant aborting rather than silently emitting
+// garbage.
+var (
+	storedSQSMetaMagic = []byte{0x00, 'S', 'Q', 0x01}
+	storedSQSMsgMagic  = []byte{0x00, 'S', 'M', 0x01}
+)
+
+// genBytes is the fixed width of the BE uint64 generation field in
+// !sqs|msg|data|<queue><gen><msgID> keys.
+const genBytes = 8
+
+// ErrSQSInvalidQueueMeta is returned for !sqs|queue|meta values that miss
+// the magic prefix or fail JSON decoding.
+var ErrSQSInvalidQueueMeta = errors.New("backup: invalid !sqs|queue|meta value")
+
+// ErrSQSInvalidMessage is returned for !sqs|msg|data values that miss the
+// magic prefix or fail JSON decoding.
+var ErrSQSInvalidMessage = errors.New("backup: invalid !sqs|msg|data value")
+
+// ErrSQSMalformedKey is returned when an SQS key cannot be parsed for the
+// queue-name segment (e.g., the heuristic boundary detection found no
+// transition byte).
+var ErrSQSMalformedKey = errors.New("backup: malformed SQS key")
+
+// SQSEncoder encodes the SQS prefix family into the per-queue layout
+// described in docs/design/2026_04_29_proposed_snapshot_logical_decoder.md
+// (Phase 0): one `_queue.json` per queue and one ordered `messages.jsonl`.
+//
+// Lifecycle: per-snapshot pass calls Handle* for each record, then exactly
+// one Finalize. Side-records (vis/byage/dedup/group/tombstone) are
+// excluded by default; opt in with WithIncludeSideRecords. Visibility
+// state on emitted messages is zeroed by default; opt in to preserve with
+// WithPreserveVisibility.
+//
+// The encoder buffers messages per queue in memory and sorts them at
+// Finalize-time by (SendTimestampMillis, SequenceNumber, MessageID). This
+// is acceptable for typical operational queues; queues with hundreds of
+// millions of messages will need a future stream-and-merge variant.
+type SQSEncoder struct {
+	outRoot            string
+	includeSideRecords bool
+	preserveVisibility bool
+
+	// queues is keyed by the base64url-encoded queue name (the on-disk
+	// segment in the !sqs|queue|meta|<seg> key). Pending messages are
+	// keyed the same way so meta records arriving later (lex 'q' > 'm')
+	// can resolve them.
+	queues map[string]*sqsQueueState
+
+	warn func(event string, fields ...any)
+}
+
+type sqsQueueState struct {
+	encoded  string // base64url segment from the meta key
+	name     string // decoded queue name; populated on meta arrival
+	meta     *sqsQueueMetaPublic
+	messages []sqsMessageRecord
+	// internalBuf accumulates side records in their on-disk shape if
+	// includeSideRecords is on. Each line is the encoded prefix +
+	// hex(rest-of-key) + value (b64) — implementation-grade detail
+	// landing in a follow-up PR; for now this PR keeps it as a bag.
+	internalBuf []sqsInternalRecord
+}
+
+type sqsInternalRecord struct {
+	Prefix   string `json:"prefix"`
+	KeyHex   string `json:"key_hex"`
+	ValueB64 string `json:"value_b64"`
+}
+
+// sqsQueueMetaPublic is the dump-format projection of the live
+// adapter/sqs_catalog.go sqsQueueMeta. Field names match the AWS-style
+// vocabulary an external restore tool would use.
+type sqsQueueMetaPublic struct {
+	FormatVersion             uint32 `json:"format_version"`
+	Name                      string `json:"name"`
+	FIFO                      bool   `json:"fifo,omitempty"`
+	ContentBasedDeduplication bool   `json:"content_based_deduplication,omitempty"`
+	VisibilityTimeoutSeconds  int64  `json:"visibility_timeout_seconds"`
+	MessageRetentionSeconds   int64  `json:"message_retention_seconds"`
+	DelaySeconds              int64  `json:"delay_seconds"`
+	ReceiveMessageWaitSeconds int64  `json:"receive_message_wait_seconds,omitempty"`
+	MaximumMessageSize        int64  `json:"maximum_message_size,omitempty"`
+	RedrivePolicy             string `json:"redrive_policy,omitempty"`
+}
+
+// sqsMessageRecord is the dump-format projection. Mirrors the live
+// adapter/sqs_messages.go:80 record one-to-one — JSON tag names match so
+// a restorer can call SendMessage with each line as the input. Visibility
+// state is included in the schema so --preserve-visibility consumers can
+// round-trip; the encoder zeroes the visibility-state fields by default.
+type sqsMessageRecord struct {
+	MessageID              string                     `json:"message_id"`
+	Body                   []byte                     `json:"body"`
+	MD5OfBody              string                     `json:"md5_of_body,omitempty"`
+	MD5OfMessageAttributes string                     `json:"md5_of_message_attributes,omitempty"`
+	MessageAttributes      map[string]json.RawMessage `json:"message_attributes,omitempty"`
+	SenderID               string                     `json:"sender_id,omitempty"`
+	SendTimestampMillis    int64                      `json:"send_timestamp_millis"`
+	AvailableAtMillis      int64                      `json:"available_at_millis"`
+	VisibleAtMillis        int64                      `json:"visible_at_millis"`
+	ReceiveCount           int64                      `json:"receive_count"`
+	FirstReceiveMillis     int64                      `json:"first_receive_millis,omitempty"`
+	CurrentReceiptToken    []byte                     `json:"current_receipt_token,omitempty"`
+	QueueGeneration        uint64                     `json:"queue_generation"`
+	MessageGroupID         string                     `json:"message_group_id,omitempty"`
+	MessageDedupID         string                     `json:"message_deduplication_id,omitempty"`
+	SequenceNumber         uint64                     `json:"sequence_number,omitempty"`
+	DeadLetterSourceArn    string                     `json:"dead_letter_source_arn,omitempty"`
+}
+
+// NewSQSEncoder constructs an encoder rooted at <outRoot>/sqs/.
+func NewSQSEncoder(outRoot string) *SQSEncoder {
+	return &SQSEncoder{
+		outRoot: outRoot,
+		queues:  make(map[string]*sqsQueueState),
+	}
+}
+
+// WithIncludeSideRecords routes vis/byage/dedup/group/tombstone records
+// into _internals/. Default is to exclude them — they are derivable from
+// the queue config + message records and replaying them on restore can
+// resurrect aborted state.
+func (s *SQSEncoder) WithIncludeSideRecords(on bool) *SQSEncoder {
+	s.includeSideRecords = on
+	return s
+}
+
+// WithPreserveVisibility passes the visibility-state fields
+// (visible_at_millis, current_receipt_token, receive_count,
+// first_receive_millis) through to the dump. Default is to zero them so
+// the restored queue starts with every message visible.
+func (s *SQSEncoder) WithPreserveVisibility(on bool) *SQSEncoder {
+	s.preserveVisibility = on
+	return s
+}
+
+// WithWarnSink wires a structured warning hook (same shape as
+// RedisDB.WithWarnSink). Used for orphan messages and unresolvable side
+// records.
+func (s *SQSEncoder) WithWarnSink(fn func(event string, fields ...any)) *SQSEncoder {
+	s.warn = fn
+	return s
+}
+
+// HandleQueueMeta processes one !sqs|queue|meta|<encoded> record. Strips
+// the magic prefix, decodes the JSON, projects to the dump-format
+// sqsQueueMetaPublic, and parks it on the per-queue state.
+func (s *SQSEncoder) HandleQueueMeta(key, value []byte) error {
+	encoded, err := stripPrefixSegment(key, []byte(SQSQueueMetaPrefix))
+	if err != nil {
+		return err
+	}
+	name, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return errors.Wrap(ErrSQSMalformedKey, err.Error())
+	}
+	meta, err := decodeSQSQueueMetaValue(value)
+	if err != nil {
+		return err
+	}
+	st := s.queueState(encoded)
+	st.name = string(name)
+	st.meta = meta
+	// The live record carries Name internally; surface it explicitly so
+	// the dump's _queue.json is self-describing.
+	if meta.Name == "" {
+		meta.Name = st.name
+	}
+	return nil
+}
+
+// HandleMessageData processes one !sqs|msg|data|<encQueue><gen><encMsgID>
+// record. The encoded queue segment is parsed out of the key and used as
+// the per-queue routing key; the message is buffered until Finalize so it
+// can be sorted and emitted in send-order.
+func (s *SQSEncoder) HandleMessageData(key, value []byte) error {
+	encQueue, err := parseSQSMessageDataKey(key)
+	if err != nil {
+		return err
+	}
+	rec, err := decodeSQSMessageValue(value)
+	if err != nil {
+		return err
+	}
+	if !s.preserveVisibility {
+		rec.VisibleAtMillis = 0
+		rec.CurrentReceiptToken = nil
+		rec.ReceiveCount = 0
+		rec.FirstReceiveMillis = 0
+	}
+	st := s.queueState(encQueue)
+	st.messages = append(st.messages, rec)
+	return nil
+}
+
+// HandleSideRecord buffers (vis|byage|dedup|group|tombstone) records when
+// includeSideRecords is on; otherwise drops them silently (this is the
+// documented Phase 0 default).
+func (s *SQSEncoder) HandleSideRecord(prefix string, key, value []byte) error {
+	if !s.includeSideRecords {
+		return nil
+	}
+	encQueue, err := parseSQSGenericKey(key, prefix)
+	if err != nil {
+		// Tombstones include a fixed-width gen but no msg ID; the
+		// generic parser tolerates the empty trailer.
+		return err
+	}
+	st := s.queueState(encQueue)
+	st.internalBuf = append(st.internalBuf, sqsInternalRecord{
+		Prefix:   prefix,
+		KeyHex:   fmt.Sprintf("%x", key),
+		ValueB64: base64.RawURLEncoding.EncodeToString(value),
+	})
+	return nil
+}
+
+// Finalize flushes every queue's _queue.json and messages.jsonl. Queues
+// with buffered messages but no meta record (orphans) emit a warning and
+// are skipped — restoring orphan messages without a queue config would
+// silently create a queue with default settings, which is rarely what
+// the operator wants.
+func (s *SQSEncoder) Finalize() error {
+	var firstErr error
+	for _, st := range s.queues {
+		if st.meta == nil {
+			s.emitWarn("sqs_orphan_messages",
+				"encoded_queue", st.encoded,
+				"buffered_messages", len(st.messages),
+				"hint", "no !sqs|queue|meta record matched this encoded prefix; messages dropped from the dump")
+			continue
+		}
+		if err := s.flushQueue(st); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func (s *SQSEncoder) flushQueue(st *sqsQueueState) error {
+	dir := filepath.Join(s.outRoot, "sqs", EncodeSegment([]byte(st.name)))
+	if err := os.MkdirAll(dir, 0o755); err != nil { //nolint:mnd // 0755 == standard dir mode
+		return errors.WithStack(err)
+	}
+	if err := writeFileAtomic(filepath.Join(dir, "_queue.json"), mustMarshalIndent(st.meta)); err != nil {
+		return err
+	}
+	if len(st.messages) == 0 {
+		return nil
+	}
+	sortMessagesForEmit(st.messages)
+	jl, err := openJSONL(filepath.Join(dir, "messages.jsonl"))
+	if err != nil {
+		return err
+	}
+	for i := range st.messages {
+		if err := jl.enc.Encode(st.messages[i]); err != nil {
+			_ = closeJSONL(jl)
+			return errors.WithStack(err)
+		}
+	}
+	if err := closeJSONL(jl); err != nil {
+		return err
+	}
+	if len(st.internalBuf) > 0 {
+		if err := s.flushInternals(dir, st.internalBuf); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *SQSEncoder) flushInternals(queueDir string, recs []sqsInternalRecord) error {
+	dir := filepath.Join(queueDir, "_internals")
+	if err := os.MkdirAll(dir, 0o755); err != nil { //nolint:mnd // 0755 == standard dir mode
+		return errors.WithStack(err)
+	}
+	jl, err := openJSONL(filepath.Join(dir, "side_records.jsonl"))
+	if err != nil {
+		return err
+	}
+	for i := range recs {
+		if err := jl.enc.Encode(recs[i]); err != nil {
+			_ = closeJSONL(jl)
+			return errors.WithStack(err)
+		}
+	}
+	return closeJSONL(jl)
+}
+
+func (s *SQSEncoder) emitWarn(event string, fields ...any) {
+	if s.warn == nil {
+		return
+	}
+	s.warn(event, fields...)
+}
+
+func (s *SQSEncoder) queueState(encoded string) *sqsQueueState {
+	if st, ok := s.queues[encoded]; ok {
+		return st
+	}
+	st := &sqsQueueState{encoded: encoded}
+	s.queues[encoded] = st
+	return st
+}
+
+// stripPrefixSegment returns the trailing string after a literal prefix.
+// It does NOT decode the segment — the caller decides whether base64url
+// or raw bytes are appropriate for the prefix family.
+func stripPrefixSegment(key, prefix []byte) (string, error) {
+	if !bytes.HasPrefix(key, prefix) {
+		return "", errors.Wrapf(ErrSQSMalformedKey, "key does not start with %q", prefix)
+	}
+	return string(key[len(prefix):]), nil
+}
+
+// parseSQSMessageDataKey peels !sqs|msg|data|<encQueue><gen 8B><encMsgID>
+// and returns encQueue. The gen and msgID are not surfaced because the
+// dump format pulls QueueGeneration / MessageID out of the value record.
+//
+// Boundary detection: encQueue is base64url-no-padding, alphabet
+// [A-Za-z0-9-_]. The gen is 8 raw bytes. For any production gen value
+// (< 2^56), the first byte is 0x00, which is not in the base64url
+// alphabet, so the first non-alphabet byte is the gen-start. We document
+// this assumption rather than build a more elaborate prober — gens
+// approaching 2^56 would have already wrapped many other invariants.
+func parseSQSMessageDataKey(key []byte) (string, error) {
+	rest, err := stripPrefixSegment(key, []byte(SQSMsgDataPrefix))
+	if err != nil {
+		return "", err
+	}
+	idx := scanBase64URLBoundary(rest)
+	if idx == 0 || idx+genBytes > len(rest) {
+		return "", errors.Wrapf(ErrSQSMalformedKey,
+			"queue segment boundary not found in %q", key)
+	}
+	encQueue := rest[:idx]
+	if _, err := base64.RawURLEncoding.DecodeString(encQueue); err != nil {
+		return "", errors.Wrap(ErrSQSMalformedKey, err.Error())
+	}
+	// Validate the msg-id segment decodes too; if it doesn't, the
+	// boundary detection got it wrong and we surface an error rather
+	// than emit a record under a wrong queue.
+	encMsgID := rest[idx+genBytes:]
+	if _, err := base64.RawURLEncoding.DecodeString(encMsgID); err != nil {
+		return "", errors.Wrap(ErrSQSMalformedKey, err.Error())
+	}
+	return encQueue, nil
+}
+
+// parseSQSGenericKey is a coarse parser for the side-record prefixes
+// (vis/byage/dedup/group/tombstone). Callers in this PR only need to
+// know the encoded queue segment for routing; full structural parsing
+// of side-record keys is deferred until Phase 0a's reaper-aware mode
+// lands.
+func parseSQSGenericKey(key []byte, prefix string) (string, error) {
+	rest, err := stripPrefixSegment(key, []byte(prefix))
+	if err != nil {
+		return "", err
+	}
+	idx := scanBase64URLBoundary(rest)
+	if idx == 0 {
+		return "", errors.Wrapf(ErrSQSMalformedKey,
+			"queue segment not found after prefix %q", prefix)
+	}
+	return rest[:idx], nil
+}
+
+// scanBase64URLBoundary returns the index of the first byte in s that is
+// NOT in the base64url alphabet [A-Za-z0-9-_]. Returns len(s) if every
+// byte is alphabet.
+func scanBase64URLBoundary(s string) int {
+	for i := 0; i < len(s); i++ {
+		if !isBase64URLByte(s[i]) {
+			return i
+		}
+	}
+	return len(s)
+}
+
+func isBase64URLByte(c byte) bool {
+	switch {
+	case c >= 'A' && c <= 'Z':
+		return true
+	case c >= 'a' && c <= 'z':
+		return true
+	case c >= '0' && c <= '9':
+		return true
+	case c == '-', c == '_':
+		return true
+	}
+	return false
+}
+
+// decodeSQSQueueMetaValue strips the SQ magic prefix, JSON-decodes the
+// live sqsQueueMeta, and projects to the dump-format
+// sqsQueueMetaPublic. Unknown fields in the live record are tolerated
+// (forward-compat with new live-side fields the dump format hasn't
+// learned yet).
+func decodeSQSQueueMetaValue(value []byte) (*sqsQueueMetaPublic, error) {
+	if !bytes.HasPrefix(value, storedSQSMetaMagic) {
+		return nil, errors.Wrap(ErrSQSInvalidQueueMeta, "missing magic prefix")
+	}
+	body := value[len(storedSQSMetaMagic):]
+	var live struct {
+		Name                      string `json:"name"`
+		IsFIFO                    bool   `json:"is_fifo"`
+		ContentBasedDedup         bool   `json:"content_based_dedup"`
+		VisibilityTimeoutSeconds  int64  `json:"visibility_timeout_seconds"`
+		MessageRetentionSeconds   int64  `json:"message_retention_seconds"`
+		DelaySeconds              int64  `json:"delay_seconds"`
+		ReceiveMessageWaitSeconds int64  `json:"receive_message_wait_seconds"`
+		MaximumMessageSize        int64  `json:"maximum_message_size"`
+		RedrivePolicy             string `json:"redrive_policy"`
+	}
+	if err := json.Unmarshal(body, &live); err != nil {
+		return nil, errors.Wrap(ErrSQSInvalidQueueMeta, err.Error())
+	}
+	return &sqsQueueMetaPublic{
+		FormatVersion:             1,
+		Name:                      live.Name,
+		FIFO:                      live.IsFIFO,
+		ContentBasedDeduplication: live.ContentBasedDedup,
+		VisibilityTimeoutSeconds:  live.VisibilityTimeoutSeconds,
+		MessageRetentionSeconds:   live.MessageRetentionSeconds,
+		DelaySeconds:              live.DelaySeconds,
+		ReceiveMessageWaitSeconds: live.ReceiveMessageWaitSeconds,
+		MaximumMessageSize:        live.MaximumMessageSize,
+		RedrivePolicy:             live.RedrivePolicy,
+	}, nil
+}
+
+// decodeSQSMessageValue strips the SM magic prefix and JSON-decodes the
+// live sqsMessageRecord into the dump-format projection. Unlike the
+// queue-meta path, every documented field is preserved (the dump format
+// is the public projection, so there is nothing to filter).
+func decodeSQSMessageValue(value []byte) (sqsMessageRecord, error) {
+	if !bytes.HasPrefix(value, storedSQSMsgMagic) {
+		return sqsMessageRecord{}, errors.Wrap(ErrSQSInvalidMessage, "missing magic prefix")
+	}
+	body := value[len(storedSQSMsgMagic):]
+	// The live record uses different JSON tag names for the fields we
+	// expose under AWS-style names (message_group_id, sequence_number,
+	// etc.). Unmarshal into a shape that mirrors the live tags, then
+	// translate.
+	var live struct {
+		MessageID              string                     `json:"message_id"`
+		Body                   []byte                     `json:"body"`
+		MD5OfBody              string                     `json:"md5_of_body"`
+		MD5OfMessageAttributes string                     `json:"md5_of_message_attributes"`
+		MessageAttributes      map[string]json.RawMessage `json:"message_attributes"`
+		SenderID               string                     `json:"sender_id"`
+		SendTimestampMillis    int64                      `json:"send_timestamp_millis"`
+		AvailableAtMillis      int64                      `json:"available_at_millis"`
+		VisibleAtMillis        int64                      `json:"visible_at_millis"`
+		ReceiveCount           int64                      `json:"receive_count"`
+		FirstReceiveMillis     int64                      `json:"first_receive_millis"`
+		CurrentReceiptToken    []byte                     `json:"current_receipt_token"`
+		QueueGeneration        uint64                     `json:"queue_generation"`
+		MessageGroupID         string                     `json:"message_group_id"`
+		MessageDedupID         string                     `json:"message_deduplication_id"`
+		SequenceNumber         uint64                     `json:"sequence_number"`
+		DeadLetterSourceArn    string                     `json:"dead_letter_source_arn"`
+	}
+	if err := json.Unmarshal(body, &live); err != nil {
+		return sqsMessageRecord{}, errors.Wrap(ErrSQSInvalidMessage, err.Error())
+	}
+	return sqsMessageRecord{
+		MessageID:              live.MessageID,
+		Body:                   live.Body,
+		MD5OfBody:              live.MD5OfBody,
+		MD5OfMessageAttributes: live.MD5OfMessageAttributes,
+		MessageAttributes:      live.MessageAttributes,
+		SenderID:               live.SenderID,
+		SendTimestampMillis:    live.SendTimestampMillis,
+		AvailableAtMillis:      live.AvailableAtMillis,
+		VisibleAtMillis:        live.VisibleAtMillis,
+		ReceiveCount:           live.ReceiveCount,
+		FirstReceiveMillis:     live.FirstReceiveMillis,
+		CurrentReceiptToken:    live.CurrentReceiptToken,
+		QueueGeneration:        live.QueueGeneration,
+		MessageGroupID:         live.MessageGroupID,
+		MessageDedupID:         live.MessageDedupID,
+		SequenceNumber:         live.SequenceNumber,
+		DeadLetterSourceArn:    live.DeadLetterSourceArn,
+	}, nil
+}
+
+func sortMessagesForEmit(msgs []sqsMessageRecord) {
+	sort.SliceStable(msgs, func(i, j int) bool {
+		a, b := msgs[i], msgs[j]
+		switch {
+		case a.SendTimestampMillis != b.SendTimestampMillis:
+			return a.SendTimestampMillis < b.SendTimestampMillis
+		case a.SequenceNumber != b.SequenceNumber:
+			return a.SequenceNumber < b.SequenceNumber
+		default:
+			return a.MessageID < b.MessageID
+		}
+	})
+}
+
+func mustMarshalIndent(v any) []byte {
+	out, err := json.MarshalIndent(v, "", "  ") //nolint:mnd // 2-space indent matches MANIFEST
+	if err != nil {
+		// MarshalIndent only fails on unsupported types; sqsQueueMetaPublic
+		// is a plain struct of primitives. A panic here is a programmer
+		// error rather than a runtime condition we should plan to handle.
+		panic(err)
+	}
+	return out
+}
+
+// keyComponents is a debugging helper exposed for tests; not used by
+// production code paths.
+type keyComponents struct {
+	Prefix  string
+	Encoded string
+	GenRaw  []byte
+	MsgID   string
+}
+
+// peekMsgDataKey is a test/debug helper that returns the structural
+// components of a !sqs|msg|data key. Production code uses
+// parseSQSMessageDataKey directly because it never needs gen or msgID.
+func peekMsgDataKey(key []byte) (keyComponents, error) {
+	rest, err := stripPrefixSegment(key, []byte(SQSMsgDataPrefix))
+	if err != nil {
+		return keyComponents{}, err
+	}
+	idx := scanBase64URLBoundary(rest)
+	if idx == 0 || idx+genBytes > len(rest) {
+		return keyComponents{}, errors.Wrap(ErrSQSMalformedKey, "boundary not found")
+	}
+	return keyComponents{
+		Prefix:  SQSMsgDataPrefix,
+		Encoded: rest[:idx],
+		GenRaw:  []byte(rest[idx : idx+genBytes]),
+		MsgID:   rest[idx+genBytes:],
+	}, nil
+}
+
+// EncodeMsgDataKey constructs a !sqs|msg|data key for tests. Mirrors the
+// live sqsMsgDataKey constructor in adapter/sqs_messages.go.
+func EncodeMsgDataKey(queueName string, gen uint64, messageID string) []byte {
+	out := make([]byte, 0, len(SQSMsgDataPrefix)+64) //nolint:mnd // 64 == sqsKeyCapLarge
+	out = append(out, SQSMsgDataPrefix...)
+	out = append(out, base64.RawURLEncoding.EncodeToString([]byte(queueName))...)
+	var b [genBytes]byte
+	binary.BigEndian.PutUint64(b[:], gen)
+	out = append(out, b[:]...)
+	out = append(out, base64.RawURLEncoding.EncodeToString([]byte(messageID))...)
+	return out
+}
+
+// EncodeQueueMetaKey constructs a !sqs|queue|meta key for tests.
+func EncodeQueueMetaKey(queueName string) []byte {
+	return []byte(SQSQueueMetaPrefix + base64.RawURLEncoding.EncodeToString([]byte(queueName)))
+}

--- a/internal/backup/sqs.go
+++ b/internal/backup/sqs.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -108,6 +109,18 @@ type sqsQueueState struct {
 	name     string // decoded queue name; populated on meta arrival
 	meta     *sqsQueueMetaPublic
 	messages []sqsMessageRecord
+	// activeGen captures the queue's current generation, parsed
+	// from a !sqs|queue|gen|<encoded> record. PurgeQueue and
+	// DeleteQueue bump the generation so the reaper can later
+	// drop residual !sqs|msg|data|<queue><oldGen><...> rows; if
+	// the snapshot is taken before reaping completes those stale
+	// rows are still in the keyspace and must NOT be emitted to
+	// messages.jsonl. Zero means "no gen record observed yet" and
+	// disables the filter (the live cluster always writes a gen
+	// record on CreateQueue, so a missing gen at backup time
+	// means we have an orphan-only queue and the orphan branch
+	// already drops messages). Codex P1 round 10.
+	activeGen uint64
 	// internalBuf accumulates side records in their on-disk shape if
 	// includeSideRecords is on. Each line is the encoded prefix +
 	// hex(rest-of-key) + value (b64) — implementation-grade detail
@@ -254,6 +267,28 @@ func (s *SQSEncoder) HandleQueueMeta(key, value []byte) error {
 	return nil
 }
 
+// HandleQueueGen processes one !sqs|queue|gen|<encoded> record. The
+// value is a base-10 decimal string holding the queue's current
+// generation (mirrors adapter/sqs_catalog.go's CreateQueue Put: the
+// live cluster writes strconv.FormatUint(gen, 10)). Capturing
+// activeGen lets flushQueue drop messages tagged with older
+// generations — those are residual rows left by PurgeQueue /
+// DeleteQueue that the reaper has not yet cleaned, and emitting
+// them to messages.jsonl would resurrect purged messages on
+// restore. Codex P1 round 10.
+func (s *SQSEncoder) HandleQueueGen(key, value []byte) error {
+	encoded, err := stripPrefixSegment(key, []byte(SQSQueueGenPrefix))
+	if err != nil {
+		return err
+	}
+	gen, err := strconv.ParseUint(strings.TrimSpace(string(value)), 10, 64) //nolint:mnd // 10 == decimal radix
+	if err != nil {
+		return errors.Wrap(ErrSQSMalformedKey, err.Error())
+	}
+	s.queueState(encoded).activeGen = gen
+	return nil
+}
+
 // HandleMessageData processes one !sqs|msg|data|<encQueue><gen><encMsgID>
 // record. The encoded queue segment is parsed out of the key and used as
 // the per-queue routing key; the message is buffered until Finalize so it
@@ -359,19 +394,24 @@ func (s *SQSEncoder) flushQueue(st *sqsQueueState) error {
 	if err := writeFileAtomic(filepath.Join(dir, "_queue.json"), mustMarshalIndent(st.meta)); err != nil {
 		return err
 	}
-	if len(st.messages) > 0 {
-		sortMessagesForEmit(st.messages)
-		jl, err := openJSONL(filepath.Join(dir, "messages.jsonl"))
-		if err != nil {
-			return err
-		}
-		for i := range st.messages {
-			if err := jl.enc.Encode(st.messages[i]); err != nil {
-				_ = closeJSONL(jl)
-				return errors.WithStack(err)
-			}
-		}
-		if err := closeJSONL(jl); err != nil {
+	// Drop messages tagged with stale generations: PurgeQueue and
+	// DeleteQueue bump the queue's gen but the reaper deletes the
+	// affected !sqs|msg|data| rows asynchronously. A snapshot taken
+	// mid-reap would otherwise resurrect purged messages on restore.
+	// activeGen == 0 means we did not see a !sqs|queue|gen| record
+	// for this queue; preserving the legacy behaviour (no filter)
+	// is the safe fallback because every CreateQueue writes a gen.
+	// Codex P1 round 10.
+	visibleMessages, dropped := filterStaleGenMessages(st.messages, st.activeGen)
+	if dropped > 0 {
+		s.emitWarn("sqs_stale_generation_messages_dropped",
+			"queue", st.name,
+			"active_gen", st.activeGen,
+			"dropped", dropped,
+			"hint", "messages with mismatched queue_generation suppressed; reaper had not finished cleanup at snapshot time")
+	}
+	if len(visibleMessages) > 0 {
+		if err := writeMessagesJSONL(dir, visibleMessages); err != nil {
 			return err
 		}
 	}
@@ -675,6 +715,50 @@ func decodeSQSMessageValue(value []byte) (sqsMessageRecord, error) {
 		SequenceNumber:         live.SequenceNumber,
 		DeadLetterSourceArn:    live.DeadLetterSourceArn,
 	}, nil
+}
+
+// writeMessagesJSONL emits the buffered (visible) messages to
+// messages.jsonl in send-order. Split out of flushQueue to keep that
+// function's cyclomatic complexity under the project's linter ceiling.
+func writeMessagesJSONL(dir string, msgs []sqsMessageRecord) error {
+	sortMessagesForEmit(msgs)
+	jl, err := openJSONL(filepath.Join(dir, "messages.jsonl"))
+	if err != nil {
+		return err
+	}
+	for i := range msgs {
+		if err := jl.enc.Encode(msgs[i]); err != nil {
+			_ = closeJSONL(jl)
+			return errors.WithStack(err)
+		}
+	}
+	if err := closeJSONL(jl); err != nil {
+		return err
+	}
+	return nil
+}
+
+// filterStaleGenMessages partitions in into (visible, droppedCount).
+// A message is visible if activeGen is zero (no gen record observed
+// for this queue, which means we cannot make a confident call) OR
+// its QueueGeneration matches activeGen. Anything else is residual
+// state from a PurgeQueue / DeleteQueue that the reaper has not yet
+// removed; emitting it would resurrect purged messages on restore.
+// Codex P1 round 10.
+func filterStaleGenMessages(in []sqsMessageRecord, activeGen uint64) ([]sqsMessageRecord, int) {
+	if activeGen == 0 {
+		return in, 0
+	}
+	out := make([]sqsMessageRecord, 0, len(in))
+	dropped := 0
+	for _, m := range in {
+		if m.QueueGeneration == activeGen {
+			out = append(out, m)
+			continue
+		}
+		dropped++
+	}
+	return out, dropped
 }
 
 func sortMessagesForEmit(msgs []sqsMessageRecord) {

--- a/internal/backup/sqs.go
+++ b/internal/backup/sqs.go
@@ -137,6 +137,14 @@ type sqsInternalRecord struct {
 // sqsQueueMetaPublic is the dump-format projection of the live
 // adapter/sqs_catalog.go sqsQueueMeta. Field names match the AWS-style
 // vocabulary an external restore tool would use.
+//
+// PartitionCount, FifoThroughputLimit, and DeduplicationScope mirror
+// the HT-FIFO attributes captured at CreateQueue time. The adapter
+// rejects mutating these via SetQueueAttributes (they are immutable
+// per AWS contract), so dropping them at backup would silently
+// recreate single-partition / default-routing / queue-scoped-dedup
+// queues on restore — non-fidelity-preserving for any partitioned
+// FIFO workload. Codex P1 round 12.
 type sqsQueueMetaPublic struct {
 	FormatVersion             uint32 `json:"format_version"`
 	Name                      string `json:"name"`
@@ -148,6 +156,9 @@ type sqsQueueMetaPublic struct {
 	ReceiveMessageWaitSeconds int64  `json:"receive_message_wait_seconds,omitempty"`
 	MaximumMessageSize        int64  `json:"maximum_message_size,omitempty"`
 	RedrivePolicy             string `json:"redrive_policy,omitempty"`
+	PartitionCount            uint32 `json:"partition_count,omitempty"`
+	FifoThroughputLimit       string `json:"fifo_throughput_limit,omitempty"`
+	DeduplicationScope        string `json:"deduplication_scope,omitempty"`
 }
 
 // sqsMessageBody is the dump-format projection's body field. It marshals
@@ -643,6 +654,10 @@ func decodeSQSQueueMetaValue(value []byte) (*sqsQueueMetaPublic, error) {
 		ReceiveMessageWaitSeconds int64  `json:"receive_message_wait_seconds"`
 		MaximumMessageSize        int64  `json:"maximum_message_size"`
 		RedrivePolicy             string `json:"redrive_policy"`
+		// HT-FIFO immutable attributes — see adapter/sqs_catalog.go.
+		PartitionCount      uint32 `json:"partition_count"`
+		FifoThroughputLimit string `json:"fifo_throughput_limit"`
+		DeduplicationScope  string `json:"deduplication_scope"`
 	}
 	if err := json.Unmarshal(body, &live); err != nil {
 		return nil, errors.Wrap(ErrSQSInvalidQueueMeta, err.Error())
@@ -658,6 +673,9 @@ func decodeSQSQueueMetaValue(value []byte) (*sqsQueueMetaPublic, error) {
 		ReceiveMessageWaitSeconds: live.ReceiveMessageWaitSeconds,
 		MaximumMessageSize:        live.MaximumMessageSize,
 		RedrivePolicy:             live.RedrivePolicy,
+		PartitionCount:            live.PartitionCount,
+		FifoThroughputLimit:       live.FifoThroughputLimit,
+		DeduplicationScope:        live.DeduplicationScope,
 	}, nil
 }
 

--- a/internal/backup/sqs.go
+++ b/internal/backup/sqs.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 )
@@ -28,6 +29,22 @@ const (
 	SQSMsgByAgePrefix       = "!sqs|msg|byage|"
 	SQSMsgDedupPrefix       = "!sqs|msg|dedup|"
 	SQSMsgGroupPrefix       = "!sqs|msg|group|"
+
+	// HT-FIFO partitioned-keyspace discriminator. Kept in sync with
+	// adapter/sqs_keys.go sqsPartitionedDiscriminator. The literal
+	// "p|" segment is inserted between the family and the queue
+	// segment in every partitioned key:
+	//
+	//	legacy:      !sqs|msg|<family>|<encQueue><gen><rest>
+	//	partitioned: !sqs|msg|<family>|p|<encQueue>|<partition u32><gen u64><rest>
+	//
+	// validateQueueName rejects raw '|' in queue names, so a legacy
+	// queue name can never start with the literal byte 'p' followed
+	// by '|'; the discriminator unambiguously selects the parser
+	// variant. Codex P1 round 9.
+	sqsPartitionedDiscriminator = "p|"
+	// partitionBytes is the fixed BE-uint32 partition field width.
+	sqsPartitionBytes = 4
 )
 
 // Stored value magic prefixes (mirrors adapter/sqs_catalog.go and
@@ -385,19 +402,26 @@ func stripPrefixSegment(key, prefix []byte) (string, error) {
 }
 
 // parseSQSMessageDataKey peels !sqs|msg|data|<encQueue><gen 8B><encMsgID>
-// and returns encQueue. The gen and msgID are not surfaced because the
-// dump format pulls QueueGeneration / MessageID out of the value record.
+// (or its partitioned variant !sqs|msg|data|p|<encQueue>|<part 4B><gen 8B><encMsgID>)
+// and returns encQueue. The gen, partition, and msgID are not surfaced
+// because the dump format pulls those fields out of the value record.
 //
-// Boundary detection: encQueue is base64url-no-padding, alphabet
+// Boundary detection (legacy): encQueue is base64url-no-padding, alphabet
 // [A-Za-z0-9-_]. The gen is 8 raw bytes. For any production gen value
 // (< 2^56), the first byte is 0x00, which is not in the base64url
 // alphabet, so the first non-alphabet byte is the gen-start. We document
 // this assumption rather than build a more elaborate prober — gens
 // approaching 2^56 would have already wrapped many other invariants.
+//
+// Boundary detection (partitioned): the queue segment is terminated by
+// a literal '|' before the fixed-width partition u32. Codex P1 round 9.
 func parseSQSMessageDataKey(key []byte) (string, error) {
 	rest, err := stripPrefixSegment(key, []byte(SQSMsgDataPrefix))
 	if err != nil {
 		return "", err
+	}
+	if isPartitionedRest(rest) {
+		return parseSQSPartitionedQueueAndTrailer(rest, true /*hasMsgID*/, key)
 	}
 	idx := scanBase64URLBoundary(rest)
 	// idx == 0 -> no queue segment; idx+genBytes >= len(rest) -> no
@@ -426,11 +450,15 @@ func parseSQSMessageDataKey(key []byte) (string, error) {
 // (vis/byage/dedup/group/tombstone). Callers in this PR only need to
 // know the encoded queue segment for routing; full structural parsing
 // of side-record keys is deferred until Phase 0a's reaper-aware mode
-// lands.
+// lands. Both the legacy and partitioned (`p|<queue>|...`) shapes are
+// recognised — Codex P2 round 9.
 func parseSQSGenericKey(key []byte, prefix string) (string, error) {
 	rest, err := stripPrefixSegment(key, []byte(prefix))
 	if err != nil {
 		return "", err
+	}
+	if isPartitionedRest(rest) {
+		return parseSQSPartitionedQueueAndTrailer(rest, false /*hasMsgID*/, key)
 	}
 	idx := scanBase64URLBoundary(rest)
 	// All side-record key shapes (vis / byage / dedup / group /
@@ -443,6 +471,58 @@ func parseSQSGenericKey(key []byte, prefix string) (string, error) {
 			"queue segment not found after prefix %q", prefix)
 	}
 	return rest[:idx], nil
+}
+
+// isPartitionedRest reports whether `rest` (the suffix after a
+// !sqs|msg|<family>| prefix has been stripped) starts with the
+// HT-FIFO partitioned discriminator "p|".
+func isPartitionedRest(rest string) bool {
+	return strings.HasPrefix(rest, sqsPartitionedDiscriminator)
+}
+
+// parseSQSPartitionedQueueAndTrailer parses the partitioned suffix
+// `p|<encQueue>|<partition 4B><gen 8B>[<encMsgID>]`. Returns the
+// encoded queue segment when the structural invariants hold:
+//
+//   - the discriminator is followed by a non-empty queue segment
+//   - the queue segment is terminated by a literal '|'
+//   - the trailer carries at least partition u32 + gen u64 bytes
+//   - if hasMsgID == true, an additional non-empty base64url
+//     msg-id segment follows the trailer.
+//
+// Anything else surfaces ErrSQSMalformedKey rather than emitting
+// records under a wrong queue.
+func parseSQSPartitionedQueueAndTrailer(rest string, hasMsgID bool, originalKey []byte) (string, error) {
+	body := rest[len(sqsPartitionedDiscriminator):]
+	terminator := strings.IndexByte(body, '|')
+	if terminator <= 0 {
+		return "", errors.Wrapf(ErrSQSMalformedKey,
+			"partitioned key missing queue terminator in %q", originalKey)
+	}
+	encQueue := body[:terminator]
+	if _, err := base64.RawURLEncoding.DecodeString(encQueue); err != nil {
+		return "", errors.Wrap(ErrSQSMalformedKey, err.Error())
+	}
+	trailer := body[terminator+1:]
+	const fixedTrailerBytes = sqsPartitionBytes + genBytes
+	if hasMsgID {
+		// Need partition+gen plus at least 1 byte of msg-id.
+		if len(trailer) <= fixedTrailerBytes {
+			return "", errors.Wrapf(ErrSQSMalformedKey,
+				"partitioned msg-data key missing message-id in %q", originalKey)
+		}
+		encMsgID := trailer[fixedTrailerBytes:]
+		if _, err := base64.RawURLEncoding.DecodeString(encMsgID); err != nil {
+			return "", errors.Wrap(ErrSQSMalformedKey, err.Error())
+		}
+		return encQueue, nil
+	}
+	// Side records: trailer must carry at least partition+gen.
+	if len(trailer) < fixedTrailerBytes {
+		return "", errors.Wrapf(ErrSQSMalformedKey,
+			"partitioned side-record key trailer truncated in %q", originalKey)
+	}
+	return encQueue, nil
 }
 
 // scanBase64URLBoundary returns the index of the first byte in s that is

--- a/internal/backup/sqs_test.go
+++ b/internal/backup/sqs_test.go
@@ -1,0 +1,384 @@
+package backup
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+)
+
+func newSQSEncoder(t *testing.T) (*SQSEncoder, string) {
+	t.Helper()
+	root := t.TempDir()
+	return NewSQSEncoder(root), root
+}
+
+func encodeQueueMetaValue(t *testing.T, m map[string]any) []byte {
+	t.Helper()
+	body, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	out := append([]byte{}, storedSQSMetaMagic...)
+	return append(out, body...)
+}
+
+func encodeMessageValue(t *testing.T, m map[string]any) []byte {
+	t.Helper()
+	body, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	out := append([]byte{}, storedSQSMsgMagic...)
+	return append(out, body...)
+}
+
+func readQueueJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+	b, err := os.ReadFile(path) //nolint:gosec // test path
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return m
+}
+
+// floatField fetches a JSON-decoded numeric field as float64, asserting it
+// exists. JSON unmarshals all numbers to float64 by default; this wrapper
+// keeps the type-assertion in one place and gives lint a structured failure
+// to point at if the assumption breaks.
+func floatField(t *testing.T, m map[string]any, key string) float64 {
+	t.Helper()
+	v, ok := m[key]
+	if !ok {
+		t.Fatalf("field %q missing in %+v", key, m)
+	}
+	f, ok := v.(float64)
+	if !ok {
+		t.Fatalf("field %q = %T(%v), want float64", key, v, v)
+	}
+	return f
+}
+
+func readMessagesJSONL(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	f, err := os.Open(path) //nolint:gosec // test path
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+	var out []map[string]any
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var rec map[string]any
+		if err := json.Unmarshal(sc.Bytes(), &rec); err != nil {
+			t.Fatalf("unmarshal %q: %v", sc.Text(), err)
+		}
+		out = append(out, rec)
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	return out
+}
+
+func TestSQS_QueueMetaRoundTrip(t *testing.T) {
+	t.Parallel()
+	enc, root := newSQSEncoder(t)
+	key := EncodeQueueMetaKey("orders-fifo.fifo")
+	val := encodeQueueMetaValue(t, map[string]any{
+		"name":                         "orders-fifo.fifo",
+		"is_fifo":                      true,
+		"content_based_dedup":          false,
+		"visibility_timeout_seconds":   30,
+		"message_retention_seconds":    345600,
+		"delay_seconds":                0,
+		"receive_message_wait_seconds": 0,
+		"maximum_message_size":         262144,
+	})
+	if err := enc.HandleQueueMeta(key, val); err != nil {
+		t.Fatalf("HandleQueueMeta: %v", err)
+	}
+	if err := enc.Finalize(); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	got := readQueueJSON(t, filepath.Join(root, "sqs", "orders-fifo.fifo", "_queue.json"))
+	if got["name"] != "orders-fifo.fifo" {
+		t.Fatalf("name = %v", got["name"])
+	}
+	if got["fifo"] != true {
+		t.Fatalf("fifo = %v", got["fifo"])
+	}
+	if floatField(t, got, "visibility_timeout_seconds") != 30 {
+		t.Fatalf("visibility_timeout_seconds = %v", got["visibility_timeout_seconds"])
+	}
+	if floatField(t, got, "format_version") != 1 {
+		t.Fatalf("format_version = %v", got["format_version"])
+	}
+}
+
+func TestSQS_MessagesSortedByTimestampSeqMessageID(t *testing.T) {
+	t.Parallel()
+	enc, root := newSQSEncoder(t)
+	queue := "orders-fifo.fifo"
+	if err := enc.HandleQueueMeta(EncodeQueueMetaKey(queue), encodeQueueMetaValue(t, map[string]any{
+		"name": queue, "is_fifo": true, "visibility_timeout_seconds": 30, "message_retention_seconds": 60,
+	})); err != nil {
+		t.Fatal(err)
+	}
+	// Insert in scrambled order; after Finalize the JSONL must be sorted
+	// by (send_ts, seq, msg_id).
+	send := func(msgID string, sendMs int64, seq uint64, body string) {
+		t.Helper()
+		key := EncodeMsgDataKey(queue, 7, msgID)
+		val := encodeMessageValue(t, map[string]any{
+			"message_id":            msgID,
+			"body":                  []byte(body),
+			"send_timestamp_millis": sendMs,
+			"available_at_millis":   sendMs,
+			"queue_generation":      7,
+			"sequence_number":       seq,
+		})
+		if err := enc.HandleMessageData(key, val); err != nil {
+			t.Fatalf("HandleMessageData: %v", err)
+		}
+	}
+	send("msg-c", 100, 3, "c")
+	send("msg-a", 90, 1, "a")
+	send("msg-b", 100, 2, "b")
+	send("msg-tieA", 200, 5, "tA")
+	send("msg-tieB", 200, 5, "tB")
+	if err := enc.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+	recs := readMessagesJSONL(t, filepath.Join(root, "sqs", queue, "messages.jsonl"))
+	wantOrder := []string{"msg-a", "msg-b", "msg-c", "msg-tieA", "msg-tieB"}
+	if len(recs) != len(wantOrder) {
+		t.Fatalf("len = %d want %d", len(recs), len(wantOrder))
+	}
+	for i, w := range wantOrder {
+		if recs[i]["message_id"] != w {
+			t.Fatalf("recs[%d].message_id = %v, want %v", i, recs[i]["message_id"], w)
+		}
+	}
+}
+
+func TestSQS_DefaultZeroesVisibilityState(t *testing.T) {
+	t.Parallel()
+	enc, root := newSQSEncoder(t)
+	queue := "q"
+	if err := enc.HandleQueueMeta(EncodeQueueMetaKey(queue), encodeQueueMetaValue(t, map[string]any{
+		"name": queue, "visibility_timeout_seconds": 30, "message_retention_seconds": 60,
+	})); err != nil {
+		t.Fatal(err)
+	}
+	val := encodeMessageValue(t, map[string]any{
+		"message_id":            "m1",
+		"body":                  []byte("payload"),
+		"send_timestamp_millis": 1000,
+		"queue_generation":      1,
+		"visible_at_millis":     5000, // populated mid-flight
+		"current_receipt_token": []byte{0x01, 0x02},
+		"receive_count":         3,
+		"first_receive_millis":  4500,
+	})
+	if err := enc.HandleMessageData(EncodeMsgDataKey(queue, 1, "m1"), val); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+	recs := readMessagesJSONL(t, filepath.Join(root, "sqs", queue, "messages.jsonl"))
+	if len(recs) != 1 {
+		t.Fatalf("recs = %d", len(recs))
+	}
+	r := recs[0]
+	if floatField(t, r, "visible_at_millis") != 0 {
+		t.Fatalf("visible_at_millis = %v want 0", r["visible_at_millis"])
+	}
+	if _, present := r["current_receipt_token"]; present {
+		t.Fatalf("current_receipt_token must be omitted on default zeroing, got %v", r["current_receipt_token"])
+	}
+	if floatField(t, r, "receive_count") != 0 {
+		t.Fatalf("receive_count = %v want 0", r["receive_count"])
+	}
+}
+
+func TestSQS_PreserveVisibilityKeepsLiveFields(t *testing.T) {
+	t.Parallel()
+	enc, root := newSQSEncoder(t)
+	enc.WithPreserveVisibility(true)
+	queue := "q"
+	if err := enc.HandleQueueMeta(EncodeQueueMetaKey(queue), encodeQueueMetaValue(t, map[string]any{
+		"name": queue, "visibility_timeout_seconds": 30, "message_retention_seconds": 60,
+	})); err != nil {
+		t.Fatal(err)
+	}
+	val := encodeMessageValue(t, map[string]any{
+		"message_id":            "m1",
+		"body":                  []byte("payload"),
+		"send_timestamp_millis": 1000,
+		"queue_generation":      1,
+		"visible_at_millis":     5000,
+		"receive_count":         3,
+		"first_receive_millis":  4500,
+	})
+	if err := enc.HandleMessageData(EncodeMsgDataKey(queue, 1, "m1"), val); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+	recs := readMessagesJSONL(t, filepath.Join(root, "sqs", queue, "messages.jsonl"))
+	if floatField(t, recs[0], "visible_at_millis") != 5000 {
+		t.Fatalf("visible_at_millis = %v want 5000", recs[0]["visible_at_millis"])
+	}
+	if floatField(t, recs[0], "receive_count") != 3 {
+		t.Fatalf("receive_count = %v want 3", recs[0]["receive_count"])
+	}
+}
+
+func TestSQS_OrphanMessagesEmitWarning(t *testing.T) {
+	t.Parallel()
+	enc, _ := newSQSEncoder(t)
+	var events []string
+	enc.WithWarnSink(func(event string, fields ...any) {
+		events = append(events, event)
+	})
+	// Message arrives before the queue meta record (typical lex order)
+	// AND no meta record arrives at all (e.g., the queue was deleted
+	// before the snapshot was taken). The encoder buffers, then warns.
+	val := encodeMessageValue(t, map[string]any{
+		"message_id":            "stranded",
+		"body":                  []byte("orphan"),
+		"send_timestamp_millis": 1,
+		"queue_generation":      1,
+	})
+	if err := enc.HandleMessageData(EncodeMsgDataKey("ghost-queue", 1, "stranded"), val); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0] != "sqs_orphan_messages" {
+		t.Fatalf("events = %v want [sqs_orphan_messages]", events)
+	}
+}
+
+func TestSQS_RejectsValueWithoutMagicPrefix(t *testing.T) {
+	t.Parallel()
+	enc, _ := newSQSEncoder(t)
+	t.Run("queue-meta", func(t *testing.T) {
+		err := enc.HandleQueueMeta(EncodeQueueMetaKey("q"), []byte(`{"name":"q"}`))
+		if !errors.Is(err, ErrSQSInvalidQueueMeta) {
+			t.Fatalf("err=%v", err)
+		}
+	})
+	t.Run("message", func(t *testing.T) {
+		err := enc.HandleMessageData(EncodeMsgDataKey("q", 1, "m"), []byte(`{"message_id":"m"}`))
+		if !errors.Is(err, ErrSQSInvalidMessage) {
+			t.Fatalf("err=%v", err)
+		}
+	})
+}
+
+func TestSQS_RejectsTrailingGarbageAfterMagic(t *testing.T) {
+	t.Parallel()
+	enc, _ := newSQSEncoder(t)
+	bad := append([]byte{}, storedSQSMsgMagic...)
+	bad = append(bad, []byte("not json")...)
+	err := enc.HandleMessageData(EncodeMsgDataKey("q", 1, "m"), bad)
+	if !errors.Is(err, ErrSQSInvalidMessage) {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestSQS_RejectsKeyWithWrongPrefix(t *testing.T) {
+	t.Parallel()
+	enc, _ := newSQSEncoder(t)
+	err := enc.HandleQueueMeta([]byte("!unknown|prefix|q"), encodeQueueMetaValue(t, map[string]any{}))
+	if !errors.Is(err, ErrSQSMalformedKey) {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestSQS_PeekMsgDataKeyParsesComponents(t *testing.T) {
+	t.Parallel()
+	key := EncodeMsgDataKey("orders", 7, "msg-id")
+	got, err := peekMsgDataKey(key)
+	if err != nil {
+		t.Fatalf("peekMsgDataKey: %v", err)
+	}
+	if got.Encoded != "b3JkZXJz" { // base64url("orders")
+		t.Fatalf("encoded queue = %q", got.Encoded)
+	}
+	if len(got.GenRaw) != genBytes {
+		t.Fatalf("gen length = %d", len(got.GenRaw))
+	}
+	if got.GenRaw[7] != 7 { // BE: high bytes zero, low byte = 7
+		t.Fatalf("gen low byte = %x", got.GenRaw[7])
+	}
+	if got.MsgID != "bXNnLWlk" { // base64url("msg-id")
+		t.Fatalf("msg id = %q", got.MsgID)
+	}
+}
+
+func TestSQS_IncludeSideRecordsBuffersBetweenFinalize(t *testing.T) {
+	t.Parallel()
+	enc, root := newSQSEncoder(t)
+	enc.WithIncludeSideRecords(true)
+	queue := "q"
+	if err := enc.HandleQueueMeta(EncodeQueueMetaKey(queue), encodeQueueMetaValue(t, map[string]any{
+		"name": queue, "visibility_timeout_seconds": 30, "message_retention_seconds": 60,
+	})); err != nil {
+		t.Fatal(err)
+	}
+	val := encodeMessageValue(t, map[string]any{
+		"message_id": "m", "body": []byte("v"), "send_timestamp_millis": 1, "queue_generation": 1,
+	})
+	if err := enc.HandleMessageData(EncodeMsgDataKey(queue, 1, "m"), val); err != nil {
+		t.Fatal(err)
+	}
+	// Synthesise a fake vis side-record. parseSQSGenericKey only looks
+	// at the encoded queue prefix, so a payload-shaped tail is fine.
+	visKey := append([]byte(SQSMsgVisPrefix), []byte("cQ")...) // base64url("q")
+	visKey = append(visKey, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01)
+	if err := enc.HandleSideRecord(SQSMsgVisPrefix, visKey, []byte("ignored-payload")); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+	side := filepath.Join(root, "sqs", queue, "_internals", "side_records.jsonl")
+	if _, err := os.Stat(side); err != nil {
+		t.Fatalf("expected side file: %v", err)
+	}
+}
+
+func TestSQS_DefaultDoesNotEmitInternals(t *testing.T) {
+	t.Parallel()
+	enc, root := newSQSEncoder(t)
+	queue := "q"
+	if err := enc.HandleQueueMeta(EncodeQueueMetaKey(queue), encodeQueueMetaValue(t, map[string]any{
+		"name": queue, "visibility_timeout_seconds": 30, "message_retention_seconds": 60,
+	})); err != nil {
+		t.Fatal(err)
+	}
+	visKey := append([]byte(SQSMsgVisPrefix), []byte("cQ")...)
+	visKey = append(visKey, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01)
+	if err := enc.HandleSideRecord(SQSMsgVisPrefix, visKey, []byte("ignored")); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "sqs", queue, "_internals")); !os.IsNotExist(err) {
+		t.Fatalf("expected no _internals dir without --include-sqs-side-records, stat err=%v", err)
+	}
+}

--- a/internal/backup/sqs_test.go
+++ b/internal/backup/sqs_test.go
@@ -361,6 +361,55 @@ func TestSQS_IncludeSideRecordsBuffersBetweenFinalize(t *testing.T) {
 	}
 }
 
+func TestSQS_ParseMessageDataKey_RejectsEmptyMsgIDSegment(t *testing.T) {
+	t.Parallel()
+	// Synthesise a key whose msg-id segment is empty: prefix +
+	// base64url("q") + 8-byte gen, nothing after. AWS SQS message
+	// IDs are non-empty by construction; an empty trailer cannot be
+	// a legitimate snapshot record.
+	key := append([]byte(SQSMsgDataPrefix), []byte("cQ")...)
+	key = append(key, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01)
+	if _, err := parseSQSMessageDataKey(key); !errors.Is(err, ErrSQSMalformedKey) {
+		t.Fatalf("err=%v want ErrSQSMalformedKey for empty msg-id", err)
+	}
+}
+
+func TestSQS_ParseGenericKey_RejectsTrailerlessKey(t *testing.T) {
+	t.Parallel()
+	// Side-record key whose entire suffix is base64url-clean (no
+	// trailer bytes). Must surface as malformed rather than treating
+	// the whole tail as the queue segment.
+	key := append([]byte(SQSMsgVisPrefix), []byte("cQQQ")...)
+	if _, err := parseSQSGenericKey(key, SQSMsgVisPrefix); !errors.Is(err, ErrSQSMalformedKey) {
+		t.Fatalf("err=%v want ErrSQSMalformedKey for trailerless side-record key", err)
+	}
+}
+
+func TestSQS_SideRecordsFlushedEvenWhenZeroMessages(t *testing.T) {
+	t.Parallel()
+	enc, root := newSQSEncoder(t)
+	enc.WithIncludeSideRecords(true)
+	queue := "purged"
+	if err := enc.HandleQueueMeta(EncodeQueueMetaKey(queue), encodeQueueMetaValue(t, map[string]any{
+		"name": queue, "visibility_timeout_seconds": 30, "message_retention_seconds": 60,
+	})); err != nil {
+		t.Fatal(err)
+	}
+	// Side record only, no message-data records — purged queue scenario.
+	visKey := append([]byte(SQSMsgVisPrefix), []byte("cHVyZ2Vk")...) // base64url("purged")
+	visKey = append(visKey, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01)
+	if err := enc.HandleSideRecord(SQSMsgVisPrefix, visKey, []byte("opaque")); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(root, "sqs", queue, "_internals", "side_records.jsonl")
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("expected side-records file even with zero messages: %v", err)
+	}
+}
+
 func TestSQS_DefaultDoesNotEmitInternals(t *testing.T) {
 	t.Parallel()
 	enc, root := newSQSEncoder(t)

--- a/internal/backup/sqs_test.go
+++ b/internal/backup/sqs_test.go
@@ -377,6 +377,45 @@ func TestSQS_ParseMessageDataKey_RejectsEmptyMsgIDSegment(t *testing.T) {
 	}
 }
 
+// TestSQS_QueueMetaPreservesHTFIFOAttributes is the regression for
+// Codex P1 round 12: PartitionCount, FifoThroughputLimit, and
+// DeduplicationScope are immutable HT-FIFO attributes captured at
+// CreateQueue and rejected by SetQueueAttributes. Dropping them at
+// backup time would silently recreate single-partition / default-
+// routing / queue-scoped-dedup queues on restore — non-fidelity
+// preserving for any partitioned FIFO workload.
+func TestSQS_QueueMetaPreservesHTFIFOAttributes(t *testing.T) {
+	t.Parallel()
+	enc, root := newSQSEncoder(t)
+	queue := "ht-fifo.fifo"
+	val := encodeQueueMetaValue(t, map[string]any{
+		"name":                       queue,
+		"is_fifo":                    true,
+		"content_based_dedup":        true,
+		"visibility_timeout_seconds": 30,
+		"message_retention_seconds":  345600,
+		"partition_count":            4,
+		"fifo_throughput_limit":      "perMessageGroupId",
+		"deduplication_scope":        "messageGroup",
+	})
+	if err := enc.HandleQueueMeta(EncodeQueueMetaKey(queue), val); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+	got := readQueueJSON(t, filepath.Join(root, "sqs", queue, "_queue.json"))
+	if floatField(t, got, "partition_count") != 4 {
+		t.Fatalf("partition_count = %v want 4", got["partition_count"])
+	}
+	if got["fifo_throughput_limit"] != "perMessageGroupId" {
+		t.Fatalf("fifo_throughput_limit = %v want perMessageGroupId", got["fifo_throughput_limit"])
+	}
+	if got["deduplication_scope"] != "messageGroup" {
+		t.Fatalf("deduplication_scope = %v want messageGroup", got["deduplication_scope"])
+	}
+}
+
 // TestSQS_StaleGenerationMessagesDropped is the regression for Codex
 // P1 round 10: PurgeQueue and DeleteQueue bump the queue's generation
 // but the affected !sqs|msg|data|<oldGen>|... rows are removed

--- a/internal/backup/sqs_test.go
+++ b/internal/backup/sqs_test.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -371,6 +372,83 @@ func TestSQS_ParseMessageDataKey_RejectsEmptyMsgIDSegment(t *testing.T) {
 	key = append(key, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01)
 	if _, err := parseSQSMessageDataKey(key); !errors.Is(err, ErrSQSMalformedKey) {
 		t.Fatalf("err=%v want ErrSQSMalformedKey for empty msg-id", err)
+	}
+}
+
+// TestSQS_MessageBodyEmittedAsTextForUTF8 is the regression for Codex
+// P1 round 9 on PR #714: `body` was a `[]byte` field, so json.Encoder
+// rendered it as base64 in messages.jsonl. Replaying that JSONL via
+// SendMessage would push the base64 string itself as the body
+// (e.g., `hello` becoming `aGVsbG8=`), corrupting application
+// payloads. The dump-format projection now emits valid UTF-8 bodies
+// as plain strings so the JSONL is restoration-equivalent.
+func TestSQS_MessageBodyEmittedAsTextForUTF8(t *testing.T) {
+	t.Parallel()
+	enc, root := newSQSEncoder(t)
+	queue := "q"
+	if err := enc.HandleQueueMeta(EncodeQueueMetaKey(queue), encodeQueueMetaValue(t, map[string]any{
+		"name": queue, "visibility_timeout_seconds": 30, "message_retention_seconds": 60,
+	})); err != nil {
+		t.Fatal(err)
+	}
+	val := encodeMessageValue(t, map[string]any{
+		"message_id":            "m1",
+		"body":                  []byte("hello"),
+		"send_timestamp_millis": 1,
+		"queue_generation":      1,
+	})
+	if err := enc.HandleMessageData(EncodeMsgDataKey(queue, 1, "m1"), val); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(root, "sqs", queue, "messages.jsonl")) //nolint:gosec // test path
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(raw, []byte(`"body":"hello"`)) {
+		t.Fatalf("body must serialise as plain string, got %s", raw)
+	}
+	if bytes.Contains(raw, []byte("aGVsbG8")) {
+		t.Fatalf("body must NOT serialise as base64, got %s", raw)
+	}
+}
+
+// TestSQS_MessageBodyFallsBackToBase64ForBinary covers the binary
+// fallback: when the body is not valid UTF-8, the projection emits
+// a typed `{"base64":"..."}` envelope so restore tools can detect
+// the encoded form rather than receiving a lossy
+// replacement-character rewrite.
+func TestSQS_MessageBodyFallsBackToBase64ForBinary(t *testing.T) {
+	t.Parallel()
+	enc, root := newSQSEncoder(t)
+	queue := "qbin"
+	if err := enc.HandleQueueMeta(EncodeQueueMetaKey(queue), encodeQueueMetaValue(t, map[string]any{
+		"name": queue, "visibility_timeout_seconds": 30, "message_retention_seconds": 60,
+	})); err != nil {
+		t.Fatal(err)
+	}
+	// 0x80 is a continuation byte; a leading 0x80 makes the sequence
+	// invalid UTF-8.
+	val := encodeMessageValue(t, map[string]any{
+		"message_id":            "m1",
+		"body":                  []byte{0x80, 0xff, 0x01},
+		"send_timestamp_millis": 1,
+		"queue_generation":      1,
+	})
+	if err := enc.HandleMessageData(EncodeMsgDataKey(queue, 1, "m1"), val); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(root, "sqs", queue, "messages.jsonl")) //nolint:gosec // test path
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(raw, []byte(`"body":{"base64":`)) {
+		t.Fatalf("binary body must use base64 envelope, got %s", raw)
 	}
 }
 

--- a/internal/backup/sqs_test.go
+++ b/internal/backup/sqs_test.go
@@ -410,6 +410,63 @@ func TestSQS_SideRecordsFlushedEvenWhenZeroMessages(t *testing.T) {
 	}
 }
 
+// TestSQS_OrphanQueueSideRecordsPreserved is the regression for Codex
+// P2 round 8: when a queue's !sqs|queue|meta record is missing (e.g.
+// after DeleteQueue left tombstones but the meta row was removed) and
+// --include-sqs-side-records is on, side records were silently dropped
+// alongside any orphan messages. The opt-in contract is the opposite:
+// side records exist precisely so deletion-era state is recoverable.
+// Now those records flush to a `<encoded>.orphan` directory while the
+// orphan-messages warning fires.
+func TestSQS_OrphanQueueSideRecordsPreserved(t *testing.T) {
+	t.Parallel()
+	enc, root := newSQSEncoder(t)
+	enc.WithIncludeSideRecords(true)
+	var events []string
+	enc.WithWarnSink(func(event string, _ ...any) { events = append(events, event) })
+	// Side record arrives without a meta row first (deletion-era).
+	encQueue := "ZGVsZXRlZA" // base64url("deleted")
+	visKey := append([]byte(SQSMsgVisPrefix), []byte(encQueue)...)
+	visKey = append(visKey, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01)
+	if err := enc.HandleSideRecord(SQSMsgVisPrefix, visKey, []byte("vis-record")); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) == 0 || events[0] != "sqs_orphan_messages" {
+		t.Fatalf("expected sqs_orphan_messages warning, got %v", events)
+	}
+	want := filepath.Join(root, "sqs", encQueue+".orphan", "_internals", "side_records.jsonl")
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("expected orphan side-records file at %s: %v", want, err)
+	}
+}
+
+// TestSQS_OrphanQueueSideRecordsSuppressedWhenOptOut asserts that the
+// orphan-side-records branch is gated on --include-sqs-side-records:
+// without the flag, the warning still fires but no .orphan dir is
+// created (consistent with the default-off contract for side records).
+func TestSQS_OrphanQueueSideRecordsSuppressedWhenOptOut(t *testing.T) {
+	t.Parallel()
+	enc, root := newSQSEncoder(t)
+	// includeSideRecords is off by default — HandleSideRecord drops
+	// the record at intake, so the buffer is empty by Finalize. We
+	// exercise the path anyway to confirm no .orphan dir is created.
+	encQueue := "b3B0LW91dA" // base64url("opt-out")
+	visKey := append([]byte(SQSMsgVisPrefix), []byte(encQueue)...)
+	visKey = append(visKey, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02)
+	if err := enc.HandleSideRecord(SQSMsgVisPrefix, visKey, []byte("vis")); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "sqs", encQueue+".orphan")); !os.IsNotExist(err) {
+		t.Fatalf("orphan dir created without --include-sqs-side-records: stat err=%v", err)
+	}
+}
+
 func TestSQS_DefaultDoesNotEmitInternals(t *testing.T) {
 	t.Parallel()
 	enc, root := newSQSEncoder(t)

--- a/internal/backup/sqs_test.go
+++ b/internal/backup/sqs_test.go
@@ -3,9 +3,11 @@ package backup
 import (
 	"bufio"
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/cockroachdb/errors"
@@ -372,6 +374,94 @@ func TestSQS_ParseMessageDataKey_RejectsEmptyMsgIDSegment(t *testing.T) {
 	key = append(key, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01)
 	if _, err := parseSQSMessageDataKey(key); !errors.Is(err, ErrSQSMalformedKey) {
 		t.Fatalf("err=%v want ErrSQSMalformedKey for empty msg-id", err)
+	}
+}
+
+// TestSQS_StaleGenerationMessagesDropped is the regression for Codex
+// P1 round 10: PurgeQueue and DeleteQueue bump the queue's generation
+// but the affected !sqs|msg|data|<oldGen>|... rows are removed
+// asynchronously by the reaper. A snapshot taken mid-cleanup would
+// otherwise resurrect those purged messages on restore. The encoder
+// now consults the !sqs|queue|gen| record and drops messages whose
+// QueueGeneration does not match the active gen, emitting an
+// `sqs_stale_generation_messages_dropped` warning for visibility.
+func TestSQS_StaleGenerationMessagesDropped(t *testing.T) {
+	t.Parallel()
+	enc, root := newSQSEncoder(t)
+	var events []string
+	enc.WithWarnSink(func(event string, _ ...any) { events = append(events, event) })
+	queue := "q"
+	if err := enc.HandleQueueMeta(EncodeQueueMetaKey(queue), encodeQueueMetaValue(t, map[string]any{
+		"name": queue, "visibility_timeout_seconds": 30, "message_retention_seconds": 60,
+	})); err != nil {
+		t.Fatal(err)
+	}
+	encQueue := base64.RawURLEncoding.EncodeToString([]byte(queue))
+	genKey := append([]byte(SQSQueueGenPrefix), []byte(encQueue)...)
+	if err := enc.HandleQueueGen(genKey, []byte("7")); err != nil {
+		t.Fatal(err)
+	}
+	live := encodeMessageValue(t, map[string]any{
+		"message_id":            "live",
+		"body":                  []byte("ok"),
+		"send_timestamp_millis": 100,
+		"queue_generation":      7,
+	})
+	if err := enc.HandleMessageData(EncodeMsgDataKey(queue, 7, "live"), live); err != nil {
+		t.Fatal(err)
+	}
+	stale := encodeMessageValue(t, map[string]any{
+		"message_id":            "ghost",
+		"body":                  []byte("from-prev-gen"),
+		"send_timestamp_millis": 50,
+		"queue_generation":      6,
+	})
+	if err := enc.HandleMessageData(EncodeMsgDataKey(queue, 6, "ghost"), stale); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+	recs := readMessagesJSONL(t, filepath.Join(root, "sqs", queue, "messages.jsonl"))
+	if len(recs) != 1 {
+		t.Fatalf("messages = %d want 1 (stale gen must drop)", len(recs))
+	}
+	if recs[0]["message_id"] != "live" {
+		t.Fatalf("survived msg = %v want live", recs[0]["message_id"])
+	}
+	if !slices.Contains(events, "sqs_stale_generation_messages_dropped") {
+		t.Fatalf("expected sqs_stale_generation_messages_dropped warning, got %v", events)
+	}
+}
+
+// TestSQS_StaleGenerationFilterDisabledWithoutGenRecord asserts the
+// safe fallback: a queue with no !sqs|queue|gen| record observed
+// keeps the legacy behavior (no filter), so a backup that lacks the
+// gen record does not silently lose every message.
+func TestSQS_StaleGenerationFilterDisabledWithoutGenRecord(t *testing.T) {
+	t.Parallel()
+	enc, root := newSQSEncoder(t)
+	queue := "q"
+	if err := enc.HandleQueueMeta(EncodeQueueMetaKey(queue), encodeQueueMetaValue(t, map[string]any{
+		"name": queue, "visibility_timeout_seconds": 30, "message_retention_seconds": 60,
+	})); err != nil {
+		t.Fatal(err)
+	}
+	val := encodeMessageValue(t, map[string]any{
+		"message_id":            "m1",
+		"body":                  []byte("payload"),
+		"send_timestamp_millis": 1000,
+		"queue_generation":      99,
+	})
+	if err := enc.HandleMessageData(EncodeMsgDataKey(queue, 99, "m1"), val); err != nil {
+		t.Fatal(err)
+	}
+	if err := enc.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+	recs := readMessagesJSONL(t, filepath.Join(root, "sqs", queue, "messages.jsonl"))
+	if len(recs) != 1 {
+		t.Fatalf("messages = %d want 1 (no gen record => no filter)", len(recs))
 	}
 }
 

--- a/internal/backup/sqs_test.go
+++ b/internal/backup/sqs_test.go
@@ -374,6 +374,73 @@ func TestSQS_ParseMessageDataKey_RejectsEmptyMsgIDSegment(t *testing.T) {
 	}
 }
 
+// TestSQS_ParsePartitionedMessageDataKey is the regression for Codex
+// P1 round 9: HT-FIFO partitioned msg-data keys carry the literal "p|"
+// discriminator before the queue segment and a fixed-width partition
+// uint32 between the queue terminator and the gen. The parser must
+// recognise this shape — the legacy heuristic would otherwise read "p"
+// as the queue segment, fail base64 decode, and abort backup decoding
+// for any cluster running partitioned FIFO queues.
+func TestSQS_ParsePartitionedMessageDataKey(t *testing.T) {
+	t.Parallel()
+	encQueue := "cXVldWUx"   // base64url("queue1")
+	encMsgID := "bXNnLTAwMQ" // base64url("msg-001")
+	// Layout: !sqs|msg|data|p|<encQueue>|<part 4B><gen 8B><encMsgID>
+	key := []byte(SQSMsgDataPrefix + sqsPartitionedDiscriminator + encQueue + "|")
+	key = append(key, 0x00, 0x00, 0x00, 0x07)                         // partition = 7
+	key = append(key, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01) // gen
+	key = append(key, []byte(encMsgID)...)
+	got, err := parseSQSMessageDataKey(key)
+	if err != nil {
+		t.Fatalf("parseSQSMessageDataKey: %v", err)
+	}
+	if got != encQueue {
+		t.Fatalf("got %q want %q", got, encQueue)
+	}
+}
+
+// TestSQS_ParsePartitionedSideRecordKey covers parseSQSGenericKey for
+// every partitioned side-record family (Codex P2 round 9).
+func TestSQS_ParsePartitionedSideRecordKey(t *testing.T) {
+	t.Parallel()
+	encQueue := "cXVldWUy" // base64url("queue2")
+	cases := []string{
+		SQSMsgVisPrefix,
+		SQSMsgByAgePrefix,
+		SQSMsgDedupPrefix,
+		SQSMsgGroupPrefix,
+	}
+	for _, prefix := range cases {
+		t.Run(prefix, func(t *testing.T) {
+			t.Parallel()
+			key := []byte(prefix + sqsPartitionedDiscriminator + encQueue + "|")
+			key = append(key, 0x00, 0x00, 0x00, 0x03)                         // partition
+			key = append(key, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01) // gen
+			got, err := parseSQSGenericKey(key, prefix)
+			if err != nil {
+				t.Fatalf("parseSQSGenericKey(%q): %v", prefix, err)
+			}
+			if got != encQueue {
+				t.Fatalf("prefix %q: got %q want %q", prefix, got, encQueue)
+			}
+		})
+	}
+}
+
+// TestSQS_ParsePartitionedMessageDataKey_RejectsTruncatedTrailer
+// guards against a partitioned key whose trailer is too short to
+// carry partition + gen + msg-id.
+func TestSQS_ParsePartitionedMessageDataKey_RejectsTruncatedTrailer(t *testing.T) {
+	t.Parallel()
+	encQueue := "cQ"
+	key := []byte(SQSMsgDataPrefix + sqsPartitionedDiscriminator + encQueue + "|")
+	// Only 4 partition bytes, no gen, no msg-id.
+	key = append(key, 0x00, 0x00, 0x00, 0x01)
+	if _, err := parseSQSMessageDataKey(key); !errors.Is(err, ErrSQSMalformedKey) {
+		t.Fatalf("err=%v want ErrSQSMalformedKey for truncated partitioned trailer", err)
+	}
+}
+
 func TestSQS_ParseGenericKey_RejectsTrailerlessKey(t *testing.T) {
 	t.Parallel()
 	// Side-record key whose entire suffix is base64url-clean (no


### PR DESCRIPTION
## Summary

Stacked on top of #713. Adds the SQS encoder for the Phase 0 logical-backup decoder.

**Snapshot prefixes handled:**
- `!sqs|queue|meta|<base64url(queue)>` → `sqs/<queue>/_queue.json` (dump-format projection of `sqsQueueMeta` with AWS-style field names)
- `!sqs|msg|data|<base64url(queue)><gen 8B BE><base64url(msgID)>` → `sqs/<queue>/messages.jsonl` (one record per line, sorted by `(SendTimestampMillis, SequenceNumber, MessageID)`)
- `!sqs|msg|{vis,byage,dedup,group}`, `!sqs|queue|tombstone`: excluded by default; `--include-sqs-side-records` routes them to `sqs/<queue>/_internals/side_records.jsonl`
- `!sqs|queue|{gen,seq}`: ignored (operational counters, not user state)

## Why buffer + sort at Finalize

Lex-order in the snapshot is `m < q`, so `msg|data` arrives BEFORE `queue|meta`. The encoder buffers per encoded-queue-prefix and resolves the human-readable queue name at Finalize via the meta records that arrive later. Per-queue memory is O(messages-per-queue); documented as a known limit for >100M-message queues.

## Boundary detection

The msg|data key shape is `<base64url(queue)><gen 8B BE><base64url(msgID)>`. base64url alphabet is `[A-Za-z0-9-_]`; the first byte of an 8-byte BE gen is 0x00 for any production gen (`< 2^56`), so the first non-alphabet byte cleanly separates queue from gen. The msgID segment is additionally validated by attempting a base64url decode — a failed decode surfaces as `ErrSQSMalformedKey` rather than routing to the wrong queue.

## Defaults

- Visibility-state fields (`visible_at_millis`, `current_receipt_token`, `receive_count`, `first_receive_millis`) are zeroed on output. `WithPreserveVisibility(true)` passes them through.
- Orphan `msg|data` records (no matching queue meta) emit a structured warning at Finalize and are dropped from the dump. Restoring orphans without a queue config would silently create a default-attribute queue.

## Test plan

- [x] `go test -race ./internal/backup/...` — pass.
- [x] `golangci-lint run ./internal/backup/...` — clean.
- [x] 11 tests covering queue-meta round-trip, message ordering with ties, visibility-state zeroing/preservation, orphan warning, magic-prefix rejection, malformed-JSON rejection, wrong-prefix rejection, key-component peek, side-records include/exclude.

## Stacking

Base: `feat/backup-phase0a-redis-simple` (PR #713).
