### PR TITLE
feat(encryption): foundation package (Stage 0)

### DIFF
--- a/internal/encryption/cipher.go
+++ b/internal/encryption/cipher.go
@@ -1,0 +1,92 @@
+package encryption
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Cipher is the AES-256-GCM primitive over a Keystore.
+//
+// Cipher does NOT compose AAD — callers in store/ (§4.1 AAD) and
+// internal/raftengine/etcd/ (§4.2 AAD) supply the full AAD bytes. This
+// keeps the cipher narrow and lets each layer choose the right AAD
+// without baking storage/raft assumptions into the foundation package.
+type Cipher struct {
+	keystore *Keystore
+}
+
+// NewCipher returns a Cipher backed by ks.
+func NewCipher(ks *Keystore) *Cipher {
+	return &Cipher{keystore: ks}
+}
+
+// Encrypt produces (ciphertext ‖ tag) for plaintext under the DEK
+// identified by keyID and the supplied nonce. aad is treated verbatim.
+//
+// Constraints:
+//   - keyID must not be ReservedKeyID; otherwise ErrReservedKeyID.
+//   - nonce must be NonceSize bytes; otherwise ErrBadNonceSize.
+//   - keyID must be present in the Keystore; otherwise ErrUnknownKeyID.
+//
+// The returned slice has length len(plaintext) + TagSize. It is
+// freshly allocated; the caller may retain it indefinitely.
+func (c *Cipher) Encrypt(plaintext, aad []byte, keyID uint32, nonce []byte) ([]byte, error) {
+	aead, err := c.aeadFor(keyID, nonce)
+	if err != nil {
+		return nil, err
+	}
+	return aead.Seal(nil, nonce, plaintext, aad), nil
+}
+
+// Decrypt verifies and decrypts (ciphertext ‖ tag) using the DEK
+// identified by keyID, the supplied nonce, and the same aad bytes that
+// were passed to Encrypt.
+//
+// On GCM tag mismatch, Decrypt returns an error wrapping ErrIntegrity.
+// Per §4.1, callers MUST treat this as a typed read error and never
+// silently zero or retry. The original Open error is attached as a
+// secondary cause for diagnostic logging.
+func (c *Cipher) Decrypt(ciphertextAndTag, aad []byte, keyID uint32, nonce []byte) ([]byte, error) {
+	aead, err := c.aeadFor(keyID, nonce)
+	if err != nil {
+		return nil, err
+	}
+	plaintext, err := aead.Open(nil, nonce, ciphertextAndTag, aad)
+	if err != nil {
+		// Wrap ErrIntegrity (the typed error callers match via errors.Is)
+		// and attach the original GCM Open error as a secondary cause for
+		// diagnostic logging. Per §4.1, callers MUST treat this as a
+		// typed read error and never silently zero or retry.
+		return nil, errors.Wrap(
+			errors.WithSecondaryError(ErrIntegrity, err),
+			"encryption: aead.Open",
+		)
+	}
+	return plaintext, nil
+}
+
+// aeadFor returns a per-call AEAD bound to the DEK looked up from the
+// keystore, after validating keyID and nonce length.
+func (c *Cipher) aeadFor(keyID uint32, nonce []byte) (cipher.AEAD, error) {
+	if keyID == ReservedKeyID {
+		return nil, errors.WithStack(ErrReservedKeyID)
+	}
+	if len(nonce) != NonceSize {
+		return nil, errors.Wrapf(ErrBadNonceSize, "got %d bytes, want %d", len(nonce), NonceSize)
+	}
+	dek, ok := c.keystore.Get(keyID)
+	if !ok {
+		return nil, errors.Wrapf(ErrUnknownKeyID, "key_id=%d", keyID)
+	}
+	block, err := aes.NewCipher(dek)
+	if err != nil {
+		return nil, errors.Wrap(err, "encryption: aes.NewCipher")
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, errors.Wrap(err, "encryption: cipher.NewGCM")
+	}
+	return aead, nil
+}

--- a/internal/encryption/cipher.go
+++ b/internal/encryption/cipher.go
@@ -1,7 +1,6 @@
 package encryption
 
 import (
-	"crypto/aes"
 	"crypto/cipher"
 
 	"github.com/cockroachdb/errors"
@@ -13,6 +12,10 @@ import (
 // internal/raftengine/etcd/ (§4.2 AAD) supply the full AAD bytes. This
 // keeps the cipher narrow and lets each layer choose the right AAD
 // without baking storage/raft assumptions into the foundation package.
+//
+// AES key expansion and GCM initialization happen once per DEK at
+// Keystore.Set time; the hot path only needs an atomic.Pointer load
+// and a Seal/Open call.
 type Cipher struct {
 	keystore *Keystore
 }
@@ -29,6 +32,14 @@ func NewCipher(ks *Keystore) *Cipher {
 //   - keyID must not be ReservedKeyID; otherwise ErrReservedKeyID.
 //   - nonce must be NonceSize bytes; otherwise ErrBadNonceSize.
 //   - keyID must be present in the Keystore; otherwise ErrUnknownKeyID.
+//
+// CRITICAL: callers MUST NOT reuse the same (keyID, nonce) pair with
+// any two distinct plaintexts. Nonce reuse under AES-GCM is
+// catastrophic: it leaks the XOR of the two plaintexts and enables
+// authentication-key recovery. The §4.1 nonce construction
+// (node_id ‖ local_epoch ‖ write_count) is designed to make reuse
+// impossible by construction; do not bypass it with crypto/rand or
+// external counters without re-deriving the same uniqueness proof.
 //
 // The returned slice has length len(plaintext) + TagSize. It is
 // freshly allocated; the caller may retain it indefinitely.
@@ -67,8 +78,10 @@ func (c *Cipher) Decrypt(ciphertextAndTag, aad []byte, keyID uint32, nonce []byt
 	return plaintext, nil
 }
 
-// aeadFor returns a per-call AEAD bound to the DEK looked up from the
-// keystore, after validating keyID and nonce length.
+// aeadFor validates keyID and nonce length, then returns the
+// pre-initialized AEAD from the keystore. The hot path here is a single
+// atomic.Pointer load + a map lookup; AES key expansion happened once
+// at Keystore.Set time.
 func (c *Cipher) aeadFor(keyID uint32, nonce []byte) (cipher.AEAD, error) {
 	if keyID == ReservedKeyID {
 		return nil, errors.WithStack(ErrReservedKeyID)
@@ -76,17 +89,9 @@ func (c *Cipher) aeadFor(keyID uint32, nonce []byte) (cipher.AEAD, error) {
 	if len(nonce) != NonceSize {
 		return nil, errors.Wrapf(ErrBadNonceSize, "got %d bytes, want %d", len(nonce), NonceSize)
 	}
-	dek, ok := c.keystore.Get(keyID)
+	aead, ok := c.keystore.AEAD(keyID)
 	if !ok {
 		return nil, errors.Wrapf(ErrUnknownKeyID, "key_id=%d", keyID)
-	}
-	block, err := aes.NewCipher(dek)
-	if err != nil {
-		return nil, errors.Wrap(err, "encryption: aes.NewCipher")
-	}
-	aead, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, errors.Wrap(err, "encryption: cipher.NewGCM")
 	}
 	return aead, nil
 }

--- a/internal/encryption/cipher.go
+++ b/internal/encryption/cipher.go
@@ -46,10 +46,12 @@ func NewCipher(ks *Keystore) (*Cipher, error) {
 // CRITICAL: callers MUST NOT reuse the same (keyID, nonce) pair with
 // any two distinct plaintexts. Nonce reuse under AES-GCM is
 // catastrophic: it leaks the XOR of the two plaintexts and enables
-// authentication-key recovery. The §4.1 nonce construction
-// (node_id ‖ local_epoch ‖ write_count) is designed to make reuse
-// impossible by construction; do not bypass it with crypto/rand or
-// external counters without re-deriving the same uniqueness proof.
+// authentication-key recovery. The §4.1 storage-layer integration
+// uses the nonce construction (node_id ‖ local_epoch ‖ write_count)
+// to guarantee uniqueness by construction; do not substitute a
+// different nonce scheme in that layer without a corresponding
+// uniqueness proof. (For tests / benchmarks, fresh crypto/rand
+// nonces are perfectly safe.)
 //
 // The returned slice has length len(plaintext) + TagSize. It is
 // freshly allocated; the caller may retain it indefinitely.

--- a/internal/encryption/cipher.go
+++ b/internal/encryption/cipher.go
@@ -21,8 +21,18 @@ type Cipher struct {
 }
 
 // NewCipher returns a Cipher backed by ks.
-func NewCipher(ks *Keystore) *Cipher {
-	return &Cipher{keystore: ks}
+//
+// Returns ErrNilKeystore if ks is nil. Catching this at construction
+// time turns a wiring mistake into a typed error during process
+// startup or DEK rotation, rather than a nil-deref panic on the first
+// Encrypt/Decrypt — important for the dynamic dependency-wiring paths
+// where the encryption stack may be re-initialised after a sidecar
+// resync (§5.5) or rotation (§5.2).
+func NewCipher(ks *Keystore) (*Cipher, error) {
+	if ks == nil {
+		return nil, errors.WithStack(ErrNilKeystore)
+	}
+	return &Cipher{keystore: ks}, nil
 }
 
 // Encrypt produces (ciphertext ‖ tag) for plaintext under the DEK

--- a/internal/encryption/cipher.go
+++ b/internal/encryption/cipher.go
@@ -16,6 +16,10 @@ import (
 // AES key expansion and GCM initialization happen once per DEK at
 // Keystore.Set time; the hot path only needs an atomic.Pointer load
 // and a Seal/Open call.
+//
+// The zero value is NOT safe to use: Encrypt/Decrypt return
+// ErrNilKeystore for a zero-value or nil Cipher rather than nil-deref
+// panicking. Always construct via NewCipher.
 type Cipher struct {
 	keystore *Keystore
 }
@@ -94,7 +98,15 @@ func (c *Cipher) Decrypt(ciphertextAndTag, aad []byte, keyID uint32, nonce []byt
 // pre-initialized AEAD from the keystore. The hot path here is a single
 // atomic.Pointer load + a map lookup; AES key expansion happened once
 // at Keystore.Set time.
+//
+// A nil receiver or zero-value Cipher (i.e. c.keystore == nil) is
+// rejected with ErrNilKeystore so a caller that bypasses NewCipher and
+// uses var c encryption.Cipher gets a typed error instead of a
+// nil-deref panic on the first Encrypt/Decrypt.
 func (c *Cipher) aeadFor(keyID uint32, nonce []byte) (cipher.AEAD, error) {
+	if c == nil || c.keystore == nil {
+		return nil, errors.WithStack(ErrNilKeystore)
+	}
 	if keyID == ReservedKeyID {
 		return nil, errors.WithStack(ErrReservedKeyID)
 	}

--- a/internal/encryption/cipher_bench_test.go
+++ b/internal/encryption/cipher_bench_test.go
@@ -2,6 +2,7 @@ package encryption_test
 
 import (
 	"crypto/rand"
+	"strconv"
 	"testing"
 
 	"github.com/bootjp/elastickv/internal/encryption"
@@ -112,28 +113,14 @@ func BenchmarkKeystore_AEAD(b *testing.B) {
 }
 
 // name returns a sub-benchmark label scaling with size for readable
-// benchstat output ("64B", "1.0KiB", "16KiB", "64KiB").
+// benchstat output ("64B", "1KiB", "16KiB", "64KiB").
 func name(size int) string {
 	switch {
 	case size < 1024:
-		return formatBytes(size, "B")
+		return strconv.Itoa(size) + "B"
 	case size < 1024*1024:
-		return formatBytes(size/1024, "KiB")
+		return strconv.Itoa(size/1024) + "KiB"
 	default:
-		return formatBytes(size/(1024*1024), "MiB")
+		return strconv.Itoa(size/(1024*1024)) + "MiB"
 	}
-}
-
-func formatBytes(n int, unit string) string {
-	// Avoid fmt.Sprintf to keep the benchmark file self-contained on
-	// the smallest possible import surface.
-	digits := []byte{}
-	if n == 0 {
-		digits = append(digits, '0')
-	}
-	for n > 0 {
-		digits = append([]byte{byte('0' + n%10)}, digits...)
-		n /= 10
-	}
-	return string(digits) + unit
 }

--- a/internal/encryption/cipher_bench_test.go
+++ b/internal/encryption/cipher_bench_test.go
@@ -1,0 +1,139 @@
+package encryption_test
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+)
+
+// benchPlaintextSizes covers the value-size range that storage / raft
+// envelopes hit on the hot path: small (Redis counters, SET keys),
+// medium (typical KV payloads, JSON), large (DynamoDB items, S3 small
+// objects). 64 KiB caps the upper end so the benchmark stays under a
+// few seconds; bigger plaintexts are AES-NI-bound and the per-byte
+// throughput is already extracted at 64 KiB.
+var benchPlaintextSizes = []int{64, 1024, 16 * 1024, 64 * 1024}
+
+func setupBench(b *testing.B) (*encryption.Cipher, uint32, []byte) {
+	b.Helper()
+	ks := encryption.NewKeystore()
+	dek := make([]byte, encryption.KeySize)
+	if _, err := rand.Read(dek); err != nil {
+		b.Fatalf("rand.Read dek: %v", err)
+	}
+	if err := ks.Set(testKeyID, dek); err != nil {
+		b.Fatalf("Set: %v", err)
+	}
+	c, err := encryption.NewCipher(ks)
+	if err != nil {
+		b.Fatalf("NewCipher: %v", err)
+	}
+	nonce := make([]byte, encryption.NonceSize)
+	if _, err := rand.Read(nonce); err != nil {
+		b.Fatalf("rand.Read nonce: %v", err)
+	}
+	return c, testKeyID, nonce
+}
+
+// BenchmarkCipher_Encrypt verifies the post-keystore-redesign hot path:
+// Set installed the AEAD once, so each Encrypt call should be a single
+// atomic.Pointer load + AEAD.Seal.
+func BenchmarkCipher_Encrypt(b *testing.B) {
+	c, keyID, nonce := setupBench(b)
+	aad := []byte("storage-aad-context")
+
+	for _, size := range benchPlaintextSizes {
+		plaintext := make([]byte, size)
+		if _, err := rand.Read(plaintext); err != nil {
+			b.Fatalf("rand.Read plaintext: %v", err)
+		}
+		b.Run(name(size), func(b *testing.B) {
+			b.SetBytes(int64(size))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := c.Encrypt(plaintext, aad, keyID, nonce); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkCipher_Decrypt mirrors BenchmarkCipher_Encrypt for the read
+// side. Each iteration runs AEAD.Open against the same ciphertext so we
+// measure the steady-state cost rather than seeding overhead.
+func BenchmarkCipher_Decrypt(b *testing.B) {
+	c, keyID, nonce := setupBench(b)
+	aad := []byte("storage-aad-context")
+
+	for _, size := range benchPlaintextSizes {
+		plaintext := make([]byte, size)
+		if _, err := rand.Read(plaintext); err != nil {
+			b.Fatalf("rand.Read plaintext: %v", err)
+		}
+		ct, err := c.Encrypt(plaintext, aad, keyID, nonce)
+		if err != nil {
+			b.Fatalf("Encrypt: %v", err)
+		}
+		b.Run(name(size), func(b *testing.B) {
+			b.SetBytes(int64(size))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := c.Decrypt(ct, aad, keyID, nonce); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkKeystore_AEAD exercises the hot-path lookup in isolation.
+// AEAD() should be a single atomic.Pointer load + map lookup; no
+// allocations, no per-call AES key expansion.
+func BenchmarkKeystore_AEAD(b *testing.B) {
+	ks := encryption.NewKeystore()
+	dek := make([]byte, encryption.KeySize)
+	if _, err := rand.Read(dek); err != nil {
+		b.Fatalf("rand.Read: %v", err)
+	}
+	if err := ks.Set(testKeyID, dek); err != nil {
+		b.Fatalf("Set: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, ok := ks.AEAD(testKeyID); !ok {
+			b.Fatal("AEAD lookup missed")
+		}
+	}
+}
+
+// name returns a sub-benchmark label scaling with size for readable
+// benchstat output ("64B", "1.0KiB", "16KiB", "64KiB").
+func name(size int) string {
+	switch {
+	case size < 1024:
+		return formatBytes(size, "B")
+	case size < 1024*1024:
+		return formatBytes(size/1024, "KiB")
+	default:
+		return formatBytes(size/(1024*1024), "MiB")
+	}
+}
+
+func formatBytes(n int, unit string) string {
+	// Avoid fmt.Sprintf to keep the benchmark file self-contained on
+	// the smallest possible import surface.
+	digits := []byte{}
+	if n == 0 {
+		digits = append(digits, '0')
+	}
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits) + unit
+}

--- a/internal/encryption/cipher_prop_test.go
+++ b/internal/encryption/cipher_prop_test.go
@@ -1,0 +1,97 @@
+package encryption_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/cockroachdb/errors"
+	"pgregory.net/rapid"
+)
+
+// TestCipher_RoundTripProperty checks that for arbitrary plaintext, AAD,
+// nonce, and key_id, Encrypt followed by Decrypt with the same inputs
+// recovers the exact plaintext. CLAUDE.md flags this kind of test as the
+// canonical safety net for envelope-format / compress-then-encrypt bugs.
+func TestCipher_RoundTripProperty(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		ks := encryption.NewKeystore()
+		// Random 32-byte DEK installed at a random non-reserved key_id.
+		dek := make([]byte, encryption.KeySize)
+		if _, err := rand.Read(dek); err != nil {
+			t.Fatalf("rand.Read dek: %v", err)
+		}
+		keyID := rapid.Uint32Range(1, 0xFFFFFFFF).Draw(t, "keyID")
+		if err := ks.Set(keyID, dek); err != nil {
+			t.Fatalf("ks.Set: %v", err)
+		}
+
+		c := encryption.NewCipher(ks)
+		plaintext := rapid.SliceOfN(rapid.Byte(), 0, 4096).Draw(t, "plaintext")
+		aad := rapid.SliceOfN(rapid.Byte(), 0, 256).Draw(t, "aad")
+		nonce := make([]byte, encryption.NonceSize)
+		if _, err := rand.Read(nonce); err != nil {
+			t.Fatalf("rand.Read nonce: %v", err)
+		}
+
+		ct, err := c.Encrypt(plaintext, aad, keyID, nonce)
+		if err != nil {
+			t.Fatalf("Encrypt: %v", err)
+		}
+		got, err := c.Decrypt(ct, aad, keyID, nonce)
+		if err != nil {
+			t.Fatalf("Decrypt: %v", err)
+		}
+		// Both empty plaintext and empty got should compare equal; treat
+		// nil and empty as the same here so the property holds for the
+		// 0-length boundary.
+		if len(got) == 0 && len(plaintext) == 0 {
+			return
+		}
+		if !bytes.Equal(got, plaintext) {
+			t.Fatalf("plaintext mismatch:\n  got %x\n  want %x", got, plaintext)
+		}
+	})
+}
+
+// TestCipher_AADTamperProperty checks that any single-bit flip in the AAD
+// at decrypt time causes ErrIntegrity. This is the property that backs the
+// §4.1 cut-and-paste / blob-relocation defence.
+func TestCipher_AADTamperProperty(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		ks := encryption.NewKeystore()
+		dek := make([]byte, encryption.KeySize)
+		if _, err := rand.Read(dek); err != nil {
+			t.Fatalf("rand.Read dek: %v", err)
+		}
+		keyID := uint32(1)
+		if err := ks.Set(keyID, dek); err != nil {
+			t.Fatalf("ks.Set: %v", err)
+		}
+		c := encryption.NewCipher(ks)
+
+		plaintext := rapid.SliceOfN(rapid.Byte(), 1, 256).Draw(t, "plaintext")
+		// AAD must be at least 1 byte so we can tamper.
+		aad := rapid.SliceOfN(rapid.Byte(), 1, 64).Draw(t, "aad")
+		nonce := make([]byte, encryption.NonceSize)
+		if _, err := rand.Read(nonce); err != nil {
+			t.Fatalf("rand.Read nonce: %v", err)
+		}
+
+		ct, err := c.Encrypt(plaintext, aad, keyID, nonce)
+		if err != nil {
+			t.Fatalf("Encrypt: %v", err)
+		}
+
+		idx := rapid.IntRange(0, len(aad)-1).Draw(t, "idx")
+		bit := rapid.Uint8Range(0, 7).Draw(t, "bit")
+		bad := append([]byte(nil), aad...)
+		bad[idx] ^= 1 << bit
+
+		_, err = c.Decrypt(ct, bad, keyID, nonce)
+		if !errors.Is(err, encryption.ErrIntegrity) {
+			t.Fatalf("expected ErrIntegrity for tampered AAD, got %v", err)
+		}
+	})
+}

--- a/internal/encryption/cipher_prop_test.go
+++ b/internal/encryption/cipher_prop_test.go
@@ -27,7 +27,10 @@ func TestCipher_RoundTripProperty(t *testing.T) {
 			t.Fatalf("ks.Set: %v", err)
 		}
 
-		c := encryption.NewCipher(ks)
+		c, err := encryption.NewCipher(ks)
+		if err != nil {
+			t.Fatalf("NewCipher: %v", err)
+		}
 		plaintext := rapid.SliceOfN(rapid.Byte(), 0, 4096).Draw(t, "plaintext")
 		aad := rapid.SliceOfN(rapid.Byte(), 0, 256).Draw(t, "aad")
 		nonce := make([]byte, encryption.NonceSize)
@@ -69,7 +72,10 @@ func TestCipher_AADTamperProperty(t *testing.T) {
 		if err := ks.Set(keyID, dek); err != nil {
 			t.Fatalf("ks.Set: %v", err)
 		}
-		c := encryption.NewCipher(ks)
+		c, err := encryption.NewCipher(ks)
+		if err != nil {
+			t.Fatalf("NewCipher: %v", err)
+		}
 
 		plaintext := rapid.SliceOfN(rapid.Byte(), 1, 256).Draw(t, "plaintext")
 		// AAD must be at least 1 byte so we can tamper.

--- a/internal/encryption/cipher_test.go
+++ b/internal/encryption/cipher_test.go
@@ -180,6 +180,31 @@ func TestCipher_Decrypt_UnknownKeyID(t *testing.T) {
 	}
 }
 
+func TestCipher_Decrypt_RejectsReservedKeyID(t *testing.T) {
+	ks := encryption.NewKeystore()
+	c := encryption.NewCipher(ks)
+	nonce := newRandomNonce(t)
+	// Provide enough bytes to look like a valid envelope body so the
+	// length check is not the failure cause.
+	body := make([]byte, encryption.TagSize+1)
+	_, err := c.Decrypt(body, nil, encryption.ReservedKeyID, nonce)
+	if !errors.Is(err, encryption.ErrReservedKeyID) {
+		t.Fatalf("expected ErrReservedKeyID, got %v", err)
+	}
+}
+
+func TestCipher_Decrypt_RejectsBadNonceSize(t *testing.T) {
+	ks, keyID := newKeystoreWithKey(t)
+	c := encryption.NewCipher(ks)
+	body := make([]byte, encryption.TagSize+1)
+	for _, nonceLen := range []int{0, 1, 11, 13, 16} {
+		_, err := c.Decrypt(body, nil, keyID, make([]byte, nonceLen))
+		if !errors.Is(err, encryption.ErrBadNonceSize) {
+			t.Fatalf("nonce=%d: expected ErrBadNonceSize, got %v", nonceLen, err)
+		}
+	}
+}
+
 func TestCipher_DistinctNoncesProduceDistinctCiphertexts(t *testing.T) {
 	ks, keyID := newKeystoreWithKey(t)
 	c := encryption.NewCipher(ks)

--- a/internal/encryption/cipher_test.go
+++ b/internal/encryption/cipher_test.go
@@ -12,7 +12,7 @@ import (
 const testKeyID uint32 = 0xDEADBEEF
 
 // newKeystoreWithKey returns a Keystore with one freshly-drawn DEK at
-// testKeyID. Tests that need the raw DEK bytes can call ks.Get(testKeyID).
+// testKeyID. Tests that need the raw DEK bytes can call ks.DEK(testKeyID).
 func newKeystoreWithKey(t *testing.T) (*encryption.Keystore, uint32) {
 	t.Helper()
 	ks := encryption.NewKeystore()

--- a/internal/encryption/cipher_test.go
+++ b/internal/encryption/cipher_test.go
@@ -1,0 +1,204 @@
+package encryption_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/cockroachdb/errors"
+)
+
+const testKeyID uint32 = 0xDEADBEEF
+
+// newKeystoreWithKey returns a Keystore with one freshly-drawn DEK at
+// testKeyID. Tests that need the raw DEK bytes can call ks.Get(testKeyID).
+func newKeystoreWithKey(t *testing.T) (*encryption.Keystore, uint32) {
+	t.Helper()
+	ks := encryption.NewKeystore()
+	dek := make([]byte, encryption.KeySize)
+	if _, err := rand.Read(dek); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	if err := ks.Set(testKeyID, dek); err != nil {
+		t.Fatalf("ks.Set: %v", err)
+	}
+	return ks, testKeyID
+}
+
+func newRandomNonce(t *testing.T) []byte {
+	t.Helper()
+	n := make([]byte, encryption.NonceSize)
+	if _, err := rand.Read(n); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	return n
+}
+
+func TestCipher_RoundTrip(t *testing.T) {
+	ks, keyID := newKeystoreWithKey(t)
+	c := encryption.NewCipher(ks)
+	cases := []struct {
+		name      string
+		plaintext []byte
+		aad       []byte
+	}{
+		{"empty plaintext", []byte{}, []byte("aad")},
+		{"empty aad", []byte("hello"), nil},
+		{"both populated", []byte("hello world"), []byte("ctx")},
+		{"binary plaintext", []byte{0x00, 0x01, 0xff, 0xfe, 0x7f, 0x80}, []byte("ctx")},
+		{"large plaintext", bytes.Repeat([]byte("X"), 64*1024), []byte("ctx")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			nonce := newRandomNonce(t)
+			ct, err := c.Encrypt(tc.plaintext, tc.aad, keyID, nonce)
+			if err != nil {
+				t.Fatalf("Encrypt: %v", err)
+			}
+			if got, want := len(ct), len(tc.plaintext)+encryption.TagSize; got != want {
+				t.Fatalf("ciphertext len = %d, want %d", got, want)
+			}
+			pt, err := c.Decrypt(ct, tc.aad, keyID, nonce)
+			if err != nil {
+				t.Fatalf("Decrypt: %v", err)
+			}
+			if !bytes.Equal(pt, tc.plaintext) {
+				t.Fatalf("plaintext mismatch")
+			}
+		})
+	}
+}
+
+func TestCipher_Decrypt_TagTamper(t *testing.T) {
+	ks, keyID := newKeystoreWithKey(t)
+	c := encryption.NewCipher(ks)
+	nonce := newRandomNonce(t)
+	ct, err := c.Encrypt([]byte("payload"), []byte("aad"), keyID, nonce)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	// Flip the last byte (in the GCM tag region) and confirm Decrypt fails.
+	ct[len(ct)-1] ^= 0x01
+	_, err = c.Decrypt(ct, []byte("aad"), keyID, nonce)
+	if err == nil || !errors.Is(err, encryption.ErrIntegrity) {
+		t.Fatalf("expected ErrIntegrity, got %v", err)
+	}
+}
+
+func TestCipher_Decrypt_AADTamper(t *testing.T) {
+	ks, keyID := newKeystoreWithKey(t)
+	c := encryption.NewCipher(ks)
+	nonce := newRandomNonce(t)
+	ct, err := c.Encrypt([]byte("payload"), []byte("original aad"), keyID, nonce)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	_, err = c.Decrypt(ct, []byte("different aad"), keyID, nonce)
+	if err == nil || !errors.Is(err, encryption.ErrIntegrity) {
+		t.Fatalf("expected ErrIntegrity, got %v", err)
+	}
+}
+
+func TestCipher_Decrypt_CiphertextTamper(t *testing.T) {
+	ks, keyID := newKeystoreWithKey(t)
+	c := encryption.NewCipher(ks)
+	nonce := newRandomNonce(t)
+	ct, err := c.Encrypt([]byte("payload"), []byte("aad"), keyID, nonce)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	// Flip the first ciphertext byte (well before the tag).
+	ct[0] ^= 0x01
+	_, err = c.Decrypt(ct, []byte("aad"), keyID, nonce)
+	if err == nil || !errors.Is(err, encryption.ErrIntegrity) {
+		t.Fatalf("expected ErrIntegrity, got %v", err)
+	}
+}
+
+func TestCipher_Decrypt_NonceTamper(t *testing.T) {
+	ks, keyID := newKeystoreWithKey(t)
+	c := encryption.NewCipher(ks)
+	nonce := newRandomNonce(t)
+	ct, err := c.Encrypt([]byte("payload"), []byte("aad"), keyID, nonce)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	// Flip a bit in the nonce passed to Decrypt — this is a different
+	// nonce, so GCM verification fails.
+	nonce[0] ^= 0x01
+	_, err = c.Decrypt(ct, []byte("aad"), keyID, nonce)
+	if err == nil || !errors.Is(err, encryption.ErrIntegrity) {
+		t.Fatalf("expected ErrIntegrity, got %v", err)
+	}
+}
+
+func TestCipher_Encrypt_RejectsReservedKeyID(t *testing.T) {
+	ks := encryption.NewKeystore()
+	c := encryption.NewCipher(ks)
+	nonce := newRandomNonce(t)
+	_, err := c.Encrypt([]byte("x"), nil, encryption.ReservedKeyID, nonce)
+	if !errors.Is(err, encryption.ErrReservedKeyID) {
+		t.Fatalf("expected ErrReservedKeyID, got %v", err)
+	}
+}
+
+func TestCipher_Encrypt_RejectsBadNonceSize(t *testing.T) {
+	ks, keyID := newKeystoreWithKey(t)
+	c := encryption.NewCipher(ks)
+	for _, nonceLen := range []int{0, 1, 11, 13, 16} {
+		_, err := c.Encrypt([]byte("x"), nil, keyID, make([]byte, nonceLen))
+		if !errors.Is(err, encryption.ErrBadNonceSize) {
+			t.Fatalf("nonce=%d: expected ErrBadNonceSize, got %v", nonceLen, err)
+		}
+	}
+}
+
+func TestCipher_Encrypt_UnknownKeyID(t *testing.T) {
+	ks := encryption.NewKeystore()
+	c := encryption.NewCipher(ks)
+	nonce := newRandomNonce(t)
+	_, err := c.Encrypt([]byte("x"), nil, 12345, nonce)
+	if !errors.Is(err, encryption.ErrUnknownKeyID) {
+		t.Fatalf("expected ErrUnknownKeyID, got %v", err)
+	}
+}
+
+func TestCipher_Decrypt_UnknownKeyID(t *testing.T) {
+	ks, keyID := newKeystoreWithKey(t)
+	c := encryption.NewCipher(ks)
+	nonce := newRandomNonce(t)
+	ct, err := c.Encrypt([]byte("x"), nil, keyID, nonce)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	// Forget the DEK and try to decrypt.
+	ks.Delete(keyID)
+	_, err = c.Decrypt(ct, nil, keyID, nonce)
+	if !errors.Is(err, encryption.ErrUnknownKeyID) {
+		t.Fatalf("expected ErrUnknownKeyID, got %v", err)
+	}
+}
+
+func TestCipher_DistinctNoncesProduceDistinctCiphertexts(t *testing.T) {
+	ks, keyID := newKeystoreWithKey(t)
+	c := encryption.NewCipher(ks)
+	plaintext := []byte("same message")
+	aad := []byte("same aad")
+	n1 := newRandomNonce(t)
+	n2 := newRandomNonce(t)
+	if bytes.Equal(n1, n2) {
+		t.Fatal("test bug: random nonces collided")
+	}
+	ct1, err := c.Encrypt(plaintext, aad, keyID, n1)
+	if err != nil {
+		t.Fatalf("Encrypt n1: %v", err)
+	}
+	ct2, err := c.Encrypt(plaintext, aad, keyID, n2)
+	if err != nil {
+		t.Fatalf("Encrypt n2: %v", err)
+	}
+	if bytes.Equal(ct1, ct2) {
+		t.Fatal("ciphertexts collided despite different nonces")
+	}
+}

--- a/internal/encryption/cipher_test.go
+++ b/internal/encryption/cipher_test.go
@@ -35,9 +35,20 @@ func newRandomNonce(t *testing.T) []byte {
 	return n
 }
 
+// mustCipher wraps NewCipher's error return so test bodies stay
+// readable. The error path is exercised by TestNewCipher_RejectsNil.
+func mustCipher(t *testing.T, ks *encryption.Keystore) *encryption.Cipher {
+	t.Helper()
+	c, err := encryption.NewCipher(ks)
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	return c
+}
+
 func TestCipher_RoundTrip(t *testing.T) {
 	ks, keyID := newKeystoreWithKey(t)
-	c := encryption.NewCipher(ks)
+	c := mustCipher(t, ks)
 	cases := []struct {
 		name      string
 		plaintext []byte
@@ -72,7 +83,7 @@ func TestCipher_RoundTrip(t *testing.T) {
 
 func TestCipher_Decrypt_TagTamper(t *testing.T) {
 	ks, keyID := newKeystoreWithKey(t)
-	c := encryption.NewCipher(ks)
+	c := mustCipher(t, ks)
 	nonce := newRandomNonce(t)
 	ct, err := c.Encrypt([]byte("payload"), []byte("aad"), keyID, nonce)
 	if err != nil {
@@ -88,7 +99,7 @@ func TestCipher_Decrypt_TagTamper(t *testing.T) {
 
 func TestCipher_Decrypt_AADTamper(t *testing.T) {
 	ks, keyID := newKeystoreWithKey(t)
-	c := encryption.NewCipher(ks)
+	c := mustCipher(t, ks)
 	nonce := newRandomNonce(t)
 	ct, err := c.Encrypt([]byte("payload"), []byte("original aad"), keyID, nonce)
 	if err != nil {
@@ -102,7 +113,7 @@ func TestCipher_Decrypt_AADTamper(t *testing.T) {
 
 func TestCipher_Decrypt_CiphertextTamper(t *testing.T) {
 	ks, keyID := newKeystoreWithKey(t)
-	c := encryption.NewCipher(ks)
+	c := mustCipher(t, ks)
 	nonce := newRandomNonce(t)
 	ct, err := c.Encrypt([]byte("payload"), []byte("aad"), keyID, nonce)
 	if err != nil {
@@ -118,7 +129,7 @@ func TestCipher_Decrypt_CiphertextTamper(t *testing.T) {
 
 func TestCipher_Decrypt_NonceTamper(t *testing.T) {
 	ks, keyID := newKeystoreWithKey(t)
-	c := encryption.NewCipher(ks)
+	c := mustCipher(t, ks)
 	nonce := newRandomNonce(t)
 	ct, err := c.Encrypt([]byte("payload"), []byte("aad"), keyID, nonce)
 	if err != nil {
@@ -135,7 +146,7 @@ func TestCipher_Decrypt_NonceTamper(t *testing.T) {
 
 func TestCipher_Encrypt_RejectsReservedKeyID(t *testing.T) {
 	ks := encryption.NewKeystore()
-	c := encryption.NewCipher(ks)
+	c := mustCipher(t, ks)
 	nonce := newRandomNonce(t)
 	_, err := c.Encrypt([]byte("x"), nil, encryption.ReservedKeyID, nonce)
 	if !errors.Is(err, encryption.ErrReservedKeyID) {
@@ -145,7 +156,7 @@ func TestCipher_Encrypt_RejectsReservedKeyID(t *testing.T) {
 
 func TestCipher_Encrypt_RejectsBadNonceSize(t *testing.T) {
 	ks, keyID := newKeystoreWithKey(t)
-	c := encryption.NewCipher(ks)
+	c := mustCipher(t, ks)
 	for _, nonceLen := range []int{0, 1, 11, 13, 16} {
 		_, err := c.Encrypt([]byte("x"), nil, keyID, make([]byte, nonceLen))
 		if !errors.Is(err, encryption.ErrBadNonceSize) {
@@ -156,7 +167,7 @@ func TestCipher_Encrypt_RejectsBadNonceSize(t *testing.T) {
 
 func TestCipher_Encrypt_UnknownKeyID(t *testing.T) {
 	ks := encryption.NewKeystore()
-	c := encryption.NewCipher(ks)
+	c := mustCipher(t, ks)
 	nonce := newRandomNonce(t)
 	_, err := c.Encrypt([]byte("x"), nil, 12345, nonce)
 	if !errors.Is(err, encryption.ErrUnknownKeyID) {
@@ -166,7 +177,7 @@ func TestCipher_Encrypt_UnknownKeyID(t *testing.T) {
 
 func TestCipher_Decrypt_UnknownKeyID(t *testing.T) {
 	ks, keyID := newKeystoreWithKey(t)
-	c := encryption.NewCipher(ks)
+	c := mustCipher(t, ks)
 	nonce := newRandomNonce(t)
 	ct, err := c.Encrypt([]byte("x"), nil, keyID, nonce)
 	if err != nil {
@@ -182,7 +193,7 @@ func TestCipher_Decrypt_UnknownKeyID(t *testing.T) {
 
 func TestCipher_Decrypt_RejectsReservedKeyID(t *testing.T) {
 	ks := encryption.NewKeystore()
-	c := encryption.NewCipher(ks)
+	c := mustCipher(t, ks)
 	nonce := newRandomNonce(t)
 	// Provide enough bytes to look like a valid envelope body so the
 	// length check is not the failure cause.
@@ -195,7 +206,7 @@ func TestCipher_Decrypt_RejectsReservedKeyID(t *testing.T) {
 
 func TestCipher_Decrypt_RejectsBadNonceSize(t *testing.T) {
 	ks, keyID := newKeystoreWithKey(t)
-	c := encryption.NewCipher(ks)
+	c := mustCipher(t, ks)
 	body := make([]byte, encryption.TagSize+1)
 	for _, nonceLen := range []int{0, 1, 11, 13, 16} {
 		_, err := c.Decrypt(body, nil, keyID, make([]byte, nonceLen))
@@ -205,9 +216,19 @@ func TestCipher_Decrypt_RejectsBadNonceSize(t *testing.T) {
 	}
 }
 
+func TestNewCipher_RejectsNil(t *testing.T) {
+	c, err := encryption.NewCipher(nil)
+	if !errors.Is(err, encryption.ErrNilKeystore) {
+		t.Fatalf("expected ErrNilKeystore, got err=%v", err)
+	}
+	if c != nil {
+		t.Fatal("NewCipher(nil) returned non-nil Cipher")
+	}
+}
+
 func TestCipher_DistinctNoncesProduceDistinctCiphertexts(t *testing.T) {
 	ks, keyID := newKeystoreWithKey(t)
-	c := encryption.NewCipher(ks)
+	c := mustCipher(t, ks)
 	plaintext := []byte("same message")
 	aad := []byte("same aad")
 	n1 := newRandomNonce(t)

--- a/internal/encryption/cipher_test.go
+++ b/internal/encryption/cipher_test.go
@@ -226,6 +226,46 @@ func TestNewCipher_RejectsNil(t *testing.T) {
 	}
 }
 
+// TestCipher_ZeroValueRejected covers the case where a caller bypasses
+// NewCipher and instantiates encryption.Cipher{} directly (or holds a
+// nil *Cipher). Encrypt/Decrypt must return ErrNilKeystore rather than
+// panic on the unset internal keystore pointer.
+func TestCipher_ZeroValueRejected(t *testing.T) {
+	t.Parallel()
+	nonce := make([]byte, encryption.NonceSize)
+	zero := encryption.Cipher{}
+	cases := []struct {
+		name string
+		fn   func() error
+	}{
+		{"zero-value Encrypt", func() error {
+			_, err := zero.Encrypt(nil, nil, 1, nonce)
+			return err
+		}},
+		{"zero-value Decrypt", func() error {
+			_, err := zero.Decrypt(nil, nil, 1, nonce)
+			return err
+		}},
+		{"nil receiver Encrypt", func() error {
+			var c *encryption.Cipher
+			_, err := c.Encrypt(nil, nil, 1, nonce)
+			return err
+		}},
+		{"nil receiver Decrypt", func() error {
+			var c *encryption.Cipher
+			_, err := c.Decrypt(nil, nil, 1, nonce)
+			return err
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.fn(); !errors.Is(err, encryption.ErrNilKeystore) {
+				t.Fatalf("expected ErrNilKeystore, got err=%v", err)
+			}
+		})
+	}
+}
+
 func TestCipher_DistinctNoncesProduceDistinctCiphertexts(t *testing.T) {
 	ks, keyID := newKeystoreWithKey(t)
 	c := mustCipher(t, ks)

--- a/internal/encryption/doc.go
+++ b/internal/encryption/doc.go
@@ -1,0 +1,19 @@
+// Package encryption implements the AES-256-GCM envelope encryption scheme
+// described in
+// docs/design/2026_04_29_proposed_data_at_rest_encryption.md §4.
+//
+// Stage 0 (foundation) provides the primitive Encrypt/Decrypt operations,
+// the wire format envelope encoder/decoder, and the in-memory keystore.
+// Composition of AAD bytes for storage-layer envelopes (§4.1) and
+// raft-layer envelopes (§4.2) is the responsibility of callers in
+// store/ and internal/raftengine/etcd/, added in later stages.
+//
+// Wire format (§4.1):
+//
+//	+--------+------+---------+----------+-----------+--------+
+//	| 0x01   | flag | key_id  | nonce    | ciphertext| tag    |
+//	| 1 byte | 1 B  | 4 bytes | 12 bytes | N bytes   | 16 B   |
+//	+--------+------+---------+----------+-----------+--------+
+//
+// Per-value overhead is 34 bytes (HeaderSize + TagSize).
+package encryption

--- a/internal/encryption/envelope.go
+++ b/internal/encryption/envelope.go
@@ -1,0 +1,127 @@
+package encryption
+
+import (
+	"encoding/binary"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Public constants for the §4.1 wire format.
+const (
+	// EnvelopeVersionV1 is the current envelope format version. §11.3
+	// reserves 0x02..0x0F for future authenticated formats; values
+	// outside that range cause DecodeEnvelope to return ErrEnvelopeVersion.
+	EnvelopeVersionV1 byte = 0x01
+
+	// FlagCompressed (bit 0) is set when ciphertext encrypts a Snappy-
+	// compressed plaintext (§6.4). The flag participates in the AAD so a
+	// post-hoc bit-flip is rejected by GCM verification.
+	FlagCompressed byte = 1 << 0
+
+	// KeySize is the AES-256 key length in bytes.
+	KeySize = 32
+
+	// NonceSize is the AES-GCM standard nonce size in bytes.
+	NonceSize = 12
+
+	// TagSize is the AES-GCM authentication tag size in bytes.
+	TagSize = 16
+
+	// versionBytes is the size of the envelope version field.
+	versionBytes = 1
+	// flagBytes is the size of the envelope flag field.
+	flagBytes = 1
+	// keyIDBytes is the size of the envelope key_id field (uint32 BE).
+	keyIDBytes = 4
+
+	// HeaderAADSize covers version + flag + key_id (the bytes that
+	// participate in storage AAD, distinct from the full envelope header
+	// which also carries nonce). Exposed as the input length of
+	// HeaderAADBytes.
+	HeaderAADSize = versionBytes + flagBytes + keyIDBytes // 6
+
+	// HeaderSize covers version + flag + key_id + nonce, in that order.
+	HeaderSize = HeaderAADSize + NonceSize // 18
+
+	// EnvelopeOverhead is the per-value byte overhead introduced by the
+	// envelope: HeaderSize + TagSize.
+	EnvelopeOverhead = HeaderSize + TagSize // 34
+
+	// ReservedKeyID is the cluster-wide "not bootstrapped" sentinel
+	// (§5.1). Implementations MUST refuse to install or look up this
+	// key_id.
+	ReservedKeyID uint32 = 0
+
+	// versionOffset / flagOffset / keyIDOffset / nonceOffset are the
+	// byte offsets of each header field. Exposed as private constants so
+	// envelope.go and cipher.go agree without duplicated magic numbers.
+	versionOffset = 0
+	flagOffset    = 1
+	keyIDOffset   = 2
+	nonceOffset   = 6
+)
+
+// Envelope is the parsed form of the §4.1 wire format.
+type Envelope struct {
+	Version byte
+	Flag    byte
+	KeyID   uint32
+	Nonce   [NonceSize]byte
+	// Body is the concatenation of ciphertext and the GCM tag, as produced
+	// by AEAD.Seal. Length is plaintext_len + TagSize.
+	Body []byte
+}
+
+// Encode serialises the envelope into a single byte slice using the §4.1
+// wire format. The returned slice is freshly allocated.
+func (e *Envelope) Encode() []byte {
+	out := make([]byte, HeaderSize+len(e.Body))
+	out[versionOffset] = e.Version
+	out[flagOffset] = e.Flag
+	binary.BigEndian.PutUint32(out[keyIDOffset:keyIDOffset+4], e.KeyID)
+	copy(out[nonceOffset:nonceOffset+NonceSize], e.Nonce[:])
+	copy(out[HeaderSize:], e.Body)
+	return out
+}
+
+// DecodeEnvelope parses an envelope. It does NOT verify the GCM tag —
+// authentication happens at Cipher.Decrypt time once the AAD is known.
+//
+// DecodeEnvelope copies Body so the returned Envelope does not alias src.
+func DecodeEnvelope(src []byte) (*Envelope, error) {
+	if len(src) < HeaderSize+TagSize {
+		return nil, errors.Wrapf(ErrEnvelopeShort,
+			"got %d bytes, want >= %d", len(src), HeaderSize+TagSize)
+	}
+	if src[versionOffset] != EnvelopeVersionV1 {
+		return nil, errors.Wrapf(ErrEnvelopeVersion,
+			"got 0x%02x, want 0x%02x", src[versionOffset], EnvelopeVersionV1)
+	}
+	e := &Envelope{
+		Version: src[versionOffset],
+		Flag:    src[flagOffset],
+		KeyID:   binary.BigEndian.Uint32(src[keyIDOffset : keyIDOffset+4]),
+	}
+	copy(e.Nonce[:], src[nonceOffset:nonceOffset+NonceSize])
+	body := make([]byte, len(src)-HeaderSize)
+	copy(body, src[HeaderSize:])
+	e.Body = body
+	return e, nil
+}
+
+// HeaderAADBytes returns the first 6 bytes of the envelope header
+// (version, flag, key_id) in their on-disk order. These bytes participate
+// in the §4.1 storage-layer AAD (storage AAD = HeaderAADBytes ‖ pebble_key)
+// and in the §4.2 raft-layer AAD's middle slice (raft AAD =
+// "R" ‖ version ‖ key_id, computed by raft-layer callers in a later
+// stage).
+//
+// The function is exported so storage/ and raftengine/ callers can compose
+// the right AAD without re-implementing the byte order.
+func HeaderAADBytes(version, flag byte, keyID uint32) []byte {
+	out := make([]byte, HeaderAADSize)
+	out[0] = version
+	out[1] = flag
+	binary.BigEndian.PutUint32(out[2:HeaderAADSize], keyID)
+	return out
+}

--- a/internal/encryption/envelope.go
+++ b/internal/encryption/envelope.go
@@ -9,8 +9,11 @@ import (
 // Public constants for the §4.1 wire format.
 const (
 	// EnvelopeVersionV1 is the current envelope format version. §11.3
-	// reserves 0x02..0x0F for future authenticated formats; values
-	// outside that range cause DecodeEnvelope to return ErrEnvelopeVersion.
+	// reserves 0x02..0x0F for future authenticated formats. The current
+	// build only understands 0x01; ANY other version byte (including the
+	// 0x02..0x0F reserved range) causes DecodeEnvelope to return
+	// ErrEnvelopeVersion. Future decoders that know how to handle the
+	// reserved range will widen this check.
 	EnvelopeVersionV1 byte = 0x01
 
 	// FlagCompressed (bit 0) is set when ciphertext encrypts a Snappy-
@@ -74,14 +77,30 @@ type Envelope struct {
 
 // Encode serialises the envelope into a single byte slice using the §4.1
 // wire format. The returned slice is freshly allocated.
-func (e *Envelope) Encode() []byte {
+//
+// Encode validates the envelope at build time so a programmer error
+// (uninitialised Version, truncated Body) fails here with a clear
+// stack trace, rather than surfacing later as a confusing
+// DecodeEnvelope or Cipher.Decrypt failure on the read side. Returns:
+//   - ErrEnvelopeVersion if Version is not EnvelopeVersionV1.
+//   - ErrEnvelopeShort   if Body is shorter than TagSize (every valid
+//     body must contain at least the GCM tag).
+func (e *Envelope) Encode() ([]byte, error) {
+	if e.Version != EnvelopeVersionV1 {
+		return nil, errors.Wrapf(ErrEnvelopeVersion,
+			"encode: got 0x%02x, want 0x%02x", e.Version, EnvelopeVersionV1)
+	}
+	if len(e.Body) < TagSize {
+		return nil, errors.Wrapf(ErrEnvelopeShort,
+			"encode: body %d bytes, want >= %d", len(e.Body), TagSize)
+	}
 	out := make([]byte, HeaderSize+len(e.Body))
 	out[versionOffset] = e.Version
 	out[flagOffset] = e.Flag
-	binary.BigEndian.PutUint32(out[keyIDOffset:keyIDOffset+4], e.KeyID)
+	binary.BigEndian.PutUint32(out[keyIDOffset:keyIDOffset+keyIDBytes], e.KeyID)
 	copy(out[nonceOffset:nonceOffset+NonceSize], e.Nonce[:])
 	copy(out[HeaderSize:], e.Body)
-	return out
+	return out, nil
 }
 
 // DecodeEnvelope parses an envelope. It does NOT verify the GCM tag —
@@ -116,12 +135,22 @@ func DecodeEnvelope(src []byte) (*Envelope, error) {
 // "R" ‖ version ‖ key_id, computed by raft-layer callers in a later
 // stage).
 //
-// The function is exported so storage/ and raftengine/ callers can compose
-// the right AAD without re-implementing the byte order.
+// Allocates HeaderAADSize bytes. Hot-path callers should prefer
+// AppendHeaderAADBytes to reuse a buffer.
 func HeaderAADBytes(version, flag byte, keyID uint32) []byte {
-	out := make([]byte, HeaderAADSize)
-	out[0] = version
-	out[1] = flag
-	binary.BigEndian.PutUint32(out[2:HeaderAADSize], keyID)
-	return out
+	return AppendHeaderAADBytes(make([]byte, 0, HeaderAADSize), version, flag, keyID)
+}
+
+// AppendHeaderAADBytes appends the same 6-byte header prefix (version,
+// flag, key_id) onto dst and returns the extended slice. Allocation-free
+// when dst already has HeaderAADSize spare capacity, which lets storage
+// callers in later stages write the AAD directly into a pooled buffer
+// alongside the per-record context (e.g., pebble_key) without an
+// intermediate make().
+func AppendHeaderAADBytes(dst []byte, version, flag byte, keyID uint32) []byte {
+	var hdr [HeaderAADSize]byte
+	hdr[0] = version
+	hdr[1] = flag
+	binary.BigEndian.PutUint32(hdr[2:], keyID)
+	return append(dst, hdr[:]...)
 }

--- a/internal/encryption/envelope_test.go
+++ b/internal/encryption/envelope_test.go
@@ -59,7 +59,10 @@ func checkEnvelopeRoundTrip(t *testing.T, env encryption.Envelope) {
 	for i := range env.Nonce {
 		env.Nonce[i] = byte(i + 1)
 	}
-	encoded := env.Encode()
+	encoded, err := env.Encode()
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
 	checkEncodedHeader(t, encoded, env)
 
 	decoded, err := encryption.DecodeEnvelope(encoded)
@@ -148,5 +151,50 @@ func TestHeaderAADBytes_Layout(t *testing.T) {
 	want := []byte{0x01, 0x01, 0x12, 0x34, 0x56, 0x78}
 	if !bytes.Equal(got, want) {
 		t.Fatalf("HeaderAADBytes layout mismatch:\n  got  %x\n  want %x", got, want)
+	}
+}
+
+func TestAppendHeaderAADBytes_AppendsAndAllocFree(t *testing.T) {
+	// Append onto an existing buffer. The result should be the original
+	// bytes followed by the 6-byte header.
+	prefix := []byte{0xCA, 0xFE}
+	got := encryption.AppendHeaderAADBytes(prefix, encryption.EnvelopeVersionV1, encryption.FlagCompressed, 0x12345678)
+	want := []byte{0xCA, 0xFE, 0x01, 0x01, 0x12, 0x34, 0x56, 0x78}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("AppendHeaderAADBytes mismatch:\n  got  %x\n  want %x", got, want)
+	}
+
+	// With cap >= len(prefix)+HeaderAADSize, append should reuse the
+	// backing array (no allocation). This is the storage-layer hot-path
+	// expectation.
+	buf := make([]byte, 0, 32)
+	buf = append(buf, 0xAA, 0xBB)
+	out := encryption.AppendHeaderAADBytes(buf, 0x01, 0x00, 0xDEADBEEF)
+	if &out[0] != &buf[0] {
+		t.Fatal("AppendHeaderAADBytes allocated when input had spare capacity")
+	}
+}
+
+func TestEnvelope_Encode_RejectsBadVersion(t *testing.T) {
+	env := encryption.Envelope{
+		Version: 0x02, // not EnvelopeVersionV1
+		Body:    bytes.Repeat([]byte{0xAA}, encryption.TagSize),
+	}
+	_, err := env.Encode()
+	if !errors.Is(err, encryption.ErrEnvelopeVersion) {
+		t.Fatalf("expected ErrEnvelopeVersion, got %v", err)
+	}
+}
+
+func TestEnvelope_Encode_RejectsShortBody(t *testing.T) {
+	for _, n := range []int{0, 1, encryption.TagSize - 1} {
+		env := encryption.Envelope{
+			Version: encryption.EnvelopeVersionV1,
+			Body:    make([]byte, n),
+		}
+		_, err := env.Encode()
+		if !errors.Is(err, encryption.ErrEnvelopeShort) {
+			t.Fatalf("body=%d: expected ErrEnvelopeShort, got %v", n, err)
+		}
 	}
 }

--- a/internal/encryption/envelope_test.go
+++ b/internal/encryption/envelope_test.go
@@ -1,0 +1,152 @@
+package encryption_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/cockroachdb/errors"
+)
+
+func TestEnvelope_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		env  encryption.Envelope
+	}{
+		{
+			name: "empty body",
+			env: encryption.Envelope{
+				Version: encryption.EnvelopeVersionV1,
+				Flag:    0,
+				KeyID:   1,
+				Body:    bytes.Repeat([]byte{0xAA}, encryption.TagSize),
+			},
+		},
+		{
+			name: "compressed flag set",
+			env: encryption.Envelope{
+				Version: encryption.EnvelopeVersionV1,
+				Flag:    encryption.FlagCompressed,
+				KeyID:   0xCAFE_F00D,
+				Body:    bytes.Repeat([]byte{0x55}, 64+encryption.TagSize),
+			},
+		},
+		{
+			name: "max key_id",
+			env: encryption.Envelope{
+				Version: encryption.EnvelopeVersionV1,
+				Flag:    0xff,
+				KeyID:   0xFFFF_FFFF,
+				Body:    bytes.Repeat([]byte{0x77}, 1024+encryption.TagSize),
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			checkEnvelopeRoundTrip(t, tc.env)
+		})
+	}
+}
+
+// checkEnvelopeRoundTrip encodes the envelope, validates header layout, then
+// decodes and asserts every field is preserved bit-for-bit. Split out of
+// TestEnvelope_RoundTrip to keep the table-driven loop body simple enough
+// for the project's gocognit / cyclop thresholds.
+func checkEnvelopeRoundTrip(t *testing.T, env encryption.Envelope) {
+	t.Helper()
+	// Set a deterministic nonce to make round-trip checks trivially
+	// comparable.
+	for i := range env.Nonce {
+		env.Nonce[i] = byte(i + 1)
+	}
+	encoded := env.Encode()
+	checkEncodedHeader(t, encoded, env)
+
+	decoded, err := encryption.DecodeEnvelope(encoded)
+	if err != nil {
+		t.Fatalf("DecodeEnvelope: %v", err)
+	}
+	checkDecodedFields(t, decoded, env)
+}
+
+func checkEncodedHeader(t *testing.T, encoded []byte, env encryption.Envelope) {
+	t.Helper()
+	if got, want := len(encoded), encryption.HeaderSize+len(env.Body); got != want {
+		t.Fatalf("encoded length = %d, want %d", got, want)
+	}
+	if encoded[0] != env.Version {
+		t.Fatalf("version byte mismatch: got 0x%02x, want 0x%02x", encoded[0], env.Version)
+	}
+	if encoded[1] != env.Flag {
+		t.Fatalf("flag byte mismatch: got 0x%02x, want 0x%02x", encoded[1], env.Flag)
+	}
+}
+
+func checkDecodedFields(t *testing.T, decoded *encryption.Envelope, want encryption.Envelope) {
+	t.Helper()
+	if decoded.Version != want.Version {
+		t.Fatal("Version mismatch")
+	}
+	if decoded.Flag != want.Flag {
+		t.Fatal("Flag mismatch")
+	}
+	if decoded.KeyID != want.KeyID {
+		t.Fatalf("KeyID mismatch: got %d, want %d", decoded.KeyID, want.KeyID)
+	}
+	if decoded.Nonce != want.Nonce {
+		t.Fatal("Nonce mismatch")
+	}
+	if !bytes.Equal(decoded.Body, want.Body) {
+		t.Fatal("Body mismatch")
+	}
+}
+
+func TestEnvelope_Decode_TooShort(t *testing.T) {
+	// Anything less than HeaderSize + TagSize is invalid.
+	for _, n := range []int{0, 1, encryption.HeaderSize - 1, encryption.HeaderSize, encryption.HeaderSize + encryption.TagSize - 1} {
+		buf := make([]byte, n)
+		if n > 0 {
+			buf[0] = encryption.EnvelopeVersionV1
+		}
+		_, err := encryption.DecodeEnvelope(buf)
+		if !errors.Is(err, encryption.ErrEnvelopeShort) {
+			t.Fatalf("len=%d: expected ErrEnvelopeShort, got %v", n, err)
+		}
+	}
+}
+
+func TestEnvelope_Decode_RejectsUnknownVersion(t *testing.T) {
+	for _, version := range []byte{0x00, 0x02, 0x10, 0xFE, 0xFF} {
+		buf := make([]byte, encryption.HeaderSize+encryption.TagSize)
+		buf[0] = version
+		_, err := encryption.DecodeEnvelope(buf)
+		if !errors.Is(err, encryption.ErrEnvelopeVersion) {
+			t.Fatalf("version=0x%02x: expected ErrEnvelopeVersion, got %v", version, err)
+		}
+	}
+}
+
+func TestEnvelope_Decode_DoesNotAliasInput(t *testing.T) {
+	src := make([]byte, encryption.HeaderSize+encryption.TagSize+8)
+	src[0] = encryption.EnvelopeVersionV1
+	for i := encryption.HeaderSize; i < len(src); i++ {
+		src[i] = 0x42
+	}
+	decoded, err := encryption.DecodeEnvelope(src)
+	if err != nil {
+		t.Fatalf("DecodeEnvelope: %v", err)
+	}
+	// Mutate src; decoded.Body must not change.
+	src[encryption.HeaderSize] = 0xff
+	if decoded.Body[0] == 0xff {
+		t.Fatal("Decode aliased input: src mutation leaked into decoded.Body")
+	}
+}
+
+func TestHeaderAADBytes_Layout(t *testing.T) {
+	got := encryption.HeaderAADBytes(encryption.EnvelopeVersionV1, encryption.FlagCompressed, 0x12345678)
+	want := []byte{0x01, 0x01, 0x12, 0x34, 0x56, 0x78}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("HeaderAADBytes layout mismatch:\n  got  %x\n  want %x", got, want)
+	}
+}

--- a/internal/encryption/errors.go
+++ b/internal/encryption/errors.go
@@ -34,4 +34,9 @@ var (
 	// ErrEnvelopeVersion indicates DecodeEnvelope saw a version byte the
 	// current build does not know how to parse. Reserved values per §11.3.
 	ErrEnvelopeVersion = errors.New("encryption: unknown envelope version")
+
+	// ErrNilKeystore indicates NewCipher was called with a nil Keystore.
+	// Surfaced at construction time so a wiring mistake is caught
+	// before the first Encrypt/Decrypt would otherwise nil-deref panic.
+	ErrNilKeystore = errors.New("encryption: keystore is nil")
 )

--- a/internal/encryption/errors.go
+++ b/internal/encryption/errors.go
@@ -1,0 +1,37 @@
+package encryption
+
+import "github.com/cockroachdb/errors"
+
+var (
+	// ErrUnknownKeyID is returned when a wrap/unwrap call references a key_id
+	// that is not present in the Keystore. Surfaces as `unknown_key_id` on
+	// the §9.2 elastickv_encryption_decrypt_failures_total counter.
+	ErrUnknownKeyID = errors.New("encryption: unknown key_id")
+
+	// ErrReservedKeyID is returned when a caller tries to install or use
+	// key_id 0; that value is reserved cluster-wide as the
+	// "not bootstrapped" sentinel per §5.1.
+	ErrReservedKeyID = errors.New("encryption: key_id 0 is reserved as the not-bootstrapped sentinel")
+
+	// ErrBadNonceSize indicates the nonce passed to Encrypt/Decrypt was not
+	// exactly NonceSize bytes.
+	ErrBadNonceSize = errors.New("encryption: nonce size invalid")
+
+	// ErrBadKeySize indicates the DEK passed to Keystore.Set was not exactly
+	// KeySize bytes (AES-256 requires 32).
+	ErrBadKeySize = errors.New("encryption: DEK size invalid")
+
+	// ErrIntegrity indicates a GCM tag mismatch on Decrypt — i.e., the
+	// ciphertext was tampered with, the AAD does not match the one used at
+	// Encrypt, or the wrong DEK is loaded. Per §4.1, callers MUST treat this
+	// as a typed read error and never silently zero or retry.
+	ErrIntegrity = errors.New("encryption: integrity check failed (GCM tag mismatch)")
+
+	// ErrEnvelopeShort indicates DecodeEnvelope received fewer bytes than the
+	// minimum envelope size (HeaderSize + TagSize).
+	ErrEnvelopeShort = errors.New("encryption: envelope shorter than header+tag")
+
+	// ErrEnvelopeVersion indicates DecodeEnvelope saw a version byte the
+	// current build does not know how to parse. Reserved values per §11.3.
+	ErrEnvelopeVersion = errors.New("encryption: unknown envelope version")
+)

--- a/internal/encryption/errors.go
+++ b/internal/encryption/errors.go
@@ -39,4 +39,12 @@ var (
 	// Surfaced at construction time so a wiring mistake is caught
 	// before the first Encrypt/Decrypt would otherwise nil-deref panic.
 	ErrNilKeystore = errors.New("encryption: keystore is nil")
+
+	// ErrKeyConflict indicates Keystore.Set was called with a keyID
+	// already loaded under DIFFERENT key material. Replacing live key
+	// bytes for an in-use key_id would render every envelope already
+	// persisted under that id undecryptable, so Set fails closed
+	// rather than silently overwriting. Set with the SAME bytes is
+	// idempotent (returns nil) and does not raise this error.
+	ErrKeyConflict = errors.New("encryption: key_id already loaded with different key material")
 )

--- a/internal/encryption/kek/file.go
+++ b/internal/encryption/kek/file.go
@@ -81,6 +81,10 @@ func (w *FileWrapper) Wrap(dek []byte) ([]byte, error) {
 // the AEAD library (the parent encryption package's ErrIntegrity is the
 // caller's responsibility to wrap, since this package must stay
 // dependency-free of the parent).
+//
+// The post-Open length check that earlier drafts had was unreachable —
+// the strict-length input check above guarantees Open returns exactly
+// fileKEKSize bytes on success — and has been removed.
 func (w *FileWrapper) Unwrap(wrapped []byte) ([]byte, error) {
 	if len(wrapped) != fileNonceSize+fileKEKSize+fileTagSize {
 		return nil, errors.Errorf("kek: wrapped DEK is %d bytes, want %d",
@@ -92,12 +96,10 @@ func (w *FileWrapper) Unwrap(wrapped []byte) ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "kek: AES-GCM Open")
 	}
-	if len(plain) != fileKEKSize {
-		return nil, errors.Errorf("kek: unwrapped DEK is %d bytes, want %d",
-			len(plain), fileKEKSize)
-	}
 	return plain, nil
 }
 
-// Name implements Wrapper.
-func (*FileWrapper) Name() string { return "file" }
+// Name returns the provider id plus the file path so log lines and the
+// EncryptionAdmin status RPC let an operator distinguish multiple
+// configured KEKs without grepping config.
+func (w *FileWrapper) Name() string { return "file:" + w.path }

--- a/internal/encryption/kek/file.go
+++ b/internal/encryption/kek/file.go
@@ -73,6 +73,11 @@ func (w *FileWrapper) Wrap(dek []byte) ([]byte, error) {
 	}
 	out := make([]byte, 0, fileNonceSize+fileKEKSize+fileTagSize)
 	out = append(out, nonce...)
+	// AAD is intentionally nil. Key-ID binding at the KEK layer (so a
+	// wrapped DEK from one key_id cannot be replayed under another) is
+	// deferred to Stage 9, when the KMS-backed providers add their own
+	// AAD scheme. Adding AAD here in isolation would silently break
+	// every persisted wrapped-DEK blob.
 	out = w.aead.Seal(out, nonce, dek, nil)
 	return out, nil
 }

--- a/internal/encryption/kek/file.go
+++ b/internal/encryption/kek/file.go
@@ -1,0 +1,103 @@
+package kek
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"os"
+
+	"github.com/cockroachdb/errors"
+)
+
+const (
+	// fileKEKSize is the on-disk KEK length: 32 bytes for AES-256.
+	fileKEKSize = 32
+
+	// fileNonceSize is the AES-GCM nonce length the FileWrapper produces.
+	// Same as the package-level encryption.NonceSize constant; redeclared
+	// here to keep this file dependency-free of the parent package.
+	fileNonceSize = 12
+
+	// fileTagSize is the AES-GCM tag length the FileWrapper produces.
+	fileTagSize = 16
+)
+
+// FileWrapper wraps DEKs using AES-256-GCM under a KEK read from a file
+// at construction time.
+//
+// Suitable for tests, single-host clusters, and deployments that store
+// the KEK on a sealed tmpfs volume. Production deployments should
+// prefer a KMS-backed Wrapper (Stage 9: aws_kms.go, gcp_kms.go,
+// vault.go); see §5.1 for the recommended provider ordering.
+type FileWrapper struct {
+	aead cipher.AEAD
+	path string
+}
+
+// NewFileWrapper reads a KEK from path. The file must contain exactly
+// 32 bytes (an AES-256 key). Any other length returns an error rather
+// than silently padding or truncating.
+func NewFileWrapper(path string) (*FileWrapper, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "kek: read %q", path)
+	}
+	if len(raw) != fileKEKSize {
+		return nil, errors.Errorf("kek: file %q is %d bytes, want exactly %d",
+			path, len(raw), fileKEKSize)
+	}
+	block, err := aes.NewCipher(raw)
+	if err != nil {
+		return nil, errors.Wrap(err, "kek: aes.NewCipher")
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, errors.Wrap(err, "kek: cipher.NewGCM")
+	}
+	return &FileWrapper{aead: aead, path: path}, nil
+}
+
+// Wrap returns AES-GCM(KEK, dek) prefixed by a freshly-drawn random
+// nonce. Output layout:
+//
+//	[nonce 12 bytes] [ciphertext 32 bytes] [tag 16 bytes]
+//
+// Total wrapped size: 60 bytes for a 32-byte DEK.
+func (w *FileWrapper) Wrap(dek []byte) ([]byte, error) {
+	if len(dek) != fileKEKSize {
+		return nil, errors.Errorf("kek: dek is %d bytes, want %d", len(dek), fileKEKSize)
+	}
+	nonce := make([]byte, fileNonceSize)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, errors.Wrap(err, "kek: random nonce")
+	}
+	out := make([]byte, 0, fileNonceSize+fileKEKSize+fileTagSize)
+	out = append(out, nonce...)
+	out = w.aead.Seal(out, nonce, dek, nil)
+	return out, nil
+}
+
+// Unwrap reverses Wrap. It returns ErrIntegrity-equivalent errors via
+// the AEAD library (the parent encryption package's ErrIntegrity is the
+// caller's responsibility to wrap, since this package must stay
+// dependency-free of the parent).
+func (w *FileWrapper) Unwrap(wrapped []byte) ([]byte, error) {
+	if len(wrapped) != fileNonceSize+fileKEKSize+fileTagSize {
+		return nil, errors.Errorf("kek: wrapped DEK is %d bytes, want %d",
+			len(wrapped), fileNonceSize+fileKEKSize+fileTagSize)
+	}
+	nonce := wrapped[:fileNonceSize]
+	ct := wrapped[fileNonceSize:]
+	plain, err := w.aead.Open(nil, nonce, ct, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "kek: AES-GCM Open")
+	}
+	if len(plain) != fileKEKSize {
+		return nil, errors.Errorf("kek: unwrapped DEK is %d bytes, want %d",
+			len(plain), fileKEKSize)
+	}
+	return plain, nil
+}
+
+// Name implements Wrapper.
+func (*FileWrapper) Name() string { return "file" }

--- a/internal/encryption/kek/file.go
+++ b/internal/encryption/kek/file.go
@@ -5,9 +5,18 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"os"
+	"runtime"
 
 	"github.com/cockroachdb/errors"
 )
+
+// ErrInsecureKEKFile is returned by NewFileWrapper when the KEK file
+// permission bits permit group or other access. Loading such a file
+// would silently weaken the at-rest encryption boundary on a
+// multi-user host (any local user could read the master key bytes),
+// so the wrapper fails closed rather than warning. Owner-only modes
+// (0o400 / 0o600) are accepted; anything with bits in 0o077 is not.
+var ErrInsecureKEKFile = errors.New("kek: file is group/world-accessible; require owner-only mode")
 
 const (
 	// fileKEKSize is the on-disk KEK length: 32 bytes for AES-256.
@@ -37,8 +46,19 @@ type FileWrapper struct {
 // NewFileWrapper reads a KEK from path. The file must contain exactly
 // 32 bytes (an AES-256 key). Any other length returns an error rather
 // than silently padding or truncating.
+//
+// On unix, the file's permission bits MUST be owner-only (no group or
+// other access bits set, i.e. mode & 0o077 == 0). A misconfigured
+// 0o644 or 0o666 KEK file would let any local user read the master
+// key on a multi-user host, defeating the entire at-rest encryption
+// boundary — NewFileWrapper fails closed with ErrInsecureKEKFile
+// rather than logging a warning. Windows has a fundamentally
+// different permission model and is not gated.
 func NewFileWrapper(path string) (*FileWrapper, error) {
-	raw, err := os.ReadFile(path)
+	if err := checkSecureKEKMode(path); err != nil {
+		return nil, err
+	}
+	raw, err := os.ReadFile(path) //nolint:gosec // path comes from operator config; mode pre-checked above
 	if err != nil {
 		return nil, errors.Wrapf(err, "kek: read %q", path)
 	}
@@ -55,6 +75,23 @@ func NewFileWrapper(path string) (*FileWrapper, error) {
 		return nil, errors.Wrap(err, "kek: cipher.NewGCM")
 	}
 	return &FileWrapper{aead: aead, path: path}, nil
+}
+
+// checkSecureKEKMode rejects a KEK file whose permission bits permit
+// group or other access. Skipped on Windows, where the unix mode
+// model does not apply.
+func checkSecureKEKMode(path string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	st, err := os.Stat(path)
+	if err != nil {
+		return errors.Wrapf(err, "kek: stat %q", path)
+	}
+	if perm := st.Mode().Perm(); perm&0o077 != 0 {
+		return errors.Wrapf(ErrInsecureKEKFile, "%q has mode %#o", path, perm)
+	}
+	return nil
 }
 
 // Wrap returns AES-GCM(KEK, dek) prefixed by a freshly-drawn random

--- a/internal/encryption/kek/file.go
+++ b/internal/encryption/kek/file.go
@@ -19,6 +19,15 @@ import (
 // (0o400 / 0o600) are accepted; anything with bits in 0o077 is not.
 var ErrInsecureKEKFile = errors.New("kek: file is group/world-accessible; require owner-only mode")
 
+// ErrNilFileWrapper is returned by Wrap/Unwrap when called on a nil
+// receiver or a zero-value FileWrapper (i.e. one whose internal AEAD
+// was never initialised by NewFileWrapper). Surfaced as a typed error
+// rather than a nil-deref panic so a wiring mistake during bootstrap
+// or rotation surfaces as a recoverable failure instead of a process
+// crash. Mirrors the encryption.Cipher / encryption.Keystore
+// zero-value contract.
+var ErrNilFileWrapper = errors.New("kek: FileWrapper is nil or uninitialised; construct with NewFileWrapper")
+
 const (
 	// fileKEKSize is the on-disk KEK length: 32 bytes for AES-256.
 	fileKEKSize = 32
@@ -39,6 +48,10 @@ const (
 // the KEK on a sealed tmpfs volume. Production deployments should
 // prefer a KMS-backed Wrapper (Stage 9: aws_kms.go, gcp_kms.go,
 // vault.go); see §5.1 for the recommended provider ordering.
+//
+// The zero value is NOT safe to use: Wrap/Unwrap return
+// ErrNilFileWrapper for a nil pointer or a FileWrapper whose internal
+// AEAD was never initialised. Always construct via NewFileWrapper.
 type FileWrapper struct {
 	aead cipher.AEAD
 	path string
@@ -130,7 +143,15 @@ func checkSecureKEKModeFD(f *os.File, path string) error {
 //	[nonce 12 bytes] [ciphertext 32 bytes] [tag 16 bytes]
 //
 // Total wrapped size: 60 bytes for a 32-byte DEK.
+//
+// Returns ErrNilFileWrapper if w is nil or the embedded AEAD was
+// never initialised by NewFileWrapper. A wiring/configuration
+// mistake during bootstrap or rotation surfaces as a typed error
+// rather than a nil-deref panic.
 func (w *FileWrapper) Wrap(dek []byte) ([]byte, error) {
+	if w == nil || w.aead == nil {
+		return nil, errors.WithStack(ErrNilFileWrapper)
+	}
 	if len(dek) != fileKEKSize {
 		return nil, errors.Errorf("kek: dek is %d bytes, want %d", len(dek), fileKEKSize)
 	}
@@ -157,7 +178,13 @@ func (w *FileWrapper) Wrap(dek []byte) ([]byte, error) {
 // The post-Open length check that earlier drafts had was unreachable —
 // the strict-length input check above guarantees Open returns exactly
 // fileKEKSize bytes on success — and has been removed.
+//
+// Returns ErrNilFileWrapper for a nil receiver or zero-value
+// FileWrapper, symmetric with Wrap.
 func (w *FileWrapper) Unwrap(wrapped []byte) ([]byte, error) {
+	if w == nil || w.aead == nil {
+		return nil, errors.WithStack(ErrNilFileWrapper)
+	}
 	if len(wrapped) != fileNonceSize+fileKEKSize+fileTagSize {
 		return nil, errors.Errorf("kek: wrapped DEK is %d bytes, want %d",
 			len(wrapped), fileNonceSize+fileKEKSize+fileTagSize)

--- a/internal/encryption/kek/file.go
+++ b/internal/encryption/kek/file.go
@@ -44,9 +44,9 @@ type FileWrapper struct {
 	path string
 }
 
-// NewFileWrapper reads a KEK from path. The file must contain exactly
-// 32 bytes (an AES-256 key). Any other length returns an error rather
-// than silently padding or truncating.
+// NewFileWrapper reads a KEK from path. The file must be a regular
+// file containing exactly 32 bytes (an AES-256 key). Any other length
+// returns an error rather than silently padding or truncating.
 //
 // On unix, the file's permission bits MUST be owner-only (no group or
 // other access bits set, i.e. mode & 0o077 == 0). A misconfigured
@@ -60,8 +60,13 @@ type FileWrapper struct {
 // path swap (or symlink retarget) between checks cannot race the
 // load. f.Stat resolves the inode behind the open fd, not the path,
 // so what is validated is exactly what is read.
+//
+// The read is bounded to fileKEKSize+1 bytes and is preceded by a
+// "regular file" stat check, so a misconfigured path pointing at a
+// FIFO, device, or huge file (a misaligned cluster bootstrap could
+// otherwise hang or OOM on /dev/zero) fails fast.
 func NewFileWrapper(path string) (*FileWrapper, error) {
-	f, err := os.Open(path) //nolint:gosec // path comes from operator config; mode is checked via f.Stat below
+	f, err := os.OpenFile(path, os.O_RDONLY|kekOpenExtraFlags, 0) //nolint:gosec // path comes from operator config; mode/type checked via f.Stat below
 	if err != nil {
 		return nil, errors.Wrapf(err, "kek: open %q", path)
 	}
@@ -70,7 +75,13 @@ func NewFileWrapper(path string) (*FileWrapper, error) {
 	if err := checkSecureKEKModeFD(f, path); err != nil {
 		return nil, err
 	}
-	raw, err := io.ReadAll(f)
+	// io.LimitReader caps the read at fileKEKSize+1: a well-formed KEK
+	// fits in fileKEKSize bytes, so a +1 budget is exactly enough to
+	// distinguish "right size" (read returns N == fileKEKSize, EOF)
+	// from "too long" (read returns N == fileKEKSize+1, no EOF). Any
+	// larger file or unbounded source (e.g. /dev/zero) is rejected at
+	// the same length-check site without first allocating a slab.
+	raw, err := io.ReadAll(io.LimitReader(f, fileKEKSize+1))
 	if err != nil {
 		return nil, errors.Wrapf(err, "kek: read %q", path)
 	}
@@ -90,17 +101,22 @@ func NewFileWrapper(path string) (*FileWrapper, error) {
 }
 
 // checkSecureKEKModeFD rejects a KEK file whose permission bits permit
-// group or other access. Operates on an already-open *os.File so the
-// stat and the subsequent read share the same inode (closes the
-// TOCTOU window an os.Stat-then-ReadFile pair would leave open).
-// Skipped on Windows, where the unix mode model does not apply.
+// group or other access, and rejects non-regular files (FIFO, device,
+// directory, etc.). Operates on an already-open *os.File so the stat
+// and the subsequent read share the same inode (closes the TOCTOU
+// window an os.Stat-then-ReadFile pair would leave open). The
+// non-regular reject is unix and Windows; the perm reject is unix
+// only.
 func checkSecureKEKModeFD(f *os.File, path string) error {
-	if runtime.GOOS == "windows" {
-		return nil
-	}
 	st, err := f.Stat()
 	if err != nil {
 		return errors.Wrapf(err, "kek: stat %q", path)
+	}
+	if !st.Mode().IsRegular() {
+		return errors.Errorf("kek: %q is not a regular file (mode=%v)", path, st.Mode())
+	}
+	if runtime.GOOS == "windows" {
+		return nil
 	}
 	if perm := st.Mode().Perm(); perm&0o077 != 0 {
 		return errors.Wrapf(ErrInsecureKEKFile, "%q has mode %#o", path, perm)

--- a/internal/encryption/kek/file.go
+++ b/internal/encryption/kek/file.go
@@ -4,6 +4,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"io"
 	"os"
 	"runtime"
 
@@ -54,11 +55,22 @@ type FileWrapper struct {
 // boundary — NewFileWrapper fails closed with ErrInsecureKEKFile
 // rather than logging a warning. Windows has a fundamentally
 // different permission model and is not gated.
+//
+// The mode check and the key-bytes read share a single os.File so a
+// path swap (or symlink retarget) between checks cannot race the
+// load. f.Stat resolves the inode behind the open fd, not the path,
+// so what is validated is exactly what is read.
 func NewFileWrapper(path string) (*FileWrapper, error) {
-	if err := checkSecureKEKMode(path); err != nil {
+	f, err := os.Open(path) //nolint:gosec // path comes from operator config; mode is checked via f.Stat below
+	if err != nil {
+		return nil, errors.Wrapf(err, "kek: open %q", path)
+	}
+	defer func() { _ = f.Close() }()
+
+	if err := checkSecureKEKModeFD(f, path); err != nil {
 		return nil, err
 	}
-	raw, err := os.ReadFile(path) //nolint:gosec // path comes from operator config; mode pre-checked above
+	raw, err := io.ReadAll(f)
 	if err != nil {
 		return nil, errors.Wrapf(err, "kek: read %q", path)
 	}
@@ -77,14 +89,16 @@ func NewFileWrapper(path string) (*FileWrapper, error) {
 	return &FileWrapper{aead: aead, path: path}, nil
 }
 
-// checkSecureKEKMode rejects a KEK file whose permission bits permit
-// group or other access. Skipped on Windows, where the unix mode
-// model does not apply.
-func checkSecureKEKMode(path string) error {
+// checkSecureKEKModeFD rejects a KEK file whose permission bits permit
+// group or other access. Operates on an already-open *os.File so the
+// stat and the subsequent read share the same inode (closes the
+// TOCTOU window an os.Stat-then-ReadFile pair would leave open).
+// Skipped on Windows, where the unix mode model does not apply.
+func checkSecureKEKModeFD(f *os.File, path string) error {
 	if runtime.GOOS == "windows" {
 		return nil
 	}
-	st, err := os.Stat(path)
+	st, err := f.Stat()
 	if err != nil {
 		return errors.Wrapf(err, "kek: stat %q", path)
 	}

--- a/internal/encryption/kek/file_fifo_unix_test.go
+++ b/internal/encryption/kek/file_fifo_unix_test.go
@@ -1,0 +1,47 @@
+//go:build !windows
+
+package kek_test
+
+import (
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/bootjp/elastickv/internal/encryption/kek"
+)
+
+// TestFileWrapper_RejectsFIFO covers the unbounded-read DoS vector
+// codex flagged on PR #719: a path pointing at a FIFO without a
+// writer would hang NewFileWrapper indefinitely if either the
+// O_NONBLOCK open flag or the IsRegular() stat reject were
+// removed. The goroutine+timeout makes a regression in either
+// surface as a deterministic test failure rather than a hung run.
+//
+// Unix-only: syscall.Mkfifo is not portable to Windows, and Windows
+// named pipes use a different syscall path that we don't try to
+// model here.
+func TestFileWrapper_RejectsFIFO(t *testing.T) {
+	dir := t.TempDir()
+	fifoPath := filepath.Join(dir, "kek.fifo")
+	if err := syscall.Mkfifo(fifoPath, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported in this environment: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, err := kek.NewFileWrapper(fifoPath)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("NewFileWrapper accepted a FIFO")
+		}
+		if !strings.Contains(err.Error(), "regular file") {
+			t.Fatalf("expected regular-file error, got: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("NewFileWrapper hung on a FIFO (O_NONBLOCK or IsRegular missing?)")
+	}
+}

--- a/internal/encryption/kek/file_test.go
+++ b/internal/encryption/kek/file_test.go
@@ -174,8 +174,9 @@ func TestFileWrapper_Name(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewFileWrapper: %v", err)
 	}
-	if w.Name() != "file" {
-		t.Fatalf("Name() = %q, want %q", w.Name(), "file")
+	want := "file:" + path
+	if w.Name() != want {
+		t.Fatalf("Name() = %q, want %q", w.Name(), want)
 	}
 }
 

--- a/internal/encryption/kek/file_test.go
+++ b/internal/encryption/kek/file_test.go
@@ -1,0 +1,188 @@
+package kek_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption/kek"
+)
+
+func writeKEK(t *testing.T, n int) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kek.bin")
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	if err := os.WriteFile(path, buf, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path
+}
+
+func TestFileWrapper_RoundTrip(t *testing.T) {
+	path := writeKEK(t, 32)
+	w, err := kek.NewFileWrapper(path)
+	if err != nil {
+		t.Fatalf("NewFileWrapper: %v", err)
+	}
+	dek := make([]byte, 32)
+	if _, err := rand.Read(dek); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	wrapped, err := w.Wrap(dek)
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+	if got, want := len(wrapped), 12+32+16; got != want {
+		t.Fatalf("wrapped len = %d, want %d", got, want)
+	}
+	got, err := w.Unwrap(wrapped)
+	if err != nil {
+		t.Fatalf("Unwrap: %v", err)
+	}
+	if !bytes.Equal(got, dek) {
+		t.Fatal("Unwrap returned different bytes than Wrap input")
+	}
+}
+
+func TestFileWrapper_DifferentNonceEachWrap(t *testing.T) {
+	path := writeKEK(t, 32)
+	w, err := kek.NewFileWrapper(path)
+	if err != nil {
+		t.Fatalf("NewFileWrapper: %v", err)
+	}
+	dek := make([]byte, 32)
+	w1, err := w.Wrap(dek)
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+	w2, err := w.Wrap(dek)
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+	// Even with the same DEK, distinct nonces must produce distinct
+	// wrapped outputs.
+	if bytes.Equal(w1, w2) {
+		t.Fatal("two Wrap calls produced identical output (nonce reuse)")
+	}
+	// First 12 bytes are the random nonce; they must differ.
+	if bytes.Equal(w1[:12], w2[:12]) {
+		t.Fatal("nonce did not change between Wrap calls")
+	}
+}
+
+func TestFileWrapper_RejectsBadKEKLength(t *testing.T) {
+	for _, n := range []int{0, 1, 16, 24, 31, 33, 64} {
+		path := writeKEK(t, n)
+		_, err := kek.NewFileWrapper(path)
+		if err == nil {
+			t.Fatalf("expected error for %d-byte KEK, got nil", n)
+		}
+	}
+}
+
+func TestFileWrapper_RejectsBadDEKLength(t *testing.T) {
+	path := writeKEK(t, 32)
+	w, err := kek.NewFileWrapper(path)
+	if err != nil {
+		t.Fatalf("NewFileWrapper: %v", err)
+	}
+	for _, n := range []int{0, 1, 16, 31, 33} {
+		_, err := w.Wrap(make([]byte, n))
+		if err == nil {
+			t.Fatalf("expected error for %d-byte DEK, got nil", n)
+		}
+	}
+}
+
+func TestFileWrapper_Unwrap_TamperedNonce(t *testing.T) {
+	path := writeKEK(t, 32)
+	w, err := kek.NewFileWrapper(path)
+	if err != nil {
+		t.Fatalf("NewFileWrapper: %v", err)
+	}
+	dek := make([]byte, 32)
+	wrapped, err := w.Wrap(dek)
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+	wrapped[0] ^= 0x01 // flip a nonce bit
+	_, err = w.Unwrap(wrapped)
+	if err == nil {
+		t.Fatal("expected error on tampered nonce, got nil")
+	}
+}
+
+func TestFileWrapper_Unwrap_TamperedTag(t *testing.T) {
+	path := writeKEK(t, 32)
+	w, err := kek.NewFileWrapper(path)
+	if err != nil {
+		t.Fatalf("NewFileWrapper: %v", err)
+	}
+	dek := make([]byte, 32)
+	wrapped, err := w.Wrap(dek)
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+	wrapped[len(wrapped)-1] ^= 0x01 // flip a tag bit
+	_, err = w.Unwrap(wrapped)
+	if err == nil {
+		t.Fatal("expected error on tampered tag, got nil")
+	}
+}
+
+func TestFileWrapper_Unwrap_TooShort(t *testing.T) {
+	path := writeKEK(t, 32)
+	w, err := kek.NewFileWrapper(path)
+	if err != nil {
+		t.Fatalf("NewFileWrapper: %v", err)
+	}
+	for _, n := range []int{0, 11, 12, 30, 59} { // < 12+32+16
+		_, err := w.Unwrap(make([]byte, n))
+		if err == nil {
+			t.Fatalf("expected error for %d-byte wrapped, got nil", n)
+		}
+	}
+}
+
+func TestFileWrapper_Unwrap_TooLong(t *testing.T) {
+	path := writeKEK(t, 32)
+	w, err := kek.NewFileWrapper(path)
+	if err != nil {
+		t.Fatalf("NewFileWrapper: %v", err)
+	}
+	dek := make([]byte, 32)
+	wrapped, err := w.Wrap(dek)
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+	wrapped = append(wrapped, 0x00)
+	_, err = w.Unwrap(wrapped)
+	if err == nil {
+		t.Fatal("expected error for over-length wrapped, got nil")
+	}
+}
+
+func TestFileWrapper_Name(t *testing.T) {
+	path := writeKEK(t, 32)
+	w, err := kek.NewFileWrapper(path)
+	if err != nil {
+		t.Fatalf("NewFileWrapper: %v", err)
+	}
+	if w.Name() != "file" {
+		t.Fatalf("Name() = %q, want %q", w.Name(), "file")
+	}
+}
+
+func TestFileWrapper_NewFileWrapper_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	_, err := kek.NewFileWrapper(filepath.Join(dir, "does-not-exist.bin"))
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}

--- a/internal/encryption/kek/file_test.go
+++ b/internal/encryption/kek/file_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/bootjp/elastickv/internal/encryption/kek"
@@ -263,5 +264,46 @@ func TestFileWrapper_AcceptsOwnerOnlyMode(t *testing.T) {
 		if w == nil {
 			t.Fatalf("nil wrapper for mode %o", mode)
 		}
+	}
+}
+
+// TestFileWrapper_RejectsOversizedFile is the regression for the PR
+// #719 codex P2 finding: io.ReadAll without a size bound would read
+// gigabytes of garbage before checking length. NewFileWrapper now
+// caps the read at fileKEKSize+1 so a too-long file fails fast on
+// the length check without exhausting memory.
+func TestFileWrapper_RejectsOversizedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kek.bin")
+	// 64 KiB — large enough that an unbounded ReadAll would observably
+	// pull more than fileKEKSize+1; small enough to not be a real
+	// resource problem if the bound regresses.
+	buf := make([]byte, 64<<10)
+	if _, err := rand.Read(buf); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	if err := os.WriteFile(path, buf, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err := kek.NewFileWrapper(path)
+	if err == nil {
+		t.Fatal("NewFileWrapper accepted an oversized file")
+	}
+	if !strings.Contains(err.Error(), "want exactly 32") {
+		t.Fatalf("expected length error, got: %v", err)
+	}
+}
+
+// TestFileWrapper_RejectsDirectory is the lower-cost cousin to the
+// FIFO test: a directory is also a non-regular file. Works on every
+// platform (no syscall.Mkfifo dependency).
+func TestFileWrapper_RejectsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	_, err := kek.NewFileWrapper(dir)
+	if err == nil {
+		t.Fatal("NewFileWrapper accepted a directory path")
+	}
+	if !strings.Contains(err.Error(), "regular file") {
+		t.Fatalf("expected regular-file error, got: %v", err)
 	}
 }

--- a/internal/encryption/kek/file_test.go
+++ b/internal/encryption/kek/file_test.go
@@ -5,9 +5,11 @@ import (
 	"crypto/rand"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/bootjp/elastickv/internal/encryption/kek"
+	"github.com/cockroachdb/errors"
 )
 
 func writeKEK(t *testing.T, n int) string {
@@ -185,5 +187,81 @@ func TestFileWrapper_NewFileWrapper_MissingFile(t *testing.T) {
 	_, err := kek.NewFileWrapper(filepath.Join(dir, "does-not-exist.bin"))
 	if err == nil {
 		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+// TestFileWrapper_RejectsInsecureMode covers the PR #719 CodeRabbit
+// Major finding: a 0o644 / 0o666 KEK file would still be loaded under
+// the previous implementation, weakening the at-rest encryption
+// boundary on a multi-user host. NewFileWrapper now stat()s the file
+// and refuses anything with bits in 0o077.
+func TestFileWrapper_RejectsInsecureMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not enforced on Windows")
+	}
+	cases := []struct {
+		name string
+		mode os.FileMode
+	}{
+		{"group-readable 0o640", 0o640},
+		{"world-readable 0o644", 0o644},
+		{"group/world-writable 0o666", 0o666},
+		{"group-execute 0o610", 0o610},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "kek.bin")
+			buf := make([]byte, 32)
+			if _, err := rand.Read(buf); err != nil {
+				t.Fatalf("rand.Read: %v", err)
+			}
+			// Write at the secure mode first (gosec G306 forbids
+			// >0o600 in WriteFile), then chmod to the insecure target.
+			if err := os.WriteFile(path, buf, 0o600); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			if err := os.Chmod(path, tc.mode); err != nil {
+				t.Fatalf("Chmod %o: %v", tc.mode, err)
+			}
+			st, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("Stat: %v", err)
+			}
+			if st.Mode().Perm() != tc.mode {
+				t.Skipf("environment refused mode %o (got %o)", tc.mode, st.Mode().Perm())
+			}
+			_, err = kek.NewFileWrapper(path)
+			if !errors.Is(err, kek.ErrInsecureKEKFile) {
+				t.Fatalf("expected ErrInsecureKEKFile for mode %o, got %v", tc.mode, err)
+			}
+		})
+	}
+}
+
+func TestFileWrapper_AcceptsOwnerOnlyMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not enforced on Windows")
+	}
+	for _, mode := range []os.FileMode{0o400, 0o600} {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "kek.bin")
+		buf := make([]byte, 32)
+		if _, err := rand.Read(buf); err != nil {
+			t.Fatalf("rand.Read: %v", err)
+		}
+		if err := os.WriteFile(path, buf, 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if err := os.Chmod(path, mode); err != nil {
+			t.Fatalf("Chmod %o: %v", mode, err)
+		}
+		w, err := kek.NewFileWrapper(path)
+		if err != nil {
+			t.Fatalf("NewFileWrapper(mode=%o): %v", mode, err)
+		}
+		if w == nil {
+			t.Fatalf("nil wrapper for mode %o", mode)
+		}
 	}
 }

--- a/internal/encryption/kek/file_test.go
+++ b/internal/encryption/kek/file_test.go
@@ -307,3 +307,36 @@ func TestFileWrapper_RejectsDirectory(t *testing.T) {
 		t.Fatalf("expected regular-file error, got: %v", err)
 	}
 }
+
+// TestFileWrapper_NilOrZeroValueRejected covers the PR #719 codex P2
+// finding: a wiring/configuration mistake in a bootstrap or rotation
+// path could hand callers a nil *FileWrapper or a zero-value
+// FileWrapper{}, and Wrap/Unwrap dereference w.aead unconditionally.
+// They now return ErrNilFileWrapper symmetrically with the
+// encryption.Cipher / encryption.Keystore zero-value contract.
+func TestFileWrapper_NilOrZeroValueRejected(t *testing.T) {
+	t.Parallel()
+	dek := make([]byte, 32)
+	wrapped := make([]byte, 60)
+	cases := []struct {
+		name string
+		w    *kek.FileWrapper
+	}{
+		{"nil receiver", (*kek.FileWrapper)(nil)},
+		{"zero-value", &kek.FileWrapper{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name+"/Wrap", func(t *testing.T) {
+			_, err := tc.w.Wrap(dek)
+			if !errors.Is(err, kek.ErrNilFileWrapper) {
+				t.Fatalf("expected ErrNilFileWrapper, got %v", err)
+			}
+		})
+		t.Run(tc.name+"/Unwrap", func(t *testing.T) {
+			_, err := tc.w.Unwrap(wrapped)
+			if !errors.Is(err, kek.ErrNilFileWrapper) {
+				t.Fatalf("expected ErrNilFileWrapper, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/encryption/kek/file_unix.go
+++ b/internal/encryption/kek/file_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package kek
+
+import "syscall"
+
+// kekOpenExtraFlags carries O_NONBLOCK on unix so a path that points
+// at a FIFO with no writer (one of the DoS shapes the §5.1
+// fail-closed-on-bad-KEK rule defends against) does not hang
+// NewFileWrapper at the os.OpenFile call before the regular-file
+// stat check can run. The non-blocking flag has no effect on
+// regular files.
+const kekOpenExtraFlags = syscall.O_NONBLOCK

--- a/internal/encryption/kek/file_windows.go
+++ b/internal/encryption/kek/file_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package kek
+
+// kekOpenExtraFlags is 0 on Windows: there is no portable O_NONBLOCK,
+// and the FIFO-block scenario it guards against on unix does not
+// apply to a regular Windows file path. The IsRegular() check on
+// the fd's stat is enough to reject pipes, devices, and directories.
+const kekOpenExtraFlags = 0

--- a/internal/encryption/kek/kek.go
+++ b/internal/encryption/kek/kek.go
@@ -1,0 +1,30 @@
+// Package kek implements KEK (Key Encryption Key) providers that wrap
+// and unwrap DEKs (Data Encryption Keys) per §5.1 of the data-at-rest
+// encryption design.
+//
+// The KEK never appears in elastickv's data dir. It is held externally —
+// in a KMS, a sealed file, or HashiCorp Vault — and only exercised at
+// process boot and at DEK rotation.
+//
+// Stage 0 ships only the FileWrapper for tests / single-host clusters.
+// AWS KMS, GCP KMS, and Vault providers are added in Stage 9.
+package kek
+
+// Wrapper wraps and unwraps DEK bytes under an externally-held KEK.
+//
+// Wrap input is always exactly encryption.KeySize (32) bytes; the
+// wrapped output's exact size depends on the provider but is at least
+// the input size plus an AEAD nonce and tag (or KMS protocol overhead).
+//
+// Implementations MUST be safe for concurrent use by multiple goroutines
+// because the encryption Keystore may issue Wrap/Unwrap from rotation
+// and resync paths simultaneously.
+type Wrapper interface {
+	Wrap(dek []byte) ([]byte, error)
+	Unwrap(wrapped []byte) ([]byte, error)
+
+	// Name returns a short identifier of the KEK source ("file",
+	// "aws-kms", "gcp-kms", "vault", "env"). Surfaces in logs and the
+	// EncryptionAdmin status RPC.
+	Name() string
+}

--- a/internal/encryption/keystore.go
+++ b/internal/encryption/keystore.go
@@ -11,14 +11,12 @@ import (
 
 // keyEntry holds a single DEK plus its pre-initialized AEAD instance. The
 // AEAD is built once at Set time so the hot path (Cipher.Encrypt /
-// Cipher.Decrypt) never pays for aes.NewCipher / cipher.NewGCM —
-// per-call key expansion would be a measurable regression in any
-// production-realistic write rate (gemini-code-assist review on PR #719).
+// Cipher.Decrypt) never pays for aes.NewCipher / cipher.NewGCM on every
+// call.
 //
 // dek is stored as a fixed-size array rather than a slice so the type
-// system enforces immutability: callers of DEK() get a value copy, not a
-// pointer into the live map. This closes the "Get returns mutable slice"
-// hazard flagged by claude[bot] review.
+// system enforces immutability: callers of DEK() receive a value copy,
+// not a pointer into the live map.
 type keyEntry struct {
 	dek  [KeySize]byte
 	aead cipher.AEAD
@@ -32,6 +30,11 @@ type keyEntry struct {
 //
 // Per §10 self-review lens 2: this avoids contending a mutex on the hot
 // path while keeping rotation atomic with respect to readers.
+//
+// The zero value is NOT safe to use — `var ks Keystore` panics on the
+// first method call because the internal atomic.Pointer is nil. Always
+// construct with NewKeystore. Code that embeds a Keystore in another
+// struct must invoke NewKeystore explicitly before any read or write.
 type Keystore struct {
 	snap atomic.Pointer[map[uint32]*keyEntry]
 }

--- a/internal/encryption/keystore.go
+++ b/internal/encryption/keystore.go
@@ -1,0 +1,109 @@
+package encryption
+
+import (
+	"sort"
+	"sync/atomic"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Keystore is a copy-on-write map from key_id to DEK bytes.
+//
+// Reads on the hot path (Cipher.Encrypt / Cipher.Decrypt) take a single
+// atomic load and observe an immutable snapshot of the DEK map. Writes
+// (rotation, bootstrap, retire) allocate a new map and CAS it in via
+// atomic.Pointer.Store.
+//
+// Per §10 self-review lens 2: this avoids contending a mutex on the hot
+// path while keeping rotation atomic with respect to readers.
+type Keystore struct {
+	snap atomic.Pointer[map[uint32][]byte]
+}
+
+// NewKeystore returns an empty Keystore.
+func NewKeystore() *Keystore {
+	ks := &Keystore{}
+	empty := map[uint32][]byte{}
+	ks.snap.Store(&empty)
+	return ks
+}
+
+// Get returns the DEK bytes for keyID and whether it was found.
+//
+// The returned slice MUST NOT be modified by the caller; the keystore
+// treats DEK bytes as immutable so an atomic.Pointer load is sufficient.
+// Callers that need to mutate must Clone first.
+func (k *Keystore) Get(keyID uint32) ([]byte, bool) {
+	m := *k.snap.Load()
+	dek, ok := m[keyID]
+	return dek, ok
+}
+
+// Has reports whether keyID is loaded. Equivalent to the second return of
+// Get without exposing the bytes.
+func (k *Keystore) Has(keyID uint32) bool {
+	m := *k.snap.Load()
+	_, ok := m[keyID]
+	return ok
+}
+
+// Set installs a DEK under keyID. dek must be exactly KeySize bytes; the
+// reserved key_id 0 is rejected with ErrReservedKeyID. The DEK bytes are
+// copied so the caller is free to zero or reuse the source slice.
+func (k *Keystore) Set(keyID uint32, dek []byte) error {
+	if keyID == ReservedKeyID {
+		return errors.WithStack(ErrReservedKeyID)
+	}
+	if len(dek) != KeySize {
+		return errors.Wrapf(ErrBadKeySize, "got %d bytes, want %d", len(dek), KeySize)
+	}
+	cp := make([]byte, KeySize)
+	copy(cp, dek)
+
+	for {
+		cur := k.snap.Load()
+		m := make(map[uint32][]byte, len(*cur)+1)
+		for id, v := range *cur {
+			m[id] = v
+		}
+		m[keyID] = cp
+		if k.snap.CompareAndSwap(cur, &m) {
+			return nil
+		}
+	}
+}
+
+// Delete removes the DEK for keyID. No-op if absent.
+func (k *Keystore) Delete(keyID uint32) {
+	for {
+		cur := k.snap.Load()
+		if _, ok := (*cur)[keyID]; !ok {
+			return
+		}
+		m := make(map[uint32][]byte, len(*cur))
+		for id, v := range *cur {
+			if id != keyID {
+				m[id] = v
+			}
+		}
+		if k.snap.CompareAndSwap(cur, &m) {
+			return
+		}
+	}
+}
+
+// IDs returns a sorted snapshot of all currently-loaded key_ids.
+func (k *Keystore) IDs() []uint32 {
+	m := *k.snap.Load()
+	ids := make([]uint32, 0, len(m))
+	for id := range m {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
+// Len reports the number of currently-loaded keys.
+func (k *Keystore) Len() int {
+	return len(*k.snap.Load())
+}

--- a/internal/encryption/keystore.go
+++ b/internal/encryption/keystore.go
@@ -1,55 +1,92 @@
 package encryption
 
 import (
-	"sort"
+	"crypto/aes"
+	"crypto/cipher"
+	"slices"
 	"sync/atomic"
 
 	"github.com/cockroachdb/errors"
 )
 
-// Keystore is a copy-on-write map from key_id to DEK bytes.
+// keyEntry holds a single DEK plus its pre-initialized AEAD instance. The
+// AEAD is built once at Set time so the hot path (Cipher.Encrypt /
+// Cipher.Decrypt) never pays for aes.NewCipher / cipher.NewGCM —
+// per-call key expansion would be a measurable regression in any
+// production-realistic write rate (gemini-code-assist review on PR #719).
 //
-// Reads on the hot path (Cipher.Encrypt / Cipher.Decrypt) take a single
-// atomic load and observe an immutable snapshot of the DEK map. Writes
-// (rotation, bootstrap, retire) allocate a new map and CAS it in via
-// atomic.Pointer.Store.
+// dek is stored as a fixed-size array rather than a slice so the type
+// system enforces immutability: callers of DEK() get a value copy, not a
+// pointer into the live map. This closes the "Get returns mutable slice"
+// hazard flagged by claude[bot] review.
+type keyEntry struct {
+	dek  [KeySize]byte
+	aead cipher.AEAD
+}
+
+// Keystore is a copy-on-write map from key_id to (DEK, pre-init AEAD).
+//
+// Reads on the hot path take a single atomic load and observe an
+// immutable snapshot of the map. Writes (rotation, bootstrap, retire)
+// allocate a new map and CAS it in via atomic.Pointer.Store.
 //
 // Per §10 self-review lens 2: this avoids contending a mutex on the hot
 // path while keeping rotation atomic with respect to readers.
 type Keystore struct {
-	snap atomic.Pointer[map[uint32][]byte]
+	snap atomic.Pointer[map[uint32]*keyEntry]
 }
 
 // NewKeystore returns an empty Keystore.
 func NewKeystore() *Keystore {
 	ks := &Keystore{}
-	empty := map[uint32][]byte{}
+	empty := map[uint32]*keyEntry{}
 	ks.snap.Store(&empty)
 	return ks
 }
 
-// Get returns the DEK bytes for keyID and whether it was found.
+// AEAD returns the pre-initialized cipher.AEAD for keyID, ready for
+// Seal/Open. The returned value is safe for concurrent use by multiple
+// goroutines (Go stdlib AEAD implementations are stateless after
+// initialization).
 //
-// The returned slice MUST NOT be modified by the caller; the keystore
-// treats DEK bytes as immutable so an atomic.Pointer load is sufficient.
-// Callers that need to mutate must Clone first.
-func (k *Keystore) Get(keyID uint32) ([]byte, bool) {
+// Used by Cipher.Encrypt / Cipher.Decrypt on the hot path. Returns
+// (nil, false) if keyID is not loaded.
+func (k *Keystore) AEAD(keyID uint32) (cipher.AEAD, bool) {
 	m := *k.snap.Load()
-	dek, ok := m[keyID]
-	return dek, ok
+	e, ok := m[keyID]
+	if !ok {
+		return nil, false
+	}
+	return e.aead, true
 }
 
-// Has reports whether keyID is loaded. Equivalent to the second return of
-// Get without exposing the bytes.
+// DEK returns the raw 32-byte DEK for keyID. The returned array is a
+// value copy — callers are free to mutate it without affecting the
+// keystore. The bool reports whether keyID is loaded.
+//
+// Most call sites should use AEAD instead; DEK is provided for the
+// rotation / rewrap path that needs the raw key material to wrap it
+// under a new KEK.
+func (k *Keystore) DEK(keyID uint32) ([KeySize]byte, bool) {
+	m := *k.snap.Load()
+	e, ok := m[keyID]
+	if !ok {
+		return [KeySize]byte{}, false
+	}
+	return e.dek, true
+}
+
+// Has reports whether keyID is loaded.
 func (k *Keystore) Has(keyID uint32) bool {
 	m := *k.snap.Load()
 	_, ok := m[keyID]
 	return ok
 }
 
-// Set installs a DEK under keyID. dek must be exactly KeySize bytes; the
-// reserved key_id 0 is rejected with ErrReservedKeyID. The DEK bytes are
-// copied so the caller is free to zero or reuse the source slice.
+// Set installs a DEK under keyID and pre-initializes the cipher.AEAD.
+// dek must be exactly KeySize bytes; the reserved key_id 0 is rejected
+// with ErrReservedKeyID. The DEK bytes are copied into the keystore so
+// the caller is free to zero or reuse the source slice.
 func (k *Keystore) Set(keyID uint32, dek []byte) error {
 	if keyID == ReservedKeyID {
 		return errors.WithStack(ErrReservedKeyID)
@@ -57,16 +94,25 @@ func (k *Keystore) Set(keyID uint32, dek []byte) error {
 	if len(dek) != KeySize {
 		return errors.Wrapf(ErrBadKeySize, "got %d bytes, want %d", len(dek), KeySize)
 	}
-	cp := make([]byte, KeySize)
-	copy(cp, dek)
+	entry := &keyEntry{}
+	copy(entry.dek[:], dek)
+	block, err := aes.NewCipher(entry.dek[:])
+	if err != nil {
+		return errors.Wrap(err, "encryption: aes.NewCipher")
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return errors.Wrap(err, "encryption: cipher.NewGCM")
+	}
+	entry.aead = aead
 
 	for {
 		cur := k.snap.Load()
-		m := make(map[uint32][]byte, len(*cur)+1)
+		m := make(map[uint32]*keyEntry, len(*cur)+1)
 		for id, v := range *cur {
 			m[id] = v
 		}
-		m[keyID] = cp
+		m[keyID] = entry
 		if k.snap.CompareAndSwap(cur, &m) {
 			return nil
 		}
@@ -80,7 +126,7 @@ func (k *Keystore) Delete(keyID uint32) {
 		if _, ok := (*cur)[keyID]; !ok {
 			return
 		}
-		m := make(map[uint32][]byte, len(*cur))
+		m := make(map[uint32]*keyEntry, len(*cur))
 		for id, v := range *cur {
 			if id != keyID {
 				m[id] = v
@@ -99,7 +145,7 @@ func (k *Keystore) IDs() []uint32 {
 	for id := range m {
 		ids = append(ids, id)
 	}
-	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	slices.Sort(ids)
 	return ids
 }
 

--- a/internal/encryption/keystore.go
+++ b/internal/encryption/keystore.go
@@ -31,10 +31,12 @@ type keyEntry struct {
 // Per §10 self-review lens 2: this avoids contending a mutex on the hot
 // path while keeping rotation atomic with respect to readers.
 //
-// The zero value is NOT safe to use — `var ks Keystore` panics on the
-// first method call because the internal atomic.Pointer is nil. Always
-// construct with NewKeystore. Code that embeds a Keystore in another
-// struct must invoke NewKeystore explicitly before any read or write.
+// Zero-value safety: a `var ks Keystore` (or a nil *Keystore) is
+// degraded but does not panic — read methods (AEAD, DEK, Has, IDs,
+// Len) treat it as the empty keystore, Delete is a no-op, and Set
+// returns ErrNilKeystore for a nil receiver. Always prefer NewKeystore
+// so an unwrap path that needs to install keys reports the wiring
+// mistake immediately.
 type Keystore struct {
 	snap atomic.Pointer[map[uint32]*keyEntry]
 }
@@ -47,16 +49,33 @@ func NewKeystore() *Keystore {
 	return ks
 }
 
+// loadMap returns the current snapshot map, or nil for a nil receiver
+// or zero-value Keystore (where snap.Load() returns nil because nothing
+// was Stored). Read methods treat a nil map as the empty keystore so a
+// caller that bypasses NewKeystore observes consistent (zero/false)
+// results instead of nil-deref panicking. Mirrors the defensive pattern
+// Cipher uses for ErrNilKeystore.
+func (k *Keystore) loadMap() map[uint32]*keyEntry {
+	if k == nil {
+		return nil
+	}
+	p := k.snap.Load()
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
 // AEAD returns the pre-initialized cipher.AEAD for keyID, ready for
 // Seal/Open. The returned value is safe for concurrent use by multiple
 // goroutines (Go stdlib AEAD implementations are stateless after
 // initialization).
 //
 // Used by Cipher.Encrypt / Cipher.Decrypt on the hot path. Returns
-// (nil, false) if keyID is not loaded.
+// (nil, false) if keyID is not loaded, the receiver is nil, or the
+// Keystore is zero-valued.
 func (k *Keystore) AEAD(keyID uint32) (cipher.AEAD, bool) {
-	m := *k.snap.Load()
-	e, ok := m[keyID]
+	e, ok := k.loadMap()[keyID]
 	if !ok {
 		return nil, false
 	}
@@ -71,8 +90,7 @@ func (k *Keystore) AEAD(keyID uint32) (cipher.AEAD, bool) {
 // rotation / rewrap path that needs the raw key material to wrap it
 // under a new KEK.
 func (k *Keystore) DEK(keyID uint32) ([KeySize]byte, bool) {
-	m := *k.snap.Load()
-	e, ok := m[keyID]
+	e, ok := k.loadMap()[keyID]
 	if !ok {
 		return [KeySize]byte{}, false
 	}
@@ -81,8 +99,7 @@ func (k *Keystore) DEK(keyID uint32) ([KeySize]byte, bool) {
 
 // Has reports whether keyID is loaded.
 func (k *Keystore) Has(keyID uint32) bool {
-	m := *k.snap.Load()
-	_, ok := m[keyID]
+	_, ok := k.loadMap()[keyID]
 	return ok
 }
 
@@ -90,29 +107,34 @@ func (k *Keystore) Has(keyID uint32) bool {
 // dek must be exactly KeySize bytes; the reserved key_id 0 is rejected
 // with ErrReservedKeyID. The DEK bytes are copied into the keystore so
 // the caller is free to zero or reuse the source slice.
+//
+// Set is set-once with idempotent-same semantics: re-Set under an
+// existing keyID with byte-identical DEK is a no-op (returns nil), but
+// Set with DIFFERENT bytes for an already-loaded keyID returns
+// ErrKeyConflict. Replacing live key bytes for a keyID would render
+// every envelope already persisted under that id undecryptable.
+//
+// A nil receiver returns ErrNilKeystore; zero-value Keystores are
+// rejected at the same boundary as Cipher.
 func (k *Keystore) Set(keyID uint32, dek []byte) error {
-	if keyID == ReservedKeyID {
-		return errors.WithStack(ErrReservedKeyID)
+	if k == nil {
+		return errors.WithStack(ErrNilKeystore)
 	}
-	if len(dek) != KeySize {
-		return errors.Wrapf(ErrBadKeySize, "got %d bytes, want %d", len(dek), KeySize)
-	}
-	entry := &keyEntry{}
-	copy(entry.dek[:], dek)
-	block, err := aes.NewCipher(entry.dek[:])
+	entry, err := buildKeyEntry(keyID, dek)
 	if err != nil {
-		return errors.Wrap(err, "encryption: aes.NewCipher")
+		return err
 	}
-	aead, err := cipher.NewGCM(block)
-	if err != nil {
-		return errors.Wrap(err, "encryption: cipher.NewGCM")
-	}
-	entry.aead = aead
-
 	for {
 		cur := k.snap.Load()
-		m := make(map[uint32]*keyEntry, len(*cur)+1)
-		for id, v := range *cur {
+		var src map[uint32]*keyEntry
+		if cur != nil {
+			src = *cur
+		}
+		if done, err := checkExistingEntry(src, keyID, entry); done || err != nil {
+			return err
+		}
+		m := make(map[uint32]*keyEntry, len(src)+1)
+		for id, v := range src {
 			m[id] = v
 		}
 		m[keyID] = entry
@@ -122,10 +144,56 @@ func (k *Keystore) Set(keyID uint32, dek []byte) error {
 	}
 }
 
-// Delete removes the DEK for keyID. No-op if absent.
+// buildKeyEntry validates keyID/dek and pre-initializes the AEAD.
+// Hoisted out of Set so the CAS retry loop stays cyclomatically simple.
+func buildKeyEntry(keyID uint32, dek []byte) (*keyEntry, error) {
+	if keyID == ReservedKeyID {
+		return nil, errors.WithStack(ErrReservedKeyID)
+	}
+	if len(dek) != KeySize {
+		return nil, errors.Wrapf(ErrBadKeySize, "got %d bytes, want %d", len(dek), KeySize)
+	}
+	entry := &keyEntry{}
+	copy(entry.dek[:], dek)
+	block, err := aes.NewCipher(entry.dek[:])
+	if err != nil {
+		return nil, errors.Wrap(err, "encryption: aes.NewCipher")
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, errors.Wrap(err, "encryption: cipher.NewGCM")
+	}
+	entry.aead = aead
+	return entry, nil
+}
+
+// checkExistingEntry implements Set's set-once-with-idempotent-same
+// rule. Returns (done=true, nil) if keyID is already present with the
+// same DEK bytes (Set is a no-op), (true, ErrKeyConflict) if it is
+// present with different bytes, or (false, nil) to indicate the
+// caller should proceed with the CAS insert.
+func checkExistingEntry(src map[uint32]*keyEntry, keyID uint32, entry *keyEntry) (bool, error) {
+	existing, ok := src[keyID]
+	if !ok {
+		return false, nil
+	}
+	if existing.dek == entry.dek {
+		return true, nil
+	}
+	return true, errors.Wrapf(ErrKeyConflict, "key_id=%d", keyID)
+}
+
+// Delete removes the DEK for keyID. No-op if absent, the receiver is
+// nil, or the Keystore is zero-valued (no map ever Stored).
 func (k *Keystore) Delete(keyID uint32) {
+	if k == nil {
+		return
+	}
 	for {
 		cur := k.snap.Load()
+		if cur == nil {
+			return
+		}
 		if _, ok := (*cur)[keyID]; !ok {
 			return
 		}
@@ -142,8 +210,12 @@ func (k *Keystore) Delete(keyID uint32) {
 }
 
 // IDs returns a sorted snapshot of all currently-loaded key_ids.
+// Returns nil for a nil receiver or zero-value Keystore.
 func (k *Keystore) IDs() []uint32 {
-	m := *k.snap.Load()
+	m := k.loadMap()
+	if len(m) == 0 {
+		return nil
+	}
 	ids := make([]uint32, 0, len(m))
 	for id := range m {
 		ids = append(ids, id)
@@ -152,7 +224,8 @@ func (k *Keystore) IDs() []uint32 {
 	return ids
 }
 
-// Len reports the number of currently-loaded keys.
+// Len reports the number of currently-loaded keys. Returns 0 for a
+// nil receiver or zero-value Keystore.
 func (k *Keystore) Len() int {
-	return len(*k.snap.Load())
+	return len(k.loadMap())
 }

--- a/internal/encryption/keystore_test.go
+++ b/internal/encryption/keystore_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-func TestKeystore_SetGet(t *testing.T) {
+func TestKeystore_SetDEK(t *testing.T) {
 	ks := encryption.NewKeystore()
 	dek := make([]byte, encryption.KeySize)
 	if _, err := rand.Read(dek); err != nil {
@@ -19,12 +19,58 @@ func TestKeystore_SetGet(t *testing.T) {
 	if err := ks.Set(42, dek); err != nil {
 		t.Fatalf("Set: %v", err)
 	}
-	got, ok := ks.Get(42)
+	got, ok := ks.DEK(42)
 	if !ok {
-		t.Fatal("Get(42) reported not found")
+		t.Fatal("DEK(42) reported not found")
 	}
-	if !bytes.Equal(got, dek) {
-		t.Fatal("Get(42) returned different bytes")
+	if !bytes.Equal(got[:], dek) {
+		t.Fatal("DEK(42) returned different bytes")
+	}
+}
+
+// TestKeystore_DEK_ValueCopy confirms DEK returns an array by value, so a
+// caller mutating the result cannot leak back into the live keystore.
+// This is the type-safe alternative to a defensive []byte copy: the
+// signature itself enforces immutability of the live entry.
+func TestKeystore_DEK_ValueCopy(t *testing.T) {
+	ks := encryption.NewKeystore()
+	dek := make([]byte, encryption.KeySize)
+	dek[0] = 0xAA
+	if err := ks.Set(1, dek); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, ok := ks.DEK(1)
+	if !ok {
+		t.Fatal("DEK(1) not found")
+	}
+	// Mutate the value copy via copy() so we don't take &got[0] directly
+	// — gosec G602 is over-cautious about [N]byte indexing in tests.
+	corruptor := [1]byte{0xCC}
+	copy(got[:], corruptor[:])
+	got2, ok := ks.DEK(1)
+	if !ok {
+		t.Fatal("DEK(1) not found on second call")
+	}
+	wantPrefix := [1]byte{0xAA}
+	if !bytes.Equal(got2[:1], wantPrefix[:]) {
+		t.Fatalf("keystore was mutated via value copy: got2[:1]=%x, want %x", got2[:1], wantPrefix[:])
+	}
+}
+
+func TestKeystore_AEAD_FoundAndMissing(t *testing.T) {
+	ks := encryption.NewKeystore()
+	dek := make([]byte, encryption.KeySize)
+	if _, err := rand.Read(dek); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	if err := ks.Set(99, dek); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if aead, ok := ks.AEAD(99); !ok || aead == nil {
+		t.Fatal("AEAD(99) should return a non-nil AEAD")
+	}
+	if _, ok := ks.AEAD(123); ok {
+		t.Fatal("AEAD(123) should report not found")
 	}
 }
 
@@ -59,12 +105,13 @@ func TestKeystore_Set_CopiesInput(t *testing.T) {
 	}
 	// Mutate caller's slice; the keystore copy must be unaffected.
 	dek[0] = 0xBB
-	got, ok := ks.Get(1)
+	got, ok := ks.DEK(1)
 	if !ok {
-		t.Fatal("Get(1) reported not found")
+		t.Fatal("DEK(1) reported not found")
 	}
-	if got[0] != 0xAA {
-		t.Fatalf("keystore aliased input: got[0]=0x%02x, want 0xAA", got[0])
+	wantPrefix := [1]byte{0xAA}
+	if !bytes.Equal(got[:1], wantPrefix[:]) {
+		t.Fatalf("keystore aliased input: got[:1]=%x, want %x", got[:1], wantPrefix[:])
 	}
 }
 
@@ -158,7 +205,8 @@ func TestKeystore_Concurrent(t *testing.T) {
 			defer wg.Done()
 			for i := uint32(0); i < iterations; i++ {
 				_ = ks.IDs()
-				_, _ = ks.Get(1)
+				_, _ = ks.DEK(1)
+				_, _ = ks.AEAD(1)
 			}
 		}()
 	}

--- a/internal/encryption/keystore_test.go
+++ b/internal/encryption/keystore_test.go
@@ -1,0 +1,166 @@
+package encryption_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"sync"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/cockroachdb/errors"
+)
+
+func TestKeystore_SetGet(t *testing.T) {
+	ks := encryption.NewKeystore()
+	dek := make([]byte, encryption.KeySize)
+	if _, err := rand.Read(dek); err != nil {
+		t.Fatalf("rand.Read: %v", err)
+	}
+	if err := ks.Set(42, dek); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, ok := ks.Get(42)
+	if !ok {
+		t.Fatal("Get(42) reported not found")
+	}
+	if !bytes.Equal(got, dek) {
+		t.Fatal("Get(42) returned different bytes")
+	}
+}
+
+func TestKeystore_Set_RejectsReservedKeyID(t *testing.T) {
+	ks := encryption.NewKeystore()
+	dek := make([]byte, encryption.KeySize)
+	err := ks.Set(encryption.ReservedKeyID, dek)
+	if !errors.Is(err, encryption.ErrReservedKeyID) {
+		t.Fatalf("expected ErrReservedKeyID, got %v", err)
+	}
+	if ks.Has(encryption.ReservedKeyID) {
+		t.Fatal("ReservedKeyID was inserted despite the rejection")
+	}
+}
+
+func TestKeystore_Set_RejectsBadKeySize(t *testing.T) {
+	ks := encryption.NewKeystore()
+	for _, n := range []int{0, 1, 16, 24, 31, 33, 64} {
+		err := ks.Set(7, make([]byte, n))
+		if !errors.Is(err, encryption.ErrBadKeySize) {
+			t.Fatalf("len=%d: expected ErrBadKeySize, got %v", n, err)
+		}
+	}
+}
+
+func TestKeystore_Set_CopiesInput(t *testing.T) {
+	ks := encryption.NewKeystore()
+	dek := make([]byte, encryption.KeySize)
+	dek[0] = 0xAA
+	if err := ks.Set(1, dek); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	// Mutate caller's slice; the keystore copy must be unaffected.
+	dek[0] = 0xBB
+	got, ok := ks.Get(1)
+	if !ok {
+		t.Fatal("Get(1) reported not found")
+	}
+	if got[0] != 0xAA {
+		t.Fatalf("keystore aliased input: got[0]=0x%02x, want 0xAA", got[0])
+	}
+}
+
+func TestKeystore_Delete(t *testing.T) {
+	ks := encryption.NewKeystore()
+	dek := make([]byte, encryption.KeySize)
+	_ = ks.Set(1, dek)
+	_ = ks.Set(2, dek)
+	ks.Delete(1)
+	if ks.Has(1) {
+		t.Fatal("Delete(1) left it present")
+	}
+	if !ks.Has(2) {
+		t.Fatal("Delete(1) removed unrelated keys")
+	}
+	// Delete on an absent key must be a no-op (no panic, no error).
+	ks.Delete(999)
+}
+
+func TestKeystore_IDs_Sorted(t *testing.T) {
+	ks := encryption.NewKeystore()
+	dek := make([]byte, encryption.KeySize)
+	for _, id := range []uint32{5, 1, 9, 3, 7} {
+		if err := ks.Set(id, dek); err != nil {
+			t.Fatalf("Set(%d): %v", id, err)
+		}
+	}
+	got := ks.IDs()
+	want := []uint32{1, 3, 5, 7, 9}
+	if len(got) != len(want) {
+		t.Fatalf("IDs() length: got %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("IDs()[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+}
+
+func TestKeystore_Len(t *testing.T) {
+	ks := encryption.NewKeystore()
+	if ks.Len() != 0 {
+		t.Fatalf("empty Len() = %d, want 0", ks.Len())
+	}
+	dek := make([]byte, encryption.KeySize)
+	_ = ks.Set(1, dek)
+	_ = ks.Set(2, dek)
+	if ks.Len() != 2 {
+		t.Fatalf("Len() after 2 Sets = %d, want 2", ks.Len())
+	}
+	ks.Delete(1)
+	if ks.Len() != 1 {
+		t.Fatalf("Len() after Delete = %d, want 1", ks.Len())
+	}
+}
+
+// TestKeystore_Concurrent stresses the copy-on-write semantics: many
+// readers should see consistent snapshots even while writers churn the
+// map. Run under -race.
+func TestKeystore_Concurrent(t *testing.T) {
+	ks := encryption.NewKeystore()
+	dek := make([]byte, encryption.KeySize)
+	dek[0] = 0xAA
+
+	const (
+		writers    uint32 = 4
+		readers    uint32 = 16
+		iterations uint32 = 5_000
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(int(writers + readers))
+	for w := uint32(0); w < writers; w++ {
+		go func() {
+			defer wg.Done()
+			for i := uint32(0); i < iterations; i++ {
+				id := (w << 16) | (i & 0xffff)
+				if id == encryption.ReservedKeyID {
+					continue
+				}
+				_ = ks.Set(id, dek)
+				if i%4 == 0 {
+					ks.Delete(id)
+				}
+			}
+		}()
+	}
+	for r := uint32(0); r < readers; r++ {
+		_ = r
+		go func() {
+			defer wg.Done()
+			for i := uint32(0); i < iterations; i++ {
+				_ = ks.IDs()
+				_, _ = ks.Get(1)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/encryption/keystore_test.go
+++ b/internal/encryption/keystore_test.go
@@ -212,3 +212,99 @@ func TestKeystore_Concurrent(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// TestKeystore_ZeroValueRead covers the nil-safe contract for the
+// read-side methods (PR #719 CodeRabbit Major: contradiction with the
+// Cipher zero-value pattern). A zero-value Keystore and a nil receiver
+// must both behave as the empty keystore rather than nil-deref panic.
+func TestKeystore_ZeroValueRead(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		k    *encryption.Keystore
+	}{
+		{"zero-value", &encryption.Keystore{}},
+		{"nil receiver", (*encryption.Keystore)(nil)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, ok := tc.k.AEAD(1); got != nil || ok {
+				t.Fatalf("AEAD: got=%v ok=%v, want nil/false", got, ok)
+			}
+			if got, ok := tc.k.DEK(1); got != ([encryption.KeySize]byte{}) || ok {
+				t.Fatalf("DEK: ok=%v, want zero/false", ok)
+			}
+			if tc.k.Has(1) {
+				t.Fatal("Has: got true, want false")
+			}
+			if got := tc.k.IDs(); got != nil {
+				t.Fatalf("IDs: got %v, want nil", got)
+			}
+			if got := tc.k.Len(); got != 0 {
+				t.Fatalf("Len: got %d, want 0", got)
+			}
+			tc.k.Delete(1) // must not panic
+		})
+	}
+}
+
+// TestKeystore_NilReceiverSet exercises the only mutating operation
+// where the nil-safety contract is "fail with typed error" rather
+// than "no-op": Set on a nil receiver cannot install a key, so it
+// reports ErrNilKeystore.
+func TestKeystore_NilReceiverSet(t *testing.T) {
+	t.Parallel()
+	var k *encryption.Keystore
+	dek := make([]byte, encryption.KeySize)
+	err := k.Set(1, dek)
+	if !errors.Is(err, encryption.ErrNilKeystore) {
+		t.Fatalf("expected ErrNilKeystore, got %v", err)
+	}
+}
+
+// TestKeystore_SetConflict locks down the PR #719 CodeRabbit Major
+// finding on Set: re-Set under an existing keyID with the same DEK
+// bytes is idempotent (returns nil), but a Set with DIFFERENT bytes
+// returns ErrKeyConflict instead of silently replacing live key
+// material — replacement would render every envelope already
+// persisted under that id undecryptable.
+func TestKeystore_SetConflict(t *testing.T) {
+	t.Parallel()
+	t.Run("idempotent same DEK", func(t *testing.T) {
+		ks := encryption.NewKeystore()
+		dek := make([]byte, encryption.KeySize)
+		dek[0] = 0xAA
+		if err := ks.Set(7, dek); err != nil {
+			t.Fatalf("first Set: %v", err)
+		}
+		if err := ks.Set(7, dek); err != nil {
+			t.Fatalf("second Set with identical bytes returned %v, want nil (idempotent)", err)
+		}
+		if ks.Len() != 1 {
+			t.Fatalf("Len after duplicate Set = %d, want 1", ks.Len())
+		}
+	})
+	t.Run("conflicting DEK rejected", func(t *testing.T) {
+		ks := encryption.NewKeystore()
+		dek1 := make([]byte, encryption.KeySize)
+		dek1[0] = 0xAA
+		if err := ks.Set(7, dek1); err != nil {
+			t.Fatalf("first Set: %v", err)
+		}
+		dek2 := make([]byte, encryption.KeySize)
+		dek2[0] = 0xBB // differs in first byte
+		err := ks.Set(7, dek2)
+		if !errors.Is(err, encryption.ErrKeyConflict) {
+			t.Fatalf("expected ErrKeyConflict, got %v", err)
+		}
+		// Original DEK must remain intact.
+		got, ok := ks.DEK(7)
+		if !ok {
+			t.Fatal("DEK(7) reported not found after conflict rejection")
+		}
+		if !bytes.Equal(got[:1], []byte{0xAA}) {
+			t.Fatalf("conflicting Set silently replaced bytes: got[:1]=%x want %x",
+				got[:1], []byte{0xAA})
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Stage 0 of the data-at-rest encryption rollout from PR #707 (`docs/design/2026_04_29_proposed_data_at_rest_encryption.md`). This PR is library-only — no integration with existing storage / raft / FSM layers. Those land in Stages 1–9.

New package `internal/encryption/`:

- `cipher.go` — AES-256-GCM `Encrypt` / `Decrypt` primitive over a `Keystore`. Caller-supplied AAD bytes (no AAD composition baked in — storage and raft layers compose their own AAD per §4.1 / §4.2 in later stages). `Decrypt` wraps GCM tag mismatch as `ErrIntegrity` with the original `Open` error attached as a secondary cause, so callers match via `errors.Is` and never silently zero or retry.
- `envelope.go` — §4.1 wire format encoder/decoder. Layout: `[version 1B][flag 1B][key_id 4B BE][nonce 12B][ciphertext+tag]`. `EnvelopeOverhead = 34` bytes. `HeaderAADBytes` helper exposed for storage callers that compose `AAD = HeaderAADBytes ‖ pebble_key`. `ReservedKeyID = 0` sentinel per §5.1.
- `keystore.go` — copy-on-write `atomic.Pointer[map[uint32][]byte]` DEK store. `Get` is a single atomic load (no mutex on the hot path per §10 self-review lens 2). `Set` rejects `ReservedKeyID` and non-32-byte DEKs; copies input.
- `errors.go` — typed errors: `ErrUnknownKeyID`, `ErrReservedKeyID`, `ErrBadNonceSize`, `ErrBadKeySize`, `ErrIntegrity`, `ErrEnvelopeShort`, `ErrEnvelopeVersion`.
- `kek/kek.go` — `Wrapper` interface (`Wrap` / `Unwrap` / `Name`). KMS-backed providers (AWS KMS, GCP KMS, Vault) come in Stage 9.
- `kek/file.go` — `FileWrapper`: AES-256-GCM under a 32-byte KEK read from a file. Output `[12B nonce][32B ct][16B tag] = 60 bytes`. Validates lengths instead of padding/truncating.

Tests:

- `cipher_test.go` — round-trip across plaintext/AAD shapes; tag/AAD/ciphertext/nonce tamper rejected with `ErrIntegrity`; typed error checks for reserved/bad-nonce/unknown-key cases; distinct nonces produce distinct ciphertexts.
- `cipher_prop_test.go` — `pgregory.net/rapid` property tests for arbitrary plaintext/AAD round-trip and single-bit AAD-flip rejection (the §4.1 cut-and-paste defence property).
- `envelope_test.go` — encode/decode round-trip; under-length input rejected; unknown version bytes rejected; decode does not alias input.
- `keystore_test.go` — Set/Get/Delete/IDs/Len; concurrent reader/writer stress under `-race`.
- `kek/file_test.go` — round-trip; distinct Wrap nonces; bad-length rejection; tag/nonce tamper rejected; missing file.

## Self-review (per CLAUDE.md 5 lenses)

1. **Data loss** — Pure library, no persistence yet. `ErrIntegrity` always propagated. Round-trip property test guards envelope-format bugs.
2. **Concurrency** — `atomic.Pointer[map]` for keystore; concurrent stress test under `-race`.
3. **Performance** — AES-NI via `crypto/aes`. No allocations beyond per-call ciphertext buffer (sync.Pool optimisation deferred to integration stages).
4. **Data consistency** — No MVCC/OCC interaction yet.
5. **Test coverage** — 23 unit tests + 2 property tests, `-race` clean, 0 lint issues against project `.golangci.yaml`.

## Test plan

- [x] `go test ./internal/encryption/...` (~14s)
- [x] `go test -race ./internal/encryption/...` (~65s)
- [x] `golangci-lint run ./internal/encryption/...` (0 issues)
- [ ] Reviewer: confirm `Cipher` API does not bake storage/raft AAD assumptions in (§4.1 vs §4.2 layouts must remain orthogonal).
- [ ] Reviewer: confirm `ReservedKeyID = 0` is rejected at all entry points (`Cipher.Encrypt`, `Cipher.Decrypt`, `Keystore.Set`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added AES-256-GCM encryption support with envelope-based encryption format
* Implemented key management system for secure encryption key handling
* Added file-based key encryption key (KEK) support for key wrapping and unwrapping
* Introduced comprehensive error handling for encryption operations including integrity verification

## Tests
* Added extensive unit, benchmark, and property-based tests for encryption functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->