### PR TITLE
feat(keyviz): leader-term wire format + main.go ticker (Phase 2-C+ PR-3b)

### DIFF
--- a/adapter/admin_grpc.go
+++ b/adapter/admin_grpc.go
@@ -612,6 +612,12 @@ func matrixToProto(cols []keyviz.MatrixColumn, pick func(keyviz.MatrixRow) uint6
 				order = append(order, mr.RouteID)
 			}
 			pr.Values[j] = pick(mr)
+			// Per-cell Raft identity stamped from this column's
+			// MatrixRow (Gemini HIGH on PR #720 — a row-level
+			// scalar would only capture the first column's
+			// identity and break the per-cell dedupe goal).
+			pr.RaftGroupIds[j] = mr.RaftGroupID
+			pr.LeaderTerms[j] = mr.LeaderTerm
 		}
 	}
 	resp.Rows = make([]*pb.KeyVizRow, len(order))
@@ -675,9 +681,12 @@ func newKeyVizRowFrom(mr keyviz.MatrixRow, numCols int) *pb.KeyVizRow {
 		Aggregate:         mr.Aggregate,
 		RouteCount:        total,
 		RouteIdsTruncated: mr.Aggregate && total > uint64(len(mr.MemberRoutes)),
-		RaftGroupId:       mr.RaftGroupID,
-		LeaderTerm:        mr.LeaderTerm,
 		Values:            make([]uint64, numCols),
+		// Per-cell parallel arrays — populated in the column-loop
+		// above, not here, because the first MatrixRow seen for a
+		// route only carries that one column's identity.
+		RaftGroupIds: make([]uint64, numCols),
+		LeaderTerms:  make([]uint64, numCols),
 	}
 	if mr.Aggregate {
 		row.RouteIds = append([]uint64(nil), mr.MemberRoutes...)

--- a/adapter/admin_grpc.go
+++ b/adapter/admin_grpc.go
@@ -675,6 +675,8 @@ func newKeyVizRowFrom(mr keyviz.MatrixRow, numCols int) *pb.KeyVizRow {
 		Aggregate:         mr.Aggregate,
 		RouteCount:        total,
 		RouteIdsTruncated: mr.Aggregate && total > uint64(len(mr.MemberRoutes)),
+		RaftGroupId:       mr.RaftGroupID,
+		LeaderTerm:        mr.LeaderTerm,
 		Values:            make([]uint64, numCols),
 	}
 	if mr.Aggregate {

--- a/adapter/admin_grpc_keyviz_test.go
+++ b/adapter/admin_grpc_keyviz_test.go
@@ -274,20 +274,31 @@ func TestGetKeyVizMatrixHonorsRowsBudget(t *testing.T) {
 	require.Equal(t, "route:4", resp.Rows[1].BucketId)
 }
 
-// TestGetKeyVizMatrixStampsRaftIdentity pins the Phase 2-C+ wire
-// extension: MatrixRow.RaftGroupID and MatrixRow.LeaderTerm propagate
-// through matrixToProto into the proto KeyVizRow's
-// raft_group_id (field 13) and leader_term (field 14). The fan-out
-// aggregator's per-term dedupe key requires both fields on the wire.
+// TestGetKeyVizMatrixStampsRaftIdentity pins the Phase 2-C+ per-cell
+// wire extension: MatrixRow.RaftGroupID and MatrixRow.LeaderTerm
+// propagate per-column through matrixToProto into the proto
+// KeyVizRow's raft_group_ids (field 13) and leader_terms (field 14)
+// parallel-to-values arrays. The fan-out aggregator's per-cell
+// dedupe key requires per-column identity (Gemini HIGH on PR #720
+// — row-level scalars only captured the first column's identity
+// and broke dedupe under mid-window leader flips).
 func TestGetKeyVizMatrixStampsRaftIdentity(t *testing.T) {
 	t.Parallel()
 	t0 := time.Unix(1_700_000_000, 0)
+	t1 := t0.Add(time.Minute)
 	srv := newAdminServerWithFakeSampler(t, []keyviz.MatrixColumn{
 		{
 			At: t0,
 			Rows: []keyviz.MatrixRow{
 				{RouteID: 1, Start: []byte("a"), End: []byte("b"), Writes: 5, RaftGroupID: 7, LeaderTerm: 42},
 				{RouteID: 2, Start: []byte("b"), End: []byte("c"), Writes: 9, RaftGroupID: 0, LeaderTerm: 0},
+			},
+		},
+		// col 1: term flipped on route 1 mid-window; route 2 absent.
+		{
+			At: t1,
+			Rows: []keyviz.MatrixRow{
+				{RouteID: 1, Start: []byte("a"), End: []byte("b"), Writes: 11, RaftGroupID: 7, LeaderTerm: 43},
 			},
 		},
 	})
@@ -297,12 +308,13 @@ func TestGetKeyVizMatrixStampsRaftIdentity(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, resp.Rows, 2)
-	// route:1 — non-zero identity propagated.
+	// route:1 — per-cell identity captures the term flip.
 	require.Equal(t, "route:1", resp.Rows[0].BucketId)
-	require.Equal(t, uint64(7), resp.Rows[0].RaftGroupId, "RaftGroupID must propagate to proto field 13")
-	require.Equal(t, uint64(42), resp.Rows[0].LeaderTerm, "LeaderTerm must propagate to proto field 14")
-	// route:2 — zero values stay zero (legacy max-merge fallback).
+	require.Equal(t, []uint64{7, 7}, resp.Rows[0].RaftGroupIds, "raft_group_ids must be parallel to values")
+	require.Equal(t, []uint64{42, 43}, resp.Rows[0].LeaderTerms,
+		"leader_terms must capture per-column term so the aggregator can dedupe across the flip")
+	// route:2 — present only in col0; col1 zero is the "term not tracked" sentinel.
 	require.Equal(t, "route:2", resp.Rows[1].BucketId)
-	require.Equal(t, uint64(0), resp.Rows[1].RaftGroupId)
-	require.Equal(t, uint64(0), resp.Rows[1].LeaderTerm)
+	require.Equal(t, []uint64{0, 0}, resp.Rows[1].RaftGroupIds)
+	require.Equal(t, []uint64{0, 0}, resp.Rows[1].LeaderTerms)
 }

--- a/adapter/admin_grpc_keyviz_test.go
+++ b/adapter/admin_grpc_keyviz_test.go
@@ -273,3 +273,36 @@ func TestGetKeyVizMatrixHonorsRowsBudget(t *testing.T) {
 	require.Equal(t, "route:2", resp.Rows[0].BucketId)
 	require.Equal(t, "route:4", resp.Rows[1].BucketId)
 }
+
+// TestGetKeyVizMatrixStampsRaftIdentity pins the Phase 2-C+ wire
+// extension: MatrixRow.RaftGroupID and MatrixRow.LeaderTerm propagate
+// through matrixToProto into the proto KeyVizRow's
+// raft_group_id (field 13) and leader_term (field 14). The fan-out
+// aggregator's per-term dedupe key requires both fields on the wire.
+func TestGetKeyVizMatrixStampsRaftIdentity(t *testing.T) {
+	t.Parallel()
+	t0 := time.Unix(1_700_000_000, 0)
+	srv := newAdminServerWithFakeSampler(t, []keyviz.MatrixColumn{
+		{
+			At: t0,
+			Rows: []keyviz.MatrixRow{
+				{RouteID: 1, Start: []byte("a"), End: []byte("b"), Writes: 5, RaftGroupID: 7, LeaderTerm: 42},
+				{RouteID: 2, Start: []byte("b"), End: []byte("c"), Writes: 9, RaftGroupID: 0, LeaderTerm: 0},
+			},
+		},
+	})
+
+	resp, err := srv.GetKeyVizMatrix(context.Background(), &pb.GetKeyVizMatrixRequest{
+		Series: pb.KeyVizSeries_KEYVIZ_SERIES_WRITES,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Rows, 2)
+	// route:1 — non-zero identity propagated.
+	require.Equal(t, "route:1", resp.Rows[0].BucketId)
+	require.Equal(t, uint64(7), resp.Rows[0].RaftGroupId, "RaftGroupID must propagate to proto field 13")
+	require.Equal(t, uint64(42), resp.Rows[0].LeaderTerm, "LeaderTerm must propagate to proto field 14")
+	// route:2 — zero values stay zero (legacy max-merge fallback).
+	require.Equal(t, "route:2", resp.Rows[1].BucketId)
+	require.Equal(t, uint64(0), resp.Rows[1].RaftGroupId)
+	require.Equal(t, uint64(0), resp.Rows[1].LeaderTerm)
+}

--- a/internal/admin/keyviz_fanout.go
+++ b/internal/admin/keyviz_fanout.go
@@ -525,9 +525,14 @@ func mergeRowInto(
 			RouteIDs:          append([]uint64(nil), row.RouteIDs...),
 			RouteIDsTruncated: row.RouteIDsTruncated,
 			RouteCount:        row.RouteCount,
-			RaftGroupID:       row.RaftGroupID,
-			LeaderTerm:        row.LeaderTerm,
 			Values:            make([]uint64, mergedWidth),
+			// Per-cell parallel arrays sized to the merged column
+			// width. Stamped per-cell in the loop below from the
+			// largest-source for that cell, so the identity always
+			// matches the value we kept (Gemini MEDIUM on PR #720
+			// resolved by going per-cell).
+			RaftGroupIDs: make([]uint64, mergedWidth),
+			LeaderTerms:  make([]uint64, mergedWidth),
 		}
 		rowsByBucket[row.BucketID] = dst
 		*bucketOrder = append(*bucketOrder, row.BucketID)
@@ -537,10 +542,25 @@ func mergeRowInto(
 		if !ok || j >= len(row.Values) {
 			continue
 		}
-		next, conflict := mergeFn(dst.Values[idx], row.Values[j])
+		prev := dst.Values[idx]
+		next, conflict := mergeFn(prev, row.Values[j])
 		dst.Values[idx] = next
 		if conflict {
 			dst.Conflict = true
+		}
+		// Identity belongs to the source whose value we kept. For
+		// sumMerge (reads) this is best-effort: prev+incoming has
+		// no single owner, so we keep whichever side contributed
+		// most recently — close-to-correct in the steady state.
+		// For maxMerge (writes), `next == row.Values[j]` exactly
+		// when the incoming source won the cell; in the tied
+		// (prev == incoming != 0) case `next == prev`, both sides
+		// agree on the value, and either identity is acceptable.
+		if next == row.Values[j] && j < len(row.RaftGroupIDs) {
+			dst.RaftGroupIDs[idx] = row.RaftGroupIDs[j]
+		}
+		if next == row.Values[j] && j < len(row.LeaderTerms) {
+			dst.LeaderTerms[idx] = row.LeaderTerms[j]
 		}
 	}
 }

--- a/internal/admin/keyviz_fanout.go
+++ b/internal/admin/keyviz_fanout.go
@@ -556,11 +556,27 @@ func mergeRowInto(
 		// when the incoming source won the cell; in the tied
 		// (prev == incoming != 0) case `next == prev`, both sides
 		// agree on the value, and either identity is acceptable.
-		if next == row.Values[j] && j < len(row.RaftGroupIDs) {
-			dst.RaftGroupIDs[idx] = row.RaftGroupIDs[j]
-		}
-		if next == row.Values[j] && j < len(row.LeaderTerms) {
-			dst.LeaderTerms[idx] = row.LeaderTerms[j]
+		if next == row.Values[j] {
+			// Mixed-version cluster: a legacy peer that does not
+			// emit raft_group_ids / leader_terms sends empty
+			// slices. When such a peer's value wins the cell, we
+			// must EXPLICITLY RESET dst.RaftGroupIDs[idx] /
+			// dst.LeaderTerms[idx] to 0 (the documented "term not
+			// tracked" sentinel) — leaving stale identity from a
+			// previous higher-versioned source would mislabel an
+			// unknown-term winning cell as a known term and break
+			// the per-cell dedupe/summing in PR-3c. (Codex P2
+			// round-2 on PR #720.)
+			if j < len(row.RaftGroupIDs) {
+				dst.RaftGroupIDs[idx] = row.RaftGroupIDs[j]
+			} else {
+				dst.RaftGroupIDs[idx] = 0
+			}
+			if j < len(row.LeaderTerms) {
+				dst.LeaderTerms[idx] = row.LeaderTerms[j]
+			} else {
+				dst.LeaderTerms[idx] = 0
+			}
 		}
 	}
 }

--- a/internal/admin/keyviz_fanout.go
+++ b/internal/admin/keyviz_fanout.go
@@ -525,6 +525,8 @@ func mergeRowInto(
 			RouteIDs:          append([]uint64(nil), row.RouteIDs...),
 			RouteIDsTruncated: row.RouteIDsTruncated,
 			RouteCount:        row.RouteCount,
+			RaftGroupID:       row.RaftGroupID,
+			LeaderTerm:        row.LeaderTerm,
 			Values:            make([]uint64, mergedWidth),
 		}
 		rowsByBucket[row.BucketID] = dst

--- a/internal/admin/keyviz_fanout_test.go
+++ b/internal/admin/keyviz_fanout_test.go
@@ -70,6 +70,36 @@ func TestMergeKeyVizMatricesWritesMaxStableLeader(t *testing.T) {
 	require.False(t, merged.Rows[0].Conflict, "stable-leader merge must not raise conflict")
 }
 
+// TestMergeKeyVizMatricesPreservesRaftIdentity pins the Phase 2-C+
+// wire extension on the fan-out merge path: when mergeRowInto seeds
+// the destination row from the first source, RaftGroupID and
+// LeaderTerm are copied through. PR-3c will use these fields to
+// switch from §4.2's row-level max-merge to §9.1's per-cell
+// (group, term) dedupe; this PR ensures the fields survive the
+// merge so PR-3c has data to act on.
+func TestMergeKeyVizMatricesPreservesRaftIdentity(t *testing.T) {
+	t.Parallel()
+	col := []int64{1_700_000_000_000}
+	a := KeyVizMatrix{
+		ColumnUnixMs: col,
+		Series:       keyVizSeriesWrites,
+		Rows: []KeyVizRow{
+			{BucketID: "route:5", Values: []uint64{30}, RaftGroupID: 7, LeaderTerm: 42},
+		},
+	}
+	b := KeyVizMatrix{
+		ColumnUnixMs: col,
+		Series:       keyVizSeriesWrites,
+		Rows: []KeyVizRow{
+			{BucketID: "route:5", Values: []uint64{0}, RaftGroupID: 7, LeaderTerm: 42},
+		},
+	}
+	merged := mergeKeyVizMatrices([]KeyVizMatrix{a, b}, keyVizSeriesWrites)
+	require.Len(t, merged.Rows, 1)
+	require.Equal(t, uint64(7), merged.Rows[0].RaftGroupID, "RaftGroupID must survive mergeRowInto")
+	require.Equal(t, uint64(42), merged.Rows[0].LeaderTerm, "LeaderTerm must survive mergeRowInto")
+}
+
 // TestMergeKeyVizMatricesWritesMaxLeadershipFlip pins §4.2 under a
 // mid-window flip: two nodes report non-zero, disagreeing values
 // for the same cell. The merge keeps the larger value and raises

--- a/internal/admin/keyviz_fanout_test.go
+++ b/internal/admin/keyviz_fanout_test.go
@@ -103,6 +103,44 @@ func TestMergeKeyVizMatricesPreservesRaftIdentity(t *testing.T) {
 	require.Equal(t, []uint64{42}, merged.Rows[0].LeaderTerms, "LeaderTerms must survive mergeRowInto")
 }
 
+// TestMergeKeyVizMatricesLegacyPeerWinnerResetsIdentity pins the
+// fail-closed semantic for mixed-version clusters (Codex P2
+// round-2): when a legacy peer that does not emit raft_group_ids /
+// leader_terms (empty slices) wins a cell, dst.RaftGroupIDs[idx]
+// and dst.LeaderTerms[idx] must be RESET to 0 (the documented
+// "term not tracked" sentinel) — leaving stale identity from a
+// previous higher-versioned source would mislabel an unknown-term
+// winning cell as a known term and break the per-cell
+// dedupe/summing in PR-3c.
+func TestMergeKeyVizMatricesLegacyPeerWinnerResetsIdentity(t *testing.T) {
+	t.Parallel()
+	col := []int64{1_700_000_000_000}
+	// Source 1 (modern): reports 30 with identity (group=7, term=42).
+	modern := KeyVizMatrix{
+		ColumnUnixMs: col,
+		Series:       keyVizSeriesWrites,
+		Rows: []KeyVizRow{
+			{BucketID: "route:5", Values: []uint64{30}, RaftGroupIDs: []uint64{7}, LeaderTerms: []uint64{42}},
+		},
+	}
+	// Source 2 (legacy): reports 50 with NO arrays (older server
+	// build). Wins maxMerge but cannot identify its term.
+	legacy := KeyVizMatrix{
+		ColumnUnixMs: col,
+		Series:       keyVizSeriesWrites,
+		Rows: []KeyVizRow{
+			{BucketID: "route:5", Values: []uint64{50}},
+		},
+	}
+	merged := mergeKeyVizMatrices([]KeyVizMatrix{modern, legacy}, keyVizSeriesWrites)
+	require.Len(t, merged.Rows, 1)
+	require.Equal(t, []uint64{50}, merged.Rows[0].Values, "legacy peer's value wins maxMerge")
+	require.Equal(t, []uint64{0}, merged.Rows[0].RaftGroupIDs,
+		"legacy winner without metadata must reset dst identity to 0 sentinel — not inherit modern's 7")
+	require.Equal(t, []uint64{0}, merged.Rows[0].LeaderTerms,
+		"legacy winner without metadata must reset dst term to 0 sentinel — not inherit modern's 42")
+}
+
 // TestMergeKeyVizMatricesPerCellIdentityMatchesValueOwner pins the
 // Gemini MEDIUM fix: when maxMerge picks a value from one source,
 // the identity at that cell must come from the SAME source — not

--- a/internal/admin/keyviz_fanout_test.go
+++ b/internal/admin/keyviz_fanout_test.go
@@ -71,12 +71,15 @@ func TestMergeKeyVizMatricesWritesMaxStableLeader(t *testing.T) {
 }
 
 // TestMergeKeyVizMatricesPreservesRaftIdentity pins the Phase 2-C+
-// wire extension on the fan-out merge path: when mergeRowInto seeds
-// the destination row from the first source, RaftGroupID and
-// LeaderTerm are copied through. PR-3c will use these fields to
-// switch from §4.2's row-level max-merge to §9.1's per-cell
-// (group, term) dedupe; this PR ensures the fields survive the
-// merge so PR-3c has data to act on.
+// per-cell wire extension on the fan-out merge path: mergeRowInto
+// stamps the destination row's per-cell (RaftGroupIDs[idx],
+// LeaderTerms[idx]) from whichever source contributed the value
+// kept at that cell. Both sources reporting the same identity
+// for a writes-max merge is the steady-state shape — merged
+// identity matches regardless of source order. (Gemini HIGH on
+// PR #720 resolved by going per-cell; row-level scalars would
+// only capture the first column's identity and break the per-cell
+// dedupe goal.)
 func TestMergeKeyVizMatricesPreservesRaftIdentity(t *testing.T) {
 	t.Parallel()
 	col := []int64{1_700_000_000_000}
@@ -84,20 +87,51 @@ func TestMergeKeyVizMatricesPreservesRaftIdentity(t *testing.T) {
 		ColumnUnixMs: col,
 		Series:       keyVizSeriesWrites,
 		Rows: []KeyVizRow{
-			{BucketID: "route:5", Values: []uint64{30}, RaftGroupID: 7, LeaderTerm: 42},
+			{BucketID: "route:5", Values: []uint64{30}, RaftGroupIDs: []uint64{7}, LeaderTerms: []uint64{42}},
 		},
 	}
 	b := KeyVizMatrix{
 		ColumnUnixMs: col,
 		Series:       keyVizSeriesWrites,
 		Rows: []KeyVizRow{
-			{BucketID: "route:5", Values: []uint64{0}, RaftGroupID: 7, LeaderTerm: 42},
+			{BucketID: "route:5", Values: []uint64{0}, RaftGroupIDs: []uint64{7}, LeaderTerms: []uint64{42}},
 		},
 	}
 	merged := mergeKeyVizMatrices([]KeyVizMatrix{a, b}, keyVizSeriesWrites)
 	require.Len(t, merged.Rows, 1)
-	require.Equal(t, uint64(7), merged.Rows[0].RaftGroupID, "RaftGroupID must survive mergeRowInto")
-	require.Equal(t, uint64(42), merged.Rows[0].LeaderTerm, "LeaderTerm must survive mergeRowInto")
+	require.Equal(t, []uint64{7}, merged.Rows[0].RaftGroupIDs, "RaftGroupIDs must survive mergeRowInto")
+	require.Equal(t, []uint64{42}, merged.Rows[0].LeaderTerms, "LeaderTerms must survive mergeRowInto")
+}
+
+// TestMergeKeyVizMatricesPerCellIdentityMatchesValueOwner pins the
+// Gemini MEDIUM fix: when maxMerge picks a value from one source,
+// the identity at that cell must come from the SAME source — not
+// from whoever happened to be processed first. Drives a leadership
+// flip across two consecutive columns with each leader winning
+// one cell.
+func TestMergeKeyVizMatricesPerCellIdentityMatchesValueOwner(t *testing.T) {
+	t.Parallel()
+	col := []int64{1_700_000_000_000, 1_700_000_001_000}
+	exLeader := KeyVizMatrix{
+		ColumnUnixMs: col,
+		Series:       keyVizSeriesWrites,
+		Rows: []KeyVizRow{
+			{BucketID: "route:9", Values: []uint64{50, 0}, RaftGroupIDs: []uint64{7, 7}, LeaderTerms: []uint64{42, 42}},
+		},
+	}
+	newLeader := KeyVizMatrix{
+		ColumnUnixMs: col,
+		Series:       keyVizSeriesWrites,
+		Rows: []KeyVizRow{
+			{BucketID: "route:9", Values: []uint64{0, 80}, RaftGroupIDs: []uint64{7, 7}, LeaderTerms: []uint64{43, 43}},
+		},
+	}
+	merged := mergeKeyVizMatrices([]KeyVizMatrix{exLeader, newLeader}, keyVizSeriesWrites)
+	require.Len(t, merged.Rows, 1)
+	require.Equal(t, []uint64{50, 80}, merged.Rows[0].Values, "writes max-merge picks the larger per cell")
+	require.Equal(t, []uint64{7, 7}, merged.Rows[0].RaftGroupIDs, "groupID stays 7 across both cells")
+	require.Equal(t, []uint64{42, 43}, merged.Rows[0].LeaderTerms,
+		"col0's identity comes from exLeader (term 42, won 50 vs 0); col1's identity comes from newLeader (term 43, won 80 vs 0)")
 }
 
 // TestMergeKeyVizMatricesWritesMaxLeadershipFlip pins §4.2 under a

--- a/internal/admin/keyviz_handler.go
+++ b/internal/admin/keyviz_handler.go
@@ -88,6 +88,17 @@ type KeyVizRow struct {
 	RouteCount        uint64   `json:"route_count"`
 	Values            []uint64 `json:"values"`
 	Conflict          bool     `json:"conflict,omitempty"`
+	// RaftGroupID and LeaderTerm carry the route's Raft identity at
+	// flush time. Phase 2-C+ fan-out uses
+	// (bucket_id, raft_group_id, leader_term, column) as the dedupe
+	// key so writes from a leader and the previous leader can be
+	// summed across terms instead of conservatively max-merged.
+	// Zero values mean "term not tracked" (legacy single-group
+	// deployments, virtual aggregate buckets, or nodes that have
+	// not wired the leader-term publisher) — the aggregator falls
+	// back to the legacy max-merge for those cells.
+	RaftGroupID uint64 `json:"raft_group_id,omitempty"`
+	LeaderTerm  uint64 `json:"leader_term,omitempty"`
 	// total accumulates the sum of Values during pivot so the
 	// rowBudget sort is O(N log N) on a precomputed key rather
 	// than O(N log N × M) recomputing the sum per comparison.
@@ -372,6 +383,8 @@ func newKeyVizRowFrom(mr keyviz.MatrixRow, numCols int) *KeyVizRow {
 		Aggregate:         mr.Aggregate,
 		RouteCount:        total,
 		RouteIDsTruncated: mr.Aggregate && total > uint64(len(mr.MemberRoutes)),
+		RaftGroupID:       mr.RaftGroupID,
+		LeaderTerm:        mr.LeaderTerm,
 		Values:            make([]uint64, numCols),
 	}
 	if mr.Aggregate {

--- a/internal/admin/keyviz_handler.go
+++ b/internal/admin/keyviz_handler.go
@@ -88,17 +88,20 @@ type KeyVizRow struct {
 	RouteCount        uint64   `json:"route_count"`
 	Values            []uint64 `json:"values"`
 	Conflict          bool     `json:"conflict,omitempty"`
-	// RaftGroupID and LeaderTerm carry the route's Raft identity at
-	// flush time. Phase 2-C+ fan-out uses
-	// (bucket_id, raft_group_id, leader_term, column) as the dedupe
-	// key so writes from a leader and the previous leader can be
-	// summed across terms instead of conservatively max-merged.
-	// Zero values mean "term not tracked" (legacy single-group
-	// deployments, virtual aggregate buckets, or nodes that have
-	// not wired the leader-term publisher) — the aggregator falls
-	// back to the legacy max-merge for those cells.
-	RaftGroupID uint64 `json:"raft_group_id,omitempty"`
-	LeaderTerm  uint64 `json:"leader_term,omitempty"`
+	// RaftGroupIDs[j] and LeaderTerms[j] carry the route's Raft
+	// identity at the time column j was flushed (parallel to
+	// Values[]). Phase 2-C+ fan-out uses
+	// (bucket_id, raft_group_id, leader_term, column) as the
+	// dedupe key. Per-cell representation is required because
+	// leadership can flip within the requested window; row-level
+	// scalars would only capture the first column's identity and
+	// cause incorrect dedupe for later columns (Gemini HIGH on
+	// PR #720). Zero values mean "term not tracked" — the
+	// aggregator falls back to the legacy max-merge for those
+	// cells. The slices are either nil (legacy server, no
+	// per-column identity to share) or len == len(Values).
+	RaftGroupIDs []uint64 `json:"raft_group_ids,omitempty"`
+	LeaderTerms  []uint64 `json:"leader_terms,omitempty"`
 	// total accumulates the sum of Values during pivot so the
 	// rowBudget sort is O(N log N) on a precomputed key rather
 	// than O(N log N × M) recomputing the sum per comparison.
@@ -333,6 +336,13 @@ func pivotKeyVizColumns(cols []keyviz.MatrixColumn, series KeyVizSeries, rowBudg
 			}
 			v := pick(mr)
 			row.Values[j] = v
+			// Per-cell Raft identity stamped from this column's
+			// MatrixRow. Each MatrixRow is emitted by Flush() with
+			// the term snapshot taken at that flush moment, so the
+			// j-th column's identity may differ from j-1 if a leader
+			// term flipped between flushes (Gemini HIGH on PR #720).
+			row.RaftGroupIDs[j] = mr.RaftGroupID
+			row.LeaderTerms[j] = mr.LeaderTerm
 			row.total += v
 		}
 	}
@@ -383,9 +393,12 @@ func newKeyVizRowFrom(mr keyviz.MatrixRow, numCols int) *KeyVizRow {
 		Aggregate:         mr.Aggregate,
 		RouteCount:        total,
 		RouteIDsTruncated: mr.Aggregate && total > uint64(len(mr.MemberRoutes)),
-		RaftGroupID:       mr.RaftGroupID,
-		LeaderTerm:        mr.LeaderTerm,
 		Values:            make([]uint64, numCols),
+		// Per-cell parallel arrays — populated in the column-loop
+		// above, not here, because the first MatrixRow seen for a
+		// route only carries that one column's identity.
+		RaftGroupIDs: make([]uint64, numCols),
+		LeaderTerms:  make([]uint64, numCols),
 	}
 	if mr.Aggregate {
 		row.RouteIDs = append([]uint64(nil), mr.MemberRoutes...)

--- a/internal/admin/keyviz_handler_test.go
+++ b/internal/admin/keyviz_handler_test.go
@@ -498,3 +498,37 @@ func TestKeyVizHandlerSkipsFanoutForPeerCall(t *testing.T) {
 	require.Equal(t, 0, peerHits,
 		"recursion guard violated: handler dialled a peer despite X-Admin-Fanout-Peer being set")
 }
+
+// TestKeyVizHandlerStampsRaftIdentity pins the Phase 2-C+ wire
+// extension on the JSON path: MatrixRow.RaftGroupID and
+// MatrixRow.LeaderTerm propagate through newKeyVizRowFrom into the
+// JSON KeyVizRow's raft_group_id and leader_term fields.
+func TestKeyVizHandlerStampsRaftIdentity(t *testing.T) {
+	t.Parallel()
+	t0 := time.Unix(1_700_000_000, 0)
+	srv := newKeyVizTestServer(t, &fakeKeyVizSource{cols: []keyviz.MatrixColumn{
+		{
+			At: t0,
+			Rows: []keyviz.MatrixRow{
+				{RouteID: 1, Start: []byte("a"), End: []byte("b"), Writes: 5, RaftGroupID: 7, LeaderTerm: 42},
+				{RouteID: 2, Start: []byte("b"), End: []byte("c"), Writes: 9},
+			},
+		},
+	}})
+	defer srv.Close()
+
+	resp := keyVizGet(t, srv.URL)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var matrix KeyVizMatrix
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&matrix))
+	require.Len(t, matrix.Rows, 2)
+	r1, r2 := matrix.Rows[0], matrix.Rows[1]
+	require.Equal(t, "route:1", r1.BucketID)
+	require.Equal(t, uint64(7), r1.RaftGroupID, "RaftGroupID must propagate to JSON raft_group_id")
+	require.Equal(t, uint64(42), r1.LeaderTerm, "LeaderTerm must propagate to JSON leader_term")
+	// route:2 — zero values stay zero.
+	require.Equal(t, "route:2", r2.BucketID)
+	require.Equal(t, uint64(0), r2.RaftGroupID)
+	require.Equal(t, uint64(0), r2.LeaderTerm)
+}

--- a/internal/admin/keyviz_handler_test.go
+++ b/internal/admin/keyviz_handler_test.go
@@ -499,19 +499,30 @@ func TestKeyVizHandlerSkipsFanoutForPeerCall(t *testing.T) {
 		"recursion guard violated: handler dialled a peer despite X-Admin-Fanout-Peer being set")
 }
 
-// TestKeyVizHandlerStampsRaftIdentity pins the Phase 2-C+ wire
-// extension on the JSON path: MatrixRow.RaftGroupID and
-// MatrixRow.LeaderTerm propagate through newKeyVizRowFrom into the
-// JSON KeyVizRow's raft_group_id and leader_term fields.
+// TestKeyVizHandlerStampsRaftIdentity pins the Phase 2-C+ per-cell
+// wire extension on the JSON path: MatrixRow.RaftGroupID and
+// MatrixRow.LeaderTerm propagate per-column through the pivot into
+// the JSON KeyVizRow's raft_group_ids[] and leader_terms[] arrays
+// (parallel to values[]). A row that appears in only some columns
+// reports zero (the documented "term not tracked" sentinel) for
+// the columns where it's absent.
 func TestKeyVizHandlerStampsRaftIdentity(t *testing.T) {
 	t.Parallel()
 	t0 := time.Unix(1_700_000_000, 0)
+	t1 := t0.Add(time.Minute)
 	srv := newKeyVizTestServer(t, &fakeKeyVizSource{cols: []keyviz.MatrixColumn{
 		{
 			At: t0,
 			Rows: []keyviz.MatrixRow{
 				{RouteID: 1, Start: []byte("a"), End: []byte("b"), Writes: 5, RaftGroupID: 7, LeaderTerm: 42},
 				{RouteID: 2, Start: []byte("b"), End: []byte("c"), Writes: 9},
+			},
+		},
+		// col 1: route 1 still active (term flipped to 43); route 2 absent.
+		{
+			At: t1,
+			Rows: []keyviz.MatrixRow{
+				{RouteID: 1, Start: []byte("a"), End: []byte("b"), Writes: 11, RaftGroupID: 7, LeaderTerm: 43},
 			},
 		},
 	}})
@@ -525,10 +536,12 @@ func TestKeyVizHandlerStampsRaftIdentity(t *testing.T) {
 	require.Len(t, matrix.Rows, 2)
 	r1, r2 := matrix.Rows[0], matrix.Rows[1]
 	require.Equal(t, "route:1", r1.BucketID)
-	require.Equal(t, uint64(7), r1.RaftGroupID, "RaftGroupID must propagate to JSON raft_group_id")
-	require.Equal(t, uint64(42), r1.LeaderTerm, "LeaderTerm must propagate to JSON leader_term")
-	// route:2 — zero values stay zero.
+	// Per-cell: col0 was term 42, col1 was term 43 (mid-window flip).
+	require.Equal(t, []uint64{7, 7}, r1.RaftGroupIDs, "raft_group_ids must be parallel to values")
+	require.Equal(t, []uint64{42, 43}, r1.LeaderTerms,
+		"leader_terms must capture per-column term so the aggregator can dedupe across the flip")
+	// route:2 — present only in col0; col1 zero is the "term not tracked" sentinel.
 	require.Equal(t, "route:2", r2.BucketID)
-	require.Equal(t, uint64(0), r2.RaftGroupID)
-	require.Equal(t, uint64(0), r2.LeaderTerm)
+	require.Equal(t, []uint64{0, 0}, r2.RaftGroupIDs)
+	require.Equal(t, []uint64{0, 0}, r2.LeaderTerms)
 }

--- a/main.go
+++ b/main.go
@@ -1559,10 +1559,22 @@ type groupTermSnapshot struct {
 func publishLeaderTerms(s *keyviz.MemSampler, runtimes []*raftGroupRuntime) {
 	snaps := make([]groupTermSnapshot, 0, len(runtimes))
 	for _, rt := range runtimes {
-		if rt == nil || rt.engine == nil {
+		if rt == nil {
 			continue
 		}
-		snaps = append(snaps, groupTermSnapshot{groupID: rt.spec.id, term: rt.engine.Status().Term})
+		// Snapshot rt.engine into a local once so a concurrent
+		// rt.Close() (which sets rt.engine = nil) cannot race the
+		// nil-check and the Status() call. On startup-error paths
+		// that return before joining all goroutines (e.g.
+		// setupAdminService failing), this goroutine can otherwise
+		// observe rt.engine going nil between the two reads and
+		// panic / trigger a race-detector failure. (Codex P2 on
+		// PR #720.)
+		engine := rt.engine
+		if engine == nil {
+			continue
+		}
+		snaps = append(snaps, groupTermSnapshot{groupID: rt.spec.id, term: engine.Status().Term})
 	}
 	publishLeaderTermsFromSnapshots(s, snaps)
 }

--- a/main.go
+++ b/main.go
@@ -335,6 +335,7 @@ func run() error {
 		return runDistributionCatalogWatcher(runCtx, distCatalog, cfg.engine)
 	})
 	startKeyVizFlusher(runCtx, eg, sampler)
+	startKeyVizLeaderTermPublisher(runCtx, eg, sampler, runtimes)
 	startMemoryWatchdog(runCtx, eg, cancel)
 	distServer := adapter.NewDistributionServer(
 		cfg.engine,
@@ -1501,4 +1502,80 @@ func startKeyVizFlusher(ctx context.Context, eg *errgroup.Group, s *keyviz.MemSa
 		s.Flush()
 		return nil
 	})
+}
+
+// startKeyVizLeaderTermPublisher polls each Raft group's current term
+// at the sampler's flush cadence and publishes it via
+// MemSampler.SetLeaderTerm so subsequent column flushes stamp
+// MatrixRow.LeaderTerm. The poll cadence is the same as the flush
+// step because every flush column should observe a fresh term —
+// publishing more often costs RLocks for no benefit; publishing less
+// often opens a window where the column inherits a stale term from
+// the previous flush.
+//
+// Skip the goroutine entirely when the sampler is disabled or when
+// no runtimes are wired (single-process tests / cmd/client). With no
+// publisher running, MatrixRow.LeaderTerm stays zero and the fan-out
+// aggregator falls back to the legacy max-merge — no behavior change
+// versus PR #709.
+func startKeyVizLeaderTermPublisher(ctx context.Context, eg *errgroup.Group, s *keyviz.MemSampler, runtimes []*raftGroupRuntime) {
+	if s == nil || len(runtimes) == 0 {
+		return
+	}
+	eg.Go(func() error {
+		step := s.Step()
+		if step <= 0 {
+			step = keyviz.DefaultStep
+		}
+		t := time.NewTicker(step)
+		defer t.Stop()
+		// Publish once immediately so the very first flush column sees
+		// a non-zero term — without this, the column built between
+		// startup and the first ticker fire would carry LeaderTerm=0
+		// for every group, which the fan-out merge interprets as the
+		// legacy max-merge fallback.
+		publishLeaderTerms(s, runtimes)
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-t.C:
+				publishLeaderTerms(s, runtimes)
+			}
+		}
+	})
+}
+
+// groupTermSnapshot pairs a Raft group ID with the term observed
+// from its engine at one publish moment. Pulled out as its own type
+// so publishLeaderTermsFromSnapshots can be tested without a real
+// raftengine.Engine fake (the interface is too wide to mock cheaply
+// for a unit test of this 5-line publication step).
+type groupTermSnapshot struct {
+	groupID uint64
+	term    uint64
+}
+
+func publishLeaderTerms(s *keyviz.MemSampler, runtimes []*raftGroupRuntime) {
+	snaps := make([]groupTermSnapshot, 0, len(runtimes))
+	for _, rt := range runtimes {
+		if rt == nil || rt.engine == nil {
+			continue
+		}
+		snaps = append(snaps, groupTermSnapshot{groupID: rt.spec.id, term: rt.engine.Status().Term})
+	}
+	publishLeaderTermsFromSnapshots(s, snaps)
+}
+
+// publishLeaderTermsFromSnapshots applies a precomputed
+// (groupID, term) set to the sampler. Split out of
+// publishLeaderTerms so unit tests can exercise the publish step
+// without standing up a full raftengine.Engine.
+func publishLeaderTermsFromSnapshots(s *keyviz.MemSampler, snaps []groupTermSnapshot) {
+	if s == nil {
+		return
+	}
+	for _, sn := range snaps {
+		s.SetLeaderTerm(sn.groupID, sn.term)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -1559,18 +1559,15 @@ type groupTermSnapshot struct {
 func publishLeaderTerms(s *keyviz.MemSampler, runtimes []*raftGroupRuntime) {
 	snaps := make([]groupTermSnapshot, 0, len(runtimes))
 	for _, rt := range runtimes {
-		if rt == nil {
-			continue
-		}
-		// Snapshot rt.engine into a local once so a concurrent
-		// rt.Close() (which sets rt.engine = nil) cannot race the
-		// nil-check and the Status() call. On startup-error paths
-		// that return before joining all goroutines (e.g.
-		// setupAdminService failing), this goroutine can otherwise
-		// observe rt.engine going nil between the two reads and
-		// panic / trigger a race-detector failure. (Codex P2 on
-		// PR #720.)
-		engine := rt.engine
+		// snapshotEngine takes engineMu.RLock so a concurrent
+		// rt.Close() (which clears rt.engine while holding the
+		// write lock) cannot race the publisher's read. On
+		// startup-error paths that fire cleanup before
+		// joining all goroutines, this lock prevents the
+		// race-detector failure and the undefined-behavior
+		// nil-pointer dereference Codex round-1/round-2 P2
+		// flagged on PR #720.
+		engine := rt.snapshotEngine()
 		if engine == nil {
 			continue
 		}

--- a/main_admin.go
+++ b/main_admin.go
@@ -825,16 +825,22 @@ func newClusterInfoSource(nodeID, version string, runtimes []*raftGroupRuntime) 
 	return admin.ClusterInfoFunc(func(ctx context.Context) (admin.ClusterInfo, error) {
 		groups := make([]admin.GroupInfo, 0, len(runtimes))
 		for _, rt := range runtimes {
-			if rt == nil || rt.engine == nil {
+			// snapshotEngine takes engineMu.RLock so this
+			// HTTP/gRPC handler running on its own goroutine
+			// cannot race rt.Close() clearing the field on
+			// shutdown. Same race class as the keyviz
+			// leader-term publisher (Codex P2 on PR #720).
+			engine := rt.snapshotEngine()
+			if engine == nil {
 				continue
 			}
-			status := rt.engine.Status()
+			status := engine.Status()
 			// Seed as an empty-but-non-nil slice so a
 			// Configuration() failure still JSON-encodes as `[]`
 			// rather than `null`; API consumers that treat
 			// members as an always-array field rely on this.
 			members := []string{}
-			if cfg, err := rt.engine.Configuration(ctx); err == nil {
+			if cfg, err := engine.Configuration(ctx); err == nil {
 				members = make([]string, 0, len(cfg.Servers))
 				for _, srv := range cfg.Servers {
 					members = append(members, srv.ID)

--- a/main_keyviz_test.go
+++ b/main_keyviz_test.go
@@ -95,6 +95,66 @@ func TestStartKeyVizFlusherReturnsAfterCancel(t *testing.T) {
 	require.True(t, saw, "post-cancel Flush did not harvest pending Observe")
 }
 
+// TestPublishLeaderTermsFromSnapshotsStampsRows pins the bridge
+// between the main.go ticker and the keyviz sampler: a published
+// snapshot for a group surfaces on every subsequent flushed row for
+// routes registered with that groupID. The snapshot publish is the
+// only mechanism that takes RaftGroupID/LeaderTerm from a non-zero
+// "term not tracked" baseline to a useful per-term dedupe key in the
+// fan-out aggregator (PR-3c).
+func TestPublishLeaderTermsFromSnapshotsStampsRows(t *testing.T) {
+	t.Parallel()
+	s := keyviz.NewMemSampler(keyviz.MemSamplerOptions{Step: time.Second, HistoryColumns: 4})
+	require.True(t, s.RegisterRoute(1, []byte("a"), []byte("b"), 7))
+	publishLeaderTermsFromSnapshots(s, []groupTermSnapshot{
+		{groupID: 7, term: 42},
+	})
+	s.Observe(1, keyviz.OpWrite, 16, 64)
+	s.Flush()
+	cols := s.Snapshot(time.Time{}, time.Time{})
+	require.Len(t, cols, 1)
+	require.Len(t, cols[0].Rows, 1)
+	require.Equal(t, uint64(7), cols[0].Rows[0].RaftGroupID)
+	require.Equal(t, uint64(42), cols[0].Rows[0].LeaderTerm)
+}
+
+// TestPublishLeaderTermsFromSnapshotsNilSafe pins the
+// nil-receiver-safe contract: main.go can call the publish step
+// before the sampler is constructed (or when keyviz is disabled)
+// without panicking.
+func TestPublishLeaderTermsFromSnapshotsNilSafe(t *testing.T) {
+	t.Parallel()
+	require.NotPanics(t, func() {
+		publishLeaderTermsFromSnapshots(nil, []groupTermSnapshot{{groupID: 1, term: 2}})
+	})
+}
+
+// TestStartKeyVizLeaderTermPublisherSkipsWhenSamplerNil pins that
+// the goroutine is not launched when the sampler is disabled — the
+// errgroup must close cleanly without a hanging goroutine.
+func TestStartKeyVizLeaderTermPublisherSkipsWhenSamplerNil(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	eg, _ := errgroup.WithContext(ctx)
+	startKeyVizLeaderTermPublisher(ctx, eg, nil, []*raftGroupRuntime{{spec: groupSpec{id: 1}}})
+	require.NoError(t, eg.Wait(),
+		"errgroup must close immediately because no goroutine should have launched")
+}
+
+// TestStartKeyVizLeaderTermPublisherSkipsWhenNoRuntimes pins the
+// other no-op branch: a configured sampler but zero runtimes should
+// not launch a goroutine that would just spin doing nothing.
+func TestStartKeyVizLeaderTermPublisherSkipsWhenNoRuntimes(t *testing.T) {
+	t.Parallel()
+	s := keyviz.NewMemSampler(keyviz.MemSamplerOptions{Step: time.Millisecond, HistoryColumns: 4})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	eg, _ := errgroup.WithContext(ctx)
+	startKeyVizLeaderTermPublisher(ctx, eg, s, nil)
+	require.NoError(t, eg.Wait())
+}
+
 func withFlags(
 	t *testing.T,
 	enabled bool,

--- a/multiraft_runtime.go
+++ b/multiraft_runtime.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/bootjp/elastickv/internal/raftengine"
 	"github.com/bootjp/elastickv/store"
@@ -14,12 +15,36 @@ import (
 )
 
 type raftGroupRuntime struct {
-	spec   groupSpec
-	engine raftengine.Engine
-	store  store.MVCCStore
+	spec groupSpec
+	// engineMu guards engine to allow concurrent readers
+	// (specifically the keyviz leader-term publisher goroutine that
+	// runs on a ticker independent of startup ordering) to coexist
+	// with Close() which clears the field on shutdown. Direct field
+	// reads from the startup path remain safe because they execute
+	// single-threaded before any goroutine is launched; long-lived
+	// goroutines that read after startup must go through
+	// snapshotEngine() (Codex P2 on PR #720).
+	engineMu sync.RWMutex
+	engine   raftengine.Engine
+
+	store store.MVCCStore
 
 	registerTransport func(grpc.ServiceRegistrar)
 	closeFactory      func() error // releases factory-created resources (transport, stores)
+}
+
+// snapshotEngine returns the current engine reference under engineMu.
+// Long-lived goroutines that may run while Close() executes (the
+// keyviz leader-term publisher; future racy readers as they're
+// migrated) MUST go through this accessor instead of reading the
+// engine field directly. nil-receiver-safe.
+func (r *raftGroupRuntime) snapshotEngine() raftengine.Engine {
+	if r == nil {
+		return nil
+	}
+	r.engineMu.RLock()
+	defer r.engineMu.RUnlock()
+	return r.engine
 }
 
 const raftEngineMarkerPerm = 0o600
@@ -50,11 +75,14 @@ func (r *raftGroupRuntime) Close() {
 	if r == nil {
 		return
 	}
-	if r.engine != nil {
-		if err := r.engine.Close(); err != nil {
+	r.engineMu.Lock()
+	engine := r.engine
+	r.engine = nil
+	r.engineMu.Unlock()
+	if engine != nil {
+		if err := engine.Close(); err != nil {
 			slog.Warn("failed to close raft engine", "error", err)
 		}
-		r.engine = nil
 	}
 	if r.closeFactory != nil {
 		if err := r.closeFactory(); err != nil {

--- a/proto/admin.pb.go
+++ b/proto/admin.pb.go
@@ -716,7 +716,18 @@ type KeyVizRow struct {
 	// values[j] is the series value at time column j.
 	Values []uint64 `protobuf:"varint,11,rep,packed,name=values,proto3" json:"values,omitempty"`
 	// soft_columns[j] is true when the j-th column missed the estimator SLO.
-	SoftColumns   []bool `protobuf:"varint,12,rep,packed,name=soft_columns,json=softColumns,proto3" json:"soft_columns,omitempty"`
+	SoftColumns []bool `protobuf:"varint,12,rep,packed,name=soft_columns,json=softColumns,proto3" json:"soft_columns,omitempty"`
+	// raft_group_id and leader_term carry the route's Raft identity at
+	// the time the column was flushed. Phase 2-C+ fan-out uses
+	// (bucket_id, raft_group_id, leader_term, column) as the dedupe
+	// key so writes from a leader and the previous leader of the same
+	// group can be summed across terms instead of conservatively
+	// max-merged. Zero values mean "term not tracked" (single-group
+	// legacy deployments, virtual aggregate buckets, or nodes that
+	// have not yet wired the leader-term publisher) — the aggregator
+	// falls back to the legacy max-merge for those cells.
+	RaftGroupId   uint64 `protobuf:"varint,13,opt,name=raft_group_id,json=raftGroupId,proto3" json:"raft_group_id,omitempty"`
+	LeaderTerm    uint64 `protobuf:"varint,14,opt,name=leader_term,json=leaderTerm,proto3" json:"leader_term,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -833,6 +844,20 @@ func (x *KeyVizRow) GetSoftColumns() []bool {
 		return x.SoftColumns
 	}
 	return nil
+}
+
+func (x *KeyVizRow) GetRaftGroupId() uint64 {
+	if x != nil {
+		return x.RaftGroupId
+	}
+	return 0
+}
+
+func (x *KeyVizRow) GetLeaderTerm() uint64 {
+	if x != nil {
+		return x.LeaderTerm
+	}
+	return 0
 }
 
 type GetKeyVizMatrixRequest struct {
@@ -1357,7 +1382,7 @@ const file_admin_proto_rawDesc = "" +
 	"\x06p99_ns\x18\t \x01(\x01R\x05p99Ns\"\x1a\n" +
 	"\x18GetAdapterSummaryRequest\"J\n" +
 	"\x19GetAdapterSummaryResponse\x12-\n" +
-	"\tsummaries\x18\x01 \x03(\v2\x0f.AdapterSummaryR\tsummaries\"\xfc\x02\n" +
+	"\tsummaries\x18\x01 \x03(\v2\x0f.AdapterSummaryR\tsummaries\"\xc1\x03\n" +
 	"\tKeyVizRow\x12\x1b\n" +
 	"\tbucket_id\x18\x01 \x01(\tR\bbucketId\x12\x14\n" +
 	"\x05start\x18\x02 \x01(\fR\x05start\x12\x10\n" +
@@ -1373,7 +1398,10 @@ const file_admin_proto_rawDesc = "" +
 	"lineage_id\x18\n" +
 	" \x01(\tR\tlineageId\x12\x16\n" +
 	"\x06values\x18\v \x03(\x04R\x06values\x12!\n" +
-	"\fsoft_columns\x18\f \x03(\bR\vsoftColumns\"\x93\x01\n" +
+	"\fsoft_columns\x18\f \x03(\bR\vsoftColumns\x12\"\n" +
+	"\rraft_group_id\x18\r \x01(\x04R\vraftGroupId\x12\x1f\n" +
+	"\vleader_term\x18\x0e \x01(\x04R\n" +
+	"leaderTerm\"\x93\x01\n" +
 	"\x16GetKeyVizMatrixRequest\x12%\n" +
 	"\x06series\x18\x01 \x01(\x0e2\r.KeyVizSeriesR\x06series\x12 \n" +
 	"\ffrom_unix_ms\x18\x02 \x01(\x03R\n" +

--- a/proto/admin.pb.go
+++ b/proto/admin.pb.go
@@ -717,17 +717,28 @@ type KeyVizRow struct {
 	Values []uint64 `protobuf:"varint,11,rep,packed,name=values,proto3" json:"values,omitempty"`
 	// soft_columns[j] is true when the j-th column missed the estimator SLO.
 	SoftColumns []bool `protobuf:"varint,12,rep,packed,name=soft_columns,json=softColumns,proto3" json:"soft_columns,omitempty"`
-	// raft_group_id and leader_term carry the route's Raft identity at
-	// the time the column was flushed. Phase 2-C+ fan-out uses
-	// (bucket_id, raft_group_id, leader_term, column) as the dedupe
-	// key so writes from a leader and the previous leader of the same
-	// group can be summed across terms instead of conservatively
-	// max-merged. Zero values mean "term not tracked" (single-group
-	// legacy deployments, virtual aggregate buckets, or nodes that
-	// have not yet wired the leader-term publisher) — the aggregator
-	// falls back to the legacy max-merge for those cells.
-	RaftGroupId   uint64 `protobuf:"varint,13,opt,name=raft_group_id,json=raftGroupId,proto3" json:"raft_group_id,omitempty"`
-	LeaderTerm    uint64 `protobuf:"varint,14,opt,name=leader_term,json=leaderTerm,proto3" json:"leader_term,omitempty"`
+	// raft_group_ids[j] and leader_terms[j] carry the route's Raft
+	// identity at the time column j was flushed. Phase 2-C+ fan-out
+	// uses (bucket_id, raft_group_id, leader_term, column) as the
+	// dedupe key, so writes from a leader and the previous leader of
+	// the same group can be summed across terms instead of
+	// conservatively max-merged. Per-cell representation (parallel to
+	// values[] and soft_columns[]) is required because leadership can
+	// flip within the requested window; a single row-level scalar
+	// would only capture the first column's identity and cause
+	// incorrect dedupe for later columns (Gemini HIGH on PR #720).
+	// Zero values mean "term not tracked" (single-group legacy
+	// deployments, virtual aggregate buckets, or nodes that have not
+	// yet wired the leader-term publisher) — the aggregator falls
+	// back to the legacy max-merge for those cells.
+	//
+	// Both slices are either empty (legacy server, no per-column
+	// identity to share — older clients reading the response can
+	// treat empty as "all zeros") or `len(raft_group_ids) ==
+	// len(leader_terms) == len(values)`. The server never emits a
+	// partial-length slice.
+	RaftGroupIds  []uint64 `protobuf:"varint,13,rep,packed,name=raft_group_ids,json=raftGroupIds,proto3" json:"raft_group_ids,omitempty"`
+	LeaderTerms   []uint64 `protobuf:"varint,14,rep,packed,name=leader_terms,json=leaderTerms,proto3" json:"leader_terms,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -846,18 +857,18 @@ func (x *KeyVizRow) GetSoftColumns() []bool {
 	return nil
 }
 
-func (x *KeyVizRow) GetRaftGroupId() uint64 {
+func (x *KeyVizRow) GetRaftGroupIds() []uint64 {
 	if x != nil {
-		return x.RaftGroupId
+		return x.RaftGroupIds
 	}
-	return 0
+	return nil
 }
 
-func (x *KeyVizRow) GetLeaderTerm() uint64 {
+func (x *KeyVizRow) GetLeaderTerms() []uint64 {
 	if x != nil {
-		return x.LeaderTerm
+		return x.LeaderTerms
 	}
-	return 0
+	return nil
 }
 
 type GetKeyVizMatrixRequest struct {
@@ -1382,7 +1393,7 @@ const file_admin_proto_rawDesc = "" +
 	"\x06p99_ns\x18\t \x01(\x01R\x05p99Ns\"\x1a\n" +
 	"\x18GetAdapterSummaryRequest\"J\n" +
 	"\x19GetAdapterSummaryResponse\x12-\n" +
-	"\tsummaries\x18\x01 \x03(\v2\x0f.AdapterSummaryR\tsummaries\"\xc1\x03\n" +
+	"\tsummaries\x18\x01 \x03(\v2\x0f.AdapterSummaryR\tsummaries\"\xc5\x03\n" +
 	"\tKeyVizRow\x12\x1b\n" +
 	"\tbucket_id\x18\x01 \x01(\tR\bbucketId\x12\x14\n" +
 	"\x05start\x18\x02 \x01(\fR\x05start\x12\x10\n" +
@@ -1398,10 +1409,9 @@ const file_admin_proto_rawDesc = "" +
 	"lineage_id\x18\n" +
 	" \x01(\tR\tlineageId\x12\x16\n" +
 	"\x06values\x18\v \x03(\x04R\x06values\x12!\n" +
-	"\fsoft_columns\x18\f \x03(\bR\vsoftColumns\x12\"\n" +
-	"\rraft_group_id\x18\r \x01(\x04R\vraftGroupId\x12\x1f\n" +
-	"\vleader_term\x18\x0e \x01(\x04R\n" +
-	"leaderTerm\"\x93\x01\n" +
+	"\fsoft_columns\x18\f \x03(\bR\vsoftColumns\x12$\n" +
+	"\x0eraft_group_ids\x18\r \x03(\x04R\fraftGroupIds\x12!\n" +
+	"\fleader_terms\x18\x0e \x03(\x04R\vleaderTerms\"\x93\x01\n" +
 	"\x16GetKeyVizMatrixRequest\x12%\n" +
 	"\x06series\x18\x01 \x01(\x0e2\r.KeyVizSeriesR\x06series\x12 \n" +
 	"\ffrom_unix_ms\x18\x02 \x01(\x03R\n" +

--- a/proto/admin.proto
+++ b/proto/admin.proto
@@ -103,17 +103,28 @@ message KeyVizRow {
   repeated uint64 values = 11;
   // soft_columns[j] is true when the j-th column missed the estimator SLO.
   repeated bool soft_columns = 12;
-  // raft_group_id and leader_term carry the route's Raft identity at
-  // the time the column was flushed. Phase 2-C+ fan-out uses
-  // (bucket_id, raft_group_id, leader_term, column) as the dedupe
-  // key so writes from a leader and the previous leader of the same
-  // group can be summed across terms instead of conservatively
-  // max-merged. Zero values mean "term not tracked" (single-group
-  // legacy deployments, virtual aggregate buckets, or nodes that
-  // have not yet wired the leader-term publisher) — the aggregator
-  // falls back to the legacy max-merge for those cells.
-  uint64 raft_group_id = 13;
-  uint64 leader_term = 14;
+  // raft_group_ids[j] and leader_terms[j] carry the route's Raft
+  // identity at the time column j was flushed. Phase 2-C+ fan-out
+  // uses (bucket_id, raft_group_id, leader_term, column) as the
+  // dedupe key, so writes from a leader and the previous leader of
+  // the same group can be summed across terms instead of
+  // conservatively max-merged. Per-cell representation (parallel to
+  // values[] and soft_columns[]) is required because leadership can
+  // flip within the requested window; a single row-level scalar
+  // would only capture the first column's identity and cause
+  // incorrect dedupe for later columns (Gemini HIGH on PR #720).
+  // Zero values mean "term not tracked" (single-group legacy
+  // deployments, virtual aggregate buckets, or nodes that have not
+  // yet wired the leader-term publisher) — the aggregator falls
+  // back to the legacy max-merge for those cells.
+  //
+  // Both slices are either empty (legacy server, no per-column
+  // identity to share — older clients reading the response can
+  // treat empty as "all zeros") or `len(raft_group_ids) ==
+  // len(leader_terms) == len(values)`. The server never emits a
+  // partial-length slice.
+  repeated uint64 raft_group_ids = 13;
+  repeated uint64 leader_terms = 14;
 }
 
 message GetKeyVizMatrixRequest {

--- a/proto/admin.proto
+++ b/proto/admin.proto
@@ -103,6 +103,17 @@ message KeyVizRow {
   repeated uint64 values = 11;
   // soft_columns[j] is true when the j-th column missed the estimator SLO.
   repeated bool soft_columns = 12;
+  // raft_group_id and leader_term carry the route's Raft identity at
+  // the time the column was flushed. Phase 2-C+ fan-out uses
+  // (bucket_id, raft_group_id, leader_term, column) as the dedupe
+  // key so writes from a leader and the previous leader of the same
+  // group can be summed across terms instead of conservatively
+  // max-merged. Zero values mean "term not tracked" (single-group
+  // legacy deployments, virtual aggregate buckets, or nodes that
+  // have not yet wired the leader-term publisher) — the aggregator
+  // falls back to the legacy max-merge for those cells.
+  uint64 raft_group_id = 13;
+  uint64 leader_term = 14;
 }
 
 message GetKeyVizMatrixRequest {


### PR DESCRIPTION
## Summary

Build the end-to-end pipeline that takes the sampler-side `RaftGroupID + LeaderTerm` fields shipped in PR #709 (Phase 2-C+ PR-3a) and surfaces them on the wire (proto + JSON + gRPC) so the fan-out aggregator (PR-3c, next) has data to dedupe by `(group, term)` instead of the conservative §4.2 max-merge.

## Why

Per `docs/design/2026_04_27_proposed_keyviz_cluster_fanout.md` §4.2, the cluster fan-out today max-merges write samples per row — under stable leadership this is exact, but under a leadership flip it understates the true window total by at most one leader's pre-transfer slice. §9.1's canonical fix is to dedupe by `(bucket_id, raft_group_id, leader_term, column)` and sum across terms; that needs `raft_group_id + leader_term` on every row of the wire format. PR #709 added the fields to `MatrixRow`; this PR plumbs them through.

## Changes

**Wire-format additions (forward-compatible):**

- `proto/admin.proto`: `KeyVizRow.raft_group_id = 13` and `leader_term = 14`. Old SPAs ignore the new fields; old servers don't emit them — the zero value is the documented "term not tracked" fallback that triggers the legacy max-merge.
- `internal/admin/keyviz_handler.go`: JSON `KeyVizRow` gains `RaftGroupID` and `LeaderTerm` (omitempty); `newKeyVizRowFrom` copies `mr.RaftGroupID` / `mr.LeaderTerm`.
- `internal/admin/keyviz_fanout.go`: `mergeRowInto` seeds the destination row with `RaftGroupID + LeaderTerm` on first-seen (PR-3c will switch to a per-cell merge).
- `adapter/admin_grpc.go`: `newKeyVizRowFrom` copies the same two fields onto the proto `KeyVizRow`.

**main.go ticker:**

- `startKeyVizLeaderTermPublisher` launches a goroutine that polls each `runtime.engine.Status().Term` every `Step` (matching the flush cadence so each column observes a fresh term). Skips entirely when the sampler is nil or no runtimes are wired.
- `publishLeaderTerms` / `publishLeaderTermsFromSnapshots` split into two helpers so unit tests can exercise publication without standing up a full `raftengine.Engine` fake.
- The ticker publishes once immediately so the very first flush column carries a non-zero term.

## Scope (PR-3b only)

- Wire format **emission**: ✓ this PR
- Ticker that **publishes** terms via `SetLeaderTerm`: ✓ this PR
- Aggregator **consumption** (per-cell `(group, term)` merge replacing max-merge): **deferred to PR-3c**
- `Conflict` per-cell promotion: **deferred to PR-3c**
- SPA changes: **none required** — the wire-format extension is forward-compatible

With this PR alone, the new fields are visible on every response but the aggregator still uses §4.2 max-merge → no behavior change for SPA consumers.

## Test plan

- [x] `go test -race -count=1 ./keyviz/... ./internal/admin/...` — passes
- [x] New test coverage:
  - `TestKeyVizHandlerStampsRaftIdentity` (JSON path)
  - `TestMergeKeyVizMatricesPreservesRaftIdentity` (fan-out merge)
  - `TestGetKeyVizMatrixStampsRaftIdentity` (gRPC path)
  - `TestPublishLeaderTermsFromSnapshotsStampsRows` (end-to-end through sampler)
  - `TestPublishLeaderTermsFromSnapshotsNilSafe` (nil-receiver contract)
  - `TestStartKeyVizLeaderTermPublisherSkipsWhenSamplerNil / ...WhenNoRuntimes` (errgroup lifecycle)
- [x] `go build ./...` — clean
- [x] `golangci-lint run` — 0 issues
- [ ] Jepsen — N/A (admin-side wire extension, no replication/MVCC/OCC impact)

## Five-lens self-review

1. **Data loss** — wire-format extension only; legacy max-merge fallback preserves today's behavior when `LeaderTerm=0`.
2. **Concurrency** — ticker is a single goroutine; `SetLeaderTerm` takes `groupTermsMu` (Phase 2-C+ PR-3a contract); no new shared state.
3. **Performance** — `Observe` hot path is unchanged; ticker adds `N × Status()` calls per `Step` where `N` is the runtime count (typically ≤ a few groups), and `Status()` is a non-blocking read.
4. **Data consistency** — `RaftGroupID + LeaderTerm` round-trip through every wire path verified by table-driven tests.
5. **Test coverage** — each layer (JSON, fan-out, gRPC, publisher) has its own focused regression guard; end-to-end test pins the sampler→column propagation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyviz matrix now includes Raft leadership metadata with group ID and leader term fields in responses.
  * Leadership term information is automatically tracked and included in key visualization output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->