### PR TITLE
feat(encryption): sidecar crash-durable read/write (Stage 1)

### DIFF
--- a/internal/encryption/errors.go
+++ b/internal/encryption/errors.go
@@ -39,4 +39,20 @@ var (
 	// Surfaced at construction time so a wiring mistake is caught
 	// before the first Encrypt/Decrypt would otherwise nil-deref panic.
 	ErrNilKeystore = errors.New("encryption: keystore is nil")
+
+	// ErrUnsupportedFilesystem indicates the parent directory of the
+	// sidecar cannot guarantee crash-durability of os.Rename via
+	// fsync (typical on NFS, some FUSE mounts). Per §5.1 the
+	// encryption package refuses to start in that situation rather
+	// than silently degrading the durability guarantee. WriteSidecar
+	// wraps any fsync-on-directory failure with this sentinel so the
+	// Stage 5+ startup integration can errors.Is-match it.
+	ErrUnsupportedFilesystem = errors.New("encryption: filesystem does not support durable directory sync (NFS, some FUSE mounts are unsupported)")
+
+	// ErrSidecarActiveKeyMissing indicates the Sidecar has a non-zero
+	// Active.{Storage,Raft} key_id that does not appear in the Keys
+	// map. The two halves are written together by every rotation /
+	// bootstrap path; an Active id without a corresponding wrapped
+	// DEK is malformed input.
+	ErrSidecarActiveKeyMissing = errors.New("encryption: sidecar active key_id has no entry in keys map")
 )

--- a/internal/encryption/errors.go
+++ b/internal/encryption/errors.go
@@ -47,4 +47,20 @@ var (
 	// rather than silently overwriting. Set with the SAME bytes is
 	// idempotent (returns nil) and does not raise this error.
 	ErrKeyConflict = errors.New("encryption: key_id already loaded with different key material")
+
+	// ErrUnsupportedFilesystem indicates the parent directory of the
+	// sidecar cannot guarantee crash-durability of os.Rename via
+	// fsync (typical on NFS, some FUSE mounts). Per §5.1 the
+	// encryption package refuses to start in that situation rather
+	// than silently degrading the durability guarantee. WriteSidecar
+	// wraps any fsync-on-directory failure with this sentinel so the
+	// Stage 5+ startup integration can errors.Is-match it.
+	ErrUnsupportedFilesystem = errors.New("encryption: filesystem does not support durable directory sync (NFS, some FUSE mounts are unsupported)")
+
+	// ErrSidecarActiveKeyMissing indicates the Sidecar has a non-zero
+	// Active.{Storage,Raft} key_id that does not appear in the Keys
+	// map. The two halves are written together by every rotation /
+	// bootstrap path; an Active id without a corresponding wrapped
+	// DEK is malformed input.
+	ErrSidecarActiveKeyMissing = errors.New("encryption: sidecar active key_id has no entry in keys map")
 )

--- a/internal/encryption/errors.go
+++ b/internal/encryption/errors.go
@@ -63,4 +63,12 @@ var (
 	// bootstrap path; an Active id without a corresponding wrapped
 	// DEK is malformed input.
 	ErrSidecarActiveKeyMissing = errors.New("encryption: sidecar active key_id has no entry in keys map")
+
+	// ErrSidecarActivePurposeMismatch indicates the Sidecar has a
+	// non-zero Active.{Storage,Raft} key_id pointing to a Keys entry
+	// whose Purpose does not match the slot. e.g., active.storage=7
+	// but Keys["7"].purpose == "raft". Crossed pointers would route
+	// the wrong DEK into a purpose-specific encryption path after
+	// restart or rotation, so the reader fails closed.
+	ErrSidecarActivePurposeMismatch = errors.New("encryption: sidecar active key_id references a key with mismatched purpose")
 )

--- a/internal/encryption/sidecar.go
+++ b/internal/encryption/sidecar.go
@@ -130,12 +130,36 @@ func ReadSidecar(path string) (*Sidecar, error) {
 }
 
 // validateSidecar enforces the constraints ReadSidecar applies after
-// successful JSON unmarshal.
+// successful JSON unmarshal. Same predicate is run by WriteSidecar
+// before the on-disk write so a malformed sidecar cannot land on disk
+// via this package.
 func validateSidecar(sc *Sidecar) error {
 	for idStr, k := range sc.Keys {
 		if err := validateSidecarKey(idStr, k); err != nil {
 			return err
 		}
+	}
+	// Active.Storage / Active.Raft, when non-zero, must reference an
+	// entry that actually exists in Keys. Rotation and bootstrap paths
+	// always write the wrapped DEK and the Active pointer together; an
+	// Active id without a corresponding entry is malformed input.
+	if err := requireActiveKey(sc, "storage", sc.Active.Storage); err != nil {
+		return err
+	}
+	if err := requireActiveKey(sc, "raft", sc.Active.Raft); err != nil {
+		return err
+	}
+	return nil
+}
+
+func requireActiveKey(sc *Sidecar, purpose string, id uint32) error {
+	if id == ReservedKeyID {
+		return nil // not bootstrapped for this purpose; nothing to check
+	}
+	idStr := strconv.FormatUint(uint64(id), 10)
+	if _, ok := sc.Keys[idStr]; !ok {
+		return pkgerrors.Wrapf(ErrSidecarActiveKeyMissing,
+			"active.%s=%d not present in keys map", purpose, id)
 	}
 	return nil
 }
@@ -177,12 +201,17 @@ func WriteSidecar(path string, sc *Sidecar) (retErr error) {
 	if sc == nil {
 		return pkgerrors.New("encryption: WriteSidecar: sc is nil")
 	}
-	sc.Version = SidecarVersion
-	if err := validateSidecar(sc); err != nil {
+	// Operate on a shallow copy so the caller's Version field (and any
+	// other future field WriteSidecar might fill in) is not mutated as
+	// a side effect. Sidecar.Keys is a map and is shared by the copy,
+	// but validateSidecar / json.Marshal are read-only over it.
+	scCopy := *sc
+	scCopy.Version = SidecarVersion
+	if err := validateSidecar(&scCopy); err != nil {
 		return pkgerrors.Wrap(err, "encryption: validate before write")
 	}
 
-	data, err := json.MarshalIndent(sc, "", "  ")
+	data, err := json.MarshalIndent(&scCopy, "", "  ")
 	if err != nil {
 		return pkgerrors.Wrap(err, "encryption: marshal sidecar")
 	}
@@ -190,36 +219,62 @@ func WriteSidecar(path string, sc *Sidecar) (retErr error) {
 	dir := filepath.Dir(path)
 	tmpPath := filepath.Join(dir, filepath.Base(path)+".tmp")
 
-	if err := writeTmpAndFsync(tmpPath, data); err != nil {
-		return err
-	}
-	// Best-effort cleanup of the tmp file if anything below fails. On
-	// the success path it has already been renamed and removal is a
-	// no-op.
+	// Best-effort cleanup of the tmp file if anything below fails. The
+	// defer is registered BEFORE writeTmpAndFsync so a write/fsync
+	// failure inside that helper does not leak the .tmp file. On the
+	// success path the tmp has already been renamed and os.Remove is
+	// a no-op (ENOENT, ignored).
 	defer func() {
 		if retErr != nil {
 			_ = os.Remove(tmpPath)
 		}
 	}()
 
+	if err := writeTmpAndFsync(tmpPath, data); err != nil {
+		return err
+	}
 	if err := os.Rename(tmpPath, path); err != nil {
 		return pkgerrors.Wrapf(err, "encryption: rename %q -> %q", tmpPath, path)
 	}
 	if err := syncDir(dir); err != nil {
-		return pkgerrors.Wrapf(err, "encryption: fsync dir %q", dir)
+		return err
 	}
 	return nil
 }
 
-// writeTmpAndFsync writes data into tmpPath and fsyncs the file.
-// Helper exists so WriteSidecar does not nest its own defer-on-error
-// inside the rename block.
-func writeTmpAndFsync(tmpPath string, data []byte) error {
-	f, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, sidecarFileMode)
+// writeTmpAndFsync writes data into tmpPath at sidecarFileMode and
+// fsyncs the file before returning. The function is responsible for
+// the per-step §5.1 durability sequence; WriteSidecar handles the
+// rename and parent-directory fsync that come after.
+//
+// Security note (PR #722 codex P2): pre-existing tmp files are
+// removed before opening, then re-created with O_EXCL so the mode is
+// guaranteed to be sidecarFileMode (0o600). Without this, a
+// pre-existing tmp file at 0o666 (e.g., from older tooling, manual
+// poking, or a crash that left perm bits broader than expected)
+// would carry its permissive mode through os.Rename into the
+// production keys.json, defeating the wrapped-DEK file-mode
+// guarantee documented in §5.1.
+//
+// Close errors are propagated via the named return: f.Close failing
+// after a successful Sync is rare but still reported, so an FD-leak
+// or write-back failure is not silently dropped.
+func writeTmpAndFsync(tmpPath string, data []byte) (retErr error) {
+	// Defence-in-depth: drop any pre-existing tmp before O_EXCL so
+	// the new file is created fresh with our mode and ownership.
+	if err := os.Remove(tmpPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return pkgerrors.Wrapf(err, "encryption: remove stale tmp %q", tmpPath)
+	}
+	f, err := os.OpenFile(tmpPath,
+		os.O_WRONLY|os.O_CREATE|os.O_TRUNC|os.O_EXCL, sidecarFileMode)
 	if err != nil {
 		return pkgerrors.Wrapf(err, "encryption: open %q", tmpPath)
 	}
-	defer func() { _ = f.Close() }()
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil && retErr == nil {
+			retErr = pkgerrors.Wrapf(closeErr, "encryption: close %q", tmpPath)
+		}
+	}()
 
 	if _, err := f.Write(data); err != nil {
 		return pkgerrors.Wrapf(err, "encryption: write %q", tmpPath)
@@ -234,9 +289,10 @@ func writeTmpAndFsync(tmpPath string, data []byte) error {
 //
 // On most POSIX filesystems this is what makes os.Rename durable. Some
 // environments (NFS, certain FUSE mounts) return an error rather than
-// silently treating it as a no-op; the caller must surface that error
-// — the §5.1 protocol explicitly refuses to start on filesystems that
-// cannot guarantee durability of the rename.
+// silently treating it as a no-op; per §5.1 the encryption package
+// refuses to start on those filesystems. syncDir wraps the underlying
+// fsync error with ErrUnsupportedFilesystem so the Stage 5+ startup
+// integration can errors.Is-match it without parsing strings.
 func syncDir(dir string) error {
 	f, err := os.Open(dir) //nolint:gosec // dir comes from operator config
 	if err != nil {
@@ -244,7 +300,9 @@ func syncDir(dir string) error {
 	}
 	defer func() { _ = f.Close() }()
 	if err := f.Sync(); err != nil {
-		return pkgerrors.Wrapf(err, "encryption: fsync dir %q", dir)
+		return pkgerrors.Wrapf(
+			pkgerrors.WithSecondaryError(ErrUnsupportedFilesystem, err),
+			"encryption: fsync dir %q", dir)
 	}
 	return nil
 }

--- a/internal/encryption/sidecar.go
+++ b/internal/encryption/sidecar.go
@@ -1,0 +1,258 @@
+package encryption
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	pkgerrors "github.com/cockroachdb/errors"
+)
+
+// sidecarFileMode is the umask-respecting file mode used for both the
+// keys.json file and the keys.json.tmp intermediate. 0o600 means the
+// wrapped DEK material is readable only by the elastickv process owner;
+// the unwrapped DEK never appears on disk regardless.
+const sidecarFileMode = 0o600
+
+// SidecarVersion is the wire version of the on-disk sidecar JSON.
+//
+// Version 1 carries the §5.1 layout (active, keys, raft_applied_index,
+// storage_envelope_active, raft_envelope_cutover_index). Future versions
+// extend the layout via additive JSON fields plus a bump here; mismatched
+// versions are rejected at read time so an older binary cannot silently
+// drop fields it does not understand.
+const SidecarVersion = 1
+
+// SidecarFilename is the standard filename inside <dataDir>/encryption/.
+const SidecarFilename = "keys.json"
+
+// SidecarTmpFilename is the filename used for the §5.1 crash-durable write
+// protocol's intermediate write.
+const SidecarTmpFilename = SidecarFilename + ".tmp"
+
+// SidecarPurposeStorage / SidecarPurposeRaft are the only purposes the
+// reader recognises. Stage 6 may add more.
+const (
+	SidecarPurposeStorage = "storage"
+	SidecarPurposeRaft    = "raft"
+)
+
+// Sidecar is the parsed §5.1 keys.json layout.
+//
+// All fields persisted under the §5.1 illustrative JSON are represented
+// here. Fields not yet present in the design (Stage 9 audit log, etc.)
+// are omitted; they will be added as additive fields when the relevant
+// stage ships.
+type Sidecar struct {
+	Version                  int        `json:"version"`
+	RaftAppliedIndex         uint64     `json:"raft_applied_index"`
+	StorageEnvelopeActive    bool       `json:"storage_envelope_active"`
+	RaftEnvelopeCutoverIndex uint64     `json:"raft_envelope_cutover_index"`
+	Active                   ActiveKeys `json:"active"`
+	// Keys is keyed by the decimal string form of key_id (per §5.1's
+	// "JSON object keys must be strings, but the on-disk envelope and
+	// the in-memory keystore always work in the binary uint32 form").
+	Keys map[string]SidecarKey `json:"keys"`
+}
+
+// ActiveKeys holds the active key_id per envelope purpose. A zero
+// value (== ReservedKeyID) means "not bootstrapped" per §5.1.
+type ActiveKeys struct {
+	Storage uint32 `json:"storage"`
+	Raft    uint32 `json:"raft"`
+}
+
+// SidecarKey holds the metadata for a single wrapped DEK.
+//
+// Wrapped is the KEK-wrapped DEK bytes (encoding/json base64-encodes
+// []byte automatically). Created is an ISO-8601 timestamp string;
+// the package keeps it as a plain string rather than time.Time so a
+// future timezone-format addition does not break older readers.
+// LocalEpoch is consumed by the §4.1 nonce construction.
+type SidecarKey struct {
+	Purpose    string `json:"purpose"`
+	Wrapped    []byte `json:"wrapped"`
+	Created    string `json:"created"`
+	LocalEpoch uint16 `json:"local_epoch"`
+}
+
+// Errors returned by sidecar I/O.
+var (
+	// ErrSidecarVersion indicates ReadSidecar saw a wire version this
+	// build does not know how to parse. Use the message and the offending
+	// version to decide whether to upgrade the binary or fall back.
+	ErrSidecarVersion = errors.New("encryption: unsupported sidecar version")
+
+	// ErrSidecarPurpose indicates a Sidecar.Keys entry has a "purpose"
+	// field outside the recognised set ({"storage","raft"}). The reader
+	// fails closed rather than silently treating an unknown purpose as a
+	// known one — a typo'd or future-version sidecar must be the
+	// operator's explicit upgrade decision.
+	ErrSidecarPurpose = errors.New("encryption: unsupported sidecar key purpose")
+
+	// ErrSidecarKeyIDFormat indicates a Sidecar.Keys map key was not a
+	// decimal uint32 string per §5.1.
+	ErrSidecarKeyIDFormat = errors.New("encryption: sidecar key_id is not a decimal uint32")
+
+	// ErrSidecarReservedKeyID indicates a Sidecar.Keys map carries
+	// key_id 0, which §5.1 reserves as the "not bootstrapped" sentinel.
+	// On-disk presence of 0 in the keys map is malformed input.
+	ErrSidecarReservedKeyID = errors.New("encryption: sidecar key_id 0 is reserved")
+)
+
+// ReadSidecar parses the keys.json file at path. It validates the wire
+// version, the per-key purpose, and the decimal-uint32 form of every
+// keys-map entry, and rejects malformed sidecars with typed errors.
+//
+// ReadSidecar does NOT KEK-unwrap the DEK bytes — it just hands the
+// caller a parsed struct. Wrapping is the kek.Wrapper's job at a
+// higher layer.
+func ReadSidecar(path string) (*Sidecar, error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // path comes from operator config, not user input
+	if err != nil {
+		return nil, pkgerrors.Wrapf(err, "encryption: read sidecar %q", path)
+	}
+	var sc Sidecar
+	if err := json.Unmarshal(raw, &sc); err != nil {
+		return nil, pkgerrors.Wrapf(err, "encryption: parse sidecar %q", path)
+	}
+	if sc.Version != SidecarVersion {
+		return nil, pkgerrors.Wrapf(ErrSidecarVersion,
+			"got version %d, want %d (path=%q)", sc.Version, SidecarVersion, path)
+	}
+	if err := validateSidecar(&sc); err != nil {
+		return nil, pkgerrors.Wrapf(err, "encryption: validate sidecar %q", path)
+	}
+	return &sc, nil
+}
+
+// validateSidecar enforces the constraints ReadSidecar applies after
+// successful JSON unmarshal.
+func validateSidecar(sc *Sidecar) error {
+	for idStr, k := range sc.Keys {
+		if err := validateSidecarKey(idStr, k); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateSidecarKey(idStr string, k SidecarKey) error {
+	id, err := strconv.ParseUint(idStr, 10, 32)
+	if err != nil {
+		return pkgerrors.Wrapf(ErrSidecarKeyIDFormat, "%q: %v", idStr, err)
+	}
+	if uint32(id) == ReservedKeyID {
+		return pkgerrors.Wrapf(ErrSidecarReservedKeyID, "found key_id %s in keys map", idStr)
+	}
+	switch k.Purpose {
+	case SidecarPurposeStorage, SidecarPurposeRaft:
+	default:
+		return pkgerrors.Wrapf(ErrSidecarPurpose, "key_id=%s purpose=%q", idStr, k.Purpose)
+	}
+	return nil
+}
+
+// WriteSidecar persists sc to path using the §5.1 crash-durable write
+// protocol:
+//
+//  1. Build the new contents in memory (sc.Version is set to
+//     SidecarVersion so the caller never has to remember).
+//  2. Write to <path>.tmp, then file.Sync().
+//  3. os.Rename(<path>.tmp, <path>).
+//  4. dir.Sync() on the parent directory so the rename is durable.
+//
+// Skipping step 2 or 4 is a data-loss-class bug: a power loss between
+// the rename and the directory inode flush can roll back keys.json
+// while the rotation's Raft entry is already committed, stranding
+// ciphertext under a wrap that has effectively disappeared. Per §5.1
+// this is treated as a hard precondition, not an optimisation.
+//
+// The temp file is created with mode 0o600 so a stale tmp left behind
+// after a crash is not world-readable.
+func WriteSidecar(path string, sc *Sidecar) (retErr error) {
+	if sc == nil {
+		return pkgerrors.New("encryption: WriteSidecar: sc is nil")
+	}
+	sc.Version = SidecarVersion
+	if err := validateSidecar(sc); err != nil {
+		return pkgerrors.Wrap(err, "encryption: validate before write")
+	}
+
+	data, err := json.MarshalIndent(sc, "", "  ")
+	if err != nil {
+		return pkgerrors.Wrap(err, "encryption: marshal sidecar")
+	}
+
+	dir := filepath.Dir(path)
+	tmpPath := filepath.Join(dir, filepath.Base(path)+".tmp")
+
+	if err := writeTmpAndFsync(tmpPath, data); err != nil {
+		return err
+	}
+	// Best-effort cleanup of the tmp file if anything below fails. On
+	// the success path it has already been renamed and removal is a
+	// no-op.
+	defer func() {
+		if retErr != nil {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		return pkgerrors.Wrapf(err, "encryption: rename %q -> %q", tmpPath, path)
+	}
+	if err := syncDir(dir); err != nil {
+		return pkgerrors.Wrapf(err, "encryption: fsync dir %q", dir)
+	}
+	return nil
+}
+
+// writeTmpAndFsync writes data into tmpPath and fsyncs the file.
+// Helper exists so WriteSidecar does not nest its own defer-on-error
+// inside the rename block.
+func writeTmpAndFsync(tmpPath string, data []byte) error {
+	f, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, sidecarFileMode)
+	if err != nil {
+		return pkgerrors.Wrapf(err, "encryption: open %q", tmpPath)
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := f.Write(data); err != nil {
+		return pkgerrors.Wrapf(err, "encryption: write %q", tmpPath)
+	}
+	if err := f.Sync(); err != nil {
+		return pkgerrors.Wrapf(err, "encryption: fsync %q", tmpPath)
+	}
+	return nil
+}
+
+// syncDir opens dir read-only and calls fsync on its file descriptor.
+//
+// On most POSIX filesystems this is what makes os.Rename durable. Some
+// environments (NFS, certain FUSE mounts) return an error rather than
+// silently treating it as a no-op; the caller must surface that error
+// — the §5.1 protocol explicitly refuses to start on filesystems that
+// cannot guarantee durability of the rename.
+func syncDir(dir string) error {
+	f, err := os.Open(dir) //nolint:gosec // dir comes from operator config
+	if err != nil {
+		return pkgerrors.Wrapf(err, "encryption: open dir %q", dir)
+	}
+	defer func() { _ = f.Close() }()
+	if err := f.Sync(); err != nil {
+		return pkgerrors.Wrapf(err, "encryption: fsync dir %q", dir)
+	}
+	return nil
+}
+
+// IsNotExist reports whether err is a "sidecar file does not exist"
+// error from ReadSidecar. Provided as a convenience so callers can
+// branch on first-boot vs. malformed sidecar without unwrapping the
+// fs.PathError manually.
+func IsNotExist(err error) bool {
+	return errors.Is(err, fs.ErrNotExist)
+}

--- a/internal/encryption/sidecar.go
+++ b/internal/encryption/sidecar.go
@@ -140,13 +140,16 @@ func validateSidecar(sc *Sidecar) error {
 		}
 	}
 	// Active.Storage / Active.Raft, when non-zero, must reference an
-	// entry that actually exists in Keys. Rotation and bootstrap paths
-	// always write the wrapped DEK and the Active pointer together; an
-	// Active id without a corresponding entry is malformed input.
-	if err := requireActiveKey(sc, "storage", sc.Active.Storage); err != nil {
+	// entry that actually exists in Keys AND whose Purpose matches the
+	// slot. Rotation and bootstrap paths always write the wrapped DEK
+	// and the Active pointer together with consistent purpose; an
+	// Active id pointing at a missing or wrong-purpose entry is
+	// malformed input that would route the wrong DEK into a
+	// purpose-specific encryption path after restart.
+	if err := requireActiveKey(sc, SidecarPurposeStorage, sc.Active.Storage); err != nil {
 		return err
 	}
-	if err := requireActiveKey(sc, "raft", sc.Active.Raft); err != nil {
+	if err := requireActiveKey(sc, SidecarPurposeRaft, sc.Active.Raft); err != nil {
 		return err
 	}
 	return nil
@@ -157,9 +160,14 @@ func requireActiveKey(sc *Sidecar, purpose string, id uint32) error {
 		return nil // not bootstrapped for this purpose; nothing to check
 	}
 	idStr := strconv.FormatUint(uint64(id), 10)
-	if _, ok := sc.Keys[idStr]; !ok {
+	k, ok := sc.Keys[idStr]
+	if !ok {
 		return pkgerrors.Wrapf(ErrSidecarActiveKeyMissing,
 			"active.%s=%d not present in keys map", purpose, id)
+	}
+	if k.Purpose != purpose {
+		return pkgerrors.Wrapf(ErrSidecarActivePurposeMismatch,
+			"active.%s=%d but keys[%q].purpose=%q", purpose, id, idStr, k.Purpose)
 	}
 	return nil
 }

--- a/internal/encryption/sidecar_test.go
+++ b/internal/encryption/sidecar_test.go
@@ -122,15 +122,16 @@ func TestWriteSidecar_TmpFileMode(t *testing.T) {
 	}
 }
 
-func TestWriteSidecar_SetsVersion(t *testing.T) {
+// TestWriteSidecar_OnDiskVersion confirms WriteSidecar writes
+// SidecarVersion to disk regardless of the caller's struct value, so a
+// caller that builds a Sidecar with Version=0 still produces a
+// well-formed on-disk file.
+func TestWriteSidecar_OnDiskVersion(t *testing.T) {
 	path := sidecarPath(t)
 	sc := fixtureSidecar()
 	sc.Version = 0 // caller forgot to set
 	if err := encryption.WriteSidecar(path, sc); err != nil {
 		t.Fatalf("WriteSidecar: %v", err)
-	}
-	if sc.Version != encryption.SidecarVersion {
-		t.Fatalf("WriteSidecar did not set Version: got %d", sc.Version)
 	}
 	got, err := encryption.ReadSidecar(path)
 	if err != nil {
@@ -138,6 +139,28 @@ func TestWriteSidecar_SetsVersion(t *testing.T) {
 	}
 	if got.Version != encryption.SidecarVersion {
 		t.Fatalf("on-disk Version = %d, want %d", got.Version, encryption.SidecarVersion)
+	}
+}
+
+// TestWriteSidecar_DoesNotMutateCaller confirms WriteSidecar does NOT
+// rewrite the caller's struct in place. A caller that reuses the same
+// *Sidecar across rotations must see its Version field preserved
+// (including a deliberately-zero value used as a "build me" marker).
+// The mutation-as-side-effect behaviour was retracted in PR #722
+// review round 1 because it surprised callers that reuse the struct.
+func TestWriteSidecar_DoesNotMutateCaller(t *testing.T) {
+	path := sidecarPath(t)
+	sc := fixtureSidecar()
+	sc.Version = 0
+	sc.RaftAppliedIndex = 42
+	if err := encryption.WriteSidecar(path, sc); err != nil {
+		t.Fatalf("WriteSidecar: %v", err)
+	}
+	if sc.Version != 0 {
+		t.Fatalf("WriteSidecar mutated caller.Version: got %d, want 0 (preserved)", sc.Version)
+	}
+	if sc.RaftAppliedIndex != 42 {
+		t.Fatalf("WriteSidecar mutated caller.RaftAppliedIndex: got %d, want 42", sc.RaftAppliedIndex)
 	}
 }
 
@@ -349,6 +372,136 @@ func TestWriteSidecar_PartialWriteCleanup(t *testing.T) {
 	tmpPath := path + ".tmp"
 	if _, statErr := os.Stat(tmpPath); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("tmp file leaked after write failure: stat err=%v", statErr)
+	}
+}
+
+// TestWriteSidecar_RejectsActiveKeyMissing confirms validateSidecar
+// closes the gap raised by gemini and claude[bot] reviewers in PR #722:
+// a sidecar pointing Active.Storage at a key_id that does not appear
+// in the Keys map is malformed input and must not land on disk.
+func TestWriteSidecar_RejectsActiveKeyMissing(t *testing.T) {
+	cases := []struct {
+		name string
+		mut  func(*encryption.Sidecar)
+	}{
+		{
+			name: "storage active without entry",
+			mut: func(sc *encryption.Sidecar) {
+				sc.Active.Storage = 999999
+			},
+		},
+		{
+			name: "raft active without entry",
+			mut: func(sc *encryption.Sidecar) {
+				sc.Active.Raft = 888888
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := sidecarPath(t)
+			sc := fixtureSidecar()
+			tc.mut(sc)
+			err := encryption.WriteSidecar(path, sc)
+			if !errors.Is(err, encryption.ErrSidecarActiveKeyMissing) {
+				t.Fatalf("expected ErrSidecarActiveKeyMissing, got %v", err)
+			}
+		})
+	}
+}
+
+func TestReadSidecar_RejectsActiveKeyMissing(t *testing.T) {
+	path := sidecarPath(t)
+	raw := []byte(`{
+        "version": 1,
+        "raft_applied_index": 0,
+        "storage_envelope_active": false,
+        "raft_envelope_cutover_index": 0,
+        "active": {"storage": 12345, "raft": 0},
+        "keys": {}
+    }`)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err := encryption.ReadSidecar(path)
+	if !errors.Is(err, encryption.ErrSidecarActiveKeyMissing) {
+		t.Fatalf("expected ErrSidecarActiveKeyMissing, got %v", err)
+	}
+}
+
+// TestWriteSidecar_StaleTmpDoesNotLeakPermissiveMode is the security
+// regression test for the codex P2 finding on PR #722: a pre-existing
+// keys.json.tmp file with a permissive mode (e.g. 0o666 from older
+// tooling, manual poking, or a partially-recovered crash) must not
+// carry its mode into the production keys.json via os.Rename. The
+// fix in writeTmpAndFsync removes any pre-existing tmp before
+// O_EXCL-creating it fresh at sidecarFileMode.
+func TestWriteSidecar_StaleTmpDoesNotLeakPermissiveMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, encryption.SidecarFilename)
+	tmpPath := path + ".tmp"
+
+	// Plant a pre-existing tmp file. Write at restrictive mode first
+	// (gosec G306 forbids writing files at >0o600), then explicitly
+	// chmod broader so we can verify WriteSidecar does NOT carry the
+	// pre-existing mode into the production keys.json.
+	if err := os.WriteFile(tmpPath, []byte("stale"), 0o600); err != nil {
+		t.Fatalf("seed stale tmp: %v", err)
+	}
+	const broadMode = 0o666
+	if err := os.Chmod(tmpPath, broadMode); err != nil {
+		t.Fatalf("chmod stale tmp broader: %v", err)
+	}
+	// Some umasks or strict filesystems may refuse the broader mode;
+	// confirm we actually achieved a group/other-readable file before
+	// asserting the security property.
+	st, err := os.Stat(tmpPath)
+	if err != nil {
+		t.Fatalf("Stat seeded tmp: %v", err)
+	}
+	if st.Mode().Perm()&0o077 == 0 {
+		t.Skipf("environment refused permissive seed (mode=%o)", st.Mode().Perm())
+	}
+
+	if err := encryption.WriteSidecar(path, fixtureSidecar()); err != nil {
+		t.Fatalf("WriteSidecar: %v", err)
+	}
+
+	// keys.json must NOT inherit the seeded permissive mode.
+	finalSt, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat final: %v", err)
+	}
+	if finalSt.Mode().Perm()&0o077 != 0 {
+		t.Fatalf("keys.json inherited permissive mode from stale tmp: mode=%o",
+			finalSt.Mode().Perm())
+	}
+}
+
+// TestWriteSidecar_StaleTmpFileIsCleanedOnWriteFailure exercises the
+// claude[bot] minor #1 finding on PR #722: if writeTmpAndFsync itself
+// fails (not just the rename), the .tmp file must still be cleaned up.
+// We force a write failure by making the parent directory read-only;
+// this makes os.OpenFile fail (file cannot be created), which is a
+// pre-tmp-creation failure path. The post-tmp-creation failure path
+// is harder to inject portably; this test covers the "no leftover on
+// failure" property at the next-easiest reproducible boundary.
+func TestWriteSidecar_StaleTmpFileIsCleanedOnWriteFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, encryption.SidecarFilename)
+	// Make the dir read-only so OpenFile cannot create the tmp.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("Chmod ro: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	err := encryption.WriteSidecar(path, fixtureSidecar())
+	if err == nil {
+		t.Fatal("WriteSidecar succeeded with read-only dir")
+	}
+	tmpPath := path + ".tmp"
+	if _, statErr := os.Stat(tmpPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("tmp file leaked after write failure (stat err=%v)", statErr)
 	}
 }
 

--- a/internal/encryption/sidecar_test.go
+++ b/internal/encryption/sidecar_test.go
@@ -1,0 +1,364 @@
+package encryption_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/cockroachdb/errors"
+)
+
+// fixtureSidecar returns a minimally-valid Sidecar value for write-then-read
+// round-trip tests. Values mirror the §5.1 illustrative JSON.
+func fixtureSidecar() *encryption.Sidecar {
+	return &encryption.Sidecar{
+		Version:                  encryption.SidecarVersion,
+		RaftAppliedIndex:         184273,
+		StorageEnvelopeActive:    true,
+		RaftEnvelopeCutoverIndex: 184201,
+		Active: encryption.ActiveKeys{
+			Storage: 305419896,
+			Raft:    2596069104,
+		},
+		Keys: map[string]encryption.SidecarKey{
+			"305419896": {
+				Purpose:    encryption.SidecarPurposeStorage,
+				Wrapped:    []byte{0x01, 0x02, 0x03, 0x04},
+				Created:    "2026-04-29T10:00:00Z",
+				LocalEpoch: 7,
+			},
+			"2596069104": {
+				Purpose:    encryption.SidecarPurposeRaft,
+				Wrapped:    []byte{0x05, 0x06, 0x07, 0x08},
+				Created:    "2026-04-29T10:00:00Z",
+				LocalEpoch: 7,
+			},
+		},
+	}
+}
+
+func sidecarPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), encryption.SidecarFilename)
+}
+
+func TestWriteSidecar_RoundTrip(t *testing.T) {
+	path := sidecarPath(t)
+	sc := fixtureSidecar()
+
+	if err := encryption.WriteSidecar(path, sc); err != nil {
+		t.Fatalf("WriteSidecar: %v", err)
+	}
+
+	got, err := encryption.ReadSidecar(path)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	if !reflect.DeepEqual(got, sc) {
+		t.Fatalf("round-trip mismatch:\n got  = %#v\n want = %#v", got, sc)
+	}
+}
+
+// TestWriteSidecar_NoTmpFileLeftBehind exercises the §5.1 crash-durable
+// write protocol's success path: after a clean Write, the tmp file
+// must NOT remain on disk.
+func TestWriteSidecar_NoTmpFileLeftBehind(t *testing.T) {
+	path := sidecarPath(t)
+	if err := encryption.WriteSidecar(path, fixtureSidecar()); err != nil {
+		t.Fatalf("WriteSidecar: %v", err)
+	}
+	tmpPath := path + ".tmp"
+	if _, err := os.Stat(tmpPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("tmp file %q still exists after successful write (stat err=%v)", tmpPath, err)
+	}
+}
+
+func TestWriteSidecar_OverwriteExisting(t *testing.T) {
+	path := sidecarPath(t)
+	first := fixtureSidecar()
+	first.RaftAppliedIndex = 100
+	if err := encryption.WriteSidecar(path, first); err != nil {
+		t.Fatalf("WriteSidecar first: %v", err)
+	}
+	second := fixtureSidecar()
+	second.RaftAppliedIndex = 200
+	if err := encryption.WriteSidecar(path, second); err != nil {
+		t.Fatalf("WriteSidecar second: %v", err)
+	}
+	got, err := encryption.ReadSidecar(path)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	if got.RaftAppliedIndex != 200 {
+		t.Fatalf("Overwrite did not take effect: RaftAppliedIndex=%d, want 200", got.RaftAppliedIndex)
+	}
+}
+
+func TestWriteSidecar_TmpFileMode(t *testing.T) {
+	// Skip on Windows-style file systems where mode bits don't apply.
+	// The current test target is unix; we just verify the tmp path is
+	// 0o600 immediately after a write that we deliberately make fail
+	// at rename so the tmp file is left behind for inspection. Since
+	// we cannot easily make rename fail in a portable way here, we
+	// instead verify the final file's mode (which inherits from the
+	// tmp file).
+	path := sidecarPath(t)
+	if err := encryption.WriteSidecar(path, fixtureSidecar()); err != nil {
+		t.Fatalf("WriteSidecar: %v", err)
+	}
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	mode := st.Mode().Perm()
+	// We do not require an exact 0o600 because some umask settings can
+	// further restrict; just verify that no group/other read or write
+	// bit is set, which is the security property we care about.
+	if mode&0o077 != 0 {
+		t.Fatalf("sidecar file is group/other readable or writable (mode=%o)", mode)
+	}
+}
+
+func TestWriteSidecar_SetsVersion(t *testing.T) {
+	path := sidecarPath(t)
+	sc := fixtureSidecar()
+	sc.Version = 0 // caller forgot to set
+	if err := encryption.WriteSidecar(path, sc); err != nil {
+		t.Fatalf("WriteSidecar: %v", err)
+	}
+	if sc.Version != encryption.SidecarVersion {
+		t.Fatalf("WriteSidecar did not set Version: got %d", sc.Version)
+	}
+	got, err := encryption.ReadSidecar(path)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	if got.Version != encryption.SidecarVersion {
+		t.Fatalf("on-disk Version = %d, want %d", got.Version, encryption.SidecarVersion)
+	}
+}
+
+func TestWriteSidecar_RejectsNil(t *testing.T) {
+	path := sidecarPath(t)
+	err := encryption.WriteSidecar(path, nil)
+	if err == nil {
+		t.Fatal("WriteSidecar(nil) returned no error")
+	}
+}
+
+func TestWriteSidecar_RejectsBadPurpose(t *testing.T) {
+	path := sidecarPath(t)
+	sc := fixtureSidecar()
+	sc.Keys["999"] = encryption.SidecarKey{
+		Purpose: "bogus",
+		Wrapped: []byte{0x01},
+	}
+	err := encryption.WriteSidecar(path, sc)
+	if !errors.Is(err, encryption.ErrSidecarPurpose) {
+		t.Fatalf("expected ErrSidecarPurpose, got %v", err)
+	}
+}
+
+func TestWriteSidecar_RejectsReservedKeyIDInMap(t *testing.T) {
+	path := sidecarPath(t)
+	sc := fixtureSidecar()
+	sc.Keys["0"] = encryption.SidecarKey{
+		Purpose: encryption.SidecarPurposeStorage,
+	}
+	err := encryption.WriteSidecar(path, sc)
+	if !errors.Is(err, encryption.ErrSidecarReservedKeyID) {
+		t.Fatalf("expected ErrSidecarReservedKeyID, got %v", err)
+	}
+}
+
+func TestWriteSidecar_RejectsNonNumericKeyID(t *testing.T) {
+	path := sidecarPath(t)
+	sc := fixtureSidecar()
+	sc.Keys["abc"] = encryption.SidecarKey{
+		Purpose: encryption.SidecarPurposeStorage,
+	}
+	err := encryption.WriteSidecar(path, sc)
+	if !errors.Is(err, encryption.ErrSidecarKeyIDFormat) {
+		t.Fatalf("expected ErrSidecarKeyIDFormat, got %v", err)
+	}
+}
+
+func TestReadSidecar_Missing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does-not-exist.json")
+	_, err := encryption.ReadSidecar(path)
+	if err == nil {
+		t.Fatal("ReadSidecar(missing) returned no error")
+	}
+	if !encryption.IsNotExist(err) {
+		t.Fatalf("expected IsNotExist=true, got err=%v", err)
+	}
+}
+
+func TestReadSidecar_RejectsUnknownVersion(t *testing.T) {
+	path := sidecarPath(t)
+	for _, v := range []int{0, 2, 42, -1} {
+		raw, err := json.Marshal(map[string]any{
+			"version":                     v,
+			"raft_applied_index":          0,
+			"storage_envelope_active":     false,
+			"raft_envelope_cutover_index": 0,
+			"active":                      map[string]any{"storage": 0, "raft": 0},
+			"keys":                        map[string]any{},
+		})
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if err := os.WriteFile(path, raw, 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		_, err = encryption.ReadSidecar(path)
+		if !errors.Is(err, encryption.ErrSidecarVersion) {
+			t.Fatalf("version=%d: expected ErrSidecarVersion, got %v", v, err)
+		}
+	}
+}
+
+func TestReadSidecar_RejectsCorruptJSON(t *testing.T) {
+	path := sidecarPath(t)
+	cases := []struct {
+		name string
+		raw  []byte
+	}{
+		{"empty", []byte{}},
+		{"truncated", []byte(`{"version":1,"raft_app`)},
+		{"not json", []byte(`hello world`)},
+		{"wrong type", []byte(`{"version":"one"}`)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := os.WriteFile(path, tc.raw, 0o600); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			_, err := encryption.ReadSidecar(path)
+			if err == nil {
+				t.Fatal("ReadSidecar accepted corrupt JSON")
+			}
+		})
+	}
+}
+
+func TestReadSidecar_RejectsBadPurpose(t *testing.T) {
+	path := sidecarPath(t)
+	raw := []byte(`{
+        "version": 1,
+        "raft_applied_index": 0,
+        "storage_envelope_active": false,
+        "raft_envelope_cutover_index": 0,
+        "active": {"storage": 0, "raft": 0},
+        "keys": {
+            "1": {"purpose": "rogue", "wrapped": "AQ==", "created": "x", "local_epoch": 0}
+        }
+    }`)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err := encryption.ReadSidecar(path)
+	if !errors.Is(err, encryption.ErrSidecarPurpose) {
+		t.Fatalf("expected ErrSidecarPurpose, got %v", err)
+	}
+}
+
+func TestReadSidecar_RejectsReservedKeyIDInMap(t *testing.T) {
+	path := sidecarPath(t)
+	raw := []byte(`{
+        "version": 1,
+        "raft_applied_index": 0,
+        "storage_envelope_active": false,
+        "raft_envelope_cutover_index": 0,
+        "active": {"storage": 0, "raft": 0},
+        "keys": {
+            "0": {"purpose": "storage", "wrapped": "AQ==", "created": "x", "local_epoch": 0}
+        }
+    }`)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err := encryption.ReadSidecar(path)
+	if !errors.Is(err, encryption.ErrSidecarReservedKeyID) {
+		t.Fatalf("expected ErrSidecarReservedKeyID, got %v", err)
+	}
+}
+
+func TestReadSidecar_RejectsNonNumericKeyID(t *testing.T) {
+	path := sidecarPath(t)
+	raw := []byte(`{
+        "version": 1,
+        "raft_applied_index": 0,
+        "storage_envelope_active": false,
+        "raft_envelope_cutover_index": 0,
+        "active": {"storage": 0, "raft": 0},
+        "keys": {
+            "not-a-number": {"purpose": "storage", "wrapped": "AQ==", "created": "x", "local_epoch": 0}
+        }
+    }`)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err := encryption.ReadSidecar(path)
+	if !errors.Is(err, encryption.ErrSidecarKeyIDFormat) {
+		t.Fatalf("expected ErrSidecarKeyIDFormat, got %v", err)
+	}
+}
+
+func TestReadSidecar_RejectsKeyIDOverflowingUint32(t *testing.T) {
+	path := sidecarPath(t)
+	// 4294967296 == math.MaxUint32 + 1
+	raw := []byte(`{
+        "version": 1,
+        "raft_applied_index": 0,
+        "storage_envelope_active": false,
+        "raft_envelope_cutover_index": 0,
+        "active": {"storage": 0, "raft": 0},
+        "keys": {
+            "4294967296": {"purpose": "storage", "wrapped": "AQ==", "created": "x", "local_epoch": 0}
+        }
+    }`)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err := encryption.ReadSidecar(path)
+	if !errors.Is(err, encryption.ErrSidecarKeyIDFormat) {
+		t.Fatalf("expected ErrSidecarKeyIDFormat, got %v", err)
+	}
+}
+
+// TestWriteSidecar_PartialWriteCleanup confirms that when a write fails
+// AFTER the tmp file is created (we simulate this by making the parent
+// dir refuse the rename via a removed dir), no orphaned tmp file is
+// left behind.
+func TestWriteSidecar_PartialWriteCleanup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, encryption.SidecarFilename)
+	// Pre-create path as a directory so os.Rename fails with EEXIST/EISDIR.
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatalf("Mkdir target-as-dir: %v", err)
+	}
+
+	err := encryption.WriteSidecar(path, fixtureSidecar())
+	if err == nil {
+		t.Fatal("WriteSidecar succeeded despite path being a directory")
+	}
+	tmpPath := path + ".tmp"
+	if _, statErr := os.Stat(tmpPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("tmp file leaked after write failure: stat err=%v", statErr)
+	}
+}
+
+func TestSidecarPurpose_Constants(t *testing.T) {
+	// Pin the wire format constants so a future refactor can't silently
+	// rename the JSON-visible strings.
+	if encryption.SidecarPurposeStorage != "storage" {
+		t.Fatalf("SidecarPurposeStorage = %q, want %q", encryption.SidecarPurposeStorage, "storage")
+	}
+	if encryption.SidecarPurposeRaft != "raft" {
+		t.Fatalf("SidecarPurposeRaft = %q, want %q", encryption.SidecarPurposeRaft, "raft")
+	}
+}

--- a/internal/encryption/sidecar_test.go
+++ b/internal/encryption/sidecar_test.go
@@ -411,21 +411,34 @@ func TestWriteSidecar_RejectsActiveKeyMissing(t *testing.T) {
 }
 
 func TestReadSidecar_RejectsActiveKeyMissing(t *testing.T) {
-	path := sidecarPath(t)
-	raw := []byte(`{
+	cases := []struct {
+		name string
+		// active is the JSON object dropped in for "active".
+		active string
+	}{
+		{"storage active without entry", `{"storage": 12345, "raft": 0}`},
+		{"raft active without entry", `{"storage": 0, "raft": 67890}`},
+		{"both active without entries", `{"storage": 11111, "raft": 22222}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := sidecarPath(t)
+			raw := []byte(`{
         "version": 1,
         "raft_applied_index": 0,
         "storage_envelope_active": false,
         "raft_envelope_cutover_index": 0,
-        "active": {"storage": 12345, "raft": 0},
+        "active": ` + tc.active + `,
         "keys": {}
     }`)
-	if err := os.WriteFile(path, raw, 0o600); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-	_, err := encryption.ReadSidecar(path)
-	if !errors.Is(err, encryption.ErrSidecarActiveKeyMissing) {
-		t.Fatalf("expected ErrSidecarActiveKeyMissing, got %v", err)
+			if err := os.WriteFile(path, raw, 0o600); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			_, err := encryption.ReadSidecar(path)
+			if !errors.Is(err, encryption.ErrSidecarActiveKeyMissing) {
+				t.Fatalf("expected ErrSidecarActiveKeyMissing, got %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/encryption/sidecar_test.go
+++ b/internal/encryption/sidecar_test.go
@@ -516,7 +516,18 @@ func TestSidecar_RejectsActivePurposeMismatch(t *testing.T) {
 // carry its mode into the production keys.json via os.Rename. The
 // fix in writeTmpAndFsync removes any pre-existing tmp before
 // O_EXCL-creating it fresh at sidecarFileMode.
+//
+// Skipped on Windows: os.Chmod there only honours the owner-writable
+// bit and other unix permission bits are reported as synthetic
+// values, so both the seed step and the final mode&0o077 assertion
+// can produce results that don't reflect the property under test.
+// The unix path covers the security invariant; Windows lacks the
+// matching threat model (multi-user shared filesystems with unix
+// mode bits as the access boundary).
 func TestWriteSidecar_StaleTmpDoesNotLeakPermissiveMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix mode bits are not preserved by os.Chmod on Windows; threat model does not apply")
+	}
 	dir := t.TempDir()
 	path := filepath.Join(dir, encryption.SidecarFilename)
 	tmpPath := path + ".tmp"

--- a/internal/encryption/sidecar_test.go
+++ b/internal/encryption/sidecar_test.go
@@ -442,6 +442,64 @@ func TestReadSidecar_RejectsActiveKeyMissing(t *testing.T) {
 	}
 }
 
+// TestSidecar_RejectsActivePurposeMismatch covers the codex P2 finding
+// on PR #722: a sidecar where Active.Storage points to a key entry with
+// purpose="raft" (or vice versa) is malformed input that would route
+// the wrong DEK into a purpose-specific path after restart. Both
+// WriteSidecar (in-memory validation) and ReadSidecar (post-unmarshal
+// validation) must reject the mismatch with ErrSidecarActivePurposeMismatch.
+func TestSidecar_RejectsActivePurposeMismatch(t *testing.T) {
+	cases := []struct {
+		name string
+		mut  func(*encryption.Sidecar)
+	}{
+		{
+			// active.storage points to the raft-purpose key
+			name: "storage points at raft entry",
+			mut: func(sc *encryption.Sidecar) {
+				sc.Active.Storage = 2596069104
+			},
+		},
+		{
+			// active.raft points to the storage-purpose key
+			name: "raft points at storage entry",
+			mut: func(sc *encryption.Sidecar) {
+				sc.Active.Raft = 305419896
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name+"/Write", func(t *testing.T) {
+			sc := fixtureSidecar()
+			tc.mut(sc)
+			err := encryption.WriteSidecar(sidecarPath(t), sc)
+			if !errors.Is(err, encryption.ErrSidecarActivePurposeMismatch) {
+				t.Fatalf("expected ErrSidecarActivePurposeMismatch, got %v", err)
+			}
+		})
+		t.Run(tc.name+"/Read", func(t *testing.T) {
+			// Hand-roll the JSON so we bypass WriteSidecar's pre-write
+			// validation and verify ReadSidecar catches the same
+			// invariant on a sidecar that landed via some other path
+			// (older binary, manual edit, partial recovery).
+			sc := fixtureSidecar()
+			tc.mut(sc)
+			raw, err := json.MarshalIndent(sc, "", "  ")
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			path := sidecarPath(t)
+			if err := os.WriteFile(path, raw, 0o600); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			_, err = encryption.ReadSidecar(path)
+			if !errors.Is(err, encryption.ErrSidecarActivePurposeMismatch) {
+				t.Fatalf("expected ErrSidecarActivePurposeMismatch, got %v", err)
+			}
+		})
+	}
+}
+
 // TestWriteSidecar_StaleTmpDoesNotLeakPermissiveMode is the security
 // regression test for the codex P2 finding on PR #722: a pre-existing
 // keys.json.tmp file with a permissive mode (e.g. 0o666 from older

--- a/internal/encryption/sidecar_test.go
+++ b/internal/encryption/sidecar_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/bootjp/elastickv/internal/encryption"
@@ -557,7 +558,20 @@ func TestWriteSidecar_StaleTmpDoesNotLeakPermissiveMode(t *testing.T) {
 // pre-tmp-creation failure path. The post-tmp-creation failure path
 // is harder to inject portably; this test covers the "no leftover on
 // failure" property at the next-easiest reproducible boundary.
+//
+// Skipped when running as root (CI containers, sysadmin rebuild
+// environments) because UID 0 — and any process with CAP_DAC_OVERRIDE
+// — bypasses the dir's permission bits, and OpenFile would still
+// succeed; the assertion below would then fire spuriously and the
+// suite would be nondeterministic across CI setups (codex P2 on PR
+// #722 round-3).
 func TestWriteSidecar_StaleTmpFileIsCleanedOnWriteFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("dir permission bits don't gate file creation on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("UID 0 bypasses dir permission bits; chmod-based failure injection is meaningless")
+	}
 	dir := t.TempDir()
 	path := filepath.Join(dir, encryption.SidecarFilename)
 	// Make the dir read-only so OpenFile cannot create the tmp.

--- a/internal/encryption/sidecar_test.go
+++ b/internal/encryption/sidecar_test.go
@@ -99,13 +99,21 @@ func TestWriteSidecar_OverwriteExisting(t *testing.T) {
 }
 
 func TestWriteSidecar_TmpFileMode(t *testing.T) {
-	// Skip on Windows-style file systems where mode bits don't apply.
-	// The current test target is unix; we just verify the tmp path is
-	// 0o600 immediately after a write that we deliberately make fail
-	// at rename so the tmp file is left behind for inspection. Since
-	// we cannot easily make rename fail in a portable way here, we
-	// instead verify the final file's mode (which inherits from the
-	// tmp file).
+	// Windows does not preserve unix permission bits the way the
+	// mode&0o077 assertion expects (Go reports synthetic perm bits
+	// that commonly include group/other reads even on a freshly
+	// written file). The doc comment claimed a Windows skip but the
+	// guard was missing — codex P2 on PR #722 round-3 surfaced the
+	// gap. Skip the assertion path here; the equivalent inheritance
+	// is already covered by TestWriteSidecar_StaleTmpDoesNotLeakPermissiveMode.
+	if runtime.GOOS == "windows" {
+		t.Skip("unix permission bits are not preserved on Windows filesystems")
+	}
+	// We just verify the final file's mode (which inherits from the
+	// tmp file). The tmp's mode is set explicitly by writeTmpAndFsync
+	// to sidecarFileMode (0o600); we cannot easily make rename fail
+	// in a portable way here, so the tmp's mode is observed indirectly
+	// through the renamed-into-place keys.json.
 	path := sidecarPath(t)
 	if err := encryption.WriteSidecar(path, fixtureSidecar()); err != nil {
 		t.Fatalf("WriteSidecar: %v", err)


### PR DESCRIPTION
## Summary

Stage 1 of the data-at-rest encryption rollout. Stacked on **#719 (Stage 0)** — base branch is `feat/encryption-foundation`. Once Stage 0 merges to main, this PR base will switch to `main` and the diff will collapse to just the Stage 1 files.

Implements the §5.1 keys.json sidecar layer of `docs/design/2026_04_29_proposed_data_at_rest_encryption.md`. Library-only; integration with FSM apply (§5.5 reconciliation) and admin commands (§6) lands in Stage 5+.

## What is added

- **`internal/encryption/sidecar.go`** — `Sidecar` struct mirroring §5.1 JSON exactly:
  - `Version`, `RaftAppliedIndex`, `StorageEnvelopeActive`, `RaftEnvelopeCutoverIndex`
  - `ActiveKeys{Storage, Raft uint32}` — `0` is the §5.1 not-bootstrapped sentinel
  - `Keys map[string]SidecarKey` — keyed by decimal-string form of `key_id` per §5.1
  - `SidecarKey{Purpose, Wrapped, Created, LocalEpoch}` — `Created` is a string (not `time.Time`) so future timezone-format additions do not break old readers
- **`WriteSidecar(path, *Sidecar) error`** implements the §5.1 crash-durable protocol:
  1. Build contents (`Version` is set automatically) and validate.
  2. Write to `<path>.tmp` at mode `0o600`, then `file.Sync()`.
  3. `os.Rename(<path>.tmp, <path>)`.
  4. `dir.Sync()` on the parent so the rename is durable.

  Skipping any step is a data-loss-class bug per §10 lens 1; a power loss between the rename and the directory inode flush can roll back `keys.json` while the rotation Raft entry is already committed, stranding ciphertext under a wrap that has effectively disappeared. Dir-fsync errors propagate — §5.1 explicitly refuses to start on filesystems (NFS, some FUSE) that cannot guarantee durability of the rename.
- **`ReadSidecar(path) (*Sidecar, error)`** — validates wire version, per-key purpose (`storage` / `raft`), and the decimal-uint32 form of every keys-map entry. Returns typed errors (`ErrSidecarVersion`, `ErrSidecarPurpose`, `ErrSidecarKeyIDFormat`, `ErrSidecarReservedKeyID`).
- **`IsNotExist(err)`** convenience for the first-boot case.

## Tests (`sidecar_test.go`, 22 cases)

- Round-trip: Write → Read returns the same struct via `reflect.DeepEqual`.
- No `.tmp` file left behind on success; tmp cleaned up on rename failure (target as directory).
- Overwrite existing.
- File mode 0o600 (no group/other read/write).
- `WriteSidecar` sets `Version` automatically.
- Validation: bad purpose / reserved key_id / non-numeric key_id at both Read and Write.
- `ReadSidecar`: missing (`IsNotExist`), unknown version (4 values), corrupt JSON (4 cases), key_id overflowing `uint32` (`4294967296`).
- Constants pinned (`storage` / `raft` purpose strings).

## Self-review (CLAUDE.md 5 lenses)

1. **Data loss** — Crash-durable protocol matches §5.1; partial-write cleanup test confirms no orphaned `.tmp`. Validation symmetric at Read and Write so a malformed sidecar cannot land on disk via `WriteSidecar`.
2. **Concurrency** — Sidecar I/O is not concurrent (one writer per data dir). No locking; future Stage 5+ admin layer will serialize at the FSM apply boundary.
3. **Performance** — Single read at boot, single write per rotation/cutover entry. Marshal cost is negligible vs. the fsync syscalls.
4. **Data consistency** — `Version` field is the wire-format gate. Reader fails closed on unknown version. Future v2 will be additive JSON fields plus a bump.
5. **Test coverage** — 22 sidecar cases on top of Stage 0 31 tests + 2 property tests + 3 benchmarks; package total now 47 tests, `-race` clean, 0 lint issues.

## Test plan

- [x] `go test ./internal/encryption/...` (~7s)
- [x] `go test -race ./internal/encryption/...` (~33s)
- [x] `golangci-lint run ./internal/encryption/...` (0 issues)
- [ ] Reviewer: confirm Sidecar JSON matches the §5.1 illustrative shape verbatim (field names, `Wrapped` as base64).
- [ ] Reviewer: confirm crash-durable protocol order (write → file.Sync → rename → dir.Sync) is followed in `WriteSidecar`.
- [ ] Reviewer: confirm validation is applied at both Read and Write.
