### PR TITLE
feat(sqs): listenless SQSServer for admin-only deployments

### DIFF
--- a/adapter/sqs.go
+++ b/adapter/sqs.go
@@ -326,6 +326,18 @@ func (s *SQSServer) Run() error {
 	// request hot path never pays the O(N) sweep cost. Cleaned up by
 	// the same reaperCtx cancellation that stops the message reaper.
 	go s.throttle.runSweepLoop(s.reaperCtx)
+	if s.listen == nil {
+		// Listenless mode: the SQS adapter was constructed without a
+		// public HTTP listener (--sqsAddress empty). Admin endpoints
+		// in adapter/sqs_admin.go still work because they go through
+		// the coordinator/store — only the SigV4 wire surface is
+		// suppressed. Block until Stop() cancels reaperCtx so the
+		// errgroup task lifetime matches the listening branch
+		// (callers wait on Run() returning to know it's safe to tear
+		// down the underlying coordinator/store).
+		<-s.reaperCtx.Done()
+		return nil
+	}
 	if err := s.httpServer.Serve(s.listen); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return errors.WithStack(err)
 	}

--- a/adapter/sqs.go
+++ b/adapter/sqs.go
@@ -349,6 +349,11 @@ func (s *SQSServer) Stop() {
 		s.reaperCancel()
 	}
 	if s.httpServer != nil {
+		// http.Server.Shutdown returns immediately when Serve was
+		// never called (listenless mode — no public listener was
+		// constructed), so this is a no-op for admin-only
+		// deployments. The branch is still gated on httpServer
+		// being non-nil because Shutdown panics on a nil receiver.
 		_ = s.httpServer.Shutdown(context.Background())
 	}
 }

--- a/adapter/sqs_test.go
+++ b/adapter/sqs_test.go
@@ -205,3 +205,33 @@ func TestSQSServer_StopShutsDown(t *testing.T) {
 		t.Fatal("Run did not return within timeout after Stop")
 	}
 }
+
+// TestSQSServer_ListenlessRunStopRoundTrip pins the listenless
+// construction path used by startSQSServer when --sqsAddress is
+// empty: NewSQSServer must accept a nil net.Listener, Run() must
+// return cleanly when Stop() cancels the reaper context, and the
+// reaper / throttle-sweep goroutines must wind down with the same
+// cancellation. Regression guard for the admin-only deployment
+// shape — without this branch the SQS admin endpoints would be
+// dark on a build whose operator deliberately closed the public
+// SigV4 surface.
+func TestSQSServer_ListenlessRunStopRoundTrip(t *testing.T) {
+	t.Parallel()
+	srv := NewSQSServer(nil, nil, nil)
+	done := make(chan error, 1)
+	go func() { done <- srv.Run() }()
+	// Give Run() a tick to enter the reaperCtx.Done() block. Unlike
+	// the listening path there's no socket Accept loop to enter, so
+	// a shorter pause is enough.
+	time.Sleep(20 * time.Millisecond)
+	srv.Stop()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("listenless Run did not return within timeout after Stop")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1469,9 +1469,11 @@ type runtimeServerRunner struct {
 	s3Server *adapter.S3Server
 
 	// sqsServer plays the same role for the SQS admin entrypoints
-	// (adapter/sqs_admin.go). Nil when --sqsAddress is empty; the
-	// admin listener then leaves /admin/api/v1/sqs/* off the wire
-	// (the mux 404s those paths).
+	// (adapter/sqs_admin.go). Always non-nil after startup —
+	// startSQSServer constructs a listenless SQSServer when
+	// --sqsAddress is empty (the public SigV4 listener is
+	// suppressed but the admin bridge stays wired since the admin
+	// handlers only need the coordinator/store, not the listener).
 	sqsServer *adapter.SQSServer
 
 	// sqsPartitionResolver is the concrete pointer to the same

--- a/main_admin.go
+++ b/main_admin.go
@@ -182,8 +182,15 @@ func newAdminLeaderProbe(coordinate kv.Coordinator) admin.LeaderProbe {
 // Same architectural reasoning as newDynamoTablesSource and
 // newBucketsSource: the bridge stays in this file (rather than
 // internal/admin) so the admin package stays free of the heavy
-// adapter-package dependency tree. Returns nil when sqsServer is nil
-// so admin.NewServer leaves /admin/api/v1/sqs/* off the wire.
+// adapter-package dependency tree.
+//
+// Production always passes a non-nil *SQSServer now that
+// startSQSServer constructs a listenless server when sqsAddress is
+// empty (admin endpoints don't need the public SigV4 listener).
+// The nil guard below exists only for tests that build an admin
+// server without a SQS adapter wired in; an unreachable-in-prod
+// nil here would otherwise crash the admin handler chain instead
+// of cleanly omitting /admin/api/v1/sqs/* from the wire.
 func newSqsQueuesSource(sqsServer *adapter.SQSServer) admin.QueuesSource {
 	if sqsServer == nil {
 		return nil

--- a/main_sqs.go
+++ b/main_sqs.go
@@ -106,7 +106,7 @@ func loadSQSStaticCredentials(credentialsFile, sqsAddr string) (map[string]strin
 	if sqsAddr == "" {
 		return nil, nil
 	}
-	return loadSigV4StaticCredentialsFile(credentialsFile, "sqs") //nolint:wrapcheck // already wraps internally
+	return loadSigV4StaticCredentialsFile(credentialsFile, "sqs")
 }
 
 // closeSQSListenerOnError closes the listener after another startup

--- a/main_sqs.go
+++ b/main_sqs.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log/slog"
 	"net"
 	"strings"
 
@@ -36,19 +37,13 @@ func startSQSServer(
 	partitionObserver adapter.SQSPartitionObserver,
 ) (*adapter.SQSServer, error) {
 	sqsAddr = strings.TrimSpace(sqsAddr)
-	var sqsL net.Listener
-	if sqsAddr != "" {
-		var err error
-		sqsL, err = lc.Listen(ctx, "tcp", sqsAddr)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to listen on %s", sqsAddr)
-		}
-	}
-	staticCreds, err := loadSigV4StaticCredentialsFile(credentialsFile, "sqs")
+	sqsL, err := openSQSListener(ctx, lc, sqsAddr)
 	if err != nil {
-		if sqsL != nil {
-			_ = sqsL.Close()
-		}
+		return nil, err
+	}
+	staticCreds, err := loadSQSStaticCredentials(credentialsFile, sqsAddr)
+	if err != nil {
+		closeSQSListenerOnError(sqsL, sqsAddr)
 		return nil, err
 	}
 	sqsServer := adapter.NewSQSServer(
@@ -82,4 +77,47 @@ func startSQSServer(
 		return errors.WithStack(err)
 	})
 	return sqsServer, nil
+}
+
+// openSQSListener returns the bound listener for sqsAddr, or
+// (nil, nil) when sqsAddr is empty (listenless / admin-only mode).
+// Pulled out of startSQSServer so the constructor stays under the
+// cyclop budget; the listenless branch is otherwise the same one
+// the function-level docstring describes.
+func openSQSListener(ctx context.Context, lc *net.ListenConfig, sqsAddr string) (net.Listener, error) {
+	if sqsAddr == "" {
+		return nil, nil
+	}
+	l, err := lc.Listen(ctx, "tcp", sqsAddr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to listen on %s", sqsAddr)
+	}
+	return l, nil
+}
+
+// loadSQSStaticCredentials wraps loadSigV4StaticCredentialsFile with
+// the listenless-mode short-circuit: when sqsAddr is empty there is
+// no public HTTP listener and the admin /admin/api/v1/sqs/* endpoints
+// bypass SigV4, so the credentials file is not needed at all.
+// Pre-listenless behavior was "SQS disabled, no creds required" —
+// keeping creds optional here preserves that contract instead of
+// gating admin-only deployments on a stale or malformed creds path.
+func loadSQSStaticCredentials(credentialsFile, sqsAddr string) (map[string]string, error) {
+	if sqsAddr == "" {
+		return nil, nil
+	}
+	return loadSigV4StaticCredentialsFile(credentialsFile, "sqs") //nolint:wrapcheck // already wraps internally
+}
+
+// closeSQSListenerOnError closes the listener after another startup
+// step has failed and logs any Close error so listener cleanup
+// failures (port stuck bound, fd leak) are visible to operators
+// rather than silently ignored.
+func closeSQSListenerOnError(l net.Listener, sqsAddr string) {
+	if l == nil {
+		return
+	}
+	if err := l.Close(); err != nil {
+		slog.Warn("sqs listener close after startup failure", "addr", sqsAddr, "err", err)
+	}
 }

--- a/main_sqs.go
+++ b/main_sqs.go
@@ -11,11 +11,17 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// startSQSServer stands up the SQS adapter on sqsAddr and returns the
-// running *adapter.SQSServer so the admin listener can call SigV4-bypass
-// admin entrypoints against it (see adapter/sqs_admin.go). Returns
-// (nil, nil) when sqsAddr is empty — that is the "SQS disabled" branch
-// and the admin listener leaves /admin/api/v1/sqs/* off the wire.
+// startSQSServer constructs the SQS adapter and returns the running
+// *adapter.SQSServer. The admin listener calls SigV4-bypass admin
+// entrypoints against this server (see adapter/sqs_admin.go); those
+// admin methods only need the coordinator/store, NOT the public SQS
+// HTTP listener. So when sqsAddr is empty the function still
+// constructs the server (with a nil net.Listener) — Run() then skips
+// httpServer.Serve while the reaper and throttle-sweep goroutines
+// still run, keeping retention math behind the admin counters
+// correct. The admin bridge in main_admin.go therefore wires
+// /admin/api/v1/sqs/* on the wire even on builds that disabled the
+// public SigV4 endpoint.
 func startSQSServer(
 	ctx context.Context,
 	lc *net.ListenConfig,
@@ -30,16 +36,19 @@ func startSQSServer(
 	partitionObserver adapter.SQSPartitionObserver,
 ) (*adapter.SQSServer, error) {
 	sqsAddr = strings.TrimSpace(sqsAddr)
-	if sqsAddr == "" {
-		return nil, nil
-	}
-	sqsL, err := lc.Listen(ctx, "tcp", sqsAddr)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to listen on %s", sqsAddr)
+	var sqsL net.Listener
+	if sqsAddr != "" {
+		var err error
+		sqsL, err = lc.Listen(ctx, "tcp", sqsAddr)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to listen on %s", sqsAddr)
+		}
 	}
 	staticCreds, err := loadSigV4StaticCredentialsFile(credentialsFile, "sqs")
 	if err != nil {
-		_ = sqsL.Close()
+		if sqsL != nil {
+			_ = sqsL.Close()
+		}
 		return nil, err
 	}
 	sqsServer := adapter.NewSQSServer(


### PR DESCRIPTION
## Summary

Make `/admin/api/v1/sqs/*` reachable on builds that start without `--sqsAddress`. The admin handlers (list, describe, delete queues) only need the coordinator and store — not the public SigV4 listener — so this PR teaches `startSQSServer` to construct a listenless `*adapter.SQSServer` instead of returning `(nil, nil)` and dropping the admin bridge.

Concretely:

- `startSQSServer` no longer short-circuits when `sqsAddr` is empty. It still skips `lc.Listen` (no port is opened), but it constructs `NewSQSServer(nil, …)` and threads the result back through the runtime.
- `(*SQSServer).Run()` detects the nil listener and blocks on `reaperCtx.Done()` instead of calling `httpServer.Serve`. The reaper and throttle-sweep goroutines still run so retention math behind the admin counters stays correct.
- `main_admin.go`'s `newSqsQueuesSource` now sees a non-nil `*adapter.SQSServer` and wires `/admin/api/v1/sqs/*`; the `if sqsServer == nil { return nil }` guard stays as a defensive check for tests that still pass nil.
- The runtime-struct comment for `r.sqsServer` updated to reflect that the field is always non-nil after startup.

## Why this is "option A" of the prior discussion

We discussed three options earlier:
- **A** — listenless construction across all three adapters (SQS / S3 / Dynamo).
- **B** — refactor admin to use the catalog/coordinator directly, no adapter dependency. Crosses adapter and admin package boundaries; would warrant a `*_proposed_*.md` design doc per CLAUDE.md.
- **C** — keep current behaviour, document the gating.

You picked **A**. This PR scopes to **SQS only** since that was the immediate ask. Symmetric Dynamo/S3 changes can land as a parallel PR if you want; both follow the same structural pattern (drop early-return in `start*Server`, teach `(*XxxServer).Run()` to handle nil listener) but each adapter's `Run()` body has different background work to keep alive (S3 manifest cleanup workers, etc.) so a separate review pass per adapter is the cleaner cut.

## Caller / semantic audit

Per the standing rule on semantic-changing edits:

- `adapter/sqs_catalog.go::queueURL` already nil-guards `s.listen`; no other reads of `s.listen` exist in the adapter package (verified via grep).
- `main.go` runtime field: only comment updated. The Go type is unchanged; the only change is that the zero-value pathway is no longer reachable.
- `newSqsQueuesSource` still nil-guards its argument; no caller in `main.go` passes nil any more, but the guard remains for tests that construct admin servers without an SQS adapter.
- `(*SQSServer).Run()` now has two terminating paths (reaper-ctx-block and `httpServer.Serve` return). `Stop()` cancels the reaper ctx, which both paths observe — same shutdown semantics on either branch.

## Tests

- **`TestSQSServer_ListenlessRunStopRoundTrip`** (new) — pins the nil-listener Run/Stop round trip. Constructs `NewSQSServer(nil, nil, nil)`, launches `Run()` in a goroutine, calls `Stop()`, and asserts `Run()` returns nil within 2s. Without the new `s.listen == nil` branch in `Run()`, `httpServer.Serve(nil)` would panic and this test would fail.
- **`TestSQSServer_StopShutsDown`** (existing) — unchanged. Anchors the listening-path round trip so a regression in either branch does not silently swap them.

## Self-review (5 lenses)

1. **Data loss** — N/A; no storage / Raft / FSM touch.
2. **Concurrency** — `Run()` adds a second terminating path; both paths observe the same `reaperCtx` cancellation that `Stop()` triggers.
3. **Performance** — listenless mode adds zero work to the listening path. Listenless construction adds no Raft round-trips on startup.
4. **Data consistency** — admin handlers take a fresh `nextTxnReadTS` per call; the listener's presence never affected snapshot semantics.
5. **Test coverage** — `TestSQSServer_ListenlessRunStopRoundTrip` pins the new branch; the existing `TestSQSServer_StopShutsDown` anchors the listening branch.

## Test plan

- [x] `go test -race -count=1 -run 'TestSQS' ./adapter/...` (all SQS tests pass)
- [x] `golangci-lint --config=.golangci.yaml run ./...` clean
- [x] `go build ./...` clean
- [ ] Live manual smoke: start a cluster with `--sqsAddress=""`, confirm `/admin/api/v1/sqs/queues` returns the catalog list (operator-driven, out of scope for the merge gate)

## Refs

- `adapter/sqs_admin.go` — admin entrypoints
- `main_admin.go` — admin bridge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SQS server supports a listenless mode so admin operations run without a network listener; admin endpoints remain available.

* **Tests**
  * Added regression test to validate listenless startup and graceful shutdown behavior.

* **Chores**
  * Improved SQS initialization/error handling and added structured logging during listener and credential setup.

* **Documentation**
  * Clarified runtime behavior and when a listenless server is constructed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/740)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->