### PR TITLE
scripts: rolling-update SQS adapter passthrough

### DIFF
--- a/scripts/rolling-update.env.example
+++ b/scripts/rolling-update.env.example
@@ -32,6 +32,21 @@ S3_PATH_STYLE_ONLY="true"
 # The file is bind-mounted read-only into the container.
 # S3_CREDENTIALS_FILE="/etc/elastickv/s3-credentials.json"
 
+# SQS-compatible adapter (opt-in). Required to mount the admin
+# /admin/api/v1/sqs/* endpoints — those handlers are gated on a
+# non-nil sqsServer, which the binary only constructs when
+# --sqsAddress is non-empty.
+ENABLE_SQS="false"
+SQS_PORT="9324"
+SQS_REGION="us-east-1"
+# Optional: open endpoint when SQS_CREDENTIALS_FILE is empty.
+# Same JSON shape as S3_CREDENTIALS_FILE.
+# SQS_CREDENTIALS_FILE="/etc/elastickv/sqs-credentials.json"
+# Optional: HT-FIFO partition routing map. Empty disables coverage check.
+# SQS_FIFO_PARTITION_MAP="orders.fifo:4=1,1,2,2"
+# Optional: override if SQS routing addresses differ from raft hosts.
+# RAFT_TO_SQS_MAP="raft-1.internal.example:50051=sqs-1.internal.example:9324,..."
+
 # Optional: override if Redis routing addresses differ from the advertised raft hosts.
 # RAFT_TO_REDIS_MAP="raft-1.internal.example:50051=redis-1.internal.example:6379,raft-2.internal.example:50051=redis-2.internal.example:6379,raft-3.internal.example:50051=redis-3.internal.example:6379"
 

--- a/scripts/rolling-update.sh
+++ b/scripts/rolling-update.sh
@@ -44,6 +44,31 @@ Optional environment:
     exist and be readable on every remote node; it will be bind-mounted into
     the container at the same path.
   S3_PATH_STYLE_ONLY
+
+  SQS adapter (opt-in; ENABLE_SQS=true turns the listener on)
+  ENABLE_SQS
+    Master switch (default false). When true, the script forwards
+    --sqsAddress, --sqsRegion, and --raftSqsMap (plus optional
+    --sqsCredentialsFile / --sqsFifoPartitionMap) to docker run.
+    Required for the admin /admin/api/v1/sqs/* endpoints to mount —
+    main.go gates registration on r.sqsServer != nil, which only
+    happens when --sqsAddress is non-empty.
+  SQS_PORT
+    SQS HTTP listener port on each node (default 9324, the conventional
+    SQS-compatible-server port). Mirrors S3_PORT.
+  SQS_REGION
+    SigV4 region the adapter signs against (default us-east-1).
+  SQS_CREDENTIALS_FILE
+    Optional path to a JSON credentials file on each target host
+    (same shape as S3_CREDENTIALS_FILE). Empty value runs the adapter
+    as an open endpoint — clients may sign with any credentials.
+  RAFT_TO_SQS_MAP
+    Optional override; auto-derived from NODES + RAFT_PORT + SQS_PORT
+    when ENABLE_SQS=true and the variable is empty.
+  SQS_FIFO_PARTITION_MAP
+    Optional HT-FIFO partition routing map (queue.fifo:N=group_0,...).
+    Empty value disables the capability gate's coverage check;
+    partitioned queues route to the default Raft group.
   HEALTH_TIMEOUT_SECONDS
   LEADERSHIP_TRANSFER_TIMEOUT_SECONDS
   LEADER_DISCOVERY_TIMEOUT_SECONDS
@@ -149,6 +174,21 @@ ENABLE_S3="${ENABLE_S3:-true}"
 S3_REGION="${S3_REGION:-us-east-1}"
 S3_CREDENTIALS_FILE="${S3_CREDENTIALS_FILE:-}"
 S3_PATH_STYLE_ONLY="${S3_PATH_STYLE_ONLY:-true}"
+# SQS adapter knobs (mirror the S3 shape). ENABLE_SQS is the master
+# switch; when false, no SQS-related flags are passed to the
+# container and admin SQS endpoints stay 404 because sqsServer is
+# nil. Set ENABLE_SQS=true and the script forwards
+# --sqsAddress / --sqsRegion / --raftSqsMap (and optionally
+# --sqsCredentialsFile and --sqsFifoPartitionMap) to docker run.
+ENABLE_SQS="${ENABLE_SQS:-false}"
+SQS_PORT="${SQS_PORT:-9324}"
+SQS_REGION="${SQS_REGION:-us-east-1}"
+SQS_CREDENTIALS_FILE="${SQS_CREDENTIALS_FILE:-}"
+# HT-FIFO partition routing map. Empty means "single-shard / no
+# partitioned-FIFO routing"; the capability gate's coverage check
+# is bypassed (resolver==nil) and partitioned queues land on the
+# default group. Format documented at main.go::buildSQSFifoPartitionMap.
+SQS_FIFO_PARTITION_MAP="${SQS_FIFO_PARTITION_MAP:-}"
 HEALTH_TIMEOUT_SECONDS="${HEALTH_TIMEOUT_SECONDS:-60}"
 LEADERSHIP_TRANSFER_TIMEOUT_SECONDS="${LEADERSHIP_TRANSFER_TIMEOUT_SECONDS:-30}"
 LEADER_DISCOVERY_TIMEOUT_SECONDS="${LEADER_DISCOVERY_TIMEOUT_SECONDS:-30}"
@@ -163,6 +203,7 @@ SSH_TARGETS="${SSH_TARGETS:-}"
 ROLLING_ORDER="${ROLLING_ORDER:-}"
 RAFT_TO_REDIS_MAP="${RAFT_TO_REDIS_MAP:-}"
 RAFT_TO_S3_MAP="${RAFT_TO_S3_MAP:-}"
+RAFT_TO_SQS_MAP="${RAFT_TO_SQS_MAP:-}"
 
 # Admin dashboard knobs. ADMIN_ENABLED is the master switch; the
 # remaining variables only take effect when ADMIN_ENABLED=true.
@@ -389,6 +430,20 @@ derive_raft_to_s3_map() {
   )
 }
 
+derive_raft_to_sqs_map() {
+  local parts=()
+  local i
+
+  for i in "${!NODE_IDS[@]}"; do
+    parts+=("${NODE_HOSTS[$i]}:${RAFT_PORT}=${NODE_HOSTS[$i]}:${SQS_PORT}")
+  done
+
+  (
+    IFS=,
+    printf '%s\n' "${parts[*]}"
+  )
+}
+
 ensure_local_raftadmin() {
   if [[ -n "$RAFTADMIN_LOCAL_BIN" ]]; then
     if [[ ! -x "$RAFTADMIN_LOCAL_BIN" ]]; then
@@ -510,6 +565,11 @@ update_one_node() {
       S3_REGION="$S3_REGION" \
       S3_CREDENTIALS_FILE="$S3_CREDENTIALS_FILE_Q" \
       S3_PATH_STYLE_ONLY="$S3_PATH_STYLE_ONLY" \
+      ENABLE_SQS="$ENABLE_SQS" \
+      SQS_PORT="$SQS_PORT" \
+      SQS_REGION="$SQS_REGION" \
+      SQS_CREDENTIALS_FILE="$SQS_CREDENTIALS_FILE_Q" \
+      SQS_FIFO_PARTITION_MAP="$SQS_FIFO_PARTITION_MAP_Q" \
       HEALTH_TIMEOUT_SECONDS="$HEALTH_TIMEOUT_SECONDS" \
       LEADERSHIP_TRANSFER_TIMEOUT_SECONDS="$LEADERSHIP_TRANSFER_TIMEOUT_SECONDS" \
       LEADER_DISCOVERY_TIMEOUT_SECONDS="$LEADER_DISCOVERY_TIMEOUT_SECONDS" \
@@ -521,6 +581,7 @@ update_one_node() {
       ALL_NODE_HOSTS_CSV="$all_node_hosts_csv" \
       RAFT_TO_REDIS_MAP="$RAFT_TO_REDIS_MAP_Q" \
       RAFT_TO_S3_MAP="$RAFT_TO_S3_MAP_Q" \
+      RAFT_TO_SQS_MAP="$RAFT_TO_SQS_MAP_Q" \
       EXTRA_ENV="$EXTRA_ENV_Q" \
       CONTAINER_MEMORY_LIMIT="$CONTAINER_MEMORY_LIMIT_Q" \
       ADMIN_ENABLED="$ADMIN_ENABLED" \
@@ -781,6 +842,33 @@ run_container() {
     )
   fi
 
+  # SQS adapter wiring mirrors S3: optional credentials file gets
+  # bind-mounted ro at the same host path; the rest of the SQS knobs
+  # are passed verbatim. ENABLE_SQS=false leaves all arrays empty so
+  # the docker run is byte-identical to a non-SQS deploy.
+  local sqs_creds_volume=()
+  local sqs_creds_flag=()
+  local sqs_flags=()
+  if [[ "${ENABLE_SQS}" == "true" && -n "${SQS_CREDENTIALS_FILE:-}" ]]; then
+    if [[ ! -f "$SQS_CREDENTIALS_FILE" || ! -r "$SQS_CREDENTIALS_FILE" ]]; then
+      echo "SQS_CREDENTIALS_FILE is set to '$SQS_CREDENTIALS_FILE' but the file is missing or not readable; aborting docker run" >&2
+      exit 1
+    fi
+    sqs_creds_volume=(-v "${SQS_CREDENTIALS_FILE}:${SQS_CREDENTIALS_FILE}:ro")
+    sqs_creds_flag=(--sqsCredentialsFile "$SQS_CREDENTIALS_FILE")
+  fi
+  if [[ "${ENABLE_SQS}" == "true" ]]; then
+    sqs_flags=(
+      --sqsAddress "${NODE_HOST}:${SQS_PORT}"
+      --sqsRegion "$SQS_REGION"
+      --raftSqsMap "$RAFT_TO_SQS_MAP"
+      "${sqs_creds_flag[@]}"
+    )
+    if [[ -n "${SQS_FIFO_PARTITION_MAP:-}" ]]; then
+      sqs_flags+=(--sqsFifoPartitionMap "$SQS_FIFO_PARTITION_MAP")
+    fi
+  fi
+
   # Pass through additional container environment variables from EXTRA_ENV.
   # Accepts a whitespace-separated list of KEY=VALUE pairs, e.g.:
   #   EXTRA_ENV="ELASTICKV_RAFT_DISPATCHER_LANES=1 ELASTICKV_PEBBLE_CACHE_MB=512"
@@ -849,6 +937,7 @@ run_container() {
     "${memory_flags[@]}" \
     -v "$DATA_DIR:$DATA_DIR" \
     "${s3_creds_volume[@]}" \
+    "${sqs_creds_volume[@]}" \
     "${admin_volumes[@]}" \
     "${extra_env_flags[@]}" \
     "$IMAGE" "$SERVER_ENTRYPOINT" \
@@ -860,6 +949,7 @@ run_container() {
     --raftDataDir "$DATA_DIR" \
     --raftRedisMap "$RAFT_TO_REDIS_MAP" \
     "${s3_flags[@]}" \
+    "${sqs_flags[@]}" \
     "${admin_flags[@]}" \
     "${keyviz_flags[@]}" >/dev/null
 }
@@ -1115,6 +1205,10 @@ if [[ "${ENABLE_S3}" == "true" && -z "$RAFT_TO_S3_MAP" ]]; then
   RAFT_TO_S3_MAP="$(derive_raft_to_s3_map)"
 fi
 
+if [[ "${ENABLE_SQS}" == "true" && -z "$RAFT_TO_SQS_MAP" ]]; then
+  RAFT_TO_SQS_MAP="$(derive_raft_to_sqs_map)"
+fi
+
 ensure_local_raftadmin
 ensure_remote_raftadmin_binaries
 
@@ -1216,6 +1310,8 @@ EXTRA_ENV_NORMALISED="$(merge_extra_env "$EXTRA_ENV_DEFAULT_NORMALISED" "$EXTRA_
 EXTRA_ENV_Q="$(printf '%q' "$EXTRA_ENV_NORMALISED")"
 CONTAINER_MEMORY_LIMIT_Q="$(printf '%q' "${CONTAINER_MEMORY_LIMIT:-}")"
 S3_CREDENTIALS_FILE_Q="$(printf '%q' "${S3_CREDENTIALS_FILE:-}")"
+SQS_CREDENTIALS_FILE_Q="$(printf '%q' "${SQS_CREDENTIALS_FILE:-}")"
+SQS_FIFO_PARTITION_MAP_Q="$(printf '%q' "${SQS_FIFO_PARTITION_MAP:-}")"
 IMAGE_Q="$(printf '%q' "$IMAGE")"
 DATA_DIR_Q="$(printf '%q' "$DATA_DIR")"
 SERVER_ENTRYPOINT_Q="$(printf '%q' "$SERVER_ENTRYPOINT")"
@@ -1223,6 +1319,7 @@ RAFTADMIN_REMOTE_BIN_Q="$(printf '%q' "$RAFTADMIN_REMOTE_BIN")"
 CONTAINER_NAME_Q="$(printf '%q' "$CONTAINER_NAME")"
 RAFT_TO_REDIS_MAP_Q="$(printf '%q' "$RAFT_TO_REDIS_MAP")"
 RAFT_TO_S3_MAP_Q="$(printf '%q' "$RAFT_TO_S3_MAP")"
+RAFT_TO_SQS_MAP_Q="$(printf '%q' "$RAFT_TO_SQS_MAP")"
 
 # ADMIN_* values may contain commas (allow-lists), spaces (paths with
 # spaces, though discouraged), or other shell metacharacters. The

--- a/scripts/rolling-update.sh
+++ b/scripts/rolling-update.sh
@@ -930,11 +930,22 @@ run_container() {
   local keyviz_flags=()
   build_keyviz_flags keyviz_flags
 
+  # config-fingerprint label drives the skip check on the next deploy
+  # (see DEPLOY_CONFIG_FP_LABEL block above). Empty value here means
+  # the deploy script was run on an old layout that didn't compute one
+  # — the next pass will recompute and inject one regardless, so the
+  # missing label only "costs" one extra recreate during the upgrade.
+  local config_fp_label_flags=()
+  if [[ -n "${DEPLOY_CONFIG_FP:-}" && -n "${DEPLOY_CONFIG_FP_LABEL:-}" ]]; then
+    config_fp_label_flags=(--label "${DEPLOY_CONFIG_FP_LABEL}=${DEPLOY_CONFIG_FP}")
+  fi
+
   docker run -d \
     --name "$CONTAINER_NAME" \
     --restart unless-stopped \
     --network host \
     "${memory_flags[@]}" \
+    "${config_fp_label_flags[@]}" \
     -v "$DATA_DIR:$DATA_DIR" \
     "${s3_creds_volume[@]}" \
     "${sqs_creds_volume[@]}" \
@@ -1149,12 +1160,55 @@ new_image_id="$(docker image inspect "$IMAGE" --format "{{.Id}}")"
 running_image_id="$(docker inspect --format "{{.Image}}" "$CONTAINER_NAME" 2>/dev/null || true)"
 running_status="$(docker inspect --format "{{.State.Status}}" "$CONTAINER_NAME" 2>/dev/null || echo missing)"
 
-if [[ "$new_image_id" == "$running_image_id" && "$running_status" == "running" ]]; then
+# Config fingerprint: hash every variable that influences either the
+# docker run argv or the in-container elastickv flags. Pair it with a
+# matching --label on docker run; on the next deploy compare the label
+# against a freshly recomputed hash and recreate when they differ.
+# Without this, deploy.env changes that flip flags (e.g. ENABLE_SQS,
+# ADMIN_*, EXTRA_ENV) without bumping the image hash were silently
+# skipped because the previous skip check only looked at image+status.
+#
+# NUL separator + sha256sum keeps the hash injective (no value can
+# spoof the boundary). All inputs are always-present env vars so an
+# unset deploy knob hashes as the empty string consistently.
+config_fp() {
+  printf '%s\0' \
+    "$IMAGE" \
+    "$SERVER_ENTRYPOINT" \
+    "$DATA_DIR" \
+    "$NODE_HOST" "$NODE_ID" \
+    "$RAFT_ENGINE" \
+    "$RAFT_PORT" "$REDIS_PORT" "$DYNAMO_PORT" \
+    "$RAFT_TO_REDIS_MAP" \
+    "$ENABLE_S3" "$S3_PORT" "$S3_REGION" "$S3_PATH_STYLE_ONLY" \
+    "$S3_CREDENTIALS_FILE" "$RAFT_TO_S3_MAP" \
+    "$ENABLE_SQS" "$SQS_PORT" "$SQS_REGION" \
+    "$SQS_CREDENTIALS_FILE" "$RAFT_TO_SQS_MAP" "$SQS_FIFO_PARTITION_MAP" \
+    "$EXTRA_ENV" "$CONTAINER_MEMORY_LIMIT" \
+    "$ADMIN_ENABLED" "$ADMIN_ADDRESS" \
+    "$ADMIN_FULL_ACCESS_KEYS" "$ADMIN_READ_ONLY_ACCESS_KEYS" \
+    "$ADMIN_SESSION_SIGNING_KEY_FILE" "$ADMIN_SESSION_SIGNING_KEY_PREVIOUS_FILE" \
+    "$ADMIN_TLS_CERT_FILE" "$ADMIN_TLS_KEY_FILE" \
+    "$ADMIN_ALLOW_PLAINTEXT_NON_LOOPBACK" "$ADMIN_ALLOW_INSECURE_DEV_COOKIE" \
+    "$KEYVIZ_ENABLED" "$KEYVIZ_FANOUT_NODES" \
+    | sha256sum | cut -d' ' -f1
+}
+DEPLOY_CONFIG_FP_LABEL="elastickv.deploy.config-fp"
+new_config_fp="$(config_fp)"
+running_config_fp="$(docker inspect --format "{{ index .Config.Labels \"${DEPLOY_CONFIG_FP_LABEL}\" }}" "$CONTAINER_NAME" 2>/dev/null || true)"
+export DEPLOY_CONFIG_FP="$new_config_fp"
+export DEPLOY_CONFIG_FP_LABEL
+
+if [[ "$new_image_id" == "$running_image_id" && "$running_status" == "running" \
+      && "$new_config_fp" == "$running_config_fp" ]]; then
   if grpc_healthy; then
-    echo "image unchanged and gRPC healthy; skip"
+    echo "image and config unchanged and gRPC healthy; skip"
     exit 0
   fi
   echo "container is running but gRPC is not reachable; recreating"
+fi
+if [[ -n "$running_config_fp" && "$new_config_fp" != "$running_config_fp" ]]; then
+  echo "deploy config fingerprint changed (was=${running_config_fp:0:12}, now=${new_config_fp:0:12}); recreating"
 fi
 
 require_passwordless_sudo

--- a/scripts/rolling-update.sh
+++ b/scripts/rolling-update.sh
@@ -142,6 +142,8 @@ Notes:
     RAFT_PORT, and REDIS_PORT.
   - If RAFT_TO_S3_MAP is unset, it is derived automatically from NODES,
     RAFT_PORT, and S3_PORT.
+  - If RAFT_TO_SQS_MAP is unset and ENABLE_SQS=true, it is derived
+    automatically from NODES, RAFT_PORT, and SQS_PORT.
   - If RAFTADMIN_BIN is set, it must already be executable on the local control host.
 EOF
 }
@@ -235,7 +237,7 @@ KEYVIZ_FANOUT_NODES="${KEYVIZ_FANOUT_NODES:-}"
 # who typed "True", "1", or a stray quote sees a script-level error
 # pointing at the variable name instead of an inscrutable failure
 # inside the SSH heredoc.
-for _bool_var in ADMIN_ENABLED ADMIN_ALLOW_PLAINTEXT_NON_LOOPBACK ADMIN_ALLOW_INSECURE_DEV_COOKIE KEYVIZ_ENABLED; do
+for _bool_var in ADMIN_ENABLED ADMIN_ALLOW_PLAINTEXT_NON_LOOPBACK ADMIN_ALLOW_INSECURE_DEV_COOKIE KEYVIZ_ENABLED ENABLE_S3 ENABLE_SQS; do
   case "${!_bool_var}" in
     true|false) ;;
     *)
@@ -566,8 +568,8 @@ update_one_node() {
       S3_CREDENTIALS_FILE="$S3_CREDENTIALS_FILE_Q" \
       S3_PATH_STYLE_ONLY="$S3_PATH_STYLE_ONLY" \
       ENABLE_SQS="$ENABLE_SQS" \
-      SQS_PORT="$SQS_PORT" \
-      SQS_REGION="$SQS_REGION" \
+      SQS_PORT="$SQS_PORT_Q" \
+      SQS_REGION="$SQS_REGION_Q" \
       SQS_CREDENTIALS_FILE="$SQS_CREDENTIALS_FILE_Q" \
       SQS_FIFO_PARTITION_MAP="$SQS_FIFO_PARTITION_MAP_Q" \
       HEALTH_TIMEOUT_SECONDS="$HEALTH_TIMEOUT_SECONDS" \
@@ -1366,6 +1368,15 @@ CONTAINER_MEMORY_LIMIT_Q="$(printf '%q' "${CONTAINER_MEMORY_LIMIT:-}")"
 S3_CREDENTIALS_FILE_Q="$(printf '%q' "${S3_CREDENTIALS_FILE:-}")"
 SQS_CREDENTIALS_FILE_Q="$(printf '%q' "${SQS_CREDENTIALS_FILE:-}")"
 SQS_FIFO_PARTITION_MAP_Q="$(printf '%q' "${SQS_FIFO_PARTITION_MAP:-}")"
+# Scalar SQS knobs are not bool-validated (port can be any uint16,
+# region can be any AWS-style region string), so they go through
+# printf '%q' before crossing the SSH boundary. ENABLE_SQS itself
+# is bool-validated at the top of the script, so it stays unquoted
+# alongside ADMIN_ENABLED / KEYVIZ_ENABLED for readability — same
+# rule the validation comment documents. Closes Gemini security-
+# high finding on PR #741.
+SQS_PORT_Q="$(printf '%q' "$SQS_PORT")"
+SQS_REGION_Q="$(printf '%q' "$SQS_REGION")"
 IMAGE_Q="$(printf '%q' "$IMAGE")"
 DATA_DIR_Q="$(printf '%q' "$DATA_DIR")"
 SERVER_ENTRYPOINT_Q="$(printf '%q' "$SERVER_ENTRYPOINT")"


### PR DESCRIPTION
## Summary

Teach `scripts/rolling-update.sh` and the env example about the SQS-compatible adapter, mirroring how S3 is wired.

Why this matters: admin `/admin/api/v1/sqs/*` endpoints are gated on `r.sqsServer != nil` in `main.go`, and `r.sqsServer` is constructed only when `--sqsAddress` is non-empty. The previous rolling-update script had no path to forward `--sqsAddress` (or any other SQS knob), so even on builds that include the SQS admin handler the endpoints 404'd at runtime. This patch threads the new env vars all the way to the container's command line so `ENABLE_SQS=true` is sufficient to light up both the public SigV4 endpoint and the admin endpoints.

## Changes

- `scripts/rolling-update.sh`
  - New defaults: `ENABLE_SQS=false`, `SQS_PORT=9324`, `SQS_REGION=us-east-1`, `SQS_CREDENTIALS_FILE=` (empty → open endpoint), `SQS_FIFO_PARTITION_MAP=` (empty → bypass capability gate's coverage check), `RAFT_TO_SQS_MAP=` (auto-derived).
  - `derive_raft_to_sqs_map()` mirrors `derive_raft_to_s3_map()` and is invoked when `ENABLE_SQS=true && RAFT_TO_SQS_MAP=""`.
  - SSH `bash -s` passthrough block carries the new vars.
  - `run_container` builds `sqs_creds_volume` (bind-mount the cred file ro at the same host path) and `sqs_flags` (`--sqsAddress`, `--sqsRegion`, `--raftSqsMap`, optional `--sqsCredentialsFile`, optional `--sqsFifoPartitionMap`); both arrays splice into the existing `docker run` line next to the S3 ones.
  - `_Q` shell-quoting added for the new path-like vars (`SQS_CREDENTIALS_FILE_Q`, `SQS_FIFO_PARTITION_MAP_Q`, `RAFT_TO_SQS_MAP_Q`).
  - Usage docs updated to describe the new variables and the admin-endpoint gate.
- `scripts/rolling-update.env.example`
  - Adds the new variables under the existing S3 block, with comments explaining the open-endpoint default and the partition-map opt-in.

## Backward compatibility

`ENABLE_SQS` defaults to `false`. Existing deploy.env files that carry no SQS knobs produce a `docker run` byte-identical to the prior behaviour: empty `sqs_creds_volume`, empty `sqs_flags`, no `--sqsAddress`, no `--raftSqsMap`. No existing rollout changes shape.

## Self-review (5 lenses, abbreviated)

1. **Data loss** — N/A; deploy script only.
2. **Concurrency** — N/A.
3. **Performance** — N/A.
4. **Data consistency** — N/A.
5. **Test coverage** — `bash -n scripts/rolling-update.sh` returns 0. The script doesn't have a Go test surface; structural mirroring of the S3 path is the regression baseline.

## Test plan

- [x] `bash -n scripts/rolling-update.sh`
- [ ] Live rollout against the operator's cluster with `ENABLE_SQS=true` set in `deploy.env`, then `curl -b cookie.jar https://elastickv.bootjp.dev/admin/api/v1/sqs/queues` should return `200`. Operator-driven; out of scope for the merge gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional SQS-compatible adapter integration with configurable region, port, and credential settings.
  * Environment configuration extended to support SQS endpoint mapping and FIFO partition setup.
  * Deployment automation enhanced to derive and inject SQS endpoint mappings and propagate SQS settings during rolling updates when enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->