### PR TITLE
fix(raft): stream receive snapshot to disk + emit EKVT token (memory safety)

### DIFF
--- a/internal/raftengine/etcd/grpc_transport.go
+++ b/internal/raftengine/etcd/grpc_transport.go
@@ -683,28 +683,25 @@ func (t *GRPCTransport) handle(ctx context.Context, msg raftpb.Message) error {
 	return errors.WithStack(handler(ctx, msg))
 }
 
-func (t *GRPCTransport) receiveSnapshotStream(stream pb.EtcdRaft_SendSnapshotServer) (raftpb.Message, error) {
-	var metadata raftpb.Message
-	seenMetadata := false
+// snapshotSpoolPlacement returns (spoolDir, fsmSnapDir) under the transport
+// lock. When fsmSnapDir is wired, the spool itself is placed inside it so
+// FinalizeAsFSMFile's rename stays intra-filesystem and cannot fail with
+// EXDEV. Standard engine wiring puts both under cfg.DataDir, but the
+// receive code should not assume that. The legacy fallback path
+// (fsmSnapDir == "") keeps the spool in spoolDir because it never renames
+// — Bytes() materializes the payload in place.
+func (t *GRPCTransport) snapshotSpoolPlacement() (placement, fsmSnapDir string) {
 	t.mu.RLock()
-	spoolDir := t.spoolDir
-	fsmSnapDir := t.fsmSnapDir
-	t.mu.RUnlock()
-
-	// Place the spool file inside fsmSnapDir (not spoolDir) when the
-	// streaming-token path is wired, so FinalizeAsFSMFile's os.Rename
-	// stays within a single filesystem and cannot fail with EXDEV. An
-	// operator who mounts spoolDir and fsmSnapDir on different volumes
-	// would otherwise hit a hard receive failure (the leader retries
-	// indefinitely with no chance of success). Standard engine wiring
-	// already puts both under cfg.DataDir, but the receive code should
-	// not assume that. The legacy fallback path (fsmSnapDir empty)
-	// keeps the spool in spoolDir because it never renames — Bytes()
-	// materializes the payload in place.
-	spoolPlacement := spoolDir
+	defer t.mu.RUnlock()
+	fsmSnapDir = t.fsmSnapDir
 	if fsmSnapDir != "" {
-		spoolPlacement = fsmSnapDir
+		return fsmSnapDir, fsmSnapDir
 	}
+	return t.spoolDir, ""
+}
+
+func (t *GRPCTransport) receiveSnapshotStream(stream pb.EtcdRaft_SendSnapshotServer) (raftpb.Message, error) {
+	spoolPlacement, fsmSnapDir := t.snapshotSpoolPlacement()
 	spool, err := newSnapshotSpool(spoolPlacement)
 	if err != nil {
 		return raftpb.Message{}, err
@@ -723,11 +720,43 @@ func (t *GRPCTransport) receiveSnapshotStream(stream pb.EtcdRaft_SendSnapshotSer
 		}
 	}()
 
-	// Wrap spool with crc32CWriter so the CRC accumulates as bytes hit disk.
-	// The CRC is only meaningful when we have an fsmSnapDir to finalize into;
-	// the legacy fallback path discards it. Cost is hashing speed (~GB/s on
-	// modern x86 with SSE 4.2 PCLMULQDQ) which is far above the gRPC stream
-	// throughput so the wrapper is invisible in profiles.
+	msg, payloadBytes, err := drainSnapshotChunks(stream, spool, fsmSnapDir)
+	if err != nil {
+		return raftpb.Message{}, err
+	}
+	index := uint64(0)
+	if msg.Snapshot != nil {
+		index = msg.Snapshot.Metadata.Index
+	}
+	slog.Info("etcd raft snapshot stream received",
+		"index", index,
+		"from", msg.From,
+		"payload_bytes", payloadBytes,
+		"format", snapshotDataFormatLabel(msg.Snapshot),
+	)
+	return msg, nil
+}
+
+// drainSnapshotChunks consumes the SendSnapshot stream into spool, computes
+// CRC32C over the payload bytes as they hit disk, and on the final chunk
+// hands off to finalizeReceivedSnapshot — which decides between the
+// streaming-token path (rename to fsmSnapDir/<index>.fsm + 17-byte token
+// in Snapshot.Data) and the legacy materialize fallback. Extracted from
+// receiveSnapshotStream so that function stays under cyclop's complexity
+// budget.
+func drainSnapshotChunks(
+	stream pb.EtcdRaft_SendSnapshotServer,
+	spool *snapshotSpool,
+	fsmSnapDir string,
+) (raftpb.Message, int64, error) {
+	var metadata raftpb.Message
+	seenMetadata := false
+	// Wrap spool with crc32CWriter so the CRC accumulates as bytes hit
+	// disk. The CRC is only meaningful when we have an fsmSnapDir to
+	// finalize into; the legacy fallback path discards it. Cost is
+	// hashing speed (~GB/s on modern x86 with SSE 4.2 PCLMULQDQ), well
+	// above gRPC stream throughput so the wrapper is invisible in
+	// profiles.
 	crcWriter := newCRC32CWriter(spool)
 
 	var payloadBytes int64
@@ -735,32 +764,22 @@ func (t *GRPCTransport) receiveSnapshotStream(stream pb.EtcdRaft_SendSnapshotSer
 		chunk, err := stream.Recv()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
-				return raftpb.Message{}, errors.WithStack(errSnapshotStreamShort)
+				return raftpb.Message{}, 0, errors.WithStack(errSnapshotStreamShort)
 			}
-			return raftpb.Message{}, errors.WithStack(err)
+			return raftpb.Message{}, 0, errors.WithStack(err)
 		}
 		payloadBytes += int64(len(chunk.Chunk))
 		seen, err := appendSnapshotChunk(&metadata, crcWriter, chunk, seenMetadata)
 		if err != nil {
-			return raftpb.Message{}, err
+			return raftpb.Message{}, 0, err
 		}
 		seenMetadata = seen
 		if chunk.Final {
 			msg, err := finalizeReceivedSnapshot(metadata, spool, crcWriter.Sum32(), fsmSnapDir, seenMetadata)
 			if err != nil {
-				return raftpb.Message{}, err
+				return raftpb.Message{}, 0, err
 			}
-			index := uint64(0)
-			if msg.Snapshot != nil {
-				index = msg.Snapshot.Metadata.Index
-			}
-			slog.Info("etcd raft snapshot stream received",
-				"index", index,
-				"from", msg.From,
-				"payload_bytes", payloadBytes,
-				"format", snapshotDataFormatLabel(msg.Snapshot),
-			)
-			return msg, nil
+			return msg, payloadBytes, nil
 		}
 	}
 }

--- a/internal/raftengine/etcd/grpc_transport.go
+++ b/internal/raftengine/etcd/grpc_transport.go
@@ -688,6 +688,7 @@ func (t *GRPCTransport) receiveSnapshotStream(stream pb.EtcdRaft_SendSnapshotSer
 	seenMetadata := false
 	t.mu.RLock()
 	spoolDir := t.spoolDir
+	fsmSnapDir := t.fsmSnapDir
 	t.mu.RUnlock()
 
 	spool, err := newSnapshotSpool(spoolDir)
@@ -697,6 +698,13 @@ func (t *GRPCTransport) receiveSnapshotStream(stream pb.EtcdRaft_SendSnapshotSer
 	defer func() {
 		_ = spool.Close()
 	}()
+
+	// Wrap spool with crc32CWriter so the CRC accumulates as bytes hit disk.
+	// The CRC is only meaningful when we have an fsmSnapDir to finalize into;
+	// the legacy fallback path discards it. Cost is hashing speed (~GB/s on
+	// modern x86 with SSE 4.2 PCLMULQDQ) which is far above the gRPC stream
+	// throughput so the wrapper is invisible in profiles.
+	crcWriter := newCRC32CWriter(spool)
 
 	var payloadBytes int64
 	for {
@@ -708,13 +716,13 @@ func (t *GRPCTransport) receiveSnapshotStream(stream pb.EtcdRaft_SendSnapshotSer
 			return raftpb.Message{}, errors.WithStack(err)
 		}
 		payloadBytes += int64(len(chunk.Chunk))
-		seen, err := appendSnapshotChunk(&metadata, spool, chunk, seenMetadata)
+		seen, err := appendSnapshotChunk(&metadata, crcWriter, chunk, seenMetadata)
 		if err != nil {
 			return raftpb.Message{}, err
 		}
 		seenMetadata = seen
 		if chunk.Final {
-			msg, err := buildSnapshotMessage(metadata, spool, seenMetadata)
+			msg, err := finalizeReceivedSnapshot(metadata, spool, crcWriter.Sum32(), fsmSnapDir, seenMetadata)
 			if err != nil {
 				return raftpb.Message{}, err
 			}
@@ -726,10 +734,58 @@ func (t *GRPCTransport) receiveSnapshotStream(stream pb.EtcdRaft_SendSnapshotSer
 				"index", index,
 				"from", msg.From,
 				"payload_bytes", payloadBytes,
+				"format", snapshotDataFormatLabel(msg.Snapshot),
 			)
 			return msg, nil
 		}
 	}
+}
+
+// finalizeReceivedSnapshot picks between the streaming-token path (when an
+// fsmSnapDir is wired and the snapshot's metadata index is non-zero) and the
+// legacy in-memory path. The streaming path renames the spool file in place
+// to fsmSnapPath(fsmSnapDir, index), embeds a 17-byte EKVT token in
+// Snapshot.Data, and lets restoreSnapshotState read the payload off disk via
+// io.Reader — heap usage stays flat regardless of FSM size, eliminating the
+// 1.35-GiB-FSM × 2.5-GiB-container OOM hazard observed in the 2026-05-08
+// incident. The legacy path is preserved for tests and legacy receivers
+// that have not wired a snapshot directory.
+func finalizeReceivedSnapshot(
+	metadata raftpb.Message,
+	spool *snapshotSpool,
+	crc32c uint32,
+	fsmSnapDir string,
+	seenMetadata bool,
+) (raftpb.Message, error) {
+	if !seenMetadata || metadata.Snapshot == nil {
+		return raftpb.Message{}, errors.WithStack(errSnapshotMetadataNil)
+	}
+	index := metadata.Snapshot.Metadata.Index
+	if fsmSnapDir != "" && index > 0 {
+		if err := spool.FinalizeAsFSMFile(fsmSnapDir, index, crc32c); err != nil {
+			return raftpb.Message{}, err
+		}
+		metadata.Snapshot.Data = encodeSnapshotToken(index, crc32c)
+		return metadata, nil
+	}
+	// Legacy fallback: full materialization. Used by tests that don't wire an
+	// fsmSnapDir and by the index=0 edge case (no canonical filename to
+	// rename to).
+	return buildSnapshotMessage(metadata, spool, seenMetadata)
+}
+
+// snapshotDataFormatLabel exists purely for the structured log line on the
+// receiver — it lets an operator distinguish a streaming-token receive
+// (small heap, payload on disk) from a legacy materialization (heap holds
+// the full payload) at a glance, without grepping for byte counts.
+func snapshotDataFormatLabel(snap *raftpb.Snapshot) string {
+	if snap == nil {
+		return "nil"
+	}
+	if isSnapshotToken(snap.Data) {
+		return "token"
+	}
+	return "inline"
 }
 
 func appendSnapshotChunk(metadata *raftpb.Message, payload io.Writer, chunk *pb.EtcdRaftSnapshotChunk, seenMetadata bool) (bool, error) {

--- a/internal/raftengine/etcd/grpc_transport.go
+++ b/internal/raftengine/etcd/grpc_transport.go
@@ -696,7 +696,17 @@ func (t *GRPCTransport) receiveSnapshotStream(stream pb.EtcdRaft_SendSnapshotSer
 		return raftpb.Message{}, err
 	}
 	defer func() {
-		_ = spool.Close()
+		// Log rather than swallow: a Close failure here points at a
+		// half-written spool file we couldn't clean up (disk full,
+		// permission flip mid-stream, …). Once FinalizeAsFSMFile has
+		// transferred ownership, Close is a no-op so this only fires on
+		// the unhappy paths that actually need an operator to look.
+		if closeErr := spool.Close(); closeErr != nil {
+			slog.Warn("snapshot spool close failed",
+				"spool_dir", spoolDir,
+				"err", closeErr,
+			)
+		}
 	}()
 
 	// Wrap spool with crc32CWriter so the CRC accumulates as bytes hit disk.

--- a/internal/raftengine/etcd/grpc_transport.go
+++ b/internal/raftengine/etcd/grpc_transport.go
@@ -691,7 +691,21 @@ func (t *GRPCTransport) receiveSnapshotStream(stream pb.EtcdRaft_SendSnapshotSer
 	fsmSnapDir := t.fsmSnapDir
 	t.mu.RUnlock()
 
-	spool, err := newSnapshotSpool(spoolDir)
+	// Place the spool file inside fsmSnapDir (not spoolDir) when the
+	// streaming-token path is wired, so FinalizeAsFSMFile's os.Rename
+	// stays within a single filesystem and cannot fail with EXDEV. An
+	// operator who mounts spoolDir and fsmSnapDir on different volumes
+	// would otherwise hit a hard receive failure (the leader retries
+	// indefinitely with no chance of success). Standard engine wiring
+	// already puts both under cfg.DataDir, but the receive code should
+	// not assume that. The legacy fallback path (fsmSnapDir empty)
+	// keeps the spool in spoolDir because it never renames — Bytes()
+	// materializes the payload in place.
+	spoolPlacement := spoolDir
+	if fsmSnapDir != "" {
+		spoolPlacement = fsmSnapDir
+	}
+	spool, err := newSnapshotSpool(spoolPlacement)
 	if err != nil {
 		return raftpb.Message{}, err
 	}
@@ -703,7 +717,7 @@ func (t *GRPCTransport) receiveSnapshotStream(stream pb.EtcdRaft_SendSnapshotSer
 		// the unhappy paths that actually need an operator to look.
 		if closeErr := spool.Close(); closeErr != nil {
 			slog.Warn("snapshot spool close failed",
-				"spool_dir", spoolDir,
+				"spool_dir", spoolPlacement,
 				"err", closeErr,
 			)
 		}

--- a/internal/raftengine/etcd/grpc_transport.go
+++ b/internal/raftengine/etcd/grpc_transport.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"os"
 	"sync"
 	"time"
 
@@ -378,9 +379,52 @@ func (t *GRPCTransport) SendSnapshot(stream pb.EtcdRaft_SendSnapshotServer) erro
 		return err
 	}
 	if err := t.handle(stream.Context(), msg); err != nil {
+		// If receive finalized the snapshot as a .fsm file (token in
+		// Snapshot.Data), the engine refused to apply it — likely a
+		// transient context cancel or raft error. Remove the on-disk
+		// file so retries at later indexes don't leak orphan .fsm
+		// payloads into fsmSnapDir until the next startup runs
+		// cleanupStaleFSMSnaps. Same-index retries are already safe
+		// because os.Rename atomically replaces the prior file.
+		t.removeOrphanedFSMSnapshot(msg)
 		return err
 	}
 	return errors.WithStack(stream.SendAndClose(&pb.EtcdRaftAck{}))
+}
+
+// removeOrphanedFSMSnapshot deletes the .fsm file that
+// receiveSnapshotStream finalized for `msg`, if any. Used by
+// SendSnapshot when the engine apply (`t.handle`) fails after the
+// receive succeeded — the engine has NOT applied the snapshot (apply is
+// synchronous to t.handle, so a non-nil return means applied_index was
+// not advanced), so the file is unreferenced and safe to remove.
+//
+// Best-effort: a cleanup failure here is logged but not returned because
+// the original apply error is the actionable signal; orphans get swept
+// by cleanupStaleFSMSnaps at the next engine restart even if Remove
+// races with another process.
+func (t *GRPCTransport) removeOrphanedFSMSnapshot(msg raftpb.Message) {
+	if msg.Snapshot == nil || !isSnapshotToken(msg.Snapshot.Data) {
+		return
+	}
+	tok, err := decodeSnapshotToken(msg.Snapshot.Data)
+	if err != nil {
+		return
+	}
+	t.mu.RLock()
+	fsmSnapDir := t.fsmSnapDir
+	t.mu.RUnlock()
+	if fsmSnapDir == "" {
+		return
+	}
+	path := fsmSnapPath(fsmSnapDir, tok.Index)
+	if rmErr := os.Remove(path); rmErr != nil && !os.IsNotExist(rmErr) {
+		slog.Warn("failed to remove orphaned fsm snapshot file after apply failure",
+			"path", path,
+			"index", tok.Index,
+			"err", rmErr,
+		)
+	}
 }
 
 func (t *GRPCTransport) Send(ctx context.Context, req *pb.EtcdRaftMessage) (*pb.EtcdRaftAck, error) {

--- a/internal/raftengine/etcd/grpc_transport_test.go
+++ b/internal/raftengine/etcd/grpc_transport_test.go
@@ -221,6 +221,67 @@ func TestReceiveSnapshotStream_StreamingTokenWhenFSMSnapDirSet(t *testing.T) {
 	require.Equal(t, senderFSM.Applied(), receiverFSM.Applied())
 }
 
+// TestReceiveSnapshotStream_SpoolPlacedInFSMSnapDir pins the EXDEV-avoidance
+// fix from PR #747 round-3 (Codex P1): when fsmSnapDir is wired, the spool
+// file MUST be created inside fsmSnapDir (not spoolDir), so that the
+// FinalizeAsFSMFile rename stays within a single filesystem and cannot fail
+// with syscall.EXDEV. Without this, an operator who mounts spoolDir and
+// fsmSnapDir on separate volumes hits a hard receive failure with the
+// leader retrying indefinitely. Standard engine wiring puts both under
+// cfg.DataDir but the receive code must not assume that.
+func TestReceiveSnapshotStream_SpoolPlacedInFSMSnapDir(t *testing.T) {
+	const index = uint64(55)
+	metadata := raftpb.Message{
+		Type: raftpb.MsgSnap,
+		From: 1,
+		To:   2,
+		Snapshot: &raftpb.Snapshot{
+			Metadata: raftpb.SnapshotMetadata{Index: index, Term: 1},
+		},
+	}
+	raw, err := metadata.Marshal()
+	require.NoError(t, err)
+
+	// Distinct directories — different absolute paths so we can prove the
+	// spool went to fsmSnapDir, not spoolDir.
+	spoolDir := t.TempDir()
+	fsmSnapDir := t.TempDir()
+
+	// Inject a syncDir failure to keep the partial-state observable: the
+	// rename has fired (so the .fsm file is at fsmSnapPath), Finalize
+	// returned the syncDir error, and we can inspect both directories.
+	original := snapshotSyncDir
+	syncErr := errors.New("simulated syncDir failure")
+	snapshotSyncDir = func(string) error { return syncErr }
+	t.Cleanup(func() { snapshotSyncDir = original })
+
+	transport := NewGRPCTransport(nil)
+	transport.SetSpoolDir(spoolDir)
+	transport.SetFSMSnapDir(fsmSnapDir)
+
+	stream := &testSendSnapshotServer{
+		chunks: []*pb.EtcdRaftSnapshotChunk{
+			{Metadata: raw},
+			{Chunk: []byte("payload-for-spool-placement-test"), Final: true},
+		},
+	}
+	_, err = transport.receiveSnapshotStream(stream)
+	require.ErrorIs(t, err, syncErr, "should surface the simulated syncDir error")
+
+	// spoolDir must be empty: the spool was created in fsmSnapDir, not
+	// spoolDir. If a future refactor reverts the placement decision, this
+	// directory would carry an elastickv-etcd-snapshot-* leftover at
+	// minimum, or a renamed .fsm at maximum.
+	spoolEntries, err := os.ReadDir(spoolDir)
+	require.NoError(t, err)
+	require.Empty(t, spoolEntries, "spool dir must NOT receive the spool file when fsmSnapDir is wired (rename would risk EXDEV)")
+
+	// fsmSnapDir holds the renamed .fsm file at the canonical path.
+	finalPath := fsmSnapPath(fsmSnapDir, index)
+	_, statErr := os.Stat(finalPath)
+	require.NoError(t, statErr, "renamed .fsm file should exist at canonical path")
+}
+
 // TestReceiveSnapshotStream_LegacyFallbackWhenNoFSMSnapDir pins the
 // behaviour when fsmSnapDir is unset: receive still works, just via the
 // pre-PR materialization path. Tests that don't wire an fsmSnapDir (most

--- a/internal/raftengine/etcd/grpc_transport_test.go
+++ b/internal/raftengine/etcd/grpc_transport_test.go
@@ -131,6 +131,129 @@ func TestReceiveSnapshotStreamRejectsDuplicateMetadata(t *testing.T) {
 	require.True(t, errors.Is(err, errSnapshotMetadataDuplicate))
 }
 
+// TestReceiveSnapshotStream_StreamingTokenWhenFSMSnapDirSet pins the
+// memory-safety win: when the receive transport has fsmSnapDir wired,
+// the spool file is renamed to fsmSnapPath(...) and Snapshot.Data is
+// the 17-byte EKVT token instead of the materialized payload. The
+// spool dir is left empty, the fsm-snap dir holds the .fsm file, and
+// the token round-trips through restoreSnapshotState onto a fresh FSM.
+//
+// Without this path, receiving a 1.5+ GiB snapshot allocates the entire
+// payload as []byte for raftpb.Snapshot.Data — on a 2.5-GiB-container
+// production node that single allocation OOMs the process before
+// RestoreSnapshot ever runs (2026-05-08 incident).
+func TestReceiveSnapshotStream_StreamingTokenWhenFSMSnapDirSet(t *testing.T) {
+	const index = uint64(123)
+	const term = uint64(5)
+
+	// Build a properly framed testStateMachine payload (count + length-prefixed
+	// items) so restoreSnapshotState can decode it on the receiver. Three
+	// distinct entries mirror the production case where a follower has fallen
+	// behind by many log entries and is recovering from snapshot.
+	senderFSM := &testStateMachine{}
+	for _, e := range [][]byte{[]byte("alpha"), []byte("bravo"), []byte("charlie")} {
+		senderFSM.Apply(e)
+	}
+	snap, err := senderFSM.Snapshot()
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	_, err = snap.WriteTo(&buf)
+	require.NoError(t, err)
+	require.NoError(t, snap.Close())
+	payload := buf.Bytes()
+
+	metadata := raftpb.Message{
+		Type: raftpb.MsgSnap,
+		From: 1,
+		To:   2,
+		Snapshot: &raftpb.Snapshot{
+			Metadata: raftpb.SnapshotMetadata{Index: index, Term: term},
+		},
+	}
+	raw, err := metadata.Marshal()
+	require.NoError(t, err)
+
+	spoolDir := t.TempDir()
+	fsmSnapDir := t.TempDir()
+
+	transport := NewGRPCTransport(nil)
+	transport.SetSpoolDir(spoolDir)
+	transport.SetFSMSnapDir(fsmSnapDir)
+
+	stream := &testSendSnapshotServer{
+		chunks: []*pb.EtcdRaftSnapshotChunk{
+			{Metadata: raw},
+			{Chunk: payload, Final: true},
+		},
+	}
+	msg, err := transport.receiveSnapshotStream(stream)
+	require.NoError(t, err)
+	require.NotNil(t, msg.Snapshot)
+
+	// Snapshot.Data should now be a 17-byte EKVT token, not the payload.
+	require.Len(t, msg.Snapshot.Data, snapshotTokenSize, "payload must NOT be inline; got %d bytes", len(msg.Snapshot.Data))
+	require.True(t, isSnapshotToken(msg.Snapshot.Data), "Snapshot.Data is not an EKVT token")
+	tok, err := decodeSnapshotToken(msg.Snapshot.Data)
+	require.NoError(t, err)
+	require.Equal(t, index, tok.Index)
+
+	// Spool dir must be empty: the spool file was renamed into fsmSnapDir,
+	// not deleted (which would orphan the data) and not left behind (which
+	// would leak disk).
+	spoolEntries, err := os.ReadDir(spoolDir)
+	require.NoError(t, err)
+	require.Empty(t, spoolEntries, "spool dir should not retain the file after FinalizeAsFSMFile")
+
+	// .fsm file exists at the canonical path with the on-disk format
+	// openAndRestoreFSMSnapshot expects: payload + 4-byte CRC32C footer.
+	fsmPath := fsmSnapPath(fsmSnapDir, index)
+	got, err := os.ReadFile(fsmPath)
+	require.NoError(t, err)
+	require.Equal(t, len(payload)+4, len(got), "missing CRC footer")
+	require.Equal(t, payload, got[:len(payload)])
+
+	// Token round-trips through the apply path: restoreSnapshotState reads
+	// the .fsm file via the streaming io.Reader interface, never
+	// materializing the payload as []byte. Verify the receiver FSM ends up
+	// with exactly the entries the sender serialized.
+	receiverFSM := &testStateMachine{}
+	require.NoError(t, restoreSnapshotState(receiverFSM, *msg.Snapshot, fsmSnapDir))
+	require.Equal(t, senderFSM.Applied(), receiverFSM.Applied())
+}
+
+// TestReceiveSnapshotStream_LegacyFallbackWhenNoFSMSnapDir pins the
+// behaviour when fsmSnapDir is unset: receive still works, just via the
+// pre-PR materialization path. Tests that don't wire an fsmSnapDir (most
+// of the existing suite) MUST keep behaving exactly as before this PR.
+func TestReceiveSnapshotStream_LegacyFallbackWhenNoFSMSnapDir(t *testing.T) {
+	payload := []byte("legacy-inline-payload")
+	metadata := raftpb.Message{
+		Type: raftpb.MsgSnap,
+		From: 1,
+		To:   2,
+		Snapshot: &raftpb.Snapshot{
+			Metadata: raftpb.SnapshotMetadata{Index: 42, Term: 1},
+		},
+	}
+	raw, err := metadata.Marshal()
+	require.NoError(t, err)
+
+	transport := NewGRPCTransport(nil)
+	transport.SetSpoolDir(t.TempDir())
+	// fsmSnapDir intentionally unset.
+
+	stream := &testSendSnapshotServer{
+		chunks: []*pb.EtcdRaftSnapshotChunk{
+			{Metadata: raw, Chunk: payload, Final: true},
+		},
+	}
+	msg, err := transport.receiveSnapshotStream(stream)
+	require.NoError(t, err)
+	require.NotNil(t, msg.Snapshot)
+	require.Equal(t, payload, msg.Snapshot.Data)
+	require.False(t, isSnapshotToken(msg.Snapshot.Data))
+}
+
 func TestClientForDeduplicatesConcurrentDial(t *testing.T) {
 	transport := NewGRPCTransport([]Peer{{
 		NodeID:  2,

--- a/internal/raftengine/etcd/grpc_transport_test.go
+++ b/internal/raftengine/etcd/grpc_transport_test.go
@@ -282,6 +282,75 @@ func TestReceiveSnapshotStream_SpoolPlacedInFSMSnapDir(t *testing.T) {
 	require.NoError(t, statErr, "renamed .fsm file should exist at canonical path")
 }
 
+// TestSendSnapshot_ApplyFailureRemovesFinalizedFSMFile pins the
+// orphan-cleanup behaviour from PR #747 round-4 (Codex P2): when the
+// receive path successfully finalizes the snapshot as
+// fsmSnapDir/<index>.fsm but the engine's apply (t.handle) then fails
+// — transient context cancel, raft error, etc. — the finalized .fsm
+// file MUST be removed. Otherwise retries at later snapshot indexes
+// accumulate orphan .fsm payloads in fsmSnapDir until startup runs
+// cleanupStaleFSMSnaps. Same-index retries are already safe via
+// os.Rename's atomic-replace, so this test exercises the cross-index
+// case where the orphan would actually persist.
+func TestSendSnapshot_ApplyFailureRemovesFinalizedFSMFile(t *testing.T) {
+	const index = uint64(77)
+
+	// Build a real testStateMachine payload + framed bytes so receive
+	// finalizes a syntactically valid .fsm file.
+	senderFSM := &testStateMachine{}
+	senderFSM.Apply([]byte("entry-for-orphan-cleanup-test"))
+	snap, err := senderFSM.Snapshot()
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	_, err = snap.WriteTo(&buf)
+	require.NoError(t, err)
+	require.NoError(t, snap.Close())
+	payload := buf.Bytes()
+
+	metadata := raftpb.Message{
+		Type: raftpb.MsgSnap,
+		From: 1,
+		To:   2,
+		Snapshot: &raftpb.Snapshot{
+			Metadata: raftpb.SnapshotMetadata{Index: index, Term: 1},
+		},
+	}
+	raw, err := metadata.Marshal()
+	require.NoError(t, err)
+
+	fsmSnapDir := t.TempDir()
+
+	transport := NewGRPCTransport(nil)
+	transport.SetSpoolDir(t.TempDir())
+	transport.SetFSMSnapDir(fsmSnapDir)
+
+	// Wire a handler that always fails so SendSnapshot exercises the
+	// orphan-cleanup branch.
+	applyErr := errors.New("simulated apply failure")
+	transport.SetHandler(func(_ context.Context, _ raftpb.Message) error {
+		return applyErr
+	})
+
+	stream := &testSendSnapshotServer{
+		chunks: []*pb.EtcdRaftSnapshotChunk{
+			{Metadata: raw},
+			{Chunk: payload, Final: true},
+		},
+	}
+
+	err = transport.SendSnapshot(stream)
+	require.Error(t, err)
+	require.ErrorIs(t, err, applyErr, "SendSnapshot must surface the apply failure")
+
+	// THE point: the .fsm file at the canonical path MUST have been
+	// removed. Without the cleanup, leader retries at later indexes
+	// would accumulate one .fsm per failed apply until next startup.
+	finalPath := fsmSnapPath(fsmSnapDir, index)
+	_, statErr := os.Stat(finalPath)
+	require.True(t, os.IsNotExist(statErr),
+		"orphan .fsm file at %s must be removed after apply failure (got stat err: %v)", finalPath, statErr)
+}
+
 // TestReceiveSnapshotStream_LegacyFallbackWhenNoFSMSnapDir pins the
 // behaviour when fsmSnapDir is unset: receive still works, just via the
 // pre-PR materialization path. Tests that don't wire an fsmSnapDir (most

--- a/internal/raftengine/etcd/snapshot_spool.go
+++ b/internal/raftengine/etcd/snapshot_spool.go
@@ -1,6 +1,7 @@
 package etcd
 
 import (
+	"encoding/binary"
 	"io"
 	"log/slog"
 	"os"
@@ -102,6 +103,61 @@ func (s *snapshotSpool) Reader() (io.Reader, error) {
 	return s.file, nil
 }
 
+// FinalizeAsFSMFile rewrites the spool file as a fully-formed .fsm snapshot
+// (payload + 4-byte big-endian CRC32C footer) and atomically renames it to
+// fsmSnapPath(fsmSnapDir, index). On success, ownership of the on-disk file
+// transfers to fsmSnapDir — subsequent Close() becomes a no-op so the
+// renamed file is NOT removed.
+//
+// The caller is responsible for having computed crc32c over the bytes
+// already written to the spool (see crc32CWriter). This is the streaming
+// receive-side counterpart of writeFSMSnapshotFile / writeFSMSnapshotPayload
+// (sender-side in fsm_snapshot_file.go), and the on-disk format is identical
+// so openAndRestoreFSMSnapshot can read either source uniformly.
+//
+// Memory safety: this is the path that lets receiveSnapshotStream avoid
+// materializing a multi-GiB Snapshot.Data []byte. The spool file already
+// holds the payload; we only append 4 bytes and rename. Heap stays flat
+// regardless of FSM size.
+func (s *snapshotSpool) FinalizeAsFSMFile(fsmSnapDir string, index uint64, crc32c uint32) (err error) {
+	if s == nil || s.file == nil {
+		return errors.New("snapshot spool: finalize on closed/nil spool")
+	}
+	defer func() {
+		if err != nil {
+			// On failure, fall through to deferred Close() in caller — keep
+			// spool fields populated so Close removes the half-written file.
+			return
+		}
+		// Success: file has been renamed; null out so Close() is a no-op
+		// instead of trying to remove a path that no longer points at us.
+		s.file = nil
+		s.path = ""
+	}()
+
+	if err := binary.Write(s.file, binary.BigEndian, crc32c); err != nil {
+		return errors.WithStack(err)
+	}
+	if err := s.file.Sync(); err != nil {
+		return errors.WithStack(err)
+	}
+	if err := s.file.Close(); err != nil {
+		return errors.WithStack(err)
+	}
+
+	finalPath := fsmSnapPath(fsmSnapDir, index)
+	if mkErr := os.MkdirAll(fsmSnapDir, defaultDirPerm); mkErr != nil {
+		return errors.WithStack(mkErr)
+	}
+	if rnErr := os.Rename(s.path, finalPath); rnErr != nil {
+		return errors.WithStack(rnErr)
+	}
+	if syErr := syncDir(fsmSnapDir); syErr != nil {
+		return errors.WithStack(syErr)
+	}
+	return nil
+}
+
 // cleanupStaleSnapshotSpools removes orphaned snapshot spool files left behind
 // by a previous engine instance that crashed before Close could run.
 func cleanupStaleSnapshotSpools(dir string) error {
@@ -128,6 +184,9 @@ func (s *snapshotSpool) Close() error {
 	if s.file != nil {
 		err = errors.CombineErrors(err, errors.WithStack(s.file.Close()))
 	}
+	// Skip removal once FinalizeAsFSMFile has handed ownership of the file
+	// off to fsmSnapDir (it nils path so we don't try to delete a renamed
+	// .fsm file that's now serving as the durable snapshot).
 	if s.path != "" {
 		err = errors.CombineErrors(err, errors.WithStack(os.Remove(s.path)))
 	}

--- a/internal/raftengine/etcd/snapshot_spool.go
+++ b/internal/raftengine/etcd/snapshot_spool.go
@@ -119,22 +119,23 @@ func (s *snapshotSpool) Reader() (io.Reader, error) {
 // materializing a multi-GiB Snapshot.Data []byte. The spool file already
 // holds the payload; we only append 4 bytes and rename. Heap stays flat
 // regardless of FSM size.
-func (s *snapshotSpool) FinalizeAsFSMFile(fsmSnapDir string, index uint64, crc32c uint32) (err error) {
+func (s *snapshotSpool) FinalizeAsFSMFile(fsmSnapDir string, index uint64, crc32c uint32) error {
 	if s == nil || s.file == nil {
 		return errors.New("snapshot spool: finalize on closed/nil spool")
 	}
-	defer func() {
-		if err != nil {
-			// On failure, fall through to deferred Close() in caller — keep
-			// spool fields populated so Close removes the half-written file.
-			return
-		}
-		// Success: file has been renamed; null out so Close() is a no-op
-		// instead of trying to remove a path that no longer points at us.
-		s.file = nil
-		s.path = ""
-	}()
 
+	// State is cleared at each successful step so a deferred caller-side
+	// spool.Close() never tries to operate on a resource we already
+	// released. Two failure modes the original single-defer version would
+	// have produced misleading errors for, that this stepwise approach
+	// avoids:
+	//   1. file.Close() succeeds, os.Rename() fails → s.file=nil but s.path
+	//      still valid, so Close() correctly removes the half-written
+	//      spool file at its original path (the rename never happened).
+	//   2. os.Rename() succeeds, syncDir() fails → s.file=nil AND s.path=""
+	//      so Close() is a no-op. Without the per-step clear, Close()
+	//      would attempt os.Remove(s.path) and surface a misleading
+	//      ErrNotExist that buries the real syncDir error.
 	if err := binary.Write(s.file, binary.BigEndian, crc32c); err != nil {
 		return errors.WithStack(err)
 	}
@@ -144,6 +145,7 @@ func (s *snapshotSpool) FinalizeAsFSMFile(fsmSnapDir string, index uint64, crc32
 	if err := s.file.Close(); err != nil {
 		return errors.WithStack(err)
 	}
+	s.file = nil // file descriptor closed; subsequent Close() must not double-close.
 
 	finalPath := fsmSnapPath(fsmSnapDir, index)
 	if mkErr := os.MkdirAll(fsmSnapDir, defaultDirPerm); mkErr != nil {
@@ -152,6 +154,8 @@ func (s *snapshotSpool) FinalizeAsFSMFile(fsmSnapDir string, index uint64, crc32
 	if rnErr := os.Rename(s.path, finalPath); rnErr != nil {
 		return errors.WithStack(rnErr)
 	}
+	s.path = "" // file no longer at this path; subsequent Close() must not try to remove it.
+
 	if syErr := syncDir(fsmSnapDir); syErr != nil {
 		return errors.WithStack(syErr)
 	}

--- a/internal/raftengine/etcd/snapshot_spool.go
+++ b/internal/raftengine/etcd/snapshot_spool.go
@@ -50,6 +50,13 @@ func resolveMaxSnapshotPayloadBytes() int64 {
 
 var errSnapshotPayloadTooLarge = errors.New("etcd raft snapshot payload exceeds limit")
 
+// snapshotSyncDir indirects fsync-on-directory through a package var so a
+// fault-injection test can simulate "rename succeeded but the fsync that
+// would persist the directory entry failed" — that's the partial-failure
+// path FinalizeAsFSMFile's stepwise state-clearing was added to handle,
+// and without an injection seam there's no portable way to reproduce it.
+var snapshotSyncDir = syncDir
+
 const snapshotSpoolPattern = "elastickv-etcd-snapshot-*"
 
 type snapshotSpool struct {
@@ -142,10 +149,16 @@ func (s *snapshotSpool) FinalizeAsFSMFile(fsmSnapDir string, index uint64, crc32
 	if err := s.file.Sync(); err != nil {
 		return errors.WithStack(err)
 	}
-	if err := s.file.Close(); err != nil {
-		return errors.WithStack(err)
+	closeErr := s.file.Close()
+	// File descriptor is released by os.File.Close before it returns, even
+	// on error (the underlying fd is invalidated atomically before the
+	// close syscall). Clearing s.file unconditionally avoids a double-Close
+	// from the deferred caller-side Close that would log a confusing
+	// os.ErrClosed warning on top of the real error.
+	s.file = nil
+	if closeErr != nil {
+		return errors.WithStack(closeErr)
 	}
-	s.file = nil // file descriptor closed; subsequent Close() must not double-close.
 
 	finalPath := fsmSnapPath(fsmSnapDir, index)
 	if mkErr := os.MkdirAll(fsmSnapDir, defaultDirPerm); mkErr != nil {
@@ -156,7 +169,7 @@ func (s *snapshotSpool) FinalizeAsFSMFile(fsmSnapDir string, index uint64, crc32
 	}
 	s.path = "" // file no longer at this path; subsequent Close() must not try to remove it.
 
-	if syErr := syncDir(fsmSnapDir); syErr != nil {
+	if syErr := snapshotSyncDir(fsmSnapDir); syErr != nil {
 		return errors.WithStack(syErr)
 	}
 	return nil

--- a/internal/raftengine/etcd/snapshot_spool.go
+++ b/internal/raftengine/etcd/snapshot_spool.go
@@ -126,6 +126,14 @@ func (s *snapshotSpool) Reader() (io.Reader, error) {
 // materializing a multi-GiB Snapshot.Data []byte. The spool file already
 // holds the payload; we only append 4 bytes and rename. Heap stays flat
 // regardless of FSM size.
+//
+// Filesystem requirement: the spool file MUST be on the same filesystem as
+// fsmSnapDir, otherwise os.Rename returns syscall.EXDEV and the receive
+// fails (the leader will retry indefinitely with no chance of success).
+// receiveSnapshotStream guarantees this by creating the spool inside
+// fsmSnapDir when the streaming-token path is wired; standard engine
+// wiring (engine.go) keeps both spoolDir and fsmSnapDir under cfg.DataDir,
+// so the constraint is satisfied even on the legacy fallback path.
 func (s *snapshotSpool) FinalizeAsFSMFile(fsmSnapDir string, index uint64, crc32c uint32) error {
 	if s == nil || s.file == nil {
 		return errors.New("snapshot spool: finalize on closed/nil spool")

--- a/internal/raftengine/etcd/snapshot_spool_test.go
+++ b/internal/raftengine/etcd/snapshot_spool_test.go
@@ -82,6 +82,88 @@ func TestSnapshotSpool_OverrideInvalidFallsBack(t *testing.T) {
 	require.Equal(t, defaultMaxSnapshotPayloadBytes, spool.maxSize)
 }
 
+// TestFinalizeAsFSMFile_PostFinalizeCloseIsNoop pins the gemini-medium
+// review on PR #747: after a successful FinalizeAsFSMFile, the deferred
+// caller-side spool.Close() must NOT attempt to remove the renamed file
+// (which would surface a misleading os.ErrNotExist that buries any real
+// error the caller is reporting). State clearing inside FinalizeAsFSMFile
+// at each successful step makes the post-success Close() a true no-op.
+func TestFinalizeAsFSMFile_PostFinalizeCloseIsNoop(t *testing.T) {
+	const (
+		index uint64 = 99
+		crc   uint32 = 0x42424242
+	)
+	spoolDir := t.TempDir()
+	fsmSnapDir := t.TempDir()
+
+	spool, err := newSnapshotSpool(spoolDir)
+	require.NoError(t, err)
+
+	payload := []byte("payload-bytes-for-finalize-test")
+	_, err = spool.Write(payload)
+	require.NoError(t, err)
+
+	require.NoError(t, spool.FinalizeAsFSMFile(fsmSnapDir, index, crc))
+
+	// Spool dir is empty (file moved, not deleted, not orphaned).
+	spoolEntries, err := os.ReadDir(spoolDir)
+	require.NoError(t, err)
+	require.Empty(t, spoolEntries)
+
+	// .fsm file exists at canonical path with payload + 4-byte CRC footer.
+	finalPath := fsmSnapPath(fsmSnapDir, index)
+	got, err := os.ReadFile(finalPath)
+	require.NoError(t, err)
+	require.Equal(t, len(payload)+4, len(got))
+	require.Equal(t, payload, got[:len(payload)])
+
+	// Critical: post-Finalize Close() must be a clean no-op, not surface
+	// os.ErrNotExist from trying to remove the original spool path.
+	require.NoError(t, spool.Close(), "Close after successful Finalize must not error")
+
+	// Idempotent: a second Close (from a buggy / over-cautious caller)
+	// must also be a no-op.
+	require.NoError(t, spool.Close())
+
+	// Renamed file is still on disk — Close did not nuke it.
+	_, err = os.Stat(finalPath)
+	require.NoError(t, err)
+}
+
+// TestFinalizeAsFSMFile_RenameFailureCleansUpSpool pins the partial-failure
+// path: if os.Rename fails (here simulated by removing the spool dir), the
+// already-closed spool file lives at its original path. The deferred
+// caller-side Close() should still remove that orphan so we don't leak
+// disk on the unhappy path.
+func TestFinalizeAsFSMFile_RenameFailureCleansUpSpool(t *testing.T) {
+	spoolDir := t.TempDir()
+	// Point fsmSnapDir at a path under a directory we'll make unwritable
+	// AFTER the spool file is created. The file gets sync+close'd but the
+	// rename fails because the destination dir cannot be created.
+	parent := t.TempDir()
+	require.NoError(t, os.Chmod(parent, 0o500)) // r-x: MkdirAll under it fails
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o700) })
+	fsmSnapDir := filepath.Join(parent, "no-such-subdir")
+
+	spool, err := newSnapshotSpool(spoolDir)
+	require.NoError(t, err)
+	_, err = spool.Write([]byte("payload"))
+	require.NoError(t, err)
+	spoolPath := spool.path
+
+	err = spool.FinalizeAsFSMFile(fsmSnapDir, 7, 0xdeadbeef)
+	require.Error(t, err, "Finalize must report the MkdirAll/Rename failure")
+
+	// Spool file is still at its original path (rename never happened).
+	_, statErr := os.Stat(spoolPath)
+	require.NoError(t, statErr, "spool file should still exist after a pre-rename failure")
+
+	// Caller's deferred Close() now removes the orphan.
+	require.NoError(t, spool.Close())
+	_, statErr = os.Stat(spoolPath)
+	require.True(t, os.IsNotExist(statErr), "Close must remove the orphaned spool file")
+}
+
 func TestCleanupStaleSnapshotSpools(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/raftengine/etcd/snapshot_spool_test.go
+++ b/internal/raftengine/etcd/snapshot_spool_test.go
@@ -164,6 +164,63 @@ func TestFinalizeAsFSMFile_RenameFailureCleansUpSpool(t *testing.T) {
 	require.True(t, os.IsNotExist(statErr), "Close must remove the orphaned spool file")
 }
 
+// TestFinalizeAsFSMFile_SyncDirFailureCloseIsNoop pins the partial-failure
+// path documented in FinalizeAsFSMFile's comment block: when os.Rename has
+// already succeeded but the subsequent dir-fsync fails, the spool's state
+// clearing must have advanced past s.path so a deferred caller-side
+// spool.Close() returns nil instead of surfacing os.ErrNotExist from
+// trying to delete the now-renamed file. Without the snapshotSyncDir
+// injection seam there is no portable way to reproduce a syncDir failure
+// (the kernel happily fsyncs an empty tmp dir).
+func TestFinalizeAsFSMFile_SyncDirFailureCloseIsNoop(t *testing.T) {
+	const (
+		index uint64 = 17
+		crc   uint32 = 0xcafebabe
+	)
+	spoolDir := t.TempDir()
+	fsmSnapDir := t.TempDir()
+
+	original := snapshotSyncDir
+	syncErr := errors.New("simulated syncDir failure")
+	snapshotSyncDir = func(string) error { return syncErr }
+	t.Cleanup(func() { snapshotSyncDir = original })
+
+	spool, err := newSnapshotSpool(spoolDir)
+	require.NoError(t, err)
+
+	payload := []byte("payload-bytes-for-syncdir-failure-test")
+	_, err = spool.Write(payload)
+	require.NoError(t, err)
+
+	err = spool.FinalizeAsFSMFile(fsmSnapDir, index, crc)
+	require.Error(t, err)
+	require.ErrorIs(t, err, syncErr, "Finalize must surface the syncDir error")
+
+	// Crucial: rename already happened, so the .fsm file is at its
+	// canonical path. A future read MUST find it; the syncDir failure
+	// is durability-only, not a logical-state regression.
+	finalPath := fsmSnapPath(fsmSnapDir, index)
+	_, statErr := os.Stat(finalPath)
+	require.NoError(t, statErr, ".fsm file should be at canonical path despite syncDir failure")
+
+	// Spool dir is empty (file was renamed out, not deleted, not
+	// orphaned at the spool location).
+	spoolEntries, err := os.ReadDir(spoolDir)
+	require.NoError(t, err)
+	require.Empty(t, spoolEntries)
+
+	// THE point: deferred Close() must be a clean no-op despite the
+	// upstream error. Pre-fix, Close() would have tried os.Remove on
+	// the original spool path, returned os.ErrNotExist, and the slog
+	// warning in receiveSnapshotStream would bury the real syncDir
+	// signal under a misleading not-exist log line.
+	require.NoError(t, spool.Close(), "Close after syncDir failure must not surface os.ErrNotExist")
+
+	// .fsm file is still on disk after Close.
+	_, statErr = os.Stat(finalPath)
+	require.NoError(t, statErr)
+}
+
 func TestCleanupStaleSnapshotSpools(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/raftengine/etcd/wal_store.go
+++ b/internal/raftengine/etcd/wal_store.go
@@ -62,6 +62,14 @@ func prepareDataDirs(dataDir, snapDir, fsmSnapDir string) error {
 	if err := cleanupStaleSnapshotSpools(dataDir); err != nil {
 		return errors.Wrap(err, "cleanup stale snapshot spools")
 	}
+	// receiveSnapshotStream places its in-flight spool file inside
+	// fsmSnapDir (not dataDir) to keep the FinalizeAsFSMFile rename
+	// intra-filesystem, so a crash mid-receive can leak an
+	// elastickv-etcd-snapshot-* into fsmSnapDir. Sweep that dir on
+	// startup the same way we sweep dataDir.
+	if err := cleanupStaleSnapshotSpools(fsmSnapDir); err != nil {
+		return errors.Wrap(err, "cleanup stale snapshot spools (fsm-snap dir)")
+	}
 	// Startup CRC verification is disabled by default: for GiB-scale snapshots
 	// reading the entire file to compute a checksum can add seconds to recovery
 	// time. Orphan removal (index-based) still runs unconditionally. CRC


### PR DESCRIPTION
## Summary

PR #746 raised the receive-side spool cap to 16 GiB so a 1.35 GiB FSM transfer no longer fails mid-stream. But apply was still going through `buildSnapshotMessage` → `spool.Bytes()` → `io.ReadAll`, materializing the entire payload as `[]byte` for `raftpb.Snapshot.Data`. On a 2.5 GiB-container production node a 1.35 GiB allocation in addition to existing process state (Pebble cache, raft state, runtime) inflates heap past the OOM kill line before `RawNode.Step` ever runs `Restore`.

This PR routes receive into the existing token-format streaming path so heap usage during receive becomes O(chunk size), not O(FSM size).

> **Stacked on #746.** Target base: `fix/snapshot-spool-size-cap`. When #746 merges, this rebases against main automatically.

## What was already in place

The codebase already had all the apply-side machinery for streaming snapshot restore:

- `isSnapshotToken` / `decodeSnapshotToken` / `encodeSnapshotToken` (`fsm_snapshot_file.go`) — the 17-byte EKVT token format
- `openAndRestoreFSMSnapshot` — streams a `.fsm` file's payload into `StateMachine.Restore(io.Reader)` without materialization
- `engine.go::applySnapshot` already branches on `isSnapshotToken` and calls `openAndRestoreFSMSnapshot` when it sees a token
- `restoreSnapshotState` (`wal_store.go`) does the same on the startup-restore path
- `e.transport.SetFSMSnapDir(e.fsmSnapDir)` is wired at engine `Open`

What was missing was the **receive-side producing tokens**.

## What this PR adds

1. **`snapshotSpool.FinalizeAsFSMFile(fsmSnapDir, index, crc32c)`** — appends the 4-byte CRC32C footer, fsyncs, closes, atomically renames the spool file into `fsmSnapPath(fsmSnapDir, index)`. On success, ownership transfers to `fsmSnapDir` and `Close()` becomes a no-op so the renamed file is NOT removed.

2. **`receiveSnapshotStream`** wraps the spool with `crc32CWriter` so CRC accumulates as bytes hit disk (no extra read pass). After the final chunk, `finalizeReceivedSnapshot`:
   - **Streaming token path** (when `fsmSnapDir` is wired AND `metadata.Snapshot.Metadata.Index > 0`): calls `FinalizeAsFSMFile`, then sets `Snapshot.Data = encodeSnapshotToken(index, crc)` — 17 bytes.
   - **Legacy fallback** (otherwise): falls through to `buildSnapshotMessage` so tests without an `fsmSnapDir` keep behaving exactly as before this PR.

3. Receive log line gains a `format` field (`token` or `inline`) so an operator can distinguish the streaming path from legacy at a glance.

## Memory profile change

| | before | after |
|---|---|---|
| Disk write during receive | FSM size | FSM size |
| Heap during receive | chunk buffers (~MiB) | chunk buffers (~MiB) |
| Heap when `Snapshot.Data` is set | **FSM size** ← OOM hazard | **17 bytes** |
| `RawNode.Step` peak heap | FSM size | 17 bytes |
| `fsm.Restore` peak heap | FSM size (materialized) | chunk-bounded (`io.Reader`) |

A 16 GiB FSM would write 16 GiB to disk and allocate a 17-byte token plus per-chunk buffers. Container memory limits no longer constrain receive size.

## Self-review (5 lenses)

1. **Data loss** — none. The on-disk format produced by `FinalizeAsFSMFile` is byte-identical to `writeFSMSnapshotFile` (payload + 4-byte big-endian CRC32C footer). `openAndRestoreFSMSnapshot` reads either source uniformly. Tests prove a sender-FSM round-trips through streaming receive to a fresh receiver-FSM with identical `Applied()`.

2. **Concurrency** — no new locks. The spool's `path` and `file` fields are written from a single goroutine (the receive loop). `FinalizeAsFSMFile` nulls them on success so deferred `Close()` becomes a no-op without a separate `keep` flag. `crc32CWriter` wraps the spool linearly; never shared across goroutines.

3. **Performance** — one CRC32C pass over receive bytes. CRC32C on modern x86 (PCLMULQDQ) runs multi-GiB/s, well above gRPC stream throughput; invisible in profiles. Heap allocation for `Snapshot.Data` drops from O(FSM) to constant 17 bytes. Disk pattern unchanged: sequential append to spool, single rename (metadata-only), single fsync.

4. **Data consistency** — the EKVT token CRC is computed by the same `crc32CWriter` wrapper used by `writeFSMSnapshotPayload` (sender side), so the footer the receiver writes matches what `openAndRestoreFSMSnapshot`'s pre-Restore footer check expects. `ApplySnapshot` ordering is unchanged; this PR only swaps how `Snapshot.Data` is shaped before `RawNode.Step` sees it, and the apply branch on `isSnapshotToken` was already in place.

5. **Test coverage**:
   - `TestReceiveSnapshotStream_StreamingTokenWhenFSMSnapDirSet` pins:
     - `Snapshot.Data` is the 17-byte token, not the payload
     - spool dir is empty post-receive (file was renamed, not deleted, not orphaned)
     - `.fsm` file exists at `fsmSnapPath` with payload + 4-byte CRC footer
     - end-to-end round trip: `sender.Applied() == receiver.Applied()` after `restoreSnapshotState` reads the token, opens the `.fsm` file, streams it into `FSM.Restore`.
   - `TestReceiveSnapshotStream_LegacyFallbackWhenNoFSMSnapDir` pins the unchanged legacy path: when `fsmSnapDir` is empty, payload remains inline so existing tests keep passing.

## Test plan

- [x] `go test -race -count=1 -short ./internal/raftengine/etcd` — 11.5s, all green
- [x] New token-path test exercises the full sender-FSM → receive → token → `restoreSnapshotState` → receiver-FSM round-trip
- [ ] After merge: deploy to 192.168.0.x cluster, verify 213 receives a fresh snapshot, `applied_index` advances, container memory peak during receive stays well under 2.5 GiB limit (the original OOM hazard)

## Production incident context — 2026-05-08

Two followers (211, 213) fell behind the leader's log during an earlier OOM cascade, leader truncated past their match indices, snapshot transfer became required. With the pre-PR-746 1 GiB receive cap they failed mid-stream → leader retry loop → 100 MB/s outbound for hours.

PR #746 fixed the on-disk cap. This PR closes the remaining memory hazard so the same followers don't OOM during apply once the receive completes — the cluster genuinely catches up rather than trading one loop for another.

## Follow-up (separate PRs)

- Extend the streaming-token path to the leader-side `applyBridgeMode` legacy path so an upgrade in progress (some peers on the pre-token binary) doesn't fall back to materialization on the leader.
- Add a Prometheus counter for token vs inline receive so an operator can detect a regression where a peer hits the legacy fallback in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential snapshot file leaks when snapshot operations fail and retry
  * Improved startup cleanup to remove stale snapshot files

* **New Features**
  * Enhanced snapshot streaming with optimized disk-based transfer handling
  * Added support for token-based snapshot format for improved storage efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->