### PR TITLE
feat(encryption): FSM-internal Raft entry types (Stage 4)

### DIFF
--- a/internal/encryption/errors.go
+++ b/internal/encryption/errors.go
@@ -71,4 +71,24 @@ var (
 	// the wrong DEK into a purpose-specific encryption path after
 	// restart or rotation, so the reader fails closed.
 	ErrSidecarActivePurposeMismatch = errors.New("encryption: sidecar active key_id references a key with mismatched purpose")
+
+	// ErrEncryptionApply is the §6.3 / §11.3 fatal-apply sentinel
+	// surfaced by encryption FSM handlers (kv/fsm_encryption.go)
+	// when one of the opcodes (0x03 registration, 0x04 bootstrap,
+	// 0x05 rotation) cannot be applied — malformed payload,
+	// KEK-unwrap failure, local-epoch rollback, sidecar write
+	// failure, etc.
+	//
+	// The FSM packs this error in a haltApplyResponse value;
+	// internal/raftengine/etcd's applyNormalCommitted recognises
+	// the HaltApply interface, returns the error, and runLoop's
+	// fatal-error path takes the process down without advancing
+	// setApplied — the next restart must replay the entry.
+	//
+	// Defined here (and not in internal/raftengine/etcd) so
+	// kv/fsm_encryption.go can errors.Mark its handler outputs
+	// without importing the engine package, which would close
+	// the kv ↔ engine cycle (engine_test imports kv as a fake
+	// FSM).
+	ErrEncryptionApply = errors.New("encryption: FSM apply failed; halting apply (see design §6.3)")
 )

--- a/internal/encryption/fsmwire/wire.go
+++ b/internal/encryption/fsmwire/wire.go
@@ -28,6 +28,7 @@ package fsmwire
 
 import (
 	"encoding/binary"
+	"math"
 
 	"github.com/cockroachdb/errors"
 )
@@ -310,10 +311,32 @@ func readDEKAndWrapped(r *reader, opTag string) (uint32, []byte, error) {
 // readRegistrationBatch reads a uint32 count followed by that many
 // registration rows. Used by BootstrapPayload's batch-registry
 // section.
+//
+// DoS guard: the count must fit in the bytes the reader has left.
+// Without this guard, a malformed bootstrap payload that names
+// `count = 0xffffffff` triggers `make([]RegistrationPayload, count)`
+// (4G × 14 bytes ≈ 56 GiB) before the loop even tries to read the
+// first row, killing the process via OOM. Since Raft entries are
+// external input on the apply path, we fail closed with
+// ErrFSMWireMalformed instead.
 func readRegistrationBatch(r *reader) ([]RegistrationPayload, error) {
 	count, ok := r.readU32()
 	if !ok {
 		return nil, errors.Wrap(ErrFSMWireMalformed, "bootstrap: batch count truncated")
+	}
+	rem := r.remaining()
+	if rem < 0 {
+		return nil, errors.Wrap(ErrFSMWireMalformed, "bootstrap: negative remaining bytes")
+	}
+	// Compare in uint64 so neither side truncates: a 64-bit reader
+	// with > 2^32 remaining bytes (theoretical) and a count just
+	// under 2^32 must still produce a correct check. The
+	// multiplication cannot overflow uint64 because
+	// count * registrationSize <= (2^32-1) * 14 < 2^64.
+	need := uint64(count) * uint64(registrationSize)
+	if uint64(rem) < need {
+		return nil, errors.Wrapf(ErrFSMWireMalformed,
+			"bootstrap: batch count %d × %d > remaining %d", count, registrationSize, rem)
 	}
 	regs := make([]RegistrationPayload, count)
 	for i := uint32(0); i < count; i++ {
@@ -481,12 +504,14 @@ func (r *reader) readLenU32Bytes() ([]byte, bool) {
 	if !ok {
 		return nil, false
 	}
-	// Compare on the uint32 side: cast remaining (non-negative
-	// int by construction — readByte/readU32/etc. never advance
-	// past len(src)) into uint32 with a saturation guard so a
-	// 32-bit platform's int can never overflow the comparison.
+	// Compare in uint64 so a 64-bit reader with >2^32 remaining
+	// bytes (theoretical) is not silently truncated by uint32(rem)
+	// — a regression where rem = 4.3 GiB would shrink to ~300 MiB
+	// and falsely report "insufficient space". The rem<0 guard is
+	// belt-and-suspenders for any future change to remaining()
+	// that introduces a signed-cast hazard.
 	rem := r.remaining()
-	if rem < 0 || uint32(rem) < n { //nolint:gosec // rem >= 0 enforced by the rem < 0 branch
+	if rem < 0 || uint64(rem) < uint64(n) { //nolint:gosec // rem >= 0 enforced by the rem < 0 branch
 		return nil, false
 	}
 	end := r.off + int(n) //nolint:gosec // n bounded by rem above; rem fits int
@@ -523,9 +548,15 @@ func appendLenU32Bytes(dst []byte, data []byte) []byte {
 // caller controls every input length (wrapped DEK, batch count) at
 // hundred-byte / hundred-entry scale; a uint32 overflow indicates a
 // caller bug, not adversarial input, so panic is appropriate.
+//
+// Width-agnostic bound check: convert n to uint64 (safe for any
+// non-negative int) and compare against math.MaxUint32. An
+// earlier draft used `int(^uint32(0))` as the bound, which fails
+// to compile on GOARCH=386 because the constant 4,294,967,295
+// overflows the 32-bit signed int — the cross-compile build would
+// break before any runtime check fired.
 func safeU32(n int) uint32 {
-	const maxU32 = int(^uint32(0))
-	if n < 0 || n > maxU32 {
+	if n < 0 || uint64(n) > math.MaxUint32 { //nolint:gosec // n < 0 short-circuits the uint64 cast
 		panic(errors.Newf("fsmwire: length %d does not fit in uint32", n))
 	}
 	return uint32(n) //nolint:gosec // bounds checked above

--- a/internal/encryption/fsmwire/wire.go
+++ b/internal/encryption/fsmwire/wire.go
@@ -109,6 +109,37 @@ const (
 	//   0x05 — enable-raft-envelope    (Stage 6, §7.1 Phase 2)
 )
 
+// OpEncryptionMin / OpEncryptionMax delimit the FSM-internal opcode
+// range RESERVED for the encryption subsystem. kv/fsm.go's Apply
+// dispatcher routes EVERY byte in the closed range
+// [OpEncryptionMin, OpEncryptionMax] through applyEncryption, which
+// fails closed via ErrEncryptionApply for any byte that is not yet
+// implemented (Stage 4 implements only 0x03/0x04/0x05; 0x06/0x07 are
+// reserved for later stages). The widened range is the codex P1 fix
+// for PR748: previously only the three implemented opcodes were
+// routed, so a future leader emitting 0x06 against a stale follower
+// would fall through to the legacy proto3 decoder rather than halting
+// the apply loop — the same divergence shape the §6.3 fail-closed
+// halt was added to prevent.
+//
+// Upper bound 0x07 (NOT 0x0F): proto3 wire tags for field 1 occupy
+// 0x08..0x0D (field 1 with wire types varint/fixed64/length-delim/
+// start-group/end-group/fixed32). Routing those through the
+// encryption dispatcher would short-circuit the legacy proto3
+// fallback in `decodeLegacyRaftRequest` for any RaftCommand/Request
+// payload whose first encoded field is field 1 (e.g. `Request.is_txn`
+// = true → first bytes `0x08 0x01`). Bytes 0x03..0x07 are SAFE
+// because they encode either field 0 (proto3 disallows field 0) or
+// reserved/invalid wire types (0x06/0x07 = wire types 6/7 which
+// proto3 marks reserved), so no valid proto3 marshal output starts
+// with them. Future encryption opcodes 0x08+ would need a different
+// dispatch shape (e.g. a 2-byte sentinel) before they could be
+// routed safely.
+const (
+	OpEncryptionMin byte = 0x03
+	OpEncryptionMax byte = 0x07
+)
+
 // RegistrationPayload is the OpRegistration body: a single
 // (dek_id, full_node_id, local_epoch) triple inserted by FSM apply
 // into the §4.1 writer registry. The kv/fsm_encryption.go handler
@@ -437,6 +468,14 @@ func readRotationSubTag(r *reader) (byte, error) {
 
 // readRotationBody decodes the (dek_id, purpose, wrapped) triple
 // that follows the rotation sub-tag.
+//
+// Purpose is validated against the §5.1 enum at decode time so an
+// unknown byte (e.g. 0xFF) fails closed with ErrFSMWireMalformed
+// instead of being passed to the applier as an out-of-enum value.
+// Without this check a malformed entry could advance setApplied if
+// the applier did not independently re-validate purpose, weakening
+// the §6.3 fail-closed contract. This is the codex P2 fix for
+// PR748.
 func readRotationBody(r *reader) (uint32, Purpose, []byte, error) {
 	dekID, ok := r.readU32()
 	if !ok {
@@ -445,6 +484,14 @@ func readRotationBody(r *reader) (uint32, Purpose, []byte, error) {
 	purpose, ok := r.readByte()
 	if !ok {
 		return 0, 0, nil, errors.Wrap(ErrFSMWireMalformed, "rotation: purpose truncated")
+	}
+	switch Purpose(purpose) {
+	case PurposeStorage, PurposeRaft:
+		// known, fall through
+	default:
+		return 0, 0, nil, errors.Wrapf(ErrFSMWireMalformed,
+			"rotation: unknown purpose=%#x (want %#x storage / %#x raft)",
+			purpose, byte(PurposeStorage), byte(PurposeRaft))
 	}
 	wrapped, ok := r.readLenU32Bytes()
 	if !ok {

--- a/internal/encryption/fsmwire/wire.go
+++ b/internal/encryption/fsmwire/wire.go
@@ -1,0 +1,532 @@
+// Package fsmwire defines the §6.3 / §11 binary wire format for the
+// FSM-internal encryption Raft entry types (opcodes 0x03 / 0x04 /
+// 0x05). The encoding is hand-rolled binary with a leading version
+// byte rather than proto3 because:
+//
+//   - Each replica's apply path must reproduce the bytes exactly to
+//     keep state machine determinism. proto3's lenient unknown-field
+//     handling would let a future leader-built field silently drop
+//     on a stale follower, leaving registry rows or active-pointer
+//     entries missing on that follower — exactly the silent
+//     divergence the encryption tag was added to detect.
+//
+//   - The schema is small (~30 lines of encode/decode per opcode),
+//     so the maintenance cost of hand-rolled binary is negligible
+//     while keeping every state-machine-affecting bit explicit.
+//
+//   - It matches the in-house style: internal/encryption/envelope.go,
+//     raft_envelope.go, and kv/raft_payload_wrapper.go all hand-roll
+//     binary with a leading version byte.
+//
+// Version byte. Every payload starts with WireVersionV1 (0x01).
+// Future schema changes bump the version and the decoder fails
+// closed (ErrFSMWireVersion) — operators upgrade clusters fully
+// before flipping flags that produce the new format. There is no
+// "skip unknown fields" path because skipping a field on the apply
+// path is the divergence we are guarding against.
+package fsmwire
+
+import (
+	"encoding/binary"
+
+	"github.com/cockroachdb/errors"
+)
+
+// Opcode tags consumed by kv/fsm.go's Apply dispatch. Reserved
+// per design §11.3:
+//
+//	0x00 raftEncodeSingle    (kv legacy)
+//	0x01 raftEncodeBatch     (kv legacy)
+//	0x02 raftEncodeHLCLease  (kv HLC ceiling)
+//	0x03 OpRegistration      (writer-registry register, §4.1)
+//	0x04 OpBootstrap         (initial DEK install, §5.6)
+//	0x05 OpRotation          (DEK rotation / cluster flag flip, §5.2 + §7.1)
+const (
+	OpRegistration byte = 0x03
+	OpBootstrap    byte = 0x04
+	OpRotation     byte = 0x05
+)
+
+// WireVersionV1 is the current FSM-wire version. Carried as the
+// second byte of every payload (after the opcode tag, which is
+// stripped before fsmwire sees the payload).
+const WireVersionV1 byte = 0x01
+
+// Errors returned by fsmwire's encoders/decoders. All three are
+// terminal in the apply path — kv/fsm.go marks them with
+// ErrEncryptionApply so internal/raftengine/etcd halts the apply
+// loop instead of silently advancing setApplied.
+var (
+	// ErrFSMWireMalformed indicates the payload bytes do not
+	// match the fixed-shape decoder for the supplied opcode.
+	// Length mismatch, missing length-prefixed body, or trailing
+	// garbage all surface here.
+	ErrFSMWireMalformed = errors.New("fsmwire: payload is malformed")
+
+	// ErrFSMWireVersion indicates the payload version byte is
+	// not WireVersionV1. The decoder fails closed rather than
+	// trying to interpret an unknown version under the v1
+	// layout.
+	ErrFSMWireVersion = errors.New("fsmwire: unknown wire version")
+
+	// ErrFSMWireSubtag indicates the rotation opcode (0x05)
+	// carries an unknown sub-tag. Reserved for forward-compat:
+	// future opcodes that share the rotation tag (rewrap-deks,
+	// retire-dek, enable-storage-envelope, enable-raft-envelope)
+	// will allocate distinct sub-tags.
+	ErrFSMWireSubtag = errors.New("fsmwire: unknown rotation sub-tag")
+)
+
+// Purpose is the §5.1 sidecar purpose tag. The Cipher itself does
+// not enforce purpose — that contract is maintained by the sidecar
+// loader and the FSM apply handlers in kv/fsm_encryption.go. The
+// fsmwire codec carries the purpose alongside each DEK so the
+// applier can install it under the correct sidecar slot.
+type Purpose byte
+
+const (
+	// PurposeStorage marks the storage-layer DEK (§4.1 envelopes).
+	PurposeStorage Purpose = 1
+	// PurposeRaft marks the raft-layer DEK (§4.2 envelopes).
+	PurposeRaft Purpose = 2
+)
+
+// Sub-tags used by OpRotation. Encoded as the first byte after the
+// version byte.
+const (
+	// RotateSubRotateDEK is a fresh DEK install + active-pointer
+	// update. Ships in Stage 4. See §5.2.
+	RotateSubRotateDEK byte = 0x01
+
+	// Reserved for later stages; declared here so the byte space
+	// is contiguous and a future commit cannot silently re-use
+	// 0x02..0x0F without an audit:
+	//
+	//   0x02 — rewrap-deks       (Stage 9, §5.4 / §5.5)
+	//   0x03 — retire-dek        (Stage 9, §5.4)
+	//   0x04 — enable-storage-envelope (Stage 6, §7.1 Phase 1)
+	//   0x05 — enable-raft-envelope    (Stage 6, §7.1 Phase 2)
+)
+
+// RegistrationPayload is the OpRegistration body: a single
+// (dek_id, full_node_id, local_epoch) triple inserted by FSM apply
+// into the §4.1 writer registry. The kv/fsm_encryption.go handler
+// decides between case 1 (insert), 2 (re-register / monotonic
+// bump), 3 (rollback → ErrLocalEpochRollback) and 4 (collision →
+// ErrNodeIDCollision).
+type RegistrationPayload struct {
+	DEKID      uint32
+	FullNodeID uint64
+	LocalEpoch uint16
+}
+
+// BootstrapPayload is the OpBootstrap body: §5.6 step 1a's "install
+// the initial wrapped DEK pair plus a batch of writer-registry
+// rows for every member that passed the capability pre-check".
+//
+// The wrapped DEKs are KEK-output blobs the leader produced; the
+// FSM apply layer installs them into the local keystore via
+// Keystore.Set after the KEK Unwrap.
+type BootstrapPayload struct {
+	StorageDEKID   uint32
+	WrappedStorage []byte
+	RaftDEKID      uint32
+	WrappedRaft    []byte
+	BatchRegistry  []RegistrationPayload
+}
+
+// RotationPayload is the OpRotation body. SubTag selects between
+// rotate-dek / rewrap / enable-flag variants; Stage 4 ships only
+// RotateSubRotateDEK.
+//
+// For RotateSubRotateDEK the payload is:
+//   - DEKID: the new key id being installed
+//   - Purpose: which sidecar slot to update (PurposeStorage / PurposeRaft)
+//   - Wrapped: the KEK-wrapped DEK bytes
+//   - ProposerRegistration: the proposing node's writer-registry
+//     row, inserted in the same FSM apply transaction so the
+//     proposer's first encrypted write under the new DEK is
+//     covered by the §4.1 case 2 epoch monotonicity check.
+type RotationPayload struct {
+	SubTag               byte
+	DEKID                uint32
+	Purpose              Purpose
+	Wrapped              []byte
+	ProposerRegistration RegistrationPayload
+}
+
+// Field-size constants. Named so the encoder/decoder don't sprinkle
+// 1/2/4/8 magic numbers and so the layout pin tests have a single
+// source of truth to drift-check against.
+const (
+	versionByteSize   = 1
+	subTagSize        = 1
+	purposeSize       = 1
+	dekIDSize         = 4                                           // uint32 BE
+	localEpochSize    = 2                                           // uint16 BE
+	fullNodeIDSize    = 8                                           // uint64 BE
+	lengthPrefixSize  = 4                                           // uint32 BE length prefix
+	batchCountPrefix  = 4                                           // uint32 BE batch entry count
+	registrationSize  = dekIDSize + fullNodeIDSize + localEpochSize // 14
+	regPayloadEncoded = versionByteSize + registrationSize          // 15
+)
+
+// EncodeRegistration serialises p as the OpRegistration payload
+// (without the leading 0x03 opcode tag — that is added by the
+// kv/fsm.go dispatch layer).
+//
+// Wire layout:
+//
+//	[ver 1] [dek_id 4 BE] [full_node_id 8 BE] [local_epoch 2 BE]
+func EncodeRegistration(p RegistrationPayload) []byte {
+	out := make([]byte, regPayloadEncoded)
+	out[0] = WireVersionV1
+	off := versionByteSize
+	binary.BigEndian.PutUint32(out[off:off+dekIDSize], p.DEKID)
+	off += dekIDSize
+	binary.BigEndian.PutUint64(out[off:off+fullNodeIDSize], p.FullNodeID)
+	off += fullNodeIDSize
+	binary.BigEndian.PutUint16(out[off:off+localEpochSize], p.LocalEpoch)
+	return out
+}
+
+// DecodeRegistration reverses EncodeRegistration. Fails closed on
+// length mismatch or unknown version byte.
+func DecodeRegistration(raw []byte) (RegistrationPayload, error) {
+	if len(raw) != regPayloadEncoded {
+		return RegistrationPayload{}, errors.Wrapf(ErrFSMWireMalformed,
+			"registration: got %d bytes, want %d", len(raw), regPayloadEncoded)
+	}
+	if raw[0] != WireVersionV1 {
+		return RegistrationPayload{}, errors.Wrapf(ErrFSMWireVersion,
+			"registration: version=%#x", raw[0])
+	}
+	off := versionByteSize
+	dekID := binary.BigEndian.Uint32(raw[off : off+dekIDSize])
+	off += dekIDSize
+	fullNodeID := binary.BigEndian.Uint64(raw[off : off+fullNodeIDSize])
+	off += fullNodeIDSize
+	localEpoch := binary.BigEndian.Uint16(raw[off : off+localEpochSize])
+	return RegistrationPayload{
+		DEKID:      dekID,
+		FullNodeID: fullNodeID,
+		LocalEpoch: localEpoch,
+	}, nil
+}
+
+// EncodeBootstrap serialises p as the OpBootstrap payload (no
+// leading opcode tag).
+//
+// Wire layout:
+//
+//	[ver 1]
+//	[storage_dek_id 4] [storage_wrapped_len 4] [storage_wrapped ...]
+//	[raft_dek_id 4]    [raft_wrapped_len 4]    [raft_wrapped ...]
+//	[batch_count 4]    [registration_payload]*batch_count
+//
+// The two wrapped-DEK length prefixes are independent; the
+// concrete length is whatever the configured KEK produced (the
+// reference FileWrapper produces 60 bytes per 32-byte DEK).
+func EncodeBootstrap(p BootstrapPayload) []byte {
+	size := versionByteSize +
+		dekIDSize + lengthPrefixSize + len(p.WrappedStorage) +
+		dekIDSize + lengthPrefixSize + len(p.WrappedRaft) +
+		batchCountPrefix + len(p.BatchRegistry)*registrationSize
+	out := make([]byte, 0, size)
+	out = append(out, WireVersionV1)
+	out = appendU32(out, p.StorageDEKID)
+	out = appendLenU32Bytes(out, p.WrappedStorage)
+	out = appendU32(out, p.RaftDEKID)
+	out = appendLenU32Bytes(out, p.WrappedRaft)
+	out = appendU32(out, safeU32(len(p.BatchRegistry)))
+	for _, reg := range p.BatchRegistry {
+		out = appendU32(out, reg.DEKID)
+		out = appendU64(out, reg.FullNodeID)
+		out = appendU16(out, reg.LocalEpoch)
+	}
+	return out
+}
+
+// DecodeBootstrap reverses EncodeBootstrap. Fails closed on any
+// length-prefix overrun or version mismatch.
+func DecodeBootstrap(raw []byte) (BootstrapPayload, error) {
+	r := &reader{src: raw}
+	if err := readWireVersion(r, "bootstrap"); err != nil {
+		return BootstrapPayload{}, err
+	}
+	storageID, storageWrapped, err := readDEKAndWrapped(r, "bootstrap.storage")
+	if err != nil {
+		return BootstrapPayload{}, err
+	}
+	raftID, raftWrapped, err := readDEKAndWrapped(r, "bootstrap.raft")
+	if err != nil {
+		return BootstrapPayload{}, err
+	}
+	regs, err := readRegistrationBatch(r)
+	if err != nil {
+		return BootstrapPayload{}, err
+	}
+	if r.remaining() != 0 {
+		return BootstrapPayload{}, errors.Wrapf(ErrFSMWireMalformed,
+			"bootstrap: %d trailing bytes", r.remaining())
+	}
+	return BootstrapPayload{
+		StorageDEKID:   storageID,
+		WrappedStorage: storageWrapped,
+		RaftDEKID:      raftID,
+		WrappedRaft:    raftWrapped,
+		BatchRegistry:  regs,
+	}, nil
+}
+
+// readWireVersion consumes the leading version byte and validates
+// it. Used by both DecodeBootstrap and DecodeRotation so the
+// version-check error surface stays uniform.
+func readWireVersion(r *reader, opTag string) error {
+	ver, ok := r.readByte()
+	if !ok {
+		return errors.Wrapf(ErrFSMWireMalformed, "%s: missing version byte", opTag)
+	}
+	if ver != WireVersionV1 {
+		return errors.Wrapf(ErrFSMWireVersion, "%s: version=%#x", opTag, ver)
+	}
+	return nil
+}
+
+// readDEKAndWrapped reads a (dek_id, wrapped_dek) pair. Bootstrap
+// reads two; rotation reads one.
+func readDEKAndWrapped(r *reader, opTag string) (uint32, []byte, error) {
+	dekID, ok := r.readU32()
+	if !ok {
+		return 0, nil, errors.Wrapf(ErrFSMWireMalformed, "%s: dek_id truncated", opTag)
+	}
+	wrapped, ok := r.readLenU32Bytes()
+	if !ok {
+		return 0, nil, errors.Wrapf(ErrFSMWireMalformed, "%s: wrapped truncated", opTag)
+	}
+	return dekID, wrapped, nil
+}
+
+// readRegistrationBatch reads a uint32 count followed by that many
+// registration rows. Used by BootstrapPayload's batch-registry
+// section.
+func readRegistrationBatch(r *reader) ([]RegistrationPayload, error) {
+	count, ok := r.readU32()
+	if !ok {
+		return nil, errors.Wrap(ErrFSMWireMalformed, "bootstrap: batch count truncated")
+	}
+	regs := make([]RegistrationPayload, count)
+	for i := uint32(0); i < count; i++ {
+		reg, err := readRegistrationRow(r, i)
+		if err != nil {
+			return nil, err
+		}
+		regs[i] = reg
+	}
+	return regs, nil
+}
+
+// readRegistrationRow reads one (dek_id, full_node_id, local_epoch)
+// triple. Used by readRegistrationBatch and DecodeRotation's
+// proposer-registration field.
+func readRegistrationRow(r *reader, i uint32) (RegistrationPayload, error) {
+	dekID, ok1 := r.readU32()
+	fullNodeID, ok2 := r.readU64()
+	localEpoch, ok3 := r.readU16()
+	if !ok1 || !ok2 || !ok3 {
+		return RegistrationPayload{}, errors.Wrapf(ErrFSMWireMalformed,
+			"registration #%d truncated", i)
+	}
+	return RegistrationPayload{
+		DEKID:      dekID,
+		FullNodeID: fullNodeID,
+		LocalEpoch: localEpoch,
+	}, nil
+}
+
+// EncodeRotation serialises p as the OpRotation payload (no leading
+// opcode tag).
+//
+// Wire layout (RotateSubRotateDEK):
+//
+//	[ver 1] [subtag 1] [dek_id 4] [purpose 1]
+//	[wrapped_len 4] [wrapped ...]
+//	[proposer_dek_id 4] [proposer_full_node_id 8] [proposer_local_epoch 2]
+func EncodeRotation(p RotationPayload) []byte {
+	size := versionByteSize + subTagSize + dekIDSize + purposeSize +
+		lengthPrefixSize + len(p.Wrapped) + registrationSize
+	out := make([]byte, 0, size)
+	out = append(out, WireVersionV1, p.SubTag)
+	out = appendU32(out, p.DEKID)
+	out = append(out, byte(p.Purpose))
+	out = appendLenU32Bytes(out, p.Wrapped)
+	out = appendU32(out, p.ProposerRegistration.DEKID)
+	out = appendU64(out, p.ProposerRegistration.FullNodeID)
+	out = appendU16(out, p.ProposerRegistration.LocalEpoch)
+	return out
+}
+
+// DecodeRotation reverses EncodeRotation. Fails closed on length
+// prefix overrun, version mismatch, or unknown sub-tag.
+func DecodeRotation(raw []byte) (RotationPayload, error) {
+	r := &reader{src: raw}
+	if err := readWireVersion(r, "rotation"); err != nil {
+		return RotationPayload{}, err
+	}
+	sub, err := readRotationSubTag(r)
+	if err != nil {
+		return RotationPayload{}, err
+	}
+	dekID, purpose, wrapped, err := readRotationBody(r)
+	if err != nil {
+		return RotationPayload{}, err
+	}
+	proposerReg, err := readRegistrationRow(r, 0)
+	if err != nil {
+		return RotationPayload{}, errors.Wrap(err, "rotation: proposer registration")
+	}
+	if r.remaining() != 0 {
+		return RotationPayload{}, errors.Wrapf(ErrFSMWireMalformed, "rotation: %d trailing bytes", r.remaining())
+	}
+	return RotationPayload{
+		SubTag:               sub,
+		DEKID:                dekID,
+		Purpose:              purpose,
+		Wrapped:              wrapped,
+		ProposerRegistration: proposerReg,
+	}, nil
+}
+
+// readRotationSubTag consumes the 1-byte rotation sub-tag and
+// validates it against the known set. Stage 4 ships only
+// RotateSubRotateDEK; later stages (rewrap, retire, enable-flag)
+// will whitelist new values.
+func readRotationSubTag(r *reader) (byte, error) {
+	sub, ok := r.readByte()
+	if !ok {
+		return 0, errors.Wrap(ErrFSMWireMalformed, "rotation: missing sub-tag")
+	}
+	if sub != RotateSubRotateDEK {
+		return 0, errors.Wrapf(ErrFSMWireSubtag, "rotation: subtag=%#x", sub)
+	}
+	return sub, nil
+}
+
+// readRotationBody decodes the (dek_id, purpose, wrapped) triple
+// that follows the rotation sub-tag.
+func readRotationBody(r *reader) (uint32, Purpose, []byte, error) {
+	dekID, ok := r.readU32()
+	if !ok {
+		return 0, 0, nil, errors.Wrap(ErrFSMWireMalformed, "rotation: dek_id truncated")
+	}
+	purpose, ok := r.readByte()
+	if !ok {
+		return 0, 0, nil, errors.Wrap(ErrFSMWireMalformed, "rotation: purpose truncated")
+	}
+	wrapped, ok := r.readLenU32Bytes()
+	if !ok {
+		return 0, 0, nil, errors.Wrap(ErrFSMWireMalformed, "rotation: wrapped truncated")
+	}
+	return dekID, Purpose(purpose), wrapped, nil
+}
+
+// reader is a tiny binary cursor used by the Decode helpers above.
+// Centralised so the per-field length checks share one set of
+// "out-of-bounds returns ok=false" guards.
+type reader struct {
+	src []byte
+	off int
+}
+
+func (r *reader) remaining() int { return len(r.src) - r.off }
+
+func (r *reader) readByte() (byte, bool) {
+	if r.remaining() < 1 {
+		return 0, false
+	}
+	b := r.src[r.off]
+	r.off++
+	return b, true
+}
+
+func (r *reader) readU16() (uint16, bool) {
+	if r.remaining() < localEpochSize {
+		return 0, false
+	}
+	v := binary.BigEndian.Uint16(r.src[r.off : r.off+localEpochSize])
+	r.off += localEpochSize
+	return v, true
+}
+
+func (r *reader) readU32() (uint32, bool) {
+	if r.remaining() < dekIDSize {
+		return 0, false
+	}
+	v := binary.BigEndian.Uint32(r.src[r.off : r.off+dekIDSize])
+	r.off += dekIDSize
+	return v, true
+}
+
+func (r *reader) readU64() (uint64, bool) {
+	if r.remaining() < fullNodeIDSize {
+		return 0, false
+	}
+	v := binary.BigEndian.Uint64(r.src[r.off : r.off+fullNodeIDSize])
+	r.off += fullNodeIDSize
+	return v, true
+}
+
+func (r *reader) readLenU32Bytes() ([]byte, bool) {
+	n, ok := r.readU32()
+	if !ok {
+		return nil, false
+	}
+	// Compare on the uint32 side: cast remaining (non-negative
+	// int by construction — readByte/readU32/etc. never advance
+	// past len(src)) into uint32 with a saturation guard so a
+	// 32-bit platform's int can never overflow the comparison.
+	rem := r.remaining()
+	if rem < 0 || uint32(rem) < n { //nolint:gosec // rem >= 0 enforced by the rem < 0 branch
+		return nil, false
+	}
+	end := r.off + int(n) //nolint:gosec // n bounded by rem above; rem fits int
+	out := make([]byte, n)
+	copy(out, r.src[r.off:end])
+	r.off = end
+	return out, true
+}
+
+func appendU16(dst []byte, v uint16) []byte {
+	return binary.BigEndian.AppendUint16(dst, v)
+}
+
+func appendU32(dst []byte, v uint32) []byte {
+	return binary.BigEndian.AppendUint32(dst, v)
+}
+
+func appendU64(dst []byte, v uint64) []byte {
+	return binary.BigEndian.AppendUint64(dst, v)
+}
+
+// appendLenU32Bytes appends a uint32 BE length prefix followed by
+// data. Length must fit a uint32; safeU32 panics if it does not,
+// because exceeding 4 GiB in a single fsmwire payload is a
+// programmer error (a Raft entry that large could not be replicated
+// regardless of encryption framing).
+func appendLenU32Bytes(dst []byte, data []byte) []byte {
+	dst = appendU32(dst, safeU32(len(data)))
+	return append(dst, data...)
+}
+
+// safeU32 widens a non-negative int into uint32, panicking on
+// overflow. The fsmwire encoders are leader-only paths where the
+// caller controls every input length (wrapped DEK, batch count) at
+// hundred-byte / hundred-entry scale; a uint32 overflow indicates a
+// caller bug, not adversarial input, so panic is appropriate.
+func safeU32(n int) uint32 {
+	const maxU32 = int(^uint32(0))
+	if n < 0 || n > maxU32 {
+		panic(errors.Newf("fsmwire: length %d does not fit in uint32", n))
+	}
+	return uint32(n) //nolint:gosec // bounds checked above
+}

--- a/internal/encryption/fsmwire/wire.go
+++ b/internal/encryption/fsmwire/wire.go
@@ -203,6 +203,27 @@ const (
 	regPayloadEncoded = versionByteSize + registrationSize          // 15
 )
 
+// maxBootstrapBatchCount bounds the number of RegistrationPayload
+// entries `readRegistrationBatch` will allocate from a single
+// bootstrap payload. The wire-bytes check (count * registrationSize
+// ≤ remaining) is necessary but NOT sufficient: each
+// RegistrationPayload occupies 24 bytes in Go (uint32+uint64+uint16
+// + alignment padding) versus 14 bytes packed on the wire, so a
+// crafted bootstrap entry that fits the wire-bounds check could
+// still drive a >70% larger heap allocation. With a sufficiently
+// large raft entry the in-memory cost would multiply into the
+// gigabytes — codex P1 round-3 finding for PR748.
+//
+// The cap of 16384 is ~8x the largest realistic cluster (raft
+// deployments are typically tens of voters; the largest documented
+// production raft clusters are in the low thousands of nodes). A
+// bootstrap covers every member × 2 DEK purposes (storage + raft),
+// so for an 8000-node cluster the legitimate count would be 16000
+// — still under the cap. The post-cap allocation ceiling is
+// 16384 * 24 = 384 KiB, which is bounded regardless of any future
+// struct-padding changes.
+const maxBootstrapBatchCount = 1 << 14
+
 // EncodeRegistration serialises p as the OpRegistration payload
 // (without the leading 0x03 opcode tag — that is added by the
 // kv/fsm.go dispatch layer).
@@ -354,6 +375,21 @@ func readRegistrationBatch(r *reader) ([]RegistrationPayload, error) {
 	count, ok := r.readU32()
 	if !ok {
 		return nil, errors.Wrap(ErrFSMWireMalformed, "bootstrap: batch count truncated")
+	}
+	// Hard cap on count BEFORE the wire-bytes check. The
+	// wire-bytes check alone would let a count of (2^32-1) /
+	// registrationSize ≈ 306M pass for a sufficiently large raft
+	// entry, which `make([]RegistrationPayload, count)` would
+	// turn into a multi-GiB heap allocation due to the struct's
+	// alignment padding (24B in-memory vs 14B on the wire). The
+	// cap bounds the post-make allocation at maxBootstrapBatchCount
+	// * sizeof(RegistrationPayload) = 16384 * 24 = 384 KiB,
+	// independent of how many bytes the raft entry happens to
+	// carry. See the constant comment for the cluster-size
+	// rationale; this is the codex P1 round-3 fix for PR748.
+	if count > maxBootstrapBatchCount {
+		return nil, errors.Wrapf(ErrFSMWireMalformed,
+			"bootstrap: batch count %d exceeds cap %d", count, maxBootstrapBatchCount)
 	}
 	rem := r.remaining()
 	if rem < 0 {

--- a/internal/encryption/fsmwire/wire_test.go
+++ b/internal/encryption/fsmwire/wire_test.go
@@ -138,6 +138,46 @@ func TestBootstrap_RejectsTruncated(t *testing.T) {
 	}
 }
 
+// TestBootstrap_RejectsOverCapBatchCount is the codex P1 round-3
+// regression for PR748: the wire-bytes check (count *
+// registrationSize ≤ remaining) is necessary but NOT sufficient
+// because RegistrationPayload occupies more bytes in memory (24
+// on 64-bit due to alignment padding) than on the wire (14 bytes
+// packed). A crafted count that fits the wire-bounds check could
+// still drive a >70% larger heap allocation; for a multi-MiB raft
+// entry the in-memory cost would multiply into the gigabytes.
+//
+// The decoder enforces an absolute cap on `count` that bounds the
+// post-make slice size independent of the raft entry length. This
+// test asserts a cap-exceeding count fails closed BEFORE the
+// allocation, even when the wire payload would otherwise admit it.
+//
+// The literal 16385 below must equal `maxBootstrapBatchCount + 1`
+// in wire.go (1<<14 + 1). The constant is intentionally unexported
+// — it is a defensive bound, not part of the wire contract.
+func TestBootstrap_RejectsOverCapBatchCount(t *testing.T) {
+	t.Parallel()
+	good := fsmwire.EncodeBootstrap(fsmwire.BootstrapPayload{
+		StorageDEKID: 1, RaftDEKID: 2,
+	})
+	const countOffset = 1 + 4 + 4 + 0 + 4 + 4 + 0
+	if got := len(good); got < countOffset+4 {
+		t.Fatalf("encoded bootstrap shorter than expected: %d bytes, want >= %d", got, countOffset+4)
+	}
+	// Overwrite count with maxBootstrapBatchCount + 1 = 16385.
+	// The cap check fires before the wire-bytes check, so we do
+	// NOT need to extend the payload with 16385 * 14 trailing
+	// bytes — the decoder must reject on the cap regardless.
+	good[countOffset+0] = 0x00
+	good[countOffset+1] = 0x00
+	good[countOffset+2] = 0x40 // 0x4001 = 16385 = (1<<14) + 1
+	good[countOffset+3] = 0x01
+	_, err := fsmwire.DecodeBootstrap(good)
+	if !errors.Is(err, fsmwire.ErrFSMWireMalformed) {
+		t.Fatalf("expected ErrFSMWireMalformed for over-cap batch count, got %v", err)
+	}
+}
+
 // TestBootstrap_RejectsHugeBatchCount is the regression for the
 // codex P1 / gemini security-high finding: a malformed bootstrap
 // payload that names `count = 0xffffffff` would, before the guard,

--- a/internal/encryption/fsmwire/wire_test.go
+++ b/internal/encryption/fsmwire/wire_test.go
@@ -228,6 +228,54 @@ func TestRotation_RejectsUnknownSubTag(t *testing.T) {
 	}
 }
 
+// TestRotation_RejectsUnknownPurpose is the codex P2 regression for
+// PR748: the decoder previously cast the raw purpose byte to
+// `Purpose` without validating, so values outside the §5.1 enum
+// (storage=1, raft=2) — for example 0x00 or 0xFF — were accepted as
+// syntactically valid and forwarded to the applier. That weakens the
+// fail-closed wire contract: an applier that did not independently
+// re-check purpose could advance setApplied past a malformed entry.
+// Validate at decode time and surface ErrFSMWireMalformed.
+func TestRotation_RejectsUnknownPurpose(t *testing.T) {
+	t.Parallel()
+	for _, bad := range []byte{0x00, 0x03, 0x7F, 0xFF} {
+		raw := fsmwire.EncodeRotation(fsmwire.RotationPayload{
+			SubTag: fsmwire.RotateSubRotateDEK, DEKID: 1, Purpose: fsmwire.PurposeStorage,
+		})
+		// Tamper purpose byte. Layout: [ver(1)] [subtag(1)] [dek_id(4)] [purpose(1)] ...
+		const purposeOffset = 1 + 1 + 4
+		if got := len(raw); got <= purposeOffset {
+			t.Fatalf("encoded rotation shorter than expected: %d bytes, want > %d", got, purposeOffset)
+		}
+		raw[purposeOffset] = bad
+		_, err := fsmwire.DecodeRotation(raw)
+		if !errors.Is(err, fsmwire.ErrFSMWireMalformed) {
+			t.Fatalf("purpose=%#x: expected ErrFSMWireMalformed, got %v", bad, err)
+		}
+	}
+}
+
+// TestRotation_AcceptsKnownPurposes is the positive control for the
+// purpose-validation guard above: storage=1 and raft=2 must continue
+// to round-trip cleanly. A regression that reject-listed too
+// aggressively would also break Stage 6's enable-storage-envelope
+// and enable-raft-envelope paths.
+func TestRotation_AcceptsKnownPurposes(t *testing.T) {
+	t.Parallel()
+	for _, p := range []fsmwire.Purpose{fsmwire.PurposeStorage, fsmwire.PurposeRaft} {
+		raw := fsmwire.EncodeRotation(fsmwire.RotationPayload{
+			SubTag: fsmwire.RotateSubRotateDEK, DEKID: 9, Purpose: p,
+		})
+		got, err := fsmwire.DecodeRotation(raw)
+		if err != nil {
+			t.Fatalf("purpose=%d: %v", p, err)
+		}
+		if got.Purpose != p {
+			t.Fatalf("purpose round-trip: got %d want %d", got.Purpose, p)
+		}
+	}
+}
+
 func TestRotation_RejectsBadVersion(t *testing.T) {
 	t.Parallel()
 	raw := fsmwire.EncodeRotation(fsmwire.RotationPayload{SubTag: fsmwire.RotateSubRotateDEK})

--- a/internal/encryption/fsmwire/wire_test.go
+++ b/internal/encryption/fsmwire/wire_test.go
@@ -1,0 +1,220 @@
+package fsmwire_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
+	"github.com/cockroachdb/errors"
+)
+
+func TestRegistration_RoundTrip(t *testing.T) {
+	t.Parallel()
+	cases := []fsmwire.RegistrationPayload{
+		{},
+		{DEKID: 1, FullNodeID: 1, LocalEpoch: 1},
+		{DEKID: 0xCAFEBABE, FullNodeID: 0xDEADBEEFCAFEBABE, LocalEpoch: 0xABCD},
+		{DEKID: 0xFFFFFFFF, FullNodeID: ^uint64(0), LocalEpoch: 0xFFFF},
+	}
+	for _, want := range cases {
+		got, err := fsmwire.DecodeRegistration(fsmwire.EncodeRegistration(want))
+		if err != nil {
+			t.Fatalf("decode %+v: %v", want, err)
+		}
+		if got != want {
+			t.Fatalf("round-trip mismatch: got %+v want %+v", got, want)
+		}
+	}
+}
+
+func TestRegistration_ByteLayoutPin(t *testing.T) {
+	t.Parallel()
+	got := fsmwire.EncodeRegistration(fsmwire.RegistrationPayload{
+		DEKID:      0x01020304,
+		FullNodeID: 0x05060708090A0B0C,
+		LocalEpoch: 0x0D0E,
+	})
+	want := []byte{
+		fsmwire.WireVersionV1,
+		0x01, 0x02, 0x03, 0x04, // DEKID
+		0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, // FullNodeID
+		0x0D, 0x0E, // LocalEpoch
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("layout drift:\n got  %x\n want %x", got, want)
+	}
+}
+
+func TestRegistration_RejectsMalformed(t *testing.T) {
+	t.Parallel()
+	for _, l := range []int{0, 1, 14, 16, 100} {
+		_, err := fsmwire.DecodeRegistration(make([]byte, l))
+		// l == 15 is the only valid length; anything else must
+		// fail with ErrFSMWireMalformed (or, for l == 15 with
+		// version != V1, ErrFSMWireVersion — covered separately).
+		if !errors.Is(err, fsmwire.ErrFSMWireMalformed) {
+			t.Fatalf("len=%d: expected ErrFSMWireMalformed, got %v", l, err)
+		}
+	}
+}
+
+func TestRegistration_RejectsBadVersion(t *testing.T) {
+	t.Parallel()
+	raw := fsmwire.EncodeRegistration(fsmwire.RegistrationPayload{DEKID: 1})
+	raw[0] = 0x99 // tamper version byte
+	_, err := fsmwire.DecodeRegistration(raw)
+	if !errors.Is(err, fsmwire.ErrFSMWireVersion) {
+		t.Fatalf("expected ErrFSMWireVersion, got %v", err)
+	}
+}
+
+func TestBootstrap_RoundTrip(t *testing.T) {
+	t.Parallel()
+	cases := []fsmwire.BootstrapPayload{
+		{
+			StorageDEKID:   1,
+			WrappedStorage: []byte("storage-wrapped"),
+			RaftDEKID:      2,
+			WrappedRaft:    []byte("raft-wrapped"),
+		},
+		{
+			StorageDEKID:   0xAAAAAAAA,
+			WrappedStorage: bytes.Repeat([]byte{0xAA}, 60),
+			RaftDEKID:      0xBBBBBBBB,
+			WrappedRaft:    bytes.Repeat([]byte{0xBB}, 60),
+			BatchRegistry: []fsmwire.RegistrationPayload{
+				{DEKID: 0xAAAAAAAA, FullNodeID: 11, LocalEpoch: 1},
+				{DEKID: 0xAAAAAAAA, FullNodeID: 22, LocalEpoch: 1},
+				{DEKID: 0xBBBBBBBB, FullNodeID: 11, LocalEpoch: 1},
+				{DEKID: 0xBBBBBBBB, FullNodeID: 22, LocalEpoch: 1},
+			},
+		},
+		{
+			// Empty wrapped + empty batch — minimal valid bootstrap.
+			StorageDEKID: 7,
+			RaftDEKID:    8,
+		},
+	}
+	for _, want := range cases {
+		got, err := fsmwire.DecodeBootstrap(fsmwire.EncodeBootstrap(want))
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if got.StorageDEKID != want.StorageDEKID || got.RaftDEKID != want.RaftDEKID {
+			t.Fatalf("dek_id mismatch: got %+v want %+v", got, want)
+		}
+		if !bytes.Equal(got.WrappedStorage, want.WrappedStorage) {
+			t.Fatalf("storage wrapped mismatch")
+		}
+		if !bytes.Equal(got.WrappedRaft, want.WrappedRaft) {
+			t.Fatalf("raft wrapped mismatch")
+		}
+		if len(got.BatchRegistry) != len(want.BatchRegistry) {
+			t.Fatalf("batch len mismatch: got %d want %d", len(got.BatchRegistry), len(want.BatchRegistry))
+		}
+		for i := range want.BatchRegistry {
+			if got.BatchRegistry[i] != want.BatchRegistry[i] {
+				t.Fatalf("batch[%d] mismatch: got %+v want %+v", i, got.BatchRegistry[i], want.BatchRegistry[i])
+			}
+		}
+	}
+}
+
+func TestBootstrap_RejectsTruncated(t *testing.T) {
+	t.Parallel()
+	full := fsmwire.EncodeBootstrap(fsmwire.BootstrapPayload{
+		StorageDEKID: 1, WrappedStorage: []byte("abcd"),
+		RaftDEKID: 2, WrappedRaft: []byte("ef"),
+		BatchRegistry: []fsmwire.RegistrationPayload{{DEKID: 1}},
+	})
+	for cut := 0; cut < len(full); cut++ {
+		_, err := fsmwire.DecodeBootstrap(full[:cut])
+		if err == nil {
+			t.Fatalf("cut=%d: expected truncation error, got nil", cut)
+		}
+		if !errors.Is(err, fsmwire.ErrFSMWireMalformed) && !errors.Is(err, fsmwire.ErrFSMWireVersion) {
+			t.Fatalf("cut=%d: expected malformed/version, got %v", cut, err)
+		}
+	}
+}
+
+func TestBootstrap_RejectsTrailingBytes(t *testing.T) {
+	t.Parallel()
+	good := fsmwire.EncodeBootstrap(fsmwire.BootstrapPayload{StorageDEKID: 1, RaftDEKID: 2})
+	// Build a fresh slice with one extra byte rather than appending
+	// to `good` (which gocritic flags as "append result not assigned
+	// to the same slice"). The intent is "good followed by 0x99".
+	corrupted := make([]byte, 0, len(good)+1)
+	corrupted = append(corrupted, good...)
+	corrupted = append(corrupted, 0x99)
+	_, err := fsmwire.DecodeBootstrap(corrupted)
+	if !errors.Is(err, fsmwire.ErrFSMWireMalformed) {
+		t.Fatalf("expected ErrFSMWireMalformed, got %v", err)
+	}
+}
+
+func TestRotation_RoundTrip(t *testing.T) {
+	t.Parallel()
+	want := fsmwire.RotationPayload{
+		SubTag:  fsmwire.RotateSubRotateDEK,
+		DEKID:   0xCAFEBABE,
+		Purpose: fsmwire.PurposeStorage,
+		Wrapped: []byte("new-wrapped-DEK"),
+		ProposerRegistration: fsmwire.RegistrationPayload{
+			DEKID:      0xCAFEBABE,
+			FullNodeID: 0xDEADBEEFCAFEBABE,
+			LocalEpoch: 7,
+		},
+	}
+	got, err := fsmwire.DecodeRotation(fsmwire.EncodeRotation(want))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.SubTag != want.SubTag || got.DEKID != want.DEKID || got.Purpose != want.Purpose {
+		t.Fatalf("header mismatch: got %+v", got)
+	}
+	if !bytes.Equal(got.Wrapped, want.Wrapped) {
+		t.Fatalf("wrapped mismatch")
+	}
+	if got.ProposerRegistration != want.ProposerRegistration {
+		t.Fatalf("proposer reg mismatch: got %+v want %+v", got.ProposerRegistration, want.ProposerRegistration)
+	}
+}
+
+func TestRotation_RejectsUnknownSubTag(t *testing.T) {
+	t.Parallel()
+	raw := fsmwire.EncodeRotation(fsmwire.RotationPayload{
+		SubTag: fsmwire.RotateSubRotateDEK, DEKID: 1, Purpose: fsmwire.PurposeStorage,
+	})
+	raw[1] = 0x99 // sub-tag byte (after version)
+	_, err := fsmwire.DecodeRotation(raw)
+	if !errors.Is(err, fsmwire.ErrFSMWireSubtag) {
+		t.Fatalf("expected ErrFSMWireSubtag, got %v", err)
+	}
+}
+
+func TestRotation_RejectsBadVersion(t *testing.T) {
+	t.Parallel()
+	raw := fsmwire.EncodeRotation(fsmwire.RotationPayload{SubTag: fsmwire.RotateSubRotateDEK})
+	raw[0] = 0x99
+	_, err := fsmwire.DecodeRotation(raw)
+	if !errors.Is(err, fsmwire.ErrFSMWireVersion) {
+		t.Fatalf("expected ErrFSMWireVersion, got %v", err)
+	}
+}
+
+// TestOpcodes_DistinctFromKVOpcodes pins that the new opcodes do not
+// collide with kv/fsm.go's existing raftEncode* tags (0x00-0x02).
+// A drift here would route an FSM dispatch through the wrong handler.
+func TestOpcodes_DistinctFromKVOpcodes(t *testing.T) {
+	t.Parallel()
+	if fsmwire.OpRegistration <= 0x02 || fsmwire.OpBootstrap <= 0x02 || fsmwire.OpRotation <= 0x02 {
+		t.Fatalf("opcode collision with kv legacy: 0x%02x / 0x%02x / 0x%02x",
+			fsmwire.OpRegistration, fsmwire.OpBootstrap, fsmwire.OpRotation)
+	}
+	if fsmwire.OpRegistration == fsmwire.OpBootstrap ||
+		fsmwire.OpBootstrap == fsmwire.OpRotation ||
+		fsmwire.OpRegistration == fsmwire.OpRotation {
+		t.Fatal("opcodes are not distinct")
+	}
+}

--- a/internal/encryption/fsmwire/wire_test.go
+++ b/internal/encryption/fsmwire/wire_test.go
@@ -138,6 +138,41 @@ func TestBootstrap_RejectsTruncated(t *testing.T) {
 	}
 }
 
+// TestBootstrap_RejectsHugeBatchCount is the regression for the
+// codex P1 / gemini security-high finding: a malformed bootstrap
+// payload that names `count = 0xffffffff` would, before the guard,
+// trigger `make([]RegistrationPayload, count)` (4G × 14 bytes ≈
+// 56 GiB) and OOM the process before the loop tried to read the
+// first row. The decoder must fail closed via ErrFSMWireMalformed
+// before any allocation that exceeds the remaining payload.
+func TestBootstrap_RejectsHugeBatchCount(t *testing.T) {
+	t.Parallel()
+	// Hand-roll a payload whose batch count is huge but which has
+	// only a tiny tail to serve registration rows from. We start
+	// from the encoded form of a minimal valid bootstrap, then
+	// rewrite the count prefix in place.
+	good := fsmwire.EncodeBootstrap(fsmwire.BootstrapPayload{
+		StorageDEKID: 1, RaftDEKID: 2,
+	})
+	// Locate the batch-count prefix: after [ver(1)] [storage_dek_id(4)]
+	// [storage_wrapped_len(4)] [storage_wrapped(0)] [raft_dek_id(4)]
+	// [raft_wrapped_len(4)] [raft_wrapped(0)] = offset 17.
+	const countOffset = 1 + 4 + 4 + 0 + 4 + 4 + 0
+	if got := len(good); got < countOffset+4 {
+		t.Fatalf("encoded bootstrap shorter than expected: %d bytes, want >= %d", got, countOffset+4)
+	}
+	// Overwrite count with 0xFFFFFFFF (4G entries). Pre-fix this
+	// would `make([]RegistrationPayload, 4_294_967_295)` and OOM.
+	good[countOffset+0] = 0xFF
+	good[countOffset+1] = 0xFF
+	good[countOffset+2] = 0xFF
+	good[countOffset+3] = 0xFF
+	_, err := fsmwire.DecodeBootstrap(good)
+	if !errors.Is(err, fsmwire.ErrFSMWireMalformed) {
+		t.Fatalf("expected ErrFSMWireMalformed for huge batch count, got %v", err)
+	}
+}
+
 func TestBootstrap_RejectsTrailingBytes(t *testing.T) {
 	t.Parallel()
 	good := fsmwire.EncodeBootstrap(fsmwire.BootstrapPayload{StorageDEKID: 1, RaftDEKID: 2})

--- a/internal/encryption/registry.go
+++ b/internal/encryption/registry.go
@@ -1,0 +1,138 @@
+package encryption
+
+import (
+	"encoding/binary"
+
+	"github.com/cockroachdb/errors"
+)
+
+// WriterRegistryPrefix reserves the Pebble key prefix used by the
+// §4.1 writer registry. Format: `!encryption|writers|<be4 dek_id>|<be2 uint16(node_id)>`.
+//
+// The leading `!` and the pipe-separated layout match the existing
+// `!admin|` reservation in adapter/distribution_server.go and the
+// `txnInternalKeyPrefix` reservation in store/. The pebbleStore's
+// applyMutationsBatch refuses user mutations whose key starts with
+// this prefix so a malformed user Put cannot clobber registry rows.
+//
+// Registry rows are written through pebbleStore.EncryptionRegistryBatch
+// (Stage 4 admin path), NOT through the MVCC encoded-key flow —
+// these are operational state, not versioned user values.
+var WriterRegistryPrefix = []byte("!encryption|writers|")
+
+// registryKeySuffixSize is the per-row suffix that follows
+// WriterRegistryPrefix: 4 bytes dek_id (BE) + 1 byte separator '|'
+// + 2 bytes uint16(node_id) (BE).
+const registryKeySuffixSize = 4 + 1 + 2
+
+// registryValueSize is the on-disk value layout per §4.1:
+//
+//	full_node_id            uint64 BE  (8 bytes)
+//	first_seen_local_epoch  uint16 BE  (2 bytes)
+//	last_seen_local_epoch   uint16 BE  (2 bytes)
+const registryValueSize = 8 + 2 + 2
+
+// registry-key separator byte. Single-character pipe matches the
+// outer prefix.
+const registryKeySep = '|'
+
+// Errors surfaced by registry codec helpers.
+var (
+	// ErrRegistryKeyMalformed indicates a Pebble key returned to
+	// DecodeRegistryKey did not match the WriterRegistryPrefix +
+	// fixed-suffix shape produced by RegistryKey.
+	ErrRegistryKeyMalformed = errors.New("encryption: writer registry key is malformed")
+
+	// ErrRegistryValueMalformed indicates a Pebble value returned to
+	// DecodeRegistryValue did not match the fixed registryValueSize
+	// layout. Stage 4 callers fail closed on this — a corrupted
+	// registry row is fail-fast rather than silently treated as
+	// "no entry".
+	ErrRegistryValueMalformed = errors.New("encryption: writer registry value is malformed")
+)
+
+// RegistryKey constructs the Pebble key for the (dek_id,
+// uint16(node_id)) writer-registry row. The 16-bit truncation of
+// the full FNV-64a node id is per §4.1 — the registry distinguishes
+// truncation collisions via the value's full_node_id field, not the
+// key.
+func RegistryKey(dekID uint32, nodeID16 uint16) []byte {
+	out := make([]byte, len(WriterRegistryPrefix)+registryKeySuffixSize)
+	n := copy(out, WriterRegistryPrefix)
+	binary.BigEndian.PutUint32(out[n:n+4], dekID)
+	out[n+4] = registryKeySep
+	binary.BigEndian.PutUint16(out[n+5:n+7], nodeID16)
+	return out
+}
+
+// RegistryDEKPrefix returns the prefix that covers every writer
+// registry row for dekID. Used by §5.4 retirement to drop the
+// entire `!encryption|writers|<dek_id>|*` slice in the same Raft
+// entry that retires the DEK.
+func RegistryDEKPrefix(dekID uint32) []byte {
+	out := make([]byte, len(WriterRegistryPrefix)+4+1)
+	n := copy(out, WriterRegistryPrefix)
+	binary.BigEndian.PutUint32(out[n:n+4], dekID)
+	out[n+4] = registryKeySep
+	return out
+}
+
+// DecodeRegistryKey parses a registry-row key back into its
+// (dek_id, uint16 node_id) tuple. Returns ErrRegistryKeyMalformed
+// when the key does not start with WriterRegistryPrefix or has the
+// wrong length. The decoder does NOT range-check the parsed
+// dek_id against ReservedKeyID — that is the caller's policy.
+func DecodeRegistryKey(key []byte) (dekID uint32, nodeID16 uint16, err error) {
+	if len(key) != len(WriterRegistryPrefix)+registryKeySuffixSize {
+		return 0, 0, errors.Wrapf(ErrRegistryKeyMalformed, "got %d bytes", len(key))
+	}
+	for i, b := range WriterRegistryPrefix {
+		if key[i] != b {
+			return 0, 0, errors.WithStack(ErrRegistryKeyMalformed)
+		}
+	}
+	body := key[len(WriterRegistryPrefix):]
+	if body[4] != registryKeySep {
+		return 0, 0, errors.WithStack(ErrRegistryKeyMalformed)
+	}
+	dekID = binary.BigEndian.Uint32(body[0:4])
+	nodeID16 = binary.BigEndian.Uint16(body[5:7])
+	return dekID, nodeID16, nil
+}
+
+// RegistryValue is the in-memory form of a writer-registry row's
+// stored value: the full untruncated FNV-64a node id and the
+// per-DEK first/last-seen local_epoch counters used by the §4.1
+// case 1/2/3 dispatch on RegisterEncryptionWriter apply.
+type RegistryValue struct {
+	FullNodeID          uint64
+	FirstSeenLocalEpoch uint16
+	LastSeenLocalEpoch  uint16
+}
+
+// EncodeRegistryValue serialises rv to its on-disk byte form.
+// Always returns exactly registryValueSize bytes (12).
+func EncodeRegistryValue(rv RegistryValue) []byte {
+	out := make([]byte, registryValueSize)
+	binary.BigEndian.PutUint64(out[0:8], rv.FullNodeID)
+	binary.BigEndian.PutUint16(out[8:10], rv.FirstSeenLocalEpoch)
+	binary.BigEndian.PutUint16(out[10:12], rv.LastSeenLocalEpoch)
+	return out
+}
+
+// DecodeRegistryValue parses an on-disk row value. Fails closed on
+// length mismatch — a truncated or padded row is operational
+// corruption, not a "missing" entry, so the caller surfaces
+// ErrRegistryValueMalformed rather than silently treating the
+// node as un-registered.
+func DecodeRegistryValue(raw []byte) (RegistryValue, error) {
+	if len(raw) != registryValueSize {
+		return RegistryValue{}, errors.Wrapf(ErrRegistryValueMalformed,
+			"got %d bytes, want %d", len(raw), registryValueSize)
+	}
+	return RegistryValue{
+		FullNodeID:          binary.BigEndian.Uint64(raw[0:8]),
+		FirstSeenLocalEpoch: binary.BigEndian.Uint16(raw[8:10]),
+		LastSeenLocalEpoch:  binary.BigEndian.Uint16(raw[10:12]),
+	}, nil
+}

--- a/internal/encryption/registry_test.go
+++ b/internal/encryption/registry_test.go
@@ -1,0 +1,148 @@
+package encryption_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/cockroachdb/errors"
+)
+
+func TestRegistryKey_RoundTrip(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		dekID    uint32
+		nodeID16 uint16
+	}{
+		{"low ids", 1, 1},
+		{"mid ids", 0xCAFE, 0xBABE},
+		{"max ids", 0xFFFFFFFF, 0xFFFF},
+		{"reserved keyID", encryption.ReservedKeyID, 0x1234},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			key := encryption.RegistryKey(tc.dekID, tc.nodeID16)
+			if !bytes.HasPrefix(key, encryption.WriterRegistryPrefix) {
+				t.Fatalf("key missing prefix: %q", key)
+			}
+			gotDEK, gotNode, err := encryption.DecodeRegistryKey(key)
+			if err != nil {
+				t.Fatalf("DecodeRegistryKey: %v", err)
+			}
+			if gotDEK != tc.dekID || gotNode != tc.nodeID16 {
+				t.Fatalf("round-trip mismatch: got (%d, %d) want (%d, %d)",
+					gotDEK, gotNode, tc.dekID, tc.nodeID16)
+			}
+		})
+	}
+}
+
+// TestRegistryKey_ByteLayoutPin pins the on-disk byte layout so a
+// future refactor cannot silently change the wire format every
+// replica's Pebble store agrees on.
+func TestRegistryKey_ByteLayoutPin(t *testing.T) {
+	t.Parallel()
+	got := encryption.RegistryKey(0xAABBCCDD, 0xEEFF)
+	want := append([]byte("!encryption|writers|"),
+		0xAA, 0xBB, 0xCC, 0xDD,
+		'|',
+		0xEE, 0xFF,
+	)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("layout drift:\n got  %x\n want %x", got, want)
+	}
+}
+
+func TestRegistryDEKPrefix(t *testing.T) {
+	t.Parallel()
+	pfx := encryption.RegistryDEKPrefix(0x42)
+	want := append([]byte("!encryption|writers|"), 0x00, 0x00, 0x00, 0x42, '|')
+	if !bytes.Equal(pfx, want) {
+		t.Fatalf("DEK prefix drift:\n got  %x\n want %x", pfx, want)
+	}
+	// Every key for the same dek_id must start with this prefix.
+	for _, nodeID16 := range []uint16{0, 1, 0xFFFF} {
+		full := encryption.RegistryKey(0x42, nodeID16)
+		if !bytes.HasPrefix(full, pfx) {
+			t.Fatalf("nodeID16=%d key not under DEK prefix", nodeID16)
+		}
+	}
+	// A different dek_id must NOT start with this prefix.
+	other := encryption.RegistryKey(0x43, 0)
+	if bytes.HasPrefix(other, pfx) {
+		t.Fatal("different dek_id key starts with retired-DEK prefix")
+	}
+}
+
+func TestDecodeRegistryKey_RejectsMalformed(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		key  []byte
+	}{
+		{"empty", nil},
+		{"short", []byte("x")},
+		{"wrong prefix", append([]byte("!admin|writers|"), 0x01, 0x02, 0x03, 0x04, '|', 0x00, 0x01)},
+		{"missing separator", append([]byte("!encryption|writers|"), 0x01, 0x02, 0x03, 0x04, 'X', 0x00, 0x01)},
+		{"truncated suffix", append([]byte("!encryption|writers|"), 0x01, 0x02, 0x03, 0x04, '|', 0x00)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := encryption.DecodeRegistryKey(tc.key)
+			if !errors.Is(err, encryption.ErrRegistryKeyMalformed) {
+				t.Fatalf("expected ErrRegistryKeyMalformed, got %v", err)
+			}
+		})
+	}
+}
+
+func TestRegistryValue_RoundTrip(t *testing.T) {
+	t.Parallel()
+	cases := []encryption.RegistryValue{
+		{},
+		{FullNodeID: 1, FirstSeenLocalEpoch: 1, LastSeenLocalEpoch: 1},
+		{FullNodeID: 0xDEADBEEFCAFEBABE, FirstSeenLocalEpoch: 0xABCD, LastSeenLocalEpoch: 0xEF01},
+		{FullNodeID: ^uint64(0), FirstSeenLocalEpoch: 0xFFFF, LastSeenLocalEpoch: 0xFFFF},
+	}
+	for _, want := range cases {
+		raw := encryption.EncodeRegistryValue(want)
+		got, err := encryption.DecodeRegistryValue(raw)
+		if err != nil {
+			t.Fatalf("decode %+v: %v", want, err)
+		}
+		if got != want {
+			t.Fatalf("round-trip mismatch: got %+v want %+v", got, want)
+		}
+	}
+}
+
+// TestRegistryValue_ByteLayoutPin pins the on-disk value layout so
+// the registry's stored bytes survive a refactor without forcing a
+// migration of every replica's Pebble database.
+func TestRegistryValue_ByteLayoutPin(t *testing.T) {
+	t.Parallel()
+	got := encryption.EncodeRegistryValue(encryption.RegistryValue{
+		FullNodeID:          0x0102030405060708,
+		FirstSeenLocalEpoch: 0x090A,
+		LastSeenLocalEpoch:  0x0B0C,
+	})
+	want := []byte{
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // FullNodeID
+		0x09, 0x0A, // FirstSeenLocalEpoch
+		0x0B, 0x0C, // LastSeenLocalEpoch
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("layout drift:\n got  %x\n want %x", got, want)
+	}
+}
+
+func TestDecodeRegistryValue_RejectsMalformed(t *testing.T) {
+	t.Parallel()
+	for _, l := range []int{0, 1, 11, 13, 100} {
+		_, err := encryption.DecodeRegistryValue(make([]byte, l))
+		if !errors.Is(err, encryption.ErrRegistryValueMalformed) {
+			t.Fatalf("len=%d: expected ErrRegistryValueMalformed, got %v", l, err)
+		}
+	}
+}

--- a/internal/raftengine/etcd/encryption.go
+++ b/internal/raftengine/etcd/encryption.go
@@ -5,6 +5,14 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// ErrEncryptionApply is re-exported from internal/encryption so
+// callers in this package can errors.Is-match the FSM-side
+// haltApplyResponse without taking a kv-package import (which
+// would create a cycle: kv → internal/raftengine/etcd → kv tests).
+// The canonical definition lives in internal/encryption/errors.go;
+// see that file's doc for the §6.3 fail-closed contract.
+var ErrEncryptionApply = encryption.ErrEncryptionApply
+
 // ErrRaftUnwrapFailed is returned by applyNormalEntry when the
 // pre-apply hook cannot unwrap a §4.2 raft envelope (GCM tag
 // mismatch, missing DEK in the local keystore, malformed

--- a/internal/raftengine/etcd/encryption_test.go
+++ b/internal/raftengine/etcd/encryption_test.go
@@ -373,6 +373,88 @@ func TestApplyNormalEntry_NoCutoverDefault(t *testing.T) {
 	}
 }
 
+// haltStateMachine is a fakeStateMachine that returns a response
+// implementing the HaltApply interface — used by
+// TestApplyCommitted_HaltApply_DoesNotAdvanceApplied to confirm the
+// engine's seam for §6.3 encryption-apply fatal halts works
+// independently from the raft envelope unwrap hook.
+type haltStateMachine struct {
+	calls atomic.Int32
+	err   error
+}
+
+type haltResponse struct{ err error }
+
+func (h *haltResponse) HaltApply() error { return h.err }
+
+func (s *haltStateMachine) Apply([]byte) any {
+	s.calls.Add(1)
+	if s.err != nil {
+		return &haltResponse{err: s.err}
+	}
+	return nil
+}
+func (s *haltStateMachine) Snapshot() (Snapshot, error) { return nil, nil }
+func (s *haltStateMachine) Restore(_ io.Reader) error   { return nil }
+
+// TestApplyCommitted_HaltApply_DoesNotAdvanceApplied locks down the
+// HaltApply seam: when the FSM returns a value implementing
+// `HaltApply() error` and that method returns non-nil, applyCommitted
+// surfaces the error and does NOT advance setApplied. Mirrors
+// TestApplyCommitted_UnwrapFailure_DoesNotAdvanceApplied, but for
+// the encryption-FSM-apply fatal path that arrives via the FSM's
+// return value rather than the engine's pre-apply hook.
+func TestApplyCommitted_HaltApply_DoesNotAdvanceApplied(t *testing.T) {
+	t.Parallel()
+	fsm := &haltStateMachine{err: ErrEncryptionApply}
+	e := newTestEngine(fsm, nil, nil)
+	const startApplied uint64 = 99
+	e.applied = startApplied
+	e.appliedIndex.Store(startApplied)
+
+	good := raftpb.Entry{
+		Type:  raftpb.EntryNormal,
+		Index: 100,
+		Data:  encodeProposalEnvelope(7, []byte("payload")),
+	}
+	err := e.applyCommitted([]raftpb.Entry{good})
+	if !errors.Is(err, ErrEncryptionApply) {
+		t.Fatalf("expected ErrEncryptionApply, got %v", err)
+	}
+	// fsm.Apply was reached (1 call), but setApplied did NOT
+	// advance because HaltApply().err was non-nil.
+	if got := fsm.calls.Load(); got != 1 {
+		t.Fatalf("fsm.Apply call count = %d, want 1", got)
+	}
+	if e.applied != startApplied {
+		t.Fatalf("applied advanced to %d despite halt; want %d", e.applied, startApplied)
+	}
+	if got := e.appliedIndex.Load(); got != startApplied {
+		t.Fatalf("appliedIndex advanced to %d despite halt; want %d", got, startApplied)
+	}
+}
+
+// TestApplyCommitted_HaltApply_NilContinues confirms that a HaltApply
+// implementer whose `HaltApply()` returns nil does NOT halt — the
+// apply loop advances normally. This is the no-op case where the
+// encryption FSM ran a registration/bootstrap/rotation successfully.
+func TestApplyCommitted_HaltApply_NilContinues(t *testing.T) {
+	t.Parallel()
+	fsm := &haltStateMachine{err: nil}
+	e := newTestEngine(fsm, nil, nil)
+	good := raftpb.Entry{
+		Type:  raftpb.EntryNormal,
+		Index: 100,
+		Data:  encodeProposalEnvelope(7, []byte("payload")),
+	}
+	if err := e.applyCommitted([]raftpb.Entry{good}); err != nil {
+		t.Fatalf("applyCommitted: %v", err)
+	}
+	if e.applied != 100 {
+		t.Fatalf("applied = %d, want 100 (nil HaltApply must advance)", e.applied)
+	}
+}
+
 // TestUnwrapRaftPayload_Helper sanity-checks that the engine-internal
 // unwrapRaftPayload helper marks all encryption errors with
 // ErrRaftUnwrapFailed (so callers can errors.Is-match without

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -2040,10 +2040,28 @@ func (e *Engine) setApplied(index uint64) {
 // would deliver a nil/error response that the coordinator might mis-
 // interpret as a committed-but-failed apply (rather than the actual
 // "halting; please restart and retry" semantics).
+//
+// HaltApply seam: the StateMachine.Apply contract returns `any`
+// (no error), so an FSM that needs to signal "halt the apply loop"
+// (the §6.3 fatal-encryption-apply path) packs an error inside a
+// value implementing the HaltApply interface below. The applier
+// inspects the returned response for that interface and propagates
+// the error before setApplied — same fail-closed shape as the raft
+// envelope unwrap hook in applyNormalEntry. Non-fatal Apply errors
+// (today's *fsmApplyResponse, returned by kv batch apply) do NOT
+// implement HaltApply and continue to advance setApplied.
 func (e *Engine) applyNormalCommitted(entry raftpb.Entry) error {
 	response, err := e.applyNormalEntry(entry)
 	if err != nil {
 		return err
+	}
+	if h, ok := response.(interface{ HaltApply() error }); ok {
+		if herr := h.HaltApply(); herr != nil {
+			slog.Error("encryption FSM apply requested halt; not advancing setApplied",
+				slog.Uint64("entry_index", entry.Index),
+				slog.Any("err", herr))
+			return errors.Wrap(herr, "raftengine/etcd: FSM-requested apply halt")
+		}
 	}
 	e.setApplied(entry.Index)
 	e.resolveProposal(entry.Index, entry.Data, response)

--- a/kv/fsm.go
+++ b/kv/fsm.go
@@ -90,23 +90,8 @@ type fsmApplyResponse struct {
 }
 
 func (f *kvFSM) Apply(data []byte) any {
-	// HLC lease entries advance only the physical ceiling; they do not touch
-	// the MVCC store. The logical counter continues to be managed in memory.
-	if len(data) > 0 && data[0] == raftEncodeHLCLease {
-		return f.applyHLCLease(data[1:])
-	}
-	// Encryption FSM opcodes (§6.3 / §11.3 — 0x03 registration,
-	// 0x04 bootstrap, 0x05 rotation). Dispatched ahead of the
-	// kv-legacy decodeRaftRequests so a stray encryption opcode
-	// cannot fall through to the proto3 unmarshal path. The
-	// applyEncryption dispatcher returns a haltApplyResponse on
-	// failure; internal/raftengine/etcd.applyNormalCommitted
-	// recognises the HaltApply interface and halts the apply loop.
-	if len(data) > 0 {
-		switch data[0] {
-		case fsmwire.OpRegistration, fsmwire.OpBootstrap, fsmwire.OpRotation:
-			return f.applyEncryption(data[0], data[1:])
-		}
+	if resp, handled := f.applyReservedOpcode(data); handled {
+		return resp
 	}
 
 	ctx := context.TODO()
@@ -133,6 +118,36 @@ func (f *kvFSM) Apply(data []byte) any {
 		return resp
 	}
 	return nil
+}
+
+// applyReservedOpcode handles the FSM-internal opcode bands that are
+// dispatched ahead of the legacy proto3 fallback: HLC-lease entries
+// (0x02) and the encryption opcode range (§6.3 / §11.3 — 0x03..0x07,
+// the band reserved per the proto3 wire-tag analysis in
+// fsmwire.OpEncryptionMin/Max). Returning handled=false lets Apply
+// fall through to the legacy raft-request decode path. Extracted from
+// Apply to keep the dispatcher under the cyclomatic-complexity budget.
+//
+// Encryption-opcode dispatch is the codex P1 fix for PR748: a stray
+// future encryption opcode (e.g. 0x06) — including one emitted by a
+// NEWER leader during a rolling upgrade against a STALE follower —
+// must not fall through to proto3 unmarshal and silently advance
+// setApplied. applyEncryption's default case wraps any unimplemented
+// opcode with ErrEncryptionApply, which the engine's HaltApply seam
+// recognises as a halt — same fail-closed shape as the Stage 3
+// raft-envelope unwrap path.
+func (f *kvFSM) applyReservedOpcode(data []byte) (any, bool) {
+	if len(data) == 0 {
+		return nil, false
+	}
+	switch {
+	case data[0] == raftEncodeHLCLease:
+		return f.applyHLCLease(data[1:]), true
+	case data[0] >= fsmwire.OpEncryptionMin && data[0] <= fsmwire.OpEncryptionMax:
+		return f.applyEncryption(data[0], data[1:]), true
+	default:
+		return nil, false
+	}
 }
 
 // hlcLeasePayloadLen is the payload length (tag byte excluded) of an HLC lease entry.

--- a/kv/fsm.go
+++ b/kv/fsm.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
 	"github.com/bootjp/elastickv/internal/raftengine"
 	pb "github.com/bootjp/elastickv/proto"
 	"github.com/bootjp/elastickv/store"
@@ -29,23 +30,54 @@ type kvFSM struct {
 	// hlc is the shared HLC instance updated when a HLC lease entry is applied.
 	// May be nil for nodes that do not participate in physical ceiling tracking.
 	hlc *HLC
+	// encryption is the §6.3 / §11.3 encryption-opcode applier. nil in
+	// Stage 4 default and in tests that do not exercise opcodes 0x03/
+	// 0x04/0x05; Stage 5/6/7 wire a concrete implementation that
+	// mutates the keystore + sidecar + writer registry. With nil
+	// installed, the encryption-opcode dispatch fails closed via
+	// HaltApply rather than silently advancing setApplied past a
+	// proposal the local node cannot process.
+	encryption EncryptionApplier
 }
 
 type FSM interface {
 	raftengine.StateMachine
 }
 
+// FSMOption configures a *kvFSM at construction. Stage 4 introduces
+// WithEncryption; future stages may add more.
+type FSMOption func(*kvFSM)
+
+// WithEncryption installs the EncryptionApplier the kvFSM dispatches
+// opcodes 0x03 / 0x04 / 0x05 to. Pass nil (or omit the option
+// entirely) to leave the FSM in the Stage-4-default fail-closed
+// state where any encryption opcode halts the apply loop via
+// ErrEncryptionApply.
+func WithEncryption(applier EncryptionApplier) FSMOption {
+	return func(f *kvFSM) {
+		f.encryption = applier
+	}
+}
+
 // NewKvFSMWithHLC creates a KV FSM that updates hlc.physicalCeiling whenever
 // a HLC lease entry is applied. The caller must pass the same *HLC instance to
 // the coordinator so both sides share the agreed physical ceiling.
-func NewKvFSMWithHLC(store store.MVCCStore, hlc *HLC) FSM {
-	return &kvFSM{
+//
+// Optional FSMOption arguments configure additional handlers (see
+// WithEncryption). Existing callers without options keep the
+// pre-Stage-4 behaviour byte-for-byte.
+func NewKvFSMWithHLC(store store.MVCCStore, hlc *HLC, opts ...FSMOption) FSM {
+	f := &kvFSM{
 		store: store,
 		log: slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 			Level: slog.LevelWarn,
 		})),
 		hlc: hlc,
 	}
+	for _, opt := range opts {
+		opt(f)
+	}
+	return f
 }
 
 var _ FSM = (*kvFSM)(nil)
@@ -62,6 +94,19 @@ func (f *kvFSM) Apply(data []byte) any {
 	// the MVCC store. The logical counter continues to be managed in memory.
 	if len(data) > 0 && data[0] == raftEncodeHLCLease {
 		return f.applyHLCLease(data[1:])
+	}
+	// Encryption FSM opcodes (§6.3 / §11.3 — 0x03 registration,
+	// 0x04 bootstrap, 0x05 rotation). Dispatched ahead of the
+	// kv-legacy decodeRaftRequests so a stray encryption opcode
+	// cannot fall through to the proto3 unmarshal path. The
+	// applyEncryption dispatcher returns a haltApplyResponse on
+	// failure; internal/raftengine/etcd.applyNormalCommitted
+	// recognises the HaltApply interface and halts the apply loop.
+	if len(data) > 0 {
+		switch data[0] {
+		case fsmwire.OpRegistration, fsmwire.OpBootstrap, fsmwire.OpRotation:
+			return f.applyEncryption(data[0], data[1:])
+		}
 	}
 
 	ctx := context.TODO()

--- a/kv/fsm_encryption.go
+++ b/kv/fsm_encryption.go
@@ -1,0 +1,131 @@
+package kv
+
+import (
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
+	"github.com/cockroachdb/errors"
+)
+
+// EncryptionApplier owns the side-effects an encryption FSM entry
+// must persist on apply: keystore mutation, sidecar update, and
+// writer-registry insert. Stage 4 ships the dispatch seam and
+// HaltApply propagation; Stage 5/6/7 will provide a concrete
+// implementation that
+//
+//   - KEK-unwraps the wrapped DEK and calls Keystore.Set
+//   - mutates the local sidecar (Active.{Storage,Raft}, keys map,
+//     raft_envelope_cutover_index) via the §5.1 crash-durable
+//     WriteSidecar protocol
+//   - inserts writer-registry rows under the §4.1
+//     `!encryption|writers|<dek_id>|<uint16(node_id)>` Pebble key
+//
+// The separation lets Stage 4 land the byte-tag dispatch + halt
+// machinery without depending on the Stage 7 writer-registry
+// storage layer or the Stage 5 admin RPC plumbing.
+//
+// All three methods may return an error wrapped with
+// encryption.ErrEncryptionApply to halt the apply loop. The kvFSM
+// dispatcher converts any non-nil return into a haltApplyResponse
+// so internal/raftengine/etcd's HaltApply seam recognises it.
+type EncryptionApplier interface {
+	ApplyRegistration(p fsmwire.RegistrationPayload) error
+	ApplyBootstrap(p fsmwire.BootstrapPayload) error
+	ApplyRotation(p fsmwire.RotationPayload) error
+}
+
+// haltApplyResponse satisfies the HaltApply interface that
+// internal/raftengine/etcd.applyNormalCommitted inspects. Any
+// non-nil err returned by an encryption FSM handler is packed in
+// this type, which the engine recognises as "halt the apply loop
+// without advancing setApplied" — the §6.3 fail-closed contract.
+type haltApplyResponse struct {
+	err error
+}
+
+// HaltApply returns the wrapped error so the engine's
+// applyNormalCommitted halt path fires. Returning nil here would
+// be a no-op halt; callers always pass a non-nil err.
+func (h *haltApplyResponse) HaltApply() error {
+	return h.err
+}
+
+// applyEncryption is the kvFSM dispatcher for opcodes 0x03 / 0x04 /
+// 0x05. data is the payload BYTE FOLLOWING the opcode tag (the
+// caller in Apply has already stripped data[0]).
+//
+// Without an EncryptionApplier wired (Stage 4 default in tests and
+// production until Stage 5/6/7), every encryption opcode returns
+// ErrEncryptionApply via the HaltApply seam — this is the
+// fail-closed default: a malformed or premature encryption
+// proposal halts the apply loop rather than silently advancing
+// setApplied.
+func (f *kvFSM) applyEncryption(opcode byte, data []byte) any {
+	if f.encryption == nil {
+		return haltErr(errors.Wrapf(encryption.ErrEncryptionApply,
+			"encryption opcode %#x arrived but no EncryptionApplier wired", opcode))
+	}
+	switch opcode {
+	case fsmwire.OpRegistration:
+		return f.applyRegistration(data)
+	case fsmwire.OpBootstrap:
+		return f.applyBootstrap(data)
+	case fsmwire.OpRotation:
+		return f.applyRotation(data)
+	default:
+		return haltErr(errors.Wrapf(encryption.ErrEncryptionApply,
+			"unknown encryption opcode %#x", opcode))
+	}
+}
+
+// applyRegistration decodes a 0x03 payload and dispatches to the
+// EncryptionApplier. Errors are wrapped with ErrEncryptionApply so
+// the engine's HaltApply seam halts the apply loop.
+func (f *kvFSM) applyRegistration(data []byte) any {
+	p, err := fsmwire.DecodeRegistration(data)
+	if err != nil {
+		return haltErr(errors.Wrap(errors.Mark(err, encryption.ErrEncryptionApply),
+			"kv/fsm: decode registration"))
+	}
+	if err := f.encryption.ApplyRegistration(p); err != nil {
+		return haltErr(errors.Wrap(errors.Mark(err, encryption.ErrEncryptionApply),
+			"kv/fsm: apply registration"))
+	}
+	return nil
+}
+
+// applyBootstrap decodes a 0x04 payload and dispatches.
+func (f *kvFSM) applyBootstrap(data []byte) any {
+	p, err := fsmwire.DecodeBootstrap(data)
+	if err != nil {
+		return haltErr(errors.Wrap(errors.Mark(err, encryption.ErrEncryptionApply),
+			"kv/fsm: decode bootstrap"))
+	}
+	if err := f.encryption.ApplyBootstrap(p); err != nil {
+		return haltErr(errors.Wrap(errors.Mark(err, encryption.ErrEncryptionApply),
+			"kv/fsm: apply bootstrap"))
+	}
+	return nil
+}
+
+// applyRotation decodes a 0x05 payload and dispatches.
+func (f *kvFSM) applyRotation(data []byte) any {
+	p, err := fsmwire.DecodeRotation(data)
+	if err != nil {
+		return haltErr(errors.Wrap(errors.Mark(err, encryption.ErrEncryptionApply),
+			"kv/fsm: decode rotation"))
+	}
+	if err := f.encryption.ApplyRotation(p); err != nil {
+		return haltErr(errors.Wrap(errors.Mark(err, encryption.ErrEncryptionApply),
+			"kv/fsm: apply rotation"))
+	}
+	return nil
+}
+
+// haltErr is a tiny constructor so the dispatch table above stays
+// terse. Always returns a non-nil *haltApplyResponse — never use
+// this with err == nil (the resulting response would still satisfy
+// the HaltApply interface but its HaltApply() returning nil would
+// be a no-op halt, which masks intent).
+func haltErr(err error) *haltApplyResponse {
+	return &haltApplyResponse{err: err}
+}

--- a/kv/fsm_encryption_test.go
+++ b/kv/fsm_encryption_test.go
@@ -224,19 +224,22 @@ func TestApply_DecodeFailure_Halts(t *testing.T) {
 }
 
 // TestApply_ReservedRange_FutureOpcodes_Halt is the codex-P1
-// regression for PR748: every byte in [0x03, 0x0F] must route
-// through the encryption fail-closed halt path, NOT the legacy
-// proto3 decoder. A future leader emitting 0x06 (or any reserved
-// byte) against a stale follower would otherwise fall through to
-// decodeLegacyRaftRequest and either silently advance setApplied or
-// return an ordinary apply error — the rolling-upgrade divergence
-// shape the §6.3 halt was added to prevent.
+// regression for PR748: every byte in [OpEncryptionMin,
+// OpEncryptionMax] = [0x03, 0x07] must route through the encryption
+// fail-closed halt path, NOT the legacy proto3 decoder. A future
+// leader emitting 0x06 (or any reserved byte) against a stale
+// follower would otherwise fall through to decodeLegacyRaftRequest
+// and either silently advance setApplied or return an ordinary
+// apply error — the rolling-upgrade divergence shape the §6.3 halt
+// was added to prevent. The upper bound stops at 0x07 because
+// 0x08..0x0D collide with proto3 field-1 wire tags (see the comment
+// on OpEncryptionMax in fsmwire/wire.go for the analysis).
 //
 // The test sweeps the reserved range exhaustively and asserts that
 // every byte produces a haltApplyResponse wrapping
 // ErrEncryptionApply. The known opcodes (0x03/0x04/0x05) ride this
 // path because no applier is wired; the future-reserved opcodes
-// (0x06..0x0F) ride it because applyEncryption's default case fails
+// (0x06/0x07) ride it because applyEncryption's default case fails
 // closed for any byte not yet implemented.
 func TestApply_ReservedRange_FutureOpcodes_Halt(t *testing.T) {
 	t.Parallel()
@@ -256,8 +259,10 @@ func TestApply_ReservedRange_FutureOpcodes_Halt(t *testing.T) {
 // available for future non-encryption FSM extensions and continues
 // to flow through decodeRaftRequests, which will surface the
 // proto3 decode error (or proto3 stretch-decode it). The contract
-// is "encryption owns 0x03..0x0F"; that bound must hold from both
-// sides.
+// is "encryption owns 0x03..0x07 (OpEncryptionMax)"; bytes 0x08+
+// are reserved for the proto3 fallback (because 0x08..0x0D collide
+// with proto3 field-1 wire tags) and any later non-encryption FSM
+// extension. That bound must hold from both sides.
 func TestApply_AboveReservedRange_FallsThroughToLegacy(t *testing.T) {
 	t.Parallel()
 	applier := &fakeApplier{}

--- a/kv/fsm_encryption_test.go
+++ b/kv/fsm_encryption_test.go
@@ -223,6 +223,60 @@ func TestApply_DecodeFailure_Halts(t *testing.T) {
 	}
 }
 
+// TestApply_ReservedRange_FutureOpcodes_Halt is the codex-P1
+// regression for PR748: every byte in [0x03, 0x0F] must route
+// through the encryption fail-closed halt path, NOT the legacy
+// proto3 decoder. A future leader emitting 0x06 (or any reserved
+// byte) against a stale follower would otherwise fall through to
+// decodeLegacyRaftRequest and either silently advance setApplied or
+// return an ordinary apply error — the rolling-upgrade divergence
+// shape the §6.3 halt was added to prevent.
+//
+// The test sweeps the reserved range exhaustively and asserts that
+// every byte produces a haltApplyResponse wrapping
+// ErrEncryptionApply. The known opcodes (0x03/0x04/0x05) ride this
+// path because no applier is wired; the future-reserved opcodes
+// (0x06..0x0F) ride it because applyEncryption's default case fails
+// closed for any byte not yet implemented.
+func TestApply_ReservedRange_FutureOpcodes_Halt(t *testing.T) {
+	t.Parallel()
+	f := newFSMWithFake(nil)
+	for op := fsmwire.OpEncryptionMin; op <= fsmwire.OpEncryptionMax; op++ {
+		// Single-byte payload (no need to be well-formed — the
+		// no-applier dispatcher fails closed before any decode).
+		err := haltApplyOf(f.Apply([]byte{op}))
+		if !errors.Is(err, encryption.ErrEncryptionApply) {
+			t.Fatalf("op=%#x: expected halt with ErrEncryptionApply, got %v", op, err)
+		}
+	}
+}
+
+// TestApply_AboveReservedRange_FallsThroughToLegacy confirms 0x10
+// and above is NOT routed through applyEncryption — it remains
+// available for future non-encryption FSM extensions and continues
+// to flow through decodeRaftRequests, which will surface the
+// proto3 decode error (or proto3 stretch-decode it). The contract
+// is "encryption owns 0x03..0x0F"; that bound must hold from both
+// sides.
+func TestApply_AboveReservedRange_FallsThroughToLegacy(t *testing.T) {
+	t.Parallel()
+	applier := &fakeApplier{}
+	f := newFSMWithFake(applier)
+	// 0x10 with a proto3-invalid payload should trigger
+	// decodeRaftRequests' legacy fallback and surface as a non-halt
+	// error response (the kv legacy path returns plain errors via
+	// errors.WithStack — NOT via the HaltApply interface). The
+	// distinguishing assertion: the response must NOT be a
+	// haltApplyResponse.
+	resp := f.Apply([]byte{0x10, 0x99, 0x88})
+	if h, ok := resp.(interface{ HaltApply() error }); ok {
+		t.Fatalf("byte 0x10 unexpectedly routed through HaltApply: %v", h.HaltApply())
+	}
+	if got := applier.regCalls.Load() + applier.bootstrapCalls.Load() + applier.rotationCalls.Load(); got != 0 {
+		t.Fatalf("encryption applier received %d calls on a 0x10 entry", got)
+	}
+}
+
 // TestApply_LegacyOpcodesUnaffected confirms 0x00 / 0x01 / 0x02
 // continue to dispatch through the kv-legacy and HLC-lease paths.
 // A regression where the encryption switch case fell through to

--- a/kv/fsm_encryption_test.go
+++ b/kv/fsm_encryption_test.go
@@ -1,0 +1,247 @@
+package kv
+
+import (
+	"bytes"
+	"sync/atomic"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
+	"github.com/cockroachdb/errors"
+)
+
+// fakeApplier records every call and lets tests inject a per-handler
+// error. ApplyRegistration / ApplyBootstrap / ApplyRotation are the
+// three handler hooks Stage 5/6/7 will fill in for real; the kvFSM
+// dispatch logic must invoke exactly the right one and propagate
+// any returned error through the HaltApply seam.
+type fakeApplier struct {
+	regCalls       atomic.Int32
+	bootstrapCalls atomic.Int32
+	rotationCalls  atomic.Int32
+	regErr         error
+	bootstrapErr   error
+	rotationErr    error
+	lastReg        fsmwire.RegistrationPayload
+	lastBootstrap  fsmwire.BootstrapPayload
+	lastRotation   fsmwire.RotationPayload
+}
+
+func (f *fakeApplier) ApplyRegistration(p fsmwire.RegistrationPayload) error {
+	f.regCalls.Add(1)
+	f.lastReg = p
+	return f.regErr
+}
+
+func (f *fakeApplier) ApplyBootstrap(p fsmwire.BootstrapPayload) error {
+	f.bootstrapCalls.Add(1)
+	f.lastBootstrap = p
+	return f.bootstrapErr
+}
+
+func (f *fakeApplier) ApplyRotation(p fsmwire.RotationPayload) error {
+	f.rotationCalls.Add(1)
+	f.lastRotation = p
+	return f.rotationErr
+}
+
+func newFSMWithFake(applier EncryptionApplier) *kvFSM {
+	f := &kvFSM{}
+	if applier != nil {
+		WithEncryption(applier)(f)
+	}
+	return f
+}
+
+// haltApplyOf extracts a wrapped halt error from an Apply response,
+// or returns nil for non-halt responses. Mirrors the engine-side
+// type assertion in internal/raftengine/etcd.applyNormalCommitted
+// so the FSM tests can verify the dispatch produced something the
+// engine recognises as a halt.
+func haltApplyOf(resp any) error {
+	h, ok := resp.(interface{ HaltApply() error })
+	if !ok {
+		return nil
+	}
+	return h.HaltApply()
+}
+
+// TestApply_Registration_HappyPath confirms a well-formed 0x03 entry
+// dispatches to ApplyRegistration with the decoded payload and
+// returns nil (no halt).
+func TestApply_Registration_HappyPath(t *testing.T) {
+	t.Parallel()
+	applier := &fakeApplier{}
+	f := newFSMWithFake(applier)
+
+	want := fsmwire.RegistrationPayload{DEKID: 7, FullNodeID: 0xCAFEBABE, LocalEpoch: 3}
+	payload := fsmwire.EncodeRegistration(want)
+	wireBytes := append([]byte{fsmwire.OpRegistration}, payload...)
+
+	resp := f.Apply(wireBytes)
+	if err := haltApplyOf(resp); err != nil {
+		t.Fatalf("unexpected halt: %v", err)
+	}
+	if got := applier.regCalls.Load(); got != 1 {
+		t.Fatalf("regCalls = %d, want 1", got)
+	}
+	if applier.lastReg != want {
+		t.Fatalf("lastReg = %+v, want %+v", applier.lastReg, want)
+	}
+	if applier.bootstrapCalls.Load() != 0 || applier.rotationCalls.Load() != 0 {
+		t.Fatal("dispatch leaked into other handlers")
+	}
+}
+
+func TestApply_Bootstrap_HappyPath(t *testing.T) {
+	t.Parallel()
+	applier := &fakeApplier{}
+	f := newFSMWithFake(applier)
+
+	want := fsmwire.BootstrapPayload{
+		StorageDEKID:   1,
+		WrappedStorage: []byte("storage-w"),
+		RaftDEKID:      2,
+		WrappedRaft:    []byte("raft-w"),
+		BatchRegistry:  []fsmwire.RegistrationPayload{{DEKID: 1, FullNodeID: 11, LocalEpoch: 1}},
+	}
+	wireBytes := append([]byte{fsmwire.OpBootstrap}, fsmwire.EncodeBootstrap(want)...)
+
+	if err := haltApplyOf(f.Apply(wireBytes)); err != nil {
+		t.Fatalf("unexpected halt: %v", err)
+	}
+	if got := applier.bootstrapCalls.Load(); got != 1 {
+		t.Fatalf("bootstrapCalls = %d, want 1", got)
+	}
+	if applier.lastBootstrap.StorageDEKID != want.StorageDEKID {
+		t.Fatalf("storage id mismatch")
+	}
+	if !bytes.Equal(applier.lastBootstrap.WrappedStorage, want.WrappedStorage) {
+		t.Fatalf("storage wrapped mismatch")
+	}
+}
+
+func TestApply_Rotation_HappyPath(t *testing.T) {
+	t.Parallel()
+	applier := &fakeApplier{}
+	f := newFSMWithFake(applier)
+
+	want := fsmwire.RotationPayload{
+		SubTag:  fsmwire.RotateSubRotateDEK,
+		DEKID:   42,
+		Purpose: fsmwire.PurposeStorage,
+		Wrapped: []byte("new-w"),
+		ProposerRegistration: fsmwire.RegistrationPayload{
+			DEKID: 42, FullNodeID: 99, LocalEpoch: 1,
+		},
+	}
+	wireBytes := append([]byte{fsmwire.OpRotation}, fsmwire.EncodeRotation(want)...)
+
+	if err := haltApplyOf(f.Apply(wireBytes)); err != nil {
+		t.Fatalf("unexpected halt: %v", err)
+	}
+	if got := applier.rotationCalls.Load(); got != 1 {
+		t.Fatalf("rotationCalls = %d, want 1", got)
+	}
+	if applier.lastRotation.DEKID != want.DEKID || applier.lastRotation.Purpose != want.Purpose {
+		t.Fatalf("rotation payload mismatch")
+	}
+}
+
+// TestApply_NoApplierWired locks down the Stage-4 fail-closed
+// default: when WithEncryption was not used, every encryption
+// opcode halts with ErrEncryptionApply. A regression here would
+// let an opcode silently advance setApplied past a proposal the
+// local node cannot process — the §6.3 fatal-apply property we
+// added the HaltApply seam to enforce.
+func TestApply_NoApplierWired(t *testing.T) {
+	t.Parallel()
+	f := newFSMWithFake(nil)
+	cases := []struct {
+		name   string
+		opcode byte
+		body   []byte
+	}{
+		{"registration", fsmwire.OpRegistration, fsmwire.EncodeRegistration(fsmwire.RegistrationPayload{DEKID: 1})},
+		{"bootstrap", fsmwire.OpBootstrap, fsmwire.EncodeBootstrap(fsmwire.BootstrapPayload{})},
+		{"rotation", fsmwire.OpRotation, fsmwire.EncodeRotation(fsmwire.RotationPayload{SubTag: fsmwire.RotateSubRotateDEK})},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wireBytes := append([]byte{tc.opcode}, tc.body...)
+			err := haltApplyOf(f.Apply(wireBytes))
+			if !errors.Is(err, encryption.ErrEncryptionApply) {
+				t.Fatalf("expected ErrEncryptionApply, got %v", err)
+			}
+		})
+	}
+}
+
+// TestApply_HandlerError_HaltsWithEncryptionApply confirms an
+// applier-side error flows through the HaltApply seam wrapped with
+// ErrEncryptionApply so internal/raftengine/etcd recognises it.
+func TestApply_HandlerError_HaltsWithEncryptionApply(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("applier denied")
+	applier := &fakeApplier{regErr: sentinel}
+	f := newFSMWithFake(applier)
+
+	wireBytes := append([]byte{fsmwire.OpRegistration},
+		fsmwire.EncodeRegistration(fsmwire.RegistrationPayload{DEKID: 1})...)
+	err := haltApplyOf(f.Apply(wireBytes))
+	if !errors.Is(err, encryption.ErrEncryptionApply) {
+		t.Fatalf("expected wrapped ErrEncryptionApply, got %v", err)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected nested sentinel preserved, got %v", err)
+	}
+	if got := applier.regCalls.Load(); got != 1 {
+		t.Fatalf("regCalls = %d, want 1", got)
+	}
+}
+
+// TestApply_DecodeFailure_Halts pins the malformed-payload contract:
+// a truncated encryption opcode must halt rather than silently no-op.
+// The Stage-4 dispatcher marks the fsmwire decode error with
+// ErrEncryptionApply; the engine's HaltApply path then halts.
+func TestApply_DecodeFailure_Halts(t *testing.T) {
+	t.Parallel()
+	applier := &fakeApplier{}
+	f := newFSMWithFake(applier)
+
+	// Truncated registration payload (missing version + 14 body bytes).
+	wireBytes := []byte{fsmwire.OpRegistration, 0x99}
+	err := haltApplyOf(f.Apply(wireBytes))
+	if !errors.Is(err, encryption.ErrEncryptionApply) {
+		t.Fatalf("expected ErrEncryptionApply, got %v", err)
+	}
+	if !errors.Is(err, fsmwire.ErrFSMWireMalformed) {
+		t.Fatalf("expected nested ErrFSMWireMalformed, got %v", err)
+	}
+	if got := applier.regCalls.Load(); got != 0 {
+		t.Fatalf("regCalls = %d, want 0 (decode failed before applier)", got)
+	}
+}
+
+// TestApply_LegacyOpcodesUnaffected confirms 0x00 / 0x01 / 0x02
+// continue to dispatch through the kv-legacy and HLC-lease paths.
+// A regression where the encryption switch case fell through to
+// every input would route legacy proposals through the encryption
+// applier (and halt them all) — exactly the failure mode the
+// pre-Apply test guards against.
+func TestApply_LegacyOpcodesUnaffected(t *testing.T) {
+	t.Parallel()
+	applier := &fakeApplier{}
+	f := newFSMWithFake(applier)
+
+	// 0x02 raftEncodeHLCLease with a valid 8-byte big-endian payload.
+	hlcEntry := []byte{raftEncodeHLCLease, 0, 0, 0, 0, 0, 0, 0, 1}
+	if resp := f.Apply(hlcEntry); resp != nil {
+		// applyHLCLease may return nil or an HLC-style error; here
+		// we just assert it did NOT route to the encryption applier.
+		_ = resp
+	}
+	if got := applier.regCalls.Load() + applier.bootstrapCalls.Load() + applier.rotationCalls.Load(); got != 0 {
+		t.Fatalf("encryption applier received %d calls on a 0x02 entry", got)
+	}
+}


### PR DESCRIPTION
## Summary

Stage 4 of the data-at-rest encryption rollout (design doc: `docs/design/2026_04_29_proposed_data_at_rest_encryption.md`, §4.1 writer registry, §5.2 rotation, §5.6 bootstrap, §6.3 fail-closed apply, §11.3 reserved opcodes). Adds the byte-tag dispatch and HaltApply propagation seam for three new FSM-internal Raft entry types:

- `0x03 OpRegistration` — writer-registry insert / re-register
- `0x04 OpBootstrap` — initial DEK install + active pointers + batch writer-registry rows
- `0x05 OpRotation` — DEK rotation + active-pointer update + proposer registration

Stage 4 is **inert in production**: with the new `EncryptionApplier` option not wired (`NewKvFSMWithHLC` default), every existing FSM behaviour is unchanged byte-for-byte. The encryption opcodes only land once Stage 5/6/7 plug in concrete handlers.

## Out of scope (deferred)

- Stage 5: EncryptionAdmin gRPC + CLI (proposes 0x03/0x04/0x05 entries)
- Stage 6: 3-phase rollout cluster flags (`enable-storage-envelope`, `enable-raft-envelope` rotation sub-tags)
- Stage 7: Writer registry persistence + deterministic-nonce factory (consumes `internal/encryption/registry.go`)
- Stage 8: Snapshot header v2 (round-trip encrypted entries through MVCC stream)
- Stage 9: KMS-backed wrappers, compression, retire/rewrite, full Jepsen

## Test plan

- [x] `go test -race ./internal/encryption/...` — codec round-trip, byte-layout pin, malformed/version/sub-tag rejection
- [x] `go test -race ./internal/raftengine/etcd/...` — HaltApply seam halts apply loop without advancing setApplied
- [x] `go test -race ./kv/...` — per-opcode dispatch, no-applier fail-closed, handler-error wrapping, decode-failure halt, legacy opcodes unaffected
- [x] `golangci-lint run` clean (0 issues)
- [x] Wider regression: `go test -race ./internal/... ./store/... ./kv/...` — every existing test passes byte-for-byte; no FSM caller wires `WithEncryption` in Stage 4
- [ ] CI verifies build / golangci-lint / test / Jepsen

## Self-review (CLAUDE.md 5 passes)

1. **Data loss** — encryption opcodes that fail to apply (malformed payload or handler error) halt without advancing `setApplied`; next restart replays. Aligned with Stage 3's `ErrRaftUnwrapFailed` halt invariant.
2. **Concurrency** — `f.encryption` is set once at FSM construction and read-only thereafter; same single-writer discipline as `f.hlc`. The `HaltApply` interface check on the apply hot path is a single type assertion, lock-free.
3. **Performance** — cipher-disabled (no applier) and non-encryption opcode paths are pre-existing; the new opcode tags add a switch case + one type assertion per applied entry. Negligible.
4. **Consistency** — byte-tag dispatch is mutually exclusive; legacy opcodes (0x00/0x01/0x02) remain on their original code paths verbatim. Wire format fails closed on any version / sub-tag / length mismatch.
5. **Test coverage** — 35+ unit tests across four packages plus the existing wider suite continuing to pass with no changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for encryption operations including registration, bootstrap, and key rotation with robust error handling.

* **Bug Fixes**
  * Implemented fail-closed error handling for encryption apply operations to prevent data advancement on encryption failures.

* **Tests**
  * Added comprehensive test coverage for encryption wire format, registry operations, and apply loop halt behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/748)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->