### PR TITLE
refactor(redis): bound rangeList / readValueAt VerifyLeaderForKey to per-call ctx

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1876,7 +1876,16 @@ func (t *txnContext) load(key []byte) (*txnValue, error) {
 		tv.ttl = ttl
 	} else {
 		var err error
-		val, err = t.server.readValueAt(t.ctx, storageKey, t.startTS)
+		// Some redis_txn_test.go fixtures build a minimal txnContext
+		// literal without setting ctx; fall back to Background so
+		// readValueAt's coordinator.VerifyLeaderForKey does not panic
+		// when wrapped via context.WithTimeout(nil, …). Same defensive
+		// pattern as streamDeletions / loadListState.
+		ctx := t.ctx
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		val, err = t.server.readValueAt(ctx, storageKey, t.startTS)
 		if err != nil && !errors.Is(err, store.ErrKeyNotFound) {
 			return nil, errors.WithStack(err)
 		}

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1761,7 +1761,13 @@ type txnValue struct {
 }
 
 type txnContext struct {
-	server     *RedisServer
+	server *RedisServer
+	// ctx is the per-EXEC dispatch context (redisDispatchTimeout-bounded
+	// at the call site in runTransaction). Plumbed through so reads
+	// inside the EXEC such as load() → readValueAt() respect the
+	// caller's deadline rather than falling back to handlerContext +
+	// the verifyLeaderEngineCtx safety net.
+	ctx        context.Context //nolint:containedctx // EXEC is a long-lived value type that wraps a single client command, ctx must travel with it.
 	working    map[string]*txnValue
 	listStates map[string]*listTxnState
 	zsetStates map[string]*zsetTxnState
@@ -1870,7 +1876,7 @@ func (t *txnContext) load(key []byte) (*txnValue, error) {
 		tv.ttl = ttl
 	} else {
 		var err error
-		val, err = t.server.readValueAt(storageKey, t.startTS)
+		val, err = t.server.readValueAt(t.ctx, storageKey, t.startTS)
 		if err != nil && !errors.Is(err, store.ErrKeyNotFound) {
 			return nil, errors.WithStack(err)
 		}
@@ -2797,6 +2803,7 @@ func (r *RedisServer) runTransaction(queue []redcon.Command) ([]redisResult, err
 
 		txn := &txnContext{
 			server:          r,
+			ctx:             dispatchCtx,
 			working:         map[string]*txnValue{},
 			listStates:      map[string]*listTxnState{},
 			zsetStates:      map[string]*zsetTxnState{},
@@ -3244,7 +3251,7 @@ func (r *RedisServer) fetchListRange(ctx context.Context, key []byte, meta store
 	return out, nil
 }
 
-func (r *RedisServer) rangeList(key []byte, startRaw, endRaw []byte) ([]string, error) {
+func (r *RedisServer) rangeList(ctx context.Context, key []byte, startRaw, endRaw []byte) ([]string, error) {
 	if !r.coordinator.IsLeaderForKey(key) {
 		return r.proxyLRange(key, startRaw, endRaw)
 	}
@@ -3261,7 +3268,11 @@ func (r *RedisServer) rangeList(key []byte, startRaw, endRaw []byte) ([]string, 
 		return nil, wrongTypeError()
 	}
 
-	if err := r.coordinator.VerifyLeaderForKey(r.handlerContext(), key); err != nil {
+	// PR #749 follow-up: pass the per-call dispatch ctx so a stalled
+	// VerifyLeaderForKey honours the caller's deadline rather than the
+	// long-lived handlerContext + verifyLeaderEngineCtx fallback. Same
+	// shape as keys() / FLUSHDB.
+	if err := r.coordinator.VerifyLeaderForKey(ctx, key); err != nil {
 		return nil, errors.WithStack(err)
 	}
 
@@ -3498,7 +3509,7 @@ func (r *RedisServer) tryLeaderGetAt(key []byte, ts uint64) ([]byte, error) {
 	return resp.Value, nil
 }
 
-func (r *RedisServer) readValueAt(key []byte, readTS uint64) ([]byte, error) {
+func (r *RedisServer) readValueAt(ctx context.Context, key []byte, readTS uint64) ([]byte, error) {
 	ttlKey := key
 	nonStringInternal := false
 	if userKey := extractRedisInternalUserKey(key); userKey != nil {
@@ -3517,7 +3528,11 @@ func (r *RedisServer) readValueAt(key []byte, readTS uint64) ([]byte, error) {
 	}
 
 	if r.coordinator.IsLeaderForKey(key) {
-		if err := r.coordinator.VerifyLeaderForKey(r.handlerContext(), key); err != nil {
+		// PR #749 follow-up: caller-supplied ctx (with
+		// redisDispatchTimeout from the dispatch handler) replaces
+		// r.handlerContext() so VerifyLeaderForKey honours the
+		// per-command deadline. Same shape as keys() / FLUSHDB.
+		if err := r.coordinator.VerifyLeaderForKey(ctx, key); err != nil {
 			return nil, errors.WithStack(err)
 		}
 		v, err := r.store.GetAt(context.Background(), key, readTS)
@@ -3567,7 +3582,9 @@ func (r *RedisServer) rpush(conn redcon.Conn, cmd redcon.Command) {
 }
 
 func (r *RedisServer) lrange(conn redcon.Conn, cmd redcon.Command) {
-	items, err := r.rangeList(cmd.Args[1], cmd.Args[2], cmd.Args[3])
+	ctx, cancel := context.WithTimeout(r.handlerContext(), redisDispatchTimeout)
+	defer cancel()
+	items, err := r.rangeList(ctx, cmd.Args[1], cmd.Args[2], cmd.Args[3])
 	if err != nil {
 		conn.WriteError(err.Error())
 		return

--- a/adapter/redis_retry_test.go
+++ b/adapter/redis_retry_test.go
@@ -240,7 +240,7 @@ func TestRedisEvalRetriesWriteConflict(t *testing.T) {
 	require.Equal(t, "v1", string(conn.bulk))
 	require.Equal(t, 2, coord.dispatches)
 
-	rawValue, err := srv.readValueAt(redisStrKey([]byte("retry:lua")), snapshotTS(coord.clock, st))
+	rawValue, err := srv.readValueAt(context.Background(), redisStrKey([]byte("retry:lua")), snapshotTS(coord.clock, st))
 	require.NoError(t, err)
 	value, _, err := decodeRedisStr(rawValue)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- Redis adapter follow-up to PR #749. `rangeList` and `readValueAt` now accept a `ctx context.Context` parameter and forward it to `VerifyLeaderForKey` instead of using the long-lived `r.handlerContext()`.
- `lrange` wraps `r.handlerContext()` with `redisDispatchTimeout` and passes it down. Inside MULTI/EXEC, `txnContext` carries the EXEC-scoped dispatch ctx (set at construction in `runTransaction`) so `load() → readValueAt()` respects the caller's deadline.
- Not a correctness fix: the `verifyLeaderEngineCtx` default-deadline guard introduced in PR #749 r1 already bounded these paths at 5 s. This brings them under the same per-command dispatch budget as the rest of the adapter so a slow leader probe can't outlive the user-visible command timeout via the 5 s fallback.

## Background
PR #749 review (gemini/Codex) flagged that `keys()` and `FLUSHDB` had escaped the dispatch deadline by feeding `r.handlerContext()` (server baseCtx, no deadline) into `VerifyLeader*`. Those were fixed inline. Two remaining call sites — `rangeList` (LRANGE leader path) and `readValueAt` (single-key reads from EXEC bodies and string GETs) — were called out as a non-blocking follow-up because the new `verifyLeaderEngineCtx` 5 s default already protected against the unbounded-wait regression. This PR tightens them to match.

## Why `txnContext.ctx`
`txnContext` is the value type that wraps one in-flight EXEC body. `load()` is called repeatedly during EXEC and may transitively call `readValueAt()`. Plumbing ctx through each method would mean threading it through every `working[…]` access — the struct is exactly the right scope to carry the EXEC dispatch ctx, so it gets a `ctx` field with a `//nolint:containedctx` annotation explaining the rationale.

## Test plan
- [x] `go test -race -count=1 -short ./adapter` — 531s, all green
- [x] `go vet ./...` — clean
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transactions now honor per-call timeouts during execution, preventing unexpected hangs.
  * List/lookup commands use deadline-aware leader checks for more consistent timeout behavior.

* **Tests**
  * Test updated to explicitly handle value reads with a bound context to ensure reliable timeout semantics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/752)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->