### PR TITLE
fix(redis): prefix transient-leader error replies with NOTLEADER

### DIFF
--- a/.github/workflows/jepsen-test-scheduled.yml
+++ b/.github/workflows/jepsen-test-scheduled.yml
@@ -57,12 +57,48 @@ jobs:
           curl -L https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein > ~/lein
           chmod +x ~/lein
           ~/lein version
+      # Cache Maven artifacts across runs. Maven Central (repo1.maven.org)
+      # serves intermittent 429s during dependency download, which
+      # uncached scheduled runs trip frequently — the lein project pulls
+      # ~100 jars at first launch. Keying on project.clj invalidates the
+      # cache only when dependencies actually change.
+      - name: Cache Maven and Leiningen artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.lein
+          key: ${{ runner.os }}-maven-${{ hashFiles('jepsen/project.clj') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Pre-fetch Go modules
         run: |
           mkdir -p "$GOCACHE" /tmp/go-tmp
           GOPATH=$(go env GOPATH)
           export GOCACHE GOTMPDIR=/tmp/go-tmp
           go mod download
+      # Warm the Maven cache up front so unit tests / workloads start
+      # against a populated ~/.m2. `lein deps` is wrapped with a retry
+      # loop because Maven Central transiently returns 429 during peak
+      # hours, and the default lein behaviour is to fail the build on
+      # the first checksum miss. Three attempts with linear backoff is
+      # enough to ride out a typical rate-limit window.
+      - name: Warm Leiningen Maven cache
+        working-directory: jepsen
+        run: |
+          set -uo pipefail
+          n=0
+          max=3
+          until ~/lein deps; do
+            n=$((n + 1))
+            if [ "$n" -ge "$max" ]; then
+              echo "lein deps failed after $n attempts" >&2
+              exit 1
+            fi
+            sleep_secs=$((n * 30))
+            echo "lein deps failed (attempt $n/$max), retrying in ${sleep_secs}s..." >&2
+            sleep "$sleep_secs"
+          done
       - name: Run Jepsen unit tests
         working-directory: jepsen
         run: ~/lein test

--- a/.github/workflows/jepsen-test.yml
+++ b/.github/workflows/jepsen-test.yml
@@ -31,6 +31,18 @@ jobs:
           curl -L https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein > ~/lein
           chmod +x ~/lein
           ~/lein version
+      # See jepsen-test-scheduled.yml for the rationale: Maven Central
+      # 429s during peak hours have been knocking the scheduled stress
+      # run out, and the per-push run uses the same dependency set.
+      - name: Cache Maven and Leiningen artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.lein
+          key: ${{ runner.os }}-maven-${{ hashFiles('jepsen/project.clj') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Pre-fetch Go modules and build binary
         run: |
           mkdir -p "$GOCACHE" /tmp/go-tmp
@@ -38,6 +50,22 @@ jobs:
           export GOCACHE GOTMPDIR=/tmp/go-tmp
           go mod download
           go build -o /tmp/elastickv-bin .
+      - name: Warm Leiningen Maven cache
+        working-directory: jepsen
+        run: |
+          set -uo pipefail
+          n=0
+          max=3
+          until ~/lein deps; do
+            n=$((n + 1))
+            if [ "$n" -ge "$max" ]; then
+              echo "lein deps failed after $n attempts" >&2
+              exit 1
+            fi
+            sleep_secs=$((n * 30))
+            echo "lein deps failed (attempt $n/$max), retrying in ${sleep_secs}s..." >&2
+            sleep "$sleep_secs"
+          done
       - name: Run Jepsen unit tests
         working-directory: jepsen
         run: ~/lein test

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -18,6 +18,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/bootjp/elastickv/internal/raftengine"
 	"github.com/bootjp/elastickv/kv"
 	"github.com/bootjp/elastickv/monitoring"
 	pb "github.com/bootjp/elastickv/proto"
@@ -295,44 +296,47 @@ var redisMetricsConnPool = sync.Pool{
 
 func (c *redisMetricsConn) WriteError(msg string) {
 	c.hadError = true
-	c.Conn.WriteError(normalizeRedisErrorReply(msg))
+	c.Conn.WriteError(msg)
 }
 
-// normalizeRedisErrorReply prefixes transient-leader error replies with
-// the NOTLEADER semantic code. Real Redis clients (Carmine, and through
-// it jepsen-io/redis) classify error replies by their first whitespace
+// writeRedisError writes a RESP error reply for err, prepending the
+// Redis-protocol semantic code NOTLEADER when err is a transient
+// leadership-loss signal. Real Redis clients (Carmine, and through it
+// jepsen-io/redis) classify error replies by their first whitespace
 // token converted to a keyword (e.g. ERR, MOVED, NOTLEADER). A bare
 // "leader not found" reply ends up as `:prefix :leader`, which the
-// upstream `with-exceptions` macro does not catch, so a worker crashes
-// instead of recording a clean `:fail` op. NOTLEADER is the conventional
-// code for transient leadership-loss replies and is already handled
-// upstream.
+// upstream `with-exceptions` macro does not catch, so a Jepsen worker
+// crashes instead of recording a clean `:fail` op.
 //
-// Suffix matching mirrors kv.hasTransientLeaderPhrase so wrapping
-// (cockroachdb/errors %w, gRPC status, etc.) at higher layers does not
-// defeat the rewrite. The check is a no-op when the reply already
-// carries a known Redis error prefix.
-func normalizeRedisErrorReply(msg string) string {
-	if msg == "" {
-		return msg
+// Classification is purely typed: cockroachdb/errors.Is traverses both
+// the standard %w chain and Mark-based equivalence, so wrappers
+// (errors.WithStack, errors.Wrapf, raftengine's marked sentinels) do
+// not defeat the check. Sentinels mirror kv.isTransientLeaderError +
+// kv.isLeadershipLossError so any sentinel those classifiers already
+// recognize as transient also flips a Redis reply to NOTLEADER.
+func writeRedisError(conn redcon.Conn, err error) {
+	if isTransientLeaderRedisError(err) {
+		conn.WriteError("NOTLEADER " + err.Error())
+		return
 	}
-	if i := strings.IndexByte(msg, ' '); i > 0 {
-		head := msg[:i]
-		if head == strings.ToUpper(head) {
-			// Already prefixed with a semantic error code (ERR,
-			// WRONGTYPE, NOTLEADER, MOVED, ASK, READONLY, ...).
-			return msg
-		}
+	conn.WriteError(err.Error())
+}
+
+// isTransientLeaderRedisError reports whether err is a transient
+// leader-unavailable signal that the Redis adapter should rewrite to a
+// NOTLEADER reply. Uses cockroachdb/errors.Is so Mark-based equivalence
+// (used by raftengine sentinels) and %w-chain wrapping (cockroachdb
+// WithStack, fmt.Errorf %w, etc.) both resolve correctly.
+func isTransientLeaderRedisError(err error) bool {
+	if err == nil {
+		return false
 	}
-	lower := strings.ToLower(msg)
-	switch {
-	case strings.HasSuffix(lower, "leader not found"),
-		strings.HasSuffix(lower, "not leader"),
-		strings.HasSuffix(lower, "leadership lost"),
-		strings.HasSuffix(lower, "leadership transfer in progress"):
-		return "NOTLEADER " + msg
-	}
-	return msg
+	return errors.Is(err, ErrLeaderNotFound) ||
+		errors.Is(err, ErrNotLeader) ||
+		errors.Is(err, kv.ErrLeaderNotFound) ||
+		errors.Is(err, raftengine.ErrNotLeader) ||
+		errors.Is(err, raftengine.ErrLeadershipLost) ||
+		errors.Is(err, raftengine.ErrLeadershipTransferInProgress)
 }
 
 func (c *redisMetricsConn) reset(conn redcon.Conn) {
@@ -542,7 +546,7 @@ func (r *RedisServer) Run() error {
 
 			if err := r.validateCmd(cmd); err != nil {
 				r.traceCommandError(conn, name, cmd.Args[1:], err.Error())
-				conn.WriteError(err.Error())
+				writeRedisError(conn, err)
 				r.observeRedisError(name, time.Since(start))
 				return
 			}
@@ -960,14 +964,14 @@ func (r *RedisServer) trySetFastPath(conn redcon.Conn, ctx context.Context, key,
 	// still exists are detected and routed through the full cleanup path.
 	typ, err := r.rawKeyTypeAt(context.Background(), key, readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return true
 	}
 	if isNonStringCollectionType(typ) {
 		return false
 	}
 	if err := r.saveString(ctx, key, value, ttl); err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return true
 	}
 	conn.WriteString("OK")
@@ -980,7 +984,7 @@ func (r *RedisServer) set(conn redcon.Conn, cmd redcon.Command) {
 	}
 	opts, err := parseRedisSetOptions(cmd.Args[3:], time.Now())
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
@@ -993,7 +997,7 @@ func (r *RedisServer) set(conn redcon.Conn, cmd redcon.Command) {
 
 	result, err := r.executeSet(ctx, cmd.Args[1], cmd.Args[2], opts)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if result.wroteNull {
@@ -1027,7 +1031,7 @@ func (r *RedisServer) get(conn redcon.Conn, cmd redcon.Command) {
 	ctx, cancel := context.WithTimeout(r.handlerContext(), redisDispatchTimeout)
 	defer cancel()
 	if _, err := kv.LeaseReadForKeyThrough(r.coordinator, ctx, key); err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	readTS := r.readTS()
@@ -1051,7 +1055,7 @@ func (r *RedisServer) get(conn redcon.Conn, cmd redcon.Command) {
 		return
 	}
 	if !errors.Is(err, store.ErrKeyNotFound) {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
@@ -1061,7 +1065,7 @@ func (r *RedisServer) get(conn redcon.Conn, cmd redcon.Command) {
 	// pre-optimisation behaviour.
 	typ, err := r.keyTypeAt(ctx, key, readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if typ == redisTypeNone {
@@ -1189,7 +1193,7 @@ func (r *RedisServer) del(conn redcon.Conn, cmd redcon.Command) {
 	if len(proxyKeys) > 0 {
 		proxied, err := r.proxyDel(proxyKeys)
 		if err != nil {
-			conn.WriteError(err.Error())
+			writeRedisError(conn, err)
 			return
 		}
 		removed += proxied
@@ -1199,7 +1203,7 @@ func (r *RedisServer) del(conn redcon.Conn, cmd redcon.Command) {
 	if len(localKeys) > 0 {
 		localRemoved, err := r.delLocal(localKeys)
 		if err != nil {
-			conn.WriteError(err.Error())
+			writeRedisError(conn, err)
 			return
 		}
 		removed += int64(localRemoved)
@@ -1250,7 +1254,7 @@ func (r *RedisServer) exists(conn redcon.Conn, cmd redcon.Command) {
 	for _, key := range cmd.Args[1:] {
 		ok, err := r.existsAtFast(ctx, key, readTS)
 		if err != nil {
-			conn.WriteError(err.Error())
+			writeRedisError(conn, err)
 			return
 		}
 		if ok {
@@ -1332,12 +1336,12 @@ func (r *RedisServer) keys(conn redcon.Conn, cmd redcon.Command) {
 		ctx, cancel := context.WithTimeout(r.handlerContext(), redisDispatchTimeout)
 		defer cancel()
 		if err := r.coordinator.VerifyLeader(ctx); err != nil {
-			conn.WriteError(err.Error())
+			writeRedisError(conn, err)
 			return
 		}
 		keys, err := r.visibleKeys(pattern)
 		if err != nil {
-			conn.WriteError(err.Error())
+			writeRedisError(conn, err)
 			return
 		}
 		conn.WriteArray(len(keys))
@@ -1349,7 +1353,7 @@ func (r *RedisServer) keys(conn redcon.Conn, cmd redcon.Command) {
 
 	keys, err := r.proxyKeys(pattern)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
@@ -1692,7 +1696,7 @@ func (r *RedisServer) exec(conn redcon.Conn, _ redcon.Command) {
 
 	results, err := r.runTransaction(queue)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
@@ -1725,7 +1729,7 @@ func (r *RedisServer) proxyTransactionToLeader(conn redcon.Conn, queue []redcon.
 func (r *RedisServer) resolveLeaderRedisAddr(conn redcon.Conn) (string, bool) {
 	leader := r.coordinator.RaftLeader()
 	if leader == "" {
-		conn.WriteError(ErrLeaderNotFound.Error())
+		writeRedisError(conn, ErrLeaderNotFound)
 		return "", false
 	}
 	leaderAddr, ok := r.leaderRedis[leader]
@@ -1772,7 +1776,7 @@ func handleProxyTxnError(conn redcon.Conn, err error) bool {
 			errors.Is(err, io.EOF) ||
 			errors.Is(err, io.ErrUnexpectedEOF) ||
 			errors.As(err, &netErr) {
-			conn.WriteError(err.Error())
+			writeRedisError(conn, err)
 			return true
 		}
 	}
@@ -2913,7 +2917,7 @@ func (r *RedisServer) writeResults(conn redcon.Conn, results []redisResult) {
 		case resultNil:
 			conn.WriteNull()
 		case resultError:
-			conn.WriteError(res.err.Error())
+			writeRedisError(conn, res.err)
 		case resultBulk:
 			conn.WriteBulk(res.bulk)
 		case resultString:
@@ -3438,7 +3442,7 @@ func (r *RedisServer) proxyToLeader(conn redcon.Conn, cmd redcon.Command, key []
 	}
 	cli, err := r.leaderClientForKey(key)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return true
 	}
 
@@ -3459,7 +3463,7 @@ func writeGoRedisResult(conn redcon.Conn, cmd *redis.Cmd) {
 		if errors.Is(err, redis.Nil) {
 			conn.WriteNull()
 		} else {
-			conn.WriteError(err.Error())
+			writeRedisError(conn, err)
 		}
 		return
 	}
@@ -3571,7 +3575,7 @@ func (r *RedisServer) listPushCmd(conn redcon.Conn, cmd redcon.Command, pushFn l
 	if !r.coordinator.IsLeaderForKey(key) {
 		length, err := proxyFn(key, cmd.Args[2:])
 		if err != nil {
-			conn.WriteError(err.Error())
+			writeRedisError(conn, err)
 			return
 		}
 		conn.WriteInt64(length)
@@ -3581,7 +3585,7 @@ func (r *RedisServer) listPushCmd(conn redcon.Conn, cmd redcon.Command, pushFn l
 	readTS := r.readTS()
 	typ, err := r.keyTypeAt(context.Background(), key, readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if typ != redisTypeNone && typ != redisTypeList {
@@ -3593,7 +3597,7 @@ func (r *RedisServer) listPushCmd(conn redcon.Conn, cmd redcon.Command, pushFn l
 	length, err := pushFn(ctx, key, cmd.Args[2:])
 
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteInt64(length)
@@ -3606,7 +3610,7 @@ func (r *RedisServer) rpush(conn redcon.Conn, cmd redcon.Command) {
 func (r *RedisServer) lrange(conn redcon.Conn, cmd redcon.Command) {
 	items, err := r.rangeList(cmd.Args[1], cmd.Args[2], cmd.Args[3])
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteArray(len(items))

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -295,7 +295,44 @@ var redisMetricsConnPool = sync.Pool{
 
 func (c *redisMetricsConn) WriteError(msg string) {
 	c.hadError = true
-	c.Conn.WriteError(msg)
+	c.Conn.WriteError(normalizeRedisErrorReply(msg))
+}
+
+// normalizeRedisErrorReply prefixes transient-leader error replies with
+// the NOTLEADER semantic code. Real Redis clients (Carmine, and through
+// it jepsen-io/redis) classify error replies by their first whitespace
+// token converted to a keyword (e.g. ERR, MOVED, NOTLEADER). A bare
+// "leader not found" reply ends up as `:prefix :leader`, which the
+// upstream `with-exceptions` macro does not catch, so a worker crashes
+// instead of recording a clean `:fail` op. NOTLEADER is the conventional
+// code for transient leadership-loss replies and is already handled
+// upstream.
+//
+// Suffix matching mirrors kv.hasTransientLeaderPhrase so wrapping
+// (cockroachdb/errors %w, gRPC status, etc.) at higher layers does not
+// defeat the rewrite. The check is a no-op when the reply already
+// carries a known Redis error prefix.
+func normalizeRedisErrorReply(msg string) string {
+	if msg == "" {
+		return msg
+	}
+	if i := strings.IndexByte(msg, ' '); i > 0 {
+		head := msg[:i]
+		if head == strings.ToUpper(head) {
+			// Already prefixed with a semantic error code (ERR,
+			// WRONGTYPE, NOTLEADER, MOVED, ASK, READONLY, ...).
+			return msg
+		}
+	}
+	lower := strings.ToLower(msg)
+	switch {
+	case strings.HasSuffix(lower, "leader not found"),
+		strings.HasSuffix(lower, "not leader"),
+		strings.HasSuffix(lower, "leadership lost"),
+		strings.HasSuffix(lower, "leadership transfer in progress"):
+		return "NOTLEADER " + msg
+	}
+	return msg
 }
 
 func (c *redisMetricsConn) reset(conn redcon.Conn) {

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -1640,7 +1640,7 @@ func (r *RedisServer) proxyKeys(pattern []byte) ([]string, error) {
 
 	leaderAddr, ok := r.leaderRedis[leader]
 	if !ok || leaderAddr == "" {
-		return nil, errors.WithStack(errors.Newf("leader redis address unknown for %s", leader))
+		return nil, errors.WithStack(errors.Newf("ERR leader redis address unknown for %s", leader))
 	}
 
 	cli := r.getOrCreateLeaderClient(leaderAddr)
@@ -1734,7 +1734,7 @@ func (r *RedisServer) resolveLeaderRedisAddr(conn redcon.Conn) (string, bool) {
 	}
 	leaderAddr, ok := r.leaderRedis[leader]
 	if !ok || leaderAddr == "" {
-		conn.WriteError(fmt.Sprintf("leader redis address unknown for raft address %s", leader))
+		conn.WriteError(fmt.Sprintf("ERR leader redis address unknown for raft address %s", leader))
 		return "", false
 	}
 	return leaderAddr, true
@@ -3329,7 +3329,7 @@ func (r *RedisServer) proxyLRange(key []byte, startRaw, endRaw []byte) ([]string
 	}
 	leaderAddr, ok := r.leaderRedis[leader]
 	if !ok || leaderAddr == "" {
-		return nil, errors.WithStack(errors.Newf("leader redis address unknown for %s", leader))
+		return nil, errors.WithStack(errors.Newf("ERR leader redis address unknown for %s", leader))
 	}
 
 	cli := r.getOrCreateLeaderClient(leaderAddr)
@@ -3357,7 +3357,7 @@ func (r *RedisServer) proxyRPush(key []byte, values [][]byte) (int64, error) {
 	}
 	leaderAddr, ok := r.leaderRedis[leader]
 	if !ok || leaderAddr == "" {
-		return 0, errors.WithStack(errors.Newf("leader redis address unknown for %s", leader))
+		return 0, errors.WithStack(errors.Newf("ERR leader redis address unknown for %s", leader))
 	}
 
 	cli := r.getOrCreateLeaderClient(leaderAddr)
@@ -3381,7 +3381,7 @@ func (r *RedisServer) proxyLPush(key []byte, values [][]byte) (int64, error) {
 	}
 	leaderAddr, ok := r.leaderRedis[leader]
 	if !ok || leaderAddr == "" {
-		return 0, errors.WithStack(errors.Newf("leader redis address unknown for %s", leader))
+		return 0, errors.WithStack(errors.Newf("ERR leader redis address unknown for %s", leader))
 	}
 
 	cli := r.getOrCreateLeaderClient(leaderAddr)
@@ -3428,7 +3428,7 @@ func (r *RedisServer) leaderClientForKey(key []byte) (*redis.Client, error) {
 	}
 	leaderAddr, ok := r.leaderRedis[leader]
 	if !ok || leaderAddr == "" {
-		return nil, errors.WithStack(errors.Newf("leader redis address unknown for %s", leader))
+		return nil, errors.WithStack(errors.Newf("ERR leader redis address unknown for %s", leader))
 	}
 	return r.getOrCreateLeaderClient(leaderAddr), nil
 }

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -144,7 +144,7 @@ func (r *RedisServer) setex(conn redcon.Conn, cmd redcon.Command) {
 	ctx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
 	defer cancel()
 	if err := r.saveString(ctx, cmd.Args[1], cmd.Args[3], &ttl); err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteString("OK")
@@ -190,7 +190,7 @@ func (r *RedisServer) getdel(conn redcon.Conn, cmd redcon.Command) {
 		return nil
 	})
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if v == nil {
@@ -211,7 +211,7 @@ func (r *RedisServer) setnx(conn redcon.Conn, cmd redcon.Command) {
 	opts := redisSetOptions{missingCond: true}
 	result, err := r.executeSet(ctx, cmd.Args[1], cmd.Args[2], opts)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if result.wroteNull {
@@ -659,7 +659,7 @@ func parseHelloArgs(state *connState, args [][]byte) error {
 func (r *RedisServer) hello(conn redcon.Conn, cmd redcon.Command) {
 	state := getConnState(conn)
 	if err := parseHelloArgs(state, cmd.Args[1:]); err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
@@ -709,7 +709,7 @@ func (r *RedisServer) typeCmd(conn redcon.Conn, cmd redcon.Command) {
 	}
 	typ, err := r.keyType(context.Background(), cmd.Args[1])
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteString(string(typ))
@@ -733,7 +733,7 @@ func (r *RedisServer) writeTTL(conn redcon.Conn, key []byte, milliseconds bool) 
 	readTS := r.readTS()
 	exists, err := r.logicalExistsAt(context.Background(), key, readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if !exists {
@@ -742,7 +742,7 @@ func (r *RedisServer) writeTTL(conn redcon.Conn, key []byte, milliseconds bool) 
 	}
 	ttl, err := r.ttlAt(context.Background(), key, readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	ms := ttlMilliseconds(ttl)
@@ -817,13 +817,13 @@ func (r *RedisServer) prepareExpire(key []byte, nxOnly bool) (uint64, bool, erro
 func (r *RedisServer) setExpire(conn redcon.Conn, cmd redcon.Command, unit time.Duration) {
 	ttl, err := parseExpireTTL(cmd.Args[2])
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
 	nxOnly, err := parseExpireNXOnly(cmd.Args[3:])
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
@@ -847,7 +847,7 @@ func (r *RedisServer) setExpire(conn redcon.Conn, cmd redcon.Command, unit time.
 		result, retErr = r.doSetExpire(ctx, cmd.Args[1], ttl, expireAt, nxOnly)
 		return retErr
 	}); err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteInt(result)
@@ -992,13 +992,13 @@ func writeScanReply(conn redcon.Conn, next int, keys [][]byte) {
 func (r *RedisServer) scan(conn redcon.Conn, cmd redcon.Command) {
 	cursor, pattern, count, err := parseScanArgs(cmd.Args)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
 	keys, err := r.visibleKeys(pattern)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if cursor >= len(keys) {
@@ -1033,20 +1033,20 @@ func (r *RedisServer) dbsize(conn redcon.Conn, _ redcon.Command) {
 	if !r.coordinator.IsLeader() {
 		size, err := r.proxyDBSize()
 		if err != nil {
-			conn.WriteError(err.Error())
+			writeRedisError(conn, err)
 			return
 		}
 		conn.WriteInt(size)
 		return
 	}
 	if err := r.coordinator.VerifyLeader(r.handlerContext()); err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
 	keys, err := r.visibleKeys([]byte("*"))
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteInt(len(keys))
@@ -1112,7 +1112,7 @@ func (r *RedisServer) flushlegacy(conn redcon.Conn, _ redcon.Command) {
 	if !r.coordinator.IsLeader() {
 		n, err := r.proxyFlushLegacy()
 		if err != nil {
-			conn.WriteError(err.Error())
+			writeRedisError(conn, err)
 			return
 		}
 		conn.WriteInt(n)
@@ -1124,7 +1124,7 @@ func (r *RedisServer) flushlegacy(conn redcon.Conn, _ redcon.Command) {
 
 	totalDeleted, err := r.deleteLegacyKeys(ctx, r.readTS())
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteInt(totalDeleted)
@@ -1133,7 +1133,7 @@ func (r *RedisServer) flushlegacy(conn redcon.Conn, _ redcon.Command) {
 func (r *RedisServer) flushDatabase(conn redcon.Conn, all bool) {
 	if !r.coordinator.IsLeader() {
 		if err := r.proxyFlushDatabase(all); err != nil {
-			conn.WriteError(err.Error())
+			writeRedisError(conn, err)
 			return
 		}
 		conn.WriteString("OK")
@@ -1186,7 +1186,7 @@ func (r *RedisServer) flushDatabase(conn redcon.Conn, all bool) {
 		}
 		return cockerrors.WithStack(combined)
 	}); err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
@@ -1427,7 +1427,7 @@ func (r *RedisServer) mutateExactSetLegacy(conn redcon.Conn, ctx context.Context
 		}
 		return r.persistExactSetMembersTxn(ctx, kind, key, readTS, existing)
 	}); err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteInt(changed)
@@ -1487,7 +1487,7 @@ func (r *RedisServer) mutateExactSetWide(conn redcon.Conn, ctx context.Context, 
 		})
 		return cockerrors.WithStack(dispatchErr)
 	}); err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteInt(changed)
@@ -1696,7 +1696,7 @@ func (r *RedisServer) sismember(conn redcon.Conn, cmd redcon.Command) {
 
 	hit, alive, err := r.setMemberFastExists(ctx, key, member, readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if hit {
@@ -1735,7 +1735,7 @@ func (r *RedisServer) setMemberFastExists(ctx context.Context, key, member []byt
 func (r *RedisServer) sismemberSlow(conn redcon.Conn, ctx context.Context, key, member []byte, readTS uint64) {
 	typ, err := r.keyTypeAt(ctx, key, readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if typ == redisTypeNone {
@@ -1748,7 +1748,7 @@ func (r *RedisServer) sismemberSlow(conn redcon.Conn, ctx context.Context, key, 
 	}
 	value, err := r.loadSetAt(ctx, setKind, key, readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if slices.Contains(value.Members, string(member)) {
@@ -1765,7 +1765,7 @@ func (r *RedisServer) smembers(conn redcon.Conn, cmd redcon.Command) {
 	readTS := r.readTS()
 	typ, err := r.keyTypeAt(context.Background(), cmd.Args[1], readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if typ == redisTypeNone {
@@ -1779,7 +1779,7 @@ func (r *RedisServer) smembers(conn redcon.Conn, cmd redcon.Command) {
 
 	value, err := r.loadSetAt(context.Background(), setKind, cmd.Args[1], readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteArray(len(value.Members))
@@ -1813,7 +1813,7 @@ func (r *RedisServer) pfadd(conn redcon.Conn, cmd redcon.Command) {
 
 		return r.persistExactSetMembersTxn(ctx, hllKind, cmd.Args[1], readTS, existing)
 	}); err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if changed == 0 {
@@ -1832,13 +1832,13 @@ func (r *RedisServer) pfcount(conn redcon.Conn, cmd redcon.Command) {
 	for _, key := range cmd.Args[1:] {
 		typ, err := r.keyTypeAt(context.Background(), key, readTS)
 		if err != nil {
-			conn.WriteError(err.Error())
+			writeRedisError(conn, err)
 			return
 		}
 		if typ != redisTypeNone {
 			hllExists, err := r.store.ExistsAt(context.Background(), redisHLLKey(key), readTS)
 			if err != nil {
-				conn.WriteError(err.Error())
+				writeRedisError(conn, err)
 				return
 			}
 			if !hllExists {
@@ -1848,7 +1848,7 @@ func (r *RedisServer) pfcount(conn redcon.Conn, cmd redcon.Command) {
 		}
 		value, err := r.loadSetAt(context.Background(), hllKind, key, readTS)
 		if err != nil {
-			conn.WriteError(err.Error())
+			writeRedisError(conn, err)
 			return
 		}
 		for _, member := range value.Members {
@@ -1864,7 +1864,7 @@ func (r *RedisServer) hset(conn redcon.Conn, cmd redcon.Command) {
 	}
 	added, err := r.applyHashFieldPairs(cmd.Args[1], cmd.Args[2:])
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteInt(added)
@@ -1875,7 +1875,7 @@ func (r *RedisServer) hmset(conn redcon.Conn, cmd redcon.Command) {
 		return
 	}
 	if _, err := r.applyHashFieldPairs(cmd.Args[1], cmd.Args[2:]); err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteString("OK")
@@ -2133,7 +2133,7 @@ func (r *RedisServer) hget(conn redcon.Conn, cmd redcon.Command) {
 	// blob hashes miss the wide-column key and fall through.
 	raw, hit, alive, err := r.hashFieldFastLookup(ctx, key, field, readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if hit {
@@ -2541,7 +2541,7 @@ func (r *RedisServer) zsetRangeEmptyFastResult(ctx context.Context, key []byte, 
 func (r *RedisServer) hgetSlow(conn redcon.Conn, ctx context.Context, key, field []byte, readTS uint64) {
 	typ, err := r.keyTypeAtExpect(ctx, key, readTS, redisTypeHash)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if typ == redisTypeNone {
@@ -2554,7 +2554,7 @@ func (r *RedisServer) hgetSlow(conn redcon.Conn, ctx context.Context, key, field
 	}
 	value, err := r.loadHashAt(ctx, key, readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	fieldValue, ok := value[string(field)]
@@ -2572,7 +2572,7 @@ func (r *RedisServer) hmget(conn redcon.Conn, cmd redcon.Command) {
 	readTS := r.readTS()
 	typ, err := r.keyTypeAtExpect(context.Background(), cmd.Args[1], readTS, redisTypeHash)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	fields := cmd.Args[redisPairWidth:]
@@ -2590,7 +2590,7 @@ func (r *RedisServer) hmget(conn redcon.Conn, cmd redcon.Command) {
 
 	value, err := r.loadHashAt(context.Background(), cmd.Args[1], readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteArray(len(fields))
@@ -2616,7 +2616,7 @@ func (r *RedisServer) hdel(conn redcon.Conn, cmd redcon.Command) {
 		removed, err = r.hdelTxn(ctx, cmd.Args[1], cmd.Args[2:])
 		return err
 	}); err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteInt(removed)
@@ -2770,7 +2770,7 @@ func (r *RedisServer) hexists(conn redcon.Conn, cmd redcon.Command) {
 	// is cheaper than GetAt since we don't need the value payload.
 	hit, alive, err := r.hashFieldFastExists(ctx, key, field, readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if hit {
@@ -2809,7 +2809,7 @@ func (r *RedisServer) hashFieldFastExists(ctx context.Context, key, field []byte
 func (r *RedisServer) hexistsSlow(conn redcon.Conn, ctx context.Context, key, field []byte, readTS uint64) {
 	typ, err := r.keyTypeAtExpect(ctx, key, readTS, redisTypeHash)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if typ == redisTypeNone {
@@ -2822,7 +2822,7 @@ func (r *RedisServer) hexistsSlow(conn redcon.Conn, ctx context.Context, key, fi
 	}
 	value, err := r.loadHashAt(ctx, key, readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if _, ok := value[string(field)]; ok {
@@ -2839,7 +2839,7 @@ func (r *RedisServer) hlen(conn redcon.Conn, cmd redcon.Command) {
 	readTS := r.readTS()
 	typ, err := r.keyTypeAtExpect(context.Background(), cmd.Args[1], readTS, redisTypeHash)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if typ == redisTypeNone {
@@ -2854,7 +2854,7 @@ func (r *RedisServer) hlen(conn redcon.Conn, cmd redcon.Command) {
 	// Wide-column path: use delta-aggregated metadata for O(1) count.
 	count, exists, err := r.resolveHashMeta(context.Background(), cmd.Args[1], readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if exists {
@@ -2864,7 +2864,7 @@ func (r *RedisServer) hlen(conn redcon.Conn, cmd redcon.Command) {
 	// Legacy blob fallback: load all fields and count.
 	value, err := r.loadHashAt(context.Background(), cmd.Args[1], readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteInt(len(value))
@@ -2876,7 +2876,7 @@ func (r *RedisServer) hincrby(conn redcon.Conn, cmd redcon.Command) {
 	}
 	increment, err := strconv.ParseInt(string(cmd.Args[3]), 10, 64)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
@@ -2888,7 +2888,7 @@ func (r *RedisServer) hincrby(conn redcon.Conn, cmd redcon.Command) {
 		current, txnErr = r.hincrbyTxn(ctx, cmd.Args[1], cmd.Args[2], increment)
 		return txnErr
 	}); err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteInt64(current)
@@ -3044,7 +3044,7 @@ func (r *RedisServer) incr(conn redcon.Conn, cmd redcon.Command) {
 		}
 		return r.dispatchElems(ctx, true, readTS, elems)
 	}); err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteInt64(current)
@@ -3057,7 +3057,7 @@ func (r *RedisServer) hgetall(conn redcon.Conn, cmd redcon.Command) {
 	readTS := r.readTS()
 	typ, err := r.keyTypeAtExpect(context.Background(), cmd.Args[1], readTS, redisTypeHash)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if typ == redisTypeNone {
@@ -3071,7 +3071,7 @@ func (r *RedisServer) hgetall(conn redcon.Conn, cmd redcon.Command) {
 
 	value, err := r.loadHashAt(context.Background(), cmd.Args[1], readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	fields := make([]string, 0, len(value))
@@ -3174,7 +3174,7 @@ func (r *RedisServer) zadd(conn redcon.Conn, cmd redcon.Command) {
 	}
 	flags, pairStart, err := parseZAddFlags(cmd.Args)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	remaining := cmd.Args[pairStart:]
@@ -3184,7 +3184,7 @@ func (r *RedisServer) zadd(conn redcon.Conn, cmd redcon.Command) {
 	}
 	pairs, err := parseZAddPairs(remaining)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
@@ -3196,7 +3196,7 @@ func (r *RedisServer) zadd(conn redcon.Conn, cmd redcon.Command) {
 		added, err = r.zaddTxn(ctx, cmd.Args[1], flags, pairs)
 		return err
 	}); err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteInt(added)
@@ -3425,7 +3425,7 @@ func (r *RedisServer) zincrby(conn redcon.Conn, cmd redcon.Command) {
 	}
 	increment, err := strconv.ParseFloat(string(cmd.Args[2]), 64)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
@@ -3437,7 +3437,7 @@ func (r *RedisServer) zincrby(conn redcon.Conn, cmd redcon.Command) {
 		newScore, txnErr = r.zincrbyTxn(ctx, cmd.Args[1], string(cmd.Args[3]), increment)
 		return txnErr
 	}); err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteBulkString(formatRedisFloat(newScore))
@@ -3515,18 +3515,18 @@ func (r *RedisServer) zrange(conn redcon.Conn, cmd redcon.Command) {
 	}
 	start, err := parseInt(cmd.Args[2])
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	stop, err := parseInt(cmd.Args[3])
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
 	opts, err := parseZRangeOptions(cmd.Args[4:])
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
@@ -3537,7 +3537,7 @@ func (r *RedisServer) zrangeRead(conn redcon.Conn, key []byte, start, stop int, 
 	readTS := r.readTS()
 	typ, err := r.keyTypeAtExpect(context.Background(), key, readTS, redisTypeZSet)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if typ == redisTypeNone {
@@ -3551,7 +3551,7 @@ func (r *RedisServer) zrangeRead(conn redcon.Conn, key []byte, start, stop int, 
 
 	value, _, err := r.loadZSetAt(context.Background(), key, readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	entries := append([]redisZSetEntry(nil), value.Entries...)
@@ -3597,7 +3597,7 @@ func (r *RedisServer) zrem(conn redcon.Conn, cmd redcon.Command) {
 		}
 		return r.persistZSetEntriesTxn(ctx, cmd.Args[1], readTS, zsetMapToEntries(members))
 	}); err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteInt(removed)
@@ -3609,12 +3609,12 @@ func (r *RedisServer) zremrangebyrank(conn redcon.Conn, cmd redcon.Command) {
 	}
 	start, err := parseInt(cmd.Args[2])
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	stop, err := parseInt(cmd.Args[3])
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
@@ -3648,7 +3648,7 @@ func (r *RedisServer) zremrangebyrank(conn redcon.Conn, cmd redcon.Command) {
 		removed = e - s + 1
 		return r.persistZSetEntriesTxn(ctx, cmd.Args[1], readTS, remaining)
 	}); err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteInt(removed)
@@ -3832,7 +3832,7 @@ func (r *RedisServer) bzpopminTryAllKeys(conn redcon.Conn, keys [][]byte, fast b
 	for _, key := range keys {
 		result, err := r.tryBZPopMinWithMode(key, fast)
 		if err != nil {
-			conn.WriteError(err.Error())
+			writeRedisError(conn, err)
 			return true
 		}
 		if result == nil {
@@ -3905,12 +3905,12 @@ func (r *RedisServer) ltrim(conn redcon.Conn, cmd redcon.Command) {
 	}
 	start, err := parseInt(cmd.Args[2])
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	stop, err := parseInt(cmd.Args[3])
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
@@ -3938,7 +3938,7 @@ func (r *RedisServer) ltrim(conn redcon.Conn, cmd redcon.Command) {
 		}
 		return r.rewriteListTxn(ctx, cmd.Args[1], readTS, trimmed)
 	}); err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteString("OK")
@@ -3950,13 +3950,13 @@ func (r *RedisServer) lindex(conn redcon.Conn, cmd redcon.Command) {
 	}
 	index, err := parseInt(cmd.Args[2])
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	readTS := r.readTS()
 	typ, err := r.keyTypeAt(context.Background(), cmd.Args[1], readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if typ == redisTypeNone {
@@ -3969,7 +3969,7 @@ func (r *RedisServer) lindex(conn redcon.Conn, cmd redcon.Command) {
 	}
 	values, err := r.listValuesAt(context.Background(), cmd.Args[1], readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	idx := normalizeIndex(index, len(values))
@@ -4145,7 +4145,7 @@ func (r *RedisServer) xadd(conn redcon.Conn, cmd redcon.Command) {
 	}
 	req, err := parseXAddRequest(cmd.Args)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
@@ -4156,7 +4156,7 @@ func (r *RedisServer) xadd(conn redcon.Conn, cmd redcon.Command) {
 		id, err = r.xaddTxn(ctx, cmd.Args[1], req)
 		return err
 	}); err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteBulkString(id)
@@ -4488,7 +4488,7 @@ func (r *RedisServer) xtrim(conn redcon.Conn, cmd redcon.Command) {
 		removed, err = r.xtrimTxn(ctx, cmd.Args[1], maxLen)
 		return err
 	}); err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteInt(removed)
@@ -4963,7 +4963,7 @@ func isXReadIterCtxError(err error) bool {
 func (r *RedisServer) xread(conn redcon.Conn, cmd redcon.Command) {
 	req, err := parseXReadRequest(cmd.Args)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
@@ -4990,7 +4990,7 @@ func (r *RedisServer) xread(conn redcon.Conn, cmd redcon.Command) {
 	err = r.resolveXReadAfterIDs(resolveCtx, &req)
 	resolveCancel()
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
@@ -5056,7 +5056,7 @@ func (r *RedisServer) xreadBusyPoll(conn redcon.Conn, req xreadRequest, deadline
 		// timeout). xreadOnce returns nil results on any error, so
 		// suppressing iter-ctx errors here is sound.
 		if err != nil && !isXReadIterCtxError(err) {
-			conn.WriteError(err.Error())
+			writeRedisError(conn, err)
 			return
 		}
 		if len(results) > 0 {
@@ -5079,7 +5079,7 @@ func (r *RedisServer) xlen(conn redcon.Conn, cmd redcon.Command) {
 	readTS := r.readTS()
 	typ, err := r.keyTypeAtExpect(context.Background(), cmd.Args[1], readTS, redisTypeStream)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if typ == redisTypeNone {
@@ -5092,7 +5092,7 @@ func (r *RedisServer) xlen(conn redcon.Conn, cmd redcon.Command) {
 	}
 	meta, found, err := r.loadStreamMetaAt(context.Background(), cmd.Args[1], readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if found {
@@ -5101,7 +5101,7 @@ func (r *RedisServer) xlen(conn redcon.Conn, cmd redcon.Command) {
 	}
 	stream, err := r.loadStreamAt(context.Background(), cmd.Args[1], readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	conn.WriteInt64(int64(len(stream.Entries)))
@@ -5176,14 +5176,14 @@ func selectStreamRangeEntries(entries []redisStreamEntry, startRaw, endRaw strin
 func (r *RedisServer) rangeStream(conn redcon.Conn, cmd redcon.Command, reverse bool) {
 	count, err := parseRangeStreamCount(cmd.Args)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
 	readTS := r.readTS()
 	typ, err := r.keyTypeAtExpect(context.Background(), cmd.Args[1], readTS, redisTypeStream)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if typ == redisTypeNone {
@@ -5199,13 +5199,13 @@ func (r *RedisServer) rangeStream(conn redcon.Conn, cmd redcon.Command, reverse 
 
 	_, metaFound, err := r.loadStreamMetaAt(context.Background(), cmd.Args[1], readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if metaFound {
 		selected, err := r.rangeStreamNewLayout(context.Background(), cmd.Args[1], readTS, startRaw, endRaw, reverse, count)
 		if err != nil {
-			conn.WriteError(err.Error())
+			writeRedisError(conn, err)
 			return
 		}
 		writeStreamEntries(conn, selected)
@@ -5214,7 +5214,7 @@ func (r *RedisServer) rangeStream(conn redcon.Conn, cmd redcon.Command, reverse 
 
 	stream, err := r.loadStreamAt(context.Background(), cmd.Args[1], readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	selected := selectStreamRangeEntries(stream.Entries, startRaw, endRaw, reverse, count)

--- a/adapter/redis_error_prefix_test.go
+++ b/adapter/redis_error_prefix_test.go
@@ -1,51 +1,88 @@
 package adapter
 
-import "testing"
+import (
+	"fmt"
+	"io"
+	"testing"
 
-func TestNormalizeRedisErrorReply(t *testing.T) {
+	"github.com/bootjp/elastickv/internal/raftengine"
+	"github.com/bootjp/elastickv/kv"
+	"github.com/cockroachdb/errors"
+	"github.com/tidwall/redcon"
+)
+
+// captureConn is the minimal redcon.Conn surface writeRedisError uses;
+// only WriteError needs a real implementation.
+type captureConn struct {
+	redcon.Conn
+	lastErr string
+}
+
+func (c *captureConn) WriteError(msg string) { c.lastErr = msg }
+
+func TestIsTransientLeaderRedisError(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		name string
-		in   string
-		want string
+		err  error
+		want bool
 	}{
-		{"bare leader-not-found gets NOTLEADER prefix",
-			"leader not found",
-			"NOTLEADER leader not found"},
-		{"wrapped leader-not-found suffix gets NOTLEADER prefix",
-			"verify leader: leader not found",
-			"NOTLEADER verify leader: leader not found"},
-		{"not-leader suffix gets NOTLEADER prefix",
-			"raft engine: not leader",
-			"NOTLEADER raft engine: not leader"},
-		{"leadership-lost suffix gets NOTLEADER prefix",
-			"propose: leadership lost",
-			"NOTLEADER propose: leadership lost"},
-		{"leadership-transfer-in-progress suffix gets NOTLEADER prefix",
-			"raft: leadership transfer in progress",
-			"NOTLEADER raft: leadership transfer in progress"},
-		{"already-prefixed NOTLEADER reply is unchanged",
-			"NOTLEADER leader not found",
-			"NOTLEADER leader not found"},
-		{"ERR reply unchanged",
-			"ERR MULTI calls can not be nested",
-			"ERR MULTI calls can not be nested"},
-		{"WRONGTYPE reply unchanged",
-			"WRONGTYPE operation against a key holding the wrong kind of value",
-			"WRONGTYPE operation against a key holding the wrong kind of value"},
-		{"unrelated error unchanged",
-			"some random error",
-			"some random error"},
-		{"empty string unchanged",
-			"",
-			""},
+		{"adapter.ErrLeaderNotFound", ErrLeaderNotFound, true},
+		{"adapter.ErrNotLeader", ErrNotLeader, true},
+		{"kv.ErrLeaderNotFound", kv.ErrLeaderNotFound, true},
+		{"raftengine.ErrNotLeader", raftengine.ErrNotLeader, true},
+		{"raftengine.ErrLeadershipLost", raftengine.ErrLeadershipLost, true},
+		{"raftengine.ErrLeadershipTransferInProgress",
+			raftengine.ErrLeadershipTransferInProgress, true},
+		{"wrapped with errors.WithStack",
+			errors.WithStack(ErrLeaderNotFound), true},
+		{"wrapped with errors.Wrapf",
+			errors.Wrapf(kv.ErrLeaderNotFound, "verify leader"), true},
+		{"wrapped with fmt.Errorf %w",
+			fmt.Errorf("dispatch: %w", raftengine.ErrLeadershipLost), true},
+		{"unrelated error", io.EOF, false},
+		{"nil", nil, false},
+		{"wrong-type-looking error", errors.New("WRONGTYPE op"), false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := normalizeRedisErrorReply(tc.in)
-			if got != tc.want {
-				t.Fatalf("normalizeRedisErrorReply(%q) = %q, want %q", tc.in, got, tc.want)
+			if got := isTransientLeaderRedisError(tc.err); got != tc.want {
+				t.Fatalf("isTransientLeaderRedisError(%v) = %v, want %v",
+					tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWriteRedisError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"transient leader error gains NOTLEADER prefix",
+			ErrLeaderNotFound, "NOTLEADER leader not found"},
+		{"wrapped transient leader error gains NOTLEADER prefix",
+			errors.WithStack(kv.ErrLeaderNotFound),
+			"NOTLEADER leader not found"},
+		{"fmt.Errorf-wrapped raftengine error preserves wrapping in message",
+			fmt.Errorf("verify leader: %w", raftengine.ErrNotLeader),
+			"NOTLEADER verify leader: raft engine: not leader"},
+		{"unrelated error untouched",
+			errors.New("WRONGTYPE op"), "WRONGTYPE op"},
+		{"generic io.EOF untouched",
+			io.EOF, io.EOF.Error()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := &captureConn{}
+			writeRedisError(c, tc.err)
+			if c.lastErr != tc.want {
+				t.Fatalf("writeRedisError last reply = %q, want %q",
+					c.lastErr, tc.want)
 			}
 		})
 	}

--- a/adapter/redis_error_prefix_test.go
+++ b/adapter/redis_error_prefix_test.go
@@ -74,6 +74,18 @@ func TestWriteRedisError(t *testing.T) {
 			errors.New("WRONGTYPE op"), "WRONGTYPE op"},
 		{"generic io.EOF untouched",
 			io.EOF, io.EOF.Error()},
+		// Regression: address-mapping gap errors (raft leader known
+		// but raft→redis address missing in r.leaderRedis) must be
+		// ERR-prefixed at the source so Carmine maps to :prefix :err
+		// instead of :prefix :leader. This covers proxyDBSize / proxyDel /
+		// proxyFlushDatabase / proxyFlushLegacy in redis_proxy.go +
+		// proxyKeys / proxyLRange / proxyRPush / proxyLPush /
+		// leaderClientForKey / resolveLeaderRedisAddr in redis.go — all
+		// errors.Newf'd with the same "ERR leader redis address unknown
+		// for %s" prefix.
+		{"leader-address-unknown config-gap is already ERR-prefixed",
+			errors.Newf("ERR leader redis address unknown for %s", "n1"),
+			"ERR leader redis address unknown for n1"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/adapter/redis_error_prefix_test.go
+++ b/adapter/redis_error_prefix_test.go
@@ -1,0 +1,52 @@
+package adapter
+
+import "testing"
+
+func TestNormalizeRedisErrorReply(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare leader-not-found gets NOTLEADER prefix",
+			"leader not found",
+			"NOTLEADER leader not found"},
+		{"wrapped leader-not-found suffix gets NOTLEADER prefix",
+			"verify leader: leader not found",
+			"NOTLEADER verify leader: leader not found"},
+		{"not-leader suffix gets NOTLEADER prefix",
+			"raft engine: not leader",
+			"NOTLEADER raft engine: not leader"},
+		{"leadership-lost suffix gets NOTLEADER prefix",
+			"propose: leadership lost",
+			"NOTLEADER propose: leadership lost"},
+		{"leadership-transfer-in-progress suffix gets NOTLEADER prefix",
+			"raft: leadership transfer in progress",
+			"NOTLEADER raft: leadership transfer in progress"},
+		{"already-prefixed NOTLEADER reply is unchanged",
+			"NOTLEADER leader not found",
+			"NOTLEADER leader not found"},
+		{"ERR reply unchanged",
+			"ERR MULTI calls can not be nested",
+			"ERR MULTI calls can not be nested"},
+		{"WRONGTYPE reply unchanged",
+			"WRONGTYPE operation against a key holding the wrong kind of value",
+			"WRONGTYPE operation against a key holding the wrong kind of value"},
+		{"unrelated error unchanged",
+			"some random error",
+			"some random error"},
+		{"empty string unchanged",
+			"",
+			""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeRedisErrorReply(tc.in)
+			if got != tc.want {
+				t.Fatalf("normalizeRedisErrorReply(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/adapter/redis_lua.go
+++ b/adapter/redis_lua.go
@@ -111,7 +111,7 @@ func (r *RedisServer) lookupScript(sha string) (string, bool) {
 func (r *RedisServer) runLuaScript(conn redcon.Conn, script string, evalArgs [][]byte) {
 	keys, argv, err := parseRedisEvalArgs(evalArgs)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
@@ -185,7 +185,7 @@ func (r *RedisServer) runLuaScript(conn redcon.Conn, script string, evalArgs [][
 			"sha", luaScriptSHA(script),
 			"elapsed", elapsed, "attempts", attempts,
 			"redis_call_count", totalRedisCallCount, "err", err)
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	writeLuaReply(conn, reply)
@@ -854,7 +854,7 @@ func (r *RedisServer) execLuaCompat(conn redcon.Conn, command string, args [][]b
 		return nil
 	})
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	writeLuaReply(conn, reply)
@@ -915,7 +915,7 @@ func (r *RedisServer) execListPop(conn redcon.Conn, cmd redcon.Command, left boo
 
 	values, err := r.listPopClaim(ctx, cmd.Args[1], count, left)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 
@@ -976,7 +976,7 @@ func (r *RedisServer) collectionCardinal(
 	readTS := r.readTS()
 	typ, err := r.keyTypeAt(context.Background(), cmd.Args[1], readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if typ == redisTypeNone {
@@ -989,7 +989,7 @@ func (r *RedisServer) collectionCardinal(
 	}
 	count, exists, err := resolveMeta(context.Background(), cmd.Args[1], readTS)
 	if err != nil {
-		conn.WriteError(err.Error())
+		writeRedisError(conn, err)
 		return
 	}
 	if exists {

--- a/adapter/redis_proxy.go
+++ b/adapter/redis_proxy.go
@@ -14,7 +14,7 @@ func (r *RedisServer) proxyDBSize() (int, error) {
 	}
 	leaderAddr, ok := r.leaderRedis[leader]
 	if !ok || leaderAddr == "" {
-		return 0, errors.WithStack(errors.Newf("leader redis address unknown for %s", leader))
+		return 0, errors.WithStack(errors.Newf("ERR leader redis address unknown for %s", leader))
 	}
 
 	cli := r.getOrCreateLeaderClient(leaderAddr)
@@ -39,7 +39,7 @@ func (r *RedisServer) proxyDel(keys [][]byte) (int64, error) {
 		}
 		addr, ok := r.leaderRedis[leader]
 		if !ok || addr == "" {
-			return 0, errors.WithStack(errors.Newf("leader redis address unknown for %s", leader))
+			return 0, errors.WithStack(errors.Newf("ERR leader redis address unknown for %s", leader))
 		}
 		byAddr[addr] = append(byAddr[addr], string(k))
 	}
@@ -66,7 +66,7 @@ func (r *RedisServer) proxyFlushDatabase(all bool) error {
 	}
 	leaderAddr, ok := r.leaderRedis[leader]
 	if !ok || leaderAddr == "" {
-		return errors.WithStack(errors.Newf("leader redis address unknown for %s", leader))
+		return errors.WithStack(errors.Newf("ERR leader redis address unknown for %s", leader))
 	}
 
 	cli := r.getOrCreateLeaderClient(leaderAddr)
@@ -90,7 +90,7 @@ func (r *RedisServer) proxyFlushLegacy() (int, error) {
 	}
 	leaderAddr, ok := r.leaderRedis[leader]
 	if !ok || leaderAddr == "" {
-		return 0, errors.WithStack(errors.Newf("leader redis address unknown for %s", leader))
+		return 0, errors.WithStack(errors.Newf("ERR leader redis address unknown for %s", leader))
 	}
 
 	cli := r.getOrCreateLeaderClient(leaderAddr)


### PR DESCRIPTION
## Summary
- Centralize a small rewrite at `redisMetricsConn.WriteError` that prefixes transient-leader error replies (e.g. `leader not found`, `not leader`, `leadership lost`, `leadership transfer in progress`) with `NOTLEADER ` on the Redis wire.
- Replies already prefixed with a semantic Redis error code (`ERR`, `WRONGTYPE`, `NOTLEADER`, `MOVED`, `ASK`, `READONLY`, ...) are passed through unchanged.
- New unit test `TestNormalizeRedisErrorReply` covers the prefix/no-op/empty cases.

## Why
Carmine (and through it `jepsen-io/redis`) classifies Redis error replies by their first whitespace-delimited token, converted to a keyword. The upstream `with-exceptions` macro catches `:err`, `:moved`, `:nocluster`, `:clusterdown`, **`:notleader`**, `:timeout` and maps them to clean `:fail` / `:info` ops.

Our adapter was emitting bare `\"leader not found\"` / `\"not leader\"` strings. Carmine parsed those as `:prefix :leader`, which no upstream catch handles, so the Jepsen Redis worker crashed with `IllegalArgumentException: Don't know how to create ISeq from: clojure.lang.ExceptionInfo` instead of recording a retryable failure. Visible on the scheduled stress run https://github.com/bootjp/elastickv/actions/runs/25644042060 where multiple workers crashed in the post-cluster-launch window before leader election settled, taking the whole job down.

Suffix matching mirrors `kv.hasTransientLeaderPhrase`, so wrapping at higher layers (cockroachdb/errors `%w`, gRPC status, etc.) does not defeat the rewrite, and adding a new transient-leader sentinel only requires updating one place.

## Self-review
1. **Data loss** — no change to durability paths; only wire-format of error replies.
2. **Concurrency / distributed failures** — the wrapper runs synchronously per WriteError on the dispatched command; no shared state, no new lock.
3. **Performance** — one `IndexByte` + at most one `ToLower` + four `HasSuffix` calls per error reply (error path only).
4. **Data consistency** — wire format only; sentinels and error chains in Go are unchanged. `hasTransientLeaderPhrase` still classifies `\"NOTLEADER leader not found\"` correctly via `HasSuffix(\"leader not found\")`.
5. **Test coverage** — table-driven `TestNormalizeRedisErrorReply` covers all branches and the no-op cases.

## Test plan
- [x] `go test -race -count=1 -short ./adapter` — 569s, all green
- [x] `go vet ./adapter/` — clean
- [ ] CI green
- [ ] Next scheduled Jepsen run progresses past the leader-election bootstrap window without crashing workers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized Redis error responses so transient leader/unavailable conditions are consistently surfaced with a NOTLEADER prefix; normalized some “leader redis address unknown” errors to include the ERR prefix.

* **Tests**
  * Added tests verifying detection of leader-related errors (including wrapped forms) and correct NOTLEADER/ERR response behavior.

* **Chores**
  * CI: Cache Maven/Leiningen artifacts and add a warmed dependency step with retries to stabilize scheduled Jepsen runs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/753)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->