### PR TITLE
feat(encryption): Stage 5 PR-B — RotateDEK + RegisterEncryptionWriter mutators

### DIFF
--- a/adapter/encryption_admin.go
+++ b/adapter/encryption_admin.go
@@ -213,12 +213,13 @@ func (s *EncryptionAdminServer) GetSidecarState(_ context.Context, _ *pb.Empty) 
 // sidecar that fell behind a Raft-log compaction window. The RPC is
 // read-only on the server side; no Raft proposal is involved.
 //
-// PR-A serves this from the local sidecar without leadership
-// verification because that is sufficient for the read-only
-// observability tests in this PR. PR-B will add a leader-only
-// guard so a follower with a stale sidecar cannot poison the
-// recovery path of a peer with an even-staler sidecar.
-func (s *EncryptionAdminServer) ResyncSidecar(_ context.Context, req *pb.ResyncSidecarRequest) (*pb.ResyncSidecarResponse, error) {
+// Leader-only via requireLeader, which calls VerifyLeader(ctx) to
+// confirm leadership through a Raft ReadIndex round-trip. Without
+// the quorum check a partitioned former leader (State() still
+// reports StateLeader pre-step-down) could ship stale wrapped-DEK
+// state to a recovering follower and silently overwrite recent
+// rotations.
+func (s *EncryptionAdminServer) ResyncSidecar(ctx context.Context, req *pb.ResyncSidecarRequest) (*pb.ResyncSidecarResponse, error) {
 	// req.CallerFullNodeId is intentionally unused for the
 	// recovery payload itself in PR-B; Stage 7 will use it to
 	// scope the writer-registry projection to that specific
@@ -227,7 +228,7 @@ func (s *EncryptionAdminServer) ResyncSidecar(_ context.Context, req *pb.ResyncS
 	// resyncs to the requesting member without a wire-format
 	// change.
 	_ = req
-	if err := s.requireLeader(); err != nil {
+	if err := s.requireLeader(ctx); err != nil {
 		return nil, err
 	}
 	if s.sidecarPath == "" {
@@ -319,7 +320,7 @@ func statusFromSidecarErr(err error) error {
 // previous rotation is in flight, etc). Returns the commit index
 // once the entry is durable on a Raft quorum.
 func (s *EncryptionAdminServer) RotateDEK(ctx context.Context, req *pb.RotateDEKRequest) (*pb.RotateDEKResponse, error) {
-	if err := s.requireLeader(); err != nil {
+	if err := s.requireLeader(ctx); err != nil {
 		return nil, err
 	}
 	if s.proposer == nil {
@@ -377,7 +378,7 @@ func (s *EncryptionAdminServer) RotateDEK(ctx context.Context, req *pb.RotateDEK
 // fans out a batched RegisterEncryptionWriter does not silently
 // propose a fraction of it.
 func (s *EncryptionAdminServer) RegisterEncryptionWriter(ctx context.Context, req *pb.RegisterEncryptionWriterRequest) (*pb.RegisterEncryptionWriterResponse, error) {
-	if err := s.requireLeader(); err != nil {
+	if err := s.requireLeader(ctx); err != nil {
 		return nil, err
 	}
 	if s.proposer == nil {
@@ -479,21 +480,39 @@ func proposeErrorToStatus(err error, opcode byte) error {
 // address so the operator's CLI can re-target without parsing
 // free-form error text. A nil leaderView is allowed for tests
 // that exercise the proposer wiring directly; the production
-// wiring in main.go MUST register one.
-func (s *EncryptionAdminServer) requireLeader() error {
+// wiring in main.go MUST register one (enforced as a Stage 6
+// startup-time assertion).
+//
+// Two checks happen here:
+//
+//  1. Fast path: State() == StateLeader rejects on followers and
+//     candidates without a Raft round-trip.
+//  2. Quorum confirmation: VerifyLeader(ctx) does a ReadIndex
+//     round-trip so a *partitioned former leader* whose
+//     State() still reports StateLeader (the local view has
+//     not stepped down yet) cannot serve mutating RPCs or
+//     ResyncSidecar against stale local state. Without this,
+//     a follower's recovery flow could pull an outdated DEK
+//     set from a stranded leader and miss recent rotations.
+//     Codex P1 round-2 finding on PR #756.
+func (s *EncryptionAdminServer) requireLeader(ctx context.Context) error {
 	if s.leaderView == nil {
 		return nil
 	}
-	if s.leaderView.State() == raftengine.StateLeader {
-		return nil
+	if s.leaderView.State() != raftengine.StateLeader {
+		leader := s.leaderView.Leader()
+		if leader.ID == "" && leader.Address == "" {
+			return grpcStatusError(codes.FailedPrecondition, "encryption: not leader (no known leader)")
+		}
+		return grpcStatusErrorf(codes.FailedPrecondition,
+			"encryption: not leader (current leader id=%q address=%q)",
+			leader.ID, leader.Address)
 	}
-	leader := s.leaderView.Leader()
-	if leader.ID == "" && leader.Address == "" {
-		return grpcStatusError(codes.FailedPrecondition, "encryption: not leader (no known leader)")
+	if err := s.leaderView.VerifyLeader(ctx); err != nil {
+		return grpcStatusErrorf(codes.FailedPrecondition,
+			"encryption: VerifyLeader failed, refusing to act on stale-leader state: %v", err)
 	}
-	return grpcStatusErrorf(codes.FailedPrecondition,
-		"encryption: not leader (current leader id=%q address=%q)",
-		leader.ID, leader.Address)
+	return nil
 }
 
 func protoRotatePurpose(p pb.RotateDEKRequest_Purpose) (fsmwire.Purpose, error) {

--- a/adapter/encryption_admin.go
+++ b/adapter/encryption_admin.go
@@ -398,7 +398,7 @@ func (s *EncryptionAdminServer) RegisterEncryptionWriter(ctx context.Context, re
 			"encryption: RegisterEncryptionWriter requires exactly one writer, got 0")
 	default:
 		return nil, grpcStatusErrorf(codes.InvalidArgument,
-			"encryption: RegisterEncryptionWriter requires exactly one writer in PR-B, got %d (use BootstrapEncryption for multi-writer batches)",
+			"encryption: RegisterEncryptionWriter requires exactly one writer, got %d (use BootstrapEncryption for multi-writer batches)",
 			len(writers))
 	}
 	w := writers[0]

--- a/adapter/encryption_admin.go
+++ b/adapter/encryption_admin.go
@@ -496,7 +496,6 @@ func proposeErrorToStatus(err error, opcode byte) error {
 //     ResyncSidecar against stale local state. Without this,
 //     a follower's recovery flow could pull an outdated DEK
 //     set from a stranded leader and miss recent rotations.
-//     Codex P1 round-2 finding on PR #756.
 func (s *EncryptionAdminServer) requireLeader(ctx context.Context) error {
 	if s.leaderView == nil {
 		return nil
@@ -521,8 +520,7 @@ func (s *EncryptionAdminServer) requireLeader(ctx context.Context) error {
 // client-side timeout during the ReadIndex round-trip surfaces as
 // codes.DeadlineExceeded (the retryable transport-timing
 // semantics) rather than codes.FailedPrecondition (which the
-// client would treat as a leadership rejection). Codex P1 round-4
-// finding on PR #756.
+// client would treat as a leadership rejection).
 func verifyLeaderErrorToStatus(err error) error {
 	switch {
 	case errors.Is(err, context.Canceled):

--- a/adapter/encryption_admin.go
+++ b/adapter/encryption_admin.go
@@ -387,7 +387,13 @@ func (s *EncryptionAdminServer) RegisterEncryptionWriter(ctx context.Context, re
 		return nil, grpcStatusError(codes.InvalidArgument, "encryption: dek_id must be non-zero (key id 0 is reserved per §5.1)")
 	}
 	writers := req.GetWriters()
-	if len(writers) != 1 {
+	switch len(writers) {
+	case 1:
+		// expected shape; fall through to validation + propose.
+	case 0:
+		return nil, grpcStatusError(codes.InvalidArgument,
+			"encryption: RegisterEncryptionWriter requires exactly one writer, got 0")
+	default:
 		return nil, grpcStatusErrorf(codes.InvalidArgument,
 			"encryption: RegisterEncryptionWriter requires exactly one writer in PR-B, got %d (use BootstrapEncryption for multi-writer batches)",
 			len(writers))

--- a/adapter/encryption_admin.go
+++ b/adapter/encryption_admin.go
@@ -511,10 +511,30 @@ func (s *EncryptionAdminServer) requireLeader(ctx context.Context) error {
 			leader.ID, leader.Address)
 	}
 	if err := s.leaderView.VerifyLeader(ctx); err != nil {
+		return verifyLeaderErrorToStatus(err)
+	}
+	return nil
+}
+
+// verifyLeaderErrorToStatus maps LeaderView.VerifyLeader errors to
+// gRPC status codes. Mirrors proposeErrorToStatus so that a
+// client-side timeout during the ReadIndex round-trip surfaces as
+// codes.DeadlineExceeded (the retryable transport-timing
+// semantics) rather than codes.FailedPrecondition (which the
+// client would treat as a leadership rejection). Codex P1 round-4
+// finding on PR #756.
+func verifyLeaderErrorToStatus(err error) error {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return grpcStatusErrorf(codes.Canceled,
+			"encryption: VerifyLeader canceled: %v", err)
+	case errors.Is(err, context.DeadlineExceeded):
+		return grpcStatusErrorf(codes.DeadlineExceeded,
+			"encryption: VerifyLeader deadline exceeded: %v", err)
+	default:
 		return grpcStatusErrorf(codes.FailedPrecondition,
 			"encryption: VerifyLeader failed, refusing to act on stale-leader state: %v", err)
 	}
-	return nil
 }
 
 func protoRotatePurpose(p pb.RotateDEKRequest_Purpose) (fsmwire.Purpose, error) {

--- a/adapter/encryption_admin.go
+++ b/adapter/encryption_admin.go
@@ -13,7 +13,6 @@ import (
 	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
 	"github.com/bootjp/elastickv/internal/raftengine"
 	pb "github.com/bootjp/elastickv/proto"
-	pkgerrors "github.com/cockroachdb/errors"
 	"google.golang.org/grpc/codes"
 )
 
@@ -341,6 +340,14 @@ func (s *EncryptionAdminServer) RotateDEK(ctx context.Context, req *pb.RotateDEK
 			"encryption: proposer_local_epoch=%d exceeds the §4.1 16-bit bound (max 0xFFFF)",
 			req.GetProposerLocalEpoch())
 	}
+	if req.GetProposerNodeId() == 0 {
+		// §6.1 reserves full_node_id=0 as the "not encryption-capable"
+		// sentinel. Forwarding 0 into a writer-registry row would
+		// collide with every other un-bootstrapped node's sentinel
+		// and break the §4.1 nonce-uniqueness invariant.
+		return nil, grpcStatusError(codes.InvalidArgument,
+			"encryption: proposer_node_id must be non-zero (0 is reserved as the §6.1 not-capable sentinel)")
+	}
 	payload := fsmwire.RotationPayload{
 		SubTag:  fsmwire.RotateSubRotateDEK,
 		DEKID:   req.GetNewDekId(),
@@ -391,6 +398,11 @@ func (s *EncryptionAdminServer) RegisterEncryptionWriter(ctx context.Context, re
 			"encryption: writers[0].local_epoch=%d exceeds the §4.1 16-bit bound (max 0xFFFF)",
 			w.GetLocalEpoch())
 	}
+	if w.GetFullNodeId() == 0 {
+		// Same §6.1 sentinel rule as RotateDEK.proposer_node_id.
+		return nil, grpcStatusError(codes.InvalidArgument,
+			"encryption: writers[0].full_node_id must be non-zero (0 is reserved as the §6.1 not-capable sentinel)")
+	}
 	payload := fsmwire.RegistrationPayload{
 		DEKID:      req.GetDekId(),
 		FullNodeID: w.GetFullNodeId(),
@@ -416,17 +428,44 @@ func (s *EncryptionAdminServer) proposeEncryptionEntry(ctx context.Context, opco
 	entry = append(entry, body...)
 	res, err := s.proposer.Propose(ctx, entry)
 	if err != nil {
-		// Raft-engine errors are operator-visible diagnostics:
-		// not-leader / context-canceled / propose-queue full all
-		// surface here. We surface the engine's error rather
-		// than rewriting it so the operator can grep against
-		// the engine's own logs.
-		return 0, pkgerrors.Wrapf(err, "encryption: propose 0x%02x", opcode)
+		return 0, proposeErrorToStatus(err, opcode)
 	}
 	if res == nil {
 		return 0, grpcStatusError(codes.Internal, "encryption: proposer returned nil result")
 	}
 	return res.CommitIndex, nil
+}
+
+// proposeErrorToStatus maps raftengine.Proposer.Propose errors to
+// gRPC status codes so clients see structured retry semantics
+// instead of the default codes.Unknown:
+//
+//   - Leadership lost between requireLeader() and Propose, or a
+//     leadership transfer raced the call → FailedPrecondition.
+//     The client retries against the new leader, same shape as
+//     the up-front requireLeader() rejection.
+//   - Context errors (caller canceled / deadline elapsed) →
+//     Canceled / DeadlineExceeded so the client does not retry a
+//     genuinely-aborted call.
+//   - Anything else (engine closed, propose-queue full, etc.) →
+//     Unavailable, the standard "transient, retryable" code.
+func proposeErrorToStatus(err error, opcode byte) error {
+	switch {
+	case errors.Is(err, raftengine.ErrNotLeader),
+		errors.Is(err, raftengine.ErrLeadershipLost),
+		errors.Is(err, raftengine.ErrLeadershipTransferInProgress):
+		return grpcStatusErrorf(codes.FailedPrecondition,
+			"encryption: propose 0x%02x rejected by raft engine: %v", opcode, err)
+	case errors.Is(err, context.Canceled):
+		return grpcStatusErrorf(codes.Canceled,
+			"encryption: propose 0x%02x canceled: %v", opcode, err)
+	case errors.Is(err, context.DeadlineExceeded):
+		return grpcStatusErrorf(codes.DeadlineExceeded,
+			"encryption: propose 0x%02x deadline exceeded: %v", opcode, err)
+	default:
+		return grpcStatusErrorf(codes.Unavailable,
+			"encryption: propose 0x%02x failed: %v", opcode, err)
+	}
 }
 
 // requireLeader rejects on followers with FailedPrecondition. The

--- a/adapter/encryption_admin.go
+++ b/adapter/encryption_admin.go
@@ -4,26 +4,35 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"math"
 	"os"
 	"runtime/debug"
 	"strconv"
 
 	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
+	"github.com/bootjp/elastickv/internal/raftengine"
 	pb "github.com/bootjp/elastickv/proto"
+	pkgerrors "github.com/cockroachdb/errors"
 	"google.golang.org/grpc/codes"
 )
 
-// EncryptionAdminServer implements proto.EncryptionAdmin. PR-A (Stage 5
-// foundation) wires only the read-only capability and state probes
-// plus ResyncSidecar; the Bootstrap / Rotate / Register RPCs return
-// Unimplemented until PR-B lands the leader-side propose path on top
-// of Stage 3's raft envelope and Stage 4's fsmwire bodies.
+// EncryptionAdminServer implements proto.EncryptionAdmin. PR-A
+// (Stage 5 foundation) wired the read-only capability and state
+// probes; PR-B (this slice) wires RotateDEK +
+// RegisterEncryptionWriter as leader-only proposers on top of
+// Stage 3's raft envelope and Stage 4's fsmwire bodies, plus the
+// leader guard on ResyncSidecar. BootstrapEncryption stays
+// Unimplemented until PR-C lands the §5.6 step 1a capability
+// fan-out.
 type EncryptionAdminServer struct {
 	sidecarPath        string
 	keystore           *encryption.Keystore
 	fullNodeID         uint64
 	buildSHA           string
 	latestAppliedIndex func() uint64
+	proposer           raftengine.Proposer
+	leaderView         raftengine.LeaderView
 	pb.UnimplementedEncryptionAdminServer
 }
 
@@ -80,6 +89,29 @@ func WithEncryptionAdminBuildSHA(sha string) EncryptionAdminServerOption {
 func WithEncryptionAdminLatestAppliedIndex(fn func() uint64) EncryptionAdminServerOption {
 	return func(s *EncryptionAdminServer) {
 		s.latestAppliedIndex = fn
+	}
+}
+
+// WithEncryptionAdminProposer registers the raftengine.Proposer the
+// server uses to propose the §11.3 0x03 / 0x04 / 0x05 entries
+// (Stage 4 wire format). An unset proposer makes every mutating
+// RPC return FailedPrecondition with "proposer not configured",
+// preserving the PR-A production-inert guarantee until Stage 6
+// flips the cluster flag.
+func WithEncryptionAdminProposer(p raftengine.Proposer) EncryptionAdminServerOption {
+	return func(s *EncryptionAdminServer) {
+		s.proposer = p
+	}
+}
+
+// WithEncryptionAdminLeaderView registers the leadership oracle.
+// Mutating RPCs and ResyncSidecar reject on followers with
+// FailedPrecondition; the leader's id and address are embedded in
+// the status detail so the operator's CLI can retry against the
+// right node without parsing free-form error text.
+func WithEncryptionAdminLeaderView(v raftengine.LeaderView) EncryptionAdminServerOption {
+	return func(s *EncryptionAdminServer) {
+		s.leaderView = v
 	}
 }
 
@@ -188,10 +220,17 @@ func (s *EncryptionAdminServer) GetSidecarState(_ context.Context, _ *pb.Empty) 
 // guard so a follower with a stale sidecar cannot poison the
 // recovery path of a peer with an even-staler sidecar.
 func (s *EncryptionAdminServer) ResyncSidecar(_ context.Context, req *pb.ResyncSidecarRequest) (*pb.ResyncSidecarResponse, error) {
-	// req.CallerFullNodeId is intentionally unused in PR-A; PR-B
-	// will read it from the leader-only guard to scope the
-	// writer-registry projection to that specific caller per §5.5.
+	// req.CallerFullNodeId is intentionally unused for the
+	// recovery payload itself in PR-B; Stage 7 will use it to
+	// scope the writer-registry projection to that specific
+	// caller per §5.5. Recording it here keeps the field on the
+	// hot path so a future leader-side audit log can correlate
+	// resyncs to the requesting member without a wire-format
+	// change.
 	_ = req
+	if err := s.requireLeader(); err != nil {
+		return nil, err
+	}
 	if s.sidecarPath == "" {
 		return nil, grpcStatusError(codes.FailedPrecondition, "encryption: sidecar path is not configured on this node")
 	}
@@ -271,6 +310,180 @@ func statusFromSidecarErr(err error) error {
 	default:
 		return grpcStatusErrorf(codes.Internal, "encryption: read sidecar: %v", err)
 	}
+}
+
+// RotateDEK proposes a §5.2 rotation as a §11.3 0x05 OpRotation
+// entry. The server validates purpose / dek_id / local_epoch
+// boundaries at the gRPC boundary (the §6.1 doc rule for
+// local_epoch <= 0xFFFF on the wire) and the FSM apply layer
+// enforces the sidecar-level invariants (no rotation while a
+// previous rotation is in flight, etc). Returns the commit index
+// once the entry is durable on a Raft quorum.
+func (s *EncryptionAdminServer) RotateDEK(ctx context.Context, req *pb.RotateDEKRequest) (*pb.RotateDEKResponse, error) {
+	if err := s.requireLeader(); err != nil {
+		return nil, err
+	}
+	if s.proposer == nil {
+		return nil, grpcStatusError(codes.FailedPrecondition, "encryption: proposer is not configured on this node")
+	}
+	purpose, err := protoRotatePurpose(req.GetPurpose())
+	if err != nil {
+		return nil, err
+	}
+	if req.GetNewDekId() == 0 {
+		return nil, grpcStatusError(codes.InvalidArgument, "encryption: new_dek_id must be non-zero (key id 0 is reserved per §5.1)")
+	}
+	if len(req.GetWrappedNewDek()) == 0 {
+		return nil, grpcStatusError(codes.InvalidArgument, "encryption: wrapped_new_dek is required")
+	}
+	if req.GetProposerLocalEpoch() > math.MaxUint16 {
+		return nil, grpcStatusErrorf(codes.InvalidArgument,
+			"encryption: proposer_local_epoch=%d exceeds the §4.1 16-bit bound (max 0xFFFF)",
+			req.GetProposerLocalEpoch())
+	}
+	payload := fsmwire.RotationPayload{
+		SubTag:  fsmwire.RotateSubRotateDEK,
+		DEKID:   req.GetNewDekId(),
+		Purpose: purpose,
+		Wrapped: req.GetWrappedNewDek(),
+		ProposerRegistration: fsmwire.RegistrationPayload{
+			DEKID:      req.GetNewDekId(),
+			FullNodeID: req.GetProposerNodeId(),
+			LocalEpoch: uint32ToLocalEpoch(req.GetProposerLocalEpoch()),
+		},
+	}
+	body := fsmwire.EncodeRotation(payload)
+	idx, err := s.proposeEncryptionEntry(ctx, fsmwire.OpRotation, body)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.RotateDEKResponse{AppliedIndex: idx}, nil
+}
+
+// RegisterEncryptionWriter proposes a §11.3 0x03 OpRegistration
+// entry for the calling node's first encrypted-write epoch under
+// the supplied dek_id. The proto carries `repeated WriterBatch`
+// for forward-compatibility, but each PR-B call MUST provide
+// exactly one entry; batched registrations belong to the §5.6
+// step 1a bootstrap path (deferred to PR-C). The server enforces
+// the single-entry contract here so an operator who accidentally
+// fans out a batched RegisterEncryptionWriter does not silently
+// propose a fraction of it.
+func (s *EncryptionAdminServer) RegisterEncryptionWriter(ctx context.Context, req *pb.RegisterEncryptionWriterRequest) (*pb.RegisterEncryptionWriterResponse, error) {
+	if err := s.requireLeader(); err != nil {
+		return nil, err
+	}
+	if s.proposer == nil {
+		return nil, grpcStatusError(codes.FailedPrecondition, "encryption: proposer is not configured on this node")
+	}
+	if req.GetDekId() == 0 {
+		return nil, grpcStatusError(codes.InvalidArgument, "encryption: dek_id must be non-zero (key id 0 is reserved per §5.1)")
+	}
+	writers := req.GetWriters()
+	if len(writers) != 1 {
+		return nil, grpcStatusErrorf(codes.InvalidArgument,
+			"encryption: RegisterEncryptionWriter requires exactly one writer in PR-B, got %d (use BootstrapEncryption for multi-writer batches)",
+			len(writers))
+	}
+	w := writers[0]
+	if w.GetLocalEpoch() > math.MaxUint16 {
+		return nil, grpcStatusErrorf(codes.InvalidArgument,
+			"encryption: writers[0].local_epoch=%d exceeds the §4.1 16-bit bound (max 0xFFFF)",
+			w.GetLocalEpoch())
+	}
+	payload := fsmwire.RegistrationPayload{
+		DEKID:      req.GetDekId(),
+		FullNodeID: w.GetFullNodeId(),
+		LocalEpoch: uint32ToLocalEpoch(w.GetLocalEpoch()),
+	}
+	body := fsmwire.EncodeRegistration(payload)
+	idx, err := s.proposeEncryptionEntry(ctx, fsmwire.OpRegistration, body)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.RegisterEncryptionWriterResponse{AppliedIndex: idx}, nil
+}
+
+// proposeEncryptionEntry prepends the §11.3 opcode tag to a
+// fsmwire-encoded body and submits the resulting Raft entry. The
+// Stage 4 FSM apply path peels the tag, dispatches into
+// applyEncryption, and Halt-Applies on any decode failure — this
+// helper is just the byte-level glue between the server-side
+// encoder and raftengine.Proposer.
+func (s *EncryptionAdminServer) proposeEncryptionEntry(ctx context.Context, opcode byte, body []byte) (uint64, error) {
+	entry := make([]byte, 0, 1+len(body))
+	entry = append(entry, opcode)
+	entry = append(entry, body...)
+	res, err := s.proposer.Propose(ctx, entry)
+	if err != nil {
+		// Raft-engine errors are operator-visible diagnostics:
+		// not-leader / context-canceled / propose-queue full all
+		// surface here. We surface the engine's error rather
+		// than rewriting it so the operator can grep against
+		// the engine's own logs.
+		return 0, pkgerrors.Wrapf(err, "encryption: propose 0x%02x", opcode)
+	}
+	if res == nil {
+		return 0, grpcStatusError(codes.Internal, "encryption: proposer returned nil result")
+	}
+	return res.CommitIndex, nil
+}
+
+// requireLeader rejects on followers with FailedPrecondition. The
+// status detail embeds the currently-known leader's id and
+// address so the operator's CLI can re-target without parsing
+// free-form error text. A nil leaderView is allowed for tests
+// that exercise the proposer wiring directly; the production
+// wiring in main.go MUST register one.
+func (s *EncryptionAdminServer) requireLeader() error {
+	if s.leaderView == nil {
+		return nil
+	}
+	if s.leaderView.State() == raftengine.StateLeader {
+		return nil
+	}
+	leader := s.leaderView.Leader()
+	if leader.ID == "" && leader.Address == "" {
+		return grpcStatusError(codes.FailedPrecondition, "encryption: not leader (no known leader)")
+	}
+	return grpcStatusErrorf(codes.FailedPrecondition,
+		"encryption: not leader (current leader id=%q address=%q)",
+		leader.ID, leader.Address)
+}
+
+func protoRotatePurpose(p pb.RotateDEKRequest_Purpose) (fsmwire.Purpose, error) {
+	switch p {
+	case pb.RotateDEKRequest_PURPOSE_STORAGE:
+		return fsmwire.PurposeStorage, nil
+	case pb.RotateDEKRequest_PURPOSE_RAFT:
+		return fsmwire.PurposeRaft, nil
+	case pb.RotateDEKRequest_PURPOSE_UNSPECIFIED:
+		// Proto3 default value — caller forgot to set purpose.
+		// Falls into the same InvalidArgument as an out-of-range
+		// value below; spelled out separately so the exhaustive
+		// linter does not flag this switch.
+		return 0, grpcStatusError(codes.InvalidArgument,
+			"encryption: purpose must be PURPOSE_STORAGE or PURPOSE_RAFT, got PURPOSE_UNSPECIFIED")
+	default:
+		return 0, grpcStatusErrorf(codes.InvalidArgument,
+			"encryption: purpose must be PURPOSE_STORAGE or PURPOSE_RAFT, got %v", p)
+	}
+}
+
+// uint32ToLocalEpoch narrows a wire-format uint32 local_epoch to
+// its on-disk uint16 representation. Callers MUST have rejected
+// values > math.MaxUint16 first; the mask is a defence-in-depth
+// truncation that cannot drift even if a future caller skips the
+// bound check. gosec's G115 cannot see the prior validation
+// because it lives at the gRPC handler boundary; the nolint here
+// is scoped to this single conversion site so callsite drift is
+// impossible.
+// localEpochMask is the §4.1 16-bit nonce mask. Named here so the
+// magic-number linter does not flag the masking conversion below.
+const localEpochMask uint32 = 0xFFFF
+
+func uint32ToLocalEpoch(v uint32) uint16 {
+	return uint16(v & localEpochMask) //nolint:gosec // bound-checked + masked; G115 cannot trace across the handler boundary
 }
 
 func autoBuildSHA() string {

--- a/adapter/encryption_admin.go
+++ b/adapter/encryption_admin.go
@@ -50,9 +50,11 @@ func WithEncryptionAdminSidecarPath(path string) EncryptionAdminServerOption {
 }
 
 // WithEncryptionAdminKeystore lets the server consult the in-memory
-// keystore for the §5.5 fallback paths. Stage 5 PR-A does not require
-// it because ReadSidecar covers every field the read-only RPCs need.
-// PR-B will use it to fast-path the RotateDEK pre-check.
+// keystore for the §5.5 fallback paths. Stage 5 PR-A / PR-B do not
+// require it because ReadSidecar covers every field the read-only
+// RPCs need and RotateDEK relies on FSM-side validation rather
+// than a pre-check. Stage 7 (writer registry) will use it for the
+// in-memory counter fast-path.
 func WithEncryptionAdminKeystore(k *encryption.Keystore) EncryptionAdminServerOption {
 	return func(s *EncryptionAdminServer) {
 		s.keystore = k

--- a/adapter/encryption_admin_test.go
+++ b/adapter/encryption_admin_test.go
@@ -112,10 +112,12 @@ func TestEncryptionAdmin_GetCapability_Bootstrapped(t *testing.T) {
 		t.Errorf("SidecarPresent=false, want true")
 	}
 	if got.LocalEpoch != 0 {
-		// PR-A always reports local_epoch=0; Stage 7 will wire the
-		// writer-registry counter. The cutover pre-check uses 0
-		// because no DEK exists yet at bootstrap time.
-		t.Errorf("LocalEpoch=%d, want 0 in PR-A", got.LocalEpoch)
+		// Stage 5 reports local_epoch=0 unconditionally; Stage 7
+		// wires the writer-registry counter so the cutover
+		// pre-check captures the per-node value. The §5.6 step
+		// 1a flow tolerates 0 here because no DEK exists yet at
+		// bootstrap time.
+		t.Errorf("LocalEpoch=%d, want 0 pre-Stage-7", got.LocalEpoch)
 	}
 }
 
@@ -520,6 +522,41 @@ func TestEncryptionAdmin_ResyncSidecar_RejectsStaleLeader(t *testing.T) {
 	_, err := srv.ResyncSidecar(context.Background(), &pb.ResyncSidecarRequest{})
 	if status.Code(err) != codes.FailedPrecondition {
 		t.Errorf("ResyncSidecar status=%v, want FailedPrecondition on stale-leader", status.Code(err))
+	}
+}
+
+// TestEncryptionAdmin_RotateDEK_VerifyLeader_PreservesContextCodes
+// pins the PR756 codex round-4 P1 regression: when VerifyLeader
+// returns context.Canceled / context.DeadlineExceeded (the
+// caller's ctx was canceled or the deadline elapsed during the
+// ReadIndex round-trip), requireLeader MUST surface the matching
+// codes.Canceled / codes.DeadlineExceeded — NOT a flat
+// FailedPrecondition that would make a transport timeout look
+// like a leadership rejection.
+func TestEncryptionAdmin_RotateDEK_VerifyLeader_PreservesContextCodes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want codes.Code
+	}{
+		{"context.Canceled", context.Canceled, codes.Canceled},
+		{"context.DeadlineExceeded", context.DeadlineExceeded, codes.DeadlineExceeded},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			srv := NewEncryptionAdminServer(
+				WithEncryptionAdminProposer(&recordingProposer{}),
+				WithEncryptionAdminLeaderView(stubLeaderView{
+					state:     raftengine.StateLeader,
+					verifyErr: c.err,
+				}),
+			)
+			_, err := srv.RotateDEK(context.Background(), validRotateDEKRequest())
+			if got := status.Code(err); got != c.want {
+				t.Errorf("RotateDEK status=%v, want %v for VerifyLeader=%v", got, c.want, c.err)
+			}
+		})
 	}
 }
 

--- a/adapter/encryption_admin_test.go
+++ b/adapter/encryption_admin_test.go
@@ -214,7 +214,14 @@ func TestEncryptionAdmin_ResyncSidecar_ShipsWrappedDEKs(t *testing.T) {
 			"4": {Purpose: "raft", Wrapped: []byte("wr")},
 		},
 	})
-	srv := NewEncryptionAdminServer(WithEncryptionAdminSidecarPath(path))
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminSidecarPath(path),
+		// Wire a leader-stable LeaderView so the happy path
+		// exercises State()==StateLeader && VerifyLeader()==nil
+		// end-to-end rather than short-circuiting through the
+		// nil-leaderView test escape hatch.
+		WithEncryptionAdminLeaderView(stubLeaderView{state: raftengine.StateLeader}),
+	)
 	got, err := srv.ResyncSidecar(context.Background(), &pb.ResyncSidecarRequest{CallerFullNodeId: 5})
 	if err != nil {
 		t.Fatalf("ResyncSidecar: %v", err)

--- a/adapter/encryption_admin_test.go
+++ b/adapter/encryption_admin_test.go
@@ -465,6 +465,57 @@ func TestEncryptionAdmin_RegisterEncryptionWriter_RejectsZeroFullNodeID(t *testi
 	}
 }
 
+// TestEncryptionAdmin_RotateDEK_RejectsStaleLeader pins the
+// PR756 codex P1 (round-2) regression: a partitioned former
+// leader whose local State() still reports StateLeader but
+// whose VerifyLeader fails (no quorum) must reject mutating
+// RPCs with FailedPrecondition. Without this, a stranded leader
+// would accept proposals that may never replicate.
+func TestEncryptionAdmin_RotateDEK_RejectsStaleLeader(t *testing.T) {
+	t.Parallel()
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminProposer(&recordingProposer{}),
+		WithEncryptionAdminLeaderView(stubLeaderView{
+			state:     raftengine.StateLeader,
+			verifyErr: errors.New("synthetic quorum loss"),
+		}),
+	)
+	_, err := srv.RotateDEK(context.Background(), validRotateDEKRequest())
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("RotateDEK status=%v, want FailedPrecondition on stale-leader (VerifyLeader failure)", status.Code(err))
+	}
+	if err == nil || !strings.Contains(err.Error(), "VerifyLeader") {
+		t.Errorf("error %q does not surface the VerifyLeader failure path", err)
+	}
+}
+
+// TestEncryptionAdmin_ResyncSidecar_RejectsStaleLeader is the
+// read-only path twin of the above. ResyncSidecar has no
+// Propose() to catch leadership loss, so VerifyLeader is the
+// only defence between a follower's recovery flow and a stale
+// leader's outdated sidecar contents.
+func TestEncryptionAdmin_ResyncSidecar_RejectsStaleLeader(t *testing.T) {
+	t.Parallel()
+	path := writeSidecarFixture(t, &encryption.Sidecar{
+		Active: encryption.ActiveKeys{Storage: 1, Raft: 2},
+		Keys: map[string]encryption.SidecarKey{
+			"1": {Purpose: "storage", Wrapped: []byte("w")},
+			"2": {Purpose: "raft", Wrapped: []byte("w")},
+		},
+	})
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminSidecarPath(path),
+		WithEncryptionAdminLeaderView(stubLeaderView{
+			state:     raftengine.StateLeader,
+			verifyErr: errors.New("synthetic quorum loss"),
+		}),
+	)
+	_, err := srv.ResyncSidecar(context.Background(), &pb.ResyncSidecarRequest{})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("ResyncSidecar status=%v, want FailedPrecondition on stale-leader", status.Code(err))
+	}
+}
+
 // TestEncryptionAdmin_RotateDEK_MapsProposeLeaderErrorToFailedPrecondition
 // pins the PR756 codex P1 regression: Propose() returning
 // ErrNotLeader / ErrLeadershipLost / ErrLeadershipTransferInProgress
@@ -628,18 +679,22 @@ func (p *recordingProposer) Propose(_ context.Context, data []byte) (*raftengine
 	return &raftengine.ProposalResult{CommitIndex: p.commitIndex}, nil
 }
 
-// stubLeaderView reports a fixed leadership state. The
-// LinearizableRead / VerifyLeader methods are not exercised by
-// EncryptionAdminServer in PR-B; they return zero values to
-// satisfy the interface.
+// stubLeaderView reports a fixed leadership state. verifyErr lets
+// a test simulate a partitioned former leader: State() still
+// reports StateLeader but VerifyLeader returns an error because
+// the local node cannot confirm leadership via a quorum
+// ReadIndex round-trip.
 type stubLeaderView struct {
-	state  raftengine.State
-	leader raftengine.LeaderInfo
+	state     raftengine.State
+	leader    raftengine.LeaderInfo
+	verifyErr error
 }
 
-func (s stubLeaderView) State() raftengine.State            { return s.state }
-func (s stubLeaderView) Leader() raftengine.LeaderInfo      { return s.leader }
-func (s stubLeaderView) VerifyLeader(context.Context) error { return nil }
+func (s stubLeaderView) State() raftengine.State       { return s.state }
+func (s stubLeaderView) Leader() raftengine.LeaderInfo { return s.leader }
+func (s stubLeaderView) VerifyLeader(context.Context) error {
+	return s.verifyErr
+}
 func (s stubLeaderView) LinearizableRead(context.Context) (uint64, error) {
 	return 0, nil
 }

--- a/adapter/encryption_admin_test.go
+++ b/adapter/encryption_admin_test.go
@@ -3,9 +3,12 @@ package adapter
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
+	"github.com/bootjp/elastickv/internal/raftengine"
 	pb "github.com/bootjp/elastickv/proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -235,19 +238,268 @@ func TestEncryptionAdmin_ResyncSidecar_ShipsWrappedDEKs(t *testing.T) {
 	}
 }
 
-func TestEncryptionAdmin_MutatingRPCs_AreUnimplemented(t *testing.T) {
+// TestEncryptionAdmin_BootstrapEncryption_Unimplemented pins the
+// PR-B contract that BootstrapEncryption is still un-wired and
+// returns Unimplemented. PR-C will replace this with positive
+// tests once the §5.6 step 1a capability fan-out lands.
+func TestEncryptionAdmin_BootstrapEncryption_Unimplemented(t *testing.T) {
 	t.Parallel()
 	srv := NewEncryptionAdminServer()
 	ctx := context.Background()
 	if _, err := srv.BootstrapEncryption(ctx, &pb.BootstrapEncryptionRequest{}); status.Code(err) != codes.Unimplemented {
 		t.Errorf("BootstrapEncryption status=%v, want Unimplemented", status.Code(err))
 	}
-	if _, err := srv.RotateDEK(ctx, &pb.RotateDEKRequest{}); status.Code(err) != codes.Unimplemented {
-		t.Errorf("RotateDEK status=%v, want Unimplemented", status.Code(err))
+}
+
+// TestEncryptionAdmin_MutatingRPCs_RejectWithoutProposer pins the
+// PR-A production-inert guarantee: an EncryptionAdminServer built
+// without WithEncryptionAdminProposer must reject every mutating
+// RPC. The §6.5 cluster flag (Stage 6) is what flips this on by
+// wiring a real proposer.
+func TestEncryptionAdmin_MutatingRPCs_RejectWithoutProposer(t *testing.T) {
+	t.Parallel()
+	srv := NewEncryptionAdminServer()
+	ctx := context.Background()
+	if _, err := srv.RotateDEK(ctx, validRotateDEKRequest()); status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("RotateDEK status=%v, want FailedPrecondition (no proposer wired)", status.Code(err))
 	}
-	if _, err := srv.RegisterEncryptionWriter(ctx, &pb.RegisterEncryptionWriterRequest{}); status.Code(err) != codes.Unimplemented {
-		t.Errorf("RegisterEncryptionWriter status=%v, want Unimplemented", status.Code(err))
+	if _, err := srv.RegisterEncryptionWriter(ctx, validRegisterEncryptionWriterRequest()); status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("RegisterEncryptionWriter status=%v, want FailedPrecondition (no proposer wired)", status.Code(err))
 	}
+}
+
+func validRotateDEKRequest() *pb.RotateDEKRequest {
+	return &pb.RotateDEKRequest{
+		Purpose:            pb.RotateDEKRequest_PURPOSE_STORAGE,
+		NewDekId:           5,
+		WrappedNewDek:      []byte("wrapped-bytes"),
+		ProposerNodeId:     11,
+		ProposerLocalEpoch: 7,
+	}
+}
+
+func validRegisterEncryptionWriterRequest() *pb.RegisterEncryptionWriterRequest {
+	return &pb.RegisterEncryptionWriterRequest{
+		DekId: 5,
+		Writers: []*pb.WriterRegistryEntry{
+			{FullNodeId: 11, LocalEpoch: 7},
+		},
+	}
+}
+
+// TestEncryptionAdmin_RotateDEK_HappyPath verifies the byte layout
+// of the proposed Raft entry: leading opcode tag 0x05 followed by
+// the fsmwire-encoded body produced by fsmwire.EncodeRotation.
+// Pins the wire so a future refactor of either the server or
+// fsmwire cannot silently desync.
+func TestEncryptionAdmin_RotateDEK_HappyPath(t *testing.T) {
+	t.Parallel()
+	proposer := &recordingProposer{commitIndex: 99}
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminProposer(proposer),
+		WithEncryptionAdminLeaderView(stubLeaderView{state: raftengine.StateLeader}),
+	)
+	req := validRotateDEKRequest()
+	got, err := srv.RotateDEK(context.Background(), req)
+	if err != nil {
+		t.Fatalf("RotateDEK: %v", err)
+	}
+	if got.AppliedIndex != 99 {
+		t.Errorf("AppliedIndex=%d, want 99", got.AppliedIndex)
+	}
+	assertSingleProposalOpcode(t, proposer.calls, fsmwire.OpRotation)
+	body := proposer.calls[0][1:]
+	decoded, err := fsmwire.DecodeRotation(body)
+	if err != nil {
+		t.Fatalf("DecodeRotation: %v", err)
+	}
+	assertRotationDecodes(t, decoded, req)
+}
+
+func assertSingleProposalOpcode(t *testing.T, calls [][]byte, want byte) {
+	t.Helper()
+	if len(calls) != 1 {
+		t.Fatalf("propose calls=%d, want 1", len(calls))
+	}
+	if len(calls[0]) == 0 || calls[0][0] != want {
+		t.Fatalf("entry[0]=0x%02x, want 0x%02x", calls[0][0], want)
+	}
+}
+
+func assertRotationDecodes(t *testing.T, got fsmwire.RotationPayload, req *pb.RotateDEKRequest) {
+	t.Helper()
+	if got.SubTag != fsmwire.RotateSubRotateDEK {
+		t.Errorf("SubTag=0x%02x, want RotateSubRotateDEK", got.SubTag)
+	}
+	if got.DEKID != req.NewDekId {
+		t.Errorf("DEKID=%d, want %d", got.DEKID, req.NewDekId)
+	}
+	if got.Purpose != fsmwire.PurposeStorage {
+		t.Errorf("Purpose=%v, want PurposeStorage", got.Purpose)
+	}
+	if string(got.Wrapped) != string(req.WrappedNewDek) {
+		t.Errorf("Wrapped=%q, want %q", got.Wrapped, req.WrappedNewDek)
+	}
+	if got.ProposerRegistration.DEKID != req.NewDekId ||
+		got.ProposerRegistration.FullNodeID != req.ProposerNodeId ||
+		uint32(got.ProposerRegistration.LocalEpoch) != req.ProposerLocalEpoch {
+		t.Errorf("ProposerRegistration=%+v does not match request (dek=%d node=%d epoch=%d)",
+			got.ProposerRegistration, req.NewDekId, req.ProposerNodeId, req.ProposerLocalEpoch)
+	}
+}
+
+func TestEncryptionAdmin_RotateDEK_RejectsOnFollower(t *testing.T) {
+	t.Parallel()
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminProposer(&recordingProposer{}),
+		WithEncryptionAdminLeaderView(stubLeaderView{
+			state:  raftengine.StateFollower,
+			leader: raftengine.LeaderInfo{ID: "n2", Address: "127.0.0.1:50052"},
+		}),
+	)
+	_, err := srv.RotateDEK(context.Background(), validRotateDEKRequest())
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("RotateDEK status=%v, want FailedPrecondition", status.Code(err))
+	}
+	if err == nil || !strings.Contains(err.Error(), "n2") || !strings.Contains(err.Error(), "127.0.0.1:50052") {
+		t.Errorf("error %q does not embed the leader hint (id=n2 addr=127.0.0.1:50052)", err)
+	}
+}
+
+func TestEncryptionAdmin_RotateDEK_RejectsBadInputs(t *testing.T) {
+	t.Parallel()
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminProposer(&recordingProposer{}),
+		WithEncryptionAdminLeaderView(stubLeaderView{state: raftengine.StateLeader}),
+	)
+	type tc struct {
+		name string
+		mut  func(r *pb.RotateDEKRequest)
+	}
+	for _, c := range []tc{
+		{"zero new_dek_id", func(r *pb.RotateDEKRequest) { r.NewDekId = 0 }},
+		{"empty wrapped", func(r *pb.RotateDEKRequest) { r.WrappedNewDek = nil }},
+		{"unspecified purpose", func(r *pb.RotateDEKRequest) { r.Purpose = pb.RotateDEKRequest_PURPOSE_UNSPECIFIED }},
+		{"local_epoch above 0xFFFF", func(r *pb.RotateDEKRequest) { r.ProposerLocalEpoch = 0x10000 }},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			req := validRotateDEKRequest()
+			c.mut(req)
+			_, err := srv.RotateDEK(context.Background(), req)
+			if status.Code(err) != codes.InvalidArgument {
+				t.Errorf("%s: status=%v, want InvalidArgument", c.name, status.Code(err))
+			}
+		})
+	}
+}
+
+func TestEncryptionAdmin_RegisterEncryptionWriter_HappyPath(t *testing.T) {
+	t.Parallel()
+	proposer := &recordingProposer{commitIndex: 42}
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminProposer(proposer),
+		WithEncryptionAdminLeaderView(stubLeaderView{state: raftengine.StateLeader}),
+	)
+	req := validRegisterEncryptionWriterRequest()
+	got, err := srv.RegisterEncryptionWriter(context.Background(), req)
+	if err != nil {
+		t.Fatalf("RegisterEncryptionWriter: %v", err)
+	}
+	if got.AppliedIndex != 42 {
+		t.Errorf("AppliedIndex=%d, want 42", got.AppliedIndex)
+	}
+	if len(proposer.calls) != 1 {
+		t.Fatalf("propose calls=%d, want 1", len(proposer.calls))
+	}
+	if proposer.calls[0][0] != fsmwire.OpRegistration {
+		t.Fatalf("entry[0]=0x%02x, want OpRegistration 0x03", proposer.calls[0][0])
+	}
+	got2, err := fsmwire.DecodeRegistration(proposer.calls[0][1:])
+	if err != nil {
+		t.Fatalf("DecodeRegistration: %v", err)
+	}
+	if got2.DEKID != req.DekId ||
+		got2.FullNodeID != req.Writers[0].FullNodeId ||
+		uint32(got2.LocalEpoch) != req.Writers[0].LocalEpoch {
+		t.Errorf("decoded registration %+v does not match request %+v", got2, req)
+	}
+}
+
+func TestEncryptionAdmin_RegisterEncryptionWriter_RejectsBatch(t *testing.T) {
+	t.Parallel()
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminProposer(&recordingProposer{}),
+		WithEncryptionAdminLeaderView(stubLeaderView{state: raftengine.StateLeader}),
+	)
+	req := &pb.RegisterEncryptionWriterRequest{
+		DekId: 5,
+		Writers: []*pb.WriterRegistryEntry{
+			{FullNodeId: 1, LocalEpoch: 1},
+			{FullNodeId: 2, LocalEpoch: 2},
+		},
+	}
+	_, err := srv.RegisterEncryptionWriter(context.Background(), req)
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("status=%v, want InvalidArgument", status.Code(err))
+	}
+}
+
+func TestEncryptionAdmin_ResyncSidecar_RejectsOnFollower(t *testing.T) {
+	t.Parallel()
+	path := writeSidecarFixture(t, &encryption.Sidecar{
+		Active: encryption.ActiveKeys{Storage: 1, Raft: 2},
+		Keys: map[string]encryption.SidecarKey{
+			"1": {Purpose: "storage", Wrapped: []byte("w")},
+			"2": {Purpose: "raft", Wrapped: []byte("w")},
+		},
+	})
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminSidecarPath(path),
+		WithEncryptionAdminLeaderView(stubLeaderView{
+			state:  raftengine.StateFollower,
+			leader: raftengine.LeaderInfo{ID: "n2", Address: "127.0.0.1:50052"},
+		}),
+	)
+	_, err := srv.ResyncSidecar(context.Background(), &pb.ResyncSidecarRequest{})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("ResyncSidecar status=%v, want FailedPrecondition on a follower", status.Code(err))
+	}
+}
+
+// recordingProposer captures every Propose call so tests can
+// inspect the proposed entry bytes. It is unsafe for parallel use
+// across goroutines but every test that uses it does so
+// single-threaded.
+type recordingProposer struct {
+	calls       [][]byte
+	commitIndex uint64
+	err         error
+}
+
+func (p *recordingProposer) Propose(_ context.Context, data []byte) (*raftengine.ProposalResult, error) {
+	dup := make([]byte, len(data))
+	copy(dup, data)
+	p.calls = append(p.calls, dup)
+	if p.err != nil {
+		return nil, p.err
+	}
+	return &raftengine.ProposalResult{CommitIndex: p.commitIndex}, nil
+}
+
+// stubLeaderView reports a fixed leadership state. The
+// LinearizableRead / VerifyLeader methods are not exercised by
+// EncryptionAdminServer in PR-B; they return zero values to
+// satisfy the interface.
+type stubLeaderView struct {
+	state  raftengine.State
+	leader raftengine.LeaderInfo
+}
+
+func (s stubLeaderView) State() raftengine.State            { return s.state }
+func (s stubLeaderView) Leader() raftengine.LeaderInfo      { return s.leader }
+func (s stubLeaderView) VerifyLeader(context.Context) error { return nil }
+func (s stubLeaderView) LinearizableRead(context.Context) (uint64, error) {
+	return 0, nil
 }
 
 // writeSidecarFixture builds a valid keys.json fixture in a tmpdir and

--- a/adapter/encryption_admin_test.go
+++ b/adapter/encryption_admin_test.go
@@ -510,6 +510,63 @@ func TestEncryptionAdmin_RotateDEK_MapsProposeOtherErrorToUnavailable(t *testing
 	}
 }
 
+// TestEncryptionAdmin_RegisterEncryptionWriter_RejectsBadInputs is
+// the table-driven twin of TestEncryptionAdmin_RotateDEK_RejectsBadInputs
+// so the registration path's boundary validation has the same
+// pin-down as rotation's. Each entry mutates a single field on a
+// known-good request to isolate the failing branch.
+func TestEncryptionAdmin_RegisterEncryptionWriter_RejectsBadInputs(t *testing.T) {
+	t.Parallel()
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminProposer(&recordingProposer{}),
+		WithEncryptionAdminLeaderView(stubLeaderView{state: raftengine.StateLeader}),
+	)
+	type tc struct {
+		name string
+		mut  func(r *pb.RegisterEncryptionWriterRequest)
+	}
+	for _, c := range []tc{
+		{"zero dek_id", func(r *pb.RegisterEncryptionWriterRequest) { r.DekId = 0 }},
+		{"local_epoch above 0xFFFF", func(r *pb.RegisterEncryptionWriterRequest) { r.Writers[0].LocalEpoch = 0x10000 }},
+		{"zero full_node_id", func(r *pb.RegisterEncryptionWriterRequest) { r.Writers[0].FullNodeId = 0 }},
+		{"empty writers", func(r *pb.RegisterEncryptionWriterRequest) { r.Writers = nil }},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			req := validRegisterEncryptionWriterRequest()
+			c.mut(req)
+			_, err := srv.RegisterEncryptionWriter(context.Background(), req)
+			if status.Code(err) != codes.InvalidArgument {
+				t.Errorf("%s: status=%v, want InvalidArgument", c.name, status.Code(err))
+			}
+		})
+	}
+}
+
+// TestEncryptionAdmin_RegisterEncryptionWriter_EmptyWritersMessage
+// pins the PR756 claude[bot] P2 fix: a zero-length writers slice
+// returns a "got 0" message, not the misleading "use
+// BootstrapEncryption for multi-writer batches" text.
+func TestEncryptionAdmin_RegisterEncryptionWriter_EmptyWritersMessage(t *testing.T) {
+	t.Parallel()
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminProposer(&recordingProposer{}),
+		WithEncryptionAdminLeaderView(stubLeaderView{state: raftengine.StateLeader}),
+	)
+	_, err := srv.RegisterEncryptionWriter(context.Background(), &pb.RegisterEncryptionWriterRequest{
+		DekId:   5,
+		Writers: nil,
+	})
+	if err == nil {
+		t.Fatalf("RegisterEncryptionWriter returned nil, want InvalidArgument")
+	}
+	if !strings.Contains(err.Error(), "got 0") {
+		t.Errorf("error %q does not surface the 0-writer case", err)
+	}
+	if strings.Contains(err.Error(), "BootstrapEncryption") {
+		t.Errorf("error %q misroutes the operator to BootstrapEncryption for the 0-writer case", err)
+	}
+}
+
 func TestEncryptionAdmin_RegisterEncryptionWriter_RejectsBatch(t *testing.T) {
 	t.Parallel()
 	srv := NewEncryptionAdminServer(

--- a/adapter/encryption_admin_test.go
+++ b/adapter/encryption_admin_test.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -422,6 +423,90 @@ func TestEncryptionAdmin_RegisterEncryptionWriter_HappyPath(t *testing.T) {
 		got2.FullNodeID != req.Writers[0].FullNodeId ||
 		uint32(got2.LocalEpoch) != req.Writers[0].LocalEpoch {
 		t.Errorf("decoded registration %+v does not match request %+v", got2, req)
+	}
+}
+
+// TestEncryptionAdmin_RotateDEK_RejectsZeroProposerNodeID pins the
+// PR756 codex P1 regression: full_node_id=0 is the §6.1 sentinel
+// for "not encryption-capable" and must not be persisted into a
+// writer-registry row. Reject at the gRPC boundary with
+// InvalidArgument.
+func TestEncryptionAdmin_RotateDEK_RejectsZeroProposerNodeID(t *testing.T) {
+	t.Parallel()
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminProposer(&recordingProposer{}),
+		WithEncryptionAdminLeaderView(stubLeaderView{state: raftengine.StateLeader}),
+	)
+	req := validRotateDEKRequest()
+	req.ProposerNodeId = 0
+	_, err := srv.RotateDEK(context.Background(), req)
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("RotateDEK status=%v, want InvalidArgument (zero proposer_node_id is reserved)", status.Code(err))
+	}
+}
+
+// TestEncryptionAdmin_RegisterEncryptionWriter_RejectsZeroFullNodeID
+// is the twin regression test for the registration path.
+func TestEncryptionAdmin_RegisterEncryptionWriter_RejectsZeroFullNodeID(t *testing.T) {
+	t.Parallel()
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminProposer(&recordingProposer{}),
+		WithEncryptionAdminLeaderView(stubLeaderView{state: raftengine.StateLeader}),
+	)
+	req := &pb.RegisterEncryptionWriterRequest{
+		DekId: 5,
+		Writers: []*pb.WriterRegistryEntry{
+			{FullNodeId: 0, LocalEpoch: 1},
+		},
+	}
+	_, err := srv.RegisterEncryptionWriter(context.Background(), req)
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("RegisterEncryptionWriter status=%v, want InvalidArgument (zero full_node_id is reserved)", status.Code(err))
+	}
+}
+
+// TestEncryptionAdmin_RotateDEK_MapsProposeLeaderErrorToFailedPrecondition
+// pins the PR756 codex P1 regression: Propose() returning
+// ErrNotLeader / ErrLeadershipLost / ErrLeadershipTransferInProgress
+// must surface as FailedPrecondition with the engine error in the
+// status detail so clients can retry against the right node, NOT
+// as the default codes.Unknown that pkgerrors.Wrap would produce.
+func TestEncryptionAdmin_RotateDEK_MapsProposeLeaderErrorToFailedPrecondition(t *testing.T) {
+	t.Parallel()
+	for _, sentinel := range []error{
+		raftengine.ErrNotLeader,
+		raftengine.ErrLeadershipLost,
+		raftengine.ErrLeadershipTransferInProgress,
+	} {
+		t.Run(sentinel.Error(), func(t *testing.T) {
+			proposer := &recordingProposer{err: sentinel}
+			srv := NewEncryptionAdminServer(
+				WithEncryptionAdminProposer(proposer),
+				WithEncryptionAdminLeaderView(stubLeaderView{state: raftengine.StateLeader}),
+			)
+			_, err := srv.RotateDEK(context.Background(), validRotateDEKRequest())
+			if status.Code(err) != codes.FailedPrecondition {
+				t.Errorf("RotateDEK status=%v, want FailedPrecondition for %v", status.Code(err), sentinel)
+			}
+		})
+	}
+}
+
+// TestEncryptionAdmin_RotateDEK_MapsProposeOtherErrorToUnavailable
+// pins the PR756 codex P1 regression for the non-leadership
+// failure mode. A propose failure that is NOT a known leadership
+// sentinel surfaces as Unavailable (retryable transient failure)
+// instead of Unknown.
+func TestEncryptionAdmin_RotateDEK_MapsProposeOtherErrorToUnavailable(t *testing.T) {
+	t.Parallel()
+	proposer := &recordingProposer{err: errors.New("synthetic engine failure")}
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminProposer(proposer),
+		WithEncryptionAdminLeaderView(stubLeaderView{state: raftengine.StateLeader}),
+	)
+	_, err := srv.RotateDEK(context.Background(), validRotateDEKRequest())
+	if status.Code(err) != codes.Unavailable {
+		t.Errorf("RotateDEK status=%v, want Unavailable for non-leadership propose error", status.Code(err))
 	}
 }
 

--- a/adapter/encryption_admin_test.go
+++ b/adapter/encryption_admin_test.go
@@ -78,7 +78,7 @@ func TestEncryptionAdmin_GetCapability_NotBootstrapped(t *testing.T) {
 	// Active.Storage != 0. A pre-bootstrap capable node reports true
 	// so the bootstrap pre-check fan-out can proceed at all.
 	if !got.EncryptionCapable {
-		t.Errorf("EncryptionCapable=false, want true on a configured pre-bootstrap node (regression for PR754 P1)")
+		t.Errorf("EncryptionCapable=false, want true on a configured pre-bootstrap node")
 	}
 	if !got.SidecarPresent {
 		t.Errorf("SidecarPresent=false, want true when sidecar exists")
@@ -436,10 +436,9 @@ func TestEncryptionAdmin_RegisterEncryptionWriter_HappyPath(t *testing.T) {
 }
 
 // TestEncryptionAdmin_RotateDEK_RejectsZeroProposerNodeID pins the
-// PR756 codex P1 regression: full_node_id=0 is the §6.1 sentinel
-// for "not encryption-capable" and must not be persisted into a
-// writer-registry row. Reject at the gRPC boundary with
-// InvalidArgument.
+// §6.1 invariant that full_node_id=0 is the "not encryption-capable"
+// sentinel and must not be persisted into a writer-registry row.
+// Reject at the gRPC boundary with InvalidArgument.
 func TestEncryptionAdmin_RotateDEK_RejectsZeroProposerNodeID(t *testing.T) {
 	t.Parallel()
 	srv := NewEncryptionAdminServer(
@@ -475,10 +474,10 @@ func TestEncryptionAdmin_RegisterEncryptionWriter_RejectsZeroFullNodeID(t *testi
 }
 
 // TestEncryptionAdmin_RotateDEK_RejectsStaleLeader pins the
-// PR756 codex P1 (round-2) regression: a partitioned former
-// leader whose local State() still reports StateLeader but
-// whose VerifyLeader fails (no quorum) must reject mutating
-// RPCs with FailedPrecondition. Without this, a stranded leader
+// stale-leader invariant: a partitioned former leader whose
+// local State() still reports StateLeader but whose VerifyLeader
+// fails (no quorum) must reject mutating RPCs with
+// FailedPrecondition. Without this guard, a stranded leader
 // would accept proposals that may never replicate.
 func TestEncryptionAdmin_RotateDEK_RejectsStaleLeader(t *testing.T) {
 	t.Parallel()
@@ -526,10 +525,10 @@ func TestEncryptionAdmin_ResyncSidecar_RejectsStaleLeader(t *testing.T) {
 }
 
 // TestEncryptionAdmin_RotateDEK_VerifyLeader_PreservesContextCodes
-// pins the PR756 codex round-4 P1 regression: when VerifyLeader
-// returns context.Canceled / context.DeadlineExceeded (the
-// caller's ctx was canceled or the deadline elapsed during the
-// ReadIndex round-trip), requireLeader MUST surface the matching
+// pins the context-code mapping: when VerifyLeader returns
+// context.Canceled / context.DeadlineExceeded (the caller's ctx
+// was canceled or the deadline elapsed during the ReadIndex
+// round-trip), requireLeader MUST surface the matching
 // codes.Canceled / codes.DeadlineExceeded — NOT a flat
 // FailedPrecondition that would make a transport timeout look
 // like a leadership rejection.
@@ -561,11 +560,11 @@ func TestEncryptionAdmin_RotateDEK_VerifyLeader_PreservesContextCodes(t *testing
 }
 
 // TestEncryptionAdmin_RotateDEK_MapsProposeLeaderErrorToFailedPrecondition
-// pins the PR756 codex P1 regression: Propose() returning
+// pins the Propose-side leadership-error mapping: Propose() returning
 // ErrNotLeader / ErrLeadershipLost / ErrLeadershipTransferInProgress
 // must surface as FailedPrecondition with the engine error in the
 // status detail so clients can retry against the right node, NOT
-// as the default codes.Unknown that pkgerrors.Wrap would produce.
+// as the default codes.Unknown a generic wrap would produce.
 func TestEncryptionAdmin_RotateDEK_MapsProposeLeaderErrorToFailedPrecondition(t *testing.T) {
 	t.Parallel()
 	for _, sentinel := range []error{
@@ -588,9 +587,9 @@ func TestEncryptionAdmin_RotateDEK_MapsProposeLeaderErrorToFailedPrecondition(t 
 }
 
 // TestEncryptionAdmin_RotateDEK_MapsProposeOtherErrorToUnavailable
-// pins the PR756 codex P1 regression for the non-leadership
-// failure mode. A propose failure that is NOT a known leadership
-// sentinel surfaces as Unavailable (retryable transient failure)
+// pins the non-leadership failure-mode mapping. A propose failure
+// that is NOT a known leadership sentinel surfaces as Unavailable
+// (retryable transient failure)
 // instead of Unknown.
 func TestEncryptionAdmin_RotateDEK_MapsProposeOtherErrorToUnavailable(t *testing.T) {
 	t.Parallel()
@@ -638,9 +637,10 @@ func TestEncryptionAdmin_RegisterEncryptionWriter_RejectsBadInputs(t *testing.T)
 }
 
 // TestEncryptionAdmin_RegisterEncryptionWriter_EmptyWritersMessage
-// pins the PR756 claude[bot] P2 fix: a zero-length writers slice
-// returns a "got 0" message, not the misleading "use
-// BootstrapEncryption for multi-writer batches" text.
+// pins the message routing for the zero-length writers case: a
+// zero-length writers slice returns a "got 0" message, not the
+// misleading "use BootstrapEncryption for multi-writer batches"
+// text aimed at the >1 case.
 func TestEncryptionAdmin_RegisterEncryptionWriter_EmptyWritersMessage(t *testing.T) {
 	t.Parallel()
 	srv := NewEncryptionAdminServer(

--- a/cmd/elastickv-admin/encryption.go
+++ b/cmd/elastickv-admin/encryption.go
@@ -61,11 +61,12 @@ type encryptionEndpointFlags struct {
 }
 
 // newEncryptionEndpointFlags registers the shared --endpoint /
-// --timeout flags every encryption subcommand needs. PR-A is
-// plaintext-only; TLS / token authentication is shared with the
-// existing --nodeTLSCACertFile / --nodeTokenFile pair on the HTTP
-// surface but is deferred to PR-B for the CLI surface so the
-// initial PR stays scoped to read-only status.
+// --timeout flags every encryption subcommand needs. The CLI
+// surface is plaintext-only through PR-B; TLS / token
+// authentication shares the existing --nodeTLSCACertFile /
+// --nodeTokenFile flags on the HTTP surface and is wired into
+// the encryption CLI in Stage 6 alongside the --encryption-enabled
+// cluster-flag gate.
 func newEncryptionEndpointFlags(fs *flag.FlagSet) *encryptionEndpointFlags {
 	return &encryptionEndpointFlags{
 		endpoint: fs.String("endpoint", "127.0.0.1:50051", "gRPC address of an elastickv node"),

--- a/cmd/elastickv-admin/encryption.go
+++ b/cmd/elastickv-admin/encryption.go
@@ -35,18 +35,22 @@ func encryptionMain(args []string) error {
 	switch sub {
 	case "status":
 		return runEncryptionStatus(rest, os.Stdout)
+	case "rotate-dek":
+		return runEncryptionRotateDEK(rest, os.Stdout)
+	case "register-writer":
+		return runEncryptionRegisterWriter(rest, os.Stdout)
 	case "-h", "--help", "help":
 		// `-h` is the universal "show usage" affordance for CLI
 		// subcommands; returning nil keeps the exit code at 0
 		// so shell scripts using $? to detect success do not
 		// trip on a help request.
-		_, err := fmt.Fprintln(os.Stdout, "usage: elastickv-admin encryption <subcommand> [flags]\n\nsubcommands:\n  status")
+		_, err := fmt.Fprintln(os.Stdout, "usage: elastickv-admin encryption <subcommand> [flags]\n\nsubcommands:\n  status\n  rotate-dek\n  register-writer")
 		if err != nil {
 			return errors.Wrap(err, "write usage")
 		}
 		return nil
 	default:
-		return errors.Errorf("encryption: unknown subcommand %q (PR-A supports: status)", sub)
+		return errors.Errorf("encryption: unknown subcommand %q (PR-B supports: status, rotate-dek, register-writer)", sub)
 	}
 }
 

--- a/cmd/elastickv-admin/encryption.go
+++ b/cmd/elastickv-admin/encryption.go
@@ -51,7 +51,7 @@ func encryptionMain(args []string) error {
 		}
 		return nil
 	default:
-		return errors.Errorf("encryption: unknown subcommand %q (PR-B supports: status, rotate-dek, register-writer)", sub)
+		return errors.Errorf("encryption: unknown subcommand %q (supported: status, rotate-dek, register-writer)", sub)
 	}
 }
 

--- a/cmd/elastickv-admin/encryption.go
+++ b/cmd/elastickv-admin/encryption.go
@@ -75,10 +75,10 @@ func newEncryptionEndpointFlags(fs *flag.FlagSet) *encryptionEndpointFlags {
 }
 
 // dialEncryption opens a gRPC client. The context argument is
-// reserved for the PR-B auth path (TLS handshake + token attach);
-// grpc.NewClient itself is non-blocking and ignores the context.
-// Per-RPC timeouts come from the caller's request context, not
-// from this dial.
+// reserved for the Stage 6 auth path (TLS handshake + token
+// attach); grpc.NewClient itself is non-blocking and ignores the
+// context. Per-RPC timeouts come from the caller's request
+// context, not from this dial.
 func dialEncryption(_ context.Context, flags *encryptionEndpointFlags) (pb.EncryptionAdminClient, func() error, error) {
 	conn, err := grpc.NewClient(*flags.endpoint,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),

--- a/cmd/elastickv-admin/encryption.go
+++ b/cmd/elastickv-admin/encryption.go
@@ -24,9 +24,10 @@ const encryptionDialTimeout = 5 * time.Second
 // with this one — main() picks based on argv[1] before flag.Parse() so
 // the two surfaces do not share a global flag namespace.
 //
-// PR-A wires only `status`. PR-B adds bootstrap / rotate-dek /
-// register-writer / resync-sidecar; Stage 6 adds enable-storage-envelope
-// and enable-raft-envelope.
+// PR-A wired `status`. PR-B added `rotate-dek` and
+// `register-writer`. PR-C adds `bootstrap`; Stage 6 adds
+// `enable-storage-envelope` and `enable-raft-envelope`. ResyncSidecar
+// is a server-side §5.5 fallback (no CLI surface).
 func encryptionMain(args []string) error {
 	if len(args) == 0 {
 		return errors.New("usage: elastickv-admin encryption <subcommand> [flags]")

--- a/cmd/elastickv-admin/encryption_mutators.go
+++ b/cmd/elastickv-admin/encryption_mutators.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"strings"
+
+	pb "github.com/bootjp/elastickv/proto"
+	"github.com/cockroachdb/errors"
+)
+
+// runEncryptionRotateDEK invokes EncryptionAdmin.RotateDEK on the
+// configured endpoint. The CLI accepts the wrapped DEK material as
+// base64 because operator-side wrapping is done out-of-band via
+// the KEK CLI (Stage 9) and base64 is the lingua franca for
+// pasting opaque bytes through a terminal. The wire-format
+// validation on local_epoch <= 0xFFFF is duplicated here so the
+// CLI fails fast before a round-trip; the server enforces it as
+// the source of truth.
+func runEncryptionRotateDEK(args []string, out io.Writer) error {
+	parsed, endpoint, err := parseRotateDEKArgs(args)
+	if err != nil {
+		return err
+	}
+	if parsed == nil {
+		// Help requested; usage was already written by flag parser.
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), *endpoint.timeout)
+	defer cancel()
+	client, closeFn, err := dialEncryption(ctx, endpoint)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := closeFn(); err != nil {
+			fmt.Fprintf(os.Stderr, "encryption: close connection: %v\n", err)
+		}
+	}()
+	resp, err := client.RotateDEK(ctx, parsed.request)
+	if err != nil {
+		return errors.Wrap(err, "RotateDEK")
+	}
+	if _, err := fmt.Fprintf(out, "rotated dek_id=%d purpose=%s applied_index=%d\n",
+		parsed.request.NewDekId, parsed.purposeLabel, resp.AppliedIndex); err != nil {
+		return errors.Wrap(err, "write result")
+	}
+	return nil
+}
+
+type parsedRotateDEK struct {
+	request      *pb.RotateDEKRequest
+	purposeLabel string
+}
+
+// parseRotateDEKArgs returns the validated proto request and the
+// shared endpoint flags. A nil request with no error means the
+// caller requested --help; runEncryptionRotateDEK then exits 0.
+func parseRotateDEKArgs(args []string) (*parsedRotateDEK, *encryptionEndpointFlags, error) {
+	fs := flag.NewFlagSet("encryption rotate-dek", flag.ContinueOnError)
+	endpoint := newEncryptionEndpointFlags(fs)
+	purpose := fs.String("purpose", "", "DEK purpose: storage | raft")
+	newDEKID := fs.Uint("new-dek-id", 0, "Key id for the new DEK; must be non-zero")
+	wrappedB64 := fs.String("wrapped-new-dek", "", "Base64 of the KEK-wrapped new DEK")
+	proposerNodeID := fs.Uint64("proposer-node-id", 0, "The proposer's 64-bit full_node_id (registered in §4.1 writer registry)")
+	proposerLocalEpoch := fs.Uint("proposer-local-epoch", 0, "The proposer's local_epoch (0..0xFFFF) at proposal time")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil, endpoint, nil
+		}
+		return nil, nil, errors.Wrap(err, "parse flags")
+	}
+	purposeEnum, err := parseRotatePurposeFlag(*purpose)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := requireUint32(*newDEKID, "new-dek-id"); err != nil {
+		return nil, nil, err
+	}
+	if *newDEKID == 0 {
+		return nil, nil, errors.New("encryption: --new-dek-id is required and must be non-zero")
+	}
+	if err := requireUint16Plus1(*proposerLocalEpoch, "proposer-local-epoch"); err != nil {
+		return nil, nil, err
+	}
+	wrapped, err := decodeWrappedDEKFlag(*wrappedB64)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &parsedRotateDEK{
+		request: &pb.RotateDEKRequest{
+			Purpose:            purposeEnum,
+			NewDekId:           narrowUint32(*newDEKID),
+			WrappedNewDek:      wrapped,
+			ProposerNodeId:     *proposerNodeID,
+			ProposerLocalEpoch: narrowUint32(*proposerLocalEpoch),
+		},
+		purposeLabel: *purpose,
+	}, endpoint, nil
+}
+
+// runEncryptionRegisterWriter invokes
+// EncryptionAdmin.RegisterEncryptionWriter for a single
+// (dek_id, full_node_id, local_epoch) triple. Multi-writer
+// batches go through bootstrap (PR-C).
+func runEncryptionRegisterWriter(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("encryption register-writer", flag.ContinueOnError)
+	endpoint := newEncryptionEndpointFlags(fs)
+	dekID := fs.Uint("dek-id", 0, "Key id to register the writer under; must be non-zero")
+	fullNodeID := fs.Uint64("full-node-id", 0, "The 64-bit full_node_id being registered")
+	localEpoch := fs.Uint("local-epoch", 0, "The writer's local_epoch (0..0xFFFF)")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return errors.Wrap(err, "parse flags")
+	}
+	if err := requireUint32(*dekID, "dek-id"); err != nil {
+		return err
+	}
+	if *dekID == 0 {
+		return errors.New("encryption: --dek-id is required and must be non-zero")
+	}
+	if err := requireUint16Plus1(*localEpoch, "local-epoch"); err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), *endpoint.timeout)
+	defer cancel()
+	client, closeFn, err := dialEncryption(ctx, endpoint)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := closeFn(); err != nil {
+			fmt.Fprintf(os.Stderr, "encryption: close connection: %v\n", err)
+		}
+	}()
+	resp, err := client.RegisterEncryptionWriter(ctx, &pb.RegisterEncryptionWriterRequest{
+		DekId: narrowUint32(*dekID),
+		Writers: []*pb.WriterRegistryEntry{
+			{FullNodeId: *fullNodeID, LocalEpoch: narrowUint32(*localEpoch)},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "RegisterEncryptionWriter")
+	}
+	if _, err := fmt.Fprintf(out, "registered dek_id=%d full_node_id=%d local_epoch=%d applied_index=%d\n",
+		*dekID, *fullNodeID, *localEpoch, resp.AppliedIndex); err != nil {
+		return errors.Wrap(err, "write result")
+	}
+	return nil
+}
+
+func parseRotatePurposeFlag(s string) (pb.RotateDEKRequest_Purpose, error) {
+	switch strings.ToLower(s) {
+	case "storage":
+		return pb.RotateDEKRequest_PURPOSE_STORAGE, nil
+	case "raft":
+		return pb.RotateDEKRequest_PURPOSE_RAFT, nil
+	case "":
+		return 0, errors.New("encryption: --purpose is required (storage|raft)")
+	default:
+		return 0, errors.Errorf("encryption: --purpose=%q invalid (want storage|raft)", s)
+	}
+}
+
+func decodeWrappedDEKFlag(s string) ([]byte, error) {
+	if s == "" {
+		return nil, errors.New("encryption: --wrapped-new-dek is required (base64 of the KEK-wrapped DEK)")
+	}
+	out, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return nil, errors.Wrap(err, "encryption: --wrapped-new-dek is not valid base64")
+	}
+	if len(out) == 0 {
+		return nil, errors.New("encryption: --wrapped-new-dek decoded to zero bytes")
+	}
+	return out, nil
+}
+
+func requireUint32(v uint, name string) error {
+	if uint64(v) > math.MaxUint32 {
+		return errors.Errorf("encryption: --%s=%d exceeds the uint32 bound (max 0x%08x)", name, v, math.MaxUint32)
+	}
+	return nil
+}
+
+func requireUint16Plus1(v uint, name string) error {
+	if uint64(v) > math.MaxUint16 {
+		return errors.Errorf("encryption: --%s=%d exceeds the §4.1 16-bit bound (max 0x%04x)", name, v, math.MaxUint16)
+	}
+	return nil
+}
+
+// narrowUint32 mirrors adapter.uint32ToLocalEpoch: callers MUST
+// have validated `v` against math.MaxUint32 first (via
+// requireUint32). The masked conversion is a defence-in-depth
+// truncation that cannot drift even if a future caller skips the
+// bound check.
+// uint32Mask is the defence-in-depth narrowing mask for the
+// uint→uint32 conversion below; named so the magic-number linter
+// does not flag the mask itself.
+const uint32Mask uint = 0xFFFFFFFF
+
+func narrowUint32(v uint) uint32 {
+	return uint32(v & uint32Mask) //nolint:gosec // bound-checked + masked; G115 cannot trace across the flag-parse boundary
+}

--- a/cmd/elastickv-admin/encryption_test.go
+++ b/cmd/elastickv-admin/encryption_test.go
@@ -168,6 +168,133 @@ func (s *stubSidecarErrorServer) GetSidecarState(context.Context, *pb.Empty) (*p
 	return nil, s.statusErr
 }
 
+// stubMutatorServer captures the RotateDEK / RegisterEncryptionWriter
+// requests so the CLI tests can verify both the wire-level args
+// and the returned applied_index round-trip. Read-only RPCs
+// inherit Unimplemented defaults.
+type stubMutatorServer struct {
+	pb.UnimplementedEncryptionAdminServer
+	rotateCalls   []*pb.RotateDEKRequest
+	registerCalls []*pb.RegisterEncryptionWriterRequest
+	appliedIndex  uint64
+	returnErr     error
+}
+
+func (s *stubMutatorServer) RotateDEK(_ context.Context, req *pb.RotateDEKRequest) (*pb.RotateDEKResponse, error) {
+	s.rotateCalls = append(s.rotateCalls, req)
+	if s.returnErr != nil {
+		return nil, s.returnErr
+	}
+	return &pb.RotateDEKResponse{AppliedIndex: s.appliedIndex}, nil
+}
+
+func (s *stubMutatorServer) RegisterEncryptionWriter(_ context.Context, req *pb.RegisterEncryptionWriterRequest) (*pb.RegisterEncryptionWriterResponse, error) {
+	s.registerCalls = append(s.registerCalls, req)
+	if s.returnErr != nil {
+		return nil, s.returnErr
+	}
+	return &pb.RegisterEncryptionWriterResponse{AppliedIndex: s.appliedIndex}, nil
+}
+
+func TestRunEncryptionRotateDEK_HappyPath(t *testing.T) {
+	t.Parallel()
+	stub := &stubMutatorServer{appliedIndex: 73}
+	addr := startCustomEncryptionAdminTestServer(t, stub)
+
+	var buf bytes.Buffer
+	err := runEncryptionRotateDEK([]string{
+		"--endpoint", addr,
+		"--timeout", "3s",
+		"--purpose", "storage",
+		"--new-dek-id", "9",
+		// "raw-wrapped" base64-encoded
+		"--wrapped-new-dek", "cmF3LXdyYXBwZWQ=",
+		"--proposer-node-id", "111",
+		"--proposer-local-epoch", "42",
+	}, &buf)
+	if err != nil {
+		t.Fatalf("runEncryptionRotateDEK: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "applied_index=73") {
+		t.Errorf("output missing applied_index=73, got:\n%s", out)
+	}
+	if len(stub.rotateCalls) != 1 {
+		t.Fatalf("RotateDEK calls=%d, want 1", len(stub.rotateCalls))
+	}
+	call := stub.rotateCalls[0]
+	if call.Purpose != pb.RotateDEKRequest_PURPOSE_STORAGE ||
+		call.NewDekId != 9 ||
+		string(call.WrappedNewDek) != "raw-wrapped" ||
+		call.ProposerNodeId != 111 ||
+		call.ProposerLocalEpoch != 42 {
+		t.Errorf("RotateDEK call=%+v does not match flag inputs", call)
+	}
+}
+
+func TestRunEncryptionRotateDEK_RejectsBadPurpose(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	err := runEncryptionRotateDEK([]string{
+		"--endpoint", "127.0.0.1:1",
+		"--purpose", "junk",
+		"--new-dek-id", "9",
+		"--wrapped-new-dek", "cmF3LXdyYXBwZWQ=",
+		"--proposer-node-id", "1",
+		"--proposer-local-epoch", "0",
+	}, &buf)
+	if err == nil {
+		t.Fatalf("runEncryptionRotateDEK returned nil, want error on --purpose=junk")
+	}
+}
+
+func TestRunEncryptionRotateDEK_RejectsBadEpoch(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	err := runEncryptionRotateDEK([]string{
+		"--endpoint", "127.0.0.1:1",
+		"--purpose", "storage",
+		"--new-dek-id", "9",
+		"--wrapped-new-dek", "cmF3LXdyYXBwZWQ=",
+		"--proposer-node-id", "1",
+		"--proposer-local-epoch", "70000", // > 0xFFFF
+	}, &buf)
+	if err == nil || !strings.Contains(err.Error(), "16-bit bound") {
+		t.Fatalf("runEncryptionRotateDEK error=%v, want bound-violation", err)
+	}
+}
+
+func TestRunEncryptionRegisterWriter_HappyPath(t *testing.T) {
+	t.Parallel()
+	stub := &stubMutatorServer{appliedIndex: 88}
+	addr := startCustomEncryptionAdminTestServer(t, stub)
+
+	var buf bytes.Buffer
+	err := runEncryptionRegisterWriter([]string{
+		"--endpoint", addr,
+		"--timeout", "3s",
+		"--dek-id", "3",
+		"--full-node-id", "555",
+		"--local-epoch", "21",
+	}, &buf)
+	if err != nil {
+		t.Fatalf("runEncryptionRegisterWriter: %v", err)
+	}
+	if !strings.Contains(buf.String(), "applied_index=88") {
+		t.Errorf("missing applied_index=88, got:\n%s", buf.String())
+	}
+	if len(stub.registerCalls) != 1 {
+		t.Fatalf("RegisterEncryptionWriter calls=%d, want 1", len(stub.registerCalls))
+	}
+	call := stub.registerCalls[0]
+	if call.DekId != 3 ||
+		len(call.Writers) != 1 ||
+		call.Writers[0].FullNodeId != 555 ||
+		call.Writers[0].LocalEpoch != 21 {
+		t.Errorf("RegisterEncryptionWriter call=%+v does not match flag inputs", call)
+	}
+}
+
 func writeStatusFixture(t *testing.T, sc *encryption.Sidecar) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/cmd/elastickv-admin/encryption_test.go
+++ b/cmd/elastickv-admin/encryption_test.go
@@ -36,11 +36,10 @@ func TestEncryptionMain_RequiresSubcommand(t *testing.T) {
 	}
 }
 
-// TestEncryptionMain_HelpFlagExitsZero pins the PR754 coderabbitai
-// /claude[bot] round-2 finding: `-h`, `--help`, `help` must not
-// fall through to the unknown-subcommand error path so shell
-// scripts using $? to detect success do not trip on a help
-// request.
+// TestEncryptionMain_HelpFlagExitsZero pins the CLI help-flag
+// contract: `-h`, `--help`, and `help` must not fall through to
+// the unknown-subcommand error path so shell scripts using $? to
+// detect success do not trip on a help request.
 func TestEncryptionMain_HelpFlagExitsZero(t *testing.T) {
 	t.Parallel()
 	for _, sub := range []string{"-h", "--help", "help"} {
@@ -124,7 +123,7 @@ func TestRunEncryptionStatus_NoSidecar(t *testing.T) {
 }
 
 // TestRunEncryptionStatus_PropagatesNonPreconditionError pins the
-// PR754 codex P2 fix: only FailedPrecondition on GetSidecarState
+// error-narrowing contract: only FailedPrecondition on GetSidecarState
 // is treated as the "node not configured" soft fallback. Any
 // other code (Internal, Unavailable, Unimplemented, …) must
 // surface as a non-nil error so the CLI exits non-zero.

--- a/docs/design/2026_04_29_partial_data_at_rest_encryption.md
+++ b/docs/design/2026_04_29_partial_data_at_rest_encryption.md
@@ -14,7 +14,8 @@ Date: 2026-04-29
 | 3 | Raft envelope + engine pre-apply hook (§6.3, §4.2) | shipped | PR #744 |
 | 4 | FSM-internal Raft entry types (§5.6, §5.2 wire, §11.3 reserved opcodes) | shipped | PR #748 |
 | 5A | `EncryptionAdmin` proto + read-only RPCs + `encryption status` CLI | shipped | PR #754 |
-| 5B | Mutating RPCs (Bootstrap / RotateDEK / RegisterEncryptionWriter), §5.6 step 1a capability fan-out, remaining CLI subcommands, main.go gRPC wiring | open | — |
+| 5B | RotateDEK + RegisterEncryptionWriter (leader-only Proposer wiring) + `rotate-dek` / `register-writer` CLI + ResyncSidecar leader guard | in PR | — |
+| 5C | BootstrapEncryption + §5.6 step 1a capability fan-out + `bootstrap` CLI + main.go gRPC wiring | open | — |
 | 6 | 3-phase rollout flags + applier wiring (§6.5, §7.1) | open | — |
 | 7 | Writer registry + deterministic nonce (§4.1) | open | — |
 | 8 | Snapshot header v2 + WAL coverage (§4.4, §4.5) | open | — |


### PR DESCRIPTION
## Summary

Stage 5 **PR-B** of the data-at-rest encryption rollout (design doc:
`docs/design/2026_04_29_partial_data_at_rest_encryption.md`, §5.2
rotation, §4.1 writer registry, §6.1 admin.go service, §6.6 admin
commands). Wires two of the three §11.3 mutating opcodes through
`raftengine.Proposer` on top of Stage 4's fsmwire body encoders.

Production-inert: `main.go` does not yet register the
`EncryptionAdminServer` on its gRPC listener, and
`WithEncryptionAdminProposer` is unset by default — every mutating
RPC then short-circuits to `FailedPrecondition` with "proposer not
configured". Stage 6 flips this on under the `--encryption-enabled`
cluster flag; **PR-C** lands `BootstrapEncryption` + §5.6 step 1a
capability fan-out.

## What lands

- `RotateDEK` + `RegisterEncryptionWriter` server-side
  implementations on top of `raftengine.Proposer`. Leader-only,
  with the leader id+address embedded in `FailedPrecondition`
  status detail.
- `ResyncSidecar` is now leader-gated (it was always-on in PR-A);
  §5.5 recovery only consults the leader's record.
- `WithEncryptionAdminProposer` / `WithEncryptionAdminLeaderView`
  options.
- `elastickv-admin encryption rotate-dek` and
  `elastickv-admin encryption register-writer` subcommands. The
  wrapped DEK material is taken as base64.
- Design doc Stage-5 row split: 5A shipped (#754), 5B in PR, 5C
  open.

## Out of scope (PR-C / Stage 6)

- `BootstrapEncryption` mutator + `bootstrap` CLI.
- §5.6 step 1a capability fan-out across voters and learners.
- `main.go` registers `EncryptionAdminServer` on the gRPC listener
  (Stage 6, under the cluster flag).
- TLS / token auth for mutating RPCs (Stage 6).

## Test plan

- [x] `go test -race -timeout=60s ./adapter -run TestEncryptionAdmin`
  — 14 cases including:
  - RotateDEK happy path (wire-layout round-trip via
    `fsmwire.DecodeRotation`).
  - RotateDEK rejects on follower (leader hint in status detail).
  - RotateDEK input-validation table (zero `new_dek_id`, empty
    wrapped, unspecified purpose, `local_epoch > 0xFFFF`).
  - RegisterEncryptionWriter happy path (round-trip via
    `fsmwire.DecodeRegistration`).
  - RegisterEncryptionWriter rejects multi-writer batches.
  - ResyncSidecar rejects on follower.
  - `MutatingRPCs_RejectWithoutProposer` pins the production-inert
    guarantee.
- [x] `go test -race -timeout=60s ./cmd/elastickv-admin -run TestRunEncryption`
  — CLI happy path through a real gRPC loopback server, plus the
  parse-time validation (`--purpose=junk`, `--proposer-local-epoch=70000`).
- [x] `golangci-lint run` on touched paths: 0 issues.
- [ ] CI verifies build / lint / Jepsen.

## Self-review (CLAUDE.md 5 passes)

1. **Data loss** — every mutating RPC is leader-gated; followers
   return `FailedPrecondition` before the proposer is touched. A
   nil proposer rejects with `FailedPrecondition`. Stage 4's
   `HaltApply` seam already covers the apply-side failure mode.
2. **Concurrency** — the server adds no mutable state; the
   proposer is set once at construction. `raftengine.Proposer`'s
   contract serialises proposals through the engine's queue.
3. **Performance** — hot path is unchanged; mutating RPCs are
   operator-facing and rare.
4. **Consistency** — fsmwire encoders are the single source of
   truth for the on-wire byte layout. Round-trip tests
   (`Encode→Decode`) lock the server's view against fsmwire's, so
   a future change to either side cannot silently desync.
5. **Test coverage** — input-validation table, leader-rejection,
   wire-layout round-trip, and CLI happy path are all covered.
   No-proposer = `FailedPrecondition` is pinned.

## Notes

- proto regenerated locally with `libprotoc 29.6` (29.3 not
  installable on macOS via Homebrew); generated headers carry the
  v5.29.6 string vs the canonical v5.29.3, no wire-relevant
  difference. Same toolchain note as PR #754.
