### PR TITLE
feat(encryption): Stage 5 PR-C — BootstrapEncryption + bootstrap CLI + Validate()

### DIFF
--- a/adapter/encryption_admin.go
+++ b/adapter/encryption_admin.go
@@ -358,11 +358,11 @@ func (s *EncryptionAdminServer) BootstrapEncryption(ctx context.Context, req *pb
 			"encryption: storage_dek_id and raft_dek_id must differ; got both %d",
 			req.GetStorageDekId())
 	}
-	if len(req.GetWrappedStorageDek()) == 0 {
-		return nil, grpcStatusError(codes.InvalidArgument, "encryption: wrapped_storage_dek is required")
+	if err := validateWrappedDEK("storage", req.GetWrappedStorageDek()); err != nil {
+		return nil, err
 	}
-	if len(req.GetWrappedRaftDek()) == 0 {
-		return nil, grpcStatusError(codes.InvalidArgument, "encryption: wrapped_raft_dek is required")
+	if err := validateWrappedDEK("raft", req.GetWrappedRaftDek()); err != nil {
+		return nil, err
 	}
 	batch, err := buildBootstrapBatch(req.GetWriterBatch(), req.GetStorageDekId(), req.GetRaftDekId())
 	if err != nil {
@@ -413,6 +413,9 @@ func buildBootstrapBatch(writers []*pb.WriterRegistryEntry, storageDEKID, raftDE
 			fsmwire.RegistrationPayload{DEKID: raftDEKID, FullNodeID: row.FullNodeID, LocalEpoch: row.LocalEpoch},
 		)
 	}
+	if err := validateWriterBatchUniqueness(writers); err != nil {
+		return nil, err
+	}
 	return out, nil
 }
 
@@ -446,6 +449,66 @@ func validateBootstrapWriter(i int, w *pb.WriterRegistryEntry) (fsmwire.Registra
 // nonce-uniqueness invariant covers both envelope purposes from
 // the first post-bootstrap entry.
 const bootstrapRowsPerWriter = 2
+
+// maxWrappedDEKSize bounds the KEK-wrapped DEK payload size at the
+// gRPC boundary so a crafted oversized blob cannot push
+// fsmwire.EncodeBootstrap toward its safeU32 length-prefix guard
+// or inflate the resulting Raft entry beyond practical limits.
+// A real KEK-wrapped 32-byte DEK runs hundreds of bytes (KMS
+// metadata + AES-GCM tag + envelope header); 4 KiB is ~10x
+// headroom and far below the gRPC default 4 MiB message cap.
+const maxWrappedDEKSize = 4096
+
+func validateWrappedDEK(purpose string, wrapped []byte) error {
+	if len(wrapped) == 0 {
+		return grpcStatusErrorf(codes.InvalidArgument,
+			"encryption: wrapped_%s_dek is required", purpose)
+	}
+	if len(wrapped) > maxWrappedDEKSize {
+		return grpcStatusErrorf(codes.InvalidArgument,
+			"encryption: wrapped_%s_dek size %d exceeds the %d-byte gRPC-boundary cap",
+			purpose, len(wrapped), maxWrappedDEKSize)
+	}
+	return nil
+}
+
+// validateWriterBatchUniqueness rejects writer batches that would
+// fail closed at FSM apply time: §4.1 case-3 (the same
+// full_node_id appearing twice → ErrLocalEpochRollback) and §4.1
+// case-4 (two distinct full_node_ids colliding on the uint16
+// narrowing used as the registry-row key → ErrNodeIDCollision).
+// FSM apply errors halt the apply loop via HaltApply, so a
+// malformed bootstrap that reached apply would stop the cluster.
+func validateWriterBatchUniqueness(writers []*pb.WriterRegistryEntry) error {
+	seenFull := make(map[uint64]int, len(writers))
+	seenTrunc := make(map[uint16]uint64, len(writers))
+	for i, w := range writers {
+		if w == nil {
+			continue
+		}
+		id := w.GetFullNodeId()
+		if prev, dup := seenFull[id]; dup {
+			return grpcStatusErrorf(codes.InvalidArgument,
+				"encryption: writer_batch[%d] duplicates full_node_id %d already present at index %d",
+				i, id, prev)
+		}
+		trunc := uint16(id & localEpochMaskU64) //nolint:gosec // masked to 16 bits; G115 cannot trace the bitwise narrowing
+		if prevFull, collision := seenTrunc[trunc]; collision {
+			return grpcStatusErrorf(codes.InvalidArgument,
+				"encryption: writer_batch[%d].full_node_id=%d collides with %d on the uint16 narrowing 0x%04x (registry key)",
+				i, id, prevFull, trunc)
+		}
+		seenFull[id] = i
+		seenTrunc[trunc] = id
+	}
+	return nil
+}
+
+// localEpochMaskU64 mirrors localEpochMask in uint64 form for the
+// uint64→uint16 narrowing used by the registry row key. Named
+// here so the magic-number linter does not flag the masking
+// conversion below.
+const localEpochMaskU64 uint64 = 0xFFFF
 
 // bootstrapBatchRowCap mirrors fsmwire.maxBootstrapBatchCount.
 // The §5.6 step 1a bootstrap produces (storage + raft) rows per

--- a/adapter/encryption_admin.go
+++ b/adapter/encryption_admin.go
@@ -402,19 +402,27 @@ func buildBootstrapBatch(writers []*pb.WriterRegistryEntry, storageDEKID, raftDE
 			"encryption: writer_batch produces %d registry rows, exceeding the §4.1 bound %d",
 			totalRows, bootstrapBatchRowCap)
 	}
-	out := make([]fsmwire.RegistrationPayload, 0, totalRows)
+	// Per-writer shape validation first (rejects nil entries, zero
+	// node id, oversize epoch) so the uniqueness pass below can
+	// assume every entry is non-nil and well-formed. Both passes
+	// run before we allocate the output slice — a near-cap batch
+	// with a collision at the end is rejected without building
+	// thousands of throwaway registry rows.
 	for i, w := range writers {
-		row, err := validateBootstrapWriter(i, w)
-		if err != nil {
+		if _, err := validateBootstrapWriter(i, w); err != nil {
 			return nil, err
 		}
-		out = append(out,
-			fsmwire.RegistrationPayload{DEKID: storageDEKID, FullNodeID: row.FullNodeID, LocalEpoch: row.LocalEpoch},
-			fsmwire.RegistrationPayload{DEKID: raftDEKID, FullNodeID: row.FullNodeID, LocalEpoch: row.LocalEpoch},
-		)
 	}
 	if err := validateWriterBatchUniqueness(writers); err != nil {
 		return nil, err
+	}
+	out := make([]fsmwire.RegistrationPayload, 0, totalRows)
+	for _, w := range writers {
+		epoch := uint32ToLocalEpoch(w.GetLocalEpoch())
+		out = append(out,
+			fsmwire.RegistrationPayload{DEKID: storageDEKID, FullNodeID: w.GetFullNodeId(), LocalEpoch: epoch},
+			fsmwire.RegistrationPayload{DEKID: raftDEKID, FullNodeID: w.GetFullNodeId(), LocalEpoch: epoch},
+		)
 	}
 	return out, nil
 }
@@ -479,13 +487,15 @@ func validateWrappedDEK(purpose string, wrapped []byte) error {
 // narrowing used as the registry-row key → ErrNodeIDCollision).
 // FSM apply errors halt the apply loop via HaltApply, so a
 // malformed bootstrap that reached apply would stop the cluster.
+//
+// The caller (buildBootstrapBatch) runs validateBootstrapWriter
+// over the slice first, so every entry here is guaranteed
+// non-nil with a non-zero full_node_id — no defensive nil-guard
+// is needed inside this loop.
 func validateWriterBatchUniqueness(writers []*pb.WriterRegistryEntry) error {
 	seenFull := make(map[uint64]int, len(writers))
 	seenTrunc := make(map[uint16]uint64, len(writers))
 	for i, w := range writers {
-		if w == nil {
-			continue
-		}
 		id := w.GetFullNodeId()
 		if prev, dup := seenFull[id]; dup {
 			return grpcStatusErrorf(codes.InvalidArgument,
@@ -538,8 +548,8 @@ func (s *EncryptionAdminServer) RotateDEK(ctx context.Context, req *pb.RotateDEK
 	if req.GetNewDekId() == 0 {
 		return nil, grpcStatusError(codes.InvalidArgument, "encryption: new_dek_id must be non-zero (key id 0 is reserved per §5.1)")
 	}
-	if len(req.GetWrappedNewDek()) == 0 {
-		return nil, grpcStatusError(codes.InvalidArgument, "encryption: wrapped_new_dek is required")
+	if err := validateWrappedDEK("new", req.GetWrappedNewDek()); err != nil {
+		return nil, err
 	}
 	if req.GetProposerLocalEpoch() > math.MaxUint16 {
 		return nil, grpcStatusErrorf(codes.InvalidArgument,

--- a/adapter/encryption_admin.go
+++ b/adapter/encryption_admin.go
@@ -16,14 +16,12 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-// EncryptionAdminServer implements proto.EncryptionAdmin. PR-A
-// (Stage 5 foundation) wired the read-only capability and state
-// probes; PR-B (this slice) wires RotateDEK +
-// RegisterEncryptionWriter as leader-only proposers on top of
-// Stage 3's raft envelope and Stage 4's fsmwire bodies, plus the
-// leader guard on ResyncSidecar. BootstrapEncryption stays
-// Unimplemented until PR-C lands the §5.6 step 1a capability
-// fan-out.
+// EncryptionAdminServer implements proto.EncryptionAdmin. Wires
+// the §6.1 read-only probes (GetCapability, GetSidecarState,
+// ResyncSidecar) plus the three mutating opcodes (Bootstrap,
+// RotateDEK, RegisterEncryptionWriter) onto Stage 3's raft
+// envelope and Stage 4's fsmwire body encoders. Mutators are
+// leader-gated through requireLeader / VerifyLeader.
 type EncryptionAdminServer struct {
 	sidecarPath        string
 	keystore           *encryption.Keystore
@@ -121,6 +119,11 @@ func WithEncryptionAdminLeaderView(v raftengine.LeaderView) EncryptionAdminServe
 // Admin / Distribution; every RPC is concurrency-safe because the
 // only mutable state is the sidecar file, which encryption.WriteSidecar
 // already serialises via the §5.1 crash-durable write protocol.
+//
+// Production wiring MUST call Validate after construction so a
+// configuration that wires a proposer but forgets the leaderView
+// fails closed at startup rather than silently letting followers
+// mutate state.
 func NewEncryptionAdminServer(opts ...EncryptionAdminServerOption) *EncryptionAdminServer {
 	s := &EncryptionAdminServer{}
 	for _, opt := range opts {
@@ -132,6 +135,19 @@ func NewEncryptionAdminServer(opts ...EncryptionAdminServerOption) *EncryptionAd
 		s.buildSHA = autoBuildSHA()
 	}
 	return s
+}
+
+// Validate enforces the option-pairing invariants the constructor
+// cannot express through Go's option signature. Tests that wire a
+// proposer without a leaderView are intentionally allowed (the
+// requireLeader path treats nil-leaderView as always-leader for
+// the proposer-wiring unit tests); production wiring in main.go
+// MUST call this method so a misconfiguration fails closed.
+func (s *EncryptionAdminServer) Validate() error {
+	if s.proposer != nil && s.leaderView == nil {
+		return errors.New("encryption: proposer wired without leaderView — followers must not mutate state; call WithEncryptionAdminLeaderView")
+	}
+	return nil
 }
 
 // GetCapability returns the §6.1 CapabilityReport for the local
@@ -313,6 +329,130 @@ func statusFromSidecarErr(err error) error {
 		return grpcStatusErrorf(codes.Internal, "encryption: read sidecar: %v", err)
 	}
 }
+
+// BootstrapEncryption proposes the §5.6 0x04 OpBootstrap entry
+// that installs the initial wrapped DEK pair AND the cluster-wide
+// writer-registry batch in a single Raft transaction. The server
+// accepts a pre-built writer batch (capability fan-out is the
+// CLI's job today) and validates every entry against the §6.1
+// invariants before delegating to fsmwire.EncodeBootstrap. FSM
+// apply enforces the idempotency check (rejects if the sidecar's
+// active.storage is already set), so re-running this RPC against
+// an already-bootstrapped cluster is safe — the engine returns
+// the apply error and ErrEncryptionApply halts the apply loop.
+func (s *EncryptionAdminServer) BootstrapEncryption(ctx context.Context, req *pb.BootstrapEncryptionRequest) (*pb.BootstrapEncryptionResponse, error) {
+	if err := s.requireLeader(ctx); err != nil {
+		return nil, err
+	}
+	if s.proposer == nil {
+		return nil, grpcStatusError(codes.FailedPrecondition, "encryption: proposer is not configured on this node")
+	}
+	if req.GetStorageDekId() == 0 {
+		return nil, grpcStatusError(codes.InvalidArgument, "encryption: storage_dek_id must be non-zero (key id 0 is reserved per §5.1)")
+	}
+	if req.GetRaftDekId() == 0 {
+		return nil, grpcStatusError(codes.InvalidArgument, "encryption: raft_dek_id must be non-zero (key id 0 is reserved per §5.1)")
+	}
+	if req.GetStorageDekId() == req.GetRaftDekId() {
+		return nil, grpcStatusErrorf(codes.InvalidArgument,
+			"encryption: storage_dek_id and raft_dek_id must differ; got both %d",
+			req.GetStorageDekId())
+	}
+	if len(req.GetWrappedStorageDek()) == 0 {
+		return nil, grpcStatusError(codes.InvalidArgument, "encryption: wrapped_storage_dek is required")
+	}
+	if len(req.GetWrappedRaftDek()) == 0 {
+		return nil, grpcStatusError(codes.InvalidArgument, "encryption: wrapped_raft_dek is required")
+	}
+	batch, err := buildBootstrapBatch(req.GetWriterBatch(), req.GetStorageDekId(), req.GetRaftDekId())
+	if err != nil {
+		return nil, err
+	}
+	payload := fsmwire.BootstrapPayload{
+		StorageDEKID:   req.GetStorageDekId(),
+		WrappedStorage: req.GetWrappedStorageDek(),
+		RaftDEKID:      req.GetRaftDekId(),
+		WrappedRaft:    req.GetWrappedRaftDek(),
+		BatchRegistry:  batch,
+	}
+	body := fsmwire.EncodeBootstrap(payload)
+	idx, err := s.proposeEncryptionEntry(ctx, fsmwire.OpBootstrap, body)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.BootstrapEncryptionResponse{AppliedIndex: idx}, nil
+}
+
+// buildBootstrapBatch projects the proto writer batch into the
+// §11.3 0x04 fsmwire form. Each member is expanded into TWO
+// registry rows (one per active dek_id — storage and raft) so the
+// §4.1 nonce-uniqueness invariant holds for both envelope
+// purposes from the first post-bootstrap entry. The result size
+// is bounded by fsmwire.maxBootstrapBatchCount (2 × len(writers))
+// — checked at the gRPC boundary so a too-large batch is rejected
+// before the Propose round-trip.
+func buildBootstrapBatch(writers []*pb.WriterRegistryEntry, storageDEKID, raftDEKID uint32) ([]fsmwire.RegistrationPayload, error) {
+	if len(writers) == 0 {
+		return nil, grpcStatusError(codes.InvalidArgument,
+			"encryption: writer_batch must contain at least one member (per §5.6 step 1a)")
+	}
+	totalRows := bootstrapRowsPerWriter * len(writers)
+	if totalRows > bootstrapBatchRowCap {
+		return nil, grpcStatusErrorf(codes.InvalidArgument,
+			"encryption: writer_batch produces %d registry rows, exceeding the §4.1 bound %d",
+			totalRows, bootstrapBatchRowCap)
+	}
+	out := make([]fsmwire.RegistrationPayload, 0, totalRows)
+	for i, w := range writers {
+		row, err := validateBootstrapWriter(i, w)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out,
+			fsmwire.RegistrationPayload{DEKID: storageDEKID, FullNodeID: row.FullNodeID, LocalEpoch: row.LocalEpoch},
+			fsmwire.RegistrationPayload{DEKID: raftDEKID, FullNodeID: row.FullNodeID, LocalEpoch: row.LocalEpoch},
+		)
+	}
+	return out, nil
+}
+
+// validateBootstrapWriter enforces the per-writer invariants the
+// §5.6 step 1a batch must satisfy before it can be expanded into
+// the two-row-per-writer bootstrap layout. Returns a partial
+// RegistrationPayload populated with the validated fields; the
+// caller supplies dek_id when building the storage / raft rows.
+func validateBootstrapWriter(i int, w *pb.WriterRegistryEntry) (fsmwire.RegistrationPayload, error) {
+	if w == nil {
+		return fsmwire.RegistrationPayload{}, grpcStatusErrorf(codes.InvalidArgument,
+			"encryption: writer_batch[%d] is nil", i)
+	}
+	if w.GetFullNodeId() == 0 {
+		return fsmwire.RegistrationPayload{}, grpcStatusErrorf(codes.InvalidArgument,
+			"encryption: writer_batch[%d].full_node_id must be non-zero (0 is reserved as the §6.1 not-capable sentinel)", i)
+	}
+	if w.GetLocalEpoch() > math.MaxUint16 {
+		return fsmwire.RegistrationPayload{}, grpcStatusErrorf(codes.InvalidArgument,
+			"encryption: writer_batch[%d].local_epoch=%d exceeds the §4.1 16-bit bound (max 0xFFFF)",
+			i, w.GetLocalEpoch())
+	}
+	return fsmwire.RegistrationPayload{
+		FullNodeID: w.GetFullNodeId(),
+		LocalEpoch: uint32ToLocalEpoch(w.GetLocalEpoch()),
+	}, nil
+}
+
+// bootstrapRowsPerWriter is the §5.6 step 1a fan-out per member:
+// one storage-DEK row + one raft-DEK row so the §4.1
+// nonce-uniqueness invariant covers both envelope purposes from
+// the first post-bootstrap entry.
+const bootstrapRowsPerWriter = 2
+
+// bootstrapBatchRowCap mirrors fsmwire.maxBootstrapBatchCount.
+// The §5.6 step 1a bootstrap produces (storage + raft) rows per
+// member, so the practical member count cap is half this value.
+// Named here to avoid the magic-number linter and to keep the
+// boundary check next to where it fires.
+const bootstrapBatchRowCap = 1 << 14
 
 // RotateDEK proposes a §5.2 rotation as a §11.3 0x05 OpRotation
 // entry. The server validates purpose / dek_id / local_epoch

--- a/adapter/encryption_admin_test.go
+++ b/adapter/encryption_admin_test.go
@@ -446,6 +446,77 @@ func TestEncryptionAdmin_BootstrapEncryption_RejectsBadInputs(t *testing.T) {
 	}
 }
 
+// TestEncryptionAdmin_BootstrapEncryption_RejectsDuplicateFullNodeID
+// pins the cluster-safety invariant: a writer batch that names
+// the same full_node_id twice would, after FSM apply, attempt to
+// re-register the same registry row with possibly-different
+// local_epochs — which the §4.1 case-3 rollback guard would
+// reject. FSM apply errors are fatal under the HaltApply seam,
+// so the cluster halts. Reject at the gRPC boundary instead.
+func TestEncryptionAdmin_BootstrapEncryption_RejectsDuplicateFullNodeID(t *testing.T) {
+	t.Parallel()
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminProposer(&recordingProposer{}),
+		WithEncryptionAdminLeaderView(stubLeaderView{state: raftengine.StateLeader}),
+	)
+	req := validBootstrapEncryptionRequest()
+	req.WriterBatch = []*pb.WriterRegistryEntry{
+		{FullNodeId: 7, LocalEpoch: 0},
+		{FullNodeId: 7, LocalEpoch: 0},
+	}
+	_, err := srv.BootstrapEncryption(context.Background(), req)
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("status=%v, want InvalidArgument on duplicate full_node_id", status.Code(err))
+	}
+}
+
+// TestEncryptionAdmin_BootstrapEncryption_RejectsNodeIDCollision
+// pins the §4.1 case-4 invariant: two distinct full_node_ids that
+// collide on the uint16 narrowing share the same registry row
+// key (!encryption|writers|<dek_id>|<uint16(node_id)>). The FSM
+// halts on ErrNodeIDCollision so the boundary must reject.
+func TestEncryptionAdmin_BootstrapEncryption_RejectsNodeIDCollision(t *testing.T) {
+	t.Parallel()
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminProposer(&recordingProposer{}),
+		WithEncryptionAdminLeaderView(stubLeaderView{state: raftengine.StateLeader}),
+	)
+	req := validBootstrapEncryptionRequest()
+	req.WriterBatch = []*pb.WriterRegistryEntry{
+		{FullNodeId: 0x0001_0000_0000_0007, LocalEpoch: 0}, // uint16=0x0007
+		{FullNodeId: 0x0002_0000_0000_0007, LocalEpoch: 0}, // same uint16, different upper bits
+	}
+	_, err := srv.BootstrapEncryption(context.Background(), req)
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("status=%v, want InvalidArgument on uint16(node_id) collision", status.Code(err))
+	}
+}
+
+// TestEncryptionAdmin_BootstrapEncryption_RejectsOversizeWrappedDEK
+// pins the DoS-defense bound: wrapped DEK payloads above the
+// per-field cap are rejected at the gRPC boundary so a crafted
+// request cannot push fsmwire.EncodeBootstrap toward its safeU32
+// guard.
+func TestEncryptionAdmin_BootstrapEncryption_RejectsOversizeWrappedDEK(t *testing.T) {
+	t.Parallel()
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminProposer(&recordingProposer{}),
+		WithEncryptionAdminLeaderView(stubLeaderView{state: raftengine.StateLeader}),
+	)
+	huge := make([]byte, maxWrappedDEKSize+1)
+	for _, mut := range []func(r *pb.BootstrapEncryptionRequest){
+		func(r *pb.BootstrapEncryptionRequest) { r.WrappedStorageDek = huge },
+		func(r *pb.BootstrapEncryptionRequest) { r.WrappedRaftDek = huge },
+	} {
+		req := validBootstrapEncryptionRequest()
+		mut(req)
+		_, err := srv.BootstrapEncryption(context.Background(), req)
+		if status.Code(err) != codes.InvalidArgument {
+			t.Errorf("status=%v, want InvalidArgument on oversize wrapped DEK", status.Code(err))
+		}
+	}
+}
+
 func TestEncryptionAdmin_BootstrapEncryption_RejectsOversizeBatch(t *testing.T) {
 	t.Parallel()
 	srv := NewEncryptionAdminServer(

--- a/adapter/encryption_admin_test.go
+++ b/adapter/encryption_admin_test.go
@@ -248,33 +248,36 @@ func TestEncryptionAdmin_ResyncSidecar_ShipsWrappedDEKs(t *testing.T) {
 	}
 }
 
-// TestEncryptionAdmin_BootstrapEncryption_Unimplemented pins the
-// PR-B contract that BootstrapEncryption is still un-wired and
-// returns Unimplemented. PR-C will replace this with positive
-// tests once the §5.6 step 1a capability fan-out lands.
-func TestEncryptionAdmin_BootstrapEncryption_Unimplemented(t *testing.T) {
-	t.Parallel()
-	srv := NewEncryptionAdminServer()
-	ctx := context.Background()
-	if _, err := srv.BootstrapEncryption(ctx, &pb.BootstrapEncryptionRequest{}); status.Code(err) != codes.Unimplemented {
-		t.Errorf("BootstrapEncryption status=%v, want Unimplemented", status.Code(err))
-	}
-}
-
 // TestEncryptionAdmin_MutatingRPCs_RejectWithoutProposer pins the
-// PR-A production-inert guarantee: an EncryptionAdminServer built
+// production-inert guarantee: an EncryptionAdminServer built
 // without WithEncryptionAdminProposer must reject every mutating
-// RPC. The §6.5 cluster flag (Stage 6) is what flips this on by
-// wiring a real proposer.
+// RPC. The future cluster flag is what flips this on by wiring a
+// real proposer.
 func TestEncryptionAdmin_MutatingRPCs_RejectWithoutProposer(t *testing.T) {
 	t.Parallel()
 	srv := NewEncryptionAdminServer()
 	ctx := context.Background()
+	if _, err := srv.BootstrapEncryption(ctx, validBootstrapEncryptionRequest()); status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("BootstrapEncryption status=%v, want FailedPrecondition (no proposer wired)", status.Code(err))
+	}
 	if _, err := srv.RotateDEK(ctx, validRotateDEKRequest()); status.Code(err) != codes.FailedPrecondition {
 		t.Errorf("RotateDEK status=%v, want FailedPrecondition (no proposer wired)", status.Code(err))
 	}
 	if _, err := srv.RegisterEncryptionWriter(ctx, validRegisterEncryptionWriterRequest()); status.Code(err) != codes.FailedPrecondition {
 		t.Errorf("RegisterEncryptionWriter status=%v, want FailedPrecondition (no proposer wired)", status.Code(err))
+	}
+}
+
+func validBootstrapEncryptionRequest() *pb.BootstrapEncryptionRequest {
+	return &pb.BootstrapEncryptionRequest{
+		WrappedStorageDek: []byte("wrapped-storage-bytes"),
+		WrappedRaftDek:    []byte("wrapped-raft-bytes"),
+		StorageDekId:      1,
+		RaftDekId:         2,
+		WriterBatch: []*pb.WriterRegistryEntry{
+			{FullNodeId: 11, LocalEpoch: 0},
+			{FullNodeId: 22, LocalEpoch: 0},
+		},
 	}
 }
 
@@ -294,6 +297,174 @@ func validRegisterEncryptionWriterRequest() *pb.RegisterEncryptionWriterRequest 
 		Writers: []*pb.WriterRegistryEntry{
 			{FullNodeId: 11, LocalEpoch: 7},
 		},
+	}
+}
+
+// TestEncryptionAdmin_Validate_RejectsProposerWithoutLeaderView
+// pins the production-wiring guard: a server constructed with a
+// proposer but no LeaderView is rejected at Validate() time so a
+// follower cannot silently propose state-changing entries.
+func TestEncryptionAdmin_Validate_RejectsProposerWithoutLeaderView(t *testing.T) {
+	t.Parallel()
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminProposer(&recordingProposer{}),
+	)
+	if err := srv.Validate(); err == nil {
+		t.Fatalf("Validate returned nil, want error for proposer-without-leaderView")
+	}
+}
+
+// TestEncryptionAdmin_Validate_OKWithoutProposer keeps the
+// read-only-server affordance: a server with neither proposer
+// nor leaderView is valid (it just rejects every mutator with
+// "proposer not configured"). Tests in this package rely on
+// this path.
+func TestEncryptionAdmin_Validate_OKWithoutProposer(t *testing.T) {
+	t.Parallel()
+	srv := NewEncryptionAdminServer()
+	if err := srv.Validate(); err != nil {
+		t.Errorf("Validate returned %v, want nil for read-only server", err)
+	}
+}
+
+// TestEncryptionAdmin_Validate_OKWithBothWired covers the
+// production happy path.
+func TestEncryptionAdmin_Validate_OKWithBothWired(t *testing.T) {
+	t.Parallel()
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminProposer(&recordingProposer{}),
+		WithEncryptionAdminLeaderView(stubLeaderView{state: raftengine.StateLeader}),
+	)
+	if err := srv.Validate(); err != nil {
+		t.Errorf("Validate returned %v, want nil", err)
+	}
+}
+
+// TestEncryptionAdmin_BootstrapEncryption_HappyPath verifies the
+// byte layout of the proposed §5.6 0x04 Raft entry by
+// round-tripping through fsmwire.DecodeBootstrap. Each writer in
+// the request expands into TWO registry rows (one per active
+// dek_id) so the §4.1 nonce-uniqueness invariant covers both
+// envelope purposes from the first post-bootstrap entry.
+func TestEncryptionAdmin_BootstrapEncryption_HappyPath(t *testing.T) {
+	t.Parallel()
+	proposer := &recordingProposer{commitIndex: 5}
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminProposer(proposer),
+		WithEncryptionAdminLeaderView(stubLeaderView{state: raftengine.StateLeader}),
+	)
+	req := validBootstrapEncryptionRequest()
+	got, err := srv.BootstrapEncryption(context.Background(), req)
+	if err != nil {
+		t.Fatalf("BootstrapEncryption: %v", err)
+	}
+	if got.AppliedIndex != 5 {
+		t.Errorf("AppliedIndex=%d, want 5", got.AppliedIndex)
+	}
+	assertSingleProposalOpcode(t, proposer.calls, fsmwire.OpBootstrap)
+	decoded, err := fsmwire.DecodeBootstrap(proposer.calls[0][1:])
+	if err != nil {
+		t.Fatalf("DecodeBootstrap: %v", err)
+	}
+	assertBootstrapDecodes(t, decoded, req)
+}
+
+func assertBootstrapDecodes(t *testing.T, got fsmwire.BootstrapPayload, req *pb.BootstrapEncryptionRequest) {
+	t.Helper()
+	assertBootstrapHeader(t, got, req)
+	wantRows := 2 * len(req.WriterBatch)
+	if len(got.BatchRegistry) != wantRows {
+		t.Fatalf("BatchRegistry len=%d, want %d (2 rows per writer)",
+			len(got.BatchRegistry), wantRows)
+	}
+	for i, w := range req.WriterBatch {
+		assertBootstrapWriterRows(t, i, got.BatchRegistry, w, req.StorageDekId, req.RaftDekId)
+	}
+}
+
+func assertBootstrapHeader(t *testing.T, got fsmwire.BootstrapPayload, req *pb.BootstrapEncryptionRequest) {
+	t.Helper()
+	if got.StorageDEKID != req.StorageDekId || got.RaftDEKID != req.RaftDekId {
+		t.Errorf("dek_ids=(s=%d, r=%d), want (%d, %d)",
+			got.StorageDEKID, got.RaftDEKID, req.StorageDekId, req.RaftDekId)
+	}
+	if string(got.WrappedStorage) != string(req.WrappedStorageDek) {
+		t.Errorf("WrappedStorage=%q, want %q", got.WrappedStorage, req.WrappedStorageDek)
+	}
+	if string(got.WrappedRaft) != string(req.WrappedRaftDek) {
+		t.Errorf("WrappedRaft=%q, want %q", got.WrappedRaft, req.WrappedRaftDek)
+	}
+}
+
+func assertBootstrapWriterRows(t *testing.T, i int, rows []fsmwire.RegistrationPayload, w *pb.WriterRegistryEntry, storageDEKID, raftDEKID uint32) {
+	t.Helper()
+	storage := rows[2*i]
+	raft := rows[2*i+1]
+	if storage.DEKID != storageDEKID || storage.FullNodeID != w.FullNodeId ||
+		raft.DEKID != raftDEKID || raft.FullNodeID != w.FullNodeId ||
+		uint32(storage.LocalEpoch) != w.LocalEpoch || uint32(raft.LocalEpoch) != w.LocalEpoch {
+		t.Errorf("writer[%d]: storage=%+v raft=%+v, want both anchored to full_node_id=%d epoch=%d",
+			i, storage, raft, w.FullNodeId, w.LocalEpoch)
+	}
+}
+
+func TestEncryptionAdmin_BootstrapEncryption_RejectsBadInputs(t *testing.T) {
+	t.Parallel()
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminProposer(&recordingProposer{}),
+		WithEncryptionAdminLeaderView(stubLeaderView{state: raftengine.StateLeader}),
+	)
+	type tc struct {
+		name string
+		mut  func(r *pb.BootstrapEncryptionRequest)
+	}
+	for _, c := range []tc{
+		{"zero storage_dek_id", func(r *pb.BootstrapEncryptionRequest) { r.StorageDekId = 0 }},
+		{"zero raft_dek_id", func(r *pb.BootstrapEncryptionRequest) { r.RaftDekId = 0 }},
+		{"storage_dek_id == raft_dek_id", func(r *pb.BootstrapEncryptionRequest) {
+			r.StorageDekId = 7
+			r.RaftDekId = 7
+		}},
+		{"empty wrapped_storage_dek", func(r *pb.BootstrapEncryptionRequest) { r.WrappedStorageDek = nil }},
+		{"empty wrapped_raft_dek", func(r *pb.BootstrapEncryptionRequest) { r.WrappedRaftDek = nil }},
+		{"empty writer_batch", func(r *pb.BootstrapEncryptionRequest) { r.WriterBatch = nil }},
+		{"writer with zero full_node_id", func(r *pb.BootstrapEncryptionRequest) {
+			r.WriterBatch = []*pb.WriterRegistryEntry{{FullNodeId: 0, LocalEpoch: 0}}
+		}},
+		{"writer with local_epoch above 0xFFFF", func(r *pb.BootstrapEncryptionRequest) {
+			r.WriterBatch = []*pb.WriterRegistryEntry{{FullNodeId: 1, LocalEpoch: 0x10000}}
+		}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			req := validBootstrapEncryptionRequest()
+			c.mut(req)
+			_, err := srv.BootstrapEncryption(context.Background(), req)
+			if status.Code(err) != codes.InvalidArgument {
+				t.Errorf("%s: status=%v, want InvalidArgument", c.name, status.Code(err))
+			}
+		})
+	}
+}
+
+func TestEncryptionAdmin_BootstrapEncryption_RejectsOversizeBatch(t *testing.T) {
+	t.Parallel()
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminProposer(&recordingProposer{}),
+		WithEncryptionAdminLeaderView(stubLeaderView{state: raftengine.StateLeader}),
+	)
+	req := validBootstrapEncryptionRequest()
+	// bootstrapBatchRowCap is 16384 ≈ 2 * 8192 writers. Stage 1a
+	// expands each writer into two rows; we ship just above the
+	// cap so the boundary check fires.
+	writers := make([]*pb.WriterRegistryEntry, bootstrapBatchRowCap/2+1)
+	for i := range writers {
+		// i ranges 0..~8192; bound-checked to stay inside uint64.
+		writers[i] = &pb.WriterRegistryEntry{FullNodeId: uint64(i) + 1} //nolint:gosec // i is bounded by len(writers) ≪ math.MaxInt64
+	}
+	req.WriterBatch = writers
+	_, err := srv.BootstrapEncryption(context.Background(), req)
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("BootstrapEncryption status=%v, want InvalidArgument on oversize batch", status.Code(err))
 	}
 }
 

--- a/adapter/encryption_admin_test.go
+++ b/adapter/encryption_admin_test.go
@@ -434,6 +434,9 @@ func TestEncryptionAdmin_BootstrapEncryption_RejectsBadInputs(t *testing.T) {
 		{"writer with local_epoch above 0xFFFF", func(r *pb.BootstrapEncryptionRequest) {
 			r.WriterBatch = []*pb.WriterRegistryEntry{{FullNodeId: 1, LocalEpoch: 0x10000}}
 		}},
+		{"nil writer in batch", func(r *pb.BootstrapEncryptionRequest) {
+			r.WriterBatch = []*pb.WriterRegistryEntry{nil}
+		}},
 	} {
 		t.Run(c.name, func(t *testing.T) {
 			req := validBootstrapEncryptionRequest()
@@ -615,6 +618,24 @@ func TestEncryptionAdmin_RotateDEK_RejectsOnFollower(t *testing.T) {
 	}
 	if err == nil || !strings.Contains(err.Error(), "n2") || !strings.Contains(err.Error(), "127.0.0.1:50052") {
 		t.Errorf("error %q does not embed the leader hint (id=n2 addr=127.0.0.1:50052)", err)
+	}
+}
+
+// TestEncryptionAdmin_RotateDEK_RejectsOversizeWrappedDEK is the
+// RotateDEK twin of the Bootstrap size-cap defence: a wrapped DEK
+// above maxWrappedDEKSize at the gRPC boundary cannot push
+// fsmwire.EncodeRotation toward its safeU32 length-prefix guard.
+func TestEncryptionAdmin_RotateDEK_RejectsOversizeWrappedDEK(t *testing.T) {
+	t.Parallel()
+	srv := NewEncryptionAdminServer(
+		WithEncryptionAdminProposer(&recordingProposer{}),
+		WithEncryptionAdminLeaderView(stubLeaderView{state: raftengine.StateLeader}),
+	)
+	req := validRotateDEKRequest()
+	req.WrappedNewDek = make([]byte, maxWrappedDEKSize+1)
+	_, err := srv.RotateDEK(context.Background(), req)
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("RotateDEK status=%v, want InvalidArgument on oversize wrapped_new_dek", status.Code(err))
 	}
 }
 

--- a/cmd/elastickv-admin/encryption.go
+++ b/cmd/elastickv-admin/encryption.go
@@ -40,18 +40,20 @@ func encryptionMain(args []string) error {
 		return runEncryptionRotateDEK(rest, os.Stdout)
 	case "register-writer":
 		return runEncryptionRegisterWriter(rest, os.Stdout)
+	case "bootstrap":
+		return runEncryptionBootstrap(rest, os.Stdout)
 	case "-h", "--help", "help":
 		// `-h` is the universal "show usage" affordance for CLI
 		// subcommands; returning nil keeps the exit code at 0
 		// so shell scripts using $? to detect success do not
 		// trip on a help request.
-		_, err := fmt.Fprintln(os.Stdout, "usage: elastickv-admin encryption <subcommand> [flags]\n\nsubcommands:\n  status\n  rotate-dek\n  register-writer")
+		_, err := fmt.Fprintln(os.Stdout, "usage: elastickv-admin encryption <subcommand> [flags]\n\nsubcommands:\n  status\n  rotate-dek\n  register-writer\n  bootstrap")
 		if err != nil {
 			return errors.Wrap(err, "write usage")
 		}
 		return nil
 	default:
-		return errors.Errorf("encryption: unknown subcommand %q (supported: status, rotate-dek, register-writer)", sub)
+		return errors.Errorf("encryption: unknown subcommand %q (supported: status, rotate-dek, register-writer, bootstrap)", sub)
 	}
 }
 

--- a/cmd/elastickv-admin/encryption_mutators.go
+++ b/cmd/elastickv-admin/encryption_mutators.go
@@ -206,11 +206,6 @@ func requireUint16Plus1(v uint, name string) error {
 	return nil
 }
 
-// narrowUint32 mirrors adapter.uint32ToLocalEpoch: callers MUST
-// have validated `v` against math.MaxUint32 first (via
-// requireUint32). The masked conversion is a defence-in-depth
-// truncation that cannot drift even if a future caller skips the
-// bound check.
 // runEncryptionBootstrap invokes EncryptionAdmin.BootstrapEncryption.
 // The operator provides the wrapped DEK pair (base64), the two
 // dek_ids, and the §5.6 step 1a writer batch as repeated
@@ -368,6 +363,11 @@ func parseWriterBatch(raw []string) ([]*pb.WriterRegistryEntry, error) {
 // does not flag the mask itself.
 const uint32Mask uint = 0xFFFFFFFF
 
+// narrowUint32 mirrors adapter.uint32ToLocalEpoch: callers MUST
+// have validated `v` against math.MaxUint32 first (via
+// requireUint32). The masked conversion is a defence-in-depth
+// truncation that cannot drift even if a future caller skips the
+// bound check.
 func narrowUint32(v uint) uint32 {
 	return uint32(v & uint32Mask) //nolint:gosec // bound-checked + masked; G115 cannot trace across the flag-parse boundary
 }

--- a/cmd/elastickv-admin/encryption_mutators.go
+++ b/cmd/elastickv-admin/encryption_mutators.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"strconv"
 	"strings"
 
 	pb "github.com/bootjp/elastickv/proto"
@@ -202,6 +203,158 @@ func requireUint16Plus1(v uint, name string) error {
 // requireUint32). The masked conversion is a defence-in-depth
 // truncation that cannot drift even if a future caller skips the
 // bound check.
+// runEncryptionBootstrap invokes EncryptionAdmin.BootstrapEncryption.
+// The operator provides the wrapped DEK pair (base64), the two
+// dek_ids, and the §5.6 step 1a writer batch as repeated
+// --writer=<full_node_id>:<local_epoch> flag values. Cluster-wide
+// capability fan-out (computing the batch automatically by
+// dialing every member's GetCapability) is deferred to a later
+// CLI iteration; for now the operator runs `encryption status`
+// against each member to gather the batch and passes it
+// explicitly.
+func runEncryptionBootstrap(args []string, out io.Writer) error {
+	parsed, endpoint, err := parseBootstrapArgs(args)
+	if err != nil {
+		return err
+	}
+	if parsed == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), *endpoint.timeout)
+	defer cancel()
+	client, closeFn, err := dialEncryption(ctx, endpoint)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := closeFn(); err != nil {
+			fmt.Fprintf(os.Stderr, "encryption: close connection: %v\n", err)
+		}
+	}()
+	resp, err := client.BootstrapEncryption(ctx, parsed)
+	if err != nil {
+		return errors.Wrap(err, "BootstrapEncryption")
+	}
+	if _, err := fmt.Fprintf(out, "bootstrapped storage_dek_id=%d raft_dek_id=%d writers=%d applied_index=%d\n",
+		parsed.StorageDekId, parsed.RaftDekId, len(parsed.WriterBatch), resp.AppliedIndex); err != nil {
+		return errors.Wrap(err, "write result")
+	}
+	return nil
+}
+
+// parseBootstrapArgs returns the validated proto request and the
+// shared endpoint flags. A nil request with no error means the
+// caller requested --help; runEncryptionBootstrap then exits 0.
+func parseBootstrapArgs(args []string) (*pb.BootstrapEncryptionRequest, *encryptionEndpointFlags, error) {
+	fs := flag.NewFlagSet("encryption bootstrap", flag.ContinueOnError)
+	endpoint := newEncryptionEndpointFlags(fs)
+	storageDEKID := fs.Uint("storage-dek-id", 0, "Storage DEK key id; must be non-zero and differ from --raft-dek-id")
+	raftDEKID := fs.Uint("raft-dek-id", 0, "Raft DEK key id; must be non-zero and differ from --storage-dek-id")
+	wrappedStorageB64 := fs.String("wrapped-storage-dek", "", "Base64 of the KEK-wrapped storage DEK")
+	wrappedRaftB64 := fs.String("wrapped-raft-dek", "", "Base64 of the KEK-wrapped raft DEK")
+	var writerFlags stringSliceFlag
+	fs.Var(&writerFlags, "writer", "Writer-registry entry as <full_node_id>:<local_epoch>; repeat per member")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil, endpoint, nil
+		}
+		return nil, nil, errors.Wrap(err, "parse flags")
+	}
+	if err := validateBootstrapDEKIDs(*storageDEKID, *raftDEKID); err != nil {
+		return nil, nil, err
+	}
+	wrappedStorage, wrappedRaft, err := decodeBootstrapWrappedDEKs(*wrappedStorageB64, *wrappedRaftB64)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(writerFlags) == 0 {
+		return nil, nil, errors.New("encryption: at least one --writer=<full_node_id>:<local_epoch> is required")
+	}
+	batch, err := parseWriterBatch(writerFlags)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &pb.BootstrapEncryptionRequest{
+		StorageDekId:      narrowUint32(*storageDEKID),
+		RaftDekId:         narrowUint32(*raftDEKID),
+		WrappedStorageDek: wrappedStorage,
+		WrappedRaftDek:    wrappedRaft,
+		WriterBatch:       batch,
+	}, endpoint, nil
+}
+
+func validateBootstrapDEKIDs(storage, raft uint) error {
+	if err := requireUint32(storage, "storage-dek-id"); err != nil {
+		return err
+	}
+	if err := requireUint32(raft, "raft-dek-id"); err != nil {
+		return err
+	}
+	if storage == 0 {
+		return errors.New("encryption: --storage-dek-id is required and must be non-zero")
+	}
+	if raft == 0 {
+		return errors.New("encryption: --raft-dek-id is required and must be non-zero")
+	}
+	if storage == raft {
+		return errors.New("encryption: --storage-dek-id and --raft-dek-id must differ")
+	}
+	return nil
+}
+
+func decodeBootstrapWrappedDEKs(storageB64, raftB64 string) ([]byte, []byte, error) {
+	storage, err := decodeWrappedDEKFlag(storageB64)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "--wrapped-storage-dek")
+	}
+	raft, err := decodeWrappedDEKFlag(raftB64)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "--wrapped-raft-dek")
+	}
+	return storage, raft, nil
+}
+
+// stringSliceFlag accumulates repeated `--writer=` flags as a
+// flat string slice. Each entry is parsed in parseWriterBatch
+// after the flag.Parse pass so a malformed entry surfaces a
+// single composite error rather than a half-built batch.
+type stringSliceFlag []string
+
+func (s *stringSliceFlag) String() string { return strings.Join(*s, ",") }
+func (s *stringSliceFlag) Set(v string) error {
+	*s = append(*s, v)
+	return nil
+}
+
+func parseWriterBatch(raw []string) ([]*pb.WriterRegistryEntry, error) {
+	out := make([]*pb.WriterRegistryEntry, 0, len(raw))
+	for i, entry := range raw {
+		nodeIDStr, epochStr, ok := strings.Cut(entry, ":")
+		if !ok {
+			return nil, errors.Errorf("encryption: --writer[%d]=%q is not <full_node_id>:<local_epoch>", i, entry)
+		}
+		nodeID, err := strconv.ParseUint(nodeIDStr, 10, 64)
+		if err != nil {
+			return nil, errors.Wrapf(err, "encryption: --writer[%d] full_node_id", i)
+		}
+		if nodeID == 0 {
+			return nil, errors.Errorf("encryption: --writer[%d] full_node_id must be non-zero (0 is reserved)", i)
+		}
+		epoch, err := strconv.ParseUint(epochStr, 10, 32)
+		if err != nil {
+			return nil, errors.Wrapf(err, "encryption: --writer[%d] local_epoch", i)
+		}
+		if epoch > math.MaxUint16 {
+			return nil, errors.Errorf("encryption: --writer[%d] local_epoch=%d exceeds 0xFFFF", i, epoch)
+		}
+		out = append(out, &pb.WriterRegistryEntry{
+			FullNodeId: nodeID,
+			LocalEpoch: narrowUint32(uint(epoch)),
+		})
+	}
+	return out, nil
+}
+
 // uint32Mask is the defence-in-depth narrowing mask for the
 // uint→uint32 conversion below; named so the magic-number linter
 // does not flag the mask itself.

--- a/cmd/elastickv-admin/encryption_mutators.go
+++ b/cmd/elastickv-admin/encryption_mutators.go
@@ -171,15 +171,23 @@ func parseRotatePurposeFlag(s string) (pb.RotateDEKRequest_Purpose, error) {
 }
 
 func decodeWrappedDEKFlag(s string) ([]byte, error) {
+	return decodeWrappedDEKFlagWithName("wrapped-new-dek", s)
+}
+
+// decodeWrappedDEKFlagWithName is the flag-name-aware variant
+// used by bootstrap (which has two wrapped-DEK flags) so error
+// messages reference the actual flag the operator typed rather
+// than the rotate-dek default.
+func decodeWrappedDEKFlagWithName(flagName, s string) ([]byte, error) {
 	if s == "" {
-		return nil, errors.New("encryption: --wrapped-new-dek is required (base64 of the KEK-wrapped DEK)")
+		return nil, errors.Errorf("encryption: --%s is required (base64 of the KEK-wrapped DEK)", flagName)
 	}
 	out, err := base64.StdEncoding.DecodeString(s)
 	if err != nil {
-		return nil, errors.Wrap(err, "encryption: --wrapped-new-dek is not valid base64")
+		return nil, errors.Wrapf(err, "encryption: --%s is not valid base64", flagName)
 	}
 	if len(out) == 0 {
-		return nil, errors.New("encryption: --wrapped-new-dek decoded to zero bytes")
+		return nil, errors.Errorf("encryption: --%s decoded to zero bytes", flagName)
 	}
 	return out, nil
 }
@@ -303,13 +311,13 @@ func validateBootstrapDEKIDs(storage, raft uint) error {
 }
 
 func decodeBootstrapWrappedDEKs(storageB64, raftB64 string) ([]byte, []byte, error) {
-	storage, err := decodeWrappedDEKFlag(storageB64)
+	storage, err := decodeWrappedDEKFlagWithName("wrapped-storage-dek", storageB64)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "--wrapped-storage-dek")
+		return nil, nil, err
 	}
-	raft, err := decodeWrappedDEKFlag(raftB64)
+	raft, err := decodeWrappedDEKFlagWithName("wrapped-raft-dek", raftB64)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "--wrapped-raft-dek")
+		return nil, nil, err
 	}
 	return storage, raft, nil
 }

--- a/cmd/elastickv-admin/encryption_test.go
+++ b/cmd/elastickv-admin/encryption_test.go
@@ -254,6 +254,29 @@ func assertBootstrapCallMatches(t *testing.T, call *pb.BootstrapEncryptionReques
 	}
 }
 
+// TestRunEncryptionBootstrap_RejectsEmptyWriterBatch pins the CLI
+// parse-layer guard for the missing-entirely case (no --writer
+// flags at all). The server-side "empty writer_batch" path is
+// covered by adapter tests, but the CLI's own early-out in
+// parseBootstrapArgs is otherwise unexercised.
+func TestRunEncryptionBootstrap_RejectsEmptyWriterBatch(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	err := runEncryptionBootstrap([]string{
+		"--endpoint", "127.0.0.1:1",
+		"--storage-dek-id", "1",
+		"--raft-dek-id", "2",
+		"--wrapped-storage-dek", "d3JhcHBlZC1zdG9yYWdl",
+		"--wrapped-raft-dek", "d3JhcHBlZC1yYWZ0",
+	}, &buf)
+	if err == nil {
+		t.Fatalf("runEncryptionBootstrap returned nil, want error on missing --writer flags")
+	}
+	if !strings.Contains(err.Error(), "writer") {
+		t.Errorf("error %q does not surface the missing --writer condition", err)
+	}
+}
+
 func TestRunEncryptionBootstrap_RejectsBadWriter(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer

--- a/cmd/elastickv-admin/encryption_test.go
+++ b/cmd/elastickv-admin/encryption_test.go
@@ -173,10 +173,11 @@ func (s *stubSidecarErrorServer) GetSidecarState(context.Context, *pb.Empty) (*p
 // inherit Unimplemented defaults.
 type stubMutatorServer struct {
 	pb.UnimplementedEncryptionAdminServer
-	rotateCalls   []*pb.RotateDEKRequest
-	registerCalls []*pb.RegisterEncryptionWriterRequest
-	appliedIndex  uint64
-	returnErr     error
+	rotateCalls    []*pb.RotateDEKRequest
+	registerCalls  []*pb.RegisterEncryptionWriterRequest
+	bootstrapCalls []*pb.BootstrapEncryptionRequest
+	appliedIndex   uint64
+	returnErr      error
 }
 
 func (s *stubMutatorServer) RotateDEK(_ context.Context, req *pb.RotateDEKRequest) (*pb.RotateDEKResponse, error) {
@@ -193,6 +194,93 @@ func (s *stubMutatorServer) RegisterEncryptionWriter(_ context.Context, req *pb.
 		return nil, s.returnErr
 	}
 	return &pb.RegisterEncryptionWriterResponse{AppliedIndex: s.appliedIndex}, nil
+}
+
+func (s *stubMutatorServer) BootstrapEncryption(_ context.Context, req *pb.BootstrapEncryptionRequest) (*pb.BootstrapEncryptionResponse, error) {
+	s.bootstrapCalls = append(s.bootstrapCalls, req)
+	if s.returnErr != nil {
+		return nil, s.returnErr
+	}
+	return &pb.BootstrapEncryptionResponse{AppliedIndex: s.appliedIndex}, nil
+}
+
+func TestRunEncryptionBootstrap_HappyPath(t *testing.T) {
+	t.Parallel()
+	stub := &stubMutatorServer{appliedIndex: 117}
+	addr := startCustomEncryptionAdminTestServer(t, stub)
+
+	var buf bytes.Buffer
+	err := runEncryptionBootstrap([]string{
+		"--endpoint", addr,
+		"--timeout", "3s",
+		"--storage-dek-id", "1",
+		"--raft-dek-id", "2",
+		// "wrapped-storage" base64-encoded
+		"--wrapped-storage-dek", "d3JhcHBlZC1zdG9yYWdl",
+		// "wrapped-raft" base64-encoded
+		"--wrapped-raft-dek", "d3JhcHBlZC1yYWZ0",
+		"--writer", "11:0",
+		"--writer", "22:5",
+	}, &buf)
+	if err != nil {
+		t.Fatalf("runEncryptionBootstrap: %v", err)
+	}
+	if !strings.Contains(buf.String(), "applied_index=117") {
+		t.Errorf("output missing applied_index=117, got:\n%s", buf.String())
+	}
+	if len(stub.bootstrapCalls) != 1 {
+		t.Fatalf("BootstrapEncryption calls=%d, want 1", len(stub.bootstrapCalls))
+	}
+	assertBootstrapCallMatches(t, stub.bootstrapCalls[0])
+}
+
+func assertBootstrapCallMatches(t *testing.T, call *pb.BootstrapEncryptionRequest) {
+	t.Helper()
+	if call.StorageDekId != 1 || call.RaftDekId != 2 {
+		t.Errorf("dek ids=(s=%d,r=%d), want (1,2)", call.StorageDekId, call.RaftDekId)
+	}
+	if string(call.WrappedStorageDek) != "wrapped-storage" {
+		t.Errorf("WrappedStorageDek=%q, want wrapped-storage", call.WrappedStorageDek)
+	}
+	if string(call.WrappedRaftDek) != "wrapped-raft" {
+		t.Errorf("WrappedRaftDek=%q, want wrapped-raft", call.WrappedRaftDek)
+	}
+	if len(call.WriterBatch) != 2 {
+		t.Fatalf("WriterBatch len=%d, want 2", len(call.WriterBatch))
+	}
+	if call.WriterBatch[0].FullNodeId != 11 || call.WriterBatch[0].LocalEpoch != 0 ||
+		call.WriterBatch[1].FullNodeId != 22 || call.WriterBatch[1].LocalEpoch != 5 {
+		t.Errorf("WriterBatch=%v, want [(11,0),(22,5)]", call.WriterBatch)
+	}
+}
+
+func TestRunEncryptionBootstrap_RejectsBadWriter(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	for _, c := range []struct {
+		name  string
+		entry string
+	}{
+		{"missing colon", "12345"},
+		{"non-numeric node_id", "abc:0"},
+		{"non-numeric epoch", "1:xyz"},
+		{"zero node_id", "0:0"},
+		{"epoch above 0xFFFF", "1:70000"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			err := runEncryptionBootstrap([]string{
+				"--endpoint", "127.0.0.1:1",
+				"--storage-dek-id", "1",
+				"--raft-dek-id", "2",
+				"--wrapped-storage-dek", "d3JhcHBlZC1zdG9yYWdl",
+				"--wrapped-raft-dek", "d3JhcHBlZC1yYWZ0",
+				"--writer", c.entry,
+			}, &buf)
+			if err == nil {
+				t.Errorf("%s: runEncryptionBootstrap returned nil, want error for --writer=%q", c.name, c.entry)
+			}
+		})
+	}
 }
 
 func TestRunEncryptionRotateDEK_HappyPath(t *testing.T) {

--- a/docs/design/2026_04_29_partial_data_at_rest_encryption.md
+++ b/docs/design/2026_04_29_partial_data_at_rest_encryption.md
@@ -14,8 +14,9 @@ Date: 2026-04-29
 | 3 | Raft envelope + engine pre-apply hook (§6.3, §4.2) | shipped | PR #744 |
 | 4 | FSM-internal Raft entry types (§5.6, §5.2 wire, §11.3 reserved opcodes) | shipped | PR #748 |
 | 5A | `EncryptionAdmin` proto + read-only RPCs + `encryption status` CLI | shipped | PR #754 |
-| 5B | RotateDEK + RegisterEncryptionWriter (leader-only Proposer wiring) + `rotate-dek` / `register-writer` CLI + ResyncSidecar leader guard | in PR | — |
-| 5C | BootstrapEncryption + §5.6 step 1a capability fan-out + `bootstrap` CLI + main.go gRPC wiring | open | — |
+| 5B | RotateDEK + RegisterEncryptionWriter (leader-only Proposer wiring) + `rotate-dek` / `register-writer` CLI + ResyncSidecar leader guard | shipped | PR #756 |
+| 5C | BootstrapEncryption + `encryption bootstrap` CLI + nil-leaderView startup `Validate()` enforcement | in PR | — |
+| 5D | §5.6 step 1a capability fan-out helper + main.go gRPC wiring | open | — |
 | 6 | 3-phase rollout flags + applier wiring (§6.5, §7.1) | open | — |
 | 7 | Writer registry + deterministic nonce (§4.1) | open | — |
 | 8 | Snapshot header v2 + WAL coverage (§4.4, §4.5) | open | — |


### PR DESCRIPTION
## Summary

Stage 5 **PR-C** of the data-at-rest encryption rollout (design doc:
`docs/design/2026_04_29_partial_data_at_rest_encryption.md`, §5.6
bootstrap, §6.1 admin.go, §6.6 admin commands). Closes the last
mutating-RPC gap in the `proto.EncryptionAdmin` surface and adds the
production-wiring guard the PR-B review carry-forward identified.

Production-inert: `main.go` does not yet register
`EncryptionAdminServer`; that wiring is **Stage 5D** along with the
§5.6 step 1a capability fan-out helper.

## What lands

- **`BootstrapEncryption` server impl**: proposes the §5.6 0x04
  OpBootstrap entry. Validates `storage_dek_id != 0 != raft_dek_id`,
  `storage_dek_id != raft_dek_id`, non-empty wrapped DEK pair,
  non-empty writer batch, each writer's `full_node_id != 0` /
  `local_epoch <= 0xFFFF`, and `2 * len(writers) <=
  bootstrapBatchRowCap` (mirrors `fsmwire.maxBootstrapBatchCount`).
  Expands each writer into a storage-DEK row + a raft-DEK row so
  the §4.1 nonce-uniqueness invariant covers both purposes from
  the first post-bootstrap entry.
- **`elastickv-admin encryption bootstrap` CLI**: takes
  `--storage-dek-id`, `--raft-dek-id`, `--wrapped-storage-dek`
  (base64), `--wrapped-raft-dek` (base64), and repeated
  `--writer=<full_node_id>:<local_epoch>`. The capability
  fan-out is deferred; the operator ships a pre-built batch.
- **`Validate()` method**: fails closed when a proposer is wired
  without a `LeaderView` so production code in `main.go` cannot
  silently let followers mutate state. Tests still get the
  no-leaderView affordance for proposer-side unit tests.
- **Design doc**: Stage 5 row split — 5A shipped (#754), 5B
  shipped (#756), 5C in PR, 5D open.

## Out of scope (Stage 5D / Stage 6)

- §5.6 step 1a capability fan-out helper (auto-build the writer
  batch by dialing every cluster member's `GetCapability`).
- `main.go` gRPC wiring (register `EncryptionAdminServer` on the
  shard gRPC listener, plumb proposer/leaderView from the shard's
  `raftengine.Engine`, call `Validate()` at startup).
- Stage 6 `--encryption-enabled` cluster flag + §9.1 startup
  refusal guards.

## Test plan

- [x] `go test -race -timeout=60s ./adapter -run TestEncryptionAdmin`
  — adds:
  - `BootstrapEncryption_HappyPath` (wire-layout round-trip via
    `fsmwire.DecodeBootstrap`, row-ordering pinned).
  - `BootstrapEncryption_RejectsBadInputs` (8-case table: zero
    ids, equal ids, empty wrapped DEKs, empty batch, zero
    `full_node_id`, epoch > 0xFFFF).
  - `BootstrapEncryption_RejectsOversizeBatch` (above
    `bootstrapBatchRowCap`).
  - `Validate_*` three-way: no proposer / both wired /
    proposer-without-leaderView.
  - Existing `MutatingRPCs_RejectWithoutProposer` extended to
    cover Bootstrap.
- [x] `go test -race -timeout=60s ./cmd/elastickv-admin -run TestRunEncryptionBootstrap`
  — CLI happy path against a stub gRPC server + 5-case
  parse-error table (`--writer` malformed).
- [x] `golangci-lint run` on touched paths — 0 issues.
- [ ] CI verifies build / lint / Jepsen.

## Self-review (CLAUDE.md 5 passes)

1. **Data loss** — leader-gated mutator on top of Stage 4's
   `HaltApply` seam. Empty batch / oversize batch rejected at
   the gRPC boundary. Idempotency lives at the FSM apply layer
   (rejects if `active.storage != 0`).
2. **Concurrency** — no new mutable state in the server. The
   §5.6 step 1a fan-out itself is intentionally deferred.
3. **Performance** — hot path unchanged. Mutator is one-shot
   per cluster lifetime.
4. **Consistency** — `fsmwire` encoder is the single source of
   truth for the on-wire byte layout. The round-trip test locks
   the server's view against `fsmwire`'s. Row-ordering is
   pinned (storage row i precedes raft row i).
5. **Test coverage** — boundary table, oversize batch,
   no-proposer rejection, leader-gating (inherited from
   `requireLeader`), `Validate()` three-way coverage, CLI happy
   path, CLI parse-time error table.

## Notes

- Same toolchain note as #754 / #756: proto regenerated locally
  with `libprotoc 29.6`; no wire-relevant difference vs the
  canonical 29.3.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a leader-only "Bootstrap Encryption" admin RPC and an "encryption bootstrap" CLI to initialize encryption state in a single operation.
  
* **Improvements**
  * Stricter server startup validation to catch invalid configurations early.
  * Tightened wrapped-DEK and writer-entry validation (size, bounds, uniqueness).

* **Bug Fixes / Tests**
  * Extensive tests covering bootstrap, validation, and rotate-DEK rejection cases.

* **Documentation**
  * Updated encryption-at-rest rollout milestones to reflect bootstrap completion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/759?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->