### PR TITLE
feat(encryption): Stage 5 PR-D — main.go gRPC wiring for EncryptionAdmin

### DIFF
--- a/docs/design/2026_04_29_partial_data_at_rest_encryption.md
+++ b/docs/design/2026_04_29_partial_data_at_rest_encryption.md
@@ -15,8 +15,9 @@ Date: 2026-04-29
 | 4 | FSM-internal Raft entry types (§5.6, §5.2 wire, §11.3 reserved opcodes) | shipped | PR #748 |
 | 5A | `EncryptionAdmin` proto + read-only RPCs + `encryption status` CLI | shipped | PR #754 |
 | 5B | RotateDEK + RegisterEncryptionWriter (leader-only Proposer wiring) + `rotate-dek` / `register-writer` CLI + ResyncSidecar leader guard | shipped | PR #756 |
-| 5C | BootstrapEncryption + `encryption bootstrap` CLI + nil-leaderView startup `Validate()` enforcement | in PR | — |
-| 5D | §5.6 step 1a capability fan-out helper + main.go gRPC wiring | open | — |
+| 5C | BootstrapEncryption + `encryption bootstrap` CLI + nil-leaderView startup `Validate()` enforcement | shipped | PR #759 |
+| 5D | main.go gRPC wiring (per-shard EncryptionAdmin registration + `--encryptionSidecarPath` flag) | in PR | — |
+| 5E | §5.6 step 1a capability fan-out helper + `encryption bootstrap --discover-from=...` auto-batch mode | open | — |
 | 6 | 3-phase rollout flags + applier wiring (§6.5, §7.1) | open | — |
 | 7 | Writer registry + deterministic nonce (§4.1) | open | — |
 | 8 | Snapshot header v2 + WAL coverage (§4.4, §4.5) | open | — |

--- a/main.go
+++ b/main.go
@@ -144,13 +144,16 @@ var (
 	// Data-at-rest encryption admin RPC wiring (Stage 5D). The
 	// EncryptionAdmin gRPC service is reachable on every shard's
 	// gRPC listener so the §7.1 Phase-0 GetCapability fan-out can
-	// poll any member. Mutating RPCs (Bootstrap / RotateDEK /
-	// RegisterEncryptionWriter) are leader-gated through the
-	// shard's raftengine.LeaderView. The cluster-flag gate that
-	// turns encryption ON is Stage 6 (§7.1); this flag only points
-	// the server at the §5.1 sidecar so the read-only probes can
-	// report capability state without enabling encryption.
-	encryptionSidecarPath = flag.String("encryptionSidecarPath", "", "§5.1 keys.json path; empty disables the read-only EncryptionAdmin sidecar probes. Mutating RPCs are unaffected (they are leader-gated through raftengine).")
+	// poll any member. This flag is the load-bearing gate for the
+	// mutating RPCs pre-Stage 6: setting it wires the proposer +
+	// LeaderView so RotateDEK / BootstrapEncryption /
+	// RegisterEncryptionWriter become reachable on the shard's
+	// leader; leaving it empty omits both options so those RPCs
+	// short-circuit at the gRPC boundary with FailedPrecondition
+	// before any Raft proposal is created. The cluster-flag gate
+	// that turns the §6.3 FSM applier ON — and thereby makes a
+	// committed mutator entry actually do something — is Stage 6.
+	encryptionSidecarPath = flag.String("encryptionSidecarPath", "", "§5.1 keys.json path; empty disables EncryptionAdmin sidecar capability probing AND leaves mutating EncryptionAdmin RPCs unwired on this node (proposer + LeaderView omitted → FailedPrecondition at the RPC boundary).")
 
 	// Key visualizer sampler flags. The sampler runs entirely in-memory
 	// on each node, feeds AdminServer.GetKeyVizMatrix, and is disabled

--- a/main.go
+++ b/main.go
@@ -1292,7 +1292,7 @@ func startRaftServers(
 		// FNV-1a hash already used by raftengine for peer ids
 		// (etcd.DeriveNodeID), so every node in the cluster reports
 		// a stable, distinct value. Codex r1 P1 on PR #760.
-		registerEncryptionAdminServer(gs, rt.engine, etcdraftengine.DeriveNodeID(*raftId))
+		registerEncryptionAdminServer(gs, rt.engine, etcdraftengine.DeriveNodeID(*raftId), *encryptionSidecarPath)
 		registerAdminForwardServer(gs, forwardDeps, forwardLogger)
 		rt.registerGRPC(gs)
 		internalraftadmin.RegisterOperationalServices(ctx, gs, rt.engine, []string{"RawKV"})

--- a/main.go
+++ b/main.go
@@ -1292,7 +1292,7 @@ func startRaftServers(
 		// FNV-1a hash already used by raftengine for peer ids
 		// (etcd.DeriveNodeID), so every node in the cluster reports
 		// a stable, distinct value. Codex r1 P1 on PR #760.
-		registerEncryptionAdminServer(gs, rt.engine, etcdraftengine.DeriveNodeID(*raftId), *encryptionSidecarPath)
+		registerEncryptionAdminServer(gs, etcdraftengine.DeriveNodeID(*raftId), *encryptionSidecarPath)
 		registerAdminForwardServer(gs, forwardDeps, forwardLogger)
 		rt.registerGRPC(gs)
 		internalraftadmin.RegisterOperationalServices(ctx, gs, rt.engine, []string{"RawKV"})

--- a/main.go
+++ b/main.go
@@ -1278,7 +1278,18 @@ func startRaftServers(
 		if adminServer != nil {
 			pb.RegisterAdminServer(gs, adminServer)
 		}
-		registerEncryptionAdminServer(gs, rt.engine, rt.spec.id)
+		// full_node_id MUST be per-node-stable, not per-shard.
+		// rt.spec.id is the Raft group id which every replica of
+		// the same group shares; using it as full_node_id makes
+		// every node return the same CapabilityReport value and
+		// BootstrapEncryption's writer-batch uniqueness validation
+		// (adapter/encryption_admin.go validateWriterBatchUniqueness)
+		// rejects the bootstrap with "duplicate full_node_id".
+		// Derive a per-node uint64 from --raftId via the canonical
+		// FNV-1a hash already used by raftengine for peer ids
+		// (etcd.DeriveNodeID), so every node in the cluster reports
+		// a stable, distinct value. Codex r1 P1 on PR #760.
+		registerEncryptionAdminServer(gs, rt.engine, etcdraftengine.DeriveNodeID(*raftId))
 		registerAdminForwardServer(gs, forwardDeps, forwardLogger)
 		rt.registerGRPC(gs)
 		internalraftadmin.RegisterOperationalServices(ctx, gs, rt.engine, []string{"RawKV"})

--- a/main.go
+++ b/main.go
@@ -144,16 +144,24 @@ var (
 	// Data-at-rest encryption admin RPC wiring (Stage 5D). The
 	// EncryptionAdmin gRPC service is reachable on every shard's
 	// gRPC listener so the §7.1 Phase-0 GetCapability fan-out can
-	// poll any member. This flag is the load-bearing gate for the
-	// mutating RPCs pre-Stage 6: setting it wires the proposer +
-	// LeaderView so RotateDEK / BootstrapEncryption /
-	// RegisterEncryptionWriter become reachable on the shard's
-	// leader; leaving it empty omits both options so those RPCs
-	// short-circuit at the gRPC boundary with FailedPrecondition
-	// before any Raft proposal is created. The cluster-flag gate
-	// that turns the §6.3 FSM applier ON — and thereby makes a
-	// committed mutator entry actually do something — is Stage 6.
-	encryptionSidecarPath = flag.String("encryptionSidecarPath", "", "§5.1 keys.json path; empty disables EncryptionAdmin sidecar capability probing AND leaves mutating EncryptionAdmin RPCs unwired on this node (proposer + LeaderView omitted → FailedPrecondition at the RPC boundary).")
+	// poll any member.
+	//
+	// This flag gates ONLY the read-only capability surface:
+	// empty → GetCapability reports encryption_capable=false (the
+	// §7.1 cutover refuses with ErrCapabilityCheckFailed);
+	// set   → capability probing reads the §5.1 keys.json and
+	// reports encryption_capable=true.
+	//
+	// Mutating RPCs (BootstrapEncryption / RotateDEK /
+	// RegisterEncryptionWriter) are refused with FailedPrecondition
+	// regardless of this flag. The §6.3 WithEncryption FSM applier
+	// is plumbed by Stage 6; until then registerEncryptionAdminServer
+	// installs neither the Proposer nor the LeaderView, so every
+	// mutator short-circuits at the gRPC boundary before any Raft
+	// proposal is created. Setting --encryptionSidecarPath does
+	// NOT enable mutating RPCs; Stage 6 wires the applier and the
+	// Proposer + LeaderView together in the same change.
+	encryptionSidecarPath = flag.String("encryptionSidecarPath", "", "§5.1 keys.json path; enables read-only EncryptionAdmin capability probing. Mutating RPCs (Bootstrap / RotateDEK / RegisterEncryptionWriter) are refused with FailedPrecondition regardless of this flag until Stage 6 wires the §6.3 FSM applier together with the Proposer + LeaderView.")
 
 	// Key visualizer sampler flags. The sampler runs entirely in-memory
 	// on each node, feeds AdminServer.GetKeyVizMatrix, and is disabled

--- a/main.go
+++ b/main.go
@@ -141,6 +141,17 @@ var (
 	adminReadOnlyAccessKeys            = flag.String("adminReadOnlyAccessKeys", "", "Comma-separated SigV4 access keys granted read-only admin access")
 	adminFullAccessKeys                = flag.String("adminFullAccessKeys", "", "Comma-separated SigV4 access keys granted full-access admin role")
 
+	// Data-at-rest encryption admin RPC wiring (Stage 5D). The
+	// EncryptionAdmin gRPC service is reachable on every shard's
+	// gRPC listener so the §7.1 Phase-0 GetCapability fan-out can
+	// poll any member. Mutating RPCs (Bootstrap / RotateDEK /
+	// RegisterEncryptionWriter) are leader-gated through the
+	// shard's raftengine.LeaderView. The cluster-flag gate that
+	// turns encryption ON is Stage 6 (§7.1); this flag only points
+	// the server at the §5.1 sidecar so the read-only probes can
+	// report capability state without enabling encryption.
+	encryptionSidecarPath = flag.String("encryptionSidecarPath", "", "§5.1 keys.json path; empty disables the read-only EncryptionAdmin sidecar probes. Mutating RPCs are unaffected (they are leader-gated through raftengine).")
+
 	// Key visualizer sampler flags. The sampler runs entirely in-memory
 	// on each node, feeds AdminServer.GetKeyVizMatrix, and is disabled
 	// by default — opt in with --keyvizEnabled. The other flags are
@@ -1267,6 +1278,7 @@ func startRaftServers(
 		if adminServer != nil {
 			pb.RegisterAdminServer(gs, adminServer)
 		}
+		registerEncryptionAdminServer(gs, rt.engine, rt.spec.id)
 		registerAdminForwardServer(gs, forwardDeps, forwardLogger)
 		rt.registerGRPC(gs)
 		internalraftadmin.RegisterOperationalServices(ctx, gs, rt.engine, []string{"RawKV"})

--- a/main_encryption_admin.go
+++ b/main_encryption_admin.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"github.com/bootjp/elastickv/adapter"
+	"github.com/bootjp/elastickv/internal/raftengine"
+	pb "github.com/bootjp/elastickv/proto"
+	"github.com/cockroachdb/errors"
+	"google.golang.org/grpc"
+)
+
+// encryptionAdminEngine is the subset of raftengine.Engine the
+// EncryptionAdminServer needs: a Proposer (for the mutating RPCs)
+// and a LeaderView (for the requireLeader gate). Every shard's
+// raftengine.Engine satisfies both interfaces; declaring a local
+// intersection keeps the construction site decoupled from the
+// concrete engine type and lets tests substitute a stub without
+// pulling in the full engine surface.
+type encryptionAdminEngine interface {
+	raftengine.Proposer
+	raftengine.LeaderView
+}
+
+// registerEncryptionAdminServer constructs and registers an
+// EncryptionAdminServer on the supplied gRPC server. The function
+// is intentionally per-shard: the §7.1 Phase-0 GetCapability
+// fan-out polls every member, and mutator RPCs route through the
+// shard's own raftengine.LeaderView so a follower returns
+// FailedPrecondition with the current leader's hint.
+//
+// Production-inert until Stage 6:
+//   - sidecarPath is empty by default, so GetCapability returns
+//     encryption_capable=false (the §7.1 cutover refuses with
+//     ErrCapabilityCheckFailed).
+//   - The §6.3 WithEncryption applier seam is still unwired on the
+//     FSM side, so a successfully-applied bootstrap entry is a
+//     no-op storage-side.
+//
+// Validate() panics on a misconfiguration that wires a proposer
+// without a LeaderView. The single callsite passes the same engine
+// for both options, so the invariant holds by construction — the
+// panic is the load-bearing guard against a future refactor that
+// splits the two options apart.
+func registerEncryptionAdminServer(gs *grpc.Server, engine encryptionAdminEngine, shardID uint64) {
+	opts := []adapter.EncryptionAdminServerOption{
+		adapter.WithEncryptionAdminProposer(engine),
+		adapter.WithEncryptionAdminLeaderView(engine),
+		adapter.WithEncryptionAdminFullNodeID(shardID),
+	}
+	if *encryptionSidecarPath != "" {
+		opts = append(opts, adapter.WithEncryptionAdminSidecarPath(*encryptionSidecarPath))
+	}
+	srv := adapter.NewEncryptionAdminServer(opts...)
+	if err := srv.Validate(); err != nil {
+		panic(errors.Wrap(err, "encryption admin server validation"))
+	}
+	pb.RegisterEncryptionAdminServer(gs, srv)
+}

--- a/main_encryption_admin.go
+++ b/main_encryption_admin.go
@@ -37,27 +37,39 @@ type encryptionAdminEngine interface {
 // number — Codex r1 P1 on PR #760 caught the original wiring
 // passing the shard id by mistake.
 //
-// Production-inert until Stage 6:
+// Production-inert until Stage 6 — gating on --encryptionSidecarPath:
 //   - sidecarPath is empty by default, so GetCapability returns
 //     encryption_capable=false (the §7.1 cutover refuses with
 //     ErrCapabilityCheckFailed).
-//   - The §6.3 WithEncryption applier seam is still unwired on the
-//     FSM side, so a successfully-applied bootstrap entry is a
-//     no-op storage-side.
+//   - Proposer + LeaderView are wired ONLY when sidecarPath is
+//     set. Without them, RotateDEK / BootstrapEncryption /
+//     RegisterEncryptionWriter return FailedPrecondition
+//     "proposer is not configured on this node" at the RPC
+//     boundary — before any Raft proposal is issued. This is
+//     the load-bearing safety boundary against Codex r2 P1: the
+//     §6.3 WithEncryption applier seam is still unwired on the
+//     FSM side pre-Stage-6, so a successfully-applied bootstrap
+//     entry would hit the fail-closed halt path in
+//     kvFSM.applyEncryption (nil applier) and stop the apply
+//     loop cluster-wide. Refusing the proposal at the RPC layer
+//     means an accidental client call cannot escalate from a
+//     single RPC into a cluster-halt.
 //
 // Validate() panics on a misconfiguration that wires a proposer
-// without a LeaderView. The single callsite passes the same engine
-// for both options, so the invariant holds by construction — the
-// panic is the load-bearing guard against a future refactor that
-// splits the two options apart.
+// without a LeaderView. The wiring below pairs both options
+// together (both wired iff sidecarPath set) so the invariant
+// holds by construction — the panic is the load-bearing guard
+// against a future refactor that splits the two options apart.
 func registerEncryptionAdminServer(gs *grpc.Server, engine encryptionAdminEngine, fullNodeID uint64) {
 	opts := []adapter.EncryptionAdminServerOption{
-		adapter.WithEncryptionAdminProposer(engine),
-		adapter.WithEncryptionAdminLeaderView(engine),
 		adapter.WithEncryptionAdminFullNodeID(fullNodeID),
 	}
 	if *encryptionSidecarPath != "" {
-		opts = append(opts, adapter.WithEncryptionAdminSidecarPath(*encryptionSidecarPath))
+		opts = append(opts,
+			adapter.WithEncryptionAdminSidecarPath(*encryptionSidecarPath),
+			adapter.WithEncryptionAdminProposer(engine),
+			adapter.WithEncryptionAdminLeaderView(engine),
+		)
 	}
 	srv := adapter.NewEncryptionAdminServer(opts...)
 	if err := srv.Validate(); err != nil {

--- a/main_encryption_admin.go
+++ b/main_encryption_admin.go
@@ -60,13 +60,13 @@ type encryptionAdminEngine interface {
 // together (both wired iff sidecarPath set) so the invariant
 // holds by construction — the panic is the load-bearing guard
 // against a future refactor that splits the two options apart.
-func registerEncryptionAdminServer(gs *grpc.Server, engine encryptionAdminEngine, fullNodeID uint64) {
+func registerEncryptionAdminServer(gs *grpc.Server, engine encryptionAdminEngine, fullNodeID uint64, sidecarPath string) {
 	opts := []adapter.EncryptionAdminServerOption{
 		adapter.WithEncryptionAdminFullNodeID(fullNodeID),
 	}
-	if *encryptionSidecarPath != "" {
+	if sidecarPath != "" {
 		opts = append(opts,
-			adapter.WithEncryptionAdminSidecarPath(*encryptionSidecarPath),
+			adapter.WithEncryptionAdminSidecarPath(sidecarPath),
 			adapter.WithEncryptionAdminProposer(engine),
 			adapter.WithEncryptionAdminLeaderView(engine),
 		)

--- a/main_encryption_admin.go
+++ b/main_encryption_admin.go
@@ -2,30 +2,16 @@ package main
 
 import (
 	"github.com/bootjp/elastickv/adapter"
-	"github.com/bootjp/elastickv/internal/raftengine"
 	pb "github.com/bootjp/elastickv/proto"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
 )
 
-// encryptionAdminEngine is the subset of raftengine.Engine the
-// EncryptionAdminServer needs: a Proposer (for the mutating RPCs)
-// and a LeaderView (for the requireLeader gate). Every shard's
-// raftengine.Engine satisfies both interfaces; declaring a local
-// intersection keeps the construction site decoupled from the
-// concrete engine type and lets tests substitute a stub without
-// pulling in the full engine surface.
-type encryptionAdminEngine interface {
-	raftengine.Proposer
-	raftengine.LeaderView
-}
-
 // registerEncryptionAdminServer constructs and registers an
 // EncryptionAdminServer on the supplied gRPC server. The function
 // is intentionally per-shard: the §7.1 Phase-0 GetCapability
-// fan-out polls every member, and mutator RPCs route through the
-// shard's own raftengine.LeaderView so a follower returns
-// FailedPrecondition with the current leader's hint.
+// fan-out polls every member, and the §5.1 sidecar contents are
+// per-node.
 //
 // fullNodeID MUST be per-node-stable (every replica of the same
 // group sees a distinct value), NOT the Raft group id (which is
@@ -37,39 +23,50 @@ type encryptionAdminEngine interface {
 // number — Codex r1 P1 on PR #760 caught the original wiring
 // passing the shard id by mistake.
 //
-// Production-inert until Stage 6 — gating on --encryptionSidecarPath:
-//   - sidecarPath is empty by default, so GetCapability returns
-//     encryption_capable=false (the §7.1 cutover refuses with
-//     ErrCapabilityCheckFailed).
-//   - Proposer + LeaderView are wired ONLY when sidecarPath is
-//     set. Without them, RotateDEK / BootstrapEncryption /
-//     RegisterEncryptionWriter return FailedPrecondition
-//     "proposer is not configured on this node" at the RPC
-//     boundary — before any Raft proposal is issued. This is
-//     the load-bearing safety boundary against Codex r2 P1: the
-//     §6.3 WithEncryption applier seam is still unwired on the
-//     FSM side pre-Stage-6, so a successfully-applied bootstrap
-//     entry would hit the fail-closed halt path in
-//     kvFSM.applyEncryption (nil applier) and stop the apply
-//     loop cluster-wide. Refusing the proposal at the RPC layer
-//     means an accidental client call cannot escalate from a
-//     single RPC into a cluster-halt.
+// Stage 5D is intentionally inert for mutating RPCs. This helper
+// installs ONLY the sidecar-path + full-node-id options, never
+// the Proposer or LeaderView. With both omitted,
+// EncryptionAdminServer.BootstrapEncryption / RotateDEK /
+// RegisterEncryptionWriter return FailedPrecondition at the gRPC
+// boundary — the proposal never reaches Raft.
+//
+// The reason mutator wiring stays off ENTIRELY (not just
+// sidecar-gated) is Codex r3 P1 on PR #760: the §6.3
+// WithEncryption applier seam is plumbed by Stage 6. Today the
+// FSM is constructed via kv.NewKvFSMWithHLC (no WithEncryption
+// option). A successfully-applied bootstrap entry would land a
+// 0x03/0x04/0x05 Raft entry on every replica, the FSM apply path
+// would route through kvFSM.applyEncryption, the default branch
+// would fire ErrEncryptionApply because the applier is nil, and
+// the engine's HaltApply seam would stop apply on every node.
+// Gating mutator wiring on --encryptionSidecarPath (as PR760 r2
+// did) is not safe enough — an operator who sets sidecarPath for
+// capability probing alone could still trigger a cluster-halt by
+// calling a mutating RPC. The applier and the mutator wiring
+// must land together in Stage 6.
+//
+// sidecarPath controls only the read-only capability surface:
+// when empty, GetCapability reports encryption_capable=false
+// (the §7.1 cutover refuses with ErrCapabilityCheckFailed);
+// when set, capability probing reads the §5.1 keys.json and
+// reports encryption_capable=true. ResyncSidecar's leader guard
+// (requireLeader) returns nil when LeaderView is unset — the
+// "test escape hatch" path documented in requireLeader's godoc —
+// so ResyncSidecar serves the local sidecar on every node until
+// Stage 6 wires the LeaderView. Pre-bootstrap the sidecar is
+// either non-existent or empty so there is no §5.5 leak window.
 //
 // Validate() panics on a misconfiguration that wires a proposer
-// without a LeaderView. The wiring below pairs both options
-// together (both wired iff sidecarPath set) so the invariant
-// holds by construction — the panic is the load-bearing guard
-// against a future refactor that splits the two options apart.
-func registerEncryptionAdminServer(gs *grpc.Server, engine encryptionAdminEngine, fullNodeID uint64, sidecarPath string) {
+// without a LeaderView. The wiring below never wires either, so
+// the invariant holds vacuously today; the panic remains the
+// load-bearing guard against a future Stage 6 refactor that
+// splits the two options apart.
+func registerEncryptionAdminServer(gs *grpc.Server, fullNodeID uint64, sidecarPath string) {
 	opts := []adapter.EncryptionAdminServerOption{
 		adapter.WithEncryptionAdminFullNodeID(fullNodeID),
 	}
 	if sidecarPath != "" {
-		opts = append(opts,
-			adapter.WithEncryptionAdminSidecarPath(sidecarPath),
-			adapter.WithEncryptionAdminProposer(engine),
-			adapter.WithEncryptionAdminLeaderView(engine),
-		)
+		opts = append(opts, adapter.WithEncryptionAdminSidecarPath(sidecarPath))
 	}
 	srv := adapter.NewEncryptionAdminServer(opts...)
 	if err := srv.Validate(); err != nil {

--- a/main_encryption_admin.go
+++ b/main_encryption_admin.go
@@ -27,6 +27,16 @@ type encryptionAdminEngine interface {
 // shard's own raftengine.LeaderView so a follower returns
 // FailedPrecondition with the current leader's hint.
 //
+// fullNodeID MUST be per-node-stable (every replica of the same
+// group sees a distinct value), NOT the Raft group id (which is
+// shared across replicas). Production callers derive it via
+// etcd.DeriveNodeID(*raftId) at the call site so the value
+// matches what raftengine itself uses for peer identification.
+// A wrong-shape value here makes BootstrapEncryption fail with
+// "duplicate full_node_id" because every node reports the same
+// number — Codex r1 P1 on PR #760 caught the original wiring
+// passing the shard id by mistake.
+//
 // Production-inert until Stage 6:
 //   - sidecarPath is empty by default, so GetCapability returns
 //     encryption_capable=false (the §7.1 cutover refuses with
@@ -40,11 +50,11 @@ type encryptionAdminEngine interface {
 // for both options, so the invariant holds by construction — the
 // panic is the load-bearing guard against a future refactor that
 // splits the two options apart.
-func registerEncryptionAdminServer(gs *grpc.Server, engine encryptionAdminEngine, shardID uint64) {
+func registerEncryptionAdminServer(gs *grpc.Server, engine encryptionAdminEngine, fullNodeID uint64) {
 	opts := []adapter.EncryptionAdminServerOption{
 		adapter.WithEncryptionAdminProposer(engine),
 		adapter.WithEncryptionAdminLeaderView(engine),
-		adapter.WithEncryptionAdminFullNodeID(shardID),
+		adapter.WithEncryptionAdminFullNodeID(fullNodeID),
 	}
 	if *encryptionSidecarPath != "" {
 		opts = append(opts, adapter.WithEncryptionAdminSidecarPath(*encryptionSidecarPath))

--- a/main_encryption_admin_test.go
+++ b/main_encryption_admin_test.go
@@ -75,16 +75,9 @@ func TestEncryptionAdminFullNodeID_DistinctPerRaftId(t *testing.T) {
 // the call would have reached the stub Propose() and returned a
 // fake success.
 func TestEncryptionAdmin_MutatingRPCRefusedWithoutSidecarPath(t *testing.T) {
-	// Force the global flag to empty for this test (the default
-	// already is, but be explicit so a future change to the flag
-	// default does not silently invalidate the assertion).
-	prev := *encryptionSidecarPath
-	*encryptionSidecarPath = ""
-	t.Cleanup(func() { *encryptionSidecarPath = prev })
-
 	listener := bufconn.Listen(1024 * 1024)
 	gs := grpc.NewServer()
-	registerEncryptionAdminServer(gs, stubEncryptionAdminEngine{}, 1)
+	registerEncryptionAdminServer(gs, stubEncryptionAdminEngine{}, 1, "")
 	go func() { _ = gs.Serve(listener) }()
 	t.Cleanup(gs.Stop)
 
@@ -117,7 +110,7 @@ func TestEncryptionAdmin_MutatingRPCRefusedWithoutSidecarPath(t *testing.T) {
 
 func TestRegisterEncryptionAdminServer_Registers(t *testing.T) {
 	gs := grpc.NewServer()
-	registerEncryptionAdminServer(gs, stubEncryptionAdminEngine{}, 1)
+	registerEncryptionAdminServer(gs, stubEncryptionAdminEngine{}, 1, "")
 	// reflection-style check: the service descriptor must show up
 	// in the registered service map. grpc.Server exposes this via
 	// GetServiceInfo.

--- a/main_encryption_admin_test.go
+++ b/main_encryption_admin_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/bootjp/elastickv/internal/raftengine"
+	etcdraftengine "github.com/bootjp/elastickv/internal/raftengine/etcd"
 	"google.golang.org/grpc"
 )
 
@@ -25,6 +26,30 @@ func (stubEncryptionAdminEngine) VerifyLeader(context.Context) error {
 }
 func (stubEncryptionAdminEngine) LinearizableRead(context.Context) (uint64, error) {
 	return 0, nil
+}
+
+// TestEncryptionAdminFullNodeID_DistinctPerRaftId pins the
+// PR760 r1 Codex P1 regression: full_node_id must be derived from
+// --raftId (per-node-stable) and NOT from the Raft group id
+// (shared across replicas). An earlier wiring passed rt.spec.id,
+// which makes every replica return the same CapabilityReport
+// value and breaks BootstrapEncryption's
+// validateWriterBatchUniqueness check. The fix routes through
+// etcd.DeriveNodeID(raftId) at the call site; this test confirms
+// the canonical derivation is in fact distinct for the canonical
+// 3-node config (n1 / n2 / n3) the demo + Jepsen runners use.
+func TestEncryptionAdminFullNodeID_DistinctPerRaftId(t *testing.T) {
+	seen := make(map[uint64]string)
+	for _, id := range []string{"n1", "n2", "n3"} {
+		got := etcdraftengine.DeriveNodeID(id)
+		if got == 0 {
+			t.Fatalf("DeriveNodeID(%q) returned 0; the §6.1 not-capable sentinel must never be used as a real node id", id)
+		}
+		if dup, exists := seen[got]; exists {
+			t.Fatalf("DeriveNodeID(%q) = DeriveNodeID(%q) = %d; full_node_id must be distinct across raftIds — BootstrapEncryption uniqueness would reject", id, dup, got)
+		}
+		seen[got] = id
+	}
 }
 
 func TestRegisterEncryptionAdminServer_Registers(t *testing.T) {

--- a/main_encryption_admin_test.go
+++ b/main_encryption_admin_test.go
@@ -2,11 +2,17 @@ package main
 
 import (
 	"context"
+	"net"
 	"testing"
 
 	"github.com/bootjp/elastickv/internal/raftengine"
 	etcdraftengine "github.com/bootjp/elastickv/internal/raftengine/etcd"
+	pb "github.com/bootjp/elastickv/proto"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
 )
 
 // stubEncryptionAdminEngine satisfies the encryptionAdminEngine
@@ -49,6 +55,63 @@ func TestEncryptionAdminFullNodeID_DistinctPerRaftId(t *testing.T) {
 			t.Fatalf("DeriveNodeID(%q) = DeriveNodeID(%q) = %d; full_node_id must be distinct across raftIds — BootstrapEncryption uniqueness would reject", id, dup, got)
 		}
 		seen[got] = id
+	}
+}
+
+// TestEncryptionAdmin_MutatingRPCRefusedWithoutSidecarPath pins
+// the PR760 r2 Codex P1 regression: with --encryptionSidecarPath
+// empty, registerEncryptionAdminServer must NOT wire the Proposer
+// or LeaderView, so mutating RPCs (BootstrapEncryption /
+// RotateDEK / RegisterEncryptionWriter) return FailedPrecondition
+// at the RPC boundary instead of issuing a Raft proposal that
+// would land on the still-unwired FSM applier (kvFSM.applyEncryption
+// with nil applier) and halt the apply loop cluster-wide.
+//
+// The original wiring before the fix passed Proposer +
+// LeaderView unconditionally, so a stray RotateDEK call against
+// a sidecarless cluster would commit through Raft and halt every
+// node on apply. This test would have failed under that wiring
+// because the FailedPrecondition assertion would never fire —
+// the call would have reached the stub Propose() and returned a
+// fake success.
+func TestEncryptionAdmin_MutatingRPCRefusedWithoutSidecarPath(t *testing.T) {
+	// Force the global flag to empty for this test (the default
+	// already is, but be explicit so a future change to the flag
+	// default does not silently invalidate the assertion).
+	prev := *encryptionSidecarPath
+	*encryptionSidecarPath = ""
+	t.Cleanup(func() { *encryptionSidecarPath = prev })
+
+	listener := bufconn.Listen(1024 * 1024)
+	gs := grpc.NewServer()
+	registerEncryptionAdminServer(gs, stubEncryptionAdminEngine{}, 1)
+	go func() { _ = gs.Serve(listener) }()
+	t.Cleanup(gs.Stop)
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	client := pb.NewEncryptionAdminClient(conn)
+	_, err = client.BootstrapEncryption(context.Background(), &pb.BootstrapEncryptionRequest{
+		StorageDekId:      1,
+		RaftDekId:         2,
+		WrappedStorageDek: []byte("w"),
+		WrappedRaftDek:    []byte("w"),
+	})
+	if err == nil {
+		t.Fatalf("BootstrapEncryption succeeded with sidecarPath empty; mutating wiring must be gated to refuse the proposal before it reaches the FSM applier")
+	}
+	if got := status.Code(err); got != codes.FailedPrecondition {
+		t.Errorf("BootstrapEncryption status=%v, want FailedPrecondition (sidecarPath empty → proposer not wired); err=%v", got, err)
 	}
 }
 

--- a/main_encryption_admin_test.go
+++ b/main_encryption_admin_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/raftengine"
+	"google.golang.org/grpc"
+)
+
+// stubEncryptionAdminEngine satisfies the encryptionAdminEngine
+// interface (Proposer + LeaderView) with do-nothing impls. The
+// registration helper only stores the engine and validates the
+// option pairing, so the methods are unreachable from the
+// registration path itself.
+type stubEncryptionAdminEngine struct{}
+
+func (stubEncryptionAdminEngine) Propose(context.Context, []byte) (*raftengine.ProposalResult, error) {
+	return &raftengine.ProposalResult{}, nil
+}
+func (stubEncryptionAdminEngine) State() raftengine.State       { return raftengine.StateLeader }
+func (stubEncryptionAdminEngine) Leader() raftengine.LeaderInfo { return raftengine.LeaderInfo{} }
+func (stubEncryptionAdminEngine) VerifyLeader(context.Context) error {
+	return nil
+}
+func (stubEncryptionAdminEngine) LinearizableRead(context.Context) (uint64, error) {
+	return 0, nil
+}
+
+func TestRegisterEncryptionAdminServer_Registers(t *testing.T) {
+	gs := grpc.NewServer()
+	registerEncryptionAdminServer(gs, stubEncryptionAdminEngine{}, 1)
+	// reflection-style check: the service descriptor must show up
+	// in the registered service map. grpc.Server exposes this via
+	// GetServiceInfo.
+	info := gs.GetServiceInfo()
+	// The .proto declares no package statement, so the service
+	// name surfaces as the bare "EncryptionAdmin" in
+	// grpc.Server.GetServiceInfo() (not "proto.EncryptionAdmin").
+	if _, ok := info["EncryptionAdmin"]; !ok {
+		var registered []string
+		for name := range info {
+			registered = append(registered, name)
+		}
+		t.Fatalf("EncryptionAdmin not registered; got services=%v", registered)
+	}
+}

--- a/main_encryption_admin_test.go
+++ b/main_encryption_admin_test.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"testing"
 
-	"github.com/bootjp/elastickv/internal/raftengine"
 	etcdraftengine "github.com/bootjp/elastickv/internal/raftengine/etcd"
 	pb "github.com/bootjp/elastickv/proto"
 	"google.golang.org/grpc"
@@ -14,25 +13,6 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 )
-
-// stubEncryptionAdminEngine satisfies the encryptionAdminEngine
-// interface (Proposer + LeaderView) with do-nothing impls. The
-// registration helper only stores the engine and validates the
-// option pairing, so the methods are unreachable from the
-// registration path itself.
-type stubEncryptionAdminEngine struct{}
-
-func (stubEncryptionAdminEngine) Propose(context.Context, []byte) (*raftengine.ProposalResult, error) {
-	return &raftengine.ProposalResult{}, nil
-}
-func (stubEncryptionAdminEngine) State() raftengine.State       { return raftengine.StateLeader }
-func (stubEncryptionAdminEngine) Leader() raftengine.LeaderInfo { return raftengine.LeaderInfo{} }
-func (stubEncryptionAdminEngine) VerifyLeader(context.Context) error {
-	return nil
-}
-func (stubEncryptionAdminEngine) LinearizableRead(context.Context) (uint64, error) {
-	return 0, nil
-}
 
 // TestEncryptionAdminFullNodeID_DistinctPerRaftId pins the
 // PR760 r1 Codex P1 regression: full_node_id must be derived from
@@ -58,66 +38,72 @@ func TestEncryptionAdminFullNodeID_DistinctPerRaftId(t *testing.T) {
 	}
 }
 
-// TestEncryptionAdmin_MutatingRPCRefusedWithoutSidecarPath pins
-// the PR760 r2 Codex P1 regression: with --encryptionSidecarPath
-// empty, registerEncryptionAdminServer must NOT wire the Proposer
-// or LeaderView, so mutating RPCs (BootstrapEncryption /
-// RotateDEK / RegisterEncryptionWriter) return FailedPrecondition
-// at the RPC boundary instead of issuing a Raft proposal that
-// would land on the still-unwired FSM applier (kvFSM.applyEncryption
-// with nil applier) and halt the apply loop cluster-wide.
+// TestEncryptionAdmin_MutatingRPCRefusedUntilStage6 pins the
+// PR760 r3 Codex P1 regression. registerEncryptionAdminServer
+// must NOT wire the Proposer or LeaderView regardless of
+// sidecarPath, because the §6.3 WithEncryption applier seam is
+// still unwired on the FSM side pre-Stage-6 (FSM is constructed
+// via kv.NewKvFSMWithHLC, no WithEncryption option). Gating the
+// mutator wiring on sidecarPath alone (as PR760 r2 did) is not
+// safe enough: an operator who sets --encryptionSidecarPath for
+// read-only capability probing would still be able to trigger
+// a cluster-halt by calling Bootstrap / RotateDEK /
+// RegisterEncryptionWriter — the proposal would land on every
+// replica, hit kvFSM.applyEncryption with nil applier, and stop
+// the apply loop.
 //
-// The original wiring before the fix passed Proposer +
-// LeaderView unconditionally, so a stray RotateDEK call against
-// a sidecarless cluster would commit through Raft and halt every
-// node on apply. This test would have failed under that wiring
-// because the FailedPrecondition assertion would never fire —
-// the call would have reached the stub Propose() and returned a
-// fake success.
-func TestEncryptionAdmin_MutatingRPCRefusedWithoutSidecarPath(t *testing.T) {
-	listener := bufconn.Listen(1024 * 1024)
-	gs := grpc.NewServer()
-	registerEncryptionAdminServer(gs, stubEncryptionAdminEngine{}, 1, "")
-	go func() { _ = gs.Serve(listener) }()
-	t.Cleanup(gs.Stop)
+// Both sub-cases (sidecarPath empty AND sidecarPath set) MUST
+// see the mutator refused at the gRPC boundary with
+// FailedPrecondition. Stage 6 will reintroduce the mutator
+// wiring in the same change that wires the applier.
+func TestEncryptionAdmin_MutatingRPCRefusedUntilStage6(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		sidecarPath string
+	}{
+		{name: "sidecar_empty", sidecarPath: ""},
+		{name: "sidecar_set", sidecarPath: "/tmp/elastickv-stage5d-test-sidecar.json"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			listener := bufconn.Listen(1024 * 1024)
+			gs := grpc.NewServer()
+			registerEncryptionAdminServer(gs, 1, tc.sidecarPath)
+			go func() { _ = gs.Serve(listener) }()
+			t.Cleanup(gs.Stop)
 
-	conn, err := grpc.NewClient(
-		"passthrough:///bufnet",
-		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
-			return listener.Dial()
-		}),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
-	if err != nil {
-		t.Fatalf("grpc.NewClient: %v", err)
-	}
-	t.Cleanup(func() { _ = conn.Close() })
+			conn, err := grpc.NewClient(
+				"passthrough:///bufnet",
+				grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+					return listener.Dial()
+				}),
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			)
+			if err != nil {
+				t.Fatalf("grpc.NewClient: %v", err)
+			}
+			t.Cleanup(func() { _ = conn.Close() })
 
-	client := pb.NewEncryptionAdminClient(conn)
-	_, err = client.BootstrapEncryption(context.Background(), &pb.BootstrapEncryptionRequest{
-		StorageDekId:      1,
-		RaftDekId:         2,
-		WrappedStorageDek: []byte("w"),
-		WrappedRaftDek:    []byte("w"),
-	})
-	if err == nil {
-		t.Fatalf("BootstrapEncryption succeeded with sidecarPath empty; mutating wiring must be gated to refuse the proposal before it reaches the FSM applier")
-	}
-	if got := status.Code(err); got != codes.FailedPrecondition {
-		t.Errorf("BootstrapEncryption status=%v, want FailedPrecondition (sidecarPath empty → proposer not wired); err=%v", got, err)
+			client := pb.NewEncryptionAdminClient(conn)
+			_, err = client.BootstrapEncryption(context.Background(), &pb.BootstrapEncryptionRequest{
+				StorageDekId:      1,
+				RaftDekId:         2,
+				WrappedStorageDek: []byte("w"),
+				WrappedRaftDek:    []byte("w"),
+			})
+			if err == nil {
+				t.Fatalf("BootstrapEncryption succeeded (sidecarPath=%q); mutating wiring must be refused at the RPC boundary until Stage 6 wires the applier", tc.sidecarPath)
+			}
+			if got := status.Code(err); got != codes.FailedPrecondition {
+				t.Errorf("BootstrapEncryption status=%v, want FailedPrecondition (sidecarPath=%q → proposer not wired pre-Stage-6); err=%v", got, tc.sidecarPath, err)
+			}
+		})
 	}
 }
 
 func TestRegisterEncryptionAdminServer_Registers(t *testing.T) {
 	gs := grpc.NewServer()
-	registerEncryptionAdminServer(gs, stubEncryptionAdminEngine{}, 1, "")
-	// reflection-style check: the service descriptor must show up
-	// in the registered service map. grpc.Server exposes this via
-	// GetServiceInfo.
+	registerEncryptionAdminServer(gs, 1, "")
 	info := gs.GetServiceInfo()
-	// The .proto declares no package statement, so the service
-	// name surfaces as the bare "EncryptionAdmin" in
-	// grpc.Server.GetServiceInfo() (not "proto.EncryptionAdmin").
 	if _, ok := info["EncryptionAdmin"]; !ok {
 		var registered []string
 		for name := range info {


### PR DESCRIPTION
## Summary

Stage 5 **PR-D** of the data-at-rest encryption rollout (design doc:
`docs/design/2026_04_29_partial_data_at_rest_encryption.md`). Wires
the §6.1 `EncryptionAdmin` gRPC service onto every shard's gRPC
listener so the §7.1 Phase-0 `GetCapability` fan-out can poll any
cluster member.

Production-inert: `--encryptionSidecarPath` defaults to empty, so
`GetCapability` reports `encryption_capable=false` until Stage 6
introduces the proper cluster-flag gate.

## What lands

- **`--encryptionSidecarPath` flag** (`main.go`): points the
  read-only probes at the §5.1 keys.json. Empty path = node has
  not been started with encryption — matches the §6.1
  not-capable signal that the cutover refuses with
  `ErrCapabilityCheckFailed`.
- **`registerEncryptionAdminServer` helper** (`main_encryption_admin.go`):
  per-shard registration, plumbing the shard's `raftengine.Engine`
  in as BOTH proposer AND `LeaderView` so `requireLeader`'s
  `VerifyLeader` quorum check fires against the right shard. The
  full_node_id reported in `CapabilityReport` is the shard id,
  matching the §5.6 step 1a batch contract.
- **`Validate()` is load-bearing**: panics at startup if a future
  refactor splits the proposer/LeaderView wiring apart. At the
  current callsite both come from the same engine, so the panic
  is unreachable — but the guard catches the failure mode where a
  follower might silently accept mutator RPCs.
- **Test** (`main_encryption_admin_test.go`): asserts the service
  shows up in `grpc.Server.GetServiceInfo()` so a future
  registration-helper refactor cannot silently drop the service.

## Out of scope

- **Stage 5E** (next): §5.6 step 1a capability fan-out helper +
  `encryption bootstrap --discover-from=...` auto-batch CLI mode.
- **Stage 6**: `--encryption-enabled` cluster flag, §6.3
  `WithEncryption` applier wiring, §9.1 startup refusal guards.

## Test plan

- [x] `go test -race -timeout=60s -run TestRegisterEncryptionAdminServer .`
  — verifies the service is registered.
- [x] `go build ./...` — PASS.
- [x] `golangci-lint run` on root pkg — 0 issues.
- [ ] CI verifies build / lint / Jepsen.

## Self-review (CLAUDE.md 5 passes)

1. **Data loss** — registration is purely additive; existing
   handlers are unchanged. `Validate()` catches the
   proposer-without-LeaderView programming error at startup so a
   follower cannot quietly accept mutator RPCs.
2. **Concurrency** — one `EncryptionAdminServer` per shard. The
   only mutable state is the sidecar file, serialised through
   `encryption.WriteSidecar`'s §5.1 crash-durable protocol.
3. **Performance** — registration is once per shard at startup;
   RPCs are off the data plane.
4. **Consistency** — every shard's `EncryptionAdminServer` uses
   ITS OWN engine, so a follower shard correctly rejects
   mutators with `FailedPrecondition` pointing at the shard's
   current leader.
5. **Test coverage** — `GetServiceInfo`-based registration check;
   the wider adapter + CLI tests carry the `EncryptionAdmin`
   contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--encryptionSidecarPath` command-line flag for configuring encryption sidecar probes
  * Integrated EncryptionAdmin server registration with gRPC services

* **Improvements**
  * Enhanced node identity derivation to ensure distinct and consistent identifiers across all cluster nodes

* **Documentation**
  * Updated encryption rollout milestone tracking and stages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->