### PR TITLE
feat(encryption): Stage 6A — §6.3 Applier scaffolding + FSM WithEncryption wiring

### DIFF
--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -114,7 +114,7 @@ func NewApplier(registry WriterRegistryStore) (*Applier, error) {
 // the gate, or in a forensic / corruption scenario) still halts
 // rather than silently advancing setApplied.
 func (a *Applier) ApplyRegistration(p fsmwire.RegistrationPayload) error {
-	key := RegistryKey(p.DEKID, uint16(p.FullNodeID&localEpochMaskU64)) //nolint:gosec // masked to 16 bits; G115 cannot trace the bitwise narrowing
+	key := RegistryKey(p.DEKID, uint16(p.FullNodeID&nodeIDMask)) //nolint:gosec // masked to 16 bits; G115 cannot trace the bitwise narrowing
 	existing, ok, err := a.registry.GetRegistryRow(key)
 	if err != nil {
 		return errors.Wrap(err, "applier: get registry row")
@@ -180,4 +180,13 @@ func (a *Applier) ApplyRotation(_ fsmwire.RotationPayload) error {
 	return errors.Wrap(ErrKEKNotConfigured, "applier: rotation requires KEK unwrapper (Stage 6B)")
 }
 
-const localEpochMaskU64 uint64 = 0xFFFF
+// nodeIDMask narrows a uint64 full_node_id to its low 16 bits to
+// match the §4.1 writer-registry key shape
+// (`!encryption|writers|<dek_id>|<be2 uint16(node_id)>`). The
+// mask happens to share the value 0xFFFF with the unrelated
+// local_epoch field width, but the semantic purpose here is
+// FullNodeID truncation — gemini-code-assist PR #765 round-1
+// medium flagged the original `localEpochMaskU64` name as
+// misleading at this call site. Untyped so the cast at the
+// call site is explicit (no implicit uint64 promotion).
+const nodeIDMask = 0xFFFF

--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -43,13 +43,17 @@ type WriterRegistryStore interface {
 //
 // Stage 6A ships:
 //
-//   - ApplyRegistration — the §4.1 case 1 / case 2 dispatch:
-//     case 1 (new uint16 slot)            → insert
-//     case 2 (same FullNodeID, new epoch) → update LastSeen
-//     case 3 (same FullNodeID, epoch ≤)   → halt apply (rollback;
-//     recovered via §9.1)
-//     case 4 (uint16 collision)           → halt apply (uniqueness
-//     invariant; §6.1)
+//   - ApplyRegistration — the §4.1 case 1 / case 2 dispatch.
+//     For (dek_id, uint16(full_node_id)) keying:
+//
+//     case 1: no existing row → insert.
+//     case 2 (strictly greater epoch, same full_node_id) → advance LastSeen.
+//     case 2-idempotent (equal epoch, same full_node_id) → no-op (legit
+//     Raft replay; rejecting it would halt-on-replay-loop after crash).
+//     case 3 (strictly smaller epoch, same full_node_id) → halt apply
+//     (rollback; recovered via §9.1).
+//     case 4 (different full_node_id at same uint16 truncation) →
+//     halt apply (§6.1 uniqueness invariant).
 //
 //   - ApplyBootstrap and ApplyRotation — return the defense-in-depth
 //     ErrKEKNotConfigured marker. Stage 6B will swap these for the
@@ -92,8 +96,18 @@ func NewApplier(registry WriterRegistryStore) (*Applier, error) {
 //     payload.LocalEpoch. FirstSeen is preserved as the original
 //     first-registered value.
 //
-//   - case 3 (existing row, same FullNodeID, payload.LocalEpoch ≤
-//     existing.LastSeenLocalEpoch): epoch rollback / replay.
+//   - case 2-idempotent (existing row, same FullNodeID,
+//     payload.LocalEpoch == existing.LastSeenLocalEpoch): legitimate
+//     Raft replay. Raft re-applies committed entries after restart
+//     until the latest FSM snapshot, so a RegisterEncryptionWriter
+//     entry can be applied again with the same
+//     (dek_id, full_node_id, local_epoch). Returns nil with no row
+//     change. Rejecting equal epochs as rollback would pin a node
+//     in a halt-on-replay loop after any crash before snapshotting
+//     this entry — codex PR #765 round-2 P1.
+//
+//   - case 3 (existing row, same FullNodeID, payload.LocalEpoch <
+//     existing.LastSeenLocalEpoch — strictly less): epoch rollback.
 //     Returns an error wrapped with ErrEncryptionApply so the kv
 //     dispatch layer halts apply. The §9.1 ErrLocalEpochRollback
 //     startup guard is what 6C ships to prevent this from being
@@ -141,8 +155,23 @@ func (a *Applier) ApplyRegistration(p fsmwire.RegistrationPayload) error {
 			"applier: writer-registry uint16 collision at dek_id=%d (existing full_node_id=%#x, incoming=%#x)",
 			p.DEKID, prev.FullNodeID, p.FullNodeID)
 	}
-	if p.LocalEpoch <= prev.LastSeenLocalEpoch {
-		// case 3: epoch rollback / replay
+	if p.LocalEpoch == prev.LastSeenLocalEpoch {
+		// case 2-idempotent: legitimate Raft replay of an already-
+		// applied registration entry. Raft replays committed entries
+		// after restart until the latest FSM snapshot, so a
+		// RegisterEncryptionWriter entry can be applied again with
+		// the same (dek_id, full_node_id, local_epoch). Rejecting
+		// equal epochs as rollback would halt apply on every legit
+		// post-crash replay and pin the node in a restart loop
+		// (PR #765 round-2 codex P1). The row already reflects this
+		// epoch — no-op return preserves the §4.1 monotonicity
+		// invariant without false-halting.
+		return nil
+	}
+	if p.LocalEpoch < prev.LastSeenLocalEpoch {
+		// case 3: epoch rollback / replay of a STALE epoch. Strictly
+		// less-than is the rollback signal — see the equal-epoch
+		// idempotent path above for why <= would be wrong.
 		return errors.Wrapf(ErrEncryptionApply,
 			"applier: writer-registry local_epoch rollback at dek_id=%d full_node_id=%#x (existing last_seen=%d, incoming=%d)",
 			p.DEKID, p.FullNodeID, prev.LastSeenLocalEpoch, p.LocalEpoch)

--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -1,0 +1,183 @@
+package encryption
+
+import (
+	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
+	"github.com/cockroachdb/errors"
+)
+
+// WriterRegistryStore is the storage abstraction the Applier needs
+// to read and write §4.1 writer-registry rows under the
+// `!encryption|writers|<dek_id>|<uint16(node_id)>` Pebble prefix.
+//
+// The interface stays separate from store.MVCCStore because writer-
+// registry rows live OUTSIDE the MVCC namespace — they are
+// metadata about the cluster's encryption state, not user data.
+// They carry no commit timestamps, no MVCC visibility, and no
+// retention semantics; the Pebble row is the durable form and is
+// replayed on FSM apply just like any other 0x03 entry.
+//
+// Implementations MUST make Set durable before returning (or the
+// next FSM apply will see a stale read on Get and §4.1 case 2's
+// monotonic-epoch check will incorrectly accept a rolled-back
+// local_epoch). The main.go wiring satisfies this by routing
+// through the FSM's `pebble.Sync` Set path; the in-memory
+// MapWriterRegistryStore used in tests trivially satisfies it.
+type WriterRegistryStore interface {
+	// GetRegistryRow returns the value at the supplied registry
+	// key. The boolean is true iff the row exists; on a missing
+	// row both `value` and the boolean are zero. The error path
+	// is reserved for storage faults (Pebble error, etc.); a
+	// missing row is NOT an error.
+	GetRegistryRow(key []byte) (value []byte, ok bool, err error)
+
+	// SetRegistryRow writes a registry row durably. Overwrites
+	// any existing value at the same key. Idempotent at the
+	// (key, value) tuple level — writing the same value twice
+	// has no observable effect.
+	SetRegistryRow(key []byte, value []byte) error
+}
+
+// Applier is the §6.3 EncryptionApplier concrete implementation.
+// It satisfies kv.EncryptionApplier and is wired at FSM
+// construction via kv.NewKvFSMWithHLC(..., kv.WithEncryption(applier)).
+//
+// Stage 6A ships:
+//
+//   - ApplyRegistration — the §4.1 case 1 / case 2 dispatch:
+//     case 1 (new uint16 slot)            → insert
+//     case 2 (same FullNodeID, new epoch) → update LastSeen
+//     case 3 (same FullNodeID, epoch ≤)   → halt apply (rollback;
+//     recovered via §9.1)
+//     case 4 (uint16 collision)           → halt apply (uniqueness
+//     invariant; §6.1)
+//
+//   - ApplyBootstrap and ApplyRotation — return the defense-in-depth
+//     ErrKEKNotConfigured marker. Stage 6B will swap these for the
+//     real KEK-unwrap + sidecar mutate + keystore install path.
+//
+// The Applier carries no in-memory state of its own; all state
+// lives in the supplied WriterRegistryStore. This keeps it safe
+// to construct once at FSM startup and share across the lifetime
+// of the process — no per-apply allocation, no locks, no leak
+// path for stale state across snapshot restore.
+type Applier struct {
+	registry WriterRegistryStore
+}
+
+// NewApplier wires an Applier against the supplied registry store.
+// Returns an error if registry is nil so misconfiguration is caught
+// at construction time rather than at first apply (the panic site
+// is much harder to map back to a "you forgot to wire X" diagnosis
+// when it fires deep inside a Raft apply loop).
+func NewApplier(registry WriterRegistryStore) (*Applier, error) {
+	if registry == nil {
+		return nil, errors.New("encryption: NewApplier: registry is nil")
+	}
+	return &Applier{registry: registry}, nil
+}
+
+// ApplyRegistration implements §4.1's writer-registry insert
+// dispatch. The payload's (DEKID, FullNodeID, LocalEpoch) maps to
+// the Pebble key RegistryKey(DEKID, uint16(FullNodeID)) and the
+// value RegistryValue{FullNodeID, FirstSeenLocalEpoch,
+// LastSeenLocalEpoch}.
+//
+// The four-case dispatch:
+//
+//   - case 1 (no existing row at this key): insert with
+//     FirstSeen = LastSeen = payload.LocalEpoch.
+//
+//   - case 2 (existing row, same FullNodeID, payload.LocalEpoch >
+//     existing.LastSeenLocalEpoch): update LastSeenLocalEpoch to
+//     payload.LocalEpoch. FirstSeen is preserved as the original
+//     first-registered value.
+//
+//   - case 3 (existing row, same FullNodeID, payload.LocalEpoch ≤
+//     existing.LastSeenLocalEpoch): epoch rollback / replay.
+//     Returns an error wrapped with ErrEncryptionApply so the kv
+//     dispatch layer halts apply. The §9.1 ErrLocalEpochRollback
+//     startup guard is what 6C ships to prevent this from being
+//     reachable in production; until then the apply-time halt is
+//     the load-bearing backstop.
+//
+//   - case 4 (existing row, DIFFERENT FullNodeID under the same
+//     uint16 truncation): node-id collision per §6.1. Returns an
+//     error wrapped with ErrEncryptionApply. The startup
+//     ErrNodeIDCollision guard (6C) covers the cluster-wide check;
+//     this apply-time halt is the per-node backstop.
+//
+// The fail-closed paths exist as defense-in-depth: PR760
+// established that the gRPC-layer mutator gate
+// (registerEncryptionAdminServer) is the primary safety boundary;
+// the apply-time checks here exist so a malformed entry that
+// somehow committed (e.g., during a future refactor that bypasses
+// the gate, or in a forensic / corruption scenario) still halts
+// rather than silently advancing setApplied.
+func (a *Applier) ApplyRegistration(p fsmwire.RegistrationPayload) error {
+	key := RegistryKey(p.DEKID, uint16(p.FullNodeID&localEpochMaskU64)) //nolint:gosec // masked to 16 bits; G115 cannot trace the bitwise narrowing
+	existing, ok, err := a.registry.GetRegistryRow(key)
+	if err != nil {
+		return errors.Wrap(err, "applier: get registry row")
+	}
+	if !ok {
+		// case 1: insert
+		val := EncodeRegistryValue(RegistryValue{
+			FullNodeID:          p.FullNodeID,
+			FirstSeenLocalEpoch: p.LocalEpoch,
+			LastSeenLocalEpoch:  p.LocalEpoch,
+		})
+		if err := a.registry.SetRegistryRow(key, val); err != nil {
+			return errors.Wrap(err, "applier: insert registry row")
+		}
+		return nil
+	}
+	prev, err := DecodeRegistryValue(existing)
+	if err != nil {
+		return errors.Wrap(err, "applier: decode existing registry row")
+	}
+	if prev.FullNodeID != p.FullNodeID {
+		// case 4: uint16 collision under different full ids
+		return errors.Wrapf(ErrEncryptionApply,
+			"applier: writer-registry uint16 collision at dek_id=%d (existing full_node_id=%#x, incoming=%#x)",
+			p.DEKID, prev.FullNodeID, p.FullNodeID)
+	}
+	if p.LocalEpoch <= prev.LastSeenLocalEpoch {
+		// case 3: epoch rollback / replay
+		return errors.Wrapf(ErrEncryptionApply,
+			"applier: writer-registry local_epoch rollback at dek_id=%d full_node_id=%#x (existing last_seen=%d, incoming=%d)",
+			p.DEKID, p.FullNodeID, prev.LastSeenLocalEpoch, p.LocalEpoch)
+	}
+	// case 2: monotonic advance
+	val := EncodeRegistryValue(RegistryValue{
+		FullNodeID:          p.FullNodeID,
+		FirstSeenLocalEpoch: prev.FirstSeenLocalEpoch,
+		LastSeenLocalEpoch:  p.LocalEpoch,
+	})
+	if err := a.registry.SetRegistryRow(key, val); err != nil {
+		return errors.Wrap(err, "applier: update registry row")
+	}
+	return nil
+}
+
+// ApplyBootstrap returns ErrKEKNotConfigured as the Stage 6A
+// defense-in-depth marker. Real bootstrap apply — KEK-unwrap the
+// wrapped DEK pair, install both into the keystore, batch-insert
+// every RegistrationPayload in BatchRegistry as the initial
+// writer-registry rows, and crash-durably persist the sidecar
+// Active.{Storage,Raft} + keys map — lands in Stage 6B alongside
+// the KEK plumbing.
+func (a *Applier) ApplyBootstrap(_ fsmwire.BootstrapPayload) error {
+	return errors.Wrap(ErrKEKNotConfigured, "applier: bootstrap requires KEK unwrapper (Stage 6B)")
+}
+
+// ApplyRotation returns ErrKEKNotConfigured as the Stage 6A
+// defense-in-depth marker. Real rotation apply — KEK-unwrap the
+// proposed DEK, install it under the supplied DEKID, update the
+// sidecar's Active slot for the given Purpose, insert the
+// ProposerRegistration row, and crash-durably persist — lands in
+// Stage 6B.
+func (a *Applier) ApplyRotation(_ fsmwire.RotationPayload) error {
+	return errors.Wrap(ErrKEKNotConfigured, "applier: rotation requires KEK unwrapper (Stage 6B)")
+}
+
+const localEpochMaskU64 uint64 = 0xFFFF

--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -104,7 +104,7 @@ func NewApplier(registry WriterRegistryStore) (*Applier, error) {
 //     (dek_id, full_node_id, local_epoch). Returns nil with no row
 //     change. Rejecting equal epochs as rollback would pin a node
 //     in a halt-on-replay loop after any crash before snapshotting
-//     this entry — codex PR #765 round-2 P1.
+//     this entry.
 //
 //   - case 3 (existing row, same FullNodeID, payload.LocalEpoch <
 //     existing.LastSeenLocalEpoch — strictly less): epoch rollback.
@@ -162,10 +162,10 @@ func (a *Applier) ApplyRegistration(p fsmwire.RegistrationPayload) error {
 		// RegisterEncryptionWriter entry can be applied again with
 		// the same (dek_id, full_node_id, local_epoch). Rejecting
 		// equal epochs as rollback would halt apply on every legit
-		// post-crash replay and pin the node in a restart loop
-		// (PR #765 round-2 codex P1). The row already reflects this
-		// epoch — no-op return preserves the §4.1 monotonicity
-		// invariant without false-halting.
+		// post-crash replay and pin the node in a restart loop.
+		// The row already reflects this epoch — no-op return
+		// preserves the §4.1 monotonicity invariant without
+		// false-halting.
 		return nil
 	}
 	if p.LocalEpoch < prev.LastSeenLocalEpoch {
@@ -213,9 +213,8 @@ func (a *Applier) ApplyRotation(_ fsmwire.RotationPayload) error {
 // match the §4.1 writer-registry key shape
 // (`!encryption|writers|<dek_id>|<be2 uint16(node_id)>`). The
 // mask happens to share the value 0xFFFF with the unrelated
-// local_epoch field width, but the semantic purpose here is
-// FullNodeID truncation — gemini-code-assist PR #765 round-1
-// medium flagged the original `localEpochMaskU64` name as
-// misleading at this call site. Untyped so the cast at the
-// call site is explicit (no implicit uint64 promotion).
+// local_epoch field width, but the name distinguishes this
+// FullNodeID-truncation use from the local_epoch masking in
+// adapter/encryption_admin.go. Untyped so the cast at the call
+// site is explicit (no implicit uint64 promotion).
 const nodeIDMask = 0xFFFF

--- a/internal/encryption/applier_test.go
+++ b/internal/encryption/applier_test.go
@@ -1,0 +1,256 @@
+package encryption_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
+)
+
+// mapRegistryStore is a small in-memory WriterRegistryStore used by
+// the applier tests. It is deliberately ordered by raw byte slice
+// comparisons so tests that exercise key shape (e.g., uint16
+// truncation collision) match production behaviour. The map is keyed
+// by string(key) because []byte is not comparable.
+type mapRegistryStore struct {
+	rows  map[string][]byte
+	setEr error
+	getEr error
+}
+
+func newMapRegistryStore() *mapRegistryStore {
+	return &mapRegistryStore{rows: map[string][]byte{}}
+}
+
+func (m *mapRegistryStore) GetRegistryRow(key []byte) ([]byte, bool, error) {
+	if m.getEr != nil {
+		return nil, false, m.getEr
+	}
+	v, ok := m.rows[string(key)]
+	return v, ok, nil
+}
+
+func (m *mapRegistryStore) SetRegistryRow(key []byte, value []byte) error {
+	if m.setEr != nil {
+		return m.setEr
+	}
+	m.rows[string(key)] = append([]byte(nil), value...)
+	return nil
+}
+
+// TestNewApplier_RejectsNilRegistry pins the construction-time guard
+// — a nil registry would nil-deref deep in Raft apply, which is the
+// hardest possible site to diagnose. Catching it at construction
+// surfaces the wiring mistake at startup.
+func TestNewApplier_RejectsNilRegistry(t *testing.T) {
+	t.Parallel()
+	app, err := encryption.NewApplier(nil)
+	if err == nil {
+		t.Fatalf("NewApplier(nil) returned no error; want construction-time refusal")
+	}
+	if app != nil {
+		t.Errorf("NewApplier(nil) returned non-nil applier with error; want nil applier")
+	}
+}
+
+// TestApplyRegistration_Case1_Insert pins §4.1 case 1: a first-seen
+// (dek_id, uint16(node_id)) writes a fresh row with FirstSeen ==
+// LastSeen == incoming local_epoch.
+func TestApplyRegistration_Case1_Insert(t *testing.T) {
+	t.Parallel()
+	store := newMapRegistryStore()
+	app, err := encryption.NewApplier(store)
+	if err != nil {
+		t.Fatalf("NewApplier: %v", err)
+	}
+	in := fsmwire.RegistrationPayload{DEKID: 7, FullNodeID: 0xDEAD_BEEF_CAFE_BABE, LocalEpoch: 5}
+	if err := app.ApplyRegistration(in); err != nil {
+		t.Fatalf("ApplyRegistration: %v", err)
+	}
+	key := encryption.RegistryKey(in.DEKID, uint16(in.FullNodeID&0xFFFF)) //nolint:gosec // test setup, masked to 16 bits
+	raw, ok, err := store.GetRegistryRow(key)
+	if err != nil {
+		t.Fatalf("GetRegistryRow: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected row inserted, got missing")
+	}
+	got, err := encryption.DecodeRegistryValue(raw)
+	if err != nil {
+		t.Fatalf("DecodeRegistryValue: %v", err)
+	}
+	want := encryption.RegistryValue{
+		FullNodeID:          in.FullNodeID,
+		FirstSeenLocalEpoch: in.LocalEpoch,
+		LastSeenLocalEpoch:  in.LocalEpoch,
+	}
+	if got != want {
+		t.Errorf("inserted value = %+v, want %+v", got, want)
+	}
+}
+
+// TestApplyRegistration_Case2_MonotonicAdvance pins §4.1 case 2:
+// re-registering the same (dek_id, full_node_id) with a strictly
+// greater local_epoch advances LastSeenLocalEpoch and preserves
+// FirstSeenLocalEpoch.
+func TestApplyRegistration_Case2_MonotonicAdvance(t *testing.T) {
+	t.Parallel()
+	store := newMapRegistryStore()
+	app, _ := encryption.NewApplier(store)
+	const dek = 9
+	nodeID := uint64(0x0123_4567_89AB_CDEF)
+	if err := app.ApplyRegistration(fsmwire.RegistrationPayload{DEKID: dek, FullNodeID: nodeID, LocalEpoch: 1}); err != nil {
+		t.Fatalf("first ApplyRegistration: %v", err)
+	}
+	if err := app.ApplyRegistration(fsmwire.RegistrationPayload{DEKID: dek, FullNodeID: nodeID, LocalEpoch: 3}); err != nil {
+		t.Fatalf("second ApplyRegistration: %v", err)
+	}
+	raw, _, _ := store.GetRegistryRow(encryption.RegistryKey(dek, uint16(nodeID&0xFFFF))) //nolint:gosec // test setup, masked to 16 bits
+	got, _ := encryption.DecodeRegistryValue(raw)
+	if got.FirstSeenLocalEpoch != 1 {
+		t.Errorf("FirstSeenLocalEpoch = %d, want 1 (preserved across case 2 advance)", got.FirstSeenLocalEpoch)
+	}
+	if got.LastSeenLocalEpoch != 3 {
+		t.Errorf("LastSeenLocalEpoch = %d, want 3 (advanced)", got.LastSeenLocalEpoch)
+	}
+}
+
+// TestApplyRegistration_Case3_Rollback pins §4.1 case 3 (epoch
+// rollback / replay): re-registering with epoch ≤ LastSeen MUST
+// halt apply with ErrEncryptionApply. Replaying a stale local_epoch
+// under the same DEK would let a re-issued nonce collide with a
+// previously-issued one, breaking AEAD confidentiality.
+func TestApplyRegistration_Case3_Rollback(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		secondEp uint16
+	}{
+		{name: "equal_epoch", secondEp: 5},
+		{name: "lower_epoch", secondEp: 4},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newMapRegistryStore()
+			app, _ := encryption.NewApplier(store)
+			const dek = 1
+			nodeID := uint64(0xAAAA_BBBB_CCCC_DDDD)
+			if err := app.ApplyRegistration(fsmwire.RegistrationPayload{DEKID: dek, FullNodeID: nodeID, LocalEpoch: 5}); err != nil {
+				t.Fatalf("first ApplyRegistration: %v", err)
+			}
+			err := app.ApplyRegistration(fsmwire.RegistrationPayload{DEKID: dek, FullNodeID: nodeID, LocalEpoch: tc.secondEp})
+			if err == nil {
+				t.Fatalf("expected rollback error, got nil")
+			}
+			if !errors.Is(err, encryption.ErrEncryptionApply) {
+				t.Errorf("err not marked ErrEncryptionApply: %v", err)
+			}
+		})
+	}
+}
+
+// TestApplyRegistration_Case4_Uint16Collision pins §6.1's uniqueness
+// invariant at apply time: two distinct full_node_ids whose lower
+// 16 bits collide MUST halt apply. The startup ErrNodeIDCollision
+// guard (6C) prevents this from being reachable in production; this
+// is the per-node backstop.
+func TestApplyRegistration_Case4_Uint16Collision(t *testing.T) {
+	t.Parallel()
+	store := newMapRegistryStore()
+	app, _ := encryption.NewApplier(store)
+	const dek = 2
+	// Two full_node_ids that collide in the lower 16 bits (both
+	// truncate to 0x1234). Declared as vars so uint16 truncation
+	// is a runtime conversion, not a constant overflow.
+	first := uint64(0x0000_0000_0000_1234)
+	second := uint64(0xDEAD_BEEF_0000_1234)
+	if uint16(first&0xFFFF) != uint16(second&0xFFFF) { //nolint:gosec // test setup, masked to 16 bits
+		t.Fatalf("test setup wrong: first and second do not collide in uint16")
+	}
+	if err := app.ApplyRegistration(fsmwire.RegistrationPayload{DEKID: dek, FullNodeID: first, LocalEpoch: 1}); err != nil {
+		t.Fatalf("first ApplyRegistration: %v", err)
+	}
+	err := app.ApplyRegistration(fsmwire.RegistrationPayload{DEKID: dek, FullNodeID: second, LocalEpoch: 1})
+	if err == nil {
+		t.Fatalf("expected collision error, got nil")
+	}
+	if !errors.Is(err, encryption.ErrEncryptionApply) {
+		t.Errorf("err not marked ErrEncryptionApply: %v", err)
+	}
+}
+
+// TestApplyRegistration_StoreErrorPropagates pins fail-closed behavior
+// on transient storage faults: a Get or Set error from the registry
+// store is wrapped and returned (not swallowed). The kv/fsm dispatch
+// layer marks the result with ErrEncryptionApply so the engine's
+// HaltApply seam fires regardless of whether the underlying error
+// is marked.
+func TestApplyRegistration_StoreErrorPropagates(t *testing.T) {
+	t.Parallel()
+	t.Run("get_error", func(t *testing.T) {
+		store := newMapRegistryStore()
+		boom := errors.New("pebble: synthetic get failure")
+		store.getEr = boom
+		app, _ := encryption.NewApplier(store)
+		err := app.ApplyRegistration(fsmwire.RegistrationPayload{DEKID: 1, FullNodeID: 0x1234, LocalEpoch: 1})
+		if err == nil {
+			t.Fatalf("expected propagation of Get error, got nil")
+		}
+		if !errors.Is(err, boom) {
+			t.Errorf("err did not wrap synthetic Get failure: %v", err)
+		}
+	})
+	t.Run("set_error", func(t *testing.T) {
+		store := newMapRegistryStore()
+		boom := errors.New("pebble: synthetic set failure")
+		store.setEr = boom
+		app, _ := encryption.NewApplier(store)
+		err := app.ApplyRegistration(fsmwire.RegistrationPayload{DEKID: 1, FullNodeID: 0x1234, LocalEpoch: 1})
+		if err == nil {
+			t.Fatalf("expected propagation of Set error, got nil")
+		}
+		if !errors.Is(err, boom) {
+			t.Errorf("err did not wrap synthetic Set failure: %v", err)
+		}
+	})
+}
+
+// TestApplyBootstrap_ReturnsKEKNotConfigured pins the Stage 6A stub
+// contract: until 6B threads a KEK unwrapper, ApplyBootstrap is the
+// defense-in-depth marker returning ErrKEKNotConfigured (wrapped so
+// the kv/fsm dispatch layer's ErrEncryptionApply marking still
+// fires).
+func TestApplyBootstrap_ReturnsKEKNotConfigured(t *testing.T) {
+	t.Parallel()
+	app, _ := encryption.NewApplier(newMapRegistryStore())
+	err := app.ApplyBootstrap(fsmwire.BootstrapPayload{
+		StorageDEKID:   1,
+		WrappedStorage: []byte("wrapped-storage"),
+		RaftDEKID:      2,
+		WrappedRaft:    []byte("wrapped-raft"),
+	})
+	if err == nil {
+		t.Fatalf("expected ErrKEKNotConfigured, got nil")
+	}
+	if !errors.Is(err, encryption.ErrKEKNotConfigured) {
+		t.Errorf("err not marked ErrKEKNotConfigured: %v", err)
+	}
+}
+
+// TestApplyRotation_ReturnsKEKNotConfigured pins the same Stage 6A
+// stub contract for rotation.
+func TestApplyRotation_ReturnsKEKNotConfigured(t *testing.T) {
+	t.Parallel()
+	app, _ := encryption.NewApplier(newMapRegistryStore())
+	err := app.ApplyRotation(fsmwire.RotationPayload{
+		SubTag:  0x01,
+		DEKID:   1,
+		Wrapped: []byte("wrapped"),
+	})
+	if err == nil {
+		t.Fatalf("expected ErrKEKNotConfigured, got nil")
+	}
+	if !errors.Is(err, encryption.ErrKEKNotConfigured) {
+		t.Errorf("err not marked ErrKEKNotConfigured: %v", err)
+	}
+}

--- a/internal/encryption/applier_test.go
+++ b/internal/encryption/applier_test.go
@@ -117,35 +117,62 @@ func TestApplyRegistration_Case2_MonotonicAdvance(t *testing.T) {
 }
 
 // TestApplyRegistration_Case3_Rollback pins §4.1 case 3 (epoch
-// rollback / replay): re-registering with epoch ≤ LastSeen MUST
-// halt apply with ErrEncryptionApply. Replaying a stale local_epoch
-// under the same DEK would let a re-issued nonce collide with a
+// rollback): re-registering with a strictly-smaller local_epoch
+// under the same FullNodeID MUST halt apply with
+// ErrEncryptionApply. Replaying a stale local_epoch under the
+// same DEK would let a re-issued nonce collide with a
 // previously-issued one, breaking AEAD confidentiality.
+//
+// Equal-epoch is NOT rollback — it is idempotent replay (Raft
+// re-applies committed entries after restart until the latest
+// FSM snapshot). The equal-epoch path is exercised by
+// TestApplyRegistration_Case2_IdempotentReplay below.
 func TestApplyRegistration_Case3_Rollback(t *testing.T) {
 	t.Parallel()
-	for _, tc := range []struct {
-		name     string
-		secondEp uint16
-	}{
-		{name: "equal_epoch", secondEp: 5},
-		{name: "lower_epoch", secondEp: 4},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			store := newMapRegistryStore()
-			app, _ := encryption.NewApplier(store)
-			const dek = 1
-			nodeID := uint64(0xAAAA_BBBB_CCCC_DDDD)
-			if err := app.ApplyRegistration(fsmwire.RegistrationPayload{DEKID: dek, FullNodeID: nodeID, LocalEpoch: 5}); err != nil {
-				t.Fatalf("first ApplyRegistration: %v", err)
-			}
-			err := app.ApplyRegistration(fsmwire.RegistrationPayload{DEKID: dek, FullNodeID: nodeID, LocalEpoch: tc.secondEp})
-			if err == nil {
-				t.Fatalf("expected rollback error, got nil")
-			}
-			if !errors.Is(err, encryption.ErrEncryptionApply) {
-				t.Errorf("err not marked ErrEncryptionApply: %v", err)
-			}
-		})
+	store := newMapRegistryStore()
+	app, _ := encryption.NewApplier(store)
+	const dek = 1
+	nodeID := uint64(0xAAAA_BBBB_CCCC_DDDD)
+	if err := app.ApplyRegistration(fsmwire.RegistrationPayload{DEKID: dek, FullNodeID: nodeID, LocalEpoch: 5}); err != nil {
+		t.Fatalf("first ApplyRegistration: %v", err)
+	}
+	err := app.ApplyRegistration(fsmwire.RegistrationPayload{DEKID: dek, FullNodeID: nodeID, LocalEpoch: 4})
+	if err == nil {
+		t.Fatalf("expected rollback error, got nil")
+	}
+	if !errors.Is(err, encryption.ErrEncryptionApply) {
+		t.Errorf("err not marked ErrEncryptionApply: %v", err)
+	}
+}
+
+// TestApplyRegistration_Case2_IdempotentReplay pins the
+// idempotent-replay path: a duplicate RegisterEncryptionWriter
+// entry with the same (dek_id, full_node_id, local_epoch) MUST
+// succeed with no error and no observable row change. Raft
+// replays committed entries after restart until the latest FSM
+// snapshot; rejecting equal epochs as rollback would pin a
+// node in a halt-on-replay loop after any crash before
+// snapshotting the entry (PR #765 round-2 codex P1).
+func TestApplyRegistration_Case2_IdempotentReplay(t *testing.T) {
+	t.Parallel()
+	store := newMapRegistryStore()
+	app, _ := encryption.NewApplier(store)
+	const dek = 3
+	nodeID := uint64(0xCAFE_BABE_DEAD_BEEF)
+	first := fsmwire.RegistrationPayload{DEKID: dek, FullNodeID: nodeID, LocalEpoch: 7}
+	if err := app.ApplyRegistration(first); err != nil {
+		t.Fatalf("first ApplyRegistration: %v", err)
+	}
+	// Snapshot row state after the first apply.
+	keyForRow := encryption.RegistryKey(dek, uint16(nodeID&0xFFFF)) //nolint:gosec // test setup, masked to 16 bits
+	before, _, _ := store.GetRegistryRow(keyForRow)
+	// Replay the SAME entry — must be a no-op success.
+	if err := app.ApplyRegistration(first); err != nil {
+		t.Errorf("idempotent replay returned error: %v", err)
+	}
+	after, _, _ := store.GetRegistryRow(keyForRow)
+	if string(before) != string(after) {
+		t.Errorf("idempotent replay altered row: before=%x after=%x", before, after)
 	}
 }
 

--- a/internal/encryption/applier_test.go
+++ b/internal/encryption/applier_test.go
@@ -152,7 +152,7 @@ func TestApplyRegistration_Case3_Rollback(t *testing.T) {
 // replays committed entries after restart until the latest FSM
 // snapshot; rejecting equal epochs as rollback would pin a
 // node in a halt-on-replay loop after any crash before
-// snapshotting the entry (PR #765 round-2 codex P1).
+// snapshotting the entry.
 func TestApplyRegistration_Case2_IdempotentReplay(t *testing.T) {
 	t.Parallel()
 	store := newMapRegistryStore()

--- a/internal/encryption/errors.go
+++ b/internal/encryption/errors.go
@@ -91,4 +91,20 @@ var (
 	// the kv ↔ engine cycle (engine_test imports kv as a fake
 	// FSM).
 	ErrEncryptionApply = errors.New("encryption: FSM apply failed; halting apply (see design §6.3)")
+
+	// ErrKEKNotConfigured is the defense-in-depth marker returned
+	// by Applier.ApplyBootstrap and Applier.ApplyRotation when no
+	// KEK unwrapper is wired (Stage 6A scaffolding before Stage 6B
+	// fills the KEK plumbing). It is wrapped with ErrEncryptionApply
+	// at the kv/fsm dispatch layer so it routes through the same
+	// HaltApply seam as any other applier error.
+	//
+	// Per PR #762's Stage 6 plan, the production safety boundary
+	// is the gRPC-layer mutator gate in registerEncryptionAdminServer
+	// (which Stage 5D left OFF, and which 6B re-enables only when
+	// both --encryption-enabled is set AND KEKConfigured() is true);
+	// this typed error exists so a future refactor that bypasses
+	// that gate produces a named, grep-able failure mode rather
+	// than a nil-pointer panic deep in the apply path.
+	ErrKEKNotConfigured = errors.New("encryption: KEK not configured on this node; cannot unwrap wrapped DEK material")
 )

--- a/main.go
+++ b/main.go
@@ -704,11 +704,17 @@ func buildShardGroups(
 		// it gated on (--encryption-enabled AND KEKConfigured()).
 		reg, err := store.WriterRegistryFor(st)
 		if err != nil {
+			for _, rt := range runtimes {
+				rt.Close()
+			}
 			_ = st.Close()
 			return nil, nil, errors.Wrapf(err, "failed to construct writer registry for group %d", g.id)
 		}
 		applier, err := encryption.NewApplier(reg)
 		if err != nil {
+			for _, rt := range runtimes {
+				rt.Close()
+			}
 			_ = st.Close()
 			return nil, nil, errors.Wrapf(err, "failed to construct encryption applier for group %d", g.id)
 		}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/bootjp/elastickv/distribution"
 	internalutil "github.com/bootjp/elastickv/internal"
 	"github.com/bootjp/elastickv/internal/admin"
+	"github.com/bootjp/elastickv/internal/encryption"
 	"github.com/bootjp/elastickv/internal/memwatch"
 	internalraftadmin "github.com/bootjp/elastickv/internal/raftadmin"
 	"github.com/bootjp/elastickv/internal/raftengine"
@@ -691,7 +692,27 @@ func buildShardGroups(
 		}
 		// Each shard FSM shares the same HLC so any shard's lease renewal advances
 		// the global physicalCeiling. The logical counter remains in-memory only.
-		sm := kv.NewKvFSMWithHLC(st, clock)
+		//
+		// §6.3 EncryptionApplier wiring (Stage 6A). Constructs an
+		// Applier backed by the FSM's Pebble store and threads it
+		// into the FSM dispatch via kv.WithEncryption. The applier's
+		// ApplyBootstrap / ApplyRotation paths return ErrKEKNotConfigured
+		// until Stage 6B threads in the KEK plumbing; only
+		// ApplyRegistration is fully functional in 6A, but the gRPC
+		// mutator gate (registerEncryptionAdminServer, Stage 5D
+		// posture) keeps the operator surface inert until 6B re-enables
+		// it gated on (--encryption-enabled AND KEKConfigured()).
+		reg, err := store.WriterRegistryFor(st)
+		if err != nil {
+			_ = st.Close()
+			return nil, nil, errors.Wrapf(err, "failed to construct writer registry for group %d", g.id)
+		}
+		applier, err := encryption.NewApplier(reg)
+		if err != nil {
+			_ = st.Close()
+			return nil, nil, errors.Wrapf(err, "failed to construct encryption applier for group %d", g.id)
+		}
+		sm := kv.NewKvFSMWithHLC(st, clock, kv.WithEncryption(applier))
 		runtime, err := buildRuntimeForGroup(raftID, g, raftDir, multi, bootstrap, bootstrapServers, st, sm, factory, *raftJoinAsLearner)
 		if err != nil {
 			for _, rt := range runtimes {

--- a/store/encryption_glue.go
+++ b/store/encryption_glue.go
@@ -3,7 +3,93 @@ package store
 import (
 	"github.com/bootjp/elastickv/internal/encryption"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/v2"
 )
+
+// ErrUnsupportedStoreForWriterRegistry is returned by
+// WriterRegistryFor when the supplied MVCCStore is not backed by
+// the in-tree Pebble implementation. Test fakes and alternate
+// backends are detected at construction time so the failure mode
+// is "binary refuses to start" rather than "FSM apply panics
+// inside Raft loop".
+var ErrUnsupportedStoreForWriterRegistry = errors.New("store: WriterRegistryFor requires a Pebble-backed MVCCStore")
+
+// pebbleWriterRegistry adapts the Pebble-backed MVCCStore to the
+// encryption.WriterRegistryStore interface used by the §6.3
+// EncryptionApplier. The §4.1 writer-registry rows live under the
+// `!encryption|writers|...` Pebble prefix — outside the MVCC
+// namespace — so reads and writes bypass the MVCC layer entirely
+// and hit the underlying *pebble.DB directly.
+//
+// Both Get and Set hold dbMu for read (RLock) only: the apply
+// path that calls into the Applier is already serialised by
+// kv/fsm.go's applyMu, so the registry row read-modify-write is
+// safe without an exclusive Pebble-level lock. dbMu's RLock is
+// the minimum required to protect against the Pebble DB pointer
+// being swapped during snapshot restore.
+//
+// Set uses pebble.Sync so the row is durable before the FSM apply
+// returns — without that, a crash between the FSM dispatch
+// returning success and Pebble flushing the WAL would leave the
+// Raft log claiming the entry applied but the registry row
+// missing on the next restart. That would violate §4.1 case 2's
+// monotonic-epoch invariant.
+type pebbleWriterRegistry struct {
+	s *pebbleStore
+}
+
+// GetRegistryRow looks up the value at key under the
+// `!encryption|writers|...` namespace. A missing row returns
+// (nil, false, nil) — NOT an error. Any other Pebble error
+// (corruption, I/O fault) returns (nil, false, err) so the
+// applier halts apply rather than silently treating the row as
+// missing.
+func (p *pebbleWriterRegistry) GetRegistryRow(key []byte) ([]byte, bool, error) {
+	p.s.dbMu.RLock()
+	defer p.s.dbMu.RUnlock()
+	val, closer, err := p.s.db.Get(key)
+	if err != nil {
+		if errors.Is(err, pebble.ErrNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, errors.Wrap(err, "pebble: get writer registry row")
+	}
+	out := make([]byte, len(val))
+	copy(out, val)
+	if cerr := closer.Close(); cerr != nil {
+		return nil, false, errors.Wrap(cerr, "pebble: close writer registry row reader")
+	}
+	return out, true, nil
+}
+
+// SetRegistryRow durably writes value at key. Idempotent at the
+// (key, value) tuple level: writing the same bytes twice is
+// observationally identical to writing them once. pebble.Sync
+// blocks until the WAL is flushed to disk so the row survives a
+// crash that lands after the FSM apply returns.
+func (p *pebbleWriterRegistry) SetRegistryRow(key, value []byte) error {
+	p.s.dbMu.RLock()
+	defer p.s.dbMu.RUnlock()
+	if err := p.s.db.Set(key, value, pebble.Sync); err != nil {
+		return errors.Wrap(err, "pebble: set writer registry row")
+	}
+	return nil
+}
+
+// WriterRegistryFor returns an encryption.WriterRegistryStore
+// backed by the Pebble DB underlying the supplied MVCCStore.
+// Returns ErrUnsupportedStoreForWriterRegistry if the store is
+// not a Pebble-backed MVCCStore — callers should treat this as a
+// startup-fatal misconfiguration (the only in-tree non-Pebble
+// MVCCStore is the in-memory test fake, which has no encryption
+// requirements).
+func WriterRegistryFor(s MVCCStore) (encryption.WriterRegistryStore, error) {
+	ps, ok := s.(*pebbleStore)
+	if !ok {
+		return nil, errors.WithStack(ErrUnsupportedStoreForWriterRegistry)
+	}
+	return &pebbleWriterRegistry{s: ps}, nil
+}
 
 // ErrEncryptedReadIntegrity wraps encryption.ErrIntegrity for storage-layer
 // callers (Get / scan / iterator). Per design §4.1, callers MUST treat this

--- a/store/encryption_glue.go
+++ b/store/encryption_glue.go
@@ -85,7 +85,13 @@ func (p *pebbleWriterRegistry) SetRegistryRow(key, value []byte) error {
 // requirements).
 func WriterRegistryFor(s MVCCStore) (encryption.WriterRegistryStore, error) {
 	ps, ok := s.(*pebbleStore)
-	if !ok {
+	// A typed-nil (*pebbleStore)(nil) passes the assertion with
+	// ok=true but ps==nil; the adapter would then nil-deref on
+	// first call. Reject both shapes at construction so the
+	// failure mode is "binary refuses to start" rather than
+	// "FSM apply panics deep in Raft loop" — coderabbit PR #765
+	// round-2 Major.
+	if !ok || ps == nil {
 		return nil, errors.WithStack(ErrUnsupportedStoreForWriterRegistry)
 	}
 	return &pebbleWriterRegistry{s: ps}, nil

--- a/store/encryption_glue.go
+++ b/store/encryption_glue.go
@@ -89,8 +89,7 @@ func WriterRegistryFor(s MVCCStore) (encryption.WriterRegistryStore, error) {
 	// ok=true but ps==nil; the adapter would then nil-deref on
 	// first call. Reject both shapes at construction so the
 	// failure mode is "binary refuses to start" rather than
-	// "FSM apply panics deep in Raft loop" — coderabbit PR #765
-	// round-2 Major.
+	// "FSM apply panics deep in Raft loop".
 	if !ok || ps == nil {
 		return nil, errors.WithStack(ErrUnsupportedStoreForWriterRegistry)
 	}

--- a/store/writer_registry_test.go
+++ b/store/writer_registry_test.go
@@ -1,0 +1,121 @@
+package store_test
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/bootjp/elastickv/store"
+)
+
+// newRegistryTestStore opens a fresh Pebble-backed MVCCStore for
+// the writer-registry tests. Cleanup is handled via t.Cleanup so
+// each test gets an isolated db dir.
+func newRegistryTestStore(t *testing.T) store.MVCCStore {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "fsm.db")
+	s, err := store.NewPebbleStore(dir)
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// TestWriterRegistryFor_RoundTrip pins the production wiring of the
+// §6.3 EncryptionApplier's writer-registry surface: a row written
+// via the Pebble-backed adapter is read back byte-identical on a
+// subsequent Get.
+func TestWriterRegistryFor_RoundTrip(t *testing.T) {
+	t.Parallel()
+	s := newRegistryTestStore(t)
+	reg, err := store.WriterRegistryFor(s)
+	if err != nil {
+		t.Fatalf("WriterRegistryFor: %v", err)
+	}
+
+	key := encryption.RegistryKey(7, 0x1234)
+	value := encryption.EncodeRegistryValue(encryption.RegistryValue{
+		FullNodeID:          0xDEAD_BEEF_CAFE_BABE,
+		FirstSeenLocalEpoch: 5,
+		LastSeenLocalEpoch:  9,
+	})
+
+	// Missing row reads as (nil, false, nil) — NOT an error.
+	v, ok, err := reg.GetRegistryRow(key)
+	if err != nil {
+		t.Fatalf("GetRegistryRow on missing: %v", err)
+	}
+	if ok {
+		t.Errorf("expected missing row, got value %q", v)
+	}
+
+	if err := reg.SetRegistryRow(key, value); err != nil {
+		t.Fatalf("SetRegistryRow: %v", err)
+	}
+	got, ok, err := reg.GetRegistryRow(key)
+	if err != nil {
+		t.Fatalf("GetRegistryRow after Set: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected row present after Set")
+	}
+	if string(got) != string(value) {
+		t.Errorf("round-trip mismatch: got %x, want %x", got, value)
+	}
+}
+
+// TestWriterRegistryFor_Overwrite pins the idempotency / overwrite
+// semantics: SetRegistryRow on an existing key replaces the value;
+// no MVCC versioning, no append.
+func TestWriterRegistryFor_Overwrite(t *testing.T) {
+	t.Parallel()
+	s := newRegistryTestStore(t)
+	reg, err := store.WriterRegistryFor(s)
+	if err != nil {
+		t.Fatalf("WriterRegistryFor: %v", err)
+	}
+
+	key := encryption.RegistryKey(1, 0x42)
+	v1 := encryption.EncodeRegistryValue(encryption.RegistryValue{FullNodeID: 1, FirstSeenLocalEpoch: 1, LastSeenLocalEpoch: 1})
+	v2 := encryption.EncodeRegistryValue(encryption.RegistryValue{FullNodeID: 1, FirstSeenLocalEpoch: 1, LastSeenLocalEpoch: 9})
+
+	if err := reg.SetRegistryRow(key, v1); err != nil {
+		t.Fatalf("first Set: %v", err)
+	}
+	if err := reg.SetRegistryRow(key, v2); err != nil {
+		t.Fatalf("second Set: %v", err)
+	}
+	got, ok, err := reg.GetRegistryRow(key)
+	if err != nil || !ok {
+		t.Fatalf("GetRegistryRow: ok=%v err=%v", ok, err)
+	}
+	if string(got) != string(v2) {
+		t.Errorf("overwrite mismatch: got %x, want %x", got, v2)
+	}
+}
+
+// TestWriterRegistryFor_RejectsNonPebble pins the construction-time
+// guard. We use a minimal MVCCStore stub that has no Pebble backing
+// — passing it to WriterRegistryFor MUST surface
+// ErrUnsupportedStoreForWriterRegistry at construction time so the
+// startup wiring catches the misconfiguration before the FSM apply
+// path can nil-deref.
+func TestWriterRegistryFor_RejectsNonPebble(t *testing.T) {
+	t.Parallel()
+	_, err := store.WriterRegistryFor(noopMVCCStub{})
+	if err == nil {
+		t.Fatal("WriterRegistryFor(non-pebble) returned no error; want refusal")
+	}
+	if !errors.Is(err, store.ErrUnsupportedStoreForWriterRegistry) {
+		t.Errorf("err not marked ErrUnsupportedStoreForWriterRegistry: %v", err)
+	}
+}
+
+// noopMVCCStub is a do-nothing MVCCStore used only to verify the
+// type-assertion refusal path. Every method panics — the test must
+// not reach them, which is exactly the contract being verified
+// (WriterRegistryFor returns ErrUnsupportedStoreForWriterRegistry
+// before calling any method on the supplied store).
+type noopMVCCStub struct{ store.MVCCStore }


### PR DESCRIPTION
## Summary

First slice of **Stage 6A** per the [PR #762 plan](https://github.com/bootjp/elastickv/pull/762): the load-bearing safety boundary that lands the §6.3 `EncryptionApplier` so future PRs can re-enable mutating-RPC wiring without bricking the cluster.

This PR is doc-driven by the merged Stage 6 plan; specifically the 6A row:

> §6.3 `EncryptionApplier` concrete implementation (writer-registry insert + sidecar mutate + keystore update; nil-KEK code paths in `ApplyBootstrap` / `ApplyRotation` return a typed `ErrKEKNotConfigured` defense-in-depth marker until 6B fills it) + `kv.NewKvFSMWithHLC(... WithEncryption(applier))` wiring. **Mutator wiring in `registerEncryptionAdminServer` stays OFF, identical to Stage 5D**.

## What this PR ships

### Part 1 (this commit, `e2475b84`) — applier package

- **`internal/encryption/applier.go`** (new) — concrete `Applier` satisfying `kv.EncryptionApplier`:
  - `WriterRegistryStore` interface (abstract Get/Set over the `!encryption|writers|<dek_id>|<uint16(node_id)>` Pebble namespace; kept separate from `store.MVCCStore` because writer-registry rows live outside MVCC).
  - `ApplyRegistration` implements the §4.1 four-case dispatch (insert / monotonic advance / rollback halt / uint16-collision halt).
  - `ApplyBootstrap` and `ApplyRotation` return the typed `ErrKEKNotConfigured` defense-in-depth marker — Stage 6B will replace them with the real KEK-unwrap + sidecar + keystore path.

- **`internal/encryption/errors.go`** — add `ErrKEKNotConfigured` sentinel with godoc referencing the PR #762 safety-boundary decomposition.

- **`internal/encryption/applier_test.go`** (new) — 7 unit tests covering all four §4.1 cases, construction-time nil-registry refusal, store-error propagation, and the 6B-deferred stub contracts. Uses a map-backed `WriterRegistryStore` fake.

### Part 2 (follow-up commit in this PR) — FSM wiring

- Concrete `WriterRegistryStore` implementation backed by the FSM's Pebble store (`store/encryption_glue.go` or new file).
- `kv.NewKvFSMWithHLC(... kv.WithEncryption(applier))` wiring at `main.go:694`.

The Part 1 commit compiles and tests pass on its own; Part 2 plumbs it into production.

## What this PR does NOT do

`registerEncryptionAdminServer` is **untouched**. Mutating EncryptionAdmin RPCs continue to refuse with `FailedPrecondition` exactly as Stage 5D left them. The Stage 6 plan's safety invariant — do not re-enable mutator wiring until both the applier AND a KEK unwrapper are present — holds: this PR lands the applier (and the FSM dispatch is no longer a halt path for `ApplyRegistration`), but the KEK plumbing (6B) is still missing. 6B will re-enable the mutator wiring gated on (`--encryption-enabled` AND `KEKConfigured()`), both conditions required.

## Caller audit

- `kv.EncryptionApplier` interface — implemented by `*encryption.Applier`. No other callers; the FSM dispatch is the sole consumer.
- `internal/encryption/errors.go` exported sentinels — `ErrKEKNotConfigured` is new; no callers yet outside `applier.go` (the kv/fsm dispatch will wrap any non-nil return with `ErrEncryptionApply` regardless of the inner marker).

## Five-lens self-review

1. **Data loss** — applier's writes go through `WriterRegistryStore.SetRegistryRow`, which the production wiring (Part 2) routes through `pebble.Sync`. No silent skip path: every error return is propagated; the `kv/fsm` dispatch marks them with `ErrEncryptionApply` for HaltApply.
2. **Concurrency / distributed failures** — Applier carries no in-memory state between calls; the `WriterRegistryStore` is the single source of truth. FSM apply already serialises `0x03` entries via `applyMu`, so the §4.1 case-dispatch read-modify-write is safe under that lock.
3. **Performance** — `ApplyRegistration` does one Get + at most one Set per call. Production Pebble will add the sync cost; bounded.
4. **Data consistency** — §4.1 case 1/2/3/4 dispatch matches the design doc. Case 3 (rollback) halts apply; the 6C startup guard will prevent it from being reachable in production. Case 4 (uint16 collision) similarly halts and is the per-node backstop for §6.1's cluster-wide uniqueness check.
5. **Test coverage** — 7 unit tests covering all four §4.1 cases, construction refusal, store-error propagation, and the 6B-deferred stub contracts. Map-backed fake mirrors the production semantics.

## Test plan

- [x] `go test -race -timeout=60s ./internal/encryption/...` — PASS
- [x] `go build ./...` — PASS
- [x] `golangci-lint run ./internal/encryption/...` — 0 issues
- [ ] After Part 2 commit: `go test -race ./...` (full suite) — Will run before requesting review
- [ ] After Part 2 commit: Re-run jepsen-relevant suite (none of 6A's behaviour is operator-visible, so no envelope-cutover Jepsen workload applies; documented in PR description)

## Plan: 6A → 6B → 6C → 6D → 6E → 6F

This is the first of six PRs per [PR #762](https://github.com/bootjp/elastickv/pull/762). 6B will follow with the KEK plumbing + mutator gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated encryption into core system operations with enhanced writer registration and persistence.
  * Added encryption configuration validation and detailed error reporting for setup issues.

* **Tests**
  * Comprehensive test coverage for encryption functionality, data storage, and integration scenarios.
  * Verification tests for encryption configuration and startup validation.

* **Chores**
  * Enhanced application startup sequence with encryption support integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->