### PR TITLE
feat(encryption): Stage 6B part 1 — real ApplyBootstrap + ApplyRotation with KEK plumbing

### DIFF
--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -286,7 +286,6 @@ func (a *Applier) ApplyRegistration(p fsmwire.RegistrationPayload) error {
 	return nil
 }
 
-// ApplyBootstrap returns ErrKEKNotConfigured as the Stage 6A
 // ApplyBootstrap implements §5.6 step 1a's initial bootstrap apply:
 //
 //  1. KEK-unwrap the wrapped storage + raft DEK pair.
@@ -300,22 +299,38 @@ func (a *Applier) ApplyRegistration(p fsmwire.RegistrationPayload) error {
 // Without the trio of WithKEK / WithKeystore / WithSidecarPath
 // supplied at construction, returns ErrKEKNotConfigured wrapped
 // for the HaltApply pipeline — the defense-in-depth marker that
-// keeps Stage 6A consistent with the FSM contract.
+// keeps the no-options posture consistent with the FSM contract.
 //
 // Ordering for crash recovery: Keystore.Set fires before
-// WriteSidecar so an in-memory DEK only escapes to disk after
-// the keystore install succeeded. A crash before WriteSidecar
-// loses the in-memory keystore on restart, but the entry stays
-// in the Raft log uncommitted-from-sidecar — replay re-runs the
-// full sequence. A crash after WriteSidecar but before batch
-// insert is recovered by replay because §4.1 case-2-idempotent
-// makes the per-row inserts no-op on the second pass.
+// WriteSidecar so an ErrKeyConflict from Set aborts the apply
+// before any disk mutation. A crash before WriteSidecar loses
+// the in-memory keystore on restart, but the entry stays in the
+// Raft log unapplied — replay re-runs the full sequence. A crash
+// after WriteSidecar but before batch insert is recovered by
+// replay because §4.1 case-2-idempotent makes the per-row inserts
+// no-op on the second pass.
 //
 // Keystore.Set is idempotent for matching DEK bytes (returns nil)
 // and returns ErrKeyConflict only if the same key_id maps to
 // different bytes — which means a buggy KEK-unwrap path produced
 // different output for the same wrapped input. That's a halt
 // condition; the wrapped output is propagated.
+//
+// Blocking behaviour: ApplyBootstrap performs synchronous IO for
+// each step (KEK Unwrap may dial a KMS in production providers,
+// WriteSidecar fsyncs to disk, every BatchRegistry row triggers a
+// pebble.Sync). Stage 6A's main.go wiring invokes this from the
+// FSM apply path, which is already serialised under the engine's
+// applyMu, so the synchronous IO is part of the §6.3 contract —
+// a slow Bootstrap blocks the apply loop until commit, which is
+// the same shape every other 0x03/0x04/0x05 entry uses. The
+// BatchRegistry insert is the most likely contributor to apply
+// latency at scale (one pebble.Sync per cluster member); the
+// §5.6 BootstrapBatchRowCap = 1<<14 keeps the worst case bounded.
+// A future optimisation could replace the per-row Set with a
+// pebble.Batch.Commit(pebble.Sync), but the current shape is
+// correct and matches the Stage 6A ApplyRegistration semantics
+// row-for-row.
 func (a *Applier) ApplyBootstrap(p fsmwire.BootstrapPayload) error {
 	if !a.bootstrapAndRotationConfigured() {
 		return errors.Wrap(ErrKEKNotConfigured, "applier: bootstrap requires WithKEK + WithKeystore + WithSidecarPath")

--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -148,8 +148,18 @@ func NewApplier(registry WriterRegistryStore, opts ...ApplierOption) (*Applier, 
 		return nil, errors.New("encryption: NewApplier: registry is nil")
 	}
 	a := &Applier{registry: registry, now: time.Now}
-	for _, opt := range opts {
+	for i, opt := range opts {
+		if opt == nil {
+			return nil, errors.Errorf("encryption: NewApplier: opts[%d] is nil", i)
+		}
 		opt(a)
+	}
+	// WithNowFunc(nil) would overwrite the default and later panic
+	// at apply time when a.now() is invoked. Fail fast at
+	// construction so the misconfiguration surfaces at startup
+	// rather than deep inside a Raft apply loop.
+	if a.now == nil {
+		return nil, errors.New("encryption: NewApplier: WithNowFunc(nil) overwrote default time.Now")
 	}
 	return a, nil
 }
@@ -310,6 +320,15 @@ func (a *Applier) ApplyBootstrap(p fsmwire.BootstrapPayload) error {
 	if !a.bootstrapAndRotationConfigured() {
 		return errors.Wrap(ErrKEKNotConfigured, "applier: bootstrap requires WithKEK + WithKeystore + WithSidecarPath")
 	}
+	// Storage and raft DEK IDs MUST differ. If they collided, the
+	// second sc.Keys[...] assignment would overwrite the first,
+	// silently mis-labelling the purpose of the lone surviving
+	// key — a violation of §5.1's per-purpose DEK separation
+	// invariant. Halt rather than silently corrupt the sidecar.
+	if p.StorageDEKID == p.RaftDEKID {
+		return errors.Wrapf(ErrEncryptionApply,
+			"applier: bootstrap requires distinct storage and raft DEK IDs (got %d for both)", p.StorageDEKID)
+	}
 	storageDEK, err := a.kek.Unwrap(p.WrappedStorage)
 	if err != nil {
 		return errors.Wrap(err, "applier: kek-unwrap storage DEK")
@@ -407,6 +426,18 @@ func (a *Applier) ApplyRotation(p fsmwire.RotationPayload) error {
 	if p.SubTag != fsmwire.RotateSubRotateDEK {
 		return errors.Wrapf(ErrEncryptionApply,
 			"applier: rotation sub_tag %#x not implemented in Stage 6B-1", p.SubTag)
+	}
+	// The proposer-registration row MUST target the rotated DEK ID
+	// — that is the whole point of including it atomically with the
+	// rotate-dek entry (§5.2): cover the proposer's first encrypted
+	// write under the NEW DEK with a §4.1 case-1 first-seen row.
+	// Accepting a different DEK ID would mutate writer-registry
+	// state for an unrelated DEK while leaving the rotated DEK
+	// unregistered, silently breaking the rotate-dek invariant.
+	if p.ProposerRegistration.DEKID != p.DEKID {
+		return errors.Wrapf(ErrEncryptionApply,
+			"applier: rotation proposer_registration.dek_id=%d does not match rotation dek_id=%d",
+			p.ProposerRegistration.DEKID, p.DEKID)
 	}
 	dek, err := a.kek.Unwrap(p.Wrapped)
 	if err != nil {

--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -332,17 +332,8 @@ func (a *Applier) ApplyRegistration(p fsmwire.RegistrationPayload) error {
 // correct and matches the Stage 6A ApplyRegistration semantics
 // row-for-row.
 func (a *Applier) ApplyBootstrap(p fsmwire.BootstrapPayload) error {
-	if !a.bootstrapAndRotationConfigured() {
-		return errors.Wrap(ErrKEKNotConfigured, "applier: bootstrap requires WithKEK + WithKeystore + WithSidecarPath")
-	}
-	// Storage and raft DEK IDs MUST differ. If they collided, the
-	// second sc.Keys[...] assignment would overwrite the first,
-	// silently mis-labelling the purpose of the lone surviving
-	// key — a violation of §5.1's per-purpose DEK separation
-	// invariant. Halt rather than silently corrupt the sidecar.
-	if p.StorageDEKID == p.RaftDEKID {
-		return errors.Wrapf(ErrEncryptionApply,
-			"applier: bootstrap requires distinct storage and raft DEK IDs (got %d for both)", p.StorageDEKID)
+	if err := a.validateBootstrap(p); err != nil {
+		return err
 	}
 	storageDEK, err := a.kek.Unwrap(p.WrappedStorage)
 	if err != nil {
@@ -365,6 +356,41 @@ func (a *Applier) ApplyBootstrap(p fsmwire.BootstrapPayload) error {
 		if err := a.ApplyRegistration(reg); err != nil {
 			return errors.Wrapf(err, "applier: bootstrap batch registry insert at index %d (dek_id=%d, full_node_id=%#x)",
 				i, reg.DEKID, reg.FullNodeID)
+		}
+	}
+	return nil
+}
+
+// validateBootstrap runs the three input invariants the bootstrap
+// dispatch enforces before any state mutation:
+//
+//  1. WithKEK + WithKeystore + WithSidecarPath all supplied.
+//  2. StorageDEKID and RaftDEKID distinct — equal IDs would cause
+//     the second sc.Keys[...] assignment in writeBootstrapSidecar
+//     to overwrite the first, silently mis-labelling the lone
+//     surviving key's purpose.
+//  3. Every BatchRegistry row targets one of the two bootstrap
+//     DEKs — a row targeting a foreign DEK would persist
+//     writer-registry state for an unrelated key while the
+//     bootstrap installs only the declared pair, silently
+//     breaking the §4.1 first-writer invariant on the next
+//     post-bootstrap write under that foreign DEK.
+//
+// Extracted from ApplyBootstrap so the dispatch hot path stays
+// below the cyclomatic complexity budget.
+func (a *Applier) validateBootstrap(p fsmwire.BootstrapPayload) error {
+	if !a.bootstrapAndRotationConfigured() {
+		return errors.Wrap(ErrKEKNotConfigured, "applier: bootstrap requires WithKEK + WithKeystore + WithSidecarPath")
+	}
+	if p.StorageDEKID == p.RaftDEKID {
+		return errors.Wrapf(ErrEncryptionApply,
+			"applier: bootstrap requires distinct storage and raft DEK IDs (got %d for both)", p.StorageDEKID)
+	}
+	for i, reg := range p.BatchRegistry {
+		if reg.DEKID != p.StorageDEKID && reg.DEKID != p.RaftDEKID {
+			return errors.Wrapf(ErrEncryptionApply,
+				"applier: bootstrap BatchRegistry[%d].dek_id=%d does not match storage=%d or raft=%d",
+				i, reg.DEKID, p.StorageDEKID, p.RaftDEKID)
 		}
 	}
 	return nil

--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -1,6 +1,7 @@
 package encryption
 
 import (
+	"bytes"
 	"strconv"
 	"time"
 
@@ -397,15 +398,31 @@ func (a *Applier) validateBootstrap(p fsmwire.BootstrapPayload) error {
 }
 
 // checkBootstrapIdempotency enforces the §5.6 one-time-bootstrap
-// invariant. A second committed bootstrap entry with DIFFERENT
-// DEK IDs would re-point Active.{Storage,Raft} outside the
-// rotation path, leaving writer-registry and key-lifecycle
-// semantics inconsistent with the bootstrap/rotation contract.
+// invariant. A second committed bootstrap entry would re-point
+// Active.{Storage,Raft} or mutate writer-registry state outside
+// the rotation path, leaving key-lifecycle semantics inconsistent
+// with the bootstrap/rotation contract.
 //
 // Raft replay of the SAME bootstrap entry (e.g., crash after
 // bootstrap apply but before snapshot) is idempotent and allowed
-// — the existing sidecar's Active slots will match the payload's
-// DEK IDs exactly, so the check falls through.
+// — Raft entry bytes are deterministic across replicas, so a
+// legitimate replay has the same DEK IDs AND the same wrapped
+// DEK material as the original apply. The check compares both:
+//
+//  1. DEK IDs must match Active.{Storage,Raft} (otherwise the
+//     second bootstrap is rerouting active keys outside the
+//     rotation path).
+//  2. Wrapped DEK bytes must match sc.Keys[id].Wrapped
+//     (otherwise the second bootstrap is installing DIFFERENT
+//     key material under the same id — a divergent BatchRegistry
+//     would necessarily reach apply through such a payload
+//     because Raft determinism couples wrapped bytes to the
+//     entire entry hash).
+//
+// If both DEK IDs and wrapped bytes match, the BatchRegistry
+// rows must also match by Raft determinism — replay through
+// ApplyRegistration is then safe via the §4.1 case-2-idempotent
+// path.
 //
 // Split out from validateBootstrap so the dispatch path stays
 // below the cyclop complexity budget.
@@ -420,12 +437,40 @@ func (a *Applier) checkBootstrapIdempotency(p fsmwire.BootstrapPayload) error {
 	if sc.Active.Storage == 0 && sc.Active.Raft == 0 {
 		return nil
 	}
-	if sc.Active.Storage == p.StorageDEKID && sc.Active.Raft == p.RaftDEKID {
-		return nil
+	if sc.Active.Storage != p.StorageDEKID || sc.Active.Raft != p.RaftDEKID {
+		return errors.Wrapf(ErrEncryptionApply,
+			"applier: cluster already bootstrapped (Active.Storage=%d, Active.Raft=%d); cannot re-bootstrap to (%d, %d) — use rotate-dek",
+			sc.Active.Storage, sc.Active.Raft, p.StorageDEKID, p.RaftDEKID)
 	}
-	return errors.Wrapf(ErrEncryptionApply,
-		"applier: cluster already bootstrapped (Active.Storage=%d, Active.Raft=%d); cannot re-bootstrap to (%d, %d) — use rotate-dek",
-		sc.Active.Storage, sc.Active.Raft, p.StorageDEKID, p.RaftDEKID)
+	if err := a.checkBootstrapWrappedMatches(sc, p); err != nil {
+		return err
+	}
+	return nil
+}
+
+// checkBootstrapWrappedMatches compares the payload's wrapped DEK
+// bytes against the existing sidecar entries at the same DEK IDs.
+// A mismatch indicates a second bootstrap entry committed with
+// the same DEK IDs but different wrapped material — Raft
+// determinism couples wrapped bytes to the entry hash, so
+// matching wrapped bytes is the stable proof of a legitimate
+// idempotent replay.
+//
+// Split out from checkBootstrapIdempotency to keep that helper
+// under the cyclop complexity budget.
+func (a *Applier) checkBootstrapWrappedMatches(sc *Sidecar, p fsmwire.BootstrapPayload) error {
+	storageKey, hasStorage := sc.Keys[strconv.FormatUint(uint64(p.StorageDEKID), 10)]
+	raftKey, hasRaft := sc.Keys[strconv.FormatUint(uint64(p.RaftDEKID), 10)]
+	if !hasStorage || !hasRaft {
+		return errors.Wrapf(ErrEncryptionApply,
+			"applier: sidecar inconsistent — Active matches (%d, %d) but keys map missing one or both entries",
+			p.StorageDEKID, p.RaftDEKID)
+	}
+	if !bytes.Equal(storageKey.Wrapped, p.WrappedStorage) || !bytes.Equal(raftKey.Wrapped, p.WrappedRaft) {
+		return errors.Wrap(ErrEncryptionApply,
+			"applier: cluster already bootstrapped with different wrapped DEK material at the same DEK IDs — use rotate-dek")
+	}
+	return nil
 }
 
 // writeBootstrapSidecar reads the existing sidecar (or starts a

--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -1,6 +1,9 @@
 package encryption
 
 import (
+	"strconv"
+	"time"
+
 	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
 	"github.com/cockroachdb/errors"
 )
@@ -65,19 +68,104 @@ type WriterRegistryStore interface {
 // of the process — no per-apply allocation, no locks, no leak
 // path for stale state across snapshot restore.
 type Applier struct {
-	registry WriterRegistryStore
+	registry    WriterRegistryStore
+	kek         KEKUnwrapper
+	keystore    *Keystore
+	sidecarPath string
+	now         func() time.Time
 }
 
-// NewApplier wires an Applier against the supplied registry store.
+// KEKUnwrapper is the abstraction the Applier uses to recover
+// cleartext DEK bytes from the wrapped DEK material carried in
+// BootstrapPayload / RotationPayload. The supplied implementation
+// is exercised on every 0x04 / 0x05 apply, so it MUST be safe for
+// concurrent use across replays.
+//
+// kek.Wrapper from internal/encryption/kek satisfies this interface
+// structurally — the Applier carries its own local interface
+// declaration so the encryption package does not pick up a
+// transitive dependency on the kek package's import graph (which
+// in turn lets the kek package import from internal/encryption
+// without a cycle when KMS providers land in Stage 9).
+type KEKUnwrapper interface {
+	Unwrap(wrapped []byte) ([]byte, error)
+}
+
+// ApplierOption configures an Applier at construction. Stage 6A
+// shipped with only the WriterRegistryStore required; Stage 6B
+// adds the KEK / Keystore / SidecarPath plumbing that unlocks
+// real ApplyBootstrap / ApplyRotation. The functional-option
+// shape keeps the Stage 6A test surface (NewApplier(reg)) working
+// byte-for-byte while letting production main.go layer in the
+// new dependencies.
+type ApplierOption func(*Applier)
+
+// WithKEK wires the KEKUnwrapper used by ApplyBootstrap /
+// ApplyRotation. Passing nil leaves the Applier in the Stage 6A
+// posture where both paths short-circuit with ErrKEKNotConfigured.
+func WithKEK(unwrap KEKUnwrapper) ApplierOption {
+	return func(a *Applier) { a.kek = unwrap }
+}
+
+// WithKeystore wires the in-memory keystore the Applier mutates
+// on Bootstrap / Rotation. The keystore lifetime spans the
+// process — main.go passes the same instance the storage cipher
+// is reading from.
+func WithKeystore(ks *Keystore) ApplierOption {
+	return func(a *Applier) { a.keystore = ks }
+}
+
+// WithSidecarPath wires the §5.1 keys.json path the Applier
+// crash-durably mutates on Bootstrap / Rotation. Empty path
+// disables sidecar mutation (Stage 6A posture).
+func WithSidecarPath(path string) ApplierOption {
+	return func(a *Applier) { a.sidecarPath = path }
+}
+
+// WithNowFunc overrides the wall-clock used for the sidecar's
+// Created field. Tests pin this to a deterministic clock; the
+// production default is time.Now. The Created field is diagnostic
+// only — different replicas timestamp independently and that is
+// fine (§5.1 does not require byte-equal sidecars).
+func WithNowFunc(now func() time.Time) ApplierOption {
+	return func(a *Applier) { a.now = now }
+}
+
+// NewApplier wires an Applier against the supplied registry store
+// plus optional KEK / Keystore / sidecar / clock dependencies.
 // Returns an error if registry is nil so misconfiguration is caught
 // at construction time rather than at first apply (the panic site
 // is much harder to map back to a "you forgot to wire X" diagnosis
 // when it fires deep inside a Raft apply loop).
-func NewApplier(registry WriterRegistryStore) (*Applier, error) {
+//
+// Without WithKEK / WithKeystore / WithSidecarPath, the Applier
+// retains the Stage 6A behaviour — ApplyRegistration is fully
+// functional, ApplyBootstrap and ApplyRotation return the typed
+// ErrKEKNotConfigured marker. This is the test default and the
+// pre-Stage-6B production posture.
+func NewApplier(registry WriterRegistryStore, opts ...ApplierOption) (*Applier, error) {
 	if registry == nil {
 		return nil, errors.New("encryption: NewApplier: registry is nil")
 	}
-	return &Applier{registry: registry}, nil
+	a := &Applier{registry: registry, now: time.Now}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a, nil
+}
+
+// bootstrapAndRotationConfigured reports whether WithKEK,
+// WithKeystore, and WithSidecarPath have all been supplied. The
+// three are an indivisible quorum for ApplyBootstrap /
+// ApplyRotation — KEK-unwrap without a keystore to install into
+// would compute DEK bytes only to discard them; a keystore
+// install without a sidecar write would not survive restart; a
+// sidecar write without KEK would record wrapped DEKs the local
+// node cannot decrypt. The check is on read so a partial wiring
+// during a future refactor fails closed at apply time rather
+// than mis-applying with one dep present.
+func (a *Applier) bootstrapAndRotationConfigured() bool {
+	return a.kek != nil && a.keystore != nil && a.sidecarPath != ""
 }
 
 // ApplyRegistration implements §4.1's writer-registry insert
@@ -189,24 +277,203 @@ func (a *Applier) ApplyRegistration(p fsmwire.RegistrationPayload) error {
 }
 
 // ApplyBootstrap returns ErrKEKNotConfigured as the Stage 6A
-// defense-in-depth marker. Real bootstrap apply — KEK-unwrap the
-// wrapped DEK pair, install both into the keystore, batch-insert
-// every RegistrationPayload in BatchRegistry as the initial
-// writer-registry rows, and crash-durably persist the sidecar
-// Active.{Storage,Raft} + keys map — lands in Stage 6B alongside
-// the KEK plumbing.
-func (a *Applier) ApplyBootstrap(_ fsmwire.BootstrapPayload) error {
-	return errors.Wrap(ErrKEKNotConfigured, "applier: bootstrap requires KEK unwrapper (Stage 6B)")
+// ApplyBootstrap implements §5.6 step 1a's initial bootstrap apply:
+//
+//  1. KEK-unwrap the wrapped storage + raft DEK pair.
+//  2. Install both into the in-memory Keystore.
+//  3. Update the §5.1 sidecar — Active.{Storage,Raft} slots,
+//     keys[] map for both DEK IDs — and crash-durably persist
+//     via WriteSidecar.
+//  4. Batch-insert every RegistrationPayload in BatchRegistry
+//     as the cluster's initial writer-registry rows.
+//
+// Without the trio of WithKEK / WithKeystore / WithSidecarPath
+// supplied at construction, returns ErrKEKNotConfigured wrapped
+// for the HaltApply pipeline — the defense-in-depth marker that
+// keeps Stage 6A consistent with the FSM contract.
+//
+// Ordering for crash recovery: Keystore.Set fires before
+// WriteSidecar so an in-memory DEK only escapes to disk after
+// the keystore install succeeded. A crash before WriteSidecar
+// loses the in-memory keystore on restart, but the entry stays
+// in the Raft log uncommitted-from-sidecar — replay re-runs the
+// full sequence. A crash after WriteSidecar but before batch
+// insert is recovered by replay because §4.1 case-2-idempotent
+// makes the per-row inserts no-op on the second pass.
+//
+// Keystore.Set is idempotent for matching DEK bytes (returns nil)
+// and returns ErrKeyConflict only if the same key_id maps to
+// different bytes — which means a buggy KEK-unwrap path produced
+// different output for the same wrapped input. That's a halt
+// condition; the wrapped output is propagated.
+func (a *Applier) ApplyBootstrap(p fsmwire.BootstrapPayload) error {
+	if !a.bootstrapAndRotationConfigured() {
+		return errors.Wrap(ErrKEKNotConfigured, "applier: bootstrap requires WithKEK + WithKeystore + WithSidecarPath")
+	}
+	storageDEK, err := a.kek.Unwrap(p.WrappedStorage)
+	if err != nil {
+		return errors.Wrap(err, "applier: kek-unwrap storage DEK")
+	}
+	raftDEK, err := a.kek.Unwrap(p.WrappedRaft)
+	if err != nil {
+		return errors.Wrap(err, "applier: kek-unwrap raft DEK")
+	}
+	if err := a.keystore.Set(p.StorageDEKID, storageDEK); err != nil {
+		return errors.Wrap(err, "applier: keystore set storage DEK")
+	}
+	if err := a.keystore.Set(p.RaftDEKID, raftDEK); err != nil {
+		return errors.Wrap(err, "applier: keystore set raft DEK")
+	}
+	if err := a.writeBootstrapSidecar(p); err != nil {
+		return err
+	}
+	for i, reg := range p.BatchRegistry {
+		if err := a.ApplyRegistration(reg); err != nil {
+			return errors.Wrapf(err, "applier: bootstrap batch registry insert at index %d (dek_id=%d, full_node_id=%#x)",
+				i, reg.DEKID, reg.FullNodeID)
+		}
+	}
+	return nil
 }
 
-// ApplyRotation returns ErrKEKNotConfigured as the Stage 6A
-// defense-in-depth marker. Real rotation apply — KEK-unwrap the
-// proposed DEK, install it under the supplied DEKID, update the
-// sidecar's Active slot for the given Purpose, insert the
-// ProposerRegistration row, and crash-durably persist — lands in
-// Stage 6B.
-func (a *Applier) ApplyRotation(_ fsmwire.RotationPayload) error {
-	return errors.Wrap(ErrKEKNotConfigured, "applier: rotation requires KEK unwrapper (Stage 6B)")
+// writeBootstrapSidecar reads the existing sidecar (or starts a
+// fresh one if absent), sets Active.Storage / Active.Raft, inserts
+// both new wrapped DEKs into the keys[] map under the storage /
+// raft purposes, and crash-durably writes the result.
+//
+// LocalEpoch for the freshly-bootstrapped keys is 0 — bootstrap
+// is the cluster's first registration under each DEK, so the
+// §4.1 case 1 first-seen invariant holds and the registry batch
+// inserts will record FirstSeen = LastSeen = 0 for the
+// proposing node.
+func (a *Applier) writeBootstrapSidecar(p fsmwire.BootstrapPayload) error {
+	sc, err := ReadSidecar(a.sidecarPath)
+	if err != nil && !IsNotExist(err) {
+		return errors.Wrap(err, "applier: read sidecar for bootstrap")
+	}
+	if sc == nil {
+		sc = &Sidecar{Version: SidecarVersion, Keys: map[string]SidecarKey{}}
+	}
+	if sc.Keys == nil {
+		sc.Keys = map[string]SidecarKey{}
+	}
+	sc.Active.Storage = p.StorageDEKID
+	sc.Active.Raft = p.RaftDEKID
+	createdAt := a.now().UTC().Format(time.RFC3339)
+	sc.Keys[strconv.FormatUint(uint64(p.StorageDEKID), 10)] = SidecarKey{
+		Purpose:    SidecarPurposeStorage,
+		Wrapped:    append([]byte(nil), p.WrappedStorage...),
+		Created:    createdAt,
+		LocalEpoch: 0,
+	}
+	sc.Keys[strconv.FormatUint(uint64(p.RaftDEKID), 10)] = SidecarKey{
+		Purpose:    SidecarPurposeRaft,
+		Wrapped:    append([]byte(nil), p.WrappedRaft...),
+		Created:    createdAt,
+		LocalEpoch: 0,
+	}
+	if err := WriteSidecar(a.sidecarPath, sc); err != nil {
+		return errors.Wrap(err, "applier: write sidecar for bootstrap")
+	}
+	return nil
+}
+
+// ApplyRotation implements §5.2 / §5.4 rotation apply. Stage 6B-1
+// handles only the RotateSubRotateDEK sub-tag (rotate the storage
+// or raft DEK to a new key_id). Other sub-tags (rewrap-deks,
+// retire-dek, enable-storage-envelope, enable-raft-envelope) land
+// in later stages and return ErrEncryptionApply for now so the
+// HaltApply seam fires on an unrecognised sub-tag rather than
+// silently advancing setApplied.
+//
+// For RotateSubRotateDEK:
+//
+//  1. KEK-unwrap the proposed wrapped DEK.
+//  2. Install it into the keystore under p.DEKID.
+//  3. Update the §5.1 sidecar — Active slot for the supplied
+//     Purpose, keys[] map for the new DEK ID — and crash-durably
+//     persist.
+//  4. Insert the proposing node's ProposerRegistration row so the
+//     §4.1 case-2 monotonicity check covers its first encrypted
+//     write under the new DEK.
+//
+// Same WithKEK / WithKeystore / WithSidecarPath trio requirement
+// as ApplyBootstrap; partial wiring returns ErrKEKNotConfigured
+// at apply time.
+func (a *Applier) ApplyRotation(p fsmwire.RotationPayload) error {
+	if !a.bootstrapAndRotationConfigured() {
+		return errors.Wrap(ErrKEKNotConfigured, "applier: rotation requires WithKEK + WithKeystore + WithSidecarPath")
+	}
+	if p.SubTag != fsmwire.RotateSubRotateDEK {
+		return errors.Wrapf(ErrEncryptionApply,
+			"applier: rotation sub_tag %#x not implemented in Stage 6B-1", p.SubTag)
+	}
+	dek, err := a.kek.Unwrap(p.Wrapped)
+	if err != nil {
+		return errors.Wrap(err, "applier: kek-unwrap rotation DEK")
+	}
+	if err := a.keystore.Set(p.DEKID, dek); err != nil {
+		return errors.Wrap(err, "applier: keystore set rotation DEK")
+	}
+	if err := a.writeRotationSidecar(p); err != nil {
+		return err
+	}
+	if err := a.ApplyRegistration(p.ProposerRegistration); err != nil {
+		return errors.Wrap(err, "applier: rotation proposer-registration insert")
+	}
+	return nil
+}
+
+// writeRotationSidecar mutates the Active slot for the supplied
+// Purpose and inserts the new wrapped DEK into the keys[] map at
+// p.DEKID, then crash-durably writes. Existing keys[] entries are
+// preserved (rotation does not retire old DEKs — that is a
+// separate sub-tag in Stage 6E).
+func (a *Applier) writeRotationSidecar(p fsmwire.RotationPayload) error {
+	sc, err := ReadSidecar(a.sidecarPath)
+	if err != nil {
+		return errors.Wrap(err, "applier: read sidecar for rotation")
+	}
+	if sc.Keys == nil {
+		sc.Keys = map[string]SidecarKey{}
+	}
+	purpose, err := sidecarPurposeFor(p.Purpose)
+	if err != nil {
+		return err
+	}
+	switch p.Purpose {
+	case fsmwire.PurposeStorage:
+		sc.Active.Storage = p.DEKID
+	case fsmwire.PurposeRaft:
+		sc.Active.Raft = p.DEKID
+	}
+	sc.Keys[strconv.FormatUint(uint64(p.DEKID), 10)] = SidecarKey{
+		Purpose:    purpose,
+		Wrapped:    append([]byte(nil), p.Wrapped...),
+		Created:    a.now().UTC().Format(time.RFC3339),
+		LocalEpoch: 0,
+	}
+	if err := WriteSidecar(a.sidecarPath, sc); err != nil {
+		return errors.Wrap(err, "applier: write sidecar for rotation")
+	}
+	return nil
+}
+
+// sidecarPurposeFor maps the fsmwire.Purpose enum to the
+// sidecar's purpose string (SidecarPurposeStorage /
+// SidecarPurposeRaft). An unrecognised purpose halts apply
+// with ErrEncryptionApply so a future wire-format extension
+// cannot silently mis-label sidecar entries.
+func sidecarPurposeFor(p fsmwire.Purpose) (string, error) {
+	switch p {
+	case fsmwire.PurposeStorage:
+		return SidecarPurposeStorage, nil
+	case fsmwire.PurposeRaft:
+		return SidecarPurposeRaft, nil
+	default:
+		return "", errors.Wrapf(ErrEncryptionApply,
+			"applier: rotation purpose %#x not recognised", byte(p))
+	}
 }
 
 // nodeIDMask narrows a uint64 full_node_id to its low 16 bits to

--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -393,7 +393,39 @@ func (a *Applier) validateBootstrap(p fsmwire.BootstrapPayload) error {
 				i, reg.DEKID, p.StorageDEKID, p.RaftDEKID)
 		}
 	}
-	return nil
+	return a.checkBootstrapIdempotency(p)
+}
+
+// checkBootstrapIdempotency enforces the §5.6 one-time-bootstrap
+// invariant. A second committed bootstrap entry with DIFFERENT
+// DEK IDs would re-point Active.{Storage,Raft} outside the
+// rotation path, leaving writer-registry and key-lifecycle
+// semantics inconsistent with the bootstrap/rotation contract.
+//
+// Raft replay of the SAME bootstrap entry (e.g., crash after
+// bootstrap apply but before snapshot) is idempotent and allowed
+// — the existing sidecar's Active slots will match the payload's
+// DEK IDs exactly, so the check falls through.
+//
+// Split out from validateBootstrap so the dispatch path stays
+// below the cyclop complexity budget.
+func (a *Applier) checkBootstrapIdempotency(p fsmwire.BootstrapPayload) error {
+	sc, err := ReadSidecar(a.sidecarPath)
+	if err != nil && !IsNotExist(err) {
+		return errors.Wrap(err, "applier: read sidecar for bootstrap idempotency check")
+	}
+	if sc == nil {
+		return nil
+	}
+	if sc.Active.Storage == 0 && sc.Active.Raft == 0 {
+		return nil
+	}
+	if sc.Active.Storage == p.StorageDEKID && sc.Active.Raft == p.RaftDEKID {
+		return nil
+	}
+	return errors.Wrapf(ErrEncryptionApply,
+		"applier: cluster already bootstrapped (Active.Storage=%d, Active.Raft=%d); cannot re-bootstrap to (%d, %d) — use rotate-dek",
+		sc.Active.Storage, sc.Active.Raft, p.StorageDEKID, p.RaftDEKID)
 }
 
 // writeBootstrapSidecar reads the existing sidecar (or starts a

--- a/internal/encryption/applier_test.go
+++ b/internal/encryption/applier_test.go
@@ -619,3 +619,100 @@ func TestApplyRotation_UnknownPurpose(t *testing.T) {
 		t.Errorf("err not marked ErrEncryptionApply: %v", err)
 	}
 }
+
+// TestNewApplier_RejectsNilOption pins the construction-time guard
+// against nil ApplierOption values. A `WithNowFunc(nil)` (or any
+// other nil opt passed by mistake) would silently overwrite the
+// default and panic at apply time when a.now() is invoked. The
+// guard surfaces the misconfiguration at startup.
+func TestNewApplier_RejectsNilOption(t *testing.T) {
+	t.Parallel()
+	_, err := encryption.NewApplier(newMapRegistryStore(), nil)
+	if err == nil {
+		t.Fatal("NewApplier(reg, nil) returned no error; want construction-time refusal")
+	}
+}
+
+// TestNewApplier_RejectsNilNowFunc pins the specific nil-clock
+// guard. Construction MUST refuse when WithNowFunc(nil) overwrites
+// the default time.Now — otherwise a.now() would nil-deref on
+// the first Bootstrap/Rotation apply.
+func TestNewApplier_RejectsNilNowFunc(t *testing.T) {
+	t.Parallel()
+	_, err := encryption.NewApplier(newMapRegistryStore(), encryption.WithNowFunc(nil))
+	if err == nil {
+		t.Fatal("NewApplier(reg, WithNowFunc(nil)) returned no error; want construction-time refusal")
+	}
+}
+
+// TestApplyBootstrap_RejectsIdenticalDEKIDs pins the §5.1 per-purpose
+// separation invariant. If StorageDEKID == RaftDEKID, the second
+// sc.Keys[...] assignment in writeBootstrapSidecar would overwrite
+// the first, silently mis-labelling the surviving key's purpose
+// (storage vs raft). The applier halts apply with ErrEncryptionApply
+// so a malformed bootstrap payload cannot corrupt the sidecar.
+func TestApplyBootstrap_RejectsIdenticalDEKIDs(t *testing.T) {
+	t.Parallel()
+	reg := newMapRegistryStore()
+	ks := encryption.NewKeystore()
+	dir := t.TempDir()
+	app, _ := encryption.NewApplier(reg,
+		encryption.WithKEK(&fakeKEK{}),
+		encryption.WithKeystore(ks),
+		encryption.WithSidecarPath(dir+"/keys.json"),
+	)
+	err := app.ApplyBootstrap(fsmwire.BootstrapPayload{
+		StorageDEKID:   7,
+		WrappedStorage: []byte("s"),
+		RaftDEKID:      7, // same as Storage
+		WrappedRaft:    []byte("r"),
+	})
+	if err == nil {
+		t.Fatal("expected halt on identical DEK IDs, got nil")
+	}
+	if !errors.Is(err, encryption.ErrEncryptionApply) {
+		t.Errorf("err not marked ErrEncryptionApply: %v", err)
+	}
+	// Sidecar must not have been written.
+	if _, err := encryption.ReadSidecar(dir + "/keys.json"); err == nil {
+		t.Error("sidecar was written despite rejection")
+	}
+}
+
+// TestApplyRotation_RejectsProposerDEKMismatch pins the
+// ProposerRegistration vs rotated DEK invariant: the proposer's
+// first-writer row MUST target the new DEK (that is the whole
+// point of bundling it atomically with the rotate-dek entry per
+// §5.2). A mismatch mutates writer-registry state for an
+// unrelated DEK and leaves the rotated DEK unregistered.
+func TestApplyRotation_RejectsProposerDEKMismatch(t *testing.T) {
+	t.Parallel()
+	reg := newMapRegistryStore()
+	ks := encryption.NewKeystore()
+	dir := t.TempDir()
+	sidecarPath := dir + "/keys.json"
+	app, _ := encryption.NewApplier(reg,
+		encryption.WithKEK(&fakeKEK{}),
+		encryption.WithKeystore(ks),
+		encryption.WithSidecarPath(sidecarPath),
+	)
+	if err := app.ApplyBootstrap(fsmwire.BootstrapPayload{
+		StorageDEKID: 1, WrappedStorage: []byte("s"),
+		RaftDEKID: 2, WrappedRaft: []byte("r"),
+	}); err != nil {
+		t.Fatalf("pre-bootstrap: %v", err)
+	}
+	err := app.ApplyRotation(fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubRotateDEK,
+		DEKID:                5, // rotating to id 5
+		Purpose:              fsmwire.PurposeStorage,
+		Wrapped:              []byte("w"),
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: 99, FullNodeID: 0xAA, LocalEpoch: 0}, // mismatch
+	})
+	if err == nil {
+		t.Fatal("expected halt on proposer-registration DEK mismatch, got nil")
+	}
+	if !errors.Is(err, encryption.ErrEncryptionApply) {
+		t.Errorf("err not marked ErrEncryptionApply: %v", err)
+	}
+}

--- a/internal/encryption/applier_test.go
+++ b/internal/encryption/applier_test.go
@@ -417,6 +417,14 @@ func TestApplyBootstrap_PartialWiring(t *testing.T) {
 			encryption.WithKEK(&fakeKEK{}),
 			encryption.WithKeystore(encryption.NewKeystore()),
 		}},
+		{name: "kek_and_sidecar_path", opts: []encryption.ApplierOption{
+			encryption.WithKEK(&fakeKEK{}),
+			encryption.WithSidecarPath("/tmp/never-written"),
+		}},
+		{name: "keystore_and_sidecar_path", opts: []encryption.ApplierOption{
+			encryption.WithKeystore(encryption.NewKeystore()),
+			encryption.WithSidecarPath("/tmp/never-written"),
+		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			app, err := encryption.NewApplier(newMapRegistryStore(), tc.opts...)

--- a/internal/encryption/applier_test.go
+++ b/internal/encryption/applier_test.go
@@ -2,6 +2,7 @@ package encryption_test
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/bootjp/elastickv/internal/encryption"
@@ -242,11 +243,14 @@ func TestApplyRegistration_StoreErrorPropagates(t *testing.T) {
 	})
 }
 
-// TestApplyBootstrap_ReturnsKEKNotConfigured pins the Stage 6A stub
-// contract: until 6B threads a KEK unwrapper, ApplyBootstrap is the
-// defense-in-depth marker returning ErrKEKNotConfigured (wrapped so
-// the kv/fsm dispatch layer's ErrEncryptionApply marking still
-// fires).
+// TestApplyBootstrap_ReturnsKEKNotConfigured pins the no-options
+// default — without WithKEK / WithKeystore / WithSidecarPath, an
+// Applier returns ErrKEKNotConfigured wrapped for the HaltApply
+// pipeline. This is the Stage 6A posture; Stage 6B preserves it
+// as the unwired default so the FSM dispatch contract still
+// produces a typed, grep-able failure when an operator
+// hand-triggers Bootstrap on a binary that has not yet been
+// configured.
 func TestApplyBootstrap_ReturnsKEKNotConfigured(t *testing.T) {
 	t.Parallel()
 	app, _ := encryption.NewApplier(newMapRegistryStore())
@@ -264,8 +268,8 @@ func TestApplyBootstrap_ReturnsKEKNotConfigured(t *testing.T) {
 	}
 }
 
-// TestApplyRotation_ReturnsKEKNotConfigured pins the same Stage 6A
-// stub contract for rotation.
+// TestApplyRotation_ReturnsKEKNotConfigured pins the same no-options
+// default for ApplyRotation.
 func TestApplyRotation_ReturnsKEKNotConfigured(t *testing.T) {
 	t.Parallel()
 	app, _ := encryption.NewApplier(newMapRegistryStore())
@@ -279,5 +283,339 @@ func TestApplyRotation_ReturnsKEKNotConfigured(t *testing.T) {
 	}
 	if !errors.Is(err, encryption.ErrKEKNotConfigured) {
 		t.Errorf("err not marked ErrKEKNotConfigured: %v", err)
+	}
+}
+
+// fakeKEK is a deterministic KEKUnwrapper for tests. Unwrap
+// returns a 32-byte DEK derived from the wrapped input — same
+// wrapped bytes always produce the same DEK bytes, which exercises
+// the Keystore.Set idempotency path on replay. The wrapped input
+// can be any length (production uses ~48 bytes, tests use shorter
+// sentinels); the DEK output is always 32 bytes (Keystore.Set
+// requires encryption.KeySize).
+type fakeKEK struct {
+	failOn   []byte // if non-nil and Unwrap input matches, return failErr
+	failErr  error
+	override map[string][]byte // optional fixed mapping for specific wrapped inputs
+}
+
+func (f *fakeKEK) Unwrap(wrapped []byte) ([]byte, error) {
+	if f.failOn != nil && string(f.failOn) == string(wrapped) {
+		return nil, f.failErr
+	}
+	if v, ok := f.override[string(wrapped)]; ok {
+		return v, nil
+	}
+	// Deterministic derivation: pad/truncate wrapped to KeySize.
+	out := make([]byte, encryption.KeySize)
+	copy(out, wrapped)
+	return out, nil
+}
+
+// TestApplyBootstrap_FullyWired pins the §5.6 step 1a happy path:
+// Bootstrap KEK-unwraps both DEKs, installs them into the keystore,
+// writes a crash-durable sidecar with Active.{Storage,Raft} set,
+// and inserts the batch writer-registry rows. The post-apply
+// state is verified end-to-end via per-aspect helper functions.
+func TestApplyBootstrap_FullyWired(t *testing.T) {
+	t.Parallel()
+	reg := newMapRegistryStore()
+	ks := encryption.NewKeystore()
+	dir := t.TempDir()
+	sidecarPath := dir + "/keys.json"
+
+	app, err := encryption.NewApplier(reg,
+		encryption.WithKEK(&fakeKEK{}),
+		encryption.WithKeystore(ks),
+		encryption.WithSidecarPath(sidecarPath),
+	)
+	if err != nil {
+		t.Fatalf("NewApplier: %v", err)
+	}
+
+	payload := fsmwire.BootstrapPayload{
+		StorageDEKID:   1,
+		WrappedStorage: []byte("storage-wrapped-bytes"),
+		RaftDEKID:      2,
+		WrappedRaft:    []byte("raft-wrapped-bytes-different"),
+		BatchRegistry: []fsmwire.RegistrationPayload{
+			{DEKID: 1, FullNodeID: 0xAAAA, LocalEpoch: 0},
+			{DEKID: 2, FullNodeID: 0xAAAA, LocalEpoch: 0},
+		},
+	}
+	if err := app.ApplyBootstrap(payload); err != nil {
+		t.Fatalf("ApplyBootstrap: %v", err)
+	}
+	assertKeystoreHas(t, ks, payload.StorageDEKID, payload.RaftDEKID)
+	assertBootstrapSidecar(t, sidecarPath, payload)
+	assertRegistryRowsPresent(t, reg, payload.BatchRegistry)
+}
+
+func assertKeystoreHas(t *testing.T, ks *encryption.Keystore, ids ...uint32) {
+	t.Helper()
+	for _, id := range ids {
+		if !ks.Has(id) {
+			t.Errorf("keystore missing DEK id=%d", id)
+		}
+	}
+}
+
+func assertBootstrapSidecar(t *testing.T, path string, p fsmwire.BootstrapPayload) {
+	t.Helper()
+	sc, err := encryption.ReadSidecar(path)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	if sc.Active.Storage != p.StorageDEKID {
+		t.Errorf("Active.Storage = %d, want %d", sc.Active.Storage, p.StorageDEKID)
+	}
+	if sc.Active.Raft != p.RaftDEKID {
+		t.Errorf("Active.Raft = %d, want %d", sc.Active.Raft, p.RaftDEKID)
+	}
+	assertSidecarKey(t, sc, p.StorageDEKID, encryption.SidecarPurposeStorage)
+	assertSidecarKey(t, sc, p.RaftDEKID, encryption.SidecarPurposeRaft)
+}
+
+func assertSidecarKey(t *testing.T, sc *encryption.Sidecar, id uint32, wantPurpose string) {
+	t.Helper()
+	key := strconv.FormatUint(uint64(id), 10)
+	k, ok := sc.Keys[key]
+	if !ok {
+		t.Errorf("sidecar keys map missing key %s", key)
+		return
+	}
+	if k.Purpose != wantPurpose {
+		t.Errorf("keys[%s].Purpose = %q, want %q", key, k.Purpose, wantPurpose)
+	}
+}
+
+func assertRegistryRowsPresent(t *testing.T, reg *mapRegistryStore, rows []fsmwire.RegistrationPayload) {
+	t.Helper()
+	for _, r := range rows {
+		key := encryption.RegistryKey(r.DEKID, uint16(r.FullNodeID&0xFFFF)) //nolint:gosec // test setup, masked to 16 bits
+		if _, ok, _ := reg.GetRegistryRow(key); !ok {
+			t.Errorf("registry row missing for dek_id=%d full_node_id=%#x", r.DEKID, r.FullNodeID)
+		}
+	}
+}
+
+// TestApplyBootstrap_PartialWiring pins the all-or-nothing trio:
+// supplying only some of WithKEK / WithKeystore / WithSidecarPath
+// MUST return ErrKEKNotConfigured. The Applier fails closed at
+// apply time so a partial wiring during a future refactor cannot
+// mis-apply with one dep present.
+func TestApplyBootstrap_PartialWiring(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		opts []encryption.ApplierOption
+	}{
+		{name: "kek_only", opts: []encryption.ApplierOption{encryption.WithKEK(&fakeKEK{})}},
+		{name: "keystore_only", opts: []encryption.ApplierOption{encryption.WithKeystore(encryption.NewKeystore())}},
+		{name: "sidecar_path_only", opts: []encryption.ApplierOption{encryption.WithSidecarPath("/tmp/never-written")}},
+		{name: "kek_and_keystore", opts: []encryption.ApplierOption{
+			encryption.WithKEK(&fakeKEK{}),
+			encryption.WithKeystore(encryption.NewKeystore()),
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			app, err := encryption.NewApplier(newMapRegistryStore(), tc.opts...)
+			if err != nil {
+				t.Fatalf("NewApplier: %v", err)
+			}
+			err = app.ApplyBootstrap(fsmwire.BootstrapPayload{StorageDEKID: 1, RaftDEKID: 2})
+			if err == nil {
+				t.Fatal("expected ErrKEKNotConfigured for partial wiring, got nil")
+			}
+			if !errors.Is(err, encryption.ErrKEKNotConfigured) {
+				t.Errorf("err not marked ErrKEKNotConfigured: %v", err)
+			}
+		})
+	}
+}
+
+// TestApplyBootstrap_KEKUnwrapFailure pins fail-closed behavior on
+// KEK errors. The synthetic Unwrap error is propagated; the kv/fsm
+// dispatch layer will then mark it with ErrEncryptionApply for
+// HaltApply regardless of upstream marking.
+func TestApplyBootstrap_KEKUnwrapFailure(t *testing.T) {
+	t.Parallel()
+	reg := newMapRegistryStore()
+	ks := encryption.NewKeystore()
+	dir := t.TempDir()
+	boom := errors.New("kek: synthetic unwrap failure")
+	app, _ := encryption.NewApplier(reg,
+		encryption.WithKEK(&fakeKEK{failOn: []byte("doomed"), failErr: boom}),
+		encryption.WithKeystore(ks),
+		encryption.WithSidecarPath(dir+"/keys.json"),
+	)
+	err := app.ApplyBootstrap(fsmwire.BootstrapPayload{
+		StorageDEKID:   1,
+		WrappedStorage: []byte("doomed"),
+		RaftDEKID:      2,
+		WrappedRaft:    []byte("ok"),
+	})
+	if err == nil {
+		t.Fatal("expected unwrap failure, got nil")
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("err did not wrap synthetic Unwrap failure: %v", err)
+	}
+	// Keystore must not contain a partial install on failure of the
+	// FIRST unwrap.
+	if ks.Has(1) || ks.Has(2) {
+		t.Error("keystore should be empty after first-unwrap failure")
+	}
+}
+
+// TestApplyBootstrap_Replay_Idempotent pins the Raft-replay
+// invariant: applying the same BootstrapPayload twice produces
+// the same sidecar and keystore state on the second pass, with
+// no error. Replay safety is the load-bearing property that lets
+// crash-mid-apply recovery work.
+func TestApplyBootstrap_Replay_Idempotent(t *testing.T) {
+	t.Parallel()
+	reg := newMapRegistryStore()
+	ks := encryption.NewKeystore()
+	dir := t.TempDir()
+	sidecarPath := dir + "/keys.json"
+	app, _ := encryption.NewApplier(reg,
+		encryption.WithKEK(&fakeKEK{}),
+		encryption.WithKeystore(ks),
+		encryption.WithSidecarPath(sidecarPath),
+	)
+	payload := fsmwire.BootstrapPayload{
+		StorageDEKID:   1,
+		WrappedStorage: []byte("storage"),
+		RaftDEKID:      2,
+		WrappedRaft:    []byte("raft"),
+		BatchRegistry:  []fsmwire.RegistrationPayload{{DEKID: 1, FullNodeID: 0x4242, LocalEpoch: 0}},
+	}
+	if err := app.ApplyBootstrap(payload); err != nil {
+		t.Fatalf("first ApplyBootstrap: %v", err)
+	}
+	if err := app.ApplyBootstrap(payload); err != nil {
+		t.Errorf("second ApplyBootstrap (replay): %v", err)
+	}
+}
+
+// TestApplyRotation_FullyWired pins the §5.2 rotate-dek happy
+// path: KEK-unwrap, keystore install at the new DEK ID, sidecar
+// Active slot updated for the supplied Purpose, ProposerRegistration
+// row inserted.
+func TestApplyRotation_FullyWired(t *testing.T) {
+	t.Parallel()
+	reg := newMapRegistryStore()
+	ks := encryption.NewKeystore()
+	dir := t.TempDir()
+	sidecarPath := dir + "/keys.json"
+	app, _ := encryption.NewApplier(reg,
+		encryption.WithKEK(&fakeKEK{}),
+		encryption.WithKeystore(ks),
+		encryption.WithSidecarPath(sidecarPath),
+	)
+	// Pre-populate the sidecar with a bootstrap so rotation has
+	// something to advance from.
+	if err := app.ApplyBootstrap(fsmwire.BootstrapPayload{
+		StorageDEKID: 1, WrappedStorage: []byte("s1"),
+		RaftDEKID: 2, WrappedRaft: []byte("r2"),
+	}); err != nil {
+		t.Fatalf("pre-bootstrap: %v", err)
+	}
+	// Rotate the storage DEK from id 1 to id 5.
+	if err := app.ApplyRotation(fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubRotateDEK,
+		DEKID:                5,
+		Purpose:              fsmwire.PurposeStorage,
+		Wrapped:              []byte("storage-v2-wrapped"),
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: 5, FullNodeID: 0xBEEF, LocalEpoch: 0},
+	}); err != nil {
+		t.Fatalf("ApplyRotation: %v", err)
+	}
+	if !ks.Has(5) {
+		t.Error("keystore missing rotated DEK 5")
+	}
+	sc, err := encryption.ReadSidecar(sidecarPath)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	if sc.Active.Storage != 5 {
+		t.Errorf("Active.Storage = %d, want 5", sc.Active.Storage)
+	}
+	if sc.Active.Raft != 2 {
+		t.Errorf("Active.Raft = %d, want 2 (unchanged by storage rotation)", sc.Active.Raft)
+	}
+	if k, ok := sc.Keys["5"]; !ok {
+		t.Error("sidecar keys missing rotated DEK 5")
+	} else if k.Purpose != encryption.SidecarPurposeStorage {
+		t.Errorf("keys[5].Purpose = %q, want %q", k.Purpose, encryption.SidecarPurposeStorage)
+	}
+	// Old DEK 1 must remain in keys[] (rotation does not retire).
+	if _, ok := sc.Keys["1"]; !ok {
+		t.Error("sidecar keys should still contain old DEK 1 after rotation (retire is a separate sub-tag)")
+	}
+}
+
+// TestApplyRotation_UnknownSubTag pins the fail-closed dispatch:
+// any sub_tag other than RotateSubRotateDEK halts apply with
+// ErrEncryptionApply so Stage 6B-1 cannot silently mis-apply a
+// later sub_tag (rewrap-deks, retire-dek, enable-storage-envelope,
+// enable-raft-envelope) before its implementation lands.
+func TestApplyRotation_UnknownSubTag(t *testing.T) {
+	t.Parallel()
+	reg := newMapRegistryStore()
+	ks := encryption.NewKeystore()
+	dir := t.TempDir()
+	app, _ := encryption.NewApplier(reg,
+		encryption.WithKEK(&fakeKEK{}),
+		encryption.WithKeystore(ks),
+		encryption.WithSidecarPath(dir+"/keys.json"),
+	)
+	err := app.ApplyRotation(fsmwire.RotationPayload{
+		SubTag:  0xFE, // not RotateSubRotateDEK
+		DEKID:   1,
+		Wrapped: []byte("x"),
+	})
+	if err == nil {
+		t.Fatal("expected halt on unknown sub_tag, got nil")
+	}
+	if !errors.Is(err, encryption.ErrEncryptionApply) {
+		t.Errorf("err not marked ErrEncryptionApply: %v", err)
+	}
+}
+
+// TestApplyRotation_UnknownPurpose pins the same fail-closed
+// dispatch for unrecognised Purpose enum values — guards against
+// a future wire-format extension silently mis-labelling sidecar
+// entries.
+func TestApplyRotation_UnknownPurpose(t *testing.T) {
+	t.Parallel()
+	reg := newMapRegistryStore()
+	ks := encryption.NewKeystore()
+	dir := t.TempDir()
+	sidecarPath := dir + "/keys.json"
+	app, _ := encryption.NewApplier(reg,
+		encryption.WithKEK(&fakeKEK{}),
+		encryption.WithKeystore(ks),
+		encryption.WithSidecarPath(sidecarPath),
+	)
+	// Pre-bootstrap so the sidecar exists.
+	if err := app.ApplyBootstrap(fsmwire.BootstrapPayload{
+		StorageDEKID: 1, WrappedStorage: []byte("s"),
+		RaftDEKID: 2, WrappedRaft: []byte("r"),
+	}); err != nil {
+		t.Fatalf("pre-bootstrap: %v", err)
+	}
+	err := app.ApplyRotation(fsmwire.RotationPayload{
+		SubTag:  fsmwire.RotateSubRotateDEK,
+		DEKID:   9,
+		Purpose: fsmwire.Purpose(0xFE), // not Storage / Raft
+		Wrapped: []byte("y"),
+	})
+	if err == nil {
+		t.Fatal("expected halt on unknown purpose, got nil")
+	}
+	if !errors.Is(err, encryption.ErrEncryptionApply) {
+		t.Errorf("err not marked ErrEncryptionApply: %v", err)
 	}
 }

--- a/internal/encryption/applier_test.go
+++ b/internal/encryption/applier_test.go
@@ -614,17 +614,66 @@ func TestApplyRotation_UnknownPurpose(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("pre-bootstrap: %v", err)
 	}
+	// ProposerRegistration.DEKID MUST match RotationPayload.DEKID
+	// — the round-2 mismatch guard fires before sidecarPurposeFor
+	// otherwise, and the test would exercise the wrong code path.
 	err := app.ApplyRotation(fsmwire.RotationPayload{
-		SubTag:  fsmwire.RotateSubRotateDEK,
-		DEKID:   9,
-		Purpose: fsmwire.Purpose(0xFE), // not Storage / Raft
-		Wrapped: []byte("y"),
+		SubTag:               fsmwire.RotateSubRotateDEK,
+		DEKID:                9,
+		Purpose:              fsmwire.Purpose(0xFE), // not Storage / Raft
+		Wrapped:              []byte("y"),
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: 9, FullNodeID: 0x01, LocalEpoch: 0},
 	})
 	if err == nil {
 		t.Fatal("expected halt on unknown purpose, got nil")
 	}
 	if !errors.Is(err, encryption.ErrEncryptionApply) {
 		t.Errorf("err not marked ErrEncryptionApply: %v", err)
+	}
+}
+
+// TestApplyBootstrap_RejectsForeignBatchRegistryDEK pins the §5.6
+// step 1a bootstrap-batch invariant: every BatchRegistry row MUST
+// target either StorageDEKID or RaftDEKID. A row targeting a
+// foreign DEK would persist writer-registry state for an unrelated
+// key while the bootstrap installs only the two declared DEKs —
+// silently breaking the §4.1 first-writer invariant on the next
+// post-bootstrap write under that foreign key.
+func TestApplyBootstrap_RejectsForeignBatchRegistryDEK(t *testing.T) {
+	t.Parallel()
+	reg := newMapRegistryStore()
+	ks := encryption.NewKeystore()
+	dir := t.TempDir()
+	sidecarPath := dir + "/keys.json"
+	app, _ := encryption.NewApplier(reg,
+		encryption.WithKEK(&fakeKEK{}),
+		encryption.WithKeystore(ks),
+		encryption.WithSidecarPath(sidecarPath),
+	)
+	err := app.ApplyBootstrap(fsmwire.BootstrapPayload{
+		StorageDEKID:   1,
+		WrappedStorage: []byte("s"),
+		RaftDEKID:      2,
+		WrappedRaft:    []byte("r"),
+		BatchRegistry: []fsmwire.RegistrationPayload{
+			{DEKID: 1, FullNodeID: 0xAA, LocalEpoch: 0},  // valid
+			{DEKID: 99, FullNodeID: 0xBB, LocalEpoch: 0}, // foreign DEK
+		},
+	})
+	if err == nil {
+		t.Fatal("expected halt on foreign BatchRegistry DEK, got nil")
+	}
+	if !errors.Is(err, encryption.ErrEncryptionApply) {
+		t.Errorf("err not marked ErrEncryptionApply: %v", err)
+	}
+	// No side effects: keystore must not contain the bootstrap
+	// DEKs, sidecar must not have been written. The guard fires
+	// before any of those mutations.
+	if ks.Has(1) || ks.Has(2) {
+		t.Error("keystore mutated despite rejection")
+	}
+	if _, err := encryption.ReadSidecar(sidecarPath); err == nil {
+		t.Error("sidecar was written despite rejection")
 	}
 }
 

--- a/internal/encryption/applier_test.go
+++ b/internal/encryption/applier_test.go
@@ -677,6 +677,79 @@ func TestApplyBootstrap_RejectsSecondBootstrapWithDifferentDEKs(t *testing.T) {
 		t.Errorf("Active = (%d, %d), want (1, 2) — second bootstrap mutated sidecar despite rejection",
 			sc.Active.Storage, sc.Active.Raft)
 	}
+	// Keystore must NOT contain the rejected DEK IDs (guard fires
+	// before kek.Unwrap / keystore.Set), matching the pattern set
+	// by TestApplyBootstrap_RejectsForeignBatchRegistryDEK.
+	if ks.Has(7) || ks.Has(8) {
+		t.Error("keystore mutated despite rejection of second bootstrap")
+	}
+}
+
+// TestApplyBootstrap_RejectsSecondBootstrapWithSameIDsDifferentWrapped
+// pins the stricter idempotency invariant: a second bootstrap with
+// the SAME DEK IDs but DIFFERENT wrapped DEK bytes MUST be
+// rejected. The DEK-ID-only check alone would have allowed the
+// second apply to continue, which would then re-run
+// writeBootstrapSidecar (overwriting keys[].Wrapped with the new
+// bytes) and iterate the BatchRegistry — potentially mutating
+// writer-registry state for previously-unregistered nodes through
+// the §4.1 case-1 first-seen path.
+//
+// Raft determinism couples wrapped DEK bytes to the entry hash,
+// so a legitimate replay always has matching wrapped bytes. A
+// mismatch is necessarily a malformed or malicious second bootstrap.
+func TestApplyBootstrap_RejectsSecondBootstrapWithSameIDsDifferentWrapped(t *testing.T) {
+	t.Parallel()
+	reg := newMapRegistryStore()
+	ks := encryption.NewKeystore()
+	dir := t.TempDir()
+	sidecarPath := dir + "/keys.json"
+	app, _ := encryption.NewApplier(reg,
+		encryption.WithKEK(&fakeKEK{}),
+		encryption.WithKeystore(ks),
+		encryption.WithSidecarPath(sidecarPath),
+	)
+	// First bootstrap with wrapped bytes "s1" / "r2".
+	if err := app.ApplyBootstrap(fsmwire.BootstrapPayload{
+		StorageDEKID: 1, WrappedStorage: []byte("s1-orig"),
+		RaftDEKID: 2, WrappedRaft: []byte("r2-orig"),
+	}); err != nil {
+		t.Fatalf("first ApplyBootstrap: %v", err)
+	}
+	// Second bootstrap with same DEK IDs but different wrapped bytes.
+	err := app.ApplyBootstrap(fsmwire.BootstrapPayload{
+		StorageDEKID: 1, WrappedStorage: []byte("s1-tampered"),
+		RaftDEKID: 2, WrappedRaft: []byte("r2-tampered"),
+		BatchRegistry: []fsmwire.RegistrationPayload{
+			// Adding a previously-unregistered node — would silently
+			// insert via §4.1 case-1 if the second bootstrap had
+			// been allowed through.
+			{DEKID: 1, FullNodeID: 0x99, LocalEpoch: 0},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected halt on same-IDs/different-wrapped second bootstrap, got nil")
+	}
+	if !errors.Is(err, encryption.ErrEncryptionApply) {
+		t.Errorf("err not marked ErrEncryptionApply: %v", err)
+	}
+	// Verify no side effects: keys[].Wrapped still has the ORIGINAL
+	// bytes (not the tampered bytes), and the previously-
+	// unregistered node 0x99 was NOT inserted into the registry.
+	sc, err := encryption.ReadSidecar(sidecarPath)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	if got := sc.Keys["1"].Wrapped; string(got) != "s1-orig" {
+		t.Errorf("keys[1].Wrapped = %q, want %q (second bootstrap should not have overwritten)", got, "s1-orig")
+	}
+	if got := sc.Keys["2"].Wrapped; string(got) != "r2-orig" {
+		t.Errorf("keys[2].Wrapped = %q, want %q", got, "r2-orig")
+	}
+	rejectedRowKey := encryption.RegistryKey(1, 0x99)
+	if _, ok, _ := reg.GetRegistryRow(rejectedRowKey); ok {
+		t.Error("writer-registry row for previously-unregistered node was inserted despite second-bootstrap rejection")
+	}
 }
 
 // TestApplyBootstrap_RejectsForeignBatchRegistryDEK pins the §5.6

--- a/internal/encryption/applier_test.go
+++ b/internal/encryption/applier_test.go
@@ -632,6 +632,53 @@ func TestApplyRotation_UnknownPurpose(t *testing.T) {
 	}
 }
 
+// TestApplyBootstrap_RejectsSecondBootstrapWithDifferentDEKs
+// pins the §5.6 one-time-bootstrap invariant: once Active slots
+// are populated, a second committed bootstrap entry with
+// DIFFERENT DEK IDs MUST be rejected. A successful re-bootstrap
+// would re-point Active.{Storage,Raft} outside the rotation
+// path, leaving writer-registry and key-lifecycle semantics
+// inconsistent. Operators advance DEKs via rotate-dek.
+func TestApplyBootstrap_RejectsSecondBootstrapWithDifferentDEKs(t *testing.T) {
+	t.Parallel()
+	reg := newMapRegistryStore()
+	ks := encryption.NewKeystore()
+	dir := t.TempDir()
+	sidecarPath := dir + "/keys.json"
+	app, _ := encryption.NewApplier(reg,
+		encryption.WithKEK(&fakeKEK{}),
+		encryption.WithKeystore(ks),
+		encryption.WithSidecarPath(sidecarPath),
+	)
+	// First bootstrap: Active = (1, 2).
+	if err := app.ApplyBootstrap(fsmwire.BootstrapPayload{
+		StorageDEKID: 1, WrappedStorage: []byte("s1"),
+		RaftDEKID: 2, WrappedRaft: []byte("r2"),
+	}); err != nil {
+		t.Fatalf("first ApplyBootstrap: %v", err)
+	}
+	// Second bootstrap with different DEK IDs MUST be rejected.
+	err := app.ApplyBootstrap(fsmwire.BootstrapPayload{
+		StorageDEKID: 7, WrappedStorage: []byte("s7"),
+		RaftDEKID: 8, WrappedRaft: []byte("r8"),
+	})
+	if err == nil {
+		t.Fatal("expected halt on second bootstrap with different DEKs, got nil")
+	}
+	if !errors.Is(err, encryption.ErrEncryptionApply) {
+		t.Errorf("err not marked ErrEncryptionApply: %v", err)
+	}
+	// Sidecar Active slots must NOT have been re-pointed.
+	sc, err := encryption.ReadSidecar(sidecarPath)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	if sc.Active.Storage != 1 || sc.Active.Raft != 2 {
+		t.Errorf("Active = (%d, %d), want (1, 2) — second bootstrap mutated sidecar despite rejection",
+			sc.Active.Storage, sc.Active.Raft)
+	}
+}
+
 // TestApplyBootstrap_RejectsForeignBatchRegistryDEK pins the §5.6
 // step 1a bootstrap-batch invariant: every BatchRegistry row MUST
 // target either StorageDEKID or RaftDEKID. A row targeting a


### PR DESCRIPTION
## Summary

Stage 6B part 1 per the [PR #762 plan](https://github.com/bootjp/elastickv/pull/762). Lands the real `ApplyBootstrap` and `ApplyRotation` paths in `internal/encryption.Applier` — KEK-unwrap + Keystore install + crash-durable sidecar mutate + writer-registry batch insert. Replaces the Stage 6A `ErrKEKNotConfigured` stubs.

Mutator-RPC wiring in `registerEncryptionAdminServer` stays OFF (Stage 5D posture) so the operator surface is unchanged. The follow-up **6B-2** PR threads `--kekFile` / `--encryption-enabled` flags + startup KEK loader + keystore re-populate + re-enables mutator wiring gated on `(--encryption-enabled AND KEKConfigured())`.

## API additions

- **`KEKUnwrapper` interface** — local declaration so the encryption package does not pick up a transitive dependency on the kek package. `kek.Wrapper` satisfies it structurally.
- **`ApplierOption` functional-options**: `WithKEK`, `WithKeystore`, `WithSidecarPath`, `WithNowFunc`. The Stage 6A caller `NewApplier(reg)` continues to work byte-for-byte.

## Real ApplyBootstrap (§5.6 step 1a)

1. KEK-unwrap storage + raft wrapped DEKs.
2. `Keystore.Set` both (idempotent on matching bytes; `ErrKeyConflict` on mismatch → halts).
3. `WriteSidecar` with `Active.{Storage,Raft}` set + `keys[]` map updated; crash-durable via §5.1 atomic write.
4. Batch-insert every `BatchRegistry` row via `ApplyRegistration` (§4.1 case-2-idempotent makes replays no-op).

Returns `ErrKEKNotConfigured` if any of `WithKEK` / `WithKeystore` / `WithSidecarPath` is missing — the three are an indivisible trio.

**Crash-recovery ordering**: `Keystore.Set` (cheap, in-memory) → `WriteSidecar` (durable IO) → batch insert. Recovery is Raft replaying the same entry; every step is idempotent for matching inputs.

## Real ApplyRotation (§5.2 RotateDEK)

Handles `RotateSubRotateDEK` only; other sub-tags (rewrap-deks, retire-dek, enable-storage-envelope, enable-raft-envelope) halt with `ErrEncryptionApply` so 6B-1 cannot silently mis-apply later sub-tags.

For `RotateSubRotateDEK`:
1. KEK-unwrap the proposed wrapped DEK.
2. `Keystore.Set` at the new DEK ID.
3. `WriteSidecar`: Active slot updated for `Purpose` (Storage or Raft only — unknown Purpose halts); keys[] map updated; old DEKs preserved (retire is a separate Stage 6E sub-tag).
4. `ApplyRegistration` on the proposer's row.

## Tests

8 new applier tests covering happy paths + fail-closed boundaries:

| Test | What it pins |
|---|---|
| `TestApplyBootstrap_ReturnsKEKNotConfigured` | No-options default returns `ErrKEKNotConfigured` |
| `TestApplyBootstrap_FullyWired` | Happy path; factor'd per-aspect assertions |
| `TestApplyBootstrap_PartialWiring` (4 sub-cases) | All-or-nothing trio invariant |
| `TestApplyBootstrap_KEKUnwrapFailure` | Synthetic Unwrap error propagated; no partial install |
| `TestApplyBootstrap_Replay_Idempotent` | Same payload twice succeeds |
| `TestApplyRotation_ReturnsKEKNotConfigured` | No-options default |
| `TestApplyRotation_FullyWired` | Happy path with pre-bootstrap |
| `TestApplyRotation_UnknownSubTag` | Halts on `0xFE` sub-tag |
| `TestApplyRotation_UnknownPurpose` | Halts on unrecognised Purpose enum |

Tests use a `fakeKEK` that pads/truncates wrapped input to `encryption.KeySize` so `Keystore.Set`'s size check passes; same wrapped input always produces the same DEK bytes (deterministic), exercising idempotency.

## Caller audit (semantic change — `NewApplier` signature)

`NewApplier(registry)` → `NewApplier(registry, opts...)`. Variadic; the no-options call (Stage 6A test caller) still compiles and behaves identically. Audited:

```
grep -rn 'NewApplier(' --include='*.go'
```
- `main.go:711` — production caller; unchanged in this PR (still passes no opts). 6B-2 will add `WithKEK + WithKeystore + WithSidecarPath`.
- `internal/encryption/applier_test.go` — test callers; existing `NewApplier(newMapRegistryStore())` calls still work; new tests pass opts.

No other callers.

## Five-lens self-review

1. **Data loss** — `WriteSidecar` uses the existing §5.1 crash-durable write protocol. `Keystore.Set` is in-memory only but the FSM apply path is replayed from Raft on restart. No silent skip: every error propagates through the HaltApply seam.
2. **Concurrency / distributed failures** — Applier carries no per-call mutable state. FSM apply already serialises `0x03/0x04/0x05` dispatches under `applyMu`. Keystore is internally locked. Sidecar IO is single-writer per §5.1.
3. **Performance** — `ApplyBootstrap`: 2 KEK unwraps + 2 `Keystore.Set` + 1 `WriteSidecar` + N writer-registry inserts (N = bootstrap-time cluster size). `ApplyRotation`: 1+1+1+1. Bounded.
4. **Data consistency** — sidecar mutations crash-durable; install order deterministic on replay; case-2-idempotent makes registry replay safe.
5. **Test coverage** — 8 unit tests; both happy paths and fail-closed boundaries exercised. The fakeKEK is deterministic so replay tests are reproducible.

## Test plan

- [x] `go test -race -timeout=60s ./internal/encryption/...` — PASS
- [x] `go build ./...` — PASS
- [x] `golangci-lint run ./internal/encryption/...` — 0 issues
- [x] Existing kv + store + main encryption tests — PASS
- [ ] Re-run full suite (kv + store + adapter + main + Jepsen) once 6B-2 wires it in production — Will follow with 6B-2

## Plan

This is **Stage 6B part 1**. **Stage 6B-2** will:
- Add `--kekFile` / `--kekUri` flags
- Add `--encryption-enabled` flag (default off)
- Load KEK at startup, populate Keystore from sidecar
- Re-enable Proposer + LeaderView in `registerEncryptionAdminServer` gated on (`--encryption-enabled` AND `KEKConfigured()`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Encryption key management bootstrap and rotation operations are now fully operational, including proper key unwrapping, secure keystore installation, and configurable options for encryption setup.

* **Tests**
  * Comprehensive test coverage added for bootstrap and rotation scenarios, including idempotency validation, failure handling, and configuration verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/768?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->