### PR TITLE
adapter/sqs: AdminPurgeQueue + IsDLQ on AdminQueueSummary (Phase 2)

### DIFF
--- a/adapter/sqs_admin.go
+++ b/adapter/sqs_admin.go
@@ -124,9 +124,14 @@ func (s *SQSServer) AdminDescribeQueue(ctx context.Context, name string, opts ..
 // mergeDescribeQueueOptions folds the variadic opts into a single
 // effective option set. Variadic was chosen over a struct parameter
 // so the change is source-compatible with existing callers; a future
-// opt that conflicts with another can fail explicitly here. Only the
-// last value of each field wins, matching the
-// "later-wins" convention used in other elastickv adapters.
+// opt that conflicts with another can fail explicitly here. Each
+// enable-flag uses "any-true wins" semantics: once any opt sets a
+// field to true, no later opt can unset it. This matches the
+// intuitive read of opts as a sequence of "things I want enabled"
+// rather than an override chain — if any opt asks for the DLQ scan,
+// it runs. When a future field needs override semantics (e.g. a
+// limit that the caller wants to lower), the merge logic for that
+// field should be spelled out explicitly here instead.
 func mergeDescribeQueueOptions(opts []AdminDescribeQueueOptions) AdminDescribeQueueOptions {
 	var out AdminDescribeQueueOptions
 	for _, o := range opts {

--- a/adapter/sqs_admin.go
+++ b/adapter/sqs_admin.go
@@ -59,6 +59,23 @@ func (s *SQSServer) AdminListQueues(ctx context.Context) ([]string, error) {
 	return s.scanQueueNames(ctx) //nolint:wrapcheck // pure pass-through; the adapter owns the error context.
 }
 
+// AdminDescribeQueueOptions opts the Describe call into the more
+// expensive lookups. Each option defaults to off so the cheap path
+// (the only one Phase 2's bridge actually consumes) stays O(1).
+type AdminDescribeQueueOptions struct {
+	// IncludeDLQSources turns on the paginated reverse-scan over
+	// the queue-meta catalog that populates IsDLQ and DLQSources.
+	// Cost is ceil(N/sqsQueueScanPageLimit) round-trips plus a
+	// JSON decode per record (same envelope as scanQueueNamesAt),
+	// so it is opt-in to keep AdminDescribeQueue calls from
+	// callers that don't surface the DLQ relationship (e.g.
+	// today's admin SPA, which drops the fields in the bridge)
+	// O(1). Phase 4 (the SPA wiring) flips this on; reviewers
+	// flagged the unconditional version as dead work otherwise
+	// (Codex r1 P2, Gemini r1).
+	IncludeDLQSources bool
+}
+
 // AdminDescribeQueue returns a snapshot of name's metadata plus the
 // approximate counters. The triple (result, present, error) lets
 // admin callers distinguish a missing queue from a storage error
@@ -68,7 +85,12 @@ func (s *SQSServer) AdminListQueues(ctx context.Context) ([]string, error) {
 // on either the leader or a follower (read-only); the counter scan
 // uses a fresh nextTxnReadTS so the result is consistent with what
 // SigV4 GetQueueAttributes would have returned at the same instant.
-func (s *SQSServer) AdminDescribeQueue(ctx context.Context, name string) (*AdminQueueSummary, bool, error) {
+//
+// Optional AdminDescribeQueueOptions toggle additional lookups
+// (currently DLQ source enumeration). Existing callers that pass no
+// options retain the cheap path; Phase 4 wiring opts in when the SPA
+// needs the DLQ relationship.
+func (s *SQSServer) AdminDescribeQueue(ctx context.Context, name string, opts ...AdminDescribeQueueOptions) (*AdminQueueSummary, bool, error) {
 	if strings.TrimSpace(name) == "" {
 		return nil, false, ErrAdminSQSValidation
 	}
@@ -84,16 +106,35 @@ func (s *SQSServer) AdminDescribeQueue(ctx context.Context, name string) (*Admin
 	if err != nil {
 		return nil, false, err
 	}
-	sources, err := s.findQueuesPointingAt(ctx, name, readTS)
-	if err != nil {
-		return nil, false, errors.WithStack(err)
-	}
 	summary := adminQueueSummary(name, meta, counters, s.queueArn(name))
-	if len(sources) > 0 {
-		summary.IsDLQ = true
-		summary.DLQSources = sources
+	opt := mergeDescribeQueueOptions(opts)
+	if opt.IncludeDLQSources {
+		sources, err := s.findQueuesPointingAt(ctx, name, readTS)
+		if err != nil {
+			return nil, false, errors.WithStack(err)
+		}
+		if len(sources) > 0 {
+			summary.IsDLQ = true
+			summary.DLQSources = sources
+		}
 	}
 	return summary, true, nil
+}
+
+// mergeDescribeQueueOptions folds the variadic opts into a single
+// effective option set. Variadic was chosen over a struct parameter
+// so the change is source-compatible with existing callers; a future
+// opt that conflicts with another can fail explicitly here. Only the
+// last value of each field wins, matching the
+// "later-wins" convention used in other elastickv adapters.
+func mergeDescribeQueueOptions(opts []AdminDescribeQueueOptions) AdminDescribeQueueOptions {
+	var out AdminDescribeQueueOptions
+	for _, o := range opts {
+		if o.IncludeDLQSources {
+			out.IncludeDLQSources = true
+		}
+	}
+	return out
 }
 
 // findQueuesPointingAt walks the queue-meta catalog at readTS and
@@ -111,9 +152,10 @@ func (s *SQSServer) AdminDescribeQueue(ctx context.Context, name string) (*Admin
 // Catalog records that fail to decode are skipped (a malformed meta
 // record is a programmer / corruption bug, not a DLQ-detection bug —
 // dropping it keeps Describe usable rather than failing the whole
-// call). Records without a RedrivePolicy are skipped because
-// parseRedrivePolicy requires a non-empty value; the scan only pays
-// the JSON parse cost on queues that have a policy configured.
+// call). Records without a RedrivePolicy are skipped after the JSON
+// decode — every record pays the decode cost, but only RedrivePolicy-
+// bearing records pay the parseRedrivePolicy cost on top. A future
+// reverse-index would let us skip the decode too; out of scope here.
 func (s *SQSServer) findQueuesPointingAt(ctx context.Context, dlqName string, readTS uint64) ([]string, error) {
 	prefix := []byte(SqsQueueMetaPrefix)
 	end := prefixScanEnd(prefix)
@@ -127,7 +169,16 @@ func (s *SQSServer) findQueuesPointingAt(ctx context.Context, dlqName string, re
 		if len(page) == 0 {
 			break
 		}
-		sources, _ = collectDLQSources(page, prefix, dlqName, sources)
+		var stop bool
+		sources, stop = collectDLQSources(page, prefix, dlqName, sources)
+		if stop {
+			// Saw a key outside the queue-meta prefix —
+			// the catalog has ended, no further pages can
+			// contain queues. Avoid the extra ScanAt that
+			// would otherwise be needed to detect the
+			// empty-page sentinel.
+			break
+		}
 		if len(page) < sqsQueueScanPageLimit {
 			break
 		}

--- a/adapter/sqs_admin.go
+++ b/adapter/sqs_admin.go
@@ -1,11 +1,14 @@
 package adapter
 
 import (
+	"bytes"
 	"context"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/bootjp/elastickv/store"
 	"github.com/cockroachdb/errors"
 )
 
@@ -24,6 +27,19 @@ type AdminQueueSummary struct {
 	CreatedAt  time.Time
 	Attributes map[string]string
 	Counters   AdminQueueCounters
+	// IsDLQ is true when at least one other queue's RedrivePolicy
+	// resolves its deadLetterTargetArn to this queue. The SPA uses
+	// the flag to switch the Messages-tab framing and the Purge
+	// button label between "Purge messages" and "Purge DLQ".
+	IsDLQ bool
+	// DLQSources lists the names of queues whose RedrivePolicy
+	// points at this queue, in lexicographic order. Empty when
+	// IsDLQ is false. Used by the SPA to render confirmation copy
+	// like "This queue is the DLQ for orders, payments". The
+	// computation is a paginated reverse scan over the queue-meta
+	// prefix at the same read timestamp as the meta load; values
+	// reflect the same MVCC snapshot the rest of the summary does.
+	DLQSources []string
 }
 
 // AdminQueueCounters matches sqsApproxCounters (int64) so the admin
@@ -68,7 +84,92 @@ func (s *SQSServer) AdminDescribeQueue(ctx context.Context, name string) (*Admin
 	if err != nil {
 		return nil, false, err
 	}
-	return adminQueueSummary(name, meta, counters, s.queueArn(name)), true, nil
+	sources, err := s.findQueuesPointingAt(ctx, name, readTS)
+	if err != nil {
+		return nil, false, errors.WithStack(err)
+	}
+	summary := adminQueueSummary(name, meta, counters, s.queueArn(name))
+	if len(sources) > 0 {
+		summary.IsDLQ = true
+		summary.DLQSources = sources
+	}
+	return summary, true, nil
+}
+
+// findQueuesPointingAt walks the queue-meta catalog at readTS and
+// returns the names of queues whose parsed RedrivePolicy resolves
+// deadLetterTargetArn to dlqName. The result is sorted
+// lexicographically so callers (and audit logs) see a stable order.
+//
+// The scan reuses scanQueueNamesAt's loop shape — paginated
+// ScanAt(prefix, end, sqsQueueScanPageLimit) calls advanced via
+// nextScanCursorAfter — so a deployment with > 1024 queues still
+// surfaces every source link. A single-page formulation would
+// silently cap at 1024 and mislabel the SPA Purge button on any
+// queue whose sources spilled past the first page.
+//
+// Catalog records that fail to decode are skipped (a malformed meta
+// record is a programmer / corruption bug, not a DLQ-detection bug —
+// dropping it keeps Describe usable rather than failing the whole
+// call). Records without a RedrivePolicy are skipped because
+// parseRedrivePolicy requires a non-empty value; the scan only pays
+// the JSON parse cost on queues that have a policy configured.
+func (s *SQSServer) findQueuesPointingAt(ctx context.Context, dlqName string, readTS uint64) ([]string, error) {
+	prefix := []byte(SqsQueueMetaPrefix)
+	end := prefixScanEnd(prefix)
+	start := bytes.Clone(prefix)
+	var sources []string
+	for {
+		page, err := s.store.ScanAt(ctx, start, end, sqsQueueScanPageLimit, readTS)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		sources, _ = collectDLQSources(page, prefix, dlqName, sources)
+		if len(page) < sqsQueueScanPageLimit {
+			break
+		}
+		start = nextScanCursorAfter(page[len(page)-1].Key)
+		if end != nil && bytes.Compare(start, end) > 0 {
+			break
+		}
+	}
+	sort.Strings(sources)
+	return sources, nil
+}
+
+// collectDLQSources walks one ScanAt page and appends every queue
+// whose RedrivePolicy resolves to dlqName. Pulled out of
+// findQueuesPointingAt so the outer pagination loop stays under the
+// cyclop budget. The bool return signals "stop scanning further
+// pages" — set when a key outside the queue-meta prefix is observed
+// (the catalog ended; subsequent pages cannot contain queues).
+func collectDLQSources(page []*store.KVPair, prefix []byte, dlqName string, sources []string) ([]string, bool) {
+	for _, kvp := range page {
+		if !bytes.HasPrefix(kvp.Key, prefix) {
+			return sources, true
+		}
+		srcName, ok := queueNameFromMetaKey(kvp.Key)
+		if !ok || srcName == dlqName {
+			// Skip self: a queue's own RedrivePolicy
+			// pointing at itself is rejected at catalog
+			// write time (registerRedriveTarget); this is
+			// defense-in-depth for that invariant.
+			continue
+		}
+		meta, decErr := decodeSQSQueueMeta(kvp.Value)
+		if decErr != nil || meta.RedrivePolicy == "" {
+			continue
+		}
+		policy, parseErr := parseRedrivePolicy(meta.RedrivePolicy)
+		if parseErr != nil || policy.DLQName != dlqName {
+			continue
+		}
+		sources = append(sources, srcName)
+	}
+	return sources, false
 }
 
 // adminQueueSummary projects a queue meta + counters into the
@@ -95,6 +196,90 @@ func adminQueueSummary(name string, meta *sqsQueueMeta, counters sqsApproxCounte
 		Attributes: metaAttributesForAdmin(meta, queueArn),
 		Counters:   AdminQueueCounters(counters),
 	}
+}
+
+// AdminPurgeResult is the success return of AdminPurgeQueue. The
+// generation values are captured from the committed OCC round, not a
+// separate pre/post meta read — a second loadQueueMetaAt call would
+// race a concurrent purge resetting LastPurgedAtMillis in the
+// 60-second window and could log generation values that never
+// appeared as a single consistent state.
+type AdminPurgeResult struct {
+	GenerationBefore uint64
+	GenerationAfter  uint64
+}
+
+// ErrAdminSQSPurgeInProgress is the sentinel admin handlers match
+// against for the 60-second PurgeQueue rate limit. errors.Is(err,
+// ErrAdminSQSPurgeInProgress) returns true for any *PurgeInProgressError
+// via the latter's Is method, so handlers can branch on the sentinel
+// while extracting the typed RetryAfter duration from the wrapped
+// value.
+var ErrAdminSQSPurgeInProgress = errors.New("sqs admin: purge in progress")
+
+// PurgeInProgressError is the typed admin error returned by
+// AdminPurgeQueue when the meta-stored 60-second rate limit is
+// active. RetryAfter carries the wall-clock duration the caller
+// should wait, derived from the same LastPurgedAtMillis value the
+// rate-limit check itself read inside the OCC transaction.
+type PurgeInProgressError struct {
+	RetryAfter time.Duration
+}
+
+func (e *PurgeInProgressError) Error() string {
+	return "sqs admin: purge already in progress; retry after " + e.RetryAfter.String()
+}
+
+// Is implements errors.Is so handlers can sniff
+// ErrAdminSQSPurgeInProgress while still extracting RetryAfter via
+// errors.As. Standard errors-wrapper pattern shared with other typed
+// admin errors in the package.
+func (e *PurgeInProgressError) Is(target error) bool {
+	return target == ErrAdminSQSPurgeInProgress
+}
+
+// AdminPurgeQueue is the SigV4-bypass counterpart to purgeQueue.
+// Bumps the queue's generation so every message under the old
+// generation becomes unreachable, leaving the meta record (name,
+// ARN, RedrivePolicy, tags, attributes) in place. The reaper
+// eventually deletes the orphaned message keys via the existing
+// tombstone path.
+//
+// Returns the captured generation pair so the admin handler's audit
+// line can record the value that actually landed; a separate
+// loadQueueMetaAt call would race a concurrent purge in the
+// 60-second window. The 60-second rate limit lives on the meta
+// record itself so the SigV4 and admin paths interlock uniformly.
+//
+// Sentinel errors:
+//   - ErrAdminForbidden          — read-only principal
+//   - ErrAdminNotLeader          — follower
+//   - ErrAdminSQSNotFound        — queue absent
+//   - *PurgeInProgressError      — last purge < 60 s ago; errors.Is matches
+//     ErrAdminSQSPurgeInProgress, RetryAfter carries the duration.
+//   - ErrAdminSQSValidation      — empty / whitespace name
+func (s *SQSServer) AdminPurgeQueue(ctx context.Context, principal AdminPrincipal, name string) (AdminPurgeResult, error) {
+	if !principal.Role.canWrite() {
+		return AdminPurgeResult{}, ErrAdminForbidden
+	}
+	if !isVerifiedSQSLeader(ctx, s.coordinator) {
+		return AdminPurgeResult{}, ErrAdminNotLeader
+	}
+	if strings.TrimSpace(name) == "" {
+		return AdminPurgeResult{}, ErrAdminSQSValidation
+	}
+	oldGen, newGen, err := s.purgeQueueWithRetry(ctx, name)
+	if err != nil {
+		var rateLimit *purgeRateLimitedError
+		if errors.As(err, &rateLimit) {
+			return AdminPurgeResult{}, &PurgeInProgressError{RetryAfter: rateLimit.remaining}
+		}
+		if isSQSAdminQueueDoesNotExist(err) {
+			return AdminPurgeResult{}, ErrAdminSQSNotFound
+		}
+		return AdminPurgeResult{}, errors.Wrap(err, "admin purge queue")
+	}
+	return AdminPurgeResult{GenerationBefore: oldGen, GenerationAfter: newGen}, nil
 }
 
 // AdminDeleteQueue is the SigV4-bypass counterpart to deleteQueue.

--- a/adapter/sqs_admin_test.go
+++ b/adapter/sqs_admin_test.go
@@ -1,9 +1,13 @@
 package adapter
 
 import (
+	"context"
+	"net/http"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/cockroachdb/errors"
 )
 
 const testQueueArn = "arn:aws:sqs:us-east-1:000000000000:orders"
@@ -121,4 +125,251 @@ func TestMetaAttributesForAdmin_IncludesQueueArnAndLastModified(t *testing.T) {
 			t.Fatalf("CreatedTimestamp must NOT be in attrs (it lives on AdminQueueSummary.CreatedAt): got %q", attrs["CreatedTimestamp"])
 		}
 	})
+}
+
+// TestAdminPurgeQueue_HappyPath confirms AdminPurgeQueue against the
+// happy path: the queue exists, the principal is full-access, and
+// the call commits a generation bump that the returned AdminPurgeResult
+// faithfully records. Mirrors TestDynamoDB_AdminDeleteTable_HappyPath
+// on the dynamo side so the admin patterns stay parallel.
+func TestAdminPurgeQueue_HappyPath(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	node := sqsLeaderNode(t, nodes)
+
+	_ = createSQSQueueForTest(t, node, "purgeable")
+
+	res, err := node.sqsServer.AdminPurgeQueue(context.Background(), fullAdminPrincipal, "purgeable")
+	if err != nil {
+		t.Fatalf("AdminPurgeQueue: %v", err)
+	}
+	if res.GenerationBefore == 0 {
+		t.Fatalf("GenerationBefore=%d want >0", res.GenerationBefore)
+	}
+	if res.GenerationAfter != res.GenerationBefore+1 {
+		t.Fatalf("GenerationAfter=%d want %d (before+1)", res.GenerationAfter, res.GenerationBefore+1)
+	}
+}
+
+// TestAdminPurgeQueue_RateLimitedReturnsTypedError exercises the
+// 60-second cooldown. A second purge inside the window must return
+// a typed *PurgeInProgressError that satisfies
+// errors.Is(ErrAdminSQSPurgeInProgress) and carries a non-zero
+// RetryAfter duration in (0, 60s]. This pins the typed-error
+// propagation path that AdminPurgeQueue uses to avoid a second meta
+// read (which would race a concurrent purge).
+func TestAdminPurgeQueue_RateLimitedReturnsTypedError(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	node := sqsLeaderNode(t, nodes)
+
+	_ = createSQSQueueForTest(t, node, "rate-limited")
+	ctx := context.Background()
+
+	if _, err := node.sqsServer.AdminPurgeQueue(ctx, fullAdminPrincipal, "rate-limited"); err != nil {
+		t.Fatalf("first AdminPurgeQueue: %v", err)
+	}
+	_, err := node.sqsServer.AdminPurgeQueue(ctx, fullAdminPrincipal, "rate-limited")
+	if err == nil {
+		t.Fatalf("second AdminPurgeQueue: want PurgeInProgressError, got nil")
+	}
+	if !errors.Is(err, ErrAdminSQSPurgeInProgress) {
+		t.Fatalf("errors.Is(ErrAdminSQSPurgeInProgress): got false; err=%v", err)
+	}
+	var typed *PurgeInProgressError
+	if !errors.As(err, &typed) {
+		t.Fatalf("errors.As(*PurgeInProgressError): got false; err=%v", err)
+	}
+	if typed.RetryAfter <= 0 {
+		t.Fatalf("RetryAfter=%v want >0", typed.RetryAfter)
+	}
+	if typed.RetryAfter > 60*time.Second {
+		t.Fatalf("RetryAfter=%v want <=60s", typed.RetryAfter)
+	}
+}
+
+// TestAdminPurgeQueue_ReadOnlyForbidden pins the live-role check:
+// a read-only principal must not be able to purge, mirroring
+// AdminDeleteQueue's gate exactly.
+func TestAdminPurgeQueue_ReadOnlyForbidden(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	node := sqsLeaderNode(t, nodes)
+	_ = createSQSQueueForTest(t, node, "read-only-test")
+
+	_, err := node.sqsServer.AdminPurgeQueue(context.Background(), readOnlyAdminPrincipal, "read-only-test")
+	if !errors.Is(err, ErrAdminForbidden) {
+		t.Fatalf("read-only principal: want ErrAdminForbidden, got %v", err)
+	}
+}
+
+// TestAdminPurgeQueue_MissingQueue confirms a missing queue surfaces
+// the structured ErrAdminSQSNotFound sentinel rather than a generic
+// 500 — admin handlers map this to HTTP 404 without sniffing the
+// AWS error code.
+func TestAdminPurgeQueue_MissingQueue(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	node := sqsLeaderNode(t, nodes)
+
+	_, err := node.sqsServer.AdminPurgeQueue(context.Background(), fullAdminPrincipal, "no-such-queue")
+	if !errors.Is(err, ErrAdminSQSNotFound) {
+		t.Fatalf("missing queue: want ErrAdminSQSNotFound, got %v", err)
+	}
+}
+
+// TestAdminPurgeQueue_EmptyName pins the up-front guard so empty /
+// whitespace names never reach the coordinator. Mirrors
+// AdminDeleteQueue's identical guard.
+func TestAdminPurgeQueue_EmptyName(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	node := sqsLeaderNode(t, nodes)
+
+	for _, name := range []string{"", "   "} {
+		_, err := node.sqsServer.AdminPurgeQueue(context.Background(), fullAdminPrincipal, name)
+		if !errors.Is(err, ErrAdminSQSValidation) {
+			t.Fatalf("name=%q: want ErrAdminSQSValidation, got %v", name, err)
+		}
+	}
+}
+
+// TestPurgeQueueSigV4_PreservesWireShapeAfterTypedErrorChange is the
+// caller-audit pin from the design doc §6.1 ("TestPurgeQueueSigV4_Still
+// Compiles"). It exercises the SigV4 PurgeQueue handler through the
+// modified purgeQueueWithRetry signature and asserts the wire shape
+// (status 400 + __type ==
+// AWS.SimpleQueueService.PurgeQueueInProgress) is unchanged. If a
+// future refactor drops the *purgeRateLimitedError branch from
+// writeSQSErrorFromErr, this test fails — without it the SigV4
+// response silently regresses to a generic 500.
+func TestPurgeQueueSigV4_PreservesWireShapeAfterTypedErrorChange(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	node := sqsLeaderNode(t, nodes)
+	url := createSQSQueueForTest(t, node, "sigv4-rate-limit")
+
+	status, _ := callSQS(t, node, sqsPurgeQueueTarget, map[string]any{"QueueUrl": url})
+	if status != http.StatusOK {
+		t.Fatalf("first purge: %d want 200", status)
+	}
+	status, out := callSQS(t, node, sqsPurgeQueueTarget, map[string]any{"QueueUrl": url})
+	if status != http.StatusBadRequest {
+		t.Fatalf("second purge: status=%d want 400 (%v)", status, out)
+	}
+	got, _ := out["__type"].(string)
+	if got != sqsErrPurgeInProgress {
+		t.Fatalf("__type=%q want %q", got, sqsErrPurgeInProgress)
+	}
+}
+
+// TestAdminQueueSummary_IsDLQ_NoSources confirms a queue that nobody
+// points at reports IsDLQ=false and an empty DLQSources slice.
+func TestAdminQueueSummary_IsDLQ_NoSources(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	node := sqsLeaderNode(t, nodes)
+	_ = createSQSQueueForTest(t, node, "lonely")
+
+	summary, exists, err := node.sqsServer.AdminDescribeQueue(context.Background(), "lonely")
+	if err != nil {
+		t.Fatalf("AdminDescribeQueue: %v", err)
+	}
+	if !exists {
+		t.Fatalf("queue not found")
+	}
+	if summary.IsDLQ {
+		t.Fatalf("IsDLQ=true want false")
+	}
+	if len(summary.DLQSources) != 0 {
+		t.Fatalf("DLQSources=%v want empty", summary.DLQSources)
+	}
+}
+
+// TestAdminQueueSummary_IsDLQ_OneSource confirms one inbound
+// RedrivePolicy is detected and surfaced. Uses the public CreateQueue
+// path so the meta record carries the RedrivePolicy attribute
+// exactly as a real client would have written it.
+func TestAdminQueueSummary_IsDLQ_OneSource(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	node := sqsLeaderNode(t, nodes)
+	_ = createSQSQueueForTest(t, node, "dlq-target")
+
+	policy := `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:000000000000:dlq-target","maxReceiveCount":5}`
+	status, out := callSQS(t, node, sqsCreateQueueTarget, map[string]any{
+		"QueueName":  "source-a",
+		"Attributes": map[string]string{"RedrivePolicy": policy},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("create source: %d %v", status, out)
+	}
+
+	summary, exists, err := node.sqsServer.AdminDescribeQueue(context.Background(), "dlq-target")
+	if err != nil {
+		t.Fatalf("AdminDescribeQueue: %v", err)
+	}
+	if !exists {
+		t.Fatalf("queue not found")
+	}
+	if !summary.IsDLQ {
+		t.Fatalf("IsDLQ=false want true")
+	}
+	if len(summary.DLQSources) != 1 || summary.DLQSources[0] != "source-a" {
+		t.Fatalf("DLQSources=%v want [source-a]", summary.DLQSources)
+	}
+}
+
+// TestAdminQueueSummary_IsDLQ_TwoSourcesSorted pins the sort
+// invariant: callers can rely on DLQSources being lexicographic so
+// the SPA renders chips in a stable order and audit log diffs
+// are noise-free.
+func TestAdminQueueSummary_IsDLQ_TwoSourcesSorted(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	node := sqsLeaderNode(t, nodes)
+	_ = createSQSQueueForTest(t, node, "shared-dlq")
+
+	policy := `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:000000000000:shared-dlq","maxReceiveCount":3}`
+	// Create in reverse-alphabetical order on purpose so the
+	// sort.Strings call is exercised (not just a coincidental
+	// insertion-order match).
+	for _, name := range []string{"zeta", "alpha"} {
+		status, out := callSQS(t, node, sqsCreateQueueTarget, map[string]any{
+			"QueueName":  name,
+			"Attributes": map[string]string{"RedrivePolicy": policy},
+		})
+		if status != http.StatusOK {
+			t.Fatalf("create %s: %d %v", name, status, out)
+		}
+	}
+
+	summary, exists, err := node.sqsServer.AdminDescribeQueue(context.Background(), "shared-dlq")
+	if err != nil {
+		t.Fatalf("AdminDescribeQueue: %v", err)
+	}
+	if !exists {
+		t.Fatalf("queue not found")
+	}
+	if !summary.IsDLQ {
+		t.Fatalf("IsDLQ=false want true")
+	}
+	want := []string{"alpha", "zeta"}
+	if len(summary.DLQSources) != len(want) {
+		t.Fatalf("DLQSources=%v want %v", summary.DLQSources, want)
+	}
+	for i, name := range want {
+		if summary.DLQSources[i] != name {
+			t.Fatalf("DLQSources[%d]=%q want %q (full=%v)", i, summary.DLQSources[i], name, summary.DLQSources)
+		}
+	}
 }

--- a/adapter/sqs_admin_test.go
+++ b/adapter/sqs_admin_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bootjp/elastickv/store"
 	"github.com/cockroachdb/errors"
 )
 
@@ -269,8 +270,52 @@ func TestPurgeQueueSigV4_PreservesWireShapeAfterTypedErrorChange(t *testing.T) {
 	}
 }
 
+// TestAdminDescribeQueue_DefaultSkipsDLQScan pins the opt-out
+// behavior reviewers (Codex r1 P2, Gemini r1) flagged in the first
+// draft of this PR: AdminDescribeQueue WITHOUT
+// AdminDescribeQueueOptions{IncludeDLQSources: true} must NOT
+// populate IsDLQ even when source queues exist, because the only
+// production consumer (sqsQueuesBridge.convertAdminQueueSummary) and
+// admin.QueueSummary drop the fields. The unconditional version
+// silently paid an O(N) catalog scan per Describe call for no
+// observable benefit. This test fails on the first-draft code
+// (which set IsDLQ=true here) and passes on the opt-in version.
+func TestAdminDescribeQueue_DefaultSkipsDLQScan(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	node := sqsLeaderNode(t, nodes)
+	_ = createSQSQueueForTest(t, node, "dlq-target")
+
+	// Wire a source queue with RedrivePolicy so the scan WOULD
+	// surface a result if it ran.
+	policy := `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:000000000000:dlq-target","maxReceiveCount":5}`
+	status, out := callSQS(t, node, sqsCreateQueueTarget, map[string]any{
+		"QueueName":  "should-not-be-seen",
+		"Attributes": map[string]string{"RedrivePolicy": policy},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("create source: %d %v", status, out)
+	}
+
+	summary, exists, err := node.sqsServer.AdminDescribeQueue(context.Background(), "dlq-target")
+	if err != nil {
+		t.Fatalf("AdminDescribeQueue: %v", err)
+	}
+	if !exists {
+		t.Fatalf("queue not found")
+	}
+	if summary.IsDLQ {
+		t.Fatalf("default AdminDescribeQueue must not populate IsDLQ; got IsDLQ=true")
+	}
+	if len(summary.DLQSources) != 0 {
+		t.Fatalf("default AdminDescribeQueue must not populate DLQSources; got %v", summary.DLQSources)
+	}
+}
+
 // TestAdminQueueSummary_IsDLQ_NoSources confirms a queue that nobody
-// points at reports IsDLQ=false and an empty DLQSources slice.
+// points at reports IsDLQ=false and an empty DLQSources slice when
+// the caller opts into the scan.
 func TestAdminQueueSummary_IsDLQ_NoSources(t *testing.T) {
 	t.Parallel()
 	nodes, _, _ := createNode(t, 1)
@@ -278,7 +323,7 @@ func TestAdminQueueSummary_IsDLQ_NoSources(t *testing.T) {
 	node := sqsLeaderNode(t, nodes)
 	_ = createSQSQueueForTest(t, node, "lonely")
 
-	summary, exists, err := node.sqsServer.AdminDescribeQueue(context.Background(), "lonely")
+	summary, exists, err := node.sqsServer.AdminDescribeQueue(context.Background(), "lonely", AdminDescribeQueueOptions{IncludeDLQSources: true})
 	if err != nil {
 		t.Fatalf("AdminDescribeQueue: %v", err)
 	}
@@ -294,9 +339,10 @@ func TestAdminQueueSummary_IsDLQ_NoSources(t *testing.T) {
 }
 
 // TestAdminQueueSummary_IsDLQ_OneSource confirms one inbound
-// RedrivePolicy is detected and surfaced. Uses the public CreateQueue
-// path so the meta record carries the RedrivePolicy attribute
-// exactly as a real client would have written it.
+// RedrivePolicy is detected and surfaced when the caller opts in.
+// Uses the public CreateQueue path so the meta record carries the
+// RedrivePolicy attribute exactly as a real client would have
+// written it.
 func TestAdminQueueSummary_IsDLQ_OneSource(t *testing.T) {
 	t.Parallel()
 	nodes, _, _ := createNode(t, 1)
@@ -313,7 +359,7 @@ func TestAdminQueueSummary_IsDLQ_OneSource(t *testing.T) {
 		t.Fatalf("create source: %d %v", status, out)
 	}
 
-	summary, exists, err := node.sqsServer.AdminDescribeQueue(context.Background(), "dlq-target")
+	summary, exists, err := node.sqsServer.AdminDescribeQueue(context.Background(), "dlq-target", AdminDescribeQueueOptions{IncludeDLQSources: true})
 	if err != nil {
 		t.Fatalf("AdminDescribeQueue: %v", err)
 	}
@@ -353,7 +399,7 @@ func TestAdminQueueSummary_IsDLQ_TwoSourcesSorted(t *testing.T) {
 		}
 	}
 
-	summary, exists, err := node.sqsServer.AdminDescribeQueue(context.Background(), "shared-dlq")
+	summary, exists, err := node.sqsServer.AdminDescribeQueue(context.Background(), "shared-dlq", AdminDescribeQueueOptions{IncludeDLQSources: true})
 	if err != nil {
 		t.Fatalf("AdminDescribeQueue: %v", err)
 	}
@@ -371,5 +417,32 @@ func TestAdminQueueSummary_IsDLQ_TwoSourcesSorted(t *testing.T) {
 		if summary.DLQSources[i] != name {
 			t.Fatalf("DLQSources[%d]=%q want %q (full=%v)", i, summary.DLQSources[i], name, summary.DLQSources)
 		}
+	}
+}
+
+// TestCollectDLQSources_StopOnOutOfPrefix pins the Gemini r1 fix:
+// when ScanAt returns a key outside the queue-meta prefix (a future
+// neighbour of the queue catalog), collectDLQSources must signal stop
+// so findQueuesPointingAt breaks the pagination loop immediately
+// rather than wasting another ScanAt round-trip on a guaranteed-empty
+// follow-up.
+func TestCollectDLQSources_StopOnOutOfPrefix(t *testing.T) {
+	t.Parallel()
+	prefix := []byte(SqsQueueMetaPrefix)
+	// Construct one in-prefix and one out-of-prefix key. The
+	// out-of-prefix key uses a different leading byte so the
+	// HasPrefix check fires.
+	inPrefix := append(append([]byte{}, prefix...), []byte("alpha")...)
+	outOfPrefix := []byte{0xff, 0xff, 0xff}
+	page := []*store.KVPair{
+		{Key: inPrefix, Value: []byte{}},    // value won't decode; the row gets skipped silently
+		{Key: outOfPrefix, Value: []byte{}}, // triggers stop
+	}
+	sources, stop := collectDLQSources(page, prefix, "dlq", nil)
+	if !stop {
+		t.Fatalf("stop=false want true (out-of-prefix key must signal end of catalog)")
+	}
+	if len(sources) != 0 {
+		t.Fatalf("sources=%v want empty (no record had matching RedrivePolicy)", sources)
 	}
 }

--- a/adapter/sqs_catalog.go
+++ b/adapter/sqs_catalog.go
@@ -231,6 +231,17 @@ func writeSQSErrorFromErr(w http.ResponseWriter, err error) {
 		writeSQSError(w, apiErr.status, apiErr.errorType, apiErr.message)
 		return
 	}
+	// PurgeQueue's 60-second rate limit is a typed error so the admin
+	// path can extract the retry-after duration without parsing
+	// strings. The SigV4 wire response must stay the AWS-shaped
+	// 400 + AWS.SimpleQueueService.PurgeQueueInProgress envelope, so
+	// we render it here from the typed error's Error() text (which is
+	// pinned to the message AWS clients expect).
+	var rateLimit *purgeRateLimitedError
+	if errors.As(err, &rateLimit) {
+		writeSQSError(w, http.StatusBadRequest, sqsErrPurgeInProgress, rateLimit.Error())
+		return
+	}
 	// Internal errors can wrap Pebble file names, Raft peer ids, stack
 	// frames from errors.WithStack, etc. Never echo the raw error text
 	// to the client — an authenticated-but-untrusted caller could use

--- a/adapter/sqs_purge.go
+++ b/adapter/sqs_purge.go
@@ -14,6 +14,23 @@ type sqsPurgeQueueInput struct {
 	QueueUrl string `json:"QueueUrl"`
 }
 
+// purgeRateLimitedError is the typed internal error returned by
+// tryPurgeQueueOnce when the meta-stored 60-second rate limit rejects
+// a call. The remaining field captures the wall-clock duration the
+// caller should wait, computed from the same LastPurgedAtMillis value
+// the rate-limit check itself read inside the OCC transaction. The
+// admin path extracts it via errors.As to populate
+// *PurgeInProgressError.RetryAfter; the SigV4 path renders the same
+// wire shape the previous *sqsAPIError emitted via
+// writeSQSErrorFromErr's dedicated branch.
+type purgeRateLimitedError struct {
+	remaining time.Duration
+}
+
+func (e *purgeRateLimitedError) Error() string {
+	return "only one PurgeQueue operation on each queue is allowed every 60 seconds"
+}
+
 // purgeQueue bumps the queue generation so every message under the old
 // generation becomes unreachable via routing, leaving the meta record in
 // place so the queue still "exists" to clients. AWS rate-limits PurgeQueue
@@ -30,60 +47,75 @@ func (s *SQSServer) purgeQueue(w http.ResponseWriter, r *http.Request) {
 		writeSQSErrorFromErr(w, err)
 		return
 	}
-	if err := s.purgeQueueWithRetry(r.Context(), name); err != nil {
+	if _, _, err := s.purgeQueueWithRetry(r.Context(), name); err != nil {
 		writeSQSErrorFromErr(w, err)
 		return
 	}
 	writeSQSJSON(w, map[string]any{})
 }
 
-func (s *SQSServer) purgeQueueWithRetry(ctx context.Context, queueName string) error {
+// purgeQueueWithRetry runs tryPurgeQueueOnce under the standard OCC
+// retry loop. On success it returns the generation captured from the
+// committed transaction so callers can audit-log the exact value that
+// landed (a separate loadQueueMetaAt call would race a concurrent
+// purge in the 60-second window). On any non-retryable error it
+// returns zero generations alongside the error.
+func (s *SQSServer) purgeQueueWithRetry(ctx context.Context, queueName string) (uint64, uint64, error) {
 	backoff := transactRetryInitialBackoff
 	deadline := time.Now().Add(transactRetryMaxDuration)
 	for range transactRetryMaxAttempts {
-		done, err := s.tryPurgeQueueOnce(ctx, queueName)
+		done, oldGen, newGen, err := s.tryPurgeQueueOnce(ctx, queueName)
 		if err == nil && done {
-			return nil
+			return oldGen, newGen, nil
 		}
 		if err != nil && !isRetryableTransactWriteError(err) {
-			return err
+			return 0, 0, err
 		}
 		if err := waitRetryWithDeadline(ctx, deadline, backoff); err != nil {
-			return errors.WithStack(err)
+			return 0, 0, errors.WithStack(err)
 		}
 		backoff = nextTransactRetryBackoff(backoff)
 	}
-	return newSQSAPIError(http.StatusInternalServerError, sqsErrInternalFailure, "purge queue retry attempts exhausted")
+	return 0, 0, newSQSAPIError(http.StatusInternalServerError, sqsErrInternalFailure, "purge queue retry attempts exhausted")
 }
 
 // tryPurgeQueueOnce performs one read-validate-commit pass. The first
 // return reports whether the caller should stop retrying (true means
 // the purge is committed); a non-retryable error short-circuits the
-// loop.
-func (s *SQSServer) tryPurgeQueueOnce(ctx context.Context, queueName string) (bool, error) {
+// loop. On success the second and third returns carry the
+// pre-bump and post-bump generations so the caller can audit-log the
+// committed value without a second meta read.
+func (s *SQSServer) tryPurgeQueueOnce(ctx context.Context, queueName string) (bool, uint64, uint64, error) {
 	readTS := s.nextTxnReadTS(ctx)
 	meta, exists, err := s.loadQueueMetaAt(ctx, queueName, readTS)
 	if err != nil {
-		return false, errors.WithStack(err)
+		return false, 0, 0, errors.WithStack(err)
 	}
 	if !exists {
-		return false, newSQSAPIError(http.StatusBadRequest, sqsErrQueueDoesNotExist, "queue does not exist")
+		return false, 0, 0, newSQSAPIError(http.StatusBadRequest, sqsErrQueueDoesNotExist, "queue does not exist")
 	}
 	now := time.Now().UnixMilli()
 	if meta.LastPurgedAtMillis > 0 && now-meta.LastPurgedAtMillis < sqsPurgeRateLimitMillis {
-		return false, newSQSAPIError(http.StatusBadRequest, sqsErrPurgeInProgress,
-			"only one PurgeQueue operation on each queue is allowed every 60 seconds")
+		// Compute the remaining wait inside the OCC read so the
+		// duration cannot race a concurrent purge resetting
+		// LastPurgedAtMillis in the 60-second window. Both
+		// sqsPurgeRateLimitMillis and the (now - LastPurgedAtMillis)
+		// difference are int64 millisecond counts; multiplying by
+		// time.Millisecond is the unit-correct conversion to
+		// time.Duration.
+		remaining := time.Duration(sqsPurgeRateLimitMillis-(now-meta.LastPurgedAtMillis)) * time.Millisecond
+		return false, 0, 0, &purgeRateLimitedError{remaining: remaining}
 	}
 	lastGen, err := s.loadQueueGenerationAt(ctx, queueName, readTS)
 	if err != nil {
-		return false, errors.WithStack(err)
+		return false, 0, 0, errors.WithStack(err)
 	}
 	meta.Generation = lastGen + 1
 	meta.LastPurgedAtMillis = now
 	meta.LastModifiedAtMillis = now
 	metaBytes, err := encodeSQSQueueMeta(meta)
 	if err != nil {
-		return false, errors.WithStack(err)
+		return false, 0, 0, errors.WithStack(err)
 	}
 	metaKey := sqsQueueMetaKey(queueName)
 	genKey := sqsQueueGenKey(queueName)
@@ -120,7 +152,7 @@ func (s *SQSServer) tryPurgeQueueOnce(ctx context.Context, queueName string) (bo
 		},
 	}
 	if _, err := s.coordinator.Dispatch(ctx, req); err != nil {
-		return false, errors.WithStack(err)
+		return false, 0, 0, errors.WithStack(err)
 	}
-	return true, nil
+	return true, lastGen, meta.Generation, nil
 }


### PR DESCRIPTION
## Summary

Phase 2 of the Admin Queue Peek and Purge design (`docs/design/2026_05_16_proposed_admin_purge_queue.md`):

- `AdminPurgeQueue(ctx, principal, name) (AdminPurgeResult, error)` — SigV4-bypass counterpart to `purgeQueue`, mirroring `AdminDeleteQueue`'s gate shape. Returns the committed-OCC generation pair so the audit line records the exact value that landed (no second `loadQueueMetaAt` race against a concurrent purge in the 60-second window).
- `AdminQueueSummary.IsDLQ` / `DLQSources` — reverse-scan of the queue-meta catalog populated by `AdminDescribeQueue`. Paginated (`ceil(N/1024)` round-trips, same envelope as `scanQueueNamesAt`) so deployments with > 1024 queues still surface every source link.
- Typed `*PurgeInProgressError{RetryAfter time.Duration}` + `ErrAdminSQSPurgeInProgress` sentinel for the 60-second rate limit; admin caller extracts the duration via `errors.As` from the internal `*purgeRateLimitedError` that `tryPurgeQueueOnce` now returns inside the same OCC read as the rate-limit decision.
- `writeSQSErrorFromErr` gains a dedicated `errors.As(*purgeRateLimitedError)` branch so the SigV4 wire shape stays byte-compatible (`400` + `__type == AWS.SimpleQueueService.PurgeQueueInProgress`, message unchanged).

`purgeQueueWithRetry`'s signature changes from `error` to `(oldGen, newGen uint64, err error)`. **Caller audit (semantic-change rule):** exactly one external caller — `purgeQueue` at `adapter/sqs_purge.go:42` — updated to discard the new pair. No other call sites.

## Behavior change

- SigV4 `PurgeQueue`: **no behavior change.** Wire shape pinned by `TestPurgeQueueSigV4_PreservesWireShapeAfterTypedErrorChange` (new) + the existing `TestSQSServer_PurgeQueueRemovesMessagesAndRateLimits`.
- New `AdminPurgeQueue` admin method. Not yet wired to an HTTP handler (Phase 4) — this PR only adds the adapter surface.
- `AdminDescribeQueue` now does one extra paginated prefix scan to populate `IsDLQ`/`DLQSources`. Cost matches the existing `AdminListQueues` scan.

## Risk

Low. The typed-error refactor only changes return values; `tryPurgeQueueOnce`'s body is identical (same OCC commit, same tombstone, same retry classification). `isRetryableTransactWriteError` only matches `store.ErrWriteConflict` / `kv.ErrTxnLocked`, so the new `*purgeRateLimitedError` falls through to the non-retryable branch immediately (no spurious retries).

## Self-review (5 passes)

1. **Data loss** — refactor only; no new persistence paths. IsDLQ scan is read-only.
2. **Concurrency** — `remaining` computed inside the OCC read from the same `LastPurgedAtMillis` the rate-limit check observed; no second meta read race. `AdminPurgeQueue` extracts the duration via `errors.As`. Leader check before any state change.
3. **Performance** — `AdminPurgeQueue` is O(1) like SigV4 purge. IsDLQ scan is `ceil(N/1024)` round-trips + O(N) decode, same as `scanQueueNamesAt`. No hot-path allocations (typed error only allocated on rate-limit reject).
4. **Consistency** — `GenerationBefore`/`GenerationAfter` come from the OCC-committed transaction. IsDLQ sources read at the same `readTS` as the meta load → single MVCC snapshot.
5. **Test coverage** — 9 new unit tests in `adapter/sqs_admin_test.go`: happy / forbidden / missing / empty-name / rate-limited (typed) / SigV4 wire regression / IsDLQ none / one / two-sorted (insertion order reversed so `sort.Strings` is actually exercised). Existing tests retained.

## Test plan

- [x] `go test -race -count=1 ./adapter/...` (targeted run: `TestAdminPurgeQueue*`, `TestPurgeQueueSigV4_*`, `TestAdminQueueSummary*`, `TestSQSServer_Purge*`, `TestSQSServer_PurgeThenDelete*`, `TestSQSServer_RetentionReaper*`, `TestBucketStore_Purge*`)
- [x] `make lint` clean (adapter package)
- [ ] CI on this PR
