### PR TITLE
feat(encryption): Stage 6B-2 — KEK plumbing + --encryption-enabled flag + mutator-RPC gate

### DIFF
--- a/main.go
+++ b/main.go
@@ -163,7 +163,7 @@ var (
 	// registerEncryptionAdminServer omits the Proposer + LeaderView
 	// options and every mutator short-circuits at the gRPC boundary
 	// with FailedPrecondition before any Raft proposal is created.
-	encryptionSidecarPath = flag.String("encryptionSidecarPath", "", "§5.1 keys.json path; enables read-only EncryptionAdmin capability probing. Mutating RPCs (Bootstrap / RotateDEK / RegisterEncryptionWriter) are additionally gated on --encryption-enabled AND --kekFile being non-empty.")
+	encryptionSidecarPath = flag.String("encryptionSidecarPath", "", "§5.1 keys.json path; enables read-only EncryptionAdmin capability probing. Mutating RPCs (Bootstrap / RotateDEK / RegisterEncryptionWriter) are additionally gated on this flag being non-empty AND --encryption-enabled AND --kekFile being non-empty (all three required so the applier's WithKEK + WithKeystore + WithSidecarPath options are all wired before mutators can commit).")
 
 	// Stage 6B-2: cluster-wide encryption opt-in flag. The mutating
 	// EncryptionAdmin RPCs (BootstrapEncryption, RotateDEK,
@@ -724,7 +724,7 @@ func buildShardGroups(
 	factory raftengine.Factory,
 	proposalObserverForGroup func(uint64) kv.ProposalObserver,
 	clock *kv.HLC,
-	kekWrapper *kek.FileWrapper,
+	kekWrapper kek.Wrapper,
 	keystore *encryption.Keystore,
 	sidecarPath string,
 ) ([]*raftGroupRuntime, map[uint64]*kv.ShardGroup, error) {
@@ -801,10 +801,12 @@ func observerForGroup(factory func(uint64) kv.ProposalObserver, groupID uint64) 
 
 // loadKEKWrapperFromFlag constructs the file-backed KEK wrapper
 // from the --kekFile flag, returning nil if the flag is empty.
-// The error is wrapped so the calling run() context surfaces in
-// the startup-failure log message. Extracted from run() to keep
-// the startup path under the cyclop complexity budget.
-func loadKEKWrapperFromFlag() (*kek.FileWrapper, error) {
+// Returns the kek.Wrapper interface rather than the concrete
+// *kek.FileWrapper so the call site (buildShardGroups → applier)
+// stays decoupled from the file-mode provider — Stage 9 KMS
+// providers (AWS KMS, GCP KMS, Vault) will satisfy the same
+// interface and slot in without rewriting the dispatch site.
+func loadKEKWrapperFromFlag() (kek.Wrapper, error) {
 	if *kekFile == "" {
 		return nil, nil
 	}
@@ -821,7 +823,14 @@ func loadKEKWrapperFromFlag() (*kek.FileWrapper, error) {
 // suppresses its option, leaving the applier in the Stage 6A
 // posture for that axis. Extracted from buildShardGroups so the
 // per-shard loop stays under the cyclop complexity budget.
-func applierOptionsFor(kekWrapper *kek.FileWrapper, keystore *encryption.Keystore, sidecarPath string) []encryption.ApplierOption {
+//
+// kekWrapper is typed as encryption.KEKUnwrapper (the
+// applier-side narrow interface) rather than the wider
+// kek.Wrapper so the helper stays decoupled from the wrap-side
+// path. Any kek.Wrapper satisfies encryption.KEKUnwrapper
+// structurally because both declare Unwrap with the same
+// signature.
+func applierOptionsFor(kekWrapper encryption.KEKUnwrapper, keystore *encryption.Keystore, sidecarPath string) []encryption.ApplierOption {
 	const maxOpts = 3
 	opts := make([]encryption.ApplierOption, 0, maxOpts)
 	if kekWrapper != nil {

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	internalutil "github.com/bootjp/elastickv/internal"
 	"github.com/bootjp/elastickv/internal/admin"
 	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/bootjp/elastickv/internal/encryption/kek"
 	"github.com/bootjp/elastickv/internal/memwatch"
 	internalraftadmin "github.com/bootjp/elastickv/internal/raftadmin"
 	"github.com/bootjp/elastickv/internal/raftengine"
@@ -154,15 +155,33 @@ var (
 	// reports encryption_capable=true.
 	//
 	// Mutating RPCs (BootstrapEncryption / RotateDEK /
-	// RegisterEncryptionWriter) are refused with FailedPrecondition
-	// regardless of this flag. The §6.3 WithEncryption FSM applier
-	// is plumbed by Stage 6; until then registerEncryptionAdminServer
-	// installs neither the Proposer nor the LeaderView, so every
-	// mutator short-circuits at the gRPC boundary before any Raft
-	// proposal is created. Setting --encryptionSidecarPath does
-	// NOT enable mutating RPCs; Stage 6 wires the applier and the
-	// Proposer + LeaderView together in the same change.
-	encryptionSidecarPath = flag.String("encryptionSidecarPath", "", "§5.1 keys.json path; enables read-only EncryptionAdmin capability probing. Mutating RPCs (Bootstrap / RotateDEK / RegisterEncryptionWriter) are refused with FailedPrecondition regardless of this flag until Stage 6 wires the §6.3 FSM applier together with the Proposer + LeaderView.")
+	// RegisterEncryptionWriter) are gated by Stage 6B-2 on the
+	// AND of --encryption-enabled and --kekFile being non-empty.
+	// Setting --encryptionSidecarPath ALONE no longer enables
+	// mutators; the operator must explicitly opt in to encryption
+	// AND supply a KEK source. With either gate condition false,
+	// registerEncryptionAdminServer omits the Proposer + LeaderView
+	// options and every mutator short-circuits at the gRPC boundary
+	// with FailedPrecondition before any Raft proposal is created.
+	encryptionSidecarPath = flag.String("encryptionSidecarPath", "", "§5.1 keys.json path; enables read-only EncryptionAdmin capability probing. Mutating RPCs (Bootstrap / RotateDEK / RegisterEncryptionWriter) are additionally gated on --encryption-enabled AND --kekFile being non-empty.")
+
+	// Stage 6B-2: cluster-wide encryption opt-in flag. The mutating
+	// EncryptionAdmin RPCs (BootstrapEncryption, RotateDEK,
+	// RegisterEncryptionWriter) become reachable only when this
+	// flag is set AND --kekFile points at a valid KEK source.
+	// Default off; pre-Stage-6 clusters and operators who have
+	// not yet committed to encryption are unaffected.
+	encryptionEnabled = flag.Bool("encryption-enabled", false, "§6.5 opt-in to encryption-mutating EncryptionAdmin RPCs. Requires --kekFile to be set; without that, mutators still refuse with FailedPrecondition. Default off.")
+
+	// Stage 6B-2: KEK source. The KEK never appears in elastickv's
+	// data dir; it is held externally and exercised only at process
+	// boot and at DEK bootstrap/rotation per §5.1. Stage 6B-2 ships
+	// only the file-backed wrapper (kek.FileWrapper); KMS providers
+	// (--kekUri) land in Stage 9. Empty disables KEK loading; the
+	// applier's ApplyBootstrap and ApplyRotation paths then return
+	// ErrKEKNotConfigured at apply time, which is masked at the
+	// RPC boundary by the mutator gate documented above.
+	kekFile = flag.String("kekFile", "", "§5.1 KEK file path (32 raw bytes, owner-only mode). When set, the file-backed kek.Wrapper is constructed at startup and threaded into the §6.3 EncryptionApplier so ApplyBootstrap and ApplyRotation can KEK-unwrap.")
 
 	// Key visualizer sampler flags. The sampler runs entirely in-memory
 	// on each node, feeds AdminServer.GetKeyVizMatrix, and is disabled
@@ -297,6 +316,30 @@ func run() error {
 	// physicalCeiling when HLC lease entries are applied to the Raft log.
 	clock := kv.NewHLC()
 
+	// Stage 6B-2: construct the shared KEK wrapper + in-memory
+	// Keystore once at startup, before any FSM is built. Both are
+	// process-wide singletons:
+	//
+	//   - KEK is exercised at DEK bootstrap (§5.6) and rotation
+	//     (§5.2) by every shard's applier; one wrapper per process
+	//     is what the file-mode check + kek.FileWrapper invariants
+	//     assume.
+	//   - Keystore is the in-memory map of (key_id → DEK bytes) the
+	//     storage cipher (§6.2, wired in Stage 6D) and the
+	//     EncryptionApplier (Stage 6A/6B) both read from. Sharing
+	//     one instance across shards keeps post-bootstrap DEKs
+	//     visible to every shard's storage cipher.
+	//
+	// Both are nil-safe in the applier path: WithKEK / WithKeystore
+	// are only attached to the applier when --kekFile is non-empty
+	// (else the applier stays in the Stage 6A posture where
+	// ApplyBootstrap / ApplyRotation return ErrKEKNotConfigured).
+	kekWrapper, err := loadKEKWrapperFromFlag()
+	if err != nil {
+		return err
+	}
+	keystore := encryption.NewKeystore()
+
 	runtimes, shardGroups, err := buildShardGroups(
 		*raftId,
 		*raftDir,
@@ -309,6 +352,9 @@ func run() error {
 			return metricsRegistry.RaftProposalObserver(groupID)
 		},
 		clock,
+		kekWrapper,
+		keystore,
+		*encryptionSidecarPath,
 	)
 	if err != nil {
 		return err
@@ -678,6 +724,9 @@ func buildShardGroups(
 	factory raftengine.Factory,
 	proposalObserverForGroup func(uint64) kv.ProposalObserver,
 	clock *kv.HLC,
+	kekWrapper *kek.FileWrapper,
+	keystore *encryption.Keystore,
+	sidecarPath string,
 ) ([]*raftGroupRuntime, map[uint64]*kv.ShardGroup, error) {
 	runtimes := make([]*raftGroupRuntime, 0, len(groups))
 	shardGroups := make(map[uint64]*kv.ShardGroup, len(groups))
@@ -710,7 +759,13 @@ func buildShardGroups(
 			_ = st.Close()
 			return nil, nil, errors.Wrapf(err, "failed to construct writer registry for group %d", g.id)
 		}
-		applier, err := encryption.NewApplier(reg)
+		// Stage 6B-2: thread WithKEK + WithKeystore + WithSidecarPath
+		// into the Applier when all three are supplied. Without
+		// any of them the applier stays in the Stage 6A posture
+		// (ApplyBootstrap / ApplyRotation return ErrKEKNotConfigured)
+		// which is exactly the desired apply-time fail-closed
+		// behaviour when an operator has not opted in to encryption.
+		applier, err := encryption.NewApplier(reg, applierOptionsFor(kekWrapper, keystore, sidecarPath)...)
 		if err != nil {
 			for _, rt := range runtimes {
 				rt.Close()
@@ -742,6 +797,43 @@ func observerForGroup(factory func(uint64) kv.ProposalObserver, groupID uint64) 
 		return nil
 	}
 	return factory(groupID)
+}
+
+// loadKEKWrapperFromFlag constructs the file-backed KEK wrapper
+// from the --kekFile flag, returning nil if the flag is empty.
+// The error is wrapped so the calling run() context surfaces in
+// the startup-failure log message. Extracted from run() to keep
+// the startup path under the cyclop complexity budget.
+func loadKEKWrapperFromFlag() (*kek.FileWrapper, error) {
+	if *kekFile == "" {
+		return nil, nil
+	}
+	w, err := kek.NewFileWrapper(*kekFile)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to load KEK from %s", *kekFile)
+	}
+	return w, nil
+}
+
+// applierOptionsFor assembles the variadic ApplierOption slice
+// for encryption.NewApplier based on which Stage 6B-2 dependencies
+// the operator has wired at startup. Each nil/empty input
+// suppresses its option, leaving the applier in the Stage 6A
+// posture for that axis. Extracted from buildShardGroups so the
+// per-shard loop stays under the cyclop complexity budget.
+func applierOptionsFor(kekWrapper *kek.FileWrapper, keystore *encryption.Keystore, sidecarPath string) []encryption.ApplierOption {
+	const maxOpts = 3
+	opts := make([]encryption.ApplierOption, 0, maxOpts)
+	if kekWrapper != nil {
+		opts = append(opts, encryption.WithKEK(kekWrapper))
+	}
+	if keystore != nil {
+		opts = append(opts, encryption.WithKeystore(keystore))
+	}
+	if sidecarPath != "" {
+		opts = append(opts, encryption.WithSidecarPath(sidecarPath))
+	}
+	return opts
 }
 
 func raftMonitorRuntimes(runtimes []*raftGroupRuntime) []monitoring.RaftRuntime {
@@ -1291,6 +1383,7 @@ func startRaftServers(
 	// options appended below. Sized as a constant so the magic-number
 	// linter does not complain.
 	const extraOptsCap = 2
+	enableMutators := encryptionMutatorsEnabled()
 	for _, rt := range runtimes {
 		baseOpts := internalutil.GRPCServerOptions()
 		opts := make([]grpc.ServerOption, 0, len(baseOpts)+extraOptsCap)
@@ -1327,7 +1420,11 @@ func startRaftServers(
 		// FNV-1a hash already used by raftengine for peer ids
 		// (etcd.DeriveNodeID), so every node in the cluster reports
 		// a stable, distinct value. Codex r1 P1 on PR #760.
-		registerEncryptionAdminServer(gs, etcdraftengine.DeriveNodeID(*raftId), *encryptionSidecarPath)
+		// Stage 6B-2 mutator gate is resolved once above the
+		// per-shard loop. Each shard's own engine is the
+		// Proposer + LeaderView so the mutator proposes through
+		// the correct Raft group.
+		registerEncryptionAdminServer(gs, etcdraftengine.DeriveNodeID(*raftId), *encryptionSidecarPath, enableMutators, rt.engine)
 		registerAdminForwardServer(gs, forwardDeps, forwardLogger)
 		rt.registerGRPC(gs)
 		internalraftadmin.RegisterOperationalServices(ctx, gs, rt.engine, []string{"RawKV"})

--- a/main_bootstrap_e2e_test.go
+++ b/main_bootstrap_e2e_test.go
@@ -356,7 +356,7 @@ func startBootstrapE2ENode(
 		return nil, err
 	}
 	clock := kv.NewHLC()
-	runtimes, shardGroups, err := buildShardGroups(ep.id, baseDir, cfg.groups, cfg.multi, bootstrap, bootstrapServers, factory, nil, clock)
+	runtimes, shardGroups, err := buildShardGroups(ep.id, baseDir, cfg.groups, cfg.multi, bootstrap, bootstrapServers, factory, nil, clock, nil, nil, "")
 	if err != nil {
 		return nil, err
 	}

--- a/main_encryption_admin.go
+++ b/main_encryption_admin.go
@@ -44,7 +44,9 @@ import (
 //     ("don't enable any mutator RPC until every member of
 //     every Raft group reports encryption_capable") is the
 //     same operator-discipline constraint documented in PR
-//     #765 (Stage 6A) for the 6A→6B rolling upgrade.
+//     #765 (Stage 6A) and in the Stage 6 plan in
+//     docs/design/2026_04_29_partial_data_at_rest_encryption.md
+//     (6A rationale, "Rolling 6A→6B upgrade caveat").
 //   - Adding a cluster-wide readiness probe at this layer
 //     would duplicate the §7.1 capability gate and ship
 //     before the operator-facing GetCapability fan-out is

--- a/main_encryption_admin.go
+++ b/main_encryption_admin.go
@@ -2,10 +2,35 @@ package main
 
 import (
 	"github.com/bootjp/elastickv/adapter"
+	"github.com/bootjp/elastickv/internal/raftengine"
 	pb "github.com/bootjp/elastickv/proto"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
 )
+
+// encryptionMutatorsEnabled is the Stage 6B-2 double-gate
+// readback. Returns true iff the operator has BOTH opted in
+// (--encryption-enabled) AND supplied a KEK source (--kekFile).
+// Either condition false → mutator wiring stays off.
+//
+// Kept in this file (not main.go) so the flag-driven gate logic
+// is colocated with the registerEncryptionAdminServer helper
+// that consumes it.
+func encryptionMutatorsEnabled() bool {
+	return *encryptionEnabled && *kekFile != ""
+}
+
+// encryptionAdminEngine is the subset of raftengine.Engine the
+// EncryptionAdminServer needs: a Proposer (for the mutating RPCs)
+// and a LeaderView (for the requireLeader gate). Every shard's
+// raftengine.Engine satisfies both interfaces; declaring a local
+// intersection keeps the construction site decoupled from the
+// concrete engine type and lets tests substitute a stub without
+// pulling in the full engine surface.
+type encryptionAdminEngine interface {
+	raftengine.Proposer
+	raftengine.LeaderView
+}
 
 // registerEncryptionAdminServer constructs and registers an
 // EncryptionAdminServer on the supplied gRPC server. The function
@@ -23,50 +48,54 @@ import (
 // number — Codex r1 P1 on PR #760 caught the original wiring
 // passing the shard id by mistake.
 //
-// Stage 5D is intentionally inert for mutating RPCs. This helper
-// installs ONLY the sidecar-path + full-node-id options, never
-// the Proposer or LeaderView. With both omitted,
-// EncryptionAdminServer.BootstrapEncryption / RotateDEK /
-// RegisterEncryptionWriter return FailedPrecondition at the gRPC
-// boundary — the proposal never reaches Raft.
+// Stage 6B-2: the mutator wiring (Proposer + LeaderView) is now
+// gated on the supplied enableMutators boolean, which the caller
+// in main.go computes as (--encryption-enabled AND --kekFile
+// non-empty AND engine non-nil). When enableMutators is false,
+// Proposer + LeaderView stay unwired and EncryptionAdminServer's
+// BootstrapEncryption / RotateDEK / RegisterEncryptionWriter
+// short-circuit at the gRPC boundary with FailedPrecondition —
+// identical to the Stage 5D posture. When enableMutators is
+// true, both options are wired and the mutators reach the §6.3
+// applier through the supplied engine's Propose path.
 //
-// The reason mutator wiring stays off ENTIRELY (not just
-// sidecar-gated) is Codex r3 P1 on PR #760: the §6.3
-// WithEncryption applier seam is plumbed by Stage 6. Today the
-// FSM is constructed via kv.NewKvFSMWithHLC (no WithEncryption
-// option). A successfully-applied bootstrap entry would land a
-// 0x03/0x04/0x05 Raft entry on every replica, the FSM apply path
-// would route through kvFSM.applyEncryption, the default branch
-// would fire ErrEncryptionApply because the applier is nil, and
-// the engine's HaltApply seam would stop apply on every node.
-// Gating mutator wiring on --encryptionSidecarPath (as PR760 r2
-// did) is not safe enough — an operator who sets sidecarPath for
-// capability probing alone could still trigger a cluster-halt by
-// calling a mutating RPC. The applier and the mutator wiring
-// must land together in Stage 6.
+// The double gate exists because both conditions are
+// independently necessary:
+//
+//   - --encryption-enabled is the operator opt-in: an unset flag
+//     means the cluster has explicitly chosen NOT to participate
+//     in the §7.1 rollout, so mutator RPCs MUST refuse even on
+//     a fully-keyed binary.
+//   - --kekFile being non-empty means a KEK source is loaded;
+//     without it, a mutator that committed would land in the
+//     applier with no KEK and return ErrKEKNotConfigured from
+//     the §6.3 HaltApply path — that is fail-closed but it
+//     halts the whole cluster's apply loop. The RPC-layer
+//     KEKConfigured() gate keeps the halt unreachable in
+//     practice.
+//
+// Validate() panics on a misconfiguration that wires a proposer
+// without a LeaderView. The wiring below pairs both options
+// together (both wired iff enableMutators) so the invariant
+// holds by construction.
 //
 // sidecarPath controls only the read-only capability surface:
 // when empty, GetCapability reports encryption_capable=false
 // (the §7.1 cutover refuses with ErrCapabilityCheckFailed);
 // when set, capability probing reads the §5.1 keys.json and
-// reports encryption_capable=true. ResyncSidecar's leader guard
-// (requireLeader) returns nil when LeaderView is unset — the
-// "test escape hatch" path documented in requireLeader's godoc —
-// so ResyncSidecar serves the local sidecar on every node until
-// Stage 6 wires the LeaderView. Pre-bootstrap the sidecar is
-// either non-existent or empty so there is no §5.5 leak window.
-//
-// Validate() panics on a misconfiguration that wires a proposer
-// without a LeaderView. The wiring below never wires either, so
-// the invariant holds vacuously today; the panic remains the
-// load-bearing guard against a future Stage 6 refactor that
-// splits the two options apart.
-func registerEncryptionAdminServer(gs *grpc.Server, fullNodeID uint64, sidecarPath string) {
+// reports encryption_capable=true.
+func registerEncryptionAdminServer(gs *grpc.Server, fullNodeID uint64, sidecarPath string, enableMutators bool, engine encryptionAdminEngine) {
 	opts := []adapter.EncryptionAdminServerOption{
 		adapter.WithEncryptionAdminFullNodeID(fullNodeID),
 	}
 	if sidecarPath != "" {
 		opts = append(opts, adapter.WithEncryptionAdminSidecarPath(sidecarPath))
+	}
+	if enableMutators && engine != nil {
+		opts = append(opts,
+			adapter.WithEncryptionAdminProposer(engine),
+			adapter.WithEncryptionAdminLeaderView(engine),
+		)
 	}
 	srv := adapter.NewEncryptionAdminServer(opts...)
 	if err := srv.Validate(); err != nil {

--- a/main_encryption_admin.go
+++ b/main_encryption_admin.go
@@ -8,16 +8,30 @@ import (
 	"google.golang.org/grpc"
 )
 
-// encryptionMutatorsEnabled is the Stage 6B-2 double-gate
-// readback. Returns true iff the operator has BOTH opted in
-// (--encryption-enabled) AND supplied a KEK source (--kekFile).
-// Either condition false → mutator wiring stays off.
+// encryptionMutatorsEnabled is the Stage 6B-2 triple-gate
+// readback. Returns true iff the operator has all three of:
+//
+//   - --encryption-enabled (explicit operator opt-in)
+//   - --kekFile non-empty (KEK source loaded so ApplyBootstrap
+//     / ApplyRotation can KEK-unwrap)
+//   - --encryptionSidecarPath non-empty (so the applier can
+//     crash-durably persist Active.{Storage,Raft} + keys[])
+//
+// Any one false → mutator wiring stays off. The sidecarPath
+// condition was added in PR #776 codex P1 — without it, an
+// operator with --encryption-enabled + --kekFile but no
+// --encryptionSidecarPath could call BootstrapEncryption, the
+// proposal would commit, and every replica's applier would
+// HaltApply with "bootstrap requires WithKEK + WithKeystore +
+// WithSidecarPath" because the applier's WithSidecarPath
+// option was omitted in buildShardGroups. The triple gate
+// keeps that halt unreachable.
 //
 // Kept in this file (not main.go) so the flag-driven gate logic
 // is colocated with the registerEncryptionAdminServer helper
 // that consumes it.
 func encryptionMutatorsEnabled() bool {
-	return *encryptionEnabled && *kekFile != ""
+	return *encryptionEnabled && *kekFile != "" && *encryptionSidecarPath != ""
 }
 
 // encryptionAdminEngine is the subset of raftengine.Engine the

--- a/main_encryption_admin.go
+++ b/main_encryption_admin.go
@@ -9,7 +9,7 @@ import (
 )
 
 // encryptionMutatorsEnabled is the Stage 6B-2 triple-gate
-// readback. Returns true iff the operator has all three of:
+// readback. Returns true iff THIS NODE has all three of:
 //
 //   - --encryption-enabled (explicit operator opt-in)
 //   - --kekFile non-empty (KEK source loaded so ApplyBootstrap
@@ -18,14 +18,42 @@ import (
 //     crash-durably persist Active.{Storage,Raft} + keys[])
 //
 // Any one false → mutator wiring stays off. The sidecarPath
-// condition was added in PR #776 codex P1 — without it, an
-// operator with --encryption-enabled + --kekFile but no
-// --encryptionSidecarPath could call BootstrapEncryption, the
-// proposal would commit, and every replica's applier would
-// HaltApply with "bootstrap requires WithKEK + WithKeystore +
-// WithSidecarPath" because the applier's WithSidecarPath
-// option was omitted in buildShardGroups. The triple gate
-// keeps that halt unreachable.
+// condition catches the case where an operator with the other
+// two flags set could trigger a HaltApply: without
+// WithSidecarPath, the applier's bootstrapAndRotationConfigured()
+// returns false and ApplyBootstrap halts apply with
+// ErrKEKNotConfigured. The triple gate keeps that unreachable
+// at the RPC boundary.
+//
+// Scope limitation — this is a NODE-LOCAL gate, not a
+// cluster-wide readiness check. During a staged rolling
+// upgrade where some peers still run the pre-6B-2 binary (or
+// have the flags unset), a mutator proposal committed by a
+// fully-configured leader would reach those replicas'
+// appliers and HaltApply on the under-configured side. The
+// design accepts this for Stage 6B-2 because:
+//
+//   - The §7.1 Phase-1 cutover RPC (Stage 6D's
+//     enable-storage-envelope) is the load-bearing
+//     cluster-wide gate; it runs a Voters ∪ Learners
+//     capability fan-out via GetCapability and refuses if any
+//     member is not encryption_capable. That is the right
+//     layer for cluster-wide safety.
+//   - Operators using Stage 6B-2 are explicitly opting in to
+//     the mutator surface; the rolling-restart discipline
+//     ("don't enable any mutator RPC until every member of
+//     every Raft group reports encryption_capable") is the
+//     same operator-discipline constraint documented in PR
+//     #765 (Stage 6A) for the 6A→6B rolling upgrade.
+//   - Adding a cluster-wide readiness probe at this layer
+//     would duplicate the §7.1 capability gate and ship
+//     before the operator-facing GetCapability fan-out is
+//     wired into the admin CLI.
+//
+// PR #776 round-2 codex P1 flagged this scope boundary; the
+// resolution is to document the constraint explicitly here
+// rather than ship a partial cluster-wide check that would
+// be superseded by Stage 6D in any case.
 //
 // Kept in this file (not main.go) so the flag-driven gate logic
 // is colocated with the registerEncryptionAdminServer helper

--- a/main_encryption_admin_test.go
+++ b/main_encryption_admin_test.go
@@ -114,10 +114,19 @@ func TestEncryptionAdmin_MutatingRPCEnabledWhenGateOn(t *testing.T) {
 	// Whatever the deeper error, it must not be the FailedPrecondition
 	// from the gate. The stub Propose() returns success on a malformed
 	// payload, so the actual return may be a deeper InvalidArgument
-	// or codes.OK — anything except FailedPrecondition is acceptable.
+	// or codes.OK — anything except FailedPrecondition / transport
+	// statuses is acceptable.
 	if err != nil {
-		if got := status.Code(err); got == codes.FailedPrecondition {
+		got := status.Code(err)
+		if got == codes.FailedPrecondition {
 			t.Errorf("BootstrapEncryption returned FailedPrecondition with gate ON; want a deeper status (gate should not refuse): err=%v", err)
+		}
+		// Bufconn transport failures or context-derived statuses
+		// would defeat the test purpose — fail loud rather than
+		// silently passing on infra noise (coderabbit PR #776
+		// minor).
+		if got == codes.Unavailable || got == codes.DeadlineExceeded || got == codes.Canceled {
+			t.Fatalf("BootstrapEncryption failed on test transport/setup, not gate behavior: code=%v err=%v", got, err)
 		}
 	}
 }

--- a/main_encryption_admin_test.go
+++ b/main_encryption_admin_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/bootjp/elastickv/internal/raftengine"
 	etcdraftengine "github.com/bootjp/elastickv/internal/raftengine/etcd"
 	pb "github.com/bootjp/elastickv/proto"
 	"google.golang.org/grpc"
@@ -13,6 +14,29 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 )
+
+// stubEncryptionAdminEngine satisfies the encryptionAdminEngine
+// interface (Proposer + LeaderView) for tests that exercise the
+// Stage 6B-2 mutator-wiring gate. The methods are nil-deref-safe
+// stubs; the registration helper only stores them on the
+// EncryptionAdminServer options. Tests that exercise the gate via
+// a gRPC client never actually issue a Raft proposal because the
+// mutator path returns ErrFailedPrecondition before reaching
+// Propose() in the no-mutator case, and tests for the enabled
+// case stop at status.Code inspection.
+type stubEncryptionAdminEngine struct{}
+
+func (stubEncryptionAdminEngine) Propose(context.Context, []byte) (*raftengine.ProposalResult, error) {
+	return &raftengine.ProposalResult{}, nil
+}
+func (stubEncryptionAdminEngine) State() raftengine.State       { return raftengine.StateLeader }
+func (stubEncryptionAdminEngine) Leader() raftengine.LeaderInfo { return raftengine.LeaderInfo{} }
+func (stubEncryptionAdminEngine) VerifyLeader(context.Context) error {
+	return nil
+}
+func (stubEncryptionAdminEngine) LinearizableRead(context.Context) (uint64, error) {
+	return 0, nil
+}
 
 // TestEncryptionAdminFullNodeID_DistinctPerRaftId pins the
 // PR760 r1 Codex P1 regression: full_node_id must be derived from
@@ -38,71 +62,97 @@ func TestEncryptionAdminFullNodeID_DistinctPerRaftId(t *testing.T) {
 	}
 }
 
-// TestEncryptionAdmin_MutatingRPCRefusedUntilStage6 pins the
-// PR760 r3 Codex P1 regression. registerEncryptionAdminServer
-// must NOT wire the Proposer or LeaderView regardless of
-// sidecarPath, because the §6.3 WithEncryption applier seam is
-// still unwired on the FSM side pre-Stage-6 (FSM is constructed
-// via kv.NewKvFSMWithHLC, no WithEncryption option). Gating the
-// mutator wiring on sidecarPath alone (as PR760 r2 did) is not
-// safe enough: an operator who sets --encryptionSidecarPath for
-// read-only capability probing would still be able to trigger
-// a cluster-halt by calling Bootstrap / RotateDEK /
-// RegisterEncryptionWriter — the proposal would land on every
-// replica, hit kvFSM.applyEncryption with nil applier, and stop
-// the apply loop.
+// TestEncryptionAdmin_MutatingRPCRefusedWhenGateOff pins the
+// Stage 6B-2 double-gate. With either condition of the gate false
+// (enableMutators=false OR engine=nil), Proposer + LeaderView
+// MUST stay unwired and EncryptionAdminServer.BootstrapEncryption
+// returns FailedPrecondition at the gRPC boundary — the proposal
+// never reaches Raft.
 //
-// Both sub-cases (sidecarPath empty AND sidecarPath set) MUST
-// see the mutator refused at the gRPC boundary with
-// FailedPrecondition. Stage 6 will reintroduce the mutator
-// wiring in the same change that wires the applier.
-func TestEncryptionAdmin_MutatingRPCRefusedUntilStage6(t *testing.T) {
+// The matrix below exercises all 4 corners of (enableMutators,
+// engine-supplied). Only the (true, non-nil) combination is the
+// production "gate ON" case, which is tested separately by
+// TestEncryptionAdmin_MutatingRPCEnabledWhenGateOn.
+func TestEncryptionAdmin_MutatingRPCRefusedWhenGateOff(t *testing.T) {
 	for _, tc := range []struct {
-		name        string
-		sidecarPath string
+		name           string
+		enableMutators bool
+		engine         encryptionAdminEngine
 	}{
-		{name: "sidecar_empty", sidecarPath: ""},
-		{name: "sidecar_set", sidecarPath: "/tmp/elastickv-stage5d-test-sidecar.json"},
+		{name: "flag_off_engine_nil", enableMutators: false, engine: nil},
+		{name: "flag_off_engine_set", enableMutators: false, engine: stubEncryptionAdminEngine{}},
+		{name: "flag_on_engine_nil", enableMutators: true, engine: nil},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			listener := bufconn.Listen(1024 * 1024)
-			gs := grpc.NewServer()
-			registerEncryptionAdminServer(gs, 1, tc.sidecarPath)
-			go func() { _ = gs.Serve(listener) }()
-			t.Cleanup(gs.Stop)
-
-			conn, err := grpc.NewClient(
-				"passthrough:///bufnet",
-				grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
-					return listener.Dial()
-				}),
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-			)
-			if err != nil {
-				t.Fatalf("grpc.NewClient: %v", err)
-			}
-			t.Cleanup(func() { _ = conn.Close() })
-
-			client := pb.NewEncryptionAdminClient(conn)
-			_, err = client.BootstrapEncryption(context.Background(), &pb.BootstrapEncryptionRequest{
-				StorageDekId:      1,
-				RaftDekId:         2,
-				WrappedStorageDek: []byte("w"),
-				WrappedRaftDek:    []byte("w"),
-			})
+			err := callBootstrapAgainstNewServer(t, tc.enableMutators, tc.engine)
 			if err == nil {
-				t.Fatalf("BootstrapEncryption succeeded (sidecarPath=%q); mutating wiring must be refused at the RPC boundary until Stage 6 wires the applier", tc.sidecarPath)
+				t.Fatal("BootstrapEncryption succeeded with gate off; mutating wiring must be refused at the RPC boundary")
 			}
 			if got := status.Code(err); got != codes.FailedPrecondition {
-				t.Errorf("BootstrapEncryption status=%v, want FailedPrecondition (sidecarPath=%q → proposer not wired pre-Stage-6); err=%v", got, tc.sidecarPath, err)
+				t.Errorf("BootstrapEncryption status=%v, want FailedPrecondition; err=%v", got, err)
 			}
 		})
 	}
 }
 
+// TestEncryptionAdmin_MutatingRPCEnabledWhenGateOn pins the
+// other side of the Stage 6B-2 gate: when enableMutators=true AND
+// engine is non-nil, the mutator wiring is installed and
+// BootstrapEncryption reaches the Raft propose path. The stub
+// engine's Propose() returns success, so the only-RPC-layer
+// portion of the path completes; deeper apply-layer behaviour is
+// covered by the applier tests in internal/encryption.
+//
+// The expected status is NOT FailedPrecondition — that is the
+// gate-off signature. The exact OK / OtherCode depends on the
+// EncryptionAdminServer's downstream validation of the empty
+// wrapped payload; the test asserts the FailedPrecondition gate
+// is no longer firing, which is the property that distinguishes
+// gate-on from gate-off.
+func TestEncryptionAdmin_MutatingRPCEnabledWhenGateOn(t *testing.T) {
+	err := callBootstrapAgainstNewServer(t, true, stubEncryptionAdminEngine{})
+	// Whatever the deeper error, it must not be the FailedPrecondition
+	// from the gate. The stub Propose() returns success on a malformed
+	// payload, so the actual return may be a deeper InvalidArgument
+	// or codes.OK — anything except FailedPrecondition is acceptable.
+	if err != nil {
+		if got := status.Code(err); got == codes.FailedPrecondition {
+			t.Errorf("BootstrapEncryption returned FailedPrecondition with gate ON; want a deeper status (gate should not refuse): err=%v", err)
+		}
+	}
+}
+
+func callBootstrapAgainstNewServer(t *testing.T, enableMutators bool, engine encryptionAdminEngine) error {
+	t.Helper()
+	listener := bufconn.Listen(1024 * 1024)
+	gs := grpc.NewServer()
+	registerEncryptionAdminServer(gs, 1, "", enableMutators, engine)
+	go func() { _ = gs.Serve(listener) }()
+	t.Cleanup(gs.Stop)
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	client := pb.NewEncryptionAdminClient(conn)
+	_, err = client.BootstrapEncryption(context.Background(), &pb.BootstrapEncryptionRequest{
+		StorageDekId:      1,
+		RaftDekId:         2,
+		WrappedStorageDek: []byte("w"),
+		WrappedRaftDek:    []byte("w"),
+	})
+	return err
+}
+
 func TestRegisterEncryptionAdminServer_Registers(t *testing.T) {
 	gs := grpc.NewServer()
-	registerEncryptionAdminServer(gs, 1, "")
+	registerEncryptionAdminServer(gs, 1, "", false, nil)
 	info := gs.GetServiceInfo()
 	if _, ok := info["EncryptionAdmin"]; !ok {
 		var registered []string

--- a/multiraft_runtime_test.go
+++ b/multiraft_runtime_test.go
@@ -54,7 +54,7 @@ func TestBuildShardGroupsWithEtcdEngineRoutesAcrossGroups(t *testing.T) {
 	factory, err := newRaftFactory(raftEngineEtcd)
 	require.NoError(t, err)
 	clock := kv.NewHLC()
-	runtimes, shardGroups, err := buildShardGroups("n1", baseDir, groups, true, true, nil, factory, nil, clock)
+	runtimes, shardGroups, err := buildShardGroups("n1", baseDir, groups, true, true, nil, factory, nil, clock, nil, nil, "")
 	require.NoError(t, err)
 
 	engine := distribution.NewEngine()
@@ -108,7 +108,7 @@ func TestBuildShardGroupsWithEtcdEngineRestartsAcrossGroups(t *testing.T) {
 	openShardStore := func(bootstrap bool) ([]*raftGroupRuntime, map[uint64]*kv.ShardGroup, *kv.ShardStore) {
 		factory, err := newRaftFactory(raftEngineEtcd)
 		require.NoError(t, err)
-		runtimes, shardGroups, err := buildShardGroups("n1", baseDir, groups, true, bootstrap, nil, factory, nil, sharedClock)
+		runtimes, shardGroups, err := buildShardGroups("n1", baseDir, groups, true, bootstrap, nil, factory, nil, sharedClock, nil, nil, "")
 		require.NoError(t, err)
 		shardStore := kv.NewShardStore(engine, shardGroups)
 		return runtimes, shardGroups, shardStore


### PR DESCRIPTION
## Summary

Stage 6B-2 per the [PR #762 plan](https://github.com/bootjp/elastickv/pull/762). Completes Stage 6B with the operator-facing surface: `--kekFile` / `--encryption-enabled` flags, KEK loader at startup, applier threading, and the re-enabled mutator-RPC wiring in `registerEncryptionAdminServer` gated on (`--encryption-enabled` AND `--kekFile` non-empty).

Builds on Stage 6B-1 (PR #768) which landed the real `ApplyBootstrap` / `ApplyRotation` paths. This PR wires those paths into production by threading KEK + Keystore + sidecar path through the FSM construction and re-enabling the EncryptionAdmin mutator RPCs under a double gate.

## New flags

| Flag | Default | Purpose |
|---|---|---|
| `--kekFile` | `""` | §5.1 KEK file path (32 raw bytes, owner-only mode). Constructs `kek.FileWrapper` at startup; threaded into the §6.3 EncryptionApplier. `--kekUri` deferred to Stage 9 (KMS providers). |
| `--encryption-enabled` | `false` | §6.5 opt-in to the mutating EncryptionAdmin RPCs. Required (alongside `--kekFile`) for `BootstrapEncryption`/`RotateDEK`/`RegisterEncryptionWriter` to wire. |

## Double-gate

Both flags are independently necessary for the mutator wiring:

```go
func encryptionMutatorsEnabled() bool {
    return *encryptionEnabled && *kekFile != ""
}
```

- `--encryption-enabled` alone → no KEK loaded → mutators wired but ApplyBootstrap would HaltApply with `ErrKEKNotConfigured` on every replica. The RPC-layer gate refuses BEFORE the proposal commits.
- `--kekFile` alone → no operator opt-in → mutators stay refused at the RPC boundary.
- BOTH set → `WithEncryptionAdminProposer` + `WithEncryptionAdminLeaderView` installed and mutators reach the §6.3 applier through the shard's engine.

## Caller audit (semantic changes — signatures)

- **`buildShardGroups`** gains 3 new tail params `(kekWrapper *kek.FileWrapper, keystore *encryption.Keystore, sidecarPath string)`. 1 production caller (`main.go run()`), 3 test callers (`multiraft_runtime_test.go` ×2, `main_bootstrap_e2e_test.go` ×1) — all updated to pass `nil, nil, ""` for the no-encryption posture.

- **`registerEncryptionAdminServer`** gains 2 new tail params `(enableMutators bool, engine encryptionAdminEngine)`. 1 production caller (`main.go startRaftServers`), 2 test callers (`main_encryption_admin_test.go`) — all updated.

- The mutator gate is fail-CLOSED by default at every site that does not explicitly opt in.

## Test surface

| Test | Pins |
|---|---|
| `TestEncryptionAdmin_MutatingRPCRefusedWhenGateOff` (3 sub-cases) | All 3 corners of (enableMutators, engine) with at least one false → `FailedPrecondition` |
| `TestEncryptionAdmin_MutatingRPCEnabledWhenGateOn` | The (true, non-nil) corner — asserts the `FailedPrecondition` gate is NO LONGER firing |

A `stubEncryptionAdminEngine` satisfies the `encryptionAdminEngine` interface for the gate-on test (no actual Raft proposal — the stub `Propose()` returns success).

## Stage 5D safety boundary preserved

The Stage 5D regression — operators who set `--encryptionSidecarPath` alone must not see mutators wired — is preserved by the double gate. `sidecarPath` alone is strictly the capability surface; the mutator wiring is gated on the AND of two SEPARATE flags.

## Five-lens self-review

1. **Data loss** — no data path touched. The applier remains fail-closed under HaltApply for any `ErrEncryptionApply` return. Pebble Sync semantics unchanged.
2. **Concurrency / distributed failures** — shared Keystore internally locked; KEK wrapper documented safe for concurrent use; per-shard applier reads from shared instances.
3. **Performance** — no hot-path change. KEK loading is a single file read at startup. Per-shard applier construction adds one slice allocation per group (0–3 element slice).
4. **Data consistency** — mutator gate is the load-bearing safety boundary. With both gate inputs true, the applier still has Stage 6B-1's input-validation guards (bootstrap idempotency, foreign-DEK batch rejection, proposer-DEK mismatch, etc.).
5. **Test coverage** — 4 gate corners + the existing applier tests from 6B-1 + the `buildShardGroups` callers.

## Test plan

- [x] `go test -race -timeout=120s -run 'TestEncryptionAdmin|TestRegisterEncryptionAdminServer|TestApply|TestNewApplier|TestWriterRegistry' ./internal/encryption/... ./store/... ./kv/... .` — PASS
- [x] `go build ./...` — PASS
- [x] `golangci-lint run ./...` — 0 issues on touched files (cyclop / mnd under budget via factored `loadKEKWrapperFromFlag` + `applierOptionsFor` + `encryptionMutatorsEnabled` helpers)
- [ ] Full Jepsen suite — not run in this PR (no envelope cutover happens until Stage 6D; the mutator path is reachable but the operator must hand-craft a `BootstrapEncryption` RPC, which is not part of the Jepsen workload set)

## Plan

Stage 6B is now complete. The next stages per [PR #762](https://github.com/bootjp/elastickv/pull/762):
- **6C** — §9.1 startup refusal guards
- **6D** — `enable-storage-envelope` admin RPC + §7.1 Phase-1 cutover
- **6E** — `enable-raft-envelope` admin RPC + §7.1 Phase-2 cutover
- **6F** — `--encryption-rotate-on-startup` ergonomics


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added encryption opt-in configuration with new command-line flags for enabling encryption support.
  * Encryption admin mutations are now conditionally gated and fail safely when encryption is not properly configured.

* **Tests**
  * Updated test coverage for encryption admin server gating behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/776?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->