### PR TITLE
test(redis): deflake Misskey/BullMQ compat tests on CI

### DIFF
--- a/adapter/redis_bullmq_compat_test.go
+++ b/adapter/redis_bullmq_compat_test.go
@@ -47,10 +47,12 @@ func TestRedis_BullMQDirectCommands(t *testing.T) {
 	streamCh := make(chan []redis.XStream, 1)
 	streamErrCh := make(chan error, 1)
 	go func() {
+		// Block: 5s (not 1s) so the XRead does not time out before the
+		// XAdd below completes its Raft round-trip on slow CI runners.
 		streams, err := reader.XRead(ctx, &redis.XReadArgs{
 			Streams: []string{"bull:test:events", "$"},
 			Count:   10,
-			Block:   time.Second,
+			Block:   5 * time.Second,
 		}).Result()
 		if err != nil {
 			streamErrCh <- err
@@ -78,7 +80,7 @@ func TestRedis_BullMQDirectCommands(t *testing.T) {
 		require.Len(t, streams[0].Messages, 1)
 		require.Equal(t, "1000-0", streams[0].Messages[0].ID)
 		require.Equal(t, map[string]any{"event": "waiting", "jobId": "job-1"}, streams[0].Messages[0].Values)
-	case <-time.After(2 * time.Second):
+	case <-time.After(6 * time.Second):
 		t.Fatal("timed out waiting for XREAD result")
 	}
 
@@ -100,7 +102,9 @@ func TestRedis_BullMQDirectCommands(t *testing.T) {
 	popCh := make(chan *redis.ZWithKey, 1)
 	popErrCh := make(chan error, 1)
 	go func() {
-		res, err := reader.BZPopMin(ctx, time.Second, "bull:test:marker").Result()
+		// 5s (not 1s) for the same reason as the XRead block above:
+		// the ZAdd's Raft commit can take longer than 1s on slow CI.
+		res, err := reader.BZPopMin(ctx, 5*time.Second, "bull:test:marker").Result()
 		if err != nil {
 			popErrCh <- err
 			return
@@ -123,7 +127,7 @@ func TestRedis_BullMQDirectCommands(t *testing.T) {
 		require.Equal(t, "bull:test:marker", popped.Key)
 		require.Equal(t, "10", popped.Member)
 		require.Equal(t, 10.0, popped.Score)
-	case <-time.After(2 * time.Second):
+	case <-time.After(6 * time.Second):
 		t.Fatal("timed out waiting for BZPOPMIN result")
 	}
 

--- a/adapter/redis_misskey_compat_test.go
+++ b/adapter/redis_misskey_compat_test.go
@@ -25,11 +25,14 @@ func TestRedis_MisskeyConnectionCompatibility(t *testing.T) {
 	require.Equal(t, "OK", rdb.Do(ctx, "CLIENT", "SETINFO", "LIB-VER", "5.10.0").Val())
 	require.Equal(t, "OK", rdb.Do(ctx, "SELECT", "0").Val())
 
-	res := rdb.Do(ctx, "SET", "lock:ap-object", "v1", "PX", "200", "NX")
+	// PX 2000 (not 200) so the NX assertion at the next SET cannot race
+	// the TTL expiry on slow CI runners where ~200ms easily slips between
+	// two consecutive Raft-replicated SET commands.
+	res := rdb.Do(ctx, "SET", "lock:ap-object", "v1", "PX", "2000", "NX")
 	require.NoError(t, res.Err())
 	require.Equal(t, "OK", res.Val())
 
-	res = rdb.Do(ctx, "SET", "lock:ap-object", "v2", "PX", "200", "NX")
+	res = rdb.Do(ctx, "SET", "lock:ap-object", "v2", "PX", "2000", "NX")
 	require.ErrorIs(t, res.Err(), redis.Nil)
 
 	getRes := rdb.Do(ctx, "SET", "lock:ap-object", "v3", "EX", "1", "GET")


### PR DESCRIPTION
## Summary

Two compat tests under `adapter/` flaked intermittently on ubuntu-latest CI in recent PRs (#755, #762). Both are timing races against tight TTLs / block timeouts that slip past on slow CI runners under `-race`. This PR widens the windows. No production code or semantics change.

### `TestRedis_MisskeyConnectionCompatibility`

`SET ... PX 200 NX` × 2 — when the gap between the two consecutive Raft-replicated SETs exceeded 200ms, the first key expired before the second SET, the NX took effect, and the `require.ErrorIs(redis.Nil)` assertion failed.

**Fix:** PX 200 → PX 2000 (10× safety margin). The downstream `time.Sleep(1100ms)` + Get-nil expiry check is unaffected — that path tests the `EX 1` timer set later, which is a separate TTL.

### `TestRedis_BullMQDirectCommands`

`XRead Block: time.Second` and `BZPopMin(ctx, time.Second, ...)` — when the producing `XAdd` / `ZAdd` Raft commit took longer than ~900ms, the blocking read timed out with `redis.Nil` and the test failed with "received nil error" rather than the expected result.

**Fix:** Block / timeout 1s → 5s; outer select deadline 2s → 6s.

## Self-review

- **Data loss:** N/A (test-only change).
- **Concurrency / distributed failures:** N/A (no production code paths touched).
- **Performance:** Tests take slightly longer in the worst-case timeout, but pass faster than before in the common case (no flake retries).
- **Data consistency:** N/A (no semantics changed; only TTL / block timeout values).
- **Test coverage:** Both tests retain identical assertions. Verified with `-count=3 -race` locally.

## Test plan

- [x] `go test -race -run 'TestRedis_MisskeyConnectionCompatibility|TestRedis_BullMQDirectCommands' -count=3 ./adapter/` → pass
- [ ] CI green on `ubuntu-latest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased timeout durations for Redis stream and sorted-set operations to improve test reliability on slower CI environments.
  * Adjusted Redis lock test TTL values to reduce timing-related test flakiness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->