### PR TITLE
feat(encryption): Stage 6C-2 — local_epoch exhaustion guard + filesystem startup probe

### DIFF
--- a/docs/design/2026_04_29_partial_data_at_rest_encryption.md
+++ b/docs/design/2026_04_29_partial_data_at_rest_encryption.md
@@ -20,8 +20,9 @@ Date: 2026-04-29
 | 5E | §5.6 step 1a capability fan-out helper + `encryption bootstrap --discover-from=...` auto-batch mode | deferred | — |
 | 6A | §6.3 `EncryptionApplier` concrete implementation (writer-registry insert + sidecar mutate + keystore update; nil-KEK code paths in `ApplyBootstrap` / `ApplyRotation` return a typed `ErrKEKNotConfigured` defense-in-depth marker until 6B fills it) + `kv.NewKvFSMWithHLC(... WithEncryption(applier))` wiring. **Mutator wiring in `registerEncryptionAdminServer` stays OFF, identical to Stage 5D** — see Stage 6 rationale §6A note. No new flag is introduced in 6A; the applier is operator-inert in a same-version 6A cluster (exercised only via direct `FSM.Apply` unit tests). Rolling 6A→6B upgrade has a halt-on-foreign-entry caveat — see rationale | open | — |
 | 6B | §6.5 KEK plumbing — `--kekFile` / `--kekUri` flags + `internal/encryption/kek` selection at startup + thread `KEKUnwrapper` into the applier so `ApplyBootstrap` / `ApplyRotation` actually KEK-unwrap (replaces the 6A `ErrKEKNotConfigured` stubs) + introduce `--encryption-enabled` flag (default off) + re-enable mutating-RPC wiring in `registerEncryptionAdminServer` gated on (`--encryption-enabled` AND `KEKConfigured()`) | open | — |
-| 6C-1 | Subset of §9.1 startup refusal guards that depend only on flags + sidecar state: sidecar present without `--encryption-enabled` (`ErrSidecarPresentWithoutFlag`, downgrade prevention), `--encryption-enabled` without `--kekFile` (`ErrKEKRequiredWithFlag`, fail-fast), KEK loaded but sidecar wrapped DEKs do not unwrap (`ErrKEKMismatch`, operator-error catch). `internal/encryption/startup.go`'s `CheckStartupGuards` runs once in `main.go run()` before `buildShardGroups`. | open | — |
-| 6C-2 | Remaining §9.1 guards that depend on raftengine integration or shared state: `ErrSidecarBehindRaftLog` (needs the persisted applied-index from raftengine), `ErrUnsupportedFilesystem` startup probe (the current code surfaces it only on first write — a dedicated `tmpfile + dir.Sync` probe at startup would surface it before any encryption-relevant write), `ErrLocalEpochExhausted` (active DEK `local_epoch == 0xFFFF` — coupled with the writer-registry record so shipping it without the rollback peer creates an asymmetric posture future readers must reason around). | open | — |
+| 6C-1 | Subset of §9.1 startup refusal guards that depend only on flags + sidecar state: sidecar present without `--encryption-enabled` (`ErrSidecarPresentWithoutFlag`, downgrade prevention), `--encryption-enabled` without `--kekFile` (`ErrKEKRequiredWithFlag`, fail-fast), KEK loaded but sidecar wrapped DEKs do not unwrap (`ErrKEKMismatch`, operator-error catch). `internal/encryption/startup.go`'s `CheckStartupGuards` runs once in `main.go run()` before `buildShardGroups`. | shipped | PR #778 |
+| 6C-2 | Process-local §9.1 guards that read only the encryption package's own state: `ErrLocalEpochExhausted` (any active DEK with `local_epoch == 0xFFFF` — refuses to start until rotated, preventing GCM nonce reuse on the next write), `ErrUnsupportedFilesystem` startup probe (`ProbeSidecarFilesystem` exercises the §5.1 write+rename+dir.Sync sequence on a sentinel file in the sidecar directory at startup so filesystem-capability failures surface BEFORE the first encryption-relevant Raft entry, not on the first WriteSidecar call hours into operation). Also includes the gemini-r3 medium parseErr-annotation fix deferred from PR #778 (`ErrKEKMismatch` now wraps both `parseErr` and the unwrap error when the defensive non-decimal-key_id branch fires). The asymmetric `ErrLocalEpochRollback` peer is split into 6C-3 because it requires the writer-registry record (Stage 7). The `ErrSidecarBehindRaftLog` guard moves to 6C-2b because it requires raftengine integration — outside the encryption package boundary. | open | — |
+| 6C-2b | `ErrSidecarBehindRaftLog` startup guard — reads the persisted applied-index from raftengine and refuses if the sidecar's `raft_applied_index` is behind by an interval covering any encryption-relevant Raft entry (`isEncryptionRelevant` predicate per §5.5). Plumbing raftengine into the startup-guard path is the load-bearing scope here; the guard itself is a one-screen function. | open | — |
 | 6C-3 | Cluster-wide §9.1 guards that require the Voters ∪ Learners membership view: `ErrNodeIDCollision` (two members hash to the same 16-bit `node_id`), `ErrLocalEpochRollback` (sidecar `local_epoch` ≤ writer-registry record). Naturally bundles with the Stage 6D capability fan-out which already needs that membership view. | open | — |
 | 6C-4 | Phase-2-specific §9.1 guards: `ErrEnvelopeCutoverDivergence` (sidecar `raft_envelope_cutover_index` disagrees with snapshot header), `ErrEncryptionNotBootstrapped` (`enable-raft-envelope` before bootstrap), `ErrLocalEpochOutOfRange` on the wire side of `GetCapability` / `GetSidecarState`. Bundles with Stage 6E (`enable-raft-envelope` admin RPC + Phase-2 cutover). | open | — |
 | 6D | §6.6 `enable-storage-envelope` admin RPC + §7.1 Phase-1 storage cutover (§6.2 toggle ON) + Voters ∪ Learners capability gate (depends on 6B for mutator wiring AND 6C-1+6C-2 for §9.1 startup-refusal guards; bundles 6C-3 for the membership-view-dependent collision check — see rationale) | open | — |
@@ -165,17 +166,34 @@ production-safe state, and unblocks the next one.
       `buildShardGroups` so a misconfigured node refuses to boot
       rather than halting mid-flight or silently downgrading.
 
-    * **6C-2** — Raftengine-integration guards. `ErrSidecarBehindRaftLog`
-      reads the persisted applied-index from the raft engine;
-      `ErrUnsupportedFilesystem` startup probe writes a temp file
-      + `dir.Sync` to surface the failure before any encryption-
-      relevant write; `ErrLocalEpochExhausted` reads the sidecar
+    * **6C-2** — Process-local guards that read only the encryption
+      package's own state. `ErrLocalEpochExhausted` reads the sidecar
       and refuses to start if any active DEK has reached
-      `local_epoch == 0xFFFF`. (The last one bundles with 6C-2
-      rather than 6C-1 because it is the asymmetric "exhaustion"
-      side of the rollback/exhaustion pair — shipping it alone
-      would leave a half-empty `local_epoch` posture future
-      readers would have to reason around.)
+      `local_epoch == 0xFFFF` (the exhaustion side of the
+      rollback/exhaustion pair — the rollback peer needs the writer
+      registry from Stage 7 and ships in 6C-3 instead).
+      `ErrUnsupportedFilesystem` startup probe (`ProbeSidecarFilesystem`)
+      writes + syncs + renames + dir-syncs a sentinel file in the
+      sidecar directory at startup so filesystem-capability failures
+      surface BEFORE the first encryption-relevant Raft entry, not
+      on the first `WriteSidecar` call hours into operation. Also
+      bundles the gemini-r3 medium `parseErr` annotation fix
+      deferred from PR #778.
+
+      `ErrSidecarBehindRaftLog` was originally listed under 6C-2 but
+      moved to **6C-2b** because it requires raftengine integration
+      to read the persisted applied-index. The encryption-package-
+      only scope of 6C-2 lets the simpler guards ship without the
+      raftengine plumbing churn.
+
+    * **6C-2b** — `ErrSidecarBehindRaftLog`. Plumbs the raftengine's
+      persisted applied-index into the startup-guard path and refuses
+      if the sidecar's `raft_applied_index` is behind by an interval
+      that covers any encryption-relevant entry (`isEncryptionRelevant`
+      predicate per §5.5: `rotate-dek`, `rewrap-deks`, `bootstrap-
+      encryption`, `enable-storage-envelope`, `enable-raft-envelope`,
+      `retire-dek`). The guard itself is a one-screen function; the
+      load-bearing scope is the cross-package plumbing.
 
     * **6C-3** — Membership-view guards. `ErrNodeIDCollision`
       requires a Voters ∪ Learners enumeration of every Raft
@@ -193,10 +211,11 @@ production-safe state, and unblocks the next one.
       `local_epoch` values to the §4.1 16-bit field. Bundles with
       Stage 6E's `enable-raft-envelope` admin RPC.
 
-  **Shipping order:** 6C-1 → 6C-2 → 6D (bundles 6C-3) → 6E
-  (bundles 6C-4). Stage 6D is unblocked once 6C-1 + 6C-2 ship;
-  it does not need to wait for the 6C-3/6C-4 work that bundles
-  into it.
+  **Shipping order:** 6C-1 → 6C-2 → 6C-2b → 6D (bundles 6C-3) →
+  6E (bundles 6C-4). Stage 6D is unblocked once 6C-1 + 6C-2 +
+  6C-2b have all shipped (the latter is the last raftengine-
+  integration piece any cutover RPC depends on); it does not need
+  to wait for the 6C-3/6C-4 work that bundles into it.
 
 - **6D and 6E are the actual cutovers** (Phase 1 = storage, Phase
   2 = raft). Each touches a different code path (§6.2 storage

--- a/internal/encryption/errors.go
+++ b/internal/encryption/errors.go
@@ -52,9 +52,21 @@ var (
 	// sidecar cannot guarantee crash-durability of os.Rename via
 	// fsync (typical on NFS, some FUSE mounts). Per §5.1 the
 	// encryption package refuses to start in that situation rather
-	// than silently degrading the durability guarantee. WriteSidecar
-	// wraps any fsync-on-directory failure with this sentinel so the
-	// Stage 5+ startup integration can errors.Is-match it.
+	// than silently degrading the durability guarantee. Two paths
+	// surface this sentinel:
+	//
+	//   - WriteSidecar wraps any fsync-on-directory failure on the
+	//     real keys.json write path. This catches the failure on the
+	//     first encryption-relevant write — which on a fresh cluster
+	//     may be hours into operation, well past the point where
+	//     catching the misconfiguration would have been cheap.
+	//
+	//   - ProbeSidecarFilesystem (Stage 6C-2) runs at process startup
+	//     and exercises the same write+rename+dir.Sync sequence on a
+	//     sentinel file, then deletes it. The probe surfaces the
+	//     failure BEFORE any encryption-relevant Raft entry commits,
+	//     so the operator gets the unambiguous startup-time refusal
+	//     rather than a halted apply loop later.
 	ErrUnsupportedFilesystem = errors.New("encryption: filesystem does not support durable directory sync (NFS, some FUSE mounts are unsupported)")
 
 	// ErrSidecarActiveKeyMissing indicates the Sidecar has a non-zero
@@ -142,4 +154,24 @@ var (
 	// --kekFile at the correct KEK file or restore the data dir
 	// from a backup that matches the supplied KEK.
 	ErrKEKMismatch = errors.New("encryption: configured KEK cannot unwrap one or more wrapped DEKs in the sidecar; refusing to start (verify --kekFile matches the KEK that bootstrapped this data dir)")
+
+	// ErrLocalEpochExhausted is the §9.1 startup-refusal guard
+	// raised when any active DEK in the sidecar has reached the
+	// uint16 saturation value (0xFFFF). The §4.1 nonce construction
+	// reserves only 16 bits for local_epoch, so a node that already
+	// emitted a nonce with local_epoch == 0xFFFF cannot safely
+	// emit another one under the same DEK without rolling the
+	// counter back to 0 and re-issuing a nonce that has already
+	// been used (GCM catastrophic — distinct plaintexts encrypted
+	// under the same (key, nonce) pair reveal plaintext XOR via
+	// the keystream). Recovery is a deliberate DEK rotation (§5.2)
+	// which retires the exhausted DEK; the next process startup
+	// then sees a fresh DEK with local_epoch=0 and can proceed.
+	//
+	// The check runs at process startup, before any apply or new
+	// write can reach the cipher; an active DEK with
+	// local_epoch==0xFFFF is a guaranteed-future nonce-reuse
+	// liability that must be rotated before the node is allowed
+	// to participate.
+	ErrLocalEpochExhausted = errors.New("encryption: active DEK has reached local_epoch=0xFFFF saturation; refusing to start (rotate the affected DEK via `encryption rotate-dek` before the next startup or risk GCM nonce reuse — see §4.1)")
 )

--- a/internal/encryption/startup.go
+++ b/internal/encryption/startup.go
@@ -92,14 +92,30 @@ type StartupConfig struct {
 //   - Snapshot cutover divergence, raft-envelope-without-bootstrap,
 //     RPC local_epoch range — Stage 6E (raft cutover) / 6C-4.
 //
-// The function reads the sidecar at most once and is safe to call
-// before any other encryption package state is constructed; it
-// does NOT mutate the on-disk sidecar. ProbeSidecarFilesystem
-// creates a sentinel file in the sidecar's parent directory and
-// removes it before returning, leaving the on-disk state
-// indistinguishable from before the call.
+// The function reads the sidecar AT MOST ONCE (cached across every
+// sidecar-reading guard) and is safe to call before any other
+// encryption package state is constructed; it does NOT mutate the
+// on-disk sidecar. ProbeSidecarFilesystem creates a sentinel file
+// in the sidecar's parent directory and removes it before returning,
+// leaving the on-disk state indistinguishable from before the call.
+//
+// The single-read invariant matters as new sidecar-reading guards
+// land in 6C-2b / 6C-3 / 6C-4: shipping each new guard with its
+// own ReadSidecar call would silently grow the startup IO from
+// O(1) to O(N guards), and a partial-write race between the
+// guards' reads is harder to reason about than a single snapshot
+// shared across all of them (claude r1 medium on PR #781).
 func CheckStartupGuards(cfg StartupConfig) error {
 	sidecarPresent, err := sidecarOnDisk(cfg.SidecarPath)
+	if err != nil {
+		return err
+	}
+
+	// Load the sidecar once for every guard that needs it. nil
+	// means "no sidecar to consult" — either the path is empty,
+	// the file is absent, or the guards that consume sidecar
+	// state were short-circuited before this point.
+	sc, err := loadSidecarForGuards(cfg, sidecarPresent)
 	if err != nil {
 		return err
 	}
@@ -110,16 +126,37 @@ func CheckStartupGuards(cfg StartupConfig) error {
 	if err := guardKEKRequired(cfg); err != nil {
 		return err
 	}
-	if err := guardKEKMatchesSidecar(cfg, sidecarPresent); err != nil {
+	if err := guardKEKMatchesSidecar(cfg, sc); err != nil {
 		return err
 	}
-	if err := guardLocalEpochExhausted(cfg, sidecarPresent); err != nil {
+	if err := guardLocalEpochExhausted(cfg, sc); err != nil {
 		return err
 	}
 	if err := guardFilesystemDurability(cfg); err != nil {
 		return err
 	}
 	return nil
+}
+
+// loadSidecarForGuards parses the sidecar exactly once iff at least
+// one downstream guard needs it. Returns (nil, nil) when no guard
+// will consume it (sidecar absent, encryption off, or KEK missing
+// — guardKEKMatchesSidecar would short-circuit anyway), avoiding
+// the unnecessary ReadSidecar I/O.
+func loadSidecarForGuards(cfg StartupConfig, sidecarPresent bool) (*Sidecar, error) {
+	if !sidecarPresent {
+		return nil, nil
+	}
+	if !cfg.EncryptionEnabled {
+		// guardSidecarWithoutFlag will fire first; the sidecar
+		// contents are irrelevant to the refusal.
+		return nil, nil
+	}
+	sc, err := ReadSidecar(cfg.SidecarPath)
+	if err != nil {
+		return nil, pkgerrors.Wrapf(err, "encryption: read sidecar %q for startup guards", cfg.SidecarPath)
+	}
+	return sc, nil
 }
 
 // sidecarOnDisk reports whether SidecarPath names an existing file.
@@ -189,13 +226,9 @@ func guardKEKRequired(cfg StartupConfig) error {
 //     was either acted on or, in tests, deliberately suppressed),
 //   - the sidecar exists but has no wrapped DEKs (e.g., a freshly
 //     created empty sidecar — bootstrap not yet committed).
-func guardKEKMatchesSidecar(cfg StartupConfig, sidecarPresent bool) error {
-	if !cfg.EncryptionEnabled || !sidecarPresent || cfg.KEK == nil {
+func guardKEKMatchesSidecar(cfg StartupConfig, sc *Sidecar) error {
+	if !cfg.EncryptionEnabled || sc == nil || cfg.KEK == nil {
 		return nil
-	}
-	sc, err := ReadSidecar(cfg.SidecarPath)
-	if err != nil {
-		return pkgerrors.Wrapf(err, "encryption: read sidecar %q for KEK-mismatch guard", cfg.SidecarPath)
 	}
 	keyIDs := sortedSidecarKeyIDs(sc.Keys)
 	for _, idStr := range keyIDs {
@@ -245,13 +278,9 @@ func guardKEKMatchesSidecar(cfg StartupConfig, sidecarPresent bool) error {
 // wrapped under a retired DEK does not consume a new nonce, so an
 // exhausted retired DEK is harmless. Only a DEK that the next write
 // would actually wrap a new nonce under matters here.
-func guardLocalEpochExhausted(cfg StartupConfig, sidecarPresent bool) error {
-	if !cfg.EncryptionEnabled || !sidecarPresent {
+func guardLocalEpochExhausted(cfg StartupConfig, sc *Sidecar) error {
+	if !cfg.EncryptionEnabled || sc == nil {
 		return nil
-	}
-	sc, err := ReadSidecar(cfg.SidecarPath)
-	if err != nil {
-		return pkgerrors.Wrapf(err, "encryption: read sidecar %q for local-epoch-exhaustion guard", cfg.SidecarPath)
 	}
 	if err := checkActiveDEKEpochSaturated(sc, SidecarPurposeStorage, sc.Active.Storage, cfg.SidecarPath); err != nil {
 		return err
@@ -343,9 +372,15 @@ func ProbeSidecarFilesystem(sidecarPath string) (retErr error) {
 	}
 	tmpPath := tmp.Name()
 	defer func() {
+		// Removes whichever file `tmpPath` currently names: either
+		// the original CreateTemp output (if we returned before the
+		// rename below) or the renamed .final sentinel (if we got
+		// past the rename). NOTE: stale .encryption-probe-*.final
+		// files left behind by a prior probe that crashed between
+		// the rename and the dir.Sync are NOT cleaned up here — they
+		// are operator-removable by the .encryption-probe- prefix
+		// (claude r1 nit on PR #781).
 		_ = os.Remove(tmpPath)
-		// If a previous probe left .encryption-probe-*.final around,
-		// it will be cleaned up by the rename step below.
 	}()
 
 	if _, err := tmp.Write([]byte("encryption-probe\n")); err != nil {

--- a/internal/encryption/startup.go
+++ b/internal/encryption/startup.go
@@ -140,16 +140,27 @@ func CheckStartupGuards(cfg StartupConfig) error {
 
 // loadSidecarForGuards parses the sidecar exactly once iff at least
 // one downstream guard needs it. Returns (nil, nil) when no guard
-// will consume it (sidecar absent, encryption off, or KEK missing
-// — guardKEKMatchesSidecar would short-circuit anyway), avoiding
-// the unnecessary ReadSidecar I/O.
+// will consume it:
+//
+//   - sidecar absent → no file to read
+//   - encryption off → guardSidecarWithoutFlag fires first;
+//     contents are irrelevant to the refusal
+//   - KEK not configured → guardKEKRequired fires before any
+//     sidecar-consuming guard, so the read would be wasted AND
+//     (more importantly) preserves the prior error precedence:
+//     a corrupt sidecar combined with a missing --kekFile must
+//     still surface as ErrKEKRequiredWithFlag (operator's primary
+//     misconfiguration) rather than a sidecar-read error
+//     (downstream symptom). Catches claude r2 + codex P2 on PR
+//     #781.
 func loadSidecarForGuards(cfg StartupConfig, sidecarPresent bool) (*Sidecar, error) {
 	if !sidecarPresent {
 		return nil, nil
 	}
 	if !cfg.EncryptionEnabled {
-		// guardSidecarWithoutFlag will fire first; the sidecar
-		// contents are irrelevant to the refusal.
+		return nil, nil
+	}
+	if !cfg.KEKConfigured {
 		return nil, nil
 	}
 	sc, err := ReadSidecar(cfg.SidecarPath)
@@ -360,7 +371,7 @@ func guardFilesystemDurability(cfg StartupConfig) error {
 //     guarantees it on the same filesystem); the failure mode this
 //     probe specifically catches is dir.Sync being a no-op or
 //     erroring out.
-func ProbeSidecarFilesystem(sidecarPath string) (retErr error) {
+func ProbeSidecarFilesystem(sidecarPath string) error {
 	dir := filepath.Dir(sidecarPath)
 	tmp, err := os.CreateTemp(dir, ".encryption-probe-*.tmp")
 	if err != nil {

--- a/internal/encryption/startup.go
+++ b/internal/encryption/startup.go
@@ -2,7 +2,9 @@ package encryption
 
 import (
 	"errors"
+	"math"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 
@@ -49,11 +51,11 @@ type StartupConfig struct {
 }
 
 // CheckStartupGuards runs the §9.1 startup-refusal guards covered
-// by Stage 6C-1 and returns the first guard that fires. nil means
-// every guard passed and the process is safe to proceed past startup
-// into buildShardGroups / Raft engine wiring.
+// by Stage 6C-1 + 6C-2 and returns the first guard that fires.
+// nil means every guard passed and the process is safe to proceed
+// past startup into buildShardGroups / Raft engine wiring.
 //
-// Scope (Stage 6C-1, this PR):
+// Scope (Stage 6C-1, PR #778):
 //
 //   - ErrSidecarPresentWithoutFlag: sidecar on disk but flag off
 //     (downgrade prevention)
@@ -62,30 +64,40 @@ type StartupConfig struct {
 //     one wrapped DEK fails to unwrap under the configured KEK
 //     (operator-error catch)
 //
-// Out of scope (deferred to later 6C sub-milestones / Stage 6D / 6E):
+// Scope (Stage 6C-2, this PR):
 //
-//   - ErrUnsupportedFilesystem startup probe (WriteSidecar already
-//     surfaces this on the first write; a dedicated startup probe
-//     can ship without re-architecting this helper).
-//   - ErrLocalEpochExhausted (active DEK local_epoch == 0xFFFF) —
-//     coupled with the writer-registry record (Stage 7); shipping
-//     the exhaustion check without the rollback peer would create
-//     an asymmetric posture that future readers would have to
-//     reason around.
+//   - ErrLocalEpochExhausted: any active DEK in the sidecar has
+//     reached local_epoch == 0xFFFF (would-be GCM nonce-reuse on
+//     the next encrypted write). Refuse to start until rotated.
+//   - ErrUnsupportedFilesystem: ProbeSidecarFilesystem exercises
+//     the §5.1 write+rename+dir.Sync sequence at startup so the
+//     filesystem incompatibility surfaces BEFORE the first
+//     encryption-relevant Raft entry, not on the first WriteSidecar
+//     call (which on a fresh node may be hours into operation).
+//
+// Out of scope (deferred to later sub-milestones / Stage 6D / 6E):
+//
 //   - ErrNodeIDCollision — requires the cluster-wide Voters ∪
 //     Learners membership view that Stage 6D's capability fan-out
 //     provides; node-local hashing cannot detect cross-node
-//     collisions on its own.
+//     collisions on its own. Bundled with Stage 6C-3 / 6D.
+//   - ErrLocalEpochRollback — needs the writer-registry record
+//     (Stage 7); the exhaustion peer ships here, the rollback peer
+//     ships once the registry is available. Bundled with Stage 6C-3.
 //   - ErrSidecarBehindRaftLog — requires raftengine integration
 //     (read the persisted applied index) which is the same data
 //     path Stage 6D / 6E touch for the cutover gate; bundled
-//     there.
+//     there. Deferred from 6C-2 to keep this PR focused on
+//     guards that need only the encryption package's own state.
 //   - Snapshot cutover divergence, raft-envelope-without-bootstrap,
-//     RPC local_epoch range — Stage 6E (raft cutover).
+//     RPC local_epoch range — Stage 6E (raft cutover) / 6C-4.
 //
 // The function reads the sidecar at most once and is safe to call
 // before any other encryption package state is constructed; it
-// does NOT mutate the on-disk sidecar.
+// does NOT mutate the on-disk sidecar. ProbeSidecarFilesystem
+// creates a sentinel file in the sidecar's parent directory and
+// removes it before returning, leaving the on-disk state
+// indistinguishable from before the call.
 func CheckStartupGuards(cfg StartupConfig) error {
 	sidecarPresent, err := sidecarOnDisk(cfg.SidecarPath)
 	if err != nil {
@@ -99,6 +111,12 @@ func CheckStartupGuards(cfg StartupConfig) error {
 		return err
 	}
 	if err := guardKEKMatchesSidecar(cfg, sidecarPresent); err != nil {
+		return err
+	}
+	if err := guardLocalEpochExhausted(cfg, sidecarPresent); err != nil {
+		return err
+	}
+	if err := guardFilesystemDurability(cfg); err != nil {
 		return err
 	}
 	return nil
@@ -190,14 +208,184 @@ func guardKEKMatchesSidecar(cfg StartupConfig, sidecarPresent bool) error {
 			if parseErr != nil {
 				// validateSidecar would have caught a non-decimal
 				// key_id, but be defensive in case ReadSidecar's
-				// invariant changes.
+				// invariant changes. Include parseErr so an
+				// operator triaging a manual-edit sidecar can see
+				// BOTH the unwrap failure and the malformed key_id
+				// (gemini medium on PR #778; deferred to 6C-2).
 				return pkgerrors.Wrapf(ErrKEKMismatch,
-					"sidecar=%q key_id=%q: %v", cfg.SidecarPath, idStr, err)
+					"sidecar=%q key_id=%q (parse error: %v): %v",
+					cfg.SidecarPath, idStr, parseErr, err)
 			}
 			return pkgerrors.Wrapf(ErrKEKMismatch,
 				"sidecar=%q key_id=%d purpose=%q: %v",
 				cfg.SidecarPath, id, k.Purpose, err)
 		}
+	}
+	return nil
+}
+
+// guardLocalEpochExhausted fires when any active DEK in the sidecar
+// has reached the uint16 saturation value (math.MaxUint16). §4.1
+// reserves 16 bits for local_epoch in the nonce; emitting one more
+// nonce under the same DEK would either roll the counter back to 0
+// (re-issuing a nonce already in use → GCM catastrophic) or saturate
+// at 0xFFFF (the same outcome on the next bump). The right recovery
+// is a deliberate DEK rotation (§5.2), which retires the exhausted
+// DEK and lets the next process startup proceed with a fresh
+// local_epoch=0 DEK.
+//
+// Why both Active.Storage and Active.Raft are checked: §4.1 nonce
+// construction is per-DEK; an exhausted storage DEK and a fresh raft
+// DEK can coexist in the sidecar after a rotation that only rotated
+// one purpose. The guard fires on either, identifying which purpose's
+// rotation the operator must run.
+//
+// Why only ACTIVE keys are checked: a retired DEK's local_epoch is
+// frozen at the value it had when retired; reading old envelopes
+// wrapped under a retired DEK does not consume a new nonce, so an
+// exhausted retired DEK is harmless. Only a DEK that the next write
+// would actually wrap a new nonce under matters here.
+func guardLocalEpochExhausted(cfg StartupConfig, sidecarPresent bool) error {
+	if !cfg.EncryptionEnabled || !sidecarPresent {
+		return nil
+	}
+	sc, err := ReadSidecar(cfg.SidecarPath)
+	if err != nil {
+		return pkgerrors.Wrapf(err, "encryption: read sidecar %q for local-epoch-exhaustion guard", cfg.SidecarPath)
+	}
+	if err := checkActiveDEKEpochSaturated(sc, SidecarPurposeStorage, sc.Active.Storage, cfg.SidecarPath); err != nil {
+		return err
+	}
+	if err := checkActiveDEKEpochSaturated(sc, SidecarPurposeRaft, sc.Active.Raft, cfg.SidecarPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+// checkActiveDEKEpochSaturated reports ErrLocalEpochExhausted iff
+// the active DEK for the given purpose has local_epoch ==
+// math.MaxUint16. A zero active id means "not bootstrapped for this
+// purpose" and is silently passed through.
+func checkActiveDEKEpochSaturated(sc *Sidecar, purpose string, activeID uint32, sidecarPath string) error {
+	if activeID == ReservedKeyID {
+		return nil
+	}
+	idStr := strconv.FormatUint(uint64(activeID), 10)
+	k, ok := sc.Keys[idStr]
+	if !ok {
+		// validateSidecar would have caught this in ReadSidecar
+		// via ErrSidecarActiveKeyMissing; defensive bail-out.
+		return nil
+	}
+	if k.LocalEpoch == math.MaxUint16 {
+		return pkgerrors.Wrapf(ErrLocalEpochExhausted,
+			"sidecar=%q purpose=%q active_key_id=%d local_epoch=0x%X (max=0x%X)",
+			sidecarPath, purpose, activeID, k.LocalEpoch, math.MaxUint16)
+	}
+	return nil
+}
+
+// guardFilesystemDurability runs the §5.1 write+rename+dir.Sync
+// probe on the sidecar's parent directory. It only fires when the
+// operator has supplied --encryptionSidecarPath (otherwise there
+// is no encryption directory whose durability we need to verify).
+// The check skips silently if encryption is off — a pre-rollout
+// cluster on NFS is no worse off than today (cleartext storage
+// has its own durability surface; this guard's scope is the
+// §5.1 sidecar specifically).
+func guardFilesystemDurability(cfg StartupConfig) error {
+	if !cfg.EncryptionEnabled || cfg.SidecarPath == "" {
+		return nil
+	}
+	return ProbeSidecarFilesystem(cfg.SidecarPath)
+}
+
+// ProbeSidecarFilesystem exercises the §5.1 crash-durable write
+// protocol against the parent directory of sidecarPath WITHOUT
+// disturbing an existing sidecar file. The probe writes a small
+// sentinel file, fsyncs it, renames it, dir.Syncs the parent
+// directory, and removes the sentinel. Any step that fails returns
+// the failure wrapped with ErrUnsupportedFilesystem so callers can
+// errors.Is-match it identically to the WriteSidecar path.
+//
+// The probe runs before any encryption-relevant Raft entry can
+// commit (CheckStartupGuards is called from main.go before
+// buildShardGroups). Detecting NFS or a FUSE mount whose dir.Sync
+// is a no-op at startup is dramatically cheaper than discovering
+// it days later when the first bootstrap proposal commits and the
+// sidecar write fails halfway through, leaving the cluster's
+// Raft-committed bootstrap entry without a durable on-disk DEK.
+//
+// Implementation notes:
+//   - The parent directory must exist; we do not mkdir it because
+//     the operator-supplied --encryptionSidecarPath is meant to
+//     name an EXISTING data directory. Missing parent is propagated
+//     as the underlying os.MkdirTemp error (NOT wrapped with
+//     ErrUnsupportedFilesystem — a missing dir is a config error,
+//     not a filesystem-capability problem).
+//   - The sentinel filename is prefixed with .encryption-probe- so
+//     a stale file left behind by an interrupted probe is easy to
+//     identify, and so it sorts away from the real keys.json in
+//     ls output.
+//   - We do not need to test atomicity of os.Rename (POSIX
+//     guarantees it on the same filesystem); the failure mode this
+//     probe specifically catches is dir.Sync being a no-op or
+//     erroring out.
+func ProbeSidecarFilesystem(sidecarPath string) (retErr error) {
+	dir := filepath.Dir(sidecarPath)
+	tmp, err := os.CreateTemp(dir, ".encryption-probe-*.tmp")
+	if err != nil {
+		// Missing dir / permission denied here is a config error,
+		// not a filesystem-capability problem. Propagate without
+		// the ErrUnsupportedFilesystem mark so operators see the
+		// real cause.
+		return pkgerrors.Wrapf(err, "encryption: probe sidecar dir %q for fsync support", dir)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = os.Remove(tmpPath)
+		// If a previous probe left .encryption-probe-*.final around,
+		// it will be cleaned up by the rename step below.
+	}()
+
+	if _, err := tmp.Write([]byte("encryption-probe\n")); err != nil {
+		_ = tmp.Close()
+		return pkgerrors.Wrap(err, "encryption: probe write")
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return pkgerrors.Wrapf(
+			pkgerrors.WithSecondaryError(ErrUnsupportedFilesystem, err),
+			"encryption: probe fsync %q", tmpPath)
+	}
+	if err := tmp.Close(); err != nil {
+		return pkgerrors.Wrapf(err, "encryption: probe close %q", tmpPath)
+	}
+
+	// Rename to a sibling and dir.Sync the parent — the same
+	// sequence WriteSidecar does. We rename to a distinct
+	// final-name so an existing .tmp-named keys.json.tmp on
+	// disk (from a prior crash) is not affected.
+	finalPath := filepath.Join(dir, filepath.Base(tmpPath)+".final")
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		return pkgerrors.Wrapf(err, "encryption: probe rename %q -> %q", tmpPath, finalPath)
+	}
+	// Re-point the deferred cleanup at the renamed file so we
+	// don't leave a sentinel on disk when the probe succeeds.
+	tmpPath = finalPath
+
+	parent, err := os.Open(dir) //nolint:gosec // dir comes from operator config
+	if err != nil {
+		return pkgerrors.Wrapf(err, "encryption: probe open dir %q", dir)
+	}
+	if err := parent.Sync(); err != nil {
+		_ = parent.Close()
+		return pkgerrors.Wrapf(
+			pkgerrors.WithSecondaryError(ErrUnsupportedFilesystem, err),
+			"encryption: probe dir.Sync %q", dir)
+	}
+	if err := parent.Close(); err != nil {
+		return pkgerrors.Wrapf(err, "encryption: probe dir.Close %q", dir)
 	}
 	return nil
 }

--- a/internal/encryption/startup_test.go
+++ b/internal/encryption/startup_test.go
@@ -548,6 +548,34 @@ func TestCheckStartupGuards_FilesystemProbe_RunsOnlyWhenEnabled(t *testing.T) {
 	}
 }
 
+// TestCheckStartupGuards_CorruptSidecarMissingKEK_RefusesWithKEKError
+// pins the claude-r2 / codex-P2 error-precedence guarantee: when
+// BOTH the sidecar is unreadable AND --kekFile is missing, the
+// operator MUST see ErrKEKRequiredWithFlag (their primary
+// misconfiguration), not a downstream sidecar-parse error. The
+// loadSidecarForGuards KEK-missing short-circuit is what enforces
+// this ordering; without it the sidecar would be read first and
+// the parse error would mask the missing-KEK condition.
+func TestCheckStartupGuards_CorruptSidecarMissingKEK_RefusesWithKEKError(t *testing.T) {
+	dir := t.TempDir()
+	// Write a malformed sidecar — version=0 fails the ReadSidecar
+	// validation. Any unreadable file would do; we use malformed
+	// rather than missing because os.Stat distinguishes the two
+	// and "missing" wouldn't reach the ReadSidecar path at all.
+	sidecarPath := filepath.Join(dir, encryption.SidecarFilename)
+	if err := os.WriteFile(sidecarPath, []byte(`{"version":0}`), 0o600); err != nil {
+		t.Fatalf("write malformed sidecar: %v", err)
+	}
+	err := encryption.CheckStartupGuards(encryption.StartupConfig{
+		EncryptionEnabled: true,
+		KEKConfigured:     false, // <-- the missing-KEK condition
+		SidecarPath:       sidecarPath,
+	})
+	if !errors.Is(err, encryption.ErrKEKRequiredWithFlag) {
+		t.Fatalf("missing-KEK MUST take precedence over sidecar-parse error; got %v", err)
+	}
+}
+
 // TestCheckStartupGuards_KEKMismatch_ParseErrIncluded pins the
 // gemini medium finding deferred from PR #778 r3: when ParseUint
 // fails in the defensive non-decimal-key_id branch, the

--- a/internal/encryption/startup_test.go
+++ b/internal/encryption/startup_test.go
@@ -368,3 +368,207 @@ func TestCheckStartupGuards_SidecarStatError(t *testing.T) {
 		t.Errorf("invalid path must NOT be silently treated as not-exist: %v", err)
 	}
 }
+
+// writeTestSidecarWithEpoch persists a §5.1 sidecar with the
+// supplied storage active DEK and a chosen local_epoch value. Used
+// by the local-epoch exhaustion tests to inject the saturated
+// value without going through a real rotation.
+func writeTestSidecarWithEpoch(t *testing.T, dir string, wrapped []byte, localEpoch uint16) string {
+	t.Helper()
+	sc := &encryption.Sidecar{
+		Version: encryption.SidecarVersion,
+		Keys: map[string]encryption.SidecarKey{
+			"1": {
+				Purpose:    encryption.SidecarPurposeStorage,
+				Wrapped:    wrapped,
+				Created:    "2026-05-17T00:00:00Z",
+				LocalEpoch: localEpoch,
+			},
+		},
+	}
+	sc.Active.Storage = 1
+	path := filepath.Join(dir, encryption.SidecarFilename)
+	if err := encryption.WriteSidecar(path, sc); err != nil {
+		t.Fatalf("WriteSidecar: %v", err)
+	}
+	return path
+}
+
+// TestCheckStartupGuards_LocalEpochExhausted_Storage pins the
+// Stage 6C-2 ErrLocalEpochExhausted guard. An active DEK with
+// local_epoch == 0xFFFF is one bump away from rolling back to 0
+// and re-issuing a nonce already in use under the same DEK —
+// the classic GCM catastrophic key-reuse pattern. Refuse to
+// start until the operator rotates.
+func TestCheckStartupGuards_LocalEpochExhausted_Storage(t *testing.T) {
+	dir := t.TempDir()
+	k := newTestKEK(t, dir, 0x42)
+	wrapped, err := k.Wrap(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+	sidecarPath := writeTestSidecarWithEpoch(t, dir, wrapped, 0xFFFF)
+	err = encryption.CheckStartupGuards(encryption.StartupConfig{
+		EncryptionEnabled: true,
+		KEKConfigured:     true,
+		KEK:               k,
+		SidecarPath:       sidecarPath,
+	})
+	if !errors.Is(err, encryption.ErrLocalEpochExhausted) {
+		t.Fatalf("expected ErrLocalEpochExhausted, got %v", err)
+	}
+	if got := err.Error(); !strings.Contains(got, "purpose=\"storage\"") {
+		t.Errorf("exhaustion error %q must annotate purpose=storage so the operator knows which DEK to rotate", got)
+	}
+}
+
+// TestCheckStartupGuards_LocalEpochExhausted_BoundaryNotFire
+// pins the saturation boundary: local_epoch == 0xFFFE MUST pass
+// (one nonce still available), 0xFFFF MUST fire. A bug that uses
+// >= 0xFFFE instead of == 0xFFFF would refuse a perfectly safe
+// DEK and force a spurious rotation.
+func TestCheckStartupGuards_LocalEpochExhausted_BoundaryNotFire(t *testing.T) {
+	dir := t.TempDir()
+	k := newTestKEK(t, dir, 0x42)
+	wrapped, err := k.Wrap(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("Wrap: %v", err)
+	}
+	sidecarPath := writeTestSidecarWithEpoch(t, dir, wrapped, 0xFFFE)
+	err = encryption.CheckStartupGuards(encryption.StartupConfig{
+		EncryptionEnabled: true,
+		KEKConfigured:     true,
+		KEK:               k,
+		SidecarPath:       sidecarPath,
+	})
+	if errors.Is(err, encryption.ErrLocalEpochExhausted) {
+		t.Fatalf("local_epoch=0xFFFE must NOT fire exhaustion guard (one nonce still available), got %v", err)
+	}
+	if err != nil {
+		t.Fatalf("local_epoch=0xFFFE must pass cleanly, got %v", err)
+	}
+}
+
+// TestCheckStartupGuards_LocalEpochExhausted_RetiredKeyIgnored
+// verifies the guard only inspects ACTIVE DEKs. A retired DEK
+// (active id points elsewhere) with local_epoch=0xFFFF is harmless
+// — no new write will allocate a nonce under it.
+func TestCheckStartupGuards_LocalEpochExhausted_RetiredKeyIgnored(t *testing.T) {
+	dir := t.TempDir()
+	k := newTestKEK(t, dir, 0x42)
+	wrappedFresh, err := k.Wrap(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("Wrap fresh: %v", err)
+	}
+	wrappedRetired, err := k.Wrap(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("Wrap retired: %v", err)
+	}
+	// Build a sidecar where the active storage points at key_id=2
+	// (fresh, local_epoch=0) and the retired DEK at key_id=1 has
+	// local_epoch=0xFFFF. The guard must not fire.
+	sc := &encryption.Sidecar{
+		Version: encryption.SidecarVersion,
+		Keys: map[string]encryption.SidecarKey{
+			"1": {Purpose: encryption.SidecarPurposeStorage, Wrapped: wrappedRetired, Created: "2026-05-17T00:00:00Z", LocalEpoch: 0xFFFF},
+			"2": {Purpose: encryption.SidecarPurposeStorage, Wrapped: wrappedFresh, Created: "2026-05-17T00:00:00Z", LocalEpoch: 0},
+		},
+	}
+	sc.Active.Storage = 2
+	sidecarPath := filepath.Join(dir, encryption.SidecarFilename)
+	if err := encryption.WriteSidecar(sidecarPath, sc); err != nil {
+		t.Fatalf("WriteSidecar: %v", err)
+	}
+	err = encryption.CheckStartupGuards(encryption.StartupConfig{
+		EncryptionEnabled: true,
+		KEKConfigured:     true,
+		KEK:               k,
+		SidecarPath:       sidecarPath,
+	})
+	if err != nil {
+		t.Fatalf("retired DEK with exhausted local_epoch must NOT fire guard, got %v", err)
+	}
+}
+
+// TestProbeSidecarFilesystem_OK exercises the happy path: a tmp
+// directory on the host filesystem supports the write+rename+dir.Sync
+// sequence the §5.1 protocol requires, so the probe returns nil
+// and leaves no sentinel file behind.
+func TestProbeSidecarFilesystem_OK(t *testing.T) {
+	dir := t.TempDir()
+	sidecarPath := filepath.Join(dir, "keys.json")
+	if err := encryption.ProbeSidecarFilesystem(sidecarPath); err != nil {
+		t.Fatalf("probe on tmp dir must succeed, got %v", err)
+	}
+	// Probe must leave no sentinel files behind on success.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".encryption-probe-") {
+			t.Errorf("probe left behind a sentinel file on success: %s", e.Name())
+		}
+	}
+}
+
+// TestProbeSidecarFilesystem_MissingDir verifies that a missing
+// parent directory propagates as a real OS error (not wrapped with
+// ErrUnsupportedFilesystem). The two failure classes are distinct:
+// missing dir is a config error the operator must fix; filesystem
+// no-fsync is an environment problem that needs a different mount.
+func TestProbeSidecarFilesystem_MissingDir(t *testing.T) {
+	err := encryption.ProbeSidecarFilesystem("/nonexistent/elastickv-probe/keys.json")
+	if err == nil {
+		t.Fatal("expected error for missing parent directory")
+	}
+	if errors.Is(err, encryption.ErrUnsupportedFilesystem) {
+		t.Errorf("missing dir must NOT be classified as ErrUnsupportedFilesystem (config error vs FS-capability): %v", err)
+	}
+}
+
+// TestCheckStartupGuards_FilesystemProbe_RunsOnlyWhenEnabled
+// verifies that the filesystem probe is gated on
+// --encryption-enabled. A cluster that has NOT opted into the
+// §7.1 rollout has no encryption-relevant write to worry about
+// crash-durability for, so a non-fsync filesystem in the
+// sidecar dir is irrelevant — the probe must skip silently.
+func TestCheckStartupGuards_FilesystemProbe_RunsOnlyWhenEnabled(t *testing.T) {
+	// SidecarPath set, EncryptionEnabled=false → probe should
+	// not run (and even if it did, we'd hit the missing-dir
+	// branch rather than ErrUnsupportedFilesystem). Use a path
+	// whose parent does NOT exist to make any probe attempt
+	// fail loudly.
+	err := encryption.CheckStartupGuards(encryption.StartupConfig{
+		EncryptionEnabled: false,
+		SidecarPath:       "/nonexistent/elastickv-probe-disabled/keys.json",
+	})
+	if err != nil {
+		t.Fatalf("filesystem probe must skip when --encryption-enabled is off, got %v", err)
+	}
+}
+
+// TestCheckStartupGuards_KEKMismatch_ParseErrIncluded pins the
+// gemini medium finding deferred from PR #778 r3: when ParseUint
+// fails in the defensive non-decimal-key_id branch, the
+// ErrKEKMismatch annotation MUST include parseErr so an operator
+// triaging a manually-edited sidecar can see BOTH the unwrap
+// failure and the malformed key_id reason. validateSidecar
+// normally rejects non-decimal keys at ReadSidecar time, so this
+// branch is defensive-only; we cannot trigger it through the
+// public API without bypassing validation. The assertion here
+// pins the format string of the parseErr-included path.
+func TestCheckStartupGuards_KEKMismatch_ParseErrIncluded(t *testing.T) {
+	// Sanity: the format string from startup.go must reference
+	// "parse error:" in the parseErr-included branch. Grepping
+	// the package source rather than executing the unreachable
+	// branch keeps the test deterministic without forcing us
+	// to inject invalid sidecars.
+	src, err := os.ReadFile("startup.go")
+	if err != nil {
+		t.Fatalf("ReadFile startup.go: %v", err)
+	}
+	if !strings.Contains(string(src), `"sidecar=%q key_id=%q (parse error: %v): %v"`) {
+		t.Error("ErrKEKMismatch parseErr-included format string missing — gemini r3 medium regression")
+	}
+}


### PR DESCRIPTION
## Summary

Stage 6C-2 per the [PR #762 plan](https://github.com/bootjp/elastickv/pull/762) and the 6C-1 → 6C-4 sub-decomposition landed in [PR #778](https://github.com/bootjp/elastickv/pull/778).

Ships the **process-local subset** of the §9.1 startup-refusal guards — those that read only the encryption package's own state and don't need raftengine integration. The remaining `ErrSidecarBehindRaftLog` guard (which needs the raftengine's persisted applied-index) is split into a new **6C-2b** sub-milestone for a dedicated follow-up PR.

Also bundles the gemini-r3 medium parseErr-annotation fix deferred from PR #778.

## What this PR ships

### Two new §9.1 startup-refusal guards

| Sentinel | Catches |
|---|---|
| `ErrLocalEpochExhausted` | Active DEK has `local_epoch == 0xFFFF` — one bump from GCM nonce reuse. Refuses to start until rotated. |
| `ErrUnsupportedFilesystem` (via new `ProbeSidecarFilesystem`) | Filesystem doesn't actually honor `dir.Sync` (NFS, some FUSE). Surfaces BEFORE the first encryption-relevant Raft entry, not on first `WriteSidecar` call hours into operation. |

### Gemini r3 medium fix (deferred from PR #778)

`ErrKEKMismatch`'s defensive non-decimal-`key_id` branch now includes `parseErr` alongside the unwrap error in the annotation. An operator triaging a manually-edited sidecar can see BOTH the unwrap failure AND the malformed `key_id` reason in a single log line.

### New exported helper

```go
func ProbeSidecarFilesystem(sidecarPath string) error
```

Exercises the §5.1 `write + fsync + rename + dir.Sync` sequence on a sentinel file in the sidecar's parent directory, then removes it. Side-effect-free on success. Returns `ErrUnsupportedFilesystem`-wrapped on any fsync/dir.Sync failure (matching the existing `WriteSidecar` path so `errors.Is` works identically across both).

### Guard ordering in `CheckStartupGuards`

```
1. guardSidecarWithoutFlag       (6C-1, downgrade prevention)
2. guardKEKRequired              (6C-1, fail-fast)
3. guardKEKMatchesSidecar        (6C-1, wrong-KEK catch)
4. guardLocalEpochExhausted      (6C-2, GCM nonce-reuse prevention) ←NEW
5. guardFilesystemDurability     (6C-2, NFS/FUSE catch)             ←NEW
```

Each step refuses on the most specific failure first, so the operator's log line points at the actual cause rather than a downstream symptom.

## Design doc updates

- **6C-1** row marked shipped (PR #778)
- **6C-2** row rewritten to reflect the process-local-only scope of this PR
- **6C-2b** row added — `ErrSidecarBehindRaftLog` is split out because it needs raftengine integration (outside the encryption package boundary)
- Rationale section updated with the 6C-2 / 6C-2b split + shipping order

## Why split `ErrSidecarBehindRaftLog` into 6C-2b

It needs the raftengine's persisted applied-index, which requires plumbing the engine into the startup-guard path. That's load-bearing cross-package work distinct from the encryption-package-only guards in this PR. Keeping them in separate PRs lets reviewers focus on one concern at a time and gets the simpler guards shipped sooner.

## Caller audit

- No public function signatures changed.
- `CheckStartupGuards` gains two new internal guard calls; the `StartupConfig` input shape is unchanged.
- `ProbeSidecarFilesystem` is new and has no existing callers.
- `ErrKEKMismatch` format-string gains a `(parse error: %v)` segment in the defensive branch only — annotation-only change, callers that only inspect `errors.Is(err, ErrKEKMismatch)` see no behavior change.

## Five-lens self-review

1. **Data loss** — net-positive. `ErrLocalEpochExhausted` prevents GCM nonce reuse (reveals plaintext XOR via the keystream). The filesystem probe catches a misconfiguration that would silently degrade the §5.1 crash-durability guarantee. Both run before any encryption-relevant Raft entry can commit.
2. **Concurrency / distributed failures** — both guards run at process startup before any goroutine fan-out. `ProbeSidecarFilesystem` uses `os.CreateTemp + os.Rename + dir.Sync`, all process-local. No shared state.
3. **Performance** — single sidecar read + single tmpfile sync/rename/sync per process start. Zero hot-path impact. Probe is gated on `--encryption-enabled`.
4. **Data consistency** — `ErrLocalEpochExhausted` catches the most severe nonce-reuse failure mode in the §4.1 set. The filesystem probe ensures that when `WriteSidecar` IS called later, `dir.Sync`'s durability guarantee is real.
5. **Test coverage** — 7 new tests cover the boundary (`0xFFFE` pass / `0xFFFF` fire), retired-key skip, probe-OK, probe-missing-dir, gate-off skip, and the deferred parseErr fix. All run with `-race`.

## Test plan

- [x] `go test -race -timeout=120s ./internal/encryption/... .` — PASS
- [x] `go build ./...` — PASS
- [x] `golangci-lint run ./internal/encryption/...` — 0 issues
- [ ] Full Jepsen suite — not run; no envelope cutover happens until Stage 6D and this PR only adds startup refusal logic that runs before any encryption-relevant Raft entry

## Plan

Per the design doc updates in this PR, next sub-milestones:
- **6C-2b** — `ErrSidecarBehindRaftLog` (needs raftengine integration)
- **6C-3** — `ErrNodeIDCollision` + `ErrLocalEpochRollback` (bundles with Stage 6D capability fan-out)
- **6D** — `enable-storage-envelope` admin RPC + §7.1 Phase-1 cutover (unblocked once 6C-2b lands)
