### PR TITLE
feat(encryption): Stage 6C-2b — ErrSidecarBehindRaftLog guard primitive (encryption-side)

### DIFF
--- a/docs/design/2026_04_29_partial_data_at_rest_encryption.md
+++ b/docs/design/2026_04_29_partial_data_at_rest_encryption.md
@@ -22,7 +22,8 @@ Date: 2026-04-29
 | 6B | §6.5 KEK plumbing — `--kekFile` / `--kekUri` flags + `internal/encryption/kek` selection at startup + thread `KEKUnwrapper` into the applier so `ApplyBootstrap` / `ApplyRotation` actually KEK-unwrap (replaces the 6A `ErrKEKNotConfigured` stubs) + introduce `--encryption-enabled` flag (default off) + re-enable mutating-RPC wiring in `registerEncryptionAdminServer` gated on (`--encryption-enabled` AND `KEKConfigured()`) | open | — |
 | 6C-1 | Subset of §9.1 startup refusal guards that depend only on flags + sidecar state: sidecar present without `--encryption-enabled` (`ErrSidecarPresentWithoutFlag`, downgrade prevention), `--encryption-enabled` without `--kekFile` (`ErrKEKRequiredWithFlag`, fail-fast), KEK loaded but sidecar wrapped DEKs do not unwrap (`ErrKEKMismatch`, operator-error catch). `internal/encryption/startup.go`'s `CheckStartupGuards` runs once in `main.go run()` before `buildShardGroups`. | shipped | PR #778 |
 | 6C-2 | Process-local §9.1 guards that read only the encryption package's own state: `ErrLocalEpochExhausted` (any active DEK with `local_epoch == 0xFFFF` — refuses to start until rotated, preventing GCM nonce reuse on the next write), `ErrUnsupportedFilesystem` startup probe (`ProbeSidecarFilesystem` exercises the §5.1 write+rename+dir.Sync sequence on a sentinel file in the sidecar directory at startup so filesystem-capability failures surface BEFORE the first encryption-relevant Raft entry, not on the first WriteSidecar call hours into operation). Also includes the gemini-r3 medium parseErr-annotation fix deferred from PR #778 (`ErrKEKMismatch` now wraps both `parseErr` and the unwrap error when the defensive non-decimal-key_id branch fires). The asymmetric `ErrLocalEpochRollback` peer is split into 6C-3 because it requires the writer-registry record (Stage 7). The `ErrSidecarBehindRaftLog` guard moves to 6C-2b because it requires raftengine integration — outside the encryption package boundary. | open | — |
-| 6C-2b | `ErrSidecarBehindRaftLog` startup guard — reads the persisted applied-index from raftengine and refuses if the sidecar's `raft_applied_index` is behind by an interval covering any encryption-relevant Raft entry (`isEncryptionRelevant` predicate per §5.5). Plumbing raftengine into the startup-guard path is the load-bearing scope here; the guard itself is a one-screen function. | open | — |
+| 6C-2b | `ErrSidecarBehindRaftLog` guard PRIMITIVE — encryption-side sentinel, `IsEncryptionRelevantOpcode` predicate (§5.5), `EncryptionRelevantScanner` cross-package interface, and `GuardSidecarBehindRaftLog` pure-function guard that takes both indices + a scanner callback. Tests use a fake scanner to exercise every branch (caught-up / gap-not-covered / gap-covered / scanner-error / nil-scanner-fails-closed). Wires nothing into main.go; the raftengine-side implementation lands in 6C-2c. | shipped-in-this-PR | this PR |
+| 6C-2c | Raftengine implementation of `EncryptionRelevantScanner` (WAL-based scan of Raft entries in the supplied index range against the §5.5 predicate) + `main.go` startup-guard phase that runs after `buildShardGroups` for each shard with encryption enabled, before any gRPC server starts serving. Inherits the encryption-side primitive from 6C-2b. | open | — |
 | 6C-3 | Cluster-wide §9.1 guards that require the Voters ∪ Learners membership view: `ErrNodeIDCollision` (two members hash to the same 16-bit `node_id`), `ErrLocalEpochRollback` (sidecar `local_epoch` ≤ writer-registry record). Naturally bundles with the Stage 6D capability fan-out which already needs that membership view. | open | — |
 | 6C-4 | Phase-2-specific §9.1 guards: `ErrEnvelopeCutoverDivergence` (sidecar `raft_envelope_cutover_index` disagrees with snapshot header), `ErrEncryptionNotBootstrapped` (`enable-raft-envelope` before bootstrap), `ErrLocalEpochOutOfRange` on the wire side of `GetCapability` / `GetSidecarState`. Bundles with Stage 6E (`enable-raft-envelope` admin RPC + Phase-2 cutover). | open | — |
 | 6D | §6.6 `enable-storage-envelope` admin RPC + §7.1 Phase-1 storage cutover (§6.2 toggle ON) + Voters ∪ Learners capability gate (depends on 6B for mutator wiring AND 6C-1+6C-2 for §9.1 startup-refusal guards; bundles 6C-3 for the membership-view-dependent collision check — see rationale) | open | — |
@@ -186,14 +187,31 @@ production-safe state, and unblocks the next one.
       only scope of 6C-2 lets the simpler guards ship without the
       raftengine plumbing churn.
 
-    * **6C-2b** — `ErrSidecarBehindRaftLog`. Plumbs the raftengine's
-      persisted applied-index into the startup-guard path and refuses
-      if the sidecar's `raft_applied_index` is behind by an interval
-      that covers any encryption-relevant entry (`isEncryptionRelevant`
-      predicate per §5.5: `rotate-dek`, `rewrap-deks`, `bootstrap-
-      encryption`, `enable-storage-envelope`, `enable-raft-envelope`,
-      `retire-dek`). The guard itself is a one-screen function; the
-      load-bearing scope is the cross-package plumbing.
+    * **6C-2b** — `ErrSidecarBehindRaftLog` PRIMITIVE (encryption
+      package only). Adds the `ErrSidecarBehindRaftLog` sentinel,
+      `IsEncryptionRelevantOpcode` predicate (§5.5: bytes 0x03
+      through `OpEncryptionMax` 0x07), `EncryptionRelevantScanner`
+      cross-package interface, and `GuardSidecarBehindRaftLog`
+      pure-function guard. The encryption package owns the predicate
+      and the refusal logic; the raftengine implements the scanner
+      in 6C-2c. Splitting the primitive from the integration lets
+      Stage 6D-and-later code paths that need the predicate (e.g.,
+      the §7.1 capability fan-out's gap-coverage check) depend
+      ONLY on the encryption package without waiting on the
+      raftengine-side scan helper.
+
+    * **6C-2c** — Raftengine implementation of the
+      `EncryptionRelevantScanner` interface defined in 6C-2b. Walks
+      the WAL across the supplied entry-index range, decodes each
+      entry's opcode byte, and applies the §5.5 predicate. Wires
+      a new startup-guard phase into `main.go` that runs AFTER
+      `buildShardGroups` returns and each shard's engine has opened,
+      but BEFORE any gRPC server starts serving — a different
+      lifecycle phase from the existing 6C-1 / 6C-2 guards (which
+      run before engine startup). For each shard with encryption
+      enabled, the phase calls `GuardSidecarBehindRaftLog` with the
+      shard's engine `AppliedIndex()` and a scanner backed by the
+      engine's WAL.
 
     * **6C-3** — Membership-view guards. `ErrNodeIDCollision`
       requires a Voters ∪ Learners enumeration of every Raft
@@ -211,11 +229,13 @@ production-safe state, and unblocks the next one.
       `local_epoch` values to the §4.1 16-bit field. Bundles with
       Stage 6E's `enable-raft-envelope` admin RPC.
 
-  **Shipping order:** 6C-1 → 6C-2 → 6C-2b → 6D (bundles 6C-3) →
-  6E (bundles 6C-4). Stage 6D is unblocked once 6C-1 + 6C-2 +
-  6C-2b have all shipped (the latter is the last raftengine-
-  integration piece any cutover RPC depends on); it does not need
-  to wait for the 6C-3/6C-4 work that bundles into it.
+  **Shipping order:** 6C-1 → 6C-2 → 6C-2b (primitive) → 6C-2c
+  (raftengine implementation + main.go wiring) → 6D (bundles
+  6C-3) → 6E (bundles 6C-4). Stage 6D is unblocked once 6C-1
+  + 6C-2 + 6C-2b + 6C-2c have all shipped (the latter pair
+  is the load-bearing `ErrSidecarBehindRaftLog` work); 6D
+  does not need to wait for the 6C-3/6C-4 work that bundles
+  into it.
 
 - **6D and 6E are the actual cutovers** (Phase 1 = storage, Phase
   2 = raft). Each touches a different code path (§6.2 storage

--- a/internal/encryption/audit.go
+++ b/internal/encryption/audit.go
@@ -1,0 +1,105 @@
+package encryption
+
+import (
+	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
+	pkgerrors "github.com/cockroachdb/errors"
+)
+
+// IsEncryptionRelevantOpcode reports whether the supplied FSM
+// opcode byte is one of the §5.5 encryption-relevant opcodes:
+// 0x03 OpRegistration, 0x04 OpBootstrap, 0x05 OpRotation, and
+// the reserved 0x06 / 0x07 slots in the fsmwire OpEncryption
+// range. The byte is the first non-version byte of the FSM
+// payload (after the 0x01 wire-version prefix).
+//
+// The predicate is the §9.1 ErrSidecarBehindRaftLog guard's
+// gap-coverage check: an unapplied entry in the sidecar/engine
+// gap matters iff its opcode is in this range. Non-encryption-
+// relevant entries (writes, transactions, control-plane RPCs)
+// in the gap do not affect the encryption sidecar and are
+// safe to ignore.
+//
+// Defined here (rather than in fsmwire) so the encryption
+// package owns its semantic-level predicate; the fsmwire
+// package owns the wire-level constants (OpEncryptionMin /
+// OpEncryptionMax) that this function reads.
+func IsEncryptionRelevantOpcode(opcode byte) bool {
+	return opcode >= fsmwire.OpEncryptionMin && opcode <= fsmwire.OpEncryptionMax
+}
+
+// EncryptionRelevantScanner is the cross-package contract that
+// GuardSidecarBehindRaftLog uses to inspect a Raft entry-index
+// range for encryption-relevant opcodes WITHOUT importing the
+// raftengine into the encryption package.
+//
+// The raftengine implements this in a follow-up PR (Stage 6C-2c)
+// against its WAL + applied-snapshot state, exposing only the
+// predicate result. Shipping the encryption-side primitive here
+// without the engine-side implementation is intentional: it lets
+// Stage 6D-and-later RPC handlers reuse the same predicate
+// (`IsEncryptionRelevantOpcode`) without depending on raftengine
+// having shipped its scanner first.
+//
+// HasEncryptionRelevantEntryInRange returns true iff at least
+// one Raft entry with index in [startExclusive+1, endInclusive]
+// carries a §5.5-relevant opcode. The startExclusive parameter
+// is the sidecar's last-applied index (which has already been
+// reflected in the sidecar), so the entry AT that index is NOT
+// in the gap; the entries that follow it are.
+//
+// Implementations must handle the empty-range case
+// (startExclusive >= endInclusive) by returning (false, nil)
+// — the guard precomputes the gap-non-empty branch and only
+// calls scan when there's actually a range to inspect, but
+// defensive implementations are safer in the face of caller bugs.
+type EncryptionRelevantScanner interface {
+	HasEncryptionRelevantEntryInRange(startExclusive, endInclusive uint64) (bool, error)
+}
+
+// GuardSidecarBehindRaftLog implements the §9.1
+// ErrSidecarBehindRaftLog refusal logic as a pure function: it
+// reads no I/O and depends on nothing beyond the supplied indices
+// and the caller-provided scanner.
+//
+// The contract:
+//
+//  1. If sidecarAppliedIdx >= engineAppliedIdx, the sidecar is
+//     caught up (or ahead, which would itself be a bug — but
+//     this guard's scope is "behind", not "ahead"). Return nil.
+//  2. If the gap is non-empty, ask the scanner whether any entry
+//     in (sidecarAppliedIdx, engineAppliedIdx] is encryption-
+//     relevant. If yes, fire ErrSidecarBehindRaftLog. If no, the
+//     gap is harmless and we return nil.
+//  3. Propagate any scanner I/O error wrapped with context but
+//     NOT marked as ErrSidecarBehindRaftLog — scanner failure is
+//     a different operator problem than the gap-coverage refusal.
+//
+// The function does not consult flags or encryption state; it is
+// the caller's responsibility to skip the call when
+// --encryption-enabled is off (the gap is irrelevant in that
+// case) or when the engine hasn't yet been opened (no applied
+// index to compare against).
+func GuardSidecarBehindRaftLog(sidecarAppliedIdx, engineAppliedIdx uint64, scanner EncryptionRelevantScanner) error {
+	if sidecarAppliedIdx >= engineAppliedIdx {
+		return nil
+	}
+	if scanner == nil {
+		// A nil scanner cannot inspect the gap, so we cannot
+		// safely advance past it. Fail closed.
+		return pkgerrors.Wrapf(ErrSidecarBehindRaftLog,
+			"sidecar_applied_index=%d engine_applied_index=%d (no scanner provided to inspect gap)",
+			sidecarAppliedIdx, engineAppliedIdx)
+	}
+	hit, err := scanner.HasEncryptionRelevantEntryInRange(sidecarAppliedIdx, engineAppliedIdx)
+	if err != nil {
+		return pkgerrors.Wrapf(err,
+			"encryption: scan raft entries (%d, %d] for encryption-relevant opcodes",
+			sidecarAppliedIdx, engineAppliedIdx)
+	}
+	if !hit {
+		return nil
+	}
+	return pkgerrors.Wrapf(ErrSidecarBehindRaftLog,
+		"sidecar_applied_index=%d engine_applied_index=%d gap_covers_encryption_relevant_entry",
+		sidecarAppliedIdx, engineAppliedIdx)
+}

--- a/internal/encryption/audit.go
+++ b/internal/encryption/audit.go
@@ -20,8 +20,7 @@ import (
 // that misreads the layout and inspects payload bytes (e.g., a
 // rotation sub-tag at position 1+) would return false negatives,
 // silently letting GuardSidecarBehindRaftLog miss encryption-
-// relevant gaps and start with a stale sidecar (codex P2 on PR
-// #782 caught this docstring inversion).
+// relevant gaps and start with a stale sidecar.
 //
 // The predicate is the §9.1 ErrSidecarBehindRaftLog guard's
 // gap-coverage check: an unapplied entry in the sidecar/engine

--- a/internal/encryption/audit.go
+++ b/internal/encryption/audit.go
@@ -9,15 +9,26 @@ import (
 // opcode byte is one of the §5.5 encryption-relevant opcodes:
 // 0x03 OpRegistration, 0x04 OpBootstrap, 0x05 OpRotation, and
 // the reserved 0x06 / 0x07 slots in the fsmwire OpEncryption
-// range. The byte is the first non-version byte of the FSM
-// payload (after the 0x01 wire-version prefix).
+// range.
+//
+// IMPORTANT — wire-format contract: the opcode byte is `data[0]`
+// of the FSM entry payload (the LEADING opcode tag), NOT the
+// byte after a wire-version prefix. See kv/fsm_encryption.go
+// which dispatches via `wireBytes[0]` and the EncodeBootstrap /
+// EncodeRotation / EncodeRegistration helpers in fsmwire/wire.go
+// which produce `[opcode, version=0x01, ...payload]`. A scanner
+// that misreads the layout and inspects payload bytes (e.g., a
+// rotation sub-tag at position 1+) would return false negatives,
+// silently letting GuardSidecarBehindRaftLog miss encryption-
+// relevant gaps and start with a stale sidecar (codex P2 on PR
+// #782 caught this docstring inversion).
 //
 // The predicate is the §9.1 ErrSidecarBehindRaftLog guard's
 // gap-coverage check: an unapplied entry in the sidecar/engine
-// gap matters iff its opcode is in this range. Non-encryption-
+// gap matters iff its `data[0]` is in this range. Non-encryption-
 // relevant entries (writes, transactions, control-plane RPCs)
-// in the gap do not affect the encryption sidecar and are
-// safe to ignore.
+// in the gap do not affect the encryption sidecar and are safe
+// to ignore.
 //
 // Defined here (rather than in fsmwire) so the encryption
 // package owns its semantic-level predicate; the fsmwire

--- a/internal/encryption/audit.go
+++ b/internal/encryption/audit.go
@@ -6,10 +6,31 @@ import (
 )
 
 // IsEncryptionRelevantOpcode reports whether the supplied FSM
-// opcode byte is one of the §5.5 encryption-relevant opcodes:
-// 0x03 OpRegistration, 0x04 OpBootstrap, 0x05 OpRotation, and
-// the reserved 0x06 / 0x07 slots in the fsmwire OpEncryption
-// range.
+// opcode byte is one of the §5.5 SIDECAR-MUTATING opcodes —
+// the set of entry types whose apply path writes the §5.1
+// keys.json sidecar and therefore matters for the
+// ErrSidecarBehindRaftLog gap-coverage check:
+//
+//   - 0x04 OpBootstrap         (bootstrap-encryption — §5.6)
+//   - 0x05 OpRotation          (rotate-dek + future sub-tags
+//     rewrap-deks / retire-dek / enable-storage-envelope /
+//     enable-raft-envelope — §5.2 + §7.1)
+//   - 0x06 / 0x07              (reserved slots in the fsmwire
+//     OpEncryption range for Stage 6E wire extensions; whether
+//     they end up sidecar-mutating is design-stage-defined,
+//     but conservatively treating them as relevant matches the
+//     §5.5 enumeration and forces a future ABI extension to be
+//     explicit about adding a NOT-relevant opcode).
+//
+// IMPORTANT — 0x03 OpRegistration is EXCLUDED. ApplyRegistration
+// in internal/encryption/applier.go only mutates writer-registry
+// rows via SetRegistryRow; it never calls WriteSidecar. Treating
+// it as sidecar-relevant would fire ErrSidecarBehindRaftLog on
+// EVERY startup after the first registration, since the sidecar's
+// raft_applied_index is not advanced by registration applies.
+// The design's §5.5 enumeration matches this exclusion (rotate-
+// dek, rewrap-deks, bootstrap-encryption, enable-storage-envelope,
+// enable-raft-envelope, retire-dek — no register-writer).
 //
 // IMPORTANT — wire-format contract: the opcode byte is `data[0]`
 // of the FSM entry payload (the LEADING opcode tag), NOT the
@@ -24,17 +45,17 @@ import (
 //
 // The predicate is the §9.1 ErrSidecarBehindRaftLog guard's
 // gap-coverage check: an unapplied entry in the sidecar/engine
-// gap matters iff its `data[0]` is in this range. Non-encryption-
-// relevant entries (writes, transactions, control-plane RPCs)
-// in the gap do not affect the encryption sidecar and are safe
-// to ignore.
+// gap matters iff its `data[0]` is in this range. Non-sidecar-
+// mutating entries (writes, transactions, control-plane RPCs,
+// AND OpRegistration) in the gap do not affect the encryption
+// sidecar and are safe to ignore.
 //
 // Defined here (rather than in fsmwire) so the encryption
 // package owns its semantic-level predicate; the fsmwire
-// package owns the wire-level constants (OpEncryptionMin /
+// package owns the wire-level constants (OpBootstrap /
 // OpEncryptionMax) that this function reads.
 func IsEncryptionRelevantOpcode(opcode byte) bool {
-	return opcode >= fsmwire.OpEncryptionMin && opcode <= fsmwire.OpEncryptionMax
+	return opcode >= fsmwire.OpBootstrap && opcode <= fsmwire.OpEncryptionMax
 }
 
 // EncryptionRelevantScanner is the cross-package contract that

--- a/internal/encryption/audit_test.go
+++ b/internal/encryption/audit_test.go
@@ -1,0 +1,211 @@
+package encryption_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
+)
+
+// TestIsEncryptionRelevantOpcode_AllRangeMembers pins the
+// §5.5 predicate against every byte in the [OpEncryptionMin,
+// OpEncryptionMax] range AND a sampling of out-of-range bytes
+// (including the boundaries one below and one above the range).
+// The predicate is the load-bearing input to the
+// ErrSidecarBehindRaftLog guard; a regression that widens or
+// narrows the range silently changes the security guarantee.
+func TestIsEncryptionRelevantOpcode_AllRangeMembers(t *testing.T) {
+	// Every byte in the OpEncryption range MUST be relevant.
+	for opcode := fsmwire.OpEncryptionMin; opcode <= fsmwire.OpEncryptionMax; opcode++ {
+		if !encryption.IsEncryptionRelevantOpcode(opcode) {
+			t.Errorf("opcode 0x%02X in [0x%02X, 0x%02X] must be encryption-relevant",
+				opcode, fsmwire.OpEncryptionMin, fsmwire.OpEncryptionMax)
+		}
+	}
+	// The byte one below the range must NOT be relevant.
+	if fsmwire.OpEncryptionMin > 0 {
+		below := fsmwire.OpEncryptionMin - 1
+		if encryption.IsEncryptionRelevantOpcode(below) {
+			t.Errorf("opcode 0x%02X (one below OpEncryptionMin) must NOT be encryption-relevant", below)
+		}
+	}
+	// The byte one above the range must NOT be relevant.
+	if fsmwire.OpEncryptionMax < 0xFF {
+		above := fsmwire.OpEncryptionMax + 1
+		if encryption.IsEncryptionRelevantOpcode(above) {
+			t.Errorf("opcode 0x%02X (one above OpEncryptionMax) must NOT be encryption-relevant", above)
+		}
+	}
+}
+
+// TestIsEncryptionRelevantOpcode_KnownRanges pins the explicit
+// opcode values mentioned in §5.5: 0x03 (registration), 0x04
+// (bootstrap), 0x05 (rotation), plus 0x06/0x07 reserved slots.
+// Spelling them out by name catches a regression where someone
+// changes the constants but leaves the predicate range alone.
+func TestIsEncryptionRelevantOpcode_KnownRanges(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		opcode byte
+	}{
+		{"OpRegistration_0x03", fsmwire.OpRegistration},
+		{"OpBootstrap_0x04", fsmwire.OpBootstrap},
+		{"OpRotation_0x05", fsmwire.OpRotation},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if !encryption.IsEncryptionRelevantOpcode(tc.opcode) {
+				t.Errorf("known encryption opcode 0x%02X must be relevant", tc.opcode)
+			}
+		})
+	}
+	// 0x00, 0x01, 0x02 (non-encryption FSM opcodes) MUST NOT be
+	// relevant. The exact non-encryption opcode space is project-
+	// specific; what matters here is that bytes below 0x03 are
+	// never in the encryption range.
+	for _, op := range []byte{0x00, 0x01, 0x02} {
+		if encryption.IsEncryptionRelevantOpcode(op) {
+			t.Errorf("non-encryption opcode 0x%02X must NOT be relevant", op)
+		}
+	}
+}
+
+// fakeScanner implements EncryptionRelevantScanner with a
+// predetermined verdict. Lets the guard tests exercise the
+// hit/no-hit/error branches without needing a real raftengine.
+type fakeScanner struct {
+	hit                bool
+	err                error
+	lastStart, lastEnd uint64
+	calls              int
+}
+
+func (f *fakeScanner) HasEncryptionRelevantEntryInRange(start, end uint64) (bool, error) {
+	f.calls++
+	f.lastStart, f.lastEnd = start, end
+	return f.hit, f.err
+}
+
+// TestGuardSidecarBehindRaftLog_CaughtUp verifies the no-op
+// fast path: sidecar's applied index is equal to (or ahead of)
+// the engine's. The scanner is NEVER called in this branch.
+func TestGuardSidecarBehindRaftLog_CaughtUp(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		sidecarIdx, engineIdx uint64
+	}{
+		{"equal", 42, 42},
+		{"sidecar_ahead", 100, 42},
+		{"both_zero", 0, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			scanner := &fakeScanner{hit: true} // would fire IF consulted
+			err := encryption.GuardSidecarBehindRaftLog(tc.sidecarIdx, tc.engineIdx, scanner)
+			if err != nil {
+				t.Errorf("expected nil for caught-up case (%d >= %d), got %v",
+					tc.sidecarIdx, tc.engineIdx, err)
+			}
+			if scanner.calls != 0 {
+				t.Errorf("scanner must NOT be called when sidecar is caught up; got %d calls", scanner.calls)
+			}
+		})
+	}
+}
+
+// TestGuardSidecarBehindRaftLog_GapNotCovered verifies the
+// "behind but harmless" path: there is a gap but it contains no
+// encryption-relevant entries. The guard MUST pass.
+func TestGuardSidecarBehindRaftLog_GapNotCovered(t *testing.T) {
+	scanner := &fakeScanner{hit: false}
+	err := encryption.GuardSidecarBehindRaftLog(10, 50, scanner)
+	if err != nil {
+		t.Fatalf("gap (10, 50] with no encryption-relevant entries must pass; got %v", err)
+	}
+	if scanner.calls != 1 {
+		t.Errorf("scanner must be consulted exactly once on the gap path; got %d", scanner.calls)
+	}
+	if scanner.lastStart != 10 || scanner.lastEnd != 50 {
+		t.Errorf("scanner called with (%d, %d]; want (10, 50]", scanner.lastStart, scanner.lastEnd)
+	}
+}
+
+// TestGuardSidecarBehindRaftLog_GapCovered verifies the fire
+// path: there is a gap AND it covers an encryption-relevant
+// entry. The guard MUST fire ErrSidecarBehindRaftLog and the
+// error annotation MUST include both indices.
+func TestGuardSidecarBehindRaftLog_GapCovered(t *testing.T) {
+	scanner := &fakeScanner{hit: true}
+	err := encryption.GuardSidecarBehindRaftLog(10, 50, scanner)
+	if !errors.Is(err, encryption.ErrSidecarBehindRaftLog) {
+		t.Fatalf("gap covering encryption-relevant entry must fire ErrSidecarBehindRaftLog; got %v", err)
+	}
+	msg := err.Error()
+	if !containsAll(msg, "sidecar_applied_index=10", "engine_applied_index=50") {
+		t.Errorf("error annotation must include both indices; got %q", msg)
+	}
+}
+
+// TestGuardSidecarBehindRaftLog_ScannerError verifies that
+// scanner failures propagate as wrapped errors that are NOT
+// marked with ErrSidecarBehindRaftLog. The operator triages a
+// scanner failure (e.g., WAL corruption) differently from a
+// gap-coverage refusal.
+func TestGuardSidecarBehindRaftLog_ScannerError(t *testing.T) {
+	scannerErr := errors.New("simulated WAL corruption")
+	scanner := &fakeScanner{err: scannerErr}
+	err := encryption.GuardSidecarBehindRaftLog(10, 50, scanner)
+	if err == nil {
+		t.Fatal("scanner error must propagate, got nil")
+	}
+	if errors.Is(err, encryption.ErrSidecarBehindRaftLog) {
+		t.Errorf("scanner error must NOT be classified as ErrSidecarBehindRaftLog; got %v", err)
+	}
+	if !errors.Is(err, scannerErr) {
+		t.Errorf("scanner error must be in the error chain via errors.Is; got %v", err)
+	}
+}
+
+// TestGuardSidecarBehindRaftLog_NilScanner verifies the
+// fail-closed posture when no scanner is supplied: even though
+// the gap might be harmless, we cannot prove it is, so refuse.
+// A nil scanner in production is a wiring bug; the guard's job
+// is to be loud about it rather than silently accept the gap.
+func TestGuardSidecarBehindRaftLog_NilScanner(t *testing.T) {
+	err := encryption.GuardSidecarBehindRaftLog(10, 50, nil)
+	if !errors.Is(err, encryption.ErrSidecarBehindRaftLog) {
+		t.Fatalf("nil scanner with non-empty gap MUST fail closed with ErrSidecarBehindRaftLog; got %v", err)
+	}
+}
+
+// TestGuardSidecarBehindRaftLog_NilScanner_CaughtUp verifies
+// that a nil scanner on the caught-up path returns nil. The
+// scanner is not consulted when there's no gap, so its absence
+// is irrelevant — refusing here would force every non-encrypted
+// caller to wire a scanner just to get past the guard.
+func TestGuardSidecarBehindRaftLog_NilScanner_CaughtUp(t *testing.T) {
+	err := encryption.GuardSidecarBehindRaftLog(42, 42, nil)
+	if err != nil {
+		t.Errorf("caught-up case with nil scanner must pass; got %v", err)
+	}
+}
+
+// containsAll reports whether s contains every substring in subs.
+// Helper kept local to the audit tests; the startup_test.go file
+// uses strings.Contains directly because it only has a single
+// substring assertion. Here the assertion is over multiple
+// substrings and a small helper reduces the test boilerplate.
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		found := false
+		for i := 0; i+len(sub) <= len(s); i++ {
+			if s[i:i+len(sub)] == sub {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/encryption/audit_test.go
+++ b/internal/encryption/audit_test.go
@@ -22,9 +22,9 @@ func TestIsEncryptionRelevantOpcode_AllRangeMembers(t *testing.T) {
 	// Iterate via int so the loop terminates even if a future
 	// stage sets OpEncryptionMax = 0xFF; a byte-typed loop
 	// counter would wrap to 0x00 on opcode++ at 0xFF and the
-	// loop would never exit. coderabbit minor + gemini medium
-	// on PR #782 caught this fragility against the design's
-	// reserved 0x06 / 0x07 slots which signal range growth.
+	// loop would never exit. The design reserves 0x06 / 0x07
+	// for Stage 6E, so the range is expected to grow and a
+	// byte-typed loop is a latent overflow risk.
 	for i := int(fsmwire.OpEncryptionMin); i <= int(fsmwire.OpEncryptionMax); i++ {
 		opcode := byte(i)
 		if !encryption.IsEncryptionRelevantOpcode(opcode) {
@@ -66,8 +66,7 @@ func TestIsEncryptionRelevantOpcode_KnownRanges(t *testing.T) {
 		// raw bytes here ensures the predicate still treats them
 		// as relevant when 6E lands the wire-format extension
 		// and a future reader is reminded the range is reserved-
-		// not-just-currently-3-opcodes (claude r1 observation 2
-		// on PR #782).
+		// not-just-currently-3-opcodes.
 		{"Reserved_0x06", 0x06},
 		{"Reserved_0x07", 0x07},
 	} {

--- a/internal/encryption/audit_test.go
+++ b/internal/encryption/audit_test.go
@@ -2,6 +2,7 @@ package encryption_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/bootjp/elastickv/internal/encryption"
@@ -17,7 +18,15 @@ import (
 // narrows the range silently changes the security guarantee.
 func TestIsEncryptionRelevantOpcode_AllRangeMembers(t *testing.T) {
 	// Every byte in the OpEncryption range MUST be relevant.
-	for opcode := fsmwire.OpEncryptionMin; opcode <= fsmwire.OpEncryptionMax; opcode++ {
+	//
+	// Iterate via int so the loop terminates even if a future
+	// stage sets OpEncryptionMax = 0xFF; a byte-typed loop
+	// counter would wrap to 0x00 on opcode++ at 0xFF and the
+	// loop would never exit. coderabbit minor + gemini medium
+	// on PR #782 caught this fragility against the design's
+	// reserved 0x06 / 0x07 slots which signal range growth.
+	for i := int(fsmwire.OpEncryptionMin); i <= int(fsmwire.OpEncryptionMax); i++ {
+		opcode := byte(i)
 		if !encryption.IsEncryptionRelevantOpcode(opcode) {
 			t.Errorf("opcode 0x%02X in [0x%02X, 0x%02X] must be encryption-relevant",
 				opcode, fsmwire.OpEncryptionMin, fsmwire.OpEncryptionMax)
@@ -52,6 +61,15 @@ func TestIsEncryptionRelevantOpcode_KnownRanges(t *testing.T) {
 		{"OpRegistration_0x03", fsmwire.OpRegistration},
 		{"OpBootstrap_0x04", fsmwire.OpBootstrap},
 		{"OpRotation_0x05", fsmwire.OpRotation},
+		// Reserved slots in the OpEncryption range. No named
+		// constant yet (Stage 6E will assign them); pinning the
+		// raw bytes here ensures the predicate still treats them
+		// as relevant when 6E lands the wire-format extension
+		// and a future reader is reminded the range is reserved-
+		// not-just-currently-3-opcodes (claude r1 observation 2
+		// on PR #782).
+		{"Reserved_0x06", 0x06},
+		{"Reserved_0x07", 0x07},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if !encryption.IsEncryptionRelevantOpcode(tc.opcode) {
@@ -140,8 +158,10 @@ func TestGuardSidecarBehindRaftLog_GapCovered(t *testing.T) {
 		t.Fatalf("gap covering encryption-relevant entry must fire ErrSidecarBehindRaftLog; got %v", err)
 	}
 	msg := err.Error()
-	if !containsAll(msg, "sidecar_applied_index=10", "engine_applied_index=50") {
-		t.Errorf("error annotation must include both indices; got %q", msg)
+	for _, want := range []string{"sidecar_applied_index=10", "engine_applied_index=50"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error annotation must include %q; got %q", want, msg)
+		}
 	}
 }
 
@@ -187,25 +207,4 @@ func TestGuardSidecarBehindRaftLog_NilScanner_CaughtUp(t *testing.T) {
 	if err != nil {
 		t.Errorf("caught-up case with nil scanner must pass; got %v", err)
 	}
-}
-
-// containsAll reports whether s contains every substring in subs.
-// Helper kept local to the audit tests; the startup_test.go file
-// uses strings.Contains directly because it only has a single
-// substring assertion. Here the assertion is over multiple
-// substrings and a small helper reduces the test boilerplate.
-func containsAll(s string, subs ...string) bool {
-	for _, sub := range subs {
-		found := false
-		for i := 0; i+len(sub) <= len(s); i++ {
-			if s[i:i+len(sub)] == sub {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/encryption/audit_test.go
+++ b/internal/encryption/audit_test.go
@@ -10,14 +10,16 @@ import (
 )
 
 // TestIsEncryptionRelevantOpcode_AllRangeMembers pins the
-// §5.5 predicate against every byte in the [OpEncryptionMin,
-// OpEncryptionMax] range AND a sampling of out-of-range bytes
-// (including the boundaries one below and one above the range).
+// §5.5 predicate against every byte in the sidecar-mutating
+// range [OpBootstrap, OpEncryptionMax] AND a sampling of
+// out-of-range bytes (including OpRegistration directly below
+// the lower bound, since that is the most likely regression to
+// reintroduce false-positive refusals).
 // The predicate is the load-bearing input to the
 // ErrSidecarBehindRaftLog guard; a regression that widens or
 // narrows the range silently changes the security guarantee.
 func TestIsEncryptionRelevantOpcode_AllRangeMembers(t *testing.T) {
-	// Every byte in the OpEncryption range MUST be relevant.
+	// Every byte in the sidecar-mutating range MUST be relevant.
 	//
 	// Iterate via int so the loop terminates even if a future
 	// stage sets OpEncryptionMax = 0xFF; a byte-typed loop
@@ -25,18 +27,28 @@ func TestIsEncryptionRelevantOpcode_AllRangeMembers(t *testing.T) {
 	// loop would never exit. The design reserves 0x06 / 0x07
 	// for Stage 6E, so the range is expected to grow and a
 	// byte-typed loop is a latent overflow risk.
-	for i := int(fsmwire.OpEncryptionMin); i <= int(fsmwire.OpEncryptionMax); i++ {
+	for i := int(fsmwire.OpBootstrap); i <= int(fsmwire.OpEncryptionMax); i++ {
 		opcode := byte(i)
 		if !encryption.IsEncryptionRelevantOpcode(opcode) {
 			t.Errorf("opcode 0x%02X in [0x%02X, 0x%02X] must be encryption-relevant",
-				opcode, fsmwire.OpEncryptionMin, fsmwire.OpEncryptionMax)
+				opcode, fsmwire.OpBootstrap, fsmwire.OpEncryptionMax)
 		}
 	}
+	// OpRegistration sits just below the sidecar-mutating range
+	// (0x03 < 0x04) and MUST NOT be relevant. ApplyRegistration
+	// in applier.go only mutates writer-registry rows and never
+	// calls WriteSidecar, so registration-only gaps would be
+	// false-positive refusals if this byte were classified as
+	// relevant.
+	if encryption.IsEncryptionRelevantOpcode(fsmwire.OpRegistration) {
+		t.Errorf("OpRegistration (0x%02X) must NOT be encryption-relevant (writer-registry only, never WriteSidecar)",
+			fsmwire.OpRegistration)
+	}
 	// The byte one below the range must NOT be relevant.
-	if fsmwire.OpEncryptionMin > 0 {
-		below := fsmwire.OpEncryptionMin - 1
+	if fsmwire.OpBootstrap > 0 {
+		below := fsmwire.OpBootstrap - 1
 		if encryption.IsEncryptionRelevantOpcode(below) {
-			t.Errorf("opcode 0x%02X (one below OpEncryptionMin) must NOT be encryption-relevant", below)
+			t.Errorf("opcode 0x%02X (one below OpBootstrap) must NOT be encryption-relevant", below)
 		}
 	}
 	// The byte one above the range must NOT be relevant.
@@ -49,16 +61,19 @@ func TestIsEncryptionRelevantOpcode_AllRangeMembers(t *testing.T) {
 }
 
 // TestIsEncryptionRelevantOpcode_KnownRanges pins the explicit
-// opcode values mentioned in §5.5: 0x03 (registration), 0x04
-// (bootstrap), 0x05 (rotation), plus 0x06/0x07 reserved slots.
-// Spelling them out by name catches a regression where someone
-// changes the constants but leaves the predicate range alone.
+// opcode values mentioned in §5.5: 0x04 (bootstrap), 0x05
+// (rotation), plus 0x06/0x07 reserved slots. Spelling them out
+// by name catches a regression where someone changes the
+// constants but leaves the predicate range alone.
+//
+// 0x03 OpRegistration is EXCLUDED — see the per-opcode comment
+// below and the IMPORTANT block in IsEncryptionRelevantOpcode's
+// godoc.
 func TestIsEncryptionRelevantOpcode_KnownRanges(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		opcode byte
 	}{
-		{"OpRegistration_0x03", fsmwire.OpRegistration},
 		{"OpBootstrap_0x04", fsmwire.OpBootstrap},
 		{"OpRotation_0x05", fsmwire.OpRotation},
 		// Reserved slots in the OpEncryption range. No named
@@ -66,20 +81,32 @@ func TestIsEncryptionRelevantOpcode_KnownRanges(t *testing.T) {
 		// raw bytes here ensures the predicate still treats them
 		// as relevant when 6E lands the wire-format extension
 		// and a future reader is reminded the range is reserved-
-		// not-just-currently-3-opcodes.
+		// not-just-currently-2-opcodes.
 		{"Reserved_0x06", 0x06},
 		{"Reserved_0x07", 0x07},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if !encryption.IsEncryptionRelevantOpcode(tc.opcode) {
-				t.Errorf("known encryption opcode 0x%02X must be relevant", tc.opcode)
+				t.Errorf("known sidecar-mutating opcode 0x%02X must be relevant", tc.opcode)
 			}
 		})
 	}
+	// OpRegistration (0x03) is in the OpEncryption opcode range
+	// but is NOT sidecar-mutating — ApplyRegistration only writes
+	// writer-registry rows via SetRegistryRow, never WriteSidecar.
+	// Including it in the predicate would force startup refusal
+	// on every restart after the first registration, since the
+	// sidecar's raft_applied_index is not advanced by registration
+	// applies.
+	t.Run("OpRegistration_0x03_NOT_relevant", func(t *testing.T) {
+		if encryption.IsEncryptionRelevantOpcode(fsmwire.OpRegistration) {
+			t.Errorf("OpRegistration (0x%02X) must NOT be relevant (writer-registry only)", fsmwire.OpRegistration)
+		}
+	})
 	// 0x00, 0x01, 0x02 (non-encryption FSM opcodes) MUST NOT be
 	// relevant. The exact non-encryption opcode space is project-
 	// specific; what matters here is that bytes below 0x03 are
-	// never in the encryption range.
+	// never in the sidecar-mutating range.
 	for _, op := range []byte{0x00, 0x01, 0x02} {
 		if encryption.IsEncryptionRelevantOpcode(op) {
 			t.Errorf("non-encryption opcode 0x%02X must NOT be relevant", op)

--- a/internal/encryption/errors.go
+++ b/internal/encryption/errors.go
@@ -174,4 +174,34 @@ var (
 	// liability that must be rotated before the node is allowed
 	// to participate.
 	ErrLocalEpochExhausted = errors.New("encryption: active DEK has reached local_epoch=0xFFFF saturation; refusing to start (rotate the affected DEK via `encryption rotate-dek` before the next startup or risk GCM nonce reuse — see §4.1)")
+
+	// ErrSidecarBehindRaftLog is the §9.1 startup-refusal guard
+	// raised when the sidecar's raft_applied_index is behind the
+	// raftengine's persisted applied index AND the gap covers any
+	// encryption-relevant Raft entry (per §5.5's
+	// IsEncryptionRelevantOpcode predicate: 0x03 OpRegistration,
+	// 0x04 OpBootstrap, 0x05 OpRotation, plus the reserved opcodes
+	// 0x06 / 0x07 from the fsmwire OpEncryption range).
+	//
+	// The classic scenario this catches is a partial-write crash:
+	// an encryption-relevant entry was applied to the engine and
+	// the engine's applied index was advanced, but the §5.1
+	// sidecar write that should have committed the corresponding
+	// keys.json change did not complete. On the next startup the
+	// node sees a stale sidecar that does not reflect the
+	// already-Raft-committed mutation, and the encryption package
+	// would silently rebuild keystore state from an outdated
+	// wrapped-DEK snapshot — a fail-closed read would fire on the
+	// next post-cutover entry with `unknown_key_id`, halting apply.
+	//
+	// Refusing at startup with this typed error means the operator
+	// sees a single unambiguous failure pointing at the right
+	// runbook (`encryption resync-sidecar`) rather than a
+	// downstream HaltApply on the first post-cutover Raft entry.
+	//
+	// Restricting the gap check to specific encryption opcodes
+	// (rather than ANY gap) keeps non-encryption-relevant lag
+	// from forcing a spurious refusal. See §5.5 for the
+	// IsEncryptionRelevantOpcode rationale.
+	ErrSidecarBehindRaftLog = errors.New("encryption: sidecar raft_applied_index is behind the raftengine's persisted applied index and the gap covers an encryption-relevant entry; refusing to start (run `encryption resync-sidecar` to advance the sidecar past the encryption-relevant entries before retrying — see §9.1 + §5.5)")
 )

--- a/internal/encryption/errors.go
+++ b/internal/encryption/errors.go
@@ -178,10 +178,14 @@ var (
 	// ErrSidecarBehindRaftLog is the §9.1 startup-refusal guard
 	// raised when the sidecar's raft_applied_index is behind the
 	// raftengine's persisted applied index AND the gap covers any
-	// encryption-relevant Raft entry (per §5.5's
-	// IsEncryptionRelevantOpcode predicate: 0x03 OpRegistration,
-	// 0x04 OpBootstrap, 0x05 OpRotation, plus the reserved opcodes
-	// 0x06 / 0x07 from the fsmwire OpEncryption range).
+	// SIDECAR-MUTATING Raft entry (per §5.5's
+	// IsEncryptionRelevantOpcode predicate: 0x04 OpBootstrap,
+	// 0x05 OpRotation, plus the reserved opcodes 0x06 / 0x07
+	// from the fsmwire OpEncryption range). 0x03 OpRegistration
+	// is in the OpEncryption range but is NOT sidecar-mutating
+	// — its apply path writes writer-registry rows only and
+	// never WriteSidecar, so registration-only gaps would be
+	// spurious refusals.
 	//
 	// The classic scenario this catches is a partial-write crash:
 	// an encryption-relevant entry was applied to the engine and


### PR DESCRIPTION
## Summary

Stage 6C-2b per the [PR #762 plan](https://github.com/bootjp/elastickv/pull/762) and the 6C sub-decomposition landed in [PR #781](https://github.com/bootjp/elastickv/pull/781).

Ships the **encryption-side primitive** for the `ErrSidecarBehindRaftLog` §9.1 guard so Stage 6D-and-later code paths (e.g., §7.1 capability fan-out's gap-coverage check) can depend on the predicate without waiting for the raftengine-side scanner helper. The actual raftengine WAL-scan implementation + `main.go` startup-guard phase wiring lands in a follow-up **6C-2c** PR.

## What this PR ships

### One new sentinel

| Sentinel | Catches |
|---|---|
| `ErrSidecarBehindRaftLog` | Partial-write crash: encryption-relevant Raft entry applied to engine but §5.1 sidecar write didn't complete. Recovery: `encryption resync-sidecar`. |

Without this guard the encryption package would silently rebuild keystore state from an outdated wrapped-DEK snapshot, and a fail-closed read would fire on the next post-cutover entry with `unknown_key_id` (halting apply).

### Three new exported primitives in `internal/encryption/audit.go`

```go
// §5.5 predicate
func IsEncryptionRelevantOpcode(opcode byte) bool

// Cross-package contract (raftengine implements in 6C-2c)
type EncryptionRelevantScanner interface {
    HasEncryptionRelevantEntryInRange(startExclusive, endInclusive uint64) (bool, error)
}

// Pure-function guard
func GuardSidecarBehindRaftLog(sidecarAppliedIdx, engineAppliedIdx uint64,
                               scanner EncryptionRelevantScanner) error
```

The encryption package owns the **semantic-level** predicate; `fsmwire` owns the **wire-level** constants (`OpEncryptionMin` / `OpEncryptionMax`). Decoupling means a future widening of the encryption opcode range (Stage 6E reserves 0x06 / 0x07) is a single-line change in `fsmwire`, not a cross-package edit.

### Guard contract (5 branches, all tested)

| Branch | Behavior |
|---|---|
| `sidecarAppliedIdx >= engineAppliedIdx` | Caught up. Return nil. **Scanner NEVER called.** |
| Non-empty gap, scanner says no hit | Return nil. |
| Non-empty gap, scanner says hit | Fire `ErrSidecarBehindRaftLog` with both indices in annotation. |
| Scanner error | Propagate wrapped, **NOT** marked with `ErrSidecarBehindRaftLog` (scanner failure ≠ gap-coverage refusal). |
| `nil` scanner with non-empty gap | **Fail closed** with `ErrSidecarBehindRaftLog` (cannot prove safety). |
| `nil` scanner on caught-up path | Return nil (scanner is irrelevant when there's no gap). |

## Design doc updates

- **6C-2b** row rewritten to reflect the primitive-only scope of this PR (encryption package only, no `main.go` wiring).
- **6C-2c** row added — raftengine implementation of the scanner + `main.go` startup-guard phase wiring.
- Shipping order updated: `6C-1 ✅ → 6C-2 ✅ → 6C-2b (this PR) → 6C-2c → 6D (bundles 6C-3) → 6E (bundles 6C-4)`.
- Rationale section updated with the 6C-2b / 6C-2c split: the primitive lands in 6C-2b so Stage 6D-and-later RPC paths that need the same predicate (capability fan-out gap check) can depend on the encryption package without waiting for 6C-2c.

## Why split 6C-2b into "primitive" vs "integration"

The §5.5 predicate (`IsEncryptionRelevantOpcode`) is needed by more than just the startup guard. Stage 6E's capability fan-out checks the same predicate when refusing a cutover RPC if any peer's sidecar is behind. Shipping the predicate + sentinel + interface without the raftengine WAL-scan implementation lets 6D / 6E proceed against the encryption package boundary without waiting on the cross-package plumbing.

## Caller audit

No public function signatures changed. All four new exports (`IsEncryptionRelevantOpcode`, `EncryptionRelevantScanner`, `GuardSidecarBehindRaftLog`, `ErrSidecarBehindRaftLog`) are **net-additive**. No existing callers to audit.

## Five-lens self-review

1. **Data loss** — net-positive. The primitive enables the §9.1 refusal that catches partial-write crashes between an encryption-relevant Raft commit and the sidecar update. Until 6C-2c wires it into `main.go` the refusal is operator-inert, but the primitive's failure modes (nil scanner → fail closed, scanner error → propagate distinct) are correct.
2. **Concurrency / distributed failures** — pure function, no shared state. Scanner interface is single-call per guard invocation; implementations are free to lock internally.
3. **Performance** — zero hot-path impact. The guard is called once per shard per process start (in 6C-2c); within the guard it's one integer comparison + at most one scanner call.
4. **Data consistency** — `ErrSidecarBehindRaftLog` is the only §9.1 guard that catches the "Raft committed but sidecar missed it" partial-write window. Without it the next post-cutover read would HaltApply with `unknown_key_id`; with it the operator gets a single typed startup refusal pointing at the right recovery runbook.
5. **Test coverage** — 7 new tests cover the predicate (range-member + known-opcode + below/above boundary) AND every branch of the guard (caught-up, gap-not-covered, gap-covered, scanner-error, nil-scanner-fails-closed, nil-scanner-caught-up). The `fakeScanner` exercises the interface contract in isolation from any real raftengine.

## Test plan

- [x] `go test -race -timeout=60s ./internal/encryption/...` — PASS
- [x] `golangci-lint run ./internal/encryption/...` — 0 issues
- [ ] Full Jepsen suite — not run; the primitive has no caller in this PR (operator-inert until 6C-2c)

## Plan

Per the design doc updates in this PR, next sub-milestones:
- **6C-2c** — raftengine implementation of `EncryptionRelevantScanner` (WAL-based) + `main.go` startup-guard phase wiring
- **6C-3** — `ErrNodeIDCollision` + `ErrLocalEpochRollback` (bundles with Stage 6D)
- **6D** — `enable-storage-envelope` admin RPC + §7.1 Phase-1 cutover (unblocked once 6C-2c lands)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a safety guard to prevent sidecar lag from silently bypassing encryption-relevant log entries.
  * Added error handling with operator guidance for sidecar synchronization situations.

* **Tests**
  * Added comprehensive test coverage for encryption relevance detection and sidecar lag validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/782?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->