### PR TITLE
feat(raftengine): Stage 6C-2c — encryptionScanner against etcdraft.MemoryStorage

### DIFF
--- a/docs/design/2026_04_29_partial_data_at_rest_encryption.md
+++ b/docs/design/2026_04_29_partial_data_at_rest_encryption.md
@@ -23,7 +23,8 @@ Date: 2026-04-29
 | 6C-1 | Subset of §9.1 startup refusal guards that depend only on flags + sidecar state: sidecar present without `--encryption-enabled` (`ErrSidecarPresentWithoutFlag`, downgrade prevention), `--encryption-enabled` without `--kekFile` (`ErrKEKRequiredWithFlag`, fail-fast), KEK loaded but sidecar wrapped DEKs do not unwrap (`ErrKEKMismatch`, operator-error catch). `internal/encryption/startup.go`'s `CheckStartupGuards` runs once in `main.go run()` before `buildShardGroups`. | shipped | PR #778 |
 | 6C-2 | Process-local §9.1 guards that read only the encryption package's own state: `ErrLocalEpochExhausted` (any active DEK with `local_epoch == 0xFFFF` — refuses to start until rotated, preventing GCM nonce reuse on the next write), `ErrUnsupportedFilesystem` startup probe (`ProbeSidecarFilesystem` exercises the §5.1 write+rename+dir.Sync sequence on a sentinel file in the sidecar directory at startup so filesystem-capability failures surface BEFORE the first encryption-relevant Raft entry, not on the first WriteSidecar call hours into operation). Also includes the gemini-r3 medium parseErr-annotation fix deferred from PR #778 (`ErrKEKMismatch` now wraps both `parseErr` and the unwrap error when the defensive non-decimal-key_id branch fires). The asymmetric `ErrLocalEpochRollback` peer is split into 6C-3 because it requires the writer-registry record (Stage 7). The `ErrSidecarBehindRaftLog` guard moves to 6C-2b because it requires raftengine integration — outside the encryption package boundary. | open | — |
 | 6C-2b | `ErrSidecarBehindRaftLog` guard PRIMITIVE — encryption-side sentinel, `IsEncryptionRelevantOpcode` predicate (§5.5), `EncryptionRelevantScanner` cross-package interface, and `GuardSidecarBehindRaftLog` pure-function guard that takes both indices + a scanner callback. Tests use a fake scanner to exercise every branch (caught-up / gap-not-covered / gap-covered / scanner-error / nil-scanner-fails-closed). Wires nothing into main.go; the raftengine-side implementation lands in 6C-2c. | shipped-in-this-PR | this PR |
-| 6C-2c | Raftengine implementation of `EncryptionRelevantScanner` (WAL-based scan of Raft entries in the supplied index range against the §5.5 predicate) + `main.go` startup-guard phase that runs after `buildShardGroups` for each shard with encryption enabled, before any gRPC server starts serving. Inherits the encryption-side primitive from 6C-2b. | open | — |
+| 6C-2c | Raftengine implementation of `EncryptionRelevantScanner` against `etcdraft.MemoryStorage.Entries`. `Engine.EncryptionScanner()` exposes the scanner as the encryption-side interface so callers (Stage 6C-2d, 6D, 6E) inherit it without coupling to the engine internals. Tests pin every branch: empty range, no-relevant entries (with OpRegistration explicitly), bootstrap hit, rotation hit, conf-change skipped, empty-data skipped, compacted-range error propagation, nil-storage error. | shipped-in-this-PR | this PR |
+| 6C-2d | `main.go` startup-guard phase that runs after `buildShardGroups` for each shard with encryption enabled, before any gRPC server starts serving. Calls `encryption.GuardSidecarBehindRaftLog` with the shard's engine `AppliedIndex()` + sidecar `RaftAppliedIndex` + the engine's `EncryptionScanner()` from 6C-2c. The guard's existing branches (caught-up / gap-not-covered / gap-covered / scanner-error / nil-scanner-fails-closed) determine refusal behavior. | open | — |
 | 6C-3 | Cluster-wide §9.1 guards that require the Voters ∪ Learners membership view: `ErrNodeIDCollision` (two members hash to the same 16-bit `node_id`), `ErrLocalEpochRollback` (sidecar `local_epoch` ≤ writer-registry record). Naturally bundles with the Stage 6D capability fan-out which already needs that membership view. | open | — |
 | 6C-4 | Phase-2-specific §9.1 guards: `ErrEnvelopeCutoverDivergence` (sidecar `raft_envelope_cutover_index` disagrees with snapshot header), `ErrEncryptionNotBootstrapped` (`enable-raft-envelope` before bootstrap), `ErrLocalEpochOutOfRange` on the wire side of `GetCapability` / `GetSidecarState`. Bundles with Stage 6E (`enable-raft-envelope` admin RPC + Phase-2 cutover). | open | — |
 | 6D | §6.6 `enable-storage-envelope` admin RPC + §7.1 Phase-1 storage cutover (§6.2 toggle ON) + Voters ∪ Learners capability gate (depends on 6B for mutator wiring AND 6C-1+6C-2 for §9.1 startup-refusal guards; bundles 6C-3 for the membership-view-dependent collision check — see rationale) | open | — |
@@ -200,18 +201,28 @@ production-safe state, and unblocks the next one.
       ONLY on the encryption package without waiting on the
       raftengine-side scan helper.
 
-    * **6C-2c** — Raftengine implementation of the
-      `EncryptionRelevantScanner` interface defined in 6C-2b. Walks
-      the WAL across the supplied entry-index range, decodes each
-      entry's opcode byte, and applies the §5.5 predicate. Wires
-      a new startup-guard phase into `main.go` that runs AFTER
+    * **6C-2c** — Raftengine-side implementation of the
+      `EncryptionRelevantScanner` interface defined in 6C-2b.
+      Implemented against `etcdraft.MemoryStorage.Entries` so the
+      scan reads in-memory state that the engine has just replayed
+      from the WAL + snapshot at Open() time. Filters out
+      EntryConfChange / EntryConfChangeV2 and zero-length normal
+      entries (etcd-raft leadership bumps) so those don't falsely
+      trigger the predicate. Compacted-range errors propagate
+      wrapped — the caller (Stage 6C-2d's main.go phase) surfaces
+      them as a scanner-error refusal distinct from
+      ErrSidecarBehindRaftLog. Exposed via the new
+      `Engine.EncryptionScanner()` accessor.
+
+    * **6C-2d** — `main.go` startup-guard phase that ties 6C-2b's
+      pure-function guard to 6C-2c's engine scanner. Runs AFTER
       `buildShardGroups` returns and each shard's engine has opened,
       but BEFORE any gRPC server starts serving — a different
       lifecycle phase from the existing 6C-1 / 6C-2 guards (which
       run before engine startup). For each shard with encryption
-      enabled, the phase calls `GuardSidecarBehindRaftLog` with the
-      shard's engine `AppliedIndex()` and a scanner backed by the
-      engine's WAL.
+      enabled, calls `GuardSidecarBehindRaftLog` with the shard's
+      engine `AppliedIndex()` + sidecar `RaftAppliedIndex` + the
+      engine's `EncryptionScanner()`.
 
     * **6C-3** — Membership-view guards. `ErrNodeIDCollision`
       requires a Voters ∪ Learners enumeration of every Raft
@@ -229,11 +240,12 @@ production-safe state, and unblocks the next one.
       `local_epoch` values to the §4.1 16-bit field. Bundles with
       Stage 6E's `enable-raft-envelope` admin RPC.
 
-  **Shipping order:** 6C-1 → 6C-2 → 6C-2b (primitive) → 6C-2c
-  (raftengine implementation + main.go wiring) → 6D (bundles
-  6C-3) → 6E (bundles 6C-4). Stage 6D is unblocked once 6C-1
-  + 6C-2 + 6C-2b + 6C-2c have all shipped (the latter pair
-  is the load-bearing `ErrSidecarBehindRaftLog` work); 6D
+  **Shipping order:** 6C-1 → 6C-2 → 6C-2b (encryption-side
+  primitive) → 6C-2c (raftengine scanner) → 6C-2d (main.go
+  startup-guard wiring) → 6D (bundles 6C-3) → 6E (bundles
+  6C-4). Stage 6D is unblocked once 6C-1 + 6C-2 + 6C-2b +
+  6C-2c + 6C-2d have all shipped (the latter three together
+  are the load-bearing `ErrSidecarBehindRaftLog` work); 6D
   does not need to wait for the 6C-3/6C-4 work that bundles
   into it.
 

--- a/internal/raftengine/etcd/encryption_scanner.go
+++ b/internal/raftengine/etcd/encryption_scanner.go
@@ -1,0 +1,123 @@
+package etcd
+
+import (
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/cockroachdb/errors"
+	etcdraft "go.etcd.io/raft/v3"
+	raftpb "go.etcd.io/raft/v3/raftpb"
+)
+
+// scanMaxBytes caps the byte size of a single Entries() fetch from
+// MemoryStorage during a gap scan. The §9.1 ErrSidecarBehindRaftLog
+// guard runs once per process start, so a comfortable margin over
+// any expected gap (typical: 1-N entries from a partial-write
+// crash) keeps the scan to a single Entries() call without the
+// per-iteration ceremony of a pagination loop. If a real gap ever
+// exceeds this size the iteration falls back to additional calls
+// (see scanEntries() below) so the cap is not a correctness
+// boundary, only a per-call memory cap.
+const scanMaxBytes uint64 = 64 << 20 // 64 MiB
+
+// encryptionScanner implements encryption.EncryptionRelevantScanner
+// against the engine's in-memory raft storage. It is constructed
+// once per Engine and embedded into the engine struct; callers get
+// access to it via Engine.EncryptionScanner().
+//
+// The scan walks raftpb.Entry rows in (startExclusive, endInclusive]
+// via etcdraft.MemoryStorage.Entries(lo, hi, maxSize), filters out
+// non-normal entries (conf-change, empty leadership bump) since the
+// §5.5 IsEncryptionRelevantOpcode predicate only applies to normal
+// FSM entries, and reports whether any survives the predicate.
+//
+// Compacted-out-of-MemoryStorage ranges return raft's
+// ErrCompacted (or ErrUnavailable) which the scanner wraps and
+// propagates. GuardSidecarBehindRaftLog routes that as a scanner
+// error (NOT as ErrSidecarBehindRaftLog), so the operator sees a
+// distinct refusal: "the gap exists but is below the snapshot
+// horizon; run encryption resync-sidecar to advance past the
+// compacted entries". A sidecar that far behind is itself the
+// operator's primary problem; the scanner just reports honestly.
+type encryptionScanner struct {
+	storage *etcdraft.MemoryStorage
+}
+
+// HasEncryptionRelevantEntryInRange satisfies the
+// encryption.EncryptionRelevantScanner contract: returns true iff
+// at least one raftpb.Entry with index in (startExclusive,
+// endInclusive] is a §5.5 sidecar-mutating opcode per
+// encryption.IsEncryptionRelevantOpcode.
+//
+// Empty range (startExclusive >= endInclusive) returns (false, nil)
+// per the interface contract. The encryption.GuardSidecarBehindRaftLog
+// caller precomputes the non-empty-gap branch and only calls scan
+// when there's a range to inspect, but the defensive guard stays.
+func (s *encryptionScanner) HasEncryptionRelevantEntryInRange(startExclusive, endInclusive uint64) (bool, error) {
+	if s.storage == nil {
+		return false, errors.New("encryption scanner: storage is nil (engine not opened?)")
+	}
+	if startExclusive >= endInclusive {
+		return false, nil
+	}
+	// MemoryStorage.Entries(lo, hi, ...) returns indices [lo, hi).
+	// We want (startExclusive, endInclusive] = [startExclusive+1,
+	// endInclusive+1).
+	lo := startExclusive + 1
+	hi := endInclusive + 1
+	cursor := lo
+	for cursor < hi {
+		batch, err := s.storage.Entries(cursor, hi, scanMaxBytes)
+		if err != nil {
+			return false, errors.Wrapf(err,
+				"encryption scanner: read raft entries [%d, %d) from MemoryStorage",
+				cursor, hi)
+		}
+		if len(batch) == 0 {
+			// Defensive: MemoryStorage.Entries returning no entries
+			// without an error means we have made no progress. Bail
+			// out rather than spin.
+			break
+		}
+		for _, ent := range batch {
+			if isEncryptionRelevantEntry(ent) {
+				return true, nil
+			}
+		}
+		// Continue from one past the last returned index.
+		cursor = batch[len(batch)-1].Index + 1
+	}
+	return false, nil
+}
+
+// isEncryptionRelevantEntry centralises the per-Entry predicate.
+// Returns false for:
+//
+//   - EntryConfChange / EntryConfChangeV2 — never carry encryption
+//     FSM payloads.
+//   - Empty Data — etcd-raft uses a zero-length normal entry to
+//     announce a new leader; not a real FSM op.
+//
+// Returns IsEncryptionRelevantOpcode(Data[0]) otherwise. The
+// opcode is the LEADING byte per the §5.5 wire format (see
+// kv/fsm_encryption.go and the encoders in fsmwire).
+func isEncryptionRelevantEntry(ent raftpb.Entry) bool {
+	if ent.Type != raftpb.EntryNormal {
+		return false
+	}
+	if len(ent.Data) == 0 {
+		return false
+	}
+	return encryption.IsEncryptionRelevantOpcode(ent.Data[0])
+}
+
+// EncryptionScanner returns the engine's
+// encryption.EncryptionRelevantScanner implementation. The
+// returned value is safe to call after Open() has populated
+// MemoryStorage from the on-disk WAL + snapshot, and only after
+// — calling it before Open() returns a nil-storage error.
+//
+// Used by main.go's startup-guard phase (Stage 6C-2d) to invoke
+// encryption.GuardSidecarBehindRaftLog against the engine's
+// applied index and the sidecar's raft_applied_index.
+func (e *Engine) EncryptionScanner() encryption.EncryptionRelevantScanner {
+	return &encryptionScanner{storage: e.storage}
+}

--- a/internal/raftengine/etcd/encryption_scanner.go
+++ b/internal/raftengine/etcd/encryption_scanner.go
@@ -55,11 +55,21 @@ type encryptionScanner struct {
 // caller precomputes the non-empty-gap branch and only calls scan
 // when there's a range to inspect, but the defensive guard stays.
 func (s *encryptionScanner) HasEncryptionRelevantEntryInRange(startExclusive, endInclusive uint64) (bool, error) {
-	if s.storage == nil {
-		return false, errors.New("encryption scanner: storage is nil (engine not opened?)")
-	}
+	// The EncryptionRelevantScanner contract (audit.go) requires
+	// the empty-range case to return (false, nil) UNCONDITIONALLY
+	// — including on nil-storage receivers. Reorder the guards so
+	// an empty range short-circuits before any state-dependent
+	// failure path. GuardSidecarBehindRaftLog pre-filters the
+	// empty-gap case in production, so this is contract conformance
+	// rather than a reachable bug; pinning the order keeps any
+	// future caller (6C-2d, capability fan-out) from triggering
+	// the surprising "empty range on nil scanner returns error"
+	// path.
 	if startExclusive >= endInclusive {
 		return false, nil
+	}
+	if s.storage == nil {
+		return false, errors.New("encryption scanner: storage is nil (engine not opened?)")
 	}
 	// MemoryStorage.Entries(lo, hi, ...) returns indices [lo, hi).
 	// We want (startExclusive, endInclusive] = [startExclusive+1,

--- a/internal/raftengine/etcd/encryption_scanner.go
+++ b/internal/raftengine/etcd/encryption_scanner.go
@@ -1,6 +1,8 @@
 package etcd
 
 import (
+	"math"
+
 	"github.com/bootjp/elastickv/internal/encryption"
 	"github.com/cockroachdb/errors"
 	etcdraft "go.etcd.io/raft/v3"
@@ -60,7 +62,11 @@ func (s *encryptionScanner) HasEncryptionRelevantEntryInRange(startExclusive, en
 	}
 	// MemoryStorage.Entries(lo, hi, ...) returns indices [lo, hi).
 	// We want (startExclusive, endInclusive] = [startExclusive+1,
-	// endInclusive+1).
+	// endInclusive+1). Guard against uint64 wraparound at
+	// MaxUint64 (otherwise hi = 0 and the loop never runs).
+	if endInclusive == math.MaxUint64 {
+		return false, errors.New("encryption scanner: endInclusive == math.MaxUint64 cannot be expressed as half-open Entries() range")
+	}
 	lo := startExclusive + 1
 	hi := endInclusive + 1
 	cursor := lo
@@ -72,10 +78,16 @@ func (s *encryptionScanner) HasEncryptionRelevantEntryInRange(startExclusive, en
 				cursor, hi)
 		}
 		if len(batch) == 0 {
-			// Defensive: MemoryStorage.Entries returning no entries
-			// without an error means we have made no progress. Bail
-			// out rather than spin.
-			break
+			// Fail closed: an empty batch with cursor < hi means
+			// MemoryStorage didn't advance even though the requested
+			// range is non-empty. Treating this as "no hit" would
+			// silently classify an unscanned range as harmless, so
+			// we surface it as a scanner error. The caller routes
+			// scanner errors as a refusal distinct from
+			// ErrSidecarBehindRaftLog.
+			return false, errors.Wrapf(errors.New("no progress"),
+				"encryption scanner: Entries(cursor=%d, hi=%d) returned no entries and no error (unscanned gap)",
+				cursor, hi)
 		}
 		for _, ent := range batch {
 			if isEncryptionRelevantEntry(ent) {
@@ -93,31 +105,50 @@ func (s *encryptionScanner) HasEncryptionRelevantEntryInRange(startExclusive, en
 //
 //   - EntryConfChange / EntryConfChangeV2 — never carry encryption
 //     FSM payloads.
-//   - Empty Data — etcd-raft uses a zero-length normal entry to
-//     announce a new leader; not a real FSM op.
+//   - Entries whose Data does not decode as a valid proposal
+//     envelope (zero-length leadership bumps, malformed entries).
+//   - Envelopes wrapping an empty FSM payload.
 //
-// Returns IsEncryptionRelevantOpcode(Data[0]) otherwise. The
-// opcode is the LEADING byte per the §5.5 wire format (see
-// kv/fsm_encryption.go and the encoders in fsmwire).
+// For valid envelopes, returns IsEncryptionRelevantOpcode(payload[0])
+// where payload is the post-envelope-strip FSM byte sequence. The
+// engine wraps every EntryNormal in a 9-byte proposal envelope
+// (1 byte version + 8 byte proposal ID) via encodeProposalEnvelope
+// at propose time, so the raw Data[0] is always the envelope
+// version 0x01 — NEVER the FSM opcode. A scanner that misreads
+// the layout would return false for every entry in a real Raft
+// log, silently defeating the §9.1 ErrSidecarBehindRaftLog guard.
 func isEncryptionRelevantEntry(ent raftpb.Entry) bool {
 	if ent.Type != raftpb.EntryNormal {
 		return false
 	}
-	if len(ent.Data) == 0 {
+	_, payload, ok := decodeProposalEnvelope(ent.Data)
+	if !ok || len(payload) == 0 {
 		return false
 	}
-	return encryption.IsEncryptionRelevantOpcode(ent.Data[0])
+	return encryption.IsEncryptionRelevantOpcode(payload[0])
 }
 
 // EncryptionScanner returns the engine's
 // encryption.EncryptionRelevantScanner implementation. The
 // returned value is safe to call after Open() has populated
 // MemoryStorage from the on-disk WAL + snapshot, and only after
-// — calling it before Open() returns a nil-storage error.
+// — calling it before Open() returns a nil-storage error from
+// HasEncryptionRelevantEntryInRange.
 //
 // Used by main.go's startup-guard phase (Stage 6C-2d) to invoke
 // encryption.GuardSidecarBehindRaftLog against the engine's
 // applied index and the sidecar's raft_applied_index.
+//
+// Nil-receiver-safe: a nil *Engine returns a zero-value
+// encryptionScanner whose HasEncryptionRelevantEntryInRange will
+// surface the nil-storage error. This matches the rest of the
+// package's defensive nil-receiver posture (Status() / AppliedIndex()
+// return zero values on nil receivers) and lets call sites in
+// the lifecycle that may forward a maybe-nil engine pointer
+// avoid a panic during startup/refusal triage.
 func (e *Engine) EncryptionScanner() encryption.EncryptionRelevantScanner {
+	if e == nil {
+		return &encryptionScanner{}
+	}
 	return &encryptionScanner{storage: e.storage}
 }

--- a/internal/raftengine/etcd/encryption_scanner.go
+++ b/internal/raftengine/etcd/encryption_scanner.go
@@ -21,9 +21,10 @@ import (
 const scanMaxBytes uint64 = 64 << 20 // 64 MiB
 
 // encryptionScanner implements encryption.EncryptionRelevantScanner
-// against the engine's in-memory raft storage. It is constructed
-// once per Engine and embedded into the engine struct; callers get
-// access to it via Engine.EncryptionScanner().
+// against the engine's in-memory raft storage. It wraps the
+// engine's *MemoryStorage; a fresh value is constructed per
+// Engine.EncryptionScanner() call (cheap — no internal state).
+// Callers get access to it via Engine.EncryptionScanner().
 //
 // The scan walks raftpb.Entry rows in (startExclusive, endInclusive]
 // via etcdraft.MemoryStorage.Entries(lo, hi, maxSize), filters out
@@ -85,9 +86,9 @@ func (s *encryptionScanner) HasEncryptionRelevantEntryInRange(startExclusive, en
 			// we surface it as a scanner error. The caller routes
 			// scanner errors as a refusal distinct from
 			// ErrSidecarBehindRaftLog.
-			return false, errors.Wrapf(errors.New("no progress"),
+			return false, errors.WithStack(errors.Newf(
 				"encryption scanner: Entries(cursor=%d, hi=%d) returned no entries and no error (unscanned gap)",
-				cursor, hi)
+				cursor, hi))
 		}
 		for _, ent := range batch {
 			if isEncryptionRelevantEntry(ent) {

--- a/internal/raftengine/etcd/encryption_scanner_test.go
+++ b/internal/raftengine/etcd/encryption_scanner_test.go
@@ -10,15 +10,21 @@ import (
 )
 
 // newEntry constructs a normal raftpb.Entry at the supplied index
-// with a one-byte payload that begins with the supplied opcode.
-// The §5.5 wire format has the opcode at data[0], so this single
-// byte is enough to exercise the scanner's predicate.
+// whose Data is the production-shape proposal envelope:
+// [version=0x01][8-byte proposal id][payload]. The payload is a
+// one-byte buffer containing the supplied opcode. Wrapping via
+// encodeProposalEnvelope is critical — without it the entry's
+// Data[0] would be the opcode directly, which is NOT what the
+// engine ever writes; tests against bare-byte Data passed
+// trivially because Data[0] happened to match the opcode,
+// masking the envelope-strip bug fixed in the scanner per
+// gemini CRITICAL on PR #783.
 func newEntry(index uint64, opcode byte) raftpb.Entry {
 	return raftpb.Entry{
 		Type:  raftpb.EntryNormal,
 		Term:  1,
 		Index: index,
-		Data:  []byte{opcode},
+		Data:  encodeProposalEnvelope(index, []byte{opcode}),
 	}
 }
 
@@ -134,8 +140,8 @@ func TestEncryptionScanner_RotationHit(t *testing.T) {
 // not falsely trigger the predicate.
 func TestEncryptionScanner_NonNormalEntriesSkipped(t *testing.T) {
 	entries := []raftpb.Entry{
-		{Type: raftpb.EntryConfChange, Term: 1, Index: 1, Data: []byte{fsmwire.OpBootstrap}},
-		{Type: raftpb.EntryConfChangeV2, Term: 1, Index: 2, Data: []byte{fsmwire.OpRotation}},
+		{Type: raftpb.EntryConfChange, Term: 1, Index: 1, Data: encodeProposalEnvelope(1, []byte{fsmwire.OpBootstrap})},
+		{Type: raftpb.EntryConfChangeV2, Term: 1, Index: 2, Data: encodeProposalEnvelope(2, []byte{fsmwire.OpRotation})},
 	}
 	s := scannerWithEntries(t, entries...)
 	hit, err := s.HasEncryptionRelevantEntryInRange(0, 2)
@@ -143,14 +149,16 @@ func TestEncryptionScanner_NonNormalEntriesSkipped(t *testing.T) {
 		t.Fatalf("scan: %v", err)
 	}
 	if hit {
-		t.Fatal("conf-change entries must NOT be classified as encryption-relevant even if their Data byte 0 is in the OpEncryption range")
+		t.Fatal("conf-change entries must NOT be classified as encryption-relevant even if their envelope-stripped payload byte 0 is in the OpEncryption range")
 	}
 }
 
 // TestEncryptionScanner_EmptyDataSkipped verifies that
 // zero-length normal entries (etcd-raft uses these for leadership
-// bumps after election) are skipped. The opcode-byte read would
-// be an index-out-of-range panic if we didn't gate on data length.
+// bumps after election) and malformed (sub-envelope-length)
+// entries are skipped. decodeProposalEnvelope returns ok=false
+// for both — the predicate must short-circuit cleanly without
+// nil-deref or out-of-range panic.
 func TestEncryptionScanner_EmptyDataSkipped(t *testing.T) {
 	entries := []raftpb.Entry{
 		{Type: raftpb.EntryNormal, Term: 1, Index: 1, Data: nil},
@@ -163,6 +171,33 @@ func TestEncryptionScanner_EmptyDataSkipped(t *testing.T) {
 	}
 	if hit {
 		t.Fatal("zero-length normal entries (leadership bumps) must NOT be classified as encryption-relevant")
+	}
+}
+
+// TestEncryptionScanner_EnvelopeStripping_RawBytesIgnored pins
+// gemini CRITICAL on PR #783: an entry whose Data[0] coincidentally
+// matches an encryption opcode but is NOT wrapped in a proposal
+// envelope (envelope version != 0x01 or length < 9) MUST be
+// rejected by decodeProposalEnvelope, not silently classified
+// as a hit. Otherwise the scanner would have returned true for
+// every entry whose raw byte 0 happens to land in [0x04, 0x07] —
+// the exact false-positive class the envelope strip prevents.
+func TestEncryptionScanner_EnvelopeStripping_RawBytesIgnored(t *testing.T) {
+	entries := []raftpb.Entry{
+		// Bare opcode byte, no envelope. decodeProposalEnvelope
+		// returns ok=false because len(data) < envelopeHeaderSize.
+		{Type: raftpb.EntryNormal, Term: 1, Index: 1, Data: []byte{fsmwire.OpBootstrap}},
+		// Wrong version byte but full length. decodeProposalEnvelope
+		// returns ok=false because data[0] != proposalEnvelopeVersion.
+		{Type: raftpb.EntryNormal, Term: 1, Index: 2, Data: []byte{0x99, 0, 0, 0, 0, 0, 0, 0, 0, fsmwire.OpBootstrap}},
+	}
+	s := scannerWithEntries(t, entries...)
+	hit, err := s.HasEncryptionRelevantEntryInRange(0, 2)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if hit {
+		t.Fatal("entries without a valid proposal envelope must NOT be classified as encryption-relevant — would re-introduce the pre-fix false-positive class")
 	}
 }
 
@@ -190,8 +225,13 @@ func TestEncryptionScanner_CompactedRange(t *testing.T) {
 	if hit {
 		t.Errorf("compacted range must NOT report hit=true; got hit=%v err=%v", hit, err)
 	}
+	// Enforce the wrapped sentinel: the caller (GuardSidecarBehindRaftLog)
+	// distinguishes scanner errors from gap-coverage refusals AND
+	// downstream callers may want to errors.Is on ErrCompacted
+	// specifically to suggest `encryption resync-sidecar` in the
+	// recovery instructions.
 	if !errors.Is(err, etcdraft.ErrCompacted) {
-		t.Logf("note: wrapped error %v — caller surfaces this as a scanner-error refusal", err)
+		t.Fatalf("compacted-range error MUST be errors.Is(err, etcdraft.ErrCompacted); got %v", err)
 	}
 }
 
@@ -206,3 +246,49 @@ func TestEncryptionScanner_NilStorageError(t *testing.T) {
 		t.Fatal("nil-storage scanner must return an error")
 	}
 }
+
+// TestEngineEncryptionScanner_NilReceiver pins the codex P2
+// finding on PR #783: calling Engine.EncryptionScanner() on a
+// nil *Engine MUST return a usable scanner that surfaces the
+// nil-storage error rather than panicking. Production paths that
+// forward a maybe-nil engine pointer during startup/refusal
+// triage rely on this defensive return.
+func TestEngineEncryptionScanner_NilReceiver(t *testing.T) {
+	var e *Engine
+	scanner := e.EncryptionScanner()
+	if scanner == nil {
+		t.Fatal("Engine.EncryptionScanner() on nil receiver must return a non-nil scanner")
+	}
+	_, err := scanner.HasEncryptionRelevantEntryInRange(0, 5)
+	if err == nil {
+		t.Fatal("nil-receiver scanner must surface a storage error, not silently succeed")
+	}
+}
+
+// TestEncryptionScanner_EndInclusiveMaxUint64Refused pins the
+// coderabbit minor: endInclusive == math.MaxUint64 would cause
+// endInclusive+1 to wrap to 0, making the half-open Entries()
+// range degenerate. The scanner detects this and refuses with
+// an explicit error rather than silently scanning nothing.
+func TestEncryptionScanner_EndInclusiveMaxUint64Refused(t *testing.T) {
+	s := scannerWithEntries(t) // empty storage; should still hit the overflow guard before any read
+	hit, err := s.HasEncryptionRelevantEntryInRange(0, ^uint64(0))
+	if err == nil {
+		t.Fatal("endInclusive == math.MaxUint64 must refuse with an explicit error to avoid uint64 wraparound")
+	}
+	if hit {
+		t.Errorf("overflow refusal must NOT report hit=true; got hit=%v err=%v", hit, err)
+	}
+}
+
+// The "no-progress" fail-closed branch in the scanner is
+// guarded by a defensive `return false, error` when
+// storage.Entries returns an empty batch with no error. Real
+// MemoryStorage never returns this combination (it always
+// returns ErrCompacted or ErrUnavailable), so exercising the
+// branch via the public Storage API isn't possible without a
+// custom mock. The branch's correctness is verified by code
+// inspection (any zero-length non-error batch returns an
+// errors.Newf-wrapped error before the loop can advance) and
+// by the compacted-range test which exercises the same
+// fail-closed contract via a real ErrCompacted path.

--- a/internal/raftengine/etcd/encryption_scanner_test.go
+++ b/internal/raftengine/etcd/encryption_scanner_test.go
@@ -1,0 +1,208 @@
+package etcd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
+	etcdraft "go.etcd.io/raft/v3"
+	raftpb "go.etcd.io/raft/v3/raftpb"
+)
+
+// newEntry constructs a normal raftpb.Entry at the supplied index
+// with a one-byte payload that begins with the supplied opcode.
+// The §5.5 wire format has the opcode at data[0], so this single
+// byte is enough to exercise the scanner's predicate.
+func newEntry(index uint64, opcode byte) raftpb.Entry {
+	return raftpb.Entry{
+		Type:  raftpb.EntryNormal,
+		Term:  1,
+		Index: index,
+		Data:  []byte{opcode},
+	}
+}
+
+// scannerWithEntries builds an encryptionScanner backed by a fresh
+// MemoryStorage containing the supplied entries. The storage is
+// snapshot-bumped to index 0 (no snapshot) so the entries are
+// readable from index 1 onward — the same baseline a freshly
+// opened engine sees.
+func scannerWithEntries(t *testing.T, entries ...raftpb.Entry) *encryptionScanner {
+	t.Helper()
+	storage := etcdraft.NewMemoryStorage()
+	if len(entries) > 0 {
+		if err := storage.Append(entries); err != nil {
+			t.Fatalf("storage.Append: %v", err)
+		}
+	}
+	return &encryptionScanner{storage: storage}
+}
+
+// TestEncryptionScanner_EmptyRange verifies the no-op fast path:
+// startExclusive >= endInclusive must short-circuit to
+// (false, nil) without touching the storage backend.
+func TestEncryptionScanner_EmptyRange(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		start uint64
+		end   uint64
+	}{
+		{"equal", 5, 5},
+		{"start_ahead", 10, 5},
+		{"both_zero", 0, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := scannerWithEntries(t) // empty storage
+			hit, err := s.HasEncryptionRelevantEntryInRange(tc.start, tc.end)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if hit {
+				t.Fatalf("empty range must report no hit")
+			}
+		})
+	}
+}
+
+// TestEncryptionScanner_NoRelevantEntries pins the
+// "behind but harmless" path: the gap exists and entries are
+// readable, but none carry a §5.5 sidecar-mutating opcode.
+//
+// We use OpRegistration (0x03) deliberately because that opcode
+// was the codex P2 false-positive on PR #782 — pinning the
+// scanner against it ensures the predicate's exclusion is wired
+// through end-to-end.
+func TestEncryptionScanner_NoRelevantEntries(t *testing.T) {
+	entries := []raftpb.Entry{
+		newEntry(1, 0x00),                   // non-encryption opcode
+		newEntry(2, 0x01),                   // non-encryption opcode
+		newEntry(3, fsmwire.OpRegistration), // 0x03 — IN the OpEncryption range
+		newEntry(4, 0x02),                   // non-encryption opcode
+	}
+	s := scannerWithEntries(t, entries...)
+	hit, err := s.HasEncryptionRelevantEntryInRange(0, 4)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if hit {
+		t.Fatal("range with only non-sidecar-mutating opcodes must not be classified as relevant — registration (0x03) is in OpEncryption range but is NOT sidecar-mutating")
+	}
+}
+
+// TestEncryptionScanner_BootstrapHit verifies the fire path:
+// at least one OpBootstrap entry in the range triggers the
+// predicate.
+func TestEncryptionScanner_BootstrapHit(t *testing.T) {
+	entries := []raftpb.Entry{
+		newEntry(1, 0x00),
+		newEntry(2, fsmwire.OpBootstrap),
+		newEntry(3, 0x00),
+	}
+	s := scannerWithEntries(t, entries...)
+	hit, err := s.HasEncryptionRelevantEntryInRange(0, 3)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if !hit {
+		t.Fatal("range containing OpBootstrap must be classified as relevant")
+	}
+}
+
+// TestEncryptionScanner_RotationHit verifies OpRotation triggers
+// the predicate just like OpBootstrap. Uses a small range starting
+// from index 1 to keep within MemoryStorage's sequential-index
+// requirement.
+func TestEncryptionScanner_RotationHit(t *testing.T) {
+	entries := []raftpb.Entry{
+		newEntry(1, 0x00),
+		newEntry(2, fsmwire.OpRotation),
+	}
+	s := scannerWithEntries(t, entries...)
+	hit, err := s.HasEncryptionRelevantEntryInRange(1, 2)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if !hit {
+		t.Fatal("range containing OpRotation must be classified as relevant")
+	}
+}
+
+// TestEncryptionScanner_NonNormalEntriesSkipped verifies that
+// EntryConfChange / EntryConfChangeV2 entries are skipped even
+// if their Data happens to start with a byte in the encryption
+// range. Config changes never carry FSM payloads, so they must
+// not falsely trigger the predicate.
+func TestEncryptionScanner_NonNormalEntriesSkipped(t *testing.T) {
+	entries := []raftpb.Entry{
+		{Type: raftpb.EntryConfChange, Term: 1, Index: 1, Data: []byte{fsmwire.OpBootstrap}},
+		{Type: raftpb.EntryConfChangeV2, Term: 1, Index: 2, Data: []byte{fsmwire.OpRotation}},
+	}
+	s := scannerWithEntries(t, entries...)
+	hit, err := s.HasEncryptionRelevantEntryInRange(0, 2)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if hit {
+		t.Fatal("conf-change entries must NOT be classified as encryption-relevant even if their Data byte 0 is in the OpEncryption range")
+	}
+}
+
+// TestEncryptionScanner_EmptyDataSkipped verifies that
+// zero-length normal entries (etcd-raft uses these for leadership
+// bumps after election) are skipped. The opcode-byte read would
+// be an index-out-of-range panic if we didn't gate on data length.
+func TestEncryptionScanner_EmptyDataSkipped(t *testing.T) {
+	entries := []raftpb.Entry{
+		{Type: raftpb.EntryNormal, Term: 1, Index: 1, Data: nil},
+		{Type: raftpb.EntryNormal, Term: 1, Index: 2, Data: []byte{}},
+	}
+	s := scannerWithEntries(t, entries...)
+	hit, err := s.HasEncryptionRelevantEntryInRange(0, 2)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if hit {
+		t.Fatal("zero-length normal entries (leadership bumps) must NOT be classified as encryption-relevant")
+	}
+}
+
+// TestEncryptionScanner_CompactedRange propagates the storage
+// error when the requested range is below the snapshot horizon.
+// The error MUST NOT be silently classified as "no hit" — the
+// scanner cannot inspect the gap and must fail loudly so the
+// guard surfaces it as a scanner-error refusal (distinct from
+// ErrSidecarBehindRaftLog gap-coverage refusal).
+func TestEncryptionScanner_CompactedRange(t *testing.T) {
+	storage := etcdraft.NewMemoryStorage()
+	// Establish a snapshot at index 10 — entries below 10 become
+	// inaccessible via Entries().
+	snap := raftpb.Snapshot{
+		Metadata: raftpb.SnapshotMetadata{Index: 10, Term: 1},
+	}
+	if err := storage.ApplySnapshot(snap); err != nil {
+		t.Fatalf("ApplySnapshot: %v", err)
+	}
+	s := &encryptionScanner{storage: storage}
+	hit, err := s.HasEncryptionRelevantEntryInRange(0, 5)
+	if err == nil {
+		t.Fatal("expected compacted-range error, got nil")
+	}
+	if hit {
+		t.Errorf("compacted range must NOT report hit=true; got hit=%v err=%v", hit, err)
+	}
+	if !errors.Is(err, etcdraft.ErrCompacted) {
+		t.Logf("note: wrapped error %v — caller surfaces this as a scanner-error refusal", err)
+	}
+}
+
+// TestEncryptionScanner_NilStorageError verifies the defensive
+// nil-storage check. A zero-value encryptionScanner (or one
+// constructed before the engine is opened) must fail closed
+// rather than nil-deref.
+func TestEncryptionScanner_NilStorageError(t *testing.T) {
+	var s encryptionScanner
+	_, err := s.HasEncryptionRelevantEntryInRange(0, 5)
+	if err == nil {
+		t.Fatal("nil-storage scanner must return an error")
+	}
+}

--- a/internal/raftengine/etcd/encryption_scanner_test.go
+++ b/internal/raftengine/etcd/encryption_scanner_test.go
@@ -238,12 +238,32 @@ func TestEncryptionScanner_CompactedRange(t *testing.T) {
 // TestEncryptionScanner_NilStorageError verifies the defensive
 // nil-storage check. A zero-value encryptionScanner (or one
 // constructed before the engine is opened) must fail closed
-// rather than nil-deref.
+// rather than nil-deref. The range is non-empty so the
+// empty-range short-circuit doesn't fire first.
 func TestEncryptionScanner_NilStorageError(t *testing.T) {
 	var s encryptionScanner
 	_, err := s.HasEncryptionRelevantEntryInRange(0, 5)
 	if err == nil {
-		t.Fatal("nil-storage scanner must return an error")
+		t.Fatal("nil-storage scanner must return an error on a non-empty range")
+	}
+}
+
+// TestEncryptionScanner_NilStorageEmptyRange pins the
+// EncryptionRelevantScanner contract: empty range MUST return
+// (false, nil) UNCONDITIONALLY — including on a nil-storage
+// scanner. The guard order in HasEncryptionRelevantEntryInRange
+// is empty-range-first, then nil-storage, so this test pins the
+// ordering against future regressions where someone reorders the
+// guards and reintroduces the contract violation claude flagged
+// on PR #783 r3.
+func TestEncryptionScanner_NilStorageEmptyRange(t *testing.T) {
+	var s encryptionScanner
+	hit, err := s.HasEncryptionRelevantEntryInRange(5, 5)
+	if err != nil {
+		t.Fatalf("nil-storage scanner with empty range MUST return (false, nil) per contract; got err=%v", err)
+	}
+	if hit {
+		t.Fatalf("empty range must report no hit; got hit=%v", hit)
 	}
 }
 


### PR DESCRIPTION
## Summary

Stage 6C-2c per the [PR #762 plan](https://github.com/bootjp/elastickv/pull/762) and the 6C sub-decomposition landed in [PR #781](https://github.com/bootjp/elastickv/pull/781) / [PR #782](https://github.com/bootjp/elastickv/pull/782).

Ships the **raftengine-side scanner** that implements the `encryption.EncryptionRelevantScanner` interface defined in [PR #782 (Stage 6C-2b)](https://github.com/bootjp/elastickv/pull/782). The `main.go` startup-guard wiring that ties this scanner to the encryption-side guard is split into a new **6C-2d** sub-milestone per the design doc update in this PR.

## What this PR ships

### `encryptionScanner` against `etcdraft.MemoryStorage`

```go
func (e *Engine) EncryptionScanner() encryption.EncryptionRelevantScanner
```

Walks `raftpb.Entry` rows in `(startExclusive, endInclusive]` via `storage.Entries(lo, hi, scanMaxBytes)`, filters out:
- `EntryConfChange` / `EntryConfChangeV2` — config changes never carry FSM payloads; their `Data[0]` could coincidentally fall in the encryption opcode range without this gate
- Zero-length normal entries — etcd-raft leadership bumps after election; would `panic: index out of range` on a naive `Data[0]` read

Returns `IsEncryptionRelevantOpcode(ent.Data[0])` over surviving entries — i.e., asks whether any entry's opcode is in `[OpBootstrap, OpEncryptionMax]` = `[0x04, 0x07]`. Note: **OpRegistration (0x03) is correctly excluded** per the predicate's narrowed range from PR #782.

### Error semantics

| Path | Behavior |
|---|---|
| Compacted range (sidecar below snapshot horizon) | Wrapped `ErrCompacted` propagated; caller routes as scanner-error refusal **distinct** from `ErrSidecarBehindRaftLog` |
| `nil` storage (engine not opened) | Returns error rather than nil-deref |
| Empty range | `(false, nil)` fast path; storage NOT consulted |

### Tests (8 cases covering every branch)

| Test | Pins |
|---|---|
| `EmptyRange` (3 sub-cases) | equal / start-ahead / both-zero — storage never consulted |
| `NoRelevantEntries` | OpRegistration (0x03) explicitly NOT hit — pins the PR #782 predicate narrowing end-to-end |
| `BootstrapHit` | OpBootstrap in range → hit |
| `RotationHit` | OpRotation in range → hit |
| `NonNormalEntriesSkipped` | ConfChange / ConfChangeV2 with `Data[0]` in encryption range → NOT hit |
| `EmptyDataSkipped` | nil / empty `Data` → NOT hit AND no panic |
| `CompactedRange` | Snapshot at index 10, scan `[0, 5)` → error, hit=false |
| `NilStorageError` | Zero-value scanner returns an error |

## Design doc updates

- **6C-2c** row rewritten to reflect the scanner-only scope of this PR (engine implementation + `Engine.EncryptionScanner()` accessor, **no** `main.go` wiring).
- **6C-2d** row added — `main.go` startup-guard phase that ties 6C-2b's pure-function guard to 6C-2c's engine scanner. Will ship as its own PR.
- Shipping order updated: `6C-1 ✅ → 6C-2 ✅ → 6C-2b ✅ → 6C-2c (this PR) → 6C-2d → 6D (bundles 6C-3) → 6E (bundles 6C-4)`.
- Rationale section updated with the 6C-2c / 6C-2d split.

## Why split 6C-2c into "scanner" vs "wiring"

Keeping the engine scanner separate from the `main.go` wiring lets:
- Reviewers focus on one concern per PR.
- Stage 6D-and-later code paths that need the scanner (capability fan-out gap-coverage check) depend on the engine package without waiting for 6C-2d.
- 6C-2d's main.go integration touches the multi-shard lifecycle, which is a different concern from the engine-internal scanner implementation here.

## Caller audit

No public API changes outside `Engine.EncryptionScanner()`, which is net-additive. `encryptionScanner` and `isEncryptionRelevantEntry` are package-internal. No existing caller references the new accessor.

The implementation depends only on:
- `encryption.EncryptionRelevantScanner` (interface from PR #782)
- `encryption.IsEncryptionRelevantOpcode` (predicate from PR #782, OpRegistration-excluded)
- `etcdraft.MemoryStorage.Entries` (existing engine internal)
- `raftpb.Entry` / `raftpb.EntryConfChange` / V2 (existing types)

No changes to the engine's apply path or any other lifecycle.

## Five-lens self-review

1. **Data loss** — net-positive. The scanner enables the §9.1 refusal that catches partial-write crashes between an encryption-relevant Raft commit and the sidecar update. Until 6C-2d wires the scanner into main.go the scanner is operator-inert, but its failure modes (compacted-range error, conf-change skip, empty-data skip, nil-storage error) are all correct.
2. **Concurrency / distributed failures** — scanner reads from `MemoryStorage` (thread-safe per etcd-raft contract). Scanner itself is stateless.
3. **Performance** — zero hot-path impact. Called once per shard per process start in 6C-2d, with at most one `Entries()` call in the typical case (gap size << 64 MiB).
4. **Data consistency** — the scanner respects MemoryStorage's compaction boundary: never silently returns "no hit" for a range below the snapshot horizon; propagates the error so the guard routes it as a distinct scanner-error refusal.
5. **Test coverage** — 8 tests cover all 6 predicate paths, all 2 filter gates (type, length), AND the 2 error paths (compacted, nil-storage). The OpRegistration exclusion is pinned end-to-end with a dedicated test case.

## Test plan

- [x] `go test -race -timeout=120s ./internal/raftengine/etcd/... ./internal/encryption/...` — PASS
- [x] `golangci-lint run ./internal/raftengine/etcd/...` — 0 issues
- [ ] Full Jepsen suite — not run; scanner has no caller in this PR (operator-inert until 6C-2d)

## Plan

Per the design doc updates in this PR, next sub-milestones:
- **6C-2d** — `main.go` startup-guard phase that calls `encryption.GuardSidecarBehindRaftLog` with the scanner from this PR
- **6C-3** — `ErrNodeIDCollision` + `ErrLocalEpochRollback` (bundles with Stage 6D)
- **6D** — `enable-storage-envelope` admin RPC + §7.1 Phase-1 cutover (unblocked once 6C-2d lands)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Advances encryption-at-rest implementation with internal validation mechanisms to ensure system consistency during startup.

* **Documentation**
  * Updated design documentation clarifying the encryption-at-rest implementation phases and dependency chain.

* **Tests**
  * Added comprehensive test coverage for encryption validation logic, including edge cases and error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/783?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->