### PR TITLE
obs(redis): expose Lua VM pool counters to Prometheus + Grafana panels

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -24,6 +24,7 @@ import (
 	pb "github.com/bootjp/elastickv/proto"
 	"github.com/bootjp/elastickv/store"
 	"github.com/cockroachdb/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/redis/go-redis/v9"
 	"github.com/tidwall/redcon"
 )
@@ -552,6 +553,31 @@ func (r *RedisServer) Close() error {
 	}
 	if r.baseCancel != nil {
 		r.baseCancel()
+	}
+	return nil
+}
+
+// RegisterLuaPoolMetrics wires this server's bounded Lua VM pool
+// into the supplied Prometheus registerer, exposing five metrics
+// (hits / misses / drops / idle / max_idle). See
+// monitoring.RegisterLuaPool for the per-metric definitions.
+//
+// Returns nil if r, the pool, or registerer is nil — callers can
+// invoke this unconditionally from main.go without guarding for
+// test fixtures. The registration uses prometheus.NewCounterFunc /
+// NewGaugeFunc, so the values are read from the pool's atomic
+// counters at scrape time; no observability load is added to the
+// EVAL hot path.
+func (r *RedisServer) RegisterLuaPoolMetrics(registerer prometheus.Registerer) error {
+	if r == nil || registerer == nil {
+		return nil
+	}
+	pool := r.getLuaPool()
+	if pool == nil {
+		return nil
+	}
+	if err := monitoring.RegisterLuaPool(registerer, pool); err != nil {
+		return errors.Wrap(err, "register lua pool metrics")
 	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -1533,6 +1533,16 @@ func startRedisServer(ctx context.Context, lc *net.ListenConfig, eg *errgroup.Gr
 		adapter.WithRedisCompactor(deltaCompactor),
 		adapter.WithLuaPoolMaxIdle(*redisLuaMaxIdleStates),
 	)
+	// Wire the bounded Lua VM pool into Prometheus. The metrics
+	// (hits/misses/drops/idle/max_idle) are read at scrape time via
+	// CounterFunc / GaugeFunc, so the EVAL hot path stays
+	// observability-free. A registration error degrades observability
+	// only — keep running and surface via slog so the operator can
+	// notice on the next dashboard load rather than seeing a crash
+	// loop here.
+	if err := redisServer.RegisterLuaPoolMetrics(metricsRegistry.Registerer()); err != nil {
+		slog.Warn("failed to register lua pool metrics; pool counters will be invisible in Prometheus", "err", err)
+	}
 	eg.Go(func() error {
 		defer redisServer.Stop()
 		stop := make(chan struct{})

--- a/monitoring/grafana/dashboards/elastickv-redis-summary.json
+++ b/monitoring/grafana/dashboards/elastickv-redis-summary.json
@@ -1737,6 +1737,314 @@
       ],
       "title": "Hot Path (legacy PR #560)",
       "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 71
+      },
+      "id": 24,
+      "panels": [
+        {
+          "datasource": "$datasource",
+          "description": "Idle *lua.LState count retained by each node's bounded Lua VM pool (elastickv_lua_pool_idle) plotted against the configured cap (elastickv_lua_pool_max_idle). Idle staying pinned at MaxIdle for sustained periods + non-zero Drops below = pool is undersized; raise --redisLuaMaxIdleStates. Idle hovering near zero with no Drops = pool is right-sized or workload is below capacity.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "lineInterpolation": "stepAfter",
+                "lineWidth": 1,
+                "showPoints": "auto"
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "max_idle.*"
+                },
+                "properties": [
+                  {
+                    "id": "custom.lineStyle",
+                    "value": {
+                      "dash": [
+                        10,
+                        10
+                      ],
+                      "fill": "dash"
+                    }
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "id": 240,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": "$datasource",
+              "editorMode": "code",
+              "expr": "elastickv_lua_pool_idle{job=\"elastickv\"}",
+              "legendFormat": "idle {{node_id}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": "$datasource",
+              "editorMode": "code",
+              "expr": "elastickv_lua_pool_max_idle{job=\"elastickv\"}",
+              "legendFormat": "max_idle {{node_id}}",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Lua VM Pool — Idle vs MaxIdle",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "$datasource",
+          "description": "Rate of Lua VM pool outcomes: hits (get served from pool), misses (get had to allocate), drops (put rejected because pool full). Steady-state hits >> misses means the pool is doing its job; a sustained drops rate means --redisLuaMaxIdleStates is too low.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "showPoints": "auto"
+              },
+              "unit": "ops"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "drops.*"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "id": 241,
+          "options": {
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": "$datasource",
+              "editorMode": "code",
+              "expr": "sum by (node_id) (rate(elastickv_lua_pool_hits_total{job=\"elastickv\"}[5m]))",
+              "legendFormat": "hits {{node_id}}",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": "$datasource",
+              "editorMode": "code",
+              "expr": "sum by (node_id) (rate(elastickv_lua_pool_misses_total{job=\"elastickv\"}[5m]))",
+              "legendFormat": "misses {{node_id}}",
+              "range": true,
+              "refId": "B"
+            },
+            {
+              "datasource": "$datasource",
+              "editorMode": "code",
+              "expr": "sum by (node_id) (rate(elastickv_lua_pool_drops_total{job=\"elastickv\"}[5m]))",
+              "legendFormat": "drops {{node_id}}",
+              "range": true,
+              "refId": "C"
+            }
+          ],
+          "title": "Lua VM Pool — Hits / Misses / Drops Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "$datasource",
+          "description": "Cluster-wide Lua VM pool drops over the dashboard time range. Non-zero values mean at least one node's pool overflowed — raise --redisLuaMaxIdleStates on the affected nodes.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "orange",
+                    "value": 1
+                  },
+                  {
+                    "color": "red",
+                    "value": 100
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 0,
+            "y": 8
+          },
+          "id": 242,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": "$datasource",
+              "editorMode": "code",
+              "expr": "sum by (node_id) (increase(elastickv_lua_pool_drops_total{job=\"elastickv\"}[$__range]))",
+              "legendFormat": "{{node_id}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Drops over Range (per Node)",
+          "type": "stat"
+        },
+        {
+          "datasource": "$datasource",
+          "description": "Lua VM pool saturation = idle / max_idle, per node. 100% means the pool is fully populated (every put() is at risk of dropping). Sustained 100% + non-zero Drops rate = raise --redisLuaMaxIdleStates.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0.8
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 16,
+            "x": 8,
+            "y": 8
+          },
+          "id": 243,
+          "options": {
+            "displayMode": "gradient",
+            "minVizHeight": 10,
+            "minVizWidth": 0,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true
+          },
+          "pluginVersion": "11.0.0",
+          "targets": [
+            {
+              "datasource": "$datasource",
+              "editorMode": "code",
+              "expr": "elastickv_lua_pool_idle{job=\"elastickv\"} / elastickv_lua_pool_max_idle{job=\"elastickv\"}",
+              "legendFormat": "{{node_id}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Pool Saturation (idle / max_idle)",
+          "type": "bargauge"
+        }
+      ],
+      "title": "Lua VM Pool",
+      "type": "row"
     }
   ],
   "refresh": "10s",

--- a/monitoring/grafana/dashboards/elastickv-redis-summary.json
+++ b/monitoring/grafana/dashboards/elastickv-redis-summary.json
@@ -1746,7 +1746,7 @@
         "x": 0,
         "y": 71
       },
-      "id": 24,
+      "id": 33,
       "panels": [
         {
           "datasource": "$datasource",
@@ -1814,7 +1814,7 @@
             {
               "datasource": "$datasource",
               "editorMode": "code",
-              "expr": "elastickv_lua_pool_idle{job=\"elastickv\"}",
+              "expr": "elastickv_lua_pool_idle{job=\"elastickv\",node_id=~\"$node_id\"}",
               "legendFormat": "idle {{node_id}}",
               "range": true,
               "refId": "A"
@@ -1822,7 +1822,7 @@
             {
               "datasource": "$datasource",
               "editorMode": "code",
-              "expr": "elastickv_lua_pool_max_idle{job=\"elastickv\"}",
+              "expr": "elastickv_lua_pool_max_idle{job=\"elastickv\",node_id=~\"$node_id\"}",
               "legendFormat": "max_idle {{node_id}}",
               "range": true,
               "refId": "B"
@@ -1887,7 +1887,7 @@
             {
               "datasource": "$datasource",
               "editorMode": "code",
-              "expr": "sum by (node_id) (rate(elastickv_lua_pool_hits_total{job=\"elastickv\"}[5m]))",
+              "expr": "sum by (node_id) (rate(elastickv_lua_pool_hits_total{job=\"elastickv\",node_id=~\"$node_id\"}[5m]))",
               "legendFormat": "hits {{node_id}}",
               "range": true,
               "refId": "A"
@@ -1895,7 +1895,7 @@
             {
               "datasource": "$datasource",
               "editorMode": "code",
-              "expr": "sum by (node_id) (rate(elastickv_lua_pool_misses_total{job=\"elastickv\"}[5m]))",
+              "expr": "sum by (node_id) (rate(elastickv_lua_pool_misses_total{job=\"elastickv\",node_id=~\"$node_id\"}[5m]))",
               "legendFormat": "misses {{node_id}}",
               "range": true,
               "refId": "B"
@@ -1903,7 +1903,7 @@
             {
               "datasource": "$datasource",
               "editorMode": "code",
-              "expr": "sum by (node_id) (rate(elastickv_lua_pool_drops_total{job=\"elastickv\"}[5m]))",
+              "expr": "sum by (node_id) (rate(elastickv_lua_pool_drops_total{job=\"elastickv\",node_id=~\"$node_id\"}[5m]))",
               "legendFormat": "drops {{node_id}}",
               "range": true,
               "refId": "C"
@@ -1967,7 +1967,7 @@
             {
               "datasource": "$datasource",
               "editorMode": "code",
-              "expr": "sum by (node_id) (increase(elastickv_lua_pool_drops_total{job=\"elastickv\"}[$__range]))",
+              "expr": "sum by (node_id) (increase(elastickv_lua_pool_drops_total{job=\"elastickv\",node_id=~\"$node_id\"}[$__range]))",
               "legendFormat": "{{node_id}}",
               "range": true,
               "refId": "A"
@@ -2033,7 +2033,7 @@
             {
               "datasource": "$datasource",
               "editorMode": "code",
-              "expr": "elastickv_lua_pool_idle{job=\"elastickv\"} / elastickv_lua_pool_max_idle{job=\"elastickv\"}",
+              "expr": "elastickv_lua_pool_idle{job=\"elastickv\",node_id=~\"$node_id\"} / elastickv_lua_pool_max_idle{job=\"elastickv\",node_id=~\"$node_id\"}",
               "legendFormat": "{{node_id}}",
               "range": true,
               "refId": "A"

--- a/monitoring/lua_pool.go
+++ b/monitoring/lua_pool.go
@@ -1,0 +1,88 @@
+package monitoring
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// LuaPoolSource exposes the bounded *lua.LState pool counters that
+// the Redis adapter maintains. The interface is a narrow projection
+// of adapter.luaStatePool so the monitoring package does not depend
+// on the adapter package (avoiding an import cycle): adapter wires
+// `*luaStatePool` as a LuaPoolSource at NewRedisServer time.
+//
+// All four accessors are read at Prometheus scrape time via
+// prometheus.NewCounterFunc / NewGaugeFunc, so the lua hot path
+// incurs zero observability overhead — the counters live on the
+// pool as atomic.Uint64 either way; the metrics collector merely
+// reads them when /metrics is hit.
+type LuaPoolSource interface {
+	// Hits is the total number of get() calls served from the idle
+	// pool (counts pool reuses).
+	Hits() uint64
+	// Misses is the total number of get() calls that fell through
+	// to a fresh *lua.LState allocation (counts pool starvation).
+	Misses() uint64
+	// Drops is the total number of put() calls rejected because
+	// the idle pool was full (counts pool saturation — i.e.
+	// MaxIdle could be raised to retain more states).
+	Drops() uint64
+	// Idle is the current number of *lua.LState instances sitting
+	// in the pool ready for reuse.
+	Idle() int
+	// MaxIdle is the configured upper bound on Idle. Exported so
+	// dashboards can plot Idle/MaxIdle as a saturation ratio.
+	MaxIdle() int
+}
+
+// RegisterLuaPool wires `src` into the Prometheus registerer as a
+// set of CounterFunc / GaugeFunc metrics:
+//
+//   - elastickv_lua_pool_hits_total
+//   - elastickv_lua_pool_misses_total
+//   - elastickv_lua_pool_drops_total
+//   - elastickv_lua_pool_idle
+//   - elastickv_lua_pool_max_idle
+//
+// Returns nil if src or registerer is nil; returns the first
+// registration error otherwise. The caller (typically
+// adapter.RedisServer.RegisterLuaPoolMetrics) should log-and-
+// continue on error rather than refusing to start: a missing pool
+// metric is observability degradation, not a correctness issue.
+//
+// The CounterFunc / GaugeFunc closures capture `src` directly, so
+// they read live values at scrape time. There is no polling
+// goroutine and no snapshot staleness.
+func RegisterLuaPool(registerer prometheus.Registerer, src LuaPoolSource) error {
+	if registerer == nil || src == nil {
+		return nil
+	}
+	collectors := []prometheus.Collector{
+		prometheus.NewCounterFunc(prometheus.CounterOpts{
+			Name: "elastickv_lua_pool_hits_total",
+			Help: "Total number of Redis Lua VM pool get() calls served from the idle pool (reuses). Reset on process restart.",
+		}, func() float64 { return float64(src.Hits()) }),
+		prometheus.NewCounterFunc(prometheus.CounterOpts{
+			Name: "elastickv_lua_pool_misses_total",
+			Help: "Total number of Redis Lua VM pool get() calls that fell through to a fresh allocation (pool empty). Reset on process restart.",
+		}, func() float64 { return float64(src.Misses()) }),
+		prometheus.NewCounterFunc(prometheus.CounterOpts{
+			Name: "elastickv_lua_pool_drops_total",
+			Help: "Total number of Redis Lua VM pool put() calls rejected because the idle pool was at MaxIdle capacity. Drops > 0 means --redisLuaMaxIdleStates is undersized for the workload. Reset on process restart.",
+		}, func() float64 { return float64(src.Drops()) }),
+		prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+			Name: "elastickv_lua_pool_idle",
+			Help: "Current number of *lua.LState instances sitting in the Redis Lua VM pool ready for reuse. Plot against elastickv_lua_pool_max_idle to see saturation.",
+		}, func() float64 { return float64(src.Idle()) }),
+		prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+			Name: "elastickv_lua_pool_max_idle",
+			Help: "Configured upper bound on Redis Lua VM pool idle retention (--redisLuaMaxIdleStates).",
+		}, func() float64 { return float64(src.MaxIdle()) }),
+	}
+	for _, c := range collectors {
+		if err := registerer.Register(c); err != nil {
+			return errors.Wrap(err, "register lua pool collector")
+		}
+	}
+	return nil
+}

--- a/monitoring/lua_pool.go
+++ b/monitoring/lua_pool.go
@@ -81,6 +81,15 @@ func RegisterLuaPool(registerer prometheus.Registerer, src LuaPoolSource) error 
 	}
 	for _, c := range collectors {
 		if err := registerer.Register(c); err != nil {
+			// Idempotent on AlreadyRegistered so callers that retry
+			// (test harnesses with shared registries, hypothetical
+			// hot-reload paths) don't trip a spurious slog.Warn in
+			// main.go. Any other error — invalid metric name,
+			// inconsistent labels, registry conflict — surfaces.
+			var already prometheus.AlreadyRegisteredError
+			if errors.As(err, &already) {
+				continue
+			}
 			return errors.Wrap(err, "register lua pool collector")
 		}
 	}

--- a/monitoring/lua_pool_test.go
+++ b/monitoring/lua_pool_test.go
@@ -1,0 +1,148 @@
+package monitoring
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeLuaPool is a minimal in-memory LuaPoolSource for tests so the
+// monitoring package can verify wiring without pulling in the
+// adapter package. The four counter accessors read directly from
+// atomic.Uint64 values, mirroring what adapter.luaStatePool does
+// under the hood.
+type fakeLuaPool struct {
+	hits, misses, drops atomic.Uint64
+	idle                atomic.Int64
+	maxIdle             int
+}
+
+func (f *fakeLuaPool) Hits() uint64   { return f.hits.Load() }
+func (f *fakeLuaPool) Misses() uint64 { return f.misses.Load() }
+func (f *fakeLuaPool) Drops() uint64  { return f.drops.Load() }
+func (f *fakeLuaPool) Idle() int      { return int(f.idle.Load()) }
+func (f *fakeLuaPool) MaxIdle() int   { return f.maxIdle }
+
+func TestRegisterLuaPool_ExposesEachAccessorAsAMetric(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	src := &fakeLuaPool{maxIdle: 64}
+	require.NoError(t, RegisterLuaPool(reg, src))
+
+	// Seed each counter with a distinct value so a wiring swap
+	// (e.g. hits → misses) would be caught.
+	src.hits.Store(7)
+	src.misses.Store(11)
+	src.drops.Store(3)
+	src.idle.Store(5)
+
+	expect := strings.TrimLeft(`
+# HELP elastickv_lua_pool_drops_total Total number of Redis Lua VM pool put() calls rejected because the idle pool was at MaxIdle capacity. Drops > 0 means --redisLuaMaxIdleStates is undersized for the workload. Reset on process restart.
+# TYPE elastickv_lua_pool_drops_total counter
+elastickv_lua_pool_drops_total 3
+# HELP elastickv_lua_pool_hits_total Total number of Redis Lua VM pool get() calls served from the idle pool (reuses). Reset on process restart.
+# TYPE elastickv_lua_pool_hits_total counter
+elastickv_lua_pool_hits_total 7
+# HELP elastickv_lua_pool_idle Current number of *lua.LState instances sitting in the Redis Lua VM pool ready for reuse. Plot against elastickv_lua_pool_max_idle to see saturation.
+# TYPE elastickv_lua_pool_idle gauge
+elastickv_lua_pool_idle 5
+# HELP elastickv_lua_pool_max_idle Configured upper bound on Redis Lua VM pool idle retention (--redisLuaMaxIdleStates).
+# TYPE elastickv_lua_pool_max_idle gauge
+elastickv_lua_pool_max_idle 64
+# HELP elastickv_lua_pool_misses_total Total number of Redis Lua VM pool get() calls that fell through to a fresh allocation (pool empty). Reset on process restart.
+# TYPE elastickv_lua_pool_misses_total counter
+elastickv_lua_pool_misses_total 11
+`, "\n")
+	require.NoError(t, testutil.GatherAndCompare(reg, strings.NewReader(expect),
+		"elastickv_lua_pool_hits_total",
+		"elastickv_lua_pool_misses_total",
+		"elastickv_lua_pool_drops_total",
+		"elastickv_lua_pool_idle",
+		"elastickv_lua_pool_max_idle"))
+}
+
+// TestRegisterLuaPool_ReflectsLiveUpdatesAtScrapeTime locks in the
+// "read at scrape time" contract — there is no polling goroutine and
+// no snapshot, so a counter that increments AFTER registration must
+// surface on the very next gather without any flush/wait step. This
+// test would catch a regression that introduced internal caching
+// behind RegisterLuaPool.
+func TestRegisterLuaPool_ReflectsLiveUpdatesAtScrapeTime(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	src := &fakeLuaPool{maxIdle: 64}
+	require.NoError(t, RegisterLuaPool(reg, src))
+
+	// First gather: all zero.
+	require.Equal(t, float64(0),
+		testutil.ToFloat64(srcCollectorByName(t, reg, "elastickv_lua_pool_drops_total")))
+
+	// Update underlying counter, gather again, expect the new value.
+	src.drops.Add(42)
+	require.Equal(t, float64(42),
+		testutil.ToFloat64(srcCollectorByName(t, reg, "elastickv_lua_pool_drops_total")))
+}
+
+// TestRegisterLuaPool_NilSafe ensures that callers passing a nil
+// source or registerer get a no-op without panicking. This keeps
+// the adapter side free to call RegisterLuaPool unconditionally
+// (e.g. in tests that wire a bare &RedisServer{} literal).
+func TestRegisterLuaPool_NilSafe(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, RegisterLuaPool(nil, &fakeLuaPool{}))
+	require.NoError(t, RegisterLuaPool(prometheus.NewRegistry(), nil))
+	require.NoError(t, RegisterLuaPool(nil, nil))
+}
+
+// srcCollectorByName is a tiny helper that fetches a registered
+// collector by metric name so testutil.ToFloat64 can read its
+// scrape value. It hides the gather + scan boilerplate from each
+// test case.
+func srcCollectorByName(t *testing.T, reg *prometheus.Registry, name string) prometheus.Collector {
+	t.Helper()
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			// We need a Collector to hand to testutil.ToFloat64;
+			// re-wrap via a constant collector that emits the same
+			// sample.
+			require.Len(t, mf.Metric, 1, "metric %q must have exactly one sample for this test", name)
+			m := mf.Metric[0]
+			var value float64
+			switch {
+			case m.Counter != nil:
+				value = m.Counter.GetValue()
+			case m.Gauge != nil:
+				value = m.Gauge.GetValue()
+			default:
+				t.Fatalf("metric %q is neither counter nor gauge", name)
+			}
+			return &staticCollector{name: name, value: value}
+		}
+	}
+	t.Fatalf("metric %q not registered", name)
+	return nil
+}
+
+type staticCollector struct {
+	name  string
+	value float64
+}
+
+func (s *staticCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- prometheus.NewDesc(s.name, "", nil, nil)
+}
+func (s *staticCollector) Collect(ch chan<- prometheus.Metric) {
+	ch <- prometheus.MustNewConstMetric(
+		prometheus.NewDesc(s.name, "", nil, nil),
+		prometheus.GaugeValue,
+		s.value,
+	)
+}

--- a/monitoring/lua_pool_test.go
+++ b/monitoring/lua_pool_test.go
@@ -100,6 +100,25 @@ func TestRegisterLuaPool_NilSafe(t *testing.T) {
 	require.NoError(t, RegisterLuaPool(nil, nil))
 }
 
+// TestRegisterLuaPool_IdempotentOnDoubleRegister locks in the
+// AlreadyRegisteredError absorption added per gemini r1 review:
+// calling RegisterLuaPool a second time against the same registerer
+// must succeed silently rather than returning a noisy error that
+// main.go would surface as a slog.Warn. Test harnesses that share a
+// registry across sub-tests rely on this.
+func TestRegisterLuaPool_IdempotentOnDoubleRegister(t *testing.T) {
+	t.Parallel()
+	reg := prometheus.NewRegistry()
+	src := &fakeLuaPool{maxIdle: 64}
+	require.NoError(t, RegisterLuaPool(reg, src))
+	// Second call must be a no-op success: each of the five
+	// CounterFunc / GaugeFunc collectors AlreadyRegisteredError-
+	// returns on Register(), and the loop should absorb that.
+	require.NoError(t, RegisterLuaPool(reg, src),
+		"double registration must be idempotent so noisy retry paths "+
+			"don't crash main.go via the slog.Warn return")
+}
+
 // srcCollectorByName is a tiny helper that fetches a registered
 // collector by metric name so testutil.ToFloat64 can read its
 // scrape value. It hides the gather + scan boilerplate from each

--- a/monitoring/registry.go
+++ b/monitoring/registry.go
@@ -66,6 +66,20 @@ func (r *Registry) Gatherer() prometheus.Gatherer {
 	return r.gatherer
 }
 
+// Registerer exposes the label-wrapped registerer for callers that
+// own a metric source whose lifecycle does not fit the
+// newXxxMetrics(registerer) pattern in NewRegistry — currently the
+// Redis adapter's Lua VM pool, which materializes inside
+// NewRedisServer and registers via CounterFunc / GaugeFunc at that
+// point. Returns nil if r is nil so callers can dereference safely
+// in test fixtures.
+func (r *Registry) Registerer() prometheus.Registerer {
+	if r == nil {
+		return nil
+	}
+	return r.registerer
+}
+
 // DynamoDBObserver returns the DynamoDB request observer backed by this registry.
 func (r *Registry) DynamoDBObserver() DynamoDBRequestObserver {
 	if r == nil {


### PR DESCRIPTION
## Summary
Wire the bounded Lua VM pool (PR #785) counters into Prometheus and add a Grafana row.

**New metrics** (Counter / Gauge funcs — read at scrape time, zero per-EVAL cost):
- `elastickv_lua_pool_hits_total` — counter
- `elastickv_lua_pool_misses_total` — counter
- `elastickv_lua_pool_drops_total` — counter ← the **"raise --redisLuaMaxIdleStates"** alarm
- `elastickv_lua_pool_idle` — gauge
- `elastickv_lua_pool_max_idle` — gauge

**New Grafana row** "Lua VM Pool" in `elastickv-redis-summary.json`:
- Idle vs MaxIdle (timeseries, max_idle dashed in red)
- Hits / Misses / Drops rate (timeseries, drops in red)
- Drops over Range (stat per node, green/orange/red)
- Pool Saturation idle/max_idle (bargauge, 0–100%)

## Background
PR #785 (merged) added the bounded pool with internal `atomic.Uint64` counters, but they were not exposed. With this PR operators can watch `elastickv_lua_pool_drops_total` and `elastickv_lua_pool_idle / elastickv_lua_pool_max_idle` to decide whether `--redisLuaMaxIdleStates` is right-sized.

## Caller audit (LuaPoolSource interface)
- New interface in monitoring/; only implemented by `adapter.luaStatePool`. Verified at the call site by the type system; monitoring tests use a fake stub.
- All accessors are atomic loads — pure, can't panic / block / mutate. Safe from the scrape goroutine.

## Self-review (5 lenses)
1. **Data loss** — N/A (read-only observability).
2. **Concurrency** — atomic loads; -race tests pass.
3. **Performance** — zero per-EVAL cost. Scrape (every ~15s) does 5x atomic.Load.
4. **Data consistency** — N/A.
5. **Test coverage** — 3 new tests: value exposure, live-update contract, nil-safety.

## Test plan
- [x] `go test -race -count=1 ./adapter ./monitoring` — all green
- [x] `golangci-lint run` — 0 issues
- [x] JSON valid for dashboard
- [ ] Deploy to production cluster (192.168.0.210-214), verify `/metrics` shows the new counters
- [ ] Grafana dashboard re-import, verify the new "Lua VM Pool" row renders


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prometheus metrics added for Lua VM pool: idle capacity, max idle, hits, misses, drops.
  * New Grafana dashboard row with four panels visualizing Lua VM pool health, saturation, rates, and drops per node.
  * Metrics are registered during service startup and will log a warning if unavailable.

* **Tests**
  * Added tests validating metric exposure, live updates, nil-safety, and idempotent registration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/787?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->