### PR TITLE
fix(redis): NOTLEADER prefix for gRPC-wrapped leader errors (closes Jepsen run 26035515694 crash)

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -355,12 +355,58 @@ func isTransientLeaderRedisError(err error) bool {
 	if err == nil {
 		return false
 	}
-	return errors.Is(err, ErrLeaderNotFound) ||
+	if errors.Is(err, ErrLeaderNotFound) ||
 		errors.Is(err, ErrNotLeader) ||
 		errors.Is(err, kv.ErrLeaderNotFound) ||
 		errors.Is(err, raftengine.ErrNotLeader) ||
 		errors.Is(err, raftengine.ErrLeadershipLost) ||
-		errors.Is(err, raftengine.ErrLeadershipTransferInProgress)
+		errors.Is(err, raftengine.ErrLeadershipTransferInProgress) {
+		return true
+	}
+	// Suffix fallback for gRPC-wrapped sentinels. When the coordinator
+	// forwards a request to a remote leader via the operational gRPC
+	// service and that leader returns ErrLeaderNotFound, the status
+	// interceptor flattens the error to "rpc error: code = Unknown
+	// desc = leader not found"; the typed sentinel chain is stripped
+	// at the wire boundary, so errors.Is misses it. The Jepsen Redis
+	// workload (scheduled run 26035515694) saw workers crash with
+	// `:prefix :rpc` because the un-prefixed `"rpc error: …"` string
+	// reached Carmine. Match the same closed phrase set
+	// kv.hasTransientLeaderPhrase uses, with the same HasSuffix
+	// guard: free-form Contains would misclassify a user-controlled
+	// key like "key: not leader: write conflict" as transient.
+	return hasTransientLeaderSuffix(err.Error())
+}
+
+// redisLeaderErrorPhrases mirrors kv.leaderErrorPhrases (the kv
+// package keeps it unexported). Any new transient-leader phrase the
+// kv layer treats as retryable should also flip a NOTLEADER prefix
+// on the Redis wire so Carmine's with-exceptions catches it; keep
+// in lockstep.
+var redisLeaderErrorPhrases = []string{
+	"not leader",
+	"leader not found",
+	"leadership lost",
+	"leadership transfer in progress",
+}
+
+// hasTransientLeaderSuffix is the suffix-match fallback for
+// isTransientLeaderRedisError. Suffix — not free-form Contains —
+// because cockroachdb/errors %w-prefix and gRPC status.Errorf's
+// "rpc error: code = X desc = <orig>" both leave the original
+// sentinel text at the END of the composed string; a Contains
+// match would tag a user-controlled key like "key: not leader:
+// conflict" as transient. Lower-cased once up front because both
+// phrase sets are lower-case and the carmine wire is case-
+// preserving.
+func hasTransientLeaderSuffix(msg string) bool {
+	lower := strings.ToLower(msg)
+	for _, phrase := range redisLeaderErrorPhrases {
+		if strings.HasSuffix(lower, phrase) {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *redisMetricsConn) reset(conn redcon.Conn) {

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -396,13 +396,17 @@ var redisLeaderErrorPhrases = []string{
 // "rpc error: code = X desc = <orig>" both leave the original
 // sentinel text at the END of the composed string; a Contains
 // match would tag a user-controlled key like "key: not leader:
-// conflict" as transient. Lower-cased once up front because both
-// phrase sets are lower-case and the carmine wire is case-
-// preserving.
+// conflict" as transient.
+//
+// strings.EqualFold on the trailing slice — rather than
+// strings.ToLower + HasSuffix — avoids allocating a copy of the
+// full message. cockroachdb/errors messages can be multi-KB when
+// they carry a serialized stack trace; this matters on the error
+// path under leader-loss storms.
 func hasTransientLeaderSuffix(msg string) bool {
-	lower := strings.ToLower(msg)
 	for _, phrase := range redisLeaderErrorPhrases {
-		if strings.HasSuffix(lower, phrase) {
+		if len(msg) >= len(phrase) &&
+			strings.EqualFold(msg[len(msg)-len(phrase):], phrase) {
 			return true
 		}
 	}

--- a/adapter/redis_error_prefix_test.go
+++ b/adapter/redis_error_prefix_test.go
@@ -43,6 +43,28 @@ func TestIsTransientLeaderRedisError(t *testing.T) {
 		{"unrelated error", io.EOF, false},
 		{"nil", nil, false},
 		{"wrong-type-looking error", errors.New("WRONGTYPE op"), false},
+		// Suffix-fallback regression cases. These cover the gRPC-
+		// boundary path: when the coordinator forwards to a remote
+		// leader and the remote returns ErrLeaderNotFound, gRPC
+		// flattens it to "rpc error: code = X desc = leader not
+		// found"; the typed sentinel chain is gone. The Jepsen
+		// Redis workload (scheduled run 26035515694) saw workers
+		// crash with `:prefix :rpc` because this case was not
+		// classified as transient and the raw "rpc error: …"
+		// reached Carmine.
+		{"grpc-wrapped leader not found",
+			errors.New("rpc error: code = Unknown desc = leader not found"), true},
+		{"grpc-wrapped not leader",
+			errors.New("rpc error: code = FailedPrecondition desc = raft engine: not leader"), true},
+		{"grpc-wrapped leadership lost",
+			errors.New("rpc error: code = Aborted desc = raft engine: leadership lost"), true},
+		{"grpc-wrapped leadership transfer",
+			errors.New("rpc error: code = Aborted desc = raft engine: leadership transfer in progress"), true},
+		// Suffix discipline: a user-controlled key in the middle
+		// of the message must NOT trigger a false positive. The kv
+		// suffix matcher pins this exact scenario; mirror it here.
+		{"user key embedding 'not leader' in the middle",
+			errors.New("key: not leader: write conflict"), false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -74,6 +96,15 @@ func TestWriteRedisError(t *testing.T) {
 			errors.New("WRONGTYPE op"), "WRONGTYPE op"},
 		{"generic io.EOF untouched",
 			io.EOF, io.EOF.Error()},
+		// Suffix-fallback wire reply regression: the gRPC-wrapped
+		// "rpc error: code = Unknown desc = leader not found" string
+		// (the failure mode behind scheduled run 26035515694) must
+		// gain a NOTLEADER prefix on the Redis wire so Carmine maps
+		// it to `:prefix :notleader` and the upstream
+		// jepsen-io/redis with-exceptions catch fires.
+		{"grpc-wrapped leader-not-found gains NOTLEADER prefix",
+			errors.New("rpc error: code = Unknown desc = leader not found"),
+			"NOTLEADER rpc error: code = Unknown desc = leader not found"},
 		// Regression: address-mapping gap errors (raft leader known
 		// but raft→redis address missing in r.leaderRedis) must be
 		// ERR-prefixed at the source so Carmine maps to :prefix :err

--- a/adapter/redis_error_prefix_test.go
+++ b/adapter/redis_error_prefix_test.go
@@ -130,3 +130,45 @@ func TestWriteRedisError(t *testing.T) {
 		})
 	}
 }
+
+// TestHasTransientLeaderSuffix_PinsSentinels closes the gap noted
+// at kv/coordinator.go:529 ("A symmetric pin lives in the adapter
+// test package"): the adapter's redisLeaderErrorPhrases set must
+// stay in sync with the actual .Error() text of every transient-
+// leader sentinel the suffix fallback is meant to catch. If a
+// sentinel ever gets renamed (e.g. raftengine.ErrLeadershipLost
+// becomes "raft engine: leadership lost (xyz)") the kv-side pin
+// fails first, but without this adapter-side pin the adapter's
+// phrase list could drift silently and the NOTLEADER classification
+// would regress to the pre-PR-789 worker-crash failure mode.
+//
+// Each case calls hasTransientLeaderSuffix(sentinel.Error()) and
+// asserts true. Wrapping (errors.Wrap / fmt.Errorf %w) is covered
+// by TestIsTransientLeaderRedisError; this test pins the raw
+// .Error() strings only.
+func TestHasTransientLeaderSuffix_PinsSentinels(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		msg  string
+	}{
+		{"adapter.ErrLeaderNotFound", ErrLeaderNotFound.Error()},
+		{"adapter.ErrNotLeader", ErrNotLeader.Error()},
+		{"kv.ErrLeaderNotFound", kv.ErrLeaderNotFound.Error()},
+		{"raftengine.ErrNotLeader", raftengine.ErrNotLeader.Error()},
+		{"raftengine.ErrLeadershipLost", raftengine.ErrLeadershipLost.Error()},
+		{"raftengine.ErrLeadershipTransferInProgress",
+			raftengine.ErrLeadershipTransferInProgress.Error()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if !hasTransientLeaderSuffix(tc.msg) {
+				t.Fatalf("hasTransientLeaderSuffix(%q) = false; "+
+					"redisLeaderErrorPhrases is out of sync with %s — "+
+					"a sentinel rename slipped through. Update the "+
+					"phrase list in adapter/redis.go to match.", tc.msg, tc.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Fix Redis worker crashes seen in scheduled Jepsen run [26035515694](https://github.com/bootjp/elastickv/actions/runs/26035515694/job/76532418404) — many workers died with `IllegalArgumentException: Don't know how to create ISeq from: clojure.lang.ExceptionInfo` because the carmine error carried `:prefix :rpc`, which `jepsen-io/redis`'s `with-exceptions` does not catch.

PR #753 introduced the `NOTLEADER` prefix and `isTransientLeaderRedisError` classifier (typed via `errors.Is`). After gRPC boundary the typed chain is stripped and the error becomes the literal string `"rpc error: code = Unknown desc = leader not found"` — the typed classifier missed it.

This PR adds a **suffix-match fallback** to `isTransientLeaderRedisError`, mirroring `kv.hasTransientLeaderPhrase`. The phrase set is closed and `HasSuffix`-based — the same load-bearing discipline used in `kv/coordinator.go` to avoid misclassifying a user-controlled key like `"key: not leader: write conflict"`.

## Why this matters for the run-26035515694 "Analysis invalid" verdict
The run also showed apparent list-ordering anomalies (e.g. `[1 2 3 4 6 7 8 9 11 12 13 10 …]`). Workers crashing caused many transactions to be marked `:type :info` (outcome unknown), which inflates the checker's solution space and can produce spurious anomalies. Fixing the worker crash is the prerequisite — after this lands, a re-run will tell whether the list-ordering signal is real or an artifact.

## Caller audit
`isTransientLeaderRedisError` has one caller: `writeRedisError`. The change is **strictly additive** — errors that were previously classified `true` still are; errors with a transient-leader suffix on a stripped chain are now also `true`. No error loses the prefix. Carmine semantics improve from `:prefix :rpc` (uncaught → worker crash) to `:prefix :notleader` (caught by `with-exceptions` → mapped to `:type :fail :error :notleader`).

## Self-review (5 lenses)
1. **Data loss** — N/A (Redis error reply prefix only).
2. **Concurrency** — pure read; -race clean.
3. **Performance** — error path only; one `strings.ToLower` + 4 `HasSuffix` per error reply.
4. **Data consistency** — wire format only; sentinels unchanged.
5. **Test coverage** — six new classifier cases (4 gRPC-wrapped variants + 1 false-positive negative), one new wire-reply case.

## Test plan
- [x] `go test -race -count=1 -short ./adapter` — 566s, all green
- [x] `go vet ./adapter` — clean
- [x] `golangci-lint run --config=.golangci.yaml ./adapter` — 0 issues
- [ ] CI green
- [ ] Re-run scheduled Jepsen Redis workload to confirm worker crashes resolved + check whether list anomaly persists


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of transient Redis leadership errors, including cases where errors are wrapped by transport layers and lose their original type. Added a safe suffix-matching fallback to correctly classify leader-related errors while avoiding misclassification of user-controlled text.

* **Tests**
  * Extended regression tests to cover wrapped/substring leadership error scenarios and ensure correct error-prefixing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/789?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->