### PR TITLE
ops(ci): upload full demo cluster log on Jepsen failure

### DIFF
--- a/.github/workflows/jepsen-test-scheduled.yml
+++ b/.github/workflows/jepsen-test-scheduled.yml
@@ -229,7 +229,28 @@ jobs:
             --host 127.0.0.1
       - name: Dump demo cluster log on failure
         if: failure()
-        run: tail -n 500 /tmp/elastickv-demo.log || true
+        # The previous `tail -n 500` truncated a 3-minute workload's
+        # log down to startup-only lines, making it impossible to
+        # correlate a Jepsen anomaly with the server-side state
+        # (start_ts, commit_ts, raft term, write conflicts, lock-
+        # resolver events). Print head + tail inline so the GH UI
+        # still shows the most recent activity at-a-glance, then
+        # upload the full log as an artifact for offline analysis.
+        run: |
+          echo "=== first 200 lines (startup) ==="
+          head -n 200 /tmp/elastickv-demo.log || true
+          echo "=== last 1000 lines (most recent activity) ==="
+          tail -n 1000 /tmp/elastickv-demo.log || true
+          echo "=== full log line count ==="
+          wc -l /tmp/elastickv-demo.log || true
+      - name: Upload demo cluster log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: elastickv-demo-log
+          path: /tmp/elastickv-demo.log
+          retention-days: 14
+          if-no-files-found: warn
       - name: Stop demo cluster
         if: always()
         run: |

--- a/.github/workflows/jepsen-test.yml
+++ b/.github/workflows/jepsen-test.yml
@@ -194,6 +194,33 @@ jobs:
             --partition-count 4 --group-count 6 \
             --drain-time 15 \
             --sqs-ports 63501,63502,63503 --host 127.0.0.1
+      - name: Dump demo cluster logs on failure
+        if: failure()
+        # Same rationale as jepsen-test-scheduled.yml: inline summary
+        # for the GH UI + full per-node logs uploaded as artifact so
+        # any Jepsen anomaly can be traced to the server-side ts/raft
+        # state without re-running the workflow.
+        run: |
+          for node in n1 n2 n3; do
+            log=/tmp/elastickv-demo-${node}.log
+            echo "=== ${node}: first 200 lines (startup) ==="
+            head -n 200 "$log" || true
+            echo "=== ${node}: last 500 lines (most recent activity) ==="
+            tail -n 500 "$log" || true
+            echo "=== ${node}: full log line count ==="
+            wc -l "$log" || true
+          done
+      - name: Upload demo cluster logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: elastickv-demo-logs
+          path: |
+            /tmp/elastickv-demo-n1.log
+            /tmp/elastickv-demo-n2.log
+            /tmp/elastickv-demo-n3.log
+          retention-days: 14
+          if-no-files-found: warn
       - name: Stop demo cluster
         if: always()
         run: |


### PR DESCRIPTION
## Summary
Make the Jepsen workflows upload the full demo cluster log as an artifact (14-day retention) on failure, instead of only the last 500 lines inline.

## Motivation
Scheduled run [26198185540](https://github.com/bootjp/elastickv/actions/runs/26198185540) surfaced a real `:duplicate-elements` anomaly on the Redis Jepsen workload. Server-side investigation was blocked because the "Dump demo cluster log on failure" step's `tail -n 500` captured only the startup section of a 3-minute workload — the actual start_ts / commit_ts / raft-term / write-conflict / lock-resolver events that would identify the offending code path were truncated.

## Change
- **Scheduled workflow** (`jepsen-test-scheduled.yml`): inline dump now prints `head -n 200 + tail -n 1000` so the GH UI still shows enough at-a-glance; full log uploaded as `elastickv-demo-log` artifact.
- **Per-push workflow** (`jepsen-test.yml`): inline dump prints `head -n 200 + tail -n 500` per node (n1/n2/n3); full per-node logs uploaded as `elastickv-demo-logs` artifact (three files).
- Retention: 14 days, matching the existing `jepsen-store-types` artifact retention so logs and `history.txt` can be correlated for the same run.

## Test plan
- [x] yaml syntactically valid (workflow change only)
- [ ] CI green
- [ ] Next failing scheduled run produces a downloadable `elastickv-demo-log` artifact
