### PR TITLE
web/admin: SPA Messages tab + Purge button + DLQ chips (Phase 5)

### DIFF
--- a/internal/admin/sqs_handler.go
+++ b/internal/admin/sqs_handler.go
@@ -701,7 +701,14 @@ func writeQueuesError(w http.ResponseWriter, err error, logger *slog.Logger, r *
 // writePurgeInProgress emits the 429 response shape the design doc
 // §3.4 specifies: Retry-After header (rounded up to whole seconds so
 // a client retrying exactly at the deadline is guaranteed to clear)
-// + JSON body { code, message, retry_after_seconds }.
+// + JSON body { error, message, retry_after_seconds }.
+//
+// The `error` key (not `code`) matches writeJSONError's envelope so
+// the SPA's apiFetch wrapper extracts the AWS-style sentinel into
+// ApiError.code consistently with every other 4xx the admin surface
+// returns. The retry_after_seconds field is in addition to the
+// canonical Retry-After header so the SPA does not have to plumb
+// response headers through its error path.
 func writePurgeInProgress(w http.ResponseWriter, err *PurgeInProgressError) {
 	secs := int64(err.RetryAfter / time.Second)
 	if err.RetryAfter%time.Second != 0 {
@@ -712,10 +719,11 @@ func writePurgeInProgress(w http.ResponseWriter, err *PurgeInProgressError) {
 	}
 	w.Header().Set("Retry-After", strconv.FormatInt(secs, 10))
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusTooManyRequests)
 	_ = json.NewEncoder(w).Encode(map[string]any{
-		"code":                "PurgeQueueInProgress",
+		"error":               "PurgeQueueInProgress",
 		"message":             "only one PurgeQueue operation on each queue is allowed every 60 seconds",
 		"retry_after_seconds": secs,
 	})

--- a/internal/admin/sqs_handler.go
+++ b/internal/admin/sqs_handler.go
@@ -40,16 +40,9 @@ type QueueSummary struct {
 	CreatedAt  *time.Time        `json:"created_at,omitempty"`
 	Attributes map[string]string `json:"attributes,omitempty"`
 	Counters   QueueCounters     `json:"counters"`
-	// IsDLQ is true when at least one other queue's RedrivePolicy
-	// resolves its deadLetterTargetArn to this queue. The SPA uses
-	// the flag to switch the Messages-tab framing and the Purge
-	// button label between "Purge messages" and "Purge DLQ".
+	// True when another queue's RedrivePolicy points at this one.
 	IsDLQ bool `json:"is_dlq"`
-	// DLQSources lists the names of queues whose RedrivePolicy
-	// points at this queue, sorted lexicographically. Empty when
-	// IsDLQ is false; the SPA renders these as chips on the queue
-	// detail page so the operator confirms what feeds the DLQ
-	// before purging.
+	// Source queue names that point at this DLQ, sorted lex.
 	DLQSources []string `json:"dlq_sources,omitempty"`
 }
 

--- a/internal/admin/sqs_handler.go
+++ b/internal/admin/sqs_handler.go
@@ -698,17 +698,9 @@ func writeQueuesError(w http.ResponseWriter, err error, logger *slog.Logger, r *
 	}
 }
 
-// writePurgeInProgress emits the 429 response shape the design doc
-// §3.4 specifies: Retry-After header (rounded up to whole seconds so
-// a client retrying exactly at the deadline is guaranteed to clear)
-// + JSON body { error, message, retry_after_seconds }.
-//
-// The `error` key (not `code`) matches writeJSONError's envelope so
-// the SPA's apiFetch wrapper extracts the AWS-style sentinel into
-// ApiError.code consistently with every other 4xx the admin surface
-// returns. The retry_after_seconds field is in addition to the
-// canonical Retry-After header so the SPA does not have to plumb
-// response headers through its error path.
+// writePurgeInProgress emits the 429 wire shape (Retry-After header
+// + JSON body { error, message, retry_after_seconds }). Whole-second
+// rounding-up so a deadline-exact retry is guaranteed to clear.
 func writePurgeInProgress(w http.ResponseWriter, err *PurgeInProgressError) {
 	secs := int64(err.RetryAfter / time.Second)
 	if err.RetryAfter%time.Second != 0 {

--- a/internal/admin/sqs_handler_test.go
+++ b/internal/admin/sqs_handler_test.go
@@ -347,7 +347,10 @@ func TestSqsHandler_PurgeQueue_RateLimited429(t *testing.T) {
 	require.Equal(t, "43", rec.Header().Get("Retry-After"))
 	var body map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
-	require.Equal(t, "PurgeQueueInProgress", body["code"])
+	// The "error" key (not "code") matches writeJSONError's envelope
+	// so apiFetch.ts can extract the AWS-style sentinel consistently
+	// with every other 4xx error.
+	require.Equal(t, "PurgeQueueInProgress", body["error"])
 	require.EqualValues(t, 43, body["retry_after_seconds"])
 }
 

--- a/web/admin/src/api/client.ts
+++ b/web/admin/src/api/client.ts
@@ -224,12 +224,8 @@ export interface SqsQueueList {
   queues: string[];
 }
 
-// SqsPeekedAttribute mirrors the typed MessageAttribute shape AWS
-// SQS uses. data_type is "String" / "Number" / "Binary" /
-// "String.MyCustom" etc.; exactly one of string_value or
-// binary_value carries the payload (binary_value is base64 on the
-// wire — keep as string here and decode lazily if a preview needs
-// raw bytes).
+// SqsPeekedAttribute mirrors AWS's typed MessageAttribute shape;
+// binary_value arrives base64-encoded.
 export interface SqsPeekedAttribute {
   data_type: string;
   string_value?: string;
@@ -239,10 +235,6 @@ export interface SqsPeekedAttribute {
 export interface SqsPeekedMessage {
   message_id: string;
   body: string;
-  // body_truncated is true when the wire body was cut to
-  // body_max_bytes on the server side. body_original_size carries
-  // the full byte length so the modal can render "showing N of M
-  // bytes".
   body_truncated: boolean;
   body_original_size: number;
   sent_timestamp: string;
@@ -254,9 +246,7 @@ export interface SqsPeekedMessage {
 
 export interface SqsPeekResult {
   messages: SqsPeekedMessage[];
-  // next_cursor is omitted when the queue is fully drained for the
-  // current MVCC snapshot. The client treats absence as "no further
-  // pages" and re-enables the page=1 navigation.
+  // Omitted when the walk has fully completed for this MVCC snapshot.
   next_cursor?: string;
 }
 
@@ -361,12 +351,8 @@ export const api = {
     apiFetch<SqsQueueSummary>(`/sqs/queues/${encodeURIComponent(name)}`, { signal }),
   deleteQueue: (name: string) =>
     apiFetch<void>(`/sqs/queues/${encodeURIComponent(name)}`, { method: "DELETE" }),
-  // peekQueue performs a non-destructive sample of currently-visible
-  // messages. Cursor pagination: pass back the prior call's
-  // next_cursor on subsequent pages, empty on the first page. The
-  // server clamps limit to [1, 100] (default 20) and body_max_bytes
-  // to [256, 262144] (default 4096); pass undefined to use the
-  // documented defaults.
+  // Non-destructive peek of currently-visible messages. Server clamps
+  // limit to [1, 100] and body_max_bytes to [256, 262144].
   peekQueue: (name: string, opts?: SqsPeekOptions, signal?: AbortSignal) =>
     apiFetch<SqsPeekResult>(`/sqs/queues/${encodeURIComponent(name)}/messages`, {
       query: {
@@ -376,10 +362,8 @@ export const api = {
       },
       signal,
     }),
-  // purgeQueue drains the queue's messages while leaving the queue
-  // itself (ARN, RedrivePolicy, tags, attributes) intact. AWS-shape
-  // 60-second rate limit per queue: a second purge inside the window
-  // returns 429 + retry_after_seconds in the body.
+  // Drains the queue's messages while leaving meta/ARN/RedrivePolicy intact.
+  // 60-second rate limit per queue: second purge inside the window → 429.
   purgeQueue: (name: string) =>
     apiFetch<void>(`/sqs/queues/${encodeURIComponent(name)}/messages`, { method: "DELETE" }),
   keyVizMatrix: (params: KeyVizParams, signal?: AbortSignal) =>

--- a/web/admin/src/api/client.ts
+++ b/web/admin/src/api/client.ts
@@ -210,10 +210,60 @@ export interface SqsQueueSummary {
   created_at?: string;
   attributes?: Record<string, string>;
   counters: SqsQueueCounters;
+  // is_dlq is true when another queue's RedrivePolicy resolves its
+  // deadLetterTargetArn to this queue. Drives the Messages-tab
+  // framing and the Purge button label ("Purge messages" vs
+  // "Purge DLQ").
+  is_dlq: boolean;
+  // dlq_sources lists the source queues' names that point at this
+  // queue, in lexicographic order. Empty when is_dlq is false.
+  dlq_sources?: string[];
 }
 
 export interface SqsQueueList {
   queues: string[];
+}
+
+// SqsPeekedAttribute mirrors the typed MessageAttribute shape AWS
+// SQS uses. data_type is "String" / "Number" / "Binary" /
+// "String.MyCustom" etc.; exactly one of string_value or
+// binary_value carries the payload (binary_value is base64 on the
+// wire — keep as string here and decode lazily if a preview needs
+// raw bytes).
+export interface SqsPeekedAttribute {
+  data_type: string;
+  string_value?: string;
+  binary_value?: string;
+}
+
+export interface SqsPeekedMessage {
+  message_id: string;
+  body: string;
+  // body_truncated is true when the wire body was cut to
+  // body_max_bytes on the server side. body_original_size carries
+  // the full byte length so the modal can render "showing N of M
+  // bytes".
+  body_truncated: boolean;
+  body_original_size: number;
+  sent_timestamp: string;
+  receive_count: number;
+  group_id?: string;
+  deduplication_id?: string;
+  attributes?: Record<string, SqsPeekedAttribute>;
+}
+
+export interface SqsPeekResult {
+  messages: SqsPeekedMessage[];
+  // next_cursor is omitted when the queue is fully drained for the
+  // current MVCC snapshot. The client treats absence as "no further
+  // pages" and re-enables the page=1 navigation.
+  next_cursor?: string;
+}
+
+export interface SqsPeekOptions {
+  limit?: number;
+  cursor?: string;
+  body_max_bytes?: number;
 }
 
 // KeyViz wire shapes mirror internal/admin/keyviz_handler.go
@@ -311,6 +361,27 @@ export const api = {
     apiFetch<SqsQueueSummary>(`/sqs/queues/${encodeURIComponent(name)}`, { signal }),
   deleteQueue: (name: string) =>
     apiFetch<void>(`/sqs/queues/${encodeURIComponent(name)}`, { method: "DELETE" }),
+  // peekQueue performs a non-destructive sample of currently-visible
+  // messages. Cursor pagination: pass back the prior call's
+  // next_cursor on subsequent pages, empty on the first page. The
+  // server clamps limit to [1, 100] (default 20) and body_max_bytes
+  // to [256, 262144] (default 4096); pass undefined to use the
+  // documented defaults.
+  peekQueue: (name: string, opts?: SqsPeekOptions, signal?: AbortSignal) =>
+    apiFetch<SqsPeekResult>(`/sqs/queues/${encodeURIComponent(name)}/messages`, {
+      query: {
+        limit: opts?.limit,
+        cursor: opts?.cursor,
+        body_max_bytes: opts?.body_max_bytes,
+      },
+      signal,
+    }),
+  // purgeQueue drains the queue's messages while leaving the queue
+  // itself (ARN, RedrivePolicy, tags, attributes) intact. AWS-shape
+  // 60-second rate limit per queue: a second purge inside the window
+  // returns 429 + retry_after_seconds in the body.
+  purgeQueue: (name: string) =>
+    apiFetch<void>(`/sqs/queues/${encodeURIComponent(name)}/messages`, { method: "DELETE" }),
   keyVizMatrix: (params: KeyVizParams, signal?: AbortSignal) =>
     apiFetch<KeyVizMatrix>("/keyviz/matrix", {
       query: {

--- a/web/admin/src/api/client.ts
+++ b/web/admin/src/api/client.ts
@@ -210,13 +210,9 @@ export interface SqsQueueSummary {
   created_at?: string;
   attributes?: Record<string, string>;
   counters: SqsQueueCounters;
-  // is_dlq is true when another queue's RedrivePolicy resolves its
-  // deadLetterTargetArn to this queue. Drives the Messages-tab
-  // framing and the Purge button label ("Purge messages" vs
-  // "Purge DLQ").
+  // True when another queue's RedrivePolicy points at this one.
   is_dlq: boolean;
-  // dlq_sources lists the source queues' names that point at this
-  // queue, in lexicographic order. Empty when is_dlq is false.
+  // Source queue names that point at this DLQ, sorted lex.
   dlq_sources?: string[];
 }
 

--- a/web/admin/src/pages/SqsDetail.tsx
+++ b/web/admin/src/pages/SqsDetail.tsx
@@ -230,6 +230,10 @@ function MessagesSection({ queue, isFifo, isDLQ, inFlightCount, onPurged }: Mess
       } catch (err) {
         if (ctl.signal.aborted) return;
         if (err instanceof DOMException && err.name === "AbortError") return;
+        // Clear stale rows so a failed fetch after a queue change does
+        // not leave the prior queue's messages visible (Codex r3 P2).
+        setResult(null);
+        setCursor(undefined);
         setError(formatApiError(err));
         setLoading(false);
       }
@@ -238,6 +242,10 @@ function MessagesSection({ queue, isFifo, isDLQ, inFlightCount, onPurged }: Mess
   );
 
   useEffect(() => {
+    // Clear prior queue's table when the queue prop changes so the
+    // brief loading window does not show cross-queue data.
+    setResult(null);
+    setCursor(undefined);
     void fetchPage(undefined);
     return () => pendingAbortRef.current?.abort();
   }, [fetchPage]);

--- a/web/admin/src/pages/SqsDetail.tsx
+++ b/web/admin/src/pages/SqsDetail.tsx
@@ -207,11 +207,7 @@ function MessagesSection({ queue, isFifo, isDLQ, inFlightCount, onPurged }: Mess
   const [purgeName, setPurgeName] = useState("");
   const [purging, setPurging] = useState(false);
   const [purgeError, setPurgeError] = useState<string | null>(null);
-  // pendingAbortRef holds the active AbortController so a fresh
-  // peek call can cancel the previous one. Without this, two
-  // button-triggered peeks racing on the wire could land out of
-  // order and the older response would overwrite the newer state
-  // (Codex r2 P2).
+  // Cancels the prior peek so a slow response cannot overwrite newer state.
   const pendingAbortRef = useRef<AbortController | null>(null);
 
   const fetchPage = useCallback(
@@ -561,10 +557,7 @@ function utf8ByteLength(s: string): number {
   return s.length;
 }
 
-// base64DecodedByteLength returns the decoded length of a base64
-// string without doing the actual decode (cheap arithmetic on the
-// padded length). Each 4 base64 chars decode to 3 bytes, minus the
-// padding count.
+// Decoded length without actually decoding: 4 chars → 3 bytes, minus padding.
 function base64DecodedByteLength(b64: string): number {
   if (b64.length === 0) return 0;
   let padding = 0;

--- a/web/admin/src/pages/SqsDetail.tsx
+++ b/web/admin/src/pages/SqsDetail.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import {
-  ApiError,
   api,
   type SqsPeekResult,
   type SqsPeekedMessage,
@@ -208,7 +207,6 @@ function MessagesSection({ queue, isFifo, isDLQ, inFlightCount, onPurged }: Mess
   const [purgeName, setPurgeName] = useState("");
   const [purging, setPurging] = useState(false);
   const [purgeError, setPurgeError] = useState<string | null>(null);
-  const [purgeRetryAfter, setPurgeRetryAfter] = useState<number | null>(null);
 
   const fetchPage = useCallback(
     async (pageCursor: string | undefined, signal?: AbortSignal) => {
@@ -222,12 +220,13 @@ function MessagesSection({ queue, isFifo, isDLQ, inFlightCount, onPurged }: Mess
         );
         setResult(res);
         setCursor(pageCursor);
+        setLoading(false);
       } catch (err) {
-        // Ignore aborts triggered by the cleanup function below; the
-        // component is unmounting and a state update would warn.
+        // Ignore aborts (component unmount). setLoading is NOT in
+        // finally because that would clear loading on unmounted
+        // component after abort.
         if (err instanceof DOMException && err.name === "AbortError") return;
         setError(formatApiError(err));
-      } finally {
         setLoading(false);
       }
     },
@@ -247,7 +246,6 @@ function MessagesSection({ queue, isFifo, isDLQ, inFlightCount, onPurged }: Mess
     }
     setPurging(true);
     setPurgeError(null);
-    setPurgeRetryAfter(null);
     try {
       await api.purgeQueue(queue);
       setConfirmPurge(false);
@@ -255,15 +253,13 @@ function MessagesSection({ queue, isFifo, isDLQ, inFlightCount, onPurged }: Mess
       onPurged();
       void fetchPage(undefined);
     } catch (err) {
-      if (err instanceof ApiError && err.code === "PurgeQueueInProgress") {
-        // The 60-second cooldown is active. The server sends both a
-        // Retry-After header and a retry_after_seconds JSON field;
-        // ApiError currently only carries the parsed `code` and
-        // `message`, so the SPA shows the message text directly. A
-        // future apiFetch enhancement could surface the typed
-        // duration without changing the error model here.
-        setPurgeRetryAfter(60);
-      }
+      // Server includes the remaining cooldown in both the
+      // Retry-After header and the body's retry_after_seconds, but
+      // ApiError only carries code+message. formatApiError already
+      // includes the message ("only one PurgeQueue operation on each
+      // queue is allowed every 60 seconds") so showing it verbatim
+      // is sufficient; a future apiFetch enhancement could surface
+      // the typed duration if it becomes worth it.
       setPurgeError(formatApiError(err));
     } finally {
       setPurging(false);
@@ -354,14 +350,7 @@ function MessagesSection({ queue, isFifo, isDLQ, inFlightCount, onPurged }: Mess
           disabled={purging}
           autoFocus
         />
-        {purgeError && (
-          <div className="mt-3 text-sm text-danger">
-            {purgeError}
-            {purgeRetryAfter !== null && (
-              <> (retry after about {purgeRetryAfter} seconds)</>
-            )}
-          </div>
-        )}
+        {purgeError && <div className="mt-3 text-sm text-danger">{purgeError}</div>}
         <div className="flex justify-end gap-2 pt-4">
           <button
             type="button"
@@ -439,20 +428,39 @@ interface MessageDetailProps {
 
 function MessageDetail({ message, queue }: MessageDetailProps) {
   const [copied, setCopied] = useState(false);
-  const onCopyJson = () => {
-    // Schema version follows design doc §3.5: a future change to the
-    // export shape bumps schema_version so downstream tooling pins
-    // the version it expects.
+  const [copyError, setCopyError] = useState<string | null>(null);
+  const onCopyJson = async () => {
+    // Schema version per design doc §3.5; downstream tooling pins it.
     const payload = {
       schema_version: 1,
       queue,
       exported_at: new Date().toISOString(),
       message,
     };
-    void navigator.clipboard.writeText(JSON.stringify(payload, null, 2)).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    });
+    const json = JSON.stringify(payload, null, 2);
+    // navigator.clipboard is only available in secure contexts
+    // (HTTPS / localhost) and some self-hosted admin UIs run over
+    // plain HTTP. Capability check + fallback prompt keeps the
+    // modal usable in all environments. Codex r1 P2 + Gemini.
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(json);
+        setCopied(true);
+        setCopyError(null);
+        setTimeout(() => setCopied(false), 1500);
+        return;
+      } catch (err) {
+        setCopyError(`Copy failed: ${String(err)}. Use the prompt to copy manually.`);
+      }
+    } else {
+      setCopyError("Clipboard API unavailable (insecure context). Use the prompt to copy manually.");
+    }
+    // Fallback: open a prompt with the payload pre-selected so the
+    // operator can copy with Ctrl/Cmd+C. window.prompt is universally
+    // supported and works in non-secure contexts.
+    if (typeof window !== "undefined") {
+      window.prompt("Copy the JSON payload:", json);
+    }
   };
 
   return (
@@ -484,7 +492,7 @@ function MessageDetail({ message, queue }: MessageDetailProps) {
           <span className="text-xs text-muted">Body</span>
           {message.body_truncated && (
             <span className="text-xs text-danger">
-              Truncated to {formatBytes(message.body.length)} of {formatBytes(message.body_original_size)}
+              Truncated to {formatBytes(utf8ByteLength(message.body))} of {formatBytes(message.body_original_size)}
             </span>
           )}
         </div>
@@ -508,8 +516,13 @@ function MessageDetail({ message, queue }: MessageDetailProps) {
           </dl>
         </div>
       )}
+      {copyError && <div className="text-xs text-danger">{copyError}</div>}
       <div className="flex justify-end">
-        <button type="button" className="btn-secondary text-xs" onClick={onCopyJson}>
+        <button
+          type="button"
+          className="btn-secondary text-xs"
+          onClick={() => void onCopyJson()}
+        >
           {copied ? "Copied!" : "Copy as JSON"}
         </button>
       </div>
@@ -534,6 +547,17 @@ function previewBody(m: SqsPeekedMessage): string {
 
 function formatBytes(n: number): string {
   if (n < 1024) return `${n} B`;
-  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} kB`;
-  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KiB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MiB`;
+}
+
+// utf8ByteLength counts the bytes a string occupies in UTF-8. The
+// server applies BodyMaxBytes against raw UTF-8 bytes, so the
+// "truncated to X of Y" display must use bytes, not JavaScript's
+// UTF-16 string length (would underreport for CJK / emoji bodies).
+function utf8ByteLength(s: string): number {
+  if (typeof TextEncoder !== "undefined") {
+    return new TextEncoder().encode(s).byteLength;
+  }
+  return s.length; // legacy environment fallback
 }

--- a/web/admin/src/pages/SqsDetail.tsx
+++ b/web/admin/src/pages/SqsDetail.tsx
@@ -1,8 +1,28 @@
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { api } from "../api/client";
+import {
+  ApiError,
+  api,
+  type SqsPeekResult,
+  type SqsPeekedMessage,
+} from "../api/client";
 import { Modal } from "../components/Modal";
 import { formatApiError, useApiQuery } from "../lib/useApi";
+
+// kPeekPageSize is the documented Phase 5 default the SPA sends on
+// every Messages-tab fetch. The server clamps to [1, 100]; staying
+// at 20 keeps the worst-case response (20 rows × 256 KiB) at 5 MiB
+// well under typical network and JSON-parse budgets.
+const kPeekPageSize = 20;
+
+// kPeekBodyMaxBytes is the eager full-body fetch size: 256 KiB matches
+// SQS's hard cap on stored message size, so the detail modal renders
+// directly from the row already in memory — no re-peek round-trip on
+// modal open, eliminating the "row disappeared between list and
+// modal" failure modes (concurrent purge, ReceiveMessage from another
+// client, visibility timer started). Trade is initial fetch size
+// for modal-open consistency; design doc §3.5 lays out the reasoning.
+const kPeekBodyMaxBytes = 262144;
 
 export function SqsDetailPage() {
   const { name = "" } = useParams<{ name: string }>();
@@ -11,14 +31,10 @@ export function SqsDetailPage() {
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const navigate = useNavigate();
-  // The delete button is gated by the backend's live-role check
-  // (internal/admin/sqs_handler.go principalForWrite), not the JWT
-  // role cached in this session. A JWT minted as read_only stays
-  // read_only in the cookie until logout, but the operator may have
-  // been promoted to full in the live role store after login — so
-  // gating the button on session.role would hide it for users who
-  // are currently authorized. A read_only operator who clicks delete
-  // gets a 403 from the backend, surfaced in the modal's error area.
+  // The delete / purge buttons are gated by the backend's live-role
+  // check (internal/admin/sqs_handler.go principalForWrite), not the
+  // JWT role cached in this session. See SqsDetail's pre-Phase-5
+  // comment for the rationale.
 
   const onDelete = async () => {
     setDeleting(true);
@@ -40,6 +56,11 @@ export function SqsDetailPage() {
         {detail.data && (
           <span className={detail.data.is_fifo ? "pill-accent" : "pill-muted"}>
             {detail.data.is_fifo ? "FIFO" : "Standard"}
+          </span>
+        )}
+        {detail.data?.is_dlq && (
+          <span className="pill-accent" title="Another queue's RedrivePolicy points at this queue">
+            DLQ
           </span>
         )}
         {detail.data && (
@@ -76,6 +97,23 @@ export function SqsDetailPage() {
         )}
       </section>
 
+      {detail.data?.is_dlq && detail.data.dlq_sources && detail.data.dlq_sources.length > 0 && (
+        <section className="card">
+          <h2 className="text-sm font-semibold mb-3">DLQ for</h2>
+          <div className="flex flex-wrap gap-2">
+            {detail.data.dlq_sources.map((src) => (
+              <Link
+                key={src}
+                to={`/sqs/${encodeURIComponent(src)}`}
+                className="pill-muted hover:text-ink font-mono text-xs"
+              >
+                {src}
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
+
       {detail.data && (
         <section className="card">
           <div className="flex items-center justify-between mb-3">
@@ -101,6 +139,16 @@ export function SqsDetailPage() {
             ))}
           </dl>
         </section>
+      )}
+
+      {detail.data && (
+        <MessagesSection
+          queue={name}
+          isFifo={detail.data.is_fifo}
+          isDLQ={detail.data.is_dlq}
+          inFlightCount={detail.data.counters.not_visible}
+          onPurged={() => detail.reload()}
+        />
       )}
 
       <Modal
@@ -137,6 +185,338 @@ export function SqsDetailPage() {
   );
 }
 
+interface MessagesSectionProps {
+  queue: string;
+  isFifo: boolean;
+  isDLQ: boolean;
+  inFlightCount: number;
+  onPurged: () => void;
+}
+
+// MessagesSection renders the design doc §3.5 Messages tab as a
+// section beneath the queue's counters. Eager-fetches full bodies
+// (256 KiB cap) so the detail modal renders directly from the row
+// in memory, avoiding a re-peek race against concurrent purge /
+// receive / visibility timer.
+function MessagesSection({ queue, isFifo, isDLQ, inFlightCount, onPurged }: MessagesSectionProps) {
+  const [result, setResult] = useState<SqsPeekResult | null>(null);
+  const [cursor, setCursor] = useState<string | undefined>(undefined);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<SqsPeekedMessage | null>(null);
+  const [confirmPurge, setConfirmPurge] = useState(false);
+  const [purgeName, setPurgeName] = useState("");
+  const [purging, setPurging] = useState(false);
+  const [purgeError, setPurgeError] = useState<string | null>(null);
+  const [purgeRetryAfter, setPurgeRetryAfter] = useState<number | null>(null);
+
+  const fetchPage = useCallback(
+    async (pageCursor: string | undefined, signal?: AbortSignal) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await api.peekQueue(
+          queue,
+          { limit: kPeekPageSize, cursor: pageCursor, body_max_bytes: kPeekBodyMaxBytes },
+          signal,
+        );
+        setResult(res);
+        setCursor(pageCursor);
+      } catch (err) {
+        // Ignore aborts triggered by the cleanup function below; the
+        // component is unmounting and a state update would warn.
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setError(formatApiError(err));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [queue],
+  );
+
+  useEffect(() => {
+    const ctl = new AbortController();
+    void fetchPage(undefined, ctl.signal);
+    return () => ctl.abort();
+  }, [fetchPage]);
+
+  const onPurgeSubmit = async () => {
+    if (purgeName !== queue) {
+      setPurgeError(`Type "${queue}" exactly to confirm.`);
+      return;
+    }
+    setPurging(true);
+    setPurgeError(null);
+    setPurgeRetryAfter(null);
+    try {
+      await api.purgeQueue(queue);
+      setConfirmPurge(false);
+      setPurgeName("");
+      onPurged();
+      void fetchPage(undefined);
+    } catch (err) {
+      if (err instanceof ApiError && err.code === "PurgeQueueInProgress") {
+        // The 60-second cooldown is active. The server sends both a
+        // Retry-After header and a retry_after_seconds JSON field;
+        // ApiError currently only carries the parsed `code` and
+        // `message`, so the SPA shows the message text directly. A
+        // future apiFetch enhancement could surface the typed
+        // duration without changing the error model here.
+        setPurgeRetryAfter(60);
+      }
+      setPurgeError(formatApiError(err));
+    } finally {
+      setPurging(false);
+    }
+  };
+
+  const purgeLabel = isDLQ ? "Purge DLQ" : "Purge messages";
+  const purgeConfirmCopy = isDLQ
+    ? `This queue is the DLQ for one or more source queues. Purging deletes every failed message routed here. Type ${queue} to confirm.`
+    : `This will permanently delete every message in ${queue}. The queue itself remains. Type ${queue} to confirm.`;
+
+  return (
+    <section className="card">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-sm font-semibold">Messages</h2>
+        <button type="button" className="btn-danger text-xs" onClick={() => setConfirmPurge(true)}>
+          {purgeLabel}
+        </button>
+      </div>
+      <div className="text-xs text-muted mb-2">
+        Showing {result?.messages.length ?? 0} visible message
+        {(result?.messages.length ?? 0) === 1 ? "" : "s"}
+        {inFlightCount > 0 && (
+          <> ({inFlightCount} currently in-flight, not shown)</>
+        )}
+      </div>
+      {error && <div className="text-sm text-danger mb-2">{error}</div>}
+      {loading && <div className="text-sm text-muted">Loading…</div>}
+      {!loading && result && result.messages.length === 0 && (
+        <div className="text-sm text-muted">No visible messages.</div>
+      )}
+      {!loading && result && result.messages.length > 0 && (
+        <MessagesTable
+          messages={result.messages}
+          showGroup={isFifo}
+          onSelect={(m) => setSelected(m)}
+        />
+      )}
+      <div className="flex items-center gap-2 mt-3 text-xs">
+        <button
+          type="button"
+          className="btn-secondary text-xs"
+          onClick={() => void fetchPage(undefined)}
+          disabled={loading || cursor === undefined}
+        >
+          First page
+        </button>
+        <button
+          type="button"
+          className="btn-secondary text-xs"
+          onClick={() => void fetchPage(result?.next_cursor)}
+          disabled={loading || !result?.next_cursor}
+        >
+          Next page
+        </button>
+        <button
+          type="button"
+          className="btn-secondary text-xs ml-auto"
+          onClick={() => void fetchPage(cursor)}
+          disabled={loading}
+        >
+          Refresh
+        </button>
+      </div>
+
+      <Modal title="Message detail" open={selected !== null} onClose={() => setSelected(null)}>
+        {selected && <MessageDetail message={selected} queue={queue} />}
+      </Modal>
+
+      <Modal
+        title={purgeLabel}
+        open={confirmPurge}
+        onClose={() => {
+          if (purging) return;
+          setConfirmPurge(false);
+          setPurgeName("");
+          setPurgeError(null);
+        }}
+        busy={purging}
+      >
+        <p className="text-sm">{purgeConfirmCopy}</p>
+        <label className="block mt-3 text-xs text-muted">Type the queue name to confirm</label>
+        <input
+          type="text"
+          className="input mt-1 font-mono"
+          value={purgeName}
+          onChange={(e) => setPurgeName(e.target.value)}
+          disabled={purging}
+          autoFocus
+        />
+        {purgeError && (
+          <div className="mt-3 text-sm text-danger">
+            {purgeError}
+            {purgeRetryAfter !== null && (
+              <> (retry after about {purgeRetryAfter} seconds)</>
+            )}
+          </div>
+        )}
+        <div className="flex justify-end gap-2 pt-4">
+          <button
+            type="button"
+            className="btn-secondary"
+            onClick={() => {
+              setConfirmPurge(false);
+              setPurgeName("");
+              setPurgeError(null);
+            }}
+            disabled={purging}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn-danger"
+            onClick={() => void onPurgeSubmit()}
+            disabled={purging || purgeName !== queue}
+          >
+            {purging ? "Purging…" : purgeLabel}
+          </button>
+        </div>
+      </Modal>
+    </section>
+  );
+}
+
+interface MessagesTableProps {
+  messages: SqsPeekedMessage[];
+  showGroup: boolean;
+  onSelect: (m: SqsPeekedMessage) => void;
+}
+
+function MessagesTable({ messages, showGroup, onSelect }: MessagesTableProps) {
+  return (
+    <table className="w-full text-xs">
+      <thead className="text-muted text-left">
+        <tr>
+          <th className="py-1 pr-3">Message ID</th>
+          <th className="py-1 pr-3">Sent</th>
+          {showGroup && <th className="py-1 pr-3">Group</th>}
+          <th className="py-1 pr-3">Recv</th>
+          <th className="py-1 pr-3">Body</th>
+          <th className="py-1 pr-3">Size</th>
+        </tr>
+      </thead>
+      <tbody>
+        {messages.map((m) => (
+          <tr
+            key={m.message_id}
+            className="border-t border-border hover:bg-surface cursor-pointer"
+            onClick={() => onSelect(m)}
+          >
+            <td className="py-1 pr-3 font-mono" title={m.message_id}>
+              {m.message_id.slice(0, 8)}
+            </td>
+            <td className="py-1 pr-3 font-mono">{new Date(m.sent_timestamp).toLocaleString()}</td>
+            {showGroup && <td className="py-1 pr-3 font-mono">{m.group_id ?? ""}</td>}
+            <td className={`py-1 pr-3 font-mono ${m.receive_count === 0 ? "text-muted" : ""}`}>
+              {m.receive_count}
+            </td>
+            <td className="py-1 pr-3 font-mono truncate max-w-md">{previewBody(m)}</td>
+            <td className="py-1 pr-3 font-mono text-muted">{formatBytes(m.body_original_size)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+interface MessageDetailProps {
+  message: SqsPeekedMessage;
+  queue: string;
+}
+
+function MessageDetail({ message, queue }: MessageDetailProps) {
+  const [copied, setCopied] = useState(false);
+  const onCopyJson = () => {
+    // Schema version follows design doc §3.5: a future change to the
+    // export shape bumps schema_version so downstream tooling pins
+    // the version it expects.
+    const payload = {
+      schema_version: 1,
+      queue,
+      exported_at: new Date().toISOString(),
+      message,
+    };
+    void navigator.clipboard.writeText(JSON.stringify(payload, null, 2)).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  return (
+    <div className="space-y-3 text-sm">
+      <dl className="grid grid-cols-3 gap-x-4 gap-y-1 text-xs">
+        <dt className="text-muted">Message ID</dt>
+        <dd className="col-span-2 font-mono">{message.message_id}</dd>
+        <dt className="text-muted">Sent</dt>
+        <dd className="col-span-2 font-mono">{new Date(message.sent_timestamp).toLocaleString()}</dd>
+        <dt className="text-muted">Receive count</dt>
+        <dd className="col-span-2 font-mono">{message.receive_count}</dd>
+        {message.group_id && (
+          <>
+            <dt className="text-muted">Group ID</dt>
+            <dd className="col-span-2 font-mono">{message.group_id}</dd>
+          </>
+        )}
+        {message.deduplication_id && (
+          <>
+            <dt className="text-muted">Deduplication ID</dt>
+            <dd className="col-span-2 font-mono">{message.deduplication_id}</dd>
+          </>
+        )}
+        <dt className="text-muted">Original size</dt>
+        <dd className="col-span-2 font-mono">{formatBytes(message.body_original_size)}</dd>
+      </dl>
+      <div>
+        <div className="flex items-center justify-between mb-1">
+          <span className="text-xs text-muted">Body</span>
+          {message.body_truncated && (
+            <span className="text-xs text-danger">
+              Truncated to {formatBytes(message.body.length)} of {formatBytes(message.body_original_size)}
+            </span>
+          )}
+        </div>
+        <pre className="text-xs font-mono bg-surface p-2 rounded overflow-x-auto max-h-64 whitespace-pre-wrap break-all">
+          {message.body}
+        </pre>
+      </div>
+      {message.attributes && Object.keys(message.attributes).length > 0 && (
+        <div>
+          <div className="text-xs text-muted mb-1">Attributes</div>
+          <dl className="grid grid-cols-[max-content_max-content_1fr] gap-x-4 gap-y-1 text-xs">
+            {Object.entries(message.attributes).map(([k, v]) => (
+              <div key={k} className="contents">
+                <dt className="font-mono">{k}</dt>
+                <dd className="text-muted">{v.data_type}</dd>
+                <dd className="font-mono break-all">
+                  {v.string_value ?? (v.binary_value ? `<binary, base64 length=${v.binary_value.length}>` : "")}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      )}
+      <div className="flex justify-end">
+        <button type="button" className="btn-secondary text-xs" onClick={onCopyJson}>
+          {copied ? "Copied!" : "Copy as JSON"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function CounterCard({ label, value }: { label: string; value: number }) {
   return (
     <div className="rounded-md border border-border bg-surface p-3">
@@ -144,4 +524,16 @@ function CounterCard({ label, value }: { label: string; value: number }) {
       <div className="text-2xl font-semibold mt-1 font-mono">{value}</div>
     </div>
   );
+}
+
+function previewBody(m: SqsPeekedMessage): string {
+  const max = 96;
+  if (m.body.length <= max) return m.body || "(empty)";
+  return m.body.slice(0, max) + "…";
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} kB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/web/admin/src/pages/SqsDetail.tsx
+++ b/web/admin/src/pages/SqsDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import {
   api,
@@ -207,24 +207,32 @@ function MessagesSection({ queue, isFifo, isDLQ, inFlightCount, onPurged }: Mess
   const [purgeName, setPurgeName] = useState("");
   const [purging, setPurging] = useState(false);
   const [purgeError, setPurgeError] = useState<string | null>(null);
+  // pendingAbortRef holds the active AbortController so a fresh
+  // peek call can cancel the previous one. Without this, two
+  // button-triggered peeks racing on the wire could land out of
+  // order and the older response would overwrite the newer state
+  // (Codex r2 P2).
+  const pendingAbortRef = useRef<AbortController | null>(null);
 
   const fetchPage = useCallback(
-    async (pageCursor: string | undefined, signal?: AbortSignal) => {
+    async (pageCursor: string | undefined) => {
+      pendingAbortRef.current?.abort();
+      const ctl = new AbortController();
+      pendingAbortRef.current = ctl;
       setLoading(true);
       setError(null);
       try {
         const res = await api.peekQueue(
           queue,
           { limit: kPeekPageSize, cursor: pageCursor, body_max_bytes: kPeekBodyMaxBytes },
-          signal,
+          ctl.signal,
         );
+        if (ctl.signal.aborted) return;
         setResult(res);
         setCursor(pageCursor);
         setLoading(false);
       } catch (err) {
-        // Ignore aborts (component unmount). setLoading is NOT in
-        // finally because that would clear loading on unmounted
-        // component after abort.
+        if (ctl.signal.aborted) return;
         if (err instanceof DOMException && err.name === "AbortError") return;
         setError(formatApiError(err));
         setLoading(false);
@@ -234,9 +242,8 @@ function MessagesSection({ queue, isFifo, isDLQ, inFlightCount, onPurged }: Mess
   );
 
   useEffect(() => {
-    const ctl = new AbortController();
-    void fetchPage(undefined, ctl.signal);
-    return () => ctl.abort();
+    void fetchPage(undefined);
+    return () => pendingAbortRef.current?.abort();
   }, [fetchPage]);
 
   const onPurgeSubmit = async () => {
@@ -438,10 +445,10 @@ function MessageDetail({ message, queue }: MessageDetailProps) {
       message,
     };
     const json = JSON.stringify(payload, null, 2);
-    // navigator.clipboard is only available in secure contexts
-    // (HTTPS / localhost) and some self-hosted admin UIs run over
-    // plain HTTP. Capability check + fallback prompt keeps the
-    // modal usable in all environments. Codex r1 P2 + Gemini.
+    // navigator.clipboard is secure-context-only. On insecure /
+    // unavailable, point the operator at the body <pre> in the
+    // modal rather than window.prompt (blocking modal pre-empts the
+    // error message and some browsers truncate ~350KiB payloads).
     if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
       try {
         await navigator.clipboard.writeText(json);
@@ -450,17 +457,11 @@ function MessageDetail({ message, queue }: MessageDetailProps) {
         setTimeout(() => setCopied(false), 1500);
         return;
       } catch (err) {
-        setCopyError(`Copy failed: ${String(err)}. Use the prompt to copy manually.`);
+        setCopyError(`Copy failed: ${String(err)}. Select the body text above to copy manually.`);
+        return;
       }
-    } else {
-      setCopyError("Clipboard API unavailable (insecure context). Use the prompt to copy manually.");
     }
-    // Fallback: open a prompt with the payload pre-selected so the
-    // operator can copy with Ctrl/Cmd+C. window.prompt is universally
-    // supported and works in non-secure contexts.
-    if (typeof window !== "undefined") {
-      window.prompt("Copy the JSON payload:", json);
-    }
+    setCopyError("Clipboard API unavailable (insecure context). Select the body text above to copy manually.");
   };
 
   return (
@@ -509,7 +510,7 @@ function MessageDetail({ message, queue }: MessageDetailProps) {
                 <dt className="font-mono">{k}</dt>
                 <dd className="text-muted">{v.data_type}</dd>
                 <dd className="font-mono break-all">
-                  {v.string_value ?? (v.binary_value ? `<binary, base64 length=${v.binary_value.length}>` : "")}
+                  {v.string_value ?? (v.binary_value ? `<binary, ${base64DecodedByteLength(v.binary_value)} bytes>` : "")}
                 </dd>
               </div>
             ))}
@@ -551,13 +552,23 @@ function formatBytes(n: number): string {
   return `${(n / (1024 * 1024)).toFixed(1)} MiB`;
 }
 
-// utf8ByteLength counts the bytes a string occupies in UTF-8. The
-// server applies BodyMaxBytes against raw UTF-8 bytes, so the
-// "truncated to X of Y" display must use bytes, not JavaScript's
-// UTF-16 string length (would underreport for CJK / emoji bodies).
+// utf8ByteLength: server applies BodyMaxBytes to UTF-8 bytes, not
+// UTF-16 code units; CJK/emoji bodies would otherwise under-report.
 function utf8ByteLength(s: string): number {
   if (typeof TextEncoder !== "undefined") {
     return new TextEncoder().encode(s).byteLength;
   }
-  return s.length; // legacy environment fallback
+  return s.length;
+}
+
+// base64DecodedByteLength returns the decoded length of a base64
+// string without doing the actual decode (cheap arithmetic on the
+// padded length). Each 4 base64 chars decode to 3 bytes, minus the
+// padding count.
+function base64DecodedByteLength(b64: string): number {
+  if (b64.length === 0) return 0;
+  let padding = 0;
+  if (b64.endsWith("==")) padding = 2;
+  else if (b64.endsWith("=")) padding = 1;
+  return Math.floor(b64.length * 3 / 4) - padding;
 }


### PR DESCRIPTION
## Summary

Phase 5 of `docs/design/2026_05_16_proposed_admin_purge_queue.md` — operator-facing SPA UI for the `AdminPeekQueue` / `AdminPurgeQueue` endpoints PR #797 wired. The queue detail page now ships:

- **DLQ chip + "DLQ for" sources list** — when another queue's `RedrivePolicy` points at this queue, a pill in the header marks it as a DLQ and a section below lists the source queues (each linked to its detail page so the operator can navigate the topology).
- **Messages section** — paginated table of currently-visible messages: message-id prefix, sent timestamp, FIFO `MessageGroupId` (column shown only on FIFO queues), receive count, body preview, original size. Row-click opens a detail modal showing the full body, every attribute (typed `String` / `Binary` / `Number` etc.), and a "Copy as JSON" button writing a schema-versioned payload to the clipboard.
- **Purge button** — labelled `Purge messages` or `Purge DLQ` depending on `is_dlq`. Confirmation modal requires typing the exact queue name; on 429 `PurgeQueueInProgress` the modal stays open and surfaces the rate-limit message.

> ⚠️ **Stacked on PR #797.** This branch builds on `feat/sqs-admin-peek-purge-http` because the SPA needs the Phase 4 HTTP endpoints. Once #797 merges to main, please rebase (or merge #797 first then this auto-fast-forwards). I can rebase on request.

## Eager full-body fetch

The list call sets `body_max_bytes = 262144` (= 256 KiB, SQS's stored-message hard cap) so the detail modal renders directly from the row already in memory — no re-peek round-trip on modal open. This eliminates the entire "row disappeared between list and modal" class of failures: concurrent purge, ReceiveMessage from another client, visibility timer started, leader step-down (design doc §3.5).

Page size stays at the documented Phase 5 default of 20 rows. Worst case: 20 × 256 KiB = 5 MiB response, well under typical network and JSON-parse budgets.

## API client changes (`web/admin/src/api/client.ts`)

- `SqsQueueSummary` gains `is_dlq` + optional `dlq_sources`.
- New types: `SqsPeekedAttribute`, `SqsPeekedMessage`, `SqsPeekResult`, `SqsPeekOptions`.
- New methods: `api.peekQueue(name, opts, signal)` (signal-aware so navigation aborts the in-flight peek) and `api.purgeQueue(name)`.

## Handler 429 envelope (`internal/admin/sqs_handler.go`)

The Phase 4 `writePurgeInProgress` was emitting the JSON body with a `code` key, which diverged from `writeJSONError`'s canonical `error` key — so `apiFetch.ts` could not extract the AWS-style sentinel into `ApiError.code` consistently with every other 4xx. Switched to `error` (with `retry_after_seconds` still in the body alongside the canonical `Retry-After` header). The matching unit test assertion was updated.

**Caller audit (semantic-change rule):** the wire-shape adjustment has no other consumer yet — Phase 4 (#797) introduced the endpoint and the test was the sole reader. Updated.

## Risk

Low. New SPA UI only; the handler change is a 1-key rename matching the existing admin error envelope.

## Self-review (5 passes)

1. **Data loss** — read endpoint (peek) plus the existing `AdminPurgeQueue` wrapper. No new write paths.
2. **Concurrency** — eager full-body fetch eliminates the modal re-peek race. AbortController cancels in-flight peek on navigation / unmount; `DOMException name=AbortError` is filtered before setError to avoid stale-component warnings.
3. **Performance** — page size capped at 20 (default; server clamps to ≤ 100). Body cap 256 KiB. No hot-path allocations.
4. **Consistency** — Purge button reuses the queue's name as the confirmation token, matching the existing Delete confirmation. The 429 response shape now matches every other admin 4xx so the SPA error handling is uniform.
5. **Test coverage** — `npm run lint` (tsc -b --noEmit) passes. `npm run build` (vite) passes. Go-side `TestSqsHandler_PurgeQueue_RateLimited429` updated for the `error`-key envelope. No frontend test infra in the project (intentional; the `lint` script is the contract).

## Test plan

- [x] `cd web/admin && npm run lint` (tsc -b --noEmit) passes
- [x] `cd web/admin && npm run build` (vite build) passes
- [x] `go test -race -count=1 ./internal/admin/...` passes (12 existing + the 429 envelope update)
- [x] `golangci-lint run ./internal/admin/...` 0 issues
- [ ] CI on this PR
- [ ] Manual smoke: navigate to a queue detail page, peek messages, open the modal, copy-as-JSON, attempt purge twice (second attempt should hit 429)

## Out of scope (follow-ups)

- **Throttle integration**: dedicated per-queue admin-peek bucket (`bucketActionAdminPeek` + `resolveActionConfig` explicit case + typed `adminPeekThrottledError` / `PeekThrottledError`). Leader-only + `Limit ≤ 100` already bound the steady-state cost; the dedicated bucket adds a per-queue cap.
- **Audit logging & Prometheus counters** (design doc §3.6): `admin.sqs.purge_queue` audit line + `elastickv_sqs_admin_purge_queue_total{queue, outcome}` / `elastickv_sqs_admin_peek_queue_total{queue, outcome}`.
- **Page-size selector** (20 / 50 / 100) + cumulative-response-size warning. The MVP defaults to 20 to keep the worst-case at 5 MiB; larger sizes can land as a follow-up if operators request them.
- **`principalForReadSensitive` live `RoleStore` re-check** (design doc Goal 8) — blocked on the wider live-role plumbing.
- **Design doc rename** `_proposed_` → `_implemented_` once Phase 6 lands (just the rename — Phases 2/3/4/5 are functionally complete).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added message peeking with pagination for SQS queues
  * Introduced Dead Letter Queue (DLQ) indicators and source queue references
  * Added queue purge workflow with confirmation modal
  * Added "Copy as JSON" functionality for message details

* **Updates**
  * Enhanced SQS error response formatting for improved API consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/798?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->