### PR TITLE
feat(encryption): Stage 6D-4 - cutover wire byte + apply dispatch + sidecar field

### DIFF
--- a/docs/design/2026_05_18_partial_6d_enable_storage_envelope.md
+++ b/docs/design/2026_05_18_partial_6d_enable_storage_envelope.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| Status | partial — 6D-1 (doc), 6D-2 (startup guards), 6D-3 (capability fan-out helper) shipped; 6D-4, 6D-5, 6D-6 remain |
+| Status | partial — 6D-1 (doc), 6D-2 (startup guards), 6D-3 (capability fan-out helper), 6D-4 (cutover wire + apply dispatch) shipped; 6D-5, 6D-6 remain |
 | Date | 2026-05-18 |
 | Parent design | [`2026_04_29_partial_data_at_rest_encryption.md`](2026_04_29_partial_data_at_rest_encryption.md) |
 | Blockers (now satisfied) | 6B (KEK plumbing), 6C-1 / 6C-2 (startup guards), 6C-2d (`ErrSidecarBehindRaftLog` wiring) |
@@ -21,12 +21,19 @@
   `CapabilityFanoutResult` to disambiguate from the unrelated
   `admin.FanoutResult` already shipped in `keyviz_fanout.go`; the
   contract is otherwise unchanged.
+- **6D-4** (cutover wire + apply dispatch) —
+  `RotateSubEnableStorageEnvelope = 0x04` constant
+  (`internal/encryption/fsmwire/wire.go`), two-site whitelist
+  (`readRotationSubTag` decoder + `ApplyRotation` switch in
+  `internal/encryption/applier.go`), `StorageEnvelopeCutoverIndex`
+  sidecar field, and the apply-path semantics per §2.1 / §6.4:
+  malformed entries halt via `ErrEncryptionApply`, stale-DEKID and
+  already-active outcomes are benign no-ops that advance
+  `RaftAppliedIndex` without halting. Operator-inert until 6D-5
+  wires the §6.2 storage-layer toggle.
 
 ## Open milestones
 
-- **6D-4** — `RotateSubEnableStorageEnvelope = 0x04` wire-format
-  addition + FSM apply-path dispatch + `StorageEnvelopeCutoverIndex`
-  sidecar field.
 - **6D-5** — §6.2 storage-layer toggle (`PutAt` consults
   `StorageEnvelopeActive`).
 - **6D-6** — `EnableStorageEnvelope` admin RPC + CLI command +

--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -548,15 +548,39 @@ func advanceRaftAppliedIndex(sc *Sidecar, raftIdx uint64) {
 	}
 }
 
-// ApplyRotation implements §5.2 / §5.4 rotation apply. Stage 6B-1
-// handles only the RotateSubRotateDEK sub-tag (rotate the storage
-// or raft DEK to a new key_id). Other sub-tags (rewrap-deks,
-// retire-dek, enable-storage-envelope, enable-raft-envelope) land
-// in later stages and return ErrEncryptionApply for now so the
+// ApplyRotation implements §5.2 / §5.4 rotation apply. The sub-tag
+// dispatches the entry to the per-variant handler:
+//
+//   - RotateSubRotateDEK — install a new wrapped DEK and re-point
+//     the Active slot for its Purpose (Stage 6B-1).
+//   - RotateSubEnableStorageEnvelope — one-shot storage-layer
+//     cutover (Stage 6D-4). Flips StorageEnvelopeActive and records
+//     StorageEnvelopeCutoverIndex inside a single sidecar fsync.
+//
+// Other sub-tags (rewrap-deks, retire-dek, enable-raft-envelope)
+// land in later stages and return ErrEncryptionApply so the
 // HaltApply seam fires on an unrecognised sub-tag rather than
 // silently advancing setApplied.
 //
-// For RotateSubRotateDEK:
+// Same WithKEK / WithKeystore / WithSidecarPath trio requirement
+// as ApplyBootstrap; partial wiring returns ErrKEKNotConfigured
+// at apply time.
+func (a *Applier) ApplyRotation(raftIdx uint64, p fsmwire.RotationPayload) error {
+	if !a.bootstrapAndRotationConfigured() {
+		return errors.Wrap(ErrKEKNotConfigured, "applier: rotation requires WithKEK + WithKeystore + WithSidecarPath")
+	}
+	switch p.SubTag {
+	case fsmwire.RotateSubRotateDEK:
+		return a.applyRotateDEK(raftIdx, p)
+	case fsmwire.RotateSubEnableStorageEnvelope:
+		return a.applyEnableStorageEnvelope(raftIdx, p)
+	default:
+		return errors.Wrapf(ErrEncryptionApply,
+			"applier: rotation sub_tag %#x not recognised", p.SubTag)
+	}
+}
+
+// applyRotateDEK handles the RotateSubRotateDEK variant:
 //
 //  1. KEK-unwrap the proposed wrapped DEK.
 //  2. Install it into the keystore under p.DEKID.
@@ -566,18 +590,7 @@ func advanceRaftAppliedIndex(sc *Sidecar, raftIdx uint64) {
 //  4. Insert the proposing node's ProposerRegistration row so the
 //     §4.1 case-2 monotonicity check covers its first encrypted
 //     write under the new DEK.
-//
-// Same WithKEK / WithKeystore / WithSidecarPath trio requirement
-// as ApplyBootstrap; partial wiring returns ErrKEKNotConfigured
-// at apply time.
-func (a *Applier) ApplyRotation(raftIdx uint64, p fsmwire.RotationPayload) error {
-	if !a.bootstrapAndRotationConfigured() {
-		return errors.Wrap(ErrKEKNotConfigured, "applier: rotation requires WithKEK + WithKeystore + WithSidecarPath")
-	}
-	if p.SubTag != fsmwire.RotateSubRotateDEK {
-		return errors.Wrapf(ErrEncryptionApply,
-			"applier: rotation sub_tag %#x not implemented in Stage 6B-1", p.SubTag)
-	}
+func (a *Applier) applyRotateDEK(raftIdx uint64, p fsmwire.RotationPayload) error {
 	// The proposer-registration row MUST target the rotated DEK ID
 	// — that is the whole point of including it atomically with the
 	// rotate-dek entry (§5.2): cover the proposer's first encrypted
@@ -602,6 +615,128 @@ func (a *Applier) ApplyRotation(raftIdx uint64, p fsmwire.RotationPayload) error
 	}
 	if err := a.ApplyRegistration(p.ProposerRegistration); err != nil {
 		return errors.Wrap(err, "applier: rotation proposer-registration insert")
+	}
+	return nil
+}
+
+// applyEnableStorageEnvelope handles the
+// RotateSubEnableStorageEnvelope variant (§2.1, §6.4): the one-shot
+// storage-layer cutover. Defense-in-depth re-validates the four
+// §2.1 constraints on the apply side (the cutover RPC mutator,
+// shipping in 6D-6, validates the same set before propose).
+//
+// Outcomes and their FSM-level treatment:
+//
+//   - Malformed proposal (Purpose != PurposeStorage, len(Wrapped)
+//     != 0, or ProposerRegistration.DEKID mismatch) — halt apply
+//     via ErrEncryptionApply. These cannot arise from a healthy
+//     propose path and indicate either a future refactor that
+//     bypassed the mutator gate or a forensic-grade corruption.
+//
+//   - Stale DEKID (a RotateDEK raced between propose and apply, so
+//     sidecar.Active.Storage has advanced past p.DEKID) — benign
+//     no-op. The entry is consumed (RaftAppliedIndex advances) so
+//     it is not replayed, but StorageEnvelopeActive and
+//     StorageEnvelopeCutoverIndex are NOT touched. The §2.1
+//     constraint #3 race posture explicitly forbids halting on
+//     this case: it is a legitimate admin race against RotateDEK,
+//     not a malformed entry. 6D-6 will distinguish "fresh success"
+//     from "stale-DEKID no-op" via a §6.4 response-detail
+//     ride-along; for 6D-4 the FSM-level test asserts via the
+//     post-apply sidecar (StorageEnvelopeActive still false).
+//
+//   - Already active (a duplicate cutover entry committed) —
+//     idempotent. RaftAppliedIndex advances; StorageEnvelopeActive
+//     stays true; StorageEnvelopeCutoverIndex is NOT overwritten
+//     (the original first-apply value is the stable idempotency
+//     token per §6.4). The 6D-6 retry path reads
+//     sc.StorageEnvelopeCutoverIndex directly and surfaces it as
+//     `applied_index` with `was_already_active = true`.
+//
+//   - Fresh success — sidecar.StorageEnvelopeActive flips to true,
+//     sidecar.StorageEnvelopeCutoverIndex is set to raftIdx, and
+//     RaftAppliedIndex advances. All three writes land inside a
+//     single crash-durable WriteSidecar fsync (§6.4 atomicity).
+//     The ProposerRegistration row is then inserted via the
+//     standard §4.1 case 1 / case 2 dispatch so the proposer's
+//     first encrypted write under the now-active envelope is
+//     covered.
+//
+// 6D-4 deliberately does NOT wire the §6.2 storage-layer toggle —
+// PutAt continues to read pre-cutover until 6D-5 lands the
+// `StorageEnvelopeActive` consult. The cutover apply is
+// operator-inert at this stage.
+// validateEnableStorageEnvelopePayload enforces the §2.1
+// payload-shape constraints that do NOT require sidecar state
+// (purpose, empty-Wrapped, proposer DEK pinning). Sidecar-derived
+// constraints (#3 stale DEKID, #4 idempotency) live in the caller
+// so the no-op vs. fresh-success branches can read the sidecar
+// exactly once.
+func validateEnableStorageEnvelopePayload(p fsmwire.RotationPayload) error {
+	// §2.1 constraint #1.
+	if p.Purpose != fsmwire.PurposeStorage {
+		return errors.Wrapf(ErrEncryptionApply,
+			"applier: enable-storage-envelope must carry Purpose=PurposeStorage, got %#x", byte(p.Purpose))
+	}
+	// §2.1 constraint #2 — length-based, NOT `Wrapped == nil`. The
+	// wire decoder materialises a zero-length payload as an
+	// allocated empty slice (`[]byte{}`); a `== nil` check would
+	// reject every valid cutover entry and halt-apply the cluster.
+	if len(p.Wrapped) != 0 {
+		return errors.Wrapf(ErrEncryptionApply,
+			"applier: enable-storage-envelope must carry empty Wrapped, got %d bytes", len(p.Wrapped))
+	}
+	// Pin the proposer registration to the cutover's DEK — symmetric
+	// with the rotate-dek invariant. Mismatch on an empty-Wrapped
+	// cutover would otherwise silently insert a writer-registry row
+	// against an unrelated DEK.
+	if p.ProposerRegistration.DEKID != p.DEKID {
+		return errors.Wrapf(ErrEncryptionApply,
+			"applier: enable-storage-envelope proposer_registration.dek_id=%d does not match rotation dek_id=%d",
+			p.ProposerRegistration.DEKID, p.DEKID)
+	}
+	return nil
+}
+
+func (a *Applier) applyEnableStorageEnvelope(raftIdx uint64, p fsmwire.RotationPayload) error {
+	if err := validateEnableStorageEnvelopePayload(p); err != nil {
+		return err
+	}
+	sc, err := ReadSidecar(a.sidecarPath)
+	if err != nil {
+		return errors.Wrap(err, "applier: read sidecar for enable-storage-envelope")
+	}
+	// §2.1 constraint #3 — DEKID stale at apply (RotateDEK raced).
+	// Benign no-op: consume the entry without halting and without
+	// flipping the cutover fields.
+	if p.DEKID != sc.Active.Storage {
+		advanceRaftAppliedIndex(sc, raftIdx)
+		if err := WriteSidecar(a.sidecarPath, sc); err != nil {
+			return errors.Wrap(err, "applier: write sidecar for stale-dekid cutover no-op")
+		}
+		return nil
+	}
+	// §2.1 constraint #4 — idempotency. Preserve the original
+	// StorageEnvelopeCutoverIndex; only advance the generic
+	// RaftAppliedIndex so the duplicate entry is not replayed.
+	if sc.StorageEnvelopeActive {
+		advanceRaftAppliedIndex(sc, raftIdx)
+		if err := WriteSidecar(a.sidecarPath, sc); err != nil {
+			return errors.Wrap(err, "applier: write sidecar for already-active cutover no-op")
+		}
+		return nil
+	}
+	// Fresh successful apply — §6.4 atomicity demands the
+	// active-flip, the cutover-index, AND the RaftAppliedIndex bump
+	// land inside one WriteSidecar fsync.
+	sc.StorageEnvelopeActive = true
+	sc.StorageEnvelopeCutoverIndex = raftIdx
+	advanceRaftAppliedIndex(sc, raftIdx)
+	if err := WriteSidecar(a.sidecarPath, sc); err != nil {
+		return errors.Wrap(err, "applier: write sidecar for cutover")
+	}
+	if err := a.ApplyRegistration(p.ProposerRegistration); err != nil {
+		return errors.Wrap(err, "applier: cutover proposer-registration insert")
 	}
 	return nil
 }

--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -719,6 +719,16 @@ func (a *Applier) applyEnableStorageEnvelope(raftIdx uint64, p fsmwire.RotationP
 	// §2.1 constraint #4 — idempotency. Preserve the original
 	// StorageEnvelopeCutoverIndex; only advance the generic
 	// RaftAppliedIndex so the duplicate entry is not replayed.
+	//
+	// Why this branch can safely skip ApplyRegistration: the
+	// fresh-success branch below runs ApplyRegistration BEFORE
+	// WriteSidecar, so the invariant
+	//   sc.StorageEnvelopeActive == true ⇒ registration row already on disk
+	// holds across crash-restart. No re-insert is needed (and the
+	// duplicate entry's ProposerRegistration field is intentionally
+	// discarded — §2.1 #4). This addresses Codex P1 on PR #804,
+	// which was filed against commit 3eb4555c77 before the
+	// registration-before-sidecar reordering landed in 74a504c8.
 	if sc.StorageEnvelopeActive {
 		advanceRaftAppliedIndex(sc, raftIdx)
 		if err := WriteSidecar(a.sidecarPath, sc); err != nil {

--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -726,17 +726,42 @@ func (a *Applier) applyEnableStorageEnvelope(raftIdx uint64, p fsmwire.RotationP
 		}
 		return nil
 	}
-	// Fresh successful apply — §6.4 atomicity demands the
-	// active-flip, the cutover-index, AND the RaftAppliedIndex bump
-	// land inside one WriteSidecar fsync.
+	// Fresh successful apply.
+	//
+	// Crash-recovery ordering: ApplyRegistration runs BEFORE
+	// WriteSidecar. The cutover sidecar flip is the LAST observable
+	// side effect of the apply. If the process crashes between the
+	// registration insert and the sidecar write, on restart:
+	//
+	//   - The sidecar is still pre-cutover
+	//     (StorageEnvelopeActive == false), so FSM replay re-enters
+	//     this fresh-success branch rather than short-circuiting
+	//     on the §2.1 #4 already-active no-op above.
+	//   - ApplyRegistration re-runs with the same
+	//     (DEKID, FullNodeID, LocalEpoch) and hits the §4.1
+	//     case 2-idempotent path, returning nil without mutating
+	//     the row.
+	//   - WriteSidecar then lands cleanly.
+	//
+	// The reverse ordering (sidecar write first) would leave the
+	// cluster in a state where StorageEnvelopeActive == true but
+	// the proposer's writer-registry row is missing — the §5.2
+	// startup guard would refuse boot, and FSM replay would
+	// short-circuit on already-active and skip the registry insert
+	// permanently. This was gemini-code-assist medium #1 on PR804.
+	//
+	// §6.4 atomicity still holds for the three sidecar fields:
+	// `StorageEnvelopeActive`, `StorageEnvelopeCutoverIndex`, and
+	// the `RaftAppliedIndex` bump all land inside one WriteSidecar
+	// fsync.
+	if err := a.ApplyRegistration(p.ProposerRegistration); err != nil {
+		return errors.Wrap(err, "applier: cutover proposer-registration insert")
+	}
 	sc.StorageEnvelopeActive = true
 	sc.StorageEnvelopeCutoverIndex = raftIdx
 	advanceRaftAppliedIndex(sc, raftIdx)
 	if err := WriteSidecar(a.sidecarPath, sc); err != nil {
 		return errors.Wrap(err, "applier: write sidecar for cutover")
-	}
-	if err := a.ApplyRegistration(p.ProposerRegistration); err != nil {
-		return errors.Wrap(err, "applier: cutover proposer-registration insert")
 	}
 	return nil
 }

--- a/internal/encryption/applier_test.go
+++ b/internal/encryption/applier_test.go
@@ -1116,6 +1116,86 @@ const (
 	cutoverBootstrapRaftDEKID    uint32 = 8
 )
 
+// TestApplyRotation_EnableStorageEnvelope_RegistrationBeforeSidecar
+// pins the crash-recovery ordering invariant in
+// applyEnableStorageEnvelope (gemini-code-assist medium #1 on
+// PR804): the ProposerRegistration insert MUST happen BEFORE the
+// sidecar flip, so a crash between the two on-disk operations
+// leaves the cluster in a state from which FSM replay can recover
+// cleanly. The reverse ordering would leave StorageEnvelopeActive
+// = true with the registry row missing — the §5.2 startup guard
+// would then refuse boot, and a replay would short-circuit on the
+// already-active no-op and never insert the row.
+//
+// The test injects a failing SetRegistryRow on the cutover's
+// registry call and asserts:
+//
+//   - The apply call returns an error (so the FSM halts and the
+//     entry is not consumed without consequence).
+//   - The sidecar's StorageEnvelopeActive stays false (no
+//     premature flip).
+//   - The sidecar's StorageEnvelopeCutoverIndex stays 0.
+//
+// The replay-still-works property (registration insert is
+// idempotent via §4.1 case 2-idempotent) is already covered by
+// TestApplyRegistration_Case2_Idempotent and is not re-asserted
+// here.
+func TestApplyRotation_EnableStorageEnvelope_RegistrationBeforeSidecar(t *testing.T) {
+	t.Parallel()
+	reg := newMapRegistryStore()
+	ks := encryption.NewKeystore()
+	dir := t.TempDir()
+	sidecarPath := dir + "/keys.json"
+	app, err := encryption.NewApplier(reg,
+		encryption.WithKEK(&fakeKEK{}),
+		encryption.WithKeystore(ks),
+		encryption.WithSidecarPath(sidecarPath),
+	)
+	if err != nil {
+		t.Fatalf("NewApplier: %v", err)
+	}
+	if err := app.ApplyBootstrap(100, fsmwire.BootstrapPayload{
+		StorageDEKID: cutoverBootstrapStorageDEKID, WrappedStorage: []byte("s"),
+		RaftDEKID: cutoverBootstrapRaftDEKID, WrappedRaft: []byte("r"),
+		BatchRegistry: []fsmwire.RegistrationPayload{
+			{DEKID: cutoverBootstrapStorageDEKID, FullNodeID: 0xAAAA, LocalEpoch: 0},
+		},
+	}); err != nil {
+		t.Fatalf("ApplyBootstrap: %v", err)
+	}
+	// Inject a registry SetRegistryRow failure on the next call.
+	// The cutover would otherwise hit §4.1 case 2 (monotonic
+	// advance from epoch 0 → 1), so the insert reaches the
+	// (failing) SetRegistryRow.
+	reg.setEr = errors.New("simulated registry failure mid-apply")
+	err = app.ApplyRotation(500, fsmwire.RotationPayload{
+		SubTag:  fsmwire.RotateSubEnableStorageEnvelope,
+		DEKID:   cutoverBootstrapStorageDEKID,
+		Purpose: fsmwire.PurposeStorage,
+		Wrapped: []byte{},
+		ProposerRegistration: fsmwire.RegistrationPayload{
+			DEKID: cutoverBootstrapStorageDEKID, FullNodeID: 0xAAAA, LocalEpoch: 1,
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error from injected registry failure, got nil")
+	}
+	// Sidecar must NOT show a pre-flipped cutover state — if it
+	// did, the §5.2 startup guard would refuse boot on restart,
+	// and replay would short-circuit on already-active.
+	sc, err := encryption.ReadSidecar(sidecarPath)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	if sc.StorageEnvelopeActive {
+		t.Error("StorageEnvelopeActive flipped despite registration failure (ordering regression)")
+	}
+	if sc.StorageEnvelopeCutoverIndex != 0 {
+		t.Errorf("StorageEnvelopeCutoverIndex = %d despite registration failure, want 0",
+			sc.StorageEnvelopeCutoverIndex)
+	}
+}
+
 // bootstrappedDir constructs a temp dir + sidecar path with an
 // Applier-bootstrapped sidecar at
 // (cutoverBootstrapStorageDEKID, cutoverBootstrapRaftDEKID).

--- a/internal/encryption/applier_test.go
+++ b/internal/encryption/applier_test.go
@@ -801,6 +801,386 @@ func TestApplyRotation_UnknownPurpose(t *testing.T) {
 	}
 }
 
+// TestApplyRotation_EnableStorageEnvelope_FreshSuccess pins the
+// Stage 6D-4 happy-path apply: after Bootstrap, a cutover entry
+// with DEKID == Active.Storage, empty Wrapped, and
+// Purpose == PurposeStorage flips StorageEnvelopeActive and records
+// StorageEnvelopeCutoverIndex inside one sidecar fsync. The
+// ProposerRegistration row is inserted via the standard §4.1 case
+// dispatch so the proposer's first encrypted write under the
+// now-active envelope is covered.
+//
+// Run with Wrapped both as `nil` and as `[]byte{}` to pin the
+// length-based check on the applier side — `Wrapped == nil` is the
+// in-Go construction, `[]byte{}` is what the wire decoder
+// materialises for a `wrapped_len = 0` payload.
+func TestApplyRotation_EnableStorageEnvelope_FreshSuccess(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		wrapped []byte
+	}{
+		{name: "nil_wrapped", wrapped: nil},
+		{name: "empty_wrapped", wrapped: []byte{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runCutoverFreshSuccess(t, tc.wrapped)
+		})
+	}
+}
+
+func runCutoverFreshSuccess(t *testing.T, wrapped []byte) {
+	t.Helper()
+	reg := newMapRegistryStore()
+	ks := encryption.NewKeystore()
+	dir := t.TempDir()
+	sidecarPath := dir + "/keys.json"
+	app, err := encryption.NewApplier(reg,
+		encryption.WithKEK(&fakeKEK{}),
+		encryption.WithKeystore(ks),
+		encryption.WithSidecarPath(sidecarPath),
+	)
+	if err != nil {
+		t.Fatalf("NewApplier: %v", err)
+	}
+	if err := app.ApplyBootstrap(100, fsmwire.BootstrapPayload{
+		StorageDEKID: 7, WrappedStorage: []byte("s"),
+		RaftDEKID: 8, WrappedRaft: []byte("r"),
+		BatchRegistry: []fsmwire.RegistrationPayload{
+			{DEKID: 7, FullNodeID: 0xAAAA, LocalEpoch: 0},
+		},
+	}); err != nil {
+		t.Fatalf("ApplyBootstrap: %v", err)
+	}
+	const cutoverIdx uint64 = 500
+	if err := app.ApplyRotation(cutoverIdx, fsmwire.RotationPayload{
+		SubTag:  fsmwire.RotateSubEnableStorageEnvelope,
+		DEKID:   7, // matches sidecar.Active.Storage
+		Purpose: fsmwire.PurposeStorage,
+		Wrapped: wrapped,
+		ProposerRegistration: fsmwire.RegistrationPayload{
+			DEKID: 7, FullNodeID: 0xAAAA, LocalEpoch: 1,
+		},
+	}); err != nil {
+		t.Fatalf("ApplyRotation cutover: %v", err)
+	}
+	assertCutoverApplied(t, sidecarPath, cutoverIdx)
+	assertProposerEpoch(t, reg, 7, 0xAAAA, 1)
+}
+
+// assertCutoverApplied verifies the fresh-success post-conditions:
+// StorageEnvelopeActive flipped, StorageEnvelopeCutoverIndex set
+// to raftIdx, RaftAppliedIndex advanced, Active.Storage unchanged.
+func assertCutoverApplied(t *testing.T, sidecarPath string, cutoverIdx uint64) {
+	t.Helper()
+	sc, err := encryption.ReadSidecar(sidecarPath)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	if !sc.StorageEnvelopeActive {
+		t.Error("StorageEnvelopeActive = false after cutover, want true")
+	}
+	if sc.StorageEnvelopeCutoverIndex != cutoverIdx {
+		t.Errorf("StorageEnvelopeCutoverIndex = %d, want %d",
+			sc.StorageEnvelopeCutoverIndex, cutoverIdx)
+	}
+	if sc.RaftAppliedIndex != cutoverIdx {
+		t.Errorf("RaftAppliedIndex = %d, want %d", sc.RaftAppliedIndex, cutoverIdx)
+	}
+	// Active slot must NOT have been re-pointed — cutover does not
+	// install a new DEK.
+	if sc.Active.Storage != 7 {
+		t.Errorf("Active.Storage = %d, want 7 (cutover should not re-point)", sc.Active.Storage)
+	}
+}
+
+// assertProposerEpoch reads the writer-registry row for the
+// (dekID, nodeID) pair and asserts the LastSeenLocalEpoch matches
+// the cutover's LocalEpoch — proves the ProposerRegistration
+// insert happened on the fresh-success path.
+func assertProposerEpoch(t *testing.T, reg *mapRegistryStore, dekID uint32, nodeID uint16, want uint16) {
+	t.Helper()
+	key := encryption.RegistryKey(dekID, nodeID)
+	raw, ok, err := reg.GetRegistryRow(key)
+	if err != nil {
+		t.Fatalf("GetRegistryRow: %v", err)
+	}
+	if !ok {
+		t.Fatal("proposer registration row missing after cutover")
+	}
+	val, err := encryption.DecodeRegistryValue(raw)
+	if err != nil {
+		t.Fatalf("DecodeRegistryValue: %v", err)
+	}
+	if val.LastSeenLocalEpoch != want {
+		t.Errorf("LastSeenLocalEpoch = %d, want %d", val.LastSeenLocalEpoch, want)
+	}
+}
+
+// TestApplyRotation_EnableStorageEnvelope_RejectsNonStoragePurpose
+// pins constraint #1 from §2.1 on the apply side: a malformed
+// cutover with Purpose=PurposeRaft must halt apply rather than
+// silently mis-flipping the storage-envelope flag based on a raft
+// DEK reference.
+func TestApplyRotation_EnableStorageEnvelope_RejectsNonStoragePurpose(t *testing.T) {
+	t.Parallel()
+	dir, sidecarPath := bootstrappedDir(t)
+	app := newCutoverApplier(t, dir, sidecarPath)
+	err := app.ApplyRotation(500, fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubEnableStorageEnvelope,
+		DEKID:                7,
+		Purpose:              fsmwire.PurposeRaft, // wrong — cutover targets storage envelope
+		Wrapped:              []byte{},
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: 7, FullNodeID: 0xAAAA, LocalEpoch: 1},
+	})
+	if err == nil {
+		t.Fatal("expected halt on non-storage purpose, got nil")
+	}
+	if !errors.Is(err, encryption.ErrEncryptionApply) {
+		t.Errorf("err not marked ErrEncryptionApply: %v", err)
+	}
+	assertCutoverNotApplied(t, sidecarPath)
+}
+
+// TestApplyRotation_EnableStorageEnvelope_RejectsNonEmptyWrapped
+// pins constraint #2 from §2.1: a cutover entry carrying any
+// wrapped bytes is malformed. The length-based check (NOT a
+// `Wrapped == nil` check) is the critical guard — the
+// post-decode slice is always non-nil for `wrapped_len = 0`.
+func TestApplyRotation_EnableStorageEnvelope_RejectsNonEmptyWrapped(t *testing.T) {
+	t.Parallel()
+	dir, sidecarPath := bootstrappedDir(t)
+	app := newCutoverApplier(t, dir, sidecarPath)
+	err := app.ApplyRotation(500, fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubEnableStorageEnvelope,
+		DEKID:                7,
+		Purpose:              fsmwire.PurposeStorage,
+		Wrapped:              []byte("non-empty"), // must be len 0
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: 7, FullNodeID: 0xAAAA, LocalEpoch: 1},
+	})
+	if err == nil {
+		t.Fatal("expected halt on non-empty Wrapped, got nil")
+	}
+	if !errors.Is(err, encryption.ErrEncryptionApply) {
+		t.Errorf("err not marked ErrEncryptionApply: %v", err)
+	}
+	assertCutoverNotApplied(t, sidecarPath)
+}
+
+// TestApplyRotation_EnableStorageEnvelope_RejectsProposerDEKMismatch
+// pins the proposer-registration DEK-pinning symmetry: the
+// ProposerRegistration row must target the same DEK as the cutover
+// payload, otherwise an empty-Wrapped entry would silently insert
+// a writer-registry row against an unrelated DEK.
+func TestApplyRotation_EnableStorageEnvelope_RejectsProposerDEKMismatch(t *testing.T) {
+	t.Parallel()
+	dir, sidecarPath := bootstrappedDir(t)
+	app := newCutoverApplier(t, dir, sidecarPath)
+	err := app.ApplyRotation(500, fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubEnableStorageEnvelope,
+		DEKID:                7,
+		Purpose:              fsmwire.PurposeStorage,
+		Wrapped:              []byte{},
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: 99, FullNodeID: 0xAAAA, LocalEpoch: 1}, // mismatched
+	})
+	if err == nil {
+		t.Fatal("expected halt on proposer DEK mismatch, got nil")
+	}
+	if !errors.Is(err, encryption.ErrEncryptionApply) {
+		t.Errorf("err not marked ErrEncryptionApply: %v", err)
+	}
+	assertCutoverNotApplied(t, sidecarPath)
+}
+
+// TestApplyRotation_EnableStorageEnvelope_StaleDEKID_BenignNoOp
+// pins the §2.1 constraint #3 race posture: a RotateDEK race that
+// advances Active.Storage between cutover propose and apply MUST
+// NOT halt the FSM. Instead the apply path consumes the entry
+// (advance RaftAppliedIndex), leaves StorageEnvelopeActive false,
+// and returns nil — the 6D-6 ride-along will surface
+// ErrCutoverDEKIDStale to the RPC client without bricking the
+// cluster.
+func TestApplyRotation_EnableStorageEnvelope_StaleDEKID_BenignNoOp(t *testing.T) {
+	t.Parallel()
+	dir, sidecarPath := bootstrappedDir(t)
+	app := newCutoverApplier(t, dir, sidecarPath)
+	// Stage a RotateDEK that advances Active.Storage from 7 to 99 —
+	// simulates the "RotateDEK raced between cutover propose and
+	// apply" scenario.
+	if err := app.ApplyRotation(200, fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubRotateDEK,
+		DEKID:                99,
+		Purpose:              fsmwire.PurposeStorage,
+		Wrapped:              []byte("new-storage-dek"),
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: 99, FullNodeID: 0xAAAA, LocalEpoch: 1},
+	}); err != nil {
+		t.Fatalf("ApplyRotation RotateDEK: %v", err)
+	}
+	// Now the cutover lands but still carries the old DEKID=7.
+	const staleIdx uint64 = 300
+	err := app.ApplyRotation(staleIdx, fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubEnableStorageEnvelope,
+		DEKID:                7, // stale — sidecar.Active.Storage moved to 99
+		Purpose:              fsmwire.PurposeStorage,
+		Wrapped:              []byte{},
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: 7, FullNodeID: 0xAAAA, LocalEpoch: 2},
+	})
+	if err != nil {
+		t.Fatalf("stale cutover MUST be a benign no-op (no halt), got: %v", err)
+	}
+	sc, err := encryption.ReadSidecar(sidecarPath)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	// Cutover MUST NOT have flipped on a stale DEKID.
+	if sc.StorageEnvelopeActive {
+		t.Error("StorageEnvelopeActive = true after stale cutover, want false")
+	}
+	if sc.StorageEnvelopeCutoverIndex != 0 {
+		t.Errorf("StorageEnvelopeCutoverIndex = %d after stale cutover, want 0",
+			sc.StorageEnvelopeCutoverIndex)
+	}
+	// But the entry MUST be consumed so it is not replayed.
+	if sc.RaftAppliedIndex != staleIdx {
+		t.Errorf("RaftAppliedIndex = %d after stale cutover, want %d (entry must be consumed)",
+			sc.RaftAppliedIndex, staleIdx)
+	}
+	// And Active.Storage stays at the post-RotateDEK value.
+	if sc.Active.Storage != 99 {
+		t.Errorf("Active.Storage = %d, want 99", sc.Active.Storage)
+	}
+}
+
+// TestApplyRotation_EnableStorageEnvelope_AlreadyActive_IdempotentNoOp
+// pins the §2.1 constraint #4 idempotency: a duplicate cutover
+// entry consumed after the first cutover already committed MUST
+// preserve the original StorageEnvelopeCutoverIndex (the stable
+// idempotency token surfaced by the 6D-6 RPC retry path) and not
+// re-flip StorageEnvelopeActive. RaftAppliedIndex still advances
+// so the duplicate is consumed.
+func TestApplyRotation_EnableStorageEnvelope_AlreadyActive_IdempotentNoOp(t *testing.T) {
+	t.Parallel()
+	dir, sidecarPath := bootstrappedDir(t)
+	app := newCutoverApplier(t, dir, sidecarPath)
+	const firstIdx uint64 = 500
+	if err := app.ApplyRotation(firstIdx, fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubEnableStorageEnvelope,
+		DEKID:                7,
+		Purpose:              fsmwire.PurposeStorage,
+		Wrapped:              []byte{},
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: 7, FullNodeID: 0xAAAA, LocalEpoch: 1},
+	}); err != nil {
+		t.Fatalf("first cutover: %v", err)
+	}
+	// Duplicate cutover at a higher raft index — simulates the
+	// "operator retried after a network blip and the first call
+	// already committed" overlap window described in §2.1
+	// constraint #4.
+	const duplicateIdx uint64 = 600
+	err := app.ApplyRotation(duplicateIdx, fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubEnableStorageEnvelope,
+		DEKID:                7,
+		Purpose:              fsmwire.PurposeStorage,
+		Wrapped:              []byte{},
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: 7, FullNodeID: 0xAAAA, LocalEpoch: 2},
+	})
+	if err != nil {
+		t.Fatalf("duplicate cutover MUST be a benign no-op, got: %v", err)
+	}
+	sc, err := encryption.ReadSidecar(sidecarPath)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	if !sc.StorageEnvelopeActive {
+		t.Error("StorageEnvelopeActive = false after duplicate, want true")
+	}
+	// The §6.4 stable idempotency token — original cutover index
+	// MUST be preserved across the duplicate apply.
+	if sc.StorageEnvelopeCutoverIndex != firstIdx {
+		t.Errorf("StorageEnvelopeCutoverIndex = %d after duplicate, want %d (original cutover index must not be overwritten)",
+			sc.StorageEnvelopeCutoverIndex, firstIdx)
+	}
+	// RaftAppliedIndex advances so the duplicate is consumed.
+	if sc.RaftAppliedIndex != duplicateIdx {
+		t.Errorf("RaftAppliedIndex = %d after duplicate, want %d",
+			sc.RaftAppliedIndex, duplicateIdx)
+	}
+}
+
+// cutoverBootstrapStorageDEKID / cutoverBootstrapRaftDEKID are the
+// DEK IDs landed by every cutover-test bootstrap. The cutover
+// tests pin Active.Storage to this constant so the fresh-success,
+// stale-DEKID, and idempotent-retry cases share the same prelude.
+const (
+	cutoverBootstrapStorageDEKID uint32 = 7
+	cutoverBootstrapRaftDEKID    uint32 = 8
+)
+
+// bootstrappedDir constructs a temp dir + sidecar path with an
+// Applier-bootstrapped sidecar at
+// (cutoverBootstrapStorageDEKID, cutoverBootstrapRaftDEKID).
+// Used by the cutover negative tests to share the setup.
+func bootstrappedDir(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	sidecarPath := dir + "/keys.json"
+	reg := newMapRegistryStore()
+	ks := encryption.NewKeystore()
+	app, err := encryption.NewApplier(reg,
+		encryption.WithKEK(&fakeKEK{}),
+		encryption.WithKeystore(ks),
+		encryption.WithSidecarPath(sidecarPath),
+	)
+	if err != nil {
+		t.Fatalf("NewApplier: %v", err)
+	}
+	if err := app.ApplyBootstrap(100, fsmwire.BootstrapPayload{
+		StorageDEKID: cutoverBootstrapStorageDEKID, WrappedStorage: []byte("s"),
+		RaftDEKID: cutoverBootstrapRaftDEKID, WrappedRaft: []byte("r"),
+		BatchRegistry: []fsmwire.RegistrationPayload{
+			{DEKID: cutoverBootstrapStorageDEKID, FullNodeID: 0xAAAA, LocalEpoch: 0},
+		},
+	}); err != nil {
+		t.Fatalf("ApplyBootstrap: %v", err)
+	}
+	return dir, sidecarPath
+}
+
+// newCutoverApplier returns a fresh Applier wired against the
+// bootstrappedDir sidecar so cutover tests do not have to share
+// state with the bootstrap call.
+func newCutoverApplier(t *testing.T, _ string, sidecarPath string) *encryption.Applier {
+	t.Helper()
+	app, err := encryption.NewApplier(newMapRegistryStore(),
+		encryption.WithKEK(&fakeKEK{}),
+		encryption.WithKeystore(encryption.NewKeystore()),
+		encryption.WithSidecarPath(sidecarPath),
+	)
+	if err != nil {
+		t.Fatalf("NewApplier: %v", err)
+	}
+	return app
+}
+
+// assertCutoverNotApplied verifies that a rejected cutover left
+// the sidecar's cutover state untouched — neither
+// StorageEnvelopeActive nor StorageEnvelopeCutoverIndex may have
+// been mutated by a malformed entry whose apply was halted.
+func assertCutoverNotApplied(t *testing.T, sidecarPath string) {
+	t.Helper()
+	sc, err := encryption.ReadSidecar(sidecarPath)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	if sc.StorageEnvelopeActive {
+		t.Error("StorageEnvelopeActive = true despite halt, want false")
+	}
+	if sc.StorageEnvelopeCutoverIndex != 0 {
+		t.Errorf("StorageEnvelopeCutoverIndex = %d despite halt, want 0",
+			sc.StorageEnvelopeCutoverIndex)
+	}
+}
+
 // TestApplyBootstrap_RejectsSecondBootstrapWithDifferentDEKs
 // pins the §5.6 one-time-bootstrap invariant: once Active slots
 // are populated, a second committed bootstrap entry with

--- a/internal/encryption/fsmwire/wire.go
+++ b/internal/encryption/fsmwire/wire.go
@@ -99,13 +99,22 @@ const (
 	// update. Ships in Stage 4. See §5.2.
 	RotateSubRotateDEK byte = 0x01
 
+	// RotateSubEnableStorageEnvelope is the one-shot storage-layer
+	// cutover (§2.2 / §7.1 Phase 1). Ships in Stage 6D. The wire
+	// shape reuses the rotate-dek triple but with `Wrapped` empty
+	// (`len(Wrapped) == 0`) and `DEKID == sidecar.Active.Storage`;
+	// the applier re-validates both at apply time. The byte value
+	// `0x04` matches the original `0x02..0x0F` reservation block
+	// so older binaries that pre-date Stage 6D continue to halt on
+	// the existing "unknown sub-tag" branch.
+	RotateSubEnableStorageEnvelope byte = 0x04
+
 	// Reserved for later stages; declared here so the byte space
 	// is contiguous and a future commit cannot silently re-use
 	// 0x02..0x0F without an audit:
 	//
 	//   0x02 — rewrap-deks       (Stage 9, §5.4 / §5.5)
 	//   0x03 — retire-dek        (Stage 9, §5.4)
-	//   0x04 — enable-storage-envelope (Stage 6, §7.1 Phase 1)
 	//   0x05 — enable-raft-envelope    (Stage 6, §7.1 Phase 2)
 )
 
@@ -168,8 +177,8 @@ type BootstrapPayload struct {
 }
 
 // RotationPayload is the OpRotation body. SubTag selects between
-// rotate-dek / rewrap / enable-flag variants; Stage 4 ships only
-// RotateSubRotateDEK.
+// rotate-dek / rewrap / enable-flag variants. Stage 4 ships
+// RotateSubRotateDEK; Stage 6D adds RotateSubEnableStorageEnvelope.
 //
 // For RotateSubRotateDEK the payload is:
 //   - DEKID: the new key id being installed
@@ -179,6 +188,18 @@ type BootstrapPayload struct {
 //     row, inserted in the same FSM apply transaction so the
 //     proposer's first encrypted write under the new DEK is
 //     covered by the §4.1 case 2 epoch monotonicity check.
+//
+// For RotateSubEnableStorageEnvelope the payload reuses the same
+// triple but with stricter constraints (validated in both the
+// cutover RPC mutator on the propose side and `ApplyRotation` on
+// the apply side, per the 6D design's §2.1):
+//   - DEKID: MUST equal sidecar.Active.Storage at apply time
+//   - Purpose: MUST be PurposeStorage
+//   - Wrapped: MUST be empty (`len(Wrapped) == 0`, NOT nil — the
+//     wire decoder materialises zero-length payloads as an
+//     allocated empty slice)
+//   - ProposerRegistration: covers the proposer's first write
+//     under the now-active envelope
 type RotationPayload struct {
 	SubTag               byte
 	DEKID                uint32
@@ -488,18 +509,25 @@ func DecodeRotation(raw []byte) (RotationPayload, error) {
 }
 
 // readRotationSubTag consumes the 1-byte rotation sub-tag and
-// validates it against the known set. Stage 4 ships only
-// RotateSubRotateDEK; later stages (rewrap, retire, enable-flag)
-// will whitelist new values.
+// validates it against the known set. Stage 4 ships
+// RotateSubRotateDEK; Stage 6D adds RotateSubEnableStorageEnvelope.
+// Future stages (rewrap, retire, enable-raft-envelope) will
+// whitelist additional values here AND add a matching dispatch
+// branch in `internal/encryption/applier.go::ApplyRotation` —
+// updating only one site silently regresses the other (see the
+// §2.2 "Two-site whitelist change required" note in the 6D
+// design doc).
 func readRotationSubTag(r *reader) (byte, error) {
 	sub, ok := r.readByte()
 	if !ok {
 		return 0, errors.Wrap(ErrFSMWireMalformed, "rotation: missing sub-tag")
 	}
-	if sub != RotateSubRotateDEK {
+	switch sub {
+	case RotateSubRotateDEK, RotateSubEnableStorageEnvelope:
+		return sub, nil
+	default:
 		return 0, errors.Wrapf(ErrFSMWireSubtag, "rotation: subtag=%#x", sub)
 	}
-	return sub, nil
 }
 
 // readRotationBody decodes the (dek_id, purpose, wrapped) triple

--- a/internal/encryption/fsmwire/wire_test.go
+++ b/internal/encryption/fsmwire/wire_test.go
@@ -256,11 +256,71 @@ func TestRotation_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestRotation_EnableStorageEnvelope_RoundTrip pins the Stage 6D
+// wire shape for the cutover sub-tag: empty Wrapped, Purpose
+// PurposeStorage, ProposerRegistration covering the active
+// storage DEK. A regression that re-marshalled the Wrapped slice
+// as `nil` instead of `[]byte{}` would still round-trip here (the
+// applier's length-based check is the canonical guard), but a
+// regression that lost the sub-tag byte or trimmed any field
+// would surface as a header / length mismatch.
+func TestRotation_EnableStorageEnvelope_RoundTrip(t *testing.T) {
+	t.Parallel()
+	want := fsmwire.RotationPayload{
+		SubTag:  fsmwire.RotateSubEnableStorageEnvelope,
+		DEKID:   0xCAFEBABE,
+		Purpose: fsmwire.PurposeStorage,
+		Wrapped: []byte{}, // §2.1 constraint #2
+		ProposerRegistration: fsmwire.RegistrationPayload{
+			DEKID:      0xCAFEBABE,
+			FullNodeID: 0xDEADBEEFCAFEBABE,
+			LocalEpoch: 9,
+		},
+	}
+	got, err := fsmwire.DecodeRotation(fsmwire.EncodeRotation(want))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.SubTag != want.SubTag {
+		t.Fatalf("sub-tag mismatch: got %#x want %#x", got.SubTag, want.SubTag)
+	}
+	if got.DEKID != want.DEKID || got.Purpose != want.Purpose {
+		t.Fatalf("header mismatch: got %+v", got)
+	}
+	if len(got.Wrapped) != 0 {
+		t.Fatalf("expected empty Wrapped, got %d bytes", len(got.Wrapped))
+	}
+	if got.ProposerRegistration != want.ProposerRegistration {
+		t.Fatalf("proposer reg mismatch: got %+v want %+v", got.ProposerRegistration, want.ProposerRegistration)
+	}
+}
+
+// TestRotation_SubTagConstantPinned guards against a future commit
+// silently shifting the byte value for the cutover sub-tag — that
+// would break rolling-upgrade compatibility, since old binaries
+// would route the cutover entry through the rotate-dek path (or
+// halt on an unknown sub-tag depending on the byte chosen).
+func TestRotation_SubTagConstantPinned(t *testing.T) {
+	t.Parallel()
+	if fsmwire.RotateSubRotateDEK != 0x01 {
+		t.Errorf("RotateSubRotateDEK drifted from 0x01: %#x", fsmwire.RotateSubRotateDEK)
+	}
+	if fsmwire.RotateSubEnableStorageEnvelope != 0x04 {
+		t.Errorf("RotateSubEnableStorageEnvelope drifted from 0x04: %#x", fsmwire.RotateSubEnableStorageEnvelope)
+	}
+	if fsmwire.RotateSubRotateDEK == fsmwire.RotateSubEnableStorageEnvelope {
+		t.Fatal("RotateSubRotateDEK and RotateSubEnableStorageEnvelope collide")
+	}
+}
+
 func TestRotation_RejectsUnknownSubTag(t *testing.T) {
 	t.Parallel()
 	raw := fsmwire.EncodeRotation(fsmwire.RotationPayload{
 		SubTag: fsmwire.RotateSubRotateDEK, DEKID: 1, Purpose: fsmwire.PurposeStorage,
 	})
+	// 0x99 is outside the whitelisted set ({0x01, 0x04}) — pinning
+	// 0x99 specifically also catches a future change that
+	// accidentally widened the whitelist to "any non-zero byte".
 	raw[1] = 0x99 // sub-tag byte (after version)
 	_, err := fsmwire.DecodeRotation(raw)
 	if !errors.Is(err, fsmwire.ErrFSMWireSubtag) {

--- a/internal/encryption/sidecar.go
+++ b/internal/encryption/sidecar.go
@@ -20,10 +20,11 @@ const sidecarFileMode = 0o600
 // SidecarVersion is the wire version of the on-disk sidecar JSON.
 //
 // Version 1 carries the §5.1 layout (active, keys, raft_applied_index,
-// storage_envelope_active, raft_envelope_cutover_index). Future versions
-// extend the layout via additive JSON fields plus a bump here; mismatched
-// versions are rejected at read time so an older binary cannot silently
-// drop fields it does not understand.
+// storage_envelope_active, storage_envelope_cutover_index,
+// raft_envelope_cutover_index). Future versions extend the layout via
+// additive JSON fields plus a bump here; mismatched versions are
+// rejected at read time so an older binary cannot silently drop fields
+// it does not understand.
 const SidecarVersion = 1
 
 // SidecarFilename is the standard filename inside <dataDir>/encryption/.
@@ -47,11 +48,25 @@ const (
 // are omitted; they will be added as additive fields when the relevant
 // stage ships.
 type Sidecar struct {
-	Version                  int        `json:"version"`
-	RaftAppliedIndex         uint64     `json:"raft_applied_index"`
-	StorageEnvelopeActive    bool       `json:"storage_envelope_active"`
-	RaftEnvelopeCutoverIndex uint64     `json:"raft_envelope_cutover_index"`
-	Active                   ActiveKeys `json:"active"`
+	Version          int    `json:"version"`
+	RaftAppliedIndex uint64 `json:"raft_applied_index"`
+	// StorageEnvelopeActive flips to true exactly once, when the
+	// `RotateSubEnableStorageEnvelope` (§2.2 / §7) cutover entry
+	// applies. Pre-cutover storage Puts write cleartext; post-cutover
+	// Puts wrap values in the §4.1 envelope. The flip and the
+	// cutover index below are written inside a single
+	// crash-durable `WriteSidecar` fsync (§6.4 atomicity).
+	StorageEnvelopeActive bool `json:"storage_envelope_active"`
+	// StorageEnvelopeCutoverIndex is the Raft index at which the
+	// cutover entry applied. Set once by the first cutover apply
+	// (§6.4) and never overwritten by later encryption entries; the
+	// §3.2 idempotent-retry RPC path uses it as a stable
+	// applied_index across arbitrary subsequent Raft activity. A
+	// zero value with `StorageEnvelopeActive == false` is the
+	// pre-cutover baseline.
+	StorageEnvelopeCutoverIndex uint64     `json:"storage_envelope_cutover_index"`
+	RaftEnvelopeCutoverIndex    uint64     `json:"raft_envelope_cutover_index"`
+	Active                      ActiveKeys `json:"active"`
 	// Keys is keyed by the decimal string form of key_id (per §5.1's
 	// "JSON object keys must be strings, but the on-disk envelope and
 	// the in-memory keystore always work in the binary uint32 form").

--- a/internal/encryption/sidecar.go
+++ b/internal/encryption/sidecar.go
@@ -17,15 +17,31 @@ import (
 // the unwrapped DEK never appears on disk regardless.
 const sidecarFileMode = 0o600
 
-// SidecarVersion is the wire version of the on-disk sidecar JSON.
+// SidecarVersion is the current wire version written by
+// WriteSidecar. Versions 1 (pre-6D-4) and 2 (6D-4 and later) are
+// readable. Future versions extend the layout via additive JSON
+// fields plus a bump here; mismatched versions are rejected at
+// read time so an older binary cannot silently drop fields it
+// does not understand.
 //
-// Version 1 carries the §5.1 layout (active, keys, raft_applied_index,
-// storage_envelope_active, storage_envelope_cutover_index,
-// raft_envelope_cutover_index). Future versions extend the layout via
-// additive JSON fields plus a bump here; mismatched versions are
-// rejected at read time so an older binary cannot silently drop fields
-// it does not understand.
-const SidecarVersion = 1
+// Version 2 adds storage_envelope_cutover_index (6D-4 §6.4). The
+// upgrade path is automatic: a post-6D-4 binary reads a version-1
+// sidecar with the new field defaulting to 0, then writes
+// version 2 on the next sidecar mutation (WriteSidecar overrides
+// the in-struct Version with SidecarVersion). A subsequent
+// downgrade to a pre-6D-4 binary then refuses to boot because
+// that binary only accepts version 1 — preventing the silent
+// field-drop that the design doc §6.4 warns about (gemini
+// medium #2 on PR804).
+const SidecarVersion = 2
+
+// MinReadableSidecarVersion is the oldest wire version ReadSidecar
+// accepts. Set to 1 so a freshly-upgraded post-6D-4 node can read
+// the legacy pre-6D-4 sidecar that an in-place upgrade leaves on
+// disk; the very next WriteSidecar transitions it to
+// SidecarVersion. A future major version bump would raise this
+// constant to drop legacy-read support.
+const MinReadableSidecarVersion = 1
 
 // SidecarFilename is the standard filename inside <dataDir>/encryption/.
 const SidecarFilename = "keys.json"
@@ -134,9 +150,10 @@ func ReadSidecar(path string) (*Sidecar, error) {
 	if err := json.Unmarshal(raw, &sc); err != nil {
 		return nil, pkgerrors.Wrapf(err, "encryption: parse sidecar %q", path)
 	}
-	if sc.Version != SidecarVersion {
+	if sc.Version < MinReadableSidecarVersion || sc.Version > SidecarVersion {
 		return nil, pkgerrors.Wrapf(ErrSidecarVersion,
-			"got version %d, want %d (path=%q)", sc.Version, SidecarVersion, path)
+			"got version %d, want %d..%d (path=%q)",
+			sc.Version, MinReadableSidecarVersion, SidecarVersion, path)
 	}
 	if err := validateSidecar(&sc); err != nil {
 		return nil, pkgerrors.Wrapf(err, "encryption: validate sidecar %q", path)

--- a/internal/encryption/sidecar_test.go
+++ b/internal/encryption/sidecar_test.go
@@ -231,7 +231,10 @@ func TestReadSidecar_Missing(t *testing.T) {
 
 func TestReadSidecar_RejectsUnknownVersion(t *testing.T) {
 	path := sidecarPath(t)
-	for _, v := range []int{0, 2, 42, -1} {
+	// 0 and -1 are below MinReadableSidecarVersion; 3 / 42 are above
+	// SidecarVersion (currently 2). 1 and 2 are valid and exercised
+	// by the legacy-read and round-trip tests.
+	for _, v := range []int{0, 3, 42, -1} {
 		raw, err := json.Marshal(map[string]any{
 			"version":                     v,
 			"raft_applied_index":          0,
@@ -250,6 +253,55 @@ func TestReadSidecar_RejectsUnknownVersion(t *testing.T) {
 		if !errors.Is(err, encryption.ErrSidecarVersion) {
 			t.Fatalf("version=%d: expected ErrSidecarVersion, got %v", v, err)
 		}
+	}
+}
+
+// TestReadSidecar_AcceptsLegacyVersion1 pins the upgrade-path
+// invariant: a post-6D-4 binary MUST be able to read a pre-6D-4
+// version-1 sidecar so an in-place upgrade is rolling-compatible.
+// The new StorageEnvelopeCutoverIndex field defaults to 0
+// (pre-cutover baseline). Without this guarantee an in-place
+// upgrade would refuse to boot on the upgraded node — gemini
+// medium #2 on PR804.
+func TestReadSidecar_AcceptsLegacyVersion1(t *testing.T) {
+	path := sidecarPath(t)
+	// Version-1 layout WITHOUT storage_envelope_cutover_index, as
+	// written by a pre-6D-4 binary.
+	raw := []byte(`{
+        "version": 1,
+        "raft_applied_index": 184273,
+        "storage_envelope_active": false,
+        "raft_envelope_cutover_index": 0,
+        "active": {"storage": 0, "raft": 0},
+        "keys": {}
+    }`)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := encryption.ReadSidecar(path)
+	if err != nil {
+		t.Fatalf("ReadSidecar(version=1) refused legacy read: %v", err)
+	}
+	if got.Version != 1 {
+		t.Errorf("parsed Version = %d, want 1 (preserve legacy version pre-write)", got.Version)
+	}
+	if got.StorageEnvelopeCutoverIndex != 0 {
+		t.Errorf("StorageEnvelopeCutoverIndex = %d, want 0 (default for absent field)",
+			got.StorageEnvelopeCutoverIndex)
+	}
+	// The very next WriteSidecar must transition the sidecar to
+	// version 2 — WriteSidecar overrides the in-struct Version
+	// regardless of caller value.
+	if err := encryption.WriteSidecar(path, got); err != nil {
+		t.Fatalf("WriteSidecar after legacy read: %v", err)
+	}
+	rewritten, err := encryption.ReadSidecar(path)
+	if err != nil {
+		t.Fatalf("ReadSidecar after rewrite: %v", err)
+	}
+	if rewritten.Version != encryption.SidecarVersion {
+		t.Errorf("rewritten Version = %d, want %d (auto-upgrade on next write)",
+			rewritten.Version, encryption.SidecarVersion)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Stage 6D-4 lands the FSM-level half of the storage-envelope cutover per `docs/design/2026_05_18_partial_6d_enable_storage_envelope.md` §2.1 / §2.2 / §6.4. Operator-inert: no CLI, no §6.2 PutAt toggle — those land in 6D-5 / 6D-6.
- Promote the `0x04` reservation to a declared constant `RotateSubEnableStorageEnvelope`, widen `readRotationSubTag` to a whitelist switch (the §2.2 "two-site whitelist change required" property), and dispatch the new sub-tag in `ApplyRotation`.
- Add `Sidecar.StorageEnvelopeCutoverIndex uint64` field (§6.4). The fresh cutover apply flips `StorageEnvelopeActive`, records the cutover index, and advances `RaftAppliedIndex` inside one `WriteSidecar` fsync. Stale-DEKID (§2.1 #3 race against `RotateDEK`) and already-active duplicates are benign no-ops that consume the entry without halting — the §6.4 stable idempotency token is preserved across duplicates.

## Test plan

- [x] `go test -race -timeout 180s ./internal/encryption/... ./kv/... ./store/...` — all green
- [x] `golangci-lint --config=.golangci.yaml run` (new-from-rev origin/main) — 0 issues
- [x] `TestRotation_EnableStorageEnvelope_RoundTrip` — wire shape pins
- [x] `TestRotation_SubTagConstantPinned` — guards against silent byte drift (would break rolling-upgrade compatibility)
- [x] `TestApplyRotation_EnableStorageEnvelope_FreshSuccess` — bootstrap → cutover → assert sidecar flip, cutover index, `RaftAppliedIndex` advance, `Active.Storage` unchanged, proposer registration row inserted; parametrised over `Wrapped = nil` AND `Wrapped = []byte{}` to pin the length-based guard
- [x] `TestApplyRotation_EnableStorageEnvelope_RejectsNonStoragePurpose` — §2.1 #1 halt
- [x] `TestApplyRotation_EnableStorageEnvelope_RejectsNonEmptyWrapped` — §2.1 #2 halt
- [x] `TestApplyRotation_EnableStorageEnvelope_RejectsProposerDEKMismatch` — proposer DEK pinning halt
- [x] `TestApplyRotation_EnableStorageEnvelope_StaleDEKID_BenignNoOp` — `RotateDEK` races; cutover apply consumes the entry without halting
- [x] `TestApplyRotation_EnableStorageEnvelope_AlreadyActive_IdempotentNoOp` — duplicate cutover at a higher raftIdx; original `StorageEnvelopeCutoverIndex` preserved

## Self-review (5 lenses)

1. **Data loss** — no. The cutover apply touches only sidecar fields; all writes go through the existing `WriteSidecar` crash-durable protocol. Stale-DEKID and already-active no-ops still `WriteSidecar` so the `RaftAppliedIndex` advance is durable; without that, a crash + replay would re-apply the entry.
2. **Concurrency / distributed failures** — the §2.1 #3 race posture is the central concurrency invariant. The fresh-success and benign-no-op paths are exhaustive over the (`Active.Storage`, `StorageEnvelopeActive`) sidecar state at apply time. Apply is single-threaded per FSM so no internal locking is needed.
3. **Performance** — one extra `ReadSidecar` + `WriteSidecar` per cutover apply; cutover is one-shot per cluster so this is irrelevant to steady-state. Length-based check on `Wrapped` is O(1).
4. **Data consistency** — §6.4 atomicity holds (all three sidecar field writes inside one `WriteSidecar` fsync). The two-site whitelist invariant is pinned by a comment in `readRotationSubTag` and by `TestRotation_SubTagConstantPinned`. The §2.1 #4 idempotency contract holds (original `StorageEnvelopeCutoverIndex` preserved across duplicate applies, exercised by the regression test).
5. **Test coverage** — 6 new applier tests cover every §2.1 constraint + each apply-path outcome (fresh success / stale no-op / already-active no-op). 2 new wire tests pin the constant and the round-trip. `Wrapped = nil` vs `[]byte{}` is parametrised so the length-based check cannot regress to a `== nil` check.

Refs: design doc §2.1 / §2.2 / §6.4 (Stage 6D-4 row of §7 decomposition table).
