### PR TITLE
adapter/dynamodb: item-level admin RPCs (Phase 2a)

### DIFF
--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -8005,6 +8005,15 @@ func (d *DynamoDBServer) ensureLegacyTableMigrationLocked(ctx context.Context, t
 		if !exists || !schema.needsLegacyKeyMigration() {
 			return nil
 		}
+		// Admin read-only callers (AdminScanTable) must not trigger
+		// migration writes. Their own pre-check at the admin readTS
+		// already rejects needs-migration tables, but the schema can
+		// transition between that check and this one (Codex r8 P2 on
+		// PR #805) — refuse rather than racing into write-path code.
+		if isAdminReadOnlyContext(ctx) {
+			return errors.Wrap(ErrAdminDynamoValidation,
+				"table requires a one-time legacy-key migration before admin read endpoints are available; migrate via the SigV4 surface first")
+		}
 		if !schema.usesOrderedKeyEncoding() {
 			err = d.startLegacyTableKeyMigration(ctx, schema, readTS)
 		} else {

--- a/adapter/dynamodb_admin_items.go
+++ b/adapter/dynamodb_admin_items.go
@@ -43,8 +43,8 @@ type AdminItemKey struct {
 // scan output: the bounded items page plus a continuation key (nil
 // when the scan has drained for the current MVCC snapshot).
 type AdminScanResult struct {
-	Items            []AdminItem
-	LastEvaluatedKey map[string]AdminAttributeValue
+	Items            []AdminItem                    `json:"items"`
+	LastEvaluatedKey map[string]AdminAttributeValue `json:"last_evaluated_key,omitempty"`
 }
 
 // AdminScanOptions controls one AdminScanTable call. Defaults
@@ -53,8 +53,8 @@ type AdminScanResult struct {
 //	Limit = 25 (clamped to [1, adminItemScanMaxLimit=100])
 //	StartKey = nil (front of the table)
 type AdminScanOptions struct {
-	Limit          int
-	ExclusiveStart map[string]AdminAttributeValue
+	Limit          int                            `json:"limit,omitempty"`
+	ExclusiveStart map[string]AdminAttributeValue `json:"exclusive_start,omitempty"`
 }
 
 const (
@@ -237,6 +237,12 @@ func (d *DynamoDBServer) AdminPutItem(ctx context.Context, principal AdminPrinci
 
 // AdminDeleteItem removes one item by primary key. Write role
 // required.
+//
+// Sentinels:
+//   - ErrAdminForbidden        — principal lacks write role
+//   - ErrAdminNotLeader        — follower
+//   - ErrAdminDynamoNotFound   — table absent
+//   - ErrAdminDynamoValidation — empty / malformed input
 func (d *DynamoDBServer) AdminDeleteItem(ctx context.Context, principal AdminPrincipal, tableName string, key map[string]AdminAttributeValue) error {
 	if !principal.Role.canWrite() {
 		return ErrAdminForbidden

--- a/adapter/dynamodb_admin_items.go
+++ b/adapter/dynamodb_admin_items.go
@@ -1,7 +1,9 @@
 package adapter
 
 import (
+	"bytes"
 	"context"
+	"slices"
 	"strings"
 
 	"github.com/cockroachdb/errors"
@@ -115,6 +117,9 @@ func (d *DynamoDBServer) AdminScanTable(ctx context.Context, principal AdminPrin
 		return AdminScanResult{}, errors.Wrap(ErrAdminDynamoValidation,
 			"table requires a one-time legacy-key migration before admin read endpoints are available; migrate via the SigV4 surface first")
 	}
+	if err := validateAdminAttributeMapDepth(opts.ExclusiveStart); err != nil {
+		return AdminScanResult{}, err
+	}
 	limit := clampAdminScanLimit(opts.Limit)
 	scanInput := scanInput{
 		TableName:         tableName,
@@ -142,6 +147,9 @@ func (d *DynamoDBServer) AdminScanTable(ctx context.Context, principal AdminPrin
 func (d *DynamoDBServer) AdminGetItem(ctx context.Context, principal AdminPrincipal, tableName string, key map[string]AdminAttributeValue) (*AdminItem, bool, error) {
 	schema, readTS, err := d.adminLoadReadableSchema(ctx, principal, tableName, len(key))
 	if err != nil {
+		return nil, false, err
+	}
+	if err := validateAdminAttributeMapDepth(key); err != nil {
 		return nil, false, err
 	}
 	internalKey := adminToInternalAttributeMap(key)
@@ -214,6 +222,9 @@ func (d *DynamoDBServer) AdminPutItem(ctx context.Context, principal AdminPrinci
 	if len(item.Attributes) == 0 {
 		return ErrAdminDynamoValidation
 	}
+	if err := validateAdminAttributeMapDepth(item.Attributes); err != nil {
+		return err
+	}
 	in := putItemInput{
 		TableName: tableName,
 		Item:      adminToInternalAttributeMap(item.Attributes),
@@ -238,6 +249,9 @@ func (d *DynamoDBServer) AdminDeleteItem(ctx context.Context, principal AdminPri
 	}
 	if len(key) == 0 {
 		return ErrAdminDynamoValidation
+	}
+	if err := validateAdminAttributeMapDepth(key); err != nil {
+		return err
 	}
 	in := deleteItemInput{
 		TableName: tableName,
@@ -318,8 +332,8 @@ func adminToInternalAttributeMap(in map[string]AdminAttributeValue) map[string]a
 
 func internalToAdminAttributeValue(v attributeValue) AdminAttributeValue {
 	out := AdminAttributeValue{
-		S: v.S, N: v.N, B: v.B, BOOL: v.BOOL, NULL: v.NULL,
-		SS: v.SS, NS: v.NS, BS: v.BS,
+		S: v.S, N: v.N, B: bytes.Clone(v.B), BOOL: v.BOOL, NULL: v.NULL,
+		SS: slices.Clone(v.SS), NS: slices.Clone(v.NS), BS: cloneBinarySet(v.BS),
 	}
 	if len(v.L) > 0 {
 		out.L = make([]AdminAttributeValue, len(v.L))
@@ -338,8 +352,8 @@ func internalToAdminAttributeValue(v attributeValue) AdminAttributeValue {
 
 func adminToInternalAttributeValue(v AdminAttributeValue) attributeValue {
 	out := attributeValue{
-		S: v.S, N: v.N, B: v.B, BOOL: v.BOOL, NULL: v.NULL,
-		SS: v.SS, NS: v.NS, BS: v.BS,
+		S: v.S, N: v.N, B: bytes.Clone(v.B), BOOL: v.BOOL, NULL: v.NULL,
+		SS: slices.Clone(v.SS), NS: slices.Clone(v.NS), BS: cloneBinarySet(v.BS),
 	}
 	if len(v.L) > 0 {
 		out.L = make([]attributeValue, len(v.L))
@@ -354,4 +368,37 @@ func adminToInternalAttributeValue(v AdminAttributeValue) attributeValue {
 		}
 	}
 	return out
+}
+
+// validateAdminAttributeMapDepth defensively bounds the nesting
+// depth of admin-supplied attribute maps to maxAttributeValueNestingDepth.
+// The internal wire parser enforces the same cap for SigV4 inputs,
+// but admin RPCs receive AdminAttributeValue from the (Phase 3) HTTP
+// JSON decoder which does not bound recursion depth. Returns
+// ErrAdminDynamoValidation if the input is deeper than 32 (gemini r1
+// security-high on PR #805).
+func validateAdminAttributeMapDepth(in map[string]AdminAttributeValue) error {
+	for _, v := range in {
+		if err := checkAdminAttributeDepth(v, 1); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkAdminAttributeDepth(v AdminAttributeValue, depth int) error {
+	if depth > maxAttributeValueNestingDepth {
+		return errors.Wrap(ErrAdminDynamoValidation, "attribute value nested too deep")
+	}
+	for _, e := range v.L {
+		if err := checkAdminAttributeDepth(e, depth+1); err != nil {
+			return err
+		}
+	}
+	for _, e := range v.M {
+		if err := checkAdminAttributeDepth(e, depth+1); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/adapter/dynamodb_admin_items.go
+++ b/adapter/dynamodb_admin_items.go
@@ -157,6 +157,9 @@ func (d *DynamoDBServer) AdminScanTable(ctx context.Context, principal AdminPrin
 	if err := validateAdminAttributeMapDepth(opts.ExclusiveStart); err != nil {
 		return AdminScanResult{}, err
 	}
+	if err := validateAdminAttributeMapKinds(opts.ExclusiveStart); err != nil {
+		return AdminScanResult{}, err
+	}
 	limit := clampAdminScanLimit(opts.Limit)
 	scanInput := scanInput{
 		TableName:         tableName,
@@ -187,6 +190,9 @@ func (d *DynamoDBServer) AdminGetItem(ctx context.Context, principal AdminPrinci
 		return nil, false, err
 	}
 	if err := validateAdminAttributeMapDepth(key); err != nil {
+		return nil, false, err
+	}
+	if err := validateAdminAttributeMapKinds(key); err != nil {
 		return nil, false, err
 	}
 	internalKey := adminToInternalAttributeMap(key)
@@ -262,6 +268,9 @@ func (d *DynamoDBServer) AdminPutItem(ctx context.Context, principal AdminPrinci
 	if err := validateAdminAttributeMapDepth(item.Attributes); err != nil {
 		return err
 	}
+	if err := validateAdminAttributeMapKinds(item.Attributes); err != nil {
+		return err
+	}
 	in := putItemInput{
 		TableName: tableName,
 		Item:      adminToInternalAttributeMap(item.Attributes),
@@ -294,6 +303,9 @@ func (d *DynamoDBServer) AdminDeleteItem(ctx context.Context, principal AdminPri
 		return ErrAdminDynamoValidation
 	}
 	if err := validateAdminAttributeMapDepth(key); err != nil {
+		return err
+	}
+	if err := validateAdminAttributeMapKinds(key); err != nil {
 		return err
 	}
 	in := deleteItemInput{
@@ -449,4 +461,55 @@ func checkAdminAttributeDepth(v AdminAttributeValue, depth int) error {
 		}
 	}
 	return nil
+}
+
+// validateAdminAttributeMapKinds enforces the AWS-wire "exactly
+// one kind field set per AttributeValue" invariant across the
+// entire admin-supplied attribute tree. The custom MarshalJSON
+// guards the HTTP boundary (Phase 3), but Go-level callers
+// constructing AdminAttributeValue programmatically can still
+// pass zero-field or multi-field values; without this check
+// they would reach putItemWithRetry / readLogicalItemAt where
+// the storage codec surfaces a non-dynamoErrValidation error
+// that translateDynamoAdminError can't recognise — rendering
+// as a 500 instead of the documented 400 contract (Codex r5 P2
+// on PR #805).
+func validateAdminAttributeMapKinds(in map[string]AdminAttributeValue) error {
+	for _, v := range in {
+		if err := checkAdminAttributeKind(v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkAdminAttributeKind(v AdminAttributeValue) error {
+	if countAdminKindFields(v) != 1 {
+		return errors.Wrap(ErrAdminDynamoValidation, "attribute value must have exactly one kind field set")
+	}
+	for _, e := range v.L {
+		if err := checkAdminAttributeKind(e); err != nil {
+			return err
+		}
+	}
+	for _, e := range v.M {
+		if err := checkAdminAttributeKind(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func countAdminKindFields(v AdminAttributeValue) int {
+	set := []bool{
+		v.S != nil, v.N != nil, v.B != nil, v.BOOL != nil, v.NULL != nil,
+		v.SS != nil, v.NS != nil, v.BS != nil, v.L != nil, v.M != nil,
+	}
+	n := 0
+	for _, b := range set {
+		if b {
+			n++
+		}
+	}
+	return n
 }

--- a/adapter/dynamodb_admin_items.go
+++ b/adapter/dynamodb_admin_items.go
@@ -95,6 +95,26 @@ func (d *DynamoDBServer) AdminScanTable(ctx context.Context, principal AdminPrin
 	if strings.TrimSpace(tableName) == "" {
 		return AdminScanResult{}, ErrAdminDynamoValidation
 	}
+	// Refuse on legacy tables BEFORE delegating to scanItems. The
+	// SigV4 scan path calls ensureLegacyTableMigration as part of
+	// prepareReadSchema, which dispatches Raft writes to migrate the
+	// schema in-place. Letting a read-only admin trigger that path
+	// would (a) violate the read-only authorization contract and (b)
+	// generate write load on every dashboard poll until the migration
+	// finishes (Codex r1 P1 on PR #805). Operators migrate the table
+	// via the SigV4 surface before admin reads become available.
+	readTS := d.nextTxnReadTS()
+	schema, exists, err := d.loadTableSchemaAt(ctx, tableName, readTS)
+	if err != nil {
+		return AdminScanResult{}, errors.WithStack(err)
+	}
+	if !exists {
+		return AdminScanResult{}, ErrAdminDynamoNotFound
+	}
+	if schema.needsLegacyKeyMigration() {
+		return AdminScanResult{}, errors.Wrap(ErrAdminDynamoValidation,
+			"table requires a one-time legacy-key migration before admin read endpoints are available; migrate via the SigV4 surface first")
+	}
 	limit := clampAdminScanLimit(opts.Limit)
 	scanInput := scanInput{
 		TableName:         tableName,
@@ -120,27 +140,18 @@ func (d *DynamoDBServer) AdminScanTable(ctx context.Context, principal AdminPrin
 //   - ErrAdminDynamoNotFound — table absent
 //   - ErrAdminDynamoValidation — empty / malformed input
 func (d *DynamoDBServer) AdminGetItem(ctx context.Context, principal AdminPrincipal, tableName string, key map[string]AdminAttributeValue) (*AdminItem, bool, error) {
-	if !principal.Role.canRead() {
-		return nil, false, ErrAdminForbidden
-	}
-	if !isVerifiedDynamoLeader(ctx, d.coordinator) {
-		return nil, false, ErrAdminNotLeader
-	}
-	if strings.TrimSpace(tableName) == "" {
-		return nil, false, ErrAdminDynamoValidation
-	}
-	if len(key) == 0 {
-		return nil, false, ErrAdminDynamoValidation
-	}
-	readTS := d.nextTxnReadTS()
-	schema, exists, err := d.loadTableSchemaAt(ctx, tableName, readTS)
+	schema, readTS, err := d.adminLoadReadableSchema(ctx, principal, tableName, len(key))
 	if err != nil {
-		return nil, false, errors.WithStack(err)
-	}
-	if !exists {
-		return nil, false, ErrAdminDynamoNotFound
+		return nil, false, err
 	}
 	internalKey := adminToInternalAttributeMap(key)
+	// Validate the key shape against the schema BEFORE the read so a
+	// malformed input (missing hash key, wrong type) surfaces as
+	// ErrAdminDynamoValidation rather than the plain errors.New chain
+	// readLogicalItemAt would otherwise return (Codex r1 P2).
+	if _, err := schema.itemKeyFromAttributes(internalKey); err != nil {
+		return nil, false, errors.Wrap(ErrAdminDynamoValidation, err.Error())
+	}
 	current, found, err := d.readLogicalItemAt(ctx, schema, internalKey, readTS)
 	if err != nil {
 		return nil, false, translateDynamoAdminError(err)
@@ -149,6 +160,38 @@ func (d *DynamoDBServer) AdminGetItem(ctx context.Context, principal AdminPrinci
 		return nil, false, nil
 	}
 	return &AdminItem{Attributes: internalToAdminAttributeMap(current.item)}, true, nil
+}
+
+// adminLoadReadableSchema centralises the read-path preamble for
+// AdminGetItem: gate the principal, verify leader, validate the
+// table-name + non-empty key, load the schema, and refuse on
+// legacy-migration-needed tables. Returns the loaded schema + the
+// readTS the caller should reuse so the subsequent item read sees
+// the same MVCC snapshot. keyAttrs is len(key) so the helper can
+// short-circuit on an empty key.
+func (d *DynamoDBServer) adminLoadReadableSchema(ctx context.Context, principal AdminPrincipal, tableName string, keyAttrs int) (*dynamoTableSchema, uint64, error) {
+	if !principal.Role.canRead() {
+		return nil, 0, ErrAdminForbidden
+	}
+	if !isVerifiedDynamoLeader(ctx, d.coordinator) {
+		return nil, 0, ErrAdminNotLeader
+	}
+	if strings.TrimSpace(tableName) == "" || keyAttrs == 0 {
+		return nil, 0, ErrAdminDynamoValidation
+	}
+	readTS := d.nextTxnReadTS()
+	schema, exists, err := d.loadTableSchemaAt(ctx, tableName, readTS)
+	if err != nil {
+		return nil, 0, errors.WithStack(err)
+	}
+	if !exists {
+		return nil, 0, ErrAdminDynamoNotFound
+	}
+	if schema.needsLegacyKeyMigration() {
+		return nil, 0, errors.Wrap(ErrAdminDynamoValidation,
+			"table requires a one-time legacy-key migration before admin read endpoints are available; migrate via the SigV4 surface first")
+	}
+	return schema, readTS, nil
 }
 
 // AdminPutItem creates-or-replaces one item. Write role required.
@@ -236,12 +279,11 @@ func translateDynamoAdminError(err error) error {
 }
 
 // adminItemsFromInternal converts a slice of internal item rows
-// (the scanItems output) into the admin-facing AdminItem slice. Nil
-// in, nil out so callers see the contract directly.
+// (the scanItems output) into the admin-facing AdminItem slice.
+// Empty in produces an empty (non-nil) slice so the JSON encoder
+// emits "items": [] rather than "items": null — the SPA's
+// items.map(...) call would otherwise crash on null (Claude r1 low).
 func adminItemsFromInternal(items []map[string]attributeValue) []AdminItem {
-	if len(items) == 0 {
-		return nil
-	}
 	out := make([]AdminItem, len(items))
 	for i, item := range items {
 		out[i] = AdminItem{Attributes: internalToAdminAttributeMap(item)}

--- a/adapter/dynamodb_admin_items.go
+++ b/adapter/dynamodb_admin_items.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/bootjp/elastickv/kv"
 	"github.com/cockroachdb/errors"
 )
 
@@ -185,10 +186,11 @@ func (d *DynamoDBServer) AdminScanTable(ctx context.Context, principal AdminPrin
 //   - ErrAdminDynamoNotFound — table absent
 //   - ErrAdminDynamoValidation — empty / malformed input
 func (d *DynamoDBServer) AdminGetItem(ctx context.Context, principal AdminPrincipal, tableName string, key map[string]AdminAttributeValue) (*AdminItem, bool, error) {
-	schema, readTS, err := d.adminLoadReadableSchema(ctx, principal, tableName, len(key))
+	schema, readTS, readPin, err := d.adminLoadReadableSchema(ctx, principal, tableName, len(key))
 	if err != nil {
 		return nil, false, err
 	}
+	defer readPin.Release()
 	if err := validateAdminAttributeMapDepth(key); err != nil {
 		return nil, false, err
 	}
@@ -216,33 +218,42 @@ func (d *DynamoDBServer) AdminGetItem(ctx context.Context, principal AdminPrinci
 // adminLoadReadableSchema centralises the read-path preamble for
 // AdminGetItem: gate the principal, verify leader, validate the
 // table-name + non-empty key, load the schema, and refuse on
-// legacy-migration-needed tables. Returns the loaded schema + the
-// readTS the caller should reuse so the subsequent item read sees
-// the same MVCC snapshot. keyAttrs is len(key) so the helper can
-// short-circuit on an empty key.
-func (d *DynamoDBServer) adminLoadReadableSchema(ctx context.Context, principal AdminPrincipal, tableName string, keyAttrs int) (*dynamoTableSchema, uint64, error) {
+// legacy-migration-needed tables. Pins readTS via the read-tracker
+// so concurrent MVCC GC cannot advance minRetainedTS between the
+// schema load and the caller's subsequent item read at the same
+// readTS (Codex r6 P1 on PR #805; matches the SigV4 getItem path's
+// pinReadTS pattern at dynamodb.go:1386).
+//
+// On success the caller MUST defer readPin.Release(). On error the
+// helper releases the pin internally (if one was acquired) so the
+// caller never has to handle release on the error path.
+func (d *DynamoDBServer) adminLoadReadableSchema(ctx context.Context, principal AdminPrincipal, tableName string, keyAttrs int) (*dynamoTableSchema, uint64, *kv.ActiveTimestampToken, error) {
 	if !principal.Role.canRead() {
-		return nil, 0, ErrAdminForbidden
+		return nil, 0, nil, ErrAdminForbidden
 	}
 	if !isVerifiedDynamoLeader(ctx, d.coordinator) {
-		return nil, 0, ErrAdminNotLeader
+		return nil, 0, nil, ErrAdminNotLeader
 	}
 	if strings.TrimSpace(tableName) == "" || keyAttrs == 0 {
-		return nil, 0, ErrAdminDynamoValidation
+		return nil, 0, nil, ErrAdminDynamoValidation
 	}
 	readTS := d.nextTxnReadTS()
+	readPin := d.pinReadTS(readTS)
 	schema, exists, err := d.loadTableSchemaAt(ctx, tableName, readTS)
 	if err != nil {
-		return nil, 0, errors.WithStack(err)
+		readPin.Release()
+		return nil, 0, nil, errors.WithStack(err)
 	}
 	if !exists {
-		return nil, 0, ErrAdminDynamoNotFound
+		readPin.Release()
+		return nil, 0, nil, ErrAdminDynamoNotFound
 	}
 	if schema.needsLegacyKeyMigration() {
-		return nil, 0, errors.Wrap(ErrAdminDynamoValidation,
+		readPin.Release()
+		return nil, 0, nil, errors.Wrap(ErrAdminDynamoValidation,
 			"table requires a one-time legacy-key migration before admin read endpoints are available; migrate via the SigV4 surface first")
 	}
-	return schema, readTS, nil
+	return schema, readTS, readPin, nil
 }
 
 // AdminPutItem creates-or-replaces one item. Write role required.
@@ -486,6 +497,13 @@ func validateAdminAttributeMapKinds(in map[string]AdminAttributeValue) error {
 func checkAdminAttributeKind(v AdminAttributeValue) error {
 	if countAdminKindFields(v) != 1 {
 		return errors.Wrap(ErrAdminDynamoValidation, "attribute value must have exactly one kind field set")
+	}
+	// AWS-wire contract: NULL is a boolean kind tag whose value must
+	// be true; NULL=false is malformed (Codex r6 P2 on PR #805). The
+	// internal MarshalJSON would otherwise silently rewrite the input
+	// as NULL=true, hiding the caller bug.
+	if v.NULL != nil && !*v.NULL {
+		return errors.Wrap(ErrAdminDynamoValidation, "NULL attribute value must be true")
 	}
 	for _, e := range v.L {
 		if err := checkAdminAttributeKind(e); err != nil {

--- a/adapter/dynamodb_admin_items.go
+++ b/adapter/dynamodb_admin_items.go
@@ -14,6 +14,11 @@ import (
 // scalar types (S/N/B/BOOL/NULL), exactly one populated set
 // (SS/NS/BS), or a recursive container (L, M). Wire-compatible with
 // every AWS SDK and the existing SigV4 path's internal type.
+//
+// Marshal / Unmarshal delegate to the internal attributeValue's
+// AWS-wire-compatible codec (see MarshalJSON / UnmarshalJSON
+// below) so the JSON struct tags here are decorative; they're
+// kept as documentation of the wire shape.
 type AdminAttributeValue struct {
 	S    *string                        `json:"S,omitempty"`
 	N    *string                        `json:"N,omitempty"`
@@ -25,6 +30,38 @@ type AdminAttributeValue struct {
 	BS   [][]byte                       `json:"BS,omitempty"`
 	L    []AdminAttributeValue          `json:"L,omitempty"`
 	M    map[string]AdminAttributeValue `json:"M,omitempty"`
+}
+
+// MarshalJSON / UnmarshalJSON delegate to the internal
+// attributeValue's AWS-wire codec via the conversion functions.
+// This is the only way to:
+//
+//  1. preserve empty-but-present L/M ({"L": []} / {"M": {}}) on
+//     the wire — encoding/json's `omitempty` tag drops slices/maps
+//     of len 0 regardless of nil-ness (claude-bot r4 low on PR #805);
+//  2. enforce the AWS-wire "exactly one field set per
+//     AttributeValue" invariant — the internal MarshalJSON returns
+//     `invalid attribute value` for zero/multi-field inputs, which
+//     catches malformed Phase 3 HTTP handler output at the boundary
+//     rather than letting the SDK silently misinterpret a fall-back
+//     `"L": null` tag.
+//
+// Caller audit: the only consumer of AdminAttributeValue's wire
+// representation is the (not-yet-existing) Phase 3 admin HTTP
+// bridge. The new fail-closed marshal error path is a Phase 3
+// boundary contract — Phase 2a's Go-level callers never marshal.
+func (a AdminAttributeValue) MarshalJSON() ([]byte, error) {
+	internal := adminToInternalAttributeValue(a)
+	return internal.MarshalJSON()
+}
+
+func (a *AdminAttributeValue) UnmarshalJSON(data []byte) error {
+	var internal attributeValue
+	if err := internal.UnmarshalJSON(data); err != nil {
+		return err
+	}
+	*a = internalToAdminAttributeValue(internal)
+	return nil
 }
 
 // AdminItem is the admin-facing projection of one DynamoDB item.

--- a/adapter/dynamodb_admin_items.go
+++ b/adapter/dynamodb_admin_items.go
@@ -52,6 +52,22 @@ type AdminAttributeValue struct {
 // bridge. The new fail-closed marshal error path is a Phase 3
 // boundary contract — Phase 2a's Go-level callers never marshal.
 func (a AdminAttributeValue) MarshalJSON() ([]byte, error) {
+	// Validate depth + kind shape (exactly-one + NULL-must-be-true)
+	// before forwarding. Without the kind check,
+	// AdminAttributeValue{NULL:&false} would marshal as {"NULL": true}
+	// — the internal MarshalJSON detects the NULL kind by nil-ness
+	// and always emits true, silently rewriting the caller's input
+	// (Codex r7 P2 on PR #805). The depth check guards against
+	// stack overflow on a deeply-nested Go-constructed value: the
+	// four RPC entry points run validateAdminAttributeMapDepth
+	// first, but a direct json.Marshal call (e.g. a future admin
+	// response builder) does not get that protection by default.
+	if err := checkAdminAttributeDepth(a, 1); err != nil {
+		return nil, err
+	}
+	if err := checkAdminAttributeKind(a); err != nil {
+		return nil, err
+	}
 	internal := adminToInternalAttributeValue(a)
 	return internal.MarshalJSON()
 }

--- a/adapter/dynamodb_admin_items.go
+++ b/adapter/dynamodb_admin_items.go
@@ -1,0 +1,315 @@
+package adapter
+
+import (
+	"context"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// AdminAttributeValue mirrors the AWS DynamoDB-wire MessageAttribute
+// shape. Each instance carries exactly one populated field for
+// scalar types (S/N/B/BOOL/NULL), exactly one populated set
+// (SS/NS/BS), or a recursive container (L, M). Wire-compatible with
+// every AWS SDK and the existing SigV4 path's internal type.
+type AdminAttributeValue struct {
+	S    *string                        `json:"S,omitempty"`
+	N    *string                        `json:"N,omitempty"`
+	B    []byte                         `json:"B,omitempty"`
+	BOOL *bool                          `json:"BOOL,omitempty"`
+	NULL *bool                          `json:"NULL,omitempty"`
+	SS   []string                       `json:"SS,omitempty"`
+	NS   []string                       `json:"NS,omitempty"`
+	BS   [][]byte                       `json:"BS,omitempty"`
+	L    []AdminAttributeValue          `json:"L,omitempty"`
+	M    map[string]AdminAttributeValue `json:"M,omitempty"`
+}
+
+// AdminItem is the admin-facing projection of one DynamoDB item.
+type AdminItem struct {
+	Attributes map[string]AdminAttributeValue `json:"attributes"`
+}
+
+// AdminItemKey carries the primary key of a single item; SortKey is
+// nil for hash-only tables.
+type AdminItemKey struct {
+	PartitionKey AdminAttributeValue  `json:"partition_key"`
+	SortKey      *AdminAttributeValue `json:"sort_key,omitempty"`
+}
+
+// AdminScanResult is the admin-package projection of the underlying
+// scan output: the bounded items page plus a continuation key (nil
+// when the scan has drained for the current MVCC snapshot).
+type AdminScanResult struct {
+	Items            []AdminItem
+	LastEvaluatedKey map[string]AdminAttributeValue
+}
+
+// AdminScanOptions controls one AdminScanTable call. Defaults
+// match the design doc §3.1.1:
+//
+//	Limit = 25 (clamped to [1, adminItemScanMaxLimit=100])
+//	StartKey = nil (front of the table)
+type AdminScanOptions struct {
+	Limit          int
+	ExclusiveStart map[string]AdminAttributeValue
+}
+
+const (
+	adminItemScanDefaultLimit = 25
+	adminItemScanMaxLimit     = 100
+)
+
+// ErrAdminDynamoNotFound is the structured "item or table not
+// found" sentinel admin handlers match against to render 404. The
+// describe path uses (nil, false, nil) instead; this sentinel is
+// for write-path failures where the missing target is observed only
+// after the retry / commit attempt.
+var ErrAdminDynamoNotFound = errors.New("dynamodb admin: target not found")
+
+// ErrAdminDynamoValidation is returned when an admin entrypoint
+// receives a structurally-bad request (missing key, malformed
+// attribute, blank table name).
+var ErrAdminDynamoValidation = errors.New("dynamodb admin: invalid request")
+
+// AdminScanTable returns a bounded page of items. Read-only.
+//
+// Sentinels:
+//   - ErrAdminForbidden     — principal lacks read role
+//   - ErrAdminNotLeader     — follower
+//   - ErrAdminDynamoNotFound — table absent
+//   - ErrAdminDynamoValidation — empty / malformed input
+//
+// Scan-response budget: a single underlying scan may return a
+// LastEvaluatedKey before reaching Limit because of DynamoDB's
+// 1 MiB response cap. The admin RPC does NOT loop internally to
+// refill the page; partial pages are documented behaviour and the
+// caller treats any non-nil LastEvaluatedKey as "more available".
+func (d *DynamoDBServer) AdminScanTable(ctx context.Context, principal AdminPrincipal, tableName string, opts AdminScanOptions) (AdminScanResult, error) {
+	if !principal.Role.canRead() {
+		return AdminScanResult{}, ErrAdminForbidden
+	}
+	if !isVerifiedDynamoLeader(ctx, d.coordinator) {
+		return AdminScanResult{}, ErrAdminNotLeader
+	}
+	if strings.TrimSpace(tableName) == "" {
+		return AdminScanResult{}, ErrAdminDynamoValidation
+	}
+	limit := clampAdminScanLimit(opts.Limit)
+	scanInput := scanInput{
+		TableName:         tableName,
+		ExclusiveStartKey: adminToInternalAttributeMap(opts.ExclusiveStart),
+		Limit:             &limit,
+	}
+	out, err := d.scanItems(ctx, scanInput)
+	if err != nil {
+		return AdminScanResult{}, translateDynamoAdminError(err)
+	}
+	return AdminScanResult{
+		Items:            adminItemsFromInternal(out.items),
+		LastEvaluatedKey: internalToAdminAttributeMap(out.lastEvaluatedKey),
+	}, nil
+}
+
+// AdminGetItem fetches one item by primary key. Returns
+// (nil, false, nil) when the item is absent (not an error).
+//
+// Sentinels:
+//   - ErrAdminForbidden     — principal lacks read role
+//   - ErrAdminNotLeader     — follower
+//   - ErrAdminDynamoNotFound — table absent
+//   - ErrAdminDynamoValidation — empty / malformed input
+func (d *DynamoDBServer) AdminGetItem(ctx context.Context, principal AdminPrincipal, tableName string, key map[string]AdminAttributeValue) (*AdminItem, bool, error) {
+	if !principal.Role.canRead() {
+		return nil, false, ErrAdminForbidden
+	}
+	if !isVerifiedDynamoLeader(ctx, d.coordinator) {
+		return nil, false, ErrAdminNotLeader
+	}
+	if strings.TrimSpace(tableName) == "" {
+		return nil, false, ErrAdminDynamoValidation
+	}
+	if len(key) == 0 {
+		return nil, false, ErrAdminDynamoValidation
+	}
+	readTS := d.nextTxnReadTS()
+	schema, exists, err := d.loadTableSchemaAt(ctx, tableName, readTS)
+	if err != nil {
+		return nil, false, errors.WithStack(err)
+	}
+	if !exists {
+		return nil, false, ErrAdminDynamoNotFound
+	}
+	internalKey := adminToInternalAttributeMap(key)
+	current, found, err := d.readLogicalItemAt(ctx, schema, internalKey, readTS)
+	if err != nil {
+		return nil, false, translateDynamoAdminError(err)
+	}
+	if !found {
+		return nil, false, nil
+	}
+	return &AdminItem{Attributes: internalToAdminAttributeMap(current.item)}, true, nil
+}
+
+// AdminPutItem creates-or-replaces one item. Write role required.
+//
+// Sentinels:
+//   - ErrAdminForbidden        — principal lacks write role
+//   - ErrAdminNotLeader        — follower
+//   - ErrAdminDynamoNotFound   — table absent
+//   - ErrAdminDynamoValidation — empty / malformed input
+func (d *DynamoDBServer) AdminPutItem(ctx context.Context, principal AdminPrincipal, tableName string, item AdminItem) error {
+	if !principal.Role.canWrite() {
+		return ErrAdminForbidden
+	}
+	if !isVerifiedDynamoLeader(ctx, d.coordinator) {
+		return ErrAdminNotLeader
+	}
+	if strings.TrimSpace(tableName) == "" {
+		return ErrAdminDynamoValidation
+	}
+	if len(item.Attributes) == 0 {
+		return ErrAdminDynamoValidation
+	}
+	in := putItemInput{
+		TableName: tableName,
+		Item:      adminToInternalAttributeMap(item.Attributes),
+	}
+	if _, err := d.putItemWithRetry(ctx, in); err != nil {
+		return translateDynamoAdminError(err)
+	}
+	return nil
+}
+
+// AdminDeleteItem removes one item by primary key. Write role
+// required.
+func (d *DynamoDBServer) AdminDeleteItem(ctx context.Context, principal AdminPrincipal, tableName string, key map[string]AdminAttributeValue) error {
+	if !principal.Role.canWrite() {
+		return ErrAdminForbidden
+	}
+	if !isVerifiedDynamoLeader(ctx, d.coordinator) {
+		return ErrAdminNotLeader
+	}
+	if strings.TrimSpace(tableName) == "" {
+		return ErrAdminDynamoValidation
+	}
+	if len(key) == 0 {
+		return ErrAdminDynamoValidation
+	}
+	in := deleteItemInput{
+		TableName: tableName,
+		Key:       adminToInternalAttributeMap(key),
+	}
+	if _, err := d.deleteItemWithRetry(ctx, in); err != nil {
+		return translateDynamoAdminError(err)
+	}
+	return nil
+}
+
+// clampAdminScanLimit folds the user-supplied Limit into the legal
+// [1, adminItemScanMaxLimit] range, mapping 0 to the default 25.
+func clampAdminScanLimit(limit int) int32 {
+	if limit <= 0 {
+		return adminItemScanDefaultLimit
+	}
+	if limit > adminItemScanMaxLimit {
+		return adminItemScanMaxLimit
+	}
+	return int32(limit)
+}
+
+// translateDynamoAdminError maps the adapter's existing *dynamoAPIError
+// vocabulary onto the admin sentinels. Anything we cannot match is
+// forwarded as-is and the admin handler will render it as a generic
+// 500 with a sanitized body.
+func translateDynamoAdminError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case adminAPIErrorTypeIs(err, dynamoErrResourceNotFound):
+		return ErrAdminDynamoNotFound
+	case adminAPIErrorTypeIs(err, dynamoErrValidation):
+		return errors.Wrap(ErrAdminDynamoValidation, AdminErrorMessage(err))
+	default:
+		return errors.WithStack(err)
+	}
+}
+
+// adminItemsFromInternal converts a slice of internal item rows
+// (the scanItems output) into the admin-facing AdminItem slice. Nil
+// in, nil out so callers see the contract directly.
+func adminItemsFromInternal(items []map[string]attributeValue) []AdminItem {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]AdminItem, len(items))
+	for i, item := range items {
+		out[i] = AdminItem{Attributes: internalToAdminAttributeMap(item)}
+	}
+	return out
+}
+
+// internalToAdminAttributeMap converts the unexported wire type
+// into the exported one. Both share identical JSON tags so the
+// conversion is a per-field copy with recursive descent for L/M.
+func internalToAdminAttributeMap(in map[string]attributeValue) map[string]AdminAttributeValue {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]AdminAttributeValue, len(in))
+	for k, v := range in {
+		out[k] = internalToAdminAttributeValue(v)
+	}
+	return out
+}
+
+func adminToInternalAttributeMap(in map[string]AdminAttributeValue) map[string]attributeValue {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]attributeValue, len(in))
+	for k, v := range in {
+		out[k] = adminToInternalAttributeValue(v)
+	}
+	return out
+}
+
+func internalToAdminAttributeValue(v attributeValue) AdminAttributeValue {
+	out := AdminAttributeValue{
+		S: v.S, N: v.N, B: v.B, BOOL: v.BOOL, NULL: v.NULL,
+		SS: v.SS, NS: v.NS, BS: v.BS,
+	}
+	if len(v.L) > 0 {
+		out.L = make([]AdminAttributeValue, len(v.L))
+		for i, e := range v.L {
+			out.L[i] = internalToAdminAttributeValue(e)
+		}
+	}
+	if len(v.M) > 0 {
+		out.M = make(map[string]AdminAttributeValue, len(v.M))
+		for k, e := range v.M {
+			out.M[k] = internalToAdminAttributeValue(e)
+		}
+	}
+	return out
+}
+
+func adminToInternalAttributeValue(v AdminAttributeValue) attributeValue {
+	out := attributeValue{
+		S: v.S, N: v.N, B: v.B, BOOL: v.BOOL, NULL: v.NULL,
+		SS: v.SS, NS: v.NS, BS: v.BS,
+	}
+	if len(v.L) > 0 {
+		out.L = make([]attributeValue, len(v.L))
+		for i, e := range v.L {
+			out.L[i] = adminToInternalAttributeValue(e)
+		}
+	}
+	if len(v.M) > 0 {
+		out.M = make(map[string]attributeValue, len(v.M))
+		for k, e := range v.M {
+			out.M[k] = adminToInternalAttributeValue(e)
+		}
+	}
+	return out
+}

--- a/adapter/dynamodb_admin_items.go
+++ b/adapter/dynamodb_admin_items.go
@@ -123,6 +123,30 @@ const (
 // after the retry / commit attempt.
 var ErrAdminDynamoNotFound = errors.New("dynamodb admin: target not found")
 
+// adminReadOnlyContextKeyType is the unexported tag type used to
+// stash a "this request is read-only admin; never trigger writes"
+// flag on the context. ensureLegacyTableMigration honours it by
+// returning ErrAdminDynamoValidation instead of triggering a
+// migration write (Codex r8 P2 on PR #805 closed the TOCTOU race
+// where the admin entry-point legacy check could miss a migration
+// that started after the check but before scanItems reached the
+// migration trigger).
+type adminReadOnlyContextKeyType struct{}
+
+var adminReadOnlyContextKey = adminReadOnlyContextKeyType{}
+
+func withAdminReadOnlyContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, adminReadOnlyContextKey, true)
+}
+
+func isAdminReadOnlyContext(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	v, _ := ctx.Value(adminReadOnlyContextKey).(bool)
+	return v
+}
+
 // ErrAdminDynamoValidation is returned when an admin entrypoint
 // receives a structurally-bad request (missing key, malformed
 // attribute, blank table name).
@@ -183,7 +207,16 @@ func (d *DynamoDBServer) AdminScanTable(ctx context.Context, principal AdminPrin
 		ExclusiveStartKey: adminToInternalAttributeMap(opts.ExclusiveStart),
 		Limit:             &limit,
 	}
-	out, err := d.scanItems(ctx, scanInput)
+	// Tag context as read-only so scanItems' internal
+	// prepareReadSchema → ensureLegacyTableMigration call refuses
+	// to trigger Raft writes if the schema transitioned to
+	// needs-migration between the entry-point check above and the
+	// migration-trigger code path (Codex r8 P2 on PR #805). The
+	// earlier needsLegacyKeyMigration check stays as the fast
+	// happy-path rejection; this context tag closes the TOCTOU
+	// window where concurrent migration start could otherwise
+	// race an admin scan into the write path.
+	out, err := d.scanItems(withAdminReadOnlyContext(ctx), scanInput)
 	if err != nil {
 		return AdminScanResult{}, translateDynamoAdminError(err)
 	}

--- a/adapter/dynamodb_admin_items.go
+++ b/adapter/dynamodb_admin_items.go
@@ -341,13 +341,18 @@ func internalToAdminAttributeValue(v attributeValue) AdminAttributeValue {
 		S: v.S, N: v.N, B: bytes.Clone(v.B), BOOL: v.BOOL, NULL: v.NULL,
 		SS: slices.Clone(v.SS), NS: slices.Clone(v.NS), BS: cloneBinarySet(v.BS),
 	}
-	if len(v.L) > 0 {
+	// L and M use != nil gates (not len > 0) so empty-but-present
+	// containers ({"L": []} / {"M": {}}) round-trip. attributeValue's
+	// kind detection (hasListType / hasMapType in dynamodb_types.go)
+	// also tests != nil, so a len>0 gate would silently drop a valid
+	// AWS-wire empty list / empty map (Codex r3 P1 on PR #805).
+	if v.L != nil {
 		out.L = make([]AdminAttributeValue, len(v.L))
 		for i, e := range v.L {
 			out.L[i] = internalToAdminAttributeValue(e)
 		}
 	}
-	if len(v.M) > 0 {
+	if v.M != nil {
 		out.M = make(map[string]AdminAttributeValue, len(v.M))
 		for k, e := range v.M {
 			out.M[k] = internalToAdminAttributeValue(e)
@@ -361,13 +366,13 @@ func adminToInternalAttributeValue(v AdminAttributeValue) attributeValue {
 		S: v.S, N: v.N, B: bytes.Clone(v.B), BOOL: v.BOOL, NULL: v.NULL,
 		SS: slices.Clone(v.SS), NS: slices.Clone(v.NS), BS: cloneBinarySet(v.BS),
 	}
-	if len(v.L) > 0 {
+	if v.L != nil {
 		out.L = make([]attributeValue, len(v.L))
 		for i, e := range v.L {
 			out.L[i] = adminToInternalAttributeValue(e)
 		}
 	}
-	if len(v.M) > 0 {
+	if v.M != nil {
 		out.M = make(map[string]attributeValue, len(v.M))
 		for k, e := range v.M {
 			out.M[k] = adminToInternalAttributeValue(e)

--- a/adapter/dynamodb_admin_items_test.go
+++ b/adapter/dynamodb_admin_items_test.go
@@ -554,3 +554,34 @@ func TestDynamoDB_AdminPutItem_RejectsMultiFieldAttribute(t *testing.T) {
 	require.True(t, errors.Is(err, ErrAdminDynamoValidation),
 		"want ErrAdminDynamoValidation for multi-kind attribute; got %v", err)
 }
+
+// TestDynamoDB_AdminPutItem_RejectsNullFalse pins Codex r6 P2:
+// NULL is a boolean kind tag whose value must be true per the
+// AWS wire contract. A caller passing NULL=&false would otherwise
+// silently get its input rewritten to NULL=true by the internal
+// MarshalJSON, masking the caller bug.
+func TestDynamoDB_AdminPutItem_RejectsNullFalse(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	srv := nodes[0].dynamoServer
+	createTableForItemTests(t, srv, "nullfalse")
+
+	falseVal := false
+	err := srv.AdminPutItem(context.Background(), fullAdminPrincipal, "nullfalse",
+		AdminItem{Attributes: map[string]AdminAttributeValue{
+			"id":  stringAttr("k"),
+			"bad": {NULL: &falseVal},
+		}})
+	require.True(t, errors.Is(err, ErrAdminDynamoValidation),
+		"want ErrAdminDynamoValidation for NULL=false; got %v", err)
+
+	// Sanity: NULL=true is valid and round-trips.
+	trueVal := true
+	err = srv.AdminPutItem(context.Background(), fullAdminPrincipal, "nullfalse",
+		AdminItem{Attributes: map[string]AdminAttributeValue{
+			"id":   stringAttr("k"),
+			"good": {NULL: &trueVal},
+		}})
+	require.NoError(t, err, "NULL=true must be accepted")
+}

--- a/adapter/dynamodb_admin_items_test.go
+++ b/adapter/dynamodb_admin_items_test.go
@@ -424,3 +424,35 @@ func TestAdminAttributeValue_DeepCopyIsolation(t *testing.T) {
 	require.Equal(t, "a", roundTrip.SS[0], "SS must be deep-copied on internal→admin")
 	require.Equal(t, byte(0x10), roundTrip.BS[0][0], "BS must be deep-copied on internal→admin")
 }
+
+// TestAdminAttributeValue_EmptyContainersRoundTrip pins Codex r3
+// P1 on PR #805: an empty-but-present L or M ({"L": []} / {"M": {}})
+// is a legitimate AWS-wire attribute value and must round-trip
+// without being dropped. attributeValue.hasListType / hasMapType
+// detect presence via != nil, so a len>0 gate in the conversion
+// would silently drop these.
+func TestAdminAttributeValue_EmptyContainersRoundTrip(t *testing.T) {
+	t.Parallel()
+	emptyL := AdminAttributeValue{L: []AdminAttributeValue{}}
+	emptyM := AdminAttributeValue{M: map[string]AdminAttributeValue{}}
+
+	// admin → internal → admin
+	gotL := internalToAdminAttributeValue(adminToInternalAttributeValue(emptyL))
+	require.NotNil(t, gotL.L, "empty L must round-trip as non-nil (got nil = silently dropped)")
+	require.Len(t, gotL.L, 0)
+	require.Nil(t, gotL.M)
+
+	gotM := internalToAdminAttributeValue(adminToInternalAttributeValue(emptyM))
+	require.NotNil(t, gotM.M, "empty M must round-trip as non-nil (got nil = silently dropped)")
+	require.Len(t, gotM.M, 0)
+	require.Nil(t, gotM.L)
+
+	// Same on the internal kind-detection contract: the converted
+	// attributeValue must satisfy hasListType / hasMapType so OCC
+	// validation and other downstream readers see the empty
+	// container, not a missing field.
+	internalL := adminToInternalAttributeValue(emptyL)
+	require.True(t, internalL.hasListType(), "internal L must be hasListType()=true after round-trip from empty admin L")
+	internalM := adminToInternalAttributeValue(emptyM)
+	require.True(t, internalM.hasMapType(), "internal M must be hasMapType()=true after round-trip from empty admin M")
+}

--- a/adapter/dynamodb_admin_items_test.go
+++ b/adapter/dynamodb_admin_items_test.go
@@ -280,6 +280,70 @@ func TestClampAdminScanLimit(t *testing.T) {
 	}
 }
 
+// TestDynamoDB_AdminScanTable_EmptyTableReturnsEmptySlice pins
+// Claude r1 low: a freshly-created empty table must surface as
+// "items": [] on the wire (not "items": null) so the SPA's
+// items.map() call does not crash.
+func TestDynamoDB_AdminScanTable_EmptyTableReturnsEmptySlice(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	srv := nodes[0].dynamoServer
+	createTableForItemTests(t, srv, "empty")
+
+	res, err := srv.AdminScanTable(context.Background(), fullAdminPrincipal, "empty", AdminScanOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, res.Items, "empty-table scan must return [] not nil so JSON emits [] not null")
+	require.Len(t, res.Items, 0)
+}
+
+// TestDynamoDB_AdminPutItem_MissingTable confirms the write path
+// surfaces ErrAdminDynamoNotFound — the test was missing in r1
+// (Claude bot finding 3).
+func TestDynamoDB_AdminPutItem_MissingTable(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	srv := nodes[0].dynamoServer
+
+	err := srv.AdminPutItem(context.Background(), fullAdminPrincipal, "ghost",
+		AdminItem{Attributes: map[string]AdminAttributeValue{"id": stringAttr("x")}})
+	require.True(t, errors.Is(err, ErrAdminDynamoNotFound),
+		"want ErrAdminDynamoNotFound; got %v", err)
+}
+
+// TestDynamoDB_AdminDeleteItem_MissingTable mirrors the put-side test.
+func TestDynamoDB_AdminDeleteItem_MissingTable(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	srv := nodes[0].dynamoServer
+
+	err := srv.AdminDeleteItem(context.Background(), fullAdminPrincipal, "ghost",
+		map[string]AdminAttributeValue{"id": stringAttr("x")})
+	require.True(t, errors.Is(err, ErrAdminDynamoNotFound),
+		"want ErrAdminDynamoNotFound; got %v", err)
+}
+
+// TestDynamoDB_AdminGetItem_MalformedKey pins Codex r1 P2: a key
+// that fails schema validation (e.g. wrong attribute name) must
+// surface as ErrAdminDynamoValidation rather than an opaque error
+// the admin handler would render as 500.
+func TestDynamoDB_AdminGetItem_MalformedKey(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	srv := nodes[0].dynamoServer
+	ctx := context.Background()
+	createTableForItemTests(t, srv, "malformed")
+
+	// Wrong attribute name: schema expects "id" (string), but we pass "wrongkey".
+	_, _, err := srv.AdminGetItem(ctx, fullAdminPrincipal, "malformed",
+		map[string]AdminAttributeValue{"wrongkey": stringAttr("x")})
+	require.True(t, errors.Is(err, ErrAdminDynamoValidation),
+		"want ErrAdminDynamoValidation for wrong key shape; got %v", err)
+}
+
 // TestAdminAttributeValue_NestedRoundTrip pins the recursive L / M
 // conversion: a deeply nested admin value round-trips through the
 // internal type without losing any field.

--- a/adapter/dynamodb_admin_items_test.go
+++ b/adapter/dynamodb_admin_items_test.go
@@ -510,6 +510,20 @@ func TestAdminAttributeValue_JSONMarshalRejectsMultiField(t *testing.T) {
 	n := "1"
 	_, err = json.Marshal(AdminAttributeValue{S: &s, N: &n})
 	require.Error(t, err, "multi-field AdminAttributeValue must fail to marshal")
+
+	// NULL=false at the marshal boundary → ErrAdminDynamoValidation
+	// (Codex r7 P2): without the marshal-side guard, internal's
+	// MarshalJSON would silently rewrite NULL=&false as {"NULL":true}.
+	falseVal := false
+	_, err = json.Marshal(AdminAttributeValue{NULL: &falseVal})
+	require.True(t, errors.Is(err, ErrAdminDynamoValidation),
+		"NULL=false must surface as ErrAdminDynamoValidation from MarshalJSON; got %v", err)
+
+	// NULL=true (valid) round-trips through MarshalJSON.
+	trueVal := true
+	out, err := json.Marshal(AdminAttributeValue{NULL: &trueVal})
+	require.NoError(t, err, "NULL=true must marshal")
+	require.JSONEq(t, `{"NULL": true}`, string(out))
 }
 
 // TestDynamoDB_AdminPutItem_RejectsZeroFieldAttribute pins Codex

--- a/adapter/dynamodb_admin_items_test.go
+++ b/adapter/dynamodb_admin_items_test.go
@@ -511,3 +511,46 @@ func TestAdminAttributeValue_JSONMarshalRejectsMultiField(t *testing.T) {
 	_, err = json.Marshal(AdminAttributeValue{S: &s, N: &n})
 	require.Error(t, err, "multi-field AdminAttributeValue must fail to marshal")
 }
+
+// TestDynamoDB_AdminPutItem_RejectsZeroFieldAttribute pins Codex
+// r5 P2 on PR #805: a Go-level AdminPutItem caller can construct
+// an AdminAttributeValue with zero kind fields (bypassing the
+// JSON-boundary MarshalJSON check). Without validateAdminAttributeMapKinds
+// the malformed value reaches putItemWithRetry and surfaces as a
+// non-dynamoErrValidation error → 500 instead of the documented
+// 400 contract.
+func TestDynamoDB_AdminPutItem_RejectsZeroFieldAttribute(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	srv := nodes[0].dynamoServer
+	createTableForItemTests(t, srv, "zerokind")
+
+	err := srv.AdminPutItem(context.Background(), fullAdminPrincipal, "zerokind",
+		AdminItem{Attributes: map[string]AdminAttributeValue{
+			"id":    stringAttr("k"),
+			"empty": {}, // no kind field set
+		}})
+	require.True(t, errors.Is(err, ErrAdminDynamoValidation),
+		"want ErrAdminDynamoValidation for zero-kind attribute; got %v", err)
+}
+
+// TestDynamoDB_AdminPutItem_RejectsMultiFieldAttribute is the
+// multi-field counterpart of the zero-field test.
+func TestDynamoDB_AdminPutItem_RejectsMultiFieldAttribute(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	srv := nodes[0].dynamoServer
+	createTableForItemTests(t, srv, "multikind")
+
+	s := "x"
+	n := "1"
+	err := srv.AdminPutItem(context.Background(), fullAdminPrincipal, "multikind",
+		AdminItem{Attributes: map[string]AdminAttributeValue{
+			"id":  stringAttr("k"),
+			"bad": {S: &s, N: &n},
+		}})
+	require.True(t, errors.Is(err, ErrAdminDynamoValidation),
+		"want ErrAdminDynamoValidation for multi-kind attribute; got %v", err)
+}

--- a/adapter/dynamodb_admin_items_test.go
+++ b/adapter/dynamodb_admin_items_test.go
@@ -1,0 +1,303 @@
+package adapter
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// stringAttr / numberAttr / boolAttr build admin attribute values
+// inline so tests stay legible. The pointer-to-string / pointer-to-bool
+// pattern matches the underlying wire shape.
+func stringAttr(s string) AdminAttributeValue {
+	return AdminAttributeValue{S: &s}
+}
+
+func numberAttr(n int) AdminAttributeValue {
+	s := strconv.Itoa(n)
+	return AdminAttributeValue{N: &s}
+}
+
+func boolAttr(b bool) AdminAttributeValue {
+	return AdminAttributeValue{BOOL: &b}
+}
+
+// createTableForItemTests sets up a hash-only table named "items"
+// with an "id" partition key so the per-test setup stays one line.
+func createTableForItemTests(t *testing.T, srv *DynamoDBServer, name string) {
+	t.Helper()
+	_, err := srv.AdminCreateTable(context.Background(), fullAdminPrincipal, AdminCreateTableInput{
+		TableName:    name,
+		PartitionKey: AdminAttribute{Name: "id", Type: "S"},
+	})
+	require.NoError(t, err)
+}
+
+// TestDynamoDB_AdminPutItem_HappyPath pins the basic write contract:
+// PutItem followed by GetItem returns the stored attributes.
+func TestDynamoDB_AdminPutItem_HappyPath(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	srv := nodes[0].dynamoServer
+	ctx := context.Background()
+	createTableForItemTests(t, srv, "puttable")
+
+	item := AdminItem{Attributes: map[string]AdminAttributeValue{
+		"id":     stringAttr("alpha"),
+		"name":   stringAttr("Alice"),
+		"active": boolAttr(true),
+		"age":    numberAttr(42),
+	}}
+	require.NoError(t, srv.AdminPutItem(ctx, fullAdminPrincipal, "puttable", item))
+
+	got, exists, err := srv.AdminGetItem(ctx, fullAdminPrincipal, "puttable", map[string]AdminAttributeValue{"id": stringAttr("alpha")})
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Equal(t, "Alice", *got.Attributes["name"].S)
+	require.True(t, *got.Attributes["active"].BOOL)
+	require.Equal(t, "42", *got.Attributes["age"].N)
+}
+
+// TestDynamoDB_AdminGetItem_Missing returns (nil, false, nil) — not
+// an error — so the admin handler can render 404 without sniffing
+// sentinels.
+func TestDynamoDB_AdminGetItem_Missing(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	srv := nodes[0].dynamoServer
+	createTableForItemTests(t, srv, "absent")
+
+	got, exists, err := srv.AdminGetItem(context.Background(), fullAdminPrincipal, "absent", map[string]AdminAttributeValue{"id": stringAttr("no-such")})
+	require.NoError(t, err)
+	require.False(t, exists)
+	require.Nil(t, got)
+}
+
+// TestDynamoDB_AdminGetItem_MissingTable surfaces the structured
+// ErrAdminDynamoNotFound sentinel rather than a generic 500.
+func TestDynamoDB_AdminGetItem_MissingTable(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+
+	_, _, err := nodes[0].dynamoServer.AdminGetItem(context.Background(), fullAdminPrincipal, "nope", map[string]AdminAttributeValue{"id": stringAttr("k")})
+	require.True(t, errors.Is(err, ErrAdminDynamoNotFound))
+}
+
+// TestDynamoDB_AdminDeleteItem_HappyPath confirms a delete makes
+// the subsequent get return (nil, false, nil).
+func TestDynamoDB_AdminDeleteItem_HappyPath(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	srv := nodes[0].dynamoServer
+	ctx := context.Background()
+	createTableForItemTests(t, srv, "deltable")
+
+	key := map[string]AdminAttributeValue{"id": stringAttr("k1")}
+	require.NoError(t, srv.AdminPutItem(ctx, fullAdminPrincipal, "deltable", AdminItem{Attributes: key}))
+	require.NoError(t, srv.AdminDeleteItem(ctx, fullAdminPrincipal, "deltable", key))
+
+	_, exists, err := srv.AdminGetItem(ctx, fullAdminPrincipal, "deltable", key)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+// TestDynamoDB_AdminScanTable_HappyPath puts three items and
+// confirms scan returns all three. Order is not asserted (scan
+// order is not part of the contract).
+func TestDynamoDB_AdminScanTable_HappyPath(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	srv := nodes[0].dynamoServer
+	ctx := context.Background()
+	createTableForItemTests(t, srv, "scantable")
+
+	for _, id := range []string{"a", "b", "c"} {
+		require.NoError(t, srv.AdminPutItem(ctx, fullAdminPrincipal, "scantable",
+			AdminItem{Attributes: map[string]AdminAttributeValue{"id": stringAttr(id)}}))
+	}
+
+	res, err := srv.AdminScanTable(ctx, fullAdminPrincipal, "scantable", AdminScanOptions{})
+	require.NoError(t, err)
+	require.Len(t, res.Items, 3)
+	seen := map[string]bool{}
+	for _, it := range res.Items {
+		require.NotNil(t, it.Attributes["id"].S)
+		seen[*it.Attributes["id"].S] = true
+	}
+	require.True(t, seen["a"] && seen["b"] && seen["c"], "scan did not surface all 3 ids: %v", seen)
+}
+
+// TestDynamoDB_AdminScanTable_LimitClamping pins the [1, 100] clamp
+// + default-on-zero behaviour. The default (25) is exercised
+// implicitly by the happy-path test above; here we focus on the
+// over-cap branch.
+func TestDynamoDB_AdminScanTable_LimitClamping(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	srv := nodes[0].dynamoServer
+	ctx := context.Background()
+	createTableForItemTests(t, srv, "limittable")
+
+	for i := range 5 {
+		require.NoError(t, srv.AdminPutItem(ctx, fullAdminPrincipal, "limittable",
+			AdminItem{Attributes: map[string]AdminAttributeValue{"id": stringAttr("row-" + strconv.Itoa(i))}}))
+	}
+
+	// Limit=2 — under the cap, exact match.
+	res, err := srv.AdminScanTable(ctx, fullAdminPrincipal, "limittable", AdminScanOptions{Limit: 2})
+	require.NoError(t, err)
+	require.Len(t, res.Items, 2)
+	require.NotNil(t, res.LastEvaluatedKey, "Limit < total: must return continuation key")
+
+	// Limit=500 — clamped down to 100 (well above the 5 items in the table).
+	res, err = srv.AdminScanTable(ctx, fullAdminPrincipal, "limittable", AdminScanOptions{Limit: 500})
+	require.NoError(t, err)
+	require.Len(t, res.Items, 5)
+}
+
+// TestDynamoDB_AdminScanTable_CursorRoundTrip drains the table
+// across two pages and confirms the union covers every item
+// exactly once.
+func TestDynamoDB_AdminScanTable_CursorRoundTrip(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	srv := nodes[0].dynamoServer
+	ctx := context.Background()
+	createTableForItemTests(t, srv, "cursortable")
+
+	const sent = 7
+	for i := range sent {
+		require.NoError(t, srv.AdminPutItem(ctx, fullAdminPrincipal, "cursortable",
+			AdminItem{Attributes: map[string]AdminAttributeValue{"id": stringAttr("k" + strconv.Itoa(i))}}))
+	}
+
+	pageA, err := srv.AdminScanTable(ctx, fullAdminPrincipal, "cursortable", AdminScanOptions{Limit: 3})
+	require.NoError(t, err)
+	require.Len(t, pageA.Items, 3)
+	require.NotNil(t, pageA.LastEvaluatedKey)
+
+	pageB, err := srv.AdminScanTable(ctx, fullAdminPrincipal, "cursortable", AdminScanOptions{Limit: 10, ExclusiveStart: pageA.LastEvaluatedKey})
+	require.NoError(t, err)
+	require.Len(t, pageB.Items, sent-3)
+	require.Nil(t, pageB.LastEvaluatedKey, "second page drains the table")
+
+	seen := map[string]bool{}
+	for _, it := range append(pageA.Items, pageB.Items...) {
+		require.NotNil(t, it.Attributes["id"].S)
+		seen[*it.Attributes["id"].S] = true
+	}
+	require.Len(t, seen, sent)
+}
+
+// TestDynamoDB_AdminPutItem_ReadOnlyForbidden pins the write gate.
+func TestDynamoDB_AdminPutItem_ReadOnlyForbidden(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	srv := nodes[0].dynamoServer
+	createTableForItemTests(t, srv, "rotable")
+
+	err := srv.AdminPutItem(context.Background(), readOnlyAdminPrincipal, "rotable",
+		AdminItem{Attributes: map[string]AdminAttributeValue{"id": stringAttr("x")}})
+	require.True(t, errors.Is(err, ErrAdminForbidden))
+}
+
+// TestDynamoDB_AdminDeleteItem_ReadOnlyForbidden mirrors the put-side gate.
+func TestDynamoDB_AdminDeleteItem_ReadOnlyForbidden(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	srv := nodes[0].dynamoServer
+	createTableForItemTests(t, srv, "rodel")
+
+	err := srv.AdminDeleteItem(context.Background(), readOnlyAdminPrincipal, "rodel",
+		map[string]AdminAttributeValue{"id": stringAttr("x")})
+	require.True(t, errors.Is(err, ErrAdminForbidden))
+}
+
+// TestDynamoDB_AdminScanTable_NoRoleForbidden pins the lower-bound
+// gate (zero-value AdminPrincipal denied even for read).
+func TestDynamoDB_AdminScanTable_NoRoleForbidden(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	srv := nodes[0].dynamoServer
+	createTableForItemTests(t, srv, "noauth")
+
+	_, err := srv.AdminScanTable(context.Background(), AdminPrincipal{}, "noauth", AdminScanOptions{})
+	require.True(t, errors.Is(err, ErrAdminForbidden))
+}
+
+// TestDynamoDB_AdminPutItem_EmptyTableName pins the up-front
+// validation guard.
+func TestDynamoDB_AdminPutItem_EmptyTableName(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	srv := nodes[0].dynamoServer
+
+	err := srv.AdminPutItem(context.Background(), fullAdminPrincipal, "  ",
+		AdminItem{Attributes: map[string]AdminAttributeValue{"id": stringAttr("x")}})
+	require.True(t, errors.Is(err, ErrAdminDynamoValidation))
+}
+
+// TestDynamoDB_AdminGetItem_EmptyKey pins the up-front validation guard.
+func TestDynamoDB_AdminGetItem_EmptyKey(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	srv := nodes[0].dynamoServer
+	createTableForItemTests(t, srv, "emptykey")
+
+	_, _, err := srv.AdminGetItem(context.Background(), fullAdminPrincipal, "emptykey", nil)
+	require.True(t, errors.Is(err, ErrAdminDynamoValidation))
+}
+
+// TestClampAdminScanLimit pins the truth table directly.
+func TestClampAdminScanLimit(t *testing.T) {
+	t.Parallel()
+	cases := map[int]int32{
+		0:                         adminItemScanDefaultLimit,
+		-5:                        adminItemScanDefaultLimit,
+		1:                         1,
+		adminItemScanDefaultLimit: adminItemScanDefaultLimit,
+		adminItemScanMaxLimit:     adminItemScanMaxLimit,
+		adminItemScanMaxLimit + 1: adminItemScanMaxLimit,
+		1_000_000:                 adminItemScanMaxLimit,
+	}
+	for in, want := range cases {
+		require.Equalf(t, want, clampAdminScanLimit(in), "clampAdminScanLimit(%d)", in)
+	}
+}
+
+// TestAdminAttributeValue_NestedRoundTrip pins the recursive L / M
+// conversion: a deeply nested admin value round-trips through the
+// internal type without losing any field.
+func TestAdminAttributeValue_NestedRoundTrip(t *testing.T) {
+	t.Parallel()
+	s := "inner"
+	in := AdminAttributeValue{
+		M: map[string]AdminAttributeValue{
+			"list": {L: []AdminAttributeValue{
+				{S: &s},
+				{N: func() *string { v := "7"; return &v }()},
+				{M: map[string]AdminAttributeValue{"nested": {BOOL: func() *bool { b := true; return &b }()}}},
+			}},
+		},
+	}
+	internal := adminToInternalAttributeValue(in)
+	roundTripped := internalToAdminAttributeValue(internal)
+	require.Equal(t, "inner", *roundTripped.M["list"].L[0].S)
+	require.Equal(t, "7", *roundTripped.M["list"].L[1].N)
+	require.True(t, *roundTripped.M["list"].L[2].M["nested"].BOOL)
+}

--- a/adapter/dynamodb_admin_items_test.go
+++ b/adapter/dynamodb_admin_items_test.go
@@ -365,3 +365,62 @@ func TestAdminAttributeValue_NestedRoundTrip(t *testing.T) {
 	require.Equal(t, "7", *roundTripped.M["list"].L[1].N)
 	require.True(t, *roundTripped.M["list"].L[2].M["nested"].BOOL)
 }
+
+// TestDynamoDB_AdminPutItem_RejectsDeepNesting pins gemini r1
+// security-high: an admin-supplied AdminAttributeValue nested
+// deeper than maxAttributeValueNestingDepth (32) is rejected with
+// ErrAdminDynamoValidation before reaching the wire codec, so a
+// pathological JSON payload cannot exhaust resources.
+func TestDynamoDB_AdminPutItem_RejectsDeepNesting(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	srv := nodes[0].dynamoServer
+	createTableForItemTests(t, srv, "deep")
+
+	// Build a list nested one level deeper than the cap so the depth
+	// walker trips on the boundary attribute, not a side-effect.
+	leaf := AdminAttributeValue{S: func() *string { v := "x"; return &v }()}
+	cur := leaf
+	for range maxAttributeValueNestingDepth {
+		cur = AdminAttributeValue{L: []AdminAttributeValue{cur}}
+	}
+	err := srv.AdminPutItem(context.Background(), fullAdminPrincipal, "deep",
+		AdminItem{Attributes: map[string]AdminAttributeValue{
+			"id":   stringAttr("k"),
+			"deep": cur,
+		}})
+	require.True(t, errors.Is(err, ErrAdminDynamoValidation),
+		"want ErrAdminDynamoValidation for over-depth payload; got %v", err)
+}
+
+// TestAdminAttributeValue_DeepCopyIsolation pins gemini r1 medium:
+// the conversion functions deep-copy B / SS / NS / BS so mutating
+// the source after conversion does not leak into the converted
+// value (and vice-versa).
+func TestAdminAttributeValue_DeepCopyIsolation(t *testing.T) {
+	t.Parallel()
+	srcB := []byte{0x01, 0x02, 0x03}
+	srcSS := []string{"a", "b"}
+	srcBS := [][]byte{{0x10, 0x11}, {0x20, 0x21}}
+	admin := AdminAttributeValue{B: srcB, SS: srcSS, BS: srcBS}
+
+	internal := adminToInternalAttributeValue(admin)
+
+	// Mutating the source after conversion must NOT change internal.
+	srcB[0] = 0xff
+	srcSS[0] = "mutated"
+	srcBS[0][0] = 0xff
+	require.Equal(t, byte(0x01), internal.B[0], "B must be deep-copied")
+	require.Equal(t, "a", internal.SS[0], "SS must be deep-copied")
+	require.Equal(t, byte(0x10), internal.BS[0][0], "BS must be deep-copied")
+
+	// Reverse direction symmetry.
+	roundTrip := internalToAdminAttributeValue(internal)
+	internal.B[0] = 0xee
+	internal.SS[0] = "again"
+	internal.BS[0][0] = 0xee
+	require.Equal(t, byte(0x01), roundTrip.B[0], "B must be deep-copied on internal→admin")
+	require.Equal(t, "a", roundTrip.SS[0], "SS must be deep-copied on internal→admin")
+	require.Equal(t, byte(0x10), roundTrip.BS[0][0], "BS must be deep-copied on internal→admin")
+}

--- a/adapter/dynamodb_admin_items_test.go
+++ b/adapter/dynamodb_admin_items_test.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"context"
+	"encoding/json"
 	"strconv"
 	"testing"
 
@@ -455,4 +456,58 @@ func TestAdminAttributeValue_EmptyContainersRoundTrip(t *testing.T) {
 	require.True(t, internalL.hasListType(), "internal L must be hasListType()=true after round-trip from empty admin L")
 	internalM := adminToInternalAttributeValue(emptyM)
 	require.True(t, internalM.hasMapType(), "internal M must be hasMapType()=true after round-trip from empty admin M")
+}
+
+// TestAdminAttributeValue_EmptyContainersJSONRoundTrip pins
+// claude-bot r4 low on PR #805: encoding/json `omitempty` drops
+// slices/maps of len 0 regardless of nil-ness, so the default
+// struct marshaler would have lost {"L": []} / {"M": {}} on the
+// Phase 3 HTTP wire even with the r4 fix preserving the Go-level
+// distinction. The custom MarshalJSON / UnmarshalJSON delegating
+// to the internal attributeValue's AWS-wire codec fixes this.
+func TestAdminAttributeValue_EmptyContainersJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// Empty list serializes as {"L": []}, not {}.
+	emptyL := AdminAttributeValue{L: []AdminAttributeValue{}}
+	bL, err := json.Marshal(emptyL)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"L": []}`, string(bL), "empty L must serialize as {\"L\": []} not {}")
+
+	// Empty map serializes as {"M": {}}, not {}.
+	emptyM := AdminAttributeValue{M: map[string]AdminAttributeValue{}}
+	bM, err := json.Marshal(emptyM)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"M": {}}`, string(bM), "empty M must serialize as {\"M\": {}} not {}")
+
+	// And the unmarshal direction round-trips empty containers as non-nil.
+	var roundL AdminAttributeValue
+	require.NoError(t, json.Unmarshal(bL, &roundL))
+	require.NotNil(t, roundL.L, "unmarshal {\"L\": []} must yield non-nil empty L")
+	require.Len(t, roundL.L, 0)
+
+	var roundM AdminAttributeValue
+	require.NoError(t, json.Unmarshal(bM, &roundM))
+	require.NotNil(t, roundM.M, "unmarshal {\"M\": {}} must yield non-nil empty M")
+	require.Len(t, roundM.M, 0)
+}
+
+// TestAdminAttributeValue_JSONMarshalRejectsMultiField pins the
+// fail-closed contract the custom MarshalJSON inherits from the
+// internal attributeValue: an AdminAttributeValue with zero or
+// multiple kind fields set is malformed per the AWS wire and
+// surfaces as a marshal error rather than producing an invalid
+// wire payload the SDK would silently misinterpret.
+func TestAdminAttributeValue_JSONMarshalRejectsMultiField(t *testing.T) {
+	t.Parallel()
+
+	// Zero fields → invalid.
+	_, err := json.Marshal(AdminAttributeValue{})
+	require.Error(t, err, "zero-field AdminAttributeValue must fail to marshal")
+
+	// Two fields → invalid.
+	s := "x"
+	n := "1"
+	_, err = json.Marshal(AdminAttributeValue{S: &s, N: &n})
+	require.Error(t, err, "multi-field AdminAttributeValue must fail to marshal")
 }

--- a/adapter/dynamodb_migration_test.go
+++ b/adapter/dynamodb_migration_test.go
@@ -327,3 +327,57 @@ func TestDynamoDB_TransactWriteItemsWithRetry_MigratesLegacyTables(t *testing.T)
 	require.True(t, found)
 	require.Equal(t, newStringAttributeValue("new"), current.item["value"])
 }
+
+// TestDynamoDB_EnsureLegacyTableMigration_RefusesAdminReadOnlyContext
+// pins Codex r8 P2 on PR #805: an admin read-only call (tagged via
+// withAdminReadOnlyContext) must refuse to trigger Raft writes from
+// inside the migration path, even when the table genuinely needs
+// migration. This closes the TOCTOU window between AdminScanTable's
+// entry-point legacy check and scanItems' internal migration
+// trigger.
+func TestDynamoDB_EnsureLegacyTableMigration_RefusesAdminReadOnlyContext(t *testing.T) {
+	t.Parallel()
+
+	legacySchema, server, st := newLegacyMigrationTestServer(t, false, "S")
+	writer := newDynamoFixtureWriter(t, st)
+	writer.writeSchema(legacySchema)
+	writer.writeItem(legacySchema, map[string]attributeValue{
+		"pk": newStringAttributeValue("p"),
+		"sk": newStringAttributeValue("s"),
+	})
+
+	// Without the admin tag, ensureLegacyTableMigration drives the
+	// migration through to completion (control: confirm the table
+	// genuinely needs migration in this setup).
+	ctx := context.Background()
+	require.NoError(t, server.loadAndVerifyNeedsMigration(ctx, legacySchema.TableName, t))
+
+	// With the admin read-only context tag set, the same path
+	// MUST refuse with ErrAdminDynamoValidation rather than running
+	// the write-path migration.
+	adminCtx := withAdminReadOnlyContext(ctx)
+	err := server.ensureLegacyTableMigration(adminCtx, legacySchema.TableName)
+	require.True(t, errors.Is(err, ErrAdminDynamoValidation),
+		"want ErrAdminDynamoValidation from admin read-only migration trigger; got %v", err)
+
+	// The schema must not have been migrated (write-path skipped).
+	schema, exists, err := server.loadTableSchema(ctx, legacySchema.TableName)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.True(t, schema.needsLegacyKeyMigration(),
+		"schema must still need migration after refused admin call (no writes occurred)")
+}
+
+// loadAndVerifyNeedsMigration is a tiny test helper: load the
+// schema and confirm needsLegacyKeyMigration() == true. Returns
+// an error so the caller can require.NoError it.
+func (d *DynamoDBServer) loadAndVerifyNeedsMigration(ctx context.Context, tableName string, t *testing.T) error {
+	t.Helper()
+	schema, exists, err := d.loadTableSchema(ctx, tableName)
+	if err != nil {
+		return err
+	}
+	require.True(t, exists, "table must exist")
+	require.True(t, schema.needsLegacyKeyMigration(), "table must need migration in this setup")
+	return nil
+}


### PR DESCRIPTION
## Summary

**Phase 2a** of `docs/design/2026_05_22_implemented_admin_data_browser.md` (PR #801) — DynamoDB item-level admin RPCs:

- `AdminScanTable(ctx, principal, name, opts) (AdminScanResult, error)` — read role; `Limit` clamped to `[1, 100]` with default `25`; returns `LastEvaluatedKey` for cursor pagination (no internal looping on partial pages per §3.1.1).
- `AdminGetItem(ctx, principal, name, key) (*AdminItem, bool, error)` — read role; returns `(nil, false, nil)` on absence so admin handlers can render 404 without sniffing sentinels.
- `AdminPutItem(ctx, principal, name, item) error` — write role; create-or-replace.
- `AdminDeleteItem(ctx, principal, name, key) error` — write role.

`AdminAttributeValue` is the exported mirror of the internal `attributeValue` (same AWS-wire JSON shape, recursive for `L` / `M`). Conversion functions sit between admin and adapter types.

## Authorization

| Operation | Gate |
|---|---|
| Scan / Get | `principal.Role.canRead()` (RoleReadOnly or RoleFull) |
| Put / Delete | `principal.Role.canWrite()` (RoleFull only) |
| All | `isVerifiedDynamoLeader` up-front check |

## Caller audit (semantic-change rule)

No existing signatures changed. The internal helpers (`scanItems`, `loadTableSchemaAt`, `readLogicalItemAt`, `putItemWithRetry`, `deleteItemWithRetry`) are unchanged; the admin RPCs are pure gated wrappers.

## Risk

Low. All four admin entrypoints delegate to existing internal helpers that ship in production today; the additions are role gates + sentinel translation.

## Self-review (5 passes)

1. **Data loss** — Each write delegates to the existing `*WithRetry` helper that the SigV4 path uses. No new persistence paths.
2. **Concurrency** — Leader-only via `isVerifiedDynamoLeader`. Reads use `nextTxnReadTS()` for the MVCC snapshot. Cursor pagination uses the internal `ExclusiveStartKey` semantics (no race because the cursor itself encodes the item key).
3. **Performance** — O(Limit) cost on scan (hard-capped at 100). No hot-path allocations. Conversion functions recurse on L/M but the recursion depth is bounded by the existing `maxAttributeValueNestingDepth=32` constant the wire parser already enforces.
4. **Consistency** — Read RPC re-resolves the schema at `readTS` (matches the SigV4 GetItem's lease-confirm-then-read pattern). The admin path does NOT do the lease-read step (admin reads are rare, not steady-state), but the gain over the lease-confirmed SigV4 path is bounded by the leader-step-down window — same trade-off the SQS admin peek made.
5. **Test coverage** — 12 new unit tests cover happy / missing / role gates / validation / cursor pagination / recursive value round-trip / limit clamping.

## Test plan

- [x] `go test -race -count=1 -timeout=180s ./adapter/...` — 12 new tests + all existing dynamo admin tests pass
- [x] `make lint` clean (0 issues)
- [ ] CI on this PR

## Phase plan

- Phase 2a: this PR (DynamoDB)
- **Phase 2b**: S3 object-level RPCs (separate PR)
- Phase 3: HTTP handlers + bridges + integration tests
- Phase 4: SPA DynamoDetail Items tab
- Phase 5: SPA S3Detail Objects tab + Upload
- Phase 6: Doc rename `_proposed_` → `_implemented_`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin APIs for table scan (cursored pagination), get, put, and delete with role/leader checks, strict input validation, clamped scan limits, and clear not-found/validation error responses
  * Robust attribute JSON handling preserving empty lists/maps and enforcing single-kind attributes and max nesting depth

* **Tests**
  * Extensive coverage for happy paths, permission checks, pagination/cursor round-trips, limit clamping, validation failures, and attribute codec/round-trip behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/805?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->