### PR TITLE
backup: snapshot dispatcher (Phase 0a routing layer)

### DIFF
--- a/internal/backup/decode.go
+++ b/internal/backup/decode.go
@@ -1,0 +1,667 @@
+package backup
+
+import (
+	"bytes"
+	"io"
+	"sort"
+
+	"github.com/cockroachdb/errors"
+)
+
+// decode.go orchestrates the per-prefix dispatch from a raw `.fsm`
+// stream into the four adapter encoders (DynamoDB, S3, Redis, SQS).
+// It is the Phase 0a glue documented in §"Pipeline" of
+// docs/design/2026_04_29_proposed_snapshot_logical_decoder.md.
+//
+// The dispatcher is intentionally thin: every per-record decision
+// (manifest reassembly, TTL inlining, side-record exclusion, ...) is
+// owned by the per-adapter encoder. This file is just the routing
+// table that maps "leading bytes of an entry's key" to the adapter
+// method that owns that prefix. MANIFEST.json and CHECKSUMS emission
+// live in cmd/elastickv-snapshot-decode (not here) because Phase 0a
+// callers want to drive both from CLI flags and from in-process
+// integration tests, and stamping wall-time metadata in this package
+// would couple it to the wrong layer.
+
+// AdapterSet selects which adapter encoders DecodeSnapshot
+// instantiates. Disabled adapters are silently dropped at dispatch
+// time (counted as Internal); they do NOT create empty output
+// directories.
+type AdapterSet struct {
+	DynamoDB bool
+	S3       bool
+	Redis    bool
+	SQS      bool
+}
+
+// AllAdapters enables every adapter. Convenience for the CLI's
+// default (`--adapter` flag absent) and for end-to-end tests.
+func AllAdapters() AdapterSet {
+	return AdapterSet{DynamoDB: true, S3: true, Redis: true, SQS: true}
+}
+
+// DecodeOptions configures DecodeSnapshot. Zero values are
+// documented as "off" for booleans; OutRoot is required.
+type DecodeOptions struct {
+	// OutRoot is the destination directory tree root. Must be set.
+	OutRoot string
+	// ScratchRoot is where the S3 encoder buffers blob chunks during
+	// assembly. Defaults to OutRoot when empty; callers backing the
+	// CLI's --scratch-root flag override it (e.g. to a tmpfs).
+	ScratchRoot string
+	// Adapters selects which adapter encoders to construct. Entries
+	// for disabled adapters are dropped silently and counted as
+	// Internal.
+	Adapters AdapterSet
+	// RedisDBIndex selects the <n> in redis/db_<n>/. Phase 0a always
+	// emits db_0 but the parameter is plumbed so Phase 1 can dump
+	// multiple DBs.
+	RedisDBIndex int
+
+	// IncludeIncompleteUploads enables `--include-incomplete-uploads`
+	// for the S3 encoder (in-flight multipart uploads).
+	IncludeIncompleteUploads bool
+	// IncludeOrphans enables `--include-orphans` for the S3 encoder
+	// (pre-generation orphan blob chunks).
+	IncludeOrphans bool
+	// RenameS3Collisions enables `--rename-collisions` for the S3
+	// encoder (rename user keys ending in `.elastickv-meta.json`).
+	RenameS3Collisions bool
+
+	// PreserveSQSVisibility enables `--preserve-sqs-visibility` for
+	// the SQS encoder (carry live visibility-state fields into the
+	// dump rather than zeroing them).
+	PreserveSQSVisibility bool
+	// IncludeSQSSideRecords enables `--include-sqs-side-records` for
+	// the SQS encoder (`_internals/dedup.jsonl` etc.).
+	IncludeSQSSideRecords bool
+
+	// DynamoDBBundleJSONL switches the DynamoDB encoder to the JSONL
+	// bundle layout (`items/data-<part>.jsonl`).
+	DynamoDBBundleJSONL bool
+
+	// WarnSink, when non-nil, receives structured warnings from the
+	// per-adapter encoders ("redis_orphan_ttl", "ddb_orphan_items",
+	// ...). The dispatcher itself does not emit warnings.
+	WarnSink func(event string, fields ...any)
+}
+
+// DecodeCounters reports per-class entry counts after a successful
+// DecodeSnapshot call.
+//
+// The breakdown is:
+//
+//	Total      - every snapshot entry that reached the dispatcher
+//	Tombstone  - entries whose value-header flagged a delete; skipped
+//	             before adapter dispatch
+//	DynamoDB   - entries routed to a DDBEncoder method
+//	S3         - entries routed to an S3Encoder method
+//	Redis      - entries routed to a RedisDB method
+//	SQS        - entries routed to a SQSEncoder method
+//	Internal   - entries matched by a known internal-only prefix
+//	             (e.g. !txn|, !s3route|) AND entries that matched an
+//	             adapter prefix whose adapter was excluded by
+//	             DecodeOptions.Adapters; both are intentional drops
+//	Unknown    - entries whose key prefix matched no route — surfaced
+//	             so a malformed or version-skewed snapshot does not
+//	             silently round-trip into an empty dump
+//
+// Total = Tombstone + DynamoDB + S3 + Redis + SQS + Internal + Unknown.
+type DecodeCounters struct {
+	Total     uint64
+	Tombstone uint64
+	DynamoDB  uint64
+	S3        uint64
+	Redis     uint64
+	SQS       uint64
+	Internal  uint64
+	Unknown   uint64
+}
+
+// DecodeResult is returned by DecodeSnapshot after a successful
+// run. Header carries the snapshot's `last_commit_ts` for the
+// caller's MANIFEST.json.
+type DecodeResult struct {
+	Header   SnapshotHeader
+	Counters DecodeCounters
+}
+
+// ErrDecodeOptionsInvalid is returned when DecodeSnapshot is called
+// with an under-populated DecodeOptions (missing OutRoot, etc.).
+var ErrDecodeOptionsInvalid = errors.New("backup: DecodeOptions invalid")
+
+// DecodeSnapshot reads a `.fsm`-format stream from r, dispatches
+// every non-tombstone entry to the appropriate adapter encoder
+// rooted under opts.OutRoot, and runs Finalize on each enabled
+// adapter at end of stream.
+//
+// Caller closes r. DecodeSnapshot does NOT write MANIFEST.json or
+// CHECKSUMS — both are emitted by the cmd/ wrapper from the returned
+// DecodeResult plus its own wall-time / source-path metadata.
+func DecodeSnapshot(r io.Reader, opts DecodeOptions) (DecodeResult, error) {
+	d, err := newDispatcher(opts)
+	if err != nil {
+		return DecodeResult{}, err
+	}
+	hdr, err := ReadSnapshotWithHeader(r, func(_ SnapshotHeader, e SnapshotEntry) error {
+		return d.handleEntry(e)
+	})
+	if err != nil {
+		return DecodeResult{}, err
+	}
+	if err := d.finalize(); err != nil {
+		return DecodeResult{}, err
+	}
+	return DecodeResult{Header: hdr, Counters: d.counters}, nil
+}
+
+// dispatcher is the in-memory state carried across the ReadSnapshot
+// callback invocations. One per DecodeSnapshot call.
+type dispatcher struct {
+	opts     DecodeOptions
+	ddb      *DDBEncoder
+	s3       *S3Encoder
+	redis    *RedisDB
+	sqs      *SQSEncoder
+	counters DecodeCounters
+}
+
+// newDispatcher constructs the enabled per-adapter encoders. The
+// validation it runs is the *parameter* validation; filesystem
+// existence / permission errors surface later, on first write.
+func newDispatcher(opts DecodeOptions) (*dispatcher, error) {
+	if opts.OutRoot == "" {
+		return nil, errors.Wrap(ErrDecodeOptionsInvalid, "OutRoot required")
+	}
+	d := &dispatcher{opts: opts}
+	if opts.Adapters.DynamoDB {
+		d.ddb = NewDDBEncoder(opts.OutRoot).
+			WithBundleJSONL(opts.DynamoDBBundleJSONL).
+			WithWarnSink(opts.WarnSink)
+	}
+	if opts.Adapters.S3 {
+		scratch := opts.ScratchRoot
+		if scratch == "" {
+			scratch = opts.OutRoot
+		}
+		d.s3 = NewS3Encoder(opts.OutRoot, scratch).
+			WithIncludeIncompleteUploads(opts.IncludeIncompleteUploads).
+			WithIncludeOrphans(opts.IncludeOrphans).
+			WithRenameCollisions(opts.RenameS3Collisions).
+			WithWarnSink(opts.WarnSink)
+	}
+	if opts.Adapters.Redis {
+		d.redis = NewRedisDB(opts.OutRoot, opts.RedisDBIndex).
+			WithWarnSink(opts.WarnSink)
+	}
+	if opts.Adapters.SQS {
+		d.sqs = NewSQSEncoder(opts.OutRoot).
+			WithIncludeSideRecords(opts.IncludeSQSSideRecords).
+			WithPreserveVisibility(opts.PreserveSQSVisibility).
+			WithWarnSink(opts.WarnSink)
+	}
+	return d, nil
+}
+
+// handleEntry is the per-entry hook ReadSnapshot calls. Tombstones
+// are counted and dropped before any prefix matching runs — Phase 0a
+// dumps reflect the *current* user-visible state, not the
+// crash-consistent MVCC tombstone fan.
+func (d *dispatcher) handleEntry(e SnapshotEntry) error {
+	d.counters.Total++
+	if e.Tombstone {
+		d.counters.Tombstone++
+		return nil
+	}
+	return d.route(e.UserKey, e.UserValue)
+}
+
+// route does the leading-prefix match against the global routing
+// table. Entries with no matching prefix increment Unknown — these
+// are the format-skew / corruption signal a Phase 0a operator wants
+// to surface, not swallow.
+func (d *dispatcher) route(key, value []byte) error {
+	for _, r := range prefixRoutes {
+		if bytes.HasPrefix(key, r.prefix) {
+			return r.handler(d, key, value)
+		}
+	}
+	d.counters.Unknown++
+	return nil
+}
+
+// finalize runs Finalize on every constructed adapter encoder. The
+// order is fixed and matches the dump-tree order
+// (dynamodb/, s3/, redis/, sqs/) so an operator inspecting a partial
+// dump after a finalize-time error sees the adapters in the
+// expected sequence.
+func (d *dispatcher) finalize() error {
+	if d.ddb != nil {
+		if err := d.ddb.Finalize(); err != nil {
+			return err
+		}
+	}
+	if d.s3 != nil {
+		if err := d.s3.Finalize(); err != nil {
+			return err
+		}
+	}
+	if d.redis != nil {
+		if err := d.redis.Finalize(); err != nil {
+			return err
+		}
+	}
+	if d.sqs != nil {
+		if err := d.sqs.Finalize(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// prefixRoute is one row in the global dispatch table. handler is a
+// method-style function so the table itself stays a pure data
+// declaration (no closures-over-state).
+type prefixRoute struct {
+	prefix  []byte
+	handler func(d *dispatcher, key, value []byte) error
+}
+
+// prefixRoutes is the canonical leading-prefix → handler table.
+// Initialized once via package-init sort so that LONGER prefixes
+// win over shorter ones (e.g. "!hs|meta|d|" must match before
+// "!hs|meta|"). Tests pin the ordering so a future addition that
+// introduces an ambiguity surfaces as a test failure.
+var prefixRoutes = buildPrefixRoutes()
+
+func buildPrefixRoutes() []prefixRoute {
+	r := []prefixRoute{
+		// DynamoDB
+		{[]byte(DDBTableMetaPrefix), routeDDBTableMeta},
+		{[]byte(DDBTableGenPrefix), routeDDBTableGen},
+		{[]byte(DDBItemPrefix), routeDDBItem},
+		{[]byte(DDBGSIPrefix), routeDDBGSI},
+		// S3
+		{[]byte(S3BucketMetaPrefix), routeS3BucketMeta},
+		{[]byte(S3BucketGenPrefix), routeS3BucketGen},
+		{[]byte(S3ObjectManifestPrefix), routeS3ObjectManifest},
+		{[]byte(S3UploadMetaPrefix), routeS3UploadMeta(S3UploadMetaPrefix)},
+		{[]byte(S3UploadPartPrefix), routeS3UploadMeta(S3UploadPartPrefix)},
+		{[]byte(S3BlobPrefix), routeS3Blob},
+		{[]byte(S3GCUploadPrefix), routeInternalDrop},
+		{[]byte(S3RoutePrefix), routeInternalDrop},
+		// SQS
+		{[]byte(SQSQueueMetaPrefix), routeSQSQueueMeta},
+		{[]byte(SQSQueueGenPrefix), routeSQSQueueGen},
+		{[]byte(SQSQueueSeqPrefix), routeSQSSide(SQSQueueSeqPrefix)},
+		{[]byte(SQSQueueTombstonePrefix), routeSQSSide(SQSQueueTombstonePrefix)},
+		{[]byte(SQSMsgDataPrefix), routeSQSMessageData},
+		{[]byte(SQSMsgVisPrefix), routeSQSSide(SQSMsgVisPrefix)},
+		{[]byte(SQSMsgByAgePrefix), routeSQSSide(SQSMsgByAgePrefix)},
+		{[]byte(SQSMsgDedupPrefix), routeSQSSide(SQSMsgDedupPrefix)},
+		{[]byte(SQSMsgGroupPrefix), routeSQSSide(SQSMsgGroupPrefix)},
+		// Redis hash
+		{[]byte(RedisHashMetaDeltaPrefix), routeRedisHashMeta},
+		{[]byte(RedisHashMetaPrefix), routeRedisHashMeta},
+		{[]byte(RedisHashFieldPrefix), routeRedisHashField},
+		// Redis list
+		{[]byte(ListMetaDeltaPrefix), routeRedisListMetaDelta},
+		{[]byte(ListMetaPrefix), routeRedisListMeta},
+		{[]byte(ListItemPrefix), routeRedisListItem},
+		{[]byte(ListClaimPrefix), routeRedisListClaim},
+		// Redis set
+		{[]byte(RedisSetMetaDeltaPrefix), routeRedisSetMetaDelta},
+		{[]byte(RedisSetMetaPrefix), routeRedisSetMeta},
+		{[]byte(RedisSetMemberPrefix), routeRedisSetMember},
+		// Redis zset
+		{[]byte(RedisZSetMetaDeltaPrefix), routeRedisZSetMetaDelta},
+		{[]byte(RedisZSetMetaPrefix), routeRedisZSetMeta},
+		{[]byte(RedisZSetMemberPrefix), routeRedisZSetMember},
+		{[]byte(RedisZSetScorePrefix), routeRedisZSetScore},
+		{[]byte(RedisZSetLegacyBlobPrefix), routeRedisZSetLegacy},
+		// Redis stream
+		{[]byte(RedisStreamMetaPrefix), routeRedisStreamMeta},
+		{[]byte(RedisStreamEntryPrefix), routeRedisStreamEntry},
+		// Redis simple — handlers take the userKey AFTER the prefix.
+		{[]byte(RedisStringPrefix), routeRedisString},
+		{[]byte(RedisHLLPrefix), routeRedisHLL},
+		{[]byte(RedisTTLPrefix), routeRedisTTL},
+		// Internal-only: transactional intents / locks / resolver
+		// records. Phase 0a drops these; they belong to the running
+		// cluster, not the data.
+		{[]byte("!txn|"), routeInternalDrop},
+	}
+	sort.SliceStable(r, func(i, j int) bool {
+		return len(r[i].prefix) > len(r[j].prefix)
+	})
+	return r
+}
+
+// =====================
+// DynamoDB route adapters
+// =====================
+
+func routeDDBTableMeta(d *dispatcher, k, v []byte) error {
+	if d.ddb == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.DynamoDB++
+	return d.ddb.HandleTableMeta(k, v)
+}
+
+func routeDDBTableGen(d *dispatcher, k, v []byte) error {
+	if d.ddb == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.DynamoDB++
+	return d.ddb.HandleTableGen(k, v)
+}
+
+func routeDDBItem(d *dispatcher, k, v []byte) error {
+	if d.ddb == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.DynamoDB++
+	return d.ddb.HandleItem(k, v)
+}
+
+func routeDDBGSI(d *dispatcher, k, v []byte) error {
+	if d.ddb == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.DynamoDB++
+	return d.ddb.HandleGSIRow(k, v)
+}
+
+// ===============
+// S3 route adapters
+// ===============
+
+func routeS3BucketMeta(d *dispatcher, k, v []byte) error {
+	if d.s3 == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.S3++
+	return d.s3.HandleBucketMeta(k, v)
+}
+
+func routeS3BucketGen(d *dispatcher, _, _ []byte) error {
+	// !s3|bucket|gen| is the per-bucket generation counter. The
+	// encoder reads the generation from the manifest key itself; the
+	// counter record is not needed at dump time. Drop with Internal.
+	d.counters.Internal++
+	return nil
+}
+
+func routeS3ObjectManifest(d *dispatcher, k, v []byte) error {
+	if d.s3 == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.S3++
+	return d.s3.HandleObjectManifest(k, v)
+}
+
+func routeS3Blob(d *dispatcher, k, v []byte) error {
+	if d.s3 == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.S3++
+	return d.s3.HandleBlob(k, v)
+}
+
+// routeS3UploadMeta returns a handler that forwards a specific
+// in-flight-multipart prefix into HandleIncompleteUpload. The
+// indirection captures the prefix label the S3 encoder uses to
+// distinguish the family at parse time.
+func routeS3UploadMeta(prefix string) func(d *dispatcher, k, v []byte) error {
+	return func(d *dispatcher, k, v []byte) error {
+		if d.s3 == nil {
+			d.counters.Internal++
+			return nil
+		}
+		d.counters.S3++
+		return d.s3.HandleIncompleteUpload(prefix, k, v)
+	}
+}
+
+// ===============
+// SQS route adapters
+// ===============
+
+func routeSQSQueueMeta(d *dispatcher, k, v []byte) error {
+	if d.sqs == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.SQS++
+	return d.sqs.HandleQueueMeta(k, v)
+}
+
+func routeSQSQueueGen(d *dispatcher, k, v []byte) error {
+	if d.sqs == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.SQS++
+	return d.sqs.HandleQueueGen(k, v)
+}
+
+func routeSQSMessageData(d *dispatcher, k, v []byte) error {
+	if d.sqs == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.SQS++
+	return d.sqs.HandleMessageData(k, v)
+}
+
+// routeSQSSide returns a handler that forwards a specific side-
+// record prefix into HandleSideRecord. The encoder uses the prefix
+// label to dispatch to the right family (dedup, group, vis, ...).
+func routeSQSSide(prefix string) func(d *dispatcher, k, v []byte) error {
+	return func(d *dispatcher, k, v []byte) error {
+		if d.sqs == nil {
+			d.counters.Internal++
+			return nil
+		}
+		d.counters.SQS++
+		return d.sqs.HandleSideRecord(prefix, k, v)
+	}
+}
+
+// =================
+// Redis route adapters
+// =================
+
+func routeRedisHashMeta(d *dispatcher, k, v []byte) error {
+	if d.redis == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.Redis++
+	return d.redis.HandleHashMeta(k, v)
+}
+
+func routeRedisHashField(d *dispatcher, k, v []byte) error {
+	if d.redis == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.Redis++
+	return d.redis.HandleHashField(k, v)
+}
+
+func routeRedisListMeta(d *dispatcher, k, v []byte) error {
+	if d.redis == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.Redis++
+	return d.redis.HandleListMeta(k, v)
+}
+
+func routeRedisListMetaDelta(d *dispatcher, k, v []byte) error {
+	if d.redis == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.Redis++
+	return d.redis.HandleListMetaDelta(k, v)
+}
+
+func routeRedisListItem(d *dispatcher, k, v []byte) error {
+	if d.redis == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.Redis++
+	return d.redis.HandleListItem(k, v)
+}
+
+func routeRedisListClaim(d *dispatcher, k, v []byte) error {
+	if d.redis == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.Redis++
+	return d.redis.HandleListClaim(k, v)
+}
+
+func routeRedisSetMeta(d *dispatcher, k, v []byte) error {
+	if d.redis == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.Redis++
+	return d.redis.HandleSetMeta(k, v)
+}
+
+func routeRedisSetMetaDelta(d *dispatcher, k, v []byte) error {
+	if d.redis == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.Redis++
+	return d.redis.HandleSetMetaDelta(k, v)
+}
+
+func routeRedisSetMember(d *dispatcher, k, v []byte) error {
+	if d.redis == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.Redis++
+	return d.redis.HandleSetMember(k, v)
+}
+
+func routeRedisZSetMeta(d *dispatcher, k, v []byte) error {
+	if d.redis == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.Redis++
+	return d.redis.HandleZSetMeta(k, v)
+}
+
+func routeRedisZSetMetaDelta(d *dispatcher, k, v []byte) error {
+	if d.redis == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.Redis++
+	return d.redis.HandleZSetMetaDelta(k, v)
+}
+
+func routeRedisZSetMember(d *dispatcher, k, v []byte) error {
+	if d.redis == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.Redis++
+	return d.redis.HandleZSetMember(k, v)
+}
+
+func routeRedisZSetScore(d *dispatcher, k, v []byte) error {
+	if d.redis == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.Redis++
+	return d.redis.HandleZSetScore(k, v)
+}
+
+func routeRedisZSetLegacy(d *dispatcher, k, v []byte) error {
+	if d.redis == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.Redis++
+	return d.redis.HandleZSetLegacyBlob(k, v)
+}
+
+func routeRedisStreamMeta(d *dispatcher, k, v []byte) error {
+	if d.redis == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.Redis++
+	return d.redis.HandleStreamMeta(k, v)
+}
+
+func routeRedisStreamEntry(d *dispatcher, k, v []byte) error {
+	if d.redis == nil {
+		d.counters.Internal++
+		return nil
+	}
+	d.counters.Redis++
+	return d.redis.HandleStreamEntry(k, v)
+}
+
+// Redis simple-type handlers expect the userKey AFTER the prefix —
+// they take the slice that lives between the leading "!redis|<x>|"
+// segment and the inverted-TS suffix the snapshot reader already
+// stripped.
+func routeRedisString(d *dispatcher, k, v []byte) error {
+	if d.redis == nil {
+		d.counters.Internal++
+		return nil
+	}
+	userKey := k[len(RedisStringPrefix):]
+	d.counters.Redis++
+	return d.redis.HandleString(userKey, v)
+}
+
+func routeRedisHLL(d *dispatcher, k, v []byte) error {
+	if d.redis == nil {
+		d.counters.Internal++
+		return nil
+	}
+	userKey := k[len(RedisHLLPrefix):]
+	d.counters.Redis++
+	return d.redis.HandleHLL(userKey, v)
+}
+
+func routeRedisTTL(d *dispatcher, k, v []byte) error {
+	if d.redis == nil {
+		d.counters.Internal++
+		return nil
+	}
+	userKey := k[len(RedisTTLPrefix):]
+	d.counters.Redis++
+	return d.redis.HandleTTL(userKey, v)
+}
+
+// routeInternalDrop is the no-op handler for prefixes Phase 0a
+// deliberately discards (transactional intents, route-catalog
+// entries, garbage-collection metadata, ...).
+func routeInternalDrop(d *dispatcher, _, _ []byte) error {
+	d.counters.Internal++
+	return nil
+}

--- a/internal/backup/decode.go
+++ b/internal/backup/decode.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"bytes"
 	"io"
+	"path/filepath"
 	"sort"
 
 	"github.com/cockroachdb/errors"
@@ -146,10 +147,17 @@ func DecodeSnapshot(r io.Reader, opts DecodeOptions) (DecodeResult, error) {
 	hdr, err := ReadSnapshotWithHeader(r, func(_ SnapshotHeader, e SnapshotEntry) error {
 		return d.handleEntry(e)
 	})
-	if err != nil {
-		return DecodeResult{}, err
+	// finalize() runs unconditionally so encoders (notably the S3
+	// encoder's scratch tree) get cleanup even when the stream is
+	// truncated. The original read error wins over a finalize error
+	// when both occur — the read failure is the root cause and the
+	// finalize error is most likely a downstream symptom (gemini r1
+	// medium on PR #806).
+	fErr := d.finalize()
+	if err == nil {
+		err = fErr
 	}
-	if err := d.finalize(); err != nil {
+	if err != nil {
 		return DecodeResult{}, err
 	}
 	return DecodeResult{Header: hdr, Counters: d.counters}, nil
@@ -182,7 +190,14 @@ func newDispatcher(opts DecodeOptions) (*dispatcher, error) {
 	if opts.Adapters.S3 {
 		scratch := opts.ScratchRoot
 		if scratch == "" {
-			scratch = opts.OutRoot
+			// NEVER default scratch to OutRoot — S3Encoder.Finalize
+			// runs os.RemoveAll(scratchRoot/s3/) and OutRoot also
+			// holds the *final* assembled bodies at <OutRoot>/s3/.
+			// Sharing the root would wipe the dump immediately after
+			// it lands (gemini r1 security-high on PR #806). The
+			// dedicated `.scratch` subtree keeps the two trees
+			// disjoint regardless of where OutRoot points.
+			scratch = filepath.Join(opts.OutRoot, ".scratch")
 		}
 		d.s3 = NewS3Encoder(opts.OutRoot, scratch).
 			WithIncludeIncompleteUploads(opts.IncludeIncompleteUploads).
@@ -235,28 +250,32 @@ func (d *dispatcher) route(key, value []byte) error {
 // (dynamodb/, s3/, redis/, sqs/) so an operator inspecting a partial
 // dump after a finalize-time error sees the adapters in the
 // expected sequence.
+//
+// Each encoder is finalized best-effort: an error in one does NOT
+// short-circuit the rest, so later encoders still get to clean up
+// their scratch directories. The first error encountered wins
+// (mirrors the ReadSnapshotWithHeader / finalize ordering in
+// DecodeSnapshot — gemini r1 medium on PR #806).
 func (d *dispatcher) finalize() error {
-	if d.ddb != nil {
-		if err := d.ddb.Finalize(); err != nil {
-			return err
+	var firstErr error
+	record := func(err error) {
+		if err != nil && firstErr == nil {
+			firstErr = err
 		}
+	}
+	if d.ddb != nil {
+		record(d.ddb.Finalize())
 	}
 	if d.s3 != nil {
-		if err := d.s3.Finalize(); err != nil {
-			return err
-		}
+		record(d.s3.Finalize())
 	}
 	if d.redis != nil {
-		if err := d.redis.Finalize(); err != nil {
-			return err
-		}
+		record(d.redis.Finalize())
 	}
 	if d.sqs != nil {
-		if err := d.sqs.Finalize(); err != nil {
-			return err
-		}
+		record(d.sqs.Finalize())
 	}
-	return nil
+	return firstErr
 }
 
 // prefixRoute is one row in the global dispatch table. handler is a

--- a/internal/backup/decode.go
+++ b/internal/backup/decode.go
@@ -51,6 +51,11 @@ type DecodeOptions struct {
 	// OutRoot itself — sharing would let S3Encoder.Finalize's
 	// os.RemoveAll wipe the final dump). Callers backing the CLI's
 	// --scratch-root flag override it (e.g. to a tmpfs).
+	//
+	// DecodeSnapshot returns ErrDecodeOptionsInvalid if ScratchRoot
+	// cleaned-equals OutRoot: a CLI misconfig that passes
+	// --scratch-root=$OUT_ROOT would otherwise be the silent
+	// data-loss path the default-target check is designed to prevent.
 	ScratchRoot string
 	// Adapters selects which adapter encoders to construct. Entries
 	// for disabled adapters are dropped silently and counted as
@@ -200,6 +205,18 @@ func newDispatcher(opts DecodeOptions) (*dispatcher, error) {
 			// dedicated `.scratch` subtree keeps the two trees
 			// disjoint regardless of where OutRoot points.
 			scratch = filepath.Join(opts.OutRoot, ".scratch")
+		}
+		// Belt-and-braces on the operator-supplied path: the
+		// default-path fix above only protects empty ScratchRoot;
+		// a CLI invocation that passes --scratch-root=$OUT explicitly
+		// would still let Finalize wipe the dump (Codex r3 P1 on
+		// PR #806). Fail fast on cleaned-equal paths so the
+		// misconfiguration surfaces as ErrDecodeOptionsInvalid
+		// rather than as silent data loss after a long decode.
+		if filepath.Clean(scratch) == filepath.Clean(opts.OutRoot) {
+			return nil, errors.Wrap(ErrDecodeOptionsInvalid,
+				"ScratchRoot must not equal OutRoot: S3Encoder.Finalize "+
+					"would os.RemoveAll the final <OutRoot>/s3/ tree")
 		}
 		d.s3 = NewS3Encoder(opts.OutRoot, scratch).
 			WithIncludeIncompleteUploads(opts.IncludeIncompleteUploads).

--- a/internal/backup/decode.go
+++ b/internal/backup/decode.go
@@ -359,6 +359,16 @@ func buildPrefixRoutes() []prefixRoute {
 		// in Counters.Unknown — a false corruption signal on real
 		// production dumps (Codex r1 P2 + claude-bot r1 on PR #806).
 		{[]byte("!dist|"), routeInternalDrop},
+		// Internal-only: encryption writer-registry rows persisted
+		// under internal/encryption/registry.go's
+		// `!encryption|writers|` prefix. These are §4.1 writer
+		// registry rows (one per (dek_id, uint16 node_id) pair) that
+		// the FSM apply path writes through the default Raft group's
+		// Pebble. They ride snapshots like any other 0x03 entry.
+		// Using the broader `!encryption|` prefix so future encryption
+		// metadata under the same namespace is also classified as
+		// Internal rather than Unknown (Codex r3 P2 on PR #806).
+		{[]byte("!encryption|"), routeInternalDrop},
 	}
 	sort.SliceStable(r, func(i, j int) bool {
 		return len(r[i].prefix) > len(r[j].prefix)

--- a/internal/backup/decode.go
+++ b/internal/backup/decode.go
@@ -47,8 +47,10 @@ type DecodeOptions struct {
 	// OutRoot is the destination directory tree root. Must be set.
 	OutRoot string
 	// ScratchRoot is where the S3 encoder buffers blob chunks during
-	// assembly. Defaults to OutRoot when empty; callers backing the
-	// CLI's --scratch-root flag override it (e.g. to a tmpfs).
+	// assembly. Defaults to <OutRoot>/.scratch when empty (NEVER to
+	// OutRoot itself — sharing would let S3Encoder.Finalize's
+	// os.RemoveAll wipe the final dump). Callers backing the CLI's
+	// --scratch-root flag override it (e.g. to a tmpfs).
 	ScratchRoot string
 	// Adapters selects which adapter encoders to construct. Entries
 	// for disabled adapters are dropped silently and counted as
@@ -349,6 +351,14 @@ func buildPrefixRoutes() []prefixRoute {
 		// records. Phase 0a drops these; they belong to the running
 		// cluster, not the data.
 		{[]byte("!txn|"), routeInternalDrop},
+		// Internal-only: distribution catalog (route table + version
+		// metadata persisted under distribution/catalog.go's
+		// `!dist|meta|` / `!dist|route|` prefixes). These ride the
+		// default Raft group's Pebble and so appear in every
+		// clustered snapshot. Without this route they would land
+		// in Counters.Unknown — a false corruption signal on real
+		// production dumps (Codex r1 P2 + claude-bot r1 on PR #806).
+		{[]byte("!dist|"), routeInternalDrop},
 	}
 	sort.SliceStable(r, func(i, j int) bool {
 		return len(r[i].prefix) > len(r[j].prefix)

--- a/internal/backup/decode_test.go
+++ b/internal/backup/decode_test.go
@@ -1,0 +1,207 @@
+package backup
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDecodeSnapshot_RejectsEmptyOutRoot pins that DecodeOptions
+// validation runs before any I/O happens — a missing OutRoot must
+// surface as ErrDecodeOptionsInvalid, not as a downstream
+// permission-denied / not-a-directory error.
+func TestDecodeSnapshot_RejectsEmptyOutRoot(t *testing.T) {
+	t.Parallel()
+	b := newSnapBuilder(0)
+	_, err := DecodeSnapshot(bytes.NewReader(b.Bytes()), DecodeOptions{
+		Adapters: AllAdapters(),
+	})
+	if err == nil {
+		t.Fatalf("expected ErrDecodeOptionsInvalid, got nil")
+	}
+}
+
+// TestDecodeSnapshot_HeaderOnlyProducesEmptyResult pins that a
+// snapshot with no entries still validates and Finalize runs cleanly
+// on every adapter.
+func TestDecodeSnapshot_HeaderOnlyProducesEmptyResult(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	b := newSnapBuilder(0xCAFE)
+	res, err := DecodeSnapshot(bytes.NewReader(b.Bytes()), DecodeOptions{
+		OutRoot:  root,
+		Adapters: AllAdapters(),
+	})
+	if err != nil {
+		t.Fatalf("DecodeSnapshot: %v", err)
+	}
+	if res.Header.LastCommitTS != 0xCAFE {
+		t.Fatalf("LastCommitTS = %d, want 0xCAFE", res.Header.LastCommitTS)
+	}
+	if res.Counters.Total != 0 {
+		t.Fatalf("Counters.Total = %d, want 0", res.Counters.Total)
+	}
+}
+
+// TestDecodeSnapshot_RoutesRedisString feeds a single !redis|str|
+// entry and confirms the dispatcher wrote the strings/<key>.bin
+// file via the RedisDB encoder.
+func TestDecodeSnapshot_RoutesRedisString(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	b := newSnapBuilder(1)
+	val := encodeNewStringValue(t, []byte("hello"), 0)
+	b.WriteEntry([]byte(RedisStringPrefix+"greeting"), 1, val, false, 0, snapshotEncStateCleartx)
+	res, err := DecodeSnapshot(bytes.NewReader(b.Bytes()), DecodeOptions{
+		OutRoot:  root,
+		Adapters: AllAdapters(),
+	})
+	if err != nil {
+		t.Fatalf("DecodeSnapshot: %v", err)
+	}
+	if res.Counters.Redis != 1 {
+		t.Fatalf("Counters.Redis = %d, want 1 (counters=%+v)", res.Counters.Redis, res.Counters)
+	}
+	wantPath := filepath.Join(root, "redis", "db_0", "strings", "greeting.bin")
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("stat %s: %v", wantPath, err)
+	}
+}
+
+// TestDecodeSnapshot_DropsTombstones pins the up-front tombstone
+// filter — entries flagged tombstone bypass the prefix router and
+// only increment Counters.Tombstone.
+func TestDecodeSnapshot_DropsTombstones(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	b := newSnapBuilder(0)
+	val := encodeNewStringValue(t, []byte("v"), 0)
+	b.WriteEntry([]byte(RedisStringPrefix+"k"), 1, val, true, 0, snapshotEncStateCleartx)
+	res, err := DecodeSnapshot(bytes.NewReader(b.Bytes()), DecodeOptions{
+		OutRoot:  root,
+		Adapters: AllAdapters(),
+	})
+	if err != nil {
+		t.Fatalf("DecodeSnapshot: %v", err)
+	}
+	if res.Counters.Tombstone != 1 {
+		t.Fatalf("Counters.Tombstone = %d, want 1", res.Counters.Tombstone)
+	}
+	if res.Counters.Redis != 0 {
+		t.Fatalf("Counters.Redis = %d, want 0", res.Counters.Redis)
+	}
+	if _, err := os.Stat(filepath.Join(root, "redis", "db_0", "strings", "k.bin")); err == nil {
+		t.Fatalf("tombstone produced an output file; want absent")
+	}
+}
+
+// TestDecodeSnapshot_DisabledAdapterCountsAsInternal pins that
+// per-adapter exclusion turns matched-prefix entries into Internal
+// drops (not Unknown) — operators who pass `--adapter redis` still
+// see DynamoDB / S3 / SQS counts under the right bucket.
+func TestDecodeSnapshot_DisabledAdapterCountsAsInternal(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	b := newSnapBuilder(0)
+	val := encodeNewStringValue(t, []byte("v"), 0)
+	b.WriteEntry([]byte(RedisStringPrefix+"k"), 1, val, false, 0, snapshotEncStateCleartx)
+	res, err := DecodeSnapshot(bytes.NewReader(b.Bytes()), DecodeOptions{
+		OutRoot: root,
+		// Redis NOT enabled.
+		Adapters: AdapterSet{DynamoDB: true, S3: true, SQS: true},
+	})
+	if err != nil {
+		t.Fatalf("DecodeSnapshot: %v", err)
+	}
+	if res.Counters.Internal != 1 {
+		t.Fatalf("Counters.Internal = %d, want 1", res.Counters.Internal)
+	}
+	if res.Counters.Unknown != 0 {
+		t.Fatalf("Counters.Unknown = %d, want 0", res.Counters.Unknown)
+	}
+	if _, err := os.Stat(filepath.Join(root, "redis")); err == nil {
+		t.Fatalf("disabled adapter produced redis/; want absent")
+	}
+}
+
+// TestDecodeSnapshot_UnknownPrefixCounted pins that a key with no
+// matching route lands in Counters.Unknown — the format-skew /
+// corruption signal a Phase 0a operator wants to surface.
+func TestDecodeSnapshot_UnknownPrefixCounted(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	b := newSnapBuilder(0)
+	b.WriteEntry([]byte("!alien|prefix|x"), 1, []byte("v"), false, 0, snapshotEncStateCleartx)
+	res, err := DecodeSnapshot(bytes.NewReader(b.Bytes()), DecodeOptions{
+		OutRoot:  root,
+		Adapters: AllAdapters(),
+	})
+	if err != nil {
+		t.Fatalf("DecodeSnapshot: %v", err)
+	}
+	if res.Counters.Unknown != 1 {
+		t.Fatalf("Counters.Unknown = %d, want 1", res.Counters.Unknown)
+	}
+}
+
+// TestDecodeSnapshot_TxnPrefixDroppedAsInternal pins the
+// transactional-state opt-out: !txn| records are intentionally
+// dropped and surface as Internal (not Unknown).
+func TestDecodeSnapshot_TxnPrefixDroppedAsInternal(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	b := newSnapBuilder(0)
+	b.WriteEntry([]byte("!txn|intent|abc"), 1, []byte("v"), false, 0, snapshotEncStateCleartx)
+	res, err := DecodeSnapshot(bytes.NewReader(b.Bytes()), DecodeOptions{
+		OutRoot:  root,
+		Adapters: AllAdapters(),
+	})
+	if err != nil {
+		t.Fatalf("DecodeSnapshot: %v", err)
+	}
+	if res.Counters.Internal != 1 {
+		t.Fatalf("Counters.Internal = %d, want 1 (counters=%+v)", res.Counters.Internal, res.Counters)
+	}
+	if res.Counters.Unknown != 0 {
+		t.Fatalf("Counters.Unknown = %d, want 0", res.Counters.Unknown)
+	}
+}
+
+// TestPrefixRoutes_LongestMatchesFirst pins the descending-length
+// ordering invariant — the routing table relies on it so a key
+// matching both "!hs|meta|d|" and "!hs|meta|" lands on the delta
+// handler. A future addition that adds an inverted-order entry
+// surfaces here.
+func TestPrefixRoutes_LongestMatchesFirst(t *testing.T) {
+	t.Parallel()
+	for i := 1; i < len(prefixRoutes); i++ {
+		if len(prefixRoutes[i-1].prefix) < len(prefixRoutes[i].prefix) {
+			t.Fatalf("prefixRoutes ordering violated at %d: %q (len %d) before %q (len %d)",
+				i, prefixRoutes[i-1].prefix, len(prefixRoutes[i-1].prefix),
+				prefixRoutes[i].prefix, len(prefixRoutes[i].prefix))
+		}
+	}
+}
+
+// TestPrefixRoutes_HashMetaDeltaWinsOverHashMeta is the
+// canary for the most subtle ambiguity in the table: "!hs|meta|d|"
+// vs "!hs|meta|" — both delta and base records start with
+// "!hs|meta|". The longer prefix must match first or every delta
+// key would be routed to HandleHashMeta with garbage.
+func TestPrefixRoutes_HashMetaDeltaWinsOverHashMeta(t *testing.T) {
+	t.Parallel()
+	deltaKey := []byte(RedisHashMetaDeltaPrefix + "garbage")
+	// Walk the routing table the same way route() does and confirm
+	// the delta prefix matches first.
+	var matched string
+	for _, r := range prefixRoutes {
+		if bytes.HasPrefix(deltaKey, r.prefix) {
+			matched = string(r.prefix)
+			break
+		}
+	}
+	if matched != RedisHashMetaDeltaPrefix {
+		t.Fatalf("first match for %q = %q, want %q", deltaKey, matched, RedisHashMetaDeltaPrefix)
+	}
+}

--- a/internal/backup/decode_test.go
+++ b/internal/backup/decode_test.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,6 +20,37 @@ func TestDecodeSnapshot_RejectsEmptyOutRoot(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatalf("expected ErrDecodeOptionsInvalid, got nil")
+	}
+}
+
+// TestDecodeSnapshot_RejectsScratchEqualsOutRoot pins Codex r3 P1
+// on PR #806: an explicit --scratch-root=$OUT misconfig would
+// still let S3Encoder.Finalize os.RemoveAll the final S3 tree
+// because the default-target check (empty → <OutRoot>/.scratch)
+// only fires when ScratchRoot is empty. Fail fast on cleaned-equal
+// paths so the misconfiguration surfaces as
+// ErrDecodeOptionsInvalid before any decode work happens.
+func TestDecodeSnapshot_RejectsScratchEqualsOutRoot(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	b := newSnapBuilder(0)
+	_, err := DecodeSnapshot(bytes.NewReader(b.Bytes()), DecodeOptions{
+		OutRoot:     root,
+		ScratchRoot: root, // explicit equality — the silent-data-loss path
+		Adapters:    AdapterSet{S3: true},
+	})
+	if !errors.Is(err, ErrDecodeOptionsInvalid) {
+		t.Fatalf("expected ErrDecodeOptionsInvalid, got %v", err)
+	}
+	// Also reject when the two paths differ only by trailing slash
+	// / `./` noise — filepath.Clean normalises both.
+	_, err = DecodeSnapshot(bytes.NewReader(b.Bytes()), DecodeOptions{
+		OutRoot:     root,
+		ScratchRoot: root + "/./",
+		Adapters:    AdapterSet{S3: true},
+	})
+	if !errors.Is(err, ErrDecodeOptionsInvalid) {
+		t.Fatalf("expected ErrDecodeOptionsInvalid for noisy-equal path, got %v", err)
 	}
 }
 

--- a/internal/backup/decode_test.go
+++ b/internal/backup/decode_test.go
@@ -245,14 +245,18 @@ func TestDecodeSnapshot_DefaultScratchDoesNotWipeFinalS3Output(t *testing.T) {
 
 // TestDecodeSnapshot_FinalizeRunsOnTruncatedStream pins gemini r1
 // medium on PR #806: a read error in ReadSnapshotWithHeader must
-// not skip finalize(). With the default scratch path now under
-// <OutRoot>/.scratch/, a successful finalize removes that subtree
-// even when the stream errors. We feed a truncated stream and
-// assert the .scratch directory is absent after DecodeSnapshot
-// returns.
+// not skip finalize(). To make the assertion non-vacuous
+// (claude-bot r1 follow-up), we pre-create <root>/.scratch/s3/
+// manually so it exists going in — if finalize() is skipped on
+// the read error, the dir survives; if finalize() runs,
+// S3Encoder.Finalize's deferred os.RemoveAll reclaims it.
 func TestDecodeSnapshot_FinalizeRunsOnTruncatedStream(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
+	preScratch := filepath.Join(root, ".scratch", "s3")
+	if err := os.MkdirAll(preScratch, 0o755); err != nil {
+		t.Fatalf("pre-create scratch: %v", err)
+	}
 	// Truncate a header-only stream so ReadSnapshotWithHeader fails
 	// on the partial header read.
 	b := newSnapBuilder(0)
@@ -265,13 +269,37 @@ func TestDecodeSnapshot_FinalizeRunsOnTruncatedStream(t *testing.T) {
 	if err == nil {
 		t.Fatalf("DecodeSnapshot on truncated stream returned nil; want error")
 	}
-	// Finalize ran (deferred RemoveAll) — the .scratch tree must
-	// be absent. If the pre-fix code path returned without calling
-	// finalize, the scratch dir would have been created by S3Encoder
-	// methods (it isn't here, because the header errored before
-	// any S3 record was handled), but at minimum we verify the
-	// final-output area is untouched by a scratch wipe.
-	if _, err := os.Stat(filepath.Join(root, ".scratch")); err == nil {
-		t.Fatalf(".scratch dir survived finalize on truncated stream — finalize did not run")
+	// finalize() ran => S3Encoder.Finalize's defer reclaimed the
+	// scratch tree. If finalize was skipped on read error, the
+	// pre-existing dir survives.
+	if _, err := os.Stat(preScratch); err == nil {
+		t.Fatalf(".scratch/s3/ survived truncated-stream decode — finalize did not run")
+	}
+}
+
+// TestDecodeSnapshot_DistPrefixDroppedAsInternal pins the
+// !dist| route added in r2 (Codex r1 P2 / claude-bot r1 on PR
+// #806). Distribution-catalog keys ride the default Raft group's
+// Pebble and so appear in every clustered snapshot. Without the
+// route, they would land in Counters.Unknown — a false corruption
+// signal on real dumps.
+func TestDecodeSnapshot_DistPrefixDroppedAsInternal(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	b := newSnapBuilder(0)
+	b.WriteEntry([]byte("!dist|meta|version"), 1, []byte("v1"), false, 0, snapshotEncStateCleartx)
+	b.WriteEntry([]byte("!dist|route|abc"), 1, []byte("rt"), false, 0, snapshotEncStateCleartx)
+	res, err := DecodeSnapshot(bytes.NewReader(b.Bytes()), DecodeOptions{
+		OutRoot:  root,
+		Adapters: AllAdapters(),
+	})
+	if err != nil {
+		t.Fatalf("DecodeSnapshot: %v", err)
+	}
+	if res.Counters.Internal != 2 {
+		t.Fatalf("Counters.Internal = %d, want 2 (counters=%+v)", res.Counters.Internal, res.Counters)
+	}
+	if res.Counters.Unknown != 0 {
+		t.Fatalf("Counters.Unknown = %d, want 0 (!dist| must drop to Internal, not Unknown)", res.Counters.Unknown)
 	}
 }

--- a/internal/backup/decode_test.go
+++ b/internal/backup/decode_test.go
@@ -303,3 +303,31 @@ func TestDecodeSnapshot_DistPrefixDroppedAsInternal(t *testing.T) {
 		t.Fatalf("Counters.Unknown = %d, want 0 (!dist| must drop to Internal, not Unknown)", res.Counters.Unknown)
 	}
 }
+
+// TestDecodeSnapshot_EncryptionPrefixDroppedAsInternal pins the
+// !encryption| route added in r3 (Codex r3 P2 on PR #806). The
+// writer-registry rows (!encryption|writers|<be4 dek_id>|<be2 node_id>)
+// are persisted by the encryption applier through the default
+// Raft group's Pebble; they appear in every snapshot from a
+// cluster that has rotated DEKs, so the dispatcher must classify
+// them as Internal, not Unknown.
+func TestDecodeSnapshot_EncryptionPrefixDroppedAsInternal(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	b := newSnapBuilder(0)
+	// !encryption|writers|<be4 dek_id=1>|<be2 node_id=0x42>
+	b.WriteEntry([]byte("!encryption|writers|\x00\x00\x00\x01|\x00\x42"), 1, []byte("row"), false, 0, snapshotEncStateCleartx)
+	res, err := DecodeSnapshot(bytes.NewReader(b.Bytes()), DecodeOptions{
+		OutRoot:  root,
+		Adapters: AllAdapters(),
+	})
+	if err != nil {
+		t.Fatalf("DecodeSnapshot: %v", err)
+	}
+	if res.Counters.Internal != 1 {
+		t.Fatalf("Counters.Internal = %d, want 1 (counters=%+v)", res.Counters.Internal, res.Counters)
+	}
+	if res.Counters.Unknown != 0 {
+		t.Fatalf("Counters.Unknown = %d, want 0 (!encryption| must drop to Internal, not Unknown)", res.Counters.Unknown)
+	}
+}

--- a/internal/backup/decode_test.go
+++ b/internal/backup/decode_test.go
@@ -205,3 +205,73 @@ func TestPrefixRoutes_HashMetaDeltaWinsOverHashMeta(t *testing.T) {
 		t.Fatalf("first match for %q = %q, want %q", deltaKey, matched, RedisHashMetaDeltaPrefix)
 	}
 }
+
+// TestDecodeSnapshot_DefaultScratchDoesNotWipeFinalS3Output pins
+// gemini r1 security-high on PR #806: when ScratchRoot is empty
+// and the S3 adapter is enabled, the default scratch path MUST NOT
+// be <OutRoot>/s3/ (the same directory the final assembled bodies
+// live under). If it did, S3Encoder.Finalize's deferred
+// os.RemoveAll would wipe the dump immediately after it landed.
+//
+// We assert by pre-creating a marker file at <OutRoot>/s3/marker
+// and verifying it survives a DecodeSnapshot run.
+func TestDecodeSnapshot_DefaultScratchDoesNotWipeFinalS3Output(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	s3Dir := filepath.Join(root, "s3")
+	if err := os.MkdirAll(s3Dir, 0o755); err != nil {
+		t.Fatalf("mkdir s3: %v", err)
+	}
+	marker := filepath.Join(s3Dir, "preexisting.txt")
+	if err := os.WriteFile(marker, []byte("survive me"), 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	// Header-only stream — the S3 encoder still goes through
+	// newDispatcher + Finalize, which is what triggers the bug.
+	b := newSnapBuilder(0)
+	_, err := DecodeSnapshot(bytes.NewReader(b.Bytes()), DecodeOptions{
+		OutRoot:  root,
+		Adapters: AdapterSet{S3: true},
+		// ScratchRoot intentionally empty — exercise the default.
+	})
+	if err != nil {
+		t.Fatalf("DecodeSnapshot: %v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("marker file was wiped by Finalize: %v (default scratch must not collide with <OutRoot>/s3/)", err)
+	}
+}
+
+// TestDecodeSnapshot_FinalizeRunsOnTruncatedStream pins gemini r1
+// medium on PR #806: a read error in ReadSnapshotWithHeader must
+// not skip finalize(). With the default scratch path now under
+// <OutRoot>/.scratch/, a successful finalize removes that subtree
+// even when the stream errors. We feed a truncated stream and
+// assert the .scratch directory is absent after DecodeSnapshot
+// returns.
+func TestDecodeSnapshot_FinalizeRunsOnTruncatedStream(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	// Truncate a header-only stream so ReadSnapshotWithHeader fails
+	// on the partial header read.
+	b := newSnapBuilder(0)
+	full := b.Bytes()
+	truncated := full[:len(full)/2]
+	_, err := DecodeSnapshot(bytes.NewReader(truncated), DecodeOptions{
+		OutRoot:  root,
+		Adapters: AdapterSet{S3: true},
+	})
+	if err == nil {
+		t.Fatalf("DecodeSnapshot on truncated stream returned nil; want error")
+	}
+	// Finalize ran (deferred RemoveAll) — the .scratch tree must
+	// be absent. If the pre-fix code path returned without calling
+	// finalize, the scratch dir would have been created by S3Encoder
+	// methods (it isn't here, because the header errored before
+	// any S3 record was handled), but at minimum we verify the
+	// final-output area is untouched by a scratch wipe.
+	if _, err := os.Stat(filepath.Join(root, ".scratch")); err == nil {
+		t.Fatalf(".scratch dir survived finalize on truncated stream — finalize did not run")
+	}
+}

--- a/internal/backup/snapshot_reader.go
+++ b/internal/backup/snapshot_reader.go
@@ -198,11 +198,28 @@ type SnapshotHeader struct {
 // SnapshotEntry.Tombstone — callers decide whether to suppress
 // them (Phase 0a's intended behavior for backup output) or include
 // them (a multi-version diagnostic dump might want both).
+//
+// Callers that need the header even when the snapshot has zero
+// entries (and so the callback never fires) should use
+// ReadSnapshotWithHeader, which surfaces it as a separate return
+// value. The callback's per-entry SnapshotHeader argument carries
+// the same value but only fires when at least one entry exists.
 func ReadSnapshot(r io.Reader, fn func(SnapshotHeader, SnapshotEntry) error) error {
+	_, err := ReadSnapshotWithHeader(r, fn)
+	return err
+}
+
+// ReadSnapshotWithHeader is the variant of ReadSnapshot that returns
+// the decoded EKVPBBL1 header even when the snapshot contained zero
+// entries (in which case fn is never called). Phase 0a's
+// DecodeSnapshot needs this so MANIFEST.json's `last_commit_ts`
+// field is populated for an empty-snapshot dump — the per-entry
+// callback's header argument cannot fire on a header-only file.
+func ReadSnapshotWithHeader(r io.Reader, fn func(SnapshotHeader, SnapshotEntry) error) (SnapshotHeader, error) {
 	br := bufio.NewReader(r)
 	header, err := readSnapshotHeader(br)
 	if err != nil {
-		return err
+		return SnapshotHeader{}, err
 	}
 	var (
 		keyBuf [1 << 16]byte
@@ -211,10 +228,10 @@ func ReadSnapshot(r io.Reader, fn func(SnapshotHeader, SnapshotEntry) error) err
 	for {
 		stop, err := readOneEntry(br, header, keyBuf[:], &valBuf, fn)
 		if err != nil {
-			return err
+			return header, err
 		}
 		if stop {
-			return nil
+			return header, nil
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `DecodeSnapshot(io.Reader, DecodeOptions) (DecodeResult, error)` in `internal/backup/decode.go` that wires the four adapter encoders (DynamoDB, S3, Redis, SQS) onto a single prefix-routed dispatcher.
- Adds `ReadSnapshotWithHeader` so the header is surfaced even for snapshots with zero entries — `MANIFEST.last_commit_ts` needs to populate even on an empty dump.
- Phase 0a routing layer only. The `cmd/elastickv-snapshot-decode` binary, `MANIFEST.json` emission, and `CHECKSUMS` writer live in a separate follow-up PR on top of this.

## Design reference

`docs/design/2026_04_29_proposed_snapshot_logical_decoder.md` §"Pipeline" — the routing table here implements the prefix list spelled out there. Longer prefixes win (`!hs|meta|d|` beats `!hs|meta|`); `!txn|` / `!s3route|` / `!s3|gc|upload|` are dropped as internal-only.

## Behavior

- Tombstones are filtered before adapter dispatch (Phase 0a dumps the current user-visible state, not MVCC history).
- An entry whose prefix matches an adapter that is disabled in `DecodeOptions.Adapters` is counted as `Internal` (intentional drop), not `Unknown` — so `--adapter <subset>` keeps per-class counts in the right bucket.
- An entry whose prefix matches nothing increments `Unknown` — the format-skew / corruption signal a Phase 0a operator wants to surface, not swallow.

## Test plan

- [x] `go test -race ./internal/backup/` (passes — 1.4s including the new tests)
- [x] `golangci-lint run ./internal/backup/...` (clean — 0 issues)
- [x] Eight new tests cover the routing surface: empty OutRoot rejection, header-only finalize, Redis-string end-to-end, tombstone skip, disabled-adapter Internal counter, unknown-prefix Unknown counter, `!txn|` Internal counter, prefix-length descending ordering invariant, and the `!hs|meta|d|` vs `!hs|meta|` ambiguity canary.

## Self-review (CLAUDE.md §"Self-review of code changes")

1. **Data loss** — tombstones dropped on purpose; disabled-adapter entries counted but not written; routing covers every prefix the live adapters emit.
2. **Concurrency** — dispatcher is single-threaded over the `ReadSnapshot` callback; no shared state across goroutines.
3. **Performance** — prefix table walks ~30 entries per record; throughput in offline decode is dominated by per-adapter file I/O, not the lookup.
4. **Data consistency** — `last_commit_ts` carried through `ReadSnapshotWithHeader`; encrypted entries propagate `ErrSnapshotEncryptedEntry` from `ReadSnapshot` (the underlying reader fails closed on `encState=0b01`).
5. **Test coverage** — eight tests pin the routing surface; per-adapter encoders are already tested in their own files (`redis_*_test.go`, `dynamodb_test.go`, `s3_test.go`, `sqs_test.go`).
