### PR TITLE
backup: cmd/elastickv-snapshot-decode CLI + CHECKSUMS writer

### DIFF
--- a/cmd/elastickv-snapshot-decode/main.go
+++ b/cmd/elastickv-snapshot-decode/main.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -278,15 +279,35 @@ func emitManifest(cfg *config, res backup.DecodeResult) error {
 	if cfg.bundleJSONL {
 		m.DynamoDBLayout = backup.DynamoDBLayoutJSONL
 	}
-	out, err := os.Create(cfg.outputRoot + "/MANIFEST.json") //nolint:gosec // operator-supplied path
+	// filepath.Join over `+ "/"` so the manifest path uses the
+	// platform separator (gemini r1 medium on PR #810).
+	out, err := os.Create(filepath.Join(cfg.outputRoot, "MANIFEST.json")) //nolint:gosec // operator-supplied path
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	defer func() { _ = out.Close() }()
+	// Surface Close errors instead of swallowing them: on a
+	// filesystem that delays writeback until Close (NFS, some
+	// FUSE mounts), the write succeeds but the buffered-data
+	// flush failure shows up only at Close time. Without this
+	// surface, a manifest that was never durably written would
+	// pass the cmd's error-return contract and the dump-tree
+	// invariant ("MANIFEST.json is on disk") would silently
+	// fail. Gemini r1 medium on PR #810. Sync runs before Close
+	// so the explicit fsync is the authoritative durability
+	// signal; Close's role is just to surface the kernel's
+	// per-fd cleanup result.
 	if err := backup.WriteManifest(out, m); err != nil {
+		_ = out.Close()
 		return errors.WithStack(err)
 	}
-	return errors.WithStack(out.Sync())
+	if err := out.Sync(); err != nil {
+		_ = out.Close()
+		return errors.WithStack(err)
+	}
+	if err := out.Close(); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
 }
 
 // populateAdapterScopes returns a non-nil pointer for every enabled

--- a/cmd/elastickv-snapshot-decode/main.go
+++ b/cmd/elastickv-snapshot-decode/main.go
@@ -1,0 +1,330 @@
+// Command elastickv-snapshot-decode is the Phase 0a snapshot
+// decoder described in
+// docs/design/2026_04_29_proposed_snapshot_logical_decoder.md.
+//
+// It reads a Pebble snapshot (`.fsm`) emitted by the live FSM
+// (store/lsm_store.go) and writes a vendor-independent per-adapter
+// directory tree rooted at --output. The output tree carries a
+// MANIFEST.json describing the dump and a sha256sum(1)-compatible
+// CHECKSUMS file the operator can verify with stock UNIX tooling
+// — `sha256sum -c CHECKSUMS` from the dump root suffices, with no
+// elastickv binary involved.
+//
+// Phase 0a is offline-only. The tool needs a `.fsm` on disk; it
+// does not talk to a running cluster. Phase 1 (separate design)
+// adds a live-cluster extraction path that produces the same
+// directory tree from a pinned read_ts.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/bootjp/elastickv/internal/backup"
+	"github.com/cockroachdb/errors"
+)
+
+// defaultOutputDirMode mirrors the permissions every backup-package
+// encoder uses when it creates per-adapter subdirectories. Kept on
+// the CLI side so an operator who wants a more restrictive umask can
+// pre-create the output root before running the decoder; the
+// MkdirAll call below is a no-op when the directory already exists.
+const defaultOutputDirMode = 0o755
+
+// version is stamped via -ldflags "-X main.version=<git-sha>" by
+// the build pipeline. Phase 0a copies it into MANIFEST.json's
+// elastickv_version field so a downstream restore-tool author
+// knows which release-vintage of the elastickv source produced the
+// dump.
+var version = "dev"
+
+func main() {
+	if err := run(os.Args[1:], os.Stderr); err != nil {
+		fmt.Fprintf(os.Stderr, "elastickv-snapshot-decode: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// run is the testable entrypoint: argv slice in, error out. Phase 0a's
+// tests drive it directly (no os.Exit + no signal handling) so they
+// can assert on the output tree shape.
+func run(argv []string, logSink io.Writer) error {
+	cfg, err := parseFlags(argv)
+	if err != nil {
+		return err
+	}
+	logger := slog.New(slog.NewTextHandler(logSink, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	return decodeOne(cfg, logger)
+}
+
+// config carries the parsed CLI flags. Kept separate from
+// backup.DecodeOptions so the CLI can layer flags the package does
+// not need (cluster_id, source-path bookkeeping for MANIFEST,
+// log-format) without contaminating the library.
+type config struct {
+	inputPath  string
+	outputRoot string
+
+	adapters backup.AdapterSet
+
+	includeIncompleteUploads bool
+	includeOrphans           bool
+	preserveSQSVisibility    bool
+	includeSQSSideRecords    bool
+	renameCollisions         bool
+	bundleJSONL              bool
+
+	clusterID string
+}
+
+// parseFlags lifts argv into a config. The default adapter set is
+// "everything"; --adapter overrides with a comma-separated list.
+func parseFlags(argv []string) (*config, error) {
+	fs := flag.NewFlagSet("elastickv-snapshot-decode", flag.ContinueOnError)
+	fs.SetOutput(io.Discard) // we surface errors via the returned error chain
+
+	var (
+		inputPath  string
+		outputRoot string
+		adapterCSV string
+		bundleMode string
+		clusterID  string
+
+		includeIncompleteUploads bool
+		includeOrphans           bool
+		preserveSQSVisibility    bool
+		includeSQSSideRecords    bool
+		renameCollisions         bool
+	)
+	fs.StringVar(&inputPath, "input", "", "Path to the .fsm snapshot file (required)")
+	fs.StringVar(&outputRoot, "output", "", "Destination directory tree root (required)")
+	fs.StringVar(&adapterCSV, "adapter", "dynamodb,s3,redis,sqs", "Comma-separated subset of adapters to emit")
+	fs.StringVar(&bundleMode, "dynamodb-bundle-mode", "per-item", "DynamoDB item layout: per-item | jsonl")
+	fs.StringVar(&clusterID, "cluster-id", "", "Cluster identifier to stamp into MANIFEST.json (optional)")
+	fs.BoolVar(&includeIncompleteUploads, "include-incomplete-uploads", false, "Emit in-flight S3 multipart uploads under _incomplete_uploads/")
+	fs.BoolVar(&includeOrphans, "include-orphans", false, "Emit pre-generation S3 orphan blobs under _orphans/")
+	fs.BoolVar(&preserveSQSVisibility, "preserve-sqs-visibility", false, "Carry live SQS visibility-state fields into the dump instead of zeroing them")
+	fs.BoolVar(&includeSQSSideRecords, "include-sqs-side-records", false, "Emit SQS dedup/group/vis side records under _internals/")
+	fs.BoolVar(&renameCollisions, "rename-collisions", false, "Rename user S3 keys ending in .elastickv-meta.json instead of failing")
+	if err := fs.Parse(argv); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if inputPath == "" {
+		return nil, errors.New("--input is required")
+	}
+	if outputRoot == "" {
+		return nil, errors.New("--output is required")
+	}
+	adapters, err := parseAdapterSet(adapterCSV)
+	if err != nil {
+		return nil, err
+	}
+	bundleJSONL, err := parseBundleMode(bundleMode)
+	if err != nil {
+		return nil, err
+	}
+	return &config{
+		inputPath:                inputPath,
+		outputRoot:               outputRoot,
+		adapters:                 adapters,
+		includeIncompleteUploads: includeIncompleteUploads,
+		includeOrphans:           includeOrphans,
+		preserveSQSVisibility:    preserveSQSVisibility,
+		includeSQSSideRecords:    includeSQSSideRecords,
+		renameCollisions:         renameCollisions,
+		bundleJSONL:              bundleJSONL,
+		clusterID:                clusterID,
+	}, nil
+}
+
+// parseAdapterSet decodes a comma-separated adapter list.
+// "all" is accepted as shorthand; unknown names surface as a hard
+// error so a typo does not silently disable an adapter.
+func parseAdapterSet(csv string) (backup.AdapterSet, error) {
+	if csv == "" || csv == "all" {
+		return backup.AllAdapters(), nil
+	}
+	var set backup.AdapterSet
+	for _, raw := range strings.Split(csv, ",") {
+		if err := applyAdapterName(strings.TrimSpace(raw), &set); err != nil {
+			return backup.AdapterSet{}, err
+		}
+	}
+	if set == (backup.AdapterSet{}) {
+		return backup.AdapterSet{}, errors.New("--adapter selected zero adapters")
+	}
+	return set, nil
+}
+
+// applyAdapterName flips the matching field of set on. Extracted
+// from parseAdapterSet so the parent function stays under the
+// project's cyclop=10 ceiling.
+func applyAdapterName(name string, set *backup.AdapterSet) error {
+	switch name {
+	case "dynamodb":
+		set.DynamoDB = true
+	case "s3":
+		set.S3 = true
+	case "redis":
+		set.Redis = true
+	case "sqs":
+		set.SQS = true
+	case "":
+		// allow trailing comma
+	default:
+		return errors.Wrap(ErrUnknownAdapter, name)
+	}
+	return nil
+}
+
+// ErrUnknownAdapter is returned by parseAdapterSet when the CSV
+// list contains a name we do not recognise. Surfaced as a typed
+// sentinel so the CLI's flag-validation tests can assert on it
+// without string matching.
+var ErrUnknownAdapter = errors.New("unknown adapter name")
+
+// ErrBundleModeInvalid is returned by parseBundleMode when the
+// flag value is neither per-item nor jsonl.
+var ErrBundleModeInvalid = errors.New("invalid --dynamodb-bundle-mode")
+
+// parseBundleMode validates the --dynamodb-bundle-mode value. The
+// underlying encoder rejects bundleJSONL=true at Finalize time
+// (the JSONL path is a Phase 0b follow-up), but we still accept
+// the flag now so the CLI surface is stable across that change.
+func parseBundleMode(mode string) (bool, error) {
+	switch mode {
+	case "per-item", "":
+		return false, nil
+	case "jsonl":
+		return true, nil
+	default:
+		return false, errors.Wrap(ErrBundleModeInvalid, mode)
+	}
+}
+
+// decodeOne runs the dispatcher against the configured input and
+// writes MANIFEST.json + CHECKSUMS into the output tree.
+func decodeOne(cfg *config, logger *slog.Logger) error {
+	if err := os.MkdirAll(cfg.outputRoot, defaultOutputDirMode); err != nil {
+		return errors.WithStack(err)
+	}
+	in, err := os.Open(cfg.inputPath) //nolint:gosec // operator-supplied path
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer func() { _ = in.Close() }()
+
+	res, err := backup.DecodeSnapshot(in, backup.DecodeOptions{
+		OutRoot:                  cfg.outputRoot,
+		Adapters:                 cfg.adapters,
+		IncludeIncompleteUploads: cfg.includeIncompleteUploads,
+		IncludeOrphans:           cfg.includeOrphans,
+		RenameS3Collisions:       cfg.renameCollisions,
+		PreserveSQSVisibility:    cfg.preserveSQSVisibility,
+		IncludeSQSSideRecords:    cfg.includeSQSSideRecords,
+		DynamoDBBundleJSONL:      cfg.bundleJSONL,
+		WarnSink:                 warnSinkFor(logger),
+	})
+	if err != nil {
+		return errors.Wrapf(err, "decode %s", cfg.inputPath)
+	}
+	logger.Info("snapshot decoded",
+		"input", cfg.inputPath,
+		"output", cfg.outputRoot,
+		"entries", res.Counters.Total,
+		"dynamodb", res.Counters.DynamoDB,
+		"s3", res.Counters.S3,
+		"redis", res.Counters.Redis,
+		"sqs", res.Counters.SQS,
+		"tombstone", res.Counters.Tombstone,
+		"internal", res.Counters.Internal,
+		"unknown", res.Counters.Unknown,
+		"last_commit_ts", res.Header.LastCommitTS)
+
+	if err := emitManifest(cfg, res); err != nil {
+		return err
+	}
+	if err := backup.WriteChecksums(cfg.outputRoot); err != nil {
+		return errors.Wrap(err, "write CHECKSUMS")
+	}
+	return nil
+}
+
+// emitManifest writes MANIFEST.json under cfg.outputRoot. Source
+// metadata (FSM path and parsed snapshot_index) come from the CLI
+// invocation; last_commit_ts comes from the snapshot header the
+// dispatcher surfaces.
+func emitManifest(cfg *config, res backup.DecodeResult) error {
+	m := backup.NewPhase0SnapshotManifest(time.Now())
+	m.ElastickvVersion = version
+	m.ClusterID = cfg.clusterID
+	m.LastCommitTS = res.Header.LastCommitTS
+	if idx, err := backup.SnapshotIndexFromPath(cfg.inputPath); err == nil {
+		m.SnapshotIndex = idx
+	}
+	m.Source = &backup.Source{FSMPath: cfg.inputPath}
+	m.Adapters = populateAdapterScopes(cfg.adapters, res)
+	m.Exclusions = &backup.Exclusions{
+		IncludeIncompleteUploads: cfg.includeIncompleteUploads,
+		IncludeOrphans:           cfg.includeOrphans,
+		PreserveSQSVisibility:    cfg.preserveSQSVisibility,
+		IncludeSQSSideRecords:    cfg.includeSQSSideRecords,
+	}
+	if cfg.bundleJSONL {
+		m.DynamoDBLayout = backup.DynamoDBLayoutJSONL
+	}
+	out, err := os.Create(cfg.outputRoot + "/MANIFEST.json") //nolint:gosec // operator-supplied path
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer func() { _ = out.Close() }()
+	if err := backup.WriteManifest(out, m); err != nil {
+		return errors.WithStack(err)
+	}
+	return errors.WithStack(out.Sync())
+}
+
+// populateAdapterScopes returns a non-nil pointer for every enabled
+// adapter. Scope-name enumeration (per-table, per-bucket, per-DB,
+// per-queue) is a follow-up — Phase 0a's MANIFEST stamps an empty
+// Adapter{} for each enabled adapter so the on-disk shape is
+// already correct when scope enumeration lands.
+//
+// An adapter that was enabled but produced zero entries is still
+// returned as a non-nil pointer with empty scope arrays. The
+// "scope-everything-excluded" state is meaningful (operator passed
+// --adapter dynamodb but the snapshot had no DynamoDB data) and
+// distinct from "adapter not enabled".
+func populateAdapterScopes(set backup.AdapterSet, _ backup.DecodeResult) *backup.Adapters {
+	a := &backup.Adapters{}
+	if set.DynamoDB {
+		a.DynamoDB = &backup.Adapter{}
+	}
+	if set.S3 {
+		a.S3 = &backup.Adapter{}
+	}
+	if set.Redis {
+		a.Redis = &backup.Adapter{}
+	}
+	if set.SQS {
+		a.SQS = &backup.Adapter{}
+	}
+	return a
+}
+
+// warnSinkFor adapts a *slog.Logger into the warn-sink callback
+// the per-adapter encoders use. Event names ("redis_orphan_ttl",
+// "ddb_orphan_items", ...) become the slog `event` field; the
+// variadic key=value pairs are passed through verbatim so the
+// stable adapter-side keys stay stable on the way out.
+func warnSinkFor(logger *slog.Logger) func(event string, fields ...any) {
+	return func(event string, fields ...any) {
+		args := append([]any{"event", event}, fields...)
+		logger.Warn("encoder warning", args...)
+	}
+}

--- a/cmd/elastickv-snapshot-decode/main_test.go
+++ b/cmd/elastickv-snapshot-decode/main_test.go
@@ -1,0 +1,282 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/backup"
+	"github.com/cockroachdb/errors"
+)
+
+// snapshot constants — duplicated from internal/backup so the test
+// can synthesise a wire-format snapshot without exporting the
+// package-private encoding helpers. Changes to the live format
+// surface here as a test failure, which is the early signal we
+// want from the CLI's golden-path test.
+const (
+	pebbleSnapshotMagic     = "EKVPBBL1"
+	snapshotTSSize          = 8
+	snapshotValueHeaderSize = 9
+)
+
+// TestRun_DecodesSimpleRedisStringSnapshot drives the CLI from
+// argv-in to dump-tree-out: a synthetic 1-entry .fsm round-trips
+// through run() and produces the expected MANIFEST.json,
+// CHECKSUMS, and redis/db_0/strings/<key>.bin.
+func TestRun_DecodesSimpleRedisStringSnapshot(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	in := filepath.Join(dir, "0000000000000064.fsm")
+	out := filepath.Join(dir, "out")
+	mustWriteFSM(t, in, redisStringSnapshot(t, "greeting", "hello"))
+
+	var stderr bytes.Buffer
+	if err := run([]string{
+		"-input", in,
+		"-output", out,
+		"-cluster-id", "ek-test",
+	}, &stderr); err != nil {
+		t.Fatalf("run: %v\nstderr=%s", err, stderr.String())
+	}
+	assertBlobMatches(t, filepath.Join(out, "redis", "db_0", "strings", "greeting.bin"), "hello")
+	assertManifest(t, filepath.Join(out, "MANIFEST.json"), manifestShape{
+		Phase:         "phase0-snapshot-decode",
+		SnapshotIndex: 64,
+		ClusterID:     "ek-test",
+	})
+	if _, err := os.Stat(filepath.Join(out, backup.CHECKSUMSFilename)); err != nil {
+		t.Fatalf("CHECKSUMS missing: %v", err)
+	}
+	if err := backup.VerifyChecksums(out); err != nil {
+		t.Fatalf("VerifyChecksums: %v", err)
+	}
+}
+
+// assertBlobMatches reads path and asserts its bytes equal want.
+// Extracted from the parent test so the parent stays under the
+// project's cyclop=10 ceiling.
+func assertBlobMatches(t *testing.T, path, want string) {
+	t.Helper()
+	body, err := os.ReadFile(path) //nolint:gosec // test path
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(body) != want {
+		t.Fatalf("%s = %q, want %q", path, body, want)
+	}
+}
+
+// assertManifest parses MANIFEST.json at path and asserts the
+// fields the test cares about. Extracted from the parent test for
+// the same cyclop reason.
+func assertManifest(t *testing.T, path string, want manifestShape) {
+	t.Helper()
+	body, err := os.ReadFile(path) //nolint:gosec // test path
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var got manifestShape
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal %s: %v\nbody=%s", path, err, body)
+	}
+	if got.Phase != want.Phase {
+		t.Fatalf("phase = %q, want %q", got.Phase, want.Phase)
+	}
+	if got.SnapshotIndex != want.SnapshotIndex {
+		t.Fatalf("snapshot_index = %d, want %d", got.SnapshotIndex, want.SnapshotIndex)
+	}
+	if got.ClusterID != want.ClusterID {
+		t.Fatalf("cluster_id = %q, want %q", got.ClusterID, want.ClusterID)
+	}
+}
+
+// TestRun_RejectsMissingInput pins the flag-validation surface so a
+// missing --input prints a useful error rather than panicking.
+func TestRun_RejectsMissingInput(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	err := run([]string{"-output", filepath.Join(dir, "out")}, io.Discard)
+	if err == nil {
+		t.Fatalf("expected error for missing --input")
+	}
+}
+
+// TestRun_RejectsUnknownAdapter pins that a typo in --adapter
+// surfaces as a hard error instead of silently disabling the
+// adapter (Phase 0a is fail-noisy on operator misuse).
+func TestRun_RejectsUnknownAdapter(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	in := filepath.Join(dir, "1.fsm")
+	out := filepath.Join(dir, "out")
+	mustWriteFSM(t, in, emptyFSM(t))
+	err := run([]string{
+		"-input", in,
+		"-output", out,
+		"-adapter", "redis,bogus",
+	}, io.Discard)
+	if err == nil {
+		t.Fatalf("expected error for unknown adapter")
+	}
+}
+
+// TestRun_RejectsZeroAdapters pins that --adapter "" is a hard
+// error — silently producing an empty dump is worse than telling
+// the operator their flag set selected nothing.
+func TestRun_RejectsZeroAdapters(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	in := filepath.Join(dir, "1.fsm")
+	out := filepath.Join(dir, "out")
+	mustWriteFSM(t, in, emptyFSM(t))
+	err := run([]string{
+		"-input", in,
+		"-output", out,
+		"-adapter", " ,,",
+	}, io.Discard)
+	if err == nil {
+		t.Fatalf("expected error for zero-adapter selection")
+	}
+}
+
+// TestRun_UnparseableFilenameLeavesIndexZero pins the soft-failure
+// path documented in source.go: an operator-named .fsm without the
+// `<uint64>.fsm` convention still decodes; MANIFEST.snapshot_index
+// is omitted (zero value, omitempty).
+func TestRun_UnparseableFilenameLeavesIndexZero(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	in := filepath.Join(dir, "from-prod.fsm")
+	out := filepath.Join(dir, "out")
+	mustWriteFSM(t, in, emptyFSM(t))
+	if err := run([]string{"-input", in, "-output", out}, io.Discard); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	manifestBytes, err := os.ReadFile(filepath.Join(out, "MANIFEST.json"))
+	if err != nil {
+		t.Fatalf("read MANIFEST: %v", err)
+	}
+	var m manifestShape
+	if err := json.Unmarshal(manifestBytes, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m.SnapshotIndex != 0 {
+		t.Fatalf("snapshot_index = %d, want 0 for unparseable filename", m.SnapshotIndex)
+	}
+}
+
+// manifestShape is the minimal subset of MANIFEST.json the CLI's
+// golden tests check. Avoiding a hard import of backup.Manifest
+// keeps the test surface tight to what the CLI actually stamps.
+type manifestShape struct {
+	Phase         string `json:"phase"`
+	SnapshotIndex uint64 `json:"snapshot_index,omitempty"`
+	ClusterID     string `json:"cluster_id,omitempty"`
+}
+
+// mustWriteFSM writes body to path, t.Fatal-ing on any error. The
+// returned snapshot is plain bytes; the parent test wrote it via
+// the synthesise-snapshot helpers below.
+func mustWriteFSM(t *testing.T, path string, body []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// emptyFSM returns a header-only snapshot — magic + zero
+// last_commit_ts. Used to exercise the CLI's flag-validation
+// surface without spending bytes on entry encoding.
+func emptyFSM(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	buf.WriteString(pebbleSnapshotMagic)
+	if err := binary.Write(&buf, binary.LittleEndian, uint64(0)); err != nil {
+		t.Fatalf("write ts: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// redisStringSnapshot returns a one-entry snapshot whose key is
+// `!redis|str|<userKey>` and whose value is the magic-prefixed
+// no-TTL string-value envelope the live Redis adapter writes (see
+// adapter/redis_storage_codec.go).
+func redisStringSnapshot(t *testing.T, userKey, body string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	buf.WriteString(pebbleSnapshotMagic)
+	if err := binary.Write(&buf, binary.LittleEndian, uint64(1)); err != nil {
+		t.Fatalf("write ts: %v", err)
+	}
+	encKey := append([]byte(backup.RedisStringPrefix+userKey), make([]byte, snapshotTSSize)...) //nolint:gocritic // explicit append for clarity
+	// invTS = ^1
+	binary.BigEndian.PutUint64(encKey[len(encKey)-snapshotTSSize:], ^uint64(1))
+	// value-header: flags=0 (no tombstone, no encryption), expireAt=0.
+	encVal := make([]byte, snapshotValueHeaderSize+3+len(body))
+	encVal[0] = 0
+	// 0xFF 0x01 is the live magic prefix the Redis string-value
+	// codec uses to mark a non-legacy value (internal/backup/
+	// redis_string.go: redisStrMagic / redisStrVersion). The third
+	// header byte is flags (bit 0 = redisStrHasTTL); 0 means
+	// no-TTL and the body follows immediately.
+	encVal[snapshotValueHeaderSize] = 0xFF
+	encVal[snapshotValueHeaderSize+1] = 0x01
+	encVal[snapshotValueHeaderSize+2] = 0x00
+	copy(encVal[snapshotValueHeaderSize+3:], body)
+	if err := binary.Write(&buf, binary.LittleEndian, uint64(len(encKey))); err != nil {
+		t.Fatalf("write keylen: %v", err)
+	}
+	buf.Write(encKey)
+	if err := binary.Write(&buf, binary.LittleEndian, uint64(len(encVal))); err != nil {
+		t.Fatalf("write vallen: %v", err)
+	}
+	buf.Write(encVal)
+	return buf.Bytes()
+}
+
+// TestParseAdapterSet pins the CSV-to-AdapterSet conversion's
+// error reporting. The function is exported via run() only, but
+// the routing matters enough that a direct test pins the
+// per-name match table.
+func TestParseAdapterSet(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		in      string
+		want    backup.AdapterSet
+		wantErr bool
+	}{
+		{"empty defaults to all", "", backup.AllAdapters(), false},
+		{"all keyword", "all", backup.AllAdapters(), false},
+		{"single adapter", "redis", backup.AdapterSet{Redis: true}, false},
+		{"two adapters", "redis,sqs", backup.AdapterSet{Redis: true, SQS: true}, false},
+		{"trailing comma", "redis,", backup.AdapterSet{Redis: true}, false},
+		{"unknown adapter", "bogus", backup.AdapterSet{}, true},
+		{"empty list", " ,,", backup.AdapterSet{}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseAdapterSet(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("set = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+var _ = errors.New // keep the import even if assertions don't reference it directly

--- a/internal/backup/checksums.go
+++ b/internal/backup/checksums.go
@@ -72,14 +72,40 @@ func WriteChecksums(root string) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	defer func() { _ = out.Close() }()
+	if err := writeAllChecksumLines(out, entries); err != nil {
+		_ = out.Close()
+		return err
+	}
+	if err := out.Sync(); err != nil {
+		_ = out.Close()
+		return errors.WithStack(err)
+	}
+	// Surface Close errors instead of swallowing them. On NFS /
+	// some FUSE backends Close is the authoritative durability
+	// signal — writeback failures buffered after the Sync()
+	// fsync surface here, not at Write time. A swallowed Close
+	// would let the CLI declare success with a truncated or
+	// unreadable CHECKSUMS file. coderabbit Major on PR #810
+	// round 4 (same shape as the gemini r1 medium on
+	// emitManifest, applied here too).
+	if err := out.Close(); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+// writeAllChecksumLines emits the formatted CHECKSUMS rows. Split
+// out from WriteChecksums so the parent stays a thin
+// open-write-sync-close skeleton — its job is the durability
+// contract; the per-line escaping is delegated.
+func writeAllChecksumLines(w io.Writer, entries []checksumEntry) error {
 	for _, e := range entries {
 		line, prefix := formatChecksumLine(e.hex, e.relPath)
-		if _, err := fmt.Fprintf(out, "%s%s\n", prefix, line); err != nil {
+		if _, err := fmt.Fprintf(w, "%s%s\n", prefix, line); err != nil {
 			return errors.WithStack(err)
 		}
 	}
-	return errors.WithStack(out.Sync())
+	return nil
 }
 
 // formatChecksumLine builds one CHECKSUMS row using GNU coreutils

--- a/internal/backup/checksums.go
+++ b/internal/backup/checksums.go
@@ -74,11 +74,46 @@ func WriteChecksums(root string) error {
 	}
 	defer func() { _ = out.Close() }()
 	for _, e := range entries {
-		if _, err := fmt.Fprintf(out, "%s  %s\n", e.hex, e.relPath); err != nil {
+		line, prefix := formatChecksumLine(e.hex, e.relPath)
+		if _, err := fmt.Fprintf(out, "%s%s\n", prefix, line); err != nil {
 			return errors.WithStack(err)
 		}
 	}
 	return errors.WithStack(out.Sync())
+}
+
+// formatChecksumLine builds one CHECKSUMS row using GNU coreutils
+// sha256sum(1) escape conventions. When the path contains `\n`,
+// `\r`, or `\\`, sha256sum prefixes the entire line with `\\` and
+// replaces the offending bytes with `\\n` / `\\r` / `\\\\`. Phase 0a
+// emits the same shape so `sha256sum -c CHECKSUMS` from the dump
+// root parses a tampered or path-noisy filename without corrupting
+// the line-based output (codex r4 P2 on PR #810: the previous
+// `%s  %s\n` print would let a filename containing `\n` inject a
+// fake CHECKSUMS row).
+//
+// Returns (line-body, prefix). The prefix is either "" or "\\";
+// callers concatenate `prefix + body + "\n"` exactly like the
+// reference implementation.
+func formatChecksumLine(hex, relPath string) (string, string) {
+	if !strings.ContainsAny(relPath, "\n\r\\") {
+		return hex + "  " + relPath, ""
+	}
+	var sb strings.Builder
+	sb.Grow(len(relPath) + 4) //nolint:mnd // small heuristic to avoid early grow
+	for _, r := range relPath {
+		switch r {
+		case '\n':
+			sb.WriteString(`\n`)
+		case '\r':
+			sb.WriteString(`\r`)
+		case '\\':
+			sb.WriteString(`\\`)
+		default:
+			sb.WriteRune(r)
+		}
+	}
+	return hex + "  " + sb.String(), `\`
 }
 
 // checksumEntry is one row of the CHECKSUMS file.
@@ -313,10 +348,22 @@ func validateChecksumRelPath(rel string) (string, error) {
 var ErrChecksumsPathTraversal = errors.New("backup: CHECKSUMS path escapes dump root")
 
 // splitChecksumLine parses one sha256sum(1) line of the form
-// `<hex>  <relative-path>`. Returns (hex, path, ok). Lines with the
-// wrong shape are reported as not-ok so the caller can surface a
-// CHECKSUMS-corruption error rather than ingest garbage.
+// `<hex>  <relative-path>` (or its `\\`-prefixed escaped variant
+// when the path contains `\n`/`\r`/`\\`). Returns (hex, path, ok).
+// Lines with the wrong shape are reported as not-ok so the
+// caller can surface a CHECKSUMS-corruption error rather than
+// ingest garbage.
+//
+// Escape convention mirrors GNU coreutils: a leading `\\` signals
+// that the rest of the path has `\n`/`\r`/`\\` written as the
+// two-byte sequences `\\n`, `\\r`, `\\\\`. Codex r4 P2 on PR #810:
+// without this, a filename containing `\n` would split across
+// lines and a verifier would see a bogus second row.
 func splitChecksumLine(line string) (string, string, bool) {
+	escaped := strings.HasPrefix(line, `\`)
+	if escaped {
+		line = line[1:]
+	}
 	// sha256sum's "binary" mode separates digest and filename with
 	// exactly two spaces. Some tools emit `<hex> *<path>` for
 	// binary mode; we accept both.
@@ -332,7 +379,45 @@ func splitChecksumLine(line string) (string, string, bool) {
 	if !strings.HasPrefix(rest, "  ") && !strings.HasPrefix(rest, " *") {
 		return "", "", false
 	}
-	return hexPart, rest[2:], true
+	body := rest[2:]
+	if !escaped {
+		return hexPart, body, true
+	}
+	unescaped, ok := unescapeChecksumPath(body)
+	if !ok {
+		return "", "", false
+	}
+	return hexPart, unescaped, true
+}
+
+// unescapeChecksumPath reverses formatChecksumLine's `\n`/`\r`/`\\`
+// substitutions. Returns (path, ok). An unrecognised `\<byte>` or
+// a dangling trailing `\` is treated as malformed — the line is
+// rejected at the caller via the ok=false return.
+func unescapeChecksumPath(body string) (string, bool) {
+	var sb strings.Builder
+	sb.Grow(len(body))
+	for i := 0; i < len(body); i++ {
+		if body[i] != '\\' {
+			sb.WriteByte(body[i])
+			continue
+		}
+		i++
+		if i >= len(body) {
+			return "", false
+		}
+		switch body[i] {
+		case 'n':
+			sb.WriteByte('\n')
+		case 'r':
+			sb.WriteByte('\r')
+		case '\\':
+			sb.WriteByte('\\')
+		default:
+			return "", false
+		}
+	}
+	return sb.String(), true
 }
 
 func isLowerHex(s string) bool {

--- a/internal/backup/checksums.go
+++ b/internal/backup/checksums.go
@@ -1,6 +1,7 @@
 package backup
 
 import (
+	"bufio"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -12,6 +13,17 @@ import (
 
 	"github.com/cockroachdb/errors"
 )
+
+// maxChecksumLineLen bounds the bufio.Scanner buffer for one
+// CHECKSUMS line. A well-formed entry is 64 hex chars + 2 spaces +
+// the relative path; with NAME_MAX=255 on Linux, even a
+// pathologically deep tree (255 chars × ~30 levels) stays well
+// under 8 KiB. The cap exists so a corrupt CHECKSUMS with a
+// missing newline cannot force the scanner to buffer an
+// arbitrarily-long "line" — that is the OOM vector the gemini
+// security-high finding on PR #810 flagged when the previous
+// implementation slurped the whole file via os.ReadFile.
+const maxChecksumLineLen = 8 * 1024
 
 // CHECKSUMSFilename is the on-disk name of the dump-tree-wide
 // sha256sum(1)-compatible checksum file. Stored at the dump root so
@@ -134,33 +146,117 @@ func sha256File(path string) (string, error) {
 // referenced by CHECKSUMS but missing on disk surface as the same
 // error class so a partial-restore is obvious.
 //
+// Memory: streaming. Uses bufio.Scanner with a fixed 8 KiB per-line
+// budget so a multi-million-file dump tree's CHECKSUMS file does
+// not need to fit in memory, and a corrupt CHECKSUMS without
+// newlines cannot trick us into buffering arbitrarily much (the
+// gemini security-high finding on PR #810 — the previous
+// os.ReadFile + strings.Split path materialised the whole file).
+//
+// Path safety: every CHECKSUMS line's relative-path field is
+// validated by validateChecksumRelPath before being joined with
+// root, so an adversarial CHECKSUMS shipped alongside a backup
+// (e.g. with a `../../etc/shadow` entry) cannot escape root and
+// fingerprint files the operator did not intend to expose. The
+// coderabbit critical finding on PR #810.
+//
 // Used by the Phase 0b encoder's self-test path: after encoding a
 // directory tree back into a `.fsm`, it re-runs the decoder and
 // asserts WriteChecksums + VerifyChecksums round-trip cleanly.
 func VerifyChecksums(root string) error {
-	body, err := os.ReadFile(filepath.Join(root, CHECKSUMSFilename)) //nolint:gosec // operator-supplied output dir
+	f, err := os.Open(filepath.Join(root, CHECKSUMSFilename)) //nolint:gosec // operator-supplied output dir
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	lines := strings.Split(strings.TrimRight(string(body), "\n"), "\n")
-	for i, line := range lines {
-		if line == "" {
-			continue
+	defer func() { _ = f.Close() }()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, maxChecksumLineLen), maxChecksumLineLen)
+	lineNum := 0
+	for sc.Scan() {
+		lineNum++
+		if err := verifyOneChecksumLine(root, sc.Text(), lineNum); err != nil {
+			return err
 		}
-		want, rel, ok := splitChecksumLine(line)
-		if !ok {
-			return errors.Wrapf(ErrChecksumsMalformedLine, "line %d: %q", i+1, line)
-		}
-		got, err := sha256File(filepath.Join(root, rel))
-		if err != nil {
-			return errors.Wrapf(err, "verifying %s", rel)
-		}
-		if got != want {
-			return errors.Wrapf(ErrChecksumMismatch, "%s: have %s want %s", rel, got, want)
-		}
+	}
+	if err := sc.Err(); err != nil {
+		return errors.WithStack(err)
 	}
 	return nil
 }
+
+// verifyOneChecksumLine handles a single CHECKSUMS line: parse,
+// path-validate, recompute, compare. Extracted from VerifyChecksums
+// so the parent stays under the project's cyclop ceiling and the
+// per-line failure modes (malformed shape, traversal, missing file,
+// mismatch) each surface as a distinct typed error.
+func verifyOneChecksumLine(root, line string, lineNum int) error {
+	if line == "" {
+		return nil
+	}
+	want, rel, ok := splitChecksumLine(line)
+	if !ok {
+		return errors.Wrapf(ErrChecksumsMalformedLine, "line %d: %q", lineNum, line)
+	}
+	cleaned, err := validateChecksumRelPath(rel)
+	if err != nil {
+		return errors.Wrapf(err, "line %d", lineNum)
+	}
+	got, err := sha256File(filepath.Join(root, cleaned))
+	if err != nil {
+		return errors.Wrapf(err, "verifying %s", cleaned)
+	}
+	if got != want {
+		return errors.Wrapf(ErrChecksumMismatch, "%s: have %s want %s", cleaned, got, want)
+	}
+	return nil
+}
+
+// validateChecksumRelPath rejects CHECKSUMS rows whose path field
+// could escape the dump root. The acceptance rules:
+//
+//   - absolute paths are rejected;
+//   - paths containing a `..` segment (before or after Clean) are
+//     rejected;
+//   - the cleaned form must not start with `../` (covers
+//     filepath.Clean turning `a/../../b` into `../b`);
+//   - empty / `.` paths are rejected so a malformed entry that
+//     would otherwise read the root directory itself surfaces.
+//
+// Returns the cleaned form so callers join it without redoing the
+// canonicalisation. Mirrors the same guard the S3 encoder applies
+// to bucket/object path segments before scratch-dir layout.
+func validateChecksumRelPath(rel string) (string, error) {
+	if rel == "" || rel == "." {
+		return "", errors.Wrapf(ErrChecksumsMalformedLine, "empty path field")
+	}
+	if filepath.IsAbs(rel) {
+		return "", errors.Wrapf(ErrChecksumsPathTraversal, "absolute path: %q", rel)
+	}
+	cleaned := filepath.Clean(rel)
+	// Defence in depth: Clean turns `a/b/../../../etc/passwd` into
+	// `../etc/passwd`. A leading `..` segment in the cleaned form
+	// means the relative path escaped its parent, regardless of
+	// what tricks were used to write it.
+	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		return "", errors.Wrapf(ErrChecksumsPathTraversal, "escapes root: %q", rel)
+	}
+	// `Clean` strips trailing slashes but leaves the leading
+	// separator on absolute paths intact; we already filtered
+	// those, so a remaining absolute-shaped Clean result is from
+	// inputs like `/foo` on platforms where filepath.IsAbs
+	// disagrees with filepath.Clean. Belt-and-braces.
+	if filepath.IsAbs(cleaned) {
+		return "", errors.Wrapf(ErrChecksumsPathTraversal, "absolute after Clean: %q", rel)
+	}
+	return cleaned, nil
+}
+
+// ErrChecksumsPathTraversal is returned by VerifyChecksums when a
+// CHECKSUMS line's path field would resolve outside the dump root.
+// Typed so a future verifier built on top of this package can
+// branch on errors.Is and distinguish path-shape attacks from
+// honest content-mismatch.
+var ErrChecksumsPathTraversal = errors.New("backup: CHECKSUMS path escapes dump root")
 
 // splitChecksumLine parses one sha256sum(1) line of the form
 // `<hex>  <relative-path>`. Returns (hex, path, ok). Lines with the

--- a/internal/backup/checksums.go
+++ b/internal/backup/checksums.go
@@ -1,0 +1,197 @@
+package backup
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// CHECKSUMSFilename is the on-disk name of the dump-tree-wide
+// sha256sum(1)-compatible checksum file. Stored at the dump root so
+// `sha256sum -c CHECKSUMS` from the same root verifies the dump
+// without elastickv tooling — the documented vendor-independent
+// recovery property of Phase 0a.
+const CHECKSUMSFilename = "CHECKSUMS"
+
+// ErrChecksumsMalformedLine is returned by VerifyChecksums when a
+// CHECKSUMS line does not match the expected `<hex>  <path>` shape.
+// Typed so callers can distinguish "CHECKSUMS itself corrupt" from
+// "file content tampering".
+var ErrChecksumsMalformedLine = errors.New("backup: malformed CHECKSUMS line")
+
+// ErrChecksumMismatch is returned by VerifyChecksums when a
+// recomputed digest does not match the stored value.
+var ErrChecksumMismatch = errors.New("backup: checksum mismatch")
+
+// WriteChecksums walks root recursively, computes sha256 over every
+// regular file encountered, and writes a sha256sum(1)-compatible
+// CHECKSUMS file at root/CHECKSUMS.
+//
+// Each line is `<hex>  <relative-path>\n` (two spaces, "binary"
+// mode in sha256sum vocabulary). The relative path is rooted at
+// `root` itself and uses forward-slash separators so the file is
+// portable across operating systems (sha256sum on Linux and the
+// macOS/BSD shasum tool both accept this shape).
+//
+// CHECKSUMS itself is excluded from the listing — the file is
+// written last and lists every other file in the tree.
+//
+// Determinism: the line ordering is lexicographic on the relative
+// path so two invocations on the same dump tree produce
+// byte-identical CHECKSUMS files. The design (§"CHECKSUMS") relies
+// on this for the "encode → decode round-trip is byte-identical"
+// property.
+func WriteChecksums(root string) error {
+	entries, err := collectChecksumEntries(root)
+	if err != nil {
+		return err
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].relPath < entries[j].relPath
+	})
+	out, err := os.Create(filepath.Join(root, CHECKSUMSFilename)) //nolint:gosec // operator-supplied output dir
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer func() { _ = out.Close() }()
+	for _, e := range entries {
+		if _, err := fmt.Fprintf(out, "%s  %s\n", e.hex, e.relPath); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+	return errors.WithStack(out.Sync())
+}
+
+// checksumEntry is one row of the CHECKSUMS file.
+type checksumEntry struct {
+	hex     string
+	relPath string
+}
+
+// collectChecksumEntries walks root and returns a (hex, relPath)
+// list of every regular file other than root/CHECKSUMS. Symlinks
+// are skipped — sha256sum does not follow them by default and the
+// dump tree should never contain any (the encoders write only
+// regular files).
+func collectChecksumEntries(root string) ([]checksumEntry, error) {
+	var entries []checksumEntry
+	skipPath := filepath.Join(root, CHECKSUMSFilename)
+	walkErr := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if d.IsDir() || !d.Type().IsRegular() {
+			return nil
+		}
+		if path == skipPath {
+			return nil
+		}
+		sum, err := sha256File(path)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		entries = append(entries, checksumEntry{
+			hex:     sum,
+			relPath: filepath.ToSlash(rel),
+		})
+		return nil
+	})
+	if walkErr != nil {
+		return nil, errors.WithStack(walkErr)
+	}
+	return entries, nil
+}
+
+// sha256File returns the lowercase-hex SHA-256 digest of path's
+// contents. The file is read in O(1) memory via io.Copy into the
+// hash; even multi-GB dump artifacts stream without buffering.
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path) //nolint:gosec // walker-supplied path under operator-chosen root
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", errors.WithStack(err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// VerifyChecksums reads root/CHECKSUMS, recomputes sha256 of every
+// listed file, and returns the first mismatch as an error. Files
+// referenced by CHECKSUMS but missing on disk surface as the same
+// error class so a partial-restore is obvious.
+//
+// Used by the Phase 0b encoder's self-test path: after encoding a
+// directory tree back into a `.fsm`, it re-runs the decoder and
+// asserts WriteChecksums + VerifyChecksums round-trip cleanly.
+func VerifyChecksums(root string) error {
+	body, err := os.ReadFile(filepath.Join(root, CHECKSUMSFilename)) //nolint:gosec // operator-supplied output dir
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	lines := strings.Split(strings.TrimRight(string(body), "\n"), "\n")
+	for i, line := range lines {
+		if line == "" {
+			continue
+		}
+		want, rel, ok := splitChecksumLine(line)
+		if !ok {
+			return errors.Wrapf(ErrChecksumsMalformedLine, "line %d: %q", i+1, line)
+		}
+		got, err := sha256File(filepath.Join(root, rel))
+		if err != nil {
+			return errors.Wrapf(err, "verifying %s", rel)
+		}
+		if got != want {
+			return errors.Wrapf(ErrChecksumMismatch, "%s: have %s want %s", rel, got, want)
+		}
+	}
+	return nil
+}
+
+// splitChecksumLine parses one sha256sum(1) line of the form
+// `<hex>  <relative-path>`. Returns (hex, path, ok). Lines with the
+// wrong shape are reported as not-ok so the caller can surface a
+// CHECKSUMS-corruption error rather than ingest garbage.
+func splitChecksumLine(line string) (string, string, bool) {
+	// sha256sum's "binary" mode separates digest and filename with
+	// exactly two spaces. Some tools emit `<hex> *<path>` for
+	// binary mode; we accept both.
+	const sha256HexLen = 64
+	if len(line) < sha256HexLen+3 {
+		return "", "", false
+	}
+	hexPart := line[:sha256HexLen]
+	if !isLowerHex(hexPart) {
+		return "", "", false
+	}
+	rest := line[sha256HexLen:]
+	if !strings.HasPrefix(rest, "  ") && !strings.HasPrefix(rest, " *") {
+		return "", "", false
+	}
+	return hexPart, rest[2:], true
+}
+
+func isLowerHex(s string) bool {
+	for _, r := range s {
+		isDigit := r >= '0' && r <= '9'
+		isLowerAF := r >= 'a' && r <= 'f'
+		if !isDigit && !isLowerAF {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/backup/checksums.go
+++ b/internal/backup/checksums.go
@@ -259,39 +259,46 @@ func refuseSymlinkComponents(root, rel string) error {
 var ErrChecksumsSymlinkEscape = errors.New("backup: CHECKSUMS path traverses symlink")
 
 // validateChecksumRelPath rejects CHECKSUMS rows whose path field
-// could escape the dump root. The acceptance rules:
+// could escape the dump root or otherwise resolve outside the
+// regular-file subtree the verifier expects. The acceptance rule
+// is `filepath.IsLocal` — Go-stdlib's lexical "stays within the
+// subtree rooted at the evaluation directory" check, which
+// covers:
 //
-//   - absolute paths are rejected;
-//   - paths containing a `..` segment (before or after Clean) are
-//     rejected;
-//   - the cleaned form must not start with `../` (covers
-//     filepath.Clean turning `a/../../b` into `../b`);
-//   - empty / `.` paths are rejected so a malformed entry that
-//     would otherwise read the root directory itself surfaces.
+//   - absolute paths (any platform);
+//   - traversal via `..` segments (before or after Clean);
+//   - on Windows, reserved device names like `CON`, `NUL`,
+//     `COM1`-`COM9`, `LPT1`-`LPT9`, `PRN`, `AUX`, `CONIN$`,
+//     `CONOUT$`, etc. — opened via `os.Open` these would yield
+//     the host's console / device, not a dump file, and produce
+//     hash mismatches keyed off host state. Codex r3 P1 on
+//     PR #810.
 //
-// Returns the cleaned form so callers join it without redoing the
-// canonicalisation. Mirrors the same guard the S3 encoder applies
-// to bucket/object path segments before scratch-dir layout.
+// Empty and "." are rejected explicitly because IsLocal returns
+// true for "." (it does stay within the subtree, but it names
+// the root directory itself, which is not a file we can hash);
+// honest CHECKSUMS lines name regular files, not the root dir.
+//
+// Returns the Cleaned form so callers join it without redoing
+// the canonicalisation. Mirrors the same guard the S3 encoder
+// applies to bucket/object path segments before scratch-dir
+// layout.
 func validateChecksumRelPath(rel string) (string, error) {
 	if rel == "" || rel == "." {
 		return "", errors.Wrapf(ErrChecksumsMalformedLine, "empty path field")
 	}
-	if filepath.IsAbs(rel) {
-		return "", errors.Wrapf(ErrChecksumsPathTraversal, "absolute path: %q", rel)
+	if !filepath.IsLocal(rel) {
+		return "", errors.Wrapf(ErrChecksumsPathTraversal,
+			"not a local path (absolute / traversal / reserved name): %q", rel)
 	}
 	cleaned := filepath.Clean(rel)
-	// Defence in depth: Clean turns `a/b/../../../etc/passwd` into
-	// `../etc/passwd`. A leading `..` segment in the cleaned form
-	// means the relative path escaped its parent, regardless of
-	// what tricks were used to write it.
+	// IsLocal already rejects absolute paths and `..` traversal
+	// before/after Clean; the post-Clean recheck below is
+	// belt-and-braces against a future stdlib change that would
+	// loosen IsLocal but keep the cleaned-shape invariants.
 	if cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
-		return "", errors.Wrapf(ErrChecksumsPathTraversal, "escapes root: %q", rel)
+		return "", errors.Wrapf(ErrChecksumsPathTraversal, "escapes root after Clean: %q", rel)
 	}
-	// `Clean` strips trailing slashes but leaves the leading
-	// separator on absolute paths intact; we already filtered
-	// those, so a remaining absolute-shaped Clean result is from
-	// inputs like `/foo` on platforms where filepath.IsAbs
-	// disagrees with filepath.Clean. Belt-and-braces.
 	if filepath.IsAbs(cleaned) {
 		return "", errors.Wrapf(ErrChecksumsPathTraversal, "absolute after Clean: %q", rel)
 	}

--- a/internal/backup/checksums.go
+++ b/internal/backup/checksums.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -233,17 +234,38 @@ func VerifyChecksums(root string) error {
 	sc := bufio.NewScanner(f)
 	sc.Buffer(make([]byte, 0, maxChecksumLineLen), maxChecksumLineLen)
 	lineNum := 0
+	verified := 0
 	for sc.Scan() {
 		lineNum++
-		if err := verifyOneChecksumLine(root, sc.Text(), lineNum); err != nil {
+		got, err := verifyOneChecksumLine(root, sc.Text(), lineNum)
+		if err != nil {
 			return err
+		}
+		if got {
+			verified++
 		}
 	}
 	if err := sc.Err(); err != nil {
 		return errors.WithStack(err)
 	}
+	// Refuse a CHECKSUMS that yielded zero verified rows. An empty
+	// (or all-blank) file would otherwise pass verification and
+	// hide a producer-side corruption — the dump tree itself is
+	// non-empty (WriteChecksums lists every regular file), so a
+	// CHECKSUMS with no rows is always a signal, never a benign
+	// shape. Codex r5 P2 on PR #810.
+	if verified == 0 {
+		return errors.WithStack(ErrChecksumsEmpty)
+	}
 	return nil
 }
+
+// ErrChecksumsEmpty is returned by VerifyChecksums when the
+// CHECKSUMS file parsed to zero checksum rows (empty file, all
+// blank lines, or comment-only — none of which are valid Phase 0a
+// dump shapes). Typed so callers can distinguish "CHECKSUMS file
+// did not list anything" from "a listed file mismatched".
+var ErrChecksumsEmpty = errors.New("backup: CHECKSUMS contains no checksum rows")
 
 // verifyOneChecksumLine handles a single CHECKSUMS line: parse,
 // path-validate, recompute, compare. Extracted from VerifyChecksums
@@ -251,30 +273,59 @@ func VerifyChecksums(root string) error {
 // per-line failure modes (malformed shape, traversal, symlink
 // escape, missing file, mismatch) each surface as a distinct
 // typed error.
-func verifyOneChecksumLine(root, line string, lineNum int) error {
+//
+// Returns (verified, err): verified=true when the line was a real
+// checksum row that VerifyChecksums should count toward the
+// "at least one row" empty-file guard (blank lines do not count).
+// A missing file referenced by an honest CHECKSUMS row is
+// surfaced as ErrChecksumMismatch — partial restores and
+// adversarial deletions land in the same typed failure class
+// callers branch on. Codex r5 P2 on PR #810.
+func verifyOneChecksumLine(root, line string, lineNum int) (bool, error) {
 	if line == "" {
-		return nil
+		return false, nil
 	}
 	want, rel, ok := splitChecksumLine(line)
 	if !ok {
-		return errors.Wrapf(ErrChecksumsMalformedLine, "line %d: %q", lineNum, line)
+		return false, errors.Wrapf(ErrChecksumsMalformedLine, "line %d: %q", lineNum, line)
 	}
 	cleaned, err := validateChecksumRelPath(rel)
 	if err != nil {
-		return errors.Wrapf(err, "line %d", lineNum)
+		return false, errors.Wrapf(err, "line %d", lineNum)
 	}
 	joined := filepath.Join(root, cleaned)
 	if err := refuseSymlinkComponents(root, cleaned); err != nil {
-		return errors.Wrapf(err, "line %d", lineNum)
+		// Missing file along the resolved path is a partial-
+		// restore / tamper signal — same operational category
+		// as a hash mismatch. The Lstat-walk caller bubbles up
+		// raw fs.ErrNotExist; promote it to the typed
+		// ErrChecksumMismatch class so callers branching on
+		// errors.Is keep covering this case. Codex r5 P2 on
+		// PR #810.
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, errors.Wrapf(ErrChecksumMismatch,
+				"%s: missing on disk", cleaned)
+		}
+		return false, errors.Wrapf(err, "line %d", lineNum)
 	}
 	got, err := sha256File(joined)
 	if err != nil {
-		return errors.Wrapf(err, "verifying %s", cleaned)
+		// A missing target is a partial-restore or tamper
+		// signal; either way it is operationally identical to
+		// a checksum mismatch for the caller. Surface as
+		// ErrChecksumMismatch so `errors.Is(err,
+		// ErrChecksumMismatch)` covers both cases. Codex r5 P2
+		// on PR #810.
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, errors.Wrapf(ErrChecksumMismatch,
+				"%s: missing on disk", cleaned)
+		}
+		return false, errors.Wrapf(err, "verifying %s", cleaned)
 	}
 	if got != want {
-		return errors.Wrapf(ErrChecksumMismatch, "%s: have %s want %s", cleaned, got, want)
+		return false, errors.Wrapf(ErrChecksumMismatch, "%s: have %s want %s", cleaned, got, want)
 	}
-	return nil
+	return true, nil
 }
 
 // refuseSymlinkComponents walks rel one path segment at a time

--- a/internal/backup/checksums.go
+++ b/internal/backup/checksums.go
@@ -187,8 +187,9 @@ func VerifyChecksums(root string) error {
 // verifyOneChecksumLine handles a single CHECKSUMS line: parse,
 // path-validate, recompute, compare. Extracted from VerifyChecksums
 // so the parent stays under the project's cyclop ceiling and the
-// per-line failure modes (malformed shape, traversal, missing file,
-// mismatch) each surface as a distinct typed error.
+// per-line failure modes (malformed shape, traversal, symlink
+// escape, missing file, mismatch) each surface as a distinct
+// typed error.
 func verifyOneChecksumLine(root, line string, lineNum int) error {
 	if line == "" {
 		return nil
@@ -201,7 +202,11 @@ func verifyOneChecksumLine(root, line string, lineNum int) error {
 	if err != nil {
 		return errors.Wrapf(err, "line %d", lineNum)
 	}
-	got, err := sha256File(filepath.Join(root, cleaned))
+	joined := filepath.Join(root, cleaned)
+	if err := refuseSymlinkComponents(root, cleaned); err != nil {
+		return errors.Wrapf(err, "line %d", lineNum)
+	}
+	got, err := sha256File(joined)
 	if err != nil {
 		return errors.Wrapf(err, "verifying %s", cleaned)
 	}
@@ -210,6 +215,48 @@ func verifyOneChecksumLine(root, line string, lineNum int) error {
 	}
 	return nil
 }
+
+// refuseSymlinkComponents walks rel one path segment at a time
+// starting at root and rejects the first component that is a
+// symlink. This closes the codex r2 P1 symlink-escape attack on
+// PR #810: after the textual `..`-traversal guard runs,
+// `os.Open(filepath.Join(root, "safe/file"))` would still follow a
+// symlink at `safe/file` (or at any of its parent components) to
+// a file outside root and hash whatever it found. A Phase 0a dump
+// produced by the encoder writes only regular files, so refusing
+// every symlink found in the path keeps the verifier honest
+// regardless of which component an adversary planted the link in.
+//
+// The per-component walk catches BOTH terminal symlinks (where
+// `cleaned` itself names a symlink) AND intermediate ones (where
+// a parent directory along the way is a symlink). syscall
+// O_NOFOLLOW would only cover the terminal case, and
+// filepath.EvalSymlinks runs the resolution we are trying to
+// avoid in the first place.
+func refuseSymlinkComponents(root, rel string) error {
+	cur := root
+	for _, seg := range strings.Split(rel, string(filepath.Separator)) {
+		if seg == "" {
+			continue
+		}
+		cur = filepath.Join(cur, seg)
+		info, err := os.Lstat(cur)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return errors.Wrapf(ErrChecksumsSymlinkEscape,
+				"symlink in path: %s", cur)
+		}
+	}
+	return nil
+}
+
+// ErrChecksumsSymlinkEscape is returned by VerifyChecksums when a
+// CHECKSUMS line's resolved path traverses a symlink. Typed so a
+// caller branching on errors.Is can distinguish symlink-tampering
+// from textual `..`-traversal (ErrChecksumsPathTraversal).
+var ErrChecksumsSymlinkEscape = errors.New("backup: CHECKSUMS path traverses symlink")
 
 // validateChecksumRelPath rejects CHECKSUMS rows whose path field
 // could escape the dump root. The acceptance rules:

--- a/internal/backup/checksums_test.go
+++ b/internal/backup/checksums_test.go
@@ -308,6 +308,83 @@ func TestValidateChecksumRelPath_AcceptsHonestPaths(t *testing.T) {
 	}
 }
 
+// TestChecksumLine_EscapeRoundTrip is the regression for codex r4
+// P2 on PR #810: a path containing `\n`/`\r`/`\\` would corrupt
+// the line-delimited CHECKSUMS without GNU coreutils-style
+// escaping. WriteChecksums prefixes such lines with `\\` and
+// substitutes `\n`/`\r`/`\\` → `\\n`/`\\r`/`\\\\`; VerifyChecksums
+// reverses the substitution at parse time. Round-trip pins both
+// halves together.
+func TestChecksumLine_EscapeRoundTrip(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"newline", "weird\nfile"},
+		{"carriage_return", "weird\rfile"},
+		{"backslash", `weird\file`},
+		{"multiple_escapes", "a\n\rb\\c"},
+		{"no_escape_pass_through", "honest/path.txt"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			hex := "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+			body, prefix := formatChecksumLine(hex, tc.path)
+			gotHex, gotPath, ok := splitChecksumLine(prefix + body)
+			if !ok {
+				t.Fatalf("splitChecksumLine(%q) rejected its own output", prefix+body)
+			}
+			if gotHex != hex {
+				t.Fatalf("hex = %q, want %q", gotHex, hex)
+			}
+			if gotPath != tc.path {
+				t.Fatalf("path = %q, want %q", gotPath, tc.path)
+			}
+		})
+	}
+}
+
+// TestChecksumLine_EscapePrefixMatchesGNUFormat pins the exact
+// shape WriteChecksums emits for escape-needing paths:
+//
+//	\<hex>  <body-with-\n-\r-\\\>
+//
+// so `sha256sum -c CHECKSUMS` on the dump root parses the line
+// the same way GNU coreutils does.
+func TestChecksumLine_EscapePrefixMatchesGNUFormat(t *testing.T) {
+	t.Parallel()
+	hex := "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+	body, prefix := formatChecksumLine(hex, "x\ny")
+	if prefix != `\` {
+		t.Fatalf("escape prefix = %q, want %q", prefix, `\`)
+	}
+	wantBody := hex + `  x\ny`
+	if body != wantBody {
+		t.Fatalf("body = %q, want %q", body, wantBody)
+	}
+}
+
+// TestSplitChecksumLine_RejectsDanglingEscape pins the parse-side
+// guard against malformed escape sequences (`\` at end-of-line, or
+// `\x` for unknown `x`). Catches a tampered CHECKSUMS whose
+// escape-prefixed line is otherwise structurally valid.
+func TestSplitChecksumLine_RejectsDanglingEscape(t *testing.T) {
+	t.Parallel()
+	hex := "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+	cases := []string{
+		`\` + hex + `  trailing\`,   // dangling \ at end
+		`\` + hex + `  bad\xescape`, // unknown escape \x
+	}
+	for _, c := range cases {
+		_, _, ok := splitChecksumLine(c)
+		if ok {
+			t.Fatalf("splitChecksumLine(%q) accepted malformed escape", c)
+		}
+	}
+}
+
 // TestVerifyChecksums_StreamsLargeFile pins the bufio.Scanner path
 // — the previous implementation slurped the entire CHECKSUMS file
 // via os.ReadFile, which OOMs on large dump trees (gemini

--- a/internal/backup/checksums_test.go
+++ b/internal/backup/checksums_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -155,6 +156,91 @@ func TestVerifyChecksums_RejectsTraversalPath(t *testing.T) {
 				t.Fatalf("err = %v, want ErrChecksumsPathTraversal or ErrChecksumsMalformedLine", err)
 			}
 		})
+	}
+}
+
+// TestVerifyChecksums_RejectsTerminalSymlink is the regression for
+// codex r2 P1 on PR #810: after the textual `..` guard, a
+// CHECKSUMS line `<hex>  safe/file` whose `safe/file` is a symlink
+// pointing outside the dump root would have been silently
+// followed by os.Open, hashing the host-side target. The
+// per-component lstat walk in refuseSymlinkComponents catches
+// both terminal and intermediate symlinks.
+func TestVerifyChecksums_RejectsTerminalSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Windows symlink creation requires
+		// SeCreateSymbolicLinkPrivilege which is rarely available
+		// to CI users. The lstat-walk fix runs on every platform;
+		// the test only exercises Linux/macOS where os.Symlink is
+		// unprivileged.
+		t.Skip("symlink test requires unprivileged os.Symlink (skipped on Windows)")
+	}
+	t.Parallel()
+	root := t.TempDir()
+	outsideDir := t.TempDir()
+	outsideFile := filepath.Join(outsideDir, "secret")
+	mustWrite(t, outsideFile, []byte("host-only"))
+	// Build a CHECKSUMS that lists `safe/file` with a digest that
+	// would match the outside file's contents — proving the
+	// verifier did NOT follow the symlink.
+	mustWrite(t, filepath.Join(root, "safe", "honest"), []byte("dump-only"))
+	if err := WriteChecksums(root); err != nil {
+		t.Fatalf("WriteChecksums: %v", err)
+	}
+	// Now plant a symlink at safe/escape -> outsideFile and add an
+	// entry for it to CHECKSUMS. WriteChecksums followed the link
+	// during its own walk too, but VerifyChecksums must reject.
+	link := filepath.Join(root, "safe", "escape")
+	if err := os.Symlink(outsideFile, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	// Append a CHECKSUMS entry for the symlinked file.
+	checksumsPath := filepath.Join(root, CHECKSUMSFilename)
+	body, err := os.ReadFile(checksumsPath) //nolint:gosec // test path
+	if err != nil {
+		t.Fatalf("read CHECKSUMS: %v", err)
+	}
+	// Use the digest of the outside file's actual content so the
+	// shape-parse + path-traversal checks succeed; the symlink
+	// guard is the first thing that must reject.
+	body = append(body, []byte("e3d1ac1b09a9e88c0c12e9b1d31d6a92e2ec43cf2bda7bcd58e3a3b2c50e2dd2  safe/escape\n")...)
+	if err := os.WriteFile(checksumsPath, body, 0o600); err != nil {
+		t.Fatalf("write CHECKSUMS: %v", err)
+	}
+	err = VerifyChecksums(root)
+	if err == nil {
+		t.Fatalf("expected ErrChecksumsSymlinkEscape, got nil")
+	}
+	if !errors.Is(err, ErrChecksumsSymlinkEscape) {
+		t.Fatalf("err = %v, want ErrChecksumsSymlinkEscape", err)
+	}
+}
+
+// TestVerifyChecksums_RejectsIntermediateSymlink pins that a
+// symlinked PARENT component is also caught — without the
+// per-component walk, refusing only the terminal symlink would
+// still leave the verifier vulnerable to a dump with a top-level
+// symlinked directory.
+func TestVerifyChecksums_RejectsIntermediateSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test requires unprivileged os.Symlink")
+	}
+	t.Parallel()
+	root := t.TempDir()
+	outsideDir := t.TempDir()
+	mustWrite(t, filepath.Join(outsideDir, "target.txt"), []byte("host-side"))
+	// safe/ is a symlink to a directory outside the dump root.
+	if err := os.Symlink(outsideDir, filepath.Join(root, "safe")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	body := "0000000000000000000000000000000000000000000000000000000000000000  safe/target.txt\n"
+	mustWrite(t, filepath.Join(root, CHECKSUMSFilename), []byte(body))
+	err := VerifyChecksums(root)
+	if err == nil {
+		t.Fatalf("expected ErrChecksumsSymlinkEscape, got nil")
+	}
+	if !errors.Is(err, ErrChecksumsSymlinkEscape) {
+		t.Fatalf("err = %v, want ErrChecksumsSymlinkEscape", err)
 	}
 }
 

--- a/internal/backup/checksums_test.go
+++ b/internal/backup/checksums_test.go
@@ -103,7 +103,11 @@ func TestVerifyChecksums_HappyPath(t *testing.T) {
 
 // TestVerifyChecksums_DetectsTampering pins the failure mode: a
 // post-checksum write to one of the listed files must surface as
-// a verification error.
+// ErrChecksumMismatch (not just "some error"). Pinning the
+// typed sentinel keeps the contract honest — a future change
+// that turns this into ErrChecksumsMalformedLine or
+// ErrChecksumsPathTraversal would otherwise pass this test
+// silently. CodeRabbit r5 nitpick on PR #810.
 func TestVerifyChecksums_DetectsTampering(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
@@ -112,8 +116,12 @@ func TestVerifyChecksums_DetectsTampering(t *testing.T) {
 		t.Fatalf("WriteChecksums: %v", err)
 	}
 	mustWrite(t, filepath.Join(root, "a.txt"), []byte("tampered"))
-	if err := VerifyChecksums(root); err == nil {
+	err := VerifyChecksums(root)
+	if err == nil {
 		t.Fatalf("expected VerifyChecksums to detect tampering, got nil")
+	}
+	if !errors.Is(err, ErrChecksumMismatch) {
+		t.Fatalf("err = %v, want ErrChecksumMismatch", err)
 	}
 }
 

--- a/internal/backup/checksums_test.go
+++ b/internal/backup/checksums_test.go
@@ -1,0 +1,124 @@
+package backup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestWriteChecksums_BasicListing pins the on-disk shape of a
+// dump tree's CHECKSUMS file: lexicographically sorted lines, two-
+// space separator, forward-slash paths, lowercase hex digest.
+func TestWriteChecksums_BasicListing(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "a.txt"), []byte("hello"))
+	mustWrite(t, filepath.Join(root, "nested", "b.txt"), []byte("world"))
+
+	if err := WriteChecksums(root); err != nil {
+		t.Fatalf("WriteChecksums: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(root, CHECKSUMSFilename))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	// sha256("hello") and sha256("world"), pinned so a future
+	// encoder change that accidentally normalises file bytes
+	// (line endings, BOMs, etc.) surfaces as a hash mismatch.
+	want := "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824  a.txt\n" +
+		"486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7  nested/b.txt\n"
+	if string(got) != want {
+		t.Fatalf("CHECKSUMS body:\nhave %q\nwant %q", got, want)
+	}
+}
+
+// TestWriteChecksums_ExcludesSelf pins that the CHECKSUMS file is
+// not listed inside its own body — sha256sum -c CHECKSUMS otherwise
+// errors on the unreadable circular reference.
+func TestWriteChecksums_ExcludesSelf(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "a.txt"), []byte("x"))
+	if err := WriteChecksums(root); err != nil {
+		t.Fatalf("WriteChecksums: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(root, CHECKSUMSFilename))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if strings.Contains(string(body), CHECKSUMSFilename) {
+		t.Fatalf("CHECKSUMS lists itself; body=%q", body)
+	}
+}
+
+// TestWriteChecksums_DeterministicOrder pins line ordering — two
+// invocations on the same tree must produce byte-identical
+// CHECKSUMS files.
+func TestWriteChecksums_DeterministicOrder(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	// Names chosen so the alphabetic order would differ from the
+	// directory-walk order on some filesystems.
+	for _, name := range []string{"zz", "aa", "mm"} {
+		mustWrite(t, filepath.Join(root, name), []byte(name))
+	}
+	if err := WriteChecksums(root); err != nil {
+		t.Fatalf("WriteChecksums: %v", err)
+	}
+	first, err := os.ReadFile(filepath.Join(root, CHECKSUMSFilename))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if err := WriteChecksums(root); err != nil {
+		t.Fatalf("WriteChecksums (2nd): %v", err)
+	}
+	second, err := os.ReadFile(filepath.Join(root, CHECKSUMSFilename))
+	if err != nil {
+		t.Fatalf("read (2nd): %v", err)
+	}
+	if string(first) != string(second) {
+		t.Fatalf("CHECKSUMS not deterministic across runs:\nrun1=%q\nrun2=%q", first, second)
+	}
+}
+
+// TestVerifyChecksums_HappyPath round-trips a freshly written
+// CHECKSUMS file. Used to back the Phase 0b encoder's self-test.
+func TestVerifyChecksums_HappyPath(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "a.txt"), []byte("hello"))
+	mustWrite(t, filepath.Join(root, "b.txt"), []byte("world"))
+	if err := WriteChecksums(root); err != nil {
+		t.Fatalf("WriteChecksums: %v", err)
+	}
+	if err := VerifyChecksums(root); err != nil {
+		t.Fatalf("VerifyChecksums: %v", err)
+	}
+}
+
+// TestVerifyChecksums_DetectsTampering pins the failure mode: a
+// post-checksum write to one of the listed files must surface as
+// a verification error.
+func TestVerifyChecksums_DetectsTampering(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "a.txt"), []byte("hello"))
+	if err := WriteChecksums(root); err != nil {
+		t.Fatalf("WriteChecksums: %v", err)
+	}
+	mustWrite(t, filepath.Join(root, "a.txt"), []byte("tampered"))
+	if err := VerifyChecksums(root); err == nil {
+		t.Fatalf("expected VerifyChecksums to detect tampering, got nil")
+	}
+}
+
+func mustWrite(t *testing.T, path string, body []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/backup/checksums_test.go
+++ b/internal/backup/checksums_test.go
@@ -244,6 +244,70 @@ func TestVerifyChecksums_RejectsIntermediateSymlink(t *testing.T) {
 	}
 }
 
+// TestValidateChecksumRelPath_RejectsWindowsDeviceNames is the
+// regression for codex r3 P1 on PR #810: even after the textual
+// `..`-traversal guard, names like CON / NUL / COM1 / CONOUT$
+// would open the host's console / device on Windows via
+// `os.Open(filepath.Join(root, "CON"))`. The verifier delegates
+// locality to filepath.IsLocal which refuses these names
+// lexically — but only on Windows (filepath.IsLocal is
+// platform-aware; on Unix these names are valid filenames).
+//
+// The test runs the unit-level validateChecksumRelPath check
+// rather than the full VerifyChecksums flow because the lstat
+// step downstream of the IsLocal guard would fail with a
+// generic ENOENT on Unix where the names are not pre-created,
+// masking the rejection class we want to pin.
+func TestValidateChecksumRelPath_RejectsWindowsDeviceNames(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		// filepath.IsLocal only rejects reserved device names on
+		// Windows; on Unix these strings are ordinary filenames.
+		// The lexical fix lands on every platform, but the
+		// rejection is observable only where it matters.
+		t.Skip("Windows-only: filepath.IsLocal reserved-name check is platform-specific")
+	}
+	t.Parallel()
+	names := []string{"CON", "NUL", "PRN", "AUX", "COM1", "LPT1", "CONOUT$"}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, err := validateChecksumRelPath(name)
+			if err == nil {
+				t.Fatalf("expected ErrChecksumsPathTraversal for reserved name %q, got nil", name)
+			}
+			if !errors.Is(err, ErrChecksumsPathTraversal) {
+				t.Fatalf("err = %v, want ErrChecksumsPathTraversal", err)
+			}
+		})
+	}
+}
+
+// TestValidateChecksumRelPath_AcceptsHonestPaths cross-checks the
+// IsLocal switchover did not regress legitimate relative paths
+// (the Phase 0a dump tree).
+func TestValidateChecksumRelPath_AcceptsHonestPaths(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"a.txt",
+		"redis/db_0/strings/foo.bin",
+		"s3/photos/2026/04/29/img.jpg",
+		"dynamodb/orders/_schema.json",
+		"sqs/queue-1/messages.jsonl",
+	}
+	for _, p := range cases {
+		t.Run(p, func(t *testing.T) {
+			t.Parallel()
+			got, err := validateChecksumRelPath(p)
+			if err != nil {
+				t.Fatalf("validateChecksumRelPath(%q) unexpected err: %v", p, err)
+			}
+			if got != filepath.Clean(p) {
+				t.Fatalf("validateChecksumRelPath(%q) = %q, want %q", p, got, filepath.Clean(p))
+			}
+		})
+	}
+}
+
 // TestVerifyChecksums_StreamsLargeFile pins the bufio.Scanner path
 // — the previous implementation slurped the entire CHECKSUMS file
 // via os.ReadFile, which OOMs on large dump trees (gemini

--- a/internal/backup/checksums_test.go
+++ b/internal/backup/checksums_test.go
@@ -1,10 +1,13 @@
 package backup
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/cockroachdb/errors"
 )
 
 // TestWriteChecksums_BasicListing pins the on-disk shape of a
@@ -110,6 +113,69 @@ func TestVerifyChecksums_DetectsTampering(t *testing.T) {
 	mustWrite(t, filepath.Join(root, "a.txt"), []byte("tampered"))
 	if err := VerifyChecksums(root); err == nil {
 		t.Fatalf("expected VerifyChecksums to detect tampering, got nil")
+	}
+}
+
+// TestVerifyChecksums_RejectsTraversalPath is the regression for
+// the coderabbit critical finding on PR #810. A CHECKSUMS file
+// shipped alongside a backup must not be able to direct the
+// verifier to fingerprint files outside the dump root via a
+// `..`-laden path. The verifier rejects with
+// ErrChecksumsPathTraversal before any sha256 is computed.
+func TestVerifyChecksums_RejectsTraversalPath(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		relPath string
+	}{
+		{"parent traversal", "../etc/passwd"},
+		{"deep traversal", "a/../../b"},
+		{"absolute path", "/etc/passwd"},
+		{"current dir", "."},
+		{"empty", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			// Write a CHECKSUMS that references the traversal path.
+			// The digest is the sha256 of an arbitrary fixture so
+			// shape parsing succeeds and the path guard is the
+			// first thing to fire.
+			body := "0000000000000000000000000000000000000000000000000000000000000000  " + tc.relPath + "\n"
+			mustWrite(t, filepath.Join(root, CHECKSUMSFilename), []byte(body))
+			err := VerifyChecksums(root)
+			if err == nil {
+				t.Fatalf("expected error for relPath=%q, got nil", tc.relPath)
+			}
+			// `.` and "" surface as malformed-line; the rest surface
+			// as path-traversal. Both signal "do not trust the
+			// CHECKSUMS contents".
+			if !errors.Is(err, ErrChecksumsPathTraversal) && !errors.Is(err, ErrChecksumsMalformedLine) {
+				t.Fatalf("err = %v, want ErrChecksumsPathTraversal or ErrChecksumsMalformedLine", err)
+			}
+		})
+	}
+}
+
+// TestVerifyChecksums_StreamsLargeFile pins the bufio.Scanner path
+// — the previous implementation slurped the entire CHECKSUMS file
+// via os.ReadFile, which OOMs on large dump trees (gemini
+// security-high on PR #810). We do not exercise an actual large
+// file (CI cost) but we confirm the streaming code path tolerates
+// many lines without buffering them all.
+func TestVerifyChecksums_StreamsLargeFile(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	const fileCount = 64
+	for i := 0; i < fileCount; i++ {
+		mustWrite(t, filepath.Join(root, fmt.Sprintf("f-%03d", i)), []byte{byte(i)})
+	}
+	if err := WriteChecksums(root); err != nil {
+		t.Fatalf("WriteChecksums: %v", err)
+	}
+	if err := VerifyChecksums(root); err != nil {
+		t.Fatalf("VerifyChecksums: %v", err)
 	}
 }
 

--- a/internal/backup/checksums_test.go
+++ b/internal/backup/checksums_test.go
@@ -393,6 +393,63 @@ func TestSplitChecksumLine_RejectsDanglingEscape(t *testing.T) {
 	}
 }
 
+// TestVerifyChecksums_RejectsEmptyChecksumsFile is the regression
+// for codex r5 P2 on PR #810: a CHECKSUMS file with zero parsed
+// rows (empty, blank lines only) previously returned nil, hiding
+// a producer-side corruption. The dump tree is non-empty by
+// construction (WriteChecksums lists every regular file), so an
+// empty CHECKSUMS is always a signal.
+func TestVerifyChecksums_RejectsEmptyChecksumsFile(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"empty file", ""},
+		{"blank lines only", "\n\n\n"},
+		{"trailing newline only", "\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			mustWrite(t, filepath.Join(root, CHECKSUMSFilename), []byte(tc.body))
+			err := VerifyChecksums(root)
+			if err == nil {
+				t.Fatalf("expected ErrChecksumsEmpty for %q, got nil", tc.body)
+			}
+			if !errors.Is(err, ErrChecksumsEmpty) {
+				t.Fatalf("err = %v, want ErrChecksumsEmpty", err)
+			}
+		})
+	}
+}
+
+// TestVerifyChecksums_MissingTargetIsMismatch is the regression
+// for codex r5 P2 on PR #810: a CHECKSUMS line whose listed file
+// was deleted from disk (partial restore / tamper) now surfaces
+// as ErrChecksumMismatch — previously the raw fs.ErrNotExist
+// bubbled up through refuseSymlinkComponents and bypassed the
+// typed checksum-failure path callers branch on.
+func TestVerifyChecksums_MissingTargetIsMismatch(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "a.txt"), []byte("hello"))
+	if err := WriteChecksums(root); err != nil {
+		t.Fatalf("WriteChecksums: %v", err)
+	}
+	if err := os.Remove(filepath.Join(root, "a.txt")); err != nil {
+		t.Fatalf("rm a.txt: %v", err)
+	}
+	err := VerifyChecksums(root)
+	if err == nil {
+		t.Fatalf("expected ErrChecksumMismatch for missing target, got nil")
+	}
+	if !errors.Is(err, ErrChecksumMismatch) {
+		t.Fatalf("err = %v, want ErrChecksumMismatch", err)
+	}
+}
+
 // TestVerifyChecksums_StreamsLargeFile pins the bufio.Scanner path
 // — the previous implementation slurped the entire CHECKSUMS file
 // via os.ReadFile, which OOMs on large dump trees (gemini

--- a/internal/backup/source.go
+++ b/internal/backup/source.go
@@ -1,0 +1,58 @@
+package backup
+
+import (
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// source.go decodes operator-supplied .fsm paths into the
+// MANIFEST.json fields the cmd/ wrapper needs to stamp at write
+// time. The decoder package owns the parsing so a future change to
+// the snapshot filename convention surfaces in one place.
+
+// SnapshotIndexFromPath extracts the integer applied-index encoded
+// in a `.fsm` filename. The live writer (internal/raftengine/etcd/
+// engine.go) names every snapshot `<index>.fsm` where <index> is
+// the FSM's applied_index at the moment the snapshot was taken.
+// Phase 0a's MANIFEST.json carries that value as `snapshot_index`
+// so a restore-time operator knows how stale the dump is relative
+// to the cluster's last activity.
+//
+// The numeric portion is everything between the final path
+// separator (or string start) and the `.fsm` suffix. Lengths and
+// zero-padding are not enforced — the live writer happens to pad
+// to 16 digits, but a hand-rolled snapshot named `42.fsm` decodes
+// correctly too.
+//
+// Returns ErrSnapshotIndexUnparseable when path lacks the .fsm
+// suffix or when the basename is not a parseable uint64.
+func SnapshotIndexFromPath(path string) (uint64, error) {
+	base := filepath.Base(path)
+	const fsmSuffix = ".fsm"
+	if !strings.HasSuffix(base, fsmSuffix) {
+		return 0, errors.Wrapf(ErrSnapshotIndexUnparseable,
+			"path %q: missing %q suffix", path, fsmSuffix)
+	}
+	stem := strings.TrimSuffix(base, fsmSuffix)
+	if stem == "" {
+		return 0, errors.Wrapf(ErrSnapshotIndexUnparseable,
+			"path %q: empty stem before %q", path, fsmSuffix)
+	}
+	idx, err := strconv.ParseUint(stem, 10, 64)
+	if err != nil {
+		return 0, errors.Wrapf(ErrSnapshotIndexUnparseable,
+			"path %q: stem %q is not a uint64", path, stem)
+	}
+	return idx, nil
+}
+
+// ErrSnapshotIndexUnparseable is returned by SnapshotIndexFromPath
+// when the input filename does not match the live writer's
+// `<uint64>.fsm` convention. The Phase 0a CLI surfaces this as a
+// soft warning (the dump still completes; MANIFEST.snapshot_index
+// is left zero) rather than a hard failure — operator-supplied
+// .fsm files copied off-cluster sometimes carry generic names.
+var ErrSnapshotIndexUnparseable = errors.New("backup: snapshot path does not match <index>.fsm convention")

--- a/internal/backup/source_test.go
+++ b/internal/backup/source_test.go
@@ -1,0 +1,47 @@
+package backup
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/errors"
+)
+
+func TestSnapshotIndexFromPath(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		path    string
+		wantIdx uint64
+		wantErr bool
+	}{
+		{"live-writer zero-padded", "/data/fsm-snap/0000000000000064.fsm", 64, false},
+		{"unpadded hand-rolled", "42.fsm", 42, false},
+		{"max uint64", "18446744073709551615.fsm", 18446744073709551615, false},
+		{"missing .fsm suffix", "snapshot.bin", 0, true},
+		{"empty stem", ".fsm", 0, true},
+		{"non-numeric stem", "snapshot-001.fsm", 0, true},
+		{"negative stem", "-1.fsm", 0, true},
+		{"hex stem", "0xff.fsm", 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			idx, err := SnapshotIndexFromPath(tc.path)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got idx=%d", idx)
+				}
+				if !errors.Is(err, ErrSnapshotIndexUnparseable) {
+					t.Fatalf("err = %v, want ErrSnapshotIndexUnparseable", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if idx != tc.wantIdx {
+				t.Fatalf("idx = %d, want %d", idx, tc.wantIdx)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds the Phase 0a operator-facing binary on top of the dispatcher in #806. Plus the CHECKSUMS writer / verifier and the `<uint64>.fsm` filename → snapshot-index parser the CLI needs to stamp MANIFEST.json.

Stacked on `backup/snapshot-dispatcher` — once #806 merges, this PR's diff collapses to just the CLI + helpers and I'll retarget to `main`.

## What lands

| File | Purpose |
|---|---|
| `cmd/elastickv-snapshot-decode/main.go` | Flag parsing, `DecodeSnapshot` invocation, `MANIFEST.json` + `CHECKSUMS` emission |
| `cmd/elastickv-snapshot-decode/main_test.go` | End-to-end synthetic-snapshot golden path + four flag-validation paths + `parseAdapterSet` table test |
| `internal/backup/checksums.go` | `WriteChecksums(root)` / `VerifyChecksums(root)` — sha256sum(1)-compatible |
| `internal/backup/source.go` | `SnapshotIndexFromPath` — `<uint64>.fsm` filename parser used to stamp `MANIFEST.snapshot_index` |
| `internal/backup/checksums_test.go`, `source_test.go` | Pin file shape, deterministic ordering, tamper detection, parse table |

## CLI surface

```
elastickv-snapshot-decode \
  --input  <fsm-file>          (required)
  --output <directory-root>    (required)
  [--adapter dynamodb,s3,redis,sqs|all]
  [--cluster-id <id>]
  [--include-incomplete-uploads]
  [--include-orphans]
  [--preserve-sqs-visibility]
  [--include-sqs-side-records]
  [--rename-collisions]
  [--dynamodb-bundle-mode per-item|jsonl]
```

Matches the design's §"Tooling" decoder section, minus the deferred `--input-snap-dir`, `--scope`, and `--dynamodb-bundle-size` flags (called out in the design as later additions).

## Output shape

`MANIFEST.json` carries `phase = "phase0-snapshot-decode"`, the filename-derived `snapshot_index`, the dispatcher-surfaced `last_commit_ts`, exclusion flags from the CLI, and a non-nil `Adapter{}` pointer for every enabled adapter (per-scope enumeration is a follow-up).

`CHECKSUMS` is the standard `sha256sum --binary` shape — verifiable with `sha256sum -c CHECKSUMS` from the dump root, no elastickv binary involved.

## Test plan

- [x] `go test -race ./internal/backup/ ./cmd/elastickv-snapshot-decode/` (passes)
- [x] `golangci-lint run ./...` over the touched packages (clean — 0 issues)
- [x] `go build ./...` (clean)
- [x] Golden-path test: synthetic `!redis|str|greeting` → `redis/db_0/strings/greeting.bin` + `MANIFEST.json` + `CHECKSUMS` + `VerifyChecksums` round-trip

## Self-review (CLAUDE.md §"Self-review of code changes")

1. **Data loss** — CHECKSUMS is written last so a crash mid-dump leaves an intact-but-unchecked tree; `MkdirAll(outputRoot)` is idempotent.
2. **Concurrency** — single-threaded; no shared state across goroutines.
3. **Performance** — sha256 streams via `io.Copy`; multi-GB files pass without buffering. CHECKSUMS walk is O(files).
4. **Data consistency** — `MANIFEST.last_commit_ts` comes from the dispatcher header (now surfaced via `ReadSnapshotWithHeader` so empty-snapshot dumps still populate it); `snapshot_index` parsed from the filename per the documented live-writer convention; encryption-state failures propagate from `DecodeSnapshot` as `ErrSnapshotEncryptedEntry`.
5. **Test coverage** — five CLI tests (golden path + four flag-validation paths); seven backup-package tests for the new helpers; existing backup-package tests still pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI to decode local snapshots into vendor-independent directory trees with adapter selection, output options, and manifest/CHECKSUMS generation
  * CHECKSUMS written in sha256sum-compatible format for integrity verification; manifest includes version, cluster metadata and parsed snapshot index when available

* **Bug Fixes / Security**
  * CHECKSUMS verification rejects path-traversal and symlink escape attempts

* **Tests**
  * Comprehensive tests covering decoding, manifesting, checksums, parsing, and security regressions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/810?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->