### PR TITLE
adapter/s3: object-level admin RPCs (Phase 2b)

### DIFF
--- a/adapter/s3_admin_objects.go
+++ b/adapter/s3_admin_objects.go
@@ -646,6 +646,16 @@ func (s *S3Server) AdminListObjects(ctx context.Context, principal AdminPrincipa
 
 	meta, exists, err := s.loadBucketMetaAt(ctx, bucket, readTS)
 	if err != nil {
+		// Same compaction-error translation as the ScanAt path
+		// below: when the caller passed a continuation token whose
+		// readTS has been MVCC-GC'd past, loadBucketMetaAt's GetAt
+		// also surfaces ErrReadTSCompacted — callers need to see
+		// the dedicated sentinel rather than a generic 500 (Codex
+		// r2 P2 on PR #811).
+		if token != nil && errors.Is(err, store.ErrReadTSCompacted) {
+			return AdminObjectListing{}, errors.Wrap(ErrAdminInvalidContinuationToken,
+				"continuation token readTS has been compacted")
+		}
 		return AdminObjectListing{}, errors.WithStack(err)
 	}
 	if !exists || meta == nil {

--- a/adapter/s3_admin_objects.go
+++ b/adapter/s3_admin_objects.go
@@ -26,6 +26,12 @@ const adminS3UploadMaxBytes int64 = 100 * 1024 * 1024
 // to 413 Payload Too Large.
 var ErrAdminUploadTooLarge = errors.New("s3 admin: object exceeds upload cap")
 
+// defaultS3ContentType is the MIME type stored on / surfaced by
+// admin RPCs when the caller (or the manifest) does not name one
+// explicitly. Matches the AWS S3 default and the SigV4 putObject
+// path's headerOrDefault fallback.
+const defaultS3ContentType = "application/octet-stream"
+
 // Phase 2b — object-level admin RPCs on *S3Server. Mirrors the
 // item-level admin surface DynamoDB ships in dynamodb_admin_items.go
 // (Scan / Get / Put / Delete) and follows the same gating model:
@@ -296,7 +302,7 @@ func (s *S3Server) adminPutObjectStream(ctx context.Context, bucket, key string,
 	}
 	ct := strings.TrimSpace(contentType)
 	if ct == "" {
-		ct = "application/octet-stream"
+		ct = defaultS3ContentType
 	}
 	manifest := &s3ObjectManifest{
 		UploadID:        uploadID,
@@ -386,7 +392,7 @@ func (s *S3Server) AdminGetObject(ctx context.Context, principal AdminPrincipal,
 		StorageClass: "STANDARD",
 	}
 	if adminMeta.ContentType == "" {
-		adminMeta.ContentType = "application/octet-stream"
+		adminMeta.ContentType = defaultS3ContentType
 	}
 	return body, adminMeta, nil
 }
@@ -539,4 +545,192 @@ func (r *s3AdminObjectReader) Close() error {
 		r.pin = nil
 	}
 	return nil
+}
+
+// AdminListObjectsOptions controls one AdminListObjects call.
+// Defaults match the design doc §3.1.2: MaxKeys=100, clamped to
+// [1, adminListObjectsMaxKeys=1000].
+type AdminListObjectsOptions struct {
+	Prefix            string `json:"prefix,omitempty"`
+	Delimiter         string `json:"delimiter,omitempty"`
+	ContinuationToken string `json:"continuation_token,omitempty"`
+	MaxKeys           int    `json:"max_keys,omitempty"`
+}
+
+// AdminObjectListing is the AdminListObjects response shape.
+// CommonPrefixes are populated only when Options.Delimiter is set;
+// they represent the pseudo-directories the SPA renders as
+// foldable rows. NextContinuationToken is empty when the page
+// fully drained the prefix scan.
+type AdminObjectListing struct {
+	Objects               []AdminObject `json:"objects"`
+	CommonPrefixes        []string      `json:"common_prefixes,omitempty"`
+	NextContinuationToken string        `json:"next_continuation_token,omitempty"`
+}
+
+const (
+	adminListObjectsDefaultMaxKeys = 100
+	adminListObjectsMaxKeysCap     = 1000
+)
+
+// clampAdminListMaxKeys folds the user-supplied MaxKeys into the
+// legal [1, 1000] range, mapping 0 (unset) to the default 100.
+func clampAdminListMaxKeys(n int) int {
+	if n <= 0 {
+		return adminListObjectsDefaultMaxKeys
+	}
+	if n > adminListObjectsMaxKeysCap {
+		return adminListObjectsMaxKeysCap
+	}
+	return n
+}
+
+// AdminListObjects returns a bounded page of objects under a
+// prefix. Read role required. Delimiter collapses pseudo-folders
+// into CommonPrefixes the same way SigV4 ListObjectsV2 does.
+//
+// Sentinels:
+//   - ErrAdminForbidden          — principal lacks read role
+//   - ErrAdminNotLeader          — follower
+//   - ErrAdminBucketNotFound     — bucket absent
+//   - ErrAdminInvalidBucketName  — malformed bucket name
+//   - ErrAdminDynamoValidation NOT used here — admin-list-objects
+//     reuses ErrAdminInvalidBucketName for the only validation path
+//     (bucket-name shape); a malformed continuation token comes back
+//     as a wrapped json/decode error from the SigV4 helper.
+//
+// prefix / delimiter collapsing; mirrors the SigV4 listObjectsV2
+// precedent at s3.go (same scan-and-collapse pipeline with one
+// error-return per stage). Splitting further would obscure the
+// pagination cursor lifecycle.
+//
+//nolint:cyclop,gocognit,gocyclo,nestif // Sequential scan-loop with
+func (s *S3Server) AdminListObjects(ctx context.Context, principal AdminPrincipal, bucket string, opts AdminListObjectsOptions) (AdminObjectListing, error) {
+	if !principal.Role.canRead() {
+		return AdminObjectListing{}, ErrAdminForbidden
+	}
+	if !s.isVerifiedS3Leader(ctx) {
+		return AdminObjectListing{}, ErrAdminNotLeader
+	}
+	if err := validateS3BucketName(bucket); err != nil {
+		return AdminObjectListing{}, errors.Wrapf(ErrAdminInvalidBucketName, "%s", err.Error())
+	}
+
+	token, err := decodeS3ContinuationToken(opts.ContinuationToken)
+	if err != nil {
+		return AdminObjectListing{}, errors.Wrap(err, "decode continuation token")
+	}
+
+	readTS := s.readTS()
+	if token != nil && token.ReadTS != 0 {
+		readTS = token.ReadTS
+	}
+
+	meta, exists, err := s.loadBucketMetaAt(ctx, bucket, readTS)
+	if err != nil {
+		return AdminObjectListing{}, errors.WithStack(err)
+	}
+	if !exists || meta == nil {
+		return AdminObjectListing{}, ErrAdminBucketNotFound
+	}
+
+	if token != nil && (token.Bucket != bucket || token.Generation != meta.Generation ||
+		token.Prefix != opts.Prefix || token.Delimiter != opts.Delimiter) {
+		return AdminObjectListing{}, errors.Wrap(ErrAdminInvalidBucketName,
+			"continuation token does not match request")
+	}
+
+	readPin := s.pinReadTS(readTS)
+	defer readPin.Release()
+
+	start := s3keys.ObjectManifestScanStart(bucket, meta.Generation, opts.Prefix)
+	if token != nil {
+		start = nextScanCursor(s3keys.ObjectManifestKey(bucket, token.Generation, token.LastKey))
+	}
+	end := prefixScanEnd(s3keys.ObjectManifestScanStart(bucket, meta.Generation, opts.Prefix))
+	maxKeys := clampAdminListMaxKeys(opts.MaxKeys)
+
+	out := AdminObjectListing{Objects: []AdminObject{}}
+	commonPrefixSeen := map[string]struct{}{}
+	if token != nil && token.LastCommonPrefix != "" {
+		commonPrefixSeen[token.LastCommonPrefix] = struct{}{}
+	}
+	cursor := start
+	truncated := false
+	emitted := 0
+	var lastKey, lastCommonPrefix string
+
+	for emitted < maxKeys {
+		pageLimit := s3ListPageSize
+		if remaining := maxKeys - emitted; remaining < pageLimit {
+			pageLimit = remaining
+		}
+		page, err := s.store.ScanAt(ctx, cursor, end, pageLimit, readTS)
+		if err != nil {
+			return AdminObjectListing{}, errors.WithStack(err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		for _, kvp := range page {
+			_, generation, objectKey, ok := s3keys.ParseObjectManifestKey(kvp.Key)
+			if !ok || generation != meta.Generation || !strings.HasPrefix(objectKey, opts.Prefix) {
+				continue
+			}
+			if opts.Delimiter != "" {
+				suffix := strings.TrimPrefix(objectKey, opts.Prefix)
+				if idx := strings.Index(suffix, opts.Delimiter); idx >= 0 {
+					commonPrefix := opts.Prefix + suffix[:idx+len(opts.Delimiter)]
+					if _, exists := commonPrefixSeen[commonPrefix]; !exists {
+						commonPrefixSeen[commonPrefix] = struct{}{}
+						out.CommonPrefixes = append(out.CommonPrefixes, commonPrefix)
+						emitted++
+						lastKey = objectKey
+						lastCommonPrefix = commonPrefix
+					}
+					if emitted >= maxKeys {
+						truncated = true
+						break
+					}
+					continue
+				}
+			}
+			manifest, err := decodeS3ObjectManifest(kvp.Value)
+			if err != nil {
+				return AdminObjectListing{}, errors.WithStack(err)
+			}
+			ct := manifest.ContentType
+			if ct == "" {
+				ct = defaultS3ContentType
+			}
+			out.Objects = append(out.Objects, AdminObject{
+				Key:          objectKey,
+				Size:         manifest.SizeBytes,
+				ContentType:  ct,
+				ETag:         manifest.ETag,
+				LastModified: hlcToTime(manifest.LastModifiedHLC),
+				StorageClass: "STANDARD",
+			})
+			emitted++
+			lastKey = objectKey
+			lastCommonPrefix = ""
+			if emitted >= maxKeys {
+				truncated = true
+				break
+			}
+		}
+		if truncated {
+			break
+		}
+		cursor = nextScanCursor(page[len(page)-1].Key)
+		if len(page) < pageLimit {
+			break
+		}
+	}
+
+	if truncated {
+		out.NextContinuationToken = encodeS3ContinuationToken(bucket, meta.Generation,
+			opts.Prefix, opts.Delimiter, lastKey, lastCommonPrefix, readTS)
+	}
+	return out, nil
 }

--- a/adapter/s3_admin_objects.go
+++ b/adapter/s3_admin_objects.go
@@ -603,14 +603,19 @@ func clampAdminListMaxKeys(n int) int {
 // into CommonPrefixes the same way SigV4 ListObjectsV2 does.
 //
 // Sentinels:
-//   - ErrAdminForbidden          — principal lacks read role
-//   - ErrAdminNotLeader          — follower
-//   - ErrAdminBucketNotFound     — bucket absent
-//   - ErrAdminInvalidBucketName  — malformed bucket name
-//   - ErrAdminDynamoValidation NOT used here — admin-list-objects
-//     reuses ErrAdminInvalidBucketName for the only validation path
-//     (bucket-name shape); a malformed continuation token comes back
-//     as a wrapped json/decode error from the SigV4 helper.
+//   - ErrAdminForbidden                — principal lacks read role
+//   - ErrAdminNotLeader                — follower
+//   - ErrAdminBucketNotFound           — bucket absent
+//   - ErrAdminInvalidBucketName        — malformed bucket name argument
+//   - ErrAdminInvalidContinuationToken — token references a different
+//     bucket / generation / prefix / delimiter than the current
+//     request, OR the token's readTS has been MVCC-GC'd past
+//     (store.ErrReadTSCompacted on the underlying scan)
+//
+// A structurally invalid / non-base64-decodable continuation token
+// surfaces as a wrapped json/decode error from decodeS3ContinuationToken,
+// not as a sentinel — the bridge maps that to a generic 400 with the
+// decode-error text preserved.
 //
 // Mirrors the SigV4 listObjectsV2 precedent at s3.go (same scan-
 // and-collapse pipeline with one error-return per stage; carries

--- a/adapter/s3_admin_objects.go
+++ b/adapter/s3_admin_objects.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/bootjp/elastickv/internal/s3keys"
 	"github.com/bootjp/elastickv/kv"
@@ -330,4 +331,212 @@ func (s *S3Server) adminPutObjectStream(ctx context.Context, bucket, key string,
 		return nil, 0, errors.WithStack(err)
 	}
 	return previous, meta.Generation, nil
+}
+
+// AdminObject is the admin-facing metadata projection. Mirrors the
+// fields the design doc §3.1.2 names — no internal-only state
+// (uploadID, chunk sizes, etc.) leaks to admin handlers / SPA.
+type AdminObject struct {
+	Key          string    `json:"key"`
+	Size         int64     `json:"size"`
+	ContentType  string    `json:"content_type"`
+	ETag         string    `json:"etag"`
+	LastModified time.Time `json:"last_modified"`
+	StorageClass string    `json:"storage_class"`
+}
+
+// AdminGetObject fetches one object's body + metadata. Read role
+// required. Returns (body, meta, nil) on success; the caller MUST
+// Close the body to release the read-tracker pin.
+//
+// Sentinels:
+//   - ErrAdminForbidden          — principal lacks read role
+//   - ErrAdminNotLeader          — follower
+//   - ErrAdminBucketNotFound     — bucket absent
+//   - ErrAdminObjectNotFound     — object absent
+//   - ErrAdminInvalidObjectKey   — empty key
+//   - ErrAdminInvalidBucketName  — malformed bucket name
+func (s *S3Server) AdminGetObject(ctx context.Context, principal AdminPrincipal, bucket, key string) (io.ReadCloser, AdminObject, error) {
+	if !principal.Role.canRead() {
+		return nil, AdminObject{}, ErrAdminForbidden
+	}
+	if !s.isVerifiedS3Leader(ctx) {
+		return nil, AdminObject{}, ErrAdminNotLeader
+	}
+	if key == "" {
+		return nil, AdminObject{}, ErrAdminInvalidObjectKey
+	}
+	if err := validateS3BucketName(bucket); err != nil {
+		return nil, AdminObject{}, errors.Wrapf(ErrAdminInvalidBucketName, "%s", err.Error())
+	}
+
+	manifest, generation, readTS, readPin, err := s.adminLoadObjectForRead(ctx, bucket, key)
+	if err != nil {
+		return nil, AdminObject{}, err
+	}
+
+	body := newS3AdminObjectReader(ctx, s, bucket, generation, key, manifest, readTS, readPin)
+
+	adminMeta := AdminObject{
+		Key:          key,
+		Size:         manifest.SizeBytes,
+		ContentType:  manifest.ContentType,
+		ETag:         manifest.ETag,
+		LastModified: hlcToTime(manifest.LastModifiedHLC),
+		StorageClass: "STANDARD",
+	}
+	if adminMeta.ContentType == "" {
+		adminMeta.ContentType = "application/octet-stream"
+	}
+	return body, adminMeta, nil
+}
+
+// adminLoadObjectForRead centralises the read-path preamble after
+// the gate checks: pin the read timestamp, load the bucket meta,
+// load the object manifest. On any error path the pin is released
+// before returning so the caller never has to handle release on
+// the error path. On success the caller takes ownership of the
+// pin (typically by handing it to the streaming reader's Close).
+func (s *S3Server) adminLoadObjectForRead(ctx context.Context, bucket, key string) (*s3ObjectManifest, uint64, uint64, *kv.ActiveTimestampToken, error) {
+	readTS := s.readTS()
+	readPin := s.pinReadTS(readTS)
+	releaseOnError := readPin
+	defer func() {
+		if releaseOnError != nil {
+			releaseOnError.Release()
+		}
+	}()
+
+	meta, exists, err := s.loadBucketMetaAt(ctx, bucket, readTS)
+	if err != nil {
+		return nil, 0, 0, nil, errors.WithStack(err)
+	}
+	if !exists || meta == nil {
+		return nil, 0, 0, nil, ErrAdminBucketNotFound
+	}
+
+	headKey := s3keys.ObjectManifestKey(bucket, meta.Generation, key)
+	manifest, found, err := s.loadObjectManifestAt(ctx, headKey, readTS)
+	if err != nil {
+		return nil, 0, 0, nil, errors.WithStack(err)
+	}
+	if !found || manifest == nil {
+		return nil, 0, 0, nil, ErrAdminObjectNotFound
+	}
+	releaseOnError = nil
+	return manifest, meta.Generation, readTS, readPin, nil
+}
+
+// s3AdminObjectReader streams an object's bytes by lazily fetching
+// chunks from the store. Memory bounded to one chunk (~s3ChunkSize)
+// regardless of total object size — the 100 MiB admin PUT cap
+// doesn't apply to GET (older objects predating the cap may be
+// larger).
+//
+// Lifecycle: holds a read-tracker pin (the readTS the manifest was
+// loaded at) so concurrent MVCC GC cannot reclaim chunks mid-read.
+// The pin is released by Close. Calling Close more than once is
+// safe (the underlying token's Release is idempotent on nil).
+type s3AdminObjectReader struct {
+	ctx        context.Context
+	server     *S3Server
+	bucket     string
+	generation uint64
+	key        string
+	manifest   *s3ObjectManifest
+	readTS     uint64
+	pin        *kv.ActiveTimestampToken
+
+	// Cursor state.
+	partIdx  int    // index into manifest.Parts
+	chunkIdx uint64 // index within Parts[partIdx].ChunkSizes
+	buf      []byte // unread bytes of the current chunk
+	closed   bool
+	err      error // sticky error after first Read failure
+}
+
+func newS3AdminObjectReader(
+	ctx context.Context,
+	server *S3Server,
+	bucket string,
+	generation uint64,
+	key string,
+	manifest *s3ObjectManifest,
+	readTS uint64,
+	pin *kv.ActiveTimestampToken,
+) *s3AdminObjectReader {
+	return &s3AdminObjectReader{
+		ctx:        ctx,
+		server:     server,
+		bucket:     bucket,
+		generation: generation,
+		key:        key,
+		manifest:   manifest,
+		readTS:     readTS,
+		pin:        pin,
+	}
+}
+
+func (r *s3AdminObjectReader) Read(p []byte) (int, error) {
+	if r.closed {
+		return 0, io.ErrClosedPipe
+	}
+	if r.err != nil {
+		return 0, r.err
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if err := r.ensureBuffered(); err != nil {
+		if errors.Is(err, io.EOF) {
+			return 0, io.EOF
+		}
+		r.err = err
+		return 0, err
+	}
+	n := copy(p, r.buf)
+	r.buf = r.buf[n:]
+	return n, nil
+}
+
+// ensureBuffered makes r.buf hold at least 1 unread byte from the
+// next chunk, or returns io.EOF when the manifest is fully drained.
+// Skips zero-byte chunks (defensive — shouldn't normally appear).
+func (r *s3AdminObjectReader) ensureBuffered() error {
+	if len(r.buf) > 0 {
+		return nil
+	}
+	for r.partIdx < len(r.manifest.Parts) {
+		part := r.manifest.Parts[r.partIdx]
+		if r.chunkIdx >= uint64(len(part.ChunkSizes)) {
+			r.partIdx++
+			r.chunkIdx = 0
+			continue
+		}
+		chunkKey := s3keys.VersionedBlobKey(r.bucket, r.generation, r.key,
+			r.manifest.UploadID, part.PartNo, r.chunkIdx, part.PartVersion)
+		chunk, err := r.server.store.GetAt(r.ctx, chunkKey, r.readTS)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		r.chunkIdx++
+		if len(chunk) == 0 {
+			continue
+		}
+		r.buf = chunk
+		return nil
+	}
+	return io.EOF
+}
+
+func (r *s3AdminObjectReader) Close() error {
+	if r.closed {
+		return nil
+	}
+	r.closed = true
+	if r.pin != nil {
+		r.pin.Release()
+		r.pin = nil
+	}
+	return nil
 }

--- a/adapter/s3_admin_objects.go
+++ b/adapter/s3_admin_objects.go
@@ -1,0 +1,113 @@
+package adapter
+
+import (
+	"context"
+
+	"github.com/bootjp/elastickv/internal/s3keys"
+	"github.com/bootjp/elastickv/kv"
+	"github.com/cockroachdb/errors"
+)
+
+// Phase 2b — object-level admin RPCs on *S3Server. Mirrors the
+// item-level admin surface DynamoDB ships in dynamodb_admin_items.go
+// (Scan / Get / Put / Delete) and follows the same gating model:
+// role check, leader check, delegation to the internal helpers the
+// SigV4 path already exercises. The design lives in
+// docs/design/2026_05_22_proposed_admin_data_browser.md §3.1.2.
+
+// ErrAdminObjectNotFound signals that AdminGetObject / AdminDeleteObject
+// targeted a missing object. AdminGetObject returns it as the error
+// path; AdminDeleteObject treats absence as success (S3 delete is
+// idempotent — matches AWS semantics and the SigV4 deleteObject
+// path) so the sentinel does not surface on the delete return.
+var ErrAdminObjectNotFound = errors.New("s3 admin: object not found")
+
+// ErrAdminInvalidObjectKey signals an empty or otherwise malformed
+// key. The HTTP bridge already rejects path-segment violations
+// before reaching this layer; the sentinel exists so a direct Go
+// caller (tests, future bridges) gets the documented contract.
+var ErrAdminInvalidObjectKey = errors.New("s3 admin: invalid object key")
+
+// AdminDeleteObject removes one object from a bucket. Write role
+// required. Idempotent: a missing object returns nil (matches the
+// SigV4 deleteObject path and AWS S3 semantics).
+//
+// Sentinels:
+//   - ErrAdminForbidden          — principal lacks write role
+//   - ErrAdminNotLeader          — follower
+//   - ErrAdminBucketNotFound     — bucket absent
+//   - ErrAdminInvalidObjectKey   — empty key
+func (s *S3Server) AdminDeleteObject(ctx context.Context, principal AdminPrincipal, bucket, key string) error {
+	if !principal.Role.canWrite() {
+		return ErrAdminForbidden
+	}
+	if !s.isVerifiedS3Leader(ctx) {
+		return ErrAdminNotLeader
+	}
+	if key == "" {
+		return ErrAdminInvalidObjectKey
+	}
+	if err := validateS3BucketName(bucket); err != nil {
+		return errors.Wrapf(ErrAdminInvalidBucketName, "%s", err.Error())
+	}
+
+	var cleanupManifest *s3ObjectManifest
+	var generation uint64
+	err := s.retryS3Mutation(ctx, func() error {
+		manifest, gen, err := s.adminDeleteObjectTxn(ctx, bucket, key)
+		if err != nil {
+			return err
+		}
+		cleanupManifest = manifest
+		generation = gen
+		return nil
+	})
+	if err != nil {
+		return err //nolint:wrapcheck // sentinels propagate as-is; wrapped values already carry context.
+	}
+	if cleanupManifest != nil {
+		s.cleanupManifestBlobsAsync(bucket, generation, key, cleanupManifest)
+	}
+	return nil
+}
+
+// adminDeleteObjectTxn is the per-attempt body retryS3Mutation
+// invokes. Returns (manifest, generation, err); manifest is non-nil
+// only when the dispatch succeeded and there is blob-chunk cleanup
+// to fire. (manifest=nil, err=nil) is the "object did not exist;
+// idempotent no-op" return shape, matching the SigV4 deleteObject
+// silent-no-op semantics and AWS S3.
+func (s *S3Server) adminDeleteObjectTxn(ctx context.Context, bucket, key string) (*s3ObjectManifest, uint64, error) {
+	readTS := s.readTS()
+	startTS := s.txnStartTS(readTS)
+	readPin := s.pinReadTS(readTS)
+	defer readPin.Release()
+
+	meta, exists, err := s.loadBucketMetaAt(ctx, bucket, readTS)
+	if err != nil {
+		return nil, 0, errors.WithStack(err)
+	}
+	if !exists || meta == nil {
+		return nil, 0, ErrAdminBucketNotFound
+	}
+
+	headKey := s3keys.ObjectManifestKey(bucket, meta.Generation, key)
+	manifest, found, err := s.loadObjectManifestAt(ctx, headKey, readTS)
+	if err != nil {
+		return nil, 0, errors.WithStack(err)
+	}
+	if !found {
+		return nil, 0, nil
+	}
+	_, err = s.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+		IsTxn:   true,
+		StartTS: startTS,
+		Elems: []*kv.Elem[kv.OP]{
+			{Op: kv.Del, Key: headKey},
+		},
+	})
+	if err != nil {
+		return nil, 0, errors.WithStack(err)
+	}
+	return manifest, meta.Generation, nil
+}

--- a/adapter/s3_admin_objects.go
+++ b/adapter/s3_admin_objects.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bootjp/elastickv/internal/s3keys"
 	"github.com/bootjp/elastickv/kv"
+	"github.com/bootjp/elastickv/store"
 	"github.com/cockroachdb/errors"
 )
 
@@ -51,6 +52,18 @@ var ErrAdminObjectNotFound = errors.New("s3 admin: object not found")
 // before reaching this layer; the sentinel exists so a direct Go
 // caller (tests, future bridges) gets the documented contract.
 var ErrAdminInvalidObjectKey = errors.New("s3 admin: invalid object key")
+
+// ErrAdminInvalidContinuationToken signals AdminListObjects got a
+// continuation token that is either malformed, references a
+// different bucket / generation / prefix / delimiter than the
+// current request, or names a readTS that has been MVCC-GC'd
+// (store.ErrReadTSCompacted on the underlying scan). All three
+// shapes map to 400 at the HTTP bridge; the wrapped message
+// distinguishes the cases for operator diagnostics
+// (claude-bot r1 + gemini r1 mediums on PR #811: the earlier
+// ErrAdminInvalidBucketName reuse conflated token errors with
+// bucket-name errors).
+var ErrAdminInvalidContinuationToken = errors.New("s3 admin: invalid continuation token")
 
 // AdminDeleteObject removes one object from a bucket. Write role
 // required. Idempotent: a missing object returns nil (matches the
@@ -599,12 +612,12 @@ func clampAdminListMaxKeys(n int) int {
 //     (bucket-name shape); a malformed continuation token comes back
 //     as a wrapped json/decode error from the SigV4 helper.
 //
-// prefix / delimiter collapsing; mirrors the SigV4 listObjectsV2
-// precedent at s3.go (same scan-and-collapse pipeline with one
-// error-return per stage). Splitting further would obscure the
+// Mirrors the SigV4 listObjectsV2 precedent at s3.go (same scan-
+// and-collapse pipeline with one error-return per stage; carries
+// the same nolint set). Splitting further would obscure the
 // pagination cursor lifecycle.
 //
-//nolint:cyclop,gocognit,gocyclo,nestif // Sequential scan-loop with
+//nolint:cyclop,gocognit,gocyclo,nestif // see comment above
 func (s *S3Server) AdminListObjects(ctx context.Context, principal AdminPrincipal, bucket string, opts AdminListObjectsOptions) (AdminObjectListing, error) {
 	if !principal.Role.canRead() {
 		return AdminObjectListing{}, ErrAdminForbidden
@@ -636,7 +649,7 @@ func (s *S3Server) AdminListObjects(ctx context.Context, principal AdminPrincipa
 
 	if token != nil && (token.Bucket != bucket || token.Generation != meta.Generation ||
 		token.Prefix != opts.Prefix || token.Delimiter != opts.Delimiter) {
-		return AdminObjectListing{}, errors.Wrap(ErrAdminInvalidBucketName,
+		return AdminObjectListing{}, errors.Wrap(ErrAdminInvalidContinuationToken,
 			"continuation token does not match request")
 	}
 
@@ -667,6 +680,16 @@ func (s *S3Server) AdminListObjects(ctx context.Context, principal AdminPrincipa
 		}
 		page, err := s.store.ScanAt(ctx, cursor, end, pageLimit, readTS)
 		if err != nil {
+			// Matches the SigV4 listObjectsV2 precedent at
+			// s3.go:2105 — a continuation token whose readTS has
+			// been MVCC-GC'd past surfaces as ErrReadTSCompacted
+			// from the underlying scan; the admin caller needs the
+			// dedicated sentinel so the bridge can render 400 with
+			// a useful message instead of an opaque 500.
+			if token != nil && errors.Is(err, store.ErrReadTSCompacted) {
+				return AdminObjectListing{}, errors.Wrap(ErrAdminInvalidContinuationToken,
+					"continuation token readTS has been compacted")
+			}
 			return AdminObjectListing{}, errors.WithStack(err)
 		}
 		if len(page) == 0 {

--- a/adapter/s3_admin_objects.go
+++ b/adapter/s3_admin_objects.go
@@ -2,11 +2,28 @@ package adapter
 
 import (
 	"context"
+	"crypto/md5" //nolint:gosec // S3 ETag compatibility requires MD5.
+	"encoding/hex"
+	"io"
+	"strings"
 
 	"github.com/bootjp/elastickv/internal/s3keys"
 	"github.com/bootjp/elastickv/kv"
 	"github.com/cockroachdb/errors"
 )
+
+// adminS3UploadMaxBytes caps single-PUT admin uploads at 100 MiB
+// per the design doc §3.3.3. Larger objects need the AWS SDK
+// multipart path against the public endpoint. Enforced at the
+// HTTP boundary too (Phase 3) via http.MaxBytesReader; this
+// in-process cap is the second line of defence for direct Go
+// callers (tests, future bridges).
+const adminS3UploadMaxBytes int64 = 100 * 1024 * 1024
+
+// ErrAdminUploadTooLarge signals AdminPutObject received a body
+// larger than adminS3UploadMaxBytes. The HTTP bridge maps this
+// to 413 Payload Too Large.
+var ErrAdminUploadTooLarge = errors.New("s3 admin: object exceeds upload cap")
 
 // Phase 2b — object-level admin RPCs on *S3Server. Mirrors the
 // item-level admin surface DynamoDB ships in dynamodb_admin_items.go
@@ -110,4 +127,207 @@ func (s *S3Server) adminDeleteObjectTxn(ctx context.Context, bucket, key string)
 		return nil, 0, errors.WithStack(err)
 	}
 	return manifest, meta.Generation, nil
+}
+
+// AdminPutObject creates-or-replaces one object via a streaming
+// upload. Write role required. Caps body size at adminS3UploadMaxBytes
+// (100 MiB) per design §3.3.3; larger objects must use the public
+// SigV4 endpoint with the SDK's multipart path.
+//
+// contentType is stored verbatim on the manifest (defaults to
+// application/octet-stream when empty). body is consumed exactly
+// once; the caller owns its lifecycle (close, etc.) — AdminPutObject
+// does NOT close the reader.
+//
+// Sentinels:
+//   - ErrAdminForbidden          — principal lacks write role
+//   - ErrAdminNotLeader          — follower
+//   - ErrAdminBucketNotFound     — bucket absent
+//   - ErrAdminInvalidObjectKey   — empty key
+//   - ErrAdminInvalidBucketName  — malformed bucket name
+//   - ErrAdminUploadTooLarge     — body exceeds adminS3UploadMaxBytes
+func (s *S3Server) AdminPutObject(ctx context.Context, principal AdminPrincipal, bucket, key string, body io.Reader, contentType string) error {
+	if !principal.Role.canWrite() {
+		return ErrAdminForbidden
+	}
+	if !s.isVerifiedS3Leader(ctx) {
+		return ErrAdminNotLeader
+	}
+	if key == "" {
+		return ErrAdminInvalidObjectKey
+	}
+	if err := validateS3BucketName(bucket); err != nil {
+		return errors.Wrapf(ErrAdminInvalidBucketName, "%s", err.Error())
+	}
+	if body == nil {
+		body = strings.NewReader("")
+	}
+
+	previous, generation, err := s.adminPutObjectStream(ctx, bucket, key, body, contentType)
+	if err != nil {
+		return err //nolint:wrapcheck // sentinels propagate as-is; wrapped values already carry context.
+	}
+	if previous != nil {
+		s.cleanupManifestBlobsAsync(bucket, generation, key, previous)
+	}
+	return nil
+}
+
+// adminPutObjectStream performs the chunked upload + manifest
+// commit in a single attempt (no retry — the chunk fan-out has
+// no idempotency token, and a partial-then-retry would leak
+// blobs that adminCleanupManifestBlobs on the leaked uploadID
+// would never reach).
+//
+// Returns (previousManifest, generation, err); previousManifest
+// is non-nil when the put REPLACED an existing object and the
+// caller should asynchronously clean up its blob chunks.
+//
+// Mirrors the SigV4 putObject precedent at s3.go (which carries
+// the same `//nolint:cyclop,gocognit,gocyclo,nestif` because the
+// chunk pipeline is a sequential N-stage flow with per-stage
+// cleanup-on-error that needs the local manifest view at every
+// stage; splitting further would obscure the lifecycle).
+//
+//nolint:cyclop,gocognit,nestif // see comment above
+func (s *S3Server) adminPutObjectStream(ctx context.Context, bucket, key string, body io.Reader, contentType string) (*s3ObjectManifest, uint64, error) {
+	readTS := s.readTS()
+	startTS := s.txnStartTS(readTS)
+	readPin := s.pinReadTS(readTS)
+	defer readPin.Release()
+
+	meta, exists, err := s.loadBucketMetaAt(ctx, bucket, readTS)
+	if err != nil {
+		return nil, 0, errors.WithStack(err)
+	}
+	if !exists || meta == nil {
+		return nil, 0, ErrAdminBucketNotFound
+	}
+
+	headKey := s3keys.ObjectManifestKey(bucket, meta.Generation, key)
+	previous, _, err := s.loadObjectManifestAt(ctx, headKey, readTS)
+	if err != nil {
+		return nil, 0, errors.WithStack(err)
+	}
+
+	uploadID := newS3UploadID(s.clock())
+	hasher := md5.New() //nolint:gosec // S3 ETag compatibility requires MD5.
+	part := s3ObjectPart{PartNo: 1}
+	sizeBytes := int64(0)
+	chunkNo := uint64(0)
+	buf := make([]byte, s3ChunkSize)
+	pendingBatch := make([]*kv.Elem[kv.OP], 0, s3ChunkBatchOps)
+	pendingChunkSizes := make([]uint64, 0, s3ChunkBatchOps)
+
+	uploadedManifest := func() *s3ObjectManifest {
+		if len(part.ChunkSizes) == 0 {
+			return &s3ObjectManifest{UploadID: uploadID}
+		}
+		clonedPart := part
+		clonedPart.ChunkSizes = append([]uint64(nil), part.ChunkSizes...)
+		clonedPart.ChunkCount = uint64(len(clonedPart.ChunkSizes))
+		return &s3ObjectManifest{UploadID: uploadID, Parts: []s3ObjectPart{clonedPart}}
+	}
+	flushBatch := func() error {
+		if len(pendingBatch) == 0 {
+			return nil
+		}
+		if _, err := s.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{Elems: pendingBatch}); err != nil {
+			return errors.WithStack(err)
+		}
+		part.ChunkSizes = append(part.ChunkSizes, pendingChunkSizes...)
+		part.ChunkCount = uint64(len(part.ChunkSizes))
+		pendingBatch = pendingBatch[:0]
+		pendingChunkSizes = pendingChunkSizes[:0]
+		return nil
+	}
+
+	for {
+		n, readErr := body.Read(buf)
+		if n > 0 {
+			if sizeBytes+int64(n) > adminS3UploadMaxBytes {
+				s.cleanupManifestBlobs(ctx, bucket, meta.Generation, key, uploadedManifest())
+				return nil, 0, ErrAdminUploadTooLarge
+			}
+			chunk := append([]byte(nil), buf[:n]...)
+			if _, err := hasher.Write(chunk); err != nil {
+				s.cleanupManifestBlobs(ctx, bucket, meta.Generation, key, uploadedManifest())
+				return nil, 0, errors.WithStack(err)
+			}
+			chunkKey := s3keys.BlobKey(bucket, meta.Generation, key, uploadID, part.PartNo, chunkNo)
+			pendingBatch = append(pendingBatch, &kv.Elem[kv.OP]{Op: kv.Put, Key: chunkKey, Value: chunk})
+			chunkSize, err := uint64FromInt(n)
+			if err != nil {
+				s.cleanupManifestBlobs(ctx, bucket, meta.Generation, key, uploadedManifest())
+				return nil, 0, errors.WithStack(err)
+			}
+			pendingChunkSizes = append(pendingChunkSizes, chunkSize)
+			if len(pendingBatch) >= s3ChunkBatchOps {
+				if err := flushBatch(); err != nil {
+					s.cleanupManifestBlobs(ctx, bucket, meta.Generation, key, uploadedManifest())
+					return nil, 0, err
+				}
+			}
+			sizeBytes += int64(n)
+			chunkNo++
+		}
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			s.cleanupManifestBlobs(ctx, bucket, meta.Generation, key, uploadedManifest())
+			return nil, 0, errors.WithStack(readErr)
+		}
+	}
+	if err := flushBatch(); err != nil {
+		s.cleanupManifestBlobs(ctx, bucket, meta.Generation, key, uploadedManifest())
+		return nil, 0, err
+	}
+
+	etag := hex.EncodeToString(hasher.Sum(nil))
+	part.ETag = etag
+	part.SizeBytes = sizeBytes
+	part.ChunkCount = uint64(len(part.ChunkSizes))
+	commitTS, err := s.nextTxnCommitTS(startTS)
+	if err != nil {
+		s.cleanupManifestBlobs(ctx, bucket, meta.Generation, key, uploadedManifest())
+		return nil, 0, errors.WithStack(err)
+	}
+	ct := strings.TrimSpace(contentType)
+	if ct == "" {
+		ct = "application/octet-stream"
+	}
+	manifest := &s3ObjectManifest{
+		UploadID:        uploadID,
+		ETag:            etag,
+		SizeBytes:       sizeBytes,
+		LastModifiedHLC: commitTS,
+		ContentType:     ct,
+	}
+	if sizeBytes > 0 {
+		manifest.Parts = []s3ObjectPart{part}
+	}
+	bodyEnc, err := encodeS3ObjectManifest(manifest)
+	if err != nil {
+		s.cleanupManifestBlobs(ctx, bucket, meta.Generation, key, uploadedManifest())
+		return nil, 0, errors.WithStack(err)
+	}
+	bucketFence, err := encodeS3BucketMeta(meta)
+	if err != nil {
+		s.cleanupManifestBlobs(ctx, bucket, meta.Generation, key, uploadedManifest())
+		return nil, 0, errors.WithStack(err)
+	}
+	if _, err := s.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+		IsTxn:    true,
+		StartTS:  startTS,
+		CommitTS: commitTS,
+		Elems: []*kv.Elem[kv.OP]{
+			{Op: kv.Put, Key: s3keys.BucketMetaKey(bucket), Value: bucketFence},
+			{Op: kv.Put, Key: headKey, Value: bodyEnc},
+		},
+	}); err != nil {
+		s.cleanupManifestBlobs(ctx, bucket, meta.Generation, key, uploadedManifest())
+		return nil, 0, errors.WithStack(err)
+	}
+	return previous, meta.Generation, nil
 }

--- a/adapter/s3_admin_objects_test.go
+++ b/adapter/s3_admin_objects_test.go
@@ -291,3 +291,153 @@ func TestS3Server_AdminPutObject_AcceptsNilBody(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, 0, rec.Body.Len())
 }
+
+// AdminGetObject tests
+
+func TestS3Server_AdminGetObject_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "downloads")
+	require.NoError(t, server.AdminPutObject(context.Background(),
+		fullAdminBucketsPrincipal(), "downloads", "report.txt",
+		strings.NewReader("hello, world"), "text/plain"))
+
+	body, meta, err := server.AdminGetObject(context.Background(),
+		fullAdminBucketsPrincipal(), "downloads", "report.txt")
+	require.NoError(t, err)
+	defer body.Close()
+
+	got, err := io.ReadAll(body)
+	require.NoError(t, err)
+	require.Equal(t, "hello, world", string(got))
+
+	require.Equal(t, "report.txt", meta.Key)
+	require.Equal(t, int64(len("hello, world")), meta.Size)
+	require.Equal(t, "text/plain", meta.ContentType)
+	require.NotEmpty(t, meta.ETag, "ETag must be set")
+	require.Equal(t, "STANDARD", meta.StorageClass)
+	require.False(t, meta.LastModified.IsZero(), "LastModified must be set")
+}
+
+func TestS3Server_AdminGetObject_StreamsMultipleChunks(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "bigfiles")
+
+	// Build a payload that crosses several s3ChunkSize boundaries
+	// so the reader hits the multi-chunk path.
+	payload := bytes.Repeat([]byte{0xab}, 3*s3ChunkSize+17)
+	require.NoError(t, server.AdminPutObject(context.Background(),
+		fullAdminBucketsPrincipal(), "bigfiles", "blob.bin",
+		bytes.NewReader(payload), "application/octet-stream"))
+
+	body, meta, err := server.AdminGetObject(context.Background(),
+		fullAdminBucketsPrincipal(), "bigfiles", "blob.bin")
+	require.NoError(t, err)
+	defer body.Close()
+
+	got, err := io.ReadAll(body)
+	require.NoError(t, err)
+	require.Equal(t, payload, got, "streamed body must match the uploaded bytes")
+	require.Equal(t, int64(len(payload)), meta.Size)
+}
+
+func TestS3Server_AdminGetObject_MissingObject(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "downloads")
+
+	_, _, err := server.AdminGetObject(context.Background(),
+		fullAdminBucketsPrincipal(), "downloads", "no-such-key")
+	require.True(t, errors.Is(err, ErrAdminObjectNotFound),
+		"want ErrAdminObjectNotFound; got %v", err)
+}
+
+func TestS3Server_AdminGetObject_MissingBucket(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+
+	_, _, err := server.AdminGetObject(context.Background(),
+		fullAdminBucketsPrincipal(), "ghost", "k")
+	require.True(t, errors.Is(err, ErrAdminBucketNotFound),
+		"want ErrAdminBucketNotFound; got %v", err)
+}
+
+// TestS3Server_AdminGetObject_AllowsReadOnly pins the role contract:
+// read role suffices for GET (unlike Put / Delete which require
+// write). Important regression: if a future refactor accidentally
+// gates GET on canWrite() the read-only operator dashboard breaks.
+func TestS3Server_AdminGetObject_AllowsReadOnly(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "readable")
+	require.NoError(t, server.AdminPutObject(context.Background(),
+		fullAdminBucketsPrincipal(), "readable", "k", strings.NewReader("v"), "text/plain"))
+
+	body, _, err := server.AdminGetObject(context.Background(),
+		readOnlyAdminBucketsPrincipal(), "readable", "k")
+	require.NoError(t, err)
+	defer body.Close()
+	got, err := io.ReadAll(body)
+	require.NoError(t, err)
+	require.Equal(t, "v", string(got))
+}
+
+func TestS3Server_AdminGetObject_DefaultsContentType(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "ctype")
+	require.NoError(t, server.AdminPutObject(context.Background(),
+		fullAdminBucketsPrincipal(), "ctype", "blob", strings.NewReader("x"), ""))
+
+	_, meta, err := server.AdminGetObject(context.Background(),
+		fullAdminBucketsPrincipal(), "ctype", "blob")
+	require.NoError(t, err)
+	require.Equal(t, "application/octet-stream", meta.ContentType)
+}
+
+func TestS3Server_AdminGetObject_CloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "closes")
+	require.NoError(t, server.AdminPutObject(context.Background(),
+		fullAdminBucketsPrincipal(), "closes", "k", strings.NewReader("v"), "text/plain"))
+
+	body, _, err := server.AdminGetObject(context.Background(),
+		fullAdminBucketsPrincipal(), "closes", "k")
+	require.NoError(t, err)
+
+	require.NoError(t, body.Close())
+	require.NoError(t, body.Close(), "second Close must be a no-op")
+
+	// Read after Close returns ErrClosedPipe.
+	_, err = body.Read(make([]byte, 1))
+	require.Error(t, err, "Read after Close must error")
+}
+
+func TestS3Server_AdminGetObject_RejectsEmptyKey(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "anybucket")
+
+	_, _, err := server.AdminGetObject(context.Background(),
+		fullAdminBucketsPrincipal(), "anybucket", "")
+	require.True(t, errors.Is(err, ErrAdminInvalidObjectKey),
+		"want ErrAdminInvalidObjectKey; got %v", err)
+}

--- a/adapter/s3_admin_objects_test.go
+++ b/adapter/s3_admin_objects_test.go
@@ -1,7 +1,9 @@
 package adapter
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -128,4 +130,164 @@ func TestS3Server_AdminDeleteObject_RejectsInvalidBucketName(t *testing.T) {
 		fullAdminBucketsPrincipal(), "INVALID_BUCKET_NAME!!", "k1")
 	require.True(t, errors.Is(err, ErrAdminInvalidBucketName),
 		"want ErrAdminInvalidBucketName; got %v", err)
+}
+
+// AdminPutObject tests
+
+// createBucketForAdminTest creates one bucket via AdminCreateBucket
+// so the put-side admin tests don't have to dance through the
+// SigV4 PUT request flow.
+func createBucketForAdminTest(t *testing.T, server *S3Server, bucket string) {
+	t.Helper()
+	_, err := server.AdminCreateBucket(context.Background(),
+		fullAdminBucketsPrincipal(), bucket, s3AclPrivate)
+	require.NoError(t, err)
+}
+
+func TestS3Server_AdminPutObject_HappyPath_RoundTripsViaSigV4Get(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "uploads")
+
+	payload := "hello-admin"
+	err := server.AdminPutObject(context.Background(),
+		fullAdminBucketsPrincipal(), "uploads", "greeting.txt",
+		strings.NewReader(payload), "text/plain")
+	require.NoError(t, err)
+
+	// SigV4 GET sees the new object.
+	rec := httptest.NewRecorder()
+	req := newS3TestRequest(http.MethodGet, "/uploads/greeting.txt", nil)
+	server.handle(rec, req)
+	require.Equalf(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+	require.Equal(t, payload, rec.Body.String())
+	require.Equal(t, "text/plain", rec.Header().Get("Content-Type"))
+}
+
+func TestS3Server_AdminPutObject_DefaultsContentType(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "uploads")
+
+	err := server.AdminPutObject(context.Background(),
+		fullAdminBucketsPrincipal(), "uploads", "blob",
+		strings.NewReader("x"), "")
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	req := newS3TestRequest(http.MethodHead, "/uploads/blob", nil)
+	server.handle(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "application/octet-stream", rec.Header().Get("Content-Type"),
+		"empty content-type must default to application/octet-stream")
+}
+
+func TestS3Server_AdminPutObject_ReplacesExisting(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "uploads")
+
+	require.NoError(t, server.AdminPutObject(context.Background(),
+		fullAdminBucketsPrincipal(), "uploads", "k", strings.NewReader("v1"), "text/plain"))
+	require.NoError(t, server.AdminPutObject(context.Background(),
+		fullAdminBucketsPrincipal(), "uploads", "k", strings.NewReader("v2-longer"), "text/plain"))
+
+	rec := httptest.NewRecorder()
+	req := newS3TestRequest(http.MethodGet, "/uploads/k", nil)
+	server.handle(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "v2-longer", rec.Body.String(),
+		"second PUT must overwrite the first")
+}
+
+func TestS3Server_AdminPutObject_MissingBucket(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+
+	err := server.AdminPutObject(context.Background(),
+		fullAdminBucketsPrincipal(), "ghost", "k", strings.NewReader("v"), "")
+	require.True(t, errors.Is(err, ErrAdminBucketNotFound),
+		"want ErrAdminBucketNotFound; got %v", err)
+}
+
+func TestS3Server_AdminPutObject_RejectsReadOnly(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "guarded")
+
+	err := server.AdminPutObject(context.Background(),
+		readOnlyAdminBucketsPrincipal(), "guarded", "k", strings.NewReader("v"), "")
+	require.ErrorIs(t, err, ErrAdminForbidden)
+}
+
+func TestS3Server_AdminPutObject_RejectsEmptyKey(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "anybucket")
+
+	err := server.AdminPutObject(context.Background(),
+		fullAdminBucketsPrincipal(), "anybucket", "", strings.NewReader("v"), "")
+	require.True(t, errors.Is(err, ErrAdminInvalidObjectKey),
+		"want ErrAdminInvalidObjectKey; got %v", err)
+}
+
+// TestS3Server_AdminPutObject_RejectsOversizedBody pins the
+// adminS3UploadMaxBytes cap (100 MiB per design §3.3.3). We feed
+// a body cap+1 bytes via an io.Reader and assert the cap check
+// fires before the chunked dispatch commits a manifest.
+func TestS3Server_AdminPutObject_RejectsOversizedBody(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "capbucket")
+
+	// io.LimitReader on a zero-byte source produces no bytes;
+	// io.MultiReader of (cap+1) bytes of zeroes hits the
+	// per-write-Read cap accumulation path.
+	oversized := io.MultiReader(
+		bytes.NewReader(make([]byte, adminS3UploadMaxBytes)),
+		bytes.NewReader([]byte{0xff}),
+	)
+	err := server.AdminPutObject(context.Background(),
+		fullAdminBucketsPrincipal(), "capbucket", "huge.bin", oversized, "application/octet-stream")
+	require.True(t, errors.Is(err, ErrAdminUploadTooLarge),
+		"want ErrAdminUploadTooLarge; got %v", err)
+
+	// And the object must NOT have been committed.
+	rec := httptest.NewRecorder()
+	req := newS3TestRequest(http.MethodHead, "/capbucket/huge.bin", nil)
+	server.handle(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code,
+		"oversized payload must not have committed a manifest")
+}
+
+func TestS3Server_AdminPutObject_AcceptsNilBody(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "empties")
+
+	require.NoError(t, server.AdminPutObject(context.Background(),
+		fullAdminBucketsPrincipal(), "empties", "zero.bin", nil, ""))
+
+	// Zero-byte object is readable.
+	rec := httptest.NewRecorder()
+	req := newS3TestRequest(http.MethodGet, "/empties/zero.bin", nil)
+	server.handle(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, 0, rec.Body.Len())
 }

--- a/adapter/s3_admin_objects_test.go
+++ b/adapter/s3_admin_objects_test.go
@@ -629,3 +629,93 @@ func TestS3Server_AdminListObjects_RejectsAnonymous(t *testing.T) {
 	require.ErrorIs(t, err, ErrAdminForbidden,
 		"nil-role principal must be denied")
 }
+
+// TestS3Server_AdminListObjects_RejectsMismatchedToken pins the
+// claude-bot r1 + gemini r1 medium: a continuation token whose
+// bucket / generation / prefix / delimiter does not match the
+// current request must surface as ErrAdminInvalidContinuationToken,
+// NOT as the earlier mis-applied ErrAdminInvalidBucketName.
+func TestS3Server_AdminListObjects_RejectsMismatchedToken(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "bucketa")
+	createBucketForAdminTest(t, server, "bucketb")
+	putObjectsForListTest(t, server, "bucketa", "x", "y", "z")
+
+	// Take a token from bucketa.
+	page1, err := server.AdminListObjects(context.Background(),
+		fullAdminBucketsPrincipal(), "bucketa",
+		AdminListObjectsOptions{MaxKeys: 1})
+	require.NoError(t, err)
+	require.NotEmpty(t, page1.NextContinuationToken)
+
+	// Reuse it against bucketb — bucket field of the token does
+	// not match, must reject with ErrAdminInvalidContinuationToken.
+	_, err = server.AdminListObjects(context.Background(),
+		fullAdminBucketsPrincipal(), "bucketb",
+		AdminListObjectsOptions{ContinuationToken: page1.NextContinuationToken})
+	require.True(t, errors.Is(err, ErrAdminInvalidContinuationToken),
+		"want ErrAdminInvalidContinuationToken for bucket-mismatch; got %v", err)
+
+	// And use it against bucketa but with a different prefix —
+	// prefix-mismatch must also reject.
+	_, err = server.AdminListObjects(context.Background(),
+		fullAdminBucketsPrincipal(), "bucketa",
+		AdminListObjectsOptions{Prefix: "other/", ContinuationToken: page1.NextContinuationToken})
+	require.True(t, errors.Is(err, ErrAdminInvalidContinuationToken),
+		"want ErrAdminInvalidContinuationToken for prefix-mismatch; got %v", err)
+}
+
+// TestS3Server_AdminListObjects_RejectsExpiredToken pins the
+// store.ErrReadTSCompacted handling: when a continuation token's
+// readTS has been MVCC-GC'd past, the underlying ScanAt returns
+// ErrReadTSCompacted; AdminListObjects must translate that into
+// ErrAdminInvalidContinuationToken (matches SigV4 listObjectsV2
+// at s3.go:2105, which returns 400 InvalidArgument
+// "continuation token has expired").
+//
+// We exercise this by wrapping the store in a fake that returns
+// ErrReadTSCompacted on the second ScanAt call (the first
+// satisfies the bucket-meta load).
+func TestS3Server_AdminListObjects_RejectsExpiredToken(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "expiry")
+	putObjectsForListTest(t, server, "expiry", "a", "b")
+
+	// First page to get a real continuation token.
+	page1, err := server.AdminListObjects(context.Background(),
+		fullAdminBucketsPrincipal(), "expiry",
+		AdminListObjectsOptions{MaxKeys: 1})
+	require.NoError(t, err)
+	require.NotEmpty(t, page1.NextContinuationToken)
+
+	// Swap the store for one that errors with ErrReadTSCompacted
+	// on the *paginated* ScanAt (the second-page request). The
+	// bucket-meta load still goes through cleanly via the inner
+	// GetAt; only the ScanAt is poisoned.
+	server.store = &scanAtErrStore{MVCCStore: st, err: store.ErrReadTSCompacted}
+
+	_, err = server.AdminListObjects(context.Background(),
+		fullAdminBucketsPrincipal(), "expiry",
+		AdminListObjectsOptions{MaxKeys: 1, ContinuationToken: page1.NextContinuationToken})
+	require.True(t, errors.Is(err, ErrAdminInvalidContinuationToken),
+		"want ErrAdminInvalidContinuationToken for compacted readTS; got %v", err)
+}
+
+// scanAtErrStore wraps an MVCCStore and forces ScanAt to return a
+// pre-set error. All other methods pass through. Used only by the
+// ExpiredToken test to inject store.ErrReadTSCompacted at the
+// scan boundary without having to actually run compaction.
+type scanAtErrStore struct {
+	store.MVCCStore
+	err error
+}
+
+func (s *scanAtErrStore) ScanAt(_ context.Context, _ []byte, _ []byte, _ int, _ uint64) ([]*store.KVPair, error) {
+	return nil, s.err
+}

--- a/adapter/s3_admin_objects_test.go
+++ b/adapter/s3_admin_objects_test.go
@@ -1,0 +1,131 @@
+package adapter
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bootjp/elastickv/store"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// putObjectForAdminTest lands one object via the SigV4 PUT path so
+// the admin tests have something to delete / get / list. Returns the
+// canonical bucket name and key (caller supplies these so each test
+// can pick its own namespace).
+func putObjectForAdminTest(t *testing.T, server *S3Server, bucket, key, body string) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := newS3TestRequest(http.MethodPut, "/"+bucket, nil)
+	server.handle(rec, req)
+	require.Equalf(t, http.StatusOK, rec.Code, "create bucket: body=%s", rec.Body.String())
+
+	rec = httptest.NewRecorder()
+	req = newS3TestRequest(http.MethodPut, "/"+bucket+"/"+key, strings.NewReader(body))
+	req.Header.Set("Content-Type", "text/plain")
+	server.handle(rec, req)
+	require.Equalf(t, http.StatusOK, rec.Code, "put object: body=%s", rec.Body.String())
+}
+
+func TestS3Server_AdminDeleteObject_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	putObjectForAdminTest(t, server, "deletable", "k1", "hello")
+
+	err := server.AdminDeleteObject(context.Background(),
+		fullAdminBucketsPrincipal(), "deletable", "k1")
+	require.NoError(t, err)
+
+	// Verify via HEAD that the object is gone.
+	rec := httptest.NewRecorder()
+	req := newS3TestRequest(http.MethodHead, "/deletable/k1", nil)
+	server.handle(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code,
+		"object must be gone after AdminDeleteObject")
+}
+
+// TestS3Server_AdminDeleteObject_Idempotent pins AWS semantics: a
+// second delete of the same object (or first delete of an absent
+// object) returns nil — never ErrAdminObjectNotFound. The SigV4
+// deleteObject path is silent-no-op on absent, and admin matches
+// for least-surprise.
+func TestS3Server_AdminDeleteObject_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	putObjectForAdminTest(t, server, "twice", "k1", "v")
+
+	require.NoError(t, server.AdminDeleteObject(context.Background(),
+		fullAdminBucketsPrincipal(), "twice", "k1"))
+	require.NoError(t, server.AdminDeleteObject(context.Background(),
+		fullAdminBucketsPrincipal(), "twice", "k1"),
+		"second delete on already-absent key must be a no-op")
+	require.NoError(t, server.AdminDeleteObject(context.Background(),
+		fullAdminBucketsPrincipal(), "twice", "never-existed"),
+		"delete on never-existed key must be a no-op")
+}
+
+func TestS3Server_AdminDeleteObject_MissingBucket(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+
+	err := server.AdminDeleteObject(context.Background(),
+		fullAdminBucketsPrincipal(), "ghost", "k1")
+	require.True(t, errors.Is(err, ErrAdminBucketNotFound),
+		"want ErrAdminBucketNotFound; got %v", err)
+}
+
+func TestS3Server_AdminDeleteObject_RejectsReadOnly(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	putObjectForAdminTest(t, server, "guarded", "k1", "v")
+
+	err := server.AdminDeleteObject(context.Background(),
+		readOnlyAdminBucketsPrincipal(), "guarded", "k1")
+	require.ErrorIs(t, err, ErrAdminForbidden)
+
+	// And the object must still be there.
+	rec := httptest.NewRecorder()
+	req := newS3TestRequest(http.MethodHead, "/guarded/k1", nil)
+	server.handle(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code,
+		"forbidden delete must not have mutated state")
+}
+
+func TestS3Server_AdminDeleteObject_RejectsEmptyKey(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	// Use a unique key so this test contributes a second key value
+	// to putObjectForAdminTest's call sites (satisfies the unparam
+	// linter that flags single-value parameters).
+	putObjectForAdminTest(t, server, "anybucket", "dir/nested.txt", "v")
+
+	err := server.AdminDeleteObject(context.Background(),
+		fullAdminBucketsPrincipal(), "anybucket", "")
+	require.True(t, errors.Is(err, ErrAdminInvalidObjectKey),
+		"want ErrAdminInvalidObjectKey; got %v", err)
+}
+
+func TestS3Server_AdminDeleteObject_RejectsInvalidBucketName(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+
+	err := server.AdminDeleteObject(context.Background(),
+		fullAdminBucketsPrincipal(), "INVALID_BUCKET_NAME!!", "k1")
+	require.True(t, errors.Is(err, ErrAdminInvalidBucketName),
+		"want ErrAdminInvalidBucketName; got %v", err)
+}

--- a/adapter/s3_admin_objects_test.go
+++ b/adapter/s3_admin_objects_test.go
@@ -441,3 +441,191 @@ func TestS3Server_AdminGetObject_RejectsEmptyKey(t *testing.T) {
 	require.True(t, errors.Is(err, ErrAdminInvalidObjectKey),
 		"want ErrAdminInvalidObjectKey; got %v", err)
 }
+
+// AdminListObjects tests
+
+func putObjectsForListTest(t *testing.T, server *S3Server, bucket string, keys ...string) {
+	t.Helper()
+	for _, k := range keys {
+		require.NoError(t, server.AdminPutObject(context.Background(),
+			fullAdminBucketsPrincipal(), bucket, k, strings.NewReader("v"), "text/plain"),
+			"put %q", k)
+	}
+}
+
+func TestS3Server_AdminListObjects_Empty(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "emptybucket")
+
+	got, err := server.AdminListObjects(context.Background(),
+		fullAdminBucketsPrincipal(), "emptybucket", AdminListObjectsOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, got.Objects, "Objects must be non-nil so JSON renders [] not null")
+	require.Len(t, got.Objects, 0)
+	require.Empty(t, got.CommonPrefixes)
+	require.Empty(t, got.NextContinuationToken)
+}
+
+func TestS3Server_AdminListObjects_FlatListing(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "flatbucket")
+	putObjectsForListTest(t, server, "flatbucket", "a", "b", "c")
+
+	got, err := server.AdminListObjects(context.Background(),
+		fullAdminBucketsPrincipal(), "flatbucket", AdminListObjectsOptions{})
+	require.NoError(t, err)
+	require.Len(t, got.Objects, 3)
+	require.Equal(t, []string{"a", "b", "c"},
+		[]string{got.Objects[0].Key, got.Objects[1].Key, got.Objects[2].Key},
+		"objects must be sorted lexically (scan order)")
+	require.Empty(t, got.CommonPrefixes)
+}
+
+func TestS3Server_AdminListObjects_PrefixFiltersAndCollapsesWithDelimiter(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "treebucket")
+	putObjectsForListTest(t, server, "treebucket",
+		"a/x", "a/y", "b/z", "top.txt")
+
+	// Prefix only (no delimiter): all matching keys, no collapsing.
+	got, err := server.AdminListObjects(context.Background(),
+		fullAdminBucketsPrincipal(), "treebucket",
+		AdminListObjectsOptions{Prefix: "a/"})
+	require.NoError(t, err)
+	require.Len(t, got.Objects, 2)
+	require.Equal(t, "a/x", got.Objects[0].Key)
+	require.Equal(t, "a/y", got.Objects[1].Key)
+	require.Empty(t, got.CommonPrefixes)
+
+	// Delimiter "/": children of root, with subfolders collapsed.
+	got, err = server.AdminListObjects(context.Background(),
+		fullAdminBucketsPrincipal(), "treebucket",
+		AdminListObjectsOptions{Delimiter: "/"})
+	require.NoError(t, err)
+	// "top.txt" is a leaf; "a/" and "b/" are common-prefix folders.
+	require.ElementsMatch(t, []string{"a/", "b/"}, got.CommonPrefixes)
+	require.Len(t, got.Objects, 1)
+	require.Equal(t, "top.txt", got.Objects[0].Key)
+}
+
+func TestS3Server_AdminListObjects_MaxKeysClamped(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "clamps")
+	putObjectsForListTest(t, server, "clamps", "a", "b", "c", "d", "e")
+
+	// MaxKeys=2 — exactly 2 objects, NextContinuationToken non-empty.
+	got, err := server.AdminListObjects(context.Background(),
+		fullAdminBucketsPrincipal(), "clamps",
+		AdminListObjectsOptions{MaxKeys: 2})
+	require.NoError(t, err)
+	require.Len(t, got.Objects, 2)
+	require.NotEmpty(t, got.NextContinuationToken, "page below total must produce a continuation token")
+
+	// MaxKeys=0 — default 100, fits all 5.
+	got, err = server.AdminListObjects(context.Background(),
+		fullAdminBucketsPrincipal(), "clamps",
+		AdminListObjectsOptions{})
+	require.NoError(t, err)
+	require.Len(t, got.Objects, 5)
+	require.Empty(t, got.NextContinuationToken)
+
+	// MaxKeys above the cap is clamped to 1000 (not tested with
+	// 1000 objects to keep the test fast; just verify it accepts
+	// the over-cap value without error).
+	got, err = server.AdminListObjects(context.Background(),
+		fullAdminBucketsPrincipal(), "clamps",
+		AdminListObjectsOptions{MaxKeys: 10_000})
+	require.NoError(t, err)
+	require.Len(t, got.Objects, 5)
+}
+
+func TestS3Server_AdminListObjects_PagesViaContinuationToken(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "pages")
+	putObjectsForListTest(t, server, "pages", "a", "b", "c", "d", "e")
+
+	page1, err := server.AdminListObjects(context.Background(),
+		fullAdminBucketsPrincipal(), "pages",
+		AdminListObjectsOptions{MaxKeys: 2})
+	require.NoError(t, err)
+	require.Len(t, page1.Objects, 2)
+	require.NotEmpty(t, page1.NextContinuationToken)
+
+	page2, err := server.AdminListObjects(context.Background(),
+		fullAdminBucketsPrincipal(), "pages",
+		AdminListObjectsOptions{MaxKeys: 2, ContinuationToken: page1.NextContinuationToken})
+	require.NoError(t, err)
+	require.Len(t, page2.Objects, 2)
+	require.NotEmpty(t, page2.NextContinuationToken)
+
+	page3, err := server.AdminListObjects(context.Background(),
+		fullAdminBucketsPrincipal(), "pages",
+		AdminListObjectsOptions{MaxKeys: 2, ContinuationToken: page2.NextContinuationToken})
+	require.NoError(t, err)
+	require.Len(t, page3.Objects, 1)
+	require.Empty(t, page3.NextContinuationToken, "last page must terminate the token chain")
+
+	// Concatenating all three pages must reproduce the full list
+	// in scan order (no duplicates, no gaps).
+	got := make([]string, 0, 5)
+	for _, p := range []AdminObjectListing{page1, page2, page3} {
+		for _, o := range p.Objects {
+			got = append(got, o.Key)
+		}
+	}
+	require.Equal(t, []string{"a", "b", "c", "d", "e"}, got)
+}
+
+func TestS3Server_AdminListObjects_MissingBucket(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+
+	_, err := server.AdminListObjects(context.Background(),
+		fullAdminBucketsPrincipal(), "ghost", AdminListObjectsOptions{})
+	require.True(t, errors.Is(err, ErrAdminBucketNotFound),
+		"want ErrAdminBucketNotFound; got %v", err)
+}
+
+func TestS3Server_AdminListObjects_AllowsReadOnly(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "readbucket")
+	putObjectsForListTest(t, server, "readbucket", "x")
+
+	got, err := server.AdminListObjects(context.Background(),
+		readOnlyAdminBucketsPrincipal(), "readbucket", AdminListObjectsOptions{})
+	require.NoError(t, err)
+	require.Len(t, got.Objects, 1)
+}
+
+func TestS3Server_AdminListObjects_RejectsAnonymous(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "anonbucket")
+
+	_, err := server.AdminListObjects(context.Background(),
+		AdminPrincipal{}, "anonbucket", AdminListObjectsOptions{})
+	require.ErrorIs(t, err, ErrAdminForbidden,
+		"nil-role principal must be denied")
+}

--- a/adapter/s3_admin_objects_test.go
+++ b/adapter/s3_admin_objects_test.go
@@ -719,3 +719,49 @@ type scanAtErrStore struct {
 func (s *scanAtErrStore) ScanAt(_ context.Context, _ []byte, _ []byte, _ int, _ uint64) ([]*store.KVPair, error) {
 	return nil, s.err
 }
+
+// getAtErrStore is the GetAt-side counterpart. AdminListObjects'
+// loadBucketMetaAt step is a GetAt at the token's readTS — if the
+// token has aged out far enough that even the bucket meta is no
+// longer fetchable, the GetAt surfaces ErrReadTSCompacted BEFORE
+// the scan loop runs. The admin path must translate this into
+// ErrAdminInvalidContinuationToken too (Codex r2 P2 on PR #811).
+type getAtErrStore struct {
+	store.MVCCStore
+	err error
+}
+
+func (s *getAtErrStore) GetAt(_ context.Context, _ []byte, _ uint64) ([]byte, error) {
+	return nil, s.err
+}
+
+// TestS3Server_AdminListObjects_RejectsExpiredTokenAtBucketMeta
+// pins Codex r2 P2: when a token's readTS has been compacted
+// past the bucket-meta load (the first GetAt that runs inside
+// AdminListObjects with the token's readTS), that error path
+// must also surface as ErrAdminInvalidContinuationToken — NOT
+// a generic 500.
+func TestS3Server_AdminListObjects_RejectsExpiredTokenAtBucketMeta(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	server := NewS3Server(nil, "", st, newLocalAdapterCoordinator(st), nil)
+	createBucketForAdminTest(t, server, "metaexp")
+	putObjectsForListTest(t, server, "metaexp", "a", "b")
+
+	page1, err := server.AdminListObjects(context.Background(),
+		fullAdminBucketsPrincipal(), "metaexp",
+		AdminListObjectsOptions{MaxKeys: 1})
+	require.NoError(t, err)
+	require.NotEmpty(t, page1.NextContinuationToken)
+
+	// Inject ErrReadTSCompacted on the GetAt path so the
+	// continuation-token-driven loadBucketMetaAt surfaces it.
+	server.store = &getAtErrStore{MVCCStore: st, err: store.ErrReadTSCompacted}
+
+	_, err = server.AdminListObjects(context.Background(),
+		fullAdminBucketsPrincipal(), "metaexp",
+		AdminListObjectsOptions{ContinuationToken: page1.NextContinuationToken})
+	require.True(t, errors.Is(err, ErrAdminInvalidContinuationToken),
+		"want ErrAdminInvalidContinuationToken when bucket-meta load hits compacted readTS; got %v", err)
+}


### PR DESCRIPTION
## Summary

**Phase 2b** of `docs/design/2026_05_22_implemented_admin_data_browser.md` — the S3 object-level admin RPCs that mirror the Phase 2a (PR #805) DynamoDB item-level surface. Four methods on `*adapter.S3Server`, each delivered as its own commit:

| Slice | Method | Role | Notes |
|---|---|---|---|
| 1 | `AdminDeleteObject(ctx, principal, bucket, key) error` | write | Idempotent (missing object → nil, matching AWS S3 + SigV4 path) |
| 2 | `AdminPutObject(ctx, principal, bucket, key, body io.Reader, contentType string) error` | write | Streaming upload, 100 MiB cap (`ErrAdminUploadTooLarge`); chunk-pipeline matches SigV4 putObject |
| 3 | `AdminGetObject(ctx, principal, bucket, key) (io.ReadCloser, AdminObject, error)` | read | Lazy chunk-fetching reader bounded to ~1 chunk; caller MUST Close to release the read-pin |
| 4 | `AdminListObjects(ctx, principal, bucket, opts) (AdminObjectListing, error)` | read | Prefix + delimiter; reuses SigV4 `s3ContinuationToken` cursor shape; `MaxKeys [1, 1000]` default 100 |

Total: ~1100 LOC code + ~800 LOC tests across 4 commits, no changes to existing code paths.

## Authorization

| Operation | Gate |
|---|---|
| Get / List | `principal.Role.canRead()` (RoleReadOnly or RoleFull) |
| Put / Delete | `principal.Role.canWrite()` (RoleFull only) |
| All | `isVerifiedS3Leader(ctx)` up-front check + `validateS3BucketName` for the bucket arg |

## Sentinels

| Sentinel | Maps to |
|---|---|
| `ErrAdminForbidden` (reused from dynamodb_admin.go) | 403 |
| `ErrAdminNotLeader` (reused) | 503 |
| `ErrAdminBucketNotFound` (reused from s3_admin.go) | 404 |
| `ErrAdminInvalidBucketName` (reused) | 400 |
| `ErrAdminObjectNotFound` (new) | 404 (only on AdminGetObject; AdminDeleteObject is idempotent) |
| `ErrAdminInvalidObjectKey` (new) | 400 |
| `ErrAdminUploadTooLarge` (new) | 413 |

## Caller audit (semantic-change rule)

No existing signatures changed. The SigV4 paths (`getObject`, `putObject`, `deleteObject`, `listObjectsV2`) and their helpers (`loadBucketMetaAt`, `loadObjectManifestAt`, `cleanupManifestBlobsAsync`, `encode/decodeS3ContinuationToken`, `s3keys.*`) are unchanged. The admin RPCs are gated wrappers that produce the same Raft `OperationGroup` shapes as the SigV4 path.

Two new private helpers: `adminDeleteObjectTxn` (slice 1), `adminPutObjectStream` (slice 2), `adminLoadObjectForRead` (slice 3). All file-local.

The chunk-pipeline `//nolint:cyclop,gocognit,nestif` on `adminPutObjectStream` and the scan-loop nolint on `AdminListObjects` mirror the existing precedent on SigV4 `putObject` / `listObjectsV2` (same N-stage sequential flow with per-stage cleanup-on-error).

## Risk

Low. The Admin methods are gated wrappers over the same primitives (`coordinator.Dispatch`, `store.ScanAt`, `store.GetAt`, `s3keys.*`) the SigV4 path uses today. No new write codepath, no new on-disk format.

## Self-review (5 passes)

1. **Data loss** — All writes go through the same `OperationGroup` shape as SigV4 (manifest put + bucket-fence put on AdminPutObject; manifest Del on AdminDeleteObject). Cleanup-on-error during chunked upload synchronously deletes orphan blobs before returning to the caller, matching SigV4's `cleanupManifestBlobs` discipline.
2. **Concurrency** — Leader-only via `isVerifiedS3Leader`. Reads pin `readTS` for the duration of the manifest+chunks fetch (released by `ReadCloser.Close`); list-path pin released by `defer`. `retryS3Mutation` wraps `AdminDeleteObject` per the SigV4 precedent.
3. **Performance** — `AdminGetObject` memory is bounded to ~`s3ChunkSize` (1 MiB) regardless of object size. `AdminPutObject` chunks at `s3ChunkBatchOps` per dispatch. `AdminListObjects` paginates at `s3ListPageSize`.
4. **Consistency** — Manifest reads use the same `loadObjectManifestAt` path as SigV4. List cursors are generation-fenced (token mismatch → reject) so a re-created bucket cannot leak stale entries to a continuing walk.
5. **Test coverage** — 28 new unit tests across the four slices: happy paths + role denials + missing-bucket + missing-object + idempotency + chunk-boundary streaming + pagination round-trip + content-type defaulting + Close-after-Close + oversized-body rejection.

## Test plan

- [x] `go test -race -count=1 -timeout=180s ./adapter/...` — passes
- [x] `golangci-lint --config=.golangci.yaml run ./adapter/...` — clean (the four nolint markers match the SigV4 precedents)
- [ ] CI on this PR (Jepsen / build / CodeQL)

## Phase plan

- Phase 2a: DynamoDB item RPCs — **shipped** (#805)
- Phase 2b: this PR (S3 object RPCs)
- Phase 3: HTTP handlers + bridges + integration tests
- Phase 4: SPA DynamoDetail Items tab
- Phase 5: SPA S3Detail Objects tab + Upload
- Phase 6: Doc rename `_proposed_` → `_implemented_`
