### PR TITLE
internal/admin: HTTP handlers for DynamoDB item RPCs (Phase 3a)

### DIFF
--- a/internal/admin/dynamo_handler.go
+++ b/internal/admin/dynamo_handler.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -282,18 +283,24 @@ const (
 
 func (h *DynamoHandler) dispatchPerTableRoute(w http.ResponseWriter, r *http.Request) {
 	// EscapedPath() exposes percent-encoded segments verbatim so the
-	// `%`-rejection in isValidAdminPathSegment catches things like
-	// %2F (encoded /), %2E%2E (encoded ..), %252F (double-encoded).
-	// r.URL.Path is pre-decoded and would let those slip through.
+	// decode+validate step in decodeAndValidatePathSegment can
+	// distinguish raw `/` (path separator) from `%2F` (a literal `/`
+	// the operator URL-escaped) — both must be rejected as segment
+	// content. r.URL.Path is pre-decoded and would silently turn
+	// `%2F` into a real `/`, collapsing two distinct attack classes
+	// into one.
 	escaped := r.URL.EscapedPath()
 	rest := strings.TrimPrefix(escaped, pathPrefixDynamoTables)
-	segments := dropSingleTrailingEmpty(strings.Split(rest, "/"))
-	for _, seg := range segments {
-		if !isValidAdminPathSegment(seg) {
+	rawSegments := dropSingleTrailingEmpty(strings.Split(rest, "/"))
+	segments := make([]string, 0, len(rawSegments))
+	for _, seg := range rawSegments {
+		decoded, ok := decodeAndValidatePathSegment(seg)
+		if !ok {
 			writeJSONError(w, http.StatusBadRequest, "invalid_path",
-				"path segment is empty, contains %, or is a dot-segment")
+				"path segment is empty, malformed percent-encoding, contains an encoded slash, or is a dot-segment")
 			return
 		}
+		segments = append(segments, decoded)
 	}
 	switch len(segments) {
 	case dynamoRouteSegmentsTable:
@@ -311,7 +318,13 @@ func (h *DynamoHandler) dispatchPerTableRoute(w http.ResponseWriter, r *http.Req
 				"unknown sub-resource on this table")
 			return
 		}
-		h.handleItemResource(w, r, segments[0], segments[2])
+		// The {key} segment is base64-url-encoded by the SPA, so the
+		// decoded form here equals the raw form (base64-url alphabet
+		// is a subset of unreserved URL chars). Pass rawSegments[2]
+		// to handleItemResource so its existing base64 decoder runs
+		// against the wire form — a future format change in the SPA
+		// (e.g. using padded base64) wouldn't drift the contract.
+		h.handleItemResource(w, r, segments[0], rawSegments[2])
 	default:
 		writeJSONError(w, http.StatusNotFound, "unknown_endpoint",
 			"too many path segments")
@@ -332,23 +345,51 @@ func (h *DynamoHandler) dispatchTableResource(w http.ResponseWriter, r *http.Req
 	}
 }
 
-// isValidAdminPathSegment enforces the same per-segment rules
-// SQS adopted (Phase 5 of the routing procedure docs): no empty
-// segment, no percent sign (closes the %2F / %252F / %2e /
-// %2E%2E percent-encoded escape classes), no literal dot-segment
-// strings (`.` / `..` — closes the raw dot-segment traversal
-// class that path.Clean would otherwise collapse).
-func isValidAdminPathSegment(seg string) bool {
+// decodeAndValidatePathSegment is the canonical per-segment guard
+// for the dynamo dispatcher. Codex P1 on PR #813 narrowed the
+// original SQS-style "reject any %" rule, which made tables whose
+// names need URL-escaping (spaces, UTF-8, etc.) unreachable through
+// describe / delete / items even though validateCreateTableRequest
+// accepts those names.
+//
+// The new contract: percent-encoded chars are accepted, but the
+// decoded form is what gets validated.
+//
+//   - empty raw segment → reject
+//   - malformed percent-encoding (`%g`, dangling `%`) → reject
+//   - decoded `/` (e.g. `%2F`, `%2f`) → reject (closes the
+//     percent-encoded path-traversal class)
+//   - decoded `.` or `..` (e.g. raw `.`, `%2e`, `%2e%2e`, `%2E`) →
+//     reject (closes the raw + percent-encoded dot-segment class)
+//
+// Returns the decoded segment on success. The caller passes the
+// decoded form to the per-resource handlers so a URL like
+// `/tables/foo%20bar` reaches AdminDescribeTable with "foo bar"
+// rather than "foo%20bar".
+//
+// Note on double-encoding: `%252F` decodes to `%2F` (a literal
+// percent-2F), not to `/`. That's correct — `%252F` is the
+// percent-encoded form of the string "%2F", which is itself
+// non-traversal content. The decoded `%2F` does not contain a
+// literal `/`, so the slash check passes. Only a single layer of
+// percent-encoded slash is rejected, matching the actual attack
+// class (a single-encoded slash that bypasses the literal `/`
+// split).
+func decodeAndValidatePathSegment(seg string) (string, bool) {
 	if seg == "" {
-		return false
+		return "", false
 	}
-	if strings.ContainsRune(seg, '%') {
-		return false
+	decoded, err := url.PathUnescape(seg)
+	if err != nil {
+		return "", false
 	}
-	if seg == "." || seg == ".." {
-		return false
+	if strings.ContainsRune(decoded, '/') {
+		return "", false
 	}
-	return true
+	if decoded == "." || decoded == ".." {
+		return "", false
+	}
+	return decoded, true
 }
 
 // dynamoListResponse is the JSON shape returned by GET /tables.

--- a/internal/admin/dynamo_handler.go
+++ b/internal/admin/dynamo_handler.go
@@ -318,13 +318,15 @@ func (h *DynamoHandler) dispatchPerTableRoute(w http.ResponseWriter, r *http.Req
 				"unknown sub-resource on this table")
 			return
 		}
-		// The {key} segment is base64-url-encoded by the SPA, so the
-		// decoded form here equals the raw form (base64-url alphabet
-		// is a subset of unreserved URL chars). Pass rawSegments[2]
-		// to handleItemResource so its existing base64 decoder runs
-		// against the wire form — a future format change in the SPA
-		// (e.g. using padded base64) wouldn't drift the contract.
-		h.handleItemResource(w, r, segments[0], rawSegments[2])
+		// Pass the decoded segment. The raw-base64-url alphabet
+		// (A-Z a-z 0-9 - _) doesn't need percent-encoding, but
+		// padded base64-url uses `=` which clients may URL-escape
+		// to %3D (encodeURIComponent does). The decoder accepts
+		// padded base64 as a fallback per decodeAdminItemKeySegment2's
+		// docstring; passing the raw segment would defeat that
+		// fallback and 400 on hand-crafted curl with %3D padding.
+		// Codex P2 on PR #813 r7 caught the regression.
+		h.handleItemResource(w, r, segments[0], segments[2])
 	default:
 		writeJSONError(w, http.StatusNotFound, "unknown_endpoint",
 			"too many path segments")

--- a/internal/admin/dynamo_handler.go
+++ b/internal/admin/dynamo_handler.go
@@ -70,6 +70,16 @@ type TablesSource interface {
 	AdminDescribeTable(ctx context.Context, name string) (*DynamoTableSummary, bool, error)
 	AdminCreateTable(ctx context.Context, principal AuthPrincipal, in CreateTableRequest) (*DynamoTableSummary, error)
 	AdminDeleteTable(ctx context.Context, principal AuthPrincipal, name string) error
+
+	// Item-level admin RPCs (Phase 3a — design §3.1.1).
+	// The handler in dynamo_items_handler.go drives these for the
+	// /tables/{name}/items{,/{key}} sub-tree. Implementations live
+	// in main_admin.go (dynamoTablesBridge) and bridge to the
+	// adapter package's Admin*Item methods.
+	AdminScanItems(ctx context.Context, principal AuthPrincipal, table string, opts AdminScanItemsOptions) (AdminScanItemsResult, error)
+	AdminGetItem(ctx context.Context, principal AuthPrincipal, table string, key map[string]AdminAttributeValue) (*AdminItem, bool, error)
+	AdminPutItem(ctx context.Context, principal AuthPrincipal, table string, item AdminItem) error
+	AdminDeleteItem(ctx context.Context, principal AuthPrincipal, table string, key map[string]AdminAttributeValue) error
 }
 
 // CreateTableRequest is the JSON body shape for POST /tables per
@@ -241,18 +251,104 @@ func (h *DynamoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			writeJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed", "only GET or POST")
 		}
 	case strings.HasPrefix(r.URL.Path, pathPrefixDynamoTables):
-		name := strings.TrimPrefix(r.URL.Path, pathPrefixDynamoTables)
-		switch r.Method {
-		case http.MethodGet:
-			h.handleDescribe(w, r, name)
-		case http.MethodDelete:
-			h.handleDelete(w, r, name)
-		default:
-			writeJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed", "only GET or DELETE")
-		}
+		h.dispatchPerTableRoute(w, r)
 	default:
 		writeJSONError(w, http.StatusNotFound, "not_found", "")
 	}
+}
+
+// dispatchPerTableRoute fans out the /tables/{name}{,/items{,/{key}}}
+// sub-tree. Splits the URL suffix into path segments and validates
+// each against the same dot-segment / percent-encoding rejection
+// the SQS handler adopted (no `..`, no `.`, no `%`-escaped path
+// segments). The validation is up-front so a malformed `{name}` or
+// `{key}` cannot reach the Admin* methods.
+//
+//	1 seg  → /tables/{name}              (existing describe / delete)
+//	2 segs → /tables/{name}/items        (Phase 3a: scan)
+//	3 segs → /tables/{name}/items/{key}  (Phase 3a: get / put / delete)
+//
+// Anything else is a 404. The second segment is required to be the
+// literal "items" string; any other sub-resource name is also a
+// 404 (the SPA never targets one).
+// Per-table route segment counts. Named to keep the dispatcher
+// switch self-documenting and to satisfy the mnd linter (which
+// flags magic 2/3 in case-labels).
+const (
+	dynamoRouteSegmentsTable           = 1
+	dynamoRouteSegmentsItemsCollection = 2
+	dynamoRouteSegmentsItemResource    = 3
+)
+
+func (h *DynamoHandler) dispatchPerTableRoute(w http.ResponseWriter, r *http.Request) {
+	// EscapedPath() exposes percent-encoded segments verbatim so the
+	// `%`-rejection in isValidAdminPathSegment catches things like
+	// %2F (encoded /), %2E%2E (encoded ..), %252F (double-encoded).
+	// r.URL.Path is pre-decoded and would let those slip through.
+	escaped := r.URL.EscapedPath()
+	rest := strings.TrimPrefix(escaped, pathPrefixDynamoTables)
+	segments := dropSingleTrailingEmpty(strings.Split(rest, "/"))
+	for _, seg := range segments {
+		if !isValidAdminPathSegment(seg) {
+			writeJSONError(w, http.StatusBadRequest, "invalid_path",
+				"path segment is empty, contains %, or is a dot-segment")
+			return
+		}
+	}
+	switch len(segments) {
+	case dynamoRouteSegmentsTable:
+		h.dispatchTableResource(w, r, segments[0])
+	case dynamoRouteSegmentsItemsCollection:
+		if segments[1] != adminItemSubResource {
+			writeJSONError(w, http.StatusNotFound, "unknown_endpoint",
+				"unknown sub-resource on this table")
+			return
+		}
+		h.handleItemsCollection(w, r, segments[0])
+	case dynamoRouteSegmentsItemResource:
+		if segments[1] != adminItemSubResource {
+			writeJSONError(w, http.StatusNotFound, "unknown_endpoint",
+				"unknown sub-resource on this table")
+			return
+		}
+		h.handleItemResource(w, r, segments[0], segments[2])
+	default:
+		writeJSONError(w, http.StatusNotFound, "unknown_endpoint",
+			"too many path segments")
+	}
+}
+
+// dispatchTableResource handles /tables/{name}: GET = describe,
+// DELETE = delete. Extracted from dispatchPerTableRoute so the
+// parent stays under the cyclop=10 ceiling.
+func (h *DynamoHandler) dispatchTableResource(w http.ResponseWriter, r *http.Request, name string) {
+	switch r.Method {
+	case http.MethodGet:
+		h.handleDescribe(w, r, name)
+	case http.MethodDelete:
+		h.handleDelete(w, r, name)
+	default:
+		writeJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed", "only GET or DELETE")
+	}
+}
+
+// isValidAdminPathSegment enforces the same per-segment rules
+// SQS adopted (Phase 5 of the routing procedure docs): no empty
+// segment, no percent sign (closes the %2F / %252F / %2e /
+// %2E%2E percent-encoded escape classes), no literal dot-segment
+// strings (`.` / `..` — closes the raw dot-segment traversal
+// class that path.Clean would otherwise collapse).
+func isValidAdminPathSegment(seg string) bool {
+	if seg == "" {
+		return false
+	}
+	if strings.ContainsRune(seg, '%') {
+		return false
+	}
+	if seg == "." || seg == ".." {
+		return false
+	}
+	return true
 }
 
 // dynamoListResponse is the JSON shape returned by GET /tables.

--- a/internal/admin/dynamo_handler.go
+++ b/internal/admin/dynamo_handler.go
@@ -759,6 +759,16 @@ func validateCreateTableRequest(in *CreateTableRequest) error {
 	if strings.ContainsRune(in.TableName, '/') {
 		return errors.New("table_name must not contain '/'")
 	}
+	// Reject literal dot-segment names ("." / "..") symmetrically
+	// with decodeAndValidatePathSegment. Without this guard a
+	// table named "." would be creatable but every describe /
+	// delete / items URL for it would surface as 400 invalid_path
+	// (the dispatcher rejects decoded "." / ".." as path-traversal
+	// classes) — orphaned exactly like the slash case above
+	// (Codex P2 on PR #813 r5).
+	if in.TableName == "." || in.TableName == ".." {
+		return errors.New("table_name must not be \".\" or \"..\"")
+	}
 	if err := validateAttribute(in.PartitionKey, "partition_key"); err != nil {
 		return err
 	}

--- a/internal/admin/dynamo_handler_test.go
+++ b/internal/admin/dynamo_handler_test.go
@@ -93,6 +93,28 @@ func (s *stubTablesSource) AdminDeleteTable(_ context.Context, principal AuthPri
 	return nil
 }
 
+// Phase 3a stubs — most existing tests for the table-level routes
+// do not exercise the item-level surface, so the defaults return
+// zero values / ErrItemsTableNotFound for unknown tables. The
+// dedicated dynamo_items_handler_test.go file uses a richer stub
+// (stubTablesItemsSource) that overlays per-table item maps.
+
+func (s *stubTablesSource) AdminScanItems(_ context.Context, _ AuthPrincipal, _ string, _ AdminScanItemsOptions) (AdminScanItemsResult, error) {
+	return AdminScanItemsResult{Items: []AdminItem{}}, nil
+}
+
+func (s *stubTablesSource) AdminGetItem(_ context.Context, _ AuthPrincipal, _ string, _ map[string]AdminAttributeValue) (*AdminItem, bool, error) {
+	return nil, false, nil
+}
+
+func (s *stubTablesSource) AdminPutItem(_ context.Context, _ AuthPrincipal, _ string, _ AdminItem) error {
+	return nil
+}
+
+func (s *stubTablesSource) AdminDeleteItem(_ context.Context, _ AuthPrincipal, _ string, _ map[string]AdminAttributeValue) error {
+	return nil
+}
+
 func newDynamoHandlerForTest(src TablesSource) *DynamoHandler {
 	return NewDynamoHandler(src)
 }
@@ -354,11 +376,15 @@ func TestDynamoHandler_UnknownSubpathReturns404(t *testing.T) {
 func TestDynamoHandler_DescribeTable_TrailingSlashIsRejected(t *testing.T) {
 	// /admin/api/v1/dynamo/tables/ with an empty trailing component
 	// would otherwise pass an empty name down to the source.
+	// After Phase 3a's 6-step segment-validation dispatch the empty
+	// segment is rejected up front as 400 invalid_path rather than
+	// reaching the per-resource branch — semantically clearer and
+	// still keeps the empty name from reaching the source.
 	h := newDynamoHandlerForTest(&stubTablesSource{tables: map[string]*DynamoTableSummary{}})
 	req := httptest.NewRequest(http.MethodGet, pathDynamoTables+"/", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
-	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 // withWritePrincipal injects a full-access principal into the
@@ -761,13 +787,15 @@ func TestDynamoHandler_DeleteTable_NotLeaderReturns503WithRetryAfter(t *testing.
 }
 
 func TestDynamoHandler_DeleteTable_RejectsTrailingSlash(t *testing.T) {
+	// See TestDynamoHandler_DescribeTable_TrailingSlashIsRejected for
+	// the 404 → 400 rationale (Phase 3a 6-step dispatch).
 	src := &stubTablesSource{tables: map[string]*DynamoTableSummary{}}
 	h := newDynamoHandlerForTest(src)
 	req := httptest.NewRequest(http.MethodDelete, pathDynamoTables+"/", nil)
 	req = withWritePrincipal(req)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
-	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 // tableNameForIndex generates lex-sortable monotonically increasing

--- a/internal/admin/dynamo_handler_test.go
+++ b/internal/admin/dynamo_handler_test.go
@@ -440,6 +440,40 @@ func TestDynamoHandler_CreateTable_WhitespaceOnlyNameRejected(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "table_name is required")
 }
 
+// TestDynamoHandler_CreateTable_RejectsDotSegmentNames pins the
+// symmetry Codex P2 on PR #813 r5 flagged: dispatchPerTableRoute
+// rejects decoded "." and ".." segments (dot-segment traversal
+// class), but validateCreateTableRequest let those names through.
+// A table created with name="." or name=".." would be orphaned —
+// successfully stored, but every describe/delete/items URL would
+// 400 invalid_path because the dispatcher rejects the segment
+// before the source is reached. Mirrors the slash-rejection guard
+// already in validateCreateTableRequest (PR #634).
+func TestDynamoHandler_CreateTable_RejectsDotSegmentNames(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"single dot", `{"table_name":".","partition_key":{"name":"id","type":"S"}}`},
+		{"double dot", `{"table_name":"..","partition_key":{"name":"id","type":"S"}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := &stubTablesSource{tables: map[string]*DynamoTableSummary{}}
+			h := newDynamoHandlerForTest(src)
+			req := httptest.NewRequest(http.MethodPost, pathDynamoTables, strings.NewReader(tc.raw))
+			req = withWritePrincipal(req)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			require.Equal(t, http.StatusBadRequest, rec.Code,
+				"dot-segment table name must be rejected at create time; got %d body=%s",
+				rec.Code, rec.Body.String())
+			require.Empty(t, src.lastCreateInput.TableName,
+				"source must not be touched on dot-segment name")
+		})
+	}
+}
+
 // TestDynamoHandler_CreateTable_LiveRoleRevocation covers Codex P1
 // on PR #635: a session JWT with role=full from before a config
 // reload must NOT keep mutating after the access key is revoked

--- a/internal/admin/dynamo_items_handler.go
+++ b/internal/admin/dynamo_items_handler.go
@@ -312,6 +312,14 @@ func (h *DynamoHandler) handleItemDelete(w http.ResponseWriter, r *http.Request,
 // a method on DynamoHandler because it's only used by item-level
 // handlers; the existing list/describe paths use the looser session-
 // auth gate (their output is metadata, not content).
+//
+// JWT role gate fires unconditionally before the optional live-store
+// re-check (matches principalForWrite's defence-in-depth pattern from
+// PR #669). A token minted with role=none cannot slip through reads
+// via a later live-role promotion; the live re-check can only further
+// constrain. Claude review on PR #814 r2 caught the parallel S3
+// asymmetry; this fix lands on PR #813 to keep the items handler
+// consistent with the contract documented in principalForWrite.
 func (h *DynamoHandler) principalForItemRead(w http.ResponseWriter, r *http.Request) (AuthPrincipal, bool) {
 	principal, ok := PrincipalFromContext(r.Context())
 	if !ok {
@@ -325,6 +333,11 @@ func (h *DynamoHandler) principalForItemRead(w http.ResponseWriter, r *http.Requ
 		writeJSONError(w, http.StatusUnauthorized, "unauthenticated", "no session principal")
 		return AuthPrincipal{}, false
 	}
+	if !principal.Role.AllowsRead() {
+		writeJSONError(w, http.StatusForbidden, "forbidden",
+			"this access key is not authorised to read table contents")
+		return AuthPrincipal{}, false
+	}
 	if h.roles != nil {
 		live, exists := h.roles.LookupRole(principal.AccessKey)
 		if !exists || !live.AllowsRead() {
@@ -332,11 +345,10 @@ func (h *DynamoHandler) principalForItemRead(w http.ResponseWriter, r *http.Requ
 				"this access key is not authorised to read table contents")
 			return AuthPrincipal{}, false
 		}
+		// Use the live role downstream — the JWT may carry a stale
+		// value but the live one is authoritative once both gates
+		// agree the request is allowed.
 		principal.Role = live
-	} else if !principal.Role.AllowsRead() {
-		writeJSONError(w, http.StatusForbidden, "forbidden",
-			"this access key is not authorised to read table contents")
-		return AuthPrincipal{}, false
 	}
 	return principal, true
 }

--- a/internal/admin/dynamo_items_handler.go
+++ b/internal/admin/dynamo_items_handler.go
@@ -1,0 +1,448 @@
+package admin
+
+import (
+	"encoding/base64"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/goccy/go-json"
+)
+
+// Phase 3a — HTTP handlers for the item-level DynamoDB admin
+// surface. Driven by §3.3 of
+// docs/design/2026_05_22_implemented_admin_data_browser.md.
+//
+// Routes owned by this file (the parent DynamoHandler dispatches
+// after parsing /tables/{name}/...):
+//
+//	GET    /admin/api/v1/dynamo/tables/{name}/items                — scan
+//	GET    /admin/api/v1/dynamo/tables/{name}/items/{key-b64url}   — get
+//	PUT    /admin/api/v1/dynamo/tables/{name}/items/{key-b64url}   — put
+//	DELETE /admin/api/v1/dynamo/tables/{name}/items/{key-b64url}   — delete
+//
+// {key-b64url} carries a base64-url-encoded JSON object of the
+// AdminAttributeValue map for the item's primary key. Base64-url
+// is the same encoding the rest of the admin API uses for
+// arbitrary-bytes path segments, so the path validator's `%`-ban
+// passes cleanly.
+
+// adminItemSubResource is the literal second segment after the
+// table name that activates the items routes. Named so the
+// dispatcher stays self-documenting.
+const adminItemSubResource = "items"
+
+// Scan-page knobs. The default page size matches what
+// AdminScanTable on the adapter side defaults to (25 items per
+// page); the SPA overrides via ?limit=<n>. The cap mirrors the
+// adapter's adminItemScanMaxLimit (100) so an HTTP-supplied
+// limit beyond the cap silently clamps at the server-side limit
+// rather than producing a 400 — keeps the SPA pagination
+// stateless.
+const (
+	defaultAdminItemScanLimit = 25
+	adminItemScanLimitMax     = 100
+)
+
+// AdminAttributeValue mirrors the adapter package's wire shape
+// (S/N/B/BOOL/NULL scalars, SS/NS/BS sets, L/M containers).
+// Defined in this package so the admin HTTP layer stays free of
+// the adapter dependency; the main_admin.go bridge converts
+// between this type and adapter.AdminAttributeValue field-for-
+// field.
+type AdminAttributeValue struct {
+	S    *string                        `json:"S,omitempty"`
+	N    *string                        `json:"N,omitempty"`
+	B    []byte                         `json:"B,omitempty"`
+	BOOL *bool                          `json:"BOOL,omitempty"`
+	NULL *bool                          `json:"NULL,omitempty"`
+	SS   []string                       `json:"SS,omitempty"`
+	NS   []string                       `json:"NS,omitempty"`
+	BS   [][]byte                       `json:"BS,omitempty"`
+	L    []AdminAttributeValue          `json:"L,omitempty"`
+	M    map[string]AdminAttributeValue `json:"M,omitempty"`
+}
+
+// AdminItem is one row as the SPA sees it.
+type AdminItem struct {
+	Attributes map[string]AdminAttributeValue `json:"attributes"`
+}
+
+// AdminScanItemsOptions / Result mirror the adapter package's
+// shapes for the scan / continuation flow. ExclusiveStart is the
+// continuation token a previous page surfaced as LastEvaluatedKey;
+// the SPA passes it back verbatim via base64-url in the next
+// request's ?next_cursor query.
+type AdminScanItemsOptions struct {
+	Limit          int                            `json:"limit,omitempty"`
+	ExclusiveStart map[string]AdminAttributeValue `json:"exclusive_start,omitempty"`
+}
+
+type AdminScanItemsResult struct {
+	Items            []AdminItem                    `json:"items"`
+	LastEvaluatedKey map[string]AdminAttributeValue `json:"last_evaluated_key,omitempty"`
+}
+
+// Sentinel errors the bridge translates Admin*Item adapter
+// errors into, so the handler can map them to HTTP status codes
+// without sniffing the adapter's internal error vocabulary.
+
+// ErrItemsForbidden — principal lacks the required role (RoleReadOnly
+// for scan/get, RoleFull for put/delete). Maps to 403.
+var ErrItemsForbidden = errors.New("admin dynamo items: forbidden")
+
+// ErrItemsNotLeader — this node is not the Raft leader; SPA should
+// retry against the leader returned by the leader-probe endpoint.
+// Maps to 503.
+var ErrItemsNotLeader = errors.New("admin dynamo items: not leader")
+
+// ErrItemsTableNotFound — the named table does not exist. Maps to 404.
+var ErrItemsTableNotFound = errors.New("admin dynamo items: table not found")
+
+// ErrItemsValidation — empty / malformed key, body shape mismatch,
+// nesting depth exceeded, unknown kind tag. Maps to 400.
+var ErrItemsValidation = errors.New("admin dynamo items: invalid request")
+
+// ---------- handler entry points (called from DynamoHandler.ServeHTTP) ----------
+
+// handleItemsCollection serves GET /tables/{name}/items.
+func (h *DynamoHandler) handleItemsCollection(w http.ResponseWriter, r *http.Request, table string) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed", "only GET")
+		return
+	}
+	principal, ok := h.principalForItemRead(w, r)
+	if !ok {
+		return
+	}
+	opts, ok := parseAdminScanItemsQuery(w, r)
+	if !ok {
+		return
+	}
+	out, err := h.source.AdminScanItems(r.Context(), principal, table, opts)
+	if err != nil {
+		h.writeItemsError(w, r, "scan", table, err)
+		return
+	}
+	writeAdminJSONStatus(w, r.Context(), h.logger, http.StatusOK, out)
+}
+
+// handleItemResource serves /tables/{name}/items/{key-b64url}
+// (GET / PUT / DELETE).
+func (h *DynamoHandler) handleItemResource(w http.ResponseWriter, r *http.Request, table, keySegment string) {
+	key, ok := decodeAdminItemKeySegment(w, keySegment)
+	if !ok {
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		h.handleItemGet(w, r, table, key)
+	case http.MethodPut:
+		h.handleItemPut(w, r, table, key)
+	case http.MethodDelete:
+		h.handleItemDelete(w, r, table, key)
+	default:
+		writeJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed", "only GET, PUT, or DELETE")
+	}
+}
+
+func (h *DynamoHandler) handleItemGet(w http.ResponseWriter, r *http.Request, table string, key map[string]AdminAttributeValue) {
+	principal, ok := h.principalForItemRead(w, r)
+	if !ok {
+		return
+	}
+	item, found, err := h.source.AdminGetItem(r.Context(), principal, table, key)
+	if err != nil {
+		h.writeItemsError(w, r, "get", table, err)
+		return
+	}
+	if !found {
+		writeJSONError(w, http.StatusNotFound, "not_found", "item not found")
+		return
+	}
+	writeAdminJSONStatus(w, r.Context(), h.logger, http.StatusOK, item)
+}
+
+func (h *DynamoHandler) handleItemPut(w http.ResponseWriter, r *http.Request, table string, key map[string]AdminAttributeValue) {
+	principal, ok := h.principalForWrite(w, r)
+	if !ok {
+		return
+	}
+	var item AdminItem
+	if err := json.NewDecoder(r.Body).Decode(&item); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request",
+			"request body is not a valid AdminItem JSON object")
+		return
+	}
+	if err := assertItemBodyMatchesPathKey(item, key); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	if err := h.source.AdminPutItem(r.Context(), principal, table, item); err != nil {
+		h.writeItemsError(w, r, "put", table, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *DynamoHandler) handleItemDelete(w http.ResponseWriter, r *http.Request, table string, key map[string]AdminAttributeValue) {
+	principal, ok := h.principalForWrite(w, r)
+	if !ok {
+		return
+	}
+	if err := h.source.AdminDeleteItem(r.Context(), principal, table, key); err != nil {
+		h.writeItemsError(w, r, "delete", table, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ---------- helpers ----------
+
+// principalForItemRead is the read-side companion to principalForWrite
+// (live-role re-check + RoleReadOnly OR RoleFull). The payload
+// returned by scan/get is item content — `principalForReadSensitive`
+// equivalent on the Dynamo side. Defined locally here rather than as
+// a method on DynamoHandler because it's only used by item-level
+// handlers; the existing list/describe paths use the looser session-
+// auth gate (their output is metadata, not content).
+func (h *DynamoHandler) principalForItemRead(w http.ResponseWriter, r *http.Request) (AuthPrincipal, bool) {
+	principal, ok := PrincipalFromContext(r.Context())
+	if !ok {
+		writeJSONError(w, http.StatusInternalServerError, "internal", "missing session principal")
+		return AuthPrincipal{}, false
+	}
+	if h.roles != nil {
+		live, exists := h.roles.LookupRole(principal.AccessKey)
+		if !exists || !live.AllowsRead() {
+			writeJSONError(w, http.StatusForbidden, "forbidden",
+				"this access key is not authorised to read table contents")
+			return AuthPrincipal{}, false
+		}
+		principal.Role = live
+	} else if !principal.Role.AllowsRead() {
+		writeJSONError(w, http.StatusForbidden, "forbidden",
+			"this access key is not authorised to read table contents")
+		return AuthPrincipal{}, false
+	}
+	return principal, true
+}
+
+// parseAdminScanItemsQuery extracts ?limit and ?next_cursor from
+// the URL. next_cursor is the base64-url-encoded JSON of the
+// previous page's LastEvaluatedKey; absent or empty means "first
+// page". limit clamps to [1, adminItemScanLimitMax].
+func parseAdminScanItemsQuery(w http.ResponseWriter, r *http.Request) (AdminScanItemsOptions, bool) {
+	q := r.URL.Query()
+	opts := AdminScanItemsOptions{Limit: defaultAdminItemScanLimit}
+	if raw := strings.TrimSpace(q.Get("limit")); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 1 {
+			writeJSONError(w, http.StatusBadRequest, "invalid_request",
+				"limit must be a positive integer")
+			return AdminScanItemsOptions{}, false
+		}
+		if n > adminItemScanLimitMax {
+			n = adminItemScanLimitMax
+		}
+		opts.Limit = n
+	}
+	if raw := strings.TrimSpace(q.Get("next_cursor")); raw != "" {
+		cursor, err := decodeAdminItemKeySegment2(raw)
+		if err != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid_request",
+				"next_cursor is not a valid base64-url encoded key map")
+			return AdminScanItemsOptions{}, false
+		}
+		opts.ExclusiveStart = cursor
+	}
+	return opts, true
+}
+
+// decodeAdminItemKeySegment decodes the `{key}` URL segment into
+// a primary-key attribute map. Two-step decode: base64-url →
+// JSON object → map[string]AdminAttributeValue. Failures surface
+// as 400 with a body that names the failure mode so SPA debugging
+// is straightforward.
+func decodeAdminItemKeySegment(w http.ResponseWriter, segment string) (map[string]AdminAttributeValue, bool) {
+	out, err := decodeAdminItemKeySegment2(segment)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request",
+			"key segment is not a valid base64-url encoded JSON attribute map: "+err.Error())
+		return nil, false
+	}
+	if len(out) == 0 {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request",
+			"key segment decodes to an empty attribute map")
+		return nil, false
+	}
+	return out, true
+}
+
+// decodeAdminItemKeySegment2 is the non-HTTP form used by both
+// the key-segment decode and the next-cursor decode (both shapes
+// are base64-url(JSON(map[string]AdminAttributeValue))).
+func decodeAdminItemKeySegment2(segment string) (map[string]AdminAttributeValue, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(segment)
+	if err != nil {
+		// Tolerate padded base64 as a fallback so a hand-crafted
+		// curl with trailing `=` still works.
+		raw2, err2 := base64.URLEncoding.DecodeString(segment)
+		if err2 != nil {
+			return nil, errors.New("invalid base64-url encoding: " + err.Error())
+		}
+		raw = raw2
+	}
+	var out map[string]AdminAttributeValue
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, errors.New("invalid JSON in decoded segment: " + err.Error())
+	}
+	return out, nil
+}
+
+// assertItemBodyMatchesPathKey rejects requests where the JSON
+// body's primary-key attributes disagree with the {key} URL
+// segment. The path segment is authoritative (S3-style: the URL
+// names the resource), so a mismatch is a client bug we surface
+// rather than silently letting the body win.
+//
+// The implementation compares only the key attributes named in
+// the path segment — extra non-key attributes in the body are
+// fine (they're the item's payload). A path key attribute that
+// is missing from the body is the rejection case.
+func assertItemBodyMatchesPathKey(item AdminItem, pathKey map[string]AdminAttributeValue) error {
+	if item.Attributes == nil {
+		return errors.New("item body is missing the attributes field")
+	}
+	for k, want := range pathKey {
+		got, ok := item.Attributes[k]
+		if !ok {
+			return errors.New("item body is missing the path key attribute " + strconv.Quote(k))
+		}
+		if !attributeValuesEqual(got, want) {
+			return errors.New("item body's " + strconv.Quote(k) +
+				" attribute does not match the value encoded in the path key segment")
+		}
+	}
+	return nil
+}
+
+// attributeValuesEqual is a structural-equality check on
+// AdminAttributeValue. Used only by the path-key vs body-key
+// reconciliation above — pointers compare by dereferenced
+// value, byte slices and string slices compare by element,
+// recursive containers compare structurally.
+//
+// one branch per kind; collapsing further with reflection would
+// be slower and obscure the AWS-wire-shape coupling.
+//
+//nolint:cyclop // ten attribute kinds × per-kind equality means
+func attributeValuesEqual(a, b AdminAttributeValue) bool {
+	if !stringPtrEqual(a.S, b.S) || !stringPtrEqual(a.N, b.N) {
+		return false
+	}
+	if !boolPtrEqual(a.BOOL, b.BOOL) || !boolPtrEqual(a.NULL, b.NULL) {
+		return false
+	}
+	if !bytesEqual(a.B, b.B) {
+		return false
+	}
+	if !stringSliceEqual(a.SS, b.SS) || !stringSliceEqual(a.NS, b.NS) {
+		return false
+	}
+	if !byteSliceSliceEqual(a.BS, b.BS) {
+		return false
+	}
+	if len(a.L) != len(b.L) {
+		return false
+	}
+	for i := range a.L {
+		if !attributeValuesEqual(a.L[i], b.L[i]) {
+			return false
+		}
+	}
+	if len(a.M) != len(b.M) {
+		return false
+	}
+	for k, av := range a.M {
+		bv, ok := b.M[k]
+		if !ok || !attributeValuesEqual(av, bv) {
+			return false
+		}
+	}
+	return true
+}
+
+func stringPtrEqual(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func boolPtrEqual(a, b *bool) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func stringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func byteSliceSliceEqual(a, b [][]byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !bytesEqual(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// writeItemsError translates the sentinel errors the bridge
+// surfaces into the canonical HTTP status + body shape.
+func (h *DynamoHandler) writeItemsError(w http.ResponseWriter, r *http.Request, op, table string, err error) {
+	switch {
+	case errors.Is(err, ErrItemsForbidden):
+		writeJSONError(w, http.StatusForbidden, "forbidden", err.Error())
+	case errors.Is(err, ErrItemsNotLeader):
+		writeJSONError(w, http.StatusServiceUnavailable, "not_leader", err.Error())
+	case errors.Is(err, ErrItemsTableNotFound):
+		writeJSONError(w, http.StatusNotFound, "not_found", "table not found")
+	case errors.Is(err, ErrItemsValidation):
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
+	default:
+		h.logger.LogAttrs(r.Context(), slog.LevelError, "admin dynamo "+op+" item failed",
+			slog.String("table", table),
+			slog.String("error", err.Error()),
+		)
+		writeJSONError(w, http.StatusInternalServerError, "internal_error",
+			"failed to "+op+" item; see server logs")
+	}
+}

--- a/internal/admin/dynamo_items_handler.go
+++ b/internal/admin/dynamo_items_handler.go
@@ -416,6 +416,21 @@ func decodeAdminItemKeySegment2(segment string) (map[string]AdminAttributeValue,
 // the path segment — extra non-key attributes in the body are
 // fine (they're the item's payload). A path key attribute that
 // is missing from the body is the rejection case.
+//
+// Schema-awareness limit (Codex P2 on PR #813): this check cannot
+// reject a body that declares MORE primary-key columns than the
+// URL key, because the HTTP layer has no schema. On a hash+range
+// table where the URL key omits the sort key, a PUT carrying a
+// full (pk, sk) body succeeds — the item lands at (pk, sk), which
+// is a different resource from the URL's `pk`-only identifier.
+// The adapter's existing schema-aware key validation ensures the
+// stored item's primary key is well-formed; only the URL contract
+// is loose. The principled fix is to plumb the URL key into
+// AdminPutItem as a separate argument so the adapter can compare
+// body's schema-derived primary key against the URL key. That
+// change crosses the Phase-2a (adapter) boundary and is tracked
+// separately; the HTTP-only check here stays the URL ⊆ body
+// subset rule.
 func assertItemBodyMatchesPathKey(item AdminItem, pathKey map[string]AdminAttributeValue) error {
 	if item.Attributes == nil {
 		return errors.New("item body is missing the attributes field")

--- a/internal/admin/dynamo_items_handler.go
+++ b/internal/admin/dynamo_items_handler.go
@@ -1,10 +1,13 @@
 package admin
 
 import (
+	"bytes"
 	"encoding/base64"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -52,6 +55,12 @@ const (
 // the adapter dependency; the main_admin.go bridge converts
 // between this type and adapter.AdminAttributeValue field-for-
 // field.
+// Struct tags here are the wire-shape contract. MarshalJSON
+// overrides them to preserve the empty-but-present L/M distinction
+// (`{"L":[]}` and `{"M":{}}` are valid, type-bearing AttributeValue
+// shapes in DynamoDB; the SPA needs both shapes to render correctly).
+// UnmarshalJSON uses the default behaviour — a JSON `"L":[]` parses
+// to a non-nil zero-length slice via the tag.
 type AdminAttributeValue struct {
 	S    *string                        `json:"S,omitempty"`
 	N    *string                        `json:"N,omitempty"`
@@ -63,6 +72,61 @@ type AdminAttributeValue struct {
 	BS   [][]byte                       `json:"BS,omitempty"`
 	L    []AdminAttributeValue          `json:"L,omitempty"`
 	M    map[string]AdminAttributeValue `json:"M,omitempty"`
+}
+
+// MarshalJSON preserves the kind distinction between "no L/M field"
+// (nil slice/map) and "empty L/M field" (non-nil zero-length slice/map).
+// A stock json.Marshal with omitempty would collapse both into the
+// same wire shape, losing the type tag for an explicitly-empty list
+// or map — and an explicitly-empty list is a legitimate DynamoDB
+// AttributeValue ({"L":[]}). Gemini medium on PR #813.
+//
+// Mirrors the adapter package's AdminAttributeValue.MarshalJSON
+// invariant in the same way, except this side does not enforce the
+// "exactly-one-field" kind check (the bridge in main_admin.go calls
+// into the adapter, which performs that validation as part of its
+// own marshal-time depth/kind audit). Imposing the kind check here
+// too would reject legitimate responses constructed by tests where
+// a zero-value attribute is intentionally produced.
+//
+//nolint:cyclop // ten attribute kinds × per-kind nil-presence check
+func (a AdminAttributeValue) MarshalJSON() ([]byte, error) {
+	obj := make(map[string]any, 1)
+	if a.S != nil {
+		obj["S"] = *a.S
+	}
+	if a.N != nil {
+		obj["N"] = *a.N
+	}
+	if a.B != nil {
+		obj["B"] = a.B
+	}
+	if a.BOOL != nil {
+		obj["BOOL"] = *a.BOOL
+	}
+	if a.NULL != nil {
+		obj["NULL"] = *a.NULL
+	}
+	if a.SS != nil {
+		obj["SS"] = a.SS
+	}
+	if a.NS != nil {
+		obj["NS"] = a.NS
+	}
+	if a.BS != nil {
+		obj["BS"] = a.BS
+	}
+	if a.L != nil {
+		obj["L"] = a.L
+	}
+	if a.M != nil {
+		obj["M"] = a.M
+	}
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return nil, errors.New("marshal AdminAttributeValue: " + err.Error())
+	}
+	return out, nil
 }
 
 // AdminItem is one row as the SPA sees it.
@@ -170,10 +234,13 @@ func (h *DynamoHandler) handleItemPut(w http.ResponseWriter, r *http.Request, ta
 	if !ok {
 		return
 	}
-	var item AdminItem
-	if err := json.NewDecoder(r.Body).Decode(&item); err != nil {
-		writeJSONError(w, http.StatusBadRequest, "invalid_request",
-			"request body is not a valid AdminItem JSON object")
+	item, err := decodeAdminItemBody(r.Body)
+	if err != nil {
+		if errors.Is(err, errCreateBodyTooLarge) {
+			WriteMaxBytesError(w)
+			return
+		}
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
 		return
 	}
 	if err := assertItemBodyMatchesPathKey(item, key); err != nil {
@@ -185,6 +252,43 @@ func (h *DynamoHandler) handleItemPut(w http.ResponseWriter, r *http.Request, ta
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// decodeAdminItemBody is the PUT body parser. Same defence-in-depth
+// shape as decodeCreateTableRequest in dynamo_handler.go: read the
+// full body (BodyLimit middleware caps it), reject NUL bytes
+// (goccy/go-json treats raw NUL as end-of-input, which would
+// otherwise allow `{"attributes":...}\x00{"extra":1}` smuggling),
+// decode strictly with DisallowUnknownFields, then reject any
+// trailing JSON tokens. Codex P2 on PR #634 / Gemini medium on PR
+// #813.
+func decodeAdminItemBody(body io.Reader) (AdminItem, error) {
+	if body == nil {
+		return AdminItem{}, errors.New("request body is empty")
+	}
+	raw, err := io.ReadAll(body)
+	if err != nil {
+		if IsMaxBytesError(err) {
+			return AdminItem{}, errCreateBodyTooLarge
+		}
+		return AdminItem{}, errors.New("request body could not be read")
+	}
+	if len(raw) == 0 {
+		return AdminItem{}, errors.New("request body is empty")
+	}
+	if bytes.IndexByte(raw, 0) >= 0 {
+		return AdminItem{}, errors.New("request body contains a NUL byte")
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	var out AdminItem
+	if err := dec.Decode(&out); err != nil {
+		return AdminItem{}, errors.New("request body is not a valid AdminItem JSON object")
+	}
+	if dec.More() {
+		return AdminItem{}, errors.New("request body has trailing data after the JSON object")
+	}
+	return out, nil
 }
 
 func (h *DynamoHandler) handleItemDelete(w http.ResponseWriter, r *http.Request, table string, key map[string]AdminAttributeValue) {
@@ -346,22 +450,17 @@ func attributeValuesEqual(a, b AdminAttributeValue) bool {
 	if !boolPtrEqual(a.BOOL, b.BOOL) || !boolPtrEqual(a.NULL, b.NULL) {
 		return false
 	}
-	if !bytesEqual(a.B, b.B) {
+	if !bytes.Equal(a.B, b.B) {
 		return false
 	}
-	if !stringSliceEqual(a.SS, b.SS) || !stringSliceEqual(a.NS, b.NS) {
+	if !slices.Equal(a.SS, b.SS) || !slices.Equal(a.NS, b.NS) {
 		return false
 	}
-	if !byteSliceSliceEqual(a.BS, b.BS) {
+	if !slices.EqualFunc(a.BS, b.BS, bytes.Equal) {
 		return false
 	}
-	if len(a.L) != len(b.L) {
+	if !slices.EqualFunc(a.L, b.L, attributeValuesEqual) {
 		return false
-	}
-	for i := range a.L {
-		if !attributeValuesEqual(a.L[i], b.L[i]) {
-			return false
-		}
 	}
 	if len(a.M) != len(b.M) {
 		return false
@@ -387,42 +486,6 @@ func boolPtrEqual(a, b *bool) bool {
 		return a == b
 	}
 	return *a == *b
-}
-
-func bytesEqual(a, b []byte) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func stringSliceEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func byteSliceSliceEqual(a, b [][]byte) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if !bytesEqual(a[i], b[i]) {
-			return false
-		}
-	}
-	return true
 }
 
 // writeItemsError translates the sentinel errors the bridge

--- a/internal/admin/dynamo_items_handler.go
+++ b/internal/admin/dynamo_items_handler.go
@@ -315,7 +315,14 @@ func (h *DynamoHandler) handleItemDelete(w http.ResponseWriter, r *http.Request,
 func (h *DynamoHandler) principalForItemRead(w http.ResponseWriter, r *http.Request) (AuthPrincipal, bool) {
 	principal, ok := PrincipalFromContext(r.Context())
 	if !ok {
-		writeJSONError(w, http.StatusInternalServerError, "internal", "missing session principal")
+		// 401 matches principalForWrite (s3_handler.go,
+		// dynamo_handler.go.principalForWrite) — semantically,
+		// "no session principal" is unauthenticated, not internal
+		// failure. The path is unreachable in production
+		// (SessionAuth always attaches a principal upstream); the
+		// 401 keeps the contract symmetric with the rest of the
+		// admin surface (Claude review on PR #813 r2).
+		writeJSONError(w, http.StatusUnauthorized, "unauthenticated", "no session principal")
 		return AuthPrincipal{}, false
 	}
 	if h.roles != nil {
@@ -505,12 +512,29 @@ func boolPtrEqual(a, b *bool) bool {
 
 // writeItemsError translates the sentinel errors the bridge
 // surfaces into the canonical HTTP status + body shape.
+//
+// The 503 / 403 / 400 cases use fixed strings rather than
+// err.Error() — the sentinels (e.g. "admin dynamo items:
+// forbidden") are internal vocabulary and leaking them to clients
+// (a) sticks the SPA with a confusing message and (b) drifts the
+// items surface away from writeTablesError / writeBucketsError /
+// the SQS handler which all use fixed strings. Claude review on
+// PR #813 r2 caught both this and the Retry-After / canonical
+// code drift on the 503 case.
 func (h *DynamoHandler) writeItemsError(w http.ResponseWriter, r *http.Request, op, table string, err error) {
 	switch {
 	case errors.Is(err, ErrItemsForbidden):
-		writeJSONError(w, http.StatusForbidden, "forbidden", err.Error())
+		writeJSONError(w, http.StatusForbidden, "forbidden",
+			"this endpoint requires a full-access role")
 	case errors.Is(err, ErrItemsNotLeader):
-		writeJSONError(w, http.StatusServiceUnavailable, "not_leader", err.Error())
+		// Retry-After: 1 + "leader_unavailable" matches every
+		// other admin 503 (writeTablesError, writeBucketsError,
+		// sqs_handler, forward_server). Without these the SPA's
+		// shared retry helper does not back off correctly and
+		// the error branches on the wrong code string.
+		w.Header().Set("Retry-After", "1")
+		writeJSONError(w, http.StatusServiceUnavailable, "leader_unavailable",
+			"this admin node is not the raft leader")
 	case errors.Is(err, ErrItemsTableNotFound):
 		writeJSONError(w, http.StatusNotFound, "not_found", "table not found")
 	case errors.Is(err, ErrItemsValidation):

--- a/internal/admin/dynamo_items_handler.go
+++ b/internal/admin/dynamo_items_handler.go
@@ -379,6 +379,18 @@ func parseAdminScanItemsQuery(w http.ResponseWriter, r *http.Request) (AdminScan
 				"next_cursor is not a valid base64-url encoded key map")
 			return AdminScanItemsOptions{}, false
 		}
+		// Reject empty/nil decoded cursor symmetrically with
+		// decodeAdminItemKeySegment's len-zero check on the URL
+		// {key} segment. Base64-url of "null" decodes to nil and
+		// "{}" decodes to len-0 map; without this guard either
+		// would silently feed ExclusiveStart=nil to the adapter
+		// (start-from-beginning), duplicating page 0 and trapping
+		// paging-loop clients (Codex P2 on PR #813 r8).
+		if len(cursor) == 0 {
+			writeJSONError(w, http.StatusBadRequest, "invalid_request",
+				"next_cursor decodes to an empty attribute map")
+			return AdminScanItemsOptions{}, false
+		}
 		opts.ExclusiveStart = cursor
 	}
 	return opts, true

--- a/internal/admin/dynamo_items_handler_test.go
+++ b/internal/admin/dynamo_items_handler_test.go
@@ -545,13 +545,15 @@ func TestDynamoItems_Scan_RejectsAnonymous(t *testing.T) {
 	src := newStubItemsSource()
 	h := newDynamoHandlerForTest(src)
 
-	// No principal injected — should fail with internal (missing
-	// session principal).
+	// No principal injected — should fail 401 unauthenticated,
+	// matching principalForWrite and the rest of the admin
+	// surface (Claude review on PR #813 r2 caught the original
+	// 500 inconsistency).
 	req := httptest.NewRequest(http.MethodGet,
 		pathDynamoTables+"/orders/items", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
-	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
 // ---------- error translation tests ----------
@@ -581,6 +583,35 @@ func TestDynamoItems_TranslatesSentinelsToStatus(t *testing.T) {
 			require.Equal(t, tc.wantCode, rec.Code)
 		})
 	}
+}
+
+// TestDynamoItems_NotLeader503HasRetryAfterAndCanonicalCode pins
+// the items 503 contract to the same shape every other admin
+// surface uses: status 503, Retry-After: 1, error code
+// "leader_unavailable". Claude review on PR #813 r2 caught the
+// drift — translateAdminItemsError's comment promised
+// "503 + Retry-After: 1" but writeItemsError didn't set the
+// header and the items handler shipped a non-canonical
+// "not_leader" code. The SPA's retry logic branches on the code
+// string; the items 503 must be indistinguishable from the table-
+// tier / S3 / SQS 503 paths.
+func TestDynamoItems_NotLeader503HasRetryAfterAndCanonicalCode(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	src.nextErr = ErrItemsNotLeader
+	h := newDynamoHandlerForTest(src)
+
+	req := httptest.NewRequest(http.MethodGet,
+		pathDynamoTables+"/orders/items", nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Equal(t, "1", rec.Header().Get("Retry-After"),
+		"503 from items handler must set Retry-After: 1 so SPA retry backoff fires")
+	require.Contains(t, rec.Body.String(), `"leader_unavailable"`,
+		`items 503 must use the canonical "leader_unavailable" code`)
 }
 
 // ---------- body-validation defence-in-depth (Gemini medium on PR #813) ----------

--- a/internal/admin/dynamo_items_handler_test.go
+++ b/internal/admin/dynamo_items_handler_test.go
@@ -403,6 +403,57 @@ func TestDynamoItems_Get_HappyPath(t *testing.T) {
 	require.Equal(t, "hello", *got.Attributes["value"].S)
 }
 
+// TestDynamoItems_Get_AcceptsURLEncodedPaddedBase64Key pins the
+// Codex P2 on PR #813 r7 fix: the dispatcher must pass the
+// percent-decoded {key} segment to the per-key handler so a
+// client that URL-encodes padded base64 (e.g. JS's
+// encodeURIComponent turns "=" into "%3D") still routes
+// correctly. Pre-fix the dispatcher passed the raw segment with
+// %3D still present, the base64 decoder rejected it as not
+// valid base64-url, and the request 400'd despite the key
+// being well-formed.
+//
+// The decodeAdminItemKeySegment2 helper explicitly supports
+// padded base64 as a fallback for hand-crafted curl, so this
+// case is part of the documented input contract.
+func TestDynamoItems_Get_AcceptsURLEncodedPaddedBase64Key(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	key := map[string]AdminAttributeValue{"pk": stringAttr("k1")}
+	val := AdminItem{Attributes: map[string]AdminAttributeValue{
+		"pk":    stringAttr("k1"),
+		"value": stringAttr("hello"),
+	}}
+	src.seedItem("orders", key, val)
+	h := newDynamoHandlerForTest(src)
+
+	// Encode the key with PADDED base64-url (=), then URL-escape
+	// the `=` to %3D — the shape a client using
+	// encodeURIComponent on a padded base64 string would produce.
+	keyJSON, err := json.Marshal(key)
+	require.NoError(t, err)
+	padded := base64.URLEncoding.EncodeToString(keyJSON)
+	// Sanity: the encoded form must actually contain padding for
+	// this test to exercise the right code path. If it doesn't,
+	// the JSON happened to be a multiple of 3 bytes; force the
+	// padded helper anyway since the URL-escape applies the same
+	// regardless.
+	urlEscaped := strings.ReplaceAll(padded, "=", "%3D")
+	url := pathDynamoTables + "/orders/" + adminItemSubResource + "/" + urlEscaped
+
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code,
+		"URL-escaped padded base64-url key must decode and route to the item; got %d body=%s",
+		rec.Code, rec.Body.String())
+
+	var got AdminItem
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, "hello", *got.Attributes["value"].S)
+}
+
 func TestDynamoItems_Get_Missing404(t *testing.T) {
 	t.Parallel()
 	src := newStubItemsSource()

--- a/internal/admin/dynamo_items_handler_test.go
+++ b/internal/admin/dynamo_items_handler_test.go
@@ -585,6 +585,52 @@ func TestDynamoItems_TranslatesSentinelsToStatus(t *testing.T) {
 	}
 }
 
+// TestDynamoItems_Scan_JWTNoneRoleRejectedWhenLiveStoreGrantsRead
+// pins the principalForItemRead JWT-bypass fix from PR #813 r5.
+// Pre-fix, when a RoleStore was configured (h.roles != nil), the
+// JWT role check was skipped entirely and only the live store
+// was consulted — so a session whose JWT carried no read role
+// could pass through reads if the live store had since granted
+// the access key a read-or-higher role. The fix moves the JWT
+// gate ahead of the live check; both must permit the request
+// (defence-in-depth matching principalForWrite's contract).
+//
+// Pre-fix this assertion would have failed: live store grants
+// RoleReadOnly so the role-store branch accepted the request
+// and never re-checked the JWT's zero-value Role; the source's
+// AdminScanItems was invoked and returned 200 OK. Post-fix the
+// JWT check rejects first (Role="" doesn't satisfy AllowsRead)
+// and the source is never touched. Mirrors
+// TestDynamoHandler_CreateTable_LiveRoleRevocation in
+// dynamo_handler_test.go:448 (Claude review on PR #813 r5
+// flagged the missing test).
+func TestDynamoItems_Scan_JWTNoneRoleRejectedWhenLiveStoreGrantsRead(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	// Make the source return a recognisable success path so the
+	// pre-fix bug would surface as 200 (source reached) rather
+	// than a sentinel-induced status.
+	src.seedItem("orders", map[string]AdminAttributeValue{"pk": stringAttr("k1")},
+		AdminItem{Attributes: map[string]AdminAttributeValue{"pk": stringAttr("k1")}})
+	// Live role map says the access key has read access — but the
+	// JWT carries Role="" (zero value, neither read nor write).
+	roles := MapRoleStore{"AKIA_BYPASS": RoleReadOnly}
+	h := NewDynamoHandler(src).WithRoleStore(roles)
+
+	req := httptest.NewRequest(http.MethodGet,
+		pathDynamoTables+"/orders/items", nil)
+	// Inject a principal with the matching access key but no role
+	// on the JWT side. withReadOnlyPrincipal can't reproduce this —
+	// we need the JWT-without-read-role case the bypass relied on.
+	req = req.WithContext(context.WithValue(req.Context(), ctxKeyPrincipal,
+		AuthPrincipal{AccessKey: "AKIA_BYPASS", Role: ""}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusForbidden, rec.Code,
+		"JWT role with no read permission must be rejected even when the live store grants read access")
+}
+
 // TestDynamoItems_NotLeader503HasRetryAfterAndCanonicalCode pins
 // the items 503 contract to the same shape every other admin
 // surface uses: status 503, Retry-After: 1, error code

--- a/internal/admin/dynamo_items_handler_test.go
+++ b/internal/admin/dynamo_items_handler_test.go
@@ -1,0 +1,584 @@
+package admin
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/require"
+)
+
+// stubItemsSource is a richer TablesSource fake that backs the
+// item-level handler tests with an in-memory per-table item map.
+// The table-level methods inherit zero-value behaviour from the
+// embedded stubTablesSource (good enough — these tests don't
+// exercise list/describe/create/delete on the table itself).
+type stubItemsSource struct {
+	stubTablesSource
+
+	// items[table][primary-key-fingerprint] -> stored item
+	items map[string]map[string]AdminItem
+
+	// Injected error returned by the next Admin*Item call, then
+	// cleared. Tests use this to drive the error-translation
+	// branches without spinning up a real adapter.
+	nextErr error
+
+	// Last principal observed by a write call — lets tests assert
+	// the live-role re-check landed.
+	lastPutPrincipal    AuthPrincipal
+	lastDeletePrincipal AuthPrincipal
+
+	// Scan customisation for cursor tests.
+	scanCursor map[string]AdminAttributeValue
+}
+
+func newStubItemsSource() *stubItemsSource {
+	return &stubItemsSource{
+		items: map[string]map[string]AdminItem{},
+	}
+}
+
+// seedItem stores item under the fingerprint of `key`. The handler
+// reaches AdminGetItem / AdminDeleteItem with a primary-key map
+// (NOT the full attribute map), so the stub's index has to match
+// that lookup shape — fingerprinting the whole Attributes map
+// would yield a different key than the get/delete lookup uses.
+//
+// `table` is parameterised even though every current test passes
+// "orders" — the stub is intentionally multi-table-aware so future
+// tests covering cross-table isolation do not need a second helper.
+//
+//nolint:unparam // see note above; `table` is forward-looking.
+func (s *stubItemsSource) seedItem(table string, key map[string]AdminAttributeValue, item AdminItem) {
+	if s.items[table] == nil {
+		s.items[table] = map[string]AdminItem{}
+	}
+	s.items[table][itemFingerprint(key)] = item
+}
+
+// itemFingerprint is a stable deterministic representation of an
+// item's attribute map used as the in-memory map key. Marshals to
+// the same JSON the wire shape uses so the test stub doesn't have
+// to implement structural equality.
+func itemFingerprint(attrs map[string]AdminAttributeValue) string {
+	b, _ := json.Marshal(attrs)
+	return string(b)
+}
+
+func (s *stubItemsSource) AdminScanItems(_ context.Context, _ AuthPrincipal, table string, opts AdminScanItemsOptions) (AdminScanItemsResult, error) {
+	if s.nextErr != nil {
+		err := s.nextErr
+		s.nextErr = nil
+		return AdminScanItemsResult{}, err
+	}
+	rows := make([]AdminItem, 0, len(s.items[table]))
+	for _, it := range s.items[table] {
+		rows = append(rows, it)
+	}
+	if opts.Limit > 0 && len(rows) > opts.Limit {
+		rows = rows[:opts.Limit]
+	}
+	return AdminScanItemsResult{Items: rows, LastEvaluatedKey: s.scanCursor}, nil
+}
+
+func (s *stubItemsSource) AdminGetItem(_ context.Context, _ AuthPrincipal, table string, key map[string]AdminAttributeValue) (*AdminItem, bool, error) {
+	if s.nextErr != nil {
+		err := s.nextErr
+		s.nextErr = nil
+		return nil, false, err
+	}
+	// Stub does not know the table schema, so lookup is by
+	// subset-match: for each stored item, every requested-key
+	// attribute must appear with the same value in the item's
+	// Attributes map. First match wins (in practice the test
+	// inputs never have ambiguous matches).
+	for _, it := range s.items[table] {
+		if itemMatchesKey(it.Attributes, key) {
+			return &it, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+// itemMatchesKey reports whether every attribute in `key` is
+// present in `attrs` with a structurally equal value. Mirrors
+// the attributeValuesEqual logic from the handler — duplicated
+// here so test fixtures don't depend on handler internals.
+func itemMatchesKey(attrs, key map[string]AdminAttributeValue) bool {
+	for k, want := range key {
+		got, ok := attrs[k]
+		if !ok || !attributeValuesEqual(got, want) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *stubItemsSource) AdminPutItem(_ context.Context, principal AuthPrincipal, table string, item AdminItem) error {
+	s.lastPutPrincipal = principal
+	if s.nextErr != nil {
+		err := s.nextErr
+		s.nextErr = nil
+		return err
+	}
+	if s.items[table] == nil {
+		s.items[table] = map[string]AdminItem{}
+	}
+	s.items[table][itemFingerprint(item.Attributes)] = item
+	return nil
+}
+
+func (s *stubItemsSource) AdminDeleteItem(_ context.Context, principal AuthPrincipal, table string, key map[string]AdminAttributeValue) error {
+	s.lastDeletePrincipal = principal
+	if s.nextErr != nil {
+		err := s.nextErr
+		s.nextErr = nil
+		return err
+	}
+	// Same subset-match strategy as AdminGetItem.
+	for fp, it := range s.items[table] {
+		if itemMatchesKey(it.Attributes, key) {
+			delete(s.items[table], fp)
+			return nil
+		}
+	}
+	return nil
+}
+
+// encodeKey encodes a primary-key map as the URL-segment shape
+// the handler expects: base64-url(JSON(map[string]AdminAttributeValue)).
+// Test ergonomic: takes the key map directly so test bodies stay
+// readable.
+func encodeKey(t *testing.T, key map[string]AdminAttributeValue) string {
+	t.Helper()
+	raw, err := json.Marshal(key)
+	require.NoError(t, err)
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+func stringAttr(s string) AdminAttributeValue {
+	return AdminAttributeValue{S: &s}
+}
+
+// itemPath assembles the URL the per-key item handlers route on.
+// `table` is parameterised for parity with seedItem; future
+// cross-table tests will pass a non-"orders" value here without
+// needing to grow a second helper.
+//
+//nolint:unparam // see comment above
+func itemPath(table string, key map[string]AdminAttributeValue, t *testing.T) string {
+	return pathDynamoTables + "/" + table + "/" + adminItemSubResource + "/" + encodeKey(t, key)
+}
+
+// ---------- routing tests ----------
+
+func TestDynamoItems_RoutingDispatchesEachMethod(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	h := newDynamoHandlerForTest(src)
+
+	cases := []struct {
+		name           string
+		method         string
+		body           string
+		principalApply func(*http.Request) *http.Request
+		wantCode       int
+	}{
+		{"scan", http.MethodGet, "", withReadOnlyPrincipal, http.StatusOK},
+		{"get-missing", http.MethodGet, "", withReadOnlyPrincipal, http.StatusNotFound},
+		{"put", http.MethodPut, `{"attributes":{"pk":{"S":"k1"}}}`, withWritePrincipal, http.StatusNoContent},
+		{"delete", http.MethodDelete, "", withWritePrincipal, http.StatusNoContent},
+	}
+	key := map[string]AdminAttributeValue{"pk": stringAttr("k1")}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var url string
+			if tc.name == "scan" {
+				url = pathDynamoTables + "/orders/" + adminItemSubResource
+			} else {
+				url = itemPath("orders", key, t)
+			}
+			req := httptest.NewRequest(tc.method, url, strings.NewReader(tc.body))
+			req = tc.principalApply(req)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			require.Equalf(t, tc.wantCode, rec.Code, "body=%s", rec.Body.String())
+		})
+	}
+}
+
+func TestDynamoItems_RoutingRejectsUnknownSubResource(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	h := newDynamoHandlerForTest(src)
+
+	req := httptest.NewRequest(http.MethodGet, pathDynamoTables+"/orders/unknown", nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Contains(t, rec.Body.String(), "unknown sub-resource")
+}
+
+func TestDynamoItems_RoutingRejectsTooManySegments(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	h := newDynamoHandlerForTest(src)
+
+	req := httptest.NewRequest(http.MethodGet, pathDynamoTables+"/orders/items/k1/extra", nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Contains(t, rec.Body.String(), "too many path segments")
+}
+
+func TestDynamoItems_RoutingRejectsDotSegments(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	h := newDynamoHandlerForTest(src)
+
+	cases := []string{
+		pathDynamoTables + "/../etc/passwd",
+		pathDynamoTables + "/orders/./items",
+		pathDynamoTables + "/orders/items/..",
+	}
+	for _, url := range cases {
+		t.Run(url, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			req = withReadOnlyPrincipal(req)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+		})
+	}
+}
+
+func TestDynamoItems_RoutingRejectsPercentInSegment(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	h := newDynamoHandlerForTest(src)
+
+	// %2f is the URL-encoded forward slash. The 6-step dispatch
+	// rejects any `%` in a segment regardless of whether the
+	// browser decoded it; closes the percent-encoded path
+	// traversal classes.
+	req := httptest.NewRequest(http.MethodGet, pathDynamoTables+"/orders%2fother/items", nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestDynamoItems_MethodNotAllowed(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	h := newDynamoHandlerForTest(src)
+
+	// /items only accepts GET (scan).
+	req := httptest.NewRequest(http.MethodPost,
+		pathDynamoTables+"/orders/items", nil)
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+
+	// /items/{key} accepts GET / PUT / DELETE only.
+	key := map[string]AdminAttributeValue{"pk": stringAttr("k1")}
+	req = httptest.NewRequest(http.MethodPost, itemPath("orders", key, t), nil)
+	req = withWritePrincipal(req)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+// ---------- key decoding tests ----------
+
+func TestDynamoItems_RejectsMalformedKeySegment(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	h := newDynamoHandlerForTest(src)
+
+	cases := map[string]string{
+		"not-base64":         pathDynamoTables + "/orders/items/!!!notbase64",
+		"valid-b64-not-json": pathDynamoTables + "/orders/items/" + base64.RawURLEncoding.EncodeToString([]byte("not-json")),
+		"empty-map":          pathDynamoTables + "/orders/items/" + base64.RawURLEncoding.EncodeToString([]byte("{}")),
+	}
+	for name, url := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			req = withReadOnlyPrincipal(req)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			require.Equal(t, http.StatusBadRequest, rec.Code,
+				"want 400 for malformed key %q; body=%s", url, rec.Body.String())
+		})
+	}
+}
+
+// ---------- read path: scan / get ----------
+
+func TestDynamoItems_Scan_ReturnsItemsAndCursor(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	keyA := map[string]AdminAttributeValue{"pk": stringAttr("a")}
+	keyB := map[string]AdminAttributeValue{"pk": stringAttr("b")}
+	src.seedItem("orders", keyA, AdminItem{Attributes: keyA})
+	src.seedItem("orders", keyB, AdminItem{Attributes: keyB})
+	src.scanCursor = map[string]AdminAttributeValue{"pk": stringAttr("a")}
+	h := newDynamoHandlerForTest(src)
+
+	req := httptest.NewRequest(http.MethodGet,
+		pathDynamoTables+"/orders/items", nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var got AdminScanItemsResult
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got.Items, 2)
+	require.NotEmpty(t, got.LastEvaluatedKey, "cursor must be carried through")
+}
+
+func TestDynamoItems_Scan_LimitClamped(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	for _, k := range []string{"a", "b", "c", "d", "e"} {
+		key := map[string]AdminAttributeValue{"pk": stringAttr(k)}
+		src.seedItem("orders", key, AdminItem{Attributes: key})
+	}
+	h := newDynamoHandlerForTest(src)
+
+	req := httptest.NewRequest(http.MethodGet,
+		pathDynamoTables+"/orders/items?limit=2", nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var got AdminScanItemsResult
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got.Items, 2, "explicit ?limit must be honoured")
+}
+
+func TestDynamoItems_Scan_RejectsBadLimit(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	h := newDynamoHandlerForTest(src)
+
+	req := httptest.NewRequest(http.MethodGet,
+		pathDynamoTables+"/orders/items?limit=-1", nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestDynamoItems_Get_HappyPath(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	key := map[string]AdminAttributeValue{"pk": stringAttr("k1")}
+	val := AdminItem{Attributes: map[string]AdminAttributeValue{
+		"pk":    stringAttr("k1"),
+		"value": stringAttr("hello"),
+	}}
+	src.seedItem("orders", key, val)
+	h := newDynamoHandlerForTest(src)
+
+	req := httptest.NewRequest(http.MethodGet, itemPath("orders", key, t), nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var got AdminItem
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, "hello", *got.Attributes["value"].S)
+}
+
+func TestDynamoItems_Get_Missing404(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	h := newDynamoHandlerForTest(src)
+	key := map[string]AdminAttributeValue{"pk": stringAttr("ghost")}
+
+	req := httptest.NewRequest(http.MethodGet, itemPath("orders", key, t), nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// ---------- write path: put / delete ----------
+
+func TestDynamoItems_Put_RoundTrips(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	h := newDynamoHandlerForTest(src)
+	key := map[string]AdminAttributeValue{"pk": stringAttr("k1")}
+
+	body := `{"attributes":{"pk":{"S":"k1"},"value":{"S":"v1"}}}`
+	req := httptest.NewRequest(http.MethodPut, itemPath("orders", key, t),
+		bytes.NewReader([]byte(body)))
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Equal(t, "AKIA_FULL", src.lastPutPrincipal.AccessKey)
+
+	// Verify via GET that the item landed.
+	req = httptest.NewRequest(http.MethodGet, itemPath("orders", key, t), nil)
+	req = withReadOnlyPrincipal(req)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestDynamoItems_Put_RejectsBodyKeyMismatch(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	h := newDynamoHandlerForTest(src)
+	pathKey := map[string]AdminAttributeValue{"pk": stringAttr("path-k")}
+
+	// Body claims pk=body-k; path says pk=path-k. Mismatch → 400.
+	body := `{"attributes":{"pk":{"S":"body-k"}}}`
+	req := httptest.NewRequest(http.MethodPut, itemPath("orders", pathKey, t),
+		bytes.NewReader([]byte(body)))
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "does not match")
+}
+
+func TestDynamoItems_Put_RejectsMissingPathKeyInBody(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	h := newDynamoHandlerForTest(src)
+	pathKey := map[string]AdminAttributeValue{"pk": stringAttr("k1")}
+
+	// Body omits pk entirely → 400.
+	body := `{"attributes":{"value":{"S":"v"}}}`
+	req := httptest.NewRequest(http.MethodPut, itemPath("orders", pathKey, t),
+		bytes.NewReader([]byte(body)))
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "missing the path key attribute")
+}
+
+func TestDynamoItems_Put_RejectsMalformedJSON(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	h := newDynamoHandlerForTest(src)
+	key := map[string]AdminAttributeValue{"pk": stringAttr("k1")}
+
+	req := httptest.NewRequest(http.MethodPut, itemPath("orders", key, t),
+		bytes.NewReader([]byte(`{not json`)))
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestDynamoItems_Delete_HappyPath(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	key := map[string]AdminAttributeValue{"pk": stringAttr("k1")}
+	src.seedItem("orders", key, AdminItem{Attributes: key})
+	h := newDynamoHandlerForTest(src)
+
+	req := httptest.NewRequest(http.MethodDelete, itemPath("orders", key, t), nil)
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	// GET now 404.
+	req = httptest.NewRequest(http.MethodGet, itemPath("orders", key, t), nil)
+	req = withReadOnlyPrincipal(req)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// ---------- authorisation tests ----------
+
+func TestDynamoItems_Put_RejectsReadOnly(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	h := newDynamoHandlerForTest(src)
+	key := map[string]AdminAttributeValue{"pk": stringAttr("k1")}
+
+	body := `{"attributes":{"pk":{"S":"k1"}}}`
+	req := httptest.NewRequest(http.MethodPut, itemPath("orders", key, t),
+		bytes.NewReader([]byte(body)))
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestDynamoItems_Delete_RejectsReadOnly(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	h := newDynamoHandlerForTest(src)
+	key := map[string]AdminAttributeValue{"pk": stringAttr("k1")}
+
+	req := httptest.NewRequest(http.MethodDelete, itemPath("orders", key, t), nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestDynamoItems_Scan_RejectsAnonymous(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	h := newDynamoHandlerForTest(src)
+
+	// No principal injected — should fail with internal (missing
+	// session principal).
+	req := httptest.NewRequest(http.MethodGet,
+		pathDynamoTables+"/orders/items", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// ---------- error translation tests ----------
+
+func TestDynamoItems_TranslatesSentinelsToStatus(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		injected error
+		wantCode int
+	}{
+		"forbidden":       {ErrItemsForbidden, http.StatusForbidden},
+		"not-leader":      {ErrItemsNotLeader, http.StatusServiceUnavailable},
+		"table-not-found": {ErrItemsTableNotFound, http.StatusNotFound},
+		"validation":      {ErrItemsValidation, http.StatusBadRequest},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			src := newStubItemsSource()
+			src.nextErr = tc.injected
+			h := newDynamoHandlerForTest(src)
+
+			req := httptest.NewRequest(http.MethodGet,
+				pathDynamoTables+"/orders/items", nil)
+			req = withReadOnlyPrincipal(req)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			require.Equal(t, tc.wantCode, rec.Code)
+		})
+	}
+}

--- a/internal/admin/dynamo_items_handler_test.go
+++ b/internal/admin/dynamo_items_handler_test.go
@@ -582,3 +582,98 @@ func TestDynamoItems_TranslatesSentinelsToStatus(t *testing.T) {
 		})
 	}
 }
+
+// ---------- body-validation defence-in-depth (Gemini medium on PR #813) ----------
+
+// TestDynamoItems_AttributeValue_EmptyContainersRoundTrip locks down
+// that an item carrying an empty L or M attribute serializes with
+// the type tag still present (`{"L":[]}` / `{"M":{}}`) rather than
+// disappearing under omitempty. Without this the SPA cannot
+// distinguish a "list of zero elements" attribute from "no L field
+// at all" (a different attribute kind entirely).
+func TestDynamoItems_AttributeValue_EmptyContainersRoundTrip(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		input   AdminAttributeValue
+		wantSub string
+	}{
+		{
+			name:    "empty list keeps L tag",
+			input:   AdminAttributeValue{L: []AdminAttributeValue{}},
+			wantSub: `"L":[]`,
+		},
+		{
+			name:    "empty map keeps M tag",
+			input:   AdminAttributeValue{M: map[string]AdminAttributeValue{}},
+			wantSub: `"M":{}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := json.Marshal(tc.input)
+			require.NoError(t, err)
+			require.Contains(t, string(out), tc.wantSub,
+				"empty container attribute must round-trip through JSON")
+		})
+	}
+}
+
+// TestDynamoItems_Put_RejectsNULBytePayload guards against the
+// payload-smuggling vector goccy/go-json exhibits with NUL bytes —
+// a `{"attributes":...}\x00{"extra":1}` body would otherwise sneak
+// the second object past the decoder. Same shape as the
+// decodeCreateTableRequest test on /tables (Codex P2 on PR #634).
+func TestDynamoItems_Put_RejectsNULBytePayload(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	h := newDynamoHandlerForTest(src)
+	key := map[string]AdminAttributeValue{"pk": stringAttr("k1")}
+
+	body := []byte(`{"attributes":{"pk":{"S":"k1"}}}` + "\x00" + `{"extra":1}`)
+	req := httptest.NewRequest(http.MethodPut, itemPath("orders", key, t),
+		bytes.NewReader(body))
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "NUL")
+}
+
+// TestDynamoItems_Put_RejectsTrailingJSONData mirrors
+// decodeCreateTableRequest: a body like `{"attributes":...}{"a":1}`
+// must surface 400 rather than silently accepting the first object
+// and dropping the second.
+func TestDynamoItems_Put_RejectsTrailingJSONData(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	h := newDynamoHandlerForTest(src)
+	key := map[string]AdminAttributeValue{"pk": stringAttr("k1")}
+
+	body := []byte(`{"attributes":{"pk":{"S":"k1"}}}{"extra":1}`)
+	req := httptest.NewRequest(http.MethodPut, itemPath("orders", key, t),
+		bytes.NewReader(body))
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "trailing data")
+}
+
+// TestDynamoItems_Put_RejectsEmptyBody pins the existing nil-body
+// rejection contract — the io.ReadAll path returns 0 bytes which
+// would otherwise decode to a zero-value AdminItem (Attributes:
+// nil) and confuse the body/path-key reconciler.
+func TestDynamoItems_Put_RejectsEmptyBody(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	h := newDynamoHandlerForTest(src)
+	key := map[string]AdminAttributeValue{"pk": stringAttr("k1")}
+
+	req := httptest.NewRequest(http.MethodPut, itemPath("orders", key, t),
+		bytes.NewReader(nil))
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/internal/admin/dynamo_items_handler_test.go
+++ b/internal/admin/dynamo_items_handler_test.go
@@ -265,10 +265,10 @@ func TestDynamoItems_RoutingRejectsPercentInSegment(t *testing.T) {
 	src := newStubItemsSource()
 	h := newDynamoHandlerForTest(src)
 
-	// %2f is the URL-encoded forward slash. The 6-step dispatch
-	// rejects any `%` in a segment regardless of whether the
-	// browser decoded it; closes the percent-encoded path
-	// traversal classes.
+	// %2f decodes to `/` which would split the segment. The validator
+	// now decodes each segment first (Codex P1 on PR #813 — allow
+	// %20 / UTF-8 in table names) but still rejects decoded `/`,
+	// `.`, and `..` to keep the path-traversal classes closed.
 	req := httptest.NewRequest(http.MethodGet, pathDynamoTables+"/orders%2fother/items", nil)
 	req = withReadOnlyPrincipal(req)
 	rec := httptest.NewRecorder()
@@ -584,6 +584,59 @@ func TestDynamoItems_TranslatesSentinelsToStatus(t *testing.T) {
 }
 
 // ---------- body-validation defence-in-depth (Gemini medium on PR #813) ----------
+
+// TestDynamoItems_RoutingAcceptsPercentEncodedTableName pins the
+// Codex P1 on PR #813 fix: a table name containing characters that
+// must be URL-escaped (spaces, UTF-8, etc.) must still be routable
+// via its percent-encoded form. validateCreateTableRequest only
+// blocks empty and `/`, so a table named "foo bar" is creatable; if
+// the dispatcher rejected the percent-encoded segment outright, the
+// table would be unreachable through describe / delete / items.
+func TestDynamoItems_RoutingAcceptsPercentEncodedTableName(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	src.tables = map[string]*DynamoTableSummary{
+		"foo bar": {Name: "foo bar", PartitionKey: "pk"},
+	}
+	h := newDynamoHandlerForTest(src)
+
+	// GET /tables/foo%20bar must decode to "foo bar" before
+	// AdminDescribeTable is called.
+	req := httptest.NewRequest(http.MethodGet,
+		pathDynamoTables+"/foo%20bar", nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+}
+
+// TestDynamoItems_RoutingRejectsPercentEncodedSlash keeps the
+// path-traversal defence: %2f decodes to `/`, which would split the
+// segment after decode. The validator must reject the decoded `/`
+// regardless of whether it arrived raw or percent-encoded (Codex P1
+// on PR #813 narrowed the % rejection to decoded forms).
+func TestDynamoItems_RoutingRejectsPercentEncodedSlash(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	h := newDynamoHandlerForTest(src)
+
+	cases := []string{
+		pathDynamoTables + "/orders%2fother",      // %2f → decoded `/`
+		pathDynamoTables + "/orders%2Fother",      // %2F → decoded `/` (upper)
+		pathDynamoTables + "/%2e",                 // %2e → decoded `.`  (dot-segment)
+		pathDynamoTables + "/%2E%2E",              // %2E%2E → decoded `..` (dot-segment)
+		pathDynamoTables + "/orders/%2e%2e/items", // %2e%2e → `..` mid-path
+	}
+	for _, url := range cases {
+		t.Run(url, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			req = withReadOnlyPrincipal(req)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+		})
+	}
+}
 
 // TestDynamoItems_AttributeValue_EmptyContainersRoundTrip locks down
 // that an item carrying an empty L or M attribute serializes with

--- a/internal/admin/dynamo_items_handler_test.go
+++ b/internal/admin/dynamo_items_handler_test.go
@@ -381,6 +381,42 @@ func TestDynamoItems_Scan_RejectsBadLimit(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// TestDynamoItems_Scan_RejectsEmptyDecodedCursor pins the Codex P2
+// on PR #813 r8 fix: a cursor that decodes to an empty/nil map
+// (base64-url of "null", "{}", or similar) used to be silently
+// treated as ExclusiveStart=nil — i.e., "start from beginning" —
+// instead of returning 400. Clients passing a malformed cursor
+// would then see duplicated first-page results and, in a paging
+// loop driven off `next_cursor`, lock themselves into a tight
+// infinite loop on page 1.
+//
+// The URL `{key}` segment already rejects this case via
+// decodeAdminItemKeySegment's `len(out) == 0` check; this test
+// pins the parallel guard on the next_cursor query path.
+func TestDynamoItems_Scan_RejectsEmptyDecodedCursor(t *testing.T) {
+	t.Parallel()
+	src := newStubItemsSource()
+	h := newDynamoHandlerForTest(src)
+
+	cases := map[string]string{
+		"json-null":    base64.RawURLEncoding.EncodeToString([]byte("null")),
+		"empty-object": base64.RawURLEncoding.EncodeToString([]byte("{}")),
+		"empty-padded": base64.URLEncoding.EncodeToString([]byte("{}")),
+	}
+	for name, cursor := range cases {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet,
+				pathDynamoTables+"/orders/items?next_cursor="+cursor, nil)
+			req = withReadOnlyPrincipal(req)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			require.Equal(t, http.StatusBadRequest, rec.Code,
+				"empty/null cursor must surface as 400 to avoid silent reset-to-page-0; got %d body=%s",
+				rec.Code, rec.Body.String())
+		})
+	}
+}
+
 func TestDynamoItems_Get_HappyPath(t *testing.T) {
 	t.Parallel()
 	src := newStubItemsSource()

--- a/main_admin.go
+++ b/main_admin.go
@@ -729,7 +729,16 @@ func translateAdminItemsError(err error) error {
 	case errors.Is(err, adapter.ErrAdminDynamoNotFound):
 		return admin.ErrItemsTableNotFound
 	case errors.Is(err, adapter.ErrAdminDynamoValidation):
-		return admin.ErrItemsValidation
+		// Wrap rather than replace so the adapter's specific
+		// validation message ("table_name is required", legacy-
+		// migration hint at adapter/dynamodb_admin_items.go, etc.)
+		// reaches the HTTP 400 body via writeItemsError's
+		// err.Error() emission. Bare sentinel return dropped the
+		// operator-facing reason at the bridge boundary (Claude
+		// review on PR #813 r3). errors.Is(out, ErrItemsValidation)
+		// still returns true so the handler's match arm still
+		// fires.
+		return errors.Wrap(admin.ErrItemsValidation, err.Error())
 	case isLeaderChurnError(err):
 		// Mid-dispatch leadership churn looks like an internal error
 		// from the kv coordinator (election finishes between the

--- a/main_admin.go
+++ b/main_admin.go
@@ -596,6 +596,145 @@ func (b *dynamoTablesBridge) AdminDeleteTable(ctx context.Context, principal adm
 	return nil
 }
 
+// Phase 3a — item-level bridge methods. Each one converts the
+// admin-package wire types into the adapter's parallel struct
+// graph, dispatches to the adapter, and translates the adapter's
+// error vocabulary onto the admin-package sentinels.
+
+func (b *dynamoTablesBridge) AdminScanItems(ctx context.Context, principal admin.AuthPrincipal, table string, opts admin.AdminScanItemsOptions) (admin.AdminScanItemsResult, error) {
+	adapterOpts := adapter.AdminScanOptions{
+		Limit:          opts.Limit,
+		ExclusiveStart: adminToAdapterAttributeMap(opts.ExclusiveStart),
+	}
+	out, err := b.server.AdminScanTable(ctx, convertAdminPrincipal(principal), table, adapterOpts)
+	if err != nil {
+		return admin.AdminScanItemsResult{}, translateAdminItemsError(err)
+	}
+	res := admin.AdminScanItemsResult{
+		Items:            make([]admin.AdminItem, len(out.Items)),
+		LastEvaluatedKey: adapterToAdminAttributeMap(out.LastEvaluatedKey),
+	}
+	for i, item := range out.Items {
+		res.Items[i] = admin.AdminItem{Attributes: adapterToAdminAttributeMap(item.Attributes)}
+	}
+	return res, nil
+}
+
+func (b *dynamoTablesBridge) AdminGetItem(ctx context.Context, principal admin.AuthPrincipal, table string, key map[string]admin.AdminAttributeValue) (*admin.AdminItem, bool, error) {
+	item, found, err := b.server.AdminGetItem(ctx, convertAdminPrincipal(principal), table, adminToAdapterAttributeMap(key))
+	if err != nil {
+		return nil, false, translateAdminItemsError(err)
+	}
+	if !found || item == nil {
+		return nil, false, nil
+	}
+	return &admin.AdminItem{Attributes: adapterToAdminAttributeMap(item.Attributes)}, true, nil
+}
+
+func (b *dynamoTablesBridge) AdminPutItem(ctx context.Context, principal admin.AuthPrincipal, table string, item admin.AdminItem) error {
+	adapterItem := adapter.AdminItem{Attributes: adminToAdapterAttributeMap(item.Attributes)}
+	if err := b.server.AdminPutItem(ctx, convertAdminPrincipal(principal), table, adapterItem); err != nil {
+		return translateAdminItemsError(err)
+	}
+	return nil
+}
+
+func (b *dynamoTablesBridge) AdminDeleteItem(ctx context.Context, principal admin.AuthPrincipal, table string, key map[string]admin.AdminAttributeValue) error {
+	if err := b.server.AdminDeleteItem(ctx, convertAdminPrincipal(principal), table, adminToAdapterAttributeMap(key)); err != nil {
+		return translateAdminItemsError(err)
+	}
+	return nil
+}
+
+// adminToAdapterAttributeValue / map functions translate the
+// admin package's wire type into the adapter package's parallel
+// struct. The two are isomorphic field-for-field; any drift here
+// is a build break, which is the right signal.
+func adminToAdapterAttributeValue(v admin.AdminAttributeValue) adapter.AdminAttributeValue {
+	out := adapter.AdminAttributeValue{
+		S: v.S, N: v.N, B: v.B, BOOL: v.BOOL, NULL: v.NULL,
+		SS: v.SS, NS: v.NS, BS: v.BS,
+	}
+	if v.L != nil {
+		out.L = make([]adapter.AdminAttributeValue, len(v.L))
+		for i, e := range v.L {
+			out.L[i] = adminToAdapterAttributeValue(e)
+		}
+	}
+	if v.M != nil {
+		out.M = make(map[string]adapter.AdminAttributeValue, len(v.M))
+		for k, e := range v.M {
+			out.M[k] = adminToAdapterAttributeValue(e)
+		}
+	}
+	return out
+}
+
+func adapterToAdminAttributeValue(v adapter.AdminAttributeValue) admin.AdminAttributeValue {
+	out := admin.AdminAttributeValue{
+		S: v.S, N: v.N, B: v.B, BOOL: v.BOOL, NULL: v.NULL,
+		SS: v.SS, NS: v.NS, BS: v.BS,
+	}
+	if v.L != nil {
+		out.L = make([]admin.AdminAttributeValue, len(v.L))
+		for i, e := range v.L {
+			out.L[i] = adapterToAdminAttributeValue(e)
+		}
+	}
+	if v.M != nil {
+		out.M = make(map[string]admin.AdminAttributeValue, len(v.M))
+		for k, e := range v.M {
+			out.M[k] = adapterToAdminAttributeValue(e)
+		}
+	}
+	return out
+}
+
+func adminToAdapterAttributeMap(in map[string]admin.AdminAttributeValue) map[string]adapter.AdminAttributeValue {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]adapter.AdminAttributeValue, len(in))
+	for k, v := range in {
+		out[k] = adminToAdapterAttributeValue(v)
+	}
+	return out
+}
+
+func adapterToAdminAttributeMap(in map[string]adapter.AdminAttributeValue) map[string]admin.AdminAttributeValue {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]admin.AdminAttributeValue, len(in))
+	for k, v := range in {
+		out[k] = adapterToAdminAttributeValue(v)
+	}
+	return out
+}
+
+// translateAdminItemsError maps the adapter's item-level error
+// vocabulary onto the admin-package sentinels. Mirrors
+// translateAdminTablesError's shape but uses the Items
+// sentinels — kept separate so a future per-resource
+// classification change (e.g., a new "rate limited" sentinel
+// for the item path but not the table path) lands in one place.
+func translateAdminItemsError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, adapter.ErrAdminForbidden):
+		return admin.ErrItemsForbidden
+	case errors.Is(err, adapter.ErrAdminNotLeader):
+		return admin.ErrItemsNotLeader
+	case errors.Is(err, adapter.ErrAdminDynamoNotFound):
+		return admin.ErrItemsTableNotFound
+	case errors.Is(err, adapter.ErrAdminDynamoValidation):
+		return admin.ErrItemsValidation
+	default:
+		return err //nolint:wrapcheck // forwarded so the handler logs but does not surface it.
+	}
+}
+
 // convertAdminPrincipal mirrors admin.AuthPrincipal onto the
 // adapter's parallel struct. Both packages keep the principal type
 // independent so the adapter stays free of internal/admin

--- a/main_admin.go
+++ b/main_admin.go
@@ -730,6 +730,16 @@ func translateAdminItemsError(err error) error {
 		return admin.ErrItemsTableNotFound
 	case errors.Is(err, adapter.ErrAdminDynamoValidation):
 		return admin.ErrItemsValidation
+	case isLeaderChurnError(err):
+		// Mid-dispatch leadership churn looks like an internal error
+		// from the kv coordinator (election finishes between the
+		// adapter's isVerifiedDynamoLeader check and the actual
+		// Raft propose). Map to the Items not-leader sentinel so the
+		// handler returns 503 + Retry-After: 1 and the SPA's retry
+		// contract stays intact (Codex P2 on PR #813 — the table-side
+		// translator already does this; the item-side translator
+		// initially shipped without the parallel branch).
+		return admin.ErrItemsNotLeader
 	default:
 		return err //nolint:wrapcheck // forwarded so the handler logs but does not surface it.
 	}

--- a/main_admin_forward_test.go
+++ b/main_admin_forward_test.go
@@ -246,6 +246,25 @@ func (dummyTablesSource) AdminDeleteTable(_ context.Context, _ admin.AuthPrincip
 	panic("dummyTablesSource.AdminDeleteTable should not be invoked")
 }
 
+// Phase 3a item-level stubs — never invoked by the registration-
+// gate test but required for admin.TablesSource interface
+// satisfaction.
+func (dummyTablesSource) AdminScanItems(_ context.Context, _ admin.AuthPrincipal, _ string, _ admin.AdminScanItemsOptions) (admin.AdminScanItemsResult, error) {
+	panic("dummyTablesSource.AdminScanItems should not be invoked")
+}
+
+func (dummyTablesSource) AdminGetItem(_ context.Context, _ admin.AuthPrincipal, _ string, _ map[string]admin.AdminAttributeValue) (*admin.AdminItem, bool, error) {
+	panic("dummyTablesSource.AdminGetItem should not be invoked")
+}
+
+func (dummyTablesSource) AdminPutItem(_ context.Context, _ admin.AuthPrincipal, _ string, _ admin.AdminItem) error {
+	panic("dummyTablesSource.AdminPutItem should not be invoked")
+}
+
+func (dummyTablesSource) AdminDeleteItem(_ context.Context, _ admin.AuthPrincipal, _ string, _ map[string]admin.AdminAttributeValue) error {
+	panic("dummyTablesSource.AdminDeleteItem should not be invoked")
+}
+
 // dummyBucketsSource is the smallest concrete admin.BucketsSource
 // for the readyForRegistration gate test — symmetric with
 // dummyTablesSource. The S3-only branch of the gate (Codex P1 on

--- a/main_admin_test.go
+++ b/main_admin_test.go
@@ -427,6 +427,45 @@ func TestTranslateAdminTablesError_UnrelatedErrorPassesThrough(t *testing.T) {
 	require.Equal(t, in, out)
 }
 
+// TestTranslateAdminItemsError_LeaderChurn is the items-tier
+// counterpart of TestTranslateAdminTablesError_LeaderChurn — Codex
+// P2 on PR #813 flagged that translateAdminItemsError did not
+// classify transient leader-churn errors as 503/retryable, so an
+// election mid-AdminPutItem / AdminGetItem would 500 instead of
+// surfacing through the SPA's retry path.
+func TestTranslateAdminItemsError_LeaderChurn(t *testing.T) {
+	cases := []struct {
+		name string
+		in   error
+	}{
+		{"kv.ErrLeaderNotFound", kv.ErrLeaderNotFound},
+		{"adapter.ErrNotLeader", adapter.ErrNotLeader},
+		{"adapter.ErrLeaderNotFound", adapter.ErrLeaderNotFound},
+		{"wrapped not leader", errors.New("dispatch failed: not leader")},
+		{"wrapped leader not found", errors.New("dispatch: leader not found")},
+		{"wrapped leadership lost", errors.New("commit aborted: leadership lost")},
+		{"wrapped leadership transfer", errors.New("retry exhausted: leadership transfer in progress")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := translateAdminItemsError(tc.in)
+			require.ErrorIs(t, out, admin.ErrItemsNotLeader,
+				"input %q must map to ErrItemsNotLeader", tc.in)
+		})
+	}
+}
+
+// TestTranslateAdminItemsError_UnrelatedErrorPassesThrough is the
+// items-tier counterpart of the table-tier passthrough test — keep
+// the leader-churn detector narrow enough that an unrelated error
+// mentioning "leader" still surfaces as a 500.
+func TestTranslateAdminItemsError_UnrelatedErrorPassesThrough(t *testing.T) {
+	in := errors.New("team leader misconfigured")
+	out := translateAdminItemsError(in)
+	require.NotErrorIs(t, out, admin.ErrItemsNotLeader)
+	require.Equal(t, in, out)
+}
+
 // TestTranslateAdminQueuesError_LeaderChurn is the SQS counterpart of
 // TestTranslateAdminTablesError_LeaderChurn. AdminDeleteQueue clears
 // the upfront isVerifiedSQSLeader check but the kv coordinator can

--- a/main_admin_test.go
+++ b/main_admin_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"io"
 	"math/big"
 	"net"
@@ -464,6 +465,24 @@ func TestTranslateAdminItemsError_UnrelatedErrorPassesThrough(t *testing.T) {
 	out := translateAdminItemsError(in)
 	require.NotErrorIs(t, out, admin.ErrItemsNotLeader)
 	require.Equal(t, in, out)
+}
+
+// TestTranslateAdminItemsError_ValidationPreservesAdapterMessage pins
+// the Claude review on PR #813 r3 finding: a wrapped
+// adapter.ErrAdminDynamoValidation must reach the HTTP 400 body
+// with its operator-facing reason intact, not the bare sentinel
+// "admin dynamo items: invalid request". The migration-required
+// hint in particular (e.g. legacy-key migration on a freshly-loaded
+// table) is the most operator-useful 400 message in the adapter
+// vocabulary; dropping it at the bridge made the SPA unhelpful.
+func TestTranslateAdminItemsError_ValidationPreservesAdapterMessage(t *testing.T) {
+	in := fmt.Errorf("%w: table requires a one-time legacy-key migration before admin read endpoints are available",
+		adapter.ErrAdminDynamoValidation)
+	out := translateAdminItemsError(in)
+	require.ErrorIs(t, out, admin.ErrItemsValidation,
+		"wrapped adapter.ErrAdminDynamoValidation must still match admin.ErrItemsValidation")
+	require.Contains(t, out.Error(), "legacy-key migration",
+		"adapter validation message must propagate so the SPA's 400 body carries the operator hint")
 }
 
 // TestTranslateAdminQueuesError_LeaderChurn is the SQS counterpart of


### PR DESCRIPTION
## Summary

**Phase 3a** of `docs/design/2026_05_22_implemented_admin_data_browser.md` §3.3 — exposes the Phase 2a (PR #805) `*adapter.DynamoDBServer` item-level admin RPCs through the admin HTTP API.

## Surface

```
GET    /admin/api/v1/dynamo/tables/{name}/items                — scan
GET    /admin/api/v1/dynamo/tables/{name}/items/{key-b64url}   — get
PUT    /admin/api/v1/dynamo/tables/{name}/items/{key-b64url}   — put
DELETE /admin/api/v1/dynamo/tables/{name}/items/{key-b64url}   — delete
```

`{key}` is base64-url-encoded JSON of the primary-key `map[string]AdminAttributeValue`. Base64-url passes the path validator's `%`-ban cleanly so arbitrary key bytes (non-ASCII, slashes, etc.) traverse without ambiguity.

## Routing

`dispatchPerTableRoute` adopts the SQS handler's 6-step procedure (escape-aware, dot-segment-rejecting, dispatch on segment count). `EscapedPath()` — not `Path` — is consulted so percent-encoded segments (`%2F`, `%2E%2E`, `%252F`) are rejected before decoding. The pre-Phase-3 `/tables/{name}` describe/delete branch is unchanged except for the more uniform 400 invalid_path classification on a bare trailing slash (previously 404 via empty-name passthrough — two existing tests updated).

## Authorization

| Operation | Gate |
|---|---|
| Scan / Get | `principal.Role.AllowsRead()` (RoleReadOnly or RoleFull) — payload is item content, matches SQS peek precedent |
| Put / Delete | `principal.Role.AllowsWrite()` (RoleFull only) via existing `principalForWrite` |

## Sentinels

| Sentinel | Maps to |
|---|---|
| `ErrItemsForbidden` | 403 |
| `ErrItemsNotLeader` | 503 |
| `ErrItemsTableNotFound` | 404 |
| `ErrItemsValidation` | 400 |

`dynamoTablesBridge.translateAdminItemsError` translates the adapter sentinels (`ErrAdminForbidden` / `NotLeader` / `DynamoNotFound` / `DynamoValidation`) onto these.

## Caller audit (semantic-change rule)

- `TablesSource` interface grew 4 methods (`AdminScanItems` / `AdminGetItem` / `AdminPutItem` / `AdminDeleteItem`). All implementations (production bridge + 4 test fixtures) updated in lockstep — the Go compiler enforces this.
- `dispatchPerTableRoute` changes the classification of bare `/tables/` (trailing slash, empty name) from 404 to 400 `invalid_path`. Two tests updated to reflect the semantically-clearer code. The SPA never builds that URL so no production caller depends on the 404 shape.

## Risk

Low. The handler is a pure wrapper over the existing Phase 2a admin RPCs. No new write codepath. The bridge in `main_admin.go` translates wire types and sentinels — both sides are isomorphic structs.

## Self-review (5 passes)

1. **Data loss** — Pure dispatch + bridge layer; no new write path. The adapter's existing chunked-write / Raft-dispatch path is unchanged.
2. **Concurrency** — Read paths re-use the adapter's pinned-readTS lifecycle. Write paths go through the same `*WithRetry` helpers the SigV4 path uses.
3. **Performance** — Scan paginates at `defaultAdminItemScanLimit=25` (cap 100). Key decoding is O(1) base64 + O(N) JSON parse on a primary-key map (usually <10 attributes). No new hot-path allocations.
4. **Consistency** — Body/path-key reconciliation ensures clients can't accidentally `PUT` a key disagreement (full-key body alongside a different `{key}` URL).
5. **Test coverage** — 19 new unit tests covering routing, key decoding, scan/get/put/delete happy paths, RBAC, and sentinel→status translation.

## Test plan

- [x] `go test -race -count=1 -timeout=60s ./internal/admin/...` — passes
- [x] `golangci-lint --config=.golangci.yaml run` — clean
- [ ] CI

## Phase plan

- Phase 2a: DynamoDB item RPCs — merged (#805)
- Phase 2b: S3 object RPCs — merged (#811)
- **Phase 3a: this PR (DynamoDB item HTTP)**
- Phase 3b: S3 object HTTP handlers + bridge — next
- Phase 4: SPA DynamoDetail Items tab
- Phase 5: SPA S3Detail Objects tab + Upload
- Phase 6: Doc rename `_proposed_` → `_implemented_`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Item-level operations for DynamoDB tables: scan items with pagination support, retrieve individual items, write items, and delete items via the admin API.
* Enhanced path validation and error handling with appropriate HTTP status codes and retry guidance for sensitive operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/813?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->