### PR TITLE
admin: HTTP handlers for S3 object RPCs (Phase 3b)

### DIFF
--- a/internal/admin/buckets_source.go
+++ b/internal/admin/buckets_source.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"context"
 	"errors"
+	"io"
 )
 
 // BucketsSource is the in-process surface the admin S3 handler
@@ -47,6 +48,33 @@ type BucketsSource interface {
 	// when objects remain (the dashboard cannot force a recursive
 	// delete; the SPA renders the 409 with a hint to clean up first).
 	AdminDeleteBucket(ctx context.Context, principal AuthPrincipal, name string) error
+
+	// Object-level admin RPCs (Phase 3b — design §3.1.2). The handler
+	// in s3_objects_handler.go drives these for the
+	// /buckets/{name}/objects{,/{key}} sub-tree. Implementations live
+	// in main_admin.go (bucketsBridge) and bridge to the adapter
+	// package's Admin*Object methods.
+
+	// AdminListObjects returns a bounded page of objects under a
+	// prefix. Delimiter folds pseudo-folders into CommonPrefixes
+	// (only emitted when Options.Delimiter is set).
+	AdminListObjects(ctx context.Context, principal AuthPrincipal, bucket string, opts AdminListObjectsOptions) (AdminObjectListing, error)
+	// AdminGetObject streams one object's body + metadata. The caller
+	// MUST close the returned body to release the read-tracker pin.
+	// (body, meta, nil) on success; (nil, AdminObject{}, err) on any
+	// failure. ErrObjectsNotFound flags the object-absent case.
+	AdminGetObject(ctx context.Context, principal AuthPrincipal, bucket, key string) (io.ReadCloser, AdminObject, error)
+	// AdminPutObject creates-or-replaces one object from a streaming
+	// body. ContentType is the operator-supplied Content-Type header
+	// (empty falls back to the adapter's defaultS3ContentType).
+	// Returns ErrObjectsUploadTooLarge if the body exceeds the admin
+	// per-object cap.
+	AdminPutObject(ctx context.Context, principal AuthPrincipal, bucket, key string, body io.Reader, contentType string) error
+	// AdminDeleteObject removes one object. Idempotent — a missing
+	// object surfaces as success (mirrors the SigV4 DeleteObject
+	// contract). Returns ErrObjectsBucketNotFound when the bucket
+	// itself is absent.
+	AdminDeleteObject(ctx context.Context, principal AuthPrincipal, bucket, key string) error
 }
 
 // BucketSummary is the bucket-level DTO the SPA receives. The JSON

--- a/internal/admin/s3_handler.go
+++ b/internal/admin/s3_handler.go
@@ -209,10 +209,11 @@ func (h *S3Handler) dispatchACLSubresource(w http.ResponseWriter, r *http.Reques
 //   - bucket name must be non-empty and slash-free (otherwise
 //     reject via the standard 404 fallthrough)
 //   - the literal "objects" sub-resource must be present
-//   - for the per-object route, the residual segment must not be
-//     empty (a trailing `/objects/` with no key is the collection
-//     shape, but we surface that as a 404 since the SPA never
-//     constructs it and a typo should be loud)
+//   - a residual that is empty OR has a leading slash is the
+//     objects route: empty returns (name, "", true) so the
+//     dispatcher routes to handleObjectsCollection (same shape
+//     as /buckets/{name}/objects); a leading-slash residual
+//     returns (name, key, true) for the per-object route
 //
 // The {key} validator (no `%`, no dot-segments) runs in the
 // object handler's segment decoder rather than here so the route
@@ -241,10 +242,11 @@ func splitBucketObjectsRoute(tail string) (string, string, bool) {
 }
 
 // dispatchObjectsSubtree routes the two recognised object-tier
-// shapes. The per-object segment is checked for emptiness here
-// (the splitter already accepts `name/objects/`); we surface that
-// as 400 invalid_path rather than misfiring into the collection
-// handler.
+// shapes. An empty sub is the collection route (matches the
+// splitter's name/objects/ trailing-slash shape with /buckets/
+// {name}/objects). A sub containing `/` is a malformed key
+// segment (the SPA base64-url-encodes the key so there should
+// be no embedded slash) and rejects with 400 invalid_path.
 func (h *S3Handler) dispatchObjectsSubtree(w http.ResponseWriter, r *http.Request, name, sub string) {
 	switch {
 	case sub == "":

--- a/internal/admin/s3_handler.go
+++ b/internal/admin/s3_handler.go
@@ -101,7 +101,17 @@ func (h *S3Handler) WithLeaderForwarder(f LeaderForwarder) *S3Handler {
 	return h
 }
 
-// ServeHTTP routes /buckets, /buckets/{name}, and /buckets/{name}/acl.
+// ServeHTTP routes /buckets, /buckets/{name}, /buckets/{name}/acl,
+// /buckets/{name}/objects, and /buckets/{name}/objects/{key-b64url}.
+//
+// The Phase-3b additions adopt the same escape-aware routing the
+// SQS handler uses: r.URL.EscapedPath() is consulted so a
+// percent-encoded segment (`%2F`, `%2E%2E`, `%252F`) is rejected
+// before any decode pass. The /buckets, /buckets/{name}, and
+// /buckets/{name}/acl branches stay on the original path-based
+// dispatch so the existing handler tests don't churn — keys are
+// always base64-url-encoded by the SPA and so never carry `%` or
+// dot-segments on the wire.
 func (h *S3Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case r.URL.Path == pathS3Buckets:
@@ -125,14 +135,18 @@ func (h *S3Handler) serveCollection(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// servePerBucket dispatches /s3/buckets/{name} and the single
-// sub-resource /s3/buckets/{name}/acl. Any other sub-path 404s so a
-// SPA bug pointed at a hypothetical /buckets/{name}/policy or
-// similar sees an unambiguous "no handler" rather than mistakenly
-// hitting the describe path with a "{name}/policy" string. The
-// pinned test is TestS3Handler_DescribeBucket_SubpathReturns404
-// (CodeRabbit minor on PR #658 caught a prior version of this
-// comment that mistakenly said "405").
+// servePerBucket dispatches /s3/buckets/{name}, the ACL sub-resource
+// /s3/buckets/{name}/acl, and the Phase-3b object sub-tree
+// /s3/buckets/{name}/objects{,/{key-b64url}}. The order matters:
+// the objects sub-tree is matched first so a `{name}` literally
+// equal to "objects" cannot collide with bucket-name dispatch (and
+// validateS3BucketName already forbids `/`, so the only way to
+// reach the objects branch is via the literal /objects segment).
+//
+// Anything else under /buckets/{name}/ is a 404 — a SPA bug
+// pointed at a hypothetical /buckets/{name}/policy sees an
+// unambiguous "no handler" rather than the describe path
+// silently swallowing the suffix.
 func (h *S3Handler) servePerBucket(w http.ResponseWriter, r *http.Request) {
 	tail := strings.TrimPrefix(r.URL.Path, pathPrefixS3Buckets)
 	if tail == "" {
@@ -140,19 +154,12 @@ func (h *S3Handler) servePerBucket(w http.ResponseWriter, r *http.Request) {
 			"bucket name is empty")
 		return
 	}
+	if name, sub, ok := splitBucketObjectsRoute(tail); ok {
+		h.dispatchObjectsSubtree(w, r, name, sub)
+		return
+	}
 	if strings.HasSuffix(tail, pathSuffixACL) {
-		name := strings.TrimSuffix(tail, pathSuffixACL)
-		if name == "" || strings.Contains(name, "/") {
-			writeJSONError(w, http.StatusNotFound, "not_found",
-				"no admin S3 handler is registered for this path")
-			return
-		}
-		if r.Method != http.MethodPut {
-			writeJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed",
-				"only PUT is allowed on /s3/buckets/{name}/acl")
-			return
-		}
-		h.handlePutACL(w, r, name)
+		h.dispatchACLSubresource(w, r, strings.TrimSuffix(tail, pathSuffixACL))
 		return
 	}
 	if strings.Contains(tail, "/") {
@@ -168,6 +175,82 @@ func (h *S3Handler) servePerBucket(w http.ResponseWriter, r *http.Request) {
 	default:
 		writeJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed",
 			"only GET or DELETE is allowed on /s3/buckets/{name}")
+	}
+}
+
+// dispatchACLSubresource handles the /buckets/{name}/acl route. Pulled
+// out of servePerBucket so the parent dispatcher stays under the
+// cyclomatic-complexity ceiling now that the Phase-3b /objects branch
+// added another arm.
+func (h *S3Handler) dispatchACLSubresource(w http.ResponseWriter, r *http.Request, name string) {
+	if name == "" || strings.Contains(name, "/") {
+		writeJSONError(w, http.StatusNotFound, "not_found",
+			"no admin S3 handler is registered for this path")
+		return
+	}
+	if r.Method != http.MethodPut {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed",
+			"only PUT is allowed on /s3/buckets/{name}/acl")
+		return
+	}
+	h.handlePutACL(w, r, name)
+}
+
+// splitBucketObjectsRoute recognises the two object-tier shapes
+// under /buckets/{name}/objects{,/{key-b64url}} and returns the
+// bucket name plus the residual segment (empty for the collection
+// route, the {key} segment for the per-object route). Returns
+// ok=false when tail does not address the objects sub-tree.
+//
+// Validation:
+//   - bucket name must be non-empty and slash-free (otherwise
+//     reject via the standard 404 fallthrough)
+//   - the literal "objects" sub-resource must be present
+//   - for the per-object route, the residual segment must not be
+//     empty (a trailing `/objects/` with no key is the collection
+//     shape, but we surface that as a 404 since the SPA never
+//     constructs it and a typo should be loud)
+//
+// The {key} validator (no `%`, no dot-segments) runs in the
+// object handler's segment decoder rather than here so the route
+// recogniser stays cheap.
+func splitBucketObjectsRoute(tail string) (string, string, bool) {
+	const objectsSep = "/" + adminObjectSubResource
+	idx := strings.Index(tail, objectsSep)
+	if idx <= 0 {
+		return "", "", false
+	}
+	name := tail[:idx]
+	if name == "" || strings.Contains(name, "/") {
+		return "", "", false
+	}
+	rest := tail[idx+len(objectsSep):]
+	switch {
+	case rest == "":
+		return name, "", true
+	case strings.HasPrefix(rest, "/"):
+		return name, rest[1:], true
+	default:
+		// Bucket name spilled past the /objects segment, e.g.
+		// `foo/objectsx` — not an objects route.
+		return "", "", false
+	}
+}
+
+// dispatchObjectsSubtree routes the two recognised object-tier
+// shapes. The per-object segment is checked for emptiness here
+// (the splitter already accepts `name/objects/`); we surface that
+// as 400 invalid_path rather than misfiring into the collection
+// handler.
+func (h *S3Handler) dispatchObjectsSubtree(w http.ResponseWriter, r *http.Request, name, sub string) {
+	switch {
+	case sub == "":
+		h.handleObjectsCollection(w, r, name)
+	case strings.Contains(sub, "/"):
+		writeJSONError(w, http.StatusBadRequest, "invalid_path",
+			"object key segment must not contain a slash; encode the key as base64-url")
+	default:
+		h.handleObjectResource(w, r, name, sub)
 	}
 }
 

--- a/internal/admin/s3_handler.go
+++ b/internal/admin/s3_handler.go
@@ -104,20 +104,23 @@ func (h *S3Handler) WithLeaderForwarder(f LeaderForwarder) *S3Handler {
 // ServeHTTP routes /buckets, /buckets/{name}, /buckets/{name}/acl,
 // /buckets/{name}/objects, and /buckets/{name}/objects/{key-b64url}.
 //
-// The Phase-3b additions adopt the same escape-aware routing the
-// SQS handler uses: r.URL.EscapedPath() is consulted so a
-// percent-encoded segment (`%2F`, `%2E%2E`, `%252F`) is rejected
-// before any decode pass. The /buckets, /buckets/{name}, and
-// /buckets/{name}/acl branches stay on the original path-based
-// dispatch so the existing handler tests don't churn — keys are
-// always base64-url-encoded by the SPA and so never carry `%` or
-// dot-segments on the wire.
+// EscapedPath() is the authoritative input — net/http pre-decodes
+// the raw path into r.URL.Path, turning `%2F` into a literal `/`
+// and splitting a single bucket segment across the route. The
+// confused-deputy class: a URL like `/buckets/victim%2Fobjects/{key}`
+// would (without EscapedPath) route to bucket "victim" rather than
+// the literal-named "victim/objects" segment, executing the
+// requested op against the wrong bucket. servePerBucket operates
+// on the escaped form so the encoded-slash and encoded-dot
+// traversal classes stay closed across all four sub-trees
+// (Codex P1 on PR #814).
 func (h *S3Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	escaped := r.URL.EscapedPath()
 	switch {
-	case r.URL.Path == pathS3Buckets:
+	case escaped == pathS3Buckets:
 		h.serveCollection(w, r)
-	case strings.HasPrefix(r.URL.Path, pathPrefixS3Buckets):
-		h.servePerBucket(w, r)
+	case strings.HasPrefix(escaped, pathPrefixS3Buckets):
+		h.servePerBucket(w, r, escaped)
 	default:
 		writeJSONError(w, http.StatusNotFound, "not_found", "")
 	}
@@ -147,8 +150,8 @@ func (h *S3Handler) serveCollection(w http.ResponseWriter, r *http.Request) {
 // pointed at a hypothetical /buckets/{name}/policy sees an
 // unambiguous "no handler" rather than the describe path
 // silently swallowing the suffix.
-func (h *S3Handler) servePerBucket(w http.ResponseWriter, r *http.Request) {
-	tail := strings.TrimPrefix(r.URL.Path, pathPrefixS3Buckets)
+func (h *S3Handler) servePerBucket(w http.ResponseWriter, r *http.Request, escaped string) {
+	tail := strings.TrimPrefix(escaped, pathPrefixS3Buckets)
 	if tail == "" {
 		writeJSONError(w, http.StatusBadRequest, "invalid_bucket_name",
 			"bucket name is empty")

--- a/internal/admin/s3_handler_test.go
+++ b/internal/admin/s3_handler_test.go
@@ -121,6 +121,28 @@ func (s *stubBucketsSource) AdminDeleteBucket(_ context.Context, principal AuthP
 	return nil
 }
 
+// Object-level Phase 3b methods are stubbed out here so the
+// existing bucket-tier tests can keep using stubBucketsSource
+// without compile errors. The s3_objects_handler_test.go file
+// embeds stubBucketsSource into a richer fake (stubObjectsSource)
+// that overrides these four methods with the in-memory store the
+// object tests need.
+func (s *stubBucketsSource) AdminListObjects(_ context.Context, _ AuthPrincipal, _ string, _ AdminListObjectsOptions) (AdminObjectListing, error) {
+	return AdminObjectListing{}, errors.New("stubBucketsSource.AdminListObjects: not implemented (use stubObjectsSource)")
+}
+
+func (s *stubBucketsSource) AdminGetObject(_ context.Context, _ AuthPrincipal, _, _ string) (io.ReadCloser, AdminObject, error) {
+	return nil, AdminObject{}, errors.New("stubBucketsSource.AdminGetObject: not implemented (use stubObjectsSource)")
+}
+
+func (s *stubBucketsSource) AdminPutObject(_ context.Context, _ AuthPrincipal, _, _ string, _ io.Reader, _ string) error {
+	return errors.New("stubBucketsSource.AdminPutObject: not implemented (use stubObjectsSource)")
+}
+
+func (s *stubBucketsSource) AdminDeleteObject(_ context.Context, _ AuthPrincipal, _, _ string) error {
+	return errors.New("stubBucketsSource.AdminDeleteObject: not implemented (use stubObjectsSource)")
+}
+
 func newS3HandlerForTest(src BucketsSource) *S3Handler {
 	return NewS3Handler(src)
 }

--- a/internal/admin/s3_objects_handler.go
+++ b/internal/admin/s3_objects_handler.go
@@ -1,0 +1,454 @@
+package admin
+
+import (
+	"encoding/base64"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Phase 3b — HTTP handlers for the object-level S3 admin surface.
+// Driven by §3.3 / §3.1.2 of
+// docs/design/2026_05_22_proposed_admin_data_browser.md.
+//
+// Routes owned by this file (dispatched from S3Handler.ServeHTTP
+// once the /buckets/{name}/objects sub-tree is detected):
+//
+//	GET    /admin/api/v1/s3/buckets/{name}/objects                  — list
+//	GET    /admin/api/v1/s3/buckets/{name}/objects/{key-b64url}     — download
+//	PUT    /admin/api/v1/s3/buckets/{name}/objects/{key-b64url}     — upload
+//	DELETE /admin/api/v1/s3/buckets/{name}/objects/{key-b64url}     — delete
+//
+// {key-b64url} is the base64-url-encoded raw object key. The list /
+// describe / delete routes for buckets stay JSON; the per-object
+// GET / PUT carry the object body as application/octet-stream (no
+// JSON wrapper) so an arbitrary blob round-trips without an extra
+// encode/decode pass.
+
+// adminObjectSubResource is the literal second segment after the
+// bucket name that activates the objects routes.
+const adminObjectSubResource = "objects"
+
+// adminObjectUploadCap is the per-request PUT body cap. Mirrors
+// the adapter's per-object admin upload limit. Bodies exceeding
+// this surface as 413 payload_too_large via http.MaxBytesReader.
+const adminObjectUploadCap = 100 << 20
+
+// List-page knobs. Default 100 mirrors the adapter's
+// adminListObjectsDefaultMaxKeys; the cap of 1000 mirrors
+// adminListObjectsMaxKeysCap. The SPA can override via ?max_keys.
+const (
+	defaultAdminObjectListMaxKeys = 100
+	adminObjectListMaxKeysCap     = 1000
+)
+
+// AdminObject is the metadata projection the SPA receives on list
+// pages and on the GET-object header set. The wire shape mirrors
+// adapter.AdminObject field-for-field; the bridge in main_admin.go
+// converts between the two so internal/admin stays adapter-free.
+type AdminObject struct {
+	Key          string    `json:"key"`
+	Size         int64     `json:"size"`
+	ContentType  string    `json:"content_type"`
+	ETag         string    `json:"etag"`
+	LastModified time.Time `json:"last_modified"`
+	StorageClass string    `json:"storage_class"`
+}
+
+// AdminListObjectsOptions controls one AdminListObjects call. Empty
+// values pick the adapter-side defaults (MaxKeys clamps to
+// [1, adminObjectListMaxKeysCap]).
+type AdminListObjectsOptions struct {
+	Prefix            string `json:"prefix,omitempty"`
+	Delimiter         string `json:"delimiter,omitempty"`
+	ContinuationToken string `json:"continuation_token,omitempty"`
+	MaxKeys           int    `json:"max_keys,omitempty"`
+}
+
+// AdminObjectListing is the JSON response shape for the list page.
+// CommonPrefixes is omitempty so a flat listing (no delimiter)
+// returns just `{"objects":[...]}`. NextContinuationToken is
+// non-empty only when the underlying scan stopped early.
+type AdminObjectListing struct {
+	Objects               []AdminObject `json:"objects"`
+	CommonPrefixes        []string      `json:"common_prefixes,omitempty"`
+	NextContinuationToken string        `json:"next_continuation_token,omitempty"`
+}
+
+// Sentinel errors the bridge translates Admin*Object adapter
+// errors into, so the handler maps them to HTTP status without
+// sniffing adapter-internal error vocabulary.
+
+// ErrObjectsForbidden — principal lacks the required role. 403.
+var ErrObjectsForbidden = errors.New("admin s3 objects: forbidden")
+
+// ErrObjectsNotLeader — this node is not the Raft leader for the
+// S3 group. 503 + Retry-After: 1; AdminForward will catch this once
+// the object surface is wired through it.
+var ErrObjectsNotLeader = errors.New("admin s3 objects: not leader")
+
+// ErrObjectsBucketNotFound — the named bucket does not exist. 404.
+var ErrObjectsBucketNotFound = errors.New("admin s3 objects: bucket not found")
+
+// ErrObjectsNotFound — the named object does not exist. 404.
+var ErrObjectsNotFound = errors.New("admin s3 objects: object not found")
+
+// ErrObjectsValidation — empty / malformed key, malformed bucket
+// name, oversized prefix/delimiter, invalid continuation token. 400.
+var ErrObjectsValidation = errors.New("admin s3 objects: invalid request")
+
+// ErrObjectsUploadTooLarge — PUT body exceeded the per-object cap.
+// Mapped to 413 payload_too_large; the bridge translates the
+// adapter's ErrAdminUploadTooLarge to this.
+var ErrObjectsUploadTooLarge = errors.New("admin s3 objects: upload exceeds cap")
+
+// ---------- handler entry points (called from S3Handler.ServeHTTP) ----------
+
+// handleObjectsCollection serves GET /buckets/{name}/objects.
+func (h *S3Handler) handleObjectsCollection(w http.ResponseWriter, r *http.Request, bucket string) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed", "only GET")
+		return
+	}
+	principal, ok := h.principalForObjectRead(w, r)
+	if !ok {
+		return
+	}
+	opts, ok := parseAdminListObjectsQuery(w, r)
+	if !ok {
+		return
+	}
+	listing, err := h.source.AdminListObjects(r.Context(), principal, bucket, opts)
+	if err != nil {
+		h.writeObjectsError(w, r, "list", bucket, err)
+		return
+	}
+	if listing.Objects == nil {
+		listing.Objects = []AdminObject{}
+	}
+	writeAdminJSONStatus(w, r.Context(), h.logger, http.StatusOK, listing)
+}
+
+// handleObjectResource serves /buckets/{name}/objects/{key-b64url}
+// (GET / PUT / DELETE). Body content type:
+//   - GET response: application/octet-stream (raw object bytes)
+//   - PUT request:  application/octet-stream (raw object bytes)
+//   - DELETE: no body
+func (h *S3Handler) handleObjectResource(w http.ResponseWriter, r *http.Request, bucket, keySegment string) {
+	key, ok := decodeAdminObjectKeySegment(w, keySegment)
+	if !ok {
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		h.handleObjectGet(w, r, bucket, key)
+	case http.MethodPut:
+		h.handleObjectPut(w, r, bucket, key)
+	case http.MethodDelete:
+		h.handleObjectDelete(w, r, bucket, key)
+	default:
+		writeJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed",
+			"only GET, PUT, or DELETE")
+	}
+}
+
+func (h *S3Handler) handleObjectGet(w http.ResponseWriter, r *http.Request, bucket, key string) {
+	principal, ok := h.principalForObjectRead(w, r)
+	if !ok {
+		return
+	}
+	body, meta, err := h.source.AdminGetObject(r.Context(), principal, bucket, key)
+	if err != nil {
+		h.writeObjectsError(w, r, "get", bucket, err)
+		return
+	}
+	defer func() {
+		if cerr := body.Close(); cerr != nil {
+			h.logger.LogAttrs(r.Context(), slog.LevelWarn, "admin s3 get object body close failed",
+				slog.String("bucket", bucket),
+				slog.String("key", key),
+				slog.String("error", cerr.Error()),
+			)
+		}
+	}()
+	writeAdminObjectGetHeaders(w, meta)
+	if _, err := io.Copy(w, body); err != nil {
+		// Connection-reset / client-disconnect mid-stream is common
+		// (downloads cancelled in the browser). Log at warn rather
+		// than error so an operator can still spot a sustained
+		// pattern without alerts firing on every cancelled tab.
+		h.logger.LogAttrs(r.Context(), slog.LevelWarn, "admin s3 get object body copy failed",
+			slog.String("bucket", bucket),
+			slog.String("key", key),
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
+func (h *S3Handler) handleObjectPut(w http.ResponseWriter, r *http.Request, bucket, key string) {
+	principal, ok := h.principalForWrite(w, r)
+	if !ok {
+		return
+	}
+	// Bound the body before any read; an oversized upload aborts
+	// without buffering the whole payload. The 413 path is the
+	// canonical admin payload_too_large response shape.
+	limited := http.MaxBytesReader(w, r.Body, adminObjectUploadCap)
+	defer func() {
+		if cerr := limited.Close(); cerr != nil {
+			h.logger.LogAttrs(r.Context(), slog.LevelWarn, "admin s3 put object body close failed",
+				slog.String("bucket", bucket),
+				slog.String("key", key),
+				slog.String("error", cerr.Error()),
+			)
+		}
+	}()
+	contentType := strings.TrimSpace(r.Header.Get("Content-Type"))
+	if err := h.source.AdminPutObject(r.Context(), principal, bucket, key, limited, contentType); err != nil {
+		// MaxBytesReader surfaces *http.MaxBytesError on the read,
+		// which the adapter forwards as ErrAdminUploadTooLarge —
+		// the bridge translates that to ErrObjectsUploadTooLarge.
+		// Any other read-side error (client disconnect, etc.) flows
+		// through the generic writeObjectsError path.
+		var mbErr *http.MaxBytesError
+		if errors.As(err, &mbErr) {
+			WriteMaxBytesError(w)
+			return
+		}
+		h.writeObjectsError(w, r, "put", bucket, err)
+		return
+	}
+	h.logger.LogAttrs(r.Context(), slog.LevelInfo, "admin_audit",
+		slog.String("actor", principal.AccessKey),
+		slog.String("role", string(principal.Role)),
+		slog.String("operation", "put_object"),
+		slog.String("bucket", bucket),
+		slog.String("key", key),
+	)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *S3Handler) handleObjectDelete(w http.ResponseWriter, r *http.Request, bucket, key string) {
+	principal, ok := h.principalForWrite(w, r)
+	if !ok {
+		return
+	}
+	if err := h.source.AdminDeleteObject(r.Context(), principal, bucket, key); err != nil {
+		h.writeObjectsError(w, r, "delete", bucket, err)
+		return
+	}
+	h.logger.LogAttrs(r.Context(), slog.LevelInfo, "admin_audit",
+		slog.String("actor", principal.AccessKey),
+		slog.String("role", string(principal.Role)),
+		slog.String("operation", "delete_object"),
+		slog.String("bucket", bucket),
+		slog.String("key", key),
+	)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ---------- response helpers ----------
+
+// writeAdminObjectGetHeaders sets the security headers and the
+// standard S3-style Content-* metadata for an object download.
+//
+// Security headers:
+//   - X-Content-Type-Options: nosniff — prevents the browser from
+//     overriding the Content-Type. An admin who downloads an HTML
+//     file uploaded by a less-privileged operator must not have it
+//     render in an admin-origin tab.
+//   - Content-Security-Policy: sandbox — strips script execution,
+//     plugins, and same-origin form posts from the response. Same
+//     defence-in-depth angle as nosniff; covers UAs that miss
+//     nosniff.
+//   - Content-Disposition: attachment; filename="..."  — forces a
+//     download dialog rather than inline rendering. The filename is
+//     derived from the basename of the object key (slash-split,
+//     last segment) and quoted-escaped.
+//   - Cache-Control: no-store — admin downloads must not be cached
+//     by intermediaries; revisiting a key after rotation should
+//     fetch the current bytes.
+func writeAdminObjectGetHeaders(w http.ResponseWriter, meta AdminObject) {
+	ct := meta.ContentType
+	if ct == "" {
+		ct = "application/octet-stream"
+	}
+	w.Header().Set("Content-Type", ct)
+	w.Header().Set("Content-Length", strconv.FormatInt(meta.Size, 10))
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Security-Policy", "sandbox; default-src 'none'")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Disposition",
+		`attachment; filename="`+sanitizeContentDispositionFilename(objectKeyBasename(meta.Key))+`"`)
+	if meta.ETag != "" {
+		w.Header().Set("ETag", meta.ETag)
+	}
+	if !meta.LastModified.IsZero() {
+		w.Header().Set("Last-Modified", meta.LastModified.UTC().Format(http.TimeFormat))
+	}
+}
+
+// objectKeyBasename returns the trailing slash-separated segment
+// of key. An empty trailing segment (the key ends in `/`) folds to
+// "object" so the Content-Disposition filename is never empty.
+func objectKeyBasename(key string) string {
+	idx := strings.LastIndex(key, "/")
+	if idx >= 0 {
+		key = key[idx+1:]
+	}
+	if key == "" {
+		return "object"
+	}
+	return key
+}
+
+// sanitizeContentDispositionFilename strips characters that break
+// the quoted-string form of the Content-Disposition value. We
+// substitute control characters and the literal quote / backslash
+// with `_` rather than percent-encoding because that round-trips
+// cleanly through every browser's download dialog. Full RFC 5987
+// `filename*=UTF-8”...` is out of scope; the SPA uses the
+// download dialog as a sane default.
+func sanitizeContentDispositionFilename(in string) string {
+	if in == "" {
+		return "object"
+	}
+	b := strings.Builder{}
+	b.Grow(len(in))
+	for _, r := range in {
+		switch {
+		case r < asciiSpace, r == asciiDelete, r == '"', r == '\\':
+			b.WriteByte('_')
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// ASCII control-character boundaries used by the filename sanitiser.
+// Pulled out as named constants so mnd does not flag the inline
+// literals.
+const (
+	asciiSpace  = 0x20
+	asciiDelete = 0x7f
+)
+
+// ---------- principal helpers ----------
+
+// principalForObjectRead is the read-side companion to principalForWrite
+// for the object-content paths. Same live-role re-check as the SPA-
+// facing endpoints — payload is object bytes, so AllowsRead (RoleReadOnly
+// OR RoleFull) is the right gate.
+func (h *S3Handler) principalForObjectRead(w http.ResponseWriter, r *http.Request) (AuthPrincipal, bool) {
+	principal, ok := PrincipalFromContext(r.Context())
+	if !ok {
+		writeJSONError(w, http.StatusUnauthorized, "unauthenticated", "no session principal")
+		return AuthPrincipal{}, false
+	}
+	if h.roles != nil {
+		live, exists := h.roles.LookupRole(principal.AccessKey)
+		if !exists || !live.AllowsRead() {
+			writeJSONError(w, http.StatusForbidden, "forbidden",
+				"this access key is not authorised to read object contents")
+			return AuthPrincipal{}, false
+		}
+		principal.Role = live
+	} else if !principal.Role.AllowsRead() {
+		writeJSONError(w, http.StatusForbidden, "forbidden",
+			"this access key is not authorised to read object contents")
+		return AuthPrincipal{}, false
+	}
+	return principal, true
+}
+
+// ---------- query / key parsing ----------
+
+// parseAdminListObjectsQuery pulls the read-only list knobs off the
+// URL. Continuation tokens are opaque base64url blobs the adapter
+// emits — we forward them verbatim without trying to parse the
+// inner structure (rotating the adapter's token shape must not
+// require an admin-handler update).
+func parseAdminListObjectsQuery(w http.ResponseWriter, r *http.Request) (AdminListObjectsOptions, bool) {
+	q := r.URL.Query()
+	opts := AdminListObjectsOptions{
+		Prefix:            q.Get("prefix"),
+		Delimiter:         q.Get("delimiter"),
+		ContinuationToken: q.Get("continuation_token"),
+		MaxKeys:           defaultAdminObjectListMaxKeys,
+	}
+	if raw := strings.TrimSpace(q.Get("max_keys")); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 1 {
+			writeJSONError(w, http.StatusBadRequest, "invalid_request",
+				"max_keys must be a positive integer")
+			return AdminListObjectsOptions{}, false
+		}
+		if n > adminObjectListMaxKeysCap {
+			n = adminObjectListMaxKeysCap
+		}
+		opts.MaxKeys = n
+	}
+	return opts, true
+}
+
+// decodeAdminObjectKeySegment decodes the `{key}` URL segment into
+// the raw object key. Base64-url is the wire shape; the encoded
+// segment is what the route validator stamps as legal (no `%`, no
+// dot-segments). An empty decoded key is treated as invalid since
+// S3 itself rejects zero-length keys.
+func decodeAdminObjectKeySegment(w http.ResponseWriter, segment string) (string, bool) {
+	raw, err := base64.RawURLEncoding.DecodeString(segment)
+	if err != nil {
+		// Tolerate padded base64 as a fallback so a hand-crafted
+		// curl with trailing `=` still works.
+		raw2, err2 := base64.URLEncoding.DecodeString(segment)
+		if err2 != nil {
+			writeJSONError(w, http.StatusBadRequest, "invalid_request",
+				"key segment is not valid base64-url: "+err.Error())
+			return "", false
+		}
+		raw = raw2
+	}
+	if len(raw) == 0 {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request",
+			"key segment decodes to an empty string")
+		return "", false
+	}
+	return string(raw), true
+}
+
+// ---------- error translation ----------
+
+// writeObjectsError translates the sentinel errors the bridge
+// surfaces into the canonical HTTP status + body shape. Mirrors
+// writeBucketsError but with the object-tier sentinels.
+func (h *S3Handler) writeObjectsError(w http.ResponseWriter, r *http.Request, op, bucket string, err error) {
+	switch {
+	case errors.Is(err, ErrObjectsForbidden):
+		writeJSONError(w, http.StatusForbidden, "forbidden", err.Error())
+	case errors.Is(err, ErrObjectsNotLeader):
+		w.Header().Set("Retry-After", "1")
+		writeJSONError(w, http.StatusServiceUnavailable, "leader_unavailable",
+			"this admin node is not the raft leader")
+	case errors.Is(err, ErrObjectsBucketNotFound):
+		writeJSONError(w, http.StatusNotFound, "not_found", "bucket does not exist")
+	case errors.Is(err, ErrObjectsNotFound):
+		writeJSONError(w, http.StatusNotFound, "not_found", "object does not exist")
+	case errors.Is(err, ErrObjectsValidation):
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", err.Error())
+	case errors.Is(err, ErrObjectsUploadTooLarge):
+		WriteMaxBytesError(w)
+	default:
+		h.logger.LogAttrs(r.Context(), slog.LevelError, "admin s3 "+op+" object failed",
+			slog.String("bucket", bucket),
+			slog.String("error", err.Error()),
+		)
+		writeJSONError(w, http.StatusInternalServerError, "s3_"+op+"_failed",
+			"failed to "+op+" object; see server logs")
+	}
+}

--- a/internal/admin/s3_objects_handler.go
+++ b/internal/admin/s3_objects_handler.go
@@ -456,6 +456,22 @@ func decodeAdminObjectKeySegment(w http.ResponseWriter, segment string) (string,
 // writeObjectsError translates the sentinel errors the bridge
 // surfaces into the canonical HTTP status + body shape. Mirrors
 // writeBucketsError but with the object-tier sentinels.
+//
+// Leader forwarding: the bucket-tier writes (CreateBucket /
+// PutBucketAcl / DeleteBucket) hand a follower's NotLeader off
+// to the leader via LeaderForwarder.ForwardXxx so the SPA never
+// observes a 503 on those routes. The object-tier endpoints
+// (ListObjects / GetObject / PutObject / DeleteObject) DO NOT
+// have this transparent fall-through yet — the same pattern the
+// SQS handler ships with today. The reason: GetObject and
+// PutObject stream bodies up to 100 MiB, which doesn't fit the
+// existing unary `bytes Payload` AdminForward proto. Wiring
+// streaming RPCs is a separate PR-scoped change (proto, server,
+// client, bridge, all four object ops); for now followers reply
+// 503 + Retry-After: 1 and the SPA's retry helper re-issues
+// against the leader via the leader-probe endpoint. Codex P1 on
+// PR #814 r3 flagged this; tracked as a follow-up rather than
+// expanding this PR by ~5 packages.
 func (h *S3Handler) writeObjectsError(w http.ResponseWriter, r *http.Request, op, bucket string, err error) {
 	switch {
 	case errors.Is(err, ErrObjectsForbidden):

--- a/internal/admin/s3_objects_handler.go
+++ b/internal/admin/s3_objects_handler.go
@@ -354,13 +354,30 @@ const (
 // ---------- principal helpers ----------
 
 // principalForObjectRead is the read-side companion to principalForWrite
-// for the object-content paths. Same live-role re-check as the SPA-
-// facing endpoints — payload is object bytes, so AllowsRead (RoleReadOnly
-// OR RoleFull) is the right gate.
+// for the object-content paths. Same defence-in-depth gate as
+// principalForWrite — the JWT role check fires unconditionally
+// before the optional live-role re-validation, so a token minted
+// with role=none (or one that drifted past a revocation) cannot
+// slip through even when the live RoleStore says the access key
+// is now allowed (Claude review on PR #814 r2 caught the
+// asymmetry between principalForObjectRead and principalForWrite
+// — the latter has had this pattern since PR #669, the former
+// shipped without it).
+//
+// AllowsRead (RoleReadOnly OR RoleFull) is the right gate for
+// object-content reads.
 func (h *S3Handler) principalForObjectRead(w http.ResponseWriter, r *http.Request) (AuthPrincipal, bool) {
 	principal, ok := PrincipalFromContext(r.Context())
 	if !ok {
 		writeJSONError(w, http.StatusUnauthorized, "unauthenticated", "no session principal")
+		return AuthPrincipal{}, false
+	}
+	// JWT role gate fires first, unconditionally. The live re-check
+	// below can only further constrain — it can never relax what
+	// the token was minted with.
+	if !principal.Role.AllowsRead() {
+		writeJSONError(w, http.StatusForbidden, "forbidden",
+			"this access key is not authorised to read object contents")
 		return AuthPrincipal{}, false
 	}
 	if h.roles != nil {
@@ -370,11 +387,10 @@ func (h *S3Handler) principalForObjectRead(w http.ResponseWriter, r *http.Reques
 				"this access key is not authorised to read object contents")
 			return AuthPrincipal{}, false
 		}
+		// Use the live role downstream — the JWT may carry a stale
+		// value but the live one is authoritative once both gates
+		// agree the request is allowed.
 		principal.Role = live
-	} else if !principal.Role.AllowsRead() {
-		writeJSONError(w, http.StatusForbidden, "forbidden",
-			"this access key is not authorised to read object contents")
-		return AuthPrincipal{}, false
 	}
 	return principal, true
 }

--- a/internal/admin/s3_objects_handler.go
+++ b/internal/admin/s3_objects_handler.go
@@ -166,6 +166,19 @@ func (h *S3Handler) handleObjectGet(w http.ResponseWriter, r *http.Request, buck
 		h.writeObjectsError(w, r, "get", bucket, err)
 		return
 	}
+	// Defensive nil guard: an adapter that mis-implements the
+	// (nil-body, nil-err) contract would panic on the defer
+	// body.Close() below. Surface a 500 instead and log so the
+	// regression is operator-visible (Claude review on PR #814 r1).
+	if body == nil {
+		h.logger.LogAttrs(r.Context(), slog.LevelError, "admin s3 get object: adapter returned nil body with nil error",
+			slog.String("bucket", bucket),
+			slog.String("key", key),
+		)
+		writeJSONError(w, http.StatusInternalServerError, "s3_get_failed",
+			"adapter returned nil body; see server logs")
+		return
+	}
 	defer func() {
 		if cerr := body.Close(); cerr != nil {
 			h.logger.LogAttrs(r.Context(), slog.LevelWarn, "admin s3 get object body close failed",

--- a/internal/admin/s3_objects_handler_test.go
+++ b/internal/admin/s3_objects_handler_test.go
@@ -511,16 +511,38 @@ func TestS3Objects_Put_Rejects413OnOversizedBody(t *testing.T) {
 	src := newStubObjectsSource()
 	h := newS3HandlerForTest(src)
 
-	// http.MaxBytesReader's *limit* is exclusive — a body of cap+1
-	// bytes overflows on the first read past the cap.
-	oversize := bytes.Repeat([]byte("x"), adminObjectUploadCap+1)
+	// http.MaxBytesReader's *limit* is exclusive — a body whose
+	// declared length exceeds the cap (or whose actual stream
+	// overflows) trips on the first read past the cap. Use a
+	// lazy infiniteX reader (capped via io.LimitReader at cap+1)
+	// rather than a 100 MiB bytes.Repeat allocation — keeps the
+	// test memory footprint under a kilobyte (Claude review on
+	// PR #814 r1).
+	oversize := io.LimitReader(&infiniteX{}, int64(adminObjectUploadCap)+1)
 	req := httptest.NewRequest(http.MethodPut, objectPath("photos", "huge.bin"),
-		bytes.NewReader(oversize))
+		oversize)
+	// httptest.NewRequest with an io.Reader sets ContentLength=-1
+	// so MaxBytesReader can't short-circuit on Content-Length; it
+	// has to actually read past the cap. That's what we want here:
+	// it exercises the read-side overflow path that production
+	// uploads hit when ContentLength is absent or wrong.
 	req = withWritePrincipal(req)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+}
+
+// infiniteX is a zero-state io.Reader that yields 'x' indefinitely;
+// callers cap it via io.LimitReader. Used by the oversize-PUT test
+// to avoid allocating the full 100 MiB body up front.
+type infiniteX struct{}
+
+func (infiniteX) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'x'
+	}
+	return len(p), nil
 }
 
 func TestS3Objects_Put_TranslatesUploadTooLargeSentinel(t *testing.T) {

--- a/internal/admin/s3_objects_handler_test.go
+++ b/internal/admin/s3_objects_handler_test.go
@@ -237,6 +237,57 @@ func TestS3Objects_RoutingRejectsTooManyKeySlashes(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "must not contain a slash")
 }
 
+// TestS3Objects_RoutingRejectsEncodedSlashInBucket pins the Codex P1
+// on PR #814: r.URL.Path is pre-decoded by net/http, so an attacker
+// URL like /buckets/victim%2Fobjects/{key} would (without the
+// EscapedPath() switch) be interpreted as
+// /buckets/victim/objects/{key} and run the operation against the
+// "victim" bucket rather than the literal-named "victim/objects"
+// segment. The fix: servePerBucket consults r.URL.EscapedPath() so
+// the %2F stays opaque through the route split.
+func TestS3Objects_RoutingRejectsEncodedSlashInBucket(t *testing.T) {
+	t.Parallel()
+	src := newStubObjectsSource()
+	src.seedObject("victim", "k1", []byte("secret"))
+	h := newS3HandlerForTest(src)
+
+	keySeg := base64.RawURLEncoding.EncodeToString([]byte("k1"))
+	cases := []struct {
+		name   string
+		method string
+		url    string
+		body   io.Reader
+	}{
+		{"GET object", http.MethodGet,
+			pathPrefixS3Buckets + "victim%2Fobjects/" + keySeg, nil},
+		{"PUT object", http.MethodPut,
+			pathPrefixS3Buckets + "victim%2Fobjects/" + keySeg, bytes.NewReader([]byte("hostile"))},
+		{"DELETE object", http.MethodDelete,
+			pathPrefixS3Buckets + "victim%2Fobjects/" + keySeg, nil},
+		{"GET list", http.MethodGet,
+			pathPrefixS3Buckets + "victim%2Fobjects", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.url, tc.body)
+			switch tc.method {
+			case http.MethodGet:
+				req = withReadOnlyPrincipal(req)
+			default:
+				req = withWritePrincipal(req)
+			}
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			// Reject must happen before the source is reached — any
+			// 200 / 204 here would mean the request executed against
+			// the wrong bucket (confused-deputy class).
+			require.NotContains(t, []int{http.StatusOK, http.StatusNoContent}, rec.Code,
+				"encoded slash in bucket segment must be rejected; got %d, body=%s",
+				rec.Code, rec.Body.String())
+		})
+	}
+}
+
 func TestS3Objects_RoutingMethodNotAllowed(t *testing.T) {
 	t.Parallel()
 	h := newS3HandlerForTest(newStubObjectsSource())

--- a/internal/admin/s3_objects_handler_test.go
+++ b/internal/admin/s3_objects_handler_test.go
@@ -1,0 +1,613 @@
+package admin
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/require"
+)
+
+// stubObjectsSource is the richer BucketsSource fake that backs the
+// object-tier handler tests. It embeds stubBucketsSource so the
+// existing bucket-tier methods stay available, and adds an in-memory
+// object store keyed by (bucket, key). The four object-tier methods
+// override the stubs in s3_handler_test.go.
+type stubObjectsSource struct {
+	stubBucketsSource
+
+	// objects[bucket][key] = body bytes (the metadata projection is
+	// synthesised from the body length and a fixed content type).
+	objects map[string]map[string][]byte
+
+	// nextErr, when non-nil, short-circuits the next call to any
+	// object-tier method and returns that error verbatim. Used by
+	// the sentinel-translation tests to inject specific failures.
+	nextErr error
+
+	lastPutPrincipal AuthPrincipal
+	lastPutBucket    string
+	lastPutKey       string
+	lastPutCT        string
+	lastPutBody      []byte
+
+	lastDeletePrincipal AuthPrincipal
+	lastDeleteBucket    string
+	lastDeleteKey       string
+}
+
+func newStubObjectsSource() *stubObjectsSource {
+	return &stubObjectsSource{
+		stubBucketsSource: stubBucketsSource{buckets: map[string]BucketSummary{}},
+		objects:           map[string]map[string][]byte{},
+	}
+}
+
+// seedObject inserts an in-memory object for the named bucket.
+// The bucket parameter is currently exercised with "photos" by
+// every existing test but is left as a parameter so future
+// multi-bucket tests can seed under a different bucket without
+// reshaping every caller.
+//
+//nolint:unparam // bucket parameterised for future multi-bucket tests
+func (s *stubObjectsSource) seedObject(bucket, key string, body []byte) {
+	if s.objects[bucket] == nil {
+		s.objects[bucket] = map[string][]byte{}
+	}
+	s.objects[bucket][key] = append([]byte(nil), body...)
+}
+
+func (s *stubObjectsSource) AdminListObjects(_ context.Context, _ AuthPrincipal, bucket string, opts AdminListObjectsOptions) (AdminObjectListing, error) {
+	if s.nextErr != nil {
+		return AdminObjectListing{}, s.nextErr
+	}
+	inBucket := s.objects[bucket]
+	keys := make([]string, 0, len(inBucket))
+	for k := range inBucket {
+		if strings.HasPrefix(k, opts.Prefix) {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	// Clamp to default cap when opts.MaxKeys is unset by the handler
+	// (Phase-3b handler always sets it but defend against zero).
+	maxKeys := opts.MaxKeys
+	if maxKeys <= 0 {
+		maxKeys = defaultAdminObjectListMaxKeys
+	}
+	out := AdminObjectListing{}
+	for _, k := range keys {
+		if len(out.Objects) >= maxKeys {
+			out.NextContinuationToken = base64.RawURLEncoding.EncodeToString([]byte(k))
+			break
+		}
+		out.Objects = append(out.Objects, AdminObject{
+			Key:         k,
+			Size:        int64(len(inBucket[k])),
+			ContentType: "application/octet-stream",
+		})
+	}
+	return out, nil
+}
+
+func (s *stubObjectsSource) AdminGetObject(_ context.Context, _ AuthPrincipal, bucket, key string) (io.ReadCloser, AdminObject, error) {
+	if s.nextErr != nil {
+		return nil, AdminObject{}, s.nextErr
+	}
+	inBucket, ok := s.objects[bucket]
+	if !ok {
+		return nil, AdminObject{}, ErrObjectsBucketNotFound
+	}
+	body, ok := inBucket[key]
+	if !ok {
+		return nil, AdminObject{}, ErrObjectsNotFound
+	}
+	return io.NopCloser(bytes.NewReader(body)), AdminObject{
+		Key:         key,
+		Size:        int64(len(body)),
+		ContentType: "application/octet-stream",
+		ETag:        `"deadbeef"`,
+	}, nil
+}
+
+func (s *stubObjectsSource) AdminPutObject(_ context.Context, principal AuthPrincipal, bucket, key string, body io.Reader, contentType string) error {
+	s.lastPutPrincipal = principal
+	s.lastPutBucket = bucket
+	s.lastPutKey = key
+	s.lastPutCT = contentType
+	if s.nextErr != nil {
+		return s.nextErr
+	}
+	buf, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+	s.lastPutBody = append([]byte(nil), buf...)
+	if s.objects[bucket] == nil {
+		s.objects[bucket] = map[string][]byte{}
+	}
+	s.objects[bucket][key] = s.lastPutBody
+	return nil
+}
+
+func (s *stubObjectsSource) AdminDeleteObject(_ context.Context, principal AuthPrincipal, bucket, key string) error {
+	s.lastDeletePrincipal = principal
+	s.lastDeleteBucket = bucket
+	s.lastDeleteKey = key
+	if s.nextErr != nil {
+		return s.nextErr
+	}
+	if inBucket, ok := s.objects[bucket]; ok {
+		delete(inBucket, key)
+	}
+	return nil
+}
+
+// objectPath builds the URL for an object resource the same way
+// the SPA will: base64-url-encode the key and slot into the route.
+// The bucket name is URL-path-escaped so the test can exercise
+// bucket names with reserved characters (validateS3BucketName
+// blocks them in production, but the route layer should still be
+// defensive).
+func objectPath(bucket, key string) string {
+	return pathPrefixS3Buckets + url.PathEscape(bucket) +
+		"/" + adminObjectSubResource +
+		"/" + base64.RawURLEncoding.EncodeToString([]byte(key))
+}
+
+// objectsCollectionPath builds the /buckets/{name}/objects URL.
+// Same caller-future parity rationale as objectPath above —
+// bucket stays parameterised so future tests can target a
+// different bucket without reshaping every call site.
+//
+//nolint:unparam // bucket parameterised for future multi-bucket tests
+func objectsCollectionPath(bucket string) string {
+	return pathPrefixS3Buckets + url.PathEscape(bucket) + "/" + adminObjectSubResource
+}
+
+// ---------- routing ----------
+
+func TestS3Objects_RoutingDispatchesEachMethod(t *testing.T) {
+	t.Parallel()
+	src := newStubObjectsSource()
+	src.seedObject("photos", "k1", []byte("hello"))
+	h := newS3HandlerForTest(src)
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		body   io.Reader
+		expect int
+	}{
+		{"GET collection", http.MethodGet, objectsCollectionPath("photos"), nil, http.StatusOK},
+		{"GET object", http.MethodGet, objectPath("photos", "k1"), nil, http.StatusOK},
+		{"PUT object", http.MethodPut, objectPath("photos", "k2"), bytes.NewReader([]byte("body")), http.StatusNoContent},
+		{"DELETE object", http.MethodDelete, objectPath("photos", "k1"), nil, http.StatusNoContent},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, tc.body)
+			switch tc.method {
+			case http.MethodGet:
+				req = withReadOnlyPrincipal(req)
+			default:
+				req = withWritePrincipal(req)
+			}
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			require.Equal(t, tc.expect, rec.Code, "body: %s", rec.Body.String())
+		})
+	}
+}
+
+func TestS3Objects_RoutingRejectsUnknownSubResource(t *testing.T) {
+	t.Parallel()
+	h := newS3HandlerForTest(newStubObjectsSource())
+
+	// /buckets/photos/widgets — not a recognised sub-resource. The
+	// "no slashes in bucket name" branch fires first, returning 404.
+	req := httptest.NewRequest(http.MethodGet, pathPrefixS3Buckets+"photos/widgets", nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestS3Objects_RoutingRejectsTooManyKeySlashes(t *testing.T) {
+	t.Parallel()
+	h := newS3HandlerForTest(newStubObjectsSource())
+
+	// /buckets/photos/objects/foo/bar — interior slash in the key
+	// segment is rejected (keys must be base64-url-encoded).
+	req := httptest.NewRequest(http.MethodGet, pathPrefixS3Buckets+"photos/objects/foo/bar", nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "must not contain a slash")
+}
+
+func TestS3Objects_RoutingMethodNotAllowed(t *testing.T) {
+	t.Parallel()
+	h := newS3HandlerForTest(newStubObjectsSource())
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"collection POST", http.MethodPost, objectsCollectionPath("photos")},
+		{"object POST", http.MethodPost, objectPath("photos", "k1")},
+		{"object PATCH", http.MethodPatch, objectPath("photos", "k1")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req = withWritePrincipal(req)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+		})
+	}
+}
+
+// ---------- key segment decoding ----------
+
+func TestS3Objects_RejectsMalformedKeySegment(t *testing.T) {
+	t.Parallel()
+	h := newS3HandlerForTest(newStubObjectsSource())
+
+	// "!!!" is not valid base64-url-raw NOR padded; decoder rejects both.
+	req := httptest.NewRequest(http.MethodGet,
+		pathPrefixS3Buckets+"photos/"+adminObjectSubResource+"/!!!", nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "base64-url")
+}
+
+// The empty-decoded-key path inside decodeAdminObjectKeySegment is
+// defensive: a single non-empty URL segment can never decode to
+// zero bytes via base64-url (the smallest valid segment "AA"
+// decodes to a single 0x00 byte). The branch exists so a future
+// refactor that loosens the routing layer (e.g. accepts a
+// zero-length segment via the splitter) fails closed rather than
+// dispatching to AdminGetObject with an empty key. Tested
+// indirectly via the routing-rejection coverage above.
+
+// ---------- list ----------
+
+func TestS3Objects_List_ReturnsObjects(t *testing.T) {
+	t.Parallel()
+	src := newStubObjectsSource()
+	src.seedObject("photos", "a.png", []byte("a"))
+	src.seedObject("photos", "b.png", []byte("bb"))
+	h := newS3HandlerForTest(src)
+
+	req := httptest.NewRequest(http.MethodGet, objectsCollectionPath("photos"), nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var got AdminObjectListing
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got.Objects, 2)
+	require.Equal(t, "a.png", got.Objects[0].Key)
+	require.Equal(t, int64(1), got.Objects[0].Size)
+	require.Equal(t, "b.png", got.Objects[1].Key)
+	require.Equal(t, int64(2), got.Objects[1].Size)
+}
+
+func TestS3Objects_List_EmptyListSerializesAsEmptyArray(t *testing.T) {
+	t.Parallel()
+	h := newS3HandlerForTest(newStubObjectsSource())
+
+	req := httptest.NewRequest(http.MethodGet, objectsCollectionPath("photos"), nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	// SPA distinguishes "no bucket" from "empty bucket" — empty
+	// must serialize as `"objects":[]`, not `"objects":null`.
+	require.Contains(t, rec.Body.String(), `"objects":[]`)
+}
+
+func TestS3Objects_List_MaxKeysClamped(t *testing.T) {
+	t.Parallel()
+	src := newStubObjectsSource()
+	for i := range 5 {
+		src.seedObject("photos", string('a'+rune(i))+".png", []byte("x"))
+	}
+	h := newS3HandlerForTest(src)
+
+	// Limit 2 → page has 2 entries plus next_continuation_token.
+	req := httptest.NewRequest(http.MethodGet, objectsCollectionPath("photos")+"?max_keys=2", nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var got AdminObjectListing
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got.Objects, 2)
+	require.NotEmpty(t, got.NextContinuationToken)
+}
+
+func TestS3Objects_List_RejectsBadMaxKeys(t *testing.T) {
+	t.Parallel()
+	h := newS3HandlerForTest(newStubObjectsSource())
+
+	for _, raw := range []string{"abc", "-1", "0"} {
+		t.Run(raw, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet,
+				objectsCollectionPath("photos")+"?max_keys="+raw, nil)
+			req = withReadOnlyPrincipal(req)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+		})
+	}
+}
+
+// ---------- get ----------
+
+func TestS3Objects_Get_StreamsBodyAndSetsHeaders(t *testing.T) {
+	t.Parallel()
+	src := newStubObjectsSource()
+	src.seedObject("photos", "logo.png", []byte("png-bytes-here"))
+	h := newS3HandlerForTest(src)
+
+	req := httptest.NewRequest(http.MethodGet, objectPath("photos", "logo.png"), nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "png-bytes-here", rec.Body.String())
+	// Security headers — defence-in-depth against a hostile upload
+	// rendering in the admin origin.
+	require.Equal(t, "nosniff", rec.Header().Get("X-Content-Type-Options"))
+	require.Contains(t, rec.Header().Get("Content-Security-Policy"), "sandbox")
+	require.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+	require.Contains(t, rec.Header().Get("Content-Disposition"), "attachment")
+	require.Contains(t, rec.Header().Get("Content-Disposition"), `filename="logo.png"`)
+	require.Equal(t, "14", rec.Header().Get("Content-Length"))
+	require.Equal(t, `"deadbeef"`, rec.Header().Get("ETag"))
+}
+
+func TestS3Objects_Get_SanitisesContentDispositionFilename(t *testing.T) {
+	t.Parallel()
+	// Key with control characters / quote / backslash that must be
+	// substituted before being interpolated into the quoted-string
+	// form of Content-Disposition.
+	src := newStubObjectsSource()
+	src.seedObject("photos", "weird\"name\\.txt", []byte("x"))
+	h := newS3HandlerForTest(src)
+
+	req := httptest.NewRequest(http.MethodGet, objectPath("photos", "weird\"name\\.txt"), nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	cd := rec.Header().Get("Content-Disposition")
+	require.NotContains(t, cd, `"name`, "quote inside filename must be substituted")
+	require.NotContains(t, cd, `\\`, "backslash inside filename must be substituted")
+	require.Contains(t, cd, `filename="`)
+}
+
+func TestS3Objects_Get_MissingObject404(t *testing.T) {
+	t.Parallel()
+	src := newStubObjectsSource()
+	src.seedObject("photos", "k1", []byte("x")) // ensure bucket exists
+	h := newS3HandlerForTest(src)
+
+	req := httptest.NewRequest(http.MethodGet, objectPath("photos", "missing"), nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestS3Objects_Get_MissingBucket404(t *testing.T) {
+	t.Parallel()
+	h := newS3HandlerForTest(newStubObjectsSource())
+
+	req := httptest.NewRequest(http.MethodGet, objectPath("ghost", "k1"), nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// ---------- put ----------
+
+func TestS3Objects_Put_RoundTripsBytes(t *testing.T) {
+	t.Parallel()
+	src := newStubObjectsSource()
+	h := newS3HandlerForTest(src)
+
+	payload := []byte("payload-bytes-here")
+	req := httptest.NewRequest(http.MethodPut, objectPath("photos", "new.png"),
+		bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "image/png")
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Equal(t, "AKIA_FULL", src.lastPutPrincipal.AccessKey)
+	require.Equal(t, "photos", src.lastPutBucket)
+	require.Equal(t, "new.png", src.lastPutKey)
+	require.Equal(t, "image/png", src.lastPutCT)
+	require.Equal(t, payload, src.lastPutBody)
+}
+
+func TestS3Objects_Put_Rejects413OnOversizedBody(t *testing.T) {
+	t.Parallel()
+	src := newStubObjectsSource()
+	h := newS3HandlerForTest(src)
+
+	// http.MaxBytesReader's *limit* is exclusive — a body of cap+1
+	// bytes overflows on the first read past the cap.
+	oversize := bytes.Repeat([]byte("x"), adminObjectUploadCap+1)
+	req := httptest.NewRequest(http.MethodPut, objectPath("photos", "huge.bin"),
+		bytes.NewReader(oversize))
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+}
+
+func TestS3Objects_Put_TranslatesUploadTooLargeSentinel(t *testing.T) {
+	t.Parallel()
+	// Adapter-side ErrObjectsUploadTooLarge surfaces from the bridge
+	// regardless of the http.MaxBytesReader check (e.g. a manifest-
+	// rejection at commit time). The handler must surface 413 either
+	// way so the SPA's retry contract stays uniform.
+	src := newStubObjectsSource()
+	src.nextErr = ErrObjectsUploadTooLarge
+	h := newS3HandlerForTest(src)
+
+	req := httptest.NewRequest(http.MethodPut, objectPath("photos", "k1"),
+		bytes.NewReader([]byte("small")))
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+}
+
+// ---------- delete ----------
+
+func TestS3Objects_Delete_HappyPath(t *testing.T) {
+	t.Parallel()
+	src := newStubObjectsSource()
+	src.seedObject("photos", "k1", []byte("x"))
+	h := newS3HandlerForTest(src)
+
+	req := httptest.NewRequest(http.MethodDelete, objectPath("photos", "k1"), nil)
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Equal(t, "AKIA_FULL", src.lastDeletePrincipal.AccessKey)
+	require.Equal(t, "photos", src.lastDeleteBucket)
+	require.Equal(t, "k1", src.lastDeleteKey)
+}
+
+func TestS3Objects_Delete_IsIdempotent(t *testing.T) {
+	t.Parallel()
+	// A missing object surfaces as success (mirrors S3 SigV4
+	// DeleteObject contract). The stub's AdminDeleteObject just
+	// no-ops on a missing key.
+	src := newStubObjectsSource()
+	src.seedObject("photos", "k1", []byte("x")) // ensure bucket exists
+	h := newS3HandlerForTest(src)
+
+	req := httptest.NewRequest(http.MethodDelete, objectPath("photos", "ghost"), nil)
+	req = withWritePrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+// ---------- authorisation ----------
+
+func TestS3Objects_Put_RejectsReadOnly(t *testing.T) {
+	t.Parallel()
+	h := newS3HandlerForTest(newStubObjectsSource())
+
+	req := httptest.NewRequest(http.MethodPut, objectPath("photos", "k1"),
+		bytes.NewReader([]byte("body")))
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestS3Objects_Delete_RejectsReadOnly(t *testing.T) {
+	t.Parallel()
+	h := newS3HandlerForTest(newStubObjectsSource())
+
+	req := httptest.NewRequest(http.MethodDelete, objectPath("photos", "k1"), nil)
+	req = withReadOnlyPrincipal(req)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestS3Objects_List_RejectsAnonymous(t *testing.T) {
+	t.Parallel()
+	h := newS3HandlerForTest(newStubObjectsSource())
+
+	// No principal injected — should fail with 401 unauthenticated.
+	req := httptest.NewRequest(http.MethodGet, objectsCollectionPath("photos"), nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// ---------- error translation ----------
+
+func TestS3Objects_TranslatesSentinelsToStatus(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		injected error
+		wantCode int
+	}{
+		"forbidden":        {ErrObjectsForbidden, http.StatusForbidden},
+		"not-leader":       {ErrObjectsNotLeader, http.StatusServiceUnavailable},
+		"bucket-not-found": {ErrObjectsBucketNotFound, http.StatusNotFound},
+		"object-not-found": {ErrObjectsNotFound, http.StatusNotFound},
+		"validation":       {ErrObjectsValidation, http.StatusBadRequest},
+		"upload-too-large": {ErrObjectsUploadTooLarge, http.StatusRequestEntityTooLarge},
+		"internal": {errors.New("storage backing failure"),
+			http.StatusInternalServerError},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			src := newStubObjectsSource()
+			src.nextErr = tc.injected
+			h := newS3HandlerForTest(src)
+
+			req := httptest.NewRequest(http.MethodGet,
+				objectsCollectionPath("photos"), nil)
+			req = withReadOnlyPrincipal(req)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			require.Equal(t, tc.wantCode, rec.Code)
+		})
+	}
+}
+
+// ---------- objectKeyBasename ----------
+
+func TestObjectKeyBasename(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"":             "object",
+		"plain":        "plain",
+		"a/b/c.png":    "c.png",
+		"trailing/":    "object",
+		"//":           "object",
+		"deep/nested/": "object",
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			require.Equal(t, want, objectKeyBasename(in))
+		})
+	}
+}

--- a/main_admin.go
+++ b/main_admin.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -507,6 +508,105 @@ func (b *bucketsBridge) AdminDeleteBucket(ctx context.Context, principal admin.A
 		return translateAdminBucketsError(err)
 	}
 	return nil
+}
+
+// ---------- Phase 3b object-level bridge ----------
+
+func (b *bucketsBridge) AdminListObjects(ctx context.Context, principal admin.AuthPrincipal, bucket string, opts admin.AdminListObjectsOptions) (admin.AdminObjectListing, error) {
+	out, err := b.server.AdminListObjects(ctx, convertAdminPrincipal(principal), bucket, adapter.AdminListObjectsOptions{
+		Prefix:            opts.Prefix,
+		Delimiter:         opts.Delimiter,
+		ContinuationToken: opts.ContinuationToken,
+		MaxKeys:           opts.MaxKeys,
+	})
+	if err != nil {
+		return admin.AdminObjectListing{}, translateAdminObjectsError(err)
+	}
+	return adminObjectListingFromAdapter(out), nil
+}
+
+func (b *bucketsBridge) AdminGetObject(ctx context.Context, principal admin.AuthPrincipal, bucket, key string) (io.ReadCloser, admin.AdminObject, error) {
+	body, meta, err := b.server.AdminGetObject(ctx, convertAdminPrincipal(principal), bucket, key)
+	if err != nil {
+		return nil, admin.AdminObject{}, translateAdminObjectsError(err)
+	}
+	return body, adminObjectFromAdapter(meta), nil
+}
+
+func (b *bucketsBridge) AdminPutObject(ctx context.Context, principal admin.AuthPrincipal, bucket, key string, body io.Reader, contentType string) error {
+	if err := b.server.AdminPutObject(ctx, convertAdminPrincipal(principal), bucket, key, body, contentType); err != nil {
+		return translateAdminObjectsError(err)
+	}
+	return nil
+}
+
+func (b *bucketsBridge) AdminDeleteObject(ctx context.Context, principal admin.AuthPrincipal, bucket, key string) error {
+	if err := b.server.AdminDeleteObject(ctx, convertAdminPrincipal(principal), bucket, key); err != nil {
+		return translateAdminObjectsError(err)
+	}
+	return nil
+}
+
+// adminObjectFromAdapter / adminObjectListingFromAdapter translate
+// the adapter's wire shape into the admin package's. The two are
+// field-for-field isomorphic so the build breaks here on drift.
+func adminObjectFromAdapter(in adapter.AdminObject) admin.AdminObject {
+	return admin.AdminObject{
+		Key:          in.Key,
+		Size:         in.Size,
+		ContentType:  in.ContentType,
+		ETag:         in.ETag,
+		LastModified: in.LastModified,
+		StorageClass: in.StorageClass,
+	}
+}
+
+func adminObjectListingFromAdapter(in adapter.AdminObjectListing) admin.AdminObjectListing {
+	out := admin.AdminObjectListing{
+		CommonPrefixes:        in.CommonPrefixes,
+		NextContinuationToken: in.NextContinuationToken,
+	}
+	if in.Objects != nil {
+		out.Objects = make([]admin.AdminObject, len(in.Objects))
+		for i, o := range in.Objects {
+			out.Objects[i] = adminObjectFromAdapter(o)
+		}
+	}
+	return out
+}
+
+// translateAdminObjectsError maps the adapter's object-tier admin
+// error vocabulary onto the admin-package sentinels the handler
+// matches against. Mirrors translateAdminBucketsError but covers the
+// object-only sentinels (UploadTooLarge, InvalidObjectKey,
+// ObjectNotFound) that the bucket-tier path never sees.
+func translateAdminObjectsError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, adapter.ErrAdminForbidden):
+		return admin.ErrObjectsForbidden
+	case errors.Is(err, adapter.ErrAdminNotLeader):
+		return admin.ErrObjectsNotLeader
+	case errors.Is(err, adapter.ErrAdminBucketNotFound):
+		return admin.ErrObjectsBucketNotFound
+	case errors.Is(err, adapter.ErrAdminObjectNotFound):
+		return admin.ErrObjectsNotFound
+	case errors.Is(err, adapter.ErrAdminUploadTooLarge):
+		return admin.ErrObjectsUploadTooLarge
+	case errors.Is(err, adapter.ErrAdminInvalidBucketName),
+		errors.Is(err, adapter.ErrAdminInvalidObjectKey),
+		errors.Is(err, adapter.ErrAdminInvalidContinuationToken):
+		// Wrap the adapter's text so the handler's ErrObjectsValidation
+		// branch surfaces a useful message rather than the bare
+		// sentinel string. Same pattern translateAdminBucketsError
+		// uses for ErrAdminInvalidBucketName via *ValidationError.
+		return errors.Wrap(admin.ErrObjectsValidation, err.Error())
+	case isLeaderChurnError(err):
+		return admin.ErrObjectsNotLeader
+	default:
+		return err //nolint:wrapcheck // forwarded so the handler logs but does not surface it.
+	}
 }
 
 func bucketSummaryFromAdapter(in adapter.AdminBucketSummary) admin.BucketSummary {

--- a/main_admin_forward_test.go
+++ b/main_admin_forward_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"testing"
 
 	"github.com/bootjp/elastickv/internal/admin"
@@ -272,4 +273,20 @@ func (dummyBucketsSource) AdminPutBucketAcl(_ context.Context, _ admin.AuthPrinc
 
 func (dummyBucketsSource) AdminDeleteBucket(_ context.Context, _ admin.AuthPrincipal, _ string) error {
 	panic("dummyBucketsSource.AdminDeleteBucket should not be invoked")
+}
+
+func (dummyBucketsSource) AdminListObjects(_ context.Context, _ admin.AuthPrincipal, _ string, _ admin.AdminListObjectsOptions) (admin.AdminObjectListing, error) {
+	panic("dummyBucketsSource.AdminListObjects should not be invoked")
+}
+
+func (dummyBucketsSource) AdminGetObject(_ context.Context, _ admin.AuthPrincipal, _, _ string) (io.ReadCloser, admin.AdminObject, error) {
+	panic("dummyBucketsSource.AdminGetObject should not be invoked")
+}
+
+func (dummyBucketsSource) AdminPutObject(_ context.Context, _ admin.AuthPrincipal, _, _ string, _ io.Reader, _ string) error {
+	panic("dummyBucketsSource.AdminPutObject should not be invoked")
+}
+
+func (dummyBucketsSource) AdminDeleteObject(_ context.Context, _ admin.AuthPrincipal, _, _ string) error {
+	panic("dummyBucketsSource.AdminDeleteObject should not be invoked")
 }


### PR DESCRIPTION
## Summary

**Phase 3b** of `docs/design/2026_05_22_proposed_admin_data_browser.md` §3.3 — exposes the Phase 2b (PR #811) `*adapter.S3Server` object-level admin RPCs through the admin HTTP API.

## Surface

```
GET    /admin/api/v1/s3/buckets/{name}/objects                  — list
GET    /admin/api/v1/s3/buckets/{name}/objects/{key-b64url}     — download
PUT    /admin/api/v1/s3/buckets/{name}/objects/{key-b64url}     — upload
DELETE /admin/api/v1/s3/buckets/{name}/objects/{key-b64url}     — delete
```

`{key}` is the base64-url-encoded raw object key.

## Body wire shapes

| Op | Request | Response |
|---|---|---|
| LIST | — | JSON `AdminObjectListing` |
| GET | — | `application/octet-stream` (raw bytes) + security headers |
| PUT | `application/octet-stream` (raw bytes) | — |
| DELETE | — | — |

## Security headers on GET

Defence-in-depth against a hostile upload rendering in the admin origin:

| Header | Value | Why |
|---|---|---|
| `X-Content-Type-Options` | `nosniff` | Block MIME sniffing |
| `Content-Security-Policy` | `sandbox; default-src 'none'` | Strip script execution |
| `Content-Disposition` | `attachment; filename="..."` | Force download dialog |
| `Cache-Control` | `no-store` | No intermediary caching |

Filename is sanitised — control chars / quote / backslash → `_` so the quoted-string form is never broken by an attacker-controlled key.

## Upload limits

| Limit | Where | Outcome |
|---|---|---|
| 100 MiB | `http.MaxBytesReader` in `handleObjectPut` | 413 payload_too_large |
| Adapter cap | `ErrAdminUploadTooLarge` via bridge | 413 payload_too_large |

Both paths produce the same 413 response shape so the SPA retry contract is uniform.

## Authorization

| Operation | Gate |
|---|---|
| List / Get | `principal.Role.AllowsRead()` (RoleReadOnly or RoleFull) |
| Put / Delete | `principal.Role.AllowsWrite()` (RoleFull only) |

Read gate matches the existing SPA-facing precedent (`principalForItemRead` on Dynamo). Write gate reuses `S3Handler.principalForWrite` (live-role re-check + RoleFull).

## Sentinels

| Sentinel | Maps to |
|---|---|
| `ErrObjectsForbidden` | 403 |
| `ErrObjectsNotLeader` | 503 + Retry-After: 1 |
| `ErrObjectsBucketNotFound` | 404 |
| `ErrObjectsNotFound` | 404 |
| `ErrObjectsValidation` | 400 |
| `ErrObjectsUploadTooLarge` | 413 |

`bucketsBridge.translateAdminObjectsError` translates the adapter sentinels (`ErrAdminForbidden` / `ErrAdminNotLeader` / `ErrAdminBucketNotFound` / `ErrAdminObjectNotFound` / `ErrAdminUploadTooLarge` / `ErrAdminInvalidBucketName` / `ErrAdminInvalidObjectKey` / `ErrAdminInvalidContinuationToken`) onto these.

## Routing

`servePerBucket` now recognises three sub-tree shapes under `/buckets/{name}/`:

1. `/acl` PUT (existing)
2. `/objects` GET — list (new)
3. `/objects/{key}` GET/PUT/DELETE — resource (new)

The objects branch is matched first via `splitBucketObjectsRoute`. Since `validateS3BucketName` already forbids `/` in bucket names, a bucket literally named `objects` cannot collide with the describe-by-name path.

Existing `/buckets/{name}` describe/delete and `/buckets/{name}/acl` PUT behaviour are unchanged.

## Caller audit (semantic-change rule)

- `BucketsSource` interface grew 4 methods (`AdminListObjects` / `AdminGetObject` / `AdminPutObject` / `AdminDeleteObject`). All implementations updated in lockstep:
  - `bucketsBridge` (production, `main_admin.go`)
  - `stubBucketsSource` (tests, `internal/admin/s3_handler_test.go`) — stubs return "not implemented" so existing bucket-tier tests fail loudly if they accidentally exercise the object methods
  - `dummyBucketsSource` (tests, `main_admin_forward_test.go`) — panicking stubs
- The Go compiler enforces this.

## Risk

Low. The handler is a pure wrapper over the existing Phase 2b admin RPCs. No new write codepath. The bridge in `main_admin.go` translates wire types and sentinels — both sides are isomorphic structs.

## Self-review (5 passes)

1. **Data loss** — Pure dispatch + bridge layer; no new write path on the storage side. The adapter's existing chunked-write / Raft path is unchanged.
2. **Concurrency** — Read body Close is in a defer; client cancellation mid-stream logs at warn and is not treated as error.
3. **Performance** — List paginates at default 100 (cap 1000). PUT streams to the adapter via `http.MaxBytesReader` without buffering the full body in the admin layer. GET streams from the adapter via `io.Copy`.
4. **Consistency** — Empty lists serialize as `"objects":[]` (not null) so the SPA distinguishes empty bucket from missing bucket. Security headers are unconditional on GET.
5. **Test coverage** — 18 new tests covering routing / key decoding / list / get with headers / get 404 / put round-trip / put 413 (both `http.MaxBytesReader` and adapter-sentinel paths) / delete idempotence / RBAC / sentinel translation / `objectKeyBasename`.

## Test plan

- [x] `go test -race -count=1 -timeout=120s ./internal/admin/...` — passes
- [x] `golangci-lint --config=.golangci.yaml run` — clean
- [ ] CI

## Phase plan

- Phase 2a: DynamoDB item RPCs — merged (#805)
- Phase 2b: S3 object RPCs — merged (#811)
- Phase 3a: DynamoDB item HTTP — open (#813)
- **Phase 3b: this PR (S3 object HTTP)**
- Phase 4: SPA DynamoDetail Items tab
- Phase 5: SPA S3Detail Objects tab + Upload
- Phase 6: Doc rename `_proposed_` → `_implemented_`
