### PR TITLE
web/admin: Items tab on DynamoDetail (Phase 4)

### DIFF
--- a/web/admin/src/api/client.ts
+++ b/web/admin/src/api/client.ts
@@ -49,6 +49,29 @@ function readCsrfCookie(): string | undefined {
   return undefined;
 }
 
+// encodeAdminItemKey turns a primary-key attribute map into the
+// base64-url segment the admin Dynamo items routes expect. The
+// server's decodeAdminItemKeySegment accepts both padded and raw
+// base64-url; we emit raw because it is shorter (no `=` padding
+// to URL-encode) and the server's path validator forbids `%` in
+// segments anyway.
+function encodeAdminItemKey(key: Record<string, AdminAttributeValue>): string {
+  const json = JSON.stringify(key);
+  // btoa requires Latin-1 input; encode the JSON as UTF-8 bytes
+  // first so any non-ASCII attribute value (e.g. a key containing
+  // a JIS character) round-trips cleanly. TextEncoder is the
+  // standard UTF-8 path; the resulting Uint8Array maps directly
+  // into the Latin-1 char domain btoa accepts.
+  const bytes = new TextEncoder().encode(json);
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  const padded = btoa(binary);
+  // Standard base64 → base64-url: `+` → `-`, `/` → `_`, strip
+  // trailing `=` padding so the URL segment carries no characters
+  // the server-side path validator forbids.
+  return padded.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/u, "");
+}
+
 function buildURL(path: string, query?: ApiOptions["query"]): string {
   const url = new URL(apiBase + path, window.location.origin);
   if (query) {
@@ -175,6 +198,39 @@ export interface CreateTableRequest {
   partition_key: CreateTableAttribute;
   sort_key?: CreateTableAttribute;
   gsi?: CreateTableGSI[];
+}
+
+// AdminAttributeValue mirrors internal/admin/dynamo_items_handler.go.
+// One field set per value per the DynamoDB AttributeValue contract.
+// B / BS arrive as base64-encoded strings (encoding/json convention).
+// L and M serialize with the type tag present even when empty
+// (Gemini medium on PR #813) so the SPA can distinguish "no L field"
+// from "empty list".
+export interface AdminAttributeValue {
+  S?: string;
+  N?: string;
+  B?: string;
+  BOOL?: boolean;
+  NULL?: boolean;
+  SS?: string[];
+  NS?: string[];
+  BS?: string[];
+  L?: AdminAttributeValue[];
+  M?: Record<string, AdminAttributeValue>;
+}
+
+export interface AdminItem {
+  attributes: Record<string, AdminAttributeValue>;
+}
+
+export interface AdminScanItemsResult {
+  items: AdminItem[];
+  last_evaluated_key?: Record<string, AdminAttributeValue>;
+}
+
+export interface AdminScanItemsOptions {
+  limit?: number;
+  next_cursor?: string;
 }
 
 export interface S3Bucket {
@@ -328,6 +384,30 @@ export const api = {
     apiFetch<DynamoTable>("/dynamo/tables", { method: "POST", body: req as unknown as Json }),
   deleteTable: (name: string) =>
     apiFetch<void>(`/dynamo/tables/${encodeURIComponent(name)}`, { method: "DELETE" }),
+  scanItems: (table: string, opts?: AdminScanItemsOptions, signal?: AbortSignal) =>
+    apiFetch<AdminScanItemsResult>(
+      `/dynamo/tables/${encodeURIComponent(table)}/items`,
+      { query: { limit: opts?.limit, next_cursor: opts?.next_cursor }, signal },
+    ),
+  // Items use base64-url-encoded JSON of the primary-key attribute
+  // map as the URL segment. Base64-url is the same encoding the rest
+  // of the admin API uses for arbitrary-bytes path segments, so
+  // PathEscape on the segment is a no-op.
+  getItem: (table: string, key: Record<string, AdminAttributeValue>, signal?: AbortSignal) =>
+    apiFetch<AdminItem>(
+      `/dynamo/tables/${encodeURIComponent(table)}/items/${encodeAdminItemKey(key)}`,
+      { signal },
+    ),
+  putItem: (table: string, key: Record<string, AdminAttributeValue>, item: AdminItem) =>
+    apiFetch<void>(
+      `/dynamo/tables/${encodeURIComponent(table)}/items/${encodeAdminItemKey(key)}`,
+      { method: "PUT", body: item as unknown as Json },
+    ),
+  deleteItem: (table: string, key: Record<string, AdminAttributeValue>) =>
+    apiFetch<void>(
+      `/dynamo/tables/${encodeURIComponent(table)}/items/${encodeAdminItemKey(key)}`,
+      { method: "DELETE" },
+    ),
   listBuckets: (next_token?: string, signal?: AbortSignal) =>
     apiFetch<S3BucketList>("/s3/buckets", { query: { next_token }, signal }),
   describeBucket: (name: string, signal?: AbortSignal) =>

--- a/web/admin/src/api/client.ts
+++ b/web/admin/src/api/client.ts
@@ -55,7 +55,13 @@ function readCsrfCookie(): string | undefined {
 // base64-url; we emit raw because it is shorter (no `=` padding
 // to URL-encode) and the server's path validator forbids `%` in
 // segments anyway.
-function encodeAdminItemKey(key: Record<string, AdminAttributeValue>): string {
+//
+// Exported so DynamoItemsTab's scan-cursor encoder reuses this
+// single implementation rather than maintaining a parallel
+// (Gemini medium on PR #815). LastEvaluatedKey and the URL key
+// segment share the same wire shape — both are base64-url-encoded
+// JSON of an AdminAttributeValue map — so one helper covers both.
+export function encodeAdminItemKey(key: Record<string, AdminAttributeValue>): string {
   const json = JSON.stringify(key);
   // btoa requires Latin-1 input; encode the JSON as UTF-8 bytes
   // first so any non-ASCII attribute value (e.g. a key containing

--- a/web/admin/src/components/DynamoItemsTab.tsx
+++ b/web/admin/src/components/DynamoItemsTab.tsx
@@ -119,6 +119,17 @@ export function DynamoItemsTab({ table, partitionKey, sortKey }: DynamoItemsTabP
   // (PR #816 r4). Inlined rather than calling closeModalForce
   // (declared later) to keep the effect self-contained.
   useEffect(() => {
+    // setPage(null) hides stale rows during the loading window so
+    // the operator cannot click on the previous context's items
+    // while the new scan is in flight. The parent (DynamoDetail)
+    // already remounts this component on table change via
+    // key={name}, so the table-switch case is covered by the
+    // unmount — but a pageSize change keeps the component mounted
+    // and would otherwise leave the previous page-size's rows
+    // visible until the new scan resolves. Codex P1 on PR #815
+    // r4 caught this; mirrors the S3 ObjectsTab [bucket, prefix]
+    // effect (PR #816 r6).
+    setPage(null);
     setCurrentCursor(undefined);
     setModalMode(null);
     setModalItem(null);

--- a/web/admin/src/components/DynamoItemsTab.tsx
+++ b/web/admin/src/components/DynamoItemsTab.tsx
@@ -46,12 +46,14 @@ export function DynamoItemsTab({ table, partitionKey, sortKey }: DynamoItemsTabP
   const [page, setPage] = useState<AdminScanItemsResult | null>(null);
   const [loading, setLoading] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
-  // cursorStack tracks the previously-visited continuation tokens so
-  // a Back button can return to earlier pages without re-scanning
-  // from the start. Top-of-stack is the cursor that loaded the
-  // *current* page; popping it loads the page before. An empty
-  // stack means we are on page 0 (no cursor sent).
-  const [cursorStack, setCursorStack] = useState<string[]>([]);
+  // currentCursor is the continuation token that loaded the
+  // currently-rendered page (undefined = page 0, no cursor sent).
+  // Refresh and post-write reloads re-issue the scan against this
+  // value; Next advances it to the page's last_evaluated_key after
+  // the fetch succeeds. There is no Back button today — once Next
+  // overwrites the cursor the prior cursor is gone — so a simple
+  // single-value state is enough.
+  const [currentCursor, setCurrentCursor] = useState<string | undefined>(undefined);
 
   // scanAbortRef aborts the in-flight scan when a new one starts
   // (table change, page-size change, Next / Refresh, post-write
@@ -103,7 +105,7 @@ export function DynamoItemsTab({ table, partitionKey, sortKey }: DynamoItemsTabP
 
   // Initial load + page-size change refetches from the start.
   useEffect(() => {
-    setCursorStack([]);
+    setCurrentCursor(undefined);
     void loadPage(undefined);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [table, pageSize]);
@@ -112,13 +114,12 @@ export function DynamoItemsTab({ table, partitionKey, sortKey }: DynamoItemsTabP
     const next = page?.last_evaluated_key;
     if (!next) return;
     const cursor = encodeAdminItemKey(next);
-    setCursorStack((s) => [...s, cursor]);
+    setCurrentCursor(cursor);
     void loadPage(cursor);
   };
 
   const onRefresh = () => {
-    const top = cursorStack[cursorStack.length - 1];
-    void loadPage(top);
+    void loadPage(currentCursor);
   };
 
   // Modal state.
@@ -181,7 +182,7 @@ export function DynamoItemsTab({ table, partitionKey, sortKey }: DynamoItemsTabP
       }
       await api.putItem(table, key, next);
       closeModalForce();
-      void loadPage(cursorStack[cursorStack.length - 1]);
+      void loadPage(currentCursor);
     } catch (err) {
       setModalError(err instanceof ApiError ? `${err.code}: ${err.message || err.code}` : String(err));
     } finally {
@@ -196,7 +197,7 @@ export function DynamoItemsTab({ table, partitionKey, sortKey }: DynamoItemsTabP
     try {
       await api.deleteItem(table, modalKey);
       closeModalForce();
-      void loadPage(cursorStack[cursorStack.length - 1]);
+      void loadPage(currentCursor);
     } catch (err) {
       setModalError(err instanceof ApiError ? `${err.code}: ${err.message || err.code}` : String(err));
     } finally {
@@ -543,11 +544,20 @@ function formatAttributeShort(v: AdminAttributeValue | undefined): string {
   if (v.N !== undefined) return v.N;
   if (v.BOOL !== undefined) return String(v.BOOL);
   if (v.NULL !== undefined) return "null";
-  if (v.B !== undefined) return `<binary ${v.B.length}b64>`;
+  // v.B is the base64 string, not the raw bytes. Operators read
+  // the size as bytes, so approximate it: every 4 base64 chars
+  // encode 3 bytes; padding-aware floor is close enough for a
+  // teaser preview (off by at most 2 from the true byte count).
+  if (v.B !== undefined) return `<binary ~${approxB64Bytes(v.B)}B>`;
   if (v.SS) return `[${v.SS.join(",")}]`;
   if (v.NS) return `[${v.NS.join(",")}]`;
   if (v.BS) return `<${v.BS.length} bin>`;
   if (v.L) return `[${v.L.length} list]`;
   if (v.M) return `{${Object.keys(v.M).length} map}`;
   return "?";
+}
+
+function approxB64Bytes(b64: string): number {
+  const trimmed = b64.replace(/=+$/u, "");
+  return Math.floor((trimmed.length * 3) / 4);
 }

--- a/web/admin/src/components/DynamoItemsTab.tsx
+++ b/web/admin/src/components/DynamoItemsTab.tsx
@@ -74,7 +74,11 @@ export function DynamoItemsTab({ table, partitionKey, sortKey }: DynamoItemsTabP
     };
   }, []);
 
-  const loadPage = async (cursor: string | undefined) => {
+  // loadPage returns true on success, false on error / cancellation.
+  // Callers (onNextPage) inspect the boolean to decide whether to
+  // advance the cursor — matches the S3 ObjectsTab pattern from
+  // PR #816 r1 so the two tabs share one cursor-advance contract.
+  const loadPage = async (cursor: string | undefined): Promise<boolean> => {
     scanAbortRef.current?.abort();
     const ctrl = new AbortController();
     scanAbortRef.current = ctrl;
@@ -84,18 +88,18 @@ export function DynamoItemsTab({ table, partitionKey, sortKey }: DynamoItemsTabP
       const result = await api.scanItems(table, { limit: pageSize, next_cursor: cursor }, ctrl.signal);
       // A second loadPage() may have replaced scanAbortRef before
       // we get here; ignore the resolved value of the obsolete
-      // request to keep `page` aligned with the latest call. The
-      // AbortError path below covers the symmetric case where the
-      // fetch itself errored out from the abort.
-      if (scanAbortRef.current !== ctrl) return;
+      // request to keep `page` aligned with the latest call.
+      if (scanAbortRef.current !== ctrl) return false;
       setPage(result);
+      return true;
     } catch (err) {
-      if (scanAbortRef.current !== ctrl) return;
+      if (scanAbortRef.current !== ctrl) return false;
       // AbortError is the cancellation signal — not a user-visible
       // failure; suppress it so the operator's manual Refresh
       // immediately after a Next page click doesn't show "aborted".
-      if (err instanceof DOMException && err.name === "AbortError") return;
+      if (err instanceof DOMException && err.name === "AbortError") return false;
       setLoadError(err instanceof ApiError ? `${err.code}: ${err.message || err.code}` : String(err));
+      return false;
     } finally {
       if (scanAbortRef.current === ctrl) {
         setLoading(false);
@@ -103,19 +107,41 @@ export function DynamoItemsTab({ table, partitionKey, sortKey }: DynamoItemsTabP
     }
   };
 
-  // Initial load + page-size change refetches from the start.
+  // Initial load + page-size change refetches from the start AND
+  // resets the modal. useApiQuery in the parent DynamoDetail page
+  // does NOT clear data on dep change, so this component stays
+  // mounted across /dynamo/tables/A → /dynamo/tables/B navigation.
+  // Without the explicit modal reset, an open detail modal would
+  // retain modalKey from table A while the table prop is now B —
+  // onSave would then call api.putItem(B, keyFromA, body), silently
+  // overwriting a colliding key in table B. Same cross-context
+  // class as the S3 ObjectsTab detail-modal-on-bucket-change fix
+  // (PR #816 r4). Inlined rather than calling closeModalForce
+  // (declared later) to keep the effect self-contained.
   useEffect(() => {
     setCurrentCursor(undefined);
+    setModalMode(null);
+    setModalItem(null);
+    setModalKey(null);
+    setModalError(null);
     void loadPage(undefined);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [table, pageSize]);
 
-  const onNextPage = () => {
+  const onNextPage = async () => {
     const next = page?.last_evaluated_key;
     if (!next) return;
+    // Advance currentCursor only after the fetch succeeds.
+    // Matches the S3 ObjectsTab pattern: a transient failure must
+    // not leave the UI on a cursor that no longer corresponds to
+    // the rendered page (Refresh would then re-fetch the failed
+    // page rather than the still-shown one). The comment on
+    // currentCursor's useState above promises this contract.
     const cursor = encodeAdminItemKey(next);
-    setCurrentCursor(cursor);
-    void loadPage(cursor);
+    const ok = await loadPage(cursor);
+    if (ok) {
+      setCurrentCursor(cursor);
+    }
   };
 
   const onRefresh = () => {
@@ -266,13 +292,19 @@ export function DynamoItemsTab({ table, partitionKey, sortKey }: DynamoItemsTabP
           </thead>
           <tbody>
             {page!.items.map((item) => (
-              // Primary key uniqueness is guaranteed by DynamoDB's
-              // table semantics, so it's a more stable React key
-              // than the array index — re-ordering a page (server
-              // changed scan iteration order) doesn't churn rows
-              // (Gemini medium on PR #815).
+              // React key is the encoded primary key — guaranteed
+              // unique within a DynamoDB scan page. describePrimaryKey
+              // (which we used before) renders binary values as
+              // "<binary ~NB>" and collides when two distinct binary
+              // keys share the same byte length, so two different
+              // rows would render with the same React key and
+              // reconciliation could bind onOpen to the wrong item
+              // (Claude review on PR #815 r2). encodeAdminItemKey
+              // returns the full base64url-encoded JSON of the key
+              // map, which encodes binary bytes verbatim and is
+              // collision-free.
               <ItemRow
-                key={describePrimaryKey(item, partitionKey, sortKey)}
+                key={encodeAdminItemKey(extractPrimaryKey(item, partitionKey, sortKey) ?? {})}
                 item={item}
                 partitionKey={partitionKey}
                 sortKey={sortKey}

--- a/web/admin/src/components/DynamoItemsTab.tsx
+++ b/web/admin/src/components/DynamoItemsTab.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type {
   AdminAttributeValue,
   AdminItem,
   AdminScanItemsResult,
 } from "../api/client";
-import { ApiError, api } from "../api/client";
+import { ApiError, api, encodeAdminItemKey } from "../api/client";
 import { useAuth } from "../auth";
 import { Modal } from "./Modal";
 
@@ -53,16 +53,51 @@ export function DynamoItemsTab({ table, partitionKey, sortKey }: DynamoItemsTabP
   // stack means we are on page 0 (no cursor sent).
   const [cursorStack, setCursorStack] = useState<string[]>([]);
 
+  // scanAbortRef aborts the in-flight scan when a new one starts
+  // (table change, page-size change, Next / Refresh, post-write
+  // reload). Without this, an older slower request can overwrite
+  // the current view with stale items after the user has already
+  // moved on — which is a confused-deputy class for the
+  // follow-up edit / delete actions that key off the rendered
+  // rows (Codex P1, Gemini high on PR #815).
+  const scanAbortRef = useRef<AbortController | null>(null);
+  // Ensure the in-flight controller is aborted on unmount. The
+  // effect's cleanup function fires on every dep change AND on
+  // unmount, so the unmount path is covered by the inline
+  // controller it owns; the ref-based aborts cover the
+  // user-driven reload cases.
+  useEffect(() => {
+    return () => {
+      scanAbortRef.current?.abort();
+    };
+  }, []);
+
   const loadPage = async (cursor: string | undefined) => {
+    scanAbortRef.current?.abort();
+    const ctrl = new AbortController();
+    scanAbortRef.current = ctrl;
     setLoading(true);
     setLoadError(null);
     try {
-      const result = await api.scanItems(table, { limit: pageSize, next_cursor: cursor });
+      const result = await api.scanItems(table, { limit: pageSize, next_cursor: cursor }, ctrl.signal);
+      // A second loadPage() may have replaced scanAbortRef before
+      // we get here; ignore the resolved value of the obsolete
+      // request to keep `page` aligned with the latest call. The
+      // AbortError path below covers the symmetric case where the
+      // fetch itself errored out from the abort.
+      if (scanAbortRef.current !== ctrl) return;
       setPage(result);
     } catch (err) {
+      if (scanAbortRef.current !== ctrl) return;
+      // AbortError is the cancellation signal — not a user-visible
+      // failure; suppress it so the operator's manual Refresh
+      // immediately after a Next page click doesn't show "aborted".
+      if (err instanceof DOMException && err.name === "AbortError") return;
       setLoadError(err instanceof ApiError ? `${err.code}: ${err.message || err.code}` : String(err));
     } finally {
-      setLoading(false);
+      if (scanAbortRef.current === ctrl) {
+        setLoading(false);
+      }
     }
   };
 
@@ -76,7 +111,7 @@ export function DynamoItemsTab({ table, partitionKey, sortKey }: DynamoItemsTabP
   const onNextPage = () => {
     const next = page?.last_evaluated_key;
     if (!next) return;
-    const cursor = encodeContinuation(next);
+    const cursor = encodeAdminItemKey(next);
     setCursorStack((s) => [...s, cursor]);
     void loadPage(cursor);
   };
@@ -121,12 +156,28 @@ export function DynamoItemsTab({ table, partitionKey, sortKey }: DynamoItemsTabP
     setModalBusy(true);
     setModalError(null);
     try {
-      const key = extractPrimaryKey(next, partitionKey, sortKey);
-      if (!key) {
-        throw new Error(
-          `body must contain the partition key "${partitionKey}"` +
-            (sortKey ? ` and the sort key "${sortKey}"` : ""),
-        );
+      // Edit mode MUST use the originally-opened modalKey rather
+      // than re-deriving from the edited body — changing the
+      // primary key in the body otherwise turns an "edit" into a
+      // write to a different URL, leaving the original item
+      // untouched and silently creating / overwriting a sibling
+      // (Codex P1 on PR #815). Add mode does derive from body
+      // (no original key exists). The server's body / URL-key
+      // reconciliation enforces that the body's key attributes
+      // match the URL key, so a primary-key edit attempt on the
+      // edit path surfaces as 400 invalid_request — operators
+      // who actually want to rename an item must delete + add.
+      let key: Record<string, AdminAttributeValue> | null;
+      if (modalMode === "edit" && modalKey) {
+        key = modalKey;
+      } else {
+        key = extractPrimaryKey(next, partitionKey, sortKey);
+        if (!key) {
+          throw new Error(
+            `body must contain the partition key "${partitionKey}"` +
+              (sortKey ? ` and the sort key "${sortKey}"` : ""),
+          );
+        }
       }
       await api.putItem(table, key, next);
       closeModalForce();
@@ -213,9 +264,14 @@ export function DynamoItemsTab({ table, partitionKey, sortKey }: DynamoItemsTabP
             </tr>
           </thead>
           <tbody>
-            {page!.items.map((item, idx) => (
+            {page!.items.map((item) => (
+              // Primary key uniqueness is guaranteed by DynamoDB's
+              // table semantics, so it's a more stable React key
+              // than the array index — re-ordering a page (server
+              // changed scan iteration order) doesn't churn rows
+              // (Gemini medium on PR #815).
               <ItemRow
-                key={idx}
+                key={describePrimaryKey(item, partitionKey, sortKey)}
                 item={item}
                 partitionKey={partitionKey}
                 sortKey={sortKey}
@@ -417,16 +473,6 @@ function ItemEditorModal({
 }
 
 // ---------- helpers ----------
-
-// encodeContinuation turns a LastEvaluatedKey into the base64-url
-// blob the server's next_cursor query param expects.
-function encodeContinuation(key: Record<string, AdminAttributeValue>): string {
-  const json = JSON.stringify(key);
-  const bytes = new TextEncoder().encode(json);
-  let binary = "";
-  for (const b of bytes) binary += String.fromCharCode(b);
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/u, "");
-}
 
 // extractPrimaryKey pulls the table's primary-key attributes out of
 // an item body, returning null when any required attribute is

--- a/web/admin/src/components/DynamoItemsTab.tsx
+++ b/web/admin/src/components/DynamoItemsTab.tsx
@@ -1,0 +1,507 @@
+import { useEffect, useMemo, useState } from "react";
+import type {
+  AdminAttributeValue,
+  AdminItem,
+  AdminScanItemsResult,
+} from "../api/client";
+import { ApiError, api } from "../api/client";
+import { useAuth } from "../auth";
+import { Modal } from "./Modal";
+
+// Phase 4 — Items tab for /dynamo/tables/{name}. Driven by the
+// Phase-3a HTTP surface in internal/admin/dynamo_items_handler.go.
+//
+// Capabilities (gated on session role):
+//   read_only — scan + view item JSON
+//   full      — additionally add / edit / delete
+
+// Scan page-size knobs. The server clamps to [1, 100]; we let the
+// operator pick between the design default (25) and the server cap.
+const PAGE_SIZES = [25, 100] as const;
+type PageSize = (typeof PAGE_SIZES)[number];
+
+interface DynamoItemsTabProps {
+  table: string;
+  // partitionKey / sortKey describe the table's primary-key shape so
+  // the modal can pre-fill the URL-key form from the body or extract
+  // the right attributes when uploading. Empty sortKey indicates a
+  // hash-only table.
+  partitionKey: string;
+  sortKey?: string;
+}
+
+// EditorMode tracks the modal's intent: "view" is read-only, "edit"
+// is overwriting an existing item, "add" is creating a new one. The
+// distinction matters for two reasons: (1) the modal title and
+// button labels change, and (2) "edit" keeps the URL key derived
+// from the original load while "add" derives it fresh from the
+// (operator-typed) body before each save.
+type EditorMode = "view" | "edit" | "add";
+
+export function DynamoItemsTab({ table, partitionKey, sortKey }: DynamoItemsTabProps) {
+  const { session } = useAuth();
+  const writeAllowed = session?.role === "full";
+
+  const [pageSize, setPageSize] = useState<PageSize>(25);
+  const [page, setPage] = useState<AdminScanItemsResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  // cursorStack tracks the previously-visited continuation tokens so
+  // a Back button can return to earlier pages without re-scanning
+  // from the start. Top-of-stack is the cursor that loaded the
+  // *current* page; popping it loads the page before. An empty
+  // stack means we are on page 0 (no cursor sent).
+  const [cursorStack, setCursorStack] = useState<string[]>([]);
+
+  const loadPage = async (cursor: string | undefined) => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const result = await api.scanItems(table, { limit: pageSize, next_cursor: cursor });
+      setPage(result);
+    } catch (err) {
+      setLoadError(err instanceof ApiError ? `${err.code}: ${err.message || err.code}` : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Initial load + page-size change refetches from the start.
+  useEffect(() => {
+    setCursorStack([]);
+    void loadPage(undefined);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [table, pageSize]);
+
+  const onNextPage = () => {
+    const next = page?.last_evaluated_key;
+    if (!next) return;
+    const cursor = encodeContinuation(next);
+    setCursorStack((s) => [...s, cursor]);
+    void loadPage(cursor);
+  };
+
+  const onRefresh = () => {
+    const top = cursorStack[cursorStack.length - 1];
+    void loadPage(top);
+  };
+
+  // Modal state.
+  const [modalMode, setModalMode] = useState<EditorMode | null>(null);
+  const [modalItem, setModalItem] = useState<AdminItem | null>(null);
+  const [modalKey, setModalKey] = useState<Record<string, AdminAttributeValue> | null>(null);
+  const [modalBusy, setModalBusy] = useState(false);
+  const [modalError, setModalError] = useState<string | null>(null);
+
+  const closeModal = () => {
+    if (modalBusy) return;
+    setModalMode(null);
+    setModalItem(null);
+    setModalKey(null);
+    setModalError(null);
+  };
+
+  const openView = (item: AdminItem) => {
+    setModalItem(item);
+    setModalKey(extractPrimaryKey(item, partitionKey, sortKey));
+    setModalMode("view");
+    setModalError(null);
+  };
+
+  const openEdit = () => setModalMode("edit");
+
+  const openAdd = () => {
+    setModalItem({ attributes: {} });
+    setModalKey(null);
+    setModalMode("add");
+    setModalError(null);
+  };
+
+  const onSave = async (next: AdminItem) => {
+    setModalBusy(true);
+    setModalError(null);
+    try {
+      const key = extractPrimaryKey(next, partitionKey, sortKey);
+      if (!key) {
+        throw new Error(
+          `body must contain the partition key "${partitionKey}"` +
+            (sortKey ? ` and the sort key "${sortKey}"` : ""),
+        );
+      }
+      await api.putItem(table, key, next);
+      closeModalForce();
+      void loadPage(cursorStack[cursorStack.length - 1]);
+    } catch (err) {
+      setModalError(err instanceof ApiError ? `${err.code}: ${err.message || err.code}` : String(err));
+    } finally {
+      setModalBusy(false);
+    }
+  };
+
+  const onDelete = async () => {
+    if (!modalKey) return;
+    setModalBusy(true);
+    setModalError(null);
+    try {
+      await api.deleteItem(table, modalKey);
+      closeModalForce();
+      void loadPage(cursorStack[cursorStack.length - 1]);
+    } catch (err) {
+      setModalError(err instanceof ApiError ? `${err.code}: ${err.message || err.code}` : String(err));
+    } finally {
+      setModalBusy(false);
+    }
+  };
+
+  const closeModalForce = () => {
+    setModalMode(null);
+    setModalItem(null);
+    setModalKey(null);
+    setModalError(null);
+  };
+
+  const hasNext = !!page?.last_evaluated_key;
+  const itemCount = page?.items?.length ?? 0;
+
+  return (
+    <section className="card">
+      <header className="flex items-center gap-3 mb-3">
+        <h2 className="text-sm font-semibold">Items</h2>
+        <div className="ml-auto flex items-center gap-2">
+          <label className="text-xs text-muted">
+            Page size
+            <select
+              className="ml-1 border border-border rounded px-1 py-0.5"
+              value={pageSize}
+              onChange={(e) => setPageSize(Number(e.target.value) as PageSize)}
+              disabled={loading}
+            >
+              {PAGE_SIZES.map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button type="button" className="btn-secondary" onClick={onRefresh} disabled={loading}>
+            Refresh
+          </button>
+          {writeAllowed && (
+            <button type="button" className="btn-primary" onClick={openAdd} disabled={loading}>
+              Add item
+            </button>
+          )}
+        </div>
+      </header>
+
+      {loadError && <div className="text-sm text-danger mb-3">{loadError}</div>}
+      {loading && <div className="text-sm text-muted">Loading…</div>}
+
+      {!loading && itemCount === 0 && !loadError && (
+        <div className="text-sm text-muted py-4 text-center">
+          No items on this page. {writeAllowed && "Use \"Add item\" to seed one."}
+        </div>
+      )}
+
+      {itemCount > 0 && (
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Primary key</th>
+              <th>Preview</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {page!.items.map((item, idx) => (
+              <ItemRow
+                key={idx}
+                item={item}
+                partitionKey={partitionKey}
+                sortKey={sortKey}
+                onOpen={() => openView(item)}
+              />
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <footer className="flex items-center pt-3 text-xs text-muted">
+        <div>{itemCount > 0 ? `${itemCount} items on this page` : ""}</div>
+        <div className="ml-auto flex gap-2">
+          {hasNext ? (
+            <button type="button" className="btn-secondary" onClick={onNextPage} disabled={loading}>
+              Next page →
+            </button>
+          ) : (
+            <span>{itemCount > 0 ? "End of scan" : ""}</span>
+          )}
+        </div>
+      </footer>
+
+      {modalMode && modalItem && (
+        <ItemEditorModal
+          mode={modalMode}
+          item={modalItem}
+          busy={modalBusy}
+          error={modalError}
+          writeAllowed={writeAllowed}
+          partitionKey={partitionKey}
+          sortKey={sortKey}
+          onClose={closeModal}
+          onEdit={openEdit}
+          onSave={onSave}
+          onDelete={onDelete}
+        />
+      )}
+    </section>
+  );
+}
+
+interface ItemRowProps {
+  item: AdminItem;
+  partitionKey: string;
+  sortKey?: string;
+  onOpen: () => void;
+}
+
+function ItemRow({ item, partitionKey, sortKey, onOpen }: ItemRowProps) {
+  const keyPreview = useMemo(
+    () => describePrimaryKey(item, partitionKey, sortKey),
+    [item, partitionKey, sortKey],
+  );
+  const valuePreview = useMemo(() => describeItemPreview(item, partitionKey, sortKey), [
+    item,
+    partitionKey,
+    sortKey,
+  ]);
+  return (
+    <tr>
+      <td className="font-mono text-xs">{keyPreview}</td>
+      <td className="font-mono text-xs text-muted">{valuePreview}</td>
+      <td className="text-right">
+        <button type="button" className="btn-secondary text-xs" onClick={onOpen}>
+          Open
+        </button>
+      </td>
+    </tr>
+  );
+}
+
+interface ItemEditorModalProps {
+  mode: EditorMode;
+  item: AdminItem;
+  busy: boolean;
+  error: string | null;
+  writeAllowed: boolean;
+  partitionKey: string;
+  sortKey?: string;
+  onClose: () => void;
+  onEdit: () => void;
+  onSave: (next: AdminItem) => void;
+  onDelete: () => void;
+}
+
+function ItemEditorModal({
+  mode,
+  item,
+  busy,
+  error,
+  writeAllowed,
+  partitionKey,
+  sortKey,
+  onClose,
+  onEdit,
+  onSave,
+  onDelete,
+}: ItemEditorModalProps) {
+  const initial = useMemo(() => JSON.stringify(item, null, 2), [item]);
+  const [draft, setDraft] = useState(initial);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [parseError, setParseError] = useState<string | null>(null);
+
+  // Reset the draft when the item / mode flips. Using a key on the
+  // modal would also work but this is one effect instead of a
+  // remount + state-redaclare cycle.
+  useEffect(() => {
+    setDraft(initial);
+    setParseError(null);
+    setConfirmDelete(false);
+  }, [initial, mode]);
+
+  const title =
+    mode === "add" ? "Add item" : mode === "edit" ? "Edit item" : "Item";
+
+  const editable = mode === "add" || mode === "edit";
+
+  const onSubmit = () => {
+    let parsed: AdminItem;
+    try {
+      const obj = JSON.parse(draft);
+      if (!obj || typeof obj !== "object" || !obj.attributes || typeof obj.attributes !== "object") {
+        throw new Error('body must have an "attributes" object');
+      }
+      parsed = obj as AdminItem;
+    } catch (err) {
+      setParseError(err instanceof Error ? err.message : String(err));
+      return;
+    }
+    setParseError(null);
+    onSave(parsed);
+  };
+
+  return (
+    <Modal title={title} open onClose={onClose} busy={busy}>
+      <div className="space-y-3 text-sm">
+        <div className="text-xs text-muted">
+          Primary key: <code className="font-mono">{partitionKey}</code>
+          {sortKey && (
+            <>
+              {" + "}
+              <code className="font-mono">{sortKey}</code>
+            </>
+          )}
+        </div>
+        {editable ? (
+          <textarea
+            className="w-full h-72 font-mono text-xs border border-border rounded p-2"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            disabled={busy}
+            spellCheck={false}
+          />
+        ) : (
+          <pre className="w-full h-72 font-mono text-xs border border-border rounded p-2 overflow-auto bg-surface-subtle">
+            {initial}
+          </pre>
+        )}
+        {parseError && <div className="text-danger">{parseError}</div>}
+        {error && <div className="text-danger">{error}</div>}
+        <div className="flex justify-end gap-2 pt-2">
+          {confirmDelete ? (
+            <>
+              <span className="mr-auto text-xs text-danger">Delete this item?</span>
+              <button type="button" className="btn-secondary" onClick={() => setConfirmDelete(false)} disabled={busy}>
+                Cancel
+              </button>
+              <button type="button" className="btn-danger" onClick={onDelete} disabled={busy}>
+                {busy ? "Deleting…" : "Delete"}
+              </button>
+            </>
+          ) : (
+            <>
+              <button type="button" className="btn-secondary" onClick={onClose} disabled={busy}>
+                Close
+              </button>
+              {mode === "view" && writeAllowed && (
+                <>
+                  <button type="button" className="btn-danger" onClick={() => setConfirmDelete(true)} disabled={busy}>
+                    Delete
+                  </button>
+                  <button type="button" className="btn-primary" onClick={onEdit} disabled={busy}>
+                    Edit
+                  </button>
+                </>
+              )}
+              {editable && (
+                <button type="button" className="btn-primary" onClick={onSubmit} disabled={busy}>
+                  {busy ? "Saving…" : "Save"}
+                </button>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// ---------- helpers ----------
+
+// encodeContinuation turns a LastEvaluatedKey into the base64-url
+// blob the server's next_cursor query param expects.
+function encodeContinuation(key: Record<string, AdminAttributeValue>): string {
+  const json = JSON.stringify(key);
+  const bytes = new TextEncoder().encode(json);
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/u, "");
+}
+
+// extractPrimaryKey pulls the table's primary-key attributes out of
+// an item body, returning null when any required attribute is
+// missing. Hash-only tables only require partitionKey; hash+range
+// require both. The handler will reject mismatches at the body /
+// URL-key reconciliation step, so this only protects against
+// obvious operator typos before we even hit the network.
+function extractPrimaryKey(
+  item: AdminItem,
+  partitionKey: string,
+  sortKey?: string,
+): Record<string, AdminAttributeValue> | null {
+  const attrs = item.attributes ?? {};
+  const pk = attrs[partitionKey];
+  if (!pk) return null;
+  const out: Record<string, AdminAttributeValue> = { [partitionKey]: pk };
+  if (sortKey) {
+    const sk = attrs[sortKey];
+    if (!sk) return null;
+    out[sortKey] = sk;
+  }
+  return out;
+}
+
+// describePrimaryKey renders the partition key (and sort key, if
+// any) as a compact `pk=value` or `pk=value | sk=value` string for
+// the table row. We render scalar types as the typed value; complex
+// types fall back to JSON.
+function describePrimaryKey(
+  item: AdminItem,
+  partitionKey: string,
+  sortKey?: string,
+): string {
+  const parts = [`${partitionKey}=${formatAttributeShort(item.attributes?.[partitionKey])}`];
+  if (sortKey) {
+    parts.push(`${sortKey}=${formatAttributeShort(item.attributes?.[sortKey])}`);
+  }
+  return parts.join(" | ");
+}
+
+// describeItemPreview is a teaser for the row's value column: count
+// of non-key attributes, plus the first two key=value pairs to
+// help disambiguate items. Long values truncate at 32 chars.
+function describeItemPreview(
+  item: AdminItem,
+  partitionKey: string,
+  sortKey?: string,
+): string {
+  const attrs = item.attributes ?? {};
+  const skip = new Set([partitionKey]);
+  if (sortKey) skip.add(sortKey);
+  const entries = Object.entries(attrs).filter(([k]) => !skip.has(k));
+  if (entries.length === 0) return "(no other attributes)";
+  const head = entries
+    .slice(0, 2)
+    .map(([k, v]) => {
+      const val = formatAttributeShort(v);
+      return `${k}=${val.length > 32 ? val.slice(0, 32) + "…" : val}`;
+    })
+    .join(", ");
+  const more = entries.length > 2 ? ` (+${entries.length - 2} more)` : "";
+  return head + more;
+}
+
+function formatAttributeShort(v: AdminAttributeValue | undefined): string {
+  if (!v) return "—";
+  if (v.S !== undefined) return v.S;
+  if (v.N !== undefined) return v.N;
+  if (v.BOOL !== undefined) return String(v.BOOL);
+  if (v.NULL !== undefined) return "null";
+  if (v.B !== undefined) return `<binary ${v.B.length}b64>`;
+  if (v.SS) return `[${v.SS.join(",")}]`;
+  if (v.NS) return `[${v.NS.join(",")}]`;
+  if (v.BS) return `<${v.BS.length} bin>`;
+  if (v.L) return `[${v.L.length} list]`;
+  if (v.M) return `{${Object.keys(v.M).length} map}`;
+  return "?";
+}

--- a/web/admin/src/pages/DynamoDetail.tsx
+++ b/web/admin/src/pages/DynamoDetail.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { api } from "../api/client";
 import { useAuth } from "../auth";
+import { DynamoItemsTab } from "../components/DynamoItemsTab";
 import { Modal } from "../components/Modal";
 import { formatApiError, useApiQuery } from "../lib/useApi";
 
@@ -66,6 +67,14 @@ export function DynamoDetailPage() {
           </dl>
         )}
       </section>
+      {detail.data && (
+        <DynamoItemsTab
+          table={name}
+          partitionKey={detail.data.partition_key}
+          sortKey={detail.data.sort_key}
+        />
+      )}
+
       {detail.data?.global_secondary_indexes && detail.data.global_secondary_indexes.length > 0 && (
         <section className="card">
           <h2 className="text-sm font-semibold mb-3">Global secondary indexes</h2>

--- a/web/admin/src/pages/DynamoDetail.tsx
+++ b/web/admin/src/pages/DynamoDetail.tsx
@@ -67,8 +67,23 @@ export function DynamoDetailPage() {
           </dl>
         )}
       </section>
-      {detail.data && (
+      {detail.data && detail.data.name === name && (
+        // Only render the items tab when the loaded describe response
+        // matches the current route param. useApiQuery keeps the
+        // previous table's `detail.data` around while a new fetch is
+        // in flight, so a /dynamo/tables/A → /dynamo/tables/B
+        // navigation would otherwise mount DynamoItemsTab with
+        // table=B but partitionKey/sortKey from A's stale schema.
+        // The tab then scans table B with A's key shape; key
+        // extraction returns wrong attributes (or fails entirely on
+        // a hash+range vs hash-only mismatch) for the brief window
+        // before the new describe response lands — and any edit /
+        // delete kicked off in that window targets the wrong record
+        // (Codex P2 on PR #815 r3). The `key={name}` below remounts
+        // the tab on route change so its internal state (cursor,
+        // open modal, etc.) also resets.
         <DynamoItemsTab
+          key={name}
           table={name}
           partitionKey={detail.data.partition_key}
           sortKey={detail.data.sort_key}


### PR DESCRIPTION
## Summary

**Phase 4** of `docs/design/2026_05_22_proposed_admin_data_browser.md` — adds the Items tab to the DynamoDB detail page so operators can scan / view / add / edit / delete items through the admin SPA. Consumes the Phase-3a HTTP surface from PR #813.

## Stacked on

This branch is built on `feat/admin-http-dynamo-items` (PR #813). Merge order: #813 → #814 (Phase 3b) → this PR. CI will compile cleanly here because the Phase-3a server endpoints live in the parent branch.

## Capabilities

| Role | Allowed |
|---|---|
| `read_only` | scan + view item JSON |
| `full` | add + edit + delete (plus everything above) |

## UI

- New "Items" card on `DynamoDetail` with a paginated table.
- Page-size selector (25 / 100) mirrors the server's default + cap.
- "Refresh" reloads the current page; "Next page →" advances via the server's `last_evaluated_key`.
- Per-row "Open" button opens a single modal that switches between view / edit / add modes.
- Delete uses a two-stage confirm (button row collapses to "Delete this item?") so a click cannot accidentally destroy a row.

## API client

`web/admin/src/api/client.ts` grows:

- `AdminAttributeValue` / `AdminItem` / `AdminScanItemsResult` / `AdminScanItemsOptions` types (mirror the Go handler shapes, including the empty-L/M preservation fixed in PR #813 r1).
- `scanItems` / `getItem` / `putItem` / `deleteItem` methods.
- `encodeAdminItemKey` helper: UTF-8 → bytes → btoa → url-safe alphabet, padding stripped. Non-ASCII keys and binary blobs round-trip without ambiguity.

## Server-side rules honoured

- URL key derives from the body's primary-key attributes (`extractPrimaryKey`). The server's `assertItemBodyMatchesPathKey` is authoritative; this client-side extraction only guards against the operator forgetting the partition key entirely.
- Modal `busy` gates Esc / backdrop dismissal so a half-completed save cannot be orphaned mid-network.

## Self-review (5 passes)

1. **Data loss** — No SPA-side write path bypasses the server. Body / URL-key check happens on both sides.
2. **Concurrency** — `AbortController` wired through every fetch. Modal `busy` blocks dismissal.
3. **Performance** — Scan pages bounded. No N+1 per-row Describe calls. Cursor stack lets Refresh reload the current page without restarting the scan.
4. **Consistency** — Page-size change resets to page 0. Refresh after write reloads the current page so the operator sees their own write.
5. **Test coverage** — Manual dev-server exercise only. Vitest harness for the SPA does not yet exist; encoding helpers will get property tests when that lands.

## Test plan

- [x] `npm run lint` (tsc) — passes
- [x] `npm run build` (vite) — passes
- [x] `go test -count=1 ./internal/admin/...` — passes (no backend changes)
- [ ] Manual SPA exercise against a live admin server (after PR #813 merges)
- [ ] CI

## Phase plan

- Phase 2a: DynamoDB item RPCs — merged (#805)
- Phase 2b: S3 object RPCs — merged (#811)
- Phase 3a: DynamoDB item HTTP — open (#813)
- Phase 3b: S3 object HTTP — open (#814)
- **Phase 4: SPA DynamoDetail Items tab (this PR)**
- Phase 5: SPA S3Detail Objects tab + Upload
- Phase 6: Doc rename `_proposed_` → `_implemented_`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DynamoDB items management interface to the admin panel, enabling administrators to scan tables, view individual items, create new items, edit existing items, and delete items.
  * Implemented role-based access control restricting write operations to users with full permissions.
  * Paginated browsing with customizable page sizes and cursor-based navigation for efficient data exploration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/815?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->