### PR TITLE
web/admin: Objects tab on S3Detail (Phase 5)

### DIFF
--- a/web/admin/src/api/client.ts
+++ b/web/admin/src/api/client.ts
@@ -410,7 +410,12 @@ export const api = {
       `${apiBase}/s3/buckets/${encodeURIComponent(bucket)}/objects/${base64UrlEncodeBytes(key)}`,
       { method: "PUT", body, headers, credentials: "same-origin" },
     );
-    if (res.status === 204) return;
+    // Treat any 2xx as success rather than just 204. The current
+    // Go handler returns 204 (no body) but the contract intent is
+    // any successful upload; a future change that returns the
+    // metadata on 200 would otherwise be misclassified as a
+    // non-JSON error (Gemini medium on PR #816).
+    if (res.ok) return;
     const ct = res.headers.get("content-type") ?? "";
     if (!ct.includes("application/json")) {
       throw new ApiError(res.status, "non_json_response", `HTTP ${res.status}`);

--- a/web/admin/src/api/client.ts
+++ b/web/admin/src/api/client.ts
@@ -49,6 +49,17 @@ function readCsrfCookie(): string | undefined {
   return undefined;
 }
 
+// base64UrlEncodeBytes turns a UTF-8 string into the unpadded
+// base64-url alphabet the admin S3 object routes accept for the
+// {key-b64url} URL segment. Same encoding the admin Dynamo items
+// routes use for their key segment.
+function base64UrlEncodeBytes(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/u, "");
+}
+
 function buildURL(path: string, query?: ApiOptions["query"]): string {
   const url = new URL(apiBase + path, window.location.origin);
   if (query) {
@@ -191,6 +202,30 @@ export interface S3BucketList {
 export interface CreateBucketRequest {
   bucket_name: string;
   acl?: "private" | "public-read";
+}
+
+// AdminObject mirrors internal/admin/s3_objects_handler.go. The
+// per-object metadata projection list pages return.
+export interface AdminObject {
+  key: string;
+  size: number;
+  content_type: string;
+  etag: string;
+  last_modified: string;
+  storage_class: string;
+}
+
+export interface AdminObjectListing {
+  objects: AdminObject[];
+  common_prefixes?: string[];
+  next_continuation_token?: string;
+}
+
+export interface AdminListObjectsOptions {
+  prefix?: string;
+  delimiter?: string;
+  continuation_token?: string;
+  max_keys?: number;
 }
 
 // SQS queue admin DTOs (Section 16.2 of the SQS partial design doc).
@@ -341,6 +376,57 @@ export const api = {
     }),
   deleteBucket: (name: string) =>
     apiFetch<void>(`/s3/buckets/${encodeURIComponent(name)}`, { method: "DELETE" }),
+  listObjects: (bucket: string, opts?: AdminListObjectsOptions, signal?: AbortSignal) =>
+    apiFetch<AdminObjectListing>(
+      `/s3/buckets/${encodeURIComponent(bucket)}/objects`,
+      {
+        query: {
+          prefix: opts?.prefix,
+          delimiter: opts?.delimiter,
+          continuation_token: opts?.continuation_token,
+          max_keys: opts?.max_keys,
+        },
+        signal,
+      },
+    ),
+  // The object body endpoints carry raw bytes (application/octet-
+  // stream), so they bypass the JSON-only apiFetch and use a direct
+  // fetch with the CSRF header. base64UrlEncodeBytes turns the key
+  // into the {key-b64url} segment the server's
+  // decodeAdminObjectKeySegment expects.
+  downloadObjectURL: (bucket: string, key: string): string =>
+    `${apiBase}/s3/buckets/${encodeURIComponent(bucket)}/objects/${base64UrlEncodeBytes(key)}`,
+  putObject: async (
+    bucket: string,
+    key: string,
+    body: Blob,
+    contentType?: string,
+  ): Promise<void> => {
+    const headers: Record<string, string> = {};
+    if (contentType) headers["Content-Type"] = contentType;
+    const csrf = readCsrfCookie();
+    if (csrf) headers["X-Admin-CSRF"] = csrf;
+    const res = await fetch(
+      `${apiBase}/s3/buckets/${encodeURIComponent(bucket)}/objects/${base64UrlEncodeBytes(key)}`,
+      { method: "PUT", body, headers, credentials: "same-origin" },
+    );
+    if (res.status === 204) return;
+    const ct = res.headers.get("content-type") ?? "";
+    if (!ct.includes("application/json")) {
+      throw new ApiError(res.status, "non_json_response", `HTTP ${res.status}`);
+    }
+    const payload = (await res.json()) as Record<string, unknown>;
+    throw new ApiError(
+      res.status,
+      typeof payload.error === "string" ? payload.error : "request_failed",
+      typeof payload.message === "string" ? payload.message : "",
+    );
+  },
+  deleteObject: (bucket: string, key: string) =>
+    apiFetch<void>(
+      `/s3/buckets/${encodeURIComponent(bucket)}/objects/${base64UrlEncodeBytes(key)}`,
+      { method: "DELETE" },
+    ),
   listQueues: (signal?: AbortSignal) =>
     apiFetch<SqsQueueList>("/sqs/queues", { signal }),
   describeQueue: (name: string, signal?: AbortSignal) =>

--- a/web/admin/src/components/S3ObjectsTab.tsx
+++ b/web/admin/src/components/S3ObjectsTab.tsx
@@ -1,0 +1,404 @@
+import { useEffect, useRef, useState } from "react";
+import type { AdminObject, AdminObjectListing } from "../api/client";
+import { ApiError, api } from "../api/client";
+import { useAuth } from "../auth";
+import { Modal } from "./Modal";
+
+// Phase 5 — Objects tab for /s3/buckets/{name}. Driven by the
+// Phase-3b HTTP surface in internal/admin/s3_objects_handler.go.
+//
+// Capabilities (gated on session role):
+//   read_only — list + download
+//   full      — additionally upload + delete
+
+// Server clamps max_keys to [1, 1000]; we surface 100 as the
+// default page size (matches adminListObjectsDefaultMaxKeys).
+const PAGE_SIZE = 100;
+
+// Delimiter fixed to "/" — the listObjects pseudo-folder model
+// only makes sense with one separator at a time. Operators who
+// need flat listings can browse a prefix that has no slashes.
+const DELIMITER = "/";
+
+interface S3ObjectsTabProps {
+  bucket: string;
+}
+
+export function S3ObjectsTab({ bucket }: S3ObjectsTabProps) {
+  const { session } = useAuth();
+  const writeAllowed = session?.role === "full";
+
+  // prefix is the current folder address — empty string is the
+  // bucket root. The breadcrumb derives from this; clicking a
+  // segment trims the prefix. Clicking a common-prefix row pushes.
+  const [prefix, setPrefix] = useState("");
+  const [page, setPage] = useState<AdminObjectListing | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  // cursorStack tracks the continuation tokens that produced the
+  // page-N>0 views so a Back-to-previous-page button can return
+  // without scanning from the start.
+  const [cursorStack, setCursorStack] = useState<string[]>([]);
+
+  const loadPage = async (cursor: string | undefined, p: string) => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const result = await api.listObjects(bucket, {
+        prefix: p,
+        delimiter: DELIMITER,
+        continuation_token: cursor,
+        max_keys: PAGE_SIZE,
+      });
+      setPage(result);
+    } catch (err) {
+      setLoadError(err instanceof ApiError ? `${err.code}: ${err.message || err.code}` : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Initial load + bucket / prefix change refetches from the start.
+  useEffect(() => {
+    setCursorStack([]);
+    void loadPage(undefined, prefix);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bucket, prefix]);
+
+  const onNextPage = () => {
+    const next = page?.next_continuation_token;
+    if (!next) return;
+    setCursorStack((s) => [...s, next]);
+    void loadPage(next, prefix);
+  };
+
+  const onRefresh = () => {
+    const top = cursorStack[cursorStack.length - 1];
+    void loadPage(top, prefix);
+  };
+
+  const onEnterFolder = (commonPrefix: string) => {
+    // commonPrefix already includes the trailing slash (the server
+    // emits "photos/" when DELIMITER="/").
+    setPrefix(commonPrefix);
+  };
+
+  const onCrumbClick = (target: string) => setPrefix(target);
+
+  // Upload state.
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploadBusy, setUploadBusy] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+
+  const onUploadClick = () => fileInputRef.current?.click();
+
+  const onFilePicked = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    // Clear the input so picking the same file twice in a row re-fires.
+    e.target.value = "";
+    setUploadBusy(true);
+    setUploadError(null);
+    try {
+      // Object key is the prefix + the picked file's base name. The
+      // server rejects keys whose URL segment is empty so a file
+      // with an empty name (impossible via <input>, but defensive)
+      // would 400 before reaching the storage layer.
+      const key = prefix + file.name;
+      await api.putObject(bucket, key, file, file.type || "application/octet-stream");
+      void loadPage(cursorStack[cursorStack.length - 1], prefix);
+    } catch (err) {
+      setUploadError(err instanceof ApiError ? `${err.code}: ${err.message || err.code}` : String(err));
+    } finally {
+      setUploadBusy(false);
+    }
+  };
+
+  // Detail modal state.
+  const [detail, setDetail] = useState<AdminObject | null>(null);
+  const [detailBusy, setDetailBusy] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const openDetail = (obj: AdminObject) => {
+    setDetail(obj);
+    setDetailError(null);
+    setConfirmDelete(false);
+  };
+
+  const closeDetail = () => {
+    if (detailBusy) return;
+    setDetail(null);
+    setDetailError(null);
+    setConfirmDelete(false);
+  };
+
+  const onDelete = async () => {
+    if (!detail) return;
+    setDetailBusy(true);
+    setDetailError(null);
+    try {
+      await api.deleteObject(bucket, detail.key);
+      setDetail(null);
+      setConfirmDelete(false);
+      void loadPage(cursorStack[cursorStack.length - 1], prefix);
+    } catch (err) {
+      setDetailError(err instanceof ApiError ? `${err.code}: ${err.message || err.code}` : String(err));
+    } finally {
+      setDetailBusy(false);
+    }
+  };
+
+  const hasNext = !!page?.next_continuation_token;
+  const objectCount = page?.objects?.length ?? 0;
+  const folderCount = page?.common_prefixes?.length ?? 0;
+
+  return (
+    <section className="card">
+      <header className="flex items-center gap-3 mb-3">
+        <h2 className="text-sm font-semibold">Objects</h2>
+        <Breadcrumb prefix={prefix} onClick={onCrumbClick} />
+        <div className="ml-auto flex items-center gap-2">
+          <button type="button" className="btn-secondary" onClick={onRefresh} disabled={loading}>
+            Refresh
+          </button>
+          {writeAllowed && (
+            <>
+              <input
+                ref={fileInputRef}
+                type="file"
+                className="hidden"
+                onChange={onFilePicked}
+                disabled={uploadBusy}
+              />
+              <button
+                type="button"
+                className="btn-primary"
+                onClick={onUploadClick}
+                disabled={uploadBusy || loading}
+              >
+                {uploadBusy ? "Uploading…" : "Upload"}
+              </button>
+            </>
+          )}
+        </div>
+      </header>
+
+      {loadError && <div className="text-sm text-danger mb-3">{loadError}</div>}
+      {uploadError && <div className="text-sm text-danger mb-3">{uploadError}</div>}
+      {loading && <div className="text-sm text-muted">Loading…</div>}
+
+      {!loading && objectCount === 0 && folderCount === 0 && !loadError && (
+        <div className="text-sm text-muted py-4 text-center">
+          {prefix ? "This folder is empty." : "This bucket is empty."}
+          {writeAllowed && " Use \"Upload\" to add an object."}
+        </div>
+      )}
+
+      {(objectCount > 0 || folderCount > 0) && (
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Size</th>
+              <th>Last modified</th>
+              <th>Type</th>
+            </tr>
+          </thead>
+          <tbody>
+            {page?.common_prefixes?.map((cp) => (
+              <tr key={"cp:" + cp} className="cursor-pointer hover:bg-surface-subtle" onClick={() => onEnterFolder(cp)}>
+                <td className="font-mono text-xs">📁 {stripPrefix(cp, prefix)}</td>
+                <td className="text-xs text-muted">—</td>
+                <td className="text-xs text-muted">—</td>
+                <td className="text-xs text-muted">folder</td>
+              </tr>
+            ))}
+            {page?.objects.map((obj) => (
+              <tr key={obj.key} className="cursor-pointer hover:bg-surface-subtle" onClick={() => openDetail(obj)}>
+                <td className="font-mono text-xs">{stripPrefix(obj.key, prefix)}</td>
+                <td className="text-xs">{formatSize(obj.size)}</td>
+                <td className="text-xs text-muted">{formatDate(obj.last_modified)}</td>
+                <td className="text-xs text-muted">{obj.content_type || "—"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <footer className="flex items-center pt-3 text-xs text-muted">
+        <div>
+          {objectCount > 0 ? `${objectCount} objects` : ""}
+          {objectCount > 0 && folderCount > 0 ? " · " : ""}
+          {folderCount > 0 ? `${folderCount} folders` : ""}
+        </div>
+        <div className="ml-auto flex gap-2">
+          {hasNext ? (
+            <button type="button" className="btn-secondary" onClick={onNextPage} disabled={loading}>
+              Next page →
+            </button>
+          ) : (
+            <span>{objectCount > 0 || folderCount > 0 ? "End of listing" : ""}</span>
+          )}
+        </div>
+      </footer>
+
+      {detail && (
+        <ObjectDetailModal
+          bucket={bucket}
+          object={detail}
+          busy={detailBusy}
+          error={detailError}
+          writeAllowed={writeAllowed}
+          confirmDelete={confirmDelete}
+          onClose={closeDetail}
+          onConfirmDelete={() => setConfirmDelete(true)}
+          onCancelDelete={() => setConfirmDelete(false)}
+          onDelete={onDelete}
+        />
+      )}
+    </section>
+  );
+}
+
+interface BreadcrumbProps {
+  prefix: string;
+  onClick: (target: string) => void;
+}
+
+function Breadcrumb({ prefix, onClick }: BreadcrumbProps) {
+  // prefix === "" is the bucket root; segments are slash-separated
+  // folders, each retains its trailing slash so the listObjects
+  // continuation contract stays intact.
+  const segments = prefix === "" ? [] : prefix.replace(/\/$/u, "").split("/");
+  return (
+    <div className="text-xs text-muted flex items-center gap-1 font-mono">
+      <button type="button" className="hover:text-ink underline" onClick={() => onClick("")}>
+        (root)
+      </button>
+      {segments.map((seg, idx) => {
+        const target = segments.slice(0, idx + 1).join("/") + "/";
+        return (
+          <span key={idx} className="flex items-center gap-1">
+            <span>/</span>
+            <button
+              type="button"
+              className="hover:text-ink underline"
+              onClick={() => onClick(target)}
+              disabled={idx === segments.length - 1}
+            >
+              {seg}
+            </button>
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+interface ObjectDetailModalProps {
+  bucket: string;
+  object: AdminObject;
+  busy: boolean;
+  error: string | null;
+  writeAllowed: boolean;
+  confirmDelete: boolean;
+  onClose: () => void;
+  onConfirmDelete: () => void;
+  onCancelDelete: () => void;
+  onDelete: () => void;
+}
+
+function ObjectDetailModal({
+  bucket,
+  object,
+  busy,
+  error,
+  writeAllowed,
+  confirmDelete,
+  onClose,
+  onConfirmDelete,
+  onCancelDelete,
+  onDelete,
+}: ObjectDetailModalProps) {
+  const downloadHref = api.downloadObjectURL(bucket, object.key);
+  return (
+    <Modal title={object.key} open onClose={onClose} busy={busy}>
+      <div className="space-y-3 text-sm">
+        <dl className="grid grid-cols-2 gap-x-6 gap-y-1 text-xs">
+          <dt className="text-muted">Size</dt>
+          <dd className="font-mono">{formatSize(object.size)}</dd>
+          <dt className="text-muted">Content type</dt>
+          <dd className="font-mono">{object.content_type || "—"}</dd>
+          <dt className="text-muted">ETag</dt>
+          <dd className="font-mono break-all">{object.etag || "—"}</dd>
+          <dt className="text-muted">Last modified</dt>
+          <dd className="font-mono">{formatDate(object.last_modified)}</dd>
+          <dt className="text-muted">Storage class</dt>
+          <dd className="font-mono">{object.storage_class || "—"}</dd>
+        </dl>
+        {error && <div className="text-danger">{error}</div>}
+        <div className="flex justify-end gap-2 pt-2">
+          {confirmDelete ? (
+            <>
+              <span className="mr-auto text-xs text-danger">Delete this object?</span>
+              <button type="button" className="btn-secondary" onClick={onCancelDelete} disabled={busy}>
+                Cancel
+              </button>
+              <button type="button" className="btn-danger" onClick={onDelete} disabled={busy}>
+                {busy ? "Deleting…" : "Delete"}
+              </button>
+            </>
+          ) : (
+            <>
+              <button type="button" className="btn-secondary" onClick={onClose} disabled={busy}>
+                Close
+              </button>
+              <a
+                className="btn-secondary"
+                href={downloadHref}
+                // download attribute hints the browser to use the
+                // server's Content-Disposition filename; passing an
+                // empty value defers to the server.
+                download
+              >
+                Download
+              </a>
+              {writeAllowed && (
+                <button type="button" className="btn-danger" onClick={onConfirmDelete} disabled={busy}>
+                  Delete
+                </button>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// ---------- helpers ----------
+
+// stripPrefix returns the trailing portion of `key` past `prefix`.
+// Used to render `foo.png` in the table cell when the operator is
+// browsing `bucket/photos/foo.png` under prefix `photos/`.
+function stripPrefix(key: string, prefix: string): string {
+  if (prefix && key.startsWith(prefix)) return key.slice(prefix.length);
+  return key;
+}
+
+function formatSize(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KiB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MiB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(2)} GiB`;
+}
+
+function formatDate(iso: string): string {
+  if (!iso) return "—";
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}

--- a/web/admin/src/components/S3ObjectsTab.tsx
+++ b/web/admin/src/components/S3ObjectsTab.tsx
@@ -57,6 +57,15 @@ export function S3ObjectsTab({ bucket }: S3ObjectsTabProps) {
     };
   }, []);
 
+  // contextRef tracks the latest bucket/prefix so async callbacks
+  // (notably onFilePicked, which can outlive a folder navigation
+  // for large uploads) can compare against the operator's CURRENT
+  // view rather than the closure-captured value from click time.
+  // Codex P1 on PR #816 r7 caught the post-upload reload using
+  // stale prefix/cursor.
+  const contextRef = useRef({ bucket, prefix });
+  contextRef.current = { bucket, prefix };
+
   // loadPage returns true on success, false on error or
   // cancellation. Callers (notably onNextPage) inspect the
   // return value to decide whether to advance the cursor stack.
@@ -195,16 +204,47 @@ export function S3ObjectsTab({ bucket }: S3ObjectsTabProps) {
     e.target.value = "";
     setUploadBusy(true);
     setUploadError(null);
+    // Snapshot the upload's context (bucket + prefix) at click
+    // time so the completion handler can detect a mid-upload
+    // navigation. Long uploads can outlive a folder/bucket
+    // switch; without the snapshot check, the closure-captured
+    // prefix would feed loadPage with the OLD context and
+    // overwrite `page` with rows that don't match the current
+    // breadcrumb (Codex P1 on PR #816 r7). Bucket changes also
+    // remount this component via the parent's key={name} guard,
+    // but the snapshot is still belt-and-braces.
+    const uploadBucket = bucket;
+    const uploadPrefix = prefix;
+    const uploadCursor = cursorStack[cursorStack.length - 1];
     try {
       // Object key is the prefix + the picked file's base name. The
       // server rejects keys whose URL segment is empty so a file
       // with an empty name (impossible via <input>, but defensive)
       // would 400 before reaching the storage layer.
-      const key = prefix + file.name;
-      await api.putObject(bucket, key, file, file.type || "application/octet-stream");
-      void loadPage(cursorStack[cursorStack.length - 1], prefix);
+      const key = uploadPrefix + file.name;
+      await api.putObject(uploadBucket, key, file, file.type || "application/octet-stream");
+      // Skip the post-upload reload if the operator navigated
+      // mid-flight — the [bucket, prefix] effect already kicked
+      // off the right scan for the new context, and re-issuing
+      // with stale bucket/prefix would overwrite `page` with
+      // rows from the OLD context. The leaderward retry semantics
+      // are unchanged: a successful PUT against bucketA/prefixA
+      // remains durable even if we skip the listing refresh.
+      // contextRef holds the LATEST state (closure-captured
+      // bucket/prefix would compare equal against themselves).
+      const cur = contextRef.current;
+      if (uploadBucket === cur.bucket && uploadPrefix === cur.prefix) {
+        void loadPage(uploadCursor, uploadPrefix);
+      }
     } catch (err) {
-      setUploadError(err instanceof ApiError ? `${err.code}: ${err.message || err.code}` : String(err));
+      // Only surface the upload error if the operator is still
+      // looking at the context they uploaded into; otherwise the
+      // error banner would attach to a screen that has nothing to
+      // do with the failed upload.
+      const cur = contextRef.current;
+      if (uploadBucket === cur.bucket && uploadPrefix === cur.prefix) {
+        setUploadError(err instanceof ApiError ? `${err.code}: ${err.message || err.code}` : String(err));
+      }
     } finally {
       setUploadBusy(false);
     }

--- a/web/admin/src/components/S3ObjectsTab.tsx
+++ b/web/admin/src/components/S3ObjectsTab.tsx
@@ -40,21 +40,55 @@ export function S3ObjectsTab({ bucket }: S3ObjectsTabProps) {
   // without scanning from the start.
   const [cursorStack, setCursorStack] = useState<string[]>([]);
 
-  const loadPage = async (cursor: string | undefined, p: string) => {
+  // listAbortRef aborts the in-flight list when a new one starts
+  // (bucket change, prefix change, Next / Refresh, post-write
+  // reload). Without this, an older slower request can overwrite
+  // the current view with stale rows for a different prefix —
+  // and the follow-up download / delete actions on those rows
+  // would mutate the wrong resource (Codex P1, Gemini high on
+  // PR #816).
+  const listAbortRef = useRef<AbortController | null>(null);
+  // Abort the last in-flight controller on unmount so a pending
+  // network call doesn't update state after the component is
+  // gone.
+  useEffect(() => {
+    return () => {
+      listAbortRef.current?.abort();
+    };
+  }, []);
+
+  // loadPage returns true on success, false on error or
+  // cancellation. Callers (notably onNextPage) inspect the
+  // return value to decide whether to advance the cursor stack.
+  const loadPage = async (cursor: string | undefined, p: string): Promise<boolean> => {
+    listAbortRef.current?.abort();
+    const ctrl = new AbortController();
+    listAbortRef.current = ctrl;
     setLoading(true);
     setLoadError(null);
     try {
-      const result = await api.listObjects(bucket, {
-        prefix: p,
-        delimiter: DELIMITER,
-        continuation_token: cursor,
-        max_keys: PAGE_SIZE,
-      });
+      const result = await api.listObjects(
+        bucket,
+        {
+          prefix: p,
+          delimiter: DELIMITER,
+          continuation_token: cursor,
+          max_keys: PAGE_SIZE,
+        },
+        ctrl.signal,
+      );
+      if (listAbortRef.current !== ctrl) return false;
       setPage(result);
+      return true;
     } catch (err) {
+      if (listAbortRef.current !== ctrl) return false;
+      if (err instanceof DOMException && err.name === "AbortError") return false;
       setLoadError(err instanceof ApiError ? `${err.code}: ${err.message || err.code}` : String(err));
+      return false;
     } finally {
-      setLoading(false);
+      if (listAbortRef.current === ctrl) {
+        setLoading(false);
+      }
     }
   };
 
@@ -65,11 +99,19 @@ export function S3ObjectsTab({ bucket }: S3ObjectsTabProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bucket, prefix]);
 
-  const onNextPage = () => {
+  const onNextPage = async () => {
     const next = page?.next_continuation_token;
     if (!next) return;
-    setCursorStack((s) => [...s, next]);
-    void loadPage(next, prefix);
+    // Advance cursorStack only after the fetch succeeds. The
+    // previous code pushed first; on a transient API failure the
+    // UI still showed the old page while internal cursor state
+    // had already moved forward — subsequent Refresh / post-
+    // mutation reloads then used the wrong token and jumped to
+    // a different page (Codex P2 on PR #816).
+    const ok = await loadPage(next, prefix);
+    if (ok) {
+      setCursorStack((s) => [...s, next]);
+    }
   };
 
   const onRefresh = () => {

--- a/web/admin/src/components/S3ObjectsTab.tsx
+++ b/web/admin/src/components/S3ObjectsTab.tsx
@@ -92,6 +92,25 @@ export function S3ObjectsTab({ bucket }: S3ObjectsTabProps) {
     }
   };
 
+  // Reset prefix to the bucket root whenever the bucket changes.
+  // React Router param changes reuse the same component instance,
+  // so without this the previous bucket's prefix would carry over
+  // and `bucket-b` would open at `bucket-a`'s subfolder until the
+  // operator manually clicked `(root)` — uploads / deletes in
+  // that window would target the wrong subpath, and the root-
+  // level objects would be invisible (Codex P2 on PR #816).
+  //
+  // This effect runs first, schedules setPrefix(""); the
+  // [bucket, prefix] effect below fires on the *next* render once
+  // prefix has flipped, so the user-visible network call uses
+  // prefix="". A brief loadPage(undefined, oldPrefix) does fire
+  // from this render's commit before the setPrefix re-render
+  // settles; the listAbortRef cancels it before it can land,
+  // so no stale rows leak through.
+  useEffect(() => {
+    setPrefix("");
+  }, [bucket]);
+
   // Initial load + bucket / prefix change refetches from the start.
   useEffect(() => {
     setCursorStack([]);

--- a/web/admin/src/components/S3ObjectsTab.tsx
+++ b/web/admin/src/components/S3ObjectsTab.tsx
@@ -57,14 +57,15 @@ export function S3ObjectsTab({ bucket }: S3ObjectsTabProps) {
     };
   }, []);
 
-  // contextRef tracks the latest bucket/prefix so async callbacks
-  // (notably onFilePicked, which can outlive a folder navigation
-  // for large uploads) can compare against the operator's CURRENT
-  // view rather than the closure-captured value from click time.
-  // Codex P1 on PR #816 r7 caught the post-upload reload using
-  // stale prefix/cursor.
-  const contextRef = useRef({ bucket, prefix });
-  contextRef.current = { bucket, prefix };
+  // contextRef tracks the latest bucket/prefix/cursor so async
+  // callbacks (notably onFilePicked, which can outlive a folder
+  // navigation or in-prefix pagination for large uploads) can
+  // compare against the operator's CURRENT view rather than the
+  // closure-captured value from click time. Cursor was added in
+  // r9 after Codex P2 on r8 caught the in-prefix pagination race
+  // (jump-back to the upload's origin page on completion).
+  const contextRef = useRef({ bucket, prefix, cursor: "" as string | undefined });
+  contextRef.current = { bucket, prefix, cursor: cursorStack[cursorStack.length - 1] };
 
   // loadPage returns true on success, false on error or
   // cancellation. Callers (notably onNextPage) inspect the
@@ -224,25 +225,39 @@ export function S3ObjectsTab({ bucket }: S3ObjectsTabProps) {
       const key = uploadPrefix + file.name;
       await api.putObject(uploadBucket, key, file, file.type || "application/octet-stream");
       // Skip the post-upload reload if the operator navigated
-      // mid-flight — the [bucket, prefix] effect already kicked
-      // off the right scan for the new context, and re-issuing
-      // with stale bucket/prefix would overwrite `page` with
-      // rows from the OLD context. The leaderward retry semantics
-      // are unchanged: a successful PUT against bucketA/prefixA
-      // remains durable even if we skip the listing refresh.
-      // contextRef holds the LATEST state (closure-captured
-      // bucket/prefix would compare equal against themselves).
+      // mid-flight — bucket, prefix, OR page (cursor) all count.
+      // The [bucket, prefix] effect already kicked off the right
+      // scan when the bucket/prefix changed; re-issuing here
+      // would clobber it. For in-prefix pagination (Codex P2 on
+      // r8), uploadCursor was captured at click time, so the
+      // captured cursor would force the listing back to the
+      // upload's origin page even when the operator is now on a
+      // later page. contextRef holds the LATEST state across all
+      // three; only refresh when the operator is still on the
+      // exact (bucket, prefix, page) that the upload targeted.
+      // A successful PUT against (bucketA, prefixA, pageN) stays
+      // durable on the server regardless of whether we refresh
+      // the listing client-side.
       const cur = contextRef.current;
-      if (uploadBucket === cur.bucket && uploadPrefix === cur.prefix) {
+      if (
+        uploadBucket === cur.bucket &&
+        uploadPrefix === cur.prefix &&
+        uploadCursor === cur.cursor
+      ) {
         void loadPage(uploadCursor, uploadPrefix);
       }
     } catch (err) {
       // Only surface the upload error if the operator is still
       // looking at the context they uploaded into; otherwise the
       // error banner would attach to a screen that has nothing to
-      // do with the failed upload.
+      // do with the failed upload. Same three-axis check as the
+      // success path.
       const cur = contextRef.current;
-      if (uploadBucket === cur.bucket && uploadPrefix === cur.prefix) {
+      if (
+        uploadBucket === cur.bucket &&
+        uploadPrefix === cur.prefix &&
+        uploadCursor === cur.cursor
+      ) {
         setUploadError(err instanceof ApiError ? `${err.code}: ${err.message || err.code}` : String(err));
       }
     } finally {

--- a/web/admin/src/components/S3ObjectsTab.tsx
+++ b/web/admin/src/components/S3ObjectsTab.tsx
@@ -133,7 +133,21 @@ export function S3ObjectsTab({ bucket }: S3ObjectsTabProps) {
   }, [bucket]);
 
   // Initial load + bucket / prefix change refetches from the start.
+  // Clears page synchronously so stale rows from the previous
+  // context (bucket or prefix) cannot remain clickable during the
+  // loading window. Without this, a /s3/a → /s3/b navigation
+  // (which fires this effect with new bucket) would leave
+  // bucket-a's rows visible until listObjects(b) resolves; a
+  // click in that window opens the detail modal carrying
+  // bucket-a's object key but with the bucket prop already
+  // flipped to b, so Download/Delete would target
+  // (bucket=b, key=staleKeyFromA) — a cross-bucket data-integrity
+  // vector when key paths happen to overlap (Codex P1 on PR
+  // #816 r5). The brief "loading…" flash during legitimate
+  // Refresh / page-size changes is acceptable; the alternative
+  // (rows visible during loading) is unsafe.
   useEffect(() => {
+    setPage(null);
     setCursorStack([]);
     void loadPage(undefined, prefix);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/web/admin/src/components/S3ObjectsTab.tsx
+++ b/web/admin/src/components/S3ObjectsTab.tsx
@@ -83,6 +83,16 @@ export function S3ObjectsTab({ bucket }: S3ObjectsTabProps) {
     } catch (err) {
       if (listAbortRef.current !== ctrl) return false;
       if (err instanceof DOMException && err.name === "AbortError") return false;
+      // Clear stale rows on a non-abort failure. Without this, a
+      // route change from /s3/a to /s3/b followed by a transient
+      // list failure would leave bucket-a's rows visible under
+      // the bucket-b context — clicking Download/Delete would
+      // then operate on the wrong bucket with an old key (Codex
+      // P1 on PR #816 r2). The cursor stack is also cleared so
+      // a subsequent Refresh doesn't try to use a stale
+      // continuation token against the new context.
+      setPage(null);
+      setCursorStack([]);
       setLoadError(err instanceof ApiError ? `${err.code}: ${err.message || err.code}` : String(err));
       return false;
     } finally {

--- a/web/admin/src/components/S3ObjectsTab.tsx
+++ b/web/admin/src/components/S3ObjectsTab.tsx
@@ -102,23 +102,34 @@ export function S3ObjectsTab({ bucket }: S3ObjectsTabProps) {
     }
   };
 
-  // Reset prefix to the bucket root whenever the bucket changes.
-  // React Router param changes reuse the same component instance,
-  // so without this the previous bucket's prefix would carry over
-  // and `bucket-b` would open at `bucket-a`'s subfolder until the
-  // operator manually clicked `(root)` — uploads / deletes in
-  // that window would target the wrong subpath, and the root-
-  // level objects would be invisible (Codex P2 on PR #816).
+  // Reset prefix + close the detail modal whenever the bucket
+  // changes. React Router param changes reuse the same component
+  // instance, so without this two pieces of state leak across
+  // buckets:
   //
-  // This effect runs first, schedules setPrefix(""); the
-  // [bucket, prefix] effect below fires on the *next* render once
-  // prefix has flipped, so the user-visible network call uses
-  // prefix="". A brief loadPage(undefined, oldPrefix) does fire
-  // from this render's commit before the setPrefix re-render
-  // settles; the listAbortRef cancels it before it can land,
-  // so no stale rows leak through.
+  //   1. prefix — bucket-b would open at bucket-a's subfolder
+  //      until the operator manually clicked `(root)` (Codex P2
+  //      on PR #816 r1, fixed in r2);
+  //   2. detail — if a detail modal was open for an object in
+  //      bucket-a when the operator navigated to /s3/bucket-b,
+  //      the modal stayed open referencing the stale bucket-a
+  //      key. Clicking Delete would then call
+  //      api.deleteObject(bucketB, staleBucketAKey) (Claude
+  //      review on PR #816 r3 caught this — same cross-context
+  //      class as the prefix bug).
+  //
+  // This effect runs first, schedules the resets; the
+  // [bucket, prefix] effect below fires on the *next* render
+  // once prefix has flipped, so the user-visible network call
+  // uses prefix="". A brief loadPage(undefined, oldPrefix) does
+  // fire from this render's commit before the setPrefix
+  // re-render settles; listAbortRef cancels it before it can
+  // land, so no stale rows leak through.
   useEffect(() => {
     setPrefix("");
+    setDetail(null);
+    setConfirmDelete(false);
+    setDetailError(null);
   }, [bucket]);
 
   // Initial load + bucket / prefix change refetches from the start.
@@ -349,8 +360,13 @@ function Breadcrumb({ prefix, onClick }: BreadcrumbProps) {
       </button>
       {segments.map((seg, idx) => {
         const target = segments.slice(0, idx + 1).join("/") + "/";
+        // key=target rather than idx so React reconciles by the
+        // segment path itself — re-ordering or trimming the
+        // breadcrumb (e.g., the operator drops to a different
+        // depth) doesn't churn unrelated DOM nodes (Claude review
+        // on PR #816 r3 — nit).
         return (
-          <span key={idx} className="flex items-center gap-1">
+          <span key={target} className="flex items-center gap-1">
             <span>/</span>
             <button
               type="button"

--- a/web/admin/src/components/S3ObjectsTab.tsx
+++ b/web/admin/src/components/S3ObjectsTab.tsx
@@ -223,7 +223,26 @@ export function S3ObjectsTab({ bucket }: S3ObjectsTabProps) {
       await api.deleteObject(bucket, detail.key);
       setDetail(null);
       setConfirmDelete(false);
-      void loadPage(cursorStack[cursorStack.length - 1], prefix);
+      // If the deleted object was the only thing on the current
+      // page (no remaining objects and no common prefixes after
+      // its removal), reloading with the same continuation token
+      // would scan from after the now-empty cursor and surface an
+      // "empty bucket" state even when earlier pages still have
+      // content. Fall back to a page-0 reload + cursor reset so
+      // the operator lands on a non-empty view (Codex P2 on PR
+      // #816 r4). The common case — page has many entries —
+      // keeps the operator's position via the cursorStack top.
+      // Only applies when cursorStack is non-empty: at page 0 the
+      // cursor is already undefined and the empty state is
+      // unambiguous.
+      const wouldEmptyPage =
+        (page?.objects?.length ?? 0) <= 1 && (page?.common_prefixes?.length ?? 0) === 0;
+      if (wouldEmptyPage && cursorStack.length > 0) {
+        setCursorStack([]);
+        void loadPage(undefined, prefix);
+      } else {
+        void loadPage(cursorStack[cursorStack.length - 1], prefix);
+      }
     } catch (err) {
       setDetailError(err instanceof ApiError ? `${err.code}: ${err.message || err.code}` : String(err));
     } finally {

--- a/web/admin/src/pages/S3Detail.tsx
+++ b/web/admin/src/pages/S3Detail.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import { api } from "../api/client";
 import { useAuth } from "../auth";
 import { Modal } from "../components/Modal";
+import { S3ObjectsTab } from "../components/S3ObjectsTab";
 import { formatApiError, useApiQuery } from "../lib/useApi";
 
 export function S3DetailPage() {
@@ -107,6 +108,8 @@ export function S3DetailPage() {
           {aclError && <div className="text-sm text-danger mt-2">{aclError}</div>}
         </section>
       )}
+
+      {detail.data && <S3ObjectsTab bucket={name} />}
 
       <Modal
         title="Delete bucket"

--- a/web/admin/src/pages/S3Detail.tsx
+++ b/web/admin/src/pages/S3Detail.tsx
@@ -109,7 +109,22 @@ export function S3DetailPage() {
         </section>
       )}
 
-      {detail.data && <S3ObjectsTab bucket={name} />}
+      {detail.data && detail.data.bucket_name === name && (
+        // Only render the objects tab when the loaded describe
+        // response matches the current route param. useApiQuery
+        // keeps the previous bucket's `detail.data` around while
+        // a new fetch is in flight, so /s3/A → /s3/B briefly
+        // shows S3ObjectsTab with bucket=B while the describe
+        // response for B is still loading. The tab's own
+        // [bucket] effect already resets prefix/modal/cursor,
+        // but during the loading window stale rows from bucket
+        // A could remain visible and clickable (parallel of the
+        // PR #815 r4 DynamoDetail fix — same useApiQuery race
+        // shape). `key={name}` forces a fresh component instance
+        // on route change so React unmounts/remounts and the
+        // AbortController cleanup cancels any in-flight scan.
+        <S3ObjectsTab key={name} bucket={name} />
+      )}
 
       <Modal
         title="Delete bucket"


### PR DESCRIPTION
## Summary

**Phase 5** of `docs/design/2026_05_22_proposed_admin_data_browser.md` — adds the Objects tab to the S3 bucket detail page so operators can list / download / upload / delete objects through the admin SPA. Consumes the Phase-3b HTTP surface from PR #814.

## Stacked on

This branch is built on `feat/admin-http-s3-objects` (PR #814). Merge order: #814 → this PR. CI compiles cleanly here because the Phase-3b server endpoints live in the parent branch.

## Capabilities

| Role | Allowed |
|---|---|
| `read_only` | list + download |
| `full` | upload + delete (plus everything above) |

## UI

- New "Objects" card on `S3Detail` with a paginated table (page size 100, mirroring the server default).
- **Breadcrumb navigation** — clicking a path segment drops back to that prefix; "(root)" returns to the bucket root.
- **Folders** surfaced via the server's `CommonPrefixes` (delimiter fixed to `/`). Folder rows render with a 📁 prefix and clicking drills into them.
- **Object detail modal** — size / content-type / ETag / last-modified / storage-class + Download (anchor tag, `download` attr) + Delete (full role).
- **Upload** — hidden `<input type="file">` triggered by an Upload button. File uploads to `{prefix}/{file.name}` with its native Content-Type.
- **Delete** — two-stage confirm (button row collapses to "Delete this object?").

## API client

`web/admin/src/api/client.ts` grows:

- `AdminObject` / `AdminObjectListing` / `AdminListObjectsOptions` types.
- `listObjects` / `deleteObject` (JSON via `apiFetch`).
- `putObject` / `downloadObjectURL` (bypass `apiFetch` because they carry raw bytes). `putObject` does a manual `fetch()` so the body can be a `Blob`; CSRF header still attached. `downloadObjectURL` returns the URL for an `<a download>` link so the browser streams the response and honours the server's `Content-Disposition` header.
- `base64UrlEncodeBytes`: TextEncoder → btoa → url-safe alphabet, padding stripped.

## Server-side rules honoured

- 100 MiB upload cap is enforced server-side at both the `http.MaxBytesReader` and the adapter `ErrAdminUploadTooLarge` sentinel layers — both surface as 413.
- Security headers on download (nosniff, sandbox CSP, attachment Content-Disposition, no-store) come from the server; the SPA does not override them.
- Folder navigation issues a fresh `listObjects` under the new prefix rather than client-side filtering — keeps the page bounded at 100 entries regardless of bucket size.

## Self-review (5 passes)

1. **Data loss** — No SPA-side write path bypasses the server. The 100 MiB cap is enforced at two server-side layers.
2. **Concurrency** — Modal `busy` blocks dismissal during save. Upload button disabled while in flight.
3. **Performance** — Pagination bounded. Cursor stack lets Refresh reload the current page without restarting. Folder navigation is a fresh server call, not client filtering.
4. **Consistency** — Prefix change resets to page 0. Refresh after upload reloads the current page so the operator sees their own write.
5. **Test coverage** — Manual dev-server exercise only. Vitest harness for the SPA does not yet exist.

## Test plan

- [x] `npm run lint` (tsc) — passes
- [x] `npm run build` (vite) — passes
- [x] `go test -count=1 ./internal/admin/...` — passes (no backend changes)
- [ ] Manual SPA exercise against a live admin server (after PR #814 merges)
- [ ] CI

## Phase plan

- Phase 2a: DynamoDB item RPCs — merged (#805)
- Phase 2b: S3 object RPCs — merged (#811)
- Phase 3a: DynamoDB item HTTP — open (#813)
- Phase 3b: S3 object HTTP — open (#814)
- Phase 4: SPA DynamoDetail Items tab — open (#815)
- **Phase 5: SPA S3Detail Objects tab + Upload (this PR)**
- Phase 6: Doc rename `_proposed_` → `_implemented_`
