### PR TITLE
test(redis): widen TTL window on ExpiredKey_BecomesInvisible to fix CI flake

### DIFF
--- a/adapter/redis_ttl_compat_test.go
+++ b/adapter/redis_ttl_compat_test.go
@@ -186,15 +186,33 @@ func TestRedis_ExpiredKey_BecomesInvisible(t *testing.T) {
 	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
 	defer func() { _ = rdb.Close() }()
 
-	// Set a key with a very short TTL.
-	require.NoError(t, rdb.Do(ctx, "SET", "expiry:short", "v", "PX", "200").Err())
+	// PX=2000ms (was 200ms). The previous 200ms TTL races against
+	// the SET → GET round-trip latency on a 3-node Raft cluster
+	// under -race on CI runners: SET proposes through Raft, waits
+	// for quorum apply, and then returns OK, which can take
+	// 100–250ms on a slow runner. By the time the "visible before
+	// expiry" GET fires, the wall-clock-based TTL has already
+	// fired and the GET returns redis.Nil — a recurring flake
+	// observed across PRs #813/#814/#815/#816 today, all of which
+	// share no code with the Redis adapter.
+	//
+	// 2s is comfortably past the worst observed SET-ack latency
+	// (~250ms on CI) while still letting the "must be gone after
+	// expiry" loop's 5s deadline (raised below) catch the expiry
+	// well before the test deadline.
+	const initialTTL = 2 * time.Second
+	require.NoError(t, rdb.Do(ctx, "SET", "expiry:short", "v", "PX",
+		initialTTL.Milliseconds()).Err())
 
 	got, err := rdb.Get(ctx, "expiry:short").Result()
 	require.NoError(t, err)
 	require.Equal(t, "v", got, "key must be visible before expiry")
 
+	// 5s deadline (was 1s) so a slow CI runner has headroom past
+	// the 2s TTL + the Eventually poll cadence (25ms tick) +
+	// any additional latency from Raft-replicated DEL on expiry.
 	require.Eventually(t, func() bool {
 		_, e := rdb.Get(ctx, "expiry:short").Result()
 		return errors.Is(e, redis.Nil)
-	}, time.Second, 25*time.Millisecond, "key must be gone after expiry")
+	}, 5*time.Second, 25*time.Millisecond, "key must be gone after expiry")
 }

--- a/adapter/redis_ttl_compat_test.go
+++ b/adapter/redis_ttl_compat_test.go
@@ -186,20 +186,13 @@ func TestRedis_ExpiredKey_BecomesInvisible(t *testing.T) {
 	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
 	defer func() { _ = rdb.Close() }()
 
-	// PX=2000ms (was 200ms). The previous 200ms TTL races against
-	// the SET → GET round-trip latency on a 3-node Raft cluster
-	// under -race on CI runners: SET proposes through Raft, waits
-	// for quorum apply, and then returns OK, which can take
-	// 100–250ms on a slow runner. By the time the "visible before
-	// expiry" GET fires, the wall-clock-based TTL has already
-	// fired and the GET returns redis.Nil — a recurring flake
-	// observed across PRs #813/#814/#815/#816 today, all of which
-	// share no code with the Redis adapter.
-	//
-	// 2s is comfortably past the worst observed SET-ack latency
-	// (~250ms on CI) while still letting the "must be gone after
-	// expiry" loop's 5s deadline (raised below) catch the expiry
-	// well before the test deadline.
+	// initialTTL must comfortably outlast the SET → first-GET
+	// round-trip. SET on a 3-node Raft cluster must reach quorum
+	// before returning OK, which can take 100–250ms under -race on
+	// CI runners. The original 200ms TTL raced that window: by the
+	// time the "visible before expiry" GET fired, the wall-clock
+	// TTL had already burned and the GET returned redis.Nil. 2s
+	// is comfortably past the worst observed SET-ack latency.
 	const initialTTL = 2 * time.Second
 	require.NoError(t, rdb.Do(ctx, "SET", "expiry:short", "v", "PX",
 		initialTTL.Milliseconds()).Err())
@@ -208,11 +201,12 @@ func TestRedis_ExpiredKey_BecomesInvisible(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "v", got, "key must be visible before expiry")
 
-	// 5s deadline (was 1s) so a slow CI runner has headroom past
-	// the 2s TTL + the Eventually poll cadence (25ms tick) +
-	// any additional latency from Raft-replicated DEL on expiry.
+	// Deadline derives from initialTTL so a future TTL adjustment
+	// keeps the assertion window valid: ttl + 3s gives headroom
+	// for the 25ms poll cadence plus Raft-replicated DEL latency
+	// on expiry.
 	require.Eventually(t, func() bool {
 		_, e := rdb.Get(ctx, "expiry:short").Result()
 		return errors.Is(e, redis.Nil)
-	}, 5*time.Second, 25*time.Millisecond, "key must be gone after expiry")
+	}, initialTTL+3*time.Second, 25*time.Millisecond, "key must be gone after expiry")
 }


### PR DESCRIPTION
## Summary

Fixes the recurring `TestRedis_ExpiredKey_BecomesInvisible` CI flake that has been blocking unrelated admin PRs (#813, #814, #815, #816) all day.

## Root cause

The test sets a key with `PX 200` (200ms TTL) then immediately reads it back:

```go
require.NoError(t, rdb.Do(ctx, "SET", "expiry:short", "v", "PX", "200").Err())

got, err := rdb.Get(ctx, "expiry:short").Result()
require.NoError(t, err)                                          // ← fails: redis.Nil
require.Equal(t, "v", got, "key must be visible before expiry")
```

The `SET` goes through a 3-node Raft cluster: client → leader proposes → quorum apply → leader applies → response. Under `-race` on CI runners this round-trip can take 100–250ms. The TTL clock starts at the moment the leader applies, so by the time `SET` returns OK on a slow CI runner, the key may have <50ms of TTL left. The immediately-following `GET` then loses the race and hits `redis.Nil`.

That this is the bug — not anything in any of #813-#816 — is locked in by the cross-PR failure pattern: the flake fired today on PRs touching only `internal/admin/` and `web/admin/`, with zero code overlap with `adapter/`.

## Fix

`PX 200 → PX 2000`. 2s is comfortably past the worst observed SET-ack latency (~250ms on CI) while keeping the test under a 7s wall-clock budget (2s TTL + 5s `Eventually` deadline, raised from 1s).

The test's intent — verify expired keys become invisible to subsequent GETs — is preserved exactly. Only the timing constants change; the assertions are unchanged.

## Self-review (5 passes)

1. **Data loss** — none. Test-only constants.
2. **Concurrency** — closes a wall-clock vs. Raft-apply-latency race in the test fixture.
3. **Performance** — test now takes ~3s instead of ~250ms locally; still well under the 30s package timeout.
4. **Consistency** — the broader test still asserts both halves (visible before expiry, invisible after expiry) of the TTL contract.
5. **Test coverage** — no change to coverage; same assertions, friendlier timing.

## Test plan

- [x] `go test -race -count=3 -timeout=180s -run TestRedis_ExpiredKey_BecomesInvisible ./adapter/` — passes 3/3 (10.792s)
- [x] `golangci-lint --config=.golangci.yaml run` — clean
- [ ] CI

## Context

Discovered while running the PR review loop on #813-#817. The Claude bot's Round 8 review on #813 marked the PR as "Ready to merge once CI passes" — only the Redis flake was blocking. This fix unblocks #813 (and the parallel admin PRs) without touching any admin code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of the Redis TTL compatibility test by adjusting timing parameters to reduce intermittent test failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/818?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->