### PR TITLE
test(sqs): slow throttle refill on no-op SetQueueAttributes test to fix CI flake

### DIFF
--- a/adapter/sqs_throttle_integration_test.go
+++ b/adapter/sqs_throttle_integration_test.go
@@ -325,9 +325,22 @@ func TestSQSServer_Throttle_NoOpSetQueueAttributesPreservesBucket(t *testing.T) 
 	node := sqsLeaderNode(t, nodes)
 
 	url := mustCreateQueue(t, node, "throttle-noop-set")
+	// Refill rate is intentionally slow (0.01/sec = 1 token per
+	// 100 seconds) so the test's wall-clock window between drain
+	// and the post-no-op send cannot accumulate to a whole token.
+	// At 1/sec the test raced its own refill on slow CI runners:
+	// 10 drain sends + sanity send + SetQueueAttributes (each
+	// going through Raft propose+apply at ~100-250ms under -race)
+	// elapses ~1.5-2.5s before the post-no-op send fires, by which
+	// time the bucket has refilled 1+ tokens and the send returns
+	// 200 instead of the expected 400. The test's intent — verify
+	// that a no-op SetQueueAttributes does not reset the bucket —
+	// is independent of the refill rate, so slowing it down is
+	// the right scope.
+	const slowRefill = "0.01"
 	mustSetQueueAttributes(t, node, url, map[string]string{
 		"ThrottleSendCapacity":        "10",
-		"ThrottleSendRefillPerSecond": "1",
+		"ThrottleSendRefillPerSecond": slowRefill,
 	})
 	// Drain the bucket so the next charge would only succeed if the
 	// bucket was reset to a fresh full-capacity replacement.
@@ -351,7 +364,7 @@ func TestSQSServer_Throttle_NoOpSetQueueAttributesPreservesBucket(t *testing.T) 
 	// a fresh full bucket.
 	mustSetQueueAttributes(t, node, url, map[string]string{
 		"ThrottleSendCapacity":        "10",
-		"ThrottleSendRefillPerSecond": "1",
+		"ThrottleSendRefillPerSecond": slowRefill,
 	})
 	// Bucket must still be drained — no-op SetQueueAttributes must not
 	// reset the rate limiter.

--- a/adapter/sqs_throttle_integration_test.go
+++ b/adapter/sqs_throttle_integration_test.go
@@ -338,10 +338,16 @@ func TestSQSServer_Throttle_NoOpSetQueueAttributesPreservesBucket(t *testing.T) 
 	// is independent of the refill rate, so slowing it down is
 	// the right scope.
 	const slowRefill = "0.01"
-	mustSetQueueAttributes(t, node, url, map[string]string{
+	// Define the attribute map once and reuse on both calls so the
+	// "no-op" intent is structurally visible: the two
+	// mustSetQueueAttributes calls share the same map literal, so
+	// a future drift between them (e.g., a typo or a stray edit)
+	// would be obviously wrong (Gemini medium on PR #819).
+	throttleAttrs := map[string]string{
 		"ThrottleSendCapacity":        "10",
 		"ThrottleSendRefillPerSecond": slowRefill,
-	})
+	}
+	mustSetQueueAttributes(t, node, url, throttleAttrs)
 	// Drain the bucket so the next charge would only succeed if the
 	// bucket was reset to a fresh full-capacity replacement.
 	for range 10 {
@@ -362,10 +368,7 @@ func TestSQSServer_Throttle_NoOpSetQueueAttributesPreservesBucket(t *testing.T) 
 	// Re-submit identical Throttle* values. Old code invalidated on
 	// key presence and the next send would have been allowed against
 	// a fresh full bucket.
-	mustSetQueueAttributes(t, node, url, map[string]string{
-		"ThrottleSendCapacity":        "10",
-		"ThrottleSendRefillPerSecond": slowRefill,
-	})
+	mustSetQueueAttributes(t, node, url, throttleAttrs)
 	// Bucket must still be drained — no-op SetQueueAttributes must not
 	// reset the rate limiter.
 	status, _ = callSQS(t, node, sqsSendMessageTarget, map[string]any{


### PR DESCRIPTION
## Summary

Fixes the recurring `TestSQSServer_Throttle_NoOpSetQueueAttributesPreservesBucket` CI flake that has been hitting the same admin PR series (#813, #815, #816) that #818 just unblocked.

## Root cause

The test sequence:

1. `SetQueueAttributes` (capacity=10, refill=1/sec)
2. **10 drain sends** (drain the bucket)
3. Sanity-check send → expects 400 (drained)
4. `SetQueueAttributes` with identical values (no-op)
5. **Post-no-op send → expects 400** ← intermittently returns 200

Each step goes through a real Raft propose+apply. Under `-race` on slow CI runners each round-trip takes 100–250ms. Total wall-clock from start to step 5 reaches 1.5–2.5s. At **1 token/sec** refill, by step 5 the bucket has accumulated 1+ tokens and the send returns 200 — falsely indicating a no-op-invalidate-bypass regression.

The test's intent — verify that a no-op `SetQueueAttributes` does not reset bucket state — is independent of the refill rate. Slowing the refill removes the race without changing what's tested.

## Fix

`refill 1/sec → 0.01/sec` (1 token per 100s). Even a 10s test window can't accumulate to a whole token.

The throttle config validator (`adapter/sqs_catalog.go:163` `SendRefillPerSecond float64`) accepts fractional values. `0.01 != 0` so `IsEmpty` returns false and the throttle path is still exercised — only the refill cadence changes.

## Self-review (5 passes)

1. **Data loss** — none; test-only constant.
2. **Concurrency** — closes a wall-clock vs. refill-rate race in the test fixture (same shape as the Redis TTL fix in #818).
3. **Performance** — no runtime change; the test still completes in ~1–2s.
4. **Consistency** — the test still verifies the no-op-preserves-bucket invariant identically. The refill rate isn't load-bearing for the assertion.
5. **Test coverage** — unchanged. Same drain → sanity → no-op → recheck sequence; only the refill cadence differs.

## Test plan

- [x] `go test -race -count=2 -timeout=120s -run TestSQSServer_Throttle_NoOpSetQueueAttributesPreservesBucket ./adapter/` — passes both (2.1s)
- [x] `golangci-lint --config=.golangci.yaml run` — clean
- [ ] CI

## Context

Second flake-fix PR today (after #818 for Redis TTL). The admin PR series (#813, #815, #816) keeps hitting unrelated adapter-package flakes because the admin code lives in `internal/admin/` / `web/admin/` but `go test ./...` runs the whole tree. Each fix is small and scoped.
