### PR TITLE
feat(keyviz): fan-out §9.1 (group, term) dedupe (Phase 2-C+ PR-3c)

### DIFF
--- a/internal/admin/keyviz_fanout.go
+++ b/internal/admin/keyviz_fanout.go
@@ -466,8 +466,24 @@ func buildKeyVizPeerURL(peer string, params keyVizParams) (string, error) {
 // mergeKeyVizMatrices combines per-node matrices into one. The merge
 // is column-wise on column_unix_ms (a column missing from a node
 // contributes 0 for every row); per-row keying is by BucketID. The
-// rule selector follows the requested series — reads sum, writes
-// max with conflict surfacing — per design 4.
+// rule selector follows the requested series:
+//
+//   - Reads / read_bytes: sum across nodes (independent local serves).
+//     Never raise the conflict flag.
+//   - Writes / write_bytes: §9.1 canonical merge — collapse to one
+//     value per (BucketID, RaftGroupID, LeaderTerm, column) by taking
+//     max within the same (group, term) (canonical Raft invariant:
+//     at most one leader per term per group), then SUM across
+//     distinct LeaderTerm values for the same (group, column).
+//     Surface conflict=true at the row level when ≥2 sources
+//     disagree within the SAME (group, term, column). Fall back to
+//     legacy max-merge (§4.2) for any cell where at least one source
+//     reports a zero/unknown identity (RaftGroupID=0 or
+//     LeaderTerm=0) so a legacy peer that doesn't yet emit the
+//     parallel-array wire fields never over-counts. Phase 2-C+ PR-3c
+//     promotes §4.2's row-level max to §9.1's per-cell (group, term)
+//     algorithm — see parent design `docs/admin_ui_key_visualizer_-
+//     design.md` §9.1.
 func mergeKeyVizMatrices(matrices []KeyVizMatrix, series KeyVizSeries) KeyVizMatrix {
 	if len(matrices) == 0 {
 		return KeyVizMatrix{Series: series}
@@ -482,59 +498,115 @@ func mergeKeyVizMatrices(matrices []KeyVizMatrix, series KeyVizSeries) KeyVizMat
 	for i, ts := range columns {
 		indexByColumn[ts] = i
 	}
-	rowsByBucket := make(map[string]*KeyVizRow, keyVizMergeBucketHint)
+	useGroupTermDedupe := mergeUsesGroupTermDedupe(series)
+	accByBucket := make(map[string]*rowMergeAcc, keyVizMergeBucketHint)
 	bucketOrder := make([]string, 0, keyVizMergeBucketHint)
-	mergeFn := mergeFnFor(series)
 	for mi := range matrices {
 		m := &matrices[mi]
 		for ri := range m.Rows {
-			mergeRowInto(&m.Rows[ri], m.ColumnUnixMs, indexByColumn, rowsByBucket, &bucketOrder, len(columns), mergeFn)
+			mergeRowInto(&m.Rows[ri], m.ColumnUnixMs, indexByColumn, accByBucket, &bucketOrder, len(columns), useGroupTermDedupe)
 		}
 	}
 	out := KeyVizMatrix{
 		ColumnUnixMs: columns,
 		Series:       series,
-		Rows:         make([]KeyVizRow, 0, len(rowsByBucket)),
+		Rows:         make([]KeyVizRow, 0, len(accByBucket)),
 	}
 	for _, bucket := range bucketOrder {
-		out.Rows = append(out.Rows, *rowsByBucket[bucket])
+		out.Rows = append(out.Rows, resolveRowMergeAcc(accByBucket[bucket], useGroupTermDedupe))
 	}
 	return out
 }
 
-// mergeRowInto folds one source row into the merge accumulator. Split
-// out of mergeKeyVizMatrices to keep that function under the cyclop
-// budget (and so this body — the part that actually does the merge
-// per-cell — has its own contained set of branches).
+// rowMergeAcc is the per-bucket accumulator state populated by all
+// source rows that share a BucketID. Per-cell merge state lives in
+// `cells`; row-level metadata (Start, End, Aggregate, …) is captured
+// from the first-seen source.
+type rowMergeAcc struct {
+	bucketID          string
+	start, end        []byte
+	aggregate         bool
+	routeIDs          []uint64
+	routeIDsTruncated bool
+	routeCount        uint64
+	cells             []cellMergeAcc
+}
+
+// cellMergeAcc tracks merge state for one (bucket, column) cell.
+// For reads: only `sum` and the last-seen identity matter.
+// For writes: `byTerm` maps (group, term) to the canonical (max)
+// value reported by any source; `termConflict` records which keys
+// saw disagreement. `hasUnknownTerm` forces the fallback max-merge
+// path at resolve time so a legacy peer (or a node whose
+// SetLeaderTerm publisher has not fired) never causes the per-term
+// sum to over-count.
+type cellMergeAcc struct {
+	// Read path (sumMerge): running sum across all sources.
+	sum uint64
+	// Read path identity: last non-zero contributor's (group, term).
+	// Best-effort, matching the round-1/round-2 PR-3b documented
+	// "last-touched" semantics for reads. For writes the resolved
+	// identity comes from `byTerm` largest value at resolve time.
+	lastGroup, lastTerm uint64
+
+	// Write path (group-term dedupe + sum across terms):
+	byTerm         map[termKey]uint64
+	termConflict   map[termKey]bool
+	hasUnknownTerm bool
+	// Fallback max-merge state, used when hasUnknownTerm is true.
+	// Tracks the maximum value seen and whether two non-zero
+	// distinct values were ever observed at this cell.
+	fallbackMax              uint64
+	fallbackNonZeroDistinct  bool
+	fallbackSeenNonZeroValue uint64
+}
+
+type termKey struct {
+	group uint64
+	term  uint64
+}
+
+// mergeUsesGroupTermDedupe gates the §9.1 (group, term) algorithm.
+// Writes use it; reads stay on the legacy sum-across-nodes path
+// because local serves are independent and never need per-leader
+// dedupe.
+func mergeUsesGroupTermDedupe(series KeyVizSeries) bool {
+	switch series {
+	case keyVizSeriesWrites, keyVizSeriesWriteBytes:
+		return true
+	case keyVizSeriesReads, keyVizSeriesReadBytes:
+		return false
+	default:
+		return false
+	}
+}
+
+// mergeRowInto folds one source row into the per-bucket accumulator.
+// Phase 2-C+ PR-3c: per-cell state is accumulated here, but the
+// resolution (sum across (group, term); fallback to max) happens
+// after all sources have been seen — see resolveRowMergeAcc.
 func mergeRowInto(
 	row *KeyVizRow,
 	srcColumns []int64,
 	indexByColumn map[int64]int,
-	rowsByBucket map[string]*KeyVizRow,
+	accByBucket map[string]*rowMergeAcc,
 	bucketOrder *[]string,
 	mergedWidth int,
-	mergeFn mergeCellFn,
+	useGroupTermDedupe bool,
 ) {
-	dst, ok := rowsByBucket[row.BucketID]
+	acc, ok := accByBucket[row.BucketID]
 	if !ok {
-		dst = &KeyVizRow{
-			BucketID:          row.BucketID,
-			Start:             append([]byte(nil), row.Start...),
-			End:               append([]byte(nil), row.End...),
-			Aggregate:         row.Aggregate,
-			RouteIDs:          append([]uint64(nil), row.RouteIDs...),
-			RouteIDsTruncated: row.RouteIDsTruncated,
-			RouteCount:        row.RouteCount,
-			Values:            make([]uint64, mergedWidth),
-			// Per-cell parallel arrays sized to the merged column
-			// width. Stamped per-cell in the loop below from the
-			// largest-source for that cell, so the identity always
-			// matches the value we kept (Gemini MEDIUM on PR #720
-			// resolved by going per-cell).
-			RaftGroupIDs: make([]uint64, mergedWidth),
-			LeaderTerms:  make([]uint64, mergedWidth),
+		acc = &rowMergeAcc{
+			bucketID:          row.BucketID,
+			start:             append([]byte(nil), row.Start...),
+			end:               append([]byte(nil), row.End...),
+			aggregate:         row.Aggregate,
+			routeIDs:          append([]uint64(nil), row.RouteIDs...),
+			routeIDsTruncated: row.RouteIDsTruncated,
+			routeCount:        row.RouteCount,
+			cells:             make([]cellMergeAcc, mergedWidth),
 		}
-		rowsByBucket[row.BucketID] = dst
+		accByBucket[row.BucketID] = acc
 		*bucketOrder = append(*bucketOrder, row.BucketID)
 	}
 	for j, ts := range srcColumns {
@@ -542,89 +614,170 @@ func mergeRowInto(
 		if !ok || j >= len(row.Values) {
 			continue
 		}
-		prev := dst.Values[idx]
-		next, conflict := mergeFn(prev, row.Values[j])
-		dst.Values[idx] = next
-		if conflict {
-			dst.Conflict = true
+		value := row.Values[j]
+		var group, term uint64
+		if j < len(row.RaftGroupIDs) {
+			group = row.RaftGroupIDs[j]
 		}
-		// Identity belongs to the source whose value we kept. For
-		// sumMerge (reads) this is best-effort: prev+incoming has
-		// no single owner, so we keep whichever side contributed
-		// most recently — close-to-correct in the steady state.
-		// For maxMerge (writes), `next == row.Values[j]` exactly
-		// when the incoming source won the cell; in the tied
-		// (prev == incoming != 0) case `next == prev`, both sides
-		// agree on the value, and either identity is acceptable.
-		if next == row.Values[j] {
-			// Mixed-version cluster: a legacy peer that does not
-			// emit raft_group_ids / leader_terms sends empty
-			// slices. When such a peer's value wins the cell, we
-			// must EXPLICITLY RESET dst.RaftGroupIDs[idx] /
-			// dst.LeaderTerms[idx] to 0 (the documented "term not
-			// tracked" sentinel) — leaving stale identity from a
-			// previous higher-versioned source would mislabel an
-			// unknown-term winning cell as a known term and break
-			// the per-cell dedupe/summing in PR-3c. (Codex P2
-			// round-2 on PR #720.)
-			if j < len(row.RaftGroupIDs) {
-				dst.RaftGroupIDs[idx] = row.RaftGroupIDs[j]
-			} else {
-				dst.RaftGroupIDs[idx] = 0
-			}
-			if j < len(row.LeaderTerms) {
-				dst.LeaderTerms[idx] = row.LeaderTerms[j]
-			} else {
-				dst.LeaderTerms[idx] = 0
-			}
+		if j < len(row.LeaderTerms) {
+			term = row.LeaderTerms[j]
+		}
+		if useGroupTermDedupe {
+			acc.cells[idx].addWrite(value, group, term)
+		} else {
+			acc.cells[idx].addRead(value, group, term)
 		}
 	}
 }
 
-// mergeCellFn returns the merged value plus a conflict flag.
-//
-//   - Reads (and read_bytes) sum across nodes and never raise the
-//     conflict flag — distinct local serves are independent counts.
-//   - Writes (and write_bytes) take the max across nodes and raise
-//     conflict when the inputs disagree (both non-zero with
-//     different values, or one zero and one non-zero would NOT be a
-//     conflict — that is the steady-state shape).
-type mergeCellFn func(prev, incoming uint64) (uint64, bool)
-
-func mergeFnFor(series KeyVizSeries) mergeCellFn {
-	switch series {
-	case keyVizSeriesReads, keyVizSeriesReadBytes:
-		return sumMerge
-	case keyVizSeriesWrites, keyVizSeriesWriteBytes:
-		return maxMerge
-	default:
-		return sumMerge
+// addRead is the sumMerge path: independent local serves accumulate
+// across all sources. Identity is best-effort last-touched.
+func (c *cellMergeAcc) addRead(value, group, term uint64) {
+	c.sum += value
+	if value > 0 {
+		c.lastGroup = group
+		c.lastTerm = term
 	}
 }
 
-func sumMerge(prev, incoming uint64) (uint64, bool) {
-	return prev + incoming, false
+// addWrite is the §9.1 path: track (group, term) buckets and
+// fallback-max state. Zero-valued contributions are ignored
+// (legacy max-merge treats `(prev, 0)` as no-op, matching §4.2).
+func (c *cellMergeAcc) addWrite(value, group, term uint64) {
+	if value == 0 {
+		return
+	}
+	c.updateFallbackState(value)
+	// LeaderTerm == 0 (or group == 0) means "term not tracked" —
+	// the documented sentinel from a legacy peer or a publisher
+	// that has not yet fired. We CANNOT safely sum across an
+	// unknown-term contribution because the unknown-term might
+	// overlap with a known-term entry; fall back to max-merge for
+	// the whole cell at resolve time.
+	if term == 0 || group == 0 {
+		c.hasUnknownTerm = true
+		return
+	}
+	c.recordTermContribution(termKey{group: group, term: term}, value)
 }
 
-// maxMerge pairs the §4.2 description: pick the larger value, raise
-// conflict when both inputs are non-zero AND disagree. Stable
-// leadership produces (0, X) or (X, 0) which collapse to X without
-// raising conflict; a leadership flip produces (X, Y) with both > 0
-// and the SPA hatches the row.
-func maxMerge(prev, incoming uint64) (uint64, bool) {
-	if prev == 0 {
-		return incoming, false
+// updateFallbackState advances the fallback-max accounting that
+// applies when hasUnknownTerm is set at resolve time. Maintained for
+// every non-zero contribution so a cell that later flips into the
+// fallback path has the correct running max + disagreement signal.
+func (c *cellMergeAcc) updateFallbackState(value uint64) {
+	if value > c.fallbackMax {
+		c.fallbackMax = value
 	}
-	if incoming == 0 {
-		return prev, false
+	if c.fallbackSeenNonZeroValue == 0 {
+		c.fallbackSeenNonZeroValue = value
+		return
 	}
-	if prev == incoming {
-		return prev, false
+	if c.fallbackSeenNonZeroValue != value {
+		c.fallbackNonZeroDistinct = true
 	}
-	if prev > incoming {
-		return prev, true
+}
+
+// recordTermContribution folds one (group, term) contribution into
+// the canonical byTerm map, flipping termConflict when ≥2 sources
+// disagree within the same key (a Raft invariant violation — at
+// most one leader per term per group).
+func (c *cellMergeAcc) recordTermContribution(key termKey, value uint64) {
+	if c.byTerm == nil {
+		c.byTerm = make(map[termKey]uint64, 1)
 	}
-	return incoming, true
+	existing, exists := c.byTerm[key]
+	if !exists {
+		c.byTerm[key] = value
+		return
+	}
+	if existing == value {
+		return // canonical agreement, no-op
+	}
+	if c.termConflict == nil {
+		c.termConflict = make(map[termKey]bool, 1)
+	}
+	c.termConflict[key] = true
+	if value > existing {
+		c.byTerm[key] = value
+	}
+}
+
+// resolveRowMergeAcc materialises a KeyVizRow from the accumulator.
+// For reads: cell.sum + last identity. For writes: either §9.1 sum
+// across (group, term) or fallback max-merge when hasUnknownTerm.
+// Sets row-level Conflict to any-cell-saw-conflict — Phase 2-C+
+// PR-3c keeps the wire-level conflict at row granularity; future
+// PR-3d may promote it to per-cell.
+func resolveRowMergeAcc(acc *rowMergeAcc, useGroupTermDedupe bool) KeyVizRow {
+	width := len(acc.cells)
+	row := KeyVizRow{
+		BucketID:          acc.bucketID,
+		Start:             acc.start,
+		End:               acc.end,
+		Aggregate:         acc.aggregate,
+		RouteIDs:          acc.routeIDs,
+		RouteIDsTruncated: acc.routeIDsTruncated,
+		RouteCount:        acc.routeCount,
+		Values:            make([]uint64, width),
+		RaftGroupIDs:      make([]uint64, width),
+		LeaderTerms:       make([]uint64, width),
+	}
+	for j := range acc.cells {
+		c := &acc.cells[j]
+		if useGroupTermDedupe {
+			row.Values[j], row.RaftGroupIDs[j], row.LeaderTerms[j] = c.resolveWrite()
+			if c.hasConflict() {
+				row.Conflict = true
+			}
+		} else {
+			row.Values[j] = c.sum
+			row.RaftGroupIDs[j] = c.lastGroup
+			row.LeaderTerms[j] = c.lastTerm
+		}
+	}
+	return row
+}
+
+// resolveWrite returns the canonical cell value plus the (group, term)
+// owner of the largest contribution. Falls back to max-merge when
+// hasUnknownTerm is set so a legacy peer never causes summing
+// across overlapping unknown/known windows.
+func (c *cellMergeAcc) resolveWrite() (value, group, term uint64) {
+	if c.hasUnknownTerm {
+		// Fallback: max-merge across all contributions; the only
+		// identity we have for the fallback path is the
+		// last-touched group/term (which may be 0 if every
+		// contribution was unknown), which matches the legacy
+		// §4.2 / PR-3b behavior the sentinel was designed to
+		// preserve.
+		return c.fallbackMax, c.lastGroup, c.lastTerm
+	}
+	var sum, largestValue, largestGroup, largestTerm uint64
+	for k, v := range c.byTerm {
+		sum += v
+		if v > largestValue {
+			largestValue = v
+			largestGroup = k.group
+			largestTerm = k.term
+		}
+	}
+	return sum, largestGroup, largestTerm
+}
+
+// hasConflict returns true when any (group, term) at this cell saw
+// disagreement, or — under the fallback path — when ≥2 distinct
+// non-zero values were reported.
+func (c *cellMergeAcc) hasConflict() bool {
+	if c.hasUnknownTerm {
+		return c.fallbackNonZeroDistinct
+	}
+	for k := range c.termConflict {
+		if c.termConflict[k] {
+			return true
+		}
+	}
+	return false
 }
 
 // unionColumns returns the sorted union of column timestamps across

--- a/internal/admin/keyviz_fanout.go
+++ b/internal/admin/keyviz_fanout.go
@@ -544,9 +544,11 @@ type cellMergeAcc struct {
 	// Read path (sumMerge): running sum across all sources.
 	sum uint64
 	// Read path identity: last non-zero contributor's (group, term).
-	// Best-effort, matching the round-1/round-2 PR-3b documented
-	// "last-touched" semantics for reads. For writes the resolved
-	// identity comes from `byTerm` largest value at resolve time.
+	// Best-effort "last-touched" semantics for reads (the read
+	// merge has no single owner — prev+incoming is a sum, so we
+	// pick whichever side contributed most recently). For writes
+	// the resolved identity comes from `byTerm` largest value at
+	// resolve time.
 	lastGroup, lastTerm uint64
 
 	// Write path (group-term dedupe + sum across terms):
@@ -670,8 +672,7 @@ func (c *cellMergeAcc) addWrite(value, group, term uint64) {
 // equal contributions keeps the most recently processed identity.
 // Without the identity tracking, a cell with one known-term source
 // + one unknown-term source would always fall back to (0, 0) even
-// when the known-term source supplied the winning max (Gemini HIGH
-// + Codex P2 on PR #822).
+// when the known-term source supplied the winning max.
 func (c *cellMergeAcc) updateFallbackState(value, group, term uint64) {
 	if value >= c.fallbackMax {
 		c.fallbackMax = value
@@ -755,12 +756,12 @@ func resolveRowMergeAcc(acc *rowMergeAcc, useGroupTermDedupe bool) KeyVizRow {
 func (c *cellMergeAcc) resolveWrite() (value, group, term uint64) {
 	if c.hasUnknownTerm {
 		// Fallback: max-merge across all contributions. Identity
-		// is from the contributor that supplied fallbackMax (round-1
-		// fix on PR #822 — updateFallbackState now stamps
-		// lastGroup/lastTerm when value >= fallbackMax). Identity
-		// is (0, 0) only when every contribution was unknown-term
-		// or when an unknown-term source supplied the largest value.
-		// Matches the legacy §4.2 / PR-3b behavior the sentinel
+		// comes from the contributor that supplied fallbackMax
+		// (updateFallbackState stamps lastGroup/lastTerm when
+		// value >= fallbackMax). Identity is (0, 0) only when
+		// every contribution was unknown-term or when an
+		// unknown-term source supplied the largest value.
+		// Matches the legacy §4.2 max-merge behavior the sentinel
 		// was designed to preserve.
 		return c.fallbackMax, c.lastGroup, c.lastTerm
 	}
@@ -780,8 +781,8 @@ func (c *cellMergeAcc) resolveWrite() (value, group, term uint64) {
 // disagreement, or — under the fallback path — when ≥2 distinct
 // non-zero values were reported. recordTermContribution only ever
 // stores `true` in termConflict (entries are never reset), so a
-// length check is equivalent to scanning the map (Gemini MEDIUM
-// on PR #822).
+// length check is equivalent to scanning the map and avoids the
+// O(N) walk.
 func (c *cellMergeAcc) hasConflict() bool {
 	if c.hasUnknownTerm {
 		return c.fallbackNonZeroDistinct

--- a/internal/admin/keyviz_fanout.go
+++ b/internal/admin/keyviz_fanout.go
@@ -754,12 +754,14 @@ func resolveRowMergeAcc(acc *rowMergeAcc, useGroupTermDedupe bool) KeyVizRow {
 // across overlapping unknown/known windows.
 func (c *cellMergeAcc) resolveWrite() (value, group, term uint64) {
 	if c.hasUnknownTerm {
-		// Fallback: max-merge across all contributions; the only
-		// identity we have for the fallback path is the
-		// last-touched group/term (which may be 0 if every
-		// contribution was unknown), which matches the legacy
-		// §4.2 / PR-3b behavior the sentinel was designed to
-		// preserve.
+		// Fallback: max-merge across all contributions. Identity
+		// is from the contributor that supplied fallbackMax (round-1
+		// fix on PR #822 — updateFallbackState now stamps
+		// lastGroup/lastTerm when value >= fallbackMax). Identity
+		// is (0, 0) only when every contribution was unknown-term
+		// or when an unknown-term source supplied the largest value.
+		// Matches the legacy §4.2 / PR-3b behavior the sentinel
+		// was designed to preserve.
 		return c.fallbackMax, c.lastGroup, c.lastTerm
 	}
 	var sum, largestValue, largestGroup, largestTerm uint64

--- a/internal/admin/keyviz_fanout.go
+++ b/internal/admin/keyviz_fanout.go
@@ -647,7 +647,7 @@ func (c *cellMergeAcc) addWrite(value, group, term uint64) {
 	if value == 0 {
 		return
 	}
-	c.updateFallbackState(value)
+	c.updateFallbackState(value, group, term)
 	// LeaderTerm == 0 (or group == 0) means "term not tracked" —
 	// the documented sentinel from a legacy peer or a publisher
 	// that has not yet fired. We CANNOT safely sum across an
@@ -664,10 +664,19 @@ func (c *cellMergeAcc) addWrite(value, group, term uint64) {
 // updateFallbackState advances the fallback-max accounting that
 // applies when hasUnknownTerm is set at resolve time. Maintained for
 // every non-zero contribution so a cell that later flips into the
-// fallback path has the correct running max + disagreement signal.
-func (c *cellMergeAcc) updateFallbackState(value uint64) {
-	if value > c.fallbackMax {
+// fallback path has the correct running max + disagreement signal
+// AND the identity of the contributor that supplied the max value.
+// Tie-break is last-touched (matching addRead) so a cell with two
+// equal contributions keeps the most recently processed identity.
+// Without the identity tracking, a cell with one known-term source
+// + one unknown-term source would always fall back to (0, 0) even
+// when the known-term source supplied the winning max (Gemini HIGH
+// + Codex P2 on PR #822).
+func (c *cellMergeAcc) updateFallbackState(value, group, term uint64) {
+	if value >= c.fallbackMax {
 		c.fallbackMax = value
+		c.lastGroup = group
+		c.lastTerm = term
 	}
 	if c.fallbackSeenNonZeroValue == 0 {
 		c.fallbackSeenNonZeroValue = value
@@ -767,17 +776,15 @@ func (c *cellMergeAcc) resolveWrite() (value, group, term uint64) {
 
 // hasConflict returns true when any (group, term) at this cell saw
 // disagreement, or — under the fallback path — when ≥2 distinct
-// non-zero values were reported.
+// non-zero values were reported. recordTermContribution only ever
+// stores `true` in termConflict (entries are never reset), so a
+// length check is equivalent to scanning the map (Gemini MEDIUM
+// on PR #822).
 func (c *cellMergeAcc) hasConflict() bool {
 	if c.hasUnknownTerm {
 		return c.fallbackNonZeroDistinct
 	}
-	for k := range c.termConflict {
-		if c.termConflict[k] {
-			return true
-		}
-	}
-	return false
+	return len(c.termConflict) > 0
 }
 
 // unionColumns returns the sorted union of column timestamps across

--- a/internal/admin/keyviz_fanout_test.go
+++ b/internal/admin/keyviz_fanout_test.go
@@ -236,6 +236,46 @@ func TestMergeKeyVizMatricesGroupTermFallbackOnUnknownTerm(t *testing.T) {
 	require.True(t, merged.Rows[0].Conflict, "fallback path raises conflict when ≥2 distinct non-zero values were seen")
 }
 
+// TestMergeKeyVizMatricesFallbackPreservesKnownTermWinnerIdentity
+// pins the Gemini HIGH / Codex P2 fix on PR #822: when the
+// fallback path is triggered by an unknown-term contribution but
+// the KNOWN-term source supplies the winning max value, the
+// merged identity must reflect that known-term contributor —
+// NOT fall back to (0, 0). Mirror image of
+// TestMergeKeyVizMatricesGroupTermFallbackOnUnknownTerm where the
+// legacy peer wins; this test pins the case the prior PR-3c diff
+// regressed (identity was always 0 under fallback regardless of
+// who won).
+func TestMergeKeyVizMatricesFallbackPreservesKnownTermWinnerIdentity(t *testing.T) {
+	t.Parallel()
+	col := []int64{1_700_000_000_000}
+	// Modern source wins with 100.
+	modern := KeyVizMatrix{
+		ColumnUnixMs: col,
+		Series:       keyVizSeriesWrites,
+		Rows: []KeyVizRow{
+			{BucketID: "route:9", Values: []uint64{100}, RaftGroupIDs: []uint64{7}, LeaderTerms: []uint64{42}},
+		},
+	}
+	// Legacy peer reports 50 with no arrays — triggers fallback but
+	// loses the max.
+	legacy := KeyVizMatrix{
+		ColumnUnixMs: col,
+		Series:       keyVizSeriesWrites,
+		Rows: []KeyVizRow{
+			{BucketID: "route:9", Values: []uint64{50}},
+		},
+	}
+	merged := mergeKeyVizMatrices([]KeyVizMatrix{modern, legacy}, keyVizSeriesWrites)
+	require.Len(t, merged.Rows, 1)
+	require.Equal(t, []uint64{100}, merged.Rows[0].Values, "fallback max-merge keeps the larger value")
+	require.Equal(t, []uint64{7}, merged.Rows[0].RaftGroupIDs,
+		"identity must reflect the known-term contributor that supplied the winning max — not (0, 0)")
+	require.Equal(t, []uint64{42}, merged.Rows[0].LeaderTerms,
+		"same: known-term contributor's term wins because its value won the fallback max")
+	require.True(t, merged.Rows[0].Conflict, "100 != 50 disagreement raises the conflict flag under fallback")
+}
+
 // TestMergeKeyVizMatricesPerCellIdentityMatchesValueOwner pins the
 // Gemini MEDIUM fix: when maxMerge picks a value from one source,
 // the identity at that cell must come from the SAME source — not

--- a/internal/admin/keyviz_fanout_test.go
+++ b/internal/admin/keyviz_fanout_test.go
@@ -141,6 +141,101 @@ func TestMergeKeyVizMatricesLegacyPeerWinnerResetsIdentity(t *testing.T) {
 		"legacy winner without metadata must reset dst term to 0 sentinel — not inherit modern's 42")
 }
 
+// TestMergeKeyVizMatricesGroupTermSumAcrossTerms pins the Phase 2-C+
+// PR-3c canonical §9.1 algorithm: when two sources report non-zero
+// writes for the SAME (bucket, column) but DIFFERENT terms within
+// the same group, the merged cell SUMS the two values (each leader
+// only observes its own term's writes). Compare to PR-3b's §4.2
+// max-merge, which would have returned 50 and lost the ex-leader's
+// pre-transfer 30 → an undercount of the true window total.
+func TestMergeKeyVizMatricesGroupTermSumAcrossTerms(t *testing.T) {
+	t.Parallel()
+	col := []int64{1_700_000_000_000}
+	exLeader := KeyVizMatrix{
+		ColumnUnixMs: col,
+		Series:       keyVizSeriesWrites,
+		Rows: []KeyVizRow{
+			{BucketID: "route:9", Values: []uint64{30}, RaftGroupIDs: []uint64{7}, LeaderTerms: []uint64{42}},
+		},
+	}
+	newLeader := KeyVizMatrix{
+		ColumnUnixMs: col,
+		Series:       keyVizSeriesWrites,
+		Rows: []KeyVizRow{
+			{BucketID: "route:9", Values: []uint64{50}, RaftGroupIDs: []uint64{7}, LeaderTerms: []uint64{43}},
+		},
+	}
+	merged := mergeKeyVizMatrices([]KeyVizMatrix{exLeader, newLeader}, keyVizSeriesWrites)
+	require.Len(t, merged.Rows, 1)
+	require.Equal(t, []uint64{80}, merged.Rows[0].Values,
+		"§9.1: distinct (group, term) entries for the same cell must SUM, not max — ex-leader's 30 + new-leader's 50 = 80, recovering the pre-transfer slice the §4.2 max-merge would have lost")
+	require.False(t, merged.Rows[0].Conflict,
+		"distinct (group, term) entries are not a conflict — each leader is reporting its own term's writes")
+	// Identity: the larger term's value wins the per-cell identity slot.
+	require.Equal(t, []uint64{7}, merged.Rows[0].RaftGroupIDs)
+	require.Equal(t, []uint64{43}, merged.Rows[0].LeaderTerms, "new-leader (term=43, value=50) wins the identity slot because 50 > 30")
+}
+
+// TestMergeKeyVizMatricesGroupTermConflictWithinSameTerm pins the
+// §9.1 conflict predicate: two sources reporting DIFFERENT non-zero
+// values for the SAME (bucket, group, term, column) tuple is a Raft
+// invariant violation (at most one leader per term per group). The
+// merger keeps the larger value AND surfaces conflict=true.
+func TestMergeKeyVizMatricesGroupTermConflictWithinSameTerm(t *testing.T) {
+	t.Parallel()
+	col := []int64{1_700_000_000_000}
+	a := KeyVizMatrix{
+		ColumnUnixMs: col,
+		Series:       keyVizSeriesWrites,
+		Rows: []KeyVizRow{
+			{BucketID: "route:9", Values: []uint64{30}, RaftGroupIDs: []uint64{7}, LeaderTerms: []uint64{42}},
+		},
+	}
+	b := KeyVizMatrix{
+		ColumnUnixMs: col,
+		Series:       keyVizSeriesWrites,
+		Rows: []KeyVizRow{
+			{BucketID: "route:9", Values: []uint64{55}, RaftGroupIDs: []uint64{7}, LeaderTerms: []uint64{42}},
+		},
+	}
+	merged := mergeKeyVizMatrices([]KeyVizMatrix{a, b}, keyVizSeriesWrites)
+	require.Len(t, merged.Rows, 1)
+	require.Equal(t, []uint64{55}, merged.Rows[0].Values, "within-term disagreement keeps the larger value")
+	require.True(t, merged.Rows[0].Conflict,
+		"§9.1: within-(group, term) disagreement must raise the conflict flag — Raft invariant says one leader per term per group, so disagreement signals a real divergence operators need to see")
+}
+
+// TestMergeKeyVizMatricesGroupTermFallbackOnUnknownTerm pins the
+// fail-closed fallback to §4.2 max-merge when ANY source contributes
+// an unknown identity (group=0 or term=0). A modern source reporting
+// 30 with (group=7, term=42) and a legacy source reporting 50 with
+// no metadata must NOT sum to 80 — the legacy source's term might
+// overlap with the modern source's term, so summing would
+// over-count. The fallback returns max=50.
+func TestMergeKeyVizMatricesGroupTermFallbackOnUnknownTerm(t *testing.T) {
+	t.Parallel()
+	col := []int64{1_700_000_000_000}
+	modern := KeyVizMatrix{
+		ColumnUnixMs: col,
+		Series:       keyVizSeriesWrites,
+		Rows: []KeyVizRow{
+			{BucketID: "route:9", Values: []uint64{30}, RaftGroupIDs: []uint64{7}, LeaderTerms: []uint64{42}},
+		},
+	}
+	legacy := KeyVizMatrix{
+		ColumnUnixMs: col,
+		Series:       keyVizSeriesWrites,
+		Rows: []KeyVizRow{
+			{BucketID: "route:9", Values: []uint64{50}}, // no arrays — pre-PR-3b peer
+		},
+	}
+	merged := mergeKeyVizMatrices([]KeyVizMatrix{modern, legacy}, keyVizSeriesWrites)
+	require.Len(t, merged.Rows, 1)
+	require.Equal(t, []uint64{50}, merged.Rows[0].Values,
+		"unknown-term fallback returns max-merge (50), not sum (80) — summing across an unknown term risks double-counting overlapping windows")
+	require.True(t, merged.Rows[0].Conflict, "fallback path raises conflict when ≥2 distinct non-zero values were seen")
+}
+
 // TestMergeKeyVizMatricesPerCellIdentityMatchesValueOwner pins the
 // Gemini MEDIUM fix: when maxMerge picks a value from one source,
 // the identity at that cell must come from the SAME source — not

--- a/internal/admin/keyviz_handler.go
+++ b/internal/admin/keyviz_handler.go
@@ -72,12 +72,17 @@ type KeyVizMatrix struct {
 // KeyVizMatrix.ColumnUnixMs — Values[j] is the counter for that route
 // at column j.
 //
-// Conflict is true when the Phase 2-C max-merge collapsed disagreeing
-// values from multiple nodes for the same row (see fan-out design 4.2);
-// the SPA hatches such rows so operators know the displayed total may
-// understate the true per-window count during a leadership flip. The
-// flag is row-level for now and will move to per-cell when the proto
-// extension lands in Phase 2-C+.
+// Conflict is true when at least one of the row's cells observed a
+// merge disagreement. For writes the predicate fires when ≥2 sources
+// reported different non-zero values for the SAME
+// (bucket, raft_group_id, leader_term, column) tuple — a Raft
+// invariant violation (at most one leader per term per group), so
+// the SPA hatches the row. Phase 2-C+ PR-3c upgraded the merge from
+// the Phase 2-C row-level §4.2 max-merge to the canonical §9.1
+// per-cell (group, term)-keyed dedupe + sum-across-terms; the
+// row-level Conflict flag stays as the coarse SPA signal and a
+// per-cell `Conflicts []bool` is deferred to a future wire-format
+// extension.
 type KeyVizRow struct {
 	BucketID          string   `json:"bucket_id"`
 	Start             []byte   `json:"start"`


### PR DESCRIPTION
## Summary

Replace the Phase 2-C **§4.2 row-level max-merge** for writes with the parent design's canonical **§9.1 per-cell `(group, term)` dedupe + sum-across-terms**. This is the headline Phase 2-C+ behavior change: under a mid-window leader flip, the cluster heatmap now recovers the TRUE write count instead of being conservatively bounded by the larger leader's slice.

## Why

Per `docs/admin_ui_key_visualizer_design.md` §9.1:

> "For write samples the authoritative identity is `(raftGroupID, leaderTerm)` — by Raft invariants at most one leader exists per term per group — so the admin binary collapses write samples to one value per `(bucketID, raftGroupID, leaderTerm, windowStart)` key. ... Across distinct `leaderTerm` values for the same group and window, values are summed because each term's leader only observed its own term's writes."

PR-3a (#709) gave the sampler the `GroupID + LeaderTerm` fields. PR-3b (#720) wired them through the proto + JSON wire as parallel arrays and started the `main.go` publisher. This PR consumes them.

## Algorithm (per cell, writes series)

1. For each source's contribution at this cell, classify by `(group, term)`.
2. Within the same `(group, term)`: keep the larger value (Raft invariant — agreement is the steady state); raise `conflict=true` on disagreement (multiple "leaders" reporting writes for the same term is a real divergence).
3. **Sum across distinct `(group, term)` entries** — each term's leader only observed its own term's writes, so summing is exact.
4. **Fail-closed fallback**: if ANY contribution has `group=0` or `term=0` (legacy peer or a publisher that hasn't fired yet), fall back to the §4.2 max-merge for the WHOLE cell. Summing across an unknown-term entry would risk double-counting overlapping windows.

Reads / read_bytes unchanged — local serves are independent and never need per-leader dedupe (sum-across-nodes is exact). Write_bytes follows writes.

## Structural change

`mergeRowInto` no longer writes through into `dst.Values` incrementally. Each `(bucket, cell)` accumulates state in a `cellMergeAcc`; after all source rows have been processed, `resolveRowMergeAcc` materialises one final `KeyVizRow` per bucket. The accumulator carries:

- `sum` / `lastGroup` / `lastTerm`: read-path running sum + best-effort identity.
- `byTerm[(group, term)] → max value`: canonical write-path table.
- `termConflict[(group, term)] → bool`: per-key disagreement flag.
- `hasUnknownTerm`: flips fallback path on first unknown contribution.
- `fallbackMax`, `fallbackSeenNonZeroValue`, `fallbackNonZeroDistinct`: fallback max-merge state, maintained for every non-zero contribution so a cell that later flips into the fallback path has the right running max + disagreement signal.

The dispatch is gated by `mergeUsesGroupTermDedupe(series)` — `true` for writes/write_bytes, `false` for reads/read_bytes.

## Caller audit (semantic change to writes value)

- `mergeKeyVizMatrices` → only `KeyVizFanout.Run` (same package).
- `KeyVizFanout.Run` → only `KeyVizHandler.ServeHTTP` (same package).
- HTTP `/admin/api/v1/keyviz/matrix` → SPA at `web/admin/src/pages/KeyViz.tsx` treats `values[]` as opaque numbers and reads `row.conflict` as a coarse hatch signal. No max/sum assumption, no consumer-side change required.
- gRPC `AdminServer.GetKeyVizMatrix` returns single-node and does not invoke `mergeKeyVizMatrices` — unaffected.

No structural caller change. The numeric meaning of `values[]` for writes shifts from "max across nodes" to "§9.1 sum-across-terms", which is the documented intentional behavior of PR-3c.

## Out of scope

- **Per-cell `Conflicts []bool` wire format**: parent design §9.1 says "the cell-level flag will land with the leaderTerm-based merge". Deferred to a future PR-3d so this PR's diff is contained to the merge algorithm itself. The row-level `Conflict bool` is now driven by any-cell-saw-conflict, matching the existing SPA hatch contract.
- **SPA per-cell hatching**: requires the per-cell wire change above.

## Test plan

- [x] `go test -race -count=1 ./internal/admin/... ./keyviz/...` — pass.
- [x] `golangci-lint run` (full project) — 0 issues.
- [x] New tests:
  - `TestMergeKeyVizMatricesGroupTermSumAcrossTerms`: ex-leader (term=42, value=30) + new-leader (term=43, value=50) on the SAME cell merge to 80 (sum), recovering the pre-transfer slice §4.2 max would have lost.
  - `TestMergeKeyVizMatricesGroupTermConflictWithinSameTerm`: two sources reporting different non-zero values for the SAME `(group, term)` raise `conflict=true` (Raft invariant violation).
  - `TestMergeKeyVizMatricesGroupTermFallbackOnUnknownTerm`: modern (group=7, term=42, value=30) + legacy (no arrays, value=50) fall back to max=50, not sum=80 — the fail-closed guard preserves PR-3b's mixed-version safety.
- [x] Existing PR-3b tests (`TestMergeKeyVizMatricesPerCellIdentityMatchesValueOwner`, `TestMergeKeyVizMatricesLegacyPeerWinnerResetsIdentity`, the §4.2-shape `TestMergeKeyVizMatricesWritesMax*` tests with empty arrays which now hit the fallback path) all continue to pass.
- [ ] Jepsen — N/A (admin-side merge algorithm, no replication/MVCC/OCC impact).

## Five-lens self-review

1. **Data loss** — admin-side merge only; no on-disk format change. The fail-closed fallback preserves PR-3b's mixed-version safety. A cluster running mixed PR-3b/PR-3c binaries gets max-merge (PR-3b semantics) for any cell touched by an old binary, and §9.1 sum elsewhere.
2. **Concurrency** — fan-out merge runs single-goroutine after parallel peer calls return; no new shared state.
3. **Performance** — per-cell map allocation only when ≥1 source contributes a known-term write to that cell (lazy `c.byTerm == nil` check). Cells without known-term contributions (legacy fallback) skip map allocation entirely. The accumulator-based two-pass merge is O(sources × rows × columns), same asymptotic as the previous incremental merge.
4. **Data consistency** — §9.1 algorithm is the canonical reference. Tests pin the three nontrivial cases: sum across distinct terms (recovers the leader-flip slice), conflict within same term (Raft invariant violation), unknown-term fallback (mixed-version safety).
5. **Test coverage** — algorithm pinned with three new table-driven cases plus the existing PR-3b regression guards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More accurate merge behavior for write paths with finer-grained grouping and robust fallback when contributor identity is unknown, reducing incorrect aggregates and surfacing row-level conflicts reliably.

* **Documentation**
  * Clarified conflict semantics to explain when row-level conflict is set and future per-cell conflict plans.

* **Tests**
  * Added unit tests covering merge summing across terms, conflict detection, and unknown-identity fallback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/822?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->