### PR TITLE
backup: Phase 0b M1 — snapshot encoder core (EKVPBBL1 writer + MVCC re-encoding)

### DIFF
--- a/internal/backup/encode.go
+++ b/internal/backup/encode.go
@@ -150,6 +150,16 @@ func newSnapshotBuilder(commitTS uint64) *snapshotBuilder {
 // order-dependent `.fsm`. userKey/userValue are copied — callers may
 // reuse their buffers after Add returns.
 func (b *snapshotBuilder) Add(userKey, userValue []byte, expireAt uint64) error {
+	// A builder is single-use. Once WriteTo has flushed, any further
+	// Add would stage entries that can never be written (the second
+	// WriteTo fails closed before re-sorting), silently dropping
+	// records. Reject with the same sentinel WriteTo uses so a caller
+	// reusing an exhausted builder gets one consistent signal
+	// regardless of which method it calls (claude review on PR #825 —
+	// a silent-data-loss footgun for the M2-M5 adapter feed loops).
+	if b.written {
+		return errors.WithStack(ErrSnapshotBuilderReused)
+	}
 	// Size-check from the user-buffer lengths before allocating the
 	// framed buffers — encKey = userKey + snapshotTSSize, encVal =
 	// snapshotValueHeaderSize + userValue — so an oversize record

--- a/internal/backup/encode.go
+++ b/internal/backup/encode.go
@@ -53,6 +53,14 @@ var ErrEncodeDuplicateKey = errors.New("backup: duplicate encoded key in snapsho
 var ErrEncodeKeyTooLarge = errors.New("backup: encoded key length exceeds limit")
 var ErrEncodeValueTooLarge = errors.New("backup: encoded value length exceeds limit")
 
+// ErrSnapshotBuilderReused is returned by WriteTo when it is called
+// more than once on the same builder. A builder is single-use (one
+// per encode run); a second WriteTo would re-emit the already-written
+// entries, producing a valid-but-unintended stream. Enforced so the
+// per-adapter feed loops in later milestones cannot silently double-
+// emit (claude review on PR #825).
+var ErrSnapshotBuilderReused = errors.New("backup: snapshotBuilder.WriteTo called more than once")
+
 // ErrLastCommitTSRegression is returned by ResolveCommitTS when a
 // `--last-commit-ts` override is older than MANIFEST.last_commit_ts.
 // Seeding the restored node's HLC ceiling below a timestamp already
@@ -123,6 +131,7 @@ type snapshotBuilder struct {
 	commitTS uint64
 	entries  []encodedKV
 	seen     map[string]struct{}
+	written  bool
 }
 
 // newSnapshotBuilder constructs a builder that stamps every key with
@@ -141,21 +150,24 @@ func newSnapshotBuilder(commitTS uint64) *snapshotBuilder {
 // order-dependent `.fsm`. userKey/userValue are copied — callers may
 // reuse their buffers after Add returns.
 func (b *snapshotBuilder) Add(userKey, userValue []byte, expireAt uint64) error {
-	key := encodeMVCCKey(userKey, b.commitTS)
-	if uint64(len(key)) > MaxSnapshotEncodedKeySize {
+	// Size-check from the user-buffer lengths before allocating the
+	// framed buffers — encKey = userKey + snapshotTSSize, encVal =
+	// snapshotValueHeaderSize + userValue — so an oversize record
+	// fails closed without a wasted allocation (claude review nit).
+	if uint64(len(userKey))+snapshotTSSize > MaxSnapshotEncodedKeySize {
 		return errors.Wrapf(ErrEncodeKeyTooLarge,
-			"length %d > %d", len(key), MaxSnapshotEncodedKeySize)
+			"length %d > %d", len(userKey)+snapshotTSSize, MaxSnapshotEncodedKeySize)
 	}
-	val := encodeMVCCValue(userValue, expireAt)
-	if uint64(len(val)) > MaxSnapshotEncodedValueSize {
+	if uint64(len(userValue))+snapshotValueHeaderSize > MaxSnapshotEncodedValueSize {
 		return errors.Wrapf(ErrEncodeValueTooLarge,
-			"length %d > %d", len(val), MaxSnapshotEncodedValueSize)
+			"length %d > %d", len(userValue)+snapshotValueHeaderSize, MaxSnapshotEncodedValueSize)
 	}
+	key := encodeMVCCKey(userKey, b.commitTS)
 	if _, dup := b.seen[string(key)]; dup {
 		return errors.Wrapf(ErrEncodeDuplicateKey, "userKey %q", userKey)
 	}
 	b.seen[string(key)] = struct{}{}
-	b.entries = append(b.entries, encodedKV{key: key, val: val})
+	b.entries = append(b.entries, encodedKV{key: key, val: encodeMVCCValue(userValue, expireAt)})
 	return nil
 }
 
@@ -169,6 +181,10 @@ func (b *snapshotBuilder) Len() int { return len(b.entries) }
 // format terminates on a clean EOF (store/snapshot_pebble.go WriteTo,
 // internal/backup/snapshot_reader.go ReadSnapshot).
 func (b *snapshotBuilder) WriteTo(w io.Writer) (int64, error) {
+	if b.written {
+		return 0, errors.WithStack(ErrSnapshotBuilderReused)
+	}
+	b.written = true
 	sort.Slice(b.entries, func(i, j int) bool {
 		return bytes.Compare(b.entries[i].key, b.entries[j].key) < 0
 	})
@@ -214,7 +230,10 @@ type countingWriter struct {
 func (w *countingWriter) Write(p []byte) (int, error) {
 	n, err := w.w.Write(p)
 	w.n += int64(n)
-	return n, errors.WithStack(err)
+	if err != nil {
+		return n, errors.WithStack(err)
+	}
+	return n, nil
 }
 
 // RoundTripEntry is one live record recovered by DecodeLiveEntries.

--- a/internal/backup/encode.go
+++ b/internal/backup/encode.go
@@ -1,0 +1,259 @@
+package backup
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"sort"
+
+	"github.com/cockroachdb/errors"
+)
+
+// encode.go is the Phase 0b encoder core (design:
+// docs/design/2026_05_25_proposed_snapshot_logical_encoder.md). It is
+// the inverse of decode.go: per-adapter reverse encoders (added in the
+// Redis/DynamoDB/S3/SQS milestones) hand reconstructed internal
+// (userKey, userValue, expireAt) records to a snapshotBuilder, which
+// MVCC-frames them, sorts by encoded key, and streams the native
+// EKVPBBL1 `.fsm` the live store loads.
+//
+// This file owns only the format-level machinery that every adapter
+// shares:
+//
+//   - commit-timestamp resolution (MANIFEST.last_commit_ts plus the
+//     fail-closed `--last-commit-ts` override),
+//   - MVCC re-encoding (the inverse of snapshot_reader.go's
+//     decodeSnapshotEntry: invTS key suffix + value header),
+//   - duplicate-key rejection and per-entry size caps,
+//   - the sorted EKVPBBL1 writer (matching store/snapshot_pebble.go
+//     WriteTo — magic + lastCommitTS + sorted KV stream, no checksum
+//     footer),
+//   - a round-trip self-test harness that decodes the just-written
+//     bytes back through ReadSnapshot so a caller never emits an
+//     unloadable `.fsm`.
+//
+// The MVCC constants (snapshotTSSize, snapshotValueHeaderSize,
+// Max*EncodedKeySize, PebbleSnapshotMagic, the flag masks) are the
+// same ones snapshot_reader.go defines for the decode direction; encode
+// reuses them so the two directions cannot drift.
+
+// ErrEncodeDuplicateKey is returned when two reconstructed records
+// MVCC-encode to the same key. The live store's keyspace is a set;
+// a duplicate means an adapter reverse-encoder produced colliding
+// internal keys, which would make the loaded snapshot
+// order-dependent. The encoder fails closed rather than emit a
+// `.fsm` whose Pebble image depends on insertion order.
+var ErrEncodeDuplicateKey = errors.New("backup: duplicate encoded key in snapshot build")
+
+// ErrEncodeKeyTooLarge / ErrEncodeValueTooLarge mirror the decode-side
+// MaxSnapshotEncodedKeySize / MaxSnapshotEncodedValueSize caps. A
+// reconstructed entry exceeding them would produce a `.fsm` the live
+// restore path rejects, so the encoder fails closed before writing a
+// single byte rather than emit an unloadable file.
+var ErrEncodeKeyTooLarge = errors.New("backup: encoded key length exceeds limit")
+var ErrEncodeValueTooLarge = errors.New("backup: encoded value length exceeds limit")
+
+// ErrLastCommitTSRegression is returned by ResolveCommitTS when a
+// `--last-commit-ts` override is older than MANIFEST.last_commit_ts.
+// Seeding the restored node's HLC ceiling below a timestamp already
+// durable in the dump would let a post-restart leader re-issue a
+// timestamp at-or-below a restored row's commit ts — the exact
+// HLC-ceiling regression the design's §"MVCC re-encoding" forbids.
+// Raising the ceiling (T >= manifest) is always safe; lowering it is
+// not, so the override is accepted in one direction only.
+var ErrLastCommitTSRegression = errors.New("backup: --last-commit-ts override is older than manifest last_commit_ts")
+
+// ResolveCommitTS returns the commit timestamp the encoder stamps on
+// every reconstructed key (design §"MVCC re-encoding": uniform
+// stamping). manifestTS is MANIFEST.last_commit_ts; override is the
+// optional `--last-commit-ts` value (nil = no override).
+//
+// Fail-closed contract: an override is accepted only when it is
+// >= manifestTS (raising the restored HLC ceiling is safe; lowering
+// it risks a post-restart timestamp colliding with a restored row).
+// The returned value is used verbatim for BOTH the EKVPBBL1 header
+// and every key's invTS, so the two never disagree.
+func ResolveCommitTS(manifestTS uint64, override *uint64) (uint64, error) {
+	if override == nil {
+		return manifestTS, nil
+	}
+	if *override < manifestTS {
+		return 0, errors.Wrapf(ErrLastCommitTSRegression,
+			"override %d < manifest %d", *override, manifestTS)
+	}
+	return *override, nil
+}
+
+// encodeMVCCKey is the inverse of the key half of
+// snapshot_reader.go::decodeSnapshotEntry: it appends the 8-byte
+// big-endian inverted-timestamp suffix the live store's
+// fillEncodedKey writes. invTS = ^commitTS so that, under Pebble's
+// ascending byte order, newer (higher-ts) versions of a user key sort
+// before older ones — the MVCC ordering the live store relies on.
+func encodeMVCCKey(userKey []byte, commitTS uint64) []byte {
+	out := make([]byte, len(userKey)+snapshotTSSize)
+	copy(out, userKey)
+	binary.BigEndian.PutUint64(out[len(userKey):], ^commitTS)
+	return out
+}
+
+// encodeMVCCValue is the inverse of the value half of
+// decodeSnapshotEntry: it prepends the 9-byte value header
+// (flags byte + 8-byte little-endian expireAt). Phase 0b emits live,
+// cleartext, non-tombstone records only, so flags is always zero.
+func encodeMVCCValue(userValue []byte, expireAt uint64) []byte {
+	out := make([]byte, snapshotValueHeaderSize+len(userValue))
+	out[0] = 0 // flags: tombstone=0, encryption_state=cleartext, reserved=0
+	binary.LittleEndian.PutUint64(out[1:snapshotValueHeaderSize], expireAt)
+	copy(out[snapshotValueHeaderSize:], userValue)
+	return out
+}
+
+// encodedKV is one fully MVCC-framed entry held by snapshotBuilder
+// until the sorted write.
+type encodedKV struct {
+	key []byte
+	val []byte
+}
+
+// snapshotBuilder accumulates MVCC-framed entries and writes the
+// sorted EKVPBBL1 stream. One per encode run. Not safe for concurrent
+// use — adapters feed it sequentially from the directory-tree walk.
+type snapshotBuilder struct {
+	commitTS uint64
+	entries  []encodedKV
+	seen     map[string]struct{}
+}
+
+// newSnapshotBuilder constructs a builder that stamps every key with
+// commitTS (the value ResolveCommitTS returned).
+func newSnapshotBuilder(commitTS uint64) *snapshotBuilder {
+	return &snapshotBuilder{
+		commitTS: commitTS,
+		seen:     make(map[string]struct{}),
+	}
+}
+
+// Add MVCC-frames one reconstructed live record and stages it for the
+// sorted write. Applies the per-entry size caps and duplicate-key
+// rejection before retaining the bytes, so a violating record fails
+// the whole encode rather than producing an unloadable or
+// order-dependent `.fsm`. userKey/userValue are copied — callers may
+// reuse their buffers after Add returns.
+func (b *snapshotBuilder) Add(userKey, userValue []byte, expireAt uint64) error {
+	key := encodeMVCCKey(userKey, b.commitTS)
+	if uint64(len(key)) > MaxSnapshotEncodedKeySize {
+		return errors.Wrapf(ErrEncodeKeyTooLarge,
+			"length %d > %d", len(key), MaxSnapshotEncodedKeySize)
+	}
+	val := encodeMVCCValue(userValue, expireAt)
+	if uint64(len(val)) > MaxSnapshotEncodedValueSize {
+		return errors.Wrapf(ErrEncodeValueTooLarge,
+			"length %d > %d", len(val), MaxSnapshotEncodedValueSize)
+	}
+	if _, dup := b.seen[string(key)]; dup {
+		return errors.Wrapf(ErrEncodeDuplicateKey, "userKey %q", userKey)
+	}
+	b.seen[string(key)] = struct{}{}
+	b.entries = append(b.entries, encodedKV{key: key, val: val})
+	return nil
+}
+
+// Len reports how many entries have been staged.
+func (b *snapshotBuilder) Len() int { return len(b.entries) }
+
+// WriteTo sorts the staged entries by encoded key (ascending byte
+// order, matching the live Pebble-snapshot iteration order) and writes
+// the native EKVPBBL1 stream: magic + lastCommitTS (LE) + length-
+// prefixed (key, value) pairs. There is no checksum footer — the
+// format terminates on a clean EOF (store/snapshot_pebble.go WriteTo,
+// internal/backup/snapshot_reader.go ReadSnapshot).
+func (b *snapshotBuilder) WriteTo(w io.Writer) (int64, error) {
+	sort.Slice(b.entries, func(i, j int) bool {
+		return bytes.Compare(b.entries[i].key, b.entries[j].key) < 0
+	})
+	cw := &countingWriter{w: w}
+	if _, err := cw.Write([]byte(PebbleSnapshotMagic)); err != nil {
+		return cw.n, errors.WithStack(err)
+	}
+	if err := binary.Write(cw, binary.LittleEndian, b.commitTS); err != nil {
+		return cw.n, errors.WithStack(err)
+	}
+	for i := range b.entries {
+		if err := writeLengthPrefixed(cw, b.entries[i].key); err != nil {
+			return cw.n, err
+		}
+		if err := writeLengthPrefixed(cw, b.entries[i].val); err != nil {
+			return cw.n, err
+		}
+	}
+	return cw.n, nil
+}
+
+// writeLengthPrefixed writes an 8-byte little-endian length followed
+// by the bytes — the per-field framing ReadSnapshot's readEntryLen
+// consumes.
+func writeLengthPrefixed(w io.Writer, b []byte) error {
+	if err := binary.Write(w, binary.LittleEndian, uint64(len(b))); err != nil {
+		return errors.WithStack(err)
+	}
+	if _, err := w.Write(b); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+// countingWriter mirrors store/snapshot_pebble.go's helper so WriteTo
+// can report the byte count without importing the store package
+// (the offline-tool boundary the design requires).
+type countingWriter struct {
+	w io.Writer
+	n int64
+}
+
+func (w *countingWriter) Write(p []byte) (int, error) {
+	n, err := w.w.Write(p)
+	w.n += int64(n)
+	return n, errors.WithStack(err)
+}
+
+// RoundTripEntry is one live record recovered by DecodeLiveEntries.
+// The byte slices are owned by the caller (cloned out of the reader's
+// scratch buffer).
+type RoundTripEntry struct {
+	UserKey   []byte
+	UserValue []byte
+	ExpireAt  uint64
+}
+
+// DecodeLiveEntries decodes an EKVPBBL1 stream through ReadSnapshot
+// and returns its live (non-tombstone) entries plus the header. It is
+// the round-trip self-test primitive from the design's §"Round-trip
+// self-test": the encoder decodes its own just-written bytes and
+// compares the recovered records against what it fed the builder
+// before committing the final `.fsm` to disk, so a node never
+// receives an unloadable snapshot.
+//
+// Tombstones are skipped (the encoder never writes them, so seeing one
+// would indicate a corrupted build; surfacing only live records keeps
+// the comparison symmetric with what Add accepts). Byte slices are
+// cloned because ReadSnapshot reuses its scratch buffers across the
+// callback.
+func DecodeLiveEntries(r io.Reader) ([]RoundTripEntry, SnapshotHeader, error) {
+	var out []RoundTripEntry
+	hdr, err := ReadSnapshotWithHeader(r, func(_ SnapshotHeader, e SnapshotEntry) error {
+		if e.Tombstone {
+			return nil
+		}
+		out = append(out, RoundTripEntry{
+			UserKey:   bytes.Clone(e.UserKey),
+			UserValue: bytes.Clone(e.UserValue),
+			ExpireAt:  e.ExpireAt,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, SnapshotHeader{}, err
+	}
+	return out, hdr, nil
+}

--- a/internal/backup/encode_test.go
+++ b/internal/backup/encode_test.go
@@ -269,6 +269,26 @@ func TestSnapshotBuilderRejectsReuse(t *testing.T) {
 	}
 }
 
+// TestSnapshotBuilderRejectsAddAfterWriteTo pins that Add fails closed
+// after WriteTo rather than silently staging records that can never be
+// flushed (the second WriteTo would reject before re-sorting). Guards
+// the M2-M5 adapter feed loops against a silent-data-loss reuse bug.
+func TestSnapshotBuilderRejectsAddAfterWriteTo(t *testing.T) {
+	t.Parallel()
+	b := newSnapshotBuilder(encodeFixtureTS)
+	if err := b.Add([]byte("!redis|str|first"), []byte("v"), 0); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := b.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	err := b.Add([]byte("!redis|str|second"), []byte("v"), 0)
+	if !errors.Is(err, ErrSnapshotBuilderReused) {
+		t.Fatalf("Add-after-WriteTo err = %v, want ErrSnapshotBuilderReused", err)
+	}
+}
+
 // TestResolveCommitTS pins the --last-commit-ts override semantics
 // (design §"MVCC re-encoding"): no override yields the manifest value;
 // an override >= manifest is accepted; an override < manifest fails

--- a/internal/backup/encode_test.go
+++ b/internal/backup/encode_test.go
@@ -1,0 +1,242 @@
+package backup
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+)
+
+// encodeFixtureTS / encodeFixtureTS2 are representative 64-bit HLC
+// commit timestamps (non-zero physical half, non-zero logical half)
+// used across the encoder-core tests so the invTS suffix is visibly
+// distinct from both 0 and all-ones. Two distinct values are used so
+// the builder's commitTS parameter is exercised with more than one
+// argument.
+const (
+	encodeFixtureTS  uint64 = 0x0001_8F1A_2B3C_0007
+	encodeFixtureTS2 uint64 = 0x0001_8F1A_2B3C_0099
+)
+
+// TestEncodeMVCCKeyLayout pins that encodeMVCCKey produces
+// <userKey><^commitTS BE> — the layout snapshot_reader.go strips off.
+func TestEncodeMVCCKeyLayout(t *testing.T) {
+	t.Parallel()
+	userKey := []byte("!redis|str|session:abc")
+	encKey := encodeMVCCKey(userKey, encodeFixtureTS)
+	if !bytes.Equal(encKey[:len(userKey)], userKey) {
+		t.Fatalf("encKey prefix = %q, want %q", encKey[:len(userKey)], userKey)
+	}
+	gotInv := binary.BigEndian.Uint64(encKey[len(userKey):])
+	if gotInv != ^encodeFixtureTS {
+		t.Fatalf("invTS = %#x, want %#x", gotInv, ^encodeFixtureTS)
+	}
+}
+
+// TestEncodeMVCCValueLayout pins that encodeMVCCValue produces
+// <flags=0><expireAt LE><body>.
+func TestEncodeMVCCValueLayout(t *testing.T) {
+	t.Parallel()
+	userValue := []byte("hello-world")
+	const expireAt uint64 = 1_735_689_600_000
+	encVal := encodeMVCCValue(userValue, expireAt)
+	if encVal[0] != 0 {
+		t.Fatalf("flags = %#x, want 0", encVal[0])
+	}
+	gotExp := binary.LittleEndian.Uint64(encVal[1:snapshotValueHeaderSize])
+	if gotExp != expireAt {
+		t.Fatalf("expireAt = %d, want %d", gotExp, expireAt)
+	}
+	if !bytes.Equal(encVal[snapshotValueHeaderSize:], userValue) {
+		t.Fatalf("body = %q, want %q", encVal[snapshotValueHeaderSize:], userValue)
+	}
+}
+
+// TestEncodeMVCCDecodeRoundTrip is the strongest guarantee the encode
+// and decode directions agree: the decode primitive recovers exactly
+// the tuple that was MVCC-framed.
+func TestEncodeMVCCDecodeRoundTrip(t *testing.T) {
+	t.Parallel()
+	userKey := []byte("!redis|str|session:abc")
+	userValue := []byte("hello-world")
+	const expireAt uint64 = 1_735_689_600_000
+
+	encKey := encodeMVCCKey(userKey, encodeFixtureTS)
+	encVal := encodeMVCCValue(userValue, expireAt)
+	entry, err := decodeSnapshotEntry(encKey, encVal)
+	if err != nil {
+		t.Fatalf("decodeSnapshotEntry: %v", err)
+	}
+	switch {
+	case !bytes.Equal(entry.UserKey, userKey):
+		t.Fatalf("decoded UserKey = %q, want %q", entry.UserKey, userKey)
+	case !bytes.Equal(entry.UserValue, userValue):
+		t.Fatalf("decoded UserValue = %q, want %q", entry.UserValue, userValue)
+	case entry.CommitTS != encodeFixtureTS:
+		t.Fatalf("decoded CommitTS = %#x, want %#x", entry.CommitTS, encodeFixtureTS)
+	case entry.ExpireAt != expireAt:
+		t.Fatalf("decoded ExpireAt = %d, want %d", entry.ExpireAt, expireAt)
+	case entry.Tombstone:
+		t.Fatal("decoded Tombstone = true, want false")
+	}
+}
+
+// TestSnapshotBuilderRoundTrip is the M1 single-Redis-string fixture:
+// a builder with one !redis|str| record writes an EKVPBBL1 stream that
+// DecodeLiveEntries reads back to the identical (userKey, userValue,
+// expireAt) tuple, and the header carries the builder's commitTS.
+func TestSnapshotBuilderRoundTrip(t *testing.T) {
+	t.Parallel()
+	userKey := []byte("!redis|str|mykey")
+	userValue := []byte("myvalue")
+	const expireAt uint64 = 0
+
+	b := newSnapshotBuilder(encodeFixtureTS)
+	if err := b.Add(userKey, userValue, expireAt); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if b.Len() != 1 {
+		t.Fatalf("Len = %d, want 1", b.Len())
+	}
+
+	var buf bytes.Buffer
+	if _, err := b.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+
+	entries, hdr, err := DecodeLiveEntries(&buf)
+	if err != nil {
+		t.Fatalf("DecodeLiveEntries: %v", err)
+	}
+	if hdr.LastCommitTS != encodeFixtureTS {
+		t.Fatalf("header LastCommitTS = %#x, want %#x", hdr.LastCommitTS, encodeFixtureTS)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(entries))
+	}
+	if !bytes.Equal(entries[0].UserKey, userKey) {
+		t.Fatalf("UserKey = %q, want %q", entries[0].UserKey, userKey)
+	}
+	if !bytes.Equal(entries[0].UserValue, userValue) {
+		t.Fatalf("UserValue = %q, want %q", entries[0].UserValue, userValue)
+	}
+	if entries[0].ExpireAt != expireAt {
+		t.Fatalf("ExpireAt = %d, want %d", entries[0].ExpireAt, expireAt)
+	}
+}
+
+// TestSnapshotBuilderSortedOutput verifies the stream is emitted in
+// ascending encoded-key order regardless of Add order — the
+// determinism the design's §"Target .fsm format" requires and the
+// order the live Pebble-snapshot writer produces.
+func TestSnapshotBuilderSortedOutput(t *testing.T) {
+	t.Parallel()
+	// Add three keys out of order; identical commitTS means the
+	// invTS suffix is constant, so sort order is governed by userKey.
+	keys := [][]byte{
+		[]byte("!redis|str|charlie"),
+		[]byte("!redis|str|alpha"),
+		[]byte("!redis|str|bravo"),
+	}
+	// Use a distinct commitTS here so the builder's parameter is
+	// exercised with more than the one fixture value.
+	b := newSnapshotBuilder(encodeFixtureTS2)
+	for _, k := range keys {
+		if err := b.Add(k, []byte("v"), 0); err != nil {
+			t.Fatalf("Add %q: %v", k, err)
+		}
+	}
+	var buf bytes.Buffer
+	if _, err := b.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	entries, _, err := DecodeLiveEntries(&buf)
+	if err != nil {
+		t.Fatalf("DecodeLiveEntries: %v", err)
+	}
+	want := [][]byte{
+		[]byte("!redis|str|alpha"),
+		[]byte("!redis|str|bravo"),
+		[]byte("!redis|str|charlie"),
+	}
+	if len(entries) != len(want) {
+		t.Fatalf("got %d entries, want %d", len(entries), len(want))
+	}
+	for i := range want {
+		if !bytes.Equal(entries[i].UserKey, want[i]) {
+			t.Fatalf("entry[%d] UserKey = %q, want %q", i, entries[i].UserKey, want[i])
+		}
+	}
+}
+
+// TestSnapshotBuilderRejectsDuplicate pins that two records encoding
+// to the same key fail closed with ErrEncodeDuplicateKey rather than
+// producing an order-dependent Pebble image.
+func TestSnapshotBuilderRejectsDuplicate(t *testing.T) {
+	t.Parallel()
+	b := newSnapshotBuilder(encodeFixtureTS)
+	if err := b.Add([]byte("!redis|str|dup"), []byte("first"), 0); err != nil {
+		t.Fatalf("first Add: %v", err)
+	}
+	err := b.Add([]byte("!redis|str|dup"), []byte("second"), 0)
+	if !errors.Is(err, ErrEncodeDuplicateKey) {
+		t.Fatalf("err = %v, want ErrEncodeDuplicateKey", err)
+	}
+}
+
+// TestSnapshotBuilderRejectsOversizeKey pins the per-entry key cap:
+// a userKey that pushes the encoded key past MaxSnapshotEncodedKeySize
+// fails closed with ErrEncodeKeyTooLarge before any byte is written.
+// (The value cap is the identical code path against
+// MaxSnapshotEncodedValueSize; it is not exercised here because
+// allocating a 256 MiB value in a unit test is wasteful.)
+func TestSnapshotBuilderRejectsOversizeKey(t *testing.T) {
+	t.Parallel()
+	// encKey = userKey + 8-byte suffix; exceed the cap by one.
+	oversize := make([]byte, maxSnapshotUserKeySize+1)
+	b := newSnapshotBuilder(encodeFixtureTS)
+	err := b.Add(oversize, []byte("v"), 0)
+	if !errors.Is(err, ErrEncodeKeyTooLarge) {
+		t.Fatalf("err = %v, want ErrEncodeKeyTooLarge", err)
+	}
+}
+
+// TestResolveCommitTS pins the --last-commit-ts override semantics
+// (design §"MVCC re-encoding"): no override yields the manifest value;
+// an override >= manifest is accepted; an override < manifest fails
+// closed with ErrLastCommitTSRegression.
+func TestResolveCommitTS(t *testing.T) {
+	t.Parallel()
+	const manifestTS uint64 = 1000
+	ptr := func(v uint64) *uint64 { return &v }
+	cases := []struct {
+		name     string
+		override *uint64
+		want     uint64
+		wantErr  bool
+	}{
+		{"no override", nil, manifestTS, false},
+		{"override equal", ptr(manifestTS), manifestTS, false},
+		{"override higher", ptr(manifestTS + 5), manifestTS + 5, false},
+		{"override lower rejected", ptr(manifestTS - 1), 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ResolveCommitTS(manifestTS, tc.override)
+			if tc.wantErr {
+				if !errors.Is(err, ErrLastCommitTSRegression) {
+					t.Fatalf("err = %v, want ErrLastCommitTSRegression", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/backup/encode_test.go
+++ b/internal/backup/encode_test.go
@@ -101,9 +101,16 @@ func TestSnapshotBuilderRoundTrip(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if _, err := b.WriteTo(&buf); err != nil {
+	n, err := b.WriteTo(&buf)
+	if err != nil {
 		t.Fatalf("WriteTo: %v", err)
 	}
+	// Byte count is deterministic: magic + lastCommitTS + per-entry
+	// (8-byte len prefix + bytes) for both key and value.
+	wantN := int64(len(PebbleSnapshotMagic) + 8 +
+		(8 + len(userKey) + snapshotTSSize) +
+		(8 + snapshotValueHeaderSize + len(userValue)))
+	assertWriteByteCount(t, n, &buf, wantN)
 
 	entries, hdr, err := DecodeLiveEntries(&buf)
 	if err != nil {
@@ -112,17 +119,35 @@ func TestSnapshotBuilderRoundTrip(t *testing.T) {
 	if hdr.LastCommitTS != encodeFixtureTS {
 		t.Fatalf("header LastCommitTS = %#x, want %#x", hdr.LastCommitTS, encodeFixtureTS)
 	}
+	assertSingleEntry(t, entries, userKey, userValue, expireAt)
+}
+
+// assertWriteByteCount checks WriteTo's returned count matches the
+// expected value and the actual buffer length.
+func assertWriteByteCount(t *testing.T, n int64, buf *bytes.Buffer, want int64) {
+	t.Helper()
+	if n != want {
+		t.Fatalf("WriteTo n = %d, want %d", n, want)
+	}
+	if n != int64(buf.Len()) {
+		t.Fatalf("WriteTo n = %d, but buf has %d bytes", n, buf.Len())
+	}
+}
+
+// assertSingleEntry checks the decoded set has exactly one entry
+// matching the given key/value/expiry.
+func assertSingleEntry(t *testing.T, entries []RoundTripEntry, key, val []byte, exp uint64) {
+	t.Helper()
 	if len(entries) != 1 {
 		t.Fatalf("got %d entries, want 1", len(entries))
 	}
-	if !bytes.Equal(entries[0].UserKey, userKey) {
-		t.Fatalf("UserKey = %q, want %q", entries[0].UserKey, userKey)
-	}
-	if !bytes.Equal(entries[0].UserValue, userValue) {
-		t.Fatalf("UserValue = %q, want %q", entries[0].UserValue, userValue)
-	}
-	if entries[0].ExpireAt != expireAt {
-		t.Fatalf("ExpireAt = %d, want %d", entries[0].ExpireAt, expireAt)
+	switch {
+	case !bytes.Equal(entries[0].UserKey, key):
+		t.Fatalf("UserKey = %q, want %q", entries[0].UserKey, key)
+	case !bytes.Equal(entries[0].UserValue, val):
+		t.Fatalf("UserValue = %q, want %q", entries[0].UserValue, val)
+	case entries[0].ExpireAt != exp:
+		t.Fatalf("ExpireAt = %d, want %d", entries[0].ExpireAt, exp)
 	}
 }
 
@@ -199,6 +224,48 @@ func TestSnapshotBuilderRejectsOversizeKey(t *testing.T) {
 	err := b.Add(oversize, []byte("v"), 0)
 	if !errors.Is(err, ErrEncodeKeyTooLarge) {
 		t.Fatalf("err = %v, want ErrEncodeKeyTooLarge", err)
+	}
+}
+
+// TestSnapshotBuilderEmptyRoundTrip pins the empty-builder path (the
+// "fresh cluster / empty shard" restore case): WriteTo emits a valid
+// header-only stream that DecodeLiveEntries reads back as zero entries
+// with the header timestamp intact.
+func TestSnapshotBuilderEmptyRoundTrip(t *testing.T) {
+	t.Parallel()
+	b := newSnapshotBuilder(encodeFixtureTS)
+	var buf bytes.Buffer
+	if _, err := b.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	entries, hdr, err := DecodeLiveEntries(&buf)
+	if err != nil {
+		t.Fatalf("DecodeLiveEntries: %v", err)
+	}
+	if hdr.LastCommitTS != encodeFixtureTS {
+		t.Fatalf("hdr.LastCommitTS = %#x, want %#x", hdr.LastCommitTS, encodeFixtureTS)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("got %d entries, want 0", len(entries))
+	}
+}
+
+// TestSnapshotBuilderRejectsReuse pins that a builder is single-use:
+// a second WriteTo fails closed with ErrSnapshotBuilderReused rather
+// than silently re-emitting the already-written entries.
+func TestSnapshotBuilderRejectsReuse(t *testing.T) {
+	t.Parallel()
+	b := newSnapshotBuilder(encodeFixtureTS)
+	if err := b.Add([]byte("!redis|str|k"), []byte("v"), 0); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := b.WriteTo(&buf); err != nil {
+		t.Fatalf("first WriteTo: %v", err)
+	}
+	_, err := b.WriteTo(&buf)
+	if !errors.Is(err, ErrSnapshotBuilderReused) {
+		t.Fatalf("second WriteTo err = %v, want ErrSnapshotBuilderReused", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

**Phase 0b M1 — snapshot encoder core.** The format-level machinery every per-adapter reverse-encoder (M2–M5) will share, the inverse of `decode.go`'s dispatch. No adapter directory-walking yet — that lands per-adapter in the following milestones.

Design: `docs/design/2026_05_25_proposed_snapshot_logical_encoder.md` (merged in #823).

`internal/backup/encode.go`:
- **`ResolveCommitTS`** — `--last-commit-ts` override resolution with the fail-closed contract: an override is accepted only when `>= manifest.last_commit_ts` (raising the restored HLC ceiling is safe; lowering it risks a post-restart timestamp colliding with a restored row → `ErrLastCommitTSRegression`).
- **`encodeMVCCKey` / `encodeMVCCValue`** — exact inverse of `snapshot_reader.go::decodeSnapshotEntry`: `<userKey><^commitTS BE>` key, `<flags=0><expireAt LE><body>` value. Reuses the same MVCC constants the decode direction defines so the two cannot drift.
- **`snapshotBuilder`** — accumulates MVCC-framed entries; fails closed on duplicate encoded keys (`ErrEncodeDuplicateKey`) and per-entry size-cap violations (`ErrEncodeKeyTooLarge` / `ErrEncodeValueTooLarge`); `WriteTo` emits the sorted EKVPBBL1 stream (magic + `lastCommitTS` LE + length-prefixed KV pairs, **no checksum footer** — matches `store/snapshot_pebble.go::WriteTo`).
- **`DecodeLiveEntries`** — the round-trip self-test primitive: decodes a just-written buffer back through `ReadSnapshot` so a caller never emits an unloadable `.fsm`.

## Risk

New code only; no existing behavior changed. The package's offline-tool boundary is preserved (no live-cluster imports). `ResolveCommitTS` introduces fail-closed semantics but has no production caller yet — the only caller is the test; the production caller lands with the M6 CLI.

## Self-review (5 lenses)

- **Data loss**: encoder writes live records only, never tombstones; `DecodeLiveEntries` verifies decodability before finalize (the design's round-trip gate).
- **Concurrency/distributed**: `snapshotBuilder` is single-goroutine by contract (adapters feed sequentially); no shared state.
- **Performance**: in-memory sort; worst-case bound documented in the design (external-sort follow-up milestone).
- **Consistency**: uniform `commitTS` stamping keeps every key at/below the restored HLC ceiling; fail-closed override prevents a ceiling regression.
- **Test coverage**: MVCC key/value layout, decode round-trip via the **real** `decodeSnapshotEntry`, single-Redis-string `build→write→DecodeLiveEntries` round-trip, sorted output regardless of Add order, duplicate-key rejection, oversize-key rejection, `ResolveCommitTS` override table (incl. fail-closed regression).

## Test plan

- [x] `go test ./internal/backup/` (full package, no regression)
- [x] `golangci-lint run internal/backup/` (0 issues)
