### PR TITLE
feat(encryption): Stage 6D-6c-2 - production storage-envelope write-path wiring

### DIFF
--- a/docs/design/2026_05_25_partial_6d6c2_production_storage_envelope_wiring.md
+++ b/docs/design/2026_05_25_partial_6d6c2_production_storage_envelope_wiring.md
@@ -125,7 +125,7 @@ claim multi-node-churn nonce safety beyond those guards.
 
 `run()` today:
 
-```
+```go
 loadKEKAndRunStartupGuards()   // KEK load + CheckStartupGuards (6C-1/2)
 keystore := NewKeystore()      // empty
 buildShardGroups(... keystore, sidecarPath ...)  // per-shard stores + appliers
@@ -136,7 +136,7 @@ chainEncryptionStartupGuard()  // 6C-2d gap guard (post-engine)
 `buildShardGroups` (`buildEncryptionWriteWiring` →
 `prepareStorageNonceEpoch`):
 
-```
+```go
 kekWrapper := loadKEKAndRunStartupGuards()
 keystore   := NewKeystore()
 stateCache := NewStateCache()
@@ -158,7 +158,7 @@ where `prepareStorageNonceEpoch` primes the cache from the sidecar and,
 != 0`, the restart path), hydrates the keystore and performs the
 durable `local_epoch` bump:
 
-```
+```go
 sc := ReadSidecar(sidecarPath)            // IsNotExist → epoch 0
 cache.RefreshFromSidecar(sc)
 if sc.Active.Storage == 0 { return 0 }    // pre-bootstrap → epoch 0

--- a/docs/design/2026_05_25_partial_6d6c2_production_storage_envelope_wiring.md
+++ b/docs/design/2026_05_25_partial_6d6c2_production_storage_envelope_wiring.md
@@ -2,10 +2,28 @@
 
 | Field | Value |
 |---|---|
-| Status | proposed |
+| Status | partial |
 | Date | 2026-05-25 |
 | Parent designs | [`2026_04_29_partial_data_at_rest_encryption.md`](2026_04_29_partial_data_at_rest_encryption.md) (§4.1 nonce, §5.1 sidecar, §7.1 rollout), [`2026_05_18_partial_6d_enable_storage_envelope.md`](2026_05_18_partial_6d_enable_storage_envelope.md) (6D-6c milestone breakdown) |
 | Pulls forward | The deterministic-nonce core of Stage 7 (§4.1 `write_count` / `local_epoch` lifecycle). The full Raft-replicated writer-registry **registration-before-first-write** gate stays in Stage 7. |
+
+## Lifecycle status
+
+**Shipped (this PR, §1 "in scope"):** keystore hydration from the
+sidecar, the `local_epoch` bump-and-fsync lifecycle, the production
+`DeterministicNonceFactory`, and the `main.go` cipher + gate +
+`StateCache` wiring. A single-node cluster can now Bootstrap →
+EnableStorageEnvelope → Put (encrypted at rest) → read back.
+
+**Remaining (Stage 7, §1 "out of scope"):** the Raft-replicated
+registration-before-first-write coordinator gate (the §5.2
+process-start and §4.1 ConfChange-time paths) that makes multi-node
+membership churn nonce-safe beyond the existing startup guards
+(`ErrNodeIDCollision`, `ErrLocalEpochRollback`). Until that lands the
+write path is `partial`: production-correct for single-node and
+stable-membership clusters, with the documented cross-node-churn gap
+covered only by the startup guards. The doc flips to
+`*_implemented_*` when the Stage 7 gate ships.
 
 ## 0. Why this doc exists
 

--- a/docs/design/2026_05_25_proposed_6d6c2_production_storage_envelope_wiring.md
+++ b/docs/design/2026_05_25_proposed_6d6c2_production_storage_envelope_wiring.md
@@ -1,0 +1,192 @@
+# Stage 6D-6c-2 — production storage-envelope write-path wiring
+
+| Field | Value |
+|---|---|
+| Status | proposed |
+| Date | 2026-05-25 |
+| Parent designs | [`2026_04_29_partial_data_at_rest_encryption.md`](2026_04_29_partial_data_at_rest_encryption.md) (§4.1 nonce, §5.1 sidecar, §7.1 rollout), [`2026_05_18_partial_6d_enable_storage_envelope.md`](2026_05_18_partial_6d_enable_storage_envelope.md) (6D-6c milestone breakdown) |
+| Pulls forward | The deterministic-nonce core of Stage 7 (§4.1 `write_count` / `local_epoch` lifecycle). The full Raft-replicated writer-registry **registration-before-first-write** gate stays in Stage 7. |
+
+## 0. Why this doc exists
+
+6D-6c-1 landed the `StateCache` accessors (`ActiveStorageKeyID`,
+`StorageEnvelopeActive`) but left the storage layer's encryption
+options unwired in `main.go`. The remaining 6D-6c-2 milestone — as
+written in the 6D doc — is "build `encryption.NewCipher(keystore)` and
+thread `store.WithEncryption` + `store.WithStorageEnvelopeGate` into
+each shard's PebbleStore."
+
+Wiring `store.WithEncryption(cipher, nonceFactory, activeKeyID)`
+naively is **unsafe**: the only `NonceFactory` in the tree today is
+the test-only `store.CounterNonceFactory`, whose `write_count` atomic
+resets to `0` on every process load. Pinned to a fixed `local_epoch`,
+that recycles the nonce `node_id ‖ local_epoch ‖ {0,1,2,…}` after a
+restart — a catastrophic AES-GCM `(DEK, nonce)` reuse (§4.1).
+
+So a *correct* production write path needs three things the tree does
+not yet have, plus the wiring:
+
+1. **Keystore hydration from the sidecar at startup.** The cipher
+   reads DEK bytes from the shared `*Keystore`. Today the keystore is
+   populated only by FSM apply of the `OpBootstrap` / `OpRotation`
+   entries. After a restart where those entries fall behind a Raft-log
+   compaction window, the keystore comes up **empty** and the cipher
+   cannot decrypt existing envelopes. The sidecar already holds every
+   wrapped DEK; startup must unwrap them under the KEK and install
+   them.
+
+2. **A `local_epoch` bump-and-fsync on process start.** Per §4.1 the
+   `write_count` reset to `0` per process load is only safe because
+   `local_epoch` is bumped and fsync'd *before the first encryption
+   write*. The tree has the `ErrLocalEpochExhausted` (==0xFFFF) and
+   `ErrLocalEpochRollback` (sidecar <= registry) startup guards, but
+   nothing that actually performs the bump.
+
+3. **A production deterministic `NonceFactory`** pinned to the bumped
+   `local_epoch`, living in a non-test file.
+
+This doc pins the as-implemented design for all four pieces and draws
+the scope boundary against the remaining Stage 7 work.
+
+## 1. Scope
+
+### In scope (6D-6c-2)
+
+- `encryption.HydrateKeystoreFromSidecar(ks, kek, sidecarPath)` — unwrap
+  every `sidecar.Keys[*].Wrapped` under the KEK and `keystore.Set` it.
+  Runs once at startup, after `CheckStartupGuards` (which already
+  proves each DEK unwraps cleanly via the `ErrKEKMismatch` check) and
+  before `buildShardGroups`.
+- `encryption.BumpLocalEpoch(sidecarPath, dekID) (uint16, error)` —
+  read-modify-write the active storage DEK's `LocalEpoch`, refuse at
+  `0xFFFF` with `ErrLocalEpochExhausted`, fsync via the existing
+  crash-durable `WriteSidecar`, and return the new value. Idempotency
+  is **not** required: every process load consumes exactly one epoch.
+- `encryption.NonceFactory` (production) — deterministic
+  `node_id ‖ local_epoch ‖ write_count`, constructed from
+  `uint16(DeriveNodeID(raftID))` and the bumped epoch. The byte layout
+  is identical to `store.CounterNonceFactory`; the difference is
+  provenance (the epoch came from a durable bump, not a test literal).
+- `main.go` wiring: build the cipher, the single process-wide
+  `StateCache`, and the nonce factory; thread `WithStateCache` into
+  every per-shard `Applier`; thread `WithEncryption` +
+  `WithStorageEnvelopeGate` (reading `cache.ActiveStorageKeyID` /
+  `cache.StorageEnvelopeActive`) into every shard's `PebbleStore`.
+
+### Out of scope (stays in Stage 7)
+
+- **Registration-before-first-write coordinator gate** (§5.2
+  process-start path, §4.1 ConfChange-time path). A node bumping its
+  `local_epoch` locally is nonce-safe *for itself* across restarts; the
+  Raft-replicated `RegisterEncryptionWriter` propose is what makes the
+  `ErrLocalEpochRollback` guard's registry anchor advance and what
+  detects cross-node 16-bit `node_id` collisions at registration-apply
+  time. Cross-node collision is still covered in 6D-6c-2 by the
+  existing startup membership pre-check (`ErrNodeIDCollision`) and the
+  registry-apply-time collision check shipped in 6A; the
+  propose-before-write *gate* (block the coordinator's first encrypted
+  write until registration commits) is deferred.
+- KMS providers, compression, DEK retirement/rewrite (Stages 9).
+- The capability fan-out closure + multi-node e2e — that is 6D-6c-3.
+
+### Why this boundary is safe to ship
+
+The write path only ever emits an envelope when **both**
+`StorageEnvelopeActive()` is true (operator ran `EnableStorageEnvelope`)
+**and** `ActiveStorageKeyID()` returns a DEK (bootstrap committed). A
+freshly-built binary with no bootstrap writes cleartext exactly as
+today. The single-node e2e (6D-6c-3) exercises the full
+Bootstrap → cutover → Put → read-back loop on one process load where
+the registration gate is moot (the node is the only writer and is
+registered by the §5.6 bootstrap batch). Multi-node deployments that
+add a writer after bootstrap are protected by the startup guards until
+Stage 7 lands the propose-before-write gate; this doc does **not**
+claim multi-node-churn nonce safety beyond those guards.
+
+## 2. Startup ordering
+
+`run()` today:
+
+```
+loadKEKAndRunStartupGuards()   // KEK load + CheckStartupGuards (6C-1/2)
+keystore := NewKeystore()      // empty
+buildShardGroups(... keystore, sidecarPath ...)  // per-shard stores + appliers
+chainEncryptionStartupGuard()  // 6C-2d gap guard (post-engine)
+```
+
+6D-6c-2 inserts two steps between the guard load and
+`buildShardGroups`, gated on `encryptionEnabled && Active.Storage != 0`:
+
+```
+kekWrapper := loadKEKAndRunStartupGuards()
+keystore   := NewKeystore()
+stateCache := NewStateCache()
+
+if encryptionActive(sidecar) {                 // Active.Storage != 0
+    HydrateKeystoreFromSidecar(keystore, kekWrapper, sidecarPath)   // (1)
+    epoch := BumpLocalEpoch(sidecarPath, sidecar.Active.Storage)    // (2)
+    cipher := NewCipher(keystore)                                   // (3)
+    nonceFactory := NewNonceFactory(uint16(DeriveNodeID(raftID)), epoch)
+}                                                                   // (4)
+buildShardGroups(... keystore, stateCache, cipher, nonceFactory ...)
+```
+
+Ordering rationale:
+
+- **Hydrate before bump.** The bump's `ErrLocalEpochExhausted` /
+  fsync only matters once DEKs exist; hydrating first keeps the
+  "encryption active" branch self-contained and lets the cipher see
+  the DEK the bumped epoch refers to.
+- **Bump before any store opens.** No `PebbleStore` can serve a write
+  (and therefore issue a nonce) until `buildShardGroups` returns, so
+  performing the durable bump before that call guarantees the fsync
+  precedes the first nonce — the §4.1 invariant.
+- **StateCache before buildShardGroups.** The per-shard appliers need
+  the shared cache pointer (6D-6c-1's P1 fix), and the per-shard stores
+  need `cache.ActiveStorageKeyID` / `cache.StorageEnvelopeActive` as
+  their closures. `NewApplier` primes the cache from the sidecar, so by
+  the time the first store opens the cache reflects on-disk state.
+
+## 3. Crash / restart correctness
+
+- **Bump fsync vs. first write.** `BumpLocalEpoch` calls the existing
+  `WriteSidecar` (write-temp + fsync + rename + dir-sync). A crash
+  after the bump fsync but before any write simply consumes an epoch
+  (the next start bumps again); a crash before the fsync leaves the old
+  epoch and the next start retries the bump — no nonce was issued
+  either way.
+- **Hydration is read-only** w.r.t. durable state — it only mutates the
+  in-memory keystore. Idempotent across restarts.
+- **Keystore.Set conflict.** Hydration installs the same DEK bytes FSM
+  apply would; `Set` is idempotent for matching bytes and returns
+  `ErrKeyConflict` only if the KEK-unwrap produced different bytes for
+  the same id — a halt condition surfaced as a startup failure.
+
+## 4. Self-review checklist (to satisfy on the implementation PR)
+
+- **Data loss** — hydration/bump never delete a DEK or a committed
+  write; bump consumes epochs monotonically.
+- **Concurrency** — nonce factory is `atomic.Uint64`; StateCache is
+  atomic; hydration/bump run single-threaded at startup before any
+  store opens.
+- **Performance** — startup-only cost; hot path is one atomic add per
+  nonce.
+- **Data consistency** — the write path stays cleartext unless both
+  gate signals are on; AAD binding unchanged; epoch monotonicity
+  preserved across restarts.
+- **Test coverage** — unit tests for hydration (multi-DEK, KEK
+  mismatch, empty sidecar), bump (increment, 0xFFFF refusal, fsync
+  durability across a re-read), nonce factory (layout, monotonic
+  write_count, distinct epochs); main-wiring smoke test that a
+  non-bootstrapped binary stays cleartext.
+
+## 5. Open questions for review
+
+1. Should `BumpLocalEpoch` also bump the **raft** DEK's epoch, or only
+   the storage DEK? (Raft envelope is §4.2; this PR wires only the
+   storage write path, so the proposal bumps storage only and leaves
+   raft-epoch lifecycle to the raft-envelope wiring.)
+2. Is hydrating **all** sidecar DEKs (not just the active one) the
+   right call? (Yes — reads of pre-rotation versions need historical
+   DEKs; the cipher must hold every unretired DEK, matching
+   `Cipher.LoadedKeyIDs`.)

--- a/docs/design/2026_05_25_proposed_6d6c2_production_storage_envelope_wiring.md
+++ b/docs/design/2026_05_25_proposed_6d6c2_production_storage_envelope_wiring.md
@@ -212,7 +212,48 @@ hydrate+bump is gated on an active DEK:
   write_count, distinct epochs); main-wiring smoke test that a
   non-bootstrapped binary stays cleartext.
 
+## 4a. Review-driven decisions (PR #826 round 1)
+
+- **Epoch bump must precede engine replay (codex P2).** The bump is
+  performed during `buildEncryptionWriteWiring`, *before*
+  `buildShardGroups` opens the engines and *before*
+  `chainEncryptionStartupGuard` runs the §9.1 `ErrSidecarBehindRaftLog`
+  gap guard. Reviewer asked to delay the bump until after the guards
+  pass (so a refused startup does not consume an epoch). This is
+  **intentionally not done**: etcd/raft replay re-applies committed-
+  but-unpersisted entries through `kvFSM.Apply → ApplyMutationsRaft →
+  encryptForKey → nonceFactory.Next()`, so replay issues storage
+  nonces, and replay happens during engine open inside
+  `buildShardGroups` — before the gap guard can read the engine's
+  applied index. Those replay nonces MUST carry the bumped epoch, or
+  they collide with the previous load's epoch range. Moving the bump
+  after the gap guard would trade a bounded, recoverable
+  wasted-epoch-on-repeated-failed-startup (65,536 budget, 256-restart
+  warning cushion, rotate-dek recovery) for an unbounded
+  nonce-reuse-during-replay hazard. The wasted-epoch case only arises
+  when the sidecar is already behind the Raft log — itself a recovery
+  scenario where a rotate-dek is acceptable.
+- **write_count overflow fails closed (claude moderate).**
+  `DeterministicNonceFactory.Next` returns `ErrWriteCountExhausted` on
+  the 2^64 wrap rather than silently recycling `write_count=1`.
+  Unreachable in practice; recovery is a restart (bumps local_epoch).
+- **NodeID16 centralisation completed (claude moderate).** All node_id
+  narrowing code sites (`applier.go`, `local_epoch_rollback.go`,
+  `node_id_collision.go`) now call `encryption.NodeID16`; the lone
+  gosec-suppressed conversion lives inside the helper.
+
 ## 5. Open questions for review
+
+0. **Redundant KEK unwrap at startup (gemini medium, deferred).**
+   `HydrateKeystoreFromSidecar` re-unwraps every wrapped DEK that
+   `CheckStartupGuards` already unwrapped to verify the KEK. For the
+   file-mode KEK (the only provider today) the unwrap is a local AES
+   operation, so the cost is negligible. Once Stage 9 lands KMS
+   providers (network round-trips per unwrap) this doubles startup
+   KMS calls; the fix is to have the guard phase retain the unwrapped
+   DEKs (or populate the keystore during verification), which crosses
+   the guard/hydration contract boundary. Tracked for the Stage 9 KMS
+   work rather than this PR.
 
 1. Should `BumpLocalEpoch` also bump the **raft** DEK's epoch, or only
    the storage DEK? (Raft envelope is §4.2; this PR wires only the

--- a/docs/design/2026_05_25_proposed_6d6c2_production_storage_envelope_wiring.md
+++ b/docs/design/2026_05_25_proposed_6d6c2_production_storage_envelope_wiring.md
@@ -114,38 +114,70 @@ buildShardGroups(... keystore, sidecarPath ...)  // per-shard stores + appliers
 chainEncryptionStartupGuard()  // 6C-2d gap guard (post-engine)
 ```
 
-6D-6c-2 inserts two steps between the guard load and
-`buildShardGroups`, gated on `encryptionEnabled && Active.Storage != 0`:
+6D-6c-2 inserts the wiring between the guard load and
+`buildShardGroups` (`buildEncryptionWriteWiring` →
+`prepareStorageNonceEpoch`):
 
 ```
 kekWrapper := loadKEKAndRunStartupGuards()
 keystore   := NewKeystore()
 stateCache := NewStateCache()
 
-if encryptionActive(sidecar) {                 // Active.Storage != 0
-    HydrateKeystoreFromSidecar(keystore, kekWrapper, sidecarPath)   // (1)
-    epoch := BumpLocalEpoch(sidecarPath, sidecar.Active.Storage)    // (2)
-    cipher := NewCipher(keystore)                                   // (3)
-    nonceFactory := NewNonceFactory(uint16(DeriveNodeID(raftID)), epoch)
-}                                                                   // (4)
+// Cipher is wired whenever encryption is ENABLED — NOT gated on
+// bootstrap state — so a runtime Bootstrap + EnableStorageEnvelope
+// engages encryption without a restart. The per-Put gate keeps
+// writes cleartext until both signals are on.
+if encryptionEnabled && kekWrapper != nil && sidecarPath != "" {
+    cipher := NewCipher(keystore)
+    epoch  := prepareStorageNonceEpoch(sidecarPath, kekWrapper, keystore, stateCache)
+    nonceFactory := NewDeterministicNonceFactory(NodeID16(DeriveNodeID(raftID)), epoch)
+}
 buildShardGroups(... keystore, stateCache, cipher, nonceFactory ...)
 ```
 
-Ordering rationale:
+where `prepareStorageNonceEpoch` primes the cache from the sidecar and,
+**only when a storage DEK is already active on disk** (`Active.Storage
+!= 0`, the restart path), hydrates the keystore and performs the
+durable `local_epoch` bump:
 
-- **Hydrate before bump.** The bump's `ErrLocalEpochExhausted` /
-  fsync only matters once DEKs exist; hydrating first keeps the
-  "encryption active" branch self-contained and lets the cipher see
-  the DEK the bumped epoch refers to.
-- **Bump before any store opens.** No `PebbleStore` can serve a write
-  (and therefore issue a nonce) until `buildShardGroups` returns, so
-  performing the durable bump before that call guarantees the fsync
-  precedes the first nonce — the §4.1 invariant.
+```
+sc := ReadSidecar(sidecarPath)            // IsNotExist → epoch 0
+cache.RefreshFromSidecar(sc)
+if sc.Active.Storage == 0 { return 0 }    // pre-bootstrap → epoch 0
+HydrateKeystoreFromSidecar(keystore, kekWrapper, sc)   // (1)
+return BumpLocalEpoch(sidecarPath, sc.Active.Storage)  // (2)
+```
+
+Why the cipher is wired regardless of bootstrap state but the
+hydrate+bump is gated on an active DEK:
+
+- **Runtime bootstrap must work without a restart.** The §7.1 rollout
+  runs `BootstrapEncryption` and `EnableStorageEnvelope` as admin RPCs
+  at runtime. If the cipher were only wired when a DEK was active *at
+  startup*, a freshly-started cluster could never engage encryption
+  until its next restart. So the cipher + nonce factory are wired
+  whenever the operator enabled encryption; the per-Put gate
+  (`ActiveStorageKeyID` + `StorageEnvelopeActive`, both reading the
+  shared cache that FSM apply updates) is what holds writes cleartext
+  until bootstrap+cutover commit.
+- **Epoch 0 is safe for the runtime-bootstrap-this-load case.** When no
+  DEK is active at startup the nonce factory pins `local_epoch = 0` —
+  exactly the value a runtime `BootstrapEncryption` assigns the new
+  DEK, and that DEK's first-ever use, so `node_id ‖ 0 ‖ {1,2,…}` is
+  fresh. A subsequent restart sees `Active.Storage != 0` and takes the
+  bump path, so the same `(node_id, 0)` prefix is never reused under
+  the same DEK across loads.
+- **Hydrate before bump.** Hydration installs the DEK bytes the bumped
+  epoch refers to and every historical DEK needed for reads.
+- **Bump before any store opens.** No `PebbleStore` serves a write
+  (and therefore issues a nonce) until `buildShardGroups` returns, so
+  the durable bump precedes the first nonce — the §4.1 invariant.
 - **StateCache before buildShardGroups.** The per-shard appliers need
   the shared cache pointer (6D-6c-1's P1 fix), and the per-shard stores
-  need `cache.ActiveStorageKeyID` / `cache.StorageEnvelopeActive` as
-  their closures. `NewApplier` primes the cache from the sidecar, so by
-  the time the first store opens the cache reflects on-disk state.
+  capture `cache.ActiveStorageKeyID` / `cache.StorageEnvelopeActive` as
+  their gate closures. `prepareStorageNonceEpoch` primes the cache and
+  `NewApplier` re-primes it, so the gate reflects on-disk state before
+  the first Put.
 
 ## 3. Crash / restart correctness
 

--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -403,7 +403,7 @@ func (a *Applier) bootstrapAndRotationConfigured() bool {
 // the gate, or in a forensic / corruption scenario) still halts
 // rather than silently advancing setApplied.
 func (a *Applier) ApplyRegistration(p fsmwire.RegistrationPayload) error {
-	key := RegistryKey(p.DEKID, uint16(p.FullNodeID&nodeIDMask)) //nolint:gosec // masked to 16 bits; G115 cannot trace the bitwise narrowing
+	key := RegistryKey(p.DEKID, NodeID16(p.FullNodeID))
 	existing, ok, err := a.registry.GetRegistryRow(key)
 	if err != nil {
 		return errors.Wrap(err, "applier: get registry row")

--- a/internal/encryption/errors.go
+++ b/internal/encryption/errors.go
@@ -175,6 +175,18 @@ var (
 	// to participate.
 	ErrLocalEpochExhausted = errors.New("encryption: active DEK has reached local_epoch=0xFFFF saturation; refusing to start (rotate the affected DEK via `encryption rotate-dek` before the next startup or risk GCM nonce reuse — see §4.1)")
 
+	// ErrWriteCountExhausted is returned by DeterministicNonceFactory.Next
+	// when the 64-bit §4.1 write_count counter wraps within a single
+	// process load. A wrap re-issues write_count=1 under the same
+	// (node_id, local_epoch), recycling every GCM nonce already
+	// produced this load under the active DEK — catastrophic. The
+	// boundary is unreachable in any realistic deployment (2^64 ≈
+	// 1.8e19 writes per load), but the factory fails closed rather
+	// than silently wrapping. Recovery is a process restart, which
+	// bumps local_epoch (BumpLocalEpoch) and resets write_count to a
+	// fresh, non-overlapping range.
+	ErrWriteCountExhausted = errors.New("encryption: nonce write_count exhausted (uint64 wrap) within a process load; restart to bump local_epoch — see §4.1")
+
 	// ErrSidecarBehindRaftLog is the §9.1 startup-refusal guard
 	// raised when the sidecar's raft_applied_index is behind the
 	// raftengine's persisted applied index AND the gap covers any

--- a/internal/encryption/local_epoch_rollback.go
+++ b/internal/encryption/local_epoch_rollback.go
@@ -95,7 +95,7 @@ func CheckLocalEpochRollback(
 	sidecarLocalEpoch uint16,
 	storageEnvelopeActive bool,
 ) error {
-	key := RegistryKey(activeStorageDEKID, uint16(fullNodeID&nodeIDMask)) //nolint:gosec // masked to 16 bits; matches applier.go convention
+	key := RegistryKey(activeStorageDEKID, NodeID16(fullNodeID))
 	rawVal, ok, err := registry.GetRegistryRow(key)
 	if err != nil {
 		return pkgerrors.Wrapf(err,

--- a/internal/encryption/node_id_collision.go
+++ b/internal/encryption/node_id_collision.go
@@ -56,7 +56,7 @@ func CheckNodeIDCollision(fullNodeIDs []uint64) error {
 	// here keeps the primitive correct under any input ordering).
 	seen := make(map[uint16]uint64, len(fullNodeIDs))
 	for _, fnid := range fullNodeIDs {
-		nodeID := uint16(fnid & nodeIDMask) //nolint:gosec // masked to 16 bits; matches applier.go/encryption_admin.go convention
+		nodeID := NodeID16(fnid)
 		prev, exists := seen[nodeID]
 		if !exists {
 			seen[nodeID] = fnid

--- a/internal/encryption/nonce_factory.go
+++ b/internal/encryption/nonce_factory.go
@@ -3,6 +3,8 @@ package encryption
 import (
 	"encoding/binary"
 	"sync/atomic"
+
+	"github.com/cockroachdb/errors"
 )
 
 // DeterministicNonceFactory is the production §4.1 storage-envelope
@@ -54,10 +56,22 @@ func NewDeterministicNonceFactory(nodeID, localEpoch uint16) *DeterministicNonce
 // write_count — keeping the nonce space disjoint from any future
 // scheme that might want write_count=0 as a sentinel. The atomic add
 // makes Next safe for concurrent callers.
+//
+// Overflow: atomic.Uint64.Add wraps silently at 2^64. A wrap returns
+// the value 0 (the pre-increment all-ones value plus one), which
+// would recycle write_count=1.. under the same (node_id, local_epoch)
+// — a catastrophic GCM nonce reuse. Next fails closed with
+// ErrWriteCountExhausted on the wrapping call instead of emitting the
+// reused nonce. The boundary is unreachable in practice (2^64 writes
+// per process load); recovery is a restart, which bumps local_epoch.
 func (f *DeterministicNonceFactory) Next() ([NonceSize]byte, error) {
+	wc := f.writes.Add(1)
+	if wc == 0 {
+		return [NonceSize]byte{}, errors.WithStack(ErrWriteCountExhausted)
+	}
 	var n [NonceSize]byte
 	binary.BigEndian.PutUint16(n[0:2], f.nodeID)
 	binary.BigEndian.PutUint16(n[2:4], f.localEpoch)
-	binary.BigEndian.PutUint64(n[4:12], f.writes.Add(1))
+	binary.BigEndian.PutUint64(n[4:12], wc)
 	return n, nil
 }

--- a/internal/encryption/nonce_factory.go
+++ b/internal/encryption/nonce_factory.go
@@ -1,0 +1,63 @@
+package encryption
+
+import (
+	"encoding/binary"
+	"sync/atomic"
+)
+
+// DeterministicNonceFactory is the production §4.1 storage-envelope
+// nonce source. It emits the 12-byte deterministic nonce
+//
+//	bytes 0-1   node_id     (big-endian uint16)
+//	bytes 2-3   local_epoch (big-endian uint16)
+//	bytes 4-11  write_count (big-endian uint64)
+//
+// with zero random bits — nonce uniqueness is by construction across
+// (node, process-load, write). It satisfies the store.NonceFactory
+// interface structurally (Next() ([NonceSize]byte, error)).
+//
+// Safety contract (see the parent encryption design §4.1):
+//
+//   - node_id is uint16(DeriveNodeID(--raftId)); cluster-wide 16-bit
+//     uniqueness is enforced by the writer registry + the
+//     ErrNodeIDCollision / membership-snapshot startup guards.
+//   - local_epoch is pinned at construction from a value that was
+//     bumped and fsync'd on THIS process load (BumpLocalEpoch). The
+//     factory never advances the epoch; one factory instance == one
+//     process load == one epoch.
+//   - write_count is an atomic counter that resets to 0 each process
+//     load. The reset is only safe BECAUSE local_epoch advanced, so
+//     constructing this factory with an un-bumped epoch reused across
+//     restarts is a correctness bug. Always pair NewDeterministicNonceFactory
+//     with a fresh BumpLocalEpoch on the active storage DEK.
+//
+// This is the durable analogue of the test-only
+// store.CounterNonceFactory: identical byte layout, but the epoch
+// here carries the restart-safety guarantee the test factory lacks.
+type DeterministicNonceFactory struct {
+	nodeID     uint16
+	localEpoch uint16
+	writes     atomic.Uint64
+}
+
+// NewDeterministicNonceFactory constructs a factory pinned to
+// (nodeID, localEpoch). write_count starts at 0 and increments on
+// every Next(). The caller is responsible for having bumped and
+// fsync'd localEpoch for this process load before issuing any nonce.
+func NewDeterministicNonceFactory(nodeID, localEpoch uint16) *DeterministicNonceFactory {
+	return &DeterministicNonceFactory{nodeID: nodeID, localEpoch: localEpoch}
+}
+
+// Next returns the next 12-byte nonce. The write_count is
+// pre-incremented (the first nonce of a process load carries
+// write_count=1, not 0) so that no nonce ever carries the all-zero
+// write_count — keeping the nonce space disjoint from any future
+// scheme that might want write_count=0 as a sentinel. The atomic add
+// makes Next safe for concurrent callers.
+func (f *DeterministicNonceFactory) Next() ([NonceSize]byte, error) {
+	var n [NonceSize]byte
+	binary.BigEndian.PutUint16(n[0:2], f.nodeID)
+	binary.BigEndian.PutUint16(n[2:4], f.localEpoch)
+	binary.BigEndian.PutUint64(n[4:12], f.writes.Add(1))
+	return n, nil
+}

--- a/internal/encryption/nonce_factory.go
+++ b/internal/encryption/nonce_factory.go
@@ -40,6 +40,13 @@ type DeterministicNonceFactory struct {
 	nodeID     uint16
 	localEpoch uint16
 	writes     atomic.Uint64
+	// exhausted latches true the first time write_count wraps past
+	// 2^64. Once set, every subsequent Next() fails closed with
+	// ErrWriteCountExhausted rather than resuming from the recycled
+	// low write_count range. Without the latch, the call after the
+	// wrap would emit write_count=1 again — a nonce already used this
+	// load under the same (node_id, local_epoch).
+	exhausted atomic.Bool
 }
 
 // NewDeterministicNonceFactory constructs a factory pinned to
@@ -60,13 +67,21 @@ func NewDeterministicNonceFactory(nodeID, localEpoch uint16) *DeterministicNonce
 // Overflow: atomic.Uint64.Add wraps silently at 2^64. A wrap returns
 // the value 0 (the pre-increment all-ones value plus one), which
 // would recycle write_count=1.. under the same (node_id, local_epoch)
-// — a catastrophic GCM nonce reuse. Next fails closed with
-// ErrWriteCountExhausted on the wrapping call instead of emitting the
-// reused nonce. The boundary is unreachable in practice (2^64 writes
-// per process load); recovery is a restart, which bumps local_epoch.
+// — a catastrophic GCM nonce reuse. On the wrapping call Next latches
+// the factory exhausted and returns ErrWriteCountExhausted; every
+// subsequent call also returns ErrWriteCountExhausted (the latch is
+// permanent — resuming from the recycled low range would reuse nonces
+// already emitted this load). The boundary is unreachable in practice
+// (2^64 writes per process load); recovery is a restart, which bumps
+// local_epoch and resets write_count to a fresh, non-overlapping
+// range.
 func (f *DeterministicNonceFactory) Next() ([NonceSize]byte, error) {
+	if f.exhausted.Load() {
+		return [NonceSize]byte{}, errors.WithStack(ErrWriteCountExhausted)
+	}
 	wc := f.writes.Add(1)
 	if wc == 0 {
+		f.exhausted.Store(true)
 		return [NonceSize]byte{}, errors.WithStack(ErrWriteCountExhausted)
 	}
 	var n [NonceSize]byte

--- a/internal/encryption/nonce_factory_internal_test.go
+++ b/internal/encryption/nonce_factory_internal_test.go
@@ -19,11 +19,14 @@ func TestDeterministicNonceFactory_WriteCountOverflow(t *testing.T) {
 	if _, err := f.Next(); !errors.Is(err, ErrWriteCountExhausted) {
 		t.Fatalf("Next at saturation: err = %v, want ErrWriteCountExhausted", err)
 	}
-	// The wrapped value 0 must not have been emitted; a subsequent
-	// call continues from 1 and is a normal nonce again (the counter
-	// has wrapped, but in practice recovery is a restart — this just
-	// confirms Next does not panic post-wrap).
-	if _, err := f.Next(); err != nil {
-		t.Fatalf("Next after wrap: unexpected err = %v", err)
+	// The latch is permanent: every subsequent call must also fail
+	// closed with ErrWriteCountExhausted rather than resuming from the
+	// recycled low write_count range (which would reuse nonces already
+	// emitted this load). Recovery is a restart, which bumps
+	// local_epoch.
+	for i := 0; i < 3; i++ {
+		if _, err := f.Next(); !errors.Is(err, ErrWriteCountExhausted) {
+			t.Fatalf("Next #%d after wrap: err = %v, want sticky ErrWriteCountExhausted", i, err)
+		}
 	}
 }

--- a/internal/encryption/nonce_factory_internal_test.go
+++ b/internal/encryption/nonce_factory_internal_test.go
@@ -1,0 +1,29 @@
+package encryption
+
+import (
+	"errors"
+	"math"
+	"testing"
+)
+
+// TestDeterministicNonceFactory_WriteCountOverflow drives the factory's
+// internal counter to the uint64 ceiling so the next Next() call wraps
+// to 0, and asserts it fails closed with ErrWriteCountExhausted rather
+// than emitting a reused nonce. White-box (package encryption) because
+// it must set the unexported atomic counter directly.
+func TestDeterministicNonceFactory_WriteCountOverflow(t *testing.T) {
+	t.Parallel()
+	f := NewDeterministicNonceFactory(0xABCD, 0x0001)
+	// Pre-saturate: the next Add(1) wraps MaxUint64 -> 0.
+	f.writes.Store(math.MaxUint64)
+	if _, err := f.Next(); !errors.Is(err, ErrWriteCountExhausted) {
+		t.Fatalf("Next at saturation: err = %v, want ErrWriteCountExhausted", err)
+	}
+	// The wrapped value 0 must not have been emitted; a subsequent
+	// call continues from 1 and is a normal nonce again (the counter
+	// has wrapped, but in practice recovery is a restart — this just
+	// confirms Next does not panic post-wrap).
+	if _, err := f.Next(); err != nil {
+		t.Fatalf("Next after wrap: unexpected err = %v", err)
+	}
+}

--- a/internal/encryption/nonce_factory_test.go
+++ b/internal/encryption/nonce_factory_test.go
@@ -62,8 +62,14 @@ func TestDeterministicNonceFactory_DistinctEpochsDisjoint(t *testing.T) {
 	f2 := encryption.NewDeterministicNonceFactory(0x00AA, 0x0002)
 	seen := make(map[[encryption.NonceSize]byte]struct{})
 	for i := 0; i < 100; i++ {
-		a, _ := f1.Next()
-		b, _ := f2.Next()
+		a, err := f1.Next()
+		if err != nil {
+			t.Fatalf("f1.Next[%d]: %v", i, err)
+		}
+		b, err := f2.Next()
+		if err != nil {
+			t.Fatalf("f2.Next[%d]: %v", i, err)
+		}
 		if a == b {
 			t.Fatalf("epoch-disjoint factories collided at i=%d", i)
 		}

--- a/internal/encryption/nonce_factory_test.go
+++ b/internal/encryption/nonce_factory_test.go
@@ -1,0 +1,114 @@
+package encryption_test
+
+import (
+	"encoding/binary"
+	"sync"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+)
+
+func TestDeterministicNonceFactory_Layout(t *testing.T) {
+	t.Parallel()
+	const nodeID uint16 = 0xABCD
+	const epoch uint16 = 0x0007
+	f := encryption.NewDeterministicNonceFactory(nodeID, epoch)
+	n, err := f.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if got := binary.BigEndian.Uint16(n[0:2]); got != nodeID {
+		t.Errorf("node_id field = 0x%04X, want 0x%04X", got, nodeID)
+	}
+	if got := binary.BigEndian.Uint16(n[2:4]); got != epoch {
+		t.Errorf("local_epoch field = 0x%04X, want 0x%04X", got, epoch)
+	}
+	// First nonce carries write_count=1 (pre-increment), never 0.
+	if got := binary.BigEndian.Uint64(n[4:12]); got != 1 {
+		t.Errorf("write_count field = %d, want 1", got)
+	}
+}
+
+func TestDeterministicNonceFactory_MonotonicAndUnique(t *testing.T) {
+	t.Parallel()
+	f := encryption.NewDeterministicNonceFactory(0x0001, 0x0002)
+	const n = 1000
+	seen := make(map[[encryption.NonceSize]byte]struct{}, n)
+	var prev uint64
+	for i := 0; i < n; i++ {
+		nonce, err := f.Next()
+		if err != nil {
+			t.Fatalf("Next[%d]: %v", i, err)
+		}
+		if _, dup := seen[nonce]; dup {
+			t.Fatalf("duplicate nonce at i=%d: %x", i, nonce)
+		}
+		seen[nonce] = struct{}{}
+		wc := binary.BigEndian.Uint64(nonce[4:12])
+		if wc <= prev {
+			t.Fatalf("write_count not strictly increasing: %d after %d", wc, prev)
+		}
+		prev = wc
+	}
+}
+
+// TestDeterministicNonceFactory_DistinctEpochsDisjoint pins the
+// restart-safety property: two factories with the same node_id but
+// different local_epoch (as a bump produces across restarts) never
+// collide even though both reset write_count to 0.
+func TestDeterministicNonceFactory_DistinctEpochsDisjoint(t *testing.T) {
+	t.Parallel()
+	f1 := encryption.NewDeterministicNonceFactory(0x00AA, 0x0001)
+	f2 := encryption.NewDeterministicNonceFactory(0x00AA, 0x0002)
+	seen := make(map[[encryption.NonceSize]byte]struct{})
+	for i := 0; i < 100; i++ {
+		a, _ := f1.Next()
+		b, _ := f2.Next()
+		if a == b {
+			t.Fatalf("epoch-disjoint factories collided at i=%d", i)
+		}
+		seen[a] = struct{}{}
+		if _, dup := seen[b]; dup {
+			t.Fatalf("f2 nonce collided with an f1 nonce at i=%d", i)
+		}
+		seen[b] = struct{}{}
+	}
+}
+
+func TestDeterministicNonceFactory_ConcurrentNextUnique(t *testing.T) {
+	t.Parallel()
+	f := encryption.NewDeterministicNonceFactory(0xCAFE, 0x0003)
+	const goroutines = 8
+	const perG = 500
+	var wg sync.WaitGroup
+	results := make([][][encryption.NonceSize]byte, goroutines)
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			local := make([][encryption.NonceSize]byte, perG)
+			for i := 0; i < perG; i++ {
+				n, err := f.Next()
+				if err != nil {
+					t.Errorf("Next: %v", err)
+					return
+				}
+				local[i] = n
+			}
+			results[g] = local
+		}(g)
+	}
+	wg.Wait()
+	seen := make(map[[encryption.NonceSize]byte]struct{}, goroutines*perG)
+	for _, batch := range results {
+		for _, n := range batch {
+			if _, dup := seen[n]; dup {
+				t.Fatalf("concurrent duplicate nonce: %x", n)
+			}
+			seen[n] = struct{}{}
+		}
+	}
+	if len(seen) != goroutines*perG {
+		t.Errorf("unique nonces = %d, want %d", len(seen), goroutines*perG)
+	}
+}

--- a/internal/encryption/write_path_startup.go
+++ b/internal/encryption/write_path_startup.go
@@ -1,0 +1,114 @@
+package encryption
+
+import (
+	"strconv"
+
+	"github.com/cockroachdb/errors"
+)
+
+// HydrateKeystoreFromSidecar unwraps every DEK recorded in the
+// sidecar under the supplied KEK and installs it into ks. It is the
+// startup counterpart to the FSM-apply keystore install path
+// (ApplyBootstrap / ApplyRotation): on a fresh process load the
+// keystore comes up empty, and FSM replay only re-installs DEKs whose
+// OpBootstrap / OpRotation entries are still in the Raft log. After a
+// log-compaction window those entries are gone, so a node restarting
+// against a compacted log would have no DEK bytes and the cipher
+// could not decrypt existing §4.1 envelopes. The sidecar is the
+// durable record of every unretired wrapped DEK, so this function
+// rebuilds the in-memory keystore from it.
+//
+// Every key in sc.Keys is hydrated (not just sc.Active.Storage):
+// reads of versions written before a rotation need the historical
+// DEK, so the cipher must hold every unretired DEK to satisfy
+// Cipher.LoadedKeyIDs.
+//
+// Idempotent: keystore.Set is a no-op for byte-identical DEKs, so
+// calling this after some DEKs were already installed by FSM replay
+// is safe. A Set that returns ErrKeyConflict means the KEK-unwrap
+// produced different bytes for an id the keystore already holds —
+// a halt condition surfaced to the caller.
+//
+// nil ks or nil kek is a configuration error (the caller gates this
+// on encryption being active); an empty sidecar (no Keys) is a no-op.
+func HydrateKeystoreFromSidecar(ks *Keystore, kek KEKUnwrapper, sc *Sidecar) error {
+	if ks == nil {
+		return errors.New("encryption: HydrateKeystoreFromSidecar: keystore is nil")
+	}
+	if kek == nil {
+		return errors.New("encryption: HydrateKeystoreFromSidecar: kek is nil")
+	}
+	if sc == nil {
+		return errors.New("encryption: HydrateKeystoreFromSidecar: sidecar is nil")
+	}
+	for idStr, k := range sc.Keys {
+		id, err := strconv.ParseUint(idStr, 10, 32)
+		if err != nil {
+			return errors.Wrapf(err, "encryption: HydrateKeystoreFromSidecar: parse key_id %q", idStr)
+		}
+		dek, err := kek.Unwrap(k.Wrapped)
+		if err != nil {
+			return errors.Wrapf(err, "encryption: HydrateKeystoreFromSidecar: kek-unwrap key_id %s", idStr)
+		}
+		if err := ks.Set(uint32(id), dek); err != nil {
+			return errors.Wrapf(err, "encryption: HydrateKeystoreFromSidecar: keystore set key_id %s", idStr)
+		}
+	}
+	return nil
+}
+
+// BumpLocalEpoch increments the §4.1 local_epoch for the DEK at dekID,
+// fsyncs the sidecar, and returns the new value. It MUST be called on
+// every process load that will issue storage-envelope nonces, BEFORE
+// the first such nonce — the §4.1 nonce construction resets the
+// in-process write_count to 0 each load, and a bumped-and-fsync'd
+// local_epoch is what keeps `node_id ‖ local_epoch ‖ write_count`
+// unique across restarts. Without the bump a restart would re-issue
+// `node_id ‖ epoch ‖ {0,1,2,…}` and recycle previously-used GCM
+// nonces under the same DEK — catastrophic.
+//
+// The bump refuses at the uint16 ceiling: if the current epoch is
+// already 0xFFFF the function returns ErrLocalEpochExhausted (the
+// §9.1 CheckStartupGuards guard catches this earlier on the happy
+// path; the check here is defense-in-depth for callers that bump
+// without having run the guard). DEK rotation resets the epoch to 0
+// under a fresh DEK and is the only recovery.
+//
+// Durability: the increment is persisted via WriteSidecar (the same
+// write-temp + fsync + rename + dir-sync sequence the apply paths
+// use), so a crash after the return guarantees the new epoch is on
+// disk. A crash before the return leaves the old epoch and the next
+// start bumps again — no nonce was issued in between because no store
+// has opened yet.
+func BumpLocalEpoch(sidecarPath string, dekID uint32) (uint16, error) {
+	if sidecarPath == "" {
+		return 0, errors.New("encryption: BumpLocalEpoch: sidecar path is empty")
+	}
+	if dekID == ReservedKeyID {
+		return 0, errors.New("encryption: BumpLocalEpoch: dek_id 0 is reserved (cluster not bootstrapped)")
+	}
+	sc, err := ReadSidecar(sidecarPath)
+	if err != nil {
+		return 0, errors.Wrap(err, "encryption: BumpLocalEpoch: read sidecar")
+	}
+	idStr := strconv.FormatUint(uint64(dekID), 10)
+	k, ok := sc.Keys[idStr]
+	if !ok {
+		return 0, errors.Errorf("encryption: BumpLocalEpoch: no sidecar key for dek_id %d", dekID)
+	}
+	if k.LocalEpoch == localEpochMax {
+		return 0, errors.Wrapf(ErrLocalEpochExhausted,
+			"encryption: BumpLocalEpoch: dek_id %d already at local_epoch=0x%04X", dekID, localEpochMax)
+	}
+	k.LocalEpoch++
+	sc.Keys[idStr] = k
+	if err := WriteSidecar(sidecarPath, sc); err != nil {
+		return 0, errors.Wrap(err, "encryption: BumpLocalEpoch: write sidecar")
+	}
+	return k.LocalEpoch, nil
+}
+
+// localEpochMax is the §4.1 16-bit local_epoch saturation value. A
+// DEK at this epoch cannot bump further without nonce reuse, so
+// BumpLocalEpoch refuses (matching ErrLocalEpochExhausted at startup).
+const localEpochMax = uint16(0xFFFF)

--- a/internal/encryption/write_path_startup.go
+++ b/internal/encryption/write_path_startup.go
@@ -112,3 +112,15 @@ func BumpLocalEpoch(sidecarPath string, dekID uint32) (uint16, error) {
 // DEK at this epoch cannot bump further without nonce reuse, so
 // BumpLocalEpoch refuses (matching ErrLocalEpochExhausted at startup).
 const localEpochMax = uint16(0xFFFF)
+
+// NodeID16 narrows a 64-bit full node id to the 16-bit node_id field
+// of the §4.1 nonce (and of the writer-registry key). The truncation
+// is the documented `uint16(full_node_id & 0xFFFF)` rule; cluster-wide
+// uniqueness of the narrowed value is enforced by the writer registry
+// + ErrNodeIDCollision guard, not by this function. Centralised here
+// so call sites (main.go nonce-factory wiring, applier registry keys)
+// share one masked-narrowing site instead of repeating the
+// gosec-suppressed conversion.
+func NodeID16(fullNodeID uint64) uint16 {
+	return uint16(fullNodeID & nodeIDMask) //nolint:gosec // masked to 16 bits; G115 cannot trace the bitwise narrowing
+}

--- a/internal/encryption/write_path_startup_test.go
+++ b/internal/encryption/write_path_startup_test.go
@@ -1,0 +1,163 @@
+package encryption_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+)
+
+// validStorageRaftSidecar writes a consistent two-DEK sidecar
+// (storage id=7, raft id=8) to a temp path and returns the path. The
+// storage DEK's local_epoch is set to storageEpoch; the raft DEK's
+// epoch is fixed at 0 (this PR bumps only the storage write path).
+// The wrapped bytes are distinct so fakeKEK derives distinct DEKs.
+func validStorageRaftSidecar(t *testing.T, storageEpoch uint16) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := dir + "/keys.json"
+	sc := &encryption.Sidecar{
+		Version: encryption.SidecarVersion,
+		Active:  encryption.ActiveKeys{Storage: 7, Raft: 8},
+		Keys: map[string]encryption.SidecarKey{
+			"7": {Purpose: encryption.SidecarPurposeStorage, Wrapped: []byte("storage-wrapped-bytes"), LocalEpoch: storageEpoch},
+			"8": {Purpose: encryption.SidecarPurposeRaft, Wrapped: []byte("raft-wrapped-bytes-diff"), LocalEpoch: 0},
+		},
+	}
+	if err := encryption.WriteSidecar(path, sc); err != nil {
+		t.Fatalf("WriteSidecar: %v", err)
+	}
+	return path
+}
+
+func TestHydrateKeystoreFromSidecar_InstallsAllDEKs(t *testing.T) {
+	t.Parallel()
+	path := validStorageRaftSidecar(t, 0)
+	sc, err := encryption.ReadSidecar(path)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	ks := encryption.NewKeystore()
+	if err := encryption.HydrateKeystoreFromSidecar(ks, &fakeKEK{}, sc); err != nil {
+		t.Fatalf("HydrateKeystoreFromSidecar: %v", err)
+	}
+	// Both the active storage DEK and the (historical-read) raft DEK
+	// must be present so the cipher can decrypt every unretired
+	// envelope after a restart.
+	for _, id := range []uint32{7, 8} {
+		if !ks.Has(id) {
+			t.Errorf("keystore missing DEK id=%d after hydration", id)
+		}
+	}
+}
+
+func TestHydrateKeystoreFromSidecar_Idempotent(t *testing.T) {
+	t.Parallel()
+	path := validStorageRaftSidecar(t, 0)
+	sc, err := encryption.ReadSidecar(path)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	ks := encryption.NewKeystore()
+	kek := &fakeKEK{}
+	if err := encryption.HydrateKeystoreFromSidecar(ks, kek, sc); err != nil {
+		t.Fatalf("first hydration: %v", err)
+	}
+	// Second hydration over the already-populated keystore must be a
+	// no-op (byte-identical DEKs) rather than an ErrKeyConflict.
+	if err := encryption.HydrateKeystoreFromSidecar(ks, kek, sc); err != nil {
+		t.Fatalf("second hydration (idempotent): %v", err)
+	}
+}
+
+func TestHydrateKeystoreFromSidecar_KEKFailurePropagates(t *testing.T) {
+	t.Parallel()
+	path := validStorageRaftSidecar(t, 0)
+	sc, err := encryption.ReadSidecar(path)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	boom := errors.New("kek unwrap boom")
+	ks := encryption.NewKeystore()
+	err = encryption.HydrateKeystoreFromSidecar(ks, &fakeKEK{failOn: []byte("storage-wrapped-bytes"), failErr: boom}, sc)
+	if err == nil {
+		t.Fatal("expected hydration error from KEK failure, got nil")
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("error does not wrap KEK failure: %v", err)
+	}
+}
+
+func TestHydrateKeystoreFromSidecar_NilArgs(t *testing.T) {
+	t.Parallel()
+	sc := &encryption.Sidecar{Version: encryption.SidecarVersion}
+	if err := encryption.HydrateKeystoreFromSidecar(nil, &fakeKEK{}, sc); err == nil {
+		t.Error("nil keystore: expected error, got nil")
+	}
+	if err := encryption.HydrateKeystoreFromSidecar(encryption.NewKeystore(), nil, sc); err == nil {
+		t.Error("nil kek: expected error, got nil")
+	}
+	if err := encryption.HydrateKeystoreFromSidecar(encryption.NewKeystore(), &fakeKEK{}, nil); err == nil {
+		t.Error("nil sidecar: expected error, got nil")
+	}
+}
+
+func TestBumpLocalEpoch_IncrementsAndPersists(t *testing.T) {
+	t.Parallel()
+	path := validStorageRaftSidecar(t, 4)
+	got, err := encryption.BumpLocalEpoch(path, 7)
+	if err != nil {
+		t.Fatalf("BumpLocalEpoch: %v", err)
+	}
+	if got != 5 {
+		t.Errorf("returned epoch = %d, want 5", got)
+	}
+	// The bump must be durable: re-reading the sidecar shows the
+	// advanced epoch (so the next process load bumps from 5, not 4).
+	sc, err := encryption.ReadSidecar(path)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	if sc.Keys["7"].LocalEpoch != 5 {
+		t.Errorf("persisted storage epoch = %d, want 5", sc.Keys["7"].LocalEpoch)
+	}
+	// The raft DEK's epoch must be untouched — this PR bumps only the
+	// storage write path.
+	if sc.Keys["8"].LocalEpoch != 0 {
+		t.Errorf("raft epoch = %d, want 0 (bump must not touch raft)", sc.Keys["8"].LocalEpoch)
+	}
+}
+
+func TestBumpLocalEpoch_RefusesAtSaturation(t *testing.T) {
+	t.Parallel()
+	path := validStorageRaftSidecar(t, 0xFFFF)
+	_, err := encryption.BumpLocalEpoch(path, 7)
+	if err == nil {
+		t.Fatal("expected ErrLocalEpochExhausted at 0xFFFF, got nil")
+	}
+	if !errors.Is(err, encryption.ErrLocalEpochExhausted) {
+		t.Errorf("error not marked ErrLocalEpochExhausted: %v", err)
+	}
+	// The sidecar must NOT have been mutated by the refused bump.
+	sc, err := encryption.ReadSidecar(path)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	if sc.Keys["7"].LocalEpoch != 0xFFFF {
+		t.Errorf("epoch mutated despite refusal: %d", sc.Keys["7"].LocalEpoch)
+	}
+}
+
+func TestBumpLocalEpoch_RejectsUnknownDEKAndReserved(t *testing.T) {
+	t.Parallel()
+	path := validStorageRaftSidecar(t, 0)
+	if _, err := encryption.BumpLocalEpoch(path, 99); err == nil {
+		t.Error("unknown dek_id: expected error, got nil")
+	}
+	if _, err := encryption.BumpLocalEpoch(path, 0); err == nil {
+		t.Error("reserved dek_id 0: expected error, got nil")
+	}
+	if _, err := encryption.BumpLocalEpoch("", 7); err == nil {
+		t.Error("empty path: expected error, got nil")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -341,7 +341,15 @@ func run() error {
 	}
 	keystore := encryption.NewKeystore()
 
-	runtimes, shardGroups, err := buildShardGroups(
+	// Stage 6D-6c: buildShardGroupsWithEncryptionWiring assembles the
+	// storage-envelope write-path wiring (cipher + deterministic nonce
+	// factory + the process-shared StateCache) before opening any
+	// shard store, then constructs the shard groups with it. The
+	// wiring hydrates the keystore and bumps the §4.1 local_epoch when
+	// a storage DEK is already active on disk (restart path); on a
+	// pre-bootstrap binary the per-Put gate stays cleartext until a
+	// runtime Bootstrap + EnableStorageEnvelope flips it.
+	runtimes, shardGroups, err := buildShardGroupsWithEncryptionWiring(
 		*raftId,
 		*raftDir,
 		cfg.groups,
@@ -734,6 +742,7 @@ func buildShardGroups(
 	kekWrapper kek.Wrapper,
 	keystore *encryption.Keystore,
 	sidecarPath string,
+	encWiring encryptionWriteWiring,
 ) ([]*raftGroupRuntime, map[uint64]*kv.ShardGroup, error) {
 	runtimes := make([]*raftGroupRuntime, 0, len(groups))
 	shardGroups := make(map[uint64]*kv.ShardGroup, len(groups))
@@ -742,7 +751,7 @@ func buildShardGroups(
 		if err := os.MkdirAll(dir, dirPerm); err != nil {
 			return nil, nil, errors.Wrapf(err, "failed to create fsm store dir for group %d", g.id)
 		}
-		st, err := store.NewPebbleStore(filepath.Join(dir, "fsm.db"))
+		st, err := store.NewPebbleStore(filepath.Join(dir, "fsm.db"), encWiring.pebbleOptions()...)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "failed to open pebble fsm store for group %d", g.id)
 		}
@@ -772,7 +781,13 @@ func buildShardGroups(
 		// (ApplyBootstrap / ApplyRotation return ErrKEKNotConfigured)
 		// which is exactly the desired apply-time fail-closed
 		// behaviour when an operator has not opted in to encryption.
-		applier, err := encryption.NewApplier(reg, applierOptionsFor(kekWrapper, keystore, sidecarPath)...)
+		//
+		// Stage 6D-6c-1: WithStateCache threads the process-shared
+		// StateCache so an encryption apply landing on this shard's
+		// FSM updates the atomics every shard's storage layer reads.
+		applierOpts := append(applierOptionsFor(kekWrapper, keystore, sidecarPath),
+			encryption.WithStateCache(encWiring.cache))
+		applier, err := encryption.NewApplier(reg, applierOpts...)
 		if err != nil {
 			for _, rt := range runtimes {
 				rt.Close()

--- a/main.go
+++ b/main.go
@@ -364,6 +364,7 @@ func run() error {
 		kekWrapper,
 		keystore,
 		*encryptionSidecarPath,
+		*encryptionEnabled,
 	)
 	if err = chainEncryptionStartupGuard(
 		err,

--- a/main.go
+++ b/main.go
@@ -744,6 +744,12 @@ func buildShardGroups(
 	sidecarPath string,
 	encWiring encryptionWriteWiring,
 ) ([]*raftGroupRuntime, map[uint64]*kv.ShardGroup, error) {
+	// Defend the "cache is always non-nil" contract for callers that
+	// pass a zero-value encryptionWriteWiring{} (the encryption-off
+	// test harnesses). WithStateCache(nil) would otherwise make
+	// NewApplier install a private per-applier cache, silently
+	// breaking the shared-cache invariant 6D-6c-1 relies on.
+	encWiring = encWiring.withDefaultedCache()
 	runtimes := make([]*raftGroupRuntime, 0, len(groups))
 	shardGroups := make(map[uint64]*kv.ShardGroup, len(groups))
 	for _, g := range groups {

--- a/main_bootstrap_e2e_test.go
+++ b/main_bootstrap_e2e_test.go
@@ -356,7 +356,7 @@ func startBootstrapE2ENode(
 		return nil, err
 	}
 	clock := kv.NewHLC()
-	runtimes, shardGroups, err := buildShardGroups(ep.id, baseDir, cfg.groups, cfg.multi, bootstrap, bootstrapServers, factory, nil, clock, nil, nil, "")
+	runtimes, shardGroups, err := buildShardGroups(ep.id, baseDir, cfg.groups, cfg.multi, bootstrap, bootstrapServers, factory, nil, clock, nil, nil, "", encryptionWriteWiring{})
 	if err != nil {
 		return nil, err
 	}

--- a/main_encryption_write_wiring.go
+++ b/main_encryption_write_wiring.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"errors"
+	"log/slog"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/bootjp/elastickv/internal/encryption/kek"
+	"github.com/bootjp/elastickv/internal/raftengine"
+	etcdraftengine "github.com/bootjp/elastickv/internal/raftengine/etcd"
+	"github.com/bootjp/elastickv/kv"
+	"github.com/bootjp/elastickv/store"
+	pkgerrors "github.com/cockroachdb/errors"
+)
+
+// buildShardGroupsWithEncryptionWiring assembles the storage-envelope
+// write wiring from the process flags and then constructs the shard
+// groups with it. It exists so run() makes a single call (keeping its
+// cyclomatic complexity in budget) rather than building the wiring and
+// checking its error inline. The buildEncryptionWriteWiring error is
+// returned as the buildShardGroups error so run()'s existing
+// chainEncryptionStartupGuard composition handles it unchanged.
+func buildShardGroupsWithEncryptionWiring(
+	raftID string,
+	raftDir string,
+	groups []groupSpec,
+	multi bool,
+	bootstrap bool,
+	bootstrapServers []raftengine.Server,
+	factory raftengine.Factory,
+	proposalObserverForGroup func(uint64) kv.ProposalObserver,
+	clock *kv.HLC,
+	kekWrapper kek.Wrapper,
+	keystore *encryption.Keystore,
+	sidecarPath string,
+) ([]*raftGroupRuntime, map[uint64]*kv.ShardGroup, error) {
+	encWiring, err := buildEncryptionWriteWiring(kekWrapper, keystore)
+	if err != nil {
+		return nil, nil, err
+	}
+	return buildShardGroups(raftID, raftDir, groups, multi, bootstrap, bootstrapServers,
+		factory, proposalObserverForGroup, clock, kekWrapper, keystore, sidecarPath, encWiring)
+}
+
+// encryptionWriteWiring bundles the Stage 6D-6c storage-envelope
+// write-path dependencies threaded into buildShardGroups:
+//
+//   - cache is the process-shared StateCache (always non-nil). Every
+//     per-shard Applier receives it via WithStateCache, and the
+//     per-Put gate closures (cache.ActiveStorageKeyID /
+//     cache.StorageEnvelopeActive) read from it, so an encryption
+//     apply landing on one shard's FSM is visible to every shard's
+//     storage layer (6D-6c-1's shared-cache invariant).
+//   - cipher / nonceFactory are nil when encryption is not enabled
+//     (no --encryption-enabled, no --kekFile, or no sidecar path). A
+//     nil cipher leaves WithEncryption unwired, so the store stays in
+//     legacy cleartext mode. When non-nil they are wired into every
+//     shard's PebbleStore; the gate still keeps writes cleartext
+//     until a Bootstrap + EnableStorageEnvelope has flipped the cache.
+type encryptionWriteWiring struct {
+	cache        *encryption.StateCache
+	cipher       *encryption.Cipher
+	nonceFactory store.NonceFactory
+}
+
+// pebbleOptions returns the PebbleStore options for the storage
+// envelope. When the cipher is nil (encryption not enabled) it
+// returns no options, leaving the store in cleartext mode. When set,
+// it wires WithEncryption (cipher + nonce factory + active-key gate)
+// and WithStorageEnvelopeGate (the §7.1 cutover gate); both read the
+// shared cache so runtime Bootstrap / cutover applies take effect
+// without a restart.
+func (w encryptionWriteWiring) pebbleOptions() []store.PebbleStoreOption {
+	if w.cipher == nil || w.nonceFactory == nil {
+		return nil
+	}
+	return []store.PebbleStoreOption{
+		store.WithEncryption(w.cipher, w.nonceFactory, w.cache.ActiveStorageKeyID),
+		store.WithStorageEnvelopeGate(w.cache.StorageEnvelopeActive),
+	}
+}
+
+// buildEncryptionWriteWiring assembles the storage-envelope write-path
+// wiring from the process flags. It always returns a wiring with a
+// non-nil StateCache (the per-shard appliers need it regardless of
+// encryption state); the cipher + nonce factory are populated only
+// when encryption is enabled (--encryption-enabled AND --kekFile AND
+// --encryptionSidecarPath).
+//
+// When a storage DEK is already active on disk (the restart path),
+// the function hydrates the keystore from the sidecar so the cipher
+// can decrypt pre-existing envelopes whose bootstrap entry may have
+// been compacted, and bumps the §4.1 local_epoch so the per-load
+// write_count reset stays nonce-safe. On a pre-bootstrap binary the
+// epoch defaults to 0 — the value a future runtime Bootstrap assigns
+// to the freshly minted DEK, which is that DEK's first-ever use and
+// therefore nonce-safe; a later restart will then take the bump path.
+func buildEncryptionWriteWiring(kekWrapper encryption.KEKUnwrapper, keystore *encryption.Keystore) (encryptionWriteWiring, error) {
+	w := encryptionWriteWiring{cache: encryption.NewStateCache()}
+	if !*encryptionEnabled || kekWrapper == nil || *encryptionSidecarPath == "" {
+		return w, nil
+	}
+	cipher, err := encryption.NewCipher(keystore)
+	if err != nil {
+		return encryptionWriteWiring{}, pkgerrors.Wrap(err, "build encryption write wiring: new cipher")
+	}
+	epoch, err := prepareStorageNonceEpoch(*encryptionSidecarPath, kekWrapper, keystore, w.cache)
+	if err != nil {
+		return encryptionWriteWiring{}, err
+	}
+	w.cipher = cipher
+	w.nonceFactory = encryption.NewDeterministicNonceFactory(
+		encryption.NodeID16(etcdraftengine.DeriveNodeID(*raftId)), epoch)
+	return w, nil
+}
+
+// prepareStorageNonceEpoch returns the §4.1 local_epoch the nonce
+// factory should pin for this process load. It primes the shared
+// StateCache from the sidecar so the storage gate is correct before
+// the first store opens, and — when a storage DEK is active —
+// hydrates the keystore and performs the durable local_epoch bump.
+//
+// Returns epoch 0 in the two pre-bootstrap cases (no sidecar file, or
+// a sidecar with Active.Storage == 0): the cluster has no storage DEK
+// yet, so there is no epoch to bump and no envelope will be emitted
+// until a runtime Bootstrap installs one (with local_epoch 0, its
+// first use).
+func prepareStorageNonceEpoch(sidecarPath string, kekWrapper encryption.KEKUnwrapper, keystore *encryption.Keystore, cache *encryption.StateCache) (uint16, error) {
+	sc, err := encryption.ReadSidecar(sidecarPath)
+	if err != nil {
+		if encryption.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, pkgerrors.Wrap(err, "prepare storage nonce epoch: read sidecar")
+	}
+	cache.RefreshFromSidecar(sc)
+	if sc.Active.Storage == 0 {
+		return 0, nil
+	}
+	if err := encryption.HydrateKeystoreFromSidecar(keystore, kekWrapper, sc); err != nil {
+		return 0, pkgerrors.Wrap(err, "prepare storage nonce epoch: hydrate keystore")
+	}
+	epoch, err := encryption.BumpLocalEpoch(sidecarPath, sc.Active.Storage)
+	if err != nil {
+		// Surface the §9.1 exhaustion refusal verbatim so the operator
+		// log line names the rotate-dek recovery path.
+		if errors.Is(err, encryption.ErrLocalEpochExhausted) {
+			slog.Error("encryption write-path wiring refused: storage DEK local_epoch exhausted; rotate-dek required",
+				slog.String("sidecar_path", sidecarPath),
+				slog.Uint64("active_storage_dek", uint64(sc.Active.Storage)))
+		}
+		return 0, pkgerrors.Wrap(err, "prepare storage nonce epoch: bump local_epoch")
+	}
+	return epoch, nil
+}

--- a/main_encryption_write_wiring.go
+++ b/main_encryption_write_wiring.go
@@ -63,6 +63,19 @@ type encryptionWriteWiring struct {
 	nonceFactory store.NonceFactory
 }
 
+// withDefaultedCache returns a copy of w with a non-nil StateCache.
+// Zero-value wirings (the encryption-off test harnesses pass
+// encryptionWriteWiring{}) carry a nil cache; defaulting it here keeps
+// the "cache is always non-nil" contract that buildShardGroups'
+// WithStateCache wiring depends on, without adding a branch to
+// buildShardGroups itself.
+func (w encryptionWriteWiring) withDefaultedCache() encryptionWriteWiring {
+	if w.cache == nil {
+		w.cache = encryption.NewStateCache()
+	}
+	return w
+}
+
 // pebbleOptions returns the PebbleStore options for the storage
 // envelope. When the cipher is nil (encryption not enabled) it
 // returns no options, leaving the store in cleartext mode. When set,

--- a/main_encryption_write_wiring.go
+++ b/main_encryption_write_wiring.go
@@ -100,13 +100,18 @@ func buildEncryptionWriteWiring(kekWrapper encryption.KEKUnwrapper, keystore *en
 	if !*encryptionEnabled || kekWrapper == nil || *encryptionSidecarPath == "" {
 		return w, nil
 	}
+	// On error return w (with its non-nil cache) rather than a
+	// zero-value wiring: the caller aborts startup on the error and
+	// never consults the wiring, but keeping the cache non-nil on
+	// every return path avoids a latent nil-cache footgun for any
+	// future caller that reads w before checking err.
 	cipher, err := encryption.NewCipher(keystore)
 	if err != nil {
-		return encryptionWriteWiring{}, pkgerrors.Wrap(err, "build encryption write wiring: new cipher")
+		return w, pkgerrors.Wrap(err, "build encryption write wiring: new cipher")
 	}
 	epoch, err := prepareStorageNonceEpoch(*encryptionSidecarPath, kekWrapper, keystore, w.cache)
 	if err != nil {
-		return encryptionWriteWiring{}, err
+		return w, err
 	}
 	w.cipher = cipher
 	w.nonceFactory = encryption.NewDeterministicNonceFactory(

--- a/main_encryption_write_wiring.go
+++ b/main_encryption_write_wiring.go
@@ -33,8 +33,9 @@ func buildShardGroupsWithEncryptionWiring(
 	kekWrapper kek.Wrapper,
 	keystore *encryption.Keystore,
 	sidecarPath string,
+	encryptionEnabled bool,
 ) ([]*raftGroupRuntime, map[uint64]*kv.ShardGroup, error) {
-	encWiring, err := buildEncryptionWriteWiring(kekWrapper, keystore)
+	encWiring, err := buildEncryptionWriteWiring(encryptionEnabled, raftID, sidecarPath, kekWrapper, keystore)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -94,11 +95,17 @@ func (w encryptionWriteWiring) pebbleOptions() []store.PebbleStoreOption {
 }
 
 // buildEncryptionWriteWiring assembles the storage-envelope write-path
-// wiring from the process flags. It always returns a wiring with a
-// non-nil StateCache (the per-shard appliers need it regardless of
-// encryption state); the cipher + nonce factory are populated only
-// when encryption is enabled (--encryption-enabled AND --kekFile AND
-// --encryptionSidecarPath).
+// wiring. It always returns a wiring with a non-nil StateCache (the
+// per-shard appliers need it regardless of encryption state); the
+// cipher + nonce factory are populated only when encryption is enabled
+// (encryptionEnabled AND --kekFile AND a non-empty sidecarPath).
+//
+// Inputs are explicit parameters rather than the package-level flag
+// globals so the nonce factory's node_id is provably derived from the
+// same raftID the shard stores use, and so the helper is testable in
+// isolation (codex P2 on PR #826). run()'s orchestrator
+// buildShardGroupsWithEncryptionWiring threads its own raftID /
+// sidecarPath params plus *encryptionEnabled in.
 //
 // When a storage DEK is already active on disk (the restart path),
 // the function hydrates the keystore from the sidecar so the cipher
@@ -108,9 +115,9 @@ func (w encryptionWriteWiring) pebbleOptions() []store.PebbleStoreOption {
 // epoch defaults to 0 — the value a future runtime Bootstrap assigns
 // to the freshly minted DEK, which is that DEK's first-ever use and
 // therefore nonce-safe; a later restart will then take the bump path.
-func buildEncryptionWriteWiring(kekWrapper encryption.KEKUnwrapper, keystore *encryption.Keystore) (encryptionWriteWiring, error) {
+func buildEncryptionWriteWiring(encryptionEnabled bool, raftID, sidecarPath string, kekWrapper encryption.KEKUnwrapper, keystore *encryption.Keystore) (encryptionWriteWiring, error) {
 	w := encryptionWriteWiring{cache: encryption.NewStateCache()}
-	if !*encryptionEnabled || kekWrapper == nil || *encryptionSidecarPath == "" {
+	if !encryptionEnabled || kekWrapper == nil || sidecarPath == "" {
 		return w, nil
 	}
 	// On error return w (with its non-nil cache) rather than a
@@ -122,13 +129,13 @@ func buildEncryptionWriteWiring(kekWrapper encryption.KEKUnwrapper, keystore *en
 	if err != nil {
 		return w, pkgerrors.Wrap(err, "build encryption write wiring: new cipher")
 	}
-	epoch, err := prepareStorageNonceEpoch(*encryptionSidecarPath, kekWrapper, keystore, w.cache)
+	epoch, err := prepareStorageNonceEpoch(sidecarPath, kekWrapper, keystore, w.cache)
 	if err != nil {
 		return w, err
 	}
 	w.cipher = cipher
 	w.nonceFactory = encryption.NewDeterministicNonceFactory(
-		encryption.NodeID16(etcdraftengine.DeriveNodeID(*raftId)), epoch)
+		encryption.NodeID16(etcdraftengine.DeriveNodeID(raftID)), epoch)
 	return w, nil
 }
 

--- a/main_encryption_write_wiring_test.go
+++ b/main_encryption_write_wiring_test.go
@@ -134,6 +134,56 @@ func TestPrepareStorageNonceEpoch_ActiveDEK_HydratesAndBumps(t *testing.T) {
 	}
 }
 
+func TestBuildEncryptionWriteWiring_DisabledOrUnconfigured_Cleartext(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name        string
+		enabled     bool
+		sidecarPath string
+		kek         encryption.KEKUnwrapper
+	}{
+		{name: "flag_off", enabled: false, sidecarPath: "x.json", kek: wiringFakeKEK{}},
+		{name: "no_kek", enabled: true, sidecarPath: "x.json", kek: nil},
+		{name: "no_sidecar_path", enabled: true, sidecarPath: "", kek: wiringFakeKEK{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			w, err := buildEncryptionWriteWiring(tc.enabled, "n1", tc.sidecarPath, tc.kek, encryption.NewKeystore())
+			if err != nil {
+				t.Fatalf("buildEncryptionWriteWiring: %v", err)
+			}
+			if w.cache == nil {
+				t.Error("cache is nil; must be non-nil on every return path")
+			}
+			if w.cipher != nil || w.nonceFactory != nil {
+				t.Errorf("cipher/nonceFactory should be nil when encryption is off/unconfigured")
+			}
+			if opts := w.pebbleOptions(); opts != nil {
+				t.Errorf("pebbleOptions = %d, want nil (cleartext)", len(opts))
+			}
+		})
+	}
+}
+
+func TestBuildEncryptionWriteWiring_ActiveDEK_WiresCipher(t *testing.T) {
+	t.Parallel()
+	path := writeActiveStorageSidecar(t, 2)
+	w, err := buildEncryptionWriteWiring(true, "n1", path, wiringFakeKEK{}, encryption.NewKeystore())
+	if err != nil {
+		t.Fatalf("buildEncryptionWriteWiring: %v", err)
+	}
+	if w.cipher == nil || w.nonceFactory == nil {
+		t.Fatal("cipher/nonceFactory must be wired when encryption is enabled with an active DEK")
+	}
+	if opts := w.pebbleOptions(); len(opts) != 2 {
+		t.Errorf("pebbleOptions = %d, want 2", len(opts))
+	}
+	// Cache must reflect the on-disk active DEK + cutover gate.
+	if id, ok := w.cache.ActiveStorageKeyID(); !ok || id != 3 {
+		t.Errorf("cache ActiveStorageKeyID = (%d, %v), want (3, true)", id, ok)
+	}
+}
+
 func TestPrepareStorageNonceEpoch_SaturatedEpoch_RefusesWithExhausted(t *testing.T) {
 	t.Parallel()
 	// A storage DEK already at the 0xFFFF ceiling must refuse the

--- a/main_encryption_write_wiring_test.go
+++ b/main_encryption_write_wiring_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+)
+
+// wiringFakeKEK is a deterministic KEKUnwrapper for the write-wiring
+// tests: it pads/truncates the wrapped input to KeySize so the same
+// wrapped bytes always yield the same 32-byte DEK.
+type wiringFakeKEK struct{}
+
+func (wiringFakeKEK) Unwrap(wrapped []byte) ([]byte, error) {
+	out := make([]byte, encryption.KeySize)
+	copy(out, wrapped)
+	return out, nil
+}
+
+func writeActiveStorageSidecar(t *testing.T, storageEpoch uint16) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := dir + "/keys.json"
+	sc := &encryption.Sidecar{
+		Version:               encryption.SidecarVersion,
+		StorageEnvelopeActive: true,
+		Active:                encryption.ActiveKeys{Storage: 3, Raft: 4},
+		Keys: map[string]encryption.SidecarKey{
+			"3": {Purpose: encryption.SidecarPurposeStorage, Wrapped: []byte("storage-wrapped-bytes"), LocalEpoch: storageEpoch},
+			"4": {Purpose: encryption.SidecarPurposeRaft, Wrapped: []byte("raft-wrapped-bytes-diff"), LocalEpoch: 0},
+		},
+	}
+	if err := encryption.WriteSidecar(path, sc); err != nil {
+		t.Fatalf("WriteSidecar: %v", err)
+	}
+	return path
+}
+
+func TestEncryptionWriteWiring_PebbleOptions_CleartextWhenNoCipher(t *testing.T) {
+	t.Parallel()
+	if opts := (encryptionWriteWiring{}).pebbleOptions(); opts != nil {
+		t.Errorf("zero wiring pebbleOptions = %d opts, want nil (cleartext)", len(opts))
+	}
+	// cache present but cipher nil still means cleartext.
+	w := encryptionWriteWiring{cache: encryption.NewStateCache()}
+	if opts := w.pebbleOptions(); opts != nil {
+		t.Errorf("cipher-less wiring pebbleOptions = %d opts, want nil", len(opts))
+	}
+}
+
+func TestEncryptionWriteWiring_PebbleOptions_WiredWhenCipherSet(t *testing.T) {
+	t.Parallel()
+	cipher, err := encryption.NewCipher(encryption.NewKeystore())
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	w := encryptionWriteWiring{
+		cache:        encryption.NewStateCache(),
+		cipher:       cipher,
+		nonceFactory: encryption.NewDeterministicNonceFactory(0xABCD, 0),
+	}
+	if opts := w.pebbleOptions(); len(opts) != 2 {
+		t.Errorf("wired pebbleOptions = %d opts, want 2 (WithEncryption + WithStorageEnvelopeGate)", len(opts))
+	}
+}
+
+func TestPrepareStorageNonceEpoch_NoSidecar_ReturnsZero(t *testing.T) {
+	t.Parallel()
+	cache := encryption.NewStateCache()
+	epoch, err := prepareStorageNonceEpoch(t.TempDir()+"/absent.json", wiringFakeKEK{}, encryption.NewKeystore(), cache)
+	if err != nil {
+		t.Fatalf("prepareStorageNonceEpoch: %v", err)
+	}
+	if epoch != 0 {
+		t.Errorf("epoch = %d, want 0 (no sidecar / pre-bootstrap)", epoch)
+	}
+	if _, ok := cache.ActiveStorageKeyID(); ok {
+		t.Error("cache reports an active DEK with no sidecar")
+	}
+}
+
+func TestPrepareStorageNonceEpoch_NotBootstrapped_ReturnsZero(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := dir + "/keys.json"
+	// Sidecar with no active storage DEK (Active.Storage == 0).
+	if err := encryption.WriteSidecar(path, &encryption.Sidecar{Version: encryption.SidecarVersion}); err != nil {
+		t.Fatalf("WriteSidecar: %v", err)
+	}
+	cache := encryption.NewStateCache()
+	epoch, err := prepareStorageNonceEpoch(path, wiringFakeKEK{}, encryption.NewKeystore(), cache)
+	if err != nil {
+		t.Fatalf("prepareStorageNonceEpoch: %v", err)
+	}
+	if epoch != 0 {
+		t.Errorf("epoch = %d, want 0 (Active.Storage == 0)", epoch)
+	}
+}
+
+func TestPrepareStorageNonceEpoch_ActiveDEK_HydratesAndBumps(t *testing.T) {
+	t.Parallel()
+	path := writeActiveStorageSidecar(t, 6)
+	ks := encryption.NewKeystore()
+	cache := encryption.NewStateCache()
+	epoch, err := prepareStorageNonceEpoch(path, wiringFakeKEK{}, ks, cache)
+	if err != nil {
+		t.Fatalf("prepareStorageNonceEpoch: %v", err)
+	}
+	// Epoch must be bumped from the on-disk 6 to 7.
+	if epoch != 7 {
+		t.Errorf("epoch = %d, want 7 (bumped from 6)", epoch)
+	}
+	// Keystore must be hydrated with both DEKs (active + historical).
+	for _, id := range []uint32{3, 4} {
+		if !ks.Has(id) {
+			t.Errorf("keystore missing DEK id=%d after hydration", id)
+		}
+	}
+	// Cache must reflect the active storage DEK and the cutover gate.
+	if id, ok := cache.ActiveStorageKeyID(); !ok || id != 3 {
+		t.Errorf("cache ActiveStorageKeyID = (%d, %v), want (3, true)", id, ok)
+	}
+	if !cache.StorageEnvelopeActive() {
+		t.Error("cache StorageEnvelopeActive = false, want true (sidecar has it set)")
+	}
+	// The bump must be durable for the next process load.
+	sc, err := encryption.ReadSidecar(path)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	if sc.Keys["3"].LocalEpoch != 7 {
+		t.Errorf("persisted epoch = %d, want 7", sc.Keys["3"].LocalEpoch)
+	}
+}

--- a/main_encryption_write_wiring_test.go
+++ b/main_encryption_write_wiring_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/bootjp/elastickv/internal/encryption"
@@ -130,5 +131,20 @@ func TestPrepareStorageNonceEpoch_ActiveDEK_HydratesAndBumps(t *testing.T) {
 	}
 	if sc.Keys["3"].LocalEpoch != 7 {
 		t.Errorf("persisted epoch = %d, want 7", sc.Keys["3"].LocalEpoch)
+	}
+}
+
+func TestPrepareStorageNonceEpoch_SaturatedEpoch_RefusesWithExhausted(t *testing.T) {
+	t.Parallel()
+	// A storage DEK already at the 0xFFFF ceiling must refuse the
+	// bump (the ErrLocalEpochExhausted log + error path), so wiring
+	// fails closed rather than wrapping the epoch to 0.
+	path := writeActiveStorageSidecar(t, 0xFFFF)
+	_, err := prepareStorageNonceEpoch(path, wiringFakeKEK{}, encryption.NewKeystore(), encryption.NewStateCache())
+	if err == nil {
+		t.Fatal("expected error from saturated local_epoch, got nil")
+	}
+	if !errors.Is(err, encryption.ErrLocalEpochExhausted) {
+		t.Errorf("error not marked ErrLocalEpochExhausted: %v", err)
 	}
 }

--- a/multiraft_runtime_test.go
+++ b/multiraft_runtime_test.go
@@ -54,7 +54,7 @@ func TestBuildShardGroupsWithEtcdEngineRoutesAcrossGroups(t *testing.T) {
 	factory, err := newRaftFactory(raftEngineEtcd)
 	require.NoError(t, err)
 	clock := kv.NewHLC()
-	runtimes, shardGroups, err := buildShardGroups("n1", baseDir, groups, true, true, nil, factory, nil, clock, nil, nil, "")
+	runtimes, shardGroups, err := buildShardGroups("n1", baseDir, groups, true, true, nil, factory, nil, clock, nil, nil, "", encryptionWriteWiring{})
 	require.NoError(t, err)
 
 	engine := distribution.NewEngine()
@@ -108,7 +108,7 @@ func TestBuildShardGroupsWithEtcdEngineRestartsAcrossGroups(t *testing.T) {
 	openShardStore := func(bootstrap bool) ([]*raftGroupRuntime, map[uint64]*kv.ShardGroup, *kv.ShardStore) {
 		factory, err := newRaftFactory(raftEngineEtcd)
 		require.NoError(t, err)
-		runtimes, shardGroups, err := buildShardGroups("n1", baseDir, groups, true, bootstrap, nil, factory, nil, sharedClock, nil, nil, "")
+		runtimes, shardGroups, err := buildShardGroups("n1", baseDir, groups, true, bootstrap, nil, factory, nil, sharedClock, nil, nil, "", encryptionWriteWiring{})
 		require.NoError(t, err)
 		shardStore := kv.NewShardStore(engine, shardGroups)
 		return runtimes, shardGroups, shardStore


### PR DESCRIPTION
## Summary
Stage 6D-6c-2 wires the **production storage-envelope write path** in `main.go` so a `BootstrapEncryption` + `EnableStorageEnvelope` actually encrypts at-rest writes and reads them back. The naive `store.WithEncryption(cipher, nonceFactory, …)` wiring was unsafe because the only `NonceFactory` in the tree (`store.CounterNonceFactory`) resets its `write_count` to 0 on restart → catastrophic AES-GCM `(DEK, nonce)` reuse. This PR pulls forward the deterministic-nonce core of Stage 7 to make the path safe.

Doc-first per CLAUDE.md: the proposed design doc is the first commit, implementation follows.

### What landed
- **`encryption.HydrateKeystoreFromSidecar`** — unwraps every wrapped DEK in the sidecar under the KEK and installs it into the shared keystore, so the cipher can decrypt pre-existing envelopes after a restart where the `OpBootstrap`/`OpRotation` entries fell behind a Raft-log compaction window. Hydrates *all* keys (not just `Active.Storage`) so pre-rotation versions stay readable. Idempotent.
- **`encryption.BumpLocalEpoch`** — durable read-modify-write increment of the active storage DEK's §4.1 `local_epoch`, refusing at `0xFFFF` with `ErrLocalEpochExhausted`. Called once per process load before any nonce; this is what makes the per-load `write_count` reset nonce-safe across restarts.
- **`encryption.DeterministicNonceFactory`** — production `node_id ‖ local_epoch ‖ write_count` factory pinned to the bumped epoch (`store.NonceFactory`). Same layout as the test factory, but the epoch carries the restart-safety guarantee.
- **`main.go` wiring** — `buildEncryptionWriteWiring` / `prepareStorageNonceEpoch` build the cipher + nonce factory + shared `StateCache`; `buildShardGroups` threads `WithEncryption` + `WithStorageEnvelopeGate` into every shard's PebbleStore and `WithStateCache` into every Applier.
- **`encryption.NodeID16`** centralises the `uint16(full_node_id & 0xFFFF)` masked narrowing.

### Key design decision
The cipher is wired whenever encryption is **enabled** (not gated on bootstrap state) so a runtime Bootstrap + cutover engages encryption without a restart; the per-Put gate holds writes cleartext until both `ActiveStorageKeyID` and `StorageEnvelopeActive` commit. Pre-bootstrap pins `local_epoch = 0` (the value runtime Bootstrap assigns — first-ever use); a later restart takes the bump path, so the `(node_id, 0)` prefix is never reused under the same DEK across loads.

### Scope boundary (stays in Stage 7)
The Raft-replicated **registration-before-first-write** coordinator gate (cross-node-churn nonce safety) is deferred. 6D-6c-2's multi-node safety rests on the existing startup guards (`ErrNodeIDCollision`, `ErrLocalEpochRollback`) and the registry-apply-time collision check. Single-node correctness (the 6D-6c-3 e2e) is complete.

## Self-review (5 lenses)
1. **Data loss** — hydration/bump never delete a DEK or a committed write; bump consumes epochs monotonically and fsyncs (via `WriteSidecar`) before any nonce is issued; refused bump leaves the sidecar untouched.
2. **Concurrency** — nonce factory is `atomic.Uint64`; `StateCache` is atomic; hydrate/bump run single-threaded at startup before any store opens. `-race` clean.
3. **Performance** — startup-only cost; hot path is one atomic add per nonce plus the existing per-Put gate closure.
4. **Data consistency** — writes stay cleartext unless both gate signals are on; AAD binding unchanged; `local_epoch` monotonic across restarts; cipher wired-but-inert pre-cutover.
5. **Test coverage** — primitive unit tests (hydration multi-DEK/idempotent/KEK-failure/nil; bump increment+durability/0xFFFF-refusal/unknown-dek; nonce factory layout/monotonic/epoch-disjoint/concurrent) + main-wiring tests (cleartext-when-no-cipher, wired-when-cipher-set, prepareStorageNonceEpoch across no-sidecar/not-bootstrapped/active-DEK).

## Test plan
- [x] `go test -race ./internal/encryption/... ./store/... .`
- [x] `go vet ./...`
- [x] `golangci-lint run . ./internal/encryption/...` (0 issues)
- [ ] CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented production storage-envelope encryption write-path with deterministic nonce generation and epoch management.
  * Added encryption state management and sidecar hydration for secure key handling.
  * Added fail-closed error handling for write-count exhaustion with recovery via process restart.

* **Tests**
  * Comprehensive test coverage for deterministic nonce generation, concurrent uniqueness, and storage nonce epoch preparation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/826?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->