### PR TITLE
docs: promote keyviz per-cell conflict proposed -> implemented

### DIFF
--- a/docs/design/2026_05_25_implemented_keyviz_per_cell_conflict.md
+++ b/docs/design/2026_05_25_implemented_keyviz_per_cell_conflict.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: implemented
 phase: 2-C+
 parent_design: docs/admin_ui_key_visualizer_design.md
 date: 2026-05-25


### PR DESCRIPTION
PR-3d (#824) landed the per-cell `Conflicts` wire format + SPA per-cell hatching. This renames the design doc `2026_05_25_proposed_keyviz_per_cell_conflict.md` -> `*_implemented_*` and flips the frontmatter `status:` to `implemented`, per the `docs/design` lifecycle convention (and as confirmed by the PR-3d Round-3 review).

Docs-only, no code change.