### PR TITLE
backup: Phase 0b M2a — Redis string + HLL reverse encoder

### DIFF
--- a/internal/backup/encode_redis.go
+++ b/internal/backup/encode_redis.go
@@ -62,6 +62,14 @@ var ErrRedisEncodeNotDir = errors.New("backup: redis db path is not a directory"
 // on PR #828).
 var ErrRedisEncodeNotRegular = errors.New("backup: redis dump sidecar is not a regular file")
 
+// ErrRedisEncodeHardLink is returned (on platforms where the link
+// count is observable — see refuseHardLink) when a dump file has more
+// than one hard link. A hard link can name an inode outside the dump
+// subtree while passing the IsRegular and os.Root symlink guards, so
+// ingesting it would breach the untrusted-input boundary (codex P2 on
+// PR #828).
+var ErrRedisEncodeHardLink = errors.New("backup: redis dump file is hard-linked")
+
 // RedisEncoder reconstructs the internal Redis keyspace for one logical
 // database (redis/db_<n>/) from its decoded directory tree.
 type RedisEncoder struct {
@@ -258,6 +266,9 @@ func openDumpSidecar(dir, name string) (*os.File, error) {
 	if !info.Mode().IsRegular() {
 		return nil, errors.Wrapf(ErrRedisEncodeNotRegular, "%s (mode=%s)", name, info.Mode())
 	}
+	if err := refuseHardLink(info, name); err != nil {
+		return nil, err
+	}
 	root, err := os.OpenRoot(dir)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -279,6 +290,17 @@ func readRootFile(root *os.Root, name string) ([]byte, error) {
 		return nil, errors.WithStack(err)
 	}
 	defer func() { _ = f.Close() }()
+	// Refuse hard-linked blobs: a *.bin hard-linked to an inode outside
+	// the dump subtree passes IsRegular() and the os.Root escape guard,
+	// but ingesting its bytes would break the untrusted-input boundary
+	// (codex P2 on PR #828).
+	info, err := f.Stat()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if err := refuseHardLink(info, name); err != nil {
+		return nil, err
+	}
 	body, err := io.ReadAll(f)
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/internal/backup/encode_redis.go
+++ b/internal/backup/encode_redis.go
@@ -182,12 +182,24 @@ func (e *RedisEncoder) encodeHLL(b *snapshotBuilder) error {
 // to its original user key, reads the body, and invokes fn. A missing
 // subdir is not an error. Non-.bin entries and sub-directories are
 // skipped.
+//
+// Files are read through an os.Root rooted at the subdir, so a symlink
+// inside the dump that points outside the subdir is refused — a
+// crafted dump cannot make the encoder exfiltrate an arbitrary host
+// file. This also keeps the read off the tainted-path G304 lint path
+// without a //nolint suppression (the os.Root API is the gosec-blessed
+// safe-file-access primitive).
 func (e *RedisEncoder) walkBlobDir(subdir string, fn func(encoded string, rawKey, body []byte) error) error {
 	dir := filepath.Join(e.dbDir(), subdir)
-	entries, err := os.ReadDir(dir)
+	root, err := os.OpenRoot(dir)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer func() { _ = root.Close() }()
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -200,15 +212,31 @@ func (e *RedisEncoder) walkBlobDir(subdir string, fn func(encoded string, rawKey
 		if err != nil {
 			return err
 		}
-		body, err := os.ReadFile(filepath.Join(dir, ent.Name())) //nolint:gosec // path is dump-internal, validated dir
+		body, err := readRootFile(root, ent.Name())
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 		if err := fn(encoded, rawKey, body); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// readRootFile reads a regular file by name within root, refusing any
+// path that escapes the root (including via an in-dump symlink to an
+// external target).
+func readRootFile(root *os.Root, name string) ([]byte, error) {
+	f, err := root.Open(name)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer func() { _ = f.Close() }()
+	body, err := io.ReadAll(f)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return body, nil
 }
 
 // ttlSidecarRecord mirrors the JSONL shape appendTTL writes:

--- a/internal/backup/encode_redis.go
+++ b/internal/backup/encode_redis.go
@@ -204,7 +204,12 @@ func (e *RedisEncoder) walkBlobDir(subdir string, fn func(encoded string, rawKey
 		return errors.WithStack(err)
 	}
 	for _, ent := range entries {
-		if ent.IsDir() || !strings.HasSuffix(ent.Name(), ".bin") {
+		// Only regular .bin files. !IsRegular() skips directories,
+		// symlinks, and — the point of the guard — FIFOs / sockets /
+		// devices, which would otherwise reach io.ReadAll and block or
+		// misbehave (parity with openSidecarFile's non-regular refusal
+		// on the write side).
+		if !ent.Type().IsRegular() || !strings.HasSuffix(ent.Name(), ".bin") {
 			continue
 		}
 		encoded := strings.TrimSuffix(ent.Name(), ".bin")

--- a/internal/backup/encode_redis.go
+++ b/internal/backup/encode_redis.go
@@ -46,6 +46,13 @@ import (
 // under a truncated/hashed key the live cluster would never serve.
 var ErrRedisEncodeMissingKeymap = errors.New("backup: redis encode missing KEYMAP entry for sha-fallback key")
 
+// ErrRedisEncodeNotDir is returned when the redis/db_<n> path exists
+// but is a regular file rather than a directory — a malformed dump.
+// A dedicated sentinel (not ErrRedisEncodeMissingKeymap) so callers
+// can distinguish "bad dump layout" from "sha-fallback key without a
+// keymap entry" via errors.Is.
+var ErrRedisEncodeNotDir = errors.New("backup: redis db path is not a directory")
+
 // RedisEncoder reconstructs the internal Redis keyspace for one logical
 // database (redis/db_<n>/) from its decoded directory tree.
 type RedisEncoder struct {
@@ -79,7 +86,7 @@ func (e *RedisEncoder) Encode(b *snapshotBuilder) error {
 	case err != nil:
 		return errors.WithStack(err)
 	case !info.IsDir():
-		return errors.Wrapf(ErrRedisEncodeMissingKeymap, "db path %q is not a directory", dir)
+		return errors.Wrapf(ErrRedisEncodeNotDir, "db path %q", dir)
 	}
 	if err := e.loadKeymap(); err != nil {
 		return err
@@ -126,7 +133,11 @@ func (e *RedisEncoder) resolveKey(encoded string) ([]byte, error) {
 	if !ok {
 		return nil, errors.Wrapf(ErrRedisEncodeMissingKeymap, "encoded %q", encoded)
 	}
-	return rec.Original()
+	original, err := rec.Original()
+	if err != nil {
+		return nil, errors.Wrapf(err, "encoded %q", encoded)
+	}
+	return original, nil
 }
 
 // encodeStrings reconstructs !redis|str| records from strings/*.bin,
@@ -241,6 +252,14 @@ func (e *RedisEncoder) loadTTLMap(name string) (map[string]uint64, error) {
 // ([0xFF 0x01][flags][expireMs BE if has_ttl]) followed by the body.
 // expireMs == 0 means "no TTL" (flags=0); a non-zero value sets the
 // has-TTL flag and the 8-byte big-endian millis section.
+//
+// expireMs is written verbatim. The decode side clamps to MaxInt64
+// (decodeRedisStringValue), and the value originates from
+// strings_ttl.jsonl which decode already wrote post-clamp, so a
+// round-tripped dump never carries a value above MaxInt64 here. A
+// hand-crafted sidecar with a larger value would be silently clamped
+// on the next decode — an accepted asymmetry, not a live concern
+// (Unix-ms never reaches MaxInt64).
 func encodeRedisStrInlineValue(body []byte, expireMs uint64) []byte {
 	if expireMs == 0 {
 		out := make([]byte, redisStrBaseHeader+len(body))

--- a/internal/backup/encode_redis.go
+++ b/internal/backup/encode_redis.go
@@ -96,12 +96,17 @@ func (e *RedisEncoder) dbDir() string {
 // to encode for that database.
 func (e *RedisEncoder) Encode(b *snapshotBuilder) error {
 	dir := e.dbDir()
-	info, err := os.Stat(dir)
+	// Lstat (not Stat) so a symlinked db dir is refused rather than
+	// followed: os.OpenRoot below would otherwise resolve a symlinked
+	// redis/db_<n> outside the dump tree (codex P2 on PR #828).
+	info, err := os.Lstat(dir)
 	switch {
 	case errors.Is(err, os.ErrNotExist):
 		return nil
 	case err != nil:
 		return errors.WithStack(err)
+	case info.Mode()&os.ModeSymlink != 0:
+		return errors.Wrapf(ErrRedisEncodeNotDir, "db path %q is a symlink", dir)
 	case !info.IsDir():
 		return errors.Wrapf(ErrRedisEncodeNotDir, "db path %q", dir)
 	}
@@ -208,10 +213,13 @@ func (e *RedisEncoder) encodeHLL(b *snapshotBuilder) error {
 // safe-file-access primitive).
 func (e *RedisEncoder) walkBlobDir(subdir string, fn func(encoded string, rawKey, body []byte) error) error {
 	dir := filepath.Join(e.dbDir(), subdir)
-	root, err := os.OpenRoot(dir)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
+	if err := lstatDumpDir(dir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
 	}
+	root, err := os.OpenRoot(dir)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -221,26 +229,51 @@ func (e *RedisEncoder) walkBlobDir(subdir string, fn func(encoded string, rawKey
 		return errors.WithStack(err)
 	}
 	for _, ent := range entries {
-		// Only regular .bin files. !IsRegular() skips directories,
-		// symlinks, and — the point of the guard — FIFOs / sockets /
-		// devices, which would otherwise reach io.ReadAll and block or
-		// misbehave (parity with openSidecarFile's non-regular refusal
-		// on the write side).
-		if !ent.Type().IsRegular() || !strings.HasSuffix(ent.Name(), ".bin") {
-			continue
-		}
-		encoded := strings.TrimSuffix(ent.Name(), ".bin")
-		rawKey, err := e.resolveKey(encoded)
-		if err != nil {
+		if err := e.handleBlobEntry(root, ent, fn); err != nil {
 			return err
 		}
-		body, err := readRootFile(root, ent.Name())
-		if err != nil {
-			return err
-		}
-		if err := fn(encoded, rawKey, body); err != nil {
-			return err
-		}
+	}
+	return nil
+}
+
+// handleBlobEntry processes one directory entry from walkBlobDir.
+// Non-regular entries (directories, symlinks, FIFOs/sockets/devices)
+// and non-.bin names are skipped — the IsRegular() guard keeps a FIFO
+// from reaching io.ReadAll (parity with openSidecarFile's write-side
+// refusal).
+func (e *RedisEncoder) handleBlobEntry(root *os.Root, ent os.DirEntry, fn func(encoded string, rawKey, body []byte) error) error {
+	if !ent.Type().IsRegular() || !strings.HasSuffix(ent.Name(), ".bin") {
+		return nil
+	}
+	encoded := strings.TrimSuffix(ent.Name(), ".bin")
+	rawKey, err := e.resolveKey(encoded)
+	if err != nil {
+		return err
+	}
+	body, err := readRootFile(root, ent.Name())
+	if err != nil {
+		return err
+	}
+	return fn(encoded, rawKey, body)
+}
+
+// lstatDumpDir refuses a symlinked or non-directory path before it is
+// opened as an os.Root. os.OpenRoot follows a symlink in the final
+// path component, so a symlinked redis/db_<n>/<subdir> in an untrusted
+// dump would otherwise redirect the walk outside the dump tree and pull
+// external *.bin files into the snapshot (codex P2 on PR #828). The
+// wrapped os.ErrNotExist is preserved so callers treat a missing subdir
+// as a no-op.
+func lstatDumpDir(dir string) error {
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return errors.WithStack(err) // wraps os.ErrNotExist when absent
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return errors.Wrapf(ErrRedisEncodeNotDir, "%q is a symlink", dir)
+	}
+	if !info.IsDir() {
+		return errors.Wrapf(ErrRedisEncodeNotDir, "%q is not a directory", dir)
 	}
 	return nil
 }

--- a/internal/backup/encode_redis.go
+++ b/internal/backup/encode_redis.go
@@ -53,6 +53,15 @@ var ErrRedisEncodeMissingKeymap = errors.New("backup: redis encode missing KEYMA
 // keymap entry" via errors.Is.
 var ErrRedisEncodeNotDir = errors.New("backup: redis db path is not a directory")
 
+// ErrRedisEncodeNotRegular is returned when a dump sidecar
+// (KEYMAP.jsonl, strings_ttl.jsonl, ...) exists but is not a regular
+// file — a symlink, FIFO, device, or directory. Reading such a path
+// with plain os.Open would follow the symlink or block indefinitely on
+// a reader-less FIFO; the encoder fails closed instead, matching the
+// non-regular refusal walkBlobDir applies to *.bin entries (codex P2
+// on PR #828).
+var ErrRedisEncodeNotRegular = errors.New("backup: redis dump sidecar is not a regular file")
+
 // RedisEncoder reconstructs the internal Redis keyspace for one logical
 // database (redis/db_<n>/) from its decoded directory tree.
 type RedisEncoder struct {
@@ -101,13 +110,13 @@ func (e *RedisEncoder) Encode(b *snapshotBuilder) error {
 // encoded names can be reversed to their original key bytes. Absence is
 // fine — dumps without any long/sha-fallback keys carry no KEYMAP file.
 func (e *RedisEncoder) loadKeymap() error {
-	f, err := os.Open(filepath.Join(e.dbDir(), "KEYMAP.jsonl"))
+	f, err := openDumpSidecar(e.dbDir(), "KEYMAP.jsonl")
 	if errors.Is(err, os.ErrNotExist) {
 		e.keymap = map[string]KeymapRecord{}
 		return nil
 	}
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	defer func() { _ = f.Close() }()
 	m, err := LoadKeymap(f)
@@ -228,6 +237,39 @@ func (e *RedisEncoder) walkBlobDir(subdir string, fn func(encoded string, rawKey
 	return nil
 }
 
+// openDumpSidecar opens a fixed-name regular file at <dir>/<name> for
+// reading, refusing symlinks and non-regular files (FIFO / device /
+// directory) — the read-side analogue of walkBlobDir's
+// os.Root + IsRegular guard for the dump's sidecar files (KEYMAP.jsonl,
+// *_ttl.jsonl). Returns a wrapped os.ErrNotExist when the file is
+// absent so callers can treat a missing sidecar as empty.
+//
+// The Lstat type check refuses a symlink (Lstat sees the link itself,
+// not its target) and a reader-less FIFO BEFORE any blocking open, then
+// the read goes through an os.Root so the open additionally cannot
+// escape <dir>. A concurrent swap of a confirmed-regular file to a FIFO
+// between Lstat and open is the only residual race and is not a
+// concern for an offline tool reading a static dump tree.
+func openDumpSidecar(dir, name string) (*os.File, error) {
+	info, err := os.Lstat(filepath.Join(dir, name))
+	if err != nil {
+		return nil, errors.WithStack(err) // wraps os.ErrNotExist when absent
+	}
+	if !info.Mode().IsRegular() {
+		return nil, errors.Wrapf(ErrRedisEncodeNotRegular, "%s (mode=%s)", name, info.Mode())
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer func() { _ = root.Close() }()
+	f, err := root.Open(name)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return f, nil
+}
+
 // readRootFile reads a regular file by name within root, refusing any
 // path that escapes the root (including via an in-dump symlink to an
 // external target).
@@ -257,12 +299,12 @@ type ttlSidecarRecord struct {
 // sidecar stores and what the .bin filenames share, so callers look up
 // by the filename stem without re-encoding.
 func (e *RedisEncoder) loadTTLMap(name string) (map[string]uint64, error) {
-	f, err := os.Open(filepath.Join(e.dbDir(), name))
+	f, err := openDumpSidecar(e.dbDir(), name)
 	if errors.Is(err, os.ErrNotExist) {
 		return map[string]uint64{}, nil
 	}
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	defer func() { _ = f.Close() }()
 	out := map[string]uint64{}

--- a/internal/backup/encode_redis.go
+++ b/internal/backup/encode_redis.go
@@ -1,0 +1,269 @@
+package backup
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// encode_redis.go is the Phase 0b Redis reverse encoder — the inverse
+// of the RedisDB decoder in redis_*.go (design:
+// docs/design/2026_05_25_proposed_snapshot_logical_encoder.md §"Redis").
+// It walks a decoded redis/db_<n>/ subtree and feeds the reconstructed
+// internal records to a snapshotBuilder, which MVCC-frames and writes
+// them.
+//
+// This commit covers the simple-value families: strings, HLL, and the
+// TTL handling for both. The wide-column collections (hash, list, set,
+// zset, stream) land in subsequent commits on the same milestone.
+//
+// Format fidelity is pinned against the live adapter write path
+// (adapter/redis_compat_types.go, adapter/redis.go), not just the
+// decode side, so the emitted .fsm loads into a running cluster:
+//
+//   - String values carry TTL INLINE in the value header
+//     (encodeRedisStr: [0xFF 0x01][flags][expireMs BE if has_ttl][body]).
+//     The live store sets NO MVCC-level expireAt for redis writes
+//     (kv.Elem has no expiry field) and writes NO !redis|ttl| scan-index
+//     row for strings (buildTTLElems explicitly skips string keys).
+//   - HLL values are raw sketch bytes with no inline header; their TTL
+//     lives in a !redis|ttl|<userKey> scan-index row (8-byte BE ms),
+//     matching buildTTLElems for non-string types.
+//
+// All redis entries therefore use MVCC value-header expireAt = 0
+// (the redis adapter manages expiry itself); the builder's expireAt
+// argument is always 0 here.
+
+// ErrRedisEncodeMissingKeymap is returned when a strings/ or hll/ file
+// name (or a TTL sidecar key) took the SHA-fallback encoding but the
+// db's KEYMAP.jsonl has no matching record to recover the original
+// user-key bytes. The encoder fails closed rather than emit a record
+// under a truncated/hashed key the live cluster would never serve.
+var ErrRedisEncodeMissingKeymap = errors.New("backup: redis encode missing KEYMAP entry for sha-fallback key")
+
+// RedisEncoder reconstructs the internal Redis keyspace for one logical
+// database (redis/db_<n>/) from its decoded directory tree.
+type RedisEncoder struct {
+	inRoot  string
+	dbIndex int
+	keymap  map[string]KeymapRecord
+}
+
+// NewRedisEncoder constructs an encoder rooted at <inRoot>/redis/db_<n>/.
+// Negative dbIndex is coerced to 0 (mirrors NewRedisDB).
+func NewRedisEncoder(inRoot string, dbIndex int) *RedisEncoder {
+	if dbIndex < 0 {
+		dbIndex = 0
+	}
+	return &RedisEncoder{inRoot: inRoot, dbIndex: dbIndex}
+}
+
+func (e *RedisEncoder) dbDir() string {
+	return filepath.Join(e.inRoot, "redis", redisDBSegment(e.dbIndex))
+}
+
+// Encode walks the db subtree and stages every reconstructed record on
+// b. A missing db directory is not an error — there is simply nothing
+// to encode for that database.
+func (e *RedisEncoder) Encode(b *snapshotBuilder) error {
+	dir := e.dbDir()
+	info, err := os.Stat(dir)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return nil
+	case err != nil:
+		return errors.WithStack(err)
+	case !info.IsDir():
+		return errors.Wrapf(ErrRedisEncodeMissingKeymap, "db path %q is not a directory", dir)
+	}
+	if err := e.loadKeymap(); err != nil {
+		return err
+	}
+	if err := e.encodeStrings(b); err != nil {
+		return err
+	}
+	return e.encodeHLL(b)
+}
+
+// loadKeymap reads the db's KEYMAP.jsonl (if present) so sha-fallback
+// encoded names can be reversed to their original key bytes. Absence is
+// fine — dumps without any long/sha-fallback keys carry no KEYMAP file.
+func (e *RedisEncoder) loadKeymap() error {
+	f, err := os.Open(filepath.Join(e.dbDir(), "KEYMAP.jsonl"))
+	if errors.Is(err, os.ErrNotExist) {
+		e.keymap = map[string]KeymapRecord{}
+		return nil
+	}
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer func() { _ = f.Close() }()
+	m, err := LoadKeymap(f)
+	if err != nil {
+		return err
+	}
+	e.keymap = m
+	return nil
+}
+
+// resolveKey turns an encoded path segment / TTL key back into the
+// original Redis user-key bytes: percent/binary segments decode
+// directly; SHA-fallback segments are recovered from KEYMAP.jsonl.
+func (e *RedisEncoder) resolveKey(encoded string) ([]byte, error) {
+	raw, err := DecodeSegment(encoded)
+	if err == nil {
+		return raw, nil
+	}
+	if !errors.Is(err, ErrShaFallbackNeedsKeymap) {
+		return nil, err
+	}
+	rec, ok := e.keymap[encoded]
+	if !ok {
+		return nil, errors.Wrapf(ErrRedisEncodeMissingKeymap, "encoded %q", encoded)
+	}
+	return rec.Original()
+}
+
+// encodeStrings reconstructs !redis|str| records from strings/*.bin,
+// folding any strings_ttl.jsonl expiry back into the inline value
+// header (the live string format). No !redis|ttl| row is emitted for
+// strings — buildTTLElems skips them.
+func (e *RedisEncoder) encodeStrings(b *snapshotBuilder) error {
+	ttls, err := e.loadTTLMap(redisStringsTTLFile)
+	if err != nil {
+		return err
+	}
+	return e.walkBlobDir("strings", func(encoded string, rawKey, body []byte) error {
+		value := encodeRedisStrInlineValue(body, ttls[encoded])
+		key := append([]byte(RedisStringPrefix), rawKey...)
+		return b.Add(key, value, 0)
+	})
+}
+
+// encodeHLL reconstructs !redis|hll| records from hll/*.bin (raw sketch
+// bytes) plus the !redis|ttl| scan-index row for any expiring HLL key,
+// matching buildTTLElems for non-string types.
+func (e *RedisEncoder) encodeHLL(b *snapshotBuilder) error {
+	ttls, err := e.loadTTLMap(redisHLLTTLFile)
+	if err != nil {
+		return err
+	}
+	return e.walkBlobDir("hll", func(encoded string, rawKey, body []byte) error {
+		key := append([]byte(RedisHLLPrefix), rawKey...)
+		if err := b.Add(key, body, 0); err != nil {
+			return err
+		}
+		expireMs, ok := ttls[encoded]
+		if !ok || expireMs == 0 {
+			return nil
+		}
+		ttlKey := append([]byte(RedisTTLPrefix), rawKey...)
+		return b.Add(ttlKey, encodeRedisTTLValueMs(expireMs), 0)
+	})
+}
+
+// walkBlobDir iterates <dbDir>/<subdir>/*.bin, resolves each filename
+// to its original user key, reads the body, and invokes fn. A missing
+// subdir is not an error. Non-.bin entries and sub-directories are
+// skipped.
+func (e *RedisEncoder) walkBlobDir(subdir string, fn func(encoded string, rawKey, body []byte) error) error {
+	dir := filepath.Join(e.dbDir(), subdir)
+	entries, err := os.ReadDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	for _, ent := range entries {
+		if ent.IsDir() || !strings.HasSuffix(ent.Name(), ".bin") {
+			continue
+		}
+		encoded := strings.TrimSuffix(ent.Name(), ".bin")
+		rawKey, err := e.resolveKey(encoded)
+		if err != nil {
+			return err
+		}
+		body, err := os.ReadFile(filepath.Join(dir, ent.Name())) //nolint:gosec // path is dump-internal, validated dir
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if err := fn(encoded, rawKey, body); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ttlSidecarRecord mirrors the JSONL shape appendTTL writes:
+// {"key": <encoded>, "expire_at_ms": <uint64>}.
+type ttlSidecarRecord struct {
+	Key        string `json:"key"`
+	ExpireAtMs uint64 `json:"expire_at_ms"`
+}
+
+// loadTTLMap reads a TTL sidecar (strings_ttl.jsonl / hll_ttl.jsonl)
+// into encoded-key -> expire_at_ms. Absence is fine (no expiring keys).
+// The map is keyed by the ENCODED segment because that is what the
+// sidecar stores and what the .bin filenames share, so callers look up
+// by the filename stem without re-encoding.
+func (e *RedisEncoder) loadTTLMap(name string) (map[string]uint64, error) {
+	f, err := os.Open(filepath.Join(e.dbDir(), name))
+	if errors.Is(err, os.ErrNotExist) {
+		return map[string]uint64{}, nil
+	}
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer func() { _ = f.Close() }()
+	out := map[string]uint64{}
+	dec := json.NewDecoder(f)
+	for {
+		var rec ttlSidecarRecord
+		if err := dec.Decode(&rec); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, errors.Wrapf(err, "decode %s", name)
+		}
+		out[rec.Key] = rec.ExpireAtMs
+	}
+	return out, nil
+}
+
+// encodeRedisStrInlineValue reproduces adapter/redis_compat_types.go's
+// encodeRedisStr for the dump path: a new-format header
+// ([0xFF 0x01][flags][expireMs BE if has_ttl]) followed by the body.
+// expireMs == 0 means "no TTL" (flags=0); a non-zero value sets the
+// has-TTL flag and the 8-byte big-endian millis section.
+func encodeRedisStrInlineValue(body []byte, expireMs uint64) []byte {
+	if expireMs == 0 {
+		out := make([]byte, redisStrBaseHeader+len(body))
+		out[0] = redisStrMagic
+		out[1] = redisStrVersion
+		out[2] = 0
+		copy(out[redisStrBaseHeader:], body)
+		return out
+	}
+	out := make([]byte, redisStrBaseHeader+redisUint64Bytes+len(body))
+	out[0] = redisStrMagic
+	out[1] = redisStrVersion
+	out[2] = redisStrHasTTL
+	binary.BigEndian.PutUint64(out[redisStrBaseHeader:redisStrBaseHeader+redisUint64Bytes], expireMs)
+	copy(out[redisStrBaseHeader+redisUint64Bytes:], body)
+	return out
+}
+
+// encodeRedisTTLValueMs reproduces adapter/redis_compat_types.go's
+// encodeRedisTTL for the dump path: the 8-byte big-endian expiry
+// millis the !redis|ttl| scan-index row carries.
+func encodeRedisTTLValueMs(expireMs uint64) []byte {
+	buf := make([]byte, redisUint64Bytes)
+	binary.BigEndian.PutUint64(buf, expireMs)
+	return buf
+}

--- a/internal/backup/encode_redis_hardlink_unix_test.go
+++ b/internal/backup/encode_redis_hardlink_unix_test.go
@@ -68,6 +68,57 @@ func TestRedisEncodeRejectsHardLinkedKeymap(t *testing.T) {
 	}
 }
 
+// TestRedisEncodeRejectsSymlinkedBlobSubdir pins that a symlinked
+// strings/ (or hll/) subdir is refused before os.OpenRoot follows it
+// outside the dump tree. Unix-only (os.Symlink + the threat model).
+func TestRedisEncodeRejectsSymlinkedBlobSubdir(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	// External directory holding a .bin the attacker wants ingested.
+	external := filepath.Join(in, "external")
+	if err := os.MkdirAll(external, 0o755); err != nil {
+		t.Fatalf("mkdir external: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(external, EncodeSegment([]byte("k"))+".bin"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write external blob: %v", err)
+	}
+	dbDir := filepath.Join(in, "redis", "db_0")
+	if err := os.MkdirAll(dbDir, 0o755); err != nil {
+		t.Fatalf("mkdir dbDir: %v", err)
+	}
+	if err := os.Symlink(external, filepath.Join(dbDir, "strings")); err != nil {
+		t.Fatalf("symlink strings: %v", err)
+	}
+	b := newSnapshotBuilder(redisEncTS)
+	err := NewRedisEncoder(in, 0).Encode(b)
+	if !errors.Is(err, ErrRedisEncodeNotDir) {
+		t.Fatalf("Encode err = %v, want ErrRedisEncodeNotDir", err)
+	}
+}
+
+// TestRedisEncodeRejectsSymlinkedDbDir pins that a symlinked
+// redis/db_<n> directory is refused (Lstat in Encode) rather than
+// followed outside the dump tree.
+func TestRedisEncodeRejectsSymlinkedDbDir(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	external := filepath.Join(in, "external_db")
+	if err := os.MkdirAll(filepath.Join(external, "strings"), 0o755); err != nil {
+		t.Fatalf("mkdir external db: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(in, "redis"), 0o755); err != nil {
+		t.Fatalf("mkdir redis: %v", err)
+	}
+	if err := os.Symlink(external, filepath.Join(in, "redis", "db_0")); err != nil {
+		t.Fatalf("symlink db_0: %v", err)
+	}
+	b := newSnapshotBuilder(redisEncTS)
+	err := NewRedisEncoder(in, 0).Encode(b)
+	if !errors.Is(err, ErrRedisEncodeNotDir) {
+		t.Fatalf("Encode err = %v, want ErrRedisEncodeNotDir", err)
+	}
+}
+
 // TestRedisEncodeRejectsHardLinkedTTLSidecar pins the same guard for a
 // TTL sidecar (strings_ttl.jsonl) — the same openDumpSidecar path as
 // the KEYMAP case, exercised separately for coverage symmetry.

--- a/internal/backup/encode_redis_hardlink_unix_test.go
+++ b/internal/backup/encode_redis_hardlink_unix_test.go
@@ -1,0 +1,69 @@
+//go:build unix
+
+package backup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+)
+
+// TestRedisEncodeRejectsHardLinkedBlob pins that a *.bin entry which is
+// a hard link (nlink > 1) — potentially naming an inode outside the
+// dump subtree — fails closed with ErrRedisEncodeHardLink rather than
+// having its bytes ingested into the snapshot. Unix-only: the link
+// count guard (refuseHardLink) is a no-op on platforms without
+// syscall.Stat_t.Nlink.
+func TestRedisEncodeRejectsHardLinkedBlob(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	// A target file outside the strings/ subdir.
+	target := filepath.Join(in, "external.txt")
+	if err := os.WriteFile(target, []byte("external bytes"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	blobDir := filepath.Join(in, "redis", "db_0", "strings")
+	if err := os.MkdirAll(blobDir, 0o755); err != nil {
+		t.Fatalf("mkdir strings: %v", err)
+	}
+	enc := EncodeSegment([]byte("k"))
+	// Hard-link the external file into the dump as a blob (nlink == 2).
+	if err := os.Link(target, filepath.Join(blobDir, enc+".bin")); err != nil {
+		t.Fatalf("os.Link: %v", err)
+	}
+	b := newSnapshotBuilder(redisEncTS)
+	err := NewRedisEncoder(in, 0).Encode(b)
+	if !errors.Is(err, ErrRedisEncodeHardLink) {
+		t.Fatalf("Encode err = %v, want ErrRedisEncodeHardLink", err)
+	}
+}
+
+// TestRedisEncodeRejectsHardLinkedKeymap pins the same guard for the
+// KEYMAP.jsonl sidecar (read via openDumpSidecar's Lstat-based check).
+func TestRedisEncodeRejectsHardLinkedKeymap(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	target := filepath.Join(in, "external.jsonl")
+	if err := os.WriteFile(target, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	dbDir := filepath.Join(in, "redis", "db_0")
+	if err := os.MkdirAll(filepath.Join(dbDir, "strings"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// A real string so Encode reaches loadKeymap.
+	enc := EncodeSegment([]byte("k"))
+	if err := os.WriteFile(filepath.Join(dbDir, "strings", enc+".bin"), []byte("v"), 0o600); err != nil {
+		t.Fatalf("write blob: %v", err)
+	}
+	if err := os.Link(target, filepath.Join(dbDir, "KEYMAP.jsonl")); err != nil {
+		t.Fatalf("os.Link: %v", err)
+	}
+	b := newSnapshotBuilder(redisEncTS)
+	err := NewRedisEncoder(in, 0).Encode(b)
+	if !errors.Is(err, ErrRedisEncodeHardLink) {
+		t.Fatalf("Encode err = %v, want ErrRedisEncodeHardLink", err)
+	}
+}

--- a/internal/backup/encode_redis_hardlink_unix_test.go
+++ b/internal/backup/encode_redis_hardlink_unix_test.go
@@ -67,3 +67,31 @@ func TestRedisEncodeRejectsHardLinkedKeymap(t *testing.T) {
 		t.Fatalf("Encode err = %v, want ErrRedisEncodeHardLink", err)
 	}
 }
+
+// TestRedisEncodeRejectsHardLinkedTTLSidecar pins the same guard for a
+// TTL sidecar (strings_ttl.jsonl) — the same openDumpSidecar path as
+// the KEYMAP case, exercised separately for coverage symmetry.
+func TestRedisEncodeRejectsHardLinkedTTLSidecar(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	target := filepath.Join(in, "external_ttl.jsonl")
+	if err := os.WriteFile(target, []byte(`{"key":"x","expire_at_ms":1}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	dbDir := filepath.Join(in, "redis", "db_0")
+	if err := os.MkdirAll(filepath.Join(dbDir, "strings"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	enc := EncodeSegment([]byte("k"))
+	if err := os.WriteFile(filepath.Join(dbDir, "strings", enc+".bin"), []byte("v"), 0o600); err != nil {
+		t.Fatalf("write blob: %v", err)
+	}
+	if err := os.Link(target, filepath.Join(dbDir, "strings_ttl.jsonl")); err != nil {
+		t.Fatalf("os.Link: %v", err)
+	}
+	b := newSnapshotBuilder(redisEncTS)
+	err := NewRedisEncoder(in, 0).Encode(b)
+	if !errors.Is(err, ErrRedisEncodeHardLink) {
+		t.Fatalf("Encode err = %v, want ErrRedisEncodeHardLink", err)
+	}
+}

--- a/internal/backup/encode_redis_test.go
+++ b/internal/backup/encode_redis_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/cockroachdb/errors"
 )
 
 // redisEncTS is the commit timestamp the Redis encoder tests stamp.
@@ -157,8 +159,115 @@ func TestRedisEncodeMissingDBIsNoop(t *testing.T) {
 	}
 }
 
-// writeTTLSidecar appends one {"key","expire_at_ms"} record to a TTL
-// sidecar JSONL under <root>/redis/db_0/.
+// TestRedisEncodeHLLNoTTLRoundTripViaDecode pins the no-TTL HLL branch
+// (the !ok || expireMs==0 early return in encodeHLL): the sketch
+// survives and no hll_ttl.jsonl is produced.
+func TestRedisEncodeHLLNoTTLRoundTripViaDecode(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	enc := EncodeSegment([]byte("nottl"))
+	sketch := []byte{0xAA, 0xBB, 0xCC}
+	writeRedisFile(t, in, filepath.Join("hll", enc+".bin"), sketch)
+
+	out := decodeRedisTree(t, encodeRedisTree(t, in))
+
+	got, err := os.ReadFile(filepath.Join(out, "redis", "db_0", "hll", enc+".bin"))
+	if err != nil {
+		t.Fatalf("read decoded hll: %v", err)
+	}
+	if !bytes.Equal(got, sketch) {
+		t.Fatalf("decoded hll = %x, want %x", got, sketch)
+	}
+	if _, err := os.Stat(filepath.Join(out, "redis", "db_0", "hll_ttl.jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("hll_ttl.jsonl should be absent for a no-TTL HLL, stat err = %v", err)
+	}
+}
+
+// TestRedisEncodeShaFallbackResolvesViaKeymap pins the SHA-fallback
+// happy path: a key too long for direct encoding takes the SHA-fallback
+// filename, and the encoder recovers the original bytes from KEYMAP.jsonl
+// so the round-trip restores the same key.
+func TestRedisEncodeShaFallbackResolvesViaKeymap(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	longKey := bytes.Repeat([]byte("k"), 300) // > 240-byte segment cap
+	enc := EncodeSegment(longKey)
+	if !IsShaFallback(enc) {
+		t.Fatalf("EncodeSegment(300 bytes) = %q, expected sha-fallback", enc)
+	}
+	writeRedisFile(t, in, filepath.Join("strings", enc+".bin"), []byte("payload"))
+	writeKeymap(t, in, enc, longKey)
+
+	out := decodeRedisTree(t, encodeRedisTree(t, in))
+
+	// Decode re-encodes the recovered key to the same sha-fallback name.
+	got, err := os.ReadFile(filepath.Join(out, "redis", "db_0", "strings", enc+".bin"))
+	if err != nil {
+		t.Fatalf("read decoded string: %v", err)
+	}
+	if !bytes.Equal(got, []byte("payload")) {
+		t.Fatalf("decoded string = %q, want %q", got, "payload")
+	}
+}
+
+// TestRedisEncodeShaFallbackMissingKeymapFailsClosed pins the primary
+// error contract: a SHA-fallback filename with no KEYMAP entry fails
+// closed with ErrRedisEncodeMissingKeymap rather than emitting a record
+// under a hashed key.
+func TestRedisEncodeShaFallbackMissingKeymapFailsClosed(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	longKey := bytes.Repeat([]byte("m"), 300)
+	enc := EncodeSegment(longKey)
+	writeRedisFile(t, in, filepath.Join("strings", enc+".bin"), []byte("x"))
+	// No KEYMAP.jsonl written.
+
+	b := newSnapshotBuilder(redisEncTS)
+	err := NewRedisEncoder(in, 0).Encode(b)
+	if !errors.Is(err, ErrRedisEncodeMissingKeymap) {
+		t.Fatalf("Encode err = %v, want ErrRedisEncodeMissingKeymap", err)
+	}
+}
+
+// TestRedisEncodeNotDirFailsClosed pins that a redis/db_0 path that is a
+// regular file (malformed dump) fails with ErrRedisEncodeNotDir — a
+// dedicated sentinel distinct from the missing-keymap contract.
+func TestRedisEncodeNotDirFailsClosed(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(in, "redis"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(in, "redis", "db_0"), []byte("not a dir"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	b := newSnapshotBuilder(redisEncTS)
+	err := NewRedisEncoder(in, 0).Encode(b)
+	if !errors.Is(err, ErrRedisEncodeNotDir) {
+		t.Fatalf("Encode err = %v, want ErrRedisEncodeNotDir", err)
+	}
+}
+
+// writeKeymap writes a single-entry KEYMAP.jsonl mapping the encoded
+// segment back to its original bytes (base64url, the KeymapRecord
+// schema), under <root>/redis/db_0/.
+func writeKeymap(t *testing.T, root, encoded string, original []byte) {
+	t.Helper()
+	var buf bytes.Buffer
+	w := NewKeymapWriter(&buf)
+	if err := w.WriteOriginal(encoded, original, "redis-string"); err != nil {
+		t.Fatalf("keymap WriteOriginal: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("keymap Close: %v", err)
+	}
+	writeRedisFile(t, root, "KEYMAP.jsonl", buf.Bytes())
+}
+
+// writeTTLSidecar writes a single {"key","expire_at_ms"} record to a TTL
+// sidecar JSONL under <root>/redis/db_0/. NOTE: it truncates (one entry
+// per call); a multi-entry helper is added when the collection encoders
+// (M2b) need it.
 func writeTTLSidecar(t *testing.T, root, name, encodedKey string, expireMs uint64) {
 	t.Helper()
 	rec := ttlSidecarRecord{Key: encodedKey, ExpireAtMs: expireMs}

--- a/internal/backup/encode_redis_test.go
+++ b/internal/backup/encode_redis_test.go
@@ -251,6 +251,44 @@ func TestRedisEncodeNotDirFailsClosed(t *testing.T) {
 	}
 }
 
+// TestRedisEncodeRejectsNonRegularKeymap pins that a non-regular file
+// at the KEYMAP.jsonl path (here a directory, cross-platform stand-in
+// for a symlink/FIFO/device) fails closed with ErrRedisEncodeNotRegular
+// rather than being followed or blocking the encoder.
+func TestRedisEncodeRejectsNonRegularKeymap(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	// A real string so the encoder reaches loadKeymap.
+	enc := EncodeSegment([]byte("k"))
+	writeRedisFile(t, in, filepath.Join("strings", enc+".bin"), []byte("v"))
+	// Place a directory where KEYMAP.jsonl should be a regular file.
+	if err := os.MkdirAll(filepath.Join(in, "redis", "db_0", "KEYMAP.jsonl"), 0o755); err != nil {
+		t.Fatalf("mkdir KEYMAP.jsonl: %v", err)
+	}
+	b := newSnapshotBuilder(redisEncTS)
+	err := NewRedisEncoder(in, 0).Encode(b)
+	if !errors.Is(err, ErrRedisEncodeNotRegular) {
+		t.Fatalf("Encode err = %v, want ErrRedisEncodeNotRegular", err)
+	}
+}
+
+// TestRedisEncodeRejectsNonRegularTTLSidecar pins the same guard for a
+// TTL sidecar (strings_ttl.jsonl).
+func TestRedisEncodeRejectsNonRegularTTLSidecar(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	enc := EncodeSegment([]byte("k"))
+	writeRedisFile(t, in, filepath.Join("strings", enc+".bin"), []byte("v"))
+	if err := os.MkdirAll(filepath.Join(in, "redis", "db_0", "strings_ttl.jsonl"), 0o755); err != nil {
+		t.Fatalf("mkdir strings_ttl.jsonl: %v", err)
+	}
+	b := newSnapshotBuilder(redisEncTS)
+	err := NewRedisEncoder(in, 0).Encode(b)
+	if !errors.Is(err, ErrRedisEncodeNotRegular) {
+		t.Fatalf("Encode err = %v, want ErrRedisEncodeNotRegular", err)
+	}
+}
+
 // writeKeymap writes a single-entry KEYMAP.jsonl mapping the encoded
 // segment back to its original bytes (base64url, the KeymapRecord
 // schema), under <root>/redis/db_0/.

--- a/internal/backup/encode_redis_test.go
+++ b/internal/backup/encode_redis_test.go
@@ -1,0 +1,190 @@
+package backup
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// redisEncTS is the commit timestamp the Redis encoder tests stamp.
+const redisEncTS uint64 = 0x0001_8F1A_2B3C_0042
+
+// writeRedisFile writes one file under <root>/redis/db_0/<rel>,
+// creating parent dirs.
+func writeRedisFile(t *testing.T, root, rel string, data []byte) {
+	t.Helper()
+	path := filepath.Join(root, "redis", "db_0", rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("WriteFile %s: %v", rel, err)
+	}
+}
+
+// encodeRedisTree runs the Redis encoder over inRoot and returns the
+// resulting EKVPBBL1 bytes.
+func encodeRedisTree(t *testing.T, inRoot string) []byte {
+	t.Helper()
+	b := newSnapshotBuilder(redisEncTS)
+	if err := NewRedisEncoder(inRoot, 0).Encode(b); err != nil {
+		t.Fatalf("RedisEncoder.Encode: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := b.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// decodeRedisTree decodes fsm bytes through the real decode path into a
+// fresh output tree and returns its root.
+func decodeRedisTree(t *testing.T, fsm []byte) string {
+	t.Helper()
+	out := t.TempDir()
+	_, err := DecodeSnapshot(bytes.NewReader(fsm), DecodeOptions{
+		OutRoot:  out,
+		Adapters: AdapterSet{Redis: true},
+	})
+	if err != nil {
+		t.Fatalf("DecodeSnapshot: %v", err)
+	}
+	return out
+}
+
+// TestRedisEncodeStringRoundTripViaDecode runs the gold-standard
+// directory round-trip for a no-TTL string: dir -> encode -> .fsm ->
+// (real) decode -> dir', asserting the body survives byte-for-byte.
+func TestRedisEncodeStringRoundTripViaDecode(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	enc := EncodeSegment([]byte("mykey"))
+	writeRedisFile(t, in, filepath.Join("strings", enc+".bin"), []byte("hello"))
+
+	out := decodeRedisTree(t, encodeRedisTree(t, in))
+
+	got, err := os.ReadFile(filepath.Join(out, "redis", "db_0", "strings", enc+".bin"))
+	if err != nil {
+		t.Fatalf("read decoded string: %v", err)
+	}
+	if !bytes.Equal(got, []byte("hello")) {
+		t.Fatalf("decoded string = %q, want %q", got, "hello")
+	}
+}
+
+// TestRedisEncodeStringTTLRoundTripViaDecode pins that a string's TTL
+// (held in strings_ttl.jsonl on input) is folded into the inline value
+// header by the encoder and recovered on decode — back into
+// strings_ttl.jsonl — without an !redis|ttl| row leaking in.
+func TestRedisEncodeStringTTLRoundTripViaDecode(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	enc := EncodeSegment([]byte("sess"))
+	const expireMs uint64 = 1_735_689_600_000
+	writeRedisFile(t, in, filepath.Join("strings", enc+".bin"), []byte("v"))
+	writeTTLSidecar(t, in, "strings_ttl.jsonl", enc, expireMs)
+
+	out := decodeRedisTree(t, encodeRedisTree(t, in))
+
+	got, err := os.ReadFile(filepath.Join(out, "redis", "db_0", "strings", enc+".bin"))
+	if err != nil {
+		t.Fatalf("read decoded string: %v", err)
+	}
+	if !bytes.Equal(got, []byte("v")) {
+		t.Fatalf("decoded string = %q, want %q", got, "v")
+	}
+	if gotMs := readTTLSidecar(t, out, "strings_ttl.jsonl")[enc]; gotMs != expireMs {
+		t.Fatalf("decoded strings_ttl[%s] = %d, want %d", enc, gotMs, expireMs)
+	}
+}
+
+// TestRedisEncodeHLLTTLRoundTripViaDecode pins that an HLL sketch is
+// emitted raw under !redis|hll| and its TTL via an !redis|ttl| row,
+// both recovered on decode (hll/<k>.bin + hll_ttl.jsonl).
+func TestRedisEncodeHLLTTLRoundTripViaDecode(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	enc := EncodeSegment([]byte("counter"))
+	const expireMs uint64 = 1_700_000_000_000
+	sketch := []byte{0x01, 0x02, 0x03, 0xFF, 0x00}
+	writeRedisFile(t, in, filepath.Join("hll", enc+".bin"), sketch)
+	writeTTLSidecar(t, in, "hll_ttl.jsonl", enc, expireMs)
+
+	out := decodeRedisTree(t, encodeRedisTree(t, in))
+
+	got, err := os.ReadFile(filepath.Join(out, "redis", "db_0", "hll", enc+".bin"))
+	if err != nil {
+		t.Fatalf("read decoded hll: %v", err)
+	}
+	if !bytes.Equal(got, sketch) {
+		t.Fatalf("decoded hll = %x, want %x", got, sketch)
+	}
+	if gotMs := readTTLSidecar(t, out, "hll_ttl.jsonl")[enc]; gotMs != expireMs {
+		t.Fatalf("decoded hll_ttl[%s] = %d, want %d", enc, gotMs, expireMs)
+	}
+}
+
+// TestRedisEncodeStringInlineValueLayout pins the inline value bytes
+// directly (non-circular against the round-trip): no-TTL strings get a
+// 3-byte header, TTL strings an 11-byte header with BE millis.
+func TestRedisEncodeStringInlineValueLayout(t *testing.T) {
+	t.Parallel()
+	noTTL := encodeRedisStrInlineValue([]byte("ab"), 0)
+	want := []byte{redisStrMagic, redisStrVersion, 0x00, 'a', 'b'}
+	if !bytes.Equal(noTTL, want) {
+		t.Fatalf("no-TTL value = %x, want %x", noTTL, want)
+	}
+	withTTL := encodeRedisStrInlineValue([]byte("ab"), 0x0102030405060708)
+	wantHdr := []byte{redisStrMagic, redisStrVersion, redisStrHasTTL,
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 'a', 'b'}
+	if !bytes.Equal(withTTL, wantHdr) {
+		t.Fatalf("TTL value = %x, want %x", withTTL, wantHdr)
+	}
+}
+
+// TestRedisEncodeMissingDBIsNoop pins that a missing redis/db_0/ dir
+// yields zero entries and no error (nothing to encode).
+func TestRedisEncodeMissingDBIsNoop(t *testing.T) {
+	t.Parallel()
+	b := newSnapshotBuilder(redisEncTS)
+	if err := NewRedisEncoder(t.TempDir(), 0).Encode(b); err != nil {
+		t.Fatalf("Encode on empty tree: %v", err)
+	}
+	if b.Len() != 0 {
+		t.Fatalf("got %d entries, want 0", b.Len())
+	}
+}
+
+// writeTTLSidecar appends one {"key","expire_at_ms"} record to a TTL
+// sidecar JSONL under <root>/redis/db_0/.
+func writeTTLSidecar(t *testing.T, root, name, encodedKey string, expireMs uint64) {
+	t.Helper()
+	rec := ttlSidecarRecord{Key: encodedKey, ExpireAtMs: expireMs}
+	line, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatalf("marshal ttl rec: %v", err)
+	}
+	writeRedisFile(t, root, name, append(line, '\n'))
+}
+
+// readTTLSidecar parses a decoded TTL sidecar JSONL into
+// encoded-key -> expire_at_ms.
+func readTTLSidecar(t *testing.T, root, name string) map[string]uint64 {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, "redis", "db_0", name))
+	if err != nil {
+		t.Fatalf("read ttl sidecar %s: %v", name, err)
+	}
+	out := map[string]uint64{}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	for dec.More() {
+		var rec ttlSidecarRecord
+		if err := dec.Decode(&rec); err != nil {
+			t.Fatalf("decode ttl sidecar: %v", err)
+		}
+		out[rec.Key] = rec.ExpireAtMs
+	}
+	return out
+}

--- a/internal/backup/encode_redis_test.go
+++ b/internal/backup/encode_redis_test.go
@@ -74,6 +74,9 @@ func TestRedisEncodeStringRoundTripViaDecode(t *testing.T) {
 	if !bytes.Equal(got, []byte("hello")) {
 		t.Fatalf("decoded string = %q, want %q", got, "hello")
 	}
+	if _, err := os.Stat(filepath.Join(out, "redis", "db_0", "strings_ttl.jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("strings_ttl.jsonl should be absent for a no-TTL string, stat err = %v", err)
+	}
 }
 
 // TestRedisEncodeStringTTLRoundTripViaDecode pins that a string's TTL

--- a/internal/backup/open_nofollow_other.go
+++ b/internal/backup/open_nofollow_other.go
@@ -16,6 +16,14 @@ import (
 // offline / sandboxed and the threat model that motivated the unix
 // hardening (a local adversary swapping the path between syscalls)
 // does not apply. Codex P2 round 10.
+// refuseHardLink is a no-op on this platform: syscall.Stat_t.Nlink is
+// unavailable, and the threat model that motivates the unix check
+// (a local adversary hard-linking external inodes into the dump tree)
+// does not apply to the offline/sandboxed tooling these targets run.
+// Matches openSidecarFile's platform-specific posture. Codex P2 on
+// PR #828.
+func refuseHardLink(_ os.FileInfo, _ string) error { return nil }
+
 func openSidecarFile(path string) (*os.File, error) {
 	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
 		return nil, cockroachdberr.WithStack(cockroachdberr.Newf(

--- a/internal/backup/open_nofollow_unix.go
+++ b/internal/backup/open_nofollow_unix.go
@@ -37,6 +37,24 @@ import (
 // Lstat-then-OpenFile guard because Windows's
 // SeCreateSymbolicLinkPrivilege already raises the bar for the
 // equivalent attack and Windows has no FIFO concept.
+// refuseHardLink rejects a file whose inode carries more than one
+// link. A hard link can name an inode living OUTSIDE the dump subtree
+// while still presenting as a regular file — so both the IsRegular
+// check and the os.Root symlink-escape guard pass — letting a crafted
+// dump pull external bytes into the snapshot. This is the read-side
+// analogue of openSidecarFile's write-side Nlink defense (codex P2 on
+// PR #828). info must come from an Lstat/Fstat of the target.
+func refuseHardLink(info os.FileInfo, path string) error {
+	sysStat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil
+	}
+	if sysStat.Nlink > 1 {
+		return cockroachdberr.Wrapf(ErrRedisEncodeHardLink, "%s (nlink=%d)", path, sysStat.Nlink)
+	}
+	return nil
+}
+
 func openSidecarFile(path string) (*os.File, error) {
 	// Note: NO O_TRUNC here — we truncate after the link-count check.
 	const flag = os.O_WRONLY | os.O_CREATE | syscall.O_NOFOLLOW | syscall.O_NONBLOCK

--- a/internal/backup/open_nofollow_windows.go
+++ b/internal/backup/open_nofollow_windows.go
@@ -17,6 +17,13 @@ import (
 // attack on the dump tree on Windows already requires the attacker to
 // hold write access to the output directory plus the symlink-create
 // privilege, which is a much higher bar than the unix case.
+// refuseHardLink is a no-op on Windows: the syscall.Stat_t.Nlink field
+// is not available, and mounting a hard-link attack on the dump tree
+// already requires write access to the output directory — the same
+// higher bar that makes openSidecarFile's simpler guard acceptable
+// here. Codex P2 on PR #828.
+func refuseHardLink(_ os.FileInfo, _ string) error { return nil }
+
 func openSidecarFile(path string) (*os.File, error) {
 	if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
 		return nil, cockroachdberr.WithStack(cockroachdberr.Newf(


### PR DESCRIPTION
## Summary

**Phase 0b M2a — Redis string + HLL reverse encoder.** First slice of the Redis reverse encoder (M2): the simple-value families (strings, HLL) and their TTL handling. The wide-column collections (hash/list/set/zset/stream) land in follow-up PRs on the same milestone, matching how Phase 0a shipped the Redis decoders incrementally.

Builds on M1's `snapshotBuilder` (PR #825). Design: `docs/design/2026_05_25_proposed_snapshot_logical_encoder.md`.

`internal/backup/encode_redis.go`:
- **`RedisEncoder`** walks `redis/db_<n>/` and feeds reconstructed internal records to the builder.
- **Strings**: `strings/<enc>.bin` body + `strings_ttl.jsonl` expiry are folded back into the live inline value header (`[0xFF 0x01][flags][expireMs BE if has_ttl][body]`) — verified against `adapter/redis_compat_types.go::encodeRedisStr`. **No `!redis|ttl|` row** is emitted for strings (`buildTTLElems` skips string keys — their TTL is inline-only). MVCC value-header `expireAt` is `0` for all redis writes (`kv.Elem` carries no store-level expiry; the redis adapter manages expiry itself).
- **HLL**: `hll/<enc>.bin` raw sketch bytes + an `!redis|ttl|<key>` scan-index row (8-byte BE millis) for expiring keys, matching `buildTTLElems` for non-string types.
- Filenames / TTL keys reversed via `DecodeSegment`; SHA-fallback segments recovered from `KEYMAP.jsonl`, failing closed (`ErrRedisEncodeMissingKeymap`) when the keymap lacks the entry.

## Why pinned against the live write path

The encoder output must load into a running cluster, so the value formats are matched to the **live adapter writers** (`encodeRedisStr`, `buildTTLElems`), not just the decode side. Key facts confirmed in `adapter/redis.go`: string TTL is inline-only (no scan-index row); `kv.Elem` has no expiry field so redis MVCC `expireAt` is always 0; HLL/collection TTL uses `!redis|ttl|` rows.

## Risk

New code only; no existing behavior changed. Offline-tool boundary preserved (no live-cluster imports — value formats reproduced via the package's existing constants).

## Self-review (5 lenses)

- **Data loss**: gold-standard directory round-trip via the **real** `DecodeSnapshot` confirms every byte survives; fail-closed on missing keymap.
- **Concurrency/distributed**: encoder is single-goroutine, feeds one builder.
- **Performance**: streams files; no whole-tree buffering.
- **Consistency**: value format pinned against the live write path so the `.fsm` loads into a running cluster; MVCC `expireAt=0` matches redis writes; string TTL never double-emitted.
- **Test coverage**: directory round-trips (no-TTL string, TTL string, TTL'd HLL) through the real decoder + a direct inline-value byte-layout assertion + missing-db no-op.

## Test plan

- [x] `go test ./internal/backup/` (full package, no regression)
- [x] `golangci-lint run internal/backup/` (0 issues)
- [ ] Follow-up: hash/list/set/zset/stream reverse encoders (M2b).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Redis backup encoding with support for string records and data structures, including TTL preservation during backup and recovery

* **Tests**
  * Added comprehensive test coverage for backup encoding, including round-trip persistence validation and edge case scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/828?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->