### PR TITLE
backup: Phase 0b M2b — Redis wide-column reverse encoders (hash/set/list/zset/stream)

### DIFF
--- a/internal/backup/encode.go
+++ b/internal/backup/encode.go
@@ -110,11 +110,17 @@ func encodeMVCCKey(userKey []byte, commitTS uint64) []byte {
 // (flags byte + 8-byte little-endian expireAt). Phase 0b emits live,
 // cleartext, non-tombstone records only, so flags is always zero.
 func encodeMVCCValue(userValue []byte, expireAt uint64) []byte {
-	out := make([]byte, snapshotValueHeaderSize+len(userValue))
-	out[0] = 0 // flags: tombstone=0, encryption_state=cleartext, reserved=0
-	binary.LittleEndian.PutUint64(out[1:snapshotValueHeaderSize], expireAt)
-	copy(out[snapshotValueHeaderSize:], userValue)
-	return out
+	// Build by append from a const-capacity, zero-length slice: the
+	// header (flags byte + 8-byte LE expireAt) then the body. Using a
+	// constant cap (not snapshotValueHeaderSize+len(userValue)) keeps
+	// the `const + len(userValue)` arithmetic out of make(), which
+	// CodeQL flags as a potential allocation-size overflow; the
+	// zero-length start keeps makezero happy. The builder already caps
+	// userValue at MaxSnapshotEncodedValueSize before this is reached.
+	out := make([]byte, 0, snapshotValueHeaderSize)
+	out = append(out, 0) // flags: tombstone=0, encryption_state=cleartext, reserved=0
+	out = binary.LittleEndian.AppendUint64(out, expireAt)
+	return append(out, userValue...)
 }
 
 // encodedKV is one fully MVCC-framed entry held by snapshotBuilder

--- a/internal/backup/encode_redis.go
+++ b/internal/backup/encode_redis.go
@@ -125,7 +125,10 @@ func (e *RedisEncoder) Encode(b *snapshotBuilder) error {
 	if err := e.encodeSets(b); err != nil {
 		return err
 	}
-	return e.encodeLists(b)
+	if err := e.encodeLists(b); err != nil {
+		return err
+	}
+	return e.encodeZSets(b)
 }
 
 // loadKeymap reads the db's KEYMAP.jsonl (if present) so sha-fallback

--- a/internal/backup/encode_redis.go
+++ b/internal/backup/encode_redis.go
@@ -18,9 +18,9 @@ import (
 // internal records to a snapshotBuilder, which MVCC-frames and writes
 // them.
 //
-// This commit covers the simple-value families: strings, HLL, and the
-// TTL handling for both. The wide-column collections (hash, list, set,
-// zset, stream) land in subsequent commits on the same milestone.
+// This file covers the simple-value families (strings, HLL, and their
+// TTL handling); the wide-column collections (hash/set/list/zset/stream)
+// live in encode_redis_coll.go in the same package.
 //
 // Format fidelity is pinned against the live adapter write path
 // (adapter/redis_compat_types.go, adapter/redis.go), not just the

--- a/internal/backup/encode_redis.go
+++ b/internal/backup/encode_redis.go
@@ -113,22 +113,22 @@ func (e *RedisEncoder) Encode(b *snapshotBuilder) error {
 	if err := e.loadKeymap(); err != nil {
 		return err
 	}
-	if err := e.encodeStrings(b); err != nil {
-		return err
+	// Fixed order matches the dump's per-type subdirectories. Each
+	// encoder is a no-op when its subdir is absent.
+	for _, encode := range []func(*snapshotBuilder) error{
+		e.encodeStrings,
+		e.encodeHLL,
+		e.encodeHashes,
+		e.encodeSets,
+		e.encodeLists,
+		e.encodeZSets,
+		e.encodeStreams,
+	} {
+		if err := encode(b); err != nil {
+			return err
+		}
 	}
-	if err := e.encodeHLL(b); err != nil {
-		return err
-	}
-	if err := e.encodeHashes(b); err != nil {
-		return err
-	}
-	if err := e.encodeSets(b); err != nil {
-		return err
-	}
-	if err := e.encodeLists(b); err != nil {
-		return err
-	}
-	return e.encodeZSets(b)
+	return nil
 }
 
 // loadKeymap reads the db's KEYMAP.jsonl (if present) so sha-fallback

--- a/internal/backup/encode_redis.go
+++ b/internal/backup/encode_redis.go
@@ -122,7 +122,10 @@ func (e *RedisEncoder) Encode(b *snapshotBuilder) error {
 	if err := e.encodeHashes(b); err != nil {
 		return err
 	}
-	return e.encodeSets(b)
+	if err := e.encodeSets(b); err != nil {
+		return err
+	}
+	return e.encodeLists(b)
 }
 
 // loadKeymap reads the db's KEYMAP.jsonl (if present) so sha-fallback

--- a/internal/backup/encode_redis.go
+++ b/internal/backup/encode_redis.go
@@ -236,7 +236,9 @@ func (e *RedisEncoder) walkBlobDir(subdir string, fn func(encoded string, rawKey
 		return errors.WithStack(err)
 	}
 	defer func() { _ = root.Close() }()
-	entries, err := os.ReadDir(dir)
+	// List through the root fd (not os.ReadDir(dir)) to avoid the
+	// post-OpenRoot symlink-swap TOCTOU (codex/gemini on PR #831).
+	entries, err := readRootDirEntries(root)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -324,6 +326,24 @@ func openDumpSidecar(dir, name string) (*os.File, error) {
 		return nil, errors.WithStack(err)
 	}
 	return f, nil
+}
+
+// readRootDirEntries lists the directory entries THROUGH the opened
+// root fd rather than re-resolving the path with os.ReadDir, which
+// could follow a symlink swapped in after os.OpenRoot (a TOCTOU
+// window; codex/gemini security finding on PR #831). os.Root has no
+// ReadDir, so open "." within the root and read from that descriptor.
+func readRootDirEntries(root *os.Root) ([]os.DirEntry, error) {
+	d, err := root.Open(".")
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer func() { _ = d.Close() }()
+	entries, err := d.ReadDir(-1)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return entries, nil
 }
 
 // readRootFile reads a regular file by name within root, refusing any

--- a/internal/backup/encode_redis.go
+++ b/internal/backup/encode_redis.go
@@ -119,7 +119,10 @@ func (e *RedisEncoder) Encode(b *snapshotBuilder) error {
 	if err := e.encodeHLL(b); err != nil {
 		return err
 	}
-	return e.encodeHashes(b)
+	if err := e.encodeHashes(b); err != nil {
+		return err
+	}
+	return e.encodeSets(b)
 }
 
 // loadKeymap reads the db's KEYMAP.jsonl (if present) so sha-fallback

--- a/internal/backup/encode_redis.go
+++ b/internal/backup/encode_redis.go
@@ -116,7 +116,10 @@ func (e *RedisEncoder) Encode(b *snapshotBuilder) error {
 	if err := e.encodeStrings(b); err != nil {
 		return err
 	}
-	return e.encodeHLL(b)
+	if err := e.encodeHLL(b); err != nil {
+		return err
+	}
+	return e.encodeHashes(b)
 }
 
 // loadKeymap reads the db's KEYMAP.jsonl (if present) so sha-fallback

--- a/internal/backup/encode_redis_coll.go
+++ b/internal/backup/encode_redis_coll.go
@@ -62,9 +62,9 @@ type hashJSONRecord struct {
 // encodeHashes reconstructs !hs|meta| + !hs|fld| records from
 // hashes/*.json, plus an !redis|ttl| row for any expiring hash.
 func (e *RedisEncoder) encodeHashes(b *snapshotBuilder) error {
-	return e.walkJSONDir("hashes", ".json", func(rawKey, body []byte) error {
+	return e.walkJSONDir("hashes", ".json", func(rawKey []byte, r io.Reader) error {
 		var rec hashJSONRecord
-		if err := json.Unmarshal(body, &rec); err != nil {
+		if err := json.NewDecoder(r).Decode(&rec); err != nil {
 			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "hash %q: %v", rawKey, err)
 		}
 		// Base meta: element count = number of fields (consolidated,
@@ -103,9 +103,9 @@ type setJSONRecord struct {
 // encodeSets reconstructs !st|meta| + !st|mem| records from
 // sets/*.json, plus an !redis|ttl| row for any expiring set.
 func (e *RedisEncoder) encodeSets(b *snapshotBuilder) error {
-	return e.walkJSONDir("sets", ".json", func(rawKey, body []byte) error {
+	return e.walkJSONDir("sets", ".json", func(rawKey []byte, r io.Reader) error {
 		var rec setJSONRecord
-		if err := json.Unmarshal(body, &rec); err != nil {
+		if err := json.NewDecoder(r).Decode(&rec); err != nil {
 			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "set %q: %v", rawKey, err)
 		}
 		if err := b.Add(wideColMetaKey(RedisSetMetaPrefix, rawKey),
@@ -145,9 +145,9 @@ type listJSONRecord struct {
 // restored list's subsequent prepends/appends simply extend from this
 // base.
 func (e *RedisEncoder) encodeLists(b *snapshotBuilder) error {
-	return e.walkJSONDir("lists", ".json", func(rawKey, body []byte) error {
+	return e.walkJSONDir("lists", ".json", func(rawKey []byte, r io.Reader) error {
 		var rec listJSONRecord
-		if err := json.Unmarshal(body, &rec); err != nil {
+		if err := json.NewDecoder(r).Decode(&rec); err != nil {
 			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "list %q: %v", rawKey, err)
 		}
 		if err := b.Add(buildListMetaKey(rawKey), marshalListMetaHead0(uint64(len(rec.Items))), 0); err != nil {
@@ -216,9 +216,9 @@ type zsetJSONRecord struct {
 // emitted so ZSCORE/ZRANK and ZRANGEBYSCORE both work on the restored
 // set (the live write path keeps them in lockstep).
 func (e *RedisEncoder) encodeZSets(b *snapshotBuilder) error {
-	return e.walkJSONDir("zsets", ".json", func(rawKey, body []byte) error {
+	return e.walkJSONDir("zsets", ".json", func(rawKey []byte, r io.Reader) error {
 		var rec zsetJSONRecord
-		if err := json.Unmarshal(body, &rec); err != nil {
+		if err := json.NewDecoder(r).Decode(&rec); err != nil {
 			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "zset %q: %v", rawKey, err)
 		}
 		if err := b.Add(wideColMetaKey(RedisZSetMetaPrefix, rawKey),
@@ -319,8 +319,8 @@ type streamLineJSON struct {
 // protobuf carrying the interleaved (name,value,...) field list — the
 // exact format decodeStreamEntryValue consumes.
 func (e *RedisEncoder) encodeStreams(b *snapshotBuilder) error {
-	return e.walkJSONDir("streams", ".jsonl", func(rawKey, body []byte) error {
-		dec := json.NewDecoder(bytes.NewReader(body))
+	return e.walkJSONDir("streams", ".jsonl", func(rawKey []byte, r io.Reader) error {
+		dec := json.NewDecoder(r)
 		var meta *streamLineJSON
 		for {
 			var line streamLineJSON
@@ -453,11 +453,14 @@ func (e *RedisEncoder) addCollectionTTL(b *snapshotBuilder, rawKey []byte, expir
 }
 
 // walkJSONDir iterates <dbDir>/<subdir>/*<ext>, resolves each filename
-// to its original user key, reads the body, and invokes fn. A missing
-// subdir is not an error. Reads go through an os.Root so an in-dump
-// symlink cannot escape the subdir (same posture as walkBlobDir). ext
-// is ".json" for the per-key collections and ".jsonl" for streams.
-func (e *RedisEncoder) walkJSONDir(subdir, ext string, fn func(rawKey, body []byte) error) error {
+// to its original user key, and invokes fn with an io.Reader streaming
+// the file from disk — so a large stream .jsonl is decoded
+// incrementally rather than slurped into one []byte (gemini high on
+// PR #831). A missing subdir is not an error. Reads go through an
+// os.Root so an in-dump symlink cannot escape the subdir (same posture
+// as walkBlobDir). ext is ".json" for the per-key collections and
+// ".jsonl" for streams.
+func (e *RedisEncoder) walkJSONDir(subdir, ext string, fn func(rawKey []byte, r io.Reader) error) error {
 	dir := filepath.Join(e.dbDir(), subdir)
 	// Refuse a symlinked/non-directory subdir before os.OpenRoot follows
 	// it outside the dump tree (same guard walkBlobDir applies; codex P2
@@ -487,8 +490,10 @@ func (e *RedisEncoder) walkJSONDir(subdir, ext string, fn func(rawKey, body []by
 
 // handleJSONEntry processes one directory entry from walkJSONDir.
 // Non-regular entries and names not ending in ext are skipped (the
-// IsRegular() guard keeps a FIFO from reaching io.ReadAll).
-func (e *RedisEncoder) handleJSONEntry(root *os.Root, ent os.DirEntry, ext string, fn func(rawKey, body []byte) error) error {
+// IsRegular() guard keeps a FIFO from reaching the decoder). The file
+// is opened within root (symlink-escape safe), checked for hard links,
+// and streamed to fn as an io.Reader; it is closed when fn returns.
+func (e *RedisEncoder) handleJSONEntry(root *os.Root, ent os.DirEntry, ext string, fn func(rawKey []byte, r io.Reader) error) error {
 	if !ent.Type().IsRegular() || !strings.HasSuffix(ent.Name(), ext) {
 		return nil
 	}
@@ -497,11 +502,19 @@ func (e *RedisEncoder) handleJSONEntry(root *os.Root, ent os.DirEntry, ext strin
 	if err != nil {
 		return err
 	}
-	body, err := readRootFile(root, ent.Name())
+	f, err := root.Open(ent.Name())
 	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if err := refuseHardLink(info, ent.Name()); err != nil {
 		return err
 	}
-	return fn(rawKey, body)
+	return fn(rawKey, f)
 }
 
 // wideColMetaKey builds <prefix><userKeyLen(4 BE)><userKey> — the

--- a/internal/backup/encode_redis_coll.go
+++ b/internal/backup/encode_redis_coll.go
@@ -47,6 +47,23 @@ var ErrRedisEncodeInvalidJSON = errors.New("backup: redis encode invalid collect
 // interleaved field list — XADD enforces even arity.
 const streamFieldPairWidth = 2
 
+// decodeOneJSON decodes exactly one JSON value from r into v and fails
+// closed (ErrRedisEncodeInvalidJSON) if any trailing data follows it.
+// A collection file (hashes/sets/lists/zsets) is a single JSON object;
+// trailing bytes after it indicate a corrupt/concatenated dump that
+// json.Decoder.Decode would otherwise silently ignore (codex P2 on
+// PR #831).
+func decodeOneJSON(r io.Reader, v any) error {
+	dec := json.NewDecoder(r)
+	if err := dec.Decode(v); err != nil {
+		return errors.WithStack(err)
+	}
+	if dec.More() {
+		return errors.Wrap(ErrRedisEncodeInvalidJSON, "trailing data after JSON value")
+	}
+	return nil
+}
+
 // redisCollectionFormatVersion is the only format_version the
 // collection JSON encoders accept. A dump declaring a newer version
 // (or a renamed schema) would otherwise decode with zero-valued fields
@@ -72,7 +89,7 @@ type hashJSONRecord struct {
 func (e *RedisEncoder) encodeHashes(b *snapshotBuilder) error {
 	return e.walkJSONDir("hashes", ".json", func(rawKey []byte, r io.Reader) error {
 		var rec hashJSONRecord
-		if err := json.NewDecoder(r).Decode(&rec); err != nil {
+		if err := decodeOneJSON(r, &rec); err != nil {
 			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "hash %q: %v", rawKey, err)
 		}
 		if rec.FormatVersion != redisCollectionFormatVersion {
@@ -116,7 +133,7 @@ type setJSONRecord struct {
 func (e *RedisEncoder) encodeSets(b *snapshotBuilder) error {
 	return e.walkJSONDir("sets", ".json", func(rawKey []byte, r io.Reader) error {
 		var rec setJSONRecord
-		if err := json.NewDecoder(r).Decode(&rec); err != nil {
+		if err := decodeOneJSON(r, &rec); err != nil {
 			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "set %q: %v", rawKey, err)
 		}
 		if rec.FormatVersion != redisCollectionFormatVersion {
@@ -161,7 +178,7 @@ type listJSONRecord struct {
 func (e *RedisEncoder) encodeLists(b *snapshotBuilder) error {
 	return e.walkJSONDir("lists", ".json", func(rawKey []byte, r io.Reader) error {
 		var rec listJSONRecord
-		if err := json.NewDecoder(r).Decode(&rec); err != nil {
+		if err := decodeOneJSON(r, &rec); err != nil {
 			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "list %q: %v", rawKey, err)
 		}
 		if rec.FormatVersion != redisCollectionFormatVersion {
@@ -235,7 +252,7 @@ type zsetJSONRecord struct {
 func (e *RedisEncoder) encodeZSets(b *snapshotBuilder) error {
 	return e.walkJSONDir("zsets", ".json", func(rawKey []byte, r io.Reader) error {
 		var rec zsetJSONRecord
-		if err := json.NewDecoder(r).Decode(&rec); err != nil {
+		if err := decodeOneJSON(r, &rec); err != nil {
 			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "zset %q: %v", rawKey, err)
 		}
 		if rec.FormatVersion != redisCollectionFormatVersion {
@@ -352,6 +369,9 @@ func (e *RedisEncoder) encodeStreams(b *snapshotBuilder) error {
 				return errors.Wrapf(ErrRedisEncodeInvalidJSON, "stream %q: %v", rawKey, err)
 			}
 			if line.Meta {
+				if meta != nil {
+					return errors.Wrapf(ErrRedisEncodeInvalidJSON, "stream %q: multiple _meta lines", rawKey)
+				}
 				m := line
 				meta = &m
 				continue

--- a/internal/backup/encode_redis_coll.go
+++ b/internal/backup/encode_redis_coll.go
@@ -519,7 +519,12 @@ func buildStreamEntryValue(id string, interleaved []string) ([]byte, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	out := make([]byte, 0, redisStreamProtoPrefixLen+len(payload))
+	// Build by append from a const-capacity, zero-length slice (magic
+	// prefix then payload). The constant cap keeps the
+	// `const + len(payload)` arithmetic out of make() — which CodeQL
+	// flags as a potential allocation-size overflow — and the
+	// zero-length start keeps makezero happy.
+	out := make([]byte, 0, redisStreamProtoPrefixLen)
 	out = append(out, redisStreamProtoPrefix...)
 	return append(out, payload...), nil
 }

--- a/internal/backup/encode_redis_coll.go
+++ b/internal/backup/encode_redis_coll.go
@@ -322,6 +322,7 @@ func (e *RedisEncoder) encodeStreams(b *snapshotBuilder) error {
 	return e.walkJSONDir("streams", ".jsonl", func(rawKey []byte, r io.Reader) error {
 		dec := json.NewDecoder(r)
 		var meta *streamLineJSON
+		var st streamAccum
 		for {
 			var line streamLineJSON
 			if err := dec.Decode(&line); err != nil {
@@ -335,19 +336,14 @@ func (e *RedisEncoder) encodeStreams(b *snapshotBuilder) error {
 				meta = &m
 				continue
 			}
-			if err := e.addStreamEntry(b, rawKey, line); err != nil {
+			ms, seq, err := e.addStreamEntry(b, rawKey, line)
+			if err != nil {
 				return err
 			}
+			st.observe(ms, seq)
 		}
-		if meta == nil {
-			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "stream %q: missing _meta line", rawKey)
-		}
-		// Fail closed on a negative length: marshalStreamMeta casts to
-		// uint64, so "length": -1 would otherwise encode as a huge count
-		// that the restored cluster surfaces as a corrupt XLEN (codex P2
-		// on PR #831).
-		if meta.Length < 0 {
-			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "stream %q: negative _meta length %d", rawKey, meta.Length)
+		if err := validateStreamMeta(rawKey, meta, st); err != nil {
+			return err
 		}
 		if err := b.Add(wideColMetaKey(RedisStreamMetaPrefix, rawKey),
 			marshalStreamMeta(meta.Length, meta.LastMs, meta.LastSeq), 0); err != nil {
@@ -358,31 +354,77 @@ func (e *RedisEncoder) encodeStreams(b *snapshotBuilder) error {
 }
 
 // addStreamEntry emits one !stream|entry| record from a parsed JSONL
-// entry line. The ID "ms-seq" is split back into the 16-byte key
+// entry line and returns the entry's (ms, seq) ID so the caller can
+// track the entry count and the maximum ID for _meta consistency
+// validation. The ID "ms-seq" is split back into the 16-byte key
 // suffix; the fields array becomes the interleaved [name,value,...]
 // slice the protobuf carries.
-func (e *RedisEncoder) addStreamEntry(b *snapshotBuilder, rawKey []byte, line streamLineJSON) error {
-	ms, seq, err := parseStreamID(line.ID)
+func (e *RedisEncoder) addStreamEntry(b *snapshotBuilder, rawKey []byte, line streamLineJSON) (ms, seq uint64, err error) {
+	ms, seq, err = parseStreamID(line.ID)
 	if err != nil {
-		return err
+		return 0, 0, err
 	}
 	interleaved := make([]string, 0, len(line.Fields)*streamFieldPairWidth)
 	for _, f := range line.Fields {
 		name, err := unmarshalRedisBinaryValue(f.Name)
 		if err != nil {
-			return errors.Wrapf(err, "stream %q entry %s field name", rawKey, line.ID)
+			return 0, 0, errors.Wrapf(err, "stream %q entry %s field name", rawKey, line.ID)
 		}
 		value, err := unmarshalRedisBinaryValue(f.Value)
 		if err != nil {
-			return errors.Wrapf(err, "stream %q entry %s field value", rawKey, line.ID)
+			return 0, 0, errors.Wrapf(err, "stream %q entry %s field value", rawKey, line.ID)
 		}
 		interleaved = append(interleaved, string(name), string(value))
 	}
 	val, err := buildStreamEntryValue(line.ID, interleaved)
 	if err != nil {
-		return errors.Wrapf(err, "stream %q entry %s", rawKey, line.ID)
+		return 0, 0, errors.Wrapf(err, "stream %q entry %s", rawKey, line.ID)
 	}
-	return b.Add(buildStreamEntryKey(rawKey, ms, seq), val, 0)
+	if err := b.Add(buildStreamEntryKey(rawKey, ms, seq), val, 0); err != nil {
+		return 0, 0, err
+	}
+	return ms, seq, nil
+}
+
+// streamAccum tracks the entry count and the maximum (ms, seq) ID seen
+// while parsing a stream's JSONL, for validateStreamMeta.
+type streamAccum struct {
+	count         int64
+	maxMs, maxSeq uint64
+	have          bool
+}
+
+func (s *streamAccum) observe(ms, seq uint64) {
+	s.count++
+	if !s.have || ms > s.maxMs || (ms == s.maxMs && seq > s.maxSeq) {
+		s.maxMs, s.maxSeq, s.have = ms, seq, true
+	}
+}
+
+// validateStreamMeta fails closed when the _meta line is missing, has a
+// negative length, disagrees with the parsed entry count, or carries a
+// LastMs/LastSeq high-water mark BEHIND the maximum parsed entry ID.
+// The last two would silently restore an inconsistent XLEN or let a
+// future XADD '*' generate an ID that collides with (overwrites) an
+// existing entry. A well-formed dump from the decoder never trips
+// these (claude/codex on PR #831).
+func validateStreamMeta(rawKey []byte, meta *streamLineJSON, st streamAccum) error {
+	if meta == nil {
+		return errors.Wrapf(ErrRedisEncodeInvalidJSON, "stream %q: missing _meta line", rawKey)
+	}
+	if meta.Length < 0 {
+		return errors.Wrapf(ErrRedisEncodeInvalidJSON, "stream %q: negative _meta length %d", rawKey, meta.Length)
+	}
+	if meta.Length != st.count {
+		return errors.Wrapf(ErrRedisEncodeInvalidJSON,
+			"stream %q: _meta length %d disagrees with %d parsed entries", rawKey, meta.Length, st.count)
+	}
+	if st.have && (st.maxMs > meta.LastMs || (st.maxMs == meta.LastMs && st.maxSeq > meta.LastSeq)) {
+		return errors.Wrapf(ErrRedisEncodeInvalidJSON,
+			"stream %q: _meta last %d-%d is behind max entry %d-%d",
+			rawKey, meta.LastMs, meta.LastSeq, st.maxMs, st.maxSeq)
+	}
+	return nil
 }
 
 // parseStreamID splits a Redis stream ID "ms-seq" into its two uint64

--- a/internal/backup/encode_redis_coll.go
+++ b/internal/backup/encode_redis_coll.go
@@ -5,12 +5,16 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
+	pb "github.com/bootjp/elastickv/proto"
 	"github.com/cockroachdb/errors"
+	gproto "google.golang.org/protobuf/proto"
 )
 
 // encode_redis_coll.go is the wide-column slice of the Phase 0b Redis
@@ -36,6 +40,10 @@ import (
 // the dump cannot be parsed into its expected shape.
 var ErrRedisEncodeInvalidJSON = errors.New("backup: redis encode invalid collection JSON")
 
+// streamFieldPairWidth is the (name, value) arity of a stream entry's
+// interleaved field list — XADD enforces even arity.
+const streamFieldPairWidth = 2
+
 // hashJSONRecord mirrors marshalHashJSON's output: a format version, a
 // fields ARRAY of {name,value} binary envelopes (object keys can't
 // hold binary-safe field names), and an optional expiry.
@@ -51,7 +59,7 @@ type hashJSONRecord struct {
 // encodeHashes reconstructs !hs|meta| + !hs|fld| records from
 // hashes/*.json, plus an !redis|ttl| row for any expiring hash.
 func (e *RedisEncoder) encodeHashes(b *snapshotBuilder) error {
-	return e.walkJSONDir("hashes", func(rawKey, body []byte) error {
+	return e.walkJSONDir("hashes", ".json", func(rawKey, body []byte) error {
 		var rec hashJSONRecord
 		if err := json.Unmarshal(body, &rec); err != nil {
 			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "hash %q: %v", rawKey, err)
@@ -92,7 +100,7 @@ type setJSONRecord struct {
 // encodeSets reconstructs !st|meta| + !st|mem| records from
 // sets/*.json, plus an !redis|ttl| row for any expiring set.
 func (e *RedisEncoder) encodeSets(b *snapshotBuilder) error {
-	return e.walkJSONDir("sets", func(rawKey, body []byte) error {
+	return e.walkJSONDir("sets", ".json", func(rawKey, body []byte) error {
 		var rec setJSONRecord
 		if err := json.Unmarshal(body, &rec); err != nil {
 			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "set %q: %v", rawKey, err)
@@ -134,7 +142,7 @@ type listJSONRecord struct {
 // restored list's subsequent prepends/appends simply extend from this
 // base.
 func (e *RedisEncoder) encodeLists(b *snapshotBuilder) error {
-	return e.walkJSONDir("lists", func(rawKey, body []byte) error {
+	return e.walkJSONDir("lists", ".json", func(rawKey, body []byte) error {
 		var rec listJSONRecord
 		if err := json.Unmarshal(body, &rec); err != nil {
 			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "list %q: %v", rawKey, err)
@@ -205,7 +213,7 @@ type zsetJSONRecord struct {
 // emitted so ZSCORE/ZRANK and ZRANGEBYSCORE both work on the restored
 // set (the live write path keeps them in lockstep).
 func (e *RedisEncoder) encodeZSets(b *snapshotBuilder) error {
-	return e.walkJSONDir("zsets", func(rawKey, body []byte) error {
+	return e.walkJSONDir("zsets", ".json", func(rawKey, body []byte) error {
 		var rec zsetJSONRecord
 		if err := json.Unmarshal(body, &rec); err != nil {
 			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "zset %q: %v", rawKey, err)
@@ -286,6 +294,144 @@ func unmarshalRedisZSetScore(raw json.RawMessage) (float64, error) {
 	return f, nil
 }
 
+// streamLineJSON parses one JSONL line, distinguishing an entry line
+// (id + fields) from the trailing _meta terminator line. The decoder
+// emits per-entry lines first, then exactly one {"_meta":true,...}.
+type streamLineJSON struct {
+	Meta   bool   `json:"_meta"`
+	ID     string `json:"id"`
+	Fields []struct {
+		Name  json.RawMessage `json:"name"`
+		Value json.RawMessage `json:"value"`
+	} `json:"fields"`
+	Length     int64   `json:"length"`
+	LastMs     uint64  `json:"last_ms"`
+	LastSeq    uint64  `json:"last_seq"`
+	ExpireAtMs *uint64 `json:"expire_at_ms"`
+}
+
+// encodeStreams reconstructs !stream|meta| + !stream|entry| records
+// from streams/<k>.jsonl, plus an !redis|ttl| row for an expiring
+// stream. Each entry value is the magic-prefixed pb.RedisStreamEntry
+// protobuf carrying the interleaved (name,value,...) field list — the
+// exact format decodeStreamEntryValue consumes.
+func (e *RedisEncoder) encodeStreams(b *snapshotBuilder) error {
+	return e.walkJSONDir("streams", ".jsonl", func(rawKey, body []byte) error {
+		dec := json.NewDecoder(bytes.NewReader(body))
+		var meta *streamLineJSON
+		for {
+			var line streamLineJSON
+			if err := dec.Decode(&line); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				return errors.Wrapf(ErrRedisEncodeInvalidJSON, "stream %q: %v", rawKey, err)
+			}
+			if line.Meta {
+				m := line
+				meta = &m
+				continue
+			}
+			if err := e.addStreamEntry(b, rawKey, line); err != nil {
+				return err
+			}
+		}
+		if meta == nil {
+			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "stream %q: missing _meta line", rawKey)
+		}
+		if err := b.Add(wideColMetaKey(RedisStreamMetaPrefix, rawKey),
+			marshalStreamMeta(meta.Length, meta.LastMs, meta.LastSeq), 0); err != nil {
+			return err
+		}
+		return e.addCollectionTTL(b, rawKey, meta.ExpireAtMs)
+	})
+}
+
+// addStreamEntry emits one !stream|entry| record from a parsed JSONL
+// entry line. The ID "ms-seq" is split back into the 16-byte key
+// suffix; the fields array becomes the interleaved [name,value,...]
+// slice the protobuf carries.
+func (e *RedisEncoder) addStreamEntry(b *snapshotBuilder, rawKey []byte, line streamLineJSON) error {
+	ms, seq, err := parseStreamID(line.ID)
+	if err != nil {
+		return err
+	}
+	interleaved := make([]string, 0, len(line.Fields)*streamFieldPairWidth)
+	for _, f := range line.Fields {
+		name, err := unmarshalRedisBinaryValue(f.Name)
+		if err != nil {
+			return errors.Wrapf(err, "stream %q entry %s field name", rawKey, line.ID)
+		}
+		value, err := unmarshalRedisBinaryValue(f.Value)
+		if err != nil {
+			return errors.Wrapf(err, "stream %q entry %s field value", rawKey, line.ID)
+		}
+		interleaved = append(interleaved, string(name), string(value))
+	}
+	val, err := buildStreamEntryValue(line.ID, interleaved)
+	if err != nil {
+		return errors.Wrapf(err, "stream %q entry %s", rawKey, line.ID)
+	}
+	return b.Add(buildStreamEntryKey(rawKey, ms, seq), val, 0)
+}
+
+// parseStreamID splits a Redis stream ID "ms-seq" into its two uint64
+// components.
+func parseStreamID(id string) (ms, seq uint64, err error) {
+	msStr, seqStr, ok := strings.Cut(id, "-")
+	if !ok {
+		return 0, 0, errors.Wrapf(ErrRedisEncodeInvalidJSON, "stream id %q missing '-'", id)
+	}
+	ms, err = strconv.ParseUint(msStr, 10, 64)
+	if err != nil {
+		return 0, 0, errors.Wrapf(ErrRedisEncodeInvalidJSON, "stream id %q ms: %v", id, err)
+	}
+	seq, err = strconv.ParseUint(seqStr, 10, 64)
+	if err != nil {
+		return 0, 0, errors.Wrapf(ErrRedisEncodeInvalidJSON, "stream id %q seq: %v", id, err)
+	}
+	return ms, seq, nil
+}
+
+// streamEntryKey builds !stream|entry|<userKeyLen(4)><userKey><ms(8)>
+// <seq(8)> (mirror of store.StreamEntryKey + EncodeStreamID).
+func buildStreamEntryKey(userKey []byte, ms, seq uint64) []byte {
+	var id [redisStreamIDBytes]byte
+	binary.BigEndian.PutUint64(id[0:8], ms)
+	binary.BigEndian.PutUint64(id[8:16], seq)
+	return wideColElemKey(RedisStreamEntryPrefix, userKey, id[:])
+}
+
+// marshalStreamMeta encodes the 24-byte [Length][LastMs][LastSeq] meta
+// value (mirror of store.MarshalStreamMeta).
+func marshalStreamMeta(length int64, lastMs, lastSeq uint64) []byte {
+	buf := make([]byte, redisStreamMetaSize)
+	binary.BigEndian.PutUint64(buf[0:8], uint64(length)) //nolint:gosec // length is a non-negative count from the dump's _meta line
+	binary.BigEndian.PutUint64(buf[8:16], lastMs)
+	binary.BigEndian.PutUint64(buf[16:24], lastSeq)
+	return buf
+}
+
+// buildStreamEntryValue produces the magic-prefixed pb.RedisStreamEntry
+// protobuf the live store writes (adapter/redis_storage_codec.go
+// marshalStreamEntry): redisStreamProtoPrefix + the marshaled
+// {Id, Fields}. Both Id and Fields are set — the live read path
+// (unmarshalStreamEntry) returns the entry from msg.GetId() and
+// msg.GetFields(), so omitting Id would surface an empty stream ID on
+// XRANGE/XREAD even though the key carries ms/seq. Proto3 string
+// fields must be valid UTF-8; marshal fails closed otherwise, exactly
+// as the live write path would (non-UTF-8 stream fields are
+// unrepresentable on both sides).
+func buildStreamEntryValue(id string, interleaved []string) ([]byte, error) {
+	payload, err := gproto.Marshal(&pb.RedisStreamEntry{Id: id, Fields: interleaved})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	out := make([]byte, 0, redisStreamProtoPrefixLen+len(payload))
+	out = append(out, redisStreamProtoPrefix...)
+	return append(out, payload...), nil
+}
+
 // addCollectionTTL emits the !redis|ttl|<userKey> scan-index row for a
 // non-string collection with an expiry. A nil expiry is a no-op.
 func (e *RedisEncoder) addCollectionTTL(b *snapshotBuilder, rawKey []byte, expireMs *uint64) error {
@@ -296,11 +442,12 @@ func (e *RedisEncoder) addCollectionTTL(b *snapshotBuilder, rawKey []byte, expir
 	return b.Add(key, encodeRedisTTLValueMs(*expireMs), 0)
 }
 
-// walkJSONDir iterates <dbDir>/<subdir>/*.json, resolves each filename
+// walkJSONDir iterates <dbDir>/<subdir>/*<ext>, resolves each filename
 // to its original user key, reads the body, and invokes fn. A missing
 // subdir is not an error. Reads go through an os.Root so an in-dump
-// symlink cannot escape the subdir (same posture as walkBlobDir).
-func (e *RedisEncoder) walkJSONDir(subdir string, fn func(rawKey, body []byte) error) error {
+// symlink cannot escape the subdir (same posture as walkBlobDir). ext
+// is ".json" for the per-key collections and ".jsonl" for streams.
+func (e *RedisEncoder) walkJSONDir(subdir, ext string, fn func(rawKey, body []byte) error) error {
 	dir := filepath.Join(e.dbDir(), subdir)
 	root, err := os.OpenRoot(dir)
 	if errors.Is(err, os.ErrNotExist) {
@@ -315,10 +462,10 @@ func (e *RedisEncoder) walkJSONDir(subdir string, fn func(rawKey, body []byte) e
 		return errors.WithStack(err)
 	}
 	for _, ent := range entries {
-		if !ent.Type().IsRegular() || !strings.HasSuffix(ent.Name(), ".json") {
+		if !ent.Type().IsRegular() || !strings.HasSuffix(ent.Name(), ext) {
 			continue
 		}
-		encoded := strings.TrimSuffix(ent.Name(), ".json")
+		encoded := strings.TrimSuffix(ent.Name(), ext)
 		rawKey, err := e.resolveKey(encoded)
 		if err != nil {
 			return err

--- a/internal/backup/encode_redis_coll.go
+++ b/internal/backup/encode_redis_coll.go
@@ -449,10 +449,16 @@ func (e *RedisEncoder) addCollectionTTL(b *snapshotBuilder, rawKey []byte, expir
 // is ".json" for the per-key collections and ".jsonl" for streams.
 func (e *RedisEncoder) walkJSONDir(subdir, ext string, fn func(rawKey, body []byte) error) error {
 	dir := filepath.Join(e.dbDir(), subdir)
-	root, err := os.OpenRoot(dir)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
+	// Refuse a symlinked/non-directory subdir before os.OpenRoot follows
+	// it outside the dump tree (same guard walkBlobDir applies; codex P2
+	// on PR #828).
+	if err := lstatDumpDir(dir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
 	}
+	root, err := os.OpenRoot(dir)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -462,23 +468,30 @@ func (e *RedisEncoder) walkJSONDir(subdir, ext string, fn func(rawKey, body []by
 		return errors.WithStack(err)
 	}
 	for _, ent := range entries {
-		if !ent.Type().IsRegular() || !strings.HasSuffix(ent.Name(), ext) {
-			continue
-		}
-		encoded := strings.TrimSuffix(ent.Name(), ext)
-		rawKey, err := e.resolveKey(encoded)
-		if err != nil {
-			return err
-		}
-		body, err := readRootFile(root, ent.Name())
-		if err != nil {
-			return err
-		}
-		if err := fn(rawKey, body); err != nil {
+		if err := e.handleJSONEntry(root, ent, ext, fn); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// handleJSONEntry processes one directory entry from walkJSONDir.
+// Non-regular entries and names not ending in ext are skipped (the
+// IsRegular() guard keeps a FIFO from reaching io.ReadAll).
+func (e *RedisEncoder) handleJSONEntry(root *os.Root, ent os.DirEntry, ext string, fn func(rawKey, body []byte) error) error {
+	if !ent.Type().IsRegular() || !strings.HasSuffix(ent.Name(), ext) {
+		return nil
+	}
+	encoded := strings.TrimSuffix(ent.Name(), ext)
+	rawKey, err := e.resolveKey(encoded)
+	if err != nil {
+		return err
+	}
+	body, err := readRootFile(root, ent.Name())
+	if err != nil {
+		return err
+	}
+	return fn(rawKey, body)
 }
 
 // wideColMetaKey builds <prefix><userKeyLen(4 BE)><userKey> — the

--- a/internal/backup/encode_redis_coll.go
+++ b/internal/backup/encode_redis_coll.go
@@ -476,7 +476,11 @@ func (e *RedisEncoder) walkJSONDir(subdir, ext string, fn func(rawKey []byte, r 
 		return errors.WithStack(err)
 	}
 	defer func() { _ = root.Close() }()
-	entries, err := os.ReadDir(dir)
+	// List entries THROUGH the opened root fd (not os.ReadDir(dir),
+	// which re-resolves the path and could follow a symlink swapped in
+	// after OpenRoot — a TOCTOU window). Codex/gemini security finding
+	// on PR #831.
+	entries, err := readRootDirEntries(root)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/backup/encode_redis_coll.go
+++ b/internal/backup/encode_redis_coll.go
@@ -18,14 +18,17 @@ import (
 )
 
 // encode_redis_coll.go is the wide-column slice of the Phase 0b Redis
-// reverse encoder (M2b) — the inverse of the hash/list/set/zset/stream
-// decoders. This commit covers hashes; the remaining collections land
-// in follow-up commits on the same branch.
+// reverse encoder (M2b) — the inverse of the hash/set/list/zset/stream
+// decoders.
 //
 // Wide-column keys share the layout the live store builds
 // (store/hash_helpers.go etc.): <prefix><userKeyLen(4 BE)><userKey>
 // for the meta key and <prefix><userKeyLen(4 BE)><userKey><suffix> for
-// per-element keys. The meta VALUE is an 8-byte big-endian element
+// per-element keys. This applies to hash/set/zset/stream; LISTS are the
+// exception — their meta/item keys are ListMetaPrefix+userKey (no
+// length prefix), so they use buildListMetaKey/buildListItemKey rather
+// than wideColMetaKey (mirror of store.ListMetaKey). The meta VALUE is
+// an 8-byte big-endian element
 // count (store.MarshalHashMeta). The live store also writes
 // `!hs|meta|d|` length DELTAS that the read path sums onto the base;
 // the encoder emits only the consolidated base meta (full count, no
@@ -339,6 +342,13 @@ func (e *RedisEncoder) encodeStreams(b *snapshotBuilder) error {
 		if meta == nil {
 			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "stream %q: missing _meta line", rawKey)
 		}
+		// Fail closed on a negative length: marshalStreamMeta casts to
+		// uint64, so "length": -1 would otherwise encode as a huge count
+		// that the restored cluster surfaces as a corrupt XLEN (codex P2
+		// on PR #831).
+		if meta.Length < 0 {
+			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "stream %q: negative _meta length %d", rawKey, meta.Length)
+		}
 		if err := b.Add(wideColMetaKey(RedisStreamMetaPrefix, rawKey),
 			marshalStreamMeta(meta.Length, meta.LastMs, meta.LastSeq), 0); err != nil {
 			return err
@@ -534,13 +544,20 @@ func unmarshalRedisBinaryValue(raw json.RawMessage) ([]byte, error) {
 		}
 		return []byte(s), nil
 	}
+	// A pointer distinguishes an absent "base64" key (nil) from a
+	// present-but-empty one (""). A JSON object that is neither a string
+	// nor a {"base64":...} envelope (e.g. {"wrong":"x"}) would otherwise
+	// silently decode to empty bytes; fail closed instead.
 	var env struct {
-		Base64 string `json:"base64"`
+		Base64 *string `json:"base64"`
 	}
 	if err := json.Unmarshal(raw, &env); err != nil {
 		return nil, errors.WithStack(err)
 	}
-	out, err := base64.RawURLEncoding.DecodeString(env.Base64)
+	if env.Base64 == nil {
+		return nil, errors.Wrap(ErrRedisEncodeInvalidJSON, "binary value is neither a string nor a base64 envelope")
+	}
+	out, err := base64.RawURLEncoding.DecodeString(*env.Base64)
 	if err != nil {
 		return nil, errors.Wrap(ErrRedisEncodeInvalidJSON, err.Error())
 	}

--- a/internal/backup/encode_redis_coll.go
+++ b/internal/backup/encode_redis_coll.go
@@ -47,6 +47,14 @@ var ErrRedisEncodeInvalidJSON = errors.New("backup: redis encode invalid collect
 // interleaved field list — XADD enforces even arity.
 const streamFieldPairWidth = 2
 
+// redisCollectionFormatVersion is the only format_version the
+// collection JSON encoders accept. A dump declaring a newer version
+// (or a renamed schema) would otherwise decode with zero-valued fields
+// and emit corrupt/empty rows; the encoders fail closed instead
+// (codex P2 / claude on PR #831). Streams use a line-oriented JSONL
+// without a top-level format_version, so they are not gated here.
+const redisCollectionFormatVersion uint32 = 1
+
 // hashJSONRecord mirrors marshalHashJSON's output: a format version, a
 // fields ARRAY of {name,value} binary envelopes (object keys can't
 // hold binary-safe field names), and an optional expiry.
@@ -66,6 +74,9 @@ func (e *RedisEncoder) encodeHashes(b *snapshotBuilder) error {
 		var rec hashJSONRecord
 		if err := json.NewDecoder(r).Decode(&rec); err != nil {
 			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "hash %q: %v", rawKey, err)
+		}
+		if rec.FormatVersion != redisCollectionFormatVersion {
+			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "hash %q: unsupported format_version %d", rawKey, rec.FormatVersion)
 		}
 		// Base meta: element count = number of fields (consolidated,
 		// no deltas).
@@ -108,6 +119,9 @@ func (e *RedisEncoder) encodeSets(b *snapshotBuilder) error {
 		if err := json.NewDecoder(r).Decode(&rec); err != nil {
 			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "set %q: %v", rawKey, err)
 		}
+		if rec.FormatVersion != redisCollectionFormatVersion {
+			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "set %q: unsupported format_version %d", rawKey, rec.FormatVersion)
+		}
 		if err := b.Add(wideColMetaKey(RedisSetMetaPrefix, rawKey),
 			marshalCount8BE(uint64(len(rec.Members))), 0); err != nil {
 			return err
@@ -149,6 +163,9 @@ func (e *RedisEncoder) encodeLists(b *snapshotBuilder) error {
 		var rec listJSONRecord
 		if err := json.NewDecoder(r).Decode(&rec); err != nil {
 			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "list %q: %v", rawKey, err)
+		}
+		if rec.FormatVersion != redisCollectionFormatVersion {
+			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "list %q: unsupported format_version %d", rawKey, rec.FormatVersion)
 		}
 		if err := b.Add(buildListMetaKey(rawKey), marshalListMetaHead0(uint64(len(rec.Items))), 0); err != nil {
 			return err
@@ -220,6 +237,9 @@ func (e *RedisEncoder) encodeZSets(b *snapshotBuilder) error {
 		var rec zsetJSONRecord
 		if err := json.NewDecoder(r).Decode(&rec); err != nil {
 			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "zset %q: %v", rawKey, err)
+		}
+		if rec.FormatVersion != redisCollectionFormatVersion {
+			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "zset %q: unsupported format_version %d", rawKey, rec.FormatVersion)
 		}
 		if err := b.Add(wideColMetaKey(RedisZSetMetaPrefix, rawKey),
 			marshalCount8BE(uint64(len(rec.Members))), 0); err != nil {

--- a/internal/backup/encode_redis_coll.go
+++ b/internal/backup/encode_redis_coll.go
@@ -602,6 +602,14 @@ func (e *RedisEncoder) handleJSONEntry(root *os.Root, ent os.DirEntry, ext strin
 	if err != nil {
 		return errors.WithStack(err)
 	}
+	// Re-check regularity on the OPEN fd, not the (stale) ReadDir
+	// entry type: a FIFO/device swapped in between ReadDir and Open
+	// would pass ent.Type().IsRegular() yet hand attacker-controlled
+	// bytes (a reader-attached FIFO) to the decoder. The post-open
+	// fstat is authoritative (claude review on PR #831).
+	if !info.Mode().IsRegular() {
+		return errors.Wrapf(ErrRedisEncodeNotRegular, "%s (mode=%s)", ent.Name(), info.Mode())
+	}
 	if err := refuseHardLink(info, ent.Name()); err != nil {
 		return err
 	}

--- a/internal/backup/encode_redis_coll.go
+++ b/internal/backup/encode_redis_coll.go
@@ -78,6 +78,41 @@ func (e *RedisEncoder) encodeHashes(b *snapshotBuilder) error {
 	})
 }
 
+// setJSONRecord mirrors marshalSetJSON: members as an array of binary
+// envelopes plus an optional expiry. A set member's identity is the
+// key suffix; the live store writes an empty value for it
+// (redis_compat_commands.go SADD path), which the encoder reproduces.
+type setJSONRecord struct {
+	FormatVersion uint32            `json:"format_version"`
+	Members       []json.RawMessage `json:"members"`
+	ExpireAtMs    *uint64           `json:"expire_at_ms"`
+}
+
+// encodeSets reconstructs !st|meta| + !st|mem| records from
+// sets/*.json, plus an !redis|ttl| row for any expiring set.
+func (e *RedisEncoder) encodeSets(b *snapshotBuilder) error {
+	return e.walkJSONDir("sets", func(rawKey, body []byte) error {
+		var rec setJSONRecord
+		if err := json.Unmarshal(body, &rec); err != nil {
+			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "set %q: %v", rawKey, err)
+		}
+		if err := b.Add(wideColMetaKey(RedisSetMetaPrefix, rawKey),
+			marshalCount8BE(uint64(len(rec.Members))), 0); err != nil {
+			return err
+		}
+		for _, mRaw := range rec.Members {
+			member, err := unmarshalRedisBinaryValue(mRaw)
+			if err != nil {
+				return errors.Wrapf(err, "set %q member", rawKey)
+			}
+			if err := b.Add(wideColElemKey(RedisSetMemberPrefix, rawKey, member), []byte{}, 0); err != nil {
+				return err
+			}
+		}
+		return e.addCollectionTTL(b, rawKey, rec.ExpireAtMs)
+	})
+}
+
 // addCollectionTTL emits the !redis|ttl|<userKey> scan-index row for a
 // non-string collection with an expiry. A nil expiry is a no-op.
 func (e *RedisEncoder) addCollectionTTL(b *snapshotBuilder, rawKey []byte, expireMs *uint64) error {

--- a/internal/backup/encode_redis_coll.go
+++ b/internal/backup/encode_redis_coll.go
@@ -1,0 +1,180 @@
+package backup
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// encode_redis_coll.go is the wide-column slice of the Phase 0b Redis
+// reverse encoder (M2b) — the inverse of the hash/list/set/zset/stream
+// decoders. This commit covers hashes; the remaining collections land
+// in follow-up commits on the same branch.
+//
+// Wide-column keys share the layout the live store builds
+// (store/hash_helpers.go etc.): <prefix><userKeyLen(4 BE)><userKey>
+// for the meta key and <prefix><userKeyLen(4 BE)><userKey><suffix> for
+// per-element keys. The meta VALUE is an 8-byte big-endian element
+// count (store.MarshalHashMeta). The live store also writes
+// `!hs|meta|d|` length DELTAS that the read path sums onto the base;
+// the encoder emits only the consolidated base meta (full count, no
+// deltas), which is the post-compaction steady state the read path
+// accepts — and which the decoder already drops on the way in.
+//
+// Collection TTL is NOT inline (unlike strings): it lives in a
+// !redis|ttl|<userKey> scan-index row, matching buildTTLElems for
+// non-string types.
+
+// ErrRedisEncodeInvalidJSON is returned when a collection JSON file in
+// the dump cannot be parsed into its expected shape.
+var ErrRedisEncodeInvalidJSON = errors.New("backup: redis encode invalid collection JSON")
+
+// hashJSONRecord mirrors marshalHashJSON's output: a format version, a
+// fields ARRAY of {name,value} binary envelopes (object keys can't
+// hold binary-safe field names), and an optional expiry.
+type hashJSONRecord struct {
+	FormatVersion uint32 `json:"format_version"`
+	Fields        []struct {
+		Name  json.RawMessage `json:"name"`
+		Value json.RawMessage `json:"value"`
+	} `json:"fields"`
+	ExpireAtMs *uint64 `json:"expire_at_ms"`
+}
+
+// encodeHashes reconstructs !hs|meta| + !hs|fld| records from
+// hashes/*.json, plus an !redis|ttl| row for any expiring hash.
+func (e *RedisEncoder) encodeHashes(b *snapshotBuilder) error {
+	return e.walkJSONDir("hashes", func(rawKey, body []byte) error {
+		var rec hashJSONRecord
+		if err := json.Unmarshal(body, &rec); err != nil {
+			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "hash %q: %v", rawKey, err)
+		}
+		// Base meta: element count = number of fields (consolidated,
+		// no deltas).
+		if err := b.Add(wideColMetaKey(RedisHashMetaPrefix, rawKey),
+			marshalCount8BE(uint64(len(rec.Fields))), 0); err != nil {
+			return err
+		}
+		for _, f := range rec.Fields {
+			name, err := unmarshalRedisBinaryValue(f.Name)
+			if err != nil {
+				return errors.Wrapf(err, "hash %q field name", rawKey)
+			}
+			value, err := unmarshalRedisBinaryValue(f.Value)
+			if err != nil {
+				return errors.Wrapf(err, "hash %q field value", rawKey)
+			}
+			if err := b.Add(wideColElemKey(RedisHashFieldPrefix, rawKey, name), value, 0); err != nil {
+				return err
+			}
+		}
+		return e.addCollectionTTL(b, rawKey, rec.ExpireAtMs)
+	})
+}
+
+// addCollectionTTL emits the !redis|ttl|<userKey> scan-index row for a
+// non-string collection with an expiry. A nil expiry is a no-op.
+func (e *RedisEncoder) addCollectionTTL(b *snapshotBuilder, rawKey []byte, expireMs *uint64) error {
+	if expireMs == nil {
+		return nil
+	}
+	key := append([]byte(RedisTTLPrefix), rawKey...)
+	return b.Add(key, encodeRedisTTLValueMs(*expireMs), 0)
+}
+
+// walkJSONDir iterates <dbDir>/<subdir>/*.json, resolves each filename
+// to its original user key, reads the body, and invokes fn. A missing
+// subdir is not an error. Reads go through an os.Root so an in-dump
+// symlink cannot escape the subdir (same posture as walkBlobDir).
+func (e *RedisEncoder) walkJSONDir(subdir string, fn func(rawKey, body []byte) error) error {
+	dir := filepath.Join(e.dbDir(), subdir)
+	root, err := os.OpenRoot(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer func() { _ = root.Close() }()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	for _, ent := range entries {
+		if !ent.Type().IsRegular() || !strings.HasSuffix(ent.Name(), ".json") {
+			continue
+		}
+		encoded := strings.TrimSuffix(ent.Name(), ".json")
+		rawKey, err := e.resolveKey(encoded)
+		if err != nil {
+			return err
+		}
+		body, err := readRootFile(root, ent.Name())
+		if err != nil {
+			return err
+		}
+		if err := fn(rawKey, body); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// wideColMetaKey builds <prefix><userKeyLen(4 BE)><userKey> — the
+// meta key shape store/hash_helpers.go::HashMetaKey (and the set/zset
+// equivalents) produce.
+func wideColMetaKey(prefix string, userKey []byte) []byte {
+	out := make([]byte, 0, len(prefix)+wideColumnUserKeyLenSize+len(userKey))
+	out = append(out, prefix...)
+	var kl [wideColumnUserKeyLenSize]byte
+	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // bounded by max slice size
+	out = append(out, kl[:]...)
+	return append(out, userKey...)
+}
+
+// wideColElemKey builds <prefix><userKeyLen(4 BE)><userKey><suffix> —
+// the per-element key shape (hash field, set member, ...).
+func wideColElemKey(prefix string, userKey, suffix []byte) []byte {
+	out := wideColMetaKey(prefix, userKey)
+	return append(out, suffix...)
+}
+
+// marshalCount8BE encodes a collection element count as the 8-byte
+// big-endian value store.MarshalHashMeta writes.
+func marshalCount8BE(n uint64) []byte {
+	buf := make([]byte, redisUint64Bytes)
+	binary.BigEndian.PutUint64(buf, n)
+	return buf
+}
+
+// unmarshalRedisBinaryValue is the inverse of marshalRedisBinaryValue:
+// a plain JSON string decodes to its UTF-8 bytes; a
+// {"base64":"<base64url>"} envelope decodes the raw (possibly
+// non-UTF-8) bytes.
+func unmarshalRedisBinaryValue(raw json.RawMessage) ([]byte, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) > 0 && trimmed[0] == '"' {
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return nil, errors.WithStack(err)
+		}
+		return []byte(s), nil
+	}
+	var env struct {
+		Base64 string `json:"base64"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	out, err := base64.RawURLEncoding.DecodeString(env.Base64)
+	if err != nil {
+		return nil, errors.Wrap(ErrRedisEncodeInvalidJSON, err.Error())
+	}
+	return out, nil
+}

--- a/internal/backup/encode_redis_coll.go
+++ b/internal/backup/encode_redis_coll.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -111,6 +112,78 @@ func (e *RedisEncoder) encodeSets(b *snapshotBuilder) error {
 		}
 		return e.addCollectionTTL(b, rawKey, rec.ExpireAtMs)
 	})
+}
+
+// listJSONRecord mirrors marshalListJSON: items as an ordered array of
+// binary envelopes (left-to-right list order) plus an optional expiry.
+type listJSONRecord struct {
+	FormatVersion uint32            `json:"format_version"`
+	Items         []json.RawMessage `json:"items"`
+	ExpireAtMs    *uint64           `json:"expire_at_ms"`
+}
+
+// encodeLists reconstructs !lst|meta| + !lst|itm| records from
+// lists/*.json, plus an !redis|ttl| row for any expiring list.
+//
+// The dump records items in order but not their original seqs, so the
+// encoder assigns the canonical contiguous form: Head=0, item i at
+// seq i, Tail=Len. This satisfies the live store's Tail=Head+Len
+// invariant and reproduces the same left-to-right order on read
+// (store.ListItemKey scans items in sortable-seq order). The original
+// LPUSH/RPUSH seq base is not recoverable and does not need to be — a
+// restored list's subsequent prepends/appends simply extend from this
+// base.
+func (e *RedisEncoder) encodeLists(b *snapshotBuilder) error {
+	return e.walkJSONDir("lists", func(rawKey, body []byte) error {
+		var rec listJSONRecord
+		if err := json.Unmarshal(body, &rec); err != nil {
+			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "list %q: %v", rawKey, err)
+		}
+		if err := b.Add(buildListMetaKey(rawKey), marshalListMetaHead0(uint64(len(rec.Items))), 0); err != nil {
+			return err
+		}
+		for i, itemRaw := range rec.Items {
+			item, err := unmarshalRedisBinaryValue(itemRaw)
+			if err != nil {
+				return errors.Wrapf(err, "list %q item %d", rawKey, i)
+			}
+			if err := b.Add(buildListItemKey(rawKey, int64(i)), item, 0); err != nil {
+				return err
+			}
+		}
+		return e.addCollectionTTL(b, rawKey, rec.ExpireAtMs)
+	})
+}
+
+// buildListMetaKey builds !lst|meta|<userKey> (no length prefix —
+// mirror of store.ListMetaKey).
+func buildListMetaKey(userKey []byte) []byte {
+	out := make([]byte, 0, len(ListMetaPrefix)+len(userKey))
+	out = append(out, ListMetaPrefix...)
+	return append(out, userKey...)
+}
+
+// marshalListMetaHead0 encodes the 24-byte [Head][Tail][Len] meta with
+// Head=0, Len=n, Tail=n — the canonical restore form (mirror of
+// store.marshalListMeta with Head=0).
+func marshalListMetaHead0(n uint64) []byte {
+	buf := make([]byte, listMetaBinarySize)
+	binary.BigEndian.PutUint64(buf[0:8], 0)   // Head
+	binary.BigEndian.PutUint64(buf[8:16], n)  // Tail = Head + Len
+	binary.BigEndian.PutUint64(buf[16:24], n) // Len
+	return buf
+}
+
+// buildListItemKey builds !lst|itm|<userKey><sortableInt64(seq)>
+// (mirror of store.ListItemKey + encodeSortableInt64: the seq is
+// sign-flipped so a forward byte scan yields ascending int64).
+func buildListItemKey(userKey []byte, seq int64) []byte {
+	out := make([]byte, 0, len(ListItemPrefix)+len(userKey)+listSeqBytes)
+	out = append(out, ListItemPrefix...)
+	out = append(out, userKey...)
+	var raw [listSeqBytes]byte
+	binary.BigEndian.PutUint64(raw[:], uint64(seq^math.MinInt64)) //nolint:gosec // sortable-int64 sign-flip; mirrors store.encodeSortableInt64
+	return append(out, raw[:]...)
 }
 
 // addCollectionTTL emits the !redis|ttl|<userKey> scan-index row for a

--- a/internal/backup/encode_redis_coll.go
+++ b/internal/backup/encode_redis_coll.go
@@ -186,6 +186,106 @@ func buildListItemKey(userKey []byte, seq int64) []byte {
 	return append(out, raw[:]...)
 }
 
+// zsetJSONRecord mirrors marshalZSetJSON: members as an array of
+// {member (binary envelope), score (number or "+inf"/"-inf")} plus an
+// optional expiry.
+type zsetJSONRecord struct {
+	FormatVersion uint32 `json:"format_version"`
+	Members       []struct {
+		Member json.RawMessage `json:"member"`
+		Score  json.RawMessage `json:"score"`
+	} `json:"members"`
+	ExpireAtMs *uint64 `json:"expire_at_ms"`
+}
+
+// encodeZSets reconstructs the two zset indexes from zsets/*.json:
+// !zs|mem|<userKey><member> -> score (8-byte BE float bits) and the
+// !zs|scr|<userKey><sortableScore(8)><member> -> empty range index,
+// plus an !redis|ttl| row for an expiring zset. Both indexes are
+// emitted so ZSCORE/ZRANK and ZRANGEBYSCORE both work on the restored
+// set (the live write path keeps them in lockstep).
+func (e *RedisEncoder) encodeZSets(b *snapshotBuilder) error {
+	return e.walkJSONDir("zsets", func(rawKey, body []byte) error {
+		var rec zsetJSONRecord
+		if err := json.Unmarshal(body, &rec); err != nil {
+			return errors.Wrapf(ErrRedisEncodeInvalidJSON, "zset %q: %v", rawKey, err)
+		}
+		if err := b.Add(wideColMetaKey(RedisZSetMetaPrefix, rawKey),
+			marshalCount8BE(uint64(len(rec.Members))), 0); err != nil {
+			return err
+		}
+		for _, m := range rec.Members {
+			member, err := unmarshalRedisBinaryValue(m.Member)
+			if err != nil {
+				return errors.Wrapf(err, "zset %q member", rawKey)
+			}
+			score, err := unmarshalRedisZSetScore(m.Score)
+			if err != nil {
+				return errors.Wrapf(err, "zset %q score", rawKey)
+			}
+			if err := b.Add(wideColElemKey(RedisZSetMemberPrefix, rawKey, member),
+				marshalZSetScore8BE(score), 0); err != nil {
+				return err
+			}
+			sortable := encodeSortableFloat64(score)
+			scoreSuffix := append(sortable[:], member...)
+			if err := b.Add(wideColElemKey(RedisZSetScorePrefix, rawKey, scoreSuffix), []byte{}, 0); err != nil {
+				return err
+			}
+		}
+		return e.addCollectionTTL(b, rawKey, rec.ExpireAtMs)
+	})
+}
+
+// marshalZSetScore8BE encodes a float64 score as the 8-byte big-endian
+// IEEE-754 bit pattern the !zs|mem| value carries (mirror of
+// store.MarshalZSetScore).
+func marshalZSetScore8BE(score float64) []byte {
+	buf := make([]byte, redisZSetScoreSize)
+	binary.BigEndian.PutUint64(buf, math.Float64bits(score))
+	return buf
+}
+
+// encodeSortableFloat64 reproduces store.EncodeSortableFloat64: a
+// byte-order-sortable 8-byte float encoding for the !zs|scr| range
+// index (positive flips the sign bit; negative flips all bits; -0 is
+// normalised to +0).
+func encodeSortableFloat64(f float64) [8]byte {
+	if f == 0 {
+		f = 0.0
+	}
+	bits := math.Float64bits(f)
+	if bits>>63 == 0 {
+		bits ^= 0x8000000000000000
+	} else {
+		bits ^= 0xFFFFFFFFFFFFFFFF
+	}
+	var b [8]byte
+	binary.BigEndian.PutUint64(b[:], bits)
+	return b
+}
+
+// unmarshalRedisZSetScore is the inverse of marshalRedisZSetScore:
+// "+inf"/"-inf" decode to the IEEE infinities, any other token to a
+// JSON number. NaN is rejected — the live store and decoder both
+// refuse NaN scores, so the encoder fails closed too.
+func unmarshalRedisZSetScore(raw json.RawMessage) (float64, error) {
+	switch string(bytes.TrimSpace(raw)) {
+	case `"+inf"`:
+		return math.Inf(1), nil
+	case `"-inf"`:
+		return math.Inf(-1), nil
+	}
+	var f float64
+	if err := json.Unmarshal(raw, &f); err != nil {
+		return 0, errors.Wrap(ErrRedisEncodeInvalidJSON, err.Error())
+	}
+	if math.IsNaN(f) {
+		return 0, errors.Wrap(ErrRedisEncodeInvalidJSON, "zset score is NaN")
+	}
+	return f, nil
+}
+
 // addCollectionTTL emits the !redis|ttl|<userKey> scan-index row for a
 // non-string collection with an expiry. A nil expiry is a no-op.
 func (e *RedisEncoder) addCollectionTTL(b *snapshotBuilder, rawKey []byte, expireMs *uint64) error {

--- a/internal/backup/encode_redis_coll_test.go
+++ b/internal/backup/encode_redis_coll_test.go
@@ -238,6 +238,101 @@ func TestRedisEncodeSetNoTTLRoundTripViaDecode(t *testing.T) {
 	}
 }
 
+// buildListJSON constructs a lists/<k>.json body (items array in
+// left-to-right order, binary envelopes).
+func buildListJSON(t *testing.T, items []string, expireMs *uint64) []byte {
+	t.Helper()
+	raw := make([]json.RawMessage, 0, len(items))
+	for _, it := range items {
+		v, err := marshalRedisBinaryValue([]byte(it))
+		if err != nil {
+			t.Fatalf("marshal item: %v", err)
+		}
+		raw = append(raw, v)
+	}
+	out := struct {
+		FormatVersion uint32            `json:"format_version"`
+		Items         []json.RawMessage `json:"items"`
+		ExpireAtMs    *uint64           `json:"expire_at_ms"`
+	}{FormatVersion: 1, Items: raw, ExpireAtMs: expireMs}
+	body, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal list json: %v", err)
+	}
+	return body
+}
+
+// readListItems parses a decoded lists/<k>.json into an ordered slice
+// plus its expiry.
+func readListItems(t *testing.T, root, enc string) ([]string, *uint64) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, "redis", "db_0", "lists", enc+".json"))
+	if err != nil {
+		t.Fatalf("read decoded list: %v", err)
+	}
+	var rec listJSONRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatalf("unmarshal decoded list: %v", err)
+	}
+	out := make([]string, 0, len(rec.Items))
+	for _, itRaw := range rec.Items {
+		it, err := unmarshalRedisBinaryValue(itRaw)
+		if err != nil {
+			t.Fatalf("unmarshal item: %v", err)
+		}
+		out = append(out, string(it))
+	}
+	return out, rec.ExpireAtMs
+}
+
+// TestRedisEncodeListRoundTripViaDecode runs the gold-standard
+// directory round-trip for a list, asserting ORDER is preserved (the
+// defining list property) plus a TTL.
+func TestRedisEncodeListRoundTripViaDecode(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	enc := EncodeSegment([]byte("mylist"))
+	const expireMs uint64 = 1_700_000_000_777
+	items := []string{"job-1", "job-2", "job-3", "\xff\xfe"}
+	exp := expireMs
+	writeRedisFile(t, in, filepath.Join("lists", enc+".json"), buildListJSON(t, items, &exp))
+
+	out := decodeRedisTree(t, encodeRedisTree(t, in))
+
+	got, gotExp := readListItems(t, out, enc)
+	if len(got) != len(items) {
+		t.Fatalf("got %d items, want %d", len(got), len(items))
+	}
+	for i := range items {
+		if got[i] != items[i] {
+			t.Fatalf("item[%d] = %q, want %q (order must be preserved)", i, got[i], items[i])
+		}
+	}
+	if gotExp == nil || *gotExp != expireMs {
+		t.Fatalf("decoded expire_at_ms = %v, want %d", gotExp, expireMs)
+	}
+}
+
+// TestRedisEncodeListNoTTLRoundTripViaDecode pins the no-TTL list path
+// and single-element order.
+func TestRedisEncodeListNoTTLRoundTripViaDecode(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	enc := EncodeSegment([]byte("q"))
+	items := []string{"only"}
+	writeRedisFile(t, in, filepath.Join("lists", enc+".json"), buildListJSON(t, items, nil))
+
+	out := decodeRedisTree(t, encodeRedisTree(t, in))
+
+	got, gotExp := readListItems(t, out, enc)
+	if len(got) != 1 || got[0] != "only" {
+		t.Fatalf("got %v, want [only]", got)
+	}
+	if gotExp != nil {
+		t.Fatalf("decoded expire_at_ms = %v, want nil", *gotExp)
+	}
+}
+
 // TestUnmarshalRedisBinaryValue pins both envelope shapes directly.
 func TestUnmarshalRedisBinaryValue(t *testing.T) {
 	t.Parallel()

--- a/internal/backup/encode_redis_coll_test.go
+++ b/internal/backup/encode_redis_coll_test.go
@@ -449,6 +449,176 @@ func TestRedisEncodeZSetNoTTLRoundTripViaDecode(t *testing.T) {
 	}
 }
 
+// streamTestEntry is a test stream entry: an ID plus ordered
+// (name,value) field pairs.
+type streamTestEntry struct {
+	id     string
+	fields [][2]string
+}
+
+// buildStreamJSONL constructs a streams/<k>.jsonl body: one entry line
+// per entry then the _meta terminator line, matching marshalStreamJSONL.
+func buildStreamJSONL(t *testing.T, entries []streamTestEntry, lastMs, lastSeq uint64, expireMs *uint64) []byte {
+	t.Helper()
+	type fieldRec struct {
+		Name  json.RawMessage `json:"name"`
+		Value json.RawMessage `json:"value"`
+	}
+	var buf bytes.Buffer
+	for _, e := range entries {
+		recs := make([]fieldRec, 0, len(e.fields))
+		for _, f := range e.fields {
+			nameJSON, err := marshalRedisBinaryValue([]byte(f[0]))
+			if err != nil {
+				t.Fatalf("marshal name: %v", err)
+			}
+			valJSON, err := marshalRedisBinaryValue([]byte(f[1]))
+			if err != nil {
+				t.Fatalf("marshal value: %v", err)
+			}
+			recs = append(recs, fieldRec{Name: nameJSON, Value: valJSON})
+		}
+		line, err := json.Marshal(struct {
+			ID     string     `json:"id"`
+			Fields []fieldRec `json:"fields"`
+		}{ID: e.id, Fields: recs})
+		if err != nil {
+			t.Fatalf("marshal entry: %v", err)
+		}
+		buf.Write(line)
+		buf.WriteByte('\n')
+	}
+	meta, err := json.Marshal(struct {
+		Meta       bool    `json:"_meta"`
+		Length     int64   `json:"length"`
+		LastMs     uint64  `json:"last_ms"`
+		LastSeq    uint64  `json:"last_seq"`
+		ExpireAtMs *uint64 `json:"expire_at_ms"`
+	}{Meta: true, Length: int64(len(entries)), LastMs: lastMs, LastSeq: lastSeq, ExpireAtMs: expireMs})
+	if err != nil {
+		t.Fatalf("marshal meta: %v", err)
+	}
+	buf.Write(meta)
+	buf.WriteByte('\n')
+	return buf.Bytes()
+}
+
+// readStreamEntries parses a decoded streams/<k>.jsonl into ordered
+// entries plus the _meta fields.
+func readStreamEntries(t *testing.T, root, enc string) ([]streamTestEntry, streamLineJSON) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, "redis", "db_0", "streams", enc+".jsonl"))
+	if err != nil {
+		t.Fatalf("read decoded stream: %v", err)
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	var entries []streamTestEntry
+	var meta streamLineJSON
+	for dec.More() {
+		var line streamLineJSON
+		if err := dec.Decode(&line); err != nil {
+			t.Fatalf("decode stream line: %v", err)
+		}
+		if line.Meta {
+			meta = line
+			continue
+		}
+		ent := streamTestEntry{id: line.ID}
+		for _, f := range line.Fields {
+			name, err := unmarshalRedisBinaryValue(f.Name)
+			if err != nil {
+				t.Fatalf("unmarshal field name: %v", err)
+			}
+			value, err := unmarshalRedisBinaryValue(f.Value)
+			if err != nil {
+				t.Fatalf("unmarshal field value: %v", err)
+			}
+			ent.fields = append(ent.fields, [2]string{string(name), string(value)})
+		}
+		entries = append(entries, ent)
+	}
+	return entries, meta
+}
+
+// TestRedisEncodeStreamRoundTripViaDecode runs the gold-standard
+// directory round-trip for a stream: entries (with duplicate field
+// names and a binary value) preserve ID + interleaved field order, and
+// the _meta line (length, last_ms, last_seq, TTL) round-trips.
+func TestRedisEncodeStreamRoundTripViaDecode(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	enc := EncodeSegment([]byte("mystream"))
+	const expireMs uint64 = 1_700_000_000_321
+	// Stream field values must be valid UTF-8: the live store marshals
+	// them into a proto3 string field, which rejects non-UTF-8 — so a
+	// real dump never carries binary stream fields. Duplicate field
+	// names within one entry ARE valid (XADD s * f v1 f v2) and must
+	// preserve interleaved order.
+	entries := []streamTestEntry{
+		{id: "1714400000000-0", fields: [][2]string{{"event", "login"}, {"user", "alice"}}},
+		{id: "1714400000001-5", fields: [][2]string{{"f", "v1"}, {"f", "v2"}}},
+	}
+	exp := expireMs
+	writeRedisFile(t, in, filepath.Join("streams", enc+".jsonl"),
+		buildStreamJSONL(t, entries, 1714400000001, 5, &exp))
+
+	out := decodeRedisTree(t, encodeRedisTree(t, in))
+
+	got, meta := readStreamEntries(t, out, enc)
+	assertStreamEntriesEqual(t, got, entries)
+	if meta.Length != int64(len(entries)) || meta.LastMs != 1714400000001 || meta.LastSeq != 5 {
+		t.Fatalf("meta = {len:%d lastMs:%d lastSeq:%d}, want {2 1714400000001 5}", meta.Length, meta.LastMs, meta.LastSeq)
+	}
+	if meta.ExpireAtMs == nil || *meta.ExpireAtMs != expireMs {
+		t.Fatalf("meta.expire_at_ms = %v, want %d", meta.ExpireAtMs, expireMs)
+	}
+}
+
+// assertStreamEntriesEqual checks two stream-entry slices match on ID
+// and interleaved field order.
+func assertStreamEntriesEqual(t *testing.T, got, want []streamTestEntry) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %d entries, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].id != want[i].id {
+			t.Fatalf("entry[%d] id = %q, want %q", i, got[i].id, want[i].id)
+		}
+		if len(got[i].fields) != len(want[i].fields) {
+			t.Fatalf("entry[%d] field count = %d, want %d", i, len(got[i].fields), len(want[i].fields))
+		}
+		for j := range want[i].fields {
+			if got[i].fields[j] != want[i].fields[j] {
+				t.Fatalf("entry[%d] field[%d] = %v, want %v (order must hold)", i, j, got[i].fields[j], want[i].fields[j])
+			}
+		}
+	}
+}
+
+// TestRedisEncodeStreamEmptyRoundTripViaDecode pins an empty-but-meta
+// stream (length 0, no entries) — XLEN observable, no TTL.
+func TestRedisEncodeStreamEmptyRoundTripViaDecode(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	enc := EncodeSegment([]byte("emptystream"))
+	writeRedisFile(t, in, filepath.Join("streams", enc+".jsonl"),
+		buildStreamJSONL(t, nil, 0, 0, nil))
+
+	out := decodeRedisTree(t, encodeRedisTree(t, in))
+
+	got, meta := readStreamEntries(t, out, enc)
+	if len(got) != 0 {
+		t.Fatalf("got %d entries, want 0", len(got))
+	}
+	if meta.Length != 0 {
+		t.Fatalf("meta.length = %d, want 0", meta.Length)
+	}
+	if meta.ExpireAtMs != nil {
+		t.Fatalf("meta.expire_at_ms = %v, want nil", *meta.ExpireAtMs)
+	}
+}
+
 // TestUnmarshalRedisBinaryValue pins both envelope shapes directly.
 func TestUnmarshalRedisBinaryValue(t *testing.T) {
 	t.Parallel()

--- a/internal/backup/encode_redis_coll_test.go
+++ b/internal/backup/encode_redis_coll_test.go
@@ -646,6 +646,29 @@ func TestUnmarshalRedisBinaryValue(t *testing.T) {
 	}
 }
 
+// TestRedisEncodeCollectionRejectsUnknownFormatVersion pins that each
+// JSON collection encoder fails closed on an unsupported
+// format_version rather than decoding with zero-valued fields and
+// emitting corrupt/empty rows.
+func TestRedisEncodeCollectionRejectsUnknownFormatVersion(t *testing.T) {
+	t.Parallel()
+	for _, subdir := range []string{"hashes", "sets", "lists", "zsets"} {
+		t.Run(subdir, func(t *testing.T) {
+			t.Parallel()
+			in := t.TempDir()
+			enc := EncodeSegment([]byte("k"))
+			// format_version 99 is unsupported; the guard fires right
+			// after Decode, before any field is consulted.
+			writeRedisFile(t, in, filepath.Join(subdir, enc+".json"), []byte(`{"format_version":99}`))
+			b := newSnapshotBuilder(redisEncTS)
+			err := NewRedisEncoder(in, 0).Encode(b)
+			if !errors.Is(err, ErrRedisEncodeInvalidJSON) {
+				t.Fatalf("%s Encode err = %v, want ErrRedisEncodeInvalidJSON", subdir, err)
+			}
+		})
+	}
+}
+
 // TestRedisEncodeStreamRejectsMismatchedMetaLength pins that a _meta
 // length disagreeing with the parsed entry count fails closed rather
 // than restoring an inconsistent XLEN.

--- a/internal/backup/encode_redis_coll_test.go
+++ b/internal/backup/encode_redis_coll_test.go
@@ -669,6 +669,41 @@ func TestRedisEncodeCollectionRejectsUnknownFormatVersion(t *testing.T) {
 	}
 }
 
+// TestRedisEncodeCollectionRejectsTrailingJSON pins that a collection
+// file with data after the single JSON object fails closed rather than
+// silently ignoring the trailing bytes.
+func TestRedisEncodeCollectionRejectsTrailingJSON(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	enc := EncodeSegment([]byte("k"))
+	// A valid hash object followed by a second object (trailing data).
+	body := append(buildHashJSON(t, map[string]string{"f": "v"}, nil), []byte(`{"x":1}`)...)
+	writeRedisFile(t, in, filepath.Join("hashes", enc+".json"), body)
+	b := newSnapshotBuilder(redisEncTS)
+	err := NewRedisEncoder(in, 0).Encode(b)
+	if !errors.Is(err, ErrRedisEncodeInvalidJSON) {
+		t.Fatalf("Encode err = %v, want ErrRedisEncodeInvalidJSON", err)
+	}
+}
+
+// TestRedisEncodeStreamRejectsDuplicateMeta pins that a stream JSONL
+// carrying two _meta lines fails closed rather than silently letting
+// the second overwrite the first.
+func TestRedisEncodeStreamRejectsDuplicateMeta(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	enc := EncodeSegment([]byte("dupmeta"))
+	body := []byte(
+		`{"_meta":true,"length":0,"last_ms":0,"last_seq":0,"expire_at_ms":null}` + "\n" +
+			`{"_meta":true,"length":0,"last_ms":0,"last_seq":0,"expire_at_ms":null}` + "\n")
+	writeRedisFile(t, in, filepath.Join("streams", enc+".jsonl"), body)
+	b := newSnapshotBuilder(redisEncTS)
+	err := NewRedisEncoder(in, 0).Encode(b)
+	if !errors.Is(err, ErrRedisEncodeInvalidJSON) {
+		t.Fatalf("Encode err = %v, want ErrRedisEncodeInvalidJSON", err)
+	}
+}
+
 // TestRedisEncodeStreamRejectsMismatchedMetaLength pins that a _meta
 // length disagreeing with the parsed entry count fails closed rather
 // than restoring an inconsistent XLEN.

--- a/internal/backup/encode_redis_coll_test.go
+++ b/internal/backup/encode_redis_coll_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"sort"
 	"testing"
+
+	"github.com/cockroachdb/errors"
 )
 
 // buildHashJSON constructs a hashes/<k>.json body in the exact shape
@@ -631,5 +633,32 @@ func TestUnmarshalRedisBinaryValue(t *testing.T) {
 	b64, err := unmarshalRedisBinaryValue(json.RawMessage(`{"base64":"_wA"}`))
 	if err != nil || !bytes.Equal(b64, []byte{0xff, 0x00}) {
 		t.Fatalf("base64 decode = %x, %v; want ff00", b64, err)
+	}
+	// A JSON object lacking "base64" must fail closed, not silently
+	// decode to empty bytes.
+	if _, err := unmarshalRedisBinaryValue(json.RawMessage(`{"wrong":"x"}`)); !errors.Is(err, ErrRedisEncodeInvalidJSON) {
+		t.Fatalf("unknown-object decode err = %v, want ErrRedisEncodeInvalidJSON", err)
+	}
+	// An empty base64 envelope is a valid empty value (not an error).
+	empty, err := unmarshalRedisBinaryValue(json.RawMessage(`{"base64":""}`))
+	if err != nil || len(empty) != 0 {
+		t.Fatalf("empty base64 = %x, %v; want empty/no-error", empty, err)
+	}
+}
+
+// TestRedisEncodeStreamRejectsNegativeLength pins that a _meta line with
+// a negative length fails closed rather than encoding a corrupt
+// (uint64-wrapped) stream meta.
+func TestRedisEncodeStreamRejectsNegativeLength(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	enc := EncodeSegment([]byte("badstream"))
+	body := []byte(`{"_meta":true,"length":-1,"last_ms":0,"last_seq":0,"expire_at_ms":null}` + "\n")
+	writeRedisFile(t, in, filepath.Join("streams", enc+".jsonl"), body)
+
+	b := newSnapshotBuilder(redisEncTS)
+	err := NewRedisEncoder(in, 0).Encode(b)
+	if !errors.Is(err, ErrRedisEncodeInvalidJSON) {
+		t.Fatalf("Encode err = %v, want ErrRedisEncodeInvalidJSON", err)
 	}
 }

--- a/internal/backup/encode_redis_coll_test.go
+++ b/internal/backup/encode_redis_coll_test.go
@@ -142,6 +142,102 @@ func TestRedisEncodeHashBinaryFieldRoundTrip(t *testing.T) {
 	}
 }
 
+// buildSetJSON constructs a sets/<k>.json body in marshalSetJSON's
+// shape (members array of binary envelopes).
+func buildSetJSON(t *testing.T, members []string, expireMs *uint64) []byte {
+	t.Helper()
+	sort.Strings(members)
+	raw := make([]json.RawMessage, 0, len(members))
+	for _, m := range members {
+		v, err := marshalRedisBinaryValue([]byte(m))
+		if err != nil {
+			t.Fatalf("marshal member: %v", err)
+		}
+		raw = append(raw, v)
+	}
+	out := struct {
+		FormatVersion uint32            `json:"format_version"`
+		Members       []json.RawMessage `json:"members"`
+		ExpireAtMs    *uint64           `json:"expire_at_ms"`
+	}{FormatVersion: 1, Members: raw, ExpireAtMs: expireMs}
+	body, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal set json: %v", err)
+	}
+	return body
+}
+
+// readSetMembers parses a decoded sets/<k>.json into a member set plus
+// its expiry.
+func readSetMembers(t *testing.T, root, enc string) (map[string]struct{}, *uint64) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, "redis", "db_0", "sets", enc+".json"))
+	if err != nil {
+		t.Fatalf("read decoded set: %v", err)
+	}
+	var rec setJSONRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatalf("unmarshal decoded set: %v", err)
+	}
+	out := map[string]struct{}{}
+	for _, mRaw := range rec.Members {
+		m, err := unmarshalRedisBinaryValue(mRaw)
+		if err != nil {
+			t.Fatalf("unmarshal member: %v", err)
+		}
+		out[string(m)] = struct{}{}
+	}
+	return out, rec.ExpireAtMs
+}
+
+// TestRedisEncodeSetRoundTripViaDecode runs the gold-standard directory
+// round-trip for a set with TTL and a non-UTF-8 member.
+func TestRedisEncodeSetRoundTripViaDecode(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	enc := EncodeSegment([]byte("myset"))
+	const expireMs uint64 = 1_700_000_000_123
+	members := []string{"red", "green", "\xff\x00"}
+	exp := expireMs
+	writeRedisFile(t, in, filepath.Join("sets", enc+".json"), buildSetJSON(t, members, &exp))
+
+	out := decodeRedisTree(t, encodeRedisTree(t, in))
+
+	got, gotExp := readSetMembers(t, out, enc)
+	if len(got) != len(members) {
+		t.Fatalf("got %d members, want %d", len(got), len(members))
+	}
+	for _, m := range members {
+		if _, ok := got[m]; !ok {
+			t.Fatalf("member %q missing from decoded set", m)
+		}
+	}
+	if gotExp == nil || *gotExp != expireMs {
+		t.Fatalf("decoded expire_at_ms = %v, want %d", gotExp, expireMs)
+	}
+}
+
+// TestRedisEncodeSetNoTTLRoundTripViaDecode pins the no-TTL set path.
+func TestRedisEncodeSetNoTTLRoundTripViaDecode(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	enc := EncodeSegment([]byte("plainset"))
+	writeRedisFile(t, in, filepath.Join("sets", enc+".json"), buildSetJSON(t, []string{"a", "b"}, nil))
+
+	out := decodeRedisTree(t, encodeRedisTree(t, in))
+
+	got, gotExp := readSetMembers(t, out, enc)
+	if _, ok := got["a"]; !ok {
+		t.Fatal("member a missing")
+	}
+	if _, ok := got["b"]; !ok {
+		t.Fatal("member b missing")
+	}
+	if gotExp != nil {
+		t.Fatalf("decoded expire_at_ms = %v, want nil", *gotExp)
+	}
+}
+
 // TestUnmarshalRedisBinaryValue pins both envelope shapes directly.
 func TestUnmarshalRedisBinaryValue(t *testing.T) {
 	t.Parallel()

--- a/internal/backup/encode_redis_coll_test.go
+++ b/internal/backup/encode_redis_coll_test.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"bytes"
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -327,6 +328,121 @@ func TestRedisEncodeListNoTTLRoundTripViaDecode(t *testing.T) {
 	got, gotExp := readListItems(t, out, enc)
 	if len(got) != 1 || got[0] != "only" {
 		t.Fatalf("got %v, want [only]", got)
+	}
+	if gotExp != nil {
+		t.Fatalf("decoded expire_at_ms = %v, want nil", *gotExp)
+	}
+}
+
+// buildZSetJSON constructs a zsets/<k>.json body (members array of
+// {member envelope, score number/"+inf"/"-inf"}).
+func buildZSetJSON(t *testing.T, members map[string]float64, expireMs *uint64) []byte {
+	t.Helper()
+	names := make([]string, 0, len(members))
+	for n := range members {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	type rec struct {
+		Member json.RawMessage `json:"member"`
+		Score  json.RawMessage `json:"score"`
+	}
+	recs := make([]rec, 0, len(names))
+	for _, n := range names {
+		nameJSON, err := marshalRedisBinaryValue([]byte(n))
+		if err != nil {
+			t.Fatalf("marshal member: %v", err)
+		}
+		scoreJSON, err := marshalRedisZSetScore(members[n])
+		if err != nil {
+			t.Fatalf("marshal score: %v", err)
+		}
+		recs = append(recs, rec{Member: nameJSON, Score: scoreJSON})
+	}
+	out := struct {
+		FormatVersion uint32  `json:"format_version"`
+		Members       []rec   `json:"members"`
+		ExpireAtMs    *uint64 `json:"expire_at_ms"`
+	}{FormatVersion: 1, Members: recs, ExpireAtMs: expireMs}
+	body, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal zset json: %v", err)
+	}
+	return body
+}
+
+// readZSetMembers parses a decoded zsets/<k>.json into member->score
+// plus its expiry.
+func readZSetMembers(t *testing.T, root, enc string) (map[string]float64, *uint64) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, "redis", "db_0", "zsets", enc+".json"))
+	if err != nil {
+		t.Fatalf("read decoded zset: %v", err)
+	}
+	var rec zsetJSONRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatalf("unmarshal decoded zset: %v", err)
+	}
+	out := map[string]float64{}
+	for _, m := range rec.Members {
+		member, err := unmarshalRedisBinaryValue(m.Member)
+		if err != nil {
+			t.Fatalf("unmarshal member: %v", err)
+		}
+		score, err := unmarshalRedisZSetScore(m.Score)
+		if err != nil {
+			t.Fatalf("unmarshal score: %v", err)
+		}
+		out[string(member)] = score
+	}
+	return out, rec.ExpireAtMs
+}
+
+// TestRedisEncodeZSetRoundTripViaDecode runs the gold-standard
+// directory round-trip for a zset with fractional, negative, and
+// +inf scores plus a TTL.
+func TestRedisEncodeZSetRoundTripViaDecode(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	enc := EncodeSegment([]byte("myzset"))
+	const expireMs uint64 = 1_700_000_000_999
+	want := map[string]float64{
+		"alice": 100.5,
+		"bob":   -3.25,
+		"max":   math.Inf(1),
+	}
+	exp := expireMs
+	writeRedisFile(t, in, filepath.Join("zsets", enc+".json"), buildZSetJSON(t, want, &exp))
+
+	out := decodeRedisTree(t, encodeRedisTree(t, in))
+
+	got, gotExp := readZSetMembers(t, out, enc)
+	if len(got) != len(want) {
+		t.Fatalf("got %d members, want %d", len(got), len(want))
+	}
+	for m, s := range want {
+		if got[m] != s {
+			t.Fatalf("member %q score = %v, want %v", m, got[m], s)
+		}
+	}
+	if gotExp == nil || *gotExp != expireMs {
+		t.Fatalf("decoded expire_at_ms = %v, want %d", gotExp, expireMs)
+	}
+}
+
+// TestRedisEncodeZSetNoTTLRoundTripViaDecode pins the no-TTL zset path.
+func TestRedisEncodeZSetNoTTLRoundTripViaDecode(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	enc := EncodeSegment([]byte("zz"))
+	writeRedisFile(t, in, filepath.Join("zsets", enc+".json"),
+		buildZSetJSON(t, map[string]float64{"x": 1, "y": 2}, nil))
+
+	out := decodeRedisTree(t, encodeRedisTree(t, in))
+
+	got, gotExp := readZSetMembers(t, out, enc)
+	if got["x"] != 1 || got["y"] != 2 {
+		t.Fatalf("got %v, want x=1 y=2", got)
 	}
 	if gotExp != nil {
 		t.Fatalf("decoded expire_at_ms = %v, want nil", *gotExp)

--- a/internal/backup/encode_redis_coll_test.go
+++ b/internal/backup/encode_redis_coll_test.go
@@ -646,6 +646,45 @@ func TestUnmarshalRedisBinaryValue(t *testing.T) {
 	}
 }
 
+// TestRedisEncodeStreamRejectsMismatchedMetaLength pins that a _meta
+// length disagreeing with the parsed entry count fails closed rather
+// than restoring an inconsistent XLEN.
+func TestRedisEncodeStreamRejectsMismatchedMetaLength(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	enc := EncodeSegment([]byte("mism"))
+	// One entry line, but _meta claims length 0.
+	body := []byte(`{"id":"1-0","fields":[{"name":"f","value":"v"}]}` + "\n" +
+		`{"_meta":true,"length":0,"last_ms":1,"last_seq":0,"expire_at_ms":null}` + "\n")
+	writeRedisFile(t, in, filepath.Join("streams", enc+".jsonl"), body)
+
+	b := newSnapshotBuilder(redisEncTS)
+	err := NewRedisEncoder(in, 0).Encode(b)
+	if !errors.Is(err, ErrRedisEncodeInvalidJSON) {
+		t.Fatalf("Encode err = %v, want ErrRedisEncodeInvalidJSON", err)
+	}
+}
+
+// TestRedisEncodeStreamRejectsStaleLastID pins that a _meta
+// last_ms/last_seq behind the maximum parsed entry ID fails closed —
+// otherwise a future XADD '*' could mint an ID that collides with an
+// existing entry.
+func TestRedisEncodeStreamRejectsStaleLastID(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	enc := EncodeSegment([]byte("stale"))
+	// Entry at 5-0 but _meta high-water mark only 3-0.
+	body := []byte(`{"id":"5-0","fields":[{"name":"f","value":"v"}]}` + "\n" +
+		`{"_meta":true,"length":1,"last_ms":3,"last_seq":0,"expire_at_ms":null}` + "\n")
+	writeRedisFile(t, in, filepath.Join("streams", enc+".jsonl"), body)
+
+	b := newSnapshotBuilder(redisEncTS)
+	err := NewRedisEncoder(in, 0).Encode(b)
+	if !errors.Is(err, ErrRedisEncodeInvalidJSON) {
+		t.Fatalf("Encode err = %v, want ErrRedisEncodeInvalidJSON", err)
+	}
+}
+
 // TestRedisEncodeStreamRejectsNegativeLength pins that a _meta line with
 // a negative length fails closed rather than encoding a corrupt
 // (uint64-wrapped) stream meta.

--- a/internal/backup/encode_redis_coll_test.go
+++ b/internal/backup/encode_redis_coll_test.go
@@ -1,0 +1,158 @@
+package backup
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// buildHashJSON constructs a hashes/<k>.json body in the exact shape
+// marshalHashJSON emits (fields as an array of binary-envelope
+// {name,value} records), so the encoder reads a faithful decoder
+// output. expireMs nil means no TTL.
+func buildHashJSON(t *testing.T, fields map[string]string, expireMs *uint64) []byte {
+	t.Helper()
+	type fieldRec struct {
+		Name  json.RawMessage `json:"name"`
+		Value json.RawMessage `json:"value"`
+	}
+	names := make([]string, 0, len(fields))
+	for n := range fields {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	recs := make([]fieldRec, 0, len(names))
+	for _, n := range names {
+		nameJSON, err := marshalRedisBinaryValue([]byte(n))
+		if err != nil {
+			t.Fatalf("marshal name: %v", err)
+		}
+		valJSON, err := marshalRedisBinaryValue([]byte(fields[n]))
+		if err != nil {
+			t.Fatalf("marshal value: %v", err)
+		}
+		recs = append(recs, fieldRec{Name: nameJSON, Value: valJSON})
+	}
+	out := struct {
+		FormatVersion uint32     `json:"format_version"`
+		Fields        []fieldRec `json:"fields"`
+		ExpireAtMs    *uint64    `json:"expire_at_ms"`
+	}{FormatVersion: 1, Fields: recs, ExpireAtMs: expireMs}
+	body, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("marshal hash json: %v", err)
+	}
+	return body
+}
+
+// readHashFields parses a decoded hashes/<k>.json into a name->value
+// map plus its expiry.
+func readHashFields(t *testing.T, root, enc string) (map[string]string, *uint64) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, "redis", "db_0", "hashes", enc+".json"))
+	if err != nil {
+		t.Fatalf("read decoded hash: %v", err)
+	}
+	var rec hashJSONRecord
+	if err := json.Unmarshal(data, &rec); err != nil {
+		t.Fatalf("unmarshal decoded hash: %v", err)
+	}
+	out := map[string]string{}
+	for _, f := range rec.Fields {
+		name, err := unmarshalRedisBinaryValue(f.Name)
+		if err != nil {
+			t.Fatalf("unmarshal field name: %v", err)
+		}
+		value, err := unmarshalRedisBinaryValue(f.Value)
+		if err != nil {
+			t.Fatalf("unmarshal field value: %v", err)
+		}
+		out[string(name)] = string(value)
+	}
+	return out, rec.ExpireAtMs
+}
+
+// TestRedisEncodeHashRoundTripViaDecode runs the gold-standard
+// directory round-trip for a hash with fields and a TTL: the fields
+// survive and the TTL (emitted as an !redis|ttl| row by the encoder)
+// is recovered into expire_at_ms by the decoder.
+func TestRedisEncodeHashRoundTripViaDecode(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	enc := EncodeSegment([]byte("myhash"))
+	const expireMs uint64 = 1_735_689_600_000
+	want := map[string]string{"name": "alice", "age": "30", "city": "tokyo"}
+	exp := expireMs
+	writeRedisFile(t, in, filepath.Join("hashes", enc+".json"), buildHashJSON(t, want, &exp))
+
+	out := decodeRedisTree(t, encodeRedisTree(t, in))
+
+	got, gotExp := readHashFields(t, out, enc)
+	if len(got) != len(want) {
+		t.Fatalf("got %d fields, want %d", len(got), len(want))
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Fatalf("field %q = %q, want %q", k, got[k], v)
+		}
+	}
+	if gotExp == nil || *gotExp != expireMs {
+		t.Fatalf("decoded expire_at_ms = %v, want %d", gotExp, expireMs)
+	}
+}
+
+// TestRedisEncodeHashNoTTLRoundTripViaDecode pins the no-TTL hash path:
+// fields survive and expire_at_ms is null.
+func TestRedisEncodeHashNoTTLRoundTripViaDecode(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	enc := EncodeSegment([]byte("plain"))
+	want := map[string]string{"k1": "v1"}
+	writeRedisFile(t, in, filepath.Join("hashes", enc+".json"), buildHashJSON(t, want, nil))
+
+	out := decodeRedisTree(t, encodeRedisTree(t, in))
+
+	got, gotExp := readHashFields(t, out, enc)
+	if got["k1"] != "v1" {
+		t.Fatalf("field k1 = %q, want v1", got["k1"])
+	}
+	if gotExp != nil {
+		t.Fatalf("decoded expire_at_ms = %v, want nil", *gotExp)
+	}
+}
+
+// TestRedisEncodeHashBinaryFieldRoundTrip pins that non-UTF-8 field
+// names and values survive via the base64 envelope.
+func TestRedisEncodeHashBinaryFieldRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	enc := EncodeSegment([]byte("bin"))
+	// 0xFF 0xFE are not valid UTF-8 → base64 envelope on both sides.
+	want := map[string]string{"\xff\xfe": "\x00\x01\x02"}
+	writeRedisFile(t, in, filepath.Join("hashes", enc+".json"), buildHashJSON(t, want, nil))
+
+	out := decodeRedisTree(t, encodeRedisTree(t, in))
+
+	got, _ := readHashFields(t, out, enc)
+	if got["\xff\xfe"] != "\x00\x01\x02" {
+		t.Fatalf("binary field round-trip failed: got %x", got["\xff\xfe"])
+	}
+}
+
+// TestUnmarshalRedisBinaryValue pins both envelope shapes directly.
+func TestUnmarshalRedisBinaryValue(t *testing.T) {
+	t.Parallel()
+	// UTF-8 plain-string form.
+	plain, err := unmarshalRedisBinaryValue(json.RawMessage(`"hello"`))
+	if err != nil || !bytes.Equal(plain, []byte("hello")) {
+		t.Fatalf("plain decode = %q, %v; want hello", plain, err)
+	}
+	// base64 envelope form (0xff 0x00).
+	b64, err := unmarshalRedisBinaryValue(json.RawMessage(`{"base64":"_wA"}`))
+	if err != nil || !bytes.Equal(b64, []byte{0xff, 0x00}) {
+		t.Fatalf("base64 decode = %x, %v; want ff00", b64, err)
+	}
+}

--- a/internal/backup/encode_redis_coll_test.go
+++ b/internal/backup/encode_redis_coll_test.go
@@ -3,6 +3,8 @@ package backup
 import (
 	"bytes"
 	"encoding/json"
+	"io"
+	"io/fs"
 	"math"
 	"os"
 	"path/filepath"
@@ -11,6 +13,51 @@ import (
 
 	"github.com/cockroachdb/errors"
 )
+
+// fakeRegularDirEntry is an os.DirEntry that LIES about its type,
+// reporting a regular file regardless of the real on-disk object. It
+// lets a unit test drive handleJSONEntry past the pre-open
+// ent.Type().IsRegular() check so the post-open fstat guard can be
+// exercised deterministically (simulating a ReadDir-vs-Open TOCTOU
+// without an actual race).
+type fakeRegularDirEntry struct{ name string }
+
+func (f fakeRegularDirEntry) Name() string               { return f.name }
+func (f fakeRegularDirEntry) IsDir() bool                { return false }
+func (f fakeRegularDirEntry) Type() fs.FileMode          { return 0 } // 0 == regular
+func (f fakeRegularDirEntry) Info() (fs.FileInfo, error) { return nil, errors.New("unused") }
+
+// TestHandleJSONEntryRejectsNonRegularAfterOpen pins the post-open
+// regularity guard: a ReadDir entry that claims to be a regular .json
+// file but actually resolves to a directory on open is rejected with
+// ErrRedisEncodeNotRegular, and the callback never runs. This is the
+// deterministic stand-in for the FIFO-swap TOCTOU the guard defends
+// against (a directory opens without blocking, unlike a reader-less
+// FIFO).
+func TestHandleJSONEntryRejectsNonRegularAfterOpen(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// A directory named like a regular collection file.
+	if err := os.MkdirAll(filepath.Join(dir, "x.json"), 0o755); err != nil {
+		t.Fatalf("mkdir x.json: %v", err)
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatalf("OpenRoot: %v", err)
+	}
+	defer func() { _ = root.Close() }()
+
+	e := NewRedisEncoder(dir, 0)
+	called := false
+	err = e.handleJSONEntry(root, fakeRegularDirEntry{name: "x.json"}, ".json",
+		func(_ []byte, _ io.Reader) error { called = true; return nil })
+	if !errors.Is(err, ErrRedisEncodeNotRegular) {
+		t.Fatalf("handleJSONEntry err = %v, want ErrRedisEncodeNotRegular", err)
+	}
+	if called {
+		t.Fatal("callback must not run for a non-regular open target")
+	}
+}
 
 // buildHashJSON constructs a hashes/<k>.json body in the exact shape
 // marshalHashJSON emits (fields as an array of binary-envelope
@@ -612,6 +659,9 @@ func TestRedisEncodeStreamEmptyRoundTripViaDecode(t *testing.T) {
 	got, meta := readStreamEntries(t, out, enc)
 	if len(got) != 0 {
 		t.Fatalf("got %d entries, want 0", len(got))
+	}
+	if !meta.Meta {
+		t.Fatal("decoded stream missing the _meta terminator line")
 	}
 	if meta.Length != 0 {
 		t.Fatalf("meta.length = %d, want 0", meta.Length)

--- a/internal/backup/encode_redis_hardlink_unix_test.go
+++ b/internal/backup/encode_redis_hardlink_unix_test.go
@@ -96,6 +96,31 @@ func TestRedisEncodeRejectsSymlinkedBlobSubdir(t *testing.T) {
 	}
 }
 
+// TestRedisEncodeRejectsSymlinkedCollectionSubdir pins that a symlinked
+// collection subdir (hashes/) is refused before walkJSONDir's
+// os.OpenRoot follows it outside the dump tree — the .json/.jsonl
+// counterpart of the blob-subdir guard.
+func TestRedisEncodeRejectsSymlinkedCollectionSubdir(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	external := filepath.Join(in, "external_hashes")
+	if err := os.MkdirAll(external, 0o755); err != nil {
+		t.Fatalf("mkdir external: %v", err)
+	}
+	dbDir := filepath.Join(in, "redis", "db_0")
+	if err := os.MkdirAll(dbDir, 0o755); err != nil {
+		t.Fatalf("mkdir dbDir: %v", err)
+	}
+	if err := os.Symlink(external, filepath.Join(dbDir, "hashes")); err != nil {
+		t.Fatalf("symlink hashes: %v", err)
+	}
+	b := newSnapshotBuilder(redisEncTS)
+	err := NewRedisEncoder(in, 0).Encode(b)
+	if !errors.Is(err, ErrRedisEncodeNotDir) {
+		t.Fatalf("Encode err = %v, want ErrRedisEncodeNotDir", err)
+	}
+}
+
 // TestRedisEncodeRejectsSymlinkedDbDir pins that a symlinked
 // redis/db_<n> directory is refused (Lstat in Encode) rather than
 // followed outside the dump tree.


### PR DESCRIPTION
## Summary

**Phase 0b M2b — Redis wide-column collection reverse encoders.** Completes the Redis reverse encoder (M2) on top of M2a (strings + HLL, #828): the inverse of the hash/set/list/zset/stream decoders. Builds on M1's `snapshotBuilder` (#825). Design: `docs/design/2026_05_25_proposed_snapshot_logical_encoder.md`.

Per-type reverse encoders in `internal/backup/encode_redis_coll.go`, each pinned against the **live store** key/value layout so the emitted `.fsm` loads into a running cluster:

- **hash** — `!hs|meta|` (8-byte BE field count) + `!hs|fld|` per field. Emits only the consolidated base meta (no `!hs|meta|d|` deltas — the post-compaction steady state).
- **set** — `!st|meta|` count + `!st|mem|<member>` (empty value, matching the live SADD write).
- **list** — `!lst|meta|` (24-byte `[Head][Tail][Len]`) + `!lst|itm|<sortableInt64(seq)>`. The dump records order but not seqs, so items get the canonical contiguous form (Head=0, seq=i, Tail=Len); **order is preserved**.
- **zset** — both indexes: `!zs|mem|<member>` → 8-byte BE float score, and `!zs|scr|<sortableFloat64><member>` → empty range index. `+inf`/`-inf` handled; NaN rejected.
- **stream** — `!stream|meta|` (24-byte `[Length][LastMs][LastSeq]`) + `!stream|entry|` whose value is the magic-prefixed `pb.RedisStreamEntry{Id, Fields}` the live store writes (Id set so XRANGE/XREAD report the right ID). JSONL parsed line-by-line; `_meta` line drives meta + TTL.

Cross-cutting:
- Non-string collection TTL is emitted as an `!redis|ttl|` scan-index row (matching `buildTTLElems`), unlike strings' inline TTL.
- Binary field/member names round-trip through `unmarshalRedisBinaryValue` (inverse of the decoder's `{"base64":...}` envelope). Stream field values must be valid UTF-8 — the proto3 string field rejects non-UTF-8 on both the live write and this encoder.
- `walkJSONDir` reads through `os.Root` + `lstatDumpDir` symlink-refusal + `IsRegular` + `refuseHardLink`, inheriting M2a's full read-path hardening.

## Risk

New code only; no existing behavior changed. Offline-tool boundary preserved.

## Self-review (5 lenses)

- **Data loss**: every type verified by a gold-standard directory round-trip through the **real** `DecodeSnapshot`; order preserved for lists and stream entries; duplicate hash/stream field names preserved (array shape).
- **Concurrency/distributed**: single-goroutine encoder feeding one builder.
- **Performance**: streams files via `os.Root`; in-memory sort bound is the design's documented external-sort follow-up.
- **Consistency**: key/value formats pinned against the live write path (meta deltas consolidated, zset dual-index lockstep, list seq invariant `Tail=Head+Len`, stream entry `Id` set); collection TTL via scan-index row.
- **Test coverage**: per-type round-trips (with/without TTL, binary names, fractional/negative/+inf scores, list order, duplicate stream fields, empty-but-meta stream) + unix-gated symlink-subdir rejection.

## Test plan

- [x] `go test ./internal/backup/` (full package)
- [x] `golangci-lint run internal/backup/` (0 issues)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for encoding Redis collection data types (hashes, sets, lists, sorted sets, and streams) in backups.

* **Bug Fixes**
  * Hardened directory traversal to prevent symlink-swap vulnerabilities during backup processing.
  * Improved validation and error handling for corrupted or malformed collection data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->