### PR TITLE
feat(encryption): Stage 6D-6c-3b - end-to-end Bootstrap→cutover→Put→read-back test

### DIFF
--- a/docs/design/2026_05_18_implemented_6d_enable_storage_envelope.md
+++ b/docs/design/2026_05_18_implemented_6d_enable_storage_envelope.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| Status | partial — 6D-1 (doc), 6D-2 (startup guards), 6D-3 (capability fan-out helper), 6D-4 (cutover wire + apply dispatch), 6D-5 (storage-layer toggle), 6D-6a (EnableStorageEnvelope server method), 6D-6b (CLI subcommand), 6D-6c-1 (Applier in-memory accessors) shipped; 6D-6c-2 (main.go cipher + gate wiring) and 6D-6c-3 (capability fan-out closure + e2e integration test) remain |
+| Status | implemented — all milestones shipped: 6D-1 (doc), 6D-2 (startup guards), 6D-3 (capability fan-out helper), 6D-4 (cutover wire + apply dispatch), 6D-5 (storage-layer toggle), 6D-6a (EnableStorageEnvelope server method), 6D-6b (CLI subcommand), 6D-6c-1 (Applier in-memory accessors), 6D-6c-2 (main.go cipher + gate wiring), 6D-6c-3a (capability fan-out closure wiring), 6D-6c-3b (end-to-end Bootstrap→cutover→Put→read-back test). Note: the multi-node-churn registration-before-first-write nonce gate is tracked separately as a Stage 7 deferral in [`2026_05_25_partial_6d6c2_production_storage_envelope_wiring.md`](2026_05_25_partial_6d6c2_production_storage_envelope_wiring.md) — not a 6D milestone. |
 | Date | 2026-05-18 |
 | Parent design | [`2026_04_29_partial_data_at_rest_encryption.md`](2026_04_29_partial_data_at_rest_encryption.md) |
 | Blockers (now satisfied) | 6B (KEK plumbing), 6C-1 / 6C-2 (startup guards), 6C-2d (`ErrSidecarBehindRaftLog` wiring) |
@@ -111,13 +111,19 @@
   all groups + a `DialFunc` over a dedicated `kv.GRPCConnCache`),
   wired into the EnableStorageEnvelope server via
   `WithEncryptionAdminCapabilityFanout` gated on encryption mutators.
-  See [`2026_05_25_partial_6d6c3a_capability_fanout_wiring.md`](2026_05_25_partial_6d6c3a_capability_fanout_wiring.md).
+  See [`2026_05_25_implemented_6d6c3a_capability_fanout_wiring.md`](2026_05_25_implemented_6d6c3a_capability_fanout_wiring.md).
+- **6D-6c-3b** (shipped) — `package main` end-to-end integration test
+  (`main_encryption_e2e_test.go`) driving the production
+  `buildEncryptionWriteWiring` + a shared-`StateCache` applier through
+  Bootstrap → cutover → Put → read-back, proving post-cutover writes
+  land as on-disk §4.1 envelopes (a cipher-less reopen refuses them)
+  while every version reads back as correct plaintext.
 
 ## Open milestones
 
-- **6D-6c-3b** — end-to-end integration test exercising a single-node
-  cluster Bootstrap → EnableStorageEnvelope → Put →
-  read-back-via-envelope, on top of the 6D-6c-3a fan-out wiring.
+_None — Stage 6D is complete. The §7.1 rollout's remaining
+multi-node-churn nonce safety (registration-before-first-write gate)
+is a Stage 7 item, tracked in the 6D-6c-2 partial doc._
 
 ## 0. Why this doc exists
 

--- a/docs/design/2026_05_25_implemented_6d6c3a_capability_fanout_wiring.md
+++ b/docs/design/2026_05_25_implemented_6d6c3a_capability_fanout_wiring.md
@@ -2,14 +2,15 @@
 
 | Field | Value |
 |---|---|
-| Status | partial |
+| Status | implemented |
 | Date | 2026-05-25 |
-| Parent designs | [`2026_05_18_partial_6d_enable_storage_envelope.md`](2026_05_18_partial_6d_enable_storage_envelope.md) (6D-6c-3 milestone; §4 capability fan-out), [`2026_04_29_partial_data_at_rest_encryption.md`](2026_04_29_partial_data_at_rest_encryption.md) (§7.1 rollout) |
+| Parent designs | [`2026_05_18_implemented_6d_enable_storage_envelope.md`](2026_05_18_implemented_6d_enable_storage_envelope.md) (6D-6c-3 milestone; §4 capability fan-out), [`2026_04_29_partial_data_at_rest_encryption.md`](2026_04_29_partial_data_at_rest_encryption.md) (§7.1 rollout) |
 | Builds on | 6D-3 (`internal/admin.CapabilityFanout` helper), 6D-6a (`adapter.WithEncryptionAdminCapabilityFanout` option) |
 
-**Lifecycle:** the §1 fan-out closure wiring shipped in this PR; the
+**Lifecycle:** the §1 fan-out closure wiring shipped in 6D-6c-3a; the
 6D-6c-3b end-to-end test (Bootstrap → EnableStorageEnvelope → Put →
-read-back) remains open. Flips to `*_implemented_*` when 3b lands.
+read-back, `main_encryption_e2e_test.go`) shipped on top of it — this
+doc is now fully implemented.
 
 ## 0. Why this doc exists
 
@@ -58,9 +59,11 @@ wire-format change.
   `WithEncryptionAdminCapabilityFanout`, gated on the same
   `enableMutators` boolean that gates the Proposer/LeaderView (the
   fan-out is only meaningful when the cutover mutator is reachable).
-- Fan-out timeout: a `const` in `main.go` (start at 5s — generous for
-  a small cluster GetCapability round-trip; the helper bounds the
-  whole fan-out by it regardless of member count).
+- Fan-out timeout: the `capabilityFanoutTimeout` const in
+  `main_encryption_fanout.go` (5s — generous for a small-cluster
+  GetCapability round-trip; the helper bounds the whole fan-out by it
+  regardless of member count). It lives alongside the fan-out builder
+  rather than in `main.go` since it only affects fan-out behavior.
 
 ### Out of scope (6D-6c-3b)
 

--- a/docs/design/2026_05_25_partial_6d6c2_production_storage_envelope_wiring.md
+++ b/docs/design/2026_05_25_partial_6d6c2_production_storage_envelope_wiring.md
@@ -4,7 +4,7 @@
 |---|---|
 | Status | partial |
 | Date | 2026-05-25 |
-| Parent designs | [`2026_04_29_partial_data_at_rest_encryption.md`](2026_04_29_partial_data_at_rest_encryption.md) (§4.1 nonce, §5.1 sidecar, §7.1 rollout), [`2026_05_18_partial_6d_enable_storage_envelope.md`](2026_05_18_partial_6d_enable_storage_envelope.md) (6D-6c milestone breakdown) |
+| Parent designs | [`2026_04_29_partial_data_at_rest_encryption.md`](2026_04_29_partial_data_at_rest_encryption.md) (§4.1 nonce, §5.1 sidecar, §7.1 rollout), [`2026_05_18_implemented_6d_enable_storage_envelope.md`](2026_05_18_implemented_6d_enable_storage_envelope.md) (6D-6c milestone breakdown) |
 | Pulls forward | The deterministic-nonce core of Stage 7 (§4.1 `write_count` / `local_epoch` lifecycle). The full Raft-replicated writer-registry **registration-before-first-write** gate stays in Stage 7. |
 
 ## Lifecycle status

--- a/main_encryption_e2e_test.go
+++ b/main_encryption_e2e_test.go
@@ -107,7 +107,13 @@ func newE2EEncryptionFixture(t *testing.T, sidecarPath, pebbleDir string) (store
 		t.Fatalf("NewPebbleStore: %v", err)
 	}
 	var closeOnce sync.Once
-	closeStore := func() { closeOnce.Do(func() { _ = st.Close() }) }
+	closeStore := func() {
+		closeOnce.Do(func() {
+			if err := st.Close(); err != nil {
+				t.Errorf("close encrypted store: %v", err)
+			}
+		})
+	}
 	t.Cleanup(closeStore)
 	reg, err := store.WriterRegistryFor(st)
 	if err != nil {

--- a/main_encryption_e2e_test.go
+++ b/main_encryption_e2e_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/bootjp/elastickv/internal/encryption"
@@ -37,7 +38,7 @@ func TestEncryption_E2E_BootstrapCutoverPutReadback(t *testing.T) {
 	sidecarPath := dir + "/keys.json"
 	pebbleDir := dir + "/fsm.db"
 
-	st, applier, cache := newE2EEncryptionFixture(t, sidecarPath, pebbleDir)
+	st, applier, cache, closeStore := newE2EEncryptionFixture(t, sidecarPath, pebbleDir)
 
 	// Phase 0 (pre-bootstrap): no active DEK, gate off → cleartext.
 	assertActiveStorageKeyID(t, cache, 0, false)
@@ -66,9 +67,10 @@ func TestEncryption_E2E_BootstrapCutoverPutReadback(t *testing.T) {
 	assertGet(t, ctx, st, "mid", "plain-mid", 110)
 	assertGet(t, ctx, st, "after", "plain-after", 120)
 
-	if err := st.Close(); err != nil {
-		t.Fatalf("close encrypted store: %v", err)
-	}
+	// Release the Pebble lock before the cipher-less reopen. closeStore
+	// is idempotent (sync.Once) and also registered via t.Cleanup, so
+	// an early t.Fatal above still closes the store.
+	closeStore()
 	assertEncryptedAtRest(t, ctx, pebbleDir)
 }
 
@@ -76,7 +78,11 @@ func TestEncryption_E2E_BootstrapCutoverPutReadback(t *testing.T) {
 // (buildEncryptionWriteWiring) over a fresh pre-bootstrap sidecar, opens
 // a PebbleStore with its options, and constructs an Applier that shares
 // the same keystore + StateCache — exactly the main.go wiring topology.
-func newE2EEncryptionFixture(t *testing.T, sidecarPath, pebbleDir string) (store.MVCCStore, *encryption.Applier, *encryption.StateCache) {
+// The returned closeStore is idempotent (sync.Once) and registered via
+// t.Cleanup, so the Pebble store is closed exactly once whether the
+// test closes it explicitly (before the cipher-less reopen) or exits
+// early via t.Fatal.
+func newE2EEncryptionFixture(t *testing.T, sidecarPath, pebbleDir string) (store.MVCCStore, *encryption.Applier, *encryption.StateCache, func()) {
 	t.Helper()
 	keystore := encryption.NewKeystore()
 	encWiring, err := buildEncryptionWriteWiring(true, "n1", sidecarPath, wiringFakeKEK{}, keystore)
@@ -90,6 +96,9 @@ func newE2EEncryptionFixture(t *testing.T, sidecarPath, pebbleDir string) (store
 	if err != nil {
 		t.Fatalf("NewPebbleStore: %v", err)
 	}
+	var closeOnce sync.Once
+	closeStore := func() { closeOnce.Do(func() { _ = st.Close() }) }
+	t.Cleanup(closeStore)
 	reg, err := store.WriterRegistryFor(st)
 	if err != nil {
 		t.Fatalf("WriterRegistryFor: %v", err)
@@ -103,7 +112,7 @@ func newE2EEncryptionFixture(t *testing.T, sidecarPath, pebbleDir string) (store
 	if err != nil {
 		t.Fatalf("NewApplier: %v", err)
 	}
-	return st, applier, encWiring.cache
+	return st, applier, encWiring.cache, closeStore
 }
 
 func applyE2EBootstrap(t *testing.T, applier *encryption.Applier) {

--- a/main_encryption_e2e_test.go
+++ b/main_encryption_e2e_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
+	"github.com/bootjp/elastickv/store"
+)
+
+// TestEncryption_E2E_BootstrapCutoverPutReadback is the Stage 6D-6c-3b
+// end-to-end test: it drives the *production* main.go encryption wiring
+// (buildEncryptionWriteWiring → store.WithEncryption + the shared
+// StateCache) through the full §7.1 rollout — Bootstrap → cutover →
+// Put → read-back — and proves that post-cutover writes land encrypted
+// at rest while every version still reads back as correct plaintext.
+//
+// Bootstrap and the cutover are applied via the Applier (sharing the
+// same keystore + StateCache the wiring built), which is exactly the
+// FSM-apply effect of the BootstrapEncryption / EnableStorageEnvelope
+// RPCs. The gRPC RPC + §4 capability fan-out path is covered by the
+// 6D-6c-3a unit tests and the adapter EncryptionAdmin tests; this test
+// validates the data path that 6D-6c-1 (shared cache) and 6D-6c-2
+// (cipher/gate wiring) enable.
+const (
+	e2eStorageDEKID uint32 = 7
+	e2eRaftDEKID    uint32 = 8
+	e2eNodeID       uint64 = 0xAAAA
+)
+
+func TestEncryption_E2E_BootstrapCutoverPutReadback(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dir := t.TempDir()
+	sidecarPath := dir + "/keys.json"
+	pebbleDir := dir + "/fsm.db"
+
+	st, applier, cache := newE2EEncryptionFixture(t, sidecarPath, pebbleDir)
+
+	// Phase 0 (pre-bootstrap): no active DEK, gate off → cleartext.
+	assertActiveStorageKeyID(t, cache, 0, false)
+	mustPut(t, ctx, st, "before", "plain-before", 100)
+
+	// Bootstrap: installs the storage DEK into the shared keystore,
+	// writes the sidecar, and refreshes the StateCache so
+	// ActiveStorageKeyID flips — but the envelope gate stays off.
+	applyE2EBootstrap(t, applier)
+	assertActiveStorageKeyID(t, cache, e2eStorageDEKID, true)
+	assertEnvelopeActive(t, cache, false)
+	// Phase 0→1 window: DEK active but cutover not fired → still cleartext.
+	mustPut(t, ctx, st, "mid", "plain-mid", 110)
+
+	// Cutover (EnableStorageEnvelope apply effect): flips the gate.
+	applyE2ECutover(t, applier)
+	assertEnvelopeActive(t, cache, true)
+	// Phase 1: gate on + active DEK → encrypted at rest.
+	mustPut(t, ctx, st, "after", "plain-after", 120)
+
+	// Every version reads back as correct plaintext through the wired
+	// cipher, regardless of whether it was written cleartext or
+	// enveloped (the read path dispatches on each version's stored
+	// encryption_state).
+	assertGet(t, ctx, st, "before", "plain-before", 100)
+	assertGet(t, ctx, st, "mid", "plain-mid", 110)
+	assertGet(t, ctx, st, "after", "plain-after", 120)
+
+	if err := st.Close(); err != nil {
+		t.Fatalf("close encrypted store: %v", err)
+	}
+	assertEncryptedAtRest(t, ctx, pebbleDir)
+}
+
+// newE2EEncryptionFixture builds the production encryption write wiring
+// (buildEncryptionWriteWiring) over a fresh pre-bootstrap sidecar, opens
+// a PebbleStore with its options, and constructs an Applier that shares
+// the same keystore + StateCache — exactly the main.go wiring topology.
+func newE2EEncryptionFixture(t *testing.T, sidecarPath, pebbleDir string) (store.MVCCStore, *encryption.Applier, *encryption.StateCache) {
+	t.Helper()
+	keystore := encryption.NewKeystore()
+	encWiring, err := buildEncryptionWriteWiring(true, "n1", sidecarPath, wiringFakeKEK{}, keystore)
+	if err != nil {
+		t.Fatalf("buildEncryptionWriteWiring: %v", err)
+	}
+	if encWiring.cipher == nil || encWiring.nonceFactory == nil {
+		t.Fatal("expected cipher + nonce factory wired when encryption enabled")
+	}
+	st, err := store.NewPebbleStore(pebbleDir, encWiring.pebbleOptions()...)
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	reg, err := store.WriterRegistryFor(st)
+	if err != nil {
+		t.Fatalf("WriterRegistryFor: %v", err)
+	}
+	applier, err := encryption.NewApplier(reg,
+		encryption.WithKEK(wiringFakeKEK{}),
+		encryption.WithKeystore(keystore),
+		encryption.WithSidecarPath(sidecarPath),
+		encryption.WithStateCache(encWiring.cache),
+	)
+	if err != nil {
+		t.Fatalf("NewApplier: %v", err)
+	}
+	return st, applier, encWiring.cache
+}
+
+func applyE2EBootstrap(t *testing.T, applier *encryption.Applier) {
+	t.Helper()
+	if err := applier.ApplyBootstrap(1, fsmwire.BootstrapPayload{
+		StorageDEKID:   e2eStorageDEKID,
+		WrappedStorage: []byte("wrapped-storage-dek"),
+		RaftDEKID:      e2eRaftDEKID,
+		WrappedRaft:    []byte("wrapped-raft-dek-distinct"),
+		BatchRegistry: []fsmwire.RegistrationPayload{
+			{DEKID: e2eStorageDEKID, FullNodeID: e2eNodeID, LocalEpoch: 0},
+		},
+	}); err != nil {
+		t.Fatalf("ApplyBootstrap: %v", err)
+	}
+}
+
+func applyE2ECutover(t *testing.T, applier *encryption.Applier) {
+	t.Helper()
+	if err := applier.ApplyRotation(2, fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubEnableStorageEnvelope,
+		DEKID:                e2eStorageDEKID,
+		Purpose:              fsmwire.PurposeStorage,
+		Wrapped:              []byte{},
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: e2eStorageDEKID, FullNodeID: e2eNodeID, LocalEpoch: 1},
+	}); err != nil {
+		t.Fatalf("ApplyRotation cutover: %v", err)
+	}
+}
+
+// assertEncryptedAtRest reopens the Pebble dir with a cipher-LESS store
+// and proves the post-cutover version is a genuine on-disk §4.1
+// envelope (the cleartext read path refuses it) while the pre-cutover
+// versions remain plaintext-readable.
+func assertEncryptedAtRest(t *testing.T, ctx context.Context, pebbleDir string) {
+	t.Helper()
+	plainStore, err := store.NewPebbleStore(pebbleDir)
+	if err != nil {
+		t.Fatalf("reopen cipher-less store: %v", err)
+	}
+	defer func() { _ = plainStore.Close() }()
+
+	switch _, err := plainStore.GetAt(ctx, []byte("after"), 120); {
+	case err == nil:
+		t.Error("cipher-less read of post-cutover key succeeded; value was not encrypted at rest")
+	case !strings.Contains(err.Error(), "no cipher configured"):
+		t.Errorf("cipher-less read of post-cutover key: unexpected error %v", err)
+	}
+	assertGet(t, ctx, plainStore, "before", "plain-before", 100)
+	assertGet(t, ctx, plainStore, "mid", "plain-mid", 110)
+}
+
+func assertActiveStorageKeyID(t *testing.T, cache *encryption.StateCache, wantID uint32, wantOK bool) {
+	t.Helper()
+	if id, ok := cache.ActiveStorageKeyID(); id != wantID || ok != wantOK {
+		t.Fatalf("ActiveStorageKeyID = (%d,%v), want (%d,%v)", id, ok, wantID, wantOK)
+	}
+}
+
+func assertEnvelopeActive(t *testing.T, cache *encryption.StateCache, want bool) {
+	t.Helper()
+	if got := cache.StorageEnvelopeActive(); got != want {
+		t.Fatalf("StorageEnvelopeActive = %v, want %v", got, want)
+	}
+}
+
+func mustPut(t *testing.T, ctx context.Context, st store.MVCCStore, key, val string, ts uint64) {
+	t.Helper()
+	if err := st.PutAt(ctx, []byte(key), []byte(val), ts, 0); err != nil {
+		t.Fatalf("PutAt %q@%d: %v", key, ts, err)
+	}
+}
+
+func assertGet(t *testing.T, ctx context.Context, st store.MVCCStore, key, want string, ts uint64) {
+	t.Helper()
+	got, err := st.GetAt(ctx, []byte(key), ts)
+	if err != nil {
+		t.Fatalf("GetAt %q@%d: %v", key, ts, err)
+	}
+	if string(got) != want {
+		t.Errorf("GetAt %q@%d = %q, want %q", key, ts, got, want)
+	}
+}

--- a/main_encryption_e2e_test.go
+++ b/main_encryption_e2e_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bootjp/elastickv/internal/encryption"
 	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
+	etcdraftengine "github.com/bootjp/elastickv/internal/raftengine/etcd"
 	"github.com/bootjp/elastickv/store"
 )
 
@@ -28,8 +29,17 @@ import (
 const (
 	e2eStorageDEKID uint32 = 7
 	e2eRaftDEKID    uint32 = 8
-	e2eNodeID       uint64 = 0xAAAA
 )
+
+// e2eNodeID is the proposer's full node id used for the writer-registry
+// rows. It is derived from the same raftID ("n1") the fixture passes to
+// buildEncryptionWriteWiring, so the registry identity matches the
+// DeterministicNonceFactory's node_id (NodeID16(DeriveNodeID("n1"))).
+// Hardcoding an unrelated constant here would pass today (the applier
+// validates DEKID, not FullNodeID) but mislead the Stage 7
+// registration-before-first-write gate, which must confirm the nonce
+// factory's node_id has a registry row.
+var e2eNodeID = etcdraftengine.DeriveNodeID("n1")
 
 func TestEncryption_E2E_BootstrapCutoverPutReadback(t *testing.T) {
 	t.Parallel()
@@ -153,7 +163,11 @@ func assertEncryptedAtRest(t *testing.T, ctx context.Context, pebbleDir string) 
 	if err != nil {
 		t.Fatalf("reopen cipher-less store: %v", err)
 	}
-	defer func() { _ = plainStore.Close() }()
+	defer func() {
+		if err := plainStore.Close(); err != nil {
+			t.Errorf("close cipher-less store: %v", err)
+		}
+	}()
 
 	switch _, err := plainStore.GetAt(ctx, []byte("after"), 120); {
 	case err == nil:


### PR DESCRIPTION
## Summary
Stage 6D-6c-3b adds the `package main` **end-to-end integration test** (`main_encryption_e2e_test.go`) that drives the production encryption wiring through the full §7.1 rollout and proves the at-rest encryption data path. **This completes Stage 6.**

### What the test does
- Builds the real `buildEncryptionWriteWiring` (cipher + deterministic nonce factory + shared `StateCache`) over a fresh pre-bootstrap sidecar, opens a `PebbleStore` with `encWiring.pebbleOptions()`, and constructs an `Applier` that **shares the same keystore + StateCache** — the exact `main.go` topology.
- **Phase 0 (pre-bootstrap):** `ActiveStorageKeyID=(0,false)` → Put writes cleartext.
- **Bootstrap** (`applier.ApplyBootstrap` — the `BootstrapEncryption` apply effect): `ActiveStorageKeyID` flips to the storage DEK, the envelope gate stays off → Put still cleartext.
- **Cutover** (`applier.ApplyRotation` w/ `RotateSubEnableStorageEnvelope` — the `EnableStorageEnvelope` apply effect): `StorageEnvelopeActive` flips → Put writes the §4.1 envelope.
- All three versions **read back as correct plaintext** through the wired cipher (the read path dispatches on each version's `encryption_state`).
- **At-rest proof:** reopen the same Pebble dir with a **cipher-less** store — the post-cutover key is refused (`"no cipher configured"`) while the pre-cutover cleartext versions still read back, confirming only post-cutover writes were enveloped.

### Why this level
The gRPC `EnableStorageEnvelope` RPC + §4 capability fan-out path is covered by the 6D-6c-3a unit tests and the adapter `EncryptionAdmin` tests. This test fills the remaining gap: the **data path** that 6D-6c-1 (shared cache) and 6D-6c-2 (cipher/gate wiring) enable, exercised through the production wiring helper — robustly (no ports, leader election, or global-flag mutation).

### Doc lifecycle
- `2026_05_25_*_6d6c3a_capability_fanout_wiring.md`: `partial` → **`implemented`** (its 3b milestone landed).
- `2026_05_18_*_6d_enable_storage_envelope.md`: `partial` → **`implemented`** — all 6D milestones shipped. The deferred multi-node-churn registration-before-first-write nonce gate is a **Stage 7** item (tracked in the 6D-6c-2 partial doc), not a 6D milestone.
- Inbound cross-links updated; also folded in claude's round-3 cosmetic note (the 6D-6c-3a doc §1 now states `capabilityFanoutTimeout` lives in `main_encryption_fanout.go`).

## Self-review (5 lenses)
1. **Data loss** — test-only; no production code change beyond doc edits.
2. **Concurrency** — exercises the shared-`StateCache` topology single-threaded (applier apply → gate flip → store Put), matching the documented startup/apply ordering.
3. **Performance** — n/a (test).
4. **Data consistency** — asserts the gate transitions and the cleartext→envelope cutover boundary, plus the cipher-less-reopen at-rest proof and mixed-version plaintext read-back.
5. **Test coverage** — this *is* the integration coverage; complements the 6D-6c-1/2/3a unit tests.

## Test plan
- [x] `go test -race -run TestEncryption_E2E_BootstrapCutoverPutReadback .`
- [x] `go test -race .`
- [x] `golangci-lint run .` (0 issues)
- [ ] CI green
