### PR TITLE
backup: Phase 0b M3a — DynamoDB schema reverse encoder

### DIFF
--- a/internal/backup/encode_dynamodb.go
+++ b/internal/backup/encode_dynamodb.go
@@ -138,7 +138,10 @@ func (e *DynamoDBEncoder) encodeTable(b *snapshotBuilder, root *os.Root, tableDi
 
 	genKey := append([]byte(DDBTableGenPrefix), encTable...)
 	genVal := []byte(strconv.FormatUint(ddbRestoreGeneration, 10))
-	return b.Add(genKey, genVal, 0)
+	if err := b.Add(genKey, genVal, 0); err != nil {
+		return err
+	}
+	return e.encodeItems(b, root, tableDir, tableName, schema)
 }
 
 // readSchema opens <table>/_schema.json within root (symlink-escape /

--- a/internal/backup/encode_dynamodb.go
+++ b/internal/backup/encode_dynamodb.go
@@ -1,0 +1,213 @@
+package backup
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	pb "github.com/bootjp/elastickv/proto"
+	"github.com/cockroachdb/errors"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+// encode_dynamodb.go is the Phase 0b DynamoDB reverse encoder — the
+// inverse of the DDBEncoder decoder in dynamodb.go (design:
+// docs/design/2026_05_25_proposed_snapshot_logical_encoder.md
+// §"DynamoDB").
+//
+// This commit covers TABLE SCHEMAS: it reconstructs the
+// !ddb|meta|table| schema record (and the !ddb|meta|gen| generation
+// counter) from each table's _schema.json. The item records
+// (!ddb|item|, which need the ordered primary-key encoding) and the
+// derived GSI rows land in follow-up commits on this milestone.
+//
+// Generation handling (the design's decision gate): _schema.json does
+// not carry the table's original generation, so the encoder stamps a
+// uniform restore generation (ddbRestoreGeneration) into BOTH the
+// schema proto's Generation field and the !ddb|meta|gen| counter — and
+// the item encoder (next commit) embeds the SAME generation in every
+// !ddb|item| key, so the counter and the item-key generation always
+// agree. This is the Option-B path: internally consistent for a
+// single-cluster restore; the original generation number is not
+// preserved (it is unrecoverable from the public dump).
+//
+// KeyEncodingVersion is stamped to the current ordered-key version so
+// the restored table uses the same ordered primary-key encoding the
+// item encoder produces.
+
+// ddbRestoreGeneration is the uniform generation stamped into the
+// schema, the generation counter, and (in the item encoder) every
+// item key, so a restored table is internally consistent.
+const ddbRestoreGeneration uint64 = 1
+
+// ddbOrderedKeyEncodingV2 mirrors adapter/dynamodb.go's
+// dynamoOrderedKeyEncodingV2 — the ordered primary-key encoding the
+// item encoder reproduces. Stamped into the restored schema so the
+// live store reads items with the matching encoder.
+const ddbOrderedKeyEncodingV2 uint64 = 2
+
+// ErrDDBEncodeInvalidSchema is returned when a _schema.json file cannot
+// be parsed into the expected shape.
+var ErrDDBEncodeInvalidSchema = errors.New("backup: dynamodb encode invalid _schema.json")
+
+// DynamoDBEncoder reconstructs the internal DynamoDB keyspace from the
+// decoded dynamodb/ directory tree.
+type DynamoDBEncoder struct {
+	inRoot string
+}
+
+// NewDynamoDBEncoder constructs an encoder rooted at <inRoot>/dynamodb/.
+func NewDynamoDBEncoder(inRoot string) *DynamoDBEncoder {
+	return &DynamoDBEncoder{inRoot: inRoot}
+}
+
+func (e *DynamoDBEncoder) dynamoDir() string {
+	return filepath.Join(e.inRoot, "dynamodb")
+}
+
+// Encode walks dynamodb/<table>/ and stages each table's schema +
+// generation-counter records on b. A missing dynamodb/ directory is
+// not an error.
+func (e *DynamoDBEncoder) Encode(b *snapshotBuilder) error {
+	dir := e.dynamoDir()
+	if err := lstatDumpDir(dir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer func() { _ = root.Close() }()
+	entries, err := readRootDirEntries(root)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	for _, ent := range entries {
+		if !ent.IsDir() {
+			continue
+		}
+		if err := e.encodeTable(b, root, ent.Name()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// encodeTable reads one <table>/_schema.json and emits its
+// !ddb|meta|table| schema record and !ddb|meta|gen| counter.
+func (e *DynamoDBEncoder) encodeTable(b *snapshotBuilder, root *os.Root, tableDir string) error {
+	schema, err := e.readSchema(root, tableDir)
+	if err != nil {
+		return err
+	}
+	tableName := schema.GetTableName()
+	if tableName == "" {
+		return errors.Wrapf(ErrDDBEncodeInvalidSchema, "%s/_schema.json: empty table_name", tableDir)
+	}
+	encTable := base64.RawURLEncoding.EncodeToString([]byte(tableName))
+
+	metaKey := append([]byte(DDBTableMetaPrefix), encTable...)
+	metaVal, err := marshalStoredDDBSchema(schema)
+	if err != nil {
+		return err
+	}
+	if err := b.Add(metaKey, metaVal, 0); err != nil {
+		return err
+	}
+
+	genKey := append([]byte(DDBTableGenPrefix), encTable...)
+	genVal := []byte(strconv.FormatUint(ddbRestoreGeneration, 10))
+	return b.Add(genKey, genVal, 0)
+}
+
+// readSchema opens <table>/_schema.json within root (symlink-escape /
+// FIFO / hard-link safe, like the redis sidecar reads) and rebuilds the
+// DynamoTableSchema proto from its public projection.
+func (e *DynamoDBEncoder) readSchema(root *os.Root, tableDir string) (*pb.DynamoTableSchema, error) {
+	f, err := root.Open(filepath.Join(tableDir, "_schema.json"))
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, errors.Wrapf(ErrRedisEncodeNotRegular, "%s/_schema.json (mode=%s)", tableDir, info.Mode())
+	}
+	if err := refuseHardLink(info, tableDir+"/_schema.json"); err != nil {
+		return nil, err
+	}
+	var pub ddbPublicSchema
+	if err := decodeOneJSON(f, &pub); err != nil {
+		return nil, errors.Wrapf(ErrDDBEncodeInvalidSchema, "%s/_schema.json: %v", tableDir, err)
+	}
+	if pub.FormatVersion != redisCollectionFormatVersion {
+		return nil, errors.Wrapf(ErrDDBEncodeInvalidSchema,
+			"%s/_schema.json: unsupported format_version %d", tableDir, pub.FormatVersion)
+	}
+	return publicToSchema(pub), nil
+}
+
+// publicToSchema is the inverse of schemaToPublic: it rebuilds the
+// DynamoTableSchema proto from its _schema.json projection. Attribute
+// definitions come from the flat AttributeDefinitions list (the public
+// per-key Type fields are redundant copies). KeyEncodingVersion and
+// Generation are stamped for the restore (see file header).
+func publicToSchema(pub ddbPublicSchema) *pb.DynamoTableSchema {
+	defs := make(map[string]string, len(pub.AttributeDefinitions))
+	for _, d := range pub.AttributeDefinitions {
+		defs[d.Name] = d.Type
+	}
+	schema := &pb.DynamoTableSchema{
+		TableName:            pub.TableName,
+		AttributeDefinitions: defs,
+		PrimaryKey:           publicKeyToProto(pub.PrimaryKey),
+		KeyEncodingVersion:   ddbOrderedKeyEncodingV2,
+		Generation:           ddbRestoreGeneration,
+	}
+	if len(pub.GlobalSecondaryIndexes) > 0 {
+		gsis := make(map[string]*pb.DynamoGlobalSecondaryIndex, len(pub.GlobalSecondaryIndexes))
+		for _, g := range pub.GlobalSecondaryIndexes {
+			gsis[g.Name] = &pb.DynamoGlobalSecondaryIndex{
+				KeySchema: publicKeyToProto(g.KeySchema),
+				Projection: &pb.DynamoGSIProjection{
+					ProjectionType:   g.Projection.Type,
+					NonKeyAttributes: append([]string(nil), g.Projection.NonKeyAttributes...),
+				},
+			}
+		}
+		schema.GlobalSecondaryIndexes = gsis
+	}
+	return schema
+}
+
+// publicKeyToProto rebuilds a DynamoKeySchema (hash + optional range)
+// from its public projection.
+func publicKeyToProto(k publicKeySchema) *pb.DynamoKeySchema {
+	return &pb.DynamoKeySchema{
+		HashKey:  k.HashKey.Name,
+		RangeKey: k.RangeKey.Name,
+	}
+}
+
+// marshalStoredDDBSchema reproduces the live schema value:
+// storedDDBSchemaMagic + deterministic proto marshal.
+func marshalStoredDDBSchema(schema *pb.DynamoTableSchema) ([]byte, error) {
+	body, err := gproto.MarshalOptions{Deterministic: true}.Marshal(schema)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	// const-capacity, zero-length start + append (magic then body):
+	// keeps the `len(magic)+len(body)` arithmetic out of make() — which
+	// CodeQL flags as a potential allocation-size overflow — and the
+	// zero length satisfies makezero.
+	out := make([]byte, 0, len(storedDDBSchemaMagic))
+	out = append(out, storedDDBSchemaMagic...)
+	return append(out, body...), nil
+}

--- a/internal/backup/encode_dynamodb.go
+++ b/internal/backup/encode_dynamodb.go
@@ -47,9 +47,20 @@ const ddbRestoreGeneration uint64 = 1
 // live store reads items with the matching encoder.
 const ddbOrderedKeyEncodingV2 uint64 = 2
 
+// ddbSchemaFormatVersion is the only _schema.json format_version the
+// DynamoDB encoder accepts (a dedicated DDB constant rather than the
+// redis collection one, even though both are 1).
+const ddbSchemaFormatVersion uint32 = 1
+
 // ErrDDBEncodeInvalidSchema is returned when a _schema.json file cannot
 // be parsed into the expected shape.
 var ErrDDBEncodeInvalidSchema = errors.New("backup: dynamodb encode invalid _schema.json")
+
+// ErrDDBEncodeNotRegular is returned when a _schema.json (or, later,
+// item file) is not a regular file — a symlink, FIFO, device, or
+// directory. A dedicated DDB sentinel (not the redis one) so callers
+// classify it correctly via errors.Is.
+var ErrDDBEncodeNotRegular = errors.New("backup: dynamodb dump file is not a regular file")
 
 // DynamoDBEncoder reconstructs the internal DynamoDB keyspace from the
 // decoded dynamodb/ directory tree.
@@ -108,6 +119,12 @@ func (e *DynamoDBEncoder) encodeTable(b *snapshotBuilder, root *os.Root, tableDi
 	if tableName == "" {
 		return errors.Wrapf(ErrDDBEncodeInvalidSchema, "%s/_schema.json: empty table_name", tableDir)
 	}
+	// A table must have a hash key; fail early here rather than letting
+	// an empty primary key propagate into the item encoder (which
+	// builds item keys from the hash/range attributes).
+	if schema.GetPrimaryKey().GetHashKey() == "" {
+		return errors.Wrapf(ErrDDBEncodeInvalidSchema, "%s/_schema.json: empty primary hash key", tableDir)
+	}
 	encTable := base64.RawURLEncoding.EncodeToString([]byte(tableName))
 
 	metaKey := append([]byte(DDBTableMetaPrefix), encTable...)
@@ -128,28 +145,34 @@ func (e *DynamoDBEncoder) encodeTable(b *snapshotBuilder, root *os.Root, tableDi
 // FIFO / hard-link safe, like the redis sidecar reads) and rebuilds the
 // DynamoTableSchema proto from its public projection.
 func (e *DynamoDBEncoder) readSchema(root *os.Root, tableDir string) (*pb.DynamoTableSchema, error) {
-	f, err := root.Open(filepath.Join(tableDir, "_schema.json"))
+	rel := filepath.Join(tableDir, "_schema.json")
+	// Pre-open Lstat THROUGH the root fd refuses a symlink / FIFO /
+	// device / directory BEFORE root.Open, so a reader-less FIFO cannot
+	// block the open (the post-open fstat guard the walk paths use never
+	// runs if Open itself hangs). Consistent with openDumpSidecar; the
+	// Lstat is relative to the pinned root fd so it cannot escape.
+	linfo, err := root.Lstat(rel)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if !linfo.Mode().IsRegular() {
+		return nil, errors.Wrapf(ErrDDBEncodeNotRegular, "%s (mode=%s)", rel, linfo.Mode())
+	}
+	if err := refuseHardLink(linfo, rel); err != nil {
+		return nil, err
+	}
+	f, err := root.Open(rel)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	defer func() { _ = f.Close() }()
-	info, err := f.Stat()
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	if !info.Mode().IsRegular() {
-		return nil, errors.Wrapf(ErrRedisEncodeNotRegular, "%s/_schema.json (mode=%s)", tableDir, info.Mode())
-	}
-	if err := refuseHardLink(info, tableDir+"/_schema.json"); err != nil {
-		return nil, err
-	}
 	var pub ddbPublicSchema
 	if err := decodeOneJSON(f, &pub); err != nil {
-		return nil, errors.Wrapf(ErrDDBEncodeInvalidSchema, "%s/_schema.json: %v", tableDir, err)
+		return nil, errors.Wrapf(ErrDDBEncodeInvalidSchema, "%s: %v", rel, err)
 	}
-	if pub.FormatVersion != redisCollectionFormatVersion {
+	if pub.FormatVersion != ddbSchemaFormatVersion {
 		return nil, errors.Wrapf(ErrDDBEncodeInvalidSchema,
-			"%s/_schema.json: unsupported format_version %d", tableDir, pub.FormatVersion)
+			"%s: unsupported format_version %d", rel, pub.FormatVersion)
 	}
 	return publicToSchema(pub), nil
 }

--- a/internal/backup/encode_dynamodb.go
+++ b/internal/backup/encode_dynamodb.go
@@ -174,7 +174,35 @@ func (e *DynamoDBEncoder) readSchema(root *os.Root, tableDir string) (*pb.Dynamo
 		return nil, errors.Wrapf(ErrDDBEncodeInvalidSchema,
 			"%s: unsupported format_version %d", rel, pub.FormatVersion)
 	}
+	// publicToSchema folds AttributeDefinitions and GlobalSecondaryIndexes
+	// into maps keyed by name, so duplicate names would silently overwrite
+	// (losing a type or an index) instead of erroring. Reject duplicates
+	// here before conversion so a malformed dump fails closed.
+	if err := rejectDuplicateSchemaNames(pub, rel); err != nil {
+		return nil, err
+	}
 	return publicToSchema(pub), nil
+}
+
+// rejectDuplicateSchemaNames fails closed on duplicate attribute-
+// definition or GSI names, which publicToSchema would otherwise collapse
+// silently when folding the slices into maps.
+func rejectDuplicateSchemaNames(pub ddbPublicSchema, rel string) error {
+	attrSeen := make(map[string]struct{}, len(pub.AttributeDefinitions))
+	for _, d := range pub.AttributeDefinitions {
+		if _, ok := attrSeen[d.Name]; ok {
+			return errors.Wrapf(ErrDDBEncodeInvalidSchema, "%s: duplicate attribute definition %q", rel, d.Name)
+		}
+		attrSeen[d.Name] = struct{}{}
+	}
+	gsiSeen := make(map[string]struct{}, len(pub.GlobalSecondaryIndexes))
+	for _, g := range pub.GlobalSecondaryIndexes {
+		if _, ok := gsiSeen[g.Name]; ok {
+			return errors.Wrapf(ErrDDBEncodeInvalidSchema, "%s: duplicate GSI name %q", rel, g.Name)
+		}
+		gsiSeen[g.Name] = struct{}{}
+	}
+	return nil
 }
 
 // publicToSchema is the inverse of schemaToPublic: it rebuilds the

--- a/internal/backup/encode_dynamodb_items.go
+++ b/internal/backup/encode_dynamodb_items.go
@@ -395,7 +395,13 @@ func decodeAVNull(v any) (*pb.DynamoAttributeValue, error) {
 	if !ok {
 		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "NULL value is not a boolean")
 	}
-	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_NullValue{NullValue: b}}, nil
+	// AWS DynamoDB's NULL is definitionally {"NULL": true}; {"NULL": false}
+	// is invalid and unreachable from real data, so fail closed rather
+	// than emit a record the live API would reject on restore.
+	if !b {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "NULL value must be true")
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_NullValue{NullValue: true}}, nil
 }
 
 func decodeAVStringSet(v any) (*pb.DynamoAttributeValue, error) {
@@ -418,6 +424,9 @@ func decodeAVBinarySet(v any) (*pb.DynamoAttributeValue, error) {
 	arr, ok := v.([]any)
 	if !ok {
 		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "BS value is not an array")
+	}
+	if len(arr) == 0 {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "BS must not be empty")
 	}
 	out := make([][]byte, 0, len(arr))
 	for _, e := range arr {
@@ -470,11 +479,16 @@ func decodeAVMap(v any) (*pb.DynamoAttributeValue, error) {
 	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_M{M: &pb.DynamoAttributeValueMap{Values: out}}}, nil
 }
 
-// stringSliceFromAny coerces a JSON array of strings (SS / NS).
+// stringSliceFromAny coerces a JSON array of strings (SS / NS). AWS
+// DynamoDB rejects empty sets, and an empty-set record would fail on
+// restore, so an empty array fails closed.
 func stringSliceFromAny(v any) ([]string, error) {
 	arr, ok := v.([]any)
 	if !ok {
 		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "set value is not an array")
+	}
+	if len(arr) == 0 {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "set must not be empty")
 	}
 	out := make([]string, 0, len(arr))
 	for _, e := range arr {

--- a/internal/backup/encode_dynamodb_items.go
+++ b/internal/backup/encode_dynamodb_items.go
@@ -13,20 +13,15 @@ import (
 )
 
 // encode_dynamodb_items.go is the Phase 0b DynamoDB ITEM reverse encoder
-// (milestone M3b-1) — the inverse of the per-item JSON emitter in
-// dynamodb.go (writeDDBItem / itemToPublic). It reconstructs the
+// — the inverse of the per-item JSON emitter in dynamodb.go (writeDDBItem
+// / itemToPublic). It reconstructs the
 // !ddb|item|<base64url(table)>|<gen>|<orderedHash><orderedRange> records
 // from each table's items/<pk>[/<sk>].json files.
 //
-// Scope of this slice (M3b-1):
-//   - S (string) and B (binary) primary/range keys only. Numeric (N)
-//     keys take a separate ordered encoding (encodeNumericKeyBytes in the
-//     live adapter) that is reproduced in a follow-up slice; until then a
-//     numeric key fails closed (ErrDDBEncodeNumericKeyUnsupported) rather
-//     than emitting a wrongly-ordered key the live store would mis-sort.
-//   - Base items only. The derived !ddb|gsi| index rows (which the
-//     decoder drops as a no-op because they are derivable from the base
-//     item set + schema) land in a later slice.
+// Primary keys: S (string), B (binary), and N (number) are all supported;
+// the N ordered encoding lives in encode_dynamodb_numeric.go. The derived
+// !ddb|gsi| index rows (which the decoder drops as a no-op because they
+// are derivable from the base item set + schema) land in a later slice.
 //
 // Format fidelity is pinned against the live adapter write path
 // (adapter/dynamodb.go: dynamoItemKey / encodeDynamoKeySegment /
@@ -55,14 +50,9 @@ const (
 
 // ErrDDBEncodeInvalidItem is returned when an items/*.json file cannot be
 // parsed into a well-formed item (bad JSON shape, unknown attribute type,
-// missing primary-key attribute, or a non-S/N/B primary key).
+// missing primary-key attribute, a non-S/N/B primary key, or a malformed
+// number literal).
 var ErrDDBEncodeInvalidItem = errors.New("backup: dynamodb encode invalid item json")
-
-// ErrDDBEncodeNumericKeyUnsupported is returned when a primary or range
-// key attribute is numeric (N). The ordered numeric key encoding is not
-// reproduced in this slice; failing closed avoids emitting a key the live
-// store would sort incorrectly.
-var ErrDDBEncodeNumericKeyUnsupported = errors.New("backup: dynamodb numeric primary key not supported by encoder yet")
 
 // encodeItems walks <tableDir>/items/ and stages one !ddb|item| record
 // per item file. A missing items/ directory is not an error (a table may
@@ -238,8 +228,9 @@ func ddbItemKeyPrefix(tableName string, generation uint64) []byte {
 }
 
 // ddbPrimaryKeyBytes extracts the raw key bytes for a primary/range key
-// attribute. Only S and B are supported in this slice; N fails closed and
-// any non-key kind is rejected (DynamoDB primary keys are S, N, or B).
+// attribute (DynamoDB primary keys are S, N, or B). S and B contribute
+// their literal bytes; N contributes its order-preserving numeric encoding
+// (the segment escape/terminator is applied uniformly by the caller).
 func ddbPrimaryKeyBytes(av *pb.DynamoAttributeValue) ([]byte, error) {
 	switch v := av.GetValue().(type) {
 	case *pb.DynamoAttributeValue_S:
@@ -247,7 +238,7 @@ func ddbPrimaryKeyBytes(av *pb.DynamoAttributeValue) ([]byte, error) {
 	case *pb.DynamoAttributeValue_B:
 		return v.B, nil
 	case *pb.DynamoAttributeValue_N:
-		return nil, errors.Wrap(ErrDDBEncodeNumericKeyUnsupported, "numeric primary key")
+		return ddbNumericKeyBytes(v.N)
 	default:
 		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "primary key attribute is not S, N, or B")
 	}

--- a/internal/backup/encode_dynamodb_items.go
+++ b/internal/backup/encode_dynamodb_items.go
@@ -403,13 +403,11 @@ func decodeAVNull(v any) (*pb.DynamoAttributeValue, error) {
 	if !ok {
 		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "NULL value is not a boolean")
 	}
-	// AWS DynamoDB's NULL is definitionally {"NULL": true}; {"NULL": false}
-	// is invalid and unreachable from real data, so fail closed rather
-	// than emit a record the live API would reject on restore.
-	if !b {
-		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "NULL value must be true")
-	}
-	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_NullValue{NullValue: true}}, nil
+	// Preserve the boolean as-is: the decoder serializes NullValue
+	// verbatim, so the encoder must round-trip NULL=false too (an internal
+	// record may carry it). AWS-API payload validity is enforced at the
+	// adapter's PutItem boundary, not on this internal-record path.
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_NullValue{NullValue: b}}, nil
 }
 
 func decodeAVStringSet(v any) (*pb.DynamoAttributeValue, error) {
@@ -432,9 +430,6 @@ func decodeAVBinarySet(v any) (*pb.DynamoAttributeValue, error) {
 	arr, ok := v.([]any)
 	if !ok {
 		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "BS value is not an array")
-	}
-	if len(arr) == 0 {
-		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "BS must not be empty")
 	}
 	out := make([][]byte, 0, len(arr))
 	for _, e := range arr {
@@ -487,16 +482,15 @@ func decodeAVMap(v any) (*pb.DynamoAttributeValue, error) {
 	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_M{M: &pb.DynamoAttributeValueMap{Values: out}}}, nil
 }
 
-// stringSliceFromAny coerces a JSON array of strings (SS / NS). AWS
-// DynamoDB rejects empty sets, and an empty-set record would fail on
-// restore, so an empty array fails closed.
+// stringSliceFromAny coerces a JSON array of strings (SS / NS). An empty
+// array is preserved (not rejected): the decoder intentionally serializes
+// nil/empty sets as [] to avoid dropping the attribute, so the encoder
+// must round-trip that structural case rather than fail recovery of a
+// legacy/drifted snapshot.
 func stringSliceFromAny(v any) ([]string, error) {
 	arr, ok := v.([]any)
 	if !ok {
 		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "set value is not an array")
-	}
-	if len(arr) == 0 {
-		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "set must not be empty")
 	}
 	out := make([]string, 0, len(arr))
 	for _, e := range arr {

--- a/internal/backup/encode_dynamodb_items.go
+++ b/internal/backup/encode_dynamodb_items.go
@@ -108,7 +108,15 @@ func (e *DynamoDBEncoder) encodeCompositeItemDir(b *snapshotBuilder, root *os.Ro
 		return err
 	}
 	for _, ent := range entries {
-		if ent.IsDir() || !isJSONFilename(ent.Name()) {
+		// The decoder emits at most items/<hash>/<range>.json — a directory
+		// nested inside a hash directory cannot come from a valid dump, so
+		// fail closed rather than silently skip (which would under-count
+		// restored items without any error).
+		if ent.IsDir() {
+			return errors.Wrapf(ErrDDBEncodeInvalidItem,
+				"%s: unexpected nested directory %q (items layout is at most 2 levels)", sub, ent.Name())
+		}
+		if !isJSONFilename(ent.Name()) {
 			continue
 		}
 		if err := e.encodeOneItem(b, root, filepath.Join(sub, ent.Name()), tableName, schema); err != nil {

--- a/internal/backup/encode_dynamodb_items.go
+++ b/internal/backup/encode_dynamodb_items.go
@@ -1,0 +1,503 @@
+package backup
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	pb "github.com/bootjp/elastickv/proto"
+	"github.com/cockroachdb/errors"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+// encode_dynamodb_items.go is the Phase 0b DynamoDB ITEM reverse encoder
+// (milestone M3b-1) — the inverse of the per-item JSON emitter in
+// dynamodb.go (writeDDBItem / itemToPublic). It reconstructs the
+// !ddb|item|<base64url(table)>|<gen>|<orderedHash><orderedRange> records
+// from each table's items/<pk>[/<sk>].json files.
+//
+// Scope of this slice (M3b-1):
+//   - S (string) and B (binary) primary/range keys only. Numeric (N)
+//     keys take a separate ordered encoding (encodeNumericKeyBytes in the
+//     live adapter) that is reproduced in a follow-up slice; until then a
+//     numeric key fails closed (ErrDDBEncodeNumericKeyUnsupported) rather
+//     than emitting a wrongly-ordered key the live store would mis-sort.
+//   - Base items only. The derived !ddb|gsi| index rows (which the
+//     decoder drops as a no-op because they are derivable from the base
+//     item set + schema) land in a later slice.
+//
+// Format fidelity is pinned against the live adapter write path
+// (adapter/dynamodb.go: dynamoItemKey / encodeDynamoKeySegment /
+// storedDDBItemMagic), not just the decode side, so the emitted .fsm
+// loads into a running cluster. The ORDERED key encoding (not the legacy
+// base64url-segment EncodeDDBItemKey test helper) is required because the
+// restored schema stamps KeyEncodingVersion=V2.
+//
+// Generation: every item key embeds ddbRestoreGeneration — the SAME
+// uniform value the schema proto and the !ddb|meta|gen| counter carry
+// (see encode_dynamodb.go) — so the restored table's counter and its
+// item keys always agree.
+
+// Ordered-key bytes mirror adapter/dynamodb.go's dynamoKey* constants: a
+// 0x00 byte in the raw key is escaped to 0x00 0xFF, and every segment is
+// terminated with 0x00 0x01 so concatenated hash+range segments sort and
+// parse unambiguously.
+const (
+	ddbKeyEscapeByte      = byte(0x00)
+	ddbKeyTerminatorByte  = byte(0x01)
+	ddbKeyEscapedZeroByte = byte(0xFF)
+	// ddbKeySegmentOverhead is the two-byte 0x00 0x01 terminator every
+	// ordered key segment carries (mirrors dynamoKeySegmentOverhead).
+	ddbKeySegmentOverhead = 2
+)
+
+// ErrDDBEncodeInvalidItem is returned when an items/*.json file cannot be
+// parsed into a well-formed item (bad JSON shape, unknown attribute type,
+// missing primary-key attribute, or a non-S/N/B primary key).
+var ErrDDBEncodeInvalidItem = errors.New("backup: dynamodb encode invalid item json")
+
+// ErrDDBEncodeNumericKeyUnsupported is returned when a primary or range
+// key attribute is numeric (N). The ordered numeric key encoding is not
+// reproduced in this slice; failing closed avoids emitting a key the live
+// store would sort incorrectly.
+var ErrDDBEncodeNumericKeyUnsupported = errors.New("backup: dynamodb numeric primary key not supported by encoder yet")
+
+// encodeItems walks <tableDir>/items/ and stages one !ddb|item| record
+// per item file. A missing items/ directory is not an error (a table may
+// have a schema but no rows).
+func (e *DynamoDBEncoder) encodeItems(b *snapshotBuilder, root *os.Root, tableDir, tableName string, schema *pb.DynamoTableSchema) error {
+	itemsRel := filepath.Join(tableDir, "items")
+	linfo, err := root.Lstat(itemsRel)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return errors.WithStack(err)
+	}
+	if !linfo.IsDir() {
+		return errors.Wrapf(ErrDDBEncodeInvalidItem, "%s is not a directory", itemsRel)
+	}
+	entries, err := readRootSubdirEntries(root, itemsRel)
+	if err != nil {
+		return err
+	}
+	for _, ent := range entries {
+		switch {
+		case ent.IsDir():
+			if err := e.encodeCompositeItemDir(b, root, itemsRel, ent.Name(), tableName, schema); err != nil {
+				return err
+			}
+		case isJSONFilename(ent.Name()):
+			if err := e.encodeOneItem(b, root, filepath.Join(itemsRel, ent.Name()), tableName, schema); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// encodeCompositeItemDir handles the composite-key layout
+// items/<hashSeg>/<rangeSeg>.json: every .json file directly under the
+// hash directory is one item.
+func (e *DynamoDBEncoder) encodeCompositeItemDir(b *snapshotBuilder, root *os.Root, itemsRel, hashDir, tableName string, schema *pb.DynamoTableSchema) error {
+	sub := filepath.Join(itemsRel, hashDir)
+	entries, err := readRootSubdirEntries(root, sub)
+	if err != nil {
+		return err
+	}
+	for _, ent := range entries {
+		if ent.IsDir() || !isJSONFilename(ent.Name()) {
+			continue
+		}
+		if err := e.encodeOneItem(b, root, filepath.Join(sub, ent.Name()), tableName, schema); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// encodeOneItem reads one item JSON file, rebuilds the proto, and stages
+// its !ddb|item| key/value on b.
+func (e *DynamoDBEncoder) encodeOneItem(b *snapshotBuilder, root *os.Root, rel, tableName string, schema *pb.DynamoTableSchema) error {
+	public, err := readRootJSONItem(root, rel)
+	if err != nil {
+		return err
+	}
+	item, err := publicToItem(public)
+	if err != nil {
+		return errors.Wrapf(err, "%s", rel)
+	}
+	key, err := ddbItemKeyBytes(tableName, ddbRestoreGeneration, schema, item)
+	if err != nil {
+		return errors.Wrapf(err, "%s", rel)
+	}
+	val, err := marshalStoredDDBItem(item)
+	if err != nil {
+		return err
+	}
+	return b.Add(key, val, 0)
+}
+
+// readRootSubdirEntries lists a subdirectory THROUGH the pinned root fd
+// (os.Root.Open enforces no symlink escape), rather than re-resolving the
+// path with os.ReadDir.
+func readRootSubdirEntries(root *os.Root, rel string) ([]os.DirEntry, error) {
+	d, err := root.Open(rel)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer func() { _ = d.Close() }()
+	entries, err := d.ReadDir(-1)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return entries, nil
+}
+
+// readRootJSONItem opens an item file within root (symlink-escape / FIFO /
+// hard-link safe, like readSchema) and decodes its public attribute map.
+func readRootJSONItem(root *os.Root, rel string) (map[string]any, error) {
+	linfo, err := root.Lstat(rel)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if !linfo.Mode().IsRegular() {
+		return nil, errors.Wrapf(ErrDDBEncodeNotRegular, "%s (mode=%s)", rel, linfo.Mode())
+	}
+	if err := refuseHardLink(linfo, rel); err != nil {
+		return nil, err
+	}
+	f, err := root.Open(rel)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer func() { _ = f.Close() }()
+	var public map[string]any
+	if err := decodeOneJSON(f, &public); err != nil {
+		return nil, errors.Wrapf(ErrDDBEncodeInvalidItem, "%s: %v", rel, err)
+	}
+	return public, nil
+}
+
+func isJSONFilename(name string) bool {
+	return strings.HasSuffix(name, ".json")
+}
+
+// ddbItemKeyBytes builds the ordered !ddb|item| key for an item against
+// the table schema's primary-key attribute names.
+func ddbItemKeyBytes(tableName string, generation uint64, schema *pb.DynamoTableSchema, item *pb.DynamoItem) ([]byte, error) {
+	attrs := item.GetAttributes()
+	hashName := schema.GetPrimaryKey().GetHashKey()
+	hashAV, ok := attrs[hashName]
+	if !ok {
+		return nil, errors.Wrapf(ErrDDBEncodeInvalidItem, "item missing hash-key attribute %q", hashName)
+	}
+	hashRaw, err := ddbPrimaryKeyBytes(hashAV)
+	if err != nil {
+		return nil, err
+	}
+	key := ddbItemKeyPrefix(tableName, generation)
+	key = append(key, encodeDDBOrderedKeySegment(hashRaw)...)
+	rangeName := schema.GetPrimaryKey().GetRangeKey()
+	if rangeName == "" {
+		return key, nil
+	}
+	rangeAV, ok := attrs[rangeName]
+	if !ok {
+		return nil, errors.Wrapf(ErrDDBEncodeInvalidItem, "item missing range-key attribute %q", rangeName)
+	}
+	rangeRaw, err := ddbPrimaryKeyBytes(rangeAV)
+	if err != nil {
+		return nil, err
+	}
+	return append(key, encodeDDBOrderedKeySegment(rangeRaw)...), nil
+}
+
+// ddbItemKeyPrefix reproduces dynamoItemPrefixForTable:
+// !ddb|item|<base64url(table)>|<gen>|.
+func ddbItemKeyPrefix(tableName string, generation uint64) []byte {
+	enc := base64.RawURLEncoding.EncodeToString([]byte(tableName))
+	gen := strconv.FormatUint(generation, 10)
+	out := make([]byte, 0, len(DDBItemPrefix)+len(enc)+len(gen)+len("||"))
+	out = append(out, DDBItemPrefix...)
+	out = append(out, enc...)
+	out = append(out, '|')
+	out = append(out, gen...)
+	out = append(out, '|')
+	return out
+}
+
+// ddbPrimaryKeyBytes extracts the raw key bytes for a primary/range key
+// attribute. Only S and B are supported in this slice; N fails closed and
+// any non-key kind is rejected (DynamoDB primary keys are S, N, or B).
+func ddbPrimaryKeyBytes(av *pb.DynamoAttributeValue) ([]byte, error) {
+	switch v := av.GetValue().(type) {
+	case *pb.DynamoAttributeValue_S:
+		return []byte(v.S), nil
+	case *pb.DynamoAttributeValue_B:
+		return v.B, nil
+	case *pb.DynamoAttributeValue_N:
+		return nil, errors.Wrap(ErrDDBEncodeNumericKeyUnsupported, "numeric primary key")
+	default:
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "primary key attribute is not S, N, or B")
+	}
+}
+
+// encodeDDBOrderedKeySegment reproduces encodeDynamoKeySegment: escape
+// 0x00 -> 0x00 0xFF, then append the 0x00 0x01 terminator.
+func encodeDDBOrderedKeySegment(raw []byte) []byte {
+	out := make([]byte, 0, len(raw)+ddbKeySegmentOverhead)
+	for _, c := range raw {
+		if c == ddbKeyEscapeByte {
+			out = append(out, ddbKeyEscapeByte, ddbKeyEscapedZeroByte)
+			continue
+		}
+		out = append(out, c)
+	}
+	return append(out, ddbKeyEscapeByte, ddbKeyTerminatorByte)
+}
+
+// marshalStoredDDBItem reproduces the live item value:
+// storedDDBItemMagic + deterministic proto marshal.
+func marshalStoredDDBItem(item *pb.DynamoItem) ([]byte, error) {
+	body, err := gproto.MarshalOptions{Deterministic: true}.Marshal(item)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	out := make([]byte, 0, len(storedDDBItemMagic))
+	out = append(out, storedDDBItemMagic...)
+	return append(out, body...), nil
+}
+
+// publicToItem is the inverse of itemToPublic: it rebuilds a DynamoItem
+// proto from the decoded items/*.json attribute map.
+func publicToItem(public map[string]any) (*pb.DynamoItem, error) {
+	attrs := make(map[string]*pb.DynamoAttributeValue, len(public))
+	for name, raw := range public {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			return nil, errors.Wrapf(ErrDDBEncodeInvalidItem, "attribute %q is not an object", name)
+		}
+		av, err := publicToAttributeValue(m)
+		if err != nil {
+			return nil, errors.Wrapf(err, "attribute %q", name)
+		}
+		attrs[name] = av
+	}
+	return &pb.DynamoItem{Attributes: attrs}, nil
+}
+
+// publicToAttributeValue is the inverse of attributeValueToPublic: the
+// public form is a single-key object {TYPE: value}.
+func publicToAttributeValue(m map[string]any) (*pb.DynamoAttributeValue, error) {
+	if len(m) != 1 {
+		return nil, errors.Wrapf(ErrDDBEncodeInvalidItem,
+			"attribute object must have exactly one type key, got %d", len(m))
+	}
+	for typ, val := range m {
+		return decodePublicAV(typ, val)
+	}
+	return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "empty attribute object")
+}
+
+// decodePublicAV dispatches a single {TYPE: value} pair. Scalars and
+// collections are split into two grouped switches so each stays well
+// under the cyclomatic limit and so the package has no init-cycle from a
+// var-level decoder table referencing the recursive L/M decoders.
+func decodePublicAV(typ string, val any) (*pb.DynamoAttributeValue, error) {
+	if av, matched, err := decodeScalarAV(typ, val); matched || err != nil {
+		return av, err
+	}
+	if av, matched, err := decodeCollectionAV(typ, val); matched || err != nil {
+		return av, err
+	}
+	return nil, errors.Wrapf(ErrDDBEncodeInvalidItem, "unknown attribute type %q", typ)
+}
+
+func decodeScalarAV(typ string, val any) (*pb.DynamoAttributeValue, bool, error) {
+	switch typ {
+	case "S":
+		av, err := decodeAVString(val)
+		return av, true, err
+	case "N":
+		av, err := decodeAVNumber(val)
+		return av, true, err
+	case "B":
+		av, err := decodeAVBinary(val)
+		return av, true, err
+	case "BOOL":
+		av, err := decodeAVBool(val)
+		return av, true, err
+	case "NULL":
+		av, err := decodeAVNull(val)
+		return av, true, err
+	}
+	return nil, false, nil
+}
+
+func decodeCollectionAV(typ string, val any) (*pb.DynamoAttributeValue, bool, error) {
+	switch typ {
+	case "SS":
+		av, err := decodeAVStringSet(val)
+		return av, true, err
+	case "NS":
+		av, err := decodeAVNumberSet(val)
+		return av, true, err
+	case "BS":
+		av, err := decodeAVBinarySet(val)
+		return av, true, err
+	case "L":
+		av, err := decodeAVList(val)
+		return av, true, err
+	case "M":
+		av, err := decodeAVMap(val)
+		return av, true, err
+	}
+	return nil, false, nil
+}
+
+func decodeAVString(v any) (*pb.DynamoAttributeValue, error) {
+	s, ok := v.(string)
+	if !ok {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "S value is not a string")
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_S{S: s}}, nil
+}
+
+func decodeAVNumber(v any) (*pb.DynamoAttributeValue, error) {
+	s, ok := v.(string)
+	if !ok {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "N value is not a string")
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_N{N: s}}, nil
+}
+
+func decodeAVBinary(v any) (*pb.DynamoAttributeValue, error) {
+	raw, err := base64StdFromAny(v)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_B{B: raw}}, nil
+}
+
+func decodeAVBool(v any) (*pb.DynamoAttributeValue, error) {
+	b, ok := v.(bool)
+	if !ok {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "BOOL value is not a boolean")
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_BoolValue{BoolValue: b}}, nil
+}
+
+func decodeAVNull(v any) (*pb.DynamoAttributeValue, error) {
+	b, ok := v.(bool)
+	if !ok {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "NULL value is not a boolean")
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_NullValue{NullValue: b}}, nil
+}
+
+func decodeAVStringSet(v any) (*pb.DynamoAttributeValue, error) {
+	vals, err := stringSliceFromAny(v)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_Ss{Ss: &pb.DynamoStringSet{Values: vals}}}, nil
+}
+
+func decodeAVNumberSet(v any) (*pb.DynamoAttributeValue, error) {
+	vals, err := stringSliceFromAny(v)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_Ns{Ns: &pb.DynamoNumberSet{Values: vals}}}, nil
+}
+
+func decodeAVBinarySet(v any) (*pb.DynamoAttributeValue, error) {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "BS value is not an array")
+	}
+	out := make([][]byte, 0, len(arr))
+	for _, e := range arr {
+		raw, err := base64StdFromAny(e)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, raw)
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_Bs{Bs: &pb.DynamoBinarySet{Values: out}}}, nil
+}
+
+func decodeAVList(v any) (*pb.DynamoAttributeValue, error) {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "L value is not an array")
+	}
+	out := make([]*pb.DynamoAttributeValue, 0, len(arr))
+	for _, e := range arr {
+		m, ok := e.(map[string]any)
+		if !ok {
+			return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "L element is not an object")
+		}
+		child, err := publicToAttributeValue(m)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, child)
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_L{L: &pb.DynamoAttributeValueList{Values: out}}}, nil
+}
+
+func decodeAVMap(v any) (*pb.DynamoAttributeValue, error) {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "M value is not an object")
+	}
+	out := make(map[string]*pb.DynamoAttributeValue, len(m))
+	for name, child := range m {
+		cm, ok := child.(map[string]any)
+		if !ok {
+			return nil, errors.Wrapf(ErrDDBEncodeInvalidItem, "M[%q] is not an object", name)
+		}
+		av, err := publicToAttributeValue(cm)
+		if err != nil {
+			return nil, errors.Wrapf(err, "M[%q]", name)
+		}
+		out[name] = av
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_M{M: &pb.DynamoAttributeValueMap{Values: out}}}, nil
+}
+
+// stringSliceFromAny coerces a JSON array of strings (SS / NS).
+func stringSliceFromAny(v any) ([]string, error) {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "set value is not an array")
+	}
+	out := make([]string, 0, len(arr))
+	for _, e := range arr {
+		s, ok := e.(string)
+		if !ok {
+			return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "set element is not a string")
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// base64StdFromAny decodes a JSON base64 string into bytes. encoding/json
+// renders []byte as standard-base64 strings, so B / BS values round-trip
+// through StdEncoding.
+func base64StdFromAny(v any) ([]byte, error) {
+	s, ok := v.(string)
+	if !ok {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "binary value is not a base64 string")
+	}
+	raw, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return nil, errors.Wrapf(ErrDDBEncodeInvalidItem, "binary value is not valid base64: %v", err)
+	}
+	return raw, nil
+}

--- a/internal/backup/encode_dynamodb_items.go
+++ b/internal/backup/encode_dynamodb_items.go
@@ -274,6 +274,10 @@ func marshalStoredDDBItem(item *pb.DynamoItem) ([]byte, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	// const-capacity, zero-length start + append (magic then body): keeps
+	// the len(magic)+len(body) arithmetic out of make() — which CodeQL
+	// flags as a potential allocation-size overflow — and the zero length
+	// satisfies makezero. Same pattern as marshalStoredDDBSchema.
 	out := make([]byte, 0, len(storedDDBItemMagic))
 	out = append(out, storedDDBItemMagic...)
 	return append(out, body...), nil
@@ -426,6 +430,9 @@ func decodeAVNumberSet(v any) (*pb.DynamoAttributeValue, error) {
 	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_Ns{Ns: &pb.DynamoNumberSet{Values: vals}}}, nil
 }
 
+// decodeAVBinarySet rebuilds a BS attribute. Like the SS/NS path, an
+// empty array is preserved (not rejected) to round-trip the structural
+// empty case the decoder serializes for nil/empty sets.
 func decodeAVBinarySet(v any) (*pb.DynamoAttributeValue, error) {
 	arr, ok := v.([]any)
 	if !ok {

--- a/internal/backup/encode_dynamodb_items_test.go
+++ b/internal/backup/encode_dynamodb_items_test.go
@@ -271,26 +271,31 @@ func TestDDBItemKeyBytesLayout(t *testing.T) {
 	}
 }
 
-// TestDDBEncodeItemRejectsInvalidAttributes pins fail-closed validation
-// of DynamoDB semantic constraints on the untrusted dump input: NULL must
-// be true (AWS has no false NULL), and sets (SS/NS/BS) must be non-empty
-// (AWS rejects empty sets, and an empty-set record would fail on restore).
-// gemini HIGH on PR #837.
-func TestDDBEncodeItemRejectsInvalidAttributes(t *testing.T) {
+// TestDDBEncodeItemPreservesStructuralEdgeCases pins ROUND-TRIP fidelity
+// for the structural edge cases the decoder intentionally preserves
+// (rather than dropping): empty sets are serialized as [] and a NULL is
+// serialized with its boolean as-is. The encoder is the decoder's inverse
+// and must reproduce these so a snapshot of a legacy/drifted store can be
+// recovered — the encode path reconstructs internal records, it does NOT
+// re-validate AWS API payload semantics (codex P1/P2 on PR #837).
+func TestDDBEncodeItemPreservesStructuralEdgeCases(t *testing.T) {
 	t.Parallel()
-	cases := map[string]map[string]any{
-		"null false": {"a": map[string]any{"NULL": false}},
-		"empty SS":   {"a": map[string]any{"SS": []any{}}},
-		"empty NS":   {"a": map[string]any{"NS": []any{}}},
-		"empty BS":   {"a": map[string]any{"BS": []any{}}},
+	in := t.TempDir()
+	const table = "edge"
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"edge",`+
+		`"primary_key":{"hash_key":{"name":"id","type":"S"}},`+
+		`"attribute_definitions":[{"name":"id","type":"S"}]}`))
+	item := []byte(`{"id":{"S":"k"},` +
+		`"ess":{"SS":[]},"ens":{"NS":[]},"ebs":{"BS":[]},"nf":{"NULL":false}}`)
+	writeDDBItemFile(t, in, table, "k.json", item)
+
+	out := decodeDDBTree(t, encodeDDBTree(t, in))
+	got := collectDDBItems(t, out, table)
+	if len(got) != 1 {
+		t.Fatalf("decoded %d items, want 1", len(got))
 	}
-	for name, public := range cases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			if _, err := publicToItem(public); !errors.Is(err, ErrDDBEncodeInvalidItem) {
-				t.Fatalf("publicToItem err = %v, want ErrDDBEncodeInvalidItem", err)
-			}
-		})
+	if !reflect.DeepEqual(got[0], reparse(t, item)) {
+		t.Fatalf("structural edge-case round-trip mismatch:\n got = %#v\nwant = %#v", got[0], reparse(t, item))
 	}
 }
 

--- a/internal/backup/encode_dynamodb_items_test.go
+++ b/internal/backup/encode_dynamodb_items_test.go
@@ -1,0 +1,244 @@
+package backup
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	pb "github.com/bootjp/elastickv/proto"
+	"github.com/cockroachdb/errors"
+)
+
+// writeDDBItemFile writes a raw item JSON body under
+// <root>/dynamodb/<EncodeSegment(table)>/items/<rel>, creating parents.
+func writeDDBItemFile(t *testing.T, root, table, rel string, body []byte) {
+	t.Helper()
+	path := filepath.Join(root, "dynamodb", EncodeSegment([]byte(table)), "items", rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("WriteFile %s: %v", rel, err)
+	}
+}
+
+// collectDDBItems walks the decoded items/ tree for a table and returns
+// each item's public attribute map (parsed from JSON), so assertions do
+// not depend on the decoder's filename layout.
+func collectDDBItems(t *testing.T, outRoot, table string) []map[string]any {
+	t.Helper()
+	itemsDir := filepath.Join(outRoot, "dynamodb", EncodeSegment([]byte(table)), "items")
+	var out []map[string]any
+	err := filepath.WalkDir(itemsDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".json" {
+			return nil
+		}
+		data, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return rerr
+		}
+		var m map[string]any
+		if jerr := json.Unmarshal(data, &m); jerr != nil {
+			return jerr
+		}
+		out = append(out, m)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk decoded items: %v", err)
+	}
+	return out
+}
+
+// reparse normalizes a JSON body through json.Unmarshal so it can be
+// compared against decoded items with reflect.DeepEqual.
+func reparse(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("reparse: %v", err)
+	}
+	return m
+}
+
+// TestDDBEncodeItemCompositeRoundTrip pins the gold-standard directory
+// round-trip for a composite-key (S/S) table carrying every attribute
+// type: the item survives encode -> real DecodeSnapshot -> dump byte for
+// byte.
+func TestDDBEncodeItemCompositeRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "orders"
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"orders",`+
+		`"primary_key":{"hash_key":{"name":"pk","type":"S"},"range_key":{"name":"sk","type":"S"}},`+
+		`"attribute_definitions":[{"name":"pk","type":"S"},{"name":"sk","type":"S"}]}`))
+	item := []byte(`{` +
+		`"pk":{"S":"u1"},"sk":{"S":"2024"},` +
+		`"name":{"S":"alice"},"age":{"N":"30"},"active":{"BOOL":true},"meta":{"NULL":true},` +
+		`"tags":{"SS":["a","b"]},"scores":{"NS":["1","2"]},` +
+		`"blob":{"B":"aGVsbG8="},"blobs":{"BS":["AAE=","Av8="]},` +
+		`"items":{"L":[{"S":"x"},{"N":"5"}]},"nested":{"M":{"k":{"S":"v"}}}` +
+		`}`)
+	writeDDBItemFile(t, in, table, "item.json", item)
+
+	out := decodeDDBTree(t, encodeDDBTree(t, in))
+	got := collectDDBItems(t, out, table)
+	if len(got) != 1 {
+		t.Fatalf("decoded %d items, want 1", len(got))
+	}
+	want := reparse(t, item)
+	if !reflect.DeepEqual(got[0], want) {
+		t.Fatalf("round-tripped item mismatch:\n got = %#v\nwant = %#v", got[0], want)
+	}
+}
+
+// TestDDBEncodeItemHashOnlyRoundTrip pins the hash-only (no range key)
+// layout: items/<hashSeg>.json read at the top level.
+func TestDDBEncodeItemHashOnlyRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "sessions"
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"sessions",`+
+		`"primary_key":{"hash_key":{"name":"id","type":"S"}},`+
+		`"attribute_definitions":[{"name":"id","type":"S"}]}`))
+	item := []byte(`{"id":{"S":"abc"},"v":{"N":"7"}}`)
+	writeDDBItemFile(t, in, table, "abc.json", item)
+
+	out := decodeDDBTree(t, encodeDDBTree(t, in))
+	got := collectDDBItems(t, out, table)
+	if len(got) != 1 {
+		t.Fatalf("decoded %d items, want 1", len(got))
+	}
+	if !reflect.DeepEqual(got[0], reparse(t, item)) {
+		t.Fatalf("hash-only item mismatch: got %#v", got[0])
+	}
+}
+
+// TestDDBEncodeItemBinaryKeyRoundTrip pins a binary (B) hash key, whose
+// raw bytes (including a 0x00 that must be escaped 0x00 0xFF in the
+// ordered key) survive the round-trip.
+func TestDDBEncodeItemBinaryKeyRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "blobs"
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"blobs",`+
+		`"primary_key":{"hash_key":{"name":"bk","type":"B"}},`+
+		`"attribute_definitions":[{"name":"bk","type":"B"}]}`))
+	// bk = bytes {0x00,0x01} (base64 std "AAE="), exercising 0x00 escape.
+	item := []byte(`{"bk":{"B":"AAE="},"payload":{"S":"hi"}}`)
+	writeDDBItemFile(t, in, table, "sub/x.json", item) // also exercises subdir descent
+
+	out := decodeDDBTree(t, encodeDDBTree(t, in))
+	got := collectDDBItems(t, out, table)
+	if len(got) != 1 {
+		t.Fatalf("decoded %d items, want 1", len(got))
+	}
+	if !reflect.DeepEqual(got[0], reparse(t, item)) {
+		t.Fatalf("binary-key item mismatch: got %#v", got[0])
+	}
+}
+
+// TestDDBEncodeItemNumericKeyFailsClosed pins that a numeric (N) primary
+// key fails closed in this slice rather than emitting a wrongly-ordered
+// key.
+func TestDDBEncodeItemNumericKeyFailsClosed(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "counters"
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"counters",`+
+		`"primary_key":{"hash_key":{"name":"id","type":"N"}},`+
+		`"attribute_definitions":[{"name":"id","type":"N"}]}`))
+	writeDDBItemFile(t, in, table, "1.json", []byte(`{"id":{"N":"1"},"v":{"S":"x"}}`))
+
+	b := newSnapshotBuilder(ddbEncTS)
+	err := NewDynamoDBEncoder(in).Encode(b)
+	if !errors.Is(err, ErrDDBEncodeNumericKeyUnsupported) {
+		t.Fatalf("Encode err = %v, want ErrDDBEncodeNumericKeyUnsupported", err)
+	}
+}
+
+// TestDDBEncodeItemMissingHashKeyFailsClosed pins that an item whose JSON
+// lacks the schema's hash-key attribute is rejected.
+func TestDDBEncodeItemMissingHashKeyFailsClosed(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "t"
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"t",`+
+		`"primary_key":{"hash_key":{"name":"id","type":"S"}},`+
+		`"attribute_definitions":[{"name":"id","type":"S"}]}`))
+	writeDDBItemFile(t, in, table, "x.json", []byte(`{"other":{"S":"v"}}`))
+
+	b := newSnapshotBuilder(ddbEncTS)
+	err := NewDynamoDBEncoder(in).Encode(b)
+	if !errors.Is(err, ErrDDBEncodeInvalidItem) {
+		t.Fatalf("Encode err = %v, want ErrDDBEncodeInvalidItem", err)
+	}
+}
+
+// TestDDBEncodeItemMissingItemsDirIsNoop pins that a table with a schema
+// but no items/ directory encodes its schema with no item records and no
+// error.
+func TestDDBEncodeItemMissingItemsDirIsNoop(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "empty"
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"empty",`+
+		`"primary_key":{"hash_key":{"name":"id","type":"S"}},`+
+		`"attribute_definitions":[{"name":"id","type":"S"}]}`))
+	b := newSnapshotBuilder(ddbEncTS)
+	if err := NewDynamoDBEncoder(in).Encode(b); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	// schema record + gen counter, no item records.
+	if b.Len() != 2 {
+		t.Fatalf("entries = %d, want 2 (schema + gen)", b.Len())
+	}
+}
+
+// TestDDBItemKeyBytesLayout pins the FULL ordered item key against a
+// hand-computed expectation. The decoder round-trip cannot cover this
+// (it reconstructs items from the proto VALUE and ignores the key's
+// ordered hash/range payload), so this is the guard that the emitted key
+// matches what the live adapter (dynamoItemKey, KeyEncodingVersion=V2)
+// looks up — i.e. that the restored item is actually GetItem-able.
+func TestDDBItemKeyBytesLayout(t *testing.T) {
+	t.Parallel()
+	schema := &pb.DynamoTableSchema{PrimaryKey: &pb.DynamoKeySchema{HashKey: "h", RangeKey: "r"}}
+	item := &pb.DynamoItem{Attributes: map[string]*pb.DynamoAttributeValue{
+		"h": {Value: &pb.DynamoAttributeValue_S{S: "a"}},
+		"r": {Value: &pb.DynamoAttributeValue_B{B: []byte{0x00, 0x09}}},
+	}}
+	got, err := ddbItemKeyBytes("tbl", 1, schema, item)
+	if err != nil {
+		t.Fatalf("ddbItemKeyBytes: %v", err)
+	}
+	want := []byte(DDBItemPrefix)
+	want = append(want, base64.RawURLEncoding.EncodeToString([]byte("tbl"))...)
+	want = append(want, "|1|"...)
+	want = append(want, 'a', 0x00, 0x01)              // hash "a" -> 'a' 00 01
+	want = append(want, 0x00, 0xFF, 0x09, 0x00, 0x01) // range {00,09} -> 00 FF 09 00 01
+	if !bytes.Equal(got, want) {
+		t.Fatalf("item key = %x, want %x", got, want)
+	}
+}
+
+// TestEncodeDDBOrderedKeySegment pins the ordered-key byte layout
+// directly: 0x00 escapes to 0x00 0xFF and every segment ends 0x00 0x01.
+func TestEncodeDDBOrderedKeySegment(t *testing.T) {
+	t.Parallel()
+	got := encodeDDBOrderedKeySegment([]byte{'a', 0x00, 'b'})
+	want := []byte{'a', 0x00, 0xFF, 'b', 0x00, 0x01}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("ordered segment = %x, want %x", got, want)
+	}
+	if g := encodeDDBOrderedKeySegment(nil); !bytes.Equal(g, []byte{0x00, 0x01}) {
+		t.Fatalf("empty ordered segment = %x, want 0001", g)
+	}
+}

--- a/internal/backup/encode_dynamodb_items_test.go
+++ b/internal/backup/encode_dynamodb_items_test.go
@@ -229,6 +229,29 @@ func TestDDBItemKeyBytesLayout(t *testing.T) {
 	}
 }
 
+// TestDDBEncodeItemRejectsInvalidAttributes pins fail-closed validation
+// of DynamoDB semantic constraints on the untrusted dump input: NULL must
+// be true (AWS has no false NULL), and sets (SS/NS/BS) must be non-empty
+// (AWS rejects empty sets, and an empty-set record would fail on restore).
+// gemini HIGH on PR #837.
+func TestDDBEncodeItemRejectsInvalidAttributes(t *testing.T) {
+	t.Parallel()
+	cases := map[string]map[string]any{
+		"null false": {"a": map[string]any{"NULL": false}},
+		"empty SS":   {"a": map[string]any{"SS": []any{}}},
+		"empty NS":   {"a": map[string]any{"NS": []any{}}},
+		"empty BS":   {"a": map[string]any{"BS": []any{}}},
+	}
+	for name, public := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := publicToItem(public); !errors.Is(err, ErrDDBEncodeInvalidItem) {
+				t.Fatalf("publicToItem err = %v, want ErrDDBEncodeInvalidItem", err)
+			}
+		})
+	}
+}
+
 // TestEncodeDDBOrderedKeySegment pins the ordered-key byte layout
 // directly: 0x00 escapes to 0x00 0xFF and every segment ends 0x00 0x01.
 func TestEncodeDDBOrderedKeySegment(t *testing.T) {

--- a/internal/backup/encode_dynamodb_items_test.go
+++ b/internal/backup/encode_dynamodb_items_test.go
@@ -164,6 +164,48 @@ func TestDDBEncodeItemNumericKeyFailsClosed(t *testing.T) {
 	}
 }
 
+// TestDDBEncodeItemNumericRangeKeyFailsClosed pins the fail-closed path
+// for a numeric RANGE key (the hash-key case is covered separately), so
+// both primary-key positions reject N until the ordered numeric encoding
+// lands (M3b-2).
+func TestDDBEncodeItemNumericRangeKeyFailsClosed(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "events"
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"events",`+
+		`"primary_key":{"hash_key":{"name":"pk","type":"S"},"range_key":{"name":"ts","type":"N"}},`+
+		`"attribute_definitions":[{"name":"pk","type":"S"},{"name":"ts","type":"N"}]}`))
+	writeDDBItemFile(t, in, table, "e.json", []byte(`{"pk":{"S":"a"},"ts":{"N":"100"}}`))
+
+	b := newSnapshotBuilder(ddbEncTS)
+	err := NewDynamoDBEncoder(in).Encode(b)
+	if !errors.Is(err, ErrDDBEncodeNumericKeyUnsupported) {
+		t.Fatalf("Encode err = %v, want ErrDDBEncodeNumericKeyUnsupported", err)
+	}
+}
+
+// TestDDBEncodeItemRejectsDeeperNesting pins that an items/ tree deeper
+// than the decoder's fixed 2 levels (items/<hash>/<range>.json) fails
+// closed rather than silently skipping items — preventing a "restore
+// succeeded but item count is off" surprise from a corrupt/hand-crafted
+// dump (claude review on PR #837).
+func TestDDBEncodeItemRejectsDeeperNesting(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "t"
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"t",`+
+		`"primary_key":{"hash_key":{"name":"pk","type":"S"},"range_key":{"name":"sk","type":"S"}},`+
+		`"attribute_definitions":[{"name":"pk","type":"S"},{"name":"sk","type":"S"}]}`))
+	// items/h/sub/x.json — a directory nested inside a hash directory.
+	writeDDBItemFile(t, in, table, "h/sub/x.json", []byte(`{"pk":{"S":"h"},"sk":{"S":"x"}}`))
+
+	b := newSnapshotBuilder(ddbEncTS)
+	err := NewDynamoDBEncoder(in).Encode(b)
+	if !errors.Is(err, ErrDDBEncodeInvalidItem) {
+		t.Fatalf("Encode err = %v, want ErrDDBEncodeInvalidItem", err)
+	}
+}
+
 // TestDDBEncodeItemMissingHashKeyFailsClosed pins that an item whose JSON
 // lacks the schema's hash-key attribute is rejected.
 func TestDDBEncodeItemMissingHashKeyFailsClosed(t *testing.T) {

--- a/internal/backup/encode_dynamodb_items_test.go
+++ b/internal/backup/encode_dynamodb_items_test.go
@@ -188,6 +188,12 @@ func TestDDBEncodeItemNumericRangeKeyRoundTrip(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("decoded %d items, want 2", len(got))
 	}
+	wantA, wantB := reparse(t, a), reparse(t, bItem)
+	for _, item := range got {
+		if !reflect.DeepEqual(item, wantA) && !reflect.DeepEqual(item, wantB) {
+			t.Fatalf("unexpected decoded item: %#v", item)
+		}
+	}
 }
 
 // TestDDBNumericKeyOrderPreserving is the core correctness guard for the
@@ -221,7 +227,8 @@ func TestDDBNumericKeyOrderPreserving(t *testing.T) {
 }
 
 // TestDDBNumericKeyZeroLayout pins the canonical zero encoding: zero maps
-// to the single 0x01 marker, then the segment terminator.
+// to the single 0x01 marker (raw), which becomes 0x01 0x00 0x01 after the
+// segment escape/terminator.
 func TestDDBNumericKeyZeroLayout(t *testing.T) {
 	t.Parallel()
 	for _, z := range []string{"0", "0.0", "-0", "000", "0e5"} {
@@ -232,6 +239,28 @@ func TestDDBNumericKeyZeroLayout(t *testing.T) {
 		if !bytes.Equal(raw, []byte{0x01}) {
 			t.Fatalf("zero %q raw = %x, want 01", z, raw)
 		}
+		if seg := encodeDDBOrderedKeySegment(raw); !bytes.Equal(seg, []byte{0x01, 0x00, 0x01}) {
+			t.Fatalf("zero %q segment = %x, want 01 00 01", z, seg)
+		}
+	}
+}
+
+// TestDDBNumericKeyPositiveSignStripped pins that a leading '+' is stripped
+// so the value encodes identically to its unsigned form.
+func TestDDBNumericKeyPositiveSignStripped(t *testing.T) {
+	t.Parallel()
+	for _, pair := range [][2]string{{"+5", "5"}, {"+1e2", "100"}} {
+		withSign, err := ddbNumericKeyBytes(pair[0])
+		if err != nil {
+			t.Fatalf("ddbNumericKeyBytes(%q): %v", pair[0], err)
+		}
+		plain, err := ddbNumericKeyBytes(pair[1])
+		if err != nil {
+			t.Fatalf("ddbNumericKeyBytes(%q): %v", pair[1], err)
+		}
+		if !bytes.Equal(withSign, plain) {
+			t.Fatalf("%q (%x) must encode == %q (%x)", pair[0], withSign, pair[1], plain)
+		}
 	}
 }
 
@@ -239,7 +268,7 @@ func TestDDBNumericKeyZeroLayout(t *testing.T) {
 // literal in a numeric key position.
 func TestDDBNumericKeyRejectsMalformed(t *testing.T) {
 	t.Parallel()
-	for _, bad := range []string{"", "abc", "1.2.3", "+", "1e", "0x10"} {
+	for _, bad := range []string{"", "abc", "1.2.3", "+", "1e", "0x10", "e3"} {
 		if _, err := ddbNumericKeyBytes(bad); !errors.Is(err, ErrDDBEncodeInvalidItem) {
 			t.Fatalf("ddbNumericKeyBytes(%q) err = %v, want ErrDDBEncodeInvalidItem", bad, err)
 		}

--- a/internal/backup/encode_dynamodb_items_test.go
+++ b/internal/backup/encode_dynamodb_items_test.go
@@ -145,42 +145,104 @@ func TestDDBEncodeItemBinaryKeyRoundTrip(t *testing.T) {
 	}
 }
 
-// TestDDBEncodeItemNumericKeyFailsClosed pins that a numeric (N) primary
-// key fails closed in this slice rather than emitting a wrongly-ordered
-// key.
-func TestDDBEncodeItemNumericKeyFailsClosed(t *testing.T) {
+// TestDDBEncodeItemNumericHashKeyRoundTrip pins that a numeric (N) hash
+// key round-trips: its value survives encode -> real decode, and the
+// numeric ordered encoding (M3b-2) produces a valid loadable key.
+func TestDDBEncodeItemNumericHashKeyRoundTrip(t *testing.T) {
 	t.Parallel()
 	in := t.TempDir()
 	const table = "counters"
 	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"counters",`+
 		`"primary_key":{"hash_key":{"name":"id","type":"N"}},`+
 		`"attribute_definitions":[{"name":"id","type":"N"}]}`))
-	writeDDBItemFile(t, in, table, "1.json", []byte(`{"id":{"N":"1"},"v":{"S":"x"}}`))
+	item := []byte(`{"id":{"N":"100"},"v":{"S":"x"}}`)
+	writeDDBItemFile(t, in, table, "100.json", item)
 
-	b := newSnapshotBuilder(ddbEncTS)
-	err := NewDynamoDBEncoder(in).Encode(b)
-	if !errors.Is(err, ErrDDBEncodeNumericKeyUnsupported) {
-		t.Fatalf("Encode err = %v, want ErrDDBEncodeNumericKeyUnsupported", err)
+	out := decodeDDBTree(t, encodeDDBTree(t, in))
+	got := collectDDBItems(t, out, table)
+	if len(got) != 1 {
+		t.Fatalf("decoded %d items, want 1", len(got))
+	}
+	if !reflect.DeepEqual(got[0], reparse(t, item)) {
+		t.Fatalf("numeric hash-key item mismatch: got %#v", got[0])
 	}
 }
 
-// TestDDBEncodeItemNumericRangeKeyFailsClosed pins the fail-closed path
-// for a numeric RANGE key (the hash-key case is covered separately), so
-// both primary-key positions reject N until the ordered numeric encoding
-// lands (M3b-2).
-func TestDDBEncodeItemNumericRangeKeyFailsClosed(t *testing.T) {
+// TestDDBEncodeItemNumericRangeKeyRoundTrip pins a composite key with a
+// numeric (N) range key — including a fractional and negative value to
+// exercise the fraction/sign paths of the numeric encoder.
+func TestDDBEncodeItemNumericRangeKeyRoundTrip(t *testing.T) {
 	t.Parallel()
 	in := t.TempDir()
 	const table = "events"
 	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"events",`+
 		`"primary_key":{"hash_key":{"name":"pk","type":"S"},"range_key":{"name":"ts","type":"N"}},`+
 		`"attribute_definitions":[{"name":"pk","type":"S"},{"name":"ts","type":"N"}]}`))
-	writeDDBItemFile(t, in, table, "e.json", []byte(`{"pk":{"S":"a"},"ts":{"N":"100"}}`))
+	a := []byte(`{"pk":{"S":"a"},"ts":{"N":"-12.5"}}`)
+	bItem := []byte(`{"pk":{"S":"a"},"ts":{"N":"100"}}`)
+	writeDDBItemFile(t, in, table, "a/neg.json", a)
+	writeDDBItemFile(t, in, table, "a/pos.json", bItem)
 
-	b := newSnapshotBuilder(ddbEncTS)
-	err := NewDynamoDBEncoder(in).Encode(b)
-	if !errors.Is(err, ErrDDBEncodeNumericKeyUnsupported) {
-		t.Fatalf("Encode err = %v, want ErrDDBEncodeNumericKeyUnsupported", err)
+	out := decodeDDBTree(t, encodeDDBTree(t, in))
+	got := collectDDBItems(t, out, table)
+	if len(got) != 2 {
+		t.Fatalf("decoded %d items, want 2", len(got))
+	}
+}
+
+// TestDDBNumericKeyOrderPreserving is the core correctness guard for the
+// reproduced numeric encoding: the encoded key segments must sort in the
+// same byte-lexicographic order Pebble uses as the underlying numbers do.
+func TestDDBNumericKeyOrderPreserving(t *testing.T) {
+	t.Parallel()
+	// Strictly increasing numeric order.
+	nums := []string{"-1000", "-12.5", "-1", "-0.5", "0", "0.5", "1", "12.5", "100", "1000", "1e3", "12345"}
+	// dedupe equal values (1000 == 1e3) for the strict-order check below.
+	prev := []byte(nil)
+	prevNum := ""
+	for _, n := range nums {
+		raw, err := ddbNumericKeyBytes(n)
+		if err != nil {
+			t.Fatalf("ddbNumericKeyBytes(%q): %v", n, err)
+		}
+		seg := encodeDDBOrderedKeySegment(raw)
+		if prev != nil {
+			cmp := bytes.Compare(prev, seg)
+			equalValue := (prevNum == "1000" && n == "1e3")
+			switch {
+			case equalValue && cmp != 0:
+				t.Fatalf("%q vs %q: equal numbers must encode equal, cmp=%d", prevNum, n, cmp)
+			case !equalValue && cmp >= 0:
+				t.Fatalf("%q (%x) should sort before %q (%x), cmp=%d", prevNum, prev, n, seg, cmp)
+			}
+		}
+		prev, prevNum = seg, n
+	}
+}
+
+// TestDDBNumericKeyZeroLayout pins the canonical zero encoding: zero maps
+// to the single 0x01 marker, then the segment terminator.
+func TestDDBNumericKeyZeroLayout(t *testing.T) {
+	t.Parallel()
+	for _, z := range []string{"0", "0.0", "-0", "000", "0e5"} {
+		raw, err := ddbNumericKeyBytes(z)
+		if err != nil {
+			t.Fatalf("ddbNumericKeyBytes(%q): %v", z, err)
+		}
+		if !bytes.Equal(raw, []byte{0x01}) {
+			t.Fatalf("zero %q raw = %x, want 01", z, raw)
+		}
+	}
+}
+
+// TestDDBNumericKeyRejectsMalformed pins fail-closed on a non-numeric
+// literal in a numeric key position.
+func TestDDBNumericKeyRejectsMalformed(t *testing.T) {
+	t.Parallel()
+	for _, bad := range []string{"", "abc", "1.2.3", "+", "1e", "0x10"} {
+		if _, err := ddbNumericKeyBytes(bad); !errors.Is(err, ErrDDBEncodeInvalidItem) {
+			t.Fatalf("ddbNumericKeyBytes(%q) err = %v, want ErrDDBEncodeInvalidItem", bad, err)
+		}
 	}
 }
 

--- a/internal/backup/encode_dynamodb_numeric.go
+++ b/internal/backup/encode_dynamodb_numeric.go
@@ -1,0 +1,214 @@
+package backup
+
+import (
+	"encoding/binary"
+	"math/big"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// encode_dynamodb_numeric.go reproduces the live adapter's numeric
+// primary-key ordered encoding (adapter/dynamodb.go: encodeNumericKeyBytes
+// and helpers) so the item encoder can build keys for N (number) hash and
+// range keys that the live store sorts and looks up identically. (M3b-2)
+//
+// The scheme is order-preserving over the byte-lexicographic comparison
+// Pebble uses: a sign marker (0x00 negative / 0x01 zero / 0x02 positive)
+// followed, for non-zero values, by the order-encoded decimal exponent, a
+// 0x00 separator, and the significant digits — with the whole body
+// bit-inverted for negatives so larger magnitudes sort earlier. The result
+// is then escaped+terminated by encodeDDBOrderedKeySegment, exactly as the
+// live attributeValueAsKeySegment wraps attributeValueAsKeyBytes.
+
+const (
+	ddbNumNegativeMarker = byte(0x00)
+	ddbNumZeroMarker     = byte(0x01)
+	ddbNumPositiveMarker = byte(0x02)
+)
+
+// ddbNumericKeyBytes maps a DynamoDB number literal to its order-preserving
+// key bytes (the raw bytes, before the segment escape/terminator).
+func ddbNumericKeyBytes(v string) ([]byte, error) {
+	negative, exponent, digits, err := parseDDBNumericKeyParts(v)
+	if err != nil {
+		return nil, err
+	}
+	if len(digits) == 0 {
+		return []byte{ddbNumZeroMarker}, nil
+	}
+	body := encodeDDBOrderedSignedInt64(exponent)
+	body = append(body, ddbKeyEscapeByte)
+	body = append(body, digits...)
+	if !negative {
+		return append([]byte{ddbNumPositiveMarker}, body...), nil
+	}
+	return append([]byte{ddbNumNegativeMarker}, ddbInvertBytes(body)...), nil
+}
+
+// parseDDBNumericKeyParts splits a number literal into sign, decimal
+// exponent, and significant digits. A zero value yields empty digits.
+func parseDDBNumericKeyParts(v string) (bool, int64, []byte, error) {
+	trimmed, negative, exp10, err := parseDDBNumericLiteral(v)
+	if err != nil {
+		return false, 0, nil, err
+	}
+	digits, exponent, zero, err := normalizeDDBNumericParts(trimmed, exp10)
+	if err != nil {
+		return false, 0, nil, err
+	}
+	if zero {
+		return false, 0, nil, nil
+	}
+	return negative, exponent, digits, nil
+}
+
+// parseDDBNumericLiteral strips an optional sign and eE-exponent suffix.
+func parseDDBNumericLiteral(v string) (string, bool, int64, error) {
+	trimmed := strings.TrimSpace(v)
+	if trimmed == "" {
+		return "", false, 0, errors.Wrap(ErrDDBEncodeInvalidItem, "empty number literal")
+	}
+	negative := false
+	switch trimmed[0] {
+	case '+':
+		trimmed = trimmed[1:]
+	case '-':
+		negative = true
+		trimmed = trimmed[1:]
+	}
+	if trimmed == "" {
+		return "", false, 0, errors.Wrap(ErrDDBEncodeInvalidItem, "number literal is sign only")
+	}
+	exp10 := int64(0)
+	if idx := strings.IndexAny(trimmed, "eE"); idx >= 0 {
+		expPart := strings.TrimSpace(trimmed[idx+1:])
+		trimmed = trimmed[:idx]
+		parsed, err := parseDDBNumericExponent(expPart)
+		if err != nil {
+			return "", false, 0, err
+		}
+		exp10 = parsed
+	}
+	return trimmed, negative, exp10, nil
+}
+
+func parseDDBNumericExponent(expPart string) (int64, error) {
+	if expPart == "" {
+		return 0, errors.Wrap(ErrDDBEncodeInvalidItem, "empty exponent")
+	}
+	parsed, err := strconv.ParseInt(expPart, 10, 64)
+	if err != nil {
+		return 0, errors.Wrapf(ErrDDBEncodeInvalidItem, "bad exponent %q", expPart)
+	}
+	return parsed, nil
+}
+
+// normalizeDDBNumericParts trims leading/trailing zeros and computes the
+// decimal exponent of the first significant digit. The third return is
+// true when the value is zero.
+func normalizeDDBNumericParts(trimmed string, exp10 int64) ([]byte, int64, bool, error) {
+	intPart, fracPart, err := splitDDBNumericMantissa(trimmed)
+	if err != nil {
+		return nil, 0, false, err
+	}
+	combined := intPart + fracPart
+	leadingZeros := ddbLeadingZeroCount(combined)
+	if leadingZeros == len(combined) {
+		return nil, 0, true, nil
+	}
+	digits := []byte(strings.TrimRight(combined[leadingZeros:], "0"))
+	if len(digits) == 0 {
+		return nil, 0, true, nil
+	}
+	exponent := int64(len(intPart)) + exp10 - int64(leadingZeros)
+	return digits, exponent, false, nil
+}
+
+func splitDDBNumericMantissa(trimmed string) (string, string, error) {
+	if strings.Count(trimmed, ".") > 1 {
+		return "", "", errors.Wrap(ErrDDBEncodeInvalidItem, "number has multiple decimal points")
+	}
+	intPart := trimmed
+	fracPart := ""
+	if before, after, ok := strings.Cut(trimmed, "."); ok {
+		intPart = before
+		fracPart = after
+	}
+	if intPart == "" && fracPart == "" {
+		return "", "", errors.Wrap(ErrDDBEncodeInvalidItem, "number has no digits")
+	}
+	if !ddbDecimalDigitsOnly(intPart) || !ddbDecimalDigitsOnly(fracPart) {
+		return "", "", errors.Wrap(ErrDDBEncodeInvalidItem, "number has non-decimal characters")
+	}
+	return intPart, fracPart, nil
+}
+
+func ddbLeadingZeroCount(v string) int {
+	count := 0
+	for count < len(v) && v[count] == '0' {
+		count++
+	}
+	return count
+}
+
+func ddbDecimalDigitsOnly(v string) bool {
+	for i := range v {
+		if v[i] < '0' || v[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// encodeDDBOrderedSignedInt64 order-encodes a signed exponent: 0x00 +
+// inverted magnitude (negative), 0x01 (zero), or 0x02 + magnitude
+// (positive).
+func encodeDDBOrderedSignedInt64(v int64) []byte {
+	switch {
+	case v < 0:
+		return append([]byte{ddbNumNegativeMarker}, ddbInvertBytes(encodeDDBOrderedUint64(ddbSignedMagnitude(v)))...)
+	case v == 0:
+		return []byte{ddbNumZeroMarker}
+	default:
+		return append([]byte{ddbNumPositiveMarker}, encodeDDBOrderedUint64(uint64(v))...)
+	}
+}
+
+func ddbSignedMagnitude(v int64) uint64 {
+	if v >= 0 {
+		return uint64(v)
+	}
+	abs := big.NewInt(v)
+	abs.Abs(abs)
+	return abs.Uint64()
+}
+
+// ddbOrderedUint64LengthPrefix[width] == width; the array lookup avoids an
+// int->byte conversion (and keeps gosec quiet), matching the live code.
+var ddbOrderedUint64LengthPrefix = [...]byte{0, 1, 2, 3, 4, 5, 6, 7, 8}
+
+// encodeDDBOrderedUint64 emits a length-prefixed big-endian magnitude with
+// leading zero bytes stripped, so shorter (smaller) magnitudes sort first.
+func encodeDDBOrderedUint64(v uint64) []byte {
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], v)
+	start := 0
+	for start < len(buf)-1 && buf[start] == 0 {
+		start++
+	}
+	width := len(buf) - start
+	out := make([]byte, 0, width+1)
+	out = append(out, ddbOrderedUint64LengthPrefix[width])
+	out = append(out, buf[start:]...)
+	return out
+}
+
+func ddbInvertBytes(in []byte) []byte {
+	out := make([]byte, len(in))
+	for i := range in {
+		out[i] = ^in[i]
+	}
+	return out
+}

--- a/internal/backup/encode_dynamodb_test.go
+++ b/internal/backup/encode_dynamodb_test.go
@@ -182,6 +182,37 @@ func TestDDBEncodeRejectsUnknownSchemaFormatVersion(t *testing.T) {
 	}
 }
 
+// TestDDBEncodeRejectsNonRegularSchema pins the pre-open guard: a
+// _schema.json that is a directory (cross-platform stand-in for a
+// symlink/FIFO) is refused with ErrDDBEncodeNotRegular before any
+// blocking open.
+func TestDDBEncodeRejectsNonRegularSchema(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	// Place a directory where _schema.json should be a regular file.
+	if err := os.MkdirAll(filepath.Join(in, "dynamodb", "tbl", "_schema.json"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	b := newSnapshotBuilder(ddbEncTS)
+	err := NewDynamoDBEncoder(in).Encode(b)
+	if !errors.Is(err, ErrDDBEncodeNotRegular) {
+		t.Fatalf("Encode err = %v, want ErrDDBEncodeNotRegular", err)
+	}
+}
+
+// TestDDBEncodeRejectsEmptyHashKey pins that a schema with no primary
+// hash key fails closed rather than propagating into the item encoder.
+func TestDDBEncodeRejectsEmptyHashKey(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	writeDDBSchema(t, in, "tbl", []byte(`{"format_version":1,"table_name":"x","primary_key":{"hash_key":{"name":""}}}`))
+	b := newSnapshotBuilder(ddbEncTS)
+	err := NewDynamoDBEncoder(in).Encode(b)
+	if !errors.Is(err, ErrDDBEncodeInvalidSchema) {
+		t.Fatalf("Encode err = %v, want ErrDDBEncodeInvalidSchema", err)
+	}
+}
+
 // TestDDBEncodeMissingDirIsNoop pins that an absent dynamodb/ dir is a
 // no-op (no entries, no error).
 func TestDDBEncodeMissingDirIsNoop(t *testing.T) {

--- a/internal/backup/encode_dynamodb_test.go
+++ b/internal/backup/encode_dynamodb_test.go
@@ -200,6 +200,42 @@ func TestDDBEncodeRejectsNonRegularSchema(t *testing.T) {
 	}
 }
 
+// TestDDBEncodeRejectsDuplicateAttributeDefinition pins that a
+// _schema.json with two attribute definitions sharing a name fails
+// closed: publicToSchema folds AttributeDefinitions into a map, so a
+// duplicate would otherwise silently overwrite an entry and lose a type
+// without any error (coderabbit Major on PR #833).
+func TestDDBEncodeRejectsDuplicateAttributeDefinition(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	writeDDBSchema(t, in, "tbl", []byte(`{"format_version":1,"table_name":"x",`+
+		`"primary_key":{"hash_key":{"name":"id","type":"S"}},`+
+		`"attribute_definitions":[{"name":"id","type":"S"},{"name":"id","type":"N"}]}`))
+	b := newSnapshotBuilder(ddbEncTS)
+	err := NewDynamoDBEncoder(in).Encode(b)
+	if !errors.Is(err, ErrDDBEncodeInvalidSchema) {
+		t.Fatalf("Encode err = %v, want ErrDDBEncodeInvalidSchema", err)
+	}
+}
+
+// TestDDBEncodeRejectsDuplicateGSIName pins the same fail-closed guard
+// for GlobalSecondaryIndexes, which are also folded into a map.
+func TestDDBEncodeRejectsDuplicateGSIName(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	writeDDBSchema(t, in, "tbl", []byte(`{"format_version":1,"table_name":"x",`+
+		`"primary_key":{"hash_key":{"name":"id","type":"S"}},`+
+		`"attribute_definitions":[{"name":"id","type":"S"},{"name":"region","type":"S"}],`+
+		`"global_secondary_indexes":[`+
+		`{"name":"by-region","key_schema":{"hash_key":{"name":"region","type":"S"}},"projection":{"type":"ALL"}},`+
+		`{"name":"by-region","key_schema":{"hash_key":{"name":"id","type":"S"}},"projection":{"type":"ALL"}}]}`))
+	b := newSnapshotBuilder(ddbEncTS)
+	err := NewDynamoDBEncoder(in).Encode(b)
+	if !errors.Is(err, ErrDDBEncodeInvalidSchema) {
+		t.Fatalf("Encode err = %v, want ErrDDBEncodeInvalidSchema", err)
+	}
+}
+
 // TestDDBEncodeRejectsEmptyHashKey pins that a schema with no primary
 // hash key fails closed rather than propagating into the item encoder.
 func TestDDBEncodeRejectsEmptyHashKey(t *testing.T) {

--- a/internal/backup/encode_dynamodb_test.go
+++ b/internal/backup/encode_dynamodb_test.go
@@ -1,0 +1,196 @@
+package backup
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+)
+
+const ddbEncTS uint64 = 0x0001_8F1A_2B3C_00AB
+
+// writeDDBSchema writes a _schema.json under <root>/dynamodb/<dir>/.
+func writeDDBSchema(t *testing.T, root, tableDir string, body []byte) {
+	t.Helper()
+	path := filepath.Join(root, "dynamodb", tableDir, "_schema.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+// encodeDDBTree runs the DynamoDB encoder over inRoot and returns the
+// EKVPBBL1 bytes.
+func encodeDDBTree(t *testing.T, inRoot string) []byte {
+	t.Helper()
+	b := newSnapshotBuilder(ddbEncTS)
+	if err := NewDynamoDBEncoder(inRoot).Encode(b); err != nil {
+		t.Fatalf("DynamoDBEncoder.Encode: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := b.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// decodeDDBTree decodes fsm bytes through the real decode path into a
+// fresh output tree and returns its root.
+func decodeDDBTree(t *testing.T, fsm []byte) string {
+	t.Helper()
+	out := t.TempDir()
+	if _, err := DecodeSnapshot(bytes.NewReader(fsm), DecodeOptions{
+		OutRoot:  out,
+		Adapters: AdapterSet{DynamoDB: true},
+	}); err != nil {
+		t.Fatalf("DecodeSnapshot: %v", err)
+	}
+	return out
+}
+
+// readDDBSchema parses a decoded _schema.json for the given table.
+func readDDBSchema(t *testing.T, root, tableName string) ddbPublicSchema {
+	t.Helper()
+	dir := EncodeSegment([]byte(tableName))
+	data, err := os.ReadFile(filepath.Join(root, "dynamodb", dir, "_schema.json"))
+	if err != nil {
+		t.Fatalf("read decoded schema: %v", err)
+	}
+	var pub ddbPublicSchema
+	if err := json.Unmarshal(data, &pub); err != nil {
+		t.Fatalf("unmarshal decoded schema: %v", err)
+	}
+	return pub
+}
+
+// TestDDBEncodeSchemaRoundTripViaDecode runs the gold-standard
+// directory round-trip for a composite-key table with a GSI: the
+// schema (table name, primary key, attribute definitions, GSI) is
+// reconstructed into the !ddb|meta|table| record and recovered by the
+// decoder into an equivalent _schema.json.
+func TestDDBEncodeSchemaRoundTripViaDecode(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "orders"
+	input := ddbPublicSchema{
+		FormatVersion: 1,
+		TableName:     table,
+		PrimaryKey: publicKeySchema{
+			HashKey:  publicKeyAttribute{Name: "customer", Type: "S"},
+			RangeKey: publicKeyAttribute{Name: "ts", Type: "N"},
+		},
+		AttributeDefinitions: []publicAttributeDefinition{
+			{Name: "customer", Type: "S"},
+			{Name: "region", Type: "S"},
+			{Name: "ts", Type: "N"},
+		},
+		GlobalSecondaryIndexes: []publicGSI{{
+			Name: "by-region",
+			KeySchema: publicKeySchema{
+				HashKey:  publicKeyAttribute{Name: "region", Type: "S"},
+				RangeKey: publicKeyAttribute{Name: "ts", Type: "N"},
+			},
+			Projection: publicProjection{Type: "ALL"},
+		}},
+	}
+	body, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("marshal input schema: %v", err)
+	}
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), body)
+
+	out := decodeDDBTree(t, encodeDDBTree(t, in))
+	got := readDDBSchema(t, out, table)
+	assertCompositeOrdersSchema(t, got, table)
+}
+
+// assertCompositeOrdersSchema checks the round-tripped composite-key
+// "orders" schema (pk customer/ts, 3 attr defs, one GSI by-region/ALL).
+func assertCompositeOrdersSchema(t *testing.T, got ddbPublicSchema, table string) {
+	t.Helper()
+	if got.TableName != table {
+		t.Fatalf("table_name = %q, want %q", got.TableName, table)
+	}
+	assertKeyAttr(t, "hash", got.PrimaryKey.HashKey, "customer", "S")
+	assertKeyAttr(t, "range", got.PrimaryKey.RangeKey, "ts", "N")
+	if len(got.AttributeDefinitions) != 3 {
+		t.Fatalf("attr defs = %d, want 3", len(got.AttributeDefinitions))
+	}
+	if len(got.GlobalSecondaryIndexes) != 1 {
+		t.Fatalf("GSIs = %d, want 1", len(got.GlobalSecondaryIndexes))
+	}
+	gsi := got.GlobalSecondaryIndexes[0]
+	if gsi.Name != "by-region" || gsi.Projection.Type != "ALL" {
+		t.Fatalf("GSI = %+v, want by-region/ALL", gsi)
+	}
+	assertKeyAttr(t, "GSI hash", gsi.KeySchema.HashKey, "region", "S")
+}
+
+// assertKeyAttr checks one key attribute's name and type.
+func assertKeyAttr(t *testing.T, label string, got publicKeyAttribute, name, typ string) {
+	t.Helper()
+	if got.Name != name || got.Type != typ {
+		t.Fatalf("%s key = %+v, want %s/%s", label, got, name, typ)
+	}
+}
+
+// TestDDBEncodeHashOnlySchemaRoundTrip pins a hash-only (no range key)
+// table: the decoded schema omits the range key.
+func TestDDBEncodeHashOnlySchemaRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "sessions"
+	input := ddbPublicSchema{
+		FormatVersion: 1,
+		TableName:     table,
+		PrimaryKey: publicKeySchema{
+			HashKey: publicKeyAttribute{Name: "id", Type: "S"},
+		},
+		AttributeDefinitions: []publicAttributeDefinition{{Name: "id", Type: "S"}},
+	}
+	body, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), body)
+
+	out := decodeDDBTree(t, encodeDDBTree(t, in))
+	got := readDDBSchema(t, out, table)
+
+	if got.PrimaryKey.HashKey.Name != "id" {
+		t.Fatalf("hash key = %+v, want id", got.PrimaryKey.HashKey)
+	}
+	if got.PrimaryKey.RangeKey.Name != "" {
+		t.Fatalf("range key = %+v, want empty", got.PrimaryKey.RangeKey)
+	}
+}
+
+// TestDDBEncodeRejectsUnknownSchemaFormatVersion pins the format gate.
+func TestDDBEncodeRejectsUnknownSchemaFormatVersion(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	writeDDBSchema(t, in, "tbl", []byte(`{"format_version":99,"table_name":"x"}`))
+	b := newSnapshotBuilder(ddbEncTS)
+	err := NewDynamoDBEncoder(in).Encode(b)
+	if !errors.Is(err, ErrDDBEncodeInvalidSchema) {
+		t.Fatalf("Encode err = %v, want ErrDDBEncodeInvalidSchema", err)
+	}
+}
+
+// TestDDBEncodeMissingDirIsNoop pins that an absent dynamodb/ dir is a
+// no-op (no entries, no error).
+func TestDDBEncodeMissingDirIsNoop(t *testing.T) {
+	t.Parallel()
+	b := newSnapshotBuilder(ddbEncTS)
+	if err := NewDynamoDBEncoder(t.TempDir()).Encode(b); err != nil {
+		t.Fatalf("Encode on empty tree: %v", err)
+	}
+	if b.Len() != 0 {
+		t.Fatalf("got %d entries, want 0", b.Len())
+	}
+}


### PR DESCRIPTION
## Summary

**Phase 0b M3a — DynamoDB schema reverse encoder.** First slice of the DynamoDB reverse encoder (M3): table **schemas**. Reconstructs the `!ddb|meta|table|` schema record + `!ddb|meta|gen|` generation counter from each table's `_schema.json`. Item records (`!ddb|item|`, needing the ordered primary-key encoding) and derived GSI rows land in follow-up PRs on this milestone, matching how Redis (M2) shipped incrementally.

Builds on M1's `snapshotBuilder`. Design: `docs/design/2026_05_25_proposed_snapshot_logical_encoder.md`.

`internal/backup/encode_dynamodb.go`:
- **`publicToSchema`** — inverse of `dynamodb.go`'s `schemaToPublic`: rebuilds `pb.DynamoTableSchema` (TableName, PrimaryKey, AttributeDefinitions map, GSIs) from `_schema.json`. Stamps `KeyEncodingVersion=V2` (ordered) so the restored table reads items with the encoding the item encoder will produce.
- **Schema value** = `storedDDBSchemaMagic` + deterministic proto marshal; key = `!ddb|meta|table|<base64url(name)>`. Generation counter = `!ddb|meta|gen|<base64url(name)>` = decimal.
- Reads `_schema.json` through the same `os.Root` + post-open `IsRegular` + `refuseHardLink` + `decodeOneJSON` (trailing-data) + `format_version` gate the Redis encoders use.

## Decision gate: generation (design §"DynamoDB")

`_schema.json` carries no original generation, so the encoder stamps a uniform `ddbRestoreGeneration` into **both** the schema proto's `Generation` field **and** the `!ddb|meta|gen|` counter — and the item encoder (next PR) will embed the **same** generation in every `!ddb|item|` key, so the counter and item-key generation always agree. This is the **Option-B** path: internally consistent for a single-cluster restore; the original generation number is unrecoverable from the public dump. (Option A — adding a `generation` field to the decoder's `_schema.json` — remains available if exact-fidelity is later required.)

## Risk

New code only; no existing behavior changed. Offline-tool boundary preserved (proto/key formats reproduced, not imported from the live adapter).

## Self-review (5 lenses)

- **Data loss**: gold-standard directory round-trip via the **real** `DecodeSnapshot` confirms schema fidelity; fail-closed on bad `format_version` / non-regular file / hard-link.
- **Concurrency/distributed**: single-goroutine, one builder.
- **Performance**: streams each `_schema.json`.
- **Consistency**: proto/key formats pinned against the live store (schema magic, base64url meta key, decimal gen counter); generation coherent across schema + counter + (future) item keys.
- **Test coverage**: composite-key+GSI and hash-only round-trips; unknown-`format_version` rejection; missing-dir no-op.

## Test plan

- [x] `go test ./internal/backup/` (full package)
- [x] `golangci-lint run internal/backup/` (0 issues)
- [ ] Follow-up: `!ddb|item|` reverse encoder (ordered primary-key encoding) + GSI derivation gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end DynamoDB dump restore and item encoding support with deterministic encoding and strict validation; missing dump dirs are treated as no-ops.

* **Bug Fixes**
  * Improved validation to reject malformed schemas, duplicate definitions, unsupported numeric keys, non-regular files, and overly nested item layouts.

* **Tests**
  * Extensive tests covering round-trips, binary keys, edge cases, and all rejection scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/833?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->