### PR TITLE
backup: post-open IsRegular re-check in readRootFile (claude review #831)

### DIFF
--- a/internal/backup/encode_redis.go
+++ b/internal/backup/encode_redis.go
@@ -367,7 +367,7 @@ func readRootFile(root *os.Root, name string) ([]byte, error) {
 	// stale, so a FIFO/device swapped in between ReadDir and Open
 	// would otherwise reach io.ReadAll (blocking, or reading
 	// attacker-controlled bytes from a writer-attached FIFO). The
-	// post-open fstat is authoritative (claude review on PR #831).
+	// post-open fstat is authoritative; the ReadDir type is not.
 	if !info.Mode().IsRegular() {
 		return nil, errors.Wrapf(ErrRedisEncodeNotRegular, "%s (mode=%s)", name, info.Mode())
 	}

--- a/internal/backup/encode_redis.go
+++ b/internal/backup/encode_redis.go
@@ -363,6 +363,14 @@ func readRootFile(root *os.Root, name string) ([]byte, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	// Re-check regularity on the OPEN fd: the ReadDir entry type is
+	// stale, so a FIFO/device swapped in between ReadDir and Open
+	// would otherwise reach io.ReadAll (blocking, or reading
+	// attacker-controlled bytes from a writer-attached FIFO). The
+	// post-open fstat is authoritative (claude review on PR #831).
+	if !info.Mode().IsRegular() {
+		return nil, errors.Wrapf(ErrRedisEncodeNotRegular, "%s (mode=%s)", name, info.Mode())
+	}
 	if err := refuseHardLink(info, name); err != nil {
 		return nil, err
 	}

--- a/internal/backup/encode_redis_test.go
+++ b/internal/backup/encode_redis_test.go
@@ -296,8 +296,7 @@ func TestRedisEncodeRejectsNonRegularTTLSidecar(t *testing.T) {
 // (blocking on a writer-attached FIFO, or ingesting attacker-controlled
 // bytes). A directory is the cross-platform stand-in — it opens cleanly
 // but fstat reports non-regular, so readRootFile must fail closed with
-// ErrRedisEncodeNotRegular rather than reading it (claude review on PR
-// #831).
+// ErrRedisEncodeNotRegular rather than reading it.
 func TestReadRootFileRejectsNonRegularPostOpen(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/backup/encode_redis_test.go
+++ b/internal/backup/encode_redis_test.go
@@ -289,6 +289,31 @@ func TestRedisEncodeRejectsNonRegularTTLSidecar(t *testing.T) {
 	}
 }
 
+// TestReadRootFileRejectsNonRegularPostOpen pins the post-open fstat
+// guard in readRootFile, which is distinct from the walk's pre-open
+// ReadDir-type filter: the ReadDir entry type is stale, so a FIFO/device
+// swapped in between ReadDir and Open would otherwise reach io.ReadAll
+// (blocking on a writer-attached FIFO, or ingesting attacker-controlled
+// bytes). A directory is the cross-platform stand-in — it opens cleanly
+// but fstat reports non-regular, so readRootFile must fail closed with
+// ErrRedisEncodeNotRegular rather than reading it (claude review on PR
+// #831).
+func TestReadRootFileRejectsNonRegularPostOpen(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "notafile.bin"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatalf("OpenRoot: %v", err)
+	}
+	defer func() { _ = root.Close() }()
+	if _, err := readRootFile(root, "notafile.bin"); !errors.Is(err, ErrRedisEncodeNotRegular) {
+		t.Fatalf("readRootFile err = %v, want ErrRedisEncodeNotRegular", err)
+	}
+}
+
 // writeKeymap writes a single-entry KEYMAP.jsonl mapping the encoded
 // segment back to its original bytes (base64url, the KeymapRecord
 // schema), under <root>/redis/db_0/.


### PR DESCRIPTION
## Summary

**Post-open `IsRegular` re-check in `readRootFile`** — a security hardening claude flagged during the PR #831 review that merged without the fix.

`readRootFile` (the Redis blob `*.bin` reader) is reached via `walkBlobDir` → `handleBlobEntry`, which pre-filters entries by the **ReadDir** entry type (`ent.Type().IsRegular()`). That type is **stale**: a FIFO/device swapped in for a `*.bin` between `ReadDir` and `root.Open` passes the stale check and reaches `io.ReadAll` — blocking on a writer-attached FIFO, or ingesting attacker-controlled bytes. This adds the authoritative **post-open fstat** `IsRegular` check (the read-side analogue of the post-open guard the JSON-collection walk paths already use), ordered before `refuseHardLink` so a non-regular target is classified as not-regular rather than hard-linked.

## Risk

Hardening only; tightens an untrusted-dump-input boundary in the offline encode tool. No change to the happy path (regular `.bin` files read identically).

## Self-review (5 lenses)

- **Data loss**: none — read-only offline tool; rejects bad input rather than dropping good data.
- **Concurrency/distributed**: closes a TOCTOU window (stale ReadDir type vs. authoritative post-open fstat) in a single-goroutine offline encoder.
- **Performance**: one extra `Mode()` comparison on an already-`Stat`'d fd; no new syscall.
- **Consistency**: matches the post-open `IsRegular` pattern already used by the JSON-collection walk and the DDB schema reader.
- **Test coverage**: new co-located regression test calls `readRootFile` on a directory (cross-platform non-regular stand-in) and asserts `ErrRedisEncodeNotRegular`; confirmed failing without the guard (returned the hard-link error) and passing with it.

## Test plan

- [x] `go test ./internal/backup/` (full package)
- [x] `golangci-lint run internal/backup/` (0 issues)
- [x] Regression test fails without the guard, passes with it (verified by temporarily reverting the guard)
