### PR TITLE
feat(keyviz): per-route sub-range (hot-key) sampling (Phase 2-A+)

### DIFF
--- a/adapter/admin_grpc.go
+++ b/adapter/admin_grpc.go
@@ -684,10 +684,18 @@ func rowActivityTotal(r *pb.KeyVizRow) uint64 {
 // to trust route_count for drill-down decisions.
 func newKeyVizRowFrom(mr keyviz.MatrixRow, numCols int) *pb.KeyVizRow {
 	total := mr.MemberRoutesTotal
-	if !mr.Aggregate && total == 0 {
+	switch {
+	case !mr.Aggregate && total == 0:
 		// Individual slots fall through to RouteCount=1 when the
 		// sampler predates MemberRoutesTotal or never set it.
 		total = 1
+	case mr.Aggregate && total == 0:
+		// Defensive fallback mirroring the JSON pivot
+		// (keyviz_handler.go): a just-coalesced virtual bucket
+		// serialized before its count is set would otherwise render
+		// "0 routes", which is nonsense for an aggregate. Fall back to
+		// the visible member count so route_count stays meaningful.
+		total = uint64(len(mr.MemberRoutes))
 	}
 	row := &pb.KeyVizRow{
 		BucketId:          bucketIDFor(mr),

--- a/adapter/admin_grpc.go
+++ b/adapter/admin_grpc.go
@@ -600,16 +600,23 @@ func matrixToProto(cols []keyviz.MatrixColumn, pick func(keyviz.MatrixRow) uint6
 	resp := &pb.GetKeyVizMatrixResponse{
 		ColumnUnixMs: make([]int64, len(cols)),
 	}
-	rowsByID := make(map[uint64]*pb.KeyVizRow)
-	order := make([]uint64, 0)
+	// Keyed by BucketId, not bare RouteID: sub-range bucketing gives a
+	// route's sub-rows the same RouteID, so keying on RouteID would
+	// collide them. BucketId embeds the sub-bucket index when
+	// SubBucketCount > 1, so it is unique per (route, sub-bucket). The
+	// proto KeyVizRow needs no new field — the BucketId distinguishes
+	// sub-rows. See design §5.1.
+	rowsByID := make(map[string]*pb.KeyVizRow)
+	order := make([]string, 0)
 	for j, col := range cols {
 		resp.ColumnUnixMs[j] = col.At.UnixMilli()
 		for _, mr := range col.Rows {
-			pr, ok := rowsByID[mr.RouteID]
+			id := bucketIDFor(mr)
+			pr, ok := rowsByID[id]
 			if !ok {
 				pr = newKeyVizRowFrom(mr, len(cols))
-				rowsByID[mr.RouteID] = pr
-				order = append(order, mr.RouteID)
+				rowsByID[id] = pr
+				order = append(order, id)
 			}
 			pr.Values[j] = pick(mr)
 			// Per-cell Raft identity stamped from this column's
@@ -698,7 +705,13 @@ func bucketIDFor(mr keyviz.MatrixRow) string {
 	if mr.Aggregate {
 		return "virtual:" + strconv.FormatUint(mr.RouteID, 10)
 	}
-	return "route:" + strconv.FormatUint(mr.RouteID, 10)
+	id := "route:" + strconv.FormatUint(mr.RouteID, 10)
+	// Sub-bucket suffix only for genuinely sub-divided routes, so K=1 /
+	// aggregate / degenerate slots keep the exact legacy id. See §5.1.
+	if mr.SubBucketCount > 1 {
+		id += "#" + strconv.Itoa(mr.SubBucket)
+	}
+	return id
 }
 
 func sortKeyVizRowsByStart(rows []*pb.KeyVizRow) {

--- a/adapter/admin_grpc.go
+++ b/adapter/admin_grpc.go
@@ -652,7 +652,15 @@ func applyKeyVizRowBudget(rows []*pb.KeyVizRow, budget int) []*pb.KeyVizRow {
 		return rows
 	}
 	sort.Slice(rows, func(i, j int) bool {
-		return rowActivityTotal(rows[i]) > rowActivityTotal(rows[j])
+		ai, aj := rowActivityTotal(rows[i]), rowActivityTotal(rows[j])
+		if ai != aj {
+			return ai > aj
+		}
+		// Deterministic tie-break by BucketId so the retained set is
+		// stable across refreshes when sub-rows share an activity total
+		// (e.g. a uniformly-loaded route's K sub-buckets). Mirrors the
+		// JSON pivot's budget sort (keyviz_handler.go).
+		return rows[i].BucketId < rows[j].BucketId
 	})
 	return rows[:budget]
 }

--- a/adapter/admin_grpc_subrange_test.go
+++ b/adapter/admin_grpc_subrange_test.go
@@ -37,6 +37,23 @@ func TestMatrixToProtoSubRowsDoNotCollide(t *testing.T) {
 	require.Equal(t, []uint64{9}, byID["route:1#1"])
 }
 
+// TestNewKeyVizRowFromAggregateZeroTotalFallback pins the adapter/handler
+// harmonization (Claude round-2 follow-up): an aggregate row whose
+// MemberRoutesTotal is still 0 (a just-coalesced bucket serialized before
+// its count is set) reports route_count = len(MemberRoutes) rather than
+// the nonsensical 0 — matching the JSON pivot's defensive fallback.
+func TestNewKeyVizRowFromAggregateZeroTotalFallback(t *testing.T) {
+	t.Parallel()
+	mr := keyviz.MatrixRow{
+		RouteID:           99,
+		Aggregate:         true,
+		MemberRoutes:      []uint64{1, 2, 3},
+		MemberRoutesTotal: 0, // not yet set
+	}
+	row := newKeyVizRowFrom(mr, 1)
+	require.Equal(t, uint64(3), row.RouteCount, "aggregate with total=0 must fall back to len(MemberRoutes)")
+}
+
 // TestMatrixToProtoK1KeepsLegacyBucketID pins that a non-sub-divided row
 // keeps the exact legacy "route:<id>" BucketId (no #suffix).
 func TestMatrixToProtoK1KeepsLegacyBucketID(t *testing.T) {

--- a/adapter/admin_grpc_subrange_test.go
+++ b/adapter/admin_grpc_subrange_test.go
@@ -1,0 +1,56 @@
+package adapter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bootjp/elastickv/keyviz"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMatrixToProtoSubRowsDoNotCollide is the adapter-side twin of the
+// admin pivot-collision regression: sub-rows of one route share its
+// RouteID, so the proto pivot must key on BucketId (which embeds
+// #subIdx) rather than RouteID, or it would collapse them. The proto
+// KeyVizRow needs no new field — BucketId distinguishes the sub-rows.
+// See design §5.1.
+func TestMatrixToProtoSubRowsDoNotCollide(t *testing.T) {
+	t.Parallel()
+	pick := func(r keyviz.MatrixRow) uint64 { return r.Writes }
+	cols := []keyviz.MatrixColumn{
+		{
+			At: time.Unix(1_700_000_000, 0),
+			Rows: []keyviz.MatrixRow{
+				{RouteID: 1, Start: []byte{0x00}, End: []byte{0x10}, SubBucket: 0, SubBucketCount: 2, Writes: 5},
+				{RouteID: 1, Start: []byte{0x10}, End: []byte{0x20}, SubBucket: 1, SubBucketCount: 2, Writes: 9},
+			},
+		},
+	}
+	resp := matrixToProto(cols, pick, 1024)
+	require.Len(t, resp.Rows, 2, "two sub-rows of the same route must not collide")
+
+	byID := map[string][]uint64{}
+	for _, r := range resp.Rows {
+		byID[r.BucketId] = r.Values
+	}
+	require.Equal(t, []uint64{5}, byID["route:1#0"])
+	require.Equal(t, []uint64{9}, byID["route:1#1"])
+}
+
+// TestMatrixToProtoK1KeepsLegacyBucketID pins that a non-sub-divided row
+// keeps the exact legacy "route:<id>" BucketId (no #suffix).
+func TestMatrixToProtoK1KeepsLegacyBucketID(t *testing.T) {
+	t.Parallel()
+	pick := func(r keyviz.MatrixRow) uint64 { return r.Writes }
+	cols := []keyviz.MatrixColumn{
+		{
+			At: time.Unix(1_700_000_000, 0),
+			Rows: []keyviz.MatrixRow{
+				{RouteID: 7, Start: []byte{0x00}, End: []byte{0xFF}, SubBucket: 0, SubBucketCount: 1, Writes: 3},
+			},
+		},
+	}
+	resp := matrixToProto(cols, pick, 1024)
+	require.Len(t, resp.Rows, 1)
+	require.Equal(t, "route:7", resp.Rows[0].BucketId)
+}

--- a/internal/admin/keyviz_handler.go
+++ b/internal/admin/keyviz_handler.go
@@ -337,16 +337,22 @@ func pivotKeyVizColumns(cols []keyviz.MatrixColumn, series KeyVizSeries, rowBudg
 		Series:       series,
 		ColumnUnixMs: make([]int64, len(cols)),
 	}
-	rowsByID := make(map[uint64]*KeyVizRow)
-	order := make([]uint64, 0)
+	// Keyed by BucketID, not bare RouteID: with sub-range bucketing a
+	// route's sub-rows all share its RouteID, so keying on RouteID would
+	// collide them and drop all but the last per column. BucketID embeds
+	// the sub-bucket index (#subIdx) when SubBucketCount > 1, so it is
+	// unique per (route, sub-bucket). See design §5.1.
+	rowsByID := make(map[string]*KeyVizRow)
+	order := make([]string, 0)
 	for j, col := range cols {
 		matrix.ColumnUnixMs[j] = col.At.UnixMilli()
 		for _, mr := range col.Rows {
-			row, ok := rowsByID[mr.RouteID]
+			id := bucketIDFor(mr)
+			row, ok := rowsByID[id]
 			if !ok {
 				row = newKeyVizRowFrom(mr, len(cols))
-				rowsByID[mr.RouteID] = row
-				order = append(order, mr.RouteID)
+				rowsByID[id] = row
+				order = append(order, id)
 			}
 			v := pick(mr)
 			row.Values[j] = v
@@ -424,7 +430,16 @@ func bucketIDFor(mr keyviz.MatrixRow) string {
 	if mr.Aggregate {
 		return "virtual:" + strconv.FormatUint(mr.RouteID, 10)
 	}
-	return "route:" + strconv.FormatUint(mr.RouteID, 10)
+	id := "route:" + strconv.FormatUint(mr.RouteID, 10)
+	// Append the sub-bucket index only for genuinely sub-divided routes
+	// (SubBucketCount > 1), so a K=1 / aggregate / degenerate slot keeps
+	// the exact legacy "route:<id>" id and the change stays inert at the
+	// default. SubBucket == 0 alone can't disambiguate (a K=1 slot's
+	// only row and a K>1 slot's bucket-0 row both have it).
+	if mr.SubBucketCount > 1 {
+		id += "#" + strconv.Itoa(mr.SubBucket)
+	}
+	return id
 }
 
 // applyKeyVizRowBudget mirrors the adapter Phase-1 simplification:

--- a/internal/admin/keyviz_subrange_test.go
+++ b/internal/admin/keyviz_subrange_test.go
@@ -1,0 +1,93 @@
+package admin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bootjp/elastickv/keyviz"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPivotKeyVizColumnsSubRowsDoNotCollide is the Gemini-HIGH
+// regression: sub-rows of one route share its RouteID, so a pivot keyed
+// on bare RouteID would collapse them into one row and drop all but the
+// last. Keying on BucketID (which embeds #subIdx when SubBucketCount>1)
+// keeps each sub-bucket a distinct output row. See design §5.1.
+func TestPivotKeyVizColumnsSubRowsDoNotCollide(t *testing.T) {
+	t.Parallel()
+	at := time.Unix(1_700_000_000, 0)
+	cols := []keyviz.MatrixColumn{
+		{
+			At: at,
+			Rows: []keyviz.MatrixRow{
+				{RouteID: 1, Start: []byte{0x00}, End: []byte{0x10}, SubBucket: 0, SubBucketCount: 2, Writes: 5},
+				{RouteID: 1, Start: []byte{0x10}, End: []byte{0x20}, SubBucket: 1, SubBucketCount: 2, Writes: 9},
+			},
+		},
+	}
+	m := pivotKeyVizColumns(cols, keyVizSeriesWrites, keyVizRowBudgetCap)
+	require.Len(t, m.Rows, 2, "two sub-rows of the same route must not collide")
+
+	byID := map[string]KeyVizRow{}
+	for _, r := range m.Rows {
+		byID[r.BucketID] = r
+	}
+	require.Contains(t, byID, "route:1#0")
+	require.Contains(t, byID, "route:1#1")
+	require.Equal(t, []uint64{5}, byID["route:1#0"].Values)
+	require.Equal(t, []uint64{9}, byID["route:1#1"].Values)
+}
+
+// TestPivotKeyVizColumnsK1KeepsLegacyBucketID pins backward
+// compatibility: a non-sub-divided row (SubBucketCount<=1) keeps the
+// exact "route:<id>" BucketID with no #suffix.
+func TestPivotKeyVizColumnsK1KeepsLegacyBucketID(t *testing.T) {
+	t.Parallel()
+	cols := []keyviz.MatrixColumn{
+		{
+			At: time.Unix(1_700_000_000, 0),
+			Rows: []keyviz.MatrixRow{
+				{RouteID: 7, Start: []byte{0x00}, End: []byte{0xFF}, SubBucket: 0, SubBucketCount: 1, Writes: 3},
+			},
+		},
+	}
+	m := pivotKeyVizColumns(cols, keyVizSeriesWrites, keyVizRowBudgetCap)
+	require.Len(t, m.Rows, 1)
+	require.Equal(t, "route:7", m.Rows[0].BucketID)
+}
+
+// TestMergeKeyVizMatricesMixedKCoexist pins the §9 decision 2: in a
+// mixed-K cluster a K=1 peer emits "route:1" while a K=2 peer emits
+// "route:1#0"/"route:1#1". Because the merge dedupes by BucketID these
+// do NOT merge — they coexist as distinct rows (the K=1 row does not
+// absorb the sub-rows or vice versa).
+func TestMergeKeyVizMatricesMixedKCoexist(t *testing.T) {
+	t.Parallel()
+	col := []int64{1_700_000_000_000}
+	k1Peer := KeyVizMatrix{
+		ColumnUnixMs: col,
+		Series:       keyVizSeriesWrites,
+		Rows: []KeyVizRow{
+			{BucketID: "route:1", Start: []byte{0x00}, End: []byte{0x20}, Values: []uint64{40}},
+		},
+	}
+	k2Peer := KeyVizMatrix{
+		ColumnUnixMs: col,
+		Series:       keyVizSeriesWrites,
+		Rows: []KeyVizRow{
+			{BucketID: "route:1#0", Start: []byte{0x00}, End: []byte{0x10}, Values: []uint64{25}},
+			{BucketID: "route:1#1", Start: []byte{0x10}, End: []byte{0x20}, Values: []uint64{15}},
+		},
+	}
+	merged := mergeKeyVizMatrices([]KeyVizMatrix{k1Peer, k2Peer}, keyVizSeriesWrites)
+	require.Len(t, merged.Rows, 3, "K=1 row and the two K=2 sub-rows must coexist, not merge")
+
+	byID := map[string][]uint64{}
+	for _, r := range merged.Rows {
+		byID[r.BucketID] = r.Values
+		require.False(t, r.Conflict, "distinct-bucket coexistence is not a conflict")
+	}
+	require.Equal(t, []uint64{40}, byID["route:1"])
+	require.Equal(t, []uint64{25}, byID["route:1#0"])
+	require.Equal(t, []uint64{15}, byID["route:1#1"])
+}

--- a/keyviz/flusher_test.go
+++ b/keyviz/flusher_test.go
@@ -21,7 +21,7 @@ func TestRunFlusherTicksUntilCancel(t *testing.T) {
 
 	// Drive Observe across ticker firings.
 	for i := 0; i < 10; i++ {
-		s.Observe(1, OpRead, 0, 0)
+		s.Observe(1, make([]byte, 0), OpRead, 0)
 		time.Sleep(2 * time.Millisecond)
 	}
 	cancel()

--- a/keyviz/sampler.go
+++ b/keyviz/sampler.go
@@ -31,6 +31,9 @@ package keyviz
 
 import (
 	"bytes"
+	"encoding/binary"
+	"math"
+	"math/bits"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -67,11 +70,13 @@ const (
 // call site only checks for an interface-nil, not a typed-nil.
 type Sampler interface {
 	// Observe records a single request against a route. Op identifies
-	// the counter family. keyLen and valueLen are summed into the
-	// matching *Bytes counter; pass 0 for read-only ops where the
-	// payload size is irrelevant. Implementations must no-op (not
-	// panic) when invoked on a typed-nil receiver.
-	Observe(routeID uint64, op Op, keyLen, valueLen int)
+	// the counter family. The key drives sub-range bucketing (the hot
+	// key/sub-range heatmap, see docs/design/2026_05_25_proposed_keyviz_subrange_sampling.md);
+	// len(key) and valueLen are summed into the matching *Bytes
+	// counter; pass valueLen 0 for read-only ops where the response
+	// size is irrelevant. Implementations must no-op (not panic) when
+	// invoked on a typed-nil receiver.
+	Observe(routeID uint64, key []byte, op Op, valueLen int)
 }
 
 // Defaults for MemSamplerOptions when fields are left zero.
@@ -80,7 +85,26 @@ const (
 	DefaultHistoryColumns         = 1440 // 24 hours at 60s steps.
 	DefaultMaxTrackedRoutes       = 10_000
 	DefaultMaxMemberRoutesPerSlot = 256
+	// DefaultKeyBucketsPerRoute is 1 — no sub-range bucketing, i.e.
+	// today's exact route-granular behaviour. Operators opt into
+	// hot-key sub-range sampling by raising it.
+	DefaultKeyBucketsPerRoute = 1
 )
+
+// MaxKeyBucketsPerRoute caps KeyBucketsPerRoute. The cap is an
+// operationally-safe bound, not merely a finite one: per-route memory
+// is K × 4 × 8 bytes, so at the default MaxTrackedRoutes = 10_000 the
+// cap of 256 bounds the worst case to ~80 MB of counters (vs ~1.28 GB
+// at K=4096, which a monitoring subsystem must not need). The design's
+// operator rule of thumb is K_max ≈ memBudget / (32 × MaxTrackedRoutes).
+const MaxKeyBucketsPerRoute = 256
+
+// subWindowBytes is the W from the design: the fixed byte window past
+// the route's Start/End common prefix that the bucketer interpolates
+// over. Eight bytes (one uint64) gives enough resolution for K up to
+// the cap; keys whose distinguishing bytes sit past prefixLen + W
+// collapse the route to a single bucket (computeSubLayout).
+const subWindowBytes = 8
 
 // MaxHistoryColumns is the upper bound on opts.HistoryColumns. The
 // ring buffer pre-allocates a slice of capacity HistoryColumns at
@@ -113,6 +137,13 @@ type MemSamplerOptions struct {
 	// MaxTrackedRoutes. Snapshot consumers should treat the list as
 	// "first N members" rather than authoritative attribution.
 	MaxMemberRoutesPerSlot int
+	// KeyBucketsPerRoute (K) is how many order-preserving sub-range
+	// buckets each individual route's [Start, End) is divided into for
+	// the hot-key heatmap. 1 (the default) disables sub-bucketing and
+	// reproduces today's route-granular behaviour exactly. Clamped to
+	// [1, MaxKeyBucketsPerRoute] at construction. Virtual aggregate
+	// buckets are never sub-divided regardless of this value.
+	KeyBucketsPerRoute int
 	// Now overrides time.Now for tests; nil falls back to time.Now.
 	Now func() time.Time
 }
@@ -270,6 +301,40 @@ type routeSlot struct {
 	// slots.
 	MemberRoutesTotal uint64
 
+	// Sub-range layout (the hot-key heatmap). These fields are
+	// established once when the slot's range is set (RegisterRoute via
+	// initSubLayout) and are IMMUTABLE for the slot's lifetime — they
+	// are NOT recomputed on grace-window re-registration. So the hot
+	// path (subBucketIndex) and Flush (bound reconstruction) both read
+	// them lock-free; there is no writer to race with. See the design
+	// doc §4.2.
+	//
+	// subSpan == 0 (and len(subBuckets) == 1) marks a slot that is not
+	// sub-divided: K==1, a virtual aggregate, a degenerate window
+	// (subEnd <= subStart), or an unbounded-tail route (End == nil).
+	// subBucketIndex then hard-wires the index to 0, collapsing to
+	// today's route-level behaviour.
+	subPrefixLen int
+	subStart     uint64
+	subEnd       uint64
+	subSpan      uint64
+	// subLo/subHi are immutable copies of the route bounds the layout
+	// was built from, used by subBucketIndex's full-key edge clamp.
+	// They are NOT slot.Start/End (which are mutable under metaMu on
+	// grace-window re-registration and so can't be read on the lock-free
+	// hot path) — they are part of the immutable layout. nil for
+	// single-bucket slots (the clamp is unreachable there).
+	subLo      []byte
+	subHi      []byte
+	subBuckets []subCounter
+}
+
+// subCounter holds one sub-range bucket's four counter families. A
+// routeSlot owns len(subBuckets) of these (>= 1). Touched by Observe
+// (atomic.Add) and Flush (atomic.Swap); never value-copied (slots are
+// shared by pointer, and the slice is indexed in place), so the
+// embedded atomics are safe.
+type subCounter struct {
 	reads      atomic.Uint64
 	writes     atomic.Uint64
 	readBytes  atomic.Uint64
@@ -325,6 +390,20 @@ type MatrixRow struct {
 	RaftGroupID uint64
 	LeaderTerm  uint64
 
+	// SubBucket is this row's sub-range index within its parent route,
+	// 0 for the first (or only) sub-bucket. SubBucketCount is how many
+	// sub-buckets the route is divided into: 1 for a K==1 / aggregate /
+	// degenerate / unbounded-tail slot, > 1 for a genuinely sub-divided
+	// route. SubBucketCount is the disambiguator a row's BucketID
+	// suffix needs — a K==1 slot's only row and a K>1 slot's bucket-0
+	// row both have SubBucket == 0, so the count is what tells them
+	// apart (the #subIdx suffix is added only when SubBucketCount > 1).
+	// Both are int (bounded 0..MaxKeyBucketsPerRoute); they are
+	// keyviz-internal (the proto KeyVizRow has no equivalent), so no
+	// fixed-width type is required.
+	SubBucket      int
+	SubBucketCount int
+
 	Reads      uint64
 	Writes     uint64
 	ReadBytes  uint64
@@ -351,6 +430,12 @@ func NewMemSampler(opts MemSamplerOptions) *MemSampler {
 	}
 	if opts.MaxMemberRoutesPerSlot <= 0 {
 		opts.MaxMemberRoutesPerSlot = DefaultMaxMemberRoutesPerSlot
+	}
+	if opts.KeyBucketsPerRoute <= 0 {
+		opts.KeyBucketsPerRoute = DefaultKeyBucketsPerRoute
+	}
+	if opts.KeyBucketsPerRoute > MaxKeyBucketsPerRoute {
+		opts.KeyBucketsPerRoute = MaxKeyBucketsPerRoute
 	}
 	now := opts.Now
 	if now == nil {
@@ -424,7 +509,7 @@ func newEmptyRouteTable() *routeTable {
 // and bytes). Misses (RouteID never registered) drop silently — the
 // route-watch subscriber is responsible for Register before the
 // coordinator publishes the new RouteID.
-func (s *MemSampler) Observe(routeID uint64, op Op, keyLen, valueLen int) {
+func (s *MemSampler) Observe(routeID uint64, key []byte, op Op, valueLen int) {
 	if s == nil {
 		return
 	}
@@ -436,25 +521,207 @@ func (s *MemSampler) Observe(routeID uint64, op Op, keyLen, valueLen int) {
 			return
 		}
 	}
+	// Sub-range bucketing: pick the counter for the key's sub-bucket.
+	// subBucketIndex reads only immutable layout fields (lock-free) and
+	// returns 0 for non-sub-divided slots (len == 1), so this is one
+	// extra index computation versus today on the hot path.
+	sc := &slot.subBuckets[slot.subBucketIndex(key)]
 	byteCount := uint64(0)
-	if keyLen > 0 {
-		byteCount += uint64(keyLen)
+	if len(key) > 0 {
+		byteCount += uint64(len(key))
 	}
 	if valueLen > 0 {
 		byteCount += uint64(valueLen)
 	}
 	switch op {
 	case OpRead:
-		slot.reads.Add(1)
+		sc.reads.Add(1)
 		if byteCount > 0 {
-			slot.readBytes.Add(byteCount)
+			sc.readBytes.Add(byteCount)
 		}
 	case OpWrite:
-		slot.writes.Add(1)
+		sc.writes.Add(1)
 		if byteCount > 0 {
-			slot.writeBytes.Add(byteCount)
+			sc.writeBytes.Add(byteCount)
 		}
 	}
+}
+
+// subBucketIndex maps key to a sub-range bucket index in
+// [0, len(slot.subBuckets)). Lock-free: reads only the slot's immutable
+// sub-layout fields. Returns 0 for non-sub-divided slots (len == 1 or
+// subSpan == 0). See design §3.1.
+func (slot *routeSlot) subBucketIndex(key []byte) int {
+	k := len(slot.subBuckets)
+	if k <= 1 || slot.subSpan == 0 {
+		return 0
+	}
+	// Full-key edge clamp FIRST. The window only sees bytes past the
+	// Start/End common prefix, so two keys that differ *within* that
+	// prefix (i.e. a key outside [subLo, subHi)) would otherwise bucket
+	// on their window alone and break global order preservation. Keys
+	// inside the route share the prefix, so for them the window is
+	// monotone; out-of-range keys pin to the boundary buckets.
+	if bytes.Compare(key, slot.subLo) <= 0 {
+		return 0
+	}
+	if bytes.Compare(key, slot.subHi) >= 0 {
+		return k - 1
+	}
+	w := windowUint64(key, slot.subPrefixLen)
+	// In-range keys satisfy subStart <= w <= subEnd; these guards make
+	// the subtraction underflow-proof and handle the window-equals-edge
+	// case (keys that match Start/End in the first W suffix bytes).
+	if w <= slot.subStart {
+		return 0
+	}
+	if w >= slot.subEnd {
+		return k - 1
+	}
+	idx := fracMul(u64NonNeg(k), w-slot.subStart, slot.subSpan)
+	if idx >= u64NonNeg(k) {
+		// Defensive only — the interior guard guarantees idx <= k-1.
+		return k - 1
+	}
+	return intFromUint64(idx)
+}
+
+// u64NonNeg converts a known-non-negative int (a sub-bucket index or
+// count, always 0..MaxKeyBucketsPerRoute, or a slice length) to uint64.
+// The explicit guard makes gosec's G115 — which flags every int->uint64
+// as a possible negative wrap — provably safe without a //nolint, which
+// CLAUDE.md forbids.
+func u64NonNeg(n int) uint64 {
+	if n < 0 {
+		return 0
+	}
+	return uint64(n)
+}
+
+// intFromUint64 narrows a uint64 that is known to fit in an int (here a
+// sub-bucket index proven < k <= MaxKeyBucketsPerRoute). The math.MaxInt
+// guard is the in-tree idiom gosec G115 accepts (cf. internal.Uint64ToInt).
+func intFromUint64(v uint64) int {
+	if v > math.MaxInt {
+		return math.MaxInt
+	}
+	return int(v)
+}
+
+// fracMul returns floor(a*b/c) with an exact 128-bit intermediate via
+// math/bits, so the multiply cannot overflow uint64. Callers guarantee
+// c > 0 and the quotient < 2^64 (both hold for sub-bucket math: the
+// interior guard bounds a*b below c*2^64 because k is capped well below
+// 2^64). Shared by the forward index path and the Flush bound
+// reconstruction so the two can never diverge.
+func fracMul(a, b, c uint64) uint64 {
+	hi, lo := bits.Mul64(a, b)
+	q, _ := bits.Div64(hi, lo, c)
+	return q
+}
+
+// windowUint64 reads up to subWindowBytes of b starting at off,
+// big-endian, zero-padding past the end of b. A short/absent window is
+// the natural low end (0x00…) of the key space.
+func windowUint64(b []byte, off int) uint64 {
+	var v uint64
+	for i := 0; i < subWindowBytes; i++ {
+		v <<= 8
+		if off+i < len(b) {
+			v |= uint64(b[off+i])
+		}
+	}
+	return v
+}
+
+// initSubLayout computes the immutable sub-range layout for an
+// individual route spanning [start, end) and allocates its subBuckets.
+// Called once at slot creation (off the hot path). A route that cannot
+// be sub-divided — K == 1, an unbounded `end`, or a window that
+// captures no difference — gets a single bucket (subSpan 0), which
+// makes subBucketIndex hard-wire to 0 and reproduces today's behaviour.
+func (s *MemSampler) initSubLayout(slot *routeSlot, start, end []byte) {
+	prefixLen, subStart, subEnd, subSpan, effK := computeSubLayout(start, end, s.opts.KeyBucketsPerRoute)
+	slot.subPrefixLen = prefixLen
+	slot.subStart = subStart
+	slot.subEnd = subEnd
+	slot.subSpan = subSpan
+	if effK > 1 {
+		// Immutable bound snapshots for subBucketIndex's full-key clamp.
+		slot.subLo = cloneBytes(start)
+		slot.subHi = cloneBytes(end)
+	}
+	slot.subBuckets = make([]subCounter, effK)
+}
+
+// computeSubLayout derives the sub-range layout for [start, end) divided
+// into k buckets. effK is the effective bucket count: 1 (single bucket,
+// subSpan 0) when the route cannot be sub-divided, otherwise k. See
+// design §3.1–§3.2.
+func computeSubLayout(start, end []byte, k int) (prefixLen int, subStart, subEnd, subSpan uint64, effK int) {
+	if k <= 1 || len(end) == 0 {
+		// K == 1, or an unbounded high end (no finite span to divide):
+		// a single bucket until a split gives the route a finite End.
+		return 0, 0, 0, 0, 1
+	}
+	prefixLen = commonPrefixLen(start, end)
+	subStart = windowUint64(start, prefixLen)
+	subEnd = windowUint64(end, prefixLen)
+	if subEnd <= subStart {
+		// The W-byte window captures no difference (the routes differ
+		// only past prefixLen + W): single bucket.
+		return prefixLen, subStart, subEnd, 0, 1
+	}
+	return prefixLen, subStart, subEnd, subEnd - subStart, k
+}
+
+// commonPrefixLen returns the number of leading bytes a and b share.
+func commonPrefixLen(a, b []byte) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	i := 0
+	for i < n && a[i] == b[i] {
+		i++
+	}
+	return i
+}
+
+// subBucketBounds reconstructs the [start, end) key bounds of sub-bucket
+// i for a slot divided into len(subBuckets) buckets. Bucket 0 pins to
+// the route's actual start and the last bucket pins to its actual end
+// (the window arithmetic drops bytes past prefixLen + W, so the
+// reconstructed extremes would otherwise fall short); interiors use the
+// same fracMul kernel as the forward path. Together this tiles
+// [routeStart, routeEnd) exactly — each bucket's start equals the
+// previous bucket's end. Caller guarantees len(subBuckets) > 1.
+func (slot *routeSlot) subBucketBounds(i int, routeStart, routeEnd []byte) (start, end []byte) {
+	last := len(slot.subBuckets) - 1
+	if i == 0 {
+		start = cloneBytes(routeStart)
+	} else {
+		start = slot.boundaryAt(i, routeStart)
+	}
+	if i == last {
+		end = cloneBytes(routeEnd)
+	} else {
+		end = slot.boundaryAt(i+1, routeStart)
+	}
+	return start, end
+}
+
+// boundaryAt reconstructs the key at fraction i/k of the route's window:
+// subStart + floor(i*subSpan/k), written big-endian into the W-byte
+// window at subPrefixLen, behind the route's shared prefix. Uses the
+// same math/bits kernel as subBucketIndex so the forward and inverse
+// directions can never disagree.
+func (slot *routeSlot) boundaryAt(i int, routeStart []byte) []byte {
+	off := slot.subStart + fracMul(u64NonNeg(i), slot.subSpan, u64NonNeg(len(slot.subBuckets)))
+	out := make([]byte, slot.subPrefixLen+subWindowBytes)
+	copy(out, routeStart[:min(slot.subPrefixLen, len(routeStart))])
+	binary.BigEndian.PutUint64(out[slot.subPrefixLen:], off)
+	return out
 }
 
 // RegisterRoute adds a (RouteID, [Start, End)) pair to the tracking
@@ -504,6 +771,7 @@ func (s *MemSampler) RegisterRoute(routeID uint64, start, end []byte, groupID ui
 				End:               cloneBytes(end),
 				MemberRoutesTotal: 1,
 			}
+			s.initSubLayout(slot, start, end)
 		} else {
 			// Re-registering the same routeID inside the grace window:
 			// reuse the retired slot so any in-flight Observe writers
@@ -512,6 +780,17 @@ func (s *MemSampler) RegisterRoute(routeID uint64, start, end []byte, groupID ui
 			// RouteID instead of two (one live + one retired) with
 			// counts split across them. Refresh the metadata fields to
 			// match the new registration; counters are preserved.
+			//
+			// The sub-range layout (subPrefixLen/subStart/subEnd/subSpan
+			// + subBuckets) is intentionally NOT recomputed here: it is
+			// immutable for the slot's lifetime so the lock-free hot path
+			// can read it without racing this writer, and the counters
+			// must be preserved (not zeroed/resized) to honour the
+			// no-loss contract. A same-RouteID re-registration carries
+			// the same range in practice; the rare changed-range case
+			// keeps the original sub-ranges for the reused slot's
+			// lifetime — a bounded cosmetic mislabel, no lost counts.
+			// See design §4.2.
 			slot.metaMu.Lock()
 			slot.GroupID = groupID
 			slot.Start = cloneBytes(start)
@@ -539,6 +818,9 @@ func (s *MemSampler) RegisterRoute(routeID uint64, start, end []byte, groupID ui
 			Aggregate:         true,
 			MemberRoutes:      []uint64{routeID},
 			MemberRoutesTotal: 1,
+			// Aggregates are never sub-divided (they already coarsen many
+			// routes into one row) — a single counter bucket.
+			subBuckets: make([]subCounter, 1),
 		}
 		next.sortedSlots = appendSorted(next.sortedSlots, bucket)
 	} else {
@@ -911,33 +1193,51 @@ func (s *MemSampler) HistoryColumns() int {
 	return s.opts.HistoryColumns
 }
 
-// appendDrainedRow swaps the slot's counters to zero and appends a
-// MatrixRow when any counter was non-zero. Idle slots are skipped.
-// Metadata is read under the slot's metaMu so a concurrent
-// RegisterRoute fold cannot race with the row materialisation.
+// appendDrainedRow swaps each non-empty sub-bucket's counters to zero
+// and appends one MatrixRow per non-empty sub-bucket, with Start/End
+// narrowed to that sub-bucket's bounds. Idle sub-buckets are skipped,
+// so a route with one hot sub-range emits one row (not K). Slots that
+// are not sub-divided (len(subBuckets) == 1) emit at most one row with
+// the route's own bounds — today's behaviour.
+//
+// The route metadata (Start/End/Aggregate/MemberRoutes/GroupID) is read
+// under the slot's metaMu via snapshotMeta so a concurrent RegisterRoute
+// fold cannot race the read; the sub-range layout fields are immutable
+// (read lock-free, see §4.2) and the counters are per-sub-bucket atomics.
 func appendDrainedRow(rows []MatrixRow, slot *routeSlot, terms map[uint64]uint64) []MatrixRow {
-	reads := slot.reads.Swap(0)
-	writes := slot.writes.Swap(0)
-	readBytes := slot.readBytes.Swap(0)
-	writeBytes := slot.writeBytes.Swap(0)
-	if reads == 0 && writes == 0 && readBytes == 0 && writeBytes == 0 {
-		return rows
-	}
 	start, end, aggregate, members, membersTotal, groupID := slot.snapshotMeta()
-	return append(rows, MatrixRow{
-		RouteID:           slot.RouteID,
-		RaftGroupID:       groupID,
-		LeaderTerm:        terms[groupID],
-		Start:             start,
-		End:               end,
-		Aggregate:         aggregate,
-		MemberRoutes:      members,
-		MemberRoutesTotal: membersTotal,
-		Reads:             reads,
-		Writes:            writes,
-		ReadBytes:         readBytes,
-		WriteBytes:        writeBytes,
-	})
+	k := len(slot.subBuckets)
+	for i := range slot.subBuckets {
+		sc := &slot.subBuckets[i]
+		reads := sc.reads.Swap(0)
+		writes := sc.writes.Swap(0)
+		readBytes := sc.readBytes.Swap(0)
+		writeBytes := sc.writeBytes.Swap(0)
+		if reads == 0 && writes == 0 && readBytes == 0 && writeBytes == 0 {
+			continue
+		}
+		rowStart, rowEnd := start, end
+		if k > 1 {
+			rowStart, rowEnd = slot.subBucketBounds(i, start, end)
+		}
+		rows = append(rows, MatrixRow{
+			RouteID:           slot.RouteID,
+			RaftGroupID:       groupID,
+			LeaderTerm:        terms[groupID],
+			Start:             rowStart,
+			End:               rowEnd,
+			Aggregate:         aggregate,
+			MemberRoutes:      members,
+			MemberRoutesTotal: membersTotal,
+			SubBucket:         i,
+			SubBucketCount:    k,
+			Reads:             reads,
+			Writes:            writes,
+			ReadBytes:         readBytes,
+			WriteBytes:        writeBytes,
+		})
+	}
+	return rows
 }
 
 // Snapshot returns the matrix columns in the supplied [from, to)

--- a/keyviz/sampler.go
+++ b/keyviz/sampler.go
@@ -624,6 +624,11 @@ func fracMul(a, b, c uint64) uint64 {
 // big-endian, zero-padding past the end of b. A short/absent window is
 // the natural low end (0x00…) of the key space.
 func windowUint64(b []byte, off int) uint64 {
+	// Fast path: a full window is available — read it directly, skipping
+	// the per-byte loop and bounds checks (hot path, Gemini medium).
+	if off >= 0 && off+subWindowBytes <= len(b) {
+		return binary.BigEndian.Uint64(b[off:])
+	}
 	var v uint64
 	for i := 0; i < subWindowBytes; i++ {
 		v <<= 8
@@ -721,7 +726,19 @@ func (slot *routeSlot) boundaryAt(i int, routeStart []byte) []byte {
 	out := make([]byte, slot.subPrefixLen+subWindowBytes)
 	copy(out, routeStart[:min(slot.subPrefixLen, len(routeStart))])
 	binary.BigEndian.PutUint64(out[slot.subPrefixLen:], off)
-	return out
+	// Trim trailing zero bytes of the window. A variable-length key
+	// shorter than prefix+W zero-pads to the same window value, so the
+	// *minimal* key that buckets into this cell is the trimmed form.
+	// Without trimming, a key like 0x10 (which subBucketIndex places in
+	// the cell starting at 0x10) would sort BEFORE the emitted 8-byte
+	// boundary 0x10 00…00, so the displayed [Start,End) would exclude
+	// the very keys counted in the row — wrong labels for Redis-style
+	// variable-length keyspaces (Codex P2). The prefix is never trimmed.
+	end := len(out)
+	for end > slot.subPrefixLen && out[end-1] == 0x00 {
+		end--
+	}
+	return out[:end]
 }
 
 // RegisterRoute adds a (RouteID, [Start, End)) pair to the tracking

--- a/keyviz/sampler_subrange_test.go
+++ b/keyviz/sampler_subrange_test.go
@@ -1,0 +1,293 @@
+package keyviz
+
+import (
+	"bytes"
+	"encoding/binary"
+	"sort"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// layoutSlot builds a routeSlot with the sub-range layout K would
+// produce for [start, end), without going through the full sampler.
+func layoutSlot(start, end []byte, k int) *routeSlot {
+	s := &MemSampler{opts: MemSamplerOptions{KeyBucketsPerRoute: k}}
+	slot := &routeSlot{Start: cloneBytes(start), End: cloneBytes(end)}
+	s.initSubLayout(slot, start, end)
+	return slot
+}
+
+func TestComputeSubLayout(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name             string
+		start, end       []byte
+		k                int
+		wantEffK         int
+		wantSpanNonZero  bool
+		wantPrefixLen    int
+		checkStartEndSet bool
+	}{
+		{name: "k=1 single bucket", start: []byte("a"), end: []byte("z"), k: 1, wantEffK: 1},
+		{name: "unbounded end single bucket", start: []byte("a"), end: nil, k: 8, wantEffK: 1},
+		{
+			name: "normal range subdivides", start: []byte("a"), end: []byte("b"), k: 4,
+			wantEffK: 4, wantSpanNonZero: true, wantPrefixLen: 0, checkStartEndSet: true,
+		},
+		{
+			name:  "shared prefix stripped",
+			start: []byte("tenant/aaaa"), end: []byte("tenant/zzzz"), k: 8,
+			wantEffK: 8, wantSpanNonZero: true, wantPrefixLen: 7, checkStartEndSet: true,
+		},
+		{
+			// Equal start/end (empty range): the common prefix spans the
+			// whole key, the window reads only past-end zeros for both, so
+			// subEnd == subStart -> single bucket. (Because commonPrefixLen
+			// lands exactly on the first differing byte, the window always
+			// captures a real difference for start < end, so this empty
+			// range is the only degenerate case in practice.)
+			name:  "equal start and end single bucket",
+			start: []byte("abc"), end: []byte("abc"),
+			k: 16, wantEffK: 1, wantPrefixLen: 3,
+		},
+		{name: "nil start treated as zero", start: nil, end: []byte{0x10}, k: 4, wantEffK: 4, wantSpanNonZero: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			prefixLen, subStart, subEnd, subSpan, effK := computeSubLayout(tc.start, tc.end, tc.k)
+			require.Equal(t, tc.wantEffK, effK, "effK")
+			if tc.wantSpanNonZero {
+				require.Greater(t, subSpan, uint64(0), "subSpan should be non-zero")
+				require.Equal(t, subEnd-subStart, subSpan)
+			} else {
+				require.Zero(t, subSpan, "subSpan should be 0 for single-bucket layout")
+			}
+			if tc.wantPrefixLen != 0 {
+				require.Equal(t, tc.wantPrefixLen, prefixLen, "prefixLen")
+			}
+			if tc.name == "nil start treated as zero" {
+				require.Zero(t, subStart, "nil start -> subStart 0")
+			}
+		})
+	}
+}
+
+func TestSubBucketIndexEdges(t *testing.T) {
+	t.Parallel()
+	slot := layoutSlot([]byte{0x00}, []byte{0x40}, 4) // [0x00, 0x40) / 4 => width 0x10 each
+	require.Len(t, slot.subBuckets, 4)
+
+	// Below/at start pin to bucket 0; at/above end pin to last bucket.
+	require.Equal(t, 0, slot.subBucketIndex([]byte{0x00}), "start pins to 0")
+	require.Equal(t, 0, slot.subBucketIndex(nil), "nil key pins to 0")
+	require.Equal(t, 3, slot.subBucketIndex([]byte{0x40}), "end pins to last")
+	require.Equal(t, 3, slot.subBucketIndex([]byte{0xFF}), "above end pins to last")
+
+	// Interior: 0x00-0x0F -> 0, 0x10-0x1F -> 1, 0x20-0x2F -> 2, 0x30-0x3F -> 3.
+	require.Equal(t, 0, slot.subBucketIndex([]byte{0x0F}))
+	require.Equal(t, 1, slot.subBucketIndex([]byte{0x10}))
+	require.Equal(t, 2, slot.subBucketIndex([]byte{0x20}))
+	require.Equal(t, 3, slot.subBucketIndex([]byte{0x3F}))
+}
+
+func TestSubBucketIndexSingleBucketAlwaysZero(t *testing.T) {
+	t.Parallel()
+	for _, slot := range []*routeSlot{
+		layoutSlot([]byte("a"), []byte("z"), 1),   // K=1
+		layoutSlot([]byte("a"), nil, 8),           // unbounded tail
+		layoutSlot([]byte{0x00}, []byte{0x00}, 8), // degenerate
+	} {
+		require.Len(t, slot.subBuckets, 1)
+		for _, key := range [][]byte{nil, {0x00}, {0x80}, {0xFF, 0xFF}} {
+			require.Equal(t, 0, slot.subBucketIndex(key))
+		}
+	}
+}
+
+// TestSubBucketIndexMonotone is the rapid property: key1 <= key2 implies
+// idx1 <= idx2 for any [start, end) and K (order preservation).
+func TestSubBucketIndexMonotone(t *testing.T) {
+	t.Parallel()
+	rapid.Check(t, func(rt *rapid.T) {
+		k := rapid.IntRange(1, MaxKeyBucketsPerRoute).Draw(rt, "k")
+		start := rapid.SliceOfN(rapid.Byte(), 0, 12).Draw(rt, "start")
+		end := rapid.SliceOfN(rapid.Byte(), 0, 12).Draw(rt, "end")
+		slot := layoutSlot(start, end, k)
+
+		k1 := rapid.SliceOfN(rapid.Byte(), 0, 12).Draw(rt, "k1")
+		k2 := rapid.SliceOfN(rapid.Byte(), 0, 12).Draw(rt, "k2")
+		if bytes.Compare(k1, k2) > 0 {
+			k1, k2 = k2, k1
+		}
+		idx1 := slot.subBucketIndex(k1)
+		idx2 := slot.subBucketIndex(k2)
+		if idx1 > idx2 {
+			rt.Fatalf("non-monotone: key %x->%d > key %x->%d (start=%x end=%x k=%d)",
+				k1, idx1, k2, idx2, start, end, k)
+		}
+		// Index must always be in range.
+		require.GreaterOrEqual(rt, idx1, 0)
+		require.Less(rt, idx2, len(slot.subBuckets))
+	})
+}
+
+// TestSamplerSubRangeHotKeyOnDistinctRow is the end-to-end goal: a hot
+// sub-range surfaces as its own row, separate from a cold one.
+func TestSamplerSubRangeHotKeyOnDistinctRow(t *testing.T) {
+	t.Parallel()
+	s := NewMemSampler(MemSamplerOptions{Step: time.Second, HistoryColumns: 4, KeyBucketsPerRoute: 4})
+	require.True(t, s.RegisterRoute(1, []byte{0x00}, []byte{0x40}, 0))
+
+	// 100 writes into sub-bucket 3 ([0x30,0x40)), 1 into sub-bucket 0.
+	for i := 0; i < 100; i++ {
+		s.Observe(1, []byte{0x38}, OpWrite, 0)
+	}
+	s.Observe(1, []byte{0x01}, OpWrite, 0)
+	s.Flush()
+
+	cols := s.Snapshot(time.Time{}, time.Time{})
+	require.Len(t, cols, 1)
+	rows := cols[0].Rows
+	require.Len(t, rows, 2, "one row per non-empty sub-bucket")
+	for _, r := range rows {
+		require.Equal(t, 4, r.SubBucketCount)
+		require.Equal(t, uint64(1), r.RouteID)
+	}
+	// Sorted by Start: cold (bucket 0) first, hot (bucket 3) second.
+	sort.Slice(rows, func(i, j int) bool { return bytes.Compare(rows[i].Start, rows[j].Start) < 0 })
+	require.Equal(t, uint64(1), rows[0].Writes, "cold sub-range")
+	require.Equal(t, uint64(100), rows[1].Writes, "hot sub-range")
+	require.Equal(t, 0, rows[0].SubBucket)
+	require.Equal(t, 3, rows[1].SubBucket)
+}
+
+// TestSamplerSubRangeBoundsTileExactly asserts the emitted sub-rows tile
+// [routeStart, routeEnd) with no gap or overlap, with the first/last
+// bounds pinned to the route's own bounds.
+func TestSamplerSubRangeBoundsTileExactly(t *testing.T) {
+	t.Parallel()
+	const k = 4
+	routeStart, routeEnd := []byte{0x00}, []byte{0x40}
+	s := NewMemSampler(MemSamplerOptions{Step: time.Second, HistoryColumns: 4, KeyBucketsPerRoute: k})
+	require.True(t, s.RegisterRoute(1, routeStart, routeEnd, 0))
+	// Hit every sub-bucket so all K rows are emitted.
+	for _, key := range [][]byte{{0x00}, {0x10}, {0x20}, {0x30}} {
+		s.Observe(1, key, OpWrite, 0)
+	}
+	s.Flush()
+	rows := s.Snapshot(time.Time{}, time.Time{})[0].Rows
+	require.Len(t, rows, k)
+	sort.Slice(rows, func(i, j int) bool { return bytes.Compare(rows[i].Start, rows[j].Start) < 0 })
+
+	require.Equal(t, routeStart, rows[0].Start, "first sub-row pins to route Start")
+	require.Equal(t, routeEnd, rows[k-1].End, "last sub-row pins to route End")
+	for i := 1; i < k; i++ {
+		require.Equal(t, rows[i-1].End, rows[i].Start,
+			"sub-row %d Start must equal sub-row %d End (contiguous, no gap)", i, i-1)
+	}
+}
+
+// TestSamplerGraceWindowReRegistrationKeepsStaleLayout pins the design
+// §4.2 contract: a same-RouteID re-registration inside the grace window
+// reuses the slot and keeps its ORIGINAL sub-range layout (no recompute,
+// no lost counts); only a fresh registration after grace expiry gets a
+// new layout.
+func TestSamplerGraceWindowReRegistrationKeepsStaleLayout(t *testing.T) {
+	t.Parallel()
+	s, clk := newTestSampler(t, MemSamplerOptions{Step: time.Second, HistoryColumns: 8, KeyBucketsPerRoute: 4})
+
+	rangeAStart, rangeAEnd := []byte{0x00}, []byte{0x40}
+	require.True(t, s.RegisterRoute(1, rangeAStart, rangeAEnd, 0))
+	origStart := s.table.Load().slots[1].subStart
+	origSpan := s.table.Load().slots[1].subSpan
+	s.Observe(1, []byte{0x10}, OpWrite, 0)
+
+	// Remove + re-register with a DIFFERENT range, inside the grace
+	// window -> reclaimRetiredSlot reuses the slot, layout unchanged.
+	s.RemoveRoute(1)
+	require.True(t, s.RegisterRoute(1, []byte{0x80}, []byte{0xC0}, 0))
+	reused := s.table.Load().slots[1]
+	require.Equal(t, origStart, reused.subStart, "layout subStart must NOT be recomputed on in-grace re-registration")
+	require.Equal(t, origSpan, reused.subSpan, "layout subSpan must NOT be recomputed")
+
+	// The pre-removal count must survive (no zeroing on reclaim).
+	s.Flush()
+	require.Equal(t, uint64(1), totalWritesForRoute(s.Snapshot(time.Time{}, time.Time{}), 1),
+		"pre-removal count lost on grace-window re-registration")
+
+	// Companion: after grace expiry, a fresh registration gets a NEW
+	// layout matching the new range.
+	s.RemoveRoute(1)
+	clk.Advance(s.graceWindow() + time.Second)
+	s.Flush() // drop the retired slot
+	require.True(t, s.RegisterRoute(1, []byte{0x80}, []byte{0xC0}, 0))
+	fresh := s.table.Load().slots[1]
+	freshStart := windowUint64([]byte{0x80}, 0)
+	require.Equal(t, freshStart, fresh.subStart, "fresh post-grace registration must use the new range's layout")
+}
+
+// TestSamplerK1MatchesRouteLevel pins backward compatibility: with K=1,
+// the sampler behaves exactly route-level — one row per route, full
+// counts, no sub-bucket suffix signalling (SubBucketCount == 1).
+func TestSamplerK1MatchesRouteLevel(t *testing.T) {
+	t.Parallel()
+	s := NewMemSampler(MemSamplerOptions{Step: time.Second, HistoryColumns: 4, KeyBucketsPerRoute: 1})
+	require.True(t, s.RegisterRoute(1, []byte{0x00}, []byte{0xFF}, 0))
+	for _, key := range [][]byte{{0x01}, {0x80}, {0xFE}} {
+		s.Observe(1, key, OpWrite, 0)
+	}
+	s.Flush()
+	rows := s.Snapshot(time.Time{}, time.Time{})[0].Rows
+	require.Len(t, rows, 1, "K=1 must collapse to one route-level row")
+	require.Equal(t, uint64(3), rows[0].Writes)
+	require.Equal(t, 1, rows[0].SubBucketCount)
+	require.Equal(t, 0, rows[0].SubBucket)
+}
+
+// totalWritesForRoute sums Writes across all columns/sub-rows of a route.
+func totalWritesForRoute(cols []MatrixColumn, routeID uint64) uint64 {
+	var total uint64
+	for _, col := range cols {
+		for _, r := range col.Rows {
+			if r.RouteID == routeID {
+				total += r.Writes
+			}
+		}
+	}
+	return total
+}
+
+// BenchmarkObserveSubRange is the hot-path performance gate: it bounds
+// the per-Observe regression sub-range bucketing adds versus K=1 (the
+// extra cost is one windowUint64 + a bits.Mul64/Div64 and two
+// bytes.Compare clamps). Run: go test -bench ObserveSubRange ./keyviz/.
+func BenchmarkObserveSubRange(b *testing.B) {
+	for _, k := range []int{1, 64} {
+		b.Run("K="+strconv.Itoa(k), func(b *testing.B) {
+			s := NewMemSampler(MemSamplerOptions{Step: time.Hour, HistoryColumns: 4, KeyBucketsPerRoute: k})
+			s.RegisterRoute(1, make([]byte, 8), bytes.Repeat([]byte{0xFF}, 8), 0)
+			key := []byte{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				s.Observe(1, key, OpWrite, 64)
+			}
+		})
+	}
+}
+
+// sanity: boundaryAt round-trips through the window encoding.
+func TestBoundaryAtEncoding(t *testing.T) {
+	t.Parallel()
+	slot := layoutSlot([]byte{0x00}, []byte{0x40}, 4)
+	b := slot.boundaryAt(1, []byte{0x00})
+	// The window treats the first byte past the prefix as the most
+	// significant: bucket 1 of [0x00,0x40)/4 starts at 0x10 in that byte,
+	// i.e. 0x10<<56 as the window uint64.
+	require.Equal(t, uint64(0x1000000000000000), binary.BigEndian.Uint64(b[slot.subPrefixLen:]))
+}

--- a/keyviz/sampler_subrange_test.go
+++ b/keyviz/sampler_subrange_test.go
@@ -2,7 +2,6 @@ package keyviz
 
 import (
 	"bytes"
-	"encoding/binary"
 	"sort"
 	"strconv"
 	"testing"
@@ -286,8 +285,9 @@ func TestBoundaryAtEncoding(t *testing.T) {
 	t.Parallel()
 	slot := layoutSlot([]byte{0x00}, []byte{0x40}, 4)
 	b := slot.boundaryAt(1, []byte{0x00})
-	// The window treats the first byte past the prefix as the most
-	// significant: bucket 1 of [0x00,0x40)/4 starts at 0x10 in that byte,
-	// i.e. 0x10<<56 as the window uint64.
-	require.Equal(t, uint64(0x1000000000000000), binary.BigEndian.Uint64(b[slot.subPrefixLen:]))
+	// Bucket 1 of [0x00,0x40)/4 starts at 0x10 in the most-significant
+	// window byte (0x10<<56); trailing zero bytes are trimmed so the
+	// boundary is the minimal key in the cell, {0x10}, rather than the
+	// 8-byte 0x10 00…00 (which would sort after short keys like 0x10).
+	require.Equal(t, []byte{0x10}, b)
 }

--- a/keyviz/sampler_test.go
+++ b/keyviz/sampler_test.go
@@ -36,7 +36,7 @@ func (c *fakeClock) Advance(d time.Duration) {
 func TestNilSamplerObserveSafe(t *testing.T) {
 	t.Parallel()
 	var s *MemSampler // nil
-	s.Observe(1, OpRead, 10, 20)
+	s.Observe(1, make([]byte, 10), OpRead, 20)
 	if s.RegisterRoute(1, []byte("a"), []byte("b"), 0) {
 		t.Fatal("nil RegisterRoute should return false")
 	}
@@ -53,9 +53,9 @@ func TestObserveAndFlushBasic(t *testing.T) {
 	if !s.RegisterRoute(1, []byte("a"), []byte("c"), 0) {
 		t.Fatal("RegisterRoute(1) returned false")
 	}
-	s.Observe(1, OpRead, 5, 10)
-	s.Observe(1, OpRead, 5, 10)
-	s.Observe(1, OpWrite, 5, 100)
+	s.Observe(1, make([]byte, 5), OpRead, 10)
+	s.Observe(1, make([]byte, 5), OpRead, 10)
+	s.Observe(1, make([]byte, 5), OpWrite, 100)
 
 	s.Flush()
 	clk.Advance(time.Second)
@@ -106,7 +106,7 @@ func TestNoCountsLostAcrossFlush(t *testing.T) {
 					return
 				default:
 				}
-				s.Observe(1, OpRead, 1, 0)
+				s.Observe(1, make([]byte, 1), OpRead, 0)
 			}
 		}()
 	}
@@ -141,9 +141,9 @@ func TestNoCountsLostAcrossFlush(t *testing.T) {
 func TestRouteBudgetCoarsensIntoVirtualBucket(t *testing.T) {
 	t.Parallel()
 	s := budgetSetup(t)
-	s.Observe(1, OpRead, 1, 0)
-	s.Observe(2, OpRead, 1, 0)
-	s.Observe(3, OpRead, 1, 0)
+	s.Observe(1, make([]byte, 1), OpRead, 0)
+	s.Observe(2, make([]byte, 1), OpRead, 0)
+	s.Observe(3, make([]byte, 1), OpRead, 0)
 	s.Flush()
 	rows := budgetSingleColumnRows(t, s)
 	agg := findAggregateRow(t, rows)
@@ -200,7 +200,7 @@ func TestSnapshotRangeFilters(t *testing.T) {
 	s, clk := newTestSampler(t, MemSamplerOptions{Step: time.Second, HistoryColumns: 8})
 	s.RegisterRoute(1, []byte("a"), []byte("b"), 0)
 	for i := 0; i < 5; i++ {
-		s.Observe(1, OpRead, 0, 0)
+		s.Observe(1, make([]byte, 0), OpRead, 0)
 		s.Flush()
 		clk.Advance(time.Second)
 	}
@@ -224,7 +224,7 @@ func TestRingBufferDropsOldest(t *testing.T) {
 	s, clk := newTestSampler(t, MemSamplerOptions{Step: time.Second, HistoryColumns: 3})
 	s.RegisterRoute(1, []byte("a"), []byte("b"), 0)
 	for i := 0; i < 5; i++ {
-		s.Observe(1, OpRead, 0, 0)
+		s.Observe(1, make([]byte, 0), OpRead, 0)
 		s.Flush()
 		clk.Advance(time.Second)
 	}
@@ -244,9 +244,9 @@ func TestRemoveRouteSilencesObserve(t *testing.T) {
 	t.Parallel()
 	s, _ := newTestSampler(t, MemSamplerOptions{Step: time.Second, HistoryColumns: 4})
 	s.RegisterRoute(1, []byte("a"), []byte("b"), 0)
-	s.Observe(1, OpRead, 0, 0)
+	s.Observe(1, make([]byte, 0), OpRead, 0)
 	s.RemoveRoute(1)
-	s.Observe(1, OpRead, 0, 0) // silently dropped
+	s.Observe(1, make([]byte, 0), OpRead, 0) // silently dropped
 	s.Flush()
 	cols := s.Snapshot(time.Time{}, time.Time{})
 	for _, c := range cols {
@@ -266,7 +266,7 @@ func TestRemoveRouteHarvestsPendingCounts(t *testing.T) {
 	s, _ := newTestSampler(t, MemSamplerOptions{Step: time.Second, HistoryColumns: 4})
 	s.RegisterRoute(1, []byte("a"), []byte("b"), 0)
 	for i := 0; i < 7; i++ {
-		s.Observe(1, OpRead, 1, 0)
+		s.Observe(1, make([]byte, 1), OpRead, 0)
 	}
 	// Remove BEFORE flushing — pending 7 reads must surface.
 	s.RemoveRoute(1)
@@ -296,12 +296,12 @@ func TestRemoveVirtualMemberPrunesMemberRoutes(t *testing.T) {
 	// Drain at least once within grace, then advance past grace so the
 	// next Flush actually executes the prune. One more Flush captures
 	// the post-prune MemberRoutes state in a row.
-	s.Observe(3, OpRead, 1, 0)
+	s.Observe(3, make([]byte, 1), OpRead, 0)
 	s.Flush()
 	clk.Advance(s.graceWindow() + time.Second)
-	s.Observe(3, OpRead, 1, 0)
+	s.Observe(3, make([]byte, 1), OpRead, 0)
 	s.Flush()
-	s.Observe(3, OpRead, 1, 0)
+	s.Observe(3, make([]byte, 1), OpRead, 0)
 	s.Flush()
 
 	agg := findAggregateRow(t, lastSnapshotColumn(t, s).Rows)
@@ -325,7 +325,7 @@ func TestRemoveVirtualMemberPruneDeferred(t *testing.T) {
 	// so each Flush sees now-retiredAt == 0 < grace and keeps the
 	// prune entry.
 	for i := 0; i < 2; i++ {
-		s.Observe(3, OpRead, 1, 0)
+		s.Observe(3, make([]byte, 1), OpRead, 0)
 		s.Flush()
 		col := lastSnapshotColumn(t, s)
 		agg := findAggregateRow(t, col.Rows)
@@ -427,7 +427,7 @@ func TestRegisterDoesNotRaceFlushOnVirtualBucket(t *testing.T) {
 func TestObserveOnUnknownRouteIsNoop(t *testing.T) {
 	t.Parallel()
 	s, _ := newTestSampler(t, MemSamplerOptions{Step: time.Second, HistoryColumns: 4})
-	s.Observe(42, OpRead, 0, 0)
+	s.Observe(42, make([]byte, 0), OpRead, 0)
 	s.Flush()
 	cols := s.Snapshot(time.Time{}, time.Time{})
 	for _, c := range cols {
@@ -467,7 +467,7 @@ func TestConcurrentRegisterAndObserveRace(t *testing.T) {
 				default:
 				}
 				for i := uint64(1); i <= routes; i++ {
-					s.Observe(i, OpRead, 0, 0)
+					s.Observe(i, make([]byte, 0), OpRead, 0)
 					observed.Add(1)
 				}
 			}
@@ -507,7 +507,7 @@ func TestRemoveLastVirtualMemberHarvestsBucket(t *testing.T) {
 	if s.RegisterRoute(2, []byte("c"), []byte("d"), 0) {
 		t.Fatal("route 2 over budget should fold into virtual bucket")
 	}
-	s.Observe(2, OpRead, 5, 7)
+	s.Observe(2, make([]byte, 5), OpRead, 7)
 	s.RemoveRoute(2)
 	s.Flush()
 
@@ -530,10 +530,10 @@ func TestFlushSortsMixedLiveAndRetiredRows(t *testing.T) {
 	mustRegister(t, s, 1, "a", "b")
 	mustRegister(t, s, 2, "m", "n")
 	mustRegister(t, s, 3, "z", "{")
-	s.Observe(2, OpRead, 0, 0)
+	s.Observe(2, make([]byte, 0), OpRead, 0)
 	s.RemoveRoute(2)
-	s.Observe(1, OpRead, 0, 0)
-	s.Observe(3, OpRead, 0, 0)
+	s.Observe(1, make([]byte, 0), OpRead, 0)
+	s.Observe(3, make([]byte, 0), OpRead, 0)
 	s.Flush()
 	flushedRowsSorted(t, s)
 }
@@ -551,12 +551,12 @@ func TestRetiredSlotGracePeriod(t *testing.T) {
 	if !s.RegisterRoute(1, []byte("a"), []byte("b"), 0) {
 		t.Fatal("RegisterRoute(1) returned false")
 	}
-	s.Observe(1, OpRead, 1, 2)
+	s.Observe(1, make([]byte, 1), OpRead, 2)
 	s.RemoveRoute(1)
 
 	lateSlot := graceQueueSingleSlot(t, s)
 	s.Flush() // drain inside grace
-	lateSlot.reads.Add(7)
+	lateSlot.subBuckets[0].reads.Add(7)
 	s.Flush() // drain inside grace, harvests the late-writer increment
 
 	total := totalReadsForRoute(s.Snapshot(time.Time{}, time.Time{}), 1)
@@ -619,10 +619,10 @@ func TestRegisterFoldLowerStartReorders(t *testing.T) {
 	if s.RegisterRoute(4, []byte("a"), []byte("b"), 0) {
 		t.Fatal("route 4 over budget should fold into virtual bucket")
 	}
-	s.Observe(1, OpRead, 0, 0)
-	s.Observe(2, OpRead, 0, 0)
-	s.Observe(3, OpRead, 0, 0)
-	s.Observe(4, OpRead, 0, 0)
+	s.Observe(1, make([]byte, 0), OpRead, 0)
+	s.Observe(2, make([]byte, 0), OpRead, 0)
+	s.Observe(3, make([]byte, 0), OpRead, 0)
+	s.Observe(4, make([]byte, 0), OpRead, 0)
 	s.Flush()
 
 	rows := flushedRowsSorted(t, s)
@@ -665,7 +665,7 @@ func TestSnapshotReturnsDeepCopy(t *testing.T) {
 	if !s.RegisterRoute(1, []byte("aaaa"), []byte("bbbb"), 0) {
 		t.Fatal("RegisterRoute(1) returned false")
 	}
-	s.Observe(1, OpRead, 1, 2)
+	s.Observe(1, make([]byte, 1), OpRead, 2)
 	s.Flush()
 
 	first := s.Snapshot(time.Time{}, time.Time{})
@@ -702,7 +702,7 @@ func TestVirtualBucketRouteIDIsSynthetic(t *testing.T) {
 	if s.RegisterRoute(2, []byte("c"), []byte("d"), 0) {
 		t.Fatal("route 2 should fold into a fresh virtual bucket")
 	}
-	s.Observe(2, OpRead, 0, 0)
+	s.Observe(2, make([]byte, 0), OpRead, 0)
 	s.Flush()
 
 	rows := lastSnapshotColumn(t, s).Rows
@@ -739,8 +739,8 @@ func TestRejoinAsIndividualLetsBucketPruneFire(t *testing.T) {
 	if s.RegisterRoute(3, []byte("y"), []byte("z"), 0) {
 		t.Fatal("route 3 should fold (same bucket)")
 	}
-	s.Observe(2, OpRead, 0, 0)
-	s.Observe(3, OpRead, 0, 0)
+	s.Observe(2, make([]byte, 0), OpRead, 0)
+	s.Observe(3, make([]byte, 0), OpRead, 0)
 	// Free capacity (route 1) and remove the virtual member (route 3),
 	// which queues a prune against the bucket. Route 2 still keeps the
 	// bucket alive in virtualForRoute.
@@ -753,9 +753,9 @@ func TestRejoinAsIndividualLetsBucketPruneFire(t *testing.T) {
 	// Two flushes after grace: the first executes the prune, the
 	// second emits a row with the post-prune MemberRoutes.
 	clk.Advance(s.graceWindow() + time.Second)
-	s.Observe(2, OpRead, 0, 0)
+	s.Observe(2, make([]byte, 0), OpRead, 0)
 	s.Flush()
-	s.Observe(2, OpRead, 0, 0)
+	s.Observe(2, make([]byte, 0), OpRead, 0)
 	s.Flush()
 
 	rows := lastSnapshotColumn(t, s).Rows
@@ -779,10 +779,10 @@ func TestReRegisterIndividualReusesRetiredSlot(t *testing.T) {
 		HistoryColumns: 4,
 	})
 	mustRegister(t, s, 1, "a", "b")
-	s.Observe(1, OpRead, 0, 0)
+	s.Observe(1, make([]byte, 0), OpRead, 0)
 	s.RemoveRoute(1)
 	mustRegister(t, s, 1, "a", "b")
-	s.Observe(1, OpRead, 0, 0)
+	s.Observe(1, make([]byte, 0), OpRead, 0)
 	s.Flush()
 
 	rows := lastSnapshotColumn(t, s).Rows
@@ -824,7 +824,7 @@ func TestReRegisterDuringPruneGraceCancelsPrune(t *testing.T) {
 	}
 
 	clk.Advance(s.graceWindow() + time.Second)
-	s.Observe(2, OpRead, 0, 0)
+	s.Observe(2, make([]byte, 0), OpRead, 0)
 	s.Flush()
 
 	rows := lastSnapshotColumn(t, s).Rows
@@ -855,7 +855,7 @@ func TestRegisterRouteCarriesGroupID(t *testing.T) {
 	if !s.RegisterRoute(1, []byte("a"), []byte("b"), 42) {
 		t.Fatal("RegisterRoute returned false")
 	}
-	s.Observe(1, OpWrite, 16, 64)
+	s.Observe(1, make([]byte, 16), OpWrite, 64)
 	s.Flush()
 	cols := s.Snapshot(time.Time{}, time.Time{})
 	if len(cols) != 1 || len(cols[0].Rows) != 1 {
@@ -878,12 +878,12 @@ func TestSetLeaderTermStampsRows(t *testing.T) {
 		t.Fatal("RegisterRoute returned false")
 	}
 	s.SetLeaderTerm(7, 100)
-	s.Observe(1, OpWrite, 16, 64)
+	s.Observe(1, make([]byte, 16), OpWrite, 64)
 	s.Flush()
 	clk.Advance(time.Second)
 
 	s.SetLeaderTerm(7, 101)
-	s.Observe(1, OpWrite, 16, 64)
+	s.Observe(1, make([]byte, 16), OpWrite, 64)
 	s.Flush()
 
 	cols := s.Snapshot(time.Time{}, time.Time{})
@@ -919,7 +919,7 @@ func TestSetLeaderTermZeroGroupIDDoesNotPolluteVirtualBucket(t *testing.T) {
 	t.Parallel()
 	s, _ := setupOneIndividualPlusVirtualBucket(t)
 	s.SetLeaderTerm(0, 999) // bug case: caller passes the reserved groupID
-	s.Observe(2, OpWrite, 16, 64)
+	s.Observe(2, make([]byte, 16), OpWrite, 64)
 	s.Flush()
 	cols := s.Snapshot(time.Time{}, time.Time{})
 	if len(cols) == 0 {
@@ -963,7 +963,7 @@ func TestVirtualBucketRaftGroupIDIsZero(t *testing.T) {
 	if s.RegisterRoute(2, []byte("c"), []byte("d"), 42) {
 		t.Fatal("route 2 should fold into virtual bucket (group 42, over budget)")
 	}
-	s.Observe(2, OpWrite, 16, 64)
+	s.Observe(2, make([]byte, 16), OpWrite, 64)
 	s.Flush()
 	cols := s.Snapshot(time.Time{}, time.Time{})
 	if len(cols) == 0 {
@@ -999,7 +999,7 @@ func TestRegisterRouteSecondCallIgnoresGroupID(t *testing.T) {
 	if !s.RegisterRoute(1, []byte("a"), []byte("b"), 99) {
 		t.Fatal("second RegisterRoute should be a no-op returning true")
 	}
-	s.Observe(1, OpWrite, 16, 64)
+	s.Observe(1, make([]byte, 16), OpWrite, 64)
 	s.Flush()
 	cols := s.Snapshot(time.Time{}, time.Time{})
 	if len(cols) != 1 || len(cols[0].Rows) != 1 {
@@ -1094,7 +1094,7 @@ func TestMemberRoutesCappedAtConfiguredCap(t *testing.T) {
 		if s.RegisterRoute(i, key, append(key, 'z'), 0) {
 			t.Fatalf("route %d should fold (over budget)", i)
 		}
-		s.Observe(i, OpRead, 1, 0)
+		s.Observe(i, make([]byte, 1), OpRead, 0)
 	}
 	s.Flush()
 	rows := lastSnapshotColumn(t, s).Rows
@@ -1136,7 +1136,7 @@ func TestPastCapMemberRejoinDoesNotInflateTotal(t *testing.T) {
 	if s.RegisterRoute(4, []byte("g"), []byte("h"), 0) {
 		t.Fatal("route 4 should fold (hidden — past cap)")
 	}
-	s.Observe(2, OpRead, 0, 0)
+	s.Observe(2, make([]byte, 0), OpRead, 0)
 	s.Flush()
 	beforeTotal := findAggregateRow(t, lastSnapshotColumn(t, s).Rows).MemberRoutesTotal
 	if beforeTotal != 3 {
@@ -1149,7 +1149,7 @@ func TestPastCapMemberRejoinDoesNotInflateTotal(t *testing.T) {
 	if s.RegisterRoute(3, []byte("e"), []byte("f"), 0) {
 		t.Fatal("route 3 should fold again")
 	}
-	s.Observe(2, OpRead, 0, 0)
+	s.Observe(2, make([]byte, 0), OpRead, 0)
 	s.Flush()
 	afterTotal := findAggregateRow(t, lastSnapshotColumn(t, s).Rows).MemberRoutesTotal
 	if afterTotal != 3 {
@@ -1176,11 +1176,11 @@ func TestPastCapMemberPruneDecrementsTotal(t *testing.T) {
 	if s.RegisterRoute(3, []byte("e"), []byte("f"), 0) {
 		t.Fatal("route 3 should fold (hidden — past cap)")
 	}
-	s.Observe(2, OpRead, 0, 0)
+	s.Observe(2, make([]byte, 0), OpRead, 0)
 	s.Flush()
 	require := func(want uint64, ctx string) {
 		t.Helper()
-		s.Observe(2, OpRead, 0, 0)
+		s.Observe(2, make([]byte, 0), OpRead, 0)
 		s.Flush()
 		got := findAggregateRow(t, lastSnapshotColumn(t, s).Rows).MemberRoutesTotal
 		if got != want {
@@ -1206,7 +1206,7 @@ func TestRetiredTailClearedAfterDrop(t *testing.T) {
 	t.Parallel()
 	s, clk := newTestSampler(t, MemSamplerOptions{Step: time.Second, HistoryColumns: 4})
 	mustRegister(t, s, 1, "a", "b")
-	s.Observe(1, OpRead, 1, 1)
+	s.Observe(1, make([]byte, 1), OpRead, 1)
 	s.RemoveRoute(1)
 
 	s.retiredMu.Lock()
@@ -1244,7 +1244,7 @@ func BenchmarkObserveHit(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		s.Observe(1, OpRead, 16, 64)
+		s.Observe(1, make([]byte, 16), OpRead, 64)
 	}
 }
 
@@ -1256,7 +1256,7 @@ func BenchmarkObserveMiss(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		s.Observe(99, OpRead, 16, 64)
+		s.Observe(99, make([]byte, 16), OpRead, 64)
 	}
 }
 
@@ -1294,7 +1294,7 @@ func BenchmarkObserveParallel(b *testing.B) {
 		shardBase := (shardIndex * routesPerShard) % numRoutes
 		var i uint64
 		for pb.Next() {
-			s.Observe(shardBase+(i%routesPerShard)+1, OpWrite, 16, 64)
+			s.Observe(shardBase+(i%routesPerShard)+1, make([]byte, 16), OpWrite, 64)
 			i++
 		}
 	})
@@ -1361,7 +1361,7 @@ func BenchmarkFlush(b *testing.B) {
 			b.Fatalf("RegisterRoute(%d) returned false", r)
 		}
 		// Pre-seed every slot with traffic so the first Flush has work to swap.
-		s.Observe(r, OpWrite, 16, 64)
+		s.Observe(r, make([]byte, 16), OpWrite, 64)
 	}
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -1371,7 +1371,7 @@ func BenchmarkFlush(b *testing.B) {
 		clk.Advance(time.Second)
 		// Reseed so the next Flush still has counters to drain.
 		for r := uint64(1); r <= numRoutes; r++ {
-			s.Observe(r, OpWrite, 16, 64)
+			s.Observe(r, make([]byte, 16), OpWrite, 64)
 		}
 		b.StartTimer()
 	}
@@ -1401,7 +1401,7 @@ func BenchmarkSnapshot(b *testing.B) {
 	}
 	for c := 0; c < numColumns; c++ {
 		for r := uint64(1); r <= numRoutes; r++ {
-			s.Observe(r, OpWrite, 16, 64)
+			s.Observe(r, make([]byte, 16), OpWrite, 64)
 		}
 		s.Flush()
 		clk.Advance(time.Second)
@@ -1500,7 +1500,7 @@ func runConcurrentBurst(s *MemSampler, numRoutes uint64, writersPerRoute, opsPer
 				ready.Done()
 				start.Wait()
 				for op := 0; op < opsPerWriter; op++ {
-					s.Observe(routeID, OpWrite, keyLen, valueLen)
+					s.Observe(routeID, make([]byte, keyLen), OpWrite, valueLen)
 				}
 			}()
 		}

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -797,7 +797,7 @@ func (c *ShardedCoordinator) LinearizableReadForKey(ctx context.Context, key []b
 	if !ok {
 		return 0, errors.WithStack(ErrLeaderNotFound)
 	}
-	c.observeRead(routeID, len(key))
+	c.observeRead(routeID, key)
 	return linearizableReadEngineCtx(ctx, engineForGroup(g))
 }
 
@@ -819,7 +819,7 @@ func (c *ShardedCoordinator) LeaseReadForKey(ctx context.Context, key []byte) (u
 	if !ok {
 		return 0, errors.WithStack(ErrLeaderNotFound)
 	}
-	c.observeRead(routeID, len(key))
+	c.observeRead(routeID, key)
 	return groupLeaseRead(ctx, g, c.leaseObserver)
 }
 
@@ -1079,13 +1079,15 @@ func (c *ShardedCoordinator) observeMutation(routeID uint64, mut *pb.Mutation) {
 	if c.sampler == nil {
 		return
 	}
-	c.sampler.Observe(routeID, keyviz.OpWrite, len(mut.Key), len(mut.Value))
+	c.sampler.Observe(routeID, mut.Key, keyviz.OpWrite, len(mut.Value))
 }
 
 // observeRead records a single linearizable / lease read against the
-// route. valueLen is always 0 here — the consistency check at this
-// layer doesn't fetch data; the actual GetAt on the store happens
-// further down the stack and isn't observed yet.
+// route. The full key is passed (not just its length) so the sampler
+// can bucket the read into the key's sub-range for the hot-key heatmap;
+// the read's valueLen is 0 — the consistency check at this layer
+// doesn't fetch data; the actual GetAt on the store happens further
+// down the stack and isn't observed yet.
 //
 // Callers MUST pass an already-resolved routeID (via
 // routeAndGroupForKey) so the GetRoute lookup runs once across the
@@ -1097,11 +1099,11 @@ func (c *ShardedCoordinator) observeMutation(routeID uint64, mut *pb.Mutation) {
 // MVCCStore.GetAt without going through the coordinator) still
 // bypass keyviz; sampling those is task B in the design's Phase 2
 // follow-up.
-func (c *ShardedCoordinator) observeRead(routeID uint64, keyLen int) {
+func (c *ShardedCoordinator) observeRead(routeID uint64, key []byte) {
 	if c.sampler == nil {
 		return
 	}
-	c.sampler.Observe(routeID, keyviz.OpRead, keyLen, 0)
+	c.sampler.Observe(routeID, key, keyviz.OpRead, 0)
 }
 
 func (c *ShardedCoordinator) groupMutations(reqs []*Elem[OP]) (map[uint64][]*pb.Mutation, []uint64, error) {

--- a/kv/sharded_coordinator_sampler_test.go
+++ b/kv/sharded_coordinator_sampler_test.go
@@ -22,6 +22,7 @@ type recordingSampler struct {
 type sampleCall struct {
 	routeID  uint64
 	op       keyviz.Op
+	key      []byte
 	keyLen   int
 	valueLen int
 }
@@ -29,7 +30,17 @@ type sampleCall struct {
 func (r *recordingSampler) Observe(routeID uint64, key []byte, op keyviz.Op, valueLen int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.calls = append(r.calls, sampleCall{routeID: routeID, op: op, keyLen: len(key), valueLen: valueLen})
+	// Copy the key: the sampler contract lets callers reuse the buffer,
+	// and the sub-range bucketer depends on the exact bytes, so the test
+	// asserts the forwarded bytes (not just length) survived the
+	// keyLen->key signature change.
+	r.calls = append(r.calls, sampleCall{
+		routeID:  routeID,
+		op:       op,
+		key:      append([]byte(nil), key...),
+		keyLen:   len(key),
+		valueLen: valueLen,
+	})
 }
 
 func (r *recordingSampler) snapshot() []sampleCall {
@@ -91,6 +102,7 @@ func TestShardedCoordinatorObservesEveryDispatchedMutation(t *testing.T) {
 		require.Equal(t, sampleCall{
 			routeID:  route.RouteID,
 			op:       keyviz.OpWrite,
+			key:      append([]byte(nil), elem.Key...),
 			keyLen:   len(elem.Key),
 			valueLen: len(elem.Value),
 		}, calls[i], "Observe call %d for key %q", i, elem.Key)
@@ -187,11 +199,12 @@ func TestShardedCoordinatorObservesLeaseAndLinearizableReads(t *testing.T) {
 	want := sampleCall{
 		routeID:  route.RouteID,
 		op:       keyviz.OpRead,
+		key:      append([]byte(nil), key...),
 		keyLen:   len(key),
 		valueLen: 0,
 	}
-	require.Equal(t, want, calls[0])
-	require.Equal(t, want, calls[1])
+	require.Equal(t, want, calls[0], "linearizable read must forward the full key bytes")
+	require.Equal(t, want, calls[1], "lease read must forward the full key bytes")
 }
 
 // TestShardedCoordinatorSkipsObserveForLeadershipChecks pins the

--- a/kv/sharded_coordinator_sampler_test.go
+++ b/kv/sharded_coordinator_sampler_test.go
@@ -26,10 +26,10 @@ type sampleCall struct {
 	valueLen int
 }
 
-func (r *recordingSampler) Observe(routeID uint64, op keyviz.Op, keyLen, valueLen int) {
+func (r *recordingSampler) Observe(routeID uint64, key []byte, op keyviz.Op, valueLen int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.calls = append(r.calls, sampleCall{routeID: routeID, op: op, keyLen: keyLen, valueLen: valueLen})
+	r.calls = append(r.calls, sampleCall{routeID: routeID, op: op, keyLen: len(key), valueLen: valueLen})
 }
 
 func (r *recordingSampler) snapshot() []sampleCall {

--- a/main.go
+++ b/main.go
@@ -193,6 +193,7 @@ var (
 	keyvizMaxTrackedRoutes       = flag.Int("keyvizMaxTrackedRoutes", keyviz.DefaultMaxTrackedRoutes, "Maximum routes tracked individually before excess routes coarsen into virtual buckets")
 	keyvizMaxMemberRoutesPerSlot = flag.Int("keyvizMaxMemberRoutesPerSlot", keyviz.DefaultMaxMemberRoutesPerSlot, "Maximum members listed on a virtual bucket; excess routes still drive the bucket counters")
 	keyvizHistoryColumns         = flag.Int("keyvizHistoryColumns", keyviz.DefaultHistoryColumns, "Maximum matrix columns retained in the keyviz ring buffer (each column = one Step)")
+	keyvizKeyBucketsPerRoute     = flag.Int("keyvizKeyBucketsPerRoute", keyviz.DefaultKeyBucketsPerRoute, "Order-preserving sub-range buckets per individual route for the hot-key heatmap; 1 disables sub-bucketing (route-granular, today's behaviour). Capped at 256; memory is ~K*32 bytes/route, so K_max ~= memBudget/(32*keyvizMaxTrackedRoutes)")
 	// Phase 2-C cluster fan-out: comma-separated list of admin
 	// HTTP endpoints (host:port or scheme://host:port). When set,
 	// the admin keyviz handler aggregates the local matrix with
@@ -1886,6 +1887,7 @@ func buildKeyVizSampler() *keyviz.MemSampler {
 		HistoryColumns:         *keyvizHistoryColumns,
 		MaxTrackedRoutes:       *keyvizMaxTrackedRoutes,
 		MaxMemberRoutesPerSlot: *keyvizMaxMemberRoutesPerSlot,
+		KeyBucketsPerRoute:     *keyvizKeyBucketsPerRoute,
 	})
 }
 

--- a/main_keyviz_test.go
+++ b/main_keyviz_test.go
@@ -46,7 +46,7 @@ func TestSeedKeyVizRoutesCopiesEngineCatalogue(t *testing.T) {
 	seedKeyVizRoutes(s, engine)
 
 	for _, r := range engine.Stats() {
-		s.Observe(r.RouteID, keyviz.OpRead, 1, 1)
+		s.Observe(r.RouteID, make([]byte, 1), keyviz.OpRead, 1)
 	}
 	s.Flush()
 	cols := s.Snapshot(time.Time{}, time.Time{})
@@ -74,7 +74,7 @@ func TestStartKeyVizFlusherReturnsAfterCancel(t *testing.T) {
 	t.Parallel()
 	s := keyviz.NewMemSampler(keyviz.MemSamplerOptions{Step: time.Millisecond, HistoryColumns: 4})
 	require.True(t, s.RegisterRoute(1, []byte("a"), []byte("b"), 0))
-	s.Observe(1, keyviz.OpRead, 0, 0)
+	s.Observe(1, make([]byte, 0), keyviz.OpRead, 0)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	eg, _ := errgroup.WithContext(ctx)
@@ -109,7 +109,7 @@ func TestPublishLeaderTermsFromSnapshotsStampsRows(t *testing.T) {
 	publishLeaderTermsFromSnapshots(s, []groupTermSnapshot{
 		{groupID: 7, term: 42},
 	})
-	s.Observe(1, keyviz.OpWrite, 16, 64)
+	s.Observe(1, make([]byte, 16), keyviz.OpWrite, 64)
 	s.Flush()
 	cols := s.Snapshot(time.Time{}, time.Time{})
 	require.Len(t, cols, 1)


### PR DESCRIPTION
## What

Implements the merged design `docs/design/2026_05_25_proposed_keyviz_subrange_sampling.md` (#829): **per-route sub-range (hot-key) sampling**. Each individual route's `[Start, End)` is divided into `K` **order-preserving** sub-buckets, so the Key Visualizer surfaces hot keys / hot sub-ranges (BigTable-style) instead of collapsing a whole route to a single heatmap row.

Opt-in via `--keyvizKeyBucketsPerRoute` (**default 1 = today's exact route-level behaviour**, cap 256). Inert until raised.

## How

- **Sampler** (`keyviz/sampler.go`): `Observe(routeID, key, op, valueLen)` now takes the key and buckets it via `subBucketIndex`. Each `routeSlot` carries an **immutable** sub-layout (`subPrefixLen/subStart/subEnd/subSpan` + `subLo/subHi` bound snapshots + `subBuckets []subCounter`), set once at register and never recomputed — so the hot path reads it lock-free. Bucketing = even division over an 8-byte window past the Start/End common prefix, exact 128-bit math (`bits.Mul64/Div64`), with a **full-key edge clamp** so it is globally order-preserving even for out-of-range keys. `Flush` emits one row per non-empty sub-bucket, bounds tiling `[Start,End)` exactly (bucket 0 → route Start, last → route End). New `MatrixRow.SubBucket/SubBucketCount`.
- **Pivot** (`internal/admin/keyviz_handler.go` + `adapter/admin_grpc.go`): re-keyed from bare `RouteID` to `BucketID` (embeds `#subIdx` when `SubBucketCount>1`) so a route's sub-rows don't collide. K=1 keeps the exact legacy `route:<id>` id. **No proto change** — `BucketId` already distinguishes the sub-rows.
- **Coordinator**: `observeMutation`/`observeRead` forward the full key (both call sites already had it in scope).

## Performance

`BenchmarkObserveSubRange` (hot path):

| K | ns/op | allocs/op |
|---|---|---|
| 1 (default) | 8.7 | 0 |
| 64 | 18.4 | 0 |

Allocation-free at both; the K=64 cost is one `windowUint64` + `Mul64`/`Div64` + two `bytes.Compare` clamps. Memory bounded `K×32 B/route`; cap 256 → ~80 MB worst case at the default `MaxTrackedRoutes`.

## Caller audit (semantic-changing signature)

`Observe` dropped `keyLen` for `key []byte`. Non-test callers grep-audited: `observeMutation` (`mut.Key`) and `observeRead` — which itself changed signature; both its call sites (`LinearizableReadForKey`, `LeaseReadForKey`) already pass the full key. `recordingSampler` / benchmark / `sampler_test` updated. No caller treats the argument as anything but the observed key.

## Five-lens self-review (per CLAUDE.md)

1. **Data loss** — read-only sampling path; no Raft/FSM/Pebble/TTL. Sub-bucketing only re-attributes already-counted traffic. Grace-window reclaim **preserves** counters (never zeroed/resized) — pinned by `TestSamplerGraceWindowReRegistrationKeepsStaleLayout`. Existing retired-slot/grace tests green.
2. **Concurrency / distributed** — hot path lock-free: sub-layout (incl. `subLo/subHi`) immutable for the slot's lifetime, read without `metaMu`; counters per-sub-bucket atomics; `Flush` drains with `atomic.Swap`. Reclaim does not recompute the layout, so there is no writer to race the reader. Aggregates stay single-bucket (no new `metaMu`). `go test -race ./keyviz/...` green.
3. **Performance** — see table; allocation-free, no extra Raft round-trips, HLC untouched. Flush cost rises with non-empty sub-buckets (off the request path).
4. **Data consistency** — sub-rows carry the parent `(RaftGroupID, LeaderTerm)` unchanged, so fan-out dedupe + per-cell conflict operate identically. Bucketing deterministic + monotone (rapid property). Pivot re-key prevents sub-row collisions (admin + adapter regression tests). Mixed-K peers coexist (not merged). K=1 BucketID byte-identical to today.
5. **Test coverage** — `computeSubLayout` table; `subBucketIndex` edges + single-bucket + **rapid order-preservation property** (which caught a real out-of-range monotonicity bug, fixed via the full-key clamp); hot-key-on-distinct-row e2e; exact tiling; grace-window stale-layout + post-grace fresh; K=1 regression; pivot-collision (admin + adapter); mixed-K fan-out coexist; K=1-vs-K=64 benchmark.

## Test evidence

`go build ./...`, `go vet ./...`, `golangci-lint` (0 issues), `go test ./keyviz/... ./internal/admin/... ./kv/...` and scoped `./adapter/` keyviz tests all green; `go test -race ./keyviz/...` green. The full `./adapter/...` suite (S3/SQS/Dynamo/Redis integration) exceeds the local 10-min sandbox budget — left to CI.

## Implementation notes vs the proposed doc (for the doc follow-up)

Two refinements surfaced during implementation; the proposed→implemented doc rename will fold these in plus the round-5 clarity edits that landed after #829 merged:

1. **Full-key edge clamp.** The window only sees bytes past the common prefix, so window-only bucketing isn't order-preserving for keys *outside* `[Start,End)` (the rapid property found this). Added immutable `subLo/subHi` bound snapshots and clamp on the full key first. In-range keys (the only ones Observe sees in production) are unaffected.
2. **Degenerate case is empty-range-only.** Because `commonPrefixLen` lands exactly on the first differing byte, the window always captures a real difference for `Start < End`; the "window too narrow" degenerate case in §3.2 is therefore unreachable in practice — only `Start == End` collapses to a single bucket. The guard remains as correct defensive code.
