### PR TITLE
backup: Phase 0b M3b-1 — DynamoDB base-item reverse encoder (no GSI)

### DIFF
--- a/internal/backup/encode_dynamodb.go
+++ b/internal/backup/encode_dynamodb.go
@@ -138,7 +138,10 @@ func (e *DynamoDBEncoder) encodeTable(b *snapshotBuilder, root *os.Root, tableDi
 
 	genKey := append([]byte(DDBTableGenPrefix), encTable...)
 	genVal := []byte(strconv.FormatUint(ddbRestoreGeneration, 10))
-	return b.Add(genKey, genVal, 0)
+	if err := b.Add(genKey, genVal, 0); err != nil {
+		return err
+	}
+	return e.encodeItems(b, root, tableDir, tableName, schema)
 }
 
 // readSchema opens <table>/_schema.json within root (symlink-escape /

--- a/internal/backup/encode_dynamodb_items.go
+++ b/internal/backup/encode_dynamodb_items.go
@@ -395,7 +395,13 @@ func decodeAVNull(v any) (*pb.DynamoAttributeValue, error) {
 	if !ok {
 		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "NULL value is not a boolean")
 	}
-	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_NullValue{NullValue: b}}, nil
+	// AWS DynamoDB's NULL is definitionally {"NULL": true}; {"NULL": false}
+	// is invalid and unreachable from real data, so fail closed rather
+	// than emit a record the live API would reject on restore.
+	if !b {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "NULL value must be true")
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_NullValue{NullValue: true}}, nil
 }
 
 func decodeAVStringSet(v any) (*pb.DynamoAttributeValue, error) {
@@ -418,6 +424,9 @@ func decodeAVBinarySet(v any) (*pb.DynamoAttributeValue, error) {
 	arr, ok := v.([]any)
 	if !ok {
 		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "BS value is not an array")
+	}
+	if len(arr) == 0 {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "BS must not be empty")
 	}
 	out := make([][]byte, 0, len(arr))
 	for _, e := range arr {
@@ -470,11 +479,16 @@ func decodeAVMap(v any) (*pb.DynamoAttributeValue, error) {
 	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_M{M: &pb.DynamoAttributeValueMap{Values: out}}}, nil
 }
 
-// stringSliceFromAny coerces a JSON array of strings (SS / NS).
+// stringSliceFromAny coerces a JSON array of strings (SS / NS). AWS
+// DynamoDB rejects empty sets, and an empty-set record would fail on
+// restore, so an empty array fails closed.
 func stringSliceFromAny(v any) ([]string, error) {
 	arr, ok := v.([]any)
 	if !ok {
 		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "set value is not an array")
+	}
+	if len(arr) == 0 {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "set must not be empty")
 	}
 	out := make([]string, 0, len(arr))
 	for _, e := range arr {

--- a/internal/backup/encode_dynamodb_items.go
+++ b/internal/backup/encode_dynamodb_items.go
@@ -403,13 +403,11 @@ func decodeAVNull(v any) (*pb.DynamoAttributeValue, error) {
 	if !ok {
 		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "NULL value is not a boolean")
 	}
-	// AWS DynamoDB's NULL is definitionally {"NULL": true}; {"NULL": false}
-	// is invalid and unreachable from real data, so fail closed rather
-	// than emit a record the live API would reject on restore.
-	if !b {
-		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "NULL value must be true")
-	}
-	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_NullValue{NullValue: true}}, nil
+	// Preserve the boolean as-is: the decoder serializes NullValue
+	// verbatim, so the encoder must round-trip NULL=false too (an internal
+	// record may carry it). AWS-API payload validity is enforced at the
+	// adapter's PutItem boundary, not on this internal-record path.
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_NullValue{NullValue: b}}, nil
 }
 
 func decodeAVStringSet(v any) (*pb.DynamoAttributeValue, error) {
@@ -432,9 +430,6 @@ func decodeAVBinarySet(v any) (*pb.DynamoAttributeValue, error) {
 	arr, ok := v.([]any)
 	if !ok {
 		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "BS value is not an array")
-	}
-	if len(arr) == 0 {
-		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "BS must not be empty")
 	}
 	out := make([][]byte, 0, len(arr))
 	for _, e := range arr {
@@ -487,16 +482,15 @@ func decodeAVMap(v any) (*pb.DynamoAttributeValue, error) {
 	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_M{M: &pb.DynamoAttributeValueMap{Values: out}}}, nil
 }
 
-// stringSliceFromAny coerces a JSON array of strings (SS / NS). AWS
-// DynamoDB rejects empty sets, and an empty-set record would fail on
-// restore, so an empty array fails closed.
+// stringSliceFromAny coerces a JSON array of strings (SS / NS). An empty
+// array is preserved (not rejected): the decoder intentionally serializes
+// nil/empty sets as [] to avoid dropping the attribute, so the encoder
+// must round-trip that structural case rather than fail recovery of a
+// legacy/drifted snapshot.
 func stringSliceFromAny(v any) ([]string, error) {
 	arr, ok := v.([]any)
 	if !ok {
 		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "set value is not an array")
-	}
-	if len(arr) == 0 {
-		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "set must not be empty")
 	}
 	out := make([]string, 0, len(arr))
 	for _, e := range arr {

--- a/internal/backup/encode_dynamodb_items.go
+++ b/internal/backup/encode_dynamodb_items.go
@@ -108,7 +108,15 @@ func (e *DynamoDBEncoder) encodeCompositeItemDir(b *snapshotBuilder, root *os.Ro
 		return err
 	}
 	for _, ent := range entries {
-		if ent.IsDir() || !isJSONFilename(ent.Name()) {
+		// The decoder emits at most items/<hash>/<range>.json — a directory
+		// nested inside a hash directory cannot come from a valid dump, so
+		// fail closed rather than silently skip (which would under-count
+		// restored items without any error).
+		if ent.IsDir() {
+			return errors.Wrapf(ErrDDBEncodeInvalidItem,
+				"%s: unexpected nested directory %q (items layout is at most 2 levels)", sub, ent.Name())
+		}
+		if !isJSONFilename(ent.Name()) {
 			continue
 		}
 		if err := e.encodeOneItem(b, root, filepath.Join(sub, ent.Name()), tableName, schema); err != nil {

--- a/internal/backup/encode_dynamodb_items.go
+++ b/internal/backup/encode_dynamodb_items.go
@@ -1,0 +1,503 @@
+package backup
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	pb "github.com/bootjp/elastickv/proto"
+	"github.com/cockroachdb/errors"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+// encode_dynamodb_items.go is the Phase 0b DynamoDB ITEM reverse encoder
+// (milestone M3b-1) — the inverse of the per-item JSON emitter in
+// dynamodb.go (writeDDBItem / itemToPublic). It reconstructs the
+// !ddb|item|<base64url(table)>|<gen>|<orderedHash><orderedRange> records
+// from each table's items/<pk>[/<sk>].json files.
+//
+// Scope of this slice (M3b-1):
+//   - S (string) and B (binary) primary/range keys only. Numeric (N)
+//     keys take a separate ordered encoding (encodeNumericKeyBytes in the
+//     live adapter) that is reproduced in a follow-up slice; until then a
+//     numeric key fails closed (ErrDDBEncodeNumericKeyUnsupported) rather
+//     than emitting a wrongly-ordered key the live store would mis-sort.
+//   - Base items only. The derived !ddb|gsi| index rows (which the
+//     decoder drops as a no-op because they are derivable from the base
+//     item set + schema) land in a later slice.
+//
+// Format fidelity is pinned against the live adapter write path
+// (adapter/dynamodb.go: dynamoItemKey / encodeDynamoKeySegment /
+// storedDDBItemMagic), not just the decode side, so the emitted .fsm
+// loads into a running cluster. The ORDERED key encoding (not the legacy
+// base64url-segment EncodeDDBItemKey test helper) is required because the
+// restored schema stamps KeyEncodingVersion=V2.
+//
+// Generation: every item key embeds ddbRestoreGeneration — the SAME
+// uniform value the schema proto and the !ddb|meta|gen| counter carry
+// (see encode_dynamodb.go) — so the restored table's counter and its
+// item keys always agree.
+
+// Ordered-key bytes mirror adapter/dynamodb.go's dynamoKey* constants: a
+// 0x00 byte in the raw key is escaped to 0x00 0xFF, and every segment is
+// terminated with 0x00 0x01 so concatenated hash+range segments sort and
+// parse unambiguously.
+const (
+	ddbKeyEscapeByte      = byte(0x00)
+	ddbKeyTerminatorByte  = byte(0x01)
+	ddbKeyEscapedZeroByte = byte(0xFF)
+	// ddbKeySegmentOverhead is the two-byte 0x00 0x01 terminator every
+	// ordered key segment carries (mirrors dynamoKeySegmentOverhead).
+	ddbKeySegmentOverhead = 2
+)
+
+// ErrDDBEncodeInvalidItem is returned when an items/*.json file cannot be
+// parsed into a well-formed item (bad JSON shape, unknown attribute type,
+// missing primary-key attribute, or a non-S/N/B primary key).
+var ErrDDBEncodeInvalidItem = errors.New("backup: dynamodb encode invalid item json")
+
+// ErrDDBEncodeNumericKeyUnsupported is returned when a primary or range
+// key attribute is numeric (N). The ordered numeric key encoding is not
+// reproduced in this slice; failing closed avoids emitting a key the live
+// store would sort incorrectly.
+var ErrDDBEncodeNumericKeyUnsupported = errors.New("backup: dynamodb numeric primary key not supported by encoder yet")
+
+// encodeItems walks <tableDir>/items/ and stages one !ddb|item| record
+// per item file. A missing items/ directory is not an error (a table may
+// have a schema but no rows).
+func (e *DynamoDBEncoder) encodeItems(b *snapshotBuilder, root *os.Root, tableDir, tableName string, schema *pb.DynamoTableSchema) error {
+	itemsRel := filepath.Join(tableDir, "items")
+	linfo, err := root.Lstat(itemsRel)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return errors.WithStack(err)
+	}
+	if !linfo.IsDir() {
+		return errors.Wrapf(ErrDDBEncodeInvalidItem, "%s is not a directory", itemsRel)
+	}
+	entries, err := readRootSubdirEntries(root, itemsRel)
+	if err != nil {
+		return err
+	}
+	for _, ent := range entries {
+		switch {
+		case ent.IsDir():
+			if err := e.encodeCompositeItemDir(b, root, itemsRel, ent.Name(), tableName, schema); err != nil {
+				return err
+			}
+		case isJSONFilename(ent.Name()):
+			if err := e.encodeOneItem(b, root, filepath.Join(itemsRel, ent.Name()), tableName, schema); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// encodeCompositeItemDir handles the composite-key layout
+// items/<hashSeg>/<rangeSeg>.json: every .json file directly under the
+// hash directory is one item.
+func (e *DynamoDBEncoder) encodeCompositeItemDir(b *snapshotBuilder, root *os.Root, itemsRel, hashDir, tableName string, schema *pb.DynamoTableSchema) error {
+	sub := filepath.Join(itemsRel, hashDir)
+	entries, err := readRootSubdirEntries(root, sub)
+	if err != nil {
+		return err
+	}
+	for _, ent := range entries {
+		if ent.IsDir() || !isJSONFilename(ent.Name()) {
+			continue
+		}
+		if err := e.encodeOneItem(b, root, filepath.Join(sub, ent.Name()), tableName, schema); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// encodeOneItem reads one item JSON file, rebuilds the proto, and stages
+// its !ddb|item| key/value on b.
+func (e *DynamoDBEncoder) encodeOneItem(b *snapshotBuilder, root *os.Root, rel, tableName string, schema *pb.DynamoTableSchema) error {
+	public, err := readRootJSONItem(root, rel)
+	if err != nil {
+		return err
+	}
+	item, err := publicToItem(public)
+	if err != nil {
+		return errors.Wrapf(err, "%s", rel)
+	}
+	key, err := ddbItemKeyBytes(tableName, ddbRestoreGeneration, schema, item)
+	if err != nil {
+		return errors.Wrapf(err, "%s", rel)
+	}
+	val, err := marshalStoredDDBItem(item)
+	if err != nil {
+		return err
+	}
+	return b.Add(key, val, 0)
+}
+
+// readRootSubdirEntries lists a subdirectory THROUGH the pinned root fd
+// (os.Root.Open enforces no symlink escape), rather than re-resolving the
+// path with os.ReadDir.
+func readRootSubdirEntries(root *os.Root, rel string) ([]os.DirEntry, error) {
+	d, err := root.Open(rel)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer func() { _ = d.Close() }()
+	entries, err := d.ReadDir(-1)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return entries, nil
+}
+
+// readRootJSONItem opens an item file within root (symlink-escape / FIFO /
+// hard-link safe, like readSchema) and decodes its public attribute map.
+func readRootJSONItem(root *os.Root, rel string) (map[string]any, error) {
+	linfo, err := root.Lstat(rel)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if !linfo.Mode().IsRegular() {
+		return nil, errors.Wrapf(ErrDDBEncodeNotRegular, "%s (mode=%s)", rel, linfo.Mode())
+	}
+	if err := refuseHardLink(linfo, rel); err != nil {
+		return nil, err
+	}
+	f, err := root.Open(rel)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer func() { _ = f.Close() }()
+	var public map[string]any
+	if err := decodeOneJSON(f, &public); err != nil {
+		return nil, errors.Wrapf(ErrDDBEncodeInvalidItem, "%s: %v", rel, err)
+	}
+	return public, nil
+}
+
+func isJSONFilename(name string) bool {
+	return strings.HasSuffix(name, ".json")
+}
+
+// ddbItemKeyBytes builds the ordered !ddb|item| key for an item against
+// the table schema's primary-key attribute names.
+func ddbItemKeyBytes(tableName string, generation uint64, schema *pb.DynamoTableSchema, item *pb.DynamoItem) ([]byte, error) {
+	attrs := item.GetAttributes()
+	hashName := schema.GetPrimaryKey().GetHashKey()
+	hashAV, ok := attrs[hashName]
+	if !ok {
+		return nil, errors.Wrapf(ErrDDBEncodeInvalidItem, "item missing hash-key attribute %q", hashName)
+	}
+	hashRaw, err := ddbPrimaryKeyBytes(hashAV)
+	if err != nil {
+		return nil, err
+	}
+	key := ddbItemKeyPrefix(tableName, generation)
+	key = append(key, encodeDDBOrderedKeySegment(hashRaw)...)
+	rangeName := schema.GetPrimaryKey().GetRangeKey()
+	if rangeName == "" {
+		return key, nil
+	}
+	rangeAV, ok := attrs[rangeName]
+	if !ok {
+		return nil, errors.Wrapf(ErrDDBEncodeInvalidItem, "item missing range-key attribute %q", rangeName)
+	}
+	rangeRaw, err := ddbPrimaryKeyBytes(rangeAV)
+	if err != nil {
+		return nil, err
+	}
+	return append(key, encodeDDBOrderedKeySegment(rangeRaw)...), nil
+}
+
+// ddbItemKeyPrefix reproduces dynamoItemPrefixForTable:
+// !ddb|item|<base64url(table)>|<gen>|.
+func ddbItemKeyPrefix(tableName string, generation uint64) []byte {
+	enc := base64.RawURLEncoding.EncodeToString([]byte(tableName))
+	gen := strconv.FormatUint(generation, 10)
+	out := make([]byte, 0, len(DDBItemPrefix)+len(enc)+len(gen)+len("||"))
+	out = append(out, DDBItemPrefix...)
+	out = append(out, enc...)
+	out = append(out, '|')
+	out = append(out, gen...)
+	out = append(out, '|')
+	return out
+}
+
+// ddbPrimaryKeyBytes extracts the raw key bytes for a primary/range key
+// attribute. Only S and B are supported in this slice; N fails closed and
+// any non-key kind is rejected (DynamoDB primary keys are S, N, or B).
+func ddbPrimaryKeyBytes(av *pb.DynamoAttributeValue) ([]byte, error) {
+	switch v := av.GetValue().(type) {
+	case *pb.DynamoAttributeValue_S:
+		return []byte(v.S), nil
+	case *pb.DynamoAttributeValue_B:
+		return v.B, nil
+	case *pb.DynamoAttributeValue_N:
+		return nil, errors.Wrap(ErrDDBEncodeNumericKeyUnsupported, "numeric primary key")
+	default:
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "primary key attribute is not S, N, or B")
+	}
+}
+
+// encodeDDBOrderedKeySegment reproduces encodeDynamoKeySegment: escape
+// 0x00 -> 0x00 0xFF, then append the 0x00 0x01 terminator.
+func encodeDDBOrderedKeySegment(raw []byte) []byte {
+	out := make([]byte, 0, len(raw)+ddbKeySegmentOverhead)
+	for _, c := range raw {
+		if c == ddbKeyEscapeByte {
+			out = append(out, ddbKeyEscapeByte, ddbKeyEscapedZeroByte)
+			continue
+		}
+		out = append(out, c)
+	}
+	return append(out, ddbKeyEscapeByte, ddbKeyTerminatorByte)
+}
+
+// marshalStoredDDBItem reproduces the live item value:
+// storedDDBItemMagic + deterministic proto marshal.
+func marshalStoredDDBItem(item *pb.DynamoItem) ([]byte, error) {
+	body, err := gproto.MarshalOptions{Deterministic: true}.Marshal(item)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	out := make([]byte, 0, len(storedDDBItemMagic))
+	out = append(out, storedDDBItemMagic...)
+	return append(out, body...), nil
+}
+
+// publicToItem is the inverse of itemToPublic: it rebuilds a DynamoItem
+// proto from the decoded items/*.json attribute map.
+func publicToItem(public map[string]any) (*pb.DynamoItem, error) {
+	attrs := make(map[string]*pb.DynamoAttributeValue, len(public))
+	for name, raw := range public {
+		m, ok := raw.(map[string]any)
+		if !ok {
+			return nil, errors.Wrapf(ErrDDBEncodeInvalidItem, "attribute %q is not an object", name)
+		}
+		av, err := publicToAttributeValue(m)
+		if err != nil {
+			return nil, errors.Wrapf(err, "attribute %q", name)
+		}
+		attrs[name] = av
+	}
+	return &pb.DynamoItem{Attributes: attrs}, nil
+}
+
+// publicToAttributeValue is the inverse of attributeValueToPublic: the
+// public form is a single-key object {TYPE: value}.
+func publicToAttributeValue(m map[string]any) (*pb.DynamoAttributeValue, error) {
+	if len(m) != 1 {
+		return nil, errors.Wrapf(ErrDDBEncodeInvalidItem,
+			"attribute object must have exactly one type key, got %d", len(m))
+	}
+	for typ, val := range m {
+		return decodePublicAV(typ, val)
+	}
+	return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "empty attribute object")
+}
+
+// decodePublicAV dispatches a single {TYPE: value} pair. Scalars and
+// collections are split into two grouped switches so each stays well
+// under the cyclomatic limit and so the package has no init-cycle from a
+// var-level decoder table referencing the recursive L/M decoders.
+func decodePublicAV(typ string, val any) (*pb.DynamoAttributeValue, error) {
+	if av, matched, err := decodeScalarAV(typ, val); matched || err != nil {
+		return av, err
+	}
+	if av, matched, err := decodeCollectionAV(typ, val); matched || err != nil {
+		return av, err
+	}
+	return nil, errors.Wrapf(ErrDDBEncodeInvalidItem, "unknown attribute type %q", typ)
+}
+
+func decodeScalarAV(typ string, val any) (*pb.DynamoAttributeValue, bool, error) {
+	switch typ {
+	case "S":
+		av, err := decodeAVString(val)
+		return av, true, err
+	case "N":
+		av, err := decodeAVNumber(val)
+		return av, true, err
+	case "B":
+		av, err := decodeAVBinary(val)
+		return av, true, err
+	case "BOOL":
+		av, err := decodeAVBool(val)
+		return av, true, err
+	case "NULL":
+		av, err := decodeAVNull(val)
+		return av, true, err
+	}
+	return nil, false, nil
+}
+
+func decodeCollectionAV(typ string, val any) (*pb.DynamoAttributeValue, bool, error) {
+	switch typ {
+	case "SS":
+		av, err := decodeAVStringSet(val)
+		return av, true, err
+	case "NS":
+		av, err := decodeAVNumberSet(val)
+		return av, true, err
+	case "BS":
+		av, err := decodeAVBinarySet(val)
+		return av, true, err
+	case "L":
+		av, err := decodeAVList(val)
+		return av, true, err
+	case "M":
+		av, err := decodeAVMap(val)
+		return av, true, err
+	}
+	return nil, false, nil
+}
+
+func decodeAVString(v any) (*pb.DynamoAttributeValue, error) {
+	s, ok := v.(string)
+	if !ok {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "S value is not a string")
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_S{S: s}}, nil
+}
+
+func decodeAVNumber(v any) (*pb.DynamoAttributeValue, error) {
+	s, ok := v.(string)
+	if !ok {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "N value is not a string")
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_N{N: s}}, nil
+}
+
+func decodeAVBinary(v any) (*pb.DynamoAttributeValue, error) {
+	raw, err := base64StdFromAny(v)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_B{B: raw}}, nil
+}
+
+func decodeAVBool(v any) (*pb.DynamoAttributeValue, error) {
+	b, ok := v.(bool)
+	if !ok {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "BOOL value is not a boolean")
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_BoolValue{BoolValue: b}}, nil
+}
+
+func decodeAVNull(v any) (*pb.DynamoAttributeValue, error) {
+	b, ok := v.(bool)
+	if !ok {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "NULL value is not a boolean")
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_NullValue{NullValue: b}}, nil
+}
+
+func decodeAVStringSet(v any) (*pb.DynamoAttributeValue, error) {
+	vals, err := stringSliceFromAny(v)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_Ss{Ss: &pb.DynamoStringSet{Values: vals}}}, nil
+}
+
+func decodeAVNumberSet(v any) (*pb.DynamoAttributeValue, error) {
+	vals, err := stringSliceFromAny(v)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_Ns{Ns: &pb.DynamoNumberSet{Values: vals}}}, nil
+}
+
+func decodeAVBinarySet(v any) (*pb.DynamoAttributeValue, error) {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "BS value is not an array")
+	}
+	out := make([][]byte, 0, len(arr))
+	for _, e := range arr {
+		raw, err := base64StdFromAny(e)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, raw)
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_Bs{Bs: &pb.DynamoBinarySet{Values: out}}}, nil
+}
+
+func decodeAVList(v any) (*pb.DynamoAttributeValue, error) {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "L value is not an array")
+	}
+	out := make([]*pb.DynamoAttributeValue, 0, len(arr))
+	for _, e := range arr {
+		m, ok := e.(map[string]any)
+		if !ok {
+			return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "L element is not an object")
+		}
+		child, err := publicToAttributeValue(m)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, child)
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_L{L: &pb.DynamoAttributeValueList{Values: out}}}, nil
+}
+
+func decodeAVMap(v any) (*pb.DynamoAttributeValue, error) {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "M value is not an object")
+	}
+	out := make(map[string]*pb.DynamoAttributeValue, len(m))
+	for name, child := range m {
+		cm, ok := child.(map[string]any)
+		if !ok {
+			return nil, errors.Wrapf(ErrDDBEncodeInvalidItem, "M[%q] is not an object", name)
+		}
+		av, err := publicToAttributeValue(cm)
+		if err != nil {
+			return nil, errors.Wrapf(err, "M[%q]", name)
+		}
+		out[name] = av
+	}
+	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_M{M: &pb.DynamoAttributeValueMap{Values: out}}}, nil
+}
+
+// stringSliceFromAny coerces a JSON array of strings (SS / NS).
+func stringSliceFromAny(v any) ([]string, error) {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "set value is not an array")
+	}
+	out := make([]string, 0, len(arr))
+	for _, e := range arr {
+		s, ok := e.(string)
+		if !ok {
+			return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "set element is not a string")
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// base64StdFromAny decodes a JSON base64 string into bytes. encoding/json
+// renders []byte as standard-base64 strings, so B / BS values round-trip
+// through StdEncoding.
+func base64StdFromAny(v any) ([]byte, error) {
+	s, ok := v.(string)
+	if !ok {
+		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "binary value is not a base64 string")
+	}
+	raw, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return nil, errors.Wrapf(ErrDDBEncodeInvalidItem, "binary value is not valid base64: %v", err)
+	}
+	return raw, nil
+}

--- a/internal/backup/encode_dynamodb_items.go
+++ b/internal/backup/encode_dynamodb_items.go
@@ -274,6 +274,10 @@ func marshalStoredDDBItem(item *pb.DynamoItem) ([]byte, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	// const-capacity, zero-length start + append (magic then body): keeps
+	// the len(magic)+len(body) arithmetic out of make() — which CodeQL
+	// flags as a potential allocation-size overflow — and the zero length
+	// satisfies makezero. Same pattern as marshalStoredDDBSchema.
 	out := make([]byte, 0, len(storedDDBItemMagic))
 	out = append(out, storedDDBItemMagic...)
 	return append(out, body...), nil
@@ -426,6 +430,9 @@ func decodeAVNumberSet(v any) (*pb.DynamoAttributeValue, error) {
 	return &pb.DynamoAttributeValue{Value: &pb.DynamoAttributeValue_Ns{Ns: &pb.DynamoNumberSet{Values: vals}}}, nil
 }
 
+// decodeAVBinarySet rebuilds a BS attribute. Like the SS/NS path, an
+// empty array is preserved (not rejected) to round-trip the structural
+// empty case the decoder serializes for nil/empty sets.
 func decodeAVBinarySet(v any) (*pb.DynamoAttributeValue, error) {
 	arr, ok := v.([]any)
 	if !ok {

--- a/internal/backup/encode_dynamodb_items_test.go
+++ b/internal/backup/encode_dynamodb_items_test.go
@@ -271,26 +271,31 @@ func TestDDBItemKeyBytesLayout(t *testing.T) {
 	}
 }
 
-// TestDDBEncodeItemRejectsInvalidAttributes pins fail-closed validation
-// of DynamoDB semantic constraints on the untrusted dump input: NULL must
-// be true (AWS has no false NULL), and sets (SS/NS/BS) must be non-empty
-// (AWS rejects empty sets, and an empty-set record would fail on restore).
-// gemini HIGH on PR #837.
-func TestDDBEncodeItemRejectsInvalidAttributes(t *testing.T) {
+// TestDDBEncodeItemPreservesStructuralEdgeCases pins ROUND-TRIP fidelity
+// for the structural edge cases the decoder intentionally preserves
+// (rather than dropping): empty sets are serialized as [] and a NULL is
+// serialized with its boolean as-is. The encoder is the decoder's inverse
+// and must reproduce these so a snapshot of a legacy/drifted store can be
+// recovered — the encode path reconstructs internal records, it does NOT
+// re-validate AWS API payload semantics (codex P1/P2 on PR #837).
+func TestDDBEncodeItemPreservesStructuralEdgeCases(t *testing.T) {
 	t.Parallel()
-	cases := map[string]map[string]any{
-		"null false": {"a": map[string]any{"NULL": false}},
-		"empty SS":   {"a": map[string]any{"SS": []any{}}},
-		"empty NS":   {"a": map[string]any{"NS": []any{}}},
-		"empty BS":   {"a": map[string]any{"BS": []any{}}},
+	in := t.TempDir()
+	const table = "edge"
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"edge",`+
+		`"primary_key":{"hash_key":{"name":"id","type":"S"}},`+
+		`"attribute_definitions":[{"name":"id","type":"S"}]}`))
+	item := []byte(`{"id":{"S":"k"},` +
+		`"ess":{"SS":[]},"ens":{"NS":[]},"ebs":{"BS":[]},"nf":{"NULL":false}}`)
+	writeDDBItemFile(t, in, table, "k.json", item)
+
+	out := decodeDDBTree(t, encodeDDBTree(t, in))
+	got := collectDDBItems(t, out, table)
+	if len(got) != 1 {
+		t.Fatalf("decoded %d items, want 1", len(got))
 	}
-	for name, public := range cases {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			if _, err := publicToItem(public); !errors.Is(err, ErrDDBEncodeInvalidItem) {
-				t.Fatalf("publicToItem err = %v, want ErrDDBEncodeInvalidItem", err)
-			}
-		})
+	if !reflect.DeepEqual(got[0], reparse(t, item)) {
+		t.Fatalf("structural edge-case round-trip mismatch:\n got = %#v\nwant = %#v", got[0], reparse(t, item))
 	}
 }
 

--- a/internal/backup/encode_dynamodb_items_test.go
+++ b/internal/backup/encode_dynamodb_items_test.go
@@ -1,0 +1,244 @@
+package backup
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	pb "github.com/bootjp/elastickv/proto"
+	"github.com/cockroachdb/errors"
+)
+
+// writeDDBItemFile writes a raw item JSON body under
+// <root>/dynamodb/<EncodeSegment(table)>/items/<rel>, creating parents.
+func writeDDBItemFile(t *testing.T, root, table, rel string, body []byte) {
+	t.Helper()
+	path := filepath.Join(root, "dynamodb", EncodeSegment([]byte(table)), "items", rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("WriteFile %s: %v", rel, err)
+	}
+}
+
+// collectDDBItems walks the decoded items/ tree for a table and returns
+// each item's public attribute map (parsed from JSON), so assertions do
+// not depend on the decoder's filename layout.
+func collectDDBItems(t *testing.T, outRoot, table string) []map[string]any {
+	t.Helper()
+	itemsDir := filepath.Join(outRoot, "dynamodb", EncodeSegment([]byte(table)), "items")
+	var out []map[string]any
+	err := filepath.WalkDir(itemsDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".json" {
+			return nil
+		}
+		data, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return rerr
+		}
+		var m map[string]any
+		if jerr := json.Unmarshal(data, &m); jerr != nil {
+			return jerr
+		}
+		out = append(out, m)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk decoded items: %v", err)
+	}
+	return out
+}
+
+// reparse normalizes a JSON body through json.Unmarshal so it can be
+// compared against decoded items with reflect.DeepEqual.
+func reparse(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatalf("reparse: %v", err)
+	}
+	return m
+}
+
+// TestDDBEncodeItemCompositeRoundTrip pins the gold-standard directory
+// round-trip for a composite-key (S/S) table carrying every attribute
+// type: the item survives encode -> real DecodeSnapshot -> dump byte for
+// byte.
+func TestDDBEncodeItemCompositeRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "orders"
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"orders",`+
+		`"primary_key":{"hash_key":{"name":"pk","type":"S"},"range_key":{"name":"sk","type":"S"}},`+
+		`"attribute_definitions":[{"name":"pk","type":"S"},{"name":"sk","type":"S"}]}`))
+	item := []byte(`{` +
+		`"pk":{"S":"u1"},"sk":{"S":"2024"},` +
+		`"name":{"S":"alice"},"age":{"N":"30"},"active":{"BOOL":true},"meta":{"NULL":true},` +
+		`"tags":{"SS":["a","b"]},"scores":{"NS":["1","2"]},` +
+		`"blob":{"B":"aGVsbG8="},"blobs":{"BS":["AAE=","Av8="]},` +
+		`"items":{"L":[{"S":"x"},{"N":"5"}]},"nested":{"M":{"k":{"S":"v"}}}` +
+		`}`)
+	writeDDBItemFile(t, in, table, "item.json", item)
+
+	out := decodeDDBTree(t, encodeDDBTree(t, in))
+	got := collectDDBItems(t, out, table)
+	if len(got) != 1 {
+		t.Fatalf("decoded %d items, want 1", len(got))
+	}
+	want := reparse(t, item)
+	if !reflect.DeepEqual(got[0], want) {
+		t.Fatalf("round-tripped item mismatch:\n got = %#v\nwant = %#v", got[0], want)
+	}
+}
+
+// TestDDBEncodeItemHashOnlyRoundTrip pins the hash-only (no range key)
+// layout: items/<hashSeg>.json read at the top level.
+func TestDDBEncodeItemHashOnlyRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "sessions"
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"sessions",`+
+		`"primary_key":{"hash_key":{"name":"id","type":"S"}},`+
+		`"attribute_definitions":[{"name":"id","type":"S"}]}`))
+	item := []byte(`{"id":{"S":"abc"},"v":{"N":"7"}}`)
+	writeDDBItemFile(t, in, table, "abc.json", item)
+
+	out := decodeDDBTree(t, encodeDDBTree(t, in))
+	got := collectDDBItems(t, out, table)
+	if len(got) != 1 {
+		t.Fatalf("decoded %d items, want 1", len(got))
+	}
+	if !reflect.DeepEqual(got[0], reparse(t, item)) {
+		t.Fatalf("hash-only item mismatch: got %#v", got[0])
+	}
+}
+
+// TestDDBEncodeItemBinaryKeyRoundTrip pins a binary (B) hash key, whose
+// raw bytes (including a 0x00 that must be escaped 0x00 0xFF in the
+// ordered key) survive the round-trip.
+func TestDDBEncodeItemBinaryKeyRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "blobs"
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"blobs",`+
+		`"primary_key":{"hash_key":{"name":"bk","type":"B"}},`+
+		`"attribute_definitions":[{"name":"bk","type":"B"}]}`))
+	// bk = bytes {0x00,0x01} (base64 std "AAE="), exercising 0x00 escape.
+	item := []byte(`{"bk":{"B":"AAE="},"payload":{"S":"hi"}}`)
+	writeDDBItemFile(t, in, table, "sub/x.json", item) // also exercises subdir descent
+
+	out := decodeDDBTree(t, encodeDDBTree(t, in))
+	got := collectDDBItems(t, out, table)
+	if len(got) != 1 {
+		t.Fatalf("decoded %d items, want 1", len(got))
+	}
+	if !reflect.DeepEqual(got[0], reparse(t, item)) {
+		t.Fatalf("binary-key item mismatch: got %#v", got[0])
+	}
+}
+
+// TestDDBEncodeItemNumericKeyFailsClosed pins that a numeric (N) primary
+// key fails closed in this slice rather than emitting a wrongly-ordered
+// key.
+func TestDDBEncodeItemNumericKeyFailsClosed(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "counters"
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"counters",`+
+		`"primary_key":{"hash_key":{"name":"id","type":"N"}},`+
+		`"attribute_definitions":[{"name":"id","type":"N"}]}`))
+	writeDDBItemFile(t, in, table, "1.json", []byte(`{"id":{"N":"1"},"v":{"S":"x"}}`))
+
+	b := newSnapshotBuilder(ddbEncTS)
+	err := NewDynamoDBEncoder(in).Encode(b)
+	if !errors.Is(err, ErrDDBEncodeNumericKeyUnsupported) {
+		t.Fatalf("Encode err = %v, want ErrDDBEncodeNumericKeyUnsupported", err)
+	}
+}
+
+// TestDDBEncodeItemMissingHashKeyFailsClosed pins that an item whose JSON
+// lacks the schema's hash-key attribute is rejected.
+func TestDDBEncodeItemMissingHashKeyFailsClosed(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "t"
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"t",`+
+		`"primary_key":{"hash_key":{"name":"id","type":"S"}},`+
+		`"attribute_definitions":[{"name":"id","type":"S"}]}`))
+	writeDDBItemFile(t, in, table, "x.json", []byte(`{"other":{"S":"v"}}`))
+
+	b := newSnapshotBuilder(ddbEncTS)
+	err := NewDynamoDBEncoder(in).Encode(b)
+	if !errors.Is(err, ErrDDBEncodeInvalidItem) {
+		t.Fatalf("Encode err = %v, want ErrDDBEncodeInvalidItem", err)
+	}
+}
+
+// TestDDBEncodeItemMissingItemsDirIsNoop pins that a table with a schema
+// but no items/ directory encodes its schema with no item records and no
+// error.
+func TestDDBEncodeItemMissingItemsDirIsNoop(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "empty"
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"empty",`+
+		`"primary_key":{"hash_key":{"name":"id","type":"S"}},`+
+		`"attribute_definitions":[{"name":"id","type":"S"}]}`))
+	b := newSnapshotBuilder(ddbEncTS)
+	if err := NewDynamoDBEncoder(in).Encode(b); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	// schema record + gen counter, no item records.
+	if b.Len() != 2 {
+		t.Fatalf("entries = %d, want 2 (schema + gen)", b.Len())
+	}
+}
+
+// TestDDBItemKeyBytesLayout pins the FULL ordered item key against a
+// hand-computed expectation. The decoder round-trip cannot cover this
+// (it reconstructs items from the proto VALUE and ignores the key's
+// ordered hash/range payload), so this is the guard that the emitted key
+// matches what the live adapter (dynamoItemKey, KeyEncodingVersion=V2)
+// looks up — i.e. that the restored item is actually GetItem-able.
+func TestDDBItemKeyBytesLayout(t *testing.T) {
+	t.Parallel()
+	schema := &pb.DynamoTableSchema{PrimaryKey: &pb.DynamoKeySchema{HashKey: "h", RangeKey: "r"}}
+	item := &pb.DynamoItem{Attributes: map[string]*pb.DynamoAttributeValue{
+		"h": {Value: &pb.DynamoAttributeValue_S{S: "a"}},
+		"r": {Value: &pb.DynamoAttributeValue_B{B: []byte{0x00, 0x09}}},
+	}}
+	got, err := ddbItemKeyBytes("tbl", 1, schema, item)
+	if err != nil {
+		t.Fatalf("ddbItemKeyBytes: %v", err)
+	}
+	want := []byte(DDBItemPrefix)
+	want = append(want, base64.RawURLEncoding.EncodeToString([]byte("tbl"))...)
+	want = append(want, "|1|"...)
+	want = append(want, 'a', 0x00, 0x01)              // hash "a" -> 'a' 00 01
+	want = append(want, 0x00, 0xFF, 0x09, 0x00, 0x01) // range {00,09} -> 00 FF 09 00 01
+	if !bytes.Equal(got, want) {
+		t.Fatalf("item key = %x, want %x", got, want)
+	}
+}
+
+// TestEncodeDDBOrderedKeySegment pins the ordered-key byte layout
+// directly: 0x00 escapes to 0x00 0xFF and every segment ends 0x00 0x01.
+func TestEncodeDDBOrderedKeySegment(t *testing.T) {
+	t.Parallel()
+	got := encodeDDBOrderedKeySegment([]byte{'a', 0x00, 'b'})
+	want := []byte{'a', 0x00, 0xFF, 'b', 0x00, 0x01}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("ordered segment = %x, want %x", got, want)
+	}
+	if g := encodeDDBOrderedKeySegment(nil); !bytes.Equal(g, []byte{0x00, 0x01}) {
+		t.Fatalf("empty ordered segment = %x, want 0001", g)
+	}
+}

--- a/internal/backup/encode_dynamodb_items_test.go
+++ b/internal/backup/encode_dynamodb_items_test.go
@@ -229,6 +229,29 @@ func TestDDBItemKeyBytesLayout(t *testing.T) {
 	}
 }
 
+// TestDDBEncodeItemRejectsInvalidAttributes pins fail-closed validation
+// of DynamoDB semantic constraints on the untrusted dump input: NULL must
+// be true (AWS has no false NULL), and sets (SS/NS/BS) must be non-empty
+// (AWS rejects empty sets, and an empty-set record would fail on restore).
+// gemini HIGH on PR #837.
+func TestDDBEncodeItemRejectsInvalidAttributes(t *testing.T) {
+	t.Parallel()
+	cases := map[string]map[string]any{
+		"null false": {"a": map[string]any{"NULL": false}},
+		"empty SS":   {"a": map[string]any{"SS": []any{}}},
+		"empty NS":   {"a": map[string]any{"NS": []any{}}},
+		"empty BS":   {"a": map[string]any{"BS": []any{}}},
+	}
+	for name, public := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := publicToItem(public); !errors.Is(err, ErrDDBEncodeInvalidItem) {
+				t.Fatalf("publicToItem err = %v, want ErrDDBEncodeInvalidItem", err)
+			}
+		})
+	}
+}
+
 // TestEncodeDDBOrderedKeySegment pins the ordered-key byte layout
 // directly: 0x00 escapes to 0x00 0xFF and every segment ends 0x00 0x01.
 func TestEncodeDDBOrderedKeySegment(t *testing.T) {

--- a/internal/backup/encode_dynamodb_items_test.go
+++ b/internal/backup/encode_dynamodb_items_test.go
@@ -164,6 +164,48 @@ func TestDDBEncodeItemNumericKeyFailsClosed(t *testing.T) {
 	}
 }
 
+// TestDDBEncodeItemNumericRangeKeyFailsClosed pins the fail-closed path
+// for a numeric RANGE key (the hash-key case is covered separately), so
+// both primary-key positions reject N until the ordered numeric encoding
+// lands (M3b-2).
+func TestDDBEncodeItemNumericRangeKeyFailsClosed(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "events"
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"events",`+
+		`"primary_key":{"hash_key":{"name":"pk","type":"S"},"range_key":{"name":"ts","type":"N"}},`+
+		`"attribute_definitions":[{"name":"pk","type":"S"},{"name":"ts","type":"N"}]}`))
+	writeDDBItemFile(t, in, table, "e.json", []byte(`{"pk":{"S":"a"},"ts":{"N":"100"}}`))
+
+	b := newSnapshotBuilder(ddbEncTS)
+	err := NewDynamoDBEncoder(in).Encode(b)
+	if !errors.Is(err, ErrDDBEncodeNumericKeyUnsupported) {
+		t.Fatalf("Encode err = %v, want ErrDDBEncodeNumericKeyUnsupported", err)
+	}
+}
+
+// TestDDBEncodeItemRejectsDeeperNesting pins that an items/ tree deeper
+// than the decoder's fixed 2 levels (items/<hash>/<range>.json) fails
+// closed rather than silently skipping items — preventing a "restore
+// succeeded but item count is off" surprise from a corrupt/hand-crafted
+// dump (claude review on PR #837).
+func TestDDBEncodeItemRejectsDeeperNesting(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "t"
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"t",`+
+		`"primary_key":{"hash_key":{"name":"pk","type":"S"},"range_key":{"name":"sk","type":"S"}},`+
+		`"attribute_definitions":[{"name":"pk","type":"S"},{"name":"sk","type":"S"}]}`))
+	// items/h/sub/x.json — a directory nested inside a hash directory.
+	writeDDBItemFile(t, in, table, "h/sub/x.json", []byte(`{"pk":{"S":"h"},"sk":{"S":"x"}}`))
+
+	b := newSnapshotBuilder(ddbEncTS)
+	err := NewDynamoDBEncoder(in).Encode(b)
+	if !errors.Is(err, ErrDDBEncodeInvalidItem) {
+		t.Fatalf("Encode err = %v, want ErrDDBEncodeInvalidItem", err)
+	}
+}
+
 // TestDDBEncodeItemMissingHashKeyFailsClosed pins that an item whose JSON
 // lacks the schema's hash-key attribute is rejected.
 func TestDDBEncodeItemMissingHashKeyFailsClosed(t *testing.T) {


### PR DESCRIPTION
## Summary

**Phase 0b M3b-1 — DynamoDB base-item reverse encoder.** Second slice of the DynamoDB reverse encoder (M3): table **items**. Walks each table's `items/<pk>[/<sk>].json` and stages the `!ddb|item|<base64url(table)>|<gen>|<orderedHash><orderedRange>` records (value = `storedDDBItemMagic{0x00,'D','I',0x01}` + deterministic `DynamoItem` proto).

> **Stacked on #833 (M3a, schema encoder).** Base branch is `backup/snapshot-encode-dynamodb`; the diff is M3b-only. Will retarget to `main` once #833 merges.

Builds on M3a's `DynamoDBEncoder`. Design: `docs/design/2026_05_25_proposed_snapshot_logical_encoder.md`.

### Key fidelity
Pinned against the **live adapter** write path (`dynamoItemKey` / `encodeDynamoKeySegment`), **not** the legacy base64url-segment `EncodeDDBItemKey` test helper. The restored schema stamps `KeyEncodingVersion=V2`, so item keys use the **ordered** encoding (escape `0x00`→`0x00 0xFF`, `0x00 0x01` terminator per segment). A hand-computed key-layout test guards this — necessary because the decoder round-trip reconstructs items from the proto **value** and never validates the key's ordered payload.

- `publicToItem` / `publicToAttributeValue`: inverse of `itemToPublic`, covering all 10 attribute types (S, N, B, BOOL, NULL, SS, NS, BS, L, M). Dispatch split into scalar/collection switches (no var init-cycle, complexity well under the limit).
- Generation: every item key embeds `ddbRestoreGeneration` — the same uniform value M3a's schema proto and `!ddb|meta|gen|` counter carry — so the restored counter and item keys always agree.
- Item files read through the same `os.Root` + `IsRegular` + `refuseHardLink` + `decodeOneJSON` guards as the schema reader.

## Scope / deferred (fail-closed, not silent)
- **Numeric (N) keys** fail closed with `ErrDDBEncodeNumericKeyUnsupported` — the ordered numeric encoding (`encodeNumericKeyBytes`) is a follow-up slice (**M3b-2**). S and B keys work now.
- **Derived `!ddb|gsi|` rows** are **not emitted yet** (**M3b-3**). A table restored from this slice has its base items but no secondary-index rows; GSI queries would need a post-restore rebuild until M3b-3. (The decoder already drops GSI rows as a no-op, so the encode→decode round-trip is unaffected.)

## Risk
New code + one wiring line in `encodeTable`. No existing behavior changed. Offline-tool boundary preserved (key/proto formats reproduced, not imported from the live adapter).

## Self-review (5 lenses)
- **Data loss**: every item file read; round-trip via the **real** `DecodeSnapshot` confirms attribute fidelity; fail-closed on bad JSON / numeric key / missing key / non-regular file. Decoder's items layout is a fixed 2 levels and the walk matches it.
- **Concurrency/distributed**: single-goroutine, one builder.
- **Performance**: one streamed read + preallocated key buffers per item; no consensus (offline).
- **Consistency**: ordered key + magic + proto reproduce the live adapter exactly (key-layout test); generation coherent with M3a schema/counter; `KeyEncodingVersion=V2` matches the ordered key.
- **Test coverage**: composite (all 10 attr types), hash-only, binary key with `0x00` escape in a subdir (descent), full key-bytes assertion, numeric fail-closed, missing-hash-key fail-closed, missing-items-dir no-op, ordered-segment unit.

## Test plan
- [x] `go test ./internal/backup/` (full package)
- [x] `golangci-lint run internal/backup/` (0 issues)
- [ ] Follow-up: M3b-2 numeric-key ordered encoding; M3b-3 GSI derivation.
