### PR TITLE
backup: Phase 0b M3b-2 — DynamoDB numeric (N) primary-key ordered encoding

### DIFF
--- a/internal/backup/encode_dynamodb_items.go
+++ b/internal/backup/encode_dynamodb_items.go
@@ -13,20 +13,15 @@ import (
 )
 
 // encode_dynamodb_items.go is the Phase 0b DynamoDB ITEM reverse encoder
-// (milestone M3b-1) — the inverse of the per-item JSON emitter in
-// dynamodb.go (writeDDBItem / itemToPublic). It reconstructs the
+// — the inverse of the per-item JSON emitter in dynamodb.go (writeDDBItem
+// / itemToPublic). It reconstructs the
 // !ddb|item|<base64url(table)>|<gen>|<orderedHash><orderedRange> records
 // from each table's items/<pk>[/<sk>].json files.
 //
-// Scope of this slice (M3b-1):
-//   - S (string) and B (binary) primary/range keys only. Numeric (N)
-//     keys take a separate ordered encoding (encodeNumericKeyBytes in the
-//     live adapter) that is reproduced in a follow-up slice; until then a
-//     numeric key fails closed (ErrDDBEncodeNumericKeyUnsupported) rather
-//     than emitting a wrongly-ordered key the live store would mis-sort.
-//   - Base items only. The derived !ddb|gsi| index rows (which the
-//     decoder drops as a no-op because they are derivable from the base
-//     item set + schema) land in a later slice.
+// Primary keys: S (string), B (binary), and N (number) are all supported;
+// the N ordered encoding lives in encode_dynamodb_numeric.go. The derived
+// !ddb|gsi| index rows (which the decoder drops as a no-op because they
+// are derivable from the base item set + schema) land in a later slice.
 //
 // Format fidelity is pinned against the live adapter write path
 // (adapter/dynamodb.go: dynamoItemKey / encodeDynamoKeySegment /
@@ -55,14 +50,9 @@ const (
 
 // ErrDDBEncodeInvalidItem is returned when an items/*.json file cannot be
 // parsed into a well-formed item (bad JSON shape, unknown attribute type,
-// missing primary-key attribute, or a non-S/N/B primary key).
+// missing primary-key attribute, a non-S/N/B primary key, or a malformed
+// number literal).
 var ErrDDBEncodeInvalidItem = errors.New("backup: dynamodb encode invalid item json")
-
-// ErrDDBEncodeNumericKeyUnsupported is returned when a primary or range
-// key attribute is numeric (N). The ordered numeric key encoding is not
-// reproduced in this slice; failing closed avoids emitting a key the live
-// store would sort incorrectly.
-var ErrDDBEncodeNumericKeyUnsupported = errors.New("backup: dynamodb numeric primary key not supported by encoder yet")
 
 // encodeItems walks <tableDir>/items/ and stages one !ddb|item| record
 // per item file. A missing items/ directory is not an error (a table may
@@ -238,8 +228,9 @@ func ddbItemKeyPrefix(tableName string, generation uint64) []byte {
 }
 
 // ddbPrimaryKeyBytes extracts the raw key bytes for a primary/range key
-// attribute. Only S and B are supported in this slice; N fails closed and
-// any non-key kind is rejected (DynamoDB primary keys are S, N, or B).
+// attribute (DynamoDB primary keys are S, N, or B). S and B contribute
+// their literal bytes; N contributes its order-preserving numeric encoding
+// (the segment escape/terminator is applied uniformly by the caller).
 func ddbPrimaryKeyBytes(av *pb.DynamoAttributeValue) ([]byte, error) {
 	switch v := av.GetValue().(type) {
 	case *pb.DynamoAttributeValue_S:
@@ -247,7 +238,7 @@ func ddbPrimaryKeyBytes(av *pb.DynamoAttributeValue) ([]byte, error) {
 	case *pb.DynamoAttributeValue_B:
 		return v.B, nil
 	case *pb.DynamoAttributeValue_N:
-		return nil, errors.Wrap(ErrDDBEncodeNumericKeyUnsupported, "numeric primary key")
+		return ddbNumericKeyBytes(v.N)
 	default:
 		return nil, errors.Wrap(ErrDDBEncodeInvalidItem, "primary key attribute is not S, N, or B")
 	}

--- a/internal/backup/encode_dynamodb_items_test.go
+++ b/internal/backup/encode_dynamodb_items_test.go
@@ -188,6 +188,12 @@ func TestDDBEncodeItemNumericRangeKeyRoundTrip(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("decoded %d items, want 2", len(got))
 	}
+	wantA, wantB := reparse(t, a), reparse(t, bItem)
+	for _, item := range got {
+		if !reflect.DeepEqual(item, wantA) && !reflect.DeepEqual(item, wantB) {
+			t.Fatalf("unexpected decoded item: %#v", item)
+		}
+	}
 }
 
 // TestDDBNumericKeyOrderPreserving is the core correctness guard for the
@@ -221,7 +227,8 @@ func TestDDBNumericKeyOrderPreserving(t *testing.T) {
 }
 
 // TestDDBNumericKeyZeroLayout pins the canonical zero encoding: zero maps
-// to the single 0x01 marker, then the segment terminator.
+// to the single 0x01 marker (raw), which becomes 0x01 0x00 0x01 after the
+// segment escape/terminator.
 func TestDDBNumericKeyZeroLayout(t *testing.T) {
 	t.Parallel()
 	for _, z := range []string{"0", "0.0", "-0", "000", "0e5"} {
@@ -232,6 +239,28 @@ func TestDDBNumericKeyZeroLayout(t *testing.T) {
 		if !bytes.Equal(raw, []byte{0x01}) {
 			t.Fatalf("zero %q raw = %x, want 01", z, raw)
 		}
+		if seg := encodeDDBOrderedKeySegment(raw); !bytes.Equal(seg, []byte{0x01, 0x00, 0x01}) {
+			t.Fatalf("zero %q segment = %x, want 01 00 01", z, seg)
+		}
+	}
+}
+
+// TestDDBNumericKeyPositiveSignStripped pins that a leading '+' is stripped
+// so the value encodes identically to its unsigned form.
+func TestDDBNumericKeyPositiveSignStripped(t *testing.T) {
+	t.Parallel()
+	for _, pair := range [][2]string{{"+5", "5"}, {"+1e2", "100"}} {
+		withSign, err := ddbNumericKeyBytes(pair[0])
+		if err != nil {
+			t.Fatalf("ddbNumericKeyBytes(%q): %v", pair[0], err)
+		}
+		plain, err := ddbNumericKeyBytes(pair[1])
+		if err != nil {
+			t.Fatalf("ddbNumericKeyBytes(%q): %v", pair[1], err)
+		}
+		if !bytes.Equal(withSign, plain) {
+			t.Fatalf("%q (%x) must encode == %q (%x)", pair[0], withSign, pair[1], plain)
+		}
 	}
 }
 
@@ -239,7 +268,7 @@ func TestDDBNumericKeyZeroLayout(t *testing.T) {
 // literal in a numeric key position.
 func TestDDBNumericKeyRejectsMalformed(t *testing.T) {
 	t.Parallel()
-	for _, bad := range []string{"", "abc", "1.2.3", "+", "1e", "0x10"} {
+	for _, bad := range []string{"", "abc", "1.2.3", "+", "1e", "0x10", "e3"} {
 		if _, err := ddbNumericKeyBytes(bad); !errors.Is(err, ErrDDBEncodeInvalidItem) {
 			t.Fatalf("ddbNumericKeyBytes(%q) err = %v, want ErrDDBEncodeInvalidItem", bad, err)
 		}

--- a/internal/backup/encode_dynamodb_items_test.go
+++ b/internal/backup/encode_dynamodb_items_test.go
@@ -145,42 +145,104 @@ func TestDDBEncodeItemBinaryKeyRoundTrip(t *testing.T) {
 	}
 }
 
-// TestDDBEncodeItemNumericKeyFailsClosed pins that a numeric (N) primary
-// key fails closed in this slice rather than emitting a wrongly-ordered
-// key.
-func TestDDBEncodeItemNumericKeyFailsClosed(t *testing.T) {
+// TestDDBEncodeItemNumericHashKeyRoundTrip pins that a numeric (N) hash
+// key round-trips: its value survives encode -> real decode, and the
+// numeric ordered encoding (M3b-2) produces a valid loadable key.
+func TestDDBEncodeItemNumericHashKeyRoundTrip(t *testing.T) {
 	t.Parallel()
 	in := t.TempDir()
 	const table = "counters"
 	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"counters",`+
 		`"primary_key":{"hash_key":{"name":"id","type":"N"}},`+
 		`"attribute_definitions":[{"name":"id","type":"N"}]}`))
-	writeDDBItemFile(t, in, table, "1.json", []byte(`{"id":{"N":"1"},"v":{"S":"x"}}`))
+	item := []byte(`{"id":{"N":"100"},"v":{"S":"x"}}`)
+	writeDDBItemFile(t, in, table, "100.json", item)
 
-	b := newSnapshotBuilder(ddbEncTS)
-	err := NewDynamoDBEncoder(in).Encode(b)
-	if !errors.Is(err, ErrDDBEncodeNumericKeyUnsupported) {
-		t.Fatalf("Encode err = %v, want ErrDDBEncodeNumericKeyUnsupported", err)
+	out := decodeDDBTree(t, encodeDDBTree(t, in))
+	got := collectDDBItems(t, out, table)
+	if len(got) != 1 {
+		t.Fatalf("decoded %d items, want 1", len(got))
+	}
+	if !reflect.DeepEqual(got[0], reparse(t, item)) {
+		t.Fatalf("numeric hash-key item mismatch: got %#v", got[0])
 	}
 }
 
-// TestDDBEncodeItemNumericRangeKeyFailsClosed pins the fail-closed path
-// for a numeric RANGE key (the hash-key case is covered separately), so
-// both primary-key positions reject N until the ordered numeric encoding
-// lands (M3b-2).
-func TestDDBEncodeItemNumericRangeKeyFailsClosed(t *testing.T) {
+// TestDDBEncodeItemNumericRangeKeyRoundTrip pins a composite key with a
+// numeric (N) range key — including a fractional and negative value to
+// exercise the fraction/sign paths of the numeric encoder.
+func TestDDBEncodeItemNumericRangeKeyRoundTrip(t *testing.T) {
 	t.Parallel()
 	in := t.TempDir()
 	const table = "events"
 	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"events",`+
 		`"primary_key":{"hash_key":{"name":"pk","type":"S"},"range_key":{"name":"ts","type":"N"}},`+
 		`"attribute_definitions":[{"name":"pk","type":"S"},{"name":"ts","type":"N"}]}`))
-	writeDDBItemFile(t, in, table, "e.json", []byte(`{"pk":{"S":"a"},"ts":{"N":"100"}}`))
+	a := []byte(`{"pk":{"S":"a"},"ts":{"N":"-12.5"}}`)
+	bItem := []byte(`{"pk":{"S":"a"},"ts":{"N":"100"}}`)
+	writeDDBItemFile(t, in, table, "a/neg.json", a)
+	writeDDBItemFile(t, in, table, "a/pos.json", bItem)
 
-	b := newSnapshotBuilder(ddbEncTS)
-	err := NewDynamoDBEncoder(in).Encode(b)
-	if !errors.Is(err, ErrDDBEncodeNumericKeyUnsupported) {
-		t.Fatalf("Encode err = %v, want ErrDDBEncodeNumericKeyUnsupported", err)
+	out := decodeDDBTree(t, encodeDDBTree(t, in))
+	got := collectDDBItems(t, out, table)
+	if len(got) != 2 {
+		t.Fatalf("decoded %d items, want 2", len(got))
+	}
+}
+
+// TestDDBNumericKeyOrderPreserving is the core correctness guard for the
+// reproduced numeric encoding: the encoded key segments must sort in the
+// same byte-lexicographic order Pebble uses as the underlying numbers do.
+func TestDDBNumericKeyOrderPreserving(t *testing.T) {
+	t.Parallel()
+	// Strictly increasing numeric order.
+	nums := []string{"-1000", "-12.5", "-1", "-0.5", "0", "0.5", "1", "12.5", "100", "1000", "1e3", "12345"}
+	// dedupe equal values (1000 == 1e3) for the strict-order check below.
+	prev := []byte(nil)
+	prevNum := ""
+	for _, n := range nums {
+		raw, err := ddbNumericKeyBytes(n)
+		if err != nil {
+			t.Fatalf("ddbNumericKeyBytes(%q): %v", n, err)
+		}
+		seg := encodeDDBOrderedKeySegment(raw)
+		if prev != nil {
+			cmp := bytes.Compare(prev, seg)
+			equalValue := (prevNum == "1000" && n == "1e3")
+			switch {
+			case equalValue && cmp != 0:
+				t.Fatalf("%q vs %q: equal numbers must encode equal, cmp=%d", prevNum, n, cmp)
+			case !equalValue && cmp >= 0:
+				t.Fatalf("%q (%x) should sort before %q (%x), cmp=%d", prevNum, prev, n, seg, cmp)
+			}
+		}
+		prev, prevNum = seg, n
+	}
+}
+
+// TestDDBNumericKeyZeroLayout pins the canonical zero encoding: zero maps
+// to the single 0x01 marker, then the segment terminator.
+func TestDDBNumericKeyZeroLayout(t *testing.T) {
+	t.Parallel()
+	for _, z := range []string{"0", "0.0", "-0", "000", "0e5"} {
+		raw, err := ddbNumericKeyBytes(z)
+		if err != nil {
+			t.Fatalf("ddbNumericKeyBytes(%q): %v", z, err)
+		}
+		if !bytes.Equal(raw, []byte{0x01}) {
+			t.Fatalf("zero %q raw = %x, want 01", z, raw)
+		}
+	}
+}
+
+// TestDDBNumericKeyRejectsMalformed pins fail-closed on a non-numeric
+// literal in a numeric key position.
+func TestDDBNumericKeyRejectsMalformed(t *testing.T) {
+	t.Parallel()
+	for _, bad := range []string{"", "abc", "1.2.3", "+", "1e", "0x10"} {
+		if _, err := ddbNumericKeyBytes(bad); !errors.Is(err, ErrDDBEncodeInvalidItem) {
+			t.Fatalf("ddbNumericKeyBytes(%q) err = %v, want ErrDDBEncodeInvalidItem", bad, err)
+		}
 	}
 }
 

--- a/internal/backup/encode_dynamodb_numeric.go
+++ b/internal/backup/encode_dynamodb_numeric.go
@@ -1,0 +1,214 @@
+package backup
+
+import (
+	"encoding/binary"
+	"math/big"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// encode_dynamodb_numeric.go reproduces the live adapter's numeric
+// primary-key ordered encoding (adapter/dynamodb.go: encodeNumericKeyBytes
+// and helpers) so the item encoder can build keys for N (number) hash and
+// range keys that the live store sorts and looks up identically. (M3b-2)
+//
+// The scheme is order-preserving over the byte-lexicographic comparison
+// Pebble uses: a sign marker (0x00 negative / 0x01 zero / 0x02 positive)
+// followed, for non-zero values, by the order-encoded decimal exponent, a
+// 0x00 separator, and the significant digits — with the whole body
+// bit-inverted for negatives so larger magnitudes sort earlier. The result
+// is then escaped+terminated by encodeDDBOrderedKeySegment, exactly as the
+// live attributeValueAsKeySegment wraps attributeValueAsKeyBytes.
+
+const (
+	ddbNumNegativeMarker = byte(0x00)
+	ddbNumZeroMarker     = byte(0x01)
+	ddbNumPositiveMarker = byte(0x02)
+)
+
+// ddbNumericKeyBytes maps a DynamoDB number literal to its order-preserving
+// key bytes (the raw bytes, before the segment escape/terminator).
+func ddbNumericKeyBytes(v string) ([]byte, error) {
+	negative, exponent, digits, err := parseDDBNumericKeyParts(v)
+	if err != nil {
+		return nil, err
+	}
+	if len(digits) == 0 {
+		return []byte{ddbNumZeroMarker}, nil
+	}
+	body := encodeDDBOrderedSignedInt64(exponent)
+	body = append(body, ddbKeyEscapeByte)
+	body = append(body, digits...)
+	if !negative {
+		return append([]byte{ddbNumPositiveMarker}, body...), nil
+	}
+	return append([]byte{ddbNumNegativeMarker}, ddbInvertBytes(body)...), nil
+}
+
+// parseDDBNumericKeyParts splits a number literal into sign, decimal
+// exponent, and significant digits. A zero value yields empty digits.
+func parseDDBNumericKeyParts(v string) (bool, int64, []byte, error) {
+	trimmed, negative, exp10, err := parseDDBNumericLiteral(v)
+	if err != nil {
+		return false, 0, nil, err
+	}
+	digits, exponent, zero, err := normalizeDDBNumericParts(trimmed, exp10)
+	if err != nil {
+		return false, 0, nil, err
+	}
+	if zero {
+		return false, 0, nil, nil
+	}
+	return negative, exponent, digits, nil
+}
+
+// parseDDBNumericLiteral strips an optional sign and eE-exponent suffix.
+func parseDDBNumericLiteral(v string) (string, bool, int64, error) {
+	trimmed := strings.TrimSpace(v)
+	if trimmed == "" {
+		return "", false, 0, errors.Wrap(ErrDDBEncodeInvalidItem, "empty number literal")
+	}
+	negative := false
+	switch trimmed[0] {
+	case '+':
+		trimmed = trimmed[1:]
+	case '-':
+		negative = true
+		trimmed = trimmed[1:]
+	}
+	if trimmed == "" {
+		return "", false, 0, errors.Wrap(ErrDDBEncodeInvalidItem, "number literal is sign only")
+	}
+	exp10 := int64(0)
+	if idx := strings.IndexAny(trimmed, "eE"); idx >= 0 {
+		expPart := strings.TrimSpace(trimmed[idx+1:])
+		trimmed = trimmed[:idx]
+		parsed, err := parseDDBNumericExponent(expPart)
+		if err != nil {
+			return "", false, 0, err
+		}
+		exp10 = parsed
+	}
+	return trimmed, negative, exp10, nil
+}
+
+func parseDDBNumericExponent(expPart string) (int64, error) {
+	if expPart == "" {
+		return 0, errors.Wrap(ErrDDBEncodeInvalidItem, "empty exponent")
+	}
+	parsed, err := strconv.ParseInt(expPart, 10, 64)
+	if err != nil {
+		return 0, errors.Wrapf(ErrDDBEncodeInvalidItem, "bad exponent %q", expPart)
+	}
+	return parsed, nil
+}
+
+// normalizeDDBNumericParts trims leading/trailing zeros and computes the
+// decimal exponent of the first significant digit. The third return is
+// true when the value is zero.
+func normalizeDDBNumericParts(trimmed string, exp10 int64) ([]byte, int64, bool, error) {
+	intPart, fracPart, err := splitDDBNumericMantissa(trimmed)
+	if err != nil {
+		return nil, 0, false, err
+	}
+	combined := intPart + fracPart
+	leadingZeros := ddbLeadingZeroCount(combined)
+	if leadingZeros == len(combined) {
+		return nil, 0, true, nil
+	}
+	digits := []byte(strings.TrimRight(combined[leadingZeros:], "0"))
+	if len(digits) == 0 {
+		return nil, 0, true, nil
+	}
+	exponent := int64(len(intPart)) + exp10 - int64(leadingZeros)
+	return digits, exponent, false, nil
+}
+
+func splitDDBNumericMantissa(trimmed string) (string, string, error) {
+	if strings.Count(trimmed, ".") > 1 {
+		return "", "", errors.Wrap(ErrDDBEncodeInvalidItem, "number has multiple decimal points")
+	}
+	intPart := trimmed
+	fracPart := ""
+	if before, after, ok := strings.Cut(trimmed, "."); ok {
+		intPart = before
+		fracPart = after
+	}
+	if intPart == "" && fracPart == "" {
+		return "", "", errors.Wrap(ErrDDBEncodeInvalidItem, "number has no digits")
+	}
+	if !ddbDecimalDigitsOnly(intPart) || !ddbDecimalDigitsOnly(fracPart) {
+		return "", "", errors.Wrap(ErrDDBEncodeInvalidItem, "number has non-decimal characters")
+	}
+	return intPart, fracPart, nil
+}
+
+func ddbLeadingZeroCount(v string) int {
+	count := 0
+	for count < len(v) && v[count] == '0' {
+		count++
+	}
+	return count
+}
+
+func ddbDecimalDigitsOnly(v string) bool {
+	for i := range v {
+		if v[i] < '0' || v[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// encodeDDBOrderedSignedInt64 order-encodes a signed exponent: 0x00 +
+// inverted magnitude (negative), 0x01 (zero), or 0x02 + magnitude
+// (positive).
+func encodeDDBOrderedSignedInt64(v int64) []byte {
+	switch {
+	case v < 0:
+		return append([]byte{ddbNumNegativeMarker}, ddbInvertBytes(encodeDDBOrderedUint64(ddbSignedMagnitude(v)))...)
+	case v == 0:
+		return []byte{ddbNumZeroMarker}
+	default:
+		return append([]byte{ddbNumPositiveMarker}, encodeDDBOrderedUint64(uint64(v))...)
+	}
+}
+
+func ddbSignedMagnitude(v int64) uint64 {
+	if v >= 0 {
+		return uint64(v)
+	}
+	abs := big.NewInt(v)
+	abs.Abs(abs)
+	return abs.Uint64()
+}
+
+// ddbOrderedUint64LengthPrefix[width] == width; the array lookup avoids an
+// int->byte conversion (and keeps gosec quiet), matching the live code.
+var ddbOrderedUint64LengthPrefix = [...]byte{0, 1, 2, 3, 4, 5, 6, 7, 8}
+
+// encodeDDBOrderedUint64 emits a length-prefixed big-endian magnitude with
+// leading zero bytes stripped, so shorter (smaller) magnitudes sort first.
+func encodeDDBOrderedUint64(v uint64) []byte {
+	var buf [8]byte
+	binary.BigEndian.PutUint64(buf[:], v)
+	start := 0
+	for start < len(buf)-1 && buf[start] == 0 {
+		start++
+	}
+	width := len(buf) - start
+	out := make([]byte, 0, width+1)
+	out = append(out, ddbOrderedUint64LengthPrefix[width])
+	out = append(out, buf[start:]...)
+	return out
+}
+
+func ddbInvertBytes(in []byte) []byte {
+	out := make([]byte, len(in))
+	for i := range in {
+		out[i] = ^in[i]
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

**Phase 0b M3b-2 — DynamoDB numeric (N) primary-key ordered encoding.** Third slice of the DynamoDB reverse encoder (M3). `encode_dynamodb_numeric.go` reproduces the live adapter's order-preserving numeric key encoding (`adapter/dynamodb.go` `encodeNumericKeyBytes` + parse/normalize/ordered-int helpers): sign marker (`0x00` neg / `0x01` zero / `0x02` pos) + order-encoded decimal exponent + `0x00` separator + significant digits, with the body bit-inverted for negatives so larger magnitudes sort earlier.

> **Stacked on #833** (which now contains M3a schema + M3b-1 base items after #837 merged into it). Base branch is `backup/snapshot-encode-dynamodb`; the diff is M3b-2-only. Will retarget to `main` once #833 merges.

`ddbPrimaryKeyBytes` now returns these bytes for an `N` key; they flow through the **same** `encodeDDBOrderedKeySegment` escape/terminator as S/B — exactly as the live `attributeValueAsKeySegment` wraps `attributeValueAsKeyBytes`. This removes the M3b-1 fail-closed stub (`ErrDDBEncodeNumericKeyUnsupported` deleted); malformed number literals fail closed via `ErrDDBEncodeInvalidItem`.

## Why the order-preserving property test matters
The decoder round-trip reconstructs items from the proto **value** and never validates the ordered key payload, so a value round-trip can't catch a mis-encoded numeric key. `TestDDBNumericKeyOrderPreserving` asserts the encoded segments sort byte-lexicographically (the comparison Pebble uses) in numeric order across negative / zero / positive / fractional / exponent values — including `1000 == 1e3` encoding **equal** — which is the actual correctness guarantee the encoding exists to provide.

## Risk
New file + one changed branch in `ddbPrimaryKeyBytes`. No change to S/B/value handling. Offline-tool boundary preserved (numeric encoding reproduced, not imported).

## Self-review (5 lenses)
- **Data loss**: numeric keys now reconstructed; round-trip verified; malformed numbers fail closed.
- **Concurrency/distributed**: single-goroutine.
- **Performance**: O(digits) per key; no hot path (offline tool).
- **Consistency**: faithful reproduction verified by the order-preserving property + canonical zero layout; N bytes wrapped identically to S/B; generation/key format unchanged.
- **Test coverage**: numeric hash round-trip, composite S/N round-trip (negative + fractional), order-preserving property, zero layout (`0x01`), malformed-literal rejection.

## Caller audit (semantic change)
`ddbPrimaryKeyBytes`'s N case went from fail-closed error → success. Its sole caller `ddbItemKeyBytes` applies `encodeDDBOrderedKeySegment` uniformly to the returned bytes for both hash and range positions, so the new success path is handled identically to S/B. `ErrDDBEncodeNumericKeyUnsupported` had no other callers (grep).

## Test plan
- [x] `go test ./internal/backup/` (full package)
- [x] `golangci-lint run internal/backup/` (0 issues)
- [ ] Follow-up: M3b-3 GSI row derivation.
