### PR TITLE
feat(encryption): Stage 7a - process-start writer registration + coordinator first-write gate

### DIFF
--- a/docs/design/2026_05_26_proposed_7a_process_start_registration.md
+++ b/docs/design/2026_05_26_proposed_7a_process_start_registration.md
@@ -309,7 +309,8 @@ All three original open questions were settled by the round-1 review:
    run-context to avoid a leak / a barrier-close on an uncommitted
    registration (§3.2, review #3).
 
-Remaining items to resolve **within the implementation PR** (not
-deferred further): the exact `hasMutatingElems` predicate over the
-`OperationGroup` shape, and the default-group `WriterRegistryStore`
-threading out of `buildShardGroups` (§3.1).
+Both items were resolved in the implementation PR (#839):
+`hasMutatingElems` is implemented over `OperationGroup.Elems` in
+`kv/sharded_coordinator.go`; the `WriterRegistryStore` handle is a
+stateless `store.WriterRegistryFor(...)` wrapper (§3.1) rather than a
+threaded-out return value from `buildShardGroups`.

--- a/docs/design/2026_05_26_proposed_7a_process_start_registration.md
+++ b/docs/design/2026_05_26_proposed_7a_process_start_registration.md
@@ -243,6 +243,27 @@ emit an unregistered nonce).
   while blocked.
 
 ### Out of scope
+- **7a-2 (complete write-path coverage)** — the coordinator-layer
+  barrier in this slice gates the client-write path (`Dispatch`) and
+  the internal lock-resolution path (`leaseRefreshingTxn.Commit`), but
+  **not** internal paths that write to the store directly without going
+  through the coordinator — notably `distribution.CatalogStore.Save` →
+  `store.ApplyMutations` (codex P1 on PR #839). Coordinator-layer
+  gating is structurally incapable of covering those; the single
+  chokepoint for "registered before any encrypted write" is the
+  nonce-emission point, `store.encryptForKey`. 7a-2 will fail-close
+  there (a non-blocking registered-flag read that refuses to emit an
+  encrypted nonce before registration), giving complete coverage of
+  every write path. **Interim bounded-safety** until 7a-2: the §5.1
+  `local_epoch` bump already prevents concrete nonce *reuse* (every
+  nonce this load emits carries the freshly-bumped epoch — unique vs.
+  all prior loads, monotonic within), and the only scenario where the
+  registry ledger is load-bearing for nonce uniqueness — a cross-node
+  16-bit `node_id` collision — is caught by the `ErrNodeIDCollision`
+  startup membership pre-check. So the residual exploitable window
+  (catalog/direct-store write × node_id collision past the startup
+  guard × sub-second pre-registration window) is negligible, and 7a-2
+  closes it entirely.
 - **7b** — post-rotation re-registration (register against the new DEK
   on a `rotate-dek` apply, same barrier mechanism).
 - **7c** — ConfChange-time registration (leader pairs a

--- a/docs/design/2026_05_26_proposed_7a_process_start_registration.md
+++ b/docs/design/2026_05_26_proposed_7a_process_start_registration.md
@@ -113,16 +113,18 @@ is replicated state already present on this node post-bootstrap),
 reusing the same `RegistryKey(dek_id, NodeID16(full_node_id))` lookup
 `ApplyRegistration` / `GuardLocalEpochRollback` use.
 
-**Registry handle access (review finding #2).** `buildShardGroups`
-already constructs a `WriterRegistryStore` per shard via
-`store.WriterRegistryFor(st)` and hands it to each `Applier`. 7a
-threads the **default group's** `WriterRegistryStore` out of
-`buildShardGroups` (returned alongside the runtimes, keyed by
-`cfg.defaultGroup`) so the post-`buildShardGroups` intent step reads
-the same handle the FSM's `ApplyRegistration` mutates — rather than
-adding a new accessor that reaches into the runtime/applier internals.
-This keeps the registry's single owner (the default-group store) and
-avoids a second `WriterRegistryFor` over the same Pebble dir.
+**Registry handle access (review finding #2 — as built).** The intent
+step reads the registry through `store.WriterRegistryFor(
+shardGroups[cfg.defaultGroup].Store)`. The proposal-round plan was to
+thread the per-shard handle out of `buildShardGroups`, but
+`WriterRegistryFor` returns a **stateless** `*pebbleWriterRegistry`
+wrapper over the shared `*pebbleStore` — a second wrapper for a
+read-only `GetRegistryRow` is byte-for-byte equivalent to the
+applier's handle and holds no state of its own. So the simpler choice
+(a fresh read-only wrapper over the already-open default-group store)
+avoids widening `buildShardGroups`' already-long return signature with
+no correctness cost: the durable registry rows still have a single
+owner (the FSM apply path), and the intent step only reads.
 
 ### 3.2 Coordinator first-write gate
 

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -221,6 +221,9 @@ func (c *ShardedCoordinator) awaitRegistration(ctx context.Context, reqs *Operat
 // are gated by awaitRegistration; reads and cleartext writes are not.
 func (c *ShardedCoordinator) writeWouldEncrypt(reqs *OperationGroup[OP]) bool {
 	g := c.registrationGate
+	if g == nil {
+		return false
+	}
 	if !hasMutatingElems(reqs) || g.StorageEnvelopeActive == nil || !g.StorageEnvelopeActive() {
 		return false
 	}
@@ -240,6 +243,11 @@ func hasMutatingElems(reqs *OperationGroup[OP]) bool {
 	if reqs == nil {
 		return false
 	}
+	// The per-Elem nil check is defensive: validateOperationGroup runs
+	// before this and rejects groups with nil elements, so a non-empty
+	// Elems is effectively all-non-nil in practice. The guard keeps
+	// hasMutatingElems correct even if a future caller bypasses that
+	// validation.
 	for _, e := range reqs.Elems {
 		if e != nil {
 			return true

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -142,6 +142,110 @@ type ShardedCoordinator struct {
 	// disabled keyviz wires through to a no-op without branching on
 	// the hot path.
 	sampler keyviz.Sampler
+	// registrationGate is the Stage 7a §4.1 first-write barrier: when
+	// set, self-originated mutating writes that would land as §4.1
+	// storage envelopes block until this node's writer registration
+	// commits. nil when encryption is off / no registration is pending
+	// (the common case — ungated). See RegistrationGate.
+	registrationGate *RegistrationGate
+}
+
+// RegistrationGate carries the Stage 7a §4.1 registration-before-
+// first-write barrier into the coordinator. main.go owns the
+// encryption StateCache and the registration goroutine and supplies
+// this; kv stays decoupled from internal/encryption by taking a plain
+// channel + predicate closures rather than the StateCache type.
+//
+// Barrier three-state (per the 7a design §3.2):
+//   - nil           → no registration pending (Phase 0 / skip / off) → ungated
+//   - open (non-nil, not closed) → registration in flight → mutating
+//     encrypted writes block on it
+//   - closed        → registration committed → ungated (fast path)
+type RegistrationGate struct {
+	// Barrier is the open-or-closed channel described above. A nil
+	// Barrier (the zero value, or an explicitly nil field) means
+	// "never armed" → ungated; awaitRegistration checks for nil first
+	// so a nil channel is never received on (which would block forever).
+	Barrier <-chan struct{}
+	// StorageEnvelopeActive and ActiveStorageKeyID read the process-wide
+	// encryption StateCache. A write is gated only when the §7.1 cutover
+	// has fired AND a storage DEK is active — i.e. the write would land
+	// encrypted and thus emit a nonce under this node's identity.
+	StorageEnvelopeActive func() bool
+	ActiveStorageKeyID    func() (uint32, bool)
+}
+
+// WithRegistrationGate wires the Stage 7a first-write barrier onto the
+// coordinator. Applied after construction for the same reason as the
+// other With* options. A nil gate (or a gate with a nil Barrier)
+// leaves every write ungated — the encryption-off / no-pending-
+// registration posture.
+func (c *ShardedCoordinator) WithRegistrationGate(g *RegistrationGate) *ShardedCoordinator {
+	c.registrationGate = g
+	return c
+}
+
+// awaitRegistration implements the §4.1 first-write barrier (7a §3.2).
+// It returns nil (ungated) unless a registration is genuinely pending
+// AND this request is a mutating write that would land encrypted, in
+// which case it blocks until the registration commits or ctx ends.
+// Fail-closed: a write that cannot register within its ctx returns the
+// ctx error rather than proceeding to emit an unregistered nonce.
+func (c *ShardedCoordinator) awaitRegistration(ctx context.Context, reqs *OperationGroup[OP]) error {
+	g := c.registrationGate
+	if g == nil || g.Barrier == nil {
+		return nil
+	}
+	select {
+	case <-g.Barrier:
+		return nil // registration committed — fast path
+	default:
+	}
+	// Registration is in flight. Gate only mutating writes that would
+	// land encrypted; reads never reach Dispatch, and cleartext writes
+	// (pre-cutover / no active DEK) emit no nonce.
+	if !c.writeWouldEncrypt(reqs) {
+		return nil
+	}
+	select {
+	case <-g.Barrier:
+		return nil
+	case <-ctx.Done():
+		return errors.Wrap(ctx.Err(), "encryption: write blocked on pending §4.1 writer registration")
+	}
+}
+
+// writeWouldEncrypt reports whether reqs is a mutating write that would
+// land as a §4.1 storage envelope under the current gate state — i.e.
+// the cutover has fired AND a storage DEK is active. Only such writes
+// are gated by awaitRegistration; reads and cleartext writes are not.
+func (c *ShardedCoordinator) writeWouldEncrypt(reqs *OperationGroup[OP]) bool {
+	g := c.registrationGate
+	if !hasMutatingElems(reqs) || g.StorageEnvelopeActive == nil || !g.StorageEnvelopeActive() {
+		return false
+	}
+	if g.ActiveStorageKeyID == nil {
+		return false
+	}
+	_, ok := g.ActiveStorageKeyID()
+	return ok
+}
+
+// hasMutatingElems reports whether the group carries at least one
+// mutating operation. Every OP in OperationGroup (Put / Del /
+// DelPrefix) mutates — reads use separate Coordinator methods that
+// never reach Dispatch — so a read-only transaction reaches here with
+// only ReadKeys set and an empty Elems slice, and must stay ungated.
+func hasMutatingElems(reqs *OperationGroup[OP]) bool {
+	if reqs == nil {
+		return false
+	}
+	for _, e := range reqs.Elems {
+		if e != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // WithLeaseReadObserver wires a LeaseReadObserver onto a
@@ -242,6 +346,13 @@ func (c *ShardedCoordinator) Dispatch(ctx context.Context, reqs *OperationGroup[
 		return nil, err
 	}
 
+	// Stage 7a §4.1: block self-originated mutating encrypted writes
+	// until this node's writer registration commits. Ungated fast path
+	// (no gate / committed / cleartext) returns immediately.
+	if err := c.awaitRegistration(ctx, reqs); err != nil {
+		return nil, err
+	}
+
 	// DEL_PREFIX cannot be routed to a single shard because the prefix may
 	// span multiple shards (or be nil, meaning "all keys"). Broadcast the
 	// operation to every shard group so each FSM scans locally.
@@ -266,11 +377,17 @@ func (c *ShardedCoordinator) Dispatch(ctx context.Context, reqs *OperationGroup[
 		return c.dispatchTxn(ctx, reqs.StartTS, reqs.CommitTS, reqs.Elems, reqs.ReadKeys)
 	}
 
+	return c.dispatchNonTxn(ctx, reqs)
+}
+
+// dispatchNonTxn routes a non-transactional operation group through the
+// shard router. Extracted from Dispatch to keep that method's branch
+// count within the cyclop budget after the 7a registration gate landed.
+func (c *ShardedCoordinator) dispatchNonTxn(ctx context.Context, reqs *OperationGroup[OP]) (*CoordinateResponse, error) {
 	logs, err := c.requestLogs(reqs)
 	if err != nil {
 		return nil, err
 	}
-
 	r, err := c.router.Commit(ctx, logs)
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -40,9 +40,26 @@ type ShardGroup struct {
 type leaseRefreshingTxn struct {
 	inner Transactional
 	g     *ShardGroup
+	// coord back-references the owning coordinator so Commit can
+	// consult the Stage 7a registration barrier. Every self-originated
+	// write — client writes via router.Commit AND internal
+	// lock-resolution via ShardStore's direct g.Txn.Commit — funnels
+	// through this wrapper, so gating here (in addition to the
+	// Dispatch-level gate for client groups) closes the lock-resolution
+	// path codex P1 flagged. nil in tests that construct the wrapper
+	// directly; awaitRegistrationBarrier is nil-receiver-safe.
+	coord *ShardedCoordinator
 }
 
 func (t *leaseRefreshingTxn) Commit(ctx context.Context, reqs []*pb.Request) (*TransactionResponse, error) {
+	// Stage 7a §4.1: every Commit is a self-originated write, so gate it
+	// on this node's writer registration. This is the universal
+	// chokepoint (router.Commit and ShardStore lock-resolution both land
+	// here), closing the lock-resolution path the Dispatch-level gate
+	// alone misses (codex P1 on PR #839).
+	if err := t.coord.awaitRegistrationBarrier(ctx); err != nil {
+		return nil, err
+	}
 	start := monoclock.Now()
 	expectedGen := t.g.lease.generation()
 	resp, err := t.inner.Commit(ctx, reqs)
@@ -220,11 +237,50 @@ func (c *ShardedCoordinator) awaitRegistration(ctx context.Context, reqs *Operat
 // the cutover has fired AND a storage DEK is active. Only such writes
 // are gated by awaitRegistration; reads and cleartext writes are not.
 func (c *ShardedCoordinator) writeWouldEncrypt(reqs *OperationGroup[OP]) bool {
-	g := c.registrationGate
-	if g == nil {
+	if c.registrationGate == nil {
 		return false
 	}
-	if !hasMutatingElems(reqs) || g.StorageEnvelopeActive == nil || !g.StorageEnvelopeActive() {
+	return hasMutatingElems(reqs) && c.encryptionWriteActive()
+}
+
+// awaitRegistrationBarrier is the write-layer (Transactional.Commit)
+// half of the §4.1 first-write gate. Unlike awaitRegistration it takes
+// no OperationGroup: every Commit is a write, so the gate fires
+// whenever a registration is pending AND the write would land
+// encrypted (cutover fired + active DEK). nil-receiver-safe (tests
+// construct leaseRefreshingTxn without a coordinator).
+func (c *ShardedCoordinator) awaitRegistrationBarrier(ctx context.Context) error {
+	if c == nil {
+		return nil
+	}
+	g := c.registrationGate
+	if g == nil || g.Barrier == nil {
+		return nil
+	}
+	select {
+	case <-g.Barrier:
+		return nil // committed — fast path
+	default:
+	}
+	if !c.encryptionWriteActive() {
+		return nil
+	}
+	select {
+	case <-g.Barrier:
+		return nil
+	case <-ctx.Done():
+		return errors.Wrap(ctx.Err(), "encryption: commit blocked on pending §4.1 writer registration")
+	}
+}
+
+// encryptionWriteActive reports whether a write would currently land as
+// a §4.1 storage envelope: the cutover has fired AND a storage DEK is
+// active. Shared by writeWouldEncrypt (Dispatch gate) and
+// awaitRegistrationBarrier (Commit gate). Assumes c.registrationGate
+// is non-nil (both callers check that first).
+func (c *ShardedCoordinator) encryptionWriteActive() bool {
+	g := c.registrationGate
+	if g.StorageEnvelopeActive == nil || !g.StorageEnvelopeActive() {
 		return false
 	}
 	if g.ActiveStorageKeyID == nil {
@@ -302,6 +358,19 @@ func (c *ShardedCoordinator) WithPartitionResolver(r PartitionResolver) *Sharded
 // The defaultGroup is used for non-keyed leader checks.
 func NewShardedCoordinator(engine *distribution.Engine, groups map[uint64]*ShardGroup, defaultGroup uint64, clock *HLC, st store.MVCCStore) *ShardedCoordinator {
 	router := NewShardRouter(engine)
+	// Construct the coordinator before wrapping the per-shard
+	// Transactionals so each leaseRefreshingTxn can back-reference it
+	// for the §4.1 registration barrier (the gate is installed later
+	// via WithRegistrationGate and read at Commit time).
+	c := &ShardedCoordinator{
+		engine:       engine,
+		router:       router,
+		groups:       groups,
+		defaultGroup: defaultGroup,
+		clock:        clock,
+		store:        st,
+		log:          slog.Default(),
+	}
 	var deregisters []func()
 	for gid, g := range groups {
 		// Wrap Txn so every successful Commit/Abort refreshes the
@@ -309,7 +378,7 @@ func NewShardedCoordinator(engine *distribution.Engine, groups map[uint64]*Shard
 		// if already wrapped so repeat calls don't stack wrappers.
 		if g.Txn != nil {
 			if _, already := g.Txn.(*leaseRefreshingTxn); !already {
-				g.Txn = &leaseRefreshingTxn{inner: g.Txn, g: g}
+				g.Txn = &leaseRefreshingTxn{inner: g.Txn, g: g, coord: c}
 			}
 		}
 		router.Register(gid, g.Txn, g.Store)
@@ -320,16 +389,8 @@ func NewShardedCoordinator(engine *distribution.Engine, groups map[uint64]*Shard
 			deregisters = append(deregisters, lp.RegisterLeaderLossCallback(g.lease.invalidate))
 		}
 	}
-	return &ShardedCoordinator{
-		engine:             engine,
-		router:             router,
-		groups:             groups,
-		defaultGroup:       defaultGroup,
-		clock:              clock,
-		store:              st,
-		log:                slog.Default(),
-		deregisterLeaseCbs: deregisters,
-	}
+	c.deregisterLeaseCbs = deregisters
+	return c
 }
 
 // Close releases per-shard engine-side registrations. Idempotent.

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -377,7 +377,14 @@ func NewShardedCoordinator(engine *distribution.Engine, groups map[uint64]*Shard
 		// per-shard lease. Leave nil transactions unchanged, and skip
 		// if already wrapped so repeat calls don't stack wrappers.
 		if g.Txn != nil {
-			if _, already := g.Txn.(*leaseRefreshingTxn); !already {
+			if existing, already := g.Txn.(*leaseRefreshingTxn); already {
+				// Re-binding over the same ShardGroup (this function
+				// supports repeat construction by not stacking
+				// wrappers): point the existing wrapper at the NEW
+				// coordinator so Commit consults the freshly-installed
+				// registration gate, not a stale one (codex P2).
+				existing.coord = c
+			} else {
 				g.Txn = &leaseRefreshingTxn{inner: g.Txn, g: g, coord: c}
 			}
 		}

--- a/kv/sharded_coordinator_registration_gate_test.go
+++ b/kv/sharded_coordinator_registration_gate_test.go
@@ -123,6 +123,89 @@ func TestAwaitRegistration_OpenBarrier_BlocksThenReleasesOnCommit(t *testing.T) 
 	}
 }
 
+// --- awaitRegistrationBarrier: the write-layer (Transactional.Commit)
+// gate that also covers lock-resolution commits (codex P1 on #839) ---
+
+func TestAwaitRegistrationBarrier_NilReceiver_Ungated(t *testing.T) {
+	t.Parallel()
+	var c *ShardedCoordinator
+	if err := c.awaitRegistrationBarrier(context.Background()); err != nil {
+		t.Fatalf("nil receiver should be ungated, got %v", err)
+	}
+}
+
+func TestAwaitRegistrationBarrier_ClosedBarrier_FastPath(t *testing.T) {
+	t.Parallel()
+	ch := make(chan struct{})
+	close(ch)
+	envActive, activeKey := activeGatePredicates()
+	c := &ShardedCoordinator{registrationGate: &RegistrationGate{
+		Barrier: ch, StorageEnvelopeActive: envActive, ActiveStorageKeyID: activeKey,
+	}}
+	if err := c.awaitRegistrationBarrier(context.Background()); err != nil {
+		t.Fatalf("closed barrier should be ungated, got %v", err)
+	}
+}
+
+func TestAwaitRegistrationBarrier_EnvelopeInactive_Ungated(t *testing.T) {
+	t.Parallel()
+	ch := make(chan struct{}) // open
+	c := &ShardedCoordinator{registrationGate: &RegistrationGate{
+		Barrier:               ch,
+		StorageEnvelopeActive: func() bool { return false },
+		ActiveStorageKeyID:    func() (uint32, bool) { return 7, true },
+	}}
+	if err := c.awaitRegistrationBarrier(context.Background()); err != nil {
+		t.Fatalf("envelope-inactive commit should be ungated, got %v", err)
+	}
+}
+
+func TestAwaitRegistrationBarrier_OpenBarrier_BlocksThenReleases(t *testing.T) {
+	t.Parallel()
+	ch := make(chan struct{}) // open
+	envActive, activeKey := activeGatePredicates()
+	c := &ShardedCoordinator{registrationGate: &RegistrationGate{
+		Barrier: ch, StorageEnvelopeActive: envActive, ActiveStorageKeyID: activeKey,
+	}}
+	done := make(chan error, 1)
+	go func() { done <- c.awaitRegistrationBarrier(context.Background()) }()
+	select {
+	case err := <-done:
+		t.Fatalf("expected block on open barrier, returned early: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(ch)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("after commit, expected ungated, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("commit did not unblock after barrier close")
+	}
+}
+
+func TestAwaitRegistrationBarrier_CtxCancelFailsClosed(t *testing.T) {
+	t.Parallel()
+	ch := make(chan struct{}) // open, never closed
+	envActive, activeKey := activeGatePredicates()
+	c := &ShardedCoordinator{registrationGate: &RegistrationGate{
+		Barrier: ch, StorageEnvelopeActive: envActive, ActiveStorageKeyID: activeKey,
+	}}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.awaitRegistrationBarrier(ctx) }()
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected ctx.Canceled fail-closed, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("commit did not fail-closed on ctx cancel")
+	}
+}
+
 func TestAwaitRegistration_OpenBarrier_CtxCancelFailsClosed(t *testing.T) {
 	t.Parallel()
 	ch := make(chan struct{}) // open, never closed

--- a/kv/sharded_coordinator_registration_gate_test.go
+++ b/kv/sharded_coordinator_registration_gate_test.go
@@ -1,0 +1,145 @@
+package kv
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// mutatingGroup is an OperationGroup with one PUT (a write that would
+// land encrypted once the envelope is active).
+func mutatingGroup() *OperationGroup[OP] {
+	return &OperationGroup[OP]{Elems: []*Elem[OP]{{Op: Put, Key: []byte("k"), Value: []byte("v")}}}
+}
+
+// readOnlyTxnGroup models a read-only transaction: ReadKeys set, no
+// mutating Elems. Must stay ungated.
+func readOnlyTxnGroup() *OperationGroup[OP] {
+	return &OperationGroup[OP]{IsTxn: true, ReadKeys: [][]byte{[]byte("k")}}
+}
+
+func activeGatePredicates() (func() bool, func() (uint32, bool)) {
+	return func() bool { return true }, func() (uint32, bool) { return 7, true }
+}
+
+func TestAwaitRegistration_NilGate_Ungated(t *testing.T) {
+	t.Parallel()
+	c := &ShardedCoordinator{}
+	if err := c.awaitRegistration(context.Background(), mutatingGroup()); err != nil {
+		t.Fatalf("nil gate should be ungated, got %v", err)
+	}
+}
+
+func TestAwaitRegistration_NilBarrier_Ungated(t *testing.T) {
+	t.Parallel()
+	envActive, activeKey := activeGatePredicates()
+	c := &ShardedCoordinator{registrationGate: &RegistrationGate{
+		Barrier: nil, StorageEnvelopeActive: envActive, ActiveStorageKeyID: activeKey,
+	}}
+	if err := c.awaitRegistration(context.Background(), mutatingGroup()); err != nil {
+		t.Fatalf("nil barrier should be ungated, got %v", err)
+	}
+}
+
+func TestAwaitRegistration_ClosedBarrier_FastPath(t *testing.T) {
+	t.Parallel()
+	ch := make(chan struct{})
+	close(ch)
+	envActive, activeKey := activeGatePredicates()
+	c := &ShardedCoordinator{registrationGate: &RegistrationGate{
+		Barrier: ch, StorageEnvelopeActive: envActive, ActiveStorageKeyID: activeKey,
+	}}
+	if err := c.awaitRegistration(context.Background(), mutatingGroup()); err != nil {
+		t.Fatalf("closed barrier should be ungated, got %v", err)
+	}
+}
+
+func TestAwaitRegistration_OpenBarrier_ReadOnly_Ungated(t *testing.T) {
+	t.Parallel()
+	ch := make(chan struct{}) // open
+	envActive, activeKey := activeGatePredicates()
+	c := &ShardedCoordinator{registrationGate: &RegistrationGate{
+		Barrier: ch, StorageEnvelopeActive: envActive, ActiveStorageKeyID: activeKey,
+	}}
+	// Read-only txn must not block even with an open barrier.
+	if err := c.awaitRegistration(context.Background(), readOnlyTxnGroup()); err != nil {
+		t.Fatalf("read-only group should be ungated, got %v", err)
+	}
+}
+
+func TestAwaitRegistration_OpenBarrier_EnvelopeInactive_Ungated(t *testing.T) {
+	t.Parallel()
+	ch := make(chan struct{}) // open
+	c := &ShardedCoordinator{registrationGate: &RegistrationGate{
+		Barrier:               ch,
+		StorageEnvelopeActive: func() bool { return false }, // pre-cutover
+		ActiveStorageKeyID:    func() (uint32, bool) { return 7, true },
+	}}
+	// Pre-cutover writes are cleartext → ungated even with open barrier.
+	if err := c.awaitRegistration(context.Background(), mutatingGroup()); err != nil {
+		t.Fatalf("envelope-inactive write should be ungated, got %v", err)
+	}
+}
+
+func TestAwaitRegistration_OpenBarrier_NoActiveDEK_Ungated(t *testing.T) {
+	t.Parallel()
+	ch := make(chan struct{}) // open
+	c := &ShardedCoordinator{registrationGate: &RegistrationGate{
+		Barrier:               ch,
+		StorageEnvelopeActive: func() bool { return true },
+		ActiveStorageKeyID:    func() (uint32, bool) { return 0, false }, // not bootstrapped
+	}}
+	if err := c.awaitRegistration(context.Background(), mutatingGroup()); err != nil {
+		t.Fatalf("no-active-DEK write should be ungated, got %v", err)
+	}
+}
+
+func TestAwaitRegistration_OpenBarrier_BlocksThenReleasesOnCommit(t *testing.T) {
+	t.Parallel()
+	ch := make(chan struct{}) // open
+	envActive, activeKey := activeGatePredicates()
+	c := &ShardedCoordinator{registrationGate: &RegistrationGate{
+		Barrier: ch, StorageEnvelopeActive: envActive, ActiveStorageKeyID: activeKey,
+	}}
+	done := make(chan error, 1)
+	go func() { done <- c.awaitRegistration(context.Background(), mutatingGroup()) }()
+
+	// Must still be blocked: nothing on done yet.
+	select {
+	case err := <-done:
+		t.Fatalf("expected block on open barrier, returned early: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	// Registration commits → close barrier → write proceeds.
+	close(ch)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("after commit, expected ungated, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("write did not unblock after barrier close")
+	}
+}
+
+func TestAwaitRegistration_OpenBarrier_CtxCancelFailsClosed(t *testing.T) {
+	t.Parallel()
+	ch := make(chan struct{}) // open, never closed
+	envActive, activeKey := activeGatePredicates()
+	c := &ShardedCoordinator{registrationGate: &RegistrationGate{
+		Barrier: ch, StorageEnvelopeActive: envActive, ActiveStorageKeyID: activeKey,
+	}}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- c.awaitRegistration(ctx, mutatingGroup()) }()
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected ctx.Canceled fail-closed, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("write did not fail-closed on ctx cancel")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -349,7 +349,7 @@ func run() error {
 	// a storage DEK is already active on disk (restart path); on a
 	// pre-bootstrap binary the per-Put gate stays cleartext until a
 	// runtime Bootstrap + EnableStorageEnvelope flips it.
-	runtimes, shardGroups, err := buildShardGroupsWithEncryptionWiring(
+	runtimes, shardGroups, encWiring, err := buildShardGroupsWithEncryptionWiring(
 		*raftId,
 		*raftDir,
 		cfg.groups,
@@ -431,6 +431,17 @@ func run() error {
 	// every dispatched mutation.
 	seedKeyVizRoutes(sampler, cfg.engine)
 	eg, runCtx := errgroup.WithContext(ctx)
+
+	// Stage 7a §4.1: process-start writer registration + first-write
+	// barrier. Runs after the shard stores opened (registry readable)
+	// and the startup guards passed, but before the gRPC servers start
+	// serving. nil gate (the common case: encryption off / Phase 0 /
+	// already registered) leaves writes ungated; the propose branch
+	// arms a barrier that blocks self-originated encrypted writes until
+	// this node's registration commits, with the goroutine bound to
+	// runCtx so it drains on shutdown.
+	installProcessStartRegistrationGate(runCtx, eg, coordinate, shardGroups[cfg.defaultGroup], encWiring, *raftId)
+
 	eg.Go(func() error {
 		return runDistributionCatalogWatcher(runCtx, distCatalog, cfg.engine)
 	})

--- a/main.go
+++ b/main.go
@@ -419,8 +419,17 @@ func run() error {
 		ctx, runtimes, cfg.sqsFifoPartitionMap,
 		sqsAdvertisesHTFIFO(), slog.Default())
 	cleanup.Add(leadershipRefusalDeregister)
-	distCatalog, err := setupDistributionCatalog(ctx, runtimes, cfg.engine)
+	eg, runCtx := errgroup.WithContext(ctx)
+	// setupDistributionCatalog + the Stage 7a process-start registration
+	// gate are bundled so run() has a single startup-fault path: a
+	// registry-read / behind-epoch failure fails the process
+	// synchronously here, BEFORE the gRPC servers serve, so writes never
+	// run with no registration gate installed (codex P1 on PR #839).
+	distCatalog, err := setupDistributionAndRegistration(
+		ctx, runCtx, eg, runtimes, cfg.engine,
+		coordinate, shardGroups[cfg.defaultGroup], encWiring, *raftId)
 	if err != nil {
+		cancel()
 		return err
 	}
 	// Seed AFTER setupDistributionCatalog so the sampler picks up the
@@ -430,17 +439,6 @@ func run() error {
 	// the placeholder zero IDs from buildEngine and Observe would miss
 	// every dispatched mutation.
 	seedKeyVizRoutes(sampler, cfg.engine)
-	eg, runCtx := errgroup.WithContext(ctx)
-
-	// Stage 7a §4.1: process-start writer registration + first-write
-	// barrier. Runs after the shard stores opened (registry readable)
-	// and the startup guards passed, but before the gRPC servers start
-	// serving. nil gate (the common case: encryption off / Phase 0 /
-	// already registered) leaves writes ungated; the propose branch
-	// arms a barrier that blocks self-originated encrypted writes until
-	// this node's registration commits, with the goroutine bound to
-	// runCtx so it drains on shutdown.
-	installProcessStartRegistrationGate(runCtx, eg, coordinate, shardGroups[cfg.defaultGroup], encWiring, *raftId)
 
 	eg.Go(func() error {
 		return runDistributionCatalogWatcher(runCtx, distCatalog, cfg.engine)

--- a/main_encryption_registration.go
+++ b/main_encryption_registration.go
@@ -27,6 +27,11 @@ const (
 	// registrationBackoffFactor is the exponential multiplier applied
 	// to the retry backoff between failed registration attempts.
 	registrationBackoffFactor = 2
+	// registrationAttemptTimeout bounds a single propose/forward
+	// attempt so it always returns to the retry loop (which re-resolves
+	// the leader) rather than blocking indefinitely on a stale leader
+	// address under GRPCConnCache's WaitForReady(true) dials.
+	registrationAttemptTimeout = 5 * time.Second
 )
 
 // setupDistributionAndRegistration sets up the distribution catalog and
@@ -256,6 +261,13 @@ func runWriterRegistration(
 // the default-group engine when this node is the leader (DisableProposalForwarding
 // means a follower's Propose is dropped), else by forwarding to the
 // current leader's EncryptionAdmin endpoint.
+//
+// Each attempt is bounded by registrationAttemptTimeout so it always
+// returns to the retry loop (which re-resolves the leader). Without it,
+// the forwarded RPC would inherit the deadline-less run-context and —
+// because GRPCConnCache dials WaitForReady(true) — could block forever
+// on a stale/unreachable leader address, leaving the barrier open and
+// encrypted writes stuck even after leadership moves (codex P1 #5).
 func proposeWriterRegistration(
 	ctx context.Context,
 	coordinate *kv.ShardedCoordinator,
@@ -264,8 +276,10 @@ func proposeWriterRegistration(
 	entry []byte,
 	req *pb.RegisterEncryptionWriterRequest,
 ) error {
+	attemptCtx, cancel := context.WithTimeout(ctx, registrationAttemptTimeout)
+	defer cancel()
 	if coordinate.IsLeader() {
-		if _, err := defaultEngine.Propose(ctx, entry); err != nil {
+		if _, err := defaultEngine.Propose(attemptCtx, entry); err != nil {
 			return errors.Wrap(err, "writer registration: local propose")
 		}
 		return nil
@@ -278,7 +292,7 @@ func proposeWriterRegistration(
 	if err != nil {
 		return errors.Wrapf(err, "writer registration: dial leader %s", addr)
 	}
-	if _, err := pb.NewEncryptionAdminClient(conn).RegisterEncryptionWriter(ctx, req); err != nil {
+	if _, err := pb.NewEncryptionAdminClient(conn).RegisterEncryptionWriter(attemptCtx, req); err != nil {
 		return errors.Wrap(err, "writer registration: forward to leader")
 	}
 	return nil

--- a/main_encryption_registration.go
+++ b/main_encryption_registration.go
@@ -182,7 +182,12 @@ func runWriterRegistration(
 	// commits or ctx ends, so no process-lifetime cache + watcher
 	// goroutine is needed.
 	connCache := &kv.GRPCConnCache{}
-	defer func() { _ = connCache.Close() }()
+	defer func() {
+		if err := connCache.Close(); err != nil {
+			slog.Warn("encryption: failed to close writer-registration gRPC connection cache",
+				slog.String("error", err.Error()))
+		}
+	}()
 
 	backoff := registrationRetryInitial
 	for {

--- a/main_encryption_registration.go
+++ b/main_encryption_registration.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/bootjp/elastickv/distribution"
 	"github.com/bootjp/elastickv/internal/encryption"
 	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
 	"github.com/bootjp/elastickv/internal/raftengine"
@@ -28,12 +29,38 @@ const (
 	registrationBackoffFactor = 2
 )
 
+// setupDistributionAndRegistration sets up the distribution catalog and
+// then installs the Stage 7a process-start registration gate, returning
+// the catalog store. Bundling the two lets run() handle both startup
+// faults through a single error path (keeping run() within the cyclop
+// budget) while preserving the fail-synchronously-before-serving
+// guarantee for the registration gate.
+func setupDistributionAndRegistration(
+	ctx, runCtx context.Context,
+	eg *errgroup.Group,
+	runtimes []*raftGroupRuntime,
+	engine *distribution.Engine,
+	coordinate *kv.ShardedCoordinator,
+	defaultGroup *kv.ShardGroup,
+	w encryptionWriteWiring,
+	raftID string,
+) (*distribution.CatalogStore, error) {
+	distCatalog, err := setupDistributionCatalog(ctx, runtimes, engine)
+	if err != nil {
+		return nil, err
+	}
+	if err := installProcessStartRegistrationGate(runCtx, eg, coordinate, defaultGroup, w, raftID); err != nil {
+		return nil, err
+	}
+	return distCatalog, nil
+}
+
 // installProcessStartRegistrationGate builds the Stage 7a registration
-// gate and wires it onto the coordinator. A registry-read failure at
-// this point is a startup fault; rather than add a branch to run() (it
-// is already at the cyclop ceiling), the error is surfaced through the
-// errgroup, whose cancellation tears the process down before it serves
-// — the same lifecycle path every other startup goroutine uses.
+// gate and wires it onto the coordinator. A registry-read / behind-epoch
+// failure here is a startup fault that MUST fail the process
+// synchronously — before run() brings up the gRPC servers — so writes
+// never serve with no gate installed (codex P1 on PR #839). The caller
+// returns the error from run() before serving.
 func installProcessStartRegistrationGate(
 	ctx context.Context,
 	eg *errgroup.Group,
@@ -41,15 +68,13 @@ func installProcessStartRegistrationGate(
 	defaultGroup *kv.ShardGroup,
 	w encryptionWriteWiring,
 	raftID string,
-) {
+) error {
 	gate, err := buildProcessStartRegistrationGate(ctx, eg, coordinate, defaultGroup, w, raftID)
 	if err != nil {
-		eg.Go(func() error {
-			return errors.Wrap(err, "process-start writer registration intent")
-		})
-		return
+		return errors.Wrap(err, "process-start writer registration intent")
 	}
 	coordinate.WithRegistrationGate(gate)
+	return nil
 }
 
 // buildProcessStartRegistrationGate implements the Stage 7a §4.1

--- a/main_encryption_registration.go
+++ b/main_encryption_registration.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
+	"github.com/bootjp/elastickv/internal/raftengine"
+	etcdraftengine "github.com/bootjp/elastickv/internal/raftengine/etcd"
+	"github.com/bootjp/elastickv/kv"
+	pb "github.com/bootjp/elastickv/proto"
+	"github.com/bootjp/elastickv/store"
+	"github.com/cockroachdb/errors"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	// registrationRetryInitial / registrationRetryMax bound the backoff
+	// of the Stage 7a process-start registration goroutine. The first
+	// attempts often race leader election (no leader address yet), so we
+	// start small and cap so a long leaderless window does not busy-loop.
+	registrationRetryInitial = 100 * time.Millisecond
+	registrationRetryMax     = 5 * time.Second
+	// registrationBackoffFactor is the exponential multiplier applied
+	// to the retry backoff between failed registration attempts.
+	registrationBackoffFactor = 2
+)
+
+// installProcessStartRegistrationGate builds the Stage 7a registration
+// gate and wires it onto the coordinator. A registry-read failure at
+// this point is a startup fault; rather than add a branch to run() (it
+// is already at the cyclop ceiling), the error is surfaced through the
+// errgroup, whose cancellation tears the process down before it serves
+// — the same lifecycle path every other startup goroutine uses.
+func installProcessStartRegistrationGate(
+	ctx context.Context,
+	eg *errgroup.Group,
+	coordinate *kv.ShardedCoordinator,
+	defaultGroup *kv.ShardGroup,
+	w encryptionWriteWiring,
+	raftID string,
+) {
+	gate, err := buildProcessStartRegistrationGate(ctx, eg, coordinate, defaultGroup, w, raftID)
+	if err != nil {
+		eg.Go(func() error {
+			return errors.Wrap(err, "process-start writer registration intent")
+		})
+		return
+	}
+	coordinate.WithRegistrationGate(gate)
+}
+
+// buildProcessStartRegistrationGate implements the Stage 7a §4.1
+// process-start registration intent + first-write barrier. It runs
+// AFTER buildShardGroups (the default-group registry store is open) and
+// AFTER chainEncryptionStartupGuard (so CheckLocalEpochRollback has
+// passed — rollback and no-row-post-cutover are unreachable here).
+//
+// Returns nil (ungated) in every case except the "propose" branch:
+//   - encryption off (no cipher wired),
+//   - Phase 0 (cutover not yet fired — the node emits no encrypted
+//     nonces yet; runtime-cutover registration is a follow-on, not the
+//     process-start path),
+//   - not bootstrapped (no active storage DEK),
+//   - already registered at the current epoch (the bootstrap-cohort /
+//     no-op-restart case — proposing would hit ErrLocalEpochRollback).
+//
+// In the propose branch it arms an open barrier, starts the async
+// registration goroutine (leader-forwarding + bounded retry), and
+// returns a gate whose predicates read the shared StateCache.
+func buildProcessStartRegistrationGate(
+	ctx context.Context,
+	eg *errgroup.Group,
+	coordinate *kv.ShardedCoordinator,
+	defaultGroup *kv.ShardGroup,
+	w encryptionWriteWiring,
+	raftID string,
+) (*kv.RegistrationGate, error) {
+	if w.cipher == nil || defaultGroup == nil {
+		return nil, nil //nolint:nilnil // nil gate == ungated; not an error
+	}
+	if !w.cache.StorageEnvelopeActive() {
+		return nil, nil //nolint:nilnil // Phase 0: no encrypted writes yet
+	}
+	activeDEK, ok := w.cache.ActiveStorageKeyID()
+	if !ok {
+		return nil, nil //nolint:nilnil // not bootstrapped
+	}
+	fullNodeID := etcdraftengine.DeriveNodeID(raftID)
+	lastSeen, err := readWriterRegistryLastSeen(defaultGroup.Store, activeDEK, fullNodeID)
+	if err != nil {
+		return nil, err
+	}
+	// §4.1 case 2 monotonic advance: propose only when this load's epoch
+	// is strictly ahead. Equal (already registered) or — unreachable
+	// past the rollback guard — behind, skip.
+	if w.epoch <= lastSeen {
+		slog.Info("encryption: writer registration skipped (already current)",
+			slog.Uint64("dek_id", uint64(activeDEK)),
+			slog.Uint64("full_node_id", fullNodeID),
+			slog.Uint64("local_epoch", uint64(w.epoch)))
+		return nil, nil //nolint:nilnil // already registered at this epoch
+	}
+
+	barrier := make(chan struct{})
+	entry := registrationEntry(activeDEK, fullNodeID, w.epoch)
+	connCache := &kv.GRPCConnCache{}
+	eg.Go(func() error {
+		<-ctx.Done()
+		if cerr := connCache.Close(); cerr != nil {
+			return errors.Wrap(cerr, "close writer-registration gRPC connection cache")
+		}
+		return nil
+	})
+	eg.Go(func() error {
+		runWriterRegistration(ctx, coordinate, defaultGroup.Engine, connCache, entry,
+			registrationRequest(activeDEK, fullNodeID, w.epoch), barrier)
+		return nil
+	})
+	return &kv.RegistrationGate{
+		Barrier:               barrier,
+		StorageEnvelopeActive: w.cache.StorageEnvelopeActive,
+		ActiveStorageKeyID:    w.cache.ActiveStorageKeyID,
+	}, nil
+}
+
+// readWriterRegistryLastSeen returns the registry's last_seen_local_epoch
+// for (full_node_id, dek_id), or 0 when no row exists (treated as the
+// "propose" trigger per the 7a design §3.1).
+func readWriterRegistryLastSeen(st store.MVCCStore, dekID uint32, fullNodeID uint64) (uint16, error) {
+	reg, err := store.WriterRegistryFor(st)
+	if err != nil {
+		return 0, errors.Wrap(err, "writer registration: registry handle")
+	}
+	raw, ok, err := reg.GetRegistryRow(encryption.RegistryKey(dekID, encryption.NodeID16(fullNodeID)))
+	if err != nil {
+		return 0, errors.Wrap(err, "writer registration: read registry row")
+	}
+	if !ok {
+		return 0, nil
+	}
+	val, err := encryption.DecodeRegistryValue(raw)
+	if err != nil {
+		return 0, errors.Wrap(err, "writer registration: decode registry value")
+	}
+	return val.LastSeenLocalEpoch, nil
+}
+
+// registrationEntry composes the §11.3 0x03 OpRegistration Raft entry
+// for the local-leader propose path.
+func registrationEntry(dekID uint32, fullNodeID uint64, epoch uint16) []byte {
+	body := fsmwire.EncodeRegistration(fsmwire.RegistrationPayload{
+		DEKID: dekID, FullNodeID: fullNodeID, LocalEpoch: epoch,
+	})
+	entry := make([]byte, 0, 1+len(body))
+	entry = append(entry, fsmwire.OpRegistration)
+	return append(entry, body...)
+}
+
+// registrationRequest composes the EncryptionAdmin RPC request for the
+// follower-forward path.
+func registrationRequest(dekID uint32, fullNodeID uint64, epoch uint16) *pb.RegisterEncryptionWriterRequest {
+	return &pb.RegisterEncryptionWriterRequest{
+		DekId:   dekID,
+		Writers: []*pb.WriterRegistryEntry{{FullNodeId: fullNodeID, LocalEpoch: uint32(epoch)}},
+	}
+}
+
+// runWriterRegistration drives the §4.1 registration to commit, then
+// closes the barrier. It retries transient failures (no leader yet,
+// proposal dropped, transport blip) with bounded backoff against ctx;
+// on ctx cancellation it returns WITHOUT closing the barrier — never
+// releasing writes on an uncommitted registration (7a §3.2).
+func runWriterRegistration(
+	ctx context.Context,
+	coordinate *kv.ShardedCoordinator,
+	defaultEngine raftengine.Engine,
+	connCache *kv.GRPCConnCache,
+	entry []byte,
+	req *pb.RegisterEncryptionWriterRequest,
+	barrier chan struct{},
+) {
+	backoff := registrationRetryInitial
+	for {
+		if err := proposeWriterRegistration(ctx, coordinate, defaultEngine, connCache, entry, req); err == nil {
+			close(barrier)
+			slog.Info("encryption: writer registration committed; first-write barrier released",
+				slog.Uint64("dek_id", uint64(req.GetDekId())))
+			return
+		} else {
+			slog.Warn("encryption: writer registration attempt failed; retrying",
+				slog.String("error", err.Error()), slog.Duration("backoff", backoff))
+		}
+		select {
+		case <-ctx.Done():
+			return // shutdown before commit: leave barrier open (fail-closed)
+		case <-time.After(backoff):
+			backoff = minDuration(backoff*registrationBackoffFactor, registrationRetryMax)
+		}
+	}
+}
+
+// proposeWriterRegistration submits the registration once: directly via
+// the default-group engine when this node is the leader (DisableProposalForwarding
+// means a follower's Propose is dropped), else by forwarding to the
+// current leader's EncryptionAdmin endpoint.
+func proposeWriterRegistration(
+	ctx context.Context,
+	coordinate *kv.ShardedCoordinator,
+	defaultEngine raftengine.Engine,
+	connCache *kv.GRPCConnCache,
+	entry []byte,
+	req *pb.RegisterEncryptionWriterRequest,
+) error {
+	if coordinate.IsLeader() {
+		if _, err := defaultEngine.Propose(ctx, entry); err != nil {
+			return errors.Wrap(err, "writer registration: local propose")
+		}
+		return nil
+	}
+	addr := coordinate.RaftLeader()
+	if addr == "" {
+		return errors.New("writer registration: no default-group leader known yet")
+	}
+	conn, err := connCache.ConnFor(addr)
+	if err != nil {
+		return errors.Wrapf(err, "writer registration: dial leader %s", addr)
+	}
+	if _, err := pb.NewEncryptionAdminClient(conn).RegisterEncryptionWriter(ctx, req); err != nil {
+		return errors.Wrap(err, "writer registration: forward to leader")
+	}
+	return nil
+}
+
+func minDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/main_encryption_registration.go
+++ b/main_encryption_registration.go
@@ -97,15 +97,27 @@ func buildProcessStartRegistrationGate(
 	if err != nil {
 		return nil, err
 	}
-	// §4.1 case 2 monotonic advance: propose only when this load's epoch
-	// is strictly ahead. Equal (already registered) or — unreachable
-	// past the rollback guard — behind, skip.
-	if w.epoch <= lastSeen {
+	// §4.1 case 2 monotonic advance:
+	//   - epoch == last_seen → already registered (bootstrap cohort /
+	//     no-op restart) → skip, ungated.
+	//   - epoch  < last_seen → strictly behind. The §9.1
+	//     ErrLocalEpochRollback startup guard should have refused boot;
+	//     reaching here means a stale sidecar slipped past it. Fail
+	//     closed (refuse startup) rather than serving with a behind
+	//     epoch — proceeding ungated would let this load emit nonces
+	//     under a recycled (node_id, local_epoch) (codex P1).
+	//   - epoch  > last_seen → propose (the trigger).
+	switch {
+	case w.epoch == lastSeen:
 		slog.Info("encryption: writer registration skipped (already current)",
 			slog.Uint64("dek_id", uint64(activeDEK)),
 			slog.Uint64("full_node_id", fullNodeID),
 			slog.Uint64("local_epoch", uint64(w.epoch)))
-		return &kv.RegistrationGate{}, nil // already registered at this epoch
+		return &kv.RegistrationGate{}, nil
+	case w.epoch < lastSeen:
+		return nil, errors.Errorf(
+			"encryption: writer registration: local_epoch %d is behind registry last_seen %d for dek_id %d node %#x (stale sidecar past the §9.1 rollback guard)",
+			w.epoch, lastSeen, activeDEK, fullNodeID)
 	}
 
 	barrier := make(chan struct{})

--- a/main_encryption_registration.go
+++ b/main_encryption_registration.go
@@ -78,15 +78,19 @@ func buildProcessStartRegistrationGate(
 	w encryptionWriteWiring,
 	raftID string,
 ) (*kv.RegistrationGate, error) {
+	// An empty &RegistrationGate{} (nil Barrier) is the "ungated" state
+	// — awaitRegistration short-circuits on a nil Barrier. Returning it
+	// (rather than a nil gate) keeps the no-error/no-registration
+	// branches free of //nolint:nilnil.
 	if w.cipher == nil || defaultGroup == nil {
-		return nil, nil //nolint:nilnil // nil gate == ungated; not an error
+		return &kv.RegistrationGate{}, nil
 	}
 	if !w.cache.StorageEnvelopeActive() {
-		return nil, nil //nolint:nilnil // Phase 0: no encrypted writes yet
+		return &kv.RegistrationGate{}, nil // Phase 0: no encrypted writes yet
 	}
 	activeDEK, ok := w.cache.ActiveStorageKeyID()
 	if !ok {
-		return nil, nil //nolint:nilnil // not bootstrapped
+		return &kv.RegistrationGate{}, nil // not bootstrapped
 	}
 	fullNodeID := etcdraftengine.DeriveNodeID(raftID)
 	lastSeen, err := readWriterRegistryLastSeen(defaultGroup.Store, activeDEK, fullNodeID)
@@ -101,22 +105,14 @@ func buildProcessStartRegistrationGate(
 			slog.Uint64("dek_id", uint64(activeDEK)),
 			slog.Uint64("full_node_id", fullNodeID),
 			slog.Uint64("local_epoch", uint64(w.epoch)))
-		return nil, nil //nolint:nilnil // already registered at this epoch
+		return &kv.RegistrationGate{}, nil // already registered at this epoch
 	}
 
 	barrier := make(chan struct{})
 	entry := registrationEntry(activeDEK, fullNodeID, w.epoch)
-	connCache := &kv.GRPCConnCache{}
+	req := registrationRequest(activeDEK, fullNodeID, w.epoch)
 	eg.Go(func() error {
-		<-ctx.Done()
-		if cerr := connCache.Close(); cerr != nil {
-			return errors.Wrap(cerr, "close writer-registration gRPC connection cache")
-		}
-		return nil
-	})
-	eg.Go(func() error {
-		runWriterRegistration(ctx, coordinate, defaultGroup.Engine, connCache, entry,
-			registrationRequest(activeDEK, fullNodeID, w.epoch), barrier)
+		runWriterRegistration(ctx, coordinate, defaultGroup.Engine, entry, req, barrier)
 		return nil
 	})
 	return &kv.RegistrationGate{
@@ -177,27 +173,39 @@ func runWriterRegistration(
 	ctx context.Context,
 	coordinate *kv.ShardedCoordinator,
 	defaultEngine raftengine.Engine,
-	connCache *kv.GRPCConnCache,
 	entry []byte,
 	req *pb.RegisterEncryptionWriterRequest,
 	barrier chan struct{},
 ) {
+	// The conn cache (forwarding to the leader's EncryptionAdmin) is
+	// scoped to this one-shot goroutine: closed when registration
+	// commits or ctx ends, so no process-lifetime cache + watcher
+	// goroutine is needed.
+	connCache := &kv.GRPCConnCache{}
+	defer func() { _ = connCache.Close() }()
+
 	backoff := registrationRetryInitial
 	for {
-		if err := proposeWriterRegistration(ctx, coordinate, defaultEngine, connCache, entry, req); err == nil {
+		err := proposeWriterRegistration(ctx, coordinate, defaultEngine, connCache, entry, req)
+		if err == nil {
 			close(barrier)
 			slog.Info("encryption: writer registration committed; first-write barrier released",
 				slog.Uint64("dek_id", uint64(req.GetDekId())))
 			return
-		} else {
-			slog.Warn("encryption: writer registration attempt failed; retrying",
-				slog.String("error", err.Error()), slog.Duration("backoff", backoff))
 		}
+		// On shutdown the failure is just the cancelled ctx — return
+		// without a misleading "retrying" warning, leaving the barrier
+		// open (fail-closed).
+		if ctx.Err() != nil {
+			return
+		}
+		slog.Warn("encryption: writer registration attempt failed; retrying",
+			slog.String("error", err.Error()), slog.Duration("backoff", backoff))
 		select {
 		case <-ctx.Done():
 			return // shutdown before commit: leave barrier open (fail-closed)
 		case <-time.After(backoff):
-			backoff = minDuration(backoff*registrationBackoffFactor, registrationRetryMax)
+			backoff = min(backoff*registrationBackoffFactor, registrationRetryMax)
 		}
 	}
 }
@@ -232,11 +240,4 @@ func proposeWriterRegistration(
 		return errors.Wrap(err, "writer registration: forward to leader")
 	}
 	return nil
-}
-
-func minDuration(a, b time.Duration) time.Duration {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/main_encryption_registration.go
+++ b/main_encryption_registration.go
@@ -153,8 +153,23 @@ func buildProcessStartRegistrationGate(
 	barrier := make(chan struct{})
 	entry := registrationEntry(activeDEK, fullNodeID, w.epoch)
 	req := registrationRequest(activeDEK, fullNodeID, w.epoch)
+	// verifyRegistered re-reads the local registry to detect whether
+	// our epoch has actually committed — covers a Propose attempt that
+	// timed out (the waiter was removed) but whose entry Raft still
+	// applied, or a registration that landed via another path. Without
+	// it, consistently >registrationAttemptTimeout commit latency could
+	// keep retrying-without-committing forever despite durable
+	// registration (codex P2 #6).
+	regStore := defaultGroup.Store
+	verifyRegistered := func() (bool, error) {
+		ls, err := readWriterRegistryLastSeen(regStore, activeDEK, fullNodeID)
+		if err != nil {
+			return false, err
+		}
+		return ls >= w.epoch, nil
+	}
 	eg.Go(func() error {
-		runWriterRegistration(ctx, coordinate, defaultGroup.Engine, entry, req, barrier)
+		runWriterRegistration(ctx, coordinate, defaultGroup.Engine, entry, req, barrier, verifyRegistered)
 		return nil
 	})
 	return &kv.RegistrationGate{
@@ -218,6 +233,7 @@ func runWriterRegistration(
 	entry []byte,
 	req *pb.RegisterEncryptionWriterRequest,
 	barrier chan struct{},
+	verifyRegistered func() (bool, error),
 ) {
 	// The conn cache (forwarding to the leader's EncryptionAdmin) is
 	// scoped to this one-shot goroutine: closed when registration
@@ -233,6 +249,17 @@ func runWriterRegistration(
 
 	backoff := registrationRetryInitial
 	for {
+		// Verify-before-propose: a prior attempt may have timed out yet
+		// still committed (Raft applies after the waiter is removed), or
+		// another path registered us. Closing on durable registration
+		// avoids retrying-without-committing forever under high commit
+		// latency (codex P2 #6).
+		if registered, verr := verifyRegistered(); verr == nil && registered {
+			close(barrier)
+			slog.Info("encryption: writer registration confirmed committed; first-write barrier released",
+				slog.Uint64("dek_id", uint64(req.GetDekId())))
+			return
+		}
 		err := proposeWriterRegistration(ctx, coordinate, defaultEngine, connCache, entry, req)
 		if err == nil {
 			close(barrier)

--- a/main_encryption_registration_test.go
+++ b/main_encryption_registration_test.go
@@ -52,7 +52,11 @@ func newRegistrationTestStore(t *testing.T) store.MVCCStore {
 	return st
 }
 
-func writeRegistryRow(t *testing.T, st store.MVCCStore, dekID uint32, fullNodeID uint64, lastSeen uint16) {
+// testRegDEKID is the storage DEK id used across the registration
+// tests (the wiringFor fixtures activate the same id).
+const testRegDEKID uint32 = 7
+
+func writeRegistryRow(t *testing.T, st store.MVCCStore, fullNodeID uint64, lastSeen uint16) {
 	t.Helper()
 	reg, err := store.WriterRegistryFor(st)
 	if err != nil {
@@ -61,7 +65,7 @@ func writeRegistryRow(t *testing.T, st store.MVCCStore, dekID uint32, fullNodeID
 	val := encryption.EncodeRegistryValue(encryption.RegistryValue{
 		FullNodeID: fullNodeID, FirstSeenLocalEpoch: lastSeen, LastSeenLocalEpoch: lastSeen,
 	})
-	if err := reg.SetRegistryRow(encryption.RegistryKey(dekID, encryption.NodeID16(fullNodeID)), val); err != nil {
+	if err := reg.SetRegistryRow(encryption.RegistryKey(testRegDEKID, encryption.NodeID16(fullNodeID)), val); err != nil {
 		t.Fatalf("SetRegistryRow: %v", err)
 	}
 }
@@ -82,7 +86,7 @@ func TestReadWriterRegistryLastSeen(t *testing.T) {
 	}
 
 	// After writing last_seen=5 → 5.
-	writeRegistryRow(t, st, dekID, fullNodeID, 5)
+	writeRegistryRow(t, st, fullNodeID, 5)
 	got, err = readWriterRegistryLastSeen(st, dekID, fullNodeID)
 	if err != nil {
 		t.Fatalf("readWriterRegistryLastSeen (with row): %v", err)
@@ -121,7 +125,7 @@ func TestBuildProcessStartRegistrationGate_NilGateBranches(t *testing.T) {
 		{
 			name: "already_registered",
 			w:    wiringFor(t, 7, true, 3),
-			seed: func(t *testing.T, st store.MVCCStore) { writeRegistryRow(t, st, 7, fullNodeID, 3) },
+			seed: func(t *testing.T, st store.MVCCStore) { writeRegistryRow(t, st, fullNodeID, 3) },
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -147,12 +151,36 @@ func TestBuildProcessStartRegistrationGate_NilGateBranches(t *testing.T) {
 	}
 }
 
+// TestBuildProcessStartRegistrationGate_BehindEpochFailsClosed pins
+// codex P1: a strictly-behind epoch (registry last_seen > bumped epoch)
+// must fail closed (error) rather than skip ungated. The §9.1 rollback
+// guard should catch this earlier, but if a stale sidecar slips past,
+// the intent step must refuse rather than serve with a behind epoch.
+func TestBuildProcessStartRegistrationGate_BehindEpochFailsClosed(t *testing.T) {
+	t.Parallel()
+	st := newRegistrationTestStore(t)
+	fullNodeID := etcdraftengine.DeriveNodeID("n1")
+	// Registry ahead of the bumped epoch (last_seen=5 > epoch=3).
+	writeRegistryRow(t, st, fullNodeID, 5)
+
+	eg, _ := errgroup.WithContext(context.Background())
+	gate, err := buildProcessStartRegistrationGate(
+		context.Background(), eg, &kv.ShardedCoordinator{},
+		&kv.ShardGroup{Store: st}, wiringFor(t, 7, true, 3), "n1")
+	if err == nil {
+		t.Fatal("expected fail-closed error on behind epoch, got nil")
+	}
+	if gate != nil {
+		t.Errorf("behind-epoch should return nil gate, got %+v", gate)
+	}
+}
+
 func TestBuildProcessStartRegistrationGate_ProposeBranchArmsBarrier(t *testing.T) {
 	t.Parallel()
 	st := newRegistrationTestStore(t)
 	fullNodeID := etcdraftengine.DeriveNodeID("n1")
 	// Registry behind the bumped epoch (last_seen=2 < epoch=3) → propose.
-	writeRegistryRow(t, st, 7, fullNodeID, 2)
+	writeRegistryRow(t, st, fullNodeID, 2)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	eg, egCtx := errgroup.WithContext(ctx)

--- a/main_encryption_registration_test.go
+++ b/main_encryption_registration_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/bootjp/elastickv/internal/encryption"
 	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
@@ -11,6 +12,31 @@ import (
 	"github.com/bootjp/elastickv/store"
 	"golang.org/x/sync/errgroup"
 )
+
+// TestRunWriterRegistration_VerifyCommittedClosesBarrier pins codex
+// P2 #6: when the registration is already durably committed (e.g. a
+// prior attempt timed out but Raft applied it), the verify-before-
+// propose check closes the barrier without needing a successful
+// propose — so it never reaches proposeWriterRegistration (nil
+// coordinator/engine are safe here precisely because verify short-
+// circuits first).
+func TestRunWriterRegistration_VerifyCommittedClosesBarrier(t *testing.T) {
+	t.Parallel()
+	barrier := make(chan struct{})
+	verify := func() (bool, error) { return true, nil } // already committed
+	done := make(chan struct{})
+	go func() {
+		runWriterRegistration(context.Background(), nil, nil, nil,
+			registrationRequest(7, 1, 3), barrier, verify)
+		close(done)
+	}()
+	select {
+	case <-barrier:
+	case <-time.After(2 * time.Second):
+		t.Fatal("barrier not closed when registration already committed (verify path)")
+	}
+	<-done
+}
 
 func TestRegistrationEntry_RoundTrips(t *testing.T) {
 	t.Parallel()

--- a/main_encryption_registration_test.go
+++ b/main_encryption_registration_test.go
@@ -137,8 +137,11 @@ func TestBuildProcessStartRegistrationGate_NilGateBranches(t *testing.T) {
 			if err != nil {
 				t.Fatalf("buildProcessStartRegistrationGate: %v", err)
 			}
-			if gate != nil {
-				t.Errorf("%s: expected nil (ungated) gate, got %+v", tc.name, gate)
+			// Ungated == a non-nil gate with a nil Barrier (the
+			// awaitRegistration short-circuit), so no encrypted write
+			// ever blocks.
+			if gate == nil || gate.Barrier != nil {
+				t.Errorf("%s: expected ungated gate (nil Barrier), got %+v", tc.name, gate)
 			}
 		})
 	}

--- a/main_encryption_registration_test.go
+++ b/main_encryption_registration_test.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
+	etcdraftengine "github.com/bootjp/elastickv/internal/raftengine/etcd"
+	"github.com/bootjp/elastickv/kv"
+	"github.com/bootjp/elastickv/store"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestRegistrationEntry_RoundTrips(t *testing.T) {
+	t.Parallel()
+	entry := registrationEntry(7, 0xABCD, 3)
+	if entry[0] != fsmwire.OpRegistration {
+		t.Fatalf("opcode = 0x%02x, want OpRegistration 0x%02x", entry[0], fsmwire.OpRegistration)
+	}
+	p, err := fsmwire.DecodeRegistration(entry[1:])
+	if err != nil {
+		t.Fatalf("DecodeRegistration: %v", err)
+	}
+	if p.DEKID != 7 || p.FullNodeID != 0xABCD || p.LocalEpoch != 3 {
+		t.Errorf("decoded payload = %+v, want {7, 0xABCD, 3}", p)
+	}
+}
+
+func TestRegistrationRequest_Fields(t *testing.T) {
+	t.Parallel()
+	req := registrationRequest(7, 0xABCD, 3)
+	if req.GetDekId() != 7 {
+		t.Errorf("DekId = %d, want 7", req.GetDekId())
+	}
+	if len(req.GetWriters()) != 1 {
+		t.Fatalf("Writers = %d, want 1", len(req.GetWriters()))
+	}
+	w := req.GetWriters()[0]
+	if w.GetFullNodeId() != 0xABCD || w.GetLocalEpoch() != 3 {
+		t.Errorf("writer = {%d, %d}, want {0xABCD, 3}", w.GetFullNodeId(), w.GetLocalEpoch())
+	}
+}
+
+func newRegistrationTestStore(t *testing.T) store.MVCCStore {
+	t.Helper()
+	st, err := store.NewPebbleStore(t.TempDir() + "/fsm.db")
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+func writeRegistryRow(t *testing.T, st store.MVCCStore, dekID uint32, fullNodeID uint64, lastSeen uint16) {
+	t.Helper()
+	reg, err := store.WriterRegistryFor(st)
+	if err != nil {
+		t.Fatalf("WriterRegistryFor: %v", err)
+	}
+	val := encryption.EncodeRegistryValue(encryption.RegistryValue{
+		FullNodeID: fullNodeID, FirstSeenLocalEpoch: lastSeen, LastSeenLocalEpoch: lastSeen,
+	})
+	if err := reg.SetRegistryRow(encryption.RegistryKey(dekID, encryption.NodeID16(fullNodeID)), val); err != nil {
+		t.Fatalf("SetRegistryRow: %v", err)
+	}
+}
+
+func TestReadWriterRegistryLastSeen(t *testing.T) {
+	t.Parallel()
+	st := newRegistrationTestStore(t)
+	const dekID uint32 = 7
+	fullNodeID := etcdraftengine.DeriveNodeID("n1")
+
+	// No row → 0.
+	got, err := readWriterRegistryLastSeen(st, dekID, fullNodeID)
+	if err != nil {
+		t.Fatalf("readWriterRegistryLastSeen (no row): %v", err)
+	}
+	if got != 0 {
+		t.Errorf("no-row last_seen = %d, want 0", got)
+	}
+
+	// After writing last_seen=5 → 5.
+	writeRegistryRow(t, st, dekID, fullNodeID, 5)
+	got, err = readWriterRegistryLastSeen(st, dekID, fullNodeID)
+	if err != nil {
+		t.Fatalf("readWriterRegistryLastSeen (with row): %v", err)
+	}
+	if got != 5 {
+		t.Errorf("with-row last_seen = %d, want 5", got)
+	}
+}
+
+// wiringFor builds an encryptionWriteWiring with a non-nil cipher and a
+// StateCache reflecting the given (activeDEK, envelopeActive) state.
+func wiringFor(t *testing.T, activeDEK uint32, envelopeActive bool, epoch uint16) encryptionWriteWiring {
+	t.Helper()
+	cipher, err := encryption.NewCipher(encryption.NewKeystore())
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	cache := encryption.NewStateCache()
+	sc := &encryption.Sidecar{Version: encryption.SidecarVersion, StorageEnvelopeActive: envelopeActive}
+	sc.Active.Storage = activeDEK
+	cache.RefreshFromSidecar(sc)
+	return encryptionWriteWiring{cache: cache, cipher: cipher, epoch: epoch}
+}
+
+func TestBuildProcessStartRegistrationGate_NilGateBranches(t *testing.T) {
+	t.Parallel()
+	fullNodeID := etcdraftengine.DeriveNodeID("n1")
+	for _, tc := range []struct {
+		name string
+		w    encryptionWriteWiring
+		seed func(t *testing.T, st store.MVCCStore)
+	}{
+		{name: "encryption_off", w: encryptionWriteWiring{cache: encryption.NewStateCache()}}, // cipher nil
+		{name: "phase0_envelope_inactive", w: wiringFor(t, 7, false, 1)},
+		{name: "not_bootstrapped", w: wiringFor(t, 0, true, 1)},
+		{
+			name: "already_registered",
+			w:    wiringFor(t, 7, true, 3),
+			seed: func(t *testing.T, st store.MVCCStore) { writeRegistryRow(t, st, 7, fullNodeID, 3) },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			st := newRegistrationTestStore(t)
+			if tc.seed != nil {
+				tc.seed(t, st)
+			}
+			eg, _ := errgroup.WithContext(context.Background())
+			gate, err := buildProcessStartRegistrationGate(
+				context.Background(), eg, &kv.ShardedCoordinator{},
+				&kv.ShardGroup{Store: st}, tc.w, "n1")
+			if err != nil {
+				t.Fatalf("buildProcessStartRegistrationGate: %v", err)
+			}
+			if gate != nil {
+				t.Errorf("%s: expected nil (ungated) gate, got %+v", tc.name, gate)
+			}
+		})
+	}
+}
+
+func TestBuildProcessStartRegistrationGate_ProposeBranchArmsBarrier(t *testing.T) {
+	t.Parallel()
+	st := newRegistrationTestStore(t)
+	fullNodeID := etcdraftengine.DeriveNodeID("n1")
+	// Registry behind the bumped epoch (last_seen=2 < epoch=3) → propose.
+	writeRegistryRow(t, st, 7, fullNodeID, 2)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	eg, egCtx := errgroup.WithContext(ctx)
+	// The propose goroutine uses egCtx; cancel stops it (a zero
+	// coordinator reports not-leader + no leader address, so it just
+	// retries until ctx ends).
+	gate, err := buildProcessStartRegistrationGate(
+		egCtx, eg, &kv.ShardedCoordinator{},
+		&kv.ShardGroup{Store: st}, wiringFor(t, 7, true, 3), "n1")
+	if err != nil {
+		t.Fatalf("buildProcessStartRegistrationGate: %v", err)
+	}
+	if gate == nil {
+		t.Fatal("propose branch should return a non-nil gate")
+	}
+	if gate.Barrier == nil {
+		t.Error("propose branch gate must carry an open barrier")
+	}
+	if gate.StorageEnvelopeActive == nil || gate.ActiveStorageKeyID == nil {
+		t.Error("gate predicates must be wired")
+	}
+	// Barrier must still be open (registration cannot commit against the
+	// zero coordinator): a non-blocking read should not succeed.
+	select {
+	case <-gate.Barrier:
+		t.Error("barrier closed unexpectedly without a committed registration")
+	default:
+	}
+	cancel()
+	_ = eg.Wait()
+}

--- a/main_encryption_write_wiring.go
+++ b/main_encryption_write_wiring.go
@@ -34,13 +34,16 @@ func buildShardGroupsWithEncryptionWiring(
 	keystore *encryption.Keystore,
 	sidecarPath string,
 	encryptionEnabled bool,
-) ([]*raftGroupRuntime, map[uint64]*kv.ShardGroup, error) {
+) ([]*raftGroupRuntime, map[uint64]*kv.ShardGroup, encryptionWriteWiring, error) {
 	encWiring, err := buildEncryptionWriteWiring(encryptionEnabled, raftID, sidecarPath, kekWrapper, keystore)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, encryptionWriteWiring{}, err
 	}
-	return buildShardGroups(raftID, raftDir, groups, multi, bootstrap, bootstrapServers,
+	runtimes, shardGroups, err := buildShardGroups(raftID, raftDir, groups, multi, bootstrap, bootstrapServers,
 		factory, proposalObserverForGroup, clock, kekWrapper, keystore, sidecarPath, encWiring)
+	// Return the wiring (cache + bumped epoch) so run() can drive the
+	// Stage 7a process-start registration after the shard stores open.
+	return runtimes, shardGroups, encWiring, err
 }
 
 // encryptionWriteWiring bundles the Stage 6D-6c storage-envelope
@@ -62,6 +65,13 @@ type encryptionWriteWiring struct {
 	cache        *encryption.StateCache
 	cipher       *encryption.Cipher
 	nonceFactory store.NonceFactory
+	// epoch is the §4.1 local_epoch this process load pinned into the
+	// nonce factory (the value BumpLocalEpoch advanced to, or 0 in the
+	// pre-bootstrap case). Stage 7a's process-start registration
+	// proposes RegisterEncryptionWriter with this epoch so the writer
+	// registry's last_seen advances in lockstep with the nonces this
+	// load emits. Zero when encryption is off or pre-bootstrap.
+	epoch uint16
 }
 
 // withDefaultedCache returns a copy of w with a non-nil StateCache.
@@ -134,6 +144,7 @@ func buildEncryptionWriteWiring(encryptionEnabled bool, raftID, sidecarPath stri
 		return w, err
 	}
 	w.cipher = cipher
+	w.epoch = epoch
 	w.nonceFactory = encryption.NewDeterministicNonceFactory(
 		encryption.NodeID16(etcdraftengine.DeriveNodeID(raftID)), epoch)
 	return w, nil


### PR DESCRIPTION
## Summary
Implements **Stage 7a** — the process-start half of the §4.1 registration-before-first-write nonce gate — against the design approved in PR #835. Closes the deferred single-cluster restart nonce-safety gap: a node restarting under an active storage envelope now registers its bumped `local_epoch` in the writer registry before it originates any encrypted write.

Two commits:

### 1/2 — coordinator first-write barrier (`kv`)
- `RegistrationGate{Barrier, StorageEnvelopeActive, ActiveStorageKeyID}` carries the barrier + gate predicates into `ShardedCoordinator` without coupling `kv` to `internal/encryption` (plain `chan` + closures).
- `WithRegistrationGate` option; `awaitRegistration` runs at the top of `Dispatch`. Three-state barrier: `nil` (ungated) / open (pending → mutating encrypted writes block) / closed (committed → non-blocking-`select` fast path). Reads never reach `Dispatch`; cleartext writes (pre-cutover / no active DEK) are ungated via `writeWouldEncrypt`. Fail-closed: a gated write whose `ctx` ends returns the ctx error rather than emitting an unregistered nonce.

### 2/2 — process-start registration + barrier arming (`main`)
- `buildProcessStartRegistrationGate` (post-`buildShardGroups`, after the startup guards → `CheckLocalEpochRollback` has passed) decides intent per design §3.1: **nil (ungated)** for encryption-off / Phase-0 / not-bootstrapped / already-registered (`epoch <= registry.last_seen`); **propose** otherwise.
- The propose branch arms an open barrier and starts an errgroup goroutine: local `engine.Propose` when this node is the default-group leader, else **forward** to the leader's `EncryptionAdmin` (`DisableProposalForwarding` means a follower's `Propose` is dropped). Bounded exponential backoff against `runCtx`; closes the barrier on commit; returns **without** closing on ctx cancel (fail-closed). Dedicated `GRPCConnCache` drained on ctx.
- Registry read uses a stateless read-only `store.WriterRegistryFor(defaultGroup.Store)` wrapper (design §3.1 updated to reflect this as-built simplification vs. the proposal-round "thread the handle" plan — equivalent, avoids widening `buildShardGroups`' signature).

## Self-review (5 lenses)
1. **Data loss** — additive (a 0x03 `OpRegistration` entry + a registry-row advance); the gate only *delays* encrypted writes, never drops them.
2. **Concurrency** — `chan` barrier with a non-blocking fast path; the propose goroutine exits on commit-close or ctx (no leak); the conn cache is concurrency-safe. `-race` clean.
3. **Performance** — registration runs once per process load; the gate fast path after first write is a non-blocking `select`; reads are off the gated path entirely.
4. **Data consistency** — propose only when `epoch > last_seen` (matches §4.1 case-2 monotonic advance); skip-at-equal avoids the `ErrLocalEpochRollback` self-brick; the fail-closed barrier prevents this node emitting an unregistered nonce.
5. **Test coverage** — gate: nil/closed/open-barrier, read-only & cleartext ungated, blocks-then-releases-on-commit, ctx-cancel fail-closed. Registration: entry round-trip, request fields, `readWriterRegistryLastSeen` (no-row/with-row), intent nil-gate branches, propose-branch arms an open barrier. The multi-node leader-forward *commit* path is exercised by the cluster suites / Stage 9 Jepsen.

Semantic-change audit: the `Dispatch` gate adds one error case (wrapped ctx error) on a path that already returns errors; adapter callers propagate it unchanged.

## Scope
- **In (7a):** process-start registration intent, coordinator first-write barrier, follower→leader forwarding, unit tests.
- **Out:** 7b (post-rotation re-registration), 7c (ConfChange-time registration).

## Test plan
- [x] `go test -race . ./kv/...`
- [x] `golangci-lint run . ./kv/...` (0 issues)
- [ ] CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a process-start writer registration gate that blocks encrypted self-originated writes until local writer registration is confirmed (fail-closed for safety).

* **Behavior Changes**
  * Coordinator now enforces a registration-before-first-write barrier for sharded operations, preventing certain mutating encrypted writes until registration completes.

* **Tests**
  * Added extensive tests covering gating, barrier blocking/release, and registration verification paths.

* **Documentation**
  * Updated design doc clarifying registration gating scope and interim safety rationale.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/839?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->