### PR TITLE
backup: Phase 0b M3b-3 — DynamoDB GSI row derivation (completes M3)

### DIFF
--- a/internal/backup/encode_dynamodb_gsi.go
+++ b/internal/backup/encode_dynamodb_gsi.go
@@ -1,0 +1,115 @@
+package backup
+
+import (
+	"encoding/base64"
+	"sort"
+	"strconv"
+
+	pb "github.com/bootjp/elastickv/proto"
+)
+
+// encode_dynamodb_gsi.go derives the global-secondary-index rows for each
+// base item — the inverse of the decoder's no-op HandleGSIRow, which drops
+// GSI rows precisely because they are derivable from the base item set +
+// schema. It reproduces the live adapter's gsiEntryKeysForItem (V2 ordered
+// path): for every GSI whose key attributes the item carries, emit
+//
+//	key   = !ddb|gsi|<b64(table)>|<gen>|<b64(index)>|
+//	        <orderedIndexHash><orderedIndexRange><orderedPKHash><orderedPKRange>
+//	value = <the base item's !ddb|item| key>   (a pointer back to the item)
+//
+// Sparse indexing: an item missing the index hash attribute (or a defined
+// index range attribute) contributes no row for that index — matching the
+// live gsiKeyValues include=false path.
+
+// ddbGSIRow is one derived index row: the index key and the base item key
+// it points to.
+type ddbGSIRow struct {
+	key   []byte
+	value []byte
+}
+
+// ddbGSIRows derives the GSI rows for one item. itemKey is the item's
+// primary !ddb|item| key, stored as each row's value.
+func ddbGSIRows(tableName string, generation uint64, schema *pb.DynamoTableSchema, item *pb.DynamoItem, itemKey []byte) ([]ddbGSIRow, error) {
+	gsis := schema.GetGlobalSecondaryIndexes()
+	if len(gsis) == 0 {
+		return nil, nil
+	}
+	pkHash, pkRange, err := ddbOrderedPrimaryKeySegments(schema, item)
+	if err != nil {
+		return nil, err
+	}
+	rows := make([]ddbGSIRow, 0, len(gsis))
+	for _, indexName := range ddbSortedGSINames(gsis) {
+		idxHash, idxRange, include, err := ddbGSIKeySegments(item, gsis[indexName].GetKeySchema())
+		if err != nil {
+			return nil, err
+		}
+		if !include {
+			continue
+		}
+		key := ddbGSIIndexKeyPrefix(tableName, generation, indexName)
+		key = append(key, idxHash...)
+		key = append(key, idxRange...)
+		key = append(key, pkHash...)
+		key = append(key, pkRange...)
+		rows = append(rows, ddbGSIRow{key: key, value: itemKey})
+	}
+	return rows, nil
+}
+
+func ddbSortedGSINames(gsis map[string]*pb.DynamoGlobalSecondaryIndex) []string {
+	names := make([]string, 0, len(gsis))
+	for name := range gsis {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ddbGSIKeySegments extracts the ordered index hash/range segments from the
+// item for one GSI key schema. include=false (a sparse item that does not
+// project into this index) when the item lacks the index hash attribute or
+// a defined index range attribute — matching the live gsiKeyValues.
+func ddbGSIKeySegments(item *pb.DynamoItem, ks *pb.DynamoKeySchema) ([]byte, []byte, bool, error) {
+	attrs := item.GetAttributes()
+	hashAV, ok := attrs[ks.GetHashKey()]
+	if !ok {
+		return nil, nil, false, nil
+	}
+	hashRaw, err := ddbPrimaryKeyBytes(hashAV)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	hashSeg := encodeDDBOrderedKeySegment(hashRaw)
+	if ks.GetRangeKey() == "" {
+		return hashSeg, nil, true, nil
+	}
+	rangeAV, ok := attrs[ks.GetRangeKey()]
+	if !ok {
+		return nil, nil, false, nil
+	}
+	rangeRaw, err := ddbPrimaryKeyBytes(rangeAV)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	return hashSeg, encodeDDBOrderedKeySegment(rangeRaw), true, nil
+}
+
+// ddbGSIIndexKeyPrefix reproduces dynamoGSIIndexPrefixForTable:
+// !ddb|gsi|<base64url(table)>|<gen>|<base64url(indexName)>|
+func ddbGSIIndexKeyPrefix(tableName string, generation uint64, indexName string) []byte {
+	encTable := base64.RawURLEncoding.EncodeToString([]byte(tableName))
+	encIndex := base64.RawURLEncoding.EncodeToString([]byte(indexName))
+	gen := strconv.FormatUint(generation, 10)
+	out := make([]byte, 0, len(DDBGSIPrefix)+len(encTable)+len(gen)+len(encIndex)+len("|||"))
+	out = append(out, DDBGSIPrefix...)
+	out = append(out, encTable...)
+	out = append(out, '|')
+	out = append(out, gen...)
+	out = append(out, '|')
+	out = append(out, encIndex...)
+	out = append(out, '|')
+	return out
+}

--- a/internal/backup/encode_dynamodb_gsi_test.go
+++ b/internal/backup/encode_dynamodb_gsi_test.go
@@ -97,6 +97,77 @@ func TestDDBEncodeGSISparseSkipsMissingIndexKey(t *testing.T) {
 	}
 }
 
+// TestDDBEncodeGSISparseSkipsMissingIndexRange pins the second sparse
+// branch: a GSI with a defined range key skips an item that has the index
+// hash attribute but not the index range attribute (matching the live
+// gsiKeyValues include=false path).
+func TestDDBEncodeGSISparseSkipsMissingIndexRange(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "orders"
+	schema := `{"format_version":1,"table_name":"orders",` +
+		`"primary_key":{"hash_key":{"name":"customer","type":"S"},"range_key":{"name":"order","type":"S"}},` +
+		`"attribute_definitions":[{"name":"customer","type":"S"},{"name":"order","type":"S"},{"name":"region","type":"S"},{"name":"ts","type":"S"}],` +
+		`"global_secondary_indexes":[{"name":"by-region","key_schema":{"hash_key":{"name":"region","type":"S"},"range_key":{"name":"ts","type":"S"}},"projection":{"type":"ALL"}}]}`
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(schema))
+	writeDDBItemFile(t, in, table, "both.json", []byte(`{"customer":{"S":"c1"},"order":{"S":"o1"},"region":{"S":"us"},"ts":{"S":"t1"}}`))
+	writeDDBItemFile(t, in, table, "norange.json", []byte(`{"customer":{"S":"c2"},"order":{"S":"o2"},"region":{"S":"us"}}`))
+
+	itemKeys, gsiRows := splitDDBEntries(liveDDBEntries(t, in))
+	if len(itemKeys) != 2 {
+		t.Fatalf("item records = %d, want 2", len(itemKeys))
+	}
+	if len(gsiRows) != 1 {
+		t.Fatalf("GSI rows = %d, want 1 (item missing the index range key is skipped)", len(gsiRows))
+	}
+}
+
+// TestDDBEncodeGSIMultipleIndexes pins that a table with two GSIs emits a
+// row for each (covering ddbSortedGSINames over >1 index), both pointing
+// to the item and each carrying its own index prefix.
+func TestDDBEncodeGSIMultipleIndexes(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "orders"
+	schema := `{"format_version":1,"table_name":"orders",` +
+		`"primary_key":{"hash_key":{"name":"customer","type":"S"}},` +
+		`"attribute_definitions":[{"name":"customer","type":"S"},{"name":"region","type":"S"},{"name":"status","type":"S"}],` +
+		`"global_secondary_indexes":[` +
+		`{"name":"by-region","key_schema":{"hash_key":{"name":"region","type":"S"}},"projection":{"type":"ALL"}},` +
+		`{"name":"by-status","key_schema":{"hash_key":{"name":"status","type":"S"}},"projection":{"type":"ALL"}}]}`
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(schema))
+	writeDDBItemFile(t, in, table, "i.json", []byte(`{"customer":{"S":"c1"},"region":{"S":"us"},"status":{"S":"active"}}`))
+
+	itemKeys, gsiRows := splitDDBEntries(liveDDBEntries(t, in))
+	if len(itemKeys) != 1 {
+		t.Fatalf("item records = %d, want 1", len(itemKeys))
+	}
+	if len(gsiRows) != 2 {
+		t.Fatalf("GSI rows = %d, want 2", len(gsiRows))
+	}
+	for _, idx := range []string{"by-region", "by-status"} {
+		prefix := []byte(DDBGSIPrefix)
+		prefix = append(prefix, base64.RawURLEncoding.EncodeToString([]byte(table))...)
+		prefix = append(prefix, "|1|"...)
+		prefix = append(prefix, base64.RawURLEncoding.EncodeToString([]byte(idx))...)
+		prefix = append(prefix, '|')
+		found := false
+		for _, r := range gsiRows {
+			if bytes.HasPrefix(r.UserKey, prefix) {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("no GSI row for index %q", idx)
+		}
+	}
+	for _, r := range gsiRows {
+		if !bytes.Equal(r.UserValue, itemKeys[0]) {
+			t.Fatalf("GSI value %x != item key %x", r.UserValue, itemKeys[0])
+		}
+	}
+}
+
 // TestDDBGSIRowKeyLayout pins the full derived GSI key bytes against a
 // hand-computed expectation: prefix + ordered index hash + ordered PK hash
 // (no ranges), value = the item key.

--- a/internal/backup/encode_dynamodb_gsi_test.go
+++ b/internal/backup/encode_dynamodb_gsi_test.go
@@ -1,0 +1,156 @@
+package backup
+
+import (
+	"bytes"
+	"encoding/base64"
+	"testing"
+
+	pb "github.com/bootjp/elastickv/proto"
+)
+
+// liveDDBEntries encodes a dump tree and returns the decoded live
+// (userKey,userValue) records — used to inspect the derived !ddb|gsi| rows
+// directly, since the decoder's HandleGSIRow drops them (so a directory
+// round-trip cannot observe them).
+func liveDDBEntries(t *testing.T, inRoot string) []RoundTripEntry {
+	t.Helper()
+	b := newSnapshotBuilder(ddbEncTS)
+	if err := NewDynamoDBEncoder(inRoot).Encode(b); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := b.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	entries, _, err := DecodeLiveEntries(&buf)
+	if err != nil {
+		t.Fatalf("DecodeLiveEntries: %v", err)
+	}
+	return entries
+}
+
+func splitDDBEntries(entries []RoundTripEntry) (itemKeys [][]byte, gsiRows []RoundTripEntry) {
+	for _, e := range entries {
+		switch {
+		case bytes.HasPrefix(e.UserKey, []byte(DDBItemPrefix)):
+			itemKeys = append(itemKeys, e.UserKey)
+		case bytes.HasPrefix(e.UserKey, []byte(DDBGSIPrefix)):
+			gsiRows = append(gsiRows, e)
+		}
+	}
+	return itemKeys, gsiRows
+}
+
+const ddbGSIOrdersSchema = `{"format_version":1,"table_name":"orders",` +
+	`"primary_key":{"hash_key":{"name":"customer","type":"S"},"range_key":{"name":"order","type":"S"}},` +
+	`"attribute_definitions":[{"name":"customer","type":"S"},{"name":"order","type":"S"},{"name":"region","type":"S"}],` +
+	`"global_secondary_indexes":[{"name":"by-region","key_schema":{"hash_key":{"name":"region","type":"S"}},"projection":{"type":"ALL"}}]}`
+
+// TestDDBEncodeGSIRowPointsToItem pins that an item with the index key
+// attribute produces exactly one derived GSI row whose value is the base
+// item's !ddb|item| key and whose key carries the
+// !ddb|gsi|<table>|<gen>|<index>| prefix.
+func TestDDBEncodeGSIRowPointsToItem(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "orders"
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(ddbGSIOrdersSchema))
+	writeDDBItemFile(t, in, table, "i.json", []byte(`{"customer":{"S":"c1"},"order":{"S":"o1"},"region":{"S":"us"}}`))
+
+	itemKeys, gsiRows := splitDDBEntries(liveDDBEntries(t, in))
+	if len(itemKeys) != 1 {
+		t.Fatalf("item records = %d, want 1", len(itemKeys))
+	}
+	if len(gsiRows) != 1 {
+		t.Fatalf("GSI rows = %d, want 1", len(gsiRows))
+	}
+	if !bytes.Equal(gsiRows[0].UserValue, itemKeys[0]) {
+		t.Fatalf("GSI value = %x, want item key %x", gsiRows[0].UserValue, itemKeys[0])
+	}
+	wantPrefix := []byte(DDBGSIPrefix)
+	wantPrefix = append(wantPrefix, base64.RawURLEncoding.EncodeToString([]byte(table))...)
+	wantPrefix = append(wantPrefix, "|1|"...)
+	wantPrefix = append(wantPrefix, base64.RawURLEncoding.EncodeToString([]byte("by-region"))...)
+	wantPrefix = append(wantPrefix, '|')
+	if !bytes.HasPrefix(gsiRows[0].UserKey, wantPrefix) {
+		t.Fatalf("GSI key %x missing prefix %x", gsiRows[0].UserKey, wantPrefix)
+	}
+}
+
+// TestDDBEncodeGSISparseSkipsMissingIndexKey pins sparse indexing: an item
+// lacking the index hash attribute contributes no GSI row (but still its
+// base item record).
+func TestDDBEncodeGSISparseSkipsMissingIndexKey(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "orders"
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(ddbGSIOrdersSchema))
+	writeDDBItemFile(t, in, table, "with.json", []byte(`{"customer":{"S":"c1"},"order":{"S":"o1"},"region":{"S":"us"}}`))
+	writeDDBItemFile(t, in, table, "without.json", []byte(`{"customer":{"S":"c2"},"order":{"S":"o2"}}`))
+
+	itemKeys, gsiRows := splitDDBEntries(liveDDBEntries(t, in))
+	if len(itemKeys) != 2 {
+		t.Fatalf("item records = %d, want 2", len(itemKeys))
+	}
+	if len(gsiRows) != 1 {
+		t.Fatalf("GSI rows = %d, want 1 (only the item carrying region)", len(gsiRows))
+	}
+}
+
+// TestDDBGSIRowKeyLayout pins the full derived GSI key bytes against a
+// hand-computed expectation: prefix + ordered index hash + ordered PK hash
+// (no ranges), value = the item key.
+func TestDDBGSIRowKeyLayout(t *testing.T) {
+	t.Parallel()
+	schema := &pb.DynamoTableSchema{
+		PrimaryKey: &pb.DynamoKeySchema{HashKey: "ph"},
+		GlobalSecondaryIndexes: map[string]*pb.DynamoGlobalSecondaryIndex{
+			"g": {KeySchema: &pb.DynamoKeySchema{HashKey: "gh"}},
+		},
+	}
+	item := &pb.DynamoItem{Attributes: map[string]*pb.DynamoAttributeValue{
+		"ph": {Value: &pb.DynamoAttributeValue_S{S: "P"}},
+		"gh": {Value: &pb.DynamoAttributeValue_S{S: "X"}},
+	}}
+	itemKey, err := ddbItemKeyBytes("t", 1, schema, item)
+	if err != nil {
+		t.Fatalf("ddbItemKeyBytes: %v", err)
+	}
+	rows, err := ddbGSIRows("t", 1, schema, item, itemKey)
+	if err != nil {
+		t.Fatalf("ddbGSIRows: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	want := []byte(DDBGSIPrefix)
+	want = append(want, base64.RawURLEncoding.EncodeToString([]byte("t"))...)
+	want = append(want, "|1|"...)
+	want = append(want, base64.RawURLEncoding.EncodeToString([]byte("g"))...)
+	want = append(want, '|')
+	want = append(want, 'X', 0x00, 0x01) // ordered index hash
+	want = append(want, 'P', 0x00, 0x01) // ordered PK hash
+	if !bytes.Equal(rows[0].key, want) {
+		t.Fatalf("GSI key = %x, want %x", rows[0].key, want)
+	}
+	if !bytes.Equal(rows[0].value, itemKey) {
+		t.Fatalf("GSI value = %x, want item key %x", rows[0].value, itemKey)
+	}
+}
+
+// TestDDBEncodeNoGSINoRows pins that a table without GSIs emits no
+// !ddb|gsi| rows.
+func TestDDBEncodeNoGSINoRows(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const table = "sessions"
+	writeDDBSchema(t, in, EncodeSegment([]byte(table)), []byte(`{"format_version":1,"table_name":"sessions",`+
+		`"primary_key":{"hash_key":{"name":"id","type":"S"}},`+
+		`"attribute_definitions":[{"name":"id","type":"S"}]}`))
+	writeDDBItemFile(t, in, table, "a.json", []byte(`{"id":{"S":"a"}}`))
+
+	_, gsiRows := splitDDBEntries(liveDDBEntries(t, in))
+	if len(gsiRows) != 0 {
+		t.Fatalf("GSI rows = %d, want 0", len(gsiRows))
+	}
+}

--- a/internal/backup/encode_dynamodb_items.go
+++ b/internal/backup/encode_dynamodb_items.go
@@ -135,7 +135,19 @@ func (e *DynamoDBEncoder) encodeOneItem(b *snapshotBuilder, root *os.Root, rel, 
 	if err != nil {
 		return err
 	}
-	return b.Add(key, val, 0)
+	if err := b.Add(key, val, 0); err != nil {
+		return err
+	}
+	rows, err := ddbGSIRows(tableName, ddbRestoreGeneration, schema, item, key)
+	if err != nil {
+		return errors.Wrapf(err, "%s", rel)
+	}
+	for _, row := range rows {
+		if err := b.Add(row.key, row.value, 0); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // readRootSubdirEntries lists a subdirectory THROUGH the pinned root fd
@@ -186,31 +198,44 @@ func isJSONFilename(name string) bool {
 // ddbItemKeyBytes builds the ordered !ddb|item| key for an item against
 // the table schema's primary-key attribute names.
 func ddbItemKeyBytes(tableName string, generation uint64, schema *pb.DynamoTableSchema, item *pb.DynamoItem) ([]byte, error) {
-	attrs := item.GetAttributes()
-	hashName := schema.GetPrimaryKey().GetHashKey()
-	hashAV, ok := attrs[hashName]
-	if !ok {
-		return nil, errors.Wrapf(ErrDDBEncodeInvalidItem, "item missing hash-key attribute %q", hashName)
-	}
-	hashRaw, err := ddbPrimaryKeyBytes(hashAV)
+	hashSeg, rangeSeg, err := ddbOrderedPrimaryKeySegments(schema, item)
 	if err != nil {
 		return nil, err
 	}
 	key := ddbItemKeyPrefix(tableName, generation)
-	key = append(key, encodeDDBOrderedKeySegment(hashRaw)...)
+	key = append(key, hashSeg...)
+	return append(key, rangeSeg...), nil
+}
+
+// ddbOrderedPrimaryKeySegments extracts the ordered hash and (optional)
+// range key segments from an item's attributes per the schema's primary
+// key. Shared by the item key and the derived GSI rows (which embed the
+// same primary-key segments). A missing primary-key attribute fails closed.
+func ddbOrderedPrimaryKeySegments(schema *pb.DynamoTableSchema, item *pb.DynamoItem) ([]byte, []byte, error) {
+	attrs := item.GetAttributes()
+	hashName := schema.GetPrimaryKey().GetHashKey()
+	hashAV, ok := attrs[hashName]
+	if !ok {
+		return nil, nil, errors.Wrapf(ErrDDBEncodeInvalidItem, "item missing hash-key attribute %q", hashName)
+	}
+	hashRaw, err := ddbPrimaryKeyBytes(hashAV)
+	if err != nil {
+		return nil, nil, err
+	}
+	hashSeg := encodeDDBOrderedKeySegment(hashRaw)
 	rangeName := schema.GetPrimaryKey().GetRangeKey()
 	if rangeName == "" {
-		return key, nil
+		return hashSeg, nil, nil
 	}
 	rangeAV, ok := attrs[rangeName]
 	if !ok {
-		return nil, errors.Wrapf(ErrDDBEncodeInvalidItem, "item missing range-key attribute %q", rangeName)
+		return nil, nil, errors.Wrapf(ErrDDBEncodeInvalidItem, "item missing range-key attribute %q", rangeName)
 	}
 	rangeRaw, err := ddbPrimaryKeyBytes(rangeAV)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return append(key, encodeDDBOrderedKeySegment(rangeRaw)...), nil
+	return hashSeg, encodeDDBOrderedKeySegment(rangeRaw), nil
 }
 
 // ddbItemKeyPrefix reproduces dynamoItemPrefixForTable:


### PR DESCRIPTION
## Summary

**Phase 0b M3b-3 — DynamoDB GSI row derivation.** Final slice of the DynamoDB reverse encoder (M3). `encode_dynamodb_gsi.go` is the inverse of the decoder's **no-op** `HandleGSIRow` (which drops GSI rows precisely because they are derivable from the base item set + schema). It reproduces the live `gsiEntryKeysForItem` (V2 ordered path):

```
key   = !ddb|gsi|<b64(table)>|<gen>|<b64(index)>|<orderedIndexHash><orderedIndexRange><orderedPKHash><orderedPKRange>
value = <the base item's !ddb|item| key>   (pointer back to the item)
```

> #833 (M3a+M3b-1+M3b-2) has merged to main; this PR now targets `main` directly and completes M3.

- **Sparse indexing**: an item missing the index hash attribute (or a defined index range attribute) contributes no row for that index — matching the live `gsiKeyValues` `include=false` path. Index names emitted in sorted order.
- **Refactor**: primary-key segment extraction is now `ddbOrderedPrimaryKeySegments`, shared by the item key and the GSI rows' embedded PK segments, so they are guaranteed identical. `encodeOneItem` stages the item record then its GSI rows.

## Why tests use `DecodeLiveEntries`
The decoder drops GSI rows, so an encode→decode directory round-trip can't observe them. Tests instead encode → write → `DecodeLiveEntries` and inspect the staged `!ddb|gsi|` records directly.

## Risk
New file + a behavior-preserving refactor of `ddbItemKeyBytes` + GSI-row staging in `encodeOneItem`. Offline-tool boundary preserved (GSI key/value format reproduced, not imported).

## Self-review (5 lenses)
- **Data loss**: GSI rows derivable; items fully restored; round-trip unaffected; sparse skip matches live.
- **Concurrency/distributed**: single-goroutine.
- **Performance**: O(GSIs) per item; offline tool.
- **Consistency**: key/value reproduce `gsiEntryKeysForItem` exactly (hand-computed layout test + value == item key + sparse + sorted index names); PK segments shared with the item key; generation = `ddbRestoreGeneration` throughout.
- **Test coverage**: GSI row points to item (+ prefix), sparse skip, full key-bytes layout, no-GSI no-rows; existing item/numeric round-trips still pass.

## Caller audit
`ddbItemKeyBytes` refactored to call `ddbOrderedPrimaryKeySegments` — behavior-preserving (existing key-layout + round-trip tests pass, byte-identical keys). `encodeOneItem` gained GSI-row staging after the item record; no existing return semantics changed. `ddbGSIRows` is new. GSI keys embed the full PK so they cannot collide with item keys or each other (`b.Add` dup-detection would otherwise fail closed).

## Test plan
- [x] `go test ./internal/backup/` (full package)
- [x] `golangci-lint run internal/backup/` (0 issues)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced DynamoDB backup handling to properly encode and capture Global Secondary Index (GSI) rows, including support for sparse indexing (when index keys are missing) and multiple indexes per table, ensuring secondary index entries are accurately preserved and referenced with primary items in backups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/840?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->