### PR TITLE
backup: Phase 0b M4-1 — S3 bucket-meta reverse encoder

### DIFF
--- a/docs/design/2026_05_25_proposed_snapshot_logical_encoder.md
+++ b/docs/design/2026_05_25_proposed_snapshot_logical_encoder.md
@@ -225,10 +225,15 @@ each adapter, mirroring the live adapter's index builders:
   `dynamodb.go`) but does **not** persist it into the public structs:
   `s3PublicBucket`, `ddbPublicSchema`, and `sqsQueueMetaPublic` have no
   `generation` field. So the encoder cannot read it back from the dump
-  alone. Two options, **Option A chosen**:
+  alone. Two options were considered; **Option B is the implemented
+  choice** — M3 (DynamoDB, `ddbRestoreGeneration = 1`) shipped it, and
+  M4 (S3, `s3RestoreGeneration = 1`) and M5 (SQS) follow it for
+  cross-adapter consistency. Option A remains the documented
+  exact-fidelity upgrade path if cross-cluster fidelity is later
+  required.
 
-  - **Option A (chosen — exact fidelity):** add an optional
-    `generation` (or `next_gen`) field to `s3PublicBucket`,
+  - **Option A (future exact-fidelity path — not implemented):** add an
+    optional `generation` (or `next_gen`) field to `s3PublicBucket`,
     `ddbPublicSchema`, `sqsQueueMetaPublic`. This is a small,
     backward-compatible decoder change (new optional JSON field) owned
     by the corresponding encoder milestone (the decoder change lands in
@@ -237,13 +242,14 @@ each adapter, mirroring the live adapter's index builders:
     value **and** stamps the same generation into every reconstructed
     item/object key, so the counter and the embedded key generation
     agree.
-  - **Option B (fallback — internally consistent, lossy externally):**
-    emit a uniform `generation = 1` in *both* the counter row and every
-    embedded item/object key generation. This is internally consistent
-    (the restored single cluster serves correctly) but loses the
-    original generation number; any external cache or cross-cluster
-    replication keyed on the original value goes stale. Documented as
-    acceptable only for single-cluster restore.
+  - **Option B (chosen — implemented; internally consistent, lossy
+    externally):** emit a uniform `generation = 1` in *both* the counter
+    row and every embedded item/object key generation. This is
+    internally consistent (the restored single cluster serves correctly)
+    but loses the original generation number; any external cache or
+    cross-cluster replication keyed on the original value goes stale.
+    Acceptable for single-cluster restore (the Phase 0b target). The
+    decoder needs no change — the dump carries no generation field.
 
   Either way the invariant is: **the `gen` counter and the generation
   embedded in `!ddb|item|<table>|<gen>|…` / `!s3|blob|<bucket><gen>…`

--- a/internal/backup/encode_s3.go
+++ b/internal/backup/encode_s3.go
@@ -34,6 +34,11 @@ import (
 // restored bucket is internally consistent (Option B; see file header).
 const s3RestoreGeneration uint64 = 1
 
+// s3BucketFormatVersion is the only _bucket.json format_version the
+// encoder accepts; a newer version fails closed rather than being parsed
+// under the v1 schema (mirrors the DynamoDB schema reader's gate).
+const s3BucketFormatVersion uint32 = 1
+
 // ErrS3EncodeInvalidBucket is returned when a _bucket.json cannot be
 // parsed into the expected shape (or carries an empty bucket name).
 var ErrS3EncodeInvalidBucket = errors.New("backup: s3 encode invalid _bucket.json")
@@ -98,6 +103,11 @@ func (e *S3RecordEncoder) encodeBucket(b *snapshotBuilder, root *os.Root, bucket
 	if pub.Name == "" {
 		return errors.Wrapf(ErrS3EncodeInvalidBucket, "%s/_bucket.json: empty bucket name", bucketDir)
 	}
+	// s3PublicBucket carries Versioning, PolicyJSONString, and
+	// CreationTimeISO, but the internal s3LiveBucketMeta record has no
+	// counterpart for them — they are dump-only metadata the live store
+	// never persisted — so they are intentionally not restored (the
+	// decoder likewise leaves CreatedAtHLC out of the public struct).
 	live := s3LiveBucketMeta{
 		BucketName:   pub.Name,
 		Generation:   s3RestoreGeneration,
@@ -141,6 +151,10 @@ func (e *S3RecordEncoder) readBucketMeta(root *os.Root, bucketDir string) (s3Pub
 	var pub s3PublicBucket
 	if err := decodeOneJSON(f, &pub); err != nil {
 		return s3PublicBucket{}, errors.Wrapf(ErrS3EncodeInvalidBucket, "%s: %v", rel, err)
+	}
+	if pub.FormatVersion != s3BucketFormatVersion {
+		return s3PublicBucket{}, errors.Wrapf(ErrS3EncodeInvalidBucket,
+			"%s: unsupported format_version %d", rel, pub.FormatVersion)
 	}
 	return pub, nil
 }

--- a/internal/backup/encode_s3.go
+++ b/internal/backup/encode_s3.go
@@ -125,7 +125,10 @@ func (e *S3RecordEncoder) encodeBucket(b *snapshotBuilder, root *os.Root, bucket
 	}
 	var genRaw [8]byte
 	binary.BigEndian.PutUint64(genRaw[:], s3RestoreGeneration)
-	return b.Add(s3keys.BucketGenerationKey(pub.Name), genRaw[:], 0)
+	if err := b.Add(s3keys.BucketGenerationKey(pub.Name), genRaw[:], 0); err != nil {
+		return err
+	}
+	return e.encodeBucketObjects(b, root, bucketDir, pub.Name)
 }
 
 // readBucketMeta opens <bucket>/_bucket.json within root (symlink-escape /

--- a/internal/backup/encode_s3.go
+++ b/internal/backup/encode_s3.go
@@ -1,0 +1,146 @@
+package backup
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/bootjp/elastickv/internal/s3keys"
+	"github.com/cockroachdb/errors"
+)
+
+// encode_s3.go is the Phase 0b S3 reverse encoder — the inverse of the
+// S3 decoder in s3.go (type S3Encoder, which turns internal !s3|* records
+// into an s3/<bucket>/ dump tree). Design:
+// docs/design/2026_05_25_proposed_snapshot_logical_encoder.md §"S3".
+//
+// This slice (M4-1) covers BUCKET metadata: it reconstructs the
+// !s3|bucket|meta| record (JSON s3LiveBucketMeta) and the
+// !s3|bucket|gen| generation counter (8-byte big-endian) from each
+// bucket's _bucket.json. Object bodies (re-chunked into !s3|blob| +
+// !s3|obj|head| manifests) and multipart uploads land in follow-up slices.
+//
+// Generation: a uniform s3RestoreGeneration is stamped into the counter
+// (and, in later slices, every object/blob key), matching the Option-B
+// decision the DynamoDB encoder uses (design §"generation counters").
+// The dump carries no generation field, so the original value is not
+// preserved; this is internally consistent for a single-cluster restore.
+// created_at_hlc is likewise not represented in the dump and is restored
+// as 0.
+
+// s3RestoreGeneration is the uniform generation stamped into the bucket
+// generation counter and (in later slices) every object/blob key, so a
+// restored bucket is internally consistent (Option B; see file header).
+const s3RestoreGeneration uint64 = 1
+
+// ErrS3EncodeInvalidBucket is returned when a _bucket.json cannot be
+// parsed into the expected shape (or carries an empty bucket name).
+var ErrS3EncodeInvalidBucket = errors.New("backup: s3 encode invalid _bucket.json")
+
+// ErrS3EncodeNotRegular is returned when a dump file (here _bucket.json)
+// is not a regular file — a symlink, FIFO, device, or directory.
+var ErrS3EncodeNotRegular = errors.New("backup: s3 dump file is not a regular file")
+
+// S3RecordEncoder reconstructs the internal S3 keyspace from the decoded
+// s3/ directory tree. (Named distinctly from the decoder's S3Encoder in
+// s3.go, which despite its name turns records INTO the dump tree.)
+type S3RecordEncoder struct {
+	inRoot string
+}
+
+// NewS3RecordEncoder constructs an encoder rooted at <inRoot>/s3/.
+func NewS3RecordEncoder(inRoot string) *S3RecordEncoder {
+	return &S3RecordEncoder{inRoot: inRoot}
+}
+
+func (e *S3RecordEncoder) s3Dir() string {
+	return filepath.Join(e.inRoot, "s3")
+}
+
+// Encode walks s3/<bucket>/ and stages each bucket's meta + generation
+// counter records on b. A missing s3/ directory is not an error.
+func (e *S3RecordEncoder) Encode(b *snapshotBuilder) error {
+	dir := e.s3Dir()
+	if err := lstatDumpDir(dir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer func() { _ = root.Close() }()
+	entries, err := readRootDirEntries(root)
+	if err != nil {
+		return err
+	}
+	for _, ent := range entries {
+		if !ent.IsDir() {
+			continue
+		}
+		if err := e.encodeBucket(b, root, ent.Name()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// encodeBucket reads one <bucket>/_bucket.json and emits its
+// !s3|bucket|meta| record and !s3|bucket|gen| counter.
+func (e *S3RecordEncoder) encodeBucket(b *snapshotBuilder, root *os.Root, bucketDir string) error {
+	pub, err := e.readBucketMeta(root, bucketDir)
+	if err != nil {
+		return err
+	}
+	if pub.Name == "" {
+		return errors.Wrapf(ErrS3EncodeInvalidBucket, "%s/_bucket.json: empty bucket name", bucketDir)
+	}
+	live := s3LiveBucketMeta{
+		BucketName:   pub.Name,
+		Generation:   s3RestoreGeneration,
+		CreatedAtHLC: 0,
+		Owner:        pub.Owner,
+		Region:       pub.Region,
+		Acl:          pub.ACL,
+	}
+	metaVal, err := json.Marshal(live)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if err := b.Add(s3keys.BucketMetaKey(pub.Name), metaVal, 0); err != nil {
+		return err
+	}
+	var genRaw [8]byte
+	binary.BigEndian.PutUint64(genRaw[:], s3RestoreGeneration)
+	return b.Add(s3keys.BucketGenerationKey(pub.Name), genRaw[:], 0)
+}
+
+// readBucketMeta opens <bucket>/_bucket.json within root (symlink-escape /
+// FIFO / hard-link safe, like the DynamoDB schema reader) and decodes the
+// public bucket projection.
+func (e *S3RecordEncoder) readBucketMeta(root *os.Root, bucketDir string) (s3PublicBucket, error) {
+	rel := filepath.Join(bucketDir, "_bucket.json")
+	linfo, err := root.Lstat(rel)
+	if err != nil {
+		return s3PublicBucket{}, errors.WithStack(err)
+	}
+	if !linfo.Mode().IsRegular() {
+		return s3PublicBucket{}, errors.Wrapf(ErrS3EncodeNotRegular, "%s (mode=%s)", rel, linfo.Mode())
+	}
+	if err := refuseHardLink(linfo, rel); err != nil {
+		return s3PublicBucket{}, err
+	}
+	f, err := root.Open(rel)
+	if err != nil {
+		return s3PublicBucket{}, errors.WithStack(err)
+	}
+	defer func() { _ = f.Close() }()
+	var pub s3PublicBucket
+	if err := decodeOneJSON(f, &pub); err != nil {
+		return s3PublicBucket{}, errors.Wrapf(ErrS3EncodeInvalidBucket, "%s: %v", rel, err)
+	}
+	return pub, nil
+}

--- a/internal/backup/encode_s3_objects.go
+++ b/internal/backup/encode_s3_objects.go
@@ -161,48 +161,43 @@ func (e *S3RecordEncoder) walkObjectEntry(b *snapshotBuilder, root *os.Root, buc
 	}
 }
 
-// encodeObject reads one object body + sidecar and stages its blob chunks
-// and manifest. The object key is the body's path relative to bucketDir.
+// encodeObject reads one object's sidecar, streams its body into blob
+// records, and stages the manifest. The object key is the body's path
+// relative to bucketDir.
 func (e *S3RecordEncoder) encodeObject(b *snapshotBuilder, root *os.Root, bucketDir, bucketName, objRel string) error {
 	objectKey := filepath.ToSlash(objRel)
 	bodyRel := filepath.Join(bucketDir, objRel)
-	body, err := readRootBodyFile(root, bodyRel)
-	if err != nil {
-		return err
-	}
 	sidecar, err := e.readObjectSidecar(root, bodyRel+S3MetaSuffixReserved)
 	if err != nil {
 		return err
 	}
-	return e.emitObject(b, bucketName, objectKey, body, sidecar)
+	chunkSizes, err := e.streamObjectBlobs(b, root, bodyRel, bucketName, objectKey, sidecar.SizeBytes)
+	if err != nil {
+		return err
+	}
+	return e.addObjectManifest(b, bucketName, objectKey, sidecar, chunkSizes)
 }
 
-// readRootBodyFile reads an object body within root with a PRE-open Lstat
-// guard: a symlink / FIFO / device / directory is refused BEFORE root.Open,
-// so a reader-less FIFO planted at an object path cannot block the open
-// (readRootFile's post-open check happens only after the blocking Open).
-// This matches the guard readObjectSidecar / readBucketMeta use.
-func readRootBodyFile(root *os.Root, rel string) ([]byte, error) {
+// openRootRegular opens rel within root with a PRE-open Lstat guard (a
+// symlink / FIFO / device / directory is refused BEFORE root.Open, so a
+// reader-less FIFO planted at an object path cannot block the open) plus a
+// hard-link refusal, returning the open file and its size.
+func openRootRegular(root *os.Root, rel string) (*os.File, int64, error) {
 	linfo, err := root.Lstat(rel)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, 0, errors.WithStack(err)
 	}
 	if !linfo.Mode().IsRegular() {
-		return nil, errors.Wrapf(ErrS3EncodeNotRegular, "%s (mode=%s)", rel, linfo.Mode())
+		return nil, 0, errors.Wrapf(ErrS3EncodeNotRegular, "%s (mode=%s)", rel, linfo.Mode())
 	}
 	if err := refuseHardLink(linfo, rel); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	f, err := root.Open(rel)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, 0, errors.WithStack(err)
 	}
-	defer func() { _ = f.Close() }()
-	body, err := io.ReadAll(f)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	return body, nil
+	return f, linfo.Size(), nil
 }
 
 // readObjectSidecar opens <body>.elastickv-meta.json within root (symlink
@@ -234,19 +229,51 @@ func (e *S3RecordEncoder) readObjectSidecar(root *os.Root, rel string) (s3Public
 	return pub, nil
 }
 
-// emitObject re-chunks the body into blob records and builds the manifest.
-func (e *S3RecordEncoder) emitObject(b *snapshotBuilder, bucketName, objectKey string, body []byte, sidecar s3PublicManifest) error {
-	// The body file IS the object, so its length must match the manifest's
-	// declared size; a mismatch means a corrupt/inconsistent dump and fails
-	// closed rather than restoring an object whose size_bytes lies.
-	if sidecar.SizeBytes != int64(len(body)) {
-		return errors.Wrapf(ErrS3EncodeInvalidManifest,
-			"%s: size_bytes %d != body length %d", objectKey, sidecar.SizeBytes, len(body))
-	}
-	chunkSizes, err := e.addObjectBlobs(b, bucketName, objectKey, body)
+// streamObjectBlobs streams the object body in s3ChunkSize reads, staging
+// each chunk as a !s3|blob| record, and returns the per-chunk byte lengths
+// for the manifest. The body is never fully buffered in RAM (only one
+// chunk at a time), so a multi-GiB object does not blow up the encoder
+// (codex P1 #845). The declared size is validated against the file's
+// stat size before streaming — the body file IS the object, so a mismatch
+// is a corrupt dump and fails closed. A zero-length body yields no chunks.
+func (e *S3RecordEncoder) streamObjectBlobs(b *snapshotBuilder, root *os.Root, bodyRel, bucketName, objectKey string, declaredSize int64) ([]uint64, error) {
+	f, size, err := openRootRegular(root, bodyRel)
 	if err != nil {
-		return err
+		return nil, err
 	}
+	defer func() { _ = f.Close() }()
+	if size != declaredSize {
+		return nil, errors.Wrapf(ErrS3EncodeInvalidManifest,
+			"%s: size_bytes %d != body length %d", objectKey, declaredSize, size)
+	}
+	var sizes []uint64
+	var chunkNo uint64
+	buf := make([]byte, s3ChunkSize)
+	for {
+		n, rerr := io.ReadFull(f, buf)
+		if n > 0 {
+			chunk := buf[:n]
+			key := s3keys.BlobKey(bucketName, s3RestoreGeneration, objectKey, s3RestoreUploadID, s3RestorePartNo, chunkNo)
+			// b.Add copies the value (encodeMVCCValue appends), so reusing
+			// buf across iterations is safe.
+			if err := b.Add(key, chunk, 0); err != nil {
+				return nil, err
+			}
+			sizes = append(sizes, uint64(len(chunk)))
+			chunkNo++
+		}
+		if errors.Is(rerr, io.EOF) || errors.Is(rerr, io.ErrUnexpectedEOF) {
+			return sizes, nil
+		}
+		if rerr != nil {
+			return nil, errors.WithStack(rerr)
+		}
+	}
+}
+
+// addObjectManifest builds the !s3|obj|head| manifest from the sidecar and
+// the staged chunk sizes.
+func (e *S3RecordEncoder) addObjectManifest(b *snapshotBuilder, bucketName, objectKey string, sidecar s3PublicManifest, chunkSizes []uint64) error {
 	live := s3LiveManifest{
 		UploadID:           s3RestoreUploadID,
 		ETag:               sidecar.ETag,
@@ -273,28 +300,6 @@ func (e *S3RecordEncoder) emitObject(b *snapshotBuilder, bucketName, objectKey s
 		return errors.WithStack(err)
 	}
 	return b.Add(s3keys.ObjectManifestKey(bucketName, s3RestoreGeneration, objectKey), val, 0)
-}
-
-// addObjectBlobs splits body into s3ChunkSize chunks, stages each as a
-// !s3|blob| record, and returns the per-chunk byte lengths for the
-// manifest. A zero-length body yields no chunks (and no part).
-func (e *S3RecordEncoder) addObjectBlobs(b *snapshotBuilder, bucketName, objectKey string, body []byte) ([]uint64, error) {
-	var sizes []uint64
-	var chunkNo uint64
-	for start := 0; start < len(body); start += s3ChunkSize {
-		end := start + s3ChunkSize
-		if end > len(body) {
-			end = len(body)
-		}
-		chunk := body[start:end]
-		key := s3keys.BlobKey(bucketName, s3RestoreGeneration, objectKey, s3RestoreUploadID, s3RestorePartNo, chunkNo)
-		if err := b.Add(key, chunk, 0); err != nil {
-			return nil, err
-		}
-		sizes = append(sizes, uint64(len(chunk)))
-		chunkNo++
-	}
-	return sizes, nil
 }
 
 // parseRFC3339NanoAsHLC inverts formatHLCAsRFC3339Nano: it recovers the

--- a/internal/backup/encode_s3_objects.go
+++ b/internal/backup/encode_s3_objects.go
@@ -63,15 +63,47 @@ var ErrS3EncodeUnsupportedCollision = errors.New("backup: s3 encode object-name 
 var ErrS3EncodeInvalidManifest = errors.New("backup: s3 encode invalid object sidecar")
 
 // encodeBucketObjects walks a bucket's object tree and stages each
-// object's manifest + blob records. KEYMAP.jsonl (collision renames)
-// fails closed.
+// object's manifest + blob records.
+//
+// Object-name collisions: the decoder writes a top-level KEYMAP.jsonl
+// recording shorter keys renamed to <key>.elastickv-leaf-data. M4-2a does
+// not reverse those renames, so a collision-tracker KEYMAP.jsonl fails
+// closed. It is distinguished from a legitimate user object named
+// "KEYMAP.jsonl" (which the decoder also emits verbatim) by the absence of
+// a companion .elastickv-meta.json sidecar — the tracker has none. The
+// .elastickv-leaf-data suffix is NOT special-cased: a real object whose
+// key ends in it has a sidecar and round-trips normally, and any actual
+// collision is already gated by the tracker check above (codex P1 #845).
 func (e *S3RecordEncoder) encodeBucketObjects(b *snapshotBuilder, root *os.Root, bucketDir, bucketName string) error {
-	if _, err := root.Lstat(filepath.Join(bucketDir, "KEYMAP.jsonl")); err == nil {
-		return errors.Wrapf(ErrS3EncodeUnsupportedCollision, "%s: KEYMAP.jsonl present", bucketDir)
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return errors.WithStack(err)
+	keymapRel := filepath.Join(bucketDir, "KEYMAP.jsonl")
+	present, err := rootEntryExists(root, keymapRel)
+	if err != nil {
+		return err
+	}
+	if present {
+		hasSidecar, err := rootEntryExists(root, keymapRel+S3MetaSuffixReserved)
+		if err != nil {
+			return err
+		}
+		if !hasSidecar {
+			return errors.Wrapf(ErrS3EncodeUnsupportedCollision,
+				"%s: collision-rename KEYMAP.jsonl present", bucketDir)
+		}
 	}
 	return e.walkObjects(b, root, bucketDir, bucketName, "")
+}
+
+// rootEntryExists reports whether rel exists within root (via Lstat, so it
+// does not follow a final symlink).
+func rootEntryExists(root *os.Root, rel string) (bool, error) {
+	_, err := root.Lstat(rel)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, errors.WithStack(err)
+	}
+	return true, nil
 }
 
 // walkObjects recursively descends bucketDir, treating each non-sidecar
@@ -108,9 +140,12 @@ func (e *S3RecordEncoder) walkObjectEntry(b *snapshotBuilder, root *os.Root, buc
 		return nil
 	case strings.HasSuffix(name, S3MetaSuffixReserved):
 		return nil // sidecar, handled with its body
-	case strings.HasSuffix(name, S3LeafDataSuffix):
-		return errors.Wrapf(ErrS3EncodeUnsupportedCollision, "%s: leaf-data rename", childRel)
 	default:
+		// Any other regular file (including a user object literally named
+		// "KEYMAP.jsonl" or ending in .elastickv-leaf-data) is an object
+		// body; encodeObject reads its sidecar and fails closed if absent.
+		// A sidecar-less collision-tracker KEYMAP.jsonl was already gated
+		// in encodeBucketObjects.
 		return e.encodeObject(b, root, bucketDir, bucketName, childRel)
 	}
 }

--- a/internal/backup/encode_s3_objects.go
+++ b/internal/backup/encode_s3_objects.go
@@ -130,6 +130,12 @@ func (e *S3RecordEncoder) walkObjects(b *snapshotBuilder, root *os.Root, bucketD
 func (e *S3RecordEncoder) walkObjectEntry(b *snapshotBuilder, root *os.Root, bucketDir, bucketName, rel, childRel string, ent os.DirEntry) error {
 	name := ent.Name()
 	if ent.IsDir() {
+		// TODO(M4-2b): _incomplete_uploads/ and _orphans/ are the decoder's
+		// reserved dump dirs and are skipped here, but a user object key
+		// literally prefixed with "_incomplete_uploads/" or "_orphans/"
+		// would also land here and be silently dropped. The robust fix
+		// (distinguishing reserved dumps from user keys, like the
+		// KEYMAP-tracker disambiguation) is deferred to the collision slice.
 		if rel == "" && (name == "_incomplete_uploads" || name == "_orphans") {
 			return nil
 		}
@@ -225,6 +231,13 @@ func (e *S3RecordEncoder) readObjectSidecar(root *os.Root, rel string) (s3Public
 
 // emitObject re-chunks the body into blob records and builds the manifest.
 func (e *S3RecordEncoder) emitObject(b *snapshotBuilder, bucketName, objectKey string, body []byte, sidecar s3PublicManifest) error {
+	// The body file IS the object, so its length must match the manifest's
+	// declared size; a mismatch means a corrupt/inconsistent dump and fails
+	// closed rather than restoring an object whose size_bytes lies.
+	if sidecar.SizeBytes != int64(len(body)) {
+		return errors.Wrapf(ErrS3EncodeInvalidManifest,
+			"%s: size_bytes %d != body length %d", objectKey, sidecar.SizeBytes, len(body))
+	}
 	chunkSizes, err := e.addObjectBlobs(b, bucketName, objectKey, body)
 	if err != nil {
 		return err

--- a/internal/backup/encode_s3_objects.go
+++ b/internal/backup/encode_s3_objects.go
@@ -1,0 +1,235 @@
+package backup
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/bootjp/elastickv/internal/s3keys"
+	"github.com/cockroachdb/errors"
+)
+
+// encode_s3_objects.go is the M4-2 slice of the S3 reverse encoder: object
+// bodies. For each object in the dump it re-chunks the body into
+// !s3|blob| records and rebuilds the !s3|obj|head| manifest from the
+// sidecar — the inverse of the decoder's assembleObjectBody +
+// HandleObjectManifest.
+//
+// Scope of this slice (M4-2a): objects that map to a natural nested path
+// (s3/<bucket>/a/b/c). File-vs-directory collisions (the decoder renames
+// the shorter key to <key>.elastickv-leaf-data and records it in
+// KEYMAP.jsonl) are NOT yet reversed — a dump carrying KEYMAP.jsonl or a
+// .elastickv-leaf-data file fails closed rather than emit a wrong key.
+//
+// Reconstruction choices (Option-B style, consistent with the generation
+// decision; the dump does not carry these):
+//   - uploadID: the decoder drops the manifest's uploadID, so a uniform
+//     s3RestoreUploadID is synthesized. The manifest's uploadID only has
+//     to match its own blob keys' uploadID for assembleObjectBody to find
+//     the chunks (the object key already disambiguates objects), so a
+//     fixed value is sufficient for a single-cluster restore.
+//   - Every object is emitted as a SINGLE re-chunked part (partNo=1,
+//     partVersion=0). Chunk boundaries are not load-bearing — the decoder
+//     concatenates chunks in (partNo, chunkNo) order — so a body that was
+//     originally multipart still reassembles byte-identically, and the
+//     object etag is taken verbatim from the sidecar (no recompute).
+//   - last_modified_hlc is reconstructed from the sidecar's RFC3339
+//     LastModified (physical half only; the logical bits were discarded on
+//     decode). Absent/unparseable timestamps restore as 0.
+
+// s3ChunkSize mirrors adapter/s3.go: object bodies are re-split into
+// 1 MiB blob chunks.
+const s3ChunkSize = 1 << 20
+
+// s3RestorePartNo / s3RestoreUploadID are the synthesized single-part
+// identifiers stamped into every restored object's blob keys and manifest
+// (see file header).
+const (
+	s3RestorePartNo   uint64 = 1
+	s3RestoreUploadID        = "elastickv-restore"
+)
+
+// ErrS3EncodeUnsupportedCollision is returned when the dump carries an
+// object-name collision artifact (KEYMAP.jsonl or a .elastickv-leaf-data
+// file) that this slice does not yet reverse — failing closed avoids
+// emitting a record under the wrong object key.
+var ErrS3EncodeUnsupportedCollision = errors.New("backup: s3 encode object-name collision not yet supported")
+
+// ErrS3EncodeInvalidManifest is returned when an object's
+// .elastickv-meta.json sidecar cannot be parsed.
+var ErrS3EncodeInvalidManifest = errors.New("backup: s3 encode invalid object sidecar")
+
+// encodeBucketObjects walks a bucket's object tree and stages each
+// object's manifest + blob records. KEYMAP.jsonl (collision renames)
+// fails closed.
+func (e *S3RecordEncoder) encodeBucketObjects(b *snapshotBuilder, root *os.Root, bucketDir, bucketName string) error {
+	if _, err := root.Lstat(filepath.Join(bucketDir, "KEYMAP.jsonl")); err == nil {
+		return errors.Wrapf(ErrS3EncodeUnsupportedCollision, "%s: KEYMAP.jsonl present", bucketDir)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return errors.WithStack(err)
+	}
+	return e.walkObjects(b, root, bucketDir, bucketName, "")
+}
+
+// walkObjects recursively descends bucketDir, treating each non-sidecar
+// regular file as an object body whose key is its path relative to
+// bucketDir. The reserved top-level entries (_bucket.json,
+// _incomplete_uploads/, _orphans/) are skipped.
+func (e *S3RecordEncoder) walkObjects(b *snapshotBuilder, root *os.Root, bucketDir, bucketName, rel string) error {
+	entries, err := readRootSubdirEntries(root, filepath.Join(bucketDir, rel))
+	if err != nil {
+		return err
+	}
+	for _, ent := range entries {
+		childRel := filepath.Join(rel, ent.Name())
+		if err := e.walkObjectEntry(b, root, bucketDir, bucketName, rel, childRel, ent); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// walkObjectEntry classifies one directory entry: reserved skips,
+// sidecars, collision artifacts (fail closed), sub-directories (recurse),
+// or an object body.
+func (e *S3RecordEncoder) walkObjectEntry(b *snapshotBuilder, root *os.Root, bucketDir, bucketName, rel, childRel string, ent os.DirEntry) error {
+	name := ent.Name()
+	if ent.IsDir() {
+		if rel == "" && (name == "_incomplete_uploads" || name == "_orphans") {
+			return nil
+		}
+		return e.walkObjects(b, root, bucketDir, bucketName, childRel)
+	}
+	switch {
+	case rel == "" && name == "_bucket.json":
+		return nil
+	case strings.HasSuffix(name, S3MetaSuffixReserved):
+		return nil // sidecar, handled with its body
+	case strings.HasSuffix(name, S3LeafDataSuffix):
+		return errors.Wrapf(ErrS3EncodeUnsupportedCollision, "%s: leaf-data rename", childRel)
+	default:
+		return e.encodeObject(b, root, bucketDir, bucketName, childRel)
+	}
+}
+
+// encodeObject reads one object body + sidecar and stages its blob chunks
+// and manifest. The object key is the body's path relative to bucketDir.
+func (e *S3RecordEncoder) encodeObject(b *snapshotBuilder, root *os.Root, bucketDir, bucketName, objRel string) error {
+	objectKey := filepath.ToSlash(objRel)
+	bodyRel := filepath.Join(bucketDir, objRel)
+	body, err := readRootFile(root, bodyRel)
+	if err != nil {
+		return err
+	}
+	sidecar, err := e.readObjectSidecar(root, bodyRel+S3MetaSuffixReserved)
+	if err != nil {
+		return err
+	}
+	return e.emitObject(b, bucketName, objectKey, body, sidecar)
+}
+
+// readObjectSidecar opens <body>.elastickv-meta.json within root (symlink
+// / FIFO / hard-link safe) and decodes the public manifest projection.
+func (e *S3RecordEncoder) readObjectSidecar(root *os.Root, rel string) (s3PublicManifest, error) {
+	linfo, err := root.Lstat(rel)
+	if err != nil {
+		return s3PublicManifest{}, errors.WithStack(err)
+	}
+	if !linfo.Mode().IsRegular() {
+		return s3PublicManifest{}, errors.Wrapf(ErrS3EncodeNotRegular, "%s (mode=%s)", rel, linfo.Mode())
+	}
+	if err := refuseHardLink(linfo, rel); err != nil {
+		return s3PublicManifest{}, err
+	}
+	f, err := root.Open(rel)
+	if err != nil {
+		return s3PublicManifest{}, errors.WithStack(err)
+	}
+	defer func() { _ = f.Close() }()
+	var pub s3PublicManifest
+	if err := decodeOneJSON(f, &pub); err != nil {
+		return s3PublicManifest{}, errors.Wrapf(ErrS3EncodeInvalidManifest, "%s: %v", rel, err)
+	}
+	if pub.FormatVersion != s3BucketFormatVersion {
+		return s3PublicManifest{}, errors.Wrapf(ErrS3EncodeInvalidManifest,
+			"%s: unsupported format_version %d", rel, pub.FormatVersion)
+	}
+	return pub, nil
+}
+
+// emitObject re-chunks the body into blob records and builds the manifest.
+func (e *S3RecordEncoder) emitObject(b *snapshotBuilder, bucketName, objectKey string, body []byte, sidecar s3PublicManifest) error {
+	chunkSizes, err := e.addObjectBlobs(b, bucketName, objectKey, body)
+	if err != nil {
+		return err
+	}
+	live := s3LiveManifest{
+		UploadID:           s3RestoreUploadID,
+		ETag:               sidecar.ETag,
+		SizeBytes:          sidecar.SizeBytes,
+		LastModifiedHLC:    parseRFC3339NanoAsHLC(sidecar.LastModified),
+		ContentType:        sidecar.ContentType,
+		ContentEncoding:    sidecar.ContentEncoding,
+		CacheControl:       sidecar.CacheControl,
+		ContentDisposition: sidecar.ContentDisposition,
+		UserMetadata:       sidecar.UserMetadata,
+	}
+	if len(chunkSizes) > 0 {
+		live.Parts = []s3LivePart{{
+			PartNo:      s3RestorePartNo,
+			ETag:        sidecar.ETag,
+			SizeBytes:   sidecar.SizeBytes,
+			ChunkCount:  uint64(len(chunkSizes)),
+			ChunkSizes:  chunkSizes,
+			PartVersion: 0,
+		}}
+	}
+	val, err := json.Marshal(live)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return b.Add(s3keys.ObjectManifestKey(bucketName, s3RestoreGeneration, objectKey), val, 0)
+}
+
+// addObjectBlobs splits body into s3ChunkSize chunks, stages each as a
+// !s3|blob| record, and returns the per-chunk byte lengths for the
+// manifest. A zero-length body yields no chunks (and no part).
+func (e *S3RecordEncoder) addObjectBlobs(b *snapshotBuilder, bucketName, objectKey string, body []byte) ([]uint64, error) {
+	var sizes []uint64
+	var chunkNo uint64
+	for start := 0; start < len(body); start += s3ChunkSize {
+		end := start + s3ChunkSize
+		if end > len(body) {
+			end = len(body)
+		}
+		chunk := body[start:end]
+		key := s3keys.BlobKey(bucketName, s3RestoreGeneration, objectKey, s3RestoreUploadID, s3RestorePartNo, chunkNo)
+		if err := b.Add(key, chunk, 0); err != nil {
+			return nil, err
+		}
+		sizes = append(sizes, uint64(len(chunk)))
+		chunkNo++
+	}
+	return sizes, nil
+}
+
+// parseRFC3339NanoAsHLC inverts formatHLCAsRFC3339Nano: it recovers the
+// physical (millisecond) half of the HLC from the sidecar timestamp,
+// shifted into place with zero logical bits. An empty or unparseable
+// value (cosmetic metadata, not load-bearing) yields 0.
+func parseRFC3339NanoAsHLC(s string) uint64 {
+	if s == "" {
+		return 0
+	}
+	t, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		return 0
+	}
+	ms := t.UnixMilli()
+	if ms < 0 {
+		return 0
+	}
+	return uint64(ms) << hlcLogicalBitsForBackupS3
+}

--- a/internal/backup/encode_s3_objects.go
+++ b/internal/backup/encode_s3_objects.go
@@ -58,6 +58,11 @@ const (
 // emitting a record under the wrong object key.
 var ErrS3EncodeUnsupportedCollision = errors.New("backup: s3 encode object-name collision not yet supported")
 
+// s3ManifestFormatVersion is the only object .elastickv-meta.json
+// format_version the encoder accepts (a dedicated manifest constant rather
+// than reusing the bucket one, though both are currently 1).
+const s3ManifestFormatVersion uint32 = 1
+
 // ErrS3EncodeInvalidManifest is returned when an object's
 // .elastickv-meta.json sidecar cannot be parsed.
 var ErrS3EncodeInvalidManifest = errors.New("backup: s3 encode invalid object sidecar")
@@ -222,7 +227,7 @@ func (e *S3RecordEncoder) readObjectSidecar(root *os.Root, rel string) (s3Public
 	if err := decodeOneJSON(f, &pub); err != nil {
 		return s3PublicManifest{}, errors.Wrapf(ErrS3EncodeInvalidManifest, "%s: %v", rel, err)
 	}
-	if pub.FormatVersion != s3BucketFormatVersion {
+	if pub.FormatVersion != s3ManifestFormatVersion {
 		return s3PublicManifest{}, errors.Wrapf(ErrS3EncodeInvalidManifest,
 			"%s: unsupported format_version %d", rel, pub.FormatVersion)
 	}

--- a/internal/backup/encode_s3_objects.go
+++ b/internal/backup/encode_s3_objects.go
@@ -80,22 +80,40 @@ var ErrS3EncodeInvalidManifest = errors.New("backup: s3 encode invalid object si
 // key ends in it has a sidecar and round-trips normally, and any actual
 // collision is already gated by the tracker check above (codex P1 #845).
 func (e *S3RecordEncoder) encodeBucketObjects(b *snapshotBuilder, root *os.Root, bucketDir, bucketName string) error {
-	keymapRel := filepath.Join(bucketDir, "KEYMAP.jsonl")
-	present, err := rootEntryExists(root, keymapRel)
+	tracker, err := e.isKeymapCollisionTracker(root, bucketDir)
 	if err != nil {
 		return err
 	}
-	if present {
-		hasSidecar, err := rootEntryExists(root, keymapRel+S3MetaSuffixReserved)
-		if err != nil {
-			return err
-		}
-		if !hasSidecar {
-			return errors.Wrapf(ErrS3EncodeUnsupportedCollision,
-				"%s: collision-rename KEYMAP.jsonl present", bucketDir)
-		}
+	if tracker {
+		return errors.Wrapf(ErrS3EncodeUnsupportedCollision,
+			"%s: collision-rename KEYMAP.jsonl present", bucketDir)
 	}
 	return e.walkObjects(b, root, bucketDir, bucketName, "")
+}
+
+// isKeymapCollisionTracker reports whether the bucket's top-level
+// KEYMAP.jsonl is the decoder's collision-rename tracker. The tracker is a
+// regular FILE with no companion sidecar. It is NOT:
+//   - a user object literally named KEYMAP.jsonl (which has a sidecar), or
+//   - a directory holding objects under the "KEYMAP.jsonl/" key prefix
+//     (a directory, not a file).
+func (e *S3RecordEncoder) isKeymapCollisionTracker(root *os.Root, bucketDir string) (bool, error) {
+	keymapRel := filepath.Join(bucketDir, "KEYMAP.jsonl")
+	linfo, err := root.Lstat(keymapRel)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, errors.WithStack(err)
+	}
+	if !linfo.Mode().IsRegular() {
+		return false, nil // a directory (KEYMAP.jsonl/ key prefix) or other
+	}
+	hasSidecar, err := rootEntryExists(root, keymapRel+S3MetaSuffixReserved)
+	if err != nil {
+		return false, err
+	}
+	return !hasSidecar, nil
 }
 
 // rootEntryExists reports whether rel exists within root (via Lstat, so it

--- a/internal/backup/encode_s3_objects.go
+++ b/internal/backup/encode_s3_objects.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -119,7 +120,7 @@ func (e *S3RecordEncoder) walkObjectEntry(b *snapshotBuilder, root *os.Root, buc
 func (e *S3RecordEncoder) encodeObject(b *snapshotBuilder, root *os.Root, bucketDir, bucketName, objRel string) error {
 	objectKey := filepath.ToSlash(objRel)
 	bodyRel := filepath.Join(bucketDir, objRel)
-	body, err := readRootFile(root, bodyRel)
+	body, err := readRootBodyFile(root, bodyRel)
 	if err != nil {
 		return err
 	}
@@ -128,6 +129,34 @@ func (e *S3RecordEncoder) encodeObject(b *snapshotBuilder, root *os.Root, bucket
 		return err
 	}
 	return e.emitObject(b, bucketName, objectKey, body, sidecar)
+}
+
+// readRootBodyFile reads an object body within root with a PRE-open Lstat
+// guard: a symlink / FIFO / device / directory is refused BEFORE root.Open,
+// so a reader-less FIFO planted at an object path cannot block the open
+// (readRootFile's post-open check happens only after the blocking Open).
+// This matches the guard readObjectSidecar / readBucketMeta use.
+func readRootBodyFile(root *os.Root, rel string) ([]byte, error) {
+	linfo, err := root.Lstat(rel)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if !linfo.Mode().IsRegular() {
+		return nil, errors.Wrapf(ErrS3EncodeNotRegular, "%s (mode=%s)", rel, linfo.Mode())
+	}
+	if err := refuseHardLink(linfo, rel); err != nil {
+		return nil, err
+	}
+	f, err := root.Open(rel)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer func() { _ = f.Close() }()
+	body, err := io.ReadAll(f)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return body, nil
 }
 
 // readObjectSidecar opens <body>.elastickv-meta.json within root (symlink

--- a/internal/backup/encode_s3_objects_test.go
+++ b/internal/backup/encode_s3_objects_test.go
@@ -162,9 +162,10 @@ func TestReadRootBodyFileRejectsNonRegular(t *testing.T) {
 	}
 }
 
-// TestS3EncodeRejectsKeymapCollision pins fail-closed when a bucket
-// carries a KEYMAP.jsonl (object-name collision renames not yet reversed).
-func TestS3EncodeRejectsKeymapCollision(t *testing.T) {
+// TestS3EncodeRejectsKeymapCollisionTracker pins fail-closed when a bucket
+// carries a collision-tracker KEYMAP.jsonl — identified by the ABSENCE of
+// a companion .elastickv-meta.json sidecar (M4-2a does not reverse renames).
+func TestS3EncodeRejectsKeymapCollisionTracker(t *testing.T) {
 	t.Parallel()
 	in := t.TempDir()
 	const bucket = "b"
@@ -179,19 +180,37 @@ func TestS3EncodeRejectsKeymapCollision(t *testing.T) {
 	}
 }
 
-// TestS3EncodeRejectsLeafDataCollision pins fail-closed on a
-// .elastickv-leaf-data renamed object.
-func TestS3EncodeRejectsLeafDataCollision(t *testing.T) {
+// TestS3EncodeKeymapObjectRoundTrip pins that a legitimate user object
+// named "KEYMAP.jsonl" (one with a companion sidecar) round-trips, rather
+// than being mistaken for the collision tracker (codex P1 #845).
+func TestS3EncodeKeymapObjectRoundTrip(t *testing.T) {
 	t.Parallel()
 	in := t.TempDir()
-	const bucket = "b"
-	writeS3Bucket(t, in, bucket, []byte(`{"format_version":1,"name":"b"}`))
-	leaf := filepath.Join(in, "s3", EncodeSegment([]byte(bucket)), "obj"+S3LeafDataSuffix)
-	if err := os.WriteFile(leaf, []byte("x"), 0o600); err != nil {
-		t.Fatalf("write leaf-data: %v", err)
+	const bucket = "obj-keymap"
+	writeS3Bucket(t, in, bucket, []byte(`{"format_version":1,"name":"obj-keymap"}`))
+	body := []byte("user keymap object")
+	writeS3Object(t, in, bucket, "KEYMAP.jsonl", body, s3ObjectSidecar("e", int64(len(body)), "application/json", ""))
+
+	gotBody, _ := decodeS3Object(t, encodeS3Tree(t, in), bucket, "KEYMAP.jsonl")
+	if !bytes.Equal(gotBody, body) {
+		t.Fatalf("KEYMAP.jsonl object body = %q, want %q", gotBody, body)
 	}
-	b := newSnapshotBuilder(s3EncTS)
-	if err := NewS3RecordEncoder(in).Encode(b); !errors.Is(err, ErrS3EncodeUnsupportedCollision) {
-		t.Fatalf("Encode err = %v, want ErrS3EncodeUnsupportedCollision", err)
+}
+
+// TestS3EncodeLeafDataObjectRoundTrip pins that a legitimate object key
+// ending in .elastickv-leaf-data (with a sidecar, no collision) round-trips
+// rather than being rejected as a rename artifact (codex P1 #845).
+func TestS3EncodeLeafDataObjectRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const bucket = "obj-leaf"
+	writeS3Bucket(t, in, bucket, []byte(`{"format_version":1,"name":"obj-leaf"}`))
+	body := []byte("leaf-data named object")
+	objKey := "foo" + S3LeafDataSuffix
+	writeS3Object(t, in, bucket, objKey, body, s3ObjectSidecar("e", int64(len(body)), "application/octet-stream", ""))
+
+	gotBody, _ := decodeS3Object(t, encodeS3Tree(t, in), bucket, objKey)
+	if !bytes.Equal(gotBody, body) {
+		t.Fatalf("leaf-data-named object body = %q, want %q", gotBody, body)
 	}
 }

--- a/internal/backup/encode_s3_objects_test.go
+++ b/internal/backup/encode_s3_objects_test.go
@@ -143,10 +143,10 @@ func TestS3EncodeNestedObjectKeyRoundTrip(t *testing.T) {
 }
 
 // TestReadRootBodyFileRejectsNonRegular pins the PRE-open guard on the
-// object body read: a non-regular target (directory stand-in for a
+// object body open: a non-regular target (directory stand-in for a
 // symlink/FIFO) is refused before the open, so a planted FIFO cannot block
 // the encoder (gemini security-high on PR #845).
-func TestReadRootBodyFileRejectsNonRegular(t *testing.T) {
+func TestOpenRootRegularRejectsNonRegular(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	if err := os.Mkdir(filepath.Join(dir, "body"), 0o755); err != nil {
@@ -157,8 +157,8 @@ func TestReadRootBodyFileRejectsNonRegular(t *testing.T) {
 		t.Fatalf("OpenRoot: %v", err)
 	}
 	defer func() { _ = root.Close() }()
-	if _, err := readRootBodyFile(root, "body"); !errors.Is(err, ErrS3EncodeNotRegular) {
-		t.Fatalf("readRootBodyFile err = %v, want ErrS3EncodeNotRegular", err)
+	if _, _, err := openRootRegular(root, "body"); !errors.Is(err, ErrS3EncodeNotRegular) {
+		t.Fatalf("openRootRegular err = %v, want ErrS3EncodeNotRegular", err)
 	}
 }
 

--- a/internal/backup/encode_s3_objects_test.go
+++ b/internal/backup/encode_s3_objects_test.go
@@ -1,0 +1,177 @@
+package backup
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+)
+
+// writeS3Object writes an object body + its .elastickv-meta.json sidecar
+// under <root>/s3/<EncodeSegment(bucket)>/<objKey path>.
+func writeS3Object(t *testing.T, root, bucket, objKey string, body, sidecar []byte) {
+	t.Helper()
+	base := filepath.Join(root, "s3", EncodeSegment([]byte(bucket)), filepath.FromSlash(objKey))
+	if err := os.MkdirAll(filepath.Dir(base), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(base, body, 0o600); err != nil {
+		t.Fatalf("WriteFile body: %v", err)
+	}
+	if err := os.WriteFile(base+S3MetaSuffixReserved, sidecar, 0o600); err != nil {
+		t.Fatalf("WriteFile sidecar: %v", err)
+	}
+}
+
+// decodeS3Object decodes fsm bytes and returns the reassembled body and
+// parsed sidecar for one object.
+func decodeS3Object(t *testing.T, fsm []byte, bucket, objKey string) ([]byte, s3PublicManifest) {
+	t.Helper()
+	out := t.TempDir()
+	if _, err := DecodeSnapshot(bytes.NewReader(fsm), DecodeOptions{
+		OutRoot:  out,
+		Adapters: AdapterSet{S3: true},
+	}); err != nil {
+		t.Fatalf("DecodeSnapshot: %v", err)
+	}
+	base := filepath.Join(out, "s3", EncodeSegment([]byte(bucket)), filepath.FromSlash(objKey))
+	body, err := os.ReadFile(base)
+	if err != nil {
+		t.Fatalf("read decoded body %q: %v", objKey, err)
+	}
+	scData, err := os.ReadFile(base + S3MetaSuffixReserved)
+	if err != nil {
+		t.Fatalf("read decoded sidecar: %v", err)
+	}
+	var sc s3PublicManifest
+	if err := json.Unmarshal(scData, &sc); err != nil {
+		t.Fatalf("unmarshal decoded sidecar: %v", err)
+	}
+	return body, sc
+}
+
+func s3ObjectSidecar(etag string, size int64, contentType, lastModified string) []byte {
+	m := s3PublicManifest{
+		FormatVersion: 1,
+		ETag:          etag,
+		SizeBytes:     size,
+		ContentType:   contentType,
+		LastModified:  lastModified,
+	}
+	out, _ := json.Marshal(m)
+	return out
+}
+
+// TestS3EncodeObjectRoundTrip runs the gold-standard round-trip for a
+// small single-chunk object: body + sidecar survive encode -> real decode.
+func TestS3EncodeObjectRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const bucket = "obj-rt"
+	writeS3Bucket(t, in, bucket, []byte(`{"format_version":1,"name":"obj-rt"}`))
+	body := []byte("hello world")
+	writeS3Object(t, in, bucket, "greeting.txt", body,
+		s3ObjectSidecar("etag-1", int64(len(body)), "text/plain", "2024-01-02T03:04:05Z"))
+
+	gotBody, gotSC := decodeS3Object(t, encodeS3Tree(t, in), bucket, "greeting.txt")
+	if !bytes.Equal(gotBody, body) {
+		t.Fatalf("body = %q, want %q", gotBody, body)
+	}
+	if gotSC.ETag != "etag-1" || gotSC.SizeBytes != int64(len(body)) || gotSC.ContentType != "text/plain" {
+		t.Fatalf("sidecar = %+v", gotSC)
+	}
+	if gotSC.LastModified != "2024-01-02T03:04:05Z" {
+		t.Fatalf("last_modified = %q, want round-tripped 2024-01-02T03:04:05Z", gotSC.LastModified)
+	}
+}
+
+// TestS3EncodeObjectMultiChunkRoundTrip pins blob re-chunking: a body
+// larger than s3ChunkSize is split into multiple !s3|blob| records and
+// reassembled byte-identically by the decoder.
+func TestS3EncodeObjectMultiChunkRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const bucket = "obj-mc"
+	writeS3Bucket(t, in, bucket, []byte(`{"format_version":1,"name":"obj-mc"}`))
+	// 2.5 chunks worth, with a position-dependent pattern so a mis-ordered
+	// or dropped chunk is detected.
+	body := make([]byte, s3ChunkSize*2+512)
+	for i := range body {
+		body[i] = byte(i % 251)
+	}
+	writeS3Object(t, in, bucket, "big.bin", body,
+		s3ObjectSidecar("etag-big", int64(len(body)), "application/octet-stream", ""))
+
+	gotBody, _ := decodeS3Object(t, encodeS3Tree(t, in), bucket, "big.bin")
+	if !bytes.Equal(gotBody, body) {
+		t.Fatalf("multi-chunk body mismatch: got %d bytes, want %d", len(gotBody), len(body))
+	}
+}
+
+// TestS3EncodeEmptyObjectRoundTrip pins the zero-byte object (no blobs, no
+// part) round-trip.
+func TestS3EncodeEmptyObjectRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const bucket = "obj-empty"
+	writeS3Bucket(t, in, bucket, []byte(`{"format_version":1,"name":"obj-empty"}`))
+	writeS3Object(t, in, bucket, "empty", []byte{}, s3ObjectSidecar("etag-0", 0, "", ""))
+
+	gotBody, _ := decodeS3Object(t, encodeS3Tree(t, in), bucket, "empty")
+	if len(gotBody) != 0 {
+		t.Fatalf("empty object body = %d bytes, want 0", len(gotBody))
+	}
+}
+
+// TestS3EncodeNestedObjectKeyRoundTrip pins that an object key with "/"
+// (stored as a nested path) round-trips with its slash-separated key.
+func TestS3EncodeNestedObjectKeyRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const bucket = "obj-nested"
+	writeS3Bucket(t, in, bucket, []byte(`{"format_version":1,"name":"obj-nested"}`))
+	body := []byte("nested body")
+	writeS3Object(t, in, bucket, "a/b/c.txt", body, s3ObjectSidecar("e", int64(len(body)), "text/plain", ""))
+
+	gotBody, _ := decodeS3Object(t, encodeS3Tree(t, in), bucket, "a/b/c.txt")
+	if !bytes.Equal(gotBody, body) {
+		t.Fatalf("nested object body = %q, want %q", gotBody, body)
+	}
+}
+
+// TestS3EncodeRejectsKeymapCollision pins fail-closed when a bucket
+// carries a KEYMAP.jsonl (object-name collision renames not yet reversed).
+func TestS3EncodeRejectsKeymapCollision(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const bucket = "b"
+	writeS3Bucket(t, in, bucket, []byte(`{"format_version":1,"name":"b"}`))
+	km := filepath.Join(in, "s3", EncodeSegment([]byte(bucket)), "KEYMAP.jsonl")
+	if err := os.WriteFile(km, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write KEYMAP: %v", err)
+	}
+	b := newSnapshotBuilder(s3EncTS)
+	if err := NewS3RecordEncoder(in).Encode(b); !errors.Is(err, ErrS3EncodeUnsupportedCollision) {
+		t.Fatalf("Encode err = %v, want ErrS3EncodeUnsupportedCollision", err)
+	}
+}
+
+// TestS3EncodeRejectsLeafDataCollision pins fail-closed on a
+// .elastickv-leaf-data renamed object.
+func TestS3EncodeRejectsLeafDataCollision(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const bucket = "b"
+	writeS3Bucket(t, in, bucket, []byte(`{"format_version":1,"name":"b"}`))
+	leaf := filepath.Join(in, "s3", EncodeSegment([]byte(bucket)), "obj"+S3LeafDataSuffix)
+	if err := os.WriteFile(leaf, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write leaf-data: %v", err)
+	}
+	b := newSnapshotBuilder(s3EncTS)
+	if err := NewS3RecordEncoder(in).Encode(b); !errors.Is(err, ErrS3EncodeUnsupportedCollision) {
+		t.Fatalf("Encode err = %v, want ErrS3EncodeUnsupportedCollision", err)
+	}
+}

--- a/internal/backup/encode_s3_objects_test.go
+++ b/internal/backup/encode_s3_objects_test.go
@@ -162,6 +162,64 @@ func TestReadRootBodyFileRejectsNonRegular(t *testing.T) {
 	}
 }
 
+// TestS3EncodeRejectsSizeMismatch pins fail-closed when the sidecar's
+// size_bytes disagrees with the actual object body length (corrupt dump).
+func TestS3EncodeRejectsSizeMismatch(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const bucket = "b"
+	writeS3Bucket(t, in, bucket, []byte(`{"format_version":1,"name":"b"}`))
+	writeS3Object(t, in, bucket, "obj", []byte("hello"), s3ObjectSidecar("e", 999, "text/plain", ""))
+	b := newSnapshotBuilder(s3EncTS)
+	if err := NewS3RecordEncoder(in).Encode(b); !errors.Is(err, ErrS3EncodeInvalidManifest) {
+		t.Fatalf("Encode err = %v, want ErrS3EncodeInvalidManifest", err)
+	}
+}
+
+// TestReadObjectSidecarRejectsNonRegular pins the pre-open guard on the
+// sidecar read.
+func TestReadObjectSidecarRejectsNonRegular(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "sc"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatalf("OpenRoot: %v", err)
+	}
+	defer func() { _ = root.Close() }()
+	e := NewS3RecordEncoder(dir)
+	if _, err := e.readObjectSidecar(root, "sc"); !errors.Is(err, ErrS3EncodeNotRegular) {
+		t.Fatalf("readObjectSidecar err = %v, want ErrS3EncodeNotRegular", err)
+	}
+}
+
+// TestParseRFC3339NanoAsHLC pins the three silent-zero paths and the
+// sub-millisecond precision loss of the HLC reconstruction.
+func TestParseRFC3339NanoAsHLC(t *testing.T) {
+	t.Parallel()
+	if got := parseRFC3339NanoAsHLC(""); got != 0 {
+		t.Fatalf("empty = %d, want 0", got)
+	}
+	if got := parseRFC3339NanoAsHLC("not-a-time"); got != 0 {
+		t.Fatalf("invalid = %d, want 0", got)
+	}
+	if got := parseRFC3339NanoAsHLC("1969-12-31T23:59:59Z"); got != 0 {
+		t.Fatalf("pre-epoch = %d, want 0", got)
+	}
+	if got := parseRFC3339NanoAsHLC("2024-01-02T03:04:05Z"); got == 0 {
+		t.Fatalf("happy path = 0, want non-zero")
+	}
+	// Sub-millisecond precision is lost (truncated to ms), so the nanosecond
+	// form encodes identically to the millisecond form.
+	withNanos := parseRFC3339NanoAsHLC("2024-01-02T03:04:05.000000001Z")
+	withoutNanos := parseRFC3339NanoAsHLC("2024-01-02T03:04:05Z")
+	if withNanos != withoutNanos {
+		t.Fatalf("sub-ms precision not truncated: %d != %d", withNanos, withoutNanos)
+	}
+}
+
 // TestS3EncodeRejectsKeymapCollisionTracker pins fail-closed when a bucket
 // carries a collision-tracker KEYMAP.jsonl — identified by the ABSENCE of
 // a companion .elastickv-meta.json sidecar (M4-2a does not reverse renames).

--- a/internal/backup/encode_s3_objects_test.go
+++ b/internal/backup/encode_s3_objects_test.go
@@ -142,6 +142,26 @@ func TestS3EncodeNestedObjectKeyRoundTrip(t *testing.T) {
 	}
 }
 
+// TestReadRootBodyFileRejectsNonRegular pins the PRE-open guard on the
+// object body read: a non-regular target (directory stand-in for a
+// symlink/FIFO) is refused before the open, so a planted FIFO cannot block
+// the encoder (gemini security-high on PR #845).
+func TestReadRootBodyFileRejectsNonRegular(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "body"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatalf("OpenRoot: %v", err)
+	}
+	defer func() { _ = root.Close() }()
+	if _, err := readRootBodyFile(root, "body"); !errors.Is(err, ErrS3EncodeNotRegular) {
+		t.Fatalf("readRootBodyFile err = %v, want ErrS3EncodeNotRegular", err)
+	}
+}
+
 // TestS3EncodeRejectsKeymapCollision pins fail-closed when a bucket
 // carries a KEYMAP.jsonl (object-name collision renames not yet reversed).
 func TestS3EncodeRejectsKeymapCollision(t *testing.T) {

--- a/internal/backup/encode_s3_objects_test.go
+++ b/internal/backup/encode_s3_objects_test.go
@@ -220,6 +220,24 @@ func TestParseRFC3339NanoAsHLC(t *testing.T) {
 	}
 }
 
+// TestS3EncodeKeymapDirPrefixObjectRoundTrip pins that object keys under a
+// "KEYMAP.jsonl/" prefix (where KEYMAP.jsonl is a directory, not the
+// collision-tracker file) round-trip rather than being mistaken for the
+// tracker (codex P1 #845).
+func TestS3EncodeKeymapDirPrefixObjectRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const bucket = "obj-kmdir"
+	writeS3Bucket(t, in, bucket, []byte(`{"format_version":1,"name":"obj-kmdir"}`))
+	body := []byte("under keymap dir")
+	writeS3Object(t, in, bucket, "KEYMAP.jsonl/foo", body, s3ObjectSidecar("e", int64(len(body)), "text/plain", ""))
+
+	gotBody, _ := decodeS3Object(t, encodeS3Tree(t, in), bucket, "KEYMAP.jsonl/foo")
+	if !bytes.Equal(gotBody, body) {
+		t.Fatalf("object under KEYMAP.jsonl/ prefix body = %q, want %q", gotBody, body)
+	}
+}
+
 // TestS3EncodeRejectsKeymapCollisionTracker pins fail-closed when a bucket
 // carries a collision-tracker KEYMAP.jsonl — identified by the ABSENCE of
 // a companion .elastickv-meta.json sidecar (M4-2a does not reverse renames).

--- a/internal/backup/encode_s3_test.go
+++ b/internal/backup/encode_s3_test.go
@@ -111,6 +111,20 @@ func findEntry(entries []RoundTripEntry, key []byte) *RoundTripEntry {
 	return nil
 }
 
+// TestS3EncodeRejectsUnknownFormatVersion pins the format gate: a
+// _bucket.json with an unsupported format_version fails closed rather than
+// being silently parsed under the v1 schema (claude Finding 1 on PR #842;
+// mirrors the DynamoDB schema reader's format_version gate).
+func TestS3EncodeRejectsUnknownFormatVersion(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	writeS3Bucket(t, in, "b", []byte(`{"format_version":99,"name":"b"}`))
+	b := newSnapshotBuilder(s3EncTS)
+	if err := NewS3RecordEncoder(in).Encode(b); !errors.Is(err, ErrS3EncodeInvalidBucket) {
+		t.Fatalf("Encode err = %v, want ErrS3EncodeInvalidBucket", err)
+	}
+}
+
 // TestS3EncodeMissingDirIsNoop pins that an absent s3/ dir is a no-op.
 func TestS3EncodeMissingDirIsNoop(t *testing.T) {
 	t.Parallel()

--- a/internal/backup/encode_s3_test.go
+++ b/internal/backup/encode_s3_test.go
@@ -113,8 +113,8 @@ func findEntry(entries []RoundTripEntry, key []byte) *RoundTripEntry {
 
 // TestS3EncodeRejectsUnknownFormatVersion pins the format gate: a
 // _bucket.json with an unsupported format_version fails closed rather than
-// being silently parsed under the v1 schema (claude Finding 1 on PR #842;
-// mirrors the DynamoDB schema reader's format_version gate).
+// being silently parsed under the v1 schema — mirrors the DynamoDB schema
+// reader's format_version gate.
 func TestS3EncodeRejectsUnknownFormatVersion(t *testing.T) {
 	t.Parallel()
 	in := t.TempDir()

--- a/internal/backup/encode_s3_test.go
+++ b/internal/backup/encode_s3_test.go
@@ -1,0 +1,138 @@
+package backup
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/s3keys"
+	"github.com/cockroachdb/errors"
+)
+
+const s3EncTS uint64 = 0x0001_8F1A_2B3C_00CD
+
+// writeS3Bucket writes a _bucket.json under <root>/s3/<EncodeSegment(name)>/.
+func writeS3Bucket(t *testing.T, root, name string, body []byte) {
+	t.Helper()
+	path := filepath.Join(root, "s3", EncodeSegment([]byte(name)), "_bucket.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+// encodeS3Tree runs the S3 reverse encoder over inRoot and returns the
+// EKVPBBL1 bytes.
+func encodeS3Tree(t *testing.T, inRoot string) []byte {
+	t.Helper()
+	b := newSnapshotBuilder(s3EncTS)
+	if err := NewS3RecordEncoder(inRoot).Encode(b); err != nil {
+		t.Fatalf("S3RecordEncoder.Encode: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := b.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// TestS3EncodeBucketMetaRoundTrip runs the gold-standard directory
+// round-trip: a _bucket.json is reconstructed into the !s3|bucket|meta|
+// record and recovered by the real decoder into an equivalent _bucket.json.
+func TestS3EncodeBucketMetaRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const bucket = "mybucket"
+	input := []byte(`{"format_version":1,"name":"mybucket","owner":"acct-1","region":"us-east-1","acl":"private"}`)
+	writeS3Bucket(t, in, bucket, input)
+
+	out := t.TempDir()
+	if _, err := DecodeSnapshot(bytes.NewReader(encodeS3Tree(t, in)), DecodeOptions{
+		OutRoot:  out,
+		Adapters: AdapterSet{S3: true},
+	}); err != nil {
+		t.Fatalf("DecodeSnapshot: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(out, "s3", EncodeSegment([]byte(bucket)), "_bucket.json"))
+	if err != nil {
+		t.Fatalf("read decoded _bucket.json: %v", err)
+	}
+	var got s3PublicBucket
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal decoded bucket: %v", err)
+	}
+	if got.Name != bucket || got.Owner != "acct-1" || got.Region != "us-east-1" || got.ACL != "private" {
+		t.Fatalf("round-tripped bucket = %+v", got)
+	}
+}
+
+// TestS3EncodeBucketRecordsLayout pins the emitted record bytes: the
+// !s3|bucket|meta| value is JSON with generation = s3RestoreGeneration,
+// and the !s3|bucket|gen| counter is the 8-byte big-endian generation.
+func TestS3EncodeBucketRecordsLayout(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const bucket = "b1"
+	writeS3Bucket(t, in, bucket, []byte(`{"format_version":1,"name":"b1","owner":"o","region":"r","acl":"private"}`))
+
+	entries, _, err := DecodeLiveEntries(bytes.NewReader(encodeS3Tree(t, in)))
+	if err != nil {
+		t.Fatalf("DecodeLiveEntries: %v", err)
+	}
+	meta := findEntry(entries, s3keys.BucketMetaKey(bucket))
+	gen := findEntry(entries, s3keys.BucketGenerationKey(bucket))
+	if meta == nil || gen == nil {
+		t.Fatalf("missing records: meta=%v gen=%v", meta != nil, gen != nil)
+	}
+	var live s3LiveBucketMeta
+	if err := json.Unmarshal(meta.UserValue, &live); err != nil {
+		t.Fatalf("unmarshal meta value: %v", err)
+	}
+	if live.BucketName != bucket || live.Generation != s3RestoreGeneration {
+		t.Fatalf("meta value = %+v, want name=%s gen=%d", live, bucket, s3RestoreGeneration)
+	}
+	if len(gen.UserValue) != 8 || binary.BigEndian.Uint64(gen.UserValue) != s3RestoreGeneration {
+		t.Fatalf("gen counter = %x, want 8-byte BE %d", gen.UserValue, s3RestoreGeneration)
+	}
+}
+
+// findEntry returns the first live entry with the given user key, or nil.
+func findEntry(entries []RoundTripEntry, key []byte) *RoundTripEntry {
+	for i := range entries {
+		if bytes.Equal(entries[i].UserKey, key) {
+			return &entries[i]
+		}
+	}
+	return nil
+}
+
+// TestS3EncodeMissingDirIsNoop pins that an absent s3/ dir is a no-op.
+func TestS3EncodeMissingDirIsNoop(t *testing.T) {
+	t.Parallel()
+	b := newSnapshotBuilder(s3EncTS)
+	if err := NewS3RecordEncoder(t.TempDir()).Encode(b); err != nil {
+		t.Fatalf("Encode on empty tree: %v", err)
+	}
+	if b.Len() != 0 {
+		t.Fatalf("entries = %d, want 0", b.Len())
+	}
+}
+
+// TestS3EncodeRejectsNonRegularBucketMeta pins the pre-open guard: a
+// _bucket.json that is a directory is refused with ErrS3EncodeNotRegular.
+func TestS3EncodeRejectsNonRegularBucketMeta(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(in, "s3", "b", "_bucket.json"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	b := newSnapshotBuilder(s3EncTS)
+	if err := NewS3RecordEncoder(in).Encode(b); !errors.Is(err, ErrS3EncodeNotRegular) {
+		t.Fatalf("Encode err = %v, want ErrS3EncodeNotRegular", err)
+	}
+}


### PR DESCRIPTION
## Summary

**Phase 0b M4-1 — S3 bucket-meta reverse encoder.** First slice of the S3 reverse encoder (M4): bucket **metadata**. Reconstructs the `!s3|bucket|meta|` record (JSON `s3LiveBucketMeta`) and the `!s3|bucket|gen|` generation counter (8-byte big-endian, reproducing `encodeS3Generation`) from each bucket's `_bucket.json`. Object bodies (re-chunked into `!s3|blob|` + `!s3|obj|head|` manifests) and multipart uploads land in follow-up slices (M4-2, M4-3).

Design: `docs/design/2026_05_25_proposed_snapshot_logical_encoder.md` §"S3". Targets `main` (independent of the DynamoDB M3 work).

**Two commits** (design-doc-first):
1. **Doc reconciliation** — the design said "Option A chosen" for generation counters, but M3 (DynamoDB) shipped **Option B** (uniform `ddbRestoreGeneration = 1`). Reconciled: Option B is the implemented cross-adapter decision (M4 uses `s3RestoreGeneration = 1`); Option A retained as the exact-fidelity upgrade path. **Decided with the maintainer.**
2. **Implementation** — `encode_s3.go`.

### Details
- `S3RecordEncoder` walks `s3/<bucket>/` via `os.Root` and reads each `_bucket.json` through the same `Lstat` + `IsRegular` + `refuseHardLink` + `decodeOneJSON` guards the DynamoDB schema reader uses. Bucket name comes from the JSON's authoritative `Name`; keys built with the reused `s3keys.BucketMetaKey` / `BucketGenerationKey`.
- Generation: uniform `s3RestoreGeneration` (Option B). `created_at_hlc` is not represented in the dump and restores as `0` (documented lossy field).
- Named `S3RecordEncoder` to avoid colliding with the decoder's `S3Encoder` in `s3.go`.

## Risk
New code only + a design-doc edit. No existing behavior changed. Offline-tool boundary preserved (key/value formats reproduced; only the in-package `s3keys` constructors are reused).

## Self-review (5 lenses)
- **Data loss**: round-trip via the **real** `DecodeSnapshot` confirms bucket fidelity; fail-closed on non-regular file / empty name / bad JSON.
- **Concurrency/distributed**: single-goroutine, one builder.
- **Performance**: streams each `_bucket.json`.
- **Consistency**: key/value reproduced against the live store (`s3keys` constructors, JSON `s3LiveBucketMeta`, 8-byte BE gen); generation uniform per Option B; decoder ignores the gen counter (operational), so it's emitted for loadability only.
- **Test coverage**: directory round-trip; record-layout assertion (meta JSON `generation=1`, gen counter 8-byte BE 1); missing-dir no-op; non-regular `_bucket.json` fail-closed.

## Test plan
- [x] `go test ./internal/backup/` (full package)
- [x] `golangci-lint run internal/backup/` (0 issues)
- [ ] Follow-up: M4-2 object bodies + blob re-chunking + manifest; M4-3 multipart uploads.
