### PR TITLE
docs(encryption): Stage 7a-2 proposed - storage-layer registration enforcement

### DIFF
--- a/docs/design/2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md
+++ b/docs/design/2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md
@@ -1,0 +1,160 @@
+# Stage 7a-2 — storage-layer registration enforcement (complete write-path coverage)
+
+| Field | Value |
+|---|---|
+| Status | proposed |
+| Date | 2026-05-26 |
+| Parent designs | [`2026_04_29_partial_data_at_rest_encryption.md`](2026_04_29_partial_data_at_rest_encryption.md) (§4.1 writer registry), [`2026_05_26_proposed_7a_process_start_registration.md`](2026_05_26_proposed_7a_process_start_registration.md) (7a coordinator-layer gate) |
+| Builds on | 7a (coordinator-layer first-write barrier), 6D-6c-1 (`encryption.StateCache`) |
+
+## 0. Why this slice exists
+
+7a's coordinator-layer barrier (`ShardedCoordinator.Dispatch` +
+`leaseRefreshingTxn.Commit`) gates the client-write and lock-resolution
+paths. But codex P1 #3 on PR #839 showed it is **structurally
+incomplete**: internal callers that write to the store **directly**
+bypass the coordinator entirely. The confirmed case:
+
+```
+distribution.CatalogStore.Save → applySaveMutations
+  → store.ApplyMutations(...)        // the DIRECT, non-Raft local commit path
+    → encryptForKey → nonceFactory.Next()
+```
+
+`store.ApplyMutations` is the direct local-write path (catalog
+bootstrap, admin snapshots, migrations); it is **not** the Raft FSM
+apply path (`ApplyMutationsRaft`). It still flows through
+`encryptForKey`, so when the §7.1 envelope is active it emits a §4.1
+nonce — and it does so without consulting 7a's coordinator barrier, so
+a self-originated catalog write can emit a nonce before this node's
+writer registration commits.
+
+The single chokepoint where **every** encrypted write emits its nonce
+is `store.encryptForKey`. 7a-2 enforces registration there, giving
+complete coverage of all self-originated write paths.
+
+## 1. The hard constraint: direct path vs FSM-apply path
+
+`encryptForKey` is reached from **two** classes of caller, which must
+be treated differently:
+
+| Path | Entry | Origin | 7a-2 action |
+|---|---|---|---|
+| **Direct** | `store.ApplyMutations` | self-originated local write (catalog `Save`, admin snapshot, migration) | **fail-closed**: refuse to emit an encrypted nonce before registration |
+| **FSM-apply** | `store.ApplyMutationsRaft` | a committed Raft entry being applied on this node (could be any node's write) | **NOT gated**: §4.1 explicitly allows apply during the pre-registration window ("FSM apply may run on leader-proposed entries … decrypted using sidecar DEKs") |
+
+**Why the FSM-apply path must NOT fail-close.** `ApplyMutationsRaft`
+runs inside the deterministic FSM apply loop on every node. If it
+returned an error for "not registered," the apply loop would HaltApply
+— and since the registration entry itself is ordered in the same Raft
+log, a storage entry ordered *before* the registration entry would
+halt the loop permanently (it can never reach and apply its own
+registration). It would also diverge a not-yet-registered follower
+from registered peers. The §4.1 contract deliberately permits apply
+during the window precisely because the danger is **self-originated**
+writes, not replicated apply. 7a's coordinator barrier already gates
+self-originated writes that go through the coordinator; 7a-2 closes the
+remaining self-originated path (direct `ApplyMutations`), and leaves
+the replicated FSM-apply path alone.
+
+This is the key insight that makes "enforce at `encryptForKey`"
+tractable: the enforcement is **per-call-path**, gated on the direct
+path only, not a blanket check.
+
+## 2. Proposed design
+
+### 2.1 A `registered` signal on the StateCache
+
+Add to `encryption.StateCache` a `registered atomic.Bool` (and
+`MarkRegistered()` / `Registered()`), set to true when this node's
+writer registration for the active storage DEK commits. 7a's
+`runWriterRegistration`, on `close(barrier)`, also calls
+`cache.MarkRegistered()`. Pre-registration (and Phase 0 / not
+bootstrapped) it is false.
+
+Rationale for reusing the StateCache: the storage layer already reads
+`StorageEnvelopeActive` / `ActiveStorageKeyID` from it via closures
+(6D-6c-2), so a `Registered()` closure threads in the same way without
+coupling `store` to the registration machinery.
+
+### 2.2 Store wiring
+
+A new `WithStorageRegistrationGate(registered func() bool)` PebbleStore
+option (parallel to `WithStorageEnvelopeGate`). When wired,
+`encryptForKey` on the **direct** path returns a typed
+`ErrWriterNotRegistered` when the envelope would encrypt
+(`StorageEnvelopeActive && activeKeyID != 0`) but `registered()` is
+false. The FSM-apply path passes a flag that skips this check.
+
+Mechanically: `applyMutationsWithOpts` already distinguishes the two
+entry points (`ApplyMutations` vs `ApplyMutationsRaft` pass different
+write opts). 7a-2 threads a `gateRegistration bool` alongside so
+`encryptForKey` knows whether to enforce. The direct callers
+(`ApplyMutations`) set it true; `ApplyMutationsRaft` sets it false.
+
+### 2.3 Startup ordering (the catalog-bootstrap question)
+
+`EnsureCatalogSnapshot` runs at startup and may `Save` via the direct
+path. If the envelope is active at startup (post-cutover restart) and
+this node is not yet registered, a gated catalog `Save` would fail.
+Two sub-cases:
+
+- **Catalog already populated** (the steady-state restart): `Save` is
+  a no-op (version unchanged), no mutation, no nonce → ungated.
+- **Empty catalog + active envelope** (the flagged edge): the bootstrap
+  `Save` would be gated. Resolution: the §4.1 registration must
+  precede the first direct encrypted write. Since registration is a
+  Raft 0x03 entry proposed at startup (7a), and catalog bootstrap is
+  also a startup step, 7a-2 sequences catalog bootstrap **after** the
+  registration barrier closes when the envelope is active (or, if the
+  barrier is still open, the bootstrap `Save` returns
+  `ErrWriterNotRegistered` and is retried after close). **Open question
+  for review (§5):** confirm there is no circular dependency
+  (registration propose → engine → does it need the catalog?). Initial
+  reading: registration proposes a reserved-key 0x03 entry through the
+  default group's engine, independent of the route catalog, so no
+  cycle — but this needs verification against the engine bring-up
+  order.
+
+## 3. Scope
+
+### In scope (7a-2)
+- `StateCache.registered` + `MarkRegistered` / `Registered`; 7a's
+  `runWriterRegistration` marks it on barrier close.
+- `WithStorageRegistrationGate` PebbleStore option +
+  `ErrWriterNotRegistered`; `encryptForKey` direct-path enforcement.
+- The direct-vs-raft path flag threaded through `applyMutationsWithOpts`.
+- main.go wiring of the `Registered()` closure.
+- Tests: direct-path write pre-registration → `ErrWriterNotRegistered`;
+  post-registration → encrypts; FSM-apply path never gated; envelope
+  inactive / no DEK → ungated; catalog-bootstrap ordering.
+
+### Out of scope
+- 7b (post-rotation re-registration), 7c (ConfChange-time registration).
+- Re-evaluating whether route-catalog data *should* be encrypted at all
+  (it is, incidentally, when the envelope is active; changing that is a
+  separate question).
+
+## 4. Self-review checklist (for the implementation PR)
+- **Data loss** — gating only refuses to *emit* an encrypted write
+  before registration (caller sees a typed error and retries); never
+  drops a committed write. FSM-apply path untouched → no apply halt.
+- **Concurrency** — `registered` is an atomic bool; `encryptForKey`
+  fast path is one atomic load on the direct path, zero on the
+  FSM-apply path.
+- **Data consistency** — FSM-apply determinism preserved (no per-node
+  fail-close on replicated apply); coordinator gate + this direct-path
+  gate together cover every self-originated encrypted write.
+- **Test coverage** — direct vs FSM-apply path, pre/post registration,
+  envelope/DEK off, catalog-bootstrap ordering.
+
+## 5. Open questions
+1. Catalog-bootstrap ordering vs registration (§2.3) — confirm no
+   circular dependency and pick the sequencing (bootstrap-after-close
+   vs. retry-on-`ErrWriterNotRegistered`).
+2. Are there direct-`ApplyMutations` callers **other** than catalog
+   bootstrap / admin snapshot / migration that run on the hot path and
+   would be unexpectedly gated? (grep audit before implementation.)
+3. Should `Registered()` be per-DEK (matching `ActiveStorageKeyID`) so a
+   rotate-dek (7b) that resets registration is handled, or a single
+   bool reset on rotate? (Leaning per-active-DEK to compose with 7b.)

--- a/docs/design/2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md
+++ b/docs/design/2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md
@@ -98,6 +98,28 @@ needed (only one storage DEK is active at a time; 7b's rotate-dek
 re-points the active id and re-registers, which `Registered()`'s
 equality check handles for free).
 
+**Seed the already-registered startup branch too — not only the
+barrier-close paths (codex P1).** 7a's `buildProcessStartRegistrationGate`
+has an `epoch == lastSeen` branch (`main_encryption_registration.go:141`)
+— the **common restart case** where this node's epoch is already
+durably in the registry. That branch returns an *ungated*
+`&kv.RegistrationGate{}` (nil Barrier) **without** starting
+`runWriterRegistration`, so `releaseBarrier` → `MarkRegistered` never
+runs. Under 7a-2 that would leave `registeredStorageDEKID == 0`, so
+`Registered()` would report **false** on every steady-state restart and
+the direct-path bootstrap `Save` would wrongly fail-closed with
+`ErrWriterNotRegistered` despite the registry already being current.
+7a-2 therefore calls `w.cache.MarkRegistered(activeDEK)` in the
+`epoch == lastSeen` branch **before** returning the ungated gate, so the
+already-registered restart path seeds `Registered()` true. The
+strictly-behind (`epoch < lastSeen`) branch still fails closed and the
+not-active / not-bootstrapped branches need no seeding (the gate
+condition `StorageEnvelopeActive && activeKeyID != 0` is false there, so
+`encryptForKey` does not consult `Registered()` anyway). Net: every path
+that returns ungated *while the envelope is active and this node is
+registered* must seed the registered state — barrier-close is only one
+of them.
+
 Rationale for reusing the StateCache: the storage layer already reads
 `StorageEnvelopeActive` / `ActiveStorageKeyID` from it via closures
 (6D-6c-2), so a `Registered()` closure threads in the same way without
@@ -234,15 +256,18 @@ forwarder callers before merge.
 ## 3. Scope
 
 ### In scope (7a-2)
-- `StateCache.registeredStorageDEKID` + `MarkRegistered` / `Registered`; 7a's
-  `runWriterRegistration` marks it on barrier close.
+- `StateCache.registeredStorageDEKID` + `MarkRegistered` / `Registered`; seeded
+  on barrier close (`runWriterRegistration`) **and** in the
+  `epoch == lastSeen` already-registered startup branch (§2.1, codex P1).
 - `WithStorageRegistrationGate` PebbleStore option +
   `ErrWriterNotRegistered`; `encryptForKey` direct-path enforcement.
 - The direct-vs-raft path flag threaded through `applyMutationsWithOpts`.
 - main.go wiring of the `Registered()` closure.
 - Tests: direct-path write pre-registration → `ErrWriterNotRegistered`;
   post-registration → encrypts; FSM-apply path never gated; envelope
-  inactive / no DEK → ungated; catalog-bootstrap ordering.
+  inactive / no DEK → ungated; catalog-bootstrap ordering; **already-
+  registered restart (`epoch == lastSeen`) seeds `Registered()` true so
+  the first direct-path write does not fail-closed (codex P1).**
 
 ### Out of scope
 - 7b (post-rotation re-registration), 7c (ConfChange-time registration).

--- a/docs/design/2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md
+++ b/docs/design/2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md
@@ -204,12 +204,22 @@ guards.
 `ErrWriterNotRegistered` retry/backoff is implemented once (a shared
 `retryUntilRegistered(ctx, fn)` helper) and reused by every direct-path
 caller rather than duplicated, for consistent backoff + diagnostics.
-**Current vs. anticipated callers (claude P3):** today the only
-non-test caller of `store.ApplyMutations` is `distribution/catalog.go`
-(catalog bootstrap + runtime `SplitRange`); "admin snapshot" and
-"migration" are *anticipated future* direct-path callers named by the
-`lsm_store.go` doc comment as the design-time category, not code that
-exists yet — the implementation only needs to wire the catalog path.
+**Direct-path caller inventory (claude P3 + codex P2).** The gated
+direct path is `pebbleStore.ApplyMutations`. It is reached by:
+  - `distribution/catalog.go` (catalog bootstrap + runtime
+    `SplitRange`) — the only caller that *originates* a write today;
+  - the `ShardStore.ApplyMutations` and `LeaderRoutedStore.ApplyMutations`
+    **MVCCStore-interface forwarders** (`kv/shard_store.go`,
+    `kv/leader_routed_store.go`) which simply delegate to the
+    underlying `pebbleStore.ApplyMutations` — no production hot-path
+    caller of these forwarders was found (grep of `adapter/`, `kv/`,
+    `main*.go`), but they are live entry points the implementation's
+    §5 verification must re-confirm.
+"admin snapshot" and "migration" are *anticipated future* direct-path
+callers named by the `lsm_store.go` doc comment as the design-time
+category, not code that exists yet. So the implementation wires the
+catalog path now and the verification step re-greps the forwarder
+callers before merge.
 
 ## 3. Scope
 

--- a/docs/design/2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md
+++ b/docs/design/2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md
@@ -140,12 +140,18 @@ adapter hot paths, but gating them is correct and costs one bool.
 `encryptForKey`, so they are outside the gate's scope with no change
 needed (noted to close the audit loop — claude P2).
 
-**Runtime direct-write paths too, not just bootstrap (claude P2).**
-`CatalogStore.Save` is also reached at runtime via `SplitRange`, not
-only startup `EnsureCatalogSnapshot`. An unregistered node attempting a
-`SplitRange` before its barrier closes is correctly fail-closed by the
-same gate — the implementation must not special-case only the bootstrap
-path.
+**`SplitRange` does NOT use the direct path (codex P2).** An earlier
+draft claimed `CatalogStore.Save` is reached at runtime via
+`SplitRange`. That is wrong: the non-test split path
+(`adapter/distribution_server.go` `SplitRange` →
+`saveSplitResultViaCoordinator` → `coordinator.Dispatch`) commits
+through the **coordinator** (Raft-apply), so it is already covered by
+7a's coordinator-layer barrier and lands on the FSM-apply path
+(exempt). `CatalogStore.Save` has exactly **one** non-test caller —
+the startup bootstrap in `distribution/bootstrap.go` (via
+`EnsureCatalogSnapshot`). So the *only* direct-`ApplyMutations` path
+7a-2 must gate is the bootstrap `Save`; there is no runtime `SplitRange`
+direct-write path to fail-closed.
 
 ### 2.3 Startup ordering (the catalog-bootstrap question)
 
@@ -206,8 +212,12 @@ guards.
 caller rather than duplicated, for consistent backoff + diagnostics.
 **Direct-path caller inventory (claude P3 + codex P2).** The gated
 direct path is `pebbleStore.ApplyMutations`. It is reached by:
-  - `distribution/catalog.go` (catalog bootstrap + runtime
-    `SplitRange`) — the only caller that *originates* a write today;
+  - `distribution.CatalogStore.Save` → `applySaveMutations` →
+    `store.ApplyMutations`, whose **only** non-test caller is the
+    startup bootstrap (`distribution/bootstrap.go` via
+    `EnsureCatalogSnapshot`). Runtime `SplitRange` does **not** reach
+    this path — it commits through `coordinator.Dispatch` (Raft-apply),
+    already covered by 7a's coordinator barrier (codex P2);
   - the `ShardStore.ApplyMutations` and `LeaderRoutedStore.ApplyMutations`
     **MVCCStore-interface forwarders** (`kv/shard_store.go`,
     `kv/leader_routed_store.go`) which simply delegate to the
@@ -218,8 +228,8 @@ direct path is `pebbleStore.ApplyMutations`. It is reached by:
 "admin snapshot" and "migration" are *anticipated future* direct-path
 callers named by the `lsm_store.go` doc comment as the design-time
 category, not code that exists yet. So the implementation wires the
-catalog path now and the verification step re-greps the forwarder
-callers before merge.
+bootstrap `Save` path now and the verification step re-greps the
+forwarder callers before merge.
 
 ## 3. Scope
 

--- a/docs/design/2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md
+++ b/docs/design/2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md
@@ -15,7 +15,7 @@ paths. But codex P1 #3 on PR #839 showed it is **structurally
 incomplete**: internal callers that write to the store **directly**
 bypass the coordinator entirely. The confirmed case:
 
-```
+```text
 distribution.CatalogStore.Save → applySaveMutations
   → store.ApplyMutations(...)        // the DIRECT, non-Raft local commit path
     → encryptForKey → nonceFactory.Next()
@@ -203,13 +203,18 @@ guards.
 **Centralized retry helper (gemini medium).** The
 `ErrWriterNotRegistered` retry/backoff is implemented once (a shared
 `retryUntilRegistered(ctx, fn)` helper) and reused by every direct-path
-caller (catalog bootstrap, admin snapshot, migration) rather than
-duplicated, for consistent backoff + diagnostics.
+caller rather than duplicated, for consistent backoff + diagnostics.
+**Current vs. anticipated callers (claude P3):** today the only
+non-test caller of `store.ApplyMutations` is `distribution/catalog.go`
+(catalog bootstrap + runtime `SplitRange`); "admin snapshot" and
+"migration" are *anticipated future* direct-path callers named by the
+`lsm_store.go` doc comment as the design-time category, not code that
+exists yet — the implementation only needs to wire the catalog path.
 
 ## 3. Scope
 
 ### In scope (7a-2)
-- `StateCache.registered` + `MarkRegistered` / `Registered`; 7a's
+- `StateCache.registeredStorageDEKID` + `MarkRegistered` / `Registered`; 7a's
   `runWriterRegistration` marks it on barrier close.
 - `WithStorageRegistrationGate` PebbleStore option +
   `ErrWriterNotRegistered`; `encryptForKey` direct-path enforcement.

--- a/docs/design/2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md
+++ b/docs/design/2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md
@@ -112,17 +112,32 @@ option (parallel to `WithStorageEnvelopeGate`). When wired,
 false. The FSM-apply path passes a flag that skips this check.
 
 **`encryptForKey` signature, not just `applyMutationsWithOpts` (claude
-P2).** `encryptForKey` is called from more than `applyMutationsWithOpts`
-— notably `PutAt` (`store/lsm_store.go:1031`) calls it directly, and
-`ExpireAt` / `PutWithTTLAt` delegate to `PutAt`. So threading a flag
-through `applyMutationsWithOpts` alone would leave those ungated. 7a-2
-adds the path context to **`encryptForKey`'s own signature**
+P2).** `encryptForKey` is called from more than `applyMutationsWithOpts`,
+so 7a-2 adds the path context to **`encryptForKey`'s own signature**
 (Option A): `encryptForKey(pebbleKey, plaintext, expireAt, gateRegistration bool)`.
-The direct callers — `ApplyMutations`, `PutAt` (and thus `ExpireAt` /
-`PutWithTTLAt`) — pass `true`; the FSM-apply path (`ApplyMutationsRaft`)
-passes `false`. (`PutAt`/`ExpireAt`/`PutWithTTLAt` are internal/test
-surfaces today, not adapter hot paths, but gating them is correct and
-costs one bool.)
+Verified call-site inventory:
+
+| Call site | Line | Path | `gateRegistration` |
+|---|---|---|---|
+| `PutAt` | 1031 | direct | `true` |
+| `ExpireAt` | 1076 | direct (its own call, **not** via `PutAt`) | `true` |
+| `applyMutationsBatch` | 1177 | direct (via `ApplyMutations`) | `true` |
+| `applyMutationsBatch` | 1177 | FSM-apply (via `ApplyMutationsRaft`) | `false` |
+
+`PutWithTTLAt` delegates to `PutAt` (so it inherits the gate);
+**`ExpireAt` does not** — it calls `encryptForKey` directly at line
+1076, so it needs its own `gateRegistration = true` (claude P1
+correction; an earlier draft wrongly said `ExpireAt` delegates to
+`PutAt`). The shared `applyMutationsBatch` site (line 1177) is reached
+from both `ApplyMutations` (direct) and `ApplyMutationsRaft` (FSM), so
+the flag threaded through `applyMutationsWithOpts` distinguishes those
+two rows. `PutAt` / `ExpireAt` are internal/test surfaces today, not
+adapter hot paths, but gating them is correct and costs one bool.
+
+`DeletePrefixAt` / `DeletePrefixAtRaft` write only tombstones
+(`encodeValue(nil, true, 0, encStateCleartext)`) and never call
+`encryptForKey`, so they are outside the gate's scope with no change
+needed (noted to close the audit loop — claude P2).
 
 **Runtime direct-write paths too, not just bootstrap (claude P2).**
 `CatalogStore.Save` is also reached at runtime via `SplitRange`, not

--- a/docs/design/2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md
+++ b/docs/design/2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md
@@ -83,9 +83,19 @@ new id, and `Registered()` automatically evaluates false (the new id
 ≠ `registeredStorageDEKID`) until the post-rotation registration marks
 the new id — no reset logic, no mutex, one atomic load on the hot path.
 
-7a's `runWriterRegistration`, on `close(barrier)`, calls
-`cache.MarkRegistered(activeDEK)`. Pre-registration (and Phase 0 / not
-bootstrapped) `Registered()` is false.
+**Mark at BOTH barrier-close sites (claude P1).** `runWriterRegistration`
+closes `barrier` at two places — the verify-before-propose path (a
+prior attempt already committed) and the propose-success path. 7a-2
+refactors both into a single `releaseBarrier(barrier, cache, dekID)`
+helper that `close()`s the channel **and** calls
+`cache.MarkRegistered(dekID)` atomically, so the
+"timed-out-but-committed" verify path cannot leave `registered` false
+(which would have the direct-path gate reject writes even after
+confirmed registration). The single-active-storage-DEK model means
+`registeredStorageDEKID` is one `atomic.Uint32` — no map / `sync.Map`
+needed (only one storage DEK is active at a time; 7b's rotate-dek
+re-points the active id and re-registers, which `Registered()`'s
+equality check handles for free).
 
 Rationale for reusing the StateCache: the storage layer already reads
 `StorageEnvelopeActive` / `ActiveStorageKeyID` from it via closures
@@ -101,11 +111,25 @@ option (parallel to `WithStorageEnvelopeGate`). When wired,
 (`StorageEnvelopeActive && activeKeyID != 0`) but `registered()` is
 false. The FSM-apply path passes a flag that skips this check.
 
-Mechanically: `applyMutationsWithOpts` already distinguishes the two
-entry points (`ApplyMutations` vs `ApplyMutationsRaft` pass different
-write opts). 7a-2 threads a `gateRegistration bool` alongside so
-`encryptForKey` knows whether to enforce. The direct callers
-(`ApplyMutations`) set it true; `ApplyMutationsRaft` sets it false.
+**`encryptForKey` signature, not just `applyMutationsWithOpts` (claude
+P2).** `encryptForKey` is called from more than `applyMutationsWithOpts`
+— notably `PutAt` (`store/lsm_store.go:1031`) calls it directly, and
+`ExpireAt` / `PutWithTTLAt` delegate to `PutAt`. So threading a flag
+through `applyMutationsWithOpts` alone would leave those ungated. 7a-2
+adds the path context to **`encryptForKey`'s own signature**
+(Option A): `encryptForKey(pebbleKey, plaintext, expireAt, gateRegistration bool)`.
+The direct callers — `ApplyMutations`, `PutAt` (and thus `ExpireAt` /
+`PutWithTTLAt`) — pass `true`; the FSM-apply path (`ApplyMutationsRaft`)
+passes `false`. (`PutAt`/`ExpireAt`/`PutWithTTLAt` are internal/test
+surfaces today, not adapter hot paths, but gating them is correct and
+costs one bool.)
+
+**Runtime direct-write paths too, not just bootstrap (claude P2).**
+`CatalogStore.Save` is also reached at runtime via `SplitRange`, not
+only startup `EnsureCatalogSnapshot`. An unregistered node attempting a
+`SplitRange` before its barrier closes is correctly fail-closed by the
+same gate — the implementation must not special-case only the bootstrap
+path.
 
 ### 2.3 Startup ordering (the catalog-bootstrap question)
 
@@ -127,13 +151,23 @@ the registration *apply* writes a `!encryption|writers|…` registry row
 bootstrap — bootstrap-gated-on-registration introduces no cycle.
 (Verification item retained in §5 against engine bring-up order.)
 
-**Sequencing + deadlock mitigation (gemini medium).** When the
-envelope is active at startup, 7a-2 runs catalog bootstrap *after* the
-7a registration barrier; if the barrier is still open, the bootstrap's
-direct encrypted `Save` returns `ErrWriterNotRegistered` and is retried
-via a **shared, bounded** retry helper (see below) until the barrier
-closes. To prevent a permanent startup hang if registration never
-commits:
+**Reconciling with the current startup order (claude P1).** Today
+`setupDistributionAndRegistration` (`main_encryption_registration.go`)
+runs `setupDistributionCatalog` → `EnsureCatalogSnapshot` → (possible
+`Save`) **before** `installProcessStartRegistrationGate`. So the
+empty-catalog edge currently runs before any gate exists. 7a-2 resolves
+this concretely by **reordering** `setupDistributionAndRegistration`:
+install the registration gate (arm the barrier + start the 7a
+registration goroutine) **first**, then run `EnsureCatalogSnapshot`.
+With the gate armed, the bootstrap's direct encrypted `Save` (only when
+the envelope is active AND the catalog is empty) returns
+`ErrWriterNotRegistered` and is retried via the shared bounded helper
+until the barrier closes — at which point `Save` proceeds. This is safe
+because registration has no dependency on the route catalog (above), so
+arming-before-bootstrap cannot deadlock.
+
+**Deadlock mitigation (gemini medium).** To prevent a permanent startup
+hang if registration never commits:
   - the 7a registration goroutine already retries the propose with
     bounded backoff against the run-context (per-attempt timeout,
     leader re-resolution), so "no leader" resolves as leadership
@@ -192,9 +226,14 @@ duplicated, for consistent backoff + diagnostics.
 1. Catalog-bootstrap ordering vs registration (§2.3) — confirm no
    circular dependency and pick the sequencing (bootstrap-after-close
    vs. retry-on-`ErrWriterNotRegistered`).
-2. Are there direct-`ApplyMutations` callers **other** than catalog
-   bootstrap / admin snapshot / migration that run on the hot path and
-   would be unexpectedly gated? (grep audit before implementation.)
+2. Audit **all `encryptForKey` callers** (not just `ApplyMutations`):
+   confirmed `ApplyMutations`, `ApplyMutationsRaft`, and `PutAt`
+   (`ExpireAt` / `PutWithTTLAt` delegate to `PutAt`). The §2.2
+   signature change gates the direct callers
+   (`ApplyMutations`/`PutAt`) and exempts `ApplyMutationsRaft`. Confirm
+   no *other* `encryptForKey` caller exists and that no gated direct
+   caller is reached from an adapter hot path that legitimately fires
+   before registration.
 (Open question 3 — per-DEK vs single bool — is resolved: §2.1 adopts
 the per-DEK `registeredStorageDEKID atomic.Uint32`, lock-free and
 composing with 7b.)

--- a/docs/design/2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md
+++ b/docs/design/2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md
@@ -63,14 +63,29 @@ path only, not a blanket check.
 
 ## 2. Proposed design
 
-### 2.1 A `registered` signal on the StateCache
+### 2.1 A per-DEK `registered` signal on the StateCache
 
-Add to `encryption.StateCache` a `registered atomic.Bool` (and
-`MarkRegistered()` / `Registered()`), set to true when this node's
-writer registration for the active storage DEK commits. 7a's
-`runWriterRegistration`, on `close(barrier)`, also calls
-`cache.MarkRegistered()`. Pre-registration (and Phase 0 / not
-bootstrapped) it is false.
+Add to `encryption.StateCache` a `registeredStorageDEKID atomic.Uint32`
+(0 = none) with `MarkRegistered(dekID uint32)` and a `Registered()`
+predicate:
+
+```go
+func (c *StateCache) Registered() bool {
+    id := c.activeStorageDEKID.Load()
+    return id != 0 && c.registeredStorageDEKID.Load() == id
+}
+```
+
+**Per-DEK, not a single bool (gemini medium).** Tracking the registered
+DEK *id* rather than a bool gives lock-free per-DEK gating that
+composes with 7b: a `rotate-dek` re-points `activeStorageDEKID` to the
+new id, and `Registered()` automatically evaluates false (the new id
+≠ `registeredStorageDEKID`) until the post-rotation registration marks
+the new id — no reset logic, no mutex, one atomic load on the hot path.
+
+7a's `runWriterRegistration`, on `close(barrier)`, calls
+`cache.MarkRegistered(activeDEK)`. Pre-registration (and Phase 0 / not
+bootstrapped) `Registered()` is false.
 
 Rationale for reusing the StateCache: the storage layer already reads
 `StorageEnvelopeActive` / `ActiveStorageKeyID` from it via closures
@@ -102,19 +117,44 @@ Two sub-cases:
 - **Catalog already populated** (the steady-state restart): `Save` is
   a no-op (version unchanged), no mutation, no nonce → ungated.
 - **Empty catalog + active envelope** (the flagged edge): the bootstrap
-  `Save` would be gated. Resolution: the §4.1 registration must
-  precede the first direct encrypted write. Since registration is a
-  Raft 0x03 entry proposed at startup (7a), and catalog bootstrap is
-  also a startup step, 7a-2 sequences catalog bootstrap **after** the
-  registration barrier closes when the envelope is active (or, if the
-  barrier is still open, the bootstrap `Save` returns
-  `ErrWriterNotRegistered` and is retried after close). **Open question
-  for review (§5):** confirm there is no circular dependency
-  (registration propose → engine → does it need the catalog?). Initial
-  reading: registration proposes a reserved-key 0x03 entry through the
-  default group's engine, independent of the route catalog, so no
-  cycle — but this needs verification against the engine bring-up
-  order.
+  `Save` would be gated. Resolution + deadlock mitigation below.
+
+**No circular dependency.** Registration proposes a reserved-key 0x03
+`OpRegistration` entry through the default group's engine; proposing is
+submitting bytes to Raft and does not consult the route catalog, and
+the registration *apply* writes a `!encryption|writers|…` registry row
+(not a route). So registration can commit independent of catalog
+bootstrap — bootstrap-gated-on-registration introduces no cycle.
+(Verification item retained in §5 against engine bring-up order.)
+
+**Sequencing + deadlock mitigation (gemini medium).** When the
+envelope is active at startup, 7a-2 runs catalog bootstrap *after* the
+7a registration barrier; if the barrier is still open, the bootstrap's
+direct encrypted `Save` returns `ErrWriterNotRegistered` and is retried
+via a **shared, bounded** retry helper (see below) until the barrier
+closes. To prevent a permanent startup hang if registration never
+commits:
+  - the 7a registration goroutine already retries the propose with
+    bounded backoff against the run-context (per-attempt timeout,
+    leader re-resolution), so "no leader" resolves as leadership
+    settles;
+  - the direct-path retry is **bounded by the run-context** (and a
+    generous ceiling), not infinite — on shutdown it returns the error
+    and the process exits cleanly rather than hanging;
+  - a WARN log fires when the bootstrap `Save` has been blocked on
+    registration beyond a threshold, so a stuck node is diagnosable
+    rather than silently hung.
+There is no fail-OPEN fallback: bypassing the gate to let bootstrap
+proceed unregistered is the exact hazard 7a-2 closes. A node that
+genuinely cannot register (e.g. `ErrNodeIDCollision`) fails to start —
+which is the intended fail-closed posture, matching the §9.1 startup
+guards.
+
+**Centralized retry helper (gemini medium).** The
+`ErrWriterNotRegistered` retry/backoff is implemented once (a shared
+`retryUntilRegistered(ctx, fn)` helper) and reused by every direct-path
+caller (catalog bootstrap, admin snapshot, migration) rather than
+duplicated, for consistent backoff + diagnostics.
 
 ## 3. Scope
 
@@ -155,6 +195,6 @@ Two sub-cases:
 2. Are there direct-`ApplyMutations` callers **other** than catalog
    bootstrap / admin snapshot / migration that run on the hot path and
    would be unexpectedly gated? (grep audit before implementation.)
-3. Should `Registered()` be per-DEK (matching `ActiveStorageKeyID`) so a
-   rotate-dek (7b) that resets registration is handled, or a single
-   bool reset on rotate? (Leaning per-active-DEK to compose with 7b.)
+(Open question 3 — per-DEK vs single bool — is resolved: §2.1 adopts
+the per-DEK `registeredStorageDEKID atomic.Uint32`, lock-free and
+composing with 7b.)

--- a/docs/design/2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md
+++ b/docs/design/2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md
@@ -81,7 +81,8 @@ DEK *id* rather than a bool gives lock-free per-DEK gating that
 composes with 7b: a `rotate-dek` re-points `activeStorageDEKID` to the
 new id, and `Registered()` automatically evaluates false (the new id
 ≠ `registeredStorageDEKID`) until the post-rotation registration marks
-the new id — no reset logic, no mutex, one atomic load on the hot path.
+the new id — no reset logic, no mutex, just two atomic loads on the
+hot path (`activeStorageDEKID` and `registeredStorageDEKID`).
 
 **Mark at BOTH barrier-close sites (claude P1).** `runWriterRegistration`
 closes `barrier` at two places — the verify-before-propose path (a
@@ -228,27 +229,31 @@ duplicated, for consistent backoff + diagnostics.
 - **Data loss** — gating only refuses to *emit* an encrypted write
   before registration (caller sees a typed error and retries); never
   drops a committed write. FSM-apply path untouched → no apply halt.
-- **Concurrency** — `registered` is an atomic bool; `encryptForKey`
-  fast path is one atomic load on the direct path, zero on the
-  FSM-apply path.
+- **Concurrency** — registration state is `registeredStorageDEKID
+  atomic.Uint32` (§2.1); `Registered()` is lock-free — two atomic
+  loads (`activeStorageDEKID`, `registeredStorageDEKID`) when an active
+  DEK is present, and the direct-path check is skipped entirely on the
+  FSM-apply path (`gateRegistration = false`).
 - **Data consistency** — FSM-apply determinism preserved (no per-node
   fail-close on replicated apply); coordinator gate + this direct-path
   gate together cover every self-originated encrypted write.
 - **Test coverage** — direct vs FSM-apply path, pre/post registration,
   envelope/DEK off, catalog-bootstrap ordering.
 
-## 5. Open questions
-1. Catalog-bootstrap ordering vs registration (§2.3) — confirm no
-   circular dependency and pick the sequencing (bootstrap-after-close
-   vs. retry-on-`ErrWriterNotRegistered`).
-2. Audit **all `encryptForKey` callers** (not just `ApplyMutations`):
-   confirmed `ApplyMutations`, `ApplyMutationsRaft`, and `PutAt`
-   (`ExpireAt` / `PutWithTTLAt` delegate to `PutAt`). The §2.2
-   signature change gates the direct callers
-   (`ApplyMutations`/`PutAt`) and exempts `ApplyMutationsRaft`. Confirm
-   no *other* `encryptForKey` caller exists and that no gated direct
-   caller is reached from an adapter hot path that legitimately fires
-   before registration.
+## 5. Verification action items (design decisions are settled)
+1. **Sequencing is decided** (§2.3: arm the gate first, then
+   `EnsureCatalogSnapshot`, with bounded `retryUntilRegistered` for the
+   empty-catalog + active-envelope edge). Remaining **verification**
+   before implementation: confirm the `OpRegistration` apply path in
+   `kv/fsm.go` makes no route-catalog / `distribution.Engine` call, so
+   arm-before-bootstrap has no hidden cycle.
+2. **Call-site inventory is settled** (§2.2's 4-row table: `PutAt`
+   (1031) and `ExpireAt` (1076) are *separate* direct `encryptForKey`
+   callers — `ExpireAt` does **not** delegate to `PutAt`;
+   `PutWithTTLAt` does; `applyMutationsBatch` (1177) is reached from
+   both the direct and FSM paths; `DeletePrefixAt` writes tombstones
+   only and is out of scope). Remaining **verification**: grep-confirm
+   no *other* `encryptForKey` caller exists.
 (Open question 3 — per-DEK vs single bool — is resolved: §2.1 adopts
 the per-DEK `registeredStorageDEKID atomic.Uint32`, lock-free and
 composing with 7b.)

--- a/docs/design/2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md
+++ b/docs/design/2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md
@@ -40,7 +40,7 @@ be treated differently:
 
 | Path | Entry | Origin | 7a-2 action |
 |---|---|---|---|
-| **Direct** | `store.ApplyMutations` | self-originated local write (catalog `Save`, admin snapshot, migration) | **fail-closed**: refuse to emit an encrypted nonce before registration |
+| **Direct** | `store.ApplyMutations` | self-originated local write (catalog `Save` today; admin snapshot, migration: anticipated future — see §2.3) | **fail-closed**: refuse to emit an encrypted nonce before registration |
 | **FSM-apply** | `store.ApplyMutationsRaft` | a committed Raft entry being applied on this node (could be any node's write) | **NOT gated**: §4.1 explicitly allows apply during the pre-registration window ("FSM apply may run on leader-proposed entries … decrypted using sidecar DEKs") |
 
 **Why the FSM-apply path must NOT fail-close.** `ApplyMutationsRaft`


### PR DESCRIPTION
## Summary
PR #839 (7a) merged. This is the **design doc for Stage 7a-2** — completing the §4.1 registration-before-first-write coverage by enforcing at the single nonce-emission chokepoint `store.encryptForKey`, closing the direct-store-write gap codex P1 #3 flagged (`CatalogStore.Save` → `store.ApplyMutations` bypasses 7a's coordinator-layer barrier).

**Doc-only PR by design** — the enforcement touches the storage/apply layer with a real correctness constraint that needs review before implementation.

## Key constraint surfaced by investigation
`encryptForKey` is reached from two caller classes that must be treated differently:
- **Direct path** (`store.ApplyMutations`: catalog bootstrap / admin snapshot / migration — self-originated, local) → **fail-closed** with `ErrWriterNotRegistered` before registration.
- **FSM-apply path** (`store.ApplyMutationsRaft`: committed Raft entries) → **NOT gated**. Failing closed there would halt the deterministic apply loop — and deadlock if a storage entry is ordered before this node's own registration entry. §4.1 explicitly permits apply during the pre-registration window.

Per-call-path enforcement is what makes "enforce at `encryptForKey`" tractable.

## Design
- `registered atomic.Bool` on `encryption.StateCache` (`MarkRegistered`/`Registered`), set when 7a's `runWriterRegistration` closes the barrier.
- `WithStorageRegistrationGate(registered func() bool)` PebbleStore option + `ErrWriterNotRegistered`.
- A direct-vs-raft path flag threaded through `applyMutationsWithOpts` so `encryptForKey` enforces only on the direct path.

## Open questions (for review)
1. **Catalog-bootstrap vs registration ordering** (§2.3) — confirm no circular dependency (registration proposes a reserved-key 0x03 entry through the default group's engine; initial reading is it is independent of the route catalog, but needs verification against engine bring-up order), and pick the sequencing.
2. Any **other** direct-`ApplyMutations` hot-path callers that would be unexpectedly gated? (grep audit before implementation.)
3. `Registered()` per-DEK vs single bool (composing with 7b rotate-dek).

## Test plan
- [x] Doc-only; lint clean
- [ ] Implementation + tests in the follow-up 7a-2 PR once the design (esp. bootstrap ordering) is confirmed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a design proposal describing enforcement of storage-layer writer registration across encrypted write paths, including gating behavior for direct vs. deterministic apply paths, startup sequencing and retry diagnostics, and verification/audit guidance.

---

*Note: Documentation-only update; no user-visible changes.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/843?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->