### PR TITLE
backup: Phase 0b M5-1 — SQS queue + message reverse encoder

### DIFF
--- a/internal/backup/encode_sqs.go
+++ b/internal/backup/encode_sqs.go
@@ -269,6 +269,8 @@ func (e *SQSRecordEncoder) addMessage(b *snapshotBuilder, queueName string, rec 
 // missing file surfaces as a wrapped os.ErrNotExist so callers can treat
 // an absent optional file as empty.
 func (e *SQSRecordEncoder) openSQSRootFile(root *os.Root, rel string) (*os.File, error) {
+	// Pre-open Lstat refuses a symlink / FIFO / device / directory BEFORE
+	// Open, so a reader-less FIFO already in place cannot block the open.
 	linfo, err := root.Lstat(rel)
 	if err != nil {
 		return nil, errors.WithStack(err) // wraps os.ErrNotExist when absent
@@ -282,6 +284,23 @@ func (e *SQSRecordEncoder) openSQSRootFile(root *os.Root, rel string) (*os.File,
 	f, err := root.Open(rel)
 	if err != nil {
 		return nil, errors.WithStack(err)
+	}
+	// Post-open fstat is authoritative: it closes the Lstat->Open TOCTOU
+	// gap by re-checking the actual opened descriptor, so a regular file
+	// swapped to a hard link / non-regular after the Lstat is caught here
+	// (gemini security-high on PR #846).
+	fi, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, errors.WithStack(err)
+	}
+	if !fi.Mode().IsRegular() {
+		_ = f.Close()
+		return nil, errors.Wrapf(ErrSQSEncodeNotRegular, "%s (mode=%s)", rel, fi.Mode())
+	}
+	if err := refuseHardLink(fi, rel); err != nil {
+		_ = f.Close()
+		return nil, err
 	}
 	return f, nil
 }
@@ -337,6 +356,10 @@ func marshalStoredSQS(magic []byte, v any) ([]byte, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	// const-capacity, zero-length start + append (magic then body): keeps
+	// the len(magic)+len(body) arithmetic out of make() — which CodeQL
+	// flags as a potential allocation-size overflow — while makezero stays
+	// happy. Same pattern as marshalStoredDDBSchema/Item.
 	out := make([]byte, 0, len(magic))
 	out = append(out, magic...)
 	return append(out, body...), nil

--- a/internal/backup/encode_sqs.go
+++ b/internal/backup/encode_sqs.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
-	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -21,7 +20,8 @@ import (
 // plus the generation and (FIFO) sequence counters:
 //   - _queue.json        -> !sqs|queue|meta|  (storedSQSMetaMagic + JSON) + !sqs|queue|gen|
 //   - messages.jsonl     -> !sqs|msg|data|    (storedSQSMsgMagic + JSON), one per line
-//   - (FIFO) seq counter -> !sqs|queue|seq|   = max(sequence_number)+1
+//   - (FIFO) seq counter -> !sqs|queue|seq|   = max(sequence_number)
+//     (last issued — matches adapter/sqs_fifo.go's loadFifoSequence + prevSeq+1)
 //
 // The derived side records (!sqs|msg|{vis,byage,dedup,group}) — re-derivable
 // from the message set + config — land in a follow-up slice (M5-2, the
@@ -215,17 +215,16 @@ func (e *SQSRecordEncoder) encodeQueueMessages(b *snapshotBuilder, root *os.Root
 			maxSeq = seq
 		}
 	}
-	if meta.FIFO {
-		// The sequence counter is the next value the live FIFO send path
-		// will allocate; restore it to max(seen)+1 so it never reissues a
-		// sequence number an existing message already holds. Fail closed
-		// at the uint64 ceiling rather than wrap to 0 (which would reissue
-		// sequence 1 and break FIFO ordering) — coderabbit Major #846.
-		if maxSeq == math.MaxUint64 {
-			return errors.Wrapf(ErrSQSEncodeInvalidMessage,
-				"%s: sequence_number at uint64 max, cannot advance the counter", meta.Name)
-		}
-		seqVal := []byte(strconv.FormatUint(maxSeq+1, 10))
+	if meta.FIFO && maxSeq > 0 {
+		// The live FIFO send path (adapter/sqs_fifo.go: loadFifoSequence
+		// + prevSeq+1) reads this key as the LAST issued sequence number
+		// and advances by one before writing back. To preserve that
+		// contract on restore, store max(seen) — not max+1, which would
+		// cause the next send to skip a sequence number (codex P1 #846).
+		// Empty FIFO queues (maxSeq == 0) emit no counter at all,
+		// mirroring the live "no send yet" state where the missing key
+		// reads as 0 and the first send issues sequence 1.
+		seqVal := []byte(strconv.FormatUint(maxSeq, 10))
 		if err := b.Add(sqsQueueSeqKeyBytes(meta.Name), seqVal, 0); err != nil {
 			return err
 		}

--- a/internal/backup/encode_sqs.go
+++ b/internal/backup/encode_sqs.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -217,7 +218,13 @@ func (e *SQSRecordEncoder) encodeQueueMessages(b *snapshotBuilder, root *os.Root
 	if meta.FIFO {
 		// The sequence counter is the next value the live FIFO send path
 		// will allocate; restore it to max(seen)+1 so it never reissues a
-		// sequence number an existing message already holds.
+		// sequence number an existing message already holds. Fail closed
+		// at the uint64 ceiling rather than wrap to 0 (which would reissue
+		// sequence 1 and break FIFO ordering) — coderabbit Major #846.
+		if maxSeq == math.MaxUint64 {
+			return errors.Wrapf(ErrSQSEncodeInvalidMessage,
+				"%s: sequence_number at uint64 max, cannot advance the counter", meta.Name)
+		}
 		seqVal := []byte(strconv.FormatUint(maxSeq+1, 10))
 		if err := b.Add(sqsQueueSeqKeyBytes(meta.Name), seqVal, 0); err != nil {
 			return err

--- a/internal/backup/encode_sqs.go
+++ b/internal/backup/encode_sqs.go
@@ -1,0 +1,370 @@
+package backup
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/cockroachdb/errors"
+)
+
+// encode_sqs.go is the Phase 0b SQS reverse encoder — the inverse of the
+// SQS decoder in sqs.go (type SQSEncoder, which turns internal !sqs|*
+// records into an sqs/<queue>/ dump tree). Design:
+// docs/design/2026_05_25_proposed_snapshot_logical_encoder.md §"SQS".
+//
+// This slice (M5-1) covers the QUEUE config and the MESSAGE data records,
+// plus the generation and (FIFO) sequence counters:
+//   - _queue.json        -> !sqs|queue|meta|  (storedSQSMetaMagic + JSON) + !sqs|queue|gen|
+//   - messages.jsonl     -> !sqs|msg|data|    (storedSQSMsgMagic + JSON), one per line
+//   - (FIFO) seq counter -> !sqs|queue|seq|   = max(sequence_number)+1
+//
+// The derived side records (!sqs|msg|{vis,byage,dedup,group}) — re-derivable
+// from the message set + config — land in a follow-up slice (M5-2, the
+// design's side-record decision gate). Visibility state restores zeroed
+// (every message visible), matching the decoder's default.
+//
+// Generation: a uniform sqsRestoreGeneration is stamped into the queue
+// meta's Generation field, the !sqs|queue|gen| counter, and every message
+// key + each message's queue_generation, matching the Option-B decision
+// used by the DynamoDB/S3 encoders. The original generation/incarnation,
+// created-at timestamps, tags, and throttle config are not represented in
+// the dump and restore to their zero values.
+//
+// Partitioned (HT-FIFO) queues (partition_count > 1) use a different key
+// family (SqsPartitionedMsg* in adapter/sqs_keys.go) that this slice does
+// not reproduce, so they fail closed rather than emit classic keys a
+// partitioned queue would never read.
+
+// sqsRestoreGeneration is the uniform generation stamped across the queue
+// meta, gen counter, and every message key (Option B; see file header).
+const sqsRestoreGeneration uint64 = 1
+
+var (
+	// ErrSQSEncodeInvalidQueue is returned when a _queue.json cannot be
+	// parsed or carries an empty queue name.
+	ErrSQSEncodeInvalidQueue = errors.New("backup: sqs encode invalid _queue.json")
+	// ErrSQSEncodeInvalidMessage is returned when a messages.jsonl line
+	// cannot be parsed.
+	ErrSQSEncodeInvalidMessage = errors.New("backup: sqs encode invalid messages.jsonl")
+	// ErrSQSEncodeNotRegular is returned when a dump file is not a regular
+	// file (symlink / FIFO / device / directory).
+	ErrSQSEncodeNotRegular = errors.New("backup: sqs dump file is not a regular file")
+	// ErrSQSEncodeUnsupportedPartitioned is returned for HT-FIFO queues
+	// (partition_count > 1), whose partitioned key family this slice does
+	// not yet reproduce.
+	ErrSQSEncodeUnsupportedPartitioned = errors.New("backup: sqs partitioned (HT-FIFO) queue not yet supported by encoder")
+)
+
+// sqsStoredQueueMeta mirrors the live adapter's sqsQueueMeta JSON shape
+// (adapter/sqs_catalog.go). The encoder fills the fields recoverable from
+// _queue.json plus the uniform restore generation; the rest default.
+type sqsStoredQueueMeta struct {
+	Name                      string `json:"name"`
+	Generation                uint64 `json:"generation"`
+	IsFIFO                    bool   `json:"is_fifo,omitempty"`
+	ContentBasedDedup         bool   `json:"content_based_dedup,omitempty"`
+	VisibilityTimeoutSeconds  int64  `json:"visibility_timeout_seconds"`
+	MessageRetentionSeconds   int64  `json:"message_retention_seconds"`
+	DelaySeconds              int64  `json:"delay_seconds"`
+	ReceiveMessageWaitSeconds int64  `json:"receive_message_wait_seconds"`
+	MaximumMessageSize        int64  `json:"maximum_message_size"`
+	RedrivePolicy             string `json:"redrive_policy,omitempty"`
+	PartitionCount            uint32 `json:"partition_count,omitempty"`
+	FifoThroughputLimit       string `json:"fifo_throughput_limit,omitempty"`
+	DeduplicationScope        string `json:"deduplication_scope,omitempty"`
+}
+
+// sqsStoredMessage mirrors the live adapter's message value JSON
+// (adapter/sqs_messages.go). Body is a base64-std []byte (Go default) and
+// MessageAttributes pass through as raw JSON, so the emitted value is
+// byte-compatible with what the live adapter writes.
+type sqsStoredMessage struct {
+	MessageID              string                     `json:"message_id"`
+	Body                   []byte                     `json:"body"`
+	MD5OfBody              string                     `json:"md5_of_body"`
+	MD5OfMessageAttributes string                     `json:"md5_of_message_attributes,omitempty"`
+	MessageAttributes      map[string]json.RawMessage `json:"message_attributes,omitempty"`
+	SenderID               string                     `json:"sender_id,omitempty"`
+	SendTimestampMillis    int64                      `json:"send_timestamp_millis"`
+	AvailableAtMillis      int64                      `json:"available_at_millis"`
+	VisibleAtMillis        int64                      `json:"visible_at_millis"`
+	ReceiveCount           int64                      `json:"receive_count"`
+	FirstReceiveMillis     int64                      `json:"first_receive_millis,omitempty"`
+	CurrentReceiptToken    []byte                     `json:"current_receipt_token"`
+	QueueGeneration        uint64                     `json:"queue_generation"`
+	MessageGroupID         string                     `json:"message_group_id,omitempty"`
+	MessageDeduplicationID string                     `json:"message_deduplication_id,omitempty"`
+	SequenceNumber         uint64                     `json:"sequence_number,omitempty"`
+	DeadLetterSourceArn    string                     `json:"dead_letter_source_arn,omitempty"`
+}
+
+// SQSRecordEncoder reconstructs the internal SQS keyspace from the decoded
+// sqs/ directory tree. (Named distinctly from the decoder's SQSEncoder in
+// sqs.go.)
+type SQSRecordEncoder struct {
+	inRoot string
+}
+
+// NewSQSRecordEncoder constructs an encoder rooted at <inRoot>/sqs/.
+func NewSQSRecordEncoder(inRoot string) *SQSRecordEncoder {
+	return &SQSRecordEncoder{inRoot: inRoot}
+}
+
+func (e *SQSRecordEncoder) sqsDir() string {
+	return filepath.Join(e.inRoot, "sqs")
+}
+
+// Encode walks sqs/<queue>/ and stages each queue's meta + counters +
+// message records. A missing sqs/ directory is not an error.
+func (e *SQSRecordEncoder) Encode(b *snapshotBuilder) error {
+	dir := e.sqsDir()
+	if err := lstatDumpDir(dir); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer func() { _ = root.Close() }()
+	entries, err := readRootDirEntries(root)
+	if err != nil {
+		return err
+	}
+	for _, ent := range entries {
+		if !ent.IsDir() {
+			continue
+		}
+		if err := e.encodeQueue(b, root, ent.Name()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// encodeQueue reads one <queue>/_queue.json + messages.jsonl and stages the
+// queue meta, generation/sequence counters, and message data records.
+func (e *SQSRecordEncoder) encodeQueue(b *snapshotBuilder, root *os.Root, queueDir string) error {
+	meta, err := e.readQueueMeta(root, queueDir)
+	if err != nil {
+		return err
+	}
+	if meta.Name == "" {
+		return errors.Wrapf(ErrSQSEncodeInvalidQueue, "%s/_queue.json: empty queue name", queueDir)
+	}
+	if meta.PartitionCount > 1 {
+		return errors.Wrapf(ErrSQSEncodeUnsupportedPartitioned,
+			"%s: partition_count %d", queueDir, meta.PartitionCount)
+	}
+	if err := e.addQueueMeta(b, meta); err != nil {
+		return err
+	}
+	return e.encodeQueueMessages(b, root, queueDir, meta)
+}
+
+// addQueueMeta stages the !sqs|queue|meta| record and the !sqs|queue|gen|
+// counter.
+func (e *SQSRecordEncoder) addQueueMeta(b *snapshotBuilder, pub sqsQueueMetaPublic) error {
+	stored := sqsStoredQueueMeta{
+		Name:                      pub.Name,
+		Generation:                sqsRestoreGeneration,
+		IsFIFO:                    pub.FIFO,
+		ContentBasedDedup:         pub.ContentBasedDeduplication,
+		VisibilityTimeoutSeconds:  pub.VisibilityTimeoutSeconds,
+		MessageRetentionSeconds:   pub.MessageRetentionSeconds,
+		DelaySeconds:              pub.DelaySeconds,
+		ReceiveMessageWaitSeconds: pub.ReceiveMessageWaitSeconds,
+		MaximumMessageSize:        pub.MaximumMessageSize,
+		RedrivePolicy:             pub.RedrivePolicy,
+		PartitionCount:            pub.PartitionCount,
+		FifoThroughputLimit:       pub.FifoThroughputLimit,
+		DeduplicationScope:        pub.DeduplicationScope,
+	}
+	metaVal, err := marshalStoredSQS(storedSQSMetaMagic, stored)
+	if err != nil {
+		return err
+	}
+	if err := b.Add(sqsQueueMetaKeyBytes(pub.Name), metaVal, 0); err != nil {
+		return err
+	}
+	genVal := []byte(strconv.FormatUint(sqsRestoreGeneration, 10))
+	return b.Add(sqsQueueGenKeyBytes(pub.Name), genVal, 0)
+}
+
+// encodeQueueMessages reads messages.jsonl and stages a !sqs|msg|data|
+// record per message, then (for FIFO queues) the !sqs|queue|seq| counter.
+func (e *SQSRecordEncoder) encodeQueueMessages(b *snapshotBuilder, root *os.Root, queueDir string, meta sqsQueueMetaPublic) error {
+	records, err := e.readMessages(root, queueDir)
+	if err != nil {
+		return err
+	}
+	var maxSeq uint64
+	for i := range records {
+		seq, err := e.addMessage(b, meta.Name, records[i])
+		if err != nil {
+			return err
+		}
+		if seq > maxSeq {
+			maxSeq = seq
+		}
+	}
+	if meta.FIFO {
+		// The sequence counter is the next value the live FIFO send path
+		// will allocate; restore it to max(seen)+1 so it never reissues a
+		// sequence number an existing message already holds.
+		seqVal := []byte(strconv.FormatUint(maxSeq+1, 10))
+		if err := b.Add(sqsQueueSeqKeyBytes(meta.Name), seqVal, 0); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// addMessage stages one !sqs|msg|data| record and returns the message's
+// sequence number (for the seq-counter computation). Visibility state is
+// zeroed (every message restores visible), matching the decoder default.
+func (e *SQSRecordEncoder) addMessage(b *snapshotBuilder, queueName string, rec sqsMessageRecord) (uint64, error) {
+	if rec.MessageID == "" {
+		return 0, errors.Wrap(ErrSQSEncodeInvalidMessage, "message missing message_id")
+	}
+	stored := sqsStoredMessage{
+		MessageID:              rec.MessageID,
+		Body:                   []byte(rec.Body),
+		MD5OfBody:              rec.MD5OfBody,
+		MD5OfMessageAttributes: rec.MD5OfMessageAttributes,
+		MessageAttributes:      rec.MessageAttributes,
+		SenderID:               rec.SenderID,
+		SendTimestampMillis:    rec.SendTimestampMillis,
+		AvailableAtMillis:      rec.AvailableAtMillis,
+		VisibleAtMillis:        0,
+		ReceiveCount:           0,
+		FirstReceiveMillis:     0,
+		CurrentReceiptToken:    nil,
+		QueueGeneration:        sqsRestoreGeneration,
+		MessageGroupID:         rec.MessageGroupID,
+		MessageDeduplicationID: rec.MessageDedupID,
+		SequenceNumber:         rec.SequenceNumber,
+		DeadLetterSourceArn:    rec.DeadLetterSourceArn,
+	}
+	val, err := marshalStoredSQS(storedSQSMsgMagic, stored)
+	if err != nil {
+		return 0, err
+	}
+	key := sqsMsgDataKeyBytes(queueName, sqsRestoreGeneration, rec.MessageID)
+	if err := b.Add(key, val, 0); err != nil {
+		return 0, err
+	}
+	return rec.SequenceNumber, nil
+}
+
+// openSQSRootFile opens rel within root with the Lstat + IsRegular +
+// refuseHardLink guard (refusing a symlink / FIFO / device / directory
+// before the read), the same pattern the DynamoDB schema reader uses. A
+// missing file surfaces as a wrapped os.ErrNotExist so callers can treat
+// an absent optional file as empty.
+func (e *SQSRecordEncoder) openSQSRootFile(root *os.Root, rel string) (*os.File, error) {
+	linfo, err := root.Lstat(rel)
+	if err != nil {
+		return nil, errors.WithStack(err) // wraps os.ErrNotExist when absent
+	}
+	if !linfo.Mode().IsRegular() {
+		return nil, errors.Wrapf(ErrSQSEncodeNotRegular, "%s (mode=%s)", rel, linfo.Mode())
+	}
+	if err := refuseHardLink(linfo, rel); err != nil {
+		return nil, err
+	}
+	f, err := root.Open(rel)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return f, nil
+}
+
+// readQueueMeta opens <queue>/_queue.json within root (symlink / FIFO /
+// hard-link safe) and decodes the public queue projection.
+func (e *SQSRecordEncoder) readQueueMeta(root *os.Root, queueDir string) (sqsQueueMetaPublic, error) {
+	rel := filepath.Join(queueDir, "_queue.json")
+	f, err := e.openSQSRootFile(root, rel)
+	if err != nil {
+		return sqsQueueMetaPublic{}, err
+	}
+	defer func() { _ = f.Close() }()
+	var pub sqsQueueMetaPublic
+	if err := decodeOneJSON(f, &pub); err != nil {
+		return sqsQueueMetaPublic{}, errors.Wrapf(ErrSQSEncodeInvalidQueue, "%s: %v", rel, err)
+	}
+	if pub.FormatVersion != 1 {
+		return sqsQueueMetaPublic{}, errors.Wrapf(ErrSQSEncodeInvalidQueue,
+			"%s: unsupported format_version %d", rel, pub.FormatVersion)
+	}
+	return pub, nil
+}
+
+// readMessages reads <queue>/messages.jsonl (one sqsMessageRecord per
+// line). A missing file means an empty queue.
+func (e *SQSRecordEncoder) readMessages(root *os.Root, queueDir string) ([]sqsMessageRecord, error) {
+	rel := filepath.Join(queueDir, "messages.jsonl")
+	f, err := e.openSQSRootFile(root, rel)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	dec := json.NewDecoder(f)
+	var out []sqsMessageRecord
+	for dec.More() {
+		var rec sqsMessageRecord
+		if err := dec.Decode(&rec); err != nil {
+			return nil, errors.Wrapf(ErrSQSEncodeInvalidMessage, "%s: %v", rel, err)
+		}
+		out = append(out, rec)
+	}
+	return out, nil
+}
+
+// marshalStoredSQS builds magic + deterministic JSON for a stored SQS
+// value.
+func marshalStoredSQS(magic []byte, v any) ([]byte, error) {
+	body, err := json.Marshal(v)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	out := make([]byte, 0, len(magic))
+	out = append(out, magic...)
+	return append(out, body...), nil
+}
+
+// encodeSQSSegment mirrors adapter/sqs_keys.go: base64 raw-URL (never
+// emits the '|' separator).
+func encodeSQSSegment(v string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(v))
+}
+
+func sqsQueueMetaKeyBytes(queueName string) []byte {
+	return []byte(SQSQueueMetaPrefix + encodeSQSSegment(queueName))
+}
+
+func sqsQueueGenKeyBytes(queueName string) []byte {
+	return []byte(SQSQueueGenPrefix + encodeSQSSegment(queueName))
+}
+
+func sqsQueueSeqKeyBytes(queueName string) []byte {
+	return []byte(SQSQueueSeqPrefix + encodeSQSSegment(queueName))
+}
+
+// sqsMsgDataKeyBytes reproduces adapter/sqs_messages.go sqsMsgDataKey:
+// prefix + base64url(queue) + BE-u64(gen) + base64url(messageID).
+func sqsMsgDataKeyBytes(queueName string, generation uint64, messageID string) []byte {
+	out := []byte(SQSMsgDataPrefix)
+	out = append(out, encodeSQSSegment(queueName)...)
+	out = binary.BigEndian.AppendUint64(out, generation)
+	return append(out, encodeSQSSegment(messageID)...)
+}

--- a/internal/backup/encode_sqs_test.go
+++ b/internal/backup/encode_sqs_test.go
@@ -1,0 +1,210 @@
+package backup
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+)
+
+const sqsEncTS uint64 = 0x0001_8F1A_2B3C_00EE
+
+// writeSQSQueue writes a _queue.json and messages.jsonl under
+// <root>/sqs/<EncodeSegment(queue)>/.
+func writeSQSQueue(t *testing.T, root, queue string, queueJSON []byte, msgLines [][]byte) {
+	t.Helper()
+	dir := filepath.Join(root, "sqs", EncodeSegment([]byte(queue)))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "_queue.json"), queueJSON, 0o600); err != nil {
+		t.Fatalf("WriteFile _queue.json: %v", err)
+	}
+	if len(msgLines) > 0 {
+		if err := os.WriteFile(filepath.Join(dir, "messages.jsonl"), bytes.Join(msgLines, []byte("\n")), 0o600); err != nil {
+			t.Fatalf("WriteFile messages.jsonl: %v", err)
+		}
+	}
+}
+
+// encodeSQSTree runs the SQS reverse encoder over inRoot and returns the
+// EKVPBBL1 bytes.
+func encodeSQSTree(t *testing.T, inRoot string) []byte {
+	t.Helper()
+	b := newSnapshotBuilder(sqsEncTS)
+	if err := NewSQSRecordEncoder(inRoot).Encode(b); err != nil {
+		t.Fatalf("SQSRecordEncoder.Encode: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := b.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// decodeSQSAndRead decodes fsm and returns the queue's _queue.json and its
+// messages.jsonl records.
+func decodeSQSAndRead(t *testing.T, fsm []byte, queue string) (sqsQueueMetaPublic, []sqsMessageRecord) {
+	t.Helper()
+	out := t.TempDir()
+	if _, err := DecodeSnapshot(bytes.NewReader(fsm), DecodeOptions{
+		OutRoot:  out,
+		Adapters: AdapterSet{SQS: true},
+	}); err != nil {
+		t.Fatalf("DecodeSnapshot: %v", err)
+	}
+	dir := filepath.Join(out, "sqs", EncodeSegment([]byte(queue)))
+	metaData, err := os.ReadFile(filepath.Join(dir, "_queue.json"))
+	if err != nil {
+		t.Fatalf("read decoded _queue.json: %v", err)
+	}
+	var meta sqsQueueMetaPublic
+	if err := json.Unmarshal(metaData, &meta); err != nil {
+		t.Fatalf("unmarshal decoded _queue.json: %v", err)
+	}
+	var msgs []sqsMessageRecord
+	f, err := os.Open(filepath.Join(dir, "messages.jsonl"))
+	if err == nil {
+		defer func() { _ = f.Close() }()
+		sc := bufio.NewScanner(f)
+		sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+		for sc.Scan() {
+			line := sc.Bytes()
+			if len(bytes.TrimSpace(line)) == 0 {
+				continue
+			}
+			var rec sqsMessageRecord
+			if err := json.Unmarshal(line, &rec); err != nil {
+				t.Fatalf("unmarshal decoded message: %v", err)
+			}
+			msgs = append(msgs, rec)
+		}
+	}
+	return meta, msgs
+}
+
+// TestSQSEncodeStandardQueueRoundTrip pins the gold-standard round-trip
+// for a standard (non-FIFO) queue with two messages.
+func TestSQSEncodeStandardQueueRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const queue = "orders"
+	writeSQSQueue(t, in, queue, []byte(`{"format_version":1,"name":"orders",`+
+		`"visibility_timeout_seconds":30,"message_retention_seconds":345600,"delay_seconds":0}`),
+		[][]byte{
+			[]byte(`{"message_id":"m1","body":"hello","send_timestamp_millis":1000,"available_at_millis":1000}`),
+			[]byte(`{"message_id":"m2","body":"world","send_timestamp_millis":2000,"available_at_millis":2000}`),
+		})
+
+	meta, msgs := decodeSQSAndRead(t, encodeSQSTree(t, in), queue)
+	if meta.Name != queue || meta.VisibilityTimeoutSeconds != 30 || meta.MessageRetentionSeconds != 345600 {
+		t.Fatalf("decoded meta = %+v", meta)
+	}
+	got := map[string]string{}
+	for _, m := range msgs {
+		got[m.MessageID] = string(m.Body)
+	}
+	if len(got) != 2 || got["m1"] != "hello" || got["m2"] != "world" {
+		t.Fatalf("decoded messages = %#v", got)
+	}
+}
+
+// TestSQSEncodeFifoSeqCounter pins that a FIFO queue emits a
+// !sqs|queue|seq| counter = max(sequence_number)+1, and the message bodies
+// round-trip.
+func TestSQSEncodeFifoSeqCounter(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const queue = "orders.fifo"
+	writeSQSQueue(t, in, queue, []byte(`{"format_version":1,"name":"orders.fifo","fifo":true,`+
+		`"visibility_timeout_seconds":30,"message_retention_seconds":345600,"delay_seconds":0}`),
+		[][]byte{
+			[]byte(`{"message_id":"m1","body":"a","send_timestamp_millis":1000,"available_at_millis":1000,"message_group_id":"g","sequence_number":5}`),
+			[]byte(`{"message_id":"m2","body":"b","send_timestamp_millis":2000,"available_at_millis":2000,"message_group_id":"g","sequence_number":9}`),
+		})
+
+	entries, _, err := DecodeLiveEntries(bytes.NewReader(encodeSQSTree(t, in)))
+	if err != nil {
+		t.Fatalf("DecodeLiveEntries: %v", err)
+	}
+	seq := sqsFindEntry(entries, sqsQueueSeqKeyBytes(queue))
+	if seq == nil {
+		t.Fatal("no !sqs|queue|seq| counter emitted for FIFO queue")
+	}
+	if got := string(seq.UserValue); got != "10" {
+		t.Fatalf("seq counter = %q, want \"10\" (max 9 + 1)", got)
+	}
+	gen := sqsFindEntry(entries, sqsQueueGenKeyBytes(queue))
+	if gen == nil || string(gen.UserValue) != strconv.FormatUint(sqsRestoreGeneration, 10) {
+		t.Fatalf("gen counter = %v, want %d", gen, sqsRestoreGeneration)
+	}
+}
+
+// sqsFindEntry returns the first live entry with the given user key, or nil.
+func sqsFindEntry(entries []RoundTripEntry, key []byte) *RoundTripEntry {
+	for i := range entries {
+		if bytes.Equal(entries[i].UserKey, key) {
+			return &entries[i]
+		}
+	}
+	return nil
+}
+
+// TestSQSEncodeBinaryBodyRoundTrip pins that a non-UTF-8 message body
+// (stored as a {base64:...} envelope in messages.jsonl) round-trips.
+func TestSQSEncodeBinaryBodyRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const queue = "bin"
+	// body bytes {0xFF,0x00,0xFE} are not valid UTF-8 → base64url envelope.
+	writeSQSQueue(t, in, queue, []byte(`{"format_version":1,"name":"bin",`+
+		`"visibility_timeout_seconds":30,"message_retention_seconds":345600,"delay_seconds":0}`),
+		[][]byte{
+			[]byte(`{"message_id":"b1","body":{"base64":"_wD-"},"send_timestamp_millis":1000,"available_at_millis":1000}`),
+		})
+
+	_, msgs := decodeSQSAndRead(t, encodeSQSTree(t, in), queue)
+	if len(msgs) != 1 || !bytes.Equal([]byte(msgs[0].Body), []byte{0xFF, 0x00, 0xFE}) {
+		t.Fatalf("binary body round-trip = %x", []byte(msgs[0].Body))
+	}
+}
+
+// TestSQSEncodeRejectsPartitioned pins fail-closed for an HT-FIFO queue.
+func TestSQSEncodeRejectsPartitioned(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	writeSQSQueue(t, in, "ht.fifo", []byte(`{"format_version":1,"name":"ht.fifo","fifo":true,`+
+		`"visibility_timeout_seconds":30,"message_retention_seconds":345600,"delay_seconds":0,"partition_count":4}`), nil)
+	b := newSnapshotBuilder(sqsEncTS)
+	if err := NewSQSRecordEncoder(in).Encode(b); !errors.Is(err, ErrSQSEncodeUnsupportedPartitioned) {
+		t.Fatalf("Encode err = %v, want ErrSQSEncodeUnsupportedPartitioned", err)
+	}
+}
+
+// TestSQSEncodeMissingDirIsNoop pins that an absent sqs/ dir is a no-op.
+func TestSQSEncodeMissingDirIsNoop(t *testing.T) {
+	t.Parallel()
+	b := newSnapshotBuilder(sqsEncTS)
+	if err := NewSQSRecordEncoder(t.TempDir()).Encode(b); err != nil {
+		t.Fatalf("Encode on empty tree: %v", err)
+	}
+	if b.Len() != 0 {
+		t.Fatalf("entries = %d, want 0", b.Len())
+	}
+}
+
+// TestSQSEncodeRejectsUnknownFormatVersion pins the _queue.json format gate.
+func TestSQSEncodeRejectsUnknownFormatVersion(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	writeSQSQueue(t, in, "q", []byte(`{"format_version":99,"name":"q"}`), nil)
+	b := newSnapshotBuilder(sqsEncTS)
+	if err := NewSQSRecordEncoder(in).Encode(b); !errors.Is(err, ErrSQSEncodeInvalidQueue) {
+		t.Fatalf("Encode err = %v, want ErrSQSEncodeInvalidQueue", err)
+	}
+}

--- a/internal/backup/encode_sqs_test.go
+++ b/internal/backup/encode_sqs_test.go
@@ -67,25 +67,39 @@ func decodeSQSAndRead(t *testing.T, fsm []byte, queue string) (sqsQueueMetaPubli
 	if err := json.Unmarshal(metaData, &meta); err != nil {
 		t.Fatalf("unmarshal decoded _queue.json: %v", err)
 	}
-	var msgs []sqsMessageRecord
+	return meta, readDecodedSQSMessages(t, dir)
+}
+
+// readDecodedSQSMessages reads a decoded messages.jsonl (absent = empty
+// queue), failing the test on any open/scan/parse error.
+func readDecodedSQSMessages(t *testing.T, dir string) []sqsMessageRecord {
+	t.Helper()
 	f, err := os.Open(filepath.Join(dir, "messages.jsonl"))
-	if err == nil {
-		defer func() { _ = f.Close() }()
-		sc := bufio.NewScanner(f)
-		sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
-		for sc.Scan() {
-			line := sc.Bytes()
-			if len(bytes.TrimSpace(line)) == 0 {
-				continue
-			}
-			var rec sqsMessageRecord
-			if err := json.Unmarshal(line, &rec); err != nil {
-				t.Fatalf("unmarshal decoded message: %v", err)
-			}
-			msgs = append(msgs, rec)
-		}
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
 	}
-	return meta, msgs
+	if err != nil {
+		t.Fatalf("open decoded messages.jsonl: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	var msgs []sqsMessageRecord
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var rec sqsMessageRecord
+		if jerr := json.Unmarshal(line, &rec); jerr != nil {
+			t.Fatalf("unmarshal decoded message: %v", jerr)
+		}
+		msgs = append(msgs, rec)
+	}
+	if serr := sc.Err(); serr != nil {
+		t.Fatalf("scan decoded messages.jsonl: %v", serr)
+	}
+	return msgs
 }
 
 // TestSQSEncodeStandardQueueRoundTrip pins the gold-standard round-trip
@@ -169,7 +183,10 @@ func TestSQSEncodeBinaryBodyRoundTrip(t *testing.T) {
 		})
 
 	_, msgs := decodeSQSAndRead(t, encodeSQSTree(t, in), queue)
-	if len(msgs) != 1 || !bytes.Equal([]byte(msgs[0].Body), []byte{0xFF, 0x00, 0xFE}) {
+	if len(msgs) != 1 {
+		t.Fatalf("decoded %d messages, want 1", len(msgs))
+	}
+	if !bytes.Equal([]byte(msgs[0].Body), []byte{0xFF, 0x00, 0xFE}) {
 		t.Fatalf("binary body round-trip = %x", []byte(msgs[0].Body))
 	}
 }
@@ -212,6 +229,44 @@ func TestSQSEncodeRejectsEmptyMessageID(t *testing.T) {
 	b := newSnapshotBuilder(sqsEncTS)
 	if err := NewSQSRecordEncoder(in).Encode(b); !errors.Is(err, ErrSQSEncodeInvalidMessage) {
 		t.Fatalf("Encode err = %v, want ErrSQSEncodeInvalidMessage", err)
+	}
+}
+
+// TestSQSEncodeRejectsMaxSequence pins that a FIFO message at the uint64
+// sequence ceiling fails closed rather than wrapping the seq counter to 0.
+func TestSQSEncodeRejectsMaxSequence(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const queue = "max.fifo"
+	writeSQSQueue(t, in, queue, []byte(`{"format_version":1,"name":"max.fifo","fifo":true,`+
+		`"visibility_timeout_seconds":30,"message_retention_seconds":345600,"delay_seconds":0}`),
+		[][]byte{
+			[]byte(`{"message_id":"m1","body":"a","send_timestamp_millis":1,"available_at_millis":1,"message_group_id":"g","sequence_number":18446744073709551615}`),
+		})
+	b := newSnapshotBuilder(sqsEncTS)
+	if err := NewSQSRecordEncoder(in).Encode(b); !errors.Is(err, ErrSQSEncodeInvalidMessage) {
+		t.Fatalf("Encode err = %v, want ErrSQSEncodeInvalidMessage", err)
+	}
+}
+
+// TestSQSEncodeRejectsMalformedBodyObject pins that a non-string body
+// object that is not a {base64:...} envelope fails closed rather than
+// silently restoring an empty body.
+func TestSQSEncodeRejectsMalformedBodyObject(t *testing.T) {
+	t.Parallel()
+	// Note: a JSON `null` body is not covered — encoding/json skips
+	// UnmarshalJSON for null, leaving an empty body (lenient, and
+	// unreachable from a decoder-produced dump).
+	for _, body := range []string{`{}`, `{"oops":"x"}`} {
+		in := t.TempDir()
+		const queue = "q"
+		writeSQSQueue(t, in, queue, []byte(`{"format_version":1,"name":"q",`+
+			`"visibility_timeout_seconds":30,"message_retention_seconds":345600,"delay_seconds":0}`),
+			[][]byte{[]byte(`{"message_id":"m1","body":` + body + `,"send_timestamp_millis":1,"available_at_millis":1}`)})
+		b := newSnapshotBuilder(sqsEncTS)
+		if err := NewSQSRecordEncoder(in).Encode(b); !errors.Is(err, ErrSQSEncodeInvalidMessage) {
+			t.Fatalf("body %s: Encode err = %v, want ErrSQSEncodeInvalidMessage", body, err)
+		}
 	}
 }
 

--- a/internal/backup/encode_sqs_test.go
+++ b/internal/backup/encode_sqs_test.go
@@ -186,6 +186,35 @@ func TestSQSEncodeRejectsPartitioned(t *testing.T) {
 	}
 }
 
+// TestSQSEncodeRejectsNonRegularQueueMeta pins the file guard: a
+// _queue.json that is a directory is refused with ErrSQSEncodeNotRegular.
+func TestSQSEncodeRejectsNonRegularQueueMeta(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(in, "sqs", EncodeSegment([]byte("q")), "_queue.json"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	b := newSnapshotBuilder(sqsEncTS)
+	if err := NewSQSRecordEncoder(in).Encode(b); !errors.Is(err, ErrSQSEncodeNotRegular) {
+		t.Fatalf("Encode err = %v, want ErrSQSEncodeNotRegular", err)
+	}
+}
+
+// TestSQSEncodeRejectsEmptyMessageID pins fail-closed on a message lacking
+// a message_id (which would otherwise key on the empty string).
+func TestSQSEncodeRejectsEmptyMessageID(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const queue = "q-emptyid"
+	writeSQSQueue(t, in, queue, []byte(`{"format_version":1,"name":"q-emptyid",`+
+		`"visibility_timeout_seconds":30,"message_retention_seconds":345600,"delay_seconds":0}`),
+		[][]byte{[]byte(`{"message_id":"","body":"x","send_timestamp_millis":1,"available_at_millis":1}`)})
+	b := newSnapshotBuilder(sqsEncTS)
+	if err := NewSQSRecordEncoder(in).Encode(b); !errors.Is(err, ErrSQSEncodeInvalidMessage) {
+		t.Fatalf("Encode err = %v, want ErrSQSEncodeInvalidMessage", err)
+	}
+}
+
 // TestSQSEncodeMissingDirIsNoop pins that an absent sqs/ dir is a no-op.
 func TestSQSEncodeMissingDirIsNoop(t *testing.T) {
 	t.Parallel()

--- a/internal/backup/encode_sqs_test.go
+++ b/internal/backup/encode_sqs_test.go
@@ -128,6 +128,30 @@ func TestSQSEncodeStandardQueueRoundTrip(t *testing.T) {
 	}
 }
 
+// TestSQSEncodeStandardQueueCounters pins that a standard (non-FIFO)
+// queue emits the !sqs|queue|gen| counter but NO !sqs|queue|seq| counter
+// (the sequence counter is FIFO-only).
+func TestSQSEncodeStandardQueueCounters(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const queue = "std"
+	writeSQSQueue(t, in, queue, []byte(`{"format_version":1,"name":"std",`+
+		`"visibility_timeout_seconds":30,"message_retention_seconds":345600,"delay_seconds":0}`),
+		[][]byte{[]byte(`{"message_id":"m1","body":"x","send_timestamp_millis":1,"available_at_millis":1}`)})
+
+	entries, _, err := DecodeLiveEntries(bytes.NewReader(encodeSQSTree(t, in)))
+	if err != nil {
+		t.Fatalf("DecodeLiveEntries: %v", err)
+	}
+	gen := sqsFindEntry(entries, sqsQueueGenKeyBytes(queue))
+	if gen == nil || string(gen.UserValue) != strconv.FormatUint(sqsRestoreGeneration, 10) {
+		t.Fatalf("gen counter = %v, want %d", gen, sqsRestoreGeneration)
+	}
+	if seq := sqsFindEntry(entries, sqsQueueSeqKeyBytes(queue)); seq != nil {
+		t.Fatalf("standard queue emitted a !sqs|queue|seq| counter, want none")
+	}
+}
+
 // TestSQSEncodeFifoSeqCounter pins that a FIFO queue emits a
 // !sqs|queue|seq| counter = max(sequence_number)+1, and the message bodies
 // round-trip.

--- a/internal/backup/encode_sqs_test.go
+++ b/internal/backup/encode_sqs_test.go
@@ -153,8 +153,10 @@ func TestSQSEncodeStandardQueueCounters(t *testing.T) {
 }
 
 // TestSQSEncodeFifoSeqCounter pins that a FIFO queue emits a
-// !sqs|queue|seq| counter = max(sequence_number)+1, and the message bodies
-// round-trip.
+// !sqs|queue|seq| counter = max(sequence_number), matching the live FIFO
+// send path's "last issued" semantics (loadFifoSequence + prevSeq+1 in
+// adapter/sqs_fifo.go). Storing max+1 would cause the next live send to
+// skip a sequence number — codex P1 #846.
 func TestSQSEncodeFifoSeqCounter(t *testing.T) {
 	t.Parallel()
 	in := t.TempDir()
@@ -174,12 +176,32 @@ func TestSQSEncodeFifoSeqCounter(t *testing.T) {
 	if seq == nil {
 		t.Fatal("no !sqs|queue|seq| counter emitted for FIFO queue")
 	}
-	if got := string(seq.UserValue); got != "10" {
-		t.Fatalf("seq counter = %q, want \"10\" (max 9 + 1)", got)
+	if got := string(seq.UserValue); got != "9" {
+		t.Fatalf("seq counter = %q, want \"9\" (max sequence_number, last issued)", got)
 	}
 	gen := sqsFindEntry(entries, sqsQueueGenKeyBytes(queue))
 	if gen == nil || string(gen.UserValue) != strconv.FormatUint(sqsRestoreGeneration, 10) {
 		t.Fatalf("gen counter = %v, want %d", gen, sqsRestoreGeneration)
+	}
+}
+
+// TestSQSEncodeEmptyFifoQueueNoSeqCounter pins that a FIFO queue with no
+// messages emits NO !sqs|queue|seq| counter — mirrors the live "no FIFO
+// send yet" state (missing key reads as 0; first send issues sequence 1).
+// Writing 1 here would make the next live send issue sequence 2 instead.
+func TestSQSEncodeEmptyFifoQueueNoSeqCounter(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const queue = "empty.fifo"
+	writeSQSQueue(t, in, queue, []byte(`{"format_version":1,"name":"empty.fifo","fifo":true,`+
+		`"visibility_timeout_seconds":30,"message_retention_seconds":345600,"delay_seconds":0}`), nil)
+
+	entries, _, err := DecodeLiveEntries(bytes.NewReader(encodeSQSTree(t, in)))
+	if err != nil {
+		t.Fatalf("DecodeLiveEntries: %v", err)
+	}
+	if seq := sqsFindEntry(entries, sqsQueueSeqKeyBytes(queue)); seq != nil {
+		t.Fatalf("unexpected !sqs|queue|seq| counter for empty FIFO queue: %q", seq.UserValue)
 	}
 }
 
@@ -250,23 +272,6 @@ func TestSQSEncodeRejectsEmptyMessageID(t *testing.T) {
 	writeSQSQueue(t, in, queue, []byte(`{"format_version":1,"name":"q-emptyid",`+
 		`"visibility_timeout_seconds":30,"message_retention_seconds":345600,"delay_seconds":0}`),
 		[][]byte{[]byte(`{"message_id":"","body":"x","send_timestamp_millis":1,"available_at_millis":1}`)})
-	b := newSnapshotBuilder(sqsEncTS)
-	if err := NewSQSRecordEncoder(in).Encode(b); !errors.Is(err, ErrSQSEncodeInvalidMessage) {
-		t.Fatalf("Encode err = %v, want ErrSQSEncodeInvalidMessage", err)
-	}
-}
-
-// TestSQSEncodeRejectsMaxSequence pins that a FIFO message at the uint64
-// sequence ceiling fails closed rather than wrapping the seq counter to 0.
-func TestSQSEncodeRejectsMaxSequence(t *testing.T) {
-	t.Parallel()
-	in := t.TempDir()
-	const queue = "max.fifo"
-	writeSQSQueue(t, in, queue, []byte(`{"format_version":1,"name":"max.fifo","fifo":true,`+
-		`"visibility_timeout_seconds":30,"message_retention_seconds":345600,"delay_seconds":0}`),
-		[][]byte{
-			[]byte(`{"message_id":"m1","body":"a","send_timestamp_millis":1,"available_at_millis":1,"message_group_id":"g","sequence_number":18446744073709551615}`),
-		})
 	b := newSnapshotBuilder(sqsEncTS)
 	if err := NewSQSRecordEncoder(in).Encode(b); !errors.Is(err, ErrSQSEncodeInvalidMessage) {
 		t.Fatalf("Encode err = %v, want ErrSQSEncodeInvalidMessage", err)

--- a/internal/backup/sqs.go
+++ b/internal/backup/sqs.go
@@ -201,13 +201,23 @@ func (b *sqsMessageBody) UnmarshalJSON(data []byte) error {
 		*b = sqsMessageBody(s)
 		return nil
 	}
+	// Non-string: must be the exact {"base64":"..."} envelope. Reject {},
+	// null, and objects with other/extra keys (which would otherwise
+	// silently decode to an empty body) — a base64 pointer distinguishes
+	// "field absent" from "empty" and DisallowUnknownFields rejects stray
+	// keys (coderabbit Major on PR #846).
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
 	var envelope struct {
-		Base64 string `json:"base64"`
+		Base64 *string `json:"base64"`
 	}
-	if err := json.Unmarshal(data, &envelope); err != nil {
+	if err := dec.Decode(&envelope); err != nil {
 		return errors.WithStack(err)
 	}
-	raw, err := base64.RawURLEncoding.DecodeString(envelope.Base64)
+	if envelope.Base64 == nil {
+		return errors.WithStack(errors.New("sqs message body object missing base64 field"))
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(*envelope.Base64)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/backup/sqs.go
+++ b/internal/backup/sqs.go
@@ -192,6 +192,29 @@ func (b sqsMessageBody) MarshalJSON() ([]byte, error) {
 	return out, nil
 }
 
+// UnmarshalJSON is the inverse of MarshalJSON: a plain JSON string is the
+// UTF-8 body verbatim, and a {"base64":"..."} envelope is a non-UTF-8
+// payload. Used by the reverse encoder to read messages.jsonl back.
+func (b *sqsMessageBody) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		*b = sqsMessageBody(s)
+		return nil
+	}
+	var envelope struct {
+		Base64 string `json:"base64"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return errors.WithStack(err)
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(envelope.Base64)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	*b = sqsMessageBody(raw)
+	return nil
+}
+
 // sqsMessageRecord is the dump-format projection. Mirrors the live
 // adapter/sqs_messages.go:80 record one-to-one — JSON tag names match so
 // a restorer can call SendMessage with each line as the input. Visibility


### PR DESCRIPTION
## Summary

**Phase 0b M5-1 — SQS queue + message reverse encoder.** First slice of the SQS reverse encoder. Inverse of the SQS decoder in `sqs.go`.

- `_queue.json` → `!sqs|queue|meta|` (`storedSQSMetaMagic` + live `sqsQueueMeta` JSON) + `!sqs|queue|gen|` (decimal `"1"`).
- `messages.jsonl` → one `!sqs|msg|data|` record per line (`storedSQSMsgMagic` + live message JSON). The dump body (human-readable string or `{base64}` envelope) is translated to the live value's base64-std `[]byte`; message attributes pass through as raw JSON.
- FIFO queues additionally emit `!sqs|queue|seq|` = `max(sequence_number)+1`.

> Independent of the S3 chain (#842/#845) — targets `main`, reuses only main-available helpers.

### Reconstruction (Option-B, matching DDB/S3)
Uniform `sqsRestoreGeneration=1` in the meta, gen counter, message keys, and each message's `queue_generation`. Visibility state restores **zeroed** (every message visible), matching the decoder default. Generation/incarnation, created-at timestamps, tags, throttle config are not in the dump and restore to zero.

### Scope
Classic single-partition queues. **HT-FIFO partitioned queues** (`partition_count > 1`) use a different key family and **fail closed** (`ErrSQSEncodeUnsupportedPartitioned`). Derived side records (`!sqs|msg|{vis,byage,dedup,group}`) are the follow-up slice **M5-2** (the design's side-record decision gate).

Adds `sqsMessageBody.UnmarshalJSON` (symmetric with its `MarshalJSON`, additive — the decoder never unmarshals it) so the encoder can read `messages.jsonl` bodies back. Reads go through the `sqs/` `os.Root` with the `Lstat` + `IsRegular` + `refuseHardLink` guard.

## Self-review (5 lenses)
- **Data loss**: round-trip via the **real** `DecodeSnapshot` confirms meta + message + body fidelity; fail-closed on bad JSON / non-regular / partitioned / unknown version.
- **Concurrency/distributed**: single-goroutine, one builder.
- **Performance**: streamed JSONL decode.
- **Consistency**: key/value formats reproduced against the live store (prefixes, base64url + BE-u64 keys, magics, live JSON shapes); generation uniform per Option B; FIFO seq restored to max+1.
- **Test coverage**: standard-queue round-trip (meta + 2 msgs), FIFO seq + gen counters, binary `{base64}` body round-trip, partitioned fail-closed, unknown-format-version rejection, missing-dir no-op.

## Test plan
- [x] `go test ./internal/backup/` (full package)
- [x] `golangci-lint run internal/backup/` (0 issues)
- [ ] Follow-up: M5-2 SQS side-record derivation (vis/byage/dedup/group); M6 CLI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SQS queue backup and restore support, including FIFO queues with sequence tracking
  * Binary message body handling in backed-up queue data

* **Tests**
  * Comprehensive test coverage for SQS restore operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/846?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->