### PR TITLE
feat(encryption): Stage 7a-2 - storage-layer registration enforcement

### DIFF
--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -147,6 +147,19 @@ type StateCache struct {
 	// activeStorageDEKID and re-registers, which Registered()'s
 	// equality check handles without a reset.
 	registeredStorageDEKID atomic.Uint32
+	// storageRegistrationArmed reports whether this process load actually
+	// triggered a writer registration (the §4.1 propose path — envelope
+	// active at boot with a registration pending). It gates whether the
+	// Stage 7a-2 direct-path enforcement is in force at all: when a node
+	// boots in Phase 0 (envelope inactive) the process-start path skips
+	// registration, so there is no pending registration to wait on — and
+	// if EnableStorageEnvelope is applied later at runtime, the direct
+	// path must NOT start failing closed (there is no runtime registration
+	// path yet; that is the deferred 7a follow-on). This mirrors 7a's
+	// coordinator gate, which returns a permanently-ungated gate object in
+	// the same skip branches. Set once by ArmStorageRegistration from the
+	// propose branch; never reset.
+	storageRegistrationArmed atomic.Bool
 }
 
 // NewStateCache returns a zero-initialised StateCache. The
@@ -231,6 +244,43 @@ func (c *StateCache) Registered() bool {
 	}
 	id := c.activeStorageDEKID.Load()
 	return id != 0 && c.registeredStorageDEKID.Load() == id
+}
+
+// ArmStorageRegistration marks that this process load triggered a §4.1
+// writer registration (the propose path). Until armed, the Stage 7a-2
+// direct-path gate is inert (StorageRegistrationSatisfied returns true),
+// so a node that booted in Phase 0 is never trapped if EnableStorageEnvelope
+// is applied at runtime. Set once at process start; never reset.
+func (c *StateCache) ArmStorageRegistration() {
+	if c == nil {
+		return
+	}
+	c.storageRegistrationArmed.Store(true)
+}
+
+// StorageRegistrationSatisfied is the predicate the Stage 7a-2 direct-path
+// gate (WithStorageRegistrationGate) actually consults. It returns false
+// — fail closed — only when this load armed a registration (the propose
+// path) AND that registration has not yet committed for the active DEK.
+//
+// When the load did NOT arm a registration (Phase 0 boot, not bootstrapped,
+// already-registered restart), it returns true so direct encrypted writes
+// are never trapped — mirroring 7a's coordinator gate, which is a
+// permanently-ungated gate object in those branches. This is the codex P1
+// fix on PR #847: wiring the live Registered() predicate alone would have
+// made a Phase-0-booted node fail closed forever after a runtime cutover,
+// since no runtime registration path exists yet (deferred 7a follow-on).
+//
+// Composes with 7b: armed stays true across a rotate-dek, and Registered()
+// re-arms per-DEK, so a rotation correctly re-gates until re-registration.
+func (c *StateCache) StorageRegistrationSatisfied() bool {
+	if c == nil {
+		return true
+	}
+	if !c.storageRegistrationArmed.Load() {
+		return true
+	}
+	return c.Registered()
 }
 
 // KEKUnwrapper is the abstraction the Applier uses to recover

--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -147,19 +147,6 @@ type StateCache struct {
 	// activeStorageDEKID and re-registers, which Registered()'s
 	// equality check handles without a reset.
 	registeredStorageDEKID atomic.Uint32
-	// storageRegistrationArmed reports whether this process load actually
-	// triggered a writer registration (the §4.1 propose path — envelope
-	// active at boot with a registration pending). It gates whether the
-	// Stage 7a-2 direct-path enforcement is in force at all: when a node
-	// boots in Phase 0 (envelope inactive) the process-start path skips
-	// registration, so there is no pending registration to wait on — and
-	// if EnableStorageEnvelope is applied later at runtime, the direct
-	// path must NOT start failing closed (there is no runtime registration
-	// path yet; that is the deferred 7a follow-on). This mirrors 7a's
-	// coordinator gate, which returns a permanently-ungated gate object in
-	// the same skip branches. Set once by ArmStorageRegistration from the
-	// propose branch; never reset.
-	storageRegistrationArmed atomic.Bool
 }
 
 // NewStateCache returns a zero-initialised StateCache. The
@@ -227,12 +214,23 @@ func (c *StateCache) MarkRegistered(dekID uint32) {
 	c.registeredStorageDEKID.Store(dekID)
 }
 
-// Registered reports whether this process load has confirmed its
-// §4.1 writer registration for the currently-active storage DEK. It is
-// the pure "is-marked" predicate; the Stage 7a-2 direct-path gate
-// consults StorageRegistrationSatisfied() (which delegates here only
-// when a registration was armed), NOT Registered() directly — a load
-// that never armed a registration must not be gated.
+// Registered reports whether this process load has confirmed its §4.1
+// writer registration for the currently-active storage DEK. It is the
+// predicate Stage 7a-2's WithStorageRegistrationGate consults on the
+// direct write path: a self-originated encrypted write is refused
+// (ErrWriterNotRegistered) until Registered() is true.
+//
+// It is deliberately per-DEK and fail-closed (design §2.3 forbids any
+// fail-OPEN fallback): a node that has not registered for the active DEK
+// — including a freshly rotated DEK it has not yet re-registered under
+// (7b) — is gated. The runtime cases where a node legitimately needs to
+// (re)register before its first encrypted direct write (Phase-0 boot then
+// runtime EnableStorageEnvelope; non-proposer node after a runtime
+// RotateDEK) are the deferred runtime-registration follow-on; until it
+// lands they fail closed, which is the safe posture. No real runtime
+// direct-write caller exists today — the only direct ApplyMutations path
+// is the startup catalog bootstrap Save, which is covered by
+// retryUntilRegistered + the already-registered MarkRegistered seed.
 //
 // Lock-free: two atomic loads. Returns false when there is no active
 // storage DEK (id == 0) so a pre-bootstrap process never claims to be
@@ -245,43 +243,6 @@ func (c *StateCache) Registered() bool {
 	}
 	id := c.activeStorageDEKID.Load()
 	return id != 0 && c.registeredStorageDEKID.Load() == id
-}
-
-// ArmStorageRegistration marks that this process load triggered a §4.1
-// writer registration (the propose path). Until armed, the Stage 7a-2
-// direct-path gate is inert (StorageRegistrationSatisfied returns true),
-// so a node that booted in Phase 0 is never trapped if EnableStorageEnvelope
-// is applied at runtime. Set once at process start; never reset.
-func (c *StateCache) ArmStorageRegistration() {
-	if c == nil {
-		return
-	}
-	c.storageRegistrationArmed.Store(true)
-}
-
-// StorageRegistrationSatisfied is the predicate the Stage 7a-2 direct-path
-// gate (WithStorageRegistrationGate) actually consults. It returns false
-// — fail closed — only when this load armed a registration (the propose
-// path) AND that registration has not yet committed for the active DEK.
-//
-// When the load did NOT arm a registration (Phase 0 boot, not bootstrapped,
-// already-registered restart), it returns true so direct encrypted writes
-// are never trapped — mirroring 7a's coordinator gate, which is a
-// permanently-ungated gate object in those branches. This is the codex P1
-// fix on PR #847: wiring the live Registered() predicate alone would have
-// made a Phase-0-booted node fail closed forever after a runtime cutover,
-// since no runtime registration path exists yet (deferred 7a follow-on).
-//
-// Composes with 7b: armed stays true across a rotate-dek, and Registered()
-// re-arms per-DEK, so a rotation correctly re-gates until re-registration.
-func (c *StateCache) StorageRegistrationSatisfied() bool {
-	if c == nil {
-		return true
-	}
-	if !c.storageRegistrationArmed.Load() {
-		return true
-	}
-	return c.Registered()
 }
 
 // KEKUnwrapper is the abstraction the Applier uses to recover

--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -228,10 +228,11 @@ func (c *StateCache) MarkRegistered(dekID uint32) {
 }
 
 // Registered reports whether this process load has confirmed its
-// §4.1 writer registration for the currently-active storage DEK. It
-// is the predicate Stage 7a-2's WithStorageRegistrationGate consults
-// on the direct write path: an encrypted self-originated write is
-// refused (ErrWriterNotRegistered) until Registered() is true.
+// §4.1 writer registration for the currently-active storage DEK. It is
+// the pure "is-marked" predicate; the Stage 7a-2 direct-path gate
+// consults StorageRegistrationSatisfied() (which delegates here only
+// when a registration was armed), NOT Registered() directly — a load
+// that never armed a registration must not be gated.
 //
 // Lock-free: two atomic loads. Returns false when there is no active
 // storage DEK (id == 0) so a pre-bootstrap process never claims to be

--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -133,6 +133,20 @@ type StateCache struct {
 	//     §7.1 Phase 1; rotate-dek under the active envelope keeps
 	//     it true).
 	storageEnvelopeActive atomic.Bool
+	// registeredStorageDEKID is the §4.1 writer-registry DEK id this
+	// process has confirmed its own registration for (0 = none). It is
+	// NOT mirrored from the sidecar — it tracks a per-process-load
+	// fact (this load's writer registration committed) rather than
+	// durable cluster state. Stage 7a-2's direct-write gate consults
+	// it via Registered(): a self-originated encrypted write is
+	// refused until this load's registration is confirmed for the
+	// currently-active storage DEK. Set by MarkRegistered from 7a's
+	// registration paths (barrier-close and the already-registered
+	// startup branch). A single uint32 suffices because exactly one
+	// storage DEK is active at a time; 7b's rotate-dek re-points
+	// activeStorageDEKID and re-registers, which Registered()'s
+	// equality check handles without a reset.
+	registeredStorageDEKID atomic.Uint32
 }
 
 // NewStateCache returns a zero-initialised StateCache. The
@@ -185,6 +199,38 @@ func (c *StateCache) StorageEnvelopeActive() bool {
 		return false
 	}
 	return c.storageEnvelopeActive.Load()
+}
+
+// MarkRegistered records that this process load's §4.1 writer
+// registration has committed for storage DEK dekID. Stage 7a's
+// registration paths call it once their barrier closes (or in the
+// already-registered startup branch). Idempotent; a zero dekID is a
+// no-op so a not-bootstrapped caller cannot accidentally mark the
+// "no DEK" sentinel as registered.
+func (c *StateCache) MarkRegistered(dekID uint32) {
+	if c == nil || dekID == 0 {
+		return
+	}
+	c.registeredStorageDEKID.Store(dekID)
+}
+
+// Registered reports whether this process load has confirmed its
+// §4.1 writer registration for the currently-active storage DEK. It
+// is the predicate Stage 7a-2's WithStorageRegistrationGate consults
+// on the direct write path: an encrypted self-originated write is
+// refused (ErrWriterNotRegistered) until Registered() is true.
+//
+// Lock-free: two atomic loads. Returns false when there is no active
+// storage DEK (id == 0) so a pre-bootstrap process never claims to be
+// registered; once a DEK is active, returns true only when this load
+// has marked that exact id (so 7b's rotate-dek to a new id re-arms
+// the gate until the post-rotation registration marks the new id).
+func (c *StateCache) Registered() bool {
+	if c == nil {
+		return false
+	}
+	id := c.activeStorageDEKID.Load()
+	return id != 0 && c.registeredStorageDEKID.Load() == id
 }
 
 // KEKUnwrapper is the abstraction the Applier uses to recover

--- a/internal/encryption/applier_test.go
+++ b/internal/encryption/applier_test.go
@@ -1870,7 +1870,54 @@ func TestStateCache_NilSafe(t *testing.T) {
 	if c.StorageEnvelopeActive() {
 		t.Error("nil StateCache.StorageEnvelopeActive = true, want false")
 	}
+	if c.Registered() {
+		t.Error("nil StateCache.Registered = true, want false")
+	}
+	c.MarkRegistered(7)                         // must not panic
 	c.RefreshFromSidecar(&encryption.Sidecar{}) // must not panic
+}
+
+// TestStateCache_Registered exercises the Stage 7a-2 §4.1 direct-path
+// gate predicate: Registered() is true only when an active storage DEK
+// is present AND MarkRegistered has marked that exact id. A 7b-style
+// rotate-dek to a new active id automatically re-arms the gate.
+func TestStateCache_Registered(t *testing.T) {
+	t.Parallel()
+	c := encryption.NewStateCache()
+
+	// No active DEK → never registered, even after a stray MarkRegistered.
+	if c.Registered() {
+		t.Error("fresh cache Registered() = true, want false")
+	}
+	c.MarkRegistered(0) // no-op: zero id is the "no DEK" sentinel
+	if c.Registered() {
+		t.Error("after MarkRegistered(0) Registered() = true, want false")
+	}
+
+	// Activate DEK 7 but don't mark it → still false.
+	sc := &encryption.Sidecar{Version: encryption.SidecarVersion}
+	sc.Active.Storage = 7
+	c.RefreshFromSidecar(sc)
+	if c.Registered() {
+		t.Error("active DEK 7 unmarked Registered() = true, want false")
+	}
+
+	// Mark 7 → registered.
+	c.MarkRegistered(7)
+	if !c.Registered() {
+		t.Error("active DEK 7 marked Registered() = false, want true")
+	}
+
+	// Rotate active DEK to 8 (7b) → gate re-arms until 8 is marked.
+	sc.Active.Storage = 8
+	c.RefreshFromSidecar(sc)
+	if c.Registered() {
+		t.Error("after rotate to DEK 8 (8 unmarked) Registered() = true, want false")
+	}
+	c.MarkRegistered(8)
+	if !c.Registered() {
+		t.Error("active DEK 8 marked Registered() = false, want true")
+	}
 }
 
 // TestApplier_StorageAccessors_ConcurrentReads exercises the

--- a/internal/encryption/applier_test.go
+++ b/internal/encryption/applier_test.go
@@ -1920,61 +1920,6 @@ func TestStateCache_Registered(t *testing.T) {
 	}
 }
 
-// TestStateCache_StorageRegistrationSatisfied exercises the codex P1 fix
-// on PR #847: the direct-path gate predicate is inert until a load arms a
-// registration (Phase-0 boot must not trap direct writes after a runtime
-// EnableStorageEnvelope), and once armed it fails closed until the active
-// DEK is marked registered (composing with 7b rotation).
-func TestStateCache_StorageRegistrationSatisfied(t *testing.T) {
-	t.Parallel()
-	c := encryption.NewStateCache()
-	sc := &encryption.Sidecar{Version: encryption.SidecarVersion}
-	sc.Active.Storage = 7
-	c.RefreshFromSidecar(sc)
-
-	// Unarmed (Phase-0 boot posture): satisfied is always true, even with
-	// an active DEK and no registration — a runtime cutover cannot trap.
-	if !c.StorageRegistrationSatisfied() {
-		t.Error("unarmed StorageRegistrationSatisfied() = false, want true (must not trap)")
-	}
-
-	// Armed but not registered → fail closed.
-	c.ArmStorageRegistration()
-	if c.StorageRegistrationSatisfied() {
-		t.Error("armed+unregistered StorageRegistrationSatisfied() = true, want false")
-	}
-
-	// Armed + registered for the active DEK → satisfied.
-	c.MarkRegistered(7)
-	if !c.StorageRegistrationSatisfied() {
-		t.Error("armed+registered StorageRegistrationSatisfied() = false, want true")
-	}
-
-	// 7b rotate to DEK 8: armed stays true, DEK 8 unmarked → fail closed
-	// again until re-registration.
-	sc.Active.Storage = 8
-	c.RefreshFromSidecar(sc)
-	if c.StorageRegistrationSatisfied() {
-		t.Error("armed+rotated-unregistered StorageRegistrationSatisfied() = true, want false")
-	}
-	c.MarkRegistered(8)
-	if !c.StorageRegistrationSatisfied() {
-		t.Error("armed+rotated-registered StorageRegistrationSatisfied() = false, want true")
-	}
-}
-
-// TestStateCache_StorageRegistrationSatisfied_NilSafe pins the nil
-// receiver to the permissive (true) default — a nil cache must not trap
-// writes.
-func TestStateCache_StorageRegistrationSatisfied_NilSafe(t *testing.T) {
-	t.Parallel()
-	var c *encryption.StateCache
-	if !c.StorageRegistrationSatisfied() {
-		t.Error("nil StateCache.StorageRegistrationSatisfied() = false, want true")
-	}
-	c.ArmStorageRegistration() // must not panic
-}
-
 // TestApplier_StorageAccessors_ConcurrentReads exercises the
 // atomic.Uint32 / atomic.Bool seam under -race. The accessors are
 // called on the hot storage Put path, so a torn read or a missed

--- a/internal/encryption/applier_test.go
+++ b/internal/encryption/applier_test.go
@@ -1920,6 +1920,61 @@ func TestStateCache_Registered(t *testing.T) {
 	}
 }
 
+// TestStateCache_StorageRegistrationSatisfied exercises the codex P1 fix
+// on PR #847: the direct-path gate predicate is inert until a load arms a
+// registration (Phase-0 boot must not trap direct writes after a runtime
+// EnableStorageEnvelope), and once armed it fails closed until the active
+// DEK is marked registered (composing with 7b rotation).
+func TestStateCache_StorageRegistrationSatisfied(t *testing.T) {
+	t.Parallel()
+	c := encryption.NewStateCache()
+	sc := &encryption.Sidecar{Version: encryption.SidecarVersion}
+	sc.Active.Storage = 7
+	c.RefreshFromSidecar(sc)
+
+	// Unarmed (Phase-0 boot posture): satisfied is always true, even with
+	// an active DEK and no registration — a runtime cutover cannot trap.
+	if !c.StorageRegistrationSatisfied() {
+		t.Error("unarmed StorageRegistrationSatisfied() = false, want true (must not trap)")
+	}
+
+	// Armed but not registered → fail closed.
+	c.ArmStorageRegistration()
+	if c.StorageRegistrationSatisfied() {
+		t.Error("armed+unregistered StorageRegistrationSatisfied() = true, want false")
+	}
+
+	// Armed + registered for the active DEK → satisfied.
+	c.MarkRegistered(7)
+	if !c.StorageRegistrationSatisfied() {
+		t.Error("armed+registered StorageRegistrationSatisfied() = false, want true")
+	}
+
+	// 7b rotate to DEK 8: armed stays true, DEK 8 unmarked → fail closed
+	// again until re-registration.
+	sc.Active.Storage = 8
+	c.RefreshFromSidecar(sc)
+	if c.StorageRegistrationSatisfied() {
+		t.Error("armed+rotated-unregistered StorageRegistrationSatisfied() = true, want false")
+	}
+	c.MarkRegistered(8)
+	if !c.StorageRegistrationSatisfied() {
+		t.Error("armed+rotated-registered StorageRegistrationSatisfied() = false, want true")
+	}
+}
+
+// TestStateCache_StorageRegistrationSatisfied_NilSafe pins the nil
+// receiver to the permissive (true) default — a nil cache must not trap
+// writes.
+func TestStateCache_StorageRegistrationSatisfied_NilSafe(t *testing.T) {
+	t.Parallel()
+	var c *encryption.StateCache
+	if !c.StorageRegistrationSatisfied() {
+		t.Error("nil StateCache.StorageRegistrationSatisfied() = false, want true")
+	}
+	c.ArmStorageRegistration() // must not panic
+}
+
 // TestApplier_StorageAccessors_ConcurrentReads exercises the
 // atomic.Uint32 / atomic.Bool seam under -race. The accessors are
 // called on the hot storage Put path, so a torn read or a missed

--- a/main.go
+++ b/main.go
@@ -427,7 +427,7 @@ func run() error {
 	// synchronously here, BEFORE the gRPC servers serve, so writes never
 	// run with no registration gate installed (codex P1 on PR #839).
 	distCatalog, err := setupDistributionAndRegistration(
-		ctx, runCtx, eg, runtimes, cfg.engine,
+		runCtx, eg, runtimes, cfg.engine,
 		coordinate, shardGroups[cfg.defaultGroup], encWiring, *raftId)
 	if err != nil {
 		cancel()
@@ -1696,7 +1696,19 @@ func setupDistributionCatalog(
 	if distCatalog == nil {
 		return nil, errors.WithStack(errors.Newf("distribution catalog store is not available for group %d", catalogGroupID))
 	}
-	if _, err := distribution.EnsureCatalogSnapshot(ctx, distCatalog, engine); err != nil {
+	// EnsureCatalogSnapshot may Save through the direct (non-raft) write
+	// path. When the §7.1 storage envelope is active and this load's
+	// writer registration has not yet committed, that Save fails closed
+	// with store.ErrWriterNotRegistered (Stage 7a-2). retryUntilRegistered
+	// retries the bootstrap until the registration goroutine — armed
+	// before this call in setupDistributionAndRegistration — commits and
+	// the gate clears. The common cases (populated catalog → no-op Save,
+	// or pre-cutover → cleartext Save) never hit the gate and return on
+	// the first attempt.
+	if err := retryUntilRegistered(ctx, "distribution catalog bootstrap", func() error {
+		_, e := distribution.EnsureCatalogSnapshot(ctx, distCatalog, engine)
+		return errors.Wrap(e, "ensure catalog snapshot")
+	}); err != nil {
 		return nil, errors.Wrapf(err, "initialize distribution catalog")
 	}
 	return distCatalog, nil

--- a/main.go
+++ b/main.go
@@ -1705,6 +1705,11 @@ func setupDistributionCatalog(
 	// the gate clears. The common cases (populated catalog → no-op Save,
 	// or pre-cutover → cleartext Save) never hit the gate and return on
 	// the first attempt.
+	//
+	// Idempotency requirement: the retry re-invokes EnsureCatalogSnapshot
+	// from scratch on each ErrWriterNotRegistered, so it MUST be
+	// re-entrant — on the populated-catalog path it is a version-unchanged
+	// no-op Save (no mutation, no nonce), so re-running it is safe.
 	if err := retryUntilRegistered(ctx, "distribution catalog bootstrap", func() error {
 		_, e := distribution.EnsureCatalogSnapshot(ctx, distCatalog, engine)
 		return errors.Wrap(e, "ensure catalog snapshot")

--- a/main_encryption_e2e_test.go
+++ b/main_encryption_e2e_test.go
@@ -68,13 +68,15 @@ func TestEncryption_E2E_BootstrapCutoverPutReadback(t *testing.T) {
 	assertEnvelopeActive(t, cache, true)
 	// Stage 7a-2 §4.1: with the envelope active, the DIRECT write path
 	// (PutAt) fails closed until this load's writer registration has
-	// committed. In production main.go's registration goroutine calls
-	// MarkRegistered once the barrier closes (or in the already-registered
-	// startup branch); here we drive the Applier directly, so mark the
-	// cache to simulate that registration step. Without it the Phase-1
-	// PutAt below would return ErrWriterNotRegistered.
+	// committed AND was armed. In production main.go's registration
+	// goroutine arms the gate (propose branch) and calls MarkRegistered
+	// once the barrier closes; here we drive the Applier directly, so
+	// reproduce both steps to exercise the armed+registered gate-pass
+	// path. Without them the Phase-1 PutAt below would return
+	// ErrWriterNotRegistered (armed) — see TestStateCache_StorageRegistrationSatisfied.
+	cache.ArmStorageRegistration()
 	cache.MarkRegistered(e2eStorageDEKID)
-	// Phase 1: gate on + active DEK + registered → encrypted at rest.
+	// Phase 1: gate armed + active DEK + registered → encrypted at rest.
 	mustPut(t, ctx, st, "after", "plain-after", 120)
 
 	// Every version reads back as correct plaintext through the wired

--- a/main_encryption_e2e_test.go
+++ b/main_encryption_e2e_test.go
@@ -68,15 +68,13 @@ func TestEncryption_E2E_BootstrapCutoverPutReadback(t *testing.T) {
 	assertEnvelopeActive(t, cache, true)
 	// Stage 7a-2 §4.1: with the envelope active, the DIRECT write path
 	// (PutAt) fails closed until this load's writer registration has
-	// committed AND was armed. In production main.go's registration
-	// goroutine arms the gate (propose branch) and calls MarkRegistered
-	// once the barrier closes; here we drive the Applier directly, so
-	// reproduce both steps to exercise the armed+registered gate-pass
-	// path. Without them the Phase-1 PutAt below would return
-	// ErrWriterNotRegistered (armed) — see TestStateCache_StorageRegistrationSatisfied.
-	cache.ArmStorageRegistration()
+	// committed. In production main.go's registration goroutine calls
+	// MarkRegistered once the barrier closes (or in the already-registered
+	// startup branch); here we drive the Applier directly, so mark the
+	// cache to simulate that registration step. Without it the Phase-1
+	// PutAt below would return ErrWriterNotRegistered.
 	cache.MarkRegistered(e2eStorageDEKID)
-	// Phase 1: gate armed + active DEK + registered → encrypted at rest.
+	// Phase 1: gate on + active DEK + registered → encrypted at rest.
 	mustPut(t, ctx, st, "after", "plain-after", 120)
 
 	// Every version reads back as correct plaintext through the wired

--- a/main_encryption_e2e_test.go
+++ b/main_encryption_e2e_test.go
@@ -66,7 +66,15 @@ func TestEncryption_E2E_BootstrapCutoverPutReadback(t *testing.T) {
 	// Cutover (EnableStorageEnvelope apply effect): flips the gate.
 	applyE2ECutover(t, applier)
 	assertEnvelopeActive(t, cache, true)
-	// Phase 1: gate on + active DEK → encrypted at rest.
+	// Stage 7a-2 §4.1: with the envelope active, the DIRECT write path
+	// (PutAt) fails closed until this load's writer registration has
+	// committed. In production main.go's registration goroutine calls
+	// MarkRegistered once the barrier closes (or in the already-registered
+	// startup branch); here we drive the Applier directly, so mark the
+	// cache to simulate that registration step. Without it the Phase-1
+	// PutAt below would return ErrWriterNotRegistered.
+	cache.MarkRegistered(e2eStorageDEKID)
+	// Phase 1: gate on + active DEK + registered → encrypted at rest.
 	mustPut(t, ctx, st, "after", "plain-after", 120)
 
 	// Every version reads back as correct plaintext through the wired

--- a/main_encryption_registration.go
+++ b/main_encryption_registration.go
@@ -234,13 +234,6 @@ func buildProcessStartRegistrationGate(
 			w.epoch, lastSeen, activeDEK, fullNodeID)
 	}
 
-	// Arm the Stage 7a-2 direct-path gate: this load has a registration
-	// pending, so StorageRegistrationSatisfied must fail closed until the
-	// barrier closes. Only the propose branch arms it — the skip branches
-	// (Phase 0, not-bootstrapped, already-registered) leave it unarmed so
-	// a runtime EnableStorageEnvelope cannot trap their direct writes
-	// (codex P1 on PR #847).
-	w.cache.ArmStorageRegistration()
 	barrier := make(chan struct{})
 	entry := registrationEntry(activeDEK, fullNodeID, w.epoch)
 	req := registrationRequest(activeDEK, fullNodeID, w.epoch)

--- a/main_encryption_registration.go
+++ b/main_encryption_registration.go
@@ -234,6 +234,13 @@ func buildProcessStartRegistrationGate(
 			w.epoch, lastSeen, activeDEK, fullNodeID)
 	}
 
+	// Arm the Stage 7a-2 direct-path gate: this load has a registration
+	// pending, so StorageRegistrationSatisfied must fail closed until the
+	// barrier closes. Only the propose branch arms it — the skip branches
+	// (Phase 0, not-bootstrapped, already-registered) leave it unarmed so
+	// a runtime EnableStorageEnvelope cannot trap their direct writes
+	// (codex P1 on PR #847).
+	w.cache.ArmStorageRegistration()
 	barrier := make(chan struct{})
 	entry := registrationEntry(activeDEK, fullNodeID, w.epoch)
 	req := registrationRequest(activeDEK, fullNodeID, w.epoch)

--- a/main_encryption_registration.go
+++ b/main_encryption_registration.go
@@ -55,20 +55,34 @@ const (
 func retryUntilRegistered(ctx context.Context, what string, fn func() error) error {
 	backoff := registrationRetryInitial
 	start := time.Now()
-	warned := false
+	var lastWarn time.Time
 	for {
 		err := fn()
 		if err == nil || !errors.Is(err, store.ErrWriterNotRegistered) {
 			return err
 		}
-		if !warned && time.Since(start) >= registrationGateWarnAfter {
+		// Re-warn periodically (every registrationGateWarnAfter), not just
+		// once: a node stuck for minutes after the first WARN would
+		// otherwise go silent in log pipelines (claude review on PR #847).
+		// lastWarn is the zero time on the first pass, so the first WARN
+		// fires once registrationGateWarnAfter has elapsed since start.
+		if blocked := time.Since(start); blocked >= registrationGateWarnAfter && time.Since(lastWarn) >= registrationGateWarnAfter {
 			slog.Warn("encryption: direct write blocked on writer registration; still retrying",
 				slog.String("operation", what),
-				slog.Duration("blocked_for", time.Since(start)))
-			warned = true
+				slog.Duration("blocked_for", blocked))
+			lastWarn = time.Now()
 		}
 		select {
 		case <-ctx.Done():
+			// Clean-shutdown path: runCtx cancelled during the bootstrap
+			// retry window (operator graceful restart during boot). Log at
+			// INFO so this reads as shutdown, not failure (claude review on
+			// PR #847). The returned error preserves the context.Canceled
+			// chain — consistent with every other ctx-aware startup step
+			// (EnsureCatalogSnapshot included), which run() surfaces the
+			// same way.
+			slog.Info("encryption: writer-registration bootstrap retry cancelled by shutdown",
+				slog.String("operation", what))
 			return errors.Wrapf(ctx.Err(), "%s: cancelled while blocked on writer registration", what)
 		case <-time.After(backoff):
 			backoff = min(backoff*registrationBackoffFactor, registrationRetryMax)
@@ -177,7 +191,14 @@ func buildProcessStartRegistrationGate(
 		return &kv.RegistrationGate{}, nil // not bootstrapped
 	}
 	fullNodeID := etcdraftengine.DeriveNodeID(raftID)
-	lastSeen, err := readWriterRegistryLastSeen(defaultGroup.Store, activeDEK, fullNodeID)
+	// Build the registry handle once and reuse it for the initial read
+	// and the verifyRegistered retry loop, rather than re-asserting +
+	// allocating a handle per call (claude review on PR #847).
+	reg, err := store.WriterRegistryFor(defaultGroup.Store)
+	if err != nil {
+		return nil, errors.Wrap(err, "writer registration: registry handle")
+	}
+	lastSeen, err := registryLastSeen(reg, activeDEK, fullNodeID)
 	if err != nil {
 		return nil, err
 	}
@@ -223,9 +244,8 @@ func buildProcessStartRegistrationGate(
 	// it, consistently >registrationAttemptTimeout commit latency could
 	// keep retrying-without-committing forever despite durable
 	// registration (codex P2 #6).
-	regStore := defaultGroup.Store
 	verifyRegistered := func() (bool, error) {
-		ls, err := readWriterRegistryLastSeen(regStore, activeDEK, fullNodeID)
+		ls, err := registryLastSeen(reg, activeDEK, fullNodeID)
 		if err != nil {
 			return false, err
 		}
@@ -244,12 +264,21 @@ func buildProcessStartRegistrationGate(
 
 // readWriterRegistryLastSeen returns the registry's last_seen_local_epoch
 // for (full_node_id, dek_id), or 0 when no row exists (treated as the
-// "propose" trigger per the 7a design §3.1).
+// "propose" trigger per the 7a design §3.1). It builds a fresh registry
+// handle per call; hot/looping callers should build the handle once and
+// use registryLastSeen instead (claude review on PR #847).
 func readWriterRegistryLastSeen(st store.MVCCStore, dekID uint32, fullNodeID uint64) (uint16, error) {
 	reg, err := store.WriterRegistryFor(st)
 	if err != nil {
 		return 0, errors.Wrap(err, "writer registration: registry handle")
 	}
+	return registryLastSeen(reg, dekID, fullNodeID)
+}
+
+// registryLastSeen reads last_seen_local_epoch from an already-built
+// registry handle (no per-call WriterRegistryFor type-assert + alloc),
+// so the verifyRegistered retry loop can reuse one handle.
+func registryLastSeen(reg encryption.WriterRegistryStore, dekID uint32, fullNodeID uint64) (uint16, error) {
 	raw, ok, err := reg.GetRegistryRow(encryption.RegistryKey(dekID, encryption.NodeID16(fullNodeID)))
 	if err != nil {
 		return 0, errors.Wrap(err, "writer registration: read registry row")

--- a/main_encryption_registration.go
+++ b/main_encryption_registration.go
@@ -32,16 +32,68 @@ const (
 	// the leader) rather than blocking indefinitely on a stale leader
 	// address under GRPCConnCache's WaitForReady(true) dials.
 	registrationAttemptTimeout = 5 * time.Second
+	// registrationGateWarnAfter is how long the direct-path catalog
+	// bootstrap Save may stay blocked on writer registration before a
+	// diagnostic WARN fires (Stage 7a-2 §2.3). The retry continues past
+	// this; the log line just makes a stuck node visible rather than
+	// silently hung.
+	registrationGateWarnAfter = 15 * time.Second
 )
 
-// setupDistributionAndRegistration sets up the distribution catalog and
-// then installs the Stage 7a process-start registration gate, returning
-// the catalog store. Bundling the two lets run() handle both startup
-// faults through a single error path (keeping run() within the cyclop
-// budget) while preserving the fail-synchronously-before-serving
+// retryUntilRegistered runs fn, retrying with bounded backoff while it
+// returns store.ErrWriterNotRegistered — the Stage 7a-2 §4.1
+// fail-closed signal that the §7.1 envelope is active but this load's
+// writer registration has not yet committed. Any other error (or nil)
+// returns immediately, so callers that never hit an encrypted direct
+// write see the wrapped fn's result unchanged.
+//
+// The retry is bounded by ctx (the run context), so a shutdown during
+// the empty-catalog + active-envelope startup edge cancels the loop and
+// returns rather than hanging. There is deliberately no fail-OPEN
+// fallback: letting the bootstrap Save proceed unregistered is the
+// exact hazard 7a-2 closes (§2.3).
+func retryUntilRegistered(ctx context.Context, what string, fn func() error) error {
+	backoff := registrationRetryInitial
+	start := time.Now()
+	warned := false
+	for {
+		err := fn()
+		if err == nil || !errors.Is(err, store.ErrWriterNotRegistered) {
+			return err
+		}
+		if !warned && time.Since(start) >= registrationGateWarnAfter {
+			slog.Warn("encryption: direct write blocked on writer registration; still retrying",
+				slog.String("operation", what),
+				slog.Duration("blocked_for", time.Since(start)))
+			warned = true
+		}
+		select {
+		case <-ctx.Done():
+			return errors.Wrapf(ctx.Err(), "%s: cancelled while blocked on writer registration", what)
+		case <-time.After(backoff):
+			backoff = min(backoff*registrationBackoffFactor, registrationRetryMax)
+		}
+	}
+}
+
+// setupDistributionAndRegistration installs the Stage 7a process-start
+// registration gate and then sets up the distribution catalog,
+// returning the catalog store. Bundling the two lets run() handle both
+// startup faults through a single error path (keeping run() within the
+// cyclop budget) while preserving the fail-synchronously-before-serving
 // guarantee for the registration gate.
+//
+// Ordering (Stage 7a-2 §2.3): the registration gate is armed FIRST,
+// then EnsureCatalogSnapshot runs. The catalog bootstrap Save is a
+// direct encrypted write that 7a-2 gates on Registered(); arming the
+// gate (which starts the registration goroutine) before the bootstrap
+// lets the empty-catalog + active-envelope edge clear once registration
+// commits, via the bounded retryUntilRegistered wrapper inside
+// setupDistributionCatalog. Registration has no dependency on the route
+// catalog (the OpRegistration apply writes a writer-registry row, not a
+// route), so arm-before-bootstrap cannot deadlock.
 func setupDistributionAndRegistration(
-	ctx, runCtx context.Context,
+	runCtx context.Context,
 	eg *errgroup.Group,
 	runtimes []*raftGroupRuntime,
 	engine *distribution.Engine,
@@ -50,11 +102,13 @@ func setupDistributionAndRegistration(
 	w encryptionWriteWiring,
 	raftID string,
 ) (*distribution.CatalogStore, error) {
-	distCatalog, err := setupDistributionCatalog(ctx, runtimes, engine)
-	if err != nil {
+	if err := installProcessStartRegistrationGate(runCtx, eg, coordinate, defaultGroup, w, raftID); err != nil {
 		return nil, err
 	}
-	if err := installProcessStartRegistrationGate(runCtx, eg, coordinate, defaultGroup, w, raftID); err != nil {
+	// Bootstrap + registration both run under runCtx so a shutdown
+	// cancels the bounded retry rather than hanging.
+	distCatalog, err := setupDistributionCatalog(runCtx, runtimes, engine)
+	if err != nil {
 		return nil, err
 	}
 	return distCatalog, nil
@@ -139,6 +193,15 @@ func buildProcessStartRegistrationGate(
 	//   - epoch  > last_seen → propose (the trigger).
 	switch {
 	case w.epoch == lastSeen:
+		// Already registered (bootstrap cohort / no-op restart). This
+		// branch returns ungated WITHOUT starting runWriterRegistration,
+		// so it must seed the Stage 7a-2 direct-path gate itself —
+		// otherwise Registered() stays false on every steady-state
+		// restart and the direct bootstrap Save would wrongly fail-closed
+		// with ErrWriterNotRegistered despite a current registry (codex
+		// P1 on PR #843). MarkRegistered is a no-op when activeDEK == 0,
+		// but we are past the not-bootstrapped guard so it is non-zero.
+		w.cache.MarkRegistered(activeDEK)
 		slog.Info("encryption: writer registration skipped (already current)",
 			slog.Uint64("dek_id", uint64(activeDEK)),
 			slog.Uint64("full_node_id", fullNodeID),
@@ -169,7 +232,7 @@ func buildProcessStartRegistrationGate(
 		return ls >= w.epoch, nil
 	}
 	eg.Go(func() error {
-		runWriterRegistration(ctx, coordinate, defaultGroup.Engine, entry, req, barrier, verifyRegistered)
+		runWriterRegistration(ctx, coordinate, defaultGroup.Engine, w.cache, activeDEK, entry, req, barrier, verifyRegistered)
 		return nil
 	})
 	return &kv.RegistrationGate{
@@ -221,15 +284,32 @@ func registrationRequest(dekID uint32, fullNodeID uint64, epoch uint16) *pb.Regi
 	}
 }
 
+// releaseBarrier is the single barrier-close site for the Stage 7a
+// registration goroutine. It marks the Stage 7a-2 direct-path gate
+// registered for dekID BEFORE closing the channel, so any write the
+// barrier close releases (coordinator-gated client writes) observes
+// Registered() == true rather than racing a still-false gate that would
+// fail-close the first encrypted direct write. MarkRegistered is a
+// no-op for dekID == 0 (the gate condition is then false anyway).
+func releaseBarrier(barrier chan struct{}, cache *encryption.StateCache, dekID uint32) {
+	cache.MarkRegistered(dekID)
+	close(barrier)
+}
+
 // runWriterRegistration drives the §4.1 registration to commit, then
 // closes the barrier. It retries transient failures (no leader yet,
 // proposal dropped, transport blip) with bounded backoff against ctx;
 // on ctx cancellation it returns WITHOUT closing the barrier — never
 // releasing writes on an uncommitted registration (7a §3.2).
+//
+// cache + dekID feed releaseBarrier so both close sites (verify-before-
+// propose and propose-success) seed the Stage 7a-2 direct-path gate.
 func runWriterRegistration(
 	ctx context.Context,
 	coordinate *kv.ShardedCoordinator,
 	defaultEngine raftengine.Engine,
+	cache *encryption.StateCache,
+	dekID uint32,
 	entry []byte,
 	req *pb.RegisterEncryptionWriterRequest,
 	barrier chan struct{},
@@ -255,14 +335,14 @@ func runWriterRegistration(
 		// avoids retrying-without-committing forever under high commit
 		// latency (codex P2 #6).
 		if registered, verr := verifyRegistered(); verr == nil && registered {
-			close(barrier)
+			releaseBarrier(barrier, cache, dekID)
 			slog.Info("encryption: writer registration confirmed committed; first-write barrier released",
 				slog.Uint64("dek_id", uint64(req.GetDekId())))
 			return
 		}
 		err := proposeWriterRegistration(ctx, coordinate, defaultEngine, connCache, entry, req)
 		if err == nil {
-			close(barrier)
+			releaseBarrier(barrier, cache, dekID)
 			slog.Info("encryption: writer registration committed; first-write barrier released",
 				slog.Uint64("dek_id", uint64(req.GetDekId())))
 			return

--- a/main_encryption_registration_test.go
+++ b/main_encryption_registration_test.go
@@ -24,10 +24,16 @@ func TestRunWriterRegistration_VerifyCommittedClosesBarrier(t *testing.T) {
 	t.Parallel()
 	barrier := make(chan struct{})
 	verify := func() (bool, error) { return true, nil } // already committed
+	// A cache with the storage DEK active so Registered() is meaningful;
+	// releaseBarrier (via the verify path) must MarkRegistered it.
+	cache := encryption.NewStateCache()
+	sc := &encryption.Sidecar{Version: encryption.SidecarVersion, StorageEnvelopeActive: true}
+	sc.Active.Storage = testRegDEKID
+	cache.RefreshFromSidecar(sc)
 	done := make(chan struct{})
 	go func() {
-		runWriterRegistration(context.Background(), nil, nil, nil,
-			registrationRequest(7, 1, 3), barrier, verify)
+		runWriterRegistration(context.Background(), nil, nil, cache, testRegDEKID, nil,
+			registrationRequest(testRegDEKID, 1, 3), barrier, verify)
 		close(done)
 	}()
 	select {
@@ -36,6 +42,11 @@ func TestRunWriterRegistration_VerifyCommittedClosesBarrier(t *testing.T) {
 		t.Fatal("barrier not closed when registration already committed (verify path)")
 	}
 	<-done
+	// The verify-before-propose close site must seed the Stage 7a-2
+	// direct-path gate, not only the propose-success site (claude P1).
+	if !cache.Registered() {
+		t.Error("verify-committed path closed the barrier but did not MarkRegistered (Registered() = false)")
+	}
 }
 
 func TestRegistrationEntry_RoundTrips(t *testing.T) {
@@ -144,14 +155,21 @@ func TestBuildProcessStartRegistrationGate_NilGateBranches(t *testing.T) {
 		name string
 		w    encryptionWriteWiring
 		seed func(t *testing.T, st store.MVCCStore)
+		// expectRegistered is the Stage 7a-2 direct-path gate state after
+		// the ungated branch returns. Only the already-registered restart
+		// seeds Registered() true (codex P1 on PR #843); the other ungated
+		// branches leave it false (and the gate condition is false there
+		// anyway, so encryptForKey never consults it).
+		expectRegistered bool
 	}{
 		{name: "encryption_off", w: encryptionWriteWiring{cache: encryption.NewStateCache()}}, // cipher nil
 		{name: "phase0_envelope_inactive", w: wiringFor(t, 7, false, 1)},
 		{name: "not_bootstrapped", w: wiringFor(t, 0, true, 1)},
 		{
-			name: "already_registered",
-			w:    wiringFor(t, 7, true, 3),
-			seed: func(t *testing.T, st store.MVCCStore) { writeRegistryRow(t, st, fullNodeID, 3) },
+			name:             "already_registered",
+			w:                wiringFor(t, 7, true, 3),
+			seed:             func(t *testing.T, st store.MVCCStore) { writeRegistryRow(t, st, fullNodeID, 3) },
+			expectRegistered: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -172,6 +190,9 @@ func TestBuildProcessStartRegistrationGate_NilGateBranches(t *testing.T) {
 			// ever blocks.
 			if gate == nil || gate.Barrier != nil {
 				t.Errorf("%s: expected ungated gate (nil Barrier), got %+v", tc.name, gate)
+			}
+			if got := tc.w.cache.Registered(); got != tc.expectRegistered {
+				t.Errorf("%s: Registered() = %v, want %v", tc.name, got, tc.expectRegistered)
 			}
 		})
 	}

--- a/main_encryption_registration_test.go
+++ b/main_encryption_registration_test.go
@@ -267,13 +267,17 @@ func TestBuildProcessStartRegistrationGate_NilGateBranches(t *testing.T) {
 	}
 }
 
-// TestBuildProcessStartRegistrationGate_Phase0BootDoesNotArmGate pins
-// the codex P1 fix on PR #847: a node that boots in Phase 0 (envelope
-// inactive) must NOT arm the Stage 7a-2 direct-path gate, so a later
-// runtime EnableStorageEnvelope cannot trap its direct writes forever.
-// After the Phase-0 ungated return, StorageRegistrationSatisfied() must
-// remain true even once the envelope flips active at runtime.
-func TestBuildProcessStartRegistrationGate_Phase0BootDoesNotArmGate(t *testing.T) {
+// TestBuildProcessStartRegistrationGate_Phase0BootDoesNotMarkRegistered
+// documents the design §2.3 fail-closed posture: a node that boots in
+// Phase 0 (envelope inactive) skips registration without seeding
+// Registered(), so the per-DEK gate is NOT registered for the active
+// DEK. The Phase-0 boot itself emits no encrypted writes (envelope
+// inactive → cleartext, gate unconsulted); a runtime EnableStorageEnvelope
+// would then fail closed until the node (re)registers — the deferred
+// runtime-registration follow-on. This is the safe posture (no fail-OPEN
+// per §2.3), and benign today since the only direct write is the startup
+// catalog bootstrap Save (covered by retryUntilRegistered).
+func TestBuildProcessStartRegistrationGate_Phase0BootDoesNotMarkRegistered(t *testing.T) {
 	t.Parallel()
 	st := newRegistrationTestStore(t)
 	w := wiringFor(t, testRegDEKID, false /*envelope inactive: Phase 0*/, 1)
@@ -288,16 +292,12 @@ func TestBuildProcessStartRegistrationGate_Phase0BootDoesNotArmGate(t *testing.T
 	if gate == nil || gate.Barrier != nil {
 		t.Fatalf("Phase 0 should be ungated (nil Barrier), got %+v", gate)
 	}
-	// Simulate a runtime EnableStorageEnvelope: the cutover flips the
-	// envelope active on the shared cache.
-	sc := &encryption.Sidecar{Version: encryption.SidecarVersion, StorageEnvelopeActive: true}
-	sc.Active.Storage = testRegDEKID
-	w.cache.RefreshFromSidecar(sc)
-	// The direct-path gate must stay satisfied — the load never armed a
-	// registration, so it is not subject to enforcement (mirrors 7a's
-	// permanently-ungated coordinator gate for Phase-0 boots).
-	if !w.cache.StorageRegistrationSatisfied() {
-		t.Error("Phase-0 boot trapped direct writes after runtime cutover (StorageRegistrationSatisfied=false)")
+	// Phase-0 boot did not seed Registered(): the node is not registered
+	// for the active DEK, so a later runtime cutover fail-closes the gate
+	// (deferred runtime-registration). The gate is correctly per-DEK and
+	// fail-closed rather than fail-OPEN (§2.3).
+	if w.cache.Registered() {
+		t.Error("Phase-0 boot unexpectedly marked Registered() — must not seed registration")
 	}
 }
 

--- a/main_encryption_registration_test.go
+++ b/main_encryption_registration_test.go
@@ -10,6 +10,7 @@ import (
 	etcdraftengine "github.com/bootjp/elastickv/internal/raftengine/etcd"
 	"github.com/bootjp/elastickv/kv"
 	"github.com/bootjp/elastickv/store"
+	"github.com/cockroachdb/errors"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -47,6 +48,74 @@ func TestRunWriterRegistration_VerifyCommittedClosesBarrier(t *testing.T) {
 	if !cache.Registered() {
 		t.Error("verify-committed path closed the barrier but did not MarkRegistered (Registered() = false)")
 	}
+}
+
+// TestRetryUntilRegistered covers the §2.3 empty-catalog + active-
+// envelope bootstrap edge that setupDistributionCatalog relies on: the
+// helper must retry while fn returns ErrWriterNotRegistered, then return
+// fn's result once it converges; return any non-gate error immediately;
+// and surface a context.Canceled-chained error on clean shutdown
+// (claude review on PR #847).
+func TestRetryUntilRegistered(t *testing.T) {
+	t.Parallel()
+
+	t.Run("converges after transient ErrWriterNotRegistered", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		err := retryUntilRegistered(context.Background(), "test", func() error {
+			calls++
+			if calls < 3 {
+				return errors.WithStack(store.ErrWriterNotRegistered)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("retryUntilRegistered: %v", err)
+		}
+		if calls != 3 {
+			t.Errorf("fn called %d times, want 3 (2 gate failures + 1 success)", calls)
+		}
+	})
+
+	t.Run("returns non-gate error immediately", func(t *testing.T) {
+		t.Parallel()
+		sentinel := errors.New("some other failure")
+		calls := 0
+		err := retryUntilRegistered(context.Background(), "test", func() error {
+			calls++
+			return sentinel
+		})
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("got %v, want the sentinel error", err)
+		}
+		if calls != 1 {
+			t.Errorf("fn called %d times, want 1 (no retry on non-gate error)", calls)
+		}
+	})
+
+	t.Run("immediate success", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		err := retryUntilRegistered(context.Background(), "test", func() error {
+			calls++
+			return nil
+		})
+		if err != nil || calls != 1 {
+			t.Errorf("got err=%v calls=%d, want nil/1", err, calls)
+		}
+	})
+
+	t.Run("cancellation surfaces context.Canceled", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // already cancelled → first gate failure then ctx.Done()
+		err := retryUntilRegistered(ctx, "test", func() error {
+			return errors.WithStack(store.ErrWriterNotRegistered)
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("got %v, want a context.Canceled-chained error", err)
+		}
+	})
 }
 
 func TestRegistrationEntry_RoundTrips(t *testing.T) {

--- a/main_encryption_registration_test.go
+++ b/main_encryption_registration_test.go
@@ -267,6 +267,40 @@ func TestBuildProcessStartRegistrationGate_NilGateBranches(t *testing.T) {
 	}
 }
 
+// TestBuildProcessStartRegistrationGate_Phase0BootDoesNotArmGate pins
+// the codex P1 fix on PR #847: a node that boots in Phase 0 (envelope
+// inactive) must NOT arm the Stage 7a-2 direct-path gate, so a later
+// runtime EnableStorageEnvelope cannot trap its direct writes forever.
+// After the Phase-0 ungated return, StorageRegistrationSatisfied() must
+// remain true even once the envelope flips active at runtime.
+func TestBuildProcessStartRegistrationGate_Phase0BootDoesNotArmGate(t *testing.T) {
+	t.Parallel()
+	st := newRegistrationTestStore(t)
+	w := wiringFor(t, testRegDEKID, false /*envelope inactive: Phase 0*/, 1)
+
+	eg, _ := errgroup.WithContext(context.Background())
+	gate, err := buildProcessStartRegistrationGate(
+		context.Background(), eg, &kv.ShardedCoordinator{},
+		&kv.ShardGroup{Store: st}, w, "n1")
+	if err != nil {
+		t.Fatalf("buildProcessStartRegistrationGate: %v", err)
+	}
+	if gate == nil || gate.Barrier != nil {
+		t.Fatalf("Phase 0 should be ungated (nil Barrier), got %+v", gate)
+	}
+	// Simulate a runtime EnableStorageEnvelope: the cutover flips the
+	// envelope active on the shared cache.
+	sc := &encryption.Sidecar{Version: encryption.SidecarVersion, StorageEnvelopeActive: true}
+	sc.Active.Storage = testRegDEKID
+	w.cache.RefreshFromSidecar(sc)
+	// The direct-path gate must stay satisfied — the load never armed a
+	// registration, so it is not subject to enforcement (mirrors 7a's
+	// permanently-ungated coordinator gate for Phase-0 boots).
+	if !w.cache.StorageRegistrationSatisfied() {
+		t.Error("Phase-0 boot trapped direct writes after runtime cutover (StorageRegistrationSatisfied=false)")
+	}
+}
+
 // TestBuildProcessStartRegistrationGate_BehindEpochFailsClosed pins
 // codex P1: a strictly-behind epoch (registry last_seen > bumped epoch)
 // must fail closed (error) rather than skip ungated. The §9.1 rollback

--- a/main_encryption_write_wiring.go
+++ b/main_encryption_write_wiring.go
@@ -104,13 +104,12 @@ func (w encryptionWriteWiring) pebbleOptions() []store.PebbleStoreOption {
 		// Stage 7a-2 §4.1 direct-path registration gate: the store
 		// refuses to emit an encrypted envelope on a self-originated
 		// write (catalog bootstrap Save) until this load's writer
-		// registration has committed for the active storage DEK. Uses
-		// StorageRegistrationSatisfied (not Registered directly) so the
-		// gate is inert for loads that never armed a registration — a
-		// Phase-0 boot followed by a runtime EnableStorageEnvelope must
-		// not fail closed forever (codex P1 on PR #847). Reads from the
-		// same shared cache the registration paths arm + MarkRegistered.
-		store.WithStorageRegistrationGate(w.cache.StorageRegistrationSatisfied),
+		// registration has committed for the active storage DEK. Reads
+		// Registered() (per-DEK, fail-closed) from the same shared cache
+		// the registration paths MarkRegistered. Design §2.3 forbids any
+		// fail-OPEN fallback, so unregistered loads are gated — see the
+		// Registered() doc for the deferred runtime-registration cases.
+		store.WithStorageRegistrationGate(w.cache.Registered),
 	}
 }
 

--- a/main_encryption_write_wiring.go
+++ b/main_encryption_write_wiring.go
@@ -104,9 +104,13 @@ func (w encryptionWriteWiring) pebbleOptions() []store.PebbleStoreOption {
 		// Stage 7a-2 §4.1 direct-path registration gate: the store
 		// refuses to emit an encrypted envelope on a self-originated
 		// write (catalog bootstrap Save) until this load's writer
-		// registration has committed for the active storage DEK. Reads
-		// from the same shared cache the registration paths MarkRegistered.
-		store.WithStorageRegistrationGate(w.cache.Registered),
+		// registration has committed for the active storage DEK. Uses
+		// StorageRegistrationSatisfied (not Registered directly) so the
+		// gate is inert for loads that never armed a registration — a
+		// Phase-0 boot followed by a runtime EnableStorageEnvelope must
+		// not fail closed forever (codex P1 on PR #847). Reads from the
+		// same shared cache the registration paths arm + MarkRegistered.
+		store.WithStorageRegistrationGate(w.cache.StorageRegistrationSatisfied),
 	}
 }
 

--- a/main_encryption_write_wiring.go
+++ b/main_encryption_write_wiring.go
@@ -101,6 +101,12 @@ func (w encryptionWriteWiring) pebbleOptions() []store.PebbleStoreOption {
 	return []store.PebbleStoreOption{
 		store.WithEncryption(w.cipher, w.nonceFactory, w.cache.ActiveStorageKeyID),
 		store.WithStorageEnvelopeGate(w.cache.StorageEnvelopeActive),
+		// Stage 7a-2 §4.1 direct-path registration gate: the store
+		// refuses to emit an encrypted envelope on a self-originated
+		// write (catalog bootstrap Save) until this load's writer
+		// registration has committed for the active storage DEK. Reads
+		// from the same shared cache the registration paths MarkRegistered.
+		store.WithStorageRegistrationGate(w.cache.Registered),
 	}
 }
 

--- a/main_encryption_write_wiring_test.go
+++ b/main_encryption_write_wiring_test.go
@@ -60,8 +60,8 @@ func TestEncryptionWriteWiring_PebbleOptions_WiredWhenCipherSet(t *testing.T) {
 		cipher:       cipher,
 		nonceFactory: encryption.NewDeterministicNonceFactory(0xABCD, 0),
 	}
-	if opts := w.pebbleOptions(); len(opts) != 2 {
-		t.Errorf("wired pebbleOptions = %d opts, want 2 (WithEncryption + WithStorageEnvelopeGate)", len(opts))
+	if opts := w.pebbleOptions(); len(opts) != 3 {
+		t.Errorf("wired pebbleOptions = %d opts, want 3 (WithEncryption + WithStorageEnvelopeGate + WithStorageRegistrationGate)", len(opts))
 	}
 }
 
@@ -175,8 +175,10 @@ func TestBuildEncryptionWriteWiring_ActiveDEK_WiresCipher(t *testing.T) {
 	if w.cipher == nil || w.nonceFactory == nil {
 		t.Fatal("cipher/nonceFactory must be wired when encryption is enabled with an active DEK")
 	}
-	if opts := w.pebbleOptions(); len(opts) != 2 {
-		t.Errorf("pebbleOptions = %d, want 2", len(opts))
+	// WithEncryption + WithStorageEnvelopeGate + WithStorageRegistrationGate
+	// (Stage 7a-2 added the third).
+	if opts := w.pebbleOptions(); len(opts) != 3 {
+		t.Errorf("pebbleOptions = %d, want 3", len(opts))
 	}
 	// Cache must reflect the on-disk active DEK + cutover gate.
 	if id, ok := w.cache.ActiveStorageKeyID(); !ok || id != 3 {

--- a/store/encryption_glue.go
+++ b/store/encryption_glue.go
@@ -150,6 +150,27 @@ type ActiveStorageKeyID func() (uint32, bool)
 // the design supports) would still decrypt old envelopes correctly.
 type StorageEnvelopeActive func() bool
 
+// StorageRegistered reports whether this process load's §4.1 writer
+// registration has committed for the currently-active storage DEK
+// (Stage 7a-2). It gates only the DIRECT write path: when it returns
+// false while the envelope would otherwise encrypt, encryptForKey
+// refuses to emit a nonce and returns ErrWriterNotRegistered so the
+// self-originated caller (catalog bootstrap Save, admin snapshot,
+// migration) retries until registration lands rather than emitting an
+// envelope ahead of its writer-registry row.
+//
+// The FSM-apply path never consults it — see WithStorageRegistrationGate.
+type StorageRegistered func() bool
+
+// ErrWriterNotRegistered is returned by the direct write path when the
+// §7.1 storage envelope is active but this process load has not yet
+// confirmed its §4.1 writer registration for the active storage DEK
+// (Stage 7a-2). It is a transient, retryable condition: the caller
+// should retry once registration commits (the barrier closes). Callers
+// disambiguate it with errors.Is so a fail-closed pre-registration
+// write is never mistaken for a permanent storage fault.
+var ErrWriterNotRegistered = errors.New("store: storage envelope active but writer not yet registered; refusing to emit nonce before registration")
+
 // WithEncryption configures the pebble-backed store to wrap every
 // committed value in the §4.1 storage envelope.
 //
@@ -204,6 +225,78 @@ func WithStorageEnvelopeGate(active StorageEnvelopeActive) PebbleStoreOption {
 	}
 }
 
+// WithStorageRegistrationGate wires the Stage 7a-2 §4.1 registration
+// gate in front of the envelope-emit path on the DIRECT write path
+// only. After this option, when the envelope would encrypt
+// (cipher + active DEK + StorageEnvelopeActive all true) but
+// registered() reports false, the direct path (PutAt / ExpireAt /
+// ApplyMutations) returns ErrWriterNotRegistered instead of emitting a
+// nonce. The FSM-apply path (ApplyMutationsRaft) passes
+// gateRegistration=false into encryptForKey and is never gated — see
+// design §1: replicated apply must stay deterministic and may run
+// before this node's own registration entry commits, so fail-closing
+// it would halt the apply loop (and deadlock a node whose storage
+// entry is ordered before its registration entry).
+//
+// Passing nil is a no-op: the store keeps the pre-7a-2 posture where
+// the direct path emits envelopes as soon as the cutover gate is open,
+// used by existing fixtures and by deployments that have not wired the
+// writer registry. Operators thread cache.Registered in via main.go.
+func WithStorageRegistrationGate(registered StorageRegistered) PebbleStoreOption {
+	return func(s *pebbleStore) {
+		if registered == nil {
+			return
+		}
+		s.storageRegistered = registered
+	}
+}
+
+// resolveEnvelopeEmit folds the cipher-wired / active-DEK / §6.2
+// cutover-gate checks and the Stage 7a-2 §4.1 registration gate into a
+// single decision for encryptForKey. It returns (keyID, true, nil) when
+// the value should be wrapped, (0, false, nil) when it should pass
+// through cleartext, and (0, false, ErrWriterNotRegistered) when the
+// direct path would encrypt but this load's writer registration has not
+// yet committed.
+//
+// The cutover gate (storageEnvelopeActive) stays unconsulted when not
+// wired so pre-6D-6 fixtures keep working; the registration gate
+// (storageRegistered) likewise no-ops when not wired, preserving the
+// pre-7a-2 posture. gateRegistration is false on the FSM-apply path so
+// replicated apply is never blocked (design §1).
+func (s *pebbleStore) resolveEnvelopeEmit(gateRegistration bool) (keyID uint32, encrypt bool, err error) {
+	if s.cipher == nil || s.activeStorageKeyID == nil {
+		return 0, false, nil
+	}
+	id, ok := s.activeStorageKeyID()
+	if !ok {
+		return 0, false, nil
+	}
+	// Stage 6D-5 §6.2 cutover gate. When the gate is wired AND reports
+	// false (`sidecar.StorageEnvelopeActive == false`), fall through to
+	// cleartext even though a DEK is active. This is the only
+	// correctness-critical site for the §7.1 Phase 0 → Phase 1 split: a
+	// pre-cutover Put that emitted an envelope would advance the
+	// writer-registry nonce counter before every replica had agreed the
+	// cutover applied, opening the cross-replica nonce-divergence race
+	// the §6.4 atomicity contract is built to close.
+	if s.storageEnvelopeActive != nil && !s.storageEnvelopeActive() {
+		return 0, false, nil
+	}
+	// Stage 7a-2 §4.1 registration gate. Reaching here means we WILL
+	// emit an envelope (cipher + active DEK + cutover all confirmed). On
+	// the direct path, refuse to emit the nonce until this load's writer
+	// registration has committed — otherwise a self-originated write
+	// (catalog bootstrap Save) could advance the nonce counter before the
+	// writer-registry row exists, the exact pre-registration emission
+	// 7a-2 closes. The FSM-apply path passes gateRegistration=false and
+	// is never blocked here (design §1).
+	if gateRegistration && s.storageRegistered != nil && !s.storageRegistered() {
+		return 0, false, errors.WithStack(ErrWriterNotRegistered)
+	}
+	return id, true, nil
+}
+
 // encryptForKey wraps plaintext in the §4.1 storage envelope when an
 // encryption key is active for the storage purpose. Returns
 // (plaintext, encStateCleartext, nil) when encryption is disabled or
@@ -226,26 +319,25 @@ func WithStorageEnvelopeGate(active StorageEnvelopeActive) PebbleStoreOption {
 // encrypt path is never invoked for tombstone writes (deletes carry
 // no plaintext and are emitted as cleartext by the store
 // already).
-func (s *pebbleStore) encryptForKey(pebbleKey, plaintext []byte, expireAt uint64) ([]byte, byte, error) {
-	if s.cipher == nil || s.activeStorageKeyID == nil {
-		return plaintext, encStateCleartext, nil
+//
+// gateRegistration selects the Stage 7a-2 §4.1 registration enforcement
+// (design §1): true on the DIRECT write path (PutAt / ExpireAt /
+// ApplyMutations), where a self-originated encrypted write must not
+// emit a nonce before this load's writer registration commits; false
+// on the FSM-apply path (ApplyMutationsRaft), which must stay
+// deterministic and may legitimately encrypt during the pre-registration
+// window. When true and the registration gate is wired and reports
+// false, returns ErrWriterNotRegistered without emitting a nonce.
+//
+// The encrypt-vs-cleartext decision (and the registration gate) lives
+// in resolveEnvelopeEmit so this function stays within the cyclop
+// budget.
+func (s *pebbleStore) encryptForKey(pebbleKey, plaintext []byte, expireAt uint64, gateRegistration bool) ([]byte, byte, error) {
+	keyID, encrypt, err := s.resolveEnvelopeEmit(gateRegistration)
+	if err != nil {
+		return nil, 0, err
 	}
-	keyID, ok := s.activeStorageKeyID()
-	if !ok {
-		return plaintext, encStateCleartext, nil
-	}
-	// Stage 6D-5 §6.2 cutover gate. When the gate is wired AND
-	// reports false (`sidecar.StorageEnvelopeActive == false`),
-	// fall through to the cleartext path even though a DEK is
-	// active. This is the only correctness-critical site for the
-	// §7.1 Phase 0 → Phase 1 split: a pre-cutover Put that emitted
-	// an envelope would advance the writer-registry nonce counter
-	// before every replica had agreed the cutover applied, opening
-	// the cross-replica nonce-divergence race the §6.4 atomicity
-	// contract is built to close. The gate stays unconsulted when
-	// not wired so existing fixtures + the pre-6D-6 production
-	// posture keep working unchanged.
-	if s.storageEnvelopeActive != nil && !s.storageEnvelopeActive() {
+	if !encrypt {
 		return plaintext, encStateCleartext, nil
 	}
 	nonceArr, err := s.nonceFactory.Next()

--- a/store/lsm_store.go
+++ b/store/lsm_store.go
@@ -214,6 +214,17 @@ type pebbleStore struct {
 	// fixtures depend on that posture and the 6D-6 production wiring
 	// in main.go is what flips the gate on.
 	storageEnvelopeActive StorageEnvelopeActive
+	// storageRegistered is the Stage 7a-2 §4.1 registration gate. When
+	// wired, the DIRECT write path (PutAt / ExpireAt / ApplyMutations)
+	// refuses to emit an encrypted envelope — returning
+	// ErrWriterNotRegistered — until this process load's writer
+	// registration has committed for the active storage DEK. The
+	// FSM-apply path (ApplyMutationsRaft) never consults it: replicated
+	// apply must stay deterministic and may legitimately run before this
+	// node's own registration entry commits (design §1). A nil closure
+	// preserves the pre-7a-2 posture (no direct-path gating); the
+	// production main.go wiring threads cache.Registered in.
+	storageRegistered StorageRegistered
 }
 
 // Ensure pebbleStore implements MVCCStore and RetentionController.
@@ -1028,7 +1039,8 @@ func (s *pebbleStore) PutAt(ctx context.Context, key []byte, value []byte, commi
 	commitTS = s.alignCommitTS(commitTS)
 
 	k := encodeKey(key, commitTS)
-	body, encState, err := s.encryptForKey(k, value, expireAt)
+	// gateRegistration=true: PutAt is a direct (non-raft) write path.
+	body, encState, err := s.encryptForKey(k, value, expireAt, true)
 	if err != nil {
 		return err
 	}
@@ -1073,7 +1085,9 @@ func (s *pebbleStore) ExpireAt(ctx context.Context, key []byte, expireAt uint64,
 
 	commitTS = s.alignCommitTS(commitTS)
 	k := encodeKey(key, commitTS)
-	body, encState, err := s.encryptForKey(k, val, expireAt)
+	// gateRegistration=true: ExpireAt is a direct (non-raft) write path
+	// that calls encryptForKey directly (it does not delegate to PutAt).
+	body, encState, err := s.encryptForKey(k, val, expireAt, true)
 	if err != nil {
 		return err
 	}
@@ -1164,7 +1178,7 @@ func (s *pebbleStore) WriteConflictCount() uint64 {
 	return s.writeConflicts.total()
 }
 
-func (s *pebbleStore) applyMutationsBatch(b *pebble.Batch, mutations []*KVPairMutation, commitTS uint64) error {
+func (s *pebbleStore) applyMutationsBatch(b *pebble.Batch, mutations []*KVPairMutation, commitTS uint64, gateRegistration bool) error {
 	for _, mut := range mutations {
 		k := encodeKey(mut.Key, commitTS)
 		var v []byte
@@ -1174,7 +1188,7 @@ func (s *pebbleStore) applyMutationsBatch(b *pebble.Batch, mutations []*KVPairMu
 			if err := validateValueSize(mut.Value); err != nil {
 				return err
 			}
-			body, encState, encErr := s.encryptForKey(k, mut.Value, mut.ExpireAt)
+			body, encState, encErr := s.encryptForKey(k, mut.Value, mut.ExpireAt, gateRegistration)
 			if encErr != nil {
 				return encErr
 			}
@@ -1213,7 +1227,11 @@ func (s *pebbleStore) raftApplyWriteOpts() *pebble.WriteOptions {
 // backstop (catalog bootstrap, admin snapshots, migrations, tests) are never
 // affected by ELASTICKV_FSM_SYNC_MODE=nosync.
 func (s *pebbleStore) ApplyMutations(ctx context.Context, mutations []*KVPairMutation, readKeys [][]byte, startTS, commitTS uint64) error {
-	return s.applyMutationsWithOpts(ctx, mutations, readKeys, startTS, commitTS, s.directApplyWriteOpts())
+	// gateRegistration=true: the direct path is self-originated (catalog
+	// bootstrap Save, admin snapshot, migration). Stage 7a-2 refuses to
+	// emit an encrypted envelope here before this load's writer
+	// registration commits.
+	return s.applyMutationsWithOpts(ctx, mutations, readKeys, startTS, commitTS, s.directApplyWriteOpts(), true)
 }
 
 // ApplyMutationsRaft is the raft-apply commit path. Durability is governed
@@ -1227,10 +1245,15 @@ func (s *pebbleStore) ApplyMutations(ctx context.Context, mutations []*KVPairMut
 // must use ApplyMutations so a nosync opt-in cannot silently drop
 // acknowledged writes that have no raft backstop.
 func (s *pebbleStore) ApplyMutationsRaft(ctx context.Context, mutations []*KVPairMutation, readKeys [][]byte, startTS, commitTS uint64) error {
-	return s.applyMutationsWithOpts(ctx, mutations, readKeys, startTS, commitTS, s.raftApplyWriteOpts())
+	// gateRegistration=false: the FSM-apply path replays committed Raft
+	// entries and must stay deterministic. It may legitimately encrypt
+	// before this node's own registration entry commits (design §1);
+	// fail-closing here would halt the apply loop and could deadlock a
+	// node whose storage entry is ordered before its registration entry.
+	return s.applyMutationsWithOpts(ctx, mutations, readKeys, startTS, commitTS, s.raftApplyWriteOpts(), false)
 }
 
-func (s *pebbleStore) applyMutationsWithOpts(ctx context.Context, mutations []*KVPairMutation, readKeys [][]byte, startTS, commitTS uint64, writeOpts *pebble.WriteOptions) error {
+func (s *pebbleStore) applyMutationsWithOpts(ctx context.Context, mutations []*KVPairMutation, readKeys [][]byte, startTS, commitTS uint64, writeOpts *pebble.WriteOptions, gateRegistration bool) error {
 	s.dbMu.RLock()
 	defer s.dbMu.RUnlock()
 
@@ -1249,7 +1272,7 @@ func (s *pebbleStore) applyMutationsWithOpts(ctx context.Context, mutations []*K
 		return err
 	}
 
-	if err := s.applyMutationsBatch(b, mutations, commitTS); err != nil {
+	if err := s.applyMutationsBatch(b, mutations, commitTS, gateRegistration); err != nil {
 		return err
 	}
 

--- a/store/lsm_store_registration_gate_test.go
+++ b/store/lsm_store_registration_gate_test.go
@@ -1,0 +1,219 @@
+package store
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/cockroachdb/errors"
+)
+
+// regGateFixture wires an encrypted PebbleStore with the §7.1 cutover
+// gate ALWAYS active and the Stage 7a-2 registration gate driven by a
+// caller-toggled `registered` pointer, so a test can exercise the
+// pre-registration (false) vs post-registration (true) direct-write
+// behaviour without re-opening the store.
+type regGateFixture struct {
+	mvcc       MVCCStore
+	registered *bool
+}
+
+// regGateDEKID is the storage DEK id used across the registration-gate
+// fixtures.
+const regGateDEKID uint32 = 7
+
+func newRegGateStore(t *testing.T, registered *bool) *regGateFixture {
+	t.Helper()
+	ks := encryption.NewKeystore()
+	dek := make([]byte, encryption.KeySize)
+	dek[0] = 0xCC
+	if err := ks.Set(regGateDEKID, dek); err != nil {
+		t.Fatalf("Keystore.Set: %v", err)
+	}
+	c, err := encryption.NewCipher(ks)
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	dir := filepath.Join(t.TempDir(), "pebble")
+	mvcc, err := NewPebbleStore(dir,
+		WithEncryption(c,
+			NewCounterNonceFactory(0x00AA, 0x0005),
+			func() (uint32, bool) { return regGateDEKID, true }, // DEK always provisioned
+		),
+		WithStorageEnvelopeGate(func() bool { return true }), // cutover fired
+		WithStorageRegistrationGate(func() bool { return *registered }),
+	)
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	t.Cleanup(func() {
+		if cerr := mvcc.Close(); cerr != nil {
+			t.Errorf("cleanup close pebble: %v", cerr)
+		}
+	})
+	return &regGateFixture{mvcc: mvcc, registered: registered}
+}
+
+// TestRegistrationGate_DirectPathFailsClosedBeforeRegistration pins
+// the Stage 7a-2 §4.1 enforcement: with the envelope active and an
+// active DEK, the DIRECT write paths (PutAt, ExpireAt, ApplyMutations)
+// refuse to emit a nonce until the writer registration commits,
+// returning ErrWriterNotRegistered. After registration the same write
+// succeeds.
+func TestRegistrationGate_DirectPathFailsClosedBeforeRegistration(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("PutAt", func(t *testing.T) {
+		t.Parallel()
+		registered := false
+		f := newRegGateStore(t, &registered)
+		err := f.mvcc.PutAt(ctx, []byte("k"), []byte("v"), 100, 0)
+		if !errors.Is(err, ErrWriterNotRegistered) {
+			t.Fatalf("PutAt pre-registration: got %v, want ErrWriterNotRegistered", err)
+		}
+		registered = true
+		if err := f.mvcc.PutAt(ctx, []byte("k"), []byte("v"), 200, 0); err != nil {
+			t.Fatalf("PutAt post-registration: %v", err)
+		}
+		mustGet(t, f.mvcc, []byte("k"), 250, "v")
+	})
+
+	t.Run("ApplyMutations", func(t *testing.T) {
+		t.Parallel()
+		registered := false
+		f := newRegGateStore(t, &registered)
+		muts := []*KVPairMutation{{Op: OpTypePut, Key: []byte("a"), Value: []byte("1")}}
+		err := f.mvcc.ApplyMutations(ctx, muts, nil, 0, 100)
+		if !errors.Is(err, ErrWriterNotRegistered) {
+			t.Fatalf("ApplyMutations pre-registration: got %v, want ErrWriterNotRegistered", err)
+		}
+		registered = true
+		if err := f.mvcc.ApplyMutations(ctx, muts, nil, 0, 200); err != nil {
+			t.Fatalf("ApplyMutations post-registration: %v", err)
+		}
+		mustGet(t, f.mvcc, []byte("a"), 250, "1")
+	})
+
+	t.Run("ExpireAt", func(t *testing.T) {
+		t.Parallel()
+		// ExpireAt re-encrypts the latest value, so seed a value first
+		// (post-registration), then flip back to exercise the gate on the
+		// ExpireAt direct-write itself.
+		registered := true
+		f := newRegGateStore(t, &registered)
+		if err := f.mvcc.PutAt(ctx, []byte("e"), []byte("v"), 100, 0); err != nil {
+			t.Fatalf("seed PutAt: %v", err)
+		}
+		registered = false
+		err := f.mvcc.ExpireAt(ctx, []byte("e"), 5000, 200)
+		if !errors.Is(err, ErrWriterNotRegistered) {
+			t.Fatalf("ExpireAt pre-registration: got %v, want ErrWriterNotRegistered", err)
+		}
+		registered = true
+		if err := f.mvcc.ExpireAt(ctx, []byte("e"), 5000, 300); err != nil {
+			t.Fatalf("ExpireAt post-registration: %v", err)
+		}
+	})
+}
+
+// TestRegistrationGate_FSMApplyPathNeverGated pins design §1: the
+// FSM-apply path (ApplyMutationsRaft) must NOT fail closed on
+// not-registered — replicated apply stays deterministic and may
+// legitimately encrypt before this node's own registration entry
+// commits. With registered=false it still encrypts and round-trips.
+func TestRegistrationGate_FSMApplyPathNeverGated(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	registered := false // never registered
+	f := newRegGateStore(t, &registered)
+	muts := []*KVPairMutation{{Op: OpTypePut, Key: []byte("raft"), Value: []byte("applied")}}
+	if err := f.mvcc.ApplyMutationsRaft(ctx, muts, nil, 0, 100); err != nil {
+		t.Fatalf("ApplyMutationsRaft must not be gated, got: %v", err)
+	}
+	mustGet(t, f.mvcc, []byte("raft"), 150, "applied")
+}
+
+// TestRegistrationGate_NotEncryptingIsUngated confirms the gate is only
+// consulted when the write WOULD encrypt. When the cutover gate is off
+// (envelope inactive) the direct path writes cleartext and never
+// consults Registered(), so an unregistered node is not blocked.
+func TestRegistrationGate_NotEncryptingIsUngated(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ks := encryption.NewKeystore()
+	dek := make([]byte, encryption.KeySize)
+	dek[0] = 0xDD
+	if err := ks.Set(7, dek); err != nil {
+		t.Fatalf("Keystore.Set: %v", err)
+	}
+	c, err := encryption.NewCipher(ks)
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	dir := filepath.Join(t.TempDir(), "pebble")
+	registered := false
+	mvcc, err := NewPebbleStore(dir,
+		WithEncryption(c,
+			NewCounterNonceFactory(0x00BB, 0x0006),
+			func() (uint32, bool) { return 7, true },
+		),
+		WithStorageEnvelopeGate(func() bool { return false }), // cutover NOT fired
+		WithStorageRegistrationGate(func() bool { return registered }),
+	)
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	t.Cleanup(func() {
+		if cerr := mvcc.Close(); cerr != nil {
+			t.Errorf("cleanup close: %v", cerr)
+		}
+	})
+	// Envelope inactive → cleartext write → gate not consulted → no error
+	// despite registered=false.
+	if err := mvcc.PutAt(ctx, []byte("k"), []byte("v"), 100, 0); err != nil {
+		t.Fatalf("PutAt with envelope inactive must not be gated: %v", err)
+	}
+	mustGet(t, mvcc, []byte("k"), 150, "v")
+}
+
+// TestRegistrationGate_UnwiredIsNoOp confirms backward compatibility:
+// a store wired with WithEncryption + the cutover gate but WITHOUT
+// WithStorageRegistrationGate keeps the pre-7a-2 posture — the direct
+// path emits envelopes without consulting any registration state.
+func TestRegistrationGate_UnwiredIsNoOp(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ks := encryption.NewKeystore()
+	dek := make([]byte, encryption.KeySize)
+	dek[0] = 0xEE
+	if err := ks.Set(7, dek); err != nil {
+		t.Fatalf("Keystore.Set: %v", err)
+	}
+	c, err := encryption.NewCipher(ks)
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	dir := filepath.Join(t.TempDir(), "pebble")
+	mvcc, err := NewPebbleStore(dir,
+		WithEncryption(c,
+			NewCounterNonceFactory(0x00CC, 0x0007),
+			func() (uint32, bool) { return 7, true },
+		),
+		WithStorageEnvelopeGate(func() bool { return true }),
+		// No WithStorageRegistrationGate.
+	)
+	if err != nil {
+		t.Fatalf("NewPebbleStore: %v", err)
+	}
+	t.Cleanup(func() {
+		if cerr := mvcc.Close(); cerr != nil {
+			t.Errorf("cleanup close: %v", cerr)
+		}
+	})
+	if err := mvcc.PutAt(ctx, []byte("k"), []byte("v"), 100, 0); err != nil {
+		t.Fatalf("PutAt with unwired registration gate must succeed: %v", err)
+	}
+	mustGet(t, mvcc, []byte("k"), 150, "v")
+}


### PR DESCRIPTION
## Summary
Implements **Stage 7a-2** — storage-layer registration enforcement — against the merged design (#843). It closes the direct-store-write gap codex P1 #3 flagged on #839: `CatalogStore.Save → store.ApplyMutations → encryptForKey` emits a §4.1 nonce without consulting 7a's coordinator-layer barrier. 7a-2 enforces registration at the single nonce-emission chokepoint, `store.encryptForKey`.

## Key constraint (design §1): per-call-path enforcement
`encryptForKey` is reached from two caller classes treated differently:
- **DIRECT** (`PutAt` / `ExpireAt` / `ApplyMutations`, e.g. catalog bootstrap `Save`) → **fail closed** with `ErrWriterNotRegistered` until this load's writer registration commits.
- **FSM-apply** (`ApplyMutationsRaft`) → **never gated**: replicated apply must stay deterministic and may legitimately encrypt before this node's own registration entry commits. Fail-closing it would halt the apply loop (and deadlock a node whose storage entry is ordered before its registration entry).

## Changes
- **`encryption.StateCache`**: `registeredStorageDEKID atomic.Uint32` + `MarkRegistered(dekID)` / `Registered()` — lock-free, per-DEK so a 7b `rotate-dek` re-arms the gate without a reset.
- **`store`**: `ErrWriterNotRegistered`, `WithStorageRegistrationGate` option; `gateRegistration bool` threaded through `encryptForKey` / `applyMutationsBatch` / `applyMutationsWithOpts` (`ApplyMutations`→true, `ApplyMutationsRaft`→false). `resolveEnvelopeEmit` extracted to keep `encryptForKey` within the cyclop budget.
- **`main`**: `releaseBarrier` seeds the gate at **both** barrier-close sites; the `epoch == lastSeen` already-registered restart branch seeds it too (codex P1 on #843 — otherwise every steady-state restart would fail-close the bootstrap `Save`); startup **reordered** to arm the registration gate before `EnsureCatalogSnapshot`, with a bounded `retryUntilRegistered` for the empty-catalog + active-envelope edge (design §2.3). `Registered()` wired into the PebbleStore options.

## Self-review (5 lenses)
1. **Data loss** — gate only refuses to *emit* a pre-registration encrypted write (typed retryable error); never drops a committed write; FSM-apply path untouched → no apply halt.
2. **Concurrency / distributed** — `Registered()` is two atomic loads; FSM-apply skips the check entirely (`gateRegistration=false`); `releaseBarrier` MarkRegisters before `close()` so coordinator-released writes never race a still-false gate.
3. **Performance** — hot path adds at most two atomic loads on the direct write path; FSM-apply path unchanged (one extra bool arg).
4. **Data consistency** — coordinator gate + this direct-path gate together cover every self-originated encrypted write; FSM-apply determinism preserved.
5. **Test coverage** — direct pre/post-registration → `ErrWriterNotRegistered`/encrypt; FSM-apply never gated; envelope-inactive / unwired-gate no-op; already-registered restart seeds `Registered()` true; `StateCache.Registered` per-DEK + rotate-dek re-arm.

§5 design verification confirmed: `OpRegistration` apply (`kv/fsm_encryption.go`) writes only a writer-registry row — no distribution/route-catalog call, no import — so arm-before-bootstrap has no cycle; `encryptForKey` has exactly 3 callers.

## Test plan
- [x] `go test ./store/ ./internal/encryption/ ./kv/ .` (race) — green
- [x] `golangci-lint run` — 0 issues
- [x] `go build ./...`
- [ ] CI full suite. Note: `./adapter` has a **pre-existing local test hang** (grpc server-leak goroutine, reproducible on clean `main` at 240s) — unrelated to this change; no adapter test wires the registration gate, so `storageRegistered` is nil (inert).
