### PR TITLE
docs(encryption): Stage 7b proposed - runtime writer re-registration

### DIFF
--- a/docs/design/2026_05_28_proposed_7b_runtime_reregistration.md
+++ b/docs/design/2026_05_28_proposed_7b_runtime_reregistration.md
@@ -152,9 +152,14 @@ gating on the deferred rotation branch. It runs for the lifetime of
    (§2.2).
 
 4. **Marks** on success via the existing `releaseBarrier(barrier,
-   cache, activeDEK)` helper (with a fresh per-attempt barrier whose
-   only consumer is the watcher). Once `MarkRegistered(activeDEK)`
-   stores, `cache.Registered()` returns true and the gate clears.
+   cache, activeDEK)` helper. The barrier is a fresh per-attempt
+   `chan struct{}` passed in solely to satisfy
+   `runWriterRegistration`'s call signature; **the watcher does NOT
+   `select` on it** — the coordinator's per-load barrier was closed by
+   process-start and is not re-opened by the watcher. The meaningful
+   side effect inside `releaseBarrier` is the `MarkRegistered(activeDEK)`
+   call. Once that stores, `cache.Registered()` returns true and the
+   gate clears.
 
 5. **Backs off** between attempts using the existing
    `registrationRetryInitial / registrationRetryMax /
@@ -365,10 +370,23 @@ already confirmed).
    crashed before `MarkRegistered` will be picked up by `verifyRegistered`
    on the next propose, short-circuiting before re-proposing.
 
-6. Add a unit test for the pre-bootstrap branch
-   (`bootDEKID == 0` → runtime `BootstrapEncryption` + cutover): the
-   watcher proposes for the freshly-installed DEK X at `w.epoch == 0`.
-   This pins the codex P1 round-2 fix.
+6. Add unit tests for the pre-bootstrap branch
+   (`bootDEKID == 0`), split per claude P2 round-3 to cover both
+   structurally distinct sub-paths:
+   - **6a — bootstrap-then-cutover.** `bootDEKID == 0` → runtime
+     `BootstrapEncryption` installs DEK X → `EnableStorageEnvelope`
+     fires while X is the active DEK → watcher proposes
+     `(X, node, 0)`. (`sidecar.Keys[X].LocalEpoch == 0 == w.epoch`.)
+     This pins the codex P1 round-2 fix.
+   - **6b — bootstrap-then-rotate-then-cutover.** `bootDEKID == 0` →
+     `BootstrapEncryption` installs DEK X → `RotateDEK` X→Y (before
+     first cutover) → `EnableStorageEnvelope` → `activeDEK == Y`,
+     `bootDEKID == 0` keeps the skip-condition false, watcher proposes
+     `(Y, node, 0)`. The invariant `sidecar.Keys[Y].LocalEpoch == 0 ==
+     w.epoch` still holds because `writeRotationSidecar` initialises
+     `LocalEpoch` to 0 for the newly-installed DEK and the live nonce
+     factory is still pinned at `w.epoch == 0` (no `BumpLocalEpoch`
+     ever ran on a pre-bootstrap load).
 
 ## 6. Deferred — rotation case (7b')
 

--- a/docs/design/2026_05_28_proposed_7b_runtime_reregistration.md
+++ b/docs/design/2026_05_28_proposed_7b_runtime_reregistration.md
@@ -1,4 +1,4 @@
-# Stage 7b — runtime writer re-registration (cutover + rotation cases)
+# Stage 7b — runtime writer re-registration (cutover case only; rotation deferred)
 
 | Field | Value |
 |---|---|
@@ -11,34 +11,47 @@
 
 7a registers a process at process start. 7a-2 wires the storage-layer
 direct-path gate to `Registered()` — per-DEK and fail-closed. Two
-runtime scenarios fall outside 7a's process-start arm and are explicitly
-deferred as the "runtime-cutover registration follow-on" in 7a's
-docstring. Both surfaced as codex **P1** findings on PR #847:
+runtime scenarios fall outside 7a's process-start arm and surfaced as
+codex **P1** findings on PR #847:
 
-1. **Phase-0 boot → runtime `EnableStorageEnvelope`.** A node that booted
-   in Phase 0 (envelope inactive) skips `buildProcessStartRegistrationGate`'s
-   propose path. When `EnableStorageEnvelope` later applies at runtime, the
-   storage gate transitions from "not consulted" (envelope inactive) to
-   "fail-closed for an unregistered node" — direct encrypted writes are
-   refused indefinitely.
+1. **Phase-0 boot → runtime `EnableStorageEnvelope` (in scope for 7b).**
+   A node that booted in Phase 0 (envelope inactive) skips
+   `buildProcessStartRegistrationGate`'s propose path. When
+   `EnableStorageEnvelope` later applies at runtime, the storage gate
+   transitions from "not consulted" (envelope inactive) to "fail-closed
+   for an unregistered node" — direct encrypted writes are refused
+   indefinitely. **The active DEK does NOT change**, only the envelope
+   activates. `prepareStorageNonceEpoch` already called
+   `BumpLocalEpoch` for the active DEK at startup, so the sidecar's
+   `Keys[activeDEK].LocalEpoch` equals this load's pinned `w.epoch` —
+   registering at `w.epoch` keeps the sidecar and the writer-registry
+   consistent across restart.
 
-2. **Non-proposer node after runtime `RotateDEK`.** `applyRotateDEK`
-   inserts only the *proposer's* registration row for the new DEK
-   (`p.ProposerRegistration`). Every other node has `activeStorageDEKID`
-   re-pointed to the new DEK by `RefreshFromSidecar`, so its `Registered()`
-   transitions to false (the new id ≠ `registeredStorageDEKID`). Without
-   a runtime re-arm those nodes fail closed on the next direct encrypted
-   write until restart.
+2. **Non-proposer node after runtime `RotateDEK` (NOT in scope; deferred to 7b').**
+   `applyRotateDEK` inserts only the *proposer's* registration row for
+   the new DEK; every other node has `activeStorageDEKID` re-pointed to
+   the new DEK and `Registered()` returns false for it. Registering the
+   new DEK at the current load's pinned `w.epoch` would not work
+   safely — the sidecar's `Keys[newDEK].LocalEpoch` starts at 0 and is
+   bumped only on the next restart, so the registry's
+   `LastSeenLocalEpoch` for `(newDEK, node)` would diverge from the
+   sidecar and either brick the node on next restart (`w.epoch_new <
+   lastSeen`) or, if the §9.1 guard were bypassed, open a real nonce
+   reuse window. The fix requires either rebuilding the nonce factory
+   per-DEK on rotation or per-node sidecar coordination at apply time
+   — both materially larger than 7b's intended watcher slice. See §6.
+   Both codex (P1 on PR #848) and gemini (medium #2 on PR #848)
+   independently flagged this; 7b explicitly defers case 2.
 
-Both share one mechanism: when the storage gate *would* fail closed
-because the active DEK changed (or just became live), the affected node
-must propose its own registration row for the new DEK and seed
-`Registered()` once the entry commits — exactly what 7a does at process
-start, but driven by a cache transition rather than a startup decision.
-
-7b adds that runtime trigger. It is **not** a fail-OPEN fallback (design
-§2.3 of 7a-2 forbids those): the storage gate remains fail-closed for
-unregistered nodes; 7b just clears the gate by *actually registering*.
+For case 1 only, 7b adds a runtime trigger: when the storage gate
+*would* fail closed because the envelope just became live and the node
+never registered (active DEK unchanged), propose the node's own
+registration row and seed `Registered()` once the entry commits —
+exactly what 7a does at process start, but driven by the cache
+transition rather than a startup decision. It is **not** a fail-OPEN
+fallback (design §2.3 of 7a-2 forbids those): the storage gate remains
+fail-closed for unregistered nodes; 7b just clears the gate by
+*actually registering*.
 
 (7c — ConfChange-time registration for a freshly-joining node — is a
 distinct mechanism, membership-driven rather than cache-driven, and is
@@ -54,19 +67,23 @@ cache.StorageEnvelopeActive() && id, ok := cache.ActiveStorageKeyID(); ok && !ca
 ```
 
 This is precisely the state where `encryptForKey` on the direct path
-would return `ErrWriterNotRegistered`. The two runtime scenarios above
-both produce it:
+would return `ErrWriterNotRegistered`. The 7b watcher acts on this
+condition **only when the active DEK ID matches the boot-time active
+DEK** (`activeStorageDEKID` unchanged since process start) — i.e. the
+cutover case where `StorageEnvelopeActive` flipped but the DEK is the
+same one `prepareStorageNonceEpoch` bumped at startup. When the
+condition holds with a *different* active DEK id, that is the deferred
+rotation case (§6); the watcher logs and skips it.
 
-- After `EnableStorageEnvelope` apply: `StorageEnvelopeActive` flips
-  true; if this node never registered, `Registered()` is false.
-- After `RotateDEK` apply on a non-proposer: `activeStorageDEKID`
-  changes to the new id; `registeredStorageDEKID` still holds the old
-  id, so `Registered()` returns false.
+After `EnableStorageEnvelope` apply: `StorageEnvelopeActive` flips
+true; if this node never registered, `Registered()` is false; the boot
+DEK is unchanged. The trigger fires.
 
-The trigger is read off the shared `*encryption.StateCache`, which both
-apply paths already update (`a.stateCache.RefreshFromSidecar(sc)` after
-each `WriteSidecar`). 7b does not introduce a new wire-format event;
-it observes the existing cache transitions.
+The trigger is read off the shared `*encryption.StateCache`, which
+`applyEnableStorageEnvelope` and `applyRotateDEK` already update via
+`RefreshFromSidecar(sc)` after each `WriteSidecar`. 7b does not
+introduce a new wire-format event; it observes the existing cache
+transitions.
 
 ## 2. Proposed design
 
@@ -84,21 +101,24 @@ runs for the lifetime of `runCtx` and:
    there is no risk of an unbounded wakeup storm during normal operation
    (the condition flips at most once per cutover/rotation).
 
-2. **Dedupes** against the already-marked DEK: if
-   `cache.Registered()` is true the loop body is a no-op for this tick.
-   When the active DEK transitions to a new id and the registration for
-   it has not yet committed, the body proceeds.
+2. **Dedupes / scope-checks**: skip the body when (a) the cache reports
+   `Registered() == true`, (b) `StorageEnvelopeActive() == false`, or
+   (c) the active DEK id has changed from the boot-time DEK (the
+   deferred rotation case — log once and skip). Only the cutover-case
+   condition triggers the propose.
 
-3. **Proposes** a registration entry for `(activeDEK, fullNodeID,
-   w.epoch)` using the *same* `runWriterRegistration` helper 7a already
-   uses. The `local_epoch` is `w.epoch` — this load's pinned epoch from
-   `buildEncryptionWriteWiring` — which is what the nonce factory
-   actually emits, so the writer-registry row that lands is consistent
-   with on-disk nonces.
+3. **Proposes** synchronously a registration entry for
+   `(bootDEK, fullNodeID, w.epoch)` using the *same*
+   `runWriterRegistration` helper 7a already uses. The `local_epoch` is
+   `w.epoch` — this load's pinned epoch from
+   `buildEncryptionWriteWiring`, post-`BumpLocalEpoch` for the boot
+   DEK — which is what the nonce factory actually emits AND equals
+   `sidecar.Keys[bootDEK].LocalEpoch`, so the writer-registry row stays
+   coherent with the sidecar across restart (§2.2).
 
 4. **Marks** on success via the existing `releaseBarrier(barrier,
-   cache, activeDEK)` helper (with a fresh per-attempt barrier whose
-   only consumer is the watcher). Once `MarkRegistered(activeDEK)`
+   cache, bootDEK)` helper (with a fresh per-attempt barrier whose
+   only consumer is the watcher). Once `MarkRegistered(bootDEK)`
    stores, `cache.Registered()` returns true and the gate clears.
 
 5. **Backs off** between attempts using the existing
@@ -106,29 +126,64 @@ runs for the lifetime of `runCtx` and:
    registrationBackoffFactor`. Failures are bounded by `runCtx`; on
    shutdown the goroutine returns without leaving stale state.
 
+**Concurrency model (addresses gemini medium #1 on PR #848).** The
+watcher is a single goroutine and the propose is **synchronous in that
+goroutine** — no fan-out of background registration workers. This
+means:
+
+- At most one in-flight propose at any time → no goroutine
+  accumulation across poll ticks, no duplicate Raft proposals from
+  the watcher itself.
+- The next poll tick can only fire AFTER the current `runWriterRegistration`
+  returns (success, verify-committed, or `runCtx` cancellation). The
+  per-attempt `registrationAttemptTimeout` (5 s) bounds how long any
+  single sub-attempt can block before yielding back to the retry loop.
+- The watcher does **not** need to support DEK changing during an
+  in-flight propose, because rotation is out of scope (§6) and the
+  cutover case does not change the active DEK. If a rotation
+  *nevertheless* happens mid-propose, the worst case is the watcher
+  completes registration for the (now stale) boot DEK; the loop body
+  on the next tick observes the rotated active DEK ≠ boot DEK and
+  takes the deferred-skip branch (log once). No fail-OPEN, no
+  goroutine leak.
+
 The watcher does **not** touch the `RegistrationGate` the coordinator
 holds — 7a's coordinator-layer barrier is a per-process-load
-construct, not a per-DEK one. Runtime rotation does not introduce a new
-coordinator barrier; it only needs the storage-layer `Registered()`
+construct, not a per-DEK one. The cutover case does not introduce a
+new coordinator barrier; it only needs the storage-layer `Registered()`
 predicate to flip true again. The coordinator barrier from process
 start has long since closed in normal operation.
 
-### 2.2 Per-DEK `local_epoch` consistency
+### 2.2 `local_epoch` consistency (cutover case)
 
 §4.1 nonce uniqueness is per-DEK over `(node_id, local_epoch,
 write_count)`. The nonce factory is built once at process start with
-`(NodeID16(raftID), w.epoch)` — this pair is reused under whichever
-DEK is active when each Put fires. So when 7b proposes a registration
-for a freshly rotated DEK, the registration's `local_epoch` MUST equal
-`w.epoch` (the nonce factory's pinned value), not the sidecar's
-`Keys[newDEKID].LocalEpoch` (which is 0 for a freshly-rotated DEK,
-representing the cluster-wide first use of that key).
+`(NodeID16(raftID), w.epoch)`. For the cutover case the active DEK is
+the same one `prepareStorageNonceEpoch` already called `BumpLocalEpoch`
+on at startup, so:
 
-That is, the registration row records the node's pinned epoch under the
-new DEK, mirroring the 7a propose path semantics: a registration for
-`(D, node, e)` is the node's commitment that it will emit nonces
-`(node, e, write_count)` under DEK `D`. The applier's §4.1 case 1 path
-inserts FirstSeen = LastSeen = `e` exactly as designed.
+- `sidecar.Keys[activeDEK].LocalEpoch == w.epoch` (post-bump value).
+- The nonce factory emits `(node, w.epoch, write_count)` under
+  `activeDEK`.
+- 7b registers `(activeDEK, node, w.epoch)`, advancing the writer
+  registry's `LastSeenLocalEpoch` to `w.epoch`.
+
+On the next restart, `BumpLocalEpoch` reads
+`sidecar.Keys[activeDEK].LocalEpoch == w.epoch` and bumps it to
+`w.epoch + 1`. The §9.1 startup guard sees
+`w.epoch_new (w.epoch + 1) > lastSeen (w.epoch)` and takes the propose
+path, registering at `w.epoch + 1`. No brick, no nonce reuse — the
+sidecar and the writer registry stay coherent across restart.
+
+**Rotation case is materially different.** A runtime `RotateDEK`
+installs a new active DEK whose `sidecar.Keys[newDEK].LocalEpoch == 0`,
+while the live nonce factory still emits at `w.epoch > 0` under any
+DEK currently active. Registering the new DEK at `w.epoch` would make
+the registry advance past the sidecar; the next restart's
+`BumpLocalEpoch(newDEK)` would only bump `0 → 1`, the §9.1 guard would
+refuse boot, and bypassing the guard would risk real nonce reuse once
+the per-process bumped epoch under `newDEK` eventually overlapped a
+previously-emitted `(node, w.epoch, *)`. See §6 for the deferred fix.
 
 ### 2.3 Why polling, not a channel
 
@@ -161,14 +216,14 @@ taken), the watcher begins observing. The two never race because:
   for its decision (read `lastSeen`, branch). Its registration goroutine
   closes the barrier and seeds `MarkRegistered` on its own DEK.
 - Once that finishes, the watcher's condition (`!cache.Registered()`)
-  is false for the current DEK and the loop body is a no-op until a
-  runtime cutover or rotation flips a predicate.
+  is false for the boot DEK and the loop body is a no-op until a
+  runtime cutover flips `StorageEnvelopeActive`.
 
 If a runtime cutover happens *before* process-start finishes (extremely
 unlikely; admin RPC needs the cluster serving), the worst case is the
 watcher and the process-start goroutine both propose registrations for
-the same `(DEK, node, epoch)` triple. The §4.1 case 2-idempotent path
-handles a duplicate apply as a no-op, so this is safe.
+the same `(bootDEK, node, w.epoch)` triple. The §4.1 case 2-idempotent
+path handles a duplicate apply as a no-op, so this is safe.
 
 ### 2.5 Startup ordering
 
@@ -183,26 +238,28 @@ already confirmed).
 ## 3. Scope
 
 ### In scope (7b)
-- `runRuntimeRegistrationWatcher` goroutine in `main_encryption_registration.go`.
+- `runRuntimeRegistrationWatcher` goroutine in `main_encryption_registration.go`,
+  pinned to the boot-time active DEK (cutover case only).
 - A new constant `runtimeRegistrationPollInterval` (default 1 s).
 - main.go wiring: start the watcher from `setupDistributionAndRegistration`
   AFTER `installProcessStartRegistrationGate`, under the existing
   errgroup with `runCtx`.
 - Reuse of the existing `runWriterRegistration` + `releaseBarrier`
   helpers (no new propose pathway).
-- Tests: a fake cache that transitions `activeStorageDEKID` mid-watch
-  to assert the watcher proposes for the new DEK and marks
-  `Registered()` true; a transition where `StorageEnvelopeActive` flips
-  false→true (the Phase-0 cutover case) to assert the same.
+- Tests: a fake cache that flips `StorageEnvelopeActive` false→true on
+  the boot DEK to assert the watcher proposes for the boot DEK and
+  marks `Registered()` true; a transition where `activeStorageDEKID`
+  changes to a non-boot DEK to assert the watcher takes the
+  deferred-skip branch (logs and does not propose).
 
-### Out of scope
+### Out of scope (deferred slices)
+- **Rotation case (7b'):** non-proposer registration after runtime
+  `RotateDEK` — needs per-DEK `local_epoch` coordination (sidecar
+  consistency on restart). See §6.
 - 7c (ConfChange-time registration for joining nodes) — a separate
   membership-driven mechanism, not cache-driven.
 - Replacing the polling loop with a notification channel — possible
   follow-on once a workload need is identified.
-- Rebuilding the nonce factory on rotation — the design above
-  deliberately reuses the pinned `(node, epoch)` pair across DEKs,
-  which is §4.1-safe because nonce uniqueness is per-DEK.
 
 ## 4. Self-review checklist (for the implementation PR)
 - **Data loss** — the watcher only proposes registration entries; it
@@ -215,13 +272,17 @@ already confirmed).
   propose (with the process-start goroutine) safe.
 - **Performance** — 1 s polling × two atomic loads = nil overhead. The
   hot Put path is untouched.
-- **Data consistency** — registration `local_epoch` equals
-  `w.epoch` (the nonce factory's pinned value), keeping the
-  writer-registry row aligned with the on-disk nonces. The cutover and
-  rotation applies remain unmodified.
-- **Test coverage** — fake-cache transitions for cutover and rotation;
-  shutdown cancels cleanly; concurrent process-start goroutine + watcher
-  propose is no-op via case 2-idempotent.
+- **Data consistency** — registration `local_epoch` equals `w.epoch`
+  (the nonce factory's pinned value AND the sidecar's
+  `Keys[bootDEK].LocalEpoch` after startup `BumpLocalEpoch`), keeping
+  the writer-registry, the sidecar, and the on-disk nonces all aligned
+  across restart. The rotation deferral (§6) keeps this invariant safe
+  by refusing to propose for a non-boot DEK.
+- **Test coverage** — fake-cache `StorageEnvelopeActive` false→true
+  transition exercises the cutover propose; an `activeStorageDEKID`
+  change to a non-boot DEK exercises the deferred-skip branch (logs,
+  does not propose); shutdown cancels cleanly; concurrent process-start
+  goroutine + watcher propose is no-op via case 2-idempotent.
 
 ## 5. Verification action items (for the implementation PR)
 1. Confirm `runWriterRegistration` and `releaseBarrier` can be reused
@@ -230,7 +291,8 @@ already confirmed).
    propose attempt should similarly scope its own cache, or the
    long-running watcher should keep a single cache for its lifetime and
    close on `runCtx`).
-2. Confirm `applyRotateDEK` updates the shared `StateCache` via
+2. *(rotation-case verification; relevant to 7b' not 7b)*
+   Confirm `applyRotateDEK` updates the shared `StateCache` via
    `RefreshFromSidecar` AFTER the new DEK is durably committed
    (otherwise the watcher could observe `activeStorageDEKID = new` and
    propose before any node has the keystore entry to decrypt the
@@ -238,5 +300,57 @@ already confirmed).
    refreshes the cache after `WriteSidecar` succeeds; just re-verify
    the ordering when implementing the watcher.
 3. Decide the propose `local_epoch` policy explicitly in code: this
-   document specifies it MUST equal `w.epoch`. Add a unit test pinning
-   that the watcher proposes with `w.epoch`, not `sidecar.Keys[newDEK].LocalEpoch`.
+   document specifies it MUST equal `w.epoch` (the post-`BumpLocalEpoch`
+   value for the boot DEK, recorded in the sidecar at startup). Add a
+   unit test pinning that the watcher proposes with `w.epoch`, not
+   the freshly-rotated DEK's sidecar value.
+4. Add a unit test pinning the deferred-skip branch: when
+   `activeStorageDEKID` has changed from the boot DEK, the watcher
+   logs once and does NOT propose. This makes the rotation deferral
+   explicit at the code level.
+
+## 6. Deferred — rotation case (7b')
+
+Non-proposer registration after runtime `RotateDEK` is materially
+harder than the cutover case because the new active DEK arrives with
+`sidecar.Keys[newDEK].LocalEpoch == 0`, while the nonce factory
+already emits at this load's pinned `w.epoch > 0` under whichever DEK
+becomes active. Registering the new DEK at `w.epoch` would advance the
+writer registry's `LastSeenLocalEpoch` past the sidecar's record,
+producing two failure modes on next restart (codex P1 + gemini medium
+#2 on PR #848):
+
+- **Brick.** `BumpLocalEpoch(newDEK)` bumps `0 → 1`; the §9.1 startup
+  guard sees `w.epoch_new (1) < lastSeen (w.epoch_old)` and refuses to
+  boot.
+- **Nonce reuse if the guard were bypassed.** Subsequent restarts walk
+  `Keys[newDEK].LocalEpoch` up `1, 2, 3, ...` and would eventually
+  re-emit `(node, w.epoch_old, write_count)` nonces under `newDEK`,
+  colliding with what the rotating load already wrote.
+
+Three viable fixes (each requires its own design slice):
+
+(a) **Per-DEK nonce factory.** Replace the single-pointer
+   `pebbleStore.nonceFactory` with a per-DEK map keyed by
+   `activeStorageDEKID`. On rotation, the apply path installs a fresh
+   nonce factory for the new DEK at `local_epoch = 0` (or the bumped
+   per-DEK value). The runtime watcher then registers `(newDEK, node,
+   0)` consistently with the sidecar. Architecturally largest.
+
+(b) **Per-node sidecar coordination at apply time.** `applyRotateDEK`
+   on each node writes `sidecar.Keys[newDEK].LocalEpoch =
+   thisLoad.w.epoch` (this node's pinned value, NOT the proposer's),
+   then the watcher registers at the same `w.epoch`. Each node's
+   sidecar accurately records its own highest-emitted `local_epoch`
+   under `newDEK`. Requires plumbing `w.epoch` into the `Applier` (or
+   a sidecar-mutator helper exposed to the watcher).
+
+(c) **Proposer-pinned rotation epoch.** The rotation entry carries an
+   explicit `local_epoch` field; `applyRotateDEK` writes that value
+   into every node's `sidecar.Keys[newDEK].LocalEpoch` deterministically.
+   This makes the sidecar value cluster-uniform but requires that the
+   proposer's `w.epoch` ≥ every other node's `w.epoch` at apply time,
+   which is not automatic. Probably the worst of the three.
+
+Option (b) is the most likely path forward and is what 7b' will
+propose. None of these belong in 7b.

--- a/docs/design/2026_05_28_proposed_7b_runtime_reregistration.md
+++ b/docs/design/2026_05_28_proposed_7b_runtime_reregistration.md
@@ -359,16 +359,52 @@ already confirmed).
    `lastLoggedSkipDEK`) and does NOT propose. This makes the rotation
    deferral explicit at the code level.
 
-5. **`verifyRegistered` callback (claude P2 round-2).** The watcher's
-   call to `runWriterRegistration` passes a `verifyRegistered` callback
-   that reads the local Pebble writer-registry store
-   (`store.WriterRegistryFor(...).GetRegistryRow(RegistryKey(activeDEK,
-   NodeID16(fullNodeID)))`) and returns true when an existing row's
-   `LastSeenLocalEpoch >= w.epoch`. This matches 7a's process-start
-   pattern and handles the crash-between-propose-and-MarkRegistered
-   case: a prior watcher attempt that committed a registration but
-   crashed before `MarkRegistered` will be picked up by `verifyRegistered`
-   on the next propose, short-circuiting before re-proposing.
+5. **`verifyRegistered` callback (claude P2 round-2, tightened per
+   codex P1 round-3 on PR #848).** The watcher's call to
+   `runWriterRegistration` passes a `verifyRegistered` callback that
+   reads the local Pebble writer-registry store via
+   `store.WriterRegistryFor(...).GetRegistryRow(RegistryKey(activeDEK,
+   NodeID16(fullNodeID)))` and returns true **only when an existing
+   row is present AND its `LastSeenLocalEpoch >= w.epoch`**. The
+   callback MUST be explicit about the row-existence check:
+
+   ```go
+   verifyRegistered := func() (bool, error) {
+       raw, ok, err := reg.GetRegistryRow(RegistryKey(activeDEK, NodeID16(fullNodeID)))
+       if err != nil {
+           return false, err
+       }
+       if !ok {
+           return false, nil // no row → not registered, MUST propose
+       }
+       val, err := encryption.DecodeRegistryValue(raw)
+       if err != nil {
+           return false, err
+       }
+       return val.LastSeenLocalEpoch >= w.epoch, nil
+   }
+   ```
+
+   The `ok=true` gate is load-bearing for the pre-bootstrap branch
+   (`w.epoch == 0`): if the callback returned `(true, nil)` on the
+   zero-value `LastSeenLocalEpoch == 0` of a missing row, the
+   verify-before-propose short-circuit inside `runWriterRegistration`
+   would call `MarkRegistered(activeDEK)` and open the storage gate
+   without ever proposing a durable registry row — encrypted writes
+   would proceed with no on-disk evidence that this node ever
+   registered, and the next post-cutover restart would hit the §9.1
+   missing-row-post-cutover guard.
+
+   Do NOT reuse the existing `registryLastSeen(reg, dekID, fullNodeID)
+   uint16` helper from `main_encryption_registration.go` directly: it
+   swallows `ok=false` by returning 0, which is precisely the trap
+   above. 7a's process-start propose path is incidentally safe
+   because `buildProcessStartRegistrationGate` never reaches the
+   propose branch with `w.epoch == 0` (the not-bootstrapped guard
+   short-circuits first); the 7b watcher does, so it MUST gate
+   explicitly. The implementation may either inline the body above or
+   introduce a new `registryLastSeenWithExistence` helper used by both
+   callers.
 
 6. Add unit tests for the pre-bootstrap branch
    (`bootDEKID == 0`), split per claude P2 round-3 to cover both

--- a/docs/design/2026_05_28_proposed_7b_runtime_reregistration.md
+++ b/docs/design/2026_05_28_proposed_7b_runtime_reregistration.md
@@ -14,18 +14,26 @@ direct-path gate to `Registered()` — per-DEK and fail-closed. Two
 runtime scenarios fall outside 7a's process-start arm and surfaced as
 codex **P1** findings on PR #847:
 
-1. **Phase-0 boot → runtime `EnableStorageEnvelope` (in scope for 7b).**
-   A node that booted in Phase 0 (envelope inactive) skips
-   `buildProcessStartRegistrationGate`'s propose path. When
-   `EnableStorageEnvelope` later applies at runtime, the storage gate
-   transitions from "not consulted" (envelope inactive) to "fail-closed
-   for an unregistered node" — direct encrypted writes are refused
-   indefinitely. **The active DEK does NOT change**, only the envelope
-   activates. `prepareStorageNonceEpoch` already called
-   `BumpLocalEpoch` for the active DEK at startup, so the sidecar's
-   `Keys[activeDEK].LocalEpoch` equals this load's pinned `w.epoch` —
-   registering at `w.epoch` keeps the sidecar and the writer-registry
-   consistent across restart.
+1. **Phase-0 / pre-bootstrap boot → runtime cutover (in scope for 7b).**
+   A node that booted before the cluster's `EnableStorageEnvelope`
+   apply skips `buildProcessStartRegistrationGate`'s propose path. When
+   the envelope later activates at runtime, the storage gate transitions
+   from "not consulted" (envelope inactive) to "fail-closed for an
+   unregistered node" — direct encrypted writes are refused indefinitely.
+   Two sub-branches both belong to this case (§1, §2.2):
+   - **Phase-0 boot (`bootDEK != 0`):** the node was bootstrapped before
+     it booted but the cutover hadn't fired yet. `prepareStorageNonceEpoch`
+     called `BumpLocalEpoch(bootDEK)` at startup, so
+     `sidecar.Keys[bootDEK].LocalEpoch == w.epoch`. The runtime cutover
+     does not change the active DEK; registering at `w.epoch` is
+     consistent with the sidecar across restart.
+   - **Pre-bootstrap boot (`bootDEK == 0`):** the node started before
+     any `BootstrapEncryption` had ever fired. `w.epoch == 0` and the
+     nonce factory emits at epoch 0. Runtime `BootstrapEncryption` then
+     `EnableStorageEnvelope` together install a new active DEK X with
+     `sidecar.Keys[X].LocalEpoch == 0` — matching the live nonce
+     factory. Registering `(X, node, 0)` is safe and consistent
+     (codex P1 round-2 on PR #848).
 
 2. **Non-proposer node after runtime `RotateDEK` (NOT in scope; deferred to 7b').**
    `applyRotateDEK` inserts only the *proposer's* registration row for
@@ -68,16 +76,30 @@ cache.StorageEnvelopeActive() && id, ok := cache.ActiveStorageKeyID(); ok && !ca
 
 This is precisely the state where `encryptForKey` on the direct path
 would return `ErrWriterNotRegistered`. The 7b watcher acts on this
-condition **only when the active DEK ID matches the boot-time active
-DEK** (`activeStorageDEKID` unchanged since process start) — i.e. the
-cutover case where `StorageEnvelopeActive` flipped but the DEK is the
-same one `prepareStorageNonceEpoch` bumped at startup. When the
-condition holds with a *different* active DEK id, that is the deferred
-rotation case (§6); the watcher logs and skips it.
+condition **only when the active DEK is consistent with the nonce
+factory's pinned `w.epoch`**, which holds in two scenarios:
 
-After `EnableStorageEnvelope` apply: `StorageEnvelopeActive` flips
-true; if this node never registered, `Registered()` is false; the boot
-DEK is unchanged. The trigger fires.
+1. **`activeDEK == bootDEK` (Phase-0-boot cutover).** `bootDEK` is the
+   active storage DEK captured at watcher construction time. The
+   envelope just flipped active; the DEK has not changed since startup;
+   `sidecar.Keys[bootDEK].LocalEpoch == w.epoch` because
+   `prepareStorageNonceEpoch` bumped it at process start.
+
+2. **`bootDEK == 0` (pre-bootstrap → runtime bootstrap+cutover, codex P1 on PR #848 round-1).**
+   A node started before `BootstrapEncryption` had ever fired: the
+   sidecar had `Active.Storage == 0`, `prepareStorageNonceEpoch`
+   returned 0, and the nonce factory is pinned at `w.epoch == 0`. When
+   `BootstrapEncryption` + `EnableStorageEnvelope` later run, the new
+   active DEK X arrives with `sidecar.Keys[X].LocalEpoch == 0` —
+   matching the live nonce factory's `w.epoch == 0`. This is NOT a
+   rotation; registering `(X, node, 0)` is consistent across restart
+   (`BumpLocalEpoch(X)` will bump 0→1 next boot, propose path,
+   lastSeen=0 advances). The watcher MUST handle this path.
+
+When `bootDEK != 0 && activeDEK != bootDEK`, that is the deferred
+rotation case (§6) — the live nonce factory's `w.epoch` is NOT
+consistent with the new DEK's sidecar `LocalEpoch` (which is 0). The
+watcher logs (rate-limited; see §2.1) and skips.
 
 The trigger is read off the shared `*encryption.StateCache`, which
 `applyEnableStorageEnvelope` and `applyRotateDEK` already update via
@@ -91,34 +113,47 @@ transitions.
 
 `runRuntimeRegistrationWatcher(ctx, coordinate, defaultGroup, w, raftID)`
 is a single goroutine started from `setupDistributionAndRegistration`
-(or a sibling helper) AFTER `installProcessStartRegistrationGate`. It
-runs for the lifetime of `runCtx` and:
+(or a sibling helper) AFTER `installProcessStartRegistrationGate`. At
+construction time it captures **`bootDEKID uint32`** by reading
+`cache.ActiveStorageKeyID()` once — this is the DEK the live nonce
+factory was pinned against (post-`BumpLocalEpoch` if non-zero; zero if
+the boot was pre-bootstrap). The watcher also keeps a per-instance
+**`lastLoggedSkipDEK uint32`** field (initial value 0) for log-once
+gating on the deferred rotation branch. It runs for the lifetime of
+`runCtx` and:
 
 1. **Observes** the trigger condition above by polling the
    `StateCache` predicates at a fixed interval
    (`runtimeRegistrationPollInterval`, default 1 s). Polling is simpler
    than an event channel and the interval is bounded by `runCtx`, so
    there is no risk of an unbounded wakeup storm during normal operation
-   (the condition flips at most once per cutover/rotation).
+   (the condition flips at most once per cutover or rotation).
 
-2. **Dedupes / scope-checks**: skip the body when (a) the cache reports
-   `Registered() == true`, (b) `StorageEnvelopeActive() == false`, or
-   (c) the active DEK id has changed from the boot-time DEK (the
-   deferred rotation case — log once and skip). Only the cutover-case
-   condition triggers the propose.
+2. **Dedupes / scope-checks** on each tick:
+   - Skip if `cache.Registered() == true` (already covered).
+   - Skip if `cache.StorageEnvelopeActive() == false` (Phase-0 still).
+   - Skip if `bootDEKID != 0 && activeDEK != bootDEKID` (deferred
+     rotation case, §6). Apply log-once gating: emit a WARN only when
+     `activeDEK != lastLoggedSkipDEK`, then set
+     `lastLoggedSkipDEK = activeDEK`. This makes the log fire once per
+     unique rotated-into DEK rather than once per second (claude P2 on
+     round-1). Subsequent rotations to *another* DEK re-log correctly.
+   - Otherwise (`activeDEK == bootDEKID` OR `bootDEKID == 0`) proceed
+     to propose.
 
 3. **Proposes** synchronously a registration entry for
-   `(bootDEK, fullNodeID, w.epoch)` using the *same*
+   `(activeDEK, fullNodeID, w.epoch)` using the *same*
    `runWriterRegistration` helper 7a already uses. The `local_epoch` is
    `w.epoch` — this load's pinned epoch from
-   `buildEncryptionWriteWiring`, post-`BumpLocalEpoch` for the boot
-   DEK — which is what the nonce factory actually emits AND equals
-   `sidecar.Keys[bootDEK].LocalEpoch`, so the writer-registry row stays
-   coherent with the sidecar across restart (§2.2).
+   `buildEncryptionWriteWiring` — which equals
+   `sidecar.Keys[activeDEK].LocalEpoch` for both in-scope branches
+   (cutover: post-`BumpLocalEpoch`; pre-bootstrap: both are 0), so the
+   writer-registry row stays coherent with the sidecar across restart
+   (§2.2).
 
 4. **Marks** on success via the existing `releaseBarrier(barrier,
-   cache, bootDEK)` helper (with a fresh per-attempt barrier whose
-   only consumer is the watcher). Once `MarkRegistered(bootDEK)`
+   cache, activeDEK)` helper (with a fresh per-attempt barrier whose
+   only consumer is the watcher). Once `MarkRegistered(activeDEK)`
    stores, `cache.Registered()` returns true and the gate clears.
 
 5. **Backs off** between attempts using the existing
@@ -154,35 +189,42 @@ new coordinator barrier; it only needs the storage-layer `Registered()`
 predicate to flip true again. The coordinator barrier from process
 start has long since closed in normal operation.
 
-### 2.2 `local_epoch` consistency (cutover case)
+### 2.2 `local_epoch` consistency (both in-scope branches)
 
 §4.1 nonce uniqueness is per-DEK over `(node_id, local_epoch,
 write_count)`. The nonce factory is built once at process start with
-`(NodeID16(raftID), w.epoch)`. For the cutover case the active DEK is
-the same one `prepareStorageNonceEpoch` already called `BumpLocalEpoch`
-on at startup, so:
+`(NodeID16(raftID), w.epoch)`. Both in-scope branches register at
+`w.epoch` and satisfy the cross-restart invariant
+`sidecar.Keys[activeDEK].LocalEpoch == w.epoch` at the moment of
+registration:
 
-- `sidecar.Keys[activeDEK].LocalEpoch == w.epoch` (post-bump value).
-- The nonce factory emits `(node, w.epoch, write_count)` under
-  `activeDEK`.
-- 7b registers `(activeDEK, node, w.epoch)`, advancing the writer
-  registry's `LastSeenLocalEpoch` to `w.epoch`.
+**Branch A — cutover (`activeDEK == bootDEKID`, bootDEKID != 0).** The
+active DEK is the same one `prepareStorageNonceEpoch` already called
+`BumpLocalEpoch` on at startup. `sidecar.Keys[activeDEK].LocalEpoch ==
+w.epoch` (post-bump value). The nonce factory emits `(node, w.epoch,
+write_count)` under `activeDEK`. 7b registers `(activeDEK, node,
+w.epoch)`. On next restart `BumpLocalEpoch` bumps `w.epoch → w.epoch +
+1`; §9.1 guard sees `w.epoch_new > lastSeen` → propose path. ✓
 
-On the next restart, `BumpLocalEpoch` reads
-`sidecar.Keys[activeDEK].LocalEpoch == w.epoch` and bumps it to
-`w.epoch + 1`. The §9.1 startup guard sees
-`w.epoch_new (w.epoch + 1) > lastSeen (w.epoch)` and takes the propose
-path, registering at `w.epoch + 1`. No brick, no nonce reuse — the
-sidecar and the writer registry stay coherent across restart.
+**Branch B — pre-bootstrap (`bootDEKID == 0`).** No sidecar Active.Storage
+at startup → `prepareStorageNonceEpoch` returned 0; `w.epoch == 0`. At
+runtime `BootstrapEncryption` installs DEK X with
+`sidecar.Keys[X].LocalEpoch == 0` (fresh-bootstrap value), then
+`EnableStorageEnvelope` flips the envelope. The nonce factory emits
+`(node, 0, write_count)` under X. 7b registers `(X, node, 0)`. On next
+restart `BumpLocalEpoch(X)` bumps `0 → 1`; §9.1 guard sees `1 > 0` →
+propose path, registers at 1. ✓ — sidecar, registry, and on-disk
+nonces are all coherent.
 
-**Rotation case is materially different.** A runtime `RotateDEK`
-installs a new active DEK whose `sidecar.Keys[newDEK].LocalEpoch == 0`,
-while the live nonce factory still emits at `w.epoch > 0` under any
-DEK currently active. Registering the new DEK at `w.epoch` would make
-the registry advance past the sidecar; the next restart's
-`BumpLocalEpoch(newDEK)` would only bump `0 → 1`, the §9.1 guard would
-refuse boot, and bypassing the guard would risk real nonce reuse once
-the per-process bumped epoch under `newDEK` eventually overlapped a
+**Rotation case is materially different (deferred).** A runtime
+`RotateDEK` after the first bootstrap installs a new active DEK whose
+`sidecar.Keys[newDEK].LocalEpoch == 0`, while the live nonce factory
+still emits at `w.epoch > 0` (the bumped value for the *previous*
+boot DEK). Registering the new DEK at `w.epoch > 0` would advance the
+registry past the sidecar; the next restart's `BumpLocalEpoch(newDEK)`
+would bump `0 → 1` ≪ `lastSeen`, the §9.1 guard would refuse boot,
+and bypassing the guard would risk real nonce reuse once the
+per-process bumped epoch under `newDEK` eventually overlapped a
 previously-emitted `(node, w.epoch, *)`. See §6 for the deferred fix.
 
 ### 2.3 Why polling, not a channel
@@ -286,11 +328,13 @@ already confirmed).
 
 ## 5. Verification action items (for the implementation PR)
 1. Confirm `runWriterRegistration` and `releaseBarrier` can be reused
-   from the runtime watcher without leaking the conn cache (the
-   goroutine-scoped `connCache.Close()` defer in 7a stays — each watcher
-   propose attempt should similarly scope its own cache, or the
-   long-running watcher should keep a single cache for its lifetime and
-   close on `runCtx`).
+   from the runtime watcher. **Decision (claude P2 round-2):**
+   goroutine-scoped `connCache` per `runWriterRegistration` call,
+   matching 7a's pattern — the existing `defer connCache.Close()`
+   inside `runWriterRegistration` stays, the watcher passes nothing
+   extra. Registrations are rare (one per cutover or pre-bootstrap
+   activation), so the cost of opening a fresh cache per propose is
+   negligible and there is no watcher-level cleanup path to maintain.
 2. *(rotation-case verification; relevant to 7b' not 7b)*
    Confirm `applyRotateDEK` updates the shared `StateCache` via
    `RefreshFromSidecar` AFTER the new DEK is durably committed
@@ -305,9 +349,26 @@ already confirmed).
    unit test pinning that the watcher proposes with `w.epoch`, not
    the freshly-rotated DEK's sidecar value.
 4. Add a unit test pinning the deferred-skip branch: when
-   `activeStorageDEKID` has changed from the boot DEK, the watcher
-   logs once and does NOT propose. This makes the rotation deferral
-   explicit at the code level.
+   `bootDEKID != 0 && activeStorageDEKID != bootDEKID`, the watcher
+   logs once per unique rotated-into DEK (gated by
+   `lastLoggedSkipDEK`) and does NOT propose. This makes the rotation
+   deferral explicit at the code level.
+
+5. **`verifyRegistered` callback (claude P2 round-2).** The watcher's
+   call to `runWriterRegistration` passes a `verifyRegistered` callback
+   that reads the local Pebble writer-registry store
+   (`store.WriterRegistryFor(...).GetRegistryRow(RegistryKey(activeDEK,
+   NodeID16(fullNodeID)))`) and returns true when an existing row's
+   `LastSeenLocalEpoch >= w.epoch`. This matches 7a's process-start
+   pattern and handles the crash-between-propose-and-MarkRegistered
+   case: a prior watcher attempt that committed a registration but
+   crashed before `MarkRegistered` will be picked up by `verifyRegistered`
+   on the next propose, short-circuiting before re-proposing.
+
+6. Add a unit test for the pre-bootstrap branch
+   (`bootDEKID == 0` → runtime `BootstrapEncryption` + cutover): the
+   watcher proposes for the freshly-installed DEK X at `w.epoch == 0`.
+   This pins the codex P1 round-2 fix.
 
 ## 6. Deferred — rotation case (7b')
 
@@ -340,10 +401,10 @@ Three viable fixes (each requires its own design slice):
 (b) **Per-node sidecar coordination at apply time.** `applyRotateDEK`
    on each node writes `sidecar.Keys[newDEK].LocalEpoch =
    thisLoad.w.epoch` (this node's pinned value, NOT the proposer's),
-   then the watcher registers at the same `w.epoch`. Each node's
-   sidecar accurately records its own highest-emitted `local_epoch`
-   under `newDEK`. Requires plumbing `w.epoch` into the `Applier` (or
-   a sidecar-mutator helper exposed to the watcher).
+   then 7b'-the-rotation-extension registers at the same `w.epoch`.
+   Each node's sidecar accurately records its own highest-emitted
+   `local_epoch` under `newDEK`. Requires plumbing `w.epoch` into the
+   `Applier` (or a sidecar-mutator helper called from the apply path).
 
 (c) **Proposer-pinned rotation epoch.** The rotation entry carries an
    explicit `local_epoch` field; `applyRotateDEK` writes that value

--- a/docs/design/2026_05_28_proposed_7b_runtime_reregistration.md
+++ b/docs/design/2026_05_28_proposed_7b_runtime_reregistration.md
@@ -1,0 +1,242 @@
+# Stage 7b — runtime writer re-registration (cutover + rotation cases)
+
+| Field | Value |
+|---|---|
+| Status | proposed |
+| Date | 2026-05-28 |
+| Parent designs | [`2026_04_29_partial_data_at_rest_encryption.md`](2026_04_29_partial_data_at_rest_encryption.md) (§4.1 writer registry), [`2026_05_26_proposed_7a_process_start_registration.md`](2026_05_26_proposed_7a_process_start_registration.md) (process-start), [`2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md`](2026_05_26_proposed_7a2_storage_layer_registration_enforcement.md) (storage gate) |
+| Builds on | 7a (process-start propose path), 7a-2 (storage-layer `Registered()` gate) |
+
+## 0. Why this slice exists
+
+7a registers a process at process start. 7a-2 wires the storage-layer
+direct-path gate to `Registered()` — per-DEK and fail-closed. Two
+runtime scenarios fall outside 7a's process-start arm and are explicitly
+deferred as the "runtime-cutover registration follow-on" in 7a's
+docstring. Both surfaced as codex **P1** findings on PR #847:
+
+1. **Phase-0 boot → runtime `EnableStorageEnvelope`.** A node that booted
+   in Phase 0 (envelope inactive) skips `buildProcessStartRegistrationGate`'s
+   propose path. When `EnableStorageEnvelope` later applies at runtime, the
+   storage gate transitions from "not consulted" (envelope inactive) to
+   "fail-closed for an unregistered node" — direct encrypted writes are
+   refused indefinitely.
+
+2. **Non-proposer node after runtime `RotateDEK`.** `applyRotateDEK`
+   inserts only the *proposer's* registration row for the new DEK
+   (`p.ProposerRegistration`). Every other node has `activeStorageDEKID`
+   re-pointed to the new DEK by `RefreshFromSidecar`, so its `Registered()`
+   transitions to false (the new id ≠ `registeredStorageDEKID`). Without
+   a runtime re-arm those nodes fail closed on the next direct encrypted
+   write until restart.
+
+Both share one mechanism: when the storage gate *would* fail closed
+because the active DEK changed (or just became live), the affected node
+must propose its own registration row for the new DEK and seed
+`Registered()` once the entry commits — exactly what 7a does at process
+start, but driven by a cache transition rather than a startup decision.
+
+7b adds that runtime trigger. It is **not** a fail-OPEN fallback (design
+§2.3 of 7a-2 forbids those): the storage gate remains fail-closed for
+unregistered nodes; 7b just clears the gate by *actually registering*.
+
+(7c — ConfChange-time registration for a freshly-joining node — is a
+distinct mechanism, membership-driven rather than cache-driven, and is
+NOT in 7b's scope.)
+
+## 1. Where the trigger fires
+
+The defining condition for "this node must (re)register now" is:
+
+```text
+cache.StorageEnvelopeActive() && id, ok := cache.ActiveStorageKeyID(); ok && !cache.Registered()
+   ⇔ the storage gate would fail-closed for an encrypted direct write today
+```
+
+This is precisely the state where `encryptForKey` on the direct path
+would return `ErrWriterNotRegistered`. The two runtime scenarios above
+both produce it:
+
+- After `EnableStorageEnvelope` apply: `StorageEnvelopeActive` flips
+  true; if this node never registered, `Registered()` is false.
+- After `RotateDEK` apply on a non-proposer: `activeStorageDEKID`
+  changes to the new id; `registeredStorageDEKID` still holds the old
+  id, so `Registered()` returns false.
+
+The trigger is read off the shared `*encryption.StateCache`, which both
+apply paths already update (`a.stateCache.RefreshFromSidecar(sc)` after
+each `WriteSidecar`). 7b does not introduce a new wire-format event;
+it observes the existing cache transitions.
+
+## 2. Proposed design
+
+### 2.1 A runtime registration watcher
+
+`runRuntimeRegistrationWatcher(ctx, coordinate, defaultGroup, w, raftID)`
+is a single goroutine started from `setupDistributionAndRegistration`
+(or a sibling helper) AFTER `installProcessStartRegistrationGate`. It
+runs for the lifetime of `runCtx` and:
+
+1. **Observes** the trigger condition above by polling the
+   `StateCache` predicates at a fixed interval
+   (`runtimeRegistrationPollInterval`, default 1 s). Polling is simpler
+   than an event channel and the interval is bounded by `runCtx`, so
+   there is no risk of an unbounded wakeup storm during normal operation
+   (the condition flips at most once per cutover/rotation).
+
+2. **Dedupes** against the already-marked DEK: if
+   `cache.Registered()` is true the loop body is a no-op for this tick.
+   When the active DEK transitions to a new id and the registration for
+   it has not yet committed, the body proceeds.
+
+3. **Proposes** a registration entry for `(activeDEK, fullNodeID,
+   w.epoch)` using the *same* `runWriterRegistration` helper 7a already
+   uses. The `local_epoch` is `w.epoch` — this load's pinned epoch from
+   `buildEncryptionWriteWiring` — which is what the nonce factory
+   actually emits, so the writer-registry row that lands is consistent
+   with on-disk nonces.
+
+4. **Marks** on success via the existing `releaseBarrier(barrier,
+   cache, activeDEK)` helper (with a fresh per-attempt barrier whose
+   only consumer is the watcher). Once `MarkRegistered(activeDEK)`
+   stores, `cache.Registered()` returns true and the gate clears.
+
+5. **Backs off** between attempts using the existing
+   `registrationRetryInitial / registrationRetryMax /
+   registrationBackoffFactor`. Failures are bounded by `runCtx`; on
+   shutdown the goroutine returns without leaving stale state.
+
+The watcher does **not** touch the `RegistrationGate` the coordinator
+holds — 7a's coordinator-layer barrier is a per-process-load
+construct, not a per-DEK one. Runtime rotation does not introduce a new
+coordinator barrier; it only needs the storage-layer `Registered()`
+predicate to flip true again. The coordinator barrier from process
+start has long since closed in normal operation.
+
+### 2.2 Per-DEK `local_epoch` consistency
+
+§4.1 nonce uniqueness is per-DEK over `(node_id, local_epoch,
+write_count)`. The nonce factory is built once at process start with
+`(NodeID16(raftID), w.epoch)` — this pair is reused under whichever
+DEK is active when each Put fires. So when 7b proposes a registration
+for a freshly rotated DEK, the registration's `local_epoch` MUST equal
+`w.epoch` (the nonce factory's pinned value), not the sidecar's
+`Keys[newDEKID].LocalEpoch` (which is 0 for a freshly-rotated DEK,
+representing the cluster-wide first use of that key).
+
+That is, the registration row records the node's pinned epoch under the
+new DEK, mirroring the 7a propose path semantics: a registration for
+`(D, node, e)` is the node's commitment that it will emit nonces
+`(node, e, write_count)` under DEK `D`. The applier's §4.1 case 1 path
+inserts FirstSeen = LastSeen = `e` exactly as designed.
+
+### 2.3 Why polling, not a channel
+
+`StateCache` is a `sync/atomic` predicate today; it deliberately has no
+subscription API to keep the hot Put path lock-free. Adding a channel
+would mean threading a notifier into `RefreshFromSidecar` (called from
+every FSM apply that mutates encryption state), and choosing between
+buffered/unbuffered semantics that can drop or block. The polling loop
+is simpler:
+
+- One goroutine, one timer.
+- O(constant) work per tick (two atomic loads).
+- Bounded by `runCtx` so shutdown is clean.
+- Visible from logs (each propose attempt logs the trigger).
+
+The 1 s interval is short enough that the "gate trapped after cutover"
+window is sub-second in practice, and long enough that an idle node
+spends negligible CPU on it. If a future workload makes polling
+expensive the predicate could grow a `sync.Cond` or a notification
+channel as a follow-on; for 7b the simplest correct design wins.
+
+### 2.4 Composing with 7a process-start
+
+The 7a process-start path remains the primary registration trigger and
+covers every restart. 7b is purely additive: after process-start
+finishes (the propose-branch goroutine returns or the skip branch was
+taken), the watcher begins observing. The two never race because:
+
+- Process-start runs synchronously inside `installProcessStartRegistrationGate`
+  for its decision (read `lastSeen`, branch). Its registration goroutine
+  closes the barrier and seeds `MarkRegistered` on its own DEK.
+- Once that finishes, the watcher's condition (`!cache.Registered()`)
+  is false for the current DEK and the loop body is a no-op until a
+  runtime cutover or rotation flips a predicate.
+
+If a runtime cutover happens *before* process-start finishes (extremely
+unlikely; admin RPC needs the cluster serving), the worst case is the
+watcher and the process-start goroutine both propose registrations for
+the same `(DEK, node, epoch)` triple. The §4.1 case 2-idempotent path
+handles a duplicate apply as a no-op, so this is safe.
+
+### 2.5 Startup ordering
+
+Same as 7a-2 §2.3: install the watcher AFTER
+`installProcessStartRegistrationGate` so the process-start goroutine
+exists and the barrier semantics are fixed before any runtime trigger
+can fire. The watcher reads only the shared cache + the default-group
+engine handle; it has no dependency on the route catalog (the
+`OpRegistration` apply writes a writer-registry row only — §5 of 7a-2
+already confirmed).
+
+## 3. Scope
+
+### In scope (7b)
+- `runRuntimeRegistrationWatcher` goroutine in `main_encryption_registration.go`.
+- A new constant `runtimeRegistrationPollInterval` (default 1 s).
+- main.go wiring: start the watcher from `setupDistributionAndRegistration`
+  AFTER `installProcessStartRegistrationGate`, under the existing
+  errgroup with `runCtx`.
+- Reuse of the existing `runWriterRegistration` + `releaseBarrier`
+  helpers (no new propose pathway).
+- Tests: a fake cache that transitions `activeStorageDEKID` mid-watch
+  to assert the watcher proposes for the new DEK and marks
+  `Registered()` true; a transition where `StorageEnvelopeActive` flips
+  false→true (the Phase-0 cutover case) to assert the same.
+
+### Out of scope
+- 7c (ConfChange-time registration for joining nodes) — a separate
+  membership-driven mechanism, not cache-driven.
+- Replacing the polling loop with a notification channel — possible
+  follow-on once a workload need is identified.
+- Rebuilding the nonce factory on rotation — the design above
+  deliberately reuses the pinned `(node, epoch)` pair across DEKs,
+  which is §4.1-safe because nonce uniqueness is per-DEK.
+
+## 4. Self-review checklist (for the implementation PR)
+- **Data loss** — the watcher only proposes registration entries; it
+  never modifies storage or the cutover/rotation sidecar state. A
+  failed propose returns to the retry loop or to `runCtx` cancellation;
+  no committed write is dropped.
+- **Concurrency** — the watcher reads `StateCache` via the existing
+  atomic predicates; it shares no mutable state with the FSM apply
+  goroutine. The §4.1 case 2-idempotent apply path makes a duplicate
+  propose (with the process-start goroutine) safe.
+- **Performance** — 1 s polling × two atomic loads = nil overhead. The
+  hot Put path is untouched.
+- **Data consistency** — registration `local_epoch` equals
+  `w.epoch` (the nonce factory's pinned value), keeping the
+  writer-registry row aligned with the on-disk nonces. The cutover and
+  rotation applies remain unmodified.
+- **Test coverage** — fake-cache transitions for cutover and rotation;
+  shutdown cancels cleanly; concurrent process-start goroutine + watcher
+  propose is no-op via case 2-idempotent.
+
+## 5. Verification action items (for the implementation PR)
+1. Confirm `runWriterRegistration` and `releaseBarrier` can be reused
+   from the runtime watcher without leaking the conn cache (the
+   goroutine-scoped `connCache.Close()` defer in 7a stays — each watcher
+   propose attempt should similarly scope its own cache, or the
+   long-running watcher should keep a single cache for its lifetime and
+   close on `runCtx`).
+2. Confirm `applyRotateDEK` updates the shared `StateCache` via
+   `RefreshFromSidecar` AFTER the new DEK is durably committed
+   (otherwise the watcher could observe `activeStorageDEKID = new` and
+   propose before any node has the keystore entry to decrypt the
+   resulting envelope). Existing code in `writeRotationSidecar` already
+   refreshes the cache after `WriteSidecar` succeeds; just re-verify
+   the ordering when implementing the watcher.
+3. Decide the propose `local_epoch` policy explicitly in code: this
+   document specifies it MUST equal `w.epoch`. Add a unit test pinning
+   that the watcher proposes with `w.epoch`, not `sidecar.Keys[newDEK].LocalEpoch`.


### PR DESCRIPTION
## Summary
Stage 7b — runtime writer re-registration design doc. Addresses the two cache-driven runtime cases the codex **P1**s on PR #847 explicitly identified as the deferred 7a follow-on:

1. **Phase-0 boot → runtime `EnableStorageEnvelope`.** The envelope flips active on a node that skipped process-start registration; the storage gate now fail-closes direct encrypted writes until restart.
2. **Non-proposer node after runtime `RotateDEK`.** `applyRotateDEK` only inserts the *proposer's* registration row; every other node has `activeStorageDEKID` re-pointed to the new DEK and `Registered()` returns false for it.

Both produce the same trigger condition (gate would fail-closed). 7b adds a single runtime watcher goroutine that observes the shared `StateCache`, proposes a registration via the existing 7a `runWriterRegistration` helper for `(activeDEK, fullNodeID, w.epoch)`, and seeds `MarkRegistered` through the existing `releaseBarrier` on commit. **No new wire-format event.** **No fail-OPEN fallback** — design §2.3 of 7a-2 still applies; the gate stays fail-closed until the node actually registers.

## Key design decisions
- **Polling, not channel.** `StateCache` has no subscription API (atomic predicates only); polling at 1 s is O(2 atomic loads/tick), bounded by `runCtx`, no risk of dropped events.
- **`local_epoch` policy.** The registration uses `w.epoch` (the nonce factory's pinned value), NOT `sidecar.Keys[newDEK].LocalEpoch`. The nonce factory reuses the same `(node, epoch)` across DEK rotations and §4.1 nonce uniqueness is per-DEK, so this is safe and consistent with the on-disk nonces.
- **Idempotency vs. process-start.** If process-start and 7b race a propose, §4.1 case 2-idempotent makes the duplicate apply a no-op.
- **No new coordinator barrier.** 7a's per-load barrier closes once at startup; runtime cases only need the storage-layer `Registered()` to flip true.

## Out of scope
- 7c (ConfChange-time registration for a freshly-joining node) — distinct membership-driven mechanism.
- Replacing polling with a notification channel — possible follow-on.
- Rebuilding the nonce factory on rotation — deliberately not done; reusing the pinned epoch across DEKs is §4.1-safe.

## Test plan
- [x] Doc-only; lint clean
- [ ] Implementation + tests in the follow-up PR (fake-cache transitions for cutover and rotation; shutdown cancels cleanly; concurrent process-start + watcher propose is no-op via case 2-idempotent)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design documentation for a new runtime writer re-registration mechanism, including implementation requirements, test specifications, and operational guidelines for specific system scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/848?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->