### PR TITLE
ci(tla): auto-request Claude + Codex review on anchored-file changes

### DIFF
--- a/.github/workflows/tla-spec-ai-review.yml
+++ b/.github/workflows/tla-spec-ai-review.yml
@@ -18,9 +18,12 @@ name: TLA+ spec divergence — AI review
 #   - tla-check: catches *spec* bugs (the spec passes / surfaces the gap)
 #   - this workflow: catches *implementation* bugs that drift from the spec
 #
-# The path filter is intentionally a copy of tla-check.yml + the design
-# doc §7.3 list, so a change to an anchored file always triggers both
-# the model check AND the AI review request.
+# The path filter is the **implementation-anchored subset** of
+# tla-check.yml's paths.  tla/**, Makefile, and the workflow
+# self-references are intentionally omitted: spec-only changes do not
+# need an AI implementation-divergence review (tla-check.yml's TLC run
+# is sufficient).  A change to any anchored file therefore triggers
+# both the TLC run AND the AI review request.
 
 on:
   # NOTE on trigger types vs tla-check.yml: this workflow includes
@@ -32,6 +35,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      # Implementation anchors only — see the file-header comment for
+      # the rationale.  Keep this list in sync with the three other
+      # sync points (see the §7.3 enumeration in the design doc).
       - 'kv/hlc*.go'
       - 'kv/coordinator.go'
       - 'kv/sharded_coordinator.go'

--- a/.github/workflows/tla-spec-ai-review.yml
+++ b/.github/workflows/tla-spec-ai-review.yml
@@ -1,0 +1,133 @@
+name: TLA+ spec divergence — AI review
+
+# Whenever a PR touches a file that the TLA+ safety specification has an
+# anchor on (per docs/design/2026_05_28_partial_tla_safety_spec.md §3),
+# automatically post a comment that pings the AI reviewers so a focused
+# spec-divergence review always runs.
+#
+# Chain:
+#   anchored files change
+#     -> this workflow fires
+#       -> posts a PR comment containing "@claude review" and "@codex review"
+#         -> claude.yml fires on the `@claude` mention and runs Claude Code
+#         -> the chatgpt-codex-connector bot fires on the `@codex review`
+#            mention and runs a Codex review
+#
+# tla-check.yml (which runs the TLC model check itself) and this workflow
+# share the same path filter, so the two are complementary:
+#   - tla-check: catches *spec* bugs (the spec passes / surfaces the gap)
+#   - this workflow: catches *implementation* bugs that drift from the spec
+#
+# The path filter is intentionally a copy of tla-check.yml + the design
+# doc §7.3 list, so a change to an anchored file always triggers both
+# the model check AND the AI review request.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'kv/hlc*.go'
+      - 'kv/coordinator.go'
+      - 'kv/sharded_coordinator.go'
+      - 'kv/transaction.go'
+      - 'kv/fsm.go'
+      - 'kv/lock_resolver.go'
+      - 'store/mvcc_store.go'
+      - 'distribution/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-tla-ai-review
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  request-ai-review:
+    name: Request Claude + Codex spec-divergence review
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out (needed for diff)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: List spec-anchored files changed in this PR
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # The set of anchored paths must stay in sync with the `paths:`
+          # filter above AND with tla-check.yml.  Keep all three lists
+          # identical when expanding for M2..M5.
+          ANCHORS='^(kv/hlc[^/]*\.go|kv/coordinator\.go|kv/sharded_coordinator\.go|kv/transaction\.go|kv/fsm\.go|kv/lock_resolver\.go|store/mvcc_store\.go|distribution/.*)$'
+          git diff --name-only "$BASE_SHA...$HEAD_SHA" \
+            | grep -E "$ANCHORS" \
+            > anchored_changed.txt || true
+          echo "count=$(wc -l < anchored_changed.txt | tr -d ' ')" >> "$GITHUB_OUTPUT"
+          echo "Anchored files changed:"
+          cat anchored_changed.txt || true
+
+      - name: Post AI-review request comment
+        if: steps.changed.outputs.count != '0'
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const anchored = fs.readFileSync('anchored_changed.txt', 'utf8')
+              .split('\n').filter(Boolean);
+            const list = anchored.map(f => `- \`${f}\``).join('\n');
+            const marker = '<!-- tla-spec-ai-review-marker -->';
+            const body = [
+              marker,
+              `## TLA+ spec divergence review (auto-triggered)`,
+              ``,
+              `This PR touches files that the TLA+ safety spec has an anchor on (per`,
+              `[\`docs/design/2026_05_28_partial_tla_safety_spec.md\`](../blob/main/docs/design/2026_05_28_partial_tla_safety_spec.md) §3),`,
+              `so an AI review is requested below to verify the implementation has not drifted`,
+              `from the model.`,
+              ``,
+              `**Anchored files changed in this PR head (${process.env.HEAD_SHA.slice(0,10)}):**`,
+              list,
+              ``,
+              `**What to check, by subsystem:**`,
+              ``,
+              `- **\`kv/hlc*.go\`** — \`Next()\` must respect the HLC-4 preconditions (i)/(ii)/(iii) from the design doc: bounded skew, logical-counter handoff on leader change (strategy (c) Observe(MaxAppliedHLC)), and the commit-time ceiling fence (fail-closed when \`wall_now >= physicalCeiling\`). Any change to the bit layout (48/16), the CAS loop, or the ceiling getter/setter is in scope.`,
+              `- **\`kv/coordinator.go\`, \`kv/sharded_coordinator.go\`** — \`RunHLCLeaseRenewal\`, \`hlcRenewalInterval\`, \`hlcPhysicalWindowMs\` constants, and the new-term detection that calls \`Observe(fsm.MaxAppliedHLC())\` (strategy (c)). Any change to renewal cadence, group selection, or fail-closed behaviour is in scope.`,
+              `- **\`kv/transaction.go\`, \`kv/lock_resolver.go\`** — OCC commit-ts assignment, lock-map encoding \`(key, lock_ts) -> start_ts\`, and the LockResolver action OCC-3 depends on. (M2 spec will land OCC-1..OCC-5; until then the spec doc §5.2 is the contract.)`,
+              `- **\`kv/fsm.go\`** — FSM apply of HLC lease entries (\`SetPhysicalCeiling\`), and any future \`MaxAppliedHLC()\` accessor that strategy (c) needs.`,
+              `- **\`store/mvcc_store.go\`** — version visibility, snapshot install, and the MVCC-1..MVCC-4 invariants (M3 scope).`,
+              `- **\`distribution/**\`** — route catalog versioning, \`SplitRange\` atomicity, and \`CatalogWatcher\` async fan-out (M4 scope).`,
+              ``,
+              `If the change is correct but requires a spec update, edit \`tla/hlc/HLC.tla\` (or the corresponding M2..M5 module once landed) and the design doc in the same PR. The \`tla-check\` workflow runs the TLC model check on the same paths.`,
+              ``,
+              `---`,
+              ``,
+              `@claude review please verify TLA+ spec divergence per the checklist above.`,
+              ``,
+              `@codex review please verify TLA+ spec divergence per the checklist above.`,
+            ].join('\n');
+
+            // ALWAYS createComment (not update an existing one).  The
+            // upstream claude.yml workflow listens on `issue_comment` type
+            // `created` only — an edit would not re-trigger Claude on
+            // subsequent pushes.  Codex behaves the same way.  Creating a
+            // fresh comment per anchored-files push is the only reliable
+            // way to guarantee both bots fire on every diff.  Older
+            // marker comments stay in the thread; downstream tooling can
+            // collapse them via the embedded marker string above.
+            const { data } = await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.PR_NUMBER),
+              body,
+            });
+            core.info(`Created AI-review request comment ${data.id}`);

--- a/.github/workflows/tla-spec-ai-review.yml
+++ b/.github/workflows/tla-spec-ai-review.yml
@@ -23,6 +23,12 @@ name: TLA+ spec divergence — AI review
 # the model check AND the AI review request.
 
 on:
+  # NOTE on trigger types vs tla-check.yml: this workflow includes
+  # `ready_for_review` (draft → ready) because requesting an AI review is
+  # cheap and a draft-to-ready transition is exactly when a human starts
+  # paying attention.  tla-check.yml omits `ready_for_review` because the
+  # TLC run already happened on the prior `opened` or `synchronize`
+  # event — re-running it would be redundant compute.
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
@@ -53,6 +59,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # No git operations are pushed from this job — the
+          # github-token step below uses ${{ secrets.GITHUB_TOKEN }}
+          # explicitly via the github-script action.  Drop the
+          # persisted credential so a compromised subsequent step
+          # cannot reuse it (zizmor `artipacked`).
+          persist-credentials: false
 
       - name: List spec-anchored files changed in this PR
         id: changed
@@ -61,9 +73,13 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          # The set of anchored paths must stay in sync with the `paths:`
-          # filter above AND with tla-check.yml.  Keep all three lists
-          # identical when expanding for M2..M5.
+          # The set of anchored paths must stay in sync with **four**
+          # places (see §7.3 of the design doc):
+          #   1. the `paths:` filter above (this workflow)
+          #   2. the `paths:` filter in tla-check.yml
+          #   3. this ANCHORS regex
+          #   4. the enumeration in §7.3 of the design doc
+          # Keep all four identical when expanding for M2..M5.
           ANCHORS='^(kv/hlc[^/]*\.go|kv/coordinator\.go|kv/sharded_coordinator\.go|kv/transaction\.go|kv/fsm\.go|kv/lock_resolver\.go|store/mvcc_store\.go|distribution/.*)$'
           git diff --name-only "$BASE_SHA...$HEAD_SHA" \
             | grep -E "$ANCHORS" \

--- a/docs/design/2026_05_28_partial_tla_safety_spec.md
+++ b/docs/design/2026_05_28_partial_tla_safety_spec.md
@@ -590,7 +590,7 @@ check verifies the spec passes; the AI reviewers verify the
 implementation matches the spec.  Both fire on every push to an
 anchored file, so a divergence cannot land silently.  The path filter
 must stay in sync across all three places (the two workflow files and
-the doc § list).
+the list in §7.3).
 
 ---
 

--- a/docs/design/2026_05_28_partial_tla_safety_spec.md
+++ b/docs/design/2026_05_28_partial_tla_safety_spec.md
@@ -597,7 +597,17 @@ must stay in sync across **four** places:
 2. `paths:` in `.github/workflows/tla-spec-ai-review.yml`
 3. the `ANCHORS` regex inside `tla-spec-ai-review.yml` (used to populate
    the per-PR comment with the actual list of changed anchored files)
-4. the list in this §7.3.
+4. the **Implementation anchors** column of the §3 table — that table
+   is the canonical enumeration of every file the spec models, and the
+   three workflow path lists above are operational projections of it.
+   When a future milestone adds a new anchor in §3, all three workflow
+   path lists must be updated to match.
+
+Note: `tla-check.yml` additionally watches `tla/**` and `Makefile` so
+spec edits re-run TLC; `tla-spec-ai-review.yml` deliberately omits
+those because a spec-only change has no implementation to compare
+against.  The two workflows' `paths:` lists therefore differ by this
+exact delta, but the implementation-anchor portion stays identical.
 
 ---
 

--- a/docs/design/2026_05_28_partial_tla_safety_spec.md
+++ b/docs/design/2026_05_28_partial_tla_safety_spec.md
@@ -576,21 +576,28 @@ reviewers (`@claude review` + `@codex review`) with a per-subsystem
 checklist of which spec invariants to verify the implementation has
 not drifted from.  The chain is:
 
-```
+```text
 anchored-file change in PR
-  -> tla-check.yml runs TLC (catches *spec* bugs)
-  -> tla-spec-ai-review.yml posts the review-request comment
-       -> claude.yml fires on @claude in the comment
-       -> chatgpt-codex-connector bot fires on @codex review
-            -> both bots review the diff focused on TLA+ divergence
+  ├── (in parallel) tla-check.yml runs TLC          ── catches *spec* bugs
+  └── (in parallel) tla-spec-ai-review.yml posts a PR comment with
+                    @claude review + @codex review pings
+                      ├── claude.yml fires on @claude in the comment
+                      │     → Claude reviews the diff for spec divergence
+                      └── chatgpt-codex-connector fires on @codex review
+                            → Codex reviews the diff for spec divergence
 ```
 
 `tla-check` and the AI-review request are complementary — the model
 check verifies the spec passes; the AI reviewers verify the
 implementation matches the spec.  Both fire on every push to an
 anchored file, so a divergence cannot land silently.  The path filter
-must stay in sync across all three places (the two workflow files and
-the list in §7.3).
+must stay in sync across **four** places:
+
+1. `paths:` in `.github/workflows/tla-check.yml`
+2. `paths:` in `.github/workflows/tla-spec-ai-review.yml`
+3. the `ANCHORS` regex inside `tla-spec-ai-review.yml` (used to populate
+   the per-PR comment with the actual list of changed anchored files)
+4. the list in this §7.3.
 
 ---
 

--- a/docs/design/2026_05_28_partial_tla_safety_spec.md
+++ b/docs/design/2026_05_28_partial_tla_safety_spec.md
@@ -569,6 +569,29 @@ output contains the exact string
 mode (parse error, deadlock, JVM crash, different invariant) fails the
 job. The full M1 run completes in well under a minute.
 
+**Spec-divergence AI review.** A companion workflow
+`.github/workflows/tla-spec-ai-review.yml` fires on the same path
+filter and posts a PR comment that pings the Claude and Codex
+reviewers (`@claude review` + `@codex review`) with a per-subsystem
+checklist of which spec invariants to verify the implementation has
+not drifted from.  The chain is:
+
+```
+anchored-file change in PR
+  -> tla-check.yml runs TLC (catches *spec* bugs)
+  -> tla-spec-ai-review.yml posts the review-request comment
+       -> claude.yml fires on @claude in the comment
+       -> chatgpt-codex-connector bot fires on @codex review
+            -> both bots review the diff focused on TLA+ divergence
+```
+
+`tla-check` and the AI-review request are complementary — the model
+check verifies the spec passes; the AI reviewers verify the
+implementation matches the spec.  Both fire on every push to an
+anchored file, so a divergence cannot land silently.  The path filter
+must stay in sync across all three places (the two workflow files and
+the doc § list).
+
 ---
 
 ## 8. Milestones


### PR DESCRIPTION
## Summary

Auto-trigger AI review (Claude + Codex) whenever a PR touches a file the TLA+ safety spec has an anchor on, so a spec-divergence review **always** fires — never relies on a human remembering to ping.

Follows PR #856 (M1 spec + `tla-check` workflow).

## How it works

New workflow: `.github/workflows/tla-spec-ai-review.yml`

- Fires on `pull_request` (opened / synchronize / reopened / ready_for_review).
- Path filter is an exact copy of `tla-check.yml`'s — the two workflows stay paired so every anchored-file change triggers **both** the TLC run AND the AI-review request.
- Computes which anchored files actually changed (via `git diff` against the PR base) and skips the comment if none.
- Posts a fresh PR comment per push containing both `@claude review` and `@codex review` mentions, plus a per-subsystem checklist of which spec invariants to verify (HLC-4 preconditions, OCC lock encoding, MVCC visibility, Routes catalog versioning).
- **Always** `createComment` — never `updateComment`. The upstream `claude.yml` listens on `issue_comment: created` only; editing would not re-trigger Claude. Same for Codex.

## Chain

```
anchored file change in PR
  -> tla-check.yml runs TLC                    (catches *spec* bugs)
  -> tla-spec-ai-review.yml posts comment      (with @claude + @codex pings)
       -> claude.yml fires on @claude          → Claude reviews diff
       -> chatgpt-codex-connector bot fires    → Codex reviews diff
            (both focused on TLA+ divergence)
```

The two workflows are complementary: `tla-check` verifies the spec passes; the AI reviewers verify the implementation matches the spec.

## Docs

§7.3 of `docs/design/2026_05_28_partial_tla_safety_spec.md` is updated with the chain diagram, the two-workflow split, and a reminder that the path filter must stay in sync across the two YAML files and the doc § list.

## Verification

- `actionlint` clean.
- `make tla-check` still passes locally on `main` (3,594 distinct states on safe config, HLC-4 counterexample at depth 5 on gap config).
- The workflow itself doesn't run TLC — it only posts a comment — so the trigger chain can be tested by opening a follow-up PR that touches e.g. `kv/hlc.go`.

## Test plan

- [ ] CI green (`tla-check` runs again because the workflow path filter touches `tla/**`? No — this PR only adds `.github/workflows/`, which is NOT in the path filter, so `tla-check` will NOT fire on this PR. That's correct.)
- [ ] Reviewer opens a tiny follow-up PR touching e.g. `kv/hlc.go` to verify the comment+bot chain fires
- [ ] Reviewer confirms the comment template lists the right spec sections per subsystem

## Out of scope

- Auto-collapsing older marker comments after a fresh push — embedded as a marker (`<!-- tla-spec-ai-review-marker -->`) so a future PR can add a "minimize older" step if the comment noise becomes a problem.
- Triggering AI review when the spec itself changes (no impl divergence to check then — `tla-check` is sufficient).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated design documentation describing the new automated specification review workflow, including trigger conditions, review coordination processes, and how verification ensures implementations maintain alignment with formal specifications

* **Chores**
  * Added automated workflow that monitors pull requests for specification file changes and automatically coordinates review requests to verify specification compliance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/857?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->