### PR TITLE
kv(hlc): observe applied commit_ts into HLC.last — HLC-4 strategy (c)

### DIFF
--- a/kv/fsm.go
+++ b/kv/fsm.go
@@ -270,6 +270,20 @@ func (f *kvFSM) applyRequestErr(ctx context.Context, r *pb.Request) error {
 	if err := f.handleRequest(ctx, r, commitTS); err != nil {
 		return errors.WithStack(err)
 	}
+	// HLC-4 strategy (c) — observe every applied commit_ts so this node's
+	// hlc.last dominates the max committed timestamp visible in the FSM.
+	// On a follower this keeps the in-memory logical counter aligned with
+	// the cluster; when a follower is elected leader of any group,
+	// etcd/raft applies all uncommitted entries from prior terms before
+	// the leader serves a write, so by the time the new leader calls
+	// HLC.Next() for a persistence ts, hlc.last >= every commit_ts ever
+	// committed.  This closes the HLC-4 logical-handoff gap surfaced by
+	// the tla-check gap configuration on PR #856.
+	// See docs/design/2026_05_28_partial_tla_safety_spec.md §5.1 HLC-4
+	// precondition (ii) (strategy (c)) and HLC.tla BecomeLeader_HLC.
+	if f.hlc != nil && commitTS > 0 {
+		f.hlc.Observe(commitTS)
+	}
 	return nil
 }
 

--- a/kv/fsm_hlc_observe_test.go
+++ b/kv/fsm_hlc_observe_test.go
@@ -1,0 +1,129 @@
+package kv
+
+import (
+	"testing"
+
+	pb "github.com/bootjp/elastickv/proto"
+	"github.com/bootjp/elastickv/store"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// TestApplyObservesCommitTSIntoHLC verifies HLC-4 precondition (ii) /
+// strategy (c) at the FSM level: every successful Apply of a write
+// request advances the shared HLC's `last` via Observe(commitTS),
+// regardless of whether this node is a leader or a follower.  On a
+// follower this is what closes the logical-handoff gap surfaced by
+// the tla-check gap configuration on PR #856 — when a follower is
+// later elected leader, its first HLC.Next() returns a value strictly
+// greater than every commit it has previously applied.
+//
+// See:
+//   - docs/design/2026_05_28_partial_tla_safety_spec.md §5.1 HLC-4 (ii)
+//   - tla/hlc/HLC.tla BecomeLeader_HLC (strategy (c))
+func TestApplyObservesCommitTSIntoHLC(t *testing.T) {
+	st := store.NewMVCCStore()
+	hlc := NewHLC()
+	fsm, ok := NewKvFSMWithHLC(st, hlc).(*kvFSM)
+	require.True(t, ok)
+
+	// Sanity: HLC starts at 0 (no in-memory issuance, no Observe).
+	require.Equal(t, uint64(0), hlc.Current(),
+		"newly constructed HLC should have last = 0")
+
+	// Apply a write at commitTS = 100.  This simulates a leader
+	// replicating to this node (the FSM does not care whether this
+	// node is the leader; Apply is called identically on leader and
+	// follower).
+	put := &pb.Request{
+		Ts: 100,
+		Mutations: []*pb.Mutation{
+			{Op: pb.Op_PUT, Key: []byte("k"), Value: []byte("v1")},
+		},
+	}
+	data, err := proto.Marshal(put)
+	require.NoError(t, err)
+	require.Nil(t, fsm.Apply(data))
+
+	// HLC.last must now be at least 100.  Observe advances `last` to
+	// max(last, ts), so after this single apply, last >= 100.
+	require.GreaterOrEqual(t, hlc.Current(), uint64(100),
+		"Apply(commitTS=100) must Observe the commitTS into HLC.last")
+
+	// Apply a higher commit_ts — HLC.last must advance.
+	put2 := &pb.Request{
+		Ts: 250,
+		Mutations: []*pb.Mutation{
+			{Op: pb.Op_PUT, Key: []byte("k"), Value: []byte("v2")},
+		},
+	}
+	data2, err := proto.Marshal(put2)
+	require.NoError(t, err)
+	require.Nil(t, fsm.Apply(data2))
+	require.GreaterOrEqual(t, hlc.Current(), uint64(250),
+		"Apply(commitTS=250) must advance HLC.last")
+
+	// Apply a lower commit_ts (unrealistic in real traffic but valid
+	// for the model) — HLC.last must NOT regress.
+	put3 := &pb.Request{
+		Ts: 200,
+		Mutations: []*pb.Mutation{
+			{Op: pb.Op_PUT, Key: []byte("k"), Value: []byte("v3")},
+		},
+	}
+	data3, err := proto.Marshal(put3)
+	require.NoError(t, err)
+	// Apply may return a write-conflict error (since 200 < 250 on key
+	// "k") — but it must NOT regress hlc.last.  We don't assert the
+	// apply outcome, only the HLC monotonicity property.
+	fsm.Apply(data3)
+	require.GreaterOrEqual(t, hlc.Current(), uint64(250),
+		"HLC.last must never regress, even on a stale-ts Apply")
+}
+
+// TestApplyHLCObserveAfterRestart simulates the new-leader handoff
+// scenario the spec doc §5.1 HLC-4 (ii) describes: a follower whose
+// HLC was reset (e.g. process restart, all in-memory `last` lost)
+// catches up by replaying applied log entries through the FSM.  By
+// the time the catchup is complete, HLC.last must dominate every
+// previously committed timestamp — otherwise a subsequent election
+// could let this node issue an HLC strictly less than a prior commit.
+func TestApplyHLCObserveAfterRestart(t *testing.T) {
+	st := store.NewMVCCStore()
+
+	// Pre-populate the store with a write at commit_ts = 12345 — the
+	// "previous leader's last committed entry" that must not be
+	// regressed by a fresh leader on this node.
+	const priorCommit uint64 = 12345
+	require.NoError(t, st.PutAt(t.Context(), []byte("k"), []byte("v"), priorCommit, 0))
+
+	// Construct a fresh HLC + FSM: hlc.last starts at 0 — this is the
+	// post-restart state.
+	hlc := NewHLC()
+	fsm, ok := NewKvFSMWithHLC(st, hlc).(*kvFSM)
+	require.True(t, ok)
+	require.Equal(t, uint64(0), hlc.Current(),
+		"freshly constructed HLC starts at last = 0")
+
+	// Simulate Raft catchup: re-apply the prior leader's write through
+	// the FSM.  This is what etcd/raft does on a node coming up — log
+	// entries are re-applied to the FSM via StateMachine.Apply.
+	replay := &pb.Request{
+		Ts: priorCommit,
+		Mutations: []*pb.Mutation{
+			{Op: pb.Op_PUT, Key: []byte("k2"), Value: []byte("vr")},
+		},
+	}
+	data, err := proto.Marshal(replay)
+	require.NoError(t, err)
+	require.Nil(t, fsm.Apply(data))
+
+	// After replay, HLC.last must dominate the prior commit.  The
+	// first Next() this node issues — for example, if it now wins a
+	// leader election — therefore returns a value strictly greater
+	// than priorCommit, closing the HLC-4 logical-handoff gap.
+	require.GreaterOrEqual(t, hlc.Current(), priorCommit,
+		"post-replay HLC.last must dominate the prior leader's max commit_ts")
+	require.Greater(t, hlc.Next(), priorCommit,
+		"first Next() after replay must be strictly above the prior commit")
+}


### PR DESCRIPTION
## Summary

Implements the **M1 spec follow-up** per [`docs/design/2026_05_28_partial_tla_safety_spec.md`](https://github.com/bootjp/elastickv/blob/main/docs/design/2026_05_28_partial_tla_safety_spec.md) §5.1 HLC-4 precondition **(ii)** — strategy (c) "scan the FSM for max committed HLC and `Observe` before serving any persistence `Next()`".

Follows PR #856 (M1 TLA+ spec).

## What lands

One line in `kv/fsm.go` `applyRequestErr` after a successful `handleRequest`:

```go
if f.hlc != nil && commitTS > 0 {
    f.hlc.Observe(commitTS)
}
```

`HLC.Observe` is the existing CAS-to-max method (`kv/hlc.go:129-140`), so this is a **pure addition** with no signature change and no caller audit required.

## Why "observe on every apply" vs the spec doc's "observe on election"

The spec doc describes strategy (c) as "on election, scan the FSM and call `Observe`". The implementation refines this to "Observe on every apply". The two are semantically equivalent for HLC-4 because etcd/raft applies all uncommitted prior-term entries before a new leader serves a write — so by the time `HLC.Next()` runs in the new term, `hlc.last >= every prior commit`.

Two advantages over the on-election form:

1. **No protocol change** to `ShardedCoordinator` or `RunHLCLeaseRenewal`.
2. **No race window** between `BecomeLeader` and the first `Observe` — a concurrent client request landing in that window cannot see a stale `hlc.last`.

## Tests

`kv/fsm_hlc_observe_test.go`:

- `TestApplyObservesCommitTSIntoHLC` — verifies Apply advances `hlc.last` via `Observe(commitTS)`, and preserves monotonicity on a stale-ts apply.
- `TestApplyHLCObserveAfterRestart` — simulates the spec's new-leader-after-restart scenario: a fresh HLC (`last = 0`) re-plays a prior leader's write through the FSM and the resulting `Next()` is strictly greater than the prior `commit_ts`.

Both tests pass with `-race`.

## Deferred to a follow-up PR

The **ceiling-fence half** of the M1 spec contract (HLC-4 precondition **(iii)** — making `HLC.Next()` fail-closed when `wall_now >= physicalCeiling`) is intentionally NOT in this PR. That change alters `HLC.Next()`'s return signature from `uint64` to `(uint64, error)` and requires auditing **18 production call sites** across `kv/`, `adapter/`, and `store/`. Splitting it from the strategy-(c) PR keeps each diff individually reviewable per the loop-discipline reminder for semantic changes.

## Self-review (5-lens per CLAUDE.md)

1. **Data loss** — n/a; `Observe` only advances an in-memory clock counter, no persistence path touched.
2. **Concurrency** — `Observe` is the existing CAS-to-max loop; safe under concurrent `Apply` (which is serial per Raft FSM contract anyway) and concurrent `Next` (the CAS handles it).
3. **Performance** — adds one atomic load + CAS to the FSM apply hot path. The CAS only fires when `ts > current` so steady-state is one load.
4. **Data consistency** — `Observe` is monotone (only advances). No semantic change to any other code path.
5. **Test coverage** — two new tests in `kv/fsm_hlc_observe_test.go` covering the basic apply→observe path and the post-restart catchup case. Existing kv + store tests pass.

## Test plan

- [ ] CI green (the `tla-check` workflow does NOT fire — this PR is Go-only)
- [ ] The new `tla-spec-ai-review` workflow (PR #857) auto-pings Claude + Codex for spec-divergence review
- [ ] Reviewer cross-checks the Observe call against HLC-4 (ii) strategy (c) in the design doc and `BecomeLeader_HLC` in `tla/hlc/HLC.tla`

## Out of scope

- HLC-4 precondition (iii) ceiling fence (`HLC.Next()` fail-closed) — separate follow-up PR.
- Operator-visible metrics for the fence behaviour — lands with (iii).
