### PR TITLE
feat(admin): KeyViz heatmap cell click opens hot-key drill-down panel

### DIFF
--- a/web/admin/src/api/client.ts
+++ b/web/admin/src/api/client.ts
@@ -395,6 +395,48 @@ export interface KeyVizParams {
   rows?: number;
 }
 
+// Hot-key drill-down wire shape mirrors
+// internal/admin/keyviz_hotkeys_handler.go::hotKeyResponse. Counts are
+// scaled-to-true estimates; `approximate` and `error_bound` quantify
+// the Space-Saving sketch guarantee. Keys are base64-encoded raw bytes
+// (server preserves them as-is rather than coercing to UTF-8) — the
+// SPA renders them via the same decodePreview() helper the row detail
+// uses so binary keys come through as hex.
+export interface KeyVizHotKey {
+  key_b64: string;
+  count: number;
+}
+
+export interface KeyVizHotKeysResponse {
+  route_id: number;
+  // Omitted by the server when the route was registered with K=1
+  // (no sub-bucket axis); the SPA treats absence as "whole route".
+  sub_bucket?: number;
+  series: KeyVizSeries;
+  keys: KeyVizHotKey[];
+  approximate: boolean;
+  sample_rate: number;
+  sampled_n: number;
+  dropped_samples: number;
+  skipped_long_keys: number;
+  // `dropped > 0` OR `skipped_long_keys > 0` — see design §5. The
+  // server publishes this directly so older clients don't need to
+  // re-derive it (and stay consistent if the rule changes).
+  degraded: boolean;
+  error_bound: number;
+  snapshot_at: string;
+}
+
+export interface KeyVizHotKeysParams {
+  route_id: number;
+  // Sub-key-range bucket WITHIN the route (parallel to the matrix
+  // row's `#<n>` suffix). Omit for K=1 routes; the server validates
+  // the range and returns 400 invalid_query on out-of-range.
+  sub_bucket?: number;
+  series?: KeyVizSeries;
+  top?: number;
+}
+
 export const api = {
   login: (access_key: string, secret_key: string) =>
     apiFetch<LoginResponse>("/auth/login", {
@@ -533,6 +575,22 @@ export const api = {
         from_unix_ms: params.from_unix_ms,
         to_unix_ms: params.to_unix_ms,
         rows: params.rows,
+      },
+      signal,
+    }),
+  // Per-cell hot-key Top-K drill-down. The matrix cell click in the
+  // SPA maps to (route_id, sub_bucket); the server returns the keys
+  // observed in the latest aggregator window. Historical drill-down
+  // (from_unix_ms / to_unix_ms) is supported by the handler but the
+  // SPA omits the window so the client never has to negotiate the
+  // out_of_snapshot_window 400 — the panel always reflects "now".
+  keyVizHotKeys: (params: KeyVizHotKeysParams, signal?: AbortSignal) =>
+    apiFetch<KeyVizHotKeysResponse>("/keyviz/hotkeys", {
+      query: {
+        route_id: params.route_id,
+        sub_bucket: params.sub_bucket,
+        series: params.series,
+        top: params.top,
       },
       signal,
     }),

--- a/web/admin/src/pages/KeyViz.tsx
+++ b/web/admin/src/pages/KeyViz.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { KeyVizFanoutResult, KeyVizMatrix, KeyVizRow, KeyVizSeries } from "../api/client";
-import { api } from "../api/client";
+import type {
+  KeyVizFanoutResult,
+  KeyVizHotKeysResponse,
+  KeyVizMatrix,
+  KeyVizRow,
+  KeyVizSeries,
+} from "../api/client";
+import { ApiError, api } from "../api/client";
 import { ramp } from "../lib/colorRamp";
 import { formatApiError, useApiQuery } from "../lib/useApi";
 
@@ -91,6 +97,17 @@ interface HeatmapProps {
 function Heatmap({ matrix }: HeatmapProps) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const [hoverRow, setHoverRow] = useState<number | null>(null);
+  // selectedCell drives the hot-key drill-down panel. Null = no
+  // selection. Clicking the same cell twice clears it (toggle) so the
+  // user can dismiss the panel without scrolling for a close button.
+  const [selectedCell, setSelectedCell] = useState<{ row: number; col: number } | null>(null);
+  // Clear any stale selection when the matrix identity changes (new
+  // refresh, series switch, rows resize): the selected row index may
+  // now point to a completely different bucket, so dropping the
+  // selection is safer than silently re-pointing the drill-down.
+  useEffect(() => {
+    setSelectedCell(null);
+  }, [matrix]);
   // dprTick re-runs the canvas effect when the user drags the window
   // between displays of different pixel densities or changes the
   // browser zoom; window.devicePixelRatio is not reactive on its own,
@@ -191,6 +208,19 @@ function Heatmap({ matrix }: HeatmapProps) {
 
   const onLeave = () => setHoverRow(null);
 
+  const onClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const row = Math.floor(y / cellH);
+    const col = Math.floor(x / cellW);
+    if (row < 0 || row >= matrix.rows.length) return;
+    if (col < 0 || col >= matrix.column_unix_ms.length) return;
+    setSelectedCell((prev) =>
+      prev && prev.row === row && prev.col === col ? null : { row, col },
+    );
+  };
+
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between text-xs text-muted">
@@ -224,16 +254,68 @@ function Heatmap({ matrix }: HeatmapProps) {
             ref={canvasRef}
             onMouseMove={onMove}
             onMouseLeave={onLeave}
-            style={{ display: "block", width, height }}
+            onClick={onClick}
+            style={{ display: "block", width, height, cursor: "crosshair" }}
           />
           <ConflictOverlay rows={matrix.rows} cellH={cellH} cellW={cellW} width={width} />
+          <SelectionOverlay selected={selectedCell} cellH={cellH} cellW={cellW} />
           <TimeAxis columnUnixMs={matrix.column_unix_ms} cellW={cellW} />
         </div>
       )}
       {hoverRow !== null && matrix.rows[hoverRow] && (
         <RowDetail row={matrix.rows[hoverRow]} index={hoverRow} />
       )}
+      {selectedCell && matrix.rows[selectedCell.row] && (
+        <HotKeysPanel
+          row={matrix.rows[selectedCell.row]}
+          column={selectedCell.col}
+          columnUnixMs={matrix.column_unix_ms[selectedCell.col]}
+          series={matrix.series}
+          onClose={() => setSelectedCell(null)}
+        />
+      )}
     </div>
+  );
+}
+
+// SelectionOverlay outlines the clicked cell so the user can correlate
+// the heatmap position with the drill-down panel below. SVG sits in
+// the same scroll container as ConflictOverlay so it tracks horizontal
+// scrolling without manual offset math.
+interface SelectionOverlayProps {
+  selected: { row: number; col: number } | null;
+  cellH: number;
+  cellW: number;
+}
+
+function SelectionOverlay({ selected, cellH, cellW }: SelectionOverlayProps) {
+  if (!selected) return null;
+  // 2px stroke at full opacity reads against both light and dark
+  // ramp colours; the rect itself is transparent so the underlying
+  // intensity remains visible through the selection box.
+  return (
+    <svg
+      width={cellW * (selected.col + 1) + 4}
+      height={cellH * (selected.row + 1) + 4}
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        pointerEvents: "none",
+        overflow: "visible",
+      }}
+      aria-hidden="true"
+    >
+      <rect
+        x={selected.col * cellW - 1}
+        y={selected.row * cellH - 1}
+        width={cellW + 2}
+        height={cellH + 2}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={2}
+      />
+    </svg>
   );
 }
 
@@ -461,6 +543,283 @@ function RowDetail({ row, index }: RowDetailProps) {
           </>
         )}
       </dl>
+    </div>
+  );
+}
+
+// parseBucketID maps a row's bucket_id back to the (routeID, subBucket,
+// aggregate) tuple the hot-keys endpoint expects. The wire format
+// (server: bucketIDFor) is:
+//
+//   "virtual:<routeID>"            — coarsened aggregate, no drill-down
+//   "route:<routeID>"              — K=1 route, no sub-bucket axis
+//   "route:<routeID>#<subBucket>"  — sub-bucket row of a K>1 route
+//
+// Returns null when the format is unrecognised so the panel can render
+// a clear "unsupported bucket type" placeholder rather than throw.
+interface BucketIDParts {
+  kind: "virtual" | "route";
+  routeID: number;
+  subBucket?: number;
+}
+
+function parseBucketID(id: string): BucketIDParts | null {
+  if (id.startsWith("virtual:")) {
+    const n = Number.parseInt(id.slice("virtual:".length), 10);
+    if (!Number.isFinite(n)) return null;
+    return { kind: "virtual", routeID: n };
+  }
+  if (id.startsWith("route:")) {
+    const rest = id.slice("route:".length);
+    const hash = rest.indexOf("#");
+    if (hash < 0) {
+      const n = Number.parseInt(rest, 10);
+      if (!Number.isFinite(n)) return null;
+      return { kind: "route", routeID: n };
+    }
+    const routeID = Number.parseInt(rest.slice(0, hash), 10);
+    const sub = Number.parseInt(rest.slice(hash + 1), 10);
+    if (!Number.isFinite(routeID) || !Number.isFinite(sub)) return null;
+    return { kind: "route", routeID, subBucket: sub };
+  }
+  return null;
+}
+
+interface HotKeysPanelProps {
+  row: KeyVizRow;
+  column: number;
+  columnUnixMs: number;
+  series: KeyVizSeries;
+  onClose: () => void;
+}
+
+// hotKeysTopK is the Top-K we ask the server for. The server-side
+// capacity defaults to 64 and clamps top at the per-route capacity, so
+// 20 always fits and matches the "hottest keys" density the design
+// targets (§5). A future picker can lift this without server changes.
+const hotKeysTopK = 20;
+
+// HotKeysPanel renders the per-cell drill-down for the clicked
+// (route, sub-bucket) tuple. Three branches the panel surfaces
+// cleanly so users don't see a blank box waiting on a 503/404:
+//
+//   - series !== "writes"   — server only tracks the writes stream
+//                              (design §3); show a static notice.
+//   - bucket is aggregate   — design §2.2 excludes virtual buckets
+//                              from sampling; nothing to drill into.
+//   - 404 no_snapshot       — the aggregator hasn't published a window
+//                              for this route yet (cold or just-reset).
+//   - 503 hot_keys_disabled — operator started without
+//                              --keyvizHotKeysEnabled.
+function HotKeysPanel({ row, column, columnUnixMs, series, onClose }: HotKeysPanelProps) {
+  const parts = useMemo(() => parseBucketID(row.bucket_id), [row.bucket_id]);
+  const supported =
+    series === "writes" && parts !== null && parts.kind === "route";
+
+  return (
+    <div className="card text-sm border-accent/40">
+      <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-xs text-muted">Hot keys · cell</span>
+          <span className="font-mono text-xs">{row.bucket_id}</span>
+          <span className="text-xs text-muted">column {column}</span>
+          <span className="text-xs text-muted">
+            ({new Date(columnUnixMs).toLocaleTimeString()})
+          </span>
+        </div>
+        <button
+          type="button"
+          className="btn-secondary text-xs"
+          onClick={onClose}
+        >
+          Close
+        </button>
+      </div>
+      {!supported && (
+        <HotKeysUnsupportedNotice row={row} parts={parts} series={series} />
+      )}
+      {supported && parts && parts.kind === "route" && (
+        <HotKeysContent routeID={parts.routeID} subBucket={parts.subBucket} />
+      )}
+    </div>
+  );
+}
+
+interface HotKeysUnsupportedNoticeProps {
+  row: KeyVizRow;
+  parts: BucketIDParts | null;
+  series: KeyVizSeries;
+}
+
+function HotKeysUnsupportedNotice({ row, parts, series }: HotKeysUnsupportedNoticeProps) {
+  if (series !== "writes") {
+    return (
+      <p className="text-xs text-muted">
+        Hot-key drill-down is only sampled for the{" "}
+        <code className="font-mono">writes</code> series. Switch the
+        series picker to <code className="font-mono">writes</code> and
+        click a cell to inspect the hottest keys in that route.
+      </p>
+    );
+  }
+  if (parts === null) {
+    return (
+      <p className="text-xs text-muted">
+        Bucket id <code className="font-mono">{row.bucket_id}</code> is
+        not in a recognised format; nothing to drill into.
+      </p>
+    );
+  }
+  // parts.kind === "virtual" — the row is a coarsened aggregate that
+  // covers many routes (design §2.2 excludes these from per-route
+  // sampling).
+  return (
+    <p className="text-xs text-muted">
+      This row is an aggregate bucket covering{" "}
+      {row.route_count.toLocaleString()} routes. Per-route hot-key
+      drill-down is only available for individually tracked routes —
+      lift{" "}
+      <code className="font-mono">--keyvizMaxTrackedRoutes</code> to
+      track this route directly.
+    </p>
+  );
+}
+
+interface HotKeysContentProps {
+  routeID: number;
+  subBucket?: number;
+}
+
+function HotKeysContent({ routeID, subBucket }: HotKeysContentProps) {
+  const query = useApiQuery(
+    (signal) =>
+      api.keyVizHotKeys(
+        {
+          route_id: routeID,
+          sub_bucket: subBucket,
+          series: "writes",
+          top: hotKeysTopK,
+        },
+        signal,
+      ),
+    [routeID, subBucket],
+  );
+  if (query.loading && !query.data) {
+    return <p className="text-xs text-muted">Loading hot keys…</p>;
+  }
+  if (query.error) {
+    return <HotKeysErrorNotice error={query.error} />;
+  }
+  if (!query.data) return null;
+  return <HotKeysTable data={query.data} />;
+}
+
+interface HotKeysErrorNoticeProps {
+  error: ApiError;
+}
+
+function HotKeysErrorNotice({ error }: HotKeysErrorNoticeProps) {
+  if (error.status === 404) {
+    return (
+      <p className="text-xs text-muted">
+        No snapshot yet for this route — the aggregator hasn't
+        published a window since the route was registered, or every
+        recent observe was length-skipped. Drive some traffic and
+        click again.
+      </p>
+    );
+  }
+  if (error.status === 503) {
+    return (
+      <p className="text-xs text-muted">
+        Hot-key sampling is disabled on this node. Start the server
+        with{" "}
+        <code className="font-mono">--keyvizHotKeysEnabled</code> to
+        enable.
+      </p>
+    );
+  }
+  return (
+    <p className="text-xs text-danger">{formatApiError(error)}</p>
+  );
+}
+
+interface HotKeysTableProps {
+  data: KeyVizHotKeysResponse;
+}
+
+function HotKeysTable({ data }: HotKeysTableProps) {
+  return (
+    <div className="space-y-2">
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+        <dt className="text-muted">Snapshot at</dt>
+        <dd className="font-mono">
+          {new Date(data.snapshot_at).toLocaleString()}
+        </dd>
+        <dt className="text-muted">Sampled N</dt>
+        <dd className="font-mono">
+          {data.sampled_n.toLocaleString()}
+          <span className="ml-1 text-muted">
+            (1 in {data.sample_rate.toLocaleString()})
+          </span>
+        </dd>
+        <dt className="text-muted">Error bound</dt>
+        <dd className="font-mono">
+          ±{data.error_bound.toLocaleString()}
+          {data.approximate && (
+            <span className="ml-1 text-muted">(scaled estimate)</span>
+          )}
+        </dd>
+        {(data.dropped_samples > 0 || data.skipped_long_keys > 0) && (
+          <>
+            <dt className="text-muted">Dropped / skipped</dt>
+            <dd className="font-mono">
+              {data.dropped_samples.toLocaleString()} dropped ·{" "}
+              {data.skipped_long_keys.toLocaleString()} long-key skipped
+            </dd>
+          </>
+        )}
+      </dl>
+      {data.degraded && (
+        // Reusing the danger colour the FanoutBanner ("Cluster view
+        // degraded") already uses keeps a consistent "degraded sample"
+        // visual signal across the page rather than introducing a
+        // third semantic colour just for this row.
+        <p className="text-xs text-danger">
+          Degraded window — some samples were dropped or skipped, so a
+          true hot key might be missing from the list or its count
+          under-reported.
+        </p>
+      )}
+      {data.keys.length === 0 ? (
+        <p className="text-xs text-muted">
+          No keys in the snapshot — every observe in this window was
+          length-skipped or hit a queue-full drop.
+        </p>
+      ) : (
+        <table className="w-full text-xs">
+          <thead className="text-muted">
+            <tr>
+              <th className="text-left font-normal w-6">#</th>
+              <th className="text-left font-normal">Key (preview)</th>
+              <th className="text-right font-normal">Count (scaled)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.keys.map((k, i) => (
+              <tr key={`${i}-${k.key_b64}`}>
+                <td className="font-mono text-muted">{i + 1}</td>
+                <td className="font-mono break-all">
+                  {decodePreview(k.key_b64)}
+                </td>
+                <td className="font-mono text-right">
+                  {k.count.toLocaleString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }

--- a/web/admin/src/pages/KeyViz.tsx
+++ b/web/admin/src/pages/KeyViz.tsx
@@ -290,25 +290,29 @@ interface SelectionOverlayProps {
 
 function SelectionOverlay({ selected, cellH, cellW }: SelectionOverlayProps) {
   if (!selected) return null;
-  // 2px stroke at full opacity reads against both light and dark
-  // ramp colours; the rect itself is transparent so the underlying
-  // intensity remains visible through the selection box.
+  // Position the SVG container ITSELF at the selected cell so the
+  // viewport is one-cell-sized regardless of where the cell sits in
+  // the heatmap. At a max matrix of 1024 rows × ~1000 cols this
+  // avoids spawning a ~megapixel SVG just to draw one 8x4 outline
+  // at the far corner. 2px stroke at full opacity reads against both
+  // light and dark ramp colours; the rect itself is transparent so
+  // the underlying intensity stays visible through the selection box.
   return (
     <svg
-      width={cellW * (selected.col + 1) + 4}
-      height={cellH * (selected.row + 1) + 4}
+      width={cellW + 2}
+      height={cellH + 2}
       style={{
         position: "absolute",
-        top: 0,
-        left: 0,
+        top: selected.row * cellH - 1,
+        left: selected.col * cellW - 1,
         pointerEvents: "none",
         overflow: "visible",
       }}
       aria-hidden="true"
     >
       <rect
-        x={selected.col * cellW - 1}
-        y={selected.row * cellH - 1}
+        x={0}
+        y={0}
         width={cellW + 2}
         height={cellH + 2}
         fill="none"
@@ -564,8 +568,15 @@ interface BucketIDParts {
 }
 
 function parseBucketID(id: string): BucketIDParts | null {
+  // Use Number() rather than Number.parseInt() so a malformed id
+  // like "route:42abc" returns null instead of silently being read
+  // as 42 (parseInt stops at the first non-numeric character;
+  // Number() rejects trailing garbage as NaN). The server's
+  // strconv.FormatUint output never contains garbage today, but
+  // belt-and-braces parsing keeps a future server-side format
+  // change from quietly mis-routing the hot-keys API call.
   if (id.startsWith("virtual:")) {
-    const n = Number.parseInt(id.slice("virtual:".length), 10);
+    const n = Number(id.slice("virtual:".length));
     if (!Number.isFinite(n)) return null;
     return { kind: "virtual", routeID: n };
   }
@@ -573,12 +584,12 @@ function parseBucketID(id: string): BucketIDParts | null {
     const rest = id.slice("route:".length);
     const hash = rest.indexOf("#");
     if (hash < 0) {
-      const n = Number.parseInt(rest, 10);
+      const n = Number(rest);
       if (!Number.isFinite(n)) return null;
       return { kind: "route", routeID: n };
     }
-    const routeID = Number.parseInt(rest.slice(0, hash), 10);
-    const sub = Number.parseInt(rest.slice(hash + 1), 10);
+    const routeID = Number(rest.slice(0, hash));
+    const sub = Number(rest.slice(hash + 1));
     if (!Number.isFinite(routeID) || !Number.isFinite(sub)) return null;
     return { kind: "route", routeID, subBucket: sub };
   }
@@ -622,9 +633,15 @@ function HotKeysPanel({ row, column, columnUnixMs, series, onClose }: HotKeysPan
         <div className="flex items-center gap-2 flex-wrap">
           <span className="text-xs text-muted">Hot keys · cell</span>
           <span className="font-mono text-xs">{row.bucket_id}</span>
-          <span className="text-xs text-muted">column {column}</span>
+          {/* The clicked column locates the cell on the heatmap, but
+              the hot-keys API always returns the LATEST snapshot
+              (the SPA omits from/to_unix_ms by design). Label the
+              column timestamp as "clicked" so users don't read it as
+              the data's temporal anchor — the actual anchor is the
+              `Snapshot at` row in the table below. */}
           <span className="text-xs text-muted">
-            ({new Date(columnUnixMs).toLocaleTimeString()})
+            clicked column {column} (
+            {new Date(columnUnixMs).toLocaleTimeString()})
           </span>
         </div>
         <button
@@ -704,13 +721,25 @@ function HotKeysContent({ routeID, subBucket }: HotKeysContentProps) {
       ),
     [routeID, subBucket],
   );
-  if (query.loading && !query.data) {
+  // useApiQuery keeps the previous response in `data` while a new
+  // request is in flight (it doesn't reset on dep change), so when the
+  // user clicks a different bucket the table would briefly render the
+  // OLD bucket's keys under the NEW header. Compare the loaded
+  // response's identity to the current (routeID, subBucket) so the
+  // "loading" branch fires whenever they disagree. sub_bucket compares
+  // by strict equality including undefined === undefined for K=1
+  // routes.
+  const hasMatchingData =
+    !!query.data &&
+    query.data.route_id === routeID &&
+    query.data.sub_bucket === subBucket;
+  if (query.loading && !hasMatchingData) {
     return <p className="text-xs text-muted">Loading hot keys…</p>;
   }
   if (query.error) {
     return <HotKeysErrorNotice error={query.error} />;
   }
-  if (!query.data) return null;
+  if (!hasMatchingData || !query.data) return null;
   return <HotKeysTable data={query.data} />;
 }
 
@@ -730,12 +759,19 @@ function HotKeysErrorNotice({ error }: HotKeysErrorNoticeProps) {
     );
   }
   if (error.status === 503) {
+    // The handler returns two distinct 503 codes
+    // (keyviz_hotkeys_handler.go): "keyviz_disabled" when the whole
+    // sampler isn't configured, vs "hotkeys_disabled" when only
+    // hot-keys is off. Pointing operators at the wrong flag wastes
+    // a restart, so branch on error.code.
+    const flag =
+      error.code === "keyviz_disabled"
+        ? "--keyvizEnabled (plus --keyvizHotKeysEnabled)"
+        : "--keyvizHotKeysEnabled";
     return (
       <p className="text-xs text-muted">
         Hot-key sampling is disabled on this node. Start the server
-        with{" "}
-        <code className="font-mono">--keyvizHotKeysEnabled</code> to
-        enable.
+        with <code className="font-mono">{flag}</code>.
       </p>
     );
   }

--- a/web/admin/src/pages/KeyViz.tsx
+++ b/web/admin/src/pages/KeyViz.tsx
@@ -763,15 +763,22 @@ function HotKeysErrorNotice({ error }: HotKeysErrorNoticeProps) {
     // (keyviz_hotkeys_handler.go): "keyviz_disabled" when the whole
     // sampler isn't configured, vs "hotkeys_disabled" when only
     // hot-keys is off. Pointing operators at the wrong flag wastes
-    // a restart, so branch on error.code.
-    const flag =
-      error.code === "keyviz_disabled"
-        ? "--keyvizEnabled (plus --keyvizHotKeysEnabled)"
-        : "--keyvizHotKeysEnabled";
+    // a restart, so branch on error.code. Render the flags in
+    // separate <code> elements so a long compound message doesn't
+    // read as if the parenthetical is part of the flag name.
+    if (error.code === "keyviz_disabled") {
+      return (
+        <p className="text-xs text-muted">
+          KeyViz sampling is disabled on this node. Start the server
+          with <code className="font-mono">--keyvizEnabled</code> and{" "}
+          <code className="font-mono">--keyvizHotKeysEnabled</code>.
+        </p>
+      );
+    }
     return (
       <p className="text-xs text-muted">
         Hot-key sampling is disabled on this node. Start the server
-        with <code className="font-mono">{flag}</code>.
+        with <code className="font-mono">--keyvizHotKeysEnabled</code>.
       </p>
     );
   }

--- a/web/admin/src/pages/KeyViz.tsx
+++ b/web/admin/src/pages/KeyViz.tsx
@@ -285,15 +285,23 @@ function Heatmap({ matrix }: HeatmapProps) {
       {hoverRow !== null && matrix.rows[hoverRow] && (
         <RowDetail row={matrix.rows[hoverRow]} index={hoverRow} />
       )}
-      {selectedCell && matrix.rows[selectedCell.row] && (
-        <HotKeysPanel
-          row={matrix.rows[selectedCell.row]}
-          column={selectedCell.col}
-          columnUnixMs={matrix.column_unix_ms[selectedCell.col]}
-          series={matrix.series}
-          onClose={() => setSelectedCell(null)}
-        />
-      )}
+      {selectedCell &&
+        matrix.rows[selectedCell.row] &&
+        // Render-level column guard: the matrix-identity useEffect
+        // fires AFTER paint, so on the one frame between a refresh
+        // that shrinks column_unix_ms and the effect clearing the
+        // selection, column_unix_ms[col] would be undefined and the
+        // panel header would briefly read "Invalid Date". The effect
+        // is the durable fix; this guard hides the one-frame flash.
+        selectedCell.col < matrix.column_unix_ms.length && (
+          <HotKeysPanel
+            row={matrix.rows[selectedCell.row]}
+            column={selectedCell.col}
+            columnUnixMs={matrix.column_unix_ms[selectedCell.col]}
+            series={matrix.series}
+            onClose={() => setSelectedCell(null)}
+          />
+        )}
     </div>
   );
 }

--- a/web/admin/src/pages/KeyViz.tsx
+++ b/web/admin/src/pages/KeyViz.tsx
@@ -100,13 +100,25 @@ function Heatmap({ matrix }: HeatmapProps) {
   // selectedCell drives the hot-key drill-down panel. Null = no
   // selection. Clicking the same cell twice clears it (toggle) so the
   // user can dismiss the panel without scrolling for a close button.
-  const [selectedCell, setSelectedCell] = useState<{ row: number; col: number } | null>(null);
-  // Clear any stale selection when the matrix identity changes (new
-  // refresh, series switch, rows resize): the selected row index may
-  // now point to a completely different bucket, so dropping the
-  // selection is safer than silently re-pointing the drill-down.
+  // bucketId is snapshotted at click time so an auto-refresh that
+  // returns the same rows in the same order leaves the panel open —
+  // only a refresh that changes the row→bucket mapping (or a column
+  // shrink that puts the clicked column out of range) drops it.
+  const [selectedCell, setSelectedCell] = useState<{ row: number; col: number; bucketId: string } | null>(null);
+  // On every matrix refresh, validate the selection against the new
+  // shape. Without this, auto-refresh modes (5s / 30s) would clear
+  // the drill-down on every poll and the feature would be unusable
+  // while polling. The selection is kept only when the previously-
+  // clicked row still points at the same bucket_id AND the column
+  // is still in range; either invariant breaking drops the panel.
   useEffect(() => {
-    setSelectedCell(null);
+    setSelectedCell((prev) => {
+      if (!prev) return prev;
+      const row = matrix.rows[prev.row];
+      if (!row || row.bucket_id !== prev.bucketId) return null;
+      if (prev.col >= matrix.column_unix_ms.length) return null;
+      return prev;
+    });
   }, [matrix]);
   // dprTick re-runs the canvas effect when the user drags the window
   // between displays of different pixel densities or changes the
@@ -216,8 +228,16 @@ function Heatmap({ matrix }: HeatmapProps) {
     const col = Math.floor(x / cellW);
     if (row < 0 || row >= matrix.rows.length) return;
     if (col < 0 || col >= matrix.column_unix_ms.length) return;
+    // matrix.rows[row] is already bounds-checked above. Snapshotting
+    // the bucket id here lets the matrix-identity effect distinguish
+    // "the selected row still maps to the same bucket" (keep) from
+    // "the underlying data shifted and this row is now a different
+    // route" (drop).
+    const bucketId = matrix.rows[row].bucket_id;
     setSelectedCell((prev) =>
-      prev && prev.row === row && prev.col === col ? null : { row, col },
+      prev && prev.row === row && prev.col === col
+        ? null
+        : { row, col, bucketId },
     );
   };
 
@@ -567,30 +587,38 @@ interface BucketIDParts {
   subBucket?: number;
 }
 
+// parseUint accepts only a non-empty digit-only string. Number("")
+// and Number(" ") both coerce to 0 (finite), so a bare "route:" or
+// "route:42#" would otherwise parse as routeID=0 / subBucket=0 and
+// silently mis-route the drill-down. The regex also rejects
+// negatives, decimals, and trailing whitespace in one step.
+function parseUint(raw: string): number | null {
+  if (!/^\d+$/.test(raw)) return null;
+  return Number(raw);
+}
+
 function parseBucketID(id: string): BucketIDParts | null {
-  // Use Number() rather than Number.parseInt() so a malformed id
-  // like "route:42abc" returns null instead of silently being read
-  // as 42 (parseInt stops at the first non-numeric character;
-  // Number() rejects trailing garbage as NaN). The server's
-  // strconv.FormatUint output never contains garbage today, but
-  // belt-and-braces parsing keeps a future server-side format
-  // change from quietly mis-routing the hot-keys API call.
+  // parseUint enforces digit-only segments. Belt-and-braces against
+  // both Number.parseInt's prefix-tolerance (parseInt("42abc") → 42)
+  // and Number's empty-string coercion (Number("") → 0); the server's
+  // strconv output never produces either today, but a future format
+  // change cannot then silently mis-route the hot-keys API call.
   if (id.startsWith("virtual:")) {
-    const n = Number(id.slice("virtual:".length));
-    if (!Number.isFinite(n)) return null;
+    const n = parseUint(id.slice("virtual:".length));
+    if (n === null) return null;
     return { kind: "virtual", routeID: n };
   }
   if (id.startsWith("route:")) {
     const rest = id.slice("route:".length);
     const hash = rest.indexOf("#");
     if (hash < 0) {
-      const n = Number(rest);
-      if (!Number.isFinite(n)) return null;
+      const n = parseUint(rest);
+      if (n === null) return null;
       return { kind: "route", routeID: n };
     }
-    const routeID = Number(rest.slice(0, hash));
-    const sub = Number(rest.slice(hash + 1));
-    if (!Number.isFinite(routeID) || !Number.isFinite(sub)) return null;
+    const routeID = parseUint(rest.slice(0, hash));
+    const sub = parseUint(rest.slice(hash + 1));
+    if (routeID === null || sub === null) return null;
     return { kind: "route", routeID, subBucket: sub };
   }
   return null;


### PR DESCRIPTION
## What

Closes the last deferred follow-up from **PR #854** (per-cell hot-key Top-K drill-down, Phase 2-A++): SPA cell on-click handler that fetches `/admin/api/v1/keyviz/hotkeys` and renders a ranked Top-K panel below the heatmap.

**Depends on PR #854** — that PR ships the handler this UI calls. Merge order: #854 → this PR.

## Scope

Pure SPA change: two files, no Go changes, no schema change, no new design doc (the design is already in `docs/design/2026_05_28_proposed_keyviz_hot_key_topk.md` §5).

## How

### `web/admin/src/api/client.ts`
- `KeyVizHotKey` / `KeyVizHotKeysResponse` / `KeyVizHotKeysParams` types mirror `internal/admin/keyviz_hotkeys_handler.go::hotKeyResponse`.
- `api.keyVizHotKeys(params, signal)` — passes `route_id`, `sub_bucket`, `series`, `top` through. Deliberately omits `from_unix_ms`/`to_unix_ms` so the panel always reflects "now" and never triggers the `out_of_snapshot_window` 400.

### `web/admin/src/pages/KeyViz.tsx`
- `selectedCell` state on Heatmap, toggled by `onClick`: clicking the same cell twice clears it (no separate close button on the canvas).
- `SelectionOverlay` — 2px outline SVG layered inside the same scroll container as `ConflictOverlay`, so the highlight tracks the canvas horizontally on overflow.
- Matrix-identity effect clears the selection on refresh / series switch / rows resize.
- `parseBucketID` inverts `bucketIDFor` (server-side keyviz_handler.go):
  - `virtual:<routeID>` → aggregate (no drill-down available)
  - `route:<routeID>` → K=1 route, no sub-bucket axis
  - `route:<routeID>#<sub>` → sub-bucket row of a K>1 route
- **HotKeysPanel** surfaces every unsupported branch explicitly so the user never sees a blank box:
  - `series !== "writes"` → static notice (server only samples writes, design §3).
  - virtual aggregate → notice with the routes-coarsened count and a pointer to `--keyvizMaxTrackedRoutes`.
  - 404 `no_snapshot` → "drive some traffic and click again".
  - 503 `hot_keys_disabled` → "start the server with `--keyvizHotKeysEnabled`".
- On success: `snapshot_at`, `sampled_n` with 1-in-R hint, `error_bound` (with "scaled estimate" tag when approximate), dropped/skipped breakdown when non-zero, degraded banner reusing FanoutBanner's `text-danger` colour, then a Top-20 ranked table via the same `decodePreview` helper as RowDetail (binary keys → `0x...` hex).

## Test evidence

- `npm run lint` (tsc -b --noEmit) — clean.
- `npm run build` (tsc + vite build) — clean (242.89 kB JS, 16.72 kB CSS).
- `internal/admin/dist/` left as the committed placeholder (repo convention — built assets are gitignored).

## Five-lens self-review

1. **Data loss** — N/A. Pure client-side rendering of an existing read-only endpoint.
2. **Concurrency** — `useApiQuery` aborts on unmount + dep change; the selection-clearing effect bumps the abort path on matrix identity change, so a stale snapshot from a prior series cannot land on a newly-rendered row.
3. **Performance** — one fetch per cell click. Decode + render of a 20-row table is trivial. The SelectionOverlay is a single SVG `<rect>`; the canvas re-render is unchanged.
4. **Consistency** — `parseBucketID` is the inverse of `bucketIDFor`; if either side changes the format the panel's bucket-id chip will read 'unrecognised' and the API call will not fire. `ApiError` on a 400 `sub_bucket`-out-of-range surfaces via the generic error notice.
5. **Test coverage** — no JS test infra in `web/admin` (lint/build only). The server-side handler is already covered by `internal/admin/keyviz_hotkeys_handler_test.go` (landed in PR #854). Manual verification before merge: click a tracked-route cell with hot-keys enabled → panel renders; click an aggregate row → unsupported notice.

## Deferred (remaining follow-ups)

Two of the three PR #854 deferred items remain:

- **Fan-out merge** (design §6) — handler is single-node v1.
- **Deploy wiring** — `KEYVIZ_HOT_KEYS_ENABLED` + 4 friends in `deploy.env` / `rolling-update.sh::build_keyviz_flags`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Interactive heatmap drill-down: Click cells to view hot-key analytics and performance data
  * Visual selection indicator highlights the currently selected heatmap region
  * Hot-keys panel displays detailed statistics and analysis for selected drill-down areas
  * Comprehensive error handling for unsupported bucket types and unavailable snapshots

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->