### PR TITLE
feat(deploy): wire KeyViz hot-key Top-K flags through rolling-update

### DIFF
--- a/scripts/rolling-update.env.example
+++ b/scripts/rolling-update.env.example
@@ -125,3 +125,36 @@ ADMIN_ENABLED="false"
 # full design.
 KEYVIZ_ENABLED="false"
 # KEYVIZ_FANOUT_NODES="10.0.0.1:8080,10.0.0.2:8080,10.0.0.3:8080"
+
+# KeyViz hot-key Top-K drill-down (Phase 2-A++). When
+# KEYVIZ_HOT_KEYS_ENABLED=true (and KEYVIZ_ENABLED is also true), every
+# tracked route grows a Space-Saving sketch that powers the
+# /admin/api/v1/keyviz/hotkeys endpoint and the heatmap cell-click
+# drill-down. Disabled-case overhead on the sampler hot path is one
+# nil-check branch.
+#
+# Tuning (all four are sampler-side clamped to the limits documented
+# in keyviz/sampler.go; an out-of-range value rounds into the band):
+#   KEYVIZ_HOT_KEYS_PER_ROUTE — Space-Saving capacity m per route.
+#       Default 64, max 256. Each route holds at most m keys; with
+#       m=64 a key whose true frequency f > N/64 is guaranteed to
+#       survive eviction. Memory: m × (maxKeyLen + 16) per tracked
+#       route.
+#   KEYVIZ_HOT_KEYS_SAMPLE_RATE — R: the hot path enqueues 1 in R
+#       observes. Default 16, max 1024. Higher R = less CPU on the
+#       hot path + a coarser sketch (the response scales counts back
+#       up by R and surfaces `error_bound`).
+#   KEYVIZ_HOT_KEYS_QUEUE_SIZE — bounded channel between the hot
+#       path and the aggregator goroutine. Default 8192, max 65536.
+#       Overflows increment `dropped_samples` and set `degraded`
+#       on the next snapshot.
+#   KEYVIZ_HOT_KEYS_MAX_KEY_LEN — keys longer than this are skipped
+#       BEFORE the sample gate and increment `skipped_long_keys`.
+#       Default 1024, max 4096.
+# See docs/design/2026_05_28_proposed_keyviz_hot_key_topk.md §8 for the
+# full memory / overhead table.
+KEYVIZ_HOT_KEYS_ENABLED="false"
+# KEYVIZ_HOT_KEYS_PER_ROUTE="64"
+# KEYVIZ_HOT_KEYS_SAMPLE_RATE="16"
+# KEYVIZ_HOT_KEYS_QUEUE_SIZE="8192"
+# KEYVIZ_HOT_KEYS_MAX_KEY_LEN="1024"

--- a/scripts/rolling-update.sh
+++ b/scripts/rolling-update.sh
@@ -247,6 +247,20 @@ ADMIN_ALLOW_INSECURE_DEV_COOKIE="${ADMIN_ALLOW_INSECURE_DEV_COOKIE:-false}"
 KEYVIZ_ENABLED="${KEYVIZ_ENABLED:-false}"
 KEYVIZ_FANOUT_NODES="${KEYVIZ_FANOUT_NODES:-}"
 
+# KeyViz hot-key Top-K drill-down (Phase 2-A++). Master switch +
+# four tuning knobs. When KEYVIZ_HOT_KEYS_ENABLED != "true" the
+# build_keyviz_flags helper skips every --keyvizHotKeys* flag so
+# existing deploys see no behaviour change. Defaults match the
+# sampler-side constants in keyviz/sampler.go; empty values let
+# the daemon use those same defaults — keep them empty here so
+# bumping the Go-side default in a future release rolls out
+# without a separate env-file update.
+KEYVIZ_HOT_KEYS_ENABLED="${KEYVIZ_HOT_KEYS_ENABLED:-false}"
+KEYVIZ_HOT_KEYS_PER_ROUTE="${KEYVIZ_HOT_KEYS_PER_ROUTE:-}"
+KEYVIZ_HOT_KEYS_SAMPLE_RATE="${KEYVIZ_HOT_KEYS_SAMPLE_RATE:-}"
+KEYVIZ_HOT_KEYS_QUEUE_SIZE="${KEYVIZ_HOT_KEYS_QUEUE_SIZE:-}"
+KEYVIZ_HOT_KEYS_MAX_KEY_LEN="${KEYVIZ_HOT_KEYS_MAX_KEY_LEN:-}"
+
 # Validate the three boolean ADMIN_* flags must be the literal "true"
 # or "false" — they are forwarded to the remote shell unquoted (no
 # printf %q) for readability, which is only safe when the value is
@@ -254,7 +268,7 @@ KEYVIZ_FANOUT_NODES="${KEYVIZ_FANOUT_NODES:-}"
 # who typed "True", "1", or a stray quote sees a script-level error
 # pointing at the variable name instead of an inscrutable failure
 # inside the SSH heredoc.
-for _bool_var in ADMIN_ENABLED ADMIN_ALLOW_PLAINTEXT_NON_LOOPBACK ADMIN_ALLOW_INSECURE_DEV_COOKIE KEYVIZ_ENABLED ENABLE_S3 ENABLE_SQS; do
+for _bool_var in ADMIN_ENABLED ADMIN_ALLOW_PLAINTEXT_NON_LOOPBACK ADMIN_ALLOW_INSECURE_DEV_COOKIE KEYVIZ_ENABLED KEYVIZ_HOT_KEYS_ENABLED ENABLE_S3 ENABLE_SQS; do
   case "${!_bool_var}" in
     true|false) ;;
     *)
@@ -617,6 +631,11 @@ update_one_node() {
       ADMIN_ALLOW_INSECURE_DEV_COOKIE="$ADMIN_ALLOW_INSECURE_DEV_COOKIE" \
       KEYVIZ_ENABLED="$KEYVIZ_ENABLED" \
       KEYVIZ_FANOUT_NODES="$KEYVIZ_FANOUT_NODES_Q" \
+      KEYVIZ_HOT_KEYS_ENABLED="$KEYVIZ_HOT_KEYS_ENABLED" \
+      KEYVIZ_HOT_KEYS_PER_ROUTE="$KEYVIZ_HOT_KEYS_PER_ROUTE_Q" \
+      KEYVIZ_HOT_KEYS_SAMPLE_RATE="$KEYVIZ_HOT_KEYS_SAMPLE_RATE_Q" \
+      KEYVIZ_HOT_KEYS_QUEUE_SIZE="$KEYVIZ_HOT_KEYS_QUEUE_SIZE_Q" \
+      KEYVIZ_HOT_KEYS_MAX_KEY_LEN="$KEYVIZ_HOT_KEYS_MAX_KEY_LEN_Q" \
       bash -s <<'REMOTE'
 set -euo pipefail
 
@@ -1022,6 +1041,32 @@ build_keyviz_flags() {
   if [[ -n "$fanout_nodes" ]]; then
     _flags+=(--keyvizFanoutNodes "$fanout_nodes")
   fi
+
+  # Hot-key Top-K drill-down. Only emit the master flag (and its
+  # tuning knobs) when KEYVIZ_HOT_KEYS_ENABLED=true; the four tuning
+  # knobs are optional and only emitted when the operator set a
+  # non-empty value, so the daemon falls back to the sampler-side
+  # defaults (keyviz/sampler.go) when an env var is left empty.
+  local hot_keys_enabled="${KEYVIZ_HOT_KEYS_ENABLED:-false}"
+  if [[ "$hot_keys_enabled" == "true" ]]; then
+    _flags+=(--keyvizHotKeysEnabled)
+    local hot_keys_per_route="${KEYVIZ_HOT_KEYS_PER_ROUTE:-}"
+    if [[ -n "$hot_keys_per_route" ]]; then
+      _flags+=(--keyvizHotKeysPerRoute "$hot_keys_per_route")
+    fi
+    local hot_keys_sample_rate="${KEYVIZ_HOT_KEYS_SAMPLE_RATE:-}"
+    if [[ -n "$hot_keys_sample_rate" ]]; then
+      _flags+=(--keyvizHotKeysSampleRate "$hot_keys_sample_rate")
+    fi
+    local hot_keys_queue_size="${KEYVIZ_HOT_KEYS_QUEUE_SIZE:-}"
+    if [[ -n "$hot_keys_queue_size" ]]; then
+      _flags+=(--keyvizHotKeysQueueSize "$hot_keys_queue_size")
+    fi
+    local hot_keys_max_key_len="${KEYVIZ_HOT_KEYS_MAX_KEY_LEN:-}"
+    if [[ -n "$hot_keys_max_key_len" ]]; then
+      _flags+=(--keyvizHotKeysMaxKeyLen "$hot_keys_max_key_len")
+    fi
+  fi
 }
 
 # build_admin_flags emits the --admin* flag list and bind-mount list
@@ -1231,6 +1276,9 @@ config_fp() {
     "$ADMIN_TLS_CERT_FILE" "$ADMIN_TLS_KEY_FILE" \
     "$ADMIN_ALLOW_PLAINTEXT_NON_LOOPBACK" "$ADMIN_ALLOW_INSECURE_DEV_COOKIE" \
     "$KEYVIZ_ENABLED" "$KEYVIZ_FANOUT_NODES" \
+    "$KEYVIZ_HOT_KEYS_ENABLED" "$KEYVIZ_HOT_KEYS_PER_ROUTE" \
+    "$KEYVIZ_HOT_KEYS_SAMPLE_RATE" "$KEYVIZ_HOT_KEYS_QUEUE_SIZE" \
+    "$KEYVIZ_HOT_KEYS_MAX_KEY_LEN" \
     | sha256sum | cut -d' ' -f1
 }
 DEPLOY_CONFIG_FP_LABEL="elastickv.deploy.config-fp"
@@ -1446,6 +1494,17 @@ ADMIN_TLS_KEY_FILE_Q="$(printf '%q' "$ADMIN_TLS_KEY_FILE")"
 # survive an unquoted env pass but pre-quoting keeps the pattern
 # uniform with the ADMIN_* set above.
 KEYVIZ_FANOUT_NODES_Q="$(printf '%q' "$KEYVIZ_FANOUT_NODES")"
+
+# Hot-key tuning knobs are integers (or empty for sampler default);
+# integers carry no shell metacharacters, but pre-quoting matches the
+# SQS_PORT_Q precedent: anything that is not bool-validated at the top
+# of the script goes through printf '%q' before crossing the SSH
+# boundary. KEYVIZ_HOT_KEYS_ENABLED itself is bool-validated, so it
+# stays unquoted alongside the other booleans.
+KEYVIZ_HOT_KEYS_PER_ROUTE_Q="$(printf '%q' "$KEYVIZ_HOT_KEYS_PER_ROUTE")"
+KEYVIZ_HOT_KEYS_SAMPLE_RATE_Q="$(printf '%q' "$KEYVIZ_HOT_KEYS_SAMPLE_RATE")"
+KEYVIZ_HOT_KEYS_QUEUE_SIZE_Q="$(printf '%q' "$KEYVIZ_HOT_KEYS_QUEUE_SIZE")"
+KEYVIZ_HOT_KEYS_MAX_KEY_LEN_Q="$(printf '%q' "$KEYVIZ_HOT_KEYS_MAX_KEY_LEN")"
 
 echo "[rolling-update] target image: $IMAGE"
 for node_id in "${ROLLING_NODE_IDS[@]}"; do


### PR DESCRIPTION
## What

Closes the **deploy-wiring** deferred follow-up from PR #854 (KeyViz per-cell hot-key Top-K drill-down, Phase 2-A++). The five new `--keyvizHotKeys*` CLI flags are now reachable from operator env via `rolling-update.sh`, mirroring the existing `--keyvizEnabled` + `--keyvizFanoutNodes` wiring pattern.

## Scope

Pure deploy-script change (2 files). No Go changes, no schema change, no SPA change, no new design doc — the design is in `docs/design/2026_05_28_proposed_keyviz_hot_key_topk.md` §8.

## How

### `scripts/rolling-update.env.example`
Documented block for the five hot-keys env vars (master switch + four tuning knobs). Defaults are left **empty** so the daemon falls back to the sampler-side constants in `keyviz/sampler.go`; bumping a Go-side default in a future release then rolls out without an env-file edit.

### `scripts/rolling-update.sh` (five touchpoints, mirrors `KEYVIZ_FANOUT_NODES`)

1. **Top-level defaults** for all five env vars.
2. **Bool validation** — `KEYVIZ_HOT_KEYS_ENABLED` added to the bool-validated set so a typo'd value (`True`, `yes`, `1`, …) hard-errors at the script level rather than producing an inscrutable failure inside the SSH heredoc.
3. **SSH env forward + `printf '%q'` pre-quoting** for the four integer tuning knobs (matches the `SQS_PORT_Q` / `KEYVIZ_FANOUT_NODES_Q` precedent — anything not bool-validated goes through `%q` before crossing the SSH boundary).
4. **`build_keyviz_flags`** extended to emit `--keyvizHotKeysEnabled` + the four optional knobs only when `KEYVIZ_HOT_KEYS_ENABLED=true` AND each tuning knob's env var is non-empty. Master `KEYVIZ_ENABLED` still gates the whole emission so hot-keys cannot ride without the sampler being on.
5. **`config_fp()`** includes all five env vars in the deploy fingerprint so a hot-keys-only config change correctly triggers a container recreate.

## Test evidence

- `bash -n scripts/rolling-update.sh` clean.
- Extracted `build_keyviz_flags` into an isolated harness and exercised six matrices:
  - master off → no flags
  - master on / hot-keys off → only `--keyvizEnabled`
  - hot-keys on with sampler defaults (empty knobs) → no tuning flags emitted
  - hot-keys on with all knobs set → all flags emitted with the configured values
  - fan-out + hot-keys → both blocks compose correctly
  - master off overriding hot-keys=true → no flags (master-switch wins)

  All six match expected output.
- Bool validation rejects `KEYVIZ_HOT_KEYS_ENABLED='yes'` with the documented error message.

## Five-lens self-review (per CLAUDE.md)

1. **Data loss** — N/A. Deploy-script change.
2. **Concurrency** — N/A.
3. **Performance** — N/A. Disabled-case is one early-return in the helper; no behaviour change for existing deploys where `KEYVIZ_HOT_KEYS_ENABLED` stays unset.
4. **Consistency** — `config_fp` coverage means a hot-keys-only config change triggers a recreate; the bool validation rejects ambiguous values before they reach the daemon; the master-switch dependency (`KEYVIZ_ENABLED` gates hot-keys) matches the Go-side dependency.
5. **Test coverage** — exercised `build_keyviz_flags` directly via an extracted-function harness. The script itself has no Go test surface; integration is covered by the unit-test side that landed in PR #854.

## Deferred (last follow-up)

One PR #854 item remains: **Fan-out merge** (design §6) — handler is single-node v1. A separate PR will replicate the matrix fan-out infrastructure for the hot-keys endpoint.