### PR TITLE
feat(encryption): Stage 7b' — runtime writer re-registration for rotation case

### DIFF
--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -92,6 +92,26 @@ type Applier struct {
 	// constructor installs a private instance so single-applier
 	// callers and tests keep working unchanged.
 	stateCache *StateCache
+	// localEpoch is the §4.1 storage write-path local_epoch this
+	// process load pinned its nonce factory to at startup (the value
+	// `encryptionWriteWiring.epoch` holds). It is read ONLY by the
+	// Stage 7b' rotation-case applyRotateDEK path when writing
+	// `Keys[newDEK].LocalEpoch` for storage rotations — recording the
+	// LOCAL node's highest-emitted local_epoch under the new DEK so the
+	// §9.1 startup guard on next restart sees a monotone advance rather
+	// than the cluster-wide brick scenario described in 7b' §1. Raft
+	// rotations (PurposeRaft) continue to write `LocalEpoch: 0` (until
+	// raft envelope support lands with its own per-purpose epoch
+	// plumbing) per 7b' §3.1.1.
+	//
+	// Zero (the default when WithLocalEpoch is omitted) is correct for:
+	// (a) the pre-bootstrap process load — no writes have been emitted
+	//     under any DEK yet, so the sidecar's `0` accurately records this
+	//     node's highest-emitted local_epoch (7b' §3.1.2);
+	// (b) FSM-internal test harnesses that construct an Applier without
+	//     write-path state — they have no nonce factory and accept the
+	//     zero value as the "preserve today's behavior" fallback.
+	localEpoch uint16
 }
 
 // StateCache mirrors the sidecar fields the storage hot path needs
@@ -314,6 +334,21 @@ func WithNowFunc(now func() time.Time) ApplierOption {
 // and pre-multi-shard callers rely on.
 func WithStateCache(c *StateCache) ApplierOption {
 	return func(a *Applier) { a.stateCache = c }
+}
+
+// WithLocalEpoch installs the §4.1 storage write-path `local_epoch`
+// this process load pinned its nonce factory to. Threaded through
+// from `encryptionWriteWiring.epoch` so Stage 7b' rotation applies
+// can record THIS node's highest-emitted local_epoch under the new
+// DEK (see the `localEpoch` field doc on Applier and 7b' §3.1).
+//
+// A static `uint16` rather than a `func() uint16` provider is
+// deliberate (7b' §3.1): `BumpLocalEpoch` only runs at process start,
+// so there is no runtime epoch-bump path that would require late
+// binding. The option is omitted by FSM-internal test harnesses; the
+// zero value preserves today's `LocalEpoch: 0` behaviour for them.
+func WithLocalEpoch(epoch uint16) ApplierOption {
+	return func(a *Applier) { a.localEpoch = epoch }
 }
 
 // NewApplier wires an Applier against the supplied registry store
@@ -1029,18 +1064,29 @@ func (a *Applier) writeRotationSidecar(raftIdx uint64, p fsmwire.RotationPayload
 	if err != nil {
 		return err
 	}
+	// Stage 7b' §3.1: write THIS node's pinned storage local_epoch
+	// into Keys[newDEK].LocalEpoch for storage rotations so the §9.1
+	// startup guard on next restart sees a monotone advance from
+	// prior.w.epoch → prior.w.epoch+1. Raft rotations continue to
+	// write `LocalEpoch: 0` exactly as before (raft envelope support
+	// isn't implemented yet; cross-applying the storage nonce
+	// factory's epoch to a raft DEK would corrupt the raft counter
+	// before raft envelope ships — 7b' §3.1.1).
+	var keyLocalEpoch uint16
 	switch p.Purpose {
 	case fsmwire.PurposeStorage:
 		sc.Active.Storage = p.DEKID
+		keyLocalEpoch = a.localEpoch
 	case fsmwire.PurposeRaft:
 		sc.Active.Raft = p.DEKID
+		keyLocalEpoch = 0
 	}
 	advanceRaftAppliedIndex(sc, raftIdx)
 	sc.Keys[strconv.FormatUint(uint64(p.DEKID), 10)] = SidecarKey{
 		Purpose:    purpose,
 		Wrapped:    append([]byte(nil), p.Wrapped...),
 		Created:    a.now().UTC().Format(time.RFC3339),
-		LocalEpoch: 0,
+		LocalEpoch: keyLocalEpoch,
 	}
 	if err := WriteSidecar(a.sidecarPath, sc); err != nil {
 		return errors.Wrap(err, "applier: write sidecar for rotation")

--- a/internal/encryption/applier_test.go
+++ b/internal/encryption/applier_test.go
@@ -733,6 +733,201 @@ func TestApplyRotation_FullyWired(t *testing.T) {
 	}
 }
 
+// TestApplyRotateDEK_LocalEpochAppliedToStorageKey pins Stage 7b'
+// §3.1: with WithLocalEpoch installed, a PurposeStorage rotation
+// writes Keys[newDEK].LocalEpoch = the installed value (the local
+// node's pinned w.epoch) rather than the proposer's `0`. This is the
+// per-node sidecar coordination that makes the §9.1 startup guard
+// see a monotone advance on next restart instead of the brick
+// scenario described in 7b' §1.
+func TestApplyRotateDEK_LocalEpochAppliedToStorageKey(t *testing.T) {
+	t.Parallel()
+	reg := newMapRegistryStore()
+	ks := encryption.NewKeystore()
+	dir := t.TempDir()
+	sidecarPath := dir + "/keys.json"
+	const pinnedEpoch uint16 = 7
+	app, _ := encryption.NewApplier(reg,
+		encryption.WithKEK(&fakeKEK{}),
+		encryption.WithKeystore(ks),
+		encryption.WithSidecarPath(sidecarPath),
+		encryption.WithLocalEpoch(pinnedEpoch),
+	)
+	if err := app.ApplyBootstrap(0, fsmwire.BootstrapPayload{
+		StorageDEKID: 1, WrappedStorage: []byte("s1"),
+		RaftDEKID: 2, WrappedRaft: []byte("r2"),
+	}); err != nil {
+		t.Fatalf("pre-bootstrap: %v", err)
+	}
+	if err := app.ApplyRotation(0, fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubRotateDEK,
+		DEKID:                5,
+		Purpose:              fsmwire.PurposeStorage,
+		Wrapped:              []byte("storage-v2-wrapped"),
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: 5, FullNodeID: 0xBEEF, LocalEpoch: 0},
+	}); err != nil {
+		t.Fatalf("ApplyRotation: %v", err)
+	}
+	sc, err := encryption.ReadSidecar(sidecarPath)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	got, ok := sc.Keys["5"]
+	if !ok {
+		t.Fatal("sidecar keys missing rotated DEK 5")
+	}
+	if got.LocalEpoch != pinnedEpoch {
+		t.Errorf("Keys[5].LocalEpoch = %d, want %d (WithLocalEpoch's pinned value)", got.LocalEpoch, pinnedEpoch)
+	}
+}
+
+// TestApplyRotateDEK_LocalEpoch_RaftRotationKeepsZero pins 7b' §3.1.1:
+// the WithLocalEpoch value is the STORAGE write-path's pinned
+// `w.epoch`. Raft DEK rotations have their own (future) per-purpose
+// epoch counter; cross-applying the storage epoch to a raft DEK's
+// LocalEpoch would corrupt the raft counter before raft envelope
+// support consumes it. PurposeRaft rotations MUST continue to write
+// LocalEpoch: 0 even with WithLocalEpoch installed.
+func TestApplyRotateDEK_LocalEpoch_RaftRotationKeepsZero(t *testing.T) {
+	t.Parallel()
+	reg := newMapRegistryStore()
+	ks := encryption.NewKeystore()
+	dir := t.TempDir()
+	sidecarPath := dir + "/keys.json"
+	app, _ := encryption.NewApplier(reg,
+		encryption.WithKEK(&fakeKEK{}),
+		encryption.WithKeystore(ks),
+		encryption.WithSidecarPath(sidecarPath),
+		encryption.WithLocalEpoch(7), // storage epoch
+	)
+	if err := app.ApplyBootstrap(0, fsmwire.BootstrapPayload{
+		StorageDEKID: 1, WrappedStorage: []byte("s1"),
+		RaftDEKID: 2, WrappedRaft: []byte("r2"),
+	}); err != nil {
+		t.Fatalf("pre-bootstrap: %v", err)
+	}
+	// Rotate the RAFT DEK from 2 to 6 — the storage WithLocalEpoch
+	// value must NOT bleed into the new raft key's LocalEpoch.
+	if err := app.ApplyRotation(0, fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubRotateDEK,
+		DEKID:                6,
+		Purpose:              fsmwire.PurposeRaft,
+		Wrapped:              []byte("raft-v2-wrapped"),
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: 6, FullNodeID: 0xBEEF, LocalEpoch: 0},
+	}); err != nil {
+		t.Fatalf("ApplyRotation: %v", err)
+	}
+	sc, err := encryption.ReadSidecar(sidecarPath)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	got, ok := sc.Keys["6"]
+	if !ok {
+		t.Fatal("sidecar keys missing rotated raft DEK 6")
+	}
+	if got.LocalEpoch != 0 {
+		t.Errorf("Keys[6].LocalEpoch = %d, want 0 (raft rotation MUST NOT inherit storage write-path epoch — 7b' §3.1.1)", got.LocalEpoch)
+	}
+}
+
+// TestApplyRotateDEK_LocalEpoch_NoOptionFallsBackToZero pins 7b'
+// §3.1.2 backward compatibility: an Applier constructed without
+// WithLocalEpoch preserves today's Keys[newDEK].LocalEpoch=0 for
+// PurposeStorage rotations so existing FSM-internal test harnesses
+// (and pre-bootstrap process loads with w.epoch=0) keep working
+// unchanged.
+func TestApplyRotateDEK_LocalEpoch_NoOptionFallsBackToZero(t *testing.T) {
+	t.Parallel()
+	reg := newMapRegistryStore()
+	ks := encryption.NewKeystore()
+	dir := t.TempDir()
+	sidecarPath := dir + "/keys.json"
+	// NO WithLocalEpoch option — a.localEpoch defaults to 0.
+	app, _ := encryption.NewApplier(reg,
+		encryption.WithKEK(&fakeKEK{}),
+		encryption.WithKeystore(ks),
+		encryption.WithSidecarPath(sidecarPath),
+	)
+	if err := app.ApplyBootstrap(0, fsmwire.BootstrapPayload{
+		StorageDEKID: 1, WrappedStorage: []byte("s1"),
+		RaftDEKID: 2, WrappedRaft: []byte("r2"),
+	}); err != nil {
+		t.Fatalf("pre-bootstrap: %v", err)
+	}
+	if err := app.ApplyRotation(0, fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubRotateDEK,
+		DEKID:                5,
+		Purpose:              fsmwire.PurposeStorage,
+		Wrapped:              []byte("storage-v2-wrapped"),
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: 5, FullNodeID: 0xBEEF, LocalEpoch: 0},
+	}); err != nil {
+		t.Fatalf("ApplyRotation: %v", err)
+	}
+	sc, err := encryption.ReadSidecar(sidecarPath)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	got, ok := sc.Keys["5"]
+	if !ok {
+		t.Fatal("sidecar keys missing rotated DEK 5")
+	}
+	if got.LocalEpoch != 0 {
+		t.Errorf("Keys[5].LocalEpoch = %d, want 0 (no WithLocalEpoch → falls back to pre-7b' behavior)", got.LocalEpoch)
+	}
+}
+
+// TestApplyRotateDEK_LocalEpoch_AppliedPerApply pins 7b' §5 verification
+// item 3: the static a.localEpoch field is read on EACH apply, so a
+// second rotation observes the same value (not inadvertently reset
+// or derived from mutable state). Two PurposeStorage rotations in
+// sequence — both Keys[].LocalEpoch entries must equal the pinned
+// value.
+func TestApplyRotateDEK_LocalEpoch_AppliedPerApply(t *testing.T) {
+	t.Parallel()
+	reg := newMapRegistryStore()
+	ks := encryption.NewKeystore()
+	dir := t.TempDir()
+	sidecarPath := dir + "/keys.json"
+	const pinnedEpoch uint16 = 11
+	app, _ := encryption.NewApplier(reg,
+		encryption.WithKEK(&fakeKEK{}),
+		encryption.WithKeystore(ks),
+		encryption.WithSidecarPath(sidecarPath),
+		encryption.WithLocalEpoch(pinnedEpoch),
+	)
+	if err := app.ApplyBootstrap(0, fsmwire.BootstrapPayload{
+		StorageDEKID: 1, WrappedStorage: []byte("s1"),
+		RaftDEKID: 2, WrappedRaft: []byte("r2"),
+	}); err != nil {
+		t.Fatalf("pre-bootstrap: %v", err)
+	}
+	for _, dek := range []uint32{5, 6} {
+		if err := app.ApplyRotation(0, fsmwire.RotationPayload{
+			SubTag:               fsmwire.RotateSubRotateDEK,
+			DEKID:                dek,
+			Purpose:              fsmwire.PurposeStorage,
+			Wrapped:              []byte("storage-vN-wrapped"),
+			ProposerRegistration: fsmwire.RegistrationPayload{DEKID: dek, FullNodeID: 0xBEEF, LocalEpoch: 0},
+		}); err != nil {
+			t.Fatalf("ApplyRotation dek=%d: %v", dek, err)
+		}
+	}
+	sc, err := encryption.ReadSidecar(sidecarPath)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	for _, dek := range []string{"5", "6"} {
+		got, ok := sc.Keys[dek]
+		if !ok {
+			t.Errorf("sidecar keys missing rotated DEK %s", dek)
+			continue
+		}
+		if got.LocalEpoch != pinnedEpoch {
+			t.Errorf("Keys[%s].LocalEpoch = %d, want %d (per-apply read of static field)", dek, got.LocalEpoch, pinnedEpoch)
+		}
+	}
+}
+
 // TestApplyRotation_UnknownSubTag pins the fail-closed dispatch:
 // any sub_tag other than RotateSubRotateDEK halts apply with
 // ErrEncryptionApply so Stage 6B-1 cannot silently mis-apply a

--- a/main.go
+++ b/main.go
@@ -814,8 +814,15 @@ func buildShardGroups(
 		// Stage 6D-6c-1: WithStateCache threads the process-shared
 		// StateCache so an encryption apply landing on this shard's
 		// FSM updates the atomics every shard's storage layer reads.
+		// Stage 7b' §3.1: WithLocalEpoch threads this process load's
+		// pinned storage write-path w.epoch into the Applier so
+		// applyRotateDEK (PurposeStorage) can write each node's own
+		// highest-emitted local_epoch into Keys[newDEK].LocalEpoch
+		// rather than the proposer's 0. Raft rotations (PurposeRaft)
+		// keep LocalEpoch: 0 — see writeRotationSidecar's switch.
 		applierOpts := append(applierOptionsFor(kekWrapper, keystore, sidecarPath),
-			encryption.WithStateCache(encWiring.cache))
+			encryption.WithStateCache(encWiring.cache),
+			encryption.WithLocalEpoch(encWiring.epoch))
 		applier, err := encryption.NewApplier(reg, applierOpts...)
 		if err != nil {
 			for _, rt := range runtimes {

--- a/main_encryption_registration.go
+++ b/main_encryption_registration.go
@@ -548,10 +548,11 @@ func runRuntimeRegistrationWatcher(
 	bootDEKID uint32,
 	fullNodeID uint64,
 ) {
-	// Per-instance log-once gate (claude P2 round-2). Fires once per
-	// unique rotated-into DEK; a subsequent rotation to yet another DEK
-	// re-logs correctly.
-	var lastLoggedSkipDEK uint32
+	// Per-instance counter (Stage 7b' §3.2): records the most recently
+	// registered DEK so a subsequent rotation to yet another DEK
+	// re-triggers a propose. Resets to 0 on restart (per-process-load
+	// state, not durable) — §3.2.1.
+	var lastRegisteredDEK uint32
 	ticker := time.NewTicker(runtimeRegistrationPollInterval)
 	defer ticker.Stop()
 	for {
@@ -560,24 +561,34 @@ func runRuntimeRegistrationWatcher(
 			return
 		case <-ticker.C:
 		}
-		runtimeRegistrationTick(ctx, coordinate, defaultGroup, w, bootDEKID, fullNodeID, &lastLoggedSkipDEK)
+		runtimeRegistrationTick(ctx, coordinate, defaultGroup, w, bootDEKID, fullNodeID, &lastRegisteredDEK)
 	}
 }
 
 // runtimeRegistrationInScope evaluates the §1 scope check: returns the
-// active storage DEK and true ONLY when the 7b watcher should propose
-// (cutover branch or pre-bootstrap branch). All other cases — already
-// registered, envelope inactive, no active DEK, or deferred rotation
-// (bootDEKID != 0 && activeDEK != bootDEKID) — return (_, false). The
-// deferred-rotation branch logs once per unique rotated-into DEK,
-// gated by *lastLoggedSkip (claude P2 round-2). Extracted from
-// runtimeRegistrationTick to keep both under the cyclop budget.
+// active storage DEK and true when the watcher should propose
+// (cutover, pre-bootstrap, OR — after Stage 7b' — rotation).
+//
+// Stage 7b' §3.2 check ordering (load-bearing):
+//  1. `cache.Registered()` short-circuits — internally tests
+//     `activeStorageDEKID == registeredStorageDEKID` so it auto-
+//     scopes to the currently-active DEK; the single-DEK
+//     StateCache means a B→C→B oscillation will re-propose for B
+//     (safe via §4.1 case-2 idempotent — 7b' §3.2.2).
+//  2. Envelope-inactive / not-bootstrapped guards.
+//  3. Scope branches: pre-bootstrap (bootDEKID==0), cutover
+//     (activeDEK==bootDEKID), or rotation (activeDEK!=bootDEKID &&
+//     lastRegisteredDEK!=activeDEK). The 7b' implementation
+//     replaces 7b's log-once-skip deferral for the rotation branch
+//     with an in-scope propose now that applyRotateDEK records the
+//     per-node local_epoch (writeRotationSidecar §3.1).
 func runtimeRegistrationInScope(
 	cache *encryption.StateCache,
 	bootDEKID uint32,
 	fullNodeID uint64,
-	lastLoggedSkip *uint32,
+	lastRegisteredDEK *uint32,
 ) (activeDEK uint32, inScope bool) {
+	_ = fullNodeID // reserved for future per-node scope-check refinements
 	if cache.Registered() {
 		return 0, false
 	}
@@ -588,19 +599,26 @@ func runtimeRegistrationInScope(
 	if !ok {
 		return 0, false
 	}
-	if bootDEKID != 0 && activeDEK != bootDEKID {
-		// Deferred rotation case (7b'). Live nonce factory's pinned
-		// w.epoch does not match the new DEK's sidecar LocalEpoch (=0
-		// for a freshly-rotated DEK); registering here would brick the
-		// next restart or risk nonce reuse if the §9.1 guard were
-		// bypassed (see design §6).
-		if activeDEK != *lastLoggedSkip {
-			slog.Warn("encryption: 7b runtime watcher skipping deferred rotation case (7b')",
-				slog.Uint64("boot_dek_id", uint64(bootDEKID)),
-				slog.Uint64("active_dek_id", uint64(activeDEK)),
-				slog.Uint64("full_node_id", fullNodeID))
-			*lastLoggedSkip = activeDEK
-		}
+	// Cutover / pre-bootstrap branch: activeDEK == bootDEKID OR
+	// bootDEKID == 0. Both satisfy
+	// sidecar.Keys[activeDEK].LocalEpoch == w.epoch per 7b §2.2.
+	if bootDEKID == 0 || activeDEK == bootDEKID {
+		return activeDEK, true
+	}
+	// Rotation branch (Stage 7b'): bootDEKID != 0 && activeDEK !=
+	// bootDEKID. applyRotateDEK on the local node wrote
+	// Keys[activeDEK].LocalEpoch = w.epoch (the local node's pinned
+	// value, not the proposer's 0 — see internal/encryption/applier.go
+	// writeRotationSidecar). The watcher proposes
+	// (activeDEK, node, w.epoch); §4.1 case-2 idempotent acceptance
+	// covers oscillation re-proposes (§3.2.2).
+	//
+	// lastRegisteredDEK gates against re-proposing on every tick
+	// after we already MarkRegistered'd the current activeDEK in this
+	// process load. Reset-on-restart (§3.2.1) means a rotation that
+	// happened while the node was down still triggers a fresh propose
+	// on the first tick (lastRegisteredDEK starts at 0).
+	if activeDEK == *lastRegisteredDEK {
 		return 0, false
 	}
 	return activeDEK, true
@@ -609,9 +627,11 @@ func runtimeRegistrationInScope(
 // runtimeRegistrationTick is a single iteration of the watcher loop,
 // extracted so the loop body stays under the cyclop budget and the
 // scope-check + propose can be unit-tested independently of the ticker.
-// Returns to the caller after either a no-op skip, a deferred-rotation
-// skip (logged once per unique DEK via lastLoggedSkip), or a complete
+// Returns to the caller after either a no-op skip or a complete
 // synchronous registration attempt via runWriterRegistration.
+// Updates *lastRegisteredDEK to the active DEK if the registration
+// succeeded (cache.Registered() flipped true via runWriterRegistration's
+// MarkRegistered side effect on the success path).
 func runtimeRegistrationTick(
 	ctx context.Context,
 	coordinate *kv.ShardedCoordinator,
@@ -619,15 +639,18 @@ func runtimeRegistrationTick(
 	w encryptionWriteWiring,
 	bootDEKID uint32,
 	fullNodeID uint64,
-	lastLoggedSkip *uint32,
+	lastRegisteredDEK *uint32,
 ) {
-	activeDEK, inScope := runtimeRegistrationInScope(w.cache, bootDEKID, fullNodeID, lastLoggedSkip)
+	activeDEK, inScope := runtimeRegistrationInScope(w.cache, bootDEKID, fullNodeID, lastRegisteredDEK)
 	if !inScope {
 		return
 	}
-	// In scope: cutover branch (activeDEK == bootDEKID) OR pre-bootstrap
-	// branch (bootDEKID == 0). Both satisfy
-	// sidecar.Keys[activeDEK].LocalEpoch == w.epoch per design §2.2.
+	// In scope: cutover (activeDEK == bootDEKID), pre-bootstrap
+	// (bootDEKID == 0), or 7b' rotation (activeDEK != bootDEKID &&
+	// lastRegisteredDEK != activeDEK). All three satisfy
+	// sidecar.Keys[activeDEK].LocalEpoch == w.epoch (cutover/pre-
+	// bootstrap per 7b §2.2; rotation per 7b' §3.1's
+	// writeRotationSidecar local_epoch wiring).
 	slog.Info("encryption: 7b runtime watcher proposing registration",
 		slog.Uint64("active_dek_id", uint64(activeDEK)),
 		slog.Uint64("full_node_id", fullNodeID),
@@ -677,4 +700,13 @@ func runtimeRegistrationTick(
 	req := registrationRequest(activeDEK, fullNodeID, w.epoch)
 	runWriterRegistration(tickCtx, coordinate, defaultGroup.Engine, w.cache, activeDEK,
 		entry, req, barrier, verifyRegistered)
+	// 7b' §3.2: advance lastRegisteredDEK only on confirmed success so a
+	// timed-out propose doesn't gate the next tick's re-attempt.
+	// cache.Registered() (no-arg, internally tests
+	// activeStorageDEKID == registeredStorageDEKID) flips true only via
+	// runWriterRegistration's MarkRegistered success path; a partial
+	// propose, ctx timeout, or §4.1 case-3 halt-apply leaves it false.
+	if w.cache.Registered() {
+		*lastRegisteredDEK = activeDEK
+	}
 }

--- a/main_encryption_registration.go
+++ b/main_encryption_registration.go
@@ -136,11 +136,14 @@ func setupDistributionAndRegistration(
 	if err := installProcessStartRegistrationGate(runCtx, eg, coordinate, defaultGroup, w, raftID); err != nil {
 		return nil, err
 	}
-	// Stage 7b: arm the runtime watcher for the cutover case (Phase-0
-	// boot or pre-bootstrap boot, then runtime EnableStorageEnvelope).
-	// Must run AFTER installProcessStartRegistrationGate so the gate is
-	// in place before any runtime trigger can fire. Rotation cases are
-	// deferred to 7b' (see §6 of the design doc).
+	// Stage 7b/7b': arm the runtime watcher. Handles all three runtime
+	// registration triggers — cutover (Phase-0 → EnableStorageEnvelope),
+	// pre-bootstrap (no DEK → runtime Bootstrap), and rotation (RotateDEK
+	// from a non-proposer's perspective). All three collapse to the same
+	// in-scope propose under the cache.Registered() gate in
+	// runtimeRegistrationInScope. Must run AFTER
+	// installProcessStartRegistrationGate so the gate is in place before
+	// any runtime trigger can fire.
 	installRuntimeRegistrationWatcher(runCtx, eg, coordinate, defaultGroup, w, raftID)
 	// Bootstrap + registration both run under runCtx so a shutdown
 	// cancels the bounded retry rather than hanging.
@@ -528,12 +531,12 @@ func installRuntimeRegistrationWatcher(
 	})
 }
 
-// runRuntimeRegistrationWatcher is the Stage 7b polling loop. It checks
-// the §4.1 trigger condition every runtimeRegistrationPollInterval and
-// proposes a registration synchronously for the cutover case
-// (activeDEK == bootDEKID OR bootDEKID == 0). The rotation case
-// (bootDEKID != 0 && activeDEK != bootDEKID) is deferred to 7b' and
-// gets a log-once WARN gated by lastLoggedSkipDEK.
+// runRuntimeRegistrationWatcher is the Stage 7b/7b' polling loop. It
+// checks the §4.1 trigger condition every runtimeRegistrationPollInterval
+// and proposes a registration synchronously for any in-scope case: the
+// cutover (activeDEK == bootDEKID), pre-bootstrap (bootDEKID == 0), and
+// rotation (activeDEK != bootDEKID) branches all collapse to the same
+// in-scope propose under the cache.Registered() gate (7b' §3.2).
 //
 // The propose runs in this goroutine — at most one in-flight at a time,
 // no goroutine accumulation, no duplicate Raft proposals from the
@@ -644,11 +647,12 @@ func runtimeRegistrationTick(
 		return
 	}
 	// In scope: cutover (activeDEK == bootDEKID), pre-bootstrap
-	// (bootDEKID == 0), or 7b' rotation (activeDEK != bootDEKID &&
-	// lastRegisteredDEK != activeDEK). All three satisfy
-	// sidecar.Keys[activeDEK].LocalEpoch == w.epoch (cutover/pre-
-	// bootstrap per 7b §2.2; rotation per 7b' §3.1's
-	// writeRotationSidecar local_epoch wiring).
+	// (bootDEKID == 0), or 7b' rotation (activeDEK != bootDEKID).
+	// All three satisfy sidecar.Keys[activeDEK].LocalEpoch == w.epoch
+	// (cutover/pre-bootstrap per 7b §2.2; rotation per 7b' §3.1's
+	// writeRotationSidecar local_epoch wiring). cache.Registered()
+	// inside runtimeRegistrationInScope gates against re-proposing
+	// after a successful registration.
 	slog.Info("encryption: 7b runtime watcher proposing registration",
 		slog.Uint64("active_dek_id", uint64(activeDEK)),
 		slog.Uint64("full_node_id", fullNodeID),

--- a/main_encryption_registration.go
+++ b/main_encryption_registration.go
@@ -548,11 +548,6 @@ func runRuntimeRegistrationWatcher(
 	bootDEKID uint32,
 	fullNodeID uint64,
 ) {
-	// Per-instance counter (Stage 7b' §3.2): records the most recently
-	// registered DEK so a subsequent rotation to yet another DEK
-	// re-triggers a propose. Resets to 0 on restart (per-process-load
-	// state, not durable) — §3.2.1.
-	var lastRegisteredDEK uint32
 	ticker := time.NewTicker(runtimeRegistrationPollInterval)
 	defer ticker.Stop()
 	for {
@@ -561,7 +556,7 @@ func runRuntimeRegistrationWatcher(
 			return
 		case <-ticker.C:
 		}
-		runtimeRegistrationTick(ctx, coordinate, defaultGroup, w, bootDEKID, fullNodeID, &lastRegisteredDEK)
+		runtimeRegistrationTick(ctx, coordinate, defaultGroup, w, bootDEKID, fullNodeID)
 	}
 }
 
@@ -569,26 +564,37 @@ func runRuntimeRegistrationWatcher(
 // active storage DEK and true when the watcher should propose
 // (cutover, pre-bootstrap, OR — after Stage 7b' — rotation).
 //
-// Stage 7b' §3.2 check ordering (load-bearing):
+// Check ordering (load-bearing):
 //  1. `cache.Registered()` short-circuits — internally tests
 //     `activeStorageDEKID == registeredStorageDEKID` so it auto-
-//     scopes to the currently-active DEK; the single-DEK
-//     StateCache means a B→C→B oscillation will re-propose for B
-//     (safe via §4.1 case-2 idempotent — 7b' §3.2.2).
+//     scopes to the currently-active DEK and is the **single
+//     source of truth** for "this load has registered for the
+//     currently-active DEK". The §4.1 case-2 idempotent path
+//     makes re-proposing safe; a single-DEK StateCache means a
+//     B→C→B oscillation re-proposes for B and the case-2 apply
+//     is a no-op (7b' §3.2.2).
 //  2. Envelope-inactive / not-bootstrapped guards.
 //  3. Scope branches: pre-bootstrap (bootDEKID==0), cutover
-//     (activeDEK==bootDEKID), or rotation (activeDEK!=bootDEKID &&
-//     lastRegisteredDEK!=activeDEK). The 7b' implementation
-//     replaces 7b's log-once-skip deferral for the rotation branch
-//     with an in-scope propose now that applyRotateDEK records the
-//     per-node local_epoch (writeRotationSidecar §3.1).
-func runtimeRegistrationInScope(
-	cache *encryption.StateCache,
-	bootDEKID uint32,
-	fullNodeID uint64,
-	lastRegisteredDEK *uint32,
-) (activeDEK uint32, inScope bool) {
-	_ = fullNodeID // reserved for future per-node scope-check refinements
+//     (activeDEK==bootDEKID), or rotation (activeDEK!=bootDEKID).
+//     The 7b' implementation replaces 7b's log-once-skip deferral
+//     for the rotation branch with an in-scope propose now that
+//     applyRotateDEK records the per-node local_epoch
+//     (writeRotationSidecar §3.1).
+//
+// Note: an earlier 7b' draft added a per-process-load
+// `lastRegisteredDEK` counter to gate the rotation branch against
+// re-proposing once we'd already registered for the current active
+// DEK. That introduced a permanent fail-closed in the race where the
+// 7a process-start goroutine's MarkRegistered(oldDEK) lands AFTER
+// 7b's MarkRegistered(newDEK) — overwriting `registeredStorageDEKID`
+// to a stale value, making `Registered()` false, but the new gate
+// would still see `activeDEK == lastRegisteredDEK` and skip the
+// recovery propose (gemini CRITICAL on PR #864). Letting
+// `cache.Registered()` be the sole gate eliminates that hole at the
+// cost of one extra Raft round-trip per tick whenever the cache is
+// out of sync, which the §4.1 case-2 idempotent apply makes free of
+// side effects.
+func runtimeRegistrationInScope(cache *encryption.StateCache) (activeDEK uint32, inScope bool) {
 	if cache.Registered() {
 		return 0, false
 	}
@@ -599,39 +605,32 @@ func runtimeRegistrationInScope(
 	if !ok {
 		return 0, false
 	}
-	// Cutover / pre-bootstrap branch: activeDEK == bootDEKID OR
-	// bootDEKID == 0. Both satisfy
-	// sidecar.Keys[activeDEK].LocalEpoch == w.epoch per 7b §2.2.
-	if bootDEKID == 0 || activeDEK == bootDEKID {
-		return activeDEK, true
-	}
-	// Rotation branch (Stage 7b'): bootDEKID != 0 && activeDEK !=
-	// bootDEKID. applyRotateDEK on the local node wrote
-	// Keys[activeDEK].LocalEpoch = w.epoch (the local node's pinned
-	// value, not the proposer's 0 — see internal/encryption/applier.go
-	// writeRotationSidecar). The watcher proposes
-	// (activeDEK, node, w.epoch); §4.1 case-2 idempotent acceptance
-	// covers oscillation re-proposes (§3.2.2).
-	//
-	// lastRegisteredDEK gates against re-proposing on every tick
-	// after we already MarkRegistered'd the current activeDEK in this
-	// process load. Reset-on-restart (§3.2.1) means a rotation that
-	// happened while the node was down still triggers a fresh propose
-	// on the first tick (lastRegisteredDEK starts at 0).
-	if activeDEK == *lastRegisteredDEK {
-		return 0, false
-	}
+	// All three 7b/7b' sub-cases collapse to the same propose:
+	// - cutover (activeDEK == bootDEKID, Keys[activeDEK].LocalEpoch
+	//   == w.epoch per 7b §2.2),
+	// - pre-bootstrap (bootDEKID == 0, w.epoch == 0),
+	// - rotation (activeDEK != bootDEKID, Keys[activeDEK].LocalEpoch
+	//   == w.epoch via the 7b' applyRotateDEK per-node sidecar write —
+	//   see internal/encryption/applier.go writeRotationSidecar).
+	// The §4.1 case-2 idempotent apply makes a re-propose during
+	// oscillation a no-op (§3.2.2). The Registered() short-circuit
+	// above is the sole gate against busy re-proposing once a
+	// registration has succeeded — earlier drafts added a
+	// per-process-load lastRegisteredDEK gate here but that
+	// permanently fails closed in the 7a-stale-MarkRegistered race
+	// (gemini CRITICAL on PR #864).
 	return activeDEK, true
 }
 
 // runtimeRegistrationTick is a single iteration of the watcher loop,
 // extracted so the loop body stays under the cyclop budget and the
 // scope-check + propose can be unit-tested independently of the ticker.
-// Returns to the caller after either a no-op skip or a complete
-// synchronous registration attempt via runWriterRegistration.
-// Updates *lastRegisteredDEK to the active DEK if the registration
-// succeeded (cache.Registered() flipped true via runWriterRegistration's
-// MarkRegistered side effect on the success path).
+// Returns to the caller after either a no-op skip (when
+// cache.Registered() is already true for the active DEK, or scope
+// conditions reject the tick) or a complete synchronous registration
+// attempt via runWriterRegistration. The Registered() short-circuit at
+// runtimeRegistrationInScope step 1 is the sole gate against re-proposing
+// once a registration has succeeded (gemini CRITICAL on PR #864).
 func runtimeRegistrationTick(
 	ctx context.Context,
 	coordinate *kv.ShardedCoordinator,
@@ -639,9 +638,8 @@ func runtimeRegistrationTick(
 	w encryptionWriteWiring,
 	bootDEKID uint32,
 	fullNodeID uint64,
-	lastRegisteredDEK *uint32,
 ) {
-	activeDEK, inScope := runtimeRegistrationInScope(w.cache, bootDEKID, fullNodeID, lastRegisteredDEK)
+	activeDEK, inScope := runtimeRegistrationInScope(w.cache)
 	if !inScope {
 		return
 	}
@@ -700,13 +698,12 @@ func runtimeRegistrationTick(
 	req := registrationRequest(activeDEK, fullNodeID, w.epoch)
 	runWriterRegistration(tickCtx, coordinate, defaultGroup.Engine, w.cache, activeDEK,
 		entry, req, barrier, verifyRegistered)
-	// 7b' §3.2: advance lastRegisteredDEK only on confirmed success so a
-	// timed-out propose doesn't gate the next tick's re-attempt.
-	// cache.Registered() (no-arg, internally tests
-	// activeStorageDEKID == registeredStorageDEKID) flips true only via
-	// runWriterRegistration's MarkRegistered success path; a partial
-	// propose, ctx timeout, or §4.1 case-3 halt-apply leaves it false.
-	if w.cache.Registered() {
-		*lastRegisteredDEK = activeDEK
-	}
+	// No success-bookkeeping needed: cache.Registered() flips true via
+	// runWriterRegistration's MarkRegistered side effect on the success
+	// path, and the next tick's runtimeRegistrationInScope step (1)
+	// short-circuit reads that state directly. Any race that leaves the
+	// cache out of sync (e.g. the 7a process-start goroutine's
+	// MarkRegistered landing after this watcher's MarkRegistered for a
+	// newer DEK) is recovered by the next tick re-proposing, with the
+	// §4.1 case-2 idempotent apply making the re-propose a no-op.
 }

--- a/main_encryption_registration_test.go
+++ b/main_encryption_registration_test.go
@@ -365,12 +365,8 @@ func TestRuntimeRegistrationTick_AlreadyRegisteredIsNoOp(t *testing.T) {
 	st := newRegistrationTestStore(t)
 	w := wiringFor(t, testRegDEKID, true, 5)
 	w.cache.MarkRegistered(testRegDEKID) // pre-marked
-	var lastLogged uint32
 	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
-		&kv.ShardGroup{Store: st}, w, testRegDEKID, etcdraftengine.DeriveNodeID("n1"), &lastLogged)
-	if lastLogged != 0 {
-		t.Errorf("lastLogged unexpectedly mutated: %d", lastLogged)
-	}
+		&kv.ShardGroup{Store: st}, w, testRegDEKID, etcdraftengine.DeriveNodeID("n1"))
 	if !w.cache.Registered() {
 		t.Error("pre-marked Registered() flipped to false")
 	}
@@ -383,9 +379,8 @@ func TestRuntimeRegistrationTick_EnvelopeInactiveIsNoOp(t *testing.T) {
 	t.Parallel()
 	st := newRegistrationTestStore(t)
 	w := wiringFor(t, testRegDEKID, false /*envelope inactive*/, 5)
-	var lastLogged uint32
 	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
-		&kv.ShardGroup{Store: st}, w, testRegDEKID, etcdraftengine.DeriveNodeID("n1"), &lastLogged)
+		&kv.ShardGroup{Store: st}, w, testRegDEKID, etcdraftengine.DeriveNodeID("n1"))
 	if w.cache.Registered() {
 		t.Error("envelope inactive but Registered() flipped true")
 	}
@@ -400,9 +395,8 @@ func TestRuntimeRegistrationTick_NotBootstrappedIsNoOp(t *testing.T) {
 	// Envelope on but no active DEK (impossible in production but
 	// captures the not-bootstrapped guard explicitly).
 	w := wiringFor(t, 0 /*no active DEK*/, true, 0)
-	var lastLogged uint32
 	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
-		&kv.ShardGroup{Store: st}, w, 0, etcdraftengine.DeriveNodeID("n1"), &lastLogged)
+		&kv.ShardGroup{Store: st}, w, 0, etcdraftengine.DeriveNodeID("n1"))
 	if w.cache.Registered() {
 		t.Error("no active DEK but Registered() flipped true")
 	}
@@ -423,9 +417,8 @@ func TestRuntimeRegistrationTick_CutoverInScopeProposes(t *testing.T) {
 	writeRegistryRow(t, st, fullNodeID, epoch)
 
 	w := wiringFor(t, testRegDEKID, true /*envelope active*/, epoch)
-	var lastLogged uint32
 	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
-		&kv.ShardGroup{Store: st}, w, testRegDEKID /*bootDEK==activeDEK*/, fullNodeID, &lastLogged)
+		&kv.ShardGroup{Store: st}, w, testRegDEKID /*bootDEK==activeDEK*/, fullNodeID)
 	if !w.cache.Registered() {
 		t.Error("cutover branch did not MarkRegistered (Registered=false)")
 	}
@@ -445,9 +438,8 @@ func TestRuntimeRegistrationTick_PreBootstrapInScopeProposes(t *testing.T) {
 	writeRegistryRow(t, st, fullNodeID, 0) // pre-populated → verify short-circuits
 
 	w := wiringFor(t, testRegDEKID /*activeDEK=X*/, true, 0 /*w.epoch=0*/)
-	var lastLogged uint32
 	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
-		&kv.ShardGroup{Store: st}, w, 0 /*bootDEK=0*/, fullNodeID, &lastLogged)
+		&kv.ShardGroup{Store: st}, w, 0 /*bootDEK=0*/, fullNodeID)
 	if !w.cache.Registered() {
 		t.Error("pre-bootstrap branch did not MarkRegistered (Registered=false)")
 	}
@@ -478,14 +470,10 @@ func TestRuntimeRegistrationTick_PreBootstrapRotateBeforeCutoverProposes(t *test
 	preSeedRegistryRow(t, st, rotatedDEK, fullNodeID, 0)
 
 	w := wiringFor(t, rotatedDEK, true, 0 /*w.epoch=0*/)
-	var lastRegisteredDEK uint32
 	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
-		&kv.ShardGroup{Store: st}, w, 0 /*bootDEK=0*/, fullNodeID, &lastRegisteredDEK)
+		&kv.ShardGroup{Store: st}, w, 0 /*bootDEK=0*/, fullNodeID)
 	if !w.cache.Registered() {
 		t.Error("bootstrap→rotate→cutover sub-path did not MarkRegistered (Registered=false); bootDEKID==0 should keep the rotation branch off")
-	}
-	if lastRegisteredDEK != rotatedDEK {
-		t.Errorf("lastRegisteredDEK = %d, want %d (success path must advance the counter)", lastRegisteredDEK, rotatedDEK)
 	}
 }
 
@@ -496,7 +484,7 @@ func TestRuntimeRegistrationTick_PreBootstrapRotateBeforeCutoverProposes(t *test
 // per 7b' §3.1 so the §9.1 startup guard sees a monotone advance on
 // next restart. The test pre-populates a registry row at (Y, node,
 // w.epoch) so verifyRegistered short-circuits and the success-side
-// MarkRegistered fires; lastRegisteredDEK advances to Y.
+// MarkRegistered fires.
 func TestRuntimeRegistrationTick_RotationInScopeVerifyShortCircuits(t *testing.T) {
 	t.Parallel()
 	st := newRegistrationTestStore(t)
@@ -510,22 +498,18 @@ func TestRuntimeRegistrationTick_RotationInScopeVerifyShortCircuits(t *testing.T
 	preSeedRegistryRow(t, st, rotatedDEK, fullNodeID, wepoch)
 
 	w := wiringFor(t, rotatedDEK, true, wepoch)
-	var lastRegisteredDEK uint32
 	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
-		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID, &lastRegisteredDEK)
+		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID)
 	if !w.cache.Registered() {
 		t.Error("7b' rotation in-scope path did not MarkRegistered (Registered=false); applyRotateDEK + verifyRegistered short-circuit + MarkRegistered should flip the cache")
-	}
-	if lastRegisteredDEK != rotatedDEK {
-		t.Errorf("lastRegisteredDEK = %d, want %d (success advances counter to active DEK)", lastRegisteredDEK, rotatedDEK)
 	}
 }
 
 // TestRuntimeRegistrationTick_RotationAlreadyRegisteredIsNoOp pins
 // 7b' §3.2's check ordering step (1): once cache.Registered() is true
 // for the active DEK (a prior tick MarkRegistered'd it), a subsequent
-// tick is a no-op — does NOT re-propose, does NOT mutate
-// lastRegisteredDEK (which was already advanced on the first tick).
+// tick is a no-op — runtimeRegistrationInScope's first guard returns
+// before re-proposing.
 func TestRuntimeRegistrationTick_RotationAlreadyRegisteredIsNoOp(t *testing.T) {
 	t.Parallel()
 	st := newRegistrationTestStore(t)
@@ -535,28 +519,30 @@ func TestRuntimeRegistrationTick_RotationAlreadyRegisteredIsNoOp(t *testing.T) {
 	preSeedRegistryRow(t, st, rotatedDEK, fullNodeID, wepoch)
 
 	w := wiringFor(t, rotatedDEK, true, wepoch)
-	var lastRegisteredDEK uint32
 	// First tick: registers.
 	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
-		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID, &lastRegisteredDEK)
-	if !w.cache.Registered() || lastRegisteredDEK != rotatedDEK {
-		t.Fatalf("first tick failed prerequisite: Registered=%v, lastRegisteredDEK=%d (want true / %d)", w.cache.Registered(), lastRegisteredDEK, rotatedDEK)
+		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID)
+	if !w.cache.Registered() {
+		t.Fatalf("first tick failed prerequisite: Registered=false")
 	}
 	// Second tick: no-op via cache.Registered() short-circuit (step 1).
-	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
-		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID, &lastRegisteredDEK)
-	if lastRegisteredDEK != rotatedDEK {
-		t.Errorf("second tick mutated lastRegisteredDEK (=%d), want unchanged %d", lastRegisteredDEK, rotatedDEK)
+	// To assert "no propose happened", we pass a nil coordinator —
+	// runtimeRegistrationInScope must return (_, false) before
+	// runWriterRegistration is reached. If the short-circuit fails,
+	// the tick would attempt to read from a nil coordinator and panic.
+	runtimeRegistrationTick(context.Background(), nil, /*nil coordinator pins the short-circuit*/
+		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID)
+	if !w.cache.Registered() {
+		t.Error("second tick unexpectedly cleared Registered()")
 	}
 }
 
 // TestRuntimeRegistrationTick_RotationToYetAnotherDEKReProposes pins
-// 7b' §3.2's lastRegisteredDEK advance: after registering for Y, a
-// subsequent rotation to Z triggers a fresh propose (Z != Y, and
-// cache.Registered() returns false because the single-DEK
-// StateCache's activeStorageDEKID flipped to Z while
-// registeredStorageDEKID still holds Y). On success lastRegisteredDEK
-// advances to Z.
+// 7b' §3.2 fresh-rotation propose: after registering for Y, a
+// subsequent rotation to Z triggers a fresh propose because
+// cache.Registered() returns false (single-DEK StateCache: active=Z
+// while registered=Y, mismatch). On success cache.Registered() flips
+// true for Z.
 func TestRuntimeRegistrationTick_RotationToYetAnotherDEKReProposes(t *testing.T) {
 	t.Parallel()
 	st := newRegistrationTestStore(t)
@@ -567,12 +553,11 @@ func TestRuntimeRegistrationTick_RotationToYetAnotherDEKReProposes(t *testing.T)
 	preSeedRegistryRow(t, st, rotateZ, fullNodeID, wepoch)
 
 	w := wiringFor(t, rotateY, true, wepoch)
-	var lastRegisteredDEK uint32
 	// Register Y.
 	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
-		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID, &lastRegisteredDEK)
-	if lastRegisteredDEK != rotateY {
-		t.Fatalf("first tick: lastRegisteredDEK=%d, want %d", lastRegisteredDEK, rotateY)
+		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID)
+	if !w.cache.Registered() {
+		t.Fatalf("first tick (Y) failed: Registered=false")
 	}
 	// Rotation Y→Z: refresh sidecar to flip activeStorageDEKID.
 	sc := &encryption.Sidecar{Version: encryption.SidecarVersion, StorageEnvelopeActive: true}
@@ -583,12 +568,9 @@ func TestRuntimeRegistrationTick_RotationToYetAnotherDEKReProposes(t *testing.T)
 	}
 	// Second tick on Z: re-proposes, MarkRegistered(Z) flips cache.
 	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
-		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID, &lastRegisteredDEK)
+		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID)
 	if !w.cache.Registered() {
 		t.Error("rotation-to-Z tick did not MarkRegistered")
-	}
-	if lastRegisteredDEK != rotateZ {
-		t.Errorf("lastRegisteredDEK after rotation-to-Z = %d, want %d", lastRegisteredDEK, rotateZ)
 	}
 }
 
@@ -598,8 +580,7 @@ func TestRuntimeRegistrationTick_RotationToYetAnotherDEKReProposes(t *testing.T)
 // rotation back to B leaves cache.Registered() == false (active=B,
 // registered=C mismatch). The watcher re-proposes (safe via §4.1
 // case-2 idempotent on the existing B row); MarkRegistered(B) flips
-// the cache back. Pins the documented re-propose so the
-// implementation PR's tests do not mistake the re-propose for a bug.
+// the cache back.
 func TestRuntimeRegistrationTick_RotationOscillationBtoCtoBReProposes(t *testing.T) {
 	t.Parallel()
 	st := newRegistrationTestStore(t)
@@ -610,25 +591,24 @@ func TestRuntimeRegistrationTick_RotationOscillationBtoCtoBReProposes(t *testing
 	preSeedRegistryRow(t, st, dekC, fullNodeID, wepoch)
 
 	w := wiringFor(t, dekB, true, wepoch)
-	var lastRegisteredDEK uint32
 	// Register B.
 	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
-		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID, &lastRegisteredDEK)
-	if lastRegisteredDEK != dekB || !w.cache.Registered() {
-		t.Fatalf("register B failed: lastRegisteredDEK=%d Registered=%v", lastRegisteredDEK, w.cache.Registered())
+		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID)
+	if !w.cache.Registered() {
+		t.Fatalf("register B failed: Registered=false")
 	}
 	// Rotate B → C; tick registers C.
 	scC := &encryption.Sidecar{Version: encryption.SidecarVersion, StorageEnvelopeActive: true}
 	scC.Active.Storage = dekC
 	w.cache.RefreshFromSidecar(scC)
 	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
-		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID, &lastRegisteredDEK)
-	if lastRegisteredDEK != dekC || !w.cache.Registered() {
-		t.Fatalf("register C failed: lastRegisteredDEK=%d Registered=%v", lastRegisteredDEK, w.cache.Registered())
+		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID)
+	if !w.cache.Registered() {
+		t.Fatalf("register C failed: Registered=false")
 	}
 	// Rotate C → B: §3.2.2 — cache holds C; Registered() == false
 	// when active flips to B → watcher re-proposes; success path
-	// MarkRegisters B and flips lastRegisteredDEK back to B.
+	// MarkRegisters B.
 	scB := &encryption.Sidecar{Version: encryption.SidecarVersion, StorageEnvelopeActive: true}
 	scB.Active.Storage = dekB
 	w.cache.RefreshFromSidecar(scB)
@@ -636,12 +616,56 @@ func TestRuntimeRegistrationTick_RotationOscillationBtoCtoBReProposes(t *testing
 		t.Fatalf("after rotation C→B: cache.Registered() unexpectedly true; single-DEK cache should mismatch")
 	}
 	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
-		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID, &lastRegisteredDEK)
+		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID)
 	if !w.cache.Registered() {
 		t.Error("rotation C→B re-propose did not MarkRegistered (Registered=false)")
 	}
-	if lastRegisteredDEK != dekB {
-		t.Errorf("lastRegisteredDEK after C→B re-propose = %d, want %d", lastRegisteredDEK, dekB)
+}
+
+// TestRuntimeRegistrationTick_StaleMarkRegisteredRecoveryReProposes
+// pins the gemini CRITICAL fix on PR #864: even if a stale
+// MarkRegistered(oldDEK) from the 7a process-start goroutine lands
+// AFTER 7b' has already MarkRegistered(newDEK) — making
+// cache.Registered() return false for activeDEK=newDEK — the next
+// watcher tick MUST re-propose for newDEK. The earlier draft's
+// lastRegisteredDEK gate caused a permanent fail-closed in this race
+// by short-circuiting the rotation branch on activeDEK ==
+// lastRegisteredDEK. The fix is to let cache.Registered() be the
+// sole gate; §4.1 case-2 idempotent acceptance makes the recovery
+// re-propose a no-op apply.
+func TestRuntimeRegistrationTick_StaleMarkRegisteredRecoveryReProposes(t *testing.T) {
+	t.Parallel()
+	st := newRegistrationTestStore(t)
+	fullNodeID := etcdraftengine.DeriveNodeID("n1")
+	const bootDEK, newDEK, oldDEK uint32 = 7, 8, 5
+	const wepoch uint16 = 5
+	preSeedRegistryRow(t, st, newDEK, fullNodeID, wepoch)
+
+	w := wiringFor(t, newDEK, true, wepoch)
+	// 7b' tick registers for the new DEK.
+	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
+		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID)
+	if !w.cache.Registered() {
+		t.Fatalf("initial registration failed: Registered=false")
+	}
+	// Simulate a stale MarkRegistered(oldDEK) from a long-running
+	// 7a process-start goroutine that was racing with the cluster's
+	// rotation. This overwrites registeredStorageDEKID; the cache
+	// now reports Registered() == false (active=newDEK != oldDEK).
+	w.cache.MarkRegistered(oldDEK)
+	if w.cache.Registered() {
+		t.Fatalf("after stale MarkRegistered(%d): cache.Registered() should be false (active=%d != registered=%d)", oldDEK, newDEK, oldDEK)
+	}
+	// Next watcher tick MUST recover by re-proposing for newDEK.
+	// With the earlier lastRegisteredDEK gate this would have been a
+	// permanent fail-closed (lastRegisteredDEK == newDEK ==
+	// activeDEK → scope returns (_, false)). With the fix, cache.
+	// Registered() == false → step (1) falls through → rotation
+	// branch propose → MarkRegistered(newDEK) → Registered() true.
+	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
+		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID)
+	if !w.cache.Registered() {
+		t.Error("recovery tick did not re-MarkRegistered after stale MarkRegistered race; gemini CRITICAL on PR #864 fail-closed regression")
 	}
 }
 

--- a/main_encryption_registration_test.go
+++ b/main_encryption_registration_test.go
@@ -454,15 +454,19 @@ func TestRuntimeRegistrationTick_PreBootstrapInScopeProposes(t *testing.T) {
 }
 
 // TestRuntimeRegistrationTick_PreBootstrapRotateBeforeCutoverProposes
-// pins design §5 item 6b: the bootstrap→rotate→cutover sub-path. A node
-// that booted in Phase 0 (bootDEKID==0) and then observes a runtime
-// Bootstrap followed by a rotation to a different DEK *before* its
-// cutover (activeDEK = Y ≠ original-bootstrapped DEK, w.epoch == 0) MUST
-// still propose for Y — the scope check's deferred-rotation guard
-// (`bootDEKID != 0 && activeDEK != bootDEKID`) is short-circuited by
-// `bootDEKID == 0`. Without this test the guard is one `||` swap away
-// from a regression that would silently defer the watcher and leave the
-// gate fail-closed indefinitely (claude P2 round-2 on PR #853).
+// pins design §5 item 6b (PR #853): the bootstrap→rotate→cutover
+// sub-path. A node that booted in Phase 0 (bootDEKID==0) and then
+// observes a runtime Bootstrap followed by a rotation to a different
+// DEK *before* its cutover (activeDEK = Y ≠ original-bootstrapped DEK,
+// w.epoch == 0) MUST still propose for Y — the scope check's rotation
+// branch (`bootDEKID != 0 && activeDEK != bootDEKID`) is short-circuited
+// by `bootDEKID == 0`. Without this test the guard is one operand swap
+// away from a regression that would silently leave the watcher fail-
+// closed indefinitely.
+//
+// After 7b' replaces the deferred-skip branch with an in-scope propose,
+// the `bootDEKID==0` short-circuit remains the cutover/pre-bootstrap
+// route that 7b' did not touch.
 func TestRuntimeRegistrationTick_PreBootstrapRotateBeforeCutoverProposes(t *testing.T) {
 	t.Parallel()
 	st := newRegistrationTestStore(t)
@@ -470,69 +474,194 @@ func TestRuntimeRegistrationTick_PreBootstrapRotateBeforeCutoverProposes(t *test
 	// activeDEK Y=99 (≠ original bootstrap DEK), w.epoch=0, bootDEK=0.
 	const rotatedDEK uint32 = 99
 	// Pre-populate the registry under DEK 99 so verifyRegistered
-	// short-circuits without needing a real coordinator/engine — the
-	// hardcoded writeRegistryRow uses testRegDEKID, so call SetRegistryRow
-	// directly with the rotated DEK id.
+	// short-circuits without needing a real coordinator/engine.
+	preSeedRegistryRow(t, st, rotatedDEK, fullNodeID, 0)
+
+	w := wiringFor(t, rotatedDEK, true, 0 /*w.epoch=0*/)
+	var lastRegisteredDEK uint32
+	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
+		&kv.ShardGroup{Store: st}, w, 0 /*bootDEK=0*/, fullNodeID, &lastRegisteredDEK)
+	if !w.cache.Registered() {
+		t.Error("bootstrap→rotate→cutover sub-path did not MarkRegistered (Registered=false); bootDEKID==0 should keep the rotation branch off")
+	}
+	if lastRegisteredDEK != rotatedDEK {
+		t.Errorf("lastRegisteredDEK = %d, want %d (success path must advance the counter)", lastRegisteredDEK, rotatedDEK)
+	}
+}
+
+// TestRuntimeRegistrationTick_RotationInScopeVerifyShortCircuits pins
+// Stage 7b' §3.2's in-scope rotation propose path. A node that booted
+// with bootDEKID=X then observes a runtime RotateDEK to Y MUST propose
+// (Y, node, w.epoch) — applyRotateDEK wrote Keys[Y].LocalEpoch=w.epoch
+// per 7b' §3.1 so the §9.1 startup guard sees a monotone advance on
+// next restart. The test pre-populates a registry row at (Y, node,
+// w.epoch) so verifyRegistered short-circuits and the success-side
+// MarkRegistered fires; lastRegisteredDEK advances to Y.
+func TestRuntimeRegistrationTick_RotationInScopeVerifyShortCircuits(t *testing.T) {
+	t.Parallel()
+	st := newRegistrationTestStore(t)
+	fullNodeID := etcdraftengine.DeriveNodeID("n1")
+	const bootDEK, rotatedDEK uint32 = 7, 8
+	const wepoch uint16 = 5
+
+	// Pre-populate (Y, node, 5) so verifyRegistered's exact-match
+	// check returns true and runWriterRegistration short-circuits to
+	// MarkRegistered without needing a real coordinator/engine.
+	preSeedRegistryRow(t, st, rotatedDEK, fullNodeID, wepoch)
+
+	w := wiringFor(t, rotatedDEK, true, wepoch)
+	var lastRegisteredDEK uint32
+	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
+		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID, &lastRegisteredDEK)
+	if !w.cache.Registered() {
+		t.Error("7b' rotation in-scope path did not MarkRegistered (Registered=false); applyRotateDEK + verifyRegistered short-circuit + MarkRegistered should flip the cache")
+	}
+	if lastRegisteredDEK != rotatedDEK {
+		t.Errorf("lastRegisteredDEK = %d, want %d (success advances counter to active DEK)", lastRegisteredDEK, rotatedDEK)
+	}
+}
+
+// TestRuntimeRegistrationTick_RotationAlreadyRegisteredIsNoOp pins
+// 7b' §3.2's check ordering step (1): once cache.Registered() is true
+// for the active DEK (a prior tick MarkRegistered'd it), a subsequent
+// tick is a no-op — does NOT re-propose, does NOT mutate
+// lastRegisteredDEK (which was already advanced on the first tick).
+func TestRuntimeRegistrationTick_RotationAlreadyRegisteredIsNoOp(t *testing.T) {
+	t.Parallel()
+	st := newRegistrationTestStore(t)
+	fullNodeID := etcdraftengine.DeriveNodeID("n1")
+	const bootDEK, rotatedDEK uint32 = 7, 8
+	const wepoch uint16 = 5
+	preSeedRegistryRow(t, st, rotatedDEK, fullNodeID, wepoch)
+
+	w := wiringFor(t, rotatedDEK, true, wepoch)
+	var lastRegisteredDEK uint32
+	// First tick: registers.
+	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
+		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID, &lastRegisteredDEK)
+	if !w.cache.Registered() || lastRegisteredDEK != rotatedDEK {
+		t.Fatalf("first tick failed prerequisite: Registered=%v, lastRegisteredDEK=%d (want true / %d)", w.cache.Registered(), lastRegisteredDEK, rotatedDEK)
+	}
+	// Second tick: no-op via cache.Registered() short-circuit (step 1).
+	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
+		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID, &lastRegisteredDEK)
+	if lastRegisteredDEK != rotatedDEK {
+		t.Errorf("second tick mutated lastRegisteredDEK (=%d), want unchanged %d", lastRegisteredDEK, rotatedDEK)
+	}
+}
+
+// TestRuntimeRegistrationTick_RotationToYetAnotherDEKReProposes pins
+// 7b' §3.2's lastRegisteredDEK advance: after registering for Y, a
+// subsequent rotation to Z triggers a fresh propose (Z != Y, and
+// cache.Registered() returns false because the single-DEK
+// StateCache's activeStorageDEKID flipped to Z while
+// registeredStorageDEKID still holds Y). On success lastRegisteredDEK
+// advances to Z.
+func TestRuntimeRegistrationTick_RotationToYetAnotherDEKReProposes(t *testing.T) {
+	t.Parallel()
+	st := newRegistrationTestStore(t)
+	fullNodeID := etcdraftengine.DeriveNodeID("n1")
+	const bootDEK, rotateY, rotateZ uint32 = 7, 8, 9
+	const wepoch uint16 = 5
+	preSeedRegistryRow(t, st, rotateY, fullNodeID, wepoch)
+	preSeedRegistryRow(t, st, rotateZ, fullNodeID, wepoch)
+
+	w := wiringFor(t, rotateY, true, wepoch)
+	var lastRegisteredDEK uint32
+	// Register Y.
+	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
+		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID, &lastRegisteredDEK)
+	if lastRegisteredDEK != rotateY {
+		t.Fatalf("first tick: lastRegisteredDEK=%d, want %d", lastRegisteredDEK, rotateY)
+	}
+	// Rotation Y→Z: refresh sidecar to flip activeStorageDEKID.
+	sc := &encryption.Sidecar{Version: encryption.SidecarVersion, StorageEnvelopeActive: true}
+	sc.Active.Storage = rotateZ
+	w.cache.RefreshFromSidecar(sc)
+	if w.cache.Registered() {
+		t.Fatalf("after rotation Y→Z: cache.Registered() unexpectedly true; the single-DEK cache should report mismatch")
+	}
+	// Second tick on Z: re-proposes, MarkRegistered(Z) flips cache.
+	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
+		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID, &lastRegisteredDEK)
+	if !w.cache.Registered() {
+		t.Error("rotation-to-Z tick did not MarkRegistered")
+	}
+	if lastRegisteredDEK != rotateZ {
+		t.Errorf("lastRegisteredDEK after rotation-to-Z = %d, want %d", lastRegisteredDEK, rotateZ)
+	}
+}
+
+// TestRuntimeRegistrationTick_RotationOscillationBtoCtoBReProposes
+// pins 7b' §3.2.2 documented steady-state: B → C → B oscillation.
+// After registering B then C, the single-DEK StateCache holds C; a
+// rotation back to B leaves cache.Registered() == false (active=B,
+// registered=C mismatch). The watcher re-proposes (safe via §4.1
+// case-2 idempotent on the existing B row); MarkRegistered(B) flips
+// the cache back. Pins the documented re-propose so the
+// implementation PR's tests do not mistake the re-propose for a bug.
+func TestRuntimeRegistrationTick_RotationOscillationBtoCtoBReProposes(t *testing.T) {
+	t.Parallel()
+	st := newRegistrationTestStore(t)
+	fullNodeID := etcdraftengine.DeriveNodeID("n1")
+	const bootDEK, dekB, dekC uint32 = 7, 8, 9
+	const wepoch uint16 = 5
+	preSeedRegistryRow(t, st, dekB, fullNodeID, wepoch)
+	preSeedRegistryRow(t, st, dekC, fullNodeID, wepoch)
+
+	w := wiringFor(t, dekB, true, wepoch)
+	var lastRegisteredDEK uint32
+	// Register B.
+	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
+		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID, &lastRegisteredDEK)
+	if lastRegisteredDEK != dekB || !w.cache.Registered() {
+		t.Fatalf("register B failed: lastRegisteredDEK=%d Registered=%v", lastRegisteredDEK, w.cache.Registered())
+	}
+	// Rotate B → C; tick registers C.
+	scC := &encryption.Sidecar{Version: encryption.SidecarVersion, StorageEnvelopeActive: true}
+	scC.Active.Storage = dekC
+	w.cache.RefreshFromSidecar(scC)
+	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
+		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID, &lastRegisteredDEK)
+	if lastRegisteredDEK != dekC || !w.cache.Registered() {
+		t.Fatalf("register C failed: lastRegisteredDEK=%d Registered=%v", lastRegisteredDEK, w.cache.Registered())
+	}
+	// Rotate C → B: §3.2.2 — cache holds C; Registered() == false
+	// when active flips to B → watcher re-proposes; success path
+	// MarkRegisters B and flips lastRegisteredDEK back to B.
+	scB := &encryption.Sidecar{Version: encryption.SidecarVersion, StorageEnvelopeActive: true}
+	scB.Active.Storage = dekB
+	w.cache.RefreshFromSidecar(scB)
+	if w.cache.Registered() {
+		t.Fatalf("after rotation C→B: cache.Registered() unexpectedly true; single-DEK cache should mismatch")
+	}
+	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
+		&kv.ShardGroup{Store: st}, w, bootDEK, fullNodeID, &lastRegisteredDEK)
+	if !w.cache.Registered() {
+		t.Error("rotation C→B re-propose did not MarkRegistered (Registered=false)")
+	}
+	if lastRegisteredDEK != dekB {
+		t.Errorf("lastRegisteredDEK after C→B re-propose = %d, want %d", lastRegisteredDEK, dekB)
+	}
+}
+
+// preSeedRegistryRow seeds a writer-registry row at
+// (dekID, node, epoch) so verifyRegistered short-circuits and
+// runWriterRegistration's MarkRegistered side effect fires without a
+// real coordinator/engine. The hardcoded writeRegistryRow helper uses
+// testRegDEKID; this variant takes the DEK id so 7b' rotation tests
+// can target the rotated DEK.
+func preSeedRegistryRow(t *testing.T, st store.MVCCStore, dekID uint32, fullNodeID uint64, epoch uint16) {
+	t.Helper()
 	reg, err := store.WriterRegistryFor(st)
 	if err != nil {
 		t.Fatalf("WriterRegistryFor: %v", err)
 	}
 	val := encryption.EncodeRegistryValue(encryption.RegistryValue{
-		FullNodeID: fullNodeID, FirstSeenLocalEpoch: 0, LastSeenLocalEpoch: 0,
+		FullNodeID: fullNodeID, FirstSeenLocalEpoch: epoch, LastSeenLocalEpoch: epoch,
 	})
-	if err := reg.SetRegistryRow(encryption.RegistryKey(rotatedDEK, encryption.NodeID16(fullNodeID)), val); err != nil {
-		t.Fatalf("SetRegistryRow: %v", err)
-	}
-
-	w := wiringFor(t, rotatedDEK, true, 0 /*w.epoch=0*/)
-	var lastLogged uint32
-	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
-		&kv.ShardGroup{Store: st}, w, 0 /*bootDEK=0*/, fullNodeID, &lastLogged)
-	if !w.cache.Registered() {
-		t.Error("bootstrap→rotate→cutover sub-path did not MarkRegistered (Registered=false); bootDEKID==0 should keep the deferred-rotation guard off")
-	}
-	if lastLogged != 0 {
-		t.Errorf("lastLogged = %d, want 0 (no deferred-rotation WARN should fire when bootDEKID==0)", lastLogged)
-	}
-}
-
-// TestRuntimeRegistrationTick_DeferredRotationLogsOnceAndSkips pins the
-// 7b' deferral: bootDEK != 0 AND activeDEK != bootDEK → log once per
-// unique rotated-into DEK, do NOT propose. A second tick at the same
-// activeDEK does NOT re-log. A subsequent rotation to yet another DEK
-// re-logs correctly.
-func TestRuntimeRegistrationTick_DeferredRotationLogsOnceAndSkips(t *testing.T) {
-	t.Parallel()
-	st := newRegistrationTestStore(t)
-	fullNodeID := etcdraftengine.DeriveNodeID("n1")
-	// boot DEK 7, runtime rotation to DEK 8.
-	w := wiringFor(t, 8 /*activeDEK changed*/, true, 5)
-	var lastLogged uint32
-
-	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
-		&kv.ShardGroup{Store: st}, w, 7 /*bootDEK*/, fullNodeID, &lastLogged)
-	if w.cache.Registered() {
-		t.Error("deferred rotation branch unexpectedly MarkRegistered")
-	}
-	if lastLogged != 8 {
-		t.Errorf("lastLogged = %d, want 8 (first skip should record the DEK)", lastLogged)
-	}
-
-	// Second tick at same activeDEK: still no propose, lastLogged unchanged.
-	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
-		&kv.ShardGroup{Store: st}, w, 7, fullNodeID, &lastLogged)
-	if lastLogged != 8 {
-		t.Errorf("after repeat tick lastLogged = %d, want 8 (no re-log)", lastLogged)
-	}
-
-	// Rotate to DEK 9: re-log, lastLogged updates.
-	sc := &encryption.Sidecar{Version: encryption.SidecarVersion, StorageEnvelopeActive: true}
-	sc.Active.Storage = 9
-	w.cache.RefreshFromSidecar(sc)
-	runtimeRegistrationTick(context.Background(), &kv.ShardedCoordinator{},
-		&kv.ShardGroup{Store: st}, w, 7, fullNodeID, &lastLogged)
-	if lastLogged != 9 {
-		t.Errorf("after rotation-to-9 lastLogged = %d, want 9 (re-log on new DEK)", lastLogged)
+	if err := reg.SetRegistryRow(encryption.RegistryKey(dekID, encryption.NodeID16(fullNodeID)), val); err != nil {
+		t.Fatalf("SetRegistryRow(dek=%d, epoch=%d): %v", dekID, epoch, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements the merged 7b' design (PR #855) — per-node sidecar coordination at apply time (option (b) from the §6 architecture menu). Closes the gap left by 7b's deferred-rotation log-once-skip.

### Three changes

1. **`WithLocalEpoch(uint16)` Applier option** — threads `encryptionWriteWiring.epoch` (this load's pinned storage write-path `w.epoch`) into the `Applier`. Used solely by `writeRotationSidecar`.

2. **`writeRotationSidecar` per-`Purpose` epoch** — storage rotations write `Keys[newDEK].LocalEpoch = a.localEpoch`; raft rotations keep `LocalEpoch: 0` (raft envelope support has its own future per-purpose epoch plumbing per 7b' §3.1.1). Closes the brick / nonce-reuse failure modes from 7b §6 for the storage rotation case.

3. **`runtimeRegistrationInScope` rotation branch** — 7b's log-once-skip replaced with an in-scope propose when `bootDEKID != 0 && activeDEK != bootDEKID`. `lastLoggedSkipDEK` renamed to `lastRegisteredDEK`; advances only on confirmed `cache.Registered()` success.

### Test coverage per design §5

- `TestApplyRotateDEK_LocalEpochAppliedToStorageKey` — pinned epoch lands.
- `TestApplyRotateDEK_LocalEpoch_RaftRotationKeepsZero` — §3.1.1 raft scope isolation.
- `TestApplyRotateDEK_LocalEpoch_NoOptionFallsBackToZero` — §3.1.2 backward compat.
- `TestApplyRotateDEK_LocalEpoch_AppliedPerApply` — static field read per apply.
- `TestRuntimeRegistrationTick_RotationInScopeVerifyShortCircuits` — 7b' rotation propose path.
- `TestRuntimeRegistrationTick_RotationAlreadyRegisteredIsNoOp` — check-ordering step (1).
- `TestRuntimeRegistrationTick_RotationToYetAnotherDEKReProposes` — rotation-to-new advances counter.
- `TestRuntimeRegistrationTick_RotationOscillationBtoCtoBReProposes` — §3.2.2 oscillation steady-state.
- `TestRuntimeRegistrationTick_PreBootstrapRotateBeforeCutoverProposes` — §5 item 6b retained (updated to assert lastRegisteredDEK advance).

**Removed**: `TestRuntimeRegistrationTick_DeferredRotationLogsOnceAndSkips` (the 7b deferral test that 7b' supersedes — design §5 item 3).

## 5-lens self review

- **Data loss**: Clean. No propose/apply ordering change. The sidecar value change is additive (records local epoch instead of 0); FSM replay idempotency preserved.
- **Concurrency**: Clean. `a.localEpoch` is captured once at `Applier` construction in the FSM goroutine. Watcher's `lastRegisteredDEK` is per-process-load state, read/written only from the watcher goroutine.
- **Performance**: Clean. One `uint16` field on `Applier`, one `Purpose`-switch branch in `writeRotationSidecar`. Watcher's check-ordering still O(1) atomic loads + bounded scope checks.
- **Data consistency**: Each node's `Keys[newDEK].LocalEpoch` matches its own nonce factory's pinned epoch (no cross-node epoch contamination). The §4.1 case-2 idempotent path covers oscillation re-proposes safely.
- **Test coverage**: Complete per design §5; failing-test-first applied for the superseded `DeferredRotationLogsOnceAndSkips` replacement.

## Mixed-version safety (per design §6)

- 7b-only nodes still log-once-skip and remain fail-closed under the new DEK until restart on 7b'.
- Rollback safe: the sidecar's `Keys[newDEK].LocalEpoch = prior.w.epoch` satisfies §9.1 on next boot of either binary.

## Test plan

- [x] `go test -run 'TestApplier|TestApplyRotation|TestApplyBootstrap|TestRuntimeRegistration|TestBuildProcessStartRegistration|TestRegistrationCommittedAtEpoch|TestEncryption_E2E|TestRunWriterRegistration' -race -timeout 180s ./internal/encryption ./.` — green.
- [x] `make lint` clean.
- [ ] @claude review for correctness of the per-Purpose epoch wiring, watcher scope-check semantics, and oscillation behavior.
- [ ] Relevant Jepsen suite (encryption + rotation) — to be run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
