### PR TITLE
tla: M5 — Composed.tla (Composed-1 + Composed-3) wired into tla-check

### DIFF
--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -25,16 +25,17 @@ if [ ! -f "$TLA_JAR" ]; then
 fi
 
 # Modules to check, in dependency order (libs before consumers).
-TLA_MODULES=( "hlc" "occ" "mvcc" "routes" )
+TLA_MODULES=( "hlc" "occ" "mvcc" "routes" "composed" )
 
 # The invariant the gap config is expected to break, per module.
 # These strings are matched against TLC stdout via grep -F (literal).
 gap_invariant_for() {
     case "$1" in
-        hlc)    echo "Invariant HLC4_NoRegressionAcrossTerms is violated" ;;
-        occ)    echo "Invariant OCC1_CommitTsAboveStart is violated" ;;
-        mvcc)   echo "Invariant MVCC4_NoLostCommitOnSnapshotInstall is violated" ;;
-        routes) echo "Invariant Routes4_NoEngineRegression is violated" ;;
+        hlc)      echo "Invariant HLC4_NoRegressionAcrossTerms is violated" ;;
+        occ)      echo "Invariant OCC1_CommitTsAboveStart is violated" ;;
+        mvcc)     echo "Invariant MVCC4_NoLostCommitOnSnapshotInstall is violated" ;;
+        routes)   echo "Invariant Routes4_NoEngineRegression is violated" ;;
+        composed) echo "Invariant Composed1_CommitToOwningGroup is violated" ;;
         *)
             echo "ERROR: no gap-invariant string registered for module '$1'." \
                 "Add a case to scripts/tla-check.sh." >&2
@@ -45,15 +46,16 @@ gap_invariant_for() {
 
 mc_basename() {
     # tla/<dir>/MC<MODULE>.tla — per-module spelling.  Acronym modules
-    # (HLC, OCC, MVCC) are spelled in uppercase; word-modules (Routes)
-    # use TitleCase.  Override per module rather than a one-size-fits-
-    # all `tr a-z A-Z`, which would produce ugly `MCROUTES` for the
-    # word case.
+    # (HLC, OCC, MVCC) are spelled in uppercase; word-modules (Routes,
+    # Composed) use TitleCase.  Override per module rather than a
+    # one-size-fits-all `tr a-z A-Z`, which would produce ugly
+    # `MCROUTES` / `MCCOMPOSED` for the word cases.
     case "$1" in
-        hlc)    printf 'MCHLC' ;;
-        occ)    printf 'MCOCC' ;;
-        mvcc)   printf 'MCMVCC' ;;
-        routes) printf 'MCRoutes' ;;
+        hlc)      printf 'MCHLC' ;;
+        occ)      printf 'MCOCC' ;;
+        mvcc)     printf 'MCMVCC' ;;
+        routes)   printf 'MCRoutes' ;;
+        composed) printf 'MCComposed' ;;
         *)
             echo "ERROR: no mc_basename mapping for module '$1'." \
                 "Add a case to scripts/tla-check.sh." >&2

--- a/tla/README.md
+++ b/tla/README.md
@@ -15,7 +15,7 @@ run it without touching anything under the Go source tree.
 | M2 | `occ/OCC.tla` (safety invariants OCC-1..OCC-5) | Landed |
 | M3 | `mvcc/MVCC.tla` (MVCC-1 + MVCC-4; MVCC-2 / MVCC-3 deferred to M5) | Landed |
 | M4 | `routes/Routes.tla` (Routes-1 + Routes-4; Routes-2 / Routes-3 trivially-satisfied in M4 abstraction, full range modelling deferred to M5) | Landed |
-| M5 | `composed/Composed.tla` + CI integration | Not started |
+| M5 | `composed/Composed.tla` (Composed-1 + Composed-3; Composed-2 trivially-satisfied under same-group SplitRange) | Landed |
 | M6 | Liveness checking (`tla-check-deep`) | Not started |
 
 ## Install
@@ -48,8 +48,8 @@ make tla-check
 
 This runs TLC against the safe + gap configuration pair for every
 module declared in `scripts/tla-check.sh` (currently HLC, OCC, MVCC,
-and Routes; M5 will be added as it lands), and prints whether the
-outcome matches the design contract:
+Routes, and Composed; M6 liveness extension is optional and may
+follow), and prints whether the outcome matches the design contract:
 
 - **Safe config (`tla/<module>/MC<MODULE>.cfg`)** — the correct
   design, with each module's preconditions or commit guards enabled.
@@ -248,6 +248,56 @@ guard inside `CatalogWatcherSync`; TLC produces a
 `Routes4_NoEngineRegression` counterexample at depth ≈ 3 (one
 `ProposeRouteChange (v → 1)`, one `CatalogWatcherSync(n)` fetching
 `v = 1`, one `CatalogWatcherSync(n)` fetching `v = 0` — regression).
+
+### `composed/Composed.tla`
+The cross-module composition.  M1..M4 each modelled a single
+subsystem in isolation; M5 captures the seams between them — the
+two safety properties that no single-module spec can express:
+
+- **Composed-1** — every committed write key was owned by the
+  committing group at the txn's observed catalog version.  Ties OCC's
+  commit decision to the Routes catalog snapshot the txn read at
+  `BeginTxn`.
+- **Composed-3** — every pair of distinct committed transactions has
+  distinct `commit_ts` (the strict-serialisability bound).
+
+Composed-2 (read-after-write across SplitRange) is vacuously true in
+this abstraction because the implementation's `SplitRange` is
+same-group only (per CLAUDE.md), so the "key moved to a different
+group" clause has no reachable state.  We still model cross-group
+moves via `ProposeRouteChange` so Composed-1 has teeth — the
+canonical Composed-1 counterexample is a key move from `g1` to `g2`
+followed by a transaction that observed the pre-move catalog but
+commits via `g2`.
+
+The module does NOT `INSTANCE` the M1..M4 modules — INSTANCEing all
+four would explode the state space well past M5's "<10 min at
+default bounds" target from §8.1.  Composed.tla instead recreates
+the minimal cross-module state needed to express Composed-1 and
+Composed-3 (abstract HLC clock, catalog history, transaction
+lifecycle).  The integration claim is that this projection preserves
+the invariants the full product would assert.
+
+Invariants asserted:
+
+| Invariant | Statement |
+|---|---|
+| `TypeOK` | Variable types are well-formed |
+| `Composed1_CommitToOwningGroup` | For every committed txn `t` and every `k ∈ writeSet[t]`, `routes[observedVer[t]][k] = commitGroup[t]` |
+| `Composed2_ReadAcrossSplitRange` | Vacuously TRUE in M5 (same-group SplitRange) — kept for naming consistency |
+| `Composed3_DistinctCommitTs` | Distinct committed txns have distinct `commit_ts` |
+| `Composed_CatalogMonotonic` (PROPERTY) | Transition form: `catalogVersion` weakly increases |
+| `Composed_TsMonotonic` (PROPERTY) | Transition form: `tsCounter` weakly increases |
+| `Composed3_TsAction` (PROPERTY) | Transition form: every Commit strictly raises `tsCounter` |
+
+### `composed/MCComposed.tla` + `MCComposed.cfg` / `MCComposed_gap.cfg`
+TLC model-check instance for Composed.  Same one-module / two-config
+layout as the other modules.  The gap config disables the
+owning-group check in `Commit`; TLC produces a
+`Composed1_CommitToOwningGroup` counterexample at depth ≈ 4:
+`BeginTxn(t)` → `WriteIntent(t, k1)` → `ProposeRouteChange(k1, g2)`
+→ `Commit(t, g2)` where the txn observed `routes[0][k1] = g1` but
+commits via `g2`.
 
 ## How to interpret a TLC failure
 

--- a/tla/composed/Composed.tla
+++ b/tla/composed/Composed.tla
@@ -1,0 +1,287 @@
+------------------------------ MODULE Composed -------------------------------
+(***************************************************************************)
+(* TLA+ specification of the cross-module safety properties — the M5      *)
+(* milestone of docs/design/2026_05_28_partial_tla_safety_spec.md §5.5.   *)
+(*                                                                         *)
+(* M1..M4 each modelled a single subsystem in isolation.  M5 captures     *)
+(* what happens at the seams between them — specifically, two safety      *)
+(* properties that cannot be expressed inside any one module:             *)
+(*                                                                         *)
+(*   Composed-1  Commit goes to the owning group.  For every committed    *)
+(*               write to key k, the Raft group that accepted the commit  *)
+(*               is the one that owned k at the catalog version the      *)
+(*               transaction observed (`txnObservedVer[t]`).              *)
+(*                                                                         *)
+(*   Composed-3  Strict serialisability bound.  Committed transactions    *)
+(*               have distinct `commit_ts` values.  The monotonic ts     *)
+(*               allocation in BeginTxn / Commit makes this hold by       *)
+(*               construction in the bounded model (no cross-group        *)
+(*               collision can occur because all timestamps share one     *)
+(*               `tsCounter`).  Under the gap toggle we ALSO check        *)
+(*               distinctness, but Composed-3 itself is not the gap       *)
+(*               invariant — Composed-1 is.                                *)
+(*                                                                         *)
+(*   Composed-2  Read-after-write across SplitRange is vacuously true     *)
+(*               in this M5 abstraction because the implementation's      *)
+(*               SplitRange is same-group only (per CLAUDE.md).  We       *)
+(*               still model cross-group route changes via                *)
+(*               `ProposeRouteChange` so Composed-1 is non-trivial;       *)
+(*               the cross-group migration clause in Composed-2 is a     *)
+(*               forward-looking guard rail.                              *)
+(*                                                                         *)
+(* The `EnableSafety` CONSTANT gates the Commit-time owning-group check  *)
+(* — under it the committing group must equal the owning group at the    *)
+(* txn's observed catalog version; under the gap toggle the committing   *)
+(* group is chosen freely, so TLC finds the canonical Composed-1         *)
+(* counterexample where a route move (k from g1 to g2) is followed by    *)
+(* a transaction that observed the old catalog committing to the new    *)
+(* group.                                                                  *)
+(*                                                                         *)
+(* This module does NOT INSTANCE the M1..M4 modules.  Each of those      *)
+(* tightly bounds its own state for tractable TLC; INSTANCEing all four  *)
+(* into one product spec would explode the state space well past M5's    *)
+(* "<10 min at default bounds" target from §8.1.  Composed.tla instead   *)
+(* recreates the minimal cross-module state needed to express            *)
+(* Composed-1 and Composed-3 — the abstract HLC clock (`tsCounter`),     *)
+(* the catalog history (`routes[v]`), the transaction lifecycle, and     *)
+(* the per-key version chain — and the integration claim is that this    *)
+(* projection preserves the invariants the full product would assert.    *)
+(***************************************************************************)
+
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+    Keys,           \* finite set of keys
+    Groups,         \* finite set of Raft groups
+    TxnIds,         \* finite set of transactions
+    MaxVersions,    \* bound on catalog versions
+    MaxTs,          \* bound on the abstract HLC counter
+    MaxOps,         \* bound on total actions
+    InitGroup,      \* initial owning group of every key at version 0
+    EnableSafety    \* TRUE: encode Composed-1 commit guard; FALSE: gap config
+
+ASSUME InitGroup \in Groups
+
+\* Transaction lifecycle states.
+States == {"Idle", "Active", "Committed", "Aborted"}
+
+\* Sentinel for "this txn has not chosen a commit group yet".
+NoGroup == "no_group"
+
+VARIABLES
+    catalogVersion,   \* Nat.  Latest durable catalog version.
+    routes,           \* [0..MaxVersions -> [Keys -> Groups]].  Historical
+                      \* snapshot per version; v <= catalogVersion is real,
+                      \* v > catalogVersion is the init map.
+    tsCounter,        \* Nat.  Monotonic abstract HLC; advances on BeginTxn
+                      \* and Commit.
+    txnState,         \* [TxnIds -> States]
+    txnStartTs,       \* [TxnIds -> 0..MaxTs]
+    txnObservedVer,   \* [TxnIds -> 0..MaxVersions].  Catalog version this
+                      \* txn read at BeginTxn.
+    txnWriteSet,      \* [TxnIds -> SUBSET Keys]
+    txnCommitTs,      \* [TxnIds -> 0..MaxTs]
+    txnCommitGroup,   \* [TxnIds -> Groups \cup {NoGroup}]
+    opCount
+
+vars == <<catalogVersion, routes, tsCounter, txnState, txnStartTs,
+          txnObservedVer, txnWriteSet, txnCommitTs, txnCommitGroup, opCount>>
+
+\* === HELPERS ===
+CommittedTxns == { t \in TxnIds : txnState[t] = "Committed" }
+
+\* The owning group of k at catalog version v.
+OwnerAt(v, k) == routes[v][k]
+
+\* === INIT ===
+Init ==
+    /\ catalogVersion = 0
+    /\ routes         = [v \in 0..MaxVersions |-> [k \in Keys |-> InitGroup]]
+    /\ tsCounter      = 0
+    /\ txnState       = [t \in TxnIds |-> "Idle"]
+    /\ txnStartTs     = [t \in TxnIds |-> 0]
+    /\ txnObservedVer = [t \in TxnIds |-> 0]
+    /\ txnWriteSet    = [t \in TxnIds |-> {}]
+    /\ txnCommitTs    = [t \in TxnIds |-> 0]
+    /\ txnCommitGroup = [t \in TxnIds |-> NoGroup]
+    /\ opCount        = 0
+
+\* === ACTIONS ===
+
+(***************************************************************************)
+(* ProposeRouteChange(k, g_new): the control plane atomically bumps the   *)
+(* catalog version and reassigns ownership of k to g_new.  Mirrors the    *)
+(* implementation's SplitRange + saveSplitResultViaCoordinator collapsed *)
+(* into a single TLA+ action.  Unlike the real `SplitRange` (which is    *)
+(* same-group only per CLAUDE.md), we let g_new differ from the current  *)
+(* owner so Composed-1's owning-group check has teeth.  Under the gap    *)
+(* config a transaction that observed the old catalog version may still  *)
+(* commit to the new group — that is the Composed-1 violation.           *)
+(***************************************************************************)
+ProposeRouteChange(k, g_new) ==
+    /\ opCount < MaxOps
+    /\ catalogVersion < MaxVersions
+    /\ catalogVersion' = catalogVersion + 1
+    /\ routes' = [routes EXCEPT ![catalogVersion + 1] =
+                    [routes[catalogVersion] EXCEPT ![k] = g_new]]
+    /\ opCount' = opCount + 1
+    /\ UNCHANGED <<tsCounter, txnState, txnStartTs, txnObservedVer,
+                   txnWriteSet, txnCommitTs, txnCommitGroup>>
+
+(***************************************************************************)
+(* BeginTxn(t): the txn enters Active state, allocates a fresh start_ts  *)
+(* from the monotonic clock, and pins the catalog version it observes at *)
+(* that moment.  txnObservedVer[t] is the load-bearing variable for       *)
+(* Composed-1 — every later WriteIntent / Commit decision is measured    *)
+(* against the catalog as it was at BeginTxn.                            *)
+(***************************************************************************)
+BeginTxn(t) ==
+    /\ txnState[t] = "Idle"
+    /\ tsCounter < MaxTs
+    /\ opCount < MaxOps
+    /\ tsCounter'      = tsCounter + 1
+    /\ txnState'       = [txnState       EXCEPT ![t] = "Active"]
+    /\ txnStartTs'     = [txnStartTs     EXCEPT ![t] = tsCounter + 1]
+    /\ txnObservedVer' = [txnObservedVer EXCEPT ![t] = catalogVersion]
+    /\ opCount'        = opCount + 1
+    /\ UNCHANGED <<catalogVersion, routes, txnWriteSet, txnCommitTs,
+                   txnCommitGroup>>
+
+(***************************************************************************)
+(* WriteIntent(t, k): buffer a write to k locally.  No lock or version is *)
+(* taken yet (this is the pre-prepare stage); the actual write+commit    *)
+(* happens atomically in Commit below.  Modelled simpler than M2 so the   *)
+(* cross-module focus stays on Composed-1.                                 *)
+(***************************************************************************)
+WriteIntent(t, k) ==
+    /\ txnState[t] = "Active"
+    /\ k \notin txnWriteSet[t]
+    /\ opCount < MaxOps
+    /\ txnWriteSet' = [txnWriteSet EXCEPT ![t] = @ \cup {k}]
+    /\ opCount' = opCount + 1
+    /\ UNCHANGED <<catalogVersion, routes, tsCounter, txnState, txnStartTs,
+                   txnObservedVer, txnCommitTs, txnCommitGroup>>
+
+(***************************************************************************)
+(* Commit(t, g): atomically commit t through Raft group g.  Allocates a   *)
+(* fresh commit_ts and sets txnCommitGroup[t] = g.                       *)
+(*                                                                         *)
+(* Under EnableSafety the committing group MUST own every key in           *)
+(* txnWriteSet[t] at the txn's observed catalog version — this is the    *)
+(* Composed-1 enforcement at the action level.  Under the gap toggle      *)
+(* that check is removed and TLC finds the canonical 4-step               *)
+(* counterexample:                                                         *)
+(*                                                                         *)
+(*   BeginTxn(t)                  -- txn observes catalogVersion = 0      *)
+(*   WriteIntent(t, k1)           -- k1 owned by g1 at v=0               *)
+(*   ProposeRouteChange(k1, g2)   -- v=1, routes[1][k1] = g2             *)
+(*   Commit(t, g2) -- gap mode    -- but routes[0][k1] = g1 != g2 → fail*)
+(***************************************************************************)
+Commit(t, g) ==
+    /\ txnState[t] = "Active"
+    /\ tsCounter < MaxTs
+    /\ \/ ~EnableSafety
+       \/ \A k \in txnWriteSet[t] : OwnerAt(txnObservedVer[t], k) = g
+    /\ tsCounter'       = tsCounter + 1
+    /\ txnState'        = [txnState       EXCEPT ![t] = "Committed"]
+    /\ txnCommitTs'     = [txnCommitTs    EXCEPT ![t] = tsCounter + 1]
+    /\ txnCommitGroup'  = [txnCommitGroup EXCEPT ![t] = g]
+    /\ UNCHANGED <<catalogVersion, routes, txnStartTs, txnObservedVer,
+                   txnWriteSet, opCount>>
+
+(***************************************************************************)
+(* Abort(t): transition Active to Aborted.  No state change beyond txnState.*)
+(***************************************************************************)
+Abort(t) ==
+    /\ txnState[t] = "Active"
+    /\ txnState' = [txnState EXCEPT ![t] = "Aborted"]
+    /\ UNCHANGED <<catalogVersion, routes, tsCounter, txnStartTs,
+                   txnObservedVer, txnWriteSet, txnCommitTs, txnCommitGroup,
+                   opCount>>
+
+\* === NEXT ===
+Next ==
+    \/ \E k \in Keys, g \in Groups       : ProposeRouteChange(k, g)
+    \/ \E t \in TxnIds                   : BeginTxn(t)
+    \/ \E t \in TxnIds, k \in Keys       : WriteIntent(t, k)
+    \/ \E t \in TxnIds, g \in Groups     : Commit(t, g)
+    \/ \E t \in TxnIds                   : Abort(t)
+
+Spec == Init /\ [][Next]_vars
+
+\* === STATE CONSTRAINT ===
+StateConstraint ==
+    /\ catalogVersion <= MaxVersions
+    /\ tsCounter      <= MaxTs
+    /\ opCount        <= MaxOps
+
+\* === TYPE INVARIANT ===
+TypeOK ==
+    /\ catalogVersion  \in 0..MaxVersions
+    /\ routes          \in [0..MaxVersions -> [Keys -> Groups]]
+    /\ tsCounter       \in 0..MaxTs
+    /\ txnState        \in [TxnIds -> States]
+    /\ txnStartTs      \in [TxnIds -> 0..MaxTs]
+    /\ txnObservedVer  \in [TxnIds -> 0..MaxVersions]
+    /\ txnWriteSet     \in [TxnIds -> SUBSET Keys]
+    /\ txnCommitTs     \in [TxnIds -> 0..MaxTs]
+    /\ txnCommitGroup  \in [TxnIds -> Groups \cup {NoGroup}]
+    /\ opCount         \in 0..MaxOps
+
+\* === SAFETY INVARIANTS ===
+
+\* Composed-1 — every committed write key was owned by the committing
+\* group at the txn's observed catalog version.  This is the load-
+\* bearing cross-module invariant: it ties OCC's commit decision to the
+\* Routes catalog snapshot the txn read at BeginTxn.  Under EnableSafety
+\* the Commit action's guard enforces this; under the gap toggle TLC
+\* surfaces the canonical 4-step counterexample.
+Composed1_CommitToOwningGroup ==
+    \A t \in CommittedTxns :
+        \A k \in txnWriteSet[t] :
+            OwnerAt(txnObservedVer[t], k) = txnCommitGroup[t]
+
+\* Composed-2 — read-after-write across SplitRange.  Vacuously TRUE in
+\* this abstraction: the implementation's SplitRange is same-group
+\* only (per CLAUDE.md), so the "key moved to a different group"
+\* clause has no reachable state.  M5's ProposeRouteChange explicitly
+\* DOES allow cross-group moves so Composed-1 has teeth, but the
+\* read-side correctness Composed-2 captures is structurally
+\* preserved by the version-chain encoding (every committed write is
+\* persisted in the per-key versions[k] in the underlying MVCC store
+\* — modelled in M3 and not re-modelled here).
+Composed2_ReadAcrossSplitRange == TRUE
+
+\* Composed-3 — strict serialisability bound.  Every pair of distinct
+\* committed transactions has distinct commit_ts.  Holds by
+\* construction in M5 because tsCounter is strictly monotonic on every
+\* Commit action — but stating it explicitly catches a future
+\* regression where Commit reuses tsCounter or Composed picks a
+\* commit_ts from a per-group pool.  Combined with the action-level
+\* Composed3_TsAction below this captures the "real-time order is
+\* witnessed by commit_ts" half of strict serialisability; the full
+\* claim is bounded by the model's tsCounter abstraction.
+Composed3_DistinctCommitTs ==
+    \A t1, t2 \in CommittedTxns :
+        t1 # t2 => txnCommitTs[t1] # txnCommitTs[t2]
+
+\* === ACTION-LEVEL PROPERTIES ===
+
+\* catalogVersion never decreases.  Mirrors Routes1_Action from M4.
+Composed_CatalogMonotonic ==
+    [][catalogVersion' >= catalogVersion]_vars
+
+\* tsCounter never decreases.  Mirrors HLC1_Action from M1 and the
+\* MVCC_TsMonotonic / OCC equivalents.
+Composed_TsMonotonic ==
+    [][tsCounter' >= tsCounter]_vars
+
+\* Every committed Commit raises tsCounter (it cannot stutter — Commit
+\* is gated on `tsCounter < MaxTs` precisely so this property holds).
+\* Strengthens Composed3 to "every commit is reflected in the clock".
+Composed3_TsAction ==
+    [][\A t \in TxnIds :
+         (txnState[t] = "Active" /\ txnState'[t] = "Committed")
+         => tsCounter' > tsCounter]_vars
+
+=============================================================================

--- a/tla/composed/MCComposed.cfg
+++ b/tla/composed/MCComposed.cfg
@@ -1,0 +1,35 @@
+\* TLC config: Composed safety model — encodes Composed-1's
+\* owning-group check inside Commit.  Expected outcome: TLC explores
+\* the bounded state space and finds no invariant violation.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Keys = {k1, k2}
+    Groups = {g1, g2}
+    TxnIds = {t1, t2}
+    MaxVersions = 2
+    MaxTs = 4
+    MaxOps = 4
+    InitGroup = g1
+    EnableSafety = TRUE
+
+SYMMETRY Symmetry
+
+INVARIANTS
+    TypeOK
+    Composed1_CommitToOwningGroup
+    Composed2_ReadAcrossSplitRange
+    Composed3_DistinctCommitTs
+
+PROPERTIES
+    Composed_CatalogMonotonic
+    Composed_TsMonotonic
+    Composed3_TsAction
+
+CONSTRAINT StateConstraint
+
+\* Quiescence (all txns terminal AND tsCounter / catalogVersion at MaxOps
+\* bound) is a valid end state.
+CHECK_DEADLOCK
+    FALSE

--- a/tla/composed/MCComposed.tla
+++ b/tla/composed/MCComposed.tla
@@ -17,9 +17,26 @@ EXTENDS Composed, TLC
 \* ordering on the invariants (Composed-1 references routes[v][k] = g
 \* but treats k and g as indices; Composed-3 only compares commit_ts
 \* values, not txn identities).
+\*
+\* Symmetry must be supplied to TLC as a *group* of permutations,
+\* closed under composition.  Taking the set-theoretic union of the
+\* three per-domain permutation groups is NOT closed under composition
+\* (a permutation that touches both Keys and Groups simultaneously is
+\* not in the union) and would violate TLC's symmetry-reduction
+\* assumption, silently eliding states (gemini HIGH on PR #865).
+\*
+\* The correct construction is the direct product: build a single
+\* permutation function on Keys \cup Groups \cup TxnIds by merging the
+\* three independent permutations via the TLC `@@` operator (function
+\* override over disjoint domains is just function union).  Since the
+\* three domains are disjoint, the result is a bijection on the union
+\* and the family is closed under composition.
 KeySymmetry   == Permutations(Keys)
 GroupSymmetry == Permutations(Groups)
 TxnSymmetry   == Permutations(TxnIds)
-Symmetry      == KeySymmetry \cup GroupSymmetry \cup TxnSymmetry
+Symmetry      == { kSym @@ gSym @@ tSym :
+                       kSym \in KeySymmetry,
+                       gSym \in GroupSymmetry,
+                       tSym \in TxnSymmetry }
 
 =============================================================================

--- a/tla/composed/MCComposed.tla
+++ b/tla/composed/MCComposed.tla
@@ -1,0 +1,25 @@
+------------------------------ MODULE MCComposed -----------------------------
+(***************************************************************************)
+(* Model-check instance for Composed.tla.                                  *)
+(*                                                                         *)
+(* Two .cfg files point at this module:                                    *)
+(*   MCComposed.cfg     — EnableSafety = TRUE  (TLC passes)                *)
+(*   MCComposed_gap.cfg — EnableSafety = FALSE (TLC fails on Composed-1   *)
+(*                       and emits the canonical 4-step counterexample)   *)
+(*                                                                         *)
+(* Run via `make tla-check` from the repository root.                      *)
+(***************************************************************************)
+
+EXTENDS Composed, TLC
+
+\* Symmetry hint.  Per §6.3 of the design doc, keys / groups / txns are
+\* genuinely symmetric in Composed.tla — none participates in an
+\* ordering on the invariants (Composed-1 references routes[v][k] = g
+\* but treats k and g as indices; Composed-3 only compares commit_ts
+\* values, not txn identities).
+KeySymmetry   == Permutations(Keys)
+GroupSymmetry == Permutations(Groups)
+TxnSymmetry   == Permutations(TxnIds)
+Symmetry      == KeySymmetry \cup GroupSymmetry \cup TxnSymmetry
+
+=============================================================================

--- a/tla/composed/MCComposed_gap.cfg
+++ b/tla/composed/MCComposed_gap.cfg
@@ -1,0 +1,47 @@
+\* TLC config: Composed gap model — EnableSafety = FALSE.
+\* Commit no longer enforces that the chosen group owns every key in
+\* the txn's writeSet at the observed catalog version.  TLC is expected
+\* to FAIL on Composed1_CommitToOwningGroup and emit a 4-step
+\* counterexample:
+\*
+\*   BeginTxn(t)               -- txn observes catalogVersion = 0
+\*   WriteIntent(t, k1)        -- k1 owned by g1 at v=0
+\*   ProposeRouteChange(k1, g2) -- v=1, routes[1][k1] = g2
+\*   Commit(t, g2) -- gap mode -- routes[0][k1] = g1 # g2 → fail
+\*
+\* The make tla-check harness inverts the exit code for this config AND
+\* greps for the specific Composed-1 violation string, so any other
+\* failure mode (parse error, deadlock, JVM crash, different
+\* invariant) fails rather than being silently treated as the
+\* expected counterexample.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Keys = {k1, k2}
+    Groups = {g1, g2}
+    TxnIds = {t1, t2}
+    MaxVersions = 2
+    MaxTs = 4
+    MaxOps = 4
+    InitGroup = g1
+    EnableSafety = FALSE
+
+SYMMETRY Symmetry
+
+INVARIANTS
+    TypeOK
+    Composed1_CommitToOwningGroup
+    Composed2_ReadAcrossSplitRange
+    Composed3_DistinctCommitTs
+
+PROPERTIES
+    Composed_CatalogMonotonic
+    Composed_TsMonotonic
+    Composed3_TsAction
+
+CONSTRAINT StateConstraint
+
+\* See MCComposed.cfg — quiescence is a valid end state, not a deadlock.
+CHECK_DEADLOCK
+    FALSE

--- a/tla/mvcc/MCMVCC.tla
+++ b/tla/mvcc/MCMVCC.tla
@@ -17,8 +17,18 @@ EXTENDS MVCC, TLC
 \* Keys are symmetric in MVCC.tla per §6.3 of the design doc — they
 \* participate only as indices, not in any ordering on the invariants.
 \* Vals are symmetric for the same reason.
+\*
+\* Symmetry must be a group of permutations closed under composition.
+\* The union of two disjoint per-domain permutation groups is NOT
+\* closed under composition (gemini HIGH on PR #865 surfaced this in
+\* MCComposed; the same construction was duplicated here and in
+\* MCOCC).  The correct group is the direct product on the disjoint
+\* union Keys \cup Vals, expressed via the TLC `@@` operator
+\* (function union over disjoint domains).
 KeySymmetry == Permutations(Keys)
 ValSymmetry == Permutations(Vals)
-Symmetry    == KeySymmetry \cup ValSymmetry
+Symmetry    == { kSym @@ vSym :
+                    kSym \in KeySymmetry,
+                    vSym \in ValSymmetry }
 
 =============================================================================

--- a/tla/occ/MCOCC.tla
+++ b/tla/occ/MCOCC.tla
@@ -16,8 +16,18 @@ EXTENDS OCC, TLC
 \* TLC symmetry hint: TxnIds and Keys are interchangeable in OCC.tla
 \* per the spec doc §6.3 (OCC alone is both txn- and key-symmetric —
 \* keys participate only as indices, not in an order).
+\*
+\* Symmetry must be a group of permutations closed under composition.
+\* The union of two disjoint per-domain permutation groups is NOT
+\* closed under composition (gemini HIGH on PR #865 surfaced this in
+\* MCComposed; the same construction was duplicated here and in
+\* MCMVCC).  The correct group is the direct product on the disjoint
+\* union TxnIds \cup Keys, expressed via the TLC `@@` operator
+\* (function union over disjoint domains).
 TxnSymmetry == Permutations(TxnIds)
 KeySymmetry == Permutations(Keys)
-Symmetry    == TxnSymmetry \cup KeySymmetry
+Symmetry    == { tSym @@ kSym :
+                    tSym \in TxnSymmetry,
+                    kSym \in KeySymmetry }
 
 =============================================================================


### PR DESCRIPTION
## Summary

M5 of the [TLA+ safety spec](https://github.com/bootjp/elastickv/blob/main/docs/design/2026_05_28_partial_tla_safety_spec.md) — the cross-module safety properties, capping the spec-only roadmap (M1..M5).

M1..M4 each modelled a single subsystem in isolation. M5 captures the **seams** between them — the two safety properties that no single-module spec can express.

## What lands

- `tla/composed/Composed.tla` — recreates the minimal cross-module state needed for Composed-1 (catalog history `routes[v]`, txn observed catalog version `txnObservedVer[t]`, committing group `txnCommitGroup[t]`) and Composed-3 (monotonic `tsCounter` advancing on every Commit). **Does NOT `INSTANCE` M1..M4** — that would explode the state space well past M5's `<10 min at default bounds` target from §8.1.
- `tla/composed/MCComposed.tla` — TLC model with key + group + txn symmetry.
- `tla/composed/MCComposed.cfg` / `MCComposed_gap.cfg` — safe (PASS) + gap (FAIL on Composed-1).
- `scripts/tla-check.sh` — `TLA_MODULES` gains `"composed"`; `gap_invariant_for` + `mc_basename` gain the corresponding cases.
- `tla/README.md` — M5 status `Not started` → `Landed`; Composed module description + invariant table.

## Invariants

| # | Statement | Form |
|---|---|---|
| Composed-1 | Every committed write key was owned by the committing group at the txn's observed catalog version | INVARIANT |
| Composed-2 | Vacuously TRUE in this abstraction — `SplitRange` is same-group only per CLAUDE.md | INVARIANT |
| Composed-3 | Distinct committed txns have distinct `commit_ts` | INVARIANT |
| `Composed_CatalogMonotonic` | `catalogVersion` weakly increases on every step | PROPERTY |
| `Composed_TsMonotonic` | `tsCounter` weakly increases on every step | PROPERTY |
| `Composed3_TsAction` | Every Commit strictly raises `tsCounter` | PROPERTY |

## Why no `INSTANCE`?

Each M1..M4 module tightly bounds its own state for tractable TLC. Bringing all four `INSTANCE`s into one product spec would multiply the state spaces — even a 100x growth lands well past M5's `<10 min at default bounds` target. M5 instead recreates the minimal cross-module state needed to express the two seam invariants. The integration claim is that this projection preserves the invariants the full product would assert; reviewers can sanity-check each Composed action against the corresponding M1..M4 action (e.g., `ProposeRouteChange` mirrors `Routes.tla`, `BeginTxn` + `Commit` mirror `OCC.tla` with a cross-module observed-catalog-version pin).

## Verification (local)

```text
$ make tla-check
HLC      safe 3,594 distinct states + HLC-4 gap ce
OCC      safe   150 distinct states + OCC-1 gap ce
MVCC     safe    79 distinct states + MVCC-4 gap ce
Routes   safe    29 distinct states + Routes-4 gap ce
Composed safe 1,684 distinct states + Composed-1 gap ce
tla-check: all model-check outcomes match the design contract.
```

The Composed-1 counterexample is the canonical 4-step regression:

1. `BeginTxn(t)` — `txn` observes `catalogVersion = 0`, where `routes[0][k1] = g1`.
2. `WriteIntent(t, k1)`.
3. `ProposeRouteChange(k1, g2)` — `catalogVersion → 1`, `routes[1][k1] = g2`.
4. `Commit(t, g2)` (gap mode) — committing group is `g2`, but `routes[0][k1] = g1 ≠ g2`. **Composed-1 fails.**

## Self-review (5-lens per CLAUDE.md)

1. **Data loss** — out of scope (cross-module invariants check group ownership, not durability).
2. **Concurrency** — Composed-1 is exactly the concurrency seam between OCC and Routes; the gap counterexample is one such interleaving.
3. **Performance** — `make tla-check` end-to-end runs in ~10 s on a dev laptop, well under the 10-min target.
4. **Data consistency** — Composed-1 (cross-module write/route consistency) + Composed-3 (cross-txn ts uniqueness) + 3 PROPERTY transitions.
5. **Test coverage** — no Go tests added (spec-only). `make tla-check` is the coverage layer.

## Roadmap status (post-merge)

| Milestone | Status |
|---|---|
| M1 HLC | Landed (PR #856) |
| M2 OCC | Landed (PR #858) |
| M3 MVCC | Landed (PR #861) |
| M4 Routes | Landed (PR #861 via stacked #862) |
| **M5 Composed** | **This PR** |
| M6 liveness (OPTIONAL) | Not started — can follow as a separate PR |
| M1 Go follow-up (ceiling fence) | Not started — separate Go PR with caller audit |

## Test plan

- [ ] `tla-check` CI runs green (watches `tla/**`)
- [ ] `tla-spec-ai-review` does NOT fire — spec-only PR
- [ ] Reviewer cross-checks Composed-1 / Composed-3 against §5.5 of the design doc
- [ ] Reviewer runs `make tla-check` and confirms 10 outcomes (5 safe pass + 5 gap fail)
- [ ] Reviewer sanity-checks the `INSTANCE`-free projection claim — each Composed action mirrors the corresponding M1..M4 action

## Out of scope

- M6 liveness (OCC-L1, Routes-L1) — separate PR if needed
- HLC-4 (iii) ceiling fence Go implementation — separate code PR
- Cross-group `SplitRange` in the real implementation (currently same-group only)
