### PR TITLE
kv(hlc): add NextFenced() for HLC-4 (iii) ceiling fence; migrate kv coordinator paths

### DIFF
--- a/adapter/internal.go
+++ b/adapter/internal.go
@@ -80,11 +80,10 @@ func (i *Internal) stampTimestamps(req *pb.ForwardRequest) error {
 		return i.stampTxnTimestamps(req.Requests)
 	}
 
-	i.stampRawTimestamps(req.Requests)
-	return nil
+	return i.stampRawTimestamps(req.Requests)
 }
 
-func (i *Internal) stampRawTimestamps(reqs []*pb.Request) {
+func (i *Internal) stampRawTimestamps(reqs []*pb.Request) error {
 	for _, r := range reqs {
 		if r == nil {
 			continue
@@ -96,8 +95,13 @@ func (i *Internal) stampRawTimestamps(reqs []*pb.Request) {
 			r.Ts = 1
 			continue
 		}
-		r.Ts = i.clock.Next()
+		ts, err := i.clock.NextFenced()
+		if err != nil {
+			return errors.Wrap(err, "stampRawTimestamps")
+		}
+		r.Ts = ts
 	}
+	return nil
 }
 
 func (i *Internal) stampTxnTimestamps(reqs []*pb.Request) error {
@@ -106,7 +110,11 @@ func (i *Internal) stampTxnTimestamps(reqs []*pb.Request) error {
 		if i.clock == nil {
 			startTS = 1
 		} else {
-			startTS = i.clock.Next()
+			ts, err := i.clock.NextFenced()
+			if err != nil {
+				return errors.Wrap(err, "stampTxnTimestamps startTS")
+			}
+			startTS = ts
 		}
 	}
 	if startTS == ^uint64(0) {
@@ -174,18 +182,9 @@ func (i *Internal) fillForwardedTxnCommitTS(reqs []*pb.Request, startTS uint64) 
 		return nil
 	}
 
-	commitTS := startTS + 1
-	if commitTS == 0 {
-		// Overflow: can't choose a commit timestamp strictly greater than startTS.
-		return errors.WithStack(ErrTxnTimestampOverflow)
-	}
-	if i.clock != nil {
-		i.clock.Observe(startTS)
-		commitTS = i.clock.Next()
-	}
-	if commitTS <= startTS {
-		// Defensive: avoid writing an invalid CommitTS.
-		return errors.WithStack(ErrTxnTimestampOverflow)
+	commitTS, err := i.forwardedTxnCommitTS(startTS)
+	if err != nil {
+		return err
 	}
 
 	for _, item := range metaMutations {
@@ -193,4 +192,28 @@ func (i *Internal) fillForwardedTxnCommitTS(reqs []*pb.Request, startTS uint64) 
 		item.m.Value = kv.EncodeTxnMeta(item.meta)
 	}
 	return nil
+}
+
+// forwardedTxnCommitTS allocates a commit timestamp for a forwarded
+// transaction, strictly greater than startTS. Pulled out of
+// fillForwardedTxnCommitTS so that function stays under cyclop.
+func (i *Internal) forwardedTxnCommitTS(startTS uint64) (uint64, error) {
+	commitTS := startTS + 1
+	if commitTS == 0 {
+		// Overflow: can't choose a commit timestamp strictly greater than startTS.
+		return 0, errors.WithStack(ErrTxnTimestampOverflow)
+	}
+	if i.clock != nil {
+		i.clock.Observe(startTS)
+		ts, err := i.clock.NextFenced()
+		if err != nil {
+			return 0, errors.Wrap(err, "fillForwardedTxnCommitTS")
+		}
+		commitTS = ts
+	}
+	if commitTS <= startTS {
+		// Defensive: avoid writing an invalid CommitTS.
+		return 0, errors.WithStack(ErrTxnTimestampOverflow)
+	}
+	return commitTS, nil
 }

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -894,17 +894,32 @@ func (c *Coordinate) dispatchRaw(ctx context.Context, req []*Elem[OP]) (*Coordin
 	}, nil
 }
 
-func (c *Coordinate) toRawRequest(req *Elem[OP]) (*pb.Request, error) {
-	ts, err := c.clock.NextFenced()
-	if err != nil {
-		return nil, errors.Wrap(err, "allocate raw request ts")
-	}
+// toRawRequest builds a forwarded raw Request for the redirect path
+// (follower → leader Internal.Forward). The leader stamps Ts on
+// arrival via adapter.Internal.stampRawTimestamps, so the follower
+// MUST leave Ts == 0 here.
+//
+// Two reasons this is the right contract:
+//  1. HLC invariant — persistence timestamps are issued exclusively
+//     by the Raft leader (see CLAUDE.md "Timestamp Oracle"). Calling
+//     NextFenced on the follower's clock both violates that invariant
+//     and produces a ts the leader's HLC has not observed.
+//  2. HLC-4 (iii) fence — a follower whose physicalCeiling is stale
+//     (lease entry not yet applied / wall has caught up locally)
+//     would return ErrCeilingExpired here even when the actual
+//     leader has already renewed its ceiling, spuriously failing
+//     follower-routed raw writes during follower lag or
+//     re-election. Regression: TestToRawRequestLeavesTsForLeaderStamping.
+//
+// The returned Request is structurally identical to the pre-stamping
+// shape the leader's stampRawTimestamps already handles for Ts == 0
+// (see adapter/internal.go).
+func (c *Coordinate) toRawRequest(req *Elem[OP]) *pb.Request {
 	switch req.Op {
 	case Put:
 		return &pb.Request{
 			IsTxn: false,
 			Phase: pb.Phase_NONE,
-			Ts:    ts,
 			Mutations: []*pb.Mutation{
 				{
 					Op:    pb.Op_PUT,
@@ -912,33 +927,31 @@ func (c *Coordinate) toRawRequest(req *Elem[OP]) (*pb.Request, error) {
 					Value: req.Value,
 				},
 			},
-		}, nil
+		}
 
 	case Del:
 		return &pb.Request{
 			IsTxn: false,
 			Phase: pb.Phase_NONE,
-			Ts:    ts,
 			Mutations: []*pb.Mutation{
 				{
 					Op:  pb.Op_DEL,
 					Key: req.Key,
 				},
 			},
-		}, nil
+		}
 
 	case DelPrefix:
 		return &pb.Request{
 			IsTxn: false,
 			Phase: pb.Phase_NONE,
-			Ts:    ts,
 			Mutations: []*pb.Mutation{
 				{
 					Op:  pb.Op_DEL_PREFIX,
 					Key: req.Key,
 				},
 			},
-		}, nil
+		}
 	}
 
 	panic("unreachable")
@@ -994,11 +1007,7 @@ func (c *Coordinate) buildRedirectRequests(reqs *OperationGroup[OP]) ([]*pb.Requ
 	if !reqs.IsTxn {
 		requests := make([]*pb.Request, 0, len(reqs.Elems))
 		for _, req := range reqs.Elems {
-			r, err := c.toRawRequest(req)
-			if err != nil {
-				return nil, err
-			}
-			requests = append(requests, r)
+			requests = append(requests, c.toRawRequest(req))
 		}
 		return requests, nil
 	}

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -441,7 +441,11 @@ func (c *Coordinate) dispatchOnce(ctx context.Context, reqs *OperationGroup[OP])
 		// CommitTS so dispatchTxn generates both timestamps consistently.
 		// A caller-supplied CommitTS without a matching StartTS could produce
 		// CommitTS <= StartTS (an invalid transaction).
-		reqs.StartTS = c.nextStartTS()
+		startTS, err := c.nextStartTS()
+		if err != nil {
+			return nil, err
+		}
+		reqs.StartTS = startTS
 		reqs.CommitTS = 0
 	}
 
@@ -794,8 +798,38 @@ func (c *Coordinate) LeaseReadForKey(ctx context.Context, _ []byte) (uint64, err
 	return c.LeaseRead(ctx)
 }
 
-func (c *Coordinate) nextStartTS() uint64 {
-	return c.clock.Next()
+func (c *Coordinate) nextStartTS() (uint64, error) {
+	ts, err := c.clock.NextFenced()
+	if err != nil {
+		return 0, errors.Wrap(err, "allocate startTS")
+	}
+	return ts, nil
+}
+
+// resolveDispatchCommitTS centralises the commit-ts allocation for
+// dispatchTxn so the function stays under the nestif cyclomatic
+// budget. When commitTS == 0 it allocates a fresh ts via NextFenced
+// (with an Observe-and-retry path when the first allocation is not
+// strictly above startTS); otherwise it Observes the caller-supplied
+// ts to keep HLC monotonic.
+func (c *Coordinate) resolveDispatchCommitTS(commitTS, startTS uint64) (uint64, error) {
+	if commitTS != 0 {
+		c.clock.Observe(commitTS)
+		return commitTS, nil
+	}
+	next, err := c.clock.NextFenced()
+	if err != nil {
+		return 0, errors.Wrap(err, "allocate commitTS")
+	}
+	if next > startTS {
+		return next, nil
+	}
+	c.clock.Observe(startTS)
+	retry, err := c.clock.NextFenced()
+	if err != nil {
+		return 0, errors.Wrap(err, "re-allocate commitTS after Observe")
+	}
+	return retry, nil
 }
 
 func (c *Coordinate) dispatchTxn(ctx context.Context, reqs []*Elem[OP], readKeys [][]byte, startTS uint64, commitTS uint64) (*CoordinateResponse, error) {
@@ -807,17 +841,11 @@ func (c *Coordinate) dispatchTxn(ctx context.Context, reqs []*Elem[OP], readKeys
 		return nil, errors.WithStack(ErrTxnPrimaryKeyRequired)
 	}
 
-	if commitTS == 0 {
-		commitTS = c.clock.Next()
-		if commitTS <= startTS {
-			c.clock.Observe(startTS)
-			commitTS = c.clock.Next()
-		}
-	} else {
-		// Observe the caller-provided commitTS so the HLC never issues
-		// a smaller timestamp in subsequent calls, preserving monotonicity.
-		c.clock.Observe(commitTS)
+	resolvedCommitTS, err := c.resolveDispatchCommitTS(commitTS, startTS)
+	if err != nil {
+		return nil, err
 	}
+	commitTS = resolvedCommitTS
 	if commitTS <= startTS {
 		return nil, errors.WithStack(ErrTxnCommitTSRequired)
 	}
@@ -846,10 +874,14 @@ func (c *Coordinate) dispatchRaw(ctx context.Context, req []*Elem[OP]) (*Coordin
 		muts = append(muts, elemToMutation(elem))
 	}
 
+	ts, err := c.clock.NextFenced()
+	if err != nil {
+		return nil, errors.Wrap(err, "allocate raw dispatch ts")
+	}
 	logs := []*pb.Request{{
 		IsTxn:     false,
 		Phase:     pb.Phase_NONE,
-		Ts:        c.clock.Next(),
+		Ts:        ts,
 		Mutations: muts,
 	}}
 
@@ -862,13 +894,17 @@ func (c *Coordinate) dispatchRaw(ctx context.Context, req []*Elem[OP]) (*Coordin
 	}, nil
 }
 
-func (c *Coordinate) toRawRequest(req *Elem[OP]) *pb.Request {
+func (c *Coordinate) toRawRequest(req *Elem[OP]) (*pb.Request, error) {
+	ts, err := c.clock.NextFenced()
+	if err != nil {
+		return nil, errors.Wrap(err, "allocate raw request ts")
+	}
 	switch req.Op {
 	case Put:
 		return &pb.Request{
 			IsTxn: false,
 			Phase: pb.Phase_NONE,
-			Ts:    c.clock.Next(),
+			Ts:    ts,
 			Mutations: []*pb.Mutation{
 				{
 					Op:    pb.Op_PUT,
@@ -876,33 +912,33 @@ func (c *Coordinate) toRawRequest(req *Elem[OP]) *pb.Request {
 					Value: req.Value,
 				},
 			},
-		}
+		}, nil
 
 	case Del:
 		return &pb.Request{
 			IsTxn: false,
 			Phase: pb.Phase_NONE,
-			Ts:    c.clock.Next(),
+			Ts:    ts,
 			Mutations: []*pb.Mutation{
 				{
 					Op:  pb.Op_DEL,
 					Key: req.Key,
 				},
 			},
-		}
+		}, nil
 
 	case DelPrefix:
 		return &pb.Request{
 			IsTxn: false,
 			Phase: pb.Phase_NONE,
-			Ts:    c.clock.Next(),
+			Ts:    ts,
 			Mutations: []*pb.Mutation{
 				{
 					Op:  pb.Op_DEL_PREFIX,
 					Key: req.Key,
 				},
 			},
-		}
+		}, nil
 	}
 
 	panic("unreachable")
@@ -958,7 +994,11 @@ func (c *Coordinate) buildRedirectRequests(reqs *OperationGroup[OP]) ([]*pb.Requ
 	if !reqs.IsTxn {
 		requests := make([]*pb.Request, 0, len(reqs.Elems))
 		for _, req := range reqs.Elems {
-			requests = append(requests, c.toRawRequest(req))
+			r, err := c.toRawRequest(req)
+			if err != nil {
+				return nil, err
+			}
+			requests = append(requests, r)
 		}
 		return requests, nil
 	}

--- a/kv/coordinator_dispatch_test.go
+++ b/kv/coordinator_dispatch_test.go
@@ -179,3 +179,68 @@ func TestCoordinateDispatchRaw_CallsTransactionManager(t *testing.T) {
 	require.NotNil(t, resp)
 	require.Equal(t, 1, tx.commits)
 }
+
+// TestToRawRequestLeavesTsForLeaderStamping is the regression for the
+// codex P2 review on PR #867.
+//
+// buildRedirectRequests is the follower's forward path: when a client
+// hits a non-leader, the follower constructs forwarded Requests and
+// ships them to the leader's Internal.Forward, which is responsible
+// for stamping ts (adapter.Internal.stampRawTimestamps). Issuing a ts
+// on the follower violates the HLC-leader-only invariant (CLAUDE.md
+// HLC contract) and — with the HLC-4 (iii) fence now wired up — can
+// spuriously fail follower-routed raw writes when the follower's
+// physicalCeiling is stale relative to the leader.
+//
+// Contract: toRawRequest must leave Ts == 0 so the leader stamps it.
+func TestToRawRequestLeavesTsForLeaderStamping(t *testing.T) {
+	t.Parallel()
+
+	clock := NewHLC()
+	// Simulate a stale follower: ceiling sits in the past so any
+	// NextFenced() call on this clock would return ErrCeilingExpired.
+	clock.SetPhysicalCeiling(1)
+
+	c := &Coordinate{clock: clock}
+
+	cases := []struct {
+		name string
+		req  *Elem[OP]
+	}{
+		{"put", &Elem[OP]{Op: Put, Key: []byte("k"), Value: []byte("v")}},
+		{"del", &Elem[OP]{Op: Del, Key: []byte("k")}},
+		{"del-prefix", &Elem[OP]{Op: DelPrefix, Key: []byte("p")}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := c.toRawRequest(tc.req)
+			require.NotNil(t, r)
+			require.Equal(t, uint64(0), r.Ts,
+				"forwarded raw requests must arrive with Ts==0 so the leader's stampRawTimestamps assigns the canonical ts (HLC leader-only invariant + HLC-4 (iii) fence)")
+		})
+	}
+}
+
+// TestBuildRedirectRequestsSurvivesStaleFollowerCeiling exercises the
+// follower's redirect path end-to-end with an expired ceiling: it
+// confirms the follower hands off a Ts==0 request to the leader
+// instead of failing locally on ErrCeilingExpired.
+func TestBuildRedirectRequestsSurvivesStaleFollowerCeiling(t *testing.T) {
+	t.Parallel()
+
+	clock := NewHLC()
+	clock.SetPhysicalCeiling(1) // wall_now >> 1, so NextFenced would fail
+
+	c := &Coordinate{clock: clock}
+
+	got, err := c.buildRedirectRequests(&OperationGroup[OP]{
+		Elems: []*Elem[OP]{
+			{Op: Put, Key: []byte("k"), Value: []byte("v")},
+		},
+	})
+	require.NoError(t, err,
+		"buildRedirectRequests must succeed even when the follower's HLC ceiling is stale")
+	require.Len(t, got, 1)
+	require.Equal(t, uint64(0), got[0].Ts,
+		"redirect-path raw requests must carry Ts==0 (leader stamps)")
+}

--- a/kv/hlc.go
+++ b/kv/hlc.go
@@ -4,7 +4,29 @@ import (
 	"math"
 	"sync/atomic"
 	"time"
+
+	"github.com/cockroachdb/errors"
 )
+
+// ErrCeilingExpired is returned by HLC.NextFenced() when the
+// Raft-agreed physical ceiling has expired — i.e. the wall clock has
+// caught up to or passed the ceiling, meaning RunHLCLeaseRenewal has
+// not applied a fresh ceiling within `hlcPhysicalWindowMs` of the
+// current wall time. Callers MUST refuse to commit and propagate this
+// to the client.
+//
+// This implements HLC-4 precondition (iii) from
+// docs/design/2026_05_28_partial_tla_safety_spec.md §5.1: every
+// persistence-grade ts allocation is gated on `wall_now <
+// physicalCeiling`. The TLA+ MCHLC_gap.cfg counterexample at depth 5
+// demonstrates the safety property this enforces.
+//
+// Pre-bootstrap (ceiling == 0) is intentionally NOT fenced: there is
+// no prior leader to protect against and tests / demo clusters need
+// to issue ts before the first RunHLCLeaseRenewal cycle.  Strict
+// bootstrap fencing is a follow-up consideration; the current
+// semantics match the spec wherever the prior-leader hazard is real.
+var ErrCeilingExpired = errors.New("hlc: physical ceiling expired (wall_now >= physicalCeiling); refusing to issue persistence timestamp")
 
 const hlcLogicalBits = 16
 const hlcLogicalMask uint64 = (1 << hlcLogicalBits) - 1
@@ -77,7 +99,16 @@ func NewHLC() *HLC {
 	return &HLC{}
 }
 
-// Next returns the next hybrid logical timestamp.
+// Next returns the next hybrid logical timestamp, ignoring the
+// HLC-4 physical-ceiling fence.  Kept for non-persistence callers
+// (diagnostics, identifiers, retry IDs, tests, demo wiring) and for
+// adapter sites whose fail-closed migration is not yet completed.
+//
+// NEW persistence-grade allocations (everything that ends up as a
+// startTS / commitTS, an MVCC write timestamp, or a lease/expiry
+// boundary) MUST go through NextFenced instead — Next bypasses the
+// HLC-4 (iii) ceiling fence and can therefore issue a timestamp inside
+// a stale leader window after lease renewal stops.
 //
 // Physical part (upper 48 bits): derived from the wall clock, but never less
 // than the Raft-agreed physicalCeiling so that a newly elected leader cannot
@@ -87,6 +118,29 @@ func NewHLC() *HLC {
 // without any Raft round-trip. It resets to 0 whenever the physical millisecond
 // advances and overflows by bumping the physical millisecond by one.
 func (h *HLC) Next() uint64 {
+	ts, _ := h.nextLocked(false)
+	return ts
+}
+
+// NextFenced returns the next hybrid logical timestamp with the
+// HLC-4 (iii) physical-ceiling fence enforced.  ALL persistence-grade
+// allocations (startTS, commitTS, MVCC write ts, lease/expiry bounds)
+// MUST go through this entry point so that an expired-ceiling
+// allocation fails closed instead of silently issuing a ts that could
+// collide with a subsequent leader's window after renewal catches up.
+//
+// Fence semantics:
+//   - ceiling == 0 (pre-bootstrap, no prior leader): no fence, identical to Next.
+//   - ceiling > 0 AND wall_now >= ceiling: returns (0, ErrCeilingExpired).
+//   - ceiling > 0 AND wall_now < ceiling: floor wall at ceiling, then proceed.
+//
+// The TLA+ proof for this lives in tla/hlc/MCHLC_gap.cfg (HLC-4
+// counterexample, depth 5) — see docs/design/2026_05_28_partial_tla_safety_spec.md §5.1.
+func (h *HLC) NextFenced() (uint64, error) {
+	return h.nextLocked(true)
+}
+
+func (h *HLC) nextLocked(fence bool) (uint64, error) {
 	for {
 		prev := h.last.Load()
 		wallPart := prev >> hlcLogicalBits
@@ -95,10 +149,22 @@ func (h *HLC) Next() uint64 {
 		prevLogical := clampUint64ToUint16(logicalPart)
 
 		nowMs := time.Now().UnixMilli()
-		// Physical part: floor at the Raft-agreed ceiling so a new leader always
-		// starts above the previous leader's issued window.
-		if ceiling := h.physicalCeiling.Load(); ceiling > 0 && nowMs < ceiling {
-			nowMs = ceiling
+		ceiling := h.physicalCeiling.Load()
+		if ceiling > 0 {
+			if fence && nowMs >= ceiling {
+				// HLC-4 precondition (iii): ceiling has expired.  Fail
+				// closed rather than issue a timestamp that could collide
+				// with a subsequent leader's window after renewal catches
+				// up.
+				return 0, errors.WithStack(ErrCeilingExpired)
+			}
+			if nowMs < ceiling {
+				// Physical part: floor at the Raft-agreed ceiling so a
+				// new leader always starts above the previous leader's
+				// issued window.
+				nowMs = ceiling
+			}
+			// Non-fenced path with nowMs >= ceiling: keep nowMs as-is.
 		}
 
 		newWall := nowMs
@@ -115,7 +181,7 @@ func (h *HLC) Next() uint64 {
 
 		next := (nonNegativeUint64(newWall) << hlcLogicalBits) | uint64(newLogical)
 		if h.last.CompareAndSwap(prev, next) {
-			return next
+			return next, nil
 		}
 	}
 }

--- a/kv/hlc_test.go
+++ b/kv/hlc_test.go
@@ -205,3 +205,49 @@ func TestHLCLeaseRoundTrip(t *testing.T) {
 	require.Equal(t, ceilingMs, h.PhysicalCeiling(),
 		"FSM apply must advance the HLC ceiling to the encoded value")
 }
+
+// TestHLCNextFencedFailsClosedOnExpiredCeiling verifies HLC-4 precondition
+// (iii): when wall_now >= physicalCeiling, NextFenced returns
+// ErrCeilingExpired instead of issuing a persistence-grade ts that could
+// collide with a subsequent leader's window after renewal catches up.
+func TestHLCNextFencedFailsClosedOnExpiredCeiling(t *testing.T) {
+	t.Parallel()
+
+	h := NewHLC()
+	// Set a ceiling that is already in the past relative to wall_now.
+	pastMs := time.Now().UnixMilli() - 10_000
+	h.SetPhysicalCeiling(pastMs)
+
+	_, err := h.NextFenced()
+	require.ErrorIs(t, err, ErrCeilingExpired)
+}
+
+// TestHLCNextFencedIgnoredPreBootstrap verifies the documented soft-fence
+// semantics: ceiling == 0 (no prior leader) is NOT fenced — NextFenced must
+// behave identically to Next so that demo/test bootstrap can issue ts
+// before RunHLCLeaseRenewal has applied the first ceiling.
+func TestHLCNextFencedIgnoredPreBootstrap(t *testing.T) {
+	t.Parallel()
+
+	h := NewHLC()
+	require.Equal(t, int64(0), h.PhysicalCeiling())
+
+	ts, err := h.NextFenced()
+	require.NoError(t, err)
+	require.NotZero(t, ts)
+}
+
+// TestHLCNextBypassesFence documents the explicit non-fenced semantics of
+// Next: even with an expired ceiling, Next still returns a usable
+// (non-persistence) timestamp. Persistence sites must go through NextFenced.
+func TestHLCNextBypassesFence(t *testing.T) {
+	t.Parallel()
+
+	h := NewHLC()
+	pastMs := time.Now().UnixMilli() - 10_000
+	h.SetPhysicalCeiling(pastMs)
+
+	require.NotPanics(t, func() {
+		_ = h.Next()
+	})
+}

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -505,7 +505,10 @@ func (c *ShardedCoordinator) dispatchDelPrefixBroadcast(ctx context.Context, isT
 		return nil, err
 	}
 
-	ts := c.clock.Next()
+	ts, err := c.clock.NextFenced()
+	if err != nil {
+		return nil, errors.Wrap(err, "allocate DEL_PREFIX broadcast ts")
+	}
 	requests := make([]*pb.Request, 0, len(elems))
 	for _, elem := range elems {
 		requests = append(requests, &pb.Request{
@@ -620,7 +623,11 @@ func (c *ShardedCoordinator) dispatchTxn(ctx context.Context, startTS uint64, co
 
 func (c *ShardedCoordinator) resolveTxnCommitTS(startTS, commitTS uint64) (uint64, error) {
 	if commitTS == 0 {
-		commitTS = c.nextTxnTSAfter(startTS)
+		next, err := c.nextTxnTSAfter(startTS)
+		if err != nil {
+			return 0, err
+		}
+		commitTS = next
 	} else {
 		// Observe caller-provided commitTS to keep the HLC monotonic; without
 		// this the clock could later issue timestamps smaller than commitTS.
@@ -852,23 +859,29 @@ func (c *ShardedCoordinator) txnGroupForID(gid uint64) (*ShardGroup, error) {
 	return g, nil
 }
 
-func (c *ShardedCoordinator) nextTxnTSAfter(startTS uint64) uint64 {
+func (c *ShardedCoordinator) nextTxnTSAfter(startTS uint64) (uint64, error) {
 	if c.clock == nil {
 		nextTS := startTS + 1
 		if nextTS == 0 {
-			return 0
+			return 0, nil
 		}
-		return nextTS
+		return nextTS, nil
 	}
-	ts := c.clock.Next()
+	ts, err := c.clock.NextFenced()
+	if err != nil {
+		return 0, errors.Wrap(err, "allocate txn commit ts")
+	}
 	if ts <= startTS {
 		c.clock.Observe(startTS)
-		ts = c.clock.Next()
+		ts, err = c.clock.NextFenced()
+		if err != nil {
+			return 0, errors.Wrap(err, "re-allocate txn commit ts after Observe")
+		}
 	}
 	if ts <= startTS {
-		return 0
+		return 0, nil
 	}
-	return ts
+	return ts, nil
 }
 
 func abortTSFrom(startTS, commitTS uint64) uint64 {
@@ -910,7 +923,11 @@ func (c *ShardedCoordinator) nextStartTS(ctx context.Context, elems []*Elem[OP])
 	if c.clock == nil {
 		return maxTS + 1, nil
 	}
-	return c.clock.Next(), nil
+	ts, err := c.clock.NextFenced()
+	if err != nil {
+		return 0, errors.Wrap(err, "allocate sharded startTS")
+	}
+	return ts, nil
 }
 
 func (c *ShardedCoordinator) maxLatestCommitTS(ctx context.Context, elems []*Elem[OP]) (uint64, error) {
@@ -1235,10 +1252,14 @@ func (c *ShardedCoordinator) rawLogs(reqs *OperationGroup[OP]) ([]*pb.Request, e
 
 	logs := make([]*pb.Request, 0, len(gids))
 	for _, gid := range gids {
+		ts, err := c.clock.NextFenced()
+		if err != nil {
+			return nil, errors.Wrap(err, "allocate sharded raw log ts")
+		}
 		logs = append(logs, &pb.Request{
 			IsTxn:     false,
 			Phase:     pb.Phase_NONE,
-			Ts:        c.clock.Next(),
+			Ts:        ts,
 			Mutations: grouped[gid],
 		})
 	}


### PR DESCRIPTION
## Summary

- Splits HLC timestamp allocation into two APIs so the HLC-4 (iii) fail-closed contract from the TLA+ proof can be enforced at exactly the sites that persist a ts, without the multi-file blast radius of changing `Next()`'s signature project-wide.
  - `Next() uint64` — unchanged signature. Bypasses the physical-ceiling fence. Used by diagnostics / identifiers / retry IDs / demo wiring / adapter sites whose fail-closed migration is deferred to Phase 2.
  - `NextFenced() (uint64, error)` — new. Enforces `wall_now < physicalCeiling` (HLC-4 (iii)) and returns `ErrCeilingExpired` instead of issuing a ts inside a stale leader window after RunHLCLeaseRenewal stops. Pre-bootstrap (ceiling == 0) is intentionally soft.
- Migrates the kv-layer persistence-allocation paths to `NextFenced`, propagating the error with `errors.Wrap`:
  - `kv/coordinator.go` — `nextStartTS`, `dispatchTxn` commit-ts (with `Observe`-and-retry path extracted into `resolveDispatchCommitTS` for nestif), `dispatchRaw`, `toRawRequest`.
  - `kv/sharded_coordinator.go` — `dispatchDelPrefixBroadcast`, `nextTxnTSAfter`, `nextStartTS`, `rawLogs`.
  - `adapter/internal.go` — `stampRawTimestamps`, `stampTxnTimestamps`, `fillForwardedTxnCommitTS` (allocation extracted into `forwardedTxnCommitTS` for cyclop).
- `adapter/s3.go`, `adapter/redis.go`, `adapter/redis_compat_commands.go` direct callers intentionally stay on `Next()` and are tagged for **Phase 2** follow-up. The kv-layer migration alone makes every `ShardedCoordinator`-routed and `Coordinator`-routed commit fail-closed when the ceiling expires; the remaining adapter sites can be migrated per-adapter without coordinated churn.

## Spec linkage

- `docs/design/2026_05_28_partial_tla_safety_spec.md` §5.1 — HLC-4 precondition (iii).
- `tla/hlc/MCHLC_gap.cfg` — TLA+ counterexample at depth 5 demonstrating the safety property this enforces.

## Self-review (5 lenses)

1. **Data loss** — Fenced path returns `(0, ErrCeilingExpired)`; every caller propagates via `errors.Wrap` with no silent fallback. The non-fenced `Next()` path is byte-identical to pre-PR for the `ceiling == 0` and `wall_now < ceiling` cases (verified by `TestHLCNextIsMonotonic`, `TestHLCPhysicalCeilingIsFloor`, `TestHLCNextWithCeilingAtLogicalOverflow` — all unchanged).
2. **Concurrency / distributed failures** — `nextLocked` keeps the CAS loop; the fence check is inside the loop so a concurrent `SetPhysicalCeiling` between `Load` and `CompareAndSwap` naturally retries with the updated ceiling. `TestHLCConcurrentNextAndSetPhysicalCeiling` continues to exercise this under `-race`.
3. **Performance** — One extra atomic load + branch per `NextFenced` call vs. `Next`; identical to pre-PR `Next()` cost on the non-error path (CAS is unchanged). No Raft round-trip added.
4. **Data consistency** — HLC-4 (iii) is now enforced at the kv-layer persistence boundary. Pre-bootstrap soft semantics (`ceiling == 0` → no fence) match the spec's `EnableSafety ∧ ceiling > 0 ⇒ fence` shape and let demo/test bootstrap issue ts before `RunHLCLeaseRenewal` lands the first ceiling.
5. **Test coverage** — Three new unit tests:
   - `TestHLCNextFencedFailsClosedOnExpiredCeiling` — past-ceiling → `ErrCeilingExpired`.
   - `TestHLCNextFencedIgnoredPreBootstrap` — `ceiling == 0` stays soft.
   - `TestHLCNextBypassesFence` — documents `Next()`'s intentional bypass for non-persistence callers.
   Existing monotonicity / overflow / lease tests unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go test -race -count=1 ./kv` — 9.475s, pass
- [x] `go test -race -count=1 ./store` — 13.978s, pass
- [x] `make lint` (golangci-lint via pre-commit hook) — 0 issues
- [ ] Jepsen suites (HLC ordering is covered by the existing Redis + DynamoDB workloads; will run in CI on this branch)
- [ ] Phase 2 follow-up: migrate `adapter/s3.go`, `adapter/redis.go`, `adapter/redis_compat_commands.go` direct callers to `NextFenced` (separate PRs, one per adapter)
