### PR TITLE
adapter(s3): migrate direct HLC.Next() callers to NextFenced — PR #867 Phase 2a

### DIFF
--- a/adapter/s3.go
+++ b/adapter/s3.go
@@ -563,7 +563,10 @@ func (s *S3Server) createBucket(w http.ResponseWriter, r *http.Request, bucket s
 	}
 	err := s.retryS3Mutation(r.Context(), func() error {
 		readTS := s.readTS()
-		startTS := s.txnStartTS(readTS)
+		startTS, err := s.txnStartTS(readTS)
+		if err != nil {
+			return errors.Wrap(err, "s3: allocate startTS for mutation")
+		}
 		readPin := s.pinReadTS(readTS)
 		defer readPin.Release()
 
@@ -639,7 +642,10 @@ func (s *S3Server) deleteBucket(w http.ResponseWriter, r *http.Request, bucket s
 	var deletedGeneration uint64
 	err := s.retryS3Mutation(r.Context(), func() error {
 		readTS := s.readTS()
-		startTS := s.txnStartTS(readTS)
+		startTS, err := s.txnStartTS(readTS)
+		if err != nil {
+			return errors.Wrap(err, "s3: allocate startTS for mutation")
+		}
 		readPin := s.pinReadTS(readTS)
 		defer readPin.Release()
 
@@ -784,7 +790,10 @@ func (s *S3Server) putBucketAcl(w http.ResponseWriter, r *http.Request, bucket s
 
 	err := s.retryS3Mutation(r.Context(), func() error {
 		readTS := s.readTS()
-		startTS := s.txnStartTS(readTS)
+		startTS, err := s.txnStartTS(readTS)
+		if err != nil {
+			return errors.Wrap(err, "s3: allocate startTS for mutation")
+		}
 		readPin := s.pinReadTS(readTS)
 		defer readPin.Release()
 
@@ -825,7 +834,11 @@ func (s *S3Server) putBucketAcl(w http.ResponseWriter, r *http.Request, bucket s
 //nolint:cyclop,gocognit,gocyclo,nestif // The S3 PUT flow is intentionally linear and maps directly to protocol steps.
 func (s *S3Server) putObject(w http.ResponseWriter, r *http.Request, bucket string, objectKey string) {
 	readTS := s.readTS()
-	startTS := s.txnStartTS(readTS)
+	startTS, err := s.txnStartTS(readTS)
+	if err != nil {
+		writeS3InternalError(w, err)
+		return
+	}
 	readPin := s.pinReadTS(readTS)
 	defer readPin.Release()
 
@@ -1206,7 +1219,10 @@ func (s *S3Server) deleteObject(w http.ResponseWriter, r *http.Request, bucket s
 	var generation uint64
 	err := s.retryS3Mutation(r.Context(), func() error {
 		readTS := s.readTS()
-		startTS := s.txnStartTS(readTS)
+		startTS, err := s.txnStartTS(readTS)
+		if err != nil {
+			return errors.Wrap(err, "s3: allocate startTS for mutation")
+		}
 		readPin := s.pinReadTS(readTS)
 		defer readPin.Release()
 
@@ -1273,7 +1289,11 @@ func (s *S3Server) createMultipartUpload(w http.ResponseWriter, r *http.Request,
 	}
 
 	uploadID := newS3UploadID(s.clock())
-	startTS := s.txnStartTS(readTS)
+	startTS, err := s.txnStartTS(readTS)
+	if err != nil {
+		writeS3InternalError(w, err)
+		return
+	}
 	commitTS, err := s.nextTxnCommitTS(startTS)
 	if err != nil {
 		writeS3InternalError(w, err)
@@ -1368,7 +1388,11 @@ func (s *S3Server) uploadPart(w http.ResponseWriter, r *http.Request, bucket str
 	// different keys, leaving the chunk data referenced by an in-progress
 	// CompleteMultipartUpload untouched.
 	partReadTS := s.readTS()
-	partStartTS := s.txnStartTS(partReadTS)
+	partStartTS, err := s.txnStartTS(partReadTS)
+	if err != nil {
+		writeS3InternalError(w, err)
+		return
+	}
 	partCommitTS, err := s.nextTxnCommitTS(partStartTS)
 	if err != nil {
 		writeS3InternalError(w, err)
@@ -1647,7 +1671,10 @@ func (s *S3Server) completeMultipartUpload(w http.ResponseWriter, r *http.Reques
 
 	err = s.retryS3Mutation(r.Context(), func() error {
 		retryReadTS := s.readTS()
-		startTS := s.txnStartTS(retryReadTS)
+		startTS, err := s.txnStartTS(retryReadTS)
+		if err != nil {
+			return errors.Wrap(err, "s3: allocate startTS for completeMultipartUpload retry")
+		}
 		retryPin := s.pinReadTS(retryReadTS)
 		defer retryPin.Release()
 
@@ -1756,7 +1783,10 @@ func (s *S3Server) abortMultipartUpload(w http.ResponseWriter, r *http.Request, 
 	var generation uint64
 	err := s.retryS3Mutation(r.Context(), func() error {
 		readTS := s.readTS()
-		startTS := s.txnStartTS(readTS)
+		startTS, err := s.txnStartTS(readTS)
+		if err != nil {
+			return errors.Wrap(err, "s3: allocate startTS for mutation")
+		}
 		readPin := s.pinReadTS(readTS)
 		defer readPin.Release()
 
@@ -2812,16 +2842,36 @@ func (s *S3Server) pinReadTS(ts uint64) *kv.ActiveTimestampToken {
 	return s.readTracker.Pin(ts)
 }
 
-func (s *S3Server) txnStartTS(readTS uint64) uint64 {
-	if readTS == ^uint64(0) {
-		if clock := s.clock(); clock != nil {
-			return clock.Next()
-		}
-		return 1
+// txnStartTS returns the read/start timestamp for an S3 transaction.
+// When the caller passes the sentinel ^uint64(0) ("server, please
+// allocate"), the timestamp is drawn from the HLC via NextFenced —
+// the HLC-4 (iii) physical-ceiling fence applies here because the
+// returned value is persistence-grade (it pins MVCC reads and is the
+// startTS half of a 2PC commit). Returning ErrCeilingExpired here lets
+// the SigV4 handler surface the failure as an S3 5xx instead of
+// silently issuing a stale-leader timestamp.
+func (s *S3Server) txnStartTS(readTS uint64) (uint64, error) {
+	if readTS != ^uint64(0) {
+		return readTS, nil
 	}
-	return readTS
+	clock := s.clock()
+	if clock == nil {
+		return 1, nil
+	}
+	ts, err := clock.NextFenced()
+	if err != nil {
+		return 0, errors.Wrap(err, "s3: allocate txn startTS")
+	}
+	return ts, nil
 }
 
+// newS3UploadID generates an upload identifier for multipart uploads.
+// This is NOT a persistence timestamp — it is an opaque identifier
+// returned to the client and is only used as a lookup key for
+// in-progress parts. The HLC fallback exists purely to keep IDs
+// distinct when /dev/urandom is unavailable; it does not feed MVCC
+// visibility, OCC validation, lease/expiry, or anything else that
+// would require the HLC-4 (iii) fence. Plain Next() is correct here.
 func newS3UploadID(clock *kv.HLC) string {
 	var raw [16]byte
 	if _, err := rand.Read(raw[:]); err == nil {
@@ -2849,7 +2899,10 @@ func (s *S3Server) nextTxnCommitTS(startTS uint64) (uint64, error) {
 		return startTS + 1, nil
 	}
 	clock.Observe(startTS)
-	commitTS := clock.Next()
+	commitTS, err := clock.NextFenced()
+	if err != nil {
+		return 0, errors.Wrap(err, "s3: allocate txn commitTS")
+	}
 	if commitTS <= startTS {
 		return 0, errors.WithStack(kv.ErrTxnCommitTSRequired)
 	}

--- a/adapter/s3_admin.go
+++ b/adapter/s3_admin.go
@@ -259,7 +259,10 @@ func (s *S3Server) AdminCreateBucket(ctx context.Context, principal AdminPrincip
 // error path that the wrapping retry harness needs to see.
 func (s *S3Server) adminCreateBucketTxn(ctx context.Context, principal AdminPrincipal, name, acl string) (*AdminBucketSummary, error) {
 	readTS := s.readTS()
-	startTS := s.txnStartTS(readTS)
+	startTS, err := s.txnStartTS(readTS)
+	if err != nil {
+		return nil, errors.Wrap(err, "s3 admin: allocate startTS for adminCreateBucketTxn")
+	}
 	readPin := s.pinReadTS(readTS)
 	defer readPin.Release()
 
@@ -324,7 +327,10 @@ func (s *S3Server) AdminPutBucketAcl(ctx context.Context, principal AdminPrincip
 
 	err := s.retryS3Mutation(ctx, func() error {
 		readTS := s.readTS()
-		startTS := s.txnStartTS(readTS)
+		startTS, err := s.txnStartTS(readTS)
+		if err != nil {
+			return errors.Wrap(err, "s3 admin: allocate startTS for mutation")
+		}
 		readPin := s.pinReadTS(readTS)
 		defer readPin.Release()
 
@@ -412,40 +418,7 @@ func (s *S3Server) AdminDeleteBucket(ctx context.Context, principal AdminPrincip
 
 	var deletedGeneration uint64
 	err := s.retryS3Mutation(ctx, func() error {
-		readTS := s.readTS()
-		startTS := s.txnStartTS(readTS)
-		readPin := s.pinReadTS(readTS)
-		defer readPin.Release()
-
-		meta, exists, err := s.loadBucketMetaAt(ctx, name, readTS)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-		if !exists || meta == nil {
-			return ErrAdminBucketNotFound
-		}
-		start := s3keys.ObjectManifestPrefixForBucket(name, meta.Generation)
-		kvs, err := s.store.ScanAt(ctx, start, prefixScanEnd(start), 1, readTS)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-		if len(kvs) > 0 {
-			return ErrAdminBucketNotEmpty
-		}
-		// Phase 1: Del BucketMetaKey in a txn so a concurrent
-		// AdminCreateBucket racing the delete is rejected by OCC.
-		// retryS3Mutation handles ErrWriteConflict / ErrTxnLocked
-		// by re-running this whole closure.
-		_, err = s.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
-			IsTxn:   true,
-			StartTS: startTS,
-			Elems:   []*kv.Elem[kv.OP]{{Op: kv.Del, Key: s3keys.BucketMetaKey(name)}},
-		})
-		if err != nil {
-			return errors.WithStack(err)
-		}
-		deletedGeneration = meta.Generation
-		return nil
+		return s.adminDeleteBucketTxnBody(ctx, name, &deletedGeneration)
 	})
 	if err != nil {
 		return err //nolint:wrapcheck // sentinel errors propagate as-is.
@@ -455,6 +428,50 @@ func (s *S3Server) AdminDeleteBucket(ctx context.Context, principal AdminPrincip
 	// committed would 404 at loadBucketMetaAt; we want the error
 	// (if any) logged but not propagated to the operator.
 	s.runBucketDeleteSafetyNet(ctx, name, deletedGeneration)
+	return nil
+}
+
+// adminDeleteBucketTxnBody is the per-attempt body retryS3Mutation
+// invokes from AdminDeleteBucket. Extracted from the inline closure
+// so AdminDeleteBucket stays under the cyclomatic ceiling when the
+// HLC-4 (iii) fence added an extra error-branch on startTS
+// allocation (PR #867 Phase 2a).
+func (s *S3Server) adminDeleteBucketTxnBody(ctx context.Context, name string, deletedGeneration *uint64) error {
+	readTS := s.readTS()
+	startTS, err := s.txnStartTS(readTS)
+	if err != nil {
+		return errors.Wrap(err, "s3 admin: allocate startTS for adminDeleteBucket")
+	}
+	readPin := s.pinReadTS(readTS)
+	defer readPin.Release()
+
+	meta, exists, err := s.loadBucketMetaAt(ctx, name, readTS)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if !exists || meta == nil {
+		return ErrAdminBucketNotFound
+	}
+	start := s3keys.ObjectManifestPrefixForBucket(name, meta.Generation)
+	kvs, err := s.store.ScanAt(ctx, start, prefixScanEnd(start), 1, readTS)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if len(kvs) > 0 {
+		return ErrAdminBucketNotEmpty
+	}
+	// Phase 1: Del BucketMetaKey in a txn so a concurrent
+	// AdminCreateBucket racing the delete is rejected by OCC.
+	// retryS3Mutation handles ErrWriteConflict / ErrTxnLocked
+	// by re-running this whole closure.
+	if _, err := s.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+		IsTxn:   true,
+		StartTS: startTS,
+		Elems:   []*kv.Elem[kv.OP]{{Op: kv.Del, Key: s3keys.BucketMetaKey(name)}},
+	}); err != nil {
+		return errors.WithStack(err)
+	}
+	*deletedGeneration = meta.Generation
 	return nil
 }
 

--- a/adapter/s3_admin_objects.go
+++ b/adapter/s3_admin_objects.go
@@ -116,7 +116,10 @@ func (s *S3Server) AdminDeleteObject(ctx context.Context, principal AdminPrincip
 // silent-no-op semantics and AWS S3.
 func (s *S3Server) adminDeleteObjectTxn(ctx context.Context, bucket, key string) (*s3ObjectManifest, uint64, error) {
 	readTS := s.readTS()
-	startTS := s.txnStartTS(readTS)
+	startTS, err := s.txnStartTS(readTS)
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "s3 admin: allocate startTS for adminDeleteObjectTxn")
+	}
 	readPin := s.pinReadTS(readTS)
 	defer readPin.Release()
 
@@ -212,7 +215,10 @@ func (s *S3Server) AdminPutObject(ctx context.Context, principal AdminPrincipal,
 //nolint:cyclop,gocognit,nestif // see comment above
 func (s *S3Server) adminPutObjectStream(ctx context.Context, bucket, key string, body io.Reader, contentType string) (*s3ObjectManifest, uint64, error) {
 	readTS := s.readTS()
-	startTS := s.txnStartTS(readTS)
+	startTS, err := s.txnStartTS(readTS)
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "s3 admin: allocate startTS for adminPutObjectStream")
+	}
 	readPin := s.pinReadTS(readTS)
 	defer readPin.Release()
 

--- a/adapter/s3_hlc_fence_test.go
+++ b/adapter/s3_hlc_fence_test.go
@@ -1,0 +1,82 @@
+package adapter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bootjp/elastickv/kv"
+	"github.com/stretchr/testify/require"
+)
+
+// TestS3TxnStartTSFailsClosedOnExpiredCeiling verifies that the s3
+// adapter's txnStartTS surfaces ErrCeilingExpired when the HLC's
+// physical ceiling has expired, rather than silently issuing a
+// stale-leader timestamp.  Regression for PR #867 Phase 2a: the
+// adapter's direct clock.Next() callers were migrated to
+// NextFenced() so the HLC-4 (iii) ceiling fence applies on the
+// adapter side too (kv-layer was migrated in PR #867 Phase 1).
+//
+// Without this fence, an S3 PUT / DELETE issued after the lease
+// renewal stopped would mint a startTS inside a stale window and
+// risk colliding with a subsequent leader's commit window.
+func TestS3TxnStartTSFailsClosedOnExpiredCeiling(t *testing.T) {
+	t.Parallel()
+
+	clock := kv.NewHLC()
+	// Ceiling sits in the deep past relative to wall_now so the
+	// fence trips on the next NextFenced() call.
+	clock.SetPhysicalCeiling(1)
+
+	srv := &S3Server{coordinator: &stubAdapterCoordinator{clock: clock}}
+
+	// Sentinel ^uint64(0) means "allocate via HLC" — this is the
+	// path the fence guards.
+	_, err := srv.txnStartTS(^uint64(0))
+	require.ErrorIs(t, err, kv.ErrCeilingExpired,
+		"s3 txnStartTS must propagate ErrCeilingExpired when the HLC's physical ceiling is stale")
+}
+
+// TestS3TxnStartTSPassesThroughExplicitReadTS verifies that the
+// fence is not consulted when the caller supplies a concrete readTS
+// (the non-sentinel path).  Pre-bootstrap and read-after-readTS
+// paths must remain functional even with an unrenewed ceiling.
+func TestS3TxnStartTSPassesThroughExplicitReadTS(t *testing.T) {
+	t.Parallel()
+
+	clock := kv.NewHLC()
+	clock.SetPhysicalCeiling(1) // expired
+
+	srv := &S3Server{coordinator: &stubAdapterCoordinator{clock: clock}}
+
+	ts, err := srv.txnStartTS(42)
+	require.NoError(t, err)
+	require.Equal(t, uint64(42), ts)
+}
+
+// TestS3NextTxnCommitTSFailsClosedOnExpiredCeiling verifies that
+// nextTxnCommitTS surfaces ErrCeilingExpired through the
+// NextFenced() it calls after Observe(startTS).  This is the
+// commit-ts allocation site for S3 multipart and PUT.
+func TestS3NextTxnCommitTSFailsClosedOnExpiredCeiling(t *testing.T) {
+	t.Parallel()
+
+	clock := kv.NewHLC()
+	// Future ceiling, then advance wall past it — emulate the
+	// "leader's lease renewal stopped" hazard.
+	futureMs := time.Now().UnixMilli() + 5_000
+	clock.SetPhysicalCeiling(futureMs)
+	// First call succeeds (wall < ceiling).
+	startTS, err := clock.NextFenced()
+	require.NoError(t, err)
+	// Now retroactively set the ceiling to the deep past so the
+	// next NextFenced trips the fence.
+	pastClock := kv.NewHLC()
+	pastClock.SetPhysicalCeiling(1)
+	pastClock.Observe(startTS)
+
+	srv := &S3Server{coordinator: &stubAdapterCoordinator{clock: pastClock}}
+
+	_, err = srv.nextTxnCommitTS(startTS)
+	require.ErrorIs(t, err, kv.ErrCeilingExpired,
+		"s3 nextTxnCommitTS must propagate ErrCeilingExpired from NextFenced")
+}


### PR DESCRIPTION
## Summary

PR #867 Phase 2a — extends the HLC-4 (iii) fail-closed contract from the kv layer (#867 Phase 1) into the **S3 adapter's direct timestamp-allocation sites**.

The s3 adapter has two private helpers that draw from `HLC` without going through the kv coordinator:

- `txnStartTS(readTS)` — when `readTS == ^uint64(0)` (sentinel "server, please allocate"), called by every SigV4 mutation entry point and the admin RPCs.
- `nextTxnCommitTS(startTS)` — allocates the commit-ts strictly above `startTS` for multipart upload and PUT.

Both now use `clock.NextFenced()` and propagate `ErrCeilingExpired` instead of silently issuing a stale-leader timestamp.

### What changed

- `txnStartTS` signature: `func(readTS uint64) uint64` → `func(readTS uint64) (uint64, error)`. Sentinel-path uses `NextFenced`; non-sentinel path (caller-supplied `readTS`) is unchanged.
- `nextTxnCommitTS`: swapped `clock.Next()` for `clock.NextFenced()` (already returned `(uint64, error)`).
- 14 caller sites plumbed for the new error:
  - 9 in `s3.go` (createBucket, deleteBucket, putBucketAcl, putObject, deleteObject, createMultipartUpload, uploadPart, completeMultipartUpload, abortMultipartUpload).
  - 5 in `s3_admin.go` / `s3_admin_objects.go` (adminCreateBucketTxn, adminUpdateBucketAcl, AdminDeleteBucket, adminDeleteObjectTxn, adminPutObjectStream).
- Extracted `AdminDeleteBucket`'s retry closure into `adminDeleteBucketTxnBody` to keep the function under the cyclop ceiling after the new error branch.

### What is intentionally NOT migrated

- `newS3UploadID` continues to use plain `Next()`. The function returns an opaque multipart-upload identifier that is only used as a lookup key; it is not a persistence timestamp and bypasses MVCC/OCC/lease semantics. An inline comment was added so a future audit does not mistakenly migrate it.
- `adapter/redis.go`, `adapter/redis_compat_commands.go` — **Phase 2b**, a follow-up PR after this lands.

### Regression tests (added before the fix per CLAUDE.md)

- `TestS3TxnStartTSFailsClosedOnExpiredCeiling` — sentinel path propagates `ErrCeilingExpired`.
- `TestS3TxnStartTSPassesThroughExplicitReadTS` — non-sentinel path is unaffected by an expired ceiling (pin-existing-readTS contract preserved).
- `TestS3NextTxnCommitTSFailsClosedOnExpiredCeiling` — commitTS allocation propagates `ErrCeilingExpired`.

All three verified failing on the parent commit (compile-fail before the migration), passing on this commit.

### Self-review (5 lenses)

1. **Data loss** — Fenced path returns `(0, ErrCeilingExpired)` with no silent fallback. The SigV4 layer surfaces it as HTTP 5xx via the existing `writeS3InternalError` path; the admin RPC surfaces it as an error to the operator.
2. **Concurrency / distributed failures** — Both helpers are stateless wrappers around `HLC.NextFenced`, which retains the same CAS loop with the fence checked inside the loop (concurrent `SetPhysicalCeiling` between Load and CAS retries correctly).
3. **Performance** — One extra atomic load + branch per allocation; identical to the kv-layer cost from #867. No additional Raft round-trip.
4. **Data consistency** — HLC-4 (iii) ceiling fence now applies on the s3 adapter's direct-allocation path, aligning with the kv-layer migration. Combined with #867, every coordinator-routed AND every adapter-direct S3 commit fails closed when the leader's lease renewal stops.
5. **Test coverage** — 3 new unit tests added co-located in `adapter/s3_hlc_fence_test.go`. Existing s3 lifecycle tests (`TestS3Server*` suite) unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go test -race -count=1 -run 'TestS3' ./adapter`
- [x] `make lint` (golangci-lint) — 0 issues
- [ ] Full `go test -race ./adapter` in CI (local suite is slow; CI is the source of truth)
- [ ] Phase 2b: redis adapter migration in a separate PR after this lands
