### PR TITLE
adapter(redis): migrate direct HLC.Next() callers to NextFenced — PR #867 Phase 2b

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -3361,7 +3361,7 @@ func (r *RedisServer) commitListPop(ctx context.Context, key []byte, elems []*kv
 	// advances past holes and the metadata stays consistent with Tail.
 	commitTS, err := r.coordinator.Clock().NextFenced()
 	if err != nil {
-		return errors.Wrap(err, "listPopClaimOnce: allocate commitTS")
+		return errors.Wrap(err, "commitListPop: allocate commitTS")
 	}
 	var headDelta int64
 	if left {

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -2634,7 +2634,10 @@ func (t *txnContext) commit() error {
 
 	// Pre-allocate commitTS so Delta keys can embed it in their bytes before
 	// the coordinator assigns it during Dispatch.
-	commitTS := t.server.coordinator.Clock().Next()
+	commitTS, err := t.server.coordinator.Clock().NextFenced()
+	if err != nil {
+		return errors.Wrap(err, "redis txn commit: allocate commitTS")
+	}
 	listElems := t.buildListElems(commitTS)
 	zsetElems, err := t.buildZSetElems(commitTS)
 	if err != nil {
@@ -3152,7 +3155,10 @@ func (r *RedisServer) listPushCore(ctx context.Context, key []byte, values [][]b
 		}
 
 		// Pre-allocate commitTS so we can embed it in the Delta key.
-		commitTS := r.coordinator.Clock().Next()
+		commitTS, err := r.coordinator.Clock().NextFenced()
+		if err != nil {
+			return errors.Wrap(err, "listPushCore: allocate commitTS")
+		}
 		ops, updatedMeta, err := buildFn(meta, key, values, commitTS, 0)
 		if err != nil {
 			return err
@@ -3339,10 +3345,24 @@ func (r *RedisServer) listPopClaimOnce(ctx context.Context, key []byte, count in
 		return nil, buildErr
 	}
 
+	if err := r.commitListPop(ctx, key, elems, n, left, readTS); err != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
+// commitListPop allocates commitTS, appends the ListMetaDelta entry,
+// and dispatches the pop transaction. Extracted from listPopClaimOnce
+// so that function stays under the cyclop ceiling after the HLC-4
+// (iii) NextFenced fence added a new error branch (PR #867 Phase 2b).
+func (r *RedisServer) commitListPop(ctx context.Context, key []byte, elems []*kv.Elem[kv.OP], n int64, left bool, readTS uint64) error {
 	// n is the number of sequence positions claimed (including any holes).
 	// HeadDelta and LenDelta must use n, not len(values), so that Head
 	// advances past holes and the metadata stays consistent with Tail.
-	commitTS := r.coordinator.Clock().Next()
+	commitTS, err := r.coordinator.Clock().NextFenced()
+	if err != nil {
+		return errors.Wrap(err, "listPopClaimOnce: allocate commitTS")
+	}
 	var headDelta int64
 	if left {
 		headDelta = n // head advances by n positions for LPOP
@@ -3354,16 +3374,15 @@ func (r *RedisServer) listPopClaimOnce(ctx context.Context, key []byte, count in
 		Value: delta,
 	})
 
-	_, dispErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+	if _, dispErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 		IsTxn:    true,
 		StartTS:  normalizeStartTS(readTS),
 		CommitTS: commitTS,
 		Elems:    elems,
-	})
-	if dispErr != nil {
-		return nil, errors.WithStack(dispErr)
+	}); dispErr != nil {
+		return errors.WithStack(dispErr)
 	}
-	return values, nil
+	return nil
 }
 
 func (r *RedisServer) listPopClaim(ctx context.Context, key []byte, count int, left bool) ([]string, error) {

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -1442,7 +1442,10 @@ func (r *RedisServer) mutateExactSetWide(conn redcon.Conn, ctx context.Context, 
 			return err
 		}
 
-		commitTS := r.coordinator.Clock().Next()
+		commitTS, err := r.coordinator.Clock().NextFenced()
+		if err != nil {
+			return cockerrors.Wrap(err, "mutateExactSetWide: allocate commitTS")
+		}
 
 		migrationElems, migErr := r.buildSetLegacyMigrationElems(ctx, key, readTS)
 		if migErr != nil {
@@ -2057,15 +2060,14 @@ func (r *RedisServer) applyHashFieldPairs(key []byte, args [][]byte) (int, error
 	var added int
 	err := r.retryRedisWrite(ctx, func() error {
 		readTS := r.readTS()
-		typ, err := r.keyTypeAtExpect(ctx, key, readTS, redisTypeHash)
-		if err != nil {
+		if err := r.requireKeyTypeOrEmpty(ctx, key, readTS, redisTypeHash); err != nil {
 			return err
 		}
-		if typ != redisTypeNone && typ != redisTypeHash {
-			return wrongTypeError()
-		}
 
-		commitTS := r.coordinator.Clock().Next()
+		commitTS, err := r.coordinator.Clock().NextFenced()
+		if err != nil {
+			return cockerrors.Wrap(err, "applyHashFieldPairs: allocate commitTS")
+		}
 
 		// Atomically migrate any legacy blob on first wide-column write.
 		// Fetch migration elems before allocating the main elems slice so that
@@ -2631,7 +2633,10 @@ func (r *RedisServer) hdelWideColumn(ctx context.Context, key []byte, fields [][
 	if removed == 0 {
 		return 0, nil
 	}
-	commitTS := r.coordinator.Clock().Next()
+	commitTS, err := r.coordinator.Clock().NextFenced()
+	if err != nil {
+		return 0, cockerrors.Wrap(err, "hdelWideColumn: allocate commitTS")
+	}
 	elems := delElems
 	deltaVal := store.MarshalHashMetaDelta(store.HashMetaDelta{LenDelta: int64(-removed)})
 	elems = append(elems, &kv.Elem[kv.OP]{
@@ -2956,15 +2961,14 @@ func (r *RedisServer) hincrbyWithMigration(ctx context.Context, key, fieldKey []
 
 func (r *RedisServer) hincrbyTxn(ctx context.Context, key, field []byte, increment int64) (int64, error) {
 	readTS := r.readTS()
-	typ, err := r.keyTypeAtExpect(ctx, key, readTS, redisTypeHash)
-	if err != nil {
+	if err := r.requireKeyTypeOrEmpty(ctx, key, readTS, redisTypeHash); err != nil {
 		return 0, err
 	}
-	if typ != redisTypeNone && typ != redisTypeHash {
-		return 0, wrongTypeError()
-	}
 
-	commitTS := r.coordinator.Clock().Next()
+	commitTS, err := r.coordinator.Clock().NextFenced()
+	if err != nil {
+		return 0, cockerrors.Wrap(err, "hincrbyTxn: allocate commitTS")
+	}
 	fieldKey := store.HashFieldKey(key, field)
 
 	current, isNewField, legacyValue, err := r.readHashFieldInt(ctx, key, field, readTS)
@@ -3277,15 +3281,14 @@ func (r *RedisServer) applyZAddPair(ctx context.Context, key []byte, p zaddPair,
 
 func (r *RedisServer) zaddTxn(ctx context.Context, key []byte, flags zaddFlags, pairs []zaddPair) (int, error) {
 	readTS := r.readTS()
-	typ, err := r.keyTypeAtExpect(ctx, key, readTS, redisTypeZSet)
-	if err != nil {
+	if err := r.requireKeyTypeOrEmpty(ctx, key, readTS, redisTypeZSet); err != nil {
 		return 0, err
 	}
-	if typ != redisTypeNone && typ != redisTypeZSet {
-		return 0, wrongTypeError()
-	}
 
-	commitTS := r.coordinator.Clock().Next()
+	commitTS, err := r.coordinator.Clock().NextFenced()
+	if err != nil {
+		return 0, cockerrors.Wrap(err, "zaddTxn: allocate commitTS")
+	}
 
 	migrationElems, err := r.buildZSetLegacyMigrationElems(ctx, key, readTS)
 	if err != nil {
@@ -3368,16 +3371,15 @@ func (r *RedisServer) dispatchAndSignalZSet(
 // Returns the new score after applying increment.
 func (r *RedisServer) zincrbyTxn(ctx context.Context, key []byte, member string, increment float64) (float64, error) {
 	readTS := r.readTS()
-	typ, err := r.keyTypeAtExpect(ctx, key, readTS, redisTypeZSet)
-	if err != nil {
+	if err := r.requireKeyTypeOrEmpty(ctx, key, readTS, redisTypeZSet); err != nil {
 		return 0, err
-	}
-	if typ != redisTypeNone && typ != redisTypeZSet {
-		return 0, wrongTypeError()
 	}
 
 	memberKey := store.ZSetMemberKey(key, []byte(member))
-	commitTS := r.coordinator.Clock().Next()
+	commitTS, err := r.coordinator.Clock().NextFenced()
+	if err != nil {
+		return 0, cockerrors.Wrap(err, "zincrbyTxn: allocate commitTS")
+	}
 
 	migrationElems, migErr := r.buildZSetLegacyMigrationElems(ctx, key, readTS)
 	if migErr != nil {
@@ -3723,7 +3725,10 @@ func (r *RedisServer) persistBZPopMinResult(ctx context.Context, key []byte, rea
 	}
 	if isWide {
 		// Wide-column: delete the popped member key + score index, emit delta -1.
-		commitTS := r.coordinator.Clock().Next()
+		commitTS, err := r.coordinator.Clock().NextFenced()
+		if err != nil {
+			return cockerrors.Wrap(err, "persistBZPopMinResult: allocate commitTS")
+		}
 		deltaVal := store.MarshalZSetMetaDelta(store.ZSetMetaDelta{LenDelta: -1})
 		elems := []*kv.Elem[kv.OP]{
 			{Op: kv.Del, Key: store.ZSetMemberKey(key, []byte(popped.Member))},

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -314,6 +314,27 @@ func (r *RedisServer) keyTypeAt(ctx context.Context, key []byte, readTS uint64) 
 	return r.applyTTLFilter(ctx, key, readTS, typ)
 }
 
+// requireKeyTypeOrEmpty returns nil iff the key either has the expected
+// type at readTS or is absent at readTS.  wrongTypeError() is returned
+// when the key exists with a different type.
+//
+// Used by the wide-column command implementations (HSET / ZADD /
+// HINCRBY / ZINCRBY etc.) to collapse the keyTypeAtExpect +
+// wrong-type-rejection pair into a single branch at the call site —
+// this is what keeps those functions under the cyclop ceiling after
+// the HLC-4 (iii) ceiling fence added a NextFenced error branch
+// (PR #867 Phase 2b).
+func (r *RedisServer) requireKeyTypeOrEmpty(ctx context.Context, key []byte, readTS uint64, expected redisValueType) error {
+	typ, err := r.keyTypeAtExpect(ctx, key, readTS, expected)
+	if err != nil {
+		return err
+	}
+	if typ != redisTypeNone && typ != expected {
+		return wrongTypeError()
+	}
+	return nil
+}
+
 // keyTypeAtExpect is a fast-path replacement for keyTypeAt callers that
 // know the type they expect to find. The slow path probes ~19 Pebble
 // seeks across every collection family before returning. The fast path:
@@ -340,27 +361,6 @@ func (r *RedisServer) keyTypeAt(ctx context.Context, key []byte, readTS uint64) 
 // place for first-write and wrongType cases, which keep their existing
 // semantics — wrongTypeError detection is preserved by the
 // fall-through.
-// requireKeyTypeOrEmpty returns nil iff the key either has the expected
-// type at readTS or is absent at readTS.  wrongTypeError() is returned
-// when the key exists with a different type.
-//
-// Used by the wide-column command implementations (HSET / ZADD /
-// HINCRBY / ZINCRBY etc.) to collapse the keyTypeAtExpect +
-// wrong-type-rejection pair into a single branch at the call site —
-// this is what keeps those functions under the cyclop ceiling after
-// the HLC-4 (iii) ceiling fence added a NextFenced error branch
-// (PR #867 Phase 2b).
-func (r *RedisServer) requireKeyTypeOrEmpty(ctx context.Context, key []byte, readTS uint64, expected redisValueType) error {
-	typ, err := r.keyTypeAtExpect(ctx, key, readTS, expected)
-	if err != nil {
-		return err
-	}
-	if typ != redisTypeNone && typ != expected {
-		return wrongTypeError()
-	}
-	return nil
-}
-
 func (r *RedisServer) keyTypeAtExpect(ctx context.Context, key []byte, readTS uint64, expected redisValueType) (redisValueType, error) {
 	if expected == redisTypeNone {
 		return r.keyTypeAt(ctx, key, readTS)
@@ -1175,7 +1175,10 @@ func (r *RedisServer) rewriteListTxn(ctx context.Context, key []byte, readTS uin
 	for _, value := range values {
 		rawValues = append(rawValues, []byte(value))
 	}
-	commitTS := r.coordinator.Clock().Next()
+	commitTS, err := r.coordinator.Clock().NextFenced()
+	if err != nil {
+		return errors.Wrap(err, "rewriteListTxn: allocate commitTS")
+	}
 	ops, _, err := r.buildRPushOps(store.ListMeta{}, key, rawValues, commitTS, 0)
 	if err != nil {
 		return err

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -340,6 +340,27 @@ func (r *RedisServer) keyTypeAt(ctx context.Context, key []byte, readTS uint64) 
 // place for first-write and wrongType cases, which keep their existing
 // semantics — wrongTypeError detection is preserved by the
 // fall-through.
+// requireKeyTypeOrEmpty returns nil iff the key either has the expected
+// type at readTS or is absent at readTS.  wrongTypeError() is returned
+// when the key exists with a different type.
+//
+// Used by the wide-column command implementations (HSET / ZADD /
+// HINCRBY / ZINCRBY etc.) to collapse the keyTypeAtExpect +
+// wrong-type-rejection pair into a single branch at the call site —
+// this is what keeps those functions under the cyclop ceiling after
+// the HLC-4 (iii) ceiling fence added a NextFenced error branch
+// (PR #867 Phase 2b).
+func (r *RedisServer) requireKeyTypeOrEmpty(ctx context.Context, key []byte, readTS uint64, expected redisValueType) error {
+	typ, err := r.keyTypeAtExpect(ctx, key, readTS, expected)
+	if err != nil {
+		return err
+	}
+	if typ != redisTypeNone && typ != expected {
+		return wrongTypeError()
+	}
+	return nil
+}
+
 func (r *RedisServer) keyTypeAtExpect(ctx context.Context, key []byte, readTS uint64, expected redisValueType) (redisValueType, error) {
 	if expected == redisTypeNone {
 		return r.keyTypeAt(ctx, key, readTS)

--- a/adapter/redis_delta_compactor.go
+++ b/adapter/redis_delta_compactor.go
@@ -484,13 +484,21 @@ func (c *DeltaCompactor) buildBatchElems(ctx context.Context, h collectionDeltaH
 	return allElems
 }
 
-// dispatchCompaction commits elems as an OCC transaction.
+// dispatchCompaction commits elems as an OCC transaction. The commit
+// timestamp is drawn via NextFenced even though compaction is
+// idempotent in outcome: an unfenced ts inside a stale leader's
+// window can still produce post-compaction OCC ordering surprises
+// against subsequent client writes, so fail-closed is the right
+// default here too (claude-bot review on PR #871 Phase 2b).
 func (c *DeltaCompactor) dispatchCompaction(ctx context.Context, readTS uint64, elems []*kv.Elem[kv.OP]) error {
 	if len(elems) == 0 {
 		return nil
 	}
-	commitTS := c.coord.Clock().Next()
-	_, err := c.coord.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+	commitTS, err := c.coord.Clock().NextFenced()
+	if err != nil {
+		return errors.Wrap(err, "dispatchCompaction: allocate commitTS")
+	}
+	_, err = c.coord.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 		IsTxn:    true,
 		StartTS:  normalizeStartTS(readTS),
 		CommitTS: commitTS,

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -3152,7 +3152,10 @@ func (c *luaScriptContext) commit() error {
 	sort.Strings(keys)
 
 	// Pre-allocate a commitTS so Delta key bytes can embed it before dispatch.
-	commitTS := c.server.coordinator.Clock().Next()
+	commitTS, err := c.server.coordinator.Clock().NextFenced()
+	if err != nil {
+		return errors.Wrap(err, "luaScriptContext.commit: allocate commitTS")
+	}
 
 	elems := make([]*kv.Elem[kv.OP], 0, len(keys)*redisPairWidth)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

PR #867 Phase 2b — closes the adapter side of the HLC-4 (iii) fail-closed migration by extending it from the kv layer (#867) and the s3 adapter (#869) into the **redis adapter's direct timestamp-allocation sites**.

10 sites migrated from `clock.Next()` to `clock.NextFenced()` with full error propagation:

- `adapter/redis.go` (3 sites):
  - `txnContext.commit` — the MULTI/EXEC commit-ts allocation.
  - `listPushCore` — RPUSH/LPUSH retry-loop body.
  - `listPopClaimOnce` — LPOP/RPOP atomic-claim path.
- `adapter/redis_compat_commands.go` (7 sites):
  - `mutateExactSetWide` — SADD/SREM wide-column path.
  - `applyHashFieldPairs` — HSET wide-column path.
  - `hdelWideColumn` — HDEL wide-column path.
  - `hincrbyTxn` — HINCRBY wide-column path.
  - `zaddTxn` — ZADD wide-column path.
  - `zincrbyTxn` — ZINCRBY wide-column path.
  - `persistBZPopMinResult` — BZPOPMIN wide-column persist.

### Supporting refactors

- Added `requireKeyTypeOrEmpty` helper in `redis_compat_helpers.go` that collapses the existing `keyTypeAtExpect → wrong-type-rejection` pair into one branch. Used by 4 callers (`applyHashFieldPairs`, `hincrbyTxn`, `zaddTxn`, `zincrbyTxn`) so the new `NextFenced` error branch does not push them over the cyclop ceiling.
- Extracted `commitListPop` helper from `listPopClaimOnce` for the same reason.

### What this completes

With #867, #869 (Phase 2a, s3), and this PR (Phase 2b, redis) merged, **every** persistence-grade timestamp allocation in the elastickv data plane — coordinator-routed, s3 adapter direct, and redis adapter direct — now fails closed when the leader's lease renewal stops. This matches the spec contract in `docs/design/2026_05_28_partial_tla_safety_spec.md` §5.1 HLC-4 (iii).

### Self-review (5 lenses)

1. **Data loss** — Fenced path returns `(0, ErrCeilingExpired)`; every site propagates via `errors.Wrap` / `cockerrors.Wrap`, and the enclosing redis command path surfaces it as a RESP error to the client. No silent fallback.
2. **Concurrency / distributed failures** — Stateless wrappers around `HLC.NextFenced`'s existing CAS loop; no new lock ordering.
3. **Performance** — One extra atomic load + branch per allocation; no additional Raft round-trip.
4. **Data consistency** — Aligns the redis adapter with the kv layer + s3 adapter. HLC-4 (iii) ceiling fence now applies on every persistence-grade ts allocation the redis adapter reaches.
5. **Test coverage** — Migration is mechanical (signature-preserving wrap of an existing call). `HLC.NextFenced` semantics are covered by tests added in #867; adapter-level regressions for s3 landed in #869 (`s3_hlc_fence_test.go`); the same pattern can be lifted for redis as a follow-up if reviewer prefers per-adapter coverage. Existing redis lifecycle tests (`HIncrBy / ZAdd / HDel / LPush / RPush` suite) pass unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go test -race -count=1 -run 'HIncrBy|ZAdd|HDel|LPush|RPush' ./adapter` — 6.0s, pass
- [x] `make lint` — 0 issues
- [ ] Full `go test -race ./adapter` in CI
- [ ] Jepsen redis workload in CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling with clearer contextual messages for transaction operation failures across Redis operations.

* **Improvements**
  * Enhanced reliability and robustness of internal transaction processing and state management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->