### PR TITLE
feat(encryption): Stage 7c — ConfChange-time writer registration

### DIFF
--- a/internal/encryption/errors.go
+++ b/internal/encryption/errors.go
@@ -120,6 +120,18 @@ var (
 	// than a nil-pointer panic deep in the apply path.
 	ErrKEKNotConfigured = errors.New("encryption: KEK not configured on this node; cannot unwrap wrapped DEK material")
 
+	// ErrWriterUint16Collision is the Stage 7c §3.3 typed error returned
+	// by the encryption-aware MembershipChangeInterceptor when a new
+	// node's NodeID16 collides with an existing member's writer-
+	// registry row at the same uint16 truncation but with a different
+	// FullNodeID. The §3.1 read-before-propose guard catches the
+	// common case BEFORE any propose, so the admin RPC returns a
+	// retryable client-facing error rather than triggering a §4.1
+	// case-4 halt apply (which would, without 7c's interceptor, fire
+	// AFTER the conf-change had already committed — bricking the
+	// cluster). Operators choose a non-colliding raftID and retry.
+	ErrWriterUint16Collision = errors.New("encryption: writer registry uint16 collision; choose a different raftID")
+
 	// ErrSidecarPresentWithoutFlag is the §9.1 startup-refusal guard
 	// raised when the data dir already contains a sidecar (keys.json)
 	// but --encryption-enabled is NOT set. Continuing would silently

--- a/internal/raftadmin/health.go
+++ b/internal/raftadmin/health.go
@@ -21,6 +21,22 @@ const (
 )
 
 func RegisterOperationalServices(ctx context.Context, gs *grpc.Server, engine raftengine.Engine, serviceNames []string) {
+	RegisterOperationalServicesWithInterceptor(ctx, gs, engine, serviceNames, nil)
+}
+
+// RegisterOperationalServicesWithInterceptor is the Stage 7c variant
+// of RegisterOperationalServices that installs an optional
+// [MembershipChangeInterceptor] on the underlying [Server] so
+// AddVoter/AddLearner run an encryption-aware pre-step before the
+// conf-change proposal. Passing nil is equivalent to
+// [RegisterOperationalServices].
+func RegisterOperationalServicesWithInterceptor(
+	ctx context.Context,
+	gs *grpc.Server,
+	engine raftengine.Engine,
+	serviceNames []string,
+	interceptor MembershipChangeInterceptor,
+) {
 	if gs == nil {
 		return
 	}
@@ -28,7 +44,7 @@ func RegisterOperationalServices(ctx context.Context, gs *grpc.Server, engine ra
 		panic("raftadmin: RegisterOperationalServices requires non-nil context")
 	}
 
-	pb.RegisterRaftAdminServer(gs, NewServer(engine))
+	pb.RegisterRaftAdminServer(gs, NewServerWithInterceptor(engine, interceptor))
 
 	healthSrv := health.NewServer()
 	healthpb.RegisterHealthServer(gs, healthSrv)

--- a/internal/raftadmin/interceptor.go
+++ b/internal/raftadmin/interceptor.go
@@ -1,0 +1,28 @@
+package raftadmin
+
+import "context"
+
+// MembershipChangeInterceptor lets a caller of [Server] inject a
+// pre-step into [Server.AddVoter] and [Server.AddLearner] that runs
+// **before** the underlying Raft engine proposes the configuration
+// change. A non-nil error from PreAddMember aborts the conf-change
+// proposal; the error is returned to the gRPC caller verbatim.
+//
+// Stage 7c uses this hook to pre-register a new node's writer-
+// registry row (see
+// docs/design/2026_05_29_proposed_7c_confchange_time_registration.md).
+// Keeping the encryption-aware adapter outside this package preserves
+// raftadmin's engine-generic posture — no concrete dependency on
+// the KV or encryption layers.
+//
+// The hook is intentionally optional: when nil is passed to [NewServer]
+// (or [NewServerWithInterceptor] is not used), AddVoter/AddLearner run
+// exactly as they did pre-7c. Encryption-unaware builds and
+// encryption-disabled clusters therefore see no behavior change.
+type MembershipChangeInterceptor interface {
+	// PreAddMember runs on the leader before AddVoter/AddLearner
+	// proposes the conf-change. The raftID is the same string the
+	// caller passed in the AddVoter/AddLearner request (the
+	// `Id` field).
+	PreAddMember(ctx context.Context, raftID string) error
+}

--- a/internal/raftadmin/server.go
+++ b/internal/raftadmin/server.go
@@ -13,15 +13,31 @@ import (
 type Server struct {
 	engine raftengine.Engine
 	admin  raftengine.Admin
+	// interceptor is invoked from AddVoter/AddLearner before the
+	// underlying Raft engine proposes the conf-change. nil = no
+	// pre-step (the pre-7c posture). Stage 7c wires the encryption-
+	// aware adapter via NewServerWithInterceptor; encryption-unaware
+	// builds keep this nil.
+	interceptor MembershipChangeInterceptor
 
 	pb.UnimplementedRaftAdminServer
 }
 
 func NewServer(engine raftengine.Engine) *Server {
+	return NewServerWithInterceptor(engine, nil)
+}
+
+// NewServerWithInterceptor constructs a Server with an optional
+// pre-step that runs before AddVoter/AddLearner propose the
+// conf-change. See [MembershipChangeInterceptor]. Passing nil is
+// equivalent to [NewServer] — the pre-step is skipped and the
+// conf-change runs exactly as the pre-7c posture.
+func NewServerWithInterceptor(engine raftengine.Engine, interceptor MembershipChangeInterceptor) *Server {
 	admin, _ := any(engine).(raftengine.Admin)
 	return &Server{
-		engine: engine,
-		admin:  admin,
+		engine:      engine,
+		admin:       admin,
+		interceptor: interceptor,
 	}
 }
 
@@ -73,6 +89,15 @@ func (s *Server) AddVoter(ctx context.Context, req *pb.RaftAdminAddVoterRequest)
 	if req == nil || req.Id == "" || req.Address == "" {
 		return nil, grpcStatus(codes.InvalidArgument, "id and address are required")
 	}
+	// Stage 7c §3.1 pre-step: run the encryption-aware adapter (if any)
+	// before the conf-change proposal so the new node's writer-registry
+	// row exists at apply time and any §6.1 uint16 collision halts here
+	// rather than after the conf-change is durable.
+	if s.interceptor != nil {
+		if err := s.interceptor.PreAddMember(ctx, req.Id); err != nil {
+			return nil, adminError(err)
+		}
+	}
 	index, err := s.admin.AddVoter(ctx, req.Id, req.Address, req.PreviousIndex)
 	if err != nil {
 		return nil, adminError(err)
@@ -86,6 +111,11 @@ func (s *Server) AddLearner(ctx context.Context, req *pb.RaftAdminAddLearnerRequ
 	}
 	if req == nil || req.Id == "" || req.Address == "" {
 		return nil, grpcStatus(codes.InvalidArgument, "id and address are required")
+	}
+	if s.interceptor != nil {
+		if err := s.interceptor.PreAddMember(ctx, req.Id); err != nil {
+			return nil, adminError(err)
+		}
 	}
 	index, err := s.admin.AddLearner(ctx, req.Id, req.Address, req.PreviousIndex)
 	if err != nil {

--- a/internal/raftadmin/server_test.go
+++ b/internal/raftadmin/server_test.go
@@ -348,3 +348,108 @@ func TestRegisterOperationalServicesRequiresContext(t *testing.T) {
 		RegisterOperationalServices(nilCtx, server, &fakeEngine{}, []string{"RawKV"})
 	})
 }
+
+// recordingInterceptor is a test double for MembershipChangeInterceptor
+// that records every PreAddMember call and optionally returns a
+// pre-configured error so tests can drive the abort branches.
+type recordingInterceptor struct {
+	mu      sync.Mutex
+	calls   []string
+	retErr  error
+	preHook func(raftID string) // optional callback; useful for ordering assertions
+}
+
+func (r *recordingInterceptor) PreAddMember(_ context.Context, raftID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, raftID)
+	if r.preHook != nil {
+		r.preHook(raftID)
+	}
+	return r.retErr
+}
+
+// TestServer_AddVoter_InvokesInterceptorBeforeConfChange pins Stage 7c
+// §5.1 contract item 1: AddVoter calls the interceptor (with the raftID
+// from the request) before the engine's AddVoter, in that order. A
+// successful interceptor permits the conf-change to proceed.
+func TestServer_AddVoter_InvokesInterceptorBeforeConfChange(t *testing.T) {
+	t.Parallel()
+	engine := &fakeEngine{}
+	var order []string
+	interceptor := &recordingInterceptor{preHook: func(string) { order = append(order, "preAdd") }}
+	server := NewServerWithInterceptor(engine, interceptor)
+	resp, err := server.AddVoter(context.Background(), &pb.RaftAdminAddVoterRequest{Id: "n42", Address: "127.0.0.1:9999"})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, []string{"n42"}, interceptor.calls)
+	// fakeEngine.AddVoter appends to addVoterCalls AFTER the interceptor
+	// hook runs; ordering is observable.
+	order = append(order, "addVoter")
+	require.Equal(t, []string{"preAdd", "addVoter"}, order)
+	require.Equal(t, 1, len(engine.addVoterCalls))
+}
+
+// TestServer_AddVoter_InterceptorErrorAbortsConfChange pins §5.1
+// contract item 2: a non-nil PreAddMember error aborts AddVoter; the
+// engine's AddVoter is never called.
+func TestServer_AddVoter_InterceptorErrorAbortsConfChange(t *testing.T) {
+	t.Parallel()
+	engine := &fakeEngine{}
+	sentinel := context.DeadlineExceeded
+	interceptor := &recordingInterceptor{retErr: sentinel}
+	server := NewServerWithInterceptor(engine, interceptor)
+	resp, err := server.AddVoter(context.Background(), &pb.RaftAdminAddVoterRequest{Id: "n42", Address: "127.0.0.1:9999"})
+	require.Error(t, err)
+	require.Nil(t, resp)
+	require.Equal(t, []string{"n42"}, interceptor.calls)
+	require.Equal(t, 0, len(engine.addVoterCalls), "engine.AddVoter must NOT be called when PreAddMember errs")
+}
+
+// TestServer_AddVoter_NilInterceptorSkipsPreStep pins §5.1 contract
+// item 3: with no interceptor installed (the pre-7c posture, or an
+// encryption-disabled build), AddVoter proceeds directly to the
+// engine's AddVoter as today.
+func TestServer_AddVoter_NilInterceptorSkipsPreStep(t *testing.T) {
+	t.Parallel()
+	engine := &fakeEngine{}
+	server := NewServer(engine) // nil interceptor by construction
+	resp, err := server.AddVoter(context.Background(), &pb.RaftAdminAddVoterRequest{Id: "n42", Address: "127.0.0.1:9999"})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, 1, len(engine.addVoterCalls))
+}
+
+// TestServer_AddLearner_InterceptorContract is the symmetric set for
+// AddLearner — combined into one test since the behavior mirrors
+// AddVoter exactly.
+func TestServer_AddLearner_InterceptorContract(t *testing.T) {
+	t.Parallel()
+	t.Run("invokes interceptor then conf-change", func(t *testing.T) {
+		t.Parallel()
+		engine := &fakeEngine{}
+		interceptor := &recordingInterceptor{}
+		server := NewServerWithInterceptor(engine, interceptor)
+		_, err := server.AddLearner(context.Background(), &pb.RaftAdminAddLearnerRequest{Id: "l1", Address: "127.0.0.1:9000"})
+		require.NoError(t, err)
+		require.Equal(t, []string{"l1"}, interceptor.calls)
+		require.Equal(t, 1, len(engine.addLearnerCalls))
+	})
+	t.Run("interceptor error aborts", func(t *testing.T) {
+		t.Parallel()
+		engine := &fakeEngine{}
+		interceptor := &recordingInterceptor{retErr: context.DeadlineExceeded}
+		server := NewServerWithInterceptor(engine, interceptor)
+		_, err := server.AddLearner(context.Background(), &pb.RaftAdminAddLearnerRequest{Id: "l1", Address: "127.0.0.1:9000"})
+		require.Error(t, err)
+		require.Equal(t, 0, len(engine.addLearnerCalls))
+	})
+	t.Run("nil interceptor skips pre-step", func(t *testing.T) {
+		t.Parallel()
+		engine := &fakeEngine{}
+		server := NewServer(engine)
+		_, err := server.AddLearner(context.Background(), &pb.RaftAdminAddLearnerRequest{Id: "l1", Address: "127.0.0.1:9000"})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(engine.addLearnerCalls))
+	})
+}

--- a/internal/raftadmin/server_test.go
+++ b/internal/raftadmin/server_test.go
@@ -29,6 +29,14 @@ type fakeEngine struct {
 	removeServerCalls   []fakeRemoveServerCall
 	transferCalls       int
 	targetTransferCalls []fakeTransferCall
+
+	// addVoterHook is invoked synchronously inside AddVoter, before
+	// recording the call. Tests use this to observe the ordering of
+	// the engine call relative to the interceptor's hook so the
+	// "interceptor runs before engine.AddVoter" invariant is actually
+	// pinned (claude review on PR #872 — without the hook the test
+	// just observed that both ran in any order).
+	addVoterHook func()
 }
 
 type fakeAddVoterCall struct {
@@ -98,6 +106,12 @@ func (f *fakeEngine) CheckServing(context.Context) error {
 }
 
 func (f *fakeEngine) AddVoter(_ context.Context, id string, address string, prevIndex uint64) (uint64, error) {
+	f.mu.Lock()
+	hook := f.addVoterHook
+	f.mu.Unlock()
+	if hook != nil {
+		hook()
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.addVoterCalls = append(f.addVoterCalls, fakeAddVoterCall{id: id, address: address, prevIndex: prevIndex})
@@ -371,21 +385,20 @@ func (r *recordingInterceptor) PreAddMember(_ context.Context, raftID string) er
 
 // TestServer_AddVoter_InvokesInterceptorBeforeConfChange pins Stage 7c
 // §5.1 contract item 1: AddVoter calls the interceptor (with the raftID
-// from the request) before the engine's AddVoter, in that order. A
-// successful interceptor permits the conf-change to proceed.
+// from the request) before the engine's AddVoter, in that order. The
+// fakeEngine.addVoterHook appends "addVoter" synchronously from inside
+// the engine call, so the recorded ordering pins interceptor-before-
+// engine, not just that-both-ran (claude review low finding on PR #872).
 func TestServer_AddVoter_InvokesInterceptorBeforeConfChange(t *testing.T) {
 	t.Parallel()
-	engine := &fakeEngine{}
 	var order []string
+	engine := &fakeEngine{addVoterHook: func() { order = append(order, "addVoter") }}
 	interceptor := &recordingInterceptor{preHook: func(string) { order = append(order, "preAdd") }}
 	server := NewServerWithInterceptor(engine, interceptor)
 	resp, err := server.AddVoter(context.Background(), &pb.RaftAdminAddVoterRequest{Id: "n42", Address: "127.0.0.1:9999"})
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, []string{"n42"}, interceptor.calls)
-	// fakeEngine.AddVoter appends to addVoterCalls AFTER the interceptor
-	// hook runs; ordering is observable.
-	order = append(order, "addVoter")
 	require.Equal(t, []string{"preAdd", "addVoter"}, order)
 	require.Equal(t, 1, len(engine.addVoterCalls))
 }

--- a/main.go
+++ b/main.go
@@ -478,13 +478,21 @@ func run() error {
 		return nil
 	})
 
+	// Stage 7c §3.1: build the encryption-aware
+	// MembershipChangeInterceptor here where the concrete
+	// *kv.ShardedCoordinator and *kv.ShardGroup are available. Returns
+	// nil when encryption is not wired (no StateCache or no default
+	// group), in which case raftadmin.Server skips the pre-step.
+	encryptionConfChangeInterceptor := newEncryptionPreRegister(
+		coordinate, shardGroups[cfg.defaultGroup], encWiring.cache, etcdraftengine.DeriveNodeID)
 	if err := startServers(serversInput{
 		ctx: runCtx, eg: eg, cancel: cancel, lc: &lc,
 		runtimes: runtimes, bootstrapServers: bootstrapServers,
 		shardStore: shardStore, coordinate: coordinate,
 		distServer: distServer, readTracker: readTracker,
 		metricsRegistry: metricsRegistry, cfg: cfg,
-		keyvizSampler: sampler,
+		keyvizSampler:                   sampler,
+		encryptionConfChangeInterceptor: encryptionConfChangeInterceptor,
 	}); err != nil {
 		return err
 	}
@@ -1060,6 +1068,13 @@ type serversInput struct {
 	// coordinator already has its own copy from
 	// `WithSampler(...)` higher up in run().
 	keyvizSampler *keyviz.MemSampler
+	// encryptionConfChangeInterceptor is the Stage 7c §3.1
+	// pre-register hook for raftadmin AddVoter/AddLearner.
+	// Constructed in run() where concrete *kv.ShardedCoordinator and
+	// *kv.ShardGroup are still in scope; nil when encryption is not
+	// wired or the cluster is not bootstrapped, in which case
+	// raftadmin.Server skips the pre-step.
+	encryptionConfChangeInterceptor internalraftadmin.MembershipChangeInterceptor
 }
 
 // startServers wires up the AdminServer, builds the runtime runner, and
@@ -1142,13 +1157,14 @@ func startServers(in serversInput) error {
 		// sqsPartitionObserver: the metrics registry's HT-FIFO
 		// partition counter observer. nil when --metricsAddress is
 		// empty (the adapter then no-ops the observe call).
-		sqsPartitionObserver: in.metricsRegistry.SQSPartitionObserver(),
-		metricsAddress:       *metricsAddr,
-		metricsToken:         *metricsToken,
-		pprofAddress:         *pprofAddr,
-		pprofToken:           *pprofToken,
-		metricsRegistry:      in.metricsRegistry,
-		roleStore:            roleStore,
+		sqsPartitionObserver:            in.metricsRegistry.SQSPartitionObserver(),
+		metricsAddress:                  *metricsAddr,
+		metricsToken:                    *metricsToken,
+		pprofAddress:                    *pprofAddr,
+		pprofToken:                      *pprofToken,
+		metricsRegistry:                 in.metricsRegistry,
+		roleStore:                       roleStore,
+		encryptionConfChangeInterceptor: in.encryptionConfChangeInterceptor,
 	}
 	if err := runner.start(); err != nil {
 		return err
@@ -1482,6 +1498,7 @@ func startRaftServers(
 	adminServer *adapter.AdminServer,
 	adminGRPCOpts adminGRPCInterceptors,
 	forwardDeps adminForwardServerDeps,
+	confChangeInterceptor internalraftadmin.MembershipChangeInterceptor,
 ) error {
 	forwardLogger := slog.Default().With(slog.String("component", "admin"))
 	// extraOptsCap reserves slots for the unary + stream admin interceptor
@@ -1533,7 +1550,10 @@ func startRaftServers(
 		registerEncryptionAdminServer(gs, etcdraftengine.DeriveNodeID(*raftId), *encryptionSidecarPath, enableMutators, rt.engine, encryptionCapabilityFanout)
 		registerAdminForwardServer(gs, forwardDeps, forwardLogger)
 		rt.registerGRPC(gs)
-		internalraftadmin.RegisterOperationalServices(ctx, gs, rt.engine, []string{"RawKV"})
+		// Stage 7c §3.1: pass the encryption-aware pre-register hook
+		// (nil when encryption is not wired); raftadmin.Server invokes
+		// it before AddVoter/AddLearner propose the conf-change.
+		internalraftadmin.RegisterOperationalServicesWithInterceptor(ctx, gs, rt.engine, []string{"RawKV"}, confChangeInterceptor)
 		reflection.Register(gs)
 
 		grpcSock, err := lc.Listen(ctx, "tcp", rt.spec.address)
@@ -1772,36 +1792,37 @@ func waitErrgroupAfterStartupFailure(cancel context.CancelFunc, eg *errgroup.Gro
 }
 
 type runtimeServerRunner struct {
-	ctx             context.Context
-	lc              *net.ListenConfig
-	eg              *errgroup.Group
-	cancel          context.CancelFunc
-	runtimes        []*raftGroupRuntime
-	shardStore      *kv.ShardStore
-	coordinate      kv.Coordinator
-	distServer      *adapter.DistributionServer
-	adminServer     *adapter.AdminServer
-	adminGRPCOpts   adminGRPCInterceptors
-	redisAddress    string
-	leaderRedis     map[string]string
-	pubsubRelay     *adapter.RedisPubSubRelay
-	readTracker     *kv.ActiveTimestampTracker
-	dynamoAddress   string
-	leaderDynamo    map[string]string
-	s3Address       string
-	leaderS3        map[string]string
-	s3Region        string
-	s3CredsFile     string
-	s3PathStyleOnly bool
-	sqsAddress      string
-	leaderSQS       map[string]string
-	sqsRegion       string
-	sqsCredsFile    string
-	metricsAddress  string
-	metricsToken    string
-	pprofAddress    string
-	pprofToken      string
-	metricsRegistry *monitoring.Registry
+	ctx                             context.Context
+	lc                              *net.ListenConfig
+	eg                              *errgroup.Group
+	cancel                          context.CancelFunc
+	runtimes                        []*raftGroupRuntime
+	shardStore                      *kv.ShardStore
+	coordinate                      kv.Coordinator
+	distServer                      *adapter.DistributionServer
+	adminServer                     *adapter.AdminServer
+	adminGRPCOpts                   adminGRPCInterceptors
+	redisAddress                    string
+	leaderRedis                     map[string]string
+	pubsubRelay                     *adapter.RedisPubSubRelay
+	readTracker                     *kv.ActiveTimestampTracker
+	dynamoAddress                   string
+	leaderDynamo                    map[string]string
+	s3Address                       string
+	leaderS3                        map[string]string
+	s3Region                        string
+	s3CredsFile                     string
+	s3PathStyleOnly                 bool
+	sqsAddress                      string
+	leaderSQS                       map[string]string
+	sqsRegion                       string
+	sqsCredsFile                    string
+	metricsAddress                  string
+	metricsToken                    string
+	pprofAddress                    string
+	pprofToken                      string
+	metricsRegistry                 *monitoring.Registry
+	encryptionConfChangeInterceptor internalraftadmin.MembershipChangeInterceptor
 
 	// dynamoServer is populated by start() and made available to
 	// startAdminFromFlags in this package so the admin listener can
@@ -1894,6 +1915,7 @@ func (r *runtimeServerRunner) start() error {
 		r.adminServer,
 		r.adminGRPCOpts,
 		forwardDeps,
+		r.encryptionConfChangeInterceptor,
 	); err != nil {
 		return waitErrgroupAfterStartupFailure(r.cancel, r.eg, err)
 	}

--- a/main_encryption_confchange.go
+++ b/main_encryption_confchange.go
@@ -81,16 +81,30 @@ func (e *encryptionPreRegister) PreAddMember(ctx context.Context, raftID string)
 	if err != nil {
 		return errors.Wrap(err, "7c pre-register: registry handle")
 	}
-	// Read-before-propose guard (design §3.1, claude round-2 BLOCKING
-	// on PR #868). Required because §4.1 case-2 fires ONLY when
-	// proposed_epoch > last_seen_epoch (strictly greater) — re-
-	// proposing epoch=0 against an existing (epoch=0) row hits case-3
-	// ErrLocalEpochRollback, not the idempotent case-2 path. The
-	// guard reads the row first; if it already exists for this exact
-	// FullNodeID at any epoch, skip the propose (idempotent retry).
-	// FullNodeID mismatch at the same uint16 truncation is the §6.1
-	// collision — return the typed error WITHOUT proposing so we do
-	// not trigger a case-4 halt apply.
+	// Read-before-propose guard (design §3.1). Two purposes:
+	//
+	//   1. LOAD-BEARING: catch §6.1 uint16 collisions (existing row
+	//      under the same NodeID16 but a different FullNodeID) at
+	//      the RPC layer and return the typed
+	//      ErrWriterUint16Collision WITHOUT proposing. Without the
+	//      guard, the propose would commit and the apply would hit
+	//      §4.1 case-4 (different FullNodeID at same uint16) → halt
+	//      apply on a durable conf-change entry. This is the
+	//      irrecoverable scenario 7c exists to prevent.
+	//
+	//   2. OPTIMIZATION: skip a redundant Raft round-trip on a
+	//      same-FullNodeID retry (e.g. leader-flip mid-step). The
+	//      FSM would safely no-op via §4.1 case-2-idempotent
+	//      (proposed_epoch=0 == last_seen_epoch=0 → return nil; see
+	//      applier.go:526), so re-proposing is not unsafe — just
+	//      wasteful. (An earlier comment claimed case-3
+	//      ErrLocalEpochRollback fired on the retry path, which was
+	//      wrong: case-3 requires strictly less than; corrected in
+	//      claude round-3 on PR #872.)
+	//
+	// Branches: existing row + matching FullNodeID → nil (idempotent
+	// skip); existing row + FullNodeID mismatch →
+	// ErrWriterUint16Collision; no row → fall through to propose.
 	existing, exists, err := reg.GetRegistryRow(encryption.RegistryKey(activeDEK, encryption.NodeID16(newNodeFullID)))
 	if err != nil {
 		return errors.Wrap(err, "7c pre-register: read registry row")

--- a/main_encryption_confchange.go
+++ b/main_encryption_confchange.go
@@ -107,30 +107,36 @@ func (e *encryptionPreRegister) PreAddMember(ctx context.Context, raftID string)
 	}
 	entry := registrationEntry(activeDEK, newNodeFullID, 0)
 	req := registrationRequest(activeDEK, newNodeFullID, 0)
-	// connCache is only consulted by proposeWriterRegistration when
-	// the local node is NOT the leader (forward-to-leader path). On
-	// the common leader path — AddVoter/AddLearner is leader-only —
-	// the cache is never touched, so allocating it eagerly is wasted
-	// work (gemini medium on PR #872). Lazy-allocate + defer-close
-	// only on the non-leader branch.
-	var connCache *kv.GRPCConnCache
-	if !e.coordinate.IsLeader() {
-		connCache = &kv.GRPCConnCache{}
-		defer func() {
-			if cerr := connCache.Close(); cerr != nil {
-				slog.Warn("encryption: 7c pre-register failed to close gRPC connection cache",
-					slog.String("error", cerr.Error()))
-			}
-		}()
-	}
-	// TOCTOU residual (claude review on PR #872): two concurrent
+	// Always allocate connCache (NOT lazy-on-non-leader): a lazy
+	// allocation guarded by `if !e.coordinate.IsLeader()` would race
+	// with leadership change inside proposeWriterRegistration, which
+	// performs its own IsLeader() check before consulting connCache.
+	// A leader-flip between the two checks would reach
+	// connCache.ConnFor on a nil pointer — segfault (claude round-2
+	// MEDIUM on PR #872, reverting the round-1 gemini optimization).
+	// The same goroutine-scoped pattern is what the 7a/7b/7b'
+	// registration paths use.
+	connCache := &kv.GRPCConnCache{}
+	defer func() {
+		if cerr := connCache.Close(); cerr != nil {
+			slog.Warn("encryption: 7c pre-register failed to close gRPC connection cache",
+				slog.String("error", cerr.Error()))
+		}
+	}()
+	// TOCTOU residual for concurrent same-raftID AddVoter calls
+	// (claude round-2 on PR #872 — corrected): two concurrent
 	// PreAddMember calls for the SAME raftID can both read "no row"
-	// before either proposal applies, then both propose epoch=0. The
-	// FSM applies the first as §4.1 case-1 first-seen; the second
-	// hits §4.1 case-3 (proposed_epoch=0 ≤ last_seen_epoch=0) →
-	// ErrLocalEpochRollback halt-apply. Recovery is process restart;
-	// the entry replays cleanly. Concurrent AddVoter for the same
-	// raftID is an unusual operator pattern, but the guard cannot
-	// catch it because both reads precede both writes.
+	// before either proposal applies, then both propose epoch=0.
+	// The FSM applies the first as §4.1 case-1 first-seen
+	// (FirstSeen=LastSeen=0); the second hits §4.1 **case-2-
+	// idempotent** because proposed_epoch=0 == last_seen_epoch=0 →
+	// return nil (no error, no halt apply, safe no-op). Case-3
+	// requires proposed_epoch STRICTLY LESS than last_seen_epoch,
+	// which 0 == 0 does not satisfy. The concurrent same-raftID
+	// scenario is therefore harmless — one Raft round-trip on the
+	// duplicate, no operator recovery needed. (The §6.1 uint16-
+	// collision TOCTOU — different FullNodeID at the same NodeID16
+	// — is the genuine case-4 halt-apply residual; see §3.3 of the
+	// design doc.)
 	return proposeWriterRegistration(ctx, e.coordinate, e.defaultGroup.Engine, connCache, entry, req)
 }

--- a/main_encryption_confchange.go
+++ b/main_encryption_confchange.go
@@ -48,7 +48,7 @@ func newEncryptionPreRegister(
 	cache *encryption.StateCache,
 	deriveNodeID func(raftID string) uint64,
 ) raftadmin.MembershipChangeInterceptor {
-	if coordinate == nil || defaultGroup == nil || cache == nil || deriveNodeID == nil {
+	if coordinate == nil || defaultGroup == nil || defaultGroup.Store == nil || cache == nil || deriveNodeID == nil {
 		return nil
 	}
 	return &encryptionPreRegister{
@@ -107,16 +107,30 @@ func (e *encryptionPreRegister) PreAddMember(ctx context.Context, raftID string)
 	}
 	entry := registrationEntry(activeDEK, newNodeFullID, 0)
 	req := registrationRequest(activeDEK, newNodeFullID, 0)
-	// Per-RPC connCache: closed before returning. This is the same
-	// goroutine-scoped pattern the 7a/7b registration paths use; we
-	// don't want a process-lifetime cache for an admin-RPC handler
-	// invoked on demand.
-	connCache := &kv.GRPCConnCache{}
-	defer func() {
-		if cerr := connCache.Close(); cerr != nil {
-			slog.Warn("encryption: 7c pre-register failed to close gRPC connection cache",
-				slog.String("error", cerr.Error()))
-		}
-	}()
+	// connCache is only consulted by proposeWriterRegistration when
+	// the local node is NOT the leader (forward-to-leader path). On
+	// the common leader path — AddVoter/AddLearner is leader-only —
+	// the cache is never touched, so allocating it eagerly is wasted
+	// work (gemini medium on PR #872). Lazy-allocate + defer-close
+	// only on the non-leader branch.
+	var connCache *kv.GRPCConnCache
+	if !e.coordinate.IsLeader() {
+		connCache = &kv.GRPCConnCache{}
+		defer func() {
+			if cerr := connCache.Close(); cerr != nil {
+				slog.Warn("encryption: 7c pre-register failed to close gRPC connection cache",
+					slog.String("error", cerr.Error()))
+			}
+		}()
+	}
+	// TOCTOU residual (claude review on PR #872): two concurrent
+	// PreAddMember calls for the SAME raftID can both read "no row"
+	// before either proposal applies, then both propose epoch=0. The
+	// FSM applies the first as §4.1 case-1 first-seen; the second
+	// hits §4.1 case-3 (proposed_epoch=0 ≤ last_seen_epoch=0) →
+	// ErrLocalEpochRollback halt-apply. Recovery is process restart;
+	// the entry replays cleanly. Concurrent AddVoter for the same
+	// raftID is an unusual operator pattern, but the guard cannot
+	// catch it because both reads precede both writes.
 	return proposeWriterRegistration(ctx, e.coordinate, e.defaultGroup.Engine, connCache, entry, req)
 }

--- a/main_encryption_confchange.go
+++ b/main_encryption_confchange.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/bootjp/elastickv/internal/raftadmin"
+	"github.com/bootjp/elastickv/kv"
+	"github.com/bootjp/elastickv/store"
+	"github.com/cockroachdb/errors"
+)
+
+// encryptionPreRegister is the Stage 7c §3.1 encryption-aware
+// implementation of raftadmin.MembershipChangeInterceptor. It runs
+// on the leader's AddVoter/AddLearner handler before the underlying
+// Raft engine proposes the conf-change, proposing a writer-registry
+// row for the new node so:
+//
+//   - Encrypted writes from the new node never fail closed on the
+//     7a-2 storage gate after the conf-change commits (guarantee 1:
+//     write-window elimination).
+//   - A §6.1 uint16 NodeID collision is caught at the RPC layer via
+//     ErrWriterUint16Collision before the conf-change is proposed —
+//     no §4.1 case-4 halt apply on a durable conf-change entry
+//     (guarantee 2: collision-safe membership change).
+//
+// See docs/design/2026_05_29_proposed_7c_confchange_time_registration.md.
+type encryptionPreRegister struct {
+	coordinate   *kv.ShardedCoordinator
+	defaultGroup *kv.ShardGroup
+	cache        *encryption.StateCache
+	// deriveNodeID is injected so the adapter is engine-neutral —
+	// main.go supplies etcdraftengine.DeriveNodeID today; a future
+	// engine swap is a one-line wiring change here, not an adapter
+	// refactor (gemini medium #1 on PR #868 / design §3.1).
+	deriveNodeID func(raftID string) uint64
+}
+
+// newEncryptionPreRegister constructs the interceptor or returns nil
+// when encryption is not wired (no shared cache or no default
+// group). A nil interceptor causes raftadmin.Server to skip the
+// pre-step, matching the pre-7c behavior on encryption-disabled
+// clusters.
+func newEncryptionPreRegister(
+	coordinate *kv.ShardedCoordinator,
+	defaultGroup *kv.ShardGroup,
+	cache *encryption.StateCache,
+	deriveNodeID func(raftID string) uint64,
+) raftadmin.MembershipChangeInterceptor {
+	if coordinate == nil || defaultGroup == nil || cache == nil || deriveNodeID == nil {
+		return nil
+	}
+	return &encryptionPreRegister{
+		coordinate:   coordinate,
+		defaultGroup: defaultGroup,
+		cache:        cache,
+		deriveNodeID: deriveNodeID,
+	}
+}
+
+// PreAddMember implements raftadmin.MembershipChangeInterceptor.
+// Returns nil (skip) when the cluster is not bootstrapped or when a
+// matching registry row already exists; returns
+// encryption.ErrWriterUint16Collision on a §6.1 collision; otherwise
+// proposes RegisterEncryptionWriter(activeDEK, NodeID(raftID), 0)
+// and surfaces the propose result.
+func (e *encryptionPreRegister) PreAddMember(ctx context.Context, raftID string) error {
+	activeDEK, ok := e.cache.ActiveStorageKeyID()
+	if !ok {
+		// Pre-bootstrap cluster: there is no registry to gate on.
+		// (Encryption-enabled but not yet bootstrapped, or
+		// encryption-disabled with an empty cache.)
+		return nil
+	}
+	newNodeFullID := e.deriveNodeID(raftID)
+	// store.WriterRegistryFor is a stateless wrapper (same idiom as
+	// 7a §3.1 startup check); avoiding a cached field on the adapter
+	// keeps construction simple and the dependency surface narrow.
+	reg, err := store.WriterRegistryFor(e.defaultGroup.Store)
+	if err != nil {
+		return errors.Wrap(err, "7c pre-register: registry handle")
+	}
+	// Read-before-propose guard (design §3.1, claude round-2 BLOCKING
+	// on PR #868). Required because §4.1 case-2 fires ONLY when
+	// proposed_epoch > last_seen_epoch (strictly greater) — re-
+	// proposing epoch=0 against an existing (epoch=0) row hits case-3
+	// ErrLocalEpochRollback, not the idempotent case-2 path. The
+	// guard reads the row first; if it already exists for this exact
+	// FullNodeID at any epoch, skip the propose (idempotent retry).
+	// FullNodeID mismatch at the same uint16 truncation is the §6.1
+	// collision — return the typed error WITHOUT proposing so we do
+	// not trigger a case-4 halt apply.
+	existing, exists, err := reg.GetRegistryRow(encryption.RegistryKey(activeDEK, encryption.NodeID16(newNodeFullID)))
+	if err != nil {
+		return errors.Wrap(err, "7c pre-register: read registry row")
+	}
+	if exists {
+		val, derr := encryption.DecodeRegistryValue(existing)
+		if derr != nil {
+			return errors.Wrap(derr, "7c pre-register: decode registry value")
+		}
+		if val.FullNodeID == newNodeFullID {
+			return nil // already registered; idempotent skip
+		}
+		return encryption.ErrWriterUint16Collision
+	}
+	entry := registrationEntry(activeDEK, newNodeFullID, 0)
+	req := registrationRequest(activeDEK, newNodeFullID, 0)
+	// Per-RPC connCache: closed before returning. This is the same
+	// goroutine-scoped pattern the 7a/7b registration paths use; we
+	// don't want a process-lifetime cache for an admin-RPC handler
+	// invoked on demand.
+	connCache := &kv.GRPCConnCache{}
+	defer func() {
+		if cerr := connCache.Close(); cerr != nil {
+			slog.Warn("encryption: 7c pre-register failed to close gRPC connection cache",
+				slog.String("error", cerr.Error()))
+		}
+	}()
+	return proposeWriterRegistration(ctx, e.coordinate, e.defaultGroup.Engine, connCache, entry, req)
+}

--- a/main_encryption_confchange_test.go
+++ b/main_encryption_confchange_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/bootjp/elastickv/kv"
+	"github.com/bootjp/elastickv/store"
+	"github.com/cockroachdb/errors"
+)
+
+// stubDeriveNodeID returns a sentinel uint64 for any input — lets the
+// tests assert that whatever raftID lands at the adapter is hashed
+// through the injected function value, not a hardcoded global.
+const stubDerivedNodeID uint64 = 0xCAFEF00DDEADBEEF
+
+func stubDeriveNodeID(string) uint64 { return stubDerivedNodeID }
+
+// TestEncryptionPreRegister_PreBootstrapSkips pins design §5.2: when
+// the StateCache reports (0, false) — no active storage DEK, either
+// pre-bootstrap or encryption-disabled — PreAddMember returns nil
+// without proposing or reading the registry.
+func TestEncryptionPreRegister_PreBootstrapSkips(t *testing.T) {
+	t.Parallel()
+	cache := encryption.NewStateCache() // zero-value: ActiveStorageKeyID()=(0,false)
+	st := newRegistrationTestStore(t)
+	defaultGroup := &kv.ShardGroup{Store: st}
+	pre := newEncryptionPreRegister(&kv.ShardedCoordinator{}, defaultGroup, cache, stubDeriveNodeID)
+	if pre == nil {
+		t.Fatal("newEncryptionPreRegister returned nil despite non-nil cache+group")
+	}
+	if err := pre.PreAddMember(context.Background(), "n1"); err != nil {
+		t.Errorf("PreAddMember should skip pre-bootstrap: got %v", err)
+	}
+}
+
+// TestEncryptionPreRegister_NilCacheReturnsNilInterceptor pins the
+// adapter constructor's defensive nil-check: missing wiring inputs
+// produce a nil interceptor (no pre-step) rather than a panicking
+// runtime hook.
+func TestEncryptionPreRegister_NilCacheReturnsNilInterceptor(t *testing.T) {
+	t.Parallel()
+	if got := newEncryptionPreRegister(nil, nil, nil, nil); got != nil {
+		t.Errorf("all-nil inputs: want nil interceptor, got %T", got)
+	}
+	if got := newEncryptionPreRegister(&kv.ShardedCoordinator{}, &kv.ShardGroup{}, nil, stubDeriveNodeID); got != nil {
+		t.Error("nil cache: want nil interceptor")
+	}
+	if got := newEncryptionPreRegister(&kv.ShardedCoordinator{}, &kv.ShardGroup{}, encryption.NewStateCache(), nil); got != nil {
+		t.Error("nil deriveNodeID: want nil interceptor")
+	}
+}
+
+// TestEncryptionPreRegister_IdempotentWhenRowExists pins design §5.2
+// + the gemini-CRITICAL/claude-round-2 fix: when a registry row
+// already exists for (activeDEK, NodeID16(newNodeFullID)) with the
+// SAME FullNodeID, PreAddMember returns nil without proposing
+// (idempotent retry, e.g. after a leader flip). This pins the
+// §3.1 read-before-propose guard against the §4.1 case-3
+// ErrLocalEpochRollback regression that would otherwise fire on
+// re-proposing epoch=0.
+func TestEncryptionPreRegister_IdempotentWhenRowExists(t *testing.T) {
+	t.Parallel()
+	st := newRegistrationTestStore(t)
+	// Pre-populate (testRegDEKID, stubDerivedNodeID, 0). Use the
+	// registry handle directly (writeRegistryRow uses a different
+	// FullNodeID derivation).
+	reg, err := store.WriterRegistryFor(st)
+	if err != nil {
+		t.Fatalf("WriterRegistryFor: %v", err)
+	}
+	val := encryption.EncodeRegistryValue(encryption.RegistryValue{
+		FullNodeID: stubDerivedNodeID, FirstSeenLocalEpoch: 0, LastSeenLocalEpoch: 0,
+	})
+	if err := reg.SetRegistryRow(encryption.RegistryKey(testRegDEKID, encryption.NodeID16(stubDerivedNodeID)), val); err != nil {
+		t.Fatalf("SetRegistryRow: %v", err)
+	}
+
+	cache := encryption.NewStateCache()
+	sc := &encryption.Sidecar{Version: encryption.SidecarVersion, StorageEnvelopeActive: true}
+	sc.Active.Storage = testRegDEKID
+	cache.RefreshFromSidecar(sc)
+
+	pre := newEncryptionPreRegister(&kv.ShardedCoordinator{}, &kv.ShardGroup{Store: st}, cache, stubDeriveNodeID)
+	if err := pre.PreAddMember(context.Background(), "raftN"); err != nil {
+		t.Errorf("PreAddMember should skip when matching row exists: got %v", err)
+	}
+}
+
+// TestEncryptionPreRegister_Uint16CollisionReturnsTypedError pins
+// design §5.2 + §3.1's §6.1-collision branch: when a row exists at
+// the same uint16 truncation with a DIFFERENT FullNodeID, the guard
+// returns ErrWriterUint16Collision WITHOUT proposing. No §4.1
+// case-4 halt-apply is triggered; the admin RPC layer surfaces a
+// retryable client-facing error.
+func TestEncryptionPreRegister_Uint16CollisionReturnsTypedError(t *testing.T) {
+	t.Parallel()
+	st := newRegistrationTestStore(t)
+	reg, err := store.WriterRegistryFor(st)
+	if err != nil {
+		t.Fatalf("WriterRegistryFor: %v", err)
+	}
+	// Stored row's FullNodeID == stubDerivedNodeID; a colliding
+	// FullNodeID is one that hits the same uint16 truncation but
+	// differs in the upper 48 bits.
+	val := encryption.EncodeRegistryValue(encryption.RegistryValue{
+		FullNodeID: stubDerivedNodeID, FirstSeenLocalEpoch: 0, LastSeenLocalEpoch: 0,
+	})
+	if err := reg.SetRegistryRow(encryption.RegistryKey(testRegDEKID, encryption.NodeID16(stubDerivedNodeID)), val); err != nil {
+		t.Fatalf("SetRegistryRow: %v", err)
+	}
+
+	cache := encryption.NewStateCache()
+	sc := &encryption.Sidecar{Version: encryption.SidecarVersion, StorageEnvelopeActive: true}
+	sc.Active.Storage = testRegDEKID
+	cache.RefreshFromSidecar(sc)
+
+	// Adapter that derives a DIFFERENT FullNodeID with the same uint16
+	// truncation as stubDerivedNodeID.
+	collidingFullNodeID := (uint64(0x1111_2222_3333) << 16) | uint64(encryption.NodeID16(stubDerivedNodeID))
+	if collidingFullNodeID == stubDerivedNodeID {
+		t.Fatalf("test bug: colliding == stored; choose a different upper-16 mask")
+	}
+	collidingDerive := func(string) uint64 { return collidingFullNodeID }
+
+	pre := newEncryptionPreRegister(&kv.ShardedCoordinator{}, &kv.ShardGroup{Store: st}, cache, collidingDerive)
+	err = pre.PreAddMember(context.Background(), "raftN")
+	if !errors.Is(err, encryption.ErrWriterUint16Collision) {
+		t.Errorf("PreAddMember on §6.1 collision: want ErrWriterUint16Collision, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the merged 7c design (PR #868). Pre-registers a new node's writer-registry row from the admin-RPC `AddVoter`/`AddLearner` handler so that:

1. **Write-window elimination** (optimization): encrypted writes from the new node never fail closed on the 7a-2 storage gate after the conf-change commits.
2. **Collision-safe membership change** (correctness): a §6.1 uint16 NodeID collision is caught at the RPC layer with `ErrWriterUint16Collision` **before** the conf-change is proposed — no §4.1 case-4 halt-apply on a durable conf-change entry.

### Three changes

1. **`internal/raftadmin`**: `MembershipChangeInterceptor` interface + `NewServerWithInterceptor` constructor + `RegisterOperationalServicesWithInterceptor`. `Server.AddVoter`/`AddLearner` invoke the optional `PreAddMember` hook before the engine's conf-change proposal. Nil interceptor preserves the pre-7c posture.
2. **`internal/encryption`**: `ErrWriterUint16Collision` typed error for the §6.1 collision branch.
3. **`main`**: `encryptionPreRegister` adapter implements the interceptor — read-before-propose guard against §4.1 case-3 (re-proposing `epoch=0` against an existing `(epoch=0)` row), idempotent skip on FullNodeID match, typed error on FullNodeID mismatch (§6.1 collision), case-1 first-seen propose otherwise. Wired into `serversInput → runtimeServerRunner → startRaftServers → RegisterOperationalServicesWithInterceptor` so the encryption adapter coupling stays at the main-level wiring point.

### Test coverage (per design §5)

- `internal/raftadmin/server_test.go`:
  - `TestServer_AddVoter_InvokesInterceptorBeforeConfChange` — ordering: hook called, then engine.AddVoter.
  - `TestServer_AddVoter_InterceptorErrorAbortsConfChange` — engine.AddVoter NOT called when hook errs.
  - `TestServer_AddVoter_NilInterceptorSkipsPreStep` — pre-7c posture preserved.
  - `TestServer_AddLearner_InterceptorContract` — symmetric sub-tests for AddLearner.
- `main_encryption_confchange_test.go`:
  - `TestEncryptionPreRegister_PreBootstrapSkips` — `ActiveStorageKeyID() == (0, false)` → nil-skip.
  - `TestEncryptionPreRegister_NilCacheReturnsNilInterceptor` — defensive nil-check at constructor.
  - `TestEncryptionPreRegister_IdempotentWhenRowExists` — pins the §3.1 read-before-propose guard against the §4.1 case-3 `ErrLocalEpochRollback` regression (claude round-2 BLOCKING on PR #868).
  - `TestEncryptionPreRegister_Uint16CollisionReturnsTypedError` — pins the §6.1 collision branch.

## 5-lens self review

- **Data loss**: clean. Pre-register propose is additive (`0x03` entry + §4.1 case-1 insert); no user-data-path change.
- **Concurrency**: pre-register runs on the leader's RPC goroutine; the guard catches the leader-flip retry race via the durable row, NOT via case-2 monotonic (which requires strictly greater epoch).
- **Performance**: one registry read + at most one Raft round-trip per `AddVoter`/`AddLearner` call. Encryption-unaware path unchanged (nil interceptor skips the pre-step).
- **Data consistency**: §4.1 case-1 first-seen for genuinely new members; guard returns idempotent-skip or `ErrWriterUint16Collision` for existing rows. §6.1 case-4 halt-apply is restricted to the narrow TOCTOU residual (two concurrent AddVoter for uint16-colliding raftIDs).
- **Test coverage**: complete per design §5 (raftadmin contract + adapter branches). The §3.5 leader-flip retry path is pinned by `IdempotentWhenRowExists`. End-to-end test deferred per design §5.3 (requires 2-node test cluster fixture; unit + integration above cover the contract surface).

## Test plan

- [x] `go test -run 'TestApplier|TestApplyRotation|TestApplyBootstrap|TestRuntimeRegistration|TestBuildProcessStartRegistration|TestRegistrationCommittedAtEpoch|TestEncryption_E2E|TestRunWriterRegistration|TestServer|TestEncryptionPreRegister|TestRegisterOperational' -race -timeout 180s ./internal/encryption ./internal/raftadmin ./.` — green.
- [x] `make lint` clean.
- [ ] @claude review for correctness of the interceptor wiring, guard-branch invariants, and main-level construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
