### PR TITLE
tla: Composed-1a current-version fence + currentfence_gap (#870 follow-up)

### DIFF
--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -131,8 +131,23 @@ for module in "${TLA_MODULES[@]}"; do
     # Iterate every gap config registered for this module.  Each is a
     # `<cfg-stem>|<invariant-string>` line; modules with one gap have
     # one entry, modules with multiple guards (composed) have more.
+    #
+    # Validate both fields are non-empty BEFORE entering the inner
+    # body — a malformed entry that produces an empty gap_inv would
+    # silently false-positive at the `grep -qF "$gap_inv"` step below
+    # (empty pattern matches every line, so the gap would always
+    # "succeed" regardless of whether TLC actually surfaced the
+    # expected invariant — gemini medium on PR #878).
     while IFS='|' read -r gap_stem gap_inv; do
-        [ -z "$gap_stem" ] && continue
+        [ -z "$gap_stem" ] && [ -z "$gap_inv" ] && continue
+        if [ -z "$gap_stem" ] || [ -z "$gap_inv" ]; then
+            echo "ERROR: malformed gap entry for module '${module}'" \
+                "— expected '<stem>|<invariant>', got" \
+                "stem='${gap_stem}' inv='${gap_inv}'." \
+                "Fix gap_configs_for() in scripts/tla-check.sh." >&2
+            overall_rc=1
+            continue
+        fi
         gap_cfg="${mc}${gap_stem}.cfg"
         echo "================================================================"
         echo "  TLC: tla/${module}/${gap_cfg}  (no preconditions, expected FAIL on ${gap_inv})"

--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -27,17 +27,29 @@ fi
 # Modules to check, in dependency order (libs before consumers).
 TLA_MODULES=( "hlc" "occ" "mvcc" "routes" "composed" )
 
-# The invariant the gap config is expected to break, per module.
-# These strings are matched against TLC stdout via grep -F (literal).
-gap_invariant_for() {
+# Per-module list of gap configurations to run.  Each entry is
+# "<cfg-stem>|<expected-invariant-string>", one per line.  Modules
+# may register more than one gap if multiple safety guards toggle
+# independently — composed has two (Composed-1 observed-version
+# guard via EnableSafety, Composed-1a current-version fence via
+# EnableCurrentFence).
+#
+# The expected-invariant string is matched against TLC stdout via
+# grep -F (literal), so a parse error / deadlock / JVM crash /
+# different invariant breaking is NOT silently treated as the
+# expected counterexample (codex P2 on PR #856 round 2).
+gap_configs_for() {
     case "$1" in
-        hlc)      echo "Invariant HLC4_NoRegressionAcrossTerms is violated" ;;
-        occ)      echo "Invariant OCC1_CommitTsAboveStart is violated" ;;
-        mvcc)     echo "Invariant MVCC4_NoLostCommitOnSnapshotInstall is violated" ;;
-        routes)   echo "Invariant Routes4_NoEngineRegression is violated" ;;
-        composed) echo "Invariant Composed1_CommitToOwningGroup is violated" ;;
+        hlc)      printf '_gap|Invariant HLC4_NoRegressionAcrossTerms is violated\n' ;;
+        occ)      printf '_gap|Invariant OCC1_CommitTsAboveStart is violated\n' ;;
+        mvcc)     printf '_gap|Invariant MVCC4_NoLostCommitOnSnapshotInstall is violated\n' ;;
+        routes)   printf '_gap|Invariant Routes4_NoEngineRegression is violated\n' ;;
+        composed)
+            printf '_gap|Invariant Composed1_CommitToOwningGroup is violated\n'
+            printf '_currentfence_gap|Invariant Composed1a_CommitToCurrentOwner is violated\n'
+            ;;
         *)
-            echo "ERROR: no gap-invariant string registered for module '$1'." \
+            echo "ERROR: no gap-config list registered for module '$1'." \
                 "Add a case to scripts/tla-check.sh." >&2
             exit 64
             ;;
@@ -99,9 +111,8 @@ for module in "${TLA_MODULES[@]}"; do
         continue
     fi
     safe_cfg="${mc}.cfg"
-    gap_cfg="${mc}_gap.cfg"
-    if ! gap_inv="$(gap_invariant_for "$module")"; then
-        echo "ERROR: gap_invariant_for failed for module '${module}' — see error above." >&2
+    if ! gap_list="$(gap_configs_for "$module")"; then
+        echo "ERROR: gap_configs_for failed for module '${module}' — see error above." >&2
         overall_rc=1
         continue
     fi
@@ -117,39 +128,46 @@ for module in "${TLA_MODULES[@]}"; do
     fi
     echo
 
-    echo "================================================================"
-    echo "  TLC: tla/${module}/${gap_cfg}  (no preconditions, expected FAIL on ${gap_inv})"
-    echo "================================================================"
-    # Capture stdout+stderr so we can validate both the exit code AND the
-    # specific invariant string.  Without the string match, a parse
-    # error / deadlock / JVM crash / different invariant would silently
-    # count as the expected counterexample (codex P2 on PR #856 round 2).
-    gap_out=$(run_tlc "$module" "$gap_cfg" 2>&1)
-    gap_rc=$?
-    printf '%s\n' "$gap_out"
-    if [ "$gap_rc" -eq 0 ]; then
+    # Iterate every gap config registered for this module.  Each is a
+    # `<cfg-stem>|<invariant-string>` line; modules with one gap have
+    # one entry, modules with multiple guards (composed) have more.
+    while IFS='|' read -r gap_stem gap_inv; do
+        [ -z "$gap_stem" ] && continue
+        gap_cfg="${mc}${gap_stem}.cfg"
+        echo "================================================================"
+        echo "  TLC: tla/${module}/${gap_cfg}  (no preconditions, expected FAIL on ${gap_inv})"
+        echo "================================================================"
+        # Capture stdout+stderr so we can validate both the exit code AND the
+        # specific invariant string.  Without the string match, a parse
+        # error / deadlock / JVM crash / different invariant would silently
+        # count as the expected counterexample (codex P2 on PR #856 round 2).
+        gap_out=$(run_tlc "$module" "$gap_cfg" 2>&1)
+        gap_rc=$?
+        printf '%s\n' "$gap_out"
+        if [ "$gap_rc" -eq 0 ]; then
+            echo
+            echo "ERROR: ${gap_cfg} unexpectedly passed." >&2
+            echo "  The gap configuration disables the safety guard; TLC was" >&2
+            echo "  supposed to surface a counterexample.  A clean pass means" >&2
+            echo "  either the spec no longer encodes the gap correctly or the" >&2
+            echo "  safety guards leaked past the EnableSafety toggle." >&2
+            overall_rc=1
+            continue
+        fi
+        if printf '%s\n' "$gap_out" | grep -qF "$gap_inv"; then
+            echo
+            echo "OK: ${gap_cfg} failed as designed (${gap_inv})."
+        else
+            echo
+            echo "ERROR: ${gap_cfg} failed, but the reason is NOT \"${gap_inv}\"." >&2
+            echo "  The non-zero exit may indicate a parse error, deadlock, JVM" >&2
+            echo "  crash, or a different invariant breaking — review the output" >&2
+            echo "  above before treating this as a regression in the gap evidence." >&2
+            overall_rc=1
+            continue
+        fi
         echo
-        echo "ERROR: ${gap_cfg} unexpectedly passed." >&2
-        echo "  The gap configuration disables the safety guard; TLC was" >&2
-        echo "  supposed to surface a counterexample.  A clean pass means" >&2
-        echo "  either the spec no longer encodes the gap correctly or the" >&2
-        echo "  safety guards leaked past the EnableSafety toggle." >&2
-        overall_rc=1
-        continue
-    fi
-    if printf '%s\n' "$gap_out" | grep -qF "$gap_inv"; then
-        echo
-        echo "OK: ${gap_cfg} failed as designed (${gap_inv})."
-    else
-        echo
-        echo "ERROR: ${gap_cfg} failed, but the reason is NOT \"${gap_inv}\"." >&2
-        echo "  The non-zero exit may indicate a parse error, deadlock, JVM" >&2
-        echo "  crash, or a different invariant breaking — review the output" >&2
-        echo "  above before treating this as a regression in the gap evidence." >&2
-        overall_rc=1
-        continue
-    fi
-    echo
+    done <<< "$gap_list"
 done
 
 if [ "$overall_rc" -eq 0 ]; then

--- a/tla/README.md
+++ b/tla/README.md
@@ -258,6 +258,15 @@ two safety properties that no single-module spec can express:
   committing group at the txn's observed catalog version.  Ties OCC's
   commit decision to the Routes catalog snapshot the txn read at
   `BeginTxn`.
+- **Composed-1a** — strictly stronger apply-time fence: every
+  committed write key was owned by the committing group at the
+  CURRENT catalog version observed by the FSM at apply time
+  (`currentVersionAtCommit[t]`).  Composed-1 alone permits the
+  codex-P1 trace (observed-check passes; `ProposeRouteChange` moves
+  the key after `WriteIntent`; commit lands on the old owner;
+  readers at the new version miss the write).  Composed-1a is the
+  spec-level witness for the design doc §4.4 apply-time fence;
+  surfaced as a separate gap config so it is exercised independently.
 - **Composed-3** — every pair of distinct committed transactions has
   distinct `commit_ts` (the strict-serialisability bound).
 
@@ -284,6 +293,7 @@ Invariants asserted:
 |---|---|
 | `TypeOK` | Variable types are well-formed |
 | `Composed1_CommitToOwningGroup` | For every committed txn `t` and every `k ∈ writeSet[t]`, `routes[observedVer[t]][k] = commitGroup[t]` |
+| `Composed1a_CommitToCurrentOwner` | For every committed txn `t` and every `k ∈ writeSet[t]`, `routes[currentVersionAtCommit[t]][k] = commitGroup[t]` — strictly stronger than Composed-1, witnesses the §4.4 apply-time fence |
 | `Composed2_ReadAcrossSplitRange` | Vacuously TRUE in M5 (same-group SplitRange) — kept for naming consistency |
 | `Composed3_DistinctCommitTs` | Distinct committed txns have distinct `commit_ts` |
 | `Composed_CatalogMonotonic` (PROPERTY) | Transition form: `catalogVersion` weakly increases |

--- a/tla/composed/Composed.tla
+++ b/tla/composed/Composed.tla
@@ -51,14 +51,15 @@
 EXTENDS Naturals, FiniteSets
 
 CONSTANTS
-    Keys,           \* finite set of keys
-    Groups,         \* finite set of Raft groups
-    TxnIds,         \* finite set of transactions
-    MaxVersions,    \* bound on catalog versions
-    MaxTs,          \* bound on the abstract HLC counter
-    MaxOps,         \* bound on total actions
-    InitGroup,      \* initial owning group of every key at version 0
-    EnableSafety    \* TRUE: encode Composed-1 commit guard; FALSE: gap config
+    Keys,                \* finite set of keys
+    Groups,              \* finite set of Raft groups
+    TxnIds,              \* finite set of transactions
+    MaxVersions,         \* bound on catalog versions
+    MaxTs,               \* bound on the abstract HLC counter
+    MaxOps,              \* bound on total actions
+    InitGroup,           \* initial owning group of every key at version 0
+    EnableSafety,        \* TRUE: encode Composed-1  commit guard (observed-version owner)
+    EnableCurrentFence   \* TRUE: encode Composed-1a commit guard (current-version owner)
 
 ASSUME InitGroup \in Groups
 
@@ -69,23 +70,33 @@ States == {"Idle", "Active", "Committed", "Aborted"}
 NoGroup == "no_group"
 
 VARIABLES
-    catalogVersion,   \* Nat.  Latest durable catalog version.
-    routes,           \* [0..MaxVersions -> [Keys -> Groups]].  Historical
-                      \* snapshot per version; v <= catalogVersion is real,
-                      \* v > catalogVersion is the init map.
-    tsCounter,        \* Nat.  Monotonic abstract HLC; advances on BeginTxn
-                      \* and Commit.
-    txnState,         \* [TxnIds -> States]
-    txnStartTs,       \* [TxnIds -> 0..MaxTs]
-    txnObservedVer,   \* [TxnIds -> 0..MaxVersions].  Catalog version this
-                      \* txn read at BeginTxn.
-    txnWriteSet,      \* [TxnIds -> SUBSET Keys]
-    txnCommitTs,      \* [TxnIds -> 0..MaxTs]
-    txnCommitGroup,   \* [TxnIds -> Groups \cup {NoGroup}]
+    catalogVersion,         \* Nat.  Latest durable catalog version.
+    routes,                 \* [0..MaxVersions -> [Keys -> Groups]].  Historical
+                            \* snapshot per version; v <= catalogVersion is real,
+                            \* v > catalogVersion is the init map.
+    tsCounter,              \* Nat.  Monotonic abstract HLC; advances on BeginTxn
+                            \* and Commit.
+    txnState,               \* [TxnIds -> States]
+    txnStartTs,             \* [TxnIds -> 0..MaxTs]
+    txnObservedVer,         \* [TxnIds -> 0..MaxVersions].  Catalog version this
+                            \* txn read at BeginTxn.
+    txnWriteSet,            \* [TxnIds -> SUBSET Keys]
+    txnCommitTs,            \* [TxnIds -> 0..MaxTs]
+    txnCommitGroup,         \* [TxnIds -> Groups \cup {NoGroup}]
+    currentVersionAtCommit, \* [TxnIds -> 0..MaxVersions].  Catalog version the
+                            \* FSM observed at apply time (i.e. when the commit
+                            \* lands).  Set on Commit; together with
+                            \* txnObservedVer this witnesses BOTH the spec's
+                            \* observed-version check and the apply-time
+                            \* current-version cross-version-read fence
+                            \* (Composed-1a; see docs/design/
+                            \* 2026_05_29_proposed_composed1_cross_group_commit_guard.md
+                            \* §4.4 and §5).
     opCount
 
 vars == <<catalogVersion, routes, tsCounter, txnState, txnStartTs,
-          txnObservedVer, txnWriteSet, txnCommitTs, txnCommitGroup, opCount>>
+          txnObservedVer, txnWriteSet, txnCommitTs, txnCommitGroup,
+          currentVersionAtCommit, opCount>>
 
 \* === HELPERS ===
 CommittedTxns == { t \in TxnIds : txnState[t] = "Committed" }
@@ -95,16 +106,17 @@ OwnerAt(v, k) == routes[v][k]
 
 \* === INIT ===
 Init ==
-    /\ catalogVersion = 0
-    /\ routes         = [v \in 0..MaxVersions |-> [k \in Keys |-> InitGroup]]
-    /\ tsCounter      = 0
-    /\ txnState       = [t \in TxnIds |-> "Idle"]
-    /\ txnStartTs     = [t \in TxnIds |-> 0]
-    /\ txnObservedVer = [t \in TxnIds |-> 0]
-    /\ txnWriteSet    = [t \in TxnIds |-> {}]
-    /\ txnCommitTs    = [t \in TxnIds |-> 0]
-    /\ txnCommitGroup = [t \in TxnIds |-> NoGroup]
-    /\ opCount        = 0
+    /\ catalogVersion         = 0
+    /\ routes                 = [v \in 0..MaxVersions |-> [k \in Keys |-> InitGroup]]
+    /\ tsCounter              = 0
+    /\ txnState               = [t \in TxnIds |-> "Idle"]
+    /\ txnStartTs             = [t \in TxnIds |-> 0]
+    /\ txnObservedVer         = [t \in TxnIds |-> 0]
+    /\ txnWriteSet            = [t \in TxnIds |-> {}]
+    /\ txnCommitTs            = [t \in TxnIds |-> 0]
+    /\ txnCommitGroup         = [t \in TxnIds |-> NoGroup]
+    /\ currentVersionAtCommit = [t \in TxnIds |-> 0]
+    /\ opCount                = 0
 
 \* === ACTIONS ===
 
@@ -126,7 +138,8 @@ ProposeRouteChange(k, g_new) ==
                     [routes[catalogVersion] EXCEPT ![k] = g_new]]
     /\ opCount' = opCount + 1
     /\ UNCHANGED <<tsCounter, txnState, txnStartTs, txnObservedVer,
-                   txnWriteSet, txnCommitTs, txnCommitGroup>>
+                   txnWriteSet, txnCommitTs, txnCommitGroup,
+                   currentVersionAtCommit>>
 
 (***************************************************************************)
 (* BeginTxn(t): the txn enters Active state, allocates a fresh start_ts  *)
@@ -145,7 +158,7 @@ BeginTxn(t) ==
     /\ txnObservedVer' = [txnObservedVer EXCEPT ![t] = catalogVersion]
     /\ opCount'        = opCount + 1
     /\ UNCHANGED <<catalogVersion, routes, txnWriteSet, txnCommitTs,
-                   txnCommitGroup>>
+                   txnCommitGroup, currentVersionAtCommit>>
 
 (***************************************************************************)
 (* WriteIntent(t, k): buffer a write to k locally.  No lock or version is *)
@@ -160,7 +173,8 @@ WriteIntent(t, k) ==
     /\ txnWriteSet' = [txnWriteSet EXCEPT ![t] = @ \cup {k}]
     /\ opCount' = opCount + 1
     /\ UNCHANGED <<catalogVersion, routes, tsCounter, txnState, txnStartTs,
-                   txnObservedVer, txnCommitTs, txnCommitGroup>>
+                   txnObservedVer, txnCommitTs, txnCommitGroup,
+                   currentVersionAtCommit>>
 
 (***************************************************************************)
 (* Commit(t, g): atomically commit t through Raft group g.  Allocates a   *)
@@ -180,12 +194,23 @@ WriteIntent(t, k) ==
 Commit(t, g) ==
     /\ txnState[t] = "Active"
     /\ tsCounter < MaxTs
+    \* Composed-1 — observed-version owner check (the spec-level
+    \* refinement of the design doc §4.2(a) check).
     /\ \/ ~EnableSafety
        \/ \A k \in txnWriteSet[t] : OwnerAt(txnObservedVer[t], k) = g
-    /\ tsCounter'       = tsCounter + 1
-    /\ txnState'        = [txnState       EXCEPT ![t] = "Committed"]
-    /\ txnCommitTs'     = [txnCommitTs    EXCEPT ![t] = tsCounter + 1]
-    /\ txnCommitGroup'  = [txnCommitGroup EXCEPT ![t] = g]
+    \* Composed-1a — current-version owner check (the apply-time
+    \* cross-version-read fence from design doc §4.4).  This is the
+    \* strictly stronger guard the implementation adds on top of the
+    \* spec's literal Commit predicate; it prevents the codex P1 trace
+    \* where the observed-version check passes but a later
+    \* ProposeRouteChange has moved the key off the committing group.
+    /\ \/ ~EnableCurrentFence
+       \/ \A k \in txnWriteSet[t] : OwnerAt(catalogVersion, k) = g
+    /\ tsCounter'               = tsCounter + 1
+    /\ txnState'                = [txnState               EXCEPT ![t] = "Committed"]
+    /\ txnCommitTs'             = [txnCommitTs            EXCEPT ![t] = tsCounter + 1]
+    /\ txnCommitGroup'          = [txnCommitGroup         EXCEPT ![t] = g]
+    /\ currentVersionAtCommit'  = [currentVersionAtCommit EXCEPT ![t] = catalogVersion]
     /\ UNCHANGED <<catalogVersion, routes, txnStartTs, txnObservedVer,
                    txnWriteSet, opCount>>
 
@@ -197,7 +222,7 @@ Abort(t) ==
     /\ txnState' = [txnState EXCEPT ![t] = "Aborted"]
     /\ UNCHANGED <<catalogVersion, routes, tsCounter, txnStartTs,
                    txnObservedVer, txnWriteSet, txnCommitTs, txnCommitGroup,
-                   opCount>>
+                   currentVersionAtCommit, opCount>>
 
 \* === NEXT ===
 Next ==
@@ -217,16 +242,17 @@ StateConstraint ==
 
 \* === TYPE INVARIANT ===
 TypeOK ==
-    /\ catalogVersion  \in 0..MaxVersions
-    /\ routes          \in [0..MaxVersions -> [Keys -> Groups]]
-    /\ tsCounter       \in 0..MaxTs
-    /\ txnState        \in [TxnIds -> States]
-    /\ txnStartTs      \in [TxnIds -> 0..MaxTs]
-    /\ txnObservedVer  \in [TxnIds -> 0..MaxVersions]
-    /\ txnWriteSet     \in [TxnIds -> SUBSET Keys]
-    /\ txnCommitTs     \in [TxnIds -> 0..MaxTs]
-    /\ txnCommitGroup  \in [TxnIds -> Groups \cup {NoGroup}]
-    /\ opCount         \in 0..MaxOps
+    /\ catalogVersion         \in 0..MaxVersions
+    /\ routes                 \in [0..MaxVersions -> [Keys -> Groups]]
+    /\ tsCounter              \in 0..MaxTs
+    /\ txnState               \in [TxnIds -> States]
+    /\ txnStartTs             \in [TxnIds -> 0..MaxTs]
+    /\ txnObservedVer         \in [TxnIds -> 0..MaxVersions]
+    /\ txnWriteSet            \in [TxnIds -> SUBSET Keys]
+    /\ txnCommitTs            \in [TxnIds -> 0..MaxTs]
+    /\ txnCommitGroup         \in [TxnIds -> Groups \cup {NoGroup}]
+    /\ currentVersionAtCommit \in [TxnIds -> 0..MaxVersions]
+    /\ opCount                \in 0..MaxOps
 
 \* === SAFETY INVARIANTS ===
 
@@ -264,6 +290,28 @@ Composed2_ReadAcrossSplitRange == TRUE
 Composed3_DistinctCommitTs ==
     \A t1, t2 \in CommittedTxns :
         t1 # t2 => txnCommitTs[t1] # txnCommitTs[t2]
+
+\* Composed-1a — current-version cross-version-read fence.  Strictly
+\* stronger than Composed-1: every committed write key must be owned
+\* by the committing group at the CURRENT catalog version observed by
+\* the FSM at apply time (currentVersionAtCommit[t]), not only at the
+\* version the txn pinned at BeginTxn (txnObservedVer[t]).
+\*
+\* This invariant captures the design doc §4.4 apply-time fence — the
+\* implementation-level guard that closes the codex P1 trace
+\* (observed-version check passes; ProposeRouteChange has moved the
+\* key off the committing group; future readers at the new version
+\* miss the write).  The Composed-1 spec predicate alone does NOT
+\* prevent this trace; Composed-1a is the spec-level witness for the
+\* implementation's additional fence.
+\*
+\* Gated by EnableCurrentFence in Commit: under the new
+\* MCComposed_currentfence_gap.cfg model TLC finds a 4-step
+\* counterexample where this invariant fails (the codex P1 trace).
+Composed1a_CommitToCurrentOwner ==
+    \A t \in CommittedTxns :
+        \A k \in txnWriteSet[t] :
+            OwnerAt(currentVersionAtCommit[t], k) = txnCommitGroup[t]
 
 \* === ACTION-LEVEL PROPERTIES ===
 

--- a/tla/composed/MCComposed.cfg
+++ b/tla/composed/MCComposed.cfg
@@ -13,12 +13,14 @@ CONSTANTS
     MaxOps = 4
     InitGroup = g1
     EnableSafety = TRUE
+    EnableCurrentFence = TRUE
 
 SYMMETRY Symmetry
 
 INVARIANTS
     TypeOK
     Composed1_CommitToOwningGroup
+    Composed1a_CommitToCurrentOwner
     Composed2_ReadAcrossSplitRange
     Composed3_DistinctCommitTs
 

--- a/tla/composed/MCComposed_currentfence_gap.cfg
+++ b/tla/composed/MCComposed_currentfence_gap.cfg
@@ -1,0 +1,55 @@
+\* TLC config: Composed-1a gap model — EnableCurrentFence = FALSE.
+\* The observed-version owner check (Composed-1, design doc §4.2(a))
+\* is still ON.  The apply-time current-version fence (Composed-1a,
+\* design doc §4.4) is OFF.
+\*
+\* This isolates the codex P1 trace surfaced on PR #870 — the case
+\* where Composed-1 alone is insufficient to prevent G1c:
+\*
+\*   BeginTxn(t)                -- txn observes catalogVersion = 0
+\*   WriteIntent(t, k1)         -- k1 owned by g1 at v=0
+\*   ProposeRouteChange(k1, g2) -- v=1, routes[1][k1] = g2
+\*   Commit(t, g1)              -- observed-check passes (routes[0][k1] = g1)
+\*                              -- current-check is OFF, so Commit fires
+\*                              -- Composed1a fails because at apply time
+\*                              --   currentVersionAtCommit[t] = 1 and
+\*                              --   routes[1][k1] = g2 # g1
+\*
+\* The make tla-check harness inverts the exit code for this config AND
+\* greps for the specific Composed-1a violation string, so any other
+\* failure mode (parse error, deadlock, JVM crash, different
+\* invariant) fails rather than being silently treated as the
+\* expected counterexample.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Keys = {k1, k2}
+    Groups = {g1, g2}
+    TxnIds = {t1, t2}
+    MaxVersions = 2
+    MaxTs = 4
+    MaxOps = 4
+    InitGroup = g1
+    EnableSafety = TRUE
+    EnableCurrentFence = FALSE
+
+SYMMETRY Symmetry
+
+INVARIANTS
+    TypeOK
+    Composed1_CommitToOwningGroup
+    Composed1a_CommitToCurrentOwner
+    Composed2_ReadAcrossSplitRange
+    Composed3_DistinctCommitTs
+
+PROPERTIES
+    Composed_CatalogMonotonic
+    Composed_TsMonotonic
+    Composed3_TsAction
+
+CONSTRAINT StateConstraint
+
+\* See MCComposed.cfg — quiescence is a valid end state, not a deadlock.
+CHECK_DEADLOCK
+    FALSE

--- a/tla/composed/MCComposed_gap.cfg
+++ b/tla/composed/MCComposed_gap.cfg
@@ -26,12 +26,19 @@ CONSTANTS
     MaxOps = 4
     InitGroup = g1
     EnableSafety = FALSE
+    \* Current-version fence stays ON so this gap targets specifically
+    \* the observed-version check (Composed-1); the canonical 4-step
+    \* counterexample below trips Composed1_CommitToOwningGroup before
+    \* Composed1a_CommitToCurrentOwner because the routes have already
+    \* moved when Commit fires.
+    EnableCurrentFence = TRUE
 
 SYMMETRY Symmetry
 
 INVARIANTS
     TypeOK
     Composed1_CommitToOwningGroup
+    Composed1a_CommitToCurrentOwner
     Composed2_ReadAcrossSplitRange
     Composed3_DistinctCommitTs
 

--- a/tla/composed/MCComposed_gap.cfg
+++ b/tla/composed/MCComposed_gap.cfg
@@ -27,10 +27,13 @@ CONSTANTS
     InitGroup = g1
     EnableSafety = FALSE
     \* Current-version fence stays ON so this gap targets specifically
-    \* the observed-version check (Composed-1); the canonical 4-step
-    \* counterexample below trips Composed1_CommitToOwningGroup before
-    \* Composed1a_CommitToCurrentOwner because the routes have already
-    \* moved when Commit fires.
+    \* the observed-version check (Composed-1).  Composed1a holds by
+    \* construction here because EnableCurrentFence = TRUE — the
+    \* current-version guard in Commit prevents any commit where the
+    \* current owner differs from the committing group, so the
+    \* Composed1a invariant cannot fail in this config (claude review
+    \* on PR #878 — clarifying why the canonical 4-step trace surfaces
+    \* Composed-1 specifically, not "Composed-1 before Composed-1a").
     EnableCurrentFence = TRUE
 
 SYMMETRY Symmetry


### PR DESCRIPTION
## Summary

#870 follow-up: extends the M5 Composed module so the design doc §4.4 apply-time cross-version-read fence is spec-checked by TLC. The first revision of `tla/composed` proved the spec-level Composed-1 predicate (commit goes to the owning group at the txn's observed catalog version) but — as codex P1 surfaced on PR #870 — that predicate alone is **not** sufficient to prevent the G1c trace where `ProposeRouteChange` moves a key after `WriteIntent`: observed-version check passes because `routes[v_obs][k]` still records the old owner, yet readers at `v_obs+1` route to the new owner and miss the write.

This PR adds the strictly stronger **Composed-1a** invariant:

```
Composed1a_CommitToCurrentOwner ==
  \A t \in CommittedTxns :
    \A k \in txnWriteSet[t] :
      OwnerAt(currentVersionAtCommit[t], k) = txnCommitGroup[t]
```

New state variable `currentVersionAtCommit[t]` records the catalog version the FSM observed at apply time (set on `Commit`). A new CONSTANT `EnableCurrentFence` gates the matching Commit-action guard so the implementation-level fence can be toggled independently of the spec-level `EnableSafety` guard.

## Three configurations now exercise the module

| Config | Toggles | Outcome |
|---|---|---|
| `MCComposed.cfg` | safety: ON, currentfence: ON | PASS |
| `MCComposed_gap.cfg` | safety: OFF, currentfence: ON | FAIL on `Composed1_CommitToOwningGroup` (canonical 4-step counterexample) |
| `MCComposed_currentfence_gap.cfg` (**new**) | safety: ON, currentfence: OFF | FAIL on `Composed1a_CommitToCurrentOwner` — **the codex P1 trace at depth 5** |

The codex P1 trace TLC found:

1. `BeginTxn(t1)` → `txnObservedVer[t1] = 0`
2. `WriteIntent(t1, k1)`
3. `ProposeRouteChange(k1, g2)` → `catalogVersion = 1`, `routes[1][k1] = g2`
4. `Commit(t1, g1)` — observed-version check passes (`routes[0][k1] = g1`); current-fence gate is OFF, so Commit fires
5. Invariant fails: `currentVersionAtCommit[t1] = 1`, `OwnerAt(1, k1) = g2 ≠ g1`

## Other changes

- `scripts/tla-check.sh` refactored from a single-gap-per-module to a list-of-gaps-per-module. Per-module entry point `gap_configs_for` returns `<cfg-stem>|<invariant-string>` lines, one per gap; modules with a single guard (HLC, OCC, MVCC, Routes) are unchanged.
- `tla/README.md` documents Composed-1a alongside Composed-1 in the module description and the invariant table.

## Verification

```
$ make tla-check
HLC      safe pass + HLC-4 gap fail
OCC      safe pass + OCC-1 gap fail
MVCC     safe pass + MVCC-4 gap fail
Routes   safe pass + Routes-4 gap fail
Composed safe pass + Composed-1 gap fail + Composed-1a currentfence_gap fail (depth 5)
tla-check: all model-check outcomes match the design contract.
```

11 outcomes total (5 safe PASS + 6 gap FAIL), including the new codex P1 trace.

## Self-review (5 lenses)

1. **Data loss** — out of scope (spec-only).
2. **Concurrency** — Composed-1a captures the concurrency seam between OCC commit and Routes route mutation that Composed-1 alone missed; the gap counterexample IS an interleaving.
3. **Performance** — TLC state space grew from 1,684 → 5,170 distinct states on the safe config (still ~2s wall-clock), well under §8.1's <10 min target.
4. **Data consistency** — Composed-1a is strictly stronger than Composed-1. Spec → impl correspondence: §4.4 of the design doc.
5. **Test coverage** — `make tla-check` runs the new gap config automatically; no new Go tests (spec-only PR).

## Test plan

- [x] `make tla-check` PASS for all 11 outcomes
- [x] codex P1 counterexample at depth 5 reproduced on `MCComposed_currentfence_gap.cfg`
- [ ] Reviewer cross-checks `Composed1a` against §4.4 of the design doc
- [ ] Reviewer confirms `EnableCurrentFence = TRUE` on the safe config preserves the existing `MCComposed.cfg` outcome (yes — TLC PASS verified locally)

## Resolves

The "extending `Composed.tla` to model `currentVersion`" follow-up flagged in §5 of `docs/design/2026_05_29_proposed_composed1_cross_group_commit_guard.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a stronger apply-time ownership fence safety property that verifies committed writes' ownership against the current catalog version at commit time.

* **Testing**
  * Enhanced the verification framework to support multiple gap-check configurations per module, enabling more comprehensive safety verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->