### PR TITLE
monitoring(hlc): expose ceiling/skew gauges + NextFenced rejection counter

### DIFF
--- a/kv/hlc.go
+++ b/kv/hlc.go
@@ -71,6 +71,14 @@ type HLC struct {
 	// Next() uses max(now, physicalCeiling) so that a new leader always starts
 	// issuing timestamps above the previous leader's committed window.
 	physicalCeiling atomic.Int64
+	// nextFencedRejections counts the number of NextFenced() calls that
+	// returned ErrCeilingExpired (HLC-4 (iii) fence fired). Exposed via
+	// NextFencedRejections() so the monitoring layer can export it as a
+	// Prometheus counter without coupling the kv package to a metric type.
+	// A non-zero value here means the leader's lease renewal stopped long
+	// enough for wall_now to catch up to physicalCeiling — operators should
+	// alert on its rate.
+	nextFencedRejections atomic.Uint64
 }
 
 func nonNegativeUint64(v int64) uint64 {
@@ -155,7 +163,9 @@ func (h *HLC) nextLocked(fence bool) (uint64, error) {
 				// HLC-4 precondition (iii): ceiling has expired.  Fail
 				// closed rather than issue a timestamp that could collide
 				// with a subsequent leader's window after renewal catches
-				// up.
+				// up.  Increment the counter so the monitoring layer can
+				// alert on the rate (see NextFencedRejections).
+				h.nextFencedRejections.Add(1)
 				return 0, errors.WithStack(ErrCeilingExpired)
 			}
 			if nowMs < ceiling {
@@ -225,4 +235,20 @@ func (h *HLC) SetPhysicalCeiling(ms int64) {
 // milliseconds. Returns 0 if no ceiling has been established yet.
 func (h *HLC) PhysicalCeiling() int64 {
 	return h.physicalCeiling.Load()
+}
+
+// NextFencedRejections returns the cumulative count of NextFenced() calls
+// that returned ErrCeilingExpired since process start.  The monitoring
+// layer reads this on a fixed interval and exports it as a Prometheus
+// counter so operators can alert on the rate.
+//
+// A non-zero value here means the HLC-4 (i) bounded-skew assumption
+// (`MaxClockSkewMs < HlcPhysicalWindowMs` — see
+// docs/design/2026_05_28_partial_tla_safety_spec.md §5.1) has at some
+// point been violated by enough margin that wall_now caught up to
+// physicalCeiling and the fence fired — typically because the leader's
+// lease renewal stopped (network partition, GC pause, …) for longer than
+// `hlcPhysicalWindowMs`.
+func (h *HLC) NextFencedRejections() uint64 {
+	return h.nextFencedRejections.Load()
 }

--- a/kv/hlc_test.go
+++ b/kv/hlc_test.go
@@ -251,3 +251,41 @@ func TestHLCNextBypassesFence(t *testing.T) {
 		_ = h.Next()
 	})
 }
+
+// TestHLCNextFencedRejectionsCounter verifies the rejection counter
+// (exposed via NextFencedRejections) increments exactly when
+// NextFenced returns ErrCeilingExpired. The monitoring layer reads
+// this counter and exports it as a Prometheus counter; if the
+// increment did not happen in lockstep with the error return, the
+// metric would silently underreport fence trips.
+func TestHLCNextFencedRejectionsCounter(t *testing.T) {
+	t.Parallel()
+
+	h := NewHLC()
+	require.Equal(t, uint64(0), h.NextFencedRejections(),
+		"freshly constructed HLC must have a zero rejection count")
+
+	// No ceiling set yet: the fence is soft, NextFenced succeeds,
+	// the counter does NOT advance.
+	_, err := h.NextFenced()
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), h.NextFencedRejections(),
+		"pre-bootstrap NextFenced must not bump the rejection counter")
+
+	// Stale ceiling: every NextFenced call must return ErrCeilingExpired
+	// AND advance the counter.
+	h.SetPhysicalCeiling(time.Now().UnixMilli() - 10_000)
+	for i := uint64(1); i <= 3; i++ {
+		_, err := h.NextFenced()
+		require.ErrorIs(t, err, ErrCeilingExpired)
+		require.Equal(t, i, h.NextFencedRejections(),
+			"counter must advance by 1 on every ErrCeilingExpired return")
+	}
+
+	// Non-fenced Next never touches the counter even with an expired
+	// ceiling (Next bypasses the fence by design).
+	priorCount := h.NextFencedRejections()
+	_ = h.Next()
+	require.Equal(t, priorCount, h.NextFencedRejections(),
+		"plain Next() must not bump the NextFenced rejection counter")
+}

--- a/main.go
+++ b/main.go
@@ -465,7 +465,7 @@ func run() error {
 		adapter.WithDistributionCoordinator(coordinate),
 		adapter.WithDistributionActiveTimestampTracker(readTracker),
 	)
-	startMonitoringCollectors(runCtx, metricsRegistry, runtimes)
+	startMonitoringCollectors(runCtx, metricsRegistry, runtimes, clock)
 	compactor := kv.NewFSMCompactor(
 		fsmCompactionRuntimes(runtimes),
 		kv.WithFSMCompactorActiveTimestampTracker(readTracker),
@@ -1375,7 +1375,7 @@ func startMemoryWatchdog(ctx context.Context, eg *errgroup.Group, cancel context
 // on top of the running raft runtimes. Kept separate from run() so
 // the latter stays under the cyclop complexity budget and so new
 // collectors can be added without widening run() further.
-func startMonitoringCollectors(ctx context.Context, reg *monitoring.Registry, runtimes []*raftGroupRuntime) {
+func startMonitoringCollectors(ctx context.Context, reg *monitoring.Registry, runtimes []*raftGroupRuntime, clock *kv.HLC) {
 	reg.RaftObserver().Start(ctx, raftMonitorRuntimes(runtimes), raftMetricsObserveInterval)
 	if collector := reg.DispatchCollector(); collector != nil {
 		collector.Start(ctx, dispatchMonitorSources(runtimes), raftMetricsObserveInterval)
@@ -1385,6 +1385,9 @@ func startMonitoringCollectors(ctx context.Context, reg *monitoring.Registry, ru
 	}
 	if collector := reg.WriteConflictCollector(); collector != nil {
 		collector.Start(ctx, writeConflictMonitorSources(runtimes), raftMetricsObserveInterval)
+	}
+	if obs := reg.HLCObserver(); obs != nil && clock != nil {
+		obs.Start(ctx, clock, raftMetricsObserveInterval)
 	}
 }
 

--- a/monitoring/grafana/dashboards/elastickv-raft-status.json
+++ b/monitoring/grafana/dashboards/elastickv-raft-status.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "Raft control-plane status for elastickv: leader, membership, node state, index drift, backlog, and leader contact.",
+  "description": "Raft control-plane status for elastickv: leader, membership, node state, index drift, backlog, leader contact, and HLC lease (physical-ceiling fence health).",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -1068,6 +1068,293 @@
       ],
       "title": "Failed Proposals (15m)",
       "type": "stat"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "Worst wall_now - physicalCeiling across nodes. Negative is healthy (ceiling sits in the future). Alert on > -0.5s for HLC-4 (i) approaching violation, > 0s for the (iii) fence having tripped on at least one node.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": -0.5
+              },
+              {
+                "color": "red",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 44
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "max(elastickv_hlc_wall_skew_seconds{job=\"elastickv\",node_id=~\"$node_id\"})",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "Worst Wall Skew",
+      "type": "stat"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "Cumulative HLC.NextFenced() rejections in the last 24h, summed across nodes. Any non-zero value means the HLC-4 (iii) fence actually fired and refused a persistence ts allocation — operators should investigate the leader's lease renewer.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 44
+      },
+      "id": 17,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "sum(increase(elastickv_hlc_next_fenced_rejections_total{job=\"elastickv\",node_id=~\"$node_id\"}[24h]))",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "NextFenced Rejections (24h)",
+      "type": "stat"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "Maximum age (now - physicalCeiling) across nodes after the first HLC lease has landed. Stagnant value ⇒ the leader's lease renewer has stopped landing entries; once it crosses 0 the fence trips on every node that observed it. Pre-bootstrap nodes (ceiling=0) are excluded.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 44
+      },
+      "id": 18,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "max(time() - elastickv_hlc_physical_ceiling_seconds{job=\"elastickv\",node_id=~\"$node_id\"} and elastickv_hlc_physical_ceiling_seconds{job=\"elastickv\",node_id=~\"$node_id\"} > 0)",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "title": "Worst Ceiling Age",
+      "type": "stat"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "wall_now minus physicalCeiling per node. Negative = healthy (ceiling sits in the future). Zero or positive = the (iii) fence rejection boundary has been reached. Pre-bootstrap (ceiling=0) is held at 0 by the observer to avoid a spurious ~55-year skew on cold start.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "auto",
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": -0.5
+              },
+              {
+                "color": "red",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 48
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "elastickv_hlc_wall_skew_seconds{job=\"elastickv\",node_id=~\"$node_id\"}",
+          "legendFormat": "{{node_id}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Wall Skew by Node",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "rate(NextFenced ErrCeilingExpired) per node over a 5-minute window. Non-zero rate = HLC-4 (iii) fence actively rejecting persistence ts allocations on that node.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisPlacement": "auto",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "auto"
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 48
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "$datasource",
+          "editorMode": "code",
+          "expr": "rate(elastickv_hlc_next_fenced_rejections_total{job=\"elastickv\",node_id=~\"$node_id\"}[5m])",
+          "legendFormat": "{{node_id}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "NextFenced Rejection Rate by Node",
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",
@@ -1075,7 +1362,8 @@
   "tags": [
     "elastickv",
     "raft",
-    "control-plane"
+    "control-plane",
+    "hlc"
   ],
   "templating": {
     "list": [
@@ -1154,5 +1442,5 @@
   "timezone": "browser",
   "title": "Elastickv Raft Status",
   "uid": "elastickv-raft-status",
-  "version": 2
+  "version": 3
 }

--- a/monitoring/hlc.go
+++ b/monitoring/hlc.go
@@ -1,0 +1,160 @@
+package monitoring
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// hlcMsPerSecond converts the HLC's millisecond-granular ceiling and
+// wall samples into the seconds-granular gauge values Prometheus
+// convention prefers.  Named so the divisions in observeOnce read
+// as unit conversions rather than magic numbers.
+const hlcMsPerSecond = 1000.0
+
+// HLCSource is the surface monitoring needs from the kv-layer HLC.
+// Defining it here (rather than importing *kv.HLC directly) keeps the
+// monitoring package decoupled from the kv module and lets a test or
+// shim supply its own snapshot.
+//
+// PhysicalCeiling returns the Raft-agreed physical ceiling in Unix
+// milliseconds (zero before bootstrap).  NextFencedRejections is a
+// cumulative counter incremented inside HLC.NextFenced() whenever it
+// returns ErrCeilingExpired; the observer reads the difference between
+// successive ticks so Prometheus sees a counter, not a gauge.
+type HLCSource interface {
+	PhysicalCeiling() int64
+	NextFencedRejections() uint64
+}
+
+// HLCMetrics exposes the HLC-4 (i) bounded-skew assumption and the
+// HLC-4 (iii) fence-trip rate as Prometheus series so operators can
+// alert before the safety property is exercised in earnest.
+//
+// The two gauges together let operators see *why* a NextFenced
+// rejection happened (was the ceiling stale? was the wall clock
+// ahead?), and the counter captures the load-bearing fact:
+// NextFenced refused to issue a persistence ts.
+type HLCMetrics struct {
+	// physicalCeilingSeconds is the Raft-agreed physical ceiling,
+	// expressed as a Unix timestamp in seconds.  A leader's
+	// ceiling should sit ~hlcPhysicalWindowMs ms (3 s default)
+	// ahead of wall_now; a stagnant value means the lease
+	// renewer has stopped landing entries.
+	physicalCeilingSeconds prometheus.Gauge
+	// wallSkewSeconds is wall_now minus physicalCeiling, in
+	// seconds.  Negative means the ceiling is in the future
+	// (healthy, with the leader's renewer keeping up).  Zero or
+	// positive means the ceiling has expired locally —
+	// NextFenced is at-or-past the rejection boundary.  Alert
+	// on wallSkewSeconds > -0.5 (half of hlcPhysicalWindowMs)
+	// to catch a renewal stall before the fence trips.
+	wallSkewSeconds prometheus.Gauge
+	// nextFencedRejectionsTotal is the cumulative number of
+	// NextFenced() calls that returned ErrCeilingExpired.  A
+	// non-zero rate is the HLC-4 (iii) fence actually firing —
+	// every increment means at least one persistence-grade
+	// allocation was refused.
+	nextFencedRejectionsTotal prometheus.Counter
+}
+
+func newHLCMetrics(registerer prometheus.Registerer) *HLCMetrics {
+	m := &HLCMetrics{
+		physicalCeilingSeconds: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "elastickv_hlc_physical_ceiling_seconds",
+			Help: "Raft-agreed HLC physical ceiling, expressed as a Unix timestamp in seconds. Zero before bootstrap.",
+		}),
+		wallSkewSeconds: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "elastickv_hlc_wall_skew_seconds",
+			Help: "wall_now - physicalCeiling, in seconds. Negative is healthy (ceiling is in the future); zero or positive means NextFenced is at-or-past the rejection boundary. Alert on > -0.5 to catch renewal stalls before the HLC-4 (iii) fence trips.",
+		}),
+		nextFencedRejectionsTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "elastickv_hlc_next_fenced_rejections_total",
+			Help: "Cumulative number of HLC.NextFenced() calls that returned ErrCeilingExpired (HLC-4 (iii) fence fired).",
+		}),
+	}
+	if registerer != nil {
+		registerer.MustRegister(m.physicalCeilingSeconds)
+		registerer.MustRegister(m.wallSkewSeconds)
+		registerer.MustRegister(m.nextFencedRejectionsTotal)
+	}
+	return m
+}
+
+// HLCObserver polls an HLCSource on a fixed interval and updates the
+// matching HLCMetrics.  Created via Registry.HLCObserver(); started
+// by main.go alongside the other observers once the HLC is wired.
+type HLCObserver struct {
+	metrics *HLCMetrics
+	mu      sync.Mutex
+	// lastRejections is the previous-tick value of
+	// HLCSource.NextFencedRejections(); we report the delta as a
+	// counter increment so Prometheus sees monotonic rate
+	// arithmetic even though the source already snapshots a
+	// cumulative number.
+	lastRejections uint64
+}
+
+func newHLCObserver(metrics *HLCMetrics) *HLCObserver {
+	return &HLCObserver{metrics: metrics}
+}
+
+// Start polls the source on every tick until ctx is cancelled.  An
+// interval of zero falls back to defaultObserveInterval (5s) to match
+// the Raft observer.  Safe to call with a nil receiver / nil source —
+// both shapes silently no-op so test fixtures that omit the registry
+// do not need conditional wiring.
+func (o *HLCObserver) Start(ctx context.Context, source HLCSource, interval time.Duration) {
+	if o == nil || source == nil {
+		return
+	}
+	if interval <= 0 {
+		interval = defaultObserveInterval
+	}
+	o.observeOnce(source)
+	ticker := time.NewTicker(interval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				o.observeOnce(source)
+			}
+		}
+	}()
+}
+
+// ObserveOnce captures a single snapshot.  Exposed for tests.
+func (o *HLCObserver) ObserveOnce(source HLCSource) {
+	if o == nil {
+		return
+	}
+	o.observeOnce(source)
+}
+
+func (o *HLCObserver) observeOnce(source HLCSource) {
+	if o == nil || o.metrics == nil || source == nil {
+		return
+	}
+	ceilingMs := source.PhysicalCeiling()
+	nowMs := time.Now().UnixMilli()
+
+	o.metrics.physicalCeilingSeconds.Set(float64(ceilingMs) / hlcMsPerSecond)
+	o.metrics.wallSkewSeconds.Set(float64(nowMs-ceilingMs) / hlcMsPerSecond)
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	rejections := source.NextFencedRejections()
+	if rejections > o.lastRejections {
+		delta := rejections - o.lastRejections
+		// Counter increments only — float64 conversion is safe
+		// because rejections is bounded by the lifetime of the
+		// process and a single tick's delta is small in practice.
+		o.metrics.nextFencedRejectionsTotal.Add(float64(delta))
+		o.lastRejections = rejections
+	}
+}

--- a/monitoring/hlc.go
+++ b/monitoring/hlc.go
@@ -144,7 +144,20 @@ func (o *HLCObserver) observeOnce(source HLCSource) {
 	nowMs := time.Now().UnixMilli()
 
 	o.metrics.physicalCeilingSeconds.Set(float64(ceilingMs) / hlcMsPerSecond)
-	o.metrics.wallSkewSeconds.Set(float64(nowMs-ceilingMs) / hlcMsPerSecond)
+	// Pre-bootstrap (ceilingMs == 0) the skew computation would produce
+	// nowMs / 1000 ≈ 1.75e9 seconds (~55 years), which would
+	// immediately trip the recommended `wallSkewSeconds > -0.5` alert
+	// on every cold-start node until the first HLC lease lands.  Hold
+	// the gauge at 0 in that case — the physicalCeilingSeconds gauge
+	// already exposes the pre-bootstrap state (also 0), so an alert
+	// of the form
+	//   `wallSkewSeconds > -0.5 AND physicalCeilingSeconds > 0`
+	// behaves correctly.  (Claude review medium on PR #879.)
+	if ceilingMs > 0 {
+		o.metrics.wallSkewSeconds.Set(float64(nowMs-ceilingMs) / hlcMsPerSecond)
+	} else {
+		o.metrics.wallSkewSeconds.Set(0)
+	}
 
 	o.mu.Lock()
 	defer o.mu.Unlock()

--- a/monitoring/hlc_test.go
+++ b/monitoring/hlc_test.go
@@ -99,3 +99,41 @@ func TestHLCObserver_NilSourceIsNoop(t *testing.T) {
 		obs.ObserveOnce(nil)
 	})
 }
+
+// TestHLCObserveOnce_PreBootstrapHoldsSkewAtZero verifies that the
+// skew gauge stays at 0 when PhysicalCeiling() == 0 (pre-bootstrap,
+// before the first HLC lease lands).  Without this guard the
+// observer would publish wallSkewSeconds ≈ 1.75e9 (~55 years) and
+// trip the recommended `wallSkewSeconds > -0.5` alert on every cold
+// start until the first lease propagates.  Regression for the medium
+// finding on PR #879.
+func TestHLCObserveOnce_PreBootstrapHoldsSkewAtZero(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	metrics := newHLCMetrics(reg)
+	obs := newHLCObserver(metrics)
+
+	obs.ObserveOnce(&fakeHLCSource{ceiling: 0})
+
+	require.InDelta(t, 0.0, testutil.ToFloat64(metrics.wallSkewSeconds), 0.0001,
+		"pre-bootstrap (ceiling == 0) must hold wallSkewSeconds at 0; otherwise the gauge reports a 55-year skew and trips the recommended alert on every cold start")
+	require.InDelta(t, 0.0, testutil.ToFloat64(metrics.physicalCeilingSeconds), 0.0001)
+}
+
+// TestRegistryHLCObserverReturnsSameInstance is the regression for
+// the low finding on PR #879: HLCObserver() previously returned a
+// fresh observer on every call, which would reset lastRejections and
+// double-count rejections against the cumulative Prometheus counter
+// if a caller pulled the observer twice.  After the fix the observer
+// is constructed in NewRegistry and returned by reference.
+func TestRegistryHLCObserverReturnsSameInstance(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry("test-node", "127.0.0.1:0")
+	first := r.HLCObserver()
+	second := r.HLCObserver()
+	require.NotNil(t, first)
+	require.Same(t, first, second,
+		"HLCObserver() must return the same observer instance per registry so lastRejections delta state survives multiple pulls")
+}

--- a/monitoring/hlc_test.go
+++ b/monitoring/hlc_test.go
@@ -1,0 +1,101 @@
+package monitoring
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeHLCSource lets the HLCObserver tests fix PhysicalCeiling and
+// NextFencedRejections to specific values without spinning up a real
+// HLC or wiring it to a Raft group.  Mirrors the test-shim pattern
+// in monitoring/raft_test.go.
+type fakeHLCSource struct {
+	ceiling    int64
+	rejections uint64
+}
+
+func (f *fakeHLCSource) PhysicalCeiling() int64        { return f.ceiling }
+func (f *fakeHLCSource) NextFencedRejections() uint64  { return f.rejections }
+
+func TestHLCObserveOnce_NegativeSkewIsHealthy(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	metrics := newHLCMetrics(reg)
+	obs := newHLCObserver(metrics)
+
+	// Ceiling 5 s in the future → skew is negative.
+	future := time.Now().Add(5 * time.Second).UnixMilli()
+	obs.ObserveOnce(&fakeHLCSource{ceiling: future})
+
+	require.Less(t, testutil.ToFloat64(metrics.wallSkewSeconds), 0.0,
+		"a future ceiling must produce a negative wallSkewSeconds gauge — that's the healthy case")
+	require.Greater(t, testutil.ToFloat64(metrics.physicalCeilingSeconds), 0.0)
+}
+
+func TestHLCObserveOnce_PositiveSkewMeansExpired(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	metrics := newHLCMetrics(reg)
+	obs := newHLCObserver(metrics)
+
+	// Ceiling 5 s in the past → skew is positive, meaning the fence
+	// would refuse to issue.
+	past := time.Now().Add(-5 * time.Second).UnixMilli()
+	obs.ObserveOnce(&fakeHLCSource{ceiling: past})
+
+	require.Greater(t, testutil.ToFloat64(metrics.wallSkewSeconds), 0.0,
+		"a past ceiling must produce a positive wallSkewSeconds gauge — that's the alerting case")
+}
+
+func TestHLCObserveOnce_RejectionDeltasReportAsCounterIncrements(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	metrics := newHLCMetrics(reg)
+	obs := newHLCObserver(metrics)
+
+	src := &fakeHLCSource{ceiling: time.Now().UnixMilli() + 1000}
+
+	// First tick: source reports 5 rejections; counter goes from 0 → 5.
+	src.rejections = 5
+	obs.ObserveOnce(src)
+	require.InDelta(t, 5.0, testutil.ToFloat64(metrics.nextFencedRejectionsTotal), 0.0001)
+
+	// Second tick: source reports 8; counter should be 8 total
+	// (delta +3 added to the existing 5), not double-counted as 13.
+	src.rejections = 8
+	obs.ObserveOnce(src)
+	require.InDelta(t, 8.0, testutil.ToFloat64(metrics.nextFencedRejectionsTotal), 0.0001)
+
+	// Source went backwards (e.g. process restart with shared registry —
+	// not expected in production but defensive). Counter must NOT
+	// decrement; it just freezes until the source catches up.
+	src.rejections = 2
+	obs.ObserveOnce(src)
+	require.InDelta(t, 8.0, testutil.ToFloat64(metrics.nextFencedRejectionsTotal), 0.0001)
+}
+
+func TestHLCObserver_NilReceiverIsNoop(t *testing.T) {
+	t.Parallel()
+
+	var obs *HLCObserver
+	require.NotPanics(t, func() {
+		obs.ObserveOnce(&fakeHLCSource{})
+	})
+}
+
+func TestHLCObserver_NilSourceIsNoop(t *testing.T) {
+	t.Parallel()
+
+	reg := prometheus.NewRegistry()
+	obs := newHLCObserver(newHLCMetrics(reg))
+	require.NotPanics(t, func() {
+		obs.ObserveOnce(nil)
+	})
+}

--- a/monitoring/registry.go
+++ b/monitoring/registry.go
@@ -23,6 +23,7 @@ type Registry struct {
 	writeConflict *WriteConflictMetrics
 	sqs           *SQSMetrics
 	sqsObserver   *SQSObserver
+	hlc           *HLCMetrics
 }
 
 // NewRegistry builds a registry with constant labels that identify the local node.
@@ -47,6 +48,7 @@ func NewRegistry(nodeID string, nodeAddress string) *Registry {
 	r.writeConflict = newWriteConflictMetrics(registerer)
 	r.sqs = newSQSMetrics(registerer)
 	r.sqsObserver = newSQSObserver(r.sqs)
+	r.hlc = newHLCMetrics(registerer)
 	return r
 }
 
@@ -209,4 +211,17 @@ func (r *Registry) WriteConflictCollector() *WriteConflictCollector {
 		return nil
 	}
 	return newWriteConflictCollector(r.writeConflict)
+}
+
+// HLCObserver returns the HLC physical-ceiling + fence-rejection
+// observer backed by this registry. Same shape as RaftObserver /
+// SQSObserver: callers pull it via the registry, then drive
+// Start(ctx, source, interval) from main.go once the kv layer's
+// HLC is constructed. Returns nil if r is nil so test fixtures
+// can drop the observer without conditional wiring.
+func (r *Registry) HLCObserver() *HLCObserver {
+	if r == nil || r.hlc == nil {
+		return nil
+	}
+	return newHLCObserver(r.hlc)
 }

--- a/monitoring/registry.go
+++ b/monitoring/registry.go
@@ -24,6 +24,7 @@ type Registry struct {
 	sqs           *SQSMetrics
 	sqsObserver   *SQSObserver
 	hlc           *HLCMetrics
+	hlcObserver   *HLCObserver
 }
 
 // NewRegistry builds a registry with constant labels that identify the local node.
@@ -49,6 +50,7 @@ func NewRegistry(nodeID string, nodeAddress string) *Registry {
 	r.sqs = newSQSMetrics(registerer)
 	r.sqsObserver = newSQSObserver(r.sqs)
 	r.hlc = newHLCMetrics(registerer)
+	r.hlcObserver = newHLCObserver(r.hlc)
 	return r
 }
 
@@ -214,14 +216,17 @@ func (r *Registry) WriteConflictCollector() *WriteConflictCollector {
 }
 
 // HLCObserver returns the HLC physical-ceiling + fence-rejection
-// observer backed by this registry. Same shape as RaftObserver /
-// SQSObserver: callers pull it via the registry, then drive
-// Start(ctx, source, interval) from main.go once the kv layer's
-// HLC is constructed. Returns nil if r is nil so test fixtures
+// observer backed by this registry. Same shape as SQSObserver: a
+// single observer is constructed inside NewRegistry and returned by
+// reference here, so callers that pull it more than once observe
+// the same lastRejections delta state (returning a fresh observer
+// each call would reset lastRejections and risk double-counting
+// rejections against the cumulative Prometheus counter — claude
+// review on PR #879). Returns nil if r is nil so test fixtures
 // can drop the observer without conditional wiring.
 func (r *Registry) HLCObserver() *HLCObserver {
-	if r == nil || r.hlc == nil {
+	if r == nil || r.hlcObserver == nil {
 		return nil
 	}
-	return newHLCObserver(r.hlc)
+	return r.hlcObserver
 }


### PR DESCRIPTION
## Summary

Exposes the HLC-4 (i) bounded-skew assumption and the HLC-4 (iii) ceiling fence as Prometheus series so operators can observe / alert on them before clients start seeing `ErrCeilingExpired`.

Three new series under the existing `elastickv_*` namespace:

| Series | Type | Use |
|---|---|---|
| `elastickv_hlc_physical_ceiling_seconds` | gauge | Raft-agreed physical ceiling as a Unix-seconds timestamp. Stagnant value ⇒ lease renewer stopped landing entries. |
| `elastickv_hlc_wall_skew_seconds` | gauge | `wall_now − physicalCeiling` in seconds. Negative is healthy (ceiling in the future); ≥ 0 means `NextFenced` is at-or-past the rejection boundary. Alert on `> -0.5` (half of the default `hlcPhysicalWindowMs = 3 s`) to catch a renewal stall before the fence trips. |
| `elastickv_hlc_next_fenced_rejections_total` | counter | Cumulative number of `NextFenced` calls that returned `ErrCeilingExpired`. Non-zero rate ⇒ (iii) fence actually fired. |

## Wiring

- `kv/hlc.go` — adds a `nextFencedRejections atomic.Uint64` to the `HLC` struct, incremented inside `NextFenced` whenever it returns `ErrCeilingExpired`, plus a `NextFencedRejections() uint64` accessor. **No new prometheus dependency on the kv package** — monitoring reads through the new `HLCSource` interface (the `HLC` struct satisfies it).
- `monitoring/hlc.go` — `HLCMetrics` (the three series), `HLCObserver` (ticker on the standard `raftMetricsObserveInterval`), and the `HLCSource` interface.
- `monitoring/registry.go` — wires `HLCMetrics` into `NewRegistry` and exposes `HLCObserver()` alongside the existing observer surface.
- `main.go::startMonitoringCollectors` — now takes the shared `*kv.HLC` and starts the observer.

## Spec linkage

`docs/design/2026_05_28_partial_tla_safety_spec.md` §5.1 HLC-4 (i) bounded-skew ASSUME + (iii) ceiling fence. Operators can now build Prometheus alerts:

```
# Alert before the (i) assumption is violated:
elastickv_hlc_wall_skew_seconds > -0.5

# Alert when the (iii) fence actually fires:
rate(elastickv_hlc_next_fenced_rejections_total[5m]) > 0
```

## Self-review (5 lenses)

1. **Data loss** — the counter only ever advances on a genuine `ErrCeilingExpired`; the gauges are derived state and cannot mask one. No new write path.
2. **Concurrency** — `atomic.Uint64` on the kv side; `sync.Mutex` on the observer for `lastRejections` delta arithmetic. No new lock ordering.
3. **Performance** — one atomic add per `ErrCeilingExpired` (already an error-return path, not the hot path); three Set/Add ops per tick. No label vectors, bounded cardinality.
4. **Data consistency** — the counter is the spec-level (iii) fence-trip count, exposed in lockstep with the spec contract. Skew is the correct per-node projection of the (i) precondition.
5. **Test coverage** — 6 new unit tests across kv + monitoring; existing fence tests unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go test -race -count=1 ./kv ./monitoring` — 10.3s + 2.1s, pass
- [x] `make lint` — 0 issues
- [ ] Confirm `elastickv_hlc_*` series appear in the Prometheus scrape on a running cluster
- [ ] (Optional) add Grafana dashboard panels — separate PR
