### PR TITLE
feat(encryption): Stage 8a implementation — snapshot header v2 + ReadSnapshotHeader API + no-downgrade latch

### DIFF
--- a/kv/fsm.go
+++ b/kv/fsm.go
@@ -1,6 +1,7 @@
 package kv
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/binary"
@@ -50,6 +51,19 @@ type kvFSM struct {
 	// write", preserving Stage 6A behavior for backends that did
 	// not opt in).
 	pendingApplyIdx uint64
+	// cutoverSource provides the writer-side view of the Phase-2
+	// envelope cutover index for snapshot v1/v2 selection (Stage
+	// 8a §3.3). nil = always v1 output.
+	cutoverSource CutoverSource
+	// snapLatch enforces the §3.3 no-downgrade invariant: once a
+	// non-zero cutover is observed, all subsequent snapshots from
+	// this FSM emit v2 even if the sidecar later reads 0.
+	snapLatch noDowngradeLatch
+	// restoredCutover is the Stage 8a §3.4 snapshot-to-applier
+	// handoff: Restore stores the v2 cutover here for Stage 6E's
+	// apply-hook to consume. Stays 0 for v1 restores and headerless
+	// legacy paths (matches the pre-Phase-2 posture exactly).
+	restoredCutover uint64
 }
 
 // SetApplyIndex implements raftengine.ApplyIndexAware. The engine
@@ -81,6 +95,16 @@ func WithEncryption(applier EncryptionApplier) FSMOption {
 	}
 }
 
+// WithCutoverSource installs the Stage 8a §3.3 writer-side view of the
+// Phase-2 envelope cutover index. The FSM consults it once per Snapshot
+// call to decide v1 vs v2 layout. Pass nil (or omit the option) to keep
+// the pre-8a posture where every snapshot is v1.
+func WithCutoverSource(src CutoverSource) FSMOption {
+	return func(f *kvFSM) {
+		f.cutoverSource = src
+	}
+}
+
 // NewKvFSMWithHLC creates a KV FSM that updates hlc.physicalCeiling whenever
 // a HLC lease entry is applied. The caller must pass the same *HLC instance to
 // the coordinator so both sides share the agreed physical ceiling.
@@ -99,6 +123,7 @@ func NewKvFSMWithHLC(store store.MVCCStore, hlc *HLC, opts ...FSMOption) FSM {
 	for _, opt := range opts {
 		opt(f)
 	}
+	f.snapLatch.log = f.log
 	return f
 }
 
@@ -351,36 +376,47 @@ func (f *kvFSM) Snapshot() (raftengine.Snapshot, error) {
 		return nil, errors.WithStack(err)
 	}
 
+	cutover := uint64(0)
+	if f.cutoverSource != nil {
+		cutover = f.cutoverSource.RaftEnvelopeCutoverIndex()
+	}
+	emitted := f.snapLatch.observe(cutover)
+	useV2 := emitted != 0 || f.snapLatch.latched()
+
 	return &kvFSMSnapshot{
 		snapshot:  snapshot,
 		ceilingMs: hlcCeilingFromHLC(f.hlc),
+		cutover:   emitted,
+		useV2:     useV2,
 	}, nil
 }
 
 func (f *kvFSM) Restore(r io.Reader) error {
-	// Read the potential 16-byte header (magic + ceiling ms).
-	var hdr [hlcSnapshotHeaderLen]byte
-	n, err := io.ReadFull(r, hdr[:])
+	// Stage 8a §3.2: the bufio.Reader is owned by the caller (us) and
+	// MUST be passed unchanged to the inner-store path on every branch
+	// — buffered bytes can sit between the header consumption and the
+	// inner-store read; switching readers silently loses them.
+	br := bufio.NewReader(r)
+	ceilingU, cutover, err := ReadSnapshotHeader(br)
 	if err != nil {
-		if err == io.EOF || err == io.ErrUnexpectedEOF {
-			// Small (or empty) old-format snapshot: fewer than hlcSnapshotHeaderLen
-			// bytes were available. Treat the partial read as legacy store data.
-			return errors.WithStack(f.store.Restore(io.NopCloser(io.MultiReader(bytes.NewReader(hdr[:n]), r))))
-		}
 		return errors.WithStack(err)
 	}
-
-	if bytes.Equal(hdr[:8], hlcSnapshotMagic[:]) {
-		// New format: restore ceiling, then restore store from remaining bytes.
-		ceilingMs := int64(binary.BigEndian.Uint64(hdr[8:])) //nolint:gosec // ceiling is a Unix ms timestamp encoded as uint64
-		if f.hlc != nil && ceilingMs > 0 {
-			f.hlc.SetPhysicalCeiling(ceilingMs)
-		}
-		return errors.WithStack(f.store.Restore(io.NopCloser(r)))
+	if f.hlc != nil && ceilingU > 0 {
+		f.hlc.SetPhysicalCeiling(int64(ceilingU)) //nolint:gosec // ceiling is a Unix ms timestamp encoded as uint64
 	}
+	// §3.4 snapshot-to-applier handoff: store the cutover for Stage
+	// 6E's apply-hook to read on the next apply. Stays 0 for v1 and
+	// headerless-legacy restores.
+	f.restoredCutover = cutover
+	return errors.WithStack(f.store.Restore(io.NopCloser(br)))
+}
 
-	// Old format (no magic): re-prepend the 16 bytes we already consumed.
-	return errors.WithStack(f.store.Restore(io.NopCloser(io.MultiReader(bytes.NewReader(hdr[:]), r))))
+// RestoredCutover returns the most recently restored v2
+// raft_envelope_cutover_index, or 0 if the last Restore was v1 / headerless
+// / has not yet been called. Stage 6E will consume this from the apply
+// hook; visible here for test inspection (design §3.4 + §5).
+func (f *kvFSM) RestoredCutover() uint64 {
+	return f.restoredCutover
 }
 
 func (f *kvFSM) handleTxnRequest(ctx context.Context, r *pb.Request, commitTS uint64) error {

--- a/kv/fsm.go
+++ b/kv/fsm.go
@@ -395,8 +395,14 @@ func (f *kvFSM) Restore(r io.Reader) error {
 	// Stage 8a §3.2: the bufio.Reader is owned by the caller (us) and
 	// MUST be passed unchanged to the inner-store path on every branch
 	// — buffered bytes can sit between the header consumption and the
-	// inner-store read; switching readers silently loses them.
-	br := bufio.NewReader(r)
+	// inner-store read; switching readers silently loses them. If the
+	// engine already handed us a *bufio.Reader, reuse it to avoid the
+	// double-buffering overhead (gemini MEDIUM on PR #886); otherwise
+	// wrap once at this boundary.
+	br, ok := r.(*bufio.Reader)
+	if !ok {
+		br = bufio.NewReader(r)
+	}
 	ceilingU, cutover, err := ReadSnapshotHeader(br)
 	if err != nil {
 		return errors.WithStack(err)

--- a/kv/snapshot.go
+++ b/kv/snapshot.go
@@ -1,38 +1,122 @@
 package kv
 
 import (
+	"bufio"
 	"encoding/binary"
 	"io"
+	"log/slog"
 	"sync"
+	"sync/atomic"
 
 	"github.com/bootjp/elastickv/internal/raftengine"
 	"github.com/bootjp/elastickv/store"
 	"github.com/cockroachdb/errors"
 )
 
-// hlcSnapshotMagic is an 8-byte sentinel written at the start of every FSM
-// snapshot to indicate that the snapshot includes an HLC physical ceiling.
-// Old snapshots that lack this header are still readable (backward compat).
+// hlcSnapshotMagic is the v1 8-byte sentinel written at the start of every
+// pre-Stage-8a FSM snapshot. Layout: magic(8) + ceilingMs(8) = 16 bytes.
 var hlcSnapshotMagic = [8]byte{'E', 'K', 'V', 'T', 'H', 'L', 'C', '1'}
 
-// hlcSnapshotHeaderLen is the total header size: 8 magic + 8 ceiling ms.
+// hlcSnapshotHeaderLen is the total v1 header size: 8 magic + 8 ceiling ms.
 const hlcSnapshotHeaderLen = 16 //nolint:mnd
+
+// hlcSnapshotMagicV2 is the v2 sentinel introduced by Stage 8a to carry
+// raft_envelope_cutover_index alongside the HLC ceiling. Layout:
+// magic(8) + len(2,BE) + ceilingMs(8) + cutover(8) + optional trailing
+// bytes for forward-compat extensions (skipped by current readers).
+var hlcSnapshotMagicV2 = [8]byte{'E', 'K', 'V', 'T', 'H', 'L', 'C', '2'}
+
+// hlcSnapshotV2MinPayload is the minimum v2 payload length (ceiling+cutover).
+const hlcSnapshotV2MinPayload = 16 //nolint:mnd
+
+// hlcSnapshotV2LenBytes is the size of the v2 length prefix.
+const hlcSnapshotV2LenBytes = 2 //nolint:mnd
+
+// maxSnapshotHeaderPayload bounds the v2 length prefix to prevent a malformed
+// or malicious snapshot from triggering a large allocation per restore. The
+// constant is intentionally small; raise only when a v2 extension genuinely
+// needs the headroom.
+const maxSnapshotHeaderPayload = 1024 //nolint:mnd
+
+// hlcSnapshotMagicPrefix is the 7-byte common prefix of all EKVTHLC* magics;
+// used by the read-path step-4 fail-closed check for unknown version bytes.
+var hlcSnapshotMagicPrefix = []byte("EKVTHLC")
+
+// ErrSnapshotHeaderInvalidLength indicates a v2 header whose length prefix
+// is below the required minimum (cannot hold ceiling+cutover) or above the
+// maxSnapshotHeaderPayload DoS bound.
+var ErrSnapshotHeaderInvalidLength = errors.New("snapshot header: invalid v2 length prefix")
+
+// ErrSnapshotHeaderUnknownMagic indicates an EKVTHLC* magic whose version
+// byte the current binary does not recognise. The restore fail-closes; the
+// operator must upgrade.
+var ErrSnapshotHeaderUnknownMagic = errors.New("snapshot header: unknown EKVTHLC* magic")
+
+// CutoverSource is the writer-side view of the Phase-2 envelope cutover.
+// kvFSMSnapshot consults it once per snapshot to decide v1 vs v2 layout. A
+// nil source means "always v1" (matches the Phase-0/Phase-1 posture and
+// every pre-8a code path).
+type CutoverSource interface {
+	RaftEnvelopeCutoverIndex() uint64
+}
+
+// noDowngradeLatch implements the §3.3 no-downgrade invariant: once a writer
+// observes a non-zero cutover, it MUST continue emitting v2 even if a later
+// sidecar read returns 0. The latch also preserves the last observed
+// non-zero cutover so a transient sidecar reset (hypothetical reseed) does
+// not lose the value that subsequent Raft entries depend on for unwrap.
+type noDowngradeLatch struct {
+	lastSeen atomic.Uint64
+	once     sync.Once
+	log      *slog.Logger
+}
+
+// observe records the current sidecar cutover and returns the value the
+// writer should emit. If the latch is engaged (lastSeen != 0) and the
+// caller passes 0, the latch holds the previous non-zero value AND logs a
+// single Error to surface the invariant violation without taking the
+// process down mid-snapshot (design §3.3 closing paragraph).
+func (l *noDowngradeLatch) observe(current uint64) uint64 {
+	if current != 0 {
+		l.lastSeen.Store(current)
+		return current
+	}
+	seen := l.lastSeen.Load()
+	if seen != 0 && l.log != nil {
+		l.once.Do(func() {
+			l.log.Error("snapshot: sidecar cutover transitioned non-zero -> 0; no-downgrade latch holding v2 with last-observed cutover",
+				slog.Uint64("latched_cutover", seen))
+		})
+	}
+	return seen
+}
+
+// latched reports whether the writer has ever observed a non-zero cutover.
+// The v2 format is forced from then on.
+func (l *noDowngradeLatch) latched() bool {
+	return l.lastSeen.Load() != 0
+}
 
 var _ raftengine.Snapshot = (*kvFSMSnapshot)(nil)
 
 type kvFSMSnapshot struct {
 	snapshot  store.Snapshot
 	ceilingMs int64
-	once      sync.Once
-	err       error
+	// cutover is the value to emit at snapshot time. 0 + latch-not-engaged
+	// produces v1 output (byte-for-byte pre-8a); any non-zero value, or
+	// any cutover at all when the latch is engaged, produces v2.
+	cutover uint64
+	// useV2 records the v1/v2 selection made at construction time so a
+	// concurrent sidecar mutation after Snapshot() returns cannot flip
+	// the format mid-write.
+	useV2 bool
+	once  sync.Once
+	err   error
 }
 
 func (f *kvFSMSnapshot) WriteTo(w io.Writer) (int64, error) {
-	// Write the 16-byte header: magic (8 bytes) + ceiling ms (8 bytes).
-	var hdr [hlcSnapshotHeaderLen]byte
-	copy(hdr[:8], hlcSnapshotMagic[:])
-	binary.BigEndian.PutUint64(hdr[8:], uint64(f.ceilingMs)) //nolint:gosec // ceiling is a Unix ms timestamp, always positive
-	n, err := w.Write(hdr[:])
+	hdr, hdrLen := f.encodeHeader()
+	n, err := w.Write(hdr[:hdrLen])
 	if err != nil {
 		return int64(n), errors.WithStack(err)
 	}
@@ -44,6 +128,28 @@ func (f *kvFSMSnapshot) WriteTo(w io.Writer) (int64, error) {
 	}
 	return total, nil
 }
+
+// encodeHeader serialises the v1 or v2 header into a stack-allocated buffer
+// and returns the populated prefix length. v2 emits the minimum payload
+// (ceiling+cutover) — forward-compat trailing bytes are a reader-side
+// concern; the writer never emits unused trailing slots.
+func (f *kvFSMSnapshot) encodeHeader() ([hlcSnapshotV2HeaderLen]byte, int) {
+	var hdr [hlcSnapshotV2HeaderLen]byte
+	if !f.useV2 {
+		copy(hdr[:8], hlcSnapshotMagic[:])
+		binary.BigEndian.PutUint64(hdr[8:16], uint64(f.ceilingMs)) //nolint:gosec // ceiling is a Unix ms timestamp, always positive
+		return hdr, hlcSnapshotHeaderLen
+	}
+	copy(hdr[:8], hlcSnapshotMagicV2[:])
+	binary.BigEndian.PutUint16(hdr[8:10], uint16(hlcSnapshotV2MinPayload))
+	binary.BigEndian.PutUint64(hdr[10:18], uint64(f.ceilingMs)) //nolint:gosec // same as v1
+	binary.BigEndian.PutUint64(hdr[18:26], f.cutover)
+	return hdr, hlcSnapshotV2HeaderLen
+}
+
+// hlcSnapshotV2HeaderLen is the on-wire size of a minimum-payload v2 header:
+// magic(8) + len(2) + ceiling(8) + cutover(8) = 26 bytes.
+const hlcSnapshotV2HeaderLen = 8 + hlcSnapshotV2LenBytes + hlcSnapshotV2MinPayload
 
 func (f *kvFSMSnapshot) Close() error {
 	return f.closeSnapshot()
@@ -60,4 +166,108 @@ func (f *kvFSMSnapshot) closeSnapshot() error {
 		}
 	})
 	return f.err
+}
+
+// ReadSnapshotHeader is the §3.2 read path. The caller wraps the input
+// io.Reader in a *bufio.Reader and passes it here once, then MUST reuse the
+// same *bufio.Reader for the inner-store restore — buffered bytes can sit
+// in the bufio.Reader between calls; switching readers silently loses them.
+//
+// Return contract:
+//   - v1 magic: (ceiling, 0, nil), magic + ceiling consumed.
+//   - v2 magic: (ceiling, cutover, nil), full v2 header consumed; trailing
+//     bytes above the parsed fields (forward-compat extension area) are
+//     consumed and discarded.
+//   - EKVTHLC* with an unknown version byte: (0, 0,
+//     ErrSnapshotHeaderUnknownMagic) — fail-closed, restore aborts.
+//   - v2 magic with a malformed length prefix: (0, 0,
+//     ErrSnapshotHeaderInvalidLength) — fail-closed.
+//   - Anything else (including streams shorter than 8 bytes): (0, 0, nil)
+//     and ALL bytes left in the *bufio.Reader for the inner-store path.
+func ReadSnapshotHeader(r *bufio.Reader) (ceiling, cutover uint64, err error) {
+	// Step 0: peek up to 8 bytes. Short streams (< 8 bytes) fall through
+	// to the headerless-legacy branch with the partial bytes left in
+	// place — this preserves TestFSMSnapshotRestoreSmallLegacy and is
+	// the gemini-medium / coderabbit-major fix from PR #877.
+	peeked, perr := r.Peek(8) //nolint:mnd
+	if len(peeked) < 8 {      //nolint:mnd
+		// io.EOF / io.ErrUnexpectedEOF on a short stream: treat as
+		// headerless legacy. Bytes that were peeked stay in r per
+		// bufio.Reader semantics.
+		_ = perr
+		return 0, 0, nil
+	}
+
+	switch {
+	case isV2Magic(peeked):
+		return readV2(r)
+	case isV1Magic(peeked):
+		return readV1(r)
+	case isUnknownEKVTHLC(peeked):
+		return 0, 0, ErrSnapshotHeaderUnknownMagic
+	default:
+		// Headerless legacy: leave the peeked bytes in r so the
+		// inner-store path sees the payload from byte 0.
+		return 0, 0, nil
+	}
+}
+
+func isV1Magic(p []byte) bool {
+	return len(p) >= 8 && //nolint:mnd
+		p[0] == hlcSnapshotMagic[0] && p[1] == hlcSnapshotMagic[1] &&
+		p[2] == hlcSnapshotMagic[2] && p[3] == hlcSnapshotMagic[3] &&
+		p[4] == hlcSnapshotMagic[4] && p[5] == hlcSnapshotMagic[5] &&
+		p[6] == hlcSnapshotMagic[6] && p[7] == hlcSnapshotMagic[7]
+}
+
+func isV2Magic(p []byte) bool {
+	return len(p) >= 8 && //nolint:mnd
+		p[0] == hlcSnapshotMagicV2[0] && p[1] == hlcSnapshotMagicV2[1] &&
+		p[2] == hlcSnapshotMagicV2[2] && p[3] == hlcSnapshotMagicV2[3] &&
+		p[4] == hlcSnapshotMagicV2[4] && p[5] == hlcSnapshotMagicV2[5] &&
+		p[6] == hlcSnapshotMagicV2[6] && p[7] == hlcSnapshotMagicV2[7]
+}
+
+// isUnknownEKVTHLC matches the 7-byte EKVTHLC prefix where the 8th byte
+// is neither '1' nor '2'. This is the §3.2 step-4 fail-closed branch.
+func isUnknownEKVTHLC(p []byte) bool {
+	return len(p) >= 8 && //nolint:mnd
+		p[0] == hlcSnapshotMagicPrefix[0] && p[1] == hlcSnapshotMagicPrefix[1] &&
+		p[2] == hlcSnapshotMagicPrefix[2] && p[3] == hlcSnapshotMagicPrefix[3] &&
+		p[4] == hlcSnapshotMagicPrefix[4] && p[5] == hlcSnapshotMagicPrefix[5] &&
+		p[6] == hlcSnapshotMagicPrefix[6]
+}
+
+func readV1(r *bufio.Reader) (uint64, uint64, error) {
+	var rest [16]byte //nolint:mnd
+	if _, err := io.ReadFull(r, rest[:]); err != nil {
+		return 0, 0, errors.Wrap(err, "v1 header: read magic+ceiling")
+	}
+	ceiling := binary.BigEndian.Uint64(rest[8:16])
+	return ceiling, 0, nil
+}
+
+func readV2(r *bufio.Reader) (uint64, uint64, error) {
+	// Consume the 8 magic bytes.
+	if _, err := r.Discard(8); err != nil { //nolint:mnd
+		return 0, 0, errors.Wrap(err, "v2 header: discard magic")
+	}
+	// Read the 2-byte length prefix.
+	var lenBuf [hlcSnapshotV2LenBytes]byte
+	if _, err := io.ReadFull(r, lenBuf[:]); err != nil {
+		return 0, 0, errors.Wrap(err, "v2 header: read length prefix")
+	}
+	plen := int(binary.BigEndian.Uint16(lenBuf[:]))
+	if plen < hlcSnapshotV2MinPayload || plen > maxSnapshotHeaderPayload {
+		return 0, 0, ErrSnapshotHeaderInvalidLength
+	}
+	// Read exactly plen payload bytes. Parse ceiling/cutover from the
+	// first 16; ignore the remainder (forward-compat extension area).
+	payload := make([]byte, plen)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return 0, 0, errors.Wrap(err, "v2 header: read payload")
+	}
+	ceiling := binary.BigEndian.Uint64(payload[0:8])
+	cutover := binary.BigEndian.Uint64(payload[8:16])
+	return ceiling, cutover, nil
 }

--- a/kv/snapshot.go
+++ b/kv/snapshot.go
@@ -188,13 +188,20 @@ func ReadSnapshotHeader(r *bufio.Reader) (ceiling, cutover uint64, err error) {
 	// Step 0: peek up to 8 bytes. Short streams (< 8 bytes) fall through
 	// to the headerless-legacy branch with the partial bytes left in
 	// place — this preserves TestFSMSnapshotRestoreSmallLegacy and is
-	// the gemini-medium / coderabbit-major fix from PR #877.
+	// the gemini-medium / coderabbit-major fix from PR #877. Genuine
+	// I/O failures (network timeout, disk error) MUST surface as a
+	// typed error rather than masquerade as a legacy snapshot —
+	// otherwise the restore silently succeeds with no data and the
+	// downstream apply path looks at an empty store (gemini HIGH on
+	// PR #886).
 	peeked, perr := r.Peek(8) //nolint:mnd
 	if len(peeked) < 8 {      //nolint:mnd
+		if perr != nil && !errors.Is(perr, io.EOF) && !errors.Is(perr, io.ErrUnexpectedEOF) {
+			return 0, 0, errors.Wrap(perr, "snapshot header: peek")
+		}
 		// io.EOF / io.ErrUnexpectedEOF on a short stream: treat as
 		// headerless legacy. Bytes that were peeked stay in r per
 		// bufio.Reader semantics.
-		_ = perr
 		return 0, 0, nil
 	}
 
@@ -263,7 +270,11 @@ func readV2(r *bufio.Reader) (uint64, uint64, error) {
 	}
 	// Read exactly plen payload bytes. Parse ceiling/cutover from the
 	// first 16; ignore the remainder (forward-compat extension area).
-	payload := make([]byte, plen)
+	// plen is already bounded by maxSnapshotHeaderPayload (1024B), so
+	// a stack-allocated buffer is safe and skips the heap allocation
+	// per restore (gemini MEDIUM on PR #886).
+	var buf [maxSnapshotHeaderPayload]byte
+	payload := buf[:plen]
 	if _, err := io.ReadFull(r, payload); err != nil {
 		return 0, 0, errors.Wrap(err, "v2 header: read payload")
 	}

--- a/kv/snapshot_test.go
+++ b/kv/snapshot_test.go
@@ -531,3 +531,47 @@ func TestFSMSnapshotRestoreV2_PlumbsCutover(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte("vv"), val)
 }
+
+// flakyReader returns the supplied error on the first Read after returning
+// the (possibly empty) prefix. Used to drive ReadSnapshotHeader's Peek
+// down the non-EOF error path.
+type flakyReader struct {
+	prefix []byte
+	err    error
+	off    int
+}
+
+func (f *flakyReader) Read(p []byte) (int, error) {
+	if f.off < len(f.prefix) {
+		n := copy(p, f.prefix[f.off:])
+		f.off += n
+		return n, nil
+	}
+	return 0, f.err
+}
+
+// TestReadSnapshotHeader_NonEOFPeekErrorPropagates pins design §3.2 step 0
+// + gemini HIGH on PR #886: an I/O failure during the initial Peek (not
+// io.EOF / io.ErrUnexpectedEOF) MUST surface as a typed error instead of
+// silently masquerading as a headerless-legacy short stream. Without this,
+// a network timeout mid-restore would silently restore an empty store.
+func TestReadSnapshotHeader_NonEOFPeekErrorPropagates(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("synthetic disk failure")
+	// 0 bytes available, then a non-EOF error: ReadSnapshotHeader must
+	// propagate the error wrapped with context, not return (0,0,nil).
+	br := bufio.NewReader(&flakyReader{prefix: nil, err: sentinel})
+	_, _, err := ReadSnapshotHeader(br)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, sentinel),
+		"want wrapped sentinel error, got %v", err)
+
+	// A few bytes available, then a non-EOF error: same fail-closed
+	// contract (partial-stream short reads must NOT swallow the I/O
+	// error and pretend the prefix is a legacy snapshot).
+	br = bufio.NewReader(&flakyReader{prefix: []byte("EKV"), err: sentinel})
+	_, _, err = ReadSnapshotHeader(br)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, sentinel),
+		"want wrapped sentinel error on partial-then-fail, got %v", err)
+}

--- a/kv/snapshot_test.go
+++ b/kv/snapshot_test.go
@@ -1,8 +1,11 @@
 package kv
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"encoding/binary"
+	"errors"
 	"io"
 	"testing"
 
@@ -12,6 +15,43 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
+
+// staticCutoverSource is a test-only CutoverSource whose value can be
+// mutated between Snapshot() calls to exercise the §3.3 latch.
+type staticCutoverSource struct {
+	v uint64
+}
+
+func (s *staticCutoverSource) RaftEnvelopeCutoverIndex() uint64 { return s.v }
+
+// writeV1Header emits a synthetic v1 header (8 magic + 8 ceiling) for the
+// read-path tests. Equivalent to what kvFSMSnapshot.WriteTo produces when
+// useV2 is false.
+func writeV1Header(t *testing.T, w *bytes.Buffer, ceiling uint64) {
+	t.Helper()
+	w.Write(hlcSnapshotMagic[:])
+	var ceil [8]byte
+	binary.BigEndian.PutUint64(ceil[:], ceiling)
+	w.Write(ceil[:])
+}
+
+// writeV2Header emits a synthetic v2 header with the given length prefix.
+// When trailing > 0 the payload is padded with that many zero bytes after
+// the ceiling+cutover pair (exercises the forward-compat extension area).
+func writeV2Header(t *testing.T, w *bytes.Buffer, ceiling, cutover uint64, plen uint16, trailing int) {
+	t.Helper()
+	w.Write(hlcSnapshotMagicV2[:])
+	var lp [2]byte
+	binary.BigEndian.PutUint16(lp[:], plen)
+	w.Write(lp[:])
+	var pl [16]byte
+	binary.BigEndian.PutUint64(pl[0:8], ceiling)
+	binary.BigEndian.PutUint64(pl[8:16], cutover)
+	w.Write(pl[:])
+	if trailing > 0 {
+		w.Write(make([]byte, trailing))
+	}
+}
 
 func TestSnapshot(t *testing.T) {
 	store := store3.NewMVCCStore()
@@ -189,4 +229,305 @@ func TestFSMSnapshotRestoreOldFormat(t *testing.T) {
 	val, err := st2.GetAt(ctx, []byte("legacy"), ^uint64(0))
 	require.NoError(t, err)
 	require.Equal(t, []byte("data"), val)
+}
+
+// --- Stage 8a §5: ReadSnapshotHeader read-path verification ---
+
+// TestReadSnapshotHeader_V1ReturnsZeroCutover pins design §3.2 step 3: a v1
+// header returns ceiling + cutover=0 + nil. Inner-store payload following
+// the header sits in the bufio.Reader.
+func TestReadSnapshotHeader_V1ReturnsZeroCutover(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	writeV1Header(t, &buf, 12345)
+	buf.WriteString("STORE_PAYLOAD")
+	br := bufio.NewReader(&buf)
+	ceiling, cutover, err := ReadSnapshotHeader(br)
+	require.NoError(t, err)
+	require.Equal(t, uint64(12345), ceiling)
+	require.Equal(t, uint64(0), cutover)
+	rest, _ := io.ReadAll(br)
+	require.Equal(t, "STORE_PAYLOAD", string(rest))
+}
+
+// TestReadSnapshotHeader_V2ReturnsBothFields pins design §3.2 step 2: a v2
+// header with minimum payload (len=16) returns both fields and the inner
+// store sees the byte stream from the position right after the payload.
+func TestReadSnapshotHeader_V2ReturnsBothFields(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	writeV2Header(t, &buf, 0xDEAD, 0xBEEF, hlcSnapshotV2MinPayload, 0)
+	buf.WriteString("STORE_PAYLOAD")
+	br := bufio.NewReader(&buf)
+	ceiling, cutover, err := ReadSnapshotHeader(br)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0xDEAD), ceiling)
+	require.Equal(t, uint64(0xBEEF), cutover)
+	rest, _ := io.ReadAll(br)
+	require.Equal(t, "STORE_PAYLOAD", string(rest))
+}
+
+// TestReadSnapshotHeader_V2ForwardCompatExtraBytes pins design §3.1.1: a v2
+// header with len > 16 must be consumed in full (trailing bytes skipped)
+// so the inner store sees the stream from the first non-header byte.
+func TestReadSnapshotHeader_V2ForwardCompatExtraBytes(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	writeV2Header(t, &buf, 0xC, 0xD, 24, 8) // len=0x18, +8 trailing
+	buf.WriteString("STORE_PAYLOAD")
+	br := bufio.NewReader(&buf)
+	ceiling, cutover, err := ReadSnapshotHeader(br)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0xC), ceiling)
+	require.Equal(t, uint64(0xD), cutover)
+	rest, _ := io.ReadAll(br)
+	require.Equal(t, "STORE_PAYLOAD", string(rest),
+		"trailing forward-compat bytes must be skipped before the inner store reads")
+}
+
+// TestReadSnapshotHeader_UnknownEKVTHLCMagicFails pins design §3.2 step 4: a
+// version byte the current binary does not recognise produces
+// ErrSnapshotHeaderUnknownMagic and the restore aborts.
+func TestReadSnapshotHeader_UnknownEKVTHLCMagicFails(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	buf.WriteString("EKVTHLC9") // unknown version byte
+	buf.WriteString("trailing bytes that must NOT be consumed silently")
+	br := bufio.NewReader(&buf)
+	_, _, err := ReadSnapshotHeader(br)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrSnapshotHeaderUnknownMagic),
+		"want ErrSnapshotHeaderUnknownMagic, got %v", err)
+}
+
+// TestReadSnapshotHeader_HeaderlessLegacyPreserved pins design §3.2 step 5
+// and §6 backward-compat: a payload that does NOT start with EKVTHLC*
+// returns (0,0,nil) AND the inner-store path sees the payload from byte 0.
+func TestReadSnapshotHeader_HeaderlessLegacyPreserved(t *testing.T) {
+	t.Parallel()
+	const payload = "raw_store_bytes_with_no_header_at_all"
+	br := bufio.NewReader(bytes.NewReader([]byte(payload)))
+	ceiling, cutover, err := ReadSnapshotHeader(br)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), ceiling)
+	require.Equal(t, uint64(0), cutover)
+	rest, _ := io.ReadAll(br)
+	require.Equal(t, payload, string(rest),
+		"inner-store path must see the entire payload from byte 0")
+}
+
+// TestReadSnapshotHeader_V2WithLenTooShortFails pins design §3.2 step 2's
+// `len < 16` fail-closed: malformed inputs produce a typed error rather
+// than a downstream EOF or panic on slice indexing.
+func TestReadSnapshotHeader_V2WithLenTooShortFails(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	buf.Write(hlcSnapshotMagicV2[:])
+	var lp [2]byte
+	binary.BigEndian.PutUint16(lp[:], 8) // below the 16-byte minimum
+	buf.Write(lp[:])
+	buf.Write(make([]byte, 8)) // 8 payload bytes (insufficient)
+	br := bufio.NewReader(&buf)
+	_, _, err := ReadSnapshotHeader(br)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrSnapshotHeaderInvalidLength),
+		"want ErrSnapshotHeaderInvalidLength, got %v", err)
+}
+
+// TestReadSnapshotHeader_V2WithLenTooLargeFails pins design §3.2 step 2's
+// upper bound (coderabbit MAJOR on PR #877). A 0xFFFF length must
+// fail-closed before allocating a 64KiB buffer.
+func TestReadSnapshotHeader_V2WithLenTooLargeFails(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	buf.Write(hlcSnapshotMagicV2[:])
+	var lp [2]byte
+	binary.BigEndian.PutUint16(lp[:], 0xFFFF)
+	buf.Write(lp[:])
+	br := bufio.NewReader(&buf)
+	_, _, err := ReadSnapshotHeader(br)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrSnapshotHeaderInvalidLength),
+		"want ErrSnapshotHeaderInvalidLength, got %v", err)
+}
+
+// TestReadSnapshotHeader_ShortStreamFallsBackToLegacy pins design §3.2 step
+// 0 (gemini medium + coderabbit major on PR #877): a stream shorter than 8
+// bytes must fall through to the headerless-legacy branch with the
+// available bytes left in the bufio.Reader for the inner-store path.
+func TestReadSnapshotHeader_ShortStreamFallsBackToLegacy(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		payload string
+	}{
+		{"empty", ""},
+		{"four_bytes", "ABCD"},
+		{"seven_bytes", "ABCDEFG"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			br := bufio.NewReader(bytes.NewReader([]byte(tc.payload)))
+			ceiling, cutover, err := ReadSnapshotHeader(br)
+			require.NoError(t, err)
+			require.Equal(t, uint64(0), ceiling)
+			require.Equal(t, uint64(0), cutover)
+			rest, _ := io.ReadAll(br)
+			require.Equal(t, tc.payload, string(rest),
+				"available bytes must remain in the bufio.Reader for the inner-store path")
+		})
+	}
+}
+
+// --- Stage 8a §5: write-path verification ---
+
+// TestWriteSnapshotHeader_PreCutoverWritesV1 pins design §3.3 + §4: with
+// no CutoverSource installed (or cutover == 0 and the latch not engaged),
+// the snapshot header is byte-for-byte identical to the pre-8a v1 layout.
+// This is the no-migration property.
+func TestWriteSnapshotHeader_PreCutoverWritesV1(t *testing.T) {
+	t.Parallel()
+	hlc := NewHLC()
+	const ceilingMs = int64(7_777_777)
+	hlc.SetPhysicalCeiling(ceilingMs)
+	st := store3.NewMVCCStore()
+	fsm := NewKvFSMWithHLC(st, hlc) // no WithCutoverSource
+
+	snap, err := fsm.Snapshot()
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	_, err = snap.WriteTo(&buf)
+	require.NoError(t, err)
+	require.NoError(t, snap.Close())
+
+	out := buf.Bytes()
+	require.GreaterOrEqual(t, len(out), hlcSnapshotHeaderLen)
+	require.Equal(t, hlcSnapshotMagic[:], out[:8], "must emit v1 magic")
+	require.Equal(t, uint64(ceilingMs), binary.BigEndian.Uint64(out[8:16]),
+		"v1 ceiling must round-trip exactly")
+}
+
+// TestWriteSnapshotHeader_PostCutoverWritesV2 pins design §3.3: when the
+// sidecar's cutover index is non-zero, the snapshot header carries v2
+// magic + length prefix + ceiling + cutover.
+func TestWriteSnapshotHeader_PostCutoverWritesV2(t *testing.T) {
+	t.Parallel()
+	hlc := NewHLC()
+	const ceilingMs = int64(5_555_555)
+	hlc.SetPhysicalCeiling(ceilingMs)
+	st := store3.NewMVCCStore()
+	src := &staticCutoverSource{v: 0xCA11ED}
+	fsm := NewKvFSMWithHLC(st, hlc, WithCutoverSource(src))
+
+	snap, err := fsm.Snapshot()
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	_, err = snap.WriteTo(&buf)
+	require.NoError(t, err)
+	require.NoError(t, snap.Close())
+
+	out := buf.Bytes()
+	require.GreaterOrEqual(t, len(out), hlcSnapshotV2HeaderLen)
+	require.Equal(t, hlcSnapshotMagicV2[:], out[:8], "must emit v2 magic")
+	require.Equal(t, uint16(hlcSnapshotV2MinPayload),
+		binary.BigEndian.Uint16(out[8:10]),
+		"v2 length prefix must be the minimum payload size")
+	require.Equal(t, uint64(ceilingMs), binary.BigEndian.Uint64(out[10:18]))
+	require.Equal(t, uint64(0xCA11ED), binary.BigEndian.Uint64(out[18:26]))
+}
+
+// TestWriteSnapshotHeader_NoDowngradeAfterCutoverSeen pins design §3.3's
+// load-bearing no-downgrade invariant: once a writer has emitted v2, a
+// subsequent sidecar reset to 0 MUST still produce v2 output with the
+// last-observed non-zero cutover preserved. Without this latch, a
+// Phase-2 node whose sidecar gets reset would silently emit a v1
+// snapshot and corrupt followers' wrap/unwrap routing.
+func TestWriteSnapshotHeader_NoDowngradeAfterCutoverSeen(t *testing.T) {
+	t.Parallel()
+	hlc := NewHLC()
+	hlc.SetPhysicalCeiling(42)
+	st := store3.NewMVCCStore()
+	src := &staticCutoverSource{v: 5}
+	fsm := NewKvFSMWithHLC(st, hlc, WithCutoverSource(src))
+
+	// First snapshot: v2 with cutover=5.
+	snap1, err := fsm.Snapshot()
+	require.NoError(t, err)
+	var buf1 bytes.Buffer
+	_, err = snap1.WriteTo(&buf1)
+	require.NoError(t, err)
+	require.NoError(t, snap1.Close())
+	require.Equal(t, hlcSnapshotMagicV2[:], buf1.Bytes()[:8],
+		"first snapshot must be v2")
+	require.Equal(t, uint64(5),
+		binary.BigEndian.Uint64(buf1.Bytes()[18:26]),
+		"first snapshot must carry cutover=5")
+
+	// Sidecar artificially reset to 0 (hypothetical reseed path).
+	src.v = 0
+
+	// Second snapshot: MUST still be v2, latched cutover=5 preserved.
+	snap2, err := fsm.Snapshot()
+	require.NoError(t, err)
+	var buf2 bytes.Buffer
+	_, err = snap2.WriteTo(&buf2)
+	require.NoError(t, err)
+	require.NoError(t, snap2.Close())
+	require.Equal(t, hlcSnapshotMagicV2[:], buf2.Bytes()[:8],
+		"latched writer must continue emitting v2 after sidecar reset")
+	require.Equal(t, uint64(5),
+		binary.BigEndian.Uint64(buf2.Bytes()[18:26]),
+		"latched writer must preserve the last-observed non-zero cutover")
+}
+
+// --- Stage 8a §5: restore-side integration ---
+
+// TestFSMSnapshotRestoreV2_PlumbsCutover pins design §3.4: a v2 snapshot
+// restore stores the cutover on the FSM for Stage 6E's apply-hook to
+// read. The handoff is observable via the test seam RestoredCutover().
+func TestFSMSnapshotRestoreV2_PlumbsCutover(t *testing.T) {
+	t.Parallel()
+	// Source FSM with cutover source so the snapshot is v2.
+	hlc1 := NewHLC()
+	hlc1.SetPhysicalCeiling(9999)
+	st1 := store3.NewMVCCStore()
+	src := &staticCutoverSource{v: 0xC07012}
+	fsm1 := NewKvFSMWithHLC(st1, hlc1, WithCutoverSource(src))
+
+	// One key so the inner store has something to round-trip.
+	req := &pb.Request{
+		IsTxn: false,
+		Phase: pb.Phase_NONE,
+		Mutations: []*pb.Mutation{
+			{Op: pb.Op_PUT, Key: []byte("kk"), Value: []byte("vv")},
+		},
+	}
+	b, err := proto.Marshal(req)
+	require.NoError(t, err)
+	fsm1.Apply(b)
+
+	snap, err := fsm1.Snapshot()
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	_, err = snap.WriteTo(&buf)
+	require.NoError(t, err)
+	require.NoError(t, snap.Close())
+
+	// Restore into a fresh FSM (no cutover source on the receiving side).
+	hlc2 := NewHLC()
+	st2 := store3.NewMVCCStore()
+	fsm2 := NewKvFSMWithHLC(st2, hlc2)
+	require.NoError(t, fsm2.Restore(io.NopCloser(bytes.NewReader(buf.Bytes()))))
+
+	// Ceiling round-trips, cutover is plumbed, store data is intact.
+	require.Equal(t, int64(9999), hlc2.PhysicalCeiling())
+	concrete, ok := fsm2.(*kvFSM)
+	require.True(t, ok, "test seam: FSM is the concrete *kvFSM")
+	require.Equal(t, uint64(0xC07012), concrete.RestoredCutover(),
+		"v2 restore must plumb cutover to the FSM for Stage 6E")
+	ctx := context.Background()
+	val, err := st2.GetAt(ctx, []byte("kk"), ^uint64(0))
+	require.NoError(t, err)
+	require.Equal(t, []byte("vv"), val)
 }


### PR DESCRIPTION
## Summary

Implements Stage 8a — the snapshot header v2 carrier for `raft_envelope_cutover_index`. Lands on top of the merged design doc (`docs/design/2026_05_29_proposed_8a_snapshot_header_v2.md`, #877). No on-disk migration; v1 snapshots restore byte-for-byte under the new build, and only Phase-2 nodes ever emit v2.

### New API surface

- `ReadSnapshotHeader(r *bufio.Reader) (ceiling, cutover uint64, err error)` — the 6-branch §3.2 reader. Caller-owned `bufio.Reader` is passed unchanged into the inner store on every branch (the bufio-buffering-loses-bytes failure mode flagged in PR #877 review).
- `CutoverSource` interface + `WithCutoverSource(...)` FSM option — writer-side view of the sidecar's cutover index.
- `noDowngradeLatch` (process-load) — §3.3's "once non-zero observed → always v2" invariant. Preserves the last non-zero cutover across hypothetical sidecar resets and slogs an Error once on the non-zero→0 transition.
- `kvFSM.RestoredCutover()` — test seam for the §3.4 snapshot-to-applier handoff. Stage 6E will consume this via the apply hook.

### Read-path branches (all covered by tests)

| Input | Result |
|---|---|
| v1 magic `EKVTHLC1` | `(ceiling, 0, nil)` |
| v2 magic `EKVTHLC2` + valid len | `(ceiling, cutover, nil)`, trailing payload bytes skipped |
| `EKVTHLC*` w/ unknown version byte | `(0, 0, ErrSnapshotHeaderUnknownMagic)` — fail-closed |
| v2 magic + `len < 16` or `len > 1024` | `(0, 0, ErrSnapshotHeaderInvalidLength)` — fail-closed (DoS bound) |
| No `EKVTHLC` prefix | `(0, 0, nil)` — headerless legacy, bytes preserved in `bufio.Reader` |
| Stream `< 8` bytes | `(0, 0, nil)` — short-stream fallback, bytes preserved |

### Verification

- 11 new tests in `kv/snapshot_test.go` per design §5.
- 4 pre-8a regression tests (TestSnapshot, TestFSMSnapshotPreservesCeiling, TestFSMSnapshotRestoreOldFormat, TestFSMSnapshotRestoreSmallLegacy) stay green.
- `go test -race ./kv/...` clean.
- `golangci-lint --config=.golangci.yaml run ./kv/...` 0 issues.

### Self-review (5-lens)

1. **Data loss** — v1 + headerless restore byte-for-byte (TestWriteSnapshotHeader_PreCutoverWritesV1 pins the v1 bytewise output; TestFSMSnapshotRestoreOldFormat / TestFSMSnapshotRestoreSmallLegacy stay green).
2. **Concurrency / distributed failures** — `noDowngradeLatch` uses `atomic.Uint64`; v1/v2 selection captured at Snapshot() time so concurrent sidecar mutation cannot flip the format mid-write.
3. **Performance** — header is a stack-allocated `[26]byte`; v2 payload alloc bounded by `maxSnapshotHeaderPayload = 1024`. Reader uses `bufio.Reader.Discard` / `io.ReadFull`; no per-byte copies.
4. **Data consistency** — no-downgrade latch enforces §3.3; cutover plumbed through `kvFSM.restoredCutover` for Stage 6E. `cutover == 0` from a v2 snapshot routes correctly via Stage 6E's precondition guard.
5. **Test coverage** — every read-path branch + write-path selector + latch + restore-side handoff has a dedicated test. Bytewise pin on the v1 output guards against any future regression.

## Test plan

- [x] `go test -race ./kv/...` clean
- [x] `golangci-lint --config=.golangci.yaml run ./kv/...` clean
- [x] All 11 new tests + 4 legacy regression tests pass
- [ ] @claude review for the read-path branch correctness, the no-downgrade latch semantics, and the §3.4 cutover-handoff API
