### PR TITLE
test(sqs): slow throttle refill on SetQueueAttributesInvalidatesBucket to fix CI flake

### DIFF
--- a/adapter/sqs_throttle_integration_test.go
+++ b/adapter/sqs_throttle_integration_test.go
@@ -155,15 +155,15 @@ func TestSQSServer_Throttle_SetQueueAttributesInvalidatesBucket(t *testing.T) {
 	// refill on slow CI runners: 10 drain sends + the sanity send
 	// (each going through Raft propose+apply at ~100-250 ms under
 	// -race) elapses ~1.1-2.75 s before the "should-throttle"
-	// assertion at line 170 fires, by which time the bucket has
-	// refilled 1+ tokens and the send returns 200 instead of the
-	// expected 400 — observed on the run-26678774684 Test workflow
-	// failure. Same mechanism as the no-op variant fixed in
-	// commit 54c6cd56 (PR #819 follow-up). The test's intent —
-	// verify that a Capacity/Refill raise invalidates the bucket
-	// — is independent of the *initial* refill rate; the
-	// post-set send is exercised against the fresh
-	// Capacity=20 / Refill=20 bucket regardless.
+	// assertion below fires, by which time the bucket has refilled
+	// 1+ tokens and the send returns 200 instead of the expected
+	// 400 — observed on the run-26678774684 Test workflow failure.
+	// Same mechanism as the no-op variant fixed in commit 54c6cd56
+	// (PR #819 follow-up). The test's intent — verify that a
+	// Capacity/Refill raise invalidates the bucket — is
+	// independent of the *initial* refill rate; the post-set send
+	// is exercised against the fresh Capacity=20 / Refill=20
+	// bucket regardless.
 	mustSetQueueAttributes(t, node, url, map[string]string{
 		"ThrottleSendCapacity":        "10",
 		"ThrottleSendRefillPerSecond": "0.01",

--- a/adapter/sqs_throttle_integration_test.go
+++ b/adapter/sqs_throttle_integration_test.go
@@ -149,9 +149,24 @@ func TestSQSServer_Throttle_SetQueueAttributesInvalidatesBucket(t *testing.T) {
 	node := sqsLeaderNode(t, nodes)
 
 	url := mustCreateQueue(t, node, "throttle-invalidate")
+	// Refill rate is intentionally slow (0.01/sec = 1 token per
+	// 100 seconds) so the drain-then-sanity window cannot
+	// accumulate a whole token. At 1/sec the test raced its own
+	// refill on slow CI runners: 10 drain sends + the sanity send
+	// (each going through Raft propose+apply at ~100-250 ms under
+	// -race) elapses ~1.1-2.75 s before the "should-throttle"
+	// assertion at line 170 fires, by which time the bucket has
+	// refilled 1+ tokens and the send returns 200 instead of the
+	// expected 400 — observed on the run-26678774684 Test workflow
+	// failure. Same mechanism as the no-op variant fixed in
+	// commit 54c6cd56 (PR #819 follow-up). The test's intent —
+	// verify that a Capacity/Refill raise invalidates the bucket
+	// — is independent of the *initial* refill rate; the
+	// post-set send is exercised against the fresh
+	// Capacity=20 / Refill=20 bucket regardless.
 	mustSetQueueAttributes(t, node, url, map[string]string{
 		"ThrottleSendCapacity":        "10",
-		"ThrottleSendRefillPerSecond": "1",
+		"ThrottleSendRefillPerSecond": "0.01",
 	})
 	// Drain.
 	for range 10 {


### PR DESCRIPTION
## Summary

Fixes the CI flake observed in [Test workflow run 26678774684](https://github.com/bootjp/elastickv/actions/runs/26678774684):

```
--- FAIL: TestSQSServer_Throttle_SetQueueAttributesInvalidatesBucket (1.79s)
    sqs_throttle_integration_test.go:170: expected throttle, got 200
```

## Root cause

Identical race to the one fixed for `TestSQSServer_Throttle_NoOpSetQueueAttributesPreservesBucket` in commit [54c6cd56](https://github.com/bootjp/elastickv/commit/54c6cd56) (PR #819 follow-up): the 1-token-per-second refill rate races the test's own wall clock under `-race` on slow CI runners.

For **this** test:
1. `mustSetQueueAttributes(Capacity=10, Refill=1)`
2. `for range 10 { send }` — drains the bucket
3. Sanity send — expects HTTP 400 (throttle)

Each send goes through Raft propose+apply at ~100-250ms under `-race`. The 11 writes from steps 1-3 elapse ~1.1-2.75s. At Refill=1/sec the bucket has accumulated ≥1 token by step 3, so the sanity send returns HTTP 200 instead of 400 — **falsely** indicating a bucket-invalidation regression that does not exist.

## Fix

Drop the initial Refill from `"1"` to `"0.01"` (1 token per 100 seconds) so no test-window wall-clock can accumulate to a whole token. The test's intent — *verify that a Capacity/Refill **raise** invalidates the cached bucket on the very next request* — is independent of the **initial** refill rate. The post-set assertion at line 182 is exercised against the fresh `Capacity=20/Refill=20` bucket, which is what the test actually claims to pin.

## Why only this test, not the sibling

`TestSQSServer_Throttle_DeleteQueueInvalidatesBucket` has the same `Refill=1` initial config but **no post-drain sanity assertion** — it just drains without status checks, then verifies fresh capacity post-recreate. No race window there.

## Relation to other open PRs

Unrelated to PRs #887/#888/#889 (option-2 dedup work). The flake surfaced on PR #889's CI run but the fix lives in pre-existing SQS test code that none of the dedup PRs touch.

## Caller audit (per /loop semantic-change rule)

Test-only change. The throttle config validator (`sqs_catalog.go:163`) accepts fractional `float64 SendRefillPerSecond`; `0.01` is non-zero so `IsEmpty` (line 172) returns `false` and throttling stays enabled — the test still exercises the throttle path. Matches the prior fix's caller-audit conclusion verbatim.

## Validation

- `go test ./adapter/ -run TestSQSServer_Throttle -race -count=3 -timeout 120s` passes (5.3s wall, all three iterations green)
- `gofmt`, `go vet`, `golangci-lint run` all clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration and expanded documentation to improve test stability on slow CI environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/890?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->