### PR TITLE
kv(composed1): M2 — versioned-snapshot ring + kvFSM RouteHistory wiring

### DIFF
--- a/distribution/engine.go
+++ b/distribution/engine.go
@@ -36,7 +36,26 @@ type Engine struct {
 	catalogVersion   uint64
 	ts               atomic.Uint64
 	hotspotThreshold uint64
+	// history is the M2 versioned-snapshot ring for Composed-1
+	// (docs/design/2026_05_29_proposed_composed1_cross_group_commit_guard.md
+	// §M2).  Keyed by catalogVersion; populated on every successful
+	// ApplySnapshot and seeded by NewEngineWithDefaultRoute so a
+	// transaction that observed catalogVersion = 0 (the engine's
+	// pre-bootstrap snapshot) can still resolve its read-set owner.
+	// Bounded by historyDepth via a FIFO eviction list
+	// (historyOrder).  At M2 the ring is plumbing only — M3 will
+	// read from it via verifyComposed1.
+	history      map[uint64]RouteHistorySnapshot
+	historyOrder []uint64
+	historyDepth int
 }
+
+// DefaultRouteHistoryDepth is the size of Engine's versioned-snapshot
+// ring used by the Composed-1 M2 plumbing.  32 is conservative
+// against current single-leader catalog churn (operator-frequency,
+// not data-plane) per the design doc §9 Q2; raise if a future
+// control plane generates more than ~tens of versions per second.
+const DefaultRouteHistoryDepth = 32
 
 const defaultGroupID uint64 = 1
 const minRouteCountForOrderValidation = 2
@@ -54,10 +73,14 @@ func NewEngine() *Engine {
 }
 
 // NewEngineWithDefaultRoute creates an Engine and registers a default route
-// covering the full keyspace with a default group ID.
+// covering the full keyspace with a default group ID.  The default route is
+// also recorded in the M2 history ring as the version-0 snapshot so
+// transactions that observed catalogVersion = 0 can resolve their read-set
+// owner through SnapshotAt(0).
 func NewEngineWithDefaultRoute() *Engine {
 	engine := NewEngine()
 	engine.UpdateRoute([]byte(""), nil, defaultGroupID)
+	engine.recordHistorySnapshot()
 	return engine
 }
 
@@ -65,7 +88,13 @@ func NewEngineWithDefaultRoute() *Engine {
 // detection. A non-zero threshold enables automatic range splitting when the
 // number of accesses to a range exceeds the threshold.
 func NewEngineWithThreshold(threshold uint64) *Engine {
-	return &Engine{routes: make([]Route, 0), hotspotThreshold: threshold}
+	return &Engine{
+		routes:           make([]Route, 0),
+		hotspotThreshold: threshold,
+		history:          make(map[uint64]RouteHistorySnapshot, DefaultRouteHistoryDepth),
+		historyOrder:     make([]uint64, 0, DefaultRouteHistoryDepth),
+		historyDepth:     DefaultRouteHistoryDepth,
+	}
 }
 
 // Version returns current route catalog version applied to the engine.
@@ -106,7 +135,91 @@ func (e *Engine) ApplySnapshot(snapshot CatalogSnapshot) error {
 
 	e.routes = routes
 	e.catalogVersion = snapshot.Version
+	e.recordHistorySnapshot()
 	return nil
+}
+
+// RouteHistorySnapshot is a point-in-time view of the route catalog at
+// a specific version.  Returned by Engine.SnapshotAt for the M3
+// Composed-1 commit-time gate.  Carries an immutable copy of the
+// catalog's routes at the recorded version so a caller can resolve
+// ownership without holding the Engine lock.
+type RouteHistorySnapshot struct {
+	version uint64
+	routes  []Route
+}
+
+// Version returns the catalog version this snapshot was recorded at.
+func (s RouteHistorySnapshot) Version() uint64 { return s.version }
+
+// OwnerOf returns the Raft group ID that owned key at this snapshot's
+// version.  Returns (0, false) when no route covers key (the
+// pre-bootstrap state or an explicitly-uncovered range).  Mirrors
+// Engine.GetRoute's right-half-open interval semantics but against
+// the historical snapshot, not the live engine state.
+func (s RouteHistorySnapshot) OwnerOf(key []byte) (uint64, bool) {
+	for _, r := range s.routes {
+		if bytes.Compare(key, r.Start) < 0 {
+			continue
+		}
+		if r.End != nil && bytes.Compare(key, r.End) >= 0 {
+			continue
+		}
+		return r.GroupID, true
+	}
+	return 0, false
+}
+
+// SnapshotAt returns the route catalog snapshot recorded at version v.
+// Returns (zero, false) when v is not in the ring — either because v
+// is in the future (> catalogVersion), or because the FIFO ring has
+// evicted v (it was older than the historyDepth-most-recent
+// versions).  The M3 Composed-1 gate (design doc §4.3) treats the
+// not-found case as a hard error and triggers a coordinator retry,
+// so retention depth is a liveness knob, not a safety knob.
+func (e *Engine) SnapshotAt(v uint64) (RouteHistorySnapshot, bool) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	snap, ok := e.history[v]
+	return snap, ok
+}
+
+// HistoryDepth returns the configured ring depth for diagnostics.
+func (e *Engine) HistoryDepth() int {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.historyDepth
+}
+
+// recordHistorySnapshot pushes the current (catalogVersion, routes)
+// pair into the ring.  Caller MUST hold e.mu (write lock) — invoked
+// from ApplySnapshot under the write lock, and from
+// NewEngineWithDefaultRoute before the Engine is shared with any
+// concurrent reader.  Idempotent on re-record at the same version.
+func (e *Engine) recordHistorySnapshot() {
+	if e.history == nil {
+		// Engines constructed via the bare struct literal (e.g.
+		// internal test seams) — no history ring configured.  Skip
+		// the record so the M2 plumbing stays optional for those
+		// paths; the M3 gate will observe SnapshotAt → (zero,
+		// false) and trigger the soft-fail-as-retry path.
+		return
+	}
+	if _, exists := e.history[e.catalogVersion]; exists {
+		return
+	}
+	if len(e.historyOrder) >= e.historyDepth {
+		evict := e.historyOrder[0]
+		e.historyOrder = e.historyOrder[1:]
+		delete(e.history, evict)
+	}
+	cloned := make([]Route, len(e.routes))
+	copy(cloned, e.routes)
+	e.history[e.catalogVersion] = RouteHistorySnapshot{
+		version: e.catalogVersion,
+		routes:  cloned,
+	}
+	e.historyOrder = append(e.historyOrder, e.catalogVersion)
 }
 
 func staleSnapshotVersionErr(snapshotVersion, currentVersion uint64) error {

--- a/distribution/engine.go
+++ b/distribution/engine.go
@@ -80,7 +80,7 @@ func NewEngine() *Engine {
 func NewEngineWithDefaultRoute() *Engine {
 	engine := NewEngine()
 	engine.UpdateRoute([]byte(""), nil, defaultGroupID)
-	engine.recordHistorySnapshot()
+	engine.recordHistorySnapshotLocked()
 	return engine
 }
 
@@ -135,7 +135,7 @@ func (e *Engine) ApplySnapshot(snapshot CatalogSnapshot) error {
 
 	e.routes = routes
 	e.catalogVersion = snapshot.Version
-	e.recordHistorySnapshot()
+	e.recordHistorySnapshotLocked()
 	return nil
 }
 
@@ -157,10 +157,19 @@ func (s RouteHistorySnapshot) Version() uint64 { return s.version }
 // pre-bootstrap state or an explicitly-uncovered range).  Mirrors
 // Engine.GetRoute's right-half-open interval semantics but against
 // the historical snapshot, not the live engine state.
+//
+// Routes are sorted by Start (recordHistorySnapshotLocked clones from
+// e.routes, which Engine.UpdateRoute / routesFromCatalog keep sorted),
+// so the scan can break the moment key < r.Start — every later route
+// has a strictly greater Start and cannot cover key either.  This
+// matters because M3 puts OwnerOf on every txn commit's apply path
+// (claude review on PR #894 — break-vs-continue lifts the worst-case
+// scan from O(N) to "first non-covering gap" without changing the
+// resolution semantics).
 func (s RouteHistorySnapshot) OwnerOf(key []byte) (uint64, bool) {
 	for _, r := range s.routes {
 		if bytes.Compare(key, r.Start) < 0 {
-			continue
+			break
 		}
 		if r.End != nil && bytes.Compare(key, r.End) >= 0 {
 			continue
@@ -191,12 +200,15 @@ func (e *Engine) HistoryDepth() int {
 	return e.historyDepth
 }
 
-// recordHistorySnapshot pushes the current (catalogVersion, routes)
-// pair into the ring.  Caller MUST hold e.mu (write lock) — invoked
-// from ApplySnapshot under the write lock, and from
-// NewEngineWithDefaultRoute before the Engine is shared with any
-// concurrent reader.  Idempotent on re-record at the same version.
-func (e *Engine) recordHistorySnapshot() {
+// recordHistorySnapshotLocked pushes the current (catalogVersion,
+// routes) pair into the ring.  The `Locked` suffix is the Go
+// convention for "caller MUST hold the receiver's lock" — checked
+// by reviewers via name, not by the runtime (claude review on PR
+// #894 — fragile lock contract).  Invoked from ApplySnapshot under
+// the write lock and from NewEngineWithDefaultRoute before the
+// Engine is shared with any concurrent reader.  Idempotent on
+// re-record at the same version.
+func (e *Engine) recordHistorySnapshotLocked() {
 	if e.history == nil {
 		// Engines constructed via the bare struct literal (e.g.
 		// internal test seams) — no history ring configured.  Skip
@@ -210,7 +222,17 @@ func (e *Engine) recordHistorySnapshot() {
 	}
 	if len(e.historyOrder) >= e.historyDepth {
 		evict := e.historyOrder[0]
-		e.historyOrder = e.historyOrder[1:]
+		// Copy the retained tail into fresh storage rather than
+		// reslicing.  `historyOrder[1:]` only advances the slice
+		// header — the head of the original backing array stays
+		// alive and grows unboundedly across evictions.  At depth=32
+		// this is small, but the FIFO eviction is the only place
+		// the array grows, and the compaction is free (single
+		// allocation, single copy of <=historyDepth entries —
+		// claude review on PR #894 — backing-array leak).
+		retained := make([]uint64, len(e.historyOrder)-1, e.historyDepth)
+		copy(retained, e.historyOrder[1:])
+		e.historyOrder = retained
 		delete(e.history, evict)
 	}
 	cloned := make([]Route, len(e.routes))

--- a/distribution/engine_test.go
+++ b/distribution/engine_test.go
@@ -477,3 +477,171 @@ func TestEngineApplySnapshot_Concurrent(t *testing.T) {
 		t.Fatalf("expected route group %d, got %d", maxVersion, route.GroupID)
 	}
 }
+
+// TestEngineSnapshotAt_RecordsApplySnapshot is the M2 round-trip
+// witness for the Composed-1 versioned-snapshot ring (design doc
+// §M2): every successful ApplySnapshot records the (version, routes)
+// pair so SnapshotAt(v) can resolve OwnerOf(k) for any in-flight
+// transaction that observed v at BeginTxn.
+func TestEngineSnapshotAt_RecordsApplySnapshot(t *testing.T) {
+	e := NewEngine()
+	if err := e.ApplySnapshot(CatalogSnapshot{
+		Version: 1,
+		Routes: []RouteDescriptor{
+			{RouteID: 10, Start: []byte(""), End: []byte("m"), GroupID: 7, State: RouteStateActive},
+			{RouteID: 11, Start: []byte("m"), End: nil, GroupID: 9, State: RouteStateActive},
+		},
+	}); err != nil {
+		t.Fatalf("apply snapshot v1: %v", err)
+	}
+
+	snap, ok := e.SnapshotAt(1)
+	if !ok {
+		t.Fatal("expected SnapshotAt(1) to return the v1 snapshot")
+	}
+	if snap.Version() != 1 {
+		t.Fatalf("expected snapshot version 1, got %d", snap.Version())
+	}
+	if owner, found := snap.OwnerOf([]byte("a")); !found || owner != 7 {
+		t.Fatalf("expected key 'a' owner=7 in v1 snapshot; got owner=%d found=%v", owner, found)
+	}
+	if owner, found := snap.OwnerOf([]byte("z")); !found || owner != 9 {
+		t.Fatalf("expected key 'z' owner=9 in v1 snapshot; got owner=%d found=%v", owner, found)
+	}
+}
+
+// TestEngineSnapshotAt_PreservesHistoryAcrossVersions verifies the
+// M3-critical property: after ApplySnapshot has moved the catalog
+// forward, a SnapshotAt for the PRIOR version still returns the old
+// routes.  Without this, the M3 verifyComposed1 gate could not
+// resolve a txn whose observedVer is behind the current catalog —
+// exactly the case the design doc §3 G1c trace requires.
+func TestEngineSnapshotAt_PreservesHistoryAcrossVersions(t *testing.T) {
+	e := NewEngine()
+	if err := e.ApplySnapshot(CatalogSnapshot{
+		Version: 1,
+		Routes: []RouteDescriptor{
+			{RouteID: 10, Start: []byte(""), End: nil, GroupID: 1, State: RouteStateActive},
+		},
+	}); err != nil {
+		t.Fatalf("apply v1: %v", err)
+	}
+	if err := e.ApplySnapshot(CatalogSnapshot{
+		Version: 2,
+		Routes: []RouteDescriptor{
+			{RouteID: 11, Start: []byte(""), End: nil, GroupID: 2, State: RouteStateActive},
+		},
+	}); err != nil {
+		t.Fatalf("apply v2: %v", err)
+	}
+
+	snapV1, ok := e.SnapshotAt(1)
+	if !ok {
+		t.Fatal("expected v1 still in history after v2 applied")
+	}
+	if owner, _ := snapV1.OwnerOf([]byte("k")); owner != 1 {
+		t.Fatalf("v1 snapshot must still show group=1 owner; got %d", owner)
+	}
+	snapV2, ok := e.SnapshotAt(2)
+	if !ok {
+		t.Fatal("expected v2 in history")
+	}
+	if owner, _ := snapV2.OwnerOf([]byte("k")); owner != 2 {
+		t.Fatalf("v2 snapshot must show group=2 owner; got %d", owner)
+	}
+}
+
+// TestEngineSnapshotAt_FIFOEviction verifies that the ring respects
+// historyDepth: once more than depth versions have been applied, the
+// oldest is evicted and SnapshotAt returns (zero, false) for it.
+// The M3 gate (design doc §4.3) treats the not-found case as a hard
+// retryable error, so retention depth is a liveness knob — this
+// test pins the eviction order so a future depth change does not
+// silently break the M3 contract.
+func TestEngineSnapshotAt_FIFOEviction(t *testing.T) {
+	e := NewEngine()
+	// Force a tiny depth so the test is bounded and explicit.
+	e.historyDepth = 3
+
+	for v := uint64(1); v <= 5; v++ {
+		if err := e.ApplySnapshot(CatalogSnapshot{
+			Version: v,
+			Routes: []RouteDescriptor{
+				{RouteID: v, Start: []byte(""), End: nil, GroupID: v, State: RouteStateActive},
+			},
+		}); err != nil {
+			t.Fatalf("apply v%d: %v", v, err)
+		}
+	}
+
+	if _, ok := e.SnapshotAt(1); ok {
+		t.Fatal("v1 must be evicted (oldest) under depth=3 after v2..v5 applied")
+	}
+	if _, ok := e.SnapshotAt(2); ok {
+		t.Fatal("v2 must be evicted (second-oldest) under depth=3 after v3..v5 applied")
+	}
+	for v := uint64(3); v <= 5; v++ {
+		snap, ok := e.SnapshotAt(v)
+		if !ok {
+			t.Fatalf("expected v%d retained (depth=3 keeps the 3 most recent)", v)
+		}
+		if owner, _ := snap.OwnerOf([]byte("k")); owner != v {
+			t.Fatalf("v%d snapshot must show group=%d owner; got %d", v, v, owner)
+		}
+	}
+}
+
+// TestEngineSnapshotAt_UnknownVersionReturnsNotFound documents the
+// M3-relevant contract: a version that has never been applied (e.g.
+// in the future, or a typo) returns (zero, false).  The M3 gate
+// uses this signal to emit ErrComposed1VersionGCd and trigger a
+// coordinator retry.
+func TestEngineSnapshotAt_UnknownVersionReturnsNotFound(t *testing.T) {
+	e := NewEngineWithDefaultRoute()
+	if _, ok := e.SnapshotAt(42); ok {
+		t.Fatal("expected SnapshotAt for an unknown version to return false")
+	}
+}
+
+// TestEngineSnapshotAt_SeedsVersionZeroForDefaultRoute verifies that
+// the NewEngineWithDefaultRoute path records the version-0 default
+// route snapshot.  Without this, every txn that observed v=0 (the
+// common case before any ApplySnapshot lands) would fall through
+// to the M3 not-found path and trigger a spurious retry on its first
+// commit.
+func TestEngineSnapshotAt_SeedsVersionZeroForDefaultRoute(t *testing.T) {
+	e := NewEngineWithDefaultRoute()
+	snap, ok := e.SnapshotAt(0)
+	if !ok {
+		t.Fatal("expected NewEngineWithDefaultRoute to seed a v0 history entry")
+	}
+	if snap.Version() != 0 {
+		t.Fatalf("expected seed snapshot version 0, got %d", snap.Version())
+	}
+	// Default route covers the full keyspace ⇒ every key resolves to
+	// defaultGroupID at v0.
+	owner, ok := snap.OwnerOf([]byte("anything"))
+	if !ok || owner != defaultGroupID {
+		t.Fatalf("expected v0 snapshot to resolve every key to defaultGroupID=%d; got owner=%d found=%v", defaultGroupID, owner, ok)
+	}
+}
+
+// TestEngineSnapshotAt_BareEngineHasNoHistory documents that an
+// Engine constructed via the bare struct literal (e.g. via internal
+// test seams) has a nil history map and SnapshotAt always returns
+// (zero, false).  recordHistorySnapshot is nil-safe so ApplySnapshot
+// still works on such an engine, but the M3 gate will treat every
+// SnapshotAt as "not in ring" → soft-fail-as-retry, which is the
+// correct posture for unconfigured engines.
+func TestEngineSnapshotAt_BareEngineHasNoHistory(t *testing.T) {
+	e := &Engine{routes: make([]Route, 0)} // bare struct literal — no history
+	if err := e.ApplySnapshot(CatalogSnapshot{
+		Version: 1,
+		Routes:  []RouteDescriptor{{RouteID: 1, Start: []byte(""), End: nil, GroupID: 1, State: RouteStateActive}},
+	}); err != nil {
+		t.Fatalf("apply on bare engine should succeed: %v", err)
+	}
+	if _, ok := e.SnapshotAt(1); ok {
+		t.Fatal("bare engine has no history ring; SnapshotAt should always be false")
+	}
+}

--- a/distribution/engine_test.go
+++ b/distribution/engine_test.go
@@ -559,8 +559,14 @@ func TestEngineSnapshotAt_PreservesHistoryAcrossVersions(t *testing.T) {
 // test pins the eviction order so a future depth change does not
 // silently break the M3 contract.
 func TestEngineSnapshotAt_FIFOEviction(t *testing.T) {
+	t.Parallel()
 	e := NewEngine()
-	// Force a tiny depth so the test is bounded and explicit.
+	// Force a tiny depth so the test is bounded and explicit.  The
+	// direct field write is safe because `e` is local to this test
+	// goroutine and the depth is set before any ApplySnapshot fires;
+	// once the Engine is published to concurrent readers, the depth
+	// would have to flow through a constructor option (claude review
+	// on PR #894 — fragile-but-test-local lock contract).
 	e.historyDepth = 3
 
 	for v := uint64(1); v <= 5; v++ {

--- a/kv/fsm.go
+++ b/kv/fsm.go
@@ -64,6 +64,51 @@ type kvFSM struct {
 	// apply-hook to consume. Stays 0 for v1 restores and headerless
 	// legacy paths (matches the pre-Phase-2 posture exactly).
 	restoredCutover uint64
+	// routes is the M2 Composed-1 versioned-snapshot provider — the
+	// route catalog history this FSM consults at apply time to
+	// resolve OwnerOf(key) for the txn's observed catalog version.
+	// nil at M2 for nodes that have not been wired (legacy
+	// constructors), in which case the M3 verifyComposed1 gate will
+	// short-circuit as "unpinned" (no Composed-1 enforcement) —
+	// matching the pre-feature behaviour byte-for-byte.  Concrete
+	// production type is *distribution.Engine.  See
+	// docs/design/2026_05_29_proposed_composed1_cross_group_commit_guard.md
+	// §4.2 prerequisite block + §M2.
+	routes RouteHistory
+	// shardGroupID is the Raft group ID this FSM serves.  Used by
+	// the M3 verifyComposed1 gate to compare against the historical
+	// owner-of-key resolution: a txn's commit MUST land on the
+	// group that owned the key at the txn's observed catalog
+	// version.  Zero at M2 means "unset" — the M3 gate will
+	// short-circuit (matches the pre-feature behaviour).  Wired by
+	// WithRouteHistory from main.go's shard-group construction.
+	shardGroupID uint64
+}
+
+// RouteHistory is the kv-side interface to the route catalog's
+// versioned-snapshot ring.  *distribution.Engine satisfies it.
+// Defined in the kv package so kvFSM does not have to import a
+// concrete type for the field; the M3 verifyComposed1 gate uses
+// only SnapshotAt and the returned snapshot's OwnerOf, so the
+// interface stays minimal.
+type RouteHistory interface {
+	// SnapshotAt returns the route catalog at the given catalog
+	// version.  Returns (zero, false) when the version is outside
+	// the ring (either evicted by depth, or in the future).
+	SnapshotAt(version uint64) (RouteSnapshot, bool)
+}
+
+// RouteSnapshot is the historical view of the route catalog at a
+// specific version.  Returned by RouteHistory.SnapshotAt; the M3
+// gate uses Version + OwnerOf to compare against the FSM's
+// shardGroupID.
+type RouteSnapshot interface {
+	// Version returns the catalog version this snapshot was
+	// recorded at.
+	Version() uint64
+	// OwnerOf returns the Raft group ID that owned key at this
+	// snapshot's version.  (0, false) when no route covered key.
+	OwnerOf(key []byte) (uint64, bool)
 }
 
 // SetApplyIndex implements raftengine.ApplyIndexAware. The engine
@@ -102,6 +147,28 @@ func WithEncryption(applier EncryptionApplier) FSMOption {
 func WithCutoverSource(src CutoverSource) FSMOption {
 	return func(f *kvFSM) {
 		f.cutoverSource = src
+	}
+}
+
+// WithRouteHistory installs the M2 Composed-1 versioned-snapshot
+// provider and the FSM's owning shard group ID.  Both fields are
+// consumed by the M3 verifyComposed1 gate.  At M2 the values are
+// stored but not consulted (M3 wires the check); a caller that
+// constructs a kvFSM without this option remains "unpinned" — the
+// M3 gate will short-circuit and behave exactly like the
+// pre-feature FSM.
+//
+// shardGroupID MUST match the Raft group ID this FSM serves — the
+// gate uses it as the "this group" value when comparing against the
+// historical owner-of-key resolution.  Zero is reserved for the
+// not-wired case.
+//
+// See docs/design/2026_05_29_proposed_composed1_cross_group_commit_guard.md
+// §M2 + §4.2 prerequisite block.
+func WithRouteHistory(routes RouteHistory, shardGroupID uint64) FSMOption {
+	return func(f *kvFSM) {
+		f.routes = routes
+		f.shardGroupID = shardGroupID
 	}
 }
 

--- a/kv/fsm_route_history_test.go
+++ b/kv/fsm_route_history_test.go
@@ -1,0 +1,97 @@
+package kv
+
+import (
+	"testing"
+
+	"github.com/bootjp/elastickv/distribution"
+	"github.com/bootjp/elastickv/store"
+	"github.com/stretchr/testify/require"
+)
+
+// TestKvFSMWithRouteHistory_StoresFields verifies the M2 plumbing:
+// the WithRouteHistory option stores the RouteHistory provider and
+// the shardGroupID on the FSM struct.  At M2 the fields are not
+// consulted by the apply path; M3's verifyComposed1 will read them.
+// This is the design doc §M2 "Done when" criterion — the struct
+// extension is in place and compiles with the constructor wiring.
+func TestKvFSMWithRouteHistory_StoresFields(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngineWithDefaultRoute()
+	st := store.NewMVCCStore()
+
+	fsmIface := NewKvFSMWithHLC(st, NewHLC(),
+		WithRouteHistory(WrapDistributionEngine(engine), 42),
+	)
+	fsm, ok := fsmIface.(*kvFSM)
+	require.True(t, ok, "NewKvFSMWithHLC must return *kvFSM")
+
+	require.NotNil(t, fsm.routes,
+		"WithRouteHistory must install the RouteHistory provider on the FSM")
+	require.Equal(t, uint64(42), fsm.shardGroupID,
+		"WithRouteHistory must record the owning Raft group ID")
+
+	// Round-trip a known route through the provider so the adapter +
+	// the M2 ring + the v0 seed are exercised end-to-end.
+	snap, ok := fsm.routes.SnapshotAt(0)
+	require.True(t, ok,
+		"WrapDistributionEngine + NewEngineWithDefaultRoute must seed v=0")
+	require.Equal(t, uint64(0), snap.Version())
+
+	owner, found := snap.OwnerOf([]byte("anything"))
+	require.True(t, found)
+	require.NotZero(t, owner,
+		"the default route must own the keyspace at v=0 so M3 can resolve every key for unpinned txns")
+}
+
+// TestKvFSM_NilRouteHistoryByDefault documents the M2 legacy-default:
+// constructors that do NOT pass WithRouteHistory leave routes=nil and
+// shardGroupID=0.  M3's verifyComposed1 will short-circuit on the nil
+// provider and behave exactly like the pre-feature FSM.
+func TestKvFSM_NilRouteHistoryByDefault(t *testing.T) {
+	t.Parallel()
+
+	fsmIface := NewKvFSMWithHLC(store.NewMVCCStore(), NewHLC())
+	fsm, ok := fsmIface.(*kvFSM)
+	require.True(t, ok)
+
+	require.Nil(t, fsm.routes,
+		"FSM constructed without WithRouteHistory must keep routes nil — M3 reads this as 'unpinned' and skips the Composed-1 gate")
+	require.Equal(t, uint64(0), fsm.shardGroupID,
+		"shardGroupID must default to 0 (the 'unset' sentinel) when WithRouteHistory is not supplied")
+}
+
+// TestWrapDistributionEngine_NilEngineReturnsNil verifies the
+// adapter's defensive shape: passing nil yields nil, so a caller
+// that conditionally builds the option can safely pass either a
+// real engine or nil without an explicit guard at the FSM
+// construction site.
+func TestWrapDistributionEngine_NilEngineReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, WrapDistributionEngine(nil))
+}
+
+// TestKvFSM_WithRouteHistory_NilProviderTreatedAsUnwired verifies that
+// passing a nil RouteHistory through WithRouteHistory is equivalent
+// to not passing the option at all.  Production main.go uses
+// WrapDistributionEngine(nil) → nil for nodes that have not yet
+// constructed the engine (e.g. early bootstrap); the FSM should
+// treat this exactly like the legacy default.
+func TestKvFSM_WithRouteHistory_NilProviderTreatedAsUnwired(t *testing.T) {
+	t.Parallel()
+
+	fsmIface := NewKvFSMWithHLC(store.NewMVCCStore(), NewHLC(),
+		WithRouteHistory(nil, 7),
+	)
+	fsm, ok := fsmIface.(*kvFSM)
+	require.True(t, ok)
+
+	require.Nil(t, fsm.routes,
+		"nil RouteHistory must remain nil; the M3 gate will short-circuit and behave like an unwired FSM")
+	// shardGroupID is still recorded — the design doc says zero is
+	// the "unset" sentinel but a caller that explicitly passes a
+	// non-zero shardGroupID with a nil provider gets the gate
+	// short-circuited anyway via the nil routes check.  No invariant
+	// to assert on the ID here.
+}

--- a/kv/fsm_route_history_test.go
+++ b/kv/fsm_route_history_test.go
@@ -92,6 +92,9 @@ func TestKvFSM_WithRouteHistory_NilProviderTreatedAsUnwired(t *testing.T) {
 	// shardGroupID is still recorded — the design doc says zero is
 	// the "unset" sentinel but a caller that explicitly passes a
 	// non-zero shardGroupID with a nil provider gets the gate
-	// short-circuited anyway via the nil routes check.  No invariant
-	// to assert on the ID here.
+	// short-circuited anyway via the nil routes check.  Assert the
+	// non-zero ID survives so a future refactor that accidentally
+	// zeroes it would be caught (claude review on PR #894).
+	require.Equal(t, uint64(7), fsm.shardGroupID,
+		"WithRouteHistory(nil, 7) must still record shardGroupID=7; the M3 nil-routes short-circuit fires before the ID is consulted")
 }

--- a/kv/route_history.go
+++ b/kv/route_history.go
@@ -1,0 +1,54 @@
+package kv
+
+import (
+	"github.com/bootjp/elastickv/distribution"
+)
+
+// WrapDistributionEngine adapts a *distribution.Engine so it satisfies the
+// kv.RouteHistory interface that kvFSM's M2 Composed-1 plumbing consumes.
+//
+// The adapter is a thin two-hop boxing: kv.RouteHistory.SnapshotAt returns
+// a kv.RouteSnapshot interface; distribution.Engine.SnapshotAt returns a
+// concrete distribution.RouteHistorySnapshot struct.  Go's structural
+// interface satisfaction is byte-equivalent on return types, so we cannot
+// have *distribution.Engine satisfy kv.RouteHistory directly — and moving
+// the interface to the distribution package would create an import cycle
+// (kv already imports distribution via kv/sharded_coordinator.go).
+//
+// Production wiring in main.go uses WrapDistributionEngine to install the
+// engine as the FSM's route-history provider; tests that want to mock
+// kv.RouteHistory bypass the wrapper entirely and implement the kv
+// interface directly.
+//
+// See docs/design/2026_05_29_proposed_composed1_cross_group_commit_guard.md
+// §M2.
+func WrapDistributionEngine(e *distribution.Engine) RouteHistory {
+	if e == nil {
+		return nil
+	}
+	return &distributionEngineAdapter{e: e}
+}
+
+type distributionEngineAdapter struct {
+	e *distribution.Engine
+}
+
+func (a *distributionEngineAdapter) SnapshotAt(v uint64) (RouteSnapshot, bool) {
+	snap, ok := a.e.SnapshotAt(v)
+	if !ok {
+		return nil, false
+	}
+	return distributionRouteSnapshot{snap: snap}, true
+}
+
+type distributionRouteSnapshot struct {
+	snap distribution.RouteHistorySnapshot
+}
+
+func (s distributionRouteSnapshot) Version() uint64 {
+	return s.snap.Version()
+}
+
+func (s distributionRouteSnapshot) OwnerOf(key []byte) (uint64, bool) {
+	return s.snap.OwnerOf(key)
+}

--- a/main.go
+++ b/main.go
@@ -378,6 +378,7 @@ func run() error {
 		keystore,
 		*encryptionSidecarPath,
 		*encryptionEnabled,
+		cfg.engine,
 	)
 	if err = chainEncryptionStartupGuard(
 		err,
@@ -774,6 +775,7 @@ func buildShardGroups(
 	keystore *encryption.Keystore,
 	sidecarPath string,
 	encWiring encryptionWriteWiring,
+	routeEngine *distribution.Engine,
 ) ([]*raftGroupRuntime, map[uint64]*kv.ShardGroup, error) {
 	// Defend the "cache is always non-nil" contract for callers that
 	// pass a zero-value encryptionWriteWiring{} (the encryption-off
@@ -839,7 +841,17 @@ func buildShardGroups(
 			_ = st.Close()
 			return nil, nil, errors.Wrapf(err, "failed to construct encryption applier for group %d", g.id)
 		}
-		sm := kv.NewKvFSMWithHLC(st, clock, kv.WithEncryption(applier))
+		// Composed-1 M2 plumbing: wire the shared route catalog
+		// engine and this shard's owning group ID so M3's
+		// verifyComposed1 apply-time gate can resolve the
+		// observed-version owner-of-key without further plumbing
+		// work. At M2 the FSM stores both but does not consult them;
+		// see docs/design/2026_05_29_proposed_composed1_cross_group_commit_guard.md
+		// §M2.
+		sm := kv.NewKvFSMWithHLC(st, clock,
+			kv.WithEncryption(applier),
+			kv.WithRouteHistory(kv.WrapDistributionEngine(routeEngine), g.id),
+		)
 		runtime, err := buildRuntimeForGroup(raftID, g, raftDir, multi, bootstrap, bootstrapServers, st, sm, factory, *raftJoinAsLearner)
 		if err != nil {
 			for _, rt := range runtimes {

--- a/main_bootstrap_e2e_test.go
+++ b/main_bootstrap_e2e_test.go
@@ -356,7 +356,7 @@ func startBootstrapE2ENode(
 		return nil, err
 	}
 	clock := kv.NewHLC()
-	runtimes, shardGroups, err := buildShardGroups(ep.id, baseDir, cfg.groups, cfg.multi, bootstrap, bootstrapServers, factory, nil, clock, nil, nil, "", encryptionWriteWiring{})
+	runtimes, shardGroups, err := buildShardGroups(ep.id, baseDir, cfg.groups, cfg.multi, bootstrap, bootstrapServers, factory, nil, clock, nil, nil, "", encryptionWriteWiring{}, cfg.engine)
 	if err != nil {
 		return nil, err
 	}

--- a/main_encryption_write_wiring.go
+++ b/main_encryption_write_wiring.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/bootjp/elastickv/distribution"
 	"github.com/bootjp/elastickv/internal/encryption"
 	"github.com/bootjp/elastickv/internal/encryption/kek"
 	"github.com/bootjp/elastickv/internal/raftengine"
@@ -34,13 +35,14 @@ func buildShardGroupsWithEncryptionWiring(
 	keystore *encryption.Keystore,
 	sidecarPath string,
 	encryptionEnabled bool,
+	routeEngine *distribution.Engine,
 ) ([]*raftGroupRuntime, map[uint64]*kv.ShardGroup, encryptionWriteWiring, error) {
 	encWiring, err := buildEncryptionWriteWiring(encryptionEnabled, raftID, sidecarPath, kekWrapper, keystore)
 	if err != nil {
 		return nil, nil, encryptionWriteWiring{}, err
 	}
 	runtimes, shardGroups, err := buildShardGroups(raftID, raftDir, groups, multi, bootstrap, bootstrapServers,
-		factory, proposalObserverForGroup, clock, kekWrapper, keystore, sidecarPath, encWiring)
+		factory, proposalObserverForGroup, clock, kekWrapper, keystore, sidecarPath, encWiring, routeEngine)
 	// Return the wiring (cache + bumped epoch) so run() can drive the
 	// Stage 7a process-start registration after the shard stores open.
 	return runtimes, shardGroups, encWiring, err

--- a/multiraft_runtime_test.go
+++ b/multiraft_runtime_test.go
@@ -54,7 +54,7 @@ func TestBuildShardGroupsWithEtcdEngineRoutesAcrossGroups(t *testing.T) {
 	factory, err := newRaftFactory(raftEngineEtcd)
 	require.NoError(t, err)
 	clock := kv.NewHLC()
-	runtimes, shardGroups, err := buildShardGroups("n1", baseDir, groups, true, true, nil, factory, nil, clock, nil, nil, "", encryptionWriteWiring{})
+	runtimes, shardGroups, err := buildShardGroups("n1", baseDir, groups, true, true, nil, factory, nil, clock, nil, nil, "", encryptionWriteWiring{}, nil)
 	require.NoError(t, err)
 
 	engine := distribution.NewEngine()
@@ -108,7 +108,7 @@ func TestBuildShardGroupsWithEtcdEngineRestartsAcrossGroups(t *testing.T) {
 	openShardStore := func(bootstrap bool) ([]*raftGroupRuntime, map[uint64]*kv.ShardGroup, *kv.ShardStore) {
 		factory, err := newRaftFactory(raftEngineEtcd)
 		require.NoError(t, err)
-		runtimes, shardGroups, err := buildShardGroups("n1", baseDir, groups, true, bootstrap, nil, factory, nil, sharedClock, nil, nil, "", encryptionWriteWiring{})
+		runtimes, shardGroups, err := buildShardGroups("n1", baseDir, groups, true, bootstrap, nil, factory, nil, sharedClock, nil, nil, "", encryptionWriteWiring{}, nil)
 		require.NoError(t, err)
 		shardStore := kv.NewShardStore(engine, shardGroups)
 		return runtimes, shardGroups, shardStore


### PR DESCRIPTION
## Summary

Second milestone (**M2**) of the Composed-1 cross-group commit-time guard per `docs/design/2026_05_29_proposed_composed1_cross_group_commit_guard.md` §M2.

Lands the **catalog version retention ring** and the **kvFSM struct extension** end-to-end so M3 (the apply-time gate) has every piece it needs without further plumbing churn. **Behaviour-neutral**: the FSM stores `routes` + `shardGroupID` but does not consult them at apply time yet.

## What changes

### Distribution layer

- `distribution.Engine` gains a FIFO ring of `RouteHistorySnapshot` entries keyed by `catalogVersion`. Populated on every successful `ApplySnapshot` AND on `NewEngineWithDefaultRoute` (the v=0 seed, so a txn observing v=0 can resolve `OwnerOf` without falling through to the M3 not-found path on first commit).
- New public constant `DefaultRouteHistoryDepth = 32` per design doc §9 Q2.
- New `RouteHistorySnapshot` struct + `OwnerOf(key) (groupID, bool)` + `Version()` accessor. `OwnerOf` mirrors `Engine.GetRoute`'s right-half-open interval semantics against the historical snapshot.
- New `Engine.SnapshotAt(v)` reads from the ring; returns `(zero, false)` for evicted / never-seen versions (M3 will surface this as `ErrComposed1VersionGCd` → coordinator retry).

### kv layer

- `kvFSM` gains `routes RouteHistory` + `shardGroupID uint64` fields with doc comments pointing at §M2 / §4.2.
- New `RouteHistory` + `RouteSnapshot` interfaces defined in `kv` so the FSM does not import distribution concretely.
- New `WithRouteHistory(routes, shardGroupID)` FSM option.
- New `kv/route_history.go::WrapDistributionEngine` adapter boxes a `*distribution.Engine` so it satisfies `kv.RouteHistory`. Go's structural-interface satisfaction is byte-equivalent on return types — `Engine.SnapshotAt` returns the concrete struct, kv.RouteHistory's `SnapshotAt` returns the interface; moving the interface to `distribution` would create an import cycle.

### main.go wiring

- `buildShardGroups` and its caller `buildShardGroupsWithEncryptionWiring` gain a `routeEngine *distribution.Engine` parameter.
- Each shard FSM's `NewKvFSMWithHLC` now installs `WithRouteHistory(WrapDistributionEngine(routeEngine), g.id)`.
- Existing test callers (`main_bootstrap_e2e_test.go`, `multiraft_runtime_test.go`) updated for the new signature.

## Tests (10 new)

**distribution/engine_test.go (6 new)**:
- `TestEngineSnapshotAt_RecordsApplySnapshot` — round-trip witness
- `TestEngineSnapshotAt_PreservesHistoryAcrossVersions` — the M3-critical "old version is still resolvable after a new ApplySnapshot lands"
- `TestEngineSnapshotAt_FIFOEviction` — depth=3 explicit, pins eviction order so a future depth change does not silently break the M3 contract
- `TestEngineSnapshotAt_UnknownVersionReturnsNotFound`
- `TestEngineSnapshotAt_SeedsVersionZeroForDefaultRoute` — the v=0 seed for the common pre-bootstrap case
- `TestEngineSnapshotAt_BareEngineHasNoHistory` — bare-struct Engine is nil-safe; SnapshotAt always returns false (M3 will treat as "not in ring")

**kv/fsm_route_history_test.go (4 new)**:
- `TestKvFSMWithRouteHistory_StoresFields` — the M2 "Done when" criterion: struct extension wired through the adapter + v=0 seed end-to-end
- `TestKvFSM_NilRouteHistoryByDefault` — legacy-default: no `WithRouteHistory` → `routes` nil, `shardGroupID` 0
- `TestWrapDistributionEngine_NilEngineReturnsNil` — defensive
- `TestKvFSM_WithRouteHistory_NilProviderTreatedAsUnwired` — defensive: nil `RouteHistory` via the option ≡ no option

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -race -count=1 ./distribution ./kv` — 1.0 s + 7.9 s, pass
- `make lint` — 0 issues

## Self-review (5 lenses)

1. **Data loss** — no new write paths; the ring is in-memory only and rebuilt from `ApplySnapshot` on restart (catalog state is re-derived from the default Raft group's reserved keys via the existing watcher).
2. **Concurrency** — ring lives under `Engine.mu` (the existing write-lock used by `ApplySnapshot`). `recordHistorySnapshot` is called with the lock held. `RouteHistorySnapshot` is immutable (routes are cloned on record). `SnapshotAt` takes the read lock. No new lock ordering.
3. **Performance** — one extra map insert + slice append per `ApplySnapshot` (operator-frequency, not data-plane). Routes clone is `O(|routes|)`. No additional per-request hot-path work at M2.
4. **Data consistency** — at M2 the ring is plumbing only; no consistency surface change. The ring contract matches what M3's `verifyComposed1` needs.
5. **Test coverage** — 10 new unit tests cover round-trip, eviction order, v=0 seed, nil-safe bare engine, FSM struct extension, the adapter, legacy default. Existing engine and FSM tests pass unchanged.

## Test plan

- [x] `go test -race ./distribution ./kv`
- [x] `make lint`
- [ ] (Follow-up PR) **M3** — FSM `verifyComposed1` (observed-version §4.2(a) + current-version §4.4) + `ErrComposed1Violation` / `ErrComposed1VersionGCd` sentinels + coordinator retry path.

## Resolves

The M2 row in the Composed-1 design doc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Route history tracking: records versioned snapshots of route configurations and exposes snapshot lookup and history depth.
  * Route-history integration: route snapshots can be consulted by per-group state machines for cross-group verification.

* **Tests**
  * Added comprehensive tests for snapshot recording, lookup semantics, FIFO eviction, default seeding, and constructor wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->