### PR TITLE
test(util): commit one no-op entry to prove leader writeable in waitForRaftReadiness

### DIFF
--- a/adapter/test_util.go
+++ b/adapter/test_util.go
@@ -312,6 +312,70 @@ func waitForRaftReadiness(t *testing.T, nodes []Node, peers []raftengine.Server,
 	// transient "not leader" errors. A stability window catches the
 	// flip and loops until the leader actually holds.
 	waitForStableLeader(t, nodes, peers, waitTimeout)
+
+	// Prove the leader can actually COMMIT by driving one no-op
+	// entry through full Raft quorum before we hand the cluster
+	// to the test body. The 300 ms stability window above only
+	// proves leadership *appears* held; a leader can still step
+	// down on the first real heartbeat-quorum miss after that.
+	// 5ba2ef94 / rpushEventually / lpushEventually have been
+	// absorbing that post-readiness churn per-test for the past
+	// several months — this commits-one-entry probe closes the
+	// window at the readiness layer instead, so any subsequent
+	// write inherits a leader that has already held quorum
+	// through one apply.
+	waitForWriteableLeader(t, nodes, waitTimeout)
+}
+
+// raftReadinessProbePayload is the 9-byte Raft entry waitForWriteableLeader
+// proposes. The FSM dispatches on data[0]: 0x02 (raftEncodeHLCLease) selects
+// applyHLCLease, which reads `data[1:]` as a big-endian uint64 physical
+// ceiling. With ceiling=0 the function's `if ceilingMs > 0` guard skips the
+// HLC update and returns nil — a true no-op at the state-machine layer,
+// while the entry still goes through full Raft quorum so a successful
+// Propose proves the leader holds. See kv/fsm.go applyHLCLease + the
+// raftEncodeHLCLease comment.
+var raftReadinessProbePayload = []byte{
+	0x02,                                           // raftEncodeHLCLease
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // BE uint64 ceiling = 0 (no-op)
+}
+
+// waitForWriteableLeader commits one no-op Raft entry through nodes[0]'s
+// engine to prove the leader is not just *named* but actually able to
+// drive quorum. Retries on transient leader-unavailable errors up to
+// timeout — a re-election that races the probe is what this helper is
+// designed to ride out.
+//
+// Without this step, waitForRaftReadiness would return after a 300 ms
+// stability window during which leadership only *looks* stable; a
+// leader that steps down on its first real heartbeat-quorum miss can
+// surface as "etcd raft engine is not leader" on the test's first
+// write. See commits 5ba2ef94 / rpushEventually / lpushEventually for
+// the per-test work-arounds this readiness gate is meant to obsolete.
+func waitForWriteableLeader(t *testing.T, nodes []Node, timeout time.Duration) {
+	t.Helper()
+	if len(nodes) == 0 || nodes[0].engine == nil {
+		return
+	}
+	deadline := time.Now().Add(timeout)
+	const perProposeTimeout = 2 * time.Second
+	var lastErr error
+	for {
+		proposeCtx, cancel := context.WithTimeout(context.Background(), perProposeTimeout)
+		_, err := nodes[0].engine.Propose(proposeCtx, raftReadinessProbePayload)
+		cancel()
+		if err == nil {
+			return
+		}
+		lastErr = err
+		if !isTransientNotLeaderErr(err) {
+			t.Fatalf("readiness probe failed with non-transient error: %v", err)
+		}
+		if !time.Now().Before(deadline) {
+			t.Fatalf("readiness probe never committed within %s (last err: %v)", timeout, lastErr)
+		}
+		time.Sleep(leaderChurnRetryInterval)
+	}
 }
 
 // waitForStableLeader polls the cluster until nodes[0] has been the leader

--- a/adapter/test_util.go
+++ b/adapter/test_util.go
@@ -358,17 +358,18 @@ func waitForWriteableLeader(t *testing.T, nodes []Node, timeout time.Duration) {
 		return
 	}
 	deadline := time.Now().Add(timeout)
-	const perProposeTimeout = 2 * time.Second
 	var lastErr error
 	for {
-		proposeCtx, cancel := context.WithTimeout(context.Background(), perProposeTimeout)
-		_, err := nodes[0].engine.Propose(proposeCtx, raftReadinessProbePayload)
-		cancel()
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			t.Fatalf("readiness probe never committed within %s (last err: %v)", timeout, lastErr)
+		}
+		err := proposeReadinessOnce(nodes[0].engine, remaining)
 		if err == nil {
 			return
 		}
 		lastErr = err
-		if !isTransientNotLeaderErr(err) {
+		if !isReadinessProbeRetryable(err) {
 			t.Fatalf("readiness probe failed with non-transient error: %v", err)
 		}
 		if !time.Now().Before(deadline) {
@@ -376,6 +377,37 @@ func waitForWriteableLeader(t *testing.T, nodes []Node, timeout time.Duration) {
 		}
 		time.Sleep(leaderChurnRetryInterval)
 	}
+}
+
+// proposeReadinessOnce drives one no-op probe through the engine's
+// Propose, bounded by min(perProposeTimeout, remaining) so the
+// per-attempt ctx cannot block past the outer deadline (gemini PR
+// #898 HIGH point 1). Extracted from waitForWriteableLeader to keep
+// the outer loop under the cyclop budget; the retry/timeout
+// rationale lives at the call site.
+func proposeReadinessOnce(engine raftengine.Engine, remaining time.Duration) error {
+	const perProposeTimeout = 2 * time.Second
+	currTimeout := perProposeTimeout
+	if remaining < currTimeout {
+		currTimeout = remaining
+	}
+	proposeCtx, cancel := context.WithTimeout(context.Background(), currTimeout)
+	defer cancel()
+	_, err := engine.Propose(proposeCtx, raftReadinessProbePayload)
+	return err
+}
+
+// isReadinessProbeRetryable widens isTransientNotLeaderErr for the
+// readiness-probe loop: a per-propose ctx timeout under heavy CI
+// load returns context.DeadlineExceeded, which the base classifier
+// does NOT treat as transient. Without this widening the probe
+// would t.Fatalf on a slow runner instead of retrying within its
+// outer budget. context.Canceled is treated symmetrically (gemini
+// PR #898 HIGH point 2).
+func isReadinessProbeRetryable(err error) bool {
+	return isTransientNotLeaderErr(err) ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, context.Canceled)
 }
 
 // waitForStableLeader polls the cluster until nodes[0] has been the leader

--- a/adapter/test_util.go
+++ b/adapter/test_util.go
@@ -323,7 +323,13 @@ func waitForRaftReadiness(t *testing.T, nodes []Node, peers []raftengine.Server,
 	// probe closes the window at the readiness layer instead, so any
 	// subsequent write inherits a leader that has already held
 	// quorum through one apply.
-	waitForWriteableLeader(t, nodes, waitTimeout)
+	//
+	// `peers` and `waitInterval` are passed through so the probe loop
+	// can re-nudge leadership back to nodes[0] when a real re-election
+	// elects a different node mid-probe — without that, the loop
+	// would keep proposing through a follower engine until the budget
+	// expires and spuriously fail the readiness gate.
+	waitForWriteableLeader(t, nodes, peers, waitTimeout, waitInterval)
 }
 
 // raftReadinessProbePayload is the 9-byte Raft entry waitForWriteableLeader
@@ -352,7 +358,7 @@ var raftReadinessProbePayload = []byte{
 // write — the failure mode the per-test retry wrappers in this file
 // have been working around. See the PR description for the full
 // flake-fix history this readiness gate is meant to obsolete.
-func waitForWriteableLeader(t *testing.T, nodes []Node, timeout time.Duration) {
+func waitForWriteableLeader(t *testing.T, nodes []Node, peers []raftengine.Server, timeout, waitInterval time.Duration) {
 	t.Helper()
 	if len(nodes) == 0 || nodes[0].engine == nil {
 		return
@@ -372,6 +378,19 @@ func waitForWriteableLeader(t *testing.T, nodes []Node, timeout time.Duration) {
 		if !isReadinessProbeRetryable(err) {
 			t.Fatalf("readiness probe failed with non-transient error: %v", err)
 		}
+		// If the per-attempt error was specifically "not leader" (vs
+		// a ctx timeout), a real re-election has elected a different
+		// node since waitForStableLeader returned. Keep aiming the
+		// probe at nodes[0] by re-running ensureNodeZeroIsLeader
+		// before the next attempt; otherwise the loop would spin on
+		// a follower engine until the budget expires and spuriously
+		// fail the readiness gate even though the cluster has
+		// recovered with a different leader. ensureNodeZeroIsLeader
+		// is idempotent in the steady state, so this costs nothing
+		// when leadership has not actually moved.
+		if isTransientNotLeaderErr(err) && len(peers) > 0 {
+			ensureNodeZeroIsLeader(t, nodes, peers, time.Until(deadline), waitInterval)
+		}
 		if !time.Now().Before(deadline) {
 			t.Fatalf("readiness probe never committed within %s (last err: %v)", timeout, lastErr)
 		}
@@ -381,10 +400,10 @@ func waitForWriteableLeader(t *testing.T, nodes []Node, timeout time.Duration) {
 
 // proposeReadinessOnce drives one no-op probe through the engine's
 // Propose, bounded by min(perProposeTimeout, remaining) so the
-// per-attempt ctx cannot block past the outer deadline (gemini PR
-// #898 HIGH point 1). Extracted from waitForWriteableLeader to keep
-// the outer loop under the cyclop budget; the retry/timeout
-// rationale lives at the call site.
+// per-attempt ctx cannot block past the outer deadline when the
+// overall budget is nearly exhausted. Extracted from
+// waitForWriteableLeader to keep the outer loop under the cyclop
+// budget; the retry/timeout rationale lives at the call site.
 func proposeReadinessOnce(engine raftengine.Engine, remaining time.Duration) error {
 	const perProposeTimeout = 2 * time.Second
 	currTimeout := perProposeTimeout
@@ -402,8 +421,7 @@ func proposeReadinessOnce(engine raftengine.Engine, remaining time.Duration) err
 // load returns context.DeadlineExceeded, which the base classifier
 // does NOT treat as transient. Without this widening the probe
 // would t.Fatalf on a slow runner instead of retrying within its
-// outer budget. context.Canceled is treated symmetrically (gemini
-// PR #898 HIGH point 2).
+// outer budget. context.Canceled is treated symmetrically.
 func isReadinessProbeRetryable(err error) bool {
 	return isTransientNotLeaderErr(err) ||
 		errors.Is(err, context.DeadlineExceeded) ||

--- a/adapter/test_util.go
+++ b/adapter/test_util.go
@@ -318,12 +318,11 @@ func waitForRaftReadiness(t *testing.T, nodes []Node, peers []raftengine.Server,
 	// to the test body. The 300 ms stability window above only
 	// proves leadership *appears* held; a leader can still step
 	// down on the first real heartbeat-quorum miss after that.
-	// 5ba2ef94 / rpushEventually / lpushEventually have been
-	// absorbing that post-readiness churn per-test for the past
-	// several months — this commits-one-entry probe closes the
-	// window at the readiness layer instead, so any subsequent
-	// write inherits a leader that has already held quorum
-	// through one apply.
+	// The per-test retry wrappers in this file have been absorbing
+	// that post-readiness churn site-by-site; this commits-one-entry
+	// probe closes the window at the readiness layer instead, so any
+	// subsequent write inherits a leader that has already held
+	// quorum through one apply.
 	waitForWriteableLeader(t, nodes, waitTimeout)
 }
 
@@ -350,8 +349,9 @@ var raftReadinessProbePayload = []byte{
 // stability window during which leadership only *looks* stable; a
 // leader that steps down on its first real heartbeat-quorum miss can
 // surface as "etcd raft engine is not leader" on the test's first
-// write. See commits 5ba2ef94 / rpushEventually / lpushEventually for
-// the per-test work-arounds this readiness gate is meant to obsolete.
+// write — the failure mode the per-test retry wrappers in this file
+// have been working around. See the PR description for the full
+// flake-fix history this readiness gate is meant to obsolete.
 func waitForWriteableLeader(t *testing.T, nodes []Node, timeout time.Duration) {
 	t.Helper()
 	if len(nodes) == 0 || nodes[0].engine == nil {


### PR DESCRIPTION
## Summary

Structural fix for the recurring **leader-churn CI flake** pattern. Closes the post-readiness step-down window at the readiness layer instead of asking every new test author to remember to use `*Eventually` helpers.

Companion to PR #891 (SQS throttle structural fix): same recipe — *each per-test fix to a recurring flake mechanism leaves the same trap for the next test*. PR #891 hardened the SQS throttle-refill subset; this PR hardens the leader-churn subset.

## Recurring flake pattern (5+ commits this year)

| Commit | What it touched |
|---|---|
| [`5ba2ef94`](https://github.com/bootjp/elastickv/commit/5ba2ef94) | added `doEventually` / `rpushEventually` / `lpushEventually`, wrapped 2 RPUSH/LPUSH calls in `TestRedis_LuaRPopLPushBullMQLikeLists` |
| [`2b6e8f28`](https://github.com/bootjp/elastickv/commit/2b6e8f28) | widened raft election budget + retried gRPC on leader churn |
| [`78b9d091`](https://github.com/bootjp/elastickv/commit/78b9d091) | retried leader churn in consistency loops |
| [`0fb7db76`](https://github.com/bootjp/elastickv/commit/0fb7db76) | fixed flaky `TestRedis_LuaRPopLPushBullMQLikeLists` (re-fix) |
| [`ba3f5bf8`](https://github.com/bootjp/elastickv/commit/ba3f5bf8) | waited for follower apply catch-up in MultiExec |

Root cause is the same: `waitForStableLeader` only proves leadership *appears* stable for a 300 ms window. The freshly-elected leader can still step down on its first real heartbeat-quorum miss after that window closes, surfacing as `"etcd raft engine is not leader"` on the test's first write.

## Mechanism

Add `waitForWriteableLeader` that drives one no-op Raft entry through full quorum after `waitForStableLeader` returns:

```go
var raftReadinessProbePayload = []byte{
    0x02,                                           // raftEncodeHLCLease
    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // BE uint64 ceiling = 0 (no-op)
}
```

- **State-machine no-op**: `kv/fsm.go applyHLCLease` reads `data[1:]` as a big-endian uint64 ceiling. The `if ceilingMs > 0` guard at line 185 makes ceiling=0 a true no-op (no HLC mutation, no storage write, no encryption dispatch).
- **Quorum-proving**: the entry still traverses the full propose → append → replicate → commit → apply pipeline, so a successful `Propose` proves the leader can actually drive quorum.
- **Retry semantics**: retries on transient leader-unavailable errors (same set `isTransientNotLeaderErr` already classifies) up to caller-supplied `waitTimeout` (10s at the current `createNode` call site). Per-propose timeout is 2s.

Wired into `waitForRaftReadiness` as the final step.

## Caller audit (per /loop semantic-change rule)

- `waitForRaftReadiness`: single production call site (`createNode`); behavior change is **additive** — same semantics PLUS the writeable-leader gate. Tests that previously raced into a step-down window now block until the leader has committed one entry.
- `waitForWriteableLeader` / `raftReadinessProbePayload`: package-private to `adapter/test_util.go`; no external callers (grep verified).
- `applyHLCLease` (`kv/fsm.go`): receives one extra invocation per `createNode` call. Behavior on `ceiling=0` is documented no-op. No state divergence across replicas — every FSM applies the same payload.
- Side effects:
  - `pendingApplyIdx` advances by 1 (normal flow)
  - encryption applier untouched (opcode `0x02` not in encryption band)
  - snapshots include one extra applied index (already varies by test timing)
  - lease provider does not track HLC entries
- Per-test wall-clock: ~10 ms extra on a stable cluster. 29 test files use `createNode` → ~290 ms total CI overhead. Negligible.

## Validation

- `go test ./adapter/ -run TestRedis_LuaRPopLPushBullMQLikeLists -race -count=3` → ok 5.4s
- `go test ./adapter/ -run 'TestRedis_SET|TestRedis_LPush|TestRedis_RPush|TestSQSServer_Throttle|TestRedis_MULTI' -race -count=2` → ok 5.6s
- `gofmt` + `go vet` + `golangci-lint run` → 0 issues

## Follow-up note

Existing per-test `*Eventually` wrappers (`rpushEventually`, `lpushEventually`) remain valid for tests that issue writes **long after** `createNode`, where mid-test leader churn under CI load can still hit. The readiness probe targets the startup window specifically — it does not obsolete the helpers for other use cases.

Subsequent commits can audit whether tests still calling `rpushEventually` / `lpushEventually` *immediately after* `createNode` can drop back to direct calls now that the startup window is closed at the readiness layer.

## Out-of-scope (remaining recurring flake categories)

Tracked in the PR #891 description; still to be addressed in follow-up PRs:
- Redis TTL window racing → per-test deadline-multiplier helper
- VM pool / cache hit-rate assertions → "don't assert on cache hit rates" rule
