### PR TITLE
feat(encryption): Stage 6E-1a — FSM apply machinery for enable-raft-envelope cutover

### DIFF
--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -826,11 +826,17 @@ func advanceRaftAppliedIndex(sc *Sidecar, raftIdx uint64) {
 //   - RotateSubEnableStorageEnvelope — one-shot storage-layer
 //     cutover (Stage 6D-4). Flips StorageEnvelopeActive and records
 //     StorageEnvelopeCutoverIndex inside a single sidecar fsync.
+//   - RotateSubEnableRaftEnvelope — one-shot raft-layer cutover
+//     (Stage 6E-1). Records RaftEnvelopeCutoverIndex inside a
+//     single sidecar fsync. The engine apply-hook installed by
+//     6E-2 dispatches `entry.Index > sidecar.RaftEnvelopeCutoverIndex`
+//     through the unwrap path; strict `>` makes the cutover entry
+//     itself (at index == cutover) flow through unwrap-free, which
+//     is the chicken/egg bootstrap.
 //
-// Other sub-tags (rewrap-deks, retire-dek, enable-raft-envelope)
-// land in later stages and return ErrEncryptionApply so the
-// HaltApply seam fires on an unrecognised sub-tag rather than
-// silently advancing setApplied.
+// Other sub-tags (rewrap-deks, retire-dek) land in later stages
+// and return ErrEncryptionApply so the HaltApply seam fires on an
+// unrecognised sub-tag rather than silently advancing setApplied.
 //
 // Same WithKEK / WithKeystore / WithSidecarPath trio requirement
 // as ApplyBootstrap; partial wiring returns ErrKEKNotConfigured
@@ -844,6 +850,8 @@ func (a *Applier) ApplyRotation(raftIdx uint64, p fsmwire.RotationPayload) error
 		return a.applyRotateDEK(raftIdx, p)
 	case fsmwire.RotateSubEnableStorageEnvelope:
 		return a.applyEnableStorageEnvelope(raftIdx, p)
+	case fsmwire.RotateSubEnableRaftEnvelope:
+		return a.applyEnableRaftEnvelope(raftIdx, p)
 	default:
 		return errors.Wrapf(ErrEncryptionApply,
 			"applier: rotation sub_tag %#x not recognised", p.SubTag)
@@ -1042,6 +1050,126 @@ func (a *Applier) applyEnableStorageEnvelope(raftIdx uint64, p fsmwire.RotationP
 	advanceRaftAppliedIndex(sc, raftIdx)
 	if err := WriteSidecar(a.sidecarPath, sc); err != nil {
 		return errors.Wrap(err, "applier: write sidecar for cutover")
+	}
+	a.stateCache.RefreshFromSidecar(sc)
+	return nil
+}
+
+// validateEnableRaftEnvelopePayload enforces the Stage 6E-1
+// payload-shape constraints that do NOT require sidecar state
+// (purpose, empty-Wrapped, proposer-DEK pinning). The shape
+// mirrors validateEnableStorageEnvelopePayload but targets the
+// raft slot:
+//
+//   - Purpose MUST be PurposeRaft
+//   - Wrapped MUST be empty (length-based check, NOT == nil; the
+//     wire decoder materialises zero-length payloads as
+//     allocated empty slices)
+//   - ProposerRegistration.DEKID MUST equal payload DEKID
+//
+// Sidecar-derived constraints (#3 stale DEKID, #4 idempotency)
+// live in the caller so the no-op vs. fresh-success branches
+// can read the sidecar exactly once.
+func validateEnableRaftEnvelopePayload(p fsmwire.RotationPayload) error {
+	if p.Purpose != fsmwire.PurposeRaft {
+		return errors.Wrapf(ErrEncryptionApply,
+			"applier: enable-raft-envelope must carry Purpose=PurposeRaft, got %#x", byte(p.Purpose))
+	}
+	if len(p.Wrapped) != 0 {
+		return errors.Wrapf(ErrEncryptionApply,
+			"applier: enable-raft-envelope must carry empty Wrapped, got %d bytes", len(p.Wrapped))
+	}
+	if p.ProposerRegistration.DEKID != p.DEKID {
+		return errors.Wrapf(ErrEncryptionApply,
+			"applier: enable-raft-envelope proposer_registration.dek_id=%d does not match rotation dek_id=%d",
+			p.ProposerRegistration.DEKID, p.DEKID)
+	}
+	return nil
+}
+
+// applyEnableRaftEnvelope handles the RotateSubEnableRaftEnvelope
+// variant (Stage 6E-1 §3.1): the one-shot raft-layer cutover.
+// Structural mirror of applyEnableStorageEnvelope; the differences
+// from the storage variant are:
+//
+//   - Compares DEKID against sidecar.Active.Raft (not .Storage).
+//   - Records the cutover via sidecar.RaftEnvelopeCutoverIndex (a
+//     uint64 index — non-zero means "Phase-2 active"), as opposed
+//     to a separate bool flag. The same field doubles as the
+//     idempotency token for replay (constraint #4).
+//   - The proposer-registration row registers against the active
+//     raft DEK (PurposeRaft), not the storage DEK. The §4.1
+//     writer-registry layout is per-(DEK_id, NodeID) so storage
+//     and raft registrations are independent rows.
+//
+// Outcomes and FSM-level treatment match the storage variant:
+//
+//   - Malformed payload — halt-apply via ErrEncryptionApply.
+//   - Stale DEKID (RotateDEK raced between propose and apply) —
+//     benign no-op, advance RaftAppliedIndex only.
+//   - Already active (duplicate cutover entry) — idempotent;
+//     preserve original RaftEnvelopeCutoverIndex, advance
+//     RaftAppliedIndex only.
+//   - Fresh success — register proposer FIRST, then set
+//     RaftEnvelopeCutoverIndex and advance RaftAppliedIndex
+//     inside one WriteSidecar fsync. The registration-before-
+//     sidecar ordering matches the storage variant's
+//     crash-recovery invariant (§4.1 case 2-idempotent re-runs
+//     are safe; the sidecar flip is the last observable
+//     side-effect).
+//
+// Stage 6E-1 deliberately does NOT activate the §6.3 engine
+// apply-hook unwrap or the coordinator wrap-on-propose switch
+// — those land atomically in 6E-2. With only 6E-1 deployed, the
+// sidecar cutover advances on apply but no entry is wrapped or
+// unwrapped, so the apply is operator-inert (matches the design
+// doc's "no behavior change" guarantee for 6E-1).
+func (a *Applier) applyEnableRaftEnvelope(raftIdx uint64, p fsmwire.RotationPayload) error {
+	if err := validateEnableRaftEnvelopePayload(p); err != nil {
+		return err
+	}
+	sc, err := ReadSidecar(a.sidecarPath)
+	if err != nil {
+		return errors.Wrap(err, "applier: read sidecar for enable-raft-envelope")
+	}
+	// Stage 6E-1 constraint #3 — DEKID stale at apply (RotateDEK
+	// raced). Benign no-op: consume the entry without halting
+	// and without flipping the cutover field.
+	if p.DEKID != sc.Active.Raft {
+		advanceRaftAppliedIndex(sc, raftIdx)
+		if err := WriteSidecar(a.sidecarPath, sc); err != nil {
+			return errors.Wrap(err, "applier: write sidecar for stale-dekid raft-cutover no-op")
+		}
+		return nil
+	}
+	// Stage 6E-1 constraint #4 — idempotency. Preserve the
+	// original RaftEnvelopeCutoverIndex; only advance the generic
+	// RaftAppliedIndex so the duplicate entry is not replayed.
+	// Non-zero RaftEnvelopeCutoverIndex IS the "already-active"
+	// signal (no separate bool flag).
+	if sc.RaftEnvelopeCutoverIndex != 0 {
+		advanceRaftAppliedIndex(sc, raftIdx)
+		if err := WriteSidecar(a.sidecarPath, sc); err != nil {
+			return errors.Wrap(err, "applier: write sidecar for already-active raft-cutover no-op")
+		}
+		return nil
+	}
+	// Fresh successful apply. Crash-recovery ordering follows
+	// the storage variant: ApplyRegistration runs BEFORE
+	// WriteSidecar so the cutover sidecar write is the last
+	// observable side effect. If the process crashes between the
+	// registration insert and the sidecar write, on restart the
+	// sidecar is still pre-cutover (RaftEnvelopeCutoverIndex ==
+	// 0), FSM replay re-enters this branch, ApplyRegistration
+	// re-runs and hits §4.1 case 2-idempotent (no-op), then
+	// WriteSidecar lands cleanly.
+	if err := a.ApplyRegistration(p.ProposerRegistration); err != nil {
+		return errors.Wrap(err, "applier: raft-cutover proposer-registration insert")
+	}
+	sc.RaftEnvelopeCutoverIndex = raftIdx
+	advanceRaftAppliedIndex(sc, raftIdx)
+	if err := WriteSidecar(a.sidecarPath, sc); err != nil {
+		return errors.Wrap(err, "applier: write sidecar for raft cutover")
 	}
 	a.stateCache.RefreshFromSidecar(sc)
 	return nil

--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -1125,6 +1125,19 @@ func validateEnableRaftEnvelopePayload(p fsmwire.RotationPayload) error {
 // unwrapped, so the apply is operator-inert (matches the design
 // doc's "no behavior change" guarantee for 6E-1).
 func (a *Applier) applyEnableRaftEnvelope(raftIdx uint64, p fsmwire.RotationPayload) error {
+	// Fail-closed: RaftEnvelopeCutoverIndex != 0 is the sole
+	// "Phase-2 active" sentinel for the raft variant (storage
+	// variant uses a separate bool). A raftIdx of 0 — the "no
+	// index supplied" sentinel from the index-aware apply seam —
+	// would let the fresh-success branch register the proposer
+	// while leaving RaftEnvelopeCutoverIndex at 0, so the cutover
+	// would silently fail to activate AND a replay would re-enter
+	// the fresh-success branch (the already-active short-circuit
+	// only triggers on != 0). Reject before any sidecar mutation.
+	if raftIdx == 0 {
+		return errors.Wrap(ErrEncryptionApply,
+			"applier: enable-raft-envelope requires a non-zero raft index")
+	}
 	if err := validateEnableRaftEnvelopePayload(p); err != nil {
 		return err
 	}

--- a/internal/encryption/applier_test.go
+++ b/internal/encryption/applier_test.go
@@ -2370,6 +2370,37 @@ func TestApplyRotation_EnableRaftEnvelope_RejectsProposerDEKMismatch(t *testing.
 	assertRaftCutoverNotApplied(t, sidecarPath)
 }
 
+// TestApplyRotation_EnableRaftEnvelope_RejectsZeroRaftIndex pins a
+// fail-closed pre-check: `RaftEnvelopeCutoverIndex != 0` is the
+// sole "Phase-2 active" sentinel for the raft variant (unlike the
+// storage variant which carries a separate `StorageEnvelopeActive`
+// bool). If the apply path ever receives raftIdx == 0 — a sentinel
+// elsewhere meaning "no index supplied" — the fresh-success branch
+// would persist the proposer-registration row, leave
+// `RaftEnvelopeCutoverIndex` at 0 (logically inactive), and return
+// nil, while replays would re-enter the fresh-success branch since
+// the already-active short-circuit only fires on `!= 0`. Reject
+// raftIdx == 0 before any sidecar mutation so the apply halts.
+func TestApplyRotation_EnableRaftEnvelope_RejectsZeroRaftIndex(t *testing.T) {
+	t.Parallel()
+	dir, sidecarPath := bootstrappedDir(t)
+	app := newCutoverApplier(t, dir, sidecarPath)
+	err := app.ApplyRotation(0, fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubEnableRaftEnvelope,
+		DEKID:                cutoverBootstrapRaftDEKID,
+		Purpose:              fsmwire.PurposeRaft,
+		Wrapped:              []byte{},
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: cutoverBootstrapRaftDEKID, FullNodeID: 0xBBBB, LocalEpoch: 1},
+	})
+	if err == nil {
+		t.Fatal("expected halt on raftIdx == 0, got nil")
+	}
+	if !errors.Is(err, encryption.ErrEncryptionApply) {
+		t.Errorf("err not marked ErrEncryptionApply: %v", err)
+	}
+	assertRaftCutoverNotApplied(t, sidecarPath)
+}
+
 // TestApplyRotation_EnableRaftEnvelope_StaleDEKID_BenignNoOp pins
 // constraint #3 from the design: a RotateDEK race between propose
 // and apply that advances sidecar.Active.Raft past payload DEKID

--- a/internal/encryption/applier_test.go
+++ b/internal/encryption/applier_test.go
@@ -2205,3 +2205,282 @@ func validAccessorObservation(id uint32, ok bool, wantDEKID uint32) bool {
 	}
 	return false
 }
+
+// --- Stage 6E-1: RotateSubEnableRaftEnvelope tests ---
+// Mirror the storage-envelope cutover tests but target the raft slot
+// + the RaftEnvelopeCutoverIndex (uint64 index, not bool flag).
+
+// TestApplyRotation_EnableRaftEnvelope_FreshSuccess pins Stage 6E-1
+// happy-path: after Bootstrap, a cutover entry with
+// DEKID == Active.Raft, Purpose == PurposeRaft, empty Wrapped sets
+// RaftEnvelopeCutoverIndex = raftIdx inside one sidecar fsync. The
+// ProposerRegistration row is inserted via the standard §4.1 case
+// dispatch covering the proposer's first encrypted write under the
+// now-active raft envelope.
+func TestApplyRotation_EnableRaftEnvelope_FreshSuccess(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		wrapped []byte
+	}{
+		{name: "nil_wrapped", wrapped: nil},
+		{name: "empty_wrapped", wrapped: []byte{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runRaftCutoverFreshSuccess(t, tc.wrapped)
+		})
+	}
+}
+
+func runRaftCutoverFreshSuccess(t *testing.T, wrapped []byte) {
+	t.Helper()
+	reg := newMapRegistryStore()
+	ks := encryption.NewKeystore()
+	dir := t.TempDir()
+	sidecarPath := dir + "/keys.json"
+	app, err := encryption.NewApplier(reg,
+		encryption.WithKEK(&fakeKEK{}),
+		encryption.WithKeystore(ks),
+		encryption.WithSidecarPath(sidecarPath),
+	)
+	if err != nil {
+		t.Fatalf("NewApplier: %v", err)
+	}
+	if err := app.ApplyBootstrap(100, fsmwire.BootstrapPayload{
+		StorageDEKID: 7, WrappedStorage: []byte("s"),
+		RaftDEKID: 8, WrappedRaft: []byte("r"),
+		BatchRegistry: []fsmwire.RegistrationPayload{
+			{DEKID: 8, FullNodeID: 0xBBBB, LocalEpoch: 0},
+		},
+	}); err != nil {
+		t.Fatalf("ApplyBootstrap: %v", err)
+	}
+	const raftCutoverIdx uint64 = 600
+	if err := app.ApplyRotation(raftCutoverIdx, fsmwire.RotationPayload{
+		SubTag:  fsmwire.RotateSubEnableRaftEnvelope,
+		DEKID:   8, // matches sidecar.Active.Raft
+		Purpose: fsmwire.PurposeRaft,
+		Wrapped: wrapped,
+		ProposerRegistration: fsmwire.RegistrationPayload{
+			DEKID: 8, FullNodeID: 0xBBBB, LocalEpoch: 1,
+		},
+	}); err != nil {
+		t.Fatalf("ApplyRotation raft-cutover: %v", err)
+	}
+	sc, err := encryption.ReadSidecar(sidecarPath)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	if sc.RaftEnvelopeCutoverIndex != raftCutoverIdx {
+		t.Errorf("RaftEnvelopeCutoverIndex = %d, want %d",
+			sc.RaftEnvelopeCutoverIndex, raftCutoverIdx)
+	}
+	if sc.RaftAppliedIndex != raftCutoverIdx {
+		t.Errorf("RaftAppliedIndex = %d, want %d",
+			sc.RaftAppliedIndex, raftCutoverIdx)
+	}
+	if sc.Active.Raft != 8 {
+		t.Errorf("Active.Raft = %d, want 8 (raft-cutover should not re-point)",
+			sc.Active.Raft)
+	}
+	// Storage cutover state must remain untouched — raft-envelope
+	// cutover is independent of storage-envelope cutover.
+	if sc.StorageEnvelopeActive {
+		t.Error("StorageEnvelopeActive flipped by raft-cutover, want unchanged")
+	}
+	if sc.StorageEnvelopeCutoverIndex != 0 {
+		t.Errorf("StorageEnvelopeCutoverIndex = %d, want 0 (raft-cutover should not touch storage)",
+			sc.StorageEnvelopeCutoverIndex)
+	}
+	assertProposerEpoch(t, reg, 8, 0xBBBB, 1)
+}
+
+// TestApplyRotation_EnableRaftEnvelope_RejectsNonRaftPurpose pins
+// payload constraint #1: Purpose == PurposeStorage on a
+// raft-envelope cutover entry MUST halt apply rather than silently
+// mis-routing the cutover through the wrong slot accounting.
+func TestApplyRotation_EnableRaftEnvelope_RejectsNonRaftPurpose(t *testing.T) {
+	t.Parallel()
+	dir, sidecarPath := bootstrappedDir(t)
+	app := newCutoverApplier(t, dir, sidecarPath)
+	err := app.ApplyRotation(500, fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubEnableRaftEnvelope,
+		DEKID:                cutoverBootstrapRaftDEKID,
+		Purpose:              fsmwire.PurposeStorage, // wrong
+		Wrapped:              []byte{},
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: cutoverBootstrapRaftDEKID, FullNodeID: 0xBBBB, LocalEpoch: 1},
+	})
+	if err == nil {
+		t.Fatal("expected halt on non-raft purpose, got nil")
+	}
+	if !errors.Is(err, encryption.ErrEncryptionApply) {
+		t.Errorf("err not marked ErrEncryptionApply: %v", err)
+	}
+	assertRaftCutoverNotApplied(t, sidecarPath)
+}
+
+// TestApplyRotation_EnableRaftEnvelope_RejectsNonEmptyWrapped pins
+// payload constraint #2: a raft-envelope cutover carries
+// `Wrapped` empty (the active DEK is referenced by DEKID, not
+// re-shipped). A non-empty Wrapped is malformed and must halt
+// apply.
+func TestApplyRotation_EnableRaftEnvelope_RejectsNonEmptyWrapped(t *testing.T) {
+	t.Parallel()
+	dir, sidecarPath := bootstrappedDir(t)
+	app := newCutoverApplier(t, dir, sidecarPath)
+	err := app.ApplyRotation(500, fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubEnableRaftEnvelope,
+		DEKID:                cutoverBootstrapRaftDEKID,
+		Purpose:              fsmwire.PurposeRaft,
+		Wrapped:              []byte{0xDE, 0xAD, 0xBE, 0xEF}, // non-empty
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: cutoverBootstrapRaftDEKID, FullNodeID: 0xBBBB, LocalEpoch: 1},
+	})
+	if err == nil {
+		t.Fatal("expected halt on non-empty Wrapped, got nil")
+	}
+	if !errors.Is(err, encryption.ErrEncryptionApply) {
+		t.Errorf("err not marked ErrEncryptionApply: %v", err)
+	}
+	assertRaftCutoverNotApplied(t, sidecarPath)
+}
+
+// TestApplyRotation_EnableRaftEnvelope_RejectsProposerDEKMismatch
+// pins payload constraint #3: ProposerRegistration.DEKID MUST
+// equal payload DEKID. A mismatch would silently insert a
+// writer-registry row against an unrelated DEK while leaving the
+// cutover-target DEK unregistered — the same shape that the
+// rotate-dek variant guards against.
+func TestApplyRotation_EnableRaftEnvelope_RejectsProposerDEKMismatch(t *testing.T) {
+	t.Parallel()
+	dir, sidecarPath := bootstrappedDir(t)
+	app := newCutoverApplier(t, dir, sidecarPath)
+	err := app.ApplyRotation(500, fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubEnableRaftEnvelope,
+		DEKID:                cutoverBootstrapRaftDEKID,
+		Purpose:              fsmwire.PurposeRaft,
+		Wrapped:              []byte{},
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: cutoverBootstrapRaftDEKID + 1, FullNodeID: 0xBBBB, LocalEpoch: 1},
+	})
+	if err == nil {
+		t.Fatal("expected halt on proposer dek mismatch, got nil")
+	}
+	if !errors.Is(err, encryption.ErrEncryptionApply) {
+		t.Errorf("err not marked ErrEncryptionApply: %v", err)
+	}
+	assertRaftCutoverNotApplied(t, sidecarPath)
+}
+
+// TestApplyRotation_EnableRaftEnvelope_StaleDEKID_BenignNoOp pins
+// constraint #3 from the design: a RotateDEK race between propose
+// and apply that advances sidecar.Active.Raft past payload DEKID
+// is a benign no-op. Advance RaftAppliedIndex (so the entry is
+// not replayed) but do NOT mutate RaftEnvelopeCutoverIndex.
+func TestApplyRotation_EnableRaftEnvelope_StaleDEKID_BenignNoOp(t *testing.T) {
+	t.Parallel()
+	dir, sidecarPath := bootstrappedDir(t)
+	app := newCutoverApplier(t, dir, sidecarPath)
+	// Stage a RotateDEK that advances Active.Raft from
+	// cutoverBootstrapRaftDEKID to a new id — simulates "RotateDEK
+	// raced between cutover propose and apply" (mirrors the
+	// storage stale-DEKID test setup). The RotateDEK path
+	// crash-durably writes both Active.Raft AND the keys[] entry
+	// so the sidecar validator accepts the new state.
+	const newRaftDEKID uint32 = 99
+	if err := app.ApplyRotation(200, fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubRotateDEK,
+		DEKID:                newRaftDEKID,
+		Purpose:              fsmwire.PurposeRaft,
+		Wrapped:              []byte("new-raft-dek"),
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: newRaftDEKID, FullNodeID: 0xBBBB, LocalEpoch: 1},
+	}); err != nil {
+		t.Fatalf("ApplyRotation RotateDEK: %v", err)
+	}
+	// Now the cutover lands but still carries the stale DEKID.
+	const staleIdx uint64 = 300
+	if err := app.ApplyRotation(staleIdx, fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubEnableRaftEnvelope,
+		DEKID:                cutoverBootstrapRaftDEKID, // stale — Active.Raft moved to newRaftDEKID
+		Purpose:              fsmwire.PurposeRaft,
+		Wrapped:              []byte{},
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: cutoverBootstrapRaftDEKID, FullNodeID: 0xBBBB, LocalEpoch: 2},
+	}); err != nil {
+		t.Fatalf("stale-DEKID raft-cutover MUST be a benign no-op (no halt), got: %v", err)
+	}
+	sc, err := encryption.ReadSidecar(sidecarPath)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	if sc.RaftEnvelopeCutoverIndex != 0 {
+		t.Errorf("RaftEnvelopeCutoverIndex = %d on stale-DEKID no-op, want 0",
+			sc.RaftEnvelopeCutoverIndex)
+	}
+	if sc.RaftAppliedIndex != staleIdx {
+		t.Errorf("RaftAppliedIndex = %d, want %d (no-op must still advance applied)",
+			sc.RaftAppliedIndex, staleIdx)
+	}
+	if sc.Active.Raft != newRaftDEKID {
+		t.Errorf("Active.Raft = %d, want %d", sc.Active.Raft, newRaftDEKID)
+	}
+}
+
+// TestApplyRotation_EnableRaftEnvelope_AlreadyActive_IdempotentNoOp
+// pins constraint #4: a duplicate cutover entry (Phase-2 already
+// active) is idempotent. The original RaftEnvelopeCutoverIndex
+// (set by the first apply) is preserved as the stable
+// idempotency token; only RaftAppliedIndex advances so the
+// duplicate is not replayed. The ProposerRegistration field is
+// intentionally NOT re-inserted — the first apply ran
+// ApplyRegistration before WriteSidecar, so the invariant
+// "RaftEnvelopeCutoverIndex != 0 ⇒ registration row already on
+// disk" holds across crash-restart.
+func TestApplyRotation_EnableRaftEnvelope_AlreadyActive_IdempotentNoOp(t *testing.T) {
+	t.Parallel()
+	dir, sidecarPath := bootstrappedDir(t)
+	app := newCutoverApplier(t, dir, sidecarPath)
+	const firstIdx uint64 = 500
+	if err := app.ApplyRotation(firstIdx, fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubEnableRaftEnvelope,
+		DEKID:                cutoverBootstrapRaftDEKID,
+		Purpose:              fsmwire.PurposeRaft,
+		Wrapped:              []byte{},
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: cutoverBootstrapRaftDEKID, FullNodeID: 0xBBBB, LocalEpoch: 1},
+	}); err != nil {
+		t.Fatalf("first cutover: %v", err)
+	}
+	const duplicateIdx uint64 = 501
+	if err := app.ApplyRotation(duplicateIdx, fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubEnableRaftEnvelope,
+		DEKID:                cutoverBootstrapRaftDEKID,
+		Purpose:              fsmwire.PurposeRaft,
+		Wrapped:              []byte{},
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: cutoverBootstrapRaftDEKID, FullNodeID: 0xBBBB, LocalEpoch: 2},
+	}); err != nil {
+		t.Fatalf("duplicate cutover must be idempotent no-op, got %v", err)
+	}
+	sc, err := encryption.ReadSidecar(sidecarPath)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	if sc.RaftEnvelopeCutoverIndex != firstIdx {
+		t.Errorf("RaftEnvelopeCutoverIndex = %d on duplicate, want %d (first-apply value must be preserved)",
+			sc.RaftEnvelopeCutoverIndex, firstIdx)
+	}
+	if sc.RaftAppliedIndex != duplicateIdx {
+		t.Errorf("RaftAppliedIndex = %d, want %d (duplicate must still advance applied)",
+			sc.RaftAppliedIndex, duplicateIdx)
+	}
+}
+
+// assertRaftCutoverNotApplied verifies a rejected raft-envelope
+// cutover left the cutover sidecar state untouched.
+func assertRaftCutoverNotApplied(t *testing.T, sidecarPath string) {
+	t.Helper()
+	sc, err := encryption.ReadSidecar(sidecarPath)
+	if err != nil {
+		t.Fatalf("ReadSidecar: %v", err)
+	}
+	if sc.RaftEnvelopeCutoverIndex != 0 {
+		t.Errorf("RaftEnvelopeCutoverIndex = %d despite halt, want 0",
+			sc.RaftEnvelopeCutoverIndex)
+	}
+}

--- a/internal/encryption/fsmwire/wire.go
+++ b/internal/encryption/fsmwire/wire.go
@@ -109,13 +109,24 @@ const (
 	// the existing "unknown sub-tag" branch.
 	RotateSubEnableStorageEnvelope byte = 0x04
 
+	// RotateSubEnableRaftEnvelope is the one-shot raft-layer cutover
+	// (§7.1 Phase 2). Ships in Stage 6E-1. The wire shape mirrors
+	// RotateSubEnableStorageEnvelope but with the raft slot:
+	// `Wrapped` empty (`len(Wrapped) == 0`), `DEKID ==
+	// sidecar.Active.Raft`, `Purpose == PurposeRaft`. The applier
+	// re-validates all three at apply time. On a fresh-success
+	// apply the sidecar's `RaftEnvelopeCutoverIndex` is set to
+	// `raftIdx` (the cutover entry's own apply index, which Stage
+	// 6E-2's engine apply-hook compares against `entry.Index` via
+	// strict `>` to decide unwrap-or-not).
+	RotateSubEnableRaftEnvelope byte = 0x05
+
 	// Reserved for later stages; declared here so the byte space
 	// is contiguous and a future commit cannot silently re-use
 	// 0x02..0x0F without an audit:
 	//
 	//   0x02 — rewrap-deks       (Stage 9, §5.4 / §5.5)
 	//   0x03 — retire-dek        (Stage 9, §5.4)
-	//   0x05 — enable-raft-envelope    (Stage 6, §7.1 Phase 2)
 )
 
 // OpEncryptionMin / OpEncryptionMax delimit the FSM-internal opcode
@@ -523,7 +534,7 @@ func readRotationSubTag(r *reader) (byte, error) {
 		return 0, errors.Wrap(ErrFSMWireMalformed, "rotation: missing sub-tag")
 	}
 	switch sub {
-	case RotateSubRotateDEK, RotateSubEnableStorageEnvelope:
+	case RotateSubRotateDEK, RotateSubEnableStorageEnvelope, RotateSubEnableRaftEnvelope:
 		return sub, nil
 	default:
 		return 0, errors.Wrapf(ErrFSMWireSubtag, "rotation: subtag=%#x", sub)


### PR DESCRIPTION
## Summary

Stage 6E-1a — FSM apply machinery for the §7.1 Phase-2 raft-envelope cutover. Builds on the design merged in #893.

**Scope**: FSM-side only. The admin RPC + server + CLI ship in 6E-1b (separate PR, deferred to keep this slice off the protoc toolchain version pin in CLAUDE.md).

### What lands

- `RotateSubEnableRaftEnvelope byte = 0x05` — the previously-reserved sub-tag is promoted to live; wire decoder whitelist updated.
- `validateEnableRaftEnvelopePayload` — mirrors the storage variant for the raft slot (Purpose=PurposeRaft, empty-Wrapped length check, proposer-DEK pinning).
- `applyEnableRaftEnvelope` — structural mirror of `applyEnableStorageEnvelope`. Records the cutover via `sc.RaftEnvelopeCutoverIndex` (a uint64 index — non-zero ⇒ "Phase-2 active"; doubles as the idempotency token, no separate bool flag). Registration-before-sidecar ordering matches the storage variant's crash-recovery invariant.
- `ApplyRotation` dispatch case for the new sub-tag.

### Outcomes (mirror the storage variant)

| Case | Treatment |
|---|---|
| Malformed (purpose / Wrapped / proposer-DEK) | Halt-apply via `ErrEncryptionApply` |
| Stale DEKID (RotateDEK race) | Benign no-op; advance `RaftAppliedIndex` only |
| Already active (duplicate cutover) | Idempotent; preserve original `RaftEnvelopeCutoverIndex` |
| Fresh success | Register proposer → set cutover + advance applied inside one fsync |

### Operator-inertness in 6E-1a

Stage 6E-1a deliberately does NOT activate the §6.3 engine apply-hook unwrap or the coordinator wrap-on-propose switch — those land atomically in 6E-2 (the design notes 6E-2's three pieces cannot ship separately because either ordering produces cluster-wide halt-apply at cutover). With only 6E-1a deployed, the sidecar cutover field advances on apply but no entry is wrapped or unwrapped, matching the design's "no behavior change" guarantee for 6E-1.

### Verification

- 6 new tests under `TestApplyRotation_EnableRaftEnvelope_*`. All pass under `-race`.
- Full `internal/encryption/...` `-race` clean (32s).
- `golangci-lint --config=.golangci.yaml run ./internal/encryption/...` 0 issues.

### Self-review (5-lens) — full breakdown in commit body

1. **Data loss** — registration-before-sidecar ordering preserves crash-recovery invariant.
2. **Concurrency** — FSM apply is serial per Raft group; no race surface added.
3. **Performance** — one extra sub-tag dispatch case; hot-path unchanged.
4. **Data consistency** — strict-`>` is a 6E-2 concern; 6E-1a only writes the field. FSM determinism unaffected (each replica reaches the same value at the same apply index).
5. **Test coverage** — every validate branch + every apply state-machine branch has a dedicated test; 6D regression tests stay green.

## Test plan

- [x] `go test -race ./internal/encryption/...` clean
- [x] `golangci-lint --config=.golangci.yaml run ./internal/encryption/...` clean
- [x] 6 new tests + all pre-6E-1a tests green
- [ ] @claude review for the apply state machine, the registration-before-sidecar ordering rationale, and the "operator-inertness in 6E-1a" guarantee


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for raft-layer encryption envelope cutover with wire-layer acceptance of the new cutover operation, strict payload validation, and proposer-registration persistence.
  * Cutover is safe and idempotent: stale or duplicate cutovers preserve existing state while still advancing apply progress.

* **Tests**
  * Added comprehensive tests covering success paths, validation failures, edge-case rejections, and idempotency/race behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->