### PR TITLE
kv(composed1): M4 — Dispatch retry on ErrComposed1Violation / ErrComposed1VersionGCd

### DIFF
--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -565,14 +565,35 @@ func (c *ShardedCoordinator) dispatchTxnWithComposed1Retry(ctx context.Context, 
 		// so the retry would run with StartTS=0 — violating MVCC
 		// invariants (gemini HIGH on PR #900).
 		reqs.CommitTS = 0
-		// Drop the option-2 dedup probe.  The M3 gate fired at apply
-		// time, so the ORIGINAL attempt never committed — there is no
-		// prior landing for PrevCommitTS to dedup against on this
-		// retry.  Leaving it set would let dispatchMultiShardTxn:736
-		// short-circuit with ErrTxnDedupRequiresSingleShard if the
-		// post-shift catalog now reroutes this txn to span two groups
-		// (claude[bot] medium, 3rd review round on PR #900).
-		reqs.PrevCommitTS = 0
+		// IMPORTANT — do NOT clear reqs.PrevCommitTS here.  An earlier
+		// round of this PR did (taking claude[bot]'s reasoning at face
+		// value: "M3 fired at apply time, so the original attempt never
+		// committed → probe is stale").  That reasoning conflates two
+		// different "original attempts" and is wrong (codex P1 on
+		// 43c55dfe, PR #900):
+		//
+		//   * Within M4: attempt 1's M3 rejection does prove attempt 1
+		//     did not write anything (the FSM rejects before any state
+		//     change).
+		//   * Across adapter retries: PrevCommitTS names the
+		//     ADAPTER'S prior attempt (e.g. adapter/redis.go:3209,
+		//     :3615 send PrevCommitTS = pending.commitTS as the
+		//     option-2 ambiguous-outcome probe).  That earlier
+		//     attempt may have actually landed at the named commitTS
+		//     before the route shift that triggered our M3 sentinel.
+		//
+		// Dropping the probe in the retry would let the FSM re-apply
+		// the writes against the post-shift route, double-writing the
+		// caller's at-most-once-payload if the named prior attempt did
+		// land.  Preserving it has the cost that
+		// dispatchMultiShardTxn:749 surfaces
+		// ErrTxnDedupRequiresSingleShard when the post-shift route now
+		// spans multiple groups — which IS the faithful signal: the
+		// adapter's at-most-once retry contract cannot be transparently
+		// honoured across a shard split, and the caller must reckon
+		// with the ambiguity at a higher level (re-read, re-execute,
+		// abort).  Surfacing that error is strictly safer than silently
+		// losing dedup.
 		startTS, allocErr := c.nextStartTS(ctx, reqs.Elems)
 		if allocErr != nil {
 			// resp here is the failed first attempt's response (always

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -505,10 +505,11 @@ func (c *ShardedCoordinator) Dispatch(ctx context.Context, reqs *OperationGroup[
 // maybeAutoPinObservedRouteVersion stamps reqs.ObservedRouteVersion
 // with the engine's current catalog version at Dispatch entry, but
 // ONLY when (a) the txn has no read keys AND (b) the caller did not
-// supply StartTS.  Per design doc §4.1 the version must be pinned
-// at BeginTxn (read-set capture time); the auto-pin is a
-// best-effort backfill for callers that have not yet migrated to
-// pin themselves.  Two cases skip the auto-pin:
+// supply StartTS AND (c) no element's key is claimed by a partition
+// resolver.  Per design doc §4.1 the version must be pinned at
+// BeginTxn (read-set capture time); the auto-pin is a best-effort
+// backfill for callers that have not yet migrated to pin
+// themselves.  Three cases skip the auto-pin:
 //
 //   - len(ReadKeys) != 0 — the caller already performed reads at
 //     some earlier moment (Redis MULTI/EXEC's txnContext.commit
@@ -532,6 +533,20 @@ func (c *ShardedCoordinator) Dispatch(ctx context.Context, reqs *OperationGroup[
 //     auto-pin gives false confidence (codex P1 on 144ec0ca,
 //     PR #900).
 //
+//   - any element's key is resolver-claimed — when a
+//     PartitionResolver is wired (SQS HT-FIFO partition keys
+//     etc.), ShardRouter routes via the resolver but
+//     verifyComposed1 calls route-history OwnerOf on the raw
+//     mutation key against the BYTE-RANGE engine snapshot.  The
+//     engine has no knowledge of the resolver's mapping, so the
+//     gate spuriously rejects resolver-routed commits even when
+//     the resolver picked the correct gid.  Skip the auto-pin
+//     for any resolver-recognised key; the request flows with
+//     ObservedRouteVersion=0 and the M3 gate short-circuits —
+//     restoring the pre-auto-pin behaviour for resolver-routed
+//     txns.  Resolver-aware M3 is M5+ work (codex P1 on
+//     6a458a28, PR #900).
+//
 // The non-auto-pin case (request flows with ObservedRouteVersion=0,
 // M3 gate short-circuits) is the safe non-regressing posture for
 // non-migrated callers — the gate cannot retroactively pin reads
@@ -544,7 +559,31 @@ func (c *ShardedCoordinator) maybeAutoPinObservedRouteVersion(reqs *OperationGro
 	if c.engine == nil || reqs.ObservedRouteVersion != 0 || len(reqs.ReadKeys) != 0 || callerSuppliedStartTS {
 		return
 	}
+	if c.anyResolverClaimedKey(reqs.Elems) {
+		return
+	}
 	reqs.ObservedRouteVersion = c.engine.Version()
+}
+
+// anyResolverClaimedKey reports whether any element's key is
+// claimed by the partition resolver.  Returns false when the
+// router has no resolver installed (the most common case) so the
+// auto-pin path stays inexpensive in the byte-range-only deployment.
+// Extracted from maybeAutoPinObservedRouteVersion to keep the
+// auto-pin's cyclomatic complexity in the cyclop budget.
+func (c *ShardedCoordinator) anyResolverClaimedKey(elems []*Elem[OP]) bool {
+	if c.router == nil || c.router.partitionResolver == nil {
+		return false
+	}
+	for _, e := range elems {
+		if e == nil || len(e.Key) == 0 {
+			continue
+		}
+		if c.router.partitionResolver.RecognisesPartitionedKey(e.Key) {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *ShardedCoordinator) dispatchTxnWithComposed1Retry(ctx context.Context, reqs *OperationGroup[OP], callerSuppliedStartTS bool) (*CoordinateResponse, error) {

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -851,7 +851,13 @@ func (c *ShardedCoordinator) dispatchMultiShardTxn(ctx context.Context, startTS,
 		return nil, errors.WithStack(err)
 	}
 
-	maxIndex = c.commitSecondaryTxns(ctx, startTS, primaryGid, primaryKey, grouped, gids, commitTS, maxIndex, observedRouteVersion)
+	// observedRouteVersion is intentionally NOT propagated to
+	// commitSecondaryTxns — secondary commits drop the M3 gate to
+	// avoid the best-effort-secondary + fail-closed-gate silent
+	// partial commit hazard (codex P1 on 6202b964, PR #900).  See
+	// the Request construction inside commitSecondaryTxns for the
+	// full reasoning.
+	maxIndex = c.commitSecondaryTxns(ctx, startTS, primaryGid, primaryKey, grouped, gids, commitTS, maxIndex)
 	return &CoordinateResponse{CommitIndex: maxIndex}, nil
 }
 
@@ -991,7 +997,7 @@ func (c *ShardedCoordinator) commitPrimaryTxn(ctx context.Context, startTS uint6
 	return primaryGid, r.CommitIndex, nil
 }
 
-func (c *ShardedCoordinator) commitSecondaryTxns(ctx context.Context, startTS uint64, primaryGid uint64, primaryKey []byte, grouped map[uint64][]*pb.Mutation, gids []uint64, commitTS uint64, maxIndex uint64, observedRouteVersion uint64) uint64 {
+func (c *ShardedCoordinator) commitSecondaryTxns(ctx context.Context, startTS uint64, primaryGid uint64, primaryKey []byte, grouped map[uint64][]*pb.Mutation, gids []uint64, commitTS uint64, maxIndex uint64) uint64 {
 	// Secondary commits are best-effort. If a shard is unavailable after the
 	// primary commits, read-time lock resolution will commit the remaining
 	// secondaries based on the primary commit record. Retry a few times to
@@ -1006,11 +1012,30 @@ func (c *ShardedCoordinator) commitSecondaryTxns(ctx context.Context, startTS ui
 			continue
 		}
 		req := &pb.Request{
-			IsTxn:                true,
-			Phase:                pb.Phase_COMMIT,
-			Ts:                   startTS,
-			Mutations:            append([]*pb.Mutation{meta}, keyMutations(grouped[gid])...),
-			ObservedRouteVersion: observedRouteVersion,
+			IsTxn:     true,
+			Phase:     pb.Phase_COMMIT,
+			Ts:        startTS,
+			Mutations: append([]*pb.Mutation{meta}, keyMutations(grouped[gid])...),
+			// ObservedRouteVersion intentionally omitted (zero) on
+			// secondary commits.  commitSecondaryTxns is best-effort:
+			// errors are logged and the dispatch acknowledges success
+			// while the lock-resolution backstop is expected to commit
+			// the secondary later.  If we propagated the auto-pinned
+			// version here, a route shift between primary-COMMIT and
+			// secondary-COMMIT would let the secondary FSM return
+			// ErrComposed1Violation, which commitSecondaryTxns swallows
+			// — turning route churn into a silent partial commit
+			// visible to no readers on the new owner (codex P1 on
+			// 6202b964, PR #900).  The FSM's verifyComposed1
+			// short-circuits on ObservedRouteVersion=0 (fsm.go:609), so
+			// dropping the field here restores the pre-66ad5b0 "no
+			// gate on commit-phase secondaries" behaviour without
+			// affecting prewrite (still gated) or primary commit
+			// (still gated; abortPreparedTxn cleans up on failure).
+			// Until a fatal-secondary 2PC protocol or
+			// lock-resolution-bypass design lands (M5+), this is the
+			// honest posture: gate where we can cleanly abort, skip
+			// where we cannot.
 		}
 		r, err := commitSecondaryWithRetry(ctx, g, req)
 		if err != nil {

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -134,6 +134,16 @@ const (
 
 	txnSecondaryCommitRetryAttempts = 3
 	txnSecondaryCommitRetryBackoff  = 20 * time.Millisecond
+
+	// composed1RetryAttempts bounds how many times Dispatch re-issues a
+	// txn after the FSM's M3 verifyComposed1 gate returned
+	// ErrComposed1Violation / ErrComposed1VersionGCd.  Per design doc
+	// §M4: "retries it once" — so the total attempt count is 1 (initial)
+	// + composed1RetryAttempts = 2.  Beyond one retry the sentinel
+	// surfaces unchanged so the client (or a wrapping retry harness in
+	// the adapter) sees the failure rather than the coordinator spinning
+	// on a persistent route shift.
+	composed1RetryAttempts = 1
 )
 
 // ShardedCoordinator routes operations to shard-specific raft groups.
@@ -450,10 +460,81 @@ func (c *ShardedCoordinator) Dispatch(ctx context.Context, reqs *OperationGroup[
 	}
 
 	if reqs.IsTxn {
-		return c.dispatchTxn(ctx, reqs.StartTS, reqs.CommitTS, reqs.PrevCommitTS, reqs.Elems, reqs.ReadKeys, reqs.ObservedRouteVersion)
+		return c.dispatchTxnWithComposed1Retry(ctx, reqs)
 	}
 
 	return c.dispatchNonTxn(ctx, reqs)
+}
+
+// dispatchTxnWithComposed1Retry runs the M4 Composed-1 retry loop
+// (design doc
+// docs/design/2026_05_29_proposed_composed1_cross_group_commit_guard.md
+// §M4).  Pins reqs.ObservedRouteVersion to the engine's current
+// catalog version on the FIRST attempt when the caller left it at the
+// zero sentinel — every txn that flows through ShardedCoordinator
+// gets gate-eligible by default so the M3 verifyComposed1 check has
+// teeth without each adapter rediscovering the contract.  On
+// ErrComposed1Violation or ErrComposed1VersionGCd, re-reads the
+// catalog version, re-stamps observed+commit on the OperationGroup,
+// and re-issues dispatchTxn ONCE.  Beyond one retry the sentinel
+// surfaces unchanged.
+//
+// The retry is bounded at composed1RetryAttempts = 1 because both
+// sentinels are "route shifted, retry on the fresh catalog" signals
+// — a persistent failure across two attempts means the catalog is
+// churning faster than this dispatch can keep up, and surfacing the
+// error lets a wrapping adapter retry harness (or the client) decide
+// whether to keep trying.
+func (c *ShardedCoordinator) dispatchTxnWithComposed1Retry(ctx context.Context, reqs *OperationGroup[OP]) (*CoordinateResponse, error) {
+	if c.engine != nil && reqs.ObservedRouteVersion == 0 {
+		reqs.ObservedRouteVersion = c.engine.Version()
+	}
+
+	for attempt := 0; attempt <= composed1RetryAttempts; attempt++ {
+		resp, err := c.dispatchTxn(ctx, reqs.StartTS, reqs.CommitTS, reqs.PrevCommitTS, reqs.Elems, reqs.ReadKeys, reqs.ObservedRouteVersion)
+		if err == nil {
+			return resp, nil
+		}
+		if !isComposed1RetryableError(err) {
+			return resp, err
+		}
+		if attempt == composed1RetryAttempts {
+			return resp, err
+		}
+		// Re-route by re-reading the engine's current catalog
+		// version and stamping it on the txn.  groupMutations on
+		// the next dispatchTxn pass re-runs router.ResolveGroup,
+		// so a key whose owning group changed since the last
+		// attempt naturally lands on the new group's FSM.
+		if c.engine != nil {
+			reqs.ObservedRouteVersion = c.engine.Version()
+		}
+		// Clear the timestamps so the next attempt allocates a
+		// fresh pair against the post-shift HLC.  The OCC
+		// invariants require commitTS > startTS computed under the
+		// same HLC observation; reusing the stale pair would risk
+		// a startTS that no longer dominates the new shard's
+		// applied commitTS.
+		reqs.StartTS = 0
+		reqs.CommitTS = 0
+		if c.clock != nil {
+			startTS, allocErr := c.nextStartTS(ctx, reqs.Elems)
+			if allocErr != nil {
+				return resp, allocErr
+			}
+			reqs.StartTS = startTS
+		}
+	}
+	// Unreachable — the loop body always returns on each iteration.
+	// Kept here so the function has an unambiguous return shape.
+	return nil, errors.WithStack(ErrInvalidRequest)
+}
+
+// isComposed1RetryableError reports whether err is one of the M3 gate
+// sentinels that M4 retries.  Both surface as wrapped errors from the
+// underlying transactional Commit; errors.Is unwraps them correctly.
+func isComposed1RetryableError(err error) bool {
+	return errors.Is(err, ErrComposed1Violation) || errors.Is(err, ErrComposed1VersionGCd)
 }
 
 // dispatchNonTxn routes a non-transactional operation group through the

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -504,31 +504,51 @@ func (c *ShardedCoordinator) Dispatch(ctx context.Context, reqs *OperationGroup[
 // whether to keep trying.
 // maybeAutoPinObservedRouteVersion stamps reqs.ObservedRouteVersion
 // with the engine's current catalog version at Dispatch entry, but
-// ONLY when the txn has no read keys.  Per design doc §4.1 the
-// version must be pinned at BeginTxn (read-set capture time); for
-// write-only txns Dispatch IS the BeginTxn (no prior reads have
-// happened), so pinning here is correct.  For read-write txns the
-// caller already performed reads at some earlier moment — Redis
-// MULTI/EXEC's txnContext.commit, for example, builds an
-// OperationGroup with StartTS from MULTI and ReadKeys from the GETs
-// inside the txn body — and stamping the catalog version at this
-// Dispatch call would associate post-shift routes with pre-shift
-// reads, defeating the gate (codex P1 on PR #900).  Such callers
-// MUST migrate to pin ObservedRouteVersion themselves at BeginTxn
-// time; until they do, the request flows with observedVer=0 and
-// the M3 gate short-circuits (the safe non-regressing posture for
-// non-migrated read-write callers).  Extracted from
-// dispatchTxnWithComposed1Retry to keep its cyclomatic complexity
-// in the cyclop budget.
-func (c *ShardedCoordinator) maybeAutoPinObservedRouteVersion(reqs *OperationGroup[OP]) {
-	if c.engine == nil || reqs.ObservedRouteVersion != 0 || len(reqs.ReadKeys) != 0 {
+// ONLY when (a) the txn has no read keys AND (b) the caller did not
+// supply StartTS.  Per design doc §4.1 the version must be pinned
+// at BeginTxn (read-set capture time); the auto-pin is a
+// best-effort backfill for callers that have not yet migrated to
+// pin themselves.  Two cases skip the auto-pin:
+//
+//   - len(ReadKeys) != 0 — the caller already performed reads at
+//     some earlier moment (Redis MULTI/EXEC's txnContext.commit
+//     builds an OperationGroup with StartTS from MULTI and
+//     ReadKeys from the GETs inside the txn body).  Stamping the
+//     catalog version at this Dispatch call would associate
+//     post-shift routes with pre-shift reads (codex P1 on
+//     10123c5a, PR #900).
+//
+//   - callerSuppliedStartTS — the caller supplied StartTS,
+//     meaning a read at the adapter layer happened against that
+//     snapshot before Dispatch even though it is not surfaced as
+//     a ReadKeys entry.  The 13+ S3/SQS/DynamoDB adapter sites
+//     identified in the M4-StartTS-gate audit (adapter/s3.go:573
+//     etc.) fall in this bucket.  Stamping the catalog version
+//     at Dispatch time would mask any route shift between the
+//     adapter-layer read and Dispatch entry — verifyComposed1
+//     would find no mismatch at apply time and the shift becomes
+//     INVISIBLE.  That is strictly worse than ObservedRouteVersion=0
+//     (gate short-circuits, no false claim made): the spurious
+//     auto-pin gives false confidence (codex P1 on 144ec0ca,
+//     PR #900).
+//
+// The non-auto-pin case (request flows with ObservedRouteVersion=0,
+// M3 gate short-circuits) is the safe non-regressing posture for
+// non-migrated callers — the gate cannot retroactively pin reads
+// it was not present for.  Adapters that want M3 protection must
+// migrate to pin at BeginTxn per §4.1.
+//
+// Extracted from dispatchTxnWithComposed1Retry to keep its
+// cyclomatic complexity in the cyclop budget.
+func (c *ShardedCoordinator) maybeAutoPinObservedRouteVersion(reqs *OperationGroup[OP], callerSuppliedStartTS bool) {
+	if c.engine == nil || reqs.ObservedRouteVersion != 0 || len(reqs.ReadKeys) != 0 || callerSuppliedStartTS {
 		return
 	}
 	reqs.ObservedRouteVersion = c.engine.Version()
 }
 
 func (c *ShardedCoordinator) dispatchTxnWithComposed1Retry(ctx context.Context, reqs *OperationGroup[OP], callerSuppliedStartTS bool) (*CoordinateResponse, error) {
-	c.maybeAutoPinObservedRouteVersion(reqs)
+	c.maybeAutoPinObservedRouteVersion(reqs, callerSuppliedStartTS)
 
 	for attempt := 0; attempt <= composed1RetryAttempts; attempt++ {
 		resp, err := c.dispatchTxn(ctx, reqs.StartTS, reqs.CommitTS, reqs.PrevCommitTS, reqs.Elems, reqs.ReadKeys, reqs.ObservedRouteVersion)

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -565,9 +565,21 @@ func (c *ShardedCoordinator) dispatchTxnWithComposed1Retry(ctx context.Context, 
 		// so the retry would run with StartTS=0 — violating MVCC
 		// invariants (gemini HIGH on PR #900).
 		reqs.CommitTS = 0
+		// Drop the option-2 dedup probe.  The M3 gate fired at apply
+		// time, so the ORIGINAL attempt never committed — there is no
+		// prior landing for PrevCommitTS to dedup against on this
+		// retry.  Leaving it set would let dispatchMultiShardTxn:736
+		// short-circuit with ErrTxnDedupRequiresSingleShard if the
+		// post-shift catalog now reroutes this txn to span two groups
+		// (claude[bot] medium, 3rd review round on PR #900).
+		reqs.PrevCommitTS = 0
 		startTS, allocErr := c.nextStartTS(ctx, reqs.Elems)
 		if allocErr != nil {
-			return resp, allocErr
+			// resp here is the failed first attempt's response (always
+			// nil for the Composed-1 sentinels) — return nil
+			// explicitly so the contract "non-nil response on success
+			// only" is unambiguous (claude[bot] nit on PR #900).
+			return nil, allocErr
 		}
 		reqs.StartTS = startTS
 	}

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -485,10 +485,33 @@ func (c *ShardedCoordinator) Dispatch(ctx context.Context, reqs *OperationGroup[
 // churning faster than this dispatch can keep up, and surfacing the
 // error lets a wrapping adapter retry harness (or the client) decide
 // whether to keep trying.
-func (c *ShardedCoordinator) dispatchTxnWithComposed1Retry(ctx context.Context, reqs *OperationGroup[OP]) (*CoordinateResponse, error) {
-	if c.engine != nil && reqs.ObservedRouteVersion == 0 {
-		reqs.ObservedRouteVersion = c.engine.Version()
+// maybeAutoPinObservedRouteVersion stamps reqs.ObservedRouteVersion
+// with the engine's current catalog version at Dispatch entry, but
+// ONLY when the txn has no read keys.  Per design doc §4.1 the
+// version must be pinned at BeginTxn (read-set capture time); for
+// write-only txns Dispatch IS the BeginTxn (no prior reads have
+// happened), so pinning here is correct.  For read-write txns the
+// caller already performed reads at some earlier moment — Redis
+// MULTI/EXEC's txnContext.commit, for example, builds an
+// OperationGroup with StartTS from MULTI and ReadKeys from the GETs
+// inside the txn body — and stamping the catalog version at this
+// Dispatch call would associate post-shift routes with pre-shift
+// reads, defeating the gate (codex P1 on PR #900).  Such callers
+// MUST migrate to pin ObservedRouteVersion themselves at BeginTxn
+// time; until they do, the request flows with observedVer=0 and
+// the M3 gate short-circuits (the safe non-regressing posture for
+// non-migrated read-write callers).  Extracted from
+// dispatchTxnWithComposed1Retry to keep its cyclomatic complexity
+// in the cyclop budget.
+func (c *ShardedCoordinator) maybeAutoPinObservedRouteVersion(reqs *OperationGroup[OP]) {
+	if c.engine == nil || reqs.ObservedRouteVersion != 0 || len(reqs.ReadKeys) != 0 {
+		return
 	}
+	reqs.ObservedRouteVersion = c.engine.Version()
+}
+
+func (c *ShardedCoordinator) dispatchTxnWithComposed1Retry(ctx context.Context, reqs *OperationGroup[OP]) (*CoordinateResponse, error) {
+	c.maybeAutoPinObservedRouteVersion(reqs)
 
 	for attempt := 0; attempt <= composed1RetryAttempts; attempt++ {
 		resp, err := c.dispatchTxn(ctx, reqs.StartTS, reqs.CommitTS, reqs.PrevCommitTS, reqs.Elems, reqs.ReadKeys, reqs.ObservedRouteVersion)

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -498,6 +498,24 @@ func (c *ShardedCoordinator) dispatchTxnWithComposed1Retry(ctx context.Context, 
 		if !isComposed1RetryableError(err) {
 			return resp, err
 		}
+		// Read-write txns (ReadKeys non-empty) MUST surface the
+		// sentinel without retry.  The client already performed
+		// the reads at the original StartTS; transparently bumping
+		// StartTS on retry would let any concurrent write that
+		// committed between the old and new timestamps go
+		// undetected by the FSM's OCC check (which only rejects
+		// versions with `latest > startTS`), letting the retry
+		// commit decisions based on stale reads — a strict-
+		// serialisability violation (gemini CRITICAL / codex P1
+		// on PR #900).
+		//
+		// The caller / adapter is responsible for re-executing the
+		// entire txn (including re-reading the keys at a fresh
+		// timestamp) when this sentinel surfaces.  Write-only
+		// txns (no reads to invalidate) remain safe to retry.
+		if len(reqs.ReadKeys) > 0 {
+			return resp, err
+		}
 		if attempt == composed1RetryAttempts {
 			return resp, err
 		}
@@ -515,15 +533,20 @@ func (c *ShardedCoordinator) dispatchTxnWithComposed1Retry(ctx context.Context, 
 		// same HLC observation; reusing the stale pair would risk
 		// a startTS that no longer dominates the new shard's
 		// applied commitTS.
-		reqs.StartTS = 0
+		//
+		// Allocate StartTS unconditionally — nextStartTS already
+		// handles the nil-clock case (falls back to
+		// maxTS+1 internally).  Gating on c.clock!=nil would leave
+		// reqs.StartTS at 0 in the nil-clock test fixture, and
+		// dispatchTxn does NOT re-allocate when StartTS is zero,
+		// so the retry would run with StartTS=0 — violating MVCC
+		// invariants (gemini HIGH on PR #900).
 		reqs.CommitTS = 0
-		if c.clock != nil {
-			startTS, allocErr := c.nextStartTS(ctx, reqs.Elems)
-			if allocErr != nil {
-				return resp, allocErr
-			}
-			reqs.StartTS = startTS
+		startTS, allocErr := c.nextStartTS(ctx, reqs.Elems)
+		if allocErr != nil {
+			return resp, allocErr
 		}
+		reqs.StartTS = startTS
 	}
 	// Unreachable — the loop body always returns on each iteration.
 	// Kept here so the function has an unambiguous return shape.

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -446,6 +446,23 @@ func (c *ShardedCoordinator) Dispatch(ctx context.Context, reqs *OperationGroup[
 		return c.dispatchDelPrefixBroadcast(ctx, reqs.IsTxn, reqs.Elems)
 	}
 
+	// Capture whether the caller supplied a non-zero StartTS BEFORE
+	// the coordinator-allocates-on-zero branch below mutates the
+	// field.  A caller-supplied StartTS names a specific snapshot
+	// the caller already read against (e.g. adapter/s3.go:573
+	// reads bucket metadata at readTS and dispatches with
+	// StartTS=readTS; adapter/sqs_messages.go and adapter/dynamodb.go
+	// follow the same readTS-then-mutate pattern across dozens of
+	// sites).  The pre-Dispatch read is invisible to the
+	// coordinator — it is NOT surfaced as a ReadKeys entry — so
+	// the only signal that the snapshot is owned by the caller is
+	// reqs.StartTS being non-zero on entry.  The M4 retry path
+	// uses this to gate the StartTS bump: bumping a caller-owned
+	// timestamp would let any commit landed in (originalStartTS,
+	// newStartTS) bypass the FSM's latest>startTS write-conflict
+	// check (codex P1 on 57da8886, PR #900).
+	callerSuppliedStartTS := reqs.IsTxn && reqs.StartTS != 0
+
 	if reqs.IsTxn && reqs.StartTS == 0 {
 		startTS, err := c.nextStartTS(ctx, reqs.Elems)
 		if err != nil {
@@ -460,7 +477,7 @@ func (c *ShardedCoordinator) Dispatch(ctx context.Context, reqs *OperationGroup[
 	}
 
 	if reqs.IsTxn {
-		return c.dispatchTxnWithComposed1Retry(ctx, reqs)
+		return c.dispatchTxnWithComposed1Retry(ctx, reqs, callerSuppliedStartTS)
 	}
 
 	return c.dispatchNonTxn(ctx, reqs)
@@ -510,7 +527,7 @@ func (c *ShardedCoordinator) maybeAutoPinObservedRouteVersion(reqs *OperationGro
 	reqs.ObservedRouteVersion = c.engine.Version()
 }
 
-func (c *ShardedCoordinator) dispatchTxnWithComposed1Retry(ctx context.Context, reqs *OperationGroup[OP]) (*CoordinateResponse, error) {
+func (c *ShardedCoordinator) dispatchTxnWithComposed1Retry(ctx context.Context, reqs *OperationGroup[OP], callerSuppliedStartTS bool) (*CoordinateResponse, error) {
 	c.maybeAutoPinObservedRouteVersion(reqs)
 
 	for attempt := 0; attempt <= composed1RetryAttempts; attempt++ {
@@ -537,6 +554,22 @@ func (c *ShardedCoordinator) dispatchTxnWithComposed1Retry(ctx context.Context, 
 		// timestamp) when this sentinel surfaces.  Write-only
 		// txns (no reads to invalidate) remain safe to retry.
 		if len(reqs.ReadKeys) > 0 {
+			return resp, err
+		}
+		// Caller-supplied StartTS (ReadKeys-empty case) MUST also
+		// surface — the caller's pre-Dispatch read at this snapshot
+		// is invisible to the coordinator, so we cannot prove the
+		// retry's bumped StartTS would still preserve OCC against
+		// commits landed in (originalStartTS, newStartTS).  This
+		// catches dozens of adapter sites that supply
+		// StartTS=readTS without populating ReadKeys: S3
+		// createBucket / admin object writes, SQS messages /
+		// FIFO / purge / tags, DynamoDB metadata writes, etc.
+		// Only coordinator-allocated StartTS (caller passed 0
+		// at Dispatch entry, the coordinator allocated it from
+		// nextStartTS, and no read has happened at it) is safe
+		// to bump on retry (codex P1 on 57da8886, PR #900).
+		if callerSuppliedStartTS {
 			return resp, err
 		}
 		if attempt == composed1RetryAttempts {

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -851,13 +851,23 @@ func (c *ShardedCoordinator) dispatchMultiShardTxn(ctx context.Context, startTS,
 		return nil, errors.WithStack(err)
 	}
 
-	// observedRouteVersion is intentionally NOT propagated to
-	// commitSecondaryTxns — secondary commits drop the M3 gate to
-	// avoid the best-effort-secondary + fail-closed-gate silent
-	// partial commit hazard (codex P1 on 6202b964, PR #900).  See
-	// the Request construction inside commitSecondaryTxns for the
-	// full reasoning.
-	maxIndex = c.commitSecondaryTxns(ctx, startTS, primaryGid, primaryKey, grouped, gids, commitTS, maxIndex)
+	// commitSecondaryTxns propagates ObservedRouteVersion to per-
+	// secondary commits so the M3 gate fires on route shifts between
+	// primary-COMMIT and secondary-COMMIT.  Such a sentinel surfaces
+	// as ErrTxnSecondaryRouteShiftedAfterPrimaryCommit (NOT
+	// ErrComposed1Violation — the M4 retry must not loop here; the
+	// primary is already durable and re-prewriting would conflict
+	// with the existing locks).  d8487672 originally tried to avoid
+	// the silent-partial-commit hazard by dropping the gate; codex
+	// P1 (20:30:35) correctly showed that the dropped-gate posture
+	// silently lands writes on stale owners that are no longer
+	// reachable by readers on the new owner.  Both directions are
+	// silent partial commits; surfacing the error is the only honest
+	// posture (codex P1 on d8487672 + 6202b964, PR #900).
+	maxIndex, err = c.commitSecondaryTxns(ctx, startTS, primaryGid, primaryKey, grouped, gids, commitTS, maxIndex, observedRouteVersion)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
 	return &CoordinateResponse{CommitIndex: maxIndex}, nil
 }
 
@@ -997,11 +1007,28 @@ func (c *ShardedCoordinator) commitPrimaryTxn(ctx context.Context, startTS uint6
 	return primaryGid, r.CommitIndex, nil
 }
 
-func (c *ShardedCoordinator) commitSecondaryTxns(ctx context.Context, startTS uint64, primaryGid uint64, primaryKey []byte, grouped map[uint64][]*pb.Mutation, gids []uint64, commitTS uint64, maxIndex uint64) uint64 {
-	// Secondary commits are best-effort. If a shard is unavailable after the
-	// primary commits, read-time lock resolution will commit the remaining
-	// secondaries based on the primary commit record. Retry a few times to
-	// absorb short leader-election windows and reduce lock lag.
+func (c *ShardedCoordinator) commitSecondaryTxns(ctx context.Context, startTS uint64, primaryGid uint64, primaryKey []byte, grouped map[uint64][]*pb.Mutation, gids []uint64, commitTS uint64, maxIndex uint64, observedRouteVersion uint64) (uint64, error) {
+	// Secondary commits are best-effort for non-Composed-1 errors:
+	// if a shard is unavailable after the primary commits, read-time
+	// lock resolution will commit the remaining secondaries based on
+	// the primary commit record.  Retry a few times to absorb short
+	// leader-election windows and reduce lock lag.
+	//
+	// Composed-1 errors are an exception (codex P1 on d8487672 +
+	// 6202b964, PR #900).  When the M3 gate fires on a secondary
+	// commit, the route catalog has moved between primary-COMMIT and
+	// this secondary-COMMIT — the prepared lock lives at the old
+	// gid, the new owner per the catalog has no commit record.  We
+	// CANNOT silently land the write on the stale owner (codex 20:30:35
+	// — that's invisible to readers on the new owner) and we CANNOT
+	// silently swallow the error (codex 20:10:32 — uncommitted
+	// secondary, silent partial commit on the missing direction).
+	// The only honest posture is to surface
+	// ErrTxnSecondaryRouteShiftedAfterPrimaryCommit so the caller
+	// knows the txn state is uncertain and can do application-level
+	// recovery.  This sentinel is distinct from ErrComposed1Violation
+	// so the M4 retry path does not loop here (the primary is durable
+	// and re-prewriting would conflict with the existing locks).
 	meta := txnMetaMutation(primaryKey, 0, commitTS)
 	for _, gid := range gids {
 		if gid == primaryGid {
@@ -1012,33 +1039,28 @@ func (c *ShardedCoordinator) commitSecondaryTxns(ctx context.Context, startTS ui
 			continue
 		}
 		req := &pb.Request{
-			IsTxn:     true,
-			Phase:     pb.Phase_COMMIT,
-			Ts:        startTS,
-			Mutations: append([]*pb.Mutation{meta}, keyMutations(grouped[gid])...),
-			// ObservedRouteVersion intentionally omitted (zero) on
-			// secondary commits.  commitSecondaryTxns is best-effort:
-			// errors are logged and the dispatch acknowledges success
-			// while the lock-resolution backstop is expected to commit
-			// the secondary later.  If we propagated the auto-pinned
-			// version here, a route shift between primary-COMMIT and
-			// secondary-COMMIT would let the secondary FSM return
-			// ErrComposed1Violation, which commitSecondaryTxns swallows
-			// — turning route churn into a silent partial commit
-			// visible to no readers on the new owner (codex P1 on
-			// 6202b964, PR #900).  The FSM's verifyComposed1
-			// short-circuits on ObservedRouteVersion=0 (fsm.go:609), so
-			// dropping the field here restores the pre-66ad5b0 "no
-			// gate on commit-phase secondaries" behaviour without
-			// affecting prewrite (still gated) or primary commit
-			// (still gated; abortPreparedTxn cleans up on failure).
-			// Until a fatal-secondary 2PC protocol or
-			// lock-resolution-bypass design lands (M5+), this is the
-			// honest posture: gate where we can cleanly abort, skip
-			// where we cannot.
+			IsTxn:                true,
+			Phase:                pb.Phase_COMMIT,
+			Ts:                   startTS,
+			Mutations:            append([]*pb.Mutation{meta}, keyMutations(grouped[gid])...),
+			ObservedRouteVersion: observedRouteVersion,
 		}
 		r, err := commitSecondaryWithRetry(ctx, g, req)
 		if err != nil {
+			if isComposed1RetryableError(err) {
+				// Fatal: surface the new sentinel so the caller is
+				// informed that the secondary's write is missing and
+				// the txn state is half-committed.  M4 retry won't
+				// match this sentinel, so it doesn't loop.
+				c.logger().Warn("txn secondary commit failed Composed-1 — surfacing as fatal",
+					slog.Uint64("gid", gid),
+					slog.String("primary_key", string(primaryKey)),
+					slog.Uint64("start_ts", startTS),
+					slog.Uint64("commit_ts", commitTS),
+					slog.Any("err", err),
+				)
+				return maxIndex, errors.WithStack(ErrTxnSecondaryRouteShiftedAfterPrimaryCommit)
+			}
 			c.logger().Warn("txn secondary commit failed",
 				slog.Uint64("gid", gid),
 				slog.String("primary_key", string(primaryKey)),
@@ -1052,7 +1074,7 @@ func (c *ShardedCoordinator) commitSecondaryTxns(ctx context.Context, startTS ui
 			maxIndex = r.CommitIndex
 		}
 	}
-	return maxIndex
+	return maxIndex, nil
 }
 
 func commitSecondaryWithRetry(ctx context.Context, g *ShardGroup, req *pb.Request) (*TransactionResponse, error) {

--- a/kv/sharded_coordinator_composed1_retry_test.go
+++ b/kv/sharded_coordinator_composed1_retry_test.go
@@ -297,3 +297,61 @@ func TestShardedCoordinator_DoesNotRetryReadWriteTxnOnComposed1(t *testing.T) {
 	require.Equal(t, int32(1), txn.calls.Load(),
 		"read-write txn must NOT retry: exactly 1 Commit attempt — the M4 retry is reserved for write-only txns where bumping StartTS is OCC-safe")
 }
+
+// TestShardedCoordinator_DoesNotAutoPinObservedRouteVersionForReadWriteTxn
+// is the regression for the codex P1 finding on PR #900: when a caller
+// already supplies a transaction StartTS/ReadKeys but leaves
+// ObservedRouteVersion unset, this used to stamp the catalog version
+// at EXEC/commit dispatch time rather than when the read set was
+// captured.
+//
+// Concrete scenario: Redis txnContext.commit builds an OperationGroup
+// with StartTS (allocated at MULTI) and ReadKeys (the GETs / WATCHes
+// from the txn body) but no ObservedRouteVersion.  If a route moves
+// between the MULTI-time reads and this Dispatch call, an auto-pin
+// at Dispatch entry would stamp the POST-shift catalog version on
+// the request and verifyComposed1 would NOT detect the shift the
+// guard is meant to catch.
+//
+// Correct behaviour: do NOT auto-fill ObservedRouteVersion when the
+// caller already has a read snapshot (len(ReadKeys) > 0).  Such
+// callers must pin ObservedRouteVersion themselves at BeginTxn time
+// per design doc §4.1; leaving it at zero surfaces as "unpinned"
+// to the M3 gate (which short-circuits), which is the safe default
+// for non-migrated callers — the gate cannot retroactively pin
+// reads it was not present for.
+//
+// Write-only txns (len(ReadKeys) == 0) continue to get auto-pinned
+// at Dispatch entry because there are no prior reads whose
+// snapshot version could disagree with the Dispatch-time pin.
+func TestShardedCoordinator_DoesNotAutoPinObservedRouteVersionForReadWriteTxn(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	require.NoError(t, engine.ApplySnapshot(distribution.CatalogSnapshot{
+		Version: 5,
+		Routes: []distribution.RouteDescriptor{
+			{RouteID: 100, Start: []byte(""), End: nil, GroupID: 1, State: distribution.RouteStateActive},
+		},
+	}))
+
+	txn := &composed1RetryingTransactional{firstErr: nil}
+	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{
+		1: {Txn: txn},
+	}, 1, NewHLC(), nil)
+
+	_, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
+		IsTxn:    true,
+		StartTS:  10,
+		ReadKeys: [][]byte{[]byte("k_read")},
+		// ObservedRouteVersion intentionally left at zero — caller
+		// did not migrate to pin at BeginTxn.
+		Elems: []*Elem[OP]{
+			{Op: Put, Key: []byte("k_write"), Value: []byte("v")},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, txn.observedSeen, 1)
+	require.Equal(t, uint64(0), txn.observedSeen[0],
+		"read-write txns with unset ObservedRouteVersion must NOT be auto-pinned at Dispatch entry — pinning at commit time disagrees with the reads' actual snapshot version, so verifyComposed1 must short-circuit (observedVer=0) until the caller migrates to pin at BeginTxn per §4.1")
+}

--- a/kv/sharded_coordinator_composed1_retry_test.go
+++ b/kv/sharded_coordinator_composed1_retry_test.go
@@ -1,0 +1,252 @@
+package kv
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/bootjp/elastickv/distribution"
+	pb "github.com/bootjp/elastickv/proto"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// composed1RetryingTransactional is a stub Transactional that fails the
+// first Commit attempt with a Composed-1 sentinel and succeeds on the
+// next.  Used to drive the M4 retry path without spinning up two real
+// Raft groups for an integration test (a future follow-up under M5 will
+// land the full Jepsen-shaped scenario).
+type composed1RetryingTransactional struct {
+	calls        atomic.Int32
+	firstErr     error
+	observedSeen []uint64
+}
+
+func (s *composed1RetryingTransactional) Commit(_ context.Context, reqs []*pb.Request) (*TransactionResponse, error) {
+	n := s.calls.Add(1)
+	if len(reqs) > 0 {
+		s.observedSeen = append(s.observedSeen, reqs[0].GetObservedRouteVersion())
+	}
+	if n == 1 {
+		return nil, s.firstErr
+	}
+	return &TransactionResponse{CommitIndex: uint64(n)}, nil //nolint:gosec // n is a small positive counter for test-stub responses
+}
+
+func (s *composed1RetryingTransactional) Abort(context.Context, []*pb.Request) (*TransactionResponse, error) {
+	return &TransactionResponse{}, nil
+}
+
+// TestShardedCoordinator_RetriesOnComposed1Violation is the M4
+// "Done when" criterion from the design doc: a Composed-1 sentinel
+// surfacing from the underlying Commit triggers a single coordinator-
+// side retry against the engine's now-current catalog version.  The
+// caller's client-observable result must be the SECOND attempt's
+// success, not the first attempt's ErrComposed1Violation.
+func TestShardedCoordinator_RetriesOnComposed1Violation(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	require.NoError(t, engine.ApplySnapshot(distribution.CatalogSnapshot{
+		Version: 1,
+		Routes: []distribution.RouteDescriptor{
+			{RouteID: 100, Start: []byte(""), End: nil, GroupID: 1, State: distribution.RouteStateActive},
+		},
+	}))
+
+	txn := &composed1RetryingTransactional{
+		firstErr: errors.WithStack(ErrComposed1Violation),
+	}
+	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{
+		1: {Txn: txn},
+	}, 1, NewHLC(), nil)
+
+	// Between the first and second dispatch attempts, simulate the
+	// route catalog moving forward — M4's retry path must re-read
+	// the engine version and stamp the new one on the retry's
+	// pb.Request so the FSM sees the post-shift observed version.
+	go func() {
+		// The retry happens synchronously inside Dispatch; advance the
+		// catalog before the second attempt would re-read it.  In a
+		// real cluster the advance is driven by a concurrent
+		// CatalogWatcher fan-out; here we just race against the
+		// in-process Commit to model the same observable effect.
+	}()
+
+	resp, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
+		IsTxn:   true,
+		StartTS: 10,
+		Elems: []*Elem[OP]{
+			{Op: Put, Key: []byte("k"), Value: []byte("v")},
+		},
+	})
+	require.NoError(t, err, "second attempt must succeed; the first attempt's ErrComposed1Violation is what M4 absorbs")
+	require.NotNil(t, resp)
+	require.Equal(t, int32(2), txn.calls.Load(),
+		"M4 retry budget is composed1RetryAttempts=1, so exactly two attempts must fire on a single Composed-1 sentinel")
+	require.Len(t, txn.observedSeen, 2,
+		"both attempts must record an ObservedRouteVersion (the first pinned at Dispatch entry, the second re-pinned on retry)")
+	require.Equal(t, uint64(1), txn.observedSeen[0],
+		"first attempt must carry the engine's catalog version at Dispatch entry (v=1)")
+	require.Equal(t, uint64(1), txn.observedSeen[1],
+		"second attempt must re-read and re-stamp the engine version; the engine did not advance between attempts in this test so the value happens to match — the contract is that we RE-READ, not that we always change")
+}
+
+// TestShardedCoordinator_RetriesOnComposed1VersionGCd verifies the
+// second M4 sentinel (retention-miss → re-read catalog) drives the
+// same retry path.  The two sentinels differ only in their cause;
+// both call for the same "stamp a fresh ObservedRouteVersion and
+// re-issue" recovery.
+func TestShardedCoordinator_RetriesOnComposed1VersionGCd(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	require.NoError(t, engine.ApplySnapshot(distribution.CatalogSnapshot{
+		Version: 1,
+		Routes: []distribution.RouteDescriptor{
+			{RouteID: 100, Start: []byte(""), End: nil, GroupID: 1, State: distribution.RouteStateActive},
+		},
+	}))
+
+	txn := &composed1RetryingTransactional{
+		firstErr: errors.WithStack(ErrComposed1VersionGCd),
+	}
+	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{
+		1: {Txn: txn},
+	}, 1, NewHLC(), nil)
+
+	resp, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
+		IsTxn:   true,
+		StartTS: 10,
+		Elems: []*Elem[OP]{
+			{Op: Put, Key: []byte("k"), Value: []byte("v")},
+		},
+	})
+	require.NoError(t, err, "second attempt must succeed; the first attempt's ErrComposed1VersionGCd is what M4 absorbs")
+	require.NotNil(t, resp)
+	require.Equal(t, int32(2), txn.calls.Load(),
+		"retention-miss sentinel must drive exactly the same single retry as ErrComposed1Violation")
+}
+
+// TestShardedCoordinator_PersistentComposed1ViolationSurfaces verifies
+// the retry budget: a Composed-1 sentinel that survives the M4
+// re-route must surface to the caller, not loop forever.  This is
+// what lets a wrapping adapter retry harness (or the client) see
+// the failure when the catalog churn outpaces the coordinator's
+// re-read cadence.
+func TestShardedCoordinator_PersistentComposed1ViolationSurfaces(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	require.NoError(t, engine.ApplySnapshot(distribution.CatalogSnapshot{
+		Version: 1,
+		Routes: []distribution.RouteDescriptor{
+			{RouteID: 100, Start: []byte(""), End: nil, GroupID: 1, State: distribution.RouteStateActive},
+		},
+	}))
+
+	// Persistent failure — every Commit returns the sentinel.
+	persistent := &persistentComposed1Failer{err: errors.WithStack(ErrComposed1Violation)}
+	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{
+		1: {Txn: persistent},
+	}, 1, NewHLC(), nil)
+
+	_, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
+		IsTxn:   true,
+		StartTS: 10,
+		Elems: []*Elem[OP]{
+			{Op: Put, Key: []byte("k"), Value: []byte("v")},
+		},
+	})
+	require.ErrorIs(t, err, ErrComposed1Violation,
+		"the sentinel must surface unchanged after the retry budget is exhausted")
+	require.Equal(t, int32(2), persistent.calls.Load(),
+		"composed1RetryAttempts=1 means initial + 1 retry = exactly 2 total Commit calls on persistent failure")
+}
+
+type persistentComposed1Failer struct {
+	calls atomic.Int32
+	err   error
+}
+
+func (p *persistentComposed1Failer) Commit(context.Context, []*pb.Request) (*TransactionResponse, error) {
+	p.calls.Add(1)
+	return nil, p.err
+}
+
+func (p *persistentComposed1Failer) Abort(context.Context, []*pb.Request) (*TransactionResponse, error) {
+	return &TransactionResponse{}, nil
+}
+
+// TestShardedCoordinator_PinsObservedRouteVersionAtDispatchEntry
+// documents the M4 pin: every txn that flows through Dispatch with
+// ObservedRouteVersion=0 gets stamped with the engine's current
+// catalog version.  This makes the M3 verifyComposed1 gate
+// effective by default — without this pin every caller would have
+// to discover and follow the §4.1 contract independently.
+func TestShardedCoordinator_PinsObservedRouteVersionAtDispatchEntry(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	require.NoError(t, engine.ApplySnapshot(distribution.CatalogSnapshot{
+		Version: 7,
+		Routes: []distribution.RouteDescriptor{
+			{RouteID: 100, Start: []byte(""), End: nil, GroupID: 1, State: distribution.RouteStateActive},
+		},
+	}))
+
+	txn := &composed1RetryingTransactional{firstErr: nil} // succeeds on first attempt
+	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{
+		1: {Txn: txn},
+	}, 1, NewHLC(), nil)
+
+	_, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
+		IsTxn:   true,
+		StartTS: 10,
+		Elems: []*Elem[OP]{
+			{Op: Put, Key: []byte("k"), Value: []byte("v")},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, txn.observedSeen, 1)
+	require.Equal(t, uint64(7), txn.observedSeen[0],
+		"Dispatch must pin reqs.ObservedRouteVersion to engine.Version() at entry when the caller leaves it at zero")
+}
+
+// TestShardedCoordinator_HonorsCallerPinnedObservedRouteVersion
+// documents that an adapter that DOES set ObservedRouteVersion
+// explicitly (a future migration target) wins over the
+// Dispatch-entry pin.  This preserves the §4.1 contract for callers
+// that want to manage the version themselves (e.g., a BeginTxn
+// snapshot taken earlier than this Dispatch call would otherwise
+// observe).
+func TestShardedCoordinator_HonorsCallerPinnedObservedRouteVersion(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	require.NoError(t, engine.ApplySnapshot(distribution.CatalogSnapshot{
+		Version: 7,
+		Routes: []distribution.RouteDescriptor{
+			{RouteID: 100, Start: []byte(""), End: nil, GroupID: 1, State: distribution.RouteStateActive},
+		},
+	}))
+
+	txn := &composed1RetryingTransactional{firstErr: nil}
+	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{
+		1: {Txn: txn},
+	}, 1, NewHLC(), nil)
+
+	const callerPinned = uint64(3)
+	_, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
+		IsTxn:                true,
+		StartTS:              10,
+		ObservedRouteVersion: callerPinned,
+		Elems: []*Elem[OP]{
+			{Op: Put, Key: []byte("k"), Value: []byte("v")},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, txn.observedSeen, 1)
+	require.Equal(t, callerPinned, txn.observedSeen[0],
+		"a caller-supplied ObservedRouteVersion must survive the Dispatch-entry pin so adapters can manage the version themselves (§4.1)")
+}

--- a/kv/sharded_coordinator_composed1_retry_test.go
+++ b/kv/sharded_coordinator_composed1_retry_test.go
@@ -17,15 +17,33 @@ import (
 // Raft groups for an integration test (a future follow-up under M5 will
 // land the full Jepsen-shaped scenario).
 type composed1RetryingTransactional struct {
-	calls        atomic.Int32
-	firstErr     error
-	observedSeen []uint64
+	calls            atomic.Int32
+	firstErr         error
+	observedSeen     []uint64
+	prevCommitTSSeen []uint64
 }
 
 func (s *composed1RetryingTransactional) Commit(_ context.Context, reqs []*pb.Request) (*TransactionResponse, error) {
 	n := s.calls.Add(1)
 	if len(reqs) > 0 {
 		s.observedSeen = append(s.observedSeen, reqs[0].GetObservedRouteVersion())
+		// PrevCommitTS rides inside the encoded TxnMeta on the first
+		// mutation of a one-phase txn request (see
+		// onePhaseTxnRequestWithPrevCommit in coordinator.go).  Decode
+		// it so the M4 retry tests can assert the field is cleared on
+		// the retry attempt (claude[bot] medium on PR #900: the M3
+		// gate fires at apply time, so the original attempt never
+		// committed; leaving PrevCommitTS non-zero on the retry causes
+		// dispatchMultiShardTxn to refuse with
+		// ErrTxnDedupRequiresSingleShard when groupMutations now spans
+		// two groups).
+		var prev uint64
+		if muts := reqs[0].GetMutations(); len(muts) > 0 {
+			if meta, err := DecodeTxnMeta(muts[0].GetValue()); err == nil {
+				prev = meta.PrevCommitTS
+			}
+		}
+		s.prevCommitTSSeen = append(s.prevCommitTSSeen, prev)
 	}
 	if n == 1 {
 		return nil, s.firstErr
@@ -61,18 +79,14 @@ func TestShardedCoordinator_RetriesOnComposed1Violation(t *testing.T) {
 		1: {Txn: txn},
 	}, 1, NewHLC(), nil)
 
-	// Between the first and second dispatch attempts, simulate the
-	// route catalog moving forward — M4's retry path must re-read
-	// the engine version and stamp the new one on the retry's
-	// pb.Request so the FSM sees the post-shift observed version.
-	go func() {
-		// The retry happens synchronously inside Dispatch; advance the
-		// catalog before the second attempt would re-read it.  In a
-		// real cluster the advance is driven by a concurrent
-		// CatalogWatcher fan-out; here we just race against the
-		// in-process Commit to model the same observable effect.
-	}()
-
+	// In a real cluster the route catalog advance between the first
+	// and second attempts is driven by a concurrent CatalogWatcher
+	// fan-out.  This test does not model the advance directly — the
+	// stub returns the sentinel unconditionally and the retry path's
+	// re-read picks up whatever the engine reports.  observedSeen[1]
+	// equality below asserts the RE-READ contract, not a particular
+	// value (claude[bot] minor on PR #900: an empty goroutine here
+	// looked like an unfinished concurrent-advance model).
 	resp, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
 		IsTxn:   true,
 		StartTS: 10,
@@ -354,4 +368,57 @@ func TestShardedCoordinator_DoesNotAutoPinObservedRouteVersionForReadWriteTxn(t 
 	require.Len(t, txn.observedSeen, 1)
 	require.Equal(t, uint64(0), txn.observedSeen[0],
 		"read-write txns with unset ObservedRouteVersion must NOT be auto-pinned at Dispatch entry — pinning at commit time disagrees with the reads' actual snapshot version, so verifyComposed1 must short-circuit (observedVer=0) until the caller migrates to pin at BeginTxn per §4.1")
+}
+
+// TestShardedCoordinator_ClearsPrevCommitTSOnComposed1Retry verifies
+// that the M4 retry path zeros OperationGroup.PrevCommitTS before
+// the second dispatchTxn call.  Rationale (claude[bot] medium on
+// PR #900): the M3 gate fires at apply time, so the ORIGINAL attempt
+// never committed — there is no prior landing for PrevCommitTS to
+// dedup against on the retry.  If the retry kept the caller's
+// PrevCommitTS non-zero AND the post-shift catalog reroutes the txn
+// to span two groups, dispatchMultiShardTxn would short-circuit with
+// ErrTxnDedupRequiresSingleShard (kv/sharded_coordinator.go:736) on a
+// signal that no longer holds, surfacing a misleading error to the
+// caller instead of a correct re-route.  The contract is: on
+// Composed-1 retry, drop the dedup probe — the FSM's option-2
+// idempotency check has nothing valid to compare against.
+//
+// This is a write-only txn (no ReadKeys); the M4 retry is allowed
+// (per the gemini-CRITICAL gate already in place) and PrevCommitTS
+// is the option-2 dedup probe the adapter set on the first attempt.
+func TestShardedCoordinator_ClearsPrevCommitTSOnComposed1Retry(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	require.NoError(t, engine.ApplySnapshot(distribution.CatalogSnapshot{
+		Version: 1,
+		Routes: []distribution.RouteDescriptor{
+			{RouteID: 100, Start: []byte(""), End: nil, GroupID: 1, State: distribution.RouteStateActive},
+		},
+	}))
+
+	txn := &composed1RetryingTransactional{
+		firstErr: errors.WithStack(ErrComposed1Violation),
+	}
+	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{
+		1: {Txn: txn},
+	}, 1, NewHLC(), nil)
+
+	_, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
+		IsTxn:        true,
+		StartTS:      10,
+		CommitTS:     20,
+		PrevCommitTS: 17, // adapter-supplied option-2 dedup probe
+		Elems: []*Elem[OP]{
+			{Op: Put, Key: []byte("k_write"), Value: []byte("v")},
+		},
+	})
+	require.NoError(t, err, "M4 must retry write-only Composed-1 once and succeed on attempt 2")
+	require.Len(t, txn.prevCommitTSSeen, 2,
+		"both attempts must be observed for the PrevCommitTS comparison")
+	require.Equal(t, uint64(17), txn.prevCommitTSSeen[0],
+		"first attempt must carry the caller's PrevCommitTS unchanged — that is the option-2 dedup probe semantics")
+	require.Equal(t, uint64(0), txn.prevCommitTSSeen[1],
+		"second attempt must drop PrevCommitTS — the M3 gate fired at apply time so the original attempt never committed; leaving the probe set would let dispatchMultiShardTxn return ErrTxnDedupRequiresSingleShard on a stale signal if the retry's groupMutations now spans two groups")
 }

--- a/kv/sharded_coordinator_composed1_retry_test.go
+++ b/kv/sharded_coordinator_composed1_retry_test.go
@@ -250,3 +250,50 @@ func TestShardedCoordinator_HonorsCallerPinnedObservedRouteVersion(t *testing.T)
 	require.Equal(t, callerPinned, txn.observedSeen[0],
 		"a caller-supplied ObservedRouteVersion must survive the Dispatch-entry pin so adapters can manage the version themselves (§4.1)")
 }
+
+// TestShardedCoordinator_DoesNotRetryReadWriteTxnOnComposed1 is the
+// regression for the gemini CRITICAL / codex P1 finding on PR #900:
+// transparently retrying a txn with a bumped StartTS is only safe
+// when the txn is write-only.  When the txn has read keys
+// (Redis MULTI/EXEC, DynamoDB TransactGetItems → TransactWrite, etc.),
+// the client already performed those reads at the original StartTS.
+// Bumping StartTS on retry would silently mask any concurrent writes
+// that landed between the old and new timestamps — the FSM's OCC
+// check rejects only versions with `latest > startTS`, so the retry
+// could commit decisions based on stale reads, violating SSI.
+//
+// Expected behaviour: the sentinel surfaces immediately (no retry)
+// when len(ReadKeys) > 0.  The caller / adapter is then responsible
+// for re-executing the entire txn (including re-reading the keys
+// at a fresh timestamp).
+func TestShardedCoordinator_DoesNotRetryReadWriteTxnOnComposed1(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	require.NoError(t, engine.ApplySnapshot(distribution.CatalogSnapshot{
+		Version: 1,
+		Routes: []distribution.RouteDescriptor{
+			{RouteID: 100, Start: []byte(""), End: nil, GroupID: 1, State: distribution.RouteStateActive},
+		},
+	}))
+
+	txn := &composed1RetryingTransactional{
+		firstErr: errors.WithStack(ErrComposed1Violation),
+	}
+	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{
+		1: {Txn: txn},
+	}, 1, NewHLC(), nil)
+
+	_, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
+		IsTxn:    true,
+		StartTS:  10,
+		ReadKeys: [][]byte{[]byte("k_read")},
+		Elems: []*Elem[OP]{
+			{Op: Put, Key: []byte("k"), Value: []byte("v")},
+		},
+	})
+	require.ErrorIs(t, err, ErrComposed1Violation,
+		"read-write txns (ReadKeys non-empty) must surface the Composed-1 sentinel WITHOUT retry: the client read at the original StartTS, so silently bumping StartTS on retry would let concurrent writes between the old and new timestamps go undetected by OCC (SSI violation)")
+	require.Equal(t, int32(1), txn.calls.Load(),
+		"read-write txn must NOT retry: exactly 1 Commit attempt — the M4 retry is reserved for write-only txns where bumping StartTS is OCC-safe")
+}

--- a/kv/sharded_coordinator_composed1_retry_test.go
+++ b/kv/sharded_coordinator_composed1_retry_test.go
@@ -30,13 +30,16 @@ func (s *composed1RetryingTransactional) Commit(_ context.Context, reqs []*pb.Re
 		// PrevCommitTS rides inside the encoded TxnMeta on the first
 		// mutation of a one-phase txn request (see
 		// onePhaseTxnRequestWithPrevCommit in coordinator.go).  Decode
-		// it so the M4 retry tests can assert the field is cleared on
-		// the retry attempt (claude[bot] medium on PR #900: the M3
-		// gate fires at apply time, so the original attempt never
-		// committed; leaving PrevCommitTS non-zero on the retry causes
-		// dispatchMultiShardTxn to refuse with
-		// ErrTxnDedupRequiresSingleShard when groupMutations now spans
-		// two groups).
+		// it so the M4 retry tests can assert the field is PRESERVED
+		// across retry attempts — the probe names the ADAPTER'S
+		// prior attempt (e.g. adapter/redis.go:3209, :3615 send it
+		// as the option-2 ambiguous-outcome probe), which may have
+		// LANDED at the named commitTS before the route shift that
+		// triggered our M3 sentinel.  Dropping the probe in the
+		// retry would let the FSM re-apply against the post-shift
+		// route and double-write if that prior attempt landed
+		// (codex P1 on 43c55dfe, PR #900 — proved the earlier
+		// claude[bot] "clear it" advice was wrong).
 		var prev uint64
 		if muts := reqs[0].GetMutations(); len(muts) > 0 {
 			if meta, err := DecodeTxnMeta(muts[0].GetValue()); err == nil {
@@ -88,8 +91,12 @@ func TestShardedCoordinator_RetriesOnComposed1Violation(t *testing.T) {
 	// value (claude[bot] minor on PR #900: an empty goroutine here
 	// looked like an unfinished concurrent-advance model).
 	resp, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
-		IsTxn:   true,
-		StartTS: 10,
+		IsTxn: true,
+		// StartTS intentionally omitted — let the coordinator
+		// allocate via nextStartTS so the M4 retry path is
+		// eligible to fire.  Caller-supplied StartTS surfaces the
+		// sentinel without retry (codex P1 on 57da8886, PR #900);
+		// this test exercises the coordinator-allocated path.
 		Elems: []*Elem[OP]{
 			{Op: Put, Key: []byte("k"), Value: []byte("v")},
 		},
@@ -130,8 +137,10 @@ func TestShardedCoordinator_RetriesOnComposed1VersionGCd(t *testing.T) {
 	}, 1, NewHLC(), nil)
 
 	resp, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
-		IsTxn:   true,
-		StartTS: 10,
+		IsTxn: true,
+		// StartTS omitted so the coordinator allocates — see
+		// TestShardedCoordinator_RetriesOnComposed1Violation for
+		// rationale (codex P1 on 57da8886, PR #900).
 		Elems: []*Elem[OP]{
 			{Op: Put, Key: []byte("k"), Value: []byte("v")},
 		},
@@ -166,8 +175,10 @@ func TestShardedCoordinator_PersistentComposed1ViolationSurfaces(t *testing.T) {
 	}, 1, NewHLC(), nil)
 
 	_, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
-		IsTxn:   true,
-		StartTS: 10,
+		IsTxn: true,
+		// StartTS omitted so the coordinator allocates — see
+		// TestShardedCoordinator_RetriesOnComposed1Violation
+		// (codex P1 on 57da8886, PR #900).
 		Elems: []*Elem[OP]{
 			{Op: Put, Key: []byte("k"), Value: []byte("v")},
 		},
@@ -421,9 +432,12 @@ func TestShardedCoordinator_PreservesPrevCommitTSOnComposed1Retry(t *testing.T) 
 	}, 1, NewHLC(), nil)
 
 	_, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
-		IsTxn:        true,
-		StartTS:      10,
-		CommitTS:     20,
+		IsTxn: true,
+		// StartTS / CommitTS intentionally omitted — let the
+		// coordinator allocate so the M4 retry path is eligible
+		// (codex P1 on 57da8886, PR #900: caller-supplied
+		// StartTS surfaces without retry).  PrevCommitTS is a
+		// separate option-2 dedup probe and is set unchanged.
 		PrevCommitTS: 17, // adapter-supplied option-2 dedup probe
 		Elems: []*Elem[OP]{
 			{Op: Put, Key: []byte("k_write"), Value: []byte("v")},
@@ -436,4 +450,61 @@ func TestShardedCoordinator_PreservesPrevCommitTSOnComposed1Retry(t *testing.T) 
 		"first attempt must carry the caller's PrevCommitTS unchanged — that is the option-2 dedup probe semantics")
 	require.Equal(t, uint64(17), txn.prevCommitTSSeen[1],
 		"second attempt must ALSO carry PrevCommitTS=17 — the M3 gate only proves attempt 1 did not write; it tells us nothing about the ADAPTER's prior attempt (whose commitTS the probe names), so dropping the probe would double-write the caller's at-most-once payload if that prior attempt landed (codex P1 on 43c55dfe)")
+}
+
+// TestShardedCoordinator_SurfacesComposed1OnCallerSuppliedStartTS
+// pins the OCC-safety contract for caller-supplied snapshots
+// (codex P1 on 57da8886, PR #900): when the CALLER supplied a
+// non-zero StartTS — even with ReadKeys empty — the M4 retry path
+// must NOT bump StartTS and silently retry.  The caller's StartTS
+// names a specific snapshot they read against, and the M4 retry's
+// nextStartTS allocation would let any concurrent commit landed
+// in (originalStartTS, newStartTS) bypass the FSM's
+// `latest > startTS` OCC write-conflict check, since the bumped
+// snapshot now dominates the intervening commit_ts.
+//
+// Real exposure: many adapter sites read metadata at readTS and
+// then dispatch with `StartTS: readTS` and empty ReadKeys, e.g.
+// adapter/s3.go:573 (createBucket), adapter/sqs_messages.go:541,
+// adapter/dynamodb.go:4366, adapter/s3_admin_objects.go:144, etc.
+// Their pre-Dispatch read is invisible to the coordinator (no
+// ReadKeys), so the only signal that the snapshot is owned by the
+// caller is reqs.StartTS being non-zero at Dispatch entry.
+//
+// Contract: caller-supplied StartTS → surface the sentinel
+// unchanged.  Coordinator-allocated StartTS (when caller passed
+// StartTS=0 at Dispatch entry) is the only case M4 may retry —
+// the coordinator owns that timestamp and no one has read at it.
+func TestShardedCoordinator_SurfacesComposed1OnCallerSuppliedStartTS(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	require.NoError(t, engine.ApplySnapshot(distribution.CatalogSnapshot{
+		Version: 1,
+		Routes: []distribution.RouteDescriptor{
+			{RouteID: 100, Start: []byte(""), End: nil, GroupID: 1, State: distribution.RouteStateActive},
+		},
+	}))
+
+	txn := &composed1RetryingTransactional{
+		firstErr: errors.WithStack(ErrComposed1Violation),
+	}
+	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{
+		1: {Txn: txn},
+	}, 1, NewHLC(), nil)
+
+	_, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
+		IsTxn:   true,
+		StartTS: 42, // caller-supplied — adapter read metadata at this ts
+		// ReadKeys intentionally empty — the read happened at the
+		// adapter layer and is not surfaced as a ReadKeys entry
+		// (typical for S3/SQS/DynamoDB metadata reads).
+		Elems: []*Elem[OP]{
+			{Op: Put, Key: []byte("k_write"), Value: []byte("v")},
+		},
+	})
+	require.ErrorIs(t, err, ErrComposed1Violation,
+		"caller-supplied StartTS must surface the sentinel without retry — bumping StartTS would let any commit landed in (42, newStartTS) bypass the FSM's latest>startTS OCC check (codex P1 on 57da8886)")
+	require.Equal(t, int32(1), txn.calls.Load(),
+		"exactly ONE attempt must fire — M4 must NOT retry caller-supplied snapshots")
 }

--- a/kv/sharded_coordinator_composed1_retry_test.go
+++ b/kv/sharded_coordinator_composed1_retry_test.go
@@ -226,8 +226,13 @@ func TestShardedCoordinator_PinsObservedRouteVersionAtDispatchEntry(t *testing.T
 	}, 1, NewHLC(), nil)
 
 	_, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
-		IsTxn:   true,
-		StartTS: 10,
+		IsTxn: true,
+		// StartTS omitted — the auto-pin requires a
+		// coordinator-allocated snapshot (callerSuppliedStartTS=false)
+		// in addition to ReadKeys empty.  Caller-supplied StartTS
+		// skips the auto-pin to avoid masking a read→Dispatch
+		// route shift (codex P1 on 144ec0ca, PR #900); see
+		// TestShardedCoordinator_DoesNotAutoPinObservedRouteVersionForCallerSuppliedStartTS.
 		Elems: []*Elem[OP]{
 			{Op: Put, Key: []byte("k"), Value: []byte("v")},
 		},
@@ -235,7 +240,7 @@ func TestShardedCoordinator_PinsObservedRouteVersionAtDispatchEntry(t *testing.T
 	require.NoError(t, err)
 	require.Len(t, txn.observedSeen, 1)
 	require.Equal(t, uint64(7), txn.observedSeen[0],
-		"Dispatch must pin reqs.ObservedRouteVersion to engine.Version() at entry when the caller leaves it at zero")
+		"Dispatch must pin reqs.ObservedRouteVersion to engine.Version() at entry when the caller leaves it at zero (coordinator-allocated StartTS path)")
 }
 
 // TestShardedCoordinator_HonorsCallerPinnedObservedRouteVersion
@@ -507,4 +512,66 @@ func TestShardedCoordinator_SurfacesComposed1OnCallerSuppliedStartTS(t *testing.
 		"caller-supplied StartTS must surface the sentinel without retry — bumping StartTS would let any commit landed in (42, newStartTS) bypass the FSM's latest>startTS OCC check (codex P1 on 57da8886)")
 	require.Equal(t, int32(1), txn.calls.Load(),
 		"exactly ONE attempt must fire — M4 must NOT retry caller-supplied snapshots")
+}
+
+// TestShardedCoordinator_DoesNotAutoPinObservedRouteVersionForCallerSuppliedStartTS
+// is the regression for codex P1 on 144ec0ca (PR #900): when the
+// caller supplies StartTS but leaves ReadKeys empty (the 13+
+// adapter pattern: S3/SQS/DynamoDB sites that read metadata at
+// readTS and dispatch with StartTS=readTS, no ReadKeys), the
+// Dispatch-entry auto-pin of ObservedRouteVersion must SKIP.
+//
+// Rationale: stamping reqs.ObservedRouteVersion = engine.Version()
+// at Dispatch time falsely asserts "the read set was captured at
+// this catalog version".  For a caller-supplied-StartTS path the
+// actual read happened at the adapter layer BEFORE Dispatch; if a
+// route shift landed between that read and Dispatch entry, the
+// auto-pin stamps the POST-shift version and verifyComposed1
+// finds no mismatch at apply time — the route shift is INVISIBLE
+// to the M3 gate, masking exactly the failure mode the gate
+// exists to catch.  This is strictly worse than no auto-pin: an
+// honest ObservedRouteVersion=0 lets the gate short-circuit (no
+// false claim made) and the operator knows protection is not in
+// place; the spurious auto-pin gives false confidence.
+//
+// The correct fix lives in the adapters (pin
+// ObservedRouteVersion at read time, design doc §4.1), which is
+// M5+ work.  Until then, withholding the auto-pin is the only
+// honest posture.
+//
+// Coordinator-allocated StartTS (caller passed 0) continues to
+// auto-pin, because the coordinator's own allocation IS the
+// read-time-equivalent moment — no read has happened earlier
+// against a different catalog version.
+func TestShardedCoordinator_DoesNotAutoPinObservedRouteVersionForCallerSuppliedStartTS(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	require.NoError(t, engine.ApplySnapshot(distribution.CatalogSnapshot{
+		Version: 9,
+		Routes: []distribution.RouteDescriptor{
+			{RouteID: 100, Start: []byte(""), End: nil, GroupID: 1, State: distribution.RouteStateActive},
+		},
+	}))
+
+	txn := &composed1RetryingTransactional{firstErr: nil} // succeeds on first attempt
+	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{
+		1: {Txn: txn},
+	}, 1, NewHLC(), nil)
+
+	_, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
+		IsTxn:   true,
+		StartTS: 42, // caller-supplied — adapter read at this ts
+		// ReadKeys intentionally empty (typical for S3/SQS/DynamoDB
+		// metadata-read-then-write sites).
+		// ObservedRouteVersion intentionally zero — caller has not
+		// migrated to pin at BeginTxn per §4.1.
+		Elems: []*Elem[OP]{
+			{Op: Put, Key: []byte("k_write"), Value: []byte("v")},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, txn.observedSeen, 1)
+	require.Equal(t, uint64(0), txn.observedSeen[0],
+		"caller-supplied StartTS with empty ReadKeys must NOT be auto-pinned at Dispatch entry — stamping the post-shift catalog version would mask a read→Dispatch route shift from verifyComposed1, creating a false-confidence M3 gate signal worse than no gate (codex P1 on 144ec0ca)")
 }

--- a/kv/sharded_coordinator_composed1_retry_test.go
+++ b/kv/sharded_coordinator_composed1_retry_test.go
@@ -370,24 +370,39 @@ func TestShardedCoordinator_DoesNotAutoPinObservedRouteVersionForReadWriteTxn(t 
 		"read-write txns with unset ObservedRouteVersion must NOT be auto-pinned at Dispatch entry — pinning at commit time disagrees with the reads' actual snapshot version, so verifyComposed1 must short-circuit (observedVer=0) until the caller migrates to pin at BeginTxn per §4.1")
 }
 
-// TestShardedCoordinator_ClearsPrevCommitTSOnComposed1Retry verifies
-// that the M4 retry path zeros OperationGroup.PrevCommitTS before
-// the second dispatchTxn call.  Rationale (claude[bot] medium on
-// PR #900): the M3 gate fires at apply time, so the ORIGINAL attempt
-// never committed — there is no prior landing for PrevCommitTS to
-// dedup against on the retry.  If the retry kept the caller's
-// PrevCommitTS non-zero AND the post-shift catalog reroutes the txn
-// to span two groups, dispatchMultiShardTxn would short-circuit with
-// ErrTxnDedupRequiresSingleShard (kv/sharded_coordinator.go:736) on a
-// signal that no longer holds, surfacing a misleading error to the
-// caller instead of a correct re-route.  The contract is: on
-// Composed-1 retry, drop the dedup probe — the FSM's option-2
-// idempotency check has nothing valid to compare against.
+// TestShardedCoordinator_PreservesPrevCommitTSOnComposed1Retry pins
+// the at-most-once correctness contract: the M4 retry path MUST keep
+// OperationGroup.PrevCommitTS intact across attempts.
 //
-// This is a write-only txn (no ReadKeys); the M4 retry is allowed
-// (per the gemini-CRITICAL gate already in place) and PrevCommitTS
-// is the option-2 dedup probe the adapter set on the first attempt.
-func TestShardedCoordinator_ClearsPrevCommitTSOnComposed1Retry(t *testing.T) {
+// Earlier in this PR the retry path cleared PrevCommitTS in the
+// retry block (taking claude[bot]'s reasoning at face value: "M3
+// fired at apply time → original attempt never committed → probe is
+// stale").  codex P1 on 43c55dfe correctly identified that this
+// conflates two different "original attempts":
+//
+//   - Within M4: attempt 1's M3 rejection proves attempt 1 wrote
+//     nothing (the FSM rejects before any state change).
+//   - Across adapter retries: PrevCommitTS names the ADAPTER'S prior
+//     attempt — see adapter/redis.go list-push reuse path that sends
+//     PrevCommitTS = pending.commitTS as the option-2 ambiguous-outcome
+//     probe.  That earlier attempt may have actually LANDED at the
+//     named commitTS before the route shift that triggered our M3
+//     sentinel.
+//
+// Dropping the probe in the retry would let the FSM re-apply the
+// writes against the post-shift route, double-writing the caller's
+// at-most-once-payload if the named prior attempt did land.
+// Preserving the probe is the safe behaviour even at the cost of
+// dispatchMultiShardTxn:749 surfacing ErrTxnDedupRequiresSingleShard
+// in the post-shift-multi-shard case — that error IS the faithful
+// signal that the adapter's at-most-once retry contract cannot be
+// transparently honoured across a shard split.
+//
+// This test uses a single-shard fixture (one route, one ShardGroup)
+// so the second attempt succeeds in the stub; the assertion is on
+// the bytes that reach Commit, which is what the FSM actually
+// reads.
+func TestShardedCoordinator_PreservesPrevCommitTSOnComposed1Retry(t *testing.T) {
 	t.Parallel()
 
 	engine := distribution.NewEngine()
@@ -419,6 +434,6 @@ func TestShardedCoordinator_ClearsPrevCommitTSOnComposed1Retry(t *testing.T) {
 		"both attempts must be observed for the PrevCommitTS comparison")
 	require.Equal(t, uint64(17), txn.prevCommitTSSeen[0],
 		"first attempt must carry the caller's PrevCommitTS unchanged — that is the option-2 dedup probe semantics")
-	require.Equal(t, uint64(0), txn.prevCommitTSSeen[1],
-		"second attempt must drop PrevCommitTS — the M3 gate fired at apply time so the original attempt never committed; leaving the probe set would let dispatchMultiShardTxn return ErrTxnDedupRequiresSingleShard on a stale signal if the retry's groupMutations now spans two groups")
+	require.Equal(t, uint64(17), txn.prevCommitTSSeen[1],
+		"second attempt must ALSO carry PrevCommitTS=17 — the M3 gate only proves attempt 1 did not write; it tells us nothing about the ADAPTER's prior attempt (whose commitTS the probe names), so dropping the probe would double-write the caller's at-most-once payload if that prior attempt landed (codex P1 on 43c55dfe)")
 }

--- a/kv/sharded_coordinator_composed1_retry_test.go
+++ b/kv/sharded_coordinator_composed1_retry_test.go
@@ -576,39 +576,35 @@ func TestShardedCoordinator_DoesNotAutoPinObservedRouteVersionForCallerSuppliedS
 		"caller-supplied StartTS with empty ReadKeys must NOT be auto-pinned at Dispatch entry — stamping the post-shift catalog version would mask a read→Dispatch route shift from verifyComposed1, creating a false-confidence M3 gate signal worse than no gate (codex P1 on 144ec0ca)")
 }
 
-// TestShardedCoordinator_DropsObservedRouteVersionOn2PCSecondaryCommit
-// is the regression for codex P1 on 6202b964 (PR #900):
-// commitSecondaryTxns treats secondary commit errors as
-// best-effort — it logs and continues, then dispatchMultiShardTxn
-// returns success.  If we propagate a non-zero
-// ObservedRouteVersion to the secondary commit Request, a route
-// shift after PREPARE/primary-COMMIT but before secondary-COMMIT
-// makes the secondary FSM return ErrComposed1Violation; the
-// caller-visible Dispatch ACK still says success, leaving the
-// secondary write uncommitted/invisible to readers on the new
-// owner — a silent partial commit.
+// TestShardedCoordinator_PropagatesObservedRouteVersionOn2PCSecondaryCommit
+// pins the contract resolved across the two competing codex P1
+// findings on PR #900: secondary commits MUST carry the auto-pinned
+// ObservedRouteVersion (preserved as of the d8487672 revert in this
+// PR's later iterations), even though commitSecondaryTxns is
+// otherwise best-effort.  A non-zero observedVer ensures the M3
+// gate fires on a route shift between primary-COMMIT and
+// secondary-COMMIT, and
+// commitSecondaryTxns/dispatchMultiShardTxn surface that as a
+// distinct fatal sentinel
+// (ErrTxnSecondaryRouteShiftedAfterPrimaryCommit) instead of either
+// swallowing (codex P1 on 6202b964: missing-write silent partial
+// commit) or dropping the gate (codex P1 on d8487672: stale-owner
+// silent partial commit).
 //
-// The fundamental tension: 2PC's "best-effort secondary +
-// lock-resolution backstop" semantic does not compose with M3's
-// "fail-closed on route shift" semantic.  Until lock resolution or
-// a fatal-secondary 2PC variant is wired (M5+), the surgical fix is
-// to send ObservedRouteVersion=0 on secondary commit Requests.
-// The FSM's verifyComposed1 short-circuits on observedVer==0
-// (fsm.go:609), restoring the pre-66ad5b0 behaviour for this step
-// while keeping the gate on prewrite (catches mid-flight shifts
-// before lock placement) and the primary commit (catches
-// linearization shifts; abortPreparedTxn cleans up).
+// 2-shard fixture: primary "b" → g1, secondary "x" → g2.  Auto-pin
+// stamps ObservedRouteVersion = engine.Version() = 7.  Coverage
+// matrix:
 //
-// This test uses a 2-shard fixture: primary "b" → g1,
-// secondary "x" → g2.  Auto-pin fires at Dispatch entry
-// (coordinator-allocated StartTS, ReadKeys empty), stamping
-// ObservedRouteVersion = engine.Version() = 7.  Both shards
-// receive 2 Requests each (prewrite + commit).  Assertions:
+//   - Prewrite (both shards):  observedVer=7 (gate active)
+//   - Primary commit (g1):     observedVer=7 (gate active)
+//   - Secondary commit (g2):   observedVer=7 (gate active; fatal on
+//     Composed-1 — see
+//     TestShardedCoordinator_SurfacesFatalErrorOn2PCSecondaryComposed1)
 //
-//   - Prewrite on both shards carries observedVer=7 (gate active)
-//   - Primary commit on g1 carries observedVer=7 (gate active)
-//   - Secondary commit on g2 carries observedVer=0 (gate skipped)
-func TestShardedCoordinator_DropsObservedRouteVersionOn2PCSecondaryCommit(t *testing.T) {
+// See TestShardedCoordinator_SurfacesFatalErrorOn2PCSecondaryComposed1
+// for the regression that verifies the secondary's Composed-1 error
+// surfaces as the new fatal sentinel.
+func TestShardedCoordinator_PropagatesObservedRouteVersionOn2PCSecondaryCommit(t *testing.T) {
 	t.Parallel()
 
 	engine := distribution.NewEngine()
@@ -629,8 +625,6 @@ func TestShardedCoordinator_DropsObservedRouteVersionOn2PCSecondaryCommit(t *tes
 
 	_, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
 		IsTxn: true,
-		// StartTS omitted → coordinator allocates → auto-pin fires
-		// (callerSuppliedStartTS=false, ReadKeys empty).
 		Elems: []*Elem[OP]{
 			{Op: Put, Key: []byte("b"), Value: []byte("v1")}, // → g1 (primary)
 			{Op: Put, Key: []byte("x"), Value: []byte("v2")}, // → g2 (secondary)
@@ -640,22 +634,82 @@ func TestShardedCoordinator_DropsObservedRouteVersionOn2PCSecondaryCommit(t *tes
 	require.Len(t, g1Txn.requests, 2, "primary g1 receives prewrite + commit")
 	require.Len(t, g2Txn.requests, 2, "secondary g2 receives prewrite + commit")
 
-	// Prewrites on both shards must carry the auto-pinned version —
-	// gate is active there, catching shifts before lock placement.
 	require.Equal(t, uint64(7), g1Txn.requests[0].GetObservedRouteVersion(),
-		"primary prewrite must carry the auto-pinned ObservedRouteVersion (gate active before lock placement)")
+		"primary prewrite must carry observedVer=7")
 	require.Equal(t, uint64(7), g2Txn.requests[0].GetObservedRouteVersion(),
-		"secondary prewrite must carry the auto-pinned ObservedRouteVersion (gate active before lock placement)")
-
-	// Primary commit must also carry it — linearization point, gate
-	// active, abortPreparedTxn cleans up on failure.
+		"secondary prewrite must carry observedVer=7")
 	require.Equal(t, uint64(7), g1Txn.requests[1].GetObservedRouteVersion(),
-		"primary commit must carry the auto-pinned ObservedRouteVersion (gate at linearization; abort path cleans up on failure)")
+		"primary commit must carry observedVer=7")
+	require.Equal(t, uint64(7), g2Txn.requests[1].GetObservedRouteVersion(),
+		"secondary commit MUST carry observedVer=7 — the gate must fire on route shifts between primary-COMMIT and secondary-COMMIT; codex P1 on d8487672 showed that dropping the gate silently writes to a stale owner")
+}
 
-	// Secondary commit MUST carry ObservedRouteVersion=0 — the fix
-	// for codex P1 on 6202b964.  Without this, a route shift between
-	// primary-COMMIT and secondary-COMMIT turns into a silent partial
-	// commit because commitSecondaryTxns is best-effort.
-	require.Equal(t, uint64(0), g2Txn.requests[1].GetObservedRouteVersion(),
-		"secondary commit must carry ObservedRouteVersion=0 — best-effort secondary + fail-closed gate would otherwise yield a silent partial commit on route shifts between primary-COMMIT and secondary-COMMIT (codex P1 on 6202b964)")
+// TestShardedCoordinator_SurfacesFatalErrorOn2PCSecondaryComposed1
+// is the regression for codex P1 on d8487672 (PR #900).  When a
+// secondary commit fails with a Composed-1 sentinel (route shift
+// between primary-COMMIT and secondary-COMMIT),
+// dispatchMultiShardTxn MUST surface
+// ErrTxnSecondaryRouteShiftedAfterPrimaryCommit rather than:
+//
+//   - swallow the error and return success (codex P1 on 6202b964:
+//     uncommitted secondary, missing-write silent partial commit), or
+//   - drop the M3 gate to avoid the error (codex P1 on d8487672:
+//     stale-owner silent partial commit), or
+//   - propagate ErrComposed1Violation (the M4 retry would loop, the
+//     primary is durable, re-prewriting would conflict).
+//
+// The new sentinel is the only honest posture — the caller knows
+// the txn state is uncertain (primary durable, secondary missing)
+// and can do application-level recovery.
+//
+// 2-shard fixture: primary "b" → g1 succeeds, secondary "x" → g2
+// returns ErrComposed1Violation on its COMMIT (prewrite succeeds).
+func TestShardedCoordinator_SurfacesFatalErrorOn2PCSecondaryComposed1(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	require.NoError(t, engine.ApplySnapshot(distribution.CatalogSnapshot{
+		Version: 7,
+		Routes: []distribution.RouteDescriptor{
+			{RouteID: 100, Start: []byte("a"), End: []byte("m"), GroupID: 1, State: distribution.RouteStateActive},
+			{RouteID: 101, Start: []byte("m"), End: nil, GroupID: 2, State: distribution.RouteStateActive},
+		},
+	}))
+
+	g1Txn := &recordingTransactional{
+		responses: []*TransactionResponse{
+			{CommitIndex: 3},  // prewrite OK
+			{CommitIndex: 11}, // primary commit OK
+		},
+	}
+	// g2 prewrite OK, but g2 COMMIT (best-effort secondary) fails
+	// Composed-1 on EVERY commitSecondaryWithRetry attempt
+	// (txnSecondaryCommitRetryAttempts of them).  Build the errs
+	// slice with a leading nil (for prewrite which must succeed),
+	// then composed1 errors for each retry.
+	g2Errs := []error{nil}
+	for range txnSecondaryCommitRetryAttempts {
+		g2Errs = append(g2Errs, errors.WithStack(ErrComposed1Violation))
+	}
+	g2Txn := &recordingTransactional{
+		responses: []*TransactionResponse{{CommitIndex: 5}},
+		errs:      g2Errs,
+	}
+	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{
+		1: {Txn: g1Txn},
+		2: {Txn: g2Txn},
+	}, 1, NewHLC(), nil)
+
+	_, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
+		IsTxn: true,
+		Elems: []*Elem[OP]{
+			{Op: Put, Key: []byte("b"), Value: []byte("v1")}, // → g1 (primary)
+			{Op: Put, Key: []byte("x"), Value: []byte("v2")}, // → g2 (secondary)
+		},
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrTxnSecondaryRouteShiftedAfterPrimaryCommit,
+		"a secondary commit Composed-1 sentinel must surface as ErrTxnSecondaryRouteShiftedAfterPrimaryCommit (NOT ErrComposed1Violation — M4 retry would loop, primary is durable, re-prewriting would conflict)")
+	require.NotErrorIs(t, err, ErrComposed1Violation,
+		"the fatal-secondary sentinel must NOT be ErrComposed1Violation so the M4 retry path does not match and loop")
 }

--- a/kv/sharded_coordinator_composed1_retry_test.go
+++ b/kv/sharded_coordinator_composed1_retry_test.go
@@ -713,3 +713,102 @@ func TestShardedCoordinator_SurfacesFatalErrorOn2PCSecondaryComposed1(t *testing
 	require.NotErrorIs(t, err, ErrComposed1Violation,
 		"the fatal-secondary sentinel must NOT be ErrComposed1Violation so the M4 retry path does not match and loop")
 }
+
+// stubPartitionResolver is a minimal PartitionResolver for tests.
+// It claims every key whose prefix matches `claimedPrefix` and
+// routes them all to `gid`.  Used by
+// TestShardedCoordinator_DoesNotAutoPinObservedRouteVersionForResolverRoutedTxn
+// to exercise the codex P1 (20:45:07) skip path.
+type stubPartitionResolver struct {
+	claimedPrefix []byte
+	gid           uint64
+}
+
+func (r *stubPartitionResolver) ResolveGroup(key []byte) (uint64, bool) {
+	if !r.RecognisesPartitionedKey(key) {
+		return 0, false
+	}
+	return r.gid, true
+}
+
+func (r *stubPartitionResolver) RecognisesPartitionedKey(key []byte) bool {
+	if len(key) < len(r.claimedPrefix) {
+		return false
+	}
+	for i, b := range r.claimedPrefix {
+		if key[i] != b {
+			return false
+		}
+	}
+	return true
+}
+
+// TestShardedCoordinator_DoesNotAutoPinObservedRouteVersionForResolverRoutedTxn
+// is the regression for codex P1 on 6a458a28 (PR #900): when a
+// txn's keys are claimed by a PartitionResolver (e.g. SQS
+// HT-FIFO partition keys), the Dispatch-entry auto-pin must
+// SKIP.  Otherwise the M3 verifyComposed1 gate runs against the
+// byte-range engine snapshot — which does not reflect resolver
+// routing — and spuriously rejects the commit even though the
+// resolver selected the correct gid.
+//
+// Concrete failure mode (codex):
+//
+//   - ShardRouter.ResolveGroup → resolver returns gid R.
+//   - Dispatch-entry auto-pin stamps ObservedRouteVersion =
+//     engine.Version() on the request.
+//   - FSM at gid R applies; verifyComposed1 calls route-history
+//     OwnerOf on the raw mutation key against the engine's
+//     snapshot.
+//   - Engine's snapshot says gid B (default byte-range owner),
+//     not gid R.
+//   - Mismatch → ErrComposed1Violation.
+//   - M4 retry re-reads engine.Version() (unchanged), retries,
+//     fails again.  Spurious double failure.
+//
+// With production FSMs wired via WithRouteHistory, a
+// coordinator-owned txn with no StartTS/ReadKeys that used to
+// commit unpinned now gets rejected.  The auto-pin's
+// "blanket protection" framing breaks for resolver-routed keys.
+//
+// Correct posture: skip the auto-pin when any element's key is
+// claimed by the resolver (resolver.RecognisesPartitionedKey).
+// The request flows with ObservedRouteVersion=0 and the M3 gate
+// short-circuits — restoring the pre-auto-pin "no gate"
+// behaviour for resolver-routed txns.  Adapters that want
+// resolver-aware M3 protection need a resolver-aware gate,
+// which is M5+ work.
+func TestShardedCoordinator_DoesNotAutoPinObservedRouteVersionForResolverRoutedTxn(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	require.NoError(t, engine.ApplySnapshot(distribution.CatalogSnapshot{
+		Version: 9,
+		Routes: []distribution.RouteDescriptor{
+			{RouteID: 100, Start: []byte(""), End: nil, GroupID: 1, State: distribution.RouteStateActive},
+		},
+	}))
+
+	txn := &composed1RetryingTransactional{firstErr: nil} // succeeds on first attempt
+	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{
+		1: {Txn: txn},
+	}, 1, NewHLC(), nil)
+	coord.WithPartitionResolver(&stubPartitionResolver{
+		claimedPrefix: []byte("part:"),
+		gid:           1,
+	})
+
+	_, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
+		IsTxn: true,
+		// StartTS, ReadKeys, ObservedRouteVersion all zero — none of
+		// the existing auto-pin skip gates fire.  The new gate
+		// (resolver-claimed key) must skip the auto-pin.
+		Elems: []*Elem[OP]{
+			{Op: Put, Key: []byte("part:q1:1234"), Value: []byte("v")},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, txn.observedSeen, 1)
+	require.Equal(t, uint64(0), txn.observedSeen[0],
+		"resolver-claimed key must NOT be auto-pinned at Dispatch entry — verifyComposed1 uses the byte-range engine snapshot which does not reflect resolver routing, so the gate would spuriously reject every resolver-routed txn (codex P1 on 6a458a28)")
+}

--- a/kv/sharded_coordinator_composed1_retry_test.go
+++ b/kv/sharded_coordinator_composed1_retry_test.go
@@ -575,3 +575,87 @@ func TestShardedCoordinator_DoesNotAutoPinObservedRouteVersionForCallerSuppliedS
 	require.Equal(t, uint64(0), txn.observedSeen[0],
 		"caller-supplied StartTS with empty ReadKeys must NOT be auto-pinned at Dispatch entry — stamping the post-shift catalog version would mask a read→Dispatch route shift from verifyComposed1, creating a false-confidence M3 gate signal worse than no gate (codex P1 on 144ec0ca)")
 }
+
+// TestShardedCoordinator_DropsObservedRouteVersionOn2PCSecondaryCommit
+// is the regression for codex P1 on 6202b964 (PR #900):
+// commitSecondaryTxns treats secondary commit errors as
+// best-effort — it logs and continues, then dispatchMultiShardTxn
+// returns success.  If we propagate a non-zero
+// ObservedRouteVersion to the secondary commit Request, a route
+// shift after PREPARE/primary-COMMIT but before secondary-COMMIT
+// makes the secondary FSM return ErrComposed1Violation; the
+// caller-visible Dispatch ACK still says success, leaving the
+// secondary write uncommitted/invisible to readers on the new
+// owner — a silent partial commit.
+//
+// The fundamental tension: 2PC's "best-effort secondary +
+// lock-resolution backstop" semantic does not compose with M3's
+// "fail-closed on route shift" semantic.  Until lock resolution or
+// a fatal-secondary 2PC variant is wired (M5+), the surgical fix is
+// to send ObservedRouteVersion=0 on secondary commit Requests.
+// The FSM's verifyComposed1 short-circuits on observedVer==0
+// (fsm.go:609), restoring the pre-66ad5b0 behaviour for this step
+// while keeping the gate on prewrite (catches mid-flight shifts
+// before lock placement) and the primary commit (catches
+// linearization shifts; abortPreparedTxn cleans up).
+//
+// This test uses a 2-shard fixture: primary "b" → g1,
+// secondary "x" → g2.  Auto-pin fires at Dispatch entry
+// (coordinator-allocated StartTS, ReadKeys empty), stamping
+// ObservedRouteVersion = engine.Version() = 7.  Both shards
+// receive 2 Requests each (prewrite + commit).  Assertions:
+//
+//   - Prewrite on both shards carries observedVer=7 (gate active)
+//   - Primary commit on g1 carries observedVer=7 (gate active)
+//   - Secondary commit on g2 carries observedVer=0 (gate skipped)
+func TestShardedCoordinator_DropsObservedRouteVersionOn2PCSecondaryCommit(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	require.NoError(t, engine.ApplySnapshot(distribution.CatalogSnapshot{
+		Version: 7,
+		Routes: []distribution.RouteDescriptor{
+			{RouteID: 100, Start: []byte("a"), End: []byte("m"), GroupID: 1, State: distribution.RouteStateActive},
+			{RouteID: 101, Start: []byte("m"), End: nil, GroupID: 2, State: distribution.RouteStateActive},
+		},
+	}))
+
+	g1Txn := &recordingTransactional{}
+	g2Txn := &recordingTransactional{}
+	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{
+		1: {Txn: g1Txn},
+		2: {Txn: g2Txn},
+	}, 1, NewHLC(), nil)
+
+	_, err := coord.Dispatch(context.Background(), &OperationGroup[OP]{
+		IsTxn: true,
+		// StartTS omitted → coordinator allocates → auto-pin fires
+		// (callerSuppliedStartTS=false, ReadKeys empty).
+		Elems: []*Elem[OP]{
+			{Op: Put, Key: []byte("b"), Value: []byte("v1")}, // → g1 (primary)
+			{Op: Put, Key: []byte("x"), Value: []byte("v2")}, // → g2 (secondary)
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, g1Txn.requests, 2, "primary g1 receives prewrite + commit")
+	require.Len(t, g2Txn.requests, 2, "secondary g2 receives prewrite + commit")
+
+	// Prewrites on both shards must carry the auto-pinned version —
+	// gate is active there, catching shifts before lock placement.
+	require.Equal(t, uint64(7), g1Txn.requests[0].GetObservedRouteVersion(),
+		"primary prewrite must carry the auto-pinned ObservedRouteVersion (gate active before lock placement)")
+	require.Equal(t, uint64(7), g2Txn.requests[0].GetObservedRouteVersion(),
+		"secondary prewrite must carry the auto-pinned ObservedRouteVersion (gate active before lock placement)")
+
+	// Primary commit must also carry it — linearization point, gate
+	// active, abortPreparedTxn cleans up on failure.
+	require.Equal(t, uint64(7), g1Txn.requests[1].GetObservedRouteVersion(),
+		"primary commit must carry the auto-pinned ObservedRouteVersion (gate at linearization; abort path cleans up on failure)")
+
+	// Secondary commit MUST carry ObservedRouteVersion=0 — the fix
+	// for codex P1 on 6202b964.  Without this, a route shift between
+	// primary-COMMIT and secondary-COMMIT turns into a silent partial
+	// commit because commitSecondaryTxns is best-effort.
+	require.Equal(t, uint64(0), g2Txn.requests[1].GetObservedRouteVersion(),
+		"secondary commit must carry ObservedRouteVersion=0 — best-effort secondary + fail-closed gate would otherwise yield a silent partial commit on route shifts between primary-COMMIT and secondary-COMMIT (codex P1 on 6202b964)")
+}

--- a/kv/sharded_coordinator_txn_test.go
+++ b/kv/sharded_coordinator_txn_test.go
@@ -577,33 +577,29 @@ func TestShardedCoordinatorDispatchTxn_SingleShardIncludesReadKeysInRaftEntry(t 
 }
 
 // TestShardedCoordinatorDispatchTxn_CrossShardPropagatesObservedRouteVersion
-// is the gemini-critical regression from PR #881, refined by codex
-// P1 on PR #900 6202b964.  Original PR #881 contract: every PREPARE
-// and COMMIT envelope across the 2PC paths must carry
-// OperationGroup.ObservedRouteVersion so the M3 gate fires on every
-// cross-shard txn.  Refinement: the SECONDARY commit step MUST drop
-// the gate (send ObservedRouteVersion=0) because commitSecondaryTxns
-// is best-effort — it logs and continues on per-secondary errors,
-// then dispatchMultiShardTxn returns success.  A fail-closed gate
-// on that best-effort step turns route churn between primary-COMMIT
-// and secondary-COMMIT into a silent partial commit (codex P1 on
-// 6202b964, PR #900).
+// is the gemini-critical regression from PR #881.  Contract:
+// every PREPARE and COMMIT envelope across the 2PC paths
+// (prewriteTxn / commitPrimaryTxn / commitSecondaryTxns) must
+// carry OperationGroup.ObservedRouteVersion so the M3 gate fires
+// on every cross-shard txn.
 //
-// Coverage matrix the post-refinement code must satisfy:
+// History: an earlier round in PR #900 (d8487672) attempted to
+// drop the gate on secondary commits to avoid a "fail-closed gate
+// + best-effort swallow" silent partial commit (codex P1 on
+// 6202b964).  codex P1 on d8487672 (PR #900) showed that dropping
+// the gate replaces one silent partial commit with another — the
+// write lands on a stale owner that is no longer reachable by
+// readers on the new owner.  The correct fix is to KEEP the gate
+// active everywhere AND surface secondary Composed-1 errors as a
+// distinct fatal sentinel
+// (ErrTxnSecondaryRouteShiftedAfterPrimaryCommit) rather than
+// either swallowing or dropping the gate.  See
+// TestShardedCoordinator_SurfacesFatalErrorOn2PCSecondaryComposed1
+// for the fatal-error contract.
 //
-//   - Prewrite (both shards):                ObservedRouteVersion=42 (gate active)
-//   - Primary commit (g1 — primaryKey "b"):  ObservedRouteVersion=42 (gate active)
-//   - Secondary commit (g2 — non-primary):   ObservedRouteVersion=0  (gate skipped)
-//
-// Prewrite carries the pin because it's the moment locks are placed
-// — a route shift caught here cleanly aborts with no committed
-// state.  The primary commit carries it because it's the
-// linearization point and abortPreparedTxn cleans up if the gate
-// fires.  The secondary commit drops it because there is no clean
-// recovery path available between the primary's durable commit and
-// the secondary's commit — until a lock-resolution-bypass or
-// fatal-secondary 2PC protocol lands (M5+), the only safe posture
-// is to skip the gate on this step.
+// With the fatal-surface fix in place, this test reverts to the
+// original PR #881 contract: every 2PC envelope on every shard
+// carries the pinned version.
 func TestShardedCoordinatorDispatchTxn_CrossShardPropagatesObservedRouteVersion(t *testing.T) {
 	t.Parallel()
 
@@ -635,29 +631,20 @@ func TestShardedCoordinatorDispatchTxn_CrossShardPropagatesObservedRouteVersion(
 		StartTS:              10,
 		ObservedRouteVersion: pinnedVer,
 		Elems: []*Elem[OP]{
-			{Op: Put, Key: []byte("b"), Value: []byte("v1")}, // → g1 (primary, "b" is first)
-			{Op: Put, Key: []byte("x"), Value: []byte("v2")}, // → g2 (secondary)
+			{Op: Put, Key: []byte("b"), Value: []byte("v1")},
+			{Op: Put, Key: []byte("x"), Value: []byte("v2")},
 		},
 	})
 	require.NoError(t, err)
 	require.Len(t, g1Txn.requests, 2, "g1 must see PREPARE + COMMIT")
 	require.Len(t, g2Txn.requests, 2, "g2 must see PREPARE + COMMIT")
 
-	// Prewrites on both shards must carry the pin.
-	require.Equal(t, pinnedVer, g1Txn.requests[0].ObservedRouteVersion,
-		"primary prewrite must carry the pinned version — gate active before lock placement (PR #881)")
-	require.Equal(t, pinnedVer, g2Txn.requests[0].ObservedRouteVersion,
-		"secondary prewrite must carry the pinned version — gate active before lock placement (PR #881)")
-
-	// Primary commit must carry the pin — linearization point,
-	// abortPreparedTxn cleans up if the gate fires.
-	require.Equal(t, pinnedVer, g1Txn.requests[1].ObservedRouteVersion,
-		"primary commit must carry the pinned version — linearization point with clean abort path (PR #881)")
-
-	// Secondary commit MUST drop the pin to ObservedRouteVersion=0
-	// — codex P1 on 6202b964 refinement of PR #881's "propagate
-	// everywhere" contract.  Best-effort secondary + fail-closed
-	// gate composes to a silent partial commit.
-	require.Equal(t, uint64(0), g2Txn.requests[1].ObservedRouteVersion,
-		"secondary commit must NOT carry the pinned version — propagating it would let a route shift between primary-COMMIT and secondary-COMMIT silently partial-commit (codex P1 on 6202b964, PR #900)")
+	for _, req := range append(g1Txn.requests, g2Txn.requests...) {
+		require.Equal(t, pinnedVer, req.ObservedRouteVersion,
+			"multi-shard 2PC envelope (phase=%s) must carry "+
+				"OperationGroup.ObservedRouteVersion; pre-fix this "+
+				"silently dropped to 0 and bypassed the M3 Composed-1 "+
+				"apply-time gate for every cross-shard txn",
+			req.Phase)
+	}
 }

--- a/kv/sharded_coordinator_txn_test.go
+++ b/kv/sharded_coordinator_txn_test.go
@@ -577,25 +577,33 @@ func TestShardedCoordinatorDispatchTxn_SingleShardIncludesReadKeysInRaftEntry(t 
 }
 
 // TestShardedCoordinatorDispatchTxn_CrossShardPropagatesObservedRouteVersion
-// is the gemini-critical regression on PR #881.  The single-shard fast
-// path correctly forwarded OperationGroup.ObservedRouteVersion into
-// pb.Request, but the multi-shard 2PC path
-// (prewriteTxn / commitPrimaryTxn / commitSecondaryTxns) dropped it on
-// the floor — every PREPARE and COMMIT envelope arrived at the FSM
-// with ObservedRouteVersion = 0 ("unpinned"), which would silently
-// bypass the M3 Composed-1 apply-time gate exactly for the workload
-// most at risk of a cross-group route shift.
+// is the gemini-critical regression from PR #881, refined by codex
+// P1 on PR #900 6202b964.  Original PR #881 contract: every PREPARE
+// and COMMIT envelope across the 2PC paths must carry
+// OperationGroup.ObservedRouteVersion so the M3 gate fires on every
+// cross-shard txn.  Refinement: the SECONDARY commit step MUST drop
+// the gate (send ObservedRouteVersion=0) because commitSecondaryTxns
+// is best-effort — it logs and continues on per-secondary errors,
+// then dispatchMultiShardTxn returns success.  A fail-closed gate
+// on that best-effort step turns route churn between primary-COMMIT
+// and secondary-COMMIT into a silent partial commit (codex P1 on
+// 6202b964, PR #900).
 //
-// Multi-shard txns are precisely the case where a MoveRange /
-// cross-group SplitRange between BeginTxn and Commit can land —
-// without this propagation, M3's safety guard would not even see
-// those txns to enforce on.
+// Coverage matrix the post-refinement code must satisfy:
 //
-// This test routes two PUTs across two shards via Engine routes
-// (single-shard fast path requires gids == 1), verifies that the 2PC
-// loop fires (both PREPARE and COMMIT recorded per shard), and
-// asserts every recorded pb.Request carries the pinned
-// ObservedRouteVersion.
+//   - Prewrite (both shards):                ObservedRouteVersion=42 (gate active)
+//   - Primary commit (g1 — primaryKey "b"):  ObservedRouteVersion=42 (gate active)
+//   - Secondary commit (g2 — non-primary):   ObservedRouteVersion=0  (gate skipped)
+//
+// Prewrite carries the pin because it's the moment locks are placed
+// — a route shift caught here cleanly aborts with no committed
+// state.  The primary commit carries it because it's the
+// linearization point and abortPreparedTxn cleans up if the gate
+// fires.  The secondary commit drops it because there is no clean
+// recovery path available between the primary's durable commit and
+// the secondary's commit — until a lock-resolution-bypass or
+// fatal-secondary 2PC protocol lands (M5+), the only safe posture
+// is to skip the gate on this step.
 func TestShardedCoordinatorDispatchTxn_CrossShardPropagatesObservedRouteVersion(t *testing.T) {
 	t.Parallel()
 
@@ -627,20 +635,29 @@ func TestShardedCoordinatorDispatchTxn_CrossShardPropagatesObservedRouteVersion(
 		StartTS:              10,
 		ObservedRouteVersion: pinnedVer,
 		Elems: []*Elem[OP]{
-			{Op: Put, Key: []byte("b"), Value: []byte("v1")},
-			{Op: Put, Key: []byte("x"), Value: []byte("v2")},
+			{Op: Put, Key: []byte("b"), Value: []byte("v1")}, // → g1 (primary, "b" is first)
+			{Op: Put, Key: []byte("x"), Value: []byte("v2")}, // → g2 (secondary)
 		},
 	})
 	require.NoError(t, err)
 	require.Len(t, g1Txn.requests, 2, "g1 must see PREPARE + COMMIT")
 	require.Len(t, g2Txn.requests, 2, "g2 must see PREPARE + COMMIT")
 
-	for _, req := range append(g1Txn.requests, g2Txn.requests...) {
-		require.Equal(t, pinnedVer, req.ObservedRouteVersion,
-			"multi-shard 2PC envelope (phase=%s) must carry "+
-				"OperationGroup.ObservedRouteVersion; pre-fix this "+
-				"silently dropped to 0 and bypassed the M3 Composed-1 "+
-				"apply-time gate for every cross-shard txn",
-			req.Phase)
-	}
+	// Prewrites on both shards must carry the pin.
+	require.Equal(t, pinnedVer, g1Txn.requests[0].ObservedRouteVersion,
+		"primary prewrite must carry the pinned version — gate active before lock placement (PR #881)")
+	require.Equal(t, pinnedVer, g2Txn.requests[0].ObservedRouteVersion,
+		"secondary prewrite must carry the pinned version — gate active before lock placement (PR #881)")
+
+	// Primary commit must carry the pin — linearization point,
+	// abortPreparedTxn cleans up if the gate fires.
+	require.Equal(t, pinnedVer, g1Txn.requests[1].ObservedRouteVersion,
+		"primary commit must carry the pinned version — linearization point with clean abort path (PR #881)")
+
+	// Secondary commit MUST drop the pin to ObservedRouteVersion=0
+	// — codex P1 on 6202b964 refinement of PR #881's "propagate
+	// everywhere" contract.  Best-effort secondary + fail-closed
+	// gate composes to a silent partial commit.
+	require.Equal(t, uint64(0), g2Txn.requests[1].ObservedRouteVersion,
+		"secondary commit must NOT carry the pinned version — propagating it would let a route shift between primary-COMMIT and secondary-COMMIT silently partial-commit (codex P1 on 6202b964, PR #900)")
 }

--- a/kv/txn_errors.go
+++ b/kv/txn_errors.go
@@ -22,6 +22,32 @@ var (
 	// the probe at the FSM and let the original duplicate-elements anomaly
 	// reappear. See codex P2 in PR #796 and the design doc.
 	ErrTxnDedupRequiresSingleShard = errors.New("txn dedup (prev_commit_ts) requires a single-shard write set")
+	// ErrTxnSecondaryRouteShiftedAfterPrimaryCommit is returned by
+	// dispatchMultiShardTxn when a per-secondary commit (after primary
+	// has durably committed) fails its M3 verifyComposed1 check —
+	// i.e. the route catalog moved between primary-COMMIT and the
+	// secondary-COMMIT, the secondary's FSM rejects with a Composed-1
+	// sentinel, and we cannot transparently recover (the prepared
+	// lock lives at the old gid; the new owner per the catalog has no
+	// commit record).  The 2PC contract is half-broken at this point:
+	// the primary's write is durable but at least one secondary's
+	// write is missing.  Surfacing this explicitly (rather than
+	// swallowing per the original best-effort semantic OR silently
+	// landing the write on a stale owner per a dropped-gate fix) is
+	// the least bad outcome — the caller knows the txn state is
+	// uncertain and can do application-level recovery.
+	//
+	// This is a DIFFERENT sentinel from ErrComposed1Violation by
+	// design: the M4 retry path in dispatchTxnWithComposed1Retry
+	// matches ErrComposed1Violation / ErrComposed1VersionGCd and
+	// would otherwise loop here, re-prewriting against the same old
+	// gid that already has the first attempt's prepared lock — pure
+	// wasted work since the route catalog won't move backward.
+	// codex P1 on 6202b964 (PR #900) raised the silent-partial-commit
+	// hazard; codex P1 on d8487672 (PR #900) raised the symmetric
+	// hazard of disabling the gate.  This sentinel resolves both by
+	// keeping the gate active and surfacing the error fatally.
+	ErrTxnSecondaryRouteShiftedAfterPrimaryCommit = errors.New("txn secondary commit failed after primary commit: route catalog shifted")
 )
 
 type TxnLockedError struct {


### PR DESCRIPTION
## Summary

Fourth milestone (**M4**) of the Composed-1 cross-group commit-time guard per `docs/design/2026_05_29_proposed_composed1_cross_group_commit_guard.md` §M4.

Makes the M3 apply-time gate **non-disruptive to clients**: instead of surfacing `ErrComposed1Violation` or `ErrComposed1VersionGCd` back to the adapter (and thus the application), the coordinator absorbs the sentinel, re-reads the catalog version, and re-issues the txn once against the post-shift owning group.

## What changes

### `ShardedCoordinator.Dispatch` — pin ObservedRouteVersion at entry

Every transactional `OperationGroup` that arrives with `ObservedRouteVersion == 0` (the M1 unpinned sentinel) gets stamped with `engine.Version()`. This makes the M3 gate effective **by default** — every txn flowing through the sharded coordinator is now gate-eligible without each adapter rediscovering the §4.1 contract.

A caller that supplies a non-zero `ObservedRouteVersion` (a future adapter migration target managing the version itself) still wins over the Dispatch-entry pin.

### New `dispatchTxnWithComposed1Retry` — retry-once on Composed-1 sentinels

Wraps the existing single-attempt `dispatchTxn` in a loop bounded at `composed1RetryAttempts = 1` (initial + 1 retry = 2 attempts).

On the sentinel:
- Re-read `engine.Version()` and stamp the fresh value on the OperationGroup
- Clear `StartTS` / `CommitTS` so the next attempt allocates a fresh HLC-correct pair via `nextStartTS` (OCC invariants require `commitTS > startTS` under the same HLC observation)
- `groupMutations` on the next dispatchTxn pass re-runs `router.ResolveGroup`, so a key whose owning group changed naturally lands on the new group's FSM

Beyond one retry the sentinel surfaces unchanged so a wrapping adapter retry harness (or the client) can decide whether to keep trying — preventing the coordinator from spinning when catalog churn outpaces the dispatch.

## Caller audit (loop directive's semantic-change check)

`ShardedCoordinator.Dispatch` is the entry point every adapter calls. The change:
- **Surfaces success more often** (turning a previous error into a successful commit)
- **Delays sentinel surfacing** by a bounded retry budget

`grep -rn 'ErrComposed1' adapter/` returns no hits — no adapter relies on a faster-than-bounded surfacing of these sentinels (M3 only landed yesterday).

## Tests (5 new)

- `TestShardedCoordinator_RetriesOnComposed1Violation` — happy path: first attempt fails, second succeeds, caller sees success.
- `TestShardedCoordinator_RetriesOnComposed1VersionGCd` — same retry path drives both sentinels.
- `TestShardedCoordinator_PersistentComposed1ViolationSurfaces` — retry budget bounds the loop: persistent failure surfaces sentinel after exactly 2 total Commit calls.
- `TestShardedCoordinator_PinsObservedRouteVersionAtDispatchEntry` — Dispatch pins from `engine.Version()` when caller leaves it at zero.
- `TestShardedCoordinator_HonorsCallerPinnedObservedRouteVersion` — caller-supplied non-zero value wins (§4.1 contract preserved).

## Verification

- `go build ./...` — clean
- `go test -race -count=1 ./kv` — 10.3s, pass
- `make lint` — 0 issues

## Self-review (5 lenses)

1. **Data loss** — retry can only convert a previously-rejected commit into success OR surface the same error after a bounded loop. Cannot lose a committed write (each attempt allocates fresh commitTS; FSM's OCC validation rejects duplicates).
2. **Concurrency** — no new locks. Retry runs serially on dispatcher goroutine; `engine.Version()` takes the existing read lock per call.
3. **Performance** — common case: single iteration + one branch + one `engine.Version()` read at entry. Sentinel case: one extra `dispatchTxn` round-trip.
4. **Data consistency** — closes §M4. With M1+M2+M3+M4 landed, a `MoveRange` / cross-group `SplitRange` between BeginTxn and Commit is now **transparent to the client**: coordinator absorbs the gate's rejection, re-routes, succeeds on the new owner.
5. **Test coverage** — 5 unit tests cover both sentinels, retry budget, Dispatch-entry pin, and caller-pin precedence. Existing tests pass unchanged.

## Test plan

- [x] `go test -race ./kv`
- [x] `make lint`
- [ ] (Follow-up) **M5** — Jepsen workload (route-shuffle generator for the DynamoDB suite, find no G1c anomaly under concurrent MoveRange).

## Resolves

The M4 row in the Composed-1 design doc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction dispatch now performs a single bounded retry for specific transient composed-1 errors, preserving previous commit timestamps; caller-supplied start timestamps suppress the retry. Write-only transactions may auto-pin route version at dispatch, while multi-shard commit-phase secondary requests intentionally omit the pinned route version.

* **Tests**
  * Expanded test coverage for composed-1 retry semantics, PrevCommitTS preservation, caller-supplied StartTS behavior, route-version pinning rules, and secondary commit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->