### PR TITLE
fix(redis): finish option-2 dedup HLC-4 / ctx-parent parity

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -2778,12 +2778,21 @@ func (t *txnContext) prepareDispatch() (preparedTxnDispatch, error) {
 	// non-string keys get a !redis|ttl| element written in the same transaction.
 	ttlElems := t.buildTTLElems()
 
-	// Derive a single redisDispatchTimeout-bounded context covering both the
-	// stream-deletion scans (paginated ScanAt/ExistsAt over StreamEntryScanPrefix)
-	// and the final Dispatch. Without this bound, buildStreamDeletionElems would
-	// run on the server-lifetime handlerContext, leaving its scans uncancellable
-	// from the request side on a slow disk or hot-key pathological commit.
-	ctx, cancel := context.WithTimeout(t.server.handlerContext(), redisDispatchTimeout)
+	// Derive a single redisDispatchTimeout-bounded context covering both
+	// the stream-deletion scans (paginated ScanAt/ExistsAt over
+	// StreamEntryScanPrefix) and the final Dispatch. The parent is the
+	// txnContext's own ctx (the caller's dispatchCtx), not the server-
+	// lifetime handlerContext, so an outer cancellation (client
+	// disconnect, retryRedisWrite timeout) interrupts the prepare+dispatch
+	// promptly instead of waiting the full redisDispatchTimeout — same
+	// rationale as runTransactionWithDedup's reuseCtx fix on PR #887. The
+	// nil-guard falls back to handlerContext for callers that construct a
+	// txnContext without setting ctx (test fixtures).
+	parentCtx := t.ctx
+	if parentCtx == nil {
+		parentCtx = t.server.handlerContext()
+	}
+	ctx, cancel := context.WithTimeout(parentCtx, redisDispatchTimeout)
 
 	streamElems, err := t.buildStreamDeletionElems(ctx)
 	if err != nil {
@@ -3607,7 +3616,16 @@ type reusableListPush struct {
 // fresh meta. Extracted from listPushCoreWithDedup to keep that closure
 // under the cyclop / gocognit / nestif limits.
 func (r *RedisServer) dispatchListPushReuse(ctx context.Context, key []byte, pending *reusableListPush) (newLen int64, drop bool, err error) {
-	commitTS := r.coordinator.Clock().Next()
+	// HLC-4 parity: persistence-grade commit_ts allocation must honor
+	// the physical-ceiling fence so a stale-leader window cannot mint a
+	// timestamp that collides with the successor's. dispatchExecReuse
+	// already uses NextFenced (PR #887 round 1); the two listPush dedup
+	// sites shipped before the HLC-4 migration and were missed in that
+	// pass — see PR #887 verdict for the noted gap.
+	commitTS, allocErr := r.coordinator.Clock().NextFenced()
+	if allocErr != nil {
+		return 0, false, errors.Wrap(allocErr, "redis list-push reuse: allocate commitTS")
+	}
 	_, dispErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 		IsTxn:        true,
 		StartTS:      pending.startTS,
@@ -3778,7 +3796,12 @@ func (r *RedisServer) listPushCoreWithDedup(ctx context.Context, key []byte, val
 			return err
 		}
 
-		commitTS := r.coordinator.Clock().Next()
+		// HLC-4 parity with prepareDispatch / dispatchExecReuse —
+		// see dispatchListPushReuse above for the rationale.
+		commitTS, allocErr := r.coordinator.Clock().NextFenced()
+		if allocErr != nil {
+			return errors.Wrap(allocErr, "redis list-push first-attempt: allocate commitTS")
+		}
 		ops, updatedMeta, err := buildFn(meta, key, values, commitTS, 0)
 		if err != nil {
 			return err

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -2784,10 +2784,10 @@ func (t *txnContext) prepareDispatch() (preparedTxnDispatch, error) {
 	// txnContext's own ctx (the caller's dispatchCtx), not the server-
 	// lifetime handlerContext, so an outer cancellation (client
 	// disconnect, retryRedisWrite timeout) interrupts the prepare+dispatch
-	// promptly instead of waiting the full redisDispatchTimeout — same
-	// rationale as runTransactionWithDedup's reuseCtx fix on PR #887. The
-	// nil-guard falls back to handlerContext for callers that construct a
-	// txnContext without setting ctx (test fixtures).
+	// promptly instead of waiting the full redisDispatchTimeout. Symmetric
+	// with the reuseCtx threading in runTransactionWithDedup. The nil-guard
+	// falls back to handlerContext for callers that construct a txnContext
+	// without setting ctx (test fixtures).
 	parentCtx := t.ctx
 	if parentCtx == nil {
 		parentCtx = t.server.handlerContext()
@@ -3282,7 +3282,7 @@ func (r *RedisServer) runTransactionWithDedup(queue []redcon.Command) ([]redisRe
 			// fresh 10 s budget elapses. The earlier "fresh ctx from
 			// handlerContext" pattern (noted in design doc §M3) was strictly
 			// more conservative but wasted resources on a disconnected
-			// client — see PR #887 review.
+			// client.
 			reuseCtx, reuseCancel := context.WithTimeout(dispatchCtx, redisDispatchTimeout)
 			defer reuseCancel()
 			res, drop, dispErr := r.dispatchExecReuse(reuseCtx, pending)
@@ -3618,10 +3618,11 @@ type reusableListPush struct {
 func (r *RedisServer) dispatchListPushReuse(ctx context.Context, key []byte, pending *reusableListPush) (newLen int64, drop bool, err error) {
 	// HLC-4 parity: persistence-grade commit_ts allocation must honor
 	// the physical-ceiling fence so a stale-leader window cannot mint a
-	// timestamp that collides with the successor's. dispatchExecReuse
-	// already uses NextFenced (PR #887 round 1); the two listPush dedup
-	// sites shipped before the HLC-4 migration and were missed in that
-	// pass — see PR #887 verdict for the noted gap.
+	// timestamp that collides with the successor's. The error path
+	// returns ErrCeilingExpired which isRetryableRedisTxnErr classifies
+	// as non-retryable, so it exits retryRedisWrite directly to the
+	// client — same shape as the other persistence-grade Next call
+	// sites in this file.
 	commitTS, allocErr := r.coordinator.Clock().NextFenced()
 	if allocErr != nil {
 		return 0, false, errors.Wrap(allocErr, "redis list-push reuse: allocate commitTS")


### PR DESCRIPTION
## Summary

Picks up the two follow-up items noted in claude[bot]'s PR #887 verdict but deferred from that PR:

### (a) `prepareDispatch()` ctx-parent symmetric fix

`prepareDispatch()` took its bounded ctx from `t.server.handlerContext()` — the server-lifetime ctx, **not** the caller's `dispatchCtx`. The `reuseCtx` fix on PR #887 round 1 corrected `runTransactionWithDedup` to derive from `dispatchCtx`; this PR applies the symmetric fix to `prepareDispatch` so a disconnected client / `retryRedisWrite` timeout interrupts the prepare+dispatch promptly.

Nil-guard falls back to `handlerContext` for test fixtures that construct a `txnContext` without setting `ctx`.

### (b) Last two `Clock().Next()` callers in adapter/redis.go → `NextFenced()`

`dispatchListPushReuse` and the `listPushCoreWithDedup` first-attempt site both shipped before the HLC-4 physical-ceiling migration and were missed in that pass. `dispatchExecReuse` already uses `NextFenced` (PR #887 round 1) and so do all first-attempt `commit_ts` allocations through `prepareDispatch`.

These two list-push dedup sites were the **last** persistence-grade `Clock().Next()` callers in `adapter/redis.go` — verified by `grep '\.Clock()\.Next\b' adapter/redis.go` now returning only `NextFenced` variants.

Without HLC-4 parity here, a stale-leader window could let the list-push dedup path mint a `commit_ts` that collides with the successor's freshly-fenced range — defeating the same anomaly class option-2 was introduced to prevent.

## Caller audit (per /loop semantic-change rule)

- `prepareDispatch`: sole callers are `commit()` and `firstExecAttempt` (both in adapter/redis.go). Ctx-parent change is additive; same defer-cancel discipline, same error mapping.
- `dispatchListPushReuse`: sole caller `listPushCoreWithDedup`. NextFenced error wired through existing `(newLen, drop, err)` tuple; non-retryable so `retryRedisWrite` surfaces it directly — matches PR #887 round-1's `dispatchExecReuse` NextFenced wiring.
- `listPushCoreWithDedup` first-attempt: surfaces NextFenced error through existing `retryRedisWrite` closure return.

## Validation

- `go test ./adapter/ -run 'ListPushDedup|ExecDedup|StandaloneSetDedup' -race -count=2` → ok 1.2s
- `gofmt` + `go vet` + `golangci-lint run` → 0 issues

## Scope

Closes the two follow-up items explicitly noted in PR #887's round-2 verdict ("Note on pre-existing Clock().Next() callers" + `prepareDispatch` ctx deviation). No new functionality.
