### PR TITLE
chore(test): drop redundant *Eventually wrappers obsoleted by PR #898

### DIFF
--- a/adapter/redis_lua_compat_test.go
+++ b/adapter/redis_lua_compat_test.go
@@ -121,12 +121,15 @@ func TestRedis_LuaRPopLPushBullMQLikeLists(t *testing.T) {
 	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
 	defer func() { _ = rdb.Close() }()
 
-	// Raft leadership can briefly churn right after createNode returns — the
-	// freshly-elected leader can step down if the initial heartbeats miss
-	// quorum on a slow CI runner (see waitForRaftReadiness). Retry the first
-	// writes so they ride out that re-election instead of failing the test.
-	rpushEventually(t, ctx, rdb, "bull:test:wait", "job-1", "job-2", "job-3")
-	lpushEventually(t, ctx, rdb, "bull:test:active", "job-0")
+	// Direct first writes: waitForRaftReadiness (called by createNode)
+	// now drives one no-op Raft entry through full quorum before
+	// returning, so any subsequent write is guaranteed to land on a
+	// leader that has already held quorum through one apply. The
+	// post-readiness leader-churn window the prior rpushEventually /
+	// lpushEventually wrappers absorbed is closed at the readiness
+	// layer instead — see PR #898.
+	require.NoError(t, rdb.RPush(ctx, "bull:test:wait", "job-1", "job-2", "job-3").Err())
+	require.NoError(t, rdb.LPush(ctx, "bull:test:active", "job-0").Err())
 
 	result, err := rdb.Eval(ctx, `
 local moved = redis.call("RPOPLPUSH", KEYS[1], KEYS[2])

--- a/adapter/test_util.go
+++ b/adapter/test_util.go
@@ -19,7 +19,6 @@ import (
 	pb "github.com/bootjp/elastickv/proto"
 	"github.com/bootjp/elastickv/store"
 	"github.com/cockroachdb/errors"
-	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
@@ -46,10 +45,12 @@ const (
 	testEngineMaxSizePerMsg = 1 << 20
 	testEngineMaxInflight   = 256
 
-	// leaderChurnRetryTimeout bounds how long doEventually keeps retrying a
-	// write that fails with a transient leader-unavailable error. It covers
-	// both startup churn right after createNode returns and mid-test churn
-	// when the leader briefly steps down under CI load.
+	// leaderChurnRetryTimeout bounds how long retryNotLeader keeps
+	// retrying a write that fails with a transient leader-unavailable
+	// error. Used by tests that issue writes inside long mid-test
+	// loops where leadership can briefly step down under CI load.
+	// Startup churn (createNode → first write) is closed at the
+	// readiness layer by waitForWriteableLeader (PR #898), not here.
 	leaderChurnRetryTimeout = 5 * time.Second
 	// leaderChurnRetryInterval is the poll interval between retries.
 	leaderChurnRetryInterval = 50 * time.Millisecond
@@ -750,23 +751,17 @@ func eventuallyExpired(t *testing.T, ttl time.Duration, condition func() bool, m
 	require.Eventually(t, condition, ttlExpiryHeadroom, ttlExpiryPoll, msg)
 }
 
-// doEventually retries do() while it returns a transient "not leader" error,
-// giving the cluster a few seconds to re-settle leadership after startup.
-// Non-"not leader" errors fail the test immediately.
-//
-// MUST be called from the main test goroutine only. The final require.NoError
-// calls t.FailNow() on failure; invoking FailNow from a worker goroutine is
-// a testing.T contract violation. For parallel-worker use, call
-// retryNotLeader directly and report errors back via a channel.
-func doEventually(t *testing.T, do func() error) {
-	t.Helper()
-	require.NoError(t, retryNotLeader(context.Background(), do))
-}
-
 // retryNotLeader calls do() repeatedly while it returns a transient
 // leader-unavailable error, capped at leaderChurnRetryTimeout. It returns
 // the final error (or nil on success) without touching testing.T, making
 // it safe to call from worker goroutines in parallel tests.
+//
+// Use cases: mid-test leader churn under CI load (e.g. grpc_test.go's
+// 9999-iteration consistency loops). The startup window — leader-churn
+// between createNode returning and the first write — is closed at the
+// readiness layer instead (waitForWriteableLeader, PR #898), so first-
+// write callers should NOT wrap in retryNotLeader; direct calls suffice
+// and are clearer.
 func retryNotLeader(ctx context.Context, do func() error) error {
 	deadline := time.Now().Add(leaderChurnRetryTimeout)
 	var lastErr error
@@ -784,22 +779,4 @@ func retryNotLeader(ctx context.Context, do func() error) error {
 		case <-time.After(leaderChurnRetryInterval):
 		}
 	}
-}
-
-// rpushEventually wraps RPUSH in doEventually so transient leader churn
-// immediately after createNode doesn't fail the test.
-func rpushEventually(t *testing.T, ctx context.Context, rdb *redis.Client, key string, vals ...any) {
-	t.Helper()
-	doEventually(t, func() error {
-		return rdb.RPush(ctx, key, vals...).Err()
-	})
-}
-
-// lpushEventually wraps LPUSH in doEventually so transient leader churn
-// immediately after createNode doesn't fail the test.
-func lpushEventually(t *testing.T, ctx context.Context, rdb *redis.Client, key string, vals ...any) {
-	t.Helper()
-	doEventually(t, func() error {
-		return rdb.LPush(ctx, key, vals...).Err()
-	})
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #898. The readiness probe (`waitForWriteableLeader`) closes the startup leader-churn window at the readiness layer, so the per-test `rpushEventually` / `lpushEventually` wrappers that absorbed that window become dead code.

## What's dropped

- `rpushEventually` + `lpushEventually` (`test_util.go`): only callers were `redis_lua_compat_test.go` lines 128–129 (first writes immediately after `createNode`). Migrated to direct `rdb.RPush` / `rdb.LPush` with a comment pointing back to PR #898.
- `doEventually`: only used by the two helpers above; no other callers.
- Unused `github.com/redis/go-redis/v9` import in `test_util.go`.

## What's kept

- `retryNotLeader`: still used in `grpc_test.go` (9 sites) wrapping mid-test RPCs inside 9999-iteration consistency loops. The readiness probe does NOT help **mid-test** churn (a real re-election can fire halfway through a long-running loop), so this helper retains its purpose. The doc comment is refreshed to clarify the startup vs mid-test distinction.

## Caller audit (per /loop semantic-change rule)

Repo-wide grep:
- `rpushEventually\b` / `lpushEventually\b`: 0 callers remain (only historical comment refs in `redis_lua_compat_test.go`).
- `doEventually\b`: 0 callers remain.
- `retryNotLeader\b`: 9 callers, all in `grpc_test.go`. Unchanged.

## Validation

- `go test ./adapter/ -run TestRedis_LuaRPopLPushBullMQLikeLists -race -count=3` → ok 5.1s (direct RPush/LPush inherits the writeable-leader gate from `createNode`; no flake)
- `gofmt` + `go vet` + `golangci-lint run` → 0 issues

## Scope

Closes the "*Eventually helper unnecessization audit" follow-up noted in PR #898's description.
