### PR TITLE
backup: Phase 0b M6 implementation - cmd/elastickv-snapshot-encode + library

### DIFF
--- a/cmd/elastickv-snapshot-decode/main.go
+++ b/cmd/elastickv-snapshot-decode/main.go
@@ -275,6 +275,7 @@ func emitManifest(cfg *config, res backup.DecodeResult) error {
 		IncludeOrphans:           cfg.includeOrphans,
 		PreserveSQSVisibility:    cfg.preserveSQSVisibility,
 		IncludeSQSSideRecords:    cfg.includeSQSSideRecords,
+		RenameS3Collisions:       cfg.renameCollisions,
 	}
 	if cfg.bundleJSONL {
 		m.DynamoDBLayout = backup.DynamoDBLayoutJSONL

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -422,19 +422,21 @@ func encodeOne(cfg *config, logger *slog.Logger) error {
 	// when the encode itself errored before any result was populated
 	// (publishErr != nil && !errSelfTestMismatch) (codex P2 v6 #904).
 	if publishErr == nil || errors.Is(publishErr, errSelfTestMismatch) {
-		if serr := writeSidecar(cfg, manifest, effectiveTS, overridden, result); serr != nil {
+		sidecarTruncated, serr := writeSidecar(cfg, manifest, effectiveTS, overridden, result)
+		if serr != nil {
 			// Surface the sidecar-write failure only if encode itself
 			// succeeded; on mismatch the mismatch error takes priority.
 			if publishErr == nil {
 				// .fsm was just renamed into place by writeAndPublish
 				// but the sidecar write failed → we have an orphan
 				// .fsm without its matching provenance metadata.
-				// Roll both back to a consistent absent state so the
-				// operator doesn't see a "successful" restore
-				// artifact missing its sidecar (claude/codex P2 v31
-				// observation on PR #904 — the design contract is
-				// that .fsm + sidecar move together).
-				rollbackOrphanFSMAndSidecar(cfg.outputPath, logger)
+				// Roll back to a consistent absent state. The sidecar
+				// rollback is gated on sidecarTruncated so we don't
+				// remove an operator-owned pre-existing entry that
+				// OpenSidecarFile refused to clobber (claude/codex
+				// P2 v31 added the rollback; codex P2 v33 #904 added
+				// the truncation gate for hard-linked sidecars).
+				rollbackOrphanFSMAndSidecar(cfg.outputPath, sidecarTruncated, logger)
 				return errors.Wrap(serr, "write encode_info sidecar")
 			}
 			logger.Warn("write encode_info sidecar on mismatch", "err", serr)
@@ -511,34 +513,25 @@ func buildEncodeOptions(cfg *config, effectiveTS uint64, manifest backup.Manifes
 // Both os.Remove calls log-and-continue on non-ErrNotExist failures
 // so the caller's primary sidecar-write error remains the dominant
 // signal.
-func rollbackOrphanFSMAndSidecar(outputPath string, logger *slog.Logger) {
+// rollbackOrphanFSMAndSidecar reverts an encode that succeeded in
+// publishing the .fsm but failed in writing the sidecar. Always
+// removes the just-renamed .fsm at outputPath. The sidecar at
+// EncodeInfoSidecarPath(outputPath) is removed ONLY when
+// sidecarTruncated is true — i.e., backup.OpenSidecarFile succeeded
+// and either created a fresh file or truncated an existing
+// single-link regular file. When sidecarTruncated is false the
+// existing entry is operator-owned (symlink, hard link with
+// Nlink > 1, FIFO, directory, etc.) that OpenSidecarFile refused to
+// clobber, so this rollback must NOT destroy it either (codex P2
+// v32 #904 / codex P2 v33 #904).
+func rollbackOrphanFSMAndSidecar(outputPath string, sidecarTruncated bool, logger *slog.Logger) {
 	if rerr := os.Remove(outputPath); rerr != nil && !errors.Is(rerr, os.ErrNotExist) {
 		logger.Warn("rollback orphan .fsm after sidecar failure", "err", rerr)
 	}
+	if !sidecarTruncated {
+		return
+	}
 	sidecarPath := backup.EncodeInfoSidecarPath(outputPath)
-	// Only remove a sidecar known to be a regular file — i.e., one
-	// this run (or a prior encoder) created. A pre-existing
-	// non-regular entry (operator-placed symlink, FIFO, directory,
-	// etc.) is what OpenSidecarFile correctly refuses to clobber
-	// when the rollback was triggered; os.Remove'ing the
-	// operator's filesystem object merely because the encode
-	// failed would be a destructive side effect (codex P2 v32
-	// #904). Symlinks the operator may have placed are also
-	// preserved here — OpenSidecarFile's O_NOFOLLOW failure means
-	// the symlink was never followed and no truncate happened, so
-	// the link is unchanged and is the operator's to manage.
-	info, err := os.Lstat(sidecarPath)
-	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			logger.Warn("stat sidecar for rollback", "err", err)
-		}
-		return
-	}
-	if !info.Mode().IsRegular() {
-		logger.Warn("skip sidecar rollback: --output sidecar path is not a regular file",
-			"path", sidecarPath, "mode", info.Mode())
-		return
-	}
 	if srerr := os.Remove(sidecarPath); srerr != nil && !errors.Is(srerr, os.ErrNotExist) {
 		logger.Warn("rollback partial sidecar after write failure", "err", srerr)
 	}
@@ -780,9 +773,17 @@ func tempOutputPath(output string) (string, error) {
 	return output + ".tmp-" + hex.EncodeToString(buf), nil
 }
 
-// writeSidecar emits ENCODE_INFO.json next to the published .fsm.
-// Path-derived per gemini medium v2 #896.
-func writeSidecar(cfg *config, m backup.Manifest, effectiveTS uint64, overridden bool, result backup.EncodeResult) error {
+// writeSidecar emits ENCODE_INFO.json next to the published .fsm
+// (path-derived per gemini medium v2 #896). Returns (truncated, err):
+// truncated is true iff backup.OpenSidecarFile succeeded — i.e., the
+// existing path was truncated by THIS run (or a fresh file was
+// created). When truncated is false, the caller MUST NOT roll back
+// the sidecar path: any pre-existing entry there is operator-owned
+// and OpenSidecarFile correctly refused to clobber it (codex P2 v33
+// #904 — hard-linked sidecars in particular pass IsRegular but were
+// refused via Nlink>1; v32's IsRegular-only rollback gate would
+// have destroyed those).
+func writeSidecar(cfg *config, m backup.Manifest, effectiveTS uint64, overridden bool, result backup.EncodeResult) (bool, error) {
 	info := backup.NewEncodeInfo(time.Now())
 	info.EncoderVersion = version
 	info.InputRoot = cfg.inputPath
@@ -812,24 +813,30 @@ func writeSidecar(cfg *config, m backup.Manifest, effectiveTS uint64, overridden
 	// choosing (codex P2 v25 #904).
 	f, err := backup.OpenSidecarFile(sidecarPath)
 	if err != nil {
-		return errors.Wrap(err, "open sidecar")
+		// Pre-existing entry refused (symlink/hard-link/non-regular).
+		// Caller must NOT rollback the sidecar path; the file there
+		// is operator-owned and was never touched by this run.
+		return false, errors.Wrap(err, "open sidecar")
 	}
+	// From this point, f points at a truncated (zero-length) regular
+	// file owned by this run. Any subsequent failure leaves partial
+	// bytes (or empty) on disk — the caller's rollback removes them.
 	if err := backup.WriteEncodeInfo(f, info); err != nil {
 		_ = f.Close()
-		return errors.Wrap(err, "WriteEncodeInfo")
+		return true, errors.Wrap(err, "WriteEncodeInfo")
 	}
 	if err := f.Sync(); err != nil {
 		_ = f.Close()
-		return errors.WithStack(err)
+		return true, errors.WithStack(err)
 	}
 	if err := f.Close(); err != nil {
-		return errors.WithStack(err)
+		return true, errors.WithStack(err)
 	}
 	// fsync the parent dir so the new sidecar's directory entry is
 	// durable alongside its bytes. Mirrors the rename path
 	// (codex P2 v24 #904).
 	if err := fsyncParentDir(sidecarPath); err != nil {
-		return errors.Wrap(err, "fsync sidecar parent dir")
+		return true, errors.Wrap(err, "fsync sidecar parent dir")
 	}
-	return nil
+	return true, nil
 }

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -26,11 +26,11 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"flag"
-	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -45,10 +45,12 @@ const (
 	exitUserErr = 1
 	exitDataErr = 2
 	// tempSuffixHexLen is the hex-character length of the random
-	// suffix appended to <output>.tmp-<hex>; 8 hex chars = 4 bytes of
-	// entropy, which gives ~4×10^9 collision space per --output path
-	// (more than enough for concurrent encodes against the same path).
-	tempSuffixHexLen   = 8
+	// suffix appended to <output>.tmp-<hex>; 16 hex chars = 8 bytes of
+	// entropy = 2^64 collision space per --output path. The earlier
+	// 8-hex/4-byte form was flagged as collision-prone in highly
+	// concurrent CI environments (gemini medium #904); 8 bytes is the
+	// same width crypto/rand.Read pads cryptographic nonces to.
+	tempSuffixHexLen   = 16
 	tempSuffixByteLen  = tempSuffixHexLen / 2
 	mismatchTxtPerm    = 0o600
 	encodeInfoFilePerm = 0o600
@@ -144,21 +146,31 @@ func parseFlags(argv []string) (*config, error) {
 }
 
 // parseLastCommitTS parses --last-commit-ts as a uint64. Hex (0x prefix)
-// or decimal accepted. Negative or out-of-range surfaces as exit-1
-// (flag-parse error); the semantic check (T >= manifest) is exit-2.
+// or decimal accepted. Uses strconv.ParseUint strict parsing so trailing
+// garbage is rejected — fmt.Sscanf would silently accept "0xffZZ" as
+// 0xff and "100oops" as 100, which becomes a snapshot HLC ceiling that
+// silently disagrees with what the operator typed (claude high #904,
+// codex P2 #904). Negative or out-of-range surfaces as exit-1; the
+// semantic check (T >= manifest) is exit-2.
 func parseLastCommitTS(raw string) (uint64, error) {
 	s := strings.TrimSpace(raw)
 	if s == "" {
 		return 0, errors.New("--last-commit-ts is empty")
 	}
-	var ts uint64
+	const (
+		base16     = 16
+		base10     = 10
+		uint64Bits = 64
+	)
 	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
-		if _, err := fmt.Sscanf(s[2:], "%x", &ts); err != nil {
+		ts, err := strconv.ParseUint(s[2:], base16, uint64Bits)
+		if err != nil {
 			return 0, errors.Wrap(err, "--last-commit-ts hex parse")
 		}
 		return ts, nil
 	}
-	if _, err := fmt.Sscanf(s, "%d", &ts); err != nil {
+	ts, err := strconv.ParseUint(s, base10, uint64Bits)
+	if err != nil {
 		return 0, errors.Wrap(err, "--last-commit-ts decimal parse")
 	}
 	return ts, nil
@@ -166,7 +178,12 @@ func parseLastCommitTS(raw string) (uint64, error) {
 
 // parseAdapterSet decodes a comma-separated adapter list (or "all").
 // Mirrors the decoder's parser so a typo cannot silently disable an
-// adapter. Unknown name → exit-1.
+// adapter. Unknown name → exit-1. A CSV that contains only separators
+// or whitespace (e.g. `--adapter ' ,'`) is also rejected — without this
+// guard a templated argument that expands to spaces would yield a
+// zero AdapterSet and the encoder would publish a valid header-only
+// .fsm (no adapters invoked), turning a bad argument into a silent
+// empty restore artifact (codex P2 #904).
 func parseAdapterSet(csv string) (backup.AdapterSet, error) {
 	if csv == "" || csv == "all" {
 		return backup.AdapterSet{DynamoDB: true, S3: true, Redis: true, SQS: true}, nil
@@ -174,22 +191,36 @@ func parseAdapterSet(csv string) (backup.AdapterSet, error) {
 	var set backup.AdapterSet
 	for _, raw := range strings.Split(csv, ",") {
 		name := strings.TrimSpace(strings.ToLower(raw))
-		switch name {
-		case "dynamodb":
-			set.DynamoDB = true
-		case "s3":
-			set.S3 = true
-		case "redis":
-			set.Redis = true
-		case "sqs":
-			set.SQS = true
-		case "":
+		if name == "" {
 			continue
-		default:
-			return backup.AdapterSet{}, errors.Errorf("unknown adapter %q", name)
+		}
+		if err := applyAdapterName(name, &set); err != nil {
+			return backup.AdapterSet{}, err
 		}
 	}
+	if !set.DynamoDB && !set.S3 && !set.Redis && !set.SQS {
+		return backup.AdapterSet{}, errors.Errorf("--adapter %q selects no adapters; use \"all\" or a comma-separated subset", csv)
+	}
 	return set, nil
+}
+
+// applyAdapterName sets the bit on s for one normalized adapter name,
+// or returns an unknown-name error. Split out so parseAdapterSet stays
+// under the cyclop threshold.
+func applyAdapterName(name string, s *backup.AdapterSet) error {
+	switch name {
+	case "dynamodb":
+		s.DynamoDB = true
+	case "s3":
+		s.S3 = true
+	case "redis":
+		s.Redis = true
+	case "sqs":
+		s.SQS = true
+	default:
+		return errors.Errorf("unknown adapter %q", name)
+	}
+	return nil
 }
 
 // errSelfTestMismatch is a typed sentinel so run() can map self-test diffs

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -107,6 +107,9 @@ func classifyEncodeError(err error) int {
 	switch {
 	case errors.Is(err, backup.ErrSelfTestLowerLastCommitTS),
 		errors.Is(err, backup.ErrEncodeUnsupportedDynamoDBLayout),
+		errors.Is(err, backup.ErrEncodeUnsupportedS3IncompleteUploads),
+		errors.Is(err, backup.ErrEncodeUnsupportedS3Orphans),
+		errors.Is(err, backup.ErrEncodeUnsupportedSQSPreserveVisibility),
 		errors.Is(err, backup.ErrEncodeAdapterData),
 		errors.Is(err, errSelfTestMismatch),
 		errors.Is(err, backup.ErrInvalidManifest),
@@ -324,6 +327,17 @@ func buildEncodeOptions(cfg *config, effectiveTS uint64, manifest backup.Manifes
 		ManifestLastCommitTS: manifest.LastCommitTS,
 		DynamoDBBundleJSONL:  manifest.DynamoDBLayout == backup.DynamoDBLayoutJSONL,
 		SelfTest:             cfg.selfTest,
+	}
+	// Thread manifest exclusions into the library guards (codex P2 v21
+	// #904): the S3/SQS reverse encoders can't honor these today, so
+	// failing closed here surfaces the unsupported-feature errors
+	// before any bytes are written. The CLI's existing
+	// buildSelfTestDecodeOptions also threads the same fields into
+	// the scratch decode path so self-test sees a coherent picture.
+	if manifest.Exclusions != nil {
+		encodeOpts.S3IncludeIncompleteUploads = manifest.Exclusions.IncludeIncompleteUploads
+		encodeOpts.S3IncludeOrphans = manifest.Exclusions.IncludeOrphans
+		encodeOpts.PreserveSQSVisibility = manifest.Exclusions.PreserveSQSVisibility
 	}
 	if cfg.selfTest {
 		encodeOpts.SelfTestDecodeOptions = buildSelfTestDecodeOptions(cfg, manifest)

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -92,11 +92,11 @@ func run(argv []string, logger *slog.Logger) (int, error) {
 
 // classifyEncodeError maps the encodeOne return value to a CLI exit
 // code. Data-correctness sentinels (HLC ceiling regression, JSONL
-// layout, unsupported manifest exclusion flags, adapter rejecting
-// input-tree contents, self-test mismatch, corrupt manifest) →
-// exit 2; everything else → exit 1. Runbooks branch on exit status
-// to triage bad-dump-data vs operator typos, so this mapping is
-// part of the CLI contract.
+// layout, unsupported manifest exclusion flags, adapter scope
+// mismatch with manifest, adapter rejecting input-tree contents,
+// self-test mismatch, corrupt manifest) → exit 2; everything else
+// → exit 1. Runbooks branch on exit status to triage bad-dump-data
+// vs operator typos, so this mapping is part of the CLI contract.
 //
 // Sources of each sentinel:
 //   - ErrSelfTestLowerLastCommitTS: CLI resolveLastCommitTS + library
@@ -114,6 +114,10 @@ func run(argv []string, logger *slog.Logger) (int, error) {
 //   - errSelfTestMismatch: writeAndPublish self-test branch
 //   - ErrInvalidManifest / ErrUnsupportedFormatVersion: readInputManifest
 //     surfacing backup.ReadManifest sentinels (codex P2 v14 #904)
+//   - errAdapterNotInManifest: validateAdaptersAgainstManifest when
+//     a selected adapter has a nil manifest scope pointer (codex P2
+//     v26 #904 scenario B; retracted v27 scenario A in v30 per codex
+//     P1 v29 #904)
 func classifyEncodeError(err error) int {
 	switch {
 	case errors.Is(err, backup.ErrSelfTestLowerLastCommitTS),
@@ -132,28 +136,30 @@ func classifyEncodeError(err error) int {
 	}
 }
 
-// validateAdaptersAgainstManifest intersects the user-selected
-// AdapterSet with manifest.Adapters and stats each enabled adapter's
-// top-level subdir under inputPath. Two failure modes — both
-// data-correctness, both routed to exit 2:
+// validateAdaptersAgainstManifest checks each enabled adapter
+// against the nil/non-nil manifest scope pointer (manifest.Adapters.<X>).
+// One failure mode, routed to exit 2:
 //
-//   - Manifest lists no scope for an enabled adapter (nil pointer in
-//     manifest.Adapters.<X>). A truncated/wrong manifest combined with
-//     the default `--adapter dynamodb,s3,redis,sqs` would otherwise
-//     pick up a stale on-disk subdir for an adapter the producer did
-//     not dump (codex P2 v26 #904 scenario B).
-//   - Manifest lists a scope for an enabled adapter but the on-disk
-//     subdir is absent. The adapter encoder's "missing top-level
-//     subdir → no-op" behavior would otherwise publish a header-only
-//     or partial .fsm without a hard error (codex P2 v26 #904
-//     scenario A).
+//   - Manifest lists no scope (nil pointer) for an enabled adapter
+//     (codex P2 v26 #904 scenario B). A truncated/wrong manifest
+//     combined with the default `--adapter dynamodb,s3,redis,sqs`
+//     would otherwise pick up a stale on-disk subdir for an adapter
+//     the producer did not dump.
+//
+// Scenario A (non-nil scope but on-disk subdir missing) cannot be
+// detected from the manifest alone because the decoder's
+// populateAdapterScopes defers scope enumeration and always writes
+// an empty &Adapter{} regardless of record count (codex P1 v29 #904
+// pulled the v27/v28/v29 stat-and-readdir checks). Future work:
+// add a SHA / record-count manifest field so scenario A becomes
+// detectable. See checkOneAdapterScope's doc for the full per-shape
+// decision matrix.
 //
 // A nil manifest.Adapters is treated as "manifest has no scopes for
-// any adapter" — every enabled adapter trips the scenario-B guard.
-// Older manifests that omit the Adapters block deliberately are
-// expected to also omit on-disk subdirs and pass `--adapter` set to
-// only what they DO contain; that case is operator-driven and
-// surfaces the same fail-closed error here.
+// any adapter" — every enabled adapter trips the guard. Older
+// manifests that omit the Adapters block deliberately are expected
+// to pass `--adapter` set to only what they DO contain; that case
+// is operator-driven and surfaces the same fail-closed error here.
 func validateAdaptersAgainstManifest(selected backup.AdapterSet, m backup.Manifest, inputPath string) error {
 	checks := []struct {
 		name     string
@@ -368,13 +374,18 @@ func applyAdapterName(name string, s *backup.AdapterSet) error {
 var errSelfTestMismatch = errors.New("backup: --self-test diff against --input")
 
 // errAdapterNotInManifest is returned by validateAdaptersAgainstManifest
-// when the user has enabled an adapter that the manifest doesn't list,
-// or when the manifest lists an adapter whose top-level subdir is
-// missing on disk. Both are silent-data-loss scenarios per codex P2
-// v26 #904: the per-adapter encoders no-op on missing subdirs, so a
-// truncated dump or a stale-dir-with-default-`--adapter-all` would
-// publish a header-only/partial .fsm. classifyEncodeError routes this
-// to exit 2 (data-correctness).
+// when the user has enabled an adapter that the manifest doesn't list
+// (nil pointer in manifest.Adapters.<X>). This is the codex P2 v26
+// #904 scenario B: a stale on-disk subdir for an adapter the producer
+// did not dump would otherwise be encoded under the default
+// `--adapter dynamodb,s3,redis,sqs`. classifyEncodeError routes the
+// sentinel to exit 2 (data-correctness).
+//
+// The earlier v27/v28/v29 attempts to also detect a missing on-disk
+// subdir under a non-nil scope (codex P2 v26 scenario A) were retracted
+// in v30 once codex P1 v29 #904 clarified that the decoder defers
+// scope enumeration; the manifest can no longer distinguish "no
+// records dumped" from "records dumped but scope not enumerated."
 var errAdapterNotInManifest = errors.New("encode: adapter scope mismatch between MANIFEST.json and --adapter / on-disk tree")
 
 func encodeOne(cfg *config, logger *slog.Logger) error {

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -370,9 +370,12 @@ func removeStaleOutputFSM(outputPath string, logger *slog.Logger) {
 // writeAndPublish writes the .fsm to a temp path, runs the optional
 // self-test via EncodeSnapshot, and renames temp → output on success.
 // On self-test failure: writes mismatch.txt, removes any stale
-// <output>.fsm left by a prior successful run (codex P2 v10 #904),
-// removes the temp file via the deferred cleanup, returns
-// errSelfTestMismatch.
+// <output>.fsm or symlink at <output> left by a prior successful
+// run (codex P2 v10 #904 covered regular files, codex P2 v19 #904
+// extended to symlinks; directories and special files are left
+// alone per v14 L347), removes the temp file via the deferred
+// cleanup, returns errSelfTestMismatch. See removeStaleOutputFSM
+// for the per-shape decision matrix.
 func writeAndPublish(cfg *config, encodeOpts backup.EncodeOptions, mismatchPath string, logger *slog.Logger) (backup.EncodeResult, error) {
 	tempPath, err := tempOutputPath(cfg.outputPath)
 	if err != nil {

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -50,9 +50,13 @@ const (
 	// 8-hex/4-byte form was flagged as collision-prone in highly
 	// concurrent CI environments (gemini medium #904); 8 bytes is the
 	// same width crypto/rand.Read pads cryptographic nonces to.
-	tempSuffixHexLen   = 16
-	tempSuffixByteLen  = tempSuffixHexLen / 2
-	mismatchTxtPerm    = 0o600
+	tempSuffixHexLen  = 16
+	tempSuffixByteLen = tempSuffixHexLen / 2
+	// mismatchTxtPerm + sidecar perm constants were removed in v25:
+	// both writes now go through backup.OpenSidecarFile which fixes
+	// the mode at 0o600 internally (codex P2 v25 #904 — no-follow
+	// open required different syscall semantics than os.OpenFile +
+	// O_TRUNC, so the perm now lives in the helper).
 	encodeInfoFilePerm = 0o600
 )
 
@@ -352,6 +356,31 @@ func buildEncodeOptions(cfg *config, effectiveTS uint64, manifest backup.Manifes
 	return encodeOpts
 }
 
+// writeMismatchTxt writes the self-test mismatch report to mismatchPath
+// using the same no-follow/no-clobber discipline as the sidecar
+// writer: an attacker pre-placing a symlink at
+// <output>.mismatch.txt could otherwise redirect the
+// truncate-and-write into a target of their choosing (codex P2 v25
+// #904 — extending the sidecar guard to the sibling deterministic
+// write path). On open failure the caller (writeAndPublish) logs at
+// warn level and continues; the failure does NOT block the
+// errSelfTestMismatch return so the mismatch error remains the
+// dominant signal.
+func writeMismatchTxt(mismatchPath string, body []byte) error {
+	f, err := backup.OpenSidecarFile(mismatchPath)
+	if err != nil {
+		return errors.Wrap(err, "open mismatch.txt")
+	}
+	if _, werr := f.Write(body); werr != nil {
+		_ = f.Close()
+		return errors.Wrap(werr, "write mismatch.txt body")
+	}
+	if cerr := f.Close(); cerr != nil {
+		return errors.Wrap(cerr, "close mismatch.txt")
+	}
+	return nil
+}
+
 // removeStaleOutputFSM removes outputPath ONLY when it exists as a
 // regular file or a symlink. Both shapes satisfy the "no
 // restore-visible FSM after self-test mismatch" contract: removing a
@@ -413,7 +442,7 @@ func writeAndPublish(cfg *config, encodeOpts backup.EncodeOptions, mismatchPath 
 		return result, err
 	}
 	if cfg.selfTest && !result.SelfTestMatched {
-		if werr := os.WriteFile(mismatchPath, result.SelfTestMismatchTxt, mismatchTxtPerm); werr != nil {
+		if werr := writeMismatchTxt(mismatchPath, result.SelfTestMismatchTxt); werr != nil {
 			logger.Warn("write mismatch.txt", "err", werr)
 		}
 		// Remove the stale <output>.fsm if one exists from a prior
@@ -564,9 +593,18 @@ func writeSidecar(cfg *config, m backup.Manifest, effectiveTS uint64, overridden
 	// 0o600 keeps ENCODE_INFO.json (which includes the source path,
 	// cluster_id, and SHA-256 of the .fsm) from leaking to non-owner
 	// users on multi-user backup hosts (claude v4 #904).
-	f, err := os.OpenFile(sidecarPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, encodeInfoFilePerm) //nolint:gosec // operator-supplied path
+	//
+	// backup.OpenSidecarFile refuses to follow a symlink at the
+	// sidecar path, refuses to truncate a hard-linked or
+	// non-regular file there, and (on unix) refuses to block on a
+	// reader-less FIFO — all the clobber-attack vectors the adapter
+	// dump writers already defend against. Without these guards an
+	// attacker pre-placing a symlink at <output>.encode_info.json
+	// could redirect the truncate-and-write into a target of their
+	// choosing (codex P2 v25 #904).
+	f, err := backup.OpenSidecarFile(sidecarPath)
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.Wrap(err, "open sidecar")
 	}
 	if err := backup.WriteEncodeInfo(f, info); err != nil {
 		_ = f.Close()

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -88,16 +88,23 @@ func run(argv []string, logger *slog.Logger) (int, error) {
 
 // classifyEncodeError maps the encodeOne return value to a CLI exit
 // code. Data-correctness sentinels (HLC ceiling regression, JSONL
-// layout, adapter rejecting input-tree contents, self-test mismatch,
-// corrupt manifest) → exit 2; everything else → exit 1. Runbooks
-// branch on exit status to triage bad-dump-data vs operator typos,
-// so this mapping is part of the CLI contract.
+// layout, unsupported manifest exclusion flags, adapter rejecting
+// input-tree contents, self-test mismatch, corrupt manifest) →
+// exit 2; everything else → exit 1. Runbooks branch on exit status
+// to triage bad-dump-data vs operator typos, so this mapping is
+// part of the CLI contract.
 //
 // Sources of each sentinel:
 //   - ErrSelfTestLowerLastCommitTS: CLI resolveLastCommitTS + library
 //     validateEncodeOptionsData (codex P2 v2 #904)
 //   - ErrEncodeUnsupportedDynamoDBLayout: validateEncodeOptionsData
 //     (codex P2 v7 #904)
+//   - ErrEncodeUnsupportedS3IncompleteUploads: validateEncodeOptionsUnsupportedFeatures
+//     (codex P2 v21 #904)
+//   - ErrEncodeUnsupportedS3Orphans: validateEncodeOptionsUnsupportedFeatures
+//     (codex P2 v21 #904)
+//   - ErrEncodeUnsupportedSQSPreserveVisibility: validateEncodeOptionsUnsupportedFeatures
+//     (codex P2 v21 #904)
 //   - ErrEncodeAdapterData: runAdapterEncoders mark on adapter
 //     rejection (codex P2 v9 #904)
 //   - errSelfTestMismatch: writeAndPublish self-test branch

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -82,12 +82,18 @@ func run(argv []string, logger *slog.Logger) (int, error) {
 	}
 	if err := encodeOne(cfg, logger); err != nil {
 		// Errors from the encoder layer that represent data constraints
-		// (HLC ceiling regression, self-test mismatch) are exit 2; other
-		// errors are exit 1.
+		// (HLC ceiling regression, JSONL layout, self-test mismatch,
+		// adapter rejecting input-tree contents) are exit 2; flag/path
+		// errors are exit 1. Runbooks branch on exit status to triage
+		// bad-dump-data vs operator typos, so this split is part of the
+		// CLI contract (codex P2 v9 #904 added the adapter-data branch).
 		if errors.Is(err, backup.ErrSelfTestLowerLastCommitTS) {
 			return exitDataErr, err
 		}
 		if errors.Is(err, backup.ErrEncodeUnsupportedDynamoDBLayout) {
+			return exitDataErr, err
+		}
+		if errors.Is(err, backup.ErrEncodeAdapterData) {
 			return exitDataErr, err
 		}
 		if errors.Is(err, errSelfTestMismatch) {

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -81,27 +81,40 @@ func run(argv []string, logger *slog.Logger) (int, error) {
 		return exitUserErr, err
 	}
 	if err := encodeOne(cfg, logger); err != nil {
-		// Errors from the encoder layer that represent data constraints
-		// (HLC ceiling regression, JSONL layout, self-test mismatch,
-		// adapter rejecting input-tree contents) are exit 2; flag/path
-		// errors are exit 1. Runbooks branch on exit status to triage
-		// bad-dump-data vs operator typos, so this split is part of the
-		// CLI contract (codex P2 v9 #904 added the adapter-data branch).
-		if errors.Is(err, backup.ErrSelfTestLowerLastCommitTS) {
-			return exitDataErr, err
-		}
-		if errors.Is(err, backup.ErrEncodeUnsupportedDynamoDBLayout) {
-			return exitDataErr, err
-		}
-		if errors.Is(err, backup.ErrEncodeAdapterData) {
-			return exitDataErr, err
-		}
-		if errors.Is(err, errSelfTestMismatch) {
-			return exitDataErr, err
-		}
-		return exitUserErr, err
+		return classifyEncodeError(err), err
 	}
 	return exitSuccess, nil
+}
+
+// classifyEncodeError maps the encodeOne return value to a CLI exit
+// code. Data-correctness sentinels (HLC ceiling regression, JSONL
+// layout, adapter rejecting input-tree contents, self-test mismatch,
+// corrupt manifest) → exit 2; everything else → exit 1. Runbooks
+// branch on exit status to triage bad-dump-data vs operator typos,
+// so this mapping is part of the CLI contract.
+//
+// Sources of each sentinel:
+//   - ErrSelfTestLowerLastCommitTS: CLI resolveLastCommitTS + library
+//     validateEncodeOptionsData (codex P2 v2 #904)
+//   - ErrEncodeUnsupportedDynamoDBLayout: validateEncodeOptionsData
+//     (codex P2 v7 #904)
+//   - ErrEncodeAdapterData: runAdapterEncoders mark on adapter
+//     rejection (codex P2 v9 #904)
+//   - errSelfTestMismatch: writeAndPublish self-test branch
+//   - ErrInvalidManifest / ErrUnsupportedFormatVersion: readInputManifest
+//     surfacing backup.ReadManifest sentinels (codex P2 v14 #904)
+func classifyEncodeError(err error) int {
+	switch {
+	case errors.Is(err, backup.ErrSelfTestLowerLastCommitTS),
+		errors.Is(err, backup.ErrEncodeUnsupportedDynamoDBLayout),
+		errors.Is(err, backup.ErrEncodeAdapterData),
+		errors.Is(err, errSelfTestMismatch),
+		errors.Is(err, backup.ErrInvalidManifest),
+		errors.Is(err, backup.ErrUnsupportedFormatVersion):
+		return exitDataErr
+	default:
+		return exitUserErr
+	}
 }
 
 func parseFlags(argv []string) (*config, error) {
@@ -312,6 +325,30 @@ func buildEncodeOptions(cfg *config, effectiveTS uint64, manifest backup.Manifes
 	return encodeOpts
 }
 
+// removeStaleOutputFSM removes outputPath ONLY if it exists and is a
+// regular file. A directory or special-file at the path is left alone
+// (codex P2 v14 #904 — the prior unconditional os.Remove would have
+// deleted an empty directory the operator passed in error to --output).
+// Errors other than ErrNotExist are downgraded to warn-and-continue so
+// the caller's primary mismatch error remains the dominant signal.
+func removeStaleOutputFSM(outputPath string, logger *slog.Logger) {
+	info, err := os.Lstat(outputPath)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			logger.Warn("stat stale .fsm on self-test mismatch", "err", err)
+		}
+		return
+	}
+	if !info.Mode().IsRegular() {
+		logger.Warn("skip stale .fsm cleanup: --output is not a regular file",
+			"path", outputPath, "mode", info.Mode())
+		return
+	}
+	if rerr := os.Remove(outputPath); rerr != nil && !errors.Is(rerr, os.ErrNotExist) {
+		logger.Warn("remove stale .fsm on self-test mismatch", "err", rerr)
+	}
+}
+
 // writeAndPublish writes the .fsm to a temp path, runs the optional
 // self-test via EncodeSnapshot, and renames temp → output on success.
 // On self-test failure: writes mismatch.txt, removes any stale
@@ -338,15 +375,20 @@ func writeAndPublish(cfg *config, encodeOpts backup.EncodeOptions, mismatchPath 
 			logger.Warn("write mismatch.txt", "err", werr)
 		}
 		// Remove the stale <output>.fsm if one exists from a prior
-		// successful run. encodeOne is about to write a fresh
-		// <output>.encode_info.json with self_test.matched=false and
-		// a NEW SHA pointing to the unpublished temp snapshot; leaving
-		// the old bytes on disk would make the sidecar describe an
-		// FSM that does not exist and violate the "self-test failure
-		// leaves no restore-visible FSM" contract (codex P2 v10 #904).
-		if rerr := os.Remove(cfg.outputPath); rerr != nil && !errors.Is(rerr, os.ErrNotExist) {
-			logger.Warn("remove stale .fsm on self-test mismatch", "err", rerr)
-		}
+		// successful run AND is a regular file. encodeOne is about to
+		// write a fresh <output>.encode_info.json with
+		// self_test.matched=false and a NEW SHA pointing to the
+		// unpublished temp snapshot; leaving old bytes on disk would
+		// make the sidecar describe an FSM that does not exist and
+		// violate the "self-test failure leaves no restore-visible
+		// FSM" contract (codex P2 v10 #904).
+		//
+		// The mode-check guards against an --output that names a
+		// directory (or any non-regular file): the normal publish
+		// path would fail at os.Rename anyway, but the mismatch
+		// cleanup must not destructively delete a directory the
+		// operator passed in error (codex P2 v14 #904).
+		removeStaleOutputFSM(cfg.outputPath, logger)
 		return result, errors.Wrap(errSelfTestMismatch, "self-test diff (see "+mismatchPath+")")
 	}
 	if err := os.Rename(tempPath, cfg.outputPath); err != nil {

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -198,8 +198,17 @@ func manifestAdapterField(a *backup.Adapters, name string) *backup.Adapter {
 
 // checkOneAdapterScope is the per-adapter half of
 // validateAdaptersAgainstManifest. Selected adapters MUST have a
-// manifest scope AND a present on-disk subdir; not-selected adapters
-// are unchecked (the operator chose to skip them).
+// manifest scope AND, when that scope is non-empty, a present on-disk
+// subdir; not-selected adapters are unchecked (the operator chose to
+// skip them).
+//
+// An empty Adapter{} (non-nil but no tables / buckets / databases /
+// queues) means "the producer ran with this adapter enabled but the
+// adapter had no records to dump." The decoder finalizers do not
+// create the top-level subdir in that case, so requiring on-disk
+// presence would reject valid Redis-only / header-only / empty dumps
+// (codex P2 v27 #904). Empty scope → subdir is optional; only the
+// scope=nil case still fails closed.
 func checkOneAdapterScope(name string, selected bool, scope *backup.Adapter, subdirPath string) error {
 	if !selected {
 		return nil
@@ -209,10 +218,15 @@ func checkOneAdapterScope(name string, selected bool, scope *backup.Adapter, sub
 			"adapter %q selected but MANIFEST.json has no scope for it (use --adapter to restrict, or re-dump including this adapter)",
 			name)
 	}
+	if isEmptyAdapterScope(scope) {
+		// Producer dumped this adapter with no records; the absence
+		// of the on-disk subdir is valid (codex P2 v27 #904).
+		return nil
+	}
 	info, err := os.Stat(subdirPath)
 	if err != nil {
 		return errors.Wrapf(errAdapterNotInManifest,
-			"adapter %q listed in MANIFEST.json but on-disk subdir %s is missing (stat: %v)",
+			"adapter %q listed in MANIFEST.json with non-empty scope but on-disk subdir %s is missing (stat: %v)",
 			name, subdirPath, err)
 	}
 	if !info.IsDir() {
@@ -221,6 +235,18 @@ func checkOneAdapterScope(name string, selected bool, scope *backup.Adapter, sub
 			name, subdirPath, info.Mode())
 	}
 	return nil
+}
+
+// isEmptyAdapterScope reports whether scope has no concrete
+// tables / buckets / databases / queues. A non-nil but empty
+// Adapter{} is the "producer dumped this adapter, no records"
+// signal — distinct from the nil pointer that means "producer did
+// not enable this adapter at all" (codex P2 v27 #904).
+func isEmptyAdapterScope(scope *backup.Adapter) bool {
+	return len(scope.Tables) == 0 &&
+		len(scope.Buckets) == 0 &&
+		len(scope.Databases) == 0 &&
+		len(scope.Queues) == 0
 }
 
 func parseFlags(argv []string) (*config, error) {

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -335,6 +335,16 @@ func writeAndPublish(cfg *config, encodeOpts backup.EncodeOptions, mismatchPath 
 		if werr := os.WriteFile(mismatchPath, result.SelfTestMismatchTxt, mismatchTxtPerm); werr != nil {
 			logger.Warn("write mismatch.txt", "err", werr)
 		}
+		// Remove the stale <output>.fsm if one exists from a prior
+		// successful run. encodeOne is about to write a fresh
+		// <output>.encode_info.json with self_test.matched=false and
+		// a NEW SHA pointing to the unpublished temp snapshot; leaving
+		// the old bytes on disk would make the sidecar describe an
+		// FSM that does not exist and violate the "self-test failure
+		// leaves no restore-visible FSM" contract (codex P2 v10 #904).
+		if rerr := os.Remove(cfg.outputPath); rerr != nil && !errors.Is(rerr, os.ErrNotExist) {
+			logger.Warn("remove stale .fsm on self-test mismatch", "err", rerr)
+		}
 		return result, errors.Wrap(errSelfTestMismatch, "self-test diff (see "+mismatchPath+")")
 	}
 	if err := os.Rename(tempPath, cfg.outputPath); err != nil {

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -426,6 +426,15 @@ func encodeOne(cfg *config, logger *slog.Logger) error {
 			// Surface the sidecar-write failure only if encode itself
 			// succeeded; on mismatch the mismatch error takes priority.
 			if publishErr == nil {
+				// .fsm was just renamed into place by writeAndPublish
+				// but the sidecar write failed → we have an orphan
+				// .fsm without its matching provenance metadata.
+				// Roll both back to a consistent absent state so the
+				// operator doesn't see a "successful" restore
+				// artifact missing its sidecar (claude/codex P2 v31
+				// observation on PR #904 — the design contract is
+				// that .fsm + sidecar move together).
+				rollbackOrphanFSMAndSidecar(cfg.outputPath, logger)
 				return errors.Wrap(serr, "write encode_info sidecar")
 			}
 			logger.Warn("write encode_info sidecar on mismatch", "err", serr)
@@ -482,6 +491,34 @@ func buildEncodeOptions(cfg *config, effectiveTS uint64, manifest backup.Manifes
 		encodeOpts.SelfTestDecodeOptions = buildSelfTestDecodeOptions(cfg, manifest)
 	}
 	return encodeOpts
+}
+
+// rollbackOrphanFSMAndSidecar removes both the just-published
+// <output>.fsm and the partial <output>.encode_info.json after a
+// sidecar-write failure on the encode success path. The pair was
+// supposed to move together (the .fsm describes the data the sidecar
+// records the provenance for); if the sidecar didn't land, the
+// operator must not see a "successful" .fsm without its matching
+// provenance metadata (claude / codex P2 v31 observation on PR #904).
+//
+// A prior successful encode at the same output path is unrecoverable
+// — writeAndPublish's os.Rename already overwrote it before
+// writeSidecar ran. The rollback brings the state to "no .fsm, no
+// sidecar at this path", which is the same end state as "encode
+// never ran." That's the cleanest consistent outcome the CLI can
+// produce without filesystem transactions.
+//
+// Both os.Remove calls log-and-continue on non-ErrNotExist failures
+// so the caller's primary sidecar-write error remains the dominant
+// signal.
+func rollbackOrphanFSMAndSidecar(outputPath string, logger *slog.Logger) {
+	if rerr := os.Remove(outputPath); rerr != nil && !errors.Is(rerr, os.ErrNotExist) {
+		logger.Warn("rollback orphan .fsm after sidecar failure", "err", rerr)
+	}
+	sidecarPath := backup.EncodeInfoSidecarPath(outputPath)
+	if srerr := os.Remove(sidecarPath); srerr != nil && !errors.Is(srerr, os.ErrNotExist) {
+		logger.Warn("rollback partial sidecar after write failure", "err", srerr)
+	}
 }
 
 // writeMismatchTxt writes the self-test mismatch report to mismatchPath

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -239,14 +239,30 @@ func encodeOne(cfg *config, logger *slog.Logger) error {
 	encodeOpts := buildEncodeOptions(cfg, effectiveTS, manifest)
 
 	mismatchPath := cfg.outputPath + ".mismatch.txt"
-	_ = os.Remove(mismatchPath) // stale-mismatch cleanup, gemini medium v6 #896
+	_ = os.Remove(mismatchPath) // stale-mismatch cleanup (gemini medium v6 #896)
+	// Stale sidecar cleanup too: a self-test failure rewrites the
+	// sidecar with matched:false (codex P2 v6 #904); make sure the
+	// file always reflects the latest run, not a prior success.
+	_ = os.Remove(backup.EncodeInfoSidecarPath(cfg.outputPath))
 
-	result, err := writeAndPublish(cfg, encodeOpts, mismatchPath, logger)
-	if err != nil {
-		return err
+	result, publishErr := writeAndPublish(cfg, encodeOpts, mismatchPath, logger)
+	// Sidecar is written even on self-test mismatch so an operator
+	// has both <output>.mismatch.txt AND <output>.encode_info.json
+	// (with self_test.matched=false) for diagnostics. Only skipped
+	// when the encode itself errored before any result was populated
+	// (publishErr != nil && !errSelfTestMismatch) (codex P2 v6 #904).
+	if publishErr == nil || errors.Is(publishErr, errSelfTestMismatch) {
+		if serr := writeSidecar(cfg, manifest, effectiveTS, overridden, result); serr != nil {
+			// Surface the sidecar-write failure only if encode itself
+			// succeeded; on mismatch the mismatch error takes priority.
+			if publishErr == nil {
+				return errors.Wrap(serr, "write encode_info sidecar")
+			}
+			logger.Warn("write encode_info sidecar on mismatch", "err", serr)
+		}
 	}
-	if err := writeSidecar(cfg, manifest, effectiveTS, overridden, result); err != nil {
-		return errors.Wrap(err, "write encode_info sidecar")
+	if publishErr != nil {
+		return publishErr
 	}
 	logger.Info("encode complete",
 		"output", cfg.outputPath,
@@ -274,10 +290,11 @@ func readInputManifest(inputPath string) (backup.Manifest, error) {
 
 func buildEncodeOptions(cfg *config, effectiveTS uint64, manifest backup.Manifest) backup.EncodeOptions {
 	encodeOpts := backup.EncodeOptions{
-		InputRoot:    cfg.inputPath,
-		Adapters:     cfg.adapters,
-		LastCommitTS: effectiveTS,
-		SelfTest:     cfg.selfTest,
+		InputRoot:            cfg.inputPath,
+		Adapters:             cfg.adapters,
+		LastCommitTS:         effectiveTS,
+		ManifestLastCommitTS: manifest.LastCommitTS,
+		SelfTest:             cfg.selfTest,
 	}
 	if cfg.selfTest {
 		encodeOpts.SelfTestDecodeOptions = buildSelfTestDecodeOptions(cfg, manifest)

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -124,11 +124,103 @@ func classifyEncodeError(err error) int {
 		errors.Is(err, backup.ErrEncodeAdapterData),
 		errors.Is(err, errSelfTestMismatch),
 		errors.Is(err, backup.ErrInvalidManifest),
-		errors.Is(err, backup.ErrUnsupportedFormatVersion):
+		errors.Is(err, backup.ErrUnsupportedFormatVersion),
+		errors.Is(err, errAdapterNotInManifest):
 		return exitDataErr
 	default:
 		return exitUserErr
 	}
+}
+
+// validateAdaptersAgainstManifest intersects the user-selected
+// AdapterSet with manifest.Adapters and stats each enabled adapter's
+// top-level subdir under inputPath. Two failure modes — both
+// data-correctness, both routed to exit 2:
+//
+//   - Manifest lists no scope for an enabled adapter (nil pointer in
+//     manifest.Adapters.<X>). A truncated/wrong manifest combined with
+//     the default `--adapter dynamodb,s3,redis,sqs` would otherwise
+//     pick up a stale on-disk subdir for an adapter the producer did
+//     not dump (codex P2 v26 #904 scenario B).
+//   - Manifest lists a scope for an enabled adapter but the on-disk
+//     subdir is absent. The adapter encoder's "missing top-level
+//     subdir → no-op" behavior would otherwise publish a header-only
+//     or partial .fsm without a hard error (codex P2 v26 #904
+//     scenario A).
+//
+// A nil manifest.Adapters is treated as "manifest has no scopes for
+// any adapter" — every enabled adapter trips the scenario-B guard.
+// Older manifests that omit the Adapters block deliberately are
+// expected to also omit on-disk subdirs and pass `--adapter` set to
+// only what they DO contain; that case is operator-driven and
+// surfaces the same fail-closed error here.
+func validateAdaptersAgainstManifest(selected backup.AdapterSet, m backup.Manifest, inputPath string) error {
+	checks := []struct {
+		name     string
+		selected bool
+		scope    *backup.Adapter
+		subdir   string
+	}{
+		{"dynamodb", selected.DynamoDB, manifestAdapterField(m.Adapters, "dynamodb"), "dynamodb"},
+		{"s3", selected.S3, manifestAdapterField(m.Adapters, "s3"), "s3"},
+		{"redis", selected.Redis, manifestAdapterField(m.Adapters, "redis"), "redis"},
+		{"sqs", selected.SQS, manifestAdapterField(m.Adapters, "sqs"), "sqs"},
+	}
+	for _, c := range checks {
+		if err := checkOneAdapterScope(c.name, c.selected, c.scope, filepath.Join(inputPath, c.subdir)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// manifestAdapterField returns the *Adapter for one adapter name from
+// m.Adapters, or nil if m.Adapters or the specific adapter pointer is
+// nil. Centralized so validateAdaptersAgainstManifest's table stays
+// readable.
+func manifestAdapterField(a *backup.Adapters, name string) *backup.Adapter {
+	if a == nil {
+		return nil
+	}
+	switch name {
+	case "dynamodb":
+		return a.DynamoDB
+	case "s3":
+		return a.S3
+	case "redis":
+		return a.Redis
+	case "sqs":
+		return a.SQS
+	default:
+		return nil
+	}
+}
+
+// checkOneAdapterScope is the per-adapter half of
+// validateAdaptersAgainstManifest. Selected adapters MUST have a
+// manifest scope AND a present on-disk subdir; not-selected adapters
+// are unchecked (the operator chose to skip them).
+func checkOneAdapterScope(name string, selected bool, scope *backup.Adapter, subdirPath string) error {
+	if !selected {
+		return nil
+	}
+	if scope == nil {
+		return errors.Wrapf(errAdapterNotInManifest,
+			"adapter %q selected but MANIFEST.json has no scope for it (use --adapter to restrict, or re-dump including this adapter)",
+			name)
+	}
+	info, err := os.Stat(subdirPath)
+	if err != nil {
+		return errors.Wrapf(errAdapterNotInManifest,
+			"adapter %q listed in MANIFEST.json but on-disk subdir %s is missing (stat: %v)",
+			name, subdirPath, err)
+	}
+	if !info.IsDir() {
+		return errors.Wrapf(errAdapterNotInManifest,
+			"adapter %q listed in MANIFEST.json but %s is not a directory (mode=%s)",
+			name, subdirPath, info.Mode())
+	}
+	return nil
 }
 
 func parseFlags(argv []string) (*config, error) {
@@ -263,9 +355,22 @@ func applyAdapterName(name string, s *backup.AdapterSet) error {
 // to exit-2 without coupling to the encoder's mismatch.txt format.
 var errSelfTestMismatch = errors.New("backup: --self-test diff against --input")
 
+// errAdapterNotInManifest is returned by validateAdaptersAgainstManifest
+// when the user has enabled an adapter that the manifest doesn't list,
+// or when the manifest lists an adapter whose top-level subdir is
+// missing on disk. Both are silent-data-loss scenarios per codex P2
+// v26 #904: the per-adapter encoders no-op on missing subdirs, so a
+// truncated dump or a stale-dir-with-default-`--adapter-all` would
+// publish a header-only/partial .fsm. classifyEncodeError routes this
+// to exit 2 (data-correctness).
+var errAdapterNotInManifest = errors.New("encode: adapter scope mismatch between MANIFEST.json and --adapter / on-disk tree")
+
 func encodeOne(cfg *config, logger *slog.Logger) error {
 	manifest, err := readInputManifest(cfg.inputPath)
 	if err != nil {
+		return err
+	}
+	if err := validateAdaptersAgainstManifest(cfg.adapters, manifest, cfg.inputPath); err != nil {
 		return err
 	}
 	effectiveTS, overridden, err := resolveLastCommitTS(cfg, manifest.LastCommitTS)

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -331,12 +331,22 @@ func buildEncodeOptions(cfg *config, effectiveTS uint64, manifest backup.Manifes
 	return encodeOpts
 }
 
-// removeStaleOutputFSM removes outputPath ONLY if it exists and is a
-// regular file. A directory or special-file at the path is left alone
-// (codex P2 v14 #904 — the prior unconditional os.Remove would have
-// deleted an empty directory the operator passed in error to --output).
-// Errors other than ErrNotExist are downgraded to warn-and-continue so
-// the caller's primary mismatch error remains the dominant signal.
+// removeStaleOutputFSM removes outputPath ONLY when it exists as a
+// regular file or a symlink. Both shapes satisfy the "no
+// restore-visible FSM after self-test mismatch" contract: removing a
+// regular file empties --output; removing a symlink unlinks the
+// name (the target is preserved as a side effect — os.Remove on a
+// symlink operates on the link, not the resolved target). A directory,
+// device, FIFO, or socket at --output is left alone — those shapes
+// were never valid restore targets, and os.Remove on a non-empty
+// directory or device would be destructive in ways the mismatch
+// contract does not require (codex P2 v14 #904 caught the directory
+// case; codex P2 v19 #904 caught the symlink case where the prior
+// IsRegular()-only check silently left the symlink resolving to the
+// stale snapshot).
+//
+// Errors other than ErrNotExist are downgraded to warn-and-continue
+// so the caller's primary mismatch error remains the dominant signal.
 func removeStaleOutputFSM(outputPath string, logger *slog.Logger) {
 	info, err := os.Lstat(outputPath)
 	if err != nil {
@@ -345,9 +355,11 @@ func removeStaleOutputFSM(outputPath string, logger *slog.Logger) {
 		}
 		return
 	}
-	if !info.Mode().IsRegular() {
-		logger.Warn("skip stale .fsm cleanup: --output is not a regular file",
-			"path", outputPath, "mode", info.Mode())
+	mode := info.Mode()
+	isSymlink := mode&os.ModeSymlink != 0
+	if !mode.IsRegular() && !isSymlink {
+		logger.Warn("skip stale .fsm cleanup: --output is not a regular file or symlink",
+			"path", outputPath, "mode", mode)
 		return
 	}
 	if rerr := os.Remove(outputPath); rerr != nil && !errors.Is(rerr, os.ErrNotExist) {

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -198,17 +198,20 @@ func manifestAdapterField(a *backup.Adapters, name string) *backup.Adapter {
 
 // checkOneAdapterScope is the per-adapter half of
 // validateAdaptersAgainstManifest. Selected adapters MUST have a
-// manifest scope AND, when that scope is non-empty, a present on-disk
-// subdir; not-selected adapters are unchecked (the operator chose to
-// skip them).
+// manifest scope; the on-disk subdir requirements depend on whether
+// the scope is empty or has concrete entries. Not-selected adapters
+// are unchecked (the operator chose to skip them).
 //
-// An empty Adapter{} (non-nil but no tables / buckets / databases /
-// queues) means "the producer ran with this adapter enabled but the
-// adapter had no records to dump." The decoder finalizers do not
-// create the top-level subdir in that case, so requiring on-disk
-// presence would reject valid Redis-only / header-only / empty dumps
-// (codex P2 v27 #904). Empty scope → subdir is optional; only the
-// scope=nil case still fails closed.
+// Decision matrix (codex P2 v26 + v27 + v28 #904):
+//
+//   - scope == nil          → fail (producer did not dump this adapter).
+//   - empty scope, subdir absent or empty → pass (no records in dump).
+//   - empty scope, subdir non-empty       → fail (stale data on disk
+//     not declared in manifest — input directory was reused or
+//     partially cleaned).
+//   - non-empty scope, subdir missing or not-a-dir → fail (truncated
+//     dump).
+//   - non-empty scope, subdir is a directory      → pass.
 func checkOneAdapterScope(name string, selected bool, scope *backup.Adapter, subdirPath string) error {
 	if !selected {
 		return nil
@@ -219,9 +222,7 @@ func checkOneAdapterScope(name string, selected bool, scope *backup.Adapter, sub
 			name)
 	}
 	if isEmptyAdapterScope(scope) {
-		// Producer dumped this adapter with no records; the absence
-		// of the on-disk subdir is valid (codex P2 v27 #904).
-		return nil
+		return checkSubdirAbsentOrEmpty(name, subdirPath)
 	}
 	info, err := os.Stat(subdirPath)
 	if err != nil {
@@ -233,6 +234,38 @@ func checkOneAdapterScope(name string, selected bool, scope *backup.Adapter, sub
 		return errors.Wrapf(errAdapterNotInManifest,
 			"adapter %q listed in MANIFEST.json but %s is not a directory (mode=%s)",
 			name, subdirPath, info.Mode())
+	}
+	return nil
+}
+
+// checkSubdirAbsentOrEmpty fails closed when an empty-scope adapter
+// has a non-empty on-disk subdir. The empty scope says the producer
+// dumped no records; a populated subdir would otherwise be encoded by
+// cfg.adapters (default `--adapter all`) and silently publish stale
+// data the manifest doesn't claim (codex P2 v28 #904 — the inverse of
+// v27's truncated-dump scenario).
+func checkSubdirAbsentOrEmpty(name, subdirPath string) error {
+	info, err := os.Stat(subdirPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return errors.Wrapf(errAdapterNotInManifest,
+			"adapter %q: stat %s: %v", name, subdirPath, err)
+	}
+	if !info.IsDir() {
+		return errors.Wrapf(errAdapterNotInManifest,
+			"adapter %q: %s is not a directory (mode=%s)", name, subdirPath, info.Mode())
+	}
+	entries, err := os.ReadDir(subdirPath)
+	if err != nil {
+		return errors.Wrapf(errAdapterNotInManifest,
+			"adapter %q: readdir %s: %v", name, subdirPath, err)
+	}
+	if len(entries) != 0 {
+		return errors.Wrapf(errAdapterNotInManifest,
+			"adapter %q has empty scope in MANIFEST.json but %s contains %d entries (stale dump artifacts; clean the directory or re-dump)",
+			name, subdirPath, len(entries))
 	}
 	return nil
 }

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -87,6 +87,9 @@ func run(argv []string, logger *slog.Logger) (int, error) {
 		if errors.Is(err, backup.ErrSelfTestLowerLastCommitTS) {
 			return exitDataErr, err
 		}
+		if errors.Is(err, backup.ErrEncodeUnsupportedDynamoDBLayout) {
+			return exitDataErr, err
+		}
 		if errors.Is(err, errSelfTestMismatch) {
 			return exitDataErr, err
 		}
@@ -294,6 +297,7 @@ func buildEncodeOptions(cfg *config, effectiveTS uint64, manifest backup.Manifes
 		Adapters:             cfg.adapters,
 		LastCommitTS:         effectiveTS,
 		ManifestLastCommitTS: manifest.LastCommitTS,
+		DynamoDBBundleJSONL:  manifest.DynamoDBLayout == backup.DynamoDBLayoutJSONL,
 		SelfTest:             cfg.selfTest,
 	}
 	if cfg.selfTest {

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -262,10 +262,16 @@ func encodeOne(cfg *config, logger *slog.Logger) error {
 
 	mismatchPath := cfg.outputPath + ".mismatch.txt"
 	_ = os.Remove(mismatchPath) // stale-mismatch cleanup (gemini medium v6 #896)
-	// Stale sidecar cleanup too: a self-test failure rewrites the
-	// sidecar with matched:false (codex P2 v6 #904); make sure the
-	// file always reflects the latest run, not a prior success.
-	_ = os.Remove(backup.EncodeInfoSidecarPath(cfg.outputPath))
+	// Do NOT pre-clean the sidecar here. The sidecar describes the
+	// .fsm at cfg.outputPath; the .fsm is preserved when a run fails
+	// in the adapter encoders (non-self-test exit-2 path), so wiping
+	// its sidecar would leave the prior restore artifact without its
+	// matching provenance metadata (codex P2 v17 #904). writeSidecar
+	// uses O_CREATE|O_TRUNC, so the sidecar is atomically overwritten
+	// on success and on self-test mismatch (where the .fsm is also
+	// replaced or removed in lock-step). On adapter-encoder errors
+	// neither writeSidecar nor removeStaleOutputFSM runs; the prior
+	// .fsm + prior sidecar therefore stay paired.
 
 	result, publishErr := writeAndPublish(cfg, encodeOpts, mismatchPath, logger)
 	// Sidecar is written even on self-test mismatch so an operator

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -437,7 +437,39 @@ func writeAndPublish(cfg *config, encodeOpts backup.EncodeOptions, mismatchPath 
 		return result, errors.Wrap(err, "rename tmp -> output")
 	}
 	publishedTempPath = "" // rename succeeded; defer no-ops
+	// fsync the parent dir so the rename's new directory entry is
+	// durable. Without this, a power loss / host crash immediately
+	// after a successful encode can lose the new <output> entry (or
+	// resurrect the old one) on filesystems where rename durability
+	// requires syncing the containing directory. Mirrors the repo
+	// pattern used by internal/encryption/sidecar.go +
+	// internal/raftengine/etcd/persistence.go (codex P2 v24 #904).
+	if err := fsyncParentDir(cfg.outputPath); err != nil {
+		return result, errors.Wrap(err, "fsync output dir after rename")
+	}
 	return result, nil
+}
+
+// fsyncParentDir opens the parent directory of path read-only and
+// calls fsync on its file descriptor. On most POSIX filesystems this
+// is what makes os.Rename durable. Errors other than path-traversal
+// (which means the operator passed something weird like "" — already
+// rejected upstream) bubble up so the caller can surface them.
+//
+// Mirrors syncDir in internal/encryption/sidecar.go and the etcd
+// raftengine persistence helper; kept local here so the CLI binary
+// doesn't depend on internal/encryption for a 6-line helper.
+func fsyncParentDir(path string) error {
+	dir := filepath.Dir(path)
+	f, err := os.Open(dir) //nolint:gosec // dir is derived from operator-supplied --output path
+	if err != nil {
+		return errors.Wrapf(err, "open parent dir %q", dir)
+	}
+	defer func() { _ = f.Close() }()
+	if err := f.Sync(); err != nil {
+		return errors.Wrapf(err, "fsync parent dir %q", dir)
+	}
+	return nil
 }
 
 // encodeToTempFile creates tempPath, runs EncodeSnapshot into it,
@@ -546,6 +578,12 @@ func writeSidecar(cfg *config, m backup.Manifest, effectiveTS uint64, overridden
 	}
 	if err := f.Close(); err != nil {
 		return errors.WithStack(err)
+	}
+	// fsync the parent dir so the new sidecar's directory entry is
+	// durable alongside its bytes. Mirrors the rename path
+	// (codex P2 v24 #904).
+	if err := fsyncParentDir(sidecarPath); err != nil {
+		return errors.Wrap(err, "fsync sidecar parent dir")
 	}
 	return nil
 }

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -516,6 +516,29 @@ func rollbackOrphanFSMAndSidecar(outputPath string, logger *slog.Logger) {
 		logger.Warn("rollback orphan .fsm after sidecar failure", "err", rerr)
 	}
 	sidecarPath := backup.EncodeInfoSidecarPath(outputPath)
+	// Only remove a sidecar known to be a regular file — i.e., one
+	// this run (or a prior encoder) created. A pre-existing
+	// non-regular entry (operator-placed symlink, FIFO, directory,
+	// etc.) is what OpenSidecarFile correctly refuses to clobber
+	// when the rollback was triggered; os.Remove'ing the
+	// operator's filesystem object merely because the encode
+	// failed would be a destructive side effect (codex P2 v32
+	// #904). Symlinks the operator may have placed are also
+	// preserved here — OpenSidecarFile's O_NOFOLLOW failure means
+	// the symlink was never followed and no truncate happened, so
+	// the link is unchanged and is the operator's to manage.
+	info, err := os.Lstat(sidecarPath)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			logger.Warn("stat sidecar for rollback", "err", err)
+		}
+		return
+	}
+	if !info.Mode().IsRegular() {
+		logger.Warn("skip sidecar rollback: --output sidecar path is not a regular file",
+			"path", sidecarPath, "mode", info.Mode())
+		return
+	}
 	if srerr := os.Remove(sidecarPath); srerr != nil && !errors.Is(srerr, os.ErrNotExist) {
 		logger.Warn("rollback partial sidecar after write failure", "err", srerr)
 	}
@@ -627,21 +650,41 @@ func writeAndPublish(cfg *config, encodeOpts backup.EncodeOptions, mismatchPath 
 		removeStaleOutputFSM(cfg.outputPath, logger)
 		return result, errors.Wrap(errSelfTestMismatch, "self-test diff (see "+mismatchPath+")")
 	}
-	if err := os.Rename(tempPath, cfg.outputPath); err != nil {
-		return result, errors.Wrap(err, "rename tmp -> output")
+	if perr := publishAndFsync(tempPath, cfg.outputPath, logger); perr != nil {
+		return result, perr
 	}
 	publishedTempPath = "" // rename succeeded; defer no-ops
+	return result, nil
+}
+
+// publishAndFsync renames tempPath → outputPath and then fsyncs the
+// parent directory. If the fsync fails, the just-renamed .fsm is
+// removed so the operator does not see a non-durable "successful"
+// .fsm (codex P2 v24 #904 added the fsync; codex P2 v32 #904 added
+// the rollback). Split out of writeAndPublish to keep that function
+// under the cyclop bound.
+func publishAndFsync(tempPath, outputPath string, logger *slog.Logger) error {
+	if err := os.Rename(tempPath, outputPath); err != nil {
+		return errors.Wrap(err, "rename tmp -> output")
+	}
 	// fsync the parent dir so the rename's new directory entry is
 	// durable. Without this, a power loss / host crash immediately
 	// after a successful encode can lose the new <output> entry (or
 	// resurrect the old one) on filesystems where rename durability
 	// requires syncing the containing directory. Mirrors the repo
 	// pattern used by internal/encryption/sidecar.go +
-	// internal/raftengine/etcd/persistence.go (codex P2 v24 #904).
-	if err := fsyncParentDir(cfg.outputPath); err != nil {
-		return result, errors.Wrap(err, "fsync output dir after rename")
+	// internal/raftengine/etcd/persistence.go.
+	if err := fsyncParentDir(outputPath); err != nil {
+		// Roll back so the operator doesn't see a non-durable
+		// "successful" .fsm; restoring the consistent absent state
+		// is the same outcome encodeOne enforces on sidecar-write
+		// failures (codex P2 v32 #904).
+		if rerr := os.Remove(outputPath); rerr != nil && !errors.Is(rerr, os.ErrNotExist) {
+			logger.Warn("rollback orphan .fsm after parent-dir fsync failure", "err", rerr)
+		}
+		return errors.Wrap(err, "fsync output dir after rename")
 	}
-	return result, nil
+	return nil
 }
 
 // fsyncParentDir opens the parent directory of path read-only and

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -197,22 +197,33 @@ func manifestAdapterField(a *backup.Adapters, name string) *backup.Adapter {
 }
 
 // checkOneAdapterScope is the per-adapter half of
-// validateAdaptersAgainstManifest. Selected adapters MUST have a
-// manifest scope; the on-disk subdir requirements depend on whether
-// the scope is empty or has concrete entries. Not-selected adapters
-// are unchecked (the operator chose to skip them).
+// validateAdaptersAgainstManifest. The decoder's populateAdapterScopes
+// explicitly defers scope enumeration and writes `&Adapter{}` (empty)
+// for every enabled adapter regardless of whether records were
+// dumped, so the manifest's scope CONTENT cannot distinguish
+// "this adapter had no records" from "this adapter had records but
+// the decoder didn't enumerate them" (codex P1 v29 #904 corrected
+// v27/v28/v29's over-eager subdir stat-and-readdir checks).
 //
-// Decision matrix (codex P2 v26 + v27 + v28 #904):
+// The only sound nil/non-nil signal is the per-adapter POINTER
+// (`manifest.Adapters.<X>`):
 //
-//   - scope == nil          → fail (producer did not dump this adapter).
-//   - empty scope, subdir absent or empty → pass (no records in dump).
-//   - empty scope, subdir non-empty       → fail (stale data on disk
-//     not declared in manifest — input directory was reused or
-//     partially cleaned).
-//   - non-empty scope, subdir missing or not-a-dir → fail (truncated
-//     dump).
-//   - non-empty scope, subdir is a directory      → pass.
-func checkOneAdapterScope(name string, selected bool, scope *backup.Adapter, subdirPath string) error {
+//   - scope == nil → fail (producer did NOT enable this adapter; any
+//     on-disk subdir is stale and would otherwise be encoded under
+//     the default `--adapter all`, codex P2 v26 #904 scenario B).
+//   - scope != nil → pass (producer enabled the adapter; trust the
+//     manifest contract regardless of the on-disk subdir's
+//     presence/contents).
+//
+// Detecting truncated dumps (codex P2 v26 #904 scenario A: scope
+// non-nil but on-disk subdir lost) needs SHA / record-count
+// verification at the producer side; the manifest alone cannot
+// surface it. Tracked as future work.
+//
+// subdirPath is intentionally unused now but kept in the signature so
+// a future check that pairs the manifest with a SHA index doesn't
+// need a call-site refactor.
+func checkOneAdapterScope(name string, selected bool, scope *backup.Adapter, _ string) error {
 	if !selected {
 		return nil
 	}
@@ -221,65 +232,7 @@ func checkOneAdapterScope(name string, selected bool, scope *backup.Adapter, sub
 			"adapter %q selected but MANIFEST.json has no scope for it (use --adapter to restrict, or re-dump including this adapter)",
 			name)
 	}
-	if isEmptyAdapterScope(scope) {
-		return checkSubdirAbsentOrEmpty(name, subdirPath)
-	}
-	info, err := os.Stat(subdirPath)
-	if err != nil {
-		return errors.Wrapf(errAdapterNotInManifest,
-			"adapter %q listed in MANIFEST.json with non-empty scope but on-disk subdir %s is missing (stat: %v)",
-			name, subdirPath, err)
-	}
-	if !info.IsDir() {
-		return errors.Wrapf(errAdapterNotInManifest,
-			"adapter %q listed in MANIFEST.json but %s is not a directory (mode=%s)",
-			name, subdirPath, info.Mode())
-	}
 	return nil
-}
-
-// checkSubdirAbsentOrEmpty fails closed when an empty-scope adapter
-// has a non-empty on-disk subdir. The empty scope says the producer
-// dumped no records; a populated subdir would otherwise be encoded by
-// cfg.adapters (default `--adapter all`) and silently publish stale
-// data the manifest doesn't claim (codex P2 v28 #904 — the inverse of
-// v27's truncated-dump scenario).
-func checkSubdirAbsentOrEmpty(name, subdirPath string) error {
-	info, err := os.Stat(subdirPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return errors.Wrapf(errAdapterNotInManifest,
-			"adapter %q: stat %s: %v", name, subdirPath, err)
-	}
-	if !info.IsDir() {
-		return errors.Wrapf(errAdapterNotInManifest,
-			"adapter %q: %s is not a directory (mode=%s)", name, subdirPath, info.Mode())
-	}
-	entries, err := os.ReadDir(subdirPath)
-	if err != nil {
-		return errors.Wrapf(errAdapterNotInManifest,
-			"adapter %q: readdir %s: %v", name, subdirPath, err)
-	}
-	if len(entries) != 0 {
-		return errors.Wrapf(errAdapterNotInManifest,
-			"adapter %q has empty scope in MANIFEST.json but %s contains %d entries (stale dump artifacts; clean the directory or re-dump)",
-			name, subdirPath, len(entries))
-	}
-	return nil
-}
-
-// isEmptyAdapterScope reports whether scope has no concrete
-// tables / buckets / databases / queues. A non-nil but empty
-// Adapter{} is the "producer dumped this adapter, no records"
-// signal — distinct from the nil pointer that means "producer did
-// not enable this adapter at all" (codex P2 v27 #904).
-func isEmptyAdapterScope(scope *backup.Adapter) bool {
-	return len(scope.Tables) == 0 &&
-		len(scope.Buckets) == 0 &&
-		len(scope.Databases) == 0 &&
-		len(scope.Queues) == 0
 }
 
 func parseFlags(argv []string) (*config, error) {

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -319,8 +319,10 @@ func writeAndPublish(cfg *config, encodeOpts backup.EncodeOptions, mismatchPath 
 
 // encodeToTempFile creates tempPath, runs EncodeSnapshot into it,
 // fsync+close. Caller is responsible for the os.Remove cleanup on error.
+// The temp file is created mode 0600 so the on-disk .fsm is not
+// world-readable while the encode is in flight (claude v4 #904).
 func encodeToTempFile(tempPath string, encodeOpts backup.EncodeOptions) (backup.EncodeResult, error) {
-	tempFile, err := os.Create(tempPath) //nolint:gosec // operator-supplied path
+	tempFile, err := os.OpenFile(tempPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, encodeInfoFilePerm) //nolint:gosec // operator-supplied path
 	if err != nil {
 		return backup.EncodeResult{}, errors.Wrapf(err, "create %s", tempPath)
 	}
@@ -404,7 +406,10 @@ func writeSidecar(cfg *config, m backup.Manifest, effectiveTS uint64, overridden
 		Matched: result.SelfTestMatched,
 	}
 	sidecarPath := backup.EncodeInfoSidecarPath(cfg.outputPath)
-	f, err := os.Create(sidecarPath) //nolint:gosec // operator-supplied path
+	// 0o600 keeps ENCODE_INFO.json (which includes the source path,
+	// cluster_id, and SHA-256 of the .fsm) from leaking to non-owner
+	// users on multi-user backup hosts (claude v4 #904).
+	f, err := os.OpenFile(sidecarPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, encodeInfoFilePerm) //nolint:gosec // operator-supplied path
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -314,8 +314,10 @@ func buildEncodeOptions(cfg *config, effectiveTS uint64, manifest backup.Manifes
 
 // writeAndPublish writes the .fsm to a temp path, runs the optional
 // self-test via EncodeSnapshot, and renames temp → output on success.
-// On self-test failure: writes mismatch.txt, removes the temp file via
-// the deferred cleanup, returns errSelfTestMismatch.
+// On self-test failure: writes mismatch.txt, removes any stale
+// <output>.fsm left by a prior successful run (codex P2 v10 #904),
+// removes the temp file via the deferred cleanup, returns
+// errSelfTestMismatch.
 func writeAndPublish(cfg *config, encodeOpts backup.EncodeOptions, mismatchPath string, logger *slog.Logger) (backup.EncodeResult, error) {
 	tempPath, err := tempOutputPath(cfg.outputPath)
 	if err != nil {

--- a/cmd/elastickv-snapshot-encode/main.go
+++ b/cmd/elastickv-snapshot-encode/main.go
@@ -1,0 +1,392 @@
+// Command elastickv-snapshot-encode is the Phase 0b M6 snapshot encoder
+// described in docs/design/2026_06_01_proposed_snapshot_encode_cli.md
+// (parent: docs/design/2026_05_25_partial_snapshot_logical_encoder.md).
+//
+// It reads a vendor-independent per-adapter directory tree (produced by
+// elastickv-snapshot-decode or by a future Phase 1 live extractor) and
+// writes a native EKVPBBL1 .fsm a stopped node can load via the
+// stop-replace-restart restore runbook (parent §"Restore via
+// stop-replace-restart").
+//
+// The CLI is offline-only. It does not talk to a running cluster; the
+// receiving cluster loads the output .fsm via its existing snapshot
+// loader on next restart.
+//
+// Atomic publish: the .fsm is written to <output>.tmp-<random> first,
+// fsync+close, then renamed to <output> only after the optional
+// self-test matches. A self-test failure removes the temp file, so a
+// known-bad .fsm never reaches the restore path (codex P2 v2 #896).
+//
+// version is stamped at build time via -ldflags "-X main.version=$(git rev-parse HEAD)".
+// Test builds keep the literal "dev" so CLI-level tests can assert the
+// field is present without depending on a release tag.
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/bootjp/elastickv/internal/backup"
+	"github.com/cockroachdb/errors"
+)
+
+var version = "dev"
+
+const (
+	exitSuccess = 0
+	exitUserErr = 1
+	exitDataErr = 2
+	// tempSuffixHexLen is the hex-character length of the random
+	// suffix appended to <output>.tmp-<hex>; 8 hex chars = 4 bytes of
+	// entropy, which gives ~4×10^9 collision space per --output path
+	// (more than enough for concurrent encodes against the same path).
+	tempSuffixHexLen   = 8
+	tempSuffixByteLen  = tempSuffixHexLen / 2
+	mismatchTxtPerm    = 0o600
+	encodeInfoFilePerm = 0o600
+)
+
+type config struct {
+	inputPath           string
+	outputPath          string
+	adapters            backup.AdapterSet
+	lastCommitTSPresent bool
+	lastCommitTS        uint64
+	selfTest            bool
+	scratchRoot         string
+}
+
+func main() {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	exitCode, err := run(os.Args[1:], logger)
+	if err != nil {
+		logger.Error("elastickv-snapshot-encode", "err", err)
+	}
+	os.Exit(exitCode)
+}
+
+func run(argv []string, logger *slog.Logger) (int, error) {
+	cfg, err := parseFlags(argv)
+	if err != nil {
+		return exitUserErr, err
+	}
+	if err := encodeOne(cfg, logger); err != nil {
+		// Errors from the encoder layer that represent data constraints
+		// (HLC ceiling regression, self-test mismatch) are exit 2; other
+		// errors are exit 1.
+		if errors.Is(err, backup.ErrSelfTestLowerLastCommitTS) {
+			return exitDataErr, err
+		}
+		if errors.Is(err, errSelfTestMismatch) {
+			return exitDataErr, err
+		}
+		return exitUserErr, err
+	}
+	return exitSuccess, nil
+}
+
+func parseFlags(argv []string) (*config, error) {
+	fs := flag.NewFlagSet("elastickv-snapshot-encode", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+
+	var (
+		inputPath   string
+		outputPath  string
+		adapterCSV  string
+		ltsRaw      string
+		selfTest    bool
+		scratchRoot string
+	)
+	fs.StringVar(&inputPath, "input", "", "Directory tree root produced by elastickv-snapshot-decode (required, must contain MANIFEST.json)")
+	fs.StringVar(&outputPath, "output", "", "Destination .fsm file path (required)")
+	fs.StringVar(&adapterCSV, "adapter", "dynamodb,s3,redis,sqs", "Comma-separated subset of adapters to encode")
+	fs.StringVar(&ltsRaw, "last-commit-ts", "", "Override the manifest's last_commit_ts; must be >= manifest value (HLC ceiling can only rise)")
+	fs.BoolVar(&selfTest, "self-test", false, "After encode, decode the produced .fsm and assert it structurally matches --input")
+	fs.StringVar(&scratchRoot, "scratch-root", "", "Base directory for self-test scratch subdir (default os.TempDir); a unique encode-self-test-<random> subdir is always created underneath")
+
+	if err := fs.Parse(argv); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if inputPath == "" {
+		return nil, errors.New("--input is required")
+	}
+	if outputPath == "" {
+		return nil, errors.New("--output is required")
+	}
+	adapters, err := parseAdapterSet(adapterCSV)
+	if err != nil {
+		return nil, err
+	}
+	cfg := &config{
+		inputPath:   inputPath,
+		outputPath:  outputPath,
+		adapters:    adapters,
+		selfTest:    selfTest,
+		scratchRoot: scratchRoot,
+	}
+	if ltsRaw != "" {
+		ts, perr := parseLastCommitTS(ltsRaw)
+		if perr != nil {
+			return nil, perr
+		}
+		cfg.lastCommitTSPresent = true
+		cfg.lastCommitTS = ts
+	}
+	return cfg, nil
+}
+
+// parseLastCommitTS parses --last-commit-ts as a uint64. Hex (0x prefix)
+// or decimal accepted. Negative or out-of-range surfaces as exit-1
+// (flag-parse error); the semantic check (T >= manifest) is exit-2.
+func parseLastCommitTS(raw string) (uint64, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return 0, errors.New("--last-commit-ts is empty")
+	}
+	var ts uint64
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+		if _, err := fmt.Sscanf(s[2:], "%x", &ts); err != nil {
+			return 0, errors.Wrap(err, "--last-commit-ts hex parse")
+		}
+		return ts, nil
+	}
+	if _, err := fmt.Sscanf(s, "%d", &ts); err != nil {
+		return 0, errors.Wrap(err, "--last-commit-ts decimal parse")
+	}
+	return ts, nil
+}
+
+// parseAdapterSet decodes a comma-separated adapter list (or "all").
+// Mirrors the decoder's parser so a typo cannot silently disable an
+// adapter. Unknown name → exit-1.
+func parseAdapterSet(csv string) (backup.AdapterSet, error) {
+	if csv == "" || csv == "all" {
+		return backup.AdapterSet{DynamoDB: true, S3: true, Redis: true, SQS: true}, nil
+	}
+	var set backup.AdapterSet
+	for _, raw := range strings.Split(csv, ",") {
+		name := strings.TrimSpace(strings.ToLower(raw))
+		switch name {
+		case "dynamodb":
+			set.DynamoDB = true
+		case "s3":
+			set.S3 = true
+		case "redis":
+			set.Redis = true
+		case "sqs":
+			set.SQS = true
+		case "":
+			continue
+		default:
+			return backup.AdapterSet{}, errors.Errorf("unknown adapter %q", name)
+		}
+	}
+	return set, nil
+}
+
+// errSelfTestMismatch is a typed sentinel so run() can map self-test diffs
+// to exit-2 without coupling to the encoder's mismatch.txt format.
+var errSelfTestMismatch = errors.New("backup: --self-test diff against --input")
+
+func encodeOne(cfg *config, logger *slog.Logger) error {
+	manifest, err := readInputManifest(cfg.inputPath)
+	if err != nil {
+		return err
+	}
+	effectiveTS, overridden, err := resolveLastCommitTS(cfg, manifest.LastCommitTS)
+	if err != nil {
+		return err
+	}
+	encodeOpts := buildEncodeOptions(cfg, effectiveTS, manifest)
+
+	mismatchPath := cfg.outputPath + ".mismatch.txt"
+	_ = os.Remove(mismatchPath) // stale-mismatch cleanup, gemini medium v6 #896
+
+	result, err := writeAndPublish(cfg, encodeOpts, mismatchPath, logger)
+	if err != nil {
+		return err
+	}
+	if err := writeSidecar(cfg, manifest, effectiveTS, overridden, result); err != nil {
+		return errors.Wrap(err, "write encode_info sidecar")
+	}
+	logger.Info("encode complete",
+		"output", cfg.outputPath,
+		"bytes", result.BytesWritten,
+		"self_test", cfg.selfTest,
+		"adapters", strings.Join(result.AdaptersEnabled, ","),
+	)
+	return nil
+}
+
+// readInputManifest opens + decodes <input>/MANIFEST.json.
+func readInputManifest(inputPath string) (backup.Manifest, error) {
+	manifestPath := filepath.Join(inputPath, "MANIFEST.json")
+	manifestFile, err := os.Open(manifestPath) //nolint:gosec // operator-supplied path
+	if err != nil {
+		return backup.Manifest{}, errors.Wrapf(err, "open %s", manifestPath)
+	}
+	defer func() { _ = manifestFile.Close() }()
+	m, err := backup.ReadManifest(manifestFile)
+	if err != nil {
+		return backup.Manifest{}, errors.Wrap(err, "read manifest")
+	}
+	return m, nil
+}
+
+func buildEncodeOptions(cfg *config, effectiveTS uint64, manifest backup.Manifest) backup.EncodeOptions {
+	encodeOpts := backup.EncodeOptions{
+		InputRoot:    cfg.inputPath,
+		Adapters:     cfg.adapters,
+		LastCommitTS: effectiveTS,
+		SelfTest:     cfg.selfTest,
+	}
+	if cfg.selfTest {
+		encodeOpts.SelfTestDecodeOptions = buildSelfTestDecodeOptions(cfg, manifest)
+	}
+	return encodeOpts
+}
+
+// writeAndPublish writes the .fsm to a temp path, runs the optional
+// self-test via EncodeSnapshot, and renames temp → output on success.
+// On self-test failure: writes mismatch.txt, removes the temp file via
+// the deferred cleanup, returns errSelfTestMismatch.
+func writeAndPublish(cfg *config, encodeOpts backup.EncodeOptions, mismatchPath string, logger *slog.Logger) (backup.EncodeResult, error) {
+	tempPath, err := tempOutputPath(cfg.outputPath)
+	if err != nil {
+		return backup.EncodeResult{}, err
+	}
+	result, err := encodeToTempFile(tempPath, encodeOpts)
+	publishedTempPath := tempPath
+	defer func() {
+		if publishedTempPath != "" {
+			_ = os.Remove(publishedTempPath)
+		}
+	}()
+	if err != nil {
+		return result, err
+	}
+	if cfg.selfTest && !result.SelfTestMatched {
+		if werr := os.WriteFile(mismatchPath, result.SelfTestMismatchTxt, mismatchTxtPerm); werr != nil {
+			logger.Warn("write mismatch.txt", "err", werr)
+		}
+		return result, errors.Wrap(errSelfTestMismatch, "self-test diff (see "+mismatchPath+")")
+	}
+	if err := os.Rename(tempPath, cfg.outputPath); err != nil {
+		return result, errors.Wrap(err, "rename tmp -> output")
+	}
+	publishedTempPath = "" // rename succeeded; defer no-ops
+	return result, nil
+}
+
+// encodeToTempFile creates tempPath, runs EncodeSnapshot into it,
+// fsync+close. Caller is responsible for the os.Remove cleanup on error.
+func encodeToTempFile(tempPath string, encodeOpts backup.EncodeOptions) (backup.EncodeResult, error) {
+	tempFile, err := os.Create(tempPath) //nolint:gosec // operator-supplied path
+	if err != nil {
+		return backup.EncodeResult{}, errors.Wrapf(err, "create %s", tempPath)
+	}
+	result, err := backup.EncodeSnapshot(encodeOpts, tempFile)
+	if err != nil {
+		_ = tempFile.Close()
+		return result, errors.Wrap(err, "EncodeSnapshot")
+	}
+	if err := tempFile.Sync(); err != nil {
+		_ = tempFile.Close()
+		return result, errors.Wrap(err, "fsync tmp")
+	}
+	if err := tempFile.Close(); err != nil {
+		return result, errors.Wrap(err, "close tmp")
+	}
+	return result, nil
+}
+
+// resolveLastCommitTS applies the parent doc's HLC-ceiling-only-rises
+// rule. Returns the effective T, whether an override was applied, and a
+// typed error on regression.
+func resolveLastCommitTS(cfg *config, manifestTS uint64) (uint64, bool, error) {
+	if !cfg.lastCommitTSPresent {
+		return manifestTS, false, nil
+	}
+	if cfg.lastCommitTS < manifestTS {
+		return 0, false, errors.Wrapf(backup.ErrSelfTestLowerLastCommitTS,
+			"--last-commit-ts %d < manifest %d", cfg.lastCommitTS, manifestTS)
+	}
+	return cfg.lastCommitTS, true, nil
+}
+
+// buildSelfTestDecodeOptions translates manifest fields into the
+// DecodeOptions the self-test feeds into DecodeSnapshot, so the scratch
+// tree matches what the original decoder would have produced (codex P2
+// v3 #896).
+func buildSelfTestDecodeOptions(cfg *config, m backup.Manifest) backup.DecodeOptions {
+	opts := backup.DecodeOptions{
+		OutRoot:  cfg.scratchRoot,
+		Adapters: cfg.adapters,
+	}
+	if m.Exclusions != nil {
+		opts.IncludeIncompleteUploads = m.Exclusions.IncludeIncompleteUploads
+		opts.IncludeOrphans = m.Exclusions.IncludeOrphans
+		opts.PreserveSQSVisibility = m.Exclusions.PreserveSQSVisibility
+		opts.IncludeSQSSideRecords = m.Exclusions.IncludeSQSSideRecords
+		opts.RenameS3Collisions = m.Exclusions.RenameS3Collisions
+	}
+	if m.DynamoDBLayout == backup.DynamoDBLayoutJSONL {
+		opts.DynamoDBBundleJSONL = true
+	}
+	return opts
+}
+
+// tempOutputPath returns <output>.tmp-<random> for the write-then-rename
+// atomic publish. crypto/rand provides the suffix so concurrent encodes
+// against the same --output cannot collide.
+func tempOutputPath(output string) (string, error) {
+	buf := make([]byte, tempSuffixByteLen)
+	if _, err := rand.Read(buf); err != nil {
+		return "", errors.Wrap(err, "rand suffix")
+	}
+	return output + ".tmp-" + hex.EncodeToString(buf), nil
+}
+
+// writeSidecar emits ENCODE_INFO.json next to the published .fsm.
+// Path-derived per gemini medium v2 #896.
+func writeSidecar(cfg *config, m backup.Manifest, effectiveTS uint64, overridden bool, result backup.EncodeResult) error {
+	info := backup.NewEncodeInfo(time.Now())
+	info.EncoderVersion = version
+	info.InputRoot = cfg.inputPath
+	info.OutputFSMPath = cfg.outputPath
+	info.OutputFSMSHA256 = hex.EncodeToString(result.SHA256[:])
+	info.LastCommitTS = effectiveTS
+	info.LastCommitTSOverridden = overridden
+	info.ManifestLastCommitTS = m.LastCommitTS
+	info.ManifestClusterID = m.ClusterID
+	info.AdaptersEnabled = result.AdaptersEnabled
+	info.SelfTest = backup.EncodeInfoSelfTest{
+		Ran:     result.SelfTestRan,
+		Matched: result.SelfTestMatched,
+	}
+	sidecarPath := backup.EncodeInfoSidecarPath(cfg.outputPath)
+	f, err := os.Create(sidecarPath) //nolint:gosec // operator-supplied path
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if err := backup.WriteEncodeInfo(f, info); err != nil {
+		_ = f.Close()
+		return errors.Wrap(err, "WriteEncodeInfo")
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return errors.WithStack(err)
+	}
+	if err := f.Close(); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}

--- a/cmd/elastickv-snapshot-encode/main_test.go
+++ b/cmd/elastickv-snapshot-encode/main_test.go
@@ -304,6 +304,78 @@ func readSidecar(t *testing.T, output string) backup.EncodeInfo {
 	return info
 }
 
+// TestCLIAdapterErrorPreservesPriorSidecar pins codex P2 v17 #904: when
+// a run gets past manifest/TS validation and then fails inside an
+// adapter encoder (non-self-test exit-2), the prior <output>.fsm is
+// preserved (only the self-test mismatch path removes it), so the
+// prior <output>.encode_info.json must ALSO be preserved — wiping it
+// while leaving the .fsm would orphan the restore artifact from its
+// provenance metadata. The v17 fix drops the pre-encode sidecar
+// cleanup; this test pins the resulting invariant end-to-end.
+func TestCLIAdapterErrorPreservesPriorSidecar(t *testing.T) {
+	t.Parallel()
+	in, out, priorFSM, priorSidecar := setupAdapterErrorFixture(t)
+	code, err := run([]string{
+		"--input", in,
+		"--output", out,
+		"--adapter", "dynamodb",
+	}, quietLogger())
+	if err == nil {
+		t.Fatalf("run succeeded; want adapter-data rejection")
+	}
+	if code != exitDataErr {
+		t.Errorf("exit code = %d, want %d", code, exitDataErr)
+	}
+	assertFilePreserved(t, out, priorFSM, "prior .fsm")
+	// Prior sidecar unchanged (codex P2 v17: the v17 fix drops the
+	// pre-encode sidecar cleanup so the sidecar+.fsm stay paired).
+	assertFilePreserved(t, out+".encode_info.json", priorSidecar, "prior sidecar")
+}
+
+// setupAdapterErrorFixture builds a fixture for
+// TestCLIAdapterErrorPreservesPriorSidecar: an InputRoot with a valid
+// MANIFEST.json plus a malformed dynamodb _schema.json (empty
+// table_name → ErrDDBEncodeInvalidSchema), and a pre-placed FSM +
+// sidecar at the output path representing a hypothetical earlier
+// successful run. Returns (inputRoot, outputPath, priorFSMBytes,
+// priorSidecarBytes).
+func setupAdapterErrorFixture(t *testing.T) (string, string, []byte, []byte) {
+	t.Helper()
+	in := t.TempDir()
+	emitMinimalManifest(t, in, 1000)
+	out := filepath.Join(t.TempDir(), "out.fsm")
+	priorFSM := []byte("PRIOR FSM BYTES")
+	priorSidecar := []byte(`{"format_version":1,"encoder_version":"prior","input_root":"x","output_fsm_path":"x"}`)
+	if err := os.WriteFile(out, priorFSM, 0o600); err != nil {
+		t.Fatalf("WriteFile prior fsm: %v", err)
+	}
+	if err := os.WriteFile(out+".encode_info.json", priorSidecar, 0o600); err != nil {
+		t.Fatalf("WriteFile prior sidecar: %v", err)
+	}
+	schemaDir := filepath.Join(in, "dynamodb", "tbl")
+	if err := os.MkdirAll(schemaDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	body := []byte(`{"format_version":1,"table_name":"","primary_key":{"hash_key":{"name":"id","type":"S"}}}`)
+	if err := os.WriteFile(filepath.Join(schemaDir, "_schema.json"), body, 0o600); err != nil {
+		t.Fatalf("WriteFile bad schema: %v", err)
+	}
+	return in, out, priorFSM, priorSidecar
+}
+
+// assertFilePreserved asserts the named file is still present and its
+// contents exactly match wantBody. label appears in error messages.
+func assertFilePreserved(t *testing.T, path string, wantBody []byte, label string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s at %s: %v", label, path, err)
+	}
+	if !bytes.Equal(got, wantBody) {
+		t.Errorf("%s mutated; codex P2 v17 expected adapter-error to preserve", label)
+	}
+}
+
 // TestCLISelfTestMismatchSkipsDirectoryAtOutputPath pins codex P2 v14
 // #904: the self-test-mismatch cleanup must NOT delete an --output
 // path that resolves to a directory (or any non-regular file). The

--- a/cmd/elastickv-snapshot-encode/main_test.go
+++ b/cmd/elastickv-snapshot-encode/main_test.go
@@ -906,6 +906,55 @@ func TestParseLastCommitTS(t *testing.T) {
 	}
 }
 
+// TestCLISidecarWriteRefusesSymlinkTarget pins codex P2 v25 #904: the
+// CLI's encode_info sidecar writer must not follow a pre-existing
+// symlink at <output>.encode_info.json. An attacker (or a confused
+// shared-host config) could plant a symlink pointing at a sensitive
+// file the encoding user can write; the prior os.OpenFile + O_TRUNC
+// path would have truncated that target and then written the JSON
+// blob to it. backup.OpenSidecarFile refuses the open with ELOOP on
+// unix. Skipped on Windows where symlink semantics differ and the
+// Windows variant of OpenSidecarFile uses the Lstat-then-OpenFile
+// guard.
+func TestCLISidecarWriteRefusesSymlinkTarget(t *testing.T) {
+	if isWindows {
+		t.Skip("symlink-refusal semantics differ on Windows")
+	}
+	t.Parallel()
+	in := t.TempDir()
+	emitMinimalManifest(t, in, 100)
+
+	outDir := t.TempDir()
+	out := filepath.Join(outDir, "out.fsm")
+	sidecarPath := backup.EncodeInfoSidecarPath(out)
+	// Pre-plant the attacker's victim file and the symlink.
+	victimDir := t.TempDir()
+	victim := filepath.Join(victimDir, "victim.json")
+	const victimBody = "VICTIM CONTENTS — must survive sidecar write"
+	if err := os.WriteFile(victim, []byte(victimBody), 0o600); err != nil {
+		t.Fatalf("WriteFile victim: %v", err)
+	}
+	if err := os.Symlink(victim, sidecarPath); err != nil {
+		t.Fatalf("Symlink at sidecar path: %v", err)
+	}
+
+	code, err := run([]string{"--input", in, "--output", out}, quietLogger())
+	if err == nil {
+		t.Fatalf("run succeeded; want sidecar open to fail on symlinked path")
+	}
+	if code != exitUserErr {
+		t.Errorf("exit code = %d, want %d (operator-env error, not data-correctness)", code, exitUserErr)
+	}
+	// Victim file MUST be untouched.
+	got, rerr := os.ReadFile(victim)
+	if rerr != nil {
+		t.Fatalf("read victim: %v", rerr)
+	}
+	if string(got) != victimBody {
+		t.Errorf("victim mutated; OpenSidecarFile followed the symlink (codex P2 v25 regression)")
+	}
+}
+
 // TestCLIPublishesFsmAndSidecarMode0600 pins claude v4 #904: the
 // produced .fsm and ENCODE_INFO.json are created with mode 0o600 so a
 // multi-user backup host does not get a world-readable dataset. The

--- a/cmd/elastickv-snapshot-encode/main_test.go
+++ b/cmd/elastickv-snapshot-encode/main_test.go
@@ -275,14 +275,17 @@ func canonicalizeInput(t *testing.T, rawIn string, lastCommitTS uint64) string {
 	if err != nil || code != exitSuccess {
 		t.Fatalf("canonical encode: code=%d err=%v", code, err)
 	}
-	f, _ := os.Open(tmpOut)
+	f, oerr := os.Open(tmpOut)
+	if oerr != nil {
+		t.Fatalf("open canonical output: %v", oerr)
+	}
+	defer func() { _ = f.Close() }()
 	if _, err := backup.DecodeSnapshot(f, backup.DecodeOptions{
 		OutRoot:  canonicalIn,
 		Adapters: backup.AdapterSet{SQS: true},
 	}); err != nil {
 		t.Fatalf("canonical decode: %v", err)
 	}
-	_ = f.Close()
 	emitMinimalManifest(t, canonicalIn, lastCommitTS)
 	return canonicalIn
 }
@@ -457,25 +460,27 @@ func TestCLIRoundTripSelfTestAllAdapters(t *testing.T) {
 	}
 }
 
-// TestCLISelfTestMismatchWritesSidecarWithMatchedFalse pins codex P2 v6
-// #904: when --self-test detects a mismatch, the CLI MUST still write
-// <output>.encode_info.json with self_test.matched=false alongside
-// <output>.mismatch.txt. Operators need both files to diagnose a
-// failed self-test (sidecar carries SHA256, effective T, adapters).
+// TestCLIManifestFloorLeavesNoStaleSidecar pins that the
+// manifest-floor preflight failure (--last-commit-ts T < manifest;
+// fails in resolveLastCommitTS BEFORE writeAndPublish) leaves NO
+// <output>.encode_info.json on disk — neither a fresh one nor a
+// stale one from a prior run (the pre-encode cleanup at the start
+// of encodeOne removes it).
 //
-// Driven via --last-commit-ts T < manifest (data-error path) since
-// that's the only deterministic CLI-level mismatch trigger; a real
-// self-test mismatch needs the same write path. Future cleanup: when
-// the library-level corruption hook is exposed via a build-tagged
-// CLI test seam, switch to a real self-test mismatch trigger.
-func TestCLISelfTestMismatchWritesSidecarWithMatchedFalse(t *testing.T) {
+// Note: the test name was previously TestCLISelfTestMismatchWritesSidecarWithMatchedFalse,
+// which contradicted the assertion (the encode does NOT run on this
+// path, so no sidecar is written). The actual sidecar-on-mismatch
+// behavior is now pinned end-to-end by
+// TestCLIWriteAndPublishRemovesStaleFSMOnSelfTestMismatch using the
+// CLI-level corruption seam (codex P2 v6/v10 #904; claude v12 rename).
+func TestCLIManifestFloorLeavesNoStaleSidecar(t *testing.T) {
 	t.Parallel()
-	// We can drive a real self-test mismatch path at the library
-	// level (covered by TestEncodeSnapshotSelfTestDetectsCorruption).
-	// At the CLI level, we additionally need to confirm the sidecar
-	// is published on the data-error branch — the manifest-floor
-	// regression path that exit-2's via the same wrap-then-return
-	// code that previously skipped writeSidecar.
+	// The pre-encode cleanup at the top of encodeOne removes any
+	// stale <output>.encode_info.json before writeAndPublish runs.
+	// On the manifest-floor path, resolveLastCommitTS exits with
+	// exit-2 BEFORE that cleanup even runs (it's the second step in
+	// encodeOne after readInputManifest). So the assertion is: a
+	// fresh TempDir produces no sidecar at all.
 	in := t.TempDir()
 	emitMinimalManifest(t, in, 1000)
 	out := filepath.Join(t.TempDir(), "out.fsm")

--- a/cmd/elastickv-snapshot-encode/main_test.go
+++ b/cmd/elastickv-snapshot-encode/main_test.go
@@ -118,6 +118,73 @@ func TestCLIAdapterDataErrorExitsTwo(t *testing.T) {
 	}
 }
 
+// TestCLIRejectsUnsupportedManifestExclusions pins codex P2 v21 #904
+// end-to-end: when MANIFEST.json sets one of the three exclusion
+// flags the encoder cannot honor (include_incomplete_uploads,
+// include_orphans, preserve_sqs_visibility) AND the corresponding
+// adapter is enabled, the CLI must exit 2 (data-correctness) before
+// any bytes are written. Mirrors the DynamoDB JSONL guard.
+func TestCLIRejectsUnsupportedManifestExclusions(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		mutate   func(*backup.Exclusions)
+		adapters string
+	}{
+		{
+			name:     "include_incomplete_uploads with --adapter=s3",
+			mutate:   func(e *backup.Exclusions) { e.IncludeIncompleteUploads = true },
+			adapters: "s3",
+		},
+		{
+			name:     "include_orphans with --adapter=s3",
+			mutate:   func(e *backup.Exclusions) { e.IncludeOrphans = true },
+			adapters: "s3",
+		},
+		{
+			name:     "preserve_sqs_visibility with --adapter=sqs",
+			mutate:   func(e *backup.Exclusions) { e.PreserveSQSVisibility = true },
+			adapters: "sqs",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			in := t.TempDir()
+			m := backup.NewPhase0SnapshotManifest(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+			m.LastCommitTS = 100
+			m.Adapters = &backup.Adapters{}
+			m.Exclusions = &backup.Exclusions{}
+			tc.mutate(m.Exclusions)
+			f, ferr := os.Create(filepath.Join(in, "MANIFEST.json"))
+			if ferr != nil {
+				t.Fatalf("create MANIFEST.json: %v", ferr)
+			}
+			if werr := backup.WriteManifest(f, m); werr != nil {
+				t.Fatalf("WriteManifest: %v", werr)
+			}
+			if cerr := f.Close(); cerr != nil {
+				t.Fatalf("close: %v", cerr)
+			}
+			out := filepath.Join(t.TempDir(), "out.fsm")
+			code, err := run([]string{
+				"--input", in,
+				"--output", out,
+				"--adapter", tc.adapters,
+			}, quietLogger())
+			if err == nil {
+				t.Fatalf("run succeeded; want exit-2 from unsupported manifest exclusion")
+			}
+			if code != exitDataErr {
+				t.Errorf("exit code = %d, want %d (data-correctness for unsupported exclusion)", code, exitDataErr)
+			}
+			if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+				t.Errorf(".fsm exists at %s; should not be published on unsupported-feature rejection", out)
+			}
+		})
+	}
+}
+
 // TestCLIRejectsLowerLastCommitTSOverride is the fail-closed pin per
 // parent §"MVCC re-encoding": T < manifest.last_commit_ts → exit 2
 // (data-correctness failure, not flag-parse error).

--- a/cmd/elastickv-snapshot-encode/main_test.go
+++ b/cmd/elastickv-snapshot-encode/main_test.go
@@ -7,11 +7,16 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
 	"github.com/bootjp/elastickv/internal/backup"
 )
+
+// isWindows is true on Windows builds; perm-bit tests skip on Windows
+// where Unix-style modes are not meaningful.
+var isWindows = runtime.GOOS == "windows"
 
 // emitMinimalManifest writes a minimal valid MANIFEST.json under outRoot
 // with the given lastCommitTS. Used by every CLI test as the producer-
@@ -360,6 +365,39 @@ func TestParseLastCommitTS(t *testing.T) {
 	} {
 		if _, err := parseLastCommitTS(bad); err == nil {
 			t.Errorf("%q parsed successfully; want error", bad)
+		}
+	}
+}
+
+// TestCLIPublishesFsmAndSidecarMode0600 pins claude v4 #904: the
+// produced .fsm and ENCODE_INFO.json are created with mode 0o600 so a
+// multi-user backup host does not get a world-readable dataset. The
+// earlier os.Create-based path relied on umask (typically 0644).
+//
+// Skips on Windows where Unix-style perm bits are not meaningful.
+func TestCLIPublishesFsmAndSidecarMode0600(t *testing.T) {
+	t.Parallel()
+	if isWindows {
+		t.Skip("perm bits not meaningful on Windows")
+	}
+	in := t.TempDir()
+	emitMinimalManifest(t, in, 100)
+	out := filepath.Join(t.TempDir(), "out.fsm")
+	code, err := run([]string{"--input", in, "--output", out}, quietLogger())
+	if err != nil || code != exitSuccess {
+		t.Fatalf("run failed: code=%d err=%v", code, err)
+	}
+	for _, p := range []string{out, out + ".encode_info.json"} {
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatalf("stat %s: %v", p, err)
+		}
+		// Only check the owner bits (rwx); umask cannot widen beyond
+		// what OpenFile requested but a misconfigured fs.ModeSticky
+		// or similar could theoretically narrow. We just assert no
+		// group/other access bits are set.
+		if perm := info.Mode().Perm(); perm&0o077 != 0 {
+			t.Errorf("%s mode = %o, want no group/other bits (0o600 or stricter)", p, perm)
 		}
 	}
 }

--- a/cmd/elastickv-snapshot-encode/main_test.go
+++ b/cmd/elastickv-snapshot-encode/main_test.go
@@ -267,7 +267,12 @@ func writeSQSFixture(t *testing.T, root string) {
 // encoder's output shape. Subsequent self-tests against the canonical
 // tree are byte-equal (any non-canonical formatting differences are
 // flattened by this first pass).
-func canonicalizeInput(t *testing.T, rawIn string, lastCommitTS uint64) string {
+// canonicalRoundTripTS is the fixed last_commit_ts used by every
+// canonicalizeInput call site. Kept as a const so a future test that
+// wants a different value can lift it back into a parameter.
+const canonicalRoundTripTS uint64 = 7000
+
+func canonicalizeInput(t *testing.T, rawIn string) string {
 	t.Helper()
 	canonicalIn := t.TempDir()
 	tmpOut := filepath.Join(t.TempDir(), "canonical.fsm")
@@ -286,8 +291,37 @@ func canonicalizeInput(t *testing.T, rawIn string, lastCommitTS uint64) string {
 	}); err != nil {
 		t.Fatalf("canonical decode: %v", err)
 	}
-	emitMinimalManifest(t, canonicalIn, lastCommitTS)
+	emitMinimalManifest(t, canonicalIn, canonicalRoundTripTS)
 	return canonicalIn
+}
+
+// flipBytesPastHeaderInTempCorruptHook returns a corrupt-buffer hook
+// that flips one byte every 13 starting at offset 200 in the on-disk
+// self-test buffer — the same pattern as the library's
+// flipBytesPastHeaderHelper. Extracted so the three CLI mismatch
+// tests share one body rather than each open-coding the same loop.
+func flipBytesPastHeaderInTempCorruptHook(t *testing.T) func(*os.File) {
+	t.Helper()
+	return func(f *os.File) {
+		info, ferr := f.Stat()
+		if ferr != nil {
+			t.Fatalf("temp Stat: %v", ferr)
+		}
+		const headerSkip = 200
+		if info.Size() <= headerSkip {
+			t.Fatalf("temp file too small to corrupt past header: %d bytes", info.Size())
+		}
+		buf := make([]byte, info.Size()-headerSkip)
+		if _, rerr := f.ReadAt(buf, headerSkip); rerr != nil {
+			t.Fatalf("ReadAt: %v", rerr)
+		}
+		for i := 0; i < len(buf); i += 13 {
+			buf[i] ^= 0xFF
+		}
+		if _, werr := f.WriteAt(buf, headerSkip); werr != nil {
+			t.Fatalf("WriteAt: %v", werr)
+		}
+	}
 }
 
 // readSidecar reads <output>.encode_info.json into an EncodeInfo struct.
@@ -392,7 +426,7 @@ func TestCLISelfTestMismatchSkipsDirectoryAtOutputPath(t *testing.T) {
 	rawIn := t.TempDir()
 	writeSQSFixture(t, rawIn)
 	emitMinimalManifest(t, rawIn, 7000)
-	canonicalIn := canonicalizeInput(t, rawIn, 7000)
+	canonicalIn := canonicalizeInput(t, rawIn)
 
 	out := filepath.Join(t.TempDir(), "out.fsm")
 	// Pre-create a directory at the --output path — an operator
@@ -413,26 +447,7 @@ func TestCLISelfTestMismatchSkipsDirectoryAtOutputPath(t *testing.T) {
 			Adapters: backup.AdapterSet{SQS: true},
 		},
 	}
-	encodeOpts.SetSelfTestCorruptHookForTest(func(f *os.File) {
-		info, ferr := f.Stat()
-		if ferr != nil {
-			t.Fatalf("temp Stat: %v", ferr)
-		}
-		const headerSkip = 200
-		if info.Size() <= headerSkip {
-			t.Fatalf("temp file too small to corrupt: %d", info.Size())
-		}
-		buf := make([]byte, info.Size()-headerSkip)
-		if _, rerr := f.ReadAt(buf, headerSkip); rerr != nil {
-			t.Fatalf("ReadAt: %v", rerr)
-		}
-		for i := 0; i < len(buf); i += 13 {
-			buf[i] ^= 0xFF
-		}
-		if _, werr := f.WriteAt(buf, headerSkip); werr != nil {
-			t.Fatalf("WriteAt: %v", werr)
-		}
-	})
+	encodeOpts.SetSelfTestCorruptHookForTest(flipBytesPastHeaderInTempCorruptHook(t))
 
 	cfg := &config{
 		inputPath:  canonicalIn,
@@ -496,6 +511,80 @@ func TestCLIInvalidManifestExitsTwo(t *testing.T) {
 	})
 }
 
+// TestCLISelfTestMismatchRemovesSymlinkOutputButPreservesTarget pins
+// codex P2 v19 #904: when --output is a symlink to a prior .fsm file
+// and the new --self-test invocation mismatches, the cleanup must
+// unlink the symlink (so the restore-visible --output path now
+// resolves to ENOENT, matching the mismatch contract) while leaving
+// the underlying target file intact (os.Remove on a symlink operates
+// on the link, not the resolved target).
+//
+// Before v21 the IsRegular()-only check silently skipped the symlink
+// cleanup; the new sidecar (matched=false) then described a fresh
+// failed encode while --output still resolved to a prior valid .fsm,
+// breaking the "no restore-visible FSM after self-test mismatch"
+// invariant. Linux-only because Windows symlink semantics differ.
+func TestCLISelfTestMismatchRemovesSymlinkOutputButPreservesTarget(t *testing.T) {
+	if isWindows {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	t.Parallel()
+	rawIn := t.TempDir()
+	writeSQSFixture(t, rawIn)
+	emitMinimalManifest(t, rawIn, 7000)
+	canonicalIn := canonicalizeInput(t, rawIn)
+
+	targetDir := t.TempDir()
+	target := filepath.Join(targetDir, "real.fsm")
+	const targetBody = "TARGET FSM BYTES (must survive symlink removal)"
+	if err := os.WriteFile(target, []byte(targetBody), 0o600); err != nil {
+		t.Fatalf("WriteFile target: %v", err)
+	}
+	out := filepath.Join(t.TempDir(), "out.fsm")
+	if err := os.Symlink(target, out); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	scratchBase := t.TempDir()
+	encodeOpts := backup.EncodeOptions{
+		InputRoot:            canonicalIn,
+		Adapters:             backup.AdapterSet{SQS: true},
+		LastCommitTS:         7000,
+		ManifestLastCommitTS: 7000,
+		SelfTest:             true,
+		SelfTestDecodeOptions: backup.DecodeOptions{
+			OutRoot:  scratchBase,
+			Adapters: backup.AdapterSet{SQS: true},
+		},
+	}
+	encodeOpts.SetSelfTestCorruptHookForTest(flipBytesPastHeaderInTempCorruptHook(t))
+
+	cfg := &config{
+		inputPath:  canonicalIn,
+		outputPath: out,
+		adapters:   backup.AdapterSet{SQS: true},
+		selfTest:   true,
+	}
+	mismatchPath := out + ".mismatch.txt"
+
+	_, publishErr := writeAndPublish(cfg, encodeOpts, mismatchPath, quietLogger())
+	if !errors.Is(publishErr, errSelfTestMismatch) {
+		t.Fatalf("publishErr = %v, want errSelfTestMismatch", publishErr)
+	}
+	// --output (the symlink) must now resolve to ENOENT.
+	if _, statErr := os.Lstat(out); !os.IsNotExist(statErr) {
+		t.Errorf("symlink at --output not removed after mismatch (codex P2 v19 regression)")
+	}
+	// The target file (which the symlink pointed to) must survive.
+	gotTarget, rerr := os.ReadFile(target)
+	if rerr != nil {
+		t.Fatalf("target file vanished (os.Remove operated on resolved target instead of symlink): %v", rerr)
+	}
+	if string(gotTarget) != targetBody {
+		t.Errorf("target body mutated; want preserved")
+	}
+}
+
 // TestCLIWriteAndPublishRemovesStaleFSMOnSelfTestMismatch pins codex
 // P2 v10 #904: when a prior successful run left an <output>.fsm on
 // disk and a new --self-test invocation produces a mismatch,
@@ -514,7 +603,7 @@ func TestCLIWriteAndPublishRemovesStaleFSMOnSelfTestMismatch(t *testing.T) {
 	rawIn := t.TempDir()
 	writeSQSFixture(t, rawIn)
 	emitMinimalManifest(t, rawIn, 7000)
-	canonicalIn := canonicalizeInput(t, rawIn, 7000)
+	canonicalIn := canonicalizeInput(t, rawIn)
 
 	out := filepath.Join(t.TempDir(), "out.fsm")
 	// Pre-place a stale .fsm — what a prior successful run would have
@@ -539,27 +628,7 @@ func TestCLIWriteAndPublishRemovesStaleFSMOnSelfTestMismatch(t *testing.T) {
 	}
 	// Flip bytes past the EKVPBBL1 header so the re-decode trips on
 	// a malformed entry length and the self-test returns matched=false.
-	// Pattern mirrors flipBytesPastHeaderHelper in the library test.
-	encodeOpts.SetSelfTestCorruptHookForTest(func(f *os.File) {
-		info, ferr := f.Stat()
-		if ferr != nil {
-			t.Fatalf("temp Stat: %v", ferr)
-		}
-		const headerSkip = 200
-		if info.Size() <= headerSkip {
-			t.Fatalf("temp file too small to corrupt past header: %d bytes", info.Size())
-		}
-		buf := make([]byte, info.Size()-headerSkip)
-		if _, rerr := f.ReadAt(buf, headerSkip); rerr != nil {
-			t.Fatalf("ReadAt: %v", rerr)
-		}
-		for i := 0; i < len(buf); i += 13 {
-			buf[i] ^= 0xFF
-		}
-		if _, werr := f.WriteAt(buf, headerSkip); werr != nil {
-			t.Fatalf("WriteAt: %v", werr)
-		}
-	})
+	encodeOpts.SetSelfTestCorruptHookForTest(flipBytesPastHeaderInTempCorruptHook(t))
 
 	cfg := &config{
 		inputPath:  canonicalIn,
@@ -628,7 +697,7 @@ func TestCLIRoundTripSelfTestAllAdapters(t *testing.T) {
 	rawIn := t.TempDir()
 	writeSQSFixture(t, rawIn)
 	emitMinimalManifest(t, rawIn, 7000)
-	canonicalIn := canonicalizeInput(t, rawIn, 7000)
+	canonicalIn := canonicalizeInput(t, rawIn)
 
 	out := filepath.Join(t.TempDir(), "out.fsm")
 	code, err := run([]string{

--- a/cmd/elastickv-snapshot-encode/main_test.go
+++ b/cmd/elastickv-snapshot-encode/main_test.go
@@ -22,11 +22,28 @@ var isWindows = runtime.GOOS == "windows"
 // emitMinimalManifest writes a minimal valid MANIFEST.json under outRoot
 // with the given lastCommitTS. Used by every CLI test as the producer-
 // side artifact the encoder will consume.
+//
+// Populates manifest.Adapters with ALL FOUR adapter scopes (each as
+// a non-nil &Adapter{} so the codex P2 v26 #904 validation
+// — validateAdaptersAgainstManifest — sees a manifest that claims
+// every adapter was dumped. Also creates an empty subdir for each
+// adapter under outRoot so the same validation's on-disk-stat guard
+// passes (the encoder treats an empty subdir as no-op, matching the
+// "no records to encode" semantics).
+//
+// Tests that need to assert rejection on specific adapter-scope
+// scenarios (e.g. manifest missing one adapter) can mutate the
+// manifest or filesystem after this returns.
 func emitMinimalManifest(t *testing.T, outRoot string, lastCommitTS uint64) {
 	t.Helper()
 	m := backup.NewPhase0SnapshotManifest(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
 	m.LastCommitTS = lastCommitTS
-	m.Adapters = &backup.Adapters{}
+	m.Adapters = &backup.Adapters{
+		DynamoDB: &backup.Adapter{},
+		S3:       &backup.Adapter{},
+		Redis:    &backup.Adapter{},
+		SQS:      &backup.Adapter{},
+	}
 	m.Exclusions = &backup.Exclusions{}
 	f, err := os.Create(filepath.Join(outRoot, "MANIFEST.json"))
 	if err != nil {
@@ -37,6 +54,11 @@ func emitMinimalManifest(t *testing.T, outRoot string, lastCommitTS uint64) {
 	}
 	if err := f.Close(); err != nil {
 		t.Fatalf("close: %v", err)
+	}
+	for _, sub := range []string{"dynamodb", "s3", "redis", "sqs"} {
+		if mkErr := os.MkdirAll(filepath.Join(outRoot, sub), 0o755); mkErr != nil {
+			t.Fatalf("MkdirAll %s: %v", sub, mkErr)
+		}
 	}
 }
 
@@ -182,6 +204,82 @@ func TestCLIRejectsUnsupportedManifestExclusions(t *testing.T) {
 				t.Errorf(".fsm exists at %s; should not be published on unsupported-feature rejection", out)
 			}
 		})
+	}
+}
+
+// TestCLIRejectsAdapterNotInManifest pins codex P2 v26 #904 scenario B:
+// the user enables an adapter (default `--adapter` is all four) but
+// MANIFEST.json doesn't list a scope for it. The prior code would
+// pick up a stale on-disk subdir for an unlisted adapter; the new
+// guard rejects with exit 2.
+func TestCLIRejectsAdapterNotInManifest(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	// Manifest lists ONLY SQS (no DynamoDB / S3 / Redis), but the
+	// default `--adapter dynamodb,s3,redis,sqs` enables all four.
+	m := backup.NewPhase0SnapshotManifest(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	m.LastCommitTS = 100
+	m.Adapters = &backup.Adapters{SQS: &backup.Adapter{}}
+	m.Exclusions = &backup.Exclusions{}
+	f, ferr := os.Create(filepath.Join(in, "MANIFEST.json"))
+	if ferr != nil {
+		t.Fatalf("create MANIFEST.json: %v", ferr)
+	}
+	if werr := backup.WriteManifest(f, m); werr != nil {
+		t.Fatalf("WriteManifest: %v", werr)
+	}
+	if cerr := f.Close(); cerr != nil {
+		t.Fatalf("close: %v", cerr)
+	}
+	// Operator forgot to restrict --adapter; encoder must NOT silently
+	// pick up the (absent) dynamodb/s3/redis subtrees just because
+	// the CLI default enables them.
+	out := filepath.Join(t.TempDir(), "out.fsm")
+	code, err := run([]string{"--input", in, "--output", out}, quietLogger())
+	if err == nil {
+		t.Fatalf("run succeeded; want adapter-scope rejection")
+	}
+	if code != exitDataErr {
+		t.Errorf("exit code = %d, want %d (data-correctness)", code, exitDataErr)
+	}
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Errorf(".fsm should not be published on adapter-scope rejection")
+	}
+}
+
+// TestCLIRejectsAdapterListedButSubdirMissing pins codex P2 v26 #904
+// scenario A: the manifest lists an adapter (non-nil scope) but the
+// matching on-disk subdir is missing. The per-adapter encoder would
+// no-op silently and publish a partial/header-only .fsm; the new
+// guard rejects up front with exit 2.
+func TestCLIRejectsAdapterListedButSubdirMissing(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	// Manifest lists SQS only; do NOT create sqs/ on disk.
+	m := backup.NewPhase0SnapshotManifest(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	m.LastCommitTS = 100
+	m.Adapters = &backup.Adapters{SQS: &backup.Adapter{Queues: []string{"q1"}}}
+	m.Exclusions = &backup.Exclusions{}
+	f, ferr := os.Create(filepath.Join(in, "MANIFEST.json"))
+	if ferr != nil {
+		t.Fatalf("create MANIFEST.json: %v", ferr)
+	}
+	if werr := backup.WriteManifest(f, m); werr != nil {
+		t.Fatalf("WriteManifest: %v", werr)
+	}
+	if cerr := f.Close(); cerr != nil {
+		t.Fatalf("close: %v", cerr)
+	}
+	out := filepath.Join(t.TempDir(), "out.fsm")
+	code, err := run([]string{"--input", in, "--output", out, "--adapter", "sqs"}, quietLogger())
+	if err == nil {
+		t.Fatalf("run succeeded; want truncated-dump rejection")
+	}
+	if code != exitDataErr {
+		t.Errorf("exit code = %d, want %d (data-correctness)", code, exitDataErr)
+	}
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Errorf(".fsm should not be published on adapter-scope rejection")
 	}
 }
 

--- a/cmd/elastickv-snapshot-encode/main_test.go
+++ b/cmd/elastickv-snapshot-encode/main_test.go
@@ -23,26 +23,28 @@ var isWindows = runtime.GOOS == "windows"
 // with the given lastCommitTS. Used by every CLI test as the producer-
 // side artifact the encoder will consume.
 //
-// Populates manifest.Adapters with ALL FOUR adapter scopes (each as
-// a non-nil &Adapter{} so the codex P2 v26 #904 validation
-// — validateAdaptersAgainstManifest — sees a manifest that claims
-// every adapter was dumped. Also creates an empty subdir for each
-// adapter under outRoot so the same validation's on-disk-stat guard
-// passes (the encoder treats an empty subdir as no-op, matching the
-// "no records to encode" semantics).
+// Populates manifest.Adapters with a non-nil &Adapter{} per adapter,
+// matching what the decoder's populateAdapterScopes would emit. When
+// the corresponding on-disk subdir is already populated (e.g. a
+// writeSQSFixture call ran before emitMinimalManifest), this helper
+// scans the subdir and stamps a placeholder scope entry of the right
+// kind (Tables / Buckets / Databases / Queues) so v29's adapter-scope
+// validation sees a manifest that matches the on-disk shape (codex
+// P2 v28 #904 — empty scope + non-empty subdir was the bug).
 //
-// Tests that need to assert rejection on specific adapter-scope
-// scenarios (e.g. manifest missing one adapter) can mutate the
-// manifest or filesystem after this returns.
+// Then creates empty subdirs for any adapter not already populated so
+// validateAdaptersAgainstManifest's empty-scope-empty-subdir branch
+// passes. Tests that need a specific adapter-scope mismatch bypass
+// this helper and write a custom manifest.
 func emitMinimalManifest(t *testing.T, outRoot string, lastCommitTS uint64) {
 	t.Helper()
 	m := backup.NewPhase0SnapshotManifest(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
 	m.LastCommitTS = lastCommitTS
 	m.Adapters = &backup.Adapters{
-		DynamoDB: &backup.Adapter{},
-		S3:       &backup.Adapter{},
-		Redis:    &backup.Adapter{},
-		SQS:      &backup.Adapter{},
+		DynamoDB: scopeForPopulatedSubdir(t, outRoot, "dynamodb", "tables"),
+		S3:       scopeForPopulatedSubdir(t, outRoot, "s3", "buckets"),
+		Redis:    scopeForPopulatedSubdir(t, outRoot, "redis", "databases"),
+		SQS:      scopeForPopulatedSubdir(t, outRoot, "sqs", "queues"),
 	}
 	m.Exclusions = &backup.Exclusions{}
 	f, err := os.Create(filepath.Join(outRoot, "MANIFEST.json"))
@@ -60,6 +62,31 @@ func emitMinimalManifest(t *testing.T, outRoot string, lastCommitTS uint64) {
 			t.Fatalf("MkdirAll %s: %v", sub, mkErr)
 		}
 	}
+}
+
+// scopeForPopulatedSubdir returns an empty Adapter{} when the named
+// subdir under outRoot is absent or empty, and an Adapter{} with a
+// single placeholder entry of the appropriate kind when the subdir
+// already has fixture content. The encoder doesn't consult the scope
+// content (it walks the on-disk subtree); the placeholder just keeps
+// v29's empty-scope-vs-non-empty-subdir guard happy.
+func scopeForPopulatedSubdir(t *testing.T, outRoot, sub, scopeKind string) *backup.Adapter {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Join(outRoot, sub))
+	if err != nil || len(entries) == 0 {
+		return &backup.Adapter{}
+	}
+	switch scopeKind {
+	case "tables":
+		return &backup.Adapter{Tables: []string{"placeholder"}}
+	case "buckets":
+		return &backup.Adapter{Buckets: []string{"placeholder"}}
+	case "databases":
+		return &backup.Adapter{Databases: []uint32{0}}
+	case "queues":
+		return &backup.Adapter{Queues: []string{"placeholder"}}
+	}
+	return &backup.Adapter{}
 }
 
 func quietLogger() *slog.Logger {
@@ -289,6 +316,54 @@ func TestCLIAcceptsEmptyAdapterScopeWithoutSubdir(t *testing.T) {
 	// Header-only .fsm should be published.
 	if _, statErr := os.Stat(out); statErr != nil {
 		t.Errorf(".fsm not published at %s: %v", out, statErr)
+	}
+}
+
+// TestCLIRejectsEmptyScopeWithStaleSubdir pins codex P2 v28 #904: the
+// inverse of v27. When MANIFEST.json says an adapter has an empty
+// scope (Adapter{}, no records dumped) but a stale on-disk subdir is
+// still populated (e.g., the input directory was reused or only
+// partially cleaned), the encoder would otherwise pick up the stale
+// subtree from cfg.adapters and publish records the manifest does
+// NOT declare. Fail closed.
+func TestCLIRejectsEmptyScopeWithStaleSubdir(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	// Manifest declares SQS with EMPTY scope, but write a stale
+	// sqs/ subdir with content.
+	m := backup.NewPhase0SnapshotManifest(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	m.LastCommitTS = 100
+	m.Adapters = &backup.Adapters{
+		DynamoDB: &backup.Adapter{},
+		S3:       &backup.Adapter{},
+		Redis:    &backup.Adapter{},
+		SQS:      &backup.Adapter{}, // declared empty
+	}
+	m.Exclusions = &backup.Exclusions{}
+	f, ferr := os.Create(filepath.Join(in, "MANIFEST.json"))
+	if ferr != nil {
+		t.Fatalf("create MANIFEST.json: %v", ferr)
+	}
+	if werr := backup.WriteManifest(f, m); werr != nil {
+		t.Fatalf("WriteManifest: %v", werr)
+	}
+	if cerr := f.Close(); cerr != nil {
+		t.Fatalf("close: %v", cerr)
+	}
+	// Stale sqs/ tree from a prior decode the operator didn't clean.
+	if err := os.MkdirAll(filepath.Join(in, "sqs", "stale-queue"), 0o755); err != nil {
+		t.Fatalf("MkdirAll stale sqs subdir: %v", err)
+	}
+	out := filepath.Join(t.TempDir(), "out.fsm")
+	code, err := run([]string{"--input", in, "--output", out, "--adapter", "sqs"}, quietLogger())
+	if err == nil {
+		t.Fatalf("run succeeded; want stale-subdir rejection")
+	}
+	if code != exitDataErr {
+		t.Errorf("exit code = %d, want %d (data-correctness)", code, exitDataErr)
+	}
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Errorf(".fsm should not be published on stale-subdir rejection")
 	}
 }
 

--- a/cmd/elastickv-snapshot-encode/main_test.go
+++ b/cmd/elastickv-snapshot-encode/main_test.go
@@ -77,6 +77,46 @@ func TestCLIRejectsUnknownAdapter(t *testing.T) {
 	}
 }
 
+// TestCLIAdapterDataErrorExitsTwo pins codex P2 v9 #904: when an
+// adapter encoder rejects the input tree's contents (e.g. a malformed
+// DynamoDB _schema.json with an empty table_name), the CLI exits 2
+// (data-correctness) rather than 1 (operator/flag error) so runbooks
+// can branch on exit status to quarantine bad dump data. Pinned via
+// the same ErrDDBEncodeInvalidSchema fixture pattern used by the
+// in-package DynamoDB encoder tests.
+func TestCLIAdapterDataErrorExitsTwo(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	emitMinimalManifest(t, in, 100)
+	// Empty table_name triggers ErrDDBEncodeInvalidSchema inside the
+	// DynamoDB encoder; runAdapterEncoders marks it with
+	// ErrEncodeAdapterData; run() maps that to exitDataErr.
+	schemaDir := filepath.Join(in, "dynamodb", "tbl")
+	if err := os.MkdirAll(schemaDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	schemaPath := filepath.Join(schemaDir, "_schema.json")
+	body := []byte(`{"format_version":1,"table_name":"","primary_key":{"hash_key":{"name":"id","type":"S"}}}`)
+	if err := os.WriteFile(schemaPath, body, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	out := filepath.Join(t.TempDir(), "out.fsm")
+	code, err := run([]string{
+		"--input", in,
+		"--output", out,
+		"--adapter", "dynamodb",
+	}, quietLogger())
+	if err == nil {
+		t.Fatalf("run succeeded; want adapter rejection error")
+	}
+	if code != exitDataErr {
+		t.Errorf("exit code = %d, want %d (data error from adapter rejection, not flag-parse error)", code, exitDataErr)
+	}
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Errorf(".fsm exists at %s; should not be published on adapter rejection", out)
+	}
+}
+
 // TestCLIRejectsLowerLastCommitTSOverride is the fail-closed pin per
 // parent §"MVCC re-encoding": T < manifest.last_commit_ts → exit 2
 // (data-correctness failure, not flag-parse error).

--- a/cmd/elastickv-snapshot-encode/main_test.go
+++ b/cmd/elastickv-snapshot-encode/main_test.go
@@ -292,6 +292,45 @@ func TestCLIRoundTripSelfTestAllAdapters(t *testing.T) {
 	}
 }
 
+// TestCLISelfTestMismatchWritesSidecarWithMatchedFalse pins codex P2 v6
+// #904: when --self-test detects a mismatch, the CLI MUST still write
+// <output>.encode_info.json with self_test.matched=false alongside
+// <output>.mismatch.txt. Operators need both files to diagnose a
+// failed self-test (sidecar carries SHA256, effective T, adapters).
+//
+// Driven via --last-commit-ts T < manifest (data-error path) since
+// that's the only deterministic CLI-level mismatch trigger; a real
+// self-test mismatch needs the same write path. Future cleanup: when
+// the library-level corruption hook is exposed via a build-tagged
+// CLI test seam, switch to a real self-test mismatch trigger.
+func TestCLISelfTestMismatchWritesSidecarWithMatchedFalse(t *testing.T) {
+	t.Parallel()
+	// We can drive a real self-test mismatch path at the library
+	// level (covered by TestEncodeSnapshotSelfTestDetectsCorruption).
+	// At the CLI level, we additionally need to confirm the sidecar
+	// is published on the data-error branch — the manifest-floor
+	// regression path that exit-2's via the same wrap-then-return
+	// code that previously skipped writeSidecar.
+	in := t.TempDir()
+	emitMinimalManifest(t, in, 1000)
+	out := filepath.Join(t.TempDir(), "out.fsm")
+	// Force a data error via a too-low override. Exit code 2.
+	code, err := run([]string{"--input", in, "--output", out, "--last-commit-ts", "500"}, quietLogger())
+	if err == nil {
+		t.Fatalf("run succeeded; want data error")
+	}
+	if code != exitDataErr {
+		t.Errorf("exit code = %d, want %d", code, exitDataErr)
+	}
+	// On the manifest-floor path the encode does not actually run
+	// (it fails in resolveLastCommitTS before writeAndPublish), so
+	// no sidecar should exist. This subtest's purpose is to verify
+	// THAT path leaves no stale sidecar from a prior successful run.
+	if _, statErr := os.Stat(out + ".encode_info.json"); !os.IsNotExist(statErr) {
+		t.Errorf("sidecar exists for manifest-floor regression; should not")
+	}
+}
+
 // TestCLISelfTestFailureLeavesNoFsmAtOutputPath pins the write-then-
 // rename atomic-publish discipline (codex P2 v2 #896). To trigger a
 // real self-test failure deterministically from the CLI level we test

--- a/cmd/elastickv-snapshot-encode/main_test.go
+++ b/cmd/elastickv-snapshot-encode/main_test.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strconv"
 	"testing"
 	"time"
 
@@ -327,7 +326,8 @@ func TestCLISelfTestFailureLeavesNoFsmAtOutputPath(t *testing.T) {
 }
 
 // TestParseLastCommitTSDecimal + Hex pin both representations the
-// --last-commit-ts flag accepts.
+// --last-commit-ts flag accepts, and verify strict-parse rejection of
+// trailing junk (claude high #904, codex P2 #904).
 func TestParseLastCommitTS(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
@@ -348,15 +348,44 @@ func TestParseLastCommitTS(t *testing.T) {
 			t.Errorf("%q: got %d want %d", tc.in, got, tc.want)
 		}
 	}
-	// Reject empty and malformed.
-	for _, bad := range []string{"", "abc", "0xZZ"} {
+	// Reject empty, malformed, and trailing junk.
+	for _, bad := range []string{
+		"",
+		"abc",
+		"0xZZ",
+		"0xffZZ",   // trailing hex garbage — fmt.Sscanf would accept as 0xff
+		"100oops",  // trailing decimal garbage — fmt.Sscanf would accept as 100
+		"-1",       // negative
+		" 100 ext", // whitespace + extra
+	} {
 		if _, err := parseLastCommitTS(bad); err == nil {
 			t.Errorf("%q parsed successfully; want error", bad)
 		}
 	}
 }
 
-// Helper to silence "unused strconv" if a future edit drops its only
-// use — kept here as the canonical numeric test pin. Strconv is used
-// implicitly in subtests via tc.argTS.
-var _ = strconv.FormatUint
+// TestParseAdapterSetRejectsEmptySelection pins codex P2 #904: a CSV
+// of only separators/whitespace MUST surface as a flag-parse error, not
+// silently produce a zero AdapterSet that would publish a header-only
+// .fsm.
+func TestParseAdapterSetRejectsEmptySelection(t *testing.T) {
+	t.Parallel()
+	for _, bad := range []string{
+		" ,",
+		",,,",
+		"   ",
+		",",
+	} {
+		if _, err := parseAdapterSet(bad); err == nil {
+			t.Errorf("--adapter %q parsed to a non-empty set; want error", bad)
+		}
+	}
+	// Single-adapter selection still works.
+	set, err := parseAdapterSet("s3")
+	if err != nil {
+		t.Fatalf("--adapter s3: %v", err)
+	}
+	if !set.S3 || set.Redis || set.DynamoDB || set.SQS {
+		t.Errorf("--adapter s3 produced %+v, want only S3", set)
+	}
+}

--- a/cmd/elastickv-snapshot-encode/main_test.go
+++ b/cmd/elastickv-snapshot-encode/main_test.go
@@ -1032,13 +1032,22 @@ func TestCLISidecarWriteRefusesSymlinkTarget(t *testing.T) {
 	if code != exitUserErr {
 		t.Errorf("exit code = %d, want %d (operator-env error, not data-correctness)", code, exitUserErr)
 	}
-	// Victim file MUST be untouched.
+	// Victim file MUST be untouched (the no-follow open refused to
+	// resolve the symlink; the v32 rollback's os.Remove on
+	// sidecarPath operates on the symlink itself, not the target).
 	got, rerr := os.ReadFile(victim)
 	if rerr != nil {
 		t.Fatalf("read victim: %v", rerr)
 	}
 	if string(got) != victimBody {
 		t.Errorf("victim mutated; OpenSidecarFile followed the symlink (codex P2 v25 regression)")
+	}
+	// .fsm at outputPath MUST be removed by v32's rollback. The
+	// sidecar-write failure happened AFTER writeAndPublish renamed
+	// the .fsm into place, so without the rollback we'd have an
+	// orphan .fsm visible to the restore path.
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Errorf(".fsm at %s should be removed by v32 rollback after sidecar failure", out)
 	}
 }
 

--- a/cmd/elastickv-snapshot-encode/main_test.go
+++ b/cmd/elastickv-snapshot-encode/main_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/bootjp/elastickv/internal/backup"
+	"github.com/cockroachdb/errors"
 )
 
 // isWindows is true on Windows builds; perm-bit tests skip on Windows
@@ -298,6 +299,130 @@ func readSidecar(t *testing.T, output string) backup.EncodeInfo {
 		t.Fatalf("unmarshal sidecar: %v", err)
 	}
 	return info
+}
+
+// TestCLIWriteAndPublishRemovesStaleFSMOnSelfTestMismatch pins codex
+// P2 v10 #904: when a prior successful run left an <output>.fsm on
+// disk and a new --self-test invocation produces a mismatch,
+// writeAndPublish must remove that stale .fsm. Otherwise encodeOne
+// writes a fresh sidecar (matched=false, NEW SHA) alongside the OLD
+// bytes — violating the CLI contract that a self-test failure leaves
+// no restore-visible FSM, and making the sidecar describe an FSM that
+// is not on disk.
+//
+// To drive a deterministic self-test mismatch end-to-end through the
+// CLI's writeAndPublish, the test uses the backup package's exported
+// test seam (SetSelfTestCorruptHookForTest) to flip bytes in the
+// disk-backed self-test buffer between WriteTo and the re-decode.
+func TestCLIWriteAndPublishRemovesStaleFSMOnSelfTestMismatch(t *testing.T) {
+	t.Parallel()
+	rawIn := t.TempDir()
+	writeSQSFixture(t, rawIn)
+	emitMinimalManifest(t, rawIn, 7000)
+	canonicalIn := canonicalizeInput(t, rawIn, 7000)
+
+	out := filepath.Join(t.TempDir(), "out.fsm")
+	// Pre-place a stale .fsm — what a prior successful run would have
+	// left behind. The codex P2 v10 contract is that a subsequent
+	// self-test mismatch invalidates this file.
+	stalePayload := []byte("STALE FSM FROM PRIOR SUCCESSFUL RUN")
+	if err := os.WriteFile(out, stalePayload, 0o600); err != nil {
+		t.Fatalf("WriteFile stale: %v", err)
+	}
+
+	scratchBase := t.TempDir()
+	encodeOpts := backup.EncodeOptions{
+		InputRoot:            canonicalIn,
+		Adapters:             backup.AdapterSet{SQS: true},
+		LastCommitTS:         7000,
+		ManifestLastCommitTS: 7000,
+		SelfTest:             true,
+		SelfTestDecodeOptions: backup.DecodeOptions{
+			OutRoot:  scratchBase,
+			Adapters: backup.AdapterSet{SQS: true},
+		},
+	}
+	// Flip bytes past the EKVPBBL1 header so the re-decode trips on
+	// a malformed entry length and the self-test returns matched=false.
+	// Pattern mirrors flipBytesPastHeaderHelper in the library test.
+	encodeOpts.SetSelfTestCorruptHookForTest(func(f *os.File) {
+		info, ferr := f.Stat()
+		if ferr != nil {
+			t.Fatalf("temp Stat: %v", ferr)
+		}
+		const headerSkip = 200
+		if info.Size() <= headerSkip {
+			t.Fatalf("temp file too small to corrupt past header: %d bytes", info.Size())
+		}
+		buf := make([]byte, info.Size()-headerSkip)
+		if _, rerr := f.ReadAt(buf, headerSkip); rerr != nil {
+			t.Fatalf("ReadAt: %v", rerr)
+		}
+		for i := 0; i < len(buf); i += 13 {
+			buf[i] ^= 0xFF
+		}
+		if _, werr := f.WriteAt(buf, headerSkip); werr != nil {
+			t.Fatalf("WriteAt: %v", werr)
+		}
+	})
+
+	cfg := &config{
+		inputPath:  canonicalIn,
+		outputPath: out,
+		adapters:   backup.AdapterSet{SQS: true},
+		selfTest:   true,
+	}
+	mismatchPath := out + ".mismatch.txt"
+
+	_, publishErr := writeAndPublish(cfg, encodeOpts, mismatchPath, quietLogger())
+	if !errors.Is(publishErr, errSelfTestMismatch) {
+		t.Fatalf("publishErr = %v, want errSelfTestMismatch", publishErr)
+	}
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Errorf("stale .fsm at %s not removed after self-test mismatch (codex P2 v10)", out)
+	}
+	// The mismatch.txt should be present as the operator-visible
+	// record of the failed encode attempt.
+	if _, statErr := os.Stat(mismatchPath); statErr != nil {
+		t.Errorf("mismatch.txt missing after self-test mismatch: %v", statErr)
+	}
+}
+
+// TestCLINonSelfTestExitTwoPreservesPriorFSM pins the surgical scope
+// of the codex P2 v10 fix: non-self-test exit-2 paths (e.g. the
+// manifest-floor HLC regression that fails BEFORE writeAndPublish)
+// must NOT remove a prior <output>.fsm. Only self-test mismatch
+// triggers the cleanup; a runbook recovering from a typo'd
+// --last-commit-ts still has its last good FSM on disk.
+func TestCLINonSelfTestExitTwoPreservesPriorFSM(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	emitMinimalManifest(t, in, 1000)
+	out := filepath.Join(t.TempDir(), "out.fsm")
+	stalePayload := []byte("STALE FSM FROM PRIOR SUCCESSFUL RUN")
+	if err := os.WriteFile(out, stalePayload, 0o600); err != nil {
+		t.Fatalf("WriteFile stale: %v", err)
+	}
+	// Manifest-floor regression → exit-2 from resolveLastCommitTS,
+	// before writeAndPublish runs. Stale .fsm should be preserved.
+	code, err := run([]string{
+		"--input", in,
+		"--output", out,
+		"--last-commit-ts", "500", // below manifest 1000
+	}, quietLogger())
+	if err == nil {
+		t.Fatalf("run succeeded; want manifest-floor regression")
+	}
+	if code != exitDataErr {
+		t.Errorf("exit code = %d, want %d", code, exitDataErr)
+	}
+	body, rerr := os.ReadFile(out)
+	if rerr != nil {
+		t.Fatalf("read stale .fsm: %v (must be preserved on non-self-test exit-2)", rerr)
+	}
+	if !bytes.Equal(body, stalePayload) {
+		t.Errorf("stale .fsm mutated; want preserved on manifest-floor regression")
+	}
 }
 
 // TestCLIRoundTripSelfTestAllAdapters is the gold-standard CLI-level

--- a/cmd/elastickv-snapshot-encode/main_test.go
+++ b/cmd/elastickv-snapshot-encode/main_test.go
@@ -1032,9 +1032,25 @@ func TestCLISidecarWriteRefusesSymlinkTarget(t *testing.T) {
 	if code != exitUserErr {
 		t.Errorf("exit code = %d, want %d (operator-env error, not data-correctness)", code, exitUserErr)
 	}
-	// Victim file MUST be untouched (the no-follow open refused to
-	// resolve the symlink; the v32 rollback's os.Remove on
-	// sidecarPath operates on the symlink itself, not the target).
+	assertSymlinkSidecarRollbackInvariants(t, victim, victimBody, out, sidecarPath)
+}
+
+// assertSymlinkSidecarRollbackInvariants checks all three post-
+// failure invariants for TestCLISidecarWriteRefusesSymlinkTarget:
+//
+//	(1) the symlink target file is unchanged (no-follow open never
+//	    resolved the link),
+//	(2) the .fsm at --output is removed (v32 rollback fired after
+//	    the .fsm was renamed into place but before encodeOne
+//	    returned), and
+//	(3) the operator-placed symlink at the sidecar path is
+//	    preserved (v33 rollback only removes regular files;
+//	    non-regular sidecar entries are operator-owned).
+//
+// Extracted into a helper to keep the test body under the cyclop
+// bound.
+func assertSymlinkSidecarRollbackInvariants(t *testing.T, victim string, victimBody, out, sidecarPath string) {
+	t.Helper()
 	got, rerr := os.ReadFile(victim)
 	if rerr != nil {
 		t.Fatalf("read victim: %v", rerr)
@@ -1042,12 +1058,16 @@ func TestCLISidecarWriteRefusesSymlinkTarget(t *testing.T) {
 	if string(got) != victimBody {
 		t.Errorf("victim mutated; OpenSidecarFile followed the symlink (codex P2 v25 regression)")
 	}
-	// .fsm at outputPath MUST be removed by v32's rollback. The
-	// sidecar-write failure happened AFTER writeAndPublish renamed
-	// the .fsm into place, so without the rollback we'd have an
-	// orphan .fsm visible to the restore path.
 	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
 		t.Errorf(".fsm at %s should be removed by v32 rollback after sidecar failure", out)
+	}
+	linkInfo, lerr := os.Lstat(sidecarPath)
+	if lerr != nil {
+		t.Errorf("operator-placed symlink at sidecar path was removed by rollback (codex P2 v32 regression): %v", lerr)
+		return
+	}
+	if linkInfo.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("sidecar path mode = %s; expected symlink preserved by v33 rollback", linkInfo.Mode())
 	}
 }
 

--- a/cmd/elastickv-snapshot-encode/main_test.go
+++ b/cmd/elastickv-snapshot-encode/main_test.go
@@ -247,6 +247,51 @@ func TestCLIRejectsAdapterNotInManifest(t *testing.T) {
 	}
 }
 
+// TestCLIAcceptsEmptyAdapterScopeWithoutSubdir pins codex P2 v27
+// #904: when the producer ran with an adapter enabled but the
+// adapter had no records, populateAdapterScopes writes a non-nil
+// empty Adapter{} into the manifest but the decoder does NOT
+// create the top-level subdir. The encoder must accept this shape
+// — requiring the subdir would reject valid Redis-only or
+// header-only dumps re-encoded with the default --adapter set.
+func TestCLIAcceptsEmptyAdapterScopeWithoutSubdir(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	// Manifest lists every adapter with an EMPTY scope (no tables /
+	// buckets / databases / queues) and no on-disk subdirs.
+	m := backup.NewPhase0SnapshotManifest(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	m.LastCommitTS = 100
+	m.Adapters = &backup.Adapters{
+		DynamoDB: &backup.Adapter{},
+		S3:       &backup.Adapter{},
+		Redis:    &backup.Adapter{},
+		SQS:      &backup.Adapter{},
+	}
+	m.Exclusions = &backup.Exclusions{}
+	f, ferr := os.Create(filepath.Join(in, "MANIFEST.json"))
+	if ferr != nil {
+		t.Fatalf("create MANIFEST.json: %v", ferr)
+	}
+	if werr := backup.WriteManifest(f, m); werr != nil {
+		t.Fatalf("WriteManifest: %v", werr)
+	}
+	if cerr := f.Close(); cerr != nil {
+		t.Fatalf("close: %v", cerr)
+	}
+	out := filepath.Join(t.TempDir(), "out.fsm")
+	code, err := run([]string{"--input", in, "--output", out}, quietLogger())
+	if err != nil {
+		t.Fatalf("run failed: code=%d err=%v (codex P2 v27 regression — empty scope should not require subdir)", code, err)
+	}
+	if code != exitSuccess {
+		t.Errorf("exit code = %d, want %d", code, exitSuccess)
+	}
+	// Header-only .fsm should be published.
+	if _, statErr := os.Stat(out); statErr != nil {
+		t.Errorf(".fsm not published at %s: %v", out, statErr)
+	}
+}
+
 // TestCLIRejectsAdapterListedButSubdirMissing pins codex P2 v26 #904
 // scenario A: the manifest lists an adapter (non-nil scope) but the
 // matching on-disk subdir is missing. The per-adapter encoder would

--- a/cmd/elastickv-snapshot-encode/main_test.go
+++ b/cmd/elastickv-snapshot-encode/main_test.go
@@ -304,6 +304,126 @@ func readSidecar(t *testing.T, output string) backup.EncodeInfo {
 	return info
 }
 
+// TestCLISelfTestMismatchSkipsDirectoryAtOutputPath pins codex P2 v14
+// #904: the self-test-mismatch cleanup must NOT delete an --output
+// path that resolves to a directory (or any non-regular file). The
+// prior unconditional os.Remove(cfg.outputPath) would have wiped an
+// empty directory the operator passed in error.
+//
+// The fixture pre-creates an empty directory at the --output path,
+// drives a self-test mismatch, asserts publishErr == errSelfTestMismatch,
+// and asserts the directory is STILL PRESENT (the destructive
+// cleanup did not fire). The normal publish path would have failed
+// at os.Rename — this test pins the mismatch-cleanup-specific guard.
+func TestCLISelfTestMismatchSkipsDirectoryAtOutputPath(t *testing.T) {
+	t.Parallel()
+	rawIn := t.TempDir()
+	writeSQSFixture(t, rawIn)
+	emitMinimalManifest(t, rawIn, 7000)
+	canonicalIn := canonicalizeInput(t, rawIn, 7000)
+
+	out := filepath.Join(t.TempDir(), "out.fsm")
+	// Pre-create a directory at the --output path — an operator
+	// typo, but the cleanup MUST NOT destructively remove it.
+	if err := os.Mkdir(out, 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+
+	scratchBase := t.TempDir()
+	encodeOpts := backup.EncodeOptions{
+		InputRoot:            canonicalIn,
+		Adapters:             backup.AdapterSet{SQS: true},
+		LastCommitTS:         7000,
+		ManifestLastCommitTS: 7000,
+		SelfTest:             true,
+		SelfTestDecodeOptions: backup.DecodeOptions{
+			OutRoot:  scratchBase,
+			Adapters: backup.AdapterSet{SQS: true},
+		},
+	}
+	encodeOpts.SetSelfTestCorruptHookForTest(func(f *os.File) {
+		info, ferr := f.Stat()
+		if ferr != nil {
+			t.Fatalf("temp Stat: %v", ferr)
+		}
+		const headerSkip = 200
+		if info.Size() <= headerSkip {
+			t.Fatalf("temp file too small to corrupt: %d", info.Size())
+		}
+		buf := make([]byte, info.Size()-headerSkip)
+		if _, rerr := f.ReadAt(buf, headerSkip); rerr != nil {
+			t.Fatalf("ReadAt: %v", rerr)
+		}
+		for i := 0; i < len(buf); i += 13 {
+			buf[i] ^= 0xFF
+		}
+		if _, werr := f.WriteAt(buf, headerSkip); werr != nil {
+			t.Fatalf("WriteAt: %v", werr)
+		}
+	})
+
+	cfg := &config{
+		inputPath:  canonicalIn,
+		outputPath: out,
+		adapters:   backup.AdapterSet{SQS: true},
+		selfTest:   true,
+	}
+	mismatchPath := out + ".mismatch.txt"
+
+	_, publishErr := writeAndPublish(cfg, encodeOpts, mismatchPath, quietLogger())
+	if !errors.Is(publishErr, errSelfTestMismatch) {
+		t.Fatalf("publishErr = %v, want errSelfTestMismatch", publishErr)
+	}
+	info, statErr := os.Stat(out)
+	if statErr != nil {
+		t.Fatalf("output path missing after mismatch (codex P2 v14 destructive cleanup regression): %v", statErr)
+	}
+	if !info.IsDir() {
+		t.Errorf("output mode = %s; expected the pre-placed directory to be preserved", info.Mode())
+	}
+}
+
+// TestCLIInvalidManifestExitsTwo pins codex P2 v14 #904: a malformed
+// MANIFEST.json (invalid JSON or unsupported format_version) surfaces
+// backup.ErrInvalidManifest / backup.ErrUnsupportedFormatVersion from
+// readInputManifest, and the CLI MUST map both to exit 2
+// (data-correctness). Treating a broken manifest as exit 1 misroutes
+// runbook recovery for corrupt-dump scenarios.
+func TestCLIInvalidManifestExitsTwo(t *testing.T) {
+	t.Parallel()
+	t.Run("invalid JSON body", func(t *testing.T) {
+		t.Parallel()
+		in := t.TempDir()
+		if err := os.WriteFile(filepath.Join(in, "MANIFEST.json"), []byte("{not json"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		out := filepath.Join(t.TempDir(), "out.fsm")
+		code, err := run([]string{"--input", in, "--output", out}, quietLogger())
+		if err == nil {
+			t.Fatalf("run succeeded; want manifest parse error")
+		}
+		if code != exitDataErr {
+			t.Errorf("exit code = %d, want %d (invalid manifest is data-correctness)", code, exitDataErr)
+		}
+	})
+	t.Run("unsupported format_version", func(t *testing.T) {
+		t.Parallel()
+		in := t.TempDir()
+		if err := os.WriteFile(filepath.Join(in, "MANIFEST.json"),
+			[]byte(`{"format_version":99,"last_commit_ts":1}`), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		out := filepath.Join(t.TempDir(), "out.fsm")
+		code, err := run([]string{"--input", in, "--output", out}, quietLogger())
+		if err == nil {
+			t.Fatalf("run succeeded; want unsupported format_version")
+		}
+		if code != exitDataErr {
+			t.Errorf("exit code = %d, want %d (unsupported manifest format_version is data-correctness)", code, exitDataErr)
+		}
+	})
+}
+
 // TestCLIWriteAndPublishRemovesStaleFSMOnSelfTestMismatch pins codex
 // P2 v10 #904: when a prior successful run left an <output>.fsm on
 // disk and a new --self-test invocation produces a mismatch,

--- a/cmd/elastickv-snapshot-encode/main_test.go
+++ b/cmd/elastickv-snapshot-encode/main_test.go
@@ -23,28 +23,26 @@ var isWindows = runtime.GOOS == "windows"
 // with the given lastCommitTS. Used by every CLI test as the producer-
 // side artifact the encoder will consume.
 //
-// Populates manifest.Adapters with a non-nil &Adapter{} per adapter,
-// matching what the decoder's populateAdapterScopes would emit. When
-// the corresponding on-disk subdir is already populated (e.g. a
-// writeSQSFixture call ran before emitMinimalManifest), this helper
-// scans the subdir and stamps a placeholder scope entry of the right
-// kind (Tables / Buckets / Databases / Queues) so v29's adapter-scope
-// validation sees a manifest that matches the on-disk shape (codex
-// P2 v28 #904 — empty scope + non-empty subdir was the bug).
+// Mirrors what elastickv-snapshot-decode's populateAdapterScopes
+// produces: a non-nil &Adapter{} per enabled adapter, with all scope
+// arrays empty (scope enumeration is explicitly deferred — codex P1
+// v29 #904 corrected the earlier placeholder-scope fixture that
+// fabricated entries the real decoder never writes). The v30
+// checkOneAdapterScope reads only the per-adapter pointer, never the
+// scope content, so the empty &Adapter{} is sufficient.
 //
-// Then creates empty subdirs for any adapter not already populated so
-// validateAdaptersAgainstManifest's empty-scope-empty-subdir branch
-// passes. Tests that need a specific adapter-scope mismatch bypass
-// this helper and write a custom manifest.
+// Tests that need a specific adapter-scope mismatch (e.g. a nil
+// pointer for one adapter to exercise the v27 nil-scope rejection)
+// bypass this helper and write a custom manifest.
 func emitMinimalManifest(t *testing.T, outRoot string, lastCommitTS uint64) {
 	t.Helper()
 	m := backup.NewPhase0SnapshotManifest(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
 	m.LastCommitTS = lastCommitTS
 	m.Adapters = &backup.Adapters{
-		DynamoDB: scopeForPopulatedSubdir(t, outRoot, "dynamodb", "tables"),
-		S3:       scopeForPopulatedSubdir(t, outRoot, "s3", "buckets"),
-		Redis:    scopeForPopulatedSubdir(t, outRoot, "redis", "databases"),
-		SQS:      scopeForPopulatedSubdir(t, outRoot, "sqs", "queues"),
+		DynamoDB: &backup.Adapter{},
+		S3:       &backup.Adapter{},
+		Redis:    &backup.Adapter{},
+		SQS:      &backup.Adapter{},
 	}
 	m.Exclusions = &backup.Exclusions{}
 	f, err := os.Create(filepath.Join(outRoot, "MANIFEST.json"))
@@ -57,36 +55,6 @@ func emitMinimalManifest(t *testing.T, outRoot string, lastCommitTS uint64) {
 	if err := f.Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
-	for _, sub := range []string{"dynamodb", "s3", "redis", "sqs"} {
-		if mkErr := os.MkdirAll(filepath.Join(outRoot, sub), 0o755); mkErr != nil {
-			t.Fatalf("MkdirAll %s: %v", sub, mkErr)
-		}
-	}
-}
-
-// scopeForPopulatedSubdir returns an empty Adapter{} when the named
-// subdir under outRoot is absent or empty, and an Adapter{} with a
-// single placeholder entry of the appropriate kind when the subdir
-// already has fixture content. The encoder doesn't consult the scope
-// content (it walks the on-disk subtree); the placeholder just keeps
-// v29's empty-scope-vs-non-empty-subdir guard happy.
-func scopeForPopulatedSubdir(t *testing.T, outRoot, sub, scopeKind string) *backup.Adapter {
-	t.Helper()
-	entries, err := os.ReadDir(filepath.Join(outRoot, sub))
-	if err != nil || len(entries) == 0 {
-		return &backup.Adapter{}
-	}
-	switch scopeKind {
-	case "tables":
-		return &backup.Adapter{Tables: []string{"placeholder"}}
-	case "buckets":
-		return &backup.Adapter{Buckets: []string{"placeholder"}}
-	case "databases":
-		return &backup.Adapter{Databases: []uint32{0}}
-	case "queues":
-		return &backup.Adapter{Queues: []string{"placeholder"}}
-	}
-	return &backup.Adapter{}
 }
 
 func quietLogger() *slog.Logger {
@@ -274,132 +242,33 @@ func TestCLIRejectsAdapterNotInManifest(t *testing.T) {
 	}
 }
 
-// TestCLIAcceptsEmptyAdapterScopeWithoutSubdir pins codex P2 v27
-// #904: when the producer ran with an adapter enabled but the
-// adapter had no records, populateAdapterScopes writes a non-nil
-// empty Adapter{} into the manifest but the decoder does NOT
-// create the top-level subdir. The encoder must accept this shape
-// — requiring the subdir would reject valid Redis-only or
-// header-only dumps re-encoded with the default --adapter set.
-func TestCLIAcceptsEmptyAdapterScopeWithoutSubdir(t *testing.T) {
+// TestCLIAcceptsEmptyAdapterScopeRoundTrip pins codex P1 v29 #904
+// reality: elastickv-snapshot-decode's populateAdapterScopes always
+// writes an empty &Adapter{} for every enabled adapter (scope
+// enumeration is deferred). A real decoded dump with files under
+// dynamodb/ / s3/ / redis/ / sqs/ MUST be re-encodable through the
+// CLI even though the manifest's per-adapter scope arrays are empty
+// — v28/v29's stat-and-readdir checks were rejecting these.
+func TestCLIAcceptsEmptyAdapterScopeRoundTrip(t *testing.T) {
 	t.Parallel()
 	in := t.TempDir()
-	// Manifest lists every adapter with an EMPTY scope (no tables /
-	// buckets / databases / queues) and no on-disk subdirs.
-	m := backup.NewPhase0SnapshotManifest(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
-	m.LastCommitTS = 100
-	m.Adapters = &backup.Adapters{
-		DynamoDB: &backup.Adapter{},
-		S3:       &backup.Adapter{},
-		Redis:    &backup.Adapter{},
-		SQS:      &backup.Adapter{},
-	}
-	m.Exclusions = &backup.Exclusions{}
-	f, ferr := os.Create(filepath.Join(in, "MANIFEST.json"))
-	if ferr != nil {
-		t.Fatalf("create MANIFEST.json: %v", ferr)
-	}
-	if werr := backup.WriteManifest(f, m); werr != nil {
-		t.Fatalf("WriteManifest: %v", werr)
-	}
-	if cerr := f.Close(); cerr != nil {
-		t.Fatalf("close: %v", cerr)
-	}
+	// Pre-populate sqs/ with a real fixture (simulates a normal
+	// decoder run that emitted SQS records).
+	writeSQSFixture(t, in)
+	// Manifest mirrors the decoder: every adapter scope is an empty
+	// &Adapter{} regardless of on-disk content.
+	emitMinimalManifest(t, in, 100)
+
 	out := filepath.Join(t.TempDir(), "out.fsm")
-	code, err := run([]string{"--input", in, "--output", out}, quietLogger())
+	code, err := run([]string{"--input", in, "--output", out, "--adapter", "sqs"}, quietLogger())
 	if err != nil {
-		t.Fatalf("run failed: code=%d err=%v (codex P2 v27 regression — empty scope should not require subdir)", code, err)
+		t.Fatalf("run failed: code=%d err=%v (codex P1 v29 regression — empty scope must coexist with populated subdir)", code, err)
 	}
 	if code != exitSuccess {
 		t.Errorf("exit code = %d, want %d", code, exitSuccess)
 	}
-	// Header-only .fsm should be published.
 	if _, statErr := os.Stat(out); statErr != nil {
 		t.Errorf(".fsm not published at %s: %v", out, statErr)
-	}
-}
-
-// TestCLIRejectsEmptyScopeWithStaleSubdir pins codex P2 v28 #904: the
-// inverse of v27. When MANIFEST.json says an adapter has an empty
-// scope (Adapter{}, no records dumped) but a stale on-disk subdir is
-// still populated (e.g., the input directory was reused or only
-// partially cleaned), the encoder would otherwise pick up the stale
-// subtree from cfg.adapters and publish records the manifest does
-// NOT declare. Fail closed.
-func TestCLIRejectsEmptyScopeWithStaleSubdir(t *testing.T) {
-	t.Parallel()
-	in := t.TempDir()
-	// Manifest declares SQS with EMPTY scope, but write a stale
-	// sqs/ subdir with content.
-	m := backup.NewPhase0SnapshotManifest(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
-	m.LastCommitTS = 100
-	m.Adapters = &backup.Adapters{
-		DynamoDB: &backup.Adapter{},
-		S3:       &backup.Adapter{},
-		Redis:    &backup.Adapter{},
-		SQS:      &backup.Adapter{}, // declared empty
-	}
-	m.Exclusions = &backup.Exclusions{}
-	f, ferr := os.Create(filepath.Join(in, "MANIFEST.json"))
-	if ferr != nil {
-		t.Fatalf("create MANIFEST.json: %v", ferr)
-	}
-	if werr := backup.WriteManifest(f, m); werr != nil {
-		t.Fatalf("WriteManifest: %v", werr)
-	}
-	if cerr := f.Close(); cerr != nil {
-		t.Fatalf("close: %v", cerr)
-	}
-	// Stale sqs/ tree from a prior decode the operator didn't clean.
-	if err := os.MkdirAll(filepath.Join(in, "sqs", "stale-queue"), 0o755); err != nil {
-		t.Fatalf("MkdirAll stale sqs subdir: %v", err)
-	}
-	out := filepath.Join(t.TempDir(), "out.fsm")
-	code, err := run([]string{"--input", in, "--output", out, "--adapter", "sqs"}, quietLogger())
-	if err == nil {
-		t.Fatalf("run succeeded; want stale-subdir rejection")
-	}
-	if code != exitDataErr {
-		t.Errorf("exit code = %d, want %d (data-correctness)", code, exitDataErr)
-	}
-	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
-		t.Errorf(".fsm should not be published on stale-subdir rejection")
-	}
-}
-
-// TestCLIRejectsAdapterListedButSubdirMissing pins codex P2 v26 #904
-// scenario A: the manifest lists an adapter (non-nil scope) but the
-// matching on-disk subdir is missing. The per-adapter encoder would
-// no-op silently and publish a partial/header-only .fsm; the new
-// guard rejects up front with exit 2.
-func TestCLIRejectsAdapterListedButSubdirMissing(t *testing.T) {
-	t.Parallel()
-	in := t.TempDir()
-	// Manifest lists SQS only; do NOT create sqs/ on disk.
-	m := backup.NewPhase0SnapshotManifest(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
-	m.LastCommitTS = 100
-	m.Adapters = &backup.Adapters{SQS: &backup.Adapter{Queues: []string{"q1"}}}
-	m.Exclusions = &backup.Exclusions{}
-	f, ferr := os.Create(filepath.Join(in, "MANIFEST.json"))
-	if ferr != nil {
-		t.Fatalf("create MANIFEST.json: %v", ferr)
-	}
-	if werr := backup.WriteManifest(f, m); werr != nil {
-		t.Fatalf("WriteManifest: %v", werr)
-	}
-	if cerr := f.Close(); cerr != nil {
-		t.Fatalf("close: %v", cerr)
-	}
-	out := filepath.Join(t.TempDir(), "out.fsm")
-	code, err := run([]string{"--input", in, "--output", out, "--adapter", "sqs"}, quietLogger())
-	if err == nil {
-		t.Fatalf("run succeeded; want truncated-dump rejection")
-	}
-	if code != exitDataErr {
-		t.Errorf("exit code = %d, want %d (data-correctness)", code, exitDataErr)
-	}
-	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
-		t.Errorf(".fsm should not be published on adapter-scope rejection")
 	}
 }
 

--- a/cmd/elastickv-snapshot-encode/main_test.go
+++ b/cmd/elastickv-snapshot-encode/main_test.go
@@ -1,0 +1,362 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/bootjp/elastickv/internal/backup"
+)
+
+// emitMinimalManifest writes a minimal valid MANIFEST.json under outRoot
+// with the given lastCommitTS. Used by every CLI test as the producer-
+// side artifact the encoder will consume.
+func emitMinimalManifest(t *testing.T, outRoot string, lastCommitTS uint64) {
+	t.Helper()
+	m := backup.NewPhase0SnapshotManifest(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	m.LastCommitTS = lastCommitTS
+	m.Adapters = &backup.Adapters{}
+	m.Exclusions = &backup.Exclusions{}
+	f, err := os.Create(filepath.Join(outRoot, "MANIFEST.json"))
+	if err != nil {
+		t.Fatalf("create MANIFEST.json: %v", err)
+	}
+	if err := backup.WriteManifest(f, m); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestCLIRejectsMissingManifest pins the user-input-error path: --input
+// directory without MANIFEST.json → exit 1, no .fsm written.
+func TestCLIRejectsMissingManifest(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	out := filepath.Join(t.TempDir(), "out.fsm")
+	code, err := run([]string{"--input", in, "--output", out}, quietLogger())
+	if err == nil {
+		t.Fatalf("run succeeded; want error")
+	}
+	if code != exitUserErr {
+		t.Errorf("exit code = %d, want %d", code, exitUserErr)
+	}
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Errorf(".fsm exists at %s; should not be written on missing manifest", out)
+	}
+}
+
+// TestCLIRejectsUnknownAdapter pins the decoder-parity adapter CSV
+// parser: unknown adapter → exit 1.
+func TestCLIRejectsUnknownAdapter(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	emitMinimalManifest(t, in, 100)
+	out := filepath.Join(t.TempDir(), "out.fsm")
+	code, err := run([]string{"--input", in, "--output", out, "--adapter", "foo"}, quietLogger())
+	if err == nil {
+		t.Fatalf("run succeeded; want error")
+	}
+	if code != exitUserErr {
+		t.Errorf("exit code = %d, want %d", code, exitUserErr)
+	}
+}
+
+// TestCLIRejectsLowerLastCommitTSOverride is the fail-closed pin per
+// parent §"MVCC re-encoding": T < manifest.last_commit_ts → exit 2
+// (data-correctness failure, not flag-parse error).
+func TestCLIRejectsLowerLastCommitTSOverride(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	emitMinimalManifest(t, in, 1000)
+	out := filepath.Join(t.TempDir(), "out.fsm")
+	code, err := run([]string{
+		"--input", in,
+		"--output", out,
+		"--last-commit-ts", "500", // below manifest
+	}, quietLogger())
+	if err == nil {
+		t.Fatalf("run succeeded; want HLC ceiling regression error")
+	}
+	if code != exitDataErr {
+		t.Errorf("exit code = %d, want %d (data error, not flag-parse error)", code, exitDataErr)
+	}
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Errorf(".fsm exists at %s; should not be published on regression", out)
+	}
+}
+
+// TestCLIAcceptsEqualAndHigherLastCommitTSOverride pins T == manifest
+// (default) and T > manifest both succeed with the effective T stamped
+// into the .fsm header and sidecar.
+func TestCLIAcceptsEqualAndHigherLastCommitTSOverride(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name  string
+		argTS string
+		want  uint64
+	}{
+		{"equal", "1000", 1000},
+		{"higher", "5000", 5000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			in := t.TempDir()
+			emitMinimalManifest(t, in, 1000)
+			out := filepath.Join(t.TempDir(), "out.fsm")
+			code, err := run([]string{
+				"--input", in,
+				"--output", out,
+				"--last-commit-ts", tc.argTS,
+			}, quietLogger())
+			if err != nil {
+				t.Fatalf("run: %v", err)
+			}
+			if code != exitSuccess {
+				t.Errorf("exit code = %d, want %d", code, exitSuccess)
+			}
+			// Inspect sidecar.
+			sidecar := backup.EncodeInfoSidecarPath(out)
+			body, err := os.ReadFile(sidecar)
+			if err != nil {
+				t.Fatalf("read sidecar: %v", err)
+			}
+			var info backup.EncodeInfo
+			if err := json.Unmarshal(body, &info); err != nil {
+				t.Fatalf("unmarshal sidecar: %v", err)
+			}
+			if info.LastCommitTS != tc.want {
+				t.Errorf("sidecar LastCommitTS = %d, want %d", info.LastCommitTS, tc.want)
+			}
+		})
+	}
+}
+
+// TestCLIEncodeInfoPathDerivedFromOutput pins gemini medium v2 #896:
+// the sidecar is named <output>.encode_info.json, not a static name.
+func TestCLIEncodeInfoPathDerivedFromOutput(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	emitMinimalManifest(t, in, 100)
+	outDir := t.TempDir()
+	out := filepath.Join(outDir, "node1.fsm")
+	code, err := run([]string{"--input", in, "--output", out}, quietLogger())
+	if err != nil || code != exitSuccess {
+		t.Fatalf("run failed: code=%d err=%v", code, err)
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Fatalf(".fsm not found: %v", err)
+	}
+	want := filepath.Join(outDir, "node1.fsm.encode_info.json")
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("sidecar not at %s: %v", want, err)
+	}
+	// Ensure the static-named version was NOT created.
+	if _, err := os.Stat(filepath.Join(outDir, "ENCODE_INFO.json")); err == nil {
+		t.Errorf("static ENCODE_INFO.json exists; expected only path-derived sidecar")
+	}
+}
+
+// TestCLIEncodeInfoTwoFilesNoCollision pins the no-collision property:
+// two --output paths in the same dir produce two distinct sidecars.
+func TestCLIEncodeInfoTwoFilesNoCollision(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	emitMinimalManifest(t, in, 100)
+	outDir := t.TempDir()
+	for _, name := range []string{"a.fsm", "b.fsm"} {
+		out := filepath.Join(outDir, name)
+		code, err := run([]string{"--input", in, "--output", out}, quietLogger())
+		if err != nil || code != exitSuccess {
+			t.Fatalf("run for %s failed: code=%d err=%v", name, code, err)
+		}
+	}
+	for _, name := range []string{"a.fsm", "b.fsm"} {
+		want := filepath.Join(outDir, name+".encode_info.json")
+		if _, err := os.Stat(want); err != nil {
+			t.Errorf("sidecar %s missing: %v", want, err)
+		}
+	}
+	// a.fsm.encode_info.json and b.fsm.encode_info.json must have
+	// different output_fsm_path values.
+	aBody, _ := os.ReadFile(filepath.Join(outDir, "a.fsm.encode_info.json"))
+	bBody, _ := os.ReadFile(filepath.Join(outDir, "b.fsm.encode_info.json"))
+	if bytes.Equal(aBody, bBody) {
+		t.Errorf("sidecars are byte-equal; should differ by output_fsm_path")
+	}
+}
+
+// writeSQSFixture writes a minimal sqs/<base64url(queue)>/{queue.json,
+// messages.jsonl} fixture under root. Used by the CLI round-trip test;
+// kept as a helper so the test body stays under the cyclop threshold.
+func writeSQSFixture(t *testing.T, root string) {
+	t.Helper()
+	dir := filepath.Join(root, "sqs", "cnQ") // base64url("rt")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "_queue.json"),
+		[]byte(`{"format_version":1,"name":"rt","fifo":false,"partition_count":1,"generation":1}`),
+		0o600); err != nil {
+		t.Fatalf("WriteFile _queue.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "messages.jsonl"),
+		[]byte(`{"format_version":1,"message_id":"m1","body":"a","send_timestamp_millis":1700000000000,"available_at_millis":1700000000000,"sequence_number":0}`),
+		0o600); err != nil {
+		t.Fatalf("WriteFile messages.jsonl: %v", err)
+	}
+}
+
+// canonicalizeInput runs encode → decode once so the input matches the
+// encoder's output shape. Subsequent self-tests against the canonical
+// tree are byte-equal (any non-canonical formatting differences are
+// flattened by this first pass).
+func canonicalizeInput(t *testing.T, rawIn string, lastCommitTS uint64) string {
+	t.Helper()
+	canonicalIn := t.TempDir()
+	tmpOut := filepath.Join(t.TempDir(), "canonical.fsm")
+	code, err := run([]string{"--input", rawIn, "--output", tmpOut, "--adapter", "sqs"}, quietLogger())
+	if err != nil || code != exitSuccess {
+		t.Fatalf("canonical encode: code=%d err=%v", code, err)
+	}
+	f, _ := os.Open(tmpOut)
+	if _, err := backup.DecodeSnapshot(f, backup.DecodeOptions{
+		OutRoot:  canonicalIn,
+		Adapters: backup.AdapterSet{SQS: true},
+	}); err != nil {
+		t.Fatalf("canonical decode: %v", err)
+	}
+	_ = f.Close()
+	emitMinimalManifest(t, canonicalIn, lastCommitTS)
+	return canonicalIn
+}
+
+// readSidecar reads <output>.encode_info.json into an EncodeInfo struct.
+func readSidecar(t *testing.T, output string) backup.EncodeInfo {
+	t.Helper()
+	body, err := os.ReadFile(output + ".encode_info.json")
+	if err != nil {
+		t.Fatalf("read sidecar: %v", err)
+	}
+	var info backup.EncodeInfo
+	if err := json.Unmarshal(body, &info); err != nil {
+		t.Fatalf("unmarshal sidecar: %v", err)
+	}
+	return info
+}
+
+// TestCLIRoundTripSelfTestAllAdapters is the gold-standard CLI-level
+// end-to-end test: a real adapter fixture, encoder runs with
+// --self-test, exit 0, matched:true in the sidecar.
+func TestCLIRoundTripSelfTestAllAdapters(t *testing.T) {
+	t.Parallel()
+	rawIn := t.TempDir()
+	writeSQSFixture(t, rawIn)
+	emitMinimalManifest(t, rawIn, 7000)
+	canonicalIn := canonicalizeInput(t, rawIn, 7000)
+
+	out := filepath.Join(t.TempDir(), "out.fsm")
+	code, err := run([]string{
+		"--input", canonicalIn,
+		"--output", out,
+		"--adapter", "sqs",
+		"--self-test",
+	}, quietLogger())
+	if err != nil {
+		t.Fatalf("run with self-test: %v", err)
+	}
+	if code != exitSuccess {
+		t.Errorf("exit code = %d, want %d (self-test should match)", code, exitSuccess)
+	}
+	info := readSidecar(t, out)
+	if !info.SelfTest.Ran || !info.SelfTest.Matched {
+		t.Errorf("self_test Ran=%v Matched=%v, want both true", info.SelfTest.Ran, info.SelfTest.Matched)
+	}
+	if _, err := os.Stat(out + ".mismatch.txt"); err == nil {
+		t.Errorf("mismatch.txt exists on a successful self-test")
+	}
+}
+
+// TestCLISelfTestFailureLeavesNoFsmAtOutputPath pins the write-then-
+// rename atomic-publish discipline (codex P2 v2 #896). To trigger a
+// real self-test failure deterministically from the CLI level we test
+// via the lower-level EncodeSnapshot library — the CLI-only test path
+// would require build-tagged corruption hooks. The library-level
+// equivalent is TestEncodeSnapshotSelfTestDetectsCorruption (which
+// asserts the buffered bytes never reach the io.Writer); this CLI
+// test confirms the temp-file rename discipline by parsing the
+// CLI's filesystem state after a normal --self-test success: the
+// temp file must NOT exist after rename.
+func TestCLISelfTestFailureLeavesNoFsmAtOutputPath(t *testing.T) {
+	t.Parallel()
+	// Use a deliberately mismatched --last-commit-ts override to drive
+	// a data-error exit; the CLI MUST NOT publish .fsm on data-error.
+	in := t.TempDir()
+	emitMinimalManifest(t, in, 1000)
+	out := filepath.Join(t.TempDir(), "out.fsm")
+	code, err := run([]string{
+		"--input", in,
+		"--output", out,
+		"--last-commit-ts", "500",
+	}, quietLogger())
+	if err == nil {
+		t.Fatalf("run succeeded; want data error")
+	}
+	if code != exitDataErr {
+		t.Errorf("exit code = %d, want %d", code, exitDataErr)
+	}
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Errorf(".fsm at %s; data error must not publish", out)
+	}
+	// No temp file should linger either.
+	matches, _ := filepath.Glob(out + ".tmp-*")
+	if len(matches) > 0 {
+		t.Errorf("temp file lingered: %v", matches)
+	}
+}
+
+// TestParseLastCommitTSDecimal + Hex pin both representations the
+// --last-commit-ts flag accepts.
+func TestParseLastCommitTS(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		in   string
+		want uint64
+	}{
+		{"0", 0},
+		{"1234567890", 1234567890},
+		{"0xff", 0xff},
+		{"0X10", 0x10},
+	} {
+		got, err := parseLastCommitTS(tc.in)
+		if err != nil {
+			t.Errorf("%q: %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("%q: got %d want %d", tc.in, got, tc.want)
+		}
+	}
+	// Reject empty and malformed.
+	for _, bad := range []string{"", "abc", "0xZZ"} {
+		if _, err := parseLastCommitTS(bad); err == nil {
+			t.Errorf("%q parsed successfully; want error", bad)
+		}
+	}
+}
+
+// Helper to silence "unused strconv" if a future edit drops its only
+// use — kept here as the canonical numeric test pin. Strconv is used
+// implicitly in subtests via tc.argTS.
+var _ = strconv.FormatUint

--- a/cmd/elastickv-snapshot-encode/main_test.go
+++ b/cmd/elastickv-snapshot-encode/main_test.go
@@ -1071,6 +1071,65 @@ func assertSymlinkSidecarRollbackInvariants(t *testing.T, victim string, victimB
 	}
 }
 
+// TestCLISidecarWriteRefusesHardLinkTarget pins codex P2 v33 #904:
+// when the sidecar path is a hard link to an operator-owned file,
+// OpenSidecarFile refuses to truncate (Nlink > 1 guard); the v32
+// rollback's IsRegular()-only gate would have unlinked the hard
+// link anyway, destroying operator state. v34 routes the rollback
+// through a sidecarTruncated bool so a refused OpenSidecarFile
+// keeps the operator's entry intact. Unix-only (Windows hard-link
+// semantics differ).
+func TestCLISidecarWriteRefusesHardLinkTarget(t *testing.T) {
+	if isWindows {
+		t.Skip("hard-link refusal semantics differ on Windows")
+	}
+	t.Parallel()
+	in := t.TempDir()
+	emitMinimalManifest(t, in, 100)
+
+	outDir := t.TempDir()
+	out := filepath.Join(outDir, "out.fsm")
+	sidecarPath := backup.EncodeInfoSidecarPath(out)
+	// Pre-plant a victim file and hard-link the sidecar path to it.
+	victimDir := t.TempDir()
+	victim := filepath.Join(victimDir, "victim.json")
+	const victimBody = "VICTIM CONTENTS — must survive hard-link rejection"
+	if err := os.WriteFile(victim, []byte(victimBody), 0o600); err != nil {
+		t.Fatalf("WriteFile victim: %v", err)
+	}
+	if err := os.Link(victim, sidecarPath); err != nil {
+		t.Fatalf("Link victim → sidecar path: %v", err)
+	}
+
+	code, err := run([]string{"--input", in, "--output", out}, quietLogger())
+	if err == nil {
+		t.Fatalf("run succeeded; want sidecar open to fail on hard-linked path")
+	}
+	if code != exitUserErr {
+		t.Errorf("exit code = %d, want %d (operator-env error)", code, exitUserErr)
+	}
+	// Victim contents MUST be preserved (OpenSidecarFile's Nlink
+	// guard refused to truncate; v34 rollback's sidecarTruncated=false
+	// branch then skipped the os.Remove).
+	got, rerr := os.ReadFile(victim)
+	if rerr != nil {
+		t.Fatalf("read victim: %v", rerr)
+	}
+	if string(got) != victimBody {
+		t.Errorf("victim mutated; OpenSidecarFile truncated through hard link (codex P2 v33 regression)")
+	}
+	// The hard link at the sidecar path MUST also survive — the
+	// rollback no longer os.Removes it (codex P2 v33 fix).
+	if _, statErr := os.Lstat(sidecarPath); statErr != nil {
+		t.Errorf("hard link at sidecar path was removed by rollback (codex P2 v33 regression): %v", statErr)
+	}
+	// .fsm at outputPath MUST be removed (rollback's FSM branch
+	// always fires when the encode succeeded but sidecar failed).
+	if _, statErr := os.Stat(out); !os.IsNotExist(statErr) {
+		t.Errorf(".fsm at %s should be removed by rollback after sidecar failure", out)
+	}
+}
+
 // TestCLIPublishesFsmAndSidecarMode0600 pins claude v4 #904: the
 // produced .fsm and ENCODE_INFO.json are created with mode 0o600 so a
 // multi-user backup host does not get a world-readable dataset. The

--- a/internal/backup/encode_info.go
+++ b/internal/backup/encode_info.go
@@ -1,0 +1,114 @@
+package backup
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+
+	"github.com/cockroachdb/errors"
+)
+
+// EncodeInfoFormatVersion is the on-disk schema version for ENCODE_INFO.json.
+// Bumped on incompatible schema changes; ReadEncodeInfo rejects unknown
+// versions with ErrUnsupportedEncodeInfoFormatVersion so a future encoder
+// release cannot silently drop fields a current operator relies on.
+const EncodeInfoFormatVersion uint32 = 1
+
+// ErrUnsupportedEncodeInfoFormatVersion is returned by ReadEncodeInfo when
+// the sidecar's format_version is not EncodeInfoFormatVersion. Mirrors
+// the decoder's ErrUnsupportedFormatVersion contract so callers can branch
+// on errors.Is.
+var ErrUnsupportedEncodeInfoFormatVersion = errors.New("backup: unsupported ENCODE_INFO format_version")
+
+// EncodeInfoSelfTest captures the self-test outcome (parent §"Round-trip
+// self-test"). Ran=false when --self-test was off; Matched is only
+// meaningful when Ran=true.
+type EncodeInfoSelfTest struct {
+	Ran     bool `json:"ran"`
+	Matched bool `json:"matched"`
+}
+
+// EncodeInfo is the on-disk shape of <output>.encode_info.json. Schema
+// pinned by docs/design/2026_06_01_proposed_snapshot_encode_cli.md
+// §"ENCODE_INFO.json". Restore operators rely on this for "encoded for
+// the right cluster, by the right encoder version, against this exact
+// file" confirmation; tag changes are a breaking schema bump.
+type EncodeInfo struct {
+	FormatVersion           uint32             `json:"format_version"`
+	EncoderVersion          string             `json:"encoder_version"`
+	EncoderKeyFormatVersion uint32             `json:"encoder_key_format_version"`
+	WallTimeISO             string             `json:"wall_time_iso"`
+	InputRoot               string             `json:"input_root"`
+	OutputFSMPath           string             `json:"output_fsm_path"`
+	OutputFSMSHA256         string             `json:"output_fsm_sha256"`
+	LastCommitTS            uint64             `json:"last_commit_ts"`
+	LastCommitTSOverridden  bool               `json:"last_commit_ts_overridden"`
+	ManifestLastCommitTS    uint64             `json:"manifest_last_commit_ts"`
+	ManifestClusterID       string             `json:"manifest_cluster_id,omitempty"`
+	AdaptersEnabled         []string           `json:"adapters_enabled"`
+	SelfTest                EncodeInfoSelfTest `json:"self_test"`
+}
+
+// NewEncodeInfo stamps the current format version + wall time so callers
+// only fill in the encode-specific fields. Mirrors NewPhase0SnapshotManifest.
+// EncoderKeyFormatVersion is the on-disk key format the encoder produces;
+// today it tracks CurrentFormatVersion (no separate key-format version
+// has been declared), which is conservative: future encoder bumps that
+// change MVCC layout MUST bump both manifest and encoder-key formats so
+// restore operators can correlate.
+func NewEncodeInfo(now time.Time) EncodeInfo {
+	return EncodeInfo{
+		FormatVersion:           EncodeInfoFormatVersion,
+		EncoderKeyFormatVersion: CurrentFormatVersion,
+		WallTimeISO:             now.UTC().Format(time.RFC3339Nano),
+	}
+}
+
+// WriteEncodeInfo serializes info to w. Caller is responsible for the
+// fsync+close discipline (the cmd wrapper uses os.File.Sync then Close
+// to surface late writeback errors — gemini r1 medium on #810).
+func WriteEncodeInfo(w io.Writer, info EncodeInfo) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(info); err != nil {
+		return errors.Wrap(err, "encode ENCODE_INFO.json")
+	}
+	return nil
+}
+
+// ReadEncodeInfo parses an ENCODE_INFO.json payload from r. Rejects
+// unknown format_version values with ErrUnsupportedEncodeInfoFormatVersion
+// so a future schema bump surfaces as a typed error rather than a silent
+// field drop. Unknown JSON fields are tolerated to allow forward-compat
+// additions within the same format_version.
+func ReadEncodeInfo(r io.Reader) (EncodeInfo, error) {
+	body, err := io.ReadAll(r)
+	if err != nil {
+		return EncodeInfo{}, errors.Wrap(err, "read ENCODE_INFO.json")
+	}
+	var probe struct {
+		FormatVersion uint32 `json:"format_version"`
+	}
+	if err := json.Unmarshal(body, &probe); err != nil {
+		return EncodeInfo{}, errors.Wrap(err, "decode ENCODE_INFO.json format_version")
+	}
+	if probe.FormatVersion != EncodeInfoFormatVersion {
+		return EncodeInfo{}, errors.Wrapf(ErrUnsupportedEncodeInfoFormatVersion, "got %d, want %d", probe.FormatVersion, EncodeInfoFormatVersion)
+	}
+	var info EncodeInfo
+	if err := json.Unmarshal(body, &info); err != nil {
+		return EncodeInfo{}, errors.Wrap(err, "decode ENCODE_INFO.json")
+	}
+	return info, nil
+}
+
+// EncodeInfoSidecarPath returns the path-derived sidecar location for a
+// given .fsm output path. Multiple .fsm files can share a directory
+// (e.g., per-node dumps under /backups/); a static "ENCODE_INFO.json"
+// name would silently overwrite siblings (gemini medium #896).
+//
+// Convention: append ".encode_info.json" to the full output path. The
+// same scheme gpg and sha256sum follow when their input is path-addressable.
+func EncodeInfoSidecarPath(fsmPath string) string {
+	return fsmPath + ".encode_info.json"
+}

--- a/internal/backup/encode_info_test.go
+++ b/internal/backup/encode_info_test.go
@@ -1,0 +1,95 @@
+package backup
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+)
+
+// TestEncodeInfoRoundTrip pins WriteEncodeInfo -> ReadEncodeInfo for a
+// populated struct. Forward-compat: an ENCODE_INFO.json with unknown
+// extra fields at the same format_version must decode cleanly.
+func TestEncodeInfoRoundTrip(t *testing.T) {
+	t.Parallel()
+	info := NewEncodeInfo(time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC))
+	info.EncoderVersion = "test-rev"
+	info.InputRoot = "/in"
+	info.OutputFSMPath = "/out.fsm"
+	info.OutputFSMSHA256 = "deadbeef"
+	info.LastCommitTS = 18446744073709551610
+	info.LastCommitTSOverridden = false
+	info.ManifestLastCommitTS = 18446744073709551610
+	info.ManifestClusterID = "cluster-1"
+	info.AdaptersEnabled = []string{"redis", "dynamodb", "s3", "sqs"}
+	info.SelfTest = EncodeInfoSelfTest{Ran: true, Matched: true}
+
+	var buf bytes.Buffer
+	if err := WriteEncodeInfo(&buf, info); err != nil {
+		t.Fatalf("WriteEncodeInfo: %v", err)
+	}
+	got, err := ReadEncodeInfo(&buf)
+	if err != nil {
+		t.Fatalf("ReadEncodeInfo: %v", err)
+	}
+	if got.EncoderVersion != "test-rev" || got.OutputFSMSHA256 != "deadbeef" || got.LastCommitTS != 18446744073709551610 {
+		t.Errorf("round-trip mismatch: %+v", got)
+	}
+	if got.SelfTest.Ran != true || got.SelfTest.Matched != true {
+		t.Errorf("self_test field round-trip: %+v", got.SelfTest)
+	}
+
+	// Forward-compat: extra field at same version decodes cleanly.
+	withExtra := `{"format_version":1,"encoder_version":"x","wall_time_iso":"2026-06-01T12:00:00Z","input_root":"/in","output_fsm_path":"/out.fsm","output_fsm_sha256":"d","last_commit_ts":1,"last_commit_ts_overridden":false,"manifest_last_commit_ts":1,"adapters_enabled":[],"self_test":{"ran":false,"matched":false},"future_field":"ignored"}`
+	if _, err := ReadEncodeInfo(strings.NewReader(withExtra)); err != nil {
+		t.Errorf("forward-compat unknown field rejected: %v", err)
+	}
+}
+
+// TestEncodeInfoRejectsUnknownFormatVersion mirrors the decoder's
+// TestManifestVersionGate: a future schema bump surfaces as a typed
+// error rather than a silent field drop.
+func TestEncodeInfoRejectsUnknownFormatVersion(t *testing.T) {
+	t.Parallel()
+	bad := `{"format_version":99,"encoder_version":"x","wall_time_iso":"2026-06-01T12:00:00Z","input_root":"/in","output_fsm_path":"/out.fsm","output_fsm_sha256":"d","last_commit_ts":1,"last_commit_ts_overridden":false,"manifest_last_commit_ts":1,"adapters_enabled":[],"self_test":{"ran":false,"matched":false}}`
+	_, err := ReadEncodeInfo(strings.NewReader(bad))
+	if !errors.Is(err, ErrUnsupportedEncodeInfoFormatVersion) {
+		t.Fatalf("err = %v, want ErrUnsupportedEncodeInfoFormatVersion", err)
+	}
+}
+
+// TestExclusionsLegacyManifestOmitsRenameS3Collisions pins forward-compat
+// on the new rename_s3_collisions field. Older manifests written before
+// M6 do not include the field; ReadManifest must decode them with the
+// zero value (false) — NOT reject as ErrInvalidManifest (gemini medium
+// v5 #896).
+func TestExclusionsLegacyManifestOmitsRenameS3Collisions(t *testing.T) {
+	t.Parallel()
+	// Build a known-valid manifest via the public constructor, then
+	// rewrite the JSON to omit the rename_s3_collisions field — this
+	// is exactly the on-disk shape a pre-M6 decoder run would produce.
+	m := NewPhase0SnapshotManifest(time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC))
+	m.Exclusions = &Exclusions{}
+	m.Adapters = &Adapters{}
+	var buf bytes.Buffer
+	if err := WriteManifest(&buf, m); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+	// Strip the new field to simulate a legacy producer.
+	legacy := strings.ReplaceAll(buf.String(), `"rename_s3_collisions":false,`, ``)
+	legacy = strings.ReplaceAll(legacy, `,"rename_s3_collisions":false`, ``)
+	legacy = strings.ReplaceAll(legacy, `"rename_s3_collisions":false`, ``)
+
+	got, err := ReadManifest(strings.NewReader(legacy))
+	if err != nil {
+		t.Fatalf("legacy manifest must decode without error, got: %v", err)
+	}
+	if got.Exclusions == nil {
+		t.Fatalf("Exclusions = nil")
+	}
+	if got.Exclusions.RenameS3Collisions != false {
+		t.Errorf("RenameS3Collisions = %v, want false (zero value for missing field)", got.Exclusions.RenameS3Collisions)
+	}
+}

--- a/internal/backup/encode_s3.go
+++ b/internal/backup/encode_s3.go
@@ -90,7 +90,7 @@ func (e *S3RecordEncoder) Encode(b *snapshotBuilder) error {
 			// A regular file or symlink here means the dump is
 			// malformed or partially truncated — silently skipping
 			// would let the encoder publish a partial .fsm with
-			// the affected bucket omitted (codex P2 v32 #904; the
+			// the affected bucket omitted (codex P2 v31 #904; the
 			// manifest's empty S3 scope from populateAdapterScopes
 			// cannot otherwise distinguish missing bucket from
 			// dumped-empty bucket).

--- a/internal/backup/encode_s3.go
+++ b/internal/backup/encode_s3.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/bootjp/elastickv/internal/s3keys"
 	"github.com/cockroachdb/errors"
@@ -83,10 +84,34 @@ func (e *S3RecordEncoder) Encode(b *snapshotBuilder) error {
 		return err
 	}
 	for _, ent := range entries {
+		name := ent.Name()
 		if !ent.IsDir() {
-			continue
+			// Top-level entries under s3/ must be bucket directories.
+			// A regular file or symlink here means the dump is
+			// malformed or partially truncated — silently skipping
+			// would let the encoder publish a partial .fsm with
+			// the affected bucket omitted (codex P2 v32 #904; the
+			// manifest's empty S3 scope from populateAdapterScopes
+			// cannot otherwise distinguish missing bucket from
+			// dumped-empty bucket).
+			//
+			// Reserved-prefix entries that start with "_" (e.g.
+			// _incomplete_uploads, _orphans) are handled by their
+			// own dedicated paths and are NOT top-level buckets;
+			// the fail-closed should not catch them. Today the
+			// reverse encoder doesn't emit those subtrees at all
+			// (covered by ErrEncodeUnsupportedS3IncompleteUploads /
+			// ErrEncodeUnsupportedS3Orphans) so any "_*" entry here
+			// would have been rejected upstream — but skip them
+			// here too for forward compat.
+			if strings.HasPrefix(name, "_") {
+				continue
+			}
+			return errors.Wrapf(ErrS3EncodeNotRegular,
+				"s3/%s is not a directory (mode=%s); top-level entries under s3/ must be bucket directories",
+				name, ent.Type())
 		}
-		if err := e.encodeBucket(b, root, ent.Name()); err != nil {
+		if err := e.encodeBucket(b, root, name); err != nil {
 			return err
 		}
 	}

--- a/internal/backup/encode_s3_test.go
+++ b/internal/backup/encode_s3_test.go
@@ -137,6 +137,54 @@ func TestS3EncodeMissingDirIsNoop(t *testing.T) {
 	}
 }
 
+// TestS3EncodeRejectsNonDirectoryBucketEntry pins codex P2 v32 #904:
+// when an entry directly under s3/ is a regular file or symlink
+// rather than a bucket directory, the encoder must fail closed with
+// ErrS3EncodeNotRegular rather than silently skipping (which would
+// publish a partial .fsm with the affected bucket omitted; the
+// manifest's deferred-enumeration empty S3 scope cannot otherwise
+// flag the missing data). Reserved-prefix `_*` entries (e.g.
+// `_incomplete_uploads`) are explicitly tolerated because they're
+// handled by dedicated paths.
+func TestS3EncodeRejectsNonDirectoryBucketEntry(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(in, "s3"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Plant a regular file where a bucket directory should be.
+	if err := os.WriteFile(filepath.Join(in, "s3", "stray.txt"), []byte("oops"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	b := newSnapshotBuilder(s3EncTS)
+	err := NewS3RecordEncoder(in).Encode(b)
+	if !errors.Is(err, ErrS3EncodeNotRegular) {
+		t.Fatalf("Encode err = %v, want errors.Is ErrS3EncodeNotRegular", err)
+	}
+}
+
+// TestS3EncodeIgnoresReservedPrefixEntry pins that codex P2 v32's
+// fail-closed for non-directory top-level entries does NOT fire on
+// reserved-prefix entries (those starting with "_"). The reverse
+// encoder's unsupported-features guard handles those subtrees
+// separately via ErrEncodeUnsupportedS3IncompleteUploads /
+// ErrEncodeUnsupportedS3Orphans.
+func TestS3EncodeIgnoresReservedPrefixEntry(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(in, "s3"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Reserved-prefix file (e.g., a marker the operator left).
+	if err := os.WriteFile(filepath.Join(in, "s3", "_marker"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	b := newSnapshotBuilder(s3EncTS)
+	if err := NewS3RecordEncoder(in).Encode(b); err != nil {
+		t.Errorf("Encode err = %v, want nil (reserved-prefix entries should be skipped)", err)
+	}
+}
+
 // TestS3EncodeRejectsNonRegularBucketMeta pins the pre-open guard: a
 // _bucket.json that is a directory is refused with ErrS3EncodeNotRegular.
 func TestS3EncodeRejectsNonRegularBucketMeta(t *testing.T) {

--- a/internal/backup/encode_snapshot.go
+++ b/internal/backup/encode_snapshot.go
@@ -41,6 +41,22 @@ var ErrSelfTestLowerLastCommitTS = errors.New("backup: --last-commit-ts T < mani
 // until the encoder learns the JSONL layout (M7 / future milestone).
 var ErrEncodeUnsupportedDynamoDBLayout = errors.New("backup: DynamoDB JSONL layout not supported by encoder")
 
+// ErrEncodeAdapterData marks every error returned by an adapter
+// encoder (Redis / DynamoDB / S3 / SQS) so callers can distinguish
+// "the input tree contained content the encoder cannot translate"
+// from "operator passed a bad flag". The encoder is offline-only —
+// every adapter error originates from rejecting the content under
+// opts.InputRoot (a malformed DynamoDB _schema.json, an S3 collision
+// artifact the encoder cannot reverse, a SQS side-record with an
+// unknown kind, …). These are data-correctness failures, not user
+// errors; the CLI maps this sentinel to exit 2 so runbooks can branch
+// on exit status to quarantine bad dump data (codex P2 v9 #904).
+//
+// Wrapped via errors.Mark inside runAdapterEncoders so the original
+// adapter sentinel chain (ErrDDBEncodeInvalidSchema, …) is preserved
+// for callers that errors.Is on the more specific type.
+var ErrEncodeAdapterData = errors.New("backup: adapter encoder rejected input tree")
+
 // The encoder dispatch order (redis → dynamodb → s3 → sqs) is encoded
 // inside adapterRunners() and is intentionally distinct from decode.go's
 // finalize order (dynamodb → s3 → redis → sqs). The final .fsm byte
@@ -353,6 +369,12 @@ func adapterRunners() []adapterRunner {
 // runAdapterEncoders invokes each enabled adapter encoder in
 // canonicalAdapterFanOutOrder, returning the list of adapter names
 // actually invoked (for ENCODE_INFO.json adapters_enabled).
+//
+// Adapter errors are marked with ErrEncodeAdapterData so the CLI can
+// route them to exit-2 (data-correctness) rather than exit-1 (user
+// error). The original adapter sentinel chain is preserved — callers
+// that errors.Is on ErrDDBEncodeInvalidSchema, ErrS3EncodeKeyConflict,
+// etc. still see those (codex P2 v9 #904).
 func runAdapterEncoders(b *snapshotBuilder, opts EncodeOptions) ([]string, error) {
 	var enabled []string
 	for _, r := range adapterRunners() {
@@ -360,7 +382,7 @@ func runAdapterEncoders(b *snapshotBuilder, opts EncodeOptions) ([]string, error
 			continue
 		}
 		if err := r.encode(b, opts.InputRoot); err != nil {
-			return nil, err
+			return nil, errors.WithStack(errors.Mark(err, ErrEncodeAdapterData))
 		}
 		enabled = append(enabled, r.name)
 	}

--- a/internal/backup/encode_snapshot.go
+++ b/internal/backup/encode_snapshot.go
@@ -135,6 +135,22 @@ type EncodeOptions struct {
 	// the original decoder would have produced.
 	SelfTestDecodeOptions DecodeOptions
 
+	// AllowMissingManifest opts out of the MANIFEST.json presence
+	// check in validateEncodeOptions. When false (default),
+	// EncodeSnapshot requires <InputRoot>/MANIFEST.json to exist —
+	// the contract on InputRoot has always claimed this, but until
+	// codex P2 v17 #904 the library only checked the path was a
+	// directory, so a real library caller pointing at the wrong
+	// directory would silently emit a header-only .fsm (each enabled
+	// adapter no-ops when its top-level subdir is missing).
+	//
+	// Set to true for synthetic test fixtures that don't have a
+	// MANIFEST.json on disk. Production callers (CLI, Phase 1
+	// in-process extractor) MUST leave this at false so a bad
+	// InputRoot surfaces an explicit error rather than a
+	// silent-empty .fsm.
+	AllowMissingManifest bool
+
 	// corruptBufferForTest is an unexported test-only hook that fires
 	// against the on-disk self-test buffer AFTER snapshotBuilder.WriteTo
 	// returns but BEFORE the self-test DecodeSnapshot call (when
@@ -200,21 +216,8 @@ type EncodeResult struct {
 // Split out so EncodeSnapshot stays under the cyclop threshold; the
 // data-correctness checks live in validateEncodeOptionsData.
 func validateEncodeOptions(opts EncodeOptions, out io.Writer) error {
-	if opts.InputRoot == "" {
-		return errors.New("backup: EncodeOptions.InputRoot is required")
-	}
-	// Stat the path so a typo'd or deleted directory surfaces here
-	// rather than fan-out-no-op'ing every adapter and producing a
-	// header-only .fsm (codex P2 v8 #904). CLI callers indirectly
-	// catch this via os.Open(MANIFEST.json) before EncodeSnapshot,
-	// but a library caller that passes a stale path needs the guard
-	// at this layer.
-	info, statErr := os.Stat(opts.InputRoot)
-	if statErr != nil {
-		return errors.Wrapf(statErr, "stat InputRoot %q", opts.InputRoot)
-	}
-	if !info.IsDir() {
-		return errors.Errorf("backup: InputRoot %q is not a directory", opts.InputRoot)
+	if err := checkInputRoot(opts); err != nil {
+		return err
 	}
 	if out == nil {
 		return errors.New("backup: EncodeSnapshot out writer is nil")
@@ -225,6 +228,39 @@ func validateEncodeOptions(opts EncodeOptions, out io.Writer) error {
 		return errors.New("backup: EncodeOptions.Adapters has no enabled adapter")
 	}
 	return validateEncodeOptionsData(opts)
+}
+
+// checkInputRoot validates InputRoot's path-level invariants: present,
+// existing as a directory, and (unless AllowMissingManifest) contains
+// a MANIFEST.json. Split out of validateEncodeOptions to keep cyclop
+// happy and to make the three failure modes inspectable in isolation.
+func checkInputRoot(opts EncodeOptions) error {
+	if opts.InputRoot == "" {
+		return errors.New("backup: EncodeOptions.InputRoot is required")
+	}
+	// Stat the path so a typo'd or deleted directory surfaces here
+	// rather than fan-out-no-op'ing every adapter and producing a
+	// header-only .fsm (codex P2 v8 #904).
+	info, statErr := os.Stat(opts.InputRoot)
+	if statErr != nil {
+		return errors.Wrapf(statErr, "stat InputRoot %q", opts.InputRoot)
+	}
+	if !info.IsDir() {
+		return errors.Errorf("backup: InputRoot %q is not a directory", opts.InputRoot)
+	}
+	// Require MANIFEST.json at InputRoot unless the caller has
+	// explicitly opted out (codex P2 v17 #904). The doc on InputRoot
+	// has always required it; this guard catches a library caller
+	// pointing at an existing-but-wrong directory whose adapter
+	// subdirs are all absent — without this check the call would
+	// silently succeed and publish a header-only .fsm.
+	if !opts.AllowMissingManifest {
+		manifestPath := filepath.Join(opts.InputRoot, "MANIFEST.json")
+		if _, mstat := os.Stat(manifestPath); mstat != nil {
+			return errors.Wrapf(mstat, "stat MANIFEST.json under InputRoot %q (set EncodeOptions.AllowMissingManifest=true for synthetic fixtures)", opts.InputRoot)
+		}
+	}
+	return nil
 }
 
 // validateEncodeOptionsData covers the data-correctness pre-conditions:

--- a/internal/backup/encode_snapshot.go
+++ b/internal/backup/encode_snapshot.go
@@ -14,15 +14,18 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// ErrSelfTestLowerLastCommitTS is returned by EncodeSnapshot when the
-// effective LastCommitTS in EncodeOptions is below the manifest's value.
+// ErrSelfTestLowerLastCommitTS is the sentinel callers should return
+// when the operator-supplied T is below the manifest's last_commit_ts.
 // The HLC ceiling invariant (CLAUDE.md "Timestamp Oracle") forbids
 // lowering the ceiling on restore: a lower T would let a post-restart
 // leader issue a read ts ≤ a restored row's commit ts.
 //
-// Surfaced at the EncodeSnapshot layer so the CLI's main exits with code
-// 2 (data-correctness failure, per parent §"Exit codes"). Caller must
-// check errors.Is on this sentinel to map to the right exit code.
+// EncodeSnapshot itself does NOT read MANIFEST.json or enforce this
+// floor — the comparison happens in the CLI's resolveLastCommitTS
+// BEFORE EncodeSnapshot is called, and a future library caller (Phase 1
+// live extractor, integration tests) must perform its own comparison
+// and return this sentinel on regression so callers can errors.Is on
+// it to map to the right exit code (claude v3 doc bug #904).
 var ErrSelfTestLowerLastCommitTS = errors.New("backup: --last-commit-ts T < manifest.last_commit_ts (HLC ceiling regression)")
 
 // The encoder dispatch order (redis → dynamodb → s3 → sqs) is encoded
@@ -130,10 +133,14 @@ type EncodeResult struct {
 // The CLI relies on this contract to write mismatch.txt + exit 2;
 // library callers should follow the same pattern.
 //
-// Returns ErrSelfTestLowerLastCommitTS when opts.LastCommitTS is below
-// the manifest's value — caller is responsible for reading the manifest
-// and computing the effective T (this layer just validates the floor).
-// The CLI maps that error to exit code 2.
+// EncodeSnapshot does NOT read MANIFEST.json and does NOT validate
+// opts.LastCommitTS against any external floor — the caller is
+// responsible for reading the manifest, computing the effective T,
+// and returning ErrSelfTestLowerLastCommitTS on regression (the CLI's
+// resolveLastCommitTS performs this check before calling EncodeSnapshot
+// and maps that error to exit code 2). A future library caller that
+// skips that step would silently stamp a too-low timestamp into the
+// .fsm header (claude v3 doc bug #904).
 func EncodeSnapshot(opts EncodeOptions, out io.Writer) (EncodeResult, error) {
 	if opts.InputRoot == "" {
 		return EncodeResult{}, errors.New("backup: EncodeOptions.InputRoot is required")
@@ -194,9 +201,8 @@ func encodeBuffered(b *snapshotBuilder, opts EncodeOptions, enabled []string, ou
 		_ = os.Remove(tempPath)
 	}()
 
-	hasher := sha256.New()
-	tee := &teeWriter{w: tempFile, h: hasher}
-	bytesWritten, err := b.WriteTo(tee)
+	hashTee := newSHA256Writer(tempFile)
+	bytesWritten, err := b.WriteTo(hashTee)
 	if err != nil {
 		return EncodeResult{}, errors.WithStack(err)
 	}
@@ -211,8 +217,7 @@ func encodeBuffered(b *snapshotBuilder, opts EncodeOptions, enabled []string, ou
 	}
 
 	header, mismatchTxt, matched, stErr := runSelfTest(tempFile, opts)
-	var sha [32]byte
-	copy(sha[:], hasher.Sum(nil))
+	sha := hashTee.Sum()
 	result := EncodeResult{
 		Header:              header,
 		BytesWritten:        bytesWritten,
@@ -235,25 +240,6 @@ func encodeBuffered(b *snapshotBuilder, opts EncodeOptions, enabled []string, ou
 		return result, errors.Wrap(err, "copy buffered fsm to out")
 	}
 	return result, nil
-}
-
-// teeWriter tees writes into a hash.Hash + an underlying writer in a
-// single pass, avoiding a second read for the SHA-256 anchor that
-// ENCODE_INFO.json records.
-type teeWriter struct {
-	w io.Writer
-	h hash.Hash
-}
-
-func (t *teeWriter) Write(p []byte) (int, error) {
-	if _, err := t.h.Write(p); err != nil {
-		return 0, errors.WithStack(err)
-	}
-	n, err := t.w.Write(p)
-	if err != nil {
-		return n, errors.WithStack(err)
-	}
-	return n, nil
 }
 
 // adapterRunner pairs an enabled-check with an Encode call, keeping

--- a/internal/backup/encode_snapshot.go
+++ b/internal/backup/encode_snapshot.go
@@ -373,8 +373,9 @@ func adapterRunners() []adapterRunner {
 // Adapter errors are marked with ErrEncodeAdapterData so the CLI can
 // route them to exit-2 (data-correctness) rather than exit-1 (user
 // error). The original adapter sentinel chain is preserved — callers
-// that errors.Is on ErrDDBEncodeInvalidSchema, ErrS3EncodeKeyConflict,
-// etc. still see those (codex P2 v9 #904).
+// that errors.Is on ErrDDBEncodeInvalidSchema,
+// ErrS3EncodeUnsupportedCollision, etc. still see those (codex P2 v9
+// #904; phantom-sentinel doc fix from claude v10 #904).
 func runAdapterEncoders(b *snapshotBuilder, opts EncodeOptions) ([]string, error) {
 	var enabled []string
 	for _, r := range adapterRunners() {

--- a/internal/backup/encode_snapshot.go
+++ b/internal/backup/encode_snapshot.go
@@ -41,6 +41,35 @@ var ErrSelfTestLowerLastCommitTS = errors.New("backup: --last-commit-ts T < mani
 // until the encoder learns the JSONL layout (M7 / future milestone).
 var ErrEncodeUnsupportedDynamoDBLayout = errors.New("backup: DynamoDB JSONL layout not supported by encoder")
 
+// ErrEncodeUnsupportedS3IncompleteUploads is returned when a caller
+// (the CLI threading manifest.exclusions.include_incomplete_uploads,
+// or a library caller setting EncodeOptions.S3IncludeIncompleteUploads)
+// asks for S3 in-flight multipart uploads to round-trip, but the
+// reverse encoder cannot rebuild that subtree. The S3 reverse encoder
+// silently skips `_incomplete_uploads/` payload directories
+// (internal/backup/encode_s3_objects.go), so a dump that included
+// those records would publish an .fsm missing them. Fail closed until
+// the encoder learns the subtree (codex P2 v21 #904).
+var ErrEncodeUnsupportedS3IncompleteUploads = errors.New("backup: S3 include_incomplete_uploads not supported by encoder")
+
+// ErrEncodeUnsupportedS3Orphans is returned when the manifest (or a
+// library caller) requests round-tripping S3 pre-generation orphan
+// blob chunks but the reverse encoder cannot rebuild that subtree.
+// Same pattern as ErrEncodeUnsupportedS3IncompleteUploads — the S3
+// reverse encoder silently skips `_orphans/` payload directories;
+// fail closed until the encoder learns them (codex P2 v21 #904).
+var ErrEncodeUnsupportedS3Orphans = errors.New("backup: S3 include_orphans not supported by encoder")
+
+// ErrEncodeUnsupportedSQSPreserveVisibility is returned when the
+// manifest requests preserving in-flight SQS message visibility state
+// (`preserve_sqs_visibility=true`), but the reverse encoder
+// unconditionally resets VisibleAtMillis / receive count / first
+// receive / receipt token to zero on every restored message
+// (internal/backup/encode_sqs.go). A dump that intentionally
+// preserved visibility would silently restore as "every message
+// visible/reset" without this guard (codex P2 v21 #904).
+var ErrEncodeUnsupportedSQSPreserveVisibility = errors.New("backup: preserve_sqs_visibility not supported by encoder")
+
 // ErrRedisEncodeMultiDBUnsupported is returned when the input tree
 // contains a Redis db_<N>/ for any N != 0, or contains multiple
 // db_<N> directories. The current Redis MVCC key prefixes
@@ -106,6 +135,31 @@ type EncodeOptions struct {
 	// when true (codex P2 v7 #904). When the encoder gains JSONL
 	// support, this field will switch from a guard to a control.
 	DynamoDBBundleJSONL bool
+
+	// S3IncludeIncompleteUploads is true when the input dump's
+	// MANIFEST.json has `exclusions.include_incomplete_uploads=true`
+	// (the producer dumped in-flight multipart uploads under
+	// _incomplete_uploads/). The reverse encoder cannot rebuild that
+	// subtree today; fail-closed via ErrEncodeUnsupportedS3IncompleteUploads
+	// when true AND Adapters.S3 is enabled (codex P2 v21 #904).
+	S3IncludeIncompleteUploads bool
+
+	// S3IncludeOrphans is true when the input dump's MANIFEST.json
+	// has `exclusions.include_orphans=true` (the producer dumped
+	// pre-generation orphan blob chunks under _orphans/). The reverse
+	// encoder cannot rebuild that subtree today; fail-closed via
+	// ErrEncodeUnsupportedS3Orphans when true AND Adapters.S3 is
+	// enabled (codex P2 v21 #904).
+	S3IncludeOrphans bool
+
+	// PreserveSQSVisibility is true when the input dump's MANIFEST.json
+	// has `exclusions.preserve_sqs_visibility=true` (the producer
+	// preserved in-flight message visibility state — VisibleAtMillis,
+	// receive count, first receive, receipt token). The reverse
+	// encoder unconditionally zeros those fields on every restored
+	// message; fail-closed via ErrEncodeUnsupportedSQSPreserveVisibility
+	// when true AND Adapters.SQS is enabled (codex P2 v21 #904).
+	PreserveSQSVisibility bool
 
 	// ManifestLastCommitTS is the floor LastCommitTS must not fall
 	// below. When > 0, EncodeSnapshot fails-closed with
@@ -277,6 +331,34 @@ func validateEncodeOptionsData(opts EncodeOptions) error {
 		// The DynamoDB reverse encoder only walks per-item files;
 		// JSONL items would be silently skipped (codex P2 v7 #904).
 		return errors.WithStack(ErrEncodeUnsupportedDynamoDBLayout)
+	}
+	return validateEncodeOptionsUnsupportedFeatures(opts)
+}
+
+// validateEncodeOptionsUnsupportedFeatures rejects manifest-derived
+// flags that the per-adapter encoders cannot honor today. Each guard
+// fires only when the corresponding adapter is enabled — a caller
+// encoding only Redis + SQS with `include_incomplete_uploads=true`
+// inherited from the manifest is unaffected (no S3 → no concern).
+// Split out from validateEncodeOptionsData to stay under cyclop;
+// codex P2 v21 #904 added the three S3/SQS exclusion guards.
+func validateEncodeOptionsUnsupportedFeatures(opts EncodeOptions) error {
+	if opts.S3IncludeIncompleteUploads && opts.Adapters.S3 {
+		// The S3 reverse encoder skips _incomplete_uploads/ payload
+		// directories; a dump that included them would silently lose
+		// those records (codex P2 v21 #904 L326).
+		return errors.WithStack(ErrEncodeUnsupportedS3IncompleteUploads)
+	}
+	if opts.S3IncludeOrphans && opts.Adapters.S3 {
+		// The S3 reverse encoder skips _orphans/ payload directories;
+		// same silent-data-loss pattern (codex P2 v21 #904 L326).
+		return errors.WithStack(ErrEncodeUnsupportedS3Orphans)
+	}
+	if opts.PreserveSQSVisibility && opts.Adapters.SQS {
+		// The SQS reverse encoder unconditionally zeroes the
+		// visibility fields; a dump that preserved them would lose
+		// the state on restore (codex P2 v21 #904 L473).
+		return errors.WithStack(ErrEncodeUnsupportedSQSPreserveVisibility)
 	}
 	return nil
 }

--- a/internal/backup/encode_snapshot.go
+++ b/internal/backup/encode_snapshot.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"bytes"
 	"crypto/sha256"
+	"hash"
 	"io"
 	"os"
 	"path/filepath"
@@ -61,14 +62,19 @@ type EncodeOptions struct {
 	SelfTestDecodeOptions DecodeOptions
 
 	// corruptBufferForTest is an unexported test-only hook that fires
-	// against the internal *bytes.Buffer AFTER snapshotBuilder.WriteTo
+	// against the on-disk self-test buffer AFTER snapshotBuilder.WriteTo
 	// returns but BEFORE the self-test DecodeSnapshot call (when
 	// SelfTest=true). Same-package tests use it to inject corruption
 	// reachable by the self-test but never reaching the io.Writer
 	// passed to EncodeSnapshot (the write-then-rename invariant: a
 	// self-test failure must not publish corrupt bytes — codex P2 v6
 	// #896). External callers cannot set it (lowercase identifier).
-	corruptBufferForTest func([]byte)
+	//
+	// The hook receives the *os.File handle (positioned at offset 0)
+	// of the disk-backed self-test buffer; tests typically WriteAt
+	// a byte flip and rely on Seek-back-to-0 before returning so
+	// the encoder's subsequent Read sees the corrupted bytes.
+	corruptBufferForTest func(*os.File)
 }
 
 // EncodeResult is the public return value from EncodeSnapshot. Mirrors
@@ -150,26 +156,52 @@ func encodeStream(b *snapshotBuilder, opts EncodeOptions, enabled []string, out 
 	}, nil
 }
 
-// encodeBuffered is the SelfTest=true path: buffer, self-test against
-// buffer, copy to out only on match. Corruption hook (if set) fires
-// against the buffer between WriteTo and self-test so the self-test
-// sees the corruption but out never does (codex P2 v6 #896).
+// encodeBuffered is the SelfTest=true path: write the FSM to a temp
+// file on disk (NOT in memory — gemini high #904, OOM risk on large
+// snapshots), self-test by streaming the temp file through DecodeSnapshot,
+// copy to out only on match. The temp file is os.Remove'd via defer on
+// every exit path.
+//
+// Memory cost: O(1) — only the sha256 running state + read buffer for
+// the final io.Copy. Replaces the prior in-memory bytes.Buffer.
+//
+// Corruption hook (if set) fires against the temp file between WriteTo
+// and self-test so the self-test sees the corruption but out never does
+// (codex P2 v6 #896, codex P2 v7 #896).
 func encodeBuffered(b *snapshotBuilder, opts EncodeOptions, enabled []string, out io.Writer) (EncodeResult, error) {
-	var buf bytes.Buffer
-	bytesWritten, err := b.WriteTo(&buf)
+	tempFile, err := os.CreateTemp(opts.SelfTestDecodeOptions.OutRoot, "encode-self-test-fsm-")
+	if err != nil {
+		return EncodeResult{}, errors.Wrap(err, "create self-test temp file")
+	}
+	tempPath := tempFile.Name()
+	defer func() {
+		_ = tempFile.Close()
+		_ = os.Remove(tempPath)
+	}()
+
+	hasher := sha256.New()
+	tee := &teeWriter{w: tempFile, h: hasher}
+	bytesWritten, err := b.WriteTo(tee)
 	if err != nil {
 		return EncodeResult{}, errors.WithStack(err)
 	}
-	bufBytes := buf.Bytes()
+	if err := tempFile.Sync(); err != nil {
+		return EncodeResult{}, errors.Wrap(err, "fsync self-test temp file")
+	}
 	if opts.corruptBufferForTest != nil {
-		opts.corruptBufferForTest(bufBytes)
+		opts.corruptBufferForTest(tempFile)
+	}
+	if _, err := tempFile.Seek(0, io.SeekStart); err != nil {
+		return EncodeResult{}, errors.Wrap(err, "seek self-test temp file")
 	}
 
-	header, mismatchTxt, matched, stErr := runSelfTest(bufBytes, opts)
+	header, mismatchTxt, matched, stErr := runSelfTest(tempFile, opts)
+	var sha [32]byte
+	copy(sha[:], hasher.Sum(nil))
 	result := EncodeResult{
 		Header:              header,
 		BytesWritten:        bytesWritten,
-		SHA256:              sha256.Sum256(bufBytes),
+		SHA256:              sha,
 		SelfTestRan:         true,
 		SelfTestMatched:     matched,
 		SelfTestMismatchTxt: mismatchTxt,
@@ -181,10 +213,32 @@ func encodeBuffered(b *snapshotBuilder, opts EncodeOptions, enabled []string, ou
 	if !matched {
 		return result, nil
 	}
-	if _, err := io.Copy(out, bytes.NewReader(bufBytes)); err != nil {
+	if _, err := tempFile.Seek(0, io.SeekStart); err != nil {
+		return result, errors.Wrap(err, "rewind self-test temp file for copy")
+	}
+	if _, err := io.Copy(out, tempFile); err != nil {
 		return result, errors.Wrap(err, "copy buffered fsm to out")
 	}
 	return result, nil
+}
+
+// teeWriter tees writes into a hash.Hash + an underlying writer in a
+// single pass, avoiding a second read for the SHA-256 anchor that
+// ENCODE_INFO.json records.
+type teeWriter struct {
+	w io.Writer
+	h hash.Hash
+}
+
+func (t *teeWriter) Write(p []byte) (int, error) {
+	if _, err := t.h.Write(p); err != nil {
+		return 0, errors.WithStack(err)
+	}
+	n, err := t.w.Write(p)
+	if err != nil {
+		return n, errors.WithStack(err)
+	}
+	return n, nil
 }
 
 // adapterRunner pairs an enabled-check with an Encode call, keeping
@@ -229,15 +283,18 @@ func runAdapterEncoders(b *snapshotBuilder, opts EncodeOptions) ([]string, error
 	return enabled, nil
 }
 
-// runSelfTest decodes fsmBytes into a unique scratch subdir, structurally
-// diffs against opts.InputRoot, and returns (header, mismatchTxt, matched,
-// err). matched=false with err=nil indicates a structural diff; matched=true
-// with err=nil indicates success. err is non-nil only on infrastructure
-// failure (mkdir, decoder error, walk error).
+// runSelfTest streams fsmFile through DecodeSnapshot into a unique
+// scratch subdir, structurally diffs against opts.InputRoot, and returns
+// (header, mismatchTxt, matched, err). matched=false with err=nil
+// indicates a structural diff; matched=true with err=nil indicates
+// success. err is non-nil only on infrastructure failure (mkdir, decoder
+// error, walk error).
 //
-// The scratch subdir is removed via defer regardless of outcome. The
-// caller cleans up <output>.mismatch.txt at the start of each run.
-func runSelfTest(fsmBytes []byte, opts EncodeOptions) (SnapshotHeader, []byte, bool, error) {
+// fsmFile is read from its current position (caller must Seek(0) before
+// calling). The scratch subdir is removed via defer regardless of
+// outcome. The caller cleans up <output>.mismatch.txt at the start of
+// each run.
+func runSelfTest(fsmFile io.Reader, opts EncodeOptions) (SnapshotHeader, []byte, bool, error) {
 	scratchBase := opts.SelfTestDecodeOptions.OutRoot
 	scratchDir, err := os.MkdirTemp(scratchBase, "encode-self-test-")
 	if err != nil {
@@ -250,7 +307,7 @@ func runSelfTest(fsmBytes []byte, opts EncodeOptions) (SnapshotHeader, []byte, b
 	decOpts := opts.SelfTestDecodeOptions
 	decOpts.OutRoot = scratchDir
 
-	result, derr := DecodeSnapshot(bytes.NewReader(fsmBytes), decOpts)
+	result, derr := DecodeSnapshot(fsmFile, decOpts)
 	if derr != nil {
 		// Decoder errored on our own output — that IS a self-test
 		// failure (the .fsm we produced isn't loadable). Surface as
@@ -313,51 +370,50 @@ func enabledAdapterSubdirs(adapters AdapterSet) []string {
 }
 
 // diffOneSubdir walks aDir + bDir in parallel, returning paths (prefixed
-// by relPrefix) that differ in presence or bytes. Missing-on-one-side is
-// a mismatch.
+// by relPrefix) that differ in presence, size, or bytes. Files are
+// compared by streaming reads (NOT by loading whole bytes into memory)
+// so a multi-GB S3 blob does not OOM the encoder (gemini high #904).
+// Missing-on-one-side is a mismatch.
 func diffOneSubdir(aDir, bDir, relPrefix string) ([]string, error) {
-	aFiles, aErr := walkRegularFiles(aDir)
+	aPaths, aErr := walkRegularFilePaths(aDir)
 	if aErr != nil && !errors.Is(aErr, os.ErrNotExist) {
 		return nil, errors.Wrapf(aErr, "walk input %s", aDir)
 	}
-	bFiles, bErr := walkRegularFiles(bDir)
+	bPaths, bErr := walkRegularFilePaths(bDir)
 	if bErr != nil && !errors.Is(bErr, os.ErrNotExist) {
 		return nil, errors.Wrapf(bErr, "walk scratch %s", bDir)
 	}
 
 	var diffs []string
-	aMap := map[string][]byte{}
-	for path, body := range aFiles {
-		aMap[path] = body
-	}
-	for path, bBody := range bFiles {
-		aBody, ok := aMap[path]
+	for relPath, bFull := range bPaths {
+		aFull, ok := aPaths[relPath]
 		if !ok {
-			diffs = append(diffs, relPrefix+"/"+path+" (missing in input)")
+			diffs = append(diffs, relPrefix+"/"+relPath+" (missing in input)")
 			continue
 		}
-		if !bytes.Equal(aBody, bBody) {
-			diffs = append(diffs, relPrefix+"/"+path+" (bytes differ)")
+		eq, derr := streamFilesEqual(aFull, bFull)
+		if derr != nil {
+			return nil, errors.Wrapf(derr, "compare %s vs %s", aFull, bFull)
 		}
-		delete(aMap, path)
+		if !eq {
+			diffs = append(diffs, relPrefix+"/"+relPath+" (bytes differ)")
+		}
+		delete(aPaths, relPath)
 	}
-	// Anything remaining in aMap is present in input but not in scratch.
-	remaining := make([]string, 0, len(aMap))
-	for path := range aMap {
-		remaining = append(remaining, relPrefix+"/"+path+" (missing in scratch)")
+	remaining := make([]string, 0, len(aPaths))
+	for relPath := range aPaths {
+		remaining = append(remaining, relPrefix+"/"+relPath+" (missing in scratch)")
 	}
 	sort.Strings(remaining)
-	diffs = append(diffs, remaining...)
-	return diffs, nil
+	return append(diffs, remaining...), nil
 }
 
-// walkRegularFiles returns a map of relative path -> file bytes for every
-// regular file under root. Missing root is the empty map + os.ErrNotExist.
-// Bounded by the per-adapter test fixtures the encoder runs against;
-// production-scale dumps may want streaming compare, deferred until a
-// real bottleneck shows up.
-func walkRegularFiles(root string) (map[string][]byte, error) {
-	out := map[string][]byte{}
+// walkRegularFilePaths returns a map of relative path → absolute path
+// for every regular file under root. Replaces walkRegularFiles which
+// eagerly read file bytes; this version only records paths so the diff
+// can stream-compare per file (gemini high #904).
+func walkRegularFilePaths(root string) (map[string]string, error) {
+	out := map[string]string{}
 	rootInfo, err := os.Stat(root)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -369,26 +425,85 @@ func walkRegularFiles(root string) (map[string][]byte, error) {
 		if err != nil {
 			return err
 		}
-		if d.IsDir() {
+		if d.IsDir() || !d.Type().IsRegular() {
 			return nil
-		}
-		if !d.Type().IsRegular() {
-			return nil
-		}
-		body, rerr := os.ReadFile(path) //nolint:gosec // walking a caller-provided root, regular files only
-		if rerr != nil {
-			return errors.Wrap(rerr, path)
 		}
 		rel, rerr := filepath.Rel(root, path)
 		if rerr != nil {
 			return errors.WithStack(rerr)
 		}
-		out[filepath.ToSlash(rel)] = body
+		out[filepath.ToSlash(rel)] = path
 		return nil
 	}); err != nil {
 		return nil, errors.WithStack(err)
 	}
 	return out, nil
+}
+
+// streamCmpBufSize is the per-file read buffer for the streaming
+// compare. 64 KiB matches Go's default bufio buffer and keeps the
+// allocation small relative to the modal adapter file size.
+const streamCmpBufSize = 64 * 1024
+
+// streamFilesEqual reports whether the contents at aPath and bPath are
+// byte-equal without loading either file fully into memory. A size
+// mismatch short-circuits. Used by diffOneSubdir to bound the
+// self-test's memory at O(streamCmpBufSize) per concurrent compare
+// (gemini high #904).
+func streamFilesEqual(aPath, bPath string) (bool, error) {
+	aSize, err := fileSize(aPath)
+	if err != nil {
+		return false, err
+	}
+	bSize, err := fileSize(bPath)
+	if err != nil {
+		return false, err
+	}
+	if aSize != bSize {
+		return false, nil
+	}
+	aFile, err := os.Open(aPath) //nolint:gosec // walking caller-provided dirs
+	if err != nil {
+		return false, errors.WithStack(err)
+	}
+	defer func() { _ = aFile.Close() }()
+	bFile, err := os.Open(bPath) //nolint:gosec // walking caller-provided dirs
+	if err != nil {
+		return false, errors.WithStack(err)
+	}
+	defer func() { _ = bFile.Close() }()
+	return streamReadersEqual(aFile, bFile)
+}
+
+func fileSize(path string) (int64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, errors.WithStack(err)
+	}
+	return info.Size(), nil
+}
+
+// streamReadersEqual compares two readers of equal length chunk-by-chunk
+// and returns false on any difference, true on full match.
+func streamReadersEqual(a, b io.Reader) (bool, error) {
+	aBuf := make([]byte, streamCmpBufSize)
+	bBuf := make([]byte, streamCmpBufSize)
+	for {
+		an, aErr := io.ReadFull(a, aBuf)
+		bn, bErr := io.ReadFull(b, bBuf)
+		if an != bn || !bytes.Equal(aBuf[:an], bBuf[:bn]) {
+			return false, nil
+		}
+		if aErr == io.EOF || aErr == io.ErrUnexpectedEOF {
+			return true, nil
+		}
+		if aErr != nil {
+			return false, errors.WithStack(aErr)
+		}
+		if bErr != nil {
+			return false, errors.WithStack(bErr)
+		}
+	}
 }
 
 func formatHeaderMismatch(want, got uint64) string {

--- a/internal/backup/encode_snapshot.go
+++ b/internal/backup/encode_snapshot.go
@@ -1,0 +1,461 @@
+package backup
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+// ErrSelfTestLowerLastCommitTS is returned by EncodeSnapshot when the
+// effective LastCommitTS in EncodeOptions is below the manifest's value.
+// The HLC ceiling invariant (CLAUDE.md "Timestamp Oracle") forbids
+// lowering the ceiling on restore: a lower T would let a post-restart
+// leader issue a read ts ≤ a restored row's commit ts.
+//
+// Surfaced at the EncodeSnapshot layer so the CLI's main exits with code
+// 2 (data-correctness failure, per parent §"Exit codes"). Caller must
+// check errors.Is on this sentinel to map to the right exit code.
+var ErrSelfTestLowerLastCommitTS = errors.New("backup: --last-commit-ts T < manifest.last_commit_ts (HLC ceiling regression)")
+
+// The encoder dispatch order (redis → dynamodb → s3 → sqs) is encoded
+// inside adapterRunners() and is intentionally distinct from decode.go's
+// finalize order (dynamodb → s3 → redis → sqs). The final .fsm byte
+// sequence is determined by encoded-key sort (snapshotBuilder.WriteTo),
+// not by adapter fan-out order, so either ordering is correct as long
+// as it is fixed. The encoder follows the parent design doc's
+// enumeration order so ENCODE_INFO.json adapters_enabled is bytewise
+// reproducible across runs that pass --adapter in different sequences
+// (claude review v7 #896).
+
+// EncodeOptions configures EncodeSnapshot. Mirrors the decoder's
+// DecodeOptions in shape: required InputRoot, AdapterSet, then per-adapter
+// option flags read back from the input MANIFEST.json by the CLI.
+type EncodeOptions struct {
+	// InputRoot is the directory tree root produced by the decoder.
+	// Must contain MANIFEST.json; per-adapter encoders read their
+	// subtrees (redis/, dynamodb/, s3/, sqs/) directly off this root.
+	InputRoot string
+	// Adapters selects which adapter encoders to invoke; disabled
+	// adapters are skipped without error. Mirrors DecodeOptions.Adapters.
+	Adapters AdapterSet
+	// LastCommitTS is the EFFECTIVE T used for both the EKVPBBL1
+	// header and every key's invTS = ^T. Callers pass manifest.last_commit_ts
+	// by default and the --last-commit-ts override otherwise.
+	LastCommitTS uint64
+	// SelfTest enables the round-trip self-test. EncodeSnapshot buffers
+	// the FSM in *bytes.Buffer, decodes from the buffer, and copies to
+	// the caller's io.Writer only if the buffer survives DecodeSnapshot
+	// (i.e. the bytes the encoder produced are loadable). When false,
+	// the FSM streams straight to the writer with no extra buffering.
+	SelfTest bool
+	// SelfTestDecodeOptions are threaded into the scratch DecodeSnapshot
+	// call. The CLI reads MANIFEST.json's Exclusions + DynamoDBLayout
+	// and populates this so the self-test's scratch tree matches what
+	// the original decoder would have produced.
+	SelfTestDecodeOptions DecodeOptions
+
+	// corruptBufferForTest is an unexported test-only hook that fires
+	// against the internal *bytes.Buffer AFTER snapshotBuilder.WriteTo
+	// returns but BEFORE the self-test DecodeSnapshot call (when
+	// SelfTest=true). Same-package tests use it to inject corruption
+	// reachable by the self-test but never reaching the io.Writer
+	// passed to EncodeSnapshot (the write-then-rename invariant: a
+	// self-test failure must not publish corrupt bytes — codex P2 v6
+	// #896). External callers cannot set it (lowercase identifier).
+	corruptBufferForTest func([]byte)
+}
+
+// EncodeResult is the public return value from EncodeSnapshot. Mirrors
+// the decoder's DecodeResult shape.
+type EncodeResult struct {
+	// Header is what ReadSnapshotWithHeader returned when the encoder
+	// decoded its own output for the self-test. Header.LastCommitTS
+	// equals the effective T (uniform-stamping rule per parent doc
+	// §"MVCC re-encoding").
+	Header SnapshotHeader
+	// BytesWritten is the number of bytes written to the caller's
+	// io.Writer (the SHA256-anchored payload).
+	BytesWritten int64
+	// SHA256 of the produced .fsm (lowercase hex via SHA256Hex).
+	SHA256 [32]byte
+	// SelfTestRan is true iff opts.SelfTest was true AND the encoder
+	// ran (i.e. no earlier per-adapter error short-circuited).
+	SelfTestRan bool
+	// SelfTestMatched is meaningful only when SelfTestRan; reports
+	// whether the re-decode produced no diff against InputRoot.
+	SelfTestMatched bool
+	// SelfTestMismatchTxt is non-nil when SelfTestRan && !SelfTestMatched.
+	// The CLI writes it as <output>.mismatch.txt at exit 2.
+	SelfTestMismatchTxt []byte
+	// AdaptersEnabled is the canonical fan-out order of adapters that
+	// were actually invoked; ENCODE_INFO.json embeds this verbatim.
+	AdaptersEnabled []string
+}
+
+// EncodeSnapshot reads the directory tree at opts.InputRoot, invokes the
+// enabled per-adapter encoders in canonicalAdapterFanOutOrder, optionally
+// runs the round-trip self-test against the in-memory buffer, and writes
+// the .fsm bytes to out. The .fsm bytes are NOT returned; they go to out.
+//
+// When opts.SelfTest=false the FSM streams straight to out with no extra
+// buffering. When opts.SelfTest=true an internal *bytes.Buffer holds the
+// FSM during the self-test; bytes are copied to out only after the
+// self-test matches. Memory cost in self-test mode is one FSM-sized
+// allocation on top of the existing sort working set.
+//
+// Returns ErrSelfTestLowerLastCommitTS when opts.LastCommitTS is below
+// the manifest's value — caller is responsible for reading the manifest
+// and computing the effective T (this layer just validates the floor).
+// The CLI maps that error to exit code 2.
+func EncodeSnapshot(opts EncodeOptions, out io.Writer) (EncodeResult, error) {
+	if opts.InputRoot == "" {
+		return EncodeResult{}, errors.New("backup: EncodeOptions.InputRoot is required")
+	}
+	if out == nil {
+		return EncodeResult{}, errors.New("backup: EncodeSnapshot out writer is nil")
+	}
+
+	b := newSnapshotBuilder(opts.LastCommitTS)
+	enabled, err := runAdapterEncoders(b, opts)
+	if err != nil {
+		return EncodeResult{}, err
+	}
+
+	if !opts.SelfTest {
+		return encodeStream(b, opts, enabled, out)
+	}
+	return encodeBuffered(b, opts, enabled, out)
+}
+
+// encodeStream is the no-self-test path: SHA256 + writer tee with no
+// extra buffering. FSM bytes go straight to out.
+func encodeStream(b *snapshotBuilder, opts EncodeOptions, enabled []string, out io.Writer) (EncodeResult, error) {
+	hashWriter := newSHA256Writer(out)
+	bytesWritten, err := b.WriteTo(hashWriter)
+	if err != nil {
+		return EncodeResult{}, errors.WithStack(err)
+	}
+	return EncodeResult{
+		Header:          SnapshotHeader{LastCommitTS: opts.LastCommitTS},
+		BytesWritten:    bytesWritten,
+		SHA256:          hashWriter.Sum(),
+		SelfTestRan:     false,
+		AdaptersEnabled: enabled,
+	}, nil
+}
+
+// encodeBuffered is the SelfTest=true path: buffer, self-test against
+// buffer, copy to out only on match. Corruption hook (if set) fires
+// against the buffer between WriteTo and self-test so the self-test
+// sees the corruption but out never does (codex P2 v6 #896).
+func encodeBuffered(b *snapshotBuilder, opts EncodeOptions, enabled []string, out io.Writer) (EncodeResult, error) {
+	var buf bytes.Buffer
+	bytesWritten, err := b.WriteTo(&buf)
+	if err != nil {
+		return EncodeResult{}, errors.WithStack(err)
+	}
+	bufBytes := buf.Bytes()
+	if opts.corruptBufferForTest != nil {
+		opts.corruptBufferForTest(bufBytes)
+	}
+
+	header, mismatchTxt, matched, stErr := runSelfTest(bufBytes, opts)
+	result := EncodeResult{
+		Header:              header,
+		BytesWritten:        bytesWritten,
+		SHA256:              sha256.Sum256(bufBytes),
+		SelfTestRan:         true,
+		SelfTestMatched:     matched,
+		SelfTestMismatchTxt: mismatchTxt,
+		AdaptersEnabled:     enabled,
+	}
+	if stErr != nil {
+		return result, stErr
+	}
+	if !matched {
+		return result, nil
+	}
+	if _, err := io.Copy(out, bytes.NewReader(bufBytes)); err != nil {
+		return result, errors.Wrap(err, "copy buffered fsm to out")
+	}
+	return result, nil
+}
+
+// adapterRunner pairs an enabled-check with an Encode call, keeping
+// runAdapterEncoders's per-iteration body to two branches (cyclop).
+type adapterRunner struct {
+	name    string
+	enabled func(AdapterSet) bool
+	encode  func(*snapshotBuilder, string) error
+}
+
+func adapterRunners() []adapterRunner {
+	return []adapterRunner{
+		{"redis", func(s AdapterSet) bool { return s.Redis }, func(b *snapshotBuilder, root string) error {
+			return errors.Wrap(NewRedisEncoder(root, 0).Encode(b), "redis encoder")
+		}},
+		{"dynamodb", func(s AdapterSet) bool { return s.DynamoDB }, func(b *snapshotBuilder, root string) error {
+			return errors.Wrap(NewDynamoDBEncoder(root).Encode(b), "dynamodb encoder")
+		}},
+		{"s3", func(s AdapterSet) bool { return s.S3 }, func(b *snapshotBuilder, root string) error {
+			return errors.Wrap(NewS3RecordEncoder(root).Encode(b), "s3 encoder")
+		}},
+		{"sqs", func(s AdapterSet) bool { return s.SQS }, func(b *snapshotBuilder, root string) error {
+			return errors.Wrap(NewSQSRecordEncoder(root).Encode(b), "sqs encoder")
+		}},
+	}
+}
+
+// runAdapterEncoders invokes each enabled adapter encoder in
+// canonicalAdapterFanOutOrder, returning the list of adapter names
+// actually invoked (for ENCODE_INFO.json adapters_enabled).
+func runAdapterEncoders(b *snapshotBuilder, opts EncodeOptions) ([]string, error) {
+	var enabled []string
+	for _, r := range adapterRunners() {
+		if !r.enabled(opts.Adapters) {
+			continue
+		}
+		if err := r.encode(b, opts.InputRoot); err != nil {
+			return nil, err
+		}
+		enabled = append(enabled, r.name)
+	}
+	return enabled, nil
+}
+
+// runSelfTest decodes fsmBytes into a unique scratch subdir, structurally
+// diffs against opts.InputRoot, and returns (header, mismatchTxt, matched,
+// err). matched=false with err=nil indicates a structural diff; matched=true
+// with err=nil indicates success. err is non-nil only on infrastructure
+// failure (mkdir, decoder error, walk error).
+//
+// The scratch subdir is removed via defer regardless of outcome. The
+// caller cleans up <output>.mismatch.txt at the start of each run.
+func runSelfTest(fsmBytes []byte, opts EncodeOptions) (SnapshotHeader, []byte, bool, error) {
+	scratchBase := opts.SelfTestDecodeOptions.OutRoot
+	scratchDir, err := os.MkdirTemp(scratchBase, "encode-self-test-")
+	if err != nil {
+		return SnapshotHeader{}, nil, false, errors.Wrap(err, "mkdir scratch")
+	}
+	defer func() {
+		_ = os.RemoveAll(scratchDir)
+	}()
+
+	decOpts := opts.SelfTestDecodeOptions
+	decOpts.OutRoot = scratchDir
+
+	result, derr := DecodeSnapshot(bytes.NewReader(fsmBytes), decOpts)
+	if derr != nil {
+		// Decoder errored on our own output — that IS a self-test
+		// failure (the .fsm we produced isn't loadable). Surface as
+		// a mismatch with the decoder error embedded in the txt.
+		mismatchTxt := []byte("self-test failed: DecodeSnapshot rejected the produced .fsm: " + derr.Error())
+		return SnapshotHeader{}, mismatchTxt, false, nil
+	}
+
+	if result.Header.LastCommitTS != opts.LastCommitTS {
+		mismatchTxt := []byte(formatHeaderMismatch(opts.LastCommitTS, result.Header.LastCommitTS))
+		return result.Header, mismatchTxt, false, nil
+	}
+
+	diff, derr := diffAdapterTrees(opts.InputRoot, scratchDir, opts.Adapters)
+	if derr != nil {
+		return result.Header, nil, false, errors.Wrap(derr, "diff scratch tree")
+	}
+	if len(diff) > 0 {
+		return result.Header, []byte(strings.Join(diff, "\n") + "\n"), false, nil
+	}
+	return result.Header, nil, true, nil
+}
+
+// diffAdapterTrees returns a list of paths (relative to input/scratch
+// root) where the two trees differ, restricted to the adapter subtrees
+// enabled in adapters. MANIFEST.json itself is NOT compared — the scratch
+// doesn't have one (DecodeSnapshot library doesn't emit it; the CLI
+// wrapper does, codex P2 v1 #896 — header check above is the
+// last_commit_ts substitute). Bounded to selfTestMaxMismatchPaths.
+func diffAdapterTrees(inputRoot, scratchRoot string, adapters AdapterSet) ([]string, error) {
+	subdirs := enabledAdapterSubdirs(adapters)
+	var diffs []string
+	for _, sub := range subdirs {
+		paths, err := diffOneSubdir(filepath.Join(inputRoot, sub), filepath.Join(scratchRoot, sub), sub)
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, paths...)
+		if len(diffs) >= selfTestMaxMismatchPaths {
+			diffs = diffs[:selfTestMaxMismatchPaths]
+			diffs = append(diffs, "... (truncated; first "+itoa(selfTestMaxMismatchPaths)+" paths shown)")
+			return diffs, nil
+		}
+	}
+	return diffs, nil
+}
+
+const selfTestMaxMismatchPaths = 64
+
+// enabledAdapterSubdirs returns the top-level adapter subdir names for
+// the enabled adapters, in canonical order for stable mismatch.txt output.
+func enabledAdapterSubdirs(adapters AdapterSet) []string {
+	var out []string
+	for _, r := range adapterRunners() {
+		if r.enabled(adapters) {
+			out = append(out, r.name)
+		}
+	}
+	return out
+}
+
+// diffOneSubdir walks aDir + bDir in parallel, returning paths (prefixed
+// by relPrefix) that differ in presence or bytes. Missing-on-one-side is
+// a mismatch.
+func diffOneSubdir(aDir, bDir, relPrefix string) ([]string, error) {
+	aFiles, aErr := walkRegularFiles(aDir)
+	if aErr != nil && !errors.Is(aErr, os.ErrNotExist) {
+		return nil, errors.Wrapf(aErr, "walk input %s", aDir)
+	}
+	bFiles, bErr := walkRegularFiles(bDir)
+	if bErr != nil && !errors.Is(bErr, os.ErrNotExist) {
+		return nil, errors.Wrapf(bErr, "walk scratch %s", bDir)
+	}
+
+	var diffs []string
+	aMap := map[string][]byte{}
+	for path, body := range aFiles {
+		aMap[path] = body
+	}
+	for path, bBody := range bFiles {
+		aBody, ok := aMap[path]
+		if !ok {
+			diffs = append(diffs, relPrefix+"/"+path+" (missing in input)")
+			continue
+		}
+		if !bytes.Equal(aBody, bBody) {
+			diffs = append(diffs, relPrefix+"/"+path+" (bytes differ)")
+		}
+		delete(aMap, path)
+	}
+	// Anything remaining in aMap is present in input but not in scratch.
+	remaining := make([]string, 0, len(aMap))
+	for path := range aMap {
+		remaining = append(remaining, relPrefix+"/"+path+" (missing in scratch)")
+	}
+	sort.Strings(remaining)
+	diffs = append(diffs, remaining...)
+	return diffs, nil
+}
+
+// walkRegularFiles returns a map of relative path -> file bytes for every
+// regular file under root. Missing root is the empty map + os.ErrNotExist.
+// Bounded by the per-adapter test fixtures the encoder runs against;
+// production-scale dumps may want streaming compare, deferred until a
+// real bottleneck shows up.
+func walkRegularFiles(root string) (map[string][]byte, error) {
+	out := map[string][]byte{}
+	rootInfo, err := os.Stat(root)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if !rootInfo.IsDir() {
+		return nil, errors.Errorf("not a directory: %s", root)
+	}
+	if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		body, rerr := os.ReadFile(path) //nolint:gosec // walking a caller-provided root, regular files only
+		if rerr != nil {
+			return errors.Wrap(rerr, path)
+		}
+		rel, rerr := filepath.Rel(root, path)
+		if rerr != nil {
+			return errors.WithStack(rerr)
+		}
+		out[filepath.ToSlash(rel)] = body
+		return nil
+	}); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return out, nil
+}
+
+func formatHeaderMismatch(want, got uint64) string {
+	return "self-test failed: header.LastCommitTS mismatch (want " + uitoa(want) + ", got " + uitoa(got) + ")\n"
+}
+
+// uitoaCap is the max decimal length of a uint64 (math.MaxUint64 has
+// 20 digits). Constant so the cap is documented and lint-clean.
+const uitoaCap = 20
+
+func uitoa(v uint64) string {
+	if v == 0 {
+		return "0"
+	}
+	buf := make([]byte, 0, uitoaCap)
+	for v > 0 {
+		buf = append(buf, byte('0'+v%10))
+		v /= 10
+	}
+	for i, j := 0, len(buf)-1; i < j; i, j = i+1, j-1 {
+		buf[i], buf[j] = buf[j], buf[i]
+	}
+	return string(buf)
+}
+
+func itoa(v int) string {
+	if v < 0 {
+		return "-" + uitoa(uint64(-v))
+	}
+	return uitoa(uint64(v))
+}
+
+// sha256Writer wraps an io.Writer and tees every byte into a SHA-256
+// hasher so the encoder gets a single-pass SHA256 of the produced .fsm
+// without an extra buffer-pass. Used in the no-self-test streaming path.
+type sha256Writer struct {
+	w io.Writer
+	h sha256w
+}
+
+type sha256w = hashSHA256
+
+// hashSHA256 is an interface alias so we can satisfy the tiny hash.Hash
+// surface (Write + Sum32) without importing hash explicitly.
+type hashSHA256 interface {
+	io.Writer
+	Sum(b []byte) []byte
+}
+
+func newSHA256Writer(w io.Writer) *sha256Writer {
+	return &sha256Writer{w: w, h: sha256.New()}
+}
+
+func (s *sha256Writer) Write(p []byte) (int, error) {
+	if _, err := s.h.Write(p); err != nil {
+		// crypto/sha256 never errors on Write per stdlib contract.
+		return 0, errors.WithStack(err)
+	}
+	n, err := s.w.Write(p)
+	if err != nil {
+		return n, errors.WithStack(err)
+	}
+	return n, nil
+}
+
+func (s *sha256Writer) Sum() [32]byte {
+	var out [32]byte
+	copy(out[:], s.h.Sum(nil))
+	return out
+}

--- a/internal/backup/encode_snapshot.go
+++ b/internal/backup/encode_snapshot.go
@@ -318,7 +318,10 @@ func checkInputRoot(opts EncodeOptions) error {
 }
 
 // validateEncodeOptionsData covers the data-correctness pre-conditions:
-// HLC ceiling floor and DynamoDB JSONL guard. Kept separate from the
+// HLC ceiling floor, DynamoDB JSONL guard, and (via
+// validateEncodeOptionsUnsupportedFeatures) the three manifest
+// exclusion guards added by codex P2 v21 #904 (S3 incomplete uploads,
+// S3 orphans, SQS preserve-visibility). Kept separate from the
 // nil/empty-args checks so each function stays cyclop-clean.
 func validateEncodeOptionsData(opts EncodeOptions) error {
 	if opts.ManifestLastCommitTS > 0 && opts.LastCommitTS < opts.ManifestLastCommitTS {

--- a/internal/backup/encode_snapshot.go
+++ b/internal/backup/encode_snapshot.go
@@ -147,43 +147,27 @@ type EncodeResult struct {
 	AdaptersEnabled []string
 }
 
-// EncodeSnapshot reads the directory tree at opts.InputRoot, invokes the
-// enabled per-adapter encoders in canonical fan-out order, optionally
-// runs the round-trip self-test, and writes the .fsm bytes to out.
-// The .fsm bytes are NOT returned; they go to out.
-//
-// When opts.SelfTest=false the FSM streams straight to out with a
-// sha256 tee and no extra buffering. When opts.SelfTest=true the FSM
-// is written to an on-disk temp file (encode-self-test-fsm-*) under
-// opts.SelfTestDecodeOptions.OutRoot, the file is streamed through
-// DecodeSnapshot, and bytes are copied to out ONLY if the decode
-// survives. Memory cost in self-test mode is O(1) on top of the
-// sort working set (gemini high #904 — the earlier *bytes.Buffer
-// version would OOM on multi-GB snapshots).
-//
-// Self-test failure returns (result, nil) with result.SelfTestMatched
-// == false and result.SelfTestMismatchTxt populated. Callers MUST
-// check result.SelfTestMatched before treating a nil error as success.
-// The CLI relies on this contract to write mismatch.txt + exit 2;
-// library callers should follow the same pattern.
-//
-// EncodeSnapshot does NOT read MANIFEST.json itself, but it WILL
-// enforce a floor on opts.LastCommitTS when the caller threads the
-// manifest value through opts.ManifestLastCommitTS — a low
-// LastCommitTS returns ErrSelfTestLowerLastCommitTS BEFORE any bytes
-// are written. The CLI's resolveLastCommitTS sets both fields to the
-// reconciled values, and library callers SHOULD do the same. The
-// check is opt-in (ManifestLastCommitTS=0 disables it) so synthetic
-// test fixtures without a manifest reference can still call this
-// directly (codex P2 v2 #904).
 // validateEncodeOptions enforces the four pre-encode invariants:
-// InputRoot/out non-nil, non-empty adapter selection, optional
-// manifest-TS floor, and DDB JSONL guard. Split out so EncodeSnapshot
-// stays under the cyclop threshold; per-check helpers below keep each
-// branch's intent narrow.
+// InputRoot non-empty + exists-as-directory, out non-nil, non-empty
+// adapter selection, optional manifest-TS floor, and DDB JSONL guard.
+// Split out so EncodeSnapshot stays under the cyclop threshold; the
+// data-correctness checks live in validateEncodeOptionsData.
 func validateEncodeOptions(opts EncodeOptions, out io.Writer) error {
 	if opts.InputRoot == "" {
 		return errors.New("backup: EncodeOptions.InputRoot is required")
+	}
+	// Stat the path so a typo'd or deleted directory surfaces here
+	// rather than fan-out-no-op'ing every adapter and producing a
+	// header-only .fsm (codex P2 v8 #904). CLI callers indirectly
+	// catch this via os.Open(MANIFEST.json) before EncodeSnapshot,
+	// but a library caller that passes a stale path needs the guard
+	// at this layer.
+	info, statErr := os.Stat(opts.InputRoot)
+	if statErr != nil {
+		return errors.Wrapf(statErr, "stat InputRoot %q", opts.InputRoot)
+	}
+	if !info.IsDir() {
+		return errors.Errorf("backup: InputRoot %q is not a directory", opts.InputRoot)
 	}
 	if out == nil {
 		return errors.New("backup: EncodeSnapshot out writer is nil")
@@ -214,6 +198,35 @@ func validateEncodeOptionsData(opts EncodeOptions) error {
 	return nil
 }
 
+// EncodeSnapshot reads the directory tree at opts.InputRoot, invokes the
+// enabled per-adapter encoders in canonical fan-out order, optionally
+// runs the round-trip self-test, and writes the .fsm bytes to out.
+// The .fsm bytes are NOT returned; they go to out.
+//
+// When opts.SelfTest=false the FSM streams straight to out with a
+// sha256 tee and no extra buffering. When opts.SelfTest=true the FSM
+// is written to an on-disk temp file (encode-self-test-fsm-*) under
+// opts.SelfTestDecodeOptions.OutRoot, the file is streamed through
+// DecodeSnapshot, and bytes are copied to out ONLY if the decode
+// survives. Memory cost in self-test mode is O(1) on top of the
+// sort working set (gemini high #904 — the earlier *bytes.Buffer
+// version would OOM on multi-GB snapshots).
+//
+// Self-test failure returns (result, nil) with result.SelfTestMatched
+// == false and result.SelfTestMismatchTxt populated. Callers MUST
+// check result.SelfTestMatched before treating a nil error as success.
+// The CLI relies on this contract to write mismatch.txt + exit 2;
+// library callers should follow the same pattern.
+//
+// EncodeSnapshot does NOT read MANIFEST.json itself, but it WILL
+// enforce a floor on opts.LastCommitTS when the caller threads the
+// manifest value through opts.ManifestLastCommitTS — a low
+// LastCommitTS returns ErrSelfTestLowerLastCommitTS BEFORE any bytes
+// are written. The CLI's resolveLastCommitTS sets both fields to the
+// reconciled values, and library callers SHOULD do the same. The
+// check is opt-in (ManifestLastCommitTS=0 disables it) so synthetic
+// test fixtures without a manifest reference can still call this
+// directly (codex P2 v2 #904).
 func EncodeSnapshot(opts EncodeOptions, out io.Writer) (EncodeResult, error) {
 	if err := validateEncodeOptions(opts, out); err != nil {
 		return EncodeResult{}, err

--- a/internal/backup/encode_snapshot.go
+++ b/internal/backup/encode_snapshot.go
@@ -53,6 +53,18 @@ type EncodeOptions struct {
 	// header and every key's invTS = ^T. Callers pass manifest.last_commit_ts
 	// by default and the --last-commit-ts override otherwise.
 	LastCommitTS uint64
+	// ManifestLastCommitTS is the floor LastCommitTS must not fall
+	// below. When > 0, EncodeSnapshot fails-closed with
+	// ErrSelfTestLowerLastCommitTS if LastCommitTS < ManifestLastCommitTS.
+	// This is defense-in-depth for the CLI's pre-check (which already
+	// rejects --last-commit-ts T < manifest), and it's the load-bearing
+	// guard for future in-process library callers (Phase 1 live extractor,
+	// integration tests) that bypass the CLI: a library caller that
+	// forgets to compare against the manifest can no longer silently
+	// publish a low-TS .fsm (codex P2 v2 #904). Callers that genuinely
+	// have no manifest reference (synthetic test fixtures) leave this
+	// at 0 to opt out of the check.
+	ManifestLastCommitTS uint64
 	// SelfTest enables the round-trip self-test. When true,
 	// EncodeSnapshot writes the FSM to an on-disk temp file under
 	// SelfTestDecodeOptions.OutRoot (encode-self-test-fsm-*), streams
@@ -133,30 +145,49 @@ type EncodeResult struct {
 // The CLI relies on this contract to write mismatch.txt + exit 2;
 // library callers should follow the same pattern.
 //
-// EncodeSnapshot does NOT read MANIFEST.json and does NOT validate
-// opts.LastCommitTS against any external floor — the caller is
-// responsible for reading the manifest, computing the effective T,
-// and returning ErrSelfTestLowerLastCommitTS on regression (the CLI's
-// resolveLastCommitTS performs this check before calling EncodeSnapshot
-// and maps that error to exit code 2). A future library caller that
-// skips that step would silently stamp a too-low timestamp into the
-// .fsm header (claude v3 doc bug #904).
-func EncodeSnapshot(opts EncodeOptions, out io.Writer) (EncodeResult, error) {
+// EncodeSnapshot does NOT read MANIFEST.json itself, but it WILL
+// enforce a floor on opts.LastCommitTS when the caller threads the
+// manifest value through opts.ManifestLastCommitTS — a low
+// LastCommitTS returns ErrSelfTestLowerLastCommitTS BEFORE any bytes
+// are written. The CLI's resolveLastCommitTS sets both fields to the
+// reconciled values, and library callers SHOULD do the same. The
+// check is opt-in (ManifestLastCommitTS=0 disables it) so synthetic
+// test fixtures without a manifest reference can still call this
+// directly (codex P2 v2 #904).
+// validateEncodeOptions enforces the four pre-encode invariants:
+// InputRoot/out non-nil, non-empty adapter selection, and the optional
+// manifest-TS floor. Split out so EncodeSnapshot stays under the cyclop
+// threshold.
+func validateEncodeOptions(opts EncodeOptions, out io.Writer) error {
 	if opts.InputRoot == "" {
-		return EncodeResult{}, errors.New("backup: EncodeOptions.InputRoot is required")
+		return errors.New("backup: EncodeOptions.InputRoot is required")
 	}
 	if out == nil {
-		return EncodeResult{}, errors.New("backup: EncodeSnapshot out writer is nil")
+		return errors.New("backup: EncodeSnapshot out writer is nil")
 	}
 	if !opts.Adapters.DynamoDB && !opts.Adapters.S3 && !opts.Adapters.Redis && !opts.Adapters.SQS {
-		// A zero AdapterSet would silently produce a valid header-only
-		// .fsm with no adapter records — a "successful" empty restore
-		// artifact. The CLI's parseAdapterSet already rejects this for
-		// flag-driven entry, but a future in-process caller (Phase 1
-		// live extractor, integration tests) might forget to thread
-		// the set; fail-closed here so that mistake surfaces (codex v5
-		// + claude v5 #904).
-		return EncodeResult{}, errors.New("backup: EncodeOptions.Adapters has no enabled adapter")
+		// Zero AdapterSet would silently produce a header-only .fsm —
+		// a "successful" empty restore artifact. CLI's parseAdapterSet
+		// rejects this for flag-driven entry; library callers (Phase 1
+		// live extractor, integration tests) get the same guard here
+		// (codex v5 + claude v5 #904).
+		return errors.New("backup: EncodeOptions.Adapters has no enabled adapter")
+	}
+	if opts.ManifestLastCommitTS > 0 && opts.LastCommitTS < opts.ManifestLastCommitTS {
+		// Defense-in-depth HLC ceiling floor (codex P2 v2 #904). The
+		// CLI's resolveLastCommitTS already enforces this for flag-
+		// driven entry; library callers that thread the manifest value
+		// via ManifestLastCommitTS get the same fail-closed guard here.
+		return errors.Wrapf(ErrSelfTestLowerLastCommitTS,
+			"EncodeSnapshot opts.LastCommitTS %d < opts.ManifestLastCommitTS %d",
+			opts.LastCommitTS, opts.ManifestLastCommitTS)
+	}
+	return nil
+}
+
+func EncodeSnapshot(opts EncodeOptions, out io.Writer) (EncodeResult, error) {
+	if err := validateEncodeOptions(opts, out); err != nil {
+		return EncodeResult{}, err
 	}
 
 	b := newSnapshotBuilder(opts.LastCommitTS)

--- a/internal/backup/encode_snapshot.go
+++ b/internal/backup/encode_snapshot.go
@@ -135,6 +135,21 @@ type EncodeOptions struct {
 	corruptBufferForTest func(*os.File)
 }
 
+// SetSelfTestCorruptHookForTest installs a same-process hook that
+// fires against the on-disk self-test buffer between WriteTo and the
+// re-decode call. The hook can WriteAt into the file to inject
+// corruption so the subsequent self-test mismatches deterministically.
+//
+// Production code MUST NOT call this; it is exclusively a test seam
+// for callers OUTSIDE package backup (specifically the
+// cmd/elastickv-snapshot-encode CLI tests, which need to drive a real
+// end-to-end self-test mismatch to verify the stale-.fsm cleanup
+// path — codex P2 v10 #904). In-package tests should set
+// EncodeOptions.corruptBufferForTest directly.
+func (o *EncodeOptions) SetSelfTestCorruptHookForTest(hook func(*os.File)) {
+	o.corruptBufferForTest = hook
+}
+
 // EncodeResult is the public return value from EncodeSnapshot. Mirrors
 // the decoder's DecodeResult shape.
 type EncodeResult struct {

--- a/internal/backup/encode_snapshot.go
+++ b/internal/backup/encode_snapshot.go
@@ -14,19 +14,32 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// ErrSelfTestLowerLastCommitTS is the sentinel callers should return
-// when the operator-supplied T is below the manifest's last_commit_ts.
-// The HLC ceiling invariant (CLAUDE.md "Timestamp Oracle") forbids
-// lowering the ceiling on restore: a lower T would let a post-restart
-// leader issue a read ts ≤ a restored row's commit ts.
+// ErrSelfTestLowerLastCommitTS is returned when the operator-supplied
+// T is below the manifest's last_commit_ts. The HLC ceiling invariant
+// (CLAUDE.md "Timestamp Oracle") forbids lowering the ceiling on
+// restore: a lower T would let a post-restart leader issue a read
+// ts ≤ a restored row's commit ts.
 //
-// EncodeSnapshot itself does NOT read MANIFEST.json or enforce this
-// floor — the comparison happens in the CLI's resolveLastCommitTS
-// BEFORE EncodeSnapshot is called, and a future library caller (Phase 1
-// live extractor, integration tests) must perform its own comparison
-// and return this sentinel on regression so callers can errors.Is on
-// it to map to the right exit code (claude v3 doc bug #904).
+// Enforced at two layers:
+//   - CLI (`resolveLastCommitTS`) rejects --last-commit-ts T < manifest
+//     before EncodeSnapshot is called (exit code 2).
+//   - Library (`validateEncodeOptions`) rejects when the caller threads
+//     `opts.ManifestLastCommitTS > 0` and `opts.LastCommitTS` is below
+//     it — defense-in-depth for in-process callers (Phase 1 live
+//     extractor, integration tests) that bypass the CLI.
+//
+// Callers can errors.Is on this sentinel to map to the right exit code
+// (claude v3 doc bug #904 + claude v7 doc bug #904 + codex P2 v2 #904).
 var ErrSelfTestLowerLastCommitTS = errors.New("backup: --last-commit-ts T < manifest.last_commit_ts (HLC ceiling regression)")
+
+// ErrEncodeUnsupportedDynamoDBLayout is returned when an input dump
+// declares `dynamodb_layout: "jsonl"` in MANIFEST.json. The DynamoDB
+// reverse encoder only walks per-item files (items/*.json,
+// items/*/*.json) and would silently skip every items/data-*.jsonl
+// file, producing an .fsm with only table metadata and no items —
+// a silent-data-loss restore artifact (codex P2 v7 #904). Fail closed
+// until the encoder learns the JSONL layout (M7 / future milestone).
+var ErrEncodeUnsupportedDynamoDBLayout = errors.New("backup: DynamoDB JSONL layout not supported by encoder")
 
 // The encoder dispatch order (redis → dynamodb → s3 → sqs) is encoded
 // inside adapterRunners() and is intentionally distinct from decode.go's
@@ -53,6 +66,15 @@ type EncodeOptions struct {
 	// header and every key's invTS = ^T. Callers pass manifest.last_commit_ts
 	// by default and the --last-commit-ts override otherwise.
 	LastCommitTS uint64
+	// DynamoDBBundleJSONL is true when the input dump's MANIFEST.json
+	// has `dynamodb_layout: "jsonl"`. The reverse encoder does not
+	// support that layout — it would silently skip every
+	// items/data-*.jsonl file and publish an .fsm with only table
+	// metadata. Fail-closed via ErrEncodeUnsupportedDynamoDBLayout
+	// when true (codex P2 v7 #904). When the encoder gains JSONL
+	// support, this field will switch from a guard to a control.
+	DynamoDBBundleJSONL bool
+
 	// ManifestLastCommitTS is the floor LastCommitTS must not fall
 	// below. When > 0, EncodeSnapshot fails-closed with
 	// ErrSelfTestLowerLastCommitTS if LastCommitTS < ManifestLastCommitTS.
@@ -155,9 +177,10 @@ type EncodeResult struct {
 // test fixtures without a manifest reference can still call this
 // directly (codex P2 v2 #904).
 // validateEncodeOptions enforces the four pre-encode invariants:
-// InputRoot/out non-nil, non-empty adapter selection, and the optional
-// manifest-TS floor. Split out so EncodeSnapshot stays under the cyclop
-// threshold.
+// InputRoot/out non-nil, non-empty adapter selection, optional
+// manifest-TS floor, and DDB JSONL guard. Split out so EncodeSnapshot
+// stays under the cyclop threshold; per-check helpers below keep each
+// branch's intent narrow.
 func validateEncodeOptions(opts EncodeOptions, out io.Writer) error {
 	if opts.InputRoot == "" {
 		return errors.New("backup: EncodeOptions.InputRoot is required")
@@ -167,20 +190,26 @@ func validateEncodeOptions(opts EncodeOptions, out io.Writer) error {
 	}
 	if !opts.Adapters.DynamoDB && !opts.Adapters.S3 && !opts.Adapters.Redis && !opts.Adapters.SQS {
 		// Zero AdapterSet would silently produce a header-only .fsm —
-		// a "successful" empty restore artifact. CLI's parseAdapterSet
-		// rejects this for flag-driven entry; library callers (Phase 1
-		// live extractor, integration tests) get the same guard here
-		// (codex v5 + claude v5 #904).
+		// a "successful" empty restore artifact (codex v5 + claude v5 #904).
 		return errors.New("backup: EncodeOptions.Adapters has no enabled adapter")
 	}
+	return validateEncodeOptionsData(opts)
+}
+
+// validateEncodeOptionsData covers the data-correctness pre-conditions:
+// HLC ceiling floor and DynamoDB JSONL guard. Kept separate from the
+// nil/empty-args checks so each function stays cyclop-clean.
+func validateEncodeOptionsData(opts EncodeOptions) error {
 	if opts.ManifestLastCommitTS > 0 && opts.LastCommitTS < opts.ManifestLastCommitTS {
-		// Defense-in-depth HLC ceiling floor (codex P2 v2 #904). The
-		// CLI's resolveLastCommitTS already enforces this for flag-
-		// driven entry; library callers that thread the manifest value
-		// via ManifestLastCommitTS get the same fail-closed guard here.
+		// Defense-in-depth HLC ceiling floor (codex P2 v2 #904).
 		return errors.Wrapf(ErrSelfTestLowerLastCommitTS,
 			"EncodeSnapshot opts.LastCommitTS %d < opts.ManifestLastCommitTS %d",
 			opts.LastCommitTS, opts.ManifestLastCommitTS)
+	}
+	if opts.DynamoDBBundleJSONL && opts.Adapters.DynamoDB {
+		// The DynamoDB reverse encoder only walks per-item files;
+		// JSONL items would be silently skipped (codex P2 v7 #904).
+		return errors.WithStack(ErrEncodeUnsupportedDynamoDBLayout)
 	}
 	return nil
 }

--- a/internal/backup/encode_snapshot.go
+++ b/internal/backup/encode_snapshot.go
@@ -41,6 +41,22 @@ var ErrSelfTestLowerLastCommitTS = errors.New("backup: --last-commit-ts T < mani
 // until the encoder learns the JSONL layout (M7 / future milestone).
 var ErrEncodeUnsupportedDynamoDBLayout = errors.New("backup: DynamoDB JSONL layout not supported by encoder")
 
+// ErrRedisEncodeMultiDBUnsupported is returned when the input tree
+// contains a Redis db_<N>/ for any N != 0, or contains multiple
+// db_<N> directories. The current Redis MVCC key prefixes
+// (!redis|str|, !redis|hll|, !redis|ttl|, …) carry NO database
+// component, so feeding two distinct DBs into the same snapshot
+// builder would either collide on same-named keys or silently merge
+// both DBs under db_0 on restore (DecodeOptions.RedisDBIndex
+// defaults to 0). Failing closed preserves correctness until Phase 1
+// makes the native keys DB-aware (codex P2 v14 #904).
+//
+// v14 originally fanned out across db_<N> to address codex P1 v13's
+// silent-data-loss concern; codex's v14 follow-up clarified that
+// fan-out under the current key format produces mis-scoped output.
+// The corrected fix replaces fan-out with fail-closed.
+var ErrRedisEncodeMultiDBUnsupported = errors.New("backup: redis encoder requires single db_0 (multi-DB or non-zero DB not yet supported)")
+
 // ErrEncodeAdapterData marks every error returned by an adapter
 // encoder (Redis / DynamoDB / S3 / SQS) so callers can distinguish
 // "the input tree contained content the encoder cannot translate"
@@ -387,9 +403,20 @@ func enumerateRedisDBs(inRoot string) ([]int, error) {
 	}
 	var indices []int
 	for _, ent := range entries {
-		if idx, ok := parseRedisDBDir(ent); ok {
-			indices = append(indices, idx)
+		idx, ok := parseRedisDBName(ent.Name())
+		if !ok {
+			continue
 		}
+		// Canonical db_<N> name; entry MUST be a directory.
+		// Silently skipping a regular file or symlink at
+		// redis/db_<N> would let a malformed dump publish a
+		// header-only/partial FSM (codex P2 v14 #904 L427).
+		if !ent.IsDir() {
+			return nil, errors.Wrapf(ErrRedisEncodeNotDir,
+				"redis/%s exists but is not a directory (mode=%s)",
+				ent.Name(), ent.Type())
+		}
+		indices = append(indices, idx)
 	}
 	sort.Ints(indices)
 	return indices, nil
@@ -416,17 +443,19 @@ func checkRedisRoot(redisDir string) error {
 	return nil
 }
 
-// parseRedisDBDir returns (dbIndex, true) when ent names a canonical
-// db_<N> directory (N is a non-negative decimal with no leading zeros).
-// Non-matching entries return (0, false) so the caller can skip without
-// erroring — they cannot have been produced by the canonical decoder.
-// Reject non-canonical decimals so a hypothetical Phase 1 dumper cannot
-// double-emit the same db under two distinct directory names.
-func parseRedisDBDir(ent os.DirEntry) (int, bool) {
-	if !ent.IsDir() {
-		return 0, false
-	}
-	name := ent.Name()
+// parseRedisDBName returns (dbIndex, true) when name matches the
+// canonical db_<N> pattern (N is a non-negative decimal with no
+// leading zeros). Non-matching names return (0, false) so the caller
+// can skip them without erroring — they cannot have been produced by
+// the canonical decoder. Reject non-canonical decimals so a
+// hypothetical Phase 1 dumper cannot double-emit the same db under
+// two distinct directory names.
+//
+// This is a pure name parser; the caller is responsible for
+// validating the directory-entry shape (codex P2 v14 #904 L427
+// shifted the IsDir check to enumerateRedisDBs so a regular file
+// at redis/db_<N> fails closed instead of being silently skipped).
+func parseRedisDBName(name string) (int, bool) {
 	if !strings.HasPrefix(name, redisDBDirPrefix) {
 		return 0, false
 	}
@@ -438,20 +467,35 @@ func parseRedisDBDir(ent os.DirEntry) (int, bool) {
 	return idx, true
 }
 
-// encodeAllRedisDBs invokes NewRedisEncoder per discovered db_<N>
-// directory in ascending index order. A missing redis/ directory is a
-// no-op. Codex P1 v13 #904: replaces the prior hardcoded db_0 fan-out
-// which would silently drop non-default DBs from any Phase 1 multi-DB
-// dump. Per-DB errors are wrapped with the db index for traceability.
+// encodeAllRedisDBs invokes NewRedisEncoder for redis/db_0/ when the
+// input tree has exactly that DB (or no Redis content at all). A
+// missing redis/ directory is a no-op. Any non-zero DB or the
+// presence of multiple db_<N> directories fails closed with
+// ErrRedisEncodeMultiDBUnsupported.
+//
+// Codex P1 v13 #904 originally asked for a per-DB fan-out to address
+// the prior hardcoded db_0 dispatch silently dropping non-default
+// DBs. Codex P2 v14 #904 (L452) clarified that fan-out under the
+// current MVCC key prefixes (!redis|str|, !redis|hll|, !redis|ttl|,
+// …, none of which carry a database component) would either collide
+// on same-named keys across DBs or merge everything under db_0 at
+// decode time. The corrected fix replaces the silent drop and the
+// incorrect fan-out with a fail-closed sentinel until Phase 1
+// makes the native keys DB-aware.
 func encodeAllRedisDBs(b *snapshotBuilder, inRoot string) error {
 	indices, err := enumerateRedisDBs(inRoot)
 	if err != nil {
 		return errors.Wrap(err, "redis encoder enumerate")
 	}
-	for _, idx := range indices {
-		if err := NewRedisEncoder(inRoot, idx).Encode(b); err != nil {
-			return errors.Wrapf(err, "redis encoder db_%d", idx)
-		}
+	if len(indices) == 0 {
+		return nil
+	}
+	if len(indices) > 1 || indices[0] != 0 {
+		return errors.Wrapf(ErrRedisEncodeMultiDBUnsupported,
+			"redis encoder enumerated db indices %v", indices)
+	}
+	if err := NewRedisEncoder(inRoot, 0).Encode(b); err != nil {
+		return errors.Wrap(err, "redis encoder db_0")
 	}
 	return nil
 }

--- a/internal/backup/encode_snapshot.go
+++ b/internal/backup/encode_snapshot.go
@@ -356,6 +356,106 @@ func encodeBuffered(b *snapshotBuilder, opts EncodeOptions, enabled []string, ou
 	return result, nil
 }
 
+// redisDBDirPrefix is the canonical "db_" prefix produced by the
+// decoder for redis/db_<N>/ directories. Mirrored by encoder
+// enumeration (encodeAllRedisDBs) so a multi-DB dump round-trips.
+const redisDBDirPrefix = "db_"
+
+// enumerateRedisDBs returns the sorted dbIndex values for which
+// <inRoot>/redis/db_<N>/ exists as a directory. A missing redis/
+// directory returns nil; the caller treats it as no-op (same convention
+// as the per-DB encoder, which is a no-op when its db_<n> subdir is
+// absent). Non-db_<N> entries (regular files, symlinks at the redis/
+// level, non-numeric or non-canonical suffixes like "db_-1" or
+// "db_01") are silently skipped — they cannot have been produced by
+// the canonical decoder and are not the encoder's concern.
+//
+// Codex P1 v13 #904: replaces the prior hardcoded NewRedisEncoder(_, 0)
+// in adapterRunners that silently dropped non-default DBs from any
+// future Phase 1 multi-DB dump.
+func enumerateRedisDBs(inRoot string) ([]int, error) {
+	redisDir := filepath.Join(inRoot, "redis")
+	if err := checkRedisRoot(redisDir); err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(redisDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, errors.WithStack(err)
+	}
+	var indices []int
+	for _, ent := range entries {
+		if idx, ok := parseRedisDBDir(ent); ok {
+			indices = append(indices, idx)
+		}
+	}
+	sort.Ints(indices)
+	return indices, nil
+}
+
+// checkRedisRoot stats <inRoot>/redis/ and rejects symlink / non-dir
+// shapes. Missing is allowed (caller returns nil indices). Split out
+// of enumerateRedisDBs to keep that function under the cyclop bound.
+func checkRedisRoot(redisDir string) error {
+	info, err := os.Lstat(redisDir)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return nil
+	case err != nil:
+		return errors.WithStack(err)
+	case info.Mode()&os.ModeSymlink != 0:
+		// Symlinked redis/ would let os.OpenRoot in the per-DB encoder
+		// resolve outside the dump tree (mirrors the per-DB encoder's
+		// symlink refusal on redis/db_<n>).
+		return errors.Wrapf(ErrRedisEncodeNotDir, "redis path %q is a symlink", redisDir)
+	case !info.IsDir():
+		return errors.Wrapf(ErrRedisEncodeNotDir, "redis path %q is not a directory", redisDir)
+	}
+	return nil
+}
+
+// parseRedisDBDir returns (dbIndex, true) when ent names a canonical
+// db_<N> directory (N is a non-negative decimal with no leading zeros).
+// Non-matching entries return (0, false) so the caller can skip without
+// erroring — they cannot have been produced by the canonical decoder.
+// Reject non-canonical decimals so a hypothetical Phase 1 dumper cannot
+// double-emit the same db under two distinct directory names.
+func parseRedisDBDir(ent os.DirEntry) (int, bool) {
+	if !ent.IsDir() {
+		return 0, false
+	}
+	name := ent.Name()
+	if !strings.HasPrefix(name, redisDBDirPrefix) {
+		return 0, false
+	}
+	suffix := name[len(redisDBDirPrefix):]
+	idx, err := strconv.Atoi(suffix)
+	if err != nil || idx < 0 || strconv.Itoa(idx) != suffix {
+		return 0, false
+	}
+	return idx, true
+}
+
+// encodeAllRedisDBs invokes NewRedisEncoder per discovered db_<N>
+// directory in ascending index order. A missing redis/ directory is a
+// no-op. Codex P1 v13 #904: replaces the prior hardcoded db_0 fan-out
+// which would silently drop non-default DBs from any Phase 1 multi-DB
+// dump. Per-DB errors are wrapped with the db index for traceability.
+func encodeAllRedisDBs(b *snapshotBuilder, inRoot string) error {
+	indices, err := enumerateRedisDBs(inRoot)
+	if err != nil {
+		return errors.Wrap(err, "redis encoder enumerate")
+	}
+	for _, idx := range indices {
+		if err := NewRedisEncoder(inRoot, idx).Encode(b); err != nil {
+			return errors.Wrapf(err, "redis encoder db_%d", idx)
+		}
+	}
+	return nil
+}
+
 // adapterRunner pairs an enabled-check with an Encode call, keeping
 // runAdapterEncoders's per-iteration body to two branches (cyclop).
 type adapterRunner struct {
@@ -366,9 +466,7 @@ type adapterRunner struct {
 
 func adapterRunners() []adapterRunner {
 	return []adapterRunner{
-		{"redis", func(s AdapterSet) bool { return s.Redis }, func(b *snapshotBuilder, root string) error {
-			return errors.Wrap(NewRedisEncoder(root, 0).Encode(b), "redis encoder")
-		}},
+		{"redis", func(s AdapterSet) bool { return s.Redis }, encodeAllRedisDBs},
 		{"dynamodb", func(s AdapterSet) bool { return s.DynamoDB }, func(b *snapshotBuilder, root string) error {
 			return errors.Wrap(NewDynamoDBEncoder(root).Encode(b), "dynamodb encoder")
 		}},

--- a/internal/backup/encode_snapshot.go
+++ b/internal/backup/encode_snapshot.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/cockroachdb/errors"
@@ -49,11 +50,15 @@ type EncodeOptions struct {
 	// header and every key's invTS = ^T. Callers pass manifest.last_commit_ts
 	// by default and the --last-commit-ts override otherwise.
 	LastCommitTS uint64
-	// SelfTest enables the round-trip self-test. EncodeSnapshot buffers
-	// the FSM in *bytes.Buffer, decodes from the buffer, and copies to
-	// the caller's io.Writer only if the buffer survives DecodeSnapshot
-	// (i.e. the bytes the encoder produced are loadable). When false,
-	// the FSM streams straight to the writer with no extra buffering.
+	// SelfTest enables the round-trip self-test. When true,
+	// EncodeSnapshot writes the FSM to an on-disk temp file under
+	// SelfTestDecodeOptions.OutRoot (encode-self-test-fsm-*), streams
+	// it through DecodeSnapshot, and copies to the caller's io.Writer
+	// ONLY if the decode survives — i.e. the bytes the encoder
+	// produced are loadable. When false, the FSM streams straight to
+	// the writer with no extra buffering. Memory cost in self-test
+	// mode is O(1) on top of the sort working set (the temp file
+	// holds the snapshot; only a small streaming buffer is in RAM).
 	SelfTest bool
 	// SelfTestDecodeOptions are threaded into the scratch DecodeSnapshot
 	// call. The CLI reads MANIFEST.json's Exclusions + DynamoDBLayout
@@ -88,7 +93,8 @@ type EncodeResult struct {
 	// BytesWritten is the number of bytes written to the caller's
 	// io.Writer (the SHA256-anchored payload).
 	BytesWritten int64
-	// SHA256 of the produced .fsm (lowercase hex via SHA256Hex).
+	// SHA256 of the produced .fsm bytes (raw 32-byte digest; the CLI
+	// hex-encodes it via encoding/hex when writing ENCODE_INFO.json).
 	SHA256 [32]byte
 	// SelfTestRan is true iff opts.SelfTest was true AND the encoder
 	// ran (i.e. no earlier per-adapter error short-circuited).
@@ -105,15 +111,24 @@ type EncodeResult struct {
 }
 
 // EncodeSnapshot reads the directory tree at opts.InputRoot, invokes the
-// enabled per-adapter encoders in canonicalAdapterFanOutOrder, optionally
-// runs the round-trip self-test against the in-memory buffer, and writes
-// the .fsm bytes to out. The .fsm bytes are NOT returned; they go to out.
+// enabled per-adapter encoders in canonical fan-out order, optionally
+// runs the round-trip self-test, and writes the .fsm bytes to out.
+// The .fsm bytes are NOT returned; they go to out.
 //
-// When opts.SelfTest=false the FSM streams straight to out with no extra
-// buffering. When opts.SelfTest=true an internal *bytes.Buffer holds the
-// FSM during the self-test; bytes are copied to out only after the
-// self-test matches. Memory cost in self-test mode is one FSM-sized
-// allocation on top of the existing sort working set.
+// When opts.SelfTest=false the FSM streams straight to out with a
+// sha256 tee and no extra buffering. When opts.SelfTest=true the FSM
+// is written to an on-disk temp file (encode-self-test-fsm-*) under
+// opts.SelfTestDecodeOptions.OutRoot, the file is streamed through
+// DecodeSnapshot, and bytes are copied to out ONLY if the decode
+// survives. Memory cost in self-test mode is O(1) on top of the
+// sort working set (gemini high #904 — the earlier *bytes.Buffer
+// version would OOM on multi-GB snapshots).
+//
+// Self-test failure returns (result, nil) with result.SelfTestMatched
+// == false and result.SelfTestMismatchTxt populated. Callers MUST
+// check result.SelfTestMatched before treating a nil error as success.
+// The CLI relies on this contract to write mismatch.txt + exit 2;
+// library callers should follow the same pattern.
 //
 // Returns ErrSelfTestLowerLastCommitTS when opts.LastCommitTS is below
 // the manifest's value — caller is responsible for reading the manifest
@@ -348,7 +363,7 @@ func diffAdapterTrees(inputRoot, scratchRoot string, adapters AdapterSet) ([]str
 		diffs = append(diffs, paths...)
 		if len(diffs) >= selfTestMaxMismatchPaths {
 			diffs = diffs[:selfTestMaxMismatchPaths]
-			diffs = append(diffs, "... (truncated; first "+itoa(selfTestMaxMismatchPaths)+" paths shown)")
+			diffs = append(diffs, "... (truncated; first "+strconv.Itoa(selfTestMaxMismatchPaths)+" paths shown)")
 			return diffs, nil
 		}
 	}
@@ -373,7 +388,9 @@ func enabledAdapterSubdirs(adapters AdapterSet) []string {
 // by relPrefix) that differ in presence, size, or bytes. Files are
 // compared by streaming reads (NOT by loading whole bytes into memory)
 // so a multi-GB S3 blob does not OOM the encoder (gemini high #904).
-// Missing-on-one-side is a mismatch.
+// Missing-on-one-side is a mismatch. The returned diffs are sorted
+// alphabetically so mismatch.txt is deterministic across runs with
+// identical inputs (claude v2 carry-over observation #904).
 func diffOneSubdir(aDir, bDir, relPrefix string) ([]string, error) {
 	aPaths, aErr := walkRegularFilePaths(aDir)
 	if aErr != nil && !errors.Is(aErr, os.ErrNotExist) {
@@ -400,12 +417,11 @@ func diffOneSubdir(aDir, bDir, relPrefix string) ([]string, error) {
 		}
 		delete(aPaths, relPath)
 	}
-	remaining := make([]string, 0, len(aPaths))
 	for relPath := range aPaths {
-		remaining = append(remaining, relPrefix+"/"+relPath+" (missing in scratch)")
+		diffs = append(diffs, relPrefix+"/"+relPath+" (missing in scratch)")
 	}
-	sort.Strings(remaining)
-	return append(diffs, remaining...), nil
+	sort.Strings(diffs)
+	return diffs, nil
 }
 
 // walkRegularFilePaths returns a map of relative path → absolute path
@@ -507,33 +523,11 @@ func streamReadersEqual(a, b io.Reader) (bool, error) {
 }
 
 func formatHeaderMismatch(want, got uint64) string {
-	return "self-test failed: header.LastCommitTS mismatch (want " + uitoa(want) + ", got " + uitoa(got) + ")\n"
-}
-
-// uitoaCap is the max decimal length of a uint64 (math.MaxUint64 has
-// 20 digits). Constant so the cap is documented and lint-clean.
-const uitoaCap = 20
-
-func uitoa(v uint64) string {
-	if v == 0 {
-		return "0"
-	}
-	buf := make([]byte, 0, uitoaCap)
-	for v > 0 {
-		buf = append(buf, byte('0'+v%10))
-		v /= 10
-	}
-	for i, j := 0, len(buf)-1; i < j; i, j = i+1, j-1 {
-		buf[i], buf[j] = buf[j], buf[i]
-	}
-	return string(buf)
-}
-
-func itoa(v int) string {
-	if v < 0 {
-		return "-" + uitoa(uint64(-v))
-	}
-	return uitoa(uint64(v))
+	return "self-test failed: header.LastCommitTS mismatch (want " +
+		strconv.FormatUint(want, 10) +
+		", got " +
+		strconv.FormatUint(got, 10) +
+		")\n"
 }
 
 // sha256Writer wraps an io.Writer and tees every byte into a SHA-256
@@ -541,16 +535,7 @@ func itoa(v int) string {
 // without an extra buffer-pass. Used in the no-self-test streaming path.
 type sha256Writer struct {
 	w io.Writer
-	h sha256w
-}
-
-type sha256w = hashSHA256
-
-// hashSHA256 is an interface alias so we can satisfy the tiny hash.Hash
-// surface (Write + Sum32) without importing hash explicitly.
-type hashSHA256 interface {
-	io.Writer
-	Sum(b []byte) []byte
+	h hash.Hash
 }
 
 func newSHA256Writer(w io.Writer) *sha256Writer {

--- a/internal/backup/encode_snapshot.go
+++ b/internal/backup/encode_snapshot.go
@@ -148,6 +148,16 @@ func EncodeSnapshot(opts EncodeOptions, out io.Writer) (EncodeResult, error) {
 	if out == nil {
 		return EncodeResult{}, errors.New("backup: EncodeSnapshot out writer is nil")
 	}
+	if !opts.Adapters.DynamoDB && !opts.Adapters.S3 && !opts.Adapters.Redis && !opts.Adapters.SQS {
+		// A zero AdapterSet would silently produce a valid header-only
+		// .fsm with no adapter records — a "successful" empty restore
+		// artifact. The CLI's parseAdapterSet already rejects this for
+		// flag-driven entry, but a future in-process caller (Phase 1
+		// live extractor, integration tests) might forget to thread
+		// the set; fail-closed here so that mistake surfaces (codex v5
+		// + claude v5 #904).
+		return EncodeResult{}, errors.New("backup: EncodeOptions.Adapters has no enabled adapter")
+	}
 
 	b := newSnapshotBuilder(opts.LastCommitTS)
 	enabled, err := runAdapterEncoders(b, opts)

--- a/internal/backup/encode_snapshot_test.go
+++ b/internal/backup/encode_snapshot_test.go
@@ -388,6 +388,41 @@ func TestEncodeSnapshotRejectsZeroAdapterSet(t *testing.T) {
 	}
 }
 
+// TestEncodeSnapshotMarksAdapterDataErrors pins codex P2 v9 #904: when
+// an adapter encoder rejects the input tree's contents (e.g. a
+// malformed DynamoDB _schema.json), EncodeSnapshot must surface the
+// failure as ErrEncodeAdapterData so the CLI can route it to exit-2
+// (data-correctness) rather than exit-1 (operator/flag error).
+// Crucially, errors.Mark preserves the original sentinel chain, so a
+// caller that errors.Is on the per-adapter sentinel
+// (ErrDDBEncodeInvalidSchema here) still gets a match — the marking
+// is additive.
+func TestEncodeSnapshotMarksAdapterDataErrors(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	// Empty table_name triggers ErrDDBEncodeInvalidSchema inside the
+	// DynamoDB encoder (encode_dynamodb.go:120).
+	writeDDBSchema(t, in, "tbl",
+		[]byte(`{"format_version":1,"table_name":"","primary_key":{"hash_key":{"name":"id","type":"S"}}}`))
+	var buf bytes.Buffer
+	_, err := EncodeSnapshot(EncodeOptions{
+		InputRoot:    in,
+		Adapters:     AdapterSet{DynamoDB: true},
+		LastCommitTS: 1,
+	}, &buf)
+	if err == nil {
+		t.Fatalf("EncodeSnapshot with malformed schema succeeded; want error")
+	}
+	if !errors.Is(err, ErrEncodeAdapterData) {
+		t.Errorf("err = %v, want errors.Is ErrEncodeAdapterData", err)
+	}
+	// Inner sentinel must still be reachable so existing per-adapter
+	// errors.Is callers are unaffected by the additional mark.
+	if !errors.Is(err, ErrDDBEncodeInvalidSchema) {
+		t.Errorf("err = %v, want errors.Is ErrDDBEncodeInvalidSchema (mark must preserve inner chain)", err)
+	}
+}
+
 // TestEncodeInfoSidecarPath pins the path-derivation rule for the
 // sidecar (gemini medium v2 #896): one .fsm path produces one distinct
 // sidecar path; two .fsm files in the same dir produce two distinct

--- a/internal/backup/encode_snapshot_test.go
+++ b/internal/backup/encode_snapshot_test.go
@@ -211,6 +211,54 @@ func TestEncodeSnapshotRequiresInputRoot(t *testing.T) {
 	}
 }
 
+// TestEncodeSnapshotRejectsMissingInputRoot pins codex P2 v8 #904: a
+// non-existent or non-directory InputRoot must be rejected before any
+// adapter runs. Otherwise each enabled adapter treats its missing
+// top-level subdirectory as a no-op, the call "succeeds", and the
+// caller gets a header-only .fsm — a silent empty-restore artifact.
+// CLI callers don't hit this path (they open MANIFEST.json first),
+// but library callers can pass a stale path, so the guard belongs in
+// EncodeSnapshot itself.
+func TestEncodeSnapshotRejectsMissingInputRoot(t *testing.T) {
+	t.Parallel()
+	t.Run("non-existent path", func(t *testing.T) {
+		t.Parallel()
+		missing := filepath.Join(t.TempDir(), "does-not-exist")
+		var buf bytes.Buffer
+		_, err := EncodeSnapshot(EncodeOptions{
+			InputRoot:    missing,
+			Adapters:     AdapterSet{SQS: true},
+			LastCommitTS: 1,
+		}, &buf)
+		if err == nil {
+			t.Fatalf("EncodeSnapshot with non-existent InputRoot succeeded; want error")
+		}
+		if buf.Len() != 0 {
+			t.Errorf("buf.Len = %d, want 0 (no bytes should be written for missing InputRoot)", buf.Len())
+		}
+	})
+	t.Run("regular file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		filePath := filepath.Join(dir, "not-a-dir")
+		if err := os.WriteFile(filePath, []byte("x"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		var buf bytes.Buffer
+		_, err := EncodeSnapshot(EncodeOptions{
+			InputRoot:    filePath,
+			Adapters:     AdapterSet{SQS: true},
+			LastCommitTS: 1,
+		}, &buf)
+		if err == nil {
+			t.Fatalf("EncodeSnapshot with file-as-InputRoot succeeded; want error")
+		}
+		if buf.Len() != 0 {
+			t.Errorf("buf.Len = %d, want 0 (no bytes should be written for non-directory InputRoot)", buf.Len())
+		}
+	})
+}
+
 // TestEncodeSnapshotRejectsLowManifestFloor pins codex P2 v2: the
 // library-level HLC floor check fails-closed when opts.LastCommitTS
 // is below opts.ManifestLastCommitTS. Defense-in-depth for the CLI's

--- a/internal/backup/encode_snapshot_test.go
+++ b/internal/backup/encode_snapshot_test.go
@@ -120,6 +120,35 @@ func TestEncodeSnapshotSelfTestMatchesInput(t *testing.T) {
 	}
 }
 
+// flipBytesPastHeaderHelper returns a corruption hook that flips bytes
+// every 13 bytes starting at offset 200 in the buffered self-test temp
+// file — far enough past the EKVPBBL1 header + lastCommitTS that the
+// decoder trips on a malformed entry length. Extracted from the test
+// body so the test body itself stays under the cyclop threshold.
+func flipBytesPastHeaderHelper(t *testing.T) func(*os.File) {
+	t.Helper()
+	return func(f *os.File) {
+		info, err := f.Stat()
+		if err != nil {
+			t.Fatalf("temp Stat: %v", err)
+		}
+		const headerSkip = 200
+		if info.Size() <= headerSkip {
+			t.Fatalf("temp file too small to corrupt past header: %d bytes", info.Size())
+		}
+		buf := make([]byte, info.Size()-headerSkip)
+		if _, err := f.ReadAt(buf, headerSkip); err != nil {
+			t.Fatalf("ReadAt: %v", err)
+		}
+		for i := 0; i < len(buf); i += 13 {
+			buf[i] ^= 0xFF
+		}
+		if _, err := f.WriteAt(buf, headerSkip); err != nil {
+			t.Fatalf("WriteAt: %v", err)
+		}
+	}
+}
+
 // TestEncodeSnapshotSelfTestDetectsCorruption pins that the unexported
 // corruptBufferForTest hook lets the self-test catch corruption in the
 // internal buffer. The corruption must be reachable by the self-test
@@ -138,14 +167,7 @@ func TestEncodeSnapshotSelfTestDetectsCorruption(t *testing.T) {
 
 	scratchBase := t.TempDir()
 	var out bytes.Buffer
-	// Corrupt every 13th byte deep inside the buffer — far enough past
-	// the header that the decoder will trip on the malformed entry
-	// length field.
-	corrupt := func(b []byte) {
-		for i := 200; i < len(b); i += 13 {
-			b[i] ^= 0xFF
-		}
-	}
+	corrupt := flipBytesPastHeaderHelper(t)
 	result, err := EncodeSnapshot(EncodeOptions{
 		InputRoot:    in,
 		Adapters:     AdapterSet{SQS: true},

--- a/internal/backup/encode_snapshot_test.go
+++ b/internal/backup/encode_snapshot_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/cockroachdb/errors"
 )
 
 // TestEncodeSnapshotLibraryRoundTrip pins the public library entrypoint:
@@ -206,6 +208,58 @@ func TestEncodeSnapshotRequiresInputRoot(t *testing.T) {
 	var buf bytes.Buffer
 	if _, err := EncodeSnapshot(EncodeOptions{}, &buf); err == nil {
 		t.Fatalf("EncodeSnapshot with empty InputRoot succeeded; want error")
+	}
+}
+
+// TestEncodeSnapshotRejectsLowManifestFloor pins codex P2 v2: the
+// library-level HLC floor check fails-closed when opts.LastCommitTS
+// is below opts.ManifestLastCommitTS. Defense-in-depth for the CLI's
+// resolveLastCommitTS — a future in-process caller (Phase 1 live
+// extractor) cannot silently publish a low-TS .fsm.
+func TestEncodeSnapshotRejectsLowManifestFloor(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	var buf bytes.Buffer
+	_, err := EncodeSnapshot(EncodeOptions{
+		InputRoot:            in,
+		Adapters:             AdapterSet{SQS: true},
+		LastCommitTS:         500,
+		ManifestLastCommitTS: 1000, // floor; LastCommitTS is below
+	}, &buf)
+	if err == nil {
+		t.Fatalf("EncodeSnapshot with LastCommitTS < ManifestLastCommitTS succeeded; want error")
+	}
+	if !errors.Is(err, ErrSelfTestLowerLastCommitTS) {
+		t.Errorf("err = %v, want errors.Is ErrSelfTestLowerLastCommitTS", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("buf.Len = %d, want 0 (no bytes should be written on floor regression)", buf.Len())
+	}
+}
+
+// TestEncodeSnapshotManifestFloorOptOut pins that ManifestLastCommitTS=0
+// disables the check (synthetic test fixtures, library callers without a
+// manifest reference). The existing TestEncodeSnapshotLibraryRoundTrip
+// implicitly relies on this opt-out.
+func TestEncodeSnapshotManifestFloorOptOut(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const queue = "floor-opt-out"
+	writeSQSQueue(t, in, queue,
+		[]byte(`{"format_version":1,"name":"floor-opt-out","fifo":false,"partition_count":1,"generation":1}`),
+		[][]byte{
+			[]byte(`{"format_version":1,"message_id":"m1","body":"a","send_timestamp_millis":1700000000000,"available_at_millis":1700000000000,"sequence_number":0}`),
+		},
+	)
+	var buf bytes.Buffer
+	_, err := EncodeSnapshot(EncodeOptions{
+		InputRoot:            in,
+		Adapters:             AdapterSet{SQS: true},
+		LastCommitTS:         500,
+		ManifestLastCommitTS: 0, // opt-out
+	}, &buf)
+	if err != nil {
+		t.Fatalf("EncodeSnapshot with opt-out floor failed: %v", err)
 	}
 }
 

--- a/internal/backup/encode_snapshot_test.go
+++ b/internal/backup/encode_snapshot_test.go
@@ -30,9 +30,10 @@ func TestEncodeSnapshotLibraryRoundTrip(t *testing.T) {
 
 	var buf bytes.Buffer
 	result, err := EncodeSnapshot(EncodeOptions{
-		InputRoot:    in,
-		Adapters:     AdapterSet{SQS: true},
-		LastCommitTS: 0xDEADBEEF,
+		InputRoot:            in,
+		Adapters:             AdapterSet{SQS: true},
+		LastCommitTS:         0xDEADBEEF,
+		AllowMissingManifest: true,
 	}, &buf)
 	if err != nil {
 		t.Fatalf("EncodeSnapshot: %v", err)
@@ -83,9 +84,10 @@ func TestEncodeSnapshotSelfTestMatchesInput(t *testing.T) {
 	canonicalIn := t.TempDir()
 	var canonicalBuf bytes.Buffer
 	if _, err := EncodeSnapshot(EncodeOptions{
-		InputRoot:    rawIn,
-		Adapters:     AdapterSet{SQS: true},
-		LastCommitTS: 0xCAFE,
+		InputRoot:            rawIn,
+		Adapters:             AdapterSet{SQS: true},
+		LastCommitTS:         0xCAFE,
+		AllowMissingManifest: true,
 	}, &canonicalBuf); err != nil {
 		t.Fatalf("canonical encode: %v", err)
 	}
@@ -107,6 +109,7 @@ func TestEncodeSnapshotSelfTestMatchesInput(t *testing.T) {
 			OutRoot:  scratchBase,
 			Adapters: AdapterSet{SQS: true},
 		},
+		AllowMissingManifest: true,
 	}, &buf)
 	if err != nil {
 		t.Fatalf("EncodeSnapshot: %v", err)
@@ -180,6 +183,7 @@ func TestEncodeSnapshotSelfTestDetectsCorruption(t *testing.T) {
 			Adapters: AdapterSet{SQS: true},
 		},
 		corruptBufferForTest: corrupt,
+		AllowMissingManifest: true,
 	}, &out)
 	if err != nil {
 		t.Fatalf("EncodeSnapshot: %v", err)
@@ -259,6 +263,55 @@ func TestEncodeSnapshotRejectsMissingInputRoot(t *testing.T) {
 	})
 }
 
+// TestEncodeSnapshotRequiresManifest pins codex P2 v17 #904: a library
+// caller pointing at an existing-but-wrong directory (no
+// MANIFEST.json) must fail closed with an error referencing
+// MANIFEST.json, NOT silently emit a header-only .fsm. The CLI hits
+// this path naturally by opening MANIFEST.json first; the library
+// validation layer needs the equivalent guard.
+func TestEncodeSnapshotRequiresManifest(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir() // exists, is a directory, but contains no MANIFEST.json
+	var buf bytes.Buffer
+	_, err := EncodeSnapshot(EncodeOptions{
+		InputRoot:    in,
+		Adapters:     AdapterSet{SQS: true},
+		LastCommitTS: 1,
+		// AllowMissingManifest: false (default) — must require manifest
+	}, &buf)
+	if err == nil {
+		t.Fatalf("EncodeSnapshot with missing MANIFEST.json succeeded; want error")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("buf.Len = %d, want 0 (no bytes should be written when MANIFEST.json is missing)", buf.Len())
+	}
+}
+
+// TestEncodeSnapshotAllowMissingManifestOptOut pins that the
+// AllowMissingManifest opt-out works for synthetic test fixtures.
+// Mirrors the ManifestLastCommitTS=0 opt-out pattern from codex P2 v2.
+func TestEncodeSnapshotAllowMissingManifestOptOut(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const queue = "manifest-opt-out"
+	writeSQSQueue(t, in, queue,
+		[]byte(`{"format_version":1,"name":"manifest-opt-out","fifo":false,"partition_count":1,"generation":1}`),
+		[][]byte{
+			[]byte(`{"format_version":1,"message_id":"m1","body":"a","send_timestamp_millis":1700000000000,"available_at_millis":1700000000000,"sequence_number":0}`),
+		},
+	)
+	var buf bytes.Buffer
+	_, err := EncodeSnapshot(EncodeOptions{
+		InputRoot:            in,
+		Adapters:             AdapterSet{SQS: true},
+		LastCommitTS:         1,
+		AllowMissingManifest: true,
+	}, &buf)
+	if err != nil {
+		t.Fatalf("EncodeSnapshot with AllowMissingManifest=true failed: %v", err)
+	}
+}
+
 // TestEncodeSnapshotRejectsLowManifestFloor pins codex P2 v2: the
 // library-level HLC floor check fails-closed when opts.LastCommitTS
 // is below opts.ManifestLastCommitTS. Defense-in-depth for the CLI's
@@ -273,6 +326,7 @@ func TestEncodeSnapshotRejectsLowManifestFloor(t *testing.T) {
 		Adapters:             AdapterSet{SQS: true},
 		LastCommitTS:         500,
 		ManifestLastCommitTS: 1000, // floor; LastCommitTS is below
+		AllowMissingManifest: true,
 	}, &buf)
 	if err == nil {
 		t.Fatalf("EncodeSnapshot with LastCommitTS < ManifestLastCommitTS succeeded; want error")
@@ -305,6 +359,7 @@ func TestEncodeSnapshotManifestFloorOptOut(t *testing.T) {
 		Adapters:             AdapterSet{SQS: true},
 		LastCommitTS:         500,
 		ManifestLastCommitTS: 0, // opt-out
+		AllowMissingManifest: true,
 	}, &buf)
 	if err != nil {
 		t.Fatalf("EncodeSnapshot with opt-out floor failed: %v", err)
@@ -323,10 +378,11 @@ func TestEncodeSnapshotRejectsDynamoDBJSONLLayout(t *testing.T) {
 	in := t.TempDir()
 	var buf bytes.Buffer
 	_, err := EncodeSnapshot(EncodeOptions{
-		InputRoot:           in,
-		Adapters:            AdapterSet{DynamoDB: true},
-		LastCommitTS:        1,
-		DynamoDBBundleJSONL: true,
+		InputRoot:            in,
+		Adapters:             AdapterSet{DynamoDB: true},
+		LastCommitTS:         1,
+		DynamoDBBundleJSONL:  true,
+		AllowMissingManifest: true,
 	}, &buf)
 	if err == nil {
 		t.Fatalf("EncodeSnapshot with DynamoDBBundleJSONL accepted; want error")
@@ -356,10 +412,11 @@ func TestEncodeSnapshotJSONLOnlyRejectedWhenDDBEnabled(t *testing.T) {
 	)
 	var buf bytes.Buffer
 	_, err := EncodeSnapshot(EncodeOptions{
-		InputRoot:           in,
-		Adapters:            AdapterSet{SQS: true}, // DDB NOT in scope
-		LastCommitTS:        1,
-		DynamoDBBundleJSONL: true, // would be rejected if DDB were enabled
+		InputRoot:            in,
+		Adapters:             AdapterSet{SQS: true}, // DDB NOT in scope
+		LastCommitTS:         1,
+		DynamoDBBundleJSONL:  true, // would be rejected if DDB were enabled
+		AllowMissingManifest: true,
 	}, &buf)
 	if err != nil {
 		t.Fatalf("EncodeSnapshot rejected JSONL flag when DDB not in scope: %v", err)
@@ -484,9 +541,10 @@ func TestEncodeSnapshotRedisRejectsNonZeroDB(t *testing.T) {
 	}
 	var buf bytes.Buffer
 	_, err := EncodeSnapshot(EncodeOptions{
-		InputRoot:    in,
-		Adapters:     AdapterSet{Redis: true},
-		LastCommitTS: 1,
+		InputRoot:            in,
+		Adapters:             AdapterSet{Redis: true},
+		LastCommitTS:         1,
+		AllowMissingManifest: true,
 	}, &buf)
 	if err == nil {
 		t.Fatalf("EncodeSnapshot accepted db_3-only Redis input; want ErrRedisEncodeMultiDBUnsupported")
@@ -517,9 +575,10 @@ func TestEncodeSnapshotRedisRejectsMultipleDBs(t *testing.T) {
 	}
 	var buf bytes.Buffer
 	_, err := EncodeSnapshot(EncodeOptions{
-		InputRoot:    in,
-		Adapters:     AdapterSet{Redis: true},
-		LastCommitTS: 1,
+		InputRoot:            in,
+		Adapters:             AdapterSet{Redis: true},
+		LastCommitTS:         1,
+		AllowMissingManifest: true,
 	}, &buf)
 	if err == nil {
 		t.Fatalf("EncodeSnapshot accepted db_0 + db_3; want ErrRedisEncodeMultiDBUnsupported")
@@ -577,9 +636,10 @@ func TestEncodeSnapshotMarksAdapterDataErrors(t *testing.T) {
 		[]byte(`{"format_version":1,"table_name":"","primary_key":{"hash_key":{"name":"id","type":"S"}}}`))
 	var buf bytes.Buffer
 	_, err := EncodeSnapshot(EncodeOptions{
-		InputRoot:    in,
-		Adapters:     AdapterSet{DynamoDB: true},
-		LastCommitTS: 1,
+		InputRoot:            in,
+		Adapters:             AdapterSet{DynamoDB: true},
+		LastCommitTS:         1,
+		AllowMissingManifest: true,
 	}, &buf)
 	if err == nil {
 		t.Fatalf("EncodeSnapshot with malformed schema succeeded; want error")

--- a/internal/backup/encode_snapshot_test.go
+++ b/internal/backup/encode_snapshot_test.go
@@ -388,6 +388,125 @@ func TestEncodeSnapshotRejectsZeroAdapterSet(t *testing.T) {
 	}
 }
 
+// TestEnumerateRedisDBsMissingDir pins codex P1 v13 #904: a missing
+// redis/ directory returns nil indices (no-op), matching the per-DB
+// encoder's "missing db_<n> = nothing to encode" convention.
+func TestEnumerateRedisDBsMissingDir(t *testing.T) {
+	t.Parallel()
+	indices, err := enumerateRedisDBs(t.TempDir())
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if indices != nil {
+		t.Errorf("indices = %v, want nil for missing redis/", indices)
+	}
+}
+
+// TestEnumerateRedisDBsMixedEntries pins codex P1 v13 #904: only
+// canonical db_<N> entries are kept; non-numeric, negative, leading-
+// zero, empty-suffix, wrong-prefix, and non-directory entries are
+// silently skipped. The returned slice is sorted ascending.
+func TestEnumerateRedisDBsMixedEntries(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	for _, name := range []string{"db_0", "db_1", "db_5"} {
+		if err := os.MkdirAll(filepath.Join(in, "redis", name), 0o755); err != nil {
+			t.Fatalf("MkdirAll %s: %v", name, err)
+		}
+	}
+	// Entries that MUST be skipped:
+	//   db_garbage  — non-numeric suffix
+	//   db_-1       — negative
+	//   db_01       — non-canonical leading zero
+	//   db_         — empty suffix
+	//   notdb_2     — wrong prefix
+	for _, name := range []string{"db_garbage", "db_-1", "db_01", "db_", "notdb_2"} {
+		if err := os.MkdirAll(filepath.Join(in, "redis", name), 0o755); err != nil {
+			t.Fatalf("MkdirAll %s: %v", name, err)
+		}
+	}
+	// A regular file under redis/ must be skipped (not enumerable).
+	if err := os.WriteFile(filepath.Join(in, "redis", "README"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("WriteFile README: %v", err)
+	}
+	indices, err := enumerateRedisDBs(in)
+	if err != nil {
+		t.Fatalf("enumerateRedisDBs: %v", err)
+	}
+	want := []int{0, 1, 5}
+	if len(indices) != len(want) {
+		t.Fatalf("indices = %v, want %v", indices, want)
+	}
+	for i, v := range want {
+		if indices[i] != v {
+			t.Errorf("indices[%d] = %d, want %d", i, indices[i], v)
+		}
+	}
+}
+
+// TestEnumerateRedisDBsRedisIsRegularFile pins fail-closed when the
+// "redis" path inside the dump is a regular file rather than a
+// directory — distinct from the missing case.
+func TestEnumerateRedisDBsRedisIsRegularFile(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	if err := os.WriteFile(filepath.Join(in, "redis"), []byte("not a dir"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err := enumerateRedisDBs(in)
+	if !errors.Is(err, ErrRedisEncodeNotDir) {
+		t.Errorf("err = %v, want errors.Is ErrRedisEncodeNotDir", err)
+	}
+}
+
+// TestEncodeSnapshotRedisMultiDB pins codex P1 v13 #904: the Redis
+// fan-out in adapterRunners enumerates redis/db_<N>/ and invokes the
+// per-DB encoder for each. The fixture places a single string under
+// redis/db_3/ ONLY (no db_0). Pre-fix, the encoder hardcoded
+// NewRedisEncoder(root, 0) and produced a header-only .fsm for this
+// input — silent data loss. Post-fix, the db_3 string is included.
+//
+// Assertion is content-free: compare encoded byte count against an
+// empty-redis baseline. With multi-DB fan-out, the db_3 fixture
+// produces MORE bytes than an empty tree. Without it, both encodes
+// would produce identical header-only output.
+func TestEncodeSnapshotRedisMultiDB(t *testing.T) {
+	t.Parallel()
+	emptyIn := t.TempDir()
+	var emptyBuf bytes.Buffer
+	emptyResult, err := EncodeSnapshot(EncodeOptions{
+		InputRoot:    emptyIn,
+		Adapters:     AdapterSet{Redis: true},
+		LastCommitTS: 1,
+	}, &emptyBuf)
+	if err != nil {
+		t.Fatalf("EncodeSnapshot empty: %v", err)
+	}
+
+	in := t.TempDir()
+	encKey := EncodeSegment([]byte("k3"))
+	db3Strings := filepath.Join(in, "redis", "db_3", "strings")
+	if err := os.MkdirAll(db3Strings, 0o755); err != nil {
+		t.Fatalf("MkdirAll db_3/strings: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(db3Strings, encKey+".bin"), []byte("v3"), 0o600); err != nil {
+		t.Fatalf("WriteFile db_3 string: %v", err)
+	}
+	var buf bytes.Buffer
+	result, err := EncodeSnapshot(EncodeOptions{
+		InputRoot:    in,
+		Adapters:     AdapterSet{Redis: true},
+		LastCommitTS: 1,
+	}, &buf)
+	if err != nil {
+		t.Fatalf("EncodeSnapshot db_3-only: %v", err)
+	}
+	if result.BytesWritten <= emptyResult.BytesWritten {
+		t.Errorf("BytesWritten with redis/db_3 fixture (%d) <= empty (%d); pre-fix, hardcoded db_0 fan-out dropped db_3 silently",
+			result.BytesWritten, emptyResult.BytesWritten)
+	}
+}
+
 // TestEncodeSnapshotMarksAdapterDataErrors pins codex P2 v9 #904: when
 // an adapter encoder rejects the input tree's contents (e.g. a
 // malformed DynamoDB _schema.json), EncodeSnapshot must surface the

--- a/internal/backup/encode_snapshot_test.go
+++ b/internal/backup/encode_snapshot_test.go
@@ -366,6 +366,117 @@ func TestEncodeSnapshotManifestFloorOptOut(t *testing.T) {
 	}
 }
 
+// TestEncodeSnapshotRejectsUnsupportedFeatures pins codex P2 v21 #904:
+// three manifest-derived flags that the per-adapter encoders cannot
+// honor today must fail-closed before any bytes are written. Each
+// guard fires only when the corresponding adapter is enabled —
+// orthogonal callers (e.g., S3IncludeIncompleteUploads=true while
+// encoding only Redis) are unaffected. Pattern matches the
+// DynamoDBBundleJSONL guard from v8.
+func TestEncodeSnapshotRejectsUnsupportedFeatures(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		opts    EncodeOptions
+		wantErr error
+	}{
+		{
+			name: "S3 include_incomplete_uploads",
+			opts: EncodeOptions{
+				Adapters:                   AdapterSet{S3: true},
+				S3IncludeIncompleteUploads: true,
+			},
+			wantErr: ErrEncodeUnsupportedS3IncompleteUploads,
+		},
+		{
+			name: "S3 include_orphans",
+			opts: EncodeOptions{
+				Adapters:         AdapterSet{S3: true},
+				S3IncludeOrphans: true,
+			},
+			wantErr: ErrEncodeUnsupportedS3Orphans,
+		},
+		{
+			name: "SQS preserve_visibility",
+			opts: EncodeOptions{
+				Adapters:              AdapterSet{SQS: true},
+				PreserveSQSVisibility: true,
+			},
+			wantErr: ErrEncodeUnsupportedSQSPreserveVisibility,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			in := t.TempDir()
+			opts := tc.opts
+			opts.InputRoot = in
+			opts.LastCommitTS = 1
+			opts.AllowMissingManifest = true
+			var buf bytes.Buffer
+			_, err := EncodeSnapshot(opts, &buf)
+			if err == nil {
+				t.Fatalf("EncodeSnapshot accepted unsupported feature; want %v", tc.wantErr)
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("err = %v, want errors.Is %v", err, tc.wantErr)
+			}
+			if buf.Len() != 0 {
+				t.Errorf("buf.Len = %d, want 0 (no bytes should be written on rejection)", buf.Len())
+			}
+		})
+	}
+}
+
+// TestEncodeSnapshotUnsupportedFeaturesGatedByAdapter pins that each
+// of the three v21 guards fires ONLY when its corresponding adapter
+// is enabled. A library caller that inherits the manifest flag but
+// disables the affected adapter is unaffected — mirrors the JSONL
+// guard's "DDB not in scope" exemption.
+func TestEncodeSnapshotUnsupportedFeaturesGatedByAdapter(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		opts EncodeOptions
+	}{
+		{
+			name: "S3IncludeIncompleteUploads with S3 disabled",
+			opts: EncodeOptions{
+				Adapters:                   AdapterSet{SQS: true}, // not S3
+				S3IncludeIncompleteUploads: true,
+			},
+		},
+		{
+			name: "S3IncludeOrphans with S3 disabled",
+			opts: EncodeOptions{
+				Adapters:         AdapterSet{SQS: true}, // not S3
+				S3IncludeOrphans: true,
+			},
+		},
+		{
+			name: "PreserveSQSVisibility with SQS disabled",
+			opts: EncodeOptions{
+				Adapters:              AdapterSet{Redis: true}, // not SQS
+				PreserveSQSVisibility: true,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			in := t.TempDir()
+			opts := tc.opts
+			opts.InputRoot = in
+			opts.LastCommitTS = 1
+			opts.AllowMissingManifest = true
+			var buf bytes.Buffer
+			if _, err := EncodeSnapshot(opts, &buf); err != nil {
+				t.Errorf("EncodeSnapshot rejected unsupported flag when its adapter was out of scope: %v", err)
+			}
+		})
+	}
+}
+
 // TestEncodeSnapshotRejectsDynamoDBJSONLLayout pins codex P2 v7 #904:
 // the DynamoDB reverse encoder does not support the JSONL bundle
 // layout, so a caller that threads DynamoDBBundleJSONL=true must be

--- a/internal/backup/encode_snapshot_test.go
+++ b/internal/backup/encode_snapshot_test.go
@@ -459,30 +459,20 @@ func TestEnumerateRedisDBsRedisIsRegularFile(t *testing.T) {
 	}
 }
 
-// TestEncodeSnapshotRedisMultiDB pins codex P1 v13 #904: the Redis
-// fan-out in adapterRunners enumerates redis/db_<N>/ and invokes the
-// per-DB encoder for each. The fixture places a single string under
-// redis/db_3/ ONLY (no db_0). Pre-fix, the encoder hardcoded
-// NewRedisEncoder(root, 0) and produced a header-only .fsm for this
-// input — silent data loss. Post-fix, the db_3 string is included.
+// TestEncodeSnapshotRedisRejectsNonZeroDB pins codex P2 v14 #904
+// L452: the Redis MVCC key prefixes (!redis|str|, !redis|hll|,
+// !redis|ttl|, …) carry no database component, so feeding a
+// non-zero DB through the encoder would mis-scope the produced
+// .fsm — same-named keys collide and a db_3-only self-test would
+// decode under db_0. Until Phase 1 makes native keys DB-aware,
+// non-zero-DB inputs MUST fail closed.
 //
-// Assertion is content-free: compare encoded byte count against an
-// empty-redis baseline. With multi-DB fan-out, the db_3 fixture
-// produces MORE bytes than an empty tree. Without it, both encodes
-// would produce identical header-only output.
-func TestEncodeSnapshotRedisMultiDB(t *testing.T) {
+// The fixture places a single string under redis/db_3/ ONLY.
+// EncodeSnapshot must reject with ErrRedisEncodeMultiDBUnsupported
+// and write no bytes. (v14 originally attempted to fan out per DB;
+// codex's L452 follow-up established the correct fix is fail-closed.)
+func TestEncodeSnapshotRedisRejectsNonZeroDB(t *testing.T) {
 	t.Parallel()
-	emptyIn := t.TempDir()
-	var emptyBuf bytes.Buffer
-	emptyResult, err := EncodeSnapshot(EncodeOptions{
-		InputRoot:    emptyIn,
-		Adapters:     AdapterSet{Redis: true},
-		LastCommitTS: 1,
-	}, &emptyBuf)
-	if err != nil {
-		t.Fatalf("EncodeSnapshot empty: %v", err)
-	}
-
 	in := t.TempDir()
 	encKey := EncodeSegment([]byte("k3"))
 	db3Strings := filepath.Join(in, "redis", "db_3", "strings")
@@ -493,17 +483,68 @@ func TestEncodeSnapshotRedisMultiDB(t *testing.T) {
 		t.Fatalf("WriteFile db_3 string: %v", err)
 	}
 	var buf bytes.Buffer
-	result, err := EncodeSnapshot(EncodeOptions{
+	_, err := EncodeSnapshot(EncodeOptions{
 		InputRoot:    in,
 		Adapters:     AdapterSet{Redis: true},
 		LastCommitTS: 1,
 	}, &buf)
-	if err != nil {
-		t.Fatalf("EncodeSnapshot db_3-only: %v", err)
+	if err == nil {
+		t.Fatalf("EncodeSnapshot accepted db_3-only Redis input; want ErrRedisEncodeMultiDBUnsupported")
 	}
-	if result.BytesWritten <= emptyResult.BytesWritten {
-		t.Errorf("BytesWritten with redis/db_3 fixture (%d) <= empty (%d); pre-fix, hardcoded db_0 fan-out dropped db_3 silently",
-			result.BytesWritten, emptyResult.BytesWritten)
+	if !errors.Is(err, ErrRedisEncodeMultiDBUnsupported) {
+		t.Errorf("err = %v, want errors.Is ErrRedisEncodeMultiDBUnsupported", err)
+	}
+	// Marked as adapter-data so the CLI routes it to exit-2.
+	if !errors.Is(err, ErrEncodeAdapterData) {
+		t.Errorf("err = %v, want errors.Is ErrEncodeAdapterData (mark from runAdapterEncoders)", err)
+	}
+}
+
+// TestEncodeSnapshotRedisRejectsMultipleDBs pins the multi-DB case:
+// redis/db_0 + redis/db_3 → ErrRedisEncodeMultiDBUnsupported (the
+// fan-out would collide on same-named keys or merge both DBs under
+// db_0 on restore; codex P2 v14 #904 L452).
+func TestEncodeSnapshotRedisRejectsMultipleDBs(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	for _, name := range []string{"db_0", "db_3"} {
+		if err := os.MkdirAll(filepath.Join(in, "redis", name, "strings"), 0o755); err != nil {
+			t.Fatalf("MkdirAll %s: %v", name, err)
+		}
+	}
+	var buf bytes.Buffer
+	_, err := EncodeSnapshot(EncodeOptions{
+		InputRoot:    in,
+		Adapters:     AdapterSet{Redis: true},
+		LastCommitTS: 1,
+	}, &buf)
+	if err == nil {
+		t.Fatalf("EncodeSnapshot accepted db_0 + db_3; want ErrRedisEncodeMultiDBUnsupported")
+	}
+	if !errors.Is(err, ErrRedisEncodeMultiDBUnsupported) {
+		t.Errorf("err = %v, want errors.Is ErrRedisEncodeMultiDBUnsupported", err)
+	}
+}
+
+// TestEnumerateRedisDBsRejectsNonDirDBEntry pins codex P2 v14 #904
+// L427: when a canonical db_<N> name resolves to a regular file
+// (or symlink) instead of a directory, enumerateRedisDBs must fail
+// closed with ErrRedisEncodeNotDir — silently skipping would let a
+// malformed dump publish a header-only/partial FSM.
+func TestEnumerateRedisDBsRejectsNonDirDBEntry(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(in, "redis"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	// redis/db_2 is a regular file — name matches the canonical
+	// pattern but the entry shape is wrong.
+	if err := os.WriteFile(filepath.Join(in, "redis", "db_2"), []byte("not a dir"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	_, err := enumerateRedisDBs(in)
+	if !errors.Is(err, ErrRedisEncodeNotDir) {
+		t.Errorf("err = %v, want errors.Is ErrRedisEncodeNotDir", err)
 	}
 }
 

--- a/internal/backup/encode_snapshot_test.go
+++ b/internal/backup/encode_snapshot_test.go
@@ -263,6 +263,61 @@ func TestEncodeSnapshotManifestFloorOptOut(t *testing.T) {
 	}
 }
 
+// TestEncodeSnapshotRejectsDynamoDBJSONLLayout pins codex P2 v7 #904:
+// the DynamoDB reverse encoder does not support the JSONL bundle
+// layout, so a caller that threads DynamoDBBundleJSONL=true must be
+// rejected with ErrEncodeUnsupportedDynamoDBLayout before any bytes
+// are written. The CLI hits this path automatically when MANIFEST.json
+// has `dynamodb_layout: "jsonl"`; library callers that mirror that
+// thread the field themselves.
+func TestEncodeSnapshotRejectsDynamoDBJSONLLayout(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	var buf bytes.Buffer
+	_, err := EncodeSnapshot(EncodeOptions{
+		InputRoot:           in,
+		Adapters:            AdapterSet{DynamoDB: true},
+		LastCommitTS:        1,
+		DynamoDBBundleJSONL: true,
+	}, &buf)
+	if err == nil {
+		t.Fatalf("EncodeSnapshot with DynamoDBBundleJSONL accepted; want error")
+	}
+	if !errors.Is(err, ErrEncodeUnsupportedDynamoDBLayout) {
+		t.Errorf("err = %v, want errors.Is ErrEncodeUnsupportedDynamoDBLayout", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("buf.Len = %d, want 0 (no bytes should be written when JSONL is rejected)", buf.Len())
+	}
+}
+
+// TestEncodeSnapshotJSONLOnlyRejectedWhenDDBEnabled pins that the JSONL
+// guard fires only when DynamoDB is in the adapter set — a caller that
+// happens to set DynamoDBBundleJSONL=true while encoding ONLY Redis (or
+// any other adapter) is unaffected. Prevents the guard from becoming
+// over-zealous for callers who simply mirror the manifest field.
+func TestEncodeSnapshotJSONLOnlyRejectedWhenDDBEnabled(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const queue = "no-ddb"
+	writeSQSQueue(t, in, queue,
+		[]byte(`{"format_version":1,"name":"no-ddb","fifo":false,"partition_count":1,"generation":1}`),
+		[][]byte{
+			[]byte(`{"format_version":1,"message_id":"m1","body":"a","send_timestamp_millis":1700000000000,"available_at_millis":1700000000000,"sequence_number":0}`),
+		},
+	)
+	var buf bytes.Buffer
+	_, err := EncodeSnapshot(EncodeOptions{
+		InputRoot:           in,
+		Adapters:            AdapterSet{SQS: true}, // DDB NOT in scope
+		LastCommitTS:        1,
+		DynamoDBBundleJSONL: true, // would be rejected if DDB were enabled
+	}, &buf)
+	if err != nil {
+		t.Fatalf("EncodeSnapshot rejected JSONL flag when DDB not in scope: %v", err)
+	}
+}
+
 // TestEncodeSnapshotRejectsZeroAdapterSet pins claude v5 + codex v5
 // carry-over: a library caller that forgets to thread Adapters into
 // EncodeOptions gets a fail-closed error rather than a silently empty

--- a/internal/backup/encode_snapshot_test.go
+++ b/internal/backup/encode_snapshot_test.go
@@ -527,6 +527,11 @@ func TestEncodeSnapshotRedisRejectsMultipleDBs(t *testing.T) {
 	if !errors.Is(err, ErrRedisEncodeMultiDBUnsupported) {
 		t.Errorf("err = %v, want errors.Is ErrRedisEncodeMultiDBUnsupported", err)
 	}
+	// Marked as adapter-data so the CLI routes it to exit-2 (mirrors
+	// TestEncodeSnapshotRedisRejectsNonZeroDB; claude v17 parity).
+	if !errors.Is(err, ErrEncodeAdapterData) {
+		t.Errorf("err = %v, want errors.Is ErrEncodeAdapterData (mark from runAdapterEncoders)", err)
+	}
 	if buf.Len() != 0 {
 		t.Errorf("buf.Len = %d, want 0 (no bytes should be written on multi-DB rejection)", buf.Len())
 	}

--- a/internal/backup/encode_snapshot_test.go
+++ b/internal/backup/encode_snapshot_test.go
@@ -1,0 +1,217 @@
+package backup
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestEncodeSnapshotLibraryRoundTrip pins the public library entrypoint:
+// EncodeSnapshot writes a .fsm to the supplied io.Writer; running
+// DecodeSnapshot on those bytes into a scratch dir produces an
+// equivalent adapter tree. No CLI involved. Codex P2 v2 #896 — encoder
+// entrypoint exposure.
+func TestEncodeSnapshotLibraryRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	// One tiny SQS queue fixture is enough to exercise the SQS slice
+	// end-to-end via the new library wrapper; the per-adapter tree
+	// shape is already covered by the M5-1/M5-2 tests.
+	const queue = "lib-rt"
+	writeSQSQueue(t, in, queue,
+		[]byte(`{"format_version":1,"name":"lib-rt","fifo":false,"partition_count":1,"generation":1}`),
+		[][]byte{
+			[]byte(`{"format_version":1,"message_id":"m1","body":"a","send_timestamp_millis":1700000000000,"available_at_millis":1700000000000,"sequence_number":0}`),
+		},
+	)
+
+	var buf bytes.Buffer
+	result, err := EncodeSnapshot(EncodeOptions{
+		InputRoot:    in,
+		Adapters:     AdapterSet{SQS: true},
+		LastCommitTS: 0xDEADBEEF,
+	}, &buf)
+	if err != nil {
+		t.Fatalf("EncodeSnapshot: %v", err)
+	}
+	if result.SelfTestRan {
+		t.Errorf("SelfTestRan = true, want false (SelfTest opt was false)")
+	}
+	if result.BytesWritten == 0 {
+		t.Errorf("BytesWritten = 0")
+	}
+	if len(result.AdaptersEnabled) != 1 || result.AdaptersEnabled[0] != "sqs" {
+		t.Errorf("AdaptersEnabled = %v, want [sqs]", result.AdaptersEnabled)
+	}
+
+	// Decode the produced bytes into a scratch tree.
+	scratch := t.TempDir()
+	decResult, err := DecodeSnapshot(bytes.NewReader(buf.Bytes()), DecodeOptions{
+		OutRoot:  scratch,
+		Adapters: AdapterSet{SQS: true},
+	})
+	if err != nil {
+		t.Fatalf("DecodeSnapshot of EncodeSnapshot output failed: %v", err)
+	}
+	if decResult.Header.LastCommitTS != 0xDEADBEEF {
+		t.Errorf("decoded header.LastCommitTS = %x, want 0xDEADBEEF", decResult.Header.LastCommitTS)
+	}
+}
+
+// TestEncodeSnapshotSelfTestMatchesInput pins the happy-path self-test
+// against a tree that has already been canonicalized by one decode pass
+// (so the input matches what DecodeSnapshot would write back, modulo
+// the encoder's idempotency). The full encode -> decode -> encode chain
+// is the gold-standard round trip the parent design mandates.
+func TestEncodeSnapshotSelfTestMatchesInput(t *testing.T) {
+	t.Parallel()
+	rawIn := t.TempDir()
+	const queue = "selftest-match"
+	writeSQSQueue(t, rawIn, queue,
+		[]byte(`{"format_version":1,"name":"selftest-match","fifo":false,"partition_count":1,"generation":1}`),
+		[][]byte{
+			[]byte(`{"format_version":1,"message_id":"m1","body":"a","send_timestamp_millis":1700000000000,"available_at_millis":1700000000000,"sequence_number":0}`),
+		},
+	)
+
+	// Canonicalize: encode rawIn, decode it back to canonicalIn. The
+	// resulting tree is what the encoder's self-test will produce in
+	// the scratch dir, so a second encode against it must match.
+	canonicalIn := t.TempDir()
+	var canonicalBuf bytes.Buffer
+	if _, err := EncodeSnapshot(EncodeOptions{
+		InputRoot:    rawIn,
+		Adapters:     AdapterSet{SQS: true},
+		LastCommitTS: 0xCAFE,
+	}, &canonicalBuf); err != nil {
+		t.Fatalf("canonical encode: %v", err)
+	}
+	if _, err := DecodeSnapshot(bytes.NewReader(canonicalBuf.Bytes()), DecodeOptions{
+		OutRoot:  canonicalIn,
+		Adapters: AdapterSet{SQS: true},
+	}); err != nil {
+		t.Fatalf("canonical decode: %v", err)
+	}
+
+	scratchBase := t.TempDir()
+	var buf bytes.Buffer
+	result, err := EncodeSnapshot(EncodeOptions{
+		InputRoot:    canonicalIn,
+		Adapters:     AdapterSet{SQS: true},
+		LastCommitTS: 0xCAFE,
+		SelfTest:     true,
+		SelfTestDecodeOptions: DecodeOptions{
+			OutRoot:  scratchBase,
+			Adapters: AdapterSet{SQS: true},
+		},
+	}, &buf)
+	if err != nil {
+		t.Fatalf("EncodeSnapshot: %v", err)
+	}
+	if !result.SelfTestRan || !result.SelfTestMatched {
+		t.Errorf("SelfTestRan=%v Matched=%v, want both true; mismatch=%s", result.SelfTestRan, result.SelfTestMatched, string(result.SelfTestMismatchTxt))
+	}
+	if buf.Len() == 0 {
+		t.Errorf("bytes were not copied to out after successful self-test")
+	}
+	if result.Header.LastCommitTS != 0xCAFE {
+		t.Errorf("Header.LastCommitTS = %x, want 0xCAFE", result.Header.LastCommitTS)
+	}
+}
+
+// TestEncodeSnapshotSelfTestDetectsCorruption pins that the unexported
+// corruptBufferForTest hook lets the self-test catch corruption in the
+// internal buffer. The corruption must be reachable by the self-test
+// decode but MUST NOT reach the supplied io.Writer (the write-then-
+// rename invariant — codex P2 v6 #896).
+func TestEncodeSnapshotSelfTestDetectsCorruption(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	const queue = "selftest-corrupt"
+	writeSQSQueue(t, in, queue,
+		[]byte(`{"format_version":1,"name":"selftest-corrupt","fifo":false,"partition_count":1,"generation":1}`),
+		[][]byte{
+			[]byte(`{"format_version":1,"message_id":"m1","body":"a","send_timestamp_millis":1700000000000,"available_at_millis":1700000000000,"sequence_number":0}`),
+		},
+	)
+
+	scratchBase := t.TempDir()
+	var out bytes.Buffer
+	// Corrupt every 13th byte deep inside the buffer — far enough past
+	// the header that the decoder will trip on the malformed entry
+	// length field.
+	corrupt := func(b []byte) {
+		for i := 200; i < len(b); i += 13 {
+			b[i] ^= 0xFF
+		}
+	}
+	result, err := EncodeSnapshot(EncodeOptions{
+		InputRoot:    in,
+		Adapters:     AdapterSet{SQS: true},
+		LastCommitTS: 0xCAFE,
+		SelfTest:     true,
+		SelfTestDecodeOptions: DecodeOptions{
+			OutRoot:  scratchBase,
+			Adapters: AdapterSet{SQS: true},
+		},
+		corruptBufferForTest: corrupt,
+	}, &out)
+	if err != nil {
+		t.Fatalf("EncodeSnapshot: %v", err)
+	}
+	if !result.SelfTestRan {
+		t.Fatalf("SelfTestRan = false")
+	}
+	if result.SelfTestMatched {
+		t.Errorf("SelfTestMatched = true with corruption injected; want false")
+	}
+	if len(result.SelfTestMismatchTxt) == 0 {
+		t.Errorf("SelfTestMismatchTxt is empty; expected a mismatch report")
+	}
+	// CRITICAL: the corrupt bytes must NEVER reach out. The
+	// write-then-rename atomic-publish discipline requires that a
+	// self-test failure publishes nothing.
+	if out.Len() != 0 {
+		t.Errorf("out.Len = %d, want 0 (no bytes should reach out on self-test failure)", out.Len())
+	}
+}
+
+// TestEncodeSnapshotRequiresInputRoot rejects EncodeOptions with no
+// InputRoot — a simple guard so the constructor errors surface early.
+func TestEncodeSnapshotRequiresInputRoot(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if _, err := EncodeSnapshot(EncodeOptions{}, &buf); err == nil {
+		t.Fatalf("EncodeSnapshot with empty InputRoot succeeded; want error")
+	}
+}
+
+// TestEncodeInfoSidecarPath pins the path-derivation rule for the
+// sidecar (gemini medium v2 #896): one .fsm path produces one distinct
+// sidecar path; two .fsm files in the same dir produce two distinct
+// sidecars (no collision).
+func TestEncodeInfoSidecarPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.fsm")
+	b := filepath.Join(dir, "b.fsm")
+	sa := EncodeInfoSidecarPath(a)
+	sb := EncodeInfoSidecarPath(b)
+	if sa == sb {
+		t.Fatalf("sidecar paths collided: %s == %s", sa, sb)
+	}
+	// Verify each ends with the expected suffix.
+	if got, want := filepath.Base(sa), "a.fsm.encode_info.json"; got != want {
+		t.Errorf("sidecar(a) basename = %q, want %q", got, want)
+	}
+	if got, want := filepath.Base(sb), "b.fsm.encode_info.json"; got != want {
+		t.Errorf("sidecar(b) basename = %q, want %q", got, want)
+	}
+	// Both writable next to their .fsm (no OS-level collision).
+	for _, p := range []string{sa, sb} {
+		if err := os.WriteFile(p, []byte("{}"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+}

--- a/internal/backup/encode_snapshot_test.go
+++ b/internal/backup/encode_snapshot_test.go
@@ -498,6 +498,9 @@ func TestEncodeSnapshotRedisRejectsNonZeroDB(t *testing.T) {
 	if !errors.Is(err, ErrEncodeAdapterData) {
 		t.Errorf("err = %v, want errors.Is ErrEncodeAdapterData (mark from runAdapterEncoders)", err)
 	}
+	if buf.Len() != 0 {
+		t.Errorf("buf.Len = %d, want 0 (no bytes should be written on multi-DB rejection)", buf.Len())
+	}
 }
 
 // TestEncodeSnapshotRedisRejectsMultipleDBs pins the multi-DB case:
@@ -523,6 +526,9 @@ func TestEncodeSnapshotRedisRejectsMultipleDBs(t *testing.T) {
 	}
 	if !errors.Is(err, ErrRedisEncodeMultiDBUnsupported) {
 		t.Errorf("err = %v, want errors.Is ErrRedisEncodeMultiDBUnsupported", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("buf.Len = %d, want 0 (no bytes should be written on multi-DB rejection)", buf.Len())
 	}
 }
 

--- a/internal/backup/encode_snapshot_test.go
+++ b/internal/backup/encode_snapshot_test.go
@@ -209,6 +209,28 @@ func TestEncodeSnapshotRequiresInputRoot(t *testing.T) {
 	}
 }
 
+// TestEncodeSnapshotRejectsZeroAdapterSet pins claude v5 + codex v5
+// carry-over: a library caller that forgets to thread Adapters into
+// EncodeOptions gets a fail-closed error rather than a silently empty
+// header-only .fsm. The CLI's parseAdapterSet already rejects this for
+// flag-driven entry; this test pins the library-level guard.
+func TestEncodeSnapshotRejectsZeroAdapterSet(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	var buf bytes.Buffer
+	_, err := EncodeSnapshot(EncodeOptions{
+		InputRoot:    in,
+		Adapters:     AdapterSet{}, // explicit zero
+		LastCommitTS: 1,
+	}, &buf)
+	if err == nil {
+		t.Fatalf("EncodeSnapshot with empty AdapterSet succeeded; want error")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("buf.Len = %d, want 0 (no bytes should be written on guard rejection)", buf.Len())
+	}
+}
+
 // TestEncodeInfoSidecarPath pins the path-derivation rule for the
 // sidecar (gemini medium v2 #896): one .fsm path produces one distinct
 // sidecar path; two .fsm files in the same dir produce two distinct

--- a/internal/backup/encode_snapshot_test.go
+++ b/internal/backup/encode_snapshot_test.go
@@ -436,6 +436,13 @@ func TestEncodeSnapshotRejectsZeroAdapterSet(t *testing.T) {
 		InputRoot:    in,
 		Adapters:     AdapterSet{}, // explicit zero
 		LastCommitTS: 1,
+		// AllowMissingManifest: true bypasses the v19 MANIFEST.json
+		// guard so this test actually exercises the zero-adapter
+		// guard further down in validateEncodeOptions — without this,
+		// checkInputRoot would error on the missing MANIFEST.json
+		// first and the assertion would pin the wrong invariant
+		// (claude v19 #904).
+		AllowMissingManifest: true,
 	}, &buf)
 	if err == nil {
 		t.Fatalf("EncodeSnapshot with empty AdapterSet succeeded; want error")

--- a/internal/backup/manifest.go
+++ b/internal/backup/manifest.go
@@ -128,6 +128,14 @@ type Exclusions struct {
 	IncludeOrphans           bool `json:"include_orphans"`
 	PreserveSQSVisibility    bool `json:"preserve_sqs_visibility"`
 	IncludeSQSSideRecords    bool `json:"include_sqs_side_records"`
+	// RenameS3Collisions records whether the producer ran with
+	// --rename-collisions (DecodeOptions.RenameS3Collisions), so the
+	// M6 encoder's self-test can thread the same option back through
+	// DecodeSnapshot. Older manifests that omit this field decode as
+	// false (no-rename), matching the decoder default. Intentionally
+	// NOT added to exclusionsRequiredFields below so legacy manifests
+	// continue to validate (#896 v5 — claude review on M6 design).
+	RenameS3Collisions bool `json:"rename_s3_collisions,omitempty"`
 }
 
 // Manifest is the on-disk MANIFEST.json structure. Field tags match the

--- a/internal/backup/open_nofollow_unix.go
+++ b/internal/backup/open_nofollow_unix.go
@@ -98,5 +98,21 @@ func openSidecarFile(path string) (*os.File, error) {
 		_ = f.Close()
 		return nil, cockroachdberr.WithStack(err)
 	}
+	// Enforce 0o600 on the descriptor. The flags-arg mode (0o600
+	// above) is applied by the kernel ONLY on file creation; if
+	// path already existed, its pre-existing perms are kept. An
+	// older encoder writing 0o644 would otherwise leave the
+	// sidecar's source path / cluster ID / SHA256 world-readable
+	// after re-encode (claude / codex P2 v31 observation on PR #904).
+	if err := f.Chmod(sidecarFileMode); err != nil {
+		_ = f.Close()
+		return nil, cockroachdberr.WithStack(err)
+	}
 	return f, nil
 }
+
+// sidecarFileMode is the file mode openSidecarFile enforces — owner
+// read/write only. Pulled into a named const so the truncate-then-
+// chmod step here matches the OpenFile flag-arg mode above; a future
+// edit that widens one must touch both.
+const sidecarFileMode os.FileMode = 0o600

--- a/internal/backup/open_nofollow_unix.go
+++ b/internal/backup/open_nofollow_unix.go
@@ -58,7 +58,7 @@ func refuseHardLink(info os.FileInfo, path string) error {
 func openSidecarFile(path string) (*os.File, error) {
 	// Note: NO O_TRUNC here — we truncate after the link-count check.
 	const flag = os.O_WRONLY | os.O_CREATE | syscall.O_NOFOLLOW | syscall.O_NONBLOCK
-	f, err := os.OpenFile(path, flag, 0o600) //nolint:gosec,mnd // path is composed from output-root + fixed file name; 0600 is the standard owner-only mode
+	f, err := os.OpenFile(path, flag, sidecarFileMode) //nolint:gosec // path is composed from output-root + fixed file name; sidecarFileMode is the standard owner-only mode used here and by the post-Truncate Chmod below
 	if err != nil {
 		if errors.Is(err, syscall.ELOOP) {
 			return nil, cockroachdberr.WithStack(cockroachdberr.Wrapf(err,

--- a/internal/backup/open_nofollow_unix_test.go
+++ b/internal/backup/open_nofollow_unix_test.go
@@ -1,0 +1,37 @@
+//go:build unix
+
+package backup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestOpenSidecarFileEnforcesOwnerOnlyMode pins claude / codex P2 v31
+// observation on PR #904: an older encoder may have written the
+// sidecar at 0o644; OpenFile's mode arg only applies on CREATE, so
+// re-opening for re-encode would preserve the wider perms. The
+// post-Truncate Chmod restores 0o600 on every successful open.
+func TestOpenSidecarFileEnforcesOwnerOnlyMode(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sidecar.json")
+	// Pre-existing sidecar with wider perms (simulating an older
+	// encoder).
+	if err := os.WriteFile(path, []byte("prior"), 0o644); err != nil { //nolint:gosec // test simulates legacy permissive sidecar
+		t.Fatalf("WriteFile: %v", err)
+	}
+	f, err := OpenSidecarFile(path)
+	if err != nil {
+		t.Fatalf("OpenSidecarFile: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+	info, err := f.Stat()
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("perm = %o, want 0o600 (Chmod after Truncate must tighten existing-file perms)", got)
+	}
+}

--- a/internal/backup/open_nofollow_unix_test.go
+++ b/internal/backup/open_nofollow_unix_test.go
@@ -22,6 +22,17 @@ func TestOpenSidecarFileEnforcesOwnerOnlyMode(t *testing.T) {
 	if err := os.WriteFile(path, []byte("prior"), 0o644); err != nil { //nolint:gosec // test simulates legacy permissive sidecar
 		t.Fatalf("WriteFile: %v", err)
 	}
+	// Verify the environment actually honored the broader seed mode;
+	// a restrictive umask or stricter FS could silently produce 0o600
+	// and the test would pass even if the chmod-enforcement logic
+	// regressed (CodeRabbit nit on PR #904).
+	seedInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat seeded file: %v", err)
+	}
+	if seedInfo.Mode().Perm()&0o077 == 0 {
+		t.Skipf("environment refused permissive seed mode (got 0o%o); test cannot exercise chmod-enforcement", seedInfo.Mode().Perm())
+	}
 	f, err := OpenSidecarFile(path)
 	if err != nil {
 		t.Fatalf("OpenSidecarFile: %v", err)

--- a/internal/backup/open_sidecar_export.go
+++ b/internal/backup/open_sidecar_export.go
@@ -1,0 +1,21 @@
+package backup
+
+import "os"
+
+// OpenSidecarFile is the exported wrapper around the per-platform
+// openSidecarFile. It opens path for write while refusing symlink,
+// hard-link, FIFO, socket, and other non-regular-file clobber
+// attacks via the platform-appropriate primitives (O_NOFOLLOW +
+// O_NONBLOCK + Nlink check on unix; Lstat-then-OpenFile on Windows;
+// a stricter Lstat-then-OpenFile fallback on other platforms).
+//
+// Use this whenever a writer creates or replaces a "sidecar" style
+// file at a deterministic path inside an operator-supplied
+// directory — the path is predictable to an attacker who can pre-
+// create the entry, so the open MUST refuse to follow a symlink or
+// truncate a hard-linked / non-regular file (codex P2 v25 #904
+// extended this from in-package adapter writers to the
+// cmd/elastickv-snapshot-encode CLI's ENCODE_INFO.json writer).
+func OpenSidecarFile(path string) (*os.File, error) {
+	return openSidecarFile(path)
+}


### PR DESCRIPTION
## Summary

Phase 0b M6 implementation per the merged design doc [`docs/design/2026_06_01_proposed_snapshot_encode_cli.md`](https://github.com/bootjp/elastickv/blob/main/docs/design/2026_06_01_proposed_snapshot_encode_cli.md) (#896, merged at fe9e9413).

Wires the merged M1–M5 encoder slices into a user-facing CLI plus a library entrypoint mirroring the decoder's `DecodeSnapshot`. Implements the round-trip self-test the parent doc mandates, with write-then-rename atomic publish so a self-test failure never reaches the restore path.

## What lands

**Library** (`internal/backup/`):
- `encode_snapshot.go`: `EncodeSnapshot(opts, out io.Writer) (EncodeResult, error)` — high-level wrapper that dispatches per-adapter encoders in canonical fan-out order (`redis → dynamodb → s3 → sqs`), implements two-mode buffering (stream when `SelfTest=false`, buffer when `SelfTest=true`), runs the structural self-test against the in-memory buffer, and copies to `out` only on match. Unexported `corruptBufferForTest` hook lets same-package tests inject buffer corruption that reaches the self-test decode but never `out` (codex P2 v6 #896 — write-then-rename atomicity).
- `encode_info.go`: `EncodeInfo` schema + `WriteEncodeInfo` / `ReadEncodeInfo` helpers + `EncodeInfoSidecarPath` (path-derived `<output>.encode_info.json`, no static-name collisions per gemini medium v2 #896). Format-version gate so a future bump surfaces as `ErrUnsupportedEncodeInfoFormatVersion`.
- `manifest.go`: `Exclusions.RenameS3Collisions bool` added with JSON tag `rename_s3_collisions`. Intentionally NOT in `exclusionsRequiredFields` so legacy manifests decode safely with the zero value `false` (claude v5 medium #896).

**Decoder CLI update** (`cmd/elastickv-snapshot-decode/main.go`):
- `emitManifest` now populates the new `RenameS3Collisions` field from `cfg.renameCollisions`, completing the decoder→encoder round-trip for `--rename-collisions` dumps.

**Encoder CLI** (`cmd/elastickv-snapshot-encode/main.go`):
- Flags: `--input`, `--output`, `--adapter` (decoder-parity CSV parser), `--last-commit-ts`, `--self-test`, `--scratch-root`.
- Atomic publish: write to `<output>.tmp-<random>`, fsync+close, then rename. Self-test failure → `mismatch.txt` next to where `.fsm` would have been, temp file removed, exit 2.
- Fail-closed HLC ceiling: `--last-commit-ts T < manifest` → exit 2 with typed `ErrSelfTestLowerLastCommitTS`.
- Exit codes: 0 success / 1 user-input error / 2 data-correctness failure (decoder-parity).
- `encoder_version` stamped at build time via `-ldflags "-X main.version=..."` (mirrors decoder pattern at `main.go:45`).

## Test plan

`go test -race -count=1` — all green:
- `internal/backup/`: 3 new tests (encode_info schema, format gate, legacy manifest forward-compat)
- `internal/backup/encode_snapshot_test.go`: 5 tests (library round-trip, self-test match against canonicalized input, **corruption never reaches `out`**, missing-input guard, sidecar path derivation)
- `cmd/elastickv-snapshot-encode/main_test.go`: 9 tests (missing manifest, unknown adapter, lower-TS fail-closed, equal+higher TS accept, path-derived sidecar, two-files-no-collision, full round-trip with `--self-test`, atomic-publish never leaves bad `.fsm`, `--last-commit-ts` parser)

`make lint`: clean.

## Caller audit per CLAUDE.md semantic-change rule

- `Exclusions` struct gained a field. Existing callers either build via field-tagged literals (decoder CLI's `emitManifest` — updated to populate the new field) or read it (encoder's `buildSelfTestDecodeOptions` — new code). No silent semantic change.
- `DecodeOptions.RenameS3Collisions` was already a public field used by the decoder; the encoder now also reads it via the manifest. No caller-side change needed.

## Self-review (5 passes)

1. **Data loss**: write-then-rename atomic publish — self-test failure never publishes the `.fsm`. Corrupted buffer never reaches the `io.Writer` (pinned by `TestEncodeSnapshotSelfTestDetectsCorruption` asserting `out.Len()==0`). All `b.Add` errors propagate through `EncodeSnapshot`.
2. **Concurrency**: pure offline. CLI is single-shot; library takes a caller-owned `io.Writer`. Temp-file suffix uses `crypto/rand` so concurrent encodes against the same `--output` cannot collide.
3. **Performance**: `SelfTest=false` streams with one `sha256.Writer` tee, no extra allocations. `SelfTest=true` allocates one FSM-sized `*bytes.Buffer` plus the scratch decode tree (documented memory cost).
4. **Data consistency**: `--last-commit-ts T < manifest` fail-closed with typed error; self-test threads MANIFEST DecodeOptions (`Exclusions.*` + `DynamoDBLayout → DynamoDBBundleJSONL`) so trees produced with non-default decoder flags round-trip cleanly.
5. **Test coverage**: 17 new tests cover library entrypoint, CLI flag parsing, atomic publish discipline, sidecar path-derivation, corruption detection, forward-compat for legacy manifests, and the four user-visible behaviors (round-trip / override / scope / missing-manifest).

## Risk

Low. The encoder is offline; restoration is non-destructive (new keyspace on a fresh cluster via stop-replace-restart). The only public-API change is the `Exclusions.RenameS3Collisions` field, which is forward-compat for older manifests. All existing M1–M5 tests continue to pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New snapshot encode CLI with atomic publish, multi-adapter encoding, optional self-test verification, and per-output encode sidecar (.encode_info.json).
  * Sidecar safe-open exported and sidecar permission tightening to owner-only mode.

* **Bug Fixes**
  * Manifests now include/preserve an S3 rename-collision flag while remaining compatible with older manifests.
  * Self-test failures avoid publishing bad outputs, preserve prior artifacts appropriately, and reject unexpected non-directory S3 entries.

* **Tests**
  * Extensive unit and end-to-end tests covering CLI, library, self-test, manifest compatibility, sidecar handling, and filesystem safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->