### PR TITLE
feat(encryption): Stage 6E-2a — ErrEnvelopeCutoverInProgress typed error

### DIFF
--- a/internal/raftengine/etcd/encryption.go
+++ b/internal/raftengine/etcd/encryption.go
@@ -33,6 +33,31 @@ var ErrEncryptionApply = encryption.ErrEncryptionApply
 // recovery path.
 var ErrRaftUnwrapFailed = errors.New("raftengine/etcd: raft envelope unwrap failed; halting apply")
 
+// ErrEnvelopeCutoverInProgress is returned by Engine.Propose (and
+// the coordinator wrap-on-propose path) while the §7.1
+// proposal-quiescence barrier owned by EnableRaftEnvelope is open:
+// new user proposals are rejected with this error so the barrier
+// can drain the in-flight set and atomically flip wrap-on-propose
+// without the leader admitting a plaintext proposal at
+// `index > raftEnvelopeCutoverIndex`.
+//
+// The barrier admits exactly two source classes:
+//
+//   - The cutover entry itself, proposed by EnableRaftEnvelope
+//     (source = "encryption_admin") — without this exemption the
+//     barrier would deadlock on its own cutover proposal.
+//   - ConfChange-time RegisterEncryptionWriter proposals (Stage 7c
+//     §3.1) which also pass source = "encryption_admin" because
+//     a new member joining mid-barrier must still be able to
+//     register its writer-registry entry.
+//
+// All other Propose calls receive ErrEnvelopeCutoverInProgress
+// during the barrier window. Caller policy: surface this as a
+// retryable error to the client — the barrier completes in
+// O(in-flight-drain-time) and the next attempt will succeed under
+// the new (wrapped) regime.
+var ErrEnvelopeCutoverInProgress = errors.New("raftengine/etcd: raft envelope cutover barrier open; retry shortly")
+
 // RaftCutoverIndex returns the §7.1 Phase 2 cutover Raft index.
 // Entries with index strictly greater than the returned value carry
 // raft-envelope-wrapped fsm payloads; entries at or below the

--- a/internal/raftengine/etcd/encryption_test.go
+++ b/internal/raftengine/etcd/encryption_test.go
@@ -78,13 +78,6 @@ func envelopeEntry(t *testing.T, c *encryption.Cipher, kid uint32, index uint64,
 	return raftpb.Entry{Index: index, Type: raftpb.EntryNormal, Data: encodeProposalEnvelope(7, wrapped)}
 }
 
-// TestApplyNormalEntry_CutoverActive_NoCipher_FailsClosed locks down
-// the misconfig case: when the cluster has crossed the raft envelope
-// cutover (an above-cutover entry arrives) but raftCipher is nil —
-// a sidecar/init race or operator wiring mistake — the engine MUST
-// refuse to apply, NOT silently hand wrapped envelope bytes to
-// fsm.Apply. The latter would permanently diverge this node from
-// peers that DID unwrap and apply the cleartext.
 // TestErrEnvelopeCutoverInProgress_DistinctFromUnwrapFailure pins
 // the §7.1 barrier's typed error as a separate sentinel from
 // ErrRaftUnwrapFailed. The two have very different operator
@@ -105,11 +98,25 @@ func TestErrEnvelopeCutoverInProgress_DistinctFromUnwrapFailure(t *testing.T) {
 	if errors.Is(ErrRaftUnwrapFailed, ErrEnvelopeCutoverInProgress) {
 		t.Error("ErrRaftUnwrapFailed matches ErrEnvelopeCutoverInProgress; the process-fatal sentinel must not be misclassified as retryable")
 	}
-	if !errors.Is(ErrEnvelopeCutoverInProgress, ErrEnvelopeCutoverInProgress) {
-		t.Error("ErrEnvelopeCutoverInProgress fails errors.Is against itself")
+	// Pin the chain contract that Stage 6E-2b callers depend
+	// on: an errors.Wrap-wrapped sentinel must still match via
+	// errors.Is. A downstream caller that wraps the sentinel
+	// for diagnostic context would otherwise silently lose its
+	// retryable classification and fall through to a
+	// process-fatal error path.
+	wrapped := errors.Wrap(ErrEnvelopeCutoverInProgress, "cutover barrier open")
+	if !errors.Is(wrapped, ErrEnvelopeCutoverInProgress) {
+		t.Error("ErrEnvelopeCutoverInProgress lost through errors.Wrap; callers using errors.Is on a wrapped error must still match the sentinel")
 	}
 }
 
+// TestApplyNormalEntry_CutoverActive_NoCipher_FailsClosed locks down
+// the misconfig case: when the cluster has crossed the raft envelope
+// cutover (an above-cutover entry arrives) but raftCipher is nil —
+// a sidecar/init race or operator wiring mistake — the engine MUST
+// refuse to apply, NOT silently hand wrapped envelope bytes to
+// fsm.Apply. The latter would permanently diverge this node from
+// peers that DID unwrap and apply the cleartext.
 func TestApplyNormalEntry_CutoverActive_NoCipher_FailsClosed(t *testing.T) {
 	t.Parallel()
 	const cutover uint64 = 100

--- a/internal/raftengine/etcd/encryption_test.go
+++ b/internal/raftengine/etcd/encryption_test.go
@@ -85,6 +85,31 @@ func envelopeEntry(t *testing.T, c *encryption.Cipher, kid uint32, index uint64,
 // refuse to apply, NOT silently hand wrapped envelope bytes to
 // fsm.Apply. The latter would permanently diverge this node from
 // peers that DID unwrap and apply the cleartext.
+// TestErrEnvelopeCutoverInProgress_DistinctFromUnwrapFailure pins
+// the §7.1 barrier's typed error as a separate sentinel from
+// ErrRaftUnwrapFailed. The two have very different operator
+// responses: cutover-in-progress is a retryable transient (the
+// barrier completes in drain-time, then the next attempt
+// succeeds under the new wrapped regime), while unwrap-failed is
+// process-fatal (sidecar / Raft-log divergence or KEK custody
+// problem). A caller that confuses them would either drop
+// retryable cutover-window proposals on the floor or paper over
+// a fatal data-integrity error with a retry loop. errors.Is
+// distinguishes them; this test pins that distinction so future
+// refactors of the error chain do not silently merge the two.
+func TestErrEnvelopeCutoverInProgress_DistinctFromUnwrapFailure(t *testing.T) {
+	t.Parallel()
+	if errors.Is(ErrEnvelopeCutoverInProgress, ErrRaftUnwrapFailed) {
+		t.Error("ErrEnvelopeCutoverInProgress matches ErrRaftUnwrapFailed; the §7.1 barrier sentinel must be a distinct error chain")
+	}
+	if errors.Is(ErrRaftUnwrapFailed, ErrEnvelopeCutoverInProgress) {
+		t.Error("ErrRaftUnwrapFailed matches ErrEnvelopeCutoverInProgress; the process-fatal sentinel must not be misclassified as retryable")
+	}
+	if !errors.Is(ErrEnvelopeCutoverInProgress, ErrEnvelopeCutoverInProgress) {
+		t.Error("ErrEnvelopeCutoverInProgress fails errors.Is against itself")
+	}
+}
+
 func TestApplyNormalEntry_CutoverActive_NoCipher_FailsClosed(t *testing.T) {
 	t.Parallel()
 	const cutover uint64 = 100


### PR DESCRIPTION
## Summary

First foundational slice for Stage 6E-2 (engine unwrap + coordinator wrap + §7.1 barrier atomic flip). Adds the typed sentinel `ErrEnvelopeCutoverInProgress` that `Engine.Propose` (and the coordinator wrap-on-propose path) will return while the §7.1 proposal-quiescence barrier owned by `EnableRaftEnvelope` is open.

## Why this is split out

Stage 6E-2 has four interlocked pieces that must ship in one PR before the gate flips (engine unwrap path exists since Stage 3; coordinator wrap-on-propose; §7.1 barrier in admin handler; gate flip). This slice is a **purely additive foundation** — no existing code path changes, no behavior change. It exists so the upcoming 6E-2b (Propose source-tag plumbing) and 6E-2c (EnableRaftEnvelope barrier) PRs have a stable typed-error contract to import.

## What lands

- `internal/raftengine/etcd/encryption.go` — new `ErrEnvelopeCutoverInProgress` sentinel, alongside the existing `ErrRaftUnwrapFailed`. Doc comment captures:
  - The barrier-admitted source classes (cutover entry + ConfChange-time `RegisterEncryptionWriter`, both via `source="encryption_admin"`), explaining the deadlock-on-own-proposal exemption.
  - Caller policy: retryable; barrier completes in drain-time.
  - Distinction from `ErrRaftUnwrapFailed` (process-fatal).
- `internal/raftengine/etcd/encryption_test.go` — `TestErrEnvelopeCutoverInProgress_DistinctFromUnwrapFailure` pins the `errors.Is` asymmetry so future error-chain refactors cannot silently merge the two sentinels.

## Test plan

- [x] `go test -run 'ErrEnvelopeCutoverInProgress' ./internal/raftengine/etcd/` — pass.
- [x] `golangci-lint run` on the touched package — 0 issues.
- [x] No existing test affected (purely additive).

## Self-review (per CLAUDE.md)

1. Data loss — none; new variable, no execution path changes.
2. Concurrency — none; the sentinel is a constant.
3. Performance — none; package-level `errors.New` runs once at init.
4. Data consistency — none; the sentinel will gate retryable vs fatal classification in future slices.
5. Test coverage — one focused test pinning the cross-sentinel `errors.Is` asymmetry.

## Caller audit (semantic-change directive)

N/A — no semantic-change refactor in this PR; the sentinel is unused by any caller at this point. Future PRs (6E-2b coordinator wrap, 6E-2c barrier) will introduce callers and will perform the audit at that time.
