### PR TITLE
fix(ops/rolling-update): bump HEALTH_TIMEOUT_SECONDS default 60s -> 300s

### DIFF
--- a/scripts/rolling-update.sh
+++ b/scripts/rolling-update.sh
@@ -211,6 +211,11 @@ SQS_FIFO_PARTITION_MAP="${SQS_FIFO_PARTITION_MAP:-}"
 # for the multi-GiB working sets we operate against today and still
 # fails fast on genuine crash-loop bugs (which never finish (1) or (2)).
 # Operators with smaller FSMs can shrink HEALTH_TIMEOUT_SECONDS via env.
+# Root-cause fix (skip restoreSnapshotState when the on-disk FSM is
+# already at >= snapshot.Metadata.Index): see PR #910 and
+# docs/design/2026_06_02_idempotent_snapshot_restore.md. Once that
+# lands and steady-state skip rates are observed in production, this
+# default can be tightened back down.
 HEALTH_TIMEOUT_SECONDS="${HEALTH_TIMEOUT_SECONDS:-300}"
 LEADERSHIP_TRANSFER_TIMEOUT_SECONDS="${LEADERSHIP_TRANSFER_TIMEOUT_SECONDS:-30}"
 LEADER_DISCOVERY_TIMEOUT_SECONDS="${LEADER_DISCOVERY_TIMEOUT_SECONDS:-30}"

--- a/scripts/rolling-update.sh
+++ b/scripts/rolling-update.sh
@@ -193,7 +193,25 @@ SQS_CREDENTIALS_FILE="${SQS_CREDENTIALS_FILE:-}"
 # is bypassed (resolver==nil) and partitioned queues land on the
 # default group. Format documented at main.go::buildSQSFifoPartitionMap.
 SQS_FIFO_PARTITION_MAP="${SQS_FIFO_PARTITION_MAP:-}"
-HEALTH_TIMEOUT_SECONDS="${HEALTH_TIMEOUT_SECONDS:-60}"
+# Wall-clock budget wait_for_grpc allows for the restarted container to
+# bind its gRPC port. Sized to cover the worst-case cold-start path:
+#   1. pebble.Open (fsm.db, ~seconds)
+#   2. loadWalState -> restoreSnapshotState -> pebbleStore.Restore
+#      (restorePebbleNativeAtomic + swapInTempDB), which rewrites the
+#      entire FSM into a sibling temp directory before renaming it into
+#      place. For multi-GB FSMs on production hardware this is the
+#      dominant cost — we observed ~46 s on a 4-shard SSD-backed node
+#      with a ~5 M-key FSM; multi-GB datasets scale linearly with disk
+#      throughput.
+#   3. WAL replay of the entries between the persisted snapshot index
+#      and the latest WAL entry (typically thousands, sub-second).
+#   4. Raft follower-ization + gRPC.Serve bind.
+# A 60 s ceiling guaranteed a timeout-induced restart loop on any node
+# whose FSM exceeded ~1 GiB. 300 s comfortably absorbs (1)+(2)+(3)+(4)
+# for the multi-GiB working sets we operate against today and still
+# fails fast on genuine crash-loop bugs (which never finish (1) or (2)).
+# Operators with smaller FSMs can shrink HEALTH_TIMEOUT_SECONDS via env.
+HEALTH_TIMEOUT_SECONDS="${HEALTH_TIMEOUT_SECONDS:-300}"
 LEADERSHIP_TRANSFER_TIMEOUT_SECONDS="${LEADERSHIP_TRANSFER_TIMEOUT_SECONDS:-30}"
 LEADER_DISCOVERY_TIMEOUT_SECONDS="${LEADER_DISCOVERY_TIMEOUT_SECONDS:-30}"
 ROLLING_DELAY_SECONDS="${ROLLING_DELAY_SECONDS:-2}"


### PR DESCRIPTION
## Summary

`scripts/rolling-update.sh` の `HEALTH_TIMEOUT_SECONDS` デフォルトを **60s → 300s** に引き上げます。

## なぜ 60s では足りないか

2026-06-02 の 5 ノードクラスタ (192.168.0.x) ローリング再起動で、`.212` ノードが起動中に `wait_for_grpc` がタイムアウトし、スクリプトが `gRPC port did not come up on 192.168.0.212:50051` で exit。`docker logs --tail 200` を辿ると以下の wall-clock 内訳:

```
12:56:05  pebble.Open("/var/lib/elastickv/n3/fsm.db") — 既存 DB を開いて WAL 012720/012734 を replay
12:56:06  pebble.Open(<sibling tempdir>) — restorePebbleNativeAtomic が新規 Pebble を作成 (Found 0 WALs)
   ↓ +45s  restoreBatchLoopInto が FSM スナップショットを batch-loop で書き戻す
12:56:51  pebble.Open(fsm.db) — swapInTempDB が old dir を RemoveAll + temp を Rename → 再オープン (Found 4 WALs: 001309..001315)
   ↓       WAL replay (commit=57365699 / applied=57361461 → 4238 entries)
   ↓       raft follower-ization
   ↓       grpc.Serve bind
```

つまり多くの場合 **`restorePebbleNativeAtomic` + `swapInTempDB` だけで ~46 秒** 消費しており、その後にまだ WAL replay + raft follower 化 + gRPC bind が残るため、60s ceiling では確実にタイムアウトします。

タイムアウトはさらに二次被害を生みます: 再起動コンテナが応答不能のまま docker restart policy で再投入される → 残りクォーラムから見て当該ノードが選挙に応答しない → raft term が増え続ける(我々のクラスタでは term 665 まで上昇)。

## 変更内容

- `HEALTH_TIMEOUT_SECONDS` のデフォルトを `60` → `300` に
- 上に **コールドスタートの内訳と why 300s** を明記したコメントブロック (将来オペレーターが値を縮めたくなった時の根拠)

## 動作確認

- `bash -n scripts/rolling-update.sh` → syntax OK
- `HEALTH_TIMEOUT_SECONDS=120 bash scripts/rolling-update.sh ...` のようなオペレーター側オーバーライドは引き続き有効

## 設計フォローアップ (別 PR)

これは **症状の応急処置** で、根本原因(`restoreSnapshotState` がコールドスタート時に毎回 FSM 全復元する)は別 PR で扱います:

- `pebbleStore` に `LastAppliedIndex()` を生やし、毎 Apply の WriteBatch にメタキーとしてアトミックに同梱
- `restoreSnapshotState` で `LastAppliedIndex() >= snapshot.Metadata.Index` ならスキップ
- 設計ドキュメント: `docs/design/2026_06_02_idempotent_snapshot_restore.md` (Coming up next)

これが入れば 46s の payload は完全に消え、`HEALTH_TIMEOUT_SECONDS` は将来引き下げ可能になります。
