### PR TITLE
docs(design): idempotent FSM snapshot restore on cold start

### DIFF
--- a/docs/design/2026_06_02_idempotent_snapshot_restore.md
+++ b/docs/design/2026_06_02_idempotent_snapshot_restore.md
@@ -473,7 +473,7 @@ at every snapshot persist site, **before** the corresponding
 left the steady-state path uncovered (codex round-4 P2 at `:455`).
 Round-5 hooks both:
 
-**Site 1 — `persistCreatedSnapshot`** (`engine.go:2683`).  Drives
+**Site 1 — `persistCreatedSnapshot`** (`engine.go:2679`).  Drives
 **config snapshots** (created via `createConfigSnapshot` →
 `storage.CreateSnapshot`):
 
@@ -499,7 +499,7 @@ func (e *Engine) persistCreatedSnapshot(snap raftpb.Snapshot) error {
 is the **steady-state `SnapshotCount`-triggered snapshot path** —
 `maybePersistLocalSnapshot` (`engine.go:2070`) → `e.persistLocalSnapshotPayload`
 (`engine.go:4032`) → the free function `persistLocalSnapshotPayload`
-(`wal_store.go:519`) → `persist.SaveSnap` at `wal_store.go:525`.  This
+(`wal_store.go:519`) → `persist.SaveSnap` at `wal_store.go:524`.  This
 is the hot path the optimisation actually depends on; without hooking
 it, the codex round-3 P2 fallback is not closed.
 
@@ -519,7 +519,7 @@ func (e *Engine) persistLocalSnapshotPayload(index uint64, payload []byte) error
 
     // Round-5: bump metaAppliedIndex BEFORE the free-function
     // persistLocalSnapshotPayload (which calls persist.SaveSnap at
-    // wal_store.go:525). Lives in the engine wrapper so the free
+    // wal_store.go:524). Lives in the engine wrapper so the free
     // function stays signature-stable and is reusable from tests
     // that bypass the engine. Skipped silently when the FSM does
     // not implement AppliedIndexWriter (legacy fakes / test shims).
@@ -689,7 +689,7 @@ restoreSnapshotState skipped (FSM at index %d, snapshot at %d, ceiling=%d, cutov
 | Branch | Content | Behaviour change |
 |---|---|---|
 | **B1** (this PR) | Design doc | None |
-| **B2** | `ApplyMutationsRaftAt` / `DeletePrefixAtRaftAt` overloads + meta-key bundling in both leaves + `pebbleStore.LastAppliedIndex()` + `pebbleStore.SetDurableAppliedIndex()` (both with `dbMu.RLock()`) + `kvFSM.AppliedIndexReader()` accessor + `kvFSM.SetDurableAppliedIndex` forwarding + thread `f.pendingApplyIdx` into the data-Apply leaves + BOTH `persistCreatedSnapshot` (`engine.go:2683`) AND `e.persistLocalSnapshotPayload` (`engine.go:4032`, the SnapshotCount-triggered hot path) call `SetDurableAppliedIndex` BEFORE the corresponding `persist.SaveSnap` | Meta key starts being written on every data Apply AND at every snapshot persist (both config-snapshot and steady-state local-snapshot paths). Skip is still disabled. Soak in production for one release. |
+| **B2** | `ApplyMutationsRaftAt` / `DeletePrefixAtRaftAt` overloads + meta-key bundling in both leaves + `pebbleStore.LastAppliedIndex()` + `pebbleStore.SetDurableAppliedIndex()` (both with `dbMu.RLock()`) + `kvFSM.AppliedIndexReader()` accessor + `kvFSM.SetDurableAppliedIndex` forwarding + thread `f.pendingApplyIdx` into the data-Apply leaves + BOTH `persistCreatedSnapshot` (`engine.go:2679`) AND `e.persistLocalSnapshotPayload` (`engine.go:4032`, the SnapshotCount-triggered hot path) call `SetDurableAppliedIndex` BEFORE the corresponding `persist.SaveSnap` | Meta key starts being written on every data Apply AND at every snapshot persist (both config-snapshot and steady-state local-snapshot paths). Skip is still disabled. Soak in production for one release. |
 | **B3** | `restoreSnapshotState` skip gate + `applyHeaderStateOnSkip` reusing `kv.ReadSnapshotHeader` + `SnapshotHeaderApplier` seam on `kvFSM` + metrics + INFO log | **User-visible cold-start win.** |
 | **B4** | Lower `HEALTH_TIMEOUT_SECONDS` default once production data shows steady-state skip rate ≥ 90 % | Tighter ceiling; the env override remains honoured. |
 
@@ -845,7 +845,7 @@ Verified on `origin/main`:
 - `maybePersistLocalSnapshot` (`engine.go:2070`) →
   `e.persistLocalSnapshotPayload` (`engine.go:4032`) → free
   `persistLocalSnapshotPayload` (`wal_store.go:519`) →
-  `persist.SaveSnap` (`wal_store.go:525`) is the actual hot path for
+  `persist.SaveSnap` (`wal_store.go:524`) is the actual hot path for
   `SnapshotCount`-triggered snapshots; round-4's
   `persistCreatedSnapshot` hook only covers `createConfigSnapshot`
   (membership-change snapshots).

--- a/docs/design/2026_06_02_idempotent_snapshot_restore.md
+++ b/docs/design/2026_06_02_idempotent_snapshot_restore.md
@@ -1,7 +1,7 @@
 # Idempotent FSM Snapshot Restore on Cold Start
 
-**Status**: Proposal (Round 6 — thread tok.CRC32C through the skip path)
-**Date**: 2026-06-02 (round 1), 2026-06-03 (rounds 2 / 3 / 4 / 5 / 6)
+**Status**: Proposal (Round 7 — split CRC seam + force pebble.Sync on checkpoint)
+**Date**: 2026-06-02 (round 1), 2026-06-03 (rounds 2 / 3 / 4 / 5 / 6 / 7)
 **Author**: bootjp
 **Related**: PR #909 (`HEALTH_TIMEOUT_SECONDS` 60s → 300s)
 
@@ -377,37 +377,53 @@ cutover`).  Worse, a too-short / truncated file would be parsed by
 `ReadSnapshotHeader` as headerless legacy and silently apply
 `ceiling=0, cutover=0`.
 
-Round-6 mirrors the existing safety contract by threading
-`tok.CRC32C` through to the FSM and running the same three checks
-**before** applying any side-effect:
+**Seam implementability constraint (round-7 fix)**.  Round 6 placed
+the entire CRC verification inside `kvFSM.ApplySnapshotHeaderFromFile`,
+which would need to call `readFSMFooter`, `fsmMinFileSize`,
+`crc32cTable`, `fsmRestoreReadAhead`, `statFSMFileError`,
+`ErrFSMSnapshotTokenCRC`, `ErrFSMSnapshotFileCRC` —  **all
+unexported** in `internal/raftengine/etcd/fsm_snapshot_file.go`.
+Production code does not currently have `kv → internal/raftengine/etcd`
+or `internal/raftengine/etcd → kv` edges (test-only on both sides), and
+adding either to satisfy the round-6 design either duplicates the CRC
+verifier in `kv` or breaks the layering.
+
+Round-7 keeps the CRC verifier in its existing package and splits the
+seam into two phases — a **parse** phase that reads the header from a
+caller-supplied reader (and drains the rest, for CRC coverage), and an
+**apply** phase that is pure assignment.  The engine orchestrates
+size + footer + tee'd CRC computation around the parse phase, then
+calls apply only after all three pass:
 
 ```go
-// internal/raftengine/etcd/wal_store.go (new) -- never imports kv
+// internal/raftengine/statemachine.go (new, sibling to ApplyIndexAware)
+type SnapshotHeaderApplier interface {
+    // ParseSnapshotHeader reads the v1/v2 header from r, drains the
+    // remaining bytes (so a wrapping crc32 TeeReader covers the full
+    // payload), and returns the parsed (ceiling, cutover) pair WITHOUT
+    // mutating FSM state. Implementations MUST NOT touch any FSM
+    // fields here; the engine calls ApplySnapshotHeader separately
+    // only after the wrapping CRC verification passes.
+    //
+    // Errors propagate from the underlying header parser
+    // (ErrSnapshotHeaderUnknownMagic / InvalidLength) or from the
+    // drain pass (I/O errors). FSM state stays untouched on error.
+    ParseSnapshotHeader(r io.Reader) (ceiling, cutover uint64, err error)
+
+    // ApplySnapshotHeader is pure assignment of the verified header
+    // state. The engine calls this only after ParseSnapshotHeader
+    // returned and the wrapping crc32 hash matched the file footer.
+    ApplySnapshotHeader(ceiling, cutover uint64)
+}
+
+// internal/raftengine/etcd/wal_store.go -- never imports kv;
+// CRC verification stays here where the helpers live.
 func applyHeaderStateOnSkip(fsm StateMachine, snapPath string, tokenCRC uint32) error {
     setter, ok := fsm.(SnapshotHeaderApplier)
     if !ok {
         return nil // FSM has no header state; skip is harmless.
     }
-    return errors.WithStack(setter.ApplySnapshotHeaderFromFile(snapPath, tokenCRC))
-}
 
-// internal/raftengine/statemachine.go (new, sibling to ApplyIndexAware)
-type SnapshotHeaderApplier interface {
-    // ApplySnapshotHeaderFromFile opens the snapshot file at snapPath,
-    // verifies size + footer-vs-tokenCRC + full-body-CRC (matching
-    // openAndRestoreFSMSnapshot's safety contract), then applies the
-    // header side-effects the FSM's Restore would apply (HLC ceiling,
-    // Stage 8a cutover, etc.). Returns ErrFSMSnapshotTooSmall /
-    // ErrFSMSnapshotTokenCRC / ErrFSMSnapshotFileCRC for the
-    // corresponding verification failures, or
-    // ErrSnapshotHeaderUnknownMagic / InvalidLength for
-    // forward-incompat headers. MUST NOT mutate FSM state on any
-    // verification failure.
-    ApplySnapshotHeaderFromFile(snapPath string, tokenCRC uint32) error
-}
-
-// kv/fsm.go (new method on kvFSM) -- kv.ReadSnapshotHeader stays inside kv
-func (f *kvFSM) ApplySnapshotHeaderFromFile(snapPath string, tokenCRC uint32) error {
     file, err := os.Open(snapPath)
     if err != nil { return statFSMFileError(err) }
     defer file.Close()
@@ -429,28 +445,22 @@ func (f *kvFSM) ApplySnapshotHeaderFromFile(snapPath string, tokenCRC uint32) er
             "path=%s footer=%08x token=%08x", snapPath, footer, tokenCRC)
     }
 
-    // Step 3: full-body CRC, with the header parsed inside the tee'd
-    // reader so its bytes are included in the computed CRC. We
-    // intentionally drain (Discard) the body bytes -- the body is
-    // already present in fsm.db (that's why we're skipping the
-    // restore), but the CRC must cover the whole payload for the
-    // ErrFSMSnapshotFileCRC check to mean what it does in
-    // openAndRestoreFSMSnapshot.
+    // Step 3: full-body CRC. Wrap the payload in a crc32 TeeReader and
+    // hand it to the FSM's ParseSnapshotHeader for header parse + drain.
+    // The header bytes are included in the computed CRC because the
+    // FSM reads them from the tee'd reader.
     if _, err := file.Seek(0, io.SeekStart); err != nil {
         return errors.WithStack(err)
     }
     payloadSize := info.Size() - fsmFooterSize
     h := crc32.New(crc32cTable)
     tee := io.TeeReader(io.LimitReader(file, payloadSize), h)
-    br := bufio.NewReaderSize(tee, fsmRestoreReadAhead)
 
-    ceiling, cutover, herr := ReadSnapshotHeader(br)
-    if herr != nil {
-        // ErrSnapshotHeaderUnknownMagic / InvalidLength: fail closed.
-        return errors.WithStack(herr)
-    }
-    if _, err := io.Copy(io.Discard, br); err != nil {
-        return errors.WithStack(err)
+    ceiling, cutover, perr := setter.ParseSnapshotHeader(tee)
+    if perr != nil {
+        // ErrSnapshotHeaderUnknownMagic / InvalidLength / I/O error
+        // surfaced from the FSM's parse pass. State unchanged.
+        return errors.WithStack(perr)
     }
     if h.Sum32() != footer {
         return errors.Wrapf(ErrFSMSnapshotFileCRC,
@@ -458,31 +468,55 @@ func (f *kvFSM) ApplySnapshotHeaderFromFile(snapPath string, tokenCRC uint32) er
     }
 
     // All three checks passed; apply side-effects.
+    setter.ApplySnapshotHeader(ceiling, cutover)
+    return nil
+}
+
+// kv/fsm.go (new methods on kvFSM) -- kv.ReadSnapshotHeader stays inside kv;
+// no imports of internal/raftengine/etcd or its private helpers.
+func (f *kvFSM) ParseSnapshotHeader(r io.Reader) (uint64, uint64, error) {
+    // The engine has already wrapped r in a crc32 TeeReader sized at
+    // the body payload (file size minus 4-byte footer). We read the
+    // header, then drain the rest of the body so the engine's CRC
+    // covers every byte (matching restoreAndComputeCRC's behaviour).
+    br := bufio.NewReaderSize(r, 1<<20) //nolint:mnd // 1 MiB, local to kv
+    ceiling, cutover, err := ReadSnapshotHeader(br)
+    if err != nil { return 0, 0, errors.WithStack(err) }
+    if _, err := io.Copy(io.Discard, br); err != nil {
+        return 0, 0, errors.WithStack(err)
+    }
+    return ceiling, cutover, nil
+}
+
+func (f *kvFSM) ApplySnapshotHeader(ceiling, cutover uint64) {
     if f.hlc != nil && ceiling > 0 {
         f.hlc.SetPhysicalCeiling(int64(ceiling))
     }
     f.restoredCutover = cutover
-    return nil
 }
 ```
 
-**Cost note**.  Step 3 reads the full snapshot file once.  For multi-GiB
-FSMs this is a non-trivial I/O cost — but it is **strictly cheaper**
-than the restore path it replaces (which also reads the file once via
-`restoreAndComputeCRC` AND additionally writes a temp Pebble database
-with sstable / WAL output).  Observed restore wall-clock is dominated
-by Pebble writes, not reads; eliding the writes preserves the bulk of
-the win.  A future optimisation could persist the HLC ceiling +
-cutover durably (analogous to `metaAppliedIndex`) and elide the file
-read entirely — that's out of scope for this proposal but flagged
-under Open Questions.
+**Cost note**.  Step 3 reads the full snapshot file once (through the
+crc32 TeeReader).  For multi-GiB FSMs this is a non-trivial I/O cost
+— but it is **strictly cheaper** than the restore path it replaces
+(which also reads the file once via `restoreAndComputeCRC` AND
+additionally writes a temp Pebble database with sstable / WAL output).
+Observed restore wall-clock is dominated by Pebble writes, not reads;
+eliding the writes preserves the bulk of the win.  A future
+optimisation could persist the HLC ceiling + cutover durably
+(analogous to `metaAppliedIndex`) and elide the file read entirely —
+out of scope here, flagged under Open Questions.
 
-By keeping the `kv.ReadSnapshotHeader` call inside `kv/fsm.go` the
-skip path inherits v1 + v2 parity, the `ErrSnapshotHeaderUnknownMagic`
-fail-closed branch, and any future v3 the snapshot header gains —
-without `wal_store.go` ever naming the `kv` package.  The body bytes
-are read (for the CRC pass) but discarded — `file` is closed before
-returning, and no inner-store mutation occurs.
+**Why this seam shape**.  The two-phase split lets the CRC verifier
+stay co-located with its private helpers in
+`internal/raftengine/etcd/fsm_snapshot_file.go`'s package, **and**
+keeps the v1/v2 header parser inside `kv` where it already lives.
+Neither package imports the other in production.  The "do CRC on
+engine side, side-effects on FSM side after verify" contract is
+exactly the inversion of `openAndRestoreFSMSnapshot` (which inlines
+`fsm.Restore` inside the CRC tee for performance reasons): for the
+skip path we don't need a single-pass restore, so splitting the
+phases costs nothing and buys layer hygiene.
 
 ### 6. Crash-safety argument
 
@@ -500,12 +534,15 @@ and persisting the index.
 
 #### `ELASTICKV_FSM_SYNC_MODE=nosync` mode
 
-When `raftApplyWriteOpts()` returns `pebble.NoSync` (configured at
-`lsm_store.go:1094-1104`), the data + meta key still land in the same
-Pebble WAL record, but the OS may delay the fsync.  Durability shifts
-to the raft layer: the raft WAL is the canonical source of truth, and
-on crash recovery raft replays entries from the last fsync'd Pebble
-position forward.  The invariant still holds because:
+The mode applies to TWO distinct write categories with different
+durability boundaries:
+
+**(a) Per-entry data Apply batches**.  `raftApplyWriteOpts()` returns
+`pebble.NoSync` so the data + meta key land in the same Pebble WAL
+record but the OS may delay the fsync.  Durability shifts to the raft
+layer: the raft WAL is the canonical source of truth, and on crash
+recovery raft replays entries from the last fsync'd Pebble position
+forward.  The invariant still holds because:
 
 - Pebble's atomic batch property is independent of the sync option.
 - On recovery, Pebble's WAL replay reconstructs the most recent
@@ -518,6 +555,35 @@ The skip gate stays correct: a `nosync`-induced loss merely means
 `LastAppliedIndex` reports a lower value than the post-restart applied
 count would imply, which only causes us to over-restore
 conservatively.
+
+**(b) Snapshot-persist checkpoint** (round-7 fix for codex round-6 P2
+on `:660`).  `pebbleStore.SetDurableAppliedIndex` uses `pebble.Sync`
+**unconditionally**, regardless of `ELASTICKV_FSM_SYNC_MODE`.  The
+reason is that the WAL compaction following `SaveSnap` discards every
+log entry at or before `snap.Metadata.Index`, so there is no source to
+replay the meta key bump from.  If the checkpoint honoured nosync, a
+crash sequence of:
+
+1. `SetDurableAppliedIndex(X)` returns (Pebble WAL written but not
+   fsynced).
+2. `e.persist.SaveSnap(snap)` returns durably (etcd's snapshotter
+   fsyncs internally).
+3. Crash before the OS flushes the Pebble WAL.
+
+would leave the snapshot pointer at `X` durable but `metaAppliedIndex`
+rolled back to `Y < X` (the last data Apply index that *was*
+fsynced).  After restart, WAL replay starts at `X` (post-compaction),
+so the compacted HLC leases / data entries cannot rebuild
+`metaAppliedIndex`, and `fsmAlreadyAtIndex(X)` returns false forever.
+The skip permanently falls back — exactly the codex round-3 P2
+scenario, recurring permanently rather than just for the trailing
+window.
+
+By forcing `pebble.Sync` on `SetDurableAppliedIndex` we make the
+checkpoint at least as durable as the snapshot pointer that follows.
+Cost: +1 extra fsync per snapshot persist (rare; default
+`SnapshotCount=10000`).  Negligible vs. the savings, and the only
+way to keep the round-4 ordering proof intact under nosync mode.
 
 #### Encryption opcodes (`OpRegistration`/`OpBootstrap`/`OpRotation`)
 
@@ -635,8 +701,9 @@ type AppliedIndexWriter interface {
 ```
 
 `kvFSM` implements it by forwarding to a new `pebbleStore` method
-that runs a single-key `pebble.Batch` write with the same Sync mode
-as the raft-apply path (`s.raftApplyWriteOpts()`):
+that runs a single-key `pebble.Batch` write with `pebble.Sync`
+**unconditionally** (round-7 fix for codex round-6 P2 on nosync
+durability):
 
 ```go
 // kv/fsm.go
@@ -657,9 +724,29 @@ func (s *pebbleStore) SetDurableAppliedIndex(idx uint64) error {
     if err := setPebbleUint64InBatch(b, metaAppliedIndexBytes, idx); err != nil {
         return errors.WithStack(err)
     }
-    return errors.WithStack(b.Commit(s.raftApplyWriteOpts()))
+    // pebble.Sync regardless of ELASTICKV_FSM_SYNC_MODE. The whole point
+    // of this checkpoint is to be at least as durable as the raft
+    // snapshot pointer that immediately follows via SaveSnap. If we
+    // honoured ELASTICKV_FSM_SYNC_MODE=nosync here, a crash after
+    // SaveSnap (which fsyncs internally) but before Pebble's deferred
+    // flush would leave metaAppliedIndex behind the snapshot pointer;
+    // because WAL compaction starts at the snapshot index, no future
+    // replay can re-bump metaAppliedIndex from the lost lease/data
+    // applies, and the skip permanently falls back. The +1 extra fsync
+    // per snapshot persist (rare; default SnapshotCount=10000) is the
+    // right price.
+    return errors.WithStack(b.Commit(pebble.Sync))
 }
 ```
+
+**Why not `raftApplyWriteOpts()`**.  That helper returns `pebble.Sync`
+in default mode and `pebble.NoSync` under
+`ELASTICKV_FSM_SYNC_MODE=nosync`.  For per-entry data Apply batches the
+nosync mode is acceptable because the durability boundary is the raft
+WAL (raft replays unsync'd applies on restart).  For the snapshot
+checkpoint, the durability boundary IS the meta key — there is no raft
+log entry to replay it from after WAL compaction.  See the dedicated
+nosync analysis in §6.
 
 **Crash ordering**.  The bump runs before `SaveSnap`, which means the
 invariant is:
@@ -776,8 +863,8 @@ restoreSnapshotState skipped (FSM at index %d, snapshot at %d, ceiling=%d, cutov
 | Branch | Content | Behaviour change |
 |---|---|---|
 | **B1** (this PR) | Design doc | None |
-| **B2** | `ApplyMutationsRaftAt` / `DeletePrefixAtRaftAt` overloads + meta-key bundling in both leaves + `pebbleStore.LastAppliedIndex()` + `pebbleStore.SetDurableAppliedIndex()` (both with `dbMu.RLock()`) + `kvFSM.AppliedIndexReader()` accessor + `kvFSM.SetDurableAppliedIndex` forwarding + thread `f.pendingApplyIdx` into the data-Apply leaves + BOTH `persistCreatedSnapshot` (`engine.go:2679`) AND `e.persistLocalSnapshotPayload` (`engine.go:4032`, the SnapshotCount-triggered hot path) call `SetDurableAppliedIndex` BEFORE the corresponding `persist.SaveSnap` | Meta key starts being written on every data Apply AND at every snapshot persist (both config-snapshot and steady-state local-snapshot paths). Skip is still disabled. Soak in production for one release. |
-| **B3** | `restoreSnapshotState` skip gate + `applyHeaderStateOnSkip(snapPath, tok.CRC32C)` mirroring the three-step verification of `openAndRestoreFSMSnapshot` (size + footer-vs-tokenCRC + full-body-CRC) + `SnapshotHeaderApplier.ApplySnapshotHeaderFromFile(snapPath, tokenCRC)` on `kvFSM` + metrics + INFO log | **User-visible cold-start win.** |
+| **B2** | `ApplyMutationsRaftAt` / `DeletePrefixAtRaftAt` overloads + meta-key bundling in both leaves + `pebbleStore.LastAppliedIndex()` (under `dbMu.RLock()`) + `pebbleStore.SetDurableAppliedIndex()` (under `dbMu.RLock()`, **`pebble.Sync` unconditionally**) + `kvFSM.AppliedIndexReader()` accessor + `kvFSM.SetDurableAppliedIndex` forwarding + thread `f.pendingApplyIdx` into the data-Apply leaves + BOTH `persistCreatedSnapshot` (`engine.go:2679`) AND `e.persistLocalSnapshotPayload` (`engine.go:4032`, the SnapshotCount-triggered hot path) call `SetDurableAppliedIndex` BEFORE the corresponding `persist.SaveSnap` | Meta key starts being written on every data Apply AND at every snapshot persist (both config-snapshot and steady-state local-snapshot paths). Skip is still disabled. Soak in production for one release. |
+| **B3** | `restoreSnapshotState` skip gate + `applyHeaderStateOnSkip(snapPath, tok.CRC32C)` orchestrating size + footer-vs-tokenCRC + full-body-CRC verification using `internal/raftengine/etcd`'s existing helpers (matching `openAndRestoreFSMSnapshot`'s safety contract) + two-phase `SnapshotHeaderApplier` seam on `kvFSM` (`ParseSnapshotHeader(r io.Reader) (ceiling, cutover, err)` + pure `ApplySnapshotHeader(ceiling, cutover)`) + metrics + INFO log | **User-visible cold-start win.** |
 | **B4** | Lower `HEALTH_TIMEOUT_SECONDS` default once production data shows steady-state skip rate ≥ 90 % | Tighter ceiling; the env override remains honoured. |
 
 Each of B2–B3 ships behind tests:
@@ -1029,3 +1116,61 @@ cycles) but lost sight of the CRC verification it was implicitly
 inheriting from `openAndRestoreFSMSnapshot`.  Reading the existing
 restore path end-to-end before pseudocoding a replacement would have
 surfaced this.
+
+## Round-6 retraction (codex round-6 P2 × 2)
+
+Round 6 introduced two implementability / durability bugs that codex
+caught in the round-6 review:
+
+**P2 line 410 — seam not implementable as drafted.**  Round 6 placed
+the whole CRC verification in `kvFSM.ApplySnapshotHeaderFromFile`,
+which references `fsmMinFileSize`, `readFSMFooter`, `crc32cTable`,
+`fsmRestoreReadAhead`, `statFSMFileError`, `ErrFSMSnapshotTokenCRC`,
+`ErrFSMSnapshotFileCRC` — all unexported in
+`internal/raftengine/etcd/fsm_snapshot_file.go`.  Production code does
+not have an `internal/raftengine/etcd → kv` or `kv →
+internal/raftengine/etcd` edge today (both directions are test-only on
+`origin/main`), so the round-6 pseudocode would either fail to compile
+or force a layering change.
+
+Round 7 splits `SnapshotHeaderApplier` into two methods:
+`ParseSnapshotHeader(r io.Reader) (ceiling, cutover, err)` and the
+pure-assignment `ApplySnapshotHeader(ceiling, cutover)`.  The CRC
+verification orchestration stays in `internal/raftengine/etcd/wal_store.go`
+where the helpers already live; the engine wraps the file in a crc32
+TeeReader and hands the reader to `setter.ParseSnapshotHeader`, which
+calls the still-in-`kv`-package `ReadSnapshotHeader(*bufio.Reader)`
+and drains.  No package imports change; no helpers need to be
+exported.
+
+**P2 line 660 — `SetDurableAppliedIndex` honoured nosync mode.**
+Round 4 / round 5 / round 6 all wrote the checkpoint with
+`s.raftApplyWriteOpts()`, which returns `pebble.NoSync` under
+`ELASTICKV_FSM_SYNC_MODE=nosync`.  Codex pointed out the resulting
+crash sequence: `SetDurableAppliedIndex(X)` returns (Pebble WAL
+buffered) → `SaveSnap` fsyncs the snapshot pointer at `X` → crash
+before Pebble flush.  On restart `metaAppliedIndex = Y < X` (the last
+fsynced data Apply), `snapshot pointer = X`, WAL compaction starts at
+`X` so the lost lease/data applies cannot rebuild
+`metaAppliedIndex`, and `fsmAlreadyAtIndex(X)` returns false forever
+— the round-3 P2 scenario recurring **permanently** rather than just
+for the trailing window.
+
+Round 7 pins `pebbleStore.SetDurableAppliedIndex` to `pebble.Sync`
+unconditionally.  The checkpoint must be at least as durable as the
+snapshot pointer that immediately follows; there is no raft log entry
+to replay it from after WAL compaction.  Cost: +1 extra fsync per
+snapshot persist (rare, default `SnapshotCount=10000`).
+
+Lesson:
+- (P2 line 410) **Before pseudocoding cross-package helper use,
+  inventory each symbol's export status** — symbols that look obvious
+  from inside a package are often private when crossed.  Restructure
+  the seam (split into parse + apply phases) rather than reach for
+  exports as the first move.
+- (P2 line 660) **A durability boundary that depends on a sync-mode
+  knob must be examined separately for each write category.**  The
+  raft-WAL-as-source-of-truth argument applies only to per-entry
+  applies, never to writes that establish a checkpoint other code
+  paths fsync past.  When a write is the *only* durable carrier of a
+  fact, force `pebble.Sync` independent of operator mode.

--- a/docs/design/2026_06_02_idempotent_snapshot_restore.md
+++ b/docs/design/2026_06_02_idempotent_snapshot_restore.md
@@ -1,0 +1,331 @@
+# Idempotent FSM Snapshot Restore on Cold Start
+
+**Status**: Proposal
+**Date**: 2026-06-02
+**Author**: bootjp
+**Related**: PR #909 (`HEALTH_TIMEOUT_SECONDS` 60s → 300s)
+
+## Problem
+
+`loadWalState` (`internal/raftengine/etcd/wal_store.go:117`) unconditionally calls
+`restoreSnapshotState(fsm, snapshot, fsmSnapDir)` (`:246`) whenever the WAL's
+persisted snapshot pointer is non-empty.  For the EKV/token-format snapshot
+case this dispatches to:
+
+```go
+return openAndRestoreFSMSnapshot(fsm, fsmSnapPath(fsmSnapDir, tok.Index), tok.CRC32C)
+```
+
+`openAndRestoreFSMSnapshot` invokes `fsm.Restore(reader)` which, on the
+`pebbleStore` backend, lands in `restorePebbleNativeAtomic`
+(`store/lsm_store.go:1816`).  That routine:
+
+1. Creates a sibling temp directory (`pebble-native-*`).
+2. Opens a fresh `pebble.DB` at the temp path (`Found 0 WALs` log line).
+3. `restoreBatchLoopInto` writes every key from the snapshot reader.
+4. `swapInTempDB` (`:2002`) calls `db.Close()` → `os.RemoveAll(s.dir)`
+   → `os.Rename(tmpDir, s.dir)` → `pebble.Open(s.dir, ...)`.
+
+For multi-GiB FSMs this is O(snapshot size) on the I/O path.  On a 5-node
+192.168.0.x cluster with a ~5 M-key node we measured **~46 s** between
+the first `pebble.Open(fsm.db)` log line and the post-swap re-open.
+After the swap the engine still has to:
+
+- replay WAL entries between the snapshot index and the latest committed
+  index (currently ~4 k entries → sub-second), and
+- become a raft follower, then bind the gRPC listener.
+
+The cumulative cold-start budget routinely exceeded the 60-second
+`HEALTH_TIMEOUT_SECONDS` (PR #909 raises it to 300 s as a band-aid).
+Beyond the wall-clock pain, the timeout creates **second-order
+instability**: docker's restart policy re-investigates a non-responsive
+container, the remaining quorum runs elections against a phantom voter,
+and the raft term inflates linearly with restart attempts (we observed
+term 665 on a cluster that should have seen single-digit-per-day
+elections).
+
+The restore is **mostly redundant**.  Each successful `fsm.Apply` already
+persists its mutation durably (via Pebble's WriteBatch).  After the FSM
+applied entry `Y > snapshot.Metadata.Index = X`, the on-disk fsm.db
+contains state `≥ X`.  On the next cold start we tear down that state
+and rebuild it from the older snapshot — only to have raft replay the
+same entries we already had on disk.
+
+## Goal
+
+Skip `restoreSnapshotState` when the on-disk FSM is already at least as
+fresh as the persisted snapshot pointer (`stored.LastAppliedIndex ≥
+snapshot.Metadata.Index`).  In the steady-state restart, restore becomes
+a no-op and cold start collapses to:
+
+1. `pebble.Open(fsm.db)` — already paid (Pebble's own WAL replay).
+2. WAL replay of `(LastAppliedIndex, committed]` — small.
+3. Raft follower-ization + gRPC bind.
+
+Expected cold-start: **<5 s for any FSM size** in the steady-state case.
+Restore still fires correctly when (a) the FSM truly is stale (e.g.
+post-disaster recovery from someone else's snapshot), or (b)
+`LastAppliedIndex` is missing / corrupt.
+
+## Non-Goals
+
+- We are **not** changing the snapshot-install hot path
+  (`Engine.applySnapshot`, `engine.go:1641`).  That path runs at
+  runtime when a leader ships us a snapshot we genuinely don't have —
+  the FSM is stale by construction there and `Restore` must run.
+- We are **not** changing the legacy non-token snapshot path
+  (`fsm.Restore(bytes.NewReader(snapshot.Data))` at `wal_store.go:258`).
+  Those payloads are only encountered during the one-shot hashicorp →
+  etcd migration; the cost is paid once and the legacy branch is on a
+  removal trajectory.
+
+## Design
+
+### 1. Persist `LastAppliedIndex` atomically with each Apply
+
+The smallest correct primitive is to bundle the raft-applied-index into
+the same `pebble.Batch` that the FSM uses for its data mutation.  Pebble
+batches are atomic, so the index and the data move together — never
+torn.
+
+#### Interface change
+
+```go
+// internal/raftengine/statemachine.go
+type StateMachine interface {
+    Apply(index uint64, data []byte) any  // was: Apply(data []byte) any
+    Snapshot() (Snapshot, error)
+    Restore(r io.Reader) error
+}
+```
+
+The single producer (`Engine.applyNormalEntry`, `engine.go:1769`)
+becomes:
+
+```go
+return e.fsm.Apply(entry.Index, payload)
+```
+
+All in-tree implementations and tests inherit the new signature.
+Inventoried sites (8 in `internal/raftengine/`, 1 in `kv/fsm.go`, plus
+the `raftenginetest/conformance.go` shim, plus a handful of unit-test
+fakes).  The change is mechanical; reviewers can audit by grepping for
+`Apply(data []byte)` after the rebase.
+
+#### kvFSM commits index + mutation in one batch
+
+```go
+// kv/fsm.go
+func (f *kvFSM) Apply(index uint64, data []byte) any {
+    if len(data) > 0 && data[0] == raftEncodeHLCLease {
+        return f.applyHLCLease(index, data[1:])
+    }
+    ctx := context.TODO()
+    reqs, err := decodeRaftRequests(data)
+    if err != nil { return errors.WithStack(err) }
+    return f.applyAtIndex(ctx, index, reqs)
+}
+```
+
+`applyAtIndex` threads `index` through `applyRequest` /
+`applyRequestErr`; the leaf MVCC mutation acquires the `pebble.Batch`,
+adds `key=metaAppliedIndex, value=binary.BigEndian.PutUint64(index)`,
+and commits.  The cost is +16 bytes per batch and zero extra fsync
+calls (the batch was already going to commit).
+
+#### pebbleStore exposes the index
+
+```go
+// store/lsm_store.go (new method)
+func (s *pebbleStore) LastAppliedIndex() (uint64, bool, error) {
+    val, closer, err := s.db.Get(metaAppliedIndexKey)
+    if errors.Is(err, pebble.ErrNotFound) {
+        return 0, false, nil
+    }
+    if err != nil { return 0, false, errors.WithStack(err) }
+    defer closer.Close()
+    if len(val) != 8 {
+        return 0, false, errors.Newf("corrupt applied-index meta key: %d bytes", len(val))
+    }
+    return binary.BigEndian.Uint64(val), true, nil
+}
+```
+
+A narrow `AppliedIndexReader` interface lets `restoreSnapshotState`
+inspect any store that implements it, without coupling the wal_store
+package to `*pebbleStore`:
+
+```go
+// internal/raftengine/statemachine.go (or sibling)
+type AppliedIndexReader interface {
+    LastAppliedIndex() (uint64, bool, error)
+}
+```
+
+### 2. Conditional restore
+
+```go
+// internal/raftengine/etcd/wal_store.go
+func restoreSnapshotState(fsm StateMachine, snapshot raftpb.Snapshot, fsmSnapDir string) error {
+    if etcdraft.IsEmptySnap(snapshot) || len(snapshot.Data) == 0 || fsm == nil {
+        return nil
+    }
+    if isSnapshotToken(snapshot.Data) {
+        tok, err := decodeSnapshotToken(snapshot.Data)
+        if err != nil { return err }
+        if skip, err := fsmAlreadyAtIndex(fsm, tok.Index); err != nil {
+            return err
+        } else if skip {
+            // FSM data on disk is at least as fresh as the snapshot.
+            // Raft will replay [tok.Index+1, committed] from the WAL
+            // and bring us to the latest committed index without
+            // touching the LSM's bulk state.
+            return nil
+        }
+        return openAndRestoreFSMSnapshot(fsm, fsmSnapPath(fsmSnapDir, tok.Index), tok.CRC32C)
+    }
+    // Legacy non-token path: unchanged.
+    return errors.WithStack(fsm.Restore(bytes.NewReader(snapshot.Data)))
+}
+
+func fsmAlreadyAtIndex(fsm StateMachine, want uint64) (bool, error) {
+    r, ok := fsm.(AppliedIndexReader)
+    if !ok {
+        return false, nil // FSM cannot self-report; restore conservatively.
+    }
+    have, present, err := r.LastAppliedIndex()
+    if err != nil { return false, err }
+    if !present { return false, nil }
+    return have >= want, nil
+}
+```
+
+The fall-back behaviour when the FSM does not implement
+`AppliedIndexReader` or has no meta-key is **the current restore**, so
+the change is strictly additive.  The first cold start after deployment
+populates the meta key on every Apply going forward; from the second
+restart onward the skip path kicks in.
+
+### 3. Crash-safety argument
+
+We claim: `LastAppliedIndex = N` durably implies "every mutation
+produced by `fsm.Apply` for indices `[snapshotIndex+1 .. N]` is durably
+present in fsm.db."
+
+Proof: the meta key is written **in the same Pebble batch** as the data
+mutation for index N.  Pebble commits batches atomically.  Either both
+land or neither does.  After commit, both are durable per the batch's
+`pebble.Sync` option.  No crash window exists between persisting the
+mutation and persisting the index.
+
+Suppose a crash mid-Apply.  Pebble's WAL replay either:
+- restores the batch (data + index both present), or
+- discards the torn batch (data + index both absent).
+
+Either way the invariant holds; on the second startup the meta-key is
+either exactly the index of the last committed Apply, or strictly less.
+`LastAppliedIndex ≥ snapshot.Metadata.Index` correctly implies the FSM
+is at least as fresh as the snapshot.
+
+The converse risk — "skip restore when we shouldn't" — would require
+the meta key to read **a value larger than the last durable Apply**.
+Since the only writer is `fsm.Apply` and it always batches index with
+data, that's impossible barring physical corruption (in which case the
+8-byte length check rejects the read and we restore conservatively).
+
+### 4. Idempotency of replay after skip
+
+After we skip restore, raft replays entries `[snapshotIndex+1, committed]`.
+Some of those entries may have already been applied (if a previous
+restart reached `applied=K > snapshotIndex` before crashing).  We do
+**not** suppress replay of already-applied entries — `fsm.Apply` is
+required to be idempotent for snapshot recovery in any raft FSM, and
+the current kvFSM upholds that (every mutation is keyed by its raft
+metadata; re-applying the same entry produces the same Pebble write).
+The meta-key gets overwritten with the same value.  No correctness
+gap; the cost is the same replay we'd pay after a full restore.
+
+### 5. Compatibility & rollback
+
+- The interface change `Apply(data) → Apply(index, data)` is breaking
+  for **external** state machines that embed `raftengine.StateMachine`.
+  No such consumers exist in-tree.  External consumers (none known)
+  would notice immediately at compile time.
+- The meta key is new; older fsm.db files don't have it.  The
+  `present == false` branch makes the first restart after upgrade
+  fall back to the current (full restore) behaviour, populating the
+  meta key from the next Apply onward.
+- Rollback: revert the wal_store.go change to remove the skip branch.
+  The meta key remains in fsm.db (harmless dead data) and gets
+  overwritten by future Applies.  No data migration required either
+  direction.
+
+### 6. Observability
+
+Two metrics + one log line:
+
+```go
+// monitoring/metrics.go
+fsm_cold_start_restore_total{outcome="executed|skipped|fallback"}
+fsm_cold_start_applied_index_gap // snapshot.Index - lastAppliedIndex when restore is executed
+```
+
+Log line at INFO when skipping:
+
+```
+restoreSnapshotState skipped (FSM already at index N >= snapshot index X)
+```
+
+These let us verify the skip rate in production and catch regressions
+where Apply stops bundling the index.
+
+## Implementation Plan
+
+1. **Branch 1 (this design)** — PR-2-design, lands docs only.
+2. **Branch 2 (interface change)** — modify `StateMachine.Apply`
+   signature across all callers + the conformance shim.  No behaviour
+   change; index is accepted and discarded.  Pure mechanical PR with
+   ~200-line diff, easy review.
+3. **Branch 3 (meta key + batch bundling)** — `kvFSM.Apply` threads
+   `index` to leaf mutation; `pebbleStore` defines the meta key and
+   exposes `LastAppliedIndex()`; unit tests cover round-trip + torn
+   batch.  Activates the data side; the skip is **not yet wired**.
+4. **Branch 4 (wal_store.go skip)** — adds the `fsmAlreadyAtIndex` gate
+   to `restoreSnapshotState`, with the metrics and the log line.  This
+   is the user-visible perf win.
+5. **Branch 5 (cleanup)** — once branch 4 has soaked in production
+   for a release, consider lowering `HEALTH_TIMEOUT_SECONDS` back
+   toward a tighter ceiling.
+
+Branches 2–4 each ship behind tests that prove the corresponding
+invariant.  Branch 4 specifically asserts:
+
+- Skip happens when `stored ≥ snapshot.Metadata.Index`.
+- Restore runs when `stored < snapshot.Metadata.Index`.
+- Restore runs when the meta key is missing.
+- Restore runs when `LastAppliedIndex()` returns an error.
+
+## Open Questions
+
+- **Multi-group**: each shard's pebbleStore has its own meta key.  No
+  shared state; this design is per-shard naturally.  Sanity-check during
+  branch 3.
+- **HLC lease entries**: `kvFSM.applyHLCLease` advances `f.hlc` but does
+  not currently touch the store.  We must still bump the meta key on
+  lease applies (a degenerate batch with just the meta key, or — better
+  — fold the lease index into the next data Apply).  Decision deferred
+  to branch 3; the in-memory HLC state is reconstructed at startup from
+  the lease entries replayed by raft, so this is purely about getting
+  the index counter monotonic.
+- **HashiCorp backend** (if it ever returns): the raft library exposes
+  `log.Index` to `(raft.FSM).Apply(log *raft.Log)`, so the interface
+  change is satisfiable on that side too.
+
+## Out of Scope (future)
+
+- Compressing/streaming the FSM snapshot file so the restore-execute
+  path itself is faster.  Orthogonal; helps cases where we genuinely
+  need to restore.
+- Switching `restorePebbleNativeAtomic` to in-place ingest (e.g.
+  Pebble's `Ingest`).  Risky and unrelated to the skip-when-safe
+  optimisation this proposal targets.

--- a/docs/design/2026_06_02_idempotent_snapshot_restore.md
+++ b/docs/design/2026_06_02_idempotent_snapshot_restore.md
@@ -1,7 +1,7 @@
 # Idempotent FSM Snapshot Restore on Cold Start
 
-**Status**: Proposal (Round 2 — revised after PR #910 feedback)
-**Date**: 2026-06-02 (round 1), 2026-06-03 (round 2 revision)
+**Status**: Proposal (Round 3 — corrected after round-2 self-error)
+**Date**: 2026-06-02 (round 1), 2026-06-03 (round 2 + round 3)
 **Author**: bootjp
 **Related**: PR #909 (`HEALTH_TIMEOUT_SECONDS` 60s → 300s)
 
@@ -62,28 +62,32 @@ a no-op and cold start collapses to:
 Expected cold-start: **<5 s for any FSM size** in the steady-state case.
 Restore still fires correctly when (a) the FSM truly is stale (e.g.
 post-disaster recovery from someone else's snapshot), (b)
-`LastAppliedIndex` is missing / corrupt, or (c) the HLC physical
-ceiling embedded in the snapshot file is newer than what the FSM has
-in memory (see §HLC).
+`LastAppliedIndex` is missing / corrupt, or (c) the snapshot header
+contains state (HLC ceiling, Stage 8a cutover) that the skip path
+cannot supply (see §5).
 
 ## Non-Goals
 
-- We are **not** changing the snapshot-install hot path
+- Not changing the snapshot-install hot path
   (`Engine.applySnapshot`, `engine.go:1641`).  That path runs at
   runtime when a leader ships us a snapshot we genuinely don't have —
   the FSM is stale by construction there and `Restore` must run.
-- We are **not** changing the legacy non-token snapshot path
+- Not changing the legacy non-token snapshot path
   (`fsm.Restore(bytes.NewReader(snapshot.Data))` at `wal_store.go:258`).
   Those payloads are only encountered during the one-shot hashicorp →
   etcd migration; the cost is paid once and the legacy branch is on a
   removal trajectory.
+- Not designing for Stage 6/7/8 encryption opcodes we haven't shipped
+  yet beyond the existing `applyReservedOpcode` dispatch
+  (`raftEncodeHLCLease`=0x02 + `OpRegistration`=0x03 + `OpBootstrap`=0x04 +
+  `OpRotation`=0x05).
 
 ## Design
 
-### 1. Plumb `entry.Index` to `kvFSM.Apply` via a new `ApplyIndexAware` seam
+### 1. Reuse the existing `ApplyIndexAware` seam
 
-The current `StateMachine` interface (`internal/raftengine/statemachine.go:14`)
-does not carry the raft index:
+The current `StateMachine` interface
+(`internal/raftengine/statemachine.go:14`) keeps its public shape:
 
 ```go
 type StateMachine interface {
@@ -93,131 +97,66 @@ type StateMachine interface {
 }
 ```
 
-**Round-1 mistake**: the round-1 design proposed breaking this signature
-to `Apply(index uint64, data []byte)`.  That works but rebinds every
-StateMachine implementation in tree.
-
-**Round-2 design**: introduce a **new** opt-in interface alongside it
-(no breaking change to `StateMachine.Apply`):
+The repo already has the seam that delivers `entry.Index` to the FSM
+without a breaking signature change — `ApplyIndexAware`
+(`statemachine.go:46`):
 
 ```go
-// internal/raftengine/statemachine.go (new — does not exist today)
-//
-// ApplyIndexAware is an opt-in seam that delivers the raft applied-index
-// to the FSM without changing StateMachine.Apply's signature. The engine
-// calls SetApplyIndex on the same goroutine, immediately before Apply,
-// so the FSM can read it back from a field stashed during SetApplyIndex.
-//
-// FSMs that do not implement this interface continue to work as before;
-// their cold start will pay the full restoreSnapshotState cost because
-// they cannot self-report LastAppliedIndex().
 type ApplyIndexAware interface {
     SetApplyIndex(idx uint64)
 }
 ```
 
-`engine.applyNormalEntry` (`engine.go:1769`) calls it before `Apply`:
+`engine.applyNormalEntry` (`engine.go:2292-2293`) already calls it
+before every `Apply`:
 
 ```go
-func (e *Engine) applyNormalEntry(entry raftpb.Entry) any {
-    if len(entry.Data) == 0 { return nil }
-    _, payload, ok := decodeProposalEnvelope(entry.Data)
-    if !ok { return nil }
-    if aware, ok := e.fsm.(ApplyIndexAware); ok {
-        aware.SetApplyIndex(entry.Index)
-    }
-    return e.fsm.Apply(payload)
+if aware, ok := e.fsm.(raftengine.ApplyIndexAware); ok {
+    aware.SetApplyIndex(entry.Index)
 }
+return e.fsm.Apply(payload), nil
 ```
 
-Single-writer invariant: the engine's raft run loop is the only caller
-of `applyNormalEntry` and the only caller of `setApplied` (`engine.go:1764`).
-SetApplyIndex / Apply pair is observed by no other goroutine; no
-synchronisation between them is required.
+And `kvFSM` already implements it (`kv/fsm.go:122`) — `SetApplyIndex`
+stashes the index in `f.pendingApplyIdx` (`kv/fsm.go:53`), which is
+currently consumed only by `applyEncryption` for the encryption
+sidecar's `RaftAppliedIndex` field.
 
-**Compatibility audit** — concrete `StateMachine` implementations in
-this repository (count: **6**, verified by `grep 'func.*Apply(data \[\]byte) any'`):
+**The Branch-2 work** is therefore narrow: extend the **already-set**
+`f.pendingApplyIdx` to also be threaded through the data-Apply path so
+the leaf MVCC mutation can persist it as a Pebble meta key — the
+mechanism `applyEncryption` uses for the sidecar's index, applied to
+the kvFSM's data store.  **No new interface, no new SetApplyIndex
+plumbing, no engine.go change.**
 
-| File | Symbol | Action in Branch 2 |
-|---|---|---|
-| `kv/fsm.go:60` | `(*kvFSM).Apply` | Add `SetApplyIndex(idx)` storing into `f.pendingApplyIdx`. Read it inside `Apply`. |
-| `internal/raftengine/raftenginetest/conformance.go:27` | `(*TestStateMachine).Apply` | No change unless test wants to assert index. |
-| `internal/raftengine/etcd/engine_test.go:33` | `testStateMachine` | No change. |
-| `internal/raftengine/etcd/engine_test.go:139` | `blockingSnapshotStateMachine` | No change. |
-| `internal/raftengine/etcd/engine_test.go:170` | `countingSnapshotStateMachine` | No change. |
-| `internal/raftengine/etcd/fsm_snapshot_file_test.go:124` | `dummyFSM` | No change. |
+Round-1 / round-2 of this doc proposed (or pivoted to) other shapes
+here; both were corrections of the wrong baseline.  Round-3 uses
+what `origin/main` actually has.
 
-(Round-1 doc claimed "8 in `internal/raftengine/`" — that was wrong;
-the actual count is 5 non-`kvFSM` impls.  Corrected.)
+### 2. Thread `f.pendingApplyIdx` into the data-Apply leaves
 
-Only `kvFSM` needs to implement `ApplyIndexAware`; the rest stay on the
-non-aware path.  Cold-start skip is enabled only when both the FSM
-implements `ApplyIndexAware` **and** the store implements
-`AppliedIndexReader`.
-
-### 2. `kvFSM` bundles the index in the SAME pebble.Batch as the mutation
-
-`kvFSM.Apply` doesn't directly touch Pebble — it dispatches through
-`f.store.ApplyMutationsRaft(...)`, `f.store.DeletePrefixAtRaft(...)`,
-etc., which build their own `pebble.Batch` inside `pebbleStore`.  To
-land the index in the same batch as the mutation, we plumb it from
-`kvFSM.Apply` down to the leaf `applyMutationsWithOpts` /
-`deletePrefixAtWithOpts` helpers (both already bundle
-`metaLastCommitTSBytes` — the precedent for batched meta keys lives at
-`lsm_store.go:1162` and `:1231`).
+`kvFSM.Apply` already begins with the reserved-opcode dispatch
+(`applyReservedOpcode` at `kv/fsm.go` returns `(any, bool)`):
 
 ```go
-// kv/fsm.go — round-2: keep the StateMachine.Apply signature
-type kvFSM struct {
-    store           store.MVCCStore
-    log             *slog.Logger
-    hlc             *HLC
-    pendingApplyIdx uint64    // set by SetApplyIndex immediately before Apply
-}
-
-func (f *kvFSM) SetApplyIndex(idx uint64) {
-    f.pendingApplyIdx = idx
-}
-
 func (f *kvFSM) Apply(data []byte) any {
-    idx := f.pendingApplyIdx
-    // CRITICAL: leave dispatch (HLC-lease vs request) UNCHANGED. We only
-    // pass `idx` down to the leaf MVCC mutation. The original opcode
-    // discrimination (`data[0] == raftEncodeHLCLease`) at kv/fsm.go:63
-    // and the existing decodeRaftRequests / applyRequest sequence
-    // continue verbatim. Only the leaf store call gains an index
-    // parameter, which is bundled atomically with the data write.
-    // ... existing dispatch ...
+    if resp, handled := f.applyReservedOpcode(data); handled {
+        return resp
+    }
+    // ... data-Apply path ...
 }
 ```
 
-The store interface gains an index-carrying overload, so the raft-apply
-path can carry it down without breaking direct-write paths:
+This path stays unchanged.  Inside `applyRequest` / `applyRequestErr`,
+the leaf store calls (`ApplyMutationsRaft`, `DeletePrefixAtRaft`) pick
+up a new optional `appliedIndex uint64` parameter that defaults to 0
+(direct-write paths) and is non-zero for raft-apply paths.
 
-```go
-// store/store.go (new method on MVCCStore)
-ApplyMutationsRaftAt(
-    ctx context.Context,
-    muts []*KVPairMutation,
-    readKeys [][]byte,
-    startTS, commitTS uint64,
-    appliedIndex uint64,
-) error
-
-DeletePrefixAtRaftAt(
-    ctx context.Context,
-    prefix, excludePrefix []byte,
-    commitTS uint64,
-    appliedIndex uint64,
-) error
-```
-
-(The existing `ApplyMutationsRaft` / `DeletePrefixAtRaft` become thin
-wrappers that pass `appliedIndex=0` — the leaf helper treats `0` as
-"don't write the meta key", preserving direct-write semantics for
-callers outside the raft apply loop.)
-
-Implementation in the leaf:
+The leaf helpers `applyMutationsWithOpts` (`lsm_store.go:1130`) and
+`deletePrefixAtWithOpts` (`lsm_store.go:1196`) bundle a new
+`metaAppliedIndexBytes` key in the same `pebble.Batch` they already use
+for `metaLastCommitTSBytes` (`lsm_store.go:1162` and `:1231`
+respectively):
 
 ```go
 // store/lsm_store.go — applyMutationsWithOpts (existing, around :1162)
@@ -226,7 +165,6 @@ if appliedIndex > 0 {
         return errors.WithStack(err)
     }
 }
-// ... existing metaLastCommitTSBytes write at :1162 stays as-is ...
 
 // store/lsm_store.go — deletePrefixAtWithOpts (existing, around :1231)
 if appliedIndex > 0 {
@@ -234,17 +172,24 @@ if appliedIndex > 0 {
         return errors.WithStack(err)
     }
 }
-// ... existing metaLastCommitTSBytes write at :1231 stays as-is ...
 ```
 
-**Why both leaves**: `handleDelPrefix` → `DeletePrefixAtRaft` builds an
-independent `pebble.Batch` via `deletePrefixAtWithOpts` (round-1 doc
-missed this).  Threading the index ONLY through `applyMutationsWithOpts`
-would let DEL_PREFIX entries land in fsm.db without bumping
-`metaAppliedIndex`, which would silently leave the meta key behind the
-true applied index — and on the next cold start, `LastAppliedIndex`
-would underestimate, triggering a conservative full restore.  Cost: +16
-bytes per batch, zero additional fsync.
+**Why both leaves**: `handleDelPrefix` builds an independent `pebble.Batch`
+through `deletePrefixAtWithOpts`, separate from `applyMutationsWithOpts`.
+Threading the index only through one would let DEL_PREFIX entries land
+without bumping the meta key, leaving `LastAppliedIndex` behind the
+true applied count.  Cost: +16 bytes per batch, zero additional fsync.
+
+The Encryption opcodes (`OpRegistration`/`OpBootstrap`/`OpRotation`,
+fsmwire 0x03..0x05) reach `applyEncryption(f.pendingApplyIdx, op, payload)`
+in `kv/fsm.go`'s `applyReservedOpcode`.  That path already takes
+`pendingApplyIdx` and persists it in the encryption sidecar's
+`RaftAppliedIndex` field via `WriteSidecar`.  It does **not** mutate
+the kvFSM data store, so it does **not** advance `metaAppliedIndex`.
+That's accepted: a run of encryption-only entries between two
+snapshots produces a `LastAppliedIndex` below the snapshot index, the
+skip gate falls back to full restore — safe.  (See §6 for the
+analogous HLC-lease case.)
 
 ### 3. Read-back exposes the index (with `dbMu.RLock()`)
 
@@ -276,41 +221,35 @@ func (s *pebbleStore) LastAppliedIndex() (uint64, bool, error) {
 }
 ```
 
-`metaAppliedIndexBytes` is a new well-known prefix sibling to
-`metaLastCommitTSBytes` (which is defined at `lsm_store.go:145` as
-`[]byte("_meta_last_commit_ts")`).  Recommended value:
-`[]byte("_meta_applied_index")` — outside the MVCC user-key space and
-disjoint from every existing meta key (verified by reading
-`isReservedMetaKey` at `lsm_store.go:454`, which currently only checks
-`metaLastCommitTSBytes` and `metaMinRetainedTSBytes`).  Branch 3 extends
-`isReservedMetaKey` to include the new key.
+`metaAppliedIndexBytes` is `[]byte("_meta_applied_index")` — sibling to
+`metaLastCommitTSBytes` (`lsm_store.go:145`), outside the MVCC user-key
+space, disjoint from every existing meta key.  Branch 2 extends
+`isReservedMetaKey` (`lsm_store.go:454`) to include it.
 
-A narrow consumer interface lets `restoreSnapshotState` inspect the
-store without coupling the etcd raft engine to `*pebbleStore`:
+The reader interface lets `restoreSnapshotState` inspect the store
+without coupling the etcd raft engine to `*pebbleStore`:
 
 ```go
-// internal/raftengine/statemachine.go (new)
+// internal/raftengine/statemachine.go (new alongside ApplyIndexAware)
 type AppliedIndexReader interface {
     LastAppliedIndex() (uint64, bool, error)
 }
 ```
 
-**Reaching the store from inside `restoreSnapshotState`**: `kvFSM` holds
-its store via `f.store`, but `kvFSM` itself does not satisfy
-`AppliedIndexReader`.  The cleanest seam is to add a typed accessor on
-`kvFSM` (`func (f *kvFSM) AppliedIndexReader() AppliedIndexReader { return f.store }`)
-which `restoreSnapshotState` calls when the FSM implements a tiny
-companion interface:
+`kvFSM` exposes its store through a typed accessor so wal_store.go can
+reach it without importing the concrete pebble type:
 
 ```go
 type AppliedIndexReporter interface {
     AppliedIndexReader() AppliedIndexReader
 }
+func (f *kvFSM) AppliedIndexReader() AppliedIndexReader {
+    if r, ok := f.store.(AppliedIndexReader); ok {
+        return r
+    }
+    return nil
+}
 ```
-
-This keeps the public `StateMachine` interface untouched and avoids
-fattening `kvFSM` with a forwarding method.  FSMs that don't expose the
-reporter fall back to the current full-restore behaviour.
 
 ### 4. Conditional restore (with conservative error fallback)
 
@@ -324,10 +263,10 @@ func restoreSnapshotState(fsm StateMachine, snapshot raftpb.Snapshot, fsmSnapDir
         tok, err := decodeSnapshotToken(snapshot.Data)
         if err != nil { return err }
         if fsmAlreadyAtIndex(fsm, tok.Index) {
-            // The body restore is skipped, but we MUST still read the
-            // HLC ceiling header from the snapshot file so the FSM's
-            // in-memory HLC starts at the right floor (see §HLC).
-            return applyHLCCeilingFromSnapshot(fsm, fsmSnapPath(fsmSnapDir, tok.Index))
+            // The body restore is skipped, but we MUST still consume
+            // the v1/v2 snapshot header so the FSM picks up the HLC
+            // ceiling AND the Stage 8a cutover (see §5).
+            return applyHeaderStateOnSkip(fsm, fsmSnapPath(fsmSnapDir, tok.Index))
         }
         return openAndRestoreFSMSnapshot(fsm, fsmSnapPath(fsmSnapDir, tok.Index), tok.CRC32C)
     }
@@ -336,11 +275,11 @@ func restoreSnapshotState(fsm StateMachine, snapshot raftpb.Snapshot, fsmSnapDir
 }
 
 // fsmAlreadyAtIndex returns true ONLY when we can prove the FSM is
-// already at or past `want`. Any uncertainty -- FSM doesn't expose the
-// reporter, store doesn't expose the reader, read error, or missing
-// meta key -- returns false so we fall back to the full restore. The
-// idea is that a stale-but-incorrect skip is far worse than a wasteful
-// full restore, so we err strictly toward restoring.
+// already at or past `want`. Any uncertainty -- FSM doesn't expose
+// the reporter, store doesn't expose the reader, read error, or
+// missing meta key -- returns false so we fall back to the full
+// restore. A stale-but-incorrect skip is far worse than a wasteful
+// full restore; the fallback errs strictly toward restoring.
 func fsmAlreadyAtIndex(fsm StateMachine, want uint64) bool {
     reporter, ok := fsm.(AppliedIndexReporter)
     if !ok { return false }
@@ -352,98 +291,100 @@ func fsmAlreadyAtIndex(fsm StateMachine, want uint64) bool {
 }
 ```
 
-**Round-1 mistake (fixed)**: the round-1 pseudocode propagated
-`LastAppliedIndex()` errors upward, which would fail node startup on a
-corrupt meta key.  Round-2 fallback policy: any error / missing /
-uncertainty maps to `false` (run full restore).  This honours the
-"strictly additive" guarantee — adoption can never make startup worse
-than the current behaviour, only better.
+### 5. Header state preservation when skipping (P1)
 
-### 5. HLC ceiling preservation when skipping (P1 from review)
-
-`kvFSM.Restore` (`kv/fsm.go:264`) is currently the only place that reads
-the HLC physical-ceiling header from the snapshot file and applies it
-to the in-memory `f.hlc`:
+`kvFSM.Restore` (`kv/fsm.go`) parses the snapshot header via
+`kv.ReadSnapshotHeader(*bufio.Reader)` and applies **two** pieces of
+state:
 
 ```go
-// kv/fsm.go:278-286 (existing)
-if bytes.Equal(hdr[:8], hlcSnapshotMagic[:]) {
-    ceilingMs := int64(binary.BigEndian.Uint64(hdr[8:]))
-    if f.hlc != nil && ceilingMs > 0 {
-        f.hlc.SetPhysicalCeiling(ceilingMs)
-    }
-    return errors.WithStack(f.store.Restore(io.NopCloser(r)))
+// kv/fsm.go -- existing Restore
+ceilingU, cutover, err := ReadSnapshotHeader(br)
+if err != nil { return errors.WithStack(err) }
+if f.hlc != nil && ceilingU > 0 {
+    f.hlc.SetPhysicalCeiling(int64(ceilingU))
 }
+f.restoredCutover = cutover
+return errors.WithStack(f.store.Restore(io.NopCloser(br)))
 ```
 
-If we skip `Restore` we also skip this assignment.  After skip:
+`ReadSnapshotHeader` handles three live cases:
 
-- `f.hlc.physicalCeiling` stays at whatever the in-memory HLC was
-  initialised to (typically wall-clock-now, no snapshot floor).
-- Subsequent HLC lease entries in the WAL still bump the ceiling when
-  replayed by raft, BUT the lease entries are **between the snapshot
-  index and the latest committed index** — those whose ceiling was
-  baked into the snapshot itself (lease entries whose index ≤
-  `snapshot.Metadata.Index`) are compacted away from the WAL and never
-  replayed.
-- Net effect: if the snapshot was taken at ceiling C and no fresh
-  lease has bumped past C since, this node could mint timestamps
-  below C after becoming leader.
+- v1 magic (`EKVTHLC1`): 16-byte header, ceiling only.
+- v2 magic (`EKVTHLC2`): variable-length header (≥ 26 bytes), ceiling +
+  cutover + forward-compat trailing bytes.
+- Unknown `EKVTHLC*`: fails closed with `ErrSnapshotHeaderUnknownMagic`
+  (Stage 8a §3.2 step 4 — operator must upgrade).
+- Headerless legacy / short stream: returns `(0, 0, nil)`, no state to
+  apply.
 
-This violates the HLC monotonicity invariant cluster-wide.  **The skip
-path MUST set the HLC ceiling from the snapshot header even when the
-body restore is skipped.**
+If we skip `Restore` we lose **both** the HLC ceiling assignment and
+the `f.restoredCutover` write.  After skip:
 
-Mechanism — a new helper that reads the first 16 bytes of the snapshot
-file and dispatches:
+- `f.hlc.physicalCeiling` stays at the engine's wall-clock-now seed —
+  not the snapshotted floor.  Subsequent HLC lease entries replayed
+  from the WAL bump it, but lease entries whose index ≤
+  `snapshot.Metadata.Index` are compacted out of the WAL and not
+  replayed, so the in-memory ceiling can finish below the snapshotted
+  ceiling.  On the leader-election that follows, this node can mint
+  HLC timestamps below the snapshotted floor — a cluster-wide
+  monotonicity violation.
+- `f.restoredCutover` stays at zero, which Stage 6E's apply-hook reads
+  as "no envelope cutover seen", so the next data entry the FSM
+  applies would be treated as below-cutover regardless of its index.
+  In a Stage-8a cluster this silently disables the encryption
+  cutover gate for one entry.
+
+**The skip path MUST consume the snapshot header and apply the same
+two side-effects as `kvFSM.Restore` does.**  Reuse the existing
+parser, do not invent a v1-only probe:
 
 ```go
 // internal/raftengine/etcd/wal_store.go (new)
-func applyHLCCeilingFromSnapshot(fsm StateMachine, snapPath string) error {
-    setter, ok := fsm.(HLCCeilingSetter)
-    if !ok { return nil } // FSM doesn't carry HLC; nothing to set.
+func applyHeaderStateOnSkip(fsm StateMachine, snapPath string) error {
+    setter, ok := fsm.(SnapshotHeaderApplier)
+    if !ok {
+        return nil // FSM has no header state; skip is harmless.
+    }
     f, err := os.Open(snapPath)
     if err != nil { return errors.WithStack(err) }
     defer f.Close()
-    var hdr [hlcSnapshotHeaderLen]byte
-    n, err := io.ReadFull(f, hdr[:])
+    br := bufio.NewReader(f)
+    ceiling, cutover, err := kv.ReadSnapshotHeader(br)
     if err != nil {
-        // The snapshot file is too short for an HLC header. Predates
-        // the magic/ceiling format -- nothing to apply, fall through.
-        if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
-            return nil
-        }
+        // Includes ErrSnapshotHeaderUnknownMagic / InvalidLength.
+        // Fail closed -- the operator must upgrade rather than have
+        // us silently skip a forward-incompatible header.
         return errors.WithStack(err)
     }
-    _ = n
-    if !bytes.Equal(hdr[:8], hlcSnapshotMagic[:]) {
-        return nil // old format, no ceiling.
-    }
-    ceilingMs := int64(binary.BigEndian.Uint64(hdr[8:]))
-    if ceilingMs > 0 {
-        setter.SetHLCPhysicalCeiling(ceilingMs)
-    }
+    setter.ApplySnapshotHeader(ceiling, cutover)
     return nil
 }
 
 // kv/fsm.go gains:
-type HLCCeilingSetter interface {
-    SetHLCPhysicalCeiling(ms int64)
+type SnapshotHeaderApplier interface {
+    ApplySnapshotHeader(ceiling, cutover uint64)
 }
-func (f *kvFSM) SetHLCPhysicalCeiling(ms int64) {
-    if f.hlc != nil { f.hlc.SetPhysicalCeiling(ms) }
+
+func (f *kvFSM) ApplySnapshotHeader(ceiling, cutover uint64) {
+    if f.hlc != nil && ceiling > 0 {
+        f.hlc.SetPhysicalCeiling(int64(ceiling))
+    }
+    f.restoredCutover = cutover
 }
 ```
 
-Cost: a 16-byte read from the snapshot file (single syscall, no
-deserialisation).  Negligible compared to the 46 s body restore we
-elide.
+By reusing `kv.ReadSnapshotHeader` the skip path inherits v1 + v2
+parity, the `ErrSnapshotHeaderUnknownMagic` fail-closed branch, and
+any future v3 the snapshot header gains.  Cost: a single
+`bufio.NewReader(f)` + ~26-byte read.  We do **not** consume any of
+the inner-store payload — `f` is closed before returning.
 
-### 6. Crash-safety argument (revised)
+### 6. Crash-safety argument
 
 We claim: `LastAppliedIndex = N` durably implies "every raft apply for
-indices `[snapshotIndex+1 .. N]` that produced a `pebbleStore` mutation
-is durably present in fsm.db."
+indices `[snapshotIndex+1 .. N]` that produced a `pebbleStore`
+mutation is durably present in fsm.db."
 
 #### Default mode (`pebble.Sync`)
 
@@ -464,41 +405,42 @@ position forward.  The invariant still holds because:
 
 - Pebble's atomic batch property is independent of the sync option.
 - On recovery, Pebble's WAL replay reconstructs the most recent
-  committed batch (or none of it), giving us either `(data + meta)` at
-  index N or `(neither)`.
+  committed batch (or none of it), giving us either `(data + meta)`
+  at index N or `(neither)`.
 - raft will then replay any entries that the OS-buffered fsync lost,
   and each Apply re-bundles its own index.
 
-The skip gate therefore stays correct: a `nosync`-induced loss merely
-means `LastAppliedIndex` reports a lower value than the post-restart
-applied count would imply, which only causes us to over-restore
+The skip gate stays correct: a `nosync`-induced loss merely means
+`LastAppliedIndex` reports a lower value than the post-restart applied
+count would imply, which only causes us to over-restore
 conservatively.
 
-#### DEL_PREFIX path
+#### Encryption opcodes (`OpRegistration`/`OpBootstrap`/`OpRotation`)
 
-`DeletePrefixAtRaft` → `deletePrefixAtWithOpts` builds its own batch
-(`lsm_store.go:1196`) and bundles `metaLastCommitTSBytes`
-(`lsm_store.go:1231`).  Branch 3 extends that bundling to also include
-`metaAppliedIndex`.  Without this, DEL_PREFIX entries land without
-bumping the meta key and `LastAppliedIndex` drifts behind the true
-applied count (still safe — over-restoring conservatively — but
-defeats the optimisation for any workload that uses DEL_PREFIX).
+These opcodes reach `applyEncryption(f.pendingApplyIdx, op, payload)`,
+which mutates the encryption sidecar (`WriteSidecar`), not the
+kvFSM data store.  `metaAppliedIndex` therefore does NOT advance for
+these entries.  Consequence: in a Stage 6/7/8 maintenance window where
+the only entries between two snapshots are encryption ops,
+`LastAppliedIndex` stays below the snapshot index and the skip falls
+back to full restore.  Safe; rare.
 
-#### HLC lease entries (Open Question 1 — committed to Option 2)
+(The sidecar separately carries its own `RaftAppliedIndex` for §9.1
+`ErrSidecarBehindRaftLog`; that mechanism is orthogonal to this
+proposal.)
 
-`f.applyHLCLease` (kv/fsm.go around `:63`) is currently an in-memory
-mutation only; it does not touch `f.store`.  We accept that
-`LastAppliedIndex` does NOT advance for these entries.  Consequence:
-in a workload where the only entries between two snapshots are lease
-ticks, the skip gate will fall back to full restore — which is safe
-and rare.
+#### HLC lease entries (Open Question 1 — Option 2)
 
-Adding a synthetic pebble batch per lease tick (Option 1) would cost
-~1 extra pebble batch per second per group (lease cadence is 1 s),
-which is undesirable.  Option 2 (do nothing extra) is correct and
-cheaper; the trade-off is the rare false-positive restore.
+`f.applyHLCLease` is an in-memory mutation only; it does not touch
+`f.store`.  We accept that `metaAppliedIndex` does NOT advance for
+HLC lease entries.  Consequence: in a workload where the only entries
+between two snapshots are lease ticks, the skip gate will fall back
+to full restore — safe and rare.  Adding a synthetic pebble batch per
+lease tick would cost ~1 extra pebble batch per second per group;
+trading the rare false-positive restore for that ongoing cost is the
+wrong call.
 
-### 7. Idempotency of replay after skip (revised — OCC two-case)
+### 7. Idempotency of replay after skip (OCC two-case)
 
 After we skip restore, raft replays entries `[snapshotIndex+1, committed]`.
 Some of those entries may already be present in fsm.db (if a previous
@@ -527,30 +469,31 @@ End state is observationally identical to "produced the same write."
 Other request types are individually safe by similar reasoning:
 `handleCommitRequest` short-circuits via
 `applyCommitWithIdempotencyFallback`; `handleAbortRequest` is safe via
-`shouldClearAbortKey` (no-op if the lock is already gone);
-`handlePrepareRequest` collapses through the OCC write-conflict path
-when intents from prior applies are still present.
+`shouldClearAbortKey`; `handlePrepareRequest` collapses through the
+OCC write-conflict path when intents from prior applies are still
+present.
 
 ### 8. Compatibility & rollback
 
-- `StateMachine.Apply`'s public signature is **unchanged**.  External
-  state machines (none known) continue to work.
-- The new opt-in interfaces (`ApplyIndexAware`, `AppliedIndexReader`,
-  `AppliedIndexReporter`, `HLCCeilingSetter`) are additive.  FSMs that
-  don't implement them fall back to the current behaviour.
-- The `metaAppliedIndex` key is new; older fsm.db files don't have
-  it.  The `present=false` branch makes the first restart after upgrade
+- `StateMachine.Apply`'s public signature is **unchanged**.
+- `ApplyIndexAware` is **already** in `main`; this design only adds
+  consumers.
+- The new opt-in interfaces (`AppliedIndexReader`,
+  `AppliedIndexReporter`, `SnapshotHeaderApplier`) are additive.
+  FSMs that don't implement them fall back to the current behaviour.
+- `metaAppliedIndexBytes` is new.  Older fsm.db files don't have it.
+  The `present=false` branch makes the first restart after upgrade
   fall back to full restore, populating the meta key from the next
-  Apply onward.
-- Rollback: revert the wal_store.go skip branch.  The meta key remains
-  in fsm.db (harmless dead data) and gets overwritten by future
-  Applies.  No data migration in either direction.
+  data Apply onward.
+- Rollback: revert the wal_store.go skip branch.  The meta key
+  remains in fsm.db (harmless dead data) and gets overwritten by
+  future Applies.  No data migration in either direction.
 
 ### 9. Observability
 
 Two metrics + one log line:
 
-```
+```text
 fsm_cold_start_restore_total{outcome="executed|skipped|fallback"}
 fsm_cold_start_applied_index_gap{outcome="executed|skipped"}
 ```
@@ -559,13 +502,25 @@ The gap label gets emitted in both directions so we can confirm the
 **skip path actually closes the gap** (positive values when skipped
 mean `LastAppliedIndex - snapshot.Index ≥ 0`) AND confirm restore
 sizes when executed (`snapshot.Index - LastAppliedIndex > 0`).
-Asymmetric emission would hide regressions where the skip succeeds but
-the meta key is drifting behind.
+Asymmetric emission would hide regressions where the skip succeeds
+but the meta key is drifting behind.
+
+A `fallback_reason` label on the `outcome=fallback` counter surfaces
+why we conservatively restored even though the FSM was potentially
+recent enough:
+
+```text
+fsm_cold_start_restore_total{outcome="fallback", fallback_reason="not_reporter|no_reader|read_err|missing_meta|behind_snapshot"}
+```
+
+`fallback_reason="behind_snapshot"` is the expected outcome for the
+HLC-lease-only and encryption-only windows discussed in §6 — a
+non-zero count there is healthy, not a regression.
 
 Log line at INFO when skipping:
 
-```
-restoreSnapshotState skipped (FSM at index %d, snapshot at %d, HLC ceiling applied from header)
+```text
+restoreSnapshotState skipped (FSM at index %d, snapshot at %d, ceiling=%d, cutover=%d)
 ```
 
 ## Implementation Plan
@@ -573,92 +528,90 @@ restoreSnapshotState skipped (FSM at index %d, snapshot at %d, HLC ceiling appli
 | Branch | Content | Behaviour change |
 |---|---|---|
 | **B1** (this PR) | Design doc | None |
-| **B2** | New `ApplyIndexAware` interface + `kvFSM.SetApplyIndex` + engine.go call site | None (engine starts feeding index; FSM stashes it; nothing reads it yet) |
-| **B3** | Thread `appliedIndex` through `ApplyMutationsRaftAt` / `DeletePrefixAtRaftAt` + bundle meta key in both leaves + `pebbleStore.LastAppliedIndex()` with `dbMu.RLock()` + `kvFSM.AppliedIndexReader()` accessor | Meta key starts being written; skip is still disabled. Soak in production for one release. |
-| **B4** | `restoreSnapshotState` skip gate + `applyHLCCeilingFromSnapshot` + `kvFSM.SetHLCPhysicalCeiling` + metrics + INFO log | **User-visible cold-start win.** |
-| **B5** | Lower `HEALTH_TIMEOUT_SECONDS` default once production data shows steady-state skip rate ≥ 90 % | Tighter ceiling, but tracker the env override still honoured |
+| **B2** | `ApplyMutationsRaftAt` / `DeletePrefixAtRaftAt` overloads + meta-key bundling in both leaves + `pebbleStore.LastAppliedIndex()` with `dbMu.RLock()` + `kvFSM.AppliedIndexReader()` accessor + thread `f.pendingApplyIdx` into the data-Apply leaves | Meta key starts being written; skip is still disabled. Soak in production for one release. |
+| **B3** | `restoreSnapshotState` skip gate + `applyHeaderStateOnSkip` reusing `kv.ReadSnapshotHeader` + `SnapshotHeaderApplier` seam on `kvFSM` + metrics + INFO log | **User-visible cold-start win.** |
+| **B4** | Lower `HEALTH_TIMEOUT_SECONDS` default once production data shows steady-state skip rate ≥ 90 % | Tighter ceiling; the env override remains honoured. |
 
-Each of B2–B4 ships behind tests:
+Each of B2–B3 ships behind tests:
 
-- **B2**: `engine_test.go` asserts that a recorder FSM observes
-  `SetApplyIndex(entry.Index)` immediately before `Apply(data)` for
-  every Apply.
-- **B3**: pebble-level tests round-trip the meta key in
+- **B2**: pebble-level tests round-trip the meta key in
   `applyMutationsWithOpts` AND `deletePrefixAtWithOpts`; torn-batch
   test simulates pebble WAL replay across the meta key boundary.
-- **B4**: integration test seeds a fsm.db with `LastAppliedIndex = K`,
-  pairs it with a snapshot at index `K-N` (N varies), asserts skip is
-  taken for `N ≤ 0` and restore for `N > 0`.  Separate test asserts
-  that `applyHLCCeilingFromSnapshot` sets `f.hlc.PhysicalCeiling()`
-  for both skip and restore paths (i.e., the ceiling is invariant
-  under the optimisation).
-
-## Errata against Round-1 reviewer feedback
-
-For honesty about the review process: round 1 received feedback from
-`gemini-code-assist[bot]` and `claude[bot]` that referenced
-codebase entities that **do not exist in this repository**.  Verified
-by `grep -r ... --include='*.go' .` over `main` HEAD at SHA
-`94579fc0`.
-
-| Cited entity | Grep matches | Reviewer claim | Reality |
-|---|---|---|---|
-| `ApplyIndexAware` | 0 | "already in production" (gemini), "engine.go:2292" (claude) | Does not exist. Engine.go:2292 is `failPending`. |
-| `SetApplyIndex` | 0 | "already implemented on kvFSM" | Does not exist on `kvFSM`. |
-| `pendingApplyIdx` | 0 | "already holds entry.Index" | Field does not exist. |
-| `applyReservedOpcode` | 0 | "dispatches HLC lease + encryption opcodes 0x03..0x07" | Function does not exist. |
-| `applyEncryption` | 0 | "goes via WriteSidecar" | Function does not exist. |
-| `WriteSidecar` | 0 | (same as above) | Method does not exist. |
-| Encryption opcodes `0x03..0x07` | 0 | "Stage 6/7/8 encryption dispatch" | Only `raftEncodeSingle=0x00`, `raftEncodeBatch=0x01`, `raftEncodeHLCLease=0x02` exist (`kv/fsm.go:110-116`). |
-
-This design therefore proceeds with **Branch 2 in place** (we have to
-create the `ApplyIndexAware` seam; we cannot reuse one that doesn't
-exist).  The reviewers' reasoning about "avoid a breaking
-`StateMachine.Apply` signature change" was sound regardless of the
-factual error — we adopt it by creating the seam they hallucinated as
-existing.  Encryption-opcode dispatch is not addressed because the
-opcodes do not exist in main today; once Stages 6/7/8 land, the
-opcode dispatch will need to plumb `appliedIndex` through whatever
-path it takes (a follow-up problem, not a round-2 problem).
-
-The **substantively correct** findings from round-1 reviews — all
-incorporated:
-
-- 🔴 codex P1 on `:319`: HLC ceiling preservation when skipping
-  body restore (`kv/fsm.go:264-286` does read the header).  **Real
-  bug**, fixed in §5.
-- 🟠 gemini medium on `:152`: `LastAppliedIndex()` needs
-  `s.dbMu.RLock()` per `lsm_store.go:153 / :162 / :553 / :675` lock
-  ordering.  **Real**, fixed in §3.
-- 🟠 claude §3 caveat 1: `ELASTICKV_FSM_SYNC_MODE=nosync`
-  (`lsm_store.go:86`) shifts durability boundary.  **Real**, fixed
-  in §6.
-- 🟠 claude §3 caveat 2: `deletePrefixAtWithOpts` (`lsm_store.go:1196`)
-  builds an independent batch and already bundles
-  `metaLastCommitTSBytes` (`:1231`).  **Real**, fixed in §2.
-- 🟠 claude §3 error handling: `fsmAlreadyAtIndex` propagating errors
-  would fail cold start on a corrupt meta key.  **Sound design
-  improvement**, fixed in §4.
-- 🟢 claude §4 OCC two-case argument and call-site count (6 not 8).
-  **Real**, fixed in §7 and §1's table.
+  A `kvFSM` unit test asserts that `SetApplyIndex(K)` immediately
+  before a data `Apply` produces `LastAppliedIndex() == K`.
+- **B3**: integration test seeds a fsm.db with `LastAppliedIndex = K`
+  and pairs it with a snapshot at index `K-N` (N varies), asserting
+  skip is taken for `N ≤ 0` and restore for `N > 0`.  A separate
+  test asserts that `applyHeaderStateOnSkip` sets
+  `f.hlc.PhysicalCeiling()` **and** `f.restoredCutover` for both v1
+  and v2 snapshot headers — the ceiling+cutover are invariant under
+  the optimisation.
 
 ## Open Questions
 
 - **Multi-group**: each shard's `pebbleStore` has its own meta key.
-  No shared state; this design is per-shard naturally.  Branch 3 will
+  No shared state; this design is per-shard naturally.  B2 will
   verify with an integration test on a 4-group cluster.
-- **HashiCorp backend** (if it ever returns): the raft library exposes
-  `log.Index` to `(raft.FSM).Apply(log *raft.Log)`, so the
+- **HashiCorp backend** (if it ever returns): the raft library
+  exposes `log.Index` to `(raft.FSM).Apply(log *raft.Log)`, so the
   `ApplyIndexAware` seam is satisfiable on that side too.
+- **Future v3 snapshot header**: reusing `kv.ReadSnapshotHeader` means
+  the skip path inherits the parser's forward-compat behaviour
+  automatically.  If a new version adds a side-effect (e.g. a
+  cluster-membership token), `SnapshotHeaderApplier` needs an
+  additional method; the §3.2 read-path doc updates first, then this
+  proposal extends.
 
 ## Out of Scope (future)
 
-- Compressing/streaming the FSM snapshot file so the restore-execute
-  path itself is faster.  Orthogonal; helps cases where we genuinely
-  need to restore.
+- Compressing/streaming the FSM snapshot file so the
+  restore-execute path itself is faster.  Orthogonal; helps cases
+  where we genuinely need to restore.
 - Switching `restorePebbleNativeAtomic` to in-place ingest (e.g.
-  Pebble's `Ingest`).  Risky and unrelated to the skip-when-safe
-  optimisation this proposal targets.
-- Plumbing `appliedIndex` through future encryption-opcode dispatch
-  (Stages 6/7/8) — once those opcodes exist on `main`, they will need
-  the same treatment as DEL_PREFIX.
+  Pebble's `Ingest`).  Risky and unrelated.
+
+## Round-2 retraction
+
+Round 2 of this doc claimed that `ApplyIndexAware`, `SetApplyIndex`,
+`pendingApplyIdx`, `applyReservedOpcode`, `applyEncryption`,
+`WriteSidecar`, and the v2 snapshot header were "fabricated" by
+gemini and claude review bots — and proposed a fresh
+`ApplyIndexAware` introduction as if the seam had to be created from
+scratch.
+
+That round-2 self-audit was wrong.  My `grep` was running against my
+local working tree on `test/event-driven-leader-readiness`, which is
+27 commits behind `origin/main`.  All of the entities above DO exist
+on `origin/main`:
+
+- `ApplyIndexAware` at `internal/raftengine/statemachine.go:46`.
+- `kvFSM.SetApplyIndex` at `kv/fsm.go:122`, writing `f.pendingApplyIdx`
+  at `kv/fsm.go:53`.
+- `engine.applyNormalEntry` at `internal/raftengine/etcd/engine.go:2292-2293`
+  calling `aware.SetApplyIndex(entry.Index)`.
+- `applyReservedOpcode` at `kv/fsm.go` dispatching `raftEncodeHLCLease`
+  (0x02) and the fsmwire encryption opcodes `OpRegistration` (0x03),
+  `OpBootstrap` (0x04), `OpRotation` (0x05) — gemini's claimed
+  `0x06..0x07` are reserved-for-future per
+  `internal/encryption/fsmwire/wire.go:41`.
+- `applyEncryption(f.pendingApplyIdx, op, payload)` — already
+  consuming the index for the sidecar's `RaftAppliedIndex` via
+  `encryption.WriteSidecar`.
+- v2 snapshot header `EKVTHLC2` with ceiling + cutover and the
+  `ReadSnapshotHeader(*bufio.Reader)` parser at `kv/snapshot.go`.
+
+Round 3 rebases the whole design onto those existing seams.
+Branch 2's scope shrinks from "create new seam + plumb" to "plumb
+into the data-Apply leaves" — `ApplyIndexAware` and `pendingApplyIdx`
+are already in place; we just start consuming the index for the
+data-store meta key the way the encryption applier already consumes
+it for the sidecar.
+
+The codex P1 about v2 snapshot header state preservation (which
+round-2 mis-classified as fabricated) is the SAME class of bug as
+the round-1 HLC ceiling P1: both are real, both ride on the same
+`ReadSnapshotHeader` parser, and §5 now handles them together via
+the `SnapshotHeaderApplier` seam.
+
+Apologies to the review bots for the round-2 push-back.  Round 3
+proceeds against the actual code.

--- a/docs/design/2026_06_02_idempotent_snapshot_restore.md
+++ b/docs/design/2026_06_02_idempotent_snapshot_restore.md
@@ -889,9 +889,11 @@ Each of B2–B3 ships behind tests:
   `f.hlc.PhysicalCeiling()` **and** `f.restoredCutover` for both v1
   and v2 snapshot headers — the ceiling+cutover are invariant under
   the optimisation.  Three additional CRC-corruption tests (round-6,
-  one per failure mode) inject the corruption and assert the
-  specific typed error surfaces from `ApplySnapshotHeaderFromFile`
-  WITHOUT mutating `f.hlc` or `f.restoredCutover`:
+  one per failure mode) inject the corruption and drive the skip path
+  through `applyHeaderStateOnSkip` (either directly or via
+  `restoreSnapshotState` with `fsmAlreadyAtIndex` returning true),
+  asserting the specific typed error surfaces and that the FSM did
+  not mutate `f.hlc` or `f.restoredCutover`:
   - Truncate the `.fsm` file below `fsmMinFileSize` →
     `ErrFSMSnapshotTooSmall`.
   - Pair the file with a wrong-token CRC →

--- a/docs/design/2026_06_02_idempotent_snapshot_restore.md
+++ b/docs/design/2026_06_02_idempotent_snapshot_restore.md
@@ -1,7 +1,7 @@
 # Idempotent FSM Snapshot Restore on Cold Start
 
-**Status**: Proposal (Round 4 — codex P2 fix: snapshot-persist meta key bump)
-**Date**: 2026-06-02 (round 1), 2026-06-03 (rounds 2 / 3 / 4)
+**Status**: Proposal (Round 5 — import-cycle fix + cover the local snapshot path)
+**Date**: 2026-06-02 (round 1), 2026-06-03 (rounds 2 / 3 / 4 / 5)
 **Author**: bootjp
 **Related**: PR #909 (`HEALTH_TIMEOUT_SECONDS` 60s → 300s)
 
@@ -152,10 +152,10 @@ the leaf store calls (`ApplyMutationsRaft`, `DeletePrefixAtRaft`) pick
 up a new optional `appliedIndex uint64` parameter that defaults to 0
 (direct-write paths) and is non-zero for raft-apply paths.
 
-The leaf helpers `applyMutationsWithOpts` (`lsm_store.go:1130`) and
-`deletePrefixAtWithOpts` (`lsm_store.go:1196`) bundle a new
+The leaf helpers `applyMutationsWithOpts` (`lsm_store.go:1292`) and
+`deletePrefixAtWithOpts` (`lsm_store.go:1358`) bundle a new
 `metaAppliedIndexBytes` key in the same `pebble.Batch` they already use
-for `metaLastCommitTSBytes` (`lsm_store.go:1162` and `:1231`
+for `metaLastCommitTSBytes` (`lsm_store.go:1324` and `:1393`
 respectively):
 
 ```go
@@ -224,7 +224,7 @@ func (s *pebbleStore) LastAppliedIndex() (uint64, bool, error) {
 `metaAppliedIndexBytes` is `[]byte("_meta_applied_index")` — sibling to
 `metaLastCommitTSBytes` (`lsm_store.go:145`), outside the MVCC user-key
 space, disjoint from every existing meta key.  Branch 2 extends
-`isReservedMetaKey` (`lsm_store.go:454`) to include it.
+`isPebbleMetaKey` (`lsm_store.go:534`) to include it.
 
 The reader interface lets `restoreSnapshotState` inspect the store
 without coupling the etcd raft engine to `*pebbleStore`:
@@ -339,46 +339,63 @@ the `f.restoredCutover` write.  After skip:
 two side-effects as `kvFSM.Restore` does.**  Reuse the existing
 parser, do not invent a v1-only probe:
 
+**Import-cycle constraint (round-5 fix)**.  `internal/raftengine/etcd/`
+cannot import `kv` because `kv/snapshot.go` and `kv/fsm.go` already
+import `github.com/bootjp/elastickv/internal/raftengine`.  A direct
+call to `kv.ReadSnapshotHeader(...)` from `wal_store.go` would create
+the cycle `internal/raftengine/etcd → kv → internal/raftengine`, which
+the Go toolchain rejects.  The seam therefore pushes the file open AND
+the `ReadSnapshotHeader` call **into the FSM implementation**, so
+`wal_store.go` never names the `kv` package:
+
 ```go
-// internal/raftengine/etcd/wal_store.go (new)
+// internal/raftengine/etcd/wal_store.go (new) -- never imports kv
 func applyHeaderStateOnSkip(fsm StateMachine, snapPath string) error {
     setter, ok := fsm.(SnapshotHeaderApplier)
     if !ok {
         return nil // FSM has no header state; skip is harmless.
     }
-    f, err := os.Open(snapPath)
+    return errors.WithStack(setter.ApplySnapshotHeaderFromFile(snapPath))
+}
+
+// internal/raftengine/statemachine.go (new, sibling to ApplyIndexAware)
+type SnapshotHeaderApplier interface {
+    // ApplySnapshotHeaderFromFile opens the snapshot file at snapPath,
+    // consumes its v1/v2 header via the FSM's existing header parser,
+    // and applies the same side-effects the FSM's Restore would apply
+    // for that header (HLC ceiling, Stage 8a cutover, etc.). The
+    // implementation MUST NOT consume any post-header bytes. Returns
+    // ErrSnapshotHeaderUnknownMagic / InvalidLength for fail-closed
+    // forward-incompat handling.
+    ApplySnapshotHeaderFromFile(snapPath string) error
+}
+
+// kv/fsm.go (new method on kvFSM) -- kv.ReadSnapshotHeader stays inside kv
+func (f *kvFSM) ApplySnapshotHeaderFromFile(snapPath string) error {
+    file, err := os.Open(snapPath)
     if err != nil { return errors.WithStack(err) }
-    defer f.Close()
-    br := bufio.NewReader(f)
-    ceiling, cutover, err := kv.ReadSnapshotHeader(br)
+    defer file.Close()
+    ceiling, cutover, err := ReadSnapshotHeader(bufio.NewReader(file))
     if err != nil {
         // Includes ErrSnapshotHeaderUnknownMagic / InvalidLength.
         // Fail closed -- the operator must upgrade rather than have
         // us silently skip a forward-incompatible header.
         return errors.WithStack(err)
     }
-    setter.ApplySnapshotHeader(ceiling, cutover)
-    return nil
-}
-
-// kv/fsm.go gains:
-type SnapshotHeaderApplier interface {
-    ApplySnapshotHeader(ceiling, cutover uint64)
-}
-
-func (f *kvFSM) ApplySnapshotHeader(ceiling, cutover uint64) {
     if f.hlc != nil && ceiling > 0 {
         f.hlc.SetPhysicalCeiling(int64(ceiling))
     }
     f.restoredCutover = cutover
+    return nil
 }
 ```
 
-By reusing `kv.ReadSnapshotHeader` the skip path inherits v1 + v2
-parity, the `ErrSnapshotHeaderUnknownMagic` fail-closed branch, and
-any future v3 the snapshot header gains.  Cost: a single
-`bufio.NewReader(f)` + ~26-byte read.  We do **not** consume any of
-the inner-store payload — `f` is closed before returning.
+By keeping the `kv.ReadSnapshotHeader` call inside `kv/fsm.go` the
+skip path inherits v1 + v2 parity, the `ErrSnapshotHeaderUnknownMagic`
+fail-closed branch, and any future v3 the snapshot header gains —
+without `wal_store.go` ever naming the `kv` package.  Cost: a single
+`bufio.NewReader(file)` + ~26-byte read.  We do **not** consume any
+of the inner-store payload — `file` is closed before returning.
 
 ### 6. Crash-safety argument
 
@@ -450,9 +467,15 @@ re-installed from the snapshot.  Idle clusters degenerate to
 the skip never fires.  Round-3 was wrong; round-4 fixes it.
 
 **Mechanism**: bump `metaAppliedIndex` to `snapshot.Metadata.Index`
-when persisting a created snapshot, in `persistCreatedSnapshot`
-(`internal/raftengine/etcd/engine.go:2683`), **before**
-`e.persist.SaveSnap`:
+at every snapshot persist site, **before** the corresponding
+`persist.SaveSnap` call.  There are **two** persist sites in
+`internal/raftengine/etcd/`; round-4 only hooked one of them, which
+left the steady-state path uncovered (codex round-4 P2 at `:455`).
+Round-5 hooks both:
+
+**Site 1 — `persistCreatedSnapshot`** (`engine.go:2683`).  Drives
+**config snapshots** (created via `createConfigSnapshot` →
+`storage.CreateSnapshot`):
 
 ```go
 // internal/raftengine/etcd/engine.go (revised)
@@ -460,10 +483,6 @@ func (e *Engine) persistCreatedSnapshot(snap raftpb.Snapshot) error {
     if etcdraft.IsEmptySnap(snap) || e.persist == nil {
         return nil
     }
-    // Round-4: bump metaAppliedIndex BEFORE SaveSnap so a successful
-    // snapshot persist always implies LastAppliedIndex >= snap.Metadata.Index.
-    // Skip the bump silently when the FSM does not expose the writer
-    // seam (legacy fakes / test shims).
     if w, ok := e.fsm.(AppliedIndexWriter); ok {
         if err := w.SetDurableAppliedIndex(snap.Metadata.Index); err != nil {
             return errors.WithStack(err)
@@ -475,6 +494,49 @@ func (e *Engine) persistCreatedSnapshot(snap raftpb.Snapshot) error {
     // ... existing Release + purge ...
 }
 ```
+
+**Site 2 — `e.persistLocalSnapshotPayload`** (`engine.go:4032`).  This
+is the **steady-state `SnapshotCount`-triggered snapshot path** —
+`maybePersistLocalSnapshot` (`engine.go:2070`) → `e.persistLocalSnapshotPayload`
+(`engine.go:4032`) → the free function `persistLocalSnapshotPayload`
+(`wal_store.go:519`) → `persist.SaveSnap` at `wal_store.go:525`.  This
+is the hot path the optimisation actually depends on; without hooking
+it, the codex round-3 P2 fallback is not closed.
+
+The hook lives in the engine wrapper, **not** in the free function,
+because the wrapper holds `e.snapshotMu` and has direct access to
+`e.fsm`:
+
+```go
+// internal/raftengine/etcd/engine.go (revised)
+func (e *Engine) persistLocalSnapshotPayload(index uint64, payload []byte) error {
+    e.snapshotMu.Lock()
+    defer e.snapshotMu.Unlock()
+
+    current, err := e.storage.Snapshot()
+    if err != nil { return errors.WithStack(err) }
+    if index <= current.Metadata.Index { return nil }
+
+    // Round-5: bump metaAppliedIndex BEFORE the free-function
+    // persistLocalSnapshotPayload (which calls persist.SaveSnap at
+    // wal_store.go:525). Lives in the engine wrapper so the free
+    // function stays signature-stable and is reusable from tests
+    // that bypass the engine. Skipped silently when the FSM does
+    // not implement AppliedIndexWriter (legacy fakes / test shims).
+    if w, ok := e.fsm.(AppliedIndexWriter); ok {
+        if err := w.SetDurableAppliedIndex(index); err != nil {
+            return errors.WithStack(err)
+        }
+    }
+
+    _, err = persistLocalSnapshotPayload(e.storage, e.persist, index, payload)
+    // ... existing error switch + purge ...
+}
+```
+
+`index` here is `req.index = e.applied` at the time the snapshot
+request was queued, so it satisfies the same monotonicity property as
+`snap.Metadata.Index` in Site 1: it never moves backward.
 
 The new `AppliedIndexWriter` interface lives next to
 `AppliedIndexReader` in `internal/raftengine/statemachine.go`:
@@ -627,7 +689,7 @@ restoreSnapshotState skipped (FSM at index %d, snapshot at %d, ceiling=%d, cutov
 | Branch | Content | Behaviour change |
 |---|---|---|
 | **B1** (this PR) | Design doc | None |
-| **B2** | `ApplyMutationsRaftAt` / `DeletePrefixAtRaftAt` overloads + meta-key bundling in both leaves + `pebbleStore.LastAppliedIndex()` + `pebbleStore.SetDurableAppliedIndex()` (both with `dbMu.RLock()`) + `kvFSM.AppliedIndexReader()` accessor + `kvFSM.SetDurableAppliedIndex` forwarding + thread `f.pendingApplyIdx` into the data-Apply leaves + `persistCreatedSnapshot` calls `SetDurableAppliedIndex` BEFORE `e.persist.SaveSnap` | Meta key starts being written on every data Apply AND at every snapshot persist. Skip is still disabled. Soak in production for one release. |
+| **B2** | `ApplyMutationsRaftAt` / `DeletePrefixAtRaftAt` overloads + meta-key bundling in both leaves + `pebbleStore.LastAppliedIndex()` + `pebbleStore.SetDurableAppliedIndex()` (both with `dbMu.RLock()`) + `kvFSM.AppliedIndexReader()` accessor + `kvFSM.SetDurableAppliedIndex` forwarding + thread `f.pendingApplyIdx` into the data-Apply leaves + BOTH `persistCreatedSnapshot` (`engine.go:2683`) AND `e.persistLocalSnapshotPayload` (`engine.go:4032`, the SnapshotCount-triggered hot path) call `SetDurableAppliedIndex` BEFORE the corresponding `persist.SaveSnap` | Meta key starts being written on every data Apply AND at every snapshot persist (both config-snapshot and steady-state local-snapshot paths). Skip is still disabled. Soak in production for one release. |
 | **B3** | `restoreSnapshotState` skip gate + `applyHeaderStateOnSkip` reusing `kv.ReadSnapshotHeader` + `SnapshotHeaderApplier` seam on `kvFSM` + metrics + INFO log | **User-visible cold-start win.** |
 | **B4** | Lower `HEALTH_TIMEOUT_SECONDS` default once production data shows steady-state skip rate ≥ 90 % | Tighter ceiling; the env override remains honoured. |
 
@@ -652,10 +714,15 @@ Each of B2–B3 ships behind tests:
   test asserts that `applyHeaderStateOnSkip` sets
   `f.hlc.PhysicalCeiling()` **and** `f.restoredCutover` for both v1
   and v2 snapshot headers — the ceiling+cutover are invariant under
-  the optimisation.  An idle-cluster test runs a 3-node cluster with
-  no data writes for `2 * SnapshotCount * hlcRenewalInterval`
-  seconds, takes a snapshot, restarts a node, and asserts the skip
-  fires — proving the codex P2 scenario is closed end-to-end.
+  the optimisation.  An idle-cluster integration test runs a 3-node cluster with
+  `ELASTICKV_RAFT_SNAPSHOT_COUNT=10` (overriding the default
+  `defaultSnapshotEvery = 10000` at `engine.go:93` so the scenario is
+  tractable — at default + `hlcRenewalInterval = 1 s` an idle period
+  would need ≥ 20 000 s).  With the override, the test issues no data
+  writes for `2 × 10 × hlcRenewalInterval = 20 s`, takes a snapshot,
+  restarts a node, and asserts the skip fires — proving the codex
+  round-3 P2 scenario is closed end-to-end through the
+  `e.persistLocalSnapshotPayload` hook added in round-5.
 
 ## Open Questions
 
@@ -759,3 +826,49 @@ Lesson: "rare" should be a quantitative claim against the actual
 production timer cadence, not an intuition.  Codex's review process
 explicitly cited `kv/coordinator.go:641-663` — a file:line that I
 could have consulted before making the round-3 claim.
+
+## Round-4 retraction (claude carry-forward + codex local-snapshot bypass)
+
+Round 4 carried forward a §5 import cycle from round-3 (`wal_store.go`
+calling `kv.ReadSnapshotHeader` directly) and introduced a fresh hot-
+path bypass (the round-4 fix only hooked `persistCreatedSnapshot`,
+missing the steady-state `e.persistLocalSnapshotPayload` path that the
+optimisation actually depends on).
+
+Verified on `origin/main`:
+
+- `kv/snapshot.go` and `kv/fsm.go` both `import "github.com/bootjp/elastickv/internal/raftengine"`,
+  so `internal/raftengine/etcd/wal_store.go` cannot import `kv` —
+  the round-3 / round-4 pseudocode `kv.ReadSnapshotHeader(br)` from
+  `wal_store.go` would fail compilation with the cycle
+  `internal/raftengine/etcd → kv → internal/raftengine`.
+- `maybePersistLocalSnapshot` (`engine.go:2070`) →
+  `e.persistLocalSnapshotPayload` (`engine.go:4032`) → free
+  `persistLocalSnapshotPayload` (`wal_store.go:519`) →
+  `persist.SaveSnap` (`wal_store.go:525`) is the actual hot path for
+  `SnapshotCount`-triggered snapshots; round-4's
+  `persistCreatedSnapshot` hook only covers `createConfigSnapshot`
+  (membership-change snapshots).
+
+Round 5 fixes both:
+
+- §5 moves the file open AND `ReadSnapshotHeader` call inside the new
+  `kvFSM.ApplySnapshotHeaderFromFile(snapPath)` method, so
+  `wal_store.go` only ever sees the `SnapshotHeaderApplier` interface
+  and never names the `kv` package.  Import cycle eliminated.
+- §6 adds a second hook in `e.persistLocalSnapshotPayload`
+  (`engine.go:4032`), placed under `e.snapshotMu.Lock()` and before
+  the free-function call.  The B2 row of the Implementation Plan now
+  enumerates both hook sites explicitly.
+
+Cosmetic corrections incorporated from claude's annotation list:
+`isReservedMetaKey` → `isPebbleMetaKey` (`lsm_store.go:534`);
+`applyMutationsWithOpts` → `:1292` (meta-key bundle at `:1324`);
+`deletePrefixAtWithOpts` → `:1358` (meta-key bundle at `:1393`).
+
+Lesson: when a §X seam touches a package boundary, verify the import
+direction explicitly before pseudocoding the call site.  The fix in
+round-5 (push the file-open and the kv-package call **into** the FSM
+implementation) is structurally identical to how `ApplyIndexAware` was
+shaped to deliver `entry.Index` without importing kv — an existing
+template that round-3 / round-4 ignored.

--- a/docs/design/2026_06_02_idempotent_snapshot_restore.md
+++ b/docs/design/2026_06_02_idempotent_snapshot_restore.md
@@ -1,7 +1,7 @@
 # Idempotent FSM Snapshot Restore on Cold Start
 
-**Status**: Proposal (Round 5 — import-cycle fix + cover the local snapshot path)
-**Date**: 2026-06-02 (round 1), 2026-06-03 (rounds 2 / 3 / 4 / 5)
+**Status**: Proposal (Round 6 — thread tok.CRC32C through the skip path)
+**Date**: 2026-06-02 (round 1), 2026-06-03 (rounds 2 / 3 / 4 / 5 / 6)
 **Author**: bootjp
 **Related**: PR #909 (`HEALTH_TIMEOUT_SECONDS` 60s → 300s)
 
@@ -265,8 +265,11 @@ func restoreSnapshotState(fsm StateMachine, snapshot raftpb.Snapshot, fsmSnapDir
         if fsmAlreadyAtIndex(fsm, tok.Index) {
             // The body restore is skipped, but we MUST still consume
             // the v1/v2 snapshot header so the FSM picks up the HLC
-            // ceiling AND the Stage 8a cutover (see §5).
-            return applyHeaderStateOnSkip(fsm, fsmSnapPath(fsmSnapDir, tok.Index))
+            // ceiling AND the Stage 8a cutover (see §5).  Thread
+            // tok.CRC32C through so the skip path verifies the file
+            // before mutating FSM state, matching the existing
+            // openAndRestoreFSMSnapshot safety contract.
+            return applyHeaderStateOnSkip(fsm, fsmSnapPath(fsmSnapDir, tok.Index), tok.CRC32C)
         }
         return openAndRestoreFSMSnapshot(fsm, fsmSnapPath(fsmSnapDir, tok.Index), tok.CRC32C)
     }
@@ -348,40 +351,113 @@ the Go toolchain rejects.  The seam therefore pushes the file open AND
 the `ReadSnapshotHeader` call **into the FSM implementation**, so
 `wal_store.go` never names the `kv` package:
 
+**CRC verification constraint (round-6 fix, codex P1)**.
+`openAndRestoreFSMSnapshot` (`fsm_snapshot_file.go`) protects FSM state
+from corrupt snapshots with a three-step verification *before* calling
+`fsm.Restore`:
+
+1. `info.Size() < fsmMinFileSize` → `ErrFSMSnapshotTooSmall`.
+2. `readFSMFooter(f, info.Size())` → 4-byte CRC32C footer; compare to
+   `tokenCRC` from the WAL snapshot token → `ErrFSMSnapshotTokenCRC`
+   on mismatch (catches wrong-file / token-vs-content drift).
+3. `restoreAndComputeCRC(f, info.Size(), fsm)` reads the whole body
+   through a `crc32` `TeeReader` and compares the computed CRC to the
+   footer → `ErrFSMSnapshotFileCRC` on mismatch (catches bit rot
+   anywhere in the file).
+
+Side-effects on the FSM only run inside `restoreAndComputeCRC`'s
+`fsm.Restore` callback, so any pre-step failure cleanly aborts before
+mutating state.
+
+The round-5 `ApplySnapshotHeaderFromFile(snapPath)` shape does **none**
+of this.  A corrupt `.fsm` file or a wrong-token pairing would let the
+skip path silently install a bogus HLC ceiling / Stage 8a cutover
+(`f.hlc.SetPhysicalCeiling(int64(ceiling))`, `f.restoredCutover =
+cutover`).  Worse, a too-short / truncated file would be parsed by
+`ReadSnapshotHeader` as headerless legacy and silently apply
+`ceiling=0, cutover=0`.
+
+Round-6 mirrors the existing safety contract by threading
+`tok.CRC32C` through to the FSM and running the same three checks
+**before** applying any side-effect:
+
 ```go
 // internal/raftengine/etcd/wal_store.go (new) -- never imports kv
-func applyHeaderStateOnSkip(fsm StateMachine, snapPath string) error {
+func applyHeaderStateOnSkip(fsm StateMachine, snapPath string, tokenCRC uint32) error {
     setter, ok := fsm.(SnapshotHeaderApplier)
     if !ok {
         return nil // FSM has no header state; skip is harmless.
     }
-    return errors.WithStack(setter.ApplySnapshotHeaderFromFile(snapPath))
+    return errors.WithStack(setter.ApplySnapshotHeaderFromFile(snapPath, tokenCRC))
 }
 
 // internal/raftengine/statemachine.go (new, sibling to ApplyIndexAware)
 type SnapshotHeaderApplier interface {
     // ApplySnapshotHeaderFromFile opens the snapshot file at snapPath,
-    // consumes its v1/v2 header via the FSM's existing header parser,
-    // and applies the same side-effects the FSM's Restore would apply
-    // for that header (HLC ceiling, Stage 8a cutover, etc.). The
-    // implementation MUST NOT consume any post-header bytes. Returns
-    // ErrSnapshotHeaderUnknownMagic / InvalidLength for fail-closed
-    // forward-incompat handling.
-    ApplySnapshotHeaderFromFile(snapPath string) error
+    // verifies size + footer-vs-tokenCRC + full-body-CRC (matching
+    // openAndRestoreFSMSnapshot's safety contract), then applies the
+    // header side-effects the FSM's Restore would apply (HLC ceiling,
+    // Stage 8a cutover, etc.). Returns ErrFSMSnapshotTooSmall /
+    // ErrFSMSnapshotTokenCRC / ErrFSMSnapshotFileCRC for the
+    // corresponding verification failures, or
+    // ErrSnapshotHeaderUnknownMagic / InvalidLength for
+    // forward-incompat headers. MUST NOT mutate FSM state on any
+    // verification failure.
+    ApplySnapshotHeaderFromFile(snapPath string, tokenCRC uint32) error
 }
 
 // kv/fsm.go (new method on kvFSM) -- kv.ReadSnapshotHeader stays inside kv
-func (f *kvFSM) ApplySnapshotHeaderFromFile(snapPath string) error {
+func (f *kvFSM) ApplySnapshotHeaderFromFile(snapPath string, tokenCRC uint32) error {
     file, err := os.Open(snapPath)
-    if err != nil { return errors.WithStack(err) }
+    if err != nil { return statFSMFileError(err) }
     defer file.Close()
-    ceiling, cutover, err := ReadSnapshotHeader(bufio.NewReader(file))
-    if err != nil {
-        // Includes ErrSnapshotHeaderUnknownMagic / InvalidLength.
-        // Fail closed -- the operator must upgrade rather than have
-        // us silently skip a forward-incompatible header.
+
+    info, err := file.Stat()
+    if err != nil { return errors.WithStack(err) }
+
+    // Step 1: size check (matches openAndRestoreFSMSnapshot).
+    if info.Size() < fsmMinFileSize {
+        return errors.Wrapf(ErrFSMSnapshotTooSmall,
+            "file too small: %d bytes (minimum %d)", info.Size(), fsmMinFileSize)
+    }
+
+    // Step 2: footer vs tokenCRC (cheap; catches wrong-file / token drift).
+    footer, err := readFSMFooter(file, info.Size())
+    if err != nil { return err }
+    if footer != tokenCRC {
+        return errors.Wrapf(ErrFSMSnapshotTokenCRC,
+            "path=%s footer=%08x token=%08x", snapPath, footer, tokenCRC)
+    }
+
+    // Step 3: full-body CRC, with the header parsed inside the tee'd
+    // reader so its bytes are included in the computed CRC. We
+    // intentionally drain (Discard) the body bytes -- the body is
+    // already present in fsm.db (that's why we're skipping the
+    // restore), but the CRC must cover the whole payload for the
+    // ErrFSMSnapshotFileCRC check to mean what it does in
+    // openAndRestoreFSMSnapshot.
+    if _, err := file.Seek(0, io.SeekStart); err != nil {
         return errors.WithStack(err)
     }
+    payloadSize := info.Size() - fsmFooterSize
+    h := crc32.New(crc32cTable)
+    tee := io.TeeReader(io.LimitReader(file, payloadSize), h)
+    br := bufio.NewReaderSize(tee, fsmRestoreReadAhead)
+
+    ceiling, cutover, herr := ReadSnapshotHeader(br)
+    if herr != nil {
+        // ErrSnapshotHeaderUnknownMagic / InvalidLength: fail closed.
+        return errors.WithStack(herr)
+    }
+    if _, err := io.Copy(io.Discard, br); err != nil {
+        return errors.WithStack(err)
+    }
+    if h.Sum32() != footer {
+        return errors.Wrapf(ErrFSMSnapshotFileCRC,
+            "path=%s footer=%08x computed=%08x", snapPath, footer, h.Sum32())
+    }
+
+    // All three checks passed; apply side-effects.
     if f.hlc != nil && ceiling > 0 {
         f.hlc.SetPhysicalCeiling(int64(ceiling))
     }
@@ -390,12 +466,23 @@ func (f *kvFSM) ApplySnapshotHeaderFromFile(snapPath string) error {
 }
 ```
 
+**Cost note**.  Step 3 reads the full snapshot file once.  For multi-GiB
+FSMs this is a non-trivial I/O cost — but it is **strictly cheaper**
+than the restore path it replaces (which also reads the file once via
+`restoreAndComputeCRC` AND additionally writes a temp Pebble database
+with sstable / WAL output).  Observed restore wall-clock is dominated
+by Pebble writes, not reads; eliding the writes preserves the bulk of
+the win.  A future optimisation could persist the HLC ceiling +
+cutover durably (analogous to `metaAppliedIndex`) and elide the file
+read entirely — that's out of scope for this proposal but flagged
+under Open Questions.
+
 By keeping the `kv.ReadSnapshotHeader` call inside `kv/fsm.go` the
 skip path inherits v1 + v2 parity, the `ErrSnapshotHeaderUnknownMagic`
 fail-closed branch, and any future v3 the snapshot header gains —
-without `wal_store.go` ever naming the `kv` package.  Cost: a single
-`bufio.NewReader(file)` + ~26-byte read.  We do **not** consume any
-of the inner-store payload — `file` is closed before returning.
+without `wal_store.go` ever naming the `kv` package.  The body bytes
+are read (for the CRC pass) but discarded — `file` is closed before
+returning, and no inner-store mutation occurs.
 
 ### 6. Crash-safety argument
 
@@ -690,7 +777,7 @@ restoreSnapshotState skipped (FSM at index %d, snapshot at %d, ceiling=%d, cutov
 |---|---|---|
 | **B1** (this PR) | Design doc | None |
 | **B2** | `ApplyMutationsRaftAt` / `DeletePrefixAtRaftAt` overloads + meta-key bundling in both leaves + `pebbleStore.LastAppliedIndex()` + `pebbleStore.SetDurableAppliedIndex()` (both with `dbMu.RLock()`) + `kvFSM.AppliedIndexReader()` accessor + `kvFSM.SetDurableAppliedIndex` forwarding + thread `f.pendingApplyIdx` into the data-Apply leaves + BOTH `persistCreatedSnapshot` (`engine.go:2679`) AND `e.persistLocalSnapshotPayload` (`engine.go:4032`, the SnapshotCount-triggered hot path) call `SetDurableAppliedIndex` BEFORE the corresponding `persist.SaveSnap` | Meta key starts being written on every data Apply AND at every snapshot persist (both config-snapshot and steady-state local-snapshot paths). Skip is still disabled. Soak in production for one release. |
-| **B3** | `restoreSnapshotState` skip gate + `applyHeaderStateOnSkip` reusing `kv.ReadSnapshotHeader` + `SnapshotHeaderApplier` seam on `kvFSM` + metrics + INFO log | **User-visible cold-start win.** |
+| **B3** | `restoreSnapshotState` skip gate + `applyHeaderStateOnSkip(snapPath, tok.CRC32C)` mirroring the three-step verification of `openAndRestoreFSMSnapshot` (size + footer-vs-tokenCRC + full-body-CRC) + `SnapshotHeaderApplier.ApplySnapshotHeaderFromFile(snapPath, tokenCRC)` on `kvFSM` + metrics + INFO log | **User-visible cold-start win.** |
 | **B4** | Lower `HEALTH_TIMEOUT_SECONDS` default once production data shows steady-state skip rate ≥ 90 % | Tighter ceiling; the env override remains honoured. |
 
 Each of B2–B3 ships behind tests:
@@ -714,7 +801,20 @@ Each of B2–B3 ships behind tests:
   test asserts that `applyHeaderStateOnSkip` sets
   `f.hlc.PhysicalCeiling()` **and** `f.restoredCutover` for both v1
   and v2 snapshot headers — the ceiling+cutover are invariant under
-  the optimisation.  An idle-cluster integration test runs a 3-node cluster with
+  the optimisation.  Three additional CRC-corruption tests (round-6,
+  one per failure mode) inject the corruption and assert the
+  specific typed error surfaces from `ApplySnapshotHeaderFromFile`
+  WITHOUT mutating `f.hlc` or `f.restoredCutover`:
+  - Truncate the `.fsm` file below `fsmMinFileSize` →
+    `ErrFSMSnapshotTooSmall`.
+  - Pair the file with a wrong-token CRC →
+    `ErrFSMSnapshotTokenCRC`.
+  - Flip one body byte (post-header) →
+    `ErrFSMSnapshotFileCRC` (round-6's full-body CRC pass catches
+    this; without round-6 the skip would silently install state
+    from a corrupt file).
+
+  An idle-cluster integration test runs a 3-node cluster with
   `ELASTICKV_RAFT_SNAPSHOT_COUNT=10` (overriding the default
   `defaultSnapshotEvery = 10000` at `engine.go:93` so the scenario is
   tractable — at default + `hlcRenewalInterval = 1 s` an idle period
@@ -738,6 +838,20 @@ Each of B2–B3 ships behind tests:
   cluster-membership token), `SnapshotHeaderApplier` needs an
   additional method; the §3.2 read-path doc updates first, then this
   proposal extends.
+- **Persist HLC ceiling + cutover durably to elide the snapshot file
+  read entirely** (codex round-5 P1 follow-up).  The round-6 fix
+  reads the whole snapshot file on the skip path (~6 s for a 6 GiB
+  FSM at 1 GiB/s SSD read, versus ~46 s observed for restore).
+  Persisting `metaHLCCeiling` + `metaRestoredCutover` alongside
+  `metaAppliedIndex` would let the skip path consult the pebble
+  store directly and skip the file read entirely — collapsing
+  cold-start to single-digit ms.  Bundling the new meta keys
+  atomically requires plumbing through the same Apply paths as
+  `metaAppliedIndex` plus a write at `Restore` time and at every
+  HLC lease apply (or at every snapshot persist via the
+  round-4/5 hook sites).  Deferred because the round-6 design is
+  already correct and useful; this is a follow-up performance
+  optimisation, not a correctness fix.
 
 ## Out of Scope (future)
 
@@ -872,3 +986,46 @@ round-5 (push the file-open and the kv-package call **into** the FSM
 implementation) is structurally identical to how `ApplyIndexAware` was
 shaped to deliver `entry.Index` without importing kv — an existing
 template that round-3 / round-4 ignored.
+
+## Round-5 retraction (codex round-5 P1)
+
+Round 5 of this doc introduced the `SnapshotHeaderApplier` seam with
+the signature `ApplySnapshotHeaderFromFile(snapPath string) error` —
+no CRC verification.  Codex's round-5 review (P1) correctly pointed
+out that the existing `openAndRestoreFSMSnapshot`
+(`internal/raftengine/etcd/fsm_snapshot_file.go:262`) guards FSM state
+from corrupt snapshots with a three-step verification *before*
+calling `fsm.Restore`:
+
+1. `fsmMinFileSize` check → `ErrFSMSnapshotTooSmall`.
+2. footer-vs-`tokenCRC` → `ErrFSMSnapshotTokenCRC` on mismatch
+   (catches wrong-file / metadata corruption).
+3. full-body CRC vs footer → `ErrFSMSnapshotFileCRC` on mismatch
+   (catches bit rot anywhere in the file).
+
+The round-5 skip path bypassed all three.  A corrupt or wrong-file
+snapshot could silently install bogus HLC ceiling / Stage 8a cutover,
+or — worse — be parsed by `ReadSnapshotHeader` as headerless legacy
+and silently apply `ceiling=0, cutover=0` for a too-short file.
+
+Round 6 threads `tok.CRC32C` through `applyHeaderStateOnSkip` and
+`SnapshotHeaderApplier.ApplySnapshotHeaderFromFile`, and the §5
+pseudocode runs the same three-step verification before applying any
+side-effect.  Cost: one extra full-file read on the skip path — still
+strictly cheaper than the restore path it replaces (the same read
+happens during `restoreAndComputeCRC`, plus restore additionally
+writes a temp Pebble database via `restoreBatchLoopInto`).
+
+A follow-up optimisation that persists the HLC ceiling + cutover as
+durable meta keys (analogous to `metaAppliedIndex`) would let the
+skip path elide the file read entirely; flagged under Open Questions
+but not part of this proposal.
+
+Lesson: when a §X seam takes over a side-effect previously gated by
+existing fail-closed checks, **inventory those checks first and
+mirror them in the new path**.  Round 5 moved the `ReadSnapshotHeader`
+call into the FSM (which was the right structural fix for import
+cycles) but lost sight of the CRC verification it was implicitly
+inheriting from `openAndRestoreFSMSnapshot`.  Reading the existing
+restore path end-to-end before pseudocoding a replacement would have
+surfaced this.

--- a/docs/design/2026_06_02_idempotent_snapshot_restore.md
+++ b/docs/design/2026_06_02_idempotent_snapshot_restore.md
@@ -1,16 +1,16 @@
 # Idempotent FSM Snapshot Restore on Cold Start
 
-**Status**: Proposal
-**Date**: 2026-06-02
+**Status**: Proposal (Round 2 — revised after PR #910 feedback)
+**Date**: 2026-06-02 (round 1), 2026-06-03 (round 2 revision)
 **Author**: bootjp
 **Related**: PR #909 (`HEALTH_TIMEOUT_SECONDS` 60s → 300s)
 
 ## Problem
 
-`loadWalState` (`internal/raftengine/etcd/wal_store.go:117`) unconditionally calls
-`restoreSnapshotState(fsm, snapshot, fsmSnapDir)` (`:246`) whenever the WAL's
-persisted snapshot pointer is non-empty.  For the EKV/token-format snapshot
-case this dispatches to:
+`loadWalState` (`internal/raftengine/etcd/wal_store.go:117`) unconditionally
+calls `restoreSnapshotState(fsm, snapshot, fsmSnapDir)` (`:246`) whenever
+the WAL's persisted snapshot pointer is non-empty.  For the EKV/token-format
+snapshot case this dispatches to:
 
 ```go
 return openAndRestoreFSMSnapshot(fsm, fsmSnapPath(fsmSnapDir, tok.Index), tok.CRC32C)
@@ -27,29 +27,26 @@ return openAndRestoreFSMSnapshot(fsm, fsmSnapPath(fsmSnapDir, tok.Index), tok.CR
    → `os.Rename(tmpDir, s.dir)` → `pebble.Open(s.dir, ...)`.
 
 For multi-GiB FSMs this is O(snapshot size) on the I/O path.  On a 5-node
-192.168.0.x cluster with a ~5 M-key node we measured **~46 s** between
-the first `pebble.Open(fsm.db)` log line and the post-swap re-open.
-After the swap the engine still has to:
-
-- replay WAL entries between the snapshot index and the latest committed
-  index (currently ~4 k entries → sub-second), and
-- become a raft follower, then bind the gRPC listener.
+192.168.0.x cluster with a ~5 M-key node we measured **~46 s** between the
+first `pebble.Open(fsm.db)` log line and the post-swap re-open.  After the
+swap the engine still has to replay the entries between the snapshot
+index and the latest committed index, then become a raft follower and
+bind the gRPC listener.
 
 The cumulative cold-start budget routinely exceeded the 60-second
 `HEALTH_TIMEOUT_SECONDS` (PR #909 raises it to 300 s as a band-aid).
-Beyond the wall-clock pain, the timeout creates **second-order
-instability**: docker's restart policy re-investigates a non-responsive
-container, the remaining quorum runs elections against a phantom voter,
-and the raft term inflates linearly with restart attempts (we observed
-term 665 on a cluster that should have seen single-digit-per-day
-elections).
+The timeout also drives second-order instability — docker's restart
+policy reinvestigates the non-responsive container, the remaining quorum
+runs elections against a phantom voter, and the raft term inflates
+linearly with restart attempts (we observed term 665 on a cluster that
+should have seen single-digit-per-day elections).
 
 The restore is **mostly redundant**.  Each successful `fsm.Apply` already
-persists its mutation durably (via Pebble's WriteBatch).  After the FSM
-applied entry `Y > snapshot.Metadata.Index = X`, the on-disk fsm.db
-contains state `≥ X`.  On the next cold start we tear down that state
-and rebuild it from the older snapshot — only to have raft replay the
-same entries we already had on disk.
+persists its data mutations durably (via Pebble's WriteBatch).  After
+the FSM has applied entry `Y > snapshot.Metadata.Index = X`, the on-disk
+fsm.db contains state `≥ X`.  On the next cold start we tear that state
+down and rebuild it from the older snapshot, only to have raft replay
+the same entries we already had on disk.
 
 ## Goal
 
@@ -64,8 +61,10 @@ a no-op and cold start collapses to:
 
 Expected cold-start: **<5 s for any FSM size** in the steady-state case.
 Restore still fires correctly when (a) the FSM truly is stale (e.g.
-post-disaster recovery from someone else's snapshot), or (b)
-`LastAppliedIndex` is missing / corrupt.
+post-disaster recovery from someone else's snapshot), (b)
+`LastAppliedIndex` is missing / corrupt, or (c) the HLC physical
+ceiling embedded in the snapshot file is newer than what the FSM has
+in memory (see §HLC).
 
 ## Non-Goals
 
@@ -81,68 +80,194 @@ post-disaster recovery from someone else's snapshot), or (b)
 
 ## Design
 
-### 1. Persist `LastAppliedIndex` atomically with each Apply
+### 1. Plumb `entry.Index` to `kvFSM.Apply` via a new `ApplyIndexAware` seam
 
-The smallest correct primitive is to bundle the raft-applied-index into
-the same `pebble.Batch` that the FSM uses for its data mutation.  Pebble
-batches are atomic, so the index and the data move together — never
-torn.
-
-#### Interface change
+The current `StateMachine` interface (`internal/raftengine/statemachine.go:14`)
+does not carry the raft index:
 
 ```go
-// internal/raftengine/statemachine.go
 type StateMachine interface {
-    Apply(index uint64, data []byte) any  // was: Apply(data []byte) any
+    Apply(data []byte) any
     Snapshot() (Snapshot, error)
     Restore(r io.Reader) error
 }
 ```
 
-The single producer (`Engine.applyNormalEntry`, `engine.go:1769`)
-becomes:
+**Round-1 mistake**: the round-1 design proposed breaking this signature
+to `Apply(index uint64, data []byte)`.  That works but rebinds every
+StateMachine implementation in tree.
+
+**Round-2 design**: introduce a **new** opt-in interface alongside it
+(no breaking change to `StateMachine.Apply`):
 
 ```go
-return e.fsm.Apply(entry.Index, payload)
-```
-
-All in-tree implementations and tests inherit the new signature.
-Inventoried sites (8 in `internal/raftengine/`, 1 in `kv/fsm.go`, plus
-the `raftenginetest/conformance.go` shim, plus a handful of unit-test
-fakes).  The change is mechanical; reviewers can audit by grepping for
-`Apply(data []byte)` after the rebase.
-
-#### kvFSM commits index + mutation in one batch
-
-```go
-// kv/fsm.go
-func (f *kvFSM) Apply(index uint64, data []byte) any {
-    if len(data) > 0 && data[0] == raftEncodeHLCLease {
-        return f.applyHLCLease(index, data[1:])
-    }
-    ctx := context.TODO()
-    reqs, err := decodeRaftRequests(data)
-    if err != nil { return errors.WithStack(err) }
-    return f.applyAtIndex(ctx, index, reqs)
+// internal/raftengine/statemachine.go (new — does not exist today)
+//
+// ApplyIndexAware is an opt-in seam that delivers the raft applied-index
+// to the FSM without changing StateMachine.Apply's signature. The engine
+// calls SetApplyIndex on the same goroutine, immediately before Apply,
+// so the FSM can read it back from a field stashed during SetApplyIndex.
+//
+// FSMs that do not implement this interface continue to work as before;
+// their cold start will pay the full restoreSnapshotState cost because
+// they cannot self-report LastAppliedIndex().
+type ApplyIndexAware interface {
+    SetApplyIndex(idx uint64)
 }
 ```
 
-`applyAtIndex` threads `index` through `applyRequest` /
-`applyRequestErr`; the leaf MVCC mutation acquires the `pebble.Batch`,
-adds `key=metaAppliedIndex, value=binary.BigEndian.PutUint64(index)`,
-and commits.  The cost is +16 bytes per batch and zero extra fsync
-calls (the batch was already going to commit).
-
-#### pebbleStore exposes the index
+`engine.applyNormalEntry` (`engine.go:1769`) calls it before `Apply`:
 
 ```go
-// store/lsm_store.go (new method)
+func (e *Engine) applyNormalEntry(entry raftpb.Entry) any {
+    if len(entry.Data) == 0 { return nil }
+    _, payload, ok := decodeProposalEnvelope(entry.Data)
+    if !ok { return nil }
+    if aware, ok := e.fsm.(ApplyIndexAware); ok {
+        aware.SetApplyIndex(entry.Index)
+    }
+    return e.fsm.Apply(payload)
+}
+```
+
+Single-writer invariant: the engine's raft run loop is the only caller
+of `applyNormalEntry` and the only caller of `setApplied` (`engine.go:1764`).
+SetApplyIndex / Apply pair is observed by no other goroutine; no
+synchronisation between them is required.
+
+**Compatibility audit** — concrete `StateMachine` implementations in
+this repository (count: **6**, verified by `grep 'func.*Apply(data \[\]byte) any'`):
+
+| File | Symbol | Action in Branch 2 |
+|---|---|---|
+| `kv/fsm.go:60` | `(*kvFSM).Apply` | Add `SetApplyIndex(idx)` storing into `f.pendingApplyIdx`. Read it inside `Apply`. |
+| `internal/raftengine/raftenginetest/conformance.go:27` | `(*TestStateMachine).Apply` | No change unless test wants to assert index. |
+| `internal/raftengine/etcd/engine_test.go:33` | `testStateMachine` | No change. |
+| `internal/raftengine/etcd/engine_test.go:139` | `blockingSnapshotStateMachine` | No change. |
+| `internal/raftengine/etcd/engine_test.go:170` | `countingSnapshotStateMachine` | No change. |
+| `internal/raftengine/etcd/fsm_snapshot_file_test.go:124` | `dummyFSM` | No change. |
+
+(Round-1 doc claimed "8 in `internal/raftengine/`" — that was wrong;
+the actual count is 5 non-`kvFSM` impls.  Corrected.)
+
+Only `kvFSM` needs to implement `ApplyIndexAware`; the rest stay on the
+non-aware path.  Cold-start skip is enabled only when both the FSM
+implements `ApplyIndexAware` **and** the store implements
+`AppliedIndexReader`.
+
+### 2. `kvFSM` bundles the index in the SAME pebble.Batch as the mutation
+
+`kvFSM.Apply` doesn't directly touch Pebble — it dispatches through
+`f.store.ApplyMutationsRaft(...)`, `f.store.DeletePrefixAtRaft(...)`,
+etc., which build their own `pebble.Batch` inside `pebbleStore`.  To
+land the index in the same batch as the mutation, we plumb it from
+`kvFSM.Apply` down to the leaf `applyMutationsWithOpts` /
+`deletePrefixAtWithOpts` helpers (both already bundle
+`metaLastCommitTSBytes` — the precedent for batched meta keys lives at
+`lsm_store.go:1162` and `:1231`).
+
+```go
+// kv/fsm.go — round-2: keep the StateMachine.Apply signature
+type kvFSM struct {
+    store           store.MVCCStore
+    log             *slog.Logger
+    hlc             *HLC
+    pendingApplyIdx uint64    // set by SetApplyIndex immediately before Apply
+}
+
+func (f *kvFSM) SetApplyIndex(idx uint64) {
+    f.pendingApplyIdx = idx
+}
+
+func (f *kvFSM) Apply(data []byte) any {
+    idx := f.pendingApplyIdx
+    // CRITICAL: leave dispatch (HLC-lease vs request) UNCHANGED. We only
+    // pass `idx` down to the leaf MVCC mutation. The original opcode
+    // discrimination (`data[0] == raftEncodeHLCLease`) at kv/fsm.go:63
+    // and the existing decodeRaftRequests / applyRequest sequence
+    // continue verbatim. Only the leaf store call gains an index
+    // parameter, which is bundled atomically with the data write.
+    // ... existing dispatch ...
+}
+```
+
+The store interface gains an index-carrying overload, so the raft-apply
+path can carry it down without breaking direct-write paths:
+
+```go
+// store/store.go (new method on MVCCStore)
+ApplyMutationsRaftAt(
+    ctx context.Context,
+    muts []*KVPairMutation,
+    readKeys [][]byte,
+    startTS, commitTS uint64,
+    appliedIndex uint64,
+) error
+
+DeletePrefixAtRaftAt(
+    ctx context.Context,
+    prefix, excludePrefix []byte,
+    commitTS uint64,
+    appliedIndex uint64,
+) error
+```
+
+(The existing `ApplyMutationsRaft` / `DeletePrefixAtRaft` become thin
+wrappers that pass `appliedIndex=0` — the leaf helper treats `0` as
+"don't write the meta key", preserving direct-write semantics for
+callers outside the raft apply loop.)
+
+Implementation in the leaf:
+
+```go
+// store/lsm_store.go — applyMutationsWithOpts (existing, around :1162)
+if appliedIndex > 0 {
+    if err := setPebbleUint64InBatch(b, metaAppliedIndexBytes, appliedIndex); err != nil {
+        return errors.WithStack(err)
+    }
+}
+// ... existing metaLastCommitTSBytes write at :1162 stays as-is ...
+
+// store/lsm_store.go — deletePrefixAtWithOpts (existing, around :1231)
+if appliedIndex > 0 {
+    if err := setPebbleUint64InBatch(batch, metaAppliedIndexBytes, appliedIndex); err != nil {
+        return errors.WithStack(err)
+    }
+}
+// ... existing metaLastCommitTSBytes write at :1231 stays as-is ...
+```
+
+**Why both leaves**: `handleDelPrefix` → `DeletePrefixAtRaft` builds an
+independent `pebble.Batch` via `deletePrefixAtWithOpts` (round-1 doc
+missed this).  Threading the index ONLY through `applyMutationsWithOpts`
+would let DEL_PREFIX entries land in fsm.db without bumping
+`metaAppliedIndex`, which would silently leave the meta key behind the
+true applied index — and on the next cold start, `LastAppliedIndex`
+would underestimate, triggering a conservative full restore.  Cost: +16
+bytes per batch, zero additional fsync.
+
+### 3. Read-back exposes the index (with `dbMu.RLock()`)
+
+```go
+// store/lsm_store.go (new method, lock-ordering compliant)
+//
+// LastAppliedIndex returns the largest raft applied-index that any
+// raft-apply Batch has persisted via this pebbleStore. Lock order is
+// dbMu (RLock) before any db.Get, per the discipline documented at
+// lsm_store.go:153 and exemplified at :553 / :675. Without the lock,
+// a concurrent swapInTempDB could replace s.db between the Get call
+// and our access of the returned value/closer pair, racing the
+// snapshot install path.
 func (s *pebbleStore) LastAppliedIndex() (uint64, bool, error) {
-    val, closer, err := s.db.Get(metaAppliedIndexKey)
+    s.dbMu.RLock()
+    defer s.dbMu.RUnlock()
+    val, closer, err := s.db.Get(metaAppliedIndexBytes)
     if errors.Is(err, pebble.ErrNotFound) {
         return 0, false, nil
     }
-    if err != nil { return 0, false, errors.WithStack(err) }
+    if err != nil {
+        return 0, false, errors.WithStack(err)
+    }
     defer closer.Close()
     if len(val) != 8 {
         return 0, false, errors.Newf("corrupt applied-index meta key: %d bytes", len(val))
@@ -151,18 +276,43 @@ func (s *pebbleStore) LastAppliedIndex() (uint64, bool, error) {
 }
 ```
 
-A narrow `AppliedIndexReader` interface lets `restoreSnapshotState`
-inspect any store that implements it, without coupling the wal_store
-package to `*pebbleStore`:
+`metaAppliedIndexBytes` is a new well-known prefix sibling to
+`metaLastCommitTSBytes` (which is defined at `lsm_store.go:145` as
+`[]byte("_meta_last_commit_ts")`).  Recommended value:
+`[]byte("_meta_applied_index")` — outside the MVCC user-key space and
+disjoint from every existing meta key (verified by reading
+`isReservedMetaKey` at `lsm_store.go:454`, which currently only checks
+`metaLastCommitTSBytes` and `metaMinRetainedTSBytes`).  Branch 3 extends
+`isReservedMetaKey` to include the new key.
+
+A narrow consumer interface lets `restoreSnapshotState` inspect the
+store without coupling the etcd raft engine to `*pebbleStore`:
 
 ```go
-// internal/raftengine/statemachine.go (or sibling)
+// internal/raftengine/statemachine.go (new)
 type AppliedIndexReader interface {
     LastAppliedIndex() (uint64, bool, error)
 }
 ```
 
-### 2. Conditional restore
+**Reaching the store from inside `restoreSnapshotState`**: `kvFSM` holds
+its store via `f.store`, but `kvFSM` itself does not satisfy
+`AppliedIndexReader`.  The cleanest seam is to add a typed accessor on
+`kvFSM` (`func (f *kvFSM) AppliedIndexReader() AppliedIndexReader { return f.store }`)
+which `restoreSnapshotState` calls when the FSM implements a tiny
+companion interface:
+
+```go
+type AppliedIndexReporter interface {
+    AppliedIndexReader() AppliedIndexReader
+}
+```
+
+This keeps the public `StateMachine` interface untouched and avoids
+fattening `kvFSM` with a forwarding method.  FSMs that don't expose the
+reporter fall back to the current full-restore behaviour.
+
+### 4. Conditional restore (with conservative error fallback)
 
 ```go
 // internal/raftengine/etcd/wal_store.go
@@ -173,14 +323,11 @@ func restoreSnapshotState(fsm StateMachine, snapshot raftpb.Snapshot, fsmSnapDir
     if isSnapshotToken(snapshot.Data) {
         tok, err := decodeSnapshotToken(snapshot.Data)
         if err != nil { return err }
-        if skip, err := fsmAlreadyAtIndex(fsm, tok.Index); err != nil {
-            return err
-        } else if skip {
-            // FSM data on disk is at least as fresh as the snapshot.
-            // Raft will replay [tok.Index+1, committed] from the WAL
-            // and bring us to the latest committed index without
-            // touching the LSM's bulk state.
-            return nil
+        if fsmAlreadyAtIndex(fsm, tok.Index) {
+            // The body restore is skipped, but we MUST still read the
+            // HLC ceiling header from the snapshot file so the FSM's
+            // in-memory HLC starts at the right floor (see §HLC).
+            return applyHLCCeilingFromSnapshot(fsm, fsmSnapPath(fsmSnapDir, tok.Index))
         }
         return openAndRestoreFSMSnapshot(fsm, fsmSnapPath(fsmSnapDir, tok.Index), tok.CRC32C)
     }
@@ -188,138 +335,321 @@ func restoreSnapshotState(fsm StateMachine, snapshot raftpb.Snapshot, fsmSnapDir
     return errors.WithStack(fsm.Restore(bytes.NewReader(snapshot.Data)))
 }
 
-func fsmAlreadyAtIndex(fsm StateMachine, want uint64) (bool, error) {
-    r, ok := fsm.(AppliedIndexReader)
-    if !ok {
-        return false, nil // FSM cannot self-report; restore conservatively.
-    }
-    have, present, err := r.LastAppliedIndex()
-    if err != nil { return false, err }
-    if !present { return false, nil }
-    return have >= want, nil
+// fsmAlreadyAtIndex returns true ONLY when we can prove the FSM is
+// already at or past `want`. Any uncertainty -- FSM doesn't expose the
+// reporter, store doesn't expose the reader, read error, or missing
+// meta key -- returns false so we fall back to the full restore. The
+// idea is that a stale-but-incorrect skip is far worse than a wasteful
+// full restore, so we err strictly toward restoring.
+func fsmAlreadyAtIndex(fsm StateMachine, want uint64) bool {
+    reporter, ok := fsm.(AppliedIndexReporter)
+    if !ok { return false }
+    reader := reporter.AppliedIndexReader()
+    if reader == nil { return false }
+    have, present, err := reader.LastAppliedIndex()
+    if err != nil || !present { return false }
+    return have >= want
 }
 ```
 
-The fall-back behaviour when the FSM does not implement
-`AppliedIndexReader` or has no meta-key is **the current restore**, so
-the change is strictly additive.  The first cold start after deployment
-populates the meta key on every Apply going forward; from the second
-restart onward the skip path kicks in.
+**Round-1 mistake (fixed)**: the round-1 pseudocode propagated
+`LastAppliedIndex()` errors upward, which would fail node startup on a
+corrupt meta key.  Round-2 fallback policy: any error / missing /
+uncertainty maps to `false` (run full restore).  This honours the
+"strictly additive" guarantee — adoption can never make startup worse
+than the current behaviour, only better.
 
-### 3. Crash-safety argument
+### 5. HLC ceiling preservation when skipping (P1 from review)
 
-We claim: `LastAppliedIndex = N` durably implies "every mutation
-produced by `fsm.Apply` for indices `[snapshotIndex+1 .. N]` is durably
-present in fsm.db."
+`kvFSM.Restore` (`kv/fsm.go:264`) is currently the only place that reads
+the HLC physical-ceiling header from the snapshot file and applies it
+to the in-memory `f.hlc`:
 
-Proof: the meta key is written **in the same Pebble batch** as the data
-mutation for index N.  Pebble commits batches atomically.  Either both
-land or neither does.  After commit, both are durable per the batch's
-`pebble.Sync` option.  No crash window exists between persisting the
-mutation and persisting the index.
+```go
+// kv/fsm.go:278-286 (existing)
+if bytes.Equal(hdr[:8], hlcSnapshotMagic[:]) {
+    ceilingMs := int64(binary.BigEndian.Uint64(hdr[8:]))
+    if f.hlc != nil && ceilingMs > 0 {
+        f.hlc.SetPhysicalCeiling(ceilingMs)
+    }
+    return errors.WithStack(f.store.Restore(io.NopCloser(r)))
+}
+```
 
-Suppose a crash mid-Apply.  Pebble's WAL replay either:
-- restores the batch (data + index both present), or
-- discards the torn batch (data + index both absent).
+If we skip `Restore` we also skip this assignment.  After skip:
 
-Either way the invariant holds; on the second startup the meta-key is
-either exactly the index of the last committed Apply, or strictly less.
-`LastAppliedIndex ≥ snapshot.Metadata.Index` correctly implies the FSM
-is at least as fresh as the snapshot.
+- `f.hlc.physicalCeiling` stays at whatever the in-memory HLC was
+  initialised to (typically wall-clock-now, no snapshot floor).
+- Subsequent HLC lease entries in the WAL still bump the ceiling when
+  replayed by raft, BUT the lease entries are **between the snapshot
+  index and the latest committed index** — those whose ceiling was
+  baked into the snapshot itself (lease entries whose index ≤
+  `snapshot.Metadata.Index`) are compacted away from the WAL and never
+  replayed.
+- Net effect: if the snapshot was taken at ceiling C and no fresh
+  lease has bumped past C since, this node could mint timestamps
+  below C after becoming leader.
 
-The converse risk — "skip restore when we shouldn't" — would require
-the meta key to read **a value larger than the last durable Apply**.
-Since the only writer is `fsm.Apply` and it always batches index with
-data, that's impossible barring physical corruption (in which case the
-8-byte length check rejects the read and we restore conservatively).
+This violates the HLC monotonicity invariant cluster-wide.  **The skip
+path MUST set the HLC ceiling from the snapshot header even when the
+body restore is skipped.**
 
-### 4. Idempotency of replay after skip
+Mechanism — a new helper that reads the first 16 bytes of the snapshot
+file and dispatches:
+
+```go
+// internal/raftengine/etcd/wal_store.go (new)
+func applyHLCCeilingFromSnapshot(fsm StateMachine, snapPath string) error {
+    setter, ok := fsm.(HLCCeilingSetter)
+    if !ok { return nil } // FSM doesn't carry HLC; nothing to set.
+    f, err := os.Open(snapPath)
+    if err != nil { return errors.WithStack(err) }
+    defer f.Close()
+    var hdr [hlcSnapshotHeaderLen]byte
+    n, err := io.ReadFull(f, hdr[:])
+    if err != nil {
+        // The snapshot file is too short for an HLC header. Predates
+        // the magic/ceiling format -- nothing to apply, fall through.
+        if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+            return nil
+        }
+        return errors.WithStack(err)
+    }
+    _ = n
+    if !bytes.Equal(hdr[:8], hlcSnapshotMagic[:]) {
+        return nil // old format, no ceiling.
+    }
+    ceilingMs := int64(binary.BigEndian.Uint64(hdr[8:]))
+    if ceilingMs > 0 {
+        setter.SetHLCPhysicalCeiling(ceilingMs)
+    }
+    return nil
+}
+
+// kv/fsm.go gains:
+type HLCCeilingSetter interface {
+    SetHLCPhysicalCeiling(ms int64)
+}
+func (f *kvFSM) SetHLCPhysicalCeiling(ms int64) {
+    if f.hlc != nil { f.hlc.SetPhysicalCeiling(ms) }
+}
+```
+
+Cost: a 16-byte read from the snapshot file (single syscall, no
+deserialisation).  Negligible compared to the 46 s body restore we
+elide.
+
+### 6. Crash-safety argument (revised)
+
+We claim: `LastAppliedIndex = N` durably implies "every raft apply for
+indices `[snapshotIndex+1 .. N]` that produced a `pebbleStore` mutation
+is durably present in fsm.db."
+
+#### Default mode (`pebble.Sync`)
+
+The meta key is written in the same `pebble.Batch` as the data
+mutation.  Pebble commits batches atomically: either both records make
+it to the Pebble WAL and a successful fsync confirms durability, or
+neither does.  No crash window exists between persisting the mutation
+and persisting the index.
+
+#### `ELASTICKV_FSM_SYNC_MODE=nosync` mode
+
+When `raftApplyWriteOpts()` returns `pebble.NoSync` (configured at
+`lsm_store.go:1094-1104`), the data + meta key still land in the same
+Pebble WAL record, but the OS may delay the fsync.  Durability shifts
+to the raft layer: the raft WAL is the canonical source of truth, and
+on crash recovery raft replays entries from the last fsync'd Pebble
+position forward.  The invariant still holds because:
+
+- Pebble's atomic batch property is independent of the sync option.
+- On recovery, Pebble's WAL replay reconstructs the most recent
+  committed batch (or none of it), giving us either `(data + meta)` at
+  index N or `(neither)`.
+- raft will then replay any entries that the OS-buffered fsync lost,
+  and each Apply re-bundles its own index.
+
+The skip gate therefore stays correct: a `nosync`-induced loss merely
+means `LastAppliedIndex` reports a lower value than the post-restart
+applied count would imply, which only causes us to over-restore
+conservatively.
+
+#### DEL_PREFIX path
+
+`DeletePrefixAtRaft` → `deletePrefixAtWithOpts` builds its own batch
+(`lsm_store.go:1196`) and bundles `metaLastCommitTSBytes`
+(`lsm_store.go:1231`).  Branch 3 extends that bundling to also include
+`metaAppliedIndex`.  Without this, DEL_PREFIX entries land without
+bumping the meta key and `LastAppliedIndex` drifts behind the true
+applied count (still safe — over-restoring conservatively — but
+defeats the optimisation for any workload that uses DEL_PREFIX).
+
+#### HLC lease entries (Open Question 1 — committed to Option 2)
+
+`f.applyHLCLease` (kv/fsm.go around `:63`) is currently an in-memory
+mutation only; it does not touch `f.store`.  We accept that
+`LastAppliedIndex` does NOT advance for these entries.  Consequence:
+in a workload where the only entries between two snapshots are lease
+ticks, the skip gate will fall back to full restore — which is safe
+and rare.
+
+Adding a synthetic pebble batch per lease tick (Option 1) would cost
+~1 extra pebble batch per second per group (lease cadence is 1 s),
+which is undesirable.  Option 2 (do nothing extra) is correct and
+cheaper; the trade-off is the rare false-positive restore.
+
+### 7. Idempotency of replay after skip (revised — OCC two-case)
 
 After we skip restore, raft replays entries `[snapshotIndex+1, committed]`.
-Some of those entries may have already been applied (if a previous
+Some of those entries may already be present in fsm.db (if a previous
 restart reached `applied=K > snapshotIndex` before crashing).  We do
-**not** suppress replay of already-applied entries — `fsm.Apply` is
-required to be idempotent for snapshot recovery in any raft FSM, and
-the current kvFSM upholds that (every mutation is keyed by its raft
-metadata; re-applying the same entry produces the same Pebble write).
-The meta-key gets overwritten with the same value.  No correctness
-gap; the cost is the same replay we'd pay after a full restore.
+**not** suppress replay of already-applied entries.  Two cases cover
+the invariant:
 
-### 5. Compatibility & rollback
+**(a) Raw requests** (`startTS = commitTS = T`).  The kvFSM dispatch
+reaches `f.store.ApplyMutationsRaft(... T, T ...)`.  Inside
+`checkConflicts`, `latestCommitTS(T) > T` evaluates to false (equal,
+not greater), so no conflict is raised and the Pebble write is a
+deterministic overwrite of the same MVCC cell.  Re-applying is a
+no-op at the byte level.
 
-- The interface change `Apply(data) → Apply(index, data)` is breaking
-  for **external** state machines that embed `raftengine.StateMachine`.
-  No such consumers exist in-tree.  External consumers (none known)
-  would notice immediately at compile time.
-- The meta key is new; older fsm.db files don't have it.  The
-  `present == false` branch makes the first restart after upgrade
-  fall back to the current (full restore) behaviour, populating the
-  meta key from the next Apply onward.
-- Rollback: revert the wal_store.go change to remove the skip branch.
-  The meta key remains in fsm.db (harmless dead data) and gets
-  overwritten by future Applies.  No data migration required either
-  direction.
+**(b) OCC one-phase transactions** (`startTS < commitTS`).  After the
+first apply, `latestCommitTS(key) = commitTS`.  On re-apply,
+`checkConflicts` evaluates `latestCommitTS(commitTS) > startTS` to
+**true**, returning `ErrWriteConflict`.  The key is NOT re-written.
+This is safe because `ErrWriteConflict` is returned as the FSM
+**response value** (not as the `error` from `applyNormalEntry`); it
+does not implement `HaltApply`.  The engine still calls
+`setApplied(entry.Index)`, the FSM state is already correct from the
+first apply, and the meta key is overwritten with the same value.
+End state is observationally identical to "produced the same write."
 
-### 6. Observability
+Other request types are individually safe by similar reasoning:
+`handleCommitRequest` short-circuits via
+`applyCommitWithIdempotencyFallback`; `handleAbortRequest` is safe via
+`shouldClearAbortKey` (no-op if the lock is already gone);
+`handlePrepareRequest` collapses through the OCC write-conflict path
+when intents from prior applies are still present.
+
+### 8. Compatibility & rollback
+
+- `StateMachine.Apply`'s public signature is **unchanged**.  External
+  state machines (none known) continue to work.
+- The new opt-in interfaces (`ApplyIndexAware`, `AppliedIndexReader`,
+  `AppliedIndexReporter`, `HLCCeilingSetter`) are additive.  FSMs that
+  don't implement them fall back to the current behaviour.
+- The `metaAppliedIndex` key is new; older fsm.db files don't have
+  it.  The `present=false` branch makes the first restart after upgrade
+  fall back to full restore, populating the meta key from the next
+  Apply onward.
+- Rollback: revert the wal_store.go skip branch.  The meta key remains
+  in fsm.db (harmless dead data) and gets overwritten by future
+  Applies.  No data migration in either direction.
+
+### 9. Observability
 
 Two metrics + one log line:
 
-```go
-// monitoring/metrics.go
-fsm_cold_start_restore_total{outcome="executed|skipped|fallback"}
-fsm_cold_start_applied_index_gap // snapshot.Index - lastAppliedIndex when restore is executed
 ```
+fsm_cold_start_restore_total{outcome="executed|skipped|fallback"}
+fsm_cold_start_applied_index_gap{outcome="executed|skipped"}
+```
+
+The gap label gets emitted in both directions so we can confirm the
+**skip path actually closes the gap** (positive values when skipped
+mean `LastAppliedIndex - snapshot.Index ≥ 0`) AND confirm restore
+sizes when executed (`snapshot.Index - LastAppliedIndex > 0`).
+Asymmetric emission would hide regressions where the skip succeeds but
+the meta key is drifting behind.
 
 Log line at INFO when skipping:
 
 ```
-restoreSnapshotState skipped (FSM already at index N >= snapshot index X)
+restoreSnapshotState skipped (FSM at index %d, snapshot at %d, HLC ceiling applied from header)
 ```
-
-These let us verify the skip rate in production and catch regressions
-where Apply stops bundling the index.
 
 ## Implementation Plan
 
-1. **Branch 1 (this design)** — PR-2-design, lands docs only.
-2. **Branch 2 (interface change)** — modify `StateMachine.Apply`
-   signature across all callers + the conformance shim.  No behaviour
-   change; index is accepted and discarded.  Pure mechanical PR with
-   ~200-line diff, easy review.
-3. **Branch 3 (meta key + batch bundling)** — `kvFSM.Apply` threads
-   `index` to leaf mutation; `pebbleStore` defines the meta key and
-   exposes `LastAppliedIndex()`; unit tests cover round-trip + torn
-   batch.  Activates the data side; the skip is **not yet wired**.
-4. **Branch 4 (wal_store.go skip)** — adds the `fsmAlreadyAtIndex` gate
-   to `restoreSnapshotState`, with the metrics and the log line.  This
-   is the user-visible perf win.
-5. **Branch 5 (cleanup)** — once branch 4 has soaked in production
-   for a release, consider lowering `HEALTH_TIMEOUT_SECONDS` back
-   toward a tighter ceiling.
+| Branch | Content | Behaviour change |
+|---|---|---|
+| **B1** (this PR) | Design doc | None |
+| **B2** | New `ApplyIndexAware` interface + `kvFSM.SetApplyIndex` + engine.go call site | None (engine starts feeding index; FSM stashes it; nothing reads it yet) |
+| **B3** | Thread `appliedIndex` through `ApplyMutationsRaftAt` / `DeletePrefixAtRaftAt` + bundle meta key in both leaves + `pebbleStore.LastAppliedIndex()` with `dbMu.RLock()` + `kvFSM.AppliedIndexReader()` accessor | Meta key starts being written; skip is still disabled. Soak in production for one release. |
+| **B4** | `restoreSnapshotState` skip gate + `applyHLCCeilingFromSnapshot` + `kvFSM.SetHLCPhysicalCeiling` + metrics + INFO log | **User-visible cold-start win.** |
+| **B5** | Lower `HEALTH_TIMEOUT_SECONDS` default once production data shows steady-state skip rate ≥ 90 % | Tighter ceiling, but tracker the env override still honoured |
 
-Branches 2–4 each ship behind tests that prove the corresponding
-invariant.  Branch 4 specifically asserts:
+Each of B2–B4 ships behind tests:
 
-- Skip happens when `stored ≥ snapshot.Metadata.Index`.
-- Restore runs when `stored < snapshot.Metadata.Index`.
-- Restore runs when the meta key is missing.
-- Restore runs when `LastAppliedIndex()` returns an error.
+- **B2**: `engine_test.go` asserts that a recorder FSM observes
+  `SetApplyIndex(entry.Index)` immediately before `Apply(data)` for
+  every Apply.
+- **B3**: pebble-level tests round-trip the meta key in
+  `applyMutationsWithOpts` AND `deletePrefixAtWithOpts`; torn-batch
+  test simulates pebble WAL replay across the meta key boundary.
+- **B4**: integration test seeds a fsm.db with `LastAppliedIndex = K`,
+  pairs it with a snapshot at index `K-N` (N varies), asserts skip is
+  taken for `N ≤ 0` and restore for `N > 0`.  Separate test asserts
+  that `applyHLCCeilingFromSnapshot` sets `f.hlc.PhysicalCeiling()`
+  for both skip and restore paths (i.e., the ceiling is invariant
+  under the optimisation).
+
+## Errata against Round-1 reviewer feedback
+
+For honesty about the review process: round 1 received feedback from
+`gemini-code-assist[bot]` and `claude[bot]` that referenced
+codebase entities that **do not exist in this repository**.  Verified
+by `grep -r ... --include='*.go' .` over `main` HEAD at SHA
+`94579fc0`.
+
+| Cited entity | Grep matches | Reviewer claim | Reality |
+|---|---|---|---|
+| `ApplyIndexAware` | 0 | "already in production" (gemini), "engine.go:2292" (claude) | Does not exist. Engine.go:2292 is `failPending`. |
+| `SetApplyIndex` | 0 | "already implemented on kvFSM" | Does not exist on `kvFSM`. |
+| `pendingApplyIdx` | 0 | "already holds entry.Index" | Field does not exist. |
+| `applyReservedOpcode` | 0 | "dispatches HLC lease + encryption opcodes 0x03..0x07" | Function does not exist. |
+| `applyEncryption` | 0 | "goes via WriteSidecar" | Function does not exist. |
+| `WriteSidecar` | 0 | (same as above) | Method does not exist. |
+| Encryption opcodes `0x03..0x07` | 0 | "Stage 6/7/8 encryption dispatch" | Only `raftEncodeSingle=0x00`, `raftEncodeBatch=0x01`, `raftEncodeHLCLease=0x02` exist (`kv/fsm.go:110-116`). |
+
+This design therefore proceeds with **Branch 2 in place** (we have to
+create the `ApplyIndexAware` seam; we cannot reuse one that doesn't
+exist).  The reviewers' reasoning about "avoid a breaking
+`StateMachine.Apply` signature change" was sound regardless of the
+factual error — we adopt it by creating the seam they hallucinated as
+existing.  Encryption-opcode dispatch is not addressed because the
+opcodes do not exist in main today; once Stages 6/7/8 land, the
+opcode dispatch will need to plumb `appliedIndex` through whatever
+path it takes (a follow-up problem, not a round-2 problem).
+
+The **substantively correct** findings from round-1 reviews — all
+incorporated:
+
+- 🔴 codex P1 on `:319`: HLC ceiling preservation when skipping
+  body restore (`kv/fsm.go:264-286` does read the header).  **Real
+  bug**, fixed in §5.
+- 🟠 gemini medium on `:152`: `LastAppliedIndex()` needs
+  `s.dbMu.RLock()` per `lsm_store.go:153 / :162 / :553 / :675` lock
+  ordering.  **Real**, fixed in §3.
+- 🟠 claude §3 caveat 1: `ELASTICKV_FSM_SYNC_MODE=nosync`
+  (`lsm_store.go:86`) shifts durability boundary.  **Real**, fixed
+  in §6.
+- 🟠 claude §3 caveat 2: `deletePrefixAtWithOpts` (`lsm_store.go:1196`)
+  builds an independent batch and already bundles
+  `metaLastCommitTSBytes` (`:1231`).  **Real**, fixed in §2.
+- 🟠 claude §3 error handling: `fsmAlreadyAtIndex` propagating errors
+  would fail cold start on a corrupt meta key.  **Sound design
+  improvement**, fixed in §4.
+- 🟢 claude §4 OCC two-case argument and call-site count (6 not 8).
+  **Real**, fixed in §7 and §1's table.
 
 ## Open Questions
 
-- **Multi-group**: each shard's pebbleStore has its own meta key.  No
-  shared state; this design is per-shard naturally.  Sanity-check during
-  branch 3.
-- **HLC lease entries**: `kvFSM.applyHLCLease` advances `f.hlc` but does
-  not currently touch the store.  We must still bump the meta key on
-  lease applies (a degenerate batch with just the meta key, or — better
-  — fold the lease index into the next data Apply).  Decision deferred
-  to branch 3; the in-memory HLC state is reconstructed at startup from
-  the lease entries replayed by raft, so this is purely about getting
-  the index counter monotonic.
+- **Multi-group**: each shard's `pebbleStore` has its own meta key.
+  No shared state; this design is per-shard naturally.  Branch 3 will
+  verify with an integration test on a 4-group cluster.
 - **HashiCorp backend** (if it ever returns): the raft library exposes
-  `log.Index` to `(raft.FSM).Apply(log *raft.Log)`, so the interface
-  change is satisfiable on that side too.
+  `log.Index` to `(raft.FSM).Apply(log *raft.Log)`, so the
+  `ApplyIndexAware` seam is satisfiable on that side too.
 
 ## Out of Scope (future)
 
@@ -329,3 +659,6 @@ invariant.  Branch 4 specifically asserts:
 - Switching `restorePebbleNativeAtomic` to in-place ingest (e.g.
   Pebble's `Ingest`).  Risky and unrelated to the skip-when-safe
   optimisation this proposal targets.
+- Plumbing `appliedIndex` through future encryption-opcode dispatch
+  (Stages 6/7/8) — once those opcodes exist on `main`, they will need
+  the same treatment as DEL_PREFIX.

--- a/docs/design/2026_06_02_idempotent_snapshot_restore.md
+++ b/docs/design/2026_06_02_idempotent_snapshot_restore.md
@@ -159,14 +159,14 @@ for `metaLastCommitTSBytes` (`lsm_store.go:1324` and `:1393`
 respectively):
 
 ```go
-// store/lsm_store.go — applyMutationsWithOpts (existing, around :1162)
+// store/lsm_store.go — applyMutationsWithOpts (existing, around :1324)
 if appliedIndex > 0 {
     if err := setPebbleUint64InBatch(b, metaAppliedIndexBytes, appliedIndex); err != nil {
         return errors.WithStack(err)
     }
 }
 
-// store/lsm_store.go — deletePrefixAtWithOpts (existing, around :1231)
+// store/lsm_store.go — deletePrefixAtWithOpts (existing, around :1393)
 if appliedIndex > 0 {
     if err := setPebbleUint64InBatch(batch, metaAppliedIndexBytes, appliedIndex); err != nil {
         return errors.WithStack(err)

--- a/docs/design/2026_06_02_idempotent_snapshot_restore.md
+++ b/docs/design/2026_06_02_idempotent_snapshot_restore.md
@@ -1,7 +1,7 @@
 # Idempotent FSM Snapshot Restore on Cold Start
 
-**Status**: Proposal (Round 3 — corrected after round-2 self-error)
-**Date**: 2026-06-02 (round 1), 2026-06-03 (round 2 + round 3)
+**Status**: Proposal (Round 4 — codex P2 fix: snapshot-persist meta key bump)
+**Date**: 2026-06-02 (round 1), 2026-06-03 (rounds 2 / 3 / 4)
 **Author**: bootjp
 **Related**: PR #909 (`HEALTH_TIMEOUT_SECONDS` 60s → 300s)
 
@@ -429,16 +429,115 @@ back to full restore.  Safe; rare.
 `ErrSidecarBehindRaftLog`; that mechanism is orthogonal to this
 proposal.)
 
-#### HLC lease entries (Open Question 1 — Option 2)
+#### HLC lease entries — checkpoint at snapshot persist (codex round-3 P2)
 
 `f.applyHLCLease` is an in-memory mutation only; it does not touch
-`f.store`.  We accept that `metaAppliedIndex` does NOT advance for
-HLC lease entries.  Consequence: in a workload where the only entries
-between two snapshots are lease ticks, the skip gate will fall back
-to full restore — safe and rare.  Adding a synthetic pebble batch per
-lease tick would cost ~1 extra pebble batch per second per group;
-trading the rare false-positive restore for that ongoing cost is the
-wrong call.
+`f.store`, so `metaAppliedIndex` does NOT advance for HLC lease
+entries individually.
+
+Round-3 of this doc claimed the resulting full-restore fallback was
+"safe and rare."  Codex correctly pointed out it is neither:
+`RunHLCLeaseRenewal` (`kv/coordinator.go:650`) proposes a lease every
+`hlcRenewalInterval = 1 * time.Second` while the local node is leader,
+so even an active cluster will routinely accumulate a tail of lease
+entries between any two data writes.  When the next snapshot is
+persisted at index `X`, the gap between the last data-Apply index `Y`
+and `X` always contains lease entries — and once `metaAppliedIndex`
+sits at `Y < X` on restart, `fsmAlreadyAtIndex(X)` returns false, the
+full restore runs, and the same stale `metaAppliedIndex = Y` is
+re-installed from the snapshot.  Idle clusters degenerate to
+"`metaAppliedIndex` never advances past the very last data write" and
+the skip never fires.  Round-3 was wrong; round-4 fixes it.
+
+**Mechanism**: bump `metaAppliedIndex` to `snapshot.Metadata.Index`
+when persisting a created snapshot, in `persistCreatedSnapshot`
+(`internal/raftengine/etcd/engine.go:2683`), **before**
+`e.persist.SaveSnap`:
+
+```go
+// internal/raftengine/etcd/engine.go (revised)
+func (e *Engine) persistCreatedSnapshot(snap raftpb.Snapshot) error {
+    if etcdraft.IsEmptySnap(snap) || e.persist == nil {
+        return nil
+    }
+    // Round-4: bump metaAppliedIndex BEFORE SaveSnap so a successful
+    // snapshot persist always implies LastAppliedIndex >= snap.Metadata.Index.
+    // Skip the bump silently when the FSM does not expose the writer
+    // seam (legacy fakes / test shims).
+    if w, ok := e.fsm.(AppliedIndexWriter); ok {
+        if err := w.SetDurableAppliedIndex(snap.Metadata.Index); err != nil {
+            return errors.WithStack(err)
+        }
+    }
+    if err := e.persist.SaveSnap(snap); err != nil {
+        return errors.WithStack(err)
+    }
+    // ... existing Release + purge ...
+}
+```
+
+The new `AppliedIndexWriter` interface lives next to
+`AppliedIndexReader` in `internal/raftengine/statemachine.go`:
+
+```go
+type AppliedIndexWriter interface {
+    SetDurableAppliedIndex(idx uint64) error
+}
+```
+
+`kvFSM` implements it by forwarding to a new `pebbleStore` method
+that runs a single-key `pebble.Batch` write with the same Sync mode
+as the raft-apply path (`s.raftApplyWriteOpts()`):
+
+```go
+// kv/fsm.go
+func (f *kvFSM) SetDurableAppliedIndex(idx uint64) error {
+    w, ok := f.store.(interface {
+        SetDurableAppliedIndex(idx uint64) error
+    })
+    if !ok { return nil }
+    return w.SetDurableAppliedIndex(idx)
+}
+
+// store/lsm_store.go
+func (s *pebbleStore) SetDurableAppliedIndex(idx uint64) error {
+    s.dbMu.RLock()
+    defer s.dbMu.RUnlock()
+    b := s.db.NewBatch()
+    defer b.Close()
+    if err := setPebbleUint64InBatch(b, metaAppliedIndexBytes, idx); err != nil {
+        return errors.WithStack(err)
+    }
+    return errors.WithStack(b.Commit(s.raftApplyWriteOpts()))
+}
+```
+
+**Crash ordering**.  The bump runs before `SaveSnap`, which means the
+invariant is:
+
+| State at crash | metaAppliedIndex on disk | snapshot pointer on disk | After restart |
+|---|---|---|---|
+| Before bump | last data Apply index `Y` | previous snapshot at `X' < X` | skip if `Y ≥ X'` (correct) |
+| Bump done, SaveSnap not yet | `X` | still `X'` | skip succeeds against `X'` (over-restore impossible) |
+| Both done | `X` | `X` | skip succeeds against `X` (correct — the optimisation works) |
+| Both done + later data Apply at `Z > X` | `Z` | `X` | skip succeeds against `X` (correct) |
+
+In particular, there is no ordering where `snapshot pointer = X` but
+`metaAppliedIndex < X`: the snapshot pointer is only persisted after
+the meta key, so the only way to observe a snapshot pointer at `X` is
+that the meta key already reached `X` (or moved past it).  Round-3's
+permanent fallback case is closed.
+
+**Cost**: one extra pebble `Batch.Commit` (Sync per
+`ELASTICKV_FSM_SYNC_MODE`) per snapshot persist.  Snapshots fire on the
+etcd raft `SnapshotCount` cadence (default 10000 entries), so this is
+~one extra fsync per ~10000 entries — negligible.
+
+**Why not bump on every HLC lease apply**.  Option A (1 pebble batch
+per lease tick) costs ~1 fsync/sec/group continuously.  Option B (the
+snapshot-persist hook) costs ~1 fsync per 10000 entries.  Both close
+the skip gap; B costs ~10⁴× less and aligns with the natural
+durability boundary the engine already maintains.
 
 ### 7. Idempotency of replay after skip (OCC two-case)
 
@@ -528,7 +627,7 @@ restoreSnapshotState skipped (FSM at index %d, snapshot at %d, ceiling=%d, cutov
 | Branch | Content | Behaviour change |
 |---|---|---|
 | **B1** (this PR) | Design doc | None |
-| **B2** | `ApplyMutationsRaftAt` / `DeletePrefixAtRaftAt` overloads + meta-key bundling in both leaves + `pebbleStore.LastAppliedIndex()` with `dbMu.RLock()` + `kvFSM.AppliedIndexReader()` accessor + thread `f.pendingApplyIdx` into the data-Apply leaves | Meta key starts being written; skip is still disabled. Soak in production for one release. |
+| **B2** | `ApplyMutationsRaftAt` / `DeletePrefixAtRaftAt` overloads + meta-key bundling in both leaves + `pebbleStore.LastAppliedIndex()` + `pebbleStore.SetDurableAppliedIndex()` (both with `dbMu.RLock()`) + `kvFSM.AppliedIndexReader()` accessor + `kvFSM.SetDurableAppliedIndex` forwarding + thread `f.pendingApplyIdx` into the data-Apply leaves + `persistCreatedSnapshot` calls `SetDurableAppliedIndex` BEFORE `e.persist.SaveSnap` | Meta key starts being written on every data Apply AND at every snapshot persist. Skip is still disabled. Soak in production for one release. |
 | **B3** | `restoreSnapshotState` skip gate + `applyHeaderStateOnSkip` reusing `kv.ReadSnapshotHeader` + `SnapshotHeaderApplier` seam on `kvFSM` + metrics + INFO log | **User-visible cold-start win.** |
 | **B4** | Lower `HEALTH_TIMEOUT_SECONDS` default once production data shows steady-state skip rate ≥ 90 % | Tighter ceiling; the env override remains honoured. |
 
@@ -538,14 +637,25 @@ Each of B2–B3 ships behind tests:
   `applyMutationsWithOpts` AND `deletePrefixAtWithOpts`; torn-batch
   test simulates pebble WAL replay across the meta key boundary.
   A `kvFSM` unit test asserts that `SetApplyIndex(K)` immediately
-  before a data `Apply` produces `LastAppliedIndex() == K`.
+  before a data `Apply` produces `LastAppliedIndex() == K`.  An
+  engine-level test drives `persistCreatedSnapshot(snap)` against a
+  store whose latest data Apply was at index `Y < snap.Metadata.Index`
+  and asserts `LastAppliedIndex() == snap.Metadata.Index` after the
+  call returns — verifying the snapshot-persist bump closes the
+  codex round-3 P2 gap.  A separate test simulates a crash between
+  `SetDurableAppliedIndex` and `SaveSnap` by injecting a SaveSnap
+  failure and asserts the post-restart `LastAppliedIndex` is at least
+  as fresh as the previous-snapshot pointer (over-restore impossible).
 - **B3**: integration test seeds a fsm.db with `LastAppliedIndex = K`
   and pairs it with a snapshot at index `K-N` (N varies), asserting
   skip is taken for `N ≤ 0` and restore for `N > 0`.  A separate
   test asserts that `applyHeaderStateOnSkip` sets
   `f.hlc.PhysicalCeiling()` **and** `f.restoredCutover` for both v1
   and v2 snapshot headers — the ceiling+cutover are invariant under
-  the optimisation.
+  the optimisation.  An idle-cluster test runs a 3-node cluster with
+  no data writes for `2 * SnapshotCount * hlcRenewalInterval`
+  seconds, takes a snapshot, restarts a node, and asserts the skip
+  fires — proving the codex P2 scenario is closed end-to-end.
 
 ## Open Questions
 
@@ -615,3 +725,37 @@ the `SnapshotHeaderApplier` seam.
 
 Apologies to the review bots for the round-2 push-back.  Round 3
 proceeds against the actual code.
+
+## Round-3 retraction (codex P2)
+
+Round 3 of this doc declared the HLC-lease-only fallback to be "safe
+and rare" and rejected adding any synthetic pebble write for it.
+Codex's round-3 review (P2 at `:438`) pointed out the actual
+production cadence:
+
+- `RunHLCLeaseRenewal` (`kv/coordinator.go:650`) ticks at
+  `hlcRenewalInterval = 1 * time.Second` while the local node is
+  leader.
+- `applyHLCLease` is memory-only; `metaAppliedIndex` does not advance
+  on lease apply.
+- For any cluster with a leader running for >1 s, lease entries trail
+  every snapshot.  Snapshots persist at index `X`, the last
+  data-Apply index `Y < X`, and `metaAppliedIndex` stays at `Y` on
+  restart.  `fsmAlreadyAtIndex(X)` checks `Y >= X` → false → full
+  restore.  Idle clusters degenerate to "the skip never fires";
+  active clusters have a meaningful window where it doesn't fire.
+
+Round 3's framing of this as "rare" was wrong.  Round 4 (§6 HLC lease
+subsection + B2 row + B2 test list) closes the gap by bumping
+`metaAppliedIndex` to `snapshot.Metadata.Index` inside
+`persistCreatedSnapshot`, **before** `e.persist.SaveSnap`.  After a
+successful snapshot persist, `LastAppliedIndex >= snapshot.Index`
+holds unconditionally, so the skip fires reliably on the next
+restart.  Cost: one extra pebble `Batch.Commit` per snapshot persist
+(~one extra fsync per `SnapshotCount` entries, default 10000) versus
+Option A's continuous ~1 fsync/sec/group.
+
+Lesson: "rare" should be a quantitative claim against the actual
+production timer cadence, not an intuition.  Codex's review process
+explicitly cited `kv/coordinator.go:641-663` — a file:line that I
+could have consulted before making the round-3 claim.


### PR DESCRIPTION
## Summary

PR #909 (`HEALTH_TIMEOUT_SECONDS` 60s → 300s) の **根本原因側** の設計提案。コードは無変更、ドキュメント追加のみ。

## 何を解決したいか

`internal/raftengine/etcd/wal_store.go:117 loadWalState` が、WAL の persisted snapshot pointer が空でない限りコールド起動の度に
`restoreSnapshotState(fsm, snapshot, fsmSnapDir)` を呼びます。EKV/token-format snapshot の経路では最終的に
`pebbleStore.Restore` → `restorePebbleNativeAtomic` → `swapInTempDB` (`store/lsm_store.go:1816, :2002`) が走り、
**fsm.db の全内容を sibling tempdir に書き戻してから rename で差し替える** = 起動コストが **O(snapshot size)**。

5 ノード 192.168.0.x クラスタで実測 **~46 s** (Found 2 WALs `012720/012734` のオープン → Found 0 WALs の tempdir 作成 → Found 4 WALs `001309..001315` の rename 後再オープン)。
これが PR #909 で観測された "gRPC port did not come up" の主因です。

問題は **この復元の大半が冗長** だという点:
- 毎回成功した `fsm.Apply` が変更内容を Pebble の WriteBatch で durable に書き込み済み
- FSM が `applied = Y > snapshot.Metadata.Index = X` まで進んだ後の fsm.db は state ≥ X を保持済み
- にもかかわらず次のコールド起動で **その状態を捨てて古い snapshot から再構築** → raft が同じエントリを再 replay

## 提案アーキテクチャ

### (1) `StateMachine.Apply(index, data)` 化

```go
// before
Apply(data []byte) any
// after
Apply(index uint64, data []byte) any
```

Engine の唯一の呼び出しサイト (`engine.go:1769 applyNormalEntry`) で `entry.Index` を渡すだけ。
in-tree 実装は機械的変換、外部実装は無し。

### (2) `pebbleStore` の meta key に applied-index を atomic 同梱

`kvFSM.Apply(index, data)` が leaf MVCC mutation で取得する `pebble.Batch` に `key=metaAppliedIndex, value=BE64(index)` を追加。
Pebble の batch は atomic なので **torn-write window なし**。

### (3) `restoreSnapshotState` 条件分岐

```go
if skip, err := fsmAlreadyAtIndex(fsm, tok.Index); err != nil {
    return err
} else if skip {
    // FSM data on disk is at least as fresh as the snapshot.
    return nil
}
return openAndRestoreFSMSnapshot(...)
```

`AppliedIndexReader` interface 未実装の FSM、または meta key 不在 (アップグレード直後の最初の再起動) は **現状の full restore にフォールバック** → strictly additive。

## 期待される効果

- コールド起動の steady-state コスト: `pebble.Open` + WAL replay + raft follower 化 + gRPC bind の **<5 秒** (FSM サイズに依存しない)
- raft term 暴発 (timeout-induced restart loop による) の解消
- 将来 `HEALTH_TIMEOUT_SECONDS` を引き下げ可能 (Branch 5 で実施)

## 実装シーケンス (別 PR 4 本に分割)

| Branch | 内容 | 動作変化 |
|---|---|---|
| **B2** | `StateMachine.Apply(index, data)` interface 変更 + 全実装更新 (index は受け取って捨てるだけ) | なし |
| **B3** | `kvFSM` で index を leaf mutation に流し、`pebbleStore` で meta key を WriteBatch 同梱 + `LastAppliedIndex()` 公開 + 単体テスト | meta key が書き込まれ始める (まだ skip は無効) |
| **B4** | `restoreSnapshotState` に `fsmAlreadyAtIndex` ガート + metrics + INFO log | **ユーザー可視な perf 改善** ここで発火 |
| **B5** | `HEALTH_TIMEOUT_SECONDS` を tighter な値に引き下げ | docker restart loop 抑止 |

各 branch は対応する invariant を unit test でガード。

## Crash-safety / Compatibility

詳細は `docs/design/2026_06_02_idempotent_snapshot_restore.md` の §3 §5 参照。
要約:
- meta key とデータ mutation は同一 `pebble.Batch` で commit されるため、クラッシュ後の Pebble WAL replay は両者を一緒に restore するか両者を一緒に discard する。中間状態はあり得ない。
- 8-byte length check 失敗時は読み取り側が conservative に "missing" として扱い、full restore にフォールバック。
- 旧 fsm.db に meta key が無い場合は最初の再起動は現状動作。データ移行不要。
- ロールバックは wal_store.go の skip 分岐を revert するだけ。meta key は dead data として残るが無害。

## 観測対象

```
fsm_cold_start_restore_total{outcome="executed|skipped|fallback"}
fsm_cold_start_applied_index_gap (executed 時の snapshot.Index - LastAppliedIndex)
```

+ skip 時の INFO log: `restoreSnapshotState skipped (FSM already at index N >= snapshot index X)`

## レビュー観点

- §3 の Pebble batch 原子性に基づく crash-safety 証明が説得力あるか
- §4 の "skip 後の replay 冪等性" 議論で見落としは無いか (`kvFSM.Apply` が現状 idempotent と読めているか)
- Branch 分割 (4 本) の粒度が妥当か / もっと束ねるべきか
- HLC lease entry の index 監視に関する Open Question (§Open Questions 1 番目) の解像度

設計が固まり次第 Branch 2 (interface change) から着手します。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised design doc detailing idempotent snapshot restore: safe skip of heavy snapshot bodies when on-disk state is proven current, header CRC verification for the skip path, and a durable applied-index write before snapshot persistence. Clarifies crash-safety, observability, compatibility, and implementation plan.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bootjp/elastickv/pull/910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->