### PR TITLE
feat(cmd): M5a — elastickv-split + elastickv-route-key CLI tools

### DIFF
--- a/cmd/elastickv-route-key/main.go
+++ b/cmd/elastickv-route-key/main.go
@@ -1,0 +1,58 @@
+// elastickv-route-key prints the byte-string of a DynamoDB
+// table-route key for a given table name.  Used by the Composed-1
+// M5 launch script (`scripts/run-jepsen-local.sh`) and OQ-7
+// (docs/design/2026_06_02_proposed_composed1_m5_jepsen_route_shuffle.md)
+// to compute `--shardRanges` boundary keys without inlining the
+// base64-encoding logic in shell — the encoding is part of the
+// routing surface and any drift would silently mis-route.
+//
+// Usage:
+//
+//	elastickv-route-key jepsen_append_t1
+//	# → !ddb|route|table|amVwc2VuX2FwcGVuZF90MQ
+//
+// The output matches `dynamoRouteTableKey(encodeDynamoSegment(name))`
+// (kv/shard_key.go:117 + adapter/dynamodb.go:8441) byte-for-byte.
+// A test pin (main_test.go) covers the contract against
+// representative names.
+//
+// The output is written WITHOUT a trailing newline (raw bytes) so
+// shell composition (e.g. `--shardRanges "$(elastickv-route-key
+// jepsen_append_t2)=2"`) works without `tr -d '\n'`.
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+)
+
+// dynamoRoutePrefix mirrors kv.dynamoRoutePrefix (unexported in
+// the kv package).  Keep this in sync — the M5 launch script's
+// --shardRanges boundary keys must match the routing layer's
+// expectations exactly.
+const (
+	dynamoRoutePrefix = "!ddb|route|table|"
+	// usageExitCode is the conventional shell exit code for
+	// "command-line usage error" (sysexits.h EX_USAGE = 64; many
+	// CLIs simplify to 2).  Distinct from exit 1 used for runtime
+	// failures so shell callers can branch.
+	usageExitCode = 2
+)
+
+func main() {
+	if len(os.Args) != 2 || os.Args[1] == "-h" || os.Args[1] == "--help" {
+		fmt.Fprintf(os.Stderr, "usage: %s <dynamodb-table-name>\n", os.Args[0])
+		os.Exit(usageExitCode)
+	}
+	fmt.Print(routeKey(os.Args[1]))
+}
+
+// routeKey returns the table-route key for tableName.  It mirrors
+// `dynamoRouteTableKey(encodeDynamoSegment(tableName))` from the
+// adapter (adapter/dynamodb.go:8441 — base64.RawURLEncoding,
+// URL-safe charset, no '=' padding).  Extracted from main() for
+// testability.
+func routeKey(tableName string) string {
+	return dynamoRoutePrefix + base64.RawURLEncoding.EncodeToString([]byte(tableName))
+}

--- a/cmd/elastickv-route-key/main_test.go
+++ b/cmd/elastickv-route-key/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRouteKey_PinsAdapterEncoding pins the routeKey output
+// against the adapter's actual encoding so any future drift in
+// either side surfaces here.  The expected values were computed
+// by `base64.RawURLEncoding.EncodeToString([]byte(name))` — the
+// same call adapter/dynamodb.go:8441's encodeDynamoSegment makes.
+//
+// The four M5 table names are the load-bearing case (the launch
+// script's --shardRanges boundary keys come from t2 / t3).  A
+// single-character name is included to catch a class of off-by-one
+// in the encoding (zero-pad behaviour differs between Padded and
+// RawURL variants).
+func TestRouteKey_PinsAdapterEncoding(t *testing.T) {
+	cases := []struct {
+		tableName string
+		want      string
+	}{
+		{"jepsen_append_t1", "!ddb|route|table|amVwc2VuX2FwcGVuZF90MQ"},
+		{"jepsen_append_t2", "!ddb|route|table|amVwc2VuX2FwcGVuZF90Mg"},
+		{"jepsen_append_t3", "!ddb|route|table|amVwc2VuX2FwcGVuZF90Mw"},
+		{"jepsen_append_t4", "!ddb|route|table|amVwc2VuX2FwcGVuZF90NA"},
+		{"x", "!ddb|route|table|eA"}, // single byte → 2-char base64 RawURL (no padding)
+	}
+	for _, tc := range cases {
+		t.Run(tc.tableName, func(t *testing.T) {
+			require.Equal(t, tc.want, routeKey(tc.tableName))
+		})
+	}
+}

--- a/cmd/elastickv-split/main.go
+++ b/cmd/elastickv-split/main.go
@@ -34,8 +34,7 @@ import (
 )
 
 const (
-	dialTimeout = 5 * time.Second
-	rpcTimeout  = 10 * time.Second
+	rpcTimeout = 10 * time.Second
 )
 
 var (
@@ -58,17 +57,20 @@ func run() error {
 		return err
 	}
 
-	dialCtx, dialCancel := context.WithTimeout(context.Background(), dialTimeout)
-	defer dialCancel()
-
 	conn, err := grpc.NewClient(*address, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return errors.Wrapf(err, "dial %s", *address)
 	}
-	defer conn.Close()
-	_ = dialCtx // grpc.NewClient does not need the context but we
-	// keep the dial timeout in case a future enhancement wants to
-	// block on connectivity before issuing the RPC.
+	defer func() {
+		// Surface gRPC close errors on stderr so a resource-leak
+		// or half-closed-stream condition is visible (gemini medium
+		// on PR #911).  Don't promote to a process-level error
+		// since the SplitRange result is already in hand by this
+		// point; a noisy close shouldn't mask a successful RPC.
+		if cerr := conn.Close(); cerr != nil {
+			fmt.Fprintf(os.Stderr, "elastickv-split: close: %v\n", cerr)
+		}
+	}()
 
 	client := pb.NewDistributionClient(conn)
 

--- a/cmd/elastickv-split/main.go
+++ b/cmd/elastickv-split/main.go
@@ -1,0 +1,115 @@
+// elastickv-split is a single-shot CLI that invokes the
+// Distribution.SplitRange RPC on a running elastickv cluster.  Per
+// the Composed-1 M5 design doc
+// (docs/design/2026_06_02_proposed_composed1_m5_jepsen_route_shuffle.md
+// §3.1), the Jepsen route-shuffle nemesis shells out to this tool
+// rather than re-implementing the gRPC client in Clojure: keeping
+// the request construction and the SplitRangeRequest field
+// encoding in Go avoids the silent-mis-routing trap codex P1 #1
+// flagged on PR #905 (base64 RawURLEncoding for table-route keys).
+//
+// Usage:
+//
+//	elastickv-split \
+//	    --address 127.0.0.1:50051 \
+//	    --route-id 100 \
+//	    --split-key '!ddb|route|table|am...' \
+//	    --expected-version 7
+//
+// Non-zero exit on any error so the Jepsen nemesis sees the
+// failure verbatim.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	pb "github.com/bootjp/elastickv/proto"
+	"github.com/cockroachdb/errors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const (
+	dialTimeout = 5 * time.Second
+	rpcTimeout  = 10 * time.Second
+)
+
+var (
+	address         = flag.String("address", "127.0.0.1:50051", "gRPC address of an elastickv server (typically the Distribution leader)")
+	routeID         = flag.Uint64("route-id", 0, "RouteID of the route to split (required)")
+	splitKey        = flag.String("split-key", "", "Split key — must lie strictly inside the route's [Start, End) range; rejected if == Start or == End by validateSplitKey (required)")
+	expectedVersion = flag.Uint64("expected-version", 0, "Expected catalog version for OCC; obtain by calling ListRoutes first (required)")
+)
+
+func main() {
+	flag.Parse()
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "elastickv-split: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	if err := validateFlags(); err != nil {
+		return err
+	}
+
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), dialTimeout)
+	defer dialCancel()
+
+	conn, err := grpc.NewClient(*address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return errors.Wrapf(err, "dial %s", *address)
+	}
+	defer conn.Close()
+	_ = dialCtx // grpc.NewClient does not need the context but we
+	// keep the dial timeout in case a future enhancement wants to
+	// block on connectivity before issuing the RPC.
+
+	client := pb.NewDistributionClient(conn)
+
+	rpcCtx, rpcCancel := context.WithTimeout(context.Background(), rpcTimeout)
+	defer rpcCancel()
+
+	req := &pb.SplitRangeRequest{
+		ExpectedCatalogVersion: *expectedVersion,
+		RouteId:                *routeID,
+		SplitKey:               []byte(*splitKey),
+	}
+	resp, err := client.SplitRange(rpcCtx, req)
+	if err != nil {
+		return errors.Wrap(err, "SplitRange")
+	}
+	printResponse(resp)
+	return nil
+}
+
+func validateFlags() error {
+	switch {
+	case *routeID == 0:
+		return errors.New("--route-id is required and must be > 0")
+	case *splitKey == "":
+		return errors.New("--split-key is required")
+	case *expectedVersion == 0:
+		return errors.New("--expected-version is required and must be > 0")
+	}
+	return nil
+}
+
+func printResponse(resp *pb.SplitRangeResponse) {
+	fmt.Printf("catalog_version: %d\n", resp.GetCatalogVersion())
+	printRoute("left:  ", resp.GetLeft())
+	printRoute("right: ", resp.GetRight())
+}
+
+func printRoute(label string, r *pb.RouteDescriptor) {
+	if r == nil {
+		fmt.Printf("%s<nil>\n", label)
+		return
+	}
+	fmt.Printf("%sroute_id=%d group=%d [%q, %q)\n", label, r.GetRouteId(), r.GetRaftGroupId(), r.GetStart(), r.GetEnd())
+}

--- a/cmd/elastickv-split/main.go
+++ b/cmd/elastickv-split/main.go
@@ -41,7 +41,7 @@ var (
 	address         = flag.String("address", "127.0.0.1:50051", "gRPC address of an elastickv server (typically the Distribution leader)")
 	routeID         = flag.Uint64("route-id", 0, "RouteID of the route to split (required)")
 	splitKey        = flag.String("split-key", "", "Split key — must lie strictly inside the route's [Start, End) range; rejected if == Start or == End by validateSplitKey (required)")
-	expectedVersion = flag.Uint64("expected-version", 0, "Expected catalog version for OCC; obtain by calling ListRoutes first (required)")
+	expectedVersion = flag.Uint64("expected-version", 0, "Expected catalog version for OCC; obtain by calling ListRoutes first (required, must be >= 1 — catalog version is 1-based)")
 )
 
 func main() {

--- a/cmd/elastickv-split/main_test.go
+++ b/cmd/elastickv-split/main_test.go
@@ -59,7 +59,7 @@ func resetFlags(t *testing.T) {
 	// refactor that drops the package-level flags surfaces here
 	// rather than silently no-oping the resets.
 	if routeID == nil || splitKey == nil || expectedVersion == nil || address == nil {
-		t.Fatal(errors.Newf("package-level flag pointers were not initialised"))
+		t.Fatal(errors.New("package-level flag pointers were not initialised"))
 	}
 	*routeID = 0
 	*splitKey = ""

--- a/cmd/elastickv-split/main_test.go
+++ b/cmd/elastickv-split/main_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateFlags_RejectsMissingRequired pins the smoke-test
+// behaviour the M5 design doc (§3.1) names as the only unit-level
+// coverage for cmd/elastickv-split: missing required flags surface
+// a clear error so the Jepsen nemesis fails fast.  The real
+// coverage is the Jepsen run itself (M5b).
+func TestValidateFlags_RejectsMissingRequired(t *testing.T) {
+	cases := []struct {
+		name            string
+		routeID         uint64
+		splitKey        string
+		expectedVersion uint64
+		wantErrSubstr   string
+	}{
+		{"missing route-id", 0, "k", 1, "--route-id is required"},
+		{"missing split-key", 1, "", 1, "--split-key is required"},
+		{"missing expected-version", 1, "k", 0, "--expected-version is required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// validateFlags reads the package-level flag pointers, so
+			// reset them around each subtest to avoid cross-test leakage.
+			resetFlags(t)
+			*routeID = tc.routeID
+			*splitKey = tc.splitKey
+			*expectedVersion = tc.expectedVersion
+			err := validateFlags()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErrSubstr)
+		})
+	}
+}
+
+func TestValidateFlags_AcceptsAllPresent(t *testing.T) {
+	resetFlags(t)
+	*routeID = 42
+	*splitKey = "!ddb|route|table|am-test"
+	*expectedVersion = 7
+	require.NoError(t, validateFlags())
+}
+
+// resetFlags reinitialises the package-level flag pointers around
+// each test so subtests don't leak state through them.  We rebind
+// the globals directly rather than re-parsing argv because the
+// flag package's parse state is global to the process.
+func resetFlags(t *testing.T) {
+	t.Helper()
+	// Sanity-check that the pointers are set (declared at file
+	// init).  errors.Newf rather than t.Fatalf so a future
+	// refactor that drops the package-level flags surfaces here
+	// rather than silently no-oping the resets.
+	if routeID == nil || splitKey == nil || expectedVersion == nil || address == nil {
+		t.Fatal(errors.Newf("package-level flag pointers were not initialised"))
+	}
+	*routeID = 0
+	*splitKey = ""
+	*expectedVersion = 0
+	*address = "127.0.0.1:50051"
+	_ = flag.CommandLine // touch to avoid unused import on future trims
+}

--- a/cmd/elastickv-split/main_test.go
+++ b/cmd/elastickv-split/main_test.go
@@ -55,7 +55,7 @@ func TestValidateFlags_AcceptsAllPresent(t *testing.T) {
 func resetFlags(t *testing.T) {
 	t.Helper()
 	// Sanity-check that the pointers are set (declared at file
-	// init).  errors.Newf rather than t.Fatalf so a future
+	// init).  errors.New rather than t.Fatalf so a future
 	// refactor that drops the package-level flags surfaces here
 	// rather than silently no-oping the resets.
 	if routeID == nil || splitKey == nil || expectedVersion == nil || address == nil {


### PR DESCRIPTION
**Draft — first slice of Composed-1 M5a.** Based on the M5 design doc at `docs/design/2026_06_02_proposed_composed1_m5_jepsen_route_shuffle.md` (merged via #905). I'll iterate the remaining M5a pieces as separate commits on this branch and unmark draft once the workload passes locally.

## What this PR ships

### 1. `cmd/elastickv-split` (design doc §3.1)

Single-shot CLI that invokes `Distribution.SplitRange` against a running cluster. Flags: `--address`, `--route-id`, `--split-key`, `--expected-version`. Prints `catalog_version` + `left`/`right` child route descriptors; non-zero exit on any error so the Jepsen nemesis sees failures verbatim.

Smoke test covers the four required-flag rejection cases + the all-present accept case. The real coverage is the Jepsen run itself per the design doc.

### 2. `cmd/elastickv-route-key` (design doc OQ-7)

Prints the table-route key (`!ddb|route|table|<base64(name)>`) for a given DynamoDB table name. Used by the launch script (still TODO) to compute `--shardRanges` boundary keys without inlining the base64 encoding in shell — codex P1 #1 on #905 flagged that getting the encoding wrong silently mis-routes.

Test pins the output against the adapter's actual encoding (`adapter/dynamodb.go:8441` `encodeDynamoSegment` → `base64.RawURLEncoding`) for all four M5 tables plus a single-char case.

## Remaining M5a work (separate commits on this branch)

- [ ] `jepsen/src/elastickv/dynamodb_multi_table_workload.clj` — new workload variant; N=4 tables; each `TransactWriteItems` writes to ≥2 tables
- [ ] `scripts/run-jepsen-local.sh` (or new `scripts/run-jepsen-m5-local.sh`) — single-process two-group launch per design doc §3.3 (must pass BOTH `--raftGroups` AND `--shardRanges`)
- [ ] Setup-hook verification — `ListRoutes` gRPC client in Clojure, asserts multi-group routing; gated to first node via `(when (= node (first (:nodes test))) …)`
- [ ] Done-when check: workload exercises `dispatchMultiShardTxn` (via server-side log marker or probe metric) and Elle finds zero G1c

## Test plan

- [x] `go test -race ./cmd/elastickv-split ./cmd/elastickv-route-key`
- [x] `golangci-lint run` (0 issues)
- [ ] `./scripts/run-jepsen-m5-local.sh` (once that script + workload land)
- [ ] Elle finds zero G1c on the multi-table workload
