### PR TITLE
backup: #35 - validate name/dir consistency in S3 + DDB reverse encoders

### DIFF
--- a/internal/backup/encode_dynamodb.go
+++ b/internal/backup/encode_dynamodb.go
@@ -119,6 +119,19 @@ func (e *DynamoDBEncoder) encodeTable(b *snapshotBuilder, root *os.Root, tableDi
 	if tableName == "" {
 		return errors.Wrapf(ErrDDBEncodeInvalidSchema, "%s/_schema.json: empty table_name", tableDir)
 	}
+	// Name/dir consistency: the decoder spells the table subdir as
+	// EncodeSegment([]byte(name)) (dynamodb.go:213); a tampered or
+	// hand-rebuilt dump could rename one without the other and the
+	// encoder would otherwise emit DDBTableMeta records under
+	// tableName while reading items from a mismatched on-disk path.
+	// Fail closed so the round-trip invariant
+	// `<tableDir> == EncodeSegment(tableName)` holds for every table
+	// the encoder publishes (#35 follow-up).
+	if want := EncodeSegment([]byte(tableName)); want != tableDir {
+		return errors.Wrapf(ErrDDBEncodeInvalidSchema,
+			"%s/_schema.json: table_name %q encodes to dir %q, not %q (dump tampered or rebuilt by hand?)",
+			tableDir, tableName, want, tableDir)
+	}
 	// A table must have a hash key; fail early here rather than letting
 	// an empty primary key propagate into the item encoder (which
 	// builds item keys from the hash/range attributes).

--- a/internal/backup/encode_dynamodb_test.go
+++ b/internal/backup/encode_dynamodb_test.go
@@ -238,10 +238,15 @@ func TestDDBEncodeRejectsDuplicateGSIName(t *testing.T) {
 
 // TestDDBEncodeRejectsEmptyHashKey pins that a schema with no primary
 // hash key fails closed rather than propagating into the item encoder.
+// The dir intentionally matches EncodeSegment(table_name) so the new
+// name/dir consistency check (#35) does NOT fire first — otherwise
+// this test would silently pass while exercising the wrong guard
+// (claude review #912 caught this regression in the prior revision).
 func TestDDBEncodeRejectsEmptyHashKey(t *testing.T) {
 	t.Parallel()
 	in := t.TempDir()
-	writeDDBSchema(t, in, "tbl", []byte(`{"format_version":1,"table_name":"x","primary_key":{"hash_key":{"name":""}}}`))
+	writeDDBSchema(t, in, EncodeSegment([]byte("x")),
+		[]byte(`{"format_version":1,"table_name":"x","primary_key":{"hash_key":{"name":""}}}`))
 	b := newSnapshotBuilder(ddbEncTS)
 	err := NewDynamoDBEncoder(in).Encode(b)
 	if !errors.Is(err, ErrDDBEncodeInvalidSchema) {

--- a/internal/backup/encode_dynamodb_test.go
+++ b/internal/backup/encode_dynamodb_test.go
@@ -249,6 +249,26 @@ func TestDDBEncodeRejectsEmptyHashKey(t *testing.T) {
 	}
 }
 
+// TestDDBEncodeRejectsNameDirMismatch pins #35: when the on-disk
+// table dir doesn't match EncodeSegment([]byte(_schema.json.table_name)),
+// the encoder fails closed before emitting any keys. Otherwise a
+// hand-edited dump could end up with table records keyed by the
+// JSON's table_name but item bytes pulled from a different
+// filesystem subtree — a silent name/dir consistency violation.
+func TestDDBEncodeRejectsNameDirMismatch(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	// Dir is "wrong-dir" but JSON says table_name = "real". EncodeSegment("real")
+	// is "real" (alphanumeric → unreserved → unchanged), so dir != encoded-name.
+	writeDDBSchema(t, in, "wrong-dir",
+		[]byte(`{"format_version":1,"table_name":"real","primary_key":{"hash_key":{"name":"id","type":"S"}}}`))
+	b := newSnapshotBuilder(ddbEncTS)
+	err := NewDynamoDBEncoder(in).Encode(b)
+	if !errors.Is(err, ErrDDBEncodeInvalidSchema) {
+		t.Fatalf("Encode err = %v, want ErrDDBEncodeInvalidSchema for name/dir mismatch", err)
+	}
+}
+
 // TestDDBEncodeMissingDirIsNoop pins that an absent dynamodb/ dir is a
 // no-op (no entries, no error).
 func TestDDBEncodeMissingDirIsNoop(t *testing.T) {

--- a/internal/backup/encode_s3.go
+++ b/internal/backup/encode_s3.go
@@ -128,6 +128,18 @@ func (e *S3RecordEncoder) encodeBucket(b *snapshotBuilder, root *os.Root, bucket
 	if pub.Name == "" {
 		return errors.Wrapf(ErrS3EncodeInvalidBucket, "%s/_bucket.json: empty bucket name", bucketDir)
 	}
+	// Name/dir consistency: the decoder spells the bucket subdir as
+	// EncodeSegment([]byte(name)) (s3.go:564); an operator (or a
+	// malicious dump) could rename one without the other and the
+	// encoder would otherwise emit keys under pub.Name while reading
+	// objects from a mismatched on-disk path. Fail closed so the
+	// round-trip invariant `<bucketDir> == EncodeSegment(pub.Name)`
+	// holds for every bucket the encoder publishes (#35 follow-up).
+	if want := EncodeSegment([]byte(pub.Name)); want != bucketDir {
+		return errors.Wrapf(ErrS3EncodeInvalidBucket,
+			"%s/_bucket.json: bucket name %q encodes to dir %q, not %q (dump tampered or rebuilt by hand?)",
+			bucketDir, pub.Name, want, bucketDir)
+	}
 	// s3PublicBucket carries Versioning, PolicyJSONString, and
 	// CreationTimeISO, but the internal s3LiveBucketMeta record has no
 	// counterpart for them — they are dump-only metadata the live store

--- a/internal/backup/encode_s3_test.go
+++ b/internal/backup/encode_s3_test.go
@@ -137,6 +137,32 @@ func TestS3EncodeMissingDirIsNoop(t *testing.T) {
 	}
 }
 
+// TestS3EncodeRejectsNameDirMismatch pins #35: when the on-disk bucket
+// dir doesn't match EncodeSegment([]byte(_bucket.json.name)), the
+// encoder fails closed before emitting any keys. Otherwise a
+// hand-edited dump could end up with bucket-meta records keyed by
+// the JSON's name but object bytes pulled from a different
+// filesystem subtree — silent name/dir consistency violation.
+func TestS3EncodeRejectsNameDirMismatch(t *testing.T) {
+	t.Parallel()
+	in := t.TempDir()
+	// Plant the dump under s3/wrong-dir/_bucket.json with name="real".
+	// EncodeSegment("real") is "real" (unreserved chars), so dir != name.
+	path := filepath.Join(in, "s3", "wrong-dir", "_bucket.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path,
+		[]byte(`{"format_version":1,"name":"real"}`), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	b := newSnapshotBuilder(s3EncTS)
+	err := NewS3RecordEncoder(in).Encode(b)
+	if !errors.Is(err, ErrS3EncodeInvalidBucket) {
+		t.Fatalf("Encode err = %v, want ErrS3EncodeInvalidBucket for name/dir mismatch", err)
+	}
+}
+
 // TestS3EncodeRejectsNonDirectoryBucketEntry pins codex P2 v32 #904:
 // when an entry directly under s3/ is a regular file or symlink
 // rather than a bucket directory, the encoder must fail closed with


### PR DESCRIPTION
## Summary
- S3 (`encodeBucket`) and DDB (`encodeTable`) now check that the on-disk subdirectory matches `EncodeSegment([]byte(name))` from `_bucket.json` / `_schema.json` before emitting any records.
- Closes task #35 (the M4 + M5 follow-up the original session-summary tracked).

## Background

The reverse encoders use two identifiers for the same logical entity:
- On-disk subdir: `s3/<bucketDir>/`, `dynamodb/<tableDir>/` — decoder spells as `EncodeSegment([]byte(name))`.
- Embedded name in `_bucket.json` / `_schema.json` — encoder uses for MVCC keys (`s3keys.BucketMetaKey(pub.Name)`, base64'd `tableName`).

Until now, both sides were trusted independently. A tampered or hand-rebuilt dump that renamed the directory without touching the JSON (or vice versa) would silently emit records keyed by the JSON name while pulling object / item bytes from a mismatched filesystem path — a name/dir consistency violation that splits a single restore artifact across two identities.

## Fix

After the existing empty-name guard, both encoders verify `EncodeSegment([]byte(name)) == <dir>`. Mismatch fails closed with the existing per-adapter sentinel (`ErrS3EncodeInvalidBucket` / `ErrDDBEncodeInvalidSchema`), and the error message names both the JSON value and the encoded form so the operator can correct the dump.

## Caller audit (CLAUDE.md semantic-change rule)

- `encodeBucket` (S3): success path gains one new fail-closed check; sole production caller is `S3RecordEncoder.Encode`.
- `encodeTable` (DDB): success path gains one new fail-closed check; sole production caller is `DynamoDBEncoder.Encode`.
- Both checks reuse existing per-adapter sentinels, so `runAdapterEncoders`' `errors.Mark(ErrEncodeAdapterData)` wrap still routes failures through the CLI's exit-2 classification — no new sentinel needed in `classifyEncodeError`.

## Self-review of code changes (5 lenses)

1. **Data loss** — Stricter validation; no commit/apply path touched. No data-loss surface.
2. **Concurrency / distributed failures** — Encoder is single-process / single-goroutine on the input tree. No new concurrency surface.
3. **Performance** — One extra `EncodeSegment` call and string compare per bucket / per table. Negligible.
4. **Data consistency** — This IS the data-consistency improvement. The check enforces the round-trip invariant `<dir> == EncodeSegment(name)` for every published record.
5. **Test coverage** — Two new tests (one per adapter) pin the rejection. Existing positive tests use `EncodeSegment` for the dir spelling, so they remain green; existing rejection tests trip earlier guards, also green.

## Test plan
- [x] `go test -race ./internal/backup/... ./cmd/elastickv-snapshot-encode/...`
- [x] `golangci-lint --config=.golangci.yaml run`
- [ ] Bot review cycle (claude / codex / CodeRabbit)
