### PR TITLE
feat(jepsen): M5a — dynamodb-append-multi-table-workload

### DIFF
--- a/jepsen/src/elastickv/dynamodb_multi_table_workload.clj
+++ b/jepsen/src/elastickv/dynamodb_multi_table_workload.clj
@@ -292,6 +292,13 @@
       (assoc this :ddb (make-ddb-client host port))))
 
   (setup! [this _test]
+    ;; No DescribeTable poll loop is needed: elastickv's adapter
+    ;; returns TableStatus=ACTIVE synchronously in the CreateTable
+    ;; response (adapter/dynamodb.go:779-783), so the table is
+    ;; queryable as soon as create-one-table! returns.  Real DynamoDB's
+    ;; CreateTable is async and would need a poll; if this workload is
+    ;; ever pointed at a real DynamoDB endpoint, add a DescribeTable
+    ;; loop here (claude[bot] design note on PR #916 c46b2b5e).
     (create-all-tables! ddb))
 
   (teardown! [_this _test]

--- a/jepsen/src/elastickv/dynamodb_multi_table_workload.clj
+++ b/jepsen/src/elastickv/dynamodb_multi_table_workload.clj
@@ -145,6 +145,31 @@
   (doseq [t table-names]
     (create-one-table! ddb t)))
 
+(defn- delete-one-table!
+  "Delete one of the N tables; ignore ResourceNotFoundException so
+   teardown! is idempotent across cluster states (e.g. a re-run after
+   a partial setup failure)."
+  [ddb tname]
+  (try
+    (ddb-invoke! ddb :DeleteTable {:TableName tname})
+    (catch clojure.lang.ExceptionInfo e
+      (when-not (= "ResourceNotFoundException" (:type (ex-data e)))
+        (throw e)))))
+
+(defn- delete-all-tables!
+  "Delete every table this workload owns.  Idempotent.
+
+   Without this, leftover Items from a previous run remain in the four
+   tables across runs; the next run's TransactGetItems pre-read picks
+   them up as snapshot values, the txn's :r mops report those values
+   to Jepsen, and Elle sees a history that contains writes it never
+   generated — leading to spurious G-single / G1c false positives
+   (claude[bot] medium on PR #916).  Cleaning up here keeps each run's
+   history closed under the writes Elle actually generated."
+  [ddb]
+  (doseq [t table-names]
+    (delete-one-table! ddb t)))
+
 (defn- list-attr
   "Convert a Clojure vector of longs to a DynamoDB {:L [...]} attribute."
   [vs]
@@ -191,6 +216,13 @@
                               :Key       {pk-attr {:S (key->pk k)}}}})
                      ks-vec)
         resp   (ddb-invoke! ddb :TransactGetItems {:TransactItems items})]
+    ;; DynamoDB guarantees :Responses is positionally aligned with the
+    ;; :TransactItems we sent.  Assert it so a future cognitect SDK
+    ;; that ever normalises / re-orders the response surfaces loudly
+    ;; rather than silently corrupting the snapshot map (claude[bot]
+    ;; low on PR #916).
+    (assert (= (count ks-vec) (count (:Responses resp)))
+            "TransactGetItems :Responses must be positionally aligned with the requested items")
     (into {}
           (map (fn [k entry] [k (read-list-attr (:Item entry))])
                ks-vec
@@ -262,7 +294,11 @@
   (setup! [this _test]
     (create-all-tables! ddb))
 
-  (teardown! [_this _test])
+  (teardown! [_this _test]
+    ;; Delete every table this workload created so the next run starts
+    ;; with empty Items.  See delete-all-tables! for the Elle-history
+    ;; rationale (claude[bot] medium on PR #916).
+    (delete-all-tables! ddb))
 
   (close! [this _test]
     (when ddb (aws/stop ddb))
@@ -340,17 +376,28 @@
   "Builds the multi-table list-append workload.  The append/test
    generator's integer keys are routed through key->table-name +
    key->pk to land deterministically on one of N=4 tables, exercising
-   cross-table TransactGetItems / TransactWriteItems."
+   cross-table TransactGetItems / TransactWriteItems.
+
+   Refuses to build when (:key-count opts) is not a multiple of
+   num-tables: an uneven split silently gives some tables fewer
+   keys (so 1-key txns on those tables never trigger multi-group
+   dispatch — claude[bot] low on PR #916).  The default 12 satisfies
+   this; tunable via --key-count from the CLI."
   [opts]
-  (let [workload (append/test {:key-count          (or (:key-count opts) 12)
-                               :min-txn-length     1
-                               :max-txn-length     (or (:max-txn-length opts) 4)
-                               :max-writes-per-key (or (:max-writes-per-key opts) 128)
-                               :consistency-models [:strict-serializable]})
-        client   (->DynamoDBMultiTableClient (or (:node->port opts)
-                                                 (zipmap default-nodes (repeat 8000)))
-                                             nil)]
-    (assoc workload :client client)))
+  (let [key-count (or (:key-count opts) 12)]
+    (assert (zero? (mod key-count num-tables))
+            (str "key-count (" key-count
+                 ") must be a multiple of num-tables (" num-tables
+                 ") so keys distribute evenly across all tables"))
+    (let [workload (append/test {:key-count          key-count
+                                 :min-txn-length     1
+                                 :max-txn-length     (or (:max-txn-length opts) 4)
+                                 :max-writes-per-key (or (:max-writes-per-key opts) 128)
+                                 :consistency-models [:strict-serializable]})
+          client   (->DynamoDBMultiTableClient (or (:node->port opts)
+                                                   (zipmap default-nodes (repeat 8000)))
+                                               nil)]
+      (assoc workload :client client))))
 
 (defn elastickv-dynamodb-multi-table-test
   "Builds a Jepsen test map driving the multi-table list-append workload

--- a/jepsen/src/elastickv/dynamodb_multi_table_workload.clj
+++ b/jepsen/src/elastickv/dynamodb_multi_table_workload.clj
@@ -1,0 +1,452 @@
+(ns elastickv.dynamodb-multi-table-workload
+  "Composed-1 M5a multi-table variant of the DynamoDB list-append workload.
+
+   Why a separate workload exists (see
+   docs/design/2026_06_02_proposed_composed1_m5_jepsen_route_shuffle.md §3.3):
+   the single-table elastickv.dynamodb-workload cannot exercise the 2PC
+   path because kv/shard_key.go normalises every DynamoDB table-meta,
+   item, and GSI key for one table to a single per-table route key
+   (`!ddb|route|table|<base64(name)>`).  Routing always lands on one
+   shard regardless of partition-key value, so dispatchMultiShardTxn /
+   commitSecondaryTxns / the ErrTxnSecondaryRouteShiftedAfterPrimaryCommit
+   sentinel never fire.
+
+   This workload creates N=4 tables (jepsen_append_t1 … jepsen_append_t4)
+   and uses a deterministic Elle-integer-key → (table, pk) mapping so:
+
+   - each integer key k always lands at the same (table, pk) pair
+     (Elle's append checker still sees a single key namespace);
+   - default Elle txns of up to 4 mops with key-count=12 span all 4
+     tables on every multi-op txn (k mod 4 distributes keys evenly);
+   - the launch script's --shardRanges places t1-t2 in group 1 and
+     t3-t4 in group 2, so any txn touching a key with k mod 4 in
+     {0,1} AND a key with k mod 4 in {2,3} fans out to BOTH Raft
+     groups and exercises dispatchMultiShardTxn.
+
+   The TransactGetItems pre-read + TransactWriteItems atomic write
+   pattern is intentionally identical to elastickv.dynamodb-workload so
+   any G1c or G-single anomaly is attributable to the multi-shard 2PC
+   path, not to a workload-shape difference.  The two files
+   intentionally duplicate small helpers; refactoring shared helpers
+   into a third namespace would couple the workloads through a
+   maintained API and obscure the side-by-side comparability that is
+   the point of running both."
+  (:gen-class)
+  (:require [clojure.string :as str]
+            [cognitect.aws.client.api :as aws]
+            [cognitect.aws.credentials :as creds]
+            [elastickv.cli :as cli]
+            [elastickv.db :as ekdb]
+            [jepsen [client :as client]
+                    [generator :as gen]
+                    [net :as net]]
+            [jepsen.control :as control]
+            [jepsen.db :as jdb]
+            [jepsen.nemesis :as nemesis]
+            [jepsen.nemesis.combined :as combined]
+            [jepsen.os :as os]
+            [jepsen.os.debian :as debian]
+            [jepsen.tests.cycle.append :as append]))
+
+;; ---------------------------------------------------------------------------
+;; Multi-table layout
+;; ---------------------------------------------------------------------------
+
+(def ^:private num-tables   4)
+(def ^:private table-prefix "jepsen_append_t")
+(def ^:private pk-attr      "pk")
+(def ^:private val-attr     "val")
+
+(def ^:private table-names
+  "The N table names this workload owns.  1-indexed to match the
+   launch-script's --shardRanges layout (tables 1-2 → group 1,
+   3-4 → group 2).  Used by create-all-tables! and key-routing."
+  (mapv (fn [i] (str table-prefix i)) (range 1 (inc num-tables))))
+
+(defn- key->table-idx
+  "Routes Elle's integer key k to one of 1..N tables.  Pure (mod k N)+1
+   so the routing is stable across runs and the Elle checker sees a
+   single key namespace.  With N=4 and Elle's default key-count=12,
+   keys [0..11] distribute evenly across tables [1,2,3,4,…]; a 4-mop
+   txn naturally spans all 4 tables."
+  [k]
+  (inc (mod k num-tables)))
+
+(defn- key->table-name [k]
+  (str table-prefix (key->table-idx k)))
+
+(defn- key->pk
+  "Returns the DynamoDB partition-key string for Elle's integer key k.
+   Different k values that collide on the same table get distinct pks
+   (e.g. k=0 → (t1,\"0\"); k=4 → (t1,\"1\")), so each Elle key still
+   maps to a unique (table, pk) storage location."
+  [k]
+  (str (quot k num-tables)))
+
+;; ---------------------------------------------------------------------------
+;; Client construction
+;; ---------------------------------------------------------------------------
+
+(defn- make-ddb-client
+  "See elastickv.dynamodb-workload/make-ddb-client — the rationale (dummy
+   creds + fixed region to keep the SDK away from environment lookups)
+   is identical.  Duplicated rather than imported so the two workloads
+   stay side-by-side comparable."
+  [host port]
+  (aws/client
+    {:api                  :dynamodb
+     :region               "us-east-1"
+     :credentials-provider (creds/basic-credentials-provider
+                             {:access-key-id     "dummy"
+                              :secret-access-key "dummy"})
+     :endpoint-override    {:protocol :http
+                            :hostname  host
+                            :port      port}}))
+
+;; ---------------------------------------------------------------------------
+;; Low-level DynamoDB helpers
+;; ---------------------------------------------------------------------------
+
+(defn- anomaly? [resp]
+  (contains? resp :cognitect.anomalies/category))
+
+(defn- ddb-invoke!
+  [ddb-client op request]
+  (let [resp (aws/invoke ddb-client {:op op :request request})]
+    (if (anomaly? resp)
+      (let [err-type (:__type resp)
+            category (:cognitect.anomalies/category resp)
+            msg      (or (:message resp)
+                         (:Message resp)
+                         (:cognitect.anomalies/message resp)
+                         "")]
+        (throw (ex-info (str "DynamoDB " (or err-type category) ": " msg)
+                        {:type     err-type
+                         :category category
+                         :resp     resp})))
+      resp)))
+
+(defn- create-one-table!
+  "Create one of the N tables; ignore ResourceInUseException."
+  [ddb tname]
+  (try
+    (ddb-invoke! ddb :CreateTable
+                 {:TableName             tname
+                  :KeySchema             [{:AttributeName pk-attr :KeyType "HASH"}]
+                  :AttributeDefinitions  [{:AttributeName pk-attr :AttributeType "S"}]
+                  :ProvisionedThroughput {:ReadCapacityUnits 5 :WriteCapacityUnits 5}})
+    (catch clojure.lang.ExceptionInfo e
+      (when-not (= "ResourceInUseException" (:type (ex-data e)))
+        (throw e)))))
+
+(defn- create-all-tables!
+  "Create every table this workload owns.  Idempotent."
+  [ddb]
+  (doseq [t table-names]
+    (create-one-table! ddb t)))
+
+(defn- list-attr
+  "Convert a Clojure vector of longs to a DynamoDB {:L [...]} attribute."
+  [vs]
+  {:L (mapv (fn [n] {:N (str n)}) vs)})
+
+(defn- read-list-attr
+  "Extract the :val list from a DynamoDB Item map (or nil if absent)."
+  [item]
+  (when-let [lv (get-in item [(keyword val-attr) :L])]
+    (mapv #(Long/parseLong (:N %)) lv)))
+
+(defn- dynamo-append!
+  "Append single value v to the list stored at Elle key k.  Routes to
+   the table for k and writes at (table, pk)."
+  [ddb k v]
+  (ddb-invoke! ddb :UpdateItem
+               {:TableName                 (key->table-name k)
+                :Key                       {pk-attr {:S (key->pk k)}}
+                :UpdateExpression          "SET #v = list_append(if_not_exists(#v, :empty), :val)"
+                :ExpressionAttributeNames  {"#v" val-attr}
+                :ExpressionAttributeValues {":empty" {:L []}
+                                            ":val"   {:L [{:N (str v)}]}}})
+  nil)
+
+(defn- dynamo-read
+  "ConsistentRead from k's table.  Returns vector of longs, or nil if
+   the item does not exist."
+  [ddb k]
+  (let [resp (ddb-invoke! ddb :GetItem
+                          {:TableName      (key->table-name k)
+                           :Key            {pk-attr {:S (key->pk k)}}
+                           :ConsistentRead true})]
+    (read-list-attr (:Item resp))))
+
+(defn- dynamo-transact-get!
+  "Atomically read all Elle keys in ks via TransactGetItems, with each
+   Get pointing at its key's owning table.  TransactGetItems supports
+   cross-table reads in a single call, which is exactly the multi-shard
+   2PC pre-read path this workload is designed to exercise."
+  [ddb ks]
+  (let [ks-vec (vec ks)
+        items  (mapv (fn [k]
+                       {:Get {:TableName (key->table-name k)
+                              :Key       {pk-attr {:S (key->pk k)}}}})
+                     ks-vec)
+        resp   (ddb-invoke! ddb :TransactGetItems {:TransactItems items})]
+    (into {}
+          (map (fn [k entry] [k (read-list-attr (:Item entry))])
+               ks-vec
+               (:Responses resp)))))
+
+(defn- dynamo-transact-write!
+  "Cross-table TransactWriteItems.  Mirrors the single-table workload's
+   `dynamo-transact-write!`:
+
+   - one Update action per written key (snapshot-conditioned);
+   - one ConditionCheck action per read-but-not-written key.
+
+   The only delta is TableName: each action carries the table that
+   the key routes to, so a single TransactWriteItems call may span
+   1-N tables and (with the launch-script's --shardRanges) up to two
+   Raft groups → dispatchMultiShardTxn + commitSecondaryTxns + the
+   ErrTxnSecondaryRouteShiftedAfterPrimaryCommit sentinel."
+  [ddb writes snapshot]
+  (let [by-key     (reduce (fn [acc [_ k v]]
+                             (update acc k (fnil conj []) v))
+                           (array-map)
+                           writes)
+        write-keys (set (keys by-key))
+        read-only  (remove write-keys (keys snapshot))
+        checks
+        (mapv (fn [k]
+                (let [v (get snapshot k)]
+                  {:ConditionCheck
+                   (merge {:TableName (key->table-name k)
+                           :Key       {pk-attr {:S (key->pk k)}}}
+                          (if (nil? v)
+                            {:ConditionExpression      "attribute_not_exists(#pk)"
+                             :ExpressionAttributeNames {"#pk" pk-attr}}
+                            {:ConditionExpression       "#v = :cv"
+                             :ExpressionAttributeNames  {"#v" val-attr}
+                             :ExpressionAttributeValues {":cv" (list-attr v)}}))}))
+              read-only)
+        updates
+        (mapv (fn [[k vs]]
+                (let [v (get snapshot k)
+                      attr-vals (merge {":empty" {:L []}
+                                        ":val"   (list-attr vs)}
+                                       (when-not (nil? v) {":cv" (list-attr v)}))]
+                  {:Update
+                   (merge {:TableName                 (key->table-name k)
+                           :Key                       {pk-attr {:S (key->pk k)}}
+                           :UpdateExpression          "SET #v = list_append(if_not_exists(#v, :empty), :val)"
+                           :ExpressionAttributeNames  {"#v" val-attr}
+                           :ExpressionAttributeValues attr-vals}
+                          (if (nil? v)
+                            {:ConditionExpression "attribute_not_exists(#v)"}
+                            {:ConditionExpression "#v = :cv"}))}))
+              by-key)]
+    (ddb-invoke! ddb :TransactWriteItems
+                 {:TransactItems (into checks updates)})))
+
+;; ---------------------------------------------------------------------------
+;; Jepsen client
+;; ---------------------------------------------------------------------------
+
+(defrecord DynamoDBMultiTableClient [node->port ddb]
+  client/Client
+
+  (open! [this test node]
+    (let [port (get node->port node 8000)
+          host (or (:dynamo-host test) (name node))]
+      (assoc this :ddb (make-ddb-client host port))))
+
+  (setup! [this _test]
+    (create-all-tables! ddb))
+
+  (teardown! [_this _test])
+
+  (close! [this _test]
+    (when ddb (aws/stop ddb))
+    (assoc this :ddb nil))
+
+  (invoke! [_this _test op]
+    (try
+      (case (:f op)
+        :txn
+        (let [mops (:value op)]
+          (if (= 1 (count mops))
+            ;; Single micro-op: individual UpdateItem / GetItem on the
+            ;; key's owning table.
+            (let [[f k v :as mop] (first mops)]
+              (assoc op :type :ok
+                        :value [(case f
+                                  :append (do (dynamo-append! ddb k v) mop)
+                                  :r      [f k (dynamo-read ddb k)])]))
+
+            ;; Multi-op: atomic cross-table TransactGetItems pre-read,
+            ;; then RYOW simulation, then cross-table TransactWriteItems.
+            (let [all-keys      (into #{} (map second mops))
+                  snapshot      (dynamo-transact-get! ddb all-keys)
+                  local-appends (volatile! {})
+                  value' (mapv (fn [[f k v :as mop]]
+                                 (case f
+                                   :append (do (vswap! local-appends update k (fnil conj []) v)
+                                               mop)
+                                   :r      (let [base    (get snapshot k)
+                                                 pending (get @local-appends k [])]
+                                             [f k (if (and (nil? base) (empty? pending))
+                                                    nil
+                                                    (into (or base []) pending))])))
+                               mops)
+                  writes (filterv (fn [[f _ _]] (= f :append)) mops)]
+              (when (seq writes) (dynamo-transact-write! ddb writes snapshot))
+              (assoc op :type :ok :value value')))))
+
+      (catch clojure.lang.ExceptionInfo e
+        (let [data     (ex-data e)
+              err-type (:type data)
+              category (:category data)]
+          (cond
+            (and (nil? err-type)
+                 (#{:cognitect.anomalies/fault
+                    :cognitect.anomalies/unavailable} category))
+            (assoc op :type :info :error :network-error)
+
+            (contains? #{"ConditionalCheckFailedException"
+                         "InternalServerError"} err-type)
+            (assoc op :type :info :error (str err-type))
+
+            (= "TransactionCanceledException" err-type)
+            (assoc op :type :fail :error (str err-type))
+
+            (= "ValidationException" err-type)
+            (assoc op :type :fail
+                      :error (str err-type ": "
+                                  (get-in data [:resp :message]
+                                    (get-in data [:resp :Message] ""))))
+
+            :else
+            (assoc op :type :info :error (.getMessage e)))))
+
+      (catch Exception e
+        (assoc op :type :info :error (.getMessage e))))))
+
+;; ---------------------------------------------------------------------------
+;; Workload & Test builders
+;; ---------------------------------------------------------------------------
+
+(def default-nodes ["n1" "n2" "n3" "n4" "n5"])
+
+(defn dynamodb-append-multi-table-workload
+  "Builds the multi-table list-append workload.  The append/test
+   generator's integer keys are routed through key->table-name +
+   key->pk to land deterministically on one of N=4 tables, exercising
+   cross-table TransactGetItems / TransactWriteItems."
+  [opts]
+  (let [workload (append/test {:key-count          (or (:key-count opts) 12)
+                               :min-txn-length     1
+                               :max-txn-length     (or (:max-txn-length opts) 4)
+                               :max-writes-per-key (or (:max-writes-per-key opts) 128)
+                               :consistency-models [:strict-serializable]})
+        client   (->DynamoDBMultiTableClient (or (:node->port opts)
+                                                 (zipmap default-nodes (repeat 8000)))
+                                             nil)]
+    (assoc workload :client client)))
+
+(defn elastickv-dynamodb-multi-table-test
+  "Builds a Jepsen test map driving the multi-table list-append workload
+   against an elastickv cluster.  The cluster is expected to launch with
+   --raftGroups (≥2) and --shardRanges placing the table-route keys
+   across groups so cross-table txns actually fan out to multiple Raft
+   groups — see the design doc §3.3 and the M5a launch script."
+  ([] (elastickv-dynamodb-multi-table-test {}))
+  ([opts]
+   (let [nodes        (or (:nodes opts) default-nodes)
+         dynamo-ports (or (:dynamo-ports opts) (repeat (count nodes) (or (:dynamo-port opts) 8000)))
+         node->port   (or (:node->port opts) (cli/ports->node-map dynamo-ports nodes))
+         local?       (:local opts)
+         db           (if local?
+                        jdb/noop
+                        (ekdb/db {:grpc-port    (or (:grpc-port opts) 50051)
+                                  :redis-port   (or (:redis-port opts) 6379)
+                                  :dynamo-port  node->port
+                                  :raft-groups  (:raft-groups opts)
+                                  :shard-ranges (:shard-ranges opts)}))
+         rate         (double (or (:rate opts) 5))
+         time-limit   (or (:time-limit opts) 30)
+         faults       (if local?
+                        []
+                        (cli/normalize-faults (or (:faults opts) [:partition :kill])))
+         nemesis-p    (when-not local?
+                        (combined/nemesis-package {:db       db
+                                                   :faults   faults
+                                                   :interval (or (:fault-interval opts) 40)}))
+         nemesis-gen  (if nemesis-p
+                        (:generator nemesis-p)
+                        (gen/once {:type :info :f :noop}))
+         workload     (dynamodb-append-multi-table-workload (assoc opts :node->port node->port))]
+     (merge workload
+            {:name            (or (:name opts) "elastickv-dynamodb-append-multi-table")
+             :nodes           nodes
+             :db              db
+             :dynamo-host     (:dynamo-host opts)
+             :os              (if local? os/noop debian/os)
+             :net             (if local? net/noop net/iptables)
+             :ssh             (merge {:username               "vagrant"
+                                      :private-key-path       "/home/vagrant/.ssh/id_rsa"
+                                      :strict-host-key-checking false}
+                                     (when local? {:dummy true})
+                                     (:ssh opts))
+             :remote          control/ssh
+             :nemesis         (if nemesis-p (:nemesis nemesis-p) nemesis/noop)
+             :final-generator nil
+             :concurrency     (or (:concurrency opts) 5)
+             :generator       (->> (:generator workload)
+                                   (gen/nemesis nemesis-gen)
+                                   (gen/stagger (/ rate))
+                                   (gen/time-limit time-limit))}))))
+
+;; ---------------------------------------------------------------------------
+;; CLI
+;; ---------------------------------------------------------------------------
+
+(def dynamo-cli-opts
+  "DynamoDB-specific CLI options, appended to common opts.  Same
+   surface as elastickv.dynamodb-workload's CLI so the same shell
+   invocations work against either workload."
+  [[nil "--dynamo-ports PORTS" "Comma-separated DynamoDB ports (one per node)."
+    :default nil
+    :parse-fn (fn [s]
+                (->> (str/split s #",")
+                     (remove str/blank?)
+                     (mapv #(Integer/parseInt %))))]
+   [nil "--dynamo-port PORT" "DynamoDB port (applied to all nodes)."
+    :default 8000
+    :parse-fn #(Integer/parseInt %)]
+   [nil "--redis-port PORT" "Redis port."
+    :default 6379
+    :parse-fn #(Integer/parseInt %)]
+   [nil "--max-txn-length N" "Maximum number of micro-ops per transaction."
+    :default nil
+    :parse-fn #(Integer/parseInt %)]])
+
+(defn- prepare-dynamo-opts
+  "Transform parsed CLI options into the map expected by
+   elastickv-dynamodb-multi-table-test."
+  [options]
+  (let [dynamo-ports (:dynamo-ports options)
+        options      (cli/parse-common-opts options dynamo-ports)
+        node->port   (if dynamo-ports
+                       (cli/ports->node-map dynamo-ports (:nodes options))
+                       (zipmap (:nodes options) (repeat (:dynamo-port options))))]
+    (assoc options
+      :dynamo-host (:host options)
+      :node->port  node->port
+      :dynamo-port (:dynamo-port options)
+      :redis-port  (:redis-port options))))
+
+(defn -main
+  [& args]
+  (cli/run-workload! args
+                     (into cli/common-cli-opts dynamo-cli-opts)
+                     prepare-dynamo-opts
+                     elastickv-dynamodb-multi-table-test))

--- a/jepsen/test/elastickv/dynamodb_multi_table_workload_test.clj
+++ b/jepsen/test/elastickv/dynamodb_multi_table_workload_test.clj
@@ -58,7 +58,7 @@
   (is (= "jepsen_append_t1" (key->table-name 4))
       "wraparound: k=4 must hit the same table as k=0"))
 
-(deftest key-routing-pks-disambiguate_colliding_keys
+(deftest key-routing-pks-disambiguate-colliding-keys
   ;; k=0 and k=4 land on the same table (t1) but must have distinct pks
   ;; so each Elle key maps to a unique storage location.
   (is (= "0" (key->pk 0)))
@@ -67,7 +67,27 @@
   (is (not= (key->pk 0) (key->pk 4))
       "colliding-table keys must have distinct pks"))
 
-(deftest multi-op-txn-spans_multiple_groups
+(deftest rejects-key-count-not-divisible-by-num-tables
+  ;; The workload's distribution guarantee depends on key-count % N
+  ;; = 0.  A CLI invocation that passes --key-count 10 (or any value
+  ;; that splits unevenly across 4 tables) would silently leave some
+  ;; tables with fewer keys, breaking the multi-group-span invariant.
+  ;; The construction-time assertion surfaces this loudly
+  ;; (claude[bot] low on PR #916).
+  (is (thrown? AssertionError
+        (workload/dynamodb-append-multi-table-workload {:key-count 10}))
+      "key-count not divisible by 4 must fail-fast at construction")
+  (is (thrown? AssertionError
+        (workload/dynamodb-append-multi-table-workload {:key-count 7}))
+      "odd key-count must fail-fast"))
+
+(deftest accepts-divisible-key-counts
+  ;; Sanity-check that the assertion does NOT reject valid values.
+  (is (map? (workload/dynamodb-append-multi-table-workload {:key-count 4})))
+  (is (map? (workload/dynamodb-append-multi-table-workload {:key-count 8})))
+  (is (map? (workload/dynamodb-append-multi-table-workload {:key-count 16}))))
+
+(deftest multi-op-txn-spans-multiple-groups
   ;; The M5a launch script places tables {1,2} in group 1 and {3,4}
   ;; in group 2.  A default 4-mop txn with keys [0,1,2,3] must
   ;; touch BOTH groups — that is the entire point of the multi-table

--- a/jepsen/test/elastickv/dynamodb_multi_table_workload_test.clj
+++ b/jepsen/test/elastickv/dynamodb_multi_table_workload_test.clj
@@ -1,0 +1,82 @@
+(ns elastickv.dynamodb-multi-table-workload-test
+  (:require [clojure.test :refer :all]
+            [jepsen.client :as client]
+            [elastickv.dynamodb-multi-table-workload :as workload]))
+
+(deftest builds-test-spec
+  (let [test-map (workload/elastickv-dynamodb-multi-table-test {})]
+    (is (map? test-map))
+    (is (= "elastickv-dynamodb-append-multi-table" (:name test-map)))
+    (is (= ["n1" "n2" "n3" "n4" "n5"] (:nodes test-map)))))
+
+(deftest custom-options-override-defaults
+  (let [test-map (workload/elastickv-dynamodb-multi-table-test
+                   {:time-limit 60
+                    :concurrency 10
+                    :dynamo-port 9000})]
+    (is (= 10 (:concurrency test-map)))))
+
+(deftest host-override-creates-client
+  (let [test-map (workload/elastickv-dynamodb-multi-table-test
+                   {:dynamo-host "127.0.0.1"
+                    :node->port  {"n1" 8000 "n2" 8001}})
+        c        (:client test-map)
+        opened   (client/open! c test-map "n1")]
+    (is (some? (:ddb opened)))))
+
+;; ---------------------------------------------------------------------------
+;; Key routing — the load-bearing M5a invariant
+;; ---------------------------------------------------------------------------
+
+;; key->table-idx, key->table-name and key->pk are private inside the
+;; workload namespace, but the routing they encode IS the M5a contract
+;; with the launch script's --shardRanges (tables 1-2 → group 1, 3-4
+;; → group 2).  Access them via var here so a future change to the
+;; routing surfaces in this test rather than as a silent G1c during a
+;; Jepsen run.
+
+(def ^:private key->table-idx  (var-get #'workload/key->table-idx))
+(def ^:private key->table-name (var-get #'workload/key->table-name))
+(def ^:private key->pk         (var-get #'workload/key->pk))
+
+(deftest key-routing-distributes-across-all-tables
+  ;; Elle's default key-count is 12.  With N=4 tables and the
+  ;; (mod k N)+1 routing, keys [0..11] must land 3-per-table.
+  ;; If this fails, the launch script's --shardRanges layout no
+  ;; longer makes every Elle key reachable.
+  (let [table-counts (->> (range 12)
+                          (map key->table-idx)
+                          frequencies)]
+    (is (= {1 3, 2 3, 3 3, 4 3} table-counts)
+        "12 keys must distribute evenly across 4 tables (3 per table)")))
+
+(deftest key-routing-table-name-matches-prefix
+  (is (= "jepsen_append_t1" (key->table-name 0)))
+  (is (= "jepsen_append_t2" (key->table-name 1)))
+  (is (= "jepsen_append_t3" (key->table-name 2)))
+  (is (= "jepsen_append_t4" (key->table-name 3)))
+  (is (= "jepsen_append_t1" (key->table-name 4))
+      "wraparound: k=4 must hit the same table as k=0"))
+
+(deftest key-routing-pks-disambiguate_colliding_keys
+  ;; k=0 and k=4 land on the same table (t1) but must have distinct pks
+  ;; so each Elle key maps to a unique storage location.
+  (is (= "0" (key->pk 0)))
+  (is (= "1" (key->pk 4)))
+  (is (= "2" (key->pk 8)))
+  (is (not= (key->pk 0) (key->pk 4))
+      "colliding-table keys must have distinct pks"))
+
+(deftest multi-op-txn-spans_multiple_groups
+  ;; The M5a launch script places tables {1,2} in group 1 and {3,4}
+  ;; in group 2.  A default 4-mop txn with keys [0,1,2,3] must
+  ;; touch BOTH groups — that is the entire point of the multi-table
+  ;; workload (otherwise dispatchMultiShardTxn never fires).
+  (let [keys-in-group1 #{1 2}
+        keys-in-group2 #{3 4}
+        sample-txn-keys [0 1 2 3]
+        tables  (map key->table-idx sample-txn-keys)
+        hits-g1 (some keys-in-group1 tables)
+        hits-g2 (some keys-in-group2 tables)]
+    (is hits-g1 "sample 4-key txn must touch at least one table in group 1")
+    (is hits-g2 "sample 4-key txn must touch at least one table in group 2")))


### PR DESCRIPTION
**Draft** — second slice of Composed-1 M5a per `docs/design/2026_06_02_proposed_composed1_m5_jepsen_route_shuffle.md` §3.3. Follows #911 (CLI tools, merged); blocks on launch script + setup-hook verification (remaining M5a slices) before unmark-draft.

## What this PR ships

`jepsen/src/elastickv/dynamodb_multi_table_workload.clj` — a new workload variant of the DynamoDB list-append test that exercises cross-table 2PC, which the single-table `elastickv.dynamodb-workload` cannot do.

### Why a separate workload exists

`kv/shard_key.go`'s `dynamoRouteKey` normalises every DynamoDB table-meta / item / GSI key for one table to a single per-table route key (`!ddb|route|table|<base64(name)>`). Single-table workloads always route to one shard regardless of partition-key value, so `dispatchMultiShardTxn` / `commitSecondaryTxns` / the new `ErrTxnSecondaryRouteShiftedAfterPrimaryCommit` sentinel never fire (codex P1 on #905 ffb9c73f).

### What this workload does

- **N=4 tables** (`jepsen_append_t1` … `jepsen_append_t4`) created in `setup!`.
- **Deterministic key routing**: Elle's integer keys `k` route via `(mod k N)+1 → table-idx`, so each Elle key always lands at the same `(table, pk)` storage location (Elle's append checker still sees a single key namespace).
- **Default 4-mop txns with key-count=12** distribute evenly across all 4 tables — a 4-key txn touches all 4 tables and therefore both Raft groups under the launch script's planned `--shardRanges` layout (t1-t2 → group 1, t3-t4 → group 2).
- **`TransactGetItems`** for atomic cross-table pre-read; **`TransactWriteItems`** for atomic cross-table writes (both DynamoDB APIs natively support multi-table txns).
- **Same OCC condition expressions** as the single-table workload so any G1c or G-single anomaly observed is attributable to the multi-shard 2PC path rather than to a workload-shape difference.

### Why self-contained

The file intentionally duplicates small helpers from `elastickv.dynamodb-workload` rather than extracting into a shared namespace. Refactoring would couple the workloads through a maintained API and obscure the side-by-side comparability that is the point of running both — relevant because #905 commits to keeping the single-table workload as-is for trend comparison.

## Tests (`jepsen/test/elastickv/dynamodb_multi_table_workload_test.clj`)

7 tests / 17 assertions. The load-bearing ones:

- **`key-routing-distributes-across-all-tables`** — 12 keys distribute 3-per-table across 4 tables
- **`key-routing-table-name-matches-prefix`** — wraparound at k=4
- **`key-routing-pks-disambiguate_colliding_keys`** — k=0 and k=4 share table t1 but have distinct pks
- **`multi-op-txn-spans_multiple_groups`** — default 4-key txn touches BOTH the planned group-1 tables (1,2) and group-2 tables (3,4) — without this, `dispatchMultiShardTxn` never fires and the whole workload is a no-op

The routing helpers are private; tests access via `var-get` on `#'workload/key->table-idx` etc. so a future change to the routing surfaces in this test rather than as a silent G1c during a Jepsen run.

## Remaining M5a work (separate PRs after this lands)

- [ ] `scripts/run-jepsen-m5-local.sh` — single-process two-group launch with `--raftGroups` + `--shardRanges` using `elastickv-route-key` to compute boundary keys
- [ ] Setup-hook verification — Clojure `ListRoutes` gRPC client asserting multi-group routing is in place
- [ ] Done-when check — workload exercises `dispatchMultiShardTxn` (server-side log marker or probe) and Elle finds zero G1c

## Test plan

- [x] `lein test elastickv.dynamodb-multi-table-workload-test` → Ran 7 tests / 17 assertions, 0 failures, 0 errors
- [x] `lein test elastickv.dynamodb-workload-test` (existing single-table suite) → Ran 3 tests / 5 assertions, 0 failures (no regression)
- [ ] End-to-end Jepsen run (gated on launch script + setup hook landing)
