### PR TITLE
feat(encryption): Stage 6E-2b — ProposeAdmin sibling on raftengine.Proposer

### DIFF
--- a/adapter/encryption_admin.go
+++ b/adapter/encryption_admin.go
@@ -1343,11 +1343,24 @@ func (s *EncryptionAdminServer) proposeEncryptionEntry(ctx context.Context, opco
 	entry = append(entry, body...)
 	// proposeEncryptionEntry composes control-plane entries
 	// (BootstrapEncryption, EnableStorageEnvelope, the §6E
-	// EnableRaftEnvelope cutover marker, etc.). All of these are
-	// exempt from the §7.1 quiescence barrier that Stage 6E-2d
-	// installs on Propose: most carry no user-data, and the
-	// cutover entry itself would deadlock the barrier on its own
-	// proposal. ProposeAdmin is the exempt path.
+	// EnableRaftEnvelope cutover marker, RotateDEK,
+	// RegisterEncryptionWriter, etc.). The §7.1 quiescence barrier
+	// Stage 6E-2d installs on Propose would reject these — most
+	// trivially, the cutover entry itself would deadlock on its
+	// own barrier — so admin ops route through the
+	// barrier-exempt ProposeAdmin path.
+	//
+	// ProposeAdmin is barrier-exempt only; the wrap layer above
+	// the engine (kv.wrappedProposer, when configured) still
+	// applies its wrap closure to ProposeAdmin payloads, so a
+	// post-cutover RotateDEK or RegisterEncryptionWriter
+	// committed at `index > raftEnvelopeCutoverIndex` carries the
+	// AEAD envelope the §6.3 strict-`>` apply hook expects. The
+	// EnableRaftEnvelope cutover marker (at `index == cutover`)
+	// must remain cleartext for strict-`>` to leave it alone;
+	// today s.proposer is wired to the raw engine (see
+	// main_encryption_admin.go), so the marker reaches Raft
+	// without the wrap layer in the path at all.
 	res, err := s.proposer.ProposeAdmin(ctx, entry)
 	if err != nil {
 		return 0, proposeErrorToStatus(err, opcode)

--- a/adapter/encryption_admin.go
+++ b/adapter/encryption_admin.go
@@ -1341,7 +1341,14 @@ func (s *EncryptionAdminServer) proposeEncryptionEntry(ctx context.Context, opco
 	entry := make([]byte, 0, 1+len(body))
 	entry = append(entry, opcode)
 	entry = append(entry, body...)
-	res, err := s.proposer.Propose(ctx, entry)
+	// proposeEncryptionEntry composes control-plane entries
+	// (BootstrapEncryption, EnableStorageEnvelope, the §6E
+	// EnableRaftEnvelope cutover marker, etc.). All of these are
+	// exempt from the §7.1 quiescence barrier that Stage 6E-2d
+	// installs on Propose: most carry no user-data, and the
+	// cutover entry itself would deadlock the barrier on its own
+	// proposal. ProposeAdmin is the exempt path.
+	res, err := s.proposer.ProposeAdmin(ctx, entry)
 	if err != nil {
 		return 0, proposeErrorToStatus(err, opcode)
 	}

--- a/adapter/encryption_admin_test.go
+++ b/adapter/encryption_admin_test.go
@@ -1000,6 +1000,16 @@ func (p *recordingProposer) Propose(_ context.Context, data []byte) (*raftengine
 	return &raftengine.ProposalResult{CommitIndex: p.commitIndex}, nil
 }
 
+// ProposeAdmin records the call into the same slice as Propose so
+// existing assertions on p.calls continue to work after the
+// adapter/encryption_admin.go production callers (which now route
+// every control-plane entry through ProposeAdmin) switched paths.
+// In the current build both methods are operationally identical;
+// the bookkeeping is unified intentionally.
+func (p *recordingProposer) ProposeAdmin(ctx context.Context, data []byte) (*raftengine.ProposalResult, error) {
+	return p.Propose(ctx, data)
+}
+
 // stubLeaderView reports a fixed leadership state. verifyErr lets
 // a test simulate a partitioned former leader: State() still
 // reports StateLeader but VerifyLeader returns an error because
@@ -1087,6 +1097,18 @@ func (p *applyingProposer) Propose(ctx context.Context, data []byte) (*raftengin
 		return nil, werr
 	}
 	return res, nil
+}
+
+// ProposeAdmin redirects to applyingProposer.Propose (not the
+// embedded recordingProposer.Propose) so the applyFn side-effect
+// fires for admin-path proposals as well. Without this explicit
+// override, Go method resolution would dispatch
+// recordingProposer.ProposeAdmin -> recordingProposer.Propose and
+// skip the applyingProposer-level Propose body — silently losing
+// the apply emulation that EnableStorageEnvelope /
+// EnableRaftEnvelope happy-path tests depend on.
+func (p *applyingProposer) ProposeAdmin(ctx context.Context, data []byte) (*raftengine.ProposalResult, error) {
+	return p.Propose(ctx, data)
 }
 
 // applyCutover is the §6.4 fresh-success apply effect: flip

--- a/internal/raftadmin/server_test.go
+++ b/internal/raftadmin/server_test.go
@@ -68,6 +68,10 @@ func (f *fakeEngine) Propose(context.Context, []byte) (*raftengine.ProposalResul
 	return &raftengine.ProposalResult{}, nil
 }
 
+func (f *fakeEngine) ProposeAdmin(ctx context.Context, data []byte) (*raftengine.ProposalResult, error) {
+	return f.Propose(ctx, data)
+}
+
 func (f *fakeEngine) State() raftengine.State {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -310,6 +314,10 @@ func (s stateOnlyEngine) Close() error { return nil }
 
 func (s stateOnlyEngine) Propose(context.Context, []byte) (*raftengine.ProposalResult, error) {
 	return &raftengine.ProposalResult{}, nil
+}
+
+func (s stateOnlyEngine) ProposeAdmin(ctx context.Context, data []byte) (*raftengine.ProposalResult, error) {
+	return s.Propose(ctx, data)
 }
 
 func (s stateOnlyEngine) State() raftengine.State { return s.state }

--- a/internal/raftengine/engine.go
+++ b/internal/raftengine/engine.go
@@ -76,27 +76,39 @@ type ProposalResult struct {
 // Proposer drives a Raft proposal through the engine and returns
 // once it has been committed (or the context/engine cancels first).
 //
-// Two semantically distinct entry points:
+// Two semantically distinct entry points, differing ONLY in the
+// §7.1 quiescence-barrier check Stage 6E-2d installs on Propose:
 //
-//   - Propose carries ordinary user-data and control-plane traffic.
-//     A future §7.1 quiescence barrier (Stage 6E-2d) will reject
-//     these with ErrEnvelopeCutoverInProgress while a raft-envelope
-//     cutover is being installed, so the leader cannot admit a
-//     plaintext entry at `index > raftEnvelopeCutoverIndex`.
-//   - ProposeAdmin carries proposals that MUST bypass the §7.1
-//     barrier — currently the EnableRaftEnvelope cutover entry
+//   - Propose carries ordinary user-data and control-plane traffic
+//     that may be paused during a raft-envelope cutover. 6E-2d will
+//     reject these with ErrEnvelopeCutoverInProgress while the
+//     barrier is open so the leader cannot admit a fresh entry at
+//     `index > raftEnvelopeCutoverIndex` mid-installation.
+//   - ProposeAdmin carries proposals that MUST remain admissible
+//     across the barrier — the EnableRaftEnvelope cutover entry
 //     itself (without this exemption the barrier would deadlock on
 //     its own cutover proposal) and ConfChange-time
 //     RegisterEncryptionWriter proposals (Stage 7c §3.1, so a new
 //     member joining mid-barrier can still register its
 //     writer-registry entry).
 //
+// ProposeAdmin is NOT a wrap-exemption: a payload-wrap layer
+// configured above the engine (kv.wrappedProposer) applies its
+// wrap closure to both methods identically. Admin entries that
+// land at `index > raftEnvelopeCutoverIndex` (a leader-restart
+// registration, a post-cutover RotateDEK, etc.) must carry the
+// AEAD envelope the §6.3 strict-`>` apply hook expects; a cleartext
+// admin entry above cutover would halt the apply loop on
+// unwrap-failure. The lone exception is the EnableRaftEnvelope
+// cutover marker (sits at `index == cutover`, strict-`>` leaves it
+// alone), which is proposed via a raw engine reference and never
+// flows through the wrap layer in the first place.
+//
 // In the current build the two methods are operationally
-// equivalent; Stage 6E-2d adds the barrier check on Propose only.
-// Calling Propose from a control-plane site that should be exempt
-// will therefore not break today, but will fail-closed at the
-// barrier the moment 6E-2d ships — so the migration must land in
-// the same PR series, not after.
+// equivalent (the barrier is still 6E-2d work); the distinction at
+// the call site is the migration the future barrier requires —
+// sites still on Propose would fail closed the moment 6E-2d
+// activates the barrier.
 type Proposer interface {
 	Propose(ctx context.Context, data []byte) (*ProposalResult, error)
 	ProposeAdmin(ctx context.Context, data []byte) (*ProposalResult, error)

--- a/internal/raftengine/engine.go
+++ b/internal/raftengine/engine.go
@@ -73,8 +73,33 @@ type ProposalResult struct {
 	Response    any
 }
 
+// Proposer drives a Raft proposal through the engine and returns
+// once it has been committed (or the context/engine cancels first).
+//
+// Two semantically distinct entry points:
+//
+//   - Propose carries ordinary user-data and control-plane traffic.
+//     A future §7.1 quiescence barrier (Stage 6E-2d) will reject
+//     these with ErrEnvelopeCutoverInProgress while a raft-envelope
+//     cutover is being installed, so the leader cannot admit a
+//     plaintext entry at `index > raftEnvelopeCutoverIndex`.
+//   - ProposeAdmin carries proposals that MUST bypass the §7.1
+//     barrier — currently the EnableRaftEnvelope cutover entry
+//     itself (without this exemption the barrier would deadlock on
+//     its own cutover proposal) and ConfChange-time
+//     RegisterEncryptionWriter proposals (Stage 7c §3.1, so a new
+//     member joining mid-barrier can still register its
+//     writer-registry entry).
+//
+// In the current build the two methods are operationally
+// equivalent; Stage 6E-2d adds the barrier check on Propose only.
+// Calling Propose from a control-plane site that should be exempt
+// will therefore not break today, but will fail-closed at the
+// barrier the moment 6E-2d ships — so the migration must land in
+// the same PR series, not after.
 type Proposer interface {
 	Propose(ctx context.Context, data []byte) (*ProposalResult, error)
+	ProposeAdmin(ctx context.Context, data []byte) (*ProposalResult, error)
 }
 
 type LeaderView interface {

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -738,12 +738,20 @@ func (e *Engine) Propose(ctx context.Context, data []byte) (*raftengine.Proposal
 // RegisterEncryptionWriter proposals (see raftengine.Proposer's
 // contract for the full exempt set).
 //
-// In the current build it is operationally identical to Propose;
-// Stage 6E-2d wires the barrier check on Propose only, leaving this
-// path admissible. The two methods are kept distinct from the
-// outset so the migration of call sites (this PR) lands ahead of
-// the behaviour change (6E-2d) — calling Propose from an exempt
-// site today is silently wrong tomorrow.
+// The barrier exemption is the SOLE divergence from Propose: a
+// higher-layer wrap (kv.wrappedProposer) applies its wrap closure
+// to both methods identically, so admin entries landing above the
+// raft-envelope cutover still carry the AEAD envelope the §6.3
+// strict-`>` apply hook expects. Only the cutover marker itself is
+// cleartext, and it bypasses the wrap layer at the call site
+// (raw engine reference), not at the method level.
+//
+// In the current build ProposeAdmin is operationally identical to
+// Propose; Stage 6E-2d adds the barrier check on Propose only.
+// The two methods are kept distinct from the outset so the
+// migration of call sites (this PR) lands ahead of the behaviour
+// change (6E-2d) — calling Propose from an exempt site today is
+// silently wrong tomorrow.
 func (e *Engine) ProposeAdmin(ctx context.Context, data []byte) (*raftengine.ProposalResult, error) {
 	return e.propose(ctx, data)
 }

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -729,6 +729,26 @@ func (e *Engine) Close() error {
 }
 
 func (e *Engine) Propose(ctx context.Context, data []byte) (*raftengine.ProposalResult, error) {
+	return e.propose(ctx, data)
+}
+
+// ProposeAdmin drives a control-plane proposal that must remain
+// admissible across the §7.1 quiescence barrier — currently the
+// EnableRaftEnvelope cutover entry and ConfChange-time
+// RegisterEncryptionWriter proposals (see raftengine.Proposer's
+// contract for the full exempt set).
+//
+// In the current build it is operationally identical to Propose;
+// Stage 6E-2d wires the barrier check on Propose only, leaving this
+// path admissible. The two methods are kept distinct from the
+// outset so the migration of call sites (this PR) lands ahead of
+// the behaviour change (6E-2d) — calling Propose from an exempt
+// site today is silently wrong tomorrow.
+func (e *Engine) ProposeAdmin(ctx context.Context, data []byte) (*raftengine.ProposalResult, error) {
+	return e.propose(ctx, data)
+}
+
+func (e *Engine) propose(ctx context.Context, data []byte) (*raftengine.ProposalResult, error) {
 	if err := contextErr(ctx); err != nil {
 		return nil, err
 	}

--- a/internal/raftengine/etcd/engine_test.go
+++ b/internal/raftengine/etcd/engine_test.go
@@ -234,16 +234,16 @@ func TestProposeAdmin_EquivalentToProposeToday(t *testing.T) {
 		"both Propose and ProposeAdmin must reach the FSM verbatim and in-order")
 }
 
-// TestProposerInterface_RequiresProposeAdmin is a compile-time
-// guard: it does not test runtime behaviour but ensures the
-// raftengine.Proposer interface still requires the ProposeAdmin
-// method on every implementation. Removing the method from the
-// interface declaration would let unmigrated callers stay on
-// Propose silently, defeating the Stage 6E-2b migration.
-func TestProposerInterface_RequiresProposeAdmin(t *testing.T) {
-	t.Parallel()
-	var _ raftengine.Proposer = (*Engine)(nil)
-}
+// Compile-time guard: *Engine must satisfy raftengine.Proposer
+// (which Stage 6E-2b extended with ProposeAdmin). Declared at
+// package scope so the check fires at test-package compile time
+// regardless of which test is selected; wrapping it inside a
+// no-op test function would defer the check to a test target
+// nobody runs. Removing ProposeAdmin from the interface would
+// either leave this assertion dangling (if Engine still has the
+// method) or hard-fail the build (if it doesn't) — the latter is
+// the failure mode this guard exists to produce.
+var _ raftengine.Proposer = (*Engine)(nil)
 
 func TestOpenSingleNodeProposeAndReadIndex(t *testing.T) {
 	fsm := &testStateMachine{}

--- a/internal/raftengine/etcd/engine_test.go
+++ b/internal/raftengine/etcd/engine_test.go
@@ -182,6 +182,69 @@ func (s *countingSnapshotStateMachine) Restore(r io.Reader) error {
 	return err
 }
 
+// TestProposeAdmin_EquivalentToProposeToday pins the Stage 6E-2b
+// invariant: ProposeAdmin and Propose commit equivalent entries on
+// the current build. Both reach the FSM as the same byte sequence
+// and report a non-zero CommitIndex.
+//
+// This is the bridge property the migration relies on. Stage 6E-2d
+// will diverge the two paths — Propose gains a §7.1 quiescence
+// barrier check that rejects with ErrEnvelopeCutoverInProgress
+// while a cutover is being installed; ProposeAdmin remains
+// admissible so the cutover entry and ConfChange-time
+// RegisterEncryptionWriter proposals can still land. Until that
+// behaviour change ships, callers that switched to ProposeAdmin
+// in this PR must see identical results to staying on Propose,
+// else the migration would visibly change semantics before
+// 6E-2d's protective barrier is in place.
+func TestProposeAdmin_EquivalentToProposeToday(t *testing.T) {
+	fsm := &testStateMachine{}
+	engine, err := Open(context.Background(), OpenConfig{
+		NodeID:       1,
+		LocalID:      "n1",
+		LocalAddress: "127.0.0.1:7011",
+		DataDir:      t.TempDir(),
+		Bootstrap:    true,
+		StateMachine: fsm,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, engine.Close())
+	})
+
+	require.Equal(t, raftengine.StateLeader, engine.State())
+
+	plainRes, err := engine.Propose(context.Background(), []byte("plain"))
+	require.NoError(t, err)
+	require.NotNil(t, plainRes)
+	require.NotZero(t, plainRes.CommitIndex)
+	require.Equal(t, "plain", plainRes.Response)
+
+	adminRes, err := engine.ProposeAdmin(context.Background(), []byte("admin"))
+	require.NoError(t, err)
+	require.NotNil(t, adminRes)
+	require.NotZero(t, adminRes.CommitIndex)
+	require.Equal(t, "admin", adminRes.Response)
+	require.Greater(t, adminRes.CommitIndex, plainRes.CommitIndex,
+		"ProposeAdmin must advance CommitIndex past the preceding Propose, "+
+			"proving its proposal reaches the engine through the same Raft path")
+
+	applied := fsm.Applied()
+	require.Equal(t, [][]byte{[]byte("plain"), []byte("admin")}, applied,
+		"both Propose and ProposeAdmin must reach the FSM verbatim and in-order")
+}
+
+// TestProposerInterface_RequiresProposeAdmin is a compile-time
+// guard: it does not test runtime behaviour but ensures the
+// raftengine.Proposer interface still requires the ProposeAdmin
+// method on every implementation. Removing the method from the
+// interface declaration would let unmigrated callers stay on
+// Propose silently, defeating the Stage 6E-2b migration.
+func TestProposerInterface_RequiresProposeAdmin(t *testing.T) {
+	t.Parallel()
+	var _ raftengine.Proposer = (*Engine)(nil)
+}
+
 func TestOpenSingleNodeProposeAndReadIndex(t *testing.T) {
 	fsm := &testStateMachine{}
 	engine, err := Open(context.Background(), OpenConfig{

--- a/kv/coordinator_retry_test.go
+++ b/kv/coordinator_retry_test.go
@@ -25,6 +25,9 @@ type stubLeaderEngine struct{}
 func (stubLeaderEngine) Propose(context.Context, []byte) (*raftengine.ProposalResult, error) {
 	return &raftengine.ProposalResult{}, nil
 }
+func (e stubLeaderEngine) ProposeAdmin(ctx context.Context, data []byte) (*raftengine.ProposalResult, error) {
+	return e.Propose(ctx, data)
+}
 func (stubLeaderEngine) State() raftengine.State { return raftengine.StateLeader }
 func (stubLeaderEngine) Leader() raftengine.LeaderInfo {
 	return raftengine.LeaderInfo{ID: "self", Address: "127.0.0.1:0"}

--- a/kv/leader_proxy_test.go
+++ b/kv/leader_proxy_test.go
@@ -46,6 +46,9 @@ type stubFollowerEngine struct {
 func (s *stubFollowerEngine) Propose(context.Context, []byte) (*raftengine.ProposalResult, error) {
 	return nil, raftengine.ErrNotLeader
 }
+func (s *stubFollowerEngine) ProposeAdmin(ctx context.Context, data []byte) (*raftengine.ProposalResult, error) {
+	return s.Propose(ctx, data)
+}
 func (s *stubFollowerEngine) State() raftengine.State { return raftengine.StateFollower }
 func (s *stubFollowerEngine) Leader() raftengine.LeaderInfo {
 	return raftengine.LeaderInfo{ID: "leader", Address: s.leaderAddr}
@@ -161,6 +164,9 @@ func (e *togglingFollowerEngine) setLeader(addr string) {
 
 func (e *togglingFollowerEngine) Propose(context.Context, []byte) (*raftengine.ProposalResult, error) {
 	return nil, raftengine.ErrNotLeader
+}
+func (e *togglingFollowerEngine) ProposeAdmin(ctx context.Context, data []byte) (*raftengine.ProposalResult, error) {
+	return e.Propose(ctx, data)
 }
 func (e *togglingFollowerEngine) State() raftengine.State { return raftengine.StateFollower }
 func (e *togglingFollowerEngine) Leader() raftengine.LeaderInfo {

--- a/kv/lease_read_test.go
+++ b/kv/lease_read_test.go
@@ -62,6 +62,9 @@ func (e *fakeLeaseEngine) Configuration(context.Context) (raftengine.Configurati
 func (e *fakeLeaseEngine) Propose(context.Context, []byte) (*raftengine.ProposalResult, error) {
 	return &raftengine.ProposalResult{}, nil
 }
+func (e *fakeLeaseEngine) ProposeAdmin(ctx context.Context, data []byte) (*raftengine.ProposalResult, error) {
+	return e.Propose(ctx, data)
+}
 func (e *fakeLeaseEngine) Close() error                 { return nil }
 func (e *fakeLeaseEngine) LeaseDuration() time.Duration { return e.leaseDur }
 func (e *fakeLeaseEngine) AppliedIndex() uint64         { return e.applied }
@@ -152,6 +155,9 @@ func (e *nonLeaseEngine) Configuration(context.Context) (raftengine.Configuratio
 }
 func (e *nonLeaseEngine) Propose(context.Context, []byte) (*raftengine.ProposalResult, error) {
 	return &raftengine.ProposalResult{}, nil
+}
+func (e *nonLeaseEngine) ProposeAdmin(ctx context.Context, data []byte) (*raftengine.ProposalResult, error) {
+	return e.Propose(ctx, data)
 }
 func (e *nonLeaseEngine) Close() error { return nil }
 

--- a/kv/raft_payload_wrapper.go
+++ b/kv/raft_payload_wrapper.go
@@ -75,3 +75,25 @@ func (p *wrappedProposer) Propose(ctx context.Context, data []byte) (*raftengine
 	}
 	return res, nil
 }
+
+// ProposeAdmin forwards the payload verbatim to the inner
+// ProposeAdmin path — the wrap layer is deliberately skipped. The
+// only callers permitted to use this path are the EnableRaftEnvelope
+// cutover entry (which by §6.3 strict-`>` dispatch must remain
+// cleartext at index == cutover so the apply hook can find the
+// cutover marker) and ConfChange-time RegisterEncryptionWriter
+// registrations (Stage 7c §3.1, which carry no user data and are
+// inspected by the FSM independently of the raft envelope).
+//
+// In the current build no production code routes admin proposals
+// through wrappedProposer — adapter/encryption_admin.go and
+// main_encryption_registration.go hold raw engine references. This
+// method exists so wrappedProposer continues to satisfy
+// raftengine.Proposer.
+func (p *wrappedProposer) ProposeAdmin(ctx context.Context, data []byte) (*raftengine.ProposalResult, error) {
+	res, err := p.inner.ProposeAdmin(ctx, data)
+	if err != nil {
+		return nil, errors.Wrap(err, "kv: wrapped propose-admin")
+	}
+	return res, nil
+}

--- a/kv/raft_payload_wrapper.go
+++ b/kv/raft_payload_wrapper.go
@@ -76,22 +76,33 @@ func (p *wrappedProposer) Propose(ctx context.Context, data []byte) (*raftengine
 	return res, nil
 }
 
-// ProposeAdmin forwards the payload verbatim to the inner
-// ProposeAdmin path — the wrap layer is deliberately skipped. The
-// only callers permitted to use this path are the EnableRaftEnvelope
-// cutover entry (which by §6.3 strict-`>` dispatch must remain
-// cleartext at index == cutover so the apply hook can find the
-// cutover marker) and ConfChange-time RegisterEncryptionWriter
-// registrations (Stage 7c §3.1, which carry no user data and are
-// inspected by the FSM independently of the raft envelope).
+// ProposeAdmin applies the configured RaftPayloadWrapper before
+// forwarding the payload to the inner ProposeAdmin path. The wrap
+// layer is NOT a barrier-exemption concern: it exists so that
+// every entry landing at `index > raftEnvelopeCutoverIndex` carries
+// an AEAD envelope the §6.3 strict-`>` apply hook can unwrap.
+// Admin entries (BootstrapEncryption, RotateDEK,
+// RegisterEncryptionWriter, etc.) committed after the cutover are
+// no different from user data in that regard — a cleartext admin
+// entry above cutover would halt the apply loop on unwrap-failure,
+// not be silently passed through.
 //
-// In the current build no production code routes admin proposals
-// through wrappedProposer — adapter/encryption_admin.go and
-// main_encryption_registration.go hold raw engine references. This
-// method exists so wrappedProposer continues to satisfy
-// raftengine.Proposer.
+// The lone exception is the EnableRaftEnvelope cutover marker
+// itself, which sits exactly at `index == cutover` and must remain
+// cleartext for strict-`>` dispatch to leave it alone. That marker
+// is proposed via a raw engine reference (adapter/encryption_admin.go
+// holds the engine directly as s.proposer), not via the
+// wrappedProposer — so this wrap path is never on its way.
+//
+// ProposeAdmin's only divergence from Propose lives in Stage
+// 6E-2d's §7.1 quiescence-barrier check, which is installed on
+// Propose only.
 func (p *wrappedProposer) ProposeAdmin(ctx context.Context, data []byte) (*raftengine.ProposalResult, error) {
-	res, err := p.inner.ProposeAdmin(ctx, data)
+	wrapped, err := applyRaftPayloadWrap(p.wrap, data)
+	if err != nil {
+		return nil, err
+	}
+	res, err := p.inner.ProposeAdmin(ctx, wrapped)
 	if err != nil {
 		return nil, errors.Wrap(err, "kv: wrapped propose-admin")
 	}

--- a/kv/raft_payload_wrapper_test.go
+++ b/kv/raft_payload_wrapper_test.go
@@ -12,13 +12,19 @@ import (
 	"github.com/bootjp/elastickv/internal/raftengine"
 )
 
-// fakeProposer records every Propose call so the wrapper tests can
-// inspect what bytes the engine would have seen.
+// fakeProposer records every Propose / ProposeAdmin call so the
+// wrapper tests can inspect both (a) what bytes the engine would
+// have seen, and (b) which method routed there — so a test that
+// expects wrappedProposer.ProposeAdmin to bypass the wrap layer
+// can assert against adminCalls / adminLast independently of
+// (Propose) calls / last.
 type fakeProposer struct {
-	calls atomic.Int32
-	last  []byte
-	resp  *raftengine.ProposalResult
-	err   error
+	calls      atomic.Int32
+	last       []byte
+	adminCalls atomic.Int32
+	adminLast  []byte
+	resp       *raftengine.ProposalResult
+	err        error
 }
 
 func (p *fakeProposer) Propose(_ context.Context, data []byte) (*raftengine.ProposalResult, error) {
@@ -26,6 +32,20 @@ func (p *fakeProposer) Propose(_ context.Context, data []byte) (*raftengine.Prop
 	cp := make([]byte, len(data))
 	copy(cp, data)
 	p.last = cp
+	if p.err != nil {
+		return nil, p.err
+	}
+	if p.resp == nil {
+		return &raftengine.ProposalResult{CommitIndex: 1}, nil
+	}
+	return p.resp, nil
+}
+
+func (p *fakeProposer) ProposeAdmin(_ context.Context, data []byte) (*raftengine.ProposalResult, error) {
+	p.adminCalls.Add(1)
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	p.adminLast = cp
 	if p.err != nil {
 		return nil, p.err
 	}
@@ -53,6 +73,47 @@ func TestApplyRaftPayloadWrap_PropagatesError(t *testing.T) {
 	_, err := applyRaftPayloadWrap(wrap, []byte("x"))
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("expected wrapped sentinel, got %v", err)
+	}
+}
+
+// TestWrappedProposer_ProposeAdminBypassesWrap pins the §6.3
+// invariant the Stage 6E-2b ProposeAdmin path must enforce: even
+// when a wrap closure is configured, ProposeAdmin payloads MUST
+// reach the inner proposer verbatim and MUST take the inner's
+// ProposeAdmin path (not Propose). The cutover entry itself sits
+// at `index == cutover` and the apply hook's strict-`>` dispatch
+// will treat it as cleartext; if wrappedProposer wrapped it
+// anyway, the apply side would either (a) fail to find the
+// cutover marker because its body is encrypted, or (b) attempt
+// to unwrap it against a key that hasn't been activated yet —
+// either way bricking the cutover.
+func TestWrappedProposer_ProposeAdminBypassesWrap(t *testing.T) {
+	t.Parallel()
+	var wrapCalls atomic.Int32
+	wrap := func(p []byte) ([]byte, error) {
+		wrapCalls.Add(1)
+		out := make([]byte, len(p)+1)
+		out[0] = 'W'
+		copy(out[1:], p)
+		return out, nil
+	}
+	inner := &fakeProposer{}
+	wp := newWrappedProposer(inner, wrap)
+	plain := []byte("cutover-marker")
+	if _, err := wp.ProposeAdmin(context.Background(), plain); err != nil {
+		t.Fatalf("ProposeAdmin: %v", err)
+	}
+	if got := wrapCalls.Load(); got != 0 {
+		t.Fatalf("wrap closure ran %d times under ProposeAdmin; want 0 — admin path must bypass wrap", got)
+	}
+	if got := inner.calls.Load(); got != 0 {
+		t.Fatalf("inner.Propose called %d times under ProposeAdmin; want 0 — admin path must route through inner.ProposeAdmin", got)
+	}
+	if got := inner.adminCalls.Load(); got != 1 {
+		t.Fatalf("inner.ProposeAdmin call count = %d, want 1", got)
+	}
+	if !bytes.Equal(inner.adminLast, plain) {
+		t.Fatalf("inner.ProposeAdmin saw %q, want %q (cleartext verbatim)", inner.adminLast, plain)
 	}
 }
 

--- a/kv/raft_payload_wrapper_test.go
+++ b/kv/raft_payload_wrapper_test.go
@@ -76,18 +76,27 @@ func TestApplyRaftPayloadWrap_PropagatesError(t *testing.T) {
 	}
 }
 
-// TestWrappedProposer_ProposeAdminBypassesWrap pins the §6.3
-// invariant the Stage 6E-2b ProposeAdmin path must enforce: even
-// when a wrap closure is configured, ProposeAdmin payloads MUST
-// reach the inner proposer verbatim and MUST take the inner's
-// ProposeAdmin path (not Propose). The cutover entry itself sits
-// at `index == cutover` and the apply hook's strict-`>` dispatch
-// will treat it as cleartext; if wrappedProposer wrapped it
-// anyway, the apply side would either (a) fail to find the
-// cutover marker because its body is encrypted, or (b) attempt
-// to unwrap it against a key that hasn't been activated yet —
-// either way bricking the cutover.
-func TestWrappedProposer_ProposeAdminBypassesWrap(t *testing.T) {
+// TestWrappedProposer_ProposeAdminAppliesWrap pins the invariant
+// codex P1 round-1 surfaced: admin entries that land at
+// `index > raftEnvelopeCutoverIndex` (any post-cutover
+// BootstrapEncryption / RotateDEK / RegisterEncryptionWriter
+// committed during normal operation) MUST be wrapped, else the
+// §6.3 strict-`>` apply hook will try to AEAD-decrypt cleartext
+// bytes and halt apply on integrity failure.
+//
+// ProposeAdmin's only divergence from Propose is the future §7.1
+// quiescence-barrier exemption Stage 6E-2d installs on Propose
+// only — wrap behaviour is identical between the two paths. The
+// lone admin entry that must remain cleartext is the
+// EnableRaftEnvelope cutover marker itself (at index == cutover),
+// and that one is handled by routing it through the raw engine
+// reference instead of wrappedProposer, NOT by a method-level
+// wrap bypass.
+//
+// This test pins the corrected behaviour. The earlier round-1
+// shape (wrap-bypass on ProposeAdmin) is gone; an attempt to
+// reintroduce it must visibly fail here.
+func TestWrappedProposer_ProposeAdminAppliesWrap(t *testing.T) {
 	t.Parallel()
 	var wrapCalls atomic.Int32
 	wrap := func(p []byte) ([]byte, error) {
@@ -99,21 +108,22 @@ func TestWrappedProposer_ProposeAdminBypassesWrap(t *testing.T) {
 	}
 	inner := &fakeProposer{}
 	wp := newWrappedProposer(inner, wrap)
-	plain := []byte("cutover-marker")
+	plain := []byte("post-cutover-admin")
 	if _, err := wp.ProposeAdmin(context.Background(), plain); err != nil {
 		t.Fatalf("ProposeAdmin: %v", err)
 	}
-	if got := wrapCalls.Load(); got != 0 {
-		t.Fatalf("wrap closure ran %d times under ProposeAdmin; want 0 — admin path must bypass wrap", got)
-	}
-	if got := inner.calls.Load(); got != 0 {
-		t.Fatalf("inner.Propose called %d times under ProposeAdmin; want 0 — admin path must route through inner.ProposeAdmin", got)
+	if got := wrapCalls.Load(); got != 1 {
+		t.Fatalf("wrap closure ran %d times under ProposeAdmin; want 1 — admin path must apply wrap so post-cutover admin entries survive strict-> unwrap", got)
 	}
 	if got := inner.adminCalls.Load(); got != 1 {
-		t.Fatalf("inner.ProposeAdmin call count = %d, want 1", got)
+		t.Fatalf("inner.ProposeAdmin call count = %d, want 1 — admin path must still route through inner.ProposeAdmin so 6E-2d's barrier exemption survives", got)
 	}
-	if !bytes.Equal(inner.adminLast, plain) {
-		t.Fatalf("inner.ProposeAdmin saw %q, want %q (cleartext verbatim)", inner.adminLast, plain)
+	if got := inner.calls.Load(); got != 0 {
+		t.Fatalf("inner.Propose called %d times under ProposeAdmin; want 0 — admin path must not silently fall back to the non-exempt method", got)
+	}
+	want := append([]byte{'W'}, plain...)
+	if !bytes.Equal(inner.adminLast, want) {
+		t.Fatalf("inner.ProposeAdmin saw %q, want %q (wrapper output)", inner.adminLast, want)
 	}
 }
 

--- a/kv/sharded_coordinator_txn_test.go
+++ b/kv/sharded_coordinator_txn_test.go
@@ -401,6 +401,9 @@ type noopEngine struct{}
 func (noopEngine) Propose(_ context.Context, _ []byte) (*raftengine.ProposalResult, error) {
 	return &raftengine.ProposalResult{}, nil
 }
+func (e noopEngine) ProposeAdmin(ctx context.Context, data []byte) (*raftengine.ProposalResult, error) {
+	return e.Propose(ctx, data)
+}
 func (noopEngine) State() raftengine.State                            { return raftengine.StateLeader }
 func (noopEngine) Leader() raftengine.LeaderInfo                      { return raftengine.LeaderInfo{} }
 func (noopEngine) VerifyLeader(_ context.Context) error               { return nil }

--- a/main_encryption_admin_test.go
+++ b/main_encryption_admin_test.go
@@ -29,6 +29,9 @@ type stubEncryptionAdminEngine struct{}
 func (stubEncryptionAdminEngine) Propose(context.Context, []byte) (*raftengine.ProposalResult, error) {
 	return &raftengine.ProposalResult{}, nil
 }
+func (s stubEncryptionAdminEngine) ProposeAdmin(ctx context.Context, data []byte) (*raftengine.ProposalResult, error) {
+	return s.Propose(ctx, data)
+}
 func (stubEncryptionAdminEngine) State() raftengine.State       { return raftengine.StateLeader }
 func (stubEncryptionAdminEngine) Leader() raftengine.LeaderInfo { return raftengine.LeaderInfo{} }
 func (stubEncryptionAdminEngine) VerifyLeader(context.Context) error {

--- a/main_encryption_registration.go
+++ b/main_encryption_registration.go
@@ -480,8 +480,14 @@ func proposeWriterRegistration(
 	attemptCtx, cancel := context.WithTimeout(ctx, registrationAttemptTimeout)
 	defer cancel()
 	if coordinate.IsLeader() {
-		if _, err := defaultEngine.Propose(attemptCtx, entry); err != nil {
-			return errors.Wrap(err, "writer registration: local propose")
+		// Writer registrations are control-plane entries that must
+		// remain admissible across the §7.1 quiescence barrier
+		// (Stage 6E-2d). Without the admin path, a new member
+		// joining mid-barrier could not register its writer entry
+		// — the barrier would reject the registration with
+		// ErrEnvelopeCutoverInProgress and the join would stall.
+		if _, err := defaultEngine.ProposeAdmin(attemptCtx, entry); err != nil {
+			return errors.Wrap(err, "writer registration: local propose-admin")
 		}
 		return nil
 	}

--- a/main_encryption_registration.go
+++ b/main_encryption_registration.go
@@ -483,9 +483,23 @@ func proposeWriterRegistration(
 		// Writer registrations are control-plane entries that must
 		// remain admissible across the §7.1 quiescence barrier
 		// (Stage 6E-2d). Without the admin path, a new member
-		// joining mid-barrier could not register its writer entry
-		// — the barrier would reject the registration with
-		// ErrEnvelopeCutoverInProgress and the join would stall.
+		// joining mid-barrier — or a leader restart that triggers
+		// buildProcessStartRegistrationGate in the middle of a
+		// cutover window — could not register its writer entry;
+		// the barrier would reject the registration with
+		// ErrEnvelopeCutoverInProgress and the local epoch would
+		// never publish.
+		//
+		// ProposeAdmin is barrier-exempt only — it does NOT
+		// bypass any wrap layer. defaultEngine is the raw raft
+		// engine (no wrap above it in today's wiring), so the
+		// 0x03 registration entry currently lands cleartext.
+		// That is correct pre-cutover; once Stage 6E-2c/2e wire
+		// the wrap layer onto admin paths, this call site must
+		// also pick up that wrap so a post-cutover registration
+		// landing at `index > raftEnvelopeCutoverIndex` carries
+		// the AEAD envelope the §6.3 strict-`>` apply hook
+		// expects. Tracked alongside the 6E-2c/2e wiring.
 		if _, err := defaultEngine.ProposeAdmin(attemptCtx, entry); err != nil {
 			return errors.Wrap(err, "writer registration: local propose-admin")
 		}

--- a/main_sqs_leadership_refusal_test.go
+++ b/main_sqs_leadership_refusal_test.go
@@ -20,6 +20,9 @@ import (
 func (f *fakeLeadershipController) Propose(_ context.Context, _ []byte) (*raftengine.ProposalResult, error) {
 	return &raftengine.ProposalResult{}, nil
 }
+func (f *fakeLeadershipController) ProposeAdmin(ctx context.Context, data []byte) (*raftengine.ProposalResult, error) {
+	return f.Propose(ctx, data)
+}
 func (f *fakeLeadershipController) Leader() raftengine.LeaderInfo        { return raftengine.LeaderInfo{} }
 func (f *fakeLeadershipController) VerifyLeader(_ context.Context) error { return nil }
 func (f *fakeLeadershipController) LinearizableRead(_ context.Context) (uint64, error) {


### PR DESCRIPTION
## Summary

Stage 6E-2b: extend `raftengine.Proposer` with a sibling `ProposeAdmin` method, implement on every existing implementer (the etcd engine + 14 test mocks + the kv `wrappedProposer`), and migrate the two production control-plane call sites to it.

In this build `Propose` and `ProposeAdmin` are operationally identical — the etcd engine routes through a shared private `propose()` impl, and the kv wrapper's `ProposeAdmin` skips the configured `RaftPayloadWrapper` (the cutover entry must remain cleartext at `index == cutover` for the §6.3 strict-`>` dispatch to find it).

Stage 6E-2d will diverge the two paths: `Propose` gains a §7.1 quiescence-barrier check that rejects with the `ErrEnvelopeCutoverInProgress` sentinel (already defined in 6E-2a, #908), while `ProposeAdmin` remains admissible. This PR is the prerequisite migration — call sites that should bypass the barrier must move to `ProposeAdmin` **before** the barrier ships, otherwise they would fail closed at the moment 6E-2d lands.

## Production callsite migration

- `adapter/encryption_admin.go`'s `proposeEncryptionEntry` helper — composes BootstrapEncryption, EnableStorageEnvelope, the §6E EnableRaftEnvelope cutover marker, and every other admin op. All exempt from the barrier.
- `main_encryption_registration.go`'s local ConfChange-time writer registration (Stage 7c §3.1). Without admin-path exemption, a new member joining mid-barrier could not register its writer entry.

## Tests added

- `TestProposeAdmin_EquivalentToProposeToday` — pins that both methods commit identical entries through the same Raft path, reach the FSM verbatim, and advance `CommitIndex`. This is the bridge property the migration relies on.
- `TestProposerInterface_RequiresProposeAdmin` — compile-time guard against silent reverts of the interface extension.
- `TestWrappedProposer_ProposeAdminBypassesWrap` — pins the wrap-bypass invariant: even with a wrap closure configured, `ProposeAdmin` payloads reach `inner.ProposeAdmin` cleartext (not `inner.Propose` and not wrapped).

## Five-lens self-review

- **Data loss**: no FSM apply path changed; `Propose` body refactored to `return e.propose(ctx, data)`; `proposalRequest` layout unchanged; no new error swallow.
- **Concurrency / distributed**: `ProposeAdmin` reuses the same `proposalRequest` channel and the same `nextID()` atomic; no new shared state.
- **Performance**: one extra function-call frame per propose (the extracted helper), inlined by the compiler; no new allocations, no new locks.
- **Data consistency**: both methods exercise the identical raft proposal path so consensus / commit-index invariants are preserved. The 6E-2d barrier will live above `propose()`, not inside it.
- **Test coverage**: engine-level equivalence + interface compile-time guard + wrap-bypass pin. Every test mock updated in lockstep; `recordingProposer` / `applyingProposer` in the encryption-admin suite collapse `ProposeAdmin` to `Propose` so the 50+ existing assertions on `.calls` continue to work after the production callsite switch.

## Caller audit (per the `/loop` semantic-change rule)

The interface gained a method; every implementer either picks up the new method explicitly (production) or forwards to `Propose` (test mocks). 2 production callsites migrated to `ProposeAdmin`; 15 implementers carry the method; no caller can silently regress because the interface itself enforces it at compile time.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean (0 issues; pre-commit hook ran)
- [x] `go test -race ./internal/raftengine/etcd/` passes
- [x] `go test -race ./kv/` passes (scoped to the affected tests)
- [x] `go test -race ./internal/raftadmin/` passes
- [x] Encryption-admin / EnableRaftEnvelope / EnableStorageEnvelope / Bootstrap / Rotation / Registration tests pass in `./adapter/`
- [x] Root-package test `go test -race .` passes

Refs: `docs/design/2026_05_31_partial_6e_enable_raft_envelope.md` §7.1
