### PR TITLE
docs: align admin.md flags to double-dash convention

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -10,11 +10,11 @@ read that first if you're touching the code.
 A separate HTTP listener (default `127.0.0.1:8080`) that exposes a
 React SPA + JSON API for inspecting the cluster and managing
 DynamoDB tables / S3 buckets without having to construct SigV4
-requests. It is **disabled by default**: set `-adminEnabled` to turn
+requests. It is **disabled by default**: set `--adminEnabled` to turn
 it on.
 
 The listener is independent of the data-plane DynamoDB
-(`-dynamoAddress`) and S3 (`-s3Address`) endpoints — credentials,
+(`--dynamoAddress`) and S3 (`--s3Address`) endpoints — credentials,
 TLS, and auth are configured separately.
 
 ## Quick start (loopback dev)
@@ -23,13 +23,13 @@ The minimum invocation that produces a working dashboard:
 
 ```sh
 ./elastickv \
-  -raftId=n1 -raftBootstrap \
-  -dynamoAddress=127.0.0.1:8000 \
-  -s3Address=127.0.0.1:9000 \
-  -s3CredentialsFile=/path/to/creds.json \
-  -adminEnabled \
-  -adminSessionSigningKeyFile=/path/to/admin-hs256.b64 \
-  -adminFullAccessKeys=AKIA_ADMIN
+  --raftId=n1 --raftBootstrap \
+  --dynamoAddress=127.0.0.1:8000 \
+  --s3Address=127.0.0.1:9000 \
+  --s3CredentialsFile=/path/to/creds.json \
+  --adminEnabled \
+  --adminSessionSigningKeyFile=/path/to/admin-hs256.b64 \
+  --adminFullAccessKeys=AKIA_ADMIN
 ```
 
 Then open `http://127.0.0.1:8080/admin/` in a browser and log in
@@ -37,35 +37,35 @@ with the access key + secret pair from the credentials file.
 
 ## Configuration reference
 
-### Required when `-adminEnabled=true`
+### Required when `--adminEnabled=true`
 
 | Flag | Description |
 |---|---|
-| `-adminEnabled` | Master on/off switch. Default `false`. |
-| `-adminSessionSigningKey` *or* `-adminSessionSigningKeyFile` *or* `ELASTICKV_ADMIN_SESSION_SIGNING_KEY` | Cluster-shared base64-encoded HS256 key — **exactly 64 raw bytes** (88 base64 chars with standard padding, or 86 with `RawURLEncoding`). The validator rejects any other length at startup with a precise error message. **Must be the same on every node** — JWTs minted by node A are verified by node B during follower→leader forwarding, so a mismatch breaks the dashboard's read paths on follower nodes. The `*File` / env-var forms keep the secret out of `/proc/<pid>/cmdline`. |
-| `-s3CredentialsFile` | JSON file with at least one access key + secret key pair. Same file the S3 adapter uses for SigV4; the admin dashboard reuses it for login authentication. |
-| `-adminFullAccessKeys` *and/or* `-adminReadOnlyAccessKeys` | Comma-separated allow-lists. Only access keys listed here may log into the dashboard, even if their SigV4 secret validates against the credentials file. Keys must not appear in both lists. |
+| `--adminEnabled` | Master on/off switch. Default `false`. |
+| `--adminSessionSigningKey` *or* `--adminSessionSigningKeyFile` *or* `ELASTICKV_ADMIN_SESSION_SIGNING_KEY` | Cluster-shared base64-encoded HS256 key — **exactly 64 raw bytes** (88 base64 chars with standard padding, or 86 with `RawURLEncoding`). The validator rejects any other length at startup with a precise error message. **Must be the same on every node** — JWTs minted by node A are verified by node B during follower→leader forwarding, so a mismatch breaks the dashboard's read paths on follower nodes. The `*File` / env-var forms keep the secret out of `/proc/<pid>/cmdline`. |
+| `--s3CredentialsFile` | JSON file with at least one access key + secret key pair. Same file the S3 adapter uses for SigV4; the admin dashboard reuses it for login authentication. |
+| `--adminFullAccessKeys` *and/or* `--adminReadOnlyAccessKeys` | Comma-separated allow-lists. Only access keys listed here may log into the dashboard, even if their SigV4 secret validates against the credentials file. Keys must not appear in both lists. |
 
 ### Optional
 
 | Flag | Description |
 |---|---|
-| `-adminListen` | host:port for the admin listener. Defaults to `127.0.0.1:8080`. |
-| `-adminTLSCertFile` / `-adminTLSKeyFile` | PEM cert + key. Both must be set together; a partial config fails validation at startup. |
-| `-adminAllowPlaintextNonLoopback` | Explicit opt-out for the non-loopback-without-TLS startup hard-error. **Strongly discouraged** — lets the listener accept plaintext on a non-loopback bind. **Does not** affect the cookie `Secure` attribute (that is `-adminAllowInsecureDevCookie` below); a deployment that sets only this flag will mint `Secure` cookies that the browser refuses to send over the plaintext channel, breaking session lifetime end-to-end. Pair it with `-adminAllowInsecureDevCookie` if the goal is a working plaintext rig. |
-| `-adminSessionSigningKeyPrevious` *or* `-adminSessionSigningKeyPreviousFile` *or* `ELASTICKV_ADMIN_SESSION_SIGNING_KEY_PREVIOUS` | Previous HS256 key used only for verification during a rotation window. New tokens always use the primary key; existing tokens minted under the previous key continue to verify until they expire. |
-| `-adminAllowInsecureDevCookie` | Mints session cookies without `Secure` for local plaintext development. Do not set on any deployment that touches a network. |
+| `--adminListen` | host:port for the admin listener. Defaults to `127.0.0.1:8080`. |
+| `--adminTLSCertFile` / `--adminTLSKeyFile` | PEM cert + key. Both must be set together; a partial config fails validation at startup. |
+| `--adminAllowPlaintextNonLoopback` | Explicit opt-out for the non-loopback-without-TLS startup hard-error. **Strongly discouraged** — lets the listener accept plaintext on a non-loopback bind. **Does not** affect the cookie `Secure` attribute (that is `--adminAllowInsecureDevCookie` below); a deployment that sets only this flag will mint `Secure` cookies that the browser refuses to send over the plaintext channel, breaking session lifetime end-to-end. Pair it with `--adminAllowInsecureDevCookie` if the goal is a working plaintext rig. |
+| `--adminSessionSigningKeyPrevious` *or* `--adminSessionSigningKeyPreviousFile` *or* `ELASTICKV_ADMIN_SESSION_SIGNING_KEY_PREVIOUS` | Previous HS256 key used only for verification during a rotation window. New tokens always use the primary key; existing tokens minted under the previous key continue to verify until they expire. |
+| `--adminAllowInsecureDevCookie` | Mints session cookies without `Secure` for local plaintext development. Do not set on any deployment that touches a network. |
 
 ### Hard-error startup conditions
 
 The process fails to start (non-zero exit) when:
 
-- `-adminEnabled=true` but `-s3CredentialsFile` is empty or missing, or its parsed map has zero entries — without credentials every login is rejected, and "locked-down admin" is `-adminEnabled=false`.
-- `-adminEnabled=true` but `-adminSessionSigningKey` (and the `*File` / env var) all decode to empty.
-- `-adminEnabled=true` but `-adminListen` is empty or not a valid host:port.
-- `-adminTLSCertFile` xor `-adminTLSKeyFile` is set (partial TLS config).
-- `-adminListen` is bound to a non-loopback address, TLS is not configured, **and** `-adminAllowPlaintextNonLoopback` is not set. The error message names the flag combinations that resolve it.
-- `-adminFullAccessKeys` and `-adminReadOnlyAccessKeys` overlap (the same access key listed in both).
+- `--adminEnabled=true` but `--s3CredentialsFile` is empty or missing, or its parsed map has zero entries — without credentials every login is rejected, and "locked-down admin" is `--adminEnabled=false`.
+- `--adminEnabled=true` but `--adminSessionSigningKey` (and the `*File` / env var) all decode to empty.
+- `--adminEnabled=true` but `--adminListen` is empty or not a valid host:port.
+- `--adminTLSCertFile` xor `--adminTLSKeyFile` is set (partial TLS config).
+- `--adminListen` is bound to a non-loopback address, TLS is not configured, **and** `--adminAllowPlaintextNonLoopback` is not set. The error message names the flag combinations that resolve it.
+- `--adminFullAccessKeys` and `--adminReadOnlyAccessKeys` overlap (the same access key listed in both).
 
 These are deliberate — silent fallbacks to "auth disabled" or "TLS
 off" would downgrade security guarantees the operator is unaware of.
@@ -80,15 +80,15 @@ No TLS required. By default the dashboard mints cookies with
 `Secure=true`, which most modern browsers accept on the loopback
 origin even without TLS (the loopback-is-trusted policy). If a
 specific browser refuses the cookie in this configuration, set
-`-adminAllowInsecureDevCookie` to mint without `Secure` — the flag
-is intentionally distinct from `-adminAllowPlaintextNonLoopback`
+`--adminAllowInsecureDevCookie` to mint without `Secure` — the flag
+is intentionally distinct from `--adminAllowPlaintextNonLoopback`
 because the listener can be plaintext for entirely separate
 reasons (loopback) than the cookie needing to drop `Secure`.
 
 ### B. Reachable address with TLS
 
-Set `-adminListen` to the public bind, plus `-adminTLSCertFile` and
-`-adminTLSKeyFile`. TLS 1.2+ is enforced. Cookies are issued with
+Set `--adminListen` to the public bind, plus `--adminTLSCertFile` and
+`--adminTLSKeyFile`. TLS 1.2+ is enforced. Cookies are issued with
 `Secure; SameSite=Strict; HttpOnly`.
 
 Cert renewal: the listener picks up the cert files at startup only;
@@ -97,13 +97,13 @@ implemented (out of scope for the dashboard's maintenance model).
 
 ### Discouraged: plaintext non-loopback
 
-`-adminAllowPlaintextNonLoopback` exists as an escape hatch for
+`--adminAllowPlaintextNonLoopback` exists as an escape hatch for
 short-lived test deployments. The session JWT and its bearer cookie
 travel in clear text in this mode; anyone on the path can replay
 the token until it expires. Do not enable on a long-running
 deployment.
 
-A working plaintext rig also needs `-adminAllowInsecureDevCookie` —
+A working plaintext rig also needs `--adminAllowInsecureDevCookie` —
 otherwise the dashboard mints cookies with `Secure=true` and the
 browser refuses to send them back over plaintext, so login appears
 to succeed but every subsequent request 401s. The two flags are
@@ -113,14 +113,14 @@ silently downgrading both at once.
 
 ## Roles
 
-Two roles, both checked against the live `-adminFullAccessKeys` /
-`-adminReadOnlyAccessKeys` lists on **every** state-changing
+Two roles, both checked against the live `--adminFullAccessKeys` /
+`--adminReadOnlyAccessKeys` lists on **every** state-changing
 request (not just at login):
 
 - **read-only** — may list / describe Dynamo tables and S3 buckets, view cluster status. Cannot create, mutate ACL, or delete.
 - **full** — adds POST / PUT / DELETE on `/dynamo/tables` and `/s3/buckets`.
 
-A key revoked from `-adminFullAccessKeys` immediately loses
+A key revoked from `--adminFullAccessKeys` immediately loses
 write access on the next request — the dashboard does not wait for
 the token to expire. The token's role claim is treated as a hint;
 the live role index is authoritative.
@@ -158,14 +158,14 @@ acting — a follower cannot smuggle a downgraded key past the
 leader's view.
 
 This means there is **no need to point the SPA at a specific
-node**: any node with `-adminEnabled` can serve the dashboard.
+node**: any node with `--adminEnabled` can serve the dashboard.
 Operators that fan out behind a load balancer get the same
 behaviour as a single-node cluster, with one caveat below.
 
 ### Follower forwarding caveat: rolling configuration changes
 
 A configuration change (e.g. adding `AKIA_NEW` to
-`-adminFullAccessKeys`) must propagate to **every node** before
+`--adminFullAccessKeys`) must propagate to **every node** before
 the new key works against any follower's dashboard. During the
 rollout window:
 
@@ -275,7 +275,7 @@ present-only-on-login.
 
 ### "admin listener is enabled but no static credentials are configured"
 
-Either `-s3CredentialsFile` is unset or the file parses to an empty
+Either `--s3CredentialsFile` is unset or the file parses to an empty
 map. Check the file exists and contains at least one entry:
 ```json
 {"credentials":[{"access_key_id":"AKIA_ADMIN","secret_access_key":"..."}]}
@@ -283,14 +283,14 @@ map. Check the file exists and contains at least one entry:
 
 ### "is not loopback but TLS is not configured"
 
-Default-deny safety net. Either set `-adminTLSCertFile` +
-`-adminTLSKeyFile`, or pass `-adminAllowPlaintextNonLoopback` (and
+Default-deny safety net. Either set `--adminTLSCertFile` +
+`--adminTLSKeyFile`, or pass `--adminAllowPlaintextNonLoopback` (and
 read the TLS section above before doing so).
 
 ### Login returns 401 invalid_credentials
 
 The access key + secret pair did not match an entry in
-`-s3CredentialsFile`. Either the access key is unknown or the secret
+`--s3CredentialsFile`. Either the access key is unknown or the secret
 is wrong. Verify the credentials file is the one the running process
 loaded (it is read once at startup) and that the secret matches
 exactly — secrets are compared with `subtle.ConstantTimeCompare`, so
@@ -299,7 +299,7 @@ trailing whitespace counts.
 ### Login returns 403 forbidden
 
 The credentials matched, but the access key is not listed in either
-`-adminFullAccessKeys` or `-adminReadOnlyAccessKeys`. This is a
+`--adminFullAccessKeys` or `--adminReadOnlyAccessKeys`. This is a
 distinct case from the 401 above: the operator has valid SigV4
 credentials for the data plane but no admin role assignment. Add the
 key to one of the role flags and **restart every node** so each
@@ -308,8 +308,8 @@ node's live role index picks up the change.
 ### Write returns 403 forbidden
 
 The principal's role is read-only. Move the access key into
-`-adminFullAccessKeys` (and remove it from
-`-adminReadOnlyAccessKeys`), then **restart every node** so each
+`--adminFullAccessKeys` (and remove it from
+`--adminReadOnlyAccessKeys`), then **restart every node** so each
 node's live role index picks up the change.
 
 ### Write returns 503 leader_unavailable


### PR DESCRIPTION
## Summary

Follow-up to #918. The README admin dashboard section was aligned to the project's double-dash flag convention (`--adminEnabled`), but `docs/admin.md` still used single-dash flags throughout. This converts all flag references in `docs/admin.md` to double-dash so the admin docs are internally consistent with the README and the rest of the project.

Converted (61 occurrences across 43 lines): `--adminEnabled`, `--adminListen`, `--adminSessionSigningKey` (and the `File` / `Previous` / `PreviousFile` variants), `--adminFullAccessKeys`, `--adminReadOnlyAccessKeys`, `--adminTLSCertFile`, `--adminTLSKeyFile`, `--adminAllowPlaintextNonLoopback`, `--adminAllowInsecureDevCookie`, `--s3CredentialsFile`, `--s3Address`, `--dynamoAddress`, `--raftId`, `--raftBootstrap`.

The command name `cmd/elastickv-admin` is intentionally left untouched (it is a binary name, not a flag).

## Behavior change / risk

Documentation only — no code, no behavior change. Go's `flag` package accepts both `-flag` and `--flag`, so every example continues to work as written; this is purely a consistency cleanup. Risk: none.

## Test evidence

N/A (Markdown only). Verified via diff that all flag tokens were converted and `cmd/elastickv-admin` was preserved.

## Self-review

1. **Data loss** — N/A (no code paths).
2. **Concurrency / distributed failures** — N/A.
3. **Performance** — N/A.
4. **Data consistency** — N/A.
5. **Test coverage** — N/A (docs-only); replacement scope verified by diff (only `cmd/elastickv-admin` retains a single dash, by design).
