### PR TITLE
fix(adapter/dynamodb): option-2 one-phase dedup for single-item writes

### DIFF
--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -141,7 +141,7 @@ type DynamoDBServer struct {
 	// under a fresh commit_ts and carries prev_commit_ts so the FSM no-ops a
 	// commit that already landed under leadership churn (the :duplicate-elements
 	// anomaly). It MUST stay off until every node runs a probe-aware binary —
-	// see R5 in docs/design/2026_06_03_proposed_dynamodb_onephase_dedup.md.
+	// see R5 in docs/design/2026_06_03_partial_dynamodb_onephase_dedup.md.
 	// Default off; enabled via WithDynamoOnePhaseTxnDedup or the
 	// ELASTICKV_DYNAMODB_ONEPHASE_DEDUP env var.
 	onePhaseTxnDedup bool
@@ -1261,10 +1261,34 @@ func (d *DynamoDBServer) retryItemWriteWithGeneration(
 	// reuse the failed attempt's write set under a fresh commit_ts + prev_commit_ts
 	// so the FSM no-ops a commit that already landed under leadership churn,
 	// instead of re-reading and re-appending (the :duplicate-elements anomaly).
-	// See docs/design/2026_06_03_proposed_dynamodb_onephase_dedup.md.
-	if d.onePhaseTxnDedup {
+	// See docs/design/2026_06_03_partial_dynamodb_onephase_dedup.md.
+	//
+	// Leader-only (codex P1, PR #920): the dedup path allocates commit_ts from
+	// the LOCAL HLC and carries it as prev_commit_ts, so that timestamp MUST be
+	// leader-issued to stay globally unique — otherwise two frontends could mint
+	// the same commit_ts in one millisecond and the exact-ts probe would dedup
+	// against the wrong writer's version, losing an update. On the leader the
+	// single HLC issues monotonic unique values, and NextFenced's physical-ceiling
+	// fence keeps a deposed leader's window disjoint from its successor's. A
+	// non-leader (reachable only when no leaderMap HTTP proxy forwards follower
+	// ingress) falls back to the legacy path, where Coordinator.Dispatch redirects
+	// to the leader and the LEADER allocates commit_ts — never this follower's HLC.
+	if d.onePhaseTxnDedup && d.coordinator.IsLeader() {
 		return d.retryItemWriteWithGenerationDedup(ctx, tableName, exhaustedMessage, prepare)
 	}
+	return d.retryItemWriteWithGenerationLegacy(ctx, tableName, exhaustedMessage, prepare)
+}
+
+// retryItemWriteWithGenerationLegacy is the pre-dedup retry loop: it recomputes
+// the write set from a fresh read on every retryable error. It is the active
+// path whenever the dedup gate is off or this node is not the leader, so it
+// stays byte-identical to the pre-feature behavior.
+func (d *DynamoDBServer) retryItemWriteWithGenerationLegacy(
+	ctx context.Context,
+	tableName string,
+	exhaustedMessage string,
+	prepare func(readTS uint64) (*itemWritePlan, error),
+) (*itemWritePlan, error) {
 	backoff := transactRetryInitialBackoff
 	deadline := time.Now().Add(transactRetryMaxDuration)
 	for range transactRetryMaxAttempts {
@@ -1309,7 +1333,7 @@ func (d *DynamoDBServer) retryItemWriteWithGeneration(
 // leadership churn: attempt 1 commits at C1 but returns a WriteConflict, the
 // retry re-reads the now-larger list and appends again. Reuse + the FSM's
 // exact-ts dedup probe close that. See option 2 in
-// docs/design/2026_06_03_proposed_dynamodb_onephase_dedup.md.
+// docs/design/2026_06_03_partial_dynamodb_onephase_dedup.md.
 type reusableItemWrite struct {
 	// plan holds the reused OperationGroup (plan.req: Elems + fixed StartTS) and
 	// the captured current/next item. The client-visible result
@@ -1353,8 +1377,10 @@ func (d *DynamoDBServer) retryItemWriteWithGenerationDedup(
 			plan, pending, err = d.itemWriteFirstAttempt(ctx, tableName, prepare)
 		}
 		if err != nil {
+			// commitItemWrite already wraps dispatch errors; the attempt helpers
+			// return them raw, so return raw here too (no double WithStack).
 			if !isRetryableTransactWriteError(err) {
-				return nil, errors.WithStack(err)
+				return nil, err
 			}
 		} else if plan != nil {
 			return plan, nil
@@ -1395,14 +1421,15 @@ func (d *DynamoDBServer) itemWriteFirstAttempt(
 	plan.req.StartTS = readTS
 	plan.req.CommitTS = commitTS
 	if dispErr := d.commitItemWrite(ctx, plan.req); dispErr != nil {
+		// dispErr is already wrapped by commitItemWrite; return it raw.
 		if isRetryableTransactWriteError(dispErr) {
 			return nil, &reusableItemWrite{
 				plan:     plan,
 				commitTS: commitTS,
 				probeKey: kv.PrimaryKeyForElems(plan.req.Elems),
-			}, errors.WithStack(dispErr)
+			}, dispErr
 		}
-		return nil, nil, errors.WithStack(dispErr)
+		return nil, nil, dispErr
 	}
 	return d.finishItemWriteAttempt(ctx, tableName, plan)
 }
@@ -1430,11 +1457,12 @@ func (d *DynamoDBServer) itemWriteReuseAttempt(
 	}
 	if isRetryableTransactWriteError(dispErr) {
 		// Still ambiguous (e.g. TxnLocked): this reuse may itself have landed,
-		// so the next retry must probe THIS commit_ts.
+		// so the next retry must probe THIS commit_ts. dispErr is already
+		// wrapped by commitItemWrite; return it raw.
 		pending.commitTS = commitTS
-		return nil, pending, errors.WithStack(dispErr)
+		return nil, pending, dispErr
 	}
-	return nil, nil, errors.WithStack(dispErr)
+	return nil, nil, dispErr
 }
 
 // resolveReuseWriteConflict handles a WriteConflict from a reuse dispatch via
@@ -1451,11 +1479,22 @@ func (d *DynamoDBServer) resolveReuseWriteConflict(
 ) (*itemWritePlan, *reusableItemWrite, error) {
 	if len(pending.probeKey) > 0 {
 		landed, perr := d.store.CommittedVersionAt(ctx, pending.probeKey, commitTS)
-		if perr == nil && landed {
+		if perr != nil {
+			// Fail closed: a probe read error makes "did our reuse land?"
+			// unknowable, and a blind recompute would double-append if it HAD
+			// landed. Surface the probe error instead of silently recomputing,
+			// matching the FSM-side dedupProbeOnePhase (kv/fsm.go) which also
+			// propagates probe errors. The wrapped error is non-retryable, so
+			// the loop returns it to the client rather than re-applying.
+			return nil, nil, errors.Wrap(perr, "dynamodb item-write: self-conflict probe")
+		}
+		if landed {
 			return pending.plan, nil, nil
 		}
 	}
-	return nil, nil, errors.WithStack(dispErr)
+	// Probe missed (or no probe key): a genuine cross-writer conflict. dispErr
+	// is already wrapped by commitItemWrite; return it raw so the loop recomputes.
+	return nil, nil, dispErr
 }
 
 // finishItemWriteAttempt runs the table-generation fence after a successful

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -1453,7 +1453,7 @@ func (d *DynamoDBServer) itemWriteReuseAttempt(
 		return d.finishItemWriteAttempt(ctx, tableName, pending.plan)
 	}
 	if errors.Is(dispErr, store.ErrWriteConflict) {
-		return d.resolveReuseWriteConflict(ctx, pending, commitTS, dispErr)
+		return d.resolveReuseWriteConflict(ctx, tableName, pending, commitTS, dispErr)
 	}
 	if isRetryableTransactWriteError(dispErr) {
 		// Still ambiguous (e.g. TxnLocked): this reuse may itself have landed,
@@ -1473,6 +1473,7 @@ func (d *DynamoDBServer) itemWriteReuseAttempt(
 // txn — drop pending so the next iteration recomputes from a fresh read.
 func (d *DynamoDBServer) resolveReuseWriteConflict(
 	ctx context.Context,
+	tableName string,
 	pending *reusableItemWrite,
 	commitTS uint64,
 	dispErr error,
@@ -1489,7 +1490,11 @@ func (d *DynamoDBServer) resolveReuseWriteConflict(
 			return nil, nil, errors.Wrap(perr, "dynamodb item-write: self-conflict probe")
 		}
 		if landed {
-			return pending.plan, nil, nil
+			// The reuse landed at commitTS. Run the SAME generation fence +
+			// cleanup the normal success path runs (finishItemWriteAttempt), so
+			// a table dropped/recreated under us cleans up the landed write and
+			// recomputes instead of returning a stale plan (coderabbit major).
+			return d.finishItemWriteAttempt(ctx, tableName, pending.plan)
 		}
 	}
 	// Probe missed (or no probe key): a genuine cross-writer conflict. dispErr

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -12,6 +12,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"os"
 	"slices"
 	"sort"
 	"strconv"
@@ -133,6 +134,17 @@ type DynamoDBServer struct {
 	itemUpdateLocks [itemUpdateLockStripeCount]sync.Mutex
 	tableLocks      [tableLockStripeCount]sync.Mutex
 	leaderDynamo    map[string]string
+
+	// onePhaseTxnDedup enables option-2 one-phase idempotency on the
+	// single-item write path (UpdateItem / PutItem / DeleteItem): on a
+	// retryable write error, the retry REUSES the failed attempt's write set
+	// under a fresh commit_ts and carries prev_commit_ts so the FSM no-ops a
+	// commit that already landed under leadership churn (the :duplicate-elements
+	// anomaly). It MUST stay off until every node runs a probe-aware binary —
+	// see R5 in docs/design/2026_06_03_proposed_dynamodb_onephase_dedup.md.
+	// Default off; enabled via WithDynamoOnePhaseTxnDedup or the
+	// ELASTICKV_DYNAMODB_ONEPHASE_DEDUP env var.
+	onePhaseTxnDedup bool
 }
 
 // WithDynamoDBRequestObserver enables Prometheus-compatible request metrics.
@@ -157,6 +169,15 @@ func WithDynamoDBLeaderMap(m map[string]string) DynamoDBServerOption {
 		for k, v := range m {
 			server.leaderDynamo[k] = v
 		}
+	}
+}
+
+// WithDynamoOnePhaseTxnDedup enables the option-2 one-phase idempotency dedup on
+// the single-item write retry path (see DynamoDBServer.onePhaseTxnDedup). Off by
+// default; enable only after the whole cluster runs a probe-aware binary.
+func WithDynamoOnePhaseTxnDedup(enabled bool) DynamoDBServerOption {
+	return func(server *DynamoDBServer) {
+		server.onePhaseTxnDedup = enabled
 	}
 }
 
@@ -244,9 +265,10 @@ func (r *dynamoResponseRecorder) BytesWritten() int {
 
 func NewDynamoDBServer(listen net.Listener, st store.MVCCStore, coordinate kv.Coordinator, opts ...DynamoDBServerOption) *DynamoDBServer {
 	d := &DynamoDBServer{
-		listen:      listen,
-		store:       st,
-		coordinator: coordinate,
+		listen:           listen,
+		store:            st,
+		coordinator:      coordinate,
+		onePhaseTxnDedup: os.Getenv("ELASTICKV_DYNAMODB_ONEPHASE_DEDUP") == "1",
 	}
 	d.targetHandlers = map[string]func(http.ResponseWriter, *http.Request){
 		createTableTarget:        d.createTable,
@@ -1235,6 +1257,14 @@ func (d *DynamoDBServer) retryItemWriteWithGeneration(
 	exhaustedMessage string,
 	prepare func(readTS uint64) (*itemWritePlan, error),
 ) (*itemWritePlan, error) {
+	// Option-2 one-phase dedup (gated, default off): on a retryable write error,
+	// reuse the failed attempt's write set under a fresh commit_ts + prev_commit_ts
+	// so the FSM no-ops a commit that already landed under leadership churn,
+	// instead of re-reading and re-appending (the :duplicate-elements anomaly).
+	// See docs/design/2026_06_03_proposed_dynamodb_onephase_dedup.md.
+	if d.onePhaseTxnDedup {
+		return d.retryItemWriteWithGenerationDedup(ctx, tableName, exhaustedMessage, prepare)
+	}
 	backoff := transactRetryInitialBackoff
 	deadline := time.Now().Add(transactRetryMaxDuration)
 	for range transactRetryMaxAttempts {
@@ -1270,6 +1300,185 @@ func (d *DynamoDBServer) retryItemWriteWithGeneration(
 		backoff = nextTransactRetryBackoff(backoff)
 	}
 	return nil, newDynamoAPIError(http.StatusInternalServerError, dynamoErrInternal, exhaustedMessage)
+}
+
+// reusableItemWrite captures a dispatched single-item write attempt so a
+// subsequent retry can REUSE its exact write set (the same Put/Del elems) under
+// a fresh commit_ts and probe whether it already landed, instead of re-reading
+// and recomputing the item. Recomputing is what duplicates a list_append under
+// leadership churn: attempt 1 commits at C1 but returns a WriteConflict, the
+// retry re-reads the now-larger list and appends again. Reuse + the FSM's
+// exact-ts dedup probe close that. See option 2 in
+// docs/design/2026_06_03_proposed_dynamodb_onephase_dedup.md.
+type reusableItemWrite struct {
+	// plan holds the reused OperationGroup (plan.req: Elems + fixed StartTS) and
+	// the captured current/next item. The client-visible result
+	// (updateItemReturnAttributes over current/next) is invariant across reuse
+	// — the write set was built once from attempt 1's read — so plan is also the
+	// correct value to return when the FSM dedup no-ops the apply (R1).
+	plan *itemWritePlan
+	// commitTS is the most recent dispatched commit_ts for this write set; the
+	// next retry passes it as PrevCommitTS so the FSM probes exactly the attempt
+	// that might have landed.
+	commitTS uint64
+	// probeKey is kv.PrimaryKeyForElems(plan.req.Elems) — the same key the FSM
+	// uses as meta.PrimaryKey — so the adapter-side self-inflicted-conflict guard
+	// and the FSM dedup probe agree on the point they query (R4).
+	probeKey []byte
+}
+
+// retryItemWriteWithGenerationDedup is the option-2 retry loop. The first
+// attempt computes the write set from a fresh read; any retryable failure makes
+// the next iteration REUSE that write set under a fresh commit_ts carrying
+// prev_commit_ts, so the FSM no-ops if the prior attempt already landed. A
+// genuine WriteConflict on a reuse (the self-conflict probe missed) drops the
+// pending attempt and recomputes from a fresh read.
+func (d *DynamoDBServer) retryItemWriteWithGenerationDedup(
+	ctx context.Context,
+	tableName string,
+	exhaustedMessage string,
+	prepare func(readTS uint64) (*itemWritePlan, error),
+) (*itemWritePlan, error) {
+	backoff := transactRetryInitialBackoff
+	deadline := time.Now().Add(transactRetryMaxDuration)
+	var pending *reusableItemWrite
+	for range transactRetryMaxAttempts {
+		var (
+			plan *itemWritePlan
+			err  error
+		)
+		if pending != nil {
+			plan, pending, err = d.itemWriteReuseAttempt(ctx, tableName, pending)
+		} else {
+			plan, pending, err = d.itemWriteFirstAttempt(ctx, tableName, prepare)
+		}
+		if err != nil {
+			if !isRetryableTransactWriteError(err) {
+				return nil, errors.WithStack(err)
+			}
+		} else if plan != nil {
+			return plan, nil
+		}
+		if waitErr := waitRetryWithDeadline(ctx, deadline, backoff); waitErr != nil {
+			return nil, errors.WithStack(waitErr)
+		}
+		backoff = nextTransactRetryBackoff(backoff)
+	}
+	return nil, newDynamoAPIError(http.StatusInternalServerError, dynamoErrInternal, exhaustedMessage)
+}
+
+// itemWriteFirstAttempt runs the recompute branch of the dedup loop: a fresh
+// read snapshot, a locally-allocated commit_ts, and a dispatch. On a retryable
+// write error it returns a reusableItemWrite so the next iteration reuses this
+// write set. Return shapes match itemWriteReuseAttempt (see
+// retryItemWriteWithGenerationDedup).
+func (d *DynamoDBServer) itemWriteFirstAttempt(
+	ctx context.Context,
+	tableName string,
+	prepare func(readTS uint64) (*itemWritePlan, error),
+) (*itemWritePlan, *reusableItemWrite, error) {
+	readTS := d.nextTxnReadTS()
+	plan, err := prepare(readTS)
+	if err != nil {
+		return nil, nil, err
+	}
+	if plan.req == nil {
+		return plan, nil, nil
+	}
+	// NextFenced (not Next) honors the HLC physical-ceiling fence so a
+	// stale-leader window cannot mint a colliding commit_ts (HLC-4);
+	// ErrCeilingExpired is non-retryable and surfaces to the client.
+	commitTS, err := d.coordinator.Clock().NextFenced()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "dynamodb item-write first attempt: allocate commitTS")
+	}
+	plan.req.StartTS = readTS
+	plan.req.CommitTS = commitTS
+	if dispErr := d.commitItemWrite(ctx, plan.req); dispErr != nil {
+		if isRetryableTransactWriteError(dispErr) {
+			return nil, &reusableItemWrite{
+				plan:     plan,
+				commitTS: commitTS,
+				probeKey: kv.PrimaryKeyForElems(plan.req.Elems),
+			}, errors.WithStack(dispErr)
+		}
+		return nil, nil, errors.WithStack(dispErr)
+	}
+	return d.finishItemWriteAttempt(ctx, tableName, plan)
+}
+
+// itemWriteReuseAttempt runs one reuse iteration: re-dispatch the captured write
+// set under a fresh commit_ts carrying pending.commitTS as PrevCommitTS, so the
+// FSM probes whether the prior attempt landed.
+func (d *DynamoDBServer) itemWriteReuseAttempt(
+	ctx context.Context,
+	tableName string,
+	pending *reusableItemWrite,
+) (*itemWritePlan, *reusableItemWrite, error) {
+	commitTS, err := d.coordinator.Clock().NextFenced()
+	if err != nil {
+		return nil, pending, errors.Wrap(err, "dynamodb item-write reuse: allocate commitTS")
+	}
+	pending.plan.req.CommitTS = commitTS
+	pending.plan.req.PrevCommitTS = pending.commitTS
+	dispErr := d.commitItemWrite(ctx, pending.plan.req)
+	if dispErr == nil {
+		return d.finishItemWriteAttempt(ctx, tableName, pending.plan)
+	}
+	if errors.Is(dispErr, store.ErrWriteConflict) {
+		return d.resolveReuseWriteConflict(ctx, pending, commitTS, dispErr)
+	}
+	if isRetryableTransactWriteError(dispErr) {
+		// Still ambiguous (e.g. TxnLocked): this reuse may itself have landed,
+		// so the next retry must probe THIS commit_ts.
+		pending.commitTS = commitTS
+		return nil, pending, errors.WithStack(dispErr)
+	}
+	return nil, nil, errors.WithStack(dispErr)
+}
+
+// resolveReuseWriteConflict handles a WriteConflict from a reuse dispatch via
+// the self-inflicted-conflict guard: probe whether THIS reuse's commit_ts
+// actually landed (the apply may have committed but surfaced WriteConflict under
+// churn). On a hit the conflict is against our own commit — return the cached
+// plan, no double-apply. On a miss the write key is genuinely held by another
+// txn — drop pending so the next iteration recomputes from a fresh read.
+func (d *DynamoDBServer) resolveReuseWriteConflict(
+	ctx context.Context,
+	pending *reusableItemWrite,
+	commitTS uint64,
+	dispErr error,
+) (*itemWritePlan, *reusableItemWrite, error) {
+	if len(pending.probeKey) > 0 {
+		landed, perr := d.store.CommittedVersionAt(ctx, pending.probeKey, commitTS)
+		if perr == nil && landed {
+			return pending.plan, nil, nil
+		}
+	}
+	return nil, nil, errors.WithStack(dispErr)
+}
+
+// finishItemWriteAttempt runs the table-generation fence after a successful
+// commit. Returns (plan, nil, nil) when the write is durable; (nil, nil, nil)
+// when the generation changed and the caller must recompute from a fresh read;
+// (nil, nil, err) on a fence error.
+func (d *DynamoDBServer) finishItemWriteAttempt(
+	ctx context.Context,
+	tableName string,
+	plan *itemWritePlan,
+) (*itemWritePlan, *reusableItemWrite, error) {
+	retry, verifyErr := d.handleGenerationFenceResult(
+		ctx,
+		d.verifyTableGeneration(ctx, tableName, plan.generation),
+		plan.cleanup,
+	)
+	if verifyErr != nil {
+		return nil, nil, verifyErr
+	}
+	if retry {
+		return nil, nil, nil
+	}
+	return plan, nil, nil
 }
 
 func (d *DynamoDBServer) preparePutItemWrite(ctx context.Context, in putItemInput, readTS uint64) (*itemWritePlan, error) {

--- a/adapter/dynamodb_onephase_dedup_test.go
+++ b/adapter/dynamodb_onephase_dedup_test.go
@@ -16,7 +16,7 @@ import (
 // exact-ts dedup probe on kv.PrimaryKeyForElems, a passing dedup test proves the
 // probe is load-bearing: without it a reuse would conflict against attempt 1's
 // own version, recompute the list, and duplicate.
-// See docs/design/2026_06_03_proposed_dynamodb_onephase_dedup.md.
+// See docs/design/2026_06_03_partial_dynamodb_onephase_dedup.md.
 
 const dedupTestKey = "k"
 
@@ -199,6 +199,56 @@ func TestItemWriteDedup_GenuineConflictRecomputes(t *testing.T) {
 		"genuine conflict recomputes on top of the concurrent value; element 3 appears once")
 	require.Equal(t, 3, coord.dispatches, "attempt 1 pre-reject + conflicting reuse + recompute")
 	require.Equal(t, 0, coord.probeNoOps, "neither the prior attempt nor the reuse landed; the probe must miss")
+}
+
+// TestItemWriteDedup_TxnLockedOnReuseAdvancesProbe: attempt 1 pre-rejects; the
+// first reuse returns kv.ErrTxnLocked WITHOUT applying (an ambiguous lock error
+// distinct from WriteConflict). The adapter advances pending.commitTS to that
+// reuse's commit_ts and retries; the second reuse probes the new commit_ts
+// (misses, since the locked attempt never landed) and applies exactly once.
+// Locks in the pending.commitTS update on the ambiguous-retryable branch.
+func TestItemWriteDedup_TxnLockedOnReuseAdvancesProbe(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	coord := newDedupTestCoordinator(st, 1, false) // attempt 1 pre-rejects
+	coord.txnLockedAtDispatch = 2                  // reuse #1 returns ErrTxnLocked, no apply
+	schema, server := newDedupItemWriteServer(st, coord, true)
+	seedDedupItem(t, st, schema, "1", "2")
+
+	plan, err := server.updateItemWithRetry(ctx, appendListInput())
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	require.Equal(t, []string{"1", "2", "3"}, readListValues(t, server, schema),
+		"the lock cleared on retry; the reuse applies exactly once")
+	require.Equal(t, 3, coord.dispatches, "attempt 1 pre-reject + locked reuse + applying reuse")
+	require.Equal(t, 0, coord.probeNoOps, "no attempt landed before the final apply; the probe must miss")
+}
+
+// TestItemWriteDedup_NonLeaderFallsBackToLegacy pins the leader-only guard
+// (codex P1, PR #920): with the gate ON but this node NOT the leader, the dedup
+// path is skipped so a non-leader never mints the commit_ts used as the dedup
+// identity (which could collide across frontends and lose an update). The legacy
+// recompute path runs instead — identical to gate-off — so no prev_commit_ts is
+// emitted and the probe never fires.
+func TestItemWriteDedup_NonLeaderFallsBackToLegacy(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	coord := newDedupTestCoordinator(st, 1, true) // dispatch 1 lands then errors
+	coord.leaderSet = true
+	coord.leader = false // this node is NOT the leader
+	schema, server := newDedupItemWriteServer(st, coord, true)
+	seedDedupItem(t, st, schema, "1", "2")
+
+	plan, err := server.updateItemWithRetry(ctx, appendListInput())
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	require.Equal(t, 0, coord.probeNoOps, "non-leader must not emit prev_commit_ts / use the dedup probe")
+	require.Equal(t, []string{"1", "2", "3", "3"}, readListValues(t, server, schema),
+		"non-leader falls back to the legacy recompute path (leader allocates commit_ts via redirect)")
 }
 
 // TestItemWriteDedup_DisabledKeepsLegacyPath pins that the gate is load-bearing:

--- a/adapter/dynamodb_onephase_dedup_test.go
+++ b/adapter/dynamodb_onephase_dedup_test.go
@@ -1,0 +1,225 @@
+package adapter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bootjp/elastickv/kv"
+	"github.com/bootjp/elastickv/store"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests drive the option-2 one-phase idempotency dedup on the DynamoDB
+// single-item write path (UpdateItem list_append), reusing the OCC-aware
+// dedupTestCoordinator from redis_list_dedup_test.go. Because the OCC layer is
+// real (store.ApplyMutations against StartTS) and maybeProbe mimics the FSM's
+// exact-ts dedup probe on kv.PrimaryKeyForElems, a passing dedup test proves the
+// probe is load-bearing: without it a reuse would conflict against attempt 1's
+// own version, recompute the list, and duplicate.
+// See docs/design/2026_06_03_proposed_dynamodb_onephase_dedup.md.
+
+const dedupTestKey = "k"
+
+func numberListAttr(ns ...string) attributeValue {
+	l := make([]attributeValue, 0, len(ns))
+	for _, n := range ns {
+		v := n
+		l = append(l, attributeValue{N: &v})
+	}
+	return attributeValue{L: l}
+}
+
+// dedupItemTable is the GSI-free, hash-key-only table the Jepsen
+// list-append workload uses (jepsen_append: pk HASH only). With no GSI the
+// item write is a single Put(itemKey, …), so kv.PrimaryKeyForElems == itemKey.
+func dedupItemTable() *dynamoTableSchema {
+	return &dynamoTableSchema{
+		TableName:            "jepsen_append",
+		Generation:           1,
+		KeyEncodingVersion:   dynamoOrderedKeyEncodingV2,
+		AttributeDefinitions: map[string]string{"pk": "S"},
+		PrimaryKey:           dynamoKeySchema{HashKey: "pk"},
+	}
+}
+
+func appendListInput() updateItemInput {
+	const value = "3" // the unique per-key append value the assertions expect
+	return updateItemInput{
+		TableName:                "jepsen_append",
+		Key:                      map[string]attributeValue{"pk": newStringAttributeValue(dedupTestKey)},
+		UpdateExpression:         "SET #v = list_append(if_not_exists(#v, :empty), :val)",
+		ExpressionAttributeNames: map[string]string{"#v": "val"},
+		ExpressionAttributeValues: map[string]attributeValue{
+			":empty": {L: []attributeValue{}},
+			":val":   numberListAttr(value),
+		},
+	}
+}
+
+func readListValues(t *testing.T, server *DynamoDBServer, schema *dynamoTableSchema) []string {
+	t.Helper()
+	loc, found, err := server.readLogicalItemAt(
+		context.Background(),
+		schema,
+		map[string]attributeValue{"pk": newStringAttributeValue(dedupTestKey)},
+		consistentReadLatestTS,
+	)
+	require.NoError(t, err)
+	require.True(t, found, "item must exist")
+	out := make([]string, 0, len(loc.item["val"].L))
+	for _, e := range loc.item["val"].L {
+		out = append(out, e.numberValue())
+	}
+	return out
+}
+
+func newDedupItemWriteServer(st store.MVCCStore, coord kv.Coordinator, dedup bool) (*dynamoTableSchema, *DynamoDBServer) {
+	var opts []DynamoDBServerOption
+	if dedup {
+		opts = append(opts, WithDynamoOnePhaseTxnDedup(true))
+	}
+	server := NewDynamoDBServer(nil, st, coord, opts...)
+	return dedupItemTable(), server
+}
+
+func seedDedupItem(t *testing.T, st store.MVCCStore, schema *dynamoTableSchema, values ...string) {
+	t.Helper()
+	writer := newDynamoFixtureWriter(t, st)
+	writer.writeSchema(schema)
+	writer.writeItem(schema, map[string]attributeValue{
+		"pk":  newStringAttributeValue(dedupTestKey),
+		"val": numberListAttr(values...),
+	})
+}
+
+// TestItemWriteDedup_LandedPriorAttempt_NoDuplicate is the headline: attempt 1
+// commits the list_append but returns an ambiguous WriteConflict (leadership
+// churn); the retry reuses the same write set with prev_commit_ts, the probe
+// finds the landed version at exactly that ts and no-ops, and the stored list
+// has exactly ONE copy of the appended element. Without the probe, the reuse
+// would OCC-conflict against attempt 1's own version, recompute, and duplicate
+// — the :duplicate-elements anomaly from Jepsen run 26856696842.
+func TestItemWriteDedup_LandedPriorAttempt_NoDuplicate(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	coord := newDedupTestCoordinator(st, 1, true) // dispatch 1 lands then errors
+	schema, server := newDedupItemWriteServer(st, coord, true)
+	seedDedupItem(t, st, schema, "1", "2")
+
+	plan, err := server.updateItemWithRetry(ctx, appendListInput())
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	require.Equal(t, []string{"1", "2", "3"}, readListValues(t, server, schema),
+		"only attempt 1's apply lands; the reuse dedups via the exact-ts probe — no duplicate")
+	require.Equal(t, 2, coord.dispatches, "one ambiguous-land attempt + one reuse")
+	require.Equal(t, 1, coord.probeNoOps, "the reuse must dedup via the FSM exact-ts probe")
+}
+
+// TestItemWriteDedup_PriorAttemptDidNotLand_Applies: attempt 1 pre-rejects
+// (definitely did not commit); the reuse's probe misses, so it applies the
+// reused write set at a fresh commit_ts. One element, no duplicate.
+func TestItemWriteDedup_PriorAttemptDidNotLand_Applies(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	coord := newDedupTestCoordinator(st, 1, false) // dispatch 1 pre-rejects, nothing applied
+	schema, server := newDedupItemWriteServer(st, coord, true)
+	seedDedupItem(t, st, schema, "1", "2")
+
+	plan, err := server.updateItemWithRetry(ctx, appendListInput())
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	require.Equal(t, []string{"1", "2", "3"}, readListValues(t, server, schema))
+	require.Equal(t, 2, coord.dispatches, "attempt 1 pre-rejects + reuse applies")
+	require.Equal(t, 0, coord.probeNoOps, "nothing landed, so the probe must miss and the reuse applies")
+}
+
+// TestItemWriteDedup_SelfInflictedReuseConflict_ReturnsSuccess: attempt 1
+// pre-rejects, the reuse then LANDS but surfaces WriteConflict (self-inflicted
+// conflict under churn). The adapter-side self-conflict guard probes the reuse's
+// own commit_ts, finds it landed, and returns the cached result — no recompute,
+// no double-apply.
+func TestItemWriteDedup_SelfInflictedReuseConflict_ReturnsSuccess(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	coord := newDedupTestCoordinator(st, 1, false) // attempt 1 pre-rejects (no land)
+	coord.landThenWriteConflictAtDispatch = 2      // the reuse lands then errors
+	schema, server := newDedupItemWriteServer(st, coord, true)
+	seedDedupItem(t, st, schema, "1", "2")
+
+	plan, err := server.updateItemWithRetry(ctx, appendListInput())
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	require.Equal(t, []string{"1", "2", "3"}, readListValues(t, server, schema),
+		"the reuse applied exactly once; the self-conflict guard hid the ambiguous error")
+	require.Equal(t, 2, coord.dispatches, "no recompute should fire; the reuse landed")
+	require.Equal(t, 0, coord.probeNoOps, "the FSM probe at the prior ts misses; the self-conflict guard is adapter-side")
+}
+
+// TestItemWriteDedup_GenuineConflictRecomputes: attempt 1 pre-rejects; before
+// the reuse a CONCURRENT write advances the item past the reused snapshot, so
+// the reuse genuinely OCC-conflicts and the self-conflict probe misses (our
+// attempt never landed). The adapter drops the reuse and recomputes from a
+// fresh read, appending exactly once on top of the concurrent value: no
+// duplicate, no lost update.
+func TestItemWriteDedup_GenuineConflictRecomputes(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	coord := newDedupTestCoordinator(st, 1, false) // attempt 1 pre-rejects
+	schema, server := newDedupItemWriteServer(st, coord, true)
+	seedDedupItem(t, st, schema, "1", "2")
+
+	itemKey, err := schema.itemKeyFromAttributes(map[string]attributeValue{"pk": newStringAttributeValue(dedupTestKey)})
+	require.NoError(t, err)
+	coord.beforeDispatch = func(n int) {
+		if n != 2 {
+			return
+		}
+		// A concurrent txn appends 99 at a commit_ts newer than the reused
+		// snapshot, so the reuse conflicts and must recompute.
+		body, encErr := encodeStoredDynamoItem(map[string]attributeValue{
+			"pk":  newStringAttributeValue(dedupTestKey),
+			"val": numberListAttr("1", "2", "99"),
+		})
+		require.NoError(t, encErr)
+		require.NoError(t, st.PutAt(ctx, itemKey, body, 100, 0))
+	}
+
+	plan, err := server.updateItemWithRetry(ctx, appendListInput())
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	require.Equal(t, []string{"1", "2", "99", "3"}, readListValues(t, server, schema),
+		"genuine conflict recomputes on top of the concurrent value; element 3 appears once")
+	require.Equal(t, 3, coord.dispatches, "attempt 1 pre-reject + conflicting reuse + recompute")
+	require.Equal(t, 0, coord.probeNoOps, "neither the prior attempt nor the reuse landed; the probe must miss")
+}
+
+// TestItemWriteDedup_DisabledKeepsLegacyPath pins that the gate is load-bearing:
+// with onePhaseTxnDedup OFF (the default), the legacy retry RE-READS and
+// recomputes, so a landed-then-ambiguous attempt 1 is double-applied — the
+// :duplicate-elements bug. This characterizes the pre-fix behavior the gate
+// closes; flipping the gate on (the headline test) eliminates the duplicate.
+func TestItemWriteDedup_DisabledKeepsLegacyPath(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	coord := newDedupTestCoordinator(st, 1, true) // dispatch 1 lands then errors
+	schema, server := newDedupItemWriteServer(st, coord, false)
+	seedDedupItem(t, st, schema, "1", "2")
+
+	plan, err := server.updateItemWithRetry(ctx, appendListInput())
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	require.Equal(t, []string{"1", "2", "3", "3"}, readListValues(t, server, schema),
+		"legacy path re-reads and re-appends across the leader-churn retry — the duplicate the dedup gate fixes")
+	require.Equal(t, 2, coord.dispatches, "landed attempt 1 + recompute")
+	require.Equal(t, 0, coord.probeNoOps, "no prev_commit_ts is emitted while the gate is off")
+}

--- a/adapter/redis_list_dedup_test.go
+++ b/adapter/redis_list_dedup_test.go
@@ -34,8 +34,12 @@ type dedupTestCoordinator struct {
 	// store.ErrWriteConflict — modelling leadership churn that surfaces a
 	// committed entry as a write conflict.
 	landThenWriteConflictAtDispatch int
-	dispatches                      int
-	probeNoOps                      int
+	// txnLockedAtDispatch makes the named dispatch return kv.ErrTxnLocked
+	// WITHOUT applying — an ambiguous retryable error distinct from
+	// WriteConflict, exercising the "advance pending.commitTS and retry" branch.
+	txnLockedAtDispatch int
+	dispatches          int
+	probeNoOps          int
 	// beforeDispatch, if set, runs at the start of each Dispatch with the
 	// 1-based dispatch number — lets a test inject a concurrent commit
 	// between the adapter's attempts.
@@ -62,6 +66,10 @@ func (c *dedupTestCoordinator) Dispatch(ctx context.Context, req *kv.OperationGr
 	if n == c.ambiguousDispatch && !c.ambiguousLands {
 		// OCC-style pre-reject: nothing is written, definitely did not land.
 		return nil, store.ErrWriteConflict
+	}
+	if n == c.txnLockedAtDispatch {
+		// Ambiguous lock error, nothing written: definitely did not land.
+		return nil, kv.ErrTxnLocked
 	}
 	resp, err := c.occAdapterCoordinator.Dispatch(ctx, req)
 	if err != nil {

--- a/docs/design/2026_06_03_partial_dynamodb_onephase_dedup.md
+++ b/docs/design/2026_06_03_partial_dynamodb_onephase_dedup.md
@@ -1,12 +1,14 @@
 # DynamoDB item-write one-phase idempotency dedup
 
-Status: Proposed
+Status: Partial
 Author: bootjp
 Date: 2026-06-03
 
-> **Status: proposed — no implementation yet.** Extends the option-2
-> one-phase dedup (write-set reuse + exact-`commit_ts` probe) from the Redis
-> adapter to the DynamoDB adapter's single-item write path
+> **Status: partial — M1 (adapter dedup, gated off) ships in PR #920; M2
+> (validation: add DynamoDB to the dedup-mode Jepsen workflow + 7-day green
+> criterion) is open, and S3/SQS remain separate follow-ups.** Extends the
+> option-2 one-phase dedup (write-set reuse + exact-`commit_ts` probe) from the
+> Redis adapter to the DynamoDB adapter's single-item write path
 > (`UpdateItem` / `PutItem` / `DeleteItem`). The FSM-side probe
 > (`dedupProbeOnePhase`, `kv/fsm.go`) and the request plumbing
 > (`OperationGroup.PrevCommitTS` → `onePhaseTxnRequestWithPrevCommit`) already
@@ -185,6 +187,26 @@ So the prepare step gains one line: allocate `commitTS` via
 stale-leader window cannot mint a colliding timestamp (HLC-4). `NextFenced`'s
 `ErrCeilingExpired` must be classified **non-retryable** by the adapter loop
 (surface to the client), matching the Redis call sites.
+
+**Leader-only allocation (codex P1, PR #920).** This local allocation moves
+timestamp issuance from the coordinator (which has the *leader* assign it on
+the non-dedup path) into the adapter, so it is only safe **on the leader** —
+otherwise two follower frontends could mint the same `commitTS` in one
+millisecond (the HLC logical counter is process-local), and a retry carrying
+that `prev_commit_ts` would make the FSM exact-ts probe dedup against the
+*other* writer's version, losing an update. The dedup path is therefore gated
+on `d.coordinator.IsLeader()` in addition to the feature flag: on the leader
+the single HLC issues monotonic unique values and `NextFenced`'s ceiling fence
+keeps a deposed leader's window disjoint from its successor's (so even a TOCTOU
+leadership loss after the `IsLeader()` check cannot collide); a non-leader
+falls back to the legacy path, where `Coordinator.Dispatch` redirects to the
+leader and the **leader** allocates `commitTS`. In the normal multi-node
+deployment the DynamoDB adapter already HTTP-proxies all follower ingress to
+the leader (`proxyToLeader`), so `retryItemWriteWithGeneration` runs on the
+leader and the dedup path is taken; the `IsLeader()` guard only matters for the
+no-`leaderMap` topology that relies on `Coordinator.Dispatch` redirect, where
+it correctly degrades to legacy (no dedup, no lost update) rather than minting
+a follower-local timestamp.
 
 ### The retry loop (gated)
 
@@ -402,6 +424,14 @@ change (the probe already exists), no proto change, no new store primitive.
 
 ## Decision log
 
+- (2026-06-03, PR #920 round-1) **Leader-only dedup guard added** per codex P1:
+  the adapter-local `commitTS` allocation is only safe on the leader, so the
+  dedup path is gated on `d.coordinator.IsLeader()` (+ `NextFenced` ceiling
+  fence for the cross-leader case); non-leaders fall back to the legacy path
+  where the leader allocates. Covered by
+  `TestItemWriteDedup_NonLeaderFallsBackToLegacy`. Also addressed gemini's
+  redundant-`errors.WithStack` findings (the attempt helpers return the
+  already-wrapped dispatch error raw; the outer loop wraps once).
 - (2026-06-03) Initial proposal, triggered by Jepsen run 26856696842
   (`:duplicate-elements` on the DynamoDB list-append workload). Open for
   review. Diagnosis confirmed: same anomaly class as the parent design

--- a/docs/design/2026_06_03_proposed_dynamodb_onephase_dedup.md
+++ b/docs/design/2026_06_03_proposed_dynamodb_onephase_dedup.md
@@ -1,0 +1,411 @@
+# DynamoDB item-write one-phase idempotency dedup
+
+Status: Proposed
+Author: bootjp
+Date: 2026-06-03
+
+> **Status: proposed — no implementation yet.** Extends the option-2
+> one-phase dedup (write-set reuse + exact-`commit_ts` probe) from the Redis
+> adapter to the DynamoDB adapter's single-item write path
+> (`UpdateItem` / `PutItem` / `DeleteItem`). The FSM-side probe
+> (`dedupProbeOnePhase`, `kv/fsm.go`) and the request plumbing
+> (`OperationGroup.PrevCommitTS` → `onePhaseTxnRequestWithPrevCommit`) already
+> exist and are shared across adapters; only the DynamoDB adapter retry loop
+> and a default-off gate are new. Follows the parent design
+> [`2026_05_21_proposed_txn_secondary_idempotency.md`](2026_05_21_proposed_txn_secondary_idempotency.md);
+> read that first — this doc reuses its correctness argument verbatim and only
+> develops the DynamoDB-specific differences.
+>
+> Triggered by the 2026-06-03 Jepsen scheduled run
+> [26856696842](https://github.com/bootjp/elastickv/actions/runs/26856696842),
+> which surfaced a `:duplicate-elements` anomaly on the **DynamoDB**
+> list-append workload — the same anomaly class that run 26198185540 surfaced
+> on the Redis workload and that motivated the parent design.
+
+## Background — the failing run
+
+The DynamoDB Jepsen workload (`elastickv.dynamodb-workload`, list-append model)
+failed with:
+
+```clojure
+{:valid? false,
+ :anomaly-types (:duplicate-elements),
+ :anomalies {:duplicate-elements [{:op #Op{... :process 6 ...}
+                                   :mop [:r 18 [... 71 72 72 74 75]]
+                                   :duplicates {72 2}} ...]}}
+```
+
+Key `18`'s list contains the value `72` twice. Evidence that this is a
+double-apply, not a generator artifact:
+
+1. **The generator emitted `72` to key `18` exactly once.** Across the whole
+   DynamoDB run, every one of the 250 invoke-appends to key 18 carries a
+   distinct value (`elle.list-append/wr-txns` assigns a strictly increasing
+   per-key counter; a retired key is replaced by `max+1` and never reused, so
+   `(key, value)` pairs are unique). The single append of `72` is op
+   `[[:append 18 72]]` (process 21, `00:47:49.875` invoke → `00:47:50.661`
+   ok), a **single micro-op** routed through `dynamo-append!` (one `UpdateItem`
+   with `SET #v = list_append(...)`).
+2. **A Raft leader-election storm coincides with that op.** The demo-cluster
+   log (`elastickv-demo.log`) shows terms 7→8→9→10→11 elected within
+   `00:47:49`–`00:47:50`, with `hlc lease renewal failed: ... not leader`
+   logged at the same instant — the CI CPU-starvation amplifier the parent
+   doc's "CI-environment amplifier" section describes.
+
+So a single client-issued `list_append(72)` was physically stored twice. This
+is the parent doc's exact failure shape, on a different adapter.
+
+## Problem — why the DynamoDB single-item write duplicates
+
+The DynamoDB single-item write path is a **read-modify-write that recomputes on
+retry**:
+
+```text
+adapter/dynamodb.go
+  updateItem
+    → updateItemWithRetry
+      → retryItemWriteWithGeneration            // the retry loop
+          for each attempt:
+            readTS  := d.nextTxnReadTS()         // FRESH read snapshot each attempt
+            plan    := prepareUpdateItemWrite(in, readTS)
+                         readLogicalItemAt(readTS)          // re-READ current list
+                         buildUpdatedItem → applyUpdateExpression
+                                          → evalListAppendUpdateValue  // RE-APPEND value
+                         buildItemWriteRequestWithSource    // Put(itemKey, encode(newList))
+            plan.req.StartTS = readTS
+            commitItemWrite(plan.req)  → coordinator.Dispatch
+            if isRetryableTransactWriteError(err) { continue }  // WriteConflict / TxnLocked
+```
+
+The OCC snapshot is the caller-supplied `StartTS = readTS`
+(`dynamodb.go:1249`). The one-phase FSM apply rejects the write if any
+mutation key already has a committed version newer than `StartTS`
+(`store/mvcc_store.go:533`, `latestVer.TS > startTS → WriteConflict`).
+`retryItemWriteWithGeneration` retries on `store.ErrWriteConflict` /
+`kv.ErrTxnLocked` (`dynamodb.go:4757`).
+
+### The self-inflicted conflict, step by step
+
+Let key `18` hold `[A, B]` (committed at some `T < R1`).
+
+1. **Attempt 1.** `readTS = R1`, reads `[A, B]`, computes
+   `Put(item18, encode([A, B, 72]))`, `StartTS = R1`. Dispatch proposes to the
+   incumbent leader; the entry **commits at `commit_ts = C1`** and applies
+   (`item18` now has a version at `C1 > R1`).
+2. **Leadership churns** before the dispatch result is unambiguously returned.
+   The commit is real, but the path surfaces a `WriteConflict` to the adapter.
+   Two mechanisms produce this, and the fix does not depend on which:
+   - the coordinator's internal leader-change retry re-proposes with the
+     **same caller-supplied `StartTS = R1`** (it does not reset a
+     caller-owned snapshot — `sharded_coordinator.go:449-477`); the new
+     leader's OCC sees `item18@C1 > R1` and returns `WriteConflict`; or
+   - the AWS SDK / a higher layer re-issues the `UpdateItem`.
+3. **Attempt 2 (recompute).** `retryItemWriteWithGeneration` treats the
+   `WriteConflict` as retryable, takes a **fresh** `readTS = R2 > C1`, re-reads
+   — now `[A, B, 72]` (attempt 1's commit is visible) — re-appends `72`, and
+   writes `Put(item18, encode([A, B, 72, 72]))`. This commits.
+4. **End state:** `[A, B, 72, 72]`. **The element `72` appears twice.**
+
+The duplicate is born exactly where the parent doc says: the retry
+**recomputes** its write set from a fresh read, so the just-committed value is
+folded back in and re-appended. The discriminator the adapter is missing is
+"was the conflict caused by *my own* prior attempt?" — the self-inflicted
+conflict the parent doc's outcome 1 handles.
+
+### Why the existing dedup does not cover this today
+
+The parent design landed the FSM-side probe and the request plumbing, but
+gated **emission** behind the Redis adapter only:
+
+- `OperationGroup.PrevCommitTS` (`kv/transcoder.go`) →
+  `dispatchSingleShardTxn` → `onePhaseTxnRequestWithPrevCommit`
+  (`kv/coordinator.go`) → `TxnMeta.PrevCommitTS` is shared by all adapters.
+- The FSM probe `dedupProbeOnePhase` (`kv/fsm.go`) fires only when
+  `meta.PrevCommitTS != 0`; it no-ops the apply when
+  `store.CommittedVersionAt(meta.PrimaryKey, meta.PrevCommitTS)` hits.
+- **But the DynamoDB adapter never sets `PrevCommitTS`.** Every
+  `buildItemWriteRequestWithSource` returns an `OperationGroup` with
+  `PrevCommitTS` at its zero value, so the probe is always skipped. The parent
+  doc's M4 "Workflow scope rationale" states this explicitly: *"DynamoDB / S3
+  / SQS do not route through the dedup loop."*
+
+So the FSM is ready; the DynamoDB adapter is the only missing piece.
+
+## Why DynamoDB is simpler than the Redis list-push case
+
+The Redis list-push write set is **seq-addressed**: each element lands at
+`listItemKey(key, seq)` where `seq = Tail + Len` at attempt time, plus a
+`commitTS`-stamped meta-delta. The retry duplicates precisely because a fresh
+meta read advances `seq` (230 → 231), so the re-append lands at a *new index*.
+Reuse there must pin `seq` AND a boundary `readKeys` fence (the codex P1
+shrink-race).
+
+The DynamoDB item write is **whole-item content-addressed**: the write set is a
+single `Put(itemKey, encode(nextItem))` (plus GSI delta puts/dels keyed by GSI
+entry → `itemKey`). Two consequences:
+
+1. **Same-`commit_ts` replay is already idempotent** — re-applying
+   `Put(itemKey, V)` at the same `(startTS, commitTS)` is a no-op MVCC
+   overwrite. The duplicate is purely a *recompute* artifact (the value `V`
+   itself grows from `[A,B,72]` to `[A,B,72,72]`), never a key-divergence
+   artifact.
+2. **Reuse needs no `seq` pinning and no boundary fence.** Reusing the prior
+   attempt's `Elems` verbatim under a fresh `commit_ts` is the whole fix; the
+   single mutation key (`itemKey`) is its own OCC fence (it is a write key, so
+   `checkConflictsLocked` already validates it against `StartTS`). The
+   `reusableItemWrite` struct is therefore strictly smaller than
+   `reusableListPush` (no `readKeys` field is required for correctness; see R3).
+
+The correctness argument (SI preserved because new data is written only at a
+fresh monotonic `commit_ts`; the stale `commit_ts` is read-only in an exact-ts
+probe; Raft log order makes the probe race-free — E1 applies before E2 or
+never) carries over **unchanged** from the parent doc §"Correctness" and
+§"Open questions / Race-freedom linchpin". This doc does not re-derive it.
+
+## Proposed design — option 2 for the DynamoDB item-write loop
+
+Mirror `listPushCoreWithDedup` / `dispatchListPushReuse` at the
+`retryItemWriteWithGeneration` granularity.
+
+### Prerequisite: allocate `commit_ts` in the adapter
+
+Today the DynamoDB item-write path leaves `OperationGroup.CommitTS = 0` and
+lets the coordinator assign the commit timestamp internally. Option 2 requires
+the adapter to **know** the `commit_ts` it dispatched, so it can pass it as
+`PrevCommitTS` on the next attempt. The Redis adapter already does this:
+`commitTS = r.coordinator.Clock().NextFenced()`, dispatched as
+`OperationGroup.CommitTS`. The coordinator honors a caller-supplied
+`CommitTS` **when `StartTS` is also caller-supplied** (`Dispatch` only clears
+`CommitTS` on the `StartTS == 0` branch, `sharded_coordinator.go:466-477`),
+which the DynamoDB path already satisfies (`StartTS = readTS != 0`).
+
+So the prepare step gains one line: allocate `commitTS` via
+`d.coordinator.Clock().NextFenced()` and set `plan.req.CommitTS`. `NextFenced`
+(not `Next`) is mandatory — it honors the HLC physical-ceiling fence so a
+stale-leader window cannot mint a colliding timestamp (HLC-4). `NextFenced`'s
+`ErrCeilingExpired` must be classified **non-retryable** by the adapter loop
+(surface to the client), matching the Redis call sites.
+
+### The retry loop (gated)
+
+```text
+retryItemWriteWithGenerationDedup(ctx, tableName, prepare):
+    var pending *reusableItemWrite
+    for each attempt (bounded by transactRetryMaxAttempts / MaxDuration):
+        if pending != nil:
+            plan, drop, err := dispatchItemWriteReuse(ctx, pending)
+            if drop { pending = nil }
+            if err == nil { return plan }            // reuse landed (or dedup no-op)
+            if not retryable { return err }
+            continue
+        // first attempt (recompute)
+        readTS  := d.nextTxnReadTS()
+        plan    := prepare(readTS)                    // re-read + recompute write set
+        if plan.req == nil { return plan }
+        plan.req.StartTS  = readTS
+        plan.req.CommitTS = d.coordinator.Clock().NextFenced()
+        err := commitItemWrite(ctx, plan.req)
+        if err == nil {
+            verify generation fence; return plan      // unchanged
+        }
+        if isRetryableTransactWriteError(err):
+            pending = &reusableItemWrite{
+                elems:    plan.req.Elems,             // REUSE verbatim
+                startTS:  plan.req.StartTS,
+                commitTS: plan.req.CommitTS,          // becomes next PrevCommitTS
+                probeKey: primaryKeyForElems(plan.req.Elems), // == FSM meta.PrimaryKey (R4)
+                plan:     plan,                       // for result reconstruction (R1)
+            }
+        return/continue per the loop predicate
+```
+
+```text
+dispatchItemWriteReuse(ctx, pending) -> (plan, drop, err):
+    commitTS := d.coordinator.Clock().NextFenced()
+    err := commitItemWrite(ctx, &OperationGroup{
+        IsTxn:        true,
+        StartTS:      pending.startTS,
+        CommitTS:     commitTS,
+        PrevCommitTS: pending.commitTS,               // FSM probes this exact ts
+        Elems:        pending.elems,                   // REUSE verbatim — no recompute
+    })
+    if err == nil:
+        return pending.plan, false, nil                // reuse applied (or FSM no-op'd)
+    if errors.Is(err, store.ErrWriteConflict):
+        // Self-inflicted-conflict guard (parent doc codex P1): the apply may
+        // have landed at THIS commitTS but bubbled up as WriteConflict under
+        // churn. Probe the store directly.
+        landed, perr := d.store.CommittedVersionAt(ctx, pending.probeKey, commitTS)
+        if perr == nil && landed:
+            pending.commitTS = commitTS                // keep probe pointed at the landed ts
+            return pending.plan, false, nil            // success, no double-apply
+        return nil, true /*drop*/, err                 // genuine conflict → recompute
+    if isRetryableTransactWriteError(err):
+        pending.commitTS = commitTS                    // still ambiguous; next probe = this ts
+    return nil, false, err
+```
+
+This is a structural copy of `dispatchListPushReuse`, minus the `readKeys`
+fence and the meta re-read (DynamoDB's result is the item itself; see R1).
+
+### The three outcomes (DynamoDB instantiation)
+
+Reusing the parent doc's framing, with E1 = attempt 1 (`commit_ts = C1`,
+writes `Put(item18, [A,B,72])`) and E2 = reuse (`commit_ts = C2 > C1`,
+`PrevCommitTS = C1`, **reuses** `Put(item18, [A,B,72])`):
+
+1. **E1 landed (the bug case).** `CommittedVersionAt(item18, C1)` hits at FSM
+   apply → E2 no-ops. Final `[A,B,72]`. **One `72`. Correct.**
+2. **E1 never landed (truncated by the election).** Probe misses → E2 applies
+   `Put(item18, [A,B,72])` at C2. Final `[A,B,72]`. **One `72`. Correct.**
+3. **Genuine conflict (another txn wrote `item18` at `Tx > startTS`).** Probe
+   misses (E1 didn't land); OCC fires `WriteConflict` on E2's reuse; the
+   self-conflict guard probes `CommittedVersionAt(item18, C2)` → misses → drop
+   pending → recompute from a fresh read (`[A,B,X]`) → append once →
+   `[A,B,X,72]`. **No duplicate, no lost update. Correct.**
+
+### Result reconstruction (R1) — trivial, as for list-push
+
+`dynamo-append!` uses default `ReturnValues=NONE`, so the dedup no-op returns
+an empty body. For `ReturnValues=ALL_NEW`/`UPDATED_NEW` the result is
+`plan.next`; for `ALL_OLD`/`UPDATED_OLD` it is `plan.current`. Both are
+captured once on attempt 1 and are **invariant across reuse** (the write set is
+fixed), so the adapter returns the remembered `plan` on a dedup no-op — no
+store re-read. This is the parent doc's R1 invariance, instantiated for the
+item write.
+
+### Gating (R5) — default off, ship the reader before the writer
+
+Emission is gated behind a new DynamoDB flag, mirroring
+`RedisServer.onePhaseTxnDedup`:
+
+- `DynamoDBServer.onePhaseTxnDedup bool`, set from
+  `os.Getenv("ELASTICKV_DYNAMODB_ONEPHASE_DEDUP") == "1"` and/or a
+  `WithDynamoOnePhaseTxnDedup(bool)` server option (distinct symbol name to
+  avoid colliding with the Redis `WithOnePhaseTxnDedup` in the same `adapter`
+  package).
+- **Off** → `retryItemWriteWithGeneration` keeps its current
+  recompute-on-retry behavior byte-for-byte; no `PrevCommitTS` is ever emitted;
+  the FSM probe never fires. No mixed-version divergence window.
+- **On** → the dedup loop above. Enable only after the whole cluster runs a
+  probe-aware binary (the FSM probe code is already everywhere as of the parent
+  doc's M2b, so this is satisfied on current `main`).
+
+The FSM-determinism argument (R5 in the parent doc) holds unchanged: the probe
+decision depends only on the replicated `PrevCommitTS` and the deterministic
+`CommittedVersionAt`, which for a whole-item single-version key is identical on
+every replica applying the same log entry.
+
+## Scope
+
+- **In scope (M1):** the shared single-item write loop
+  `retryItemWriteWithGeneration`, which backs `UpdateItem`, `PutItem`, and
+  `DeleteItem`. The fix lives in the loop, so all three inherit it; the Jepsen
+  workload exercises `UpdateItem`.
+- **Out of scope (follow-up):** `TransactWriteItems` (multi-item) takes a
+  separate path (`dynamo-transact-write!` with explicit `ConditionExpression`
+  OCC). It already surfaces conflicts as `TransactionCanceledException`, which
+  the workload classifies as a definite `:fail` (excluded from the history), so
+  it does not produce the duplicate. Bringing it under reuse-dedup is tractable
+  but doubles the test matrix; defer it.
+- **Out of scope:** S3 / SQS adapters (same `readTS`-then-mutate pattern, same
+  latent bug class) — separate docs once this lands as the template.
+
+## Milestones
+
+### M1 — DynamoDB adapter reuse-dedup (gated)
+
+- Adapter `commit_ts` allocation in the prepare step
+  (`d.coordinator.Clock().NextFenced()` → `plan.req.CommitTS`).
+- `reusableItemWrite` struct + `dispatchItemWriteReuse` (mirror
+  `reusableListPush` / `dispatchListPushReuse`).
+- `retryItemWriteWithGeneration` gains the gated dedup loop; the gate-off path
+  is unchanged.
+- `DynamoDBServer.onePhaseTxnDedup` + `WithDynamoOnePhaseTxnDedup` + env var;
+  wire the env var in the server constructor.
+- **Tests (`adapter/dynamodb_*_dedup_test.go`), all three outcomes against the
+  real OCC + the real probe, plus the gate-off legacy path:**
+  - `LandedPriorAttempt_ReturnsCachedResult` — attempt 1 lands then errors;
+    reuse FSM-probe hits; final list has one copy; no second apply.
+  - `PriorAttemptDidNotLand_Applies` — attempt 1 pre-rejected; reuse applies
+    fresh; one copy.
+  - `GenuineConflictRebuildsAndApplies` — concurrent write advances `item18`
+    past `startTS`; reuse OCC-conflicts; probe misses; pending dropped; fresh
+    recompute appends once (no duplicate, no lost update).
+  - `SelfInflictedReuseConflict_ReturnsSuccess` — reuse lands then surfaces
+    `WriteConflict`; self-conflict guard probes fresh `commitTS`; cached result
+    returned (no double-apply).
+  - `DisabledKeepsLegacyPath` — gate off; identical to today's
+    `retryItemWriteWithGeneration`.
+- Per the repo convention (failing-test-first for a review-identified defect):
+  the `LandedPriorAttempt` test, written against the **gate-off** path first,
+  reproduces the `:duplicate-elements` double-apply; flipping the gate on makes
+  it pass.
+
+### M2 — Validation
+
+- Local reproduction: 3-node demo under CPU pressure / shortened election
+  timeouts (`cmd/server/demo.go`) so leadership flaps during the DynamoDB
+  workload, with `ELASTICKV_DYNAMODB_ONEPHASE_DEDUP=1`.
+- **CI:** add the DynamoDB workload to the dedup-mode workflow
+  (`.github/workflows/jepsen-test-scheduled-dedup.yml`) with the env var set,
+  asserting the gate before the listeners come up (mirror the Redis gate
+  assertion). The general workflow
+  (`.github/workflows/jepsen-test-scheduled.yml`) continues to run DynamoDB
+  **gate-off** so the legacy path stays covered until default-on.
+- Criterion to default-on: 7 consecutive days without `:duplicate-elements` in
+  the dedup-mode DynamoDB workload, both workflows green.
+
+Scope estimate: M1 is ~120–180 LOC Go in `adapter/dynamodb.go` + tests; no FSM
+change (the probe already exists), no proto change, no new store primitive.
+
+## Risks
+
+- **R1 — result reconstruction.** Resolved as for list-push: the item-write
+  result (`plan.current` / `plan.next`) is invariant across reuse; return the
+  remembered `plan`. No store re-read.
+- **R2 — probe cost.** One extra `uint64` and one `CommittedVersionAt` point
+  read, only on the retry path; hot path (first attempt, `PrevCommitTS == 0`)
+  untouched. Same as the parent doc R2.
+- **R3 — reuse-vs-recompute discrimination.** The exact-ts probe plus the OCC
+  check on the reuse is the discriminator (probe-miss + OCC-conflict ⇒
+  recompute). For the whole-item PUT this is *cleaner* than list-push: there is
+  a single write key, so no boundary `readKeys` fence is needed — the OCC check
+  on `itemKey` itself distinguishes a self-conflict (probe hits) from a foreign
+  write (probe misses). The tests pin both directions.
+- **R4 — `PrevCommitTS` derivation correctness + probe-key agreement.**
+  Because the adapter now allocates `commit_ts` locally, it holds the exact
+  value to probe even when the dispatch returns only an error. The probe key,
+  however, is **not** simply "the itemKey": the coordinator derives
+  `meta.PrimaryKey` via `primaryKeyForElems` (`kv/coordinator.go:1110`), which
+  selects the **lexicographically smallest** write key among the elems, not
+  the first. Two consequences:
+  - For the Jepsen `jepsen_append` table (HASH key only, **no GSI**) the write
+    set is a single `Put(itemKey, …)`, so the min key *is* the itemKey and the
+    FSM probe targets it directly — the failing workload is covered.
+  - For a table with GSIs the write set also carries GSI delta puts/dels, so
+    the min key may be a GSI entry key rather than the itemKey. This is still
+    correct: every elem commits atomically in one Raft entry at `C1`, so
+    `CommittedVersionAt(min_key, C1)` hits iff attempt 1 landed (a Del's
+    tombstone at `C1` counts as landed per the parent doc's M2a). The
+    requirement is only that the **adapter-side self-conflict guard probe the
+    SAME key the FSM uses** — so `dispatchItemWriteReuse` must compute
+    `probeKey = primaryKeyForElems(pending.elems)` (exported or duplicated for
+    the adapter), not the first write key. (This is the one place the DynamoDB
+    instantiation must deviate from `dispatchListPushReuse`, which probes
+    `firstWriteKey`; for list-push the first write key and the min key coincide
+    on the seq-addressed layout, but for the item write they need not.)
+- **R5 — FSM determinism across rolling upgrade.** Unchanged from the parent
+  doc: V1-default wire format (no `PrevCommitTS` ⇒ V1 meta), fail-loud
+  unknown-flag rejection, default-off emission. The probe-aware FSM is already
+  on `main`.
+
+## Decision log
+
+- (2026-06-03) Initial proposal, triggered by Jepsen run 26856696842
+  (`:duplicate-elements` on the DynamoDB list-append workload). Open for
+  review. Diagnosis confirmed: same anomaly class as the parent design
+  (`2026_05_21_proposed_txn_secondary_idempotency.md`); the DynamoDB
+  single-item write recomputes its write set on a self-inflicted
+  `WriteConflict` under leadership churn and double-applies. Fix: extend
+  option-2 reuse-dedup to `retryItemWriteWithGeneration`, gated off by default.

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -1107,6 +1107,16 @@ func onePhaseTxnRequestWithPrevCommit(startTS, commitTS, prevCommitTS uint64, pr
 	}
 }
 
+// PrimaryKeyForElems returns the primary key the coordinator derives for a
+// single-shard one-phase txn over elems — the lexicographically smallest write
+// key. Adapters that implement option-2 one-phase dedup must probe this exact
+// key (it becomes the FSM's meta.PrimaryKey) so the adapter-side
+// self-inflicted-conflict guard agrees with dedupProbeOnePhase. See
+// docs/design/2026_06_03_proposed_dynamodb_onephase_dedup.md (R4).
+func PrimaryKeyForElems(reqs []*Elem[OP]) []byte {
+	return primaryKeyForElems(reqs)
+}
+
 func primaryKeyForElems(reqs []*Elem[OP]) []byte {
 	var primary []byte
 	seen := make(map[string]struct{}, len(reqs))

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -1112,7 +1112,7 @@ func onePhaseTxnRequestWithPrevCommit(startTS, commitTS, prevCommitTS uint64, pr
 // key. Adapters that implement option-2 one-phase dedup must probe this exact
 // key (it becomes the FSM's meta.PrimaryKey) so the adapter-side
 // self-inflicted-conflict guard agrees with dedupProbeOnePhase. See
-// docs/design/2026_06_03_proposed_dynamodb_onephase_dedup.md (R4).
+// docs/design/2026_06_03_partial_dynamodb_onephase_dedup.md (R4).
 func PrimaryKeyForElems(reqs []*Elem[OP]) []byte {
 	return primaryKeyForElems(reqs)
 }


### PR DESCRIPTION
## Summary

Fixes the `:duplicate-elements` anomaly that the 2026-06-03 scheduled Jepsen run [26856696842](https://github.com/bootjp/elastickv/actions/runs/26856696842) surfaced on the **DynamoDB** list-append workload — value `72` stored twice in key 18.

This is the **same anomaly class** as the Redis bug behind PR #796/#884/#887 and the parent design [`2026_05_21_proposed_txn_secondary_idempotency.md`](https://github.com/bootjp/elastickv/blob/main/docs/design/2026_05_21_proposed_txn_secondary_idempotency.md), on a different adapter. The option-2 dedup landed for Redis only and is gated off; the parent doc states plainly *"DynamoDB / S3 / SQS do not route through the dedup loop."* This PR extends it to the DynamoDB single-item write path.

## Root cause (evidence)

- The generator emitted `72` to key 18 **exactly once** (all 250 invoke-appends to key 18 are unique). The op is a single-micro-op `[[:append 18 72]]` (process 21, `00:47:49.875` → `00:47:50.661`), routed through `dynamo-append!` → one `UpdateItem` with `SET #v = list_append(...)`.
- The demo-cluster log shows a **Raft leader-election storm** (terms 7→8→9→10→11) within `00:47:49`–`00:47:50`, with `hlc lease renewal failed: ... not leader` at the same instant.
- The DynamoDB single-item write (`retryItemWriteWithGeneration`) is a **read-modify-write that recomputes on retry**. Attempt 1 commits `[A,B,72]` at `C1` but, because the caller-supplied `StartTS=readTS` is not reset by the coordinator's leader-change retry, the new leader's OCC sees `item@C1 > StartTS` and returns a **self-inflicted `WriteConflict`** (`store/mvcc_store.go:533`). `isRetryableTransactWriteError` treats it as retryable, the retry re-reads `[A,B,72]` and re-appends → `[A,B,72,72]`.

## Mechanism (gated behind `onePhaseTxnDedup`, default off)

1. The adapter now allocates `commitTS` locally via `Clock().NextFenced()` (HLC-4 fence; `ErrCeilingExpired` is non-retryable → surfaces to the client), so it knows the value to carry as `PrevCommitTS` on a retry.
2. On a retryable write error the retry **reuses** the failed attempt's write set (`reusableItemWrite`) under a fresh `commitTS` carrying `PrevCommitTS`; the existing FSM probe `dedupProbeOnePhase` (`kv/fsm.go`) no-ops the apply if the prior attempt landed at exactly that ts.
3. A genuine `WriteConflict` (the adapter-side self-conflict guard's `CommittedVersionAt(probeKey, commitTS)` misses) drops the pending attempt and recomputes from a fresh read (outcome 3) — no duplicate, no lost update.
4. `kv.PrimaryKeyForElems` is exported so the adapter-side guard probes the **same key** the FSM uses as `meta.PrimaryKey` (the lexicographically-smallest write key; for the GSI-free `jepsen_append` table that is the itemKey).

**Gate off ⇒ `retryItemWriteWithGeneration` is byte-identical** (the dedup is a single `if d.onePhaseTxnDedup { ... }` early return on a default-false field). Enable via `WithDynamoOnePhaseTxnDedup` / `ELASTICKV_DYNAMODB_ONEPHASE_DEDUP=1` only after the whole cluster runs a probe-aware binary (R5).

## Scope

- **In:** the shared single-item loop `retryItemWriteWithGeneration` (backs `UpdateItem` / `PutItem` / `DeleteItem`).
- **Out (follow-up):** `TransactWriteItems` (separate path; already surfaces conflicts as a definite `TransactionCanceledException` → `:fail`), and S3 / SQS (same latent class).

## Design doc

`docs/design/2026_06_03_proposed_dynamodb_onephase_dedup.md` (proposed; committed first in this PR).

## Tests (`adapter/dynamodb_onephase_dedup_test.go`)

Reuse the OCC-aware `dedupTestCoordinator` (real `store.ApplyMutations` OCC + FSM-probe mimic), so a passing dedup test proves the probe is load-bearing.

| Test | Scenario | Pins |
|---|---|---|
| `LandedPriorAttempt_NoDuplicate` | attempt 1 lands then errors | reuse FSM-probe hits; list has one `3`; dispatches=2, probeNoOps=1 |
| `PriorAttemptDidNotLand_Applies` | attempt 1 pre-rejects | reuse applies fresh; one `3` |
| `SelfInflictedReuseConflict_ReturnsSuccess` | reuse lands then errors | adapter self-conflict guard probes fresh commitTS; cached result; no recompute |
| `GenuineConflictRecomputes` | concurrent write advances item past snapshot | reuse OCC-conflicts; probe misses; recompute appends once on top → `[1,2,99,3]` |
| `DisabledKeepsLegacyPath` | gate off | characterizes the duplicate `[1,2,3,3]` the gate fixes |

## Validation

- `go test ./adapter/ -run 'TestItemWriteDedup'` — pass (5/5).
- `go test ./adapter/ -run 'UpdateItem|PutItem|DeleteItem|TransactWrite|BatchWrite|Dedup|Migration'` — pass (item-write paths touched by the change).
- `go test ./kv/ ./store/` — pass.
- `golangci-lint run ./adapter/... ./kv/...` — 0 issues.
- Full `./adapter/...` and `-race` left to CI (the suite is slow locally; the change is gate-off-identical so existing tests exercise unchanged code).

## Self-review (5 passes)

1. **Data loss** — No committed write lost. Reuse re-dispatches the same write set; the FSM no-op only fires when the prior attempt's version exists at exactly `PrevCommitTS` (exact-ts, deterministic). Genuine conflict recomputes rather than dropping the append. Gate-off path unchanged.
2. **Concurrency / distributed** — The self-inflicted vs genuine conflict discriminator is the exact-ts probe + OCC check (R3). `NextFenced` keeps commitTS above the physical ceiling so a stale leader cannot mint a colliding ts. Race-freedom (E1 applies before E2 or never) inherited from the parent doc's Raft-log-order argument.
3. **Performance** — Hot path (first attempt, `PrevCommitTS==0`) untouched: one local `NextFenced` (already on the write path) and no probe. The extra point-read only happens on the retry path. No added Raft round-trips.
4. **Data consistency** — New data is written only at a fresh monotonic `commitTS` (SI preserved); the stale `commitTS` is read-only in the probe (dedup identity). Adapter guard and FSM probe agree on the probe key via `kv.PrimaryKeyForElems` (R4).
5. **Test coverage** — All three outcomes + self-conflict guard + gate-off legacy duplicate are pinned against real OCC + the real probe.

Caller audit (semantic-change rule): the three callers of `retryItemWriteWithGeneration` (`updateItemWithRetry`, `putItemWithRetry`, `deleteItemWithRetry`) all return `(*itemWritePlan, error)` with the same contract; the result is invariant across reuse (R1), so the cached `plan` is correct on a dedup no-op for all three. Gate-off ⇒ identical behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DynamoDB now supports optional write deduplication for single-item operations (UpdateItem, PutItem, DeleteItem). Enable via `ELASTICKV_DYNAMODB_ONEPHASE_DEDUP=1` to prevent duplicate writes on retryable failures during network disruptions or leadership transitions.

* **Tests**
  * Added comprehensive test coverage for DynamoDB write deduplication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->