### PR TITLE
ci(jepsen): add DynamoDB workload to the dedup-mode scheduled workflow (M2)

### DIFF
--- a/.github/workflows/jepsen-test-scheduled-dedup.yml
+++ b/.github/workflows/jepsen-test-scheduled-dedup.yml
@@ -1,16 +1,19 @@
 # Jepsen Scheduled Stress Test — Option-2 Dedup Mode
 #
-# Daily run with ELASTICKV_REDIS_ONEPHASE_DEDUP=1 so the demo cluster
-# exercises the option-2 idempotency path. The criterion for design doc
-# §M4 closure is 7 consecutive days of green runs with no
-# :duplicate-elements / :G-single-item-realtime anomalies in the Redis
-# workload's analysis output.
+# Daily run with ELASTICKV_REDIS_ONEPHASE_DEDUP=1 and
+# ELASTICKV_DYNAMODB_ONEPHASE_DEDUP=1 so the demo cluster exercises the
+# option-2 idempotency path on both adapters. The criterion for
+# default-on (docs/design/2026_05_21 §M4 and
+# docs/design/2026_06_03_partial_dynamodb_onephase_dedup.md §M2) is 7
+# consecutive days of green runs with no :duplicate-elements /
+# :G-single-item-realtime anomalies in each workload's analysis output.
 #
-# Scope: Redis workload only. The dedup feature only ships behind the
+# Scope: Redis + DynamoDB workloads. The dedup feature ships behind the
 # Redis adapter's onePhaseTxnDedup flag (RPUSH/LPUSH, MULTI/EXEC,
-# standalone SET); DynamoDB / S3 / SQS do not route through the dedup
-# loop, so re-running them here would add hours of CI for no signal
-# on the new code path.
+# standalone SET) and the DynamoDB adapter's onePhaseTxnDedup flag
+# (single-item UpdateItem/PutItem/DeleteItem via PR #920). S3 / SQS do
+# not yet route through the dedup loop, so re-running them here would add
+# hours of CI for no signal on the new code path.
 #
 # Cadence: 03:17 UTC daily (off-peak; non-zero minute per ScheduleWakeup
 # guidance). The general 6-hourly scheduled workflow continues to run
@@ -65,6 +68,13 @@ jobs:
       # state. Anomalies in :duplicate-elements / :G-single-item-realtime
       # under this flag indicate a regression in option-2 plumbing.
       ELASTICKV_REDIS_ONEPHASE_DEDUP: "1"
+      # Enable the DynamoDB adapter option-2 dedup gate (PR #920). demo.go
+      # wires it via adapter.NewDynamoDBServer, which reads this env var;
+      # the single-item write path (UpdateItem/PutItem/DeleteItem) then
+      # routes through retryItemWriteWithGenerationDedup on the leader,
+      # exercising the same FSM exact-ts probe as the Redis path. The
+      # DynamoDB workload below validates no :duplicate-elements under it.
+      ELASTICKV_DYNAMODB_ONEPHASE_DEDUP: "1"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -128,29 +138,37 @@ jobs:
           set -euo pipefail
           mkdir -p "$GOCACHE" /tmp/go-tmp
           export GOTMPDIR=/tmp/go-tmp
-          # The ELASTICKV_REDIS_ONEPHASE_DEDUP=1 env var is inherited
-          # from the job env above. demo.go reads it via the redis
-          # server's WithOnePhaseTxnDedup option wired in
-          # adapter/redis.go NewRedisServer.
+          # The ELASTICKV_REDIS_ONEPHASE_DEDUP=1 and
+          # ELASTICKV_DYNAMODB_ONEPHASE_DEDUP=1 env vars are inherited
+          # from the job env above. demo.go reads them via the redis
+          # server's WithOnePhaseTxnDedup option (adapter/redis.go
+          # NewRedisServer) and the DynamoDB server's NewDynamoDBServer
+          # (adapter/dynamodb.go), both of which call os.Getenv.
           nohup go run cmd/server/demo.go > /tmp/elastickv-demo.log 2>&1 &
           echo $! > /tmp/elastickv-demo.pid
 
           echo "ELASTICKV_REDIS_ONEPHASE_DEDUP=${ELASTICKV_REDIS_ONEPHASE_DEDUP}"
-          # The env var is set at the JOB level above and inherited by
+          echo "ELASTICKV_DYNAMODB_ONEPHASE_DEDUP=${ELASTICKV_DYNAMODB_ONEPHASE_DEDUP}"
+          # The env vars are set at the JOB level above and inherited by
           # all `run:` steps; nothing in demo.go can intercept or unset
-          # it before NewRedisServer reads os.Getenv. So if the env var
-          # is "1" here, the dedup gate IS active in the cluster. We
-          # print it explicitly so a failed run's log makes the
-          # configuration unambiguous (vs the general 6-hourly workflow
-          # whose runs would have an empty value here).
+          # them before the adapters read os.Getenv. So if they are "1"
+          # here, the dedup gates ARE active in the cluster. We print
+          # them explicitly so a failed run's log makes the configuration
+          # unambiguous (vs the general 6-hourly workflow whose runs would
+          # have empty values here).
           if [ "${ELASTICKV_REDIS_ONEPHASE_DEDUP:-}" != "1" ]; then
             echo "FATAL: ELASTICKV_REDIS_ONEPHASE_DEDUP is not '1' — this workflow runs only with the dedup gate on"
             exit 2
           fi
+          if [ "${ELASTICKV_DYNAMODB_ONEPHASE_DEDUP:-}" != "1" ]; then
+            echo "FATAL: ELASTICKV_DYNAMODB_ONEPHASE_DEDUP is not '1' — this workflow runs only with the dedup gate on"
+            exit 2
+          fi
 
-          echo "Waiting for redis listeners (63791-63793)..."
+          echo "Waiting for redis (63791-63793) and dynamo (63801-63803) listeners..."
           for i in {1..90}; do
-            if nc -z 127.0.0.1 63791 && nc -z 127.0.0.1 63792 && nc -z 127.0.0.1 63793; then
+            if nc -z 127.0.0.1 63791 && nc -z 127.0.0.1 63792 && nc -z 127.0.0.1 63793 \
+              && nc -z 127.0.0.1 63801 && nc -z 127.0.0.1 63802 && nc -z 127.0.0.1 63803; then
               echo "Cluster is up"
               exit 0
             fi
@@ -173,6 +191,24 @@ jobs:
             --max-txn-length ${{ inputs.max-txn-length || '4' }} \
             --ports 63791,63792,63793 \
             --host 127.0.0.1
+      - name: Run DynamoDB Jepsen workload (dedup mode) against elastickv
+        working-directory: jepsen
+        timeout-minutes: 10
+        # --local connects to the already-running demo cluster's dynamo
+        # ports (gate ON via ELASTICKV_DYNAMODB_ONEPHASE_DEDUP), so the
+        # single-item list_append writes exercise the option-2 reuse +
+        # exact-ts probe path. A :duplicate-elements anomaly here is the
+        # regression this workflow is meant to catch.
+        run: |
+          timeout 480 ~/lein run -m elastickv.dynamodb-workload --local \
+            --time-limit ${{ inputs.time-limit || '300' }} \
+            --rate ${{ inputs.rate || '10' }} \
+            --concurrency ${{ inputs.concurrency || '8' }} \
+            --key-count ${{ inputs.key-count || '16' }} \
+            --max-writes-per-key ${{ inputs.max-writes-per-key || '250' }} \
+            --max-txn-length ${{ inputs.max-txn-length || '4' }} \
+            --dynamo-ports 63801,63802,63803 \
+            --host 127.0.0.1
       - name: Dump demo cluster log on failure
         if: failure()
         run: |
@@ -194,7 +230,9 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: jepsen-store-redis-dedup
+          # Covers both the redis and dynamodb dedup-mode runs (each
+          # workload writes its own subdir under jepsen/store).
+          name: jepsen-store-dedup
           path: jepsen/store
           retention-days: 14
       - name: Stop demo cluster

--- a/docs/design/2026_06_03_partial_dynamodb_onephase_dedup.md
+++ b/docs/design/2026_06_03_partial_dynamodb_onephase_dedup.md
@@ -369,14 +369,19 @@ every replica applying the same log entry.
 - Local reproduction: 3-node demo under CPU pressure / shortened election
   timeouts (`cmd/server/demo.go`) so leadership flaps during the DynamoDB
   workload, with `ELASTICKV_DYNAMODB_ONEPHASE_DEDUP=1`.
-- **CI:** add the DynamoDB workload to the dedup-mode workflow
-  (`.github/workflows/jepsen-test-scheduled-dedup.yml`) with the env var set,
-  asserting the gate before the listeners come up (mirror the Redis gate
-  assertion). The general workflow
-  (`.github/workflows/jepsen-test-scheduled.yml`) continues to run DynamoDB
-  **gate-off** so the legacy path stays covered until default-on.
+- **CI — LANDED.** The DynamoDB list-append workload is added to the dedup-mode
+  workflow (`.github/workflows/jepsen-test-scheduled-dedup.yml`) with
+  `ELASTICKV_DYNAMODB_ONEPHASE_DEDUP=1` set at the job env (read by
+  `adapter.NewDynamoDBServer` in the demo cluster), a fail-closed gate
+  assertion before the listeners come up (mirroring the Redis assertion), and
+  the launch step now also waits on the dynamo listeners (63801-63803). The
+  general workflow (`.github/workflows/jepsen-test-scheduled.yml`) continues to
+  run DynamoDB **gate-off** so the legacy path stays covered until default-on.
 - Criterion to default-on: 7 consecutive days without `:duplicate-elements` in
-  the dedup-mode DynamoDB workload, both workflows green.
+  the dedup-mode DynamoDB workload, both workflows green. **Default-on is a
+  separate follow-up PR** flipping `DynamoDBServer.onePhaseTxnDedup`'s default
+  (and the env-var sense) only after the 7-day criterion is met — not done in
+  the workflow PR, to keep the ship-reader-before-writer sequencing (R5).
 
 Scope estimate: M1 is ~120–180 LOC Go in `adapter/dynamodb.go` + tests; no FSM
 change (the probe already exists), no proto change, no new store primitive.


### PR DESCRIPTION
## Summary

M2 of [`docs/design/2026_06_03_partial_dynamodb_onephase_dedup.md`](https://github.com/bootjp/elastickv/blob/main/docs/design/2026_06_03_partial_dynamodb_onephase_dedup.md): extend the option-2 **dedup-mode** Jepsen workflow (`jepsen-test-scheduled-dedup.yml`) to also exercise the DynamoDB single-item write path under the gate that shipped in PR #920. This starts the 7-day-green validation clock for the DynamoDB dedup path.

## Changes (`.github/workflows/jepsen-test-scheduled-dedup.yml`)

- **`ELASTICKV_DYNAMODB_ONEPHASE_DEDUP: "1"`** added at the job env. The demo cluster reads it via `adapter.NewDynamoDBServer` (`cmd/server/demo.go` → `setupDynamo`), so the single-item write path routes through `retryItemWriteWithGenerationDedup` on the leader.
- **Launch step**: now waits on the dynamo listeners (63801-63803) in addition to redis, and **fail-closed-asserts** the DynamoDB gate (`exit 2` if not `"1"`), mirroring the existing Redis assertion.
- **New step** `Run DynamoDB Jepsen workload (dedup mode)` — `lein run -m elastickv.dynamodb-workload --local --dynamo-ports 63801,63802,63803` against the gated cluster.
- Store artifact renamed `jepsen-store-redis-dedup` → `jepsen-store-dedup` (now covers both workloads); header/scope comments refreshed.

## What this does NOT do (by design)

- **Does not flip default-on.** Per the design's ship-reader-before-writer sequencing (R5), `DynamoDBServer.onePhaseTxnDedup` stays default-off; default-on is a separate follow-up PR once the 7-consecutive-days-green criterion is met. This PR only starts the clock.
- **Does not touch S3/SQS** — they don't route through the dedup loop yet (separate follow-up).
- The general 6-hourly workflow keeps running DynamoDB **gate-off**, so the legacy path stays covered.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` parses clean — 15 steps, env has all three keys, both Redis + DynamoDB workload steps present.
- Demo-cluster wiring verified: `setupDynamo` → `NewDynamoDBServer` reads `os.Getenv("ELASTICKV_DYNAMODB_ONEPHASE_DEDUP")`.
- No Go code change; `make lint` clean.

## Self-review (5 passes)

1. **Data loss** — n/a (CI-only change; no storage/replication code touched).
2. **Concurrency / distributed** — n/a; the workload exercises the existing gated path. The fail-closed gate assertions prevent a silently-misconfigured run from reporting a vacuous green.
3. **Performance** — adds one ~5-min DynamoDB workload to a daily off-peak job; within the job timeout.
4. **Data consistency** — the workflow is the *validator* for the consistency property (no `:duplicate-elements` under the gate); it changes no semantics.
5. **Test coverage** — this PR *is* the integration coverage for the DynamoDB dedup path under leader churn.
