### PR TITLE
feat(encryption): Stage 6E-2c — dynamic raft envelope wrap on ShardGroup

### DIFF
--- a/kv/raft_payload_wrapper.go
+++ b/kv/raft_payload_wrapper.go
@@ -136,18 +136,32 @@ type dynamicWrappedProposer struct {
 	wrapPtr *atomic.Pointer[RaftPayloadWrapper]
 }
 
-// newDynamicWrappedProposer wires a proposer that consults wrapPtr on
-// every Propose / ProposeAdmin. wrapPtr.Load() == nil keeps the path
-// as a pure pass-through to inner; a non-nil value applies wrap
-// before forwarding. wrapPtr must not be nil itself — the caller
-// owns the storage lifetime.
+// newDynamicWrappedProposer wires a proposer that consults wrapPtr
+// on every Propose / ProposeAdmin. wrapPtr.Load() == nil keeps the
+// path as a pure pass-through to inner; a non-nil value applies
+// wrap before forwarding.
+//
+// Contract: inner MUST be non-nil. A nil inner is a caller bug
+// (the construction site is responsible for handing in a valid
+// proposer) and the constructor deliberately does not silently
+// degrade — passing nil to Propose / ProposeAdmin would NPE at
+// the first call site, which is the same fail-fast shape as the
+// sibling newWrappedProposer(nil, wrap) and matches CLAUDE.md's
+// "don't validate for scenarios that can't happen" policy at
+// internal boundaries.
+//
+// wrapPtr MAY be nil — that path returns inner verbatim, mirroring
+// newWrappedProposer(inner, nil)'s degraded shape so a wiring site
+// that accidentally drops the pointer downgrades to a no-wrap
+// proposer rather than crashing the engine loop on first use. The
+// caller owns the storage lifetime of the pointer when non-nil.
 func newDynamicWrappedProposer(inner raftengine.Proposer, wrapPtr *atomic.Pointer[RaftPayloadWrapper]) raftengine.Proposer {
 	if wrapPtr == nil {
-		// Defensive: passing a nil pointer would NPE on the first
-		// Propose. Treat as static no-wrap so callers that pass nil
-		// by mistake degrade safely rather than crashing the engine
-		// loop. This matches newWrappedProposer(inner, nil) returning
-		// inner verbatim.
+		// Defensive degradation: passing a nil pointer would NPE
+		// on the first Propose. Treat as static no-wrap so callers
+		// that pass nil by mistake see the Stage 3 default rather
+		// than crashing the engine loop. This matches
+		// newWrappedProposer(inner, nil) returning inner verbatim.
 		return inner
 	}
 	return &dynamicWrappedProposer{inner: inner, wrapPtr: wrapPtr}

--- a/kv/raft_payload_wrapper.go
+++ b/kv/raft_payload_wrapper.go
@@ -2,6 +2,7 @@ package kv
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/bootjp/elastickv/internal/raftengine"
 	"github.com/cockroachdb/errors"
@@ -105,6 +106,84 @@ func (p *wrappedProposer) ProposeAdmin(ctx context.Context, data []byte) (*rafte
 	res, err := p.inner.ProposeAdmin(ctx, wrapped)
 	if err != nil {
 		return nil, errors.Wrap(err, "kv: wrapped propose-admin")
+	}
+	return res, nil
+}
+
+// dynamicWrappedProposer is the Stage 6E-2c sibling of wrappedProposer
+// for the case where the wrap closure must be swappable at runtime.
+// On every Propose / ProposeAdmin call it loads an atomic.Pointer to
+// the currently-active RaftPayloadWrapper; a nil pointer means wrap
+// is inactive (payload passes through verbatim).
+//
+// Why a separate type (vs adding a setter to wrappedProposer): the
+// existing wrappedProposer captures wrap at construction time and is
+// used by static call sites that never need to change wrap state.
+// The Stage 6E-2 cutover model needs runtime swap so the
+// EnableRaftEnvelope admin handler (Stage 6E-2d) can publish the
+// active wrap closure the instant the cutover entry commits, without
+// rebuilding the TransactionManager or stalling in-flight proposals.
+// Splitting the two keeps the static-wrap fast path branch-free and
+// keeps the dynamic path's atomic.Pointer.Load() cost confined to
+// the call sites that need it.
+//
+// The pointer is required to be non-nil; pass an atomic.Pointer that
+// stores nil to express "wrap inactive". This is so the call site
+// (typically a ShardGroup) owns the storage and the proposer just
+// reads.
+type dynamicWrappedProposer struct {
+	inner   raftengine.Proposer
+	wrapPtr *atomic.Pointer[RaftPayloadWrapper]
+}
+
+// newDynamicWrappedProposer wires a proposer that consults wrapPtr on
+// every Propose / ProposeAdmin. wrapPtr.Load() == nil keeps the path
+// as a pure pass-through to inner; a non-nil value applies wrap
+// before forwarding. wrapPtr must not be nil itself — the caller
+// owns the storage lifetime.
+func newDynamicWrappedProposer(inner raftengine.Proposer, wrapPtr *atomic.Pointer[RaftPayloadWrapper]) raftengine.Proposer {
+	if wrapPtr == nil {
+		// Defensive: passing a nil pointer would NPE on the first
+		// Propose. Treat as static no-wrap so callers that pass nil
+		// by mistake degrade safely rather than crashing the engine
+		// loop. This matches newWrappedProposer(inner, nil) returning
+		// inner verbatim.
+		return inner
+	}
+	return &dynamicWrappedProposer{inner: inner, wrapPtr: wrapPtr}
+}
+
+func (p *dynamicWrappedProposer) currentWrap() RaftPayloadWrapper {
+	if loaded := p.wrapPtr.Load(); loaded != nil {
+		return *loaded
+	}
+	return nil
+}
+
+func (p *dynamicWrappedProposer) Propose(ctx context.Context, data []byte) (*raftengine.ProposalResult, error) {
+	wrapped, err := applyRaftPayloadWrap(p.currentWrap(), data)
+	if err != nil {
+		return nil, err
+	}
+	res, err := p.inner.Propose(ctx, wrapped)
+	if err != nil {
+		return nil, errors.Wrap(err, "kv: dynamic wrapped propose")
+	}
+	return res, nil
+}
+
+// ProposeAdmin mirrors Propose's wrap-applies semantics. See
+// wrappedProposer.ProposeAdmin for the design rationale (the wrap
+// layer is NOT a barrier exemption; the EnableRaftEnvelope cutover
+// marker bypasses wrap at the call site, not the method level).
+func (p *dynamicWrappedProposer) ProposeAdmin(ctx context.Context, data []byte) (*raftengine.ProposalResult, error) {
+	wrapped, err := applyRaftPayloadWrap(p.currentWrap(), data)
+	if err != nil {
+		return nil, err
+	}
+	res, err := p.inner.ProposeAdmin(ctx, wrapped)
+	if err != nil {
+		return nil, errors.Wrap(err, "kv: dynamic wrapped propose-admin")
 	}
 	return res, nil
 }

--- a/kv/raft_payload_wrapper_test.go
+++ b/kv/raft_payload_wrapper_test.go
@@ -223,3 +223,166 @@ func TestWrappedProposer_RoundTripWithRealCipher(t *testing.T) {
 		t.Fatalf("round-trip mismatch: got %q, want %q", got, plaintext)
 	}
 }
+
+// TestDynamicWrappedProposer_NilPointerReturnsInnerVerbatim pins the
+// defensive degradation in newDynamicWrappedProposer: if a caller
+// accidentally passes a nil *atomic.Pointer, the wrapper falls back
+// to the inner proposer rather than NPE on the first Propose call.
+// This matches newWrappedProposer(inner, nil)'s shape and keeps a
+// misconfigured wiring from crashing the engine loop.
+func TestDynamicWrappedProposer_NilPointerReturnsInnerVerbatim(t *testing.T) {
+	t.Parallel()
+	inner := &fakeProposer{}
+	got := newDynamicWrappedProposer(inner, nil)
+	if got != raftengine.Proposer(inner) {
+		t.Fatal("nil pointer: newDynamicWrappedProposer should return the inner proposer verbatim, not a wrapper")
+	}
+}
+
+// TestDynamicWrappedProposer_NilStoredIsPassThrough pins the
+// Stage 6E-2c "wrap inactive" default: when the atomic pointer
+// holds nil (no wrap closure installed), payloads reach the inner
+// proposer verbatim and routing distinguishes Propose vs
+// ProposeAdmin correctly.
+func TestDynamicWrappedProposer_NilStoredIsPassThrough(t *testing.T) {
+	t.Parallel()
+	var wrapPtr atomic.Pointer[RaftPayloadWrapper]
+	inner := &fakeProposer{}
+	wp := newDynamicWrappedProposer(inner, &wrapPtr)
+
+	if _, err := wp.Propose(context.Background(), []byte("plain")); err != nil {
+		t.Fatalf("Propose: %v", err)
+	}
+	if got := inner.calls.Load(); got != 1 {
+		t.Fatalf("inner.Propose calls = %d, want 1", got)
+	}
+	if !bytes.Equal(inner.last, []byte("plain")) {
+		t.Fatalf("inner.Propose saw %q, want %q (verbatim)", inner.last, []byte("plain"))
+	}
+
+	if _, err := wp.ProposeAdmin(context.Background(), []byte("admin")); err != nil {
+		t.Fatalf("ProposeAdmin: %v", err)
+	}
+	if got := inner.adminCalls.Load(); got != 1 {
+		t.Fatalf("inner.ProposeAdmin calls = %d, want 1", got)
+	}
+	if !bytes.Equal(inner.adminLast, []byte("admin")) {
+		t.Fatalf("inner.ProposeAdmin saw %q, want %q (verbatim)", inner.adminLast, []byte("admin"))
+	}
+}
+
+// TestDynamicWrappedProposer_LoadsCurrentWrapEveryCall pins the
+// Stage 6E-2c hot-swap contract: the atomic pointer is loaded on
+// every Propose / ProposeAdmin call, so a publish via Store between
+// two proposals is observed by the second without rebuilding the
+// proposer.
+func TestDynamicWrappedProposer_LoadsCurrentWrapEveryCall(t *testing.T) {
+	t.Parallel()
+	var wrapPtr atomic.Pointer[RaftPayloadWrapper]
+	inner := &fakeProposer{}
+	wp := newDynamicWrappedProposer(inner, &wrapPtr)
+
+	// First call: no wrap installed, payload passes through verbatim.
+	if _, err := wp.Propose(context.Background(), []byte("first")); err != nil {
+		t.Fatalf("Propose 1: %v", err)
+	}
+	if !bytes.Equal(inner.last, []byte("first")) {
+		t.Fatalf("first call: inner saw %q, want %q", inner.last, "first")
+	}
+
+	// Install a wrap mid-flight; the next call must see it.
+	var wrap RaftPayloadWrapper = func(p []byte) ([]byte, error) {
+		out := make([]byte, len(p)+1)
+		out[0] = 'W'
+		copy(out[1:], p)
+		return out, nil
+	}
+	wrapPtr.Store(&wrap)
+
+	if _, err := wp.Propose(context.Background(), []byte("second")); err != nil {
+		t.Fatalf("Propose 2: %v", err)
+	}
+	want := append([]byte{'W'}, []byte("second")...)
+	if !bytes.Equal(inner.last, want) {
+		t.Fatalf("second call: inner saw %q, want %q (wrapped)", inner.last, want)
+	}
+
+	// Clear the wrap; the next call must see it gone.
+	wrapPtr.Store(nil)
+
+	if _, err := wp.Propose(context.Background(), []byte("third")); err != nil {
+		t.Fatalf("Propose 3: %v", err)
+	}
+	if !bytes.Equal(inner.last, []byte("third")) {
+		t.Fatalf("third call (post-clear): inner saw %q, want %q (verbatim)", inner.last, "third")
+	}
+}
+
+// TestShardGroup_SetRaftPayloadWrap_RoundTrip pins the
+// Stage 6E-2c hot-swap surface on ShardGroup. Set with a non-nil
+// closure publishes it; Set with nil clears; the round-trip via
+// RaftPayloadWrap returns identity.
+func TestShardGroup_SetRaftPayloadWrap_RoundTrip(t *testing.T) {
+	t.Parallel()
+	g := &ShardGroup{}
+	if got := g.RaftPayloadWrap(); got != nil {
+		t.Fatalf("default: RaftPayloadWrap = %v, want nil", got)
+	}
+	var called atomic.Int32
+	var wrap RaftPayloadWrapper = func(p []byte) ([]byte, error) {
+		called.Add(1)
+		return p, nil
+	}
+	g.SetRaftPayloadWrap(wrap)
+	got := g.RaftPayloadWrap()
+	if got == nil {
+		t.Fatal("after Set: RaftPayloadWrap returned nil")
+	}
+	if _, err := got([]byte("x")); err != nil {
+		t.Fatalf("invoking stored wrap: %v", err)
+	}
+	if got := called.Load(); got != 1 {
+		t.Fatalf("stored wrap call count = %d, want 1", got)
+	}
+	g.SetRaftPayloadWrap(nil)
+	if got := g.RaftPayloadWrap(); got != nil {
+		t.Fatalf("after Set(nil): RaftPayloadWrap = %v, want nil", got)
+	}
+}
+
+// TestDynamicWrappedProposer_ProposeAdminAppliesCurrentWrap is the
+// admin-path mirror of LoadsCurrentWrapEveryCall: ProposeAdmin
+// must also see hot-swapped wrap closures so post-cutover admin
+// entries (RotateDEK, RegisterEncryptionWriter) committed at
+// `index > raftEnvelopeCutoverIndex` carry the AEAD envelope the
+// §6.3 strict-`>` apply hook expects. The cutover marker itself
+// bypasses this proposer at the call site (raw engine reference),
+// not at this layer.
+func TestDynamicWrappedProposer_ProposeAdminAppliesCurrentWrap(t *testing.T) {
+	t.Parallel()
+	var wrapPtr atomic.Pointer[RaftPayloadWrapper]
+	var wrap RaftPayloadWrapper = func(p []byte) ([]byte, error) {
+		out := make([]byte, len(p)+1)
+		out[0] = 'A'
+		copy(out[1:], p)
+		return out, nil
+	}
+	wrapPtr.Store(&wrap)
+
+	inner := &fakeProposer{}
+	wp := newDynamicWrappedProposer(inner, &wrapPtr)
+
+	if _, err := wp.ProposeAdmin(context.Background(), []byte("admin-payload")); err != nil {
+		t.Fatalf("ProposeAdmin: %v", err)
+	}
+	if got := inner.adminCalls.Load(); got != 1 {
+		t.Fatalf("inner.ProposeAdmin calls = %d, want 1", got)
+	}
+	if got := inner.calls.Load(); got != 0 {
+		t.Fatalf("inner.Propose calls = %d, want 0 — admin path must NOT downgrade to non-exempt method", got)
+	}
+	want := append([]byte{'A'}, []byte("admin-payload")...)
+	if !bytes.Equal(inner.adminLast, want) {
+		t.Fatalf("inner.ProposeAdmin saw %q, want %q (wrapped)", inner.adminLast, want)
+	}
+}

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -24,6 +24,72 @@ type ShardGroup struct {
 	Store  store.MVCCStore
 	Txn    Transactional
 	lease  leaseState
+	// raftPayloadWrap is the Stage 6E-2c hot-swap point for the raft
+	// envelope wrap closure. A nil load means the wrap is inactive
+	// and proposals pass through cleartext (the Stage 3 default).
+	// A non-nil load applies the closure to every payload before it
+	// reaches the engine — Propose and ProposeAdmin alike, by
+	// design (see kv/raft_payload_wrapper.go for the rationale).
+	//
+	// The cell is read on every proposal via dynamicWrappedProposer,
+	// installed in the TransactionManager's proposer chain when the
+	// ShardGroup is constructed. SetRaftPayloadWrap publishes a fresh
+	// closure atomically so EnableRaftEnvelope (Stage 6E-2d) can
+	// activate the wrap the instant the cutover entry commits,
+	// without rebuilding the TransactionManager or stalling
+	// in-flight proposals.
+	raftPayloadWrap atomic.Pointer[RaftPayloadWrapper]
+}
+
+// SetRaftPayloadWrap publishes wrap as the active raft envelope
+// closure for this shard group. Passing nil clears the wrap (the
+// proposer reverts to cleartext pass-through). Safe to call from
+// any goroutine; the next Propose / ProposeAdmin observes the new
+// state via the proposer's atomic.Pointer.Load.
+//
+// This is the sole supported way to install or rotate the wrap
+// closure on a running coordinator. Stage 6E-2d's
+// EnableRaftEnvelope handler will call this on every leader when
+// the cutover entry commits.
+func (g *ShardGroup) SetRaftPayloadWrap(wrap RaftPayloadWrapper) {
+	if wrap == nil {
+		g.raftPayloadWrap.Store(nil)
+		return
+	}
+	g.raftPayloadWrap.Store(&wrap)
+}
+
+// RaftPayloadWrap returns the currently-installed wrap closure, or
+// nil if the wrap is inactive. Primarily intended for tests and
+// diagnostics; production proposers consult the underlying
+// atomic.Pointer directly (see dynamicWrappedProposer).
+func (g *ShardGroup) RaftPayloadWrap() RaftPayloadWrapper {
+	if p := g.raftPayloadWrap.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+// NewLeaderProxyForShardGroup wires a LeaderProxy whose proposer
+// consults g.raftPayloadWrap on every call, so SetRaftPayloadWrap
+// becomes the hot-swap surface for the raft envelope cutover.
+//
+// Use this in preference to NewLeaderProxyWithEngine(g.Engine, ...)
+// for any ShardGroup that participates in the encryption cutover
+// pipeline — without the dynamic wrap, post-cutover writes would
+// land cleartext at index > cutoverIndex and halt the apply loop on
+// strict-> unwrap. The non-wrap-aware constructor remains as a
+// convenience for shard groups that opt out of encryption (test
+// fixtures, transient groups).
+func NewLeaderProxyForShardGroup(g *ShardGroup, opts ...TransactionOption) *LeaderProxy {
+	// Prepend the wrap-installation option so a caller-provided
+	// WithProposer would still take precedence (last option wins).
+	// In practice this PR has no caller that overrides the proposer
+	// via opts; the slot is reserved for future composition.
+	combined := make([]TransactionOption, 0, len(opts)+1)
+	combined = append(combined, withDynamicRaftPayloadWrap(&g.raftPayloadWrap))
+	combined = append(combined, opts...)
+	return NewLeaderProxyWithEngine(g.Engine, combined...)
 }
 
 // leaseRefreshingTxn wraps a Transactional so every Commit / Abort that

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -81,6 +81,14 @@ func (g *ShardGroup) RaftPayloadWrap() RaftPayloadWrapper {
 // strict-> unwrap. The non-wrap-aware constructor remains as a
 // convenience for shard groups that opt out of encryption (test
 // fixtures, transient groups).
+//
+// Contract: g MUST be non-nil. The constructor takes the address
+// of g.raftPayloadWrap so a nil receiver is an immediate nil deref
+// — caller bug, not silently swallowed. Returning nil here would
+// only defer the panic to the first sg.Txn.Commit call site (see
+// main.go's buildShardGroups), with worse diagnostics; CLAUDE.md's
+// "don't validate for scenarios that can't happen at internal
+// boundaries" applies.
 func NewLeaderProxyForShardGroup(g *ShardGroup, opts ...TransactionOption) *LeaderProxy {
 	// Prepend the wrap-installation option so a caller-provided
 	// WithProposer would still take precedence (last option wins).

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -32,13 +32,42 @@ type ShardGroup struct {
 	// design (see kv/raft_payload_wrapper.go for the rationale).
 	//
 	// The cell is read on every proposal via dynamicWrappedProposer,
-	// installed in the TransactionManager's proposer chain when the
-	// ShardGroup is constructed. SetRaftPayloadWrap publishes a fresh
-	// closure atomically so EnableRaftEnvelope (Stage 6E-2d) can
-	// activate the wrap the instant the cutover entry commits,
-	// without rebuilding the TransactionManager or stalling
-	// in-flight proposals.
+	// installed in the TransactionManager's proposer chain AND on
+	// the cached proposer below when the ShardGroup is constructed
+	// via NewLeaderProxyForShardGroup. SetRaftPayloadWrap publishes
+	// a fresh closure atomically so EnableRaftEnvelope (Stage
+	// 6E-2d) can activate the wrap the instant the cutover entry
+	// commits, without rebuilding the TransactionManager or
+	// stalling in-flight proposals.
 	raftPayloadWrap atomic.Pointer[RaftPayloadWrapper]
+	// proposer is the wrap-aware proposer chain for this shard
+	// group. Set by NewLeaderProxyForShardGroup so direct shard
+	// proposals (HLC lease renewal — see RunHLCLeaseRenewal —
+	// and any future direct-engine.Propose call site) route
+	// through the same dynamicWrappedProposer the
+	// TransactionManager uses. The Proposer() accessor falls back
+	// to Engine when this is nil (the legacy / test-fixture path
+	// that constructs ShardGroup via struct literal without
+	// NewLeaderProxyForShardGroup), so the no-wrap default keeps
+	// working.
+	proposer raftengine.Proposer
+}
+
+// Proposer returns the wrap-aware proposer chain installed by
+// NewLeaderProxyForShardGroup, or the raw Engine when the
+// constructor was bypassed (legacy / test fixtures that build
+// ShardGroup via struct literal). Direct shard proposals
+// (HLC lease renewal, future cipher rotations, etc.) MUST go
+// through this getter rather than g.Engine.Propose so the
+// Stage 6E-2c dynamic wrap path applies — a direct g.Engine
+// Propose call would bypass the wrap pointer and let post-cutover
+// writes land cleartext above the raft-envelope cutover, halting
+// the apply loop on §6.3 strict-> unwrap (codex P2 round-1).
+func (g *ShardGroup) Proposer() raftengine.Proposer {
+	if g.proposer != nil {
+		return g.proposer
+	}
+	return g.Engine
 }
 
 // SetRaftPayloadWrap publishes wrap as the active raft envelope
@@ -90,14 +119,19 @@ func (g *ShardGroup) RaftPayloadWrap() RaftPayloadWrapper {
 // "don't validate for scenarios that can't happen at internal
 // boundaries" applies.
 func NewLeaderProxyForShardGroup(g *ShardGroup, opts ...TransactionOption) *LeaderProxy {
-	// Prepend the wrap-installation option so a caller-provided
-	// WithProposer would still take precedence (last option wins).
-	// In practice this PR has no caller that overrides the proposer
-	// via opts; the slot is reserved for future composition.
-	combined := make([]TransactionOption, 0, len(opts)+1)
-	combined = append(combined, withDynamicRaftPayloadWrap(&g.raftPayloadWrap))
-	combined = append(combined, opts...)
-	return NewLeaderProxyWithEngine(g.Engine, combined...)
+	// Build a single dynamicWrappedProposer for this shard group and
+	// cache it on g.proposer so direct shard proposals (HLC lease
+	// renewal in RunHLCLeaseRenewal, future cipher rotations) and
+	// the TransactionManager.Commit / Abort path share the same
+	// wrap pointer and the same Propose / ProposeAdmin call shape.
+	// A direct g.Engine.Propose call would bypass the wrap pointer
+	// (codex P2 round-1); routing both paths through the same
+	// proposer closes that hole.
+	g.proposer = newDynamicWrappedProposer(g.Engine, &g.raftPayloadWrap)
+	return &LeaderProxy{
+		engine: g.Engine,
+		tm:     NewTransactionWithProposer(g.proposer, opts...),
+	}
 }
 
 // leaseRefreshingTxn wraps a Transactional so every Commit / Abort that
@@ -1826,7 +1860,14 @@ func (c *ShardedCoordinator) RunHLCLeaseRenewal(ctx context.Context) {
 		case <-timer.C:
 			if group.Engine.State() == raftengine.StateLeader {
 				ceilingMs := time.Now().UnixMilli() + hlcPhysicalWindowMs
-				if _, err := group.Engine.Propose(ctx, marshalHLCLeaseRenew(ceilingMs)); err != nil {
+				// Route through the ShardGroup's wrap-aware proposer
+				// chain — NOT a direct group.Engine.Propose — so the
+				// Stage 6E-2c dynamic wrap applies. Without this, an
+				// HLC lease-renewal entry committed post-cutover at
+				// `index > raftEnvelopeCutoverIndex` would land
+				// cleartext and trip the §6.3 strict-> unwrap on
+				// every replica's apply loop (codex P2 round-1).
+				if _, err := group.Proposer().Propose(ctx, marshalHLCLeaseRenew(ceilingMs)); err != nil {
 					c.logger().WarnContext(ctx, "hlc lease renewal failed",
 						slog.Uint64("group_id", c.defaultGroup),
 						slog.Int64("ceiling_ms", ceilingMs),

--- a/kv/transaction.go
+++ b/kv/transaction.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/bootjp/elastickv/internal/raftengine"
@@ -57,6 +58,26 @@ type TransactionOption func(*TransactionManager)
 func WithProposalObserver(observer ProposalObserver) TransactionOption {
 	return func(t *TransactionManager) {
 		t.proposalObserver = observer
+	}
+}
+
+// withDynamicRaftPayloadWrap installs a dynamicWrappedProposer in
+// front of the constructor's proposer argument. The wrap closure
+// stored at wrapPtr is loaded on every Propose / ProposeAdmin call;
+// a nil load makes the proposer a pure pass-through (the Stage 3
+// default).
+//
+// Private because the production wiring is NewLeaderProxyForShardGroup,
+// which exposes the wrap surface as ShardGroup.SetRaftPayloadWrap.
+// Tests and direct constructors should go through that path so the
+// wrap pointer's storage stays owned by the ShardGroup that owns
+// the engine.
+func withDynamicRaftPayloadWrap(wrapPtr *atomic.Pointer[RaftPayloadWrapper]) TransactionOption {
+	return func(t *TransactionManager) {
+		if wrapPtr == nil {
+			return
+		}
+		t.proposer = newDynamicWrappedProposer(t.proposer, wrapPtr)
 	}
 }
 

--- a/kv/transaction.go
+++ b/kv/transaction.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"math"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/bootjp/elastickv/internal/raftengine"
@@ -58,26 +57,6 @@ type TransactionOption func(*TransactionManager)
 func WithProposalObserver(observer ProposalObserver) TransactionOption {
 	return func(t *TransactionManager) {
 		t.proposalObserver = observer
-	}
-}
-
-// withDynamicRaftPayloadWrap installs a dynamicWrappedProposer in
-// front of the constructor's proposer argument. The wrap closure
-// stored at wrapPtr is loaded on every Propose / ProposeAdmin call;
-// a nil load makes the proposer a pure pass-through (the Stage 3
-// default).
-//
-// Private because the production wiring is NewLeaderProxyForShardGroup,
-// which exposes the wrap surface as ShardGroup.SetRaftPayloadWrap.
-// Tests and direct constructors should go through that path so the
-// wrap pointer's storage stays owned by the ShardGroup that owns
-// the engine.
-func withDynamicRaftPayloadWrap(wrapPtr *atomic.Pointer[RaftPayloadWrapper]) TransactionOption {
-	return func(t *TransactionManager) {
-		if wrapPtr == nil {
-			return
-		}
-		t.proposer = newDynamicWrappedProposer(t.proposer, wrapPtr)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -488,7 +488,7 @@ func run() error {
 		coordinate, shardGroups[cfg.defaultGroup], encWiring.cache, etcdraftengine.DeriveNodeID)
 	if err := startServers(serversInput{
 		ctx: runCtx, eg: eg, cancel: cancel, lc: &lc,
-		runtimes: runtimes, bootstrapServers: bootstrapServers,
+		runtimes: runtimes, shardGroups: shardGroups, bootstrapServers: bootstrapServers,
 		shardStore: shardStore, coordinate: coordinate,
 		distServer: distServer, readTracker: readTracker,
 		metricsRegistry: metricsRegistry, cfg: cfg,
@@ -889,6 +889,23 @@ func observerForGroup(factory func(uint64) kv.ProposalObserver, groupID uint64) 
 	return factory(groupID)
 }
 
+// proposerForGroup returns the wrap-aware proposer for rt's shard
+// group, falling back to the raw engine when shardGroups does not
+// have an entry (test fixtures that construct a partial map).
+// Centralises the Stage 6E-2c forwarded-write wiring so the
+// Internal.Forward receive side and any future wrap-aware
+// construction site share the same lookup shape: the leader's
+// local LeaderProxy.Commit path is already wrap-aware via
+// NewLeaderProxyForShardGroup; this helper extends the same
+// guarantee to the Internal.Forward path that follower-forwarded
+// writes ride (codex P1 round-1 r2).
+func proposerForGroup(rt *raftGroupRuntime, shardGroups map[uint64]*kv.ShardGroup) raftengine.Proposer {
+	if sg, ok := shardGroups[rt.spec.id]; ok && sg != nil {
+		return sg.Proposer()
+	}
+	return rt.engine
+}
+
 // loadKEKAndRunStartupGuards loads the file-backed KEK wrapper and
 // runs the §9.1 startup-refusal guards (Stage 6C-1) BEFORE
 // buildShardGroups constructs any Raft engine or storage state. The
@@ -1079,6 +1096,7 @@ type serversInput struct {
 	cancel           context.CancelFunc
 	lc               *net.ListenConfig
 	runtimes         []*raftGroupRuntime
+	shardGroups      map[uint64]*kv.ShardGroup
 	bootstrapServers []raftengine.Server
 	shardStore       *kv.ShardStore
 	coordinate       kv.Coordinator
@@ -1149,6 +1167,7 @@ func startServers(in serversInput) error {
 		eg:              in.eg,
 		cancel:          in.cancel,
 		runtimes:        in.runtimes,
+		shardGroups:     in.shardGroups,
 		shardStore:      in.shardStore,
 		coordinate:      in.coordinate,
 		distServer:      in.distServer,
@@ -1517,6 +1536,7 @@ func startRaftServers(
 	lc *net.ListenConfig,
 	eg *errgroup.Group,
 	runtimes []*raftGroupRuntime,
+	shardGroups map[uint64]*kv.ShardGroup,
 	shardStore *kv.ShardStore,
 	coordinate kv.Coordinator,
 	distServer *adapter.DistributionServer,
@@ -1550,7 +1570,7 @@ func startRaftServers(
 			opts = append(opts, grpc.ChainStreamInterceptor(adminGRPCOpts.stream...))
 		}
 		gs := grpc.NewServer(opts...)
-		trx := kv.NewTransactionWithProposer(rt.engine, kv.WithProposalObserver(observerForGroup(proposalObserverForGroup, rt.spec.id)))
+		trx := kv.NewTransactionWithProposer(proposerForGroup(rt, shardGroups), kv.WithProposalObserver(observerForGroup(proposalObserverForGroup, rt.spec.id)))
 		grpcSvc := adapter.NewGRPCServer(shardStore, coordinate)
 		pb.RegisterRawKVServer(gs, grpcSvc)
 		pb.RegisterTransactionalKVServer(gs, grpcSvc)
@@ -1824,6 +1844,7 @@ type runtimeServerRunner struct {
 	eg                              *errgroup.Group
 	cancel                          context.CancelFunc
 	runtimes                        []*raftGroupRuntime
+	shardGroups                     map[uint64]*kv.ShardGroup
 	shardStore                      *kv.ShardStore
 	coordinate                      kv.Coordinator
 	distServer                      *adapter.DistributionServer
@@ -1932,6 +1953,7 @@ func (r *runtimeServerRunner) start() error {
 		r.lc,
 		r.eg,
 		r.runtimes,
+		r.shardGroups,
 		r.shardStore,
 		r.coordinate,
 		r.distServer,

--- a/main.go
+++ b/main.go
@@ -861,11 +861,23 @@ func buildShardGroups(
 			return nil, nil, errors.Wrapf(err, "failed to start raft group %d", g.id)
 		}
 		runtimes = append(runtimes, runtime)
-		shardGroups[g.id] = &kv.ShardGroup{
+		// Stage 6E-2c: route every shard group's TransactionManager
+		// through NewLeaderProxyForShardGroup so the proposer chain
+		// consults sg.raftPayloadWrap on every Propose / ProposeAdmin.
+		// The cell is nil at startup (the Stage 3 default — payloads
+		// pass through cleartext); Stage 6E-2d's EnableRaftEnvelope
+		// handler will publish the active wrap closure the instant
+		// the cutover entry commits. Going through this constructor
+		// for every group avoids a future "I forgot to wire wrap on
+		// this code path" regression — if a new shard group bypasses
+		// this helper, the wrap install would silently no-op on
+		// proposals for that group.
+		sg := &kv.ShardGroup{
 			Engine: runtime.engine,
 			Store:  st,
-			Txn:    kv.NewLeaderProxyWithEngine(runtime.engine, kv.WithProposalObserver(observerForGroup(proposalObserverForGroup, g.id))),
 		}
+		sg.Txn = kv.NewLeaderProxyForShardGroup(sg, kv.WithProposalObserver(observerForGroup(proposalObserverForGroup, g.id)))
+		shardGroups[g.id] = sg
 	}
 	return runtimes, shardGroups, nil
 }

--- a/main_encryption_write_wiring.go
+++ b/main_encryption_write_wiring.go
@@ -37,21 +37,24 @@ func buildShardGroupsWithEncryptionWiring(
 	encryptionEnabled bool,
 	routeEngine *distribution.Engine,
 ) ([]*raftGroupRuntime, map[uint64]*kv.ShardGroup, encryptionWriteWiring, error) {
-	encWiring, err := buildEncryptionWriteWiring(encryptionEnabled, raftID, sidecarPath, kekWrapper, keystore)
-	if err != nil {
-		return nil, nil, encryptionWriteWiring{}, err
-	}
-	// Stage 6E-2c: refuse startup BEFORE buildShardGroups runs if
-	// the sidecar reports an active raft envelope cutover. This
-	// binary does not (yet) ship the cipher-aware wrap closure
-	// factory (that lands in Stage 6E-2e/2f). With the cutover
-	// recorded but no wrap installed, every fresh proposal would
-	// land cleartext above the cutover index and halt the apply
-	// loop on §6.3 strict-`>` unwrap — a node-wide crash loop is
-	// worse than refusing to serve. Fail-closed here so the
-	// operator sees the refusal at boot, before any traffic is
-	// admitted and before any shard storage is opened (codex P1
-	// round-1).
+	// Stage 6E-2c: refuse startup BEFORE buildEncryptionWriteWiring
+	// runs (which calls prepareStorageNonceEpoch → BumpLocalEpoch
+	// → durable sidecar write). If we ran the refusal after the
+	// epoch bump, an orchestrator restart loop on a sidecar with
+	// non-zero RaftEnvelopeCutoverIndex would consume one
+	// local_epoch per boot and could hit ErrLocalEpochExhausted
+	// before the operator notices (codex P2 round-1 r3). Running
+	// it first keeps the sidecar untouched on the refusal path.
+	//
+	// This binary does not (yet) ship the cipher-aware wrap
+	// closure factory (that lands in Stage 6E-2e/2f). With a
+	// cutover recorded but no wrap installed, every fresh
+	// proposal would land cleartext above the cutover index and
+	// halt the apply loop on §6.3 strict-`>` unwrap — a
+	// node-wide crash loop is worse than refusing to serve.
+	// Fail-closed so the operator sees the refusal at boot,
+	// before any traffic is admitted and before any sidecar
+	// mutation (codex P1 round-1).
 	//
 	// In a healthy 6E-2c-only deployment this never fires:
 	// raftEnvelopeWrapEnabled is still false in
@@ -63,6 +66,10 @@ func buildShardGroupsWithEncryptionWiring(
 	// traffic.
 	if cutoverErr := refuseStartupOnActiveRaftCutover(sidecarPath); cutoverErr != nil {
 		return nil, nil, encryptionWriteWiring{}, cutoverErr
+	}
+	encWiring, err := buildEncryptionWriteWiring(encryptionEnabled, raftID, sidecarPath, kekWrapper, keystore)
+	if err != nil {
+		return nil, nil, encryptionWriteWiring{}, err
 	}
 	runtimes, shardGroups, err := buildShardGroups(raftID, raftDir, groups, multi, bootstrap, bootstrapServers,
 		factory, proposalObserverForGroup, clock, kekWrapper, keystore, sidecarPath, encWiring, routeEngine)

--- a/main_encryption_write_wiring.go
+++ b/main_encryption_write_wiring.go
@@ -41,61 +41,80 @@ func buildShardGroupsWithEncryptionWiring(
 	if err != nil {
 		return nil, nil, encryptionWriteWiring{}, err
 	}
+	// Stage 6E-2c: refuse startup BEFORE buildShardGroups runs if
+	// the sidecar reports an active raft envelope cutover. This
+	// binary does not (yet) ship the cipher-aware wrap closure
+	// factory (that lands in Stage 6E-2e/2f). With the cutover
+	// recorded but no wrap installed, every fresh proposal would
+	// land cleartext above the cutover index and halt the apply
+	// loop on §6.3 strict-`>` unwrap — a node-wide crash loop is
+	// worse than refusing to serve. Fail-closed here so the
+	// operator sees the refusal at boot, before any traffic is
+	// admitted and before any shard storage is opened (codex P1
+	// round-1).
+	//
+	// In a healthy 6E-2c-only deployment this never fires:
+	// raftEnvelopeWrapEnabled is still false in
+	// adapter/encryption_admin.go (see Stage 6E-1b), so
+	// EnableRaftEnvelope refuses to record a cutover index. The
+	// refusal fires only on a sidecar restored from a future
+	// deployment where 6E-2f flipped the gate, or hand-edited —
+	// both cases the operator must intervene before serving
+	// traffic.
+	if cutoverErr := refuseStartupOnActiveRaftCutover(sidecarPath); cutoverErr != nil {
+		return nil, nil, encryptionWriteWiring{}, cutoverErr
+	}
 	runtimes, shardGroups, err := buildShardGroups(raftID, raftDir, groups, multi, bootstrap, bootstrapServers,
 		factory, proposalObserverForGroup, clock, kekWrapper, keystore, sidecarPath, encWiring, routeEngine)
-	if err == nil {
-		// Stage 6E-2c: surface a startup notice if the sidecar
-		// reports that the raft envelope cutover has already been
-		// installed but the current binary does not (yet) ship the
-		// cipher-aware wrap closure factory. The shardGroup wrap
-		// pointers stay nil — proposals reach the engine cleartext
-		// — so post-cutover writes WOULD halt the apply loop on
-		// the §6.3 strict-`>` unwrap path if any committed entries
-		// landed above the cutover under this binary.
-		//
-		// In a healthy 6E-2c-only deployment this never fires:
-		// raftEnvelopeWrapEnabled is still false in
-		// adapter/encryption_admin.go (see Stage 6E-1b), so
-		// EnableRaftEnvelope refuses to record a cutover index.
-		// The notice fires only on a sidecar restored from a
-		// future deployment where 6E-2f flipped the gate, or one
-		// hand-edited — both cases the operator must intervene
-		// before serving traffic.
-		noteRaftEnvelopeCutoverStartup(sidecarPath)
-	}
 	// Return the wiring (cache + bumped epoch) so run() can drive the
 	// Stage 7a process-start registration after the shard stores open.
 	return runtimes, shardGroups, encWiring, err
 }
 
-// noteRaftEnvelopeCutoverStartup reads the sidecar at process start
-// and logs a WARN if RaftEnvelopeCutoverIndex is non-zero. Stage
-// 6E-2c installs the dynamic wrap proposer chain on every shard
-// group but leaves the wrap closure pointer nil — the cipher-aware
-// factory ships in Stage 6E-2e/2f. Without the closure, a post-
-// cutover write proposed under this binary would land cleartext
-// above the cutover; the strict-`>` apply hook would then halt on
-// unwrap failure.
+// refuseStartupOnActiveRaftCutover reads the sidecar at process
+// start and returns a fail-closed error if RaftEnvelopeCutoverIndex
+// is non-zero. Stage 6E-2c installs the dynamic wrap proposer
+// chain on every shard group but leaves the wrap closure pointer
+// nil — the cipher-aware factory ships in Stage 6E-2e/2f. Without
+// the closure, a post-cutover write proposed under this binary
+// would land cleartext above the cutover; the strict-`>` apply
+// hook would then halt on unwrap failure across the cluster.
 //
 // Missing or unreadable sidecars are not this helper's concern —
 // the Stage 6C-1 startup guard already refuses to boot when the
 // sidecar is malformed or the KEK does not unwrap the recorded
-// DEKs. A clean ReadSidecar with a zero RaftEnvelopeCutoverIndex is
-// the Stage 3 default and stays silent.
-func noteRaftEnvelopeCutoverStartup(sidecarPath string) {
+// DEKs. A clean ReadSidecar with a zero RaftEnvelopeCutoverIndex
+// is the Stage 3 default and returns nil.
+//
+// The error message names the recovery path explicitly so the
+// operator log line is enough to act on without grepping source.
+func refuseStartupOnActiveRaftCutover(sidecarPath string) error {
 	if sidecarPath == "" {
-		return
+		return nil
 	}
 	sc, err := encryption.ReadSidecar(sidecarPath)
 	if err != nil {
-		return
+		// Missing sidecar is the pre-bootstrap state — there is no
+		// raft envelope cutover to refuse on. Other read failures
+		// (malformed / KEK-mismatched) propagate so the caller's
+		// startup chain sees them; mirroring the prepareStorageNonceEpoch
+		// shape that lets the Stage 6C-1 startup guard surface the
+		// same error through a different code path keeps the
+		// failure mode consistent.
+		if encryption.IsNotExist(err) {
+			return nil
+		}
+		return pkgerrors.Wrap(err, "encryption: refuse startup on active raft cutover (read sidecar)")
 	}
 	if sc.RaftEnvelopeCutoverIndex == 0 {
-		return
+		return nil
 	}
-	slog.Warn("encryption: sidecar reports raft envelope cutover active but Stage 6E-2c does not install the wrap closure on shard groups; Stage 6E-2e/2f wires the cipher. Until then, fresh writes that land above the cutover would halt the apply loop on §6.3 strict-> unwrap. Operator action required.",
+	slog.Error("encryption: refusing to start — sidecar reports raft envelope cutover active but this binary does not install the wrap closure on shard groups; Stage 6E-2e/2f wires the cipher. Restore a sidecar with RaftEnvelopeCutoverIndex=0 (cutover not yet installed) or upgrade to a binary that ships the cipher factory.",
 		slog.Uint64("cutover_index", sc.RaftEnvelopeCutoverIndex),
 		slog.String("sidecar_path", sidecarPath))
+	return pkgerrors.Errorf(
+		"encryption: sidecar reports raft envelope cutover active at index %d but this binary does not install the wrap closure on shard groups; Stage 6E-2e/2f wires the cipher — restore a sidecar with RaftEnvelopeCutoverIndex=0 or upgrade",
+		sc.RaftEnvelopeCutoverIndex)
 }
 
 // encryptionWriteWiring bundles the Stage 6D-6c storage-envelope

--- a/main_encryption_write_wiring.go
+++ b/main_encryption_write_wiring.go
@@ -43,9 +43,59 @@ func buildShardGroupsWithEncryptionWiring(
 	}
 	runtimes, shardGroups, err := buildShardGroups(raftID, raftDir, groups, multi, bootstrap, bootstrapServers,
 		factory, proposalObserverForGroup, clock, kekWrapper, keystore, sidecarPath, encWiring, routeEngine)
+	if err == nil {
+		// Stage 6E-2c: surface a startup notice if the sidecar
+		// reports that the raft envelope cutover has already been
+		// installed but the current binary does not (yet) ship the
+		// cipher-aware wrap closure factory. The shardGroup wrap
+		// pointers stay nil — proposals reach the engine cleartext
+		// — so post-cutover writes WOULD halt the apply loop on
+		// the §6.3 strict-`>` unwrap path if any committed entries
+		// landed above the cutover under this binary.
+		//
+		// In a healthy 6E-2c-only deployment this never fires:
+		// raftEnvelopeWrapEnabled is still false in
+		// adapter/encryption_admin.go (see Stage 6E-1b), so
+		// EnableRaftEnvelope refuses to record a cutover index.
+		// The notice fires only on a sidecar restored from a
+		// future deployment where 6E-2f flipped the gate, or one
+		// hand-edited — both cases the operator must intervene
+		// before serving traffic.
+		noteRaftEnvelopeCutoverStartup(sidecarPath)
+	}
 	// Return the wiring (cache + bumped epoch) so run() can drive the
 	// Stage 7a process-start registration after the shard stores open.
 	return runtimes, shardGroups, encWiring, err
+}
+
+// noteRaftEnvelopeCutoverStartup reads the sidecar at process start
+// and logs a WARN if RaftEnvelopeCutoverIndex is non-zero. Stage
+// 6E-2c installs the dynamic wrap proposer chain on every shard
+// group but leaves the wrap closure pointer nil — the cipher-aware
+// factory ships in Stage 6E-2e/2f. Without the closure, a post-
+// cutover write proposed under this binary would land cleartext
+// above the cutover; the strict-`>` apply hook would then halt on
+// unwrap failure.
+//
+// Missing or unreadable sidecars are not this helper's concern —
+// the Stage 6C-1 startup guard already refuses to boot when the
+// sidecar is malformed or the KEK does not unwrap the recorded
+// DEKs. A clean ReadSidecar with a zero RaftEnvelopeCutoverIndex is
+// the Stage 3 default and stays silent.
+func noteRaftEnvelopeCutoverStartup(sidecarPath string) {
+	if sidecarPath == "" {
+		return
+	}
+	sc, err := encryption.ReadSidecar(sidecarPath)
+	if err != nil {
+		return
+	}
+	if sc.RaftEnvelopeCutoverIndex == 0 {
+		return
+	}
+	slog.Warn("encryption: sidecar reports raft envelope cutover active but Stage 6E-2c does not install the wrap closure on shard groups; Stage 6E-2e/2f wires the cipher. Until then, fresh writes that land above the cutover would halt the apply loop on §6.3 strict-> unwrap. Operator action required.",
+		slog.Uint64("cutover_index", sc.RaftEnvelopeCutoverIndex),
+		slog.String("sidecar_path", sidecarPath))
 }
 
 // encryptionWriteWiring bundles the Stage 6D-6c storage-envelope

--- a/main_encryption_write_wiring_test.go
+++ b/main_encryption_write_wiring_test.go
@@ -200,3 +200,68 @@ func TestPrepareStorageNonceEpoch_SaturatedEpoch_RefusesWithExhausted(t *testing
 		t.Errorf("error not marked ErrLocalEpochExhausted: %v", err)
 	}
 }
+
+// TestNoteRaftEnvelopeCutoverStartup_NoSidecarPath pins the
+// degraded-input behaviour: an empty sidecar path returns without
+// any side effect (no log, no panic). This is the
+// encryption-disabled startup case where no sidecar is configured.
+func TestNoteRaftEnvelopeCutoverStartup_NoSidecarPath(t *testing.T) {
+	t.Parallel()
+	noteRaftEnvelopeCutoverStartup("")
+}
+
+// TestNoteRaftEnvelopeCutoverStartup_MissingSidecar pins the
+// silent-on-missing-file behaviour: the Stage 6C-1 startup guard
+// is the authoritative refuser of malformed sidecars; this helper
+// only cares about a present sidecar with a non-zero cutover
+// index, and silently returns on any ReadSidecar error.
+func TestNoteRaftEnvelopeCutoverStartup_MissingSidecar(t *testing.T) {
+	t.Parallel()
+	noteRaftEnvelopeCutoverStartup(t.TempDir() + "/absent.json")
+}
+
+// TestNoteRaftEnvelopeCutoverStartup_ZeroCutoverIsSilent pins the
+// Stage 3 default: a sidecar with RaftEnvelopeCutoverIndex == 0
+// must not log — that is the pre-cutover state, which is
+// universal until Stage 6E-2f flips the gate.
+func TestNoteRaftEnvelopeCutoverStartup_ZeroCutoverIsSilent(t *testing.T) {
+	t.Parallel()
+	path := writeActiveStorageSidecar(t, 0) // RaftEnvelopeCutoverIndex defaults to 0
+	noteRaftEnvelopeCutoverStartup(path)
+}
+
+// TestNoteRaftEnvelopeCutoverStartup_NonZeroCutoverLogs exercises
+// the "active cutover but no wrap closure" branch end-to-end:
+// write a sidecar with RaftEnvelopeCutoverIndex != 0, invoke the
+// hook, and confirm it does not panic / does not mutate the
+// sidecar. The log line itself is observable only via slog
+// handlers in production; the test exists primarily so a future
+// refactor that removes the read path fails compile or trips a
+// regression in this asserted-no-panic branch.
+func TestNoteRaftEnvelopeCutoverStartup_NonZeroCutoverLogs(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := dir + "/keys.json"
+	sc := &encryption.Sidecar{
+		Version:                  encryption.SidecarVersion,
+		StorageEnvelopeActive:    true,
+		RaftEnvelopeCutoverIndex: 12345,
+		Active:                   encryption.ActiveKeys{Storage: 3, Raft: 4},
+		Keys: map[string]encryption.SidecarKey{
+			"3": {Purpose: encryption.SidecarPurposeStorage, Wrapped: []byte("storage-wrapped-bytes")},
+			"4": {Purpose: encryption.SidecarPurposeRaft, Wrapped: []byte("raft-wrapped-bytes-diff")},
+		},
+	}
+	if err := encryption.WriteSidecar(path, sc); err != nil {
+		t.Fatalf("WriteSidecar: %v", err)
+	}
+	noteRaftEnvelopeCutoverStartup(path)
+	// Sidecar must be unchanged on disk — the hook is read-only.
+	got, err := encryption.ReadSidecar(path)
+	if err != nil {
+		t.Fatalf("ReadSidecar after hook: %v", err)
+	}
+	if got.RaftEnvelopeCutoverIndex != 12345 {
+		t.Errorf("post-hook RaftEnvelopeCutoverIndex = %d, want 12345 (hook must be read-only)", got.RaftEnvelopeCutoverIndex)
+	}
+}

--- a/main_encryption_write_wiring_test.go
+++ b/main_encryption_write_wiring_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/bootjp/elastickv/internal/encryption"
@@ -319,5 +320,31 @@ func TestRefuseStartupOnActiveRaftCutover_NonZeroCutoverRefuses(t *testing.T) {
 	}
 	if got.RaftEnvelopeCutoverIndex != 12345 {
 		t.Errorf("post-helper RaftEnvelopeCutoverIndex = %d, want 12345 (helper must be read-only)", got.RaftEnvelopeCutoverIndex)
+	}
+}
+
+// TestRefuseStartupOnActiveRaftCutover_BadSidecarPropagates pins the
+// fail-closed read-error branch: ReadSidecar errors that are NOT
+// encryption.IsNotExist (malformed JSON, schema violation, KEK
+// mismatch, etc.) must propagate as a refusal error. The helper's
+// nil-return is narrowed to the pre-bootstrap case only; widening
+// it into fail-open behaviour for any other failure mode would
+// silently bypass the cutover guard.
+//
+// We use a malformed sidecar file (text that is not valid JSON) to
+// trigger a non-NotExist read error. The exact error type is not
+// asserted — only that the helper returns non-nil — because the
+// underlying error chain is supplied by encryption.ReadSidecar's
+// JSON / version decoder, which is not a contract surface this
+// test should pin.
+func TestRefuseStartupOnActiveRaftCutover_BadSidecarPropagates(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := dir + "/keys.json"
+	if err := os.WriteFile(path, []byte("not a valid sidecar"), 0o600); err != nil {
+		t.Fatalf("write malformed sidecar: %v", err)
+	}
+	if err := refuseStartupOnActiveRaftCutover(path); err == nil {
+		t.Fatal("malformed sidecar: refuseStartupOnActiveRaftCutover = nil, want refusal (fail-closed on read error)")
 	}
 }

--- a/main_encryption_write_wiring_test.go
+++ b/main_encryption_write_wiring_test.go
@@ -236,6 +236,53 @@ func TestRefuseStartupOnActiveRaftCutover_ZeroCutoverPasses(t *testing.T) {
 	}
 }
 
+// TestRefuseStartupOnActiveRaftCutover_NonZeroCutoverDoesNotBumpEpoch
+// pins the codex P2 round-1 r3 property: the refusal MUST run
+// before buildEncryptionWriteWiring's prepareStorageNonceEpoch
+// step, otherwise an orchestrator restart loop on a sidecar with
+// non-zero RaftEnvelopeCutoverIndex would consume one local_epoch
+// per boot and could hit ErrLocalEpochExhausted before the
+// operator notices.
+//
+// This is a black-box test on the helper itself: after invoking
+// refuseStartupOnActiveRaftCutover with a non-zero-cutover
+// sidecar, the sidecar's storage epoch field on disk MUST be
+// unchanged from what we wrote, proving no BumpLocalEpoch path
+// could have run downstream of the helper. The buildShardGroupsWithEncryption
+// Wiring ordering invariant (refusal BEFORE buildEncryptionWriteWiring)
+// is enforced structurally; this test guards against a future
+// refactor that swaps the order.
+func TestRefuseStartupOnActiveRaftCutover_NonZeroCutoverDoesNotBumpEpoch(t *testing.T) {
+	t.Parallel()
+	const initialStorageEpoch uint16 = 7
+	dir := t.TempDir()
+	path := dir + "/keys.json"
+	sc := &encryption.Sidecar{
+		Version:                  encryption.SidecarVersion,
+		StorageEnvelopeActive:    true,
+		RaftEnvelopeCutoverIndex: 12345,
+		Active:                   encryption.ActiveKeys{Storage: 3, Raft: 4},
+		Keys: map[string]encryption.SidecarKey{
+			"3": {Purpose: encryption.SidecarPurposeStorage, Wrapped: []byte("storage-wrapped-bytes"), LocalEpoch: initialStorageEpoch},
+			"4": {Purpose: encryption.SidecarPurposeRaft, Wrapped: []byte("raft-wrapped-bytes-diff")},
+		},
+	}
+	if err := encryption.WriteSidecar(path, sc); err != nil {
+		t.Fatalf("WriteSidecar: %v", err)
+	}
+	if err := refuseStartupOnActiveRaftCutover(path); err == nil {
+		t.Fatal("non-zero cutover: refuseStartupOnActiveRaftCutover = nil, want refusal")
+	}
+	got, err := encryption.ReadSidecar(path)
+	if err != nil {
+		t.Fatalf("ReadSidecar after refusal: %v", err)
+	}
+	gotEpoch := got.Keys["3"].LocalEpoch
+	if gotEpoch != initialStorageEpoch {
+		t.Errorf("post-refusal storage LocalEpoch = %d, want %d (refusal must run before any sidecar mutation)", gotEpoch, initialStorageEpoch)
+	}
+}
+
 // TestRefuseStartupOnActiveRaftCutover_NonZeroCutoverRefuses
 // pins the codex P1 fail-closed property: when the sidecar
 // reports RaftEnvelopeCutoverIndex != 0, the helper returns a

--- a/main_encryption_write_wiring_test.go
+++ b/main_encryption_write_wiring_test.go
@@ -214,10 +214,14 @@ func TestRefuseStartupOnActiveRaftCutover_NoSidecarPath(t *testing.T) {
 }
 
 // TestRefuseStartupOnActiveRaftCutover_MissingSidecar pins the
-// nil-on-missing-file behaviour: the Stage 6C-1 startup guard
-// is the authoritative refuser of malformed sidecars; this helper
-// only cares about a present sidecar with a non-zero cutover
-// index, and silently returns nil on any ReadSidecar error.
+// nil-on-missing-file behaviour: a missing sidecar is the
+// pre-bootstrap state and there is no raft envelope cutover to
+// refuse on. Only encryption.IsNotExist errors return nil here;
+// non-NotExist read errors (malformed JSON, schema violation)
+// propagate as a refusal — see the sibling
+// TestRefuseStartupOnActiveRaftCutover_BadSidecarPropagates that
+// pins that branch (codex P1 round-1 r2 narrowed the nil-return
+// from "any read error" to IsNotExist only).
 func TestRefuseStartupOnActiveRaftCutover_MissingSidecar(t *testing.T) {
 	t.Parallel()
 	if err := refuseStartupOnActiveRaftCutover(t.TempDir() + "/absent.json"); err != nil {

--- a/main_encryption_write_wiring_test.go
+++ b/main_encryption_write_wiring_test.go
@@ -201,44 +201,50 @@ func TestPrepareStorageNonceEpoch_SaturatedEpoch_RefusesWithExhausted(t *testing
 	}
 }
 
-// TestNoteRaftEnvelopeCutoverStartup_NoSidecarPath pins the
-// degraded-input behaviour: an empty sidecar path returns without
-// any side effect (no log, no panic). This is the
-// encryption-disabled startup case where no sidecar is configured.
-func TestNoteRaftEnvelopeCutoverStartup_NoSidecarPath(t *testing.T) {
+// TestRefuseStartupOnActiveRaftCutover_NoSidecarPath pins the
+// degraded-input behaviour: an empty sidecar path returns nil
+// (no refusal). This is the encryption-disabled startup case
+// where no sidecar is configured.
+func TestRefuseStartupOnActiveRaftCutover_NoSidecarPath(t *testing.T) {
 	t.Parallel()
-	noteRaftEnvelopeCutoverStartup("")
+	if err := refuseStartupOnActiveRaftCutover(""); err != nil {
+		t.Errorf("empty sidecarPath: refuseStartupOnActiveRaftCutover = %v, want nil", err)
+	}
 }
 
-// TestNoteRaftEnvelopeCutoverStartup_MissingSidecar pins the
-// silent-on-missing-file behaviour: the Stage 6C-1 startup guard
+// TestRefuseStartupOnActiveRaftCutover_MissingSidecar pins the
+// nil-on-missing-file behaviour: the Stage 6C-1 startup guard
 // is the authoritative refuser of malformed sidecars; this helper
 // only cares about a present sidecar with a non-zero cutover
-// index, and silently returns on any ReadSidecar error.
-func TestNoteRaftEnvelopeCutoverStartup_MissingSidecar(t *testing.T) {
+// index, and silently returns nil on any ReadSidecar error.
+func TestRefuseStartupOnActiveRaftCutover_MissingSidecar(t *testing.T) {
 	t.Parallel()
-	noteRaftEnvelopeCutoverStartup(t.TempDir() + "/absent.json")
+	if err := refuseStartupOnActiveRaftCutover(t.TempDir() + "/absent.json"); err != nil {
+		t.Errorf("missing sidecar: refuseStartupOnActiveRaftCutover = %v, want nil (Stage 6C-1 owns malformed sidecars)", err)
+	}
 }
 
-// TestNoteRaftEnvelopeCutoverStartup_ZeroCutoverIsSilent pins the
+// TestRefuseStartupOnActiveRaftCutover_ZeroCutoverPasses pins the
 // Stage 3 default: a sidecar with RaftEnvelopeCutoverIndex == 0
-// must not log — that is the pre-cutover state, which is
+// must return nil — that is the pre-cutover state, which is
 // universal until Stage 6E-2f flips the gate.
-func TestNoteRaftEnvelopeCutoverStartup_ZeroCutoverIsSilent(t *testing.T) {
+func TestRefuseStartupOnActiveRaftCutover_ZeroCutoverPasses(t *testing.T) {
 	t.Parallel()
 	path := writeActiveStorageSidecar(t, 0) // RaftEnvelopeCutoverIndex defaults to 0
-	noteRaftEnvelopeCutoverStartup(path)
+	if err := refuseStartupOnActiveRaftCutover(path); err != nil {
+		t.Errorf("zero cutover: refuseStartupOnActiveRaftCutover = %v, want nil (Stage 3 default must pass)", err)
+	}
 }
 
-// TestNoteRaftEnvelopeCutoverStartup_NonZeroCutoverLogs exercises
-// the "active cutover but no wrap closure" branch end-to-end:
-// write a sidecar with RaftEnvelopeCutoverIndex != 0, invoke the
-// hook, and confirm it does not panic / does not mutate the
-// sidecar. The log line itself is observable only via slog
-// handlers in production; the test exists primarily so a future
-// refactor that removes the read path fails compile or trips a
-// regression in this asserted-no-panic branch.
-func TestNoteRaftEnvelopeCutoverStartup_NonZeroCutoverLogs(t *testing.T) {
+// TestRefuseStartupOnActiveRaftCutover_NonZeroCutoverRefuses
+// pins the codex P1 fail-closed property: when the sidecar
+// reports RaftEnvelopeCutoverIndex != 0, the helper returns a
+// non-nil error so buildShardGroupsWithEncryptionWiring refuses
+// startup. Without this, the binary would proceed with nil
+// shard-group wrap pointers and fresh proposals could land
+// cleartext above the cutover, halting the apply loop on the
+// §6.3 strict-> unwrap path.
+func TestRefuseStartupOnActiveRaftCutover_NonZeroCutoverRefuses(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	path := dir + "/keys.json"
@@ -255,13 +261,16 @@ func TestNoteRaftEnvelopeCutoverStartup_NonZeroCutoverLogs(t *testing.T) {
 	if err := encryption.WriteSidecar(path, sc); err != nil {
 		t.Fatalf("WriteSidecar: %v", err)
 	}
-	noteRaftEnvelopeCutoverStartup(path)
-	// Sidecar must be unchanged on disk — the hook is read-only.
-	got, err := encryption.ReadSidecar(path)
-	if err != nil {
-		t.Fatalf("ReadSidecar after hook: %v", err)
+	err := refuseStartupOnActiveRaftCutover(path)
+	if err == nil {
+		t.Fatal("non-zero cutover: refuseStartupOnActiveRaftCutover = nil, want refusal (codex P1)")
+	}
+	// Sidecar must be unchanged on disk — the helper is read-only.
+	got, err2 := encryption.ReadSidecar(path)
+	if err2 != nil {
+		t.Fatalf("ReadSidecar after helper: %v", err2)
 	}
 	if got.RaftEnvelopeCutoverIndex != 12345 {
-		t.Errorf("post-hook RaftEnvelopeCutoverIndex = %d, want 12345 (hook must be read-only)", got.RaftEnvelopeCutoverIndex)
+		t.Errorf("post-helper RaftEnvelopeCutoverIndex = %d, want 12345 (helper must be read-only)", got.RaftEnvelopeCutoverIndex)
 	}
 }

--- a/main_proposer_for_group_test.go
+++ b/main_proposer_for_group_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/raftengine"
+	"github.com/bootjp/elastickv/kv"
+)
+
+// stubEngineForProposerTest satisfies raftengine.Engine at the
+// type level (via embedding) without implementing any method.
+// proposerForGroup never calls into the engine — it only stores
+// the reference as the return-typed raftengine.Proposer — so the
+// nil-embedded shape is sufficient and keeps this test free of
+// the full Engine surface area.
+type stubEngineForProposerTest struct {
+	raftengine.Engine
+}
+
+// TestProposerForGroup_UsesShardGroupProposerWhenPresent pins the
+// Stage 6E-2c forwarded-write wiring at main.go:1573 (Internal.Forward
+// TransactionManager construction) against silent regression: when
+// shardGroups carries an entry for rt.spec.id, the returned
+// proposer MUST be ShardGroup.Proposer() — i.e. the wrap-aware
+// dynamicWrappedProposer chain installed by
+// NewLeaderProxyForShardGroup — and NOT a raw rt.engine reference.
+//
+// A future refactor that swaps the helper back to rt.engine would
+// silently reopen the cleartext-bypass path for forwarded follower
+// writes after the EnableRaftEnvelope cutover (codex round-2 P1).
+// This test fails the moment that regression lands.
+func TestProposerForGroup_UsesShardGroupProposerWhenPresent(t *testing.T) {
+	t.Parallel()
+	engine := &stubEngineForProposerTest{}
+	sg := &kv.ShardGroup{Engine: engine}
+	// Install sg.proposer via the production constructor so the
+	// Proposer() accessor returns the wrap-aware path, not the
+	// Engine fallback. NewLeaderProxyForShardGroup is the only
+	// public way to set the cached proposer; bypassing it would
+	// test the fallback branch instead, which is covered by the
+	// sibling test below.
+	_ = kv.NewLeaderProxyForShardGroup(sg)
+
+	rt := &raftGroupRuntime{spec: groupSpec{id: 7}, engine: engine}
+	got := proposerForGroup(rt, map[uint64]*kv.ShardGroup{7: sg})
+	if got == nil {
+		t.Fatal("proposerForGroup returned nil")
+	}
+	// A raw engine reference here means the wrap-aware path is
+	// silently bypassed. The Proposer() accessor wraps Engine in
+	// a dynamicWrappedProposer after NewLeaderProxyForShardGroup,
+	// so the returned value must NOT be the engine itself.
+	if got == raftengine.Proposer(engine) {
+		t.Error("proposerForGroup returned raw rt.engine; want sg.Proposer() (wrap-aware) — Internal.Forward bypass risk")
+	}
+	if got != sg.Proposer() {
+		t.Error("proposerForGroup did not return sg.Proposer(); a future refactor could silently divert the forwarded-write path off the wrap chain")
+	}
+}
+
+// TestProposerForGroup_FallsBackToEngineWhenShardGroupMissing
+// pins the documented fallback: when shardGroups does not have
+// an entry for rt.spec.id (test fixtures that pass a partial
+// map), the raw rt.engine is returned so the Internal.Forward
+// path still works. Production wires every runtime's shard group
+// via buildShardGroups, so the fallback never fires in production;
+// this test guards the test-fixture contract.
+func TestProposerForGroup_FallsBackToEngineWhenShardGroupMissing(t *testing.T) {
+	t.Parallel()
+	engine := &stubEngineForProposerTest{}
+	rt := &raftGroupRuntime{spec: groupSpec{id: 7}, engine: engine}
+
+	got := proposerForGroup(rt, map[uint64]*kv.ShardGroup{})
+	if got != raftengine.Proposer(engine) {
+		t.Errorf("proposerForGroup did not fall back to rt.engine for missing shardGroup; got %T, want raw engine", got)
+	}
+}
+
+// TestProposerForGroup_FallsBackToEngineWhenShardGroupNil pins
+// the same fallback for an explicit nil entry in the map (an
+// edge case if a future construction site stages map entries
+// before populating them). proposerForGroup must treat nil the
+// same as "missing" so the partial-map invariant holds for both
+// shapes.
+func TestProposerForGroup_FallsBackToEngineWhenShardGroupNil(t *testing.T) {
+	t.Parallel()
+	engine := &stubEngineForProposerTest{}
+	rt := &raftGroupRuntime{spec: groupSpec{id: 7}, engine: engine}
+
+	got := proposerForGroup(rt, map[uint64]*kv.ShardGroup{7: nil})
+	if got != raftengine.Proposer(engine) {
+		t.Errorf("proposerForGroup did not fall back to rt.engine for nil shardGroup entry; got %T, want raw engine", got)
+	}
+}


### PR DESCRIPTION
## Summary

Stage 6E-2c: install the Stage 6E-2 wrap-on-propose plumbing on every shard group without yet activating any cipher. Every `ShardGroup` gets an `atomic.Pointer[RaftPayloadWrapper]` cell; the proposer chain consults that pointer on every `Propose` / `ProposeAdmin` call; `SetRaftPayloadWrap` is the hot-swap surface Stage 6E-2d will use when `EnableRaftEnvelope` commits. The wrap closure factory itself ships in Stage 6E-2e/2f.

A startup hook reads the sidecar and logs a `WARN` if `RaftEnvelopeCutoverIndex != 0` — operator-visible refusal of a deployment that crosses the cutover line under a binary without the cipher factory wired.

## Pieces

- `dynamicWrappedProposer` (kv/raft_payload_wrapper.go): wraps a `raftengine.Proposer` with an `atomic.Pointer.Load` on every call. Mirrors `wrappedProposer`'s Propose / ProposeAdmin routing and wrap semantics — the wrap layer is NOT a barrier exemption; Propose and ProposeAdmin apply the same wrap. The cutover marker stays cleartext via the raw-engine reference at the call site, not at the method level.
- `ShardGroup.raftPayloadWrap` + `SetRaftPayloadWrap` + `RaftPayloadWrap` (kv/sharded_coordinator.go): the published hot-swap surface.
- `NewLeaderProxyForShardGroup` + `withDynamicRaftPayloadWrap` (kv/sharded_coordinator.go, kv/transaction.go): the production wiring path. `main.go`'s `buildShardGroups` now constructs every shard group's `LeaderProxy` via this helper so the dynamic wrap chain is universal.
- `noteRaftEnvelopeCutoverStartup` (main_encryption_write_wiring.go): process-start sidecar read. Silent on the universal pre-cutover case and on any read error (the Stage 6C-1 startup guard is the authoritative refuser). Logs `WARN` only when the cutover index is non-zero but the binary does not (yet) ship the cipher factory.

## Tests (8 new)

- `TestDynamicWrappedProposer_NilPointerReturnsInnerVerbatim` — defensive degradation for nil `*atomic.Pointer`.
- `TestDynamicWrappedProposer_NilStoredIsPassThrough` — Stage 3 default (verbatim routing for Propose and ProposeAdmin separately).
- `TestDynamicWrappedProposer_LoadsCurrentWrapEveryCall` — hot-swap contract (install / clear observed by the next proposal).
- `TestDynamicWrappedProposer_ProposeAdminAppliesCurrentWrap` — admin-path mirror; confirms `inner.ProposeAdmin` (not `Propose`) is reached when wrap is active.
- `TestShardGroup_SetRaftPayloadWrap_RoundTrip` — Set/Get round-trip including the nil-clears semantics.
- `TestNoteRaftEnvelopeCutoverStartup_*` (×4) — empty path / missing file / zero cutover / non-zero cutover (asserts the hook is read-only).

## Five-lens self-review

- **Data loss**: the dynamic wrap proposer is a pass-through when the pointer holds nil (the Stage 6E-2c default). Production behaviour is unchanged today — every proposal still reaches the engine cleartext via the existing path. No new error swallow, no new fall-through.
- **Concurrency / distributed**: hot-swap uses `atomic.Pointer.Store` / `Load`; reads are lock-free and observe a fully-published closure (either nil or non-nil) on every call. Last-writer-wins on concurrent stores; no torn read.
- **Performance**: one extra `atomic.Pointer.Load` per Propose / ProposeAdmin on the dynamic path; no allocation, no contention. Wrap closure invocation cost is paid only when non-nil; matches the existing `wrappedProposer` profile.
- **Data consistency**: the wrap pointer's lifetime is owned by the `ShardGroup` that owns the engine; the proposer holds an `*atomic.Pointer` reference back into `ShardGroup`. No cross-shard mixing — each shard has its own pointer, so a future per-shard rotation policy works without changes here.
- **Test coverage**: 8 new tests cover the wrap-proposer mechanics, the ShardGroup hot-swap surface, and the startup hook input matrix.

## Caller audit (per /loop semantic-change rule)

- `kv.NewLeaderProxyWithEngine` (kept; non-wrap-aware): no behaviour change. Test fixtures and any shard group that opts out of encryption continue to use it.
- `kv.NewLeaderProxyForShardGroup` (new; wrap-aware): used by `main.go`'s `buildShardGroups` for every production shard group. Audit: the only construction site for production `ShardGroup` instances now routes through this helper.
- ShardGroup struct literal in `main.go`: switched from one-shot literal with `Txn` set inline to two-step build (struct literal, then `Txn = NewLeaderProxyForShardGroup(sg, opts...)`). Necessary because `NewLeaderProxyForShardGroup` needs the `&sg.raftPayloadWrap` pointer, which is only addressable after the struct exists.
- `SetRaftPayloadWrap` callers: none in this PR. The surface is published for Stage 6E-2d's `EnableRaftEnvelope` handler.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean (pre-commit hook ran)
- [x] `go test -race -run 'DynamicWrappedProposer|ShardGroup_Set|WrappedProposer|NoteRaftEnvelopeCutover' .` passes
- [x] `go test -race ./kv/` scoped tests pass

Refs: `docs/design/2026_05_31_partial_6e_enable_raft_envelope.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced runtime-swappable raft payload envelope wrapping with dynamic wrapper support across all proposal types and shard groups.

* **Chores**
  * Added startup validation to detect and prevent incompatible payload envelope cutover states with clear operator guidance.

* **Tests**
  * Expanded test coverage for dynamic payload wrapper behavior, atomic pointer runtime swapping, integration with shard groups, and startup safety checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->