### PR TITLE
fix(adapter/sqs): standard SendMessageBatch double-send under leader churn

### DIFF
--- a/adapter/sqs_batch_send_dedup_test.go
+++ b/adapter/sqs_batch_send_dedup_test.go
@@ -18,9 +18,15 @@ import (
 type recordingBatchCoordinator struct {
 	stubAdapterCoordinator
 	dispatchKeys [][]string
+	// beforeDispatch, if set, runs at the start of each Dispatch with the
+	// 1-based dispatch number — lets a test mutate queue state between attempts.
+	beforeDispatch func(n int)
 }
 
 func (c *recordingBatchCoordinator) Dispatch(_ context.Context, req *kv.OperationGroup[kv.OP]) (*kv.CoordinateResponse, error) {
+	if c.beforeDispatch != nil {
+		c.beforeDispatch(len(c.dispatchKeys) + 1)
+	}
 	keys := make([]string, 0, len(req.Elems))
 	for _, e := range req.Elems {
 		keys = append(keys, string(e.Key))
@@ -74,6 +80,41 @@ func TestSendMessageBatchStandard_RetryReusesStableKeys(t *testing.T) {
 	require.NotEmpty(t, coord.dispatchKeys[0])
 	require.Equal(t, coord.dispatchKeys[0], coord.dispatchKeys[1],
 		"the retry MUST reuse the same storage keys; fresh MessageIDs would double-send every entry under leader churn")
+}
+
+// TestSendMessageBatchStandard_VisKeyStableAcrossDelayChange pins codex P2:
+// if a SetQueueAttributes changes the queue's DelaySeconds between a
+// committed-but-conflicted attempt and its retry, the retry must still write
+// the SAME vis/by-age keys (AvailableAtMillis is captured in the identity at
+// first mint, not recomputed from the changed delay) — otherwise the first
+// attempt's vis index entry is orphaned and can redeliver the message.
+func TestSendMessageBatchStandard_VisKeyStableAcrossDelayChange(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	seedStandardQueue(t, st, "q") // DelaySeconds = 0
+
+	coord := &recordingBatchCoordinator{stubAdapterCoordinator: stubAdapterCoordinator{clock: kv.NewHLC()}}
+	coord.beforeDispatch = func(n int) {
+		if n != 2 {
+			return
+		}
+		// SetQueueAttributes raises DelaySeconds to 900 before the retry.
+		meta := &sqsQueueMeta{Name: "q", Generation: 1, MaximumMessageSize: 262144, DelaySeconds: 900}
+		body, err := encodeSQSQueueMeta(meta)
+		require.NoError(t, err)
+		require.NoError(t, st.PutAt(ctx, sqsQueueMetaKey("q"), body, 100, 0))
+	}
+	srv := &SQSServer{store: st, coordinator: coord}
+
+	entries := []sqsSendMessageBatchEntryInput{{Id: "a", MessageBody: "alpha"}} // no per-message DelaySeconds
+	successful, _, err := srv.sendMessageBatchWithRetry(ctx, "q", entries)
+	require.NoError(t, err)
+	require.Len(t, successful, 1)
+
+	require.Len(t, coord.dispatchKeys, 2)
+	require.Equal(t, coord.dispatchKeys[0], coord.dispatchKeys[1],
+		"vis/by-age keys must stay stable across a mid-retry DelaySeconds change (cached AvailableAtMillis)")
 }
 
 // TestSendMessageBatchStandard_ReturnedMessageIdsStableAcrossRetry pins that

--- a/adapter/sqs_batch_send_dedup_test.go
+++ b/adapter/sqs_batch_send_dedup_test.go
@@ -1,0 +1,103 @@
+package adapter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bootjp/elastickv/kv"
+	"github.com/bootjp/elastickv/store"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingBatchCoordinator records the mutation keys of each dispatch and
+// fails the FIRST dispatch with a retryable WriteConflict — modelling a
+// committed-but-conflicted attempt under leader churn (the apply may have
+// landed, but the dispatch surfaced WriteConflict). The second dispatch
+// succeeds. It embeds stubAdapterCoordinator for the Coordinator surface
+// (IsLeader, Clock, ...) and only overrides Dispatch.
+type recordingBatchCoordinator struct {
+	stubAdapterCoordinator
+	dispatchKeys [][]string
+}
+
+func (c *recordingBatchCoordinator) Dispatch(_ context.Context, req *kv.OperationGroup[kv.OP]) (*kv.CoordinateResponse, error) {
+	keys := make([]string, 0, len(req.Elems))
+	for _, e := range req.Elems {
+		keys = append(keys, string(e.Key))
+	}
+	c.dispatchKeys = append(c.dispatchKeys, keys)
+	if len(c.dispatchKeys) == 1 {
+		return nil, store.ErrWriteConflict
+	}
+	return &kv.CoordinateResponse{}, nil
+}
+
+func seedStandardQueue(t *testing.T, st store.MVCCStore, name string) {
+	t.Helper()
+	meta := &sqsQueueMeta{
+		Name:               name,
+		Generation:         1,
+		MaximumMessageSize: 262144,
+		IsFIFO:             false,
+	}
+	body, err := encodeSQSQueueMeta(meta)
+	require.NoError(t, err)
+	require.NoError(t, st.PutAt(context.Background(), sqsQueueMetaKey(name), body, 1, 0))
+}
+
+// TestSendMessageBatchStandard_RetryReusesStableKeys pins the standard-queue
+// batch-send dedup fix: when the first dispatch commits-then-conflicts under
+// leader churn, the retry must reuse the SAME storage keys (stable MessageIDs +
+// timestamps minted once before the loop) so the committed attempt is
+// overwritten idempotently. Without the fix the retry re-mints fresh
+// MessageIDs, writing a SECOND copy of every entry at new keys — the
+// :duplicate-elements double-send (same class as DynamoDB PR #920).
+func TestSendMessageBatchStandard_RetryReusesStableKeys(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	seedStandardQueue(t, st, "q")
+
+	coord := &recordingBatchCoordinator{stubAdapterCoordinator: stubAdapterCoordinator{clock: kv.NewHLC()}}
+	srv := &SQSServer{store: st, coordinator: coord}
+
+	entries := []sqsSendMessageBatchEntryInput{
+		{Id: "a", MessageBody: "alpha"},
+		{Id: "b", MessageBody: "bravo"},
+	}
+	successful, failed, err := srv.sendMessageBatchWithRetry(ctx, "q", entries)
+	require.NoError(t, err)
+	require.Empty(t, failed)
+	require.Len(t, successful, 2)
+
+	require.Len(t, coord.dispatchKeys, 2, "attempt 1 conflicts (committed-but-conflicted), attempt 2 retries")
+	require.NotEmpty(t, coord.dispatchKeys[0])
+	require.Equal(t, coord.dispatchKeys[0], coord.dispatchKeys[1],
+		"the retry MUST reuse the same storage keys; fresh MessageIDs would double-send every entry under leader churn")
+}
+
+// TestSendMessageBatchStandard_ReturnedMessageIdsStableAcrossRetry pins that
+// the MessageIds reported to the client are the ones actually stored on the
+// retry (not a discarded first-attempt set), so a consumer cannot observe a
+// MessageId the client never received.
+func TestSendMessageBatchStandard_ReturnedMessageIdsStableAcrossRetry(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	seedStandardQueue(t, st, "q")
+
+	coord := &recordingBatchCoordinator{stubAdapterCoordinator: stubAdapterCoordinator{clock: kv.NewHLC()}}
+	srv := &SQSServer{store: st, coordinator: coord}
+
+	entries := []sqsSendMessageBatchEntryInput{{Id: "a", MessageBody: "alpha"}}
+	successful, _, err := srv.sendMessageBatchWithRetry(ctx, "q", entries)
+	require.NoError(t, err)
+	require.Len(t, successful, 1)
+
+	// The data key embeds the MessageID; both attempts must carry the
+	// returned MessageID so the client's id matches what is stored.
+	wantDataKey := string(sqsMsgDataKeyDispatch(&sqsQueueMeta{Name: "q", Generation: 1}, "q", 0, 1, successful[0].MessageId))
+	for i, keys := range coord.dispatchKeys {
+		require.Contains(t, keys, wantDataKey, "dispatch %d must write the returned MessageID's data key", i)
+	}
+}

--- a/adapter/sqs_batch_send_dedup_test.go
+++ b/adapter/sqs_batch_send_dedup_test.go
@@ -38,7 +38,8 @@ func (c *recordingBatchCoordinator) Dispatch(_ context.Context, req *kv.Operatio
 	return &kv.CoordinateResponse{}, nil
 }
 
-func seedStandardQueue(t *testing.T, st store.MVCCStore, name string) {
+func seedStandardQueue(t *testing.T, st store.MVCCStore) {
+	const name = "q"
 	t.Helper()
 	meta := &sqsQueueMeta{
 		Name:               name,
@@ -62,7 +63,7 @@ func TestSendMessageBatchStandard_RetryReusesStableKeys(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	st := store.NewMVCCStore()
-	seedStandardQueue(t, st, "q")
+	seedStandardQueue(t, st)
 
 	coord := &recordingBatchCoordinator{stubAdapterCoordinator: stubAdapterCoordinator{clock: kv.NewHLC()}}
 	srv := &SQSServer{store: st, coordinator: coord}
@@ -92,7 +93,7 @@ func TestSendMessageBatchStandard_VisKeyStableAcrossDelayChange(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	st := store.NewMVCCStore()
-	seedStandardQueue(t, st, "q") // DelaySeconds = 0
+	seedStandardQueue(t, st) // DelaySeconds = 0
 
 	coord := &recordingBatchCoordinator{stubAdapterCoordinator: stubAdapterCoordinator{clock: kv.NewHLC()}}
 	coord.beforeDispatch = func(n int) {
@@ -117,6 +118,41 @@ func TestSendMessageBatchStandard_VisKeyStableAcrossDelayChange(t *testing.T) {
 		"vis/by-age keys must stay stable across a mid-retry DelaySeconds change (cached AvailableAtMillis)")
 }
 
+// TestSendMessageBatchStandard_RevalidatesAgainstCurrentMetaOnRetry pins codex
+// P2 round-2: if a prior attempt minted the identity but did NOT commit (lost a
+// normal OCC race) and a concurrent SetQueueAttributes then lowered
+// MaximumMessageSize below the body, the retry must re-validate against the
+// fresh meta and REJECT the entry rather than commit it on the cached identity.
+func TestSendMessageBatchStandard_RevalidatesAgainstCurrentMetaOnRetry(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	seedStandardQueue(t, st) // MaximumMessageSize = 262144
+
+	coord := &recordingBatchCoordinator{stubAdapterCoordinator: stubAdapterCoordinator{clock: kv.NewHLC()}}
+	coord.beforeDispatch = func(n int) {
+		if n != 1 {
+			return
+		}
+		// SetQueueAttributes lowers MaximumMessageSize below the body size,
+		// landing during attempt 1's dispatch (which does not commit — it
+		// returns a WriteConflict). The retry then loads this lowered meta
+		// BEFORE re-validating, so the entry must be rejected.
+		meta := &sqsQueueMeta{Name: "q", Generation: 1, MaximumMessageSize: 3}
+		body, err := encodeSQSQueueMeta(meta)
+		require.NoError(t, err)
+		require.NoError(t, st.PutAt(ctx, sqsQueueMetaKey("q"), body, 100, 0))
+	}
+	srv := &SQSServer{store: st, coordinator: coord}
+
+	entries := []sqsSendMessageBatchEntryInput{{Id: "a", MessageBody: "alpha"}} // 5 bytes > new limit 3
+	successful, failed, err := srv.sendMessageBatchWithRetry(ctx, "q", entries)
+	require.NoError(t, err)
+	require.Empty(t, successful, "the retry must re-validate against the lowered limit and reject the entry")
+	require.Len(t, failed, 1)
+	require.Equal(t, "a", failed[0].Id)
+}
+
 // TestSendMessageBatchStandard_ReturnedMessageIdsStableAcrossRetry pins that
 // the MessageIds reported to the client are the ones actually stored on the
 // retry (not a discarded first-attempt set), so a consumer cannot observe a
@@ -125,7 +161,7 @@ func TestSendMessageBatchStandard_ReturnedMessageIdsStableAcrossRetry(t *testing
 	t.Parallel()
 	ctx := context.Background()
 	st := store.NewMVCCStore()
-	seedStandardQueue(t, st, "q")
+	seedStandardQueue(t, st)
 
 	coord := &recordingBatchCoordinator{stubAdapterCoordinator: stubAdapterCoordinator{clock: kv.NewHLC()}}
 	srv := &SQSServer{store: st, coordinator: coord}

--- a/adapter/sqs_messages.go
+++ b/adapter/sqs_messages.go
@@ -654,26 +654,33 @@ func resolveSendDelay(meta *sqsQueueMeta, requested *int64) (int64, error) {
 }
 
 // sqsSendIdentity is the per-message identity that MUST stay stable across a
-// retry loop: the random MessageID, the random receipt token, and the send
-// wall-clock timestamp. All three feed the message's storage keys (data key
-// via MessageID; vis key via AvailableAtMillis = sendTs + delay; by-age key via
-// sendTs) — so if they were re-minted on every retry attempt, a committed-but-
-// conflicted attempt under leader churn plus the recomputed retry would land at
-// two different key sets, double-sending the message (the :duplicate-elements
-// class fixed for DynamoDB in PR #920). The batch send path pre-generates one
-// identity per entry once, before the retry loop, and reuses it on every
-// attempt so a retry overwrites the same keys idempotently.
+// retry loop. Every field feeds the message's storage keys: the data key via
+// MessageID; the vis key via AvailableAtMillis; the by-age key via
+// SendTimestampMillis. If they were re-minted on every retry attempt, a
+// committed-but-conflicted attempt under leader churn plus the recomputed retry
+// would land at two different key sets, double-sending the message (the
+// :duplicate-elements class fixed for DynamoDB in PR #920).
+//
+// AvailableAtMillis (= sendTs + resolved delay) is captured here too, NOT
+// recomputed per attempt: otherwise a SetQueueAttributes that changes the
+// queue's DelaySeconds between a committed-but-conflicted attempt and its retry
+// would shift the vis key and leave the first attempt's vis entry orphaned
+// (codex P2 on PR #923) — a stale visibility index entry that can redeliver the
+// message. The batch send path lazily mints one identity per entry on its first
+// standard-path attempt and reuses it on every retry, so the keys are stable.
 type sqsSendIdentity struct {
-	messageID    string
-	token        []byte
-	sendTsMillis int64
+	messageID         string
+	token             []byte
+	sendTsMillis      int64
+	availableAtMillis int64
 }
 
-// newSendIdentity mints a fresh stable identity. Single-message sends call this
-// inline (they have no in-process retry, so a self-inflicted conflict surfaces
-// to the client as a normal at-least-once SDK retry); the batch path calls it
-// once per entry before its retry loop.
-func newSendIdentity() (sqsSendIdentity, error) {
+// newSendIdentity mints a fresh stable identity for the given resolved delay.
+// Single-message sends call this inline via buildSendRecord (they have no
+// in-process retry, so a self-inflicted conflict surfaces to the client as a
+// normal at-least-once SDK retry); the batch path mints once per entry and
+// reuses across its retry loop.
+func newSendIdentity(delay int64) (sqsSendIdentity, error) {
 	messageID, err := newMessageIDHex()
 	if err != nil {
 		return sqsSendIdentity{}, errors.WithStack(err)
@@ -682,25 +689,31 @@ func newSendIdentity() (sqsSendIdentity, error) {
 	if err != nil {
 		return sqsSendIdentity{}, errors.WithStack(err)
 	}
-	return sqsSendIdentity{messageID: messageID, token: token, sendTsMillis: time.Now().UnixMilli()}, nil
+	now := time.Now().UnixMilli()
+	return sqsSendIdentity{
+		messageID:         messageID,
+		token:             token,
+		sendTsMillis:      now,
+		availableAtMillis: now + delay*sqsMillisPerSecond,
+	}, nil
 }
 
 func buildSendRecord(meta *sqsQueueMeta, in sqsSendMessageInput, delay int64) (*sqsMessageRecord, []byte, error) {
-	id, err := newSendIdentity()
+	id, err := newSendIdentity(delay)
 	if err != nil {
 		return nil, nil, err
 	}
-	return buildSendRecordWithIdentity(meta, in, delay, id)
+	return buildSendRecordWithIdentity(meta, in, id)
 }
 
 // buildSendRecordWithIdentity builds the message record from a caller-supplied
-// stable identity instead of minting a fresh one. The record value embeds the
-// current meta.Generation, so callers re-invoke this per retry attempt with the
-// freshly-read generation while keeping the identity fixed — the keys stay
-// stable for a given generation (idempotent overwrite under leader churn) and
-// follow the generation if a concurrent DeleteQueue/PurgeQueue bumps it.
-func buildSendRecordWithIdentity(meta *sqsQueueMeta, in sqsSendMessageInput, delay int64, id sqsSendIdentity) (*sqsMessageRecord, []byte, error) {
-	availableAt := id.sendTsMillis + delay*sqsMillisPerSecond
+// stable identity (MessageID + token + timestamps) instead of minting a fresh
+// one. The record value embeds the current meta.Generation, so callers re-invoke
+// this per retry attempt with the freshly-read generation while keeping the
+// identity fixed — the keys stay stable for a given generation (idempotent
+// overwrite under leader churn) and follow the generation if a concurrent
+// DeleteQueue/PurgeQueue bumps it.
+func buildSendRecordWithIdentity(meta *sqsQueueMeta, in sqsSendMessageInput, id sqsSendIdentity) (*sqsMessageRecord, []byte, error) {
 	body := []byte(in.MessageBody)
 	rec := &sqsMessageRecord{
 		MessageID:              id.messageID,
@@ -709,8 +722,8 @@ func buildSendRecordWithIdentity(meta *sqsQueueMeta, in sqsSendMessageInput, del
 		MD5OfMessageAttributes: md5OfAttributesHex(in.MessageAttributes),
 		MessageAttributes:      in.MessageAttributes,
 		SendTimestampMillis:    id.sendTsMillis,
-		AvailableAtMillis:      availableAt,
-		VisibleAtMillis:        availableAt,
+		AvailableAtMillis:      id.availableAtMillis,
+		VisibleAtMillis:        id.availableAtMillis,
 		CurrentReceiptToken:    id.token,
 		QueueGeneration:        meta.Generation,
 		MessageGroupId:         in.MessageGroupId,

--- a/adapter/sqs_messages.go
+++ b/adapter/sqs_messages.go
@@ -653,28 +653,65 @@ func resolveSendDelay(meta *sqsQueueMeta, requested *int64) (int64, error) {
 	return *requested, nil
 }
 
-func buildSendRecord(meta *sqsQueueMeta, in sqsSendMessageInput, delay int64) (*sqsMessageRecord, []byte, error) {
+// sqsSendIdentity is the per-message identity that MUST stay stable across a
+// retry loop: the random MessageID, the random receipt token, and the send
+// wall-clock timestamp. All three feed the message's storage keys (data key
+// via MessageID; vis key via AvailableAtMillis = sendTs + delay; by-age key via
+// sendTs) — so if they were re-minted on every retry attempt, a committed-but-
+// conflicted attempt under leader churn plus the recomputed retry would land at
+// two different key sets, double-sending the message (the :duplicate-elements
+// class fixed for DynamoDB in PR #920). The batch send path pre-generates one
+// identity per entry once, before the retry loop, and reuses it on every
+// attempt so a retry overwrites the same keys idempotently.
+type sqsSendIdentity struct {
+	messageID    string
+	token        []byte
+	sendTsMillis int64
+}
+
+// newSendIdentity mints a fresh stable identity. Single-message sends call this
+// inline (they have no in-process retry, so a self-inflicted conflict surfaces
+// to the client as a normal at-least-once SDK retry); the batch path calls it
+// once per entry before its retry loop.
+func newSendIdentity() (sqsSendIdentity, error) {
 	messageID, err := newMessageIDHex()
 	if err != nil {
-		return nil, nil, errors.WithStack(err)
+		return sqsSendIdentity{}, errors.WithStack(err)
 	}
 	token, err := newReceiptToken()
 	if err != nil {
-		return nil, nil, errors.WithStack(err)
+		return sqsSendIdentity{}, errors.WithStack(err)
 	}
-	now := time.Now().UnixMilli()
-	availableAt := now + delay*sqsMillisPerSecond
+	return sqsSendIdentity{messageID: messageID, token: token, sendTsMillis: time.Now().UnixMilli()}, nil
+}
+
+func buildSendRecord(meta *sqsQueueMeta, in sqsSendMessageInput, delay int64) (*sqsMessageRecord, []byte, error) {
+	id, err := newSendIdentity()
+	if err != nil {
+		return nil, nil, err
+	}
+	return buildSendRecordWithIdentity(meta, in, delay, id)
+}
+
+// buildSendRecordWithIdentity builds the message record from a caller-supplied
+// stable identity instead of minting a fresh one. The record value embeds the
+// current meta.Generation, so callers re-invoke this per retry attempt with the
+// freshly-read generation while keeping the identity fixed — the keys stay
+// stable for a given generation (idempotent overwrite under leader churn) and
+// follow the generation if a concurrent DeleteQueue/PurgeQueue bumps it.
+func buildSendRecordWithIdentity(meta *sqsQueueMeta, in sqsSendMessageInput, delay int64, id sqsSendIdentity) (*sqsMessageRecord, []byte, error) {
+	availableAt := id.sendTsMillis + delay*sqsMillisPerSecond
 	body := []byte(in.MessageBody)
 	rec := &sqsMessageRecord{
-		MessageID:              messageID,
+		MessageID:              id.messageID,
 		Body:                   body,
 		MD5OfBody:              sqsMD5Hex(body),
 		MD5OfMessageAttributes: md5OfAttributesHex(in.MessageAttributes),
 		MessageAttributes:      in.MessageAttributes,
-		SendTimestampMillis:    now,
+		SendTimestampMillis:    id.sendTsMillis,
 		AvailableAtMillis:      availableAt,
 		VisibleAtMillis:        availableAt,
-		CurrentReceiptToken:    token,
+		CurrentReceiptToken:    id.token,
 		QueueGeneration:        meta.Generation,
 		MessageGroupId:         in.MessageGroupId,
 		MessageDeduplicationId: in.MessageDeduplicationId,

--- a/adapter/sqs_messages_batch.go
+++ b/adapter/sqs_messages_batch.go
@@ -407,15 +407,20 @@ func (s *SQSServer) resolveFreshFifoSnapshot(ctx context.Context, queueName stri
 // SendMessage would, but returns the *sqsAPIError so the batch path
 // can drop the entry into Failed[] instead of failing the whole
 // request.
-// buildBatchSendRecord builds one standard-queue batch entry's record, reusing
-// a stable per-entry identity across retries. id points into the caller's
-// identities slice: on the FIRST attempt for this entry (id.messageID == "")
-// it validates, resolves the delay, and mints the identity (capturing
-// AvailableAtMillis from the delay in effect at that moment); on retries it
-// skips validation/resolution and reuses the cached identity, so the storage
-// keys are stable even if a concurrent SetQueueAttributes changes the queue's
-// DelaySeconds between attempts (codex P2). An entry that already committed on a
-// prior attempt is never re-validated against a since-changed meta.
+// buildBatchSendRecord builds one standard-queue batch entry's record. It splits
+// two concerns that must NOT be conflated:
+//
+//   - Validation against the CURRENT meta runs on EVERY attempt (`validateBatchEntry`).
+//     A prior, uncommitted attempt may have minted the identity; if a concurrent
+//     SetQueueAttributes then tightened a limit (e.g. lowered MaximumMessageSize),
+//     the retry must still reject a now-invalid entry rather than commit it
+//     (codex P2 round-2).
+//   - The stable identity (MessageID + token + timestamps incl. AvailableAtMillis)
+//     is minted ONCE, on the first attempt, and reused. This keeps the storage
+//     keys constant across retries so a committed-but-conflicted attempt is
+//     overwritten idempotently, and so a mid-retry DelaySeconds change cannot
+//     shift the vis key (codex P2 round-1). AvailableAtMillis is captured from
+//     the first attempt's resolved delay.
 func buildBatchSendRecord(meta *sqsQueueMeta, entry sqsSendMessageBatchEntryInput, id *sqsSendIdentity) (*sqsMessageRecord, []byte, error) {
 	asSingle := sqsSendMessageInput{
 		MessageBody:            entry.MessageBody,
@@ -424,39 +429,41 @@ func buildBatchSendRecord(meta *sqsQueueMeta, entry sqsSendMessageBatchEntryInpu
 		MessageGroupId:         entry.MessageGroupId,
 		MessageDeduplicationId: entry.MessageDeduplicationId,
 	}
+	delay, err := validateBatchEntry(meta, entry, asSingle)
+	if err != nil {
+		return nil, nil, err
+	}
 	if id.messageID == "" {
-		// First attempt for this entry: validate, resolve delay, mint identity.
-		minted, err := mintBatchSendIdentity(meta, entry, asSingle)
-		if err != nil {
-			return nil, nil, err
+		minted, mintErr := newSendIdentity(delay)
+		if mintErr != nil {
+			return nil, nil, mintErr
 		}
 		*id = minted
 	}
 	return buildSendRecordWithIdentity(meta, asSingle, *id)
 }
 
-// mintBatchSendIdentity validates one batch entry against the current queue
-// meta, resolves its delay, and mints the stable identity. It runs only on the
-// first attempt for an entry; retries reuse the cached identity so a
-// since-changed meta cannot re-fail an already-committed entry or shift its keys.
-func mintBatchSendIdentity(meta *sqsQueueMeta, entry sqsSendMessageBatchEntryInput, asSingle sqsSendMessageInput) (sqsSendIdentity, error) {
+// validateBatchEntry runs every per-attempt check for a standard batch entry
+// against the currently-loaded queue meta and returns the resolved delay. It is
+// invoked on EVERY attempt (not just the first mint) so a concurrent
+// SetQueueAttributes that tightened limits is honored on the retry. The returned
+// delay seeds AvailableAtMillis only on the first mint; on retries the cached
+// identity's AvailableAtMillis is reused, so re-resolving here never shifts the
+// keys — it only re-checks bounds.
+func validateBatchEntry(meta *sqsQueueMeta, entry sqsSendMessageBatchEntryInput, asSingle sqsSendMessageInput) (int64, error) {
 	if len(entry.MessageBody) == 0 {
-		return sqsSendIdentity{}, newSQSAPIError(http.StatusBadRequest, sqsErrValidation, "MessageBody is required")
+		return 0, newSQSAPIError(http.StatusBadRequest, sqsErrValidation, "MessageBody is required")
 	}
 	if int64(len(entry.MessageBody)) > meta.MaximumMessageSize {
-		return sqsSendIdentity{}, newSQSAPIError(http.StatusBadRequest, sqsErrMessageTooLong, "message body exceeds MaximumMessageSize")
+		return 0, newSQSAPIError(http.StatusBadRequest, sqsErrMessageTooLong, "message body exceeds MaximumMessageSize")
 	}
 	if err := validateMessageAttributes(entry.MessageAttributes); err != nil {
-		return sqsSendIdentity{}, err
+		return 0, err
 	}
 	if err := validateSendFIFOParams(meta, asSingle); err != nil {
-		return sqsSendIdentity{}, err
+		return 0, err
 	}
-	delay, err := resolveSendDelay(meta, entry.DelaySeconds)
-	if err != nil {
-		return sqsSendIdentity{}, err
-	}
-	return newSendIdentity(delay)
+	return resolveSendDelay(meta, entry.DelaySeconds)
 }
 
 // ------------------------ DeleteMessageBatch ------------------------

--- a/adapter/sqs_messages_batch.go
+++ b/adapter/sqs_messages_batch.go
@@ -121,22 +121,17 @@ func (s *SQSServer) sendMessageBatchWithRetry(
 	queueName string,
 	entries []sqsSendMessageBatchEntryInput,
 ) ([]sqsSendMessageBatchResultEntry, []sqsBatchResultErrorEntry, error) {
-	// Pre-generate one stable identity per entry BEFORE the retry loop. The
-	// standard-queue path keys each message by its random MessageID (and by
-	// timestamps derived from the send wall-clock), so re-minting per attempt
-	// would land a committed-but-conflicted attempt's messages at one key set
-	// and the retry's at another — double-sending every entry under leader
-	// churn. Reusing the identity makes the retry overwrite the SAME keys
-	// idempotently. Identities are indexed by entry position; FIFO entries
-	// ignore them (they mint their own per-entry dedup-fenced identity).
+	// Per-entry stable identities, indexed by entry position and shared (by
+	// reference) across every retry attempt. The standard-queue path keys each
+	// message by its random MessageID and send-derived timestamps, so re-minting
+	// per attempt would land a committed-but-conflicted attempt's messages at one
+	// key set and the retry's at another — double-sending every entry under
+	// leader churn. The standard path lazily mints each identity on its first
+	// attempt (sendBatchStandardOnce) and reuses it thereafter, so the keys stay
+	// stable. Left zero-valued here: FIFO entries never touch these (they mint
+	// their own per-entry dedup-fenced identity), so FIFO batches pay no
+	// crypto/rand cost for identities they ignore.
 	identities := make([]sqsSendIdentity, len(entries))
-	for i := range identities {
-		id, err := newSendIdentity()
-		if err != nil {
-			return nil, nil, err
-		}
-		identities[i] = id
-	}
 	backoff := transactRetryInitialBackoff
 	deadline := time.Now().Add(transactRetryMaxDuration)
 	for range transactRetryMaxAttempts {
@@ -206,11 +201,11 @@ func (s *SQSServer) sendBatchStandardOnce(
 	const opsPerEntry = 3
 	elems := make([]*kv.Elem[kv.OP], 0, opsPerEntry*len(entries))
 	for i, entry := range entries {
-		// identities[i] is the stable per-entry identity minted once before
-		// the retry loop; reusing it keeps the storage keys constant across
-		// retries so a committed-but-conflicted attempt is overwritten
-		// idempotently rather than double-sent.
-		rec, recordBytes, apiErr := buildBatchSendRecord(meta, entry, identities[i])
+		// &identities[i] is the stable per-entry identity, lazily minted on the
+		// first attempt and reused on every retry; reusing it keeps the storage
+		// keys constant across retries so a committed-but-conflicted attempt is
+		// overwritten idempotently rather than double-sent.
+		rec, recordBytes, apiErr := buildBatchSendRecord(meta, entry, &identities[i])
 		if apiErr != nil {
 			failed = append(failed, batchErrorEntryFromAPIErr(entry.Id, apiErr))
 			continue
@@ -412,16 +407,16 @@ func (s *SQSServer) resolveFreshFifoSnapshot(ctx context.Context, queueName stri
 // SendMessage would, but returns the *sqsAPIError so the batch path
 // can drop the entry into Failed[] instead of failing the whole
 // request.
-func buildBatchSendRecord(meta *sqsQueueMeta, entry sqsSendMessageBatchEntryInput, id sqsSendIdentity) (*sqsMessageRecord, []byte, error) {
-	if len(entry.MessageBody) == 0 {
-		return nil, nil, newSQSAPIError(http.StatusBadRequest, sqsErrValidation, "MessageBody is required")
-	}
-	if int64(len(entry.MessageBody)) > meta.MaximumMessageSize {
-		return nil, nil, newSQSAPIError(http.StatusBadRequest, sqsErrMessageTooLong, "message body exceeds MaximumMessageSize")
-	}
-	if err := validateMessageAttributes(entry.MessageAttributes); err != nil {
-		return nil, nil, err
-	}
+// buildBatchSendRecord builds one standard-queue batch entry's record, reusing
+// a stable per-entry identity across retries. id points into the caller's
+// identities slice: on the FIRST attempt for this entry (id.messageID == "")
+// it validates, resolves the delay, and mints the identity (capturing
+// AvailableAtMillis from the delay in effect at that moment); on retries it
+// skips validation/resolution and reuses the cached identity, so the storage
+// keys are stable even if a concurrent SetQueueAttributes changes the queue's
+// DelaySeconds between attempts (codex P2). An entry that already committed on a
+// prior attempt is never re-validated against a since-changed meta.
+func buildBatchSendRecord(meta *sqsQueueMeta, entry sqsSendMessageBatchEntryInput, id *sqsSendIdentity) (*sqsMessageRecord, []byte, error) {
 	asSingle := sqsSendMessageInput{
 		MessageBody:            entry.MessageBody,
 		DelaySeconds:           entry.DelaySeconds,
@@ -429,16 +424,39 @@ func buildBatchSendRecord(meta *sqsQueueMeta, entry sqsSendMessageBatchEntryInpu
 		MessageGroupId:         entry.MessageGroupId,
 		MessageDeduplicationId: entry.MessageDeduplicationId,
 	}
+	if id.messageID == "" {
+		// First attempt for this entry: validate, resolve delay, mint identity.
+		minted, err := mintBatchSendIdentity(meta, entry, asSingle)
+		if err != nil {
+			return nil, nil, err
+		}
+		*id = minted
+	}
+	return buildSendRecordWithIdentity(meta, asSingle, *id)
+}
+
+// mintBatchSendIdentity validates one batch entry against the current queue
+// meta, resolves its delay, and mints the stable identity. It runs only on the
+// first attempt for an entry; retries reuse the cached identity so a
+// since-changed meta cannot re-fail an already-committed entry or shift its keys.
+func mintBatchSendIdentity(meta *sqsQueueMeta, entry sqsSendMessageBatchEntryInput, asSingle sqsSendMessageInput) (sqsSendIdentity, error) {
+	if len(entry.MessageBody) == 0 {
+		return sqsSendIdentity{}, newSQSAPIError(http.StatusBadRequest, sqsErrValidation, "MessageBody is required")
+	}
+	if int64(len(entry.MessageBody)) > meta.MaximumMessageSize {
+		return sqsSendIdentity{}, newSQSAPIError(http.StatusBadRequest, sqsErrMessageTooLong, "message body exceeds MaximumMessageSize")
+	}
+	if err := validateMessageAttributes(entry.MessageAttributes); err != nil {
+		return sqsSendIdentity{}, err
+	}
 	if err := validateSendFIFOParams(meta, asSingle); err != nil {
-		return nil, nil, err
+		return sqsSendIdentity{}, err
 	}
 	delay, err := resolveSendDelay(meta, entry.DelaySeconds)
 	if err != nil {
-		return nil, nil, err
+		return sqsSendIdentity{}, err
 	}
-	// Use the caller-supplied stable identity (minted once before the batch
-	// retry loop) so retries reuse the same MessageID/timestamps/keys.
-	return buildSendRecordWithIdentity(meta, asSingle, delay, id)
+	return newSendIdentity(delay)
 }
 
 // ------------------------ DeleteMessageBatch ------------------------

--- a/adapter/sqs_messages_batch.go
+++ b/adapter/sqs_messages_batch.go
@@ -121,10 +121,26 @@ func (s *SQSServer) sendMessageBatchWithRetry(
 	queueName string,
 	entries []sqsSendMessageBatchEntryInput,
 ) ([]sqsSendMessageBatchResultEntry, []sqsBatchResultErrorEntry, error) {
+	// Pre-generate one stable identity per entry BEFORE the retry loop. The
+	// standard-queue path keys each message by its random MessageID (and by
+	// timestamps derived from the send wall-clock), so re-minting per attempt
+	// would land a committed-but-conflicted attempt's messages at one key set
+	// and the retry's at another — double-sending every entry under leader
+	// churn. Reusing the identity makes the retry overwrite the SAME keys
+	// idempotently. Identities are indexed by entry position; FIFO entries
+	// ignore them (they mint their own per-entry dedup-fenced identity).
+	identities := make([]sqsSendIdentity, len(entries))
+	for i := range identities {
+		id, err := newSendIdentity()
+		if err != nil {
+			return nil, nil, err
+		}
+		identities[i] = id
+	}
 	backoff := transactRetryInitialBackoff
 	deadline := time.Now().Add(transactRetryMaxDuration)
 	for range transactRetryMaxAttempts {
-		successful, failed, retry, err := s.trySendMessageBatchOnce(ctx, queueName, entries)
+		successful, failed, retry, err := s.trySendMessageBatchOnce(ctx, queueName, entries, identities)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -154,6 +170,7 @@ func (s *SQSServer) trySendMessageBatchOnce(
 	ctx context.Context,
 	queueName string,
 	entries []sqsSendMessageBatchEntryInput,
+	identities []sqsSendIdentity,
 ) ([]sqsSendMessageBatchResultEntry, []sqsBatchResultErrorEntry, bool, error) {
 	readTS := s.nextTxnReadTS(ctx)
 	meta, exists, err := s.loadQueueMetaAt(ctx, queueName, readTS)
@@ -166,7 +183,7 @@ func (s *SQSServer) trySendMessageBatchOnce(
 	if meta.IsFIFO {
 		return s.sendBatchFifoEntries(ctx, queueName, meta, entries)
 	}
-	return s.sendBatchStandardOnce(ctx, queueName, meta, entries, readTS)
+	return s.sendBatchStandardOnce(ctx, queueName, meta, entries, identities, readTS)
 }
 
 // sendBatchStandardOnce is the original single-OCC fast path for
@@ -177,6 +194,7 @@ func (s *SQSServer) sendBatchStandardOnce(
 	queueName string,
 	meta *sqsQueueMeta,
 	entries []sqsSendMessageBatchEntryInput,
+	identities []sqsSendIdentity,
 	readTS uint64,
 ) ([]sqsSendMessageBatchResultEntry, []sqsBatchResultErrorEntry, bool, error) {
 	successful := make([]sqsSendMessageBatchResultEntry, 0, len(entries))
@@ -187,8 +205,12 @@ func (s *SQSServer) sendBatchStandardOnce(
 	// against.
 	const opsPerEntry = 3
 	elems := make([]*kv.Elem[kv.OP], 0, opsPerEntry*len(entries))
-	for _, entry := range entries {
-		rec, recordBytes, apiErr := buildBatchSendRecord(meta, entry)
+	for i, entry := range entries {
+		// identities[i] is the stable per-entry identity minted once before
+		// the retry loop; reusing it keeps the storage keys constant across
+		// retries so a committed-but-conflicted attempt is overwritten
+		// idempotently rather than double-sent.
+		rec, recordBytes, apiErr := buildBatchSendRecord(meta, entry, identities[i])
 		if apiErr != nil {
 			failed = append(failed, batchErrorEntryFromAPIErr(entry.Id, apiErr))
 			continue
@@ -390,7 +412,7 @@ func (s *SQSServer) resolveFreshFifoSnapshot(ctx context.Context, queueName stri
 // SendMessage would, but returns the *sqsAPIError so the batch path
 // can drop the entry into Failed[] instead of failing the whole
 // request.
-func buildBatchSendRecord(meta *sqsQueueMeta, entry sqsSendMessageBatchEntryInput) (*sqsMessageRecord, []byte, error) {
+func buildBatchSendRecord(meta *sqsQueueMeta, entry sqsSendMessageBatchEntryInput, id sqsSendIdentity) (*sqsMessageRecord, []byte, error) {
 	if len(entry.MessageBody) == 0 {
 		return nil, nil, newSQSAPIError(http.StatusBadRequest, sqsErrValidation, "MessageBody is required")
 	}
@@ -414,7 +436,9 @@ func buildBatchSendRecord(meta *sqsQueueMeta, entry sqsSendMessageBatchEntryInpu
 	if err != nil {
 		return nil, nil, err
 	}
-	return buildSendRecord(meta, asSingle, delay)
+	// Use the caller-supplied stable identity (minted once before the batch
+	// retry loop) so retries reuse the same MessageID/timestamps/keys.
+	return buildSendRecordWithIdentity(meta, asSingle, delay, id)
 }
 
 // ------------------------ DeleteMessageBatch ------------------------

--- a/adapter/sqs_messages_batch.go
+++ b/adapter/sqs_messages_batch.go
@@ -403,10 +403,6 @@ func (s *SQSServer) resolveFreshFifoSnapshot(ctx context.Context, queueName stri
 	return meta, dedupID, delay, nil
 }
 
-// buildBatchSendRecord runs every per-entry validation a single
-// SendMessage would, but returns the *sqsAPIError so the batch path
-// can drop the entry into Failed[] instead of failing the whole
-// request.
 // buildBatchSendRecord builds one standard-queue batch entry's record. It splits
 // two concerns that must NOT be conflated:
 //

--- a/docs/design/2026_06_03_partial_dynamodb_onephase_dedup.md
+++ b/docs/design/2026_06_03_partial_dynamodb_onephase_dedup.md
@@ -357,7 +357,19 @@ every replica applying the same log entry.
     every attempt (`buildSendRecordWithIdentity`), so the retry overwrites the
     same keys idempotently. This needs **no** FSM probe / `PrevCommitTS` / gate —
     the keys become content-stable, so re-applying is a plain idempotent
-    overwrite. Tests: `adapter/sqs_batch_send_dedup_test.go`.
+    overwrite. The identity also pins `AvailableAtMillis` (vis-key input) and the
+    per-entry validation re-runs against the current meta on every attempt, so a
+    mid-retry `SetQueueAttributes` neither shifts the vis key (codex P2 round-1)
+    nor lets a now-too-large body through (codex P2 round-2). Tests:
+    `adapter/sqs_batch_send_dedup_test.go`.
+    - **Residual edge (within at-least-once, no action):** if attempt 1
+      *commits* (committed-but-conflicted) and a concurrent `SetQueueAttributes`
+      tightens a limit (e.g. lowers `MaximumMessageSize`) before the retry, the
+      retry's re-validation rejects the entry into `Failed[]` even though it is
+      already in the queue — an inconsistent client view (message stored, client
+      told it failed) but never a double-send. This is within the SQS
+      standard-queue at-least-once contract; distinguishing committed-vs-not
+      would need a dedup probe, which is out of proportion for this corner.
 
 ## Milestones
 

--- a/docs/design/2026_06_03_partial_dynamodb_onephase_dedup.md
+++ b/docs/design/2026_06_03_partial_dynamodb_onephase_dedup.md
@@ -330,8 +330,34 @@ every replica applying the same log entry.
   the workload classifies as a definite `:fail` (excluded from the history), so
   it does not produce the duplicate. Bringing it under reuse-dedup is tractable
   but doubles the test matrix; defer it.
-- **Out of scope:** S3 / SQS adapters (same `readTS`-then-mutate pattern, same
-  latent bug class) — separate docs once this lands as the template.
+- **S3 / SQS — audited (2026-06-03).** A handler-by-handler adversarial sweep
+  found that the original "same latent bug class" claim was over-broad. The
+  DynamoDB bug is specific to a read-modify-write that **recomputes a growing
+  value** (`list_append`) at a **stable key** on a self-conflict retry. The
+  audit verdicts:
+  - **S3 — no duplicate possible.** Object writes are whole-value PUTs at a
+    stable key (`PutObject`, `CompleteMultipartUpload` whose manifest is
+    re-assembled deterministically from the immutable uploaded parts, not from
+    a re-read of the object value). `PutObject` carries a caller-supplied
+    `StartTS`, so a leader-move coordinator retry that races an interleaved
+    write fails the OCC fence rather than clobbering it; it has no in-process
+    re-read-recompute retry. No `list_append`-style growth, no recompute-into-a-
+    different-value → no `:duplicate-elements`.
+  - **SQS single `SendMessage` / FIFO — safe.** Single send keys the message by
+    a random `MessageId` with no in-process retry (a conflict surfaces to the
+    client as a normal at-least-once SDK retry). FIFO send is fenced by the
+    `MessageDeduplicationId` dedup record (committed atomically with the
+    sequence), whose hit short-circuits any retry.
+  - **SQS standard `SendMessageBatch` — HAD the bug, FIXED here.** Unlike single
+    send, the batch path added an **in-process** retry loop
+    (`sendMessageBatchWithRetry`) that re-minted fresh random `MessageId`s (and
+    send timestamps) per attempt, so a committed-but-conflicted attempt plus the
+    retry double-sent every entry. Fixed by pre-generating one stable
+    `sqsSendIdentity` per entry **before** the retry loop and reusing it on
+    every attempt (`buildSendRecordWithIdentity`), so the retry overwrites the
+    same keys idempotently. This needs **no** FSM probe / `PrevCommitTS` / gate —
+    the keys become content-stable, so re-applying is a plain idempotent
+    overwrite. Tests: `adapter/sqs_batch_send_dedup_test.go`.
 
 ## Milestones
 


### PR DESCRIPTION
## Summary

Fixes a **double-send** bug in the SQS standard-queue `SendMessageBatch` path — the same `:duplicate-elements` class fixed for DynamoDB in PR #920, found by an adversarial S3/SQS audit prompted by the "extend dedup to S3/SQS" follow-up.

## The bug

`sendMessageBatchWithRetry` → `trySendMessageBatchOnce` → `sendBatchStandardOnce` runs an **in-process OCC retry loop** that, on every attempt, re-ran `buildBatchSendRecord` → `buildSendRecord` → `newMessageIDHex()`, minting a **fresh random MessageID (and send timestamp) per entry per attempt**, and derived the `data`/`vis`/`byage` storage keys from them.

Under a Raft leader-election storm, attempt 1 can **commit** its writes yet surface a self-inflicted `WriteConflict` to the adapter (the mechanism PR #920 documented). The retry then mints **new** MessageIDs and writes a **second copy of every entry** at new keys:

1. Attempt 1: mints `{M1,M2,M3}`, commits, but returns `WriteConflict` under churn.
2. Retry: mints `{M1',M2',M3'}`, commits cleanly, returns `{M1',M2',M3'}` + HTTP 200.
3. Queue holds **both** sets → every batch entry duplicated; the client only learns the second set.

Standard queues carry no dedup identity, and the OCC `ReadKeys` are only `[meta, gen]` (the random data keys never self-conflict), so nothing fenced this.

**Why only batch:** single `SendMessage` has **no** in-process retry (a conflict becomes a normal at-least-once SDK retry), and FIFO send is fenced by the `MessageDeduplicationId` dedup record. The batch path added an in-process retry without either fence.

## The fix

Pre-generate **one stable `sqsSendIdentity`** (MessageID + receipt token + send timestamp) **per entry, before the retry loop**, and reuse it on every attempt (`buildSendRecordWithIdentity`). The storage keys then stay constant across retries, so a committed-but-conflicted attempt is **overwritten idempotently** instead of duplicated.

No FSM probe / `PrevCommitTS` / gate is needed — unlike DynamoDB's `list_append` (which re-read a *growing* value), the batch write is a whole-value PUT at a now-stable key, so re-applying is a plain idempotent overwrite. The record's `QueueGeneration` is still re-derived per attempt, so a concurrent `DeleteQueue`/`PurgeQueue` generation bump is followed correctly (the stale-gen attempt-1 write is orphaned/unreachable).

## S3/SQS audit outcome (recorded in the design doc)

A handler-by-handler adversarial sweep found the original "S3/SQS share the same latent gap" note was over-broad:
- **S3 — safe.** Whole-value PUT at a stable key; `PutObject` is OCC-fenced by a caller-supplied `StartTS` (a leader-move retry that races an interleaved write **fails the fence rather than clobbering**), and has no in-process re-read-recompute. `CompleteMultipartUpload`'s manifest is re-assembled deterministically from the **immutable** uploaded parts (computed once before its retry loop), not from a re-read of the object value → no duplicate.
- **SQS single `SendMessage` / FIFO — safe** (random-UUID key + no in-process retry; FIFO dedup record).
- **SQS standard `SendMessageBatch` — fixed here.**

## Tests (`adapter/sqs_batch_send_dedup_test.go`)

- `TestSendMessageBatchStandard_RetryReusesStableKeys` — first dispatch commits-then-conflicts; asserts the retry dispatches the **same** storage keys (fresh MessageIDs would fail it → reproduces the bug pre-fix).
- `TestSendMessageBatchStandard_ReturnedMessageIdsStableAcrossRetry` — the returned MessageId is the one actually written on both attempts (client id == stored id).

## Validation

- `go test ./adapter/ -run 'SendMessage|Batch|FIFO|Send'` pass; new dedup tests pass.
- `golangci-lint run ./adapter/...` 0 issues; `go build ./...` clean.

## Self-review (5 passes)

1. **Data loss** — the fix prevents a double-send (extra messages), and keeps the generation re-derivation so a concurrent queue delete/recreate still routes to the live generation; no committed message is dropped.
2. **Concurrency / distributed** — stable keys make the leader-churn retry an idempotent overwrite; the `[meta,gen]` ReadKeys fence against `DeleteQueue`/`PurgeQueue` is unchanged.
3. **Performance** — identities are minted once instead of once-per-attempt (strictly fewer `crypto/rand` calls on the retry path); hot path (no retry) is one mint per entry, same as before.
4. **Data consistency** — eliminates the duplicate-element anomaly for standard batch send; FIFO/exactly-once and single-send semantics unchanged.
5. **Test coverage** — new co-located tests pin key-stability across the retry (the regression), the load-bearing property of the fix.
