### PR TITLE
fix(scripts): M5a — --host 127.0.0.1 for --local mode

### DIFF
--- a/scripts/run-jepsen-m5-local.sh
+++ b/scripts/run-jepsen-m5-local.sh
@@ -96,7 +96,6 @@ for bin in "$ROUTE_KEY_BIN" "$LIST_ROUTES_BIN" "$BINARY"; do
     exit 1
   fi
 done
-T1_KEY="$("$ROUTE_KEY_BIN" jepsen_append_t1)"
 T3_KEY="$("$ROUTE_KEY_BIN" jepsen_append_t3)"
 # Issue #930 fix: --shardRanges must cover every routing key.  Without
 # a [<empty>, T1_KEY) range, any table whose base64-encoded name sorts
@@ -207,6 +206,15 @@ mkdir -p tmp-home .lein
 # (verify-multi-group-routing!) at the workload's first setup! call.
 # Without them the hook falls back to PATH lookup which fails when
 # run from this script's tmp build.
+#
+# --host 127.0.0.1 — without this the workload's open! resolves the
+# DynamoDB client hostname from (name node) where node is one of
+# default-nodes ["n1" "n2" "n3" "n4" "n5"]; these are virtual labels,
+# not real hostnames, and DNS resolution fails with 'nodename nor
+# servname provided'.  --host overrides via cli/common-cli-opts'
+# --host -> :host -> :dynamo-host -> make-ddb-client wiring.  Required
+# for the single-process two-group topology this script launches —
+# every "node" client talks to the same loopback DynamoDB endpoint.
 HOME="$(pwd)/tmp-home" LEIN_HOME="$(pwd)/.lein" \
   LEIN_JVM_OPTS="-Duser.home=$(pwd)/tmp-home" \
   "$LEIN_BIN" run -m elastickv.dynamodb-multi-table-workload \
@@ -218,14 +226,6 @@ HOME="$(pwd)/tmp-home" LEIN_HOME="$(pwd)/.lein" \
     --list-routes-bin "$LIST_ROUTES_BIN" \
     --grpc-host-port  "$PROC_ADDR" \
   || EXIT_CODE=$?
-# --host 127.0.0.1 — without this the workload's open! resolves the
-# DynamoDB client hostname from (name node) where node is one of
-# default-nodes ["n1" "n2" "n3" "n4" "n5"]; these are virtual labels,
-# not real hostnames, and DNS resolution fails with 'nodename nor
-# servname provided'.  --host overrides via cli/common-cli-opts'
-# --host -> :host -> :dynamo-host -> make-ddb-client wiring.  Required
-# for the single-process two-group topology this script launches —
-# every "node" client talks to the same loopback DynamoDB endpoint.
 
 EXIT_CODE=${EXIT_CODE:-0}
 

--- a/scripts/run-jepsen-m5-local.sh
+++ b/scripts/run-jepsen-m5-local.sh
@@ -206,10 +206,19 @@ HOME="$(pwd)/tmp-home" LEIN_HOME="$(pwd)/.lein" \
     --local \
     --time-limit 30 \
     --rate 5 \
+    --host 127.0.0.1 \
     --dynamo-port 63801 \
     --list-routes-bin "$LIST_ROUTES_BIN" \
     --grpc-host-port  "$PROC_ADDR" \
   || EXIT_CODE=$?
+# --host 127.0.0.1 — without this the workload's open! resolves the
+# DynamoDB client hostname from (name node) where node is one of
+# default-nodes ["n1" "n2" "n3" "n4" "n5"]; these are virtual labels,
+# not real hostnames, and DNS resolution fails with 'nodename nor
+# servname provided'.  --host overrides via cli/common-cli-opts'
+# --host -> :host -> :dynamo-host -> make-ddb-client wiring.  Required
+# for the single-process two-group topology this script launches —
+# every "node" client talks to the same loopback DynamoDB endpoint.
 
 EXIT_CODE=${EXIT_CODE:-0}
 

--- a/scripts/run-jepsen-m5-local.sh
+++ b/scripts/run-jepsen-m5-local.sh
@@ -98,11 +98,18 @@ for bin in "$ROUTE_KEY_BIN" "$LIST_ROUTES_BIN" "$BINARY"; do
 done
 T1_KEY="$("$ROUTE_KEY_BIN" jepsen_append_t1)"
 T3_KEY="$("$ROUTE_KEY_BIN" jepsen_append_t3)"
-# Group 1: [T1_KEY, T3_KEY) — tables 1, 2
-# Group 2: [T3_KEY, +inf)   — tables 3, 4
-# Keys outside [T1_KEY, +inf) fall through to the default group; this
-# workload only writes table-route keys so that range is unused.
-SHARD_RANGES="${T1_KEY}:${T3_KEY}=1,${T3_KEY}:=2"
+# Issue #930 fix: --shardRanges must cover every routing key.  Without
+# a [<empty>, T1_KEY) range, any table whose base64-encoded name sorts
+# before "amVwc2VuX2FwcGVuZF90MQ" (= base64("jepsen_append_t1"))
+# returns "no route for key" from ShardedCoordinator.dispatchTxn, and
+# createTableWithRetry silently swallows that as ACTIVE.
+#
+# Group 1: [<empty>, T3_KEY)   — default + tables 1, 2
+# Group 2: [T3_KEY, +inf)      — tables 3, 4
+#
+# Note: assigning the default range to group 1 (not a third group) keeps
+# the topology consistent with the 1-process-2-groups launch.
+SHARD_RANGES=":${T3_KEY}=1,${T3_KEY}:=2"
 echo "[shard-ranges] $SHARD_RANGES"
 
 # ---- stop any previously managed cluster ----


### PR DESCRIPTION
**Bug fix** discovered during the M5a E2E run of `scripts/run-jepsen-m5-local.sh` after PR #924 + #925 merge.

## 症状

`./scripts/run-jepsen-m5-local.sh` 実行時、最初の workload setup! が以下で失敗:

```
DynamoDB :cognitect.anomalies/not-found: n5: nodename nor servname provided, or not known
```

## 根本原因

`dynamodb_multi_table_workload.clj` の `open!` で:

```clojure
host (or (:dynamo-host test) (name node))
```

`--local` 設定時、`:dynamo-host` は nil なので `(name node)` (`default-nodes` の `"n1".."n5"`) を hostname として使用 → DNS 解決失敗。

## Fix

`lein run` に `--host 127.0.0.1` を追加。`cli/common-cli-opts` 経由で `:host` → `:dynamo-host` → `make-ddb-client` に thread されて、全 5 nodes の client が同じループバック endpoint を dial する。

## 関連する未解決問題 (本 PR スコープ外)

この修正後、setup! は `n5` DNS failure を回避できるが、新たに workers が全 txn で `ResourceNotFoundException: table not found` を返す問題が surface した。:

- `create-all-tables!` は (5 並列 client で) 5 回成功 report
- ListRoutes は期待通りの 2 group catalog を返す
- 直接 curl で `CreateTable` を投げると HTTP 200 + `"TableStatus":"ACTIVE"`
- それでも `GetItem` / `TransactGetItems` は `ResourceNotFoundException`

5 client 並列での CreateTable race か、`adapter/dynamodb.go` の internal sync 問題か。別 issue で調査予定。

## Test plan

- [x] `bash -n scripts/run-jepsen-m5-local.sh` 構文OK
- [x] 実行時 `n5: nodename nor servname provided` エラーは出ない
- [ ] E2E zero G1c — 上記 `ResourceNotFoundException` 別件解決後
