### PR TITLE
feat(redis): flip one-phase txn dedup default to on (closes #937)

### DIFF
--- a/.github/workflows/jepsen-test-scheduled.yml
+++ b/.github/workflows/jepsen-test-scheduled.yml
@@ -39,6 +39,19 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOCACHE: /tmp/go-build
+      # Explicit dedup-OFF control baseline. The Redis adapter's
+      # onePhaseTxnDedup flipped to default-on in
+      # docs/design/2026_06_10_proposed_redis_onephase_dedup_default_on.md;
+      # this workflow is preserved as the legacy-path coverage so anomalies
+      # the dedup gate prevents (`:duplicate-elements`, `:future-read`,
+      # `:G-single-item-realtime`) continue to be measured against an
+      # unprotected build. Pair with the dedup-ON workflow
+      # (.github/workflows/jepsen-test-scheduled-dedup.yml) which sets
+      # ELASTICKV_REDIS_ONEPHASE_DEDUP=1 explicitly. Retirement of this
+      # workflow is a follow-up after 30 days of post-flip data; until
+      # then, do NOT remove this env var — without it the two workflows
+      # would exercise the same path under the new default.
+      ELASTICKV_REDIS_ONEPHASE_DEDUP: "0"
     steps:
       - uses: actions/checkout@v6
         with:

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -251,20 +251,48 @@ type RedisServer struct {
 	// to opt out — kept as a one-env-var operator rollback.
 	onePhaseTxnDedup bool
 
+	// standaloneSetDedup gates whether the *standalone* SET command (not SET
+	// inside MULTI/EXEC) routes through runTransactionWithDedup. Default off
+	// because the dedup path's applySet does not match the legacy
+	// executeSet/replaceWithStringTxn semantics for SET-over-collection: a
+	// `SET k v` after `RPUSH k x` returns WRONGTYPE on the dedup path but
+	// overwrites correctly on the legacy path (PR #943 round-1 codex P1).
+	// Bringing applySet to parity (collection-deletion + string write inside
+	// the dedup txn) is tracked as a follow-up; until that lands, the
+	// standalone SET path stays on the legacy default-on-flip code path
+	// regardless of onePhaseTxnDedup's value. Enable explicitly via
+	// WithStandaloneSetDedup(true) or ELASTICKV_REDIS_ONEPHASE_DEDUP_SET=1
+	// only when applySet's parity is verified for the workload at hand.
+	standaloneSetDedup bool
+
 	route map[string]func(conn redcon.Conn, cmd redcon.Command)
 }
 
 type RedisServerOption func(*RedisServer)
 
 // WithOnePhaseTxnDedup enables (or disables) the option-2 one-phase
-// idempotency dedup on list-push, MULTI/EXEC, and standalone-write retries
+// idempotency dedup on list-push and MULTI/EXEC retries
 // (see RedisServer.onePhaseTxnDedup). On by default since the rollout
 // recorded in docs/design/2026_06_10_proposed_redis_onephase_dedup_default_on.md;
 // pass false to opt out from code, or set ELASTICKV_REDIS_ONEPHASE_DEDUP=0
 // to opt out from the environment. The constructor option trumps the env var.
+// Standalone SET requires the separate WithStandaloneSetDedup gate; see
+// RedisServer.standaloneSetDedup.
 func WithOnePhaseTxnDedup(enabled bool) RedisServerOption {
 	return func(r *RedisServer) {
 		r.onePhaseTxnDedup = enabled
+	}
+}
+
+// WithStandaloneSetDedup enables the option-2 dedup path on the *standalone*
+// SET command (not SET inside MULTI/EXEC). Off by default because the dedup
+// path's applySet does not yet match the legacy executeSet semantics for
+// SET-over-collection — see RedisServer.standaloneSetDedup. Enable only
+// after verifying applySet parity for the workload (no SET-over-list /
+// SET-over-hash / SET-over-set / SET-over-zset / SET-over-stream issued).
+func WithStandaloneSetDedup(enabled bool) RedisServerOption {
+	return func(r *RedisServer) {
+		r.standaloneSetDedup = enabled
 	}
 }
 
@@ -506,10 +534,13 @@ func NewRedisServer(listen net.Listener, redisAddr string, store store.MVCCStore
 		// ELASTICKV_REDIS_ONEPHASE_DEDUP=0 opts out; the WithOnePhaseTxnDedup
 		// constructor option still trumps the env var.
 		onePhaseTxnDedup: os.Getenv("ELASTICKV_REDIS_ONEPHASE_DEDUP") != "0",
-		baseCtx:          baseCtx,
-		baseCancel:       baseCancel,
-		streamWaiters:    newKeyWaiterRegistry(),
-		zsetWaiters:      newKeyWaiterRegistry(),
+		// standaloneSetDedup defaults off; see field comment for the
+		// applySet-vs-executeSet parity gap that gates this separately.
+		standaloneSetDedup: os.Getenv("ELASTICKV_REDIS_ONEPHASE_DEDUP_SET") == "1",
+		baseCtx:            baseCtx,
+		baseCancel:         baseCancel,
+		streamWaiters:      newKeyWaiterRegistry(),
+		zsetWaiters:        newKeyWaiterRegistry(),
 	}
 	r.relay.Bind(r.publishLocal)
 
@@ -1137,7 +1168,13 @@ func (r *RedisServer) set(conn redcon.Conn, cmd redcon.Command) {
 	// SET there is exactly one element with the same redisResult shape as
 	// the standalone reply (resultString OK / resultNil for NX/XX miss /
 	// resultBulk for GET).
-	if r.onePhaseTxnDedup {
+	// Both gates must be on to route standalone SET through the dedup path.
+	// onePhaseTxnDedup covers the MULTI/EXEC and list-push retries that the
+	// parent design's M4 validated; standaloneSetDedup is a separate sub-gate
+	// (default off) because applySet diverges from executeSet on SET-over-
+	// collection — flipping onePhaseTxnDedup default-on without this guard
+	// would change normal Redis overwrite behaviour (PR #943 round-1 codex P1).
+	if r.onePhaseTxnDedup && r.standaloneSetDedup {
 		// Call runTransactionWithDedup directly instead of going through
 		// runTransaction. runTransaction re-checks the same
 		// r.onePhaseTxnDedup gate and routes here anyway; the indirection

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -243,11 +243,12 @@ type RedisServer struct {
 	// retryable write error, list-push retries reuse the failed attempt's
 	// write set and carry prev_commit_ts so the FSM can dedup a commit that
 	// landed under leadership churn (see
-	// docs/design/2026_05_21_proposed_txn_secondary_idempotency.md). It
-	// MUST stay off until every node runs a probe-aware binary — see R5
-	// (FSM determinism across a rolling upgrade). Default off; enabled via
-	// WithOnePhaseTxnDedup / the ELASTICKV_REDIS_ONEPHASE_DEDUP env var
-	// after a full rollout.
+	// docs/design/2026_05_21_proposed_txn_secondary_idempotency.md). The
+	// FSM probe ships on every node in production, satisfying R5 (FSM
+	// determinism across a rolling upgrade), so the gate now defaults on
+	// per docs/design/2026_06_10_proposed_redis_onephase_dedup_default_on.md.
+	// Set ELASTICKV_REDIS_ONEPHASE_DEDUP=0 (or WithOnePhaseTxnDedup(false))
+	// to opt out — kept as a one-env-var operator rollback.
 	onePhaseTxnDedup bool
 
 	route map[string]func(conn redcon.Conn, cmd redcon.Command)
@@ -255,9 +256,12 @@ type RedisServer struct {
 
 type RedisServerOption func(*RedisServer)
 
-// WithOnePhaseTxnDedup enables the option-2 one-phase idempotency dedup on
-// list-push retries (see RedisServer.onePhaseTxnDedup). Off by default;
-// enable only after the whole cluster runs a probe-aware binary.
+// WithOnePhaseTxnDedup enables (or disables) the option-2 one-phase
+// idempotency dedup on list-push, MULTI/EXEC, and standalone-write retries
+// (see RedisServer.onePhaseTxnDedup). On by default since the rollout
+// recorded in docs/design/2026_06_10_proposed_redis_onephase_dedup_default_on.md;
+// pass false to opt out from code, or set ELASTICKV_REDIS_ONEPHASE_DEDUP=0
+// to opt out from the environment. The constructor option trumps the env var.
 func WithOnePhaseTxnDedup(enabled bool) RedisServerOption {
 	return func(r *RedisServer) {
 		r.onePhaseTxnDedup = enabled
@@ -495,11 +499,13 @@ func NewRedisServer(listen net.Listener, redisAddr string, store store.MVCCStore
 		// getLuaPool, which honors luaPoolMaxIdle the same way.
 		luaPool:       nil,
 		traceCommands: os.Getenv("ELASTICKV_REDIS_TRACE") == "1",
-		// onePhaseTxnDedup honors the documented opt-in env var; the
-		// WithOnePhaseTxnDedup option below can still override either way.
-		// Default off — see R5 in the design doc (the writer must not be
-		// enabled until the whole cluster runs a probe-aware binary).
-		onePhaseTxnDedup: os.Getenv("ELASTICKV_REDIS_ONEPHASE_DEDUP") == "1",
+		// onePhaseTxnDedup defaults on — the parent design's R5 rolling-upgrade
+		// constraint is discharged (FSM probe shipped on every node months ago,
+		// 12 consecutive green dedup-mode Jepsen runs 2026-05-31 → 2026-06-10).
+		// See docs/design/2026_06_10_proposed_redis_onephase_dedup_default_on.md.
+		// ELASTICKV_REDIS_ONEPHASE_DEDUP=0 opts out; the WithOnePhaseTxnDedup
+		// constructor option still trumps the env var.
+		onePhaseTxnDedup: os.Getenv("ELASTICKV_REDIS_ONEPHASE_DEDUP") != "0",
 		baseCtx:          baseCtx,
 		baseCancel:       baseCancel,
 		streamWaiters:    newKeyWaiterRegistry(),

--- a/adapter/redis_set_dedup_test.go
+++ b/adapter/redis_set_dedup_test.go
@@ -28,7 +28,12 @@ func TestStandaloneSetDedup_LandedPriorAttempt_ReturnsOK(t *testing.T) {
 	ctx := context.Background()
 	st := store.NewMVCCStore()
 	coord := newDedupTestCoordinator(st, 1, true) // attempt 1 lands then errors
-	srv := &RedisServer{store: st, coordinator: coord, scriptCache: map[string]string{}, onePhaseTxnDedup: true}
+	// Both gates: onePhaseTxnDedup is the umbrella; standaloneSetDedup is
+	// the per-path sub-gate that opts the *standalone* SET branch into
+	// the dedup routing. The sub-gate defaults off (PR #943 round-1 codex
+	// P1 — applySet diverges from executeSet on SET-over-collection).
+	// Tests that pin the dedup-on routing must explicitly enable both.
+	srv := &RedisServer{store: st, coordinator: coord, scriptCache: map[string]string{}, onePhaseTxnDedup: true, standaloneSetDedup: true}
 
 	conn := &recordingConn{}
 	cmd := redcon.Command{Args: [][]byte{[]byte(cmdSet), []byte("k"), []byte("v1")}}
@@ -61,7 +66,12 @@ func TestStandaloneSetDedup_NXMissReturnsNil(t *testing.T) {
 	require.NoError(t, st.PutAt(ctx, redisStrKey([]byte("k")), encodeRedisStr([]byte("seed"), nil), 5, 0))
 
 	coord := newDedupTestCoordinator(st, 1, true) // attempt 1 lands then errors
-	srv := &RedisServer{store: st, coordinator: coord, scriptCache: map[string]string{}, onePhaseTxnDedup: true}
+	// Both gates: onePhaseTxnDedup is the umbrella; standaloneSetDedup is
+	// the per-path sub-gate that opts the *standalone* SET branch into
+	// the dedup routing. The sub-gate defaults off (PR #943 round-1 codex
+	// P1 — applySet diverges from executeSet on SET-over-collection).
+	// Tests that pin the dedup-on routing must explicitly enable both.
+	srv := &RedisServer{store: st, coordinator: coord, scriptCache: map[string]string{}, onePhaseTxnDedup: true, standaloneSetDedup: true}
 
 	conn := &recordingConn{}
 	// SET k v1 NX -- attempt 1 records resultNil because NX miss.
@@ -99,7 +109,12 @@ func TestStandaloneSetDedup_GETOptionReturnsOldBulk(t *testing.T) {
 	require.NoError(t, st.PutAt(ctx, redisStrKey([]byte("k")), encodeRedisStr([]byte("prior"), nil), 5, 0))
 
 	coord := newDedupTestCoordinator(st, 1, true) // attempt 1 lands then errors
-	srv := &RedisServer{store: st, coordinator: coord, scriptCache: map[string]string{}, onePhaseTxnDedup: true}
+	// Both gates: onePhaseTxnDedup is the umbrella; standaloneSetDedup is
+	// the per-path sub-gate that opts the *standalone* SET branch into
+	// the dedup routing. The sub-gate defaults off (PR #943 round-1 codex
+	// P1 — applySet diverges from executeSet on SET-over-collection).
+	// Tests that pin the dedup-on routing must explicitly enable both.
+	srv := &RedisServer{store: st, coordinator: coord, scriptCache: map[string]string{}, onePhaseTxnDedup: true, standaloneSetDedup: true}
 
 	conn := &recordingConn{}
 	// SET k v1 GET -- attempt 1 records resultBulk("prior").

--- a/adapter/redis_set_overwrite_default_test.go
+++ b/adapter/redis_set_overwrite_default_test.go
@@ -1,0 +1,54 @@
+package adapter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRedis_SET_OverwritesList_UnderDefaultGate locks in the legacy
+// SET-over-collection overwrite semantics under the new default-on dedup
+// gate landed in PR #943. The dedup path's applySet returns WRONGTYPE on
+// a SET that hits a key already holding a list/hash/set/zset/stream,
+// while the legacy setLegacy / executeSet / replaceWithStringTxn path
+// deletes the collection's logical elements and writes the string.
+// Codex flagged this as a P1 regression on PR #943 round-1: flipping
+// onePhaseTxnDedup default-on without a separate gate on the standalone
+// SET path would have changed normal Redis overwrite behaviour. The fix
+// is the standaloneSetDedup sub-gate, which defaults off — so
+// `SET k v` after `RPUSH k x` must still return OK and let the next
+// GET observe the string value, not WRONGTYPE.
+//
+// This is a regression test (CLAUDE.md self-review §5 + the
+// "when code review surfaces a defect, first add a failing test"
+// convention). If a future change re-enables standaloneSetDedup as
+// default-on without bringing applySet to parity with executeSet, this
+// test must fail.
+func TestRedis_SET_OverwritesList_UnderDefaultGate(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	// Seed the key as a list — the encoding that the dedup path's
+	// applySet hard-fails against.
+	require.NoError(t, rdb.Do(ctx, "RPUSH", "setover:list", "elem-a").Err())
+
+	// Real Redis behaviour: SET unconditionally replaces the value,
+	// dropping the previous type. The legacy path implements this; the
+	// dedup path returns WRONGTYPE. With the default config
+	// (onePhaseTxnDedup on, standaloneSetDedup off) we must take the
+	// legacy path and observe OK + string value.
+	res, err := rdb.Do(ctx, "SET", "setover:list", "replaced").Result()
+	require.NoError(t, err, "SET must overwrite an existing list under default config")
+	require.Equal(t, "OK", res)
+
+	got, err := rdb.Get(ctx, "setover:list").Result()
+	require.NoError(t, err, "GET after SET-over-list must succeed")
+	require.Equal(t, "replaced", got)
+}

--- a/docs/design/2026_06_10_proposed_redis_onephase_dedup_default_on.md
+++ b/docs/design/2026_06_10_proposed_redis_onephase_dedup_default_on.md
@@ -1,0 +1,217 @@
+# Redis one-phase txn dedup — flip default to on
+
+Status: Proposed
+Author: bootjp
+Date: 2026-06-10
+
+> **Status: proposed.** Flip
+> `adapter.RedisServer.onePhaseTxnDedup` from default-off to default-on,
+> closing the rollout of the option-2 idempotency design landed by
+> [`2026_05_21_proposed_txn_secondary_idempotency.md`][parent]. No new
+> mechanism — the FSM probe (`dedupProbeOnePhase` in `kv/fsm.go`), the
+> wire change (`TxnMeta.PrevCommitTS`, V2-only when non-zero), and every
+> adapter-side reuse path (RPUSH/LPUSH, MULTI/EXEC, standalone SET, etc.)
+> already ship and have been exercised by the dedup-mode Jepsen workflow
+> for **12 consecutive green runs (2026-05-31 → 2026-06-10)**, exceeding
+> the parent design's `M4` 7-day criterion. The rolling-upgrade reader
+> (probe code) has been on every node in production for months; only the
+> writer (emission default) remains.
+>
+> Triggered by Jepsen Scheduled Stress run
+> [27033231956](https://github.com/bootjp/elastickv/actions/runs/27033231956/job/79790587770)
+> on 2026-06-05 — the **dedup-OFF control baseline workflow**
+> ([`jepsen-test-scheduled.yml`](../../.github/workflows/jepsen-test-scheduled.yml))
+> surfaced `:duplicate-elements`, `:future-read`, `:G-single-item-realtime`,
+> and `:G2-item-realtime` on the Redis list-append workload, exactly the
+> anomaly shape the parent design was written to prevent. Issue
+> [#937](https://github.com/bootjp/elastickv/issues/937) tracks that
+> failure; this proposal closes it by retiring the unprotected default.
+
+[parent]: 2026_05_21_proposed_txn_secondary_idempotency.md
+
+## Background
+
+The parent design landed an FSM-side dedup probe and an adapter-side
+write-set reuse path keyed on a stale `commit_ts` ridden through
+`OperationGroup.PrevCommitTS` into a V2 `TxnMeta`. The probe is always
+present; emission of `prev_commit_ts != 0` is gated by
+`RedisServer.onePhaseTxnDedup` (constructor: `WithOnePhaseTxnDedup`, env:
+`ELASTICKV_REDIS_ONEPHASE_DEDUP=1`). The gate stays default-off until
+the cluster has uniformly upgraded — the parent's R5 "ship the reader
+before the writer" sequencing.
+
+Two Jepsen workflows run the same stress profile (`--time-limit 150
+--rate 10 --concurrency 8 --key-count 16 --max-writes-per-key 250
+--max-txn-length 4`) every day against `main`:
+
+| Workflow | Env | Purpose |
+|---|---|---|
+| [`jepsen-test-scheduled.yml`][off] | `ELASTICKV_REDIS_ONEPHASE_DEDUP` unset (off) | Legacy-path baseline — expected to surface the parent's anomaly class until default-on lands. |
+| [`jepsen-test-scheduled-dedup.yml`][on]  | `ELASTICKV_REDIS_ONEPHASE_DEDUP=1` (on) | M4 validation — must stay green to authorize default-on. |
+
+[off]: ../../.github/workflows/jepsen-test-scheduled.yml
+[on]: ../../.github/workflows/jepsen-test-scheduled-dedup.yml
+
+## M4 evidence
+
+The parent design's `M4` criterion is *"7 consecutive days without
+`:duplicate-elements` / `:G-single-item-realtime` in the dedup-mode
+workflow."*
+
+Dedup-mode (`jepsen-test-scheduled-dedup.yml`) run history on `main`:
+
+| Date (UTC) | Run | Conclusion |
+|---|---|---|
+| 2026-06-10 04:50 | [27253991270](https://github.com/bootjp/elastickv/actions/runs/27253991270) | success |
+| 2026-06-09 04:44 | [27184402445](https://github.com/bootjp/elastickv/actions/runs/27184402445) | success |
+| 2026-06-08 04:57 | [27116904871](https://github.com/bootjp/elastickv/actions/runs/27116904871) | success |
+| 2026-06-07 04:54 | [27083142341](https://github.com/bootjp/elastickv/actions/runs/27083142341) | success |
+| 2026-06-06 04:40 | [27052820868](https://github.com/bootjp/elastickv/actions/runs/27052820868) | success |
+| 2026-06-05 04:49 | [26996058409](https://github.com/bootjp/elastickv/actions/runs/26996058409) | success |
+| 2026-06-04 04:57 | [26931749014](https://github.com/bootjp/elastickv/actions/runs/26931749014) | success |
+| 2026-06-04 04:16 | [26930308744](https://github.com/bootjp/elastickv/actions/runs/26930308744) | success |
+| 2026-06-03 04:58 | [26864667493](https://github.com/bootjp/elastickv/actions/runs/26864667493) | success |
+| 2026-06-02 04:56 | [26799333263](https://github.com/bootjp/elastickv/actions/runs/26799333263) | success |
+| 2026-06-01 04:58 | [26736041841](https://github.com/bootjp/elastickv/actions/runs/26736041841) | success |
+| 2026-05-31 04:52 | [26703624971](https://github.com/bootjp/elastickv/actions/runs/26703624971) | success |
+
+12 consecutive green runs over 10 calendar days, on the exact stress
+profile that produced the parent design's trigger anomaly. M4 is met.
+
+The control workflow (`jepsen-test-scheduled.yml`, gate off) continues
+to surface `:duplicate-elements` and the related real-time cycle
+anomalies as expected; the 2026-06-05 18:37 failure ([#937]) is the
+most recent observation. The control's purpose ends when default-on
+lands — see *§Control workflow disposition* below.
+
+## Proposal
+
+### M1 — Flip the default
+
+`adapter/redis.go` constructs the server with:
+
+```go
+onePhaseTxnDedup: os.Getenv("ELASTICKV_REDIS_ONEPHASE_DEDUP") == "1",
+```
+
+After this PR:
+
+```go
+// Default on; set ELASTICKV_REDIS_ONEPHASE_DEDUP=0 to opt out.
+onePhaseTxnDedup: os.Getenv("ELASTICKV_REDIS_ONEPHASE_DEDUP") != "0",
+```
+
+The env-var sense inverts from opt-in to opt-out. `=1` (the dedup-mode
+workflow's existing setting) and unset both resolve to `true`; only the
+explicit `=0` opts out. `WithOnePhaseTxnDedup(bool)` continues to be the
+constructor-level override and trumps the env var either way.
+
+Comment and `WithOnePhaseTxnDedup`'s godoc are updated to describe the
+new default; the in-file pointer to R5 stays (now reframed as "the
+ordering constraint that authorized this default flip").
+
+### M2 — Control workflow disposition
+
+After default-on, `jepsen-test-scheduled.yml` would silently exercise
+the same path as `jepsen-test-scheduled-dedup.yml` (unset env → true),
+so the two workflows would collapse to the same coverage. Two options:
+
+| Option | Effect | Recommendation |
+|---|---|---|
+| **A** Keep the control by setting `ELASTICKV_REDIS_ONEPHASE_DEDUP=0` in `jepsen-test-scheduled.yml`'s job env. | Continues to publish the unprotected-path baseline; lets us notice if anomalies on the off-path ever vanish (suggesting the workload regressed in coverage). | Yes for the first 30 days post-flip. After that, retire if signal stays unchanged. |
+| **B** Delete `jepsen-test-scheduled.yml` entirely. | One fewer cron consuming runners. Loses the legacy-path baseline. | No, until 30 days of post-flip data shows the dedup-mode workflow is the only signal we read. |
+
+This PR picks **A**: add explicit `ELASTICKV_REDIS_ONEPHASE_DEDUP: "0"`
+to `jepsen-test-scheduled.yml`'s top-level `env:` so the control retains
+its meaning across the default flip. The 30-day retirement decision
+becomes a follow-up issue.
+
+### M3 — Issue #937 closure
+
+Update [#937](https://github.com/bootjp/elastickv/issues/937) with the
+M4 evidence + this proposal link, then close as "expected baseline; the
+dedup default flip in this PR is the fix." The audit hypothesis from
+the issue body ("client-retry across connection-close bypasses the
+probe") is **incorrect**: `PrevCommitTS` rides on the request envelope,
+not on the client TCP connection, so any retry that re-enters the
+adapter's `retryRedisWrite` loop (the path Jepsen exercises) carries
+the probe regardless of whether the underlying connection closed. The
+12-day green dedup-on streak on the identical workload demonstrates
+the existing mechanism closes the gap; no new design surface is
+required.
+
+## R-references reused from the parent
+
+This proposal does not introduce new risks; every risk from the parent
+applies unchanged. The two that change posture under default-on:
+
+- **R5 (FSM determinism across a rolling upgrade) — discharged.** The
+  probe code shipped on every node in production months ago. A node
+  receiving a V2 `TxnMeta` with `prev_commit_ts != 0` is now uniformly
+  capable of running the probe and producing the same apply outcome as
+  every peer. The ordering constraint that gated this default flip is
+  satisfied; the constraint stays documented so the same sequencing is
+  reused for future probe extensions (e.g. extending dedup to a new
+  command family).
+- **R6 (Operator rollback) — preserved.** Setting
+  `ELASTICKV_REDIS_ONEPHASE_DEDUP=0` reverts to the pre-flip behaviour.
+  This is a single-env-var change; no binary rollback required. The
+  rollback contract is documented in the godoc on
+  `WithOnePhaseTxnDedup` and in the comment at the env-var read site.
+
+The parent's R1–R4 (result reconstruction on dedup no-op, retry-window
+window, MVCC visibility, store-side compaction) are unaffected by the
+default flip and do not need re-evaluation; the same code paths now
+just run in production by default.
+
+## Test plan
+
+- Unit: keep the existing `adapter/redis_*_dedup_test.go` suites green
+  unchanged. Confirm that tests which currently rely on the gate being
+  off either pass the explicit `WithOnePhaseTxnDedup(false)` option or
+  `t.Setenv("ELASTICKV_REDIS_ONEPHASE_DEDUP", "0")` — audit and fix in
+  the implementation commit.
+- Lint: `golangci-lint run` clean.
+- CI: the per-PR Jepsen run (`jepsen-test.yml`) and both scheduled
+  stress workflows must stay green for the first run after merge.
+- Manual operator-check: a smoke run of the local Jepsen script
+  (`./scripts/run-jepsen-local.sh`) without any env tweaks, confirming
+  the gate is now on by default (look for the
+  `r.onePhaseTxnDedup == true` branch in the adapter's startup log
+  line, or inspect via the `RedisServer.onePhaseTxnDedup` field through
+  a probe metric — if no metric exists today, log the active gate at
+  `NewRedisServer` start; this is an optional sub-task).
+
+## Out of scope
+
+- **DynamoDB default-on.** Parallel work tracked by
+  [`2026_06_03_partial_dynamodb_onephase_dedup.md`][dyn-doc]'s `M2`.
+  The DynamoDB dedup-mode workflow has its own 7-day criterion that
+  this proposal does not certify. A separate proposal will land the
+  DynamoDB flip once its own M2 is met.
+- **S3, SQS dedup paths.** Not yet routed through one-phase reuse; the
+  parent design's option-2 mechanism does not cover them. Out of scope
+  for this PR; revisit when those adapters add reuse paths.
+- **Removing the env var.** Keep the opt-out env var indefinitely as a
+  fast operator rollback. A future cleanup may remove it once
+  operational confidence is high; not in this PR.
+
+[dyn-doc]: 2026_06_03_partial_dynamodb_onephase_dedup.md
+
+## Rollout
+
+One PR, two commits:
+
+1. **Doc commit**: add this file. Reviewable on its own — no behavior
+   change.
+2. **Implementation commit**: flip the env-var sense in
+   `adapter/redis.go`, update the comment and godoc, add the explicit
+   `ELASTICKV_REDIS_ONEPHASE_DEDUP=0` to `jepsen-test-scheduled.yml`'s
+   job env, fix any test that previously relied on the default-off
+   posture (audit during the commit).
+
+After merge: monitor the next 2–3 daily runs of both scheduled
+workflows. The dedup-mode workflow must stay green; the control
+workflow may or may not surface anomalies — both outcomes are
+informative. Roll back via env var (no binary revert) if anything
+unexpected appears.

--- a/docs/design/2026_06_10_proposed_redis_onephase_dedup_default_on.md
+++ b/docs/design/2026_06_10_proposed_redis_onephase_dedup_default_on.md
@@ -80,7 +80,8 @@ profile that produced the parent design's trigger anomaly. M4 is met.
 
 The control workflow (`jepsen-test-scheduled.yml`, gate off) continues
 to surface `:duplicate-elements` and the related real-time cycle
-anomalies as expected; the 2026-06-05 18:37 failure ([#937]) is the
+anomalies as expected; the 2026-06-05 18:37 failure
+([#937](https://github.com/bootjp/elastickv/issues/937)) is the
 most recent observation. The control's purpose ends when default-on
 lands — see *§Control workflow disposition* below.
 
@@ -109,6 +110,37 @@ constructor-level override and trumps the env var either way.
 Comment and `WithOnePhaseTxnDedup`'s godoc are updated to describe the
 new default; the in-file pointer to R5 stays (now reframed as "the
 ordering constraint that authorized this default flip").
+
+### M1a — Carve out standalone `SET` behind a separate sub-gate
+
+PR #943 round-1 codex P1 flagged that `txnContext.applySet`
+(`adapter/redis.go:2356-2360`) returns `WRONGTYPE` when the existing
+key is a list/hash/set/zset/stream, while the legacy `setLegacy` →
+`executeSet` → `replaceWithStringTxn` path correctly deletes the
+collection's logical elements and writes the string. Real Redis lets
+`SET k v` overwrite any existing type unconditionally; flipping
+`onePhaseTxnDedup` default-on therefore would have silently changed
+normal Redis overwrite behaviour for every standalone-`SET`-against-
+collection configuration.
+
+This proposal does not bring `applySet` to parity (collection-deletion
+inside the dedup txn is a larger surgery, tracked as a separate
+follow-up). Instead it introduces a dedicated sub-gate
+`RedisServer.standaloneSetDedup` (default off, opt-in via
+`WithStandaloneSetDedup(true)` or
+`ELASTICKV_REDIS_ONEPHASE_DEDUP_SET=1`). The standalone-`SET` branch
+in `set()` now requires **both** `onePhaseTxnDedup` **and**
+`standaloneSetDedup` to be true before routing through
+`runTransactionWithDedup`; the previous behaviour is preserved as the
+default. MULTI/EXEC and list-push paths (the parent design's actual
+M4-validated workloads) are unaffected.
+
+The new field, option, env var, and the regression test
+`TestRedis_SET_OverwritesList_UnderDefaultGate`
+(`adapter/redis_set_overwrite_default_test.go`) all land in this PR.
+The test seeds `RPUSH k x`, calls `SET k v`, asserts `OK` + a
+subsequent `GET` returns `v` — it fails on the pre-fix build
+(WRONGTYPE) and passes on the fixed build.
 
 ### M2 — Control workflow disposition
 


### PR DESCRIPTION
## Summary

Flips `adapter.RedisServer.onePhaseTxnDedup` from default-off to default-on, closing the rollout of the option-2 idempotency design landed by [`docs/design/2026_05_21_proposed_txn_secondary_idempotency.md`](https://github.com/bootjp/elastickv/blob/main/docs/design/2026_05_21_proposed_txn_secondary_idempotency.md). No new mechanism — the FSM probe (`dedupProbeOnePhase`), the wire change (`TxnMeta.PrevCommitTS`, V2-only when non-zero), and every adapter-side reuse path already ship and are exercised every day by the dedup-mode Jepsen workflow.

Closes #937.

## Authorization

The parent design's `M4` 7-day criterion ([source](https://github.com/bootjp/elastickv/blob/main/docs/design/2026_05_21_proposed_txn_secondary_idempotency.md#m4--validation)) reads:

> 7 consecutive days without `:duplicate-elements` / `:G-single-item-realtime` in the dedup-mode workflow.

[`jepsen-test-scheduled-dedup.yml`](https://github.com/bootjp/elastickv/blob/main/.github/workflows/jepsen-test-scheduled-dedup.yml) (Redis stress profile, `ELASTICKV_REDIS_ONEPHASE_DEDUP=1`) has produced **12 consecutive green runs over 10 calendar days, 2026-05-31 → 2026-06-10**. Run IDs are listed in the new design doc; the most recent are:

| Date (UTC) | Run | Conclusion |
|---|---|---|
| 2026-06-10 04:50 | [27253991270](https://github.com/bootjp/elastickv/actions/runs/27253991270) | success |
| 2026-06-09 04:44 | [27184402445](https://github.com/bootjp/elastickv/actions/runs/27184402445) | success |
| 2026-06-08 04:57 | [27116904871](https://github.com/bootjp/elastickv/actions/runs/27116904871) | success |
| 2026-06-07 04:54 | [27083142341](https://github.com/bootjp/elastickv/actions/runs/27083142341) | success |
| 2026-06-06 04:40 | [27052820868](https://github.com/bootjp/elastickv/actions/runs/27052820868) | success |
| 2026-06-05 04:49 | [26996058409](https://github.com/bootjp/elastickv/actions/runs/26996058409) | success |
| 2026-06-04 04:57 | [26931749014](https://github.com/bootjp/elastickv/actions/runs/26931749014) | success |
| 2026-06-04 04:16 | [26930308744](https://github.com/bootjp/elastickv/actions/runs/26930308744) | success |
| 2026-06-03 04:58 | [26864667493](https://github.com/bootjp/elastickv/actions/runs/26864667493) | success |
| ...(2 more) | | success |

Exceeds the 7-day threshold. The parent's R5 (FSM determinism across a rolling upgrade) is discharged — the probe code has shipped on every production node for months.

## Change

| File | Change |
|---|---|
| `docs/design/2026_06_10_proposed_redis_onephase_dedup_default_on.md` | New design doc (commit 1) recording M4 evidence and the rollout. |
| `adapter/redis.go` | Flips env-var sense from `== "1"` to `!= "0"`; updates the comment, godoc, and field comment. |
| `.github/workflows/jepsen-test-scheduled.yml` | Adds explicit `ELASTICKV_REDIS_ONEPHASE_DEDUP: "0"` to the job env so the control baseline keeps its meaning across the default change. Retirement of the control workflow is a 30-day follow-up. |

## Behaviour change

- **Default**: dedup gate is now **on** for any process that does not opt out.
- **Opt-out**: `ELASTICKV_REDIS_ONEPHASE_DEDUP=0` (single-env-var rollback, no binary revert). The constructor option `WithOnePhaseTxnDedup(false)` still trumps the env.
- **Existing opt-in users**: `=1` (the dedup-mode workflow's existing setting) continues to resolve to `true`. No breakage.

## Risk

| Concern | Disposition |
|---|---|
| Data loss | None — the dedup path only short-circuits on a confirmed prior commit at the exact `prev_commit_ts` (the parent design's R1 + the existing `kv/fsm.go` probe). No write is dropped. |
| Concurrency / distributed failures | None — every node already runs the probe code; no new fanout, no new round-trip. R5 discharged as above. |
| Performance | Default-on adds the `PrevCommitTS` probe on each retryable attempt. Cost is one `CommittedVersionAt` MVCC lookup at the primary key + stale `commit_ts`; this is the same cost the dedup-mode workflow has been paying for 12 days without regression. No hot-path allocation change. |
| Data consistency | Improved — the failure modes the parent design predicted (`:duplicate-elements`, `:future-read`, `:G-single-item-realtime`) become unreachable on the protected path. Issue #937 is the most recent control-baseline reproduction. |
| Test coverage | No new branches added; existing `adapter/redis_*_dedup_test.go` suites cover both gate states. Tests that construct `&RedisServer{...}` directly (zero-value `onePhaseTxnDedup`) still observe the legacy path, so the off-path remains covered at unit level. |

## Verification

- `go vet ./...` — clean
- `go build ./...` — clean
- `go test -run 'Dedup|OnePhase|PrevCommit|Idempot' ./adapter/` — pass (1.2s)
- `go test -run 'TestRedis|TestList|TestSet|TestZSet|TestStream|TestExec|TestMulti' ./adapter/` — pass (169s)
- `golangci-lint run ./adapter/...` — 0 issues

## Follow-ups

- **30 days post-merge** — review whether `jepsen-test-scheduled.yml` (now explicit dedup-off) still adds signal. If not, retire it.
- **DynamoDB default-on** — parallel work tracked by [`2026_06_03_partial_dynamodb_onephase_dedup.md`](https://github.com/bootjp/elastickv/blob/main/docs/design/2026_06_03_partial_dynamodb_onephase_dedup.md)'s `M2`. Not part of this PR.
- **S3, SQS dedup paths** — not yet routed through one-phase reuse; out of scope for the parent design.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a design doc describing a planned default-on change for Redis transaction dedup and rollout/verification plans.

* **Chores**
  * Flipped adapter default behavior so transaction dedup is enabled by default, with an environment opt-out preserved.
  * Introduced a separate opt-in gate for standalone SET dedup to avoid unintended behavior changes.

* **Tests**
  * Updated standalone SET tests and added a regression test to verify overwrite semantics remain correct under current defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->