### PR TITLE
perf(lease-read): store lease expiry as atomic.Int64 nanoseconds (zero-alloc extend)

### DIFF
--- a/kv/lease_state.go
+++ b/kv/lease_state.go
@@ -1,6 +1,7 @@
 package kv
 
 import (
+	"sync"
 	"sync/atomic"
 
 	"github.com/bootjp/elastickv/internal/monoclock"
@@ -30,55 +31,56 @@ func isLeadershipLossError(err error) bool {
 		errors.Is(err, raftengine.ErrLeadershipTransferInProgress)
 }
 
-// leaseSlot is the immutable payload stored behind leaseState.current.
-// Each successful extend installs a freshly-allocated *leaseSlot, so
-// pointer identity alone disambiguates two extenders that happened to
-// compute the same expiry value (clock-granularity tie). A rollback
-// CAS that compares against the extender's own *leaseSlot therefore
-// cannot clobber a newer lease installed by a concurrent winner, even
-// if the newer lease carries an equal expiryNanos.
-//
-// expiryNanos == 0 is the sentinel for "no lease"; the zero-valued
-// *leaseSlot (returned on startup before any extend) carries gen 0.
-type leaseSlot struct {
-	// expiryNanos is monoclock.Instant.Nanos(); 0 means "no lease".
-	expiryNanos int64
-	// gen is the monotonic invalidation counter. Each invalidate
-	// installs a new slot with gen+1; each extend observes it via
-	// generation() BEFORE the quorum operation and refuses to install
-	// a slot whose gen no longer matches. This preserves the
-	// leader-loss guard: a Dispatch that returned just before an
-	// invalidate fires must not resurrect the lease.
-	gen uint64
-}
-
 // leaseState tracks the monotonic-raw expiry of a leader-local read
-// lease. The hot-path read (valid) remains lock-free via a single
-// atomic pointer load; writes go through CAS on the pointer so
-// pointer identity gates the extender-vs-rollback race.
+// lease.
 //
-// expiryNanos == 0 in the current slot means the lease has never been
-// issued or has been invalidated. A non-zero value is the
-// monotonic-raw instant after which the lease is considered expired;
-// a caller comparing monoclock.Now() against the loaded value can
-// decide whether to skip a quorum confirmation. The monotonic-raw
-// clock is immune to NTP rate adjustment and wall-clock steps (see
-// internal/monoclock).
+// Storage layout. The expiry is held as a single atomic int64 of
+// monotonic-raw nanoseconds and the invalidation generation as a single
+// atomic uint64. Neither write path allocates: the previous
+// pointer-swap design heap-allocated a slot on every successful extend,
+// which is 1:1 with Dispatch throughput and a measurable GC source at
+// tens of thousands of writes per second. Two plain atomics remove that
+// allocation entirely.
+//
+// Clock source. expiryNanos stores monoclock.Instant.Nanos(), i.e. a
+// reading of CLOCK_MONOTONIC_RAW (see internal/monoclock). It is NOT
+// wall-clock nanoseconds. valid() compares it against a caller-supplied
+// monoclock.Now(), so the lease-vs-safety-window comparison is immune to
+// NTP rate adjustment and wall-clock step events: a backward or forward
+// wall-clock step cannot prematurely expire the lease or, worse, extend
+// it past its true safety window. Both the stored expiry and the now
+// passed to valid() MUST originate from monoclock so they share that
+// arbitrary zero point; mixing in time.Now()-derived nanoseconds here
+// would reintroduce the NTP-step hazard this clock source exists to
+// avoid.
+//
+// expiryNanos == 0 means the lease has never been issued or has been
+// invalidated; valid() returns false for it unconditionally. A non-zero
+// value is the monotonic-raw instant after which the lease is expired.
+//
+// Concurrency. valid() is the hot path (one per read) and stays
+// lock-free: a single atomic load of expiryNanos. The write paths
+// (extend / invalidate) run once per Dispatch / leadership change, not
+// per read, and serialize on writeMu so an extend and an invalidate can
+// never interleave their (gen, expiry) updates. Serializing only the
+// writers keeps the pair update atomic without a 128-bit CAS and without
+// the post-write rollback dance a lock-free two-atomic scheme would
+// otherwise need, while leaving the read path uncontended.
 type leaseState struct {
-	// current is the live *leaseSlot. A nil pointer means "never
-	// extended"; valid() treats it identically to an explicit
-	// zero-expiry slot.
-	current atomic.Pointer[leaseSlot]
-}
-
-// slotOrZero returns the current slot, substituting a synthetic zero
-// slot when the pointer has never been stored. Keeps callers free of
-// nil checks.
-func slotOrZero(p *leaseSlot) *leaseSlot {
-	if p == nil {
-		return &leaseSlot{}
-	}
-	return p
+	// writeMu serializes extend and invalidate so their two-field
+	// updates appear atomic to each other. Readers never take it.
+	writeMu sync.Mutex
+	// expiryNanos is monoclock.Instant.Nanos(); 0 means "no lease".
+	// Read lock-free by valid(); written only under writeMu.
+	expiryNanos atomic.Int64
+	// gen is the monotonic invalidation counter. Each invalidate
+	// increments it; each extend observes it via generation() BEFORE
+	// the quorum operation and refuses to install an expiry whose
+	// generation no longer matches. This preserves the leader-loss
+	// guard: a Dispatch that returned just before an invalidate fires
+	// must not resurrect the lease. Read lock-free by generation();
+	// written only under writeMu.
+	gen atomic.Uint64
 }
 
 // valid reports whether the lease is unexpired at now.
@@ -93,11 +95,11 @@ func (s *leaseState) valid(now monoclock.Instant) bool {
 	if s == nil || now.IsZero() {
 		return false
 	}
-	slot := s.current.Load()
-	if slot == nil || slot.expiryNanos == 0 {
+	expiry := s.expiryNanos.Load()
+	if expiry == 0 {
 		return false
 	}
-	return now.Before(monoclock.FromNanos(slot.expiryNanos))
+	return now.Before(monoclock.FromNanos(expiry))
 }
 
 // generation returns the current invalidation counter. Callers MUST
@@ -110,7 +112,7 @@ func (s *leaseState) generation() uint64 {
 	if s == nil {
 		return 0
 	}
-	return slotOrZero(s.current.Load()).gen
+	return s.gen.Load()
 }
 
 // extend sets the lease expiry to until iff (a) until is strictly
@@ -118,12 +120,13 @@ func (s *leaseState) generation() uint64 {
 // (b) no invalidate has happened since the caller captured
 // expectedGen via generation() BEFORE the quorum operation.
 //
-// Pointer-identity CAS guards the rollback: after a racing
-// invalidate fires, the rollback clears ONLY the exact *leaseSlot
-// this extender installed, so a concurrent extender that captured
-// the post-invalidate generation and computed the same expiry value
-// (clock-granularity tie) cannot be clobbered -- its slot is a
-// distinct allocation with a distinct pointer.
+// The generation recheck under writeMu is the leader-loss guard: an
+// invalidate that fired DURING the quorum operation has bumped gen, so
+// the captured expectedGen no longer matches and the extend is dropped
+// before it can resurrect a lease the leadership-loss callback just
+// cleared. Because extend and invalidate are mutually exclusive on
+// writeMu, no post-write rollback is needed: an invalidate cannot land
+// between the generation recheck and the expiry store.
 func (s *leaseState) extend(until monoclock.Instant, expectedGen uint64) {
 	if s == nil {
 		return
@@ -131,59 +134,46 @@ func (s *leaseState) extend(until monoclock.Instant, expectedGen uint64) {
 	target := until.Nanos()
 	if target == 0 {
 		// Refuse to store 0 -- that value is the sentinel for "no
-		// lease" and would race with invalidate's zero-store.
+		// lease" and would be indistinguishable from invalidate's
+		// zero-store.
 		return
 	}
-	for {
-		// Load the live pointer once per iteration; all decisions
-		// below are based on THIS observation. The CAS old-value
-		// must match this exact pointer.
-		stored := s.current.Load()
-		old := slotOrZero(stored)
-		// Pre-CAS gate: if invalidate already advanced the generation
-		// past expectedGen, skip the CAS entirely.
-		if old.gen != expectedGen {
-			return
-		}
-		if old.expiryNanos != 0 && target <= old.expiryNanos {
-			return
-		}
-		next := &leaseSlot{expiryNanos: target, gen: expectedGen}
-		if !s.current.CompareAndSwap(stored, next) {
-			continue
-		}
-		// CAS landed. If invalidate raced in between the pre-CAS
-		// gate and the CAS itself, the current gen now exceeds
-		// expectedGen; undo our write via a pointer-identity CAS on
-		// `next`. A later writer (concurrent extender, concurrent
-		// invalidate) that already replaced `next` with its own
-		// allocation owns the state; its pointer differs from
-		// `next`, our CAS fails, and we leave its value intact --
-		// EVEN IF its expiryNanos equals our target.
-		if observed := slotOrZero(s.current.Load()); observed.gen != expectedGen {
-			rb := &leaseSlot{expiryNanos: 0, gen: observed.gen}
-			s.current.CompareAndSwap(next, rb)
-		}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	// Generation guard: an invalidate since expectedGen was captured
+	// means a leader-loss callback fired during the quorum op; refuse
+	// to resurrect the lease.
+	if s.gen.Load() != expectedGen {
 		return
 	}
+	// Monotonicity: never regress a lease. An out-of-order writer that
+	// sampled monoclock.Now() earlier must not shorten a freshly
+	// extended lease and force callers onto the slow path while the
+	// leader is still confirmed.
+	cur := s.expiryNanos.Load()
+	if cur != 0 && target <= cur {
+		return
+	}
+	s.expiryNanos.Store(target)
 }
 
-// invalidate clears the lease so the next read takes the slow path.
-// Each call installs a fresh zero-expiry slot whose gen is one more
-// than the current slot's, via CAS retry. A concurrent extender that
-// captured the pre-invalidate generation will see the advanced gen
-// on its post-CAS recheck and roll back its own slot via pointer-
-// identity CAS.
+// invalidate clears the lease so the next read takes the slow path and
+// bumps the generation so a concurrent extender that captured the
+// pre-invalidate generation cannot resurrect the lease. The store of
+// the zero sentinel is unconditional, even when the current expiry is
+// in the future: otherwise leadership-loss callbacks would be powerless
+// once a lease is in place.
+//
+// extend serializes on writeMu so the two never interleave: an extend
+// either runs fully before this invalidate (and is then cleared here) or
+// fully after (and observes the bumped generation via its guard and is
+// dropped).
 func (s *leaseState) invalidate() {
 	if s == nil {
 		return
 	}
-	for {
-		stored := s.current.Load()
-		old := slotOrZero(stored)
-		next := &leaseSlot{expiryNanos: 0, gen: old.gen + 1}
-		if s.current.CompareAndSwap(stored, next) {
-			return
-		}
-	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	s.gen.Add(1)
+	s.expiryNanos.Store(0)
 }

--- a/kv/lease_state.go
+++ b/kv/lease_state.go
@@ -164,16 +164,41 @@ func (s *leaseState) extend(until monoclock.Instant, expectedGen uint64) {
 // in the future: otherwise leadership-loss callbacks would be powerless
 // once a lease is in place.
 //
+// Store order matters for the lock-free reader. valid() reads only
+// expiryNanos; generation() reads only gen. Clearing the expiry BEFORE
+// bumping the generation guarantees that the fast-path guard (valid())
+// fails closed at least as early as the generation bump becomes visible.
+// If the generation were bumped first, a reader that loaded gen and then
+// loaded expiryNanos in the window before the zero-store landed could
+// observe "new generation, old (still valid) expiry" and serve a
+// fast-path read after leadership loss was already detected. With the
+// expiry cleared first, once any reader can observe the post-invalidate
+// generation it can also observe the cleared expiry, so the fast path is
+// never served past the point invalidation began.
+//
 // extend serializes on writeMu so the two never interleave: an extend
 // either runs fully before this invalidate (and is then cleared here) or
 // fully after (and observes the bumped generation via its guard and is
-// dropped).
+// dropped). The intra-invalidate store order is invisible to a
+// mutex-serialized extend, so reordering does not weaken the extend
+// generation guard.
 func (s *leaseState) invalidate() {
 	if s == nil {
 		return
 	}
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
-	s.gen.Add(1)
 	s.expiryNanos.Store(0)
+	if onInvalidateBetweenStores != nil {
+		onInvalidateBetweenStores()
+	}
+	s.gen.Add(1)
 }
+
+// onInvalidateBetweenStores is a test-only hook invoked inside
+// invalidate() after the expiry has been cleared but before the
+// generation is bumped. It exists to make the intra-invalidate store
+// ordering deterministically observable so the fail-closed invariant can
+// be regression-tested; it is nil in production and adds a single
+// predictable-branch nil check to the once-per-leadership-change path.
+var onInvalidateBetweenStores func()

--- a/kv/lease_state_test.go
+++ b/kv/lease_state_test.go
@@ -161,96 +161,78 @@ func TestLeaseState_ExtendWithFreshGenSucceedsAfterInvalidate(t *testing.T) {
 	require.True(t, s.valid(now))
 }
 
-// TestLeaseState_RollbackCASUsesPointerIdentity pins the codex-P3
-// invariant: when a stale extender rolls back after a racing
-// invalidate, its rollback CAS must be gated on pointer identity, NOT
-// on the expiry-nanos value. A value-gated CAS could clobber a fresh
-// lease installed by a concurrent extender that (due to clock-
-// granularity ties) computed the same expiry.
+// TestLeaseState_StaleExtendCannotClobberFreshLeaseSameExpiry pins the
+// invariant that a stale-generation extend (a Dispatch that captured the
+// pre-invalidate generation) must never clobber a fresh lease installed
+// at a newer generation, even when both compute the SAME expiry value
+// because their monoclock samples collided at clock granularity. The
+// generation guard, not the expiry value, is what disambiguates the two
+// writers: extend stores only when its captured generation still
+// matches the live one.
 //
 // Scenario:
-//  1. Extender A captures genA = 0 and installs slot{target, gen=0}.
-//  2. invalidate fires, bumping the live slot to gen=1 with zero
-//     expiry. A's post-CAS gen check now MUST see the mismatch and
-//     attempt a rollback.
-//  3. A concurrent extender B captures genB = 1 and installs a FRESH
-//     *leaseSlot{target, gen=1} -- same target value, distinct
-//     allocation.
-//  4. A's rollback CAS runs LAST. A value-gated CAS (old impl
-//     expiryNanos.CompareAndSwap(target, 0)) would erase B's
-//     still-valid lease. A pointer-gated CAS (new impl
-//     current.CompareAndSwap(aSlot, rb)) fails because the live
-//     pointer is B's allocation, preserving B's lease.
-//
-// Simulated step-by-step (no goroutines) against internal state so
-// the ordering is deterministic. Without the fix this test fails:
-// s.valid(now) observes the rolled-back zero-expiry slot.
-func TestLeaseState_RollbackCASUsesPointerIdentity(t *testing.T) {
+//  1. Extender A captures genA = 0 (BEFORE its quorum op).
+//  2. invalidate fires (leader-loss callback), bumping gen to 1 and
+//     clearing the expiry.
+//  3. A concurrent extender B captures genB = 1 (after invalidate) and
+//     installs a fresh lease with target T.
+//  4. A's delayed extend(T, genA=0) runs LAST with the SAME target T.
+//     It must be dropped by the generation guard, leaving B's lease
+//     untouched.
+func TestLeaseState_StaleExtendCannotClobberFreshLeaseSameExpiry(t *testing.T) {
 	t.Parallel()
 	var s leaseState
 	now := monoclock.Now()
 	target := now.Add(time.Hour)
-	targetNanos := target.Nanos()
 
-	// Step 1: simulate A's CAS having already landed.
-	aSlot := &leaseSlot{expiryNanos: targetNanos, gen: 0}
-	s.current.Store(aSlot)
+	// Step 1: A captures the pre-invalidate generation.
+	genA := s.generation()
 
-	// Step 2: invalidate races in. It CAS-replaces aSlot with a
-	// zero-expiry slot at gen=1.
+	// Step 2: leader-loss invalidate fires during A's quorum op.
 	s.invalidate()
-	require.Equal(t, uint64(1), s.generation())
+	require.NotEqual(t, genA, s.generation(), "invalidate must bump the generation")
 
-	// Step 3: concurrent extender B captures genB=1 (post-invalidate)
-	// and installs a distinct *leaseSlot with the same target value.
-	// This exercises the clock-granularity tie.
-	bSlot := &leaseSlot{expiryNanos: targetNanos, gen: 1}
-	bOld := s.current.Load()
-	require.True(t, s.current.CompareAndSwap(bOld, bSlot),
-		"B's CAS install must succeed in this simulated ordering")
+	// Step 3: B captures the post-invalidate generation and installs a
+	// fresh lease with the exact same target value A will compute.
+	genB := s.generation()
+	s.extend(target, genB)
 	require.True(t, s.valid(now), "B's fresh lease must be valid")
+	expiryAfterB := s.expiryNanos.Load()
 
-	// Step 4: A's delayed rollback runs. The fix is that rollback is
-	// pointer-identity CAS on aSlot, which fails here because the
-	// live pointer is bSlot (even though bSlot.expiryNanos equals
-	// aSlot.expiryNanos).
-	rb := &leaseSlot{expiryNanos: 0, gen: 1}
-	swapped := s.current.CompareAndSwap(aSlot, rb)
-	require.False(t, swapped,
-		"pointer-identity rollback must NOT clobber a fresh lease that happened to compute the same expiry value")
+	// Step 4: A's delayed extend with the stale generation and the same
+	// target. The generation guard must drop it.
+	s.extend(target, genA)
 
-	// Invariant: B's lease is still live.
 	require.True(t, s.valid(now),
-		"fresh lease with matching expiry must survive a stale extender's rollback")
-	require.Equal(t, bSlot, s.current.Load(),
-		"live slot must still be B's allocation, unchanged")
+		"fresh lease with matching expiry must survive a stale extender's write")
+	require.Equal(t, expiryAfterB, s.expiryNanos.Load(),
+		"stale-generation extend must not overwrite the live expiry, even with an equal value")
 }
 
-// TestLeaseState_RollbackCASClearsOwnSlot is the positive control:
-// when NO concurrent extender has replaced A's slot, A's rollback
-// DOES clear it (because the live pointer is still aSlot). Exercises
-// the happy path for the rollback branch inside extend.
-func TestLeaseState_RollbackCASClearsOwnSlot(t *testing.T) {
+// TestLeaseState_StaleExtendAfterInvalidateIsNoop is the negative
+// control: when a stale-generation extend races an invalidate and NO
+// concurrent fresh extender re-warms the lease, the lease stays cleared.
+// A re-entered caller that captures the post-invalidate generation can
+// then warm and clear it normally.
+func TestLeaseState_StaleExtendAfterInvalidateIsNoop(t *testing.T) {
 	t.Parallel()
 	var s leaseState
 	now := monoclock.Now()
 
 	// Caller pattern: sample generation, then quorum op races with
-	// invalidate, then extend. extend sees the gen advance in its
-	// post-CAS recheck and rolls back its own freshly-installed slot.
+	// invalidate, then extend with the now-stale generation.
 	expectedGen := s.generation()
 	s.invalidate() // concurrent leader-loss during the quorum op
 
-	// extend with the pre-invalidate generation. Internal flow:
-	// pre-CAS gate observes gen mismatch and returns WITHOUT
-	// installing any slot. The invalidate's zero-slot remains.
+	// extend with the pre-invalidate generation: the guard sees the
+	// mismatch and drops the write. The invalidate's cleared state
+	// remains.
 	s.extend(now.Add(time.Hour), expectedGen)
 	require.False(t, s.valid(now),
 		"pre-invalidate extend must not resurrect the lease")
 
-	// Separately, run the actual extend race: sample a FRESH gen
-	// (simulating a caller that re-entered after invalidate), install
-	// a lease, then invalidate, then verify clearing.
+	// A re-entered caller samples a FRESH generation, warms the lease,
+	// then a later invalidate clears it.
 	freshGen := s.generation()
 	s.extend(now.Add(time.Hour), freshGen)
 	require.True(t, s.valid(now))
@@ -299,4 +281,37 @@ func TestLeaseState_ConcurrentExtendAndRead(t *testing.T) {
 	close(stop)
 	<-done
 	<-done
+}
+
+// BenchmarkLeaseStateExtend pins the zero-allocation acceptance
+// criterion for the write path. Every successful extend installs a new
+// expiry; the int64-atomic layout must not heap-allocate (the previous
+// pointer-swap design allocated one slot per call, 1:1 with Dispatch
+// throughput). Run with -benchmem; allocs/op MUST be 0.
+//
+// Each iteration advances the target by 1ns so the monotonic gate
+// always takes the store branch (the worst case for allocation), rather
+// than short-circuiting on a non-increasing target.
+func BenchmarkLeaseStateExtend(b *testing.B) {
+	var s leaseState
+	base := monoclock.Now()
+	gen := s.generation()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.extend(base.Add(time.Duration(i+1)), gen)
+	}
+}
+
+// BenchmarkLeaseStateValid pins the hot read path: a single atomic load
+// and comparison, zero allocations.
+func BenchmarkLeaseStateValid(b *testing.B) {
+	var s leaseState
+	now := monoclock.Now()
+	s.extend(now.Add(time.Hour), s.generation())
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = s.valid(now)
+	}
 }

--- a/kv/lease_state_test.go
+++ b/kv/lease_state_test.go
@@ -241,6 +241,54 @@ func TestLeaseState_StaleExtendAfterInvalidateIsNoop(t *testing.T) {
 		"invalidate after a successful extend must clear the lease")
 }
 
+// TestLeaseState_InvalidateClearsExpiryBeforeBumpingGen pins the store
+// ordering inside invalidate(): the expiry sentinel must be cleared
+// BEFORE the generation is bumped. valid() reads only expiryNanos and
+// generation() reads only gen, so if the generation were bumped first a
+// reader could observe the post-invalidate generation together with the
+// still-valid old expiry and serve a fast-path read after leadership
+// loss was already detected.
+//
+// The intra-invalidate hook fires after the expiry store but before the
+// generation bump; with the correct ordering valid() must already report
+// false at that point. With the buggy ordering (gen bumped first) the
+// hook would observe a still-valid lease and the assertion fails.
+func TestLeaseState_InvalidateClearsExpiryBeforeBumpingGen(t *testing.T) {
+	// Not parallel: mutates the package-level onInvalidateBetweenStores
+	// hook.
+	var s leaseState
+	now := monoclock.Now()
+	s.extend(now.Add(time.Hour), s.generation())
+	require.True(t, s.valid(now), "sanity: warmed lease is valid before invalidate")
+
+	genBefore := s.generation()
+
+	var (
+		validInWindow bool
+		genInWindow   uint64
+		hookFired     bool
+	)
+	onInvalidateBetweenStores = func() {
+		hookFired = true
+		// At this point invalidate() has cleared the expiry but has not
+		// yet bumped the generation. A lock-free reader interleaving here
+		// must already see the lease as invalid.
+		validInWindow = s.valid(now)
+		genInWindow = s.generation()
+	}
+	t.Cleanup(func() { onInvalidateBetweenStores = nil })
+
+	s.invalidate()
+
+	require.True(t, hookFired, "intra-invalidate hook must fire")
+	require.False(t, validInWindow,
+		"expiry must be cleared before the generation bump so valid() fails closed as early as the gen bump")
+	require.Equal(t, genBefore, genInWindow,
+		"generation must not be bumped before the expiry is cleared")
+	require.False(t, s.valid(now), "lease stays invalid after invalidate completes")
+	require.NotEqual(t, genBefore, s.generation(), "invalidate must bump the generation")
+}
+
 func TestLeaseState_ConcurrentExtendAndRead(t *testing.T) {
 	t.Parallel()
 	var s leaseState


### PR DESCRIPTION
Closes #554.

## Behavior change

`leaseState` no longer heap-allocates on the lease write path. The expiry is now stored as a single `atomic.Int64` of monotonic-raw nanoseconds and the invalidation generation as a single `atomic.Uint64`, replacing the `atomic.Pointer[leaseSlot]` whose every successful `extend` allocated a fresh `*leaseSlot`. That allocation was 1:1 with Dispatch throughput (issue #554: ~50k allocs/s at 50k Dispatch/s) and a matching GC source.

All externally observable lease semantics are preserved:

- `valid(now)` boundary unchanged: `now.Before(expiry)` (strict / exclusive at the expiry instant), zero-expiry treated as "no lease", zero `now` fails closed.
- `extend` monotonicity unchanged: a shorter target never regresses a longer live lease.
- Generation guard unchanged: an `extend` carrying a generation captured before a racing `invalidate` is dropped, so a leader-loss callback cannot be resurrected.
- `invalidate` still clears unconditionally and bumps the generation.
- Nil-receiver and zero-value `leaseState` behavior unchanged.

The method signatures (`valid`, `generation`, `extend`, `invalidate`) are byte-for-byte identical, so the callers in `kv/coordinator.go` and `kv/sharded_coordinator.go` are untouched.

## Clock-source decision (called out explicitly)

The issue offered two directions for the expiry value:

1. `time.Now().UnixNano()` (wall clock) — zero alloc but **loses Go's monotonic-clock comparison**: a backward NTP step prematurely expires the lease (safe), a forward step extends it past its true safety window (**unsafe**).
2. A monotonic source (`runtime.nanotime` / `CLOCK_MONOTONIC_RAW`) — zero alloc **and** step-immune, avoiding the caveat entirely.

This PR takes **option 2**, and in fact the repo already adopted `CLOCK_MONOTONIC_RAW` via `internal/monoclock` (PR #551, which landed after #554 was filed). `expiryNanos` stores `monoclock.Instant.Nanos()` and `valid()` compares it against a caller-supplied `monoclock.Now()`. Both endpoints share the same arbitrary monotonic-raw zero point, so the lease-vs-safety-window comparison is immune to NTP rate adjustment **and** wall-clock step events — strictly stronger than `time.Now().UnixNano()` and with no allocation. The wall-clock dependency the issue asked to document is captured in a code comment on `leaseState` (constraint stated as an invariant, no PR/issue reference): both the stored expiry and the `now` passed to `valid()` must originate from monoclock; mixing in `time.Now()`-derived nanoseconds would reintroduce the NTP-step hazard.

So the only outstanding part of #554 was the per-`extend` `*leaseSlot` allocation, which this PR removes.

## Concurrency design

`valid()` (the hot path, one per read) stays lock-free: a single atomic load of `expiryNanos` and a comparison. `extend` and `invalidate` (one per Dispatch / leadership change, not per read) serialize on a writer-only `sync.Mutex`, so their two-field `(gen, expiry)` updates appear atomic to each other without needing a 128-bit CAS and without the post-write rollback dance a lock-free two-atomic scheme would require. Because writers are mutually exclusive, an `extend` and an `invalidate` can never interleave: the `extend` either runs fully before the `invalidate` (and is then cleared) or fully after (and is dropped by the generation guard). Readers never take the mutex.

This replaces the previous pointer-identity rollback machinery (the clock-granularity-tie disambiguation): with serialized writers there is no rollback, so the value-clobber hazard that machinery guarded cannot occur. The test that pinned the pointer-identity invariant is replaced by one pinning the same observable safety property (`TestLeaseState_StaleExtendCannotClobberFreshLeaseSameExpiry`).

## Risk

- Adds a `sync.Mutex` on the lease write paths. These run once per Dispatch (already gated by Raft consensus) / once per leadership change, not on the per-read hot path. The critical section is two atomic stores. Lock contention is negligible relative to the consensus round-trip; the read hot path is unaffected.
- The clock-source choice is the load-bearing safety decision. monoclock (CLOCK_MONOTONIC_RAW) preserves the existing step-immune behavior; no wall-clock regression is introduced.

## Test evidence

`go test -race -run 'TestLeaseState|TestIsLeadershipLossError' ./kv/`:

```
ok  	github.com/bootjp/elastickv/kv	1.094s
```

Full package, `go test -race ./kv/...`:

```
ok  	github.com/bootjp/elastickv/kv	10.721s
```

`golangci-lint --config=.golangci.yaml run ./kv/...`:

```
0 issues.
```

Benchmark, `go test -run='^$' -bench='BenchmarkLeaseState' -benchmem ./kv/`:

```
goos: darwin
goarch: arm64
pkg: github.com/bootjp/elastickv/kv
cpu: Apple M1 Max
BenchmarkLeaseStateExtend-10    	79673116	        14.65 ns/op	       0 B/op	       0 allocs/op
BenchmarkLeaseStateValid-10     	1000000000	         0.5511 ns/op	       0 B/op	       0 allocs/op
```

Before this change the same `extend` benchmark measured `23.08 ns/op  16 B/op  1 allocs/op`. Acceptance criterion (0 allocs/op) met; `extend` is also ~37% faster.

Per-PR Jepsen CI covers the lease-read window (DynamoDB / Redis workloads), which is the integration-level safety net for this path.

## Self-review

1. **Data loss** — No persistence path touched. The lease is leader-local, in-memory, advisory fast-path state; it gates whether a read takes the fast or slow (LinearizableRead) path but never affects what is written or committed. A lost/cleared lease only downgrades to the slow path (safe). No FSM, Raft, Pebble, or snapshot semantics change.
2. **Concurrency / distributed failures** — Writers serialize on `writeMu`; readers are lock-free single-atomic. Eliminates the extend/invalidate interleave the old design handled via pointer-identity rollback (the interleave can no longer occur). Generation guard preserved, so leader-loss invalidation still beats a racing stale extend. Verified with `go test -race` on the full `kv` package, including the concurrent extend/read test.
3. **Performance** — Removes the per-`extend` 16 B heap allocation (0 allocs/op, confirmed by benchmark); read path stays lock-free at 0.55 ns/op. New writer mutex critical section is two atomic stores, off the read hot path and dwarfed by the consensus round-trip that precedes every extend.
4. **Data consistency** — Lease validity boundary, monotonic-extend rule, zero/sentinel handling, and the monotonic-raw clock source are all preserved, so the lease-read freshness bound is unchanged. Reads still go through the leader-issued read pipeline; nothing here bypasses `HLC.Next()` or the read-timestamp path.
5. **Test coverage** — All existing lease tests retained and passing. Replaced the implementation-internal pointer-identity test with `TestLeaseState_StaleExtendCannotClobberFreshLeaseSameExpiry` (same observable invariant against the new internals) and `TestLeaseState_StaleExtendAfterInvalidateIsNoop`. Added `BenchmarkLeaseStateExtend` (the acceptance criterion, 0 allocs/op) and `BenchmarkLeaseStateValid`.
