### PR TITLE
perf(lease-read): background lease warm-up via HLC renewal proposes

### DIFF
--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -644,11 +644,22 @@ func (c *Coordinate) Clock() *HLC {
 // stale lease. This is the background warm-up that flattens the
 // read-only lease-expiry sawtooth on idle-write workloads -- no extra
 // goroutine, no change to the lease window/duration semantics.
+//
+// On a leadership-loss propose error the lease is invalidated eagerly,
+// mirroring refreshLeaseAfterDispatch's error branch exactly: when
+// Propose returns the loss before the async RegisterLeaderLossCallback
+// fires, a stale-warm lease must not survive on a non-leader node for
+// the callback latency window. Non-leadership errors (no quorum,
+// validation) are NOT leadership signals and must not tear down a warm
+// lease -- doing so would force every read onto the slow path.
 func (c *Coordinate) ProposeHLCLease(ctx context.Context, ceilingMs int64) error {
 	dispatchStart := monoclock.Now()
 	expectedGen := c.lease.generation()
 	_, err := c.engine.Propose(ctx, marshalHLCLeaseRenew(ceilingMs))
 	if err != nil {
+		if isLeadershipLossError(err) {
+			c.lease.invalidate()
+		}
 		return errors.WithStack(err)
 	}
 	c.extendLeaseAfterRenewal(dispatchStart, expectedGen)

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -633,9 +633,42 @@ func (c *Coordinate) Clock() *HLC {
 // ProposeHLCLease proposes a new physical ceiling to the Raft cluster.
 // Only the current leader should call this; followers silently ignore
 // proposals from non-leaders via Raft's leader-only write guarantee.
+//
+// A successful propose is a quorum-acked Raft commit, exactly the same
+// confirmation Dispatch relies on, so it also warms the leader-local
+// read lease. The lease-extension base (dispatchStart) and the
+// invalidation generation are sampled BEFORE the propose, mirroring
+// refreshLeaseAfterDispatch: the window can only ever be SHORTER than
+// the true safety window, and a leader-loss callback that fires during
+// the propose advances the generation so extend refuses to resurrect a
+// stale lease. This is the background warm-up that flattens the
+// read-only lease-expiry sawtooth on idle-write workloads -- no extra
+// goroutine, no change to the lease window/duration semantics.
 func (c *Coordinate) ProposeHLCLease(ctx context.Context, ceilingMs int64) error {
+	dispatchStart := monoclock.Now()
+	expectedGen := c.lease.generation()
 	_, err := c.engine.Propose(ctx, marshalHLCLeaseRenew(ceilingMs))
-	return errors.WithStack(err)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	c.extendLeaseAfterRenewal(dispatchStart, expectedGen)
+	return nil
+}
+
+// extendLeaseAfterRenewal warms the read lease after a successful HLC
+// ceiling propose. It is the renewal-path counterpart of
+// refreshLeaseAfterDispatch's success branch: the propose was a
+// quorum-acked commit, so the lease can be extended by LeaseDuration
+// measured from dispatchStart (sampled before the propose). extend
+// rejects the refresh if expectedGen no longer matches -- i.e. a
+// leader-loss invalidation raced the propose -- so a node that stopped
+// being leader during the propose cannot widen its lease-read window.
+func (c *Coordinate) extendLeaseAfterRenewal(dispatchStart monoclock.Instant, expectedGen uint64) {
+	lp, ok := c.engine.(raftengine.LeaseProvider)
+	if !ok {
+		return
+	}
+	c.lease.extend(dispatchStart.Add(lp.LeaseDuration()), expectedGen)
 }
 
 // RunHLCLeaseRenewal runs a background loop that periodically proposes a new

--- a/kv/lease_read_test.go
+++ b/kv/lease_read_test.go
@@ -21,6 +21,9 @@ type fakeLeaseEngine struct {
 	leaseDur                 time.Duration
 	linearizableErr          error
 	linearizableCalls        atomic.Int32
+	proposeErr               error // when set, Propose returns it (warm-up failure tests)
+	proposeCalls             atomic.Int32
+	proposeHook              func()       // invoked inside Propose before returning (race injection)
 	state                    atomic.Value // stores raftengine.State; default Leader
 	lastQuorumAckMonoNs      atomic.Int64 // 0 = no ack yet. Updated by setQuorumAck().
 	leaderLossCallbacksMu    sync.Mutex
@@ -60,6 +63,13 @@ func (e *fakeLeaseEngine) Configuration(context.Context) (raftengine.Configurati
 	return raftengine.Configuration{}, nil
 }
 func (e *fakeLeaseEngine) Propose(context.Context, []byte) (*raftengine.ProposalResult, error) {
+	e.proposeCalls.Add(1)
+	if e.proposeHook != nil {
+		e.proposeHook()
+	}
+	if e.proposeErr != nil {
+		return nil, e.proposeErr
+	}
 	return &raftengine.ProposalResult{}, nil
 }
 func (e *fakeLeaseEngine) ProposeAdmin(ctx context.Context, data []byte) (*raftengine.ProposalResult, error) {

--- a/kv/lease_warmup_test.go
+++ b/kv/lease_warmup_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/bootjp/elastickv/internal/monoclock"
+	"github.com/bootjp/elastickv/internal/raftengine"
 	"github.com/stretchr/testify/require"
 )
 
@@ -58,6 +59,52 @@ func TestCoordinate_ProposeHLCLease_FailedProposeDoesNotWarmLease(t *testing.T) 
 	require.NoError(t, err)
 	require.Equal(t, int32(1), eng.linearizableCalls.Load(),
 		"cold lease after a failed renewal must fall through to LinearizableRead")
+}
+
+// TestCoordinate_ProposeHLCLease_LeadershipLossErrorInvalidatesLease is
+// the SEQUENTIAL leadership-loss case (distinct from the concurrent
+// proposeHook race below). When Propose itself returns a
+// leadership-loss error -- this node lost leadership BEFORE the propose
+// completed, before any async RegisterLeaderLossCallback could fire --
+// the warm-up path must EAGERLY invalidate an already-warm lease, so no
+// stale-warm lease survives on a non-leader node for the callback
+// latency window. This is the exact-parity guarantee with
+// refreshLeaseAfterDispatch's leadership-loss branch.
+func TestCoordinate_ProposeHLCLease_LeadershipLossErrorInvalidatesLease(t *testing.T) {
+	t.Parallel()
+	eng := &fakeLeaseEngine{applied: 11, leaseDur: time.Hour}
+	c := NewCoordinatorWithEngine(nil, eng)
+
+	// Warm the lease so a regression (no eager invalidation) leaves it
+	// valid -- the assertion below would then fail.
+	require.NoError(t, c.ProposeHLCLease(context.Background(), time.Now().UnixMilli()+hlcPhysicalWindowMs))
+	require.True(t, c.lease.valid(monoclock.Now()), "precondition: lease must be warm")
+
+	// Next propose loses leadership before completing.
+	eng.proposeErr = raftengine.ErrNotLeader
+	err := c.ProposeHLCLease(context.Background(), time.Now().UnixMilli()+hlcPhysicalWindowMs)
+	require.ErrorIs(t, err, raftengine.ErrNotLeader)
+	require.False(t, c.lease.valid(monoclock.Now()),
+		"a leadership-loss propose error must EAGERLY invalidate the warm lease")
+}
+
+// TestCoordinate_ProposeHLCLease_NonLeadershipErrorKeepsLease proves the
+// invalidation is narrow: a non-leadership propose failure (e.g. no
+// quorum) must NOT tear down an already-warm lease, otherwise every
+// subsequent read would be forced onto the slow LinearizableRead path.
+func TestCoordinate_ProposeHLCLease_NonLeadershipErrorKeepsLease(t *testing.T) {
+	t.Parallel()
+	eng := &fakeLeaseEngine{applied: 11, leaseDur: time.Hour}
+	c := NewCoordinatorWithEngine(nil, eng)
+
+	require.NoError(t, c.ProposeHLCLease(context.Background(), time.Now().UnixMilli()+hlcPhysicalWindowMs))
+	require.True(t, c.lease.valid(monoclock.Now()), "precondition: lease must be warm")
+
+	eng.proposeErr = errors.New("propose rejected: no quorum")
+	err := c.ProposeHLCLease(context.Background(), time.Now().UnixMilli()+hlcPhysicalWindowMs)
+	require.Error(t, err)
+	require.True(t, c.lease.valid(monoclock.Now()),
+		"a non-leadership propose error must NOT invalidate the warm lease")
 }
 
 // TestCoordinate_ProposeHLCLease_LeaderLossDuringProposeDoesNotWarmLease
@@ -139,6 +186,46 @@ func TestShardedCoordinator_RenewHLCLease_FailedProposeDoesNotWarmLease(t *testi
 	require.NoError(t, err)
 	require.Equal(t, int32(1), eng1.linearizableCalls.Load(),
 		"cold default-group lease after a failed renewal must fall through to LinearizableRead")
+}
+
+// TestShardedCoordinator_RenewHLCLease_LeadershipLossErrorInvalidatesLease
+// is the sharded counterpart of the sequential leadership-loss case: if
+// the default group's Propose returns a leadership-loss error, the
+// already-warm group lease must be eagerly invalidated, matching
+// leaseRefreshingTxn's leadership-loss branch on that same group.
+func TestShardedCoordinator_RenewHLCLease_LeadershipLossErrorInvalidatesLease(t *testing.T) {
+	t.Parallel()
+	eng1 := newShardedLeaseEngine(100)
+	eng2 := newShardedLeaseEngine(200)
+	coord := mustShardedLeaseCoord(t, eng1, eng2)
+	g1 := coord.groups[1]
+
+	coord.renewHLCLease(context.Background(), g1)
+	require.True(t, g1.lease.valid(monoclock.Now()), "precondition: default group lease must be warm")
+
+	eng1.proposeErr = raftengine.ErrNotLeader
+	coord.renewHLCLease(context.Background(), g1)
+	require.False(t, g1.lease.valid(monoclock.Now()),
+		"a leadership-loss propose error must EAGERLY invalidate the default group's warm lease")
+}
+
+// TestShardedCoordinator_RenewHLCLease_NonLeadershipErrorKeepsLease
+// proves the sharded invalidation is narrow: a non-leadership propose
+// failure must NOT tear down the already-warm default group lease.
+func TestShardedCoordinator_RenewHLCLease_NonLeadershipErrorKeepsLease(t *testing.T) {
+	t.Parallel()
+	eng1 := newShardedLeaseEngine(100)
+	eng2 := newShardedLeaseEngine(200)
+	coord := mustShardedLeaseCoord(t, eng1, eng2)
+	g1 := coord.groups[1]
+
+	coord.renewHLCLease(context.Background(), g1)
+	require.True(t, g1.lease.valid(monoclock.Now()), "precondition: default group lease must be warm")
+
+	eng1.proposeErr = errors.New("propose rejected: no quorum")
+	coord.renewHLCLease(context.Background(), g1)
+	require.True(t, g1.lease.valid(monoclock.Now()),
+		"a non-leadership propose error must NOT invalidate the default group's warm lease")
 }
 
 // TestShardedCoordinator_RenewHLCLease_LeaderLossDuringProposeDoesNotWarm

--- a/kv/lease_warmup_test.go
+++ b/kv/lease_warmup_test.go
@@ -1,0 +1,157 @@
+package kv
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/bootjp/elastickv/internal/monoclock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCoordinate_ProposeHLCLease_WarmsLease proves the background HLC
+// ceiling renewal also extends the read lease: after a single successful
+// ProposeHLCLease (no Dispatch, no LinearizableRead), the caller-side
+// lease must be valid so the next LeaseRead serves from the fast path.
+// This is the warm-up that flattens the read-only lease-expiry sawtooth.
+func TestCoordinate_ProposeHLCLease_WarmsLease(t *testing.T) {
+	t.Parallel()
+	eng := &fakeLeaseEngine{applied: 11, leaseDur: time.Hour}
+	c := NewCoordinatorWithEngine(nil, eng)
+
+	require.False(t, c.lease.valid(monoclock.Now()),
+		"lease must start cold so a fast-path hit is attributable to the renewal")
+
+	require.NoError(t, c.ProposeHLCLease(context.Background(), time.Now().UnixMilli()+hlcPhysicalWindowMs))
+	require.Equal(t, int32(1), eng.proposeCalls.Load())
+
+	require.True(t, c.lease.valid(monoclock.Now()),
+		"a successful HLC renewal propose must warm the read lease")
+
+	// The next LeaseRead must hit the warmed lease without a
+	// LinearizableRead round-trip.
+	idx, err := c.LeaseRead(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, uint64(11), idx)
+	require.Equal(t, int32(0), eng.linearizableCalls.Load(),
+		"warmed lease must serve the read without LinearizableRead")
+}
+
+// TestCoordinate_ProposeHLCLease_FailedProposeDoesNotWarmLease is the
+// CRITICAL safety case: a propose that fails (no quorum confirmation)
+// must NOT extend the lease, otherwise the lease-read freshness window
+// would widen on an unconfirmed renewal.
+func TestCoordinate_ProposeHLCLease_FailedProposeDoesNotWarmLease(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("propose rejected: no quorum")
+	eng := &fakeLeaseEngine{applied: 11, leaseDur: time.Hour, proposeErr: sentinel}
+	c := NewCoordinatorWithEngine(nil, eng)
+
+	err := c.ProposeHLCLease(context.Background(), time.Now().UnixMilli()+hlcPhysicalWindowMs)
+	require.ErrorIs(t, err, sentinel)
+	require.False(t, c.lease.valid(monoclock.Now()),
+		"a failed renewal propose must NOT warm the read lease")
+
+	// The next LeaseRead must still take the slow path.
+	_, err = c.LeaseRead(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int32(1), eng.linearizableCalls.Load(),
+		"cold lease after a failed renewal must fall through to LinearizableRead")
+}
+
+// TestCoordinate_ProposeHLCLease_LeaderLossDuringProposeDoesNotWarmLease
+// pins the generation guard: if a leader-loss callback fires DURING the
+// propose (between sampling the generation and the post-propose extend),
+// extend must observe the advanced generation and refuse to resurrect
+// the lease -- even though the propose itself "succeeded". This mirrors
+// the Dispatch hook's expectedGen-sampled-before-propose semantics.
+func TestCoordinate_ProposeHLCLease_LeaderLossDuringProposeDoesNotWarmLease(t *testing.T) {
+	t.Parallel()
+	eng := &fakeLeaseEngine{applied: 11, leaseDur: time.Hour}
+	c := NewCoordinatorWithEngine(nil, eng)
+	// Fire leader-loss inside the propose so the lease generation advances
+	// after ProposeHLCLease sampled it but before the extend.
+	eng.proposeHook = func() { eng.fireLeaderLoss() }
+
+	require.NoError(t, c.ProposeHLCLease(context.Background(), time.Now().UnixMilli()+hlcPhysicalWindowMs))
+	require.False(t, c.lease.valid(monoclock.Now()),
+		"a leader-loss racing the propose must prevent the lease warm-up")
+}
+
+// TestCoordinate_ProposeHLCLease_NoLeaseProviderNoPanic covers an engine
+// without LeaseProvider: the propose still succeeds and the lease is
+// simply never warmed (there is no lease infrastructure to warm).
+func TestCoordinate_ProposeHLCLease_NoLeaseProviderNoPanic(t *testing.T) {
+	t.Parallel()
+	eng := &nonLeaseEngine{}
+	c := NewCoordinatorWithEngine(nil, eng)
+
+	require.NoError(t, c.ProposeHLCLease(context.Background(), time.Now().UnixMilli()+hlcPhysicalWindowMs))
+	require.False(t, c.lease.valid(monoclock.Now()))
+}
+
+// TestShardedCoordinator_RenewHLCLease_WarmsDefaultGroupLease proves the
+// sharded renewal path warms the DEFAULT group's lease on a successful
+// propose, so LeaseReadForKey on a default-group key serves from the
+// fast path without a per-shard LinearizableRead.
+func TestShardedCoordinator_RenewHLCLease_WarmsDefaultGroupLease(t *testing.T) {
+	t.Parallel()
+	eng1 := newShardedLeaseEngine(100)
+	eng2 := newShardedLeaseEngine(200)
+	coord := mustShardedLeaseCoord(t, eng1, eng2)
+	// defaultGroup is 1 (see mustShardedLeaseCoord).
+	g1 := coord.groups[1]
+	require.False(t, g1.lease.valid(monoclock.Now()))
+
+	coord.renewHLCLease(context.Background(), g1)
+	require.Equal(t, int32(1), eng1.proposeCalls.Load())
+	require.True(t, g1.lease.valid(monoclock.Now()),
+		"a successful renewal propose must warm the default group's lease")
+
+	// LeaseReadForKey on a default-group key ("apple" -> group 1) now
+	// hits the warmed lease.
+	idx, err := coord.LeaseReadForKey(context.Background(), []byte("apple"))
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), idx)
+	require.Equal(t, int32(0), eng1.linearizableCalls.Load(),
+		"warmed default-group lease must serve the read without LinearizableRead")
+}
+
+// TestShardedCoordinator_RenewHLCLease_FailedProposeDoesNotWarmLease is
+// the sharded counterpart of the single-shard safety case: a failed
+// propose must leave the default group's lease cold.
+func TestShardedCoordinator_RenewHLCLease_FailedProposeDoesNotWarmLease(t *testing.T) {
+	t.Parallel()
+	eng1 := newShardedLeaseEngine(100)
+	eng2 := newShardedLeaseEngine(200)
+	eng1.proposeErr = errors.New("propose rejected: no quorum")
+	coord := mustShardedLeaseCoord(t, eng1, eng2)
+	g1 := coord.groups[1]
+
+	coord.renewHLCLease(context.Background(), g1)
+	require.Equal(t, int32(1), eng1.proposeCalls.Load())
+	require.False(t, g1.lease.valid(monoclock.Now()),
+		"a failed renewal propose must NOT warm the default group's lease")
+
+	// LeaseReadForKey on a default-group key must still take the slow path.
+	_, err := coord.LeaseReadForKey(context.Background(), []byte("apple"))
+	require.NoError(t, err)
+	require.Equal(t, int32(1), eng1.linearizableCalls.Load(),
+		"cold default-group lease after a failed renewal must fall through to LinearizableRead")
+}
+
+// TestShardedCoordinator_RenewHLCLease_LeaderLossDuringProposeDoesNotWarm
+// pins the generation guard for the sharded path.
+func TestShardedCoordinator_RenewHLCLease_LeaderLossDuringProposeDoesNotWarm(t *testing.T) {
+	t.Parallel()
+	eng1 := newShardedLeaseEngine(100)
+	eng2 := newShardedLeaseEngine(200)
+	coord := mustShardedLeaseCoord(t, eng1, eng2)
+	g1 := coord.groups[1]
+	eng1.proposeHook = func() { eng1.fireLeaderLoss() }
+
+	coord.renewHLCLease(context.Background(), g1)
+	require.False(t, g1.lease.valid(monoclock.Now()),
+		"a leader-loss racing the propose must prevent the default group's lease warm-up")
+}

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -1953,6 +1953,14 @@ func (c *ShardedCoordinator) RunHLCLeaseRenewal(ctx context.Context) {
 // This is the background warm-up that flattens the read-only
 // lease-expiry sawtooth for the default group on idle-write workloads;
 // the lease window/duration semantics are unchanged.
+//
+// On a leadership-loss propose error the group lease is invalidated
+// eagerly, mirroring leaseRefreshingTxn's error branch exactly: when
+// Propose returns the loss before the async RegisterLeaderLossCallback
+// fires, a stale-warm lease must not survive on a non-leader node for
+// the callback latency window. Non-leadership errors (no quorum,
+// validation) are NOT leadership signals and must not tear down a warm
+// lease -- doing so would force every read onto the slow path.
 func (c *ShardedCoordinator) renewHLCLease(ctx context.Context, group *ShardGroup) {
 	ceilingMs := time.Now().UnixMilli() + hlcPhysicalWindowMs
 	start := monoclock.Now()
@@ -1964,6 +1972,9 @@ func (c *ShardedCoordinator) renewHLCLease(ctx context.Context, group *ShardGrou
 	// cleartext and trip the §6.3 strict-> unwrap on every replica's
 	// apply loop (codex P2 round-1).
 	if _, err := group.Proposer().Propose(ctx, marshalHLCLeaseRenew(ceilingMs)); err != nil {
+		if isLeadershipLossError(err) {
+			group.lease.invalidate()
+		}
 		c.logger().WarnContext(ctx, "hlc lease renewal failed",
 			slog.Uint64("group_id", c.defaultGroup),
 			slog.Int64("ceiling_ms", ceilingMs),

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -1929,26 +1929,50 @@ func (c *ShardedCoordinator) RunHLCLeaseRenewal(ctx context.Context) {
 		select {
 		case <-timer.C:
 			if group.Engine.State() == raftengine.StateLeader {
-				ceilingMs := time.Now().UnixMilli() + hlcPhysicalWindowMs
-				// Route through the ShardGroup's wrap-aware proposer
-				// chain — NOT a direct group.Engine.Propose — so the
-				// Stage 6E-2c dynamic wrap applies. Without this, an
-				// HLC lease-renewal entry committed post-cutover at
-				// `index > raftEnvelopeCutoverIndex` would land
-				// cleartext and trip the §6.3 strict-> unwrap on
-				// every replica's apply loop (codex P2 round-1).
-				if _, err := group.Proposer().Propose(ctx, marshalHLCLeaseRenew(ceilingMs)); err != nil {
-					c.logger().WarnContext(ctx, "hlc lease renewal failed",
-						slog.Uint64("group_id", c.defaultGroup),
-						slog.Int64("ceiling_ms", ceilingMs),
-						slog.Any("err", err),
-					)
-				}
+				c.renewHLCLease(ctx, group)
 			}
 			timer.Reset(hlcRenewalInterval)
 		case <-ctx.Done():
 			return
 		}
+	}
+}
+
+// renewHLCLease proposes a fresh physical ceiling on the default shard
+// group and, on a successful (quorum-acked) propose, warms that group's
+// read lease.
+//
+// The lease-extension base (start) and the invalidation generation are
+// sampled BEFORE the propose so the warm-up mirrors leaseRefreshingTxn's
+// success branch exactly: the window can only be SHORTER than the true
+// safety window, and a leader-loss callback that fires during the
+// propose advances the generation so extend refuses to resurrect a
+// stale lease. The propose is the SAME quorum confirmation a client
+// write goes through, so warming on its success cannot widen the
+// lease-read freshness window beyond what a write on this group would.
+// This is the background warm-up that flattens the read-only
+// lease-expiry sawtooth for the default group on idle-write workloads;
+// the lease window/duration semantics are unchanged.
+func (c *ShardedCoordinator) renewHLCLease(ctx context.Context, group *ShardGroup) {
+	ceilingMs := time.Now().UnixMilli() + hlcPhysicalWindowMs
+	start := monoclock.Now()
+	expectedGen := group.lease.generation()
+	// Route through the ShardGroup's wrap-aware proposer chain — NOT a
+	// direct group.Engine.Propose — so the Stage 6E-2c dynamic wrap
+	// applies. Without this, an HLC lease-renewal entry committed
+	// post-cutover at `index > raftEnvelopeCutoverIndex` would land
+	// cleartext and trip the §6.3 strict-> unwrap on every replica's
+	// apply loop (codex P2 round-1).
+	if _, err := group.Proposer().Propose(ctx, marshalHLCLeaseRenew(ceilingMs)); err != nil {
+		c.logger().WarnContext(ctx, "hlc lease renewal failed",
+			slog.Uint64("group_id", c.defaultGroup),
+			slog.Int64("ceiling_ms", ceilingMs),
+			slog.Any("err", err),
+		)
+		return
+	}
+	if lp, ok := group.Engine.(raftengine.LeaseProvider); ok {
+		group.lease.extend(start.Add(lp.LeaseDuration()), expectedGen)
 	}
 }
 


### PR DESCRIPTION
## perf(lease-read): background lease warm-up via HLC renewal proposes

Closes #556 (deferred from #549).

### Behavior change
Pure-read workloads previously saw the leader-local read lease expire every `LeaseDuration` (700ms). The first read after each expiry fell back to a full `LinearizableRead`, producing a read-only latency sawtooth.

The leader already proposes a fresh HLC physical ceiling every `hlcRenewalInterval` (1s) while it stays leader, but that propose went straight to `engine.Propose` / `group.Proposer().Propose` without touching the read lease. This PR routes the renewal propose through the same lease-extend semantics the `Dispatch` hook uses, so the periodic ceiling renewal also warms the read lease. On an idle-write but read-heavy workload the lease is now refreshed roughly every 1s rather than only on writes, so reads stay on the fast path and the sawtooth flattens.

**No extra goroutine** (accepted direction "option 1"): the warm-up piggybacks on the existing `RunHLCLeaseRenewal` loops. **The lease window/duration semantics are unchanged** — only the refresh frequency for idle-write workloads improves.

Two paths are covered:
- Single-shard `Coordinate.ProposeHLCLease` (warms `c.lease`).
- `ShardedCoordinator` default-group renewal — extracted into `renewHLCLease`, warms the **default group's** `lease` (the only group whose quorum this propose actually confirms).

### Lease-extension safety (the load-bearing invariant)
Extending a lease on a failed or ambiguous propose would widen the lease-read freshness window incorrectly. The warm-up mirrors `refreshLeaseAfterDispatch` / `leaseRefreshingTxn.maybeRefresh` **exactly**:

1. **Extension base sampled BEFORE the propose** (`monoclock.Now()`, CLOCK_MONOTONIC_RAW). The lease is extended to `start.Add(LeaseDuration())`, so the warmed window can only ever be *shorter* than the true safety window, never longer.
2. **Invalidation generation sampled BEFORE the propose** (`lease.generation()`). If a leader-loss callback fires during the propose, `lease.extend` sees the advanced generation and refuses to resurrect the lease.
3. **Extend only on a successful propose.** `engine.Propose` returns success only on a quorum-acked Raft commit — the same confirmation `Dispatch` relies on. On error we log and return early without touching the lease.
4. **Leader-only.** Both renewal loops already gate the propose on `IsLeaderAcceptingWrites()` / `State()==StateLeader`; warming on a quorum-acked propose cannot widen the window beyond what a client write on that group would.

Because the propose is the identical quorum confirmation a write goes through, warming the lease from it carries no freshness penalty relative to the existing write-driven refresh.

### Potential merge conflict
PR #947 (`perf/lease-provider-assertion-cache`) caches an `lp raftengine.LeaseProvider` field on Coordinate/ShardGroup and touches `LeaseRead` / `refreshLeaseAfterDispatch`. This PR is based on `main` (without it). To keep the conflict surface minimal I left `refreshLeaseAfterDispatch` and `LeaseRead` untouched and added the warm-up in `ProposeHLCLease` (new helper `extendLeaseAfterRenewal`) and the new `renewHLCLease` helper. If #947 lands first, the only adjustment here is to reuse its cached `lp` field instead of the local `engine.(raftengine.LeaseProvider)` assertion in the two new helpers.

### Test evidence
- `go test -race ./kv/...` — PASS (12.4s).
- New targeted tests (`go test -race -run 'TestCoordinate_ProposeHLCLease|TestShardedCoordinator_RenewHLCLease' ./kv/...`) — PASS:
  - `TestCoordinate_ProposeHLCLease_WarmsLease` — a successful renewal propose alone (no Dispatch / no LinearizableRead) warms the lease and the next `LeaseRead` hits the fast path.
  - `TestCoordinate_ProposeHLCLease_FailedProposeDoesNotWarmLease` — a failed propose leaves the lease cold; next read takes the slow path.
  - `TestCoordinate_ProposeHLCLease_LeaderLossDuringProposeDoesNotWarmLease` — a leader-loss callback firing during the propose advances the generation; `extend` refuses to warm.
  - `TestCoordinate_ProposeHLCLease_NoLeaseProviderNoPanic` — engine without `LeaseProvider` proposes fine, never warms.
  - `TestShardedCoordinator_RenewHLCLease_WarmsDefaultGroupLease` / `_FailedProposeDoesNotWarmLease` / `_LeaderLossDuringProposeDoesNotWarm` — sharded counterparts.
- `golangci-lint --config=.golangci.yaml run ./kv/...` — 0 issues.

The acceptance metric (read-only workload <1% slow reads) is a CI/bench-level claim. Per the issue it is approximated here with the targeted warm-up unit tests rather than a load harness. The per-PR Jepsen CI exercises the lease window under partition/heal and leader churn, which is the integration-level safety net for the lease-read freshness bound.

### Self-review
1. **Data loss** — None. The change only extends an in-memory read lease after a confirmed Raft commit; it adds no FSM/apply/propose ordering, no new persistence, and does not alter what gets committed (the ceiling entry is byte-identical).
2. **Concurrency / distributed failures** — The generation-before-propose + pointer-identity CAS in `lease.extend` already guards the leader-loss race; the new call sites sample generation/base before the propose exactly as the Dispatch hook does, and a dedicated test fires leader-loss *inside* the propose. `go test -race ./kv/...` is clean.
3. **Performance** — Removes slow-path `LinearizableRead`s on idle-write read workloads; adds only a `monoclock.Now()` + atomic generation load + one `extend` CAS per 1s renewal tick. No hot-path or per-request cost, no extra Raft round-trip, no new goroutine.
4. **Data consistency** — Lease window/duration unchanged; the warmed window is bounded by `start (pre-propose) + LeaseDuration`, never wider than a write-driven refresh, and is gated on a quorum-acked propose while leader. The lease-read freshness bound is preserved.
5. **Test coverage** — Six new co-located unit tests cover both code paths × {success warms, failure does not warm, leader-loss race does not warm} plus the no-LeaseProvider fallback; full `kv` suite passes under `-race`.
