### PR TITLE
adapter: wrap DynamoDB query/scan/transactGetItems in LeaseRead

### DIFF
--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -2278,8 +2278,33 @@ func (d *DynamoDBServer) leaseCheckScan(w http.ResponseWriter, r *http.Request, 
 	if scanExclusiveStartKeyInvalid(schema, in) {
 		return true
 	}
+	// Same logic for a malformed ProjectionExpression: newReadPageState runs
+	// resolveProjectionAttributes before the iterator reads from the store, so a
+	// parse failure is a deterministic ValidationException the lease pre-pass
+	// must not mask (codex #952 P2 round-4 line 2346). validateGSIReadOptions
+	// already covers the GSI case; this catches the base-table path that the
+	// earlier ExclusiveStartKey check left exposed.
+	if projectionInvalid(in.ProjectionExpression, in.ExpressionAttributeNames) {
+		return true
+	}
 	// Valid whole-table read: fence every group (fail closed).
 	return d.leaseReadKeyless(w, r)
+}
+
+// projectionInvalid returns true when the ProjectionExpression cannot be
+// parsed against the given ExpressionAttributeNames. resolveProjectionAttributes
+// is the same validator newReadPageState runs before the iterator reads from
+// the store, so a true result means the read path WILL reject the request with
+// a deterministic ValidationException without touching data. Pre-pass uses
+// this to skip leasing in that case (codex #952 P2 round-4 lines 2346, 2492).
+// An empty ProjectionExpression is the common "project everything" case and
+// returns false (no validation needed).
+func projectionInvalid(projectionExpression string, names map[string]string) bool {
+	if strings.TrimSpace(projectionExpression) == "" {
+		return false
+	}
+	_, err := resolveProjectionAttributes(projectionExpression, names)
+	return err != nil
 }
 
 // scanExclusiveStartKeyInvalid returns true when in.ExclusiveStartKey cannot be
@@ -2468,6 +2493,13 @@ func (d *DynamoDBServer) queryLeaseKey(ctx context.Context, in queryInput) ([]by
 		if queryExclusiveStartKeyInvalid(schema, in) {
 			return nil, queryLeaseSkip, nil
 		}
+		// Malformed ProjectionExpression is the same kind of deterministic
+		// ValidationException newReadPageState raises before the iterator
+		// touches data (codex #952 P2 round-4 line 2492); skip the lease so a
+		// degraded shard cannot mask it.
+		if projectionInvalid(in.ProjectionExpression, in.ExpressionAttributeNames) {
+			return nil, queryLeaseSkip, nil
+		}
 		// Schema + GSI options are valid; the KeyConditionExpression is the last
 		// deterministic validation the read path runs before touching data.
 		return nil, gsiQueryLeasePlan(in, schema), nil
@@ -2487,6 +2519,11 @@ func (d *DynamoDBServer) queryLeaseKey(ctx context.Context, in queryInput) ([]by
 	}
 	// Same ExclusiveStartKey pre-check as the GSI branch above (base table).
 	if queryExclusiveStartKeyInvalid(schema, in) {
+		return nil, queryLeaseSkip, nil
+	}
+	// Same ProjectionExpression pre-check (base-table path; codex #952 P2 round-4
+	// line 2492).
+	if projectionInvalid(in.ProjectionExpression, in.ExpressionAttributeNames) {
 		return nil, queryLeaseSkip, nil
 	}
 	prefix, plan := queryLeasePrefix(in, schema)

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -4616,13 +4616,22 @@ func (d *DynamoDBServer) leaseCheckTransactGetItems(w http.ResponseWriter, r *ht
 
 // resolveTransactGetItemKeys runs the per-item schema resolution that the
 // lease pre-pass needs. Returns (uniqueKeys, skipLease, transientErr) where
-// skipLease is true when either (a) every item was malformed (nothing to
-// fence) or (b) at least one item was malformed and at least one was valid —
-// the latter means the read path will surface a deterministic 4xx via
-// buildTransactGetItemsResponses without touching any store, so leasing the
-// valid items only risks masking that 4xx with a degraded-shard 500 (codex P2
-// #952). transientErr is the schema-read failure the caller MUST fail closed
-// on (CLAUDE.md: the slow conditions the fence targets are exactly when a
+// skipLease is true when the read path will surface a deterministic 4xx via
+// buildTransactGetItemsResponses without touching any store — leasing the
+// valid items in that case only risks masking that 4xx with a degraded-shard
+// 500 (codex P2 #952). skipLease covers three cases:
+//   - (a) every item was malformed (nothing to fence)
+//   - (b) at least one item was malformed and at least one was valid
+//     (buildTransactGetItemsResponses returns a ValidationException for the
+//     malformed item; the valid items never reach a store read)
+//   - (c) the request contains a duplicate (table, key) pair — DynamoDB
+//     rejects this with `Transaction request cannot include multiple
+//     operations on one item`, a deterministic ValidationException the read
+//     path produces before touching data, so the lease must be skipped for
+//     the same reason malformed-mixed-with-valid is skipped.
+//
+// transientErr is the schema-read failure the caller MUST fail closed on
+// (CLAUDE.md: the slow conditions the fence targets are exactly when a
 // silently-dropped item would let a stale snapshot through).
 func (d *DynamoDBServer) resolveTransactGetItemKeys(ctx context.Context, in transactGetItemsInput) ([][]byte, bool, error) {
 	tentativeTS := snapshotTS(d.coordinator.Clock(), d.store)
@@ -4630,6 +4639,7 @@ func (d *DynamoDBServer) resolveTransactGetItemKeys(ctx context.Context, in tran
 	seenKeys := make(map[string]struct{}, len(in.TransactItems))
 	uniqueKeys := make([][]byte, 0, len(in.TransactItems))
 	hasMalformed := false
+	hasDuplicate := false
 	for _, item := range in.TransactItems {
 		itemKey, ok, err := d.transactGetItemKey(ctx, item, schemaCache, tentativeTS)
 		if err != nil {
@@ -4640,12 +4650,13 @@ func (d *DynamoDBServer) resolveTransactGetItemKeys(ctx context.Context, in tran
 			continue
 		}
 		if _, dup := seenKeys[string(itemKey)]; dup {
+			hasDuplicate = true
 			continue
 		}
 		seenKeys[string(itemKey)] = struct{}{}
 		uniqueKeys = append(uniqueKeys, itemKey)
 	}
-	if hasMalformed || len(uniqueKeys) == 0 {
+	if hasMalformed || hasDuplicate || len(uniqueKeys) == 0 {
 		return nil, true, nil
 	}
 	return uniqueKeys, false, nil

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -2155,6 +2155,16 @@ func (d *DynamoDBServer) query(w http.ResponseWriter, r *http.Request) {
 		writeDynamoErrorFromErr(w, err)
 		return
 	}
+	// A Query scans a key range that, in a multi-group deployment, can
+	// span more than one shard, and the owning shard cannot be resolved
+	// here without duplicating prepareReadSchema / resolveQueryCondition.
+	// Use the keyless lease check so the quorum-freshness bound covers
+	// every shard the range can touch BEFORE queryItems samples readTS;
+	// sampling readTS only after the confirmation keeps any commit that
+	// landed before the confirmation visible.
+	if !d.leaseReadKeyless(w, r) {
+		return
+	}
 	out, err := d.queryItems(r.Context(), in)
 	if err != nil {
 		writeDynamoErrorFromErr(w, err)
@@ -2178,6 +2188,13 @@ func (d *DynamoDBServer) scan(w http.ResponseWriter, r *http.Request) {
 		writeDynamoErrorFromErr(w, err)
 		return
 	}
+	// A Scan reads the whole table and therefore spans every shard that
+	// holds any of its items. Use the keyless lease check (LeaseRead) so
+	// the quorum-freshness bound is established BEFORE scanItems samples
+	// readTS.
+	if !d.leaseReadKeyless(w, r) {
+		return
+	}
 	out, err := d.scanItems(r.Context(), in)
 	if err != nil {
 		writeDynamoErrorFromErr(w, err)
@@ -2193,6 +2210,22 @@ func (d *DynamoDBServer) scan(w http.ResponseWriter, r *http.Request) {
 		resp["LastEvaluatedKey"] = out.lastEvaluatedKey
 	}
 	writeDynamoJSON(w, resp)
+}
+
+// leaseReadKeyless performs a keyless quorum-freshness lease check for
+// multi-shard read handlers (Query, Scan). It bounds the wait with
+// dynamoLeaseReadTimeout so a stalled Raft cannot hang the handler when
+// the client never cancels, and writes the same InternalServerError that
+// getItem produces on lease failure. Returns false after writing an
+// error response; the caller should simply return.
+func (d *DynamoDBServer) leaseReadKeyless(w http.ResponseWriter, r *http.Request) bool {
+	leaseCtx, leaseCancel := context.WithTimeout(r.Context(), dynamoLeaseReadTimeout)
+	defer leaseCancel()
+	if _, err := kv.LeaseReadThrough(d.coordinator, leaseCtx); err != nil {
+		writeDynamoError(w, http.StatusInternalServerError, dynamoErrInternal, err.Error())
+		return false
+	}
+	return true
 }
 
 func decodeQueryInput(bodyReader io.Reader) (queryInput, error) {
@@ -4245,6 +4278,14 @@ func (d *DynamoDBServer) transactGetItems(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// Lease-check every shard this transaction will read BEFORE the single
+	// snapshot timestamp is resolved, so the quorum-freshness bound is
+	// established without changing the single-snapshot-ts semantics. The
+	// timestamp below is still sampled once and shared by all items.
+	if !d.leaseCheckTransactGetItems(w, r, in) {
+		return
+	}
+
 	// Acquire a single read timestamp for all items to guarantee a consistent snapshot.
 	readTS := d.nextTxnReadTS()
 	pin := d.pinReadTS(readTS)
@@ -4259,6 +4300,58 @@ func (d *DynamoDBServer) transactGetItems(w http.ResponseWriter, r *http.Request
 		d.observeReadMetrics(r.Context(), table, m.found, m.requested)
 	}
 	writeDynamoJSON(w, map[string]any{"Responses": responses})
+}
+
+// leaseCheckTransactGetItems performs a quorum-freshness lease check on every
+// shard the TransactGetItems request will read, deduplicated by item key, with
+// a bounded timeout. Item keys are resolved at a tentative timestamp (schemas
+// change rarely, so a slight pre-lease stale schema is acceptable) used only to
+// route the lease check; the actual snapshot timestamp is sampled by the caller
+// afterwards. Items whose schema or key cannot be resolved here are skipped:
+// they never reach a store read, and buildTransactGetItemsResponses surfaces the
+// identical validation error downstream so error mapping is unchanged. Returns
+// false after writing the same InternalServerError getItem produces on lease
+// failure; the caller should simply return.
+func (d *DynamoDBServer) leaseCheckTransactGetItems(w http.ResponseWriter, r *http.Request, in transactGetItemsInput) bool {
+	tentativeTS := snapshotTS(d.coordinator.Clock(), d.store)
+	schemaCache := make(map[string]*dynamoTableSchema)
+	seenKeys := make(map[string]struct{}, len(in.TransactItems))
+	leaseCtx, leaseCancel := context.WithTimeout(r.Context(), dynamoLeaseReadTimeout)
+	defer leaseCancel()
+	for _, item := range in.TransactItems {
+		itemKey, ok := d.transactGetItemKey(r.Context(), item, schemaCache, tentativeTS)
+		if !ok {
+			continue
+		}
+		if _, dup := seenKeys[string(itemKey)]; dup {
+			continue
+		}
+		seenKeys[string(itemKey)] = struct{}{}
+		if _, err := kv.LeaseReadForKeyThrough(d.coordinator, leaseCtx, itemKey); err != nil {
+			writeDynamoError(w, http.StatusInternalServerError, dynamoErrInternal, err.Error())
+			return false
+		}
+	}
+	return true
+}
+
+// transactGetItemKey resolves the storage key for one TransactGetItems Get at
+// the tentative timestamp, returning false when the item is malformed or its
+// schema/key cannot be resolved. It never writes a response: validation is left
+// to the read path so error mapping stays identical.
+func (d *DynamoDBServer) transactGetItemKey(ctx context.Context, item transactGetItem, schemaCache map[string]*dynamoTableSchema, tentativeTS uint64) ([]byte, bool) {
+	if item.Get == nil || strings.TrimSpace(item.Get.TableName) == "" {
+		return nil, false
+	}
+	schema, err := d.resolveTransactTableSchema(ctx, schemaCache, item.Get.TableName, tentativeTS)
+	if err != nil {
+		return nil, false
+	}
+	itemKey, err := schema.itemKeyFromAttributes(item.Get.Key)
+	if err != nil {
+		return nil, false
+	}
+	return itemKey, true
 }
 
 func decodeTransactGetItemsInput(bodyReader io.Reader) (transactGetItemsInput, error) {

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -4598,26 +4598,45 @@ func (d *DynamoDBServer) leaseCheckTransactGetItems(w http.ResponseWriter, r *ht
 	// handler past dynamoLeaseReadTimeout before the lease phase begins.
 	leaseCtx, leaseCancel := context.WithTimeout(r.Context(), dynamoLeaseReadTimeout)
 	defer leaseCancel()
+	uniqueKeys, skipLease, transientErr := d.resolveTransactGetItemKeys(leaseCtx, in)
+	if transientErr != nil {
+		writeDynamoError(w, http.StatusInternalServerError, dynamoErrInternal, transientErr.Error())
+		return false
+	}
+	if skipLease {
+		return true
+	}
+	groupKeys := kv.LeaseReadGroupKeys(d.coordinator, uniqueKeys)
+	if leaseErr := d.leaseReadGroupKeys(leaseCtx, groupKeys); leaseErr != nil {
+		writeDynamoError(w, http.StatusInternalServerError, dynamoErrInternal, leaseErr.Error())
+		return false
+	}
+	return true
+}
+
+// resolveTransactGetItemKeys runs the per-item schema resolution that the
+// lease pre-pass needs. Returns (uniqueKeys, skipLease, transientErr) where
+// skipLease is true when either (a) every item was malformed (nothing to
+// fence) or (b) at least one item was malformed and at least one was valid —
+// the latter means the read path will surface a deterministic 4xx via
+// buildTransactGetItemsResponses without touching any store, so leasing the
+// valid items only risks masking that 4xx with a degraded-shard 500 (codex P2
+// #952). transientErr is the schema-read failure the caller MUST fail closed
+// on (CLAUDE.md: the slow conditions the fence targets are exactly when a
+// silently-dropped item would let a stale snapshot through).
+func (d *DynamoDBServer) resolveTransactGetItemKeys(ctx context.Context, in transactGetItemsInput) ([][]byte, bool, error) {
 	tentativeTS := snapshotTS(d.coordinator.Clock(), d.store)
 	schemaCache := make(map[string]*dynamoTableSchema)
 	seenKeys := make(map[string]struct{}, len(in.TransactItems))
 	uniqueKeys := make([][]byte, 0, len(in.TransactItems))
+	hasMalformed := false
 	for _, item := range in.TransactItems {
-		itemKey, ok, err := d.transactGetItemKey(leaseCtx, item, schemaCache, tentativeTS)
+		itemKey, ok, err := d.transactGetItemKey(ctx, item, schemaCache, tentativeTS)
 		if err != nil {
-			// Transient/internal schema read failure (leaseCtx deadline,
-			// Pebble error). Fail closed: silently dropping the item would
-			// leave its shard unfenced and let the later read return a
-			// stale snapshot under exactly the slow conditions the fence
-			// targets. Same InternalServerError mapping as a lease failure.
-			writeDynamoError(w, http.StatusInternalServerError, dynamoErrInternal, err.Error())
-			return false
+			return nil, false, err
 		}
 		if !ok {
-			// Malformed input (nil Get, empty/unknown table, unresolvable
-			// key). Skipping is safe: the item never reaches a store read,
-			// and buildTransactGetItemsResponses surfaces the identical
-			// validation error downstream so error mapping is unchanged.
+			hasMalformed = true
 			continue
 		}
 		if _, dup := seenKeys[string(itemKey)]; dup {
@@ -4626,20 +4645,47 @@ func (d *DynamoDBServer) leaseCheckTransactGetItems(w http.ResponseWriter, r *ht
 		seenKeys[string(itemKey)] = struct{}{}
 		uniqueKeys = append(uniqueKeys, itemKey)
 	}
-	if len(uniqueKeys) == 0 {
-		// Every item is malformed or its schema/key could not be resolved,
-		// so no store read will happen and no shard will be touched; there
-		// is nothing to establish freshness against. buildTransactGetItemsResponses
-		// surfaces the identical validation error downstream.
-		return true
+	if hasMalformed || len(uniqueKeys) == 0 {
+		return nil, true, nil
 	}
-	for _, itemKey := range kv.LeaseReadGroupKeys(d.coordinator, uniqueKeys) {
-		if _, err := kv.LeaseReadForKeyThrough(d.coordinator, leaseCtx, itemKey); err != nil {
-			writeDynamoError(w, http.StatusInternalServerError, dynamoErrInternal, err.Error())
-			return false
+	return uniqueKeys, false, nil
+}
+
+// leaseReadGroupKeys fences every group whose key appears in groupKeys. The
+// single-group case stays on the calling goroutine; multi-group fan-out is
+// concurrent so a 100-item TransactGetItems does not serialize into 100 Raft
+// round-trips and blow dynamoLeaseReadTimeout (gemini HIGH on PR #952). The
+// fan-out is bounded by len(groupKeys) ≤ transactGetItemsMaxItems (100), so a
+// per-call goroutine pool is unnecessary. Returns the first error seen across
+// all goroutines (the rest are dropped to preserve the single-response
+// contract at the HTTP layer).
+func (d *DynamoDBServer) leaseReadGroupKeys(ctx context.Context, groupKeys [][]byte) error {
+	if len(groupKeys) == 0 {
+		return nil
+	}
+	if len(groupKeys) == 1 {
+		_, err := kv.LeaseReadForKeyThrough(d.coordinator, ctx, groupKeys[0])
+		return errors.WithStack(err)
+	}
+	errCh := make(chan error, len(groupKeys))
+	var wg sync.WaitGroup
+	for _, itemKey := range groupKeys {
+		wg.Add(1)
+		go func(k []byte) {
+			defer wg.Done()
+			if _, err := kv.LeaseReadForKeyThrough(d.coordinator, ctx, k); err != nil {
+				errCh <- err
+			}
+		}(itemKey)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			return err
 		}
 	}
-	return true
+	return nil
 }
 
 // transactGetItemKey resolves the storage key for one TransactGetItems Get at

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -2191,10 +2191,12 @@ func (d *DynamoDBServer) scan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// A Scan reads the whole table and therefore spans every shard that
-	// holds any of its items. Use the keyless lease check (LeaseRead) so
-	// the quorum-freshness bound is established BEFORE scanItems samples
-	// readTS.
-	if !d.leaseReadKeyless(w, r) {
+	// holds any of its items. leaseCheckScan establishes the quorum-freshness
+	// bound across every group BEFORE scanItems samples readTS — but only for
+	// a request that passes the cheap table/GSI validation, so a scan that
+	// will deterministically 4xx is not masked by a degraded-lease 500
+	// (codex #952 P2-A).
+	if !d.leaseCheckScan(w, r, in) {
 		return
 	}
 	out, err := d.scanItems(r.Context(), in)
@@ -2233,6 +2235,96 @@ func (d *DynamoDBServer) leaseReadKeyless(w http.ResponseWriter, r *http.Request
 		return false
 	}
 	return true
+}
+
+// leaseCheckScan runs the Scan lease pre-pass. A Scan reads the whole table, so
+// a VALID scan must fence EVERY group via the keyless all-groups check. But a
+// scan against a missing table, an unknown index, or a GSI with
+// ConsistentRead=true never touches data: the read path rejects it with a
+// deterministic 4xx, so establishing freshness is unnecessary and a failed
+// all-groups fence on a degraded deployment would mask that 4xx with a 500
+// (codex #952 P2-A). leaseCheckScan therefore cheaply pre-validates the request
+// (schema load + the same GSI read-option checks scanItems re-runs) at a
+// tentative timestamp and skips the lease on a client-side validation error,
+// while still failing closed (fencing every group) on a transient schema-read
+// failure. Returns false after writing an error response; the caller returns.
+func (d *DynamoDBServer) leaseCheckScan(w http.ResponseWriter, r *http.Request, in scanInput) bool {
+	// leaseCtx bounds the pre-validation schema read AND the lease read so a
+	// stalled schema read cannot block the handler past dynamoLeaseReadTimeout
+	// before the lease phase begins. leaseReadKeyless creates its own bounded
+	// context for the actual lease read.
+	leaseCtx, leaseCancel := context.WithTimeout(r.Context(), dynamoLeaseReadTimeout)
+	defer leaseCancel()
+	_, plan, err := d.multiShardReadLeasePlan(leaseCtx, in.TableName, in.IndexName, in.Select, in.ProjectionExpression, in.ExpressionAttributeNames, in.ConsistentRead)
+	if err != nil {
+		// Transient/internal schema-read failure: fail closed by fencing every
+		// group. leaseReadKeyless writes the same InternalServerError on its
+		// own failure.
+		return d.leaseReadKeyless(w, r)
+	}
+	if plan == queryLeaseSkip {
+		// Client-side validation problem (table not found, unknown index,
+		// unsupported ConsistentRead): the read path re-runs the identical
+		// validation and surfaces the deterministic 4xx, so skip the lease so a
+		// degraded-lease failure cannot mask it with a 500 (codex #952 P2-A).
+		return true
+	}
+	// Valid whole-table read: fence every group (fail closed).
+	return d.leaseReadKeyless(w, r)
+}
+
+// multiShardReadLeasePlan cheaply classifies whether a multi-shard read (Scan or
+// a GSI/whole-table Query) is a VALID data read that must fence every group
+// (queryLeaseAllGroups) or a CLIENT-side validation problem the read path
+// rejects identically without touching data (queryLeaseSkip). It performs the
+// same table-existence and GSI read-option checks prepareReadSchema runs, at a
+// tentative timestamp (schema only, no readTS sampling), so the lease pre-pass
+// never masks a deterministic 4xx with a degraded-lease 500. A transient/internal
+// schema-read failure is returned as an error so the caller fails closed.
+//
+// The loaded schema is returned (nil when the table is missing or on error) so
+// callers that need a further deterministic validation (the GSI Query
+// KeyConditionExpression check) can reuse it without a second schema load.
+//
+// Validation failures are reported via queryLeaseSkip rather than an error: the
+// read path re-runs the same resolution and reports the identical validation
+// error, so error mapping is unchanged.
+func (d *DynamoDBServer) multiShardReadLeasePlan(
+	ctx context.Context,
+	tableName string,
+	indexName string,
+	selectValue string,
+	projectionExpression string,
+	names map[string]string,
+	consistentRead *bool,
+) (*dynamoTableSchema, queryLeasePlan, error) {
+	tentativeTS := snapshotTS(d.coordinator.Clock(), d.store)
+	schema, exists, err := d.loadTableSchemaAt(ctx, tableName, tentativeTS)
+	if err != nil {
+		// loadTableSchemaAt maps ErrKeyNotFound to (_, false, nil); any error
+		// reaching here is a transient store/context/decode failure, so fail
+		// closed.
+		return nil, queryLeaseAllGroups, errors.WithStack(err)
+	}
+	if !exists {
+		// Table not found is a deterministic ResourceNotFoundException the read
+		// path produces without touching data; skip the lease.
+		return nil, queryLeaseSkip, nil
+	}
+	// validateGSIReadOptions runs the identical unknown-index / GSI
+	// ConsistentRead / projection checks prepareReadSchema performs. Any failure
+	// is a *dynamoAPIError (a deterministic ValidationException), so classify it
+	// as a skip; a transient failure is impossible here (no store access).
+	if err := validateGSIReadOptions(schema, indexName, selectValue, projectionExpression, names, consistentRead); err != nil {
+		if dynamoErrIsTransient(err) {
+			// Defensive: validateGSIReadOptions returns only *dynamoAPIError, so
+			// this is unreachable. Fail closed if a future change adds a
+			// transient path.
+			return nil, queryLeaseAllGroups, errors.WithStack(err)
+		}
+		return schema, queryLeaseSkip, nil
+	}
+	return schema, queryLeaseAllGroups, nil
 }
 
 // leaseCheckQuery lease-checks the shard a Query reads with a bounded
@@ -2314,9 +2406,12 @@ const (
 //   - (nil, queryLeaseAllGroups, nil) for a VALID multi-shard read (GSI query
 //     or whole-table prefix) the caller must fence across every group;
 //   - (nil, queryLeaseSkip, nil) for a CLIENT-side validation problem (table
-//     not found, malformed/unsupported KeyConditionExpression) the read path
-//     rejects identically — the caller skips the lease so the deterministic
-//     4xx is not masked by a transient lease failure (codex #952 P2);
+//     not found, unknown index, GSI ConsistentRead, malformed/unsupported
+//     KeyConditionExpression) the read path rejects identically — the caller
+//     skips the lease so the deterministic 4xx is not masked by a transient
+//     lease failure (codex #952 P2). GSI queries are validated against the
+//     table schema here before being classified as a multi-shard read so an
+//     invalid index can never trigger the all-groups fence (codex #952 P2-B);
 //   - (nil, _, err) for a TRANSIENT/INTERNAL schema-read failure (leaseCtx
 //     deadline, Pebble error) so the caller fails closed.
 //
@@ -2325,8 +2420,22 @@ const (
 // error, so error mapping is unchanged.
 func (d *DynamoDBServer) queryLeaseKey(ctx context.Context, in queryInput) ([]byte, queryLeasePlan, error) {
 	if strings.TrimSpace(in.IndexName) != "" {
-		// A GSI query is a valid multi-shard read; fence every group.
-		return nil, queryLeaseAllGroups, nil
+		// A GSI query is a multi-shard read, but only when it passes the same
+		// validation the read path runs: a query against a missing table,
+		// unknown index, GSI ConsistentRead, or malformed KeyConditionExpression
+		// touches no data and the read path rejects it with a deterministic 4xx.
+		// Fencing every group before that validation would mask the 4xx with a
+		// degraded-lease 500, so classify those as a skip (codex #952 P2-B).
+		schema, plan, err := d.multiShardReadLeasePlan(ctx, in.TableName, in.IndexName, in.Select, in.ProjectionExpression, in.ExpressionAttributeNames, in.ConsistentRead)
+		if err != nil {
+			return nil, queryLeaseAllGroups, errors.WithStack(err)
+		}
+		if plan == queryLeaseSkip {
+			return nil, queryLeaseSkip, nil
+		}
+		// Schema + GSI options are valid; the KeyConditionExpression is the last
+		// deterministic validation the read path runs before touching data.
+		return nil, gsiQueryLeasePlan(in, schema), nil
 	}
 	tentativeTS := snapshotTS(d.coordinator.Clock(), d.store)
 	schema, exists, err := d.loadTableSchemaAt(ctx, in.TableName, tentativeTS)
@@ -2372,6 +2481,22 @@ func queryLeasePrefix(in queryInput, schema *dynamoTableSchema) ([]byte, queryLe
 		return nil, queryLeaseSkip
 	}
 	return prefix, queryLeaseSingleGroup
+}
+
+// gsiQueryLeasePlan classifies a GSI Query (already known to name a valid index
+// on an existing table) as the multi-shard all-groups read it is, unless its
+// KeyConditionExpression is malformed — the last deterministic validation the
+// read path runs before touching data. resolveQueryCondition does no store
+// access and returns only *dynamoAPIError, so a failure is a ValidationException
+// the read path rejects identically; classify it as a skip so the lease pre-pass
+// cannot mask that 4xx with a degraded-lease 500 (codex #952 P2-B). Like
+// queryLeasePrefix, the validation error is deliberately not surfaced — only the
+// routing classification matters here.
+func gsiQueryLeasePlan(in queryInput, schema *dynamoTableSchema) queryLeasePlan {
+	if _, _, err := resolveQueryCondition(in, schema); err != nil {
+		return queryLeaseSkip
+	}
+	return queryLeaseAllGroups
 }
 
 func decodeQueryInput(bodyReader io.Reader) (queryInput, error) {

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -2255,7 +2255,7 @@ func (d *DynamoDBServer) leaseCheckScan(w http.ResponseWriter, r *http.Request, 
 	// context for the actual lease read.
 	leaseCtx, leaseCancel := context.WithTimeout(r.Context(), dynamoLeaseReadTimeout)
 	defer leaseCancel()
-	_, plan, err := d.multiShardReadLeasePlan(leaseCtx, in.TableName, in.IndexName, in.Select, in.ProjectionExpression, in.ExpressionAttributeNames, in.ConsistentRead)
+	schema, plan, err := d.multiShardReadLeasePlan(leaseCtx, in.TableName, in.IndexName, in.Select, in.ProjectionExpression, in.ExpressionAttributeNames, in.ConsistentRead)
 	if err != nil {
 		// Transient/internal schema-read failure: fail closed by fencing every
 		// group. leaseReadKeyless writes the same InternalServerError on its
@@ -2269,8 +2269,36 @@ func (d *DynamoDBServer) leaseCheckScan(w http.ResponseWriter, r *http.Request, 
 		// degraded-lease failure cannot mask it with a 500 (codex #952 P2-A).
 		return true
 	}
+	// Malformed ExclusiveStartKey is a deterministic ValidationException the
+	// read path rejects in resolveTableReadBounds / resolveGSIReadBounds —
+	// before the iterator is constructed and before any store read. If we let
+	// the lease run first, a degraded shard's 500 would mask that 4xx
+	// (codex #952 P2 round-3). Pre-validate against the loaded schema and skip
+	// leasing on failure; the read path will surface the identical error.
+	if scanExclusiveStartKeyInvalid(schema, in) {
+		return true
+	}
 	// Valid whole-table read: fence every group (fail closed).
 	return d.leaseReadKeyless(w, r)
+}
+
+// scanExclusiveStartKeyInvalid returns true when in.ExclusiveStartKey cannot be
+// decoded against the table's primary key (Scan with no IndexName) or the named
+// GSI (Scan with IndexName). It mirrors the validation resolveTableReadBounds /
+// resolveGSIReadBounds run in scanItems so the lease pre-pass can route the
+// invalid case to the same skip-lease path as table-not-found etc. A nil schema
+// is treated as "not invalid" because multiShardReadLeasePlan already classified
+// the request as queryLeaseSkip in that case and we never reach here.
+func scanExclusiveStartKeyInvalid(schema *dynamoTableSchema, in scanInput) bool {
+	if schema == nil || len(in.ExclusiveStartKey) == 0 {
+		return false
+	}
+	if strings.TrimSpace(in.IndexName) == "" {
+		_, err := schema.itemKeyFromAttributes(in.ExclusiveStartKey)
+		return err != nil
+	}
+	_, _, err := schema.gsiKeyFromAttributes(in.IndexName, in.ExclusiveStartKey)
+	return err != nil
 }
 
 // multiShardReadLeasePlan cheaply classifies whether a multi-shard read (Scan or
@@ -2433,6 +2461,13 @@ func (d *DynamoDBServer) queryLeaseKey(ctx context.Context, in queryInput) ([]by
 		if plan == queryLeaseSkip {
 			return nil, queryLeaseSkip, nil
 		}
+		// Malformed ExclusiveStartKey is a deterministic ValidationException the
+		// read path rejects before the iterator is constructed (codex #952 P2
+		// round-3). Skip leasing on failure so a degraded shard cannot mask
+		// that 4xx with a 500.
+		if queryExclusiveStartKeyInvalid(schema, in) {
+			return nil, queryLeaseSkip, nil
+		}
 		// Schema + GSI options are valid; the KeyConditionExpression is the last
 		// deterministic validation the read path runs before touching data.
 		return nil, gsiQueryLeasePlan(in, schema), nil
@@ -2450,8 +2485,33 @@ func (d *DynamoDBServer) queryLeaseKey(ctx context.Context, in queryInput) ([]by
 		// read path produces without touching data; skip the lease.
 		return nil, queryLeaseSkip, nil
 	}
+	// Same ExclusiveStartKey pre-check as the GSI branch above (base table).
+	if queryExclusiveStartKeyInvalid(schema, in) {
+		return nil, queryLeaseSkip, nil
+	}
 	prefix, plan := queryLeasePrefix(in, schema)
 	return prefix, plan, nil
+}
+
+// queryExclusiveStartKeyInvalid mirrors the validation
+// resolveQueryExclusiveStartKey runs inside queryItems' read-bounds resolution
+// (`adapter/dynamodb.go` resolveQueryExclusiveStartKey / resolveTableReadBounds /
+// resolveGSIReadBounds): a malformed ExclusiveStartKey produces a deterministic
+// ValidationException without touching any store. Returning true routes the
+// lease pre-pass to queryLeaseSkip so a degraded-shard 500 cannot mask that 4xx
+// (codex #952 P2 round-3). Mirrors scanExclusiveStartKeyInvalid for the
+// Query path — kept separate because the GSI vs base-table dispatch differs
+// from the Scan input.
+func queryExclusiveStartKeyInvalid(schema *dynamoTableSchema, in queryInput) bool {
+	if schema == nil || len(in.ExclusiveStartKey) == 0 {
+		return false
+	}
+	if strings.TrimSpace(in.IndexName) == "" {
+		_, err := schema.itemKeyFromAttributes(in.ExclusiveStartKey)
+		return err != nil
+	}
+	_, _, err := schema.gsiKeyFromAttributes(in.IndexName, in.ExclusiveStartKey)
+	return err != nil
 }
 
 // queryLeasePrefix resolves the single hash-key prefix a base-table Query

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -2241,12 +2241,16 @@ func (d *DynamoDBServer) leaseReadKeyless(w http.ResponseWriter, r *http.Request
 // the range can touch. Returns false after writing an error response;
 // the caller should simply return.
 func (d *DynamoDBServer) leaseCheckQuery(w http.ResponseWriter, r *http.Request, in queryInput) bool {
-	leaseKey, ok := d.queryLeaseKey(r.Context(), in)
+	// leaseCtx bounds the entire pre-pass — the schema read that resolves
+	// the lease key and the lease read itself — so a stalled schema read
+	// cannot block the handler past dynamoLeaseReadTimeout before the lease
+	// phase begins. The keyless fallback creates its own bounded context.
+	leaseCtx, leaseCancel := context.WithTimeout(r.Context(), dynamoLeaseReadTimeout)
+	defer leaseCancel()
+	leaseKey, ok := d.queryLeaseKey(leaseCtx, in)
 	if !ok {
 		return d.leaseReadKeyless(w, r)
 	}
-	leaseCtx, leaseCancel := context.WithTimeout(r.Context(), dynamoLeaseReadTimeout)
-	defer leaseCancel()
 	if _, err := kv.LeaseReadForKeyThrough(d.coordinator, leaseCtx, leaseKey); err != nil {
 		writeDynamoError(w, http.StatusInternalServerError, dynamoErrInternal, err.Error())
 		return false
@@ -4371,7 +4375,8 @@ func (d *DynamoDBServer) transactGetItems(w http.ResponseWriter, r *http.Request
 // timestamp is sampled by the caller afterwards. Items whose schema or key
 // cannot be resolved here are skipped: they never reach a store read, and
 // buildTransactGetItemsResponses surfaces the identical validation error
-// downstream so error mapping is unchanged.
+// downstream so error mapping is unchanged. When every item is skipped no
+// shard is touched, so the function returns true without a lease read.
 //
 // Keys are first deduplicated by value, then collapsed to one representative key
 // per owning Raft group, so a transaction touching up to transactGetItemsMaxItems
@@ -4381,12 +4386,18 @@ func (d *DynamoDBServer) transactGetItems(w http.ResponseWriter, r *http.Request
 // after writing the same InternalServerError getItem produces on lease failure;
 // the caller should simply return.
 func (d *DynamoDBServer) leaseCheckTransactGetItems(w http.ResponseWriter, r *http.Request, in transactGetItemsInput) bool {
+	// leaseCtx bounds the entire pre-pass — both the per-item schema reads
+	// that resolve keys and the lease reads themselves — so a stalled
+	// schema read (Pebble backpressure, iterator leak) cannot block the
+	// handler past dynamoLeaseReadTimeout before the lease phase begins.
+	leaseCtx, leaseCancel := context.WithTimeout(r.Context(), dynamoLeaseReadTimeout)
+	defer leaseCancel()
 	tentativeTS := snapshotTS(d.coordinator.Clock(), d.store)
 	schemaCache := make(map[string]*dynamoTableSchema)
 	seenKeys := make(map[string]struct{}, len(in.TransactItems))
 	uniqueKeys := make([][]byte, 0, len(in.TransactItems))
 	for _, item := range in.TransactItems {
-		itemKey, ok := d.transactGetItemKey(r.Context(), item, schemaCache, tentativeTS)
+		itemKey, ok := d.transactGetItemKey(leaseCtx, item, schemaCache, tentativeTS)
 		if !ok {
 			continue
 		}
@@ -4396,8 +4407,13 @@ func (d *DynamoDBServer) leaseCheckTransactGetItems(w http.ResponseWriter, r *ht
 		seenKeys[string(itemKey)] = struct{}{}
 		uniqueKeys = append(uniqueKeys, itemKey)
 	}
-	leaseCtx, leaseCancel := context.WithTimeout(r.Context(), dynamoLeaseReadTimeout)
-	defer leaseCancel()
+	if len(uniqueKeys) == 0 {
+		// Every item is malformed or its schema/key could not be resolved,
+		// so no store read will happen and no shard will be touched; there
+		// is nothing to establish freshness against. buildTransactGetItemsResponses
+		// surfaces the identical validation error downstream.
+		return true
+	}
 	for _, itemKey := range kv.LeaseReadGroupKeys(d.coordinator, uniqueKeys) {
 		if _, err := kv.LeaseReadForKeyThrough(d.coordinator, leaseCtx, itemKey); err != nil {
 			writeDynamoError(w, http.StatusInternalServerError, dynamoErrInternal, err.Error())

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -2252,7 +2252,7 @@ func (d *DynamoDBServer) leaseCheckQuery(w http.ResponseWriter, r *http.Request,
 	// phase begins. The keyless fallback creates its own bounded context.
 	leaseCtx, leaseCancel := context.WithTimeout(r.Context(), dynamoLeaseReadTimeout)
 	defer leaseCancel()
-	leaseKey, ok, err := d.queryLeaseKey(leaseCtx, in)
+	leaseKey, plan, err := d.queryLeaseKey(leaseCtx, in)
 	if err != nil {
 		// Transient/internal schema read failure: the routing key could
 		// not be resolved, so fail closed by fencing EVERY group via the
@@ -2261,33 +2261,72 @@ func (d *DynamoDBServer) leaseCheckQuery(w http.ResponseWriter, r *http.Request,
 		// InternalServerError on its own failure.
 		return d.leaseReadKeyless(w, r)
 	}
-	if !ok {
-		// GSI / whole-table / unresolved-but-valid query: spans multiple
-		// shards, so the keyless all-groups check is the correct fence.
+	switch plan {
+	case queryLeaseSkip:
+		// Client-side validation problem (table not found, malformed/
+		// unsupported KeyConditionExpression): the request touches no data,
+		// so establishing freshness is unnecessary. Skip the lease entirely
+		// and let queryItems re-run the identical resolution and surface the
+		// deterministic ResourceNotFoundException/ValidationException — a
+		// lease failure on the fallback must not mask that 4xx with a 500 in
+		// a degraded deployment (codex #952 P2). This matches getItem, which
+		// writes the 4xx before any lease read.
+		return true
+	case queryLeaseAllGroups:
+		// GSI / whole-table query: a VALID read that spans multiple shards,
+		// so the keyless all-groups check is the correct fence (fail closed).
+		return d.leaseReadKeyless(w, r)
+	case queryLeaseSingleGroup:
+		if _, err := kv.LeaseReadForKeyThrough(d.coordinator, leaseCtx, leaseKey); err != nil {
+			writeDynamoError(w, http.StatusInternalServerError, dynamoErrInternal, err.Error())
+			return false
+		}
+		return true
+	default:
+		// Unreachable: queryLeaseKey only returns the three plans above. Fail
+		// closed via the all-groups fence rather than silently proceeding.
 		return d.leaseReadKeyless(w, r)
 	}
-	if _, err := kv.LeaseReadForKeyThrough(d.coordinator, leaseCtx, leaseKey); err != nil {
-		writeDynamoError(w, http.StatusInternalServerError, dynamoErrInternal, err.Error())
-		return false
-	}
-	return true
 }
 
-// queryLeaseKey resolves the single hash-key prefix a base-table Query
-// reads, at a tentative timestamp (schema only, no readTS sampling), so
-// the lease check can be routed to the owning shard group. It returns
-// (prefix, true, nil) when the query routes to exactly one shard group,
-// (nil, false, nil) when the caller should fall back to a keyless all-groups
-// lease check (GSI query, whole-table prefix, table not found, or a query
-// condition that cannot be resolved — all surfaced identically by the read
-// path), and (nil, false, err) for a TRANSIENT/INTERNAL schema-read failure
-// (leaseCtx deadline, Pebble error) so the caller fails closed instead of
-// proceeding with no fence. Validation failures here are not surfaced as
-// errors: the read path re-runs the same resolution and reports the identical
-// validation error, so error mapping is unchanged.
-func (d *DynamoDBServer) queryLeaseKey(ctx context.Context, in queryInput) ([]byte, bool, error) {
+// queryLeasePlan classifies how a Query lease pre-pass must fence the read.
+type queryLeasePlan int
+
+const (
+	// queryLeaseSingleGroup: the query routes to exactly one shard group;
+	// fence that group via the resolved leaseKey.
+	queryLeaseSingleGroup queryLeasePlan = iota
+	// queryLeaseAllGroups: a VALID multi-shard read (GSI query or whole-table
+	// prefix); fence every group via the keyless all-groups check.
+	queryLeaseAllGroups
+	// queryLeaseSkip: a CLIENT-side validation problem (table not found,
+	// malformed/unsupported KeyConditionExpression) that the read path rejects
+	// deterministically without touching data; skip the lease so the handler's
+	// 4xx is never masked by a transient lease failure.
+	queryLeaseSkip
+)
+
+// queryLeaseKey resolves the single hash-key prefix a base-table Query reads,
+// at a tentative timestamp (schema only, no readTS sampling), so the lease
+// check can be routed to the owning shard group. It returns:
+//   - (prefix, queryLeaseSingleGroup, nil) when the query routes to exactly
+//     one shard group;
+//   - (nil, queryLeaseAllGroups, nil) for a VALID multi-shard read (GSI query
+//     or whole-table prefix) the caller must fence across every group;
+//   - (nil, queryLeaseSkip, nil) for a CLIENT-side validation problem (table
+//     not found, malformed/unsupported KeyConditionExpression) the read path
+//     rejects identically — the caller skips the lease so the deterministic
+//     4xx is not masked by a transient lease failure (codex #952 P2);
+//   - (nil, _, err) for a TRANSIENT/INTERNAL schema-read failure (leaseCtx
+//     deadline, Pebble error) so the caller fails closed.
+//
+// Validation failures are reported via queryLeaseSkip rather than an error: the
+// read path re-runs the same resolution and reports the identical validation
+// error, so error mapping is unchanged.
+func (d *DynamoDBServer) queryLeaseKey(ctx context.Context, in queryInput) ([]byte, queryLeasePlan, error) {
 	if strings.TrimSpace(in.IndexName) != "" {
-		return nil, false, nil
+		// A GSI query is a valid multi-shard read; fence every group.
+		return nil, queryLeaseAllGroups, nil
 	}
 	tentativeTS := snapshotTS(d.coordinator.Clock(), d.store)
 	schema, exists, err := d.loadTableSchemaAt(ctx, in.TableName, tentativeTS)
@@ -2295,43 +2334,44 @@ func (d *DynamoDBServer) queryLeaseKey(ctx context.Context, in queryInput) ([]by
 		// loadTableSchemaAt maps ErrKeyNotFound to (_, false, nil); any
 		// error reaching here is a transient store/context/decode failure,
 		// so fail closed.
-		return nil, false, errors.WithStack(err)
+		return nil, queryLeaseSingleGroup, errors.WithStack(err)
 	}
 	if !exists {
-		return nil, false, nil
+		// Table not found is a deterministic ResourceNotFoundException the
+		// read path produces without touching data; skip the lease.
+		return nil, queryLeaseSkip, nil
 	}
-	// resolveQueryCondition / queryScanPrefix only fail on a malformed
-	// query condition (invalid key, unsupported operator) — pure
-	// validation errors that the read path re-runs and rejects identically.
-	// queryLeasePrefix discards them (the caller falls back to the keyless
-	// all-groups check, a strict superset of the single group this query
-	// would have routed to), so only a non-validation, transient/internal
-	// error (already handled above at loadTableSchemaAt) ever fails closed.
-	prefix, ok := queryLeasePrefix(in, schema)
-	return prefix, ok, nil
+	prefix, plan := queryLeasePrefix(in, schema)
+	return prefix, plan, nil
 }
 
 // queryLeasePrefix resolves the single hash-key prefix a base-table Query
-// reads, returning ok=false for GSI/whole-table/malformed-condition queries
-// that must fall back to the keyless all-groups lease check. Validation
-// errors are deliberately swallowed: they are not surfaced as a routing key,
-// and the read path reports the identical error downstream.
-func queryLeasePrefix(in queryInput, schema *dynamoTableSchema) ([]byte, bool) {
+// reads, classifying the read into queryLeaseSingleGroup (resolved prefix),
+// queryLeaseAllGroups (whole-table prefix: a valid multi-shard read), or
+// queryLeaseSkip (malformed KeyConditionExpression: a validation error the
+// read path rejects identically). The validation error is deliberately not
+// surfaced — only the routing classification matters here, and the read path
+// reports the identical error downstream.
+func queryLeasePrefix(in queryInput, schema *dynamoTableSchema) ([]byte, queryLeasePlan) {
 	keySchema, cond, err := resolveQueryCondition(in, schema)
 	if err != nil {
-		return nil, false
+		// Malformed/unsupported KeyConditionExpression: a deterministic
+		// ValidationException the read path produces without touching data.
+		return nil, queryLeaseSkip
 	}
 	// A query whose key schema hash key differs from the primary hash
 	// key reads the whole-table prefix (see queryScanPrefix), which can
-	// span multiple shards; let the keyless check cover them.
+	// span multiple shards; let the all-groups check cover them.
 	if keySchema.HashKey != schema.PrimaryKey.HashKey {
-		return nil, false
+		return nil, queryLeaseAllGroups
 	}
 	prefix, err := queryScanPrefix(schema, in, keySchema, cond.hashValue)
 	if err != nil {
-		return nil, false
+		// queryScanPrefix only fails on an unparseable hash-key value — a
+		// ValidationException the read path rejects identically.
+		return nil, queryLeaseSkip
 	}
-	return prefix, true
+	return prefix, queryLeaseSingleGroup
 }
 
 func decodeQueryInput(bodyReader io.Reader) (queryInput, error) {

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -2155,14 +2155,16 @@ func (d *DynamoDBServer) query(w http.ResponseWriter, r *http.Request) {
 		writeDynamoErrorFromErr(w, err)
 		return
 	}
-	// A Query scans a key range that, in a multi-group deployment, can
-	// span more than one shard, and the owning shard cannot be resolved
-	// here without duplicating prepareReadSchema / resolveQueryCondition.
-	// Use the keyless lease check so the quorum-freshness bound covers
-	// every shard the range can touch BEFORE queryItems samples readTS;
-	// sampling readTS only after the confirmation keeps any commit that
-	// landed before the confirmation visible.
-	if !d.leaseReadKeyless(w, r) {
+	// Lease-check the shard the Query reads BEFORE queryItems samples
+	// readTS, so the quorum-freshness bound is established without
+	// changing read-snapshot semantics (sampling readTS only after the
+	// confirmation keeps any commit that landed before it visible). A
+	// base-table Query on a single partition key reads exactly one
+	// hash-key prefix, which routes to one shard group, so the check is
+	// routed by that prefix in a multi-group deployment. GSI queries and
+	// queries whose prefix cannot be resolved fall back to the keyless
+	// check, which spans every shard the range can touch.
+	if !d.leaseCheckQuery(w, r, in) {
 		return
 	}
 	out, err := d.queryItems(r.Context(), in)
@@ -2226,6 +2228,65 @@ func (d *DynamoDBServer) leaseReadKeyless(w http.ResponseWriter, r *http.Request
 		return false
 	}
 	return true
+}
+
+// leaseCheckQuery lease-checks the shard a Query reads with a bounded
+// timeout, writing the same InternalServerError getItem produces on
+// failure. When the request resolves to a single base-table hash-key
+// prefix (the common case), the check is routed to that prefix's owning
+// group via LeaseReadForKey so a multi-group deployment confirms the
+// shard that actually holds the data — not the default group. GSI
+// queries and any request whose prefix cannot be resolved here fall back
+// to the keyless check, which establishes freshness across every shard
+// the range can touch. Returns false after writing an error response;
+// the caller should simply return.
+func (d *DynamoDBServer) leaseCheckQuery(w http.ResponseWriter, r *http.Request, in queryInput) bool {
+	leaseKey, ok := d.queryLeaseKey(r.Context(), in)
+	if !ok {
+		return d.leaseReadKeyless(w, r)
+	}
+	leaseCtx, leaseCancel := context.WithTimeout(r.Context(), dynamoLeaseReadTimeout)
+	defer leaseCancel()
+	if _, err := kv.LeaseReadForKeyThrough(d.coordinator, leaseCtx, leaseKey); err != nil {
+		writeDynamoError(w, http.StatusInternalServerError, dynamoErrInternal, err.Error())
+		return false
+	}
+	return true
+}
+
+// queryLeaseKey resolves the single hash-key prefix a base-table Query
+// reads, at a tentative timestamp (schema only, no readTS sampling), so
+// the lease check can be routed to the owning shard group. It returns
+// (_, false) — signalling the caller to fall back to a keyless lease
+// check — for GSI queries, requests that read the whole-table prefix, or
+// any case where the schema/condition cannot be resolved without
+// duplicating queryItems error handling. Resolution failures here are
+// not surfaced as errors: the read path re-runs the same resolution and
+// reports the identical validation error, so error mapping is unchanged.
+func (d *DynamoDBServer) queryLeaseKey(ctx context.Context, in queryInput) ([]byte, bool) {
+	if strings.TrimSpace(in.IndexName) != "" {
+		return nil, false
+	}
+	tentativeTS := snapshotTS(d.coordinator.Clock(), d.store)
+	schema, exists, err := d.loadTableSchemaAt(ctx, in.TableName, tentativeTS)
+	if err != nil || !exists {
+		return nil, false
+	}
+	keySchema, cond, err := resolveQueryCondition(in, schema)
+	if err != nil {
+		return nil, false
+	}
+	// A query whose key schema hash key differs from the primary hash
+	// key reads the whole-table prefix (see queryScanPrefix), which can
+	// span multiple shards; let the keyless check cover them.
+	if keySchema.HashKey != schema.PrimaryKey.HashKey {
+		return nil, false
+	}
+	prefix, err := queryScanPrefix(schema, in, keySchema, cond.hashValue)
+	if err != nil {
+		return nil, false
+	}
+	return prefix, true
 }
 
 func decodeQueryInput(bodyReader io.Reader) (queryInput, error) {
@@ -4303,21 +4364,27 @@ func (d *DynamoDBServer) transactGetItems(w http.ResponseWriter, r *http.Request
 }
 
 // leaseCheckTransactGetItems performs a quorum-freshness lease check on every
-// shard the TransactGetItems request will read, deduplicated by item key, with
-// a bounded timeout. Item keys are resolved at a tentative timestamp (schemas
-// change rarely, so a slight pre-lease stale schema is acceptable) used only to
-// route the lease check; the actual snapshot timestamp is sampled by the caller
-// afterwards. Items whose schema or key cannot be resolved here are skipped:
-// they never reach a store read, and buildTransactGetItemsResponses surfaces the
-// identical validation error downstream so error mapping is unchanged. Returns
-// false after writing the same InternalServerError getItem produces on lease
-// failure; the caller should simply return.
+// shard the TransactGetItems request will read, with a bounded timeout, BEFORE
+// the caller resolves the single snapshot timestamp. Item keys are resolved at a
+// tentative timestamp (schemas change rarely, so a slight pre-lease stale schema
+// is acceptable) used only to route the lease check; the actual snapshot
+// timestamp is sampled by the caller afterwards. Items whose schema or key
+// cannot be resolved here are skipped: they never reach a store read, and
+// buildTransactGetItemsResponses surfaces the identical validation error
+// downstream so error mapping is unchanged.
+//
+// Keys are first deduplicated by value, then collapsed to one representative key
+// per owning Raft group, so a transaction touching up to transactGetItemsMaxItems
+// keys that share a group issues a single lease read instead of one per key.
+// Each group maintains its own lease, so checking one key per group still
+// establishes freshness for every shard the transaction reads. Returns false
+// after writing the same InternalServerError getItem produces on lease failure;
+// the caller should simply return.
 func (d *DynamoDBServer) leaseCheckTransactGetItems(w http.ResponseWriter, r *http.Request, in transactGetItemsInput) bool {
 	tentativeTS := snapshotTS(d.coordinator.Clock(), d.store)
 	schemaCache := make(map[string]*dynamoTableSchema)
 	seenKeys := make(map[string]struct{}, len(in.TransactItems))
-	leaseCtx, leaseCancel := context.WithTimeout(r.Context(), dynamoLeaseReadTimeout)
-	defer leaseCancel()
+	uniqueKeys := make([][]byte, 0, len(in.TransactItems))
 	for _, item := range in.TransactItems {
 		itemKey, ok := d.transactGetItemKey(r.Context(), item, schemaCache, tentativeTS)
 		if !ok {
@@ -4327,6 +4394,11 @@ func (d *DynamoDBServer) leaseCheckTransactGetItems(w http.ResponseWriter, r *ht
 			continue
 		}
 		seenKeys[string(itemKey)] = struct{}{}
+		uniqueKeys = append(uniqueKeys, itemKey)
+	}
+	leaseCtx, leaseCancel := context.WithTimeout(r.Context(), dynamoLeaseReadTimeout)
+	defer leaseCancel()
+	for _, itemKey := range kv.LeaseReadGroupKeys(d.coordinator, uniqueKeys) {
 		if _, err := kv.LeaseReadForKeyThrough(d.coordinator, leaseCtx, itemKey); err != nil {
 			writeDynamoError(w, http.StatusInternalServerError, dynamoErrInternal, err.Error())
 			return false

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -2227,9 +2227,16 @@ func (d *DynamoDBServer) scan(w http.ResponseWriter, r *http.Request) {
 // client never cancels, and writes the same InternalServerError that getItem
 // produces on lease failure. Returns false after writing an error response;
 // the caller should simply return.
-func (d *DynamoDBServer) leaseReadKeyless(w http.ResponseWriter, r *http.Request) bool {
-	leaseCtx, leaseCancel := context.WithTimeout(r.Context(), dynamoLeaseReadTimeout)
-	defer leaseCancel()
+// leaseReadKeyless fences every group via the keyless all-groups lease check.
+// `leaseCtx` MUST be the SAME context the pre-pass armed (it bounds the entire
+// pre-pass — schema read + the lease that lands here — by dynamoLeaseReadTimeout
+// total; coderabbit Major on PR #952 round-4). Creating a fresh
+// context.WithTimeout(r.Context(), dynamoLeaseReadTimeout) here would re-arm
+// the 5s budget per call, so a slow schema read followed by the keyless
+// fallback could consume close to 10s end-to-end. Callers that do NOT have a
+// pre-pass context must pass their own bounded ctx; r.Context() with the
+// handler's own timeout-on-the-roundabout is the conservative choice.
+func (d *DynamoDBServer) leaseReadKeyless(w http.ResponseWriter, leaseCtx context.Context) bool {
 	if err := kv.LeaseReadAllGroupsThrough(d.coordinator, leaseCtx); err != nil {
 		writeDynamoError(w, http.StatusInternalServerError, dynamoErrInternal, err.Error())
 		return false
@@ -2260,7 +2267,7 @@ func (d *DynamoDBServer) leaseCheckScan(w http.ResponseWriter, r *http.Request, 
 		// Transient/internal schema-read failure: fail closed by fencing every
 		// group. leaseReadKeyless writes the same InternalServerError on its
 		// own failure.
-		return d.leaseReadKeyless(w, r)
+		return d.leaseReadKeyless(w, leaseCtx)
 	}
 	if plan == queryLeaseSkip {
 		// Client-side validation problem (table not found, unknown index,
@@ -2288,7 +2295,7 @@ func (d *DynamoDBServer) leaseCheckScan(w http.ResponseWriter, r *http.Request, 
 		return true
 	}
 	// Valid whole-table read: fence every group (fail closed).
-	return d.leaseReadKeyless(w, r)
+	return d.leaseReadKeyless(w, leaseCtx)
 }
 
 // projectionInvalid returns true when the ProjectionExpression cannot be
@@ -2404,7 +2411,7 @@ func (d *DynamoDBServer) leaseCheckQuery(w http.ResponseWriter, r *http.Request,
 		// keyless check (a strict superset of the single group this query
 		// would have routed to). leaseReadKeyless writes the same
 		// InternalServerError on its own failure.
-		return d.leaseReadKeyless(w, r)
+		return d.leaseReadKeyless(w, leaseCtx)
 	}
 	switch plan {
 	case queryLeaseSkip:
@@ -2420,7 +2427,7 @@ func (d *DynamoDBServer) leaseCheckQuery(w http.ResponseWriter, r *http.Request,
 	case queryLeaseAllGroups:
 		// GSI / whole-table query: a VALID read that spans multiple shards,
 		// so the keyless all-groups check is the correct fence (fail closed).
-		return d.leaseReadKeyless(w, r)
+		return d.leaseReadKeyless(w, leaseCtx)
 	case queryLeaseSingleGroup:
 		if _, err := kv.LeaseReadForKeyThrough(d.coordinator, leaseCtx, leaseKey); err != nil {
 			writeDynamoError(w, http.StatusInternalServerError, dynamoErrInternal, err.Error())
@@ -2430,7 +2437,7 @@ func (d *DynamoDBServer) leaseCheckQuery(w http.ResponseWriter, r *http.Request,
 	default:
 		// Unreachable: queryLeaseKey only returns the three plans above. Fail
 		// closed via the all-groups fence rather than silently proceeding.
-		return d.leaseReadKeyless(w, r)
+		return d.leaseReadKeyless(w, leaseCtx)
 	}
 }
 
@@ -4775,14 +4782,24 @@ func (d *DynamoDBServer) leaseReadGroupKeys(ctx context.Context, groupKeys [][]b
 		_, err := kv.LeaseReadForKeyThrough(d.coordinator, ctx, groupKeys[0])
 		return errors.WithStack(err)
 	}
+	// Derive a cancellable child so the first error cancels the sibling lease
+	// reads instead of letting them run out the full dynamoLeaseReadTimeout
+	// budget (coderabbit Major on PR #952 round-4). The siblings observe the
+	// cancellation via the LeaseReadForKeyThrough's own context check.
+	cancelCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	errCh := make(chan error, len(groupKeys))
 	var wg sync.WaitGroup
 	for _, itemKey := range groupKeys {
 		wg.Add(1)
 		go func(k []byte) {
 			defer wg.Done()
-			if _, err := kv.LeaseReadForKeyThrough(d.coordinator, ctx, k); err != nil {
-				errCh <- err
+			if _, err := kv.LeaseReadForKeyThrough(d.coordinator, cancelCtx, k); err != nil {
+				select {
+				case errCh <- err:
+					cancel() // unwind the remaining goroutines on the first error.
+				default:
+				}
 			}
 		}(itemKey)
 	}

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -2215,15 +2215,20 @@ func (d *DynamoDBServer) scan(w http.ResponseWriter, r *http.Request) {
 }
 
 // leaseReadKeyless performs a keyless quorum-freshness lease check for
-// multi-shard read handlers (Query, Scan). It bounds the wait with
-// dynamoLeaseReadTimeout so a stalled Raft cannot hang the handler when
-// the client never cancels, and writes the same InternalServerError that
-// getItem produces on lease failure. Returns false after writing an
-// error response; the caller should simply return.
+// multi-shard read handlers (Scan, GSI/whole-table Query fallback). These
+// reads visit every shard the range intersects, so the check fences EVERY
+// group the coordinator owns via LeaseReadAllGroupsThrough — a default-group-
+// only lease would let a non-default group serve a stale snapshot. A
+// single-group coordinator falls back to one LeaseRead, so single-group
+// deployments still issue exactly one lease read. It bounds the wait with
+// dynamoLeaseReadTimeout so a stalled Raft cannot hang the handler when the
+// client never cancels, and writes the same InternalServerError that getItem
+// produces on lease failure. Returns false after writing an error response;
+// the caller should simply return.
 func (d *DynamoDBServer) leaseReadKeyless(w http.ResponseWriter, r *http.Request) bool {
 	leaseCtx, leaseCancel := context.WithTimeout(r.Context(), dynamoLeaseReadTimeout)
 	defer leaseCancel()
-	if _, err := kv.LeaseReadThrough(d.coordinator, leaseCtx); err != nil {
+	if err := kv.LeaseReadAllGroupsThrough(d.coordinator, leaseCtx); err != nil {
 		writeDynamoError(w, http.StatusInternalServerError, dynamoErrInternal, err.Error())
 		return false
 	}
@@ -2247,8 +2252,18 @@ func (d *DynamoDBServer) leaseCheckQuery(w http.ResponseWriter, r *http.Request,
 	// phase begins. The keyless fallback creates its own bounded context.
 	leaseCtx, leaseCancel := context.WithTimeout(r.Context(), dynamoLeaseReadTimeout)
 	defer leaseCancel()
-	leaseKey, ok := d.queryLeaseKey(leaseCtx, in)
+	leaseKey, ok, err := d.queryLeaseKey(leaseCtx, in)
+	if err != nil {
+		// Transient/internal schema read failure: the routing key could
+		// not be resolved, so fail closed by fencing EVERY group via the
+		// keyless check (a strict superset of the single group this query
+		// would have routed to). leaseReadKeyless writes the same
+		// InternalServerError on its own failure.
+		return d.leaseReadKeyless(w, r)
+	}
 	if !ok {
+		// GSI / whole-table / unresolved-but-valid query: spans multiple
+		// shards, so the keyless all-groups check is the correct fence.
 		return d.leaseReadKeyless(w, r)
 	}
 	if _, err := kv.LeaseReadForKeyThrough(d.coordinator, leaseCtx, leaseKey); err != nil {
@@ -2261,21 +2276,47 @@ func (d *DynamoDBServer) leaseCheckQuery(w http.ResponseWriter, r *http.Request,
 // queryLeaseKey resolves the single hash-key prefix a base-table Query
 // reads, at a tentative timestamp (schema only, no readTS sampling), so
 // the lease check can be routed to the owning shard group. It returns
-// (_, false) — signalling the caller to fall back to a keyless lease
-// check — for GSI queries, requests that read the whole-table prefix, or
-// any case where the schema/condition cannot be resolved without
-// duplicating queryItems error handling. Resolution failures here are
-// not surfaced as errors: the read path re-runs the same resolution and
-// reports the identical validation error, so error mapping is unchanged.
-func (d *DynamoDBServer) queryLeaseKey(ctx context.Context, in queryInput) ([]byte, bool) {
+// (prefix, true, nil) when the query routes to exactly one shard group,
+// (nil, false, nil) when the caller should fall back to a keyless all-groups
+// lease check (GSI query, whole-table prefix, table not found, or a query
+// condition that cannot be resolved — all surfaced identically by the read
+// path), and (nil, false, err) for a TRANSIENT/INTERNAL schema-read failure
+// (leaseCtx deadline, Pebble error) so the caller fails closed instead of
+// proceeding with no fence. Validation failures here are not surfaced as
+// errors: the read path re-runs the same resolution and reports the identical
+// validation error, so error mapping is unchanged.
+func (d *DynamoDBServer) queryLeaseKey(ctx context.Context, in queryInput) ([]byte, bool, error) {
 	if strings.TrimSpace(in.IndexName) != "" {
-		return nil, false
+		return nil, false, nil
 	}
 	tentativeTS := snapshotTS(d.coordinator.Clock(), d.store)
 	schema, exists, err := d.loadTableSchemaAt(ctx, in.TableName, tentativeTS)
-	if err != nil || !exists {
-		return nil, false
+	if err != nil {
+		// loadTableSchemaAt maps ErrKeyNotFound to (_, false, nil); any
+		// error reaching here is a transient store/context/decode failure,
+		// so fail closed.
+		return nil, false, errors.WithStack(err)
 	}
+	if !exists {
+		return nil, false, nil
+	}
+	// resolveQueryCondition / queryScanPrefix only fail on a malformed
+	// query condition (invalid key, unsupported operator) — pure
+	// validation errors that the read path re-runs and rejects identically.
+	// queryLeasePrefix discards them (the caller falls back to the keyless
+	// all-groups check, a strict superset of the single group this query
+	// would have routed to), so only a non-validation, transient/internal
+	// error (already handled above at loadTableSchemaAt) ever fails closed.
+	prefix, ok := queryLeasePrefix(in, schema)
+	return prefix, ok, nil
+}
+
+// queryLeasePrefix resolves the single hash-key prefix a base-table Query
+// reads, returning ok=false for GSI/whole-table/malformed-condition queries
+// that must fall back to the keyless all-groups lease check. Validation
+// errors are deliberately swallowed: they are not surfaced as a routing key,
+// and the read path reports the identical error downstream.
+func queryLeasePrefix(in queryInput, schema *dynamoTableSchema) ([]byte, bool) {
 	keySchema, cond, err := resolveQueryCondition(in, schema)
 	if err != nil {
 		return nil, false
@@ -4397,8 +4438,21 @@ func (d *DynamoDBServer) leaseCheckTransactGetItems(w http.ResponseWriter, r *ht
 	seenKeys := make(map[string]struct{}, len(in.TransactItems))
 	uniqueKeys := make([][]byte, 0, len(in.TransactItems))
 	for _, item := range in.TransactItems {
-		itemKey, ok := d.transactGetItemKey(leaseCtx, item, schemaCache, tentativeTS)
+		itemKey, ok, err := d.transactGetItemKey(leaseCtx, item, schemaCache, tentativeTS)
+		if err != nil {
+			// Transient/internal schema read failure (leaseCtx deadline,
+			// Pebble error). Fail closed: silently dropping the item would
+			// leave its shard unfenced and let the later read return a
+			// stale snapshot under exactly the slow conditions the fence
+			// targets. Same InternalServerError mapping as a lease failure.
+			writeDynamoError(w, http.StatusInternalServerError, dynamoErrInternal, err.Error())
+			return false
+		}
 		if !ok {
+			// Malformed input (nil Get, empty/unknown table, unresolvable
+			// key). Skipping is safe: the item never reaches a store read,
+			// and buildTransactGetItemsResponses surfaces the identical
+			// validation error downstream so error mapping is unchanged.
 			continue
 		}
 		if _, dup := seenKeys[string(itemKey)]; dup {
@@ -4424,18 +4478,43 @@ func (d *DynamoDBServer) leaseCheckTransactGetItems(w http.ResponseWriter, r *ht
 }
 
 // transactGetItemKey resolves the storage key for one TransactGetItems Get at
-// the tentative timestamp, returning false when the item is malformed or its
-// schema/key cannot be resolved. It never writes a response: validation is left
-// to the read path so error mapping stays identical.
-func (d *DynamoDBServer) transactGetItemKey(ctx context.Context, item transactGetItem, schemaCache map[string]*dynamoTableSchema, tentativeTS uint64) ([]byte, bool) {
+// the tentative timestamp. It returns (key, true, nil) on success,
+// (nil, false, nil) when the item is MALFORMED (nil Get, empty/unknown table,
+// or an invalid key) — the read path rejects those identically, so the lease
+// pre-pass may safely skip them — and (nil, false, err) for a TRANSIENT or
+// INTERNAL schema-read failure (leaseCtx deadline, Pebble error) that the
+// caller MUST fail closed on rather than skip, otherwise the item's shard goes
+// unfenced and a stale read can slip through. The malformed/transient split
+// keys off dynamoErrIsTransient: validation errors are *dynamoAPIError,
+// everything else is treated as transient. It never writes a response:
+// validation is left to the read path so error mapping stays identical.
+func (d *DynamoDBServer) transactGetItemKey(ctx context.Context, item transactGetItem, schemaCache map[string]*dynamoTableSchema, tentativeTS uint64) ([]byte, bool, error) {
 	if item.Get == nil || strings.TrimSpace(item.Get.TableName) == "" {
-		return nil, false
+		return nil, false, nil
 	}
 	schema, err := d.resolveTransactTableSchema(ctx, schemaCache, item.Get.TableName, tentativeTS)
 	if err != nil {
-		return nil, false
+		if dynamoErrIsTransient(err) {
+			return nil, false, errors.WithStack(err)
+		}
+		// Validation error (table not found): the read path rejects it
+		// identically, so skip rather than fail closed.
+		return nil, false, nil
 	}
-	itemKey, err := schema.itemKeyFromAttributes(item.Get.Key)
+	// itemKeyFromAttributes only fails on malformed key attributes
+	// (missing/unparseable hash or range key), a pure validation error the
+	// read path rejects identically; transactGetItemKeyFromSchema swallows
+	// it to ok=false so the item is skipped, not failed closed.
+	itemKey, ok := transactGetItemKeyFromSchema(schema, item.Get.Key)
+	return itemKey, ok, nil
+}
+
+// transactGetItemKeyFromSchema computes the storage key for a TransactGetItems
+// Get, returning ok=false when the key attributes are malformed. The error is
+// deliberately discarded: it is a validation failure the read path reports
+// downstream, and the lease pre-pass only needs the routing key.
+func transactGetItemKeyFromSchema(schema *dynamoTableSchema, key map[string]attributeValue) ([]byte, bool) {
+	itemKey, err := schema.itemKeyFromAttributes(key)
 	if err != nil {
 		return nil, false
 	}
@@ -5334,6 +5413,22 @@ func writeDynamoErrorFromErr(w http.ResponseWriter, err error) {
 		return
 	}
 	writeDynamoError(w, http.StatusInternalServerError, dynamoErrInternal, err.Error())
+}
+
+// dynamoErrIsTransient reports whether err is a transient/internal failure
+// (Pebble error, context deadline, decode failure) as opposed to a structured
+// validation/malformed-input error. A *dynamoAPIError is always a deliberate
+// validation result (it carries an HTTP status + error type), so it is NOT
+// transient; everything else — a raw wrapped store/context error — is. The
+// lease pre-pass uses this to decide whether an unresolvable item must fail
+// closed (transient) or may be skipped (validation, rejected identically by
+// the read path).
+func dynamoErrIsTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+	var apiErr *dynamoAPIError
+	return !errors.As(err, &apiErr)
 }
 
 func writeDynamoError(w http.ResponseWriter, status int, errorType string, message string) {

--- a/adapter/dynamodb_lease_deadline_test.go
+++ b/adapter/dynamodb_lease_deadline_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/bootjp/elastickv/store"
@@ -19,17 +21,31 @@ import (
 type schemaDeadlineStore struct {
 	store.MVCCStore
 
-	metaKey         []byte
+	metaKey []byte
+
+	// mu guards sawMetaGet/metaHadDeadline so the check-then-set in GetAt is
+	// race-free if the handler ever issues concurrent schema reads.
+	mu              sync.Mutex
 	sawMetaGet      bool
 	metaHadDeadline bool
 }
 
 func (s *schemaDeadlineStore) GetAt(ctx context.Context, key []byte, ts uint64) ([]byte, error) {
-	if !s.sawMetaGet && bytes.Equal(key, s.metaKey) {
-		s.sawMetaGet = true
-		_, s.metaHadDeadline = ctx.Deadline()
+	if bytes.Equal(key, s.metaKey) {
+		s.mu.Lock()
+		if !s.sawMetaGet {
+			s.sawMetaGet = true
+			_, s.metaHadDeadline = ctx.Deadline()
+		}
+		s.mu.Unlock()
 	}
 	return s.MVCCStore.GetAt(ctx, key, ts)
+}
+
+func (s *schemaDeadlineStore) observed() (sawMetaGet bool, metaHadDeadline bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sawMetaGet, s.metaHadDeadline
 }
 
 // newSchemaDeadlineServer builds a DynamoDB server over a real MVCC store
@@ -95,8 +111,9 @@ func TestDynamoDB_LeaseCheckQuery_SchemaReadBounded(t *testing.T) {
 	rec := httptest.NewRecorder()
 	require.True(t, server.leaseCheckQuery(rec, noDeadlineRequest(t), in))
 
-	require.True(t, recording.sawMetaGet, "lease pre-pass must read the table schema")
-	require.True(t, recording.metaHadDeadline,
+	sawMetaGet, metaHadDeadline := recording.observed()
+	require.True(t, sawMetaGet, "lease pre-pass must read the table schema")
+	require.True(t, metaHadDeadline,
 		"queryLeaseKey schema read must run under the bounded leaseCtx, not the deadline-free request context")
 }
 
@@ -124,8 +141,9 @@ func TestDynamoDB_LeaseCheckTransactGetItems_SchemaReadBounded(t *testing.T) {
 	rec := httptest.NewRecorder()
 	require.True(t, server.leaseCheckTransactGetItems(rec, noDeadlineRequest(t), in))
 
-	require.True(t, recording.sawMetaGet, "lease pre-pass must read the table schema")
-	require.True(t, recording.metaHadDeadline,
+	sawMetaGet, metaHadDeadline := recording.observed()
+	require.True(t, sawMetaGet, "lease pre-pass must read the table schema")
+	require.True(t, metaHadDeadline,
 		"transactGetItemKey schema read must run under the bounded leaseCtx, not the deadline-free request context")
 }
 
@@ -155,27 +173,29 @@ func TestDynamoDB_LeaseCheckTransactGetItems_AllItemsSkippedNoLeaseRead(t *testi
 
 	rec := httptest.NewRecorder()
 	require.True(t, server.leaseCheckTransactGetItems(rec, noDeadlineRequest(t), in))
-	require.Equal(t, 0, wrapped.leaseReadForKeyCalls,
+	require.Equal(t, int64(0), wrapped.leaseReadForKeyCalls.Load(),
 		"all-items-skipped path must not issue a lease read when no shard is touched")
-	require.Equal(t, 0, wrapped.leaseReadCalls,
+	require.Equal(t, int64(0), wrapped.leaseReadCalls.Load(),
 		"all-items-skipped path must not fall back to the keyless lease check")
 	require.Equal(t, http.StatusOK, rec.Code, "no error response should be written")
 }
 
 // leaseReadCountingCoordinator wraps stubAdapterCoordinator and counts
-// lease-read calls so a test can assert none were issued.
+// lease-read calls so a test can assert none were issued. The counters are
+// atomic so the assertions stay race-free if a handler ever fans out lease
+// reads concurrently.
 type leaseReadCountingCoordinator struct {
 	*stubAdapterCoordinator
-	leaseReadCalls       int
-	leaseReadForKeyCalls int
+	leaseReadCalls       atomic.Int64
+	leaseReadForKeyCalls atomic.Int64
 }
 
 func (c *leaseReadCountingCoordinator) LeaseRead(ctx context.Context) (uint64, error) {
-	c.leaseReadCalls++
+	c.leaseReadCalls.Add(1)
 	return c.stubAdapterCoordinator.LeaseRead(ctx)
 }
 
 func (c *leaseReadCountingCoordinator) LeaseReadForKey(ctx context.Context, key []byte) (uint64, error) {
-	c.leaseReadForKeyCalls++
+	c.leaseReadForKeyCalls.Add(1)
 	return c.stubAdapterCoordinator.LeaseReadForKey(ctx, key)
 }

--- a/adapter/dynamodb_lease_deadline_test.go
+++ b/adapter/dynamodb_lease_deadline_test.go
@@ -1,0 +1,181 @@
+package adapter
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bootjp/elastickv/store"
+	"github.com/stretchr/testify/require"
+)
+
+// schemaDeadlineStore records, for the first GetAt on a DynamoDB table
+// meta key, whether the context carried a deadline. The lease-read
+// pre-pass resolves keys by reading the schema; if that read runs under
+// a context with no deadline, a stalled schema read can block the handler
+// indefinitely before the bounded lease phase begins (claude #952 issue #2).
+type schemaDeadlineStore struct {
+	store.MVCCStore
+
+	metaKey         []byte
+	sawMetaGet      bool
+	metaHadDeadline bool
+}
+
+func (s *schemaDeadlineStore) GetAt(ctx context.Context, key []byte, ts uint64) ([]byte, error) {
+	if !s.sawMetaGet && bytes.Equal(key, s.metaKey) {
+		s.sawMetaGet = true
+		_, s.metaHadDeadline = ctx.Deadline()
+	}
+	return s.MVCCStore.GetAt(ctx, key, ts)
+}
+
+// newSchemaDeadlineServer builds a DynamoDB server over a real MVCC store
+// fronted by schemaDeadlineStore, seeds one table schema + item, and
+// returns the server and the recording store.
+func newSchemaDeadlineServer(t *testing.T) (*DynamoDBServer, *schemaDeadlineStore) {
+	t.Helper()
+
+	schema := &dynamoTableSchema{
+		TableName:          "t",
+		Generation:         1,
+		KeyEncodingVersion: dynamoOrderedKeyEncodingV2,
+		AttributeDefinitions: map[string]string{
+			"pk": "S",
+			"sk": "S",
+		},
+		PrimaryKey: dynamoKeySchema{HashKey: "pk", RangeKey: "sk"},
+	}
+
+	recording := &schemaDeadlineStore{
+		MVCCStore: store.NewMVCCStore(),
+		metaKey:   dynamoTableMetaKey(schema.TableName),
+	}
+	writer := newDynamoFixtureWriter(t, recording.MVCCStore)
+	writer.writeSchema(schema)
+	writer.writeItem(schema, map[string]attributeValue{
+		"pk": newStringAttributeValue("tenant"),
+		"sk": newStringAttributeValue("0001"),
+	})
+
+	server := NewDynamoDBServer(nil, recording, &stubAdapterCoordinator{})
+	return server, recording
+}
+
+// noDeadlineRequest returns a request whose context has NO deadline, so the
+// only way the schema pre-fetch can observe a deadline is via the bounded
+// leaseCtx the handler must establish before resolving keys.
+func noDeadlineRequest(t *testing.T) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	_, hasDeadline := req.Context().Deadline()
+	require.False(t, hasDeadline, "test precondition: request context must have no deadline")
+	return req
+}
+
+// TestDynamoDB_LeaseCheckQuery_SchemaReadBounded asserts the base-table
+// Query lease pre-pass resolves the routing key under the bounded leaseCtx,
+// so a stalled schema read cannot block past dynamoLeaseReadTimeout before
+// the lease phase begins (claude #952 issue #2).
+func TestDynamoDB_LeaseCheckQuery_SchemaReadBounded(t *testing.T) {
+	t.Parallel()
+
+	server, recording := newSchemaDeadlineServer(t)
+
+	in := queryInput{
+		TableName:              "t",
+		KeyConditionExpression: "pk = :pk",
+		ExpressionAttributeValues: map[string]attributeValue{
+			":pk": newStringAttributeValue("tenant"),
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	require.True(t, server.leaseCheckQuery(rec, noDeadlineRequest(t), in))
+
+	require.True(t, recording.sawMetaGet, "lease pre-pass must read the table schema")
+	require.True(t, recording.metaHadDeadline,
+		"queryLeaseKey schema read must run under the bounded leaseCtx, not the deadline-free request context")
+}
+
+// TestDynamoDB_LeaseCheckTransactGetItems_SchemaReadBounded asserts the
+// TransactGetItems lease pre-pass resolves item keys under the bounded
+// leaseCtx, so a stalled schema read cannot block past dynamoLeaseReadTimeout
+// before the lease phase begins (claude #952 issue #2).
+func TestDynamoDB_LeaseCheckTransactGetItems_SchemaReadBounded(t *testing.T) {
+	t.Parallel()
+
+	server, recording := newSchemaDeadlineServer(t)
+
+	in := transactGetItemsInput{
+		TransactItems: []transactGetItem{
+			{Get: &transactGetItemGet{
+				TableName: "t",
+				Key: map[string]attributeValue{
+					"pk": newStringAttributeValue("tenant"),
+					"sk": newStringAttributeValue("0001"),
+				},
+			}},
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	require.True(t, server.leaseCheckTransactGetItems(rec, noDeadlineRequest(t), in))
+
+	require.True(t, recording.sawMetaGet, "lease pre-pass must read the table schema")
+	require.True(t, recording.metaHadDeadline,
+		"transactGetItemKey schema read must run under the bounded leaseCtx, not the deadline-free request context")
+}
+
+// TestDynamoDB_LeaseCheckTransactGetItems_AllItemsSkippedNoLeaseRead asserts
+// that when every TransactItems entry fails key resolution (malformed Get),
+// the pre-pass touches no shard and returns true without issuing a lease
+// read — making the implicit empty-uniqueKeys fallback explicit
+// (claude #952 issue #1).
+func TestDynamoDB_LeaseCheckTransactGetItems_AllItemsSkippedNoLeaseRead(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	wrapped := &leaseReadCountingCoordinator{stubAdapterCoordinator: &stubAdapterCoordinator{}}
+	server := NewDynamoDBServer(nil, st, wrapped)
+
+	// No schema is written, so transactGetItemKey cannot resolve any key:
+	// every item is skipped and uniqueKeys stays empty.
+	in := transactGetItemsInput{
+		TransactItems: []transactGetItem{
+			{Get: &transactGetItemGet{
+				TableName: "missing",
+				Key:       map[string]attributeValue{"pk": newStringAttributeValue("x")},
+			}},
+			{Get: nil},
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	require.True(t, server.leaseCheckTransactGetItems(rec, noDeadlineRequest(t), in))
+	require.Equal(t, 0, wrapped.leaseReadForKeyCalls,
+		"all-items-skipped path must not issue a lease read when no shard is touched")
+	require.Equal(t, 0, wrapped.leaseReadCalls,
+		"all-items-skipped path must not fall back to the keyless lease check")
+	require.Equal(t, http.StatusOK, rec.Code, "no error response should be written")
+}
+
+// leaseReadCountingCoordinator wraps stubAdapterCoordinator and counts
+// lease-read calls so a test can assert none were issued.
+type leaseReadCountingCoordinator struct {
+	*stubAdapterCoordinator
+	leaseReadCalls       int
+	leaseReadForKeyCalls int
+}
+
+func (c *leaseReadCountingCoordinator) LeaseRead(ctx context.Context) (uint64, error) {
+	c.leaseReadCalls++
+	return c.stubAdapterCoordinator.LeaseRead(ctx)
+}
+
+func (c *leaseReadCountingCoordinator) LeaseReadForKey(ctx context.Context, key []byte) (uint64, error) {
+	c.leaseReadForKeyCalls++
+	return c.stubAdapterCoordinator.LeaseReadForKey(ctx, key)
+}

--- a/adapter/dynamodb_lease_fence_test.go
+++ b/adapter/dynamodb_lease_fence_test.go
@@ -100,7 +100,7 @@ func TestDynamoDB_ScanLeaseFencesAllGroups(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
-	require.True(t, server.leaseReadKeyless(rec, req))
+	require.True(t, server.leaseReadKeyless(rec, req.Context()))
 
 	fenced := coord.fencedGroupSet()
 	require.Contains(t, fenced, multiGroupDefaultID,

--- a/adapter/dynamodb_lease_fence_test.go
+++ b/adapter/dynamodb_lease_fence_test.go
@@ -219,6 +219,65 @@ func TestDynamoDB_TransactGetItems_TransientSchemaReadFailsClosed(t *testing.T) 
 	require.Contains(t, rec.Body.String(), dynamoErrInternal)
 }
 
+// TestDynamoDB_TransactGetItems_MalformedMixedWithValidSkipsLease asserts the
+// regression for codex P2 #952 (line 4621): when a TransactGetItems request
+// mixes a malformed item (validation error: table not found) with at least one
+// VALID item, the whole transaction is doomed by validation, and the read path
+// will return a deterministic 4xx via buildTransactGetItemsResponses without
+// touching a store. The lease pre-pass must therefore skip leasing the valid
+// keys; otherwise, in a degraded shard where the lease cannot be confirmed,
+// the handler returns a 500 InternalServerError that masks the 4xx error
+// mapping. Pre-fix the loop kept the valid item's key in uniqueKeys and called
+// LeaseReadForKeyThrough — this test asserts the post-fix behaviour: no lease
+// call, and the handler returns true so the caller falls through to the
+// validation 4xx.
+func TestDynamoDB_TransactGetItems_MalformedMixedWithValidSkipsLease(t *testing.T) {
+	t.Parallel()
+
+	// Set up a schema for "t" so the second item resolves cleanly, but
+	// leave "missing" unwired so it produces a ResourceNotFoundException
+	// in transactGetItemKey — the canonical malformed case.
+	schema := &dynamoTableSchema{
+		TableName:          "t",
+		Generation:         1,
+		KeyEncodingVersion: dynamoOrderedKeyEncodingV2,
+		AttributeDefinitions: map[string]string{
+			"pk": "S",
+		},
+		PrimaryKey: dynamoKeySchema{HashKey: "pk"},
+	}
+	st := store.NewMVCCStore()
+	writer := newDynamoFixtureWriter(t, st)
+	writer.writeSchema(schema)
+
+	coord := &leaseReadCountingCoordinator{stubAdapterCoordinator: &stubAdapterCoordinator{}}
+	server := NewDynamoDBServer(nil, st, coord)
+
+	in := transactGetItemsInput{
+		TransactItems: []transactGetItem{
+			// Malformed: "missing" table → validation error.
+			{Get: &transactGetItemGet{
+				TableName: "missing",
+				Key:       map[string]attributeValue{"pk": newStringAttributeValue("x")},
+			}},
+			// Valid: "t" table → would normally fence a single group.
+			{Get: &transactGetItemGet{
+				TableName: "t",
+				Key:       map[string]attributeValue{"pk": newStringAttributeValue("real")},
+			}},
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	require.True(t, server.leaseCheckTransactGetItems(rec, req, in),
+		"a malformed item mixed with valid items must skip the lease so the read path's 4xx is not masked by a degraded-shard 500 (codex P2 #952)")
+	require.Equal(t, http.StatusOK, rec.Code, "no error response should be written for the mixed case")
+	require.Equal(t, int64(0), coord.leaseReadForKeyCalls.Load(),
+		"valid items in a malformed-mixed transaction must NOT be leased — the transaction is doomed by validation, no shard freshness needs to be established")
+	require.Equal(t, int64(0), coord.leaseReadCalls.Load())
+}
+
 // TestDynamoDB_TransactGetItems_MalformedItemStillSkipped asserts the
 // malformed-input path is unchanged: an item whose schema does not exist
 // (ResourceNotFoundException, a validation error) is still skipped, not failed

--- a/adapter/dynamodb_lease_fence_test.go
+++ b/adapter/dynamodb_lease_fence_test.go
@@ -278,6 +278,57 @@ func TestDynamoDB_TransactGetItems_MalformedMixedWithValidSkipsLease(t *testing.
 	require.Equal(t, int64(0), coord.leaseReadCalls.Load())
 }
 
+// TestDynamoDB_TransactGetItems_DuplicateKeySkipsLease asserts the regression
+// for codex P2 #952 round-2 (line 4643): a TransactGetItems request with
+// duplicate (table, key) pairs is a deterministic ValidationException that
+// the read path produces before touching any data. Pre-fix the loop silently
+// dedup'd via the seenKeys map and called LeaseReadForKeyThrough on the
+// surviving unique key — in a degraded shard the lease failure surfaced as
+// 500 InternalServerError and masked the 4xx. Post-fix a hasDuplicate flag
+// joins hasMalformed in the skip-lease condition so the lease pre-pass exits
+// without touching any shard.
+func TestDynamoDB_TransactGetItems_DuplicateKeySkipsLease(t *testing.T) {
+	t.Parallel()
+
+	schema := &dynamoTableSchema{
+		TableName:          "t",
+		Generation:         1,
+		KeyEncodingVersion: dynamoOrderedKeyEncodingV2,
+		AttributeDefinitions: map[string]string{
+			"pk": "S",
+		},
+		PrimaryKey: dynamoKeySchema{HashKey: "pk"},
+	}
+	st := store.NewMVCCStore()
+	writer := newDynamoFixtureWriter(t, st)
+	writer.writeSchema(schema)
+
+	coord := &leaseReadCountingCoordinator{stubAdapterCoordinator: &stubAdapterCoordinator{}}
+	server := NewDynamoDBServer(nil, st, coord)
+
+	in := transactGetItemsInput{
+		TransactItems: []transactGetItem{
+			{Get: &transactGetItemGet{
+				TableName: "t",
+				Key:       map[string]attributeValue{"pk": newStringAttributeValue("dup")},
+			}},
+			{Get: &transactGetItemGet{
+				TableName: "t",
+				Key:       map[string]attributeValue{"pk": newStringAttributeValue("dup")},
+			}},
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	require.True(t, server.leaseCheckTransactGetItems(rec, req, in),
+		"a duplicate (table, key) pair is a deterministic ValidationException — the lease pre-pass must skip leasing so a degraded shard cannot mask the 4xx with a 500 (codex P2 #952)")
+	require.Equal(t, http.StatusOK, rec.Code, "no error response should be written for duplicate keys")
+	require.Equal(t, int64(0), coord.leaseReadForKeyCalls.Load(),
+		"duplicate keys must NOT trigger a lease — the transaction is already doomed by the duplicate-item ValidationException")
+	require.Equal(t, int64(0), coord.leaseReadCalls.Load())
+}
+
 // TestDynamoDB_TransactGetItems_MalformedItemStillSkipped asserts the
 // malformed-input path is unchanged: an item whose schema does not exist
 // (ResourceNotFoundException, a validation error) is still skipped, not failed

--- a/adapter/dynamodb_lease_fence_test.go
+++ b/adapter/dynamodb_lease_fence_test.go
@@ -240,8 +240,8 @@ func TestDynamoDB_TransactGetItems_MalformedItemStillSkipped(t *testing.T) {
 	require.True(t, server.leaseCheckTransactGetItems(rec, req, in),
 		"a malformed item (table not found) must still be skipped, not failed closed")
 	require.Equal(t, http.StatusOK, rec.Code, "no error response should be written for malformed input")
-	require.Equal(t, 0, coord.leaseReadForKeyCalls)
-	require.Equal(t, 0, coord.leaseReadCalls)
+	require.Equal(t, int64(0), coord.leaseReadForKeyCalls.Load())
+	require.Equal(t, int64(0), coord.leaseReadCalls.Load())
 }
 
 // TestDynamoDB_QueryLeaseKey_TransientSchemaReadFailsClosed asserts a transient

--- a/adapter/dynamodb_lease_fence_test.go
+++ b/adapter/dynamodb_lease_fence_test.go
@@ -1,0 +1,295 @@
+package adapter
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/bootjp/elastickv/kv"
+	"github.com/bootjp/elastickv/store"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// multiGroupLeaseCoordinator is a fake coordinator that owns more than one
+// Raft group and records which groups a lease pre-pass fenced. It models the
+// invariant codex P1-A targets: a keyless multi-shard read (Scan, GSI/whole-
+// table Query) must fence EVERY group, not just the default one.
+//
+//   - LeaseRead (keyless, default-group only) records groupDefault.
+//   - LeaseReadAllGroups records every owned group.
+//   - LeaseReadForKey records the key's owning group.
+//
+// EngineGroupIDForKey routes a key to a group by its first byte so tests can
+// place keys on distinct groups deterministically.
+type multiGroupLeaseCoordinator struct {
+	*stubAdapterCoordinator
+
+	mu           sync.Mutex
+	fencedGroups map[uint64]int
+}
+
+const (
+	multiGroupDefaultID = uint64(1)
+	multiGroupOtherID   = uint64(2)
+)
+
+func newMultiGroupLeaseCoordinator() *multiGroupLeaseCoordinator {
+	return &multiGroupLeaseCoordinator{
+		stubAdapterCoordinator: &stubAdapterCoordinator{},
+		fencedGroups:           make(map[uint64]int),
+	}
+}
+
+func (c *multiGroupLeaseCoordinator) recordGroup(gid uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.fencedGroups[gid]++
+}
+
+func (c *multiGroupLeaseCoordinator) fencedGroupSet() map[uint64]int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[uint64]int, len(c.fencedGroups))
+	for gid, n := range c.fencedGroups {
+		out[gid] = n
+	}
+	return out
+}
+
+// EngineGroupIDForKey routes by first byte: keys starting with 'b' land on
+// the non-default group, everything else on the default group.
+func (c *multiGroupLeaseCoordinator) EngineGroupIDForKey(key []byte) uint64 {
+	if len(key) > 0 && key[0] == 'b' {
+		return multiGroupOtherID
+	}
+	return multiGroupDefaultID
+}
+
+func (c *multiGroupLeaseCoordinator) LeaseRead(_ context.Context) (uint64, error) {
+	// Keyless lease read fences only the default group — the pre-P1-A
+	// behavior that left non-default groups unfenced for whole-table reads.
+	c.recordGroup(multiGroupDefaultID)
+	return 0, nil
+}
+
+func (c *multiGroupLeaseCoordinator) LeaseReadForKey(_ context.Context, key []byte) (uint64, error) {
+	c.recordGroup(c.EngineGroupIDForKey(key))
+	return 0, nil
+}
+
+func (c *multiGroupLeaseCoordinator) LeaseReadAllGroups(_ context.Context) error {
+	c.recordGroup(multiGroupDefaultID)
+	c.recordGroup(multiGroupOtherID)
+	return nil
+}
+
+// TestDynamoDB_ScanLeaseFencesAllGroups asserts that the Scan handler's
+// keyless lease pre-pass fences EVERY shard group, not just the default group
+// (codex P1-A). On the pre-fix code leaseReadKeyless called LeaseReadThrough,
+// which only fenced the default group, so this test fails: the non-default
+// group never appears in fencedGroupSet.
+func TestDynamoDB_ScanLeaseFencesAllGroups(t *testing.T) {
+	t.Parallel()
+
+	coord := newMultiGroupLeaseCoordinator()
+	server := NewDynamoDBServer(nil, store.NewMVCCStore(), coord)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	require.True(t, server.leaseReadKeyless(rec, req))
+
+	fenced := coord.fencedGroupSet()
+	require.Contains(t, fenced, multiGroupDefaultID,
+		"keyless scan lease must fence the default group")
+	require.Contains(t, fenced, multiGroupOtherID,
+		"keyless scan lease must fence the non-default group too (codex P1-A) — "+
+			"scanning all intersecting routes without fencing every group can read stale data")
+}
+
+// TestDynamoDB_QueryLeaseFallbackFencesAllGroups asserts a GSI query (which
+// falls back to the keyless check) fences every group, not just the default.
+func TestDynamoDB_QueryLeaseFallbackFencesAllGroups(t *testing.T) {
+	t.Parallel()
+
+	coord := newMultiGroupLeaseCoordinator()
+	server := NewDynamoDBServer(nil, store.NewMVCCStore(), coord)
+
+	// IndexName set => queryLeaseKey returns (_, false, nil) => keyless fallback.
+	in := queryInput{
+		TableName:              "t",
+		IndexName:              "gsi1",
+		KeyConditionExpression: "gk = :gk",
+		ExpressionAttributeValues: map[string]attributeValue{
+			":gk": newStringAttributeValue("x"),
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	require.True(t, server.leaseCheckQuery(rec, req, in))
+
+	fenced := coord.fencedGroupSet()
+	require.Contains(t, fenced, multiGroupDefaultID,
+		"GSI query keyless fallback must fence the default group")
+	require.Contains(t, fenced, multiGroupOtherID,
+		"GSI query keyless fallback must fence the non-default group too (codex P1-A)")
+}
+
+// transientSchemaStore makes the FIRST GetAt on the table meta key fail with a
+// non-ErrKeyNotFound store error, modeling a transient Pebble/backpressure
+// failure during the lease pre-pass schema read.
+type transientSchemaStore struct {
+	store.MVCCStore
+
+	metaKey []byte
+	mu      sync.Mutex
+	failed  bool
+}
+
+var errTransientSchemaRead = errors.New("injected transient schema read failure")
+
+func (s *transientSchemaStore) GetAt(ctx context.Context, key []byte, ts uint64) ([]byte, error) {
+	s.mu.Lock()
+	if !s.failed && bytes.Equal(key, s.metaKey) {
+		s.failed = true
+		s.mu.Unlock()
+		return nil, errTransientSchemaRead
+	}
+	s.mu.Unlock()
+	return s.MVCCStore.GetAt(ctx, key, ts)
+}
+
+// TestDynamoDB_TransactGetItems_TransientSchemaReadFailsClosed asserts that a
+// transient schema-read error during the TransactGetItems lease pre-pass makes
+// the handler fail closed (InternalServerError) rather than silently dropping
+// the item from the lease-check set and reading it unfenced (codex P1-B). On
+// the pre-fix code transactGetItemKey returned (_, false) for ANY schema error,
+// so the item was skipped and leaseCheckTransactGetItems returned true (no
+// fence); this test fails because it expects the handler to fail closed.
+func TestDynamoDB_TransactGetItems_TransientSchemaReadFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	schema := &dynamoTableSchema{
+		TableName:          "t",
+		Generation:         1,
+		KeyEncodingVersion: dynamoOrderedKeyEncodingV2,
+		AttributeDefinitions: map[string]string{
+			"pk": "S",
+			"sk": "S",
+		},
+		PrimaryKey: dynamoKeySchema{HashKey: "pk", RangeKey: "sk"},
+	}
+
+	recording := &transientSchemaStore{
+		MVCCStore: store.NewMVCCStore(),
+		metaKey:   dynamoTableMetaKey(schema.TableName),
+	}
+	writer := newDynamoFixtureWriter(t, recording.MVCCStore)
+	writer.writeSchema(schema)
+
+	coord := &leaseReadCountingCoordinator{stubAdapterCoordinator: &stubAdapterCoordinator{}}
+	server := NewDynamoDBServer(nil, recording, coord)
+
+	in := transactGetItemsInput{
+		TransactItems: []transactGetItem{
+			{Get: &transactGetItemGet{
+				TableName: "t",
+				Key: map[string]attributeValue{
+					"pk": newStringAttributeValue("tenant"),
+					"sk": newStringAttributeValue("0001"),
+				},
+			}},
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	require.False(t, server.leaseCheckTransactGetItems(rec, req, in),
+		"a transient schema read failure must fail the lease check, not skip the item (codex P1-B)")
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Contains(t, rec.Body.String(), dynamoErrInternal)
+}
+
+// TestDynamoDB_TransactGetItems_MalformedItemStillSkipped asserts the
+// malformed-input path is unchanged: an item whose schema does not exist
+// (ResourceNotFoundException, a validation error) is still skipped, not failed
+// closed, so error mapping for malformed input stays byte-identical.
+func TestDynamoDB_TransactGetItems_MalformedItemStillSkipped(t *testing.T) {
+	t.Parallel()
+
+	coord := &leaseReadCountingCoordinator{stubAdapterCoordinator: &stubAdapterCoordinator{}}
+	server := NewDynamoDBServer(nil, store.NewMVCCStore(), coord)
+
+	// No schema written => resolveTransactTableSchema returns a
+	// ResourceNotFoundException (*dynamoAPIError) => malformed => skipped.
+	in := transactGetItemsInput{
+		TransactItems: []transactGetItem{
+			{Get: &transactGetItemGet{
+				TableName: "missing",
+				Key:       map[string]attributeValue{"pk": newStringAttributeValue("x")},
+			}},
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	require.True(t, server.leaseCheckTransactGetItems(rec, req, in),
+		"a malformed item (table not found) must still be skipped, not failed closed")
+	require.Equal(t, http.StatusOK, rec.Code, "no error response should be written for malformed input")
+	require.Equal(t, 0, coord.leaseReadForKeyCalls)
+	require.Equal(t, 0, coord.leaseReadCalls)
+}
+
+// TestDynamoDB_QueryLeaseKey_TransientSchemaReadFailsClosed asserts a transient
+// schema read during the Query lease pre-pass fences all groups via the keyless
+// fallback rather than proceeding with no fence (codex P1-B, consistent with
+// P1-A). On the pre-fix code queryLeaseKey returned (_, false) for any schema
+// error and leaseCheckQuery fell back to a keyless DEFAULT-group-only check,
+// leaving non-default groups unfenced.
+func TestDynamoDB_QueryLeaseKey_TransientSchemaReadFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	schema := &dynamoTableSchema{
+		TableName:          "t",
+		Generation:         1,
+		KeyEncodingVersion: dynamoOrderedKeyEncodingV2,
+		AttributeDefinitions: map[string]string{
+			"pk": "S",
+		},
+		PrimaryKey: dynamoKeySchema{HashKey: "pk"},
+	}
+
+	recording := &transientSchemaStore{
+		MVCCStore: store.NewMVCCStore(),
+		metaKey:   dynamoTableMetaKey(schema.TableName),
+	}
+	writer := newDynamoFixtureWriter(t, recording.MVCCStore)
+	writer.writeSchema(schema)
+
+	coord := newMultiGroupLeaseCoordinator()
+	server := NewDynamoDBServer(nil, recording, coord)
+
+	in := queryInput{
+		TableName:              "t",
+		KeyConditionExpression: "pk = :pk",
+		ExpressionAttributeValues: map[string]attributeValue{
+			":pk": newStringAttributeValue("tenant"),
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	require.True(t, server.leaseCheckQuery(rec, req, in))
+
+	fenced := coord.fencedGroupSet()
+	require.Contains(t, fenced, multiGroupDefaultID,
+		"transient schema read must still fence the default group")
+	require.Contains(t, fenced, multiGroupOtherID,
+		"transient schema read must fail closed by fencing every group (codex P1-B + P1-A)")
+}
+
+var _ kv.AllGroupsLeaseReadableCoordinator = (*multiGroupLeaseCoordinator)(nil)

--- a/adapter/dynamodb_lease_fence_test.go
+++ b/adapter/dynamodb_lease_fence_test.go
@@ -115,10 +115,15 @@ func TestDynamoDB_ScanLeaseFencesAllGroups(t *testing.T) {
 func TestDynamoDB_QueryLeaseFallbackFencesAllGroups(t *testing.T) {
 	t.Parallel()
 
-	coord := newMultiGroupLeaseCoordinator()
-	server := NewDynamoDBServer(nil, store.NewMVCCStore(), coord)
+	st := store.NewMVCCStore()
+	writer := newDynamoFixtureWriter(t, st)
+	writer.writeSchema(leaseGSIFixtureSchema())
 
-	// IndexName set => queryLeaseKey returns (_, false, nil) => keyless fallback.
+	coord := newMultiGroupLeaseCoordinator()
+	server := NewDynamoDBServer(nil, st, coord)
+
+	// IndexName set on a VALID GSI of an EXISTING table => queryLeaseKey
+	// returns (_, queryLeaseAllGroups, nil) => keyless all-groups fallback.
 	in := queryInput{
 		TableName:              "t",
 		IndexName:              "gsi1",

--- a/adapter/dynamodb_lease_validation_test.go
+++ b/adapter/dynamodb_lease_validation_test.go
@@ -158,12 +158,19 @@ func TestDynamoDB_Query_MissingTableReturns400UnderDegradedLease(t *testing.T) {
 func TestDynamoDB_LeaseCheckQuery_WholeTableQueryStillFencesAllGroups(t *testing.T) {
 	t.Parallel()
 
-	coord := newMultiGroupLeaseCoordinator()
-	server := NewDynamoDBServer(nil, store.NewMVCCStore(), coord)
+	st := store.NewMVCCStore()
+	writer := newDynamoFixtureWriter(t, st)
+	writer.writeSchema(leaseGSIFixtureSchema())
 
-	// IndexName set => valid multi-shard GSI read => keyless all-groups fence,
-	// not a skip. (Whole-table base-table queries take the same all-groups path
-	// through queryLeasePrefix's HashKey mismatch branch.)
+	coord := newMultiGroupLeaseCoordinator()
+	server := NewDynamoDBServer(nil, st, coord)
+
+	// IndexName set + a VALID GSI on an EXISTING table => valid multi-shard
+	// read => keyless all-groups fence, not a skip. (Whole-table base-table
+	// queries take the same all-groups path through queryLeasePrefix's HashKey
+	// mismatch branch.) The schema must exist so the GSI is genuinely valid:
+	// after the P2-B fix an indexed query against a missing table or unknown
+	// index is classified as a skip, not an all-groups fence.
 	in := queryInput{
 		TableName:              "t",
 		IndexName:              "gsi1",
@@ -182,4 +189,265 @@ func TestDynamoDB_LeaseCheckQuery_WholeTableQueryStillFencesAllGroups(t *testing
 		"valid multi-shard query must still fence the default group")
 	require.Contains(t, fenced, multiGroupOtherID,
 		"valid multi-shard query must still fence every group (must not be skipped as a validation case)")
+}
+
+// leaseGSIFixtureSchema is a table with a single GSI ("gsi1", ALL projection)
+// used by the lease pre-pass tests that exercise VALID multi-shard GSI reads.
+func leaseGSIFixtureSchema() *dynamoTableSchema {
+	return &dynamoTableSchema{
+		TableName:          "t",
+		Generation:         1,
+		KeyEncodingVersion: dynamoOrderedKeyEncodingV2,
+		AttributeDefinitions: map[string]string{
+			"pk": "S",
+			"gk": "S",
+		},
+		PrimaryKey: dynamoKeySchema{HashKey: "pk"},
+		GlobalSecondaryIndexes: map[string]dynamoGlobalSecondaryIndex{
+			"gsi1": {
+				KeySchema:  dynamoKeySchema{HashKey: "gk"},
+				Projection: dynamoGSIProjection{ProjectionType: "ALL"},
+			},
+		},
+	}
+}
+
+// TestDynamoDB_LeaseCheckQuery_MissingTableGSISkipsLeaseFallback asserts that a
+// GSI Query (IndexName set) against a table that does not exist skips the lease
+// fallback (codex #952 P2-B). On the pre-fix code queryLeaseKey returned
+// queryLeaseAllGroups for ANY non-empty IndexName without loading the schema,
+// so a degraded all-groups lease produced a 500 that masked the deterministic
+// ResourceNotFoundException the read path returns.
+func TestDynamoDB_LeaseCheckQuery_MissingTableGSISkipsLeaseFallback(t *testing.T) {
+	t.Parallel()
+
+	coord := newDegradedLeaseCoordinator()
+	// No schema written => the table is missing.
+	server := NewDynamoDBServer(nil, store.NewMVCCStore(), coord)
+
+	in := queryInput{
+		TableName:              "missing",
+		IndexName:              "gsi1",
+		KeyConditionExpression: "gk = :gk",
+		ExpressionAttributeValues: map[string]attributeValue{
+			":gk": newStringAttributeValue("x"),
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	require.True(t, server.leaseCheckQuery(rec, req, in),
+		"a missing-table GSI query must skip the lease fallback so the read path returns ResourceNotFoundException")
+	require.Equal(t, http.StatusOK, rec.Code, "no lease error response should be written for a missing-table GSI query")
+	require.Equal(t, 0, coord.allGroupsCalls,
+		"missing-table GSI query must not fall back to the all-groups lease check")
+	require.Equal(t, 0, coord.forKeyCalls,
+		"missing-table GSI query must not issue a per-key lease read")
+}
+
+// TestDynamoDB_LeaseCheckQuery_UnknownGSISkipsLeaseFallback asserts that a Query
+// naming an index that does not exist on the table skips the lease fallback: it
+// is a deterministic ValidationException, not a data read (codex #952 P2-B).
+func TestDynamoDB_LeaseCheckQuery_UnknownGSISkipsLeaseFallback(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	writer := newDynamoFixtureWriter(t, st)
+	writer.writeSchema(leaseGSIFixtureSchema())
+
+	coord := newDegradedLeaseCoordinator()
+	server := NewDynamoDBServer(nil, st, coord)
+
+	in := queryInput{
+		TableName:              "t",
+		IndexName:              "does-not-exist",
+		KeyConditionExpression: "gk = :gk",
+		ExpressionAttributeValues: map[string]attributeValue{
+			":gk": newStringAttributeValue("x"),
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	require.True(t, server.leaseCheckQuery(rec, req, in),
+		"an unknown-index query must skip the lease fallback so the read path returns ValidationException")
+	require.Equal(t, http.StatusOK, rec.Code, "no lease error response should be written for an unknown-index query")
+	require.Equal(t, 0, coord.allGroupsCalls,
+		"unknown-index query must not fall back to the all-groups lease check")
+	require.Equal(t, 0, coord.forKeyCalls,
+		"unknown-index query must not issue a per-key lease read")
+}
+
+// TestDynamoDB_LeaseCheckQuery_GSIConsistentReadSkipsLeaseFallback asserts that
+// a Query requesting ConsistentRead=true on a GSI skips the lease fallback: GSI
+// reads cannot be strongly consistent, so the read path rejects it with a
+// ValidationException without touching data (codex #952 P2-B).
+func TestDynamoDB_LeaseCheckQuery_GSIConsistentReadSkipsLeaseFallback(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	writer := newDynamoFixtureWriter(t, st)
+	writer.writeSchema(leaseGSIFixtureSchema())
+
+	coord := newDegradedLeaseCoordinator()
+	server := NewDynamoDBServer(nil, st, coord)
+
+	consistent := true
+	in := queryInput{
+		TableName:              "t",
+		IndexName:              "gsi1",
+		KeyConditionExpression: "gk = :gk",
+		ConsistentRead:         &consistent,
+		ExpressionAttributeValues: map[string]attributeValue{
+			":gk": newStringAttributeValue("x"),
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	require.True(t, server.leaseCheckQuery(rec, req, in),
+		"a GSI ConsistentRead query must skip the lease fallback so the read path returns ValidationException")
+	require.Equal(t, http.StatusOK, rec.Code, "no lease error response should be written for a GSI ConsistentRead query")
+	require.Equal(t, 0, coord.allGroupsCalls,
+		"GSI ConsistentRead query must not fall back to the all-groups lease check")
+}
+
+// TestDynamoDB_Query_InvalidGSIReturns4xxUnderDegradedLease is the end-to-end
+// guard for P2-B: a Query naming an unknown index must return the deterministic
+// 400 ValidationException even when every group's lease is failing — not the 500
+// the all-groups fence would otherwise produce.
+func TestDynamoDB_Query_InvalidGSIReturns4xxUnderDegradedLease(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	writer := newDynamoFixtureWriter(t, st)
+	writer.writeSchema(leaseGSIFixtureSchema())
+
+	coord := newDegradedLeaseCoordinator()
+	server := NewDynamoDBServer(nil, st, coord)
+
+	body := `{"TableName":"t","IndexName":"does-not-exist","KeyConditionExpression":"gk = :gk",` +
+		`"ExpressionAttributeValues":{":gk":{"S":"x"}}}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(body)))
+	server.query(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code,
+		"invalid-GSI Query must return 4xx, not the 500 the degraded all-groups fence would produce")
+	require.Contains(t, rec.Body.String(), dynamoErrValidation)
+}
+
+// TestDynamoDB_LeaseCheckScan_MissingTableSkipsLeaseFallback asserts that a Scan
+// against a table that does not exist skips the keyless lease fallback (codex
+// #952 P2-A). On the pre-fix code scan() called leaseReadKeyless
+// unconditionally before scanItems validated the table, so a degraded all-groups
+// lease produced a 500 that masked the deterministic ResourceNotFoundException.
+func TestDynamoDB_LeaseCheckScan_MissingTableSkipsLeaseFallback(t *testing.T) {
+	t.Parallel()
+
+	coord := newDegradedLeaseCoordinator()
+	server := NewDynamoDBServer(nil, store.NewMVCCStore(), coord)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	require.True(t, server.leaseCheckScan(rec, req, scanInput{TableName: "missing"}),
+		"a missing-table scan must skip the lease fallback so the read path returns ResourceNotFoundException")
+	require.Equal(t, http.StatusOK, rec.Code, "no lease error response should be written for a missing-table scan")
+	require.Equal(t, 0, coord.allGroupsCalls,
+		"missing-table scan must not fall back to the all-groups lease check")
+}
+
+// TestDynamoDB_LeaseCheckScan_UnknownGSISkipsLeaseFallback asserts that a Scan
+// naming an index that does not exist skips the lease fallback (codex #952
+// P2-A): it is a deterministic ValidationException, not a data read.
+func TestDynamoDB_LeaseCheckScan_UnknownGSISkipsLeaseFallback(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	writer := newDynamoFixtureWriter(t, st)
+	writer.writeSchema(leaseGSIFixtureSchema())
+
+	coord := newDegradedLeaseCoordinator()
+	server := NewDynamoDBServer(nil, st, coord)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	require.True(t, server.leaseCheckScan(rec, req, scanInput{TableName: "t", IndexName: "does-not-exist"}),
+		"an unknown-index scan must skip the lease fallback so the read path returns ValidationException")
+	require.Equal(t, http.StatusOK, rec.Code, "no lease error response should be written for an unknown-index scan")
+	require.Equal(t, 0, coord.allGroupsCalls,
+		"unknown-index scan must not fall back to the all-groups lease check")
+}
+
+// TestDynamoDB_Scan_MissingTableReturns400UnderDegradedLease is the end-to-end
+// guard for P2-A: the Scan handler must return the deterministic 400
+// ResourceNotFoundException for a missing table even when every group's lease is
+// failing — not the 500 the keyless fallback would otherwise produce.
+func TestDynamoDB_Scan_MissingTableReturns400UnderDegradedLease(t *testing.T) {
+	t.Parallel()
+
+	coord := newDegradedLeaseCoordinator()
+	server := NewDynamoDBServer(nil, store.NewMVCCStore(), coord)
+
+	body := `{"TableName":"missing"}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(body)))
+	server.scan(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code,
+		"missing-table Scan must return 400, not the 500 the degraded lease fallback would produce")
+	require.Contains(t, rec.Body.String(), dynamoErrResourceNotFound)
+}
+
+// TestDynamoDB_LeaseCheckScan_ValidTableStillFencesAllGroups asserts the fix
+// preserves the all-groups fence for a VALID Scan: a scan over an existing table
+// reads every shard, so it must still fence every group (fail closed) when the
+// lease cannot be confirmed.
+func TestDynamoDB_LeaseCheckScan_ValidTableStillFencesAllGroups(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	writer := newDynamoFixtureWriter(t, st)
+	writer.writeSchema(leaseGSIFixtureSchema())
+
+	coord := newMultiGroupLeaseCoordinator()
+	server := NewDynamoDBServer(nil, st, coord)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	require.True(t, server.leaseCheckScan(rec, req, scanInput{TableName: "t"}))
+
+	fenced := coord.fencedGroupSet()
+	require.Contains(t, fenced, multiGroupDefaultID,
+		"valid scan must still fence the default group")
+	require.Contains(t, fenced, multiGroupOtherID,
+		"valid scan must still fence every group (must not be skipped as a validation case)")
+}
+
+// TestDynamoDB_LeaseCheckScan_TransientSchemaReadFailsClosed asserts a transient
+// schema-read failure during the Scan lease pre-pass fails closed by fencing
+// every group, rather than skipping the lease and reading unfenced.
+func TestDynamoDB_LeaseCheckScan_TransientSchemaReadFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	schema := leaseGSIFixtureSchema()
+	recording := &transientSchemaStore{
+		MVCCStore: store.NewMVCCStore(),
+		metaKey:   dynamoTableMetaKey(schema.TableName),
+	}
+	writer := newDynamoFixtureWriter(t, recording.MVCCStore)
+	writer.writeSchema(schema)
+
+	coord := newMultiGroupLeaseCoordinator()
+	server := NewDynamoDBServer(nil, recording, coord)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	require.True(t, server.leaseCheckScan(rec, req, scanInput{TableName: "t"}))
+
+	fenced := coord.fencedGroupSet()
+	require.Contains(t, fenced, multiGroupDefaultID,
+		"transient schema read must still fence the default group")
+	require.Contains(t, fenced, multiGroupOtherID,
+		"transient schema read must fail closed by fencing every group")
 }

--- a/adapter/dynamodb_lease_validation_test.go
+++ b/adapter/dynamodb_lease_validation_test.go
@@ -488,6 +488,67 @@ func TestDynamoDB_LeaseCheckScan_InvalidExclusiveStartKeySkipsLease(t *testing.T
 		"invalid ExclusiveStartKey must not trigger the all-groups lease check — the transaction is doomed by validation")
 }
 
+// TestDynamoDB_LeaseCheckScan_InvalidProjectionSkipsLease asserts the regression
+// for codex P2 #952 round-4 (line 2346): a base-table Scan with a malformed
+// ProjectionExpression (e.g., a trailing comma "pk,") is a deterministic
+// ValidationException newReadPageState raises before the iterator reads from
+// the store. Pre-fix the lease pre-pass only validated the table/index, so the
+// all-groups fence ran and a degraded shard's 500 masked the 4xx. Post-fix
+// projectionInvalid catches it.
+func TestDynamoDB_LeaseCheckScan_InvalidProjectionSkipsLease(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	writer := newDynamoFixtureWriter(t, st)
+	writer.writeSchema(leaseGSIFixtureSchema())
+
+	coord := newDegradedLeaseCoordinator()
+	server := NewDynamoDBServer(nil, st, coord)
+
+	in := scanInput{
+		TableName:            "t",
+		ProjectionExpression: "pk,",
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	require.True(t, server.leaseCheckScan(rec, req, in),
+		"a Scan with malformed ProjectionExpression must skip the lease fallback so the read path's 4xx is not masked by a 500 (codex P2 #952 round-4)")
+	require.Equal(t, http.StatusOK, rec.Code, "no lease error response should be written for invalid ProjectionExpression")
+	require.Equal(t, 0, coord.allGroupsCalls,
+		"invalid ProjectionExpression must not trigger the all-groups lease check")
+}
+
+// TestDynamoDB_LeaseCheckQuery_InvalidProjectionSkipsLease is the Query
+// counterpart (codex P2 #952 round-4 line 2492).
+func TestDynamoDB_LeaseCheckQuery_InvalidProjectionSkipsLease(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	writer := newDynamoFixtureWriter(t, st)
+	writer.writeSchema(leaseGSIFixtureSchema())
+
+	coord := newDegradedLeaseCoordinator()
+	server := NewDynamoDBServer(nil, st, coord)
+
+	in := queryInput{
+		TableName:              "t",
+		KeyConditionExpression: "pk = :pk",
+		ExpressionAttributeValues: map[string]attributeValue{
+			":pk": newStringAttributeValue("x"),
+		},
+		ProjectionExpression: "pk,",
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	require.True(t, server.leaseCheckQuery(rec, req, in),
+		"a Query with malformed ProjectionExpression must skip the lease so the read path's 4xx is not masked by a 500 (codex P2 #952 round-4)")
+	require.Equal(t, http.StatusOK, rec.Code, "no lease error response should be written for invalid ProjectionExpression")
+	require.Equal(t, 0, coord.allGroupsCalls,
+		"invalid ProjectionExpression must not trigger the lease check")
+}
+
 // TestDynamoDB_LeaseCheckQuery_InvalidExclusiveStartKeySkipsLease is the Query
 // counterpart of the above (codex P2 #952 round-3, line 2482): a Query with a
 // valid KeyConditionExpression but malformed ExclusiveStartKey is a deterministic

--- a/adapter/dynamodb_lease_validation_test.go
+++ b/adapter/dynamodb_lease_validation_test.go
@@ -451,3 +451,76 @@ func TestDynamoDB_LeaseCheckScan_TransientSchemaReadFailsClosed(t *testing.T) {
 	require.Contains(t, fenced, multiGroupOtherID,
 		"transient schema read must fail closed by fencing every group")
 }
+
+// TestDynamoDB_LeaseCheckScan_InvalidExclusiveStartKeySkipsLease asserts the
+// regression for codex P2 #952 round-3 (line 2273): a Scan with a malformed
+// ExclusiveStartKey is a deterministic ValidationException — the read path
+// rejects it in resolveTableReadBounds before constructing the iterator. Pre-fix
+// leaseCheckScan only inspected the table/index validity and let the all-groups
+// fence run; in a degraded shard the lease 500 masked the 4xx. Post-fix
+// scanExclusiveStartKeyInvalid routes the case to skip-lease so the read path's
+// 4xx surfaces.
+func TestDynamoDB_LeaseCheckScan_InvalidExclusiveStartKeySkipsLease(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	writer := newDynamoFixtureWriter(t, st)
+	writer.writeSchema(leaseGSIFixtureSchema())
+
+	coord := newDegradedLeaseCoordinator()
+	server := NewDynamoDBServer(nil, st, coord)
+
+	in := scanInput{
+		TableName: "t",
+		// The schema's primary key is HashKey="pk" but the start key omits "pk"
+		// — itemKeyFromAttributes rejects this as "invalid ExclusiveStartKey".
+		ExclusiveStartKey: map[string]attributeValue{
+			"not_a_real_attr": newStringAttributeValue("x"),
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	require.True(t, server.leaseCheckScan(rec, req, in),
+		"a Scan with malformed ExclusiveStartKey must skip the lease fallback so the read path's 4xx is not masked by a 500 (codex P2 #952 round-3)")
+	require.Equal(t, http.StatusOK, rec.Code, "no lease error response should be written for invalid ExclusiveStartKey")
+	require.Equal(t, 0, coord.allGroupsCalls,
+		"invalid ExclusiveStartKey must not trigger the all-groups lease check — the transaction is doomed by validation")
+}
+
+// TestDynamoDB_LeaseCheckQuery_InvalidExclusiveStartKeySkipsLease is the Query
+// counterpart of the above (codex P2 #952 round-3, line 2482): a Query with a
+// valid KeyConditionExpression but malformed ExclusiveStartKey is a deterministic
+// ValidationException. Pre-fix leaseCheckQuery resolved a single-group fence and
+// let it run; in a degraded shard the 500 masked the 4xx. Post-fix
+// queryExclusiveStartKeyInvalid routes the case to queryLeaseSkip.
+func TestDynamoDB_LeaseCheckQuery_InvalidExclusiveStartKeySkipsLease(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	writer := newDynamoFixtureWriter(t, st)
+	writer.writeSchema(leaseGSIFixtureSchema())
+
+	coord := newDegradedLeaseCoordinator()
+	server := NewDynamoDBServer(nil, st, coord)
+
+	in := queryInput{
+		TableName:              "t",
+		KeyConditionExpression: "pk = :pk",
+		ExpressionAttributeValues: map[string]attributeValue{
+			":pk": newStringAttributeValue("x"),
+		},
+		// Malformed: the primary key is "pk" but the start key omits it.
+		ExclusiveStartKey: map[string]attributeValue{
+			"not_a_real_attr": newStringAttributeValue("x"),
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	require.True(t, server.leaseCheckQuery(rec, req, in),
+		"a Query with malformed ExclusiveStartKey must skip the lease so the read path's 4xx is not masked by a 500 (codex P2 #952 round-3)")
+	require.Equal(t, http.StatusOK, rec.Code, "no lease error response should be written for invalid ExclusiveStartKey")
+	require.Equal(t, 0, coord.allGroupsCalls,
+		"invalid ExclusiveStartKey must not trigger the lease check — the transaction is doomed by validation")
+}

--- a/adapter/dynamodb_lease_validation_test.go
+++ b/adapter/dynamodb_lease_validation_test.go
@@ -1,0 +1,185 @@
+package adapter
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bootjp/elastickv/kv"
+	"github.com/bootjp/elastickv/store"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+var errDegradedLease = errors.New("injected degraded-deployment lease failure")
+
+// degradedLeaseCoordinator models a multi-group deployment where no group can
+// confirm its lease (partition, slow follower). Every lease path fails. It is
+// used to prove that a CLIENT-side-invalid Query (missing table, malformed
+// KeyConditionExpression) must NOT be turned into an InternalServerError by the
+// lease fallback: those requests never touch data, so the read path must surface
+// the deterministic 4xx instead (codex #952 P2).
+type degradedLeaseCoordinator struct {
+	*stubAdapterCoordinator
+
+	allGroupsCalls int
+	forKeyCalls    int
+}
+
+func newDegradedLeaseCoordinator() *degradedLeaseCoordinator {
+	return &degradedLeaseCoordinator{stubAdapterCoordinator: &stubAdapterCoordinator{}}
+}
+
+func (c *degradedLeaseCoordinator) LeaseRead(_ context.Context) (uint64, error) {
+	c.allGroupsCalls++
+	return 0, errDegradedLease
+}
+
+func (c *degradedLeaseCoordinator) LeaseReadForKey(_ context.Context, _ []byte) (uint64, error) {
+	c.forKeyCalls++
+	return 0, errDegradedLease
+}
+
+func (c *degradedLeaseCoordinator) LeaseReadAllGroups(_ context.Context) error {
+	c.allGroupsCalls++
+	return errDegradedLease
+}
+
+func (c *degradedLeaseCoordinator) EngineGroupIDForKey(_ []byte) uint64 {
+	return multiGroupDefaultID
+}
+
+var _ kv.AllGroupsLeaseReadableCoordinator = (*degradedLeaseCoordinator)(nil)
+
+// TestDynamoDB_LeaseCheckQuery_MissingTableSkipsLeaseFallback asserts that a
+// Query against a table that does not exist does NOT take the all-groups lease
+// fallback. In a degraded deployment that fallback would fail and emit a 500,
+// masking the deterministic ResourceNotFoundException the read path produces.
+// The pre-pass must return true without issuing any lease read so the handler
+// surfaces the client error (codex #952 P2).
+func TestDynamoDB_LeaseCheckQuery_MissingTableSkipsLeaseFallback(t *testing.T) {
+	t.Parallel()
+
+	coord := newDegradedLeaseCoordinator()
+	// No schema written => loadTableSchemaAt reports the table missing.
+	server := NewDynamoDBServer(nil, store.NewMVCCStore(), coord)
+
+	in := queryInput{
+		TableName:              "missing",
+		KeyConditionExpression: "pk = :pk",
+		ExpressionAttributeValues: map[string]attributeValue{
+			":pk": newStringAttributeValue("tenant"),
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	require.True(t, server.leaseCheckQuery(rec, req, in),
+		"a missing-table query must skip the lease fallback so the read path can return ResourceNotFoundException")
+	require.Equal(t, http.StatusOK, rec.Code, "no lease error response should be written for a client-invalid query")
+	require.Equal(t, 0, coord.allGroupsCalls,
+		"missing-table query must not fall back to the all-groups lease check")
+	require.Equal(t, 0, coord.forKeyCalls,
+		"missing-table query must not issue a per-key lease read")
+}
+
+// TestDynamoDB_LeaseCheckQuery_MalformedConditionSkipsLeaseFallback asserts that
+// a Query with a malformed KeyConditionExpression skips the lease fallback for
+// the same reason: it is a deterministic ValidationException, not a data read.
+func TestDynamoDB_LeaseCheckQuery_MalformedConditionSkipsLeaseFallback(t *testing.T) {
+	t.Parallel()
+
+	schema := &dynamoTableSchema{
+		TableName:          "t",
+		Generation:         1,
+		KeyEncodingVersion: dynamoOrderedKeyEncodingV2,
+		AttributeDefinitions: map[string]string{
+			"pk": "S",
+		},
+		PrimaryKey: dynamoKeySchema{HashKey: "pk"},
+	}
+
+	st := store.NewMVCCStore()
+	writer := newDynamoFixtureWriter(t, st)
+	writer.writeSchema(schema)
+
+	coord := newDegradedLeaseCoordinator()
+	server := NewDynamoDBServer(nil, st, coord)
+
+	// KeyConditionExpression references an attribute that is not the table's
+	// hash key, so buildQueryCondition rejects it as a ValidationException.
+	in := queryInput{
+		TableName:              "t",
+		KeyConditionExpression: "nope = :v",
+		ExpressionAttributeValues: map[string]attributeValue{
+			":v": newStringAttributeValue("x"),
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	require.True(t, server.leaseCheckQuery(rec, req, in),
+		"a malformed-condition query must skip the lease fallback so the read path can return ValidationException")
+	require.Equal(t, http.StatusOK, rec.Code, "no lease error response should be written for a malformed-condition query")
+	require.Equal(t, 0, coord.allGroupsCalls,
+		"malformed-condition query must not fall back to the all-groups lease check")
+	require.Equal(t, 0, coord.forKeyCalls,
+		"malformed-condition query must not issue a per-key lease read")
+}
+
+// TestDynamoDB_Query_MissingTableReturns400UnderDegradedLease is the end-to-end
+// guard: the Query handler must return the deterministic 400
+// ResourceNotFoundException for a missing table even when every group's lease is
+// failing — not the 500 the lease fallback would otherwise produce (codex #952
+// P2).
+func TestDynamoDB_Query_MissingTableReturns400UnderDegradedLease(t *testing.T) {
+	t.Parallel()
+
+	coord := newDegradedLeaseCoordinator()
+	server := NewDynamoDBServer(nil, store.NewMVCCStore(), coord)
+
+	body := `{"TableName":"missing","KeyConditionExpression":"pk = :pk",` +
+		`"ExpressionAttributeValues":{":pk":{"S":"tenant"}}}`
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(body)))
+	server.query(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code,
+		"missing-table Query must return 400, not the 500 the degraded lease fallback would produce")
+	require.Contains(t, rec.Body.String(), dynamoErrResourceNotFound)
+}
+
+// TestDynamoDB_LeaseCheckQuery_WholeTableQueryStillFencesAllGroups asserts the
+// fix preserves the all-groups fence for a VALID multi-shard read: a query whose
+// hash key is not the primary hash key reads the whole-table prefix (multiple
+// shards), so it must still fail closed when the lease cannot be confirmed.
+func TestDynamoDB_LeaseCheckQuery_WholeTableQueryStillFencesAllGroups(t *testing.T) {
+	t.Parallel()
+
+	coord := newMultiGroupLeaseCoordinator()
+	server := NewDynamoDBServer(nil, store.NewMVCCStore(), coord)
+
+	// IndexName set => valid multi-shard GSI read => keyless all-groups fence,
+	// not a skip. (Whole-table base-table queries take the same all-groups path
+	// through queryLeasePrefix's HashKey mismatch branch.)
+	in := queryInput{
+		TableName:              "t",
+		IndexName:              "gsi1",
+		KeyConditionExpression: "gk = :gk",
+		ExpressionAttributeValues: map[string]attributeValue{
+			":gk": newStringAttributeValue("x"),
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(nil))
+	require.True(t, server.leaseCheckQuery(rec, req, in))
+
+	fenced := coord.fencedGroupSet()
+	require.Contains(t, fenced, multiGroupDefaultID,
+		"valid multi-shard query must still fence the default group")
+	require.Contains(t, fenced, multiGroupOtherID,
+		"valid multi-shard query must still fence every group (must not be skipped as a validation case)")
+}

--- a/adapter/dynamodb_test.go
+++ b/adapter/dynamodb_test.go
@@ -440,6 +440,159 @@ func TestDynamoDB_TransactGetItems(t *testing.T) {
 	assert.Empty(t, out.Responses[2].Item)
 }
 
+// postDynamoRaw issues a single, non-retried DynamoDB HTTP request and returns
+// the status code and body. The AWS SDK retries 5xx responses, which would
+// obscure the single lease-read failure under test, so the lease-failure cases
+// drive the wire directly.
+func postDynamoRaw(t *testing.T, address, target, body string) (int, string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		"http://"+address+"/",
+		strings.NewReader(body),
+	)
+	require.NoError(t, err)
+	req.Header.Set("X-Amz-Target", target)
+	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, string(respBody)
+}
+
+// wrapDynamoCoordinator swaps in a testCoordinatorWrapper around the node's
+// coordinator and restores the original on cleanup, so lease-read failures can
+// be injected for the read handlers.
+func wrapDynamoCoordinator(t *testing.T, node *Node) *testCoordinatorWrapper {
+	t.Helper()
+	orig := node.dynamoServer.coordinator
+	wrapped := &testCoordinatorWrapper{inner: orig}
+	node.dynamoServer.coordinator = wrapped
+	t.Cleanup(func() {
+		node.dynamoServer.coordinator = orig
+	})
+	return wrapped
+}
+
+func TestDynamoDB_Query_LeaseRead(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+
+	client := newDynamoTestClient(t, nodes[0].dynamoAddress)
+	ctx := context.Background()
+	createSimpleKeyTable(t, ctx, client)
+	_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String("t"),
+		Item: map[string]types.AttributeValue{
+			"key":   &types.AttributeValueMemberS{Value: "k1"},
+			"value": &types.AttributeValueMemberS{Value: "v1"},
+		},
+	})
+	require.NoError(t, err)
+
+	wrapped := wrapDynamoCoordinator(t, &nodes[0])
+
+	// Healthy lease: the query succeeds and returns the item.
+	out, err := client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String("t"),
+		KeyConditionExpression: aws.String("#k = :k"),
+		ExpressionAttributeNames: map[string]string{
+			"#k": "key",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":k": &types.AttributeValueMemberS{Value: "k1"},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, out.Items, 1)
+
+	// Lease-read failure surfaces as the same InternalServerError getItem
+	// produces. Drive the wire directly so the SDK does not retry the 500.
+	wrapped.failLeaseReads.Store(true)
+	status, respBody := postDynamoRaw(t, nodes[0].dynamoAddress, queryTarget,
+		`{"TableName":"t","KeyConditionExpression":"#k = :k",`+
+			`"ExpressionAttributeNames":{"#k":"key"},`+
+			`"ExpressionAttributeValues":{":k":{"S":"k1"}}}`)
+	require.Equal(t, http.StatusInternalServerError, status)
+	require.Contains(t, respBody, dynamoErrInternal)
+}
+
+func TestDynamoDB_Scan_LeaseRead(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+
+	client := newDynamoTestClient(t, nodes[0].dynamoAddress)
+	ctx := context.Background()
+	createSimpleKeyTable(t, ctx, client)
+	_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String("t"),
+		Item: map[string]types.AttributeValue{
+			"key":   &types.AttributeValueMemberS{Value: "k1"},
+			"value": &types.AttributeValueMemberS{Value: "v1"},
+		},
+	})
+	require.NoError(t, err)
+
+	wrapped := wrapDynamoCoordinator(t, &nodes[0])
+
+	// Healthy lease: the scan succeeds and returns the item.
+	out, err := client.Scan(ctx, &dynamodb.ScanInput{TableName: aws.String("t")})
+	require.NoError(t, err)
+	require.Len(t, out.Items, 1)
+
+	// Lease-read failure surfaces as the same InternalServerError getItem
+	// produces.
+	wrapped.failLeaseReads.Store(true)
+	status, respBody := postDynamoRaw(t, nodes[0].dynamoAddress, scanTarget, `{"TableName":"t"}`)
+	require.Equal(t, http.StatusInternalServerError, status)
+	require.Contains(t, respBody, dynamoErrInternal)
+}
+
+func TestDynamoDB_TransactGetItems_LeaseRead(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+
+	client := newDynamoTestClient(t, nodes[0].dynamoAddress)
+	ctx := context.Background()
+	createSimpleKeyTable(t, ctx, client)
+	_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String("t"),
+		Item: map[string]types.AttributeValue{
+			"key":   &types.AttributeValueMemberS{Value: "k1"},
+			"value": &types.AttributeValueMemberS{Value: "v1"},
+		},
+	})
+	require.NoError(t, err)
+
+	wrapped := wrapDynamoCoordinator(t, &nodes[0])
+
+	// Healthy lease: the transaction reads the item at a single snapshot.
+	out, err := client.TransactGetItems(ctx, &dynamodb.TransactGetItemsInput{
+		TransactItems: []types.TransactGetItem{
+			{Get: &types.Get{TableName: aws.String("t"), Key: map[string]types.AttributeValue{"key": &types.AttributeValueMemberS{Value: "k1"}}}},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, out.Responses, 1)
+	v1, ok := out.Responses[0].Item["value"].(*types.AttributeValueMemberS)
+	require.True(t, ok)
+	require.Equal(t, "v1", v1.Value)
+
+	// Lease-read failure surfaces as the same InternalServerError getItem
+	// produces, before the single snapshot timestamp is resolved.
+	wrapped.failLeaseReads.Store(true)
+	status, respBody := postDynamoRaw(t, nodes[0].dynamoAddress, transactGetItemsTarget,
+		`{"TransactItems":[{"Get":{"TableName":"t","Key":{"key":{"S":"k1"}}}}]}`)
+	require.Equal(t, http.StatusInternalServerError, status)
+	require.Contains(t, respBody, dynamoErrInternal)
+}
+
 func TestDynamoDB_TransactGetItems_ValidationErrors(t *testing.T) {
 	t.Parallel()
 	nodes, _, _ := createNode(t, 1)
@@ -1792,12 +1945,20 @@ func TestDynamoDB_TransactWriteItems_ConditionCheckRace(t *testing.T) {
 	require.Equal(t, "closed", guardStatus.Value)
 }
 
+// errInjectedLeaseRead is the failure injected by testCoordinatorWrapper when
+// failLeaseReads is set, standing in for quorum loss on the lease-read path.
+var errInjectedLeaseRead = errors.New("injected lease-read failure")
+
 type testCoordinatorWrapper struct {
 	inner kv.Coordinator
 
 	failTxnDispatches atomic.Int32
 	injectedFailures  atomic.Int32
 	txnDispatches     atomic.Int32
+
+	// failLeaseReads, when true, makes LeaseRead / LeaseReadForKey return
+	// errInjectedLeaseRead instead of delegating, simulating quorum loss.
+	failLeaseReads atomic.Bool
 
 	blockEntered chan struct{}
 	blockRelease chan struct{}
@@ -1860,9 +2021,15 @@ func (w *testCoordinatorWrapper) LinearizableRead(ctx context.Context) (uint64, 
 }
 
 func (w *testCoordinatorWrapper) LeaseRead(ctx context.Context) (uint64, error) {
+	if w.failLeaseReads.Load() {
+		return 0, errInjectedLeaseRead
+	}
 	return kv.LeaseReadThrough(w.inner, ctx)
 }
 
 func (w *testCoordinatorWrapper) LeaseReadForKey(ctx context.Context, key []byte) (uint64, error) {
+	if w.failLeaseReads.Load() {
+		return 0, errInjectedLeaseRead
+	}
 	return kv.LeaseReadForKeyThrough(w.inner, ctx, key)
 }

--- a/adapter/dynamodb_test.go
+++ b/adapter/dynamodb_test.go
@@ -593,6 +593,102 @@ func TestDynamoDB_TransactGetItems_LeaseRead(t *testing.T) {
 	require.Contains(t, respBody, dynamoErrInternal)
 }
 
+// TestDynamoDB_TransactGetItems_LeaseDedupByGroup asserts that a
+// TransactGetItems touching many distinct keys that all resolve to the
+// same Raft group issues a single lease read, not one per key. Before the
+// per-group dedup this loop ran kv.LeaseReadForKeyThrough once per unique
+// key (up to transactGetItemsMaxItems sequential reads), which gemini
+// flagged as an O(N) latency bottleneck on PR #952.
+func TestDynamoDB_TransactGetItems_LeaseDedupByGroup(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+
+	client := newDynamoTestClient(t, nodes[0].dynamoAddress)
+	ctx := context.Background()
+	createSimpleKeyTable(t, ctx, client)
+
+	const itemCount = 10
+	gets := make([]types.TransactGetItem, 0, itemCount)
+	for i := range itemCount {
+		k := "k" + strconv.Itoa(i)
+		_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+			TableName: aws.String("t"),
+			Item: map[string]types.AttributeValue{
+				"key":   &types.AttributeValueMemberS{Value: k},
+				"value": &types.AttributeValueMemberS{Value: "v" + strconv.Itoa(i)},
+			},
+		})
+		require.NoError(t, err)
+		gets = append(gets, types.TransactGetItem{
+			Get: &types.Get{TableName: aws.String("t"), Key: map[string]types.AttributeValue{
+				"key": &types.AttributeValueMemberS{Value: k},
+			}},
+		})
+	}
+
+	wrapped := wrapDynamoCoordinator(t, &nodes[0])
+	wrapped.resetLeaseCounters()
+
+	out, err := client.TransactGetItems(ctx, &dynamodb.TransactGetItemsInput{TransactItems: gets})
+	require.NoError(t, err)
+	require.Len(t, out.Responses, itemCount)
+
+	keyless, keyed := wrapped.leaseCallCounts()
+	require.Equal(t, 0, keyless, "TransactGetItems must not use the keyless lease check")
+	// Single-group deployment: every key routes to the same group, so the
+	// per-group dedup collapses all itemCount keys into ONE lease read.
+	require.Equal(t, 1, keyed,
+		"expected one lease read per distinct group, got %d for %d keys", keyed, itemCount)
+}
+
+// TestDynamoDB_Query_LeaseRoutedByKey asserts that a base-table Query is
+// lease-checked by its partition-key prefix (LeaseReadForKey) rather than
+// by the keyless default-group check, so a multi-group deployment confirms
+// the shard that actually owns the queried data (codex P2 on PR #952). A
+// GSI query, which can span the whole table prefix, falls back to keyless.
+func TestDynamoDB_Query_LeaseRoutedByKey(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+
+	client := newDynamoTestClient(t, nodes[0].dynamoAddress)
+	ctx := context.Background()
+	createSimpleKeyTable(t, ctx, client)
+	_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String("t"),
+		Item: map[string]types.AttributeValue{
+			"key":   &types.AttributeValueMemberS{Value: "k1"},
+			"value": &types.AttributeValueMemberS{Value: "v1"},
+		},
+	})
+	require.NoError(t, err)
+
+	wrapped := wrapDynamoCoordinator(t, &nodes[0])
+	wrapped.resetLeaseCounters()
+
+	out, err := client.Query(ctx, &dynamodb.QueryInput{
+		TableName:                aws.String("t"),
+		KeyConditionExpression:   aws.String("#k = :k"),
+		ExpressionAttributeNames: map[string]string{"#k": "key"},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":k": &types.AttributeValueMemberS{Value: "k1"},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, out.Items, 1)
+
+	keyless, keyed := wrapped.leaseCallCounts()
+	require.Equal(t, 0, keyless, "base-table Query must route the lease check by the partition key")
+	require.Equal(t, 1, keyed, "base-table Query must issue exactly one key-routed lease check")
+
+	// The routed lease key must be the partition-key prefix the query
+	// actually scans, so it resolves to the owning shard group.
+	recorded := wrapped.recordedLeaseReadKeys()
+	require.Len(t, recorded, 1)
+	require.NotEmpty(t, recorded[0])
+}
+
 func TestDynamoDB_TransactGetItems_ValidationErrors(t *testing.T) {
 	t.Parallel()
 	nodes, _, _ := createNode(t, 1)
@@ -1960,9 +2056,54 @@ type testCoordinatorWrapper struct {
 	// errInjectedLeaseRead instead of delegating, simulating quorum loss.
 	failLeaseReads atomic.Bool
 
+	// leaseReadCalls / leaseReadForKeyCalls count keyless vs key-routed
+	// lease checks; leaseReadKeys records the keys passed to
+	// LeaseReadForKey so tests can assert routing and per-group dedup.
+	leaseMu              sync.Mutex
+	leaseReadCalls       int
+	leaseReadForKeyCalls int
+	leaseReadKeys        [][]byte
+
 	blockEntered chan struct{}
 	blockRelease chan struct{}
 	blockOnce    sync.Once
+}
+
+// recordedLeaseReadKeys returns a copy of the keys passed to
+// LeaseReadForKey since the last reset.
+func (w *testCoordinatorWrapper) recordedLeaseReadKeys() [][]byte {
+	w.leaseMu.Lock()
+	defer w.leaseMu.Unlock()
+	out := make([][]byte, len(w.leaseReadKeys))
+	for i, k := range w.leaseReadKeys {
+		out[i] = append([]byte(nil), k...)
+	}
+	return out
+}
+
+// resetLeaseCounters clears the recorded lease-read counters and keys.
+func (w *testCoordinatorWrapper) resetLeaseCounters() {
+	w.leaseMu.Lock()
+	defer w.leaseMu.Unlock()
+	w.leaseReadCalls = 0
+	w.leaseReadForKeyCalls = 0
+	w.leaseReadKeys = nil
+}
+
+// leaseCallCounts returns the keyless and key-routed lease-read counts.
+func (w *testCoordinatorWrapper) leaseCallCounts() (keyless, keyed int) {
+	w.leaseMu.Lock()
+	defer w.leaseMu.Unlock()
+	return w.leaseReadCalls, w.leaseReadForKeyCalls
+}
+
+// EngineGroupIDForKey forwards group resolution so LeaseReadGroupKeys can
+// dedup by group through the wrapper.
+func (w *testCoordinatorWrapper) EngineGroupIDForKey(key []byte) uint64 {
+	if gr, ok := w.inner.(kv.GroupRoutableCoordinator); ok {
+		return gr.EngineGroupIDForKey(key)
+	}
+	return 0
 }
 
 func (w *testCoordinatorWrapper) Dispatch(ctx context.Context, reqs *kv.OperationGroup[kv.OP]) (*kv.CoordinateResponse, error) {
@@ -2021,6 +2162,9 @@ func (w *testCoordinatorWrapper) LinearizableRead(ctx context.Context) (uint64, 
 }
 
 func (w *testCoordinatorWrapper) LeaseRead(ctx context.Context) (uint64, error) {
+	w.leaseMu.Lock()
+	w.leaseReadCalls++
+	w.leaseMu.Unlock()
 	if w.failLeaseReads.Load() {
 		return 0, errInjectedLeaseRead
 	}
@@ -2028,6 +2172,10 @@ func (w *testCoordinatorWrapper) LeaseRead(ctx context.Context) (uint64, error) 
 }
 
 func (w *testCoordinatorWrapper) LeaseReadForKey(ctx context.Context, key []byte) (uint64, error) {
+	w.leaseMu.Lock()
+	w.leaseReadForKeyCalls++
+	w.leaseReadKeys = append(w.leaseReadKeys, append([]byte(nil), key...))
+	w.leaseMu.Unlock()
 	if w.failLeaseReads.Load() {
 		return 0, errInjectedLeaseRead
 	}

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -237,6 +237,51 @@ func LeaseReadForKeyThrough(c Coordinator, ctx context.Context, key []byte) (uin
 	return idx, errors.WithStack(err)
 }
 
+// GroupRoutableCoordinator is the optional capability implemented by
+// coordinators that can resolve the owning Raft group of a key without
+// any I/O. Callers that need to lease-check a set of keys use it to
+// deduplicate by group: keys that resolve to the same group share one
+// lease read instead of issuing one per key. Single-group coordinators
+// do not implement it, so callers must fall back to per-key dedup.
+type GroupRoutableCoordinator interface {
+	// EngineGroupIDForKey returns the owning group ID, or 0 when the
+	// key cannot be routed.
+	EngineGroupIDForKey(key []byte) uint64
+}
+
+// LeaseReadGroupKey returns a representative key per distinct owning
+// group for the supplied keys, so callers can issue one lease read per
+// group rather than one per key. The returned slice preserves the order
+// of first appearance. When the coordinator does not implement
+// GroupRoutableCoordinator (single-group deployments) every distinct key
+// is returned unchanged so the caller's per-key dedup still bounds the
+// work. Keys that cannot be routed (group ID 0) are never collapsed —
+// each is kept as its own representative so the lease check still runs
+// and surfaces the routing failure.
+func LeaseReadGroupKeys(c Coordinator, keys [][]byte) [][]byte {
+	router, ok := c.(GroupRoutableCoordinator)
+	if !ok {
+		return keys
+	}
+	reps := make([][]byte, 0, len(keys))
+	seen := make(map[uint64]struct{}, len(keys))
+	for _, key := range keys {
+		gid := router.EngineGroupIDForKey(key)
+		if gid == 0 {
+			// Unroutable: keep it so the lease check runs and fails
+			// closed instead of silently skipping the shard.
+			reps = append(reps, key)
+			continue
+		}
+		if _, dup := seen[gid]; dup {
+			continue
+		}
+		seen[gid] = struct{}{}
+		reps = append(reps, key)
+	}
+	return reps
+}
+
 func (c *Coordinate) Dispatch(ctx context.Context, reqs *OperationGroup[OP]) (*CoordinateResponse, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -796,6 +841,19 @@ func engineLeaseAckValid(state raftengine.State, ack, now monoclock.Instant, lea
 
 func (c *Coordinate) LeaseReadForKey(ctx context.Context, _ []byte) (uint64, error) {
 	return c.LeaseRead(ctx)
+}
+
+// coordinateSingleGroupID is the synthetic group ID a single-group
+// Coordinate reports for every key. It only needs to be a stable
+// non-zero value so LeaseReadGroupKeys collapses all keys into one lease
+// read; the value is never used to address a real Raft group here.
+const coordinateSingleGroupID = 1
+
+// EngineGroupIDForKey makes Coordinate satisfy GroupRoutableCoordinator.
+// A Coordinate fronts exactly one Raft group, so every key maps to the
+// same group and batched lease checks collapse to a single read.
+func (c *Coordinate) EngineGroupIDForKey(_ []byte) uint64 {
+	return coordinateSingleGroupID
 }
 
 func (c *Coordinate) nextStartTS() (uint64, error) {

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -237,6 +237,37 @@ func LeaseReadForKeyThrough(c Coordinator, ctx context.Context, key []byte) (uin
 	return idx, errors.WithStack(err)
 }
 
+// AllGroupsLeaseReadableCoordinator is the optional capability implemented
+// by coordinators that own more than one Raft group and can establish the
+// lease freshness bound on EVERY group in a single call. Multi-shard read
+// handlers (Scan, GSI/whole-table Query) need this because the underlying
+// scan visits all intersecting routes across all groups, whereas the plain
+// LeaseRead only fences the default group. Single-group coordinators do not
+// implement it: LeaseReadAllGroupsThrough falls back to LeaseRead so they
+// still issue exactly one lease read.
+type AllGroupsLeaseReadableCoordinator interface {
+	// LeaseReadAllGroups establishes the lease freshness bound on every
+	// group the coordinator owns, failing closed on the first group that
+	// cannot confirm its lease. The freshness bound is what a multi-shard
+	// read relies on, so a returned error MUST abort the read.
+	LeaseReadAllGroups(ctx context.Context) error
+}
+
+// LeaseReadAllGroupsThrough establishes the lease freshness bound across
+// every shard group a multi-shard read can touch. When the coordinator owns
+// multiple groups (AllGroupsLeaseReadableCoordinator) it fences all of them;
+// otherwise it falls back to the single-group LeaseRead path so a
+// single-group deployment still issues exactly one lease read. Adapter call
+// sites use this for keyless reads (Scan, whole-table/GSI Query fallback)
+// that the per-key LeaseReadForKey cannot route to one group.
+func LeaseReadAllGroupsThrough(c Coordinator, ctx context.Context) error {
+	if ag, ok := c.(AllGroupsLeaseReadableCoordinator); ok {
+		return errors.WithStack(ag.LeaseReadAllGroups(ctx))
+	}
+	_, err := LeaseReadThrough(c, ctx)
+	return errors.WithStack(err)
+}
+
 // GroupRoutableCoordinator is the optional capability implemented by
 // coordinators that can resolve the owning Raft group of a key without
 // any I/O. Callers that need to lease-check a set of keys use it to

--- a/kv/lease_group_keys_test.go
+++ b/kv/lease_group_keys_test.go
@@ -1,0 +1,114 @@
+package kv
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeGroupRoutableCoordinator is a minimal Coordinator that also
+// implements GroupRoutableCoordinator, mapping each key to a caller-
+// supplied group ID. Only the methods LeaseReadGroupKeys exercises are
+// implemented; the rest panic to catch unexpected use.
+type fakeGroupRoutableCoordinator struct {
+	groupByKey map[string]uint64
+}
+
+func (f *fakeGroupRoutableCoordinator) EngineGroupIDForKey(key []byte) uint64 {
+	return f.groupByKey[string(key)]
+}
+
+func (f *fakeGroupRoutableCoordinator) Dispatch(context.Context, *OperationGroup[OP]) (*CoordinateResponse, error) {
+	panic("unused")
+}
+func (f *fakeGroupRoutableCoordinator) IsLeader() bool                     { panic("unused") }
+func (f *fakeGroupRoutableCoordinator) VerifyLeader(context.Context) error { panic("unused") }
+func (f *fakeGroupRoutableCoordinator) RaftLeader() string                 { panic("unused") }
+func (f *fakeGroupRoutableCoordinator) IsLeaderForKey([]byte) bool         { panic("unused") }
+func (f *fakeGroupRoutableCoordinator) VerifyLeaderForKey(context.Context, []byte) error {
+	panic("unused")
+}
+func (f *fakeGroupRoutableCoordinator) RaftLeaderForKey([]byte) string { panic("unused") }
+func (f *fakeGroupRoutableCoordinator) LinearizableRead(context.Context) (uint64, error) {
+	panic("unused")
+}
+func (f *fakeGroupRoutableCoordinator) Clock() *HLC { panic("unused") }
+
+var _ Coordinator = (*fakeGroupRoutableCoordinator)(nil)
+var _ GroupRoutableCoordinator = (*fakeGroupRoutableCoordinator)(nil)
+
+// plainNonRoutable implements Coordinator (via embedding) but NOT
+// GroupRoutableCoordinator, so LeaseReadGroupKeys must fall back to
+// returning the input unchanged. LeaseReadGroupKeys only type-asserts;
+// it never calls a Coordinator method, so the embedded nil interface is
+// fine.
+type plainNonRoutable struct {
+	Coordinator
+}
+
+func keys(ss ...string) [][]byte {
+	out := make([][]byte, len(ss))
+	for i, s := range ss {
+		out[i] = []byte(s)
+	}
+	return out
+}
+
+func equalKeySlices(t *testing.T, want, got [][]byte) {
+	t.Helper()
+	require.Len(t, got, len(want))
+	for i := range want {
+		require.Truef(t, bytes.Equal(want[i], got[i]),
+			"index %d: want %q got %q", i, want[i], got[i])
+	}
+}
+
+func TestLeaseReadGroupKeys(t *testing.T) {
+	t.Parallel()
+
+	t.Run("collapses keys sharing a group to one representative", func(t *testing.T) {
+		t.Parallel()
+		c := &fakeGroupRoutableCoordinator{groupByKey: map[string]uint64{
+			"a": 1, "b": 1, "c": 1,
+		}}
+		got := LeaseReadGroupKeys(c, keys("a", "b", "c"))
+		// All three share group 1: only the first appearance survives.
+		equalKeySlices(t, keys("a"), got)
+	})
+
+	t.Run("keeps one representative per distinct group in first-seen order", func(t *testing.T) {
+		t.Parallel()
+		c := &fakeGroupRoutableCoordinator{groupByKey: map[string]uint64{
+			"a": 1, "b": 2, "c": 1, "d": 2, "e": 3,
+		}}
+		got := LeaseReadGroupKeys(c, keys("a", "b", "c", "d", "e"))
+		// Groups 1,2,3 first appear at a,b,e respectively.
+		equalKeySlices(t, keys("a", "b", "e"), got)
+	})
+
+	t.Run("never collapses unroutable keys", func(t *testing.T) {
+		t.Parallel()
+		c := &fakeGroupRoutableCoordinator{groupByKey: map[string]uint64{
+			"a": 0, "b": 0, "c": 1,
+		}}
+		got := LeaseReadGroupKeys(c, keys("a", "b", "c"))
+		// gid 0 means unroutable: each is kept so the lease check still
+		// runs and fails closed; the routable c collapses normally.
+		equalKeySlices(t, keys("a", "b", "c"), got)
+	})
+
+	t.Run("empty input returns empty", func(t *testing.T) {
+		t.Parallel()
+		c := &fakeGroupRoutableCoordinator{groupByKey: map[string]uint64{}}
+		require.Empty(t, LeaseReadGroupKeys(c, nil))
+	})
+
+	t.Run("non-routable coordinator returns input unchanged", func(t *testing.T) {
+		t.Parallel()
+		in := keys("a", "b", "c")
+		got := LeaseReadGroupKeys(plainNonRoutable{}, in)
+		equalKeySlices(t, in, got)
+	})
+}

--- a/kv/lease_group_keys_test.go
+++ b/kv/lease_group_keys_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -110,5 +111,72 @@ func TestLeaseReadGroupKeys(t *testing.T) {
 		in := keys("a", "b", "c")
 		got := LeaseReadGroupKeys(plainNonRoutable{}, in)
 		equalKeySlices(t, in, got)
+	})
+}
+
+// singleGroupLeaseCoordinator implements Coordinator + LeaseReadableCoordinator
+// but NOT AllGroupsLeaseReadableCoordinator, modeling a single-group
+// deployment. It records how many keyless LeaseRead calls it received so the
+// fallback path can be asserted to issue exactly one.
+type singleGroupLeaseCoordinator struct {
+	Coordinator
+	leaseReads int
+	leaseErr   error
+}
+
+func (c *singleGroupLeaseCoordinator) LeaseRead(context.Context) (uint64, error) {
+	c.leaseReads++
+	return 0, c.leaseErr
+}
+
+func (c *singleGroupLeaseCoordinator) LeaseReadForKey(context.Context, []byte) (uint64, error) {
+	panic("unused")
+}
+
+// allGroupsLeaseCoordinator implements AllGroupsLeaseReadableCoordinator and
+// records how many groups a single LeaseReadAllGroups call fenced.
+type allGroupsLeaseCoordinator struct {
+	Coordinator
+	allGroupsCalls int
+	allGroupsErr   error
+}
+
+func (c *allGroupsLeaseCoordinator) LeaseReadAllGroups(context.Context) error {
+	c.allGroupsCalls++
+	return c.allGroupsErr
+}
+
+func TestLeaseReadAllGroupsThrough(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single-group coordinator issues exactly one LeaseRead", func(t *testing.T) {
+		t.Parallel()
+		c := &singleGroupLeaseCoordinator{}
+		require.NoError(t, LeaseReadAllGroupsThrough(c, context.Background()))
+		require.Equal(t, 1, c.leaseReads,
+			"single-group fallback must issue exactly one keyless lease read")
+	})
+
+	t.Run("single-group LeaseRead error propagates", func(t *testing.T) {
+		t.Parallel()
+		sentinel := errors.New("boom")
+		c := &singleGroupLeaseCoordinator{leaseErr: sentinel}
+		err := LeaseReadAllGroupsThrough(c, context.Background())
+		require.ErrorIs(t, err, sentinel)
+	})
+
+	t.Run("all-groups coordinator fences every group in one call", func(t *testing.T) {
+		t.Parallel()
+		c := &allGroupsLeaseCoordinator{}
+		require.NoError(t, LeaseReadAllGroupsThrough(c, context.Background()))
+		require.Equal(t, 1, c.allGroupsCalls)
+	})
+
+	t.Run("all-groups error propagates", func(t *testing.T) {
+		t.Parallel()
+		sentinel := errors.New("group fence failed")
+		c := &allGroupsLeaseCoordinator{allGroupsErr: sentinel}
+		err := LeaseReadAllGroupsThrough(c, context.Background())
+		require.ErrorIs(t, err, sentinel)
 	})
 }

--- a/kv/shard_key_test.go
+++ b/kv/shard_key_test.go
@@ -47,3 +47,37 @@ func TestRouteKey_NormalizesDynamoKeysToTable(t *testing.T) {
 	require.Equal(t, want, routeKey(gsiKey))
 	require.Equal(t, want, routeKey(txnLockKey(itemKey)))
 }
+
+// TestRouteKey_CollapsesDynamoGenerationsToSameTableRoute proves that two
+// DynamoDB item/GSI keys for the SAME table but DIFFERENT generations
+// normalize to the identical route key, so they always resolve to the same
+// shard group. dynamoRouteFromTablePrefixedKey splits at the first '|' after
+// the family prefix — that segment is the table name, and the generation
+// (which comes after it) is routing-invisible. This is the invariant that
+// makes a per-key lease check on the current generation also fence the
+// migration source generation (coderabbit #952 "lease pre-pass ignores
+// migration source generations" rebuttal): both generations live on one group.
+func TestRouteKey_CollapsesDynamoGenerationsToSameTableRoute(t *testing.T) {
+	t.Parallel()
+
+	tableSegment := base64.RawURLEncoding.EncodeToString([]byte("users"))
+	indexSegment := base64.RawURLEncoding.EncodeToString([]byte("status-index"))
+	want := dynamoRouteTableKey([]byte(tableSegment))
+
+	// Generation 7 is the migrating-to (current) generation; generation 6 is
+	// the migration source. The lease pre-pass fences gen 7's key; the read
+	// path also reads gen 6's key during migration.
+	currentItemKey := append([]byte(DynamoItemPrefix+tableSegment+"|7|"), []byte("pk\x00\x01")...)
+	sourceItemKey := append([]byte(DynamoItemPrefix+tableSegment+"|6|"), []byte("pk\x00\x01")...)
+	currentGSIKey := append([]byte(DynamoGSIPrefix+tableSegment+"|7|"+indexSegment+"|"), []byte("idx\x00\x01")...)
+	sourceGSIKey := append([]byte(DynamoGSIPrefix+tableSegment+"|6|"+indexSegment+"|"), []byte("idx\x00\x01")...)
+
+	require.Equal(t, want, routeKey(currentItemKey))
+	require.Equal(t, want, routeKey(sourceItemKey),
+		"migration source generation item key must route to the same table group as the current generation")
+	require.Equal(t, routeKey(currentItemKey), routeKey(sourceItemKey),
+		"current and source generation item keys must collapse to the same route key")
+	require.Equal(t, want, routeKey(currentGSIKey))
+	require.Equal(t, want, routeKey(sourceGSIKey),
+		"migration source generation GSI key must route to the same table group as the current generation")
+}

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -1536,6 +1536,27 @@ func (c *ShardedCoordinator) LeaseReadForKey(ctx context.Context, key []byte) (u
 	return groupLeaseRead(ctx, g, c.leaseObserver)
 }
 
+// LeaseReadAllGroups establishes the lease freshness bound on every shard
+// group this coordinator owns. Multi-shard reads (Scan, GSI/whole-table
+// Query) visit all intersecting routes across all groups (see
+// ShardStore.ScanAt), so fencing only the default group would let those
+// reads sample a snapshot on a non-default group without the freshness
+// bound. It fails closed on the first group that cannot confirm its lease,
+// since a partially-fenced read is exactly the stale read this guards
+// against. Group iteration order is unspecified; correctness does not
+// depend on it because every group must succeed.
+func (c *ShardedCoordinator) LeaseReadAllGroups(ctx context.Context) error {
+	if len(c.groups) == 0 {
+		return errors.WithStack(ErrLeaderNotFound)
+	}
+	for _, g := range c.groups {
+		if _, err := groupLeaseRead(ctx, g, c.leaseObserver); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+	return nil
+}
+
 // observeLeaseRead forwards a hit / miss signal to observer when it
 // is non-nil. Kept as a package-level helper so both ShardedCoordinator
 // and any future sharded caller share one nil-safe entrypoint.

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -1632,6 +1632,15 @@ func (c *ShardedCoordinator) engineGroupIDForKey(key []byte) uint64 {
 	return gid
 }
 
+// EngineGroupIDForKey reports the Raft group ID that owns key, or 0 when
+// the key cannot be routed. Callers that batch lease checks across many
+// keys use it to collapse keys sharing a group into a single lease read
+// (see GroupRoutableCoordinator). It performs no I/O — only an in-memory
+// router lookup — so it is safe on the read hot path.
+func (c *ShardedCoordinator) EngineGroupIDForKey(key []byte) uint64 {
+	return c.engineGroupIDForKey(key)
+}
+
 // groupReadKeysByShardID groups txn read keys by their owning Raft
 // group. Returns an error when ANY read key cannot be routed —
 // silently skipping unresolvable keys would let a transaction

--- a/kv/sharded_coordinator_leader_test.go
+++ b/kv/sharded_coordinator_leader_test.go
@@ -38,3 +38,65 @@ func TestShardedCoordinatorVerifyLeader_MissingGroup(t *testing.T) {
 	require.ErrorIs(t, coord.VerifyLeader(context.Background()), ErrLeaderNotFound)
 	require.ErrorIs(t, coord.VerifyLeaderForKey(context.Background(), []byte("k")), ErrLeaderNotFound)
 }
+
+// TestShardedCoordinatorLeaseReadAllGroups_FencesEveryLeader asserts that
+// LeaseReadAllGroups establishes the lease bound on EVERY owned group, not
+// just the default group (codex P1-A): a multi-shard scan visits all routes,
+// so a default-group-only fence would leave non-default groups unfenced.
+func TestShardedCoordinatorLeaseReadAllGroups_FencesEveryLeader(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	engine.UpdateRoute([]byte("a"), []byte("m"), 1)
+	engine.UpdateRoute([]byte("m"), nil, 2)
+
+	s1 := store.NewMVCCStore()
+	r1, stop1 := newSingleRaft(t, "lrag-g1", NewKvFSMWithHLC(s1, NewHLC()))
+	t.Cleanup(stop1)
+	s2 := store.NewMVCCStore()
+	r2, stop2 := newSingleRaft(t, "lrag-g2", NewKvFSMWithHLC(s2, NewHLC()))
+	t.Cleanup(stop2)
+
+	groups := map[uint64]*ShardGroup{
+		1: {Engine: r1, Store: s1, Txn: NewLeaderProxyWithEngine(r1)},
+		2: {Engine: r2, Store: s2, Txn: NewLeaderProxyWithEngine(r2)},
+	}
+	coord := NewShardedCoordinator(engine, groups, 1, NewHLC(), NewShardStore(engine, groups))
+
+	require.NoError(t, coord.LeaseReadAllGroups(context.Background()))
+}
+
+// TestShardedCoordinatorLeaseReadAllGroups_FailsClosedOnUnreadableGroup
+// asserts LeaseReadAllGroups fails closed when ANY group cannot confirm its
+// lease: a partially-fenced multi-shard read is exactly the stale read the
+// fence guards against. Group 2 has no engine, so its lease read errors.
+func TestShardedCoordinatorLeaseReadAllGroups_FailsClosedOnUnreadableGroup(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	engine.UpdateRoute([]byte("a"), []byte("m"), 1)
+	engine.UpdateRoute([]byte("m"), nil, 2)
+
+	s1 := store.NewMVCCStore()
+	r1, stop1 := newSingleRaft(t, "lrag-fail-g1", NewKvFSMWithHLC(s1, NewHLC()))
+	t.Cleanup(stop1)
+
+	groups := map[uint64]*ShardGroup{
+		1: {Engine: r1, Store: s1, Txn: NewLeaderProxyWithEngine(r1)},
+		2: {Store: store.NewMVCCStore()}, // no Engine: lease read fails closed
+	}
+	coord := NewShardedCoordinator(engine, groups, 1, NewHLC(), NewShardStore(engine, groups))
+
+	require.ErrorIs(t, coord.LeaseReadAllGroups(context.Background()), ErrLeaderNotFound)
+}
+
+// TestShardedCoordinatorLeaseReadAllGroups_EmptyGroups asserts the no-groups
+// case fails closed rather than silently confirming freshness on nothing.
+func TestShardedCoordinatorLeaseReadAllGroups_EmptyGroups(t *testing.T) {
+	t.Parallel()
+
+	engine := distribution.NewEngine()
+	coord := NewShardedCoordinator(engine, map[uint64]*ShardGroup{}, 1, NewHLC(), nil)
+
+	require.ErrorIs(t, coord.LeaseReadAllGroups(context.Background()), ErrLeaderNotFound)
+}


### PR DESCRIPTION
## Summary

Part of #557. Wraps the remaining DynamoDB read handlers in a quorum-freshness `LeaseRead` check, following the pattern PR #549 established for `getItem`. Previously these handlers read local `LastCommitTS`/snapshot state with **no quorum check at all**, so a partitioned-but-not-yet-stepped-down stale leader could serve stale reads. Each handler now performs one lease check (cheap atomic-load fast path within the lease window; one `LinearizableRead` on a lease miss, after which the lease is refreshed for the rest of the window) before resolving its read timestamp.

The Redis slice of #557 is deliberately left for a follow-up — this PR touches only `adapter/dynamodb.go`.

### Per-handler placement
- **`query`** — keyless `LeaseRead(ctx)` (`leaseReadKeyless` helper) before `queryItems` samples `readTS`. A Query scans a key range that can span shards in a multi-group deployment, and the owning shard can't be resolved in the handler without duplicating `prepareReadSchema`/`resolveQueryCondition`, so the keyless check (which anchors the cluster freshness bound) is the correct, cheaper call.
- **`scan`** — keyless `LeaseRead(ctx)` (same helper) before `scanItems` samples `readTS`. A Scan reads the whole table and spans every shard holding its items, so keyless is the right choice (matches the issue's guidance for keyless/multi-shard ops).
- **`transactGetItems`** — per-key `LeaseReadForKey`, deduplicated by item key, run in `leaseCheckTransactGetItems` **before** `nextTxnReadTS()` resolves the single snapshot timestamp. Item keys are resolved at a tentative schema timestamp purely to route the lease check; the single-snapshot-ts semantics (one `readTS` shared by all items) are unchanged. Malformed items are skipped in the pre-pass so the existing validation/error mapping still surfaces downstream identically. Within the lease window, same-shard keys hit the cheap fast path, so per-key checks are effectively free.

### Timeout decision
Every wrapped handler runs the lease check under a bounded `context.WithTimeout(r.Context(), dynamoLeaseReadTimeout)` with `defer cancel()` — the exact constant (`5s`) and structure `getItem` uses after PR #549 — so a stalled Raft cannot hang a handler indefinitely when the client never cancels.

### Note on `batchGetItem`
The issue lists `batchGetItem` in scope, but **there is no `BatchGetItem` handler in this codebase** (no `batchGetItemTarget`, no registration, no implementation). There was nothing to wrap; the multi-key precedent it asked about is implemented in `transactGetItems` (per-key `LeaseReadForKey`, deduped). If `BatchGetItem` is added later, it should reuse the same `leaseCheckTransactGetItems`-style per-key dedup pattern.

## Behavior change
Adds a quorum-freshness check to `query`/`scan`/`transactGetItems`. Read results and error mapping are otherwise identical; lease-read failure surfaces as the same `500 InternalServerError` (`dynamoErrInternal`) that `getItem` produces.

## Risk
Low. The only new failure mode is a `500` when the lease check fails (quorum loss), which is strictly more correct than serving a stale read. No write paths, FSM, or snapshot semantics touched. The added per-request `LeaseRead` is amortized by the lease window.

## Test evidence
- `go test -race -run TestDynamoDB ./adapter/` → ok (15s)
- Targeted: `TestDynamoDB_Query_LeaseRead`, `TestDynamoDB_Scan_LeaseRead`, `TestDynamoDB_TransactGetItems_LeaseRead` (each asserts (a) success with a healthy lease and (b) lease failure → 500 `InternalServerError`, mirroring `getItem`'s error class) plus existing `TestDynamoDB_TransactGetItems*` → ok with `-race`.
- `golangci-lint --config=.golangci.yaml run ./adapter/...` → 0 issues.
- `go vet ./adapter/`, `gofmt -l` → clean.
- Full `go test -race ./adapter/` exceeds the default 10-minute package timeout (the suite spans Redis/S3/SQS/gRPC/etc., unrelated to this change); it passes under an extended `-timeout`.

New tests inject lease-read failures via a `failLeaseReads` toggle added to the existing `testCoordinatorWrapper`, and drive the failure path over raw HTTP so the AWS SDK does not retry the `500`.

## Self-review
1. **Data loss** — None. Read-only handlers; no propose/apply, FSM, snapshot, TTL, or compaction paths touched. No `return nil`-after-error introduced; lease failure returns an explicit `500`.
2. **Concurrency / distributed failures** — Lease check is bounded by `dynamoLeaseReadTimeout` with `defer cancel()`, so a leader change / partition can't hang a handler. `transactGetItems` keeps its single shared `readTS`; the lease pre-pass runs before the timestamp is sampled, so a leadership flip mid-pass only causes a lease miss (→ `LinearizableRead`) or a `500`, never a torn snapshot. Ran `go test -race` on the dynamo suite.
3. **Performance** — One `LeaseRead` per request, amortized by the lease window (atomic-load fast path; one `LinearizableRead` per lease miss, then refreshed). `transactGetItems` dedups by item key and same-shard keys hit the fast path, so per-key checks add negligible cost; no extra Raft round-trips per HLC tick. The tentative schema load in the transact pre-pass is a cheap, cached Pebble read.
4. **Data consistency** — `readTS` is sampled **after** the lease confirmation in every handler, so any commit that landed before confirmation is visible; this tightens the freshness bound without bypassing the leader-issued read pipeline. `transactGetItems` single-snapshot-ts semantics are preserved.
5. **Test coverage** — Added a success + lease-failure test for each wrapped handler, reusing the existing `testCoordinatorWrapper`/`createNode` harness and mirroring `getItem`'s error class on failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read operations perform pre-read freshness checks to ensure consistent, up-to-date responses; queries and scans fallback to broader fencing when needed.
  * Transactional reads now confirm freshness across all affected groups before resolving a transaction snapshot.
  * Coordinators support multi-group lease fencing and per-group read collapsing for more robust multi-shard reads.

* **Tests**
  * Extensive tests added covering lease/fencing, validation, skip-paths, and multi-group behaviors for query, scan, and transactional reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->