### PR TITLE
ci: raise dedup Jepsen `max-writes-per-key` default to 3000

### DIFF
--- a/.github/workflows/jepsen-test-scheduled-dedup.yml
+++ b/.github/workflows/jepsen-test-scheduled-dedup.yml
@@ -41,9 +41,13 @@ on:
         required: false
         default: "16"
       max-writes-per-key:
+        # Keep this comfortably above rate * concurrency * time-limit / key-count.
+        # The scheduled default is 10 * 8 * 300 / 16 = 1500 writes/key before
+        # multi-op expansion; 3000 prevents the append generator from exhausting
+        # its value space before the 300s stress window completes.
         description: "Maximum writes per key before exhaustion"
         required: false
-        default: "250"
+        default: "3000"
       max-txn-length:
         description: "Maximum micro-ops per transaction"
         required: false
@@ -187,7 +191,7 @@ jobs:
             --rate ${{ inputs.rate || '10' }} \
             --concurrency ${{ inputs.concurrency || '8' }} \
             --key-count ${{ inputs.key-count || '16' }} \
-            --max-writes-per-key ${{ inputs.max-writes-per-key || '250' }} \
+            --max-writes-per-key ${{ inputs.max-writes-per-key || '3000' }} \
             --max-txn-length ${{ inputs.max-txn-length || '4' }} \
             --ports 63791,63792,63793 \
             --host 127.0.0.1
@@ -205,7 +209,7 @@ jobs:
             --rate ${{ inputs.rate || '10' }} \
             --concurrency ${{ inputs.concurrency || '8' }} \
             --key-count ${{ inputs.key-count || '16' }} \
-            --max-writes-per-key ${{ inputs.max-writes-per-key || '250' }} \
+            --max-writes-per-key ${{ inputs.max-writes-per-key || '3000' }} \
             --max-txn-length ${{ inputs.max-txn-length || '4' }} \
             --dynamo-ports 63801,63802,63803 \
             --host 127.0.0.1


### PR DESCRIPTION
### Motivation
- The scheduled Option-2 dedup Jepsen workload was failing because the default `max-writes-per-key` (250) was too small for the stress window (`rate=10`, `concurrency=8`, `time-limit=300`, `key-count=16`), allowing the append workload to exhaust its value space during the run.

### Description
- Increase the scheduled workflow `max-writes-per-key` default from `250` to `3000` and align the executed command-line fallback (`--max-writes-per-key`) to `3000` in `.github/workflows/jepsen-test-scheduled-dedup.yml`, and add a short comment explaining the rationale.

### Testing
- Verified the workflow file contents with a `python3` assertion that checks the `default: "3000"` and the command-line fallback uses `3000`, which succeeded.
- Ran `go test ./kv` and `go test ./adapter` locally, both packages completed successfully.
- Attempted to run `golangci-lint` but it failed to complete due to environment/tooling issues: the preinstalled `golangci-lint` binary is incompatible with the repo's Go target and installing the required `v2.9.0` was blocked by a transient `proxy.golang.org` error; this prevented a lint run to completion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30fa83ebd483249a4e02c6b7cb0271)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal testing infrastructure configuration parameters to enhance test coverage for dedup-mode operations on supported data stores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->