### PR TITLE
adapter: add SQS DLQ redrive configuration

### DIFF
--- a/adapter/sqs_admin.go
+++ b/adapter/sqs_admin.go
@@ -338,6 +338,33 @@ func (s *SQSServer) AdminPurgeQueue(ctx context.Context, principal AdminPrincipa
 	return AdminPurgeResult{GenerationBefore: oldGen, GenerationAfter: newGen}, nil
 }
 
+// AdminSetQueueAttributes is the SigV4-bypass counterpart to
+// SetQueueAttributes. It is intentionally generic rather than
+// DLQ-specific so the admin SPA can edit RedrivePolicy and
+// RedriveAllowPolicy through the same validator the public SQS API
+// uses.
+func (s *SQSServer) AdminSetQueueAttributes(ctx context.Context, principal AdminPrincipal, name string, attrs map[string]string) error {
+	if !principal.Role.canWrite() {
+		return ErrAdminForbidden
+	}
+	if !isVerifiedSQSLeader(ctx, s.coordinator) {
+		return ErrAdminNotLeader
+	}
+	if strings.TrimSpace(name) == "" || len(attrs) == 0 {
+		return ErrAdminSQSValidation
+	}
+	if _, err := s.setQueueAttributesWithRetry(ctx, name, attrs); err != nil {
+		if isSQSAdminQueueDoesNotExist(err) {
+			return ErrAdminSQSNotFound
+		}
+		if isSQSAdminValidationError(err) {
+			return ErrAdminSQSValidation
+		}
+		return errors.Wrap(err, "admin set queue attributes")
+	}
+	return nil
+}
+
 // AdminDeleteQueue is the SigV4-bypass counterpart to deleteQueue.
 // Returns the same sentinel errors as AdminCreateTable on the Dynamo
 // side: ErrAdminForbidden on a read-only principal, ErrAdminNotLeader
@@ -397,6 +424,9 @@ func metaAttributesForAdmin(meta *sqsQueueMeta, queueArn string) map[string]stri
 	if meta.RedrivePolicy != "" {
 		out["RedrivePolicy"] = meta.RedrivePolicy
 	}
+	if meta.RedriveAllowPolicy != "" {
+		out["RedriveAllowPolicy"] = meta.RedriveAllowPolicy
+	}
 	return out
 }
 
@@ -421,4 +451,17 @@ func isSQSAdminQueueDoesNotExist(err error) bool {
 		return false
 	}
 	return apiErr.errorType == sqsErrQueueDoesNotExist
+}
+
+func isSQSAdminValidationError(err error) bool {
+	var apiErr *sqsAPIError
+	if !errors.As(err, &apiErr) || apiErr == nil {
+		return false
+	}
+	switch apiErr.errorType {
+	case sqsErrValidation, sqsErrMissingParameter, sqsErrInvalidAttributeName, sqsErrInvalidAttributeValue:
+		return true
+	default:
+		return false
+	}
 }

--- a/adapter/sqs_admin.go
+++ b/adapter/sqs_admin.go
@@ -353,7 +353,8 @@ func (s *SQSServer) AdminSetQueueAttributes(ctx context.Context, principal Admin
 	if strings.TrimSpace(name) == "" || len(attrs) == 0 {
 		return ErrAdminSQSValidation
 	}
-	if _, err := s.setQueueAttributesWithRetry(ctx, name, attrs); err != nil {
+	throttleChanged, err := s.setQueueAttributesWithRetry(ctx, name, attrs)
+	if err != nil {
 		if isSQSAdminQueueDoesNotExist(err) {
 			return ErrAdminSQSNotFound
 		}
@@ -361,6 +362,9 @@ func (s *SQSServer) AdminSetQueueAttributes(ctx context.Context, principal Admin
 			return ErrAdminSQSValidation
 		}
 		return errors.Wrap(err, "admin set queue attributes")
+	}
+	if throttleChanged {
+		s.throttle.invalidateQueue(name)
 	}
 	return nil
 }

--- a/adapter/sqs_admin_test.go
+++ b/adapter/sqs_admin_test.go
@@ -240,6 +240,46 @@ func TestAdminPurgeQueue_EmptyName(t *testing.T) {
 	}
 }
 
+func TestAdminSetQueueAttributes_InvalidatesThrottleBucket(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	node := sqsLeaderNode(t, nodes)
+
+	const queueName = "admin-throttle"
+	_ = createSQSQueueForTest(t, node, queueName)
+
+	ctx := context.Background()
+	readTS := node.sqsServer.nextTxnReadTS(ctx)
+	meta, exists, err := node.sqsServer.loadQueueMetaAt(ctx, queueName, readTS)
+	if err != nil {
+		t.Fatalf("loadQueueMetaAt: %v", err)
+	}
+	if !exists {
+		t.Fatalf("queue not found")
+	}
+
+	cfg := &sqsQueueThrottle{SendCapacity: 10, SendRefillPerSecond: 1}
+	if out := node.sqsServer.throttle.charge(cfg, queueName, bucketActionSend, meta.Incarnation, 1); !out.allowed {
+		t.Fatalf("seed throttle bucket: denied with retryAfter=%v", out.retryAfter)
+	}
+	key := bucketKey{queue: queueName, action: bucketActionSend, incarnation: meta.Incarnation}
+	if _, ok := node.sqsServer.throttle.buckets.Load(key); !ok {
+		t.Fatalf("seed throttle bucket missing before admin attribute update")
+	}
+
+	err = node.sqsServer.AdminSetQueueAttributes(ctx, fullAdminPrincipal, queueName, map[string]string{
+		"ThrottleSendCapacity":        "20",
+		"ThrottleSendRefillPerSecond": "1",
+	})
+	if err != nil {
+		t.Fatalf("AdminSetQueueAttributes: %v", err)
+	}
+	if _, ok := node.sqsServer.throttle.buckets.Load(key); ok {
+		t.Fatalf("admin throttle update must invalidate cached throttle bucket")
+	}
+}
+
 // TestPurgeQueueSigV4_PreservesWireShapeAfterTypedErrorChange is the
 // caller-audit pin from the design doc §6.1 ("TestPurgeQueueSigV4_Still
 // Compiles"). It exercises the SigV4 PurgeQueue handler through the

--- a/adapter/sqs_catalog.go
+++ b/adapter/sqs_catalog.go
@@ -97,6 +97,7 @@ type sqsQueueMeta struct {
 	ReceiveMessageWaitSeconds int64             `json:"receive_message_wait_seconds"`
 	MaximumMessageSize        int64             `json:"maximum_message_size"`
 	RedrivePolicy             string            `json:"redrive_policy,omitempty"`
+	RedriveAllowPolicy        string            `json:"redrive_allow_policy,omitempty"`
 	Tags                      map[string]string `json:"tags,omitempty"`
 	// LastPurgedAtMillis is the wall-clock time of the last successful
 	// PurgeQueue. AWS rate-limits PurgeQueue to once per 60 seconds per
@@ -565,6 +566,13 @@ var sqsAttributeAppliers = map[string]attributeApplier{
 		m.RedrivePolicy = v
 		return nil
 	},
+	"RedriveAllowPolicy": func(m *sqsQueueMeta, v string) error {
+		if _, err := parseRedriveAllowPolicy(v); err != nil {
+			return err
+		}
+		m.RedriveAllowPolicy = v
+		return nil
+	},
 }
 
 // applyAttributes writes every entry in attrs into meta, returning a typed
@@ -784,7 +792,8 @@ func baseAttributesEqual(a, b *sqsQueueMeta) bool {
 		a.DelaySeconds == b.DelaySeconds &&
 		a.ReceiveMessageWaitSeconds == b.ReceiveMessageWaitSeconds &&
 		a.MaximumMessageSize == b.MaximumMessageSize &&
-		a.RedrivePolicy == b.RedrivePolicy
+		a.RedrivePolicy == b.RedrivePolicy &&
+		a.RedriveAllowPolicy == b.RedriveAllowPolicy
 }
 
 // throttleConfigEqual compares two Throttle configs for the
@@ -985,6 +994,9 @@ func (s *SQSServer) tryCreateQueueOnce(ctx context.Context, requested *sqsQueueM
 	// #734) and BEFORE the dispatch (so a rejected create does not
 	// burn an OCC commit).
 	if err := s.validateHTFIFOCapability(ctx, requested); err != nil {
+		return false, err
+	}
+	if err := s.validateRedrivePolicyTarget(ctx, requested, readTS); err != nil {
 		return false, err
 	}
 	lastGen, err := s.loadQueueGenerationAt(ctx, requested.Name, readTS)
@@ -1446,9 +1458,7 @@ func queueMetaToAttributes(meta *sqsQueueMeta, selection sqsAttributeSelection, 
 		all["ApproximateNumberOfMessagesNotVisible"] = strconv.FormatInt(counters.NotVisible, 10)
 		all["ApproximateNumberOfMessagesDelayed"] = strconv.FormatInt(counters.Delayed, 10)
 	}
-	if meta.RedrivePolicy != "" {
-		all["RedrivePolicy"] = meta.RedrivePolicy
-	}
+	addRedriveAttributes(all, meta)
 	// Throttle* are non-AWS extensions. Surfacing them in
 	// GetQueueAttributes lets operators read back what they set; SDKs
 	// that strictly validate the attribute set will ignore unknown
@@ -1469,6 +1479,15 @@ func queueMetaToAttributes(meta *sqsQueueMeta, selection sqsAttributeSelection, 
 		}
 	}
 	return out
+}
+
+func addRedriveAttributes(out map[string]string, meta *sqsQueueMeta) {
+	if meta.RedrivePolicy != "" {
+		out["RedrivePolicy"] = meta.RedrivePolicy
+	}
+	if meta.RedriveAllowPolicy != "" {
+		out["RedriveAllowPolicy"] = meta.RedriveAllowPolicy
+	}
 }
 
 func (s *SQSServer) setQueueAttributes(w http.ResponseWriter, r *http.Request) {
@@ -1597,6 +1616,9 @@ func (s *SQSServer) trySetQueueAttributesOnce(ctx context.Context, queueName str
 	// floats wrapped in a struct).
 	preThrottle := snapshotThrottle(meta.Throttle)
 	if err := applyAndValidateSetAttributes(meta, attrs); err != nil {
+		return false, false, err
+	}
+	if err := s.validateRedrivePolicyTarget(ctx, meta, readTS); err != nil {
 		return false, false, err
 	}
 	throttleChanged := !throttleConfigEqual(preThrottle, meta.Throttle)

--- a/adapter/sqs_catalog_test.go
+++ b/adapter/sqs_catalog_test.go
@@ -383,25 +383,34 @@ func TestSQSServer_SetQueueAttributesRequiresAttributes(t *testing.T) {
 
 func TestSQSServer_CreateQueueValidatesRedrivePolicy(t *testing.T) {
 	t.Parallel()
-	// Now that the receive path implements DLQ redrive, RedrivePolicy
-	// must round-trip; only malformed policies are rejected.
+	// SQS requires the DLQ to exist before a source queue can point
+	// RedrivePolicy at it. maxReceiveCount itself defaults to 10 when
+	// omitted, matching the API reference.
 	nodes, _, _ := createNode(t, 1)
 	defer shutdown(nodes)
 	node := sqsLeaderNode(t, nodes)
 
-	// Missing maxReceiveCount → InvalidAttributeValue.
 	status, out := callSQS(t, node, sqsCreateQueueTarget, map[string]any{
-		"QueueName": "bad-redrive",
+		"QueueName": "missing-dlq-redrive",
 		"Attributes": map[string]string{
 			"RedrivePolicy": `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:000000000000:dlq"}`,
 		},
 	})
 	if status != http.StatusBadRequest {
-		t.Fatalf("CreateQueue with malformed RedrivePolicy: got %d want 400 (%v)", status, out)
+		t.Fatalf("CreateQueue with missing DLQ target: got %d want 400 (%v)", status, out)
 	}
 
-	// Well-formed RedrivePolicy succeeds and round-trips.
-	policy := `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:000000000000:dlq","maxReceiveCount":5}`
+	_ = createSQSQueueForTest(t, node, "dlq")
+	status, out = callSQS(t, node, sqsCreateQueueTarget, map[string]any{
+		"QueueName": "wrong-region-redrive",
+		"Attributes": map[string]string{
+			"RedrivePolicy": `{"deadLetterTargetArn":"arn:aws:sqs:us-west-2:000000000000:dlq","maxReceiveCount":5}`,
+		},
+	})
+	if status != http.StatusBadRequest {
+		t.Fatalf("CreateQueue with wrong-region DLQ ARN: got %d want 400 (%v)", status, out)
+	}
+	policy := `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:000000000000:dlq"}`
 	status, out = callSQS(t, node, sqsCreateQueueTarget, map[string]any{
 		"QueueName": "with-redrive",
 		"Attributes": map[string]string{
@@ -419,6 +428,74 @@ func TestSQSServer_CreateQueueValidatesRedrivePolicy(t *testing.T) {
 	attrs, _ := out["Attributes"].(map[string]any)
 	if attrs["RedrivePolicy"] != policy {
 		t.Fatalf("RedrivePolicy not echoed back: %v", attrs)
+	}
+}
+
+func TestSQSServer_RedriveAllowPolicyControlsSourceQueues(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	node := sqsLeaderNode(t, nodes)
+
+	denyAll := `{"redrivePermission":"denyAll"}`
+	status, out := callSQS(t, node, sqsCreateQueueTarget, map[string]any{
+		"QueueName": "dlq-deny-all",
+		"Attributes": map[string]string{
+			"RedriveAllowPolicy": denyAll,
+		},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("create deny-all DLQ: %d %v", status, out)
+	}
+	status, out = callSQS(t, node, sqsCreateQueueTarget, map[string]any{
+		"QueueName": "deny-all-source",
+		"Attributes": map[string]string{
+			"RedrivePolicy": `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:000000000000:dlq-deny-all","maxReceiveCount":1}`,
+		},
+	})
+	if status != http.StatusBadRequest {
+		t.Fatalf("source should not attach to denyAll DLQ: got %d want 400 (%v)", status, out)
+	}
+
+	byQueue := `{"redrivePermission":"byQueue","sourceQueueArns":["arn:aws:sqs:us-east-1:000000000000:allowed-source"]}`
+	status, out = callSQS(t, node, sqsCreateQueueTarget, map[string]any{
+		"QueueName": "dlq-by-queue",
+		"Attributes": map[string]string{
+			"RedriveAllowPolicy": byQueue,
+		},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("create byQueue DLQ: %d %v", status, out)
+	}
+	status, out = callSQS(t, node, sqsCreateQueueTarget, map[string]any{
+		"QueueName": "rejected-source",
+		"Attributes": map[string]string{
+			"RedrivePolicy": `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:000000000000:dlq-by-queue","maxReceiveCount":1}`,
+		},
+	})
+	if status != http.StatusBadRequest {
+		t.Fatalf("unlisted source should not attach to byQueue DLQ: got %d want 400 (%v)", status, out)
+	}
+	status, out = callSQS(t, node, sqsCreateQueueTarget, map[string]any{
+		"QueueName": "allowed-source",
+		"Attributes": map[string]string{
+			"RedrivePolicy": `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:000000000000:dlq-by-queue","maxReceiveCount":1}`,
+		},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("listed source should attach to byQueue DLQ: got %d (%v)", status, out)
+	}
+	url, _ := out["QueueUrl"].(string)
+	if url == "" {
+		t.Fatalf("allowed source create returned empty QueueUrl: %v", out)
+	}
+	_, out = callSQS(t, node, sqsGetQueueAttributesTarget, map[string]any{
+		"QueueUrl":       "http://example.invalid/dlq-by-queue",
+		"AttributeNames": []string{"RedriveAllowPolicy"},
+	})
+	attrs, _ := out["Attributes"].(map[string]any)
+	if attrs["RedriveAllowPolicy"] != byQueue {
+		t.Fatalf("RedriveAllowPolicy not echoed back: %v", attrs)
 	}
 }
 

--- a/adapter/sqs_extra_test.go
+++ b/adapter/sqs_extra_test.go
@@ -1739,13 +1739,16 @@ func TestSQSServer_RedrivePolicyStandardDlqRejectsFifoSource(t *testing.T) {
 		t.Fatalf("create FIFO source with Standard-DLQ policy: got %d want 400 (%v)", status, out)
 	}
 
-	_, out = callSQS(t, node, sqsCreateQueueTarget, map[string]any{
+	status, out = callSQS(t, node, sqsCreateQueueTarget, map[string]any{
 		"QueueName":  "src-fifo-set.fifo",
 		"Attributes": map[string]string{"FifoQueue": "true"},
 	})
+	if status != http.StatusOK {
+		t.Fatalf("create FIFO source for setattrs path: got %d want 200 (%v)", status, out)
+	}
 	srcURL, _ := out["QueueUrl"].(string)
 	if srcURL == "" {
-		t.Fatalf("FIFO source create failed: %v", out)
+		t.Fatalf("create FIFO source for setattrs path returned empty QueueUrl: %v", out)
 	}
 	status, out = callSQS(t, node, sqsSetQueueAttributesTarget, map[string]any{
 		"QueueUrl":   srcURL,

--- a/adapter/sqs_extra_test.go
+++ b/adapter/sqs_extra_test.go
@@ -662,6 +662,24 @@ func TestSQSServer_DLQRedriveOnMaxReceiveCount(t *testing.T) {
 		"MessageBody": "poison",
 	})
 
+	sourceMessageID, sourceSentTimestamp := receiveSourceTwiceBeforeRedrive(t, node, srcURL)
+
+	// Third receive triggers the redrive; source returns 0 messages.
+	_, out = callSQS(t, node, sqsReceiveMessageTarget, map[string]any{
+		"QueueUrl":            srcURL,
+		"MaxNumberOfMessages": 1,
+		"VisibilityTimeout":   1,
+	})
+	if msgs, _ := out["Messages"].([]any); len(msgs) != 0 {
+		t.Fatalf("source still returning poison message after redrive: %v", msgs)
+	}
+
+	assertStandardDLQRedriveMessage(t, node, dlqURL, sourceMessageID, sourceSentTimestamp)
+}
+
+func receiveSourceTwiceBeforeRedrive(t *testing.T, node Node, srcURL string) (string, string) {
+	t.Helper()
+	var sourceMessageID, sourceSentTimestamp string
 	// First two receives deliver the message normally (count 1, 2).
 	for i := range 2 {
 		_, out := callSQS(t, node, sqsReceiveMessageTarget, map[string]any{
@@ -673,23 +691,29 @@ func TestSQSServer_DLQRedriveOnMaxReceiveCount(t *testing.T) {
 		if len(msgs) != 1 {
 			t.Fatalf("receive #%d expected 1 msg, got %d (%v)", i, len(msgs), out)
 		}
+		if i == 0 {
+			sourceMessageID, sourceSentTimestamp = sourceMessageIdentity(t, msgs[0])
+		}
 		// Wait past the visibility window so the next receive can pick
 		// it up again.
 		time.Sleep(1100 * time.Millisecond)
 	}
+	return sourceMessageID, sourceSentTimestamp
+}
 
-	// Third receive triggers the redrive — source returns 0 messages.
-	_, out = callSQS(t, node, sqsReceiveMessageTarget, map[string]any{
-		"QueueUrl":            srcURL,
-		"MaxNumberOfMessages": 1,
-		"VisibilityTimeout":   1,
-	})
-	if msgs, _ := out["Messages"].([]any); len(msgs) != 0 {
-		t.Fatalf("source still returning poison message after redrive: %v", msgs)
-	}
+func sourceMessageIdentity(t *testing.T, raw any) (string, string) {
+	t.Helper()
+	msg, _ := raw.(map[string]any)
+	messageID, _ := msg["MessageId"].(string)
+	attrs, _ := msg["Attributes"].(map[string]any)
+	sentTimestamp, _ := attrs["SentTimestamp"].(string)
+	return messageID, sentTimestamp
+}
 
+func assertStandardDLQRedriveMessage(t *testing.T, node Node, dlqURL, sourceMessageID, sourceSentTimestamp string) {
+	t.Helper()
 	// DLQ now has the moved message.
-	_, out = callSQS(t, node, sqsReceiveMessageTarget, map[string]any{
+	_, out := callSQS(t, node, sqsReceiveMessageTarget, map[string]any{
 		"QueueUrl":            dlqURL,
 		"MaxNumberOfMessages": 1,
 		"VisibilityTimeout":   60,
@@ -702,11 +726,71 @@ func TestSQSServer_DLQRedriveOnMaxReceiveCount(t *testing.T) {
 	if moved["Body"] != "poison" {
 		t.Fatalf("DLQ message body = %v, want poison", moved["Body"])
 	}
+	if moved["MessageId"] != sourceMessageID {
+		t.Fatalf("DLQ MessageId = %v, want original %s", moved["MessageId"], sourceMessageID)
+	}
 	// ApproximateReceiveCount on the DLQ side starts at 1 (this single
 	// receive); the source's count is not carried over.
 	movedAttrs, _ := moved["Attributes"].(map[string]any)
+	if movedAttrs["SentTimestamp"] != sourceSentTimestamp {
+		t.Fatalf("standard DLQ SentTimestamp = %v, want original %s", movedAttrs["SentTimestamp"], sourceSentTimestamp)
+	}
 	if movedAttrs["ApproximateReceiveCount"] != "1" {
 		t.Fatalf("DLQ message ApproximateReceiveCount = %v, want 1", movedAttrs["ApproximateReceiveCount"])
+	}
+}
+
+func TestSQSServer_RedriveAllowPolicyEnforcedAtMove(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	node := sqsLeaderNode(t, nodes)
+
+	dlqURL := createSQSQueueForTest(t, node, "runtime-policy-dlq")
+	policy := `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:000000000000:runtime-policy-dlq","maxReceiveCount":1}`
+	status, out := callSQS(t, node, sqsCreateQueueTarget, map[string]any{
+		"QueueName": "runtime-policy-src",
+		"Attributes": map[string]string{
+			"RedrivePolicy": policy,
+		},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("create source: %d %v", status, out)
+	}
+	srcURL, _ := out["QueueUrl"].(string)
+	_, _ = callSQS(t, node, sqsSendMessageTarget, map[string]any{
+		"QueueUrl":    srcURL,
+		"MessageBody": "poison",
+	})
+	_, _ = callSQS(t, node, sqsReceiveMessageTarget, map[string]any{
+		"QueueUrl":            srcURL,
+		"MaxNumberOfMessages": 1,
+		"VisibilityTimeout":   1,
+	})
+	status, out = callSQS(t, node, sqsSetQueueAttributesTarget, map[string]any{
+		"QueueUrl": dlqURL,
+		"Attributes": map[string]string{
+			"RedriveAllowPolicy": `{"redrivePermission":"denyAll"}`,
+		},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("set denyAll on DLQ: %d %v", status, out)
+	}
+	time.Sleep(1100 * time.Millisecond)
+	status, out = callSQS(t, node, sqsReceiveMessageTarget, map[string]any{
+		"QueueUrl":            srcURL,
+		"MaxNumberOfMessages": 1,
+	})
+	if status != http.StatusBadRequest {
+		t.Fatalf("receive should fail when DLQ now denies source: got %d want 400 (%v)", status, out)
+	}
+
+	_, out = callSQS(t, node, sqsReceiveMessageTarget, map[string]any{
+		"QueueUrl":            dlqURL,
+		"MaxNumberOfMessages": 1,
+	})
+	if msgs, _ := out["Messages"].([]any); len(msgs) != 0 {
+		t.Fatalf("DLQ should remain empty after denied redrive, got %v", msgs)
 	}
 }
 
@@ -1594,17 +1678,12 @@ func TestSQSServer_BatchOnMissingQueueIsRequestLevelError(t *testing.T) {
 
 func TestSQSServer_RedrivePolicyFifoDlqRejectsStandardSource(t *testing.T) {
 	t.Parallel()
-	// A Standard source pointing at a FIFO DLQ would copy empty
-	// MessageGroupId into the DLQ record; the DLQ-side receive only
-	// enforces FIFO group-lock when MessageGroupId is non-empty, so
-	// those messages bypass FIFO semantics inside a queue clients
-	// believe is strictly ordered. The redrive path must reject the
-	// move when this would happen.
+	// AWS requires source and DLQ queue types to match. A Standard
+	// source cannot configure a FIFO DLQ.
 	nodes, _, _ := createNode(t, 1)
 	defer shutdown(nodes)
 	node := sqsLeaderNode(t, nodes)
 
-	// Create FIFO DLQ.
 	_, out := callSQS(t, node, sqsCreateQueueTarget, map[string]any{
 		"QueueName":  "dlq.fifo",
 		"Attributes": map[string]string{"FifoQueue": "true"},
@@ -1613,63 +1692,33 @@ func TestSQSServer_RedrivePolicyFifoDlqRejectsStandardSource(t *testing.T) {
 		t.Fatalf("FIFO DLQ create failed: %v", out)
 	}
 
-	// Standard source with RedrivePolicy targeting the FIFO DLQ.
 	policy := `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:000000000000:dlq.fifo","maxReceiveCount":1}`
 	status, out := callSQS(t, node, sqsCreateQueueTarget, map[string]any{
 		"QueueName":  "src-standard",
 		"Attributes": map[string]string{"RedrivePolicy": policy},
 	})
-	if status != http.StatusOK {
-		t.Fatalf("create standard source with FIFO-DLQ policy: %d %v", status, out)
+	if status != http.StatusBadRequest {
+		t.Fatalf("create standard source with FIFO-DLQ policy: got %d want 400 (%v)", status, out)
 	}
-	srcURL, _ := out["QueueUrl"].(string)
 
-	_, _ = callSQS(t, node, sqsSendMessageTarget, map[string]any{
-		"QueueUrl":    srcURL,
-		"MessageBody": "poison",
+	srcURL := createSQSQueueForTest(t, node, "src-standard")
+	status, out = callSQS(t, node, sqsSetQueueAttributesTarget, map[string]any{
+		"QueueUrl":   srcURL,
+		"Attributes": map[string]string{"RedrivePolicy": policy},
 	})
-	// First receive bumps ReceiveCount to 1 == maxReceiveCount; second
-	// receive should attempt redrive and the FIFO compatibility gate
-	// must trip. The receive path returns 5xx (sqsErrInternalFailure
-	// surfaced via sqsAPIError) rather than silently moving an
-	// invalid record.
-	_, _ = callSQS(t, node, sqsReceiveMessageTarget, map[string]any{
-		"QueueUrl":            srcURL,
-		"MaxNumberOfMessages": 1,
-		"VisibilityTimeout":   1,
-	})
-	time.Sleep(1100 * time.Millisecond)
-	status, body := callSQS(t, node, sqsReceiveMessageTarget, map[string]any{
-		"QueueUrl":            srcURL,
-		"MaxNumberOfMessages": 1,
-	})
-	if status == http.StatusOK {
-		// AWS-level invariant: the message must NOT have been
-		// redriven into the FIFO DLQ. Even if the receive returns
-		// OK, the failure is that the FIFO DLQ should not now hold
-		// a record with an empty MessageGroupId.
-		if msgs, _ := body["Messages"].([]any); len(msgs) > 0 {
-			t.Fatalf("FIFO DLQ should not receive redriven Standard source records, got msgs=%v", msgs)
-		}
+	if status != http.StatusBadRequest {
+		t.Fatalf("set standard source with FIFO-DLQ policy: got %d want 400 (%v)", status, out)
 	}
 }
 
 func TestSQSServer_RedrivePolicyStandardDlqRejectsFifoSource(t *testing.T) {
 	t.Parallel()
-	// Symmetric to RedrivePolicyFifoDlqRejectsStandardSource: the
-	// existing guard rejected only the Standard→FIFO direction, but
-	// FIFO→Standard was equally broken. A FIFO source carries
-	// MessageGroupId on every record; copying that into a Standard
-	// DLQ and then issuing ReceiveMessage on the DLQ trips
-	// tryDeliverCandidate's FIFO group-lock branch (gated solely on
-	// MessageGroupId != ""), which serializes delivery in a queue
-	// clients believe behaves as Standard. AWS rejects mixed-type
-	// redrive policies; this test pins that behavior.
+	// Symmetric to RedrivePolicyFifoDlqRejectsStandardSource:
+	// a FIFO source cannot configure a Standard DLQ.
 	nodes, _, _ := createNode(t, 1)
 	defer shutdown(nodes)
 	node := sqsLeaderNode(t, nodes)
 
-	// Standard DLQ (no FifoQueue attribute).
 	_, out := callSQS(t, node, sqsCreateQueueTarget, map[string]any{
 		"QueueName": "dlq-standard",
 	})
@@ -1678,7 +1727,6 @@ func TestSQSServer_RedrivePolicyStandardDlqRejectsFifoSource(t *testing.T) {
 		t.Fatalf("Standard DLQ create failed: %v", out)
 	}
 
-	// FIFO source with RedrivePolicy targeting the Standard DLQ.
 	policy := `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:000000000000:dlq-standard","maxReceiveCount":1}`
 	status, out := callSQS(t, node, sqsCreateQueueTarget, map[string]any{
 		"QueueName": "src-fifo.fifo",
@@ -1687,41 +1735,21 @@ func TestSQSServer_RedrivePolicyStandardDlqRejectsFifoSource(t *testing.T) {
 			"RedrivePolicy": policy,
 		},
 	})
-	if status != http.StatusOK {
-		t.Fatalf("create FIFO source with Standard-DLQ policy: %d %v", status, out)
+	if status != http.StatusBadRequest {
+		t.Fatalf("create FIFO source with Standard-DLQ policy: got %d want 400 (%v)", status, out)
 	}
+
+	_, out = callSQS(t, node, sqsCreateQueueTarget, map[string]any{
+		"QueueName":  "src-fifo-set.fifo",
+		"Attributes": map[string]string{"FifoQueue": "true"},
+	})
 	srcURL, _ := out["QueueUrl"].(string)
-
-	_, _ = callSQS(t, node, sqsSendMessageTarget, map[string]any{
-		"QueueUrl":               srcURL,
-		"MessageBody":            "poison",
-		"MessageGroupId":         "g1",
-		"MessageDeduplicationId": "d1",
+	status, out = callSQS(t, node, sqsSetQueueAttributesTarget, map[string]any{
+		"QueueUrl":   srcURL,
+		"Attributes": map[string]string{"RedrivePolicy": policy},
 	})
-	// First receive bumps ReceiveCount to 1 == maxReceiveCount;
-	// second receive (after visibility expiry) should attempt redrive.
-	// The runtime type-compatibility gate must trip, leaving the DLQ
-	// empty and the source message intact.
-	_, _ = callSQS(t, node, sqsReceiveMessageTarget, map[string]any{
-		"QueueUrl":            srcURL,
-		"MaxNumberOfMessages": 1,
-		"VisibilityTimeout":   1,
-	})
-	time.Sleep(1100 * time.Millisecond)
-	_, _ = callSQS(t, node, sqsReceiveMessageTarget, map[string]any{
-		"QueueUrl":            srcURL,
-		"MaxNumberOfMessages": 1,
-	})
-
-	// Direct DLQ receive: a successful redrive would have written a
-	// record with non-empty MessageGroupId here; the fix must keep
-	// the DLQ empty.
-	_, body := callSQS(t, node, sqsReceiveMessageTarget, map[string]any{
-		"QueueUrl":            dlqURL,
-		"MaxNumberOfMessages": 10,
-	})
-	if msgs, _ := body["Messages"].([]any); len(msgs) > 0 {
-		t.Fatalf("Standard DLQ received a redriven FIFO record (would carry MessageGroupId): %v", msgs)
+	if status != http.StatusBadRequest {
+		t.Fatalf("set FIFO source with Standard-DLQ policy: got %d want 400 (%v)", status, out)
 	}
 }
 
@@ -1800,11 +1828,17 @@ func TestSQSServer_FifoFifoRedriveAssignsSequenceNumber(t *testing.T) {
 
 	// First receive bumps ReceiveCount to 1 == maxReceiveCount;
 	// second receive (after visibility expiry) triggers the redrive.
-	_, _ = callSQS(t, node, sqsReceiveMessageTarget, map[string]any{
+	_, out = callSQS(t, node, sqsReceiveMessageTarget, map[string]any{
 		"QueueUrl":            srcURL,
 		"MaxNumberOfMessages": 1,
 		"VisibilityTimeout":   1,
 	})
+	srcMsgs, _ := out["Messages"].([]any)
+	if len(srcMsgs) != 1 {
+		t.Fatalf("source expected 1 first receive, got %d (%v)", len(srcMsgs), out)
+	}
+	srcMsg, _ := srcMsgs[0].(map[string]any)
+	sourceMessageID, _ := srcMsg["MessageId"].(string)
 	time.Sleep(1100 * time.Millisecond)
 	_, _ = callSQS(t, node, sqsReceiveMessageTarget, map[string]any{
 		"QueueUrl":            srcURL,
@@ -1824,6 +1858,12 @@ func TestSQSServer_FifoFifoRedriveAssignsSequenceNumber(t *testing.T) {
 	}
 	moved, _ := msgs[0].(map[string]any)
 	movedAttrs, _ := moved["Attributes"].(map[string]any)
+	if moved["MessageId"] != sourceMessageID {
+		t.Fatalf("FIFO DLQ MessageId = %v, want original %s", moved["MessageId"], sourceMessageID)
+	}
+	if movedAttrs["MessageDeduplicationId"] != sourceMessageID {
+		t.Fatalf("FIFO DLQ MessageDeduplicationId = %v, want original MessageId %s", movedAttrs["MessageDeduplicationId"], sourceMessageID)
+	}
 	movedSeqStr, _ := movedAttrs["SequenceNumber"].(string)
 	movedSeq, _ := strconv.ParseUint(movedSeqStr, 10, 64)
 	if movedSeq == 0 {

--- a/adapter/sqs_extra_test.go
+++ b/adapter/sqs_extra_test.go
@@ -1744,6 +1744,9 @@ func TestSQSServer_RedrivePolicyStandardDlqRejectsFifoSource(t *testing.T) {
 		"Attributes": map[string]string{"FifoQueue": "true"},
 	})
 	srcURL, _ := out["QueueUrl"].(string)
+	if srcURL == "" {
+		t.Fatalf("FIFO source create failed: %v", out)
+	}
 	status, out = callSQS(t, node, sqsSetQueueAttributesTarget, map[string]any{
 		"QueueUrl":   srcURL,
 		"Attributes": map[string]string{"RedrivePolicy": policy},

--- a/adapter/sqs_redrive.go
+++ b/adapter/sqs_redrive.go
@@ -21,6 +21,11 @@ type parsedRedrivePolicy struct {
 	MaxReceiveCount     int64
 }
 
+type parsedRedriveAllowPolicy struct {
+	RedrivePermission string
+	SourceQueueArns   []string
+}
+
 // rawRedrivePolicy mirrors the AWS JSON shape. maxReceiveCount uses
 // json.Number so we can accept both numeric and string forms without
 // disagreeing with the SDKs.
@@ -29,10 +34,21 @@ type rawRedrivePolicy struct {
 	MaxReceiveCount     json.Number `json:"maxReceiveCount"`
 }
 
+type rawRedriveAllowPolicy struct {
+	RedrivePermission string   `json:"redrivePermission"`
+	SourceQueueArns   []string `json:"sourceQueueArns"`
+}
+
 // AWS SQS allows maxReceiveCount in [1, 1000].
 const (
-	sqsRedriveMaxReceiveCountMax = 1000
-	sqsRedriveMaxReceiveCountMin = 1
+	sqsRedriveDefaultMaxReceiveCount = 10
+	sqsRedriveMaxReceiveCountMax     = 1000
+	sqsRedriveMaxReceiveCountMin     = 1
+
+	sqsRedrivePermissionAllowAll    = "allowAll"
+	sqsRedrivePermissionDenyAll     = "denyAll"
+	sqsRedrivePermissionByQueue     = "byQueue"
+	sqsRedriveAllowPolicyMaxSources = 10
 )
 
 // parseRedrivePolicy validates a RedrivePolicy JSON blob and extracts
@@ -55,10 +71,14 @@ func parseRedrivePolicy(s string) (*parsedRedrivePolicy, error) {
 		return nil, newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
 			"RedrivePolicy.deadLetterTargetArn is required")
 	}
-	maxReceive, err := raw.MaxReceiveCount.Int64()
-	if err != nil {
-		return nil, newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
-			"RedrivePolicy.maxReceiveCount must be an integer")
+	maxReceive := int64(sqsRedriveDefaultMaxReceiveCount)
+	if raw.MaxReceiveCount != "" {
+		var err error
+		maxReceive, err = raw.MaxReceiveCount.Int64()
+		if err != nil {
+			return nil, newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
+				"RedrivePolicy.maxReceiveCount must be an integer")
+		}
 	}
 	if maxReceive < sqsRedriveMaxReceiveCountMin || maxReceive > sqsRedriveMaxReceiveCountMax {
 		return nil, newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
@@ -74,6 +94,71 @@ func parseRedrivePolicy(s string) (*parsedRedrivePolicy, error) {
 		DLQName:             dlqName,
 		MaxReceiveCount:     maxReceive,
 	}, nil
+}
+
+// parseRedriveAllowPolicy validates the DLQ-side RedriveAllowPolicy
+// JSON blob. AWS defaults an absent redrivePermission to allowAll;
+// the queue meta represents that default by leaving RedriveAllowPolicy
+// empty, but a caller that explicitly sends {} should get the same
+// semantics.
+func parseRedriveAllowPolicy(s string) (*parsedRedriveAllowPolicy, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
+			"RedriveAllowPolicy must be non-empty JSON")
+	}
+	var raw rawRedriveAllowPolicy
+	if err := json.Unmarshal([]byte(s), &raw); err != nil {
+		return nil, newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
+			"RedriveAllowPolicy is not valid JSON")
+	}
+	permission := strings.TrimSpace(raw.RedrivePermission)
+	if permission == "" {
+		permission = sqsRedrivePermissionAllowAll
+	}
+	if err := validateRawRedriveAllowPolicy(permission, raw.SourceQueueArns); err != nil {
+		return nil, err
+	}
+	return &parsedRedriveAllowPolicy{
+		RedrivePermission: permission,
+		SourceQueueArns:   raw.SourceQueueArns,
+	}, nil
+}
+
+func validateRawRedriveAllowPolicy(permission string, sourceQueueArns []string) error {
+	switch permission {
+	case sqsRedrivePermissionAllowAll, sqsRedrivePermissionDenyAll:
+		if len(sourceQueueArns) > 0 {
+			return newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
+				"RedriveAllowPolicy.sourceQueueArns is only valid when redrivePermission is byQueue")
+		}
+	case sqsRedrivePermissionByQueue:
+		if err := validateByQueueSourceArns(sourceQueueArns); err != nil {
+			return err
+		}
+	default:
+		return newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
+			"RedriveAllowPolicy.redrivePermission must be allowAll, denyAll, or byQueue")
+	}
+	return nil
+}
+
+func validateByQueueSourceArns(sourceQueueArns []string) error {
+	if len(sourceQueueArns) == 0 {
+		return newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
+			"RedriveAllowPolicy.sourceQueueArns is required when redrivePermission is byQueue")
+	}
+	if len(sourceQueueArns) > sqsRedriveAllowPolicyMaxSources {
+		return newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
+			"RedriveAllowPolicy.sourceQueueArns can contain at most 10 queue ARNs")
+	}
+	for _, arn := range sourceQueueArns {
+		if dlqNameFromArn(strings.TrimSpace(arn)) == "" {
+			return newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
+				"RedriveAllowPolicy.sourceQueueArns contains a malformed ARN")
+		}
+	}
+	return nil
 }
 
 // dlqNameFromArn returns the queue name segment of an SQS ARN. AWS
@@ -184,40 +269,135 @@ func (s *SQSServer) validateRedriveTargets(
 	policy *parsedRedrivePolicy,
 	readTS uint64,
 ) (*sqsQueueMeta, error) {
-	if policy.DLQName == srcQueueName {
-		return nil, newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
-			"RedrivePolicy.deadLetterTargetArn must not point at the source queue")
+	if err := s.validateRedrivePolicyReference(srcQueueName, policy); err != nil {
+		return nil, err
 	}
-	dlqMeta, dlqExists, err := s.loadQueueMetaAt(ctx, policy.DLQName, readTS)
+	srcMeta, dlqMeta, err := s.loadRedrivePairMeta(ctx, srcQueueName, policy.DLQName, readTS)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
-	if !dlqExists {
-		return nil, newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
-			"RedrivePolicy targets non-existent DLQ "+policy.DLQName)
+	if err := validateRedriveQueuePair(srcMeta, dlqMeta); err != nil {
+		return nil, err
 	}
-	srcMeta, srcExists, err := s.loadQueueMetaAt(ctx, srcQueueName, readTS)
-	if err != nil {
-		return nil, errors.WithStack(err)
+	if err := s.validateRedriveAllowPolicyForSource(srcQueueName, dlqMeta); err != nil {
+		return nil, err
 	}
-	if !srcExists {
-		return nil, newSQSAPIError(http.StatusBadRequest, sqsErrQueueDoesNotExist,
-			"source queue disappeared during redrive")
-	}
-	if srcMeta.IsFIFO != dlqMeta.IsFIFO {
-		return nil, newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
-			"RedrivePolicy queue-type mismatch: source and DLQ must both be FIFO or both Standard")
-	}
-	if dlqMeta.IsFIFO && srcRec.MessageGroupId == "" {
-		return nil, newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
-			"FIFO DLQ requires source records to carry MessageGroupId")
+	if err := validateRedriveFIFORecord(srcRec, dlqMeta); err != nil {
+		return nil, err
 	}
 	return dlqMeta, nil
 }
 
-// buildDLQRecord assembles the DLQ-side message record. Reset
-// ReceiveCount and FirstReceiveMillis so the DLQ consumer sees a
-// fresh delivery, not the source's bounce history.
+func (s *SQSServer) validateRedrivePolicyReference(srcQueueName string, policy *parsedRedrivePolicy) error {
+	if policy.DLQName == srcQueueName {
+		return newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
+			"RedrivePolicy.deadLetterTargetArn must not point at the source queue")
+	}
+	if policy.DeadLetterTargetArn != s.queueArn(policy.DLQName) {
+		return newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
+			"RedrivePolicy.deadLetterTargetArn must target a queue in this SQS account and region")
+	}
+	return nil
+}
+
+func (s *SQSServer) loadRedrivePairMeta(ctx context.Context, srcQueueName, dlqName string, readTS uint64) (*sqsQueueMeta, *sqsQueueMeta, error) {
+	dlqMeta, dlqExists, err := s.loadQueueMetaAt(ctx, dlqName, readTS)
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+	if !dlqExists {
+		return nil, nil, newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
+			"RedrivePolicy targets non-existent DLQ "+dlqName)
+	}
+	srcMeta, srcExists, err := s.loadQueueMetaAt(ctx, srcQueueName, readTS)
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+	if !srcExists {
+		return nil, nil, newSQSAPIError(http.StatusBadRequest, sqsErrQueueDoesNotExist,
+			"source queue disappeared during redrive")
+	}
+	return srcMeta, dlqMeta, nil
+}
+
+func validateRedriveQueuePair(srcMeta, dlqMeta *sqsQueueMeta) error {
+	if srcMeta.IsFIFO != dlqMeta.IsFIFO {
+		return newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
+			"RedrivePolicy queue-type mismatch: source and DLQ must both be FIFO or both Standard")
+	}
+	return nil
+}
+
+func validateRedriveFIFORecord(srcRec *sqsMessageRecord, dlqMeta *sqsQueueMeta) error {
+	if dlqMeta.IsFIFO && srcRec.MessageGroupId == "" {
+		return newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
+			"FIFO DLQ requires source records to carry MessageGroupId")
+	}
+	return nil
+}
+
+func (s *SQSServer) validateRedrivePolicyTarget(ctx context.Context, sourceMeta *sqsQueueMeta, readTS uint64) error {
+	if sourceMeta == nil || strings.TrimSpace(sourceMeta.RedrivePolicy) == "" {
+		return nil
+	}
+	policy, err := parseRedrivePolicy(sourceMeta.RedrivePolicy)
+	if err != nil {
+		return err
+	}
+	if err := s.validateRedrivePolicyReference(sourceMeta.Name, policy); err != nil {
+		return err
+	}
+	dlqMeta, dlqExists, err := s.loadQueueMetaAt(ctx, policy.DLQName, readTS)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if !dlqExists {
+		return newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
+			"RedrivePolicy targets non-existent DLQ "+policy.DLQName)
+	}
+	if err := validateRedriveQueuePair(sourceMeta, dlqMeta); err != nil {
+		return err
+	}
+	return s.validateRedriveAllowPolicyForSource(sourceMeta.Name, dlqMeta)
+}
+
+func (s *SQSServer) validateRedriveAllowPolicyForSource(sourceQueueName string, dlqMeta *sqsQueueMeta) error {
+	if dlqMeta == nil || strings.TrimSpace(dlqMeta.RedriveAllowPolicy) == "" {
+		return nil
+	}
+	allow, err := parseRedriveAllowPolicy(dlqMeta.RedriveAllowPolicy)
+	if err != nil {
+		return err
+	}
+	switch allow.RedrivePermission {
+	case sqsRedrivePermissionAllowAll:
+		return nil
+	case sqsRedrivePermissionDenyAll:
+		return newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
+			"RedriveAllowPolicy denies all source queues for DLQ "+dlqMeta.Name)
+	case sqsRedrivePermissionByQueue:
+		sourceArn := s.queueArn(sourceQueueName)
+		for _, arn := range allow.SourceQueueArns {
+			if strings.TrimSpace(arn) == sourceArn {
+				return nil
+			}
+		}
+		return newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
+			"RedriveAllowPolicy does not allow source queue "+sourceQueueName)
+	default:
+		return newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
+			"RedriveAllowPolicy.redrivePermission must be allowAll, denyAll, or byQueue")
+	}
+}
+
+// buildDLQRecord assembles the DLQ-side message record. MessageID is
+// preserved across the move. Standard queues keep the original
+// SentTimestamp so DLQ retention is based on the original enqueue
+// time; FIFO queues get a fresh enqueue timestamp and use the
+// original MessageID as the DLQ-side MessageDeduplicationId, matching
+// Amazon SQS's FIFO DLQ behavior. ReceiveCount and FirstReceiveMillis
+// reset so the DLQ consumer sees a fresh delivery, not the source's
+// bounce history.
 //
 // dlqSeq is the SequenceNumber to assign on the DLQ record, computed
 // by the caller as `loadFifoSequence(dlq) + 1` for FIFO DLQs and
@@ -228,23 +408,27 @@ func (s *SQSServer) validateRedriveTargets(
 // and a later FIFO send to the DLQ produces a non-monotonic
 // SequenceNumber.
 func buildDLQRecord(srcRec *sqsMessageRecord, dlqMeta *sqsQueueMeta, srcArn string, dlqSeq uint64) (*sqsMessageRecord, []byte, error) {
-	dlqMsgID, err := newMessageIDHex()
-	if err != nil {
-		return nil, nil, errors.WithStack(err)
-	}
 	dlqToken, err := newReceiptToken()
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
 	now := time.Now().UnixMilli()
+	sendTimestamp := now
+	if !dlqMeta.IsFIFO {
+		sendTimestamp = srcRec.SendTimestampMillis
+	}
+	deduplicationID := srcRec.MessageDeduplicationId
+	if dlqMeta.IsFIFO {
+		deduplicationID = srcRec.MessageID
+	}
 	rec := &sqsMessageRecord{
-		MessageID:              dlqMsgID,
+		MessageID:              srcRec.MessageID,
 		Body:                   srcRec.Body,
 		MD5OfBody:              srcRec.MD5OfBody,
 		MD5OfMessageAttributes: srcRec.MD5OfMessageAttributes,
 		MessageAttributes:      srcRec.MessageAttributes,
 		SenderID:               srcRec.SenderID,
-		SendTimestampMillis:    now,
+		SendTimestampMillis:    sendTimestamp,
 		AvailableAtMillis:      now,
 		VisibleAtMillis:        now,
 		ReceiveCount:           0,
@@ -252,7 +436,7 @@ func buildDLQRecord(srcRec *sqsMessageRecord, dlqMeta *sqsQueueMeta, srcArn stri
 		CurrentReceiptToken:    dlqToken,
 		QueueGeneration:        dlqMeta.Generation,
 		MessageGroupId:         srcRec.MessageGroupId,
-		MessageDeduplicationId: srcRec.MessageDeduplicationId,
+		MessageDeduplicationId: deduplicationID,
 		DeadLetterSourceArn:    srcArn,
 		SequenceNumber:         dlqSeq,
 	}
@@ -290,15 +474,16 @@ func (s *SQSServer) buildRedriveOps(
 	readTS uint64,
 ) (*kv.OperationGroup[kv.OP], error) {
 	srcGen := srcMeta.Generation
-	now := dlqRec.SendTimestampMillis
+	visibleAt := dlqRec.VisibleAtMillis
+	sentAt := dlqRec.SendTimestampMillis
 	// DLQ partition for FIFO sources: redrive carries the source's
 	// MessageGroupId forward, so the DLQ partition is the result of
 	// hashing that group through the DLQ's partitionFor. Standard
 	// DLQs (or any DLQ with PartitionCount <= 1) collapse this to 0.
 	dlqPartition := partitionFor(dlqMeta, dlqRec.MessageGroupId)
 	dlqDataKey := sqsMsgDataKeyDispatch(dlqMeta, policy.DLQName, dlqPartition, dlqMeta.Generation, dlqRec.MessageID)
-	dlqVisKey := sqsMsgVisKeyDispatch(dlqMeta, policy.DLQName, dlqPartition, dlqMeta.Generation, now, dlqRec.MessageID)
-	dlqByAgeKey := sqsMsgByAgeKeyDispatch(dlqMeta, policy.DLQName, dlqPartition, dlqMeta.Generation, now, dlqRec.MessageID)
+	dlqVisKey := sqsMsgVisKeyDispatch(dlqMeta, policy.DLQName, dlqPartition, dlqMeta.Generation, visibleAt, dlqRec.MessageID)
+	dlqByAgeKey := sqsMsgByAgeKeyDispatch(dlqMeta, policy.DLQName, dlqPartition, dlqMeta.Generation, sentAt, dlqRec.MessageID)
 	srcByAgeKey := sqsMsgByAgeKeyDispatch(srcMeta, srcQueueName, cand.partition, srcGen, srcRec.SendTimestampMillis, srcRec.MessageID)
 	readKeys := [][]byte{
 		cand.visKey, srcDataKey,

--- a/docs/design/2026_06_16_proposed_sqs_dlq_redrive_admin_ui.md
+++ b/docs/design/2026_06_16_proposed_sqs_dlq_redrive_admin_ui.md
@@ -1,0 +1,415 @@
+# SQS DLQ Redrive Policy and Admin Configuration UI
+
+Status: Proposed
+Author: bootjp
+Date: 2026-06-16
+
+---
+
+## 1. Background and Motivation
+
+The SQS adapter already models queues, visibility timeouts, receive counts, FIFO group locks, and the admin SQS detail page. The missing piece was a complete dead-letter queue (DLQ) control plane:
+
+1. A source queue could reference a DLQ, but the implementation did not fully enforce the AWS `RedrivePolicy` and DLQ-side `RedriveAllowPolicy` contracts.
+2. Operators could inspect and purge queue contents from the admin Web UI, but they could not configure which queue receives poison messages or how many failed receives are allowed before the move.
+
+The failure mode is operationally severe: without an AWS-compatible DLQ redrive boundary, a poison message can be repeatedly delivered forever. The fix needs to be part of the SQS data path, not only the Web UI, because SDK/CLI clients configure DLQs through `CreateQueue` and `SetQueueAttributes` and consumers trigger redrive through `ReceiveMessage`.
+
+This document defines:
+
+- AWS-compatible `RedrivePolicy` parsing and validation.
+- AWS-compatible `RedriveAllowPolicy` parsing and enforcement.
+- The receive-time move from source queue to DLQ.
+- The admin HTTP endpoint used by the Web UI to update SQS queue attributes.
+- The Web UI flow for configuring source-side and DLQ-side policies.
+
+---
+
+## 2. Goals and Non-Goals
+
+### 2.1 Goals
+
+1. **Move by failed receive count.** A message is moved to the configured DLQ when the next receive would exceed `RedrivePolicy.maxReceiveCount`.
+2. **SQS-compatible policy creation and updates.** Accept the AWS `RedrivePolicy` and `RedriveAllowPolicy` JSON shapes for creating and updating DLQ configuration. The initial rollout has one explicit clearing deviation documented in §2.2 and §3.4.
+3. **SQS-compatible `RedrivePolicy`.** Accept the AWS JSON shape:
+
+   ```json
+   {"deadLetterTargetArn":"arn:aws:sqs:us-east-1:000000000000:orders-dlq","maxReceiveCount":5}
+   ```
+
+   `maxReceiveCount` defaults to 10 when omitted and is valid only in `[1, 1000]`.
+
+4. **SQS-compatible `RedriveAllowPolicy`.** Accept the AWS JSON shape:
+
+   ```json
+   {"redrivePermission":"byQueue","sourceQueueArns":["arn:aws:sqs:us-east-1:000000000000:orders"]}
+   ```
+
+   Supported permissions are `allowAll`, `denyAll`, and `byQueue`; `byQueue` allows at most 10 source queue ARNs.
+
+5. **Control-plane validation.** `CreateQueue` and `SetQueueAttributes` reject invalid DLQ configuration before it is stored.
+6. **Runtime validation.** The receive-time redrive path revalidates the source/DLQ relationship before moving a message, so a later DLQ policy change cannot be bypassed by an older source policy.
+7. **Type safety.** FIFO sources can target only FIFO DLQs, and Standard sources can target only Standard DLQs.
+8. **Admin UI configuration.** The SQS detail page lets full-access operators set:
+   - Source-side `RedrivePolicy`: DLQ target + `maxReceiveCount`.
+   - DLQ-side `RedriveAllowPolicy`: `allowAll` / `denyAll` / `byQueue`.
+9. **Backup compatibility.** Logical backup and restore include `RedriveAllowPolicy` alongside `RedrivePolicy`.
+
+### 2.2 Non-Goals
+
+1. **StartMessageMoveTask / DLQ redrive back to source.** Moving messages out of a DLQ is a separate feature with partial-progress and throttling concerns. This design only covers source-to-DLQ redrive.
+2. **Cross-account or cross-region DLQs.** elastickv has a single configured SQS account/region namespace. A `deadLetterTargetArn` must resolve to a queue in that same namespace.
+3. **IAM-style resource policies.** `RedriveAllowPolicy` is the only DLQ access policy implemented here.
+4. **Selective per-message DLQ actions in the Web UI.** Operators can peek and purge via the existing admin messages view, but this design does not add per-message delete or redrive actions.
+5. **Policy clearing in the initial rollout.** AWS clients can remove a DLQ configuration by clearing attributes, but this initial rollout rejects empty `RedrivePolicy` / `RedriveAllowPolicy` values and the Web UI has no remove button. Operators can update a policy in place or delete/recreate the queue when they need a full reset. A clear/reset path is tracked as a follow-up in §10.
+
+---
+
+## 3. SQS Compatibility Contract
+
+### 3.1 `RedrivePolicy`
+
+`RedrivePolicy` is stored on the source queue meta record as the exact JSON string supplied by the client after validation.
+
+The parser accepts:
+
+- `deadLetterTargetArn` as a required string.
+- `maxReceiveCount` as either a JSON number or a numeric JSON string, matching SDK behaviour.
+
+Validation rules:
+
+1. Empty or non-JSON values are rejected with `InvalidAttributeValue`.
+2. `deadLetterTargetArn` is required and must have a final colon-delimited queue-name segment.
+3. `maxReceiveCount` defaults to `10` when omitted.
+4. `maxReceiveCount` must be an integer from `1` to `1000`, inclusive.
+5. The target ARN must equal this server's ARN form for the named DLQ (`s.queueArn(dlqName)`), which enforces same account and region.
+6. The source queue must not target itself.
+7. The target DLQ must already exist when the policy is set.
+8. Source and DLQ queue types must match:
+   - Standard -> Standard
+   - FIFO -> FIFO
+
+The receive path uses the same parsed policy shape, so client-configured JSON and admin UI JSON have identical semantics.
+
+### 3.2 `RedriveAllowPolicy`
+
+`RedriveAllowPolicy` is stored on the DLQ queue meta record as the exact JSON string supplied by the client after validation.
+
+The parser accepts:
+
+```go
+type rawRedriveAllowPolicy struct {
+    RedrivePermission string   `json:"redrivePermission"`
+    SourceQueueArns   []string `json:"sourceQueueArns"`
+}
+```
+
+Validation rules:
+
+1. Empty or non-JSON values are rejected with `InvalidAttributeValue`.
+2. Missing or empty `redrivePermission` defaults to `allowAll`; an explicit `{}` is therefore equivalent to allowing all source queues.
+3. `redrivePermission` must be one of:
+   - `allowAll`
+   - `denyAll`
+   - `byQueue`
+4. `allowAll` and `denyAll` must not include `sourceQueueArns`.
+5. `byQueue` requires `sourceQueueArns`.
+6. `byQueue.sourceQueueArns` can contain at most 10 ARNs.
+7. Each source ARN must be syntactically parseable as an SQS ARN with a final queue-name segment.
+
+The parser only validates the JSON shape and the ARN shape. Authorization is stricter: when a source queue is configured or redriven, the implementation generates the canonical source ARN with `s.queueArn(sourceQueueName)` and requires an exact string match against one of the configured `sourceQueueArns`. A cross-account, cross-region, or otherwise non-canonical ARN with the same final queue name does not authorize the source.
+
+### 3.3 Receive Count Semantics
+
+AWS describes `maxReceiveCount` as the number of times a message can be received before being moved to the DLQ. The implementation enforces that by checking the candidate's *next* receive:
+
+```go
+return rec.ReceiveCount + 1 > policy.MaxReceiveCount
+```
+
+Consequences:
+
+- If `maxReceiveCount = 1`, the first receive can deliver the source message. The next receive attempt moves it to the DLQ.
+- If `maxReceiveCount = 2`, the first two receives can deliver the source message. The third receive attempt moves it to the DLQ.
+- A message moved to the DLQ is not returned to the source queue consumer on the receive call that triggered the move.
+
+This preserves the intuitive "deliver up to N times, then stop delivering from the source" contract.
+
+### 3.4 Policy Clearing Deviation
+
+The first implementation rejects empty `RedrivePolicy` and `RedriveAllowPolicy` values. This is intentionally documented as a compatibility gap rather than hidden behind the "SQS-compatible" wording above:
+
+- `RedrivePolicy=""` is rejected instead of removing the source queue's DLQ target.
+- `RedriveAllowPolicy=""` is rejected instead of removing the explicit DLQ-side policy and returning to the implicit `allowAll` default.
+
+The reason is API safety, not data-model limitation: clearing a DLQ target is an operator-visible behaviour change that can resume poison-message retries on the source queue. The initial Web UI only exposes positive configuration writes. A follow-up should add explicit clear/reset buttons and route those through the same audit and confirmation pattern as queue purge/delete.
+
+---
+
+## 4. Data Model
+
+`sqsQueueMeta` stores both policies:
+
+```go
+type sqsQueueMeta struct {
+    // ...
+    RedrivePolicy      string `json:"redrive_policy,omitempty"`
+    RedriveAllowPolicy string `json:"redrive_allow_policy,omitempty"`
+}
+```
+
+The admin projection includes both values in the attribute map returned by `AdminDescribeQueue`:
+
+```go
+Attributes["RedrivePolicy"] = meta.RedrivePolicy
+Attributes["RedriveAllowPolicy"] = meta.RedriveAllowPolicy
+```
+
+Logical backup includes both values so snapshot export/import preserves DLQ wiring:
+
+```go
+RedrivePolicy      string `json:"redrive_policy,omitempty"`
+RedriveAllowPolicy string `json:"redrive_allow_policy,omitempty"`
+```
+
+No new message-key family is introduced by this design. A redrive move reuses the existing source message data key, source visibility index key, DLQ message data key, and DLQ visibility index key inside one OCC transaction.
+
+---
+
+## 5. Request Flows
+
+### 5.1 CreateQueue / SetQueueAttributes
+
+Queue attribute application remains all-or-nothing:
+
+1. Load or construct the requested queue meta.
+2. Apply each requested attribute into the in-memory meta.
+3. Parse `RedrivePolicy` when present.
+4. Parse `RedriveAllowPolicy` when present.
+5. If `RedrivePolicy` is present, validate the target DLQ:
+   - same account/region ARN,
+   - not self,
+   - target exists,
+   - target type matches,
+   - target DLQ's `RedriveAllowPolicy` allows this source.
+6. Commit the meta via the existing OCC write.
+
+If any step fails, no attributes from that request are persisted.
+
+### 5.2 ReceiveMessage Redrive
+
+`ReceiveMessage` parses the source queue's `RedrivePolicy` once per call. During candidate selection:
+
+1. Load the candidate message record.
+2. If no redrive policy exists, proceed with normal receive handling.
+3. If `rec.ReceiveCount + 1 <= maxReceiveCount`, proceed with normal receive handling.
+4. If `rec.ReceiveCount + 1 > maxReceiveCount`, move the candidate to the DLQ instead of delivering it:
+   - Re-load and validate the DLQ target at the same read timestamp.
+   - Re-check the DLQ-side `RedriveAllowPolicy`.
+   - Delete the source message data record.
+   - Delete the source visibility index entry.
+   - Write the DLQ message data record.
+   - Write the DLQ visibility index entry.
+   - Add `DeadLetterQueueSourceArn` so DLQ consumers can identify the source queue.
+
+The move is an OCC transaction. A write conflict means another receiver changed the same record first; the current receive call skips that candidate and continues.
+
+### 5.3 Standard vs FIFO DLQ Record Semantics
+
+The DLQ record preserves operational traceability while following AWS's age semantics:
+
+- The DLQ message keeps the original `MessageID`.
+- `ReceiveCount` resets on the DLQ record.
+- `DeadLetterQueueSourceArn` is set to the source queue ARN.
+- Standard DLQs preserve the original sent timestamp so retention age remains tied to the original enqueue time.
+- FIFO DLQs reset the sent timestamp at the time of the DLQ move so retention age starts at DLQ insertion time.
+- FIFO DLQ writes use the original `MessageID` as the DLQ `MessageDeduplicationId`, satisfying FIFO deduplication requirements without generating a user-visible new identifier.
+- FIFO DLQ writes participate in the DLQ's FIFO sequence-number allocation so the DLQ preserves its own ordered message stream.
+
+Visibility timestamps and retention timestamps remain distinct. A message can be visible immediately in the DLQ while its retention age is computed from the correct Standard/FIFO sent timestamp rule above.
+
+---
+
+## 6. Admin API
+
+The Web UI uses a new admin endpoint:
+
+```text
+PUT /admin/api/v1/sqs/queues/{name}/attributes
+```
+
+Request body:
+
+```json
+{
+  "attributes": {
+    "RedrivePolicy": "{\"deadLetterTargetArn\":\"arn:aws:sqs:us-east-1:000000000000:orders-dlq\",\"maxReceiveCount\":5}"
+  }
+}
+```
+
+or:
+
+```json
+{
+  "attributes": {
+    "RedriveAllowPolicy": "{\"redrivePermission\":\"byQueue\",\"sourceQueueArns\":[\"arn:aws:sqs:us-east-1:000000000000:orders\"]}"
+  }
+}
+```
+
+Response:
+
+- `204 No Content` on success.
+- `400 invalid_request` for malformed JSON, empty attributes, or SQS attribute validation failure.
+- `403 forbidden` for read-only principals.
+- `404 queue_not_found` when the target queue does not exist.
+- `503 leader_unavailable` when the local node is not the verified SQS leader.
+
+The handler uses the existing admin write path:
+
+1. Session auth + CSRF middleware.
+2. `principalForWrite`.
+3. `QueuesSource.AdminSetQueueAttributes`.
+4. Bridge to `adapter.SQSServer.AdminSetQueueAttributes`.
+5. Adapter calls `setQueueAttributesWithRetry`.
+
+This intentionally avoids a parallel DLQ-specific mutation path. Admin UI writes and public SQS `SetQueueAttributes` writes share the same parser, validator, OCC retry loop, and error vocabulary.
+
+---
+
+## 7. Web UI
+
+The SQS detail page adds a `DLQ settings` section below counters and above the raw configuration table.
+
+Both forms update the **current queue** shown in the URL:
+
+- On a source queue page, the redrive form updates that source queue's `RedrivePolicy`.
+- On a DLQ queue page, the allow-policy form updates that DLQ queue's `RedriveAllowPolicy`.
+- Selecting a DLQ in the source form does not automatically modify the selected DLQ. If the selected DLQ currently has `denyAll` or excludes the source, the source-form save is rejected by the server; the operator must open the DLQ's detail page and update its allow policy there.
+
+### 7.1 Source-Side Redrive Policy Form
+
+Inputs:
+
+- `Dead-letter queue`: a select box populated from `ListQueues`.
+- `maxReceiveCount`: a number input constrained to `[1, 1000]`.
+
+Candidate filtering:
+
+- The current queue is excluded.
+- FIFO queues list only FIFO DLQ candidates.
+- Standard queues list only Standard DLQ candidates.
+- If the currently configured DLQ is no longer in the candidate list, it remains visible as the selected option so operators can see and correct stale configuration.
+
+Save behaviour:
+
+1. Read the current queue's `QueueArn`.
+2. Derive the ARN prefix up to the final colon.
+3. Convert the selected DLQ queue name into an ARN using that prefix.
+4. Send:
+
+   ```json
+   {
+     "attributes": {
+       "RedrivePolicy": "{\"deadLetterTargetArn\":\"<derived-arn>\",\"maxReceiveCount\":<n>}"
+     }
+   }
+   ```
+
+5. Refresh the queue detail on success.
+
+The UI performs client-side range validation for fast feedback, but the adapter remains authoritative.
+
+### 7.2 DLQ-Side Allow Policy Form
+
+Inputs:
+
+- `Redrive permission`: `allowAll`, `denyAll`, or `byQueue`.
+- `Source queue names`: shown only for `byQueue`, newline- or comma-separated.
+
+Save behaviour:
+
+1. For `allowAll` or `denyAll`, send only `redrivePermission`.
+2. For `byQueue`, deduplicate source queue names, require at least one, require at most 10, derive source ARNs from the same account/region prefix, and send:
+
+   ```json
+   {
+     "attributes": {
+       "RedriveAllowPolicy": "{\"redrivePermission\":\"byQueue\",\"sourceQueueArns\":[\"<source-arn>\"]}"
+     }
+   }
+   ```
+
+3. Refresh the queue detail on success.
+
+The UI does not try to predict every server-side failure. For example, an operator may type a source queue name that does not exist yet; the adapter-side `RedriveAllowPolicy` parser accepts syntactically valid source ARNs, and the source queue's later `RedrivePolicy` validation enforces whether it is actually allowed. The effective allow check is still an exact canonical source-ARN comparison, so a hand-written ARN for a different account or region cannot authorize a local source queue with the same name.
+
+---
+
+## 8. Failure Modes and Safety
+
+### 8.1 DLQ Deleted After Policy Set
+
+If a DLQ is deleted after a source queue policy is configured, receive-time redrive validation fails. The candidate is not moved. The source message remains in the source queue and can be retried after the operator fixes the policy or recreates the DLQ.
+
+### 8.2 DLQ Allow Policy Tightened After Policy Set
+
+If a DLQ changes from `allowAll` to `denyAll` or to a `byQueue` list that excludes the source, receive-time validation fails. This is intentional: the DLQ owner can revoke sources after they were configured.
+
+### 8.3 Source/DLQ Type Changed by Delete/Recreate
+
+Queue type is immutable for a single queue incarnation, but a queue name can be deleted and recreated. Receive-time validation re-checks the target queue type, so a source policy cannot move Standard messages into a newly recreated FIFO DLQ or vice versa.
+
+### 8.4 Concurrent Receivers
+
+Two receivers may observe the same candidate near the redrive threshold. The OCC transaction deletes the exact source record and visibility entry that were read. Only one move can commit; the other receives a conflict and skips the candidate.
+
+### 8.5 Admin UI Stale Queue List
+
+The UI's DLQ candidate list is advisory. Saving goes through the server validator, so a stale list cannot persist an invalid policy.
+
+---
+
+## 9. Testing Plan
+
+Backend tests cover:
+
+1. `RedrivePolicy` default `maxReceiveCount = 10`.
+2. `RedrivePolicy.maxReceiveCount` range `[1, 1000]`.
+3. Rejection of self-referential DLQ policies.
+4. Rejection of cross-region/account DLQ ARNs.
+5. Rejection of Standard -> FIFO and FIFO -> Standard DLQ pairs.
+6. `RedriveAllowPolicy` `denyAll`.
+7. `RedriveAllowPolicy` `byQueue` allowing only listed sources.
+8. Runtime enforcement when `RedriveAllowPolicy` is changed after source policy configuration.
+9. `RedriveAllowPolicy` rejects `byQueue` with missing or empty `sourceQueueArns`.
+10. `RedriveAllowPolicy` rejects more than 10 source ARNs.
+11. `RedriveAllowPolicy` rejects `allowAll` / `denyAll` when `sourceQueueArns` is present.
+12. `RedriveAllowPolicy` with a non-canonical source ARN does not authorize a local source queue with the same final name.
+13. Message move after receive count exceeds the configured threshold.
+14. `DeadLetterQueueSourceArn` on DLQ messages.
+15. Standard vs FIFO DLQ timestamp/deduplication behaviour.
+16. Backup encode/decode preservation of `RedriveAllowPolicy`.
+
+Admin tests cover:
+
+1. `PUT /admin/api/v1/sqs/queues/{name}/attributes` happy path.
+2. Read-only principal rejection.
+3. Error mapping for missing queue and SQS validation errors.
+
+Frontend checks cover:
+
+1. TypeScript compile of the SQS detail page and API client.
+2. Vite production build.
+3. Browser smoke test that the admin SPA loads without console errors.
+
+---
+
+## 10. Open Follow-Ups
+
+1. Add an explicit Web UI action to clear `RedrivePolicy`.
+2. Add an explicit Web UI action to clear or reset `RedriveAllowPolicy` to the implicit default.
+3. Add a DLQ redrive-back-to-source design for `StartMessageMoveTask` semantics.
+4. Add richer admin audit fields for attribute updates, such as changed attribute names and target DLQ ARN, once the admin audit schema supports per-route payload metadata.
+5. Consider surfacing parsed DLQ policy values in `AdminQueueSummary` as typed fields so the SPA does not have to parse AWS JSON strings client-side.

--- a/internal/admin/sqs_handler.go
+++ b/internal/admin/sqs_handler.go
@@ -68,6 +68,11 @@ type QueuesSource interface {
 	AdminListQueues(ctx context.Context) ([]string, error)
 	AdminDescribeQueue(ctx context.Context, name string) (*QueueSummary, bool, error)
 	AdminDeleteQueue(ctx context.Context, principal AuthPrincipal, name string) error
+	// AdminSetQueueAttributes updates SQS queue attributes through the
+	// same validator as the public SQS SetQueueAttributes path. The
+	// SPA uses this for DLQ configuration (RedrivePolicy and
+	// RedriveAllowPolicy).
+	AdminSetQueueAttributes(ctx context.Context, principal AuthPrincipal, name string, attrs map[string]string) error
 	// AdminPeekQueue returns a non-destructive sample of currently-
 	// visible messages on the queue (read role required). Wired only
 	// when the source supports it; the bridge in main_admin.go
@@ -228,6 +233,7 @@ func (h *SqsHandler) WithRoleStore(r RoleStore) *SqsHandler {
 //	GET    /admin/api/v1/sqs/queues                       — list
 //	GET    /admin/api/v1/sqs/queues/{name}                — describe
 //	DELETE /admin/api/v1/sqs/queues/{name}                — delete
+//	PUT    /admin/api/v1/sqs/queues/{name}/attributes     — set attributes
 //	GET    /admin/api/v1/sqs/queues/{name}/messages       — peek
 //	DELETE /admin/api/v1/sqs/queues/{name}/messages       — purge
 //
@@ -240,6 +246,7 @@ func (h *SqsHandler) WithRoleStore(r RoleStore) *SqsHandler {
 // /queues/{name}/{sub}. Anything else is a 404. Lifted to a constant
 // so the dispatcher and any future routing layer stay aligned.
 const sqsSubResourceMessages = "messages"
+const sqsSubResourceAttributes = "attributes"
 
 // sqsRouteSegmentsQueue / sqsRouteSegmentsMessages are the segment
 // counts the dispatcher recognises after the prefix trim. Named to
@@ -331,12 +338,20 @@ func (h *SqsHandler) dispatchSqsRoute(w http.ResponseWriter, r *http.Request, se
 		h.dispatchQueueResource(w, r, name)
 	case sqsRouteSegmentsMessages:
 		sub, err := decodeSqsPathSegment(segments[1])
-		if err != nil || sub != sqsSubResourceMessages {
+		if err != nil {
 			writeJSONError(w, http.StatusNotFound, "unknown_endpoint",
 				"unknown sub-resource on this queue")
 			return
 		}
-		h.dispatchMessagesResource(w, r, name)
+		switch sub {
+		case sqsSubResourceMessages:
+			h.dispatchMessagesResource(w, r, name)
+		case sqsSubResourceAttributes:
+			h.dispatchAttributesResource(w, r, name)
+		default:
+			writeJSONError(w, http.StatusNotFound, "unknown_endpoint",
+				"unknown sub-resource on this queue")
+		}
 	default:
 		writeJSONError(w, http.StatusNotFound, "unknown_endpoint",
 			"too many path segments")
@@ -366,6 +381,17 @@ func (h *SqsHandler) dispatchMessagesResource(w http.ResponseWriter, r *http.Req
 		h.handlePurge(w, r, name)
 	default:
 		writeJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed", "only GET or DELETE")
+	}
+}
+
+// dispatchAttributesResource handles .../queues/{name}/attributes:
+// PUT = SetQueueAttributes through the admin-auth path.
+func (h *SqsHandler) dispatchAttributesResource(w http.ResponseWriter, r *http.Request, name string) {
+	switch r.Method {
+	case http.MethodPut:
+		h.handleSetAttributes(w, r, name)
+	default:
+		writeJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed", "only PUT")
 	}
 }
 
@@ -464,6 +490,36 @@ func (h *SqsHandler) handleDelete(w http.ResponseWriter, r *http.Request, name s
 		return
 	}
 	if err := h.source.AdminDeleteQueue(r.Context(), principal, name); err != nil {
+		writeQueuesError(w, err, h.logger, r)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusNoContent)
+}
+
+type setQueueAttributesRequest struct {
+	Attributes map[string]string `json:"attributes"`
+}
+
+func (h *SqsHandler) handleSetAttributes(w http.ResponseWriter, r *http.Request, name string) {
+	principal, ok := h.principalForWrite(w, r, "set queue attributes")
+	if !ok {
+		return
+	}
+	if strings.TrimSpace(name) == "" {
+		writeJSONError(w, http.StatusBadRequest, "invalid_queue_name", "queue name is required")
+		return
+	}
+	var req setQueueAttributesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", "request body must be JSON")
+		return
+	}
+	if len(req.Attributes) == 0 {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", "attributes is required")
+		return
+	}
+	if err := h.source.AdminSetQueueAttributes(r.Context(), principal, name, req.Attributes); err != nil {
 		writeQueuesError(w, err, h.logger, r)
 		return
 	}

--- a/internal/admin/sqs_handler_test.go
+++ b/internal/admin/sqs_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,20 +18,24 @@ import (
 // principal that flowed through to the source so tests can assert
 // live-role forwarding.
 type stubQueuesSource struct {
-	queues              []string
-	describeErr         error
-	deleteErr           error
-	peekErr             error
-	peekResult          PeekResult
-	purgeErr            error
-	purgeResult         PurgeResult
-	lastDeleteName      string
-	lastDeletePrincipal AuthPrincipal
-	lastPeekName        string
-	lastPeekPrincipal   AuthPrincipal
-	lastPeekOpts        PeekMessageOptions
-	lastPurgeName       string
-	lastPurgePrincipal  AuthPrincipal
+	queues                []string
+	describeErr           error
+	deleteErr             error
+	setAttrsErr           error
+	peekErr               error
+	peekResult            PeekResult
+	purgeErr              error
+	purgeResult           PurgeResult
+	lastDeleteName        string
+	lastDeletePrincipal   AuthPrincipal
+	lastSetAttrsName      string
+	lastSetAttrsPrincipal AuthPrincipal
+	lastSetAttrs          map[string]string
+	lastPeekName          string
+	lastPeekPrincipal     AuthPrincipal
+	lastPeekOpts          PeekMessageOptions
+	lastPurgeName         string
+	lastPurgePrincipal    AuthPrincipal
 }
 
 func (s *stubQueuesSource) AdminListQueues(_ context.Context) ([]string, error) {
@@ -62,6 +67,16 @@ func (s *stubQueuesSource) AdminDeleteQueue(_ context.Context, principal AuthPri
 		}
 	}
 	return ErrQueuesNotFound
+}
+
+func (s *stubQueuesSource) AdminSetQueueAttributes(_ context.Context, principal AuthPrincipal, name string, attrs map[string]string) error {
+	s.lastSetAttrsName = name
+	s.lastSetAttrsPrincipal = principal
+	s.lastSetAttrs = attrs
+	if s.setAttrsErr != nil {
+		return s.setAttrsErr
+	}
+	return nil
 }
 
 func (s *stubQueuesSource) AdminPeekQueue(_ context.Context, principal AuthPrincipal, name string, opts PeekMessageOptions) (PeekResult, error) {
@@ -184,6 +199,35 @@ func TestSqsHandler_DeleteQueue_NoRoleStore(t *testing.T) {
 		require.Equal(t, http.StatusForbidden, rec.Code)
 		require.Empty(t, src.lastDeleteName)
 	})
+}
+
+func TestSqsHandler_SetQueueAttributes_HappyPath(t *testing.T) {
+	src := &stubQueuesSource{queues: []string{"orders"}}
+	h := NewSqsHandler(src)
+	body := `{"attributes":{"RedrivePolicy":"{\"deadLetterTargetArn\":\"arn:aws:sqs:us-east-1:000000000000:orders-dlq\",\"maxReceiveCount\":5}"}}`
+	req := httptest.NewRequest(http.MethodPut, pathPrefixSqsQueues+"orders/attributes", strings.NewReader(body))
+	req = req.WithContext(context.WithValue(req.Context(), ctxKeyPrincipal,
+		AuthPrincipal{AccessKey: "AKIA_FULL", Role: RoleFull}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNoContent, rec.Code, "body=%s", rec.Body.String())
+	require.Equal(t, "orders", src.lastSetAttrsName)
+	require.Equal(t, RoleFull, src.lastSetAttrsPrincipal.Role)
+	require.Equal(t, `{"deadLetterTargetArn":"arn:aws:sqs:us-east-1:000000000000:orders-dlq","maxReceiveCount":5}`, src.lastSetAttrs["RedrivePolicy"])
+}
+
+func TestSqsHandler_SetQueueAttributes_ReadOnlyForbidden(t *testing.T) {
+	src := &stubQueuesSource{queues: []string{"orders"}}
+	h := NewSqsHandler(src)
+	req := httptest.NewRequest(http.MethodPut, pathPrefixSqsQueues+"orders/attributes", strings.NewReader(`{"attributes":{"RedriveAllowPolicy":"{}"}}`))
+	req = req.WithContext(context.WithValue(req.Context(), ctxKeyPrincipal,
+		AuthPrincipal{AccessKey: "AKIA_RO", Role: RoleReadOnly}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Empty(t, src.lastSetAttrsName, "read-only principal must not reach the set-attributes source")
 }
 
 // TestSqsHandler_ListQueues_EmptyArrayNotNull pins the nil→[]

--- a/internal/backup/encode_sqs.go
+++ b/internal/backup/encode_sqs.go
@@ -104,6 +104,7 @@ type sqsStoredQueueMeta struct {
 	ReceiveMessageWaitSeconds int64  `json:"receive_message_wait_seconds"`
 	MaximumMessageSize        int64  `json:"maximum_message_size"`
 	RedrivePolicy             string `json:"redrive_policy,omitempty"`
+	RedriveAllowPolicy        string `json:"redrive_allow_policy,omitempty"`
 	PartitionCount            uint32 `json:"partition_count,omitempty"`
 	FifoThroughputLimit       string `json:"fifo_throughput_limit,omitempty"`
 	DeduplicationScope        string `json:"deduplication_scope,omitempty"`
@@ -209,6 +210,7 @@ func (e *SQSRecordEncoder) addQueueMeta(b *snapshotBuilder, pub sqsQueueMetaPubl
 		ReceiveMessageWaitSeconds: pub.ReceiveMessageWaitSeconds,
 		MaximumMessageSize:        pub.MaximumMessageSize,
 		RedrivePolicy:             pub.RedrivePolicy,
+		RedriveAllowPolicy:        pub.RedriveAllowPolicy,
 		PartitionCount:            pub.PartitionCount,
 		FifoThroughputLimit:       pub.FifoThroughputLimit,
 		DeduplicationScope:        pub.DeduplicationScope,

--- a/internal/backup/sqs.go
+++ b/internal/backup/sqs.go
@@ -156,6 +156,7 @@ type sqsQueueMetaPublic struct {
 	ReceiveMessageWaitSeconds int64  `json:"receive_message_wait_seconds,omitempty"`
 	MaximumMessageSize        int64  `json:"maximum_message_size,omitempty"`
 	RedrivePolicy             string `json:"redrive_policy,omitempty"`
+	RedriveAllowPolicy        string `json:"redrive_allow_policy,omitempty"`
 	PartitionCount            uint32 `json:"partition_count,omitempty"`
 	FifoThroughputLimit       string `json:"fifo_throughput_limit,omitempty"`
 	DeduplicationScope        string `json:"deduplication_scope,omitempty"`
@@ -714,6 +715,7 @@ func decodeSQSQueueMetaValue(value []byte) (*sqsQueueMetaPublic, error) {
 		ReceiveMessageWaitSeconds int64  `json:"receive_message_wait_seconds"`
 		MaximumMessageSize        int64  `json:"maximum_message_size"`
 		RedrivePolicy             string `json:"redrive_policy"`
+		RedriveAllowPolicy        string `json:"redrive_allow_policy"`
 		// HT-FIFO immutable attributes — see adapter/sqs_catalog.go.
 		PartitionCount      uint32 `json:"partition_count"`
 		FifoThroughputLimit string `json:"fifo_throughput_limit"`
@@ -733,6 +735,7 @@ func decodeSQSQueueMetaValue(value []byte) (*sqsQueueMetaPublic, error) {
 		ReceiveMessageWaitSeconds: live.ReceiveMessageWaitSeconds,
 		MaximumMessageSize:        live.MaximumMessageSize,
 		RedrivePolicy:             live.RedrivePolicy,
+		RedriveAllowPolicy:        live.RedriveAllowPolicy,
 		PartitionCount:            live.PartitionCount,
 		FifoThroughputLimit:       live.FifoThroughputLimit,
 		DeduplicationScope:        live.DeduplicationScope,

--- a/main_admin.go
+++ b/main_admin.go
@@ -236,6 +236,13 @@ func (b *sqsQueuesBridge) AdminDeleteQueue(ctx context.Context, principal admin.
 	return nil
 }
 
+func (b *sqsQueuesBridge) AdminSetQueueAttributes(ctx context.Context, principal admin.AuthPrincipal, name string, attrs map[string]string) error {
+	if err := b.server.AdminSetQueueAttributes(ctx, convertAdminPrincipal(principal), name, attrs); err != nil {
+		return translateAdminQueuesError(err)
+	}
+	return nil
+}
+
 func (b *sqsQueuesBridge) AdminPeekQueue(ctx context.Context, principal admin.AuthPrincipal, name string, opts admin.PeekMessageOptions) (admin.PeekResult, error) {
 	rows, nextCursor, err := b.server.AdminPeekQueue(ctx, convertAdminPrincipal(principal), name, adapter.AdminPeekMessageOptions{
 		Limit:        opts.Limit,

--- a/web/admin/src/api/client.ts
+++ b/web/admin/src/api/client.ts
@@ -299,6 +299,10 @@ export interface SqsQueueList {
   queues: string[];
 }
 
+export interface UpdateQueueAttributesRequest {
+  attributes: Record<string, string>;
+}
+
 // SqsPeekedAttribute mirrors AWS's typed MessageAttribute shape;
 // binary_value arrives base64-encoded.
 export interface SqsPeekedAttribute {
@@ -553,6 +557,11 @@ export const api = {
     apiFetch<SqsQueueSummary>(`/sqs/queues/${encodeURIComponent(name)}`, { signal }),
   deleteQueue: (name: string) =>
     apiFetch<void>(`/sqs/queues/${encodeURIComponent(name)}`, { method: "DELETE" }),
+  updateQueueAttributes: (name: string, req: UpdateQueueAttributesRequest) =>
+    apiFetch<void>(`/sqs/queues/${encodeURIComponent(name)}/attributes`, {
+      method: "PUT",
+      body: req as unknown as Json,
+    }),
   // Non-destructive peek of currently-visible messages. Server clamps
   // limit to [1, 100] and body_max_bytes to [256, 262144].
   peekQueue: (name: string, opts?: SqsPeekOptions, signal?: AbortSignal) =>

--- a/web/admin/src/pages/SqsDetail.tsx
+++ b/web/admin/src/pages/SqsDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import {
   api,
@@ -26,6 +26,7 @@ const kPeekBodyMaxBytes = 262144;
 export function SqsDetailPage() {
   const { name = "" } = useParams<{ name: string }>();
   const detail = useApiQuery((signal) => api.describeQueue(name, signal), [name]);
+  const queues = useApiQuery((signal) => api.listQueues(signal), []);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
@@ -126,6 +127,18 @@ export function SqsDetailPage() {
         </section>
       )}
 
+      {detail.data && (
+        <DLQSettingsSection
+          queue={name}
+          isFifo={detail.data.is_fifo}
+          attributes={detail.data.attributes ?? {}}
+          allQueues={queues.data?.queues ?? []}
+          queuesLoading={queues.loading}
+          queuesError={queues.error ? formatApiError(queues.error) : null}
+          onSaved={() => detail.reload()}
+        />
+      )}
+
       {detail.data?.attributes && Object.keys(detail.data.attributes).length > 0 && (
         <section className="card">
           <h2 className="text-sm font-semibold mb-3">Configuration</h2>
@@ -133,7 +146,7 @@ export function SqsDetailPage() {
             {Object.entries(detail.data.attributes).map(([k, v]) => (
               <div key={k} className="contents">
                 <dt className="text-muted font-mono text-xs">{k}</dt>
-                <dd className="font-mono">{v}</dd>
+                <dd className="font-mono break-all">{v}</dd>
               </div>
             ))}
           </dl>
@@ -182,6 +195,318 @@ export function SqsDetailPage() {
       </Modal>
     </div>
   );
+}
+
+type RedrivePermission = "allowAll" | "denyAll" | "byQueue";
+
+interface ParsedRedrivePolicy {
+  targetName: string;
+  maxReceiveCount: number;
+}
+
+interface ParsedRedriveAllowPolicy {
+  permission: RedrivePermission;
+  sourceNames: string[];
+}
+
+interface DLQSettingsSectionProps {
+  queue: string;
+  isFifo: boolean;
+  attributes: Record<string, string>;
+  allQueues: string[];
+  queuesLoading: boolean;
+  queuesError: string | null;
+  onSaved: () => void;
+}
+
+function DLQSettingsSection({
+  queue,
+  isFifo,
+  attributes,
+  allQueues,
+  queuesLoading,
+  queuesError,
+  onSaved,
+}: DLQSettingsSectionProps) {
+  const arnPrefix = queueArnPrefix(attributes.QueueArn);
+  const parsedRedrive = useMemo(
+    () => parseRedrivePolicyAttribute(attributes.RedrivePolicy),
+    [attributes.RedrivePolicy],
+  );
+  const parsedAllow = useMemo(
+    () => parseRedriveAllowPolicyAttribute(attributes.RedriveAllowPolicy),
+    [attributes.RedriveAllowPolicy],
+  );
+  const candidateQueues = useMemo(
+    () => allQueues.filter((q) => q !== queue && isFifoQueueName(q) === isFifo),
+    [allQueues, isFifo, queue],
+  );
+  const parsedAllowSourceText = parsedAllow.sourceNames.join("\n");
+
+  const [targetName, setTargetName] = useState(parsedRedrive.targetName);
+  const [maxReceiveCount, setMaxReceiveCount] = useState(String(parsedRedrive.maxReceiveCount));
+  const [redriveSaving, setRedriveSaving] = useState(false);
+  const [redriveError, setRedriveError] = useState<string | null>(null);
+  const [redriveSaved, setRedriveSaved] = useState<string | null>(null);
+
+  const [permission, setPermission] = useState<RedrivePermission>(parsedAllow.permission);
+  const [sourceNamesText, setSourceNamesText] = useState(parsedAllow.sourceNames.join("\n"));
+  const [allowSaving, setAllowSaving] = useState(false);
+  const [allowError, setAllowError] = useState<string | null>(null);
+  const [allowSaved, setAllowSaved] = useState<string | null>(null);
+  const redriveChoices = useMemo(() => {
+    if (!targetName || candidateQueues.includes(targetName)) return candidateQueues;
+    return [targetName, ...candidateQueues];
+  }, [candidateQueues, targetName]);
+
+  useEffect(() => {
+    setTargetName(parsedRedrive.targetName);
+    setMaxReceiveCount(String(parsedRedrive.maxReceiveCount));
+    setRedriveError(null);
+    setRedriveSaved(null);
+  }, [queue, parsedRedrive.maxReceiveCount, parsedRedrive.targetName]);
+
+  useEffect(() => {
+    setPermission(parsedAllow.permission);
+    setSourceNamesText(parsedAllowSourceText);
+    setAllowError(null);
+    setAllowSaved(null);
+  }, [queue, parsedAllow.permission, parsedAllowSourceText]);
+
+  const onSaveRedrive = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setRedriveError(null);
+    setRedriveSaved(null);
+    const dlq = targetName.trim();
+    const maxReceive = Number(maxReceiveCount);
+    if (!arnPrefix) {
+      setRedriveError("QueueArn is not available for this queue.");
+      return;
+    }
+    if (!dlq) {
+      setRedriveError("Select a dead-letter queue.");
+      return;
+    }
+    if (!Number.isInteger(maxReceive) || maxReceive < 1 || maxReceive > 1000) {
+      setRedriveError("maxReceiveCount must be an integer from 1 to 1000.");
+      return;
+    }
+    setRedriveSaving(true);
+    try {
+      await api.updateQueueAttributes(queue, {
+        attributes: {
+          RedrivePolicy: JSON.stringify({
+            deadLetterTargetArn: queueArnForName(arnPrefix, dlq),
+            maxReceiveCount: maxReceive,
+          }),
+        },
+      });
+      setRedriveSaved("Saved");
+      onSaved();
+    } catch (err) {
+      setRedriveError(formatApiError(err));
+    } finally {
+      setRedriveSaving(false);
+    }
+  };
+
+  const onSaveAllowPolicy = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setAllowError(null);
+    setAllowSaved(null);
+    if (!arnPrefix) {
+      setAllowError("QueueArn is not available for this queue.");
+      return;
+    }
+    const policy: { redrivePermission: RedrivePermission; sourceQueueArns?: string[] } = {
+      redrivePermission: permission,
+    };
+    if (permission === "byQueue") {
+      const names = parseQueueNamesInput(sourceNamesText);
+      if (names.length === 0) {
+        setAllowError("Enter at least one source queue name.");
+        return;
+      }
+      if (names.length > 10) {
+        setAllowError("sourceQueueArns can contain at most 10 queues.");
+        return;
+      }
+      policy.sourceQueueArns = names.map((name) => queueArnForName(arnPrefix, name));
+    }
+    setAllowSaving(true);
+    try {
+      await api.updateQueueAttributes(queue, {
+        attributes: { RedriveAllowPolicy: JSON.stringify(policy) },
+      });
+      setAllowSaved("Saved");
+      onSaved();
+    } catch (err) {
+      setAllowError(formatApiError(err));
+    } finally {
+      setAllowSaving(false);
+    }
+  };
+
+  return (
+    <section className="card">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-sm font-semibold">DLQ settings</h2>
+        {queuesLoading && <span className="text-xs text-muted">Loading queues…</span>}
+      </div>
+      {queuesError && <div className="text-sm text-danger mb-3">{queuesError}</div>}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <form className="space-y-3" onSubmit={(event) => void onSaveRedrive(event)}>
+          <div>
+            <label className="label" htmlFor="redrive-dlq">Dead-letter queue</label>
+            <select
+              id="redrive-dlq"
+              className="input font-mono"
+              value={targetName}
+              onChange={(e) => setTargetName(e.target.value)}
+              disabled={redriveSaving}
+            >
+              <option value="">None selected</option>
+              {redriveChoices.map((q) => (
+                <option key={q} value={q}>{q}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="label" htmlFor="redrive-max-receive">maxReceiveCount</label>
+            <input
+              id="redrive-max-receive"
+              type="number"
+              min={1}
+              max={1000}
+              step={1}
+              className="input font-mono"
+              value={maxReceiveCount}
+              onChange={(e) => setMaxReceiveCount(e.target.value)}
+              disabled={redriveSaving}
+            />
+          </div>
+          {redriveError && <div className="text-sm text-danger">{redriveError}</div>}
+          {redriveSaved && <div className="text-xs text-muted">{redriveSaved}</div>}
+          <button type="submit" className="btn-primary" disabled={redriveSaving}>
+            {redriveSaving ? "Saving…" : "Save redrive policy"}
+          </button>
+        </form>
+
+        <form className="space-y-3" onSubmit={(event) => void onSaveAllowPolicy(event)}>
+          <div>
+            <label className="label" htmlFor="redrive-allow-permission">Redrive permission</label>
+            <select
+              id="redrive-allow-permission"
+              className="input"
+              value={permission}
+              onChange={(e) => setPermission(e.target.value as RedrivePermission)}
+              disabled={allowSaving}
+            >
+              <option value="allowAll">allowAll</option>
+              <option value="denyAll">denyAll</option>
+              <option value="byQueue">byQueue</option>
+            </select>
+          </div>
+          {permission === "byQueue" && (
+            <div>
+              <label className="label" htmlFor="redrive-source-queues">Source queue names</label>
+              <textarea
+                id="redrive-source-queues"
+                className="input font-mono min-h-24"
+                value={sourceNamesText}
+                onChange={(e) => setSourceNamesText(e.target.value)}
+                disabled={allowSaving}
+                placeholder={candidateQueues.join("\n")}
+              />
+            </div>
+          )}
+          {allowError && <div className="text-sm text-danger">{allowError}</div>}
+          {allowSaved && <div className="text-xs text-muted">{allowSaved}</div>}
+          <button type="submit" className="btn-primary" disabled={allowSaving}>
+            {allowSaving ? "Saving…" : "Save access policy"}
+          </button>
+        </form>
+      </div>
+    </section>
+  );
+}
+
+function parseRedrivePolicyAttribute(raw?: string): ParsedRedrivePolicy {
+  const fallback = { targetName: "", maxReceiveCount: 10 };
+  if (!raw) return fallback;
+  try {
+    const obj = JSON.parse(raw) as Record<string, unknown>;
+    const targetArn = typeof obj.deadLetterTargetArn === "string" ? obj.deadLetterTargetArn : "";
+    const rawMax = obj.maxReceiveCount;
+    let maxReceiveCount = fallback.maxReceiveCount;
+    if (typeof rawMax === "number" && Number.isFinite(rawMax)) {
+      maxReceiveCount = Math.trunc(rawMax);
+    } else if (typeof rawMax === "string" && rawMax.trim() !== "") {
+      const parsed = Number(rawMax);
+      if (Number.isFinite(parsed)) maxReceiveCount = Math.trunc(parsed);
+    }
+    return {
+      targetName: queueNameFromArn(targetArn),
+      maxReceiveCount,
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+function parseRedriveAllowPolicyAttribute(raw?: string): ParsedRedriveAllowPolicy {
+  if (!raw) return { permission: "allowAll", sourceNames: [] };
+  try {
+    const obj = JSON.parse(raw) as Record<string, unknown>;
+    const permission = parseRedrivePermission(obj.redrivePermission);
+    const sourceNames = Array.isArray(obj.sourceQueueArns)
+      ? obj.sourceQueueArns
+        .filter((arn): arn is string => typeof arn === "string")
+        .map(queueNameFromArn)
+        .filter((name) => name !== "")
+      : [];
+    return { permission, sourceNames };
+  } catch {
+    return { permission: "allowAll", sourceNames: [] };
+  }
+}
+
+function parseRedrivePermission(value: unknown): RedrivePermission {
+  if (value === "denyAll" || value === "byQueue") return value;
+  return "allowAll";
+}
+
+function queueNameFromArn(arn: string): string {
+  const idx = arn.lastIndexOf(":");
+  if (idx < 0 || idx === arn.length - 1) return "";
+  return arn.slice(idx + 1);
+}
+
+function queueArnPrefix(arn?: string): string {
+  if (!arn) return "";
+  const idx = arn.lastIndexOf(":");
+  if (idx < 0) return "";
+  return arn.slice(0, idx + 1);
+}
+
+function queueArnForName(prefix: string, name: string): string {
+  return prefix + name;
+}
+
+function isFifoQueueName(name: string): boolean {
+  return name.endsWith(".fifo");
+}
+
+function parseQueueNamesInput(value: string): string[] {
+  const seen = new Set<string>();
+  const names: string[] = [];
+  for (const part of value.split(/[,\n]/u)) {
+    const name = part.trim();
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    names.push(name);
+  }
+  return names;
 }
 
 interface MessagesSectionProps {

--- a/web/admin/src/pages/SqsDetail.tsx
+++ b/web/admin/src/pages/SqsDetail.tsx
@@ -206,7 +206,7 @@ interface ParsedRedrivePolicy {
 
 interface ParsedRedriveAllowPolicy {
   permission: RedrivePermission;
-  sourceNames: string[];
+  sourceQueueArns: string[];
 }
 
 interface DLQSettingsSectionProps {
@@ -241,7 +241,7 @@ function DLQSettingsSection({
     () => allQueues.filter((q) => q !== queue && isFifoQueueName(q) === isFifo),
     [allQueues, isFifo, queue],
   );
-  const parsedAllowSourceText = parsedAllow.sourceNames.join("\n");
+  const parsedAllowSourceText = parsedAllow.sourceQueueArns.join("\n");
 
   const [targetName, setTargetName] = useState(parsedRedrive.targetName);
   const [maxReceiveCount, setMaxReceiveCount] = useState(String(parsedRedrive.maxReceiveCount));
@@ -250,7 +250,7 @@ function DLQSettingsSection({
   const [redriveSaved, setRedriveSaved] = useState<string | null>(null);
 
   const [permission, setPermission] = useState<RedrivePermission>(parsedAllow.permission);
-  const [sourceNamesText, setSourceNamesText] = useState(parsedAllow.sourceNames.join("\n"));
+  const [sourceQueueArnsText, setSourceQueueArnsText] = useState(parsedAllowSourceText);
   const [allowSaving, setAllowSaving] = useState(false);
   const [allowError, setAllowError] = useState<string | null>(null);
   const [allowSaved, setAllowSaved] = useState<string | null>(null);
@@ -268,7 +268,7 @@ function DLQSettingsSection({
 
   useEffect(() => {
     setPermission(parsedAllow.permission);
-    setSourceNamesText(parsedAllowSourceText);
+    setSourceQueueArnsText(parsedAllowSourceText);
     setAllowError(null);
     setAllowSaved(null);
   }, [queue, parsedAllow.permission, parsedAllowSourceText]);
@@ -314,24 +314,24 @@ function DLQSettingsSection({
     event.preventDefault();
     setAllowError(null);
     setAllowSaved(null);
-    if (!arnPrefix) {
-      setAllowError("QueueArn is not available for this queue.");
-      return;
-    }
     const policy: { redrivePermission: RedrivePermission; sourceQueueArns?: string[] } = {
       redrivePermission: permission,
     };
     if (permission === "byQueue") {
-      const names = parseQueueNamesInput(sourceNamesText);
-      if (names.length === 0) {
-        setAllowError("Enter at least one source queue name.");
+      const parsedSources = parseSourceQueueArnInput(sourceQueueArnsText, arnPrefix);
+      if (parsedSources.needsArnPrefix) {
+        setAllowError("QueueArn is not available to expand local queue names. Enter full source queue ARNs.");
         return;
       }
-      if (names.length > 10) {
+      if (parsedSources.sourceQueueArns.length === 0) {
+        setAllowError("Enter at least one source queue ARN or local queue name.");
+        return;
+      }
+      if (parsedSources.sourceQueueArns.length > 10) {
         setAllowError("sourceQueueArns can contain at most 10 queues.");
         return;
       }
-      policy.sourceQueueArns = names.map((name) => queueArnForName(arnPrefix, name));
+      policy.sourceQueueArns = parsedSources.sourceQueueArns;
     }
     setAllowSaving(true);
     try {
@@ -409,14 +409,16 @@ function DLQSettingsSection({
           </div>
           {permission === "byQueue" && (
             <div>
-              <label className="label" htmlFor="redrive-source-queues">Source queue names</label>
+              <label className="label" htmlFor="redrive-source-queues">Source queue ARNs</label>
               <textarea
                 id="redrive-source-queues"
                 className="input font-mono min-h-24"
-                value={sourceNamesText}
-                onChange={(e) => setSourceNamesText(e.target.value)}
+                value={sourceQueueArnsText}
+                onChange={(e) => setSourceQueueArnsText(e.target.value)}
                 disabled={allowSaving}
-                placeholder={candidateQueues.join("\n")}
+                placeholder={candidateQueues
+                  .map((name) => (arnPrefix ? queueArnForName(arnPrefix, name) : name))
+                  .join("\n")}
               />
             </div>
           )}
@@ -455,19 +457,19 @@ function parseRedrivePolicyAttribute(raw?: string): ParsedRedrivePolicy {
 }
 
 function parseRedriveAllowPolicyAttribute(raw?: string): ParsedRedriveAllowPolicy {
-  if (!raw) return { permission: "allowAll", sourceNames: [] };
+  if (!raw) return { permission: "allowAll", sourceQueueArns: [] };
   try {
     const obj = JSON.parse(raw) as Record<string, unknown>;
     const permission = parseRedrivePermission(obj.redrivePermission);
-    const sourceNames = Array.isArray(obj.sourceQueueArns)
+    const sourceQueueArns = Array.isArray(obj.sourceQueueArns)
       ? obj.sourceQueueArns
         .filter((arn): arn is string => typeof arn === "string")
-        .map(queueNameFromArn)
-        .filter((name) => name !== "")
+        .map((arn) => arn.trim())
+        .filter((arn) => arn !== "")
       : [];
-    return { permission, sourceNames };
+    return { permission, sourceQueueArns };
   } catch {
-    return { permission: "allowAll", sourceNames: [] };
+    return { permission: "allowAll", sourceQueueArns: [] };
   }
 }
 
@@ -497,16 +499,23 @@ function isFifoQueueName(name: string): boolean {
   return name.endsWith(".fifo");
 }
 
-function parseQueueNamesInput(value: string): string[] {
+function parseSourceQueueArnInput(value: string, arnPrefix: string): { sourceQueueArns: string[]; needsArnPrefix: boolean } {
   const seen = new Set<string>();
-  const names: string[] = [];
+  const sourceQueueArns: string[] = [];
+  let needsArnPrefix = false;
   for (const part of value.split(/[,\n]/u)) {
-    const name = part.trim();
-    if (!name || seen.has(name)) continue;
-    seen.add(name);
-    names.push(name);
+    const raw = part.trim();
+    if (!raw) continue;
+    const arn = raw.startsWith("arn:") ? raw : arnPrefix ? queueArnForName(arnPrefix, raw) : "";
+    if (!arn) {
+      needsArnPrefix = true;
+      continue;
+    }
+    if (seen.has(arn)) continue;
+    seen.add(arn);
+    sourceQueueArns.push(arn);
   }
-  return names;
+  return { sourceQueueArns, needsArnPrefix };
 }
 
 interface MessagesSectionProps {


### PR DESCRIPTION
## Summary
- Add SQS-compatible `RedrivePolicy` and `RedriveAllowPolicy` support, including `maxReceiveCount` validation, same-account/region/type checks, and `allowAll` / `denyAll` / `byQueue` permissions.
- Move messages to the configured DLQ after the source receive threshold is exceeded, including `DeadLetterQueueSourceArn` and queue-type-specific metadata behavior.
- Add admin API and Web UI controls for configuring DLQ redrive settings, plus a reviewed design doc.

## Tests
- `go test ./adapter -run 'AdminSetQueueAttributes|RedriveAllowPolicy|RedrivePolicy|DLQRedrive' -count=1 -timeout=180s`
- `go test ./internal/admin ./internal/backup -count=1 -timeout=180s`
- `npm run lint` from `web/admin`
- `npm run build` from `web/admin`
- `golangci-lint --config=.golangci.yaml run --fix`
- `git diff --check && git diff --cached --check`

## Notes
- `go test ./... -count=1 -timeout=300s` was attempted earlier and timed out in the existing `adapter` package test suite after 5 minutes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Admin API and web interface for updating queue attributes and managing dead-letter queue configurations
  * New DLQ settings form to configure redrive policies (target DLQ + max receive count) and allow policies  
  * RedriveAllowPolicy support enabling dead-letter queues to control which source queues can target them
  * Improved redrive operations with message metadata preservation (original IDs and timestamps retained)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->