### PR TITLE
raft: avoid stale leadership transfer targets

### DIFF
--- a/cmd/raftadmin/main.go
+++ b/cmd/raftadmin/main.go
@@ -187,6 +187,7 @@ func isLoopbackHost(host string) bool {
 
 func readOnlyCommands() map[string]func(context.Context, pb.RaftAdminClient) error {
 	return map[string]func(context.Context, pb.RaftAdminClient) error{
+		"status":        printStatus,
 		"leader":        printLeader,
 		"state":         printState,
 		"configuration": printConfiguration,
@@ -236,6 +237,25 @@ func printState(ctx context.Context, client pb.RaftAdminClient) error {
 		return errors.Wrap(err, "get state")
 	}
 	fmt.Printf("state: %s\n", formatState(resp.State))
+	return nil
+}
+
+func printStatus(ctx context.Context, client pb.RaftAdminClient) error {
+	resp, err := client.Status(ctx, &pb.RaftAdminStatusRequest{})
+	if err != nil {
+		return errors.Wrap(err, "get status")
+	}
+	fmt.Printf("state: %s\n", formatState(resp.State))
+	fmt.Printf("leader_id: %q\n", resp.LeaderId)
+	fmt.Printf("leader_address: %q\n", resp.LeaderAddress)
+	fmt.Printf("term: %d\n", resp.Term)
+	fmt.Printf("commit_index: %d\n", resp.CommitIndex)
+	fmt.Printf("applied_index: %d\n", resp.AppliedIndex)
+	fmt.Printf("last_log_index: %d\n", resp.LastLogIndex)
+	fmt.Printf("last_snapshot_index: %d\n", resp.LastSnapshotIndex)
+	fmt.Printf("fsm_pending: %d\n", resp.FsmPending)
+	fmt.Printf("num_peers: %d\n", resp.NumPeers)
+	fmt.Printf("last_contact_nanos: %d\n", resp.LastContactNanos)
 	return nil
 }
 
@@ -424,11 +444,12 @@ var usageStrings = map[string]string{
 	"add_learner":                   "raftadmin <addr> add_learner <id> <address> [previous_index]",
 	"promote_learner":               "raftadmin <addr> promote_learner <id> [previous_index] [min_applied_index] [skip_min_applied_check]",
 	"remove_server":                 "raftadmin <addr> remove_server <id> [previous_index]",
+	"status":                        "raftadmin <addr> status",
 	"leadership_transfer":           "raftadmin <addr> leadership_transfer",
 	"leadership_transfer_to_server": "raftadmin <addr> leadership_transfer_to_server <id> <address>",
 }
 
-const usageFallback = "raftadmin <addr> <leader|state|configuration|add_voter|add_learner|promote_learner|remove_server|leadership_transfer|leadership_transfer_to_server> [args]"
+const usageFallback = "raftadmin <addr> <status|leader|state|configuration|add_voter|add_learner|promote_learner|remove_server|leadership_transfer|leadership_transfer_to_server> [args]"
 
 func usage(command string) string {
 	if u, ok := usageStrings[command]; ok {

--- a/cmd/raftadmin/main_test.go
+++ b/cmd/raftadmin/main_test.go
@@ -70,6 +70,14 @@ func TestExecuteCommandLeaderAndStateOutput(t *testing.T) {
 		require.NoError(t, executeCommand(context.Background(), client, "state", nil))
 	})
 	require.Equal(t, "state: LEADER\n", out)
+
+	out = captureStdout(t, func() {
+		require.NoError(t, executeCommand(context.Background(), client, "status", nil))
+	})
+	require.Contains(t, out, "state: LEADER")
+	require.Contains(t, out, "leader_id: \"n1\"")
+	require.Contains(t, out, "leader_address: \"127.0.0.1:50051\"")
+	require.Contains(t, out, "commit_index: 0")
 }
 
 func TestRPCTimeoutHonorsEnvSeconds(t *testing.T) {
@@ -90,11 +98,12 @@ func TestUsageErrorForCommand(t *testing.T) {
 	require.EqualError(t, usageError("add_learner"), "usage: raftadmin <addr> add_learner <id> <address> [previous_index]")
 	require.EqualError(t, usageError("promote_learner"), "usage: raftadmin <addr> promote_learner <id> [previous_index] [min_applied_index] [skip_min_applied_check]")
 	require.EqualError(t, usageError("remove_server"), "usage: raftadmin <addr> remove_server <id> [previous_index]")
+	require.EqualError(t, usageError("status"), "usage: raftadmin <addr> status")
 	require.EqualError(t, usageError("leadership_transfer_to_server"), "usage: raftadmin <addr> leadership_transfer_to_server <id> <address>")
 }
 
 func TestUsageErrorFallback(t *testing.T) {
-	want := "usage: raftadmin <addr> <leader|state|configuration|add_voter|add_learner|promote_learner|remove_server|leadership_transfer|leadership_transfer_to_server> [args]"
+	want := "usage: raftadmin <addr> <status|leader|state|configuration|add_voter|add_learner|promote_learner|remove_server|leadership_transfer|leadership_transfer_to_server> [args]"
 	require.EqualError(t, usageError(""), want)
 	require.EqualError(t, usageError("unknown"), want)
 }

--- a/internal/raftengine/etcd/dispatch_report_test.go
+++ b/internal/raftengine/etcd/dispatch_report_test.go
@@ -85,3 +85,53 @@ func TestPostDispatchReport_AbortsOnClose(t *testing.T) {
 		t.Fatal("postDispatchReport did not abort when closeCh was signalled")
 	}
 }
+
+func TestEnqueueDispatchReportsDroppedSnapshotWhenLaneFull(t *testing.T) {
+	t.Parallel()
+	snapshotCh := make(chan dispatchRequest, 1)
+	snapshotCh <- dispatchRequest{msg: raftpb.Message{Type: raftpb.MsgSnap, To: 2}}
+	e := &Engine{
+		transport:              &GRPCTransport{},
+		dispatcherLanesEnabled: true,
+		dispatchReportCh:       make(chan dispatchReport, 1),
+		closeCh:                make(chan struct{}),
+		peerDispatchers: map[uint64]*peerQueues{
+			2: {snapshot: snapshotCh},
+		},
+	}
+
+	require.NoError(t, e.enqueueDispatchMessage(raftpb.Message{Type: raftpb.MsgSnap, To: 2}))
+
+	require.Equal(t, uint64(1), e.DispatchDropCount())
+	select {
+	case got := <-e.dispatchReportCh:
+		require.Equal(t, dispatchReport{to: 2, msgType: raftpb.MsgSnap}, got)
+	default:
+		t.Fatal("expected dropped MsgSnap to report SnapshotFailure input")
+	}
+}
+
+func TestEnqueueDispatchReportsDroppedRegularMessageWhenLaneFull(t *testing.T) {
+	t.Parallel()
+	replicationCh := make(chan dispatchRequest, 1)
+	replicationCh <- dispatchRequest{msg: raftpb.Message{Type: raftpb.MsgApp, To: 2}}
+	e := &Engine{
+		transport:              &GRPCTransport{},
+		dispatcherLanesEnabled: true,
+		dispatchReportCh:       make(chan dispatchReport, 1),
+		closeCh:                make(chan struct{}),
+		peerDispatchers: map[uint64]*peerQueues{
+			2: {replication: replicationCh},
+		},
+	}
+
+	require.NoError(t, e.enqueueDispatchMessage(raftpb.Message{Type: raftpb.MsgApp, To: 2}))
+
+	require.Equal(t, uint64(1), e.DispatchDropCount())
+	select {
+	case got := <-e.dispatchReportCh:
+		require.Equal(t, dispatchReport{to: 2, msgType: raftpb.MsgApp}, got)
+	default:
+		t.Fatal("expected dropped MsgApp to report unreachable input")
+	}
+}

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -1534,10 +1534,12 @@ func (e *Engine) handleDispatchReport(report dispatchReport) {
 }
 
 // postDispatchReport delivers a dispatch failure to the event loop without
-// blocking the worker. If the channel is full (unlikely — the buffer is
-// sized to MaxInflightMsg), the report is dropped and logged; this is
-// acceptable because raft will retry on the next tick and we only need
-// eventual consistency between transport state and Progress state.
+// blocking the caller. Dispatch workers use it for transport failures, and the
+// event loop uses it for local queue drops before transport. If the channel is
+// full (unlikely — the buffer is sized to MaxInflightMsg), the report is
+// dropped and logged; this is acceptable because raft will retry on the next
+// tick and we only need eventual consistency between transport state and
+// Progress state.
 func (e *Engine) postDispatchReport(report dispatchReport) {
 	select {
 	case e.dispatchReportCh <- report:
@@ -4073,6 +4075,14 @@ func (e *Engine) recordDroppedDispatch(msg raftpb.Message) {
 			"drop_count", count,
 		)
 	}
+	e.reportDroppedDispatch(msg)
+}
+
+func (e *Engine) reportDroppedDispatch(msg raftpb.Message) {
+	if e.dispatchReportCh == nil {
+		return
+	}
+	e.postDispatchReport(dispatchReport{to: msg.To, msgType: msg.Type})
 }
 
 // dispatchErrorCodeOf extracts the grpc status code name from err, or

--- a/scripts/rolling-update.env.example
+++ b/scripts/rolling-update.env.example
@@ -72,11 +72,12 @@ RAFTADMIN_REMOTE_BIN="/tmp/elastickv-raftadmin"
 RAFTADMIN_RPC_TIMEOUT_SECONDS="15"
 RAFTADMIN_ALLOW_INSECURE="true"
 
-# Retry the targeted leadership_transfer_to_server RPC up to N times
-# before falling back to generic transfer. Each retry waits
-# LEADERSHIP_TRANSFER_RETRY_BACKOFF_SECONDS to let the candidate's
-# log catch up. Counts the first attempt toward the budget; set to 1
-# to disable retry.
+# Retry each eligible targeted leadership_transfer_to_server RPC up to N
+# times. Each retry waits LEADERSHIP_TRANSFER_RETRY_BACKOFF_SECONDS to let
+# the candidate's log catch up. Counts the first attempt toward the budget;
+# set to 1 to disable retry. If all caught-up targeted candidates fail, the
+# rollout aborts instead of falling back to a generic transfer that may pick
+# a stale peer.
 LEADERSHIP_TRANSFER_RETRY_ATTEMPTS="3"
 LEADERSHIP_TRANSFER_RETRY_BACKOFF_SECONDS="5"
 

--- a/scripts/rolling-update.sh
+++ b/scripts/rolling-update.sh
@@ -72,6 +72,7 @@ Optional environment:
     partitioned queues route to the default Raft group.
   HEALTH_TIMEOUT_SECONDS
   LEADERSHIP_TRANSFER_TIMEOUT_SECONDS
+  LEADERSHIP_TRANSFER_MAX_LOG_LAG
   LEADER_DISCOVERY_TIMEOUT_SECONDS
   ROLLING_DELAY_SECONDS
   SSH_CONNECT_TIMEOUT_SECONDS
@@ -220,6 +221,11 @@ SQS_FIFO_PARTITION_MAP="${SQS_FIFO_PARTITION_MAP:-}"
 # default can be tightened back down.
 HEALTH_TIMEOUT_SECONDS="${HEALTH_TIMEOUT_SECONDS:-300}"
 LEADERSHIP_TRANSFER_TIMEOUT_SECONDS="${LEADERSHIP_TRANSFER_TIMEOUT_SECONDS:-30}"
+# Maximum leader-commit-to-candidate-last-log lag tolerated for a targeted
+# leadership transfer. A target that needs a snapshot, or is farther behind
+# than this, is likely to make etcd/raft abort the transfer before catch-up
+# completes. The default matches the engine's default snapshot cadence.
+LEADERSHIP_TRANSFER_MAX_LOG_LAG="${LEADERSHIP_TRANSFER_MAX_LOG_LAG:-10000}"
 LEADER_DISCOVERY_TIMEOUT_SECONDS="${LEADER_DISCOVERY_TIMEOUT_SECONDS:-30}"
 ROLLING_DELAY_SECONDS="${ROLLING_DELAY_SECONDS:-2}"
 SSH_CONNECT_TIMEOUT_SECONDS="${SSH_CONNECT_TIMEOUT_SECONDS:-10}"
@@ -631,6 +637,7 @@ update_one_node() {
       SQS_FIFO_PARTITION_MAP="$SQS_FIFO_PARTITION_MAP_Q" \
       HEALTH_TIMEOUT_SECONDS="$HEALTH_TIMEOUT_SECONDS" \
       LEADERSHIP_TRANSFER_TIMEOUT_SECONDS="$LEADERSHIP_TRANSFER_TIMEOUT_SECONDS" \
+      LEADERSHIP_TRANSFER_MAX_LOG_LAG="$LEADERSHIP_TRANSFER_MAX_LOG_LAG" \
       LEADERSHIP_TRANSFER_RETRY_ATTEMPTS="$LEADERSHIP_TRANSFER_RETRY_ATTEMPTS" \
       LEADERSHIP_TRANSFER_RETRY_BACKOFF_SECONDS="$LEADERSHIP_TRANSFER_RETRY_BACKOFF_SECONDS" \
       LEADER_DISCOVERY_TIMEOUT_SECONDS="$LEADER_DISCOVERY_TIMEOUT_SECONDS" \
@@ -707,6 +714,15 @@ extract_proto_enum() {
     tail -n1
 }
 
+extract_proto_uint() {
+  local field="$1"
+  local payload="$2"
+
+  printf '%s' "$payload" |
+    sed -nE "s/.*${field}:[[:space:]]+\"?([0-9]+)\"?.*/\1/p" |
+    tail -n1
+}
+
 raftadmin_text() {
   local addr="$1"
   shift
@@ -717,6 +733,11 @@ raftadmin_text() {
   fi
 
   "$RAFTADMIN_BIN_PATH" "$addr" "$@" 2>&1
+}
+
+raft_status() {
+  local addr="$1"
+  raftadmin_text "$addr" status
 }
 
 raft_leader_addr() {
@@ -800,19 +821,77 @@ cluster_reachability_summary() {
 }
 
 choose_transfer_candidate() {
-  local i
+  local leader_addr leader_status leader_commit leader_last_log leader_last_snapshot target_index
+  local i addr output state last_log applied lag rows
 
+  leader_addr="${NODE_HOST}:${RAFT_PORT}"
+  leader_status="$(raft_status "$leader_addr")" || {
+    echo "unable to read leader raft status from $leader_addr" >&2
+    return 1
+  }
+  leader_commit="$(extract_proto_uint "commit_index" "$leader_status")"
+  leader_last_log="$(extract_proto_uint "last_log_index" "$leader_status")"
+  leader_last_snapshot="$(extract_proto_uint "last_snapshot_index" "$leader_status")"
+  if [[ -z "$leader_commit" || -z "$leader_last_log" || -z "$leader_last_snapshot" ]]; then
+    echo "unable to parse leader raft indexes from $leader_addr status: $leader_status" >&2
+    return 1
+  fi
+  target_index="$leader_commit"
+  if (( leader_last_log > target_index )); then
+    target_index="$leader_last_log"
+  fi
+
+  rows=()
   for i in "${!ALL_NODE_IDS[@]}"; do
     if [[ "${ALL_NODE_IDS[$i]}" == "$NODE_ID" ]]; then
       continue
     fi
-    if peer_grpc_healthy "${ALL_NODE_HOSTS[$i]}"; then
-      printf '%s %s\n' "${ALL_NODE_IDS[$i]}" "${ALL_NODE_HOSTS[$i]}"
-      return 0
+    addr="${ALL_NODE_HOSTS[$i]}:${RAFT_PORT}"
+    if ! peer_grpc_healthy "${ALL_NODE_HOSTS[$i]}"; then
+      echo "skip transfer target ${ALL_NODE_IDS[$i]}@${addr}: gRPC unreachable" >&2
+      continue
     fi
+    output="$(raft_status "$addr" || true)"
+    if [[ -z "$output" ]]; then
+      echo "skip transfer target ${ALL_NODE_IDS[$i]}@${addr}: status RPC failed" >&2
+      continue
+    fi
+    state="$(extract_proto_enum "state" "$output")"
+    if [[ "$state" != "FOLLOWER" ]]; then
+      echo "skip transfer target ${ALL_NODE_IDS[$i]}@${addr}: state=${state:-unknown}" >&2
+      continue
+    fi
+    last_log="$(extract_proto_uint "last_log_index" "$output")"
+    applied="$(extract_proto_uint "applied_index" "$output")"
+    if [[ -z "$last_log" || -z "$applied" ]]; then
+      echo "skip transfer target ${ALL_NODE_IDS[$i]}@${addr}: unable to parse indexes from status: $output" >&2
+      continue
+    fi
+    if (( last_log < leader_last_snapshot )); then
+      echo "skip transfer target ${ALL_NODE_IDS[$i]}@${addr}: last_log_index=${last_log} is behind leader snapshot index ${leader_last_snapshot}" >&2
+      continue
+    fi
+    if (( target_index > last_log )); then
+      lag=$(( target_index - last_log ))
+    else
+      lag=0
+    fi
+    if (( lag > LEADERSHIP_TRANSFER_MAX_LOG_LAG )); then
+      echo "skip transfer target ${ALL_NODE_IDS[$i]}@${addr}: log lag ${lag} exceeds LEADERSHIP_TRANSFER_MAX_LOG_LAG=${LEADERSHIP_TRANSFER_MAX_LOG_LAG}" >&2
+      continue
+    fi
+    rows+=("${lag} ${i} ${ALL_NODE_IDS[$i]} ${ALL_NODE_HOSTS[$i]} ${last_log} ${applied}")
   done
 
-  return 1
+  if [[ "${#rows[@]}" -eq 0 ]]; then
+    return 1
+  fi
+
+  printf '%s\n' "${rows[@]}" |
+    sort -n -k1,1 -k2,2 |
+    while read -r lag _ordinal candidate_id candidate_host last_log applied; do
+      printf '%s %s %s %s %s\n' "$candidate_id" "$candidate_host" "$lag" "$last_log" "$applied"
+    done
 }
 
 wait_for_leader_change() {
@@ -858,40 +937,49 @@ ensure_not_leader_before_restart() {
     return 1
   fi
 
-  if ! read -r candidate_id candidate_host < <(choose_transfer_candidate); then
-    echo "node is leader but no healthy peer is available as transfer target" >&2
+  local transfer_succeeded=false
+  local candidate_rows candidate_lag candidate_last_log candidate_applied
+  candidate_rows="$(choose_transfer_candidate || true)"
+  if [[ -z "$candidate_rows" ]]; then
+    echo "node is leader but no caught-up healthy follower is available as transfer target" >&2
+    echo "cluster reachability: $(cluster_reachability_summary)" >&2
     return 1
   fi
-  candidate_addr="${candidate_host}:${RAFT_PORT}"
 
-  echo "node is leader; transferring leadership to ${candidate_id}@${candidate_addr}"
-  # Retry the targeted transfer up to LEADERSHIP_TRANSFER_RETRY_ATTEMPTS
-  # times. A common failure shape under rolling restarts is etcd raft
-  # rejecting the transfer with "etcd raft leadership transfer aborted"
-  # when the candidate's log has not yet caught up to the leader. The
-  # candidate typically becomes ready within a few seconds, so a brief
-  # backoff between attempts is usually enough. Only when ALL targeted
-  # retries are exhausted do we fall back to the generic transfer.
-  local attempt=1 transfer_succeeded=false
-  while (( attempt <= LEADERSHIP_TRANSFER_RETRY_ATTEMPTS )); do
-    if rpc_output="$(raftadmin_text "${NODE_HOST}:${RAFT_PORT}" leadership_transfer_to_server "${candidate_id}" "${candidate_addr}")"; then
-      transfer_succeeded=true
+  # Retry each eligible targeted transfer up to
+  # LEADERSHIP_TRANSFER_RETRY_ATTEMPTS times. A common failure shape
+  # under rolling restarts is etcd raft rejecting the transfer with
+  # "etcd raft leadership transfer aborted" when the candidate's log
+  # has not caught up. We rank candidates by log lag and try every
+  # non-stale follower before refusing the restart. We intentionally
+  # do not fall back to the generic transfer RPC: the engine's generic
+  # target selection is configuration-order based and can reselect the
+  # exact stale peer this filter skipped.
+  while read -r candidate_id candidate_host candidate_lag candidate_last_log candidate_applied; do
+    [[ -n "$candidate_id" ]] || continue
+    candidate_addr="${candidate_host}:${RAFT_PORT}"
+    echo "node is leader; transferring leadership to ${candidate_id}@${candidate_addr} (lag=${candidate_lag}, last_log=${candidate_last_log}, applied=${candidate_applied})"
+    local attempt=1
+    while (( attempt <= LEADERSHIP_TRANSFER_RETRY_ATTEMPTS )); do
+      if rpc_output="$(raftadmin_text "${NODE_HOST}:${RAFT_PORT}" leadership_transfer_to_server "${candidate_id}" "${candidate_addr}")"; then
+        transfer_succeeded=true
+        break
+      fi
+      echo "targeted leadership transfer to ${candidate_id}@${candidate_addr} attempt ${attempt}/${LEADERSHIP_TRANSFER_RETRY_ATTEMPTS} failed: $rpc_output" >&2
+      if (( attempt < LEADERSHIP_TRANSFER_RETRY_ATTEMPTS )); then
+        echo "retrying in ${LEADERSHIP_TRANSFER_RETRY_BACKOFF_SECONDS}s..." >&2
+        sleep "${LEADERSHIP_TRANSFER_RETRY_BACKOFF_SECONDS}"
+      fi
+      attempt=$(( attempt + 1 ))
+    done
+    if [[ "$transfer_succeeded" == "true" ]]; then
       break
     fi
-    echo "targeted leadership transfer attempt ${attempt}/${LEADERSHIP_TRANSFER_RETRY_ATTEMPTS} failed: $rpc_output" >&2
-    if (( attempt < LEADERSHIP_TRANSFER_RETRY_ATTEMPTS )); then
-      echo "retrying in ${LEADERSHIP_TRANSFER_RETRY_BACKOFF_SECONDS}s..." >&2
-      sleep "${LEADERSHIP_TRANSFER_RETRY_BACKOFF_SECONDS}"
-    fi
-    attempt=$(( attempt + 1 ))
-  done
+  done <<< "$candidate_rows"
+
   if [[ "$transfer_succeeded" != "true" ]]; then
-    echo "falling back to generic leadership transfer"
-    rpc_output="$(raftadmin_text "${NODE_HOST}:${RAFT_PORT}" leadership_transfer)" || {
-      echo "generic leadership transfer RPC failed: $rpc_output" >&2
-      return 1
-    }
-    candidate_addr=""
+    echo "all caught-up targeted leadership transfer attempts failed; refusing generic transfer because it may pick a stale peer" >&2
+    return 1
   fi
 
   if ! wait_for_leader_change "${NODE_HOST}:${RAFT_PORT}" "$candidate_addr"; then

--- a/scripts/rolling-update.sh
+++ b/scripts/rolling-update.sh
@@ -826,7 +826,7 @@ choose_transfer_candidate() {
 
   leader_addr="${NODE_HOST}:${RAFT_PORT}"
   leader_status="$(raft_status "$leader_addr")" || {
-    echo "unable to read leader raft status from $leader_addr" >&2
+    echo "unable to read leader raft status from $leader_addr: $leader_status" >&2
     return 1
   }
   leader_commit="$(extract_proto_uint "commit_index" "$leader_status")"
@@ -851,9 +851,8 @@ choose_transfer_candidate() {
       echo "skip transfer target ${ALL_NODE_IDS[$i]}@${addr}: gRPC unreachable" >&2
       continue
     fi
-    output="$(raft_status "$addr" || true)"
-    if [[ -z "$output" ]]; then
-      echo "skip transfer target ${ALL_NODE_IDS[$i]}@${addr}: status RPC failed" >&2
+    if ! output="$(raft_status "$addr")"; then
+      echo "skip transfer target ${ALL_NODE_IDS[$i]}@${addr}: status RPC failed: $output" >&2
       continue
     fi
     state="$(extract_proto_enum "state" "$output")"


### PR DESCRIPTION
## Summary
- add `raftadmin status` so rollout can inspect raft log indexes
- skip stale, unreachable, non-follower, or over-lagged leadership transfer targets and try eligible followers by lag
- report local raft dispatch queue drops back through snapshot/unreachable report handling

## Tests
- `go test ./cmd/raftadmin ./internal/raftengine/etcd`
- `bash -n scripts/rolling-update.sh && git diff --check`
- `go test ./adapter -run '^TestRedis_MisskeyConnectionCompatibility$' -count=1 -timeout=2m`\n- `go test ./...` fails: `adapter` package timed out after 600s\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `status` command to raftadmin CLI tool providing cluster state information

* **Improvements**
  * Enhanced rolling-update script with configurable leadership transfer maximum log lag threshold
  * Improved peer failure detection by reporting dropped messages to the raft engine

* **Tests**
  * Added test coverage for the new status command output
  * Added tests for message drop handling in dispatch lanes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->