### PR TITLE
raftengine: seed RawNode applied on restart

### DIFF
--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"io"
 	"log/slog"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime/debug"
@@ -505,7 +506,14 @@ func Open(ctx context.Context, cfg OpenConfig) (*Engine, error) {
 		return nil, err
 	}
 
-	rawNode, err := newRawNode(prepared.cfg, prepared.disk.Storage)
+	initialApplied := coldStartApplied(prepared.disk)
+	rawNodeApplied, err := rawNodeAppliedForOpen(prepared.disk.Storage, initialApplied, prepared.cfg)
+	if err != nil {
+		_ = closePersist(prepared.disk.Persist)
+		return nil, err
+	}
+
+	rawNode, err := newRawNode(prepared.cfg, prepared.disk.Storage, rawNodeApplied)
 	if err != nil {
 		_ = closePersist(prepared.disk.Persist)
 		return nil, err
@@ -557,7 +565,7 @@ func Open(ctx context.Context, cfg OpenConfig) (*Engine, error) {
 		config:           configurationFromConfState(peerMap, prepared.disk.LocalSnap.Metadata.ConfState),
 		voterCount:       len(prepared.disk.LocalSnap.Metadata.ConfState.Voters),
 		isLearnerNode:    learnerSetFromConfState(prepared.disk.LocalSnap.Metadata.ConfState),
-		applied:          coldStartApplied(prepared.disk),
+		applied:          initialApplied,
 		dispatchCtx:      dispatchCtx,
 		dispatchCancel:   dispatchCancel,
 		pendingProposals: map[uint64]proposalRequest{},
@@ -572,7 +580,7 @@ func Open(ctx context.Context, cfg OpenConfig) (*Engine, error) {
 		maxWALFiles:   maxWALFilesFromEnv(),
 	}
 	engine.configIndex.Store(maxAppliedIndex(prepared.disk.LocalSnap))
-	engine.appliedIndex.Store(coldStartApplied(prepared.disk))
+	engine.appliedIndex.Store(initialApplied)
 	engine.initTransport(prepared.cfg)
 	engine.initSnapshotWorker()
 	engine.refreshStatus()
@@ -689,12 +697,95 @@ func (e *Engine) initSnapshotWorker() {
 	e.startSnapshotWorker()
 }
 
-func newRawNode(cfg OpenConfig, storage *etcdraft.MemoryStorage) (*etcdraft.RawNode, error) {
+func rawNodeAppliedForOpen(storage *etcdraft.MemoryStorage, applied uint64, cfg OpenConfig) (uint64, error) {
+	if applied == 0 {
+		return 0, nil
+	}
+	baseApplied, applied, err := rawNodeAppliedBounds(storage, applied)
+	if err != nil {
+		return 0, err
+	}
+	if applied <= baseApplied {
+		return applied, nil
+	}
+	return trimRawNodeAppliedForReplay(storage, baseApplied, applied, cfg), nil
+}
+
+func rawNodeAppliedBounds(storage *etcdraft.MemoryStorage, applied uint64) (uint64, uint64, error) {
+	firstIndex, err := storage.FirstIndex()
+	if err != nil {
+		return 0, 0, errors.WithStack(err)
+	}
+	baseApplied := uint64(0)
+	if firstIndex > 0 {
+		baseApplied = firstIndex - 1
+	}
+	committed := baseApplied
+	hardState, _, err := storage.InitialState()
+	if err != nil {
+		return 0, 0, errors.WithStack(err)
+	}
+	if !etcdraft.IsEmptyHardState(hardState) && hardState.Commit > committed {
+		committed = hardState.Commit
+	}
+	if applied > committed {
+		applied = committed
+	}
+	return baseApplied, applied, nil
+}
+
+func trimRawNodeAppliedForReplay(storage *etcdraft.MemoryStorage, baseApplied, applied uint64, cfg OpenConfig) uint64 {
+	entries, entriesErr := storage.Entries(baseApplied+1, applied+1, math.MaxUint64)
+	if entriesErr != nil {
+		return applied
+	}
+	for _, entry := range entries {
+		if coldStartEntryRequiresReplay(entry, cfg) {
+			return entry.Index - 1
+		}
+	}
+	return applied
+}
+
+func coldStartEntryRequiresReplay(entry raftpb.Entry, cfg OpenConfig) bool {
+	switch entry.Type {
+	case raftpb.EntryConfChange, raftpb.EntryConfChangeV2:
+		return true
+	case raftpb.EntryNormal:
+	default:
+		return false
+	}
+	if len(entry.Data) == 0 {
+		return false
+	}
+	_, payload, ok := decodeProposalEnvelope(entry.Data)
+	if !ok {
+		return false
+	}
+	if entry.Index > orInertCutover(cfg.RaftCutoverIndex)() {
+		if cfg.RaftCipher == nil {
+			return true
+		}
+		plain, err := unwrapRaftPayload(cfg.RaftCipher, payload)
+		if err != nil {
+			return true
+		}
+		payload = plain
+	}
+	classifier, ok := cfg.StateMachine.(raftengine.VolatileEntryClassifier)
+	if !ok {
+		return false
+	}
+	return classifier.IsVolatileOnlyPayload(payload)
+}
+
+func newRawNode(cfg OpenConfig, storage *etcdraft.MemoryStorage, applied uint64) (*etcdraft.RawNode, error) {
 	rawNode, err := etcdraft.NewRawNode(&etcdraft.Config{
 		ID:                        cfg.NodeID,
 		ElectionTick:              cfg.ElectionTick,
 		HeartbeatTick:             cfg.HeartbeatTick,
 		Storage:                   storage,
+		Applied:                   applied,
 		MaxSizePerMsg:             cfg.MaxSizePerMsg,
 		MaxCommittedSizePerReady:  cfg.MaxSizePerMsg,
 		MaxInflightMsgs:           cfg.MaxInflightMsg,

--- a/internal/raftengine/etcd/engine_test.go
+++ b/internal/raftengine/etcd/engine_test.go
@@ -1767,6 +1767,127 @@ func mustRawNode(t *testing.T, storage *etcdraft.MemoryStorage, nodeID uint64) *
 	return rawNode
 }
 
+func rawNodeTestConfig() OpenConfig {
+	return OpenConfig{
+		NodeID:         1,
+		ElectionTick:   defaultElectionTick,
+		HeartbeatTick:  defaultHeartbeatTick,
+		MaxSizePerMsg:  defaultMaxSizePerMsg,
+		MaxInflightMsg: defaultMaxInflightMsg,
+	}
+}
+
+func committedTailStorage(t *testing.T, snapIndex, commit uint64) *etcdraft.MemoryStorage {
+	t.Helper()
+	return committedTailStorageWithEntries(t, snapIndex, commit, nil)
+}
+
+func committedTailStorageWithEntries(t *testing.T, snapIndex, commit uint64, overrides map[uint64]raftpb.Entry) *etcdraft.MemoryStorage {
+	t.Helper()
+	storage := etcdraft.NewMemoryStorage()
+	require.NoError(t, storage.ApplySnapshot(raftpb.Snapshot{
+		Metadata: raftpb.SnapshotMetadata{
+			ConfState: raftpb.ConfState{Voters: []uint64{1}},
+			Index:     snapIndex,
+			Term:      1,
+		},
+	}))
+	entries := make([]raftpb.Entry, 0, commit-snapIndex)
+	for index := snapIndex + 1; index <= commit; index++ {
+		entry := raftpb.Entry{
+			Index: index,
+			Term:  1,
+			Type:  raftpb.EntryNormal,
+			Data:  []byte("already-applied"),
+		}
+		if override, ok := overrides[index]; ok {
+			entry = override
+			entry.Index = index
+			if entry.Term == 0 {
+				entry.Term = 1
+			}
+		}
+		entries = append(entries, entry)
+	}
+	require.NoError(t, storage.Append(entries))
+	require.NoError(t, storage.SetHardState(raftpb.HardState{
+		Term:   1,
+		Commit: commit,
+	}))
+	return storage
+}
+
+func TestNewRawNodeSeedsAppliedFromColdStart(t *testing.T) {
+	storage := committedTailStorage(t, 100, 150)
+	rawApplied, err := rawNodeAppliedForOpen(storage, 150, rawNodeTestConfig())
+	require.NoError(t, err)
+	require.Equal(t, uint64(150), rawApplied)
+
+	rawNode, err := newRawNode(rawNodeTestConfig(), storage, rawApplied)
+	require.NoError(t, err)
+	require.False(t, rawNode.HasReady(),
+		"restarting from an already-applied committed tail must not redeliver it through Ready")
+}
+
+func TestNewRawNodeWithoutAppliedRedeliversCommittedTail(t *testing.T) {
+	storage := committedTailStorage(t, 100, 150)
+
+	rawNode, err := newRawNode(rawNodeTestConfig(), storage, 0)
+	require.NoError(t, err)
+	require.True(t, rawNode.HasReady())
+	ready := rawNode.Ready()
+	require.Len(t, ready.CommittedEntries, 50)
+	require.Equal(t, uint64(101), ready.CommittedEntries[0].Index)
+	require.Equal(t, uint64(150), ready.CommittedEntries[len(ready.CommittedEntries)-1].Index)
+}
+
+func TestRawNodeAppliedForOpenClipsToCommitted(t *testing.T) {
+	storage := committedTailStorage(t, 100, 150)
+
+	rawApplied, err := rawNodeAppliedForOpen(storage, 200, rawNodeTestConfig())
+	require.NoError(t, err)
+	require.Equal(t, uint64(150), rawApplied,
+		"etcd/raft Config.Applied cannot exceed the local committed index")
+}
+
+func TestRawNodeAppliedForOpenPreservesVolatileReplay(t *testing.T) {
+	storage := committedTailStorageWithEntries(t, 100, 150, map[uint64]raftpb.Entry{
+		125: {
+			Type: raftpb.EntryNormal,
+			Data: encodeProposalEnvelope(1, []byte{0x02, 0xaa}),
+		},
+	})
+	cfg := rawNodeTestConfig()
+	cfg.StateMachine = &volatileTagFakeFSM{}
+
+	rawApplied, err := rawNodeAppliedForOpen(storage, 150, cfg)
+	require.NoError(t, err)
+	require.Equal(t, uint64(124), rawApplied,
+		"RawNode must still deliver volatile duplicate entries for in-memory replay")
+
+	rawNode, err := newRawNode(cfg, storage, rawApplied)
+	require.NoError(t, err)
+	require.True(t, rawNode.HasReady())
+	ready := rawNode.Ready()
+	require.NotEmpty(t, ready.CommittedEntries)
+	require.Equal(t, uint64(125), ready.CommittedEntries[0].Index)
+}
+
+func TestRawNodeAppliedForOpenPreservesConfChangeReplay(t *testing.T) {
+	storage := committedTailStorageWithEntries(t, 100, 150, map[uint64]raftpb.Entry{
+		130: {
+			Type: raftpb.EntryConfChange,
+			Data: []byte("conf"),
+		},
+	})
+	cfg := rawNodeTestConfig()
+
+	rawApplied, err := rawNodeAppliedForOpen(storage, 150, cfg)
+	require.NoError(t, err)
+	require.Equal(t, uint64(129), rawApplied,
+		"RawNode must deliver committed config changes so ApplyConfChange rebuilds membership")
+}
+
 // TestErrNotLeaderMatchesRaftEngineSentinel pins the invariant that the
 // etcd engine's internal leadership-loss errors are marked against the
 // shared raftengine sentinels. The lease-read fast path in package kv


### PR DESCRIPTION
## Summary
- Seed etcd/raft Config.Applied from the cold-start durable applied index.
- Clip the RawNode applied seed to the local committed index so raft accepts it safely.
- Add regression tests for already-applied committed tail restart behavior.

## Verification
- GOCACHE=$(pwd)/.cache GOTMPDIR=$(pwd)/.cache/tmp go test ./internal/raftengine/...
- GOCACHE=$(pwd)/.cache GOTMPDIR=$(pwd)/.cache/tmp go test ./kv
- Deployed elastickv:raft-applied-main-20260704-182012 to n1-n5.
- Raft status: n2 leader, all nodes running with fsm_pending=0.
- SQS lifecycle create/send/receive/delete succeeded.

Author: bootjp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup handling for the Raft engine by preserving the correct applied index during cold start.
  * Prevented duplicate delivery of already committed entries after restart.
  * Added safer bounds checking so applied progress cannot advance beyond what is locally committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->