### PR TITLE
Complete SQS query protocol support

### DIFF
--- a/adapter/sqs.go
+++ b/adapter/sqs.go
@@ -369,7 +369,7 @@ func (s *SQSServer) handle(w http.ResponseWriter, r *http.Request) {
 	// pickSqsProtocol decides between the JSON path (X-Amz-Target +
 	// JSON body, the existing default) and the query path (form-
 	// encoded body, XML response) on a per-request basis. See
-	// docs/design/2026_04_26_proposed_sqs_query_protocol.md for the
+	// docs/design/2026_04_26_partial_sqs_query_protocol.md for the
 	// detection rules.
 	if pickSqsProtocol(r) == sqsProtocolQuery {
 		s.handleQueryProtocol(w, r)

--- a/adapter/sqs.go
+++ b/adapter/sqs.go
@@ -369,7 +369,7 @@ func (s *SQSServer) handle(w http.ResponseWriter, r *http.Request) {
 	// pickSqsProtocol decides between the JSON path (X-Amz-Target +
 	// JSON body, the existing default) and the query path (form-
 	// encoded body, XML response) on a per-request basis. See
-	// docs/design/2026_04_26_partial_sqs_query_protocol.md for the
+	// docs/design/2026_04_26_implemented_sqs_query_protocol.md for the
 	// detection rules.
 	if pickSqsProtocol(r) == sqsProtocolQuery {
 		s.handleQueryProtocol(w, r)

--- a/adapter/sqs_catalog.go
+++ b/adapter/sqs_catalog.go
@@ -1070,9 +1070,17 @@ func (s *SQSServer) deleteQueue(w http.ResponseWriter, r *http.Request) {
 		writeSQSErrorFromErr(w, err)
 		return
 	}
-	if err := s.deleteQueueWithRetry(r.Context(), name); err != nil {
+	if err := s.deleteQueueCore(r.Context(), name); err != nil {
 		writeSQSErrorFromErr(w, err)
 		return
+	}
+	// SQS DeleteQueue returns 200 with an empty body.
+	writeSQSJSON(w, map[string]any{})
+}
+
+func (s *SQSServer) deleteQueueCore(ctx context.Context, name string) error {
+	if err := s.deleteQueueWithRetry(ctx, name); err != nil {
+		return err
 	}
 	// Drop in-memory throttle buckets belonging to this queue so a
 	// same-name CreateQueue immediately after this delete starts with
@@ -1085,11 +1093,9 @@ func (s *SQSServer) deleteQueue(w http.ResponseWriter, r *http.Request) {
 	// Drop the per-queue fanout-rotation counter as well. Without
 	// this, repeated DeleteQueue of unique queue names retains one
 	// receiveFanoutCounters entry per name for the process lifetime
-	// — a leak in multi-tenant / high-churn deployments. Codex P2,
-	// PR #732 round 5.
+	// — a leak in multi-tenant / high-churn deployments.
 	s.dropReceiveFanoutCounter(name)
-	// SQS DeleteQueue returns 200 with an empty body.
-	writeSQSJSON(w, map[string]any{})
+	return nil
 }
 
 func (s *SQSServer) deleteQueueWithRetry(ctx context.Context, queueName string) error {
@@ -1330,32 +1336,37 @@ func (s *SQSServer) getQueueAttributes(w http.ResponseWriter, r *http.Request) {
 		writeSQSErrorFromErr(w, err)
 		return
 	}
-	readTS := s.nextTxnReadTS(r.Context())
-	meta, exists, err := s.loadQueueMetaAt(r.Context(), name, readTS)
+	attrs, err := s.getQueueAttributesCore(r.Context(), name, in.AttributeNames)
 	if err != nil {
 		writeSQSErrorFromErr(w, err)
 		return
 	}
-	if !exists {
-		writeSQSError(w, http.StatusBadRequest, sqsErrQueueDoesNotExist, "queue does not exist")
-		return
+	writeSQSJSON(w, map[string]any{"Attributes": attrs})
+}
+
+func (s *SQSServer) getQueueAttributesCore(ctx context.Context, name string, attributeNames []string) (map[string]string, error) {
+	readTS := s.nextTxnReadTS(ctx)
+	meta, exists, err := s.loadQueueMetaAt(ctx, name, readTS)
+	if err != nil {
+		return nil, err
 	}
-	selection := selectedAttributeNames(in.AttributeNames)
+	if !exists {
+		return nil, newSQSAPIError(http.StatusBadRequest, sqsErrQueueDoesNotExist, "queue does not exist")
+	}
+	selection := selectedAttributeNames(attributeNames)
 	// Counter computation is the only path that touches per-message
 	// state, so skip the scan when the caller did not ask for any of
 	// the Approximate* attributes. AWS itself documents these as
 	// approximate; a snapshot read is correct enough.
 	var counters *sqsApproxCounters
 	if selectionWantsApproxCounters(selection) {
-		c, scanErr := s.scanApproxCounters(r.Context(), name, meta.Generation, readTS)
+		c, scanErr := s.scanApproxCounters(ctx, name, meta.Generation, readTS)
 		if scanErr != nil {
-			writeSQSErrorFromErr(w, scanErr)
-			return
+			return nil, scanErr
 		}
 		counters = &c
 	}
-	attrs := queueMetaToAttributes(meta, selection, counters, s.queueArn(name))
-	writeSQSJSON(w, map[string]any{"Attributes": attrs})
+	return queueMetaToAttributes(meta, selection, counters, s.queueArn(name)), nil
 }
 
 // queueArn synthesises the AWS-shaped ARN clients expect to find on
@@ -1501,18 +1512,24 @@ func (s *SQSServer) setQueueAttributes(w http.ResponseWriter, r *http.Request) {
 		writeSQSErrorFromErr(w, err)
 		return
 	}
+	if err := s.setQueueAttributesCore(r.Context(), name, in.Attributes); err != nil {
+		writeSQSErrorFromErr(w, err)
+		return
+	}
+	writeSQSJSON(w, map[string]any{})
+}
+
+func (s *SQSServer) setQueueAttributesCore(ctx context.Context, name string, attrs map[string]string) error {
 	// AWS marks Attributes as a required parameter on SetQueueAttributes.
 	// Without this check, a client that forgets (or mis-serializes) the
 	// field gets a 200 success and no change — a silent failure that hides
 	// automation bugs. Reject omission with MissingParameter.
-	if len(in.Attributes) == 0 {
-		writeSQSError(w, http.StatusBadRequest, sqsErrMissingParameter, "Attributes is required")
-		return
+	if len(attrs) == 0 {
+		return newSQSAPIError(http.StatusBadRequest, sqsErrMissingParameter, "Attributes is required")
 	}
-	throttleChanged, err := s.setQueueAttributesWithRetry(r.Context(), name, in.Attributes)
+	throttleChanged, err := s.setQueueAttributesWithRetry(ctx, name, attrs)
 	if err != nil {
-		writeSQSErrorFromErr(w, err)
-		return
+		return err
 	}
 	// Drop the in-memory bucket entries belonging to this queue *after*
 	// the Raft commit so the next request rebuilds from the freshly
@@ -1535,7 +1552,7 @@ func (s *SQSServer) setQueueAttributes(w http.ResponseWriter, r *http.Request) {
 	if throttleChanged {
 		s.throttle.invalidateQueue(name)
 	}
-	writeSQSJSON(w, map[string]any{})
+	return nil
 }
 
 func (s *SQSServer) setQueueAttributesWithRetry(ctx context.Context, queueName string, attrs map[string]string) (bool, error) {

--- a/adapter/sqs_catalog.go
+++ b/adapter/sqs_catalog.go
@@ -227,6 +227,11 @@ func newSQSAPIError(status int, errorType string, message string) error {
 }
 
 func writeSQSErrorFromErr(w http.ResponseWriter, err error) {
+	var throttled *sqsThrottlingError
+	if errors.As(err, &throttled) {
+		writeSQSThrottlingError(w, throttled.queue, throttled.action, throttled.retryAfter)
+		return
+	}
 	var apiErr *sqsAPIError
 	if errors.As(err, &apiErr) {
 		writeSQSError(w, apiErr.status, apiErr.errorType, apiErr.message)

--- a/adapter/sqs_keys.go
+++ b/adapter/sqs_keys.go
@@ -10,7 +10,7 @@ import (
 )
 
 // SQS keyspace prefixes. Kept in sync with the naming in
-// docs/design/2026_04_24_proposed_sqs_compatible_adapter.md.
+// docs/design/2026_04_24_partial_sqs_compatible_adapter.md.
 const (
 	// SqsQueueMetaPrefix prefixes queue-metadata records.
 	SqsQueueMetaPrefix = "!sqs|queue|meta|"

--- a/adapter/sqs_messages.go
+++ b/adapter/sqs_messages.go
@@ -558,6 +558,56 @@ func (s *SQSServer) sendMessage(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (s *SQSServer) sendMessageCore(ctx context.Context, queueName string, in sqsSendMessageInput) (map[string]string, error) {
+	meta, readTS, apiErr := s.loadQueueMetaForSend(ctx, queueName, []byte(in.MessageBody))
+	if apiErr != nil {
+		return nil, apiErr
+	}
+	if err := s.chargeQueueWithThrottleErr(queueName, bucketActionSend, 1, meta.Throttle, meta.Incarnation); err != nil {
+		return nil, err
+	}
+	if apiErr := validateMessageAttributes(in.MessageAttributes); apiErr != nil {
+		return nil, apiErr
+	}
+	if apiErr := validateSendFIFOParams(meta, in); apiErr != nil {
+		return nil, apiErr
+	}
+	delay, apiErr := resolveSendDelay(meta, in.DelaySeconds)
+	if apiErr != nil {
+		return nil, apiErr
+	}
+	if meta.IsFIFO {
+		return s.runFifoSendWithRetry(ctx, queueName, in)
+	}
+
+	rec, recordBytes, apiErr := buildSendRecord(meta, in, delay)
+	if apiErr != nil {
+		return nil, apiErr
+	}
+	const partition uint32 = 0
+	dataKey := sqsMsgDataKeyDispatch(meta, queueName, partition, meta.Generation, rec.MessageID)
+	visKey := sqsMsgVisKeyDispatch(meta, queueName, partition, meta.Generation, rec.AvailableAtMillis, rec.MessageID)
+	byAgeKey := sqsMsgByAgeKeyDispatch(meta, queueName, partition, meta.Generation, rec.SendTimestampMillis, rec.MessageID)
+	req := &kv.OperationGroup[kv.OP]{
+		IsTxn:    true,
+		StartTS:  readTS,
+		ReadKeys: [][]byte{sqsQueueMetaKey(queueName), sqsQueueGenKey(queueName)},
+		Elems: []*kv.Elem[kv.OP]{
+			{Op: kv.Put, Key: dataKey, Value: recordBytes},
+			{Op: kv.Put, Key: visKey, Value: []byte(rec.MessageID)},
+			{Op: kv.Put, Key: byAgeKey, Value: []byte(rec.MessageID)},
+		},
+	}
+	if _, err := s.coordinator.Dispatch(ctx, req); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return map[string]string{
+		"MessageId":              rec.MessageID,
+		"MD5OfMessageBody":       rec.MD5OfBody,
+		"MD5OfMessageAttributes": md5OfAttributesHex(in.MessageAttributes),
+	}, nil
+}
+
 // sendMessageFifoLoop runs the dedup-aware OCC send for FIFO queues
 // under the standard retry budget. Stamping the dedup record + new
 // sequence number happens inside one transaction so a concurrent send
@@ -807,6 +857,44 @@ func (s *SQSServer) receiveMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeSQSJSON(w, map[string]any{"Messages": delivered})
+}
+
+func (s *SQSServer) receiveMessageCore(ctx context.Context, queueName string, in sqsReceiveMessageInput) ([]map[string]any, error) {
+	if _, err := kv.LeaseReadThrough(s.coordinator, ctx); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	readTS := s.nextTxnReadTS(ctx)
+	meta, exists, err := s.loadQueueMetaAt(ctx, queueName, readTS)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, newSQSAPIError(http.StatusBadRequest, sqsErrQueueDoesNotExist, "queue does not exist")
+	}
+	if err := s.chargeQueueWithThrottleErr(queueName, bucketActionReceive, 1, meta.Throttle, meta.Incarnation); err != nil {
+		return nil, err
+	}
+	max, maxErr := resolveReceiveMaxMessages(in.MaxNumberOfMessages)
+	if maxErr != nil {
+		return nil, maxErr
+	}
+	visibilityTimeout := meta.VisibilityTimeoutSeconds
+	if in.VisibilityTimeout != nil {
+		if *in.VisibilityTimeout < 0 || *in.VisibilityTimeout > sqsChangeVisibilityMaxSeconds {
+			return nil, newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue, "VisibilityTimeout out of range")
+		}
+		visibilityTimeout = *in.VisibilityTimeout
+	}
+	waitSeconds, waitErr := resolveReceiveWaitSeconds(in.WaitTimeSeconds, meta.ReceiveMessageWaitSeconds)
+	if waitErr != nil {
+		return nil, waitErr
+	}
+	return s.longPollReceive(ctx, queueName, sqsReceiveOptions{
+		Max:                   max,
+		VisibilityTimeout:     visibilityTimeout,
+		WaitSeconds:           waitSeconds,
+		MessageAttributeNames: in.MessageAttributeNames,
+	})
 }
 
 // sqsReceiveOptions bundles the per-request settings that ride down
@@ -1466,6 +1554,13 @@ func (s *SQSServer) deleteMessage(w http.ResponseWriter, r *http.Request) {
 	writeSQSJSON(w, map[string]any{})
 }
 
+func (s *SQSServer) deleteMessageCore(ctx context.Context, queueName string, handle *decodedReceiptHandle) error {
+	if err := s.chargeQueueErr(ctx, queueName, bucketActionReceive, 1); err != nil {
+		return err
+	}
+	return s.deleteMessageWithRetry(ctx, queueName, handle)
+}
+
 // deleteMessageWithRetry runs the load-check-commit flow under one OCC
 // budget. AWS SQS semantics: a stale receipt handle (message already
 // gone, or token rotated by another consumer) is a 200 no-op, NOT an
@@ -1628,6 +1723,16 @@ func (s *SQSServer) changeMessageVisibility(w http.ResponseWriter, r *http.Reque
 		return
 	}
 	writeSQSJSON(w, map[string]any{})
+}
+
+func (s *SQSServer) changeMessageVisibilityCore(ctx context.Context, queueName string, handle *decodedReceiptHandle, timeout int64) error {
+	if timeout < 0 || timeout > sqsChangeVisibilityMaxSeconds {
+		return newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue, "VisibilityTimeout out of range")
+	}
+	if err := s.chargeQueueErr(ctx, queueName, bucketActionReceive, 1); err != nil {
+		return err
+	}
+	return s.changeVisibilityWithRetry(ctx, queueName, handle, timeout)
 }
 
 // changeVisibilityWithRetry runs the validate-and-swap flow under an OCC

--- a/adapter/sqs_messages_batch.go
+++ b/adapter/sqs_messages_batch.go
@@ -110,6 +110,20 @@ func (s *SQSServer) sendMessageBatch(w http.ResponseWriter, r *http.Request) {
 	writeSQSJSON(w, resp)
 }
 
+func (s *SQSServer) sendMessageBatchCore(ctx context.Context, queueName string, entries []sqsSendMessageBatchEntryInput) ([]sqsSendMessageBatchResultEntry, []sqsBatchResultErrorEntry, error) {
+	if err := validateBatchEntryShape(len(entries), batchEntryIDs(entries)); err != nil {
+		return nil, nil, err
+	}
+	if total := totalBatchPayloadBytes(entries); total > sqsBatchMaxTotalPayloadBytes {
+		return nil, nil, newSQSAPIError(http.StatusBadRequest, sqsErrBatchRequestTooLong,
+			"total batch payload exceeds 262144 bytes")
+	}
+	if err := s.chargeQueueErr(ctx, queueName, bucketActionSend, throttleChargeCount(len(entries))); err != nil {
+		return nil, nil, err
+	}
+	return s.sendMessageBatchWithRetry(ctx, queueName, entries)
+}
+
 // sendMessageBatchWithRetry pre-validates every entry, splits them into
 // "will-attempt" and "rejected before storage", and runs one OCC
 // transaction over the will-attempt set. On ErrWriteConflict the whole
@@ -539,6 +553,42 @@ func (s *SQSServer) deleteMessageBatch(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (s *SQSServer) deleteMessageBatchCore(ctx context.Context, queueName string, entries []sqsDeleteMessageBatchEntryInput) ([]sqsBatchResultEntry, []sqsBatchResultErrorEntry, error) {
+	ids := make([]string, 0, len(entries))
+	for _, e := range entries {
+		ids = append(ids, e.Id)
+	}
+	if err := validateBatchEntryShape(len(entries), ids); err != nil {
+		return nil, nil, err
+	}
+	if err := s.requireQueueExists(ctx, queueName); err != nil {
+		return nil, nil, err
+	}
+	if err := s.chargeQueueErr(ctx, queueName, bucketActionReceive, throttleChargeCount(len(entries))); err != nil {
+		return nil, nil, err
+	}
+	successful := make([]sqsBatchResultEntry, 0, len(entries))
+	failed := make([]sqsBatchResultErrorEntry, 0)
+	for _, entry := range entries {
+		handle, decodeErr := decodeClientReceiptHandle(entry.ReceiptHandle)
+		if decodeErr != nil {
+			failed = append(failed, sqsBatchResultErrorEntry{
+				Id:          entry.Id,
+				Code:        sqsErrReceiptHandleInvalid,
+				Message:     "receipt handle is not parseable",
+				SenderFault: true,
+			})
+			continue
+		}
+		if err := s.deleteMessageWithRetry(ctx, queueName, handle); err != nil {
+			failed = append(failed, batchErrorEntryFromErr(entry.Id, err))
+			continue
+		}
+		successful = append(successful, sqsBatchResultEntry{Id: entry.Id})
+	}
+	return successful, failed, nil
+}
+
 // ------------------------ ChangeMessageVisibilityBatch ------------------------
 
 type sqsChangeVisBatchInput struct {
@@ -593,6 +643,33 @@ func (s *SQSServer) changeMessageVisibilityBatch(w http.ResponseWriter, r *http.
 		"Successful": successful,
 		"Failed":     failed,
 	})
+}
+
+func (s *SQSServer) changeMessageVisibilityBatchCore(ctx context.Context, queueName string, entries []sqsChangeVisBatchEntryInput) ([]sqsBatchResultEntry, []sqsBatchResultErrorEntry, error) {
+	ids := make([]string, 0, len(entries))
+	for _, e := range entries {
+		ids = append(ids, e.Id)
+	}
+	if err := validateBatchEntryShape(len(entries), ids); err != nil {
+		return nil, nil, err
+	}
+	if err := s.requireQueueExists(ctx, queueName); err != nil {
+		return nil, nil, err
+	}
+	if err := s.chargeQueueErr(ctx, queueName, bucketActionReceive, throttleChargeCount(len(entries))); err != nil {
+		return nil, nil, err
+	}
+	successful := make([]sqsBatchResultEntry, 0, len(entries))
+	failed := make([]sqsBatchResultErrorEntry, 0)
+	for _, entry := range entries {
+		ok, errEntry := s.applyChangeVisibilityBatchEntry(ctx, queueName, entry)
+		if !ok {
+			failed = append(failed, errEntry)
+			continue
+		}
+		successful = append(successful, sqsBatchResultEntry{Id: entry.Id})
+	}
+	return successful, failed, nil
 }
 
 // applyChangeVisibilityBatchEntry runs the per-entry validate-and-commit

--- a/adapter/sqs_purge.go
+++ b/adapter/sqs_purge.go
@@ -47,11 +47,16 @@ func (s *SQSServer) purgeQueue(w http.ResponseWriter, r *http.Request) {
 		writeSQSErrorFromErr(w, err)
 		return
 	}
-	if _, _, err := s.purgeQueueWithRetry(r.Context(), name); err != nil {
+	if err := s.purgeQueueCore(r.Context(), name); err != nil {
 		writeSQSErrorFromErr(w, err)
 		return
 	}
 	writeSQSJSON(w, map[string]any{})
+}
+
+func (s *SQSServer) purgeQueueCore(ctx context.Context, name string) error {
+	_, _, err := s.purgeQueueWithRetry(ctx, name)
+	return err
 }
 
 // purgeQueueWithRetry runs tryPurgeQueueOnce under the standard OCC

--- a/adapter/sqs_query_protocol.go
+++ b/adapter/sqs_query_protocol.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"crypto/rand"
 	"encoding/base32"
+	"encoding/base64"
 	"encoding/xml"
 	"io"
 	"net/http"
@@ -15,7 +16,7 @@ import (
 )
 
 // SQS query-protocol (form-encoded request, XML response) support per
-// docs/design/2026_04_26_partial_sqs_query_protocol.md. Detection
+// docs/design/2026_04_26_implemented_sqs_query_protocol.md. Detection
 // runs on every inbound SQS request alongside the existing JSON path
 // — no separate listener, no flag. The implementation deliberately
 // touches as little of the JSON path as possible: the SQS handlers
@@ -70,16 +71,23 @@ const (
 type sqsQueryHandler func(*SQSServer, http.ResponseWriter, *http.Request, url.Values)
 
 var sqsQueryHandlers = map[string]sqsQueryHandler{
-	"CreateQueue":        (*SQSServer).handleQueryCreateQueue,
-	"DeleteQueue":        (*SQSServer).handleQueryDeleteQueue,
-	"ListQueues":         (*SQSServer).handleQueryListQueues,
-	"GetQueueUrl":        (*SQSServer).handleQueryGetQueueUrl,
-	"GetQueueAttributes": (*SQSServer).handleQueryGetQueueAttributes,
-	"SetQueueAttributes": (*SQSServer).handleQuerySetQueueAttributes,
-	"PurgeQueue":         (*SQSServer).handleQueryPurgeQueue,
-	"TagQueue":           (*SQSServer).handleQueryTagQueue,
-	"UntagQueue":         (*SQSServer).handleQueryUntagQueue,
-	"ListQueueTags":      (*SQSServer).handleQueryListQueueTags,
+	"CreateQueue":                  (*SQSServer).handleQueryCreateQueue,
+	"DeleteQueue":                  (*SQSServer).handleQueryDeleteQueue,
+	"ListQueues":                   (*SQSServer).handleQueryListQueues,
+	"GetQueueUrl":                  (*SQSServer).handleQueryGetQueueUrl,
+	"GetQueueAttributes":           (*SQSServer).handleQueryGetQueueAttributes,
+	"SetQueueAttributes":           (*SQSServer).handleQuerySetQueueAttributes,
+	"PurgeQueue":                   (*SQSServer).handleQueryPurgeQueue,
+	"SendMessage":                  (*SQSServer).handleQuerySendMessage,
+	"SendMessageBatch":             (*SQSServer).handleQuerySendMessageBatch,
+	"ReceiveMessage":               (*SQSServer).handleQueryReceiveMessage,
+	"DeleteMessage":                (*SQSServer).handleQueryDeleteMessage,
+	"DeleteMessageBatch":           (*SQSServer).handleQueryDeleteMessageBatch,
+	"ChangeMessageVisibility":      (*SQSServer).handleQueryChangeMessageVisibility,
+	"ChangeMessageVisibilityBatch": (*SQSServer).handleQueryChangeMessageVisibilityBatch,
+	"TagQueue":                     (*SQSServer).handleQueryTagQueue,
+	"UntagQueue":                   (*SQSServer).handleQueryUntagQueue,
+	"ListQueueTags":                (*SQSServer).handleQueryListQueueTags,
 }
 
 // pickSqsProtocol decides which wire format a request is using. The
@@ -287,6 +295,129 @@ func (s *SQSServer) handleQueryPurgeQueue(w http.ResponseWriter, r *http.Request
 	writeSQSQueryResponse(w, "PurgeQueue", queryEmptyResult{XMLName: xml.Name{Local: "PurgeQueueResult"}})
 }
 
+func (s *SQSServer) handleQuerySendMessage(w http.ResponseWriter, r *http.Request, form url.Values) {
+	in, err := parseQuerySendMessage(form)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	queueName, err := queueNameFromURL(in.QueueUrl)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	out, err := s.sendMessageCore(r.Context(), queueName, *in)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	writeSQSQueryResponse(w, "SendMessage", querySendMessageResultFromMap(out))
+}
+
+func (s *SQSServer) handleQueryReceiveMessage(w http.ResponseWriter, r *http.Request, form url.Values) {
+	in, err := parseQueryReceiveMessage(form)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	queueName, err := queueNameFromURL(in.QueueUrl)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	messages, err := s.receiveMessageCore(r.Context(), queueName, *in)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	writeSQSQueryResponse(w, "ReceiveMessage", queryReceiveMessageResultFromMaps(messages))
+}
+
+func (s *SQSServer) handleQueryDeleteMessage(w http.ResponseWriter, r *http.Request, form url.Values) {
+	in := parseQueryDeleteMessage(form)
+	queueName, handle, err := s.parseQueueAndReceipt(in.QueueUrl, in.ReceiptHandle)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	if err := s.deleteMessageCore(r.Context(), queueName, handle); err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	writeSQSQueryResponse(w, "DeleteMessage", queryEmptyResult{XMLName: xml.Name{Local: "DeleteMessageResult"}})
+}
+
+func (s *SQSServer) handleQueryChangeMessageVisibility(w http.ResponseWriter, r *http.Request, form url.Values) {
+	in, err := parseQueryChangeMessageVisibility(form)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	queueName, handle, err := s.parseQueueAndReceipt(in.QueueUrl, in.ReceiptHandle)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	if err := s.changeMessageVisibilityCore(r.Context(), queueName, handle, *in.VisibilityTimeout); err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	writeSQSQueryResponse(w, "ChangeMessageVisibility", queryEmptyResult{XMLName: xml.Name{Local: "ChangeMessageVisibilityResult"}})
+}
+
+func (s *SQSServer) handleQuerySendMessageBatch(w http.ResponseWriter, r *http.Request, form url.Values) {
+	in, err := parseQuerySendMessageBatch(form)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	queueName, err := queueNameFromURL(in.QueueUrl)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	successful, failed, err := s.sendMessageBatchCore(r.Context(), queueName, in.Entries)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	writeSQSQueryResponse(w, "SendMessageBatch", querySendMessageBatchResultFromEntries(successful, failed))
+}
+
+func (s *SQSServer) handleQueryDeleteMessageBatch(w http.ResponseWriter, r *http.Request, form url.Values) {
+	in := parseQueryDeleteMessageBatch(form)
+	queueName, err := queueNameFromURL(in.QueueUrl)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	successful, failed, err := s.deleteMessageBatchCore(r.Context(), queueName, in.Entries)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	writeSQSQueryResponse(w, "DeleteMessageBatch", queryDeleteMessageBatchResultFromEntries(successful, failed))
+}
+
+func (s *SQSServer) handleQueryChangeMessageVisibilityBatch(w http.ResponseWriter, r *http.Request, form url.Values) {
+	in, err := parseQueryChangeMessageVisibilityBatch(form)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	queueName, err := queueNameFromURL(in.QueueUrl)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	successful, failed, err := s.changeMessageVisibilityBatchCore(r.Context(), queueName, in.Entries)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	writeSQSQueryResponse(w, "ChangeMessageVisibilityBatch", queryChangeMessageVisibilityBatchResultFromEntries(successful, failed))
+}
+
 func (s *SQSServer) handleQueryTagQueue(w http.ResponseWriter, r *http.Request, form url.Values) {
 	in := parseQueryTagQueue(form)
 	queueName, err := queueNameFromURL(in.QueueUrl)
@@ -418,6 +549,238 @@ func parseQueryListQueueTags(form url.Values) *sqsListQueueTagsInput {
 	return &sqsListQueueTagsInput{
 		QueueUrl: strings.TrimSpace(form.Get("QueueUrl")),
 	}
+}
+
+func parseQuerySendMessage(form url.Values) (*sqsSendMessageInput, error) {
+	delay, err := parseOptionalQueryInt64(form, "DelaySeconds")
+	if err != nil {
+		return nil, err
+	}
+	attrs, err := parseQueryMessageAttributes(form, "MessageAttribute")
+	if err != nil {
+		return nil, err
+	}
+	return &sqsSendMessageInput{
+		QueueUrl:               strings.TrimSpace(form.Get("QueueUrl")),
+		MessageBody:            form.Get("MessageBody"),
+		DelaySeconds:           delay,
+		MessageAttributes:      attrs,
+		MessageGroupId:         form.Get("MessageGroupId"),
+		MessageDeduplicationId: form.Get("MessageDeduplicationId"),
+	}, nil
+}
+
+func parseQueryReceiveMessage(form url.Values) (*sqsReceiveMessageInput, error) {
+	max, err := parseOptionalQueryInt(form, "MaxNumberOfMessages")
+	if err != nil {
+		return nil, err
+	}
+	visibility, err := parseOptionalQueryInt64(form, "VisibilityTimeout")
+	if err != nil {
+		return nil, err
+	}
+	wait, err := parseOptionalQueryInt64(form, "WaitTimeSeconds")
+	if err != nil {
+		return nil, err
+	}
+	return &sqsReceiveMessageInput{
+		QueueUrl:              strings.TrimSpace(form.Get("QueueUrl")),
+		MaxNumberOfMessages:   max,
+		VisibilityTimeout:     visibility,
+		WaitTimeSeconds:       wait,
+		MessageAttributeNames: collectIndexedValues(form, "MessageAttributeName"),
+	}, nil
+}
+
+func parseQueryDeleteMessage(form url.Values) *sqsDeleteMessageInput {
+	return &sqsDeleteMessageInput{
+		QueueUrl:      strings.TrimSpace(form.Get("QueueUrl")),
+		ReceiptHandle: form.Get("ReceiptHandle"),
+	}
+}
+
+func parseQueryChangeMessageVisibility(form url.Values) (*sqsChangeVisibilityInput, error) {
+	timeout, err := parseRequiredQueryInt64(form, "VisibilityTimeout")
+	if err != nil {
+		return nil, err
+	}
+	return &sqsChangeVisibilityInput{
+		QueueUrl:          strings.TrimSpace(form.Get("QueueUrl")),
+		ReceiptHandle:     form.Get("ReceiptHandle"),
+		VisibilityTimeout: timeout,
+	}, nil
+}
+
+func parseQuerySendMessageBatch(form url.Values) (*sqsSendMessageBatchInput, error) {
+	entries := make([]sqsSendMessageBatchEntryInput, 0)
+	for _, idx := range collectQueryEntryIndices(form, "SendMessageBatchRequestEntry") {
+		prefix := "SendMessageBatchRequestEntry." + strconv.Itoa(idx)
+		delay, err := parseOptionalQueryInt64At(form, prefix+".DelaySeconds")
+		if err != nil {
+			return nil, err
+		}
+		attrs, err := parseQueryMessageAttributes(form, prefix+".MessageAttribute")
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, sqsSendMessageBatchEntryInput{
+			Id:                     form.Get(prefix + ".Id"),
+			MessageBody:            form.Get(prefix + ".MessageBody"),
+			DelaySeconds:           delay,
+			MessageAttributes:      attrs,
+			MessageGroupId:         form.Get(prefix + ".MessageGroupId"),
+			MessageDeduplicationId: form.Get(prefix + ".MessageDeduplicationId"),
+		})
+	}
+	return &sqsSendMessageBatchInput{
+		QueueUrl: strings.TrimSpace(form.Get("QueueUrl")),
+		Entries:  entries,
+	}, nil
+}
+
+func parseQueryDeleteMessageBatch(form url.Values) *sqsDeleteMessageBatchInput {
+	entries := make([]sqsDeleteMessageBatchEntryInput, 0)
+	for _, idx := range collectQueryEntryIndices(form, "DeleteMessageBatchRequestEntry") {
+		prefix := "DeleteMessageBatchRequestEntry." + strconv.Itoa(idx)
+		entries = append(entries, sqsDeleteMessageBatchEntryInput{
+			Id:            form.Get(prefix + ".Id"),
+			ReceiptHandle: form.Get(prefix + ".ReceiptHandle"),
+		})
+	}
+	return &sqsDeleteMessageBatchInput{
+		QueueUrl: strings.TrimSpace(form.Get("QueueUrl")),
+		Entries:  entries,
+	}
+}
+
+func parseQueryChangeMessageVisibilityBatch(form url.Values) (*sqsChangeVisBatchInput, error) {
+	entries := make([]sqsChangeVisBatchEntryInput, 0)
+	for _, idx := range collectQueryEntryIndices(form, "ChangeMessageVisibilityBatchRequestEntry") {
+		prefix := "ChangeMessageVisibilityBatchRequestEntry." + strconv.Itoa(idx)
+		timeout, err := parseRequiredQueryInt64At(form, prefix+".VisibilityTimeout")
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, sqsChangeVisBatchEntryInput{
+			Id:                form.Get(prefix + ".Id"),
+			ReceiptHandle:     form.Get(prefix + ".ReceiptHandle"),
+			VisibilityTimeout: timeout,
+		})
+	}
+	return &sqsChangeVisBatchInput{
+		QueueUrl: strings.TrimSpace(form.Get("QueueUrl")),
+		Entries:  entries,
+	}, nil
+}
+
+func parseOptionalQueryInt(form url.Values, name string) (*int, error) {
+	v, err := parseOptionalQueryInt64(form, name)
+	if err != nil || v == nil {
+		return nil, err
+	}
+	n := int(*v)
+	if int64(n) != *v {
+		return nil, newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue, name+" is out of range")
+	}
+	return &n, nil
+}
+
+func parseOptionalQueryInt64(form url.Values, name string) (*int64, error) {
+	return parseOptionalQueryInt64At(form, name)
+}
+
+func parseOptionalQueryInt64At(form url.Values, key string) (*int64, error) {
+	raw := strings.TrimSpace(form.Get(key))
+	if raw == "" {
+		return nil, nil
+	}
+	n, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return nil, newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue, key+" must be an integer")
+	}
+	return &n, nil
+}
+
+func parseRequiredQueryInt64(form url.Values, name string) (*int64, error) {
+	return parseRequiredQueryInt64At(form, name)
+}
+
+func parseRequiredQueryInt64At(form url.Values, key string) (*int64, error) {
+	v, err := parseOptionalQueryInt64At(form, key)
+	if err != nil {
+		return nil, err
+	}
+	if v == nil {
+		return nil, newSQSAPIError(http.StatusBadRequest, sqsErrMissingParameter, key+" is required")
+	}
+	return v, nil
+}
+
+func parseQueryMessageAttributes(form url.Values, prefix string) (map[string]sqsMessageAttributeValue, error) {
+	indices := collectQueryEntryIndices(form, prefix)
+	if len(indices) == 0 {
+		return nil, nil
+	}
+	attrs := make(map[string]sqsMessageAttributeValue, len(indices))
+	for _, idx := range indices {
+		itemPrefix := prefix + "." + strconv.Itoa(idx)
+		name := form.Get(itemPrefix + ".Name")
+		if name == "" {
+			continue
+		}
+		valuePrefix := itemPrefix + ".Value"
+		attr := sqsMessageAttributeValue{
+			DataType:    form.Get(valuePrefix + ".DataType"),
+			StringValue: form.Get(valuePrefix + ".StringValue"),
+		}
+		if raw := form.Get(valuePrefix + ".BinaryValue"); raw != "" {
+			decoded, err := base64.StdEncoding.DecodeString(raw)
+			if err != nil {
+				return nil, newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue,
+					itemPrefix+".Value.BinaryValue must be base64 encoded")
+			}
+			attr.BinaryValue = decoded
+		}
+		if _, exists := attrs[name]; !exists {
+			attrs[name] = attr
+		}
+	}
+	if len(attrs) == 0 {
+		return nil, nil
+	}
+	return attrs, nil
+}
+
+func collectQueryEntryIndices(form url.Values, prefix string) []int {
+	if len(form) == 0 {
+		return nil
+	}
+	wantPrefix := prefix + "."
+	seen := map[int]bool{}
+	for key := range form {
+		if !strings.HasPrefix(key, wantPrefix) {
+			continue
+		}
+		rest := strings.TrimPrefix(key, wantPrefix)
+		dot := strings.IndexByte(rest, '.')
+		if dot < 0 {
+			continue
+		}
+		idx, err := strconv.Atoi(rest[:dot])
+		if err != nil || idx <= 0 {
+			continue
+		}
+		seen[idx] = true
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]int, 0, len(seen))
+	for idx := range seen {
+		out = append(out, idx)
+	}
+	sort.Ints(out)
+	return out
 }
 
 // collectIndexedValues reads AWS-style indexed values of the form
@@ -641,6 +1004,214 @@ func queryTagPairs(tags map[string]string) []queryTagPair {
 	return out
 }
 
+type querySendMessageResult struct {
+	XMLName                xml.Name `xml:"SendMessageResult"`
+	MessageId              string   `xml:"MessageId"`
+	MD5OfMessageBody       string   `xml:"MD5OfMessageBody"`
+	MD5OfMessageAttributes string   `xml:"MD5OfMessageAttributes,omitempty"`
+	SequenceNumber         string   `xml:"SequenceNumber,omitempty"`
+}
+
+func querySendMessageResultFromMap(out map[string]string) querySendMessageResult {
+	return querySendMessageResult{
+		MessageId:              out["MessageId"],
+		MD5OfMessageBody:       out["MD5OfMessageBody"],
+		MD5OfMessageAttributes: out["MD5OfMessageAttributes"],
+		SequenceNumber:         out["SequenceNumber"],
+	}
+}
+
+type queryReceiveMessageResult struct {
+	XMLName  xml.Name       `xml:"ReceiveMessageResult"`
+	Messages []queryMessage `xml:"Message,omitempty"`
+}
+
+type queryMessage struct {
+	MessageId              string                      `xml:"MessageId"`
+	ReceiptHandle          string                      `xml:"ReceiptHandle"`
+	MD5OfBody              string                      `xml:"MD5OfBody"`
+	Body                   string                      `xml:"Body"`
+	Attributes             []queryAttributePair        `xml:"Attribute,omitempty"`
+	MD5OfMessageAttributes string                      `xml:"MD5OfMessageAttributes,omitempty"`
+	MessageAttributes      []queryMessageAttributePair `xml:"MessageAttribute,omitempty"`
+}
+
+type queryMessageAttributePair struct {
+	Name  string                     `xml:"Name"`
+	Value queryMessageAttributeValue `xml:"Value"`
+}
+
+type queryMessageAttributeValue struct {
+	DataType    string `xml:"DataType"`
+	StringValue string `xml:"StringValue,omitempty"`
+	BinaryValue string `xml:"BinaryValue,omitempty"`
+}
+
+func queryReceiveMessageResultFromMaps(messages []map[string]any) queryReceiveMessageResult {
+	out := queryReceiveMessageResult{Messages: make([]queryMessage, 0, len(messages))}
+	for _, m := range messages {
+		qm := queryMessage{
+			MessageId:              stringValueFromAny(m["MessageId"]),
+			ReceiptHandle:          stringValueFromAny(m["ReceiptHandle"]),
+			MD5OfBody:              stringValueFromAny(m["MD5OfBody"]),
+			Body:                   stringValueFromAny(m["Body"]),
+			MD5OfMessageAttributes: stringValueFromAny(m["MD5OfMessageAttributes"]),
+			Attributes:             queryAttributePairs(stringMapFromAny(m["Attributes"])),
+			MessageAttributes:      queryMessageAttributePairs(messageAttributesFromAny(m["MessageAttributes"])),
+		}
+		out.Messages = append(out.Messages, qm)
+	}
+	return out
+}
+
+func queryMessageAttributePairs(attrs map[string]sqsMessageAttributeValue) []queryMessageAttributePair {
+	if len(attrs) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(attrs))
+	for name := range attrs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]queryMessageAttributePair, 0, len(names))
+	for _, name := range names {
+		attr := attrs[name]
+		value := queryMessageAttributeValue{
+			DataType:    attr.DataType,
+			StringValue: attr.StringValue,
+		}
+		if len(attr.BinaryValue) > 0 {
+			value.BinaryValue = base64.StdEncoding.EncodeToString(attr.BinaryValue)
+		}
+		out = append(out, queryMessageAttributePair{Name: name, Value: value})
+	}
+	return out
+}
+
+type querySendMessageBatchResult struct {
+	XMLName    xml.Name                           `xml:"SendMessageBatchResult"`
+	Successful []querySendMessageBatchResultEntry `xml:"SendMessageBatchResultEntry,omitempty"`
+	Failed     []queryBatchResultErrorEntry       `xml:"BatchResultErrorEntry,omitempty"`
+}
+
+type querySendMessageBatchResultEntry struct {
+	Id                     string `xml:"Id"`
+	MessageId              string `xml:"MessageId"`
+	MD5OfMessageBody       string `xml:"MD5OfMessageBody"`
+	MD5OfMessageAttributes string `xml:"MD5OfMessageAttributes,omitempty"`
+	SequenceNumber         string `xml:"SequenceNumber,omitempty"`
+}
+
+func querySendMessageBatchResultFromEntries(successful []sqsSendMessageBatchResultEntry, failed []sqsBatchResultErrorEntry) querySendMessageBatchResult {
+	out := querySendMessageBatchResult{
+		Successful: make([]querySendMessageBatchResultEntry, 0, len(successful)),
+		Failed:     queryBatchErrorEntries(failed),
+	}
+	for _, e := range successful {
+		out.Successful = append(out.Successful, querySendMessageBatchResultEntry(e))
+	}
+	return out
+}
+
+type queryDeleteMessageBatchResult struct {
+	XMLName    xml.Name                     `xml:"DeleteMessageBatchResult"`
+	Successful []queryBatchResultEntry      `xml:"DeleteMessageBatchResultEntry,omitempty"`
+	Failed     []queryBatchResultErrorEntry `xml:"BatchResultErrorEntry,omitempty"`
+}
+
+type queryChangeMessageVisibilityBatchResult struct {
+	XMLName    xml.Name                     `xml:"ChangeMessageVisibilityBatchResult"`
+	Successful []queryBatchResultEntry      `xml:"ChangeMessageVisibilityBatchResultEntry,omitempty"`
+	Failed     []queryBatchResultErrorEntry `xml:"BatchResultErrorEntry,omitempty"`
+}
+
+type queryBatchResultEntry struct {
+	Id string `xml:"Id"`
+}
+
+type queryBatchResultErrorEntry struct {
+	Id          string `xml:"Id"`
+	SenderFault bool   `xml:"SenderFault"`
+	Code        string `xml:"Code"`
+	Message     string `xml:"Message"`
+}
+
+func queryDeleteMessageBatchResultFromEntries(successful []sqsBatchResultEntry, failed []sqsBatchResultErrorEntry) queryDeleteMessageBatchResult {
+	return queryDeleteMessageBatchResult{
+		Successful: queryBatchResultEntries(successful),
+		Failed:     queryBatchErrorEntries(failed),
+	}
+}
+
+func queryChangeMessageVisibilityBatchResultFromEntries(successful []sqsBatchResultEntry, failed []sqsBatchResultErrorEntry) queryChangeMessageVisibilityBatchResult {
+	return queryChangeMessageVisibilityBatchResult{
+		Successful: queryBatchResultEntries(successful),
+		Failed:     queryBatchErrorEntries(failed),
+	}
+}
+
+func queryBatchResultEntries(entries []sqsBatchResultEntry) []queryBatchResultEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]queryBatchResultEntry, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, queryBatchResultEntry(e))
+	}
+	return out
+}
+
+func queryBatchErrorEntries(entries []sqsBatchResultErrorEntry) []queryBatchResultErrorEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]queryBatchResultErrorEntry, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, queryBatchResultErrorEntry{
+			Id:          e.Id,
+			SenderFault: e.SenderFault,
+			Code:        e.Code,
+			Message:     e.Message,
+		})
+	}
+	return out
+}
+
+func stringValueFromAny(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	default:
+		return ""
+	}
+}
+
+func stringMapFromAny(v any) map[string]string {
+	switch t := v.(type) {
+	case map[string]string:
+		return t
+	case map[string]any:
+		out := make(map[string]string, len(t))
+		for k, val := range t {
+			if s, ok := val.(string); ok {
+				out[k] = s
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func messageAttributesFromAny(v any) map[string]sqsMessageAttributeValue {
+	switch t := v.(type) {
+	case map[string]sqsMessageAttributeValue:
+		return t
+	default:
+		return nil
+	}
+}
+
 // queryResponseEnvelope wraps the per-verb result in the AWS
 // outer-envelope shape:
 //
@@ -708,8 +1279,16 @@ func writeSQSQueryError(w http.ResponseWriter, err error) {
 	status := http.StatusInternalServerError
 	code := sqsErrInternalFailure
 	message := "internal error"
+	retryAfter := 0
+	var throttled *sqsThrottlingError
+	if errors.As(err, &throttled) {
+		status = http.StatusBadRequest
+		code = sqsErrThrottling
+		message = throttled.Error()
+		retryAfter = throttled.retryAfterSeconds()
+	}
 	var apiErr *sqsAPIError
-	if errors.As(err, &apiErr) {
+	if retryAfter == 0 && errors.As(err, &apiErr) {
 		status = apiErr.status
 		if apiErr.errorType != "" {
 			code = apiErr.errorType
@@ -735,6 +1314,9 @@ func writeSQSQueryError(w http.ResponseWriter, err error) {
 	w.Header().Set("x-amzn-RequestId", env.RequestId)
 	if code != "" {
 		w.Header().Set("x-amzn-ErrorType", code)
+	}
+	if retryAfter > 0 {
+		w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
 	}
 	w.WriteHeader(status)
 	_, _ = w.Write([]byte(xml.Header))

--- a/adapter/sqs_query_protocol.go
+++ b/adapter/sqs_query_protocol.go
@@ -15,7 +15,7 @@ import (
 )
 
 // SQS query-protocol (form-encoded request, XML response) support per
-// docs/design/2026_04_26_proposed_sqs_query_protocol.md. Detection
+// docs/design/2026_04_26_partial_sqs_query_protocol.md. Detection
 // runs on every inbound SQS request alongside the existing JSON path
 // — no separate listener, no flag. The implementation deliberately
 // touches as little of the JSON path as possible: the SQS handlers
@@ -67,6 +67,21 @@ const (
 	sqsProtocolUnknown
 )
 
+type sqsQueryHandler func(*SQSServer, http.ResponseWriter, *http.Request, url.Values)
+
+var sqsQueryHandlers = map[string]sqsQueryHandler{
+	"CreateQueue":        (*SQSServer).handleQueryCreateQueue,
+	"DeleteQueue":        (*SQSServer).handleQueryDeleteQueue,
+	"ListQueues":         (*SQSServer).handleQueryListQueues,
+	"GetQueueUrl":        (*SQSServer).handleQueryGetQueueUrl,
+	"GetQueueAttributes": (*SQSServer).handleQueryGetQueueAttributes,
+	"SetQueueAttributes": (*SQSServer).handleQuerySetQueueAttributes,
+	"PurgeQueue":         (*SQSServer).handleQueryPurgeQueue,
+	"TagQueue":           (*SQSServer).handleQueryTagQueue,
+	"UntagQueue":         (*SQSServer).handleQueryUntagQueue,
+	"ListQueueTags":      (*SQSServer).handleQueryListQueueTags,
+}
+
 // pickSqsProtocol decides which wire format a request is using. The
 // rules are documented in §3 of the design doc:
 //
@@ -117,24 +132,19 @@ func (s *SQSServer) handleQuery(w http.ResponseWriter, r *http.Request) {
 		writeSQSError(w, http.StatusBadRequest, sqsErrMissingParameter, "Action is required")
 		return
 	}
-	switch action {
-	case "CreateQueue":
-		s.handleQueryCreateQueue(w, r, form)
-	case "ListQueues":
-		s.handleQueryListQueues(w, r, form)
-	case "GetQueueUrl":
-		s.handleQueryGetQueueUrl(w, r, form)
-	default:
-		// Per design §4.1: every wired verb appears here; everything
-		// else returns 501 NotImplementedYet so operators see the
-		// gap explicitly rather than the request silently failing
-		// against the JSON dispatch table.
-		writeSQSQueryError(w, newSQSAPIError(
-			http.StatusNotImplemented,
-			"NotImplementedYet",
-			"query-protocol Action "+action+" is not yet wired in elastickv (Phase 3.B follow-up)",
-		))
+	if h := sqsQueryHandlers[action]; h != nil {
+		h(s, w, r, form)
+		return
 	}
+	// Per design §4.1: every wired verb appears in sqsQueryHandlers;
+	// everything else returns 501 NotImplementedYet so operators see
+	// the gap explicitly rather than the request silently failing
+	// against the JSON dispatch table.
+	writeSQSQueryError(w, newSQSAPIError(
+		http.StatusNotImplemented,
+		"NotImplementedYet",
+		"query-protocol Action "+action+" is not yet wired in elastickv (Phase 3.B follow-up)",
+	))
 }
 
 // readQueryForm extracts the form values from either the request
@@ -189,6 +199,20 @@ func (s *SQSServer) handleQueryCreateQueue(w http.ResponseWriter, r *http.Reques
 	})
 }
 
+func (s *SQSServer) handleQueryDeleteQueue(w http.ResponseWriter, r *http.Request, form url.Values) {
+	in := parseQueryDeleteQueue(form)
+	queueName, err := queueNameFromURL(in.QueueUrl)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	if err := s.deleteQueueCore(r.Context(), queueName); err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	writeSQSQueryResponse(w, "DeleteQueue", queryEmptyResult{XMLName: xml.Name{Local: "DeleteQueueResult"}})
+}
+
 func (s *SQSServer) handleQueryListQueues(w http.ResponseWriter, r *http.Request, form url.Values) {
 	in := parseQueryListQueues(form)
 	page, nextToken, err := s.listQueuesCore(r.Context(), in)
@@ -218,6 +242,96 @@ func (s *SQSServer) handleQueryGetQueueUrl(w http.ResponseWriter, r *http.Reques
 	})
 }
 
+func (s *SQSServer) handleQueryGetQueueAttributes(w http.ResponseWriter, r *http.Request, form url.Values) {
+	in := parseQueryGetQueueAttributes(form)
+	queueName, err := queueNameFromURL(in.QueueUrl)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	attrs, err := s.getQueueAttributesCore(r.Context(), queueName, in.AttributeNames)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	writeSQSQueryResponse(w, "GetQueueAttributes", queryGetQueueAttributesResult{
+		Attributes: queryAttributePairs(attrs),
+	})
+}
+
+func (s *SQSServer) handleQuerySetQueueAttributes(w http.ResponseWriter, r *http.Request, form url.Values) {
+	in := parseQuerySetQueueAttributes(form)
+	queueName, err := queueNameFromURL(in.QueueUrl)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	if err := s.setQueueAttributesCore(r.Context(), queueName, in.Attributes); err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	writeSQSQueryResponse(w, "SetQueueAttributes", queryEmptyResult{XMLName: xml.Name{Local: "SetQueueAttributesResult"}})
+}
+
+func (s *SQSServer) handleQueryPurgeQueue(w http.ResponseWriter, r *http.Request, form url.Values) {
+	in := parseQueryPurgeQueue(form)
+	queueName, err := queueNameFromURL(in.QueueUrl)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	if err := s.purgeQueueCore(r.Context(), queueName); err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	writeSQSQueryResponse(w, "PurgeQueue", queryEmptyResult{XMLName: xml.Name{Local: "PurgeQueueResult"}})
+}
+
+func (s *SQSServer) handleQueryTagQueue(w http.ResponseWriter, r *http.Request, form url.Values) {
+	in := parseQueryTagQueue(form)
+	queueName, err := queueNameFromURL(in.QueueUrl)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	if err := s.tagQueueCore(r.Context(), queueName, in.Tags); err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	writeSQSQueryResponse(w, "TagQueue", queryEmptyResult{XMLName: xml.Name{Local: "TagQueueResult"}})
+}
+
+func (s *SQSServer) handleQueryUntagQueue(w http.ResponseWriter, r *http.Request, form url.Values) {
+	in := parseQueryUntagQueue(form)
+	queueName, err := queueNameFromURL(in.QueueUrl)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	if err := s.untagQueueCore(r.Context(), queueName, in.TagKeys); err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	writeSQSQueryResponse(w, "UntagQueue", queryEmptyResult{XMLName: xml.Name{Local: "UntagQueueResult"}})
+}
+
+func (s *SQSServer) handleQueryListQueueTags(w http.ResponseWriter, r *http.Request, form url.Values) {
+	in := parseQueryListQueueTags(form)
+	queueName, err := queueNameFromURL(in.QueueUrl)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	tags, err := s.listQueueTagsCore(r.Context(), queueName)
+	if err != nil {
+		writeSQSQueryError(w, err)
+		return
+	}
+	writeSQSQueryResponse(w, "ListQueueTags", queryListQueueTagsResult{
+		Tags: queryTagPairs(tags),
+	})
+}
+
 // ----------- form parsers -----------
 
 func parseQueryCreateQueue(form url.Values) (*sqsCreateQueueInput, error) {
@@ -235,6 +349,12 @@ func parseQueryCreateQueue(form url.Values) (*sqsCreateQueueInput, error) {
 	// vocabulary for that resource.
 	in.Tags = collectIndexedKVPairs(form, "Tag", "Key")
 	return in, nil
+}
+
+func parseQueryDeleteQueue(form url.Values) *sqsDeleteQueueInput {
+	return &sqsDeleteQueueInput{
+		QueueUrl: strings.TrimSpace(form.Get("QueueUrl")),
+	}
 }
 
 func parseQueryListQueues(form url.Values) *sqsListQueuesInput {
@@ -258,6 +378,92 @@ func parseQueryGetQueueUrl(form url.Values) *sqsGetQueueUrlInput {
 	return &sqsGetQueueUrlInput{
 		QueueName: strings.TrimSpace(form.Get("QueueName")),
 	}
+}
+
+func parseQueryGetQueueAttributes(form url.Values) *sqsGetQueueAttributesInput {
+	return &sqsGetQueueAttributesInput{
+		QueueUrl:       strings.TrimSpace(form.Get("QueueUrl")),
+		AttributeNames: collectIndexedValues(form, "AttributeName"),
+	}
+}
+
+func parseQuerySetQueueAttributes(form url.Values) *sqsSetQueueAttributesInput {
+	return &sqsSetQueueAttributesInput{
+		QueueUrl:   strings.TrimSpace(form.Get("QueueUrl")),
+		Attributes: collectIndexedKVPairs(form, "Attribute", "Name"),
+	}
+}
+
+func parseQueryPurgeQueue(form url.Values) *sqsPurgeQueueInput {
+	return &sqsPurgeQueueInput{
+		QueueUrl: strings.TrimSpace(form.Get("QueueUrl")),
+	}
+}
+
+func parseQueryTagQueue(form url.Values) *sqsTagQueueInput {
+	return &sqsTagQueueInput{
+		QueueUrl: strings.TrimSpace(form.Get("QueueUrl")),
+		Tags:     collectIndexedKVPairs(form, "Tag", "Key"),
+	}
+}
+
+func parseQueryUntagQueue(form url.Values) *sqsUntagQueueInput {
+	return &sqsUntagQueueInput{
+		QueueUrl: strings.TrimSpace(form.Get("QueueUrl")),
+		TagKeys:  collectIndexedValues(form, "TagKey"),
+	}
+}
+
+func parseQueryListQueueTags(form url.Values) *sqsListQueueTagsInput {
+	return &sqsListQueueTagsInput{
+		QueueUrl: strings.TrimSpace(form.Get("QueueUrl")),
+	}
+}
+
+// collectIndexedValues reads AWS-style indexed values of the form
+// "<prefix>.1=value1&<prefix>.2=value2". A repeated unindexed
+// "<prefix>=value" is accepted first as a compatibility courtesy for
+// hand-rolled clients; SDK-generated query requests use indexed keys.
+func collectIndexedValues(form url.Values, prefix string) []string {
+	if len(form) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(form[prefix]))
+	for _, v := range form[prefix] {
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	indexed := gatherIndexedValues(form, prefix)
+	for _, item := range indexed {
+		out = append(out, item.val)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+type indexedValue struct {
+	idx int
+	val string
+}
+
+func gatherIndexedValues(form url.Values, prefix string) []indexedValue {
+	var indexed []indexedValue
+	wantPrefix := prefix + "."
+	for k, vs := range form {
+		if !strings.HasPrefix(k, wantPrefix) {
+			continue
+		}
+		idx, err := strconv.Atoi(strings.TrimPrefix(k, wantPrefix))
+		if err != nil || len(vs) == 0 || vs[0] == "" {
+			continue
+		}
+		indexed = append(indexed, indexedValue{idx: idx, val: vs[0]})
+	}
+	sort.Slice(indexed, func(i, j int) bool { return indexed[i].idx < indexed[j].idx })
+	return indexed
 }
 
 // collectIndexedKVPairs reads AWS-style indexed pairs of the form
@@ -368,6 +574,10 @@ type queryCreateQueueResult struct {
 	QueueUrl string   `xml:"QueueUrl"`
 }
 
+type queryEmptyResult struct {
+	XMLName xml.Name
+}
+
 type queryListQueuesResult struct {
 	XMLName   xml.Name `xml:"ListQueuesResult"`
 	QueueUrl  []string `xml:"QueueUrl"`
@@ -377,6 +587,58 @@ type queryListQueuesResult struct {
 type queryGetQueueUrlResult struct {
 	XMLName  xml.Name `xml:"GetQueueUrlResult"`
 	QueueUrl string   `xml:"QueueUrl"`
+}
+
+type queryGetQueueAttributesResult struct {
+	XMLName    xml.Name             `xml:"GetQueueAttributesResult"`
+	Attributes []queryAttributePair `xml:"Attribute,omitempty"`
+}
+
+type queryAttributePair struct {
+	Name  string `xml:"Name"`
+	Value string `xml:"Value"`
+}
+
+func queryAttributePairs(attrs map[string]string) []queryAttributePair {
+	if len(attrs) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(attrs))
+	for k := range attrs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]queryAttributePair, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, queryAttributePair{Name: k, Value: attrs[k]})
+	}
+	return out
+}
+
+type queryListQueueTagsResult struct {
+	XMLName xml.Name       `xml:"ListQueueTagsResult"`
+	Tags    []queryTagPair `xml:"Tag,omitempty"`
+}
+
+type queryTagPair struct {
+	Key   string `xml:"Key"`
+	Value string `xml:"Value"`
+}
+
+func queryTagPairs(tags map[string]string) []queryTagPair {
+	if len(tags) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]queryTagPair, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, queryTagPair{Key: k, Value: tags[k]})
+	}
+	return out
 }
 
 // queryResponseEnvelope wraps the per-verb result in the AWS

--- a/adapter/sqs_query_protocol.go
+++ b/adapter/sqs_query_protocol.go
@@ -140,6 +140,7 @@ func (s *SQSServer) handleQuery(w http.ResponseWriter, r *http.Request) {
 		writeSQSError(w, http.StatusBadRequest, sqsErrMissingParameter, "Action is required")
 		return
 	}
+	s.fillQueryQueueURLFromPath(r, form)
 	if h := sqsQueryHandlers[action]; h != nil {
 		h(s, w, r, form)
 		return
@@ -153,6 +154,29 @@ func (s *SQSServer) handleQuery(w http.ResponseWriter, r *http.Request) {
 		"NotImplementedYet",
 		"query-protocol Action "+action+" is not yet wired in elastickv (Phase 3.B follow-up)",
 	))
+}
+
+func (s *SQSServer) fillQueryQueueURLFromPath(r *http.Request, form url.Values) {
+	if strings.TrimSpace(form.Get("QueueUrl")) != "" {
+		return
+	}
+	queueName := queryQueueNameFromRequestPath(r)
+	if queueName == "" {
+		return
+	}
+	form.Set("QueueUrl", s.queueURL(r, queueName))
+}
+
+func queryQueueNameFromRequestPath(r *http.Request) string {
+	if r == nil || r.URL == nil {
+		return ""
+	}
+	path := strings.Trim(r.URL.Path, "/")
+	if path == "" {
+		return ""
+	}
+	parts := strings.Split(path, "/")
+	return strings.TrimSpace(parts[len(parts)-1])
 }
 
 // readQueryForm extracts the form values from either the request
@@ -657,7 +681,7 @@ func parseQueryChangeMessageVisibilityBatch(form url.Values) (*sqsChangeVisBatch
 	entries := make([]sqsChangeVisBatchEntryInput, 0)
 	for _, idx := range collectQueryEntryIndices(form, "ChangeMessageVisibilityBatchRequestEntry") {
 		prefix := "ChangeMessageVisibilityBatchRequestEntry." + strconv.Itoa(idx)
-		timeout, err := parseRequiredQueryInt64At(form, prefix+".VisibilityTimeout")
+		timeout, err := parseOptionalQueryInt64At(form, prefix+".VisibilityTimeout")
 		if err != nil {
 			return nil, err
 		}
@@ -864,6 +888,7 @@ func collectIndexedKVPairs(form url.Values, prefix, keyField string) map[string]
 		return nil
 	}
 	pairs := gatherIndexedKVPairs(form, prefix+".", "."+keyField)
+	pairs = append(pairs, gatherUnindexedKVPair(form, prefix, keyField)...)
 	if len(pairs) == 0 {
 		return nil
 	}
@@ -881,6 +906,15 @@ func collectIndexedKVPairs(form url.Values, prefix, keyField string) map[string]
 		return nil
 	}
 	return out
+}
+
+func gatherUnindexedKVPair(form url.Values, prefix, keyField string) []indexedKVPair {
+	key := form.Get(prefix + "." + keyField)
+	value := form.Get(prefix + ".Value")
+	if key == "" || value == "" {
+		return nil
+	}
+	return []indexedKVPair{{idx: 0, mapKey: key, mapVal: value}}
 }
 
 // indexedKVPair is an intermediate (idx, key, value) triple used to

--- a/adapter/sqs_query_protocol.go
+++ b/adapter/sqs_query_protocol.go
@@ -674,12 +674,20 @@ func parseQueryChangeMessageVisibilityBatch(form url.Values) (*sqsChangeVisBatch
 }
 
 func parseOptionalQueryInt(form url.Values, name string) (*int, error) {
-	v, err := parseOptionalQueryInt64(form, name)
-	if err != nil || v == nil {
-		return nil, err
+	raw := strings.TrimSpace(form.Get(name))
+	if raw == "" {
+		return nil, nil
 	}
-	n := int(*v)
-	if int64(n) != *v {
+	parsed, err := strconv.ParseInt(raw, 10, strconv.IntSize)
+	if err != nil {
+		var numErr *strconv.NumError
+		if errors.As(err, &numErr) && errors.Is(numErr.Err, strconv.ErrRange) {
+			return nil, newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue, name+" is out of range")
+		}
+		return nil, newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue, name+" must be an integer")
+	}
+	n := int(parsed)
+	if int64(n) != parsed {
 		return nil, newSQSAPIError(http.StatusBadRequest, sqsErrInvalidAttributeValue, name+" is out of range")
 	}
 	return &n, nil
@@ -1275,7 +1283,7 @@ func writeSQSQueryResponse(w http.ResponseWriter, action string, result any) {
 // HTTP status, so keeping them aligned across protocols means a
 // retry policy that works for the JSON client also works for the
 // query client.
-func writeSQSQueryError(w http.ResponseWriter, err error) {
+func sqsQueryErrorDetails(err error) (int, string, string, int) {
 	status := http.StatusInternalServerError
 	code := sqsErrInternalFailure
 	message := "internal error"
@@ -1287,6 +1295,12 @@ func writeSQSQueryError(w http.ResponseWriter, err error) {
 		message = throttled.Error()
 		retryAfter = throttled.retryAfterSeconds()
 	}
+	var rateLimit *purgeRateLimitedError
+	if retryAfter == 0 && errors.As(err, &rateLimit) {
+		status = http.StatusBadRequest
+		code = sqsErrPurgeInProgress
+		message = rateLimit.Error()
+	}
 	var apiErr *sqsAPIError
 	if retryAfter == 0 && errors.As(err, &apiErr) {
 		status = apiErr.status
@@ -1297,6 +1311,11 @@ func writeSQSQueryError(w http.ResponseWriter, err error) {
 			message = apiErr.message
 		}
 	}
+	return status, code, message, retryAfter
+}
+
+func writeSQSQueryError(w http.ResponseWriter, err error) {
+	status, code, message, retryAfter := sqsQueryErrorDetails(err)
 	env := queryErrorEnvelope{
 		XMLName:   xml.Name{Local: "ErrorResponse"},
 		XMLNS:     sqsQueryNamespace,

--- a/adapter/sqs_query_protocol_test.go
+++ b/adapter/sqs_query_protocol_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/xml"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -219,6 +220,42 @@ func TestWriteSQSQueryError_5xxIsReceiver(t *testing.T) {
 	writeSQSQueryError(rec, newSQSAPIError(http.StatusInternalServerError, sqsErrInternalFailure, "boom"))
 	if !strings.Contains(rec.Body.String(), "<Type>Receiver</Type>") {
 		t.Fatalf("expected <Type>Receiver</Type> for 5xx; body=%s", rec.Body.String())
+	}
+}
+
+func TestWriteSQSQueryError_PurgeRateLimit(t *testing.T) {
+	t.Parallel()
+	rec := httptest.NewRecorder()
+	writeSQSQueryError(rec, &purgeRateLimitedError{remaining: 60})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if got := rec.Header().Get("x-amzn-ErrorType"); got != sqsErrPurgeInProgress {
+		t.Fatalf("x-amzn-ErrorType = %q, want %q", got, sqsErrPurgeInProgress)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "<Code>"+sqsErrPurgeInProgress+"</Code>") {
+		t.Fatalf("missing purge-in-progress code; body=%s", body)
+	}
+}
+
+func TestParseOptionalQueryIntRejectsOutOfRange(t *testing.T) {
+	t.Parallel()
+	_, err := parseOptionalQueryInt(url.Values{
+		"MaxNumberOfMessages": []string{"9223372036854775808"},
+	}, "MaxNumberOfMessages")
+	if err == nil {
+		t.Fatal("expected range error")
+	}
+	apiErr := &sqsAPIError{}
+	ok := errors.As(err, &apiErr)
+	if !ok {
+		t.Fatalf("error type = %T, want *sqsAPIError", err)
+	}
+	if apiErr.status != http.StatusBadRequest || apiErr.errorType != sqsErrInvalidAttributeValue {
+		t.Fatalf("api error = status %d type %q, want 400 %q", apiErr.status, apiErr.errorType, sqsErrInvalidAttributeValue)
+	}
+	if !strings.Contains(apiErr.message, "out of range") {
+		t.Fatalf("message = %q, want out of range", apiErr.message)
 	}
 }
 

--- a/adapter/sqs_query_protocol_test.go
+++ b/adapter/sqs_query_protocol_test.go
@@ -387,6 +387,202 @@ func TestSQSServer_QueryProtocol_ControlPlaneRoundTrip(t *testing.T) {
 	assertJSONQueueDeleted(t, node, "query-control")
 }
 
+func TestSQSServer_QueryProtocol_MessageLifecycleRoundTrip(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	node := sqsLeaderNode(t, nodes)
+
+	queueURL := queryCreateQueueURL(t, node, "query-message")
+	_, sendBody := queryOK(t, node, "SendMessage", url.Values{
+		"QueueUrl":                             []string{queueURL},
+		"MessageBody":                          []string{"hello-query"},
+		"MessageAttribute.1.Name":              []string{"City"},
+		"MessageAttribute.1.Value.DataType":    []string{"String"},
+		"MessageAttribute.1.Value.StringValue": []string{"Tokyo"},
+	})
+	var sendResp struct {
+		Result struct {
+			MessageId              string `xml:"MessageId"`
+			MD5OfMessageBody       string `xml:"MD5OfMessageBody"`
+			MD5OfMessageAttributes string `xml:"MD5OfMessageAttributes"`
+		} `xml:"SendMessageResult"`
+	}
+	if err := xml.Unmarshal(bytes.TrimSpace(sendBody), &sendResp); err != nil {
+		t.Fatalf("decode send: %v\nbody=%s", err, sendBody)
+	}
+	if sendResp.Result.MessageId == "" || sendResp.Result.MD5OfMessageBody == "" || sendResp.Result.MD5OfMessageAttributes == "" {
+		t.Fatalf("incomplete SendMessage result: %+v body=%s", sendResp.Result, sendBody)
+	}
+
+	_, recvBody := queryOK(t, node, "ReceiveMessage", url.Values{
+		"QueueUrl":               []string{queueURL},
+		"MaxNumberOfMessages":    []string{"1"},
+		"VisibilityTimeout":      []string{"60"},
+		"MessageAttributeName.1": []string{"All"},
+	})
+	recvResp := decodeQueryReceiveResponse(t, recvBody)
+	if len(recvResp.Result.Messages) != 1 {
+		t.Fatalf("ReceiveMessage returned %d messages, want 1; body=%s", len(recvResp.Result.Messages), recvBody)
+	}
+	msg := recvResp.Result.Messages[0]
+	if msg.MessageId != sendResp.Result.MessageId || msg.Body != "hello-query" {
+		t.Fatalf("received message mismatch: %+v send=%+v", msg, sendResp.Result)
+	}
+	if msg.MessageAttributes["City"].Value.StringValue != "Tokyo" {
+		t.Fatalf("message attributes = %+v, want City=Tokyo; body=%s", msg.MessageAttributes, recvBody)
+	}
+
+	queryOK(t, node, "ChangeMessageVisibility", url.Values{
+		"QueueUrl":          []string{queueURL},
+		"ReceiptHandle":     []string{msg.ReceiptHandle},
+		"VisibilityTimeout": []string{"120"},
+	})
+	queryOK(t, node, "DeleteMessage", url.Values{
+		"QueueUrl":      []string{queueURL},
+		"ReceiptHandle": []string{msg.ReceiptHandle},
+	})
+	_, emptyBody := queryOK(t, node, "ReceiveMessage", url.Values{
+		"QueueUrl":            []string{queueURL},
+		"MaxNumberOfMessages": []string{"1"},
+		"WaitTimeSeconds":     []string{"0"},
+	})
+	emptyResp := decodeQueryReceiveResponse(t, emptyBody)
+	if len(emptyResp.Result.Messages) != 0 {
+		t.Fatalf("message should be deleted; got %d messages body=%s", len(emptyResp.Result.Messages), emptyBody)
+	}
+}
+
+func TestSQSServer_QueryProtocol_BatchRoundTrip(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	node := sqsLeaderNode(t, nodes)
+
+	queueURL := queryCreateQueueURL(t, node, "query-batch")
+	_, sendBody := queryOK(t, node, "SendMessageBatch", url.Values{
+		"QueueUrl":                                   []string{queueURL},
+		"SendMessageBatchRequestEntry.1.Id":          []string{"a"},
+		"SendMessageBatchRequestEntry.1.MessageBody": []string{"alpha"},
+		"SendMessageBatchRequestEntry.2.Id":          []string{"b"},
+		"SendMessageBatchRequestEntry.2.MessageBody": []string{"beta"},
+	})
+	var sendResp struct {
+		Result struct {
+			Successful []struct {
+				Id        string `xml:"Id"`
+				MessageId string `xml:"MessageId"`
+			} `xml:"SendMessageBatchResultEntry"`
+			Failed []struct {
+				Id string `xml:"Id"`
+			} `xml:"BatchResultErrorEntry"`
+		} `xml:"SendMessageBatchResult"`
+	}
+	if err := xml.Unmarshal(bytes.TrimSpace(sendBody), &sendResp); err != nil {
+		t.Fatalf("decode batch send: %v\nbody=%s", err, sendBody)
+	}
+	if len(sendResp.Result.Successful) != 2 || len(sendResp.Result.Failed) != 0 {
+		t.Fatalf("SendMessageBatch result = %+v body=%s", sendResp.Result, sendBody)
+	}
+
+	_, recvBody := queryOK(t, node, "ReceiveMessage", url.Values{
+		"QueueUrl":            []string{queueURL},
+		"MaxNumberOfMessages": []string{"2"},
+		"VisibilityTimeout":   []string{"60"},
+	})
+	recvResp := decodeQueryReceiveResponse(t, recvBody)
+	if len(recvResp.Result.Messages) != 2 {
+		t.Fatalf("ReceiveMessage returned %d messages, want 2; body=%s", len(recvResp.Result.Messages), recvBody)
+	}
+	changeForm := url.Values{"QueueUrl": []string{queueURL}}
+	deleteForm := url.Values{"QueueUrl": []string{queueURL}}
+	for i, msg := range recvResp.Result.Messages {
+		idx := strconv.Itoa(i + 1)
+		changePrefix := "ChangeMessageVisibilityBatchRequestEntry." + idx
+		changeForm.Set(changePrefix+".Id", "c"+idx)
+		changeForm.Set(changePrefix+".ReceiptHandle", msg.ReceiptHandle)
+		changeForm.Set(changePrefix+".VisibilityTimeout", "90")
+		deletePrefix := "DeleteMessageBatchRequestEntry." + idx
+		deleteForm.Set(deletePrefix+".Id", "d"+idx)
+		deleteForm.Set(deletePrefix+".ReceiptHandle", msg.ReceiptHandle)
+	}
+	queryOK(t, node, "ChangeMessageVisibilityBatch", changeForm)
+	_, deleteBody := queryOK(t, node, "DeleteMessageBatch", deleteForm)
+	var deleteResp struct {
+		Result struct {
+			Successful []struct {
+				Id string `xml:"Id"`
+			} `xml:"DeleteMessageBatchResultEntry"`
+			Failed []struct {
+				Id string `xml:"Id"`
+			} `xml:"BatchResultErrorEntry"`
+		} `xml:"DeleteMessageBatchResult"`
+	}
+	if err := xml.Unmarshal(bytes.TrimSpace(deleteBody), &deleteResp); err != nil {
+		t.Fatalf("decode batch delete: %v\nbody=%s", err, deleteBody)
+	}
+	if len(deleteResp.Result.Successful) != 2 || len(deleteResp.Result.Failed) != 0 {
+		t.Fatalf("DeleteMessageBatch result = %+v body=%s", deleteResp.Result, deleteBody)
+	}
+}
+
+type queryReceiveTestResponse struct {
+	Result struct {
+		Messages []struct {
+			MessageId     string `xml:"MessageId"`
+			ReceiptHandle string `xml:"ReceiptHandle"`
+			Body          string `xml:"Body"`
+			Attributes    []struct {
+				Name  string `xml:"Name"`
+				Value string `xml:"Value"`
+			} `xml:"Attribute"`
+			MessageAttributes map[string]struct {
+				Value struct {
+					DataType    string `xml:"DataType"`
+					StringValue string `xml:"StringValue"`
+					BinaryValue string `xml:"BinaryValue"`
+				} `xml:"Value"`
+			}
+			RawMessageAttributes []struct {
+				Name  string `xml:"Name"`
+				Value struct {
+					DataType    string `xml:"DataType"`
+					StringValue string `xml:"StringValue"`
+					BinaryValue string `xml:"BinaryValue"`
+				} `xml:"Value"`
+			} `xml:"MessageAttribute"`
+		} `xml:"Message"`
+	} `xml:"ReceiveMessageResult"`
+}
+
+func decodeQueryReceiveResponse(t *testing.T, body []byte) queryReceiveTestResponse {
+	t.Helper()
+	var resp queryReceiveTestResponse
+	if err := xml.Unmarshal(bytes.TrimSpace(body), &resp); err != nil {
+		t.Fatalf("decode receive: %v\nbody=%s", err, body)
+	}
+	for i := range resp.Result.Messages {
+		attrs := make(map[string]struct {
+			Value struct {
+				DataType    string `xml:"DataType"`
+				StringValue string `xml:"StringValue"`
+				BinaryValue string `xml:"BinaryValue"`
+			} `xml:"Value"`
+		}, len(resp.Result.Messages[i].RawMessageAttributes))
+		for _, attr := range resp.Result.Messages[i].RawMessageAttributes {
+			attrs[attr.Name] = struct {
+				Value struct {
+					DataType    string `xml:"DataType"`
+					StringValue string `xml:"StringValue"`
+					BinaryValue string `xml:"BinaryValue"`
+				} `xml:"Value"`
+			}{Value: attr.Value}
+		}
+		resp.Result.Messages[i].MessageAttributes = attrs
+	}
+	return resp
+}
+
 func queryCreateQueueURL(t *testing.T, node Node, name string) string {
 	t.Helper()
 	_, body := queryOK(t, node, "CreateQueue", url.Values{"QueueName": []string{name}})

--- a/adapter/sqs_query_protocol_test.go
+++ b/adapter/sqs_query_protocol_test.go
@@ -115,6 +115,24 @@ func TestCollectIndexedKVPairs_TagSuffix(t *testing.T) {
 	}
 }
 
+func TestCollectIndexedKVPairs_UnindexedSinglePair(t *testing.T) {
+	t.Parallel()
+	form := url.Values{
+		"Attribute.Name":  []string{"VisibilityTimeout"},
+		"Attribute.Value": []string{"60"},
+		"Tag.Key":         []string{"env"},
+		"Tag.Value":       []string{"prod"},
+	}
+	attrs := collectIndexedKVPairs(form, "Attribute", "Name")
+	if attrs["VisibilityTimeout"] != "60" {
+		t.Fatalf("unindexed attribute map = %v, want VisibilityTimeout=60", attrs)
+	}
+	tags := collectIndexedKVPairs(form, "Tag", "Key")
+	if tags["env"] != "prod" {
+		t.Fatalf("unindexed tag map = %v, want env=prod", tags)
+	}
+}
+
 // TestCollectIndexedKVPairs_DeterministicOnDuplicates pins that two
 // entries resolving to the same logical key resolve deterministically
 // (lower index wins). CodexP2 flagged the previous map iteration as
@@ -265,9 +283,14 @@ func TestParseOptionalQueryIntRejectsOutOfRange(t *testing.T) {
 // in-process listener and returns the decoded response envelope.
 func queryRoundTrip(t *testing.T, node Node, action string, form url.Values) (int, []byte) {
 	t.Helper()
+	return queryRoundTripPath(t, node, "/", action, form)
+}
+
+func queryRoundTripPath(t *testing.T, node Node, requestPath, action string, form url.Values) (int, []byte) {
+	t.Helper()
 	form.Set("Action", action)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
-		"http://"+node.sqsAddress+"/", strings.NewReader(form.Encode()))
+		"http://"+node.sqsAddress+requestPath, strings.NewReader(form.Encode()))
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}
@@ -279,6 +302,21 @@ func queryRoundTrip(t *testing.T, node Node, action string, form url.Values) (in
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	return resp.StatusCode, body
+}
+
+func TestSQSServer_QueryProtocol_QueueURLFromPath(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	node := sqsLeaderNode(t, nodes)
+
+	queueURL := queryCreateQueueURL(t, node, "query-path")
+	status, body := queryRoundTripPath(t, node, "/123456789012/query-path", "SendMessage", url.Values{
+		"MessageBody": []string{"path-routed"},
+	})
+	if status != http.StatusOK {
+		t.Fatalf("SendMessage path QueueUrl fallback: status %d body %s queueURL=%s", status, body, queueURL)
+	}
 }
 
 func TestSQSServer_QueryProtocol_CreateQueueRoundTrip(t *testing.T) {
@@ -560,6 +598,41 @@ func TestSQSServer_QueryProtocol_BatchRoundTrip(t *testing.T) {
 	}
 	if len(deleteResp.Result.Successful) != 2 || len(deleteResp.Result.Failed) != 0 {
 		t.Fatalf("DeleteMessageBatch result = %+v body=%s", deleteResp.Result, deleteBody)
+	}
+}
+
+func TestSQSServer_QueryProtocol_ChangeVisibilityBatchMissingTimeoutIsEntryFailure(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	node := sqsLeaderNode(t, nodes)
+
+	queueURL := queryCreateQueueURL(t, node, "query-change-missing-timeout")
+	_, body := queryOK(t, node, "ChangeMessageVisibilityBatch", url.Values{
+		"QueueUrl": []string{queueURL},
+		"ChangeMessageVisibilityBatchRequestEntry.1.Id":            []string{"missing-timeout"},
+		"ChangeMessageVisibilityBatchRequestEntry.1.ReceiptHandle": []string{"not-used"},
+	})
+	var resp struct {
+		Result struct {
+			Successful []struct {
+				Id string `xml:"Id"`
+			} `xml:"ChangeMessageVisibilityBatchResultEntry"`
+			Failed []struct {
+				Id      string `xml:"Id"`
+				Code    string `xml:"Code"`
+				Message string `xml:"Message"`
+			} `xml:"BatchResultErrorEntry"`
+		} `xml:"ChangeMessageVisibilityBatchResult"`
+	}
+	if err := xml.Unmarshal(bytes.TrimSpace(body), &resp); err != nil {
+		t.Fatalf("decode change visibility batch: %v\nbody=%s", err, body)
+	}
+	if len(resp.Result.Successful) != 0 || len(resp.Result.Failed) != 1 {
+		t.Fatalf("result = %+v body=%s", resp.Result, body)
+	}
+	if got := resp.Result.Failed[0]; got.Id != "missing-timeout" || got.Code != sqsErrMissingParameter {
+		t.Fatalf("failed entry = %+v, want id missing-timeout code %s", got, sqsErrMissingParameter)
 	}
 }
 

--- a/adapter/sqs_query_protocol_test.go
+++ b/adapter/sqs_query_protocol_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sort"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -144,6 +146,27 @@ func TestCollectIndexedKVPairs_Empty(t *testing.T) {
 	}
 	if got := collectIndexedKVPairs(url.Values{"Other.1.Name": []string{"x"}, "Other.1.Value": []string{"y"}}, "Attribute", "Name"); got != nil {
 		t.Fatalf("unrelated form: got %v, want nil", got)
+	}
+}
+
+func TestCollectIndexedValues(t *testing.T) {
+	t.Parallel()
+	form := url.Values{
+		"AttributeName":   []string{"All"},
+		"AttributeName.3": []string{"DelaySeconds"},
+		"AttributeName.1": []string{"VisibilityTimeout"},
+		"AttributeName.x": []string{"ignored"},
+		"TagKey.1":        []string{"not-an-attribute"},
+	}
+	got := collectIndexedValues(form, "AttributeName")
+	want := []string{"All", "VisibilityTimeout", "DelaySeconds"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("value %d = %q, want %q (all=%v)", i, got[i], want[i], got)
+		}
 	}
 }
 
@@ -328,6 +351,156 @@ func TestSQSServer_QueryProtocol_GetQueueUrlNotFoundError(t *testing.T) {
 	}
 	if !strings.Contains(bodyStr, "<Code>"+sqsErrQueueDoesNotExist+"</Code>") {
 		t.Fatalf("expected QueueDoesNotExist code; body=%s", bodyStr)
+	}
+}
+
+func TestSQSServer_QueryProtocol_ControlPlaneRoundTrip(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 1)
+	defer shutdown(nodes)
+	node := sqsLeaderNode(t, nodes)
+
+	queueURL := queryCreateQueueURL(t, node, "query-control")
+	querySetVisibilityTimeout(t, node, queueURL, "12")
+	attrs := queryAttributes(t, node, queueURL, []string{"VisibilityTimeout", "QueueArn"})
+	if got := attrs["VisibilityTimeout"]; got != "12" {
+		t.Fatalf("VisibilityTimeout = %q, want 12; attrs=%v", got, attrs)
+	}
+	if got := attrs["QueueArn"]; !strings.HasSuffix(got, ":query-control") {
+		t.Fatalf("QueueArn = %q, want suffix :query-control; attrs=%v", got, attrs)
+	}
+
+	queryTagQueue(t, node, queueURL, map[string]string{"env": "prod", "team": "storage"})
+	tags := queryTags(t, node, queueURL)
+	if tags["env"] != "prod" || tags["team"] != "storage" {
+		t.Fatalf("tags = %v, want env/prod and team/storage", tags)
+	}
+
+	queryUntagQueue(t, node, queueURL, []string{"env"})
+	tags = queryTags(t, node, queueURL)
+	if _, ok := tags["env"]; ok || tags["team"] != "storage" {
+		t.Fatalf("tags after untag = %v, want only team/storage", tags)
+	}
+
+	queryOK(t, node, "PurgeQueue", url.Values{"QueueUrl": []string{queueURL}})
+	queryOK(t, node, "DeleteQueue", url.Values{"QueueUrl": []string{queueURL}})
+	assertJSONQueueDeleted(t, node, "query-control")
+}
+
+func queryCreateQueueURL(t *testing.T, node Node, name string) string {
+	t.Helper()
+	_, body := queryOK(t, node, "CreateQueue", url.Values{"QueueName": []string{name}})
+	var createResp struct {
+		Result struct {
+			QueueUrl string `xml:"QueueUrl"`
+		} `xml:"CreateQueueResult"`
+	}
+	if err := xml.Unmarshal(bytes.TrimSpace(body), &createResp); err != nil {
+		t.Fatalf("decode create: %v\nbody=%s", err, body)
+	}
+	queueURL := createResp.Result.QueueUrl
+	if queueURL == "" {
+		t.Fatalf("missing QueueUrl in create response: %s", body)
+	}
+	return queueURL
+}
+
+func querySetVisibilityTimeout(t *testing.T, node Node, queueURL, value string) {
+	t.Helper()
+	queryOK(t, node, "SetQueueAttributes", url.Values{
+		"QueueUrl":          []string{queueURL},
+		"Attribute.1.Name":  []string{"VisibilityTimeout"},
+		"Attribute.1.Value": []string{value},
+	})
+}
+
+func queryAttributes(t *testing.T, node Node, queueURL string, names []string) map[string]string {
+	t.Helper()
+	form := url.Values{"QueueUrl": []string{queueURL}}
+	for i, name := range names {
+		form.Set("AttributeName."+strconv.Itoa(i+1), name)
+	}
+	_, body := queryOK(t, node, "GetQueueAttributes", form)
+	var attrsResp struct {
+		Result struct {
+			Attributes []struct {
+				Name  string `xml:"Name"`
+				Value string `xml:"Value"`
+			} `xml:"Attribute"`
+		} `xml:"GetQueueAttributesResult"`
+	}
+	if err := xml.Unmarshal(bytes.TrimSpace(body), &attrsResp); err != nil {
+		t.Fatalf("decode attrs: %v\nbody=%s", err, body)
+	}
+	attrs := map[string]string{}
+	for _, a := range attrsResp.Result.Attributes {
+		attrs[a.Name] = a.Value
+	}
+	return attrs
+}
+
+func queryTagQueue(t *testing.T, node Node, queueURL string, tags map[string]string) {
+	t.Helper()
+	form := url.Values{"QueueUrl": []string{queueURL}}
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for i, k := range keys {
+		prefix := "Tag." + strconv.Itoa(i+1)
+		form.Set(prefix+".Key", k)
+		form.Set(prefix+".Value", tags[k])
+	}
+	queryOK(t, node, "TagQueue", form)
+}
+
+func queryTags(t *testing.T, node Node, queueURL string) map[string]string {
+	t.Helper()
+	_, body := queryOK(t, node, "ListQueueTags", url.Values{"QueueUrl": []string{queueURL}})
+	var tagsResp struct {
+		Result struct {
+			Tags []struct {
+				Key   string `xml:"Key"`
+				Value string `xml:"Value"`
+			} `xml:"Tag"`
+		} `xml:"ListQueueTagsResult"`
+	}
+	if err := xml.Unmarshal(bytes.TrimSpace(body), &tagsResp); err != nil {
+		t.Fatalf("decode tags: %v\nbody=%s", err, body)
+	}
+	tags := map[string]string{}
+	for _, tag := range tagsResp.Result.Tags {
+		tags[tag.Key] = tag.Value
+	}
+	return tags
+}
+
+func queryUntagQueue(t *testing.T, node Node, queueURL string, tagKeys []string) {
+	t.Helper()
+	form := url.Values{"QueueUrl": []string{queueURL}}
+	for i, k := range tagKeys {
+		form.Set("TagKey."+strconv.Itoa(i+1), k)
+	}
+	queryOK(t, node, "UntagQueue", form)
+}
+
+func queryOK(t *testing.T, node Node, action string, form url.Values) (int, []byte) {
+	t.Helper()
+	status, body := queryRoundTrip(t, node, action, form)
+	if status != http.StatusOK {
+		t.Fatalf("%s: status %d body %s", action, status, body)
+	}
+	return status, body
+}
+
+func assertJSONQueueDeleted(t *testing.T, node Node, name string) {
+	t.Helper()
+	jStatus, jOut := callSQS(t, node, sqsGetQueueUrlTarget, map[string]any{
+		"QueueName": name,
+	})
+	if jStatus != http.StatusBadRequest || jOut["__type"] != sqsErrQueueDoesNotExist {
+		t.Fatalf("JSON GetQueueUrl after query DeleteQueue: status=%d body=%v", jStatus, jOut)
 	}
 }
 

--- a/adapter/sqs_tags.go
+++ b/adapter/sqs_tags.go
@@ -38,15 +38,22 @@ func (s *SQSServer) tagQueue(w http.ResponseWriter, r *http.Request) {
 		writeSQSErrorFromErr(w, err)
 		return
 	}
-	if len(in.Tags) == 0 {
-		writeSQSError(w, http.StatusBadRequest, sqsErrMissingParameter, "Tags is required")
+	if err := s.tagQueueCore(r.Context(), name, in.Tags); err != nil {
+		writeSQSErrorFromErr(w, err)
 		return
 	}
-	if err := s.mutateQueueTagsWithRetry(r.Context(), name, func(meta *sqsQueueMeta) error {
+	writeSQSJSON(w, map[string]any{})
+}
+
+func (s *SQSServer) tagQueueCore(ctx context.Context, name string, tags map[string]string) error {
+	if len(tags) == 0 {
+		return newSQSAPIError(http.StatusBadRequest, sqsErrMissingParameter, "Tags is required")
+	}
+	return s.mutateQueueTagsWithRetry(ctx, name, func(meta *sqsQueueMeta) error {
 		if meta.Tags == nil {
-			meta.Tags = make(map[string]string, len(in.Tags))
+			meta.Tags = make(map[string]string, len(tags))
 		}
-		for k, v := range in.Tags {
+		for k, v := range tags {
 			meta.Tags[k] = v
 		}
 		// Cap the per-queue tag count after merging so a follow-up
@@ -57,11 +64,7 @@ func (s *SQSServer) tagQueue(w http.ResponseWriter, r *http.Request) {
 				"queue tag count exceeds 50")
 		}
 		return nil
-	}); err != nil {
-		writeSQSErrorFromErr(w, err)
-		return
-	}
-	writeSQSJSON(w, map[string]any{})
+	})
 }
 
 func (s *SQSServer) untagQueue(w http.ResponseWriter, r *http.Request) {
@@ -75,20 +78,23 @@ func (s *SQSServer) untagQueue(w http.ResponseWriter, r *http.Request) {
 		writeSQSErrorFromErr(w, err)
 		return
 	}
-	if len(in.TagKeys) == 0 {
-		writeSQSError(w, http.StatusBadRequest, sqsErrMissingParameter, "TagKeys is required")
-		return
-	}
-	if err := s.mutateQueueTagsWithRetry(r.Context(), name, func(meta *sqsQueueMeta) error {
-		for _, k := range in.TagKeys {
-			delete(meta.Tags, k)
-		}
-		return nil
-	}); err != nil {
+	if err := s.untagQueueCore(r.Context(), name, in.TagKeys); err != nil {
 		writeSQSErrorFromErr(w, err)
 		return
 	}
 	writeSQSJSON(w, map[string]any{})
+}
+
+func (s *SQSServer) untagQueueCore(ctx context.Context, name string, tagKeys []string) error {
+	if len(tagKeys) == 0 {
+		return newSQSAPIError(http.StatusBadRequest, sqsErrMissingParameter, "TagKeys is required")
+	}
+	return s.mutateQueueTagsWithRetry(ctx, name, func(meta *sqsQueueMeta) error {
+		for _, k := range tagKeys {
+			delete(meta.Tags, k)
+		}
+		return nil
+	})
 }
 
 func (s *SQSServer) listQueueTags(w http.ResponseWriter, r *http.Request) {
@@ -102,14 +108,21 @@ func (s *SQSServer) listQueueTags(w http.ResponseWriter, r *http.Request) {
 		writeSQSErrorFromErr(w, err)
 		return
 	}
-	meta, exists, err := s.loadQueueMetaAt(r.Context(), name, s.nextTxnReadTS(r.Context()))
+	tags, err := s.listQueueTagsCore(r.Context(), name)
 	if err != nil {
 		writeSQSErrorFromErr(w, err)
 		return
 	}
+	writeSQSJSON(w, map[string]any{"Tags": tags})
+}
+
+func (s *SQSServer) listQueueTagsCore(ctx context.Context, name string) (map[string]string, error) {
+	meta, exists, err := s.loadQueueMetaAt(ctx, name, s.nextTxnReadTS(ctx))
+	if err != nil {
+		return nil, err
+	}
 	if !exists {
-		writeSQSError(w, http.StatusBadRequest, sqsErrQueueDoesNotExist, "queue does not exist")
-		return
+		return nil, newSQSAPIError(http.StatusBadRequest, sqsErrQueueDoesNotExist, "queue does not exist")
 	}
 	tags := meta.Tags
 	if tags == nil {
@@ -117,7 +130,7 @@ func (s *SQSServer) listQueueTags(w http.ResponseWriter, r *http.Request) {
 		// null and trip strict JSON consumers.
 		tags = map[string]string{}
 	}
-	writeSQSJSON(w, map[string]any{"Tags": tags})
+	return tags, nil
 }
 
 // mutateQueueTagsWithRetry runs an OCC-bounded read-modify-write of the

--- a/adapter/sqs_throttle.go
+++ b/adapter/sqs_throttle.go
@@ -582,23 +582,11 @@ func throttleChargeCount(entries int) int {
 // sendMessageWithRetry et al. would otherwise busy-loop on a
 // permanent rate-limit reject, burning leader CPU.
 func (s *SQSServer) chargeQueue(w http.ResponseWriter, r *http.Request, queueName, action string, count int) bool {
-	if s.throttle == nil {
-		return true
-	}
-	throttle, incarnation, err := s.queueThrottleConfig(r, queueName)
-	if err != nil {
-		// Fail closed on a transient storage error. Earlier code
-		// converted the error to (nil, 0)
-		// which made the throttle check short-circuit to "allowed";
-		// if the same storage hiccup did not also break the OCC
-		// commit a few lines later, the request would be processed
-		// unthrottled — a silent rate-limit bypass under storage
-		// instability. 500 here matches what the OCC layer would
-		// also surface for a meta read failure.
+	if err := s.chargeQueueErr(r.Context(), queueName, action, count); err != nil {
 		writeSQSErrorFromErr(w, err)
 		return false
 	}
-	return s.chargeQueueWithThrottle(w, queueName, action, count, throttle, incarnation)
+	return true
 }
 
 // chargeQueueWithThrottle is the variant for handlers that already
@@ -613,15 +601,57 @@ func (s *SQSServer) chargeQueue(w http.ResponseWriter, r *http.Request, queueNam
 // Incarnation, so keying the bucket by Generation would let a caller
 // bypass the rate limit by repeatedly purging.
 func (s *SQSServer) chargeQueueWithThrottle(w http.ResponseWriter, queueName, action string, count int, throttle *sqsQueueThrottle, incarnation uint64) bool {
+	if err := s.chargeQueueWithThrottleErr(queueName, action, count, throttle, incarnation); err != nil {
+		writeSQSErrorFromErr(w, err)
+		return false
+	}
+	return true
+}
+
+func (s *SQSServer) chargeQueueErr(ctx context.Context, queueName, action string, count int) error {
 	if s.throttle == nil {
-		return true
+		return nil
+	}
+	throttle, incarnation, err := s.queueThrottleConfigContext(ctx, queueName)
+	if err != nil {
+		return err
+	}
+	return s.chargeQueueWithThrottleErr(queueName, action, count, throttle, incarnation)
+}
+
+func (s *SQSServer) chargeQueueWithThrottleErr(queueName, action string, count int, throttle *sqsQueueThrottle, incarnation uint64) error {
+	if s.throttle == nil {
+		return nil
 	}
 	outcome := s.throttle.charge(throttle, queueName, action, incarnation, count)
 	if outcome.allowed {
-		return true
+		return nil
 	}
-	writeSQSThrottlingError(w, queueName, action, outcome.retryAfter)
-	return false
+	return &sqsThrottlingError{queue: queueName, action: action, retryAfter: outcome.retryAfter}
+}
+
+type sqsThrottlingError struct {
+	queue      string
+	action     string
+	retryAfter time.Duration
+}
+
+func (e *sqsThrottlingError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return "Rate exceeded for queue '" + e.queue + "' action '" + e.action + "'"
+}
+
+func (e *sqsThrottlingError) retryAfterSeconds() int {
+	if e == nil {
+		return 0
+	}
+	retryAfter := e.retryAfter
+	if retryAfter < time.Second {
+		retryAfter = time.Second
+	}
+	return int(retryAfter / time.Second)
 }
 
 // queueThrottleConfig loads the Throttle config and Incarnation off a
@@ -638,15 +668,12 @@ func (s *SQSServer) chargeQueueWithThrottle(w http.ResponseWriter, queueName, ac
 //     the request closed; converting an error to (nil, 0) silently
 //     would let traffic bypass the throttle check during a transient
 //     storage outage if the OCC commit later succeeded.
-//
-// Held as a method on *SQSServer so a test can swap the meta loader
-// via the existing nextTxnReadTS / loadQueueMetaAt seam.
-func (s *SQSServer) queueThrottleConfig(r *http.Request, queueName string) (*sqsQueueThrottle, uint64, error) {
+func (s *SQSServer) queueThrottleConfigContext(ctx context.Context, queueName string) (*sqsQueueThrottle, uint64, error) {
 	if s.store == nil {
 		return nil, 0, nil
 	}
-	readTS := s.nextTxnReadTS(r.Context())
-	meta, exists, err := s.loadQueueMetaAt(r.Context(), queueName, readTS)
+	readTS := s.nextTxnReadTS(ctx)
+	meta, exists, err := s.loadQueueMetaAt(ctx, queueName, readTS)
 	if err != nil {
 		return nil, 0, errors.WithStack(err)
 	}

--- a/docs/design/2026_04_24_partial_sqs_compatible_adapter.md
+++ b/docs/design/2026_04_24_partial_sqs_compatible_adapter.md
@@ -1,6 +1,9 @@
 # SQS-Compatible Adapter Design for Elastickv
 
-Status: Proposed
+Status: Partial — core JSON SQS APIs, FIFO/batch/DLQ/tag APIs, admin UI,
+per-queue throttling, HT-FIFO partitioning, and query-protocol control-plane
+verbs have shipped. Query-protocol message lifecycle/batch XML, split-queue
+FIFO completion, and broader scaling roadmap items remain open.
 Author: bootjp
 Date: 2026-04-24
 
@@ -15,7 +18,7 @@ Elastickv exposes four protocol surfaces as of 2026-04-24:
 3. DynamoDB-compatible HTTP APIs (`adapter/dynamodb.go`)
 4. S3-compatible HTTP APIs (`adapter/s3.go`)
 
-There is no message-queue surface. This document proposes an HTTP adapter that exposes an Amazon SQS-compatible API while reusing the existing Raft, MVCC, HLC, shard-routing, leader-proxy, and SigV4 patterns that the DynamoDB and S3 adapters already established.
+Before this work there was no message-queue surface. This document tracks the HTTP adapter that exposes an Amazon SQS-compatible API while reusing the existing Raft, MVCC, HLC, shard-routing, leader-proxy, and SigV4 patterns that the DynamoDB and S3 adapters already established.
 
 The goal is SQS compatibility for standard AWS SDK/CLI workflows against a self-hosted Elastickv cluster, not AWS feature parity. The adapter should transparently support `aws sqs`, the AWS SDK for Go v2, the JVM SDK, and boto3 against the same endpoint.
 
@@ -685,7 +688,7 @@ Structured logs include `route`, `queue`, `action`, `remote_ip`, `token_hash_pre
 
 ### Phase 3
 
-1. Query-protocol full XML fidelity for older SDKs.
+1. Query-protocol XML support for older SDKs. Control-plane verbs are wired; message lifecycle and batch XML remain TODO.
 2. `ApproximateNumberOfMessagesDelayed` / `NotVisible` accuracy.
 3. Per-queue throttling and fairness across tenants.
 4. Split-queue FIFO for very hot queues.

--- a/docs/design/2026_04_24_partial_sqs_compatible_adapter.md
+++ b/docs/design/2026_04_24_partial_sqs_compatible_adapter.md
@@ -1,9 +1,9 @@
 # SQS-Compatible Adapter Design for Elastickv
 
 Status: Partial — core JSON SQS APIs, FIFO/batch/DLQ/tag APIs, admin UI,
-per-queue throttling, HT-FIFO partitioning, and query-protocol control-plane
-verbs have shipped. Query-protocol message lifecycle/batch XML, split-queue
-FIFO completion, and broader scaling roadmap items remain open.
+per-queue throttling, HT-FIFO partitioning, and query-protocol XML coverage
+for the supported public verbs have shipped. Split-queue FIFO completion and
+broader scaling roadmap items remain open.
 Author: bootjp
 Date: 2026-04-24
 
@@ -688,7 +688,7 @@ Structured logs include `route`, `queue`, `action`, `remote_ip`, `token_hash_pre
 
 ### Phase 3
 
-1. Query-protocol XML support for older SDKs. Control-plane verbs are wired; message lifecycle and batch XML remain TODO.
+1. Query-protocol XML support for older SDKs is wired for the supported public verbs; see [`2026_04_26_implemented_sqs_query_protocol.md`](2026_04_26_implemented_sqs_query_protocol.md).
 2. `ApproximateNumberOfMessagesDelayed` / `NotVisible` accuracy.
 3. Per-queue throttling and fairness across tenants.
 4. Split-queue FIFO for very hot queues.

--- a/docs/design/2026_04_26_implemented_sqs_query_protocol.md
+++ b/docs/design/2026_04_26_implemented_sqs_query_protocol.md
@@ -1,10 +1,8 @@
 # SQS Query-Protocol Wire Format Support
 
-**Status:** Partial — dispatch, XML success/error envelopes, form parsing,
-and control-plane verbs (`CreateQueue`, `DeleteQueue`, `ListQueues`,
-`GetQueueUrl`, `GetQueueAttributes`, `SetQueueAttributes`, `PurgeQueue`,
-`TagQueue`, `UntagQueue`, `ListQueueTags`) have shipped. Message lifecycle
-and batch XML remain open.
+**Status:** Implemented — dispatch, XML success/error envelopes, form parsing,
+control-plane verbs, message lifecycle verbs, and batch verbs are wired on the
+same SQS listener as the JSON protocol.
 **Author:** bootjp
 **Date:** 2026-04-26
 
@@ -16,7 +14,7 @@ The elastickv SQS adapter originally spoke only the **AWS JSON 1.0 protocol**: `
 
 A long tail of clients still emits the older **query protocol** (form-encoded request, XML response) — `aws-sdk-java` v1, older `boto`/`boto3 < 1.34`, every CLI tool that builds requests by hand, and the AWS CLI itself when used against a region that defaults to query. Before the staged query-protocol work, these clients failed with `400 MalformedRequest` or `415 UnsupportedMediaType` on the very first request, even when the underlying SQS feature was already implemented on the JSON path.
 
-Completing query-protocol support is the last piece needed to claim "drop-in SQS compatibility" for v1-era SDKs. Phase 3.B in [`docs/design/2026_04_24_partial_sqs_compatible_adapter.md`](2026_04_24_partial_sqs_compatible_adapter.md) §16.4 marked this as TODO; this document tracks the staged implementation.
+Completing query-protocol support is the last piece needed to claim "drop-in SQS compatibility" for v1-era SDKs. Phase 3.B in [`docs/design/2026_04_24_partial_sqs_compatible_adapter.md`](2026_04_24_partial_sqs_compatible_adapter.md) §16.4 marked this as TODO; this document records the implemented wire surface.
 
 ---
 
@@ -126,7 +124,7 @@ This refactor is mechanical and trivially reviewable: the JSON wrapper before th
 
 ### 4.1 Verb coverage in the current implementation
 
-The shipped implementation provides dispatch, decoding, encoding, error envelope, and the refactor pattern, with the catalog/control-plane verbs wired end-to-end. The pattern then extends mechanically to the remaining message lifecycle and batch verbs (each follow-up adds a parser + response struct + one line in the dispatch table).
+The shipped implementation provides dispatch, decoding, encoding, error envelope, and shared business-logic entry points for the catalog, message lifecycle, and batch verbs.
 
 | Verb | Coverage |
 |---|---|
@@ -137,18 +135,16 @@ The shipped implementation provides dispatch, decoding, encoding, error envelope
 | `GetQueueAttributes` | Supports indexed `AttributeName.N` selection and emits repeated `<Attribute><Name>…</Name><Value>…</Value></Attribute>` pairs in stable name order. |
 | `SetQueueAttributes` | Supports indexed `Attribute.N.Name` / `Attribute.N.Value` pairs and reuses the JSON path's validation, retry, and throttle-invalidation rules. |
 | `PurgeQueue` | Reuses the JSON path's generation bump and 60-second purge limiter. |
+| `SendMessage` | Supports standard and FIFO parameters, `DelaySeconds`, and message attributes. |
+| `ReceiveMessage` | Supports `MaxNumberOfMessages`, `VisibilityTimeout`, `WaitTimeSeconds`, and `MessageAttributeName.N`; emits message, system attribute, and message-attribute XML. |
+| `DeleteMessage` | Reuses the JSON path's stale-handle-idempotent delete semantics. |
+| `ChangeMessageVisibility` | Reuses the JSON path's in-flight validation and visibility-index swap. |
+| `SendMessageBatch` | Supports `SendMessageBatchRequestEntry.N.*`, per-entry message attributes, FIFO fields, and partial-success XML. |
+| `DeleteMessageBatch` | Supports `DeleteMessageBatchRequestEntry.N.*` and partial-success XML. |
+| `ChangeMessageVisibilityBatch` | Supports `ChangeMessageVisibilityBatchRequestEntry.N.*` and partial-success XML. |
 | `TagQueue` / `UntagQueue` / `ListQueueTags` | Supports `Tag.N.Key` / `Tag.N.Value`, `TagKey.N`, and repeated `<Tag>` XML output. |
 
-`SendMessage` / `ReceiveMessage` / `DeleteMessage` are the highest-priority follow-ups; they need the `*Core` refactor to also reach into the FIFO send loop (`sqs_messages.go: sendMessageFifoLoop`) and the in-flight lifecycle, which is mechanical but larger than the control-plane codec.
-
-Verbs **not** yet wired (recorded as TODO in the PR description and in §16.4 of the partial doc):
-
-- `ReceiveMessage` / `DeleteMessage` / `ChangeMessageVisibility` — the in-flight message lifecycle. Each non-trivial because of `Attribute.N` plumbing on responses.
-- `SendMessageBatch` / `DeleteMessageBatch` / `ChangeMessageVisibilityBatch` — query-protocol batch encoding has its own quirks (`SendMessageBatchRequestEntry.1.MessageBody=...`); deserves its own focused PR.
-- `SendMessage` — simple standard-queue sends are straightforward, but FIFO/dedup attributes must share the same core path as JSON before the XML surface can be marked complete.
-- DLQ redrive control-plane verbs — small additions if those public AWS APIs are enabled in the adapter.
-
-The `pickSqsAction` switch returns a **501 `NotImplementedYet`** for any query-protocol Action that has not been wired yet, with an XML envelope that names the missing action. Operators see the gap explicitly rather than silently falling through to JSON-style errors. As verbs land, their entries move from the "TODO" branch to the live dispatch table — no other code changes per added verb.
+Unknown or unsupported Actions still return **501 `NotImplementedYet`** with an XML envelope. That response now only covers SQS APIs outside elastickv's public SQS surface, not missing query-codec coverage for supported JSON verbs.
 
 ---
 
@@ -156,9 +152,9 @@ The `pickSqsAction` switch returns a **501 `NotImplementedYet`** for any query-p
 
 Form parsing uses `net/url.ParseQuery` after `io.ReadAll` on the request body (capped at the existing `sqsMaxRequestBodyBytes` so the query path inherits the JSON path's DoS protection without separate plumbing). Each verb has a dedicated parser that walks the parsed `url.Values` and produces the *same* internal input struct the JSON path already uses — the parsers are the only protocol-specific code per verb.
 
-AWS-style numeric collection encoding (`AttributeName.1=...`, `AttributeName.2=...`) is handled by a single `collectIndexedValues(form url.Values, prefix string) []string` helper that strips the dotted suffix, sorts by the integer index, and returns the values in order. All multi-value parameters (`AttributeNames`, `MessageAttribute.N.Name`, …) go through this helper, so the indexed-collection parsing logic exists once.
+AWS-style numeric collection encoding (`AttributeName.1=...`, `AttributeName.2=...`) is handled by shared indexed helpers that strip dotted suffixes, sort by integer index, and return values or entry groups in order. Multi-value and nested parameters (`AttributeNames`, `MessageAttribute.N.Name`, `SendMessageBatchRequestEntry.N.MessageBody`, …) go through these helpers so the indexed parsing rules are centralized.
 
-`MessageAttribute.N.Name` / `MessageAttribute.N.Value.DataType` / etc. is the only nested case; the code lives in `parseMessageAttributesQuery` and produces the same `[]sqsMessageAttribute` slice the JSON path consumes. No SQS handler sees the difference.
+`MessageAttribute.N.Name` / `MessageAttribute.N.Value.DataType` / etc. is the main nested case; `parseQueryMessageAttributes` produces the same `map[string]sqsMessageAttributeValue` shape the JSON path consumes. Batch message attributes reuse the same parser with a longer prefix (`SendMessageBatchRequestEntry.N.MessageAttribute`).
 
 ---
 
@@ -179,7 +175,7 @@ Response XML follows the AWS SQS QueryProtocol envelope per verb:
 </SendMessageResponse>
 ```
 
-`encoding/xml` marshals every response struct directly. The wrapper `writeSQSQueryResponse(w, action, payload)` constructs the action-specific outer envelope (`<{Action}Response>` + `<{Action}Result>`) and the `<ResponseMetadata>` block, then streams the marshalled payload. Per-verb response struct definitions live in `adapter/sqs_query_responses.go` and use struct tags so the XML schema is grep-able.
+`encoding/xml` marshals every response struct directly. The wrapper `writeSQSQueryResponse(w, action, payload)` constructs the action-specific outer envelope (`<{Action}Response>` + `<{Action}Result>`) and the `<ResponseMetadata>` block, then streams the marshalled payload. Per-verb response struct definitions live in `adapter/sqs_query_protocol.go` and use struct tags so the XML schema is grep-able.
 
 `RequestId` is generated server-side: a 22-character base32 of 16 random bytes. The same value is logged in the access-log line so operator support requests can be cross-referenced.
 
@@ -223,13 +219,12 @@ The conservative default (accept both protocols) matches AWS itself: even region
 
 ## 9. Testing Strategy
 
-1. **Golden-file XML tests** (`adapter/sqs_query_protocol_test.go`):
-   - For each wired verb, build a typical SDK v1 request as `url.Values`, send it through the in-process listener, and assert the XML response byte-for-byte against a stored golden file under `adapter/testdata/sqs_query/<Verb>.xml`.
-   - The golden files are *exactly* what `aws-sdk-java` v1 unmarshals; updating them is a deliberate review event.
+1. **XML round-trip tests** (`adapter/sqs_query_protocol_test.go`):
+   - Build SDK-v1-shaped `url.Values` requests against the in-process listener and decode the XML envelopes.
+   - Cover control-plane round trips, single-message lifecycle, message attributes, and batch send/change/delete.
 
-2. **Round-trip parity** (`adapter/sqs_query_protocol_parity_test.go`):
-   - For each wired verb, perform the same logical operation through both the JSON and query protocols (e.g. `SendMessage` with body `"hello"` and `MessageGroupId=g1` on a FIFO queue).
-   - Read back via `ReceiveMessage` on whichever protocol opposes the send protocol. Confirm body, MD5, attributes, and any sequencing fields match across the two paths.
+2. **Round-trip parity**:
+   - Seed or verify selected state through the JSON protocol where useful (for example, query `CreateQueue` followed by JSON `GetQueueUrl`) so both protocols share the same backing state.
 
 3. **Detection edge cases** (`adapter/sqs_dispatch_test.go`):
    - `Content-Type: application/x-www-form-urlencoded` + missing `Action` → JSON-style 400 `MissingAction`.
@@ -252,10 +247,9 @@ Deployments that *want* to refuse query-protocol traffic (e.g. lock down to v2-S
 Rollout sequence:
 
 1. Landed — implementation + tests for the catalog/control-plane verb subset (§4.1).
-2. Follow-up PR — message lifecycle verbs (`SendMessage`, `ReceiveMessage`, `DeleteMessage`, `ChangeMessageVisibility`).
-3. Follow-up PR — batch verbs.
-4. Follow-up PR — DLQ redrive admin / FIFO administrative verbs if exposed publicly.
-5. Eventually, when the `_partial_` doc's TODO list is empty, the SQS design doc transitions to `_implemented_`.
+2. Landed — message lifecycle verbs (`SendMessage`, `ReceiveMessage`, `DeleteMessage`, `ChangeMessageVisibility`).
+3. Landed — batch verbs (`SendMessageBatch`, `DeleteMessageBatch`, `ChangeMessageVisibilityBatch`).
+4. Future public SQS APIs, if added, should include query-codec entries in the same PR as their JSON handler.
 
 ---
 

--- a/docs/design/2026_04_26_partial_sqs_query_protocol.md
+++ b/docs/design/2026_04_26_partial_sqs_query_protocol.md
@@ -1,6 +1,10 @@
 # SQS Query-Protocol Wire Format Support
 
-**Status:** Proposed
+**Status:** Partial — dispatch, XML success/error envelopes, form parsing,
+and control-plane verbs (`CreateQueue`, `DeleteQueue`, `ListQueues`,
+`GetQueueUrl`, `GetQueueAttributes`, `SetQueueAttributes`, `PurgeQueue`,
+`TagQueue`, `UntagQueue`, `ListQueueTags`) have shipped. Message lifecycle
+and batch XML remain open.
 **Author:** bootjp
 **Date:** 2026-04-26
 
@@ -8,11 +12,11 @@
 
 ## 1. Background and Motivation
 
-The elastickv SQS adapter currently speaks only the **AWS JSON 1.0 protocol**: `Content-Type: application/x-www-form-urlencoded` is rejected, the request must carry `X-Amz-Target: AmazonSQS.<Action>`, and the body is JSON. This matches what the modern AWS SDK v2 family (`aws-sdk-go-v2`, `boto3 ≥ 1.34`, `aws-sdk-java-v2`) emits.
+The elastickv SQS adapter originally spoke only the **AWS JSON 1.0 protocol**: `Content-Type: application/x-www-form-urlencoded` was rejected, the request had to carry `X-Amz-Target: AmazonSQS.<Action>`, and the body was JSON. This matches what the modern AWS SDK v2 family (`aws-sdk-go-v2`, `boto3 ≥ 1.34`, `aws-sdk-java-v2`) emits.
 
-A long tail of clients still emits the older **query protocol** (form-encoded request, XML response) — `aws-sdk-java` v1, older `boto`/`boto3 < 1.34`, every CLI tool that builds requests by hand, and the AWS CLI itself when used against a region that defaults to query. Today these clients fail with `400 MalformedRequest` or `415 UnsupportedMediaType` on the very first request, even though the underlying SQS feature is fully implemented.
+A long tail of clients still emits the older **query protocol** (form-encoded request, XML response) — `aws-sdk-java` v1, older `boto`/`boto3 < 1.34`, every CLI tool that builds requests by hand, and the AWS CLI itself when used against a region that defaults to query. Before the staged query-protocol work, these clients failed with `400 MalformedRequest` or `415 UnsupportedMediaType` on the very first request, even when the underlying SQS feature was already implemented on the JSON path.
 
-Adding query-protocol support is the last piece needed to claim "drop-in SQS compatibility" for v1-era SDKs. Phase 3.B in [`docs/design/2026_04_24_partial_sqs_compatible_adapter.md`](2026_04_24_partial_sqs_compatible_adapter.md) §16.4 marked this as TODO; this document is the proposal that unblocks the implementation.
+Completing query-protocol support is the last piece needed to claim "drop-in SQS compatibility" for v1-era SDKs. Phase 3.B in [`docs/design/2026_04_24_partial_sqs_compatible_adapter.md`](2026_04_24_partial_sqs_compatible_adapter.md) §16.4 marked this as TODO; this document tracks the staged implementation.
 
 ---
 
@@ -24,7 +28,7 @@ Adding query-protocol support is the last piece needed to claim "drop-in SQS com
 2. Reuse every existing handler. The wire codec is the only new code; no SQS business logic moves or duplicates.
 3. Emit XML responses that AWS SDK v1 / older boto unmarshal without modification.
 4. Preserve the existing JSON-protocol behaviour bit-for-bit. No regression test on the JSON path may change.
-5. Keep the doc-driven coverage explicit: the first PR ships a subset of verbs; later PRs widen it without further design work.
+5. Keep the doc-driven coverage explicit: each PR ships a named subset of verbs; later PRs widen it without further design work.
 
 ### 2.2 Non-Goals
 
@@ -120,24 +124,29 @@ func (s *SQSServer) handleQuerySendMessage(w http.ResponseWriter, r *http.Reques
 
 This refactor is mechanical and trivially reviewable: the JSON wrapper before the change is identical to the JSON wrapper after the change, except `decodeSQSJSONInput` and the in-place body have been split. Existing tests cover every verb's JSON path and pass unchanged.
 
-### 4.1 Verb coverage in the first PR
+### 4.1 Verb coverage in the current implementation
 
-The first PR is **architectural proof** — it ships dispatch, decoding, encoding, error envelope, and the refactor pattern, with **three verbs** wired end-to-end as concrete proof. The pattern then extends mechanically to every other verb in follow-up PRs (each follow-up adds a parser + response struct + one line in the dispatch table).
+The shipped implementation provides dispatch, decoding, encoding, error envelope, and the refactor pattern, with the catalog/control-plane verbs wired end-to-end. The pattern then extends mechanically to the remaining message lifecycle and batch verbs (each follow-up adds a parser + response struct + one line in the dispatch table).
 
-| Verb | Why it's in the proof set |
+| Verb | Coverage |
 |---|---|
-| `CreateQueue` | Simplest write verb: takes `QueueName` + optional `Attribute.N`, returns `QueueUrl`. Exercises the indexed-collection parser for `Attribute.N.Name`/`Attribute.N.Value`. |
-| `ListQueues` | Read-only verb. Exercises the repeated-element XML shape (`<QueueUrl>...</QueueUrl>` repeated under `<ListQueuesResult>`) which is harder than the typical leaf-element response. |
-| `GetQueueUrl` | Trivial round-trip verb. Pins that single-leaf XML response shape (`<GetQueueUrlResult><QueueUrl>...</QueueUrl></GetQueueUrlResult>`) and the `QueueDoesNotExist` error envelope path. |
+| `CreateQueue` | Takes `QueueName`, optional `Attribute.N.Name`/`Attribute.N.Value`, and optional `Tag.N.Key`/`Tag.N.Value`; returns `QueueUrl`. |
+| `DeleteQueue` | Takes `QueueUrl`; shares the JSON path's tombstone, throttle invalidation, and receive-fanout cleanup logic. |
+| `ListQueues` | Supports `QueueNamePrefix`, `MaxResults`, and `NextToken`; emits repeated `<QueueUrl>` elements and optional `NextToken`. |
+| `GetQueueUrl` | Pins the single-leaf XML response shape and the `QueueDoesNotExist` error envelope path. |
+| `GetQueueAttributes` | Supports indexed `AttributeName.N` selection and emits repeated `<Attribute><Name>…</Name><Value>…</Value></Attribute>` pairs in stable name order. |
+| `SetQueueAttributes` | Supports indexed `Attribute.N.Name` / `Attribute.N.Value` pairs and reuses the JSON path's validation, retry, and throttle-invalidation rules. |
+| `PurgeQueue` | Reuses the JSON path's generation bump and 60-second purge limiter. |
+| `TagQueue` / `UntagQueue` / `ListQueueTags` | Supports `Tag.N.Key` / `Tag.N.Value`, `TagKey.N`, and repeated `<Tag>` XML output. |
 
-`SendMessage` / `ReceiveMessage` / `DeleteMessage` are the highest-priority follow-ups; they need the `*Core` refactor to also reach into the FIFO send loop (`sqs_messages.go: sendMessageFifoLoop`), which is mechanical but bigger than this proof PR should swallow.
+`SendMessage` / `ReceiveMessage` / `DeleteMessage` are the highest-priority follow-ups; they need the `*Core` refactor to also reach into the FIFO send loop (`sqs_messages.go: sendMessageFifoLoop`) and the in-flight lifecycle, which is mechanical but larger than the control-plane codec.
 
-Verbs **not** in the first round (recorded as TODO in the PR description and in §16.4 of the partial doc):
+Verbs **not** yet wired (recorded as TODO in the PR description and in §16.4 of the partial doc):
 
-- `DeleteQueue`, `GetQueueUrl`, `GetQueueAttributes`, `SetQueueAttributes`, `PurgeQueue` — single-call extensions; each is one parser + one response shape.
 - `ReceiveMessage` / `DeleteMessage` / `ChangeMessageVisibility` — the in-flight message lifecycle. Each non-trivial because of `Attribute.N` plumbing on responses.
 - `SendMessageBatch` / `DeleteMessageBatch` / `ChangeMessageVisibilityBatch` — query-protocol batch encoding has its own quirks (`SendMessageBatchRequestEntry.1.MessageBody=...`); deserves its own focused PR.
-- `TagQueue`, `UntagQueue`, `ListQueueTags`, DLQ redrive control-plane verbs — small additions, easy to land incrementally.
+- `SendMessage` — simple standard-queue sends are straightforward, but FIFO/dedup attributes must share the same core path as JSON before the XML surface can be marked complete.
+- DLQ redrive control-plane verbs — small additions if those public AWS APIs are enabled in the adapter.
 
 The `pickSqsAction` switch returns a **501 `NotImplementedYet`** for any query-protocol Action that has not been wired yet, with an XML envelope that names the missing action. Operators see the gap explicitly rather than silently falling through to JSON-style errors. As verbs land, their entries move from the "TODO" branch to the live dispatch table — no other code changes per added verb.
 
@@ -242,10 +251,11 @@ Deployments that *want* to refuse query-protocol traffic (e.g. lock down to v2-S
 
 Rollout sequence:
 
-1. This PR — implementation + tests for the first verb subset (§4.1).
-2. Follow-up PR — batch verbs + tag verbs.
-3. Follow-up PR — DLQ redrive admin / FIFO administrative verbs.
-4. Eventually, when the `_partial_` doc's TODO list is empty, the SQS design doc transitions to `_implemented_`.
+1. Landed — implementation + tests for the catalog/control-plane verb subset (§4.1).
+2. Follow-up PR — message lifecycle verbs (`SendMessage`, `ReceiveMessage`, `DeleteMessage`, `ChangeMessageVisibility`).
+3. Follow-up PR — batch verbs.
+4. Follow-up PR — DLQ redrive admin / FIFO administrative verbs if exposed publicly.
+5. Eventually, when the `_partial_` doc's TODO list is empty, the SQS design doc transitions to `_implemented_`.
 
 ---
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -34,7 +34,7 @@ YYYY_MM_DD_<status>_<name>.md
 2026_04_20_implemented_lease_read.md
 2026_04_18_proposed_raft_grpc_streaming_transport.md
 2026_02_18_partial_hotspot_shard_split.md
-2026_04_24_proposed_sqs_compatible_adapter.md
+2026_04_24_partial_sqs_compatible_adapter.md
 ```
 
 ## Document header


### PR DESCRIPTION
## Summary
- expand SQS Query protocol parsing and response coverage
- complete query protocol action handling and tests
- mark the SQS query protocol design implemented

## Design doc
- docs/design/2026_04_26_implemented_sqs_query_protocol.md

## Validation
- go test ./adapter -run 'TestSQS.*Query|TestSQSServer_Query|TestSQSQuery|TestParseQuery|TestBuildQuery|TestCreateQueue|TestListQueues' -count=1
- golangci-lint --config=.golangci.yaml run ./adapter --timeout=5m
- git verify-commit for all branch commits

Author: bootjp