### PR TITLE
Add snapshot restore token helper

### DIFF
--- a/cmd/elastickv-snap-token/main.go
+++ b/cmd/elastickv-snap-token/main.go
@@ -19,6 +19,8 @@ import (
 	etcdraftengine "github.com/bootjp/elastickv/internal/raftengine/etcd"
 	"github.com/cockroachdb/errors"
 	etcdsnap "go.etcd.io/etcd/server/v3/etcdserver/api/snap"
+	etcdstorage "go.etcd.io/etcd/server/v3/storage"
+	"go.etcd.io/etcd/server/v3/storage/wal"
 	raftpb "go.etcd.io/raft/v3/raftpb"
 	"go.uber.org/zap"
 )
@@ -27,6 +29,7 @@ const (
 	snapshotTokenVersion = byte(0x01)
 	snapshotTokenSize    = 17
 	snapshotTokenMagic   = "EKVT"
+	pebbleSnapshotMagic  = "EKVPBBL1"
 	fsmFooterSize        = 4
 	copyBufferSize       = 1 << 20
 	dirPerm              = 0o755
@@ -40,6 +43,7 @@ type config struct {
 	dataDir    string
 	snapDir    string
 	fsmSnapDir string
+	walDir     string
 	index      uint64
 	term       uint64
 	voters     []uint64
@@ -63,13 +67,19 @@ func run(argv []string, out io.Writer) error {
 	if err != nil {
 		return err
 	}
-	_, err = fmt.Fprintf(out, "wrote %s and %s (crc32c=%08x)\n", result.fsmPath, result.snapPath, result.crc32c)
+	_, err = fmt.Fprintf(out, "wrote %s, %s, and %s (crc32c=%08x)\n",
+		result.fsmPath,
+		result.snapPath,
+		result.walDir,
+		result.crc32c,
+	)
 	return errors.WithStack(err)
 }
 
 type writeResult struct {
 	fsmPath  string
 	snapPath string
+	walDir   string
 	crc32c   uint32
 }
 
@@ -88,6 +98,7 @@ func parseFlags(argv []string) (config, error) {
 	fs.StringVar(&cfg.dataDir, "data-dir", "", "Raft data directory containing snap/ and fsm-snap/")
 	fs.StringVar(&cfg.snapDir, "snap-dir", "", "Directory for etcd .snap metadata; overrides --data-dir/snap")
 	fs.StringVar(&cfg.fsmSnapDir, "fsm-snap-dir", "", "Directory for footer-sealed .fsm files; overrides --data-dir/fsm-snap")
+	fs.StringVar(&cfg.walDir, "wal-dir", "", "Directory for etcd WAL metadata; overrides --data-dir/wal")
 	fs.StringVar(&indexRaw, "index", "", "Snapshot applied index to write into .snap metadata and fsm-snap filename")
 	fs.StringVar(&termRaw, "term", "", "Raft term to write into .snap metadata filename")
 	fs.StringVar(&votersRaw, "voters", "", "Comma-separated raft IDs for ConfState voters; use node:<uint64> for an explicit node ID")
@@ -120,6 +131,9 @@ func parseFlags(argv []string) (config, error) {
 	if err != nil {
 		return config{}, err
 	}
+	if err := validateConfStateDisjoint(cfg.voters, cfg.learners); err != nil {
+		return config{}, err
+	}
 	return cfg, nil
 }
 
@@ -146,9 +160,12 @@ func resolveOutputDirs(cfg *config) error {
 		if cfg.fsmSnapDir == "" {
 			cfg.fsmSnapDir = filepath.Join(cfg.dataDir, "fsm-snap")
 		}
+		if cfg.walDir == "" {
+			cfg.walDir = filepath.Join(cfg.dataDir, "wal")
+		}
 	}
-	if cfg.snapDir == "" || cfg.fsmSnapDir == "" {
-		return errors.New("pass --data-dir or both --snap-dir and --fsm-snap-dir")
+	if cfg.snapDir == "" || cfg.fsmSnapDir == "" || cfg.walDir == "" {
+		return errors.New("pass --data-dir or --snap-dir, --fsm-snap-dir, and --wal-dir")
 	}
 	return nil
 }
@@ -177,6 +194,22 @@ func parseNodeIDs(name string, raw string, required bool) ([]uint64, error) {
 	return out, nil
 }
 
+func validateConfStateDisjoint(voters []uint64, learners []uint64) error {
+	if len(voters) == 0 || len(learners) == 0 {
+		return nil
+	}
+	seen := make(map[uint64]struct{}, len(voters))
+	for _, id := range voters {
+		seen[id] = struct{}{}
+	}
+	for _, id := range learners {
+		if _, ok := seen[id]; ok {
+			return errors.Errorf("node id %d cannot be listed as both voter and learner", id)
+		}
+	}
+	return nil
+}
+
 func parseOneNodeID(raw string) (uint64, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -200,82 +233,349 @@ func parseOneNodeID(raw string) (uint64, error) {
 	return id, nil
 }
 
-func writeRestorePair(cfg config) (writeResult, error) {
-	if err := os.MkdirAll(cfg.fsmSnapDir, dirPerm); err != nil {
-		return writeResult{}, errors.Wrap(err, "create fsm-snap dir")
-	}
-	if err := os.MkdirAll(cfg.snapDir, dirPerm); err != nil {
-		return writeResult{}, errors.Wrap(err, "create snap dir")
-	}
-	fsmPath := filepath.Join(cfg.fsmSnapDir, fmt.Sprintf("%016x.fsm", cfg.index))
-	snapPath := filepath.Join(cfg.snapDir, fmt.Sprintf("%016x-%016x.snap", cfg.term, cfg.index))
-	if err := ensureCanWrite(fsmPath, cfg.force); err != nil {
-		return writeResult{}, err
-	}
-	if err := ensureCanWrite(snapPath, cfg.force); err != nil {
-		return writeResult{}, err
-	}
-	crc, err := writeFooterSealedFSM(cfg.inputPath, fsmPath)
-	if err != nil {
-		return writeResult{}, err
-	}
-	if err := saveSnapshotToken(cfg, crc); err != nil {
-		return writeResult{}, err
-	}
-	return writeResult{fsmPath: fsmPath, snapPath: snapPath, crc32c: crc}, nil
+type restorePaths struct {
+	fsm  string
+	snap string
+	wal  string
 }
 
-func ensureCanWrite(path string, force bool) error {
-	if _, err := os.Lstat(path); err == nil {
-		if !force {
-			return errors.Errorf("%s already exists; pass --force to overwrite", path)
-		}
-		if err := os.Remove(path); err != nil {
-			return errors.Wrapf(err, "remove existing %s", path)
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return errors.Wrapf(err, "stat %s", path)
+type stagedRestoreArtifacts struct {
+	fsm     string
+	snapDir string
+	snap    string
+	walDir  string
+	crc     uint32
+}
+
+func writeRestorePair(cfg config) (writeResult, error) {
+	if err := validateUnsealedEKVPBBL1(cfg.inputPath); err != nil {
+		return writeResult{}, err
+	}
+	if err := prepareOutputParents(cfg); err != nil {
+		return writeResult{}, err
+	}
+
+	paths := restorePathsForConfig(cfg)
+	staged, cleanup, err := stageRestoreArtifacts(cfg, paths)
+	if err != nil {
+		cleanup()
+		return writeResult{}, err
+	}
+	defer cleanup()
+
+	if err := publishRestoreArtifacts(cfg, paths, staged); err != nil {
+		return writeResult{}, err
+	}
+	return writeResult{fsmPath: paths.fsm, snapPath: paths.snap, walDir: paths.wal, crc32c: staged.crc}, nil
+}
+
+func prepareOutputParents(cfg config) error {
+	if err := os.MkdirAll(cfg.fsmSnapDir, dirPerm); err != nil {
+		return errors.Wrap(err, "create fsm-snap dir")
+	}
+	if err := os.MkdirAll(cfg.snapDir, dirPerm); err != nil {
+		return errors.Wrap(err, "create snap dir")
+	}
+	if err := os.MkdirAll(filepath.Dir(cfg.walDir), dirPerm); err != nil {
+		return errors.Wrap(err, "create WAL parent dir")
 	}
 	return nil
 }
 
-func writeFooterSealedFSM(inputPath string, outputPath string) (uint32, error) {
-	in, err := os.Open(inputPath) //nolint:gosec // operator-supplied path.
+func restorePathsForConfig(cfg config) restorePaths {
+	return restorePaths{
+		fsm:  filepath.Join(cfg.fsmSnapDir, fmt.Sprintf("%016x.fsm", cfg.index)),
+		snap: filepath.Join(cfg.snapDir, fmt.Sprintf("%016x-%016x.snap", cfg.term, cfg.index)),
+		wal:  cfg.walDir,
+	}
+}
+
+func stageRestoreArtifacts(cfg config, paths restorePaths) (stagedRestoreArtifacts, func(), error) {
+	var staged stagedRestoreArtifacts
+	cleanup := func() {
+		_ = os.Remove(staged.fsm)
+		_ = os.RemoveAll(staged.snapDir)
+		_ = os.RemoveAll(staged.walDir)
+	}
+	var err error
+	stagedFSM, crc, err := writeFooterSealedFSMToTemp(cfg.inputPath, cfg.fsmSnapDir)
 	if err != nil {
-		return 0, errors.Wrap(err, "open input .fsm")
+		return staged, cleanup, err
+	}
+	staged.fsm = stagedFSM
+	staged.crc = crc
+
+	stagedSnapDir, err := os.MkdirTemp(cfg.snapDir, ".snap-token-*")
+	if err != nil {
+		return staged, cleanup, errors.Wrap(err, "create staged snap dir")
+	}
+	staged.snapDir = stagedSnapDir
+
+	stagedWALDir, err := reserveTempPath(filepath.Dir(cfg.walDir), ".wal-token-*")
+	if err != nil {
+		return staged, cleanup, errors.Wrap(err, "reserve staged WAL dir")
+	}
+	staged.walDir = stagedWALDir
+
+	if err := writeSnapshotState(cfg, crc, stagedSnapDir, stagedWALDir); err != nil {
+		return staged, cleanup, err
+	}
+
+	staged.snap = filepath.Join(stagedSnapDir, filepath.Base(paths.snap))
+	if _, err := os.Lstat(staged.snap); err != nil {
+		return staged, cleanup, errors.Wrap(err, "stat staged .snap token")
+	}
+	return staged, cleanup, nil
+}
+
+func publishRestoreArtifacts(cfg config, paths restorePaths, staged stagedRestoreArtifacts) error {
+	publisher := newPublishTxn()
+	if err := publisher.publishFile(staged.fsm, paths.fsm, cfg.force); err != nil {
+		publisher.rollback()
+		return err
+	}
+	if err := publisher.publishFile(staged.snap, paths.snap, cfg.force); err != nil {
+		publisher.rollback()
+		return err
+	}
+	if err := publisher.publishDir(staged.walDir, paths.wal, cfg.force); err != nil {
+		publisher.rollback()
+		return err
+	}
+	if err := publisher.commit(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateUnsealedEKVPBBL1(path string) error {
+	in, err := os.Open(path) //nolint:gosec // operator-supplied path.
+	if err != nil {
+		return errors.Wrap(err, "open input .fsm")
 	}
 	defer func() { _ = in.Close() }()
 
-	tmp, err := os.CreateTemp(filepath.Dir(outputPath), "*.fsm.tmp")
+	size, err := validateInputMagic(in)
 	if err != nil {
-		return 0, errors.Wrap(err, "create temp .fsm")
+		return err
+	}
+	return rejectFooterSealedInput(in, size)
+}
+
+func validateInputMagic(in *os.File) (int64, error) {
+	info, err := in.Stat()
+	if err != nil {
+		return 0, errors.Wrap(err, "stat input .fsm")
+	}
+	if info.Size() < int64(len(pebbleSnapshotMagic)) {
+		return 0, errors.Errorf("input is not an %s payload: file too small", pebbleSnapshotMagic)
+	}
+	magic := make([]byte, len(pebbleSnapshotMagic))
+	if _, err := io.ReadFull(in, magic); err != nil {
+		return 0, errors.Wrap(err, "read input magic")
+	}
+	if string(magic) != pebbleSnapshotMagic {
+		return 0, errors.Errorf("input is not an %s payload", pebbleSnapshotMagic)
+	}
+	return info.Size(), nil
+}
+
+func rejectFooterSealedInput(in *os.File, size int64) error {
+	if size <= int64(len(pebbleSnapshotMagic)+fsmFooterSize) {
+		return nil
+	}
+	if _, err := in.Seek(0, io.SeekStart); err != nil {
+		return errors.Wrap(err, "rewind input .fsm")
+	}
+	payloadSize := size - fsmFooterSize
+	h := crc32.New(crc32cTable)
+	if _, err := io.CopyBuffer(h, io.LimitReader(in, payloadSize), make([]byte, copyBufferSize)); err != nil {
+		return errors.Wrap(err, "checksum input .fsm")
+	}
+	var footer [fsmFooterSize]byte
+	if _, err := io.ReadFull(in, footer[:]); err != nil {
+		return errors.Wrap(err, "read input .fsm footer candidate")
+	}
+	if binary.BigEndian.Uint32(footer[:]) == h.Sum32() {
+		return errors.New("input appears to be an already footer-sealed .fsm")
+	}
+	return nil
+}
+
+func reserveTempPath(dir string, pattern string) (string, error) {
+	if err := os.MkdirAll(dir, dirPerm); err != nil {
+		return "", errors.WithStack(err)
+	}
+	f, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	path := f.Name()
+	closeErr := f.Close()
+	removeErr := os.Remove(path)
+	if err := errors.CombineErrors(closeErr, removeErr); err != nil {
+		return "", errors.Wrap(err, "reserve temp path")
+	}
+	return path, nil
+}
+
+type publishTxn struct {
+	paths []publishedPath
+}
+
+type publishedPath struct {
+	final  string
+	backup string
+	isDir  bool
+}
+
+func newPublishTxn() *publishTxn {
+	return &publishTxn{}
+}
+
+func (p *publishTxn) publishFile(src string, dst string, force bool) error {
+	return p.publishPath(src, dst, force, false)
+}
+
+func (p *publishTxn) publishDir(src string, dst string, force bool) error {
+	return p.publishPath(src, dst, force, true)
+}
+
+func (p *publishTxn) publishPath(src string, dst string, force bool, isDir bool) error {
+	if err := os.MkdirAll(filepath.Dir(dst), dirPerm); err != nil {
+		return errors.WithStack(err)
+	}
+	backup, err := moveExistingAside(dst, force)
+	if err != nil {
+		return err
+	}
+	if err := os.Rename(src, dst); err != nil {
+		if backup != "" {
+			_ = os.Rename(backup, dst)
+		}
+		return errors.Wrapf(err, "publish %s", dst)
+	}
+	p.paths = append(p.paths, publishedPath{final: dst, backup: backup, isDir: isDir})
+	if err := syncDir(filepath.Dir(dst)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func moveExistingAside(path string, force bool) (string, error) {
+	info, err := os.Lstat(path)
+	switch {
+	case err == nil:
+		if !force {
+			return "", errors.Errorf("%s already exists; pass --force to overwrite", path)
+		}
+	case errors.Is(err, os.ErrNotExist):
+		return "", nil
+	default:
+		return "", errors.Wrapf(err, "stat %s", path)
+	}
+
+	backup, err := reserveBackupPath(filepath.Dir(path), filepath.Base(path), info.IsDir())
+	if err != nil {
+		return "", err
+	}
+	if err := os.Rename(path, backup); err != nil {
+		return "", errors.Wrapf(err, "move existing %s aside", path)
+	}
+	return backup, nil
+}
+
+func reserveBackupPath(dir string, base string, isDir bool) (string, error) {
+	pattern := "." + base + ".bak-*"
+	if isDir {
+		path, err := os.MkdirTemp(dir, pattern)
+		if err != nil {
+			return "", errors.WithStack(err)
+		}
+		if err := os.Remove(path); err != nil {
+			return "", errors.WithStack(err)
+		}
+		return path, nil
+	}
+	return reserveTempPath(dir, pattern)
+}
+
+func (p *publishTxn) rollback() {
+	for i := len(p.paths) - 1; i >= 0; i-- {
+		published := p.paths[i]
+		_ = removePublishedPath(published.final, published.isDir)
+		if published.backup != "" {
+			_ = os.Rename(published.backup, published.final)
+		}
+		_ = syncDir(filepath.Dir(published.final))
+	}
+	p.paths = nil
+}
+
+func (p *publishTxn) commit() error {
+	var err error
+	for _, published := range p.paths {
+		if published.backup == "" {
+			continue
+		}
+		err = errors.CombineErrors(err, errors.WithStack(os.RemoveAll(published.backup)))
+	}
+	p.paths = nil
+	if err != nil {
+		return errors.Wrap(err, "remove replaced restore artifacts")
+	}
+	return nil
+}
+
+func removePublishedPath(path string, isDir bool) error {
+	if isDir {
+		return errors.WithStack(os.RemoveAll(path))
+	}
+	err := os.Remove(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return errors.WithStack(err)
+}
+
+func writeFooterSealedFSMToTemp(inputPath string, outputDir string) (string, uint32, error) {
+	in, err := os.Open(inputPath) //nolint:gosec // operator-supplied path.
+	if err != nil {
+		return "", 0, errors.Wrap(err, "open input .fsm")
+	}
+	defer func() { _ = in.Close() }()
+
+	tmp, err := os.CreateTemp(outputDir, "*.fsm.tmp")
+	if err != nil {
+		return "", 0, errors.Wrap(err, "create temp .fsm")
 	}
 	tmpPath := tmp.Name()
 	closed := false
+	keep := false
 	defer func() {
 		if !closed {
 			_ = tmp.Close()
 		}
-		_ = os.Remove(tmpPath)
+		if !keep {
+			_ = os.Remove(tmpPath)
+		}
 	}()
 	if err := tmp.Chmod(filePerm); err != nil {
-		return 0, errors.Wrap(err, "chmod temp .fsm")
+		return "", 0, errors.Wrap(err, "chmod temp .fsm")
 	}
 	crc, err := copyPayloadWithFooter(in, tmp)
 	if err != nil {
-		return 0, err
+		return "", 0, err
 	}
 	closed = true
 	if err := tmp.Close(); err != nil {
-		return 0, errors.Wrap(err, "close temp .fsm")
+		return "", 0, errors.Wrap(err, "close temp .fsm")
 	}
-	if err := os.Rename(tmpPath, outputPath); err != nil {
-		return 0, errors.Wrap(err, "publish .fsm")
+	if err := syncDir(outputDir); err != nil {
+		return "", 0, err
 	}
-	if err := syncDir(filepath.Dir(outputPath)); err != nil {
-		return 0, err
-	}
-	return crc, nil
+	keep = true
+	return tmpPath, crc, nil
 }
 
 func copyPayloadWithFooter(in io.Reader, out *os.File) (uint32, error) {
@@ -319,8 +619,41 @@ func (c *crc32CWriter) Sum32() uint32 {
 	return c.h.Sum32()
 }
 
-func saveSnapshotToken(cfg config, crc uint32) error {
-	snapshot := raftpb.Snapshot{
+func writeSnapshotState(cfg config, crc uint32, snapDir string, walDir string) error {
+	logger := zap.NewNop()
+	w, err := wal.Create(logger, walDir, nil)
+	if err != nil {
+		return errors.Wrap(err, "create WAL")
+	}
+	persist := etcdstorage.NewStorage(logger, w, etcdsnap.New(logger, snapDir))
+	closed := false
+	defer func() {
+		if !closed {
+			_ = persist.Close()
+		}
+	}()
+	if err := persist.SaveSnap(snapshotForConfig(cfg, crc)); err != nil {
+		return errors.Wrap(err, "write .snap token and WAL snapshot")
+	}
+	hardState := raftpb.HardState{Term: cfg.term, Commit: cfg.index}
+	if err := persist.Save(hardState, nil); err != nil {
+		return errors.Wrap(err, "write WAL hard state")
+	}
+	closed = true
+	if err := persist.Close(); err != nil {
+		return errors.Wrap(err, "close WAL")
+	}
+	if err := syncDir(snapDir); err != nil {
+		return err
+	}
+	if err := syncDir(walDir); err != nil {
+		return err
+	}
+	return nil
+}
+
+func snapshotForConfig(cfg config, crc uint32) raftpb.Snapshot {
+	return raftpb.Snapshot{
 		Data: encodeSnapshotToken(cfg.index, crc),
 		Metadata: raftpb.SnapshotMetadata{
 			Index: cfg.index,
@@ -331,13 +664,6 @@ func saveSnapshotToken(cfg config, crc uint32) error {
 			},
 		},
 	}
-	if err := etcdsnap.New(zap.NewNop(), cfg.snapDir).SaveSnap(snapshot); err != nil {
-		return errors.Wrap(err, "write .snap token")
-	}
-	if err := syncDir(cfg.snapDir); err != nil {
-		return err
-	}
-	return nil
 }
 
 func encodeSnapshotToken(index uint64, crc uint32) []byte {

--- a/cmd/elastickv-snap-token/main.go
+++ b/cmd/elastickv-snap-token/main.go
@@ -124,7 +124,8 @@ func parseFlags(argv []string) (config, error) {
 }
 
 func parseRequiredUint64(name string, raw string) (uint64, error) {
-	if strings.TrimSpace(raw) == "" {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
 		return 0, errors.Errorf("%s is required", name)
 	}
 	v, err := strconv.ParseUint(raw, 0, 64)
@@ -177,10 +178,12 @@ func parseNodeIDs(name string, raw string, required bool) ([]uint64, error) {
 }
 
 func parseOneNodeID(raw string) (uint64, error) {
+	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return 0, errors.New("empty node id")
 	}
 	if explicit, ok := strings.CutPrefix(raw, "node:"); ok {
+		explicit = strings.TrimSpace(explicit)
 		id, err := strconv.ParseUint(explicit, 0, 64)
 		if err != nil {
 			return 0, errors.Wrap(err, "parse explicit node id")
@@ -223,11 +226,13 @@ func writeRestorePair(cfg config) (writeResult, error) {
 }
 
 func ensureCanWrite(path string, force bool) error {
-	if force {
-		return nil
-	}
 	if _, err := os.Lstat(path); err == nil {
-		return errors.Errorf("%s already exists; pass --force to overwrite", path)
+		if !force {
+			return errors.Errorf("%s already exists; pass --force to overwrite", path)
+		}
+		if err := os.Remove(path); err != nil {
+			return errors.Wrapf(err, "remove existing %s", path)
+		}
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return errors.Wrapf(err, "stat %s", path)
 	}

--- a/cmd/elastickv-snap-token/main.go
+++ b/cmd/elastickv-snap-token/main.go
@@ -1,0 +1,357 @@
+// Command elastickv-snap-token prepares an offline-encoded .fsm for
+// stop-replace-restart restore by writing the disk-offload .fsm file
+// and its matching etcd .snap metadata token.
+package main
+
+import (
+	"bufio"
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"hash"
+	"hash/crc32"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	etcdraftengine "github.com/bootjp/elastickv/internal/raftengine/etcd"
+	"github.com/cockroachdb/errors"
+	etcdsnap "go.etcd.io/etcd/server/v3/etcdserver/api/snap"
+	raftpb "go.etcd.io/raft/v3/raftpb"
+	"go.uber.org/zap"
+)
+
+const (
+	snapshotTokenVersion = byte(0x01)
+	snapshotTokenSize    = 17
+	snapshotTokenMagic   = "EKVT"
+	fsmFooterSize        = 4
+	copyBufferSize       = 1 << 20
+	dirPerm              = 0o755
+	filePerm             = 0o600
+)
+
+var crc32cTable = crc32.MakeTable(crc32.Castagnoli)
+
+type config struct {
+	inputPath  string
+	dataDir    string
+	snapDir    string
+	fsmSnapDir string
+	index      uint64
+	term       uint64
+	voters     []uint64
+	learners   []uint64
+	force      bool
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "elastickv-snap-token: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(argv []string, out io.Writer) error {
+	cfg, err := parseFlags(argv)
+	if err != nil {
+		return err
+	}
+	result, err := writeRestorePair(cfg)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(out, "wrote %s and %s (crc32c=%08x)\n", result.fsmPath, result.snapPath, result.crc32c)
+	return errors.WithStack(err)
+}
+
+type writeResult struct {
+	fsmPath  string
+	snapPath string
+	crc32c   uint32
+}
+
+func parseFlags(argv []string) (config, error) {
+	fs := flag.NewFlagSet("elastickv-snap-token", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+
+	var (
+		cfg         config
+		indexRaw    string
+		termRaw     string
+		votersRaw   string
+		learnersRaw string
+	)
+	fs.StringVar(&cfg.inputPath, "input", "", "Input EKVPBBL1 .fsm payload produced by elastickv-snapshot-encode")
+	fs.StringVar(&cfg.dataDir, "data-dir", "", "Raft data directory containing snap/ and fsm-snap/")
+	fs.StringVar(&cfg.snapDir, "snap-dir", "", "Directory for etcd .snap metadata; overrides --data-dir/snap")
+	fs.StringVar(&cfg.fsmSnapDir, "fsm-snap-dir", "", "Directory for footer-sealed .fsm files; overrides --data-dir/fsm-snap")
+	fs.StringVar(&indexRaw, "index", "", "Snapshot applied index to write into .snap metadata and fsm-snap filename")
+	fs.StringVar(&termRaw, "term", "", "Raft term to write into .snap metadata filename")
+	fs.StringVar(&votersRaw, "voters", "", "Comma-separated raft IDs for ConfState voters; use node:<uint64> for an explicit node ID")
+	fs.StringVar(&learnersRaw, "learners", "", "Comma-separated raft IDs for ConfState learners; use node:<uint64> for an explicit node ID")
+	fs.BoolVar(&cfg.force, "force", false, "Overwrite an existing target .fsm/.snap pair")
+	if err := fs.Parse(argv); err != nil {
+		return config{}, errors.WithStack(err)
+	}
+	if cfg.inputPath == "" {
+		return config{}, errors.New("--input is required")
+	}
+	index, err := parseRequiredUint64("--index", indexRaw)
+	if err != nil {
+		return config{}, err
+	}
+	term, err := parseRequiredUint64("--term", termRaw)
+	if err != nil {
+		return config{}, err
+	}
+	cfg.index = index
+	cfg.term = term
+	if err := resolveOutputDirs(&cfg); err != nil {
+		return config{}, err
+	}
+	cfg.voters, err = parseNodeIDs("--voters", votersRaw, true)
+	if err != nil {
+		return config{}, err
+	}
+	cfg.learners, err = parseNodeIDs("--learners", learnersRaw, false)
+	if err != nil {
+		return config{}, err
+	}
+	return cfg, nil
+}
+
+func parseRequiredUint64(name string, raw string) (uint64, error) {
+	if strings.TrimSpace(raw) == "" {
+		return 0, errors.Errorf("%s is required", name)
+	}
+	v, err := strconv.ParseUint(raw, 0, 64)
+	if err != nil {
+		return 0, errors.Wrapf(err, "parse %s", name)
+	}
+	if v == 0 {
+		return 0, errors.Errorf("%s must be > 0", name)
+	}
+	return v, nil
+}
+
+func resolveOutputDirs(cfg *config) error {
+	if cfg.dataDir != "" {
+		if cfg.snapDir == "" {
+			cfg.snapDir = filepath.Join(cfg.dataDir, "snap")
+		}
+		if cfg.fsmSnapDir == "" {
+			cfg.fsmSnapDir = filepath.Join(cfg.dataDir, "fsm-snap")
+		}
+	}
+	if cfg.snapDir == "" || cfg.fsmSnapDir == "" {
+		return errors.New("pass --data-dir or both --snap-dir and --fsm-snap-dir")
+	}
+	return nil
+}
+
+func parseNodeIDs(name string, raw string, required bool) ([]uint64, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		if required {
+			return nil, errors.Errorf("%s is required", name)
+		}
+		return nil, nil
+	}
+	seen := make(map[uint64]struct{})
+	var out []uint64
+	for _, part := range strings.Split(raw, ",") {
+		id, err := parseOneNodeID(strings.TrimSpace(part))
+		if err != nil {
+			return nil, errors.Wrapf(err, "parse %s", name)
+		}
+		if _, ok := seen[id]; ok {
+			return nil, errors.Errorf("%s contains duplicate node id %d", name, id)
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out, nil
+}
+
+func parseOneNodeID(raw string) (uint64, error) {
+	if raw == "" {
+		return 0, errors.New("empty node id")
+	}
+	if explicit, ok := strings.CutPrefix(raw, "node:"); ok {
+		id, err := strconv.ParseUint(explicit, 0, 64)
+		if err != nil {
+			return 0, errors.Wrap(err, "parse explicit node id")
+		}
+		if id == 0 {
+			return 0, errors.New("node id must be > 0")
+		}
+		return id, nil
+	}
+	id := etcdraftengine.DeriveNodeID(raw)
+	if id == 0 {
+		return 0, errors.New("derived node id is zero")
+	}
+	return id, nil
+}
+
+func writeRestorePair(cfg config) (writeResult, error) {
+	if err := os.MkdirAll(cfg.fsmSnapDir, dirPerm); err != nil {
+		return writeResult{}, errors.Wrap(err, "create fsm-snap dir")
+	}
+	if err := os.MkdirAll(cfg.snapDir, dirPerm); err != nil {
+		return writeResult{}, errors.Wrap(err, "create snap dir")
+	}
+	fsmPath := filepath.Join(cfg.fsmSnapDir, fmt.Sprintf("%016x.fsm", cfg.index))
+	snapPath := filepath.Join(cfg.snapDir, fmt.Sprintf("%016x-%016x.snap", cfg.term, cfg.index))
+	if err := ensureCanWrite(fsmPath, cfg.force); err != nil {
+		return writeResult{}, err
+	}
+	if err := ensureCanWrite(snapPath, cfg.force); err != nil {
+		return writeResult{}, err
+	}
+	crc, err := writeFooterSealedFSM(cfg.inputPath, fsmPath)
+	if err != nil {
+		return writeResult{}, err
+	}
+	if err := saveSnapshotToken(cfg, crc); err != nil {
+		return writeResult{}, err
+	}
+	return writeResult{fsmPath: fsmPath, snapPath: snapPath, crc32c: crc}, nil
+}
+
+func ensureCanWrite(path string, force bool) error {
+	if force {
+		return nil
+	}
+	if _, err := os.Lstat(path); err == nil {
+		return errors.Errorf("%s already exists; pass --force to overwrite", path)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return errors.Wrapf(err, "stat %s", path)
+	}
+	return nil
+}
+
+func writeFooterSealedFSM(inputPath string, outputPath string) (uint32, error) {
+	in, err := os.Open(inputPath) //nolint:gosec // operator-supplied path.
+	if err != nil {
+		return 0, errors.Wrap(err, "open input .fsm")
+	}
+	defer func() { _ = in.Close() }()
+
+	tmp, err := os.CreateTemp(filepath.Dir(outputPath), "*.fsm.tmp")
+	if err != nil {
+		return 0, errors.Wrap(err, "create temp .fsm")
+	}
+	tmpPath := tmp.Name()
+	closed := false
+	defer func() {
+		if !closed {
+			_ = tmp.Close()
+		}
+		_ = os.Remove(tmpPath)
+	}()
+	if err := tmp.Chmod(filePerm); err != nil {
+		return 0, errors.Wrap(err, "chmod temp .fsm")
+	}
+	crc, err := copyPayloadWithFooter(in, tmp)
+	if err != nil {
+		return 0, err
+	}
+	closed = true
+	if err := tmp.Close(); err != nil {
+		return 0, errors.Wrap(err, "close temp .fsm")
+	}
+	if err := os.Rename(tmpPath, outputPath); err != nil {
+		return 0, errors.Wrap(err, "publish .fsm")
+	}
+	if err := syncDir(filepath.Dir(outputPath)); err != nil {
+		return 0, err
+	}
+	return crc, nil
+}
+
+func copyPayloadWithFooter(in io.Reader, out *os.File) (uint32, error) {
+	buf := bufio.NewWriterSize(out, copyBufferSize)
+	crcWriter := newCRC32CWriter(buf)
+	if _, err := io.CopyBuffer(crcWriter, in, make([]byte, copyBufferSize)); err != nil {
+		return 0, errors.Wrap(err, "copy .fsm payload")
+	}
+	crc := crcWriter.Sum32()
+	if err := binary.Write(buf, binary.BigEndian, crc); err != nil {
+		return 0, errors.Wrap(err, "write .fsm footer")
+	}
+	if err := buf.Flush(); err != nil {
+		return 0, errors.Wrap(err, "flush .fsm")
+	}
+	if err := out.Sync(); err != nil {
+		return 0, errors.Wrap(err, "sync .fsm")
+	}
+	return crc, nil
+}
+
+type crc32CWriter struct {
+	w io.Writer
+	h hash.Hash32
+}
+
+func newCRC32CWriter(w io.Writer) *crc32CWriter {
+	return &crc32CWriter{w: w, h: crc32.New(crc32cTable)}
+}
+
+func (c *crc32CWriter) Write(p []byte) (int, error) {
+	n, err := c.w.Write(p)
+	c.h.Write(p[:n])
+	if err != nil {
+		return n, errors.WithStack(err)
+	}
+	return n, nil
+}
+
+func (c *crc32CWriter) Sum32() uint32 {
+	return c.h.Sum32()
+}
+
+func saveSnapshotToken(cfg config, crc uint32) error {
+	snapshot := raftpb.Snapshot{
+		Data: encodeSnapshotToken(cfg.index, crc),
+		Metadata: raftpb.SnapshotMetadata{
+			Index: cfg.index,
+			Term:  cfg.term,
+			ConfState: raftpb.ConfState{
+				Voters:   cfg.voters,
+				Learners: cfg.learners,
+			},
+		},
+	}
+	if err := etcdsnap.New(zap.NewNop(), cfg.snapDir).SaveSnap(snapshot); err != nil {
+		return errors.Wrap(err, "write .snap token")
+	}
+	if err := syncDir(cfg.snapDir); err != nil {
+		return err
+	}
+	return nil
+}
+
+func encodeSnapshotToken(index uint64, crc uint32) []byte {
+	token := make([]byte, snapshotTokenSize)
+	copy(token[:4], snapshotTokenMagic)
+	token[4] = snapshotTokenVersion
+	binary.BigEndian.PutUint64(token[5:13], index)
+	binary.BigEndian.PutUint32(token[13:17], crc)
+	return token
+}
+
+func syncDir(dir string) error {
+	f, err := os.Open(dir) //nolint:gosec // operator-supplied path.
+	if err != nil {
+		return errors.Wrap(err, "open directory for fsync")
+	}
+	defer func() { _ = f.Close() }()
+	if err := f.Sync(); err != nil {
+		return errors.Wrap(err, "fsync directory")
+	}
+	return nil
+}

--- a/cmd/elastickv-snap-token/main_test.go
+++ b/cmd/elastickv-snap-token/main_test.go
@@ -11,6 +11,8 @@ import (
 	etcdraftengine "github.com/bootjp/elastickv/internal/raftengine/etcd"
 	"github.com/stretchr/testify/require"
 	etcdsnap "go.etcd.io/etcd/server/v3/etcdserver/api/snap"
+	"go.etcd.io/etcd/server/v3/storage/wal"
+	raftpb "go.etcd.io/raft/v3/raftpb"
 	"go.uber.org/zap"
 )
 
@@ -46,13 +48,15 @@ func TestRunWritesRestorePair(t *testing.T) {
 	require.Equal(t, []uint64{etcdraftengine.DeriveNodeID("n1"), 2}, snap.Metadata.ConfState.Voters)
 	require.Equal(t, []uint64{etcdraftengine.DeriveNodeID("n3")}, snap.Metadata.ConfState.Learners)
 	require.Equal(t, encodeSnapshotToken(100, crc), snap.Data)
+
+	requireWALSnapshot(t, filepath.Join(dir, "raft", "wal"), *snap)
 }
 
 func TestRunRejectsExistingTargetWithoutForce(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	input := filepath.Join(dir, "payload.fsm")
-	require.NoError(t, os.WriteFile(input, []byte("payload"), 0o600))
+	require.NoError(t, os.WriteFile(input, []byte("EKVPBBL1payload"), 0o600))
 
 	args := []string{
 		"--input", input,
@@ -68,6 +72,95 @@ func TestRunRejectsExistingTargetWithoutForce(t *testing.T) {
 
 	forced := append(append([]string(nil), args...), "--force")
 	require.NoError(t, run(forced, bytes.NewBuffer(nil)))
+}
+
+func TestRunRejectsVoterLearnerOverlap(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	input := filepath.Join(dir, "payload.fsm")
+	require.NoError(t, os.WriteFile(input, []byte("EKVPBBL1payload"), 0o600))
+
+	err := run([]string{
+		"--input", input,
+		"--data-dir", filepath.Join(dir, "raft"),
+		"--index", "1",
+		"--term", "1",
+		"--voters", "node:2",
+		"--learners", "node:2",
+	}, bytes.NewBuffer(nil))
+	require.ErrorContains(t, err, "both voter and learner")
+}
+
+func TestRunRejectsInvalidInputWithoutReplacingExistingArtifacts(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	dataDir := filepath.Join(dir, "raft")
+	input := filepath.Join(dir, "payload.fsm")
+	oldPayload := []byte("EKVPBBL1old-payload")
+	require.NoError(t, os.WriteFile(input, oldPayload, 0o600))
+
+	args := []string{
+		"--input", input,
+		"--data-dir", dataDir,
+		"--index", "10",
+		"--term", "3",
+		"--voters", "n1",
+	}
+	require.NoError(t, run(args, bytes.NewBuffer(nil)))
+
+	fsmPath := filepath.Join(dataDir, "fsm-snap", "000000000000000a.fsm")
+	oldFSM, err := os.ReadFile(fsmPath)
+	require.NoError(t, err)
+	oldSnap, err := etcdsnap.New(zap.NewNop(), filepath.Join(dataDir, "snap")).Load()
+	require.NoError(t, err)
+	requireWALSnapshot(t, filepath.Join(dataDir, "wal"), *oldSnap)
+
+	badInput := filepath.Join(dir, "bad.fsm")
+	require.NoError(t, os.WriteFile(badInput, []byte("not-a-pebble-snapshot"), 0o600))
+	forced := []string{
+		"--input", badInput,
+		"--data-dir", dataDir,
+		"--index", "10",
+		"--term", "3",
+		"--voters", "n1",
+		"--force",
+	}
+	err = run(forced, bytes.NewBuffer(nil))
+	require.ErrorContains(t, err, "EKVPBBL1")
+
+	gotFSM, err := os.ReadFile(fsmPath)
+	require.NoError(t, err)
+	require.Equal(t, oldFSM, gotFSM)
+	gotSnap, err := etcdsnap.New(zap.NewNop(), filepath.Join(dataDir, "snap")).Load()
+	require.NoError(t, err)
+	require.Equal(t, oldSnap.Metadata, gotSnap.Metadata)
+	require.Equal(t, oldSnap.Data, gotSnap.Data)
+	requireWALSnapshot(t, filepath.Join(dataDir, "wal"), *gotSnap)
+}
+
+func TestRunRejectsAlreadyFooterSealedInput(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	input := filepath.Join(dir, "payload.fsm")
+	require.NoError(t, os.WriteFile(input, []byte("EKVPBBL1payload"), 0o600))
+
+	sourceDataDir := filepath.Join(dir, "source")
+	require.NoError(t, run([]string{
+		"--input", input,
+		"--data-dir", sourceDataDir,
+		"--index", "1",
+		"--term", "1",
+		"--voters", "n1",
+	}, bytes.NewBuffer(nil)))
+
+	err := run([]string{
+		"--input", filepath.Join(sourceDataDir, "fsm-snap", "0000000000000001.fsm"),
+		"--data-dir", filepath.Join(dir, "target"),
+		"--index", "2",
+		"--term", "1",
+		"--voters", "n1",
+	}, bytes.NewBuffer(nil))
+	require.ErrorContains(t, err, "already footer-sealed")
 }
 
 func TestParseNodeIDsRequiresVoters(t *testing.T) {
@@ -97,16 +190,35 @@ func TestParseOneNodeIDTrimsExplicitID(t *testing.T) {
 	require.Equal(t, uint64(2), got)
 }
 
-func TestEnsureCanWriteForceRemovesExistingTarget(t *testing.T) {
-	t.Parallel()
-	path := filepath.Join(t.TempDir(), "target.fsm")
-	require.NoError(t, os.WriteFile(path, []byte("old"), 0o600))
-	require.NoError(t, ensureCanWrite(path, true))
-	require.NoFileExists(t, path)
-}
-
 func be32(v uint32) []byte {
 	out := make([]byte, 4)
 	binary.BigEndian.PutUint32(out, v)
 	return out
+}
+
+func requireWALSnapshot(t *testing.T, walDir string, snap raftpb.Snapshot) {
+	t.Helper()
+
+	walSnaps, err := wal.ValidSnapshotEntries(zap.NewNop(), walDir)
+	require.NoError(t, err)
+
+	var found bool
+	for _, walSnap := range walSnaps {
+		if walSnap.Index != snap.Metadata.Index || walSnap.Term != snap.Metadata.Term {
+			continue
+		}
+		found = true
+		require.NotNil(t, walSnap.ConfState)
+		require.Equal(t, snap.Metadata.ConfState, *walSnap.ConfState)
+
+		w, err := wal.Open(zap.NewNop(), walDir, walSnap)
+		require.NoError(t, err)
+		_, hardState, entries, err := w.ReadAll()
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+		require.Equal(t, snap.Metadata.Term, hardState.Term)
+		require.Equal(t, snap.Metadata.Index, hardState.Commit)
+		require.Empty(t, entries)
+	}
+	require.True(t, found, "missing WAL snapshot entry for %d/%d", snap.Metadata.Term, snap.Metadata.Index)
 }

--- a/cmd/elastickv-snap-token/main_test.go
+++ b/cmd/elastickv-snap-token/main_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"hash/crc32"
+	"os"
+	"path/filepath"
+	"testing"
+
+	etcdraftengine "github.com/bootjp/elastickv/internal/raftengine/etcd"
+	"github.com/stretchr/testify/require"
+	etcdsnap "go.etcd.io/etcd/server/v3/etcdserver/api/snap"
+	"go.uber.org/zap"
+)
+
+func TestRunWritesRestorePair(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	input := filepath.Join(dir, "payload.fsm")
+	payload := []byte("EKVPBBL1payload")
+	require.NoError(t, os.WriteFile(input, payload, 0o600))
+
+	var stdout bytes.Buffer
+	err := run([]string{
+		"--input", input,
+		"--data-dir", filepath.Join(dir, "raft"),
+		"--index", "100",
+		"--term", "7",
+		"--voters", "n1,node:2",
+		"--learners", "n3",
+	}, &stdout)
+	require.NoError(t, err)
+	require.Contains(t, stdout.String(), "crc32c=")
+
+	crc := crc32.Checksum(payload, crc32cTable)
+	fsmPath := filepath.Join(dir, "raft", "fsm-snap", "0000000000000064.fsm")
+	fsmBytes, err := os.ReadFile(fsmPath)
+	require.NoError(t, err)
+	require.Equal(t, append(payload, be32(crc)...), fsmBytes)
+
+	snap, err := etcdsnap.New(zap.NewNop(), filepath.Join(dir, "raft", "snap")).Load()
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), snap.Metadata.Index)
+	require.Equal(t, uint64(7), snap.Metadata.Term)
+	require.Equal(t, []uint64{etcdraftengine.DeriveNodeID("n1"), 2}, snap.Metadata.ConfState.Voters)
+	require.Equal(t, []uint64{etcdraftengine.DeriveNodeID("n3")}, snap.Metadata.ConfState.Learners)
+	require.Equal(t, encodeSnapshotToken(100, crc), snap.Data)
+}
+
+func TestRunRejectsExistingTargetWithoutForce(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	input := filepath.Join(dir, "payload.fsm")
+	require.NoError(t, os.WriteFile(input, []byte("payload"), 0o600))
+
+	args := []string{
+		"--input", input,
+		"--data-dir", filepath.Join(dir, "raft"),
+		"--index", "1",
+		"--term", "1",
+		"--voters", "n1",
+	}
+	require.NoError(t, run(args, bytes.NewBuffer(nil)))
+	err := run(args, bytes.NewBuffer(nil))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "already exists")
+
+	forced := append(append([]string(nil), args...), "--force")
+	require.NoError(t, run(forced, bytes.NewBuffer(nil)))
+}
+
+func TestParseNodeIDsRequiresVoters(t *testing.T) {
+	t.Parallel()
+	_, err := parseNodeIDs("--voters", "", true)
+	require.Error(t, err)
+
+	got, err := parseNodeIDs("--voters", "n1,node:2", true)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{etcdraftengine.DeriveNodeID("n1"), 2}, got)
+
+	_, err = parseNodeIDs("--voters", "node:0", true)
+	require.ErrorContains(t, err, "node id must be > 0")
+}
+
+func be32(v uint32) []byte {
+	out := make([]byte, 4)
+	binary.BigEndian.PutUint32(out, v)
+	return out
+}

--- a/cmd/elastickv-snap-token/main_test.go
+++ b/cmd/elastickv-snap-token/main_test.go
@@ -83,6 +83,28 @@ func TestParseNodeIDsRequiresVoters(t *testing.T) {
 	require.ErrorContains(t, err, "node id must be > 0")
 }
 
+func TestParseRequiredUint64TrimsWhitespace(t *testing.T) {
+	t.Parallel()
+	got, err := parseRequiredUint64("--index", " 0x64 ")
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), got)
+}
+
+func TestParseOneNodeIDTrimsExplicitID(t *testing.T) {
+	t.Parallel()
+	got, err := parseOneNodeID(" node: 2 ")
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), got)
+}
+
+func TestEnsureCanWriteForceRemovesExistingTarget(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "target.fsm")
+	require.NoError(t, os.WriteFile(path, []byte("old"), 0o600))
+	require.NoError(t, ensureCanWrite(path, true))
+	require.NoFileExists(t, path)
+}
+
 func be32(v uint32) []byte {
 	out := make([]byte, 4)
 	binary.BigEndian.PutUint32(out, v)

--- a/cmd/elastickv-snapshot-decode/main.go
+++ b/cmd/elastickv-snapshot-decode/main.go
@@ -1,6 +1,6 @@
 // Command elastickv-snapshot-decode is the Phase 0a snapshot
 // decoder described in
-// docs/design/2026_04_29_proposed_snapshot_logical_decoder.md.
+// docs/design/2026_04_29_implemented_snapshot_logical_decoder.md.
 //
 // It reads a Pebble snapshot (`.fsm`) emitted by the live FSM
 // (store/lsm_store.go) and writes a vendor-independent per-adapter

--- a/docs/design/2026_04_29_implemented_snapshot_logical_decoder.md
+++ b/docs/design/2026_04_29_implemented_snapshot_logical_decoder.md
@@ -8,7 +8,7 @@ Date: 2026-04-29
 > `internal/backup/` + `cmd/elastickv-snapshot-decode` (PRs #790,
 > #791, #792, #806, #810). Phase 0b (encoder) has shipped and is
 > specified in detail in
-> `2026_05_25_implemented_snapshot_logical_encoder.md`. Phase 0c
+> `2026_05_25_partial_snapshot_logical_encoder.md`. Phase 0c
 > (operator integration) is now shipped via `cmd/elastickv-snap-token`
 > and `docs/operations/snapshot_restore.md`. This doc remains the
 > format owner; the encoder doc owns the reverse-direction wire-format
@@ -547,9 +547,10 @@ right index, etc.). Operators restore by:
    encoder writes the native EKVPBBL1 payload stream (no footer);
    `elastickv-snap-token` copies that payload into
    `{dataDir}/fsm-snap/<index>.fsm`, appends the disk-offload CRC32C
-   footer, and writes the matching `{term}-{index}.snap` file whose
+   footer, writes the matching `{term}-{index}.snap` file whose
    `raftpb.Snapshot.Data` is the 17-byte EKVT token described in
-   `2026_04_14_implemented_etcd_snapshot_disk_offload.md`.
+   `2026_04_14_implemented_etcd_snapshot_disk_offload.md`, and seeds
+   `wal/` with the matching snapshot pointer plus hard-state commit.
 3. Confirm the generated `ENCODE_INFO.json`, `MANIFEST.json`,
    target `cluster_id`, `term`, `index`, and voter set match the
    target restore plan before starting the node.
@@ -562,9 +563,9 @@ node.
 
 For a *fresh cluster* (zero state, just-bootstrapped), use
 `elastickv-snap-token --term 1` with the intended initial voter set.
-The helper still writes the footer-sealed `.fsm` plus `.snap` pair;
-placing the raw encoder output directly under `fsm-snap/` is not a
-valid disk-offload artifact.
+The helper still writes the footer-sealed `.fsm`, `.snap`, and `wal/`
+set; placing the raw encoder output directly under `fsm-snap/` is not
+a valid disk-offload artifact.
 
 The runbook for both is documented in
 `docs/operations/snapshot_restore.md`.
@@ -673,8 +674,9 @@ bespoke parser, the format has failed its goal.
 - Self-test: encode → decode round-trip asserts byte-identical
   output for the user-visible directory tree (modulo wall-time and
   encoder version metadata).
-- End-to-end test: encode a synthetic dump, place output in a
-  fresh single-node cluster's `fsm-snap/` + `snap/`, start the
+- End-to-end test: encode a synthetic dump, seal it with
+  `cmd/elastickv-snap-token`, place the generated `fsm-snap/`,
+  `snap/`, and `wal/` under a fresh single-node cluster, start the
   cluster, verify reads return the original data via the
   DynamoDB / S3 / Redis / SQS adapters.
 
@@ -684,7 +686,7 @@ bespoke parser, the format has failed its goal.
 - The helper copies an encoder-produced EKVPBBL1 payload into the
   disk-offload `{dataDir}/fsm-snap/<index>.fsm` shape, appends the
   CRC32C footer, and writes the matching `.snap` EKVT token metadata
-  through etcd's `Snapshotter`.
+  plus WAL snapshot pointer through etcd's storage APIs.
 - The helper fails closed on existing target artifacts unless
   `--force` is supplied, requires `--term`, `--index`, and `--voters`,
   and supports `node:<uint64>` for explicit raft node IDs.
@@ -719,11 +721,11 @@ bespoke parser, the format has failed its goal.
 
 | Test | Verifies |
 |------|---|
-| `TestEncoderProducesLoadableSnapshot` | Encoder output placed under a fresh node's `fsm-snap/` + `snap/` is loaded successfully on `Open`; the resulting cluster serves the original data via every adapter |
+| `TestEncoderProducesLoadableSnapshot` | Encoder output sealed through `cmd/elastickv-snap-token` and placed under a fresh node's `fsm-snap/`, `snap/`, and `wal/` is loaded successfully on `Open`; the resulting cluster serves the original data via every adapter |
 | `TestLongKeySHA256Fallback` | A 1 KiB key encodes to `<sha256-prefix-32>__<truncated>`; `KEYMAP.jsonl` records the original; encoder reverses correctly |
 | `TestExternalToolReplay` | Generated `aws s3 sync` / `aws dynamodb put-item` / `redis-cli --pipe` scripts (run in CI against MinIO / a local DynamoDB / a real Redis) reproduce the decoded state on a non-elastickv target |
 | `TestEncoderClusterIDGuard` | Encoder writes `cluster_id` in `MANIFEST.json`; the restore runbook step refuses to place the file if the target node's `cluster_id` differs |
-| `TestSnapTokenWritesRestorePair` | `cmd/elastickv-snap-token` writes a footer-sealed `fsm-snap/<index>.fsm`, a matching EKVT `.snap`, and the requested ConfState voter/learner sets |
+| `TestSnapTokenWritesRestorePair` | `cmd/elastickv-snap-token` writes a footer-sealed `fsm-snap/<index>.fsm`, a matching EKVT `.snap`, a WAL snapshot pointer, and the requested ConfState voter/learner sets |
 | `TestPhaseFieldDistinguishesPhase0And1` | A Phase 1 dump and a Phase 0 dump containing the same logical state both pass the decoder's structural validation but `MANIFEST.phase` distinguishes them |
 
 ### P2

--- a/docs/design/2026_04_29_implemented_snapshot_logical_decoder.md
+++ b/docs/design/2026_04_29_implemented_snapshot_logical_decoder.md
@@ -1,16 +1,18 @@
 # Snapshot ↔ Logical-Format Decoder (Phase 0)
 
-Status: Partial
+Status: Implemented
 Author: bootjp
 Date: 2026-04-29
 
-> **Lifecycle (2026-05-25):** Phase 0a (decoder) has fully shipped —
+> **Lifecycle (2026-07-07):** Phase 0a (decoder) has fully shipped —
 > `internal/backup/` + `cmd/elastickv-snapshot-decode` (PRs #790,
-> #791, #792, #806, #810). Phase 0b (encoder) is specified in detail
-> in `2026_05_25_proposed_snapshot_logical_encoder.md` and is not yet
-> implemented. Phase 0c (operator integration) is open. This doc
-> remains the format owner; the encoder doc owns the reverse-direction
-> wire-format reconstruction.
+> #791, #792, #806, #810). Phase 0b (encoder) has shipped and is
+> specified in detail in
+> `2026_05_25_implemented_snapshot_logical_encoder.md`. Phase 0c
+> (operator integration) is now shipped via `cmd/elastickv-snap-token`
+> and `docs/operations/snapshot_restore.md`. This doc remains the
+> format owner; the encoder doc owns the reverse-direction wire-format
+> reconstruction.
 
 ## Background
 
@@ -541,13 +543,16 @@ non-trivial (would need pause/resume Apply, install snapshot at the
 right index, etc.). Operators restore by:
 
 1. Stop the target node.
-2. Generate the matching `.snap` token file (see
-   `2026_04_14_implemented_etcd_snapshot_disk_offload.md` for the
-   17-byte EKVT format) using a small `cmd/elastickv-snap-token`
-   helper that takes the `.fsm` path and emits the token file.
-3. Place the new `.fsm` in `{dataDir}/fsm-snap/<index>.fsm` and the
-   token in `{dataDir}/snap/<index>.snap` (atomic rename of both,
-   then `syncDir` of both directories).
+2. Run `cmd/elastickv-snap-token` against the encoder output. The
+   encoder writes the native EKVPBBL1 payload stream (no footer);
+   `elastickv-snap-token` copies that payload into
+   `{dataDir}/fsm-snap/<index>.fsm`, appends the disk-offload CRC32C
+   footer, and writes the matching `{term}-{index}.snap` file whose
+   `raftpb.Snapshot.Data` is the 17-byte EKVT token described in
+   `2026_04_14_implemented_etcd_snapshot_disk_offload.md`.
+3. Confirm the generated `ENCODE_INFO.json`, `MANIFEST.json`,
+   target `cluster_id`, `term`, `index`, and voter set match the
+   target restore plan before starting the node.
 4. Start the node. It loads the snapshot at startup as if it had
    just installed it from a leader.
 
@@ -555,14 +560,14 @@ For multi-node clusters: do this on one node first, then re-add the
 others as fresh members so they snapshot-install from the seeded
 node.
 
-For a *fresh cluster* (zero state, just-bootstrapped), the encoder
-output can be placed directly under `fsm-snap/` and the cluster
-opens to it as its initial state. This is the cleanest restore
-path.
+For a *fresh cluster* (zero state, just-bootstrapped), use
+`elastickv-snap-token --term 1` with the intended initial voter set.
+The helper still writes the footer-sealed `.fsm` plus `.snap` pair;
+placing the raw encoder output directly under `fsm-snap/` is not a
+valid disk-offload artifact.
 
 The runbook for both is documented in
-`docs/operations/snapshot_restore.md` (separate PR after this
-design lands).
+`docs/operations/snapshot_restore.md`.
 
 ### External tools
 
@@ -660,10 +665,6 @@ bespoke parser, the format has failed its goal.
   - `internal/backup/sqs.go` — `_queue.json` + `messages.jsonl`.
 - Filename encoding lives in `internal/backup/filename.go` with
   shared unit tests for round-trip safety.
-- `cmd/elastickv-snap-token` helper for synthesizing the matching
-  `.snap` EKVT token file from a `.fsm`.
-- Documentation: `docs/operations/snapshot_restore.md` runbook
-  (separate PR after this design lands).
 
 ### Phase 0b — Encoder
 
@@ -679,10 +680,21 @@ bespoke parser, the format has failed its goal.
 
 ### Phase 0c — Operator integration
 
-- Stop-replace-restart runbook in `docs/operations/`.
-- Cluster-id and version-compatibility guards.
-- Tar / tar+zstd helpers for shipping decoded directory trees off
-  the host.
+- New binary `cmd/elastickv-snap-token/`.
+- The helper copies an encoder-produced EKVPBBL1 payload into the
+  disk-offload `{dataDir}/fsm-snap/<index>.fsm` shape, appends the
+  CRC32C footer, and writes the matching `.snap` EKVT token metadata
+  through etcd's `Snapshotter`.
+- The helper fails closed on existing target artifacts unless
+  `--force` is supplied, requires `--term`, `--index`, and `--voters`,
+  and supports `node:<uint64>` for explicit raft node IDs.
+- Stop-replace-restart runbook in `docs/operations/snapshot_restore.md`.
+- Cluster-id and version-compatibility guards are documented in the
+  runbook and enforced by operator verification of `MANIFEST.json` and
+  `ENCODE_INFO.json`; live cluster-id discovery remains out of scope
+  for offline Phase 0.
+- Tar / tar+zstd shipping helpers remain a convenience script layer,
+  not part of the core recovery contract.
 
 ## Required Tests
 
@@ -711,6 +723,7 @@ bespoke parser, the format has failed its goal.
 | `TestLongKeySHA256Fallback` | A 1 KiB key encodes to `<sha256-prefix-32>__<truncated>`; `KEYMAP.jsonl` records the original; encoder reverses correctly |
 | `TestExternalToolReplay` | Generated `aws s3 sync` / `aws dynamodb put-item` / `redis-cli --pipe` scripts (run in CI against MinIO / a local DynamoDB / a real Redis) reproduce the decoded state on a non-elastickv target |
 | `TestEncoderClusterIDGuard` | Encoder writes `cluster_id` in `MANIFEST.json`; the restore runbook step refuses to place the file if the target node's `cluster_id` differs |
+| `TestSnapTokenWritesRestorePair` | `cmd/elastickv-snap-token` writes a footer-sealed `fsm-snap/<index>.fsm`, a matching EKVT `.snap`, and the requested ConfState voter/learner sets |
 | `TestPhaseFieldDistinguishesPhase0And1` | A Phase 1 dump and a Phase 0 dump containing the same logical state both pass the decoder's structural validation but `MANIFEST.phase` distinguishes them |
 
 ### P2

--- a/docs/design/2026_04_29_proposed_logical_backup.md
+++ b/docs/design/2026_04_29_proposed_logical_backup.md
@@ -13,7 +13,7 @@ given dump.
 
 | Phase | Doc | Scope |
 |-------|-----|-------|
-| **Phase 0** | [`2026_04_29_proposed_snapshot_logical_decoder.md`](./2026_04_29_proposed_snapshot_logical_decoder.md) | Offline `.fsm` ↔ logical-format directory tree converter. No live cluster, no admin RPCs, no FSM/Raft changes. **Owns the format definition.** Sufficient for single-shard clusters, one-time exports off elastickv, and any use case where the latest available snapshot is a good-enough recovery point. |
+| **Phase 0** | [`2026_04_29_implemented_snapshot_logical_decoder.md`](./2026_04_29_implemented_snapshot_logical_decoder.md) | Offline `.fsm` ↔ logical-format directory tree converter. No live cluster, no admin RPCs, no FSM/Raft changes. **Owns the format definition.** Sufficient for single-shard clusters, one-time exports off elastickv, and any use case where the latest available snapshot is a good-enough recovery point. |
 | **Phase 1 (this doc)** | This file | Live, running-cluster extraction with cluster-wide point-in-time consistency across multiple Raft groups. Adds `BeginBackup` / `RenewBackup` / `EndBackup` admin RPCs, replicated `BackupPin` / `Extend` / `Release` Raft FSM commands, version-gated rolling-upgrade safety, expected-keys baseline. Required only when cross-shard PIT consistency or "snapshot now" cadence is needed. |
 
 The format details (per-adapter directory layout, filename encoding,

--- a/docs/design/2026_05_25_partial_snapshot_logical_encoder.md
+++ b/docs/design/2026_05_25_partial_snapshot_logical_encoder.md
@@ -6,7 +6,7 @@ Date: 2026-05-25 (promoted proposed → partial 2026-06-01 in PR #896)
 
 ## Background
 
-Phase 0a (`2026_04_29_partial_snapshot_logical_decoder.md`,
+Phase 0a (`2026_04_29_implemented_snapshot_logical_decoder.md`,
 milestones all merged: PRs #790, #791, #792, #806, #810) shipped the
 **decoder**: an offline tool that reads a native Pebble `.fsm`
 snapshot and writes a vendor-independent, per-adapter directory tree
@@ -453,7 +453,7 @@ P2:
 
 ## References
 
-- `2026_04_29_partial_snapshot_logical_decoder.md` — Phase 0 format
+- `2026_04_29_implemented_snapshot_logical_decoder.md` — Phase 0 format
   owner; Phase 0a (decoder) shipped. Promoted to `partial` on landing
   this doc.
 - `2026_04_29_proposed_logical_backup.md` — Phase 1 (live PIT

--- a/docs/design/2026_05_25_partial_snapshot_logical_encoder.md
+++ b/docs/design/2026_05_25_partial_snapshot_logical_encoder.md
@@ -442,7 +442,7 @@ P1:
 
 | Test | Verifies |
 |---|---|
-| `TestEncoderProducesLoadableSnapshot` | Output placed under a fresh node's `fsm-snap/` + `snap/` loads on `Open`; every adapter serves the original data |
+| `TestEncoderProducesLoadableSnapshot` | Output sealed through `cmd/elastickv-snap-token` and placed under a fresh node's `fsm-snap/`, `snap/`, and `wal/` loads on `Open`; every adapter serves the original data |
 | `TestEncoderClusterIDProvenance` | `ENCODE_INFO.json` carries `cluster_id` + key-format version; mismatch is detectable by the runbook step |
 
 P2:
@@ -459,7 +459,8 @@ P2:
 - `2026_04_29_proposed_logical_backup.md` — Phase 1 (live PIT
   extraction); produces the same directory format this encoder reads.
 - `2026_04_14_implemented_etcd_snapshot_disk_offload.md` — the `.fsm`
-  / `.snap` EKVT token format the restore runbook seeds.
+  / `.snap` EKVT token and WAL snapshot-pointer format the restore
+  runbook seeds.
 - `store/snapshot_pebble.go` (`WriteTo`),
   `internal/backup/snapshot_reader.go` (`ReadSnapshot`) — the
   authoritative native `.fsm` format this encoder must reproduce.

--- a/docs/operations/snapshot_restore.md
+++ b/docs/operations/snapshot_restore.md
@@ -1,0 +1,115 @@
+# Snapshot Logical Restore Runbook
+
+This runbook restores a Phase 0 logical dump into a stopped elastickv
+node by converting the dump back to an EKVPBBL1 payload and then
+sealing that payload into the Raft disk-offload snapshot layout.
+
+Use this only while the target node is stopped. Phase 0 is an offline
+restore path; it is not a live import RPC.
+
+## Inputs
+
+- A decoded logical dump directory containing `MANIFEST.json`.
+- A target raft data directory for one raft group.
+- The target snapshot `index`, `term`, and ConfState voter set.
+- The target cluster plan, including the intended `cluster_id`.
+
+The encoder output is a native EKVPBBL1 payload stream without the
+disk-offload CRC32C footer. Do not copy it directly into
+`fsm-snap/`. Always run `elastickv-snap-token` to produce the
+footer-sealed `.fsm` and the matching `.snap` token metadata.
+
+## Single-Node Fresh Restore
+
+1. Stop the target process.
+
+2. Encode the logical tree:
+
+   ```sh
+   elastickv-snapshot-encode \
+     --input /backup/dump \
+     --output /tmp/restore.fsm \
+     --self-test
+   ```
+
+3. Inspect `/backup/dump/MANIFEST.json` and
+   `/tmp/restore.fsm.encode_info.json`. Confirm `cluster_id`,
+   `format_version`, `last_commit_ts`, and enabled adapters match the
+   restore plan.
+
+4. Generate the restore pair. `--voters` uses the same string IDs as
+   `--raftId`; use `node:<uint64>` only when the target was configured
+   with an explicit numeric raft node ID.
+
+   ```sh
+   elastickv-snap-token \
+     --input /tmp/restore.fsm \
+     --data-dir /var/lib/elastickv/group-1 \
+     --index 1 \
+     --term 1 \
+     --voters n1
+   ```
+
+   This writes:
+
+   ```text
+   /var/lib/elastickv/group-1/fsm-snap/0000000000000001.fsm
+   /var/lib/elastickv/group-1/snap/0000000000000001-0000000000000001.snap
+   ```
+
+5. Start the node with the same raft ID and raft data directory.
+
+6. Verify adapter reads against the restored data before accepting
+   writes.
+
+## Existing Cluster Restore
+
+For a cluster that already had multiple members, restore into one
+stopped seed node first, then rebuild the other members from that
+seed by rejoining or re-adding them. Do not place the same logical
+snapshot independently onto multiple live members; each member's WAL,
+term, membership metadata, and applied-index state must agree.
+
+Use the target group's current or planned ConfState:
+
+```sh
+elastickv-snap-token \
+  --input /tmp/restore.fsm \
+  --data-dir /var/lib/elastickv/group-1 \
+  --index 18432021 \
+  --term 57 \
+  --voters n1,n2,n3
+```
+
+If a target `.fsm` or `.snap` already exists, the helper refuses to
+overwrite it. Use `--force` only after moving the old artifacts out of
+the data directory or after confirming this is an intentional retry of
+the same restore operation.
+
+## Multi-Group Restore
+
+Run the encode and token-seal flow once per raft group. Phase 0
+snapshots are per-group and can represent different applied indexes.
+If the application requires a single cross-group point in time, use a
+future Phase 1 live pinned backup instead of this offline path.
+
+For each group:
+
+1. Select that group's logical dump or encoded `.fsm`.
+2. Run `elastickv-snap-token` with that group's `--data-dir`,
+   `--index`, `--term`, and voter set.
+3. Start only after every group directory has a matching
+   `fsm-snap/<index>.fsm` and `snap/<term>-<index>.snap` pair.
+
+## Safety Checks
+
+- Confirm the target process is stopped before writing under the data
+  directory.
+- Keep a copy of the pre-restore `wal/`, `snap/`, and `fsm-snap/`
+  directories until verification completes.
+- Match `--voters` to the raft IDs or explicit node IDs used by the
+  target configuration.
+- Do not lower the HLC ceiling: `elastickv-snapshot-encode` rejects a
+  `--last-commit-ts` below `MANIFEST.last_commit_ts`.
+- Treat Phase 0 dumps as per-group crash-consistent artifacts, not as
+  live cluster-wide point-in-time backups.

--- a/docs/operations/snapshot_restore.md
+++ b/docs/operations/snapshot_restore.md
@@ -17,7 +17,8 @@ restore path; it is not a live import RPC.
 The encoder output is a native EKVPBBL1 payload stream without the
 disk-offload CRC32C footer. Do not copy it directly into
 `fsm-snap/`. Always run `elastickv-snap-token` to produce the
-footer-sealed `.fsm` and the matching `.snap` token metadata.
+footer-sealed `.fsm`, the matching `.snap` token metadata, and the
+WAL snapshot pointer that makes startup consume that token.
 
 ## Single-Node Fresh Restore
 
@@ -55,6 +56,7 @@ footer-sealed `.fsm` and the matching `.snap` token metadata.
    ```text
    /var/lib/elastickv/group-1/fsm-snap/0000000000000001.fsm
    /var/lib/elastickv/group-1/snap/0000000000000001-0000000000000001.snap
+   /var/lib/elastickv/group-1/wal/
    ```
 
 5. Start the node with the same raft ID and raft data directory.
@@ -81,10 +83,10 @@ elastickv-snap-token \
   --voters n1,n2,n3
 ```
 
-If a target `.fsm` or `.snap` already exists, the helper refuses to
-overwrite it. Use `--force` only after moving the old artifacts out of
-the data directory or after confirming this is an intentional retry of
-the same restore operation.
+If a target `.fsm`, `.snap`, or `wal/` already exists, the helper
+refuses to overwrite it. `--force` stages the replacement set first
+and only then swaps it into place, but keep an external backup until
+the restored node has been verified.
 
 ## Multi-Group Restore
 
@@ -99,7 +101,8 @@ For each group:
 2. Run `elastickv-snap-token` with that group's `--data-dir`,
    `--index`, `--term`, and voter set.
 3. Start only after every group directory has a matching
-   `fsm-snap/<index>.fsm` and `snap/<term>-<index>.snap` pair.
+   `fsm-snap/<index>.fsm`, `snap/<term>-<index>.snap`, and `wal/`
+   snapshot pointer.
 
 ## Safety Checks
 

--- a/internal/backup/decode.go
+++ b/internal/backup/decode.go
@@ -12,7 +12,7 @@ import (
 // decode.go orchestrates the per-prefix dispatch from a raw `.fsm`
 // stream into the four adapter encoders (DynamoDB, S3, Redis, SQS).
 // It is the Phase 0a glue documented in §"Pipeline" of
-// docs/design/2026_04_29_proposed_snapshot_logical_decoder.md.
+// docs/design/2026_04_29_implemented_snapshot_logical_decoder.md.
 //
 // The dispatcher is intentionally thin: every per-record decision
 // (manifest reassembly, TTL inlining, side-record exclusion, ...) is

--- a/internal/backup/dynamodb.go
+++ b/internal/backup/dynamodb.go
@@ -44,7 +44,7 @@ var (
 )
 
 // DDBEncoder encodes the DynamoDB prefix family into the per-table layout
-// described in docs/design/2026_04_29_proposed_snapshot_logical_decoder.md
+// described in docs/design/2026_04_29_implemented_snapshot_logical_decoder.md
 // (Phase 0): one `_schema.json` per table and one
 // `items/<pk>/<sk>.json` per item (default per-item layout).
 //

--- a/internal/backup/filename.go
+++ b/internal/backup/filename.go
@@ -1,5 +1,5 @@
 // Package backup implements the per-adapter logical-backup format defined in
-// docs/design/2026_04_29_proposed_snapshot_logical_decoder.md (Phase 0) and
+// docs/design/2026_04_29_implemented_snapshot_logical_decoder.md (Phase 0) and
 // reused by docs/design/2026_04_29_proposed_logical_backup.md (Phase 1).
 //
 // This file owns the filename encoding rules for non-S3 segments. S3 object

--- a/internal/backup/manifest.go
+++ b/internal/backup/manifest.go
@@ -139,7 +139,7 @@ type Exclusions struct {
 }
 
 // Manifest is the on-disk MANIFEST.json structure. Field tags match the
-// spec in docs/design/2026_04_29_proposed_snapshot_logical_decoder.md.
+// spec in docs/design/2026_04_29_implemented_snapshot_logical_decoder.md.
 type Manifest struct {
 	FormatVersion    uint32  `json:"format_version"`
 	Phase            string  `json:"phase"`

--- a/internal/backup/redis_list.go
+++ b/internal/backup/redis_list.go
@@ -13,7 +13,7 @@ import (
 
 // Redis list encoder. Translates raw !lst|... snapshot records into the
 // per-list `lists/<key>.json` shape defined by Phase 0
-// (docs/design/2026_04_29_proposed_snapshot_logical_decoder.md).
+// (docs/design/2026_04_29_implemented_snapshot_logical_decoder.md).
 //
 // Three on-disk key families share the `!lst|` namespace; only two
 // carry restorable state:

--- a/internal/backup/redis_set.go
+++ b/internal/backup/redis_set.go
@@ -13,7 +13,7 @@ import (
 
 // Redis set encoder. Translates raw !st|... snapshot records into the
 // per-set `sets/<key>.json` shape defined by Phase 0
-// (docs/design/2026_04_29_proposed_snapshot_logical_decoder.md).
+// (docs/design/2026_04_29_implemented_snapshot_logical_decoder.md).
 //
 // Wire format mirrors store/set_helpers.go:
 //   - !st|meta|<userKeyLen(4)><userKey>          → 8-byte BE Len

--- a/internal/backup/redis_stream.go
+++ b/internal/backup/redis_stream.go
@@ -16,7 +16,7 @@ import (
 
 // Redis stream encoder. Translates raw !stream|... snapshot records
 // into the per-stream `streams/<key>.jsonl` shape defined by Phase 0
-// (docs/design/2026_04_29_proposed_snapshot_logical_decoder.md, lines
+// (docs/design/2026_04_29_implemented_snapshot_logical_decoder.md, lines
 // 336-344).
 //
 // Wire format mirrors store/stream_helpers.go and
@@ -311,7 +311,7 @@ func (r *RedisDB) writeStreamJSONL(dir string, userKey []byte, st *redisStreamSt
 // names within one entry — e.g. `XADD s * f v1 f v2` records BOTH
 // (f, v1) and (f, v2) as distinct interleaved entries in the
 // stored protobuf's Fields slice. The design example at
-// docs/design/2026_04_29_proposed_snapshot_logical_decoder.md:338
+// docs/design/2026_04_29_implemented_snapshot_logical_decoder.md:338
 // showed an object shape, but that representation silently drops
 // duplicates and a restore would not reproduce the original
 // stream entry. Codex P1 (PR #791) — switched to a name/value

--- a/internal/backup/redis_string.go
+++ b/internal/backup/redis_string.go
@@ -17,7 +17,7 @@ import (
 
 // Redis simple-type encoders translate raw snapshot key/value records into
 // the per-adapter directory tree defined by Phase 0
-// (docs/design/2026_04_29_proposed_snapshot_logical_decoder.md). This file
+// (docs/design/2026_04_29_implemented_snapshot_logical_decoder.md). This file
 // covers the three "simple" Redis prefixes — strings, HLLs, and TTL scan
 // index entries — that always map to ONE snapshot record per user key and
 // therefore need no cross-record assembly.

--- a/internal/backup/redis_zset.go
+++ b/internal/backup/redis_zset.go
@@ -15,7 +15,7 @@ import (
 
 // Redis zset encoder. Translates raw !zs|... snapshot records into the
 // per-zset `zsets/<key>.json` shape defined by Phase 0
-// (docs/design/2026_04_29_proposed_snapshot_logical_decoder.md).
+// (docs/design/2026_04_29_implemented_snapshot_logical_decoder.md).
 //
 // Wire format mirrors store/zset_helpers.go:
 //   - !zs|meta|<userKeyLen(4)><userKey>                              → 8-byte BE Len

--- a/internal/backup/s3.go
+++ b/internal/backup/s3.go
@@ -108,7 +108,7 @@ func verifyChunkCompleteness(chunks []s3ChunkKey, declaredParts map[s3PartKey]s3
 
 // S3Encoder emits per-bucket _bucket.json + assembled object bodies +
 // .elastickv-meta.json sidecars + KEYMAP.jsonl, per the Phase 0
-// design (docs/design/2026_04_29_proposed_snapshot_logical_decoder.md).
+// design (docs/design/2026_04_29_implemented_snapshot_logical_decoder.md).
 //
 // Lifecycle: Handle* per record, Finalize once. Records arrive in
 // snapshot lex order:

--- a/internal/backup/sqs.go
+++ b/internal/backup/sqs.go
@@ -77,7 +77,7 @@ var ErrSQSInvalidMessage = errors.New("backup: invalid !sqs|msg|data value")
 var ErrSQSMalformedKey = errors.New("backup: malformed SQS key")
 
 // SQSEncoder encodes the SQS prefix family into the per-queue layout
-// described in docs/design/2026_04_29_proposed_snapshot_logical_decoder.md
+// described in docs/design/2026_04_29_implemented_snapshot_logical_decoder.md
 // (Phase 0): one `_queue.json` per queue and one ordered `messages.jsonl`.
 //
 // Lifecycle: per-snapshot pass calls Handle* for each record, then exactly


### PR DESCRIPTION
## Summary
- add elastickv-snap-token for offline snapshot restore token metadata
- add operator restore runbook and wire decoder metadata needed for the flow
- mark snapshot logical decoder operator integration implemented

## Design doc
- docs/design/2026_04_29_implemented_snapshot_logical_decoder.md

## Validation
- go test ./cmd/elastickv-snap-token ./cmd/elastickv-snapshot-decode ./internal/backup -run 'Test.*Snap|Test.*Token|Test.*Decode|Test.*Manifest|Test.*Filename|Test.*Restore' -count=1
- golangci-lint --config=.golangci.yaml run ./cmd/elastickv-snap-token ./cmd/elastickv-snapshot-decode ./internal/backup --timeout=5m
- git verify-commit HEAD

Author: bootjp