### PR TITLE
Add raft gRPC streaming transport

### DIFF
--- a/docs/design/2026_04_18_implemented_raft_grpc_streaming_transport.md
+++ b/docs/design/2026_04_18_implemented_raft_grpc_streaming_transport.md
@@ -1,15 +1,17 @@
 # Design: gRPC Streaming Transport for Raft Messages
 
-> **Status: proposed — not yet implemented.**
-> PR #522 delivers the per-peer dispatch channel foundation described in §2.
-> This document specifies the next step: replacing per-message unary RPCs with
-> a long-lived client-streaming gRPC connection per peer.
+> **Status: implemented.**
+> The per-peer dispatch channel foundation from PR #522 remains in place.
+> Regular Raft messages now use a long-lived client-streaming gRPC connection
+> per peer when the remote node supports `SendStream`, with unary `Send`
+> retained as the mixed-version fallback.
 
 ## 1. Background and motivation
 
 ### Problem
 
-The current Raft transport uses a unary gRPC RPC (`Send`) for every outbound message:
+Before this implementation, the Raft transport used a unary gRPC RPC (`Send`)
+for every outbound message:
 
 ```text
 dispatchRegular:
@@ -36,7 +38,7 @@ being RTT-limited.
 
 ---
 
-## 2. Current architecture
+## 2. Previous architecture
 
 ```text
 Engine run loop
@@ -59,15 +61,16 @@ Engine run loop
                                  GRPCTransport.dispatchRegular()
 ```
 
-Snapshot messages already use client streaming (`SendSnapshot`); regular messages do not.
+Snapshot messages already used client streaming (`SendSnapshot`); regular
+messages now use `SendStream` when the peer supports it.
 
 ---
 
-## 3. Proposed design
+## 3. Implemented design
 
 ### 3.1 Protocol change
 
-Add a client-streaming RPC to `etcd_raft.proto`:
+`etcd_raft.proto` adds a client-streaming RPC:
 
 ```protobuf
 service EtcdRaft {
@@ -85,23 +88,27 @@ confirmation at stream granularity.
 
 ### 3.2 Sender side (`GRPCTransport`)
 
-Add a `peerStream` map protected by `mu`:
+`GRPCTransport` keeps a stream cache protected by `mu`:
 
 ```go
 type peerStream struct {
+    mu     sync.Mutex
     stream pb.EtcdRaft_SendStreamClient
     cancel context.CancelFunc
 }
 
 type GRPCTransport struct {
     // existing fields ...
-    streams map[uint64]*peerStream   // nodeID → active stream
+    streams           map[string]*peerStream // peer address -> active stream
+    streamSupported   map[string]bool
+    streamUnsupported map[string]bool
 }
 ```
 
-`getOrOpenStream(nodeID)` returns the existing stream or opens a new one.
-On error (network drop, server restart), the stream is torn down and a new
-one is opened on the next send attempt.
+`streamFor(address, client)` returns the existing stream or opens a new one.
+On error (network drop, server restart), the stream is torn down and the next
+send attempt reopens it. `RemovePeer`, address replacement, and
+`GRPCTransport.Close` cancel the stream context and delete the stream entry.
 
 `dispatchRegular` changes from:
 
@@ -112,7 +119,7 @@ _, err = client.Send(ctx, &pb.EtcdRaftMessage{Message: raw})
 to:
 
 ```go
-stream, err := t.getOrOpenStream(msg.To)
+stream, err := t.streamFor(ctx, peer.Address, client)
 if err != nil { return err }
 err = stream.Send(&pb.EtcdRaftMessage{Message: raw})
 ```
@@ -124,23 +131,12 @@ pick up the next message from the per-peer channel.
 > **Concurrency constraint**: gRPC-go's `stream.Send` / `SendMsg` is **not**
 > goroutine-safe. Each per-peer stream must be written by exactly one goroutine.
 >
-> PR #522 runs **two** dispatch workers per peer (one for normal messages, one for
-> heartbeats). When streaming is introduced, these two workers cannot share a
-> single `SendStream` stream without external synchronization. Two approaches:
->
-> **Option A — single multiplexing worker**: merge both channels into one goroutine
-> that reads from either channel via `select` and writes to the stream. Preserves
-> stream ownership with no locking.
->
-> **Option B — stream-level mutex**: keep the two-worker model and protect
-> `stream.Send` with a `sync.Mutex` per peer. Simpler to implement but adds
-> a lock on the hot path.
->
-> Option A is preferred: it eliminates the lock on the hot path, and within-peer
-> ordering is already guaranteed by the single multiplexing worker. `getOrOpenStream`
-> uses `mu` only to serialize map access; the per-peer stream itself is then written
-> by exactly one goroutine (the multiplexing worker), satisfying gRPC's
-> single-writer requirement.
+> PR #522 runs **two** dispatch workers per peer (one for normal messages, one
+> for heartbeats in the default layout; four lanes when
+> `ELASTICKV_RAFT_DISPATCHER_LANES=1` is enabled). The implementation preserves
+> that worker model and uses a per-stream `sync.Mutex` to satisfy gRPC's
+> single-writer requirement. This keeps the change scoped to the transport layer
+> and avoids reshaping the dispatcher scheduler in the same rollout.
 
 ### 3.3 Receiver side (`GRPCTransport`)
 
@@ -171,18 +167,20 @@ func (t *GRPCTransport) SendStream(stream pb.EtcdRaft_SendStreamServer) error {
 
 | Event | Action |
 |---|---|
-| First message to peer | Open stream, store in `streams[nodeID]` |
-| `stream.Send()` error | Close and delete stream; caller retries via `getOrOpenStream` |
-| `removePeer(nodeID)` | Cancel stream context, delete from `streams` |
+| First message to peer | Probe `SendStream`, open stream, store in `streams[address]` |
+| `stream.Send()` error | Close and delete stream; caller retries via `streamFor` |
+| `removePeer(nodeID)` / peer address replacement | Cancel stream context, delete from `streams` |
 | `GRPCTransport.Close()` | Cancel all stream contexts, close all streams |
 | Peer restart / network partition | Server closes stream → sender gets error on next `Send()` → reconnect |
 
 ### 3.5 Backward compatibility
 
-Nodes that have not yet upgraded only register `Send()`. The sender detects
-`codes.Unimplemented` on `SendStream` and falls back to the existing unary
-`Send()` path. A version negotiation flag (e.g., a field in peer metadata) can
-be used to skip the probe after the first successful stream is established.
+Nodes that have not yet upgraded only register `Send()`. The sender opens an
+empty `SendStream` probe and calls `CloseAndRecv()` before caching support.
+If the peer returns `codes.Unimplemented`, the address is marked unsupported
+and `dispatchRegular` falls back to the existing unary `Send()` path. A
+successful probe marks the address supported and subsequent sends reuse a
+long-lived stream.
 
 ---
 
@@ -197,67 +195,30 @@ be used to skip the probe after the first successful stream is established.
 | **Memory** | gRPC stream send buffer (typically 32 KB) replaces per-peer channel as primary buffer; channel can be reduced |
 | **Complexity** | Stream state machine in `GRPCTransport`; backward-compat fallback path |
 | **Ordering** | Single stream per peer preserves FIFO — safe for Raft |
-| **Heartbeat starvation** | Under a burst of log entries, heartbeats could be delayed in the send buffer. Mitigated via biased-select (see below). |
+| **Heartbeat starvation** | The existing heartbeat lane remains separate until `dispatchRegular`; `stream.Send` is serialized with a per-stream mutex. |
 
-### 3.6 Heartbeat starvation mitigation — biased select
+### 3.6 Heartbeat handling
 
-When the multiplexing dispatch worker (Option A from §3.2) reads from both
-channels, a sustained `MsgApp` burst can delay heartbeats. The mitigation is
-a **biased select**: check the priority channel non-blocking first, fall back
-to either channel:
-
-```go
-for {
-    // Drain the priority channel before accepting normal messages.
-    // ctx.Done() is checked here too so a sustained heartbeat burst
-    // cannot prevent a prompt shutdown.
-    select {
-    case <-ctx.Done():
-        return nil
-    case req := <-pd.heartbeat:
-        if err := stream.Send(req); err != nil {
-            return err // triggers teardown + reconnect (§3.4)
-        }
-        continue
-    default:
-    }
-    // No priority message pending; wait on either.
-    select {
-    case req := <-pd.heartbeat:
-        if err := stream.Send(req); err != nil {
-            return err
-        }
-    case req := <-pd.normal:
-        if err := stream.Send(req); err != nil {
-            return err
-        }
-    case <-ctx.Done():
-        return nil
-    }
-}
-```
-
-`stream.Send` errors (broken stream, lost connection) are returned immediately,
-triggering the stream teardown and reconnect path described in §3.4. Raft's
-built-in retransmission handles any messages dropped during the reconnect window
-— identical to the behaviour of the existing unary `Send` drop path.
-
-This guarantees heartbeats are flushed before the next log entry is written
-to the stream, bounding heartbeat delay to one normal-message send time.
+The implementation preserves the existing dispatcher lanes. Heartbeats still
+have a dedicated channel and worker before entering the transport, which keeps
+cross-peer and normal-message queueing isolated. At the stream boundary,
+`peerStream.mu` serializes `stream.Send` calls from the existing workers.
+If the stream breaks, the transport closes the cached stream and lets Raft's
+built-in retransmission recover any message lost during the reconnect window,
+matching the previous unary drop semantics.
 
 ---
 
-## 5. Implementation plan
+## 5. Implementation status
 
-| Step | Scope | Estimate |
+| Step | Scope | Status |
 |---|---|---|
-| 1. Proto: add `SendStream` RPC | `proto/etcd_raft.proto` + regenerate | 0.5 day |
-| 2. Receiver handler | `GRPCTransport.SendStream` | 0.5 day |
-| 3. Stream open/close/reconnect | `getOrOpenStream`, `peerStream` lifecycle | 1 day |
-| 4. Sender: swap unary → stream in `dispatchRegular` | `GRPCTransport.dispatchRegular` | 0.5 day |
-| 5. Backward-compat fallback | Unimplemented detection, version flag | 1 day |
-| 6. Tests | Unit + conformance | 1 day |
-| **Total** | | **~4.5 days** |
+| 1. Proto: add `SendStream` RPC | `proto/etcd_raft.proto` + regenerated Go stubs | Implemented |
+| 2. Receiver handler | `GRPCTransport.SendStream` | Implemented |
+| 3. Stream open/close/reconnect | `streamFor`, `peerStream` lifecycle, peer removal cleanup | Implemented |
+| 4. Sender: swap unary → stream in `dispatchRegular` | Streaming default with unary fallback | Implemented |
+| 5. Backward-compat fallback | Empty-stream probe plus `codes.Unimplemented` cache | Implemented |
+| 6. Tests | Server handler, streaming dispatch, legacy-peer fallback | Implemented |
 
 ---
 
@@ -268,7 +229,7 @@ Because `SendStream` is additive, the rollout is zero-downtime by design:
 | Phase | Action |
 |---|---|
 | **Deploy new server binary** | All nodes register both `Send` (unary) and `SendStream`. Existing peers that have not yet upgraded continue to use `Send` — no behaviour change. |
-| **Gradual upgrade** | As each peer is upgraded, the sender detects `SendStream` availability (no `codes.Unimplemented`) and opens a stream. Unary `Send` remains the fallback for un-upgraded peers. |
+| **Gradual upgrade** | As each peer is upgraded, the sender's empty-stream probe detects `SendStream` availability and opens a stream. Unary `Send` remains the fallback for un-upgraded peers. |
 | **Full cutover** | Once all peers run the new binary, every peer-to-peer path uses streaming. The unary `Send` handler is kept indefinitely for backward compatibility. |
 
 No dual-write or blue/green deployment is required: the `codes.Unimplemented` probe
@@ -279,5 +240,5 @@ No dual-write or blue/green deployment is required: the `codes.Unimplemented` pr
 ## 7. Out of scope
 
 - Batch encoding (multiple `EtcdRaftMessage` payloads in one proto message) — independent optimisation.
-- Priority queuing for heartbeats vs log entries — orthogonal to transport protocol.
+- Replacing the current per-lane workers with one biased-select multiplexing worker — an optional scheduler optimization on top of this transport protocol.
 - Snapshot streaming changes — already implemented.

--- a/docs/design/2026_04_18_implemented_raft_grpc_streaming_transport.md
+++ b/docs/design/2026_04_18_implemented_raft_grpc_streaming_transport.md
@@ -95,20 +95,30 @@ type peerStream struct {
     mu     sync.Mutex
     stream pb.EtcdRaft_SendStreamClient
     cancel context.CancelFunc
+    done   chan struct{}
 }
 
 type GRPCTransport struct {
     // existing fields ...
-    streams           map[string]*peerStream // peer address -> active stream
-    streamSupported   map[string]bool
-    streamUnsupported map[string]bool
+    streams             map[string]*peerStream // peer address -> active stream
+    streamSupported     map[string]bool
+    streamUnsupported   map[string]bool
+    streamUnsupportedAt map[string]time.Time
 }
 ```
 
 `streamFor(address, client)` returns the existing stream or opens a new one.
-On error (network drop, server restart), the stream is torn down and the next
-send attempt reopens it. `RemovePeer`, address replacement, and
+Stream establishment is serialized with singleflight per peer address so
+concurrent dispatch workers do not open duplicate streams during first contact
+or reconnect.
+
+On error (network drop, server restart), a reader goroutine observes the
+terminal stream result, the stream is torn down, and the next send attempt
+reopens it. `RemovePeer`, address replacement, and
 `GRPCTransport.Close` cancel the stream context and delete the stream entry.
+If an in-flight dispatch context is cancelled or times out while `Send` is
+blocked in gRPC flow control, the dispatch closes the cached stream to unblock
+the sender.
 
 `dispatchRegular` changes from:
 
@@ -125,8 +135,9 @@ err = stream.Send(&pb.EtcdRaftMessage{Message: raw})
 ```
 
 `stream.Send()` returns as soon as the message enters the gRPC send buffer
-(non-blocking under normal conditions). The dispatch worker can immediately
-pick up the next message from the per-peer channel.
+(non-blocking under normal conditions). Priority control traffic such as
+heartbeats and votes keeps using unary `Send` so it does not wait behind a
+large replication send on the stream mutex.
 
 > **Concurrency constraint**: gRPC-go's `stream.Send` / `SendMsg` is **not**
 > goroutine-safe. Each per-peer stream must be written by exactly one goroutine.
@@ -171,7 +182,8 @@ func (t *GRPCTransport) SendStream(stream pb.EtcdRaft_SendStreamServer) error {
 | `stream.Send()` error | Close and delete stream; caller retries via `streamFor` |
 | `removePeer(nodeID)` / peer address replacement | Cancel stream context, delete from `streams` |
 | `GRPCTransport.Close()` | Cancel all stream contexts, close all streams |
-| Peer restart / network partition | Server closes stream → sender gets error on next `Send()` → reconnect |
+| Peer restart / network partition | Stream monitor observes terminal error → cached stream closes → reconnect on next stream send |
+| Dispatch context cancelled while `Send` is blocked | Close cached stream to unblock the dispatch worker |
 
 ### 3.5 Backward compatibility
 
@@ -179,8 +191,10 @@ Nodes that have not yet upgraded only register `Send()`. The sender opens an
 empty `SendStream` probe and calls `CloseAndRecv()` before caching support.
 If the peer returns `codes.Unimplemented`, the address is marked unsupported
 and `dispatchRegular` falls back to the existing unary `Send()` path. A
-successful probe marks the address supported and subsequent sends reuse a
-long-lived stream.
+successful probe marks the address supported and subsequent non-priority sends
+reuse a long-lived stream. Unsupported markers expire after a short reprobe
+interval so rolling upgrades can move from unary fallback to `SendStream`
+without waiting for a membership change or process restart.
 
 ---
 
@@ -195,17 +209,17 @@ long-lived stream.
 | **Memory** | gRPC stream send buffer (typically 32 KB) replaces per-peer channel as primary buffer; channel can be reduced |
 | **Complexity** | Stream state machine in `GRPCTransport`; backward-compat fallback path |
 | **Ordering** | Single stream per peer preserves FIFO — safe for Raft |
-| **Heartbeat starvation** | The existing heartbeat lane remains separate until `dispatchRegular`; `stream.Send` is serialized with a per-stream mutex. |
+| **Heartbeat starvation** | Priority control traffic stays on unary `Send`, preserving the dedicated heartbeat lane through the transport boundary. |
 
 ### 3.6 Heartbeat handling
 
-The implementation preserves the existing dispatcher lanes. Heartbeats still
-have a dedicated channel and worker before entering the transport, which keeps
-cross-peer and normal-message queueing isolated. At the stream boundary,
-`peerStream.mu` serializes `stream.Send` calls from the existing workers.
-If the stream breaks, the transport closes the cached stream and lets Raft's
-built-in retransmission recover any message lost during the reconnect window,
-matching the previous unary drop semantics.
+The implementation preserves the existing dispatcher lanes. Heartbeats and
+other priority control messages still have a dedicated channel and worker
+before entering the transport, and they use unary `Send` at the transport
+boundary. Normal replication traffic uses the cached stream and `peerStream.mu`
+serializes `stream.Send` calls. If the stream breaks, the transport closes the
+cached stream and lets Raft's built-in retransmission recover any message lost
+during the reconnect window, matching the previous drop semantics.
 
 ---
 

--- a/docs/design/2026_04_25_proposed_s3_admission_control.md
+++ b/docs/design/2026_04_25_proposed_s3_admission_control.md
@@ -462,7 +462,7 @@ Acceptance criteria:
 - Per-bucket admission classes (e.g. system buckets get their own
   budget). Punted to the workload-isolation rollout.
 - Coordinated admission across the multi-region read replica path
-  proposed in `docs/design/2026_04_18_proposed_raft_grpc_streaming_transport.md`.
+  implemented in `docs/design/2026_04_18_implemented_raft_grpc_streaming_transport.md`.
 - Token-bucket rate-shaping (e.g. bytes-per-second). The current
   proposal only bounds *concurrent* bytes; rate-shaping is a separate
   policy choice.

--- a/docs/design/2026_04_25_proposed_s3_raft_blob_offload.md
+++ b/docs/design/2026_04_25_proposed_s3_raft_blob_offload.md
@@ -500,9 +500,8 @@ message PushChunkBlobResponse {
 Streamed because a chunkblob is up to `s3ChunkSize = 1 MiB`. The
 existing gRPC `MaxRecvMsgSize = 64 MiB` (PR #593 → `internal.GRPCCallOptions`)
 already covers this in a single RPC, but streaming keeps the
-implementation symmetric with how the future Raft streaming
-transport (proposed under
-`docs/design/2026_04_18_proposed_raft_grpc_streaming_transport.md`)
+implementation symmetric with how the Raft streaming transport, implemented in
+`docs/design/2026_04_18_implemented_raft_grpc_streaming_transport.md`,
 handles large payloads.
 
 ### 3.7 Backwards compatibility & rollout
@@ -586,9 +585,9 @@ capability-advertising peers exists.
 - **PR #589 (snapshot tuning) and PR #614 (etcd-snapshot-disk-offload).**
   Already implemented. The offload path makes those tunables more
   effective by reducing the per-snapshot byte count.
-- **`docs/design/2026_04_18_proposed_raft_grpc_streaming_transport.md`.**
+- **`docs/design/2026_04_18_implemented_raft_grpc_streaming_transport.md`.**
   The blob-fetch RPC reuses the same chunked-streaming approach
-  proposed for Raft transport. We can land both behind the same
+  implemented for Raft transport. We can land both behind the same
   abstraction.
 - **Lease read & MVCC snapshot reads.** No change. Manifests remain
   the linearisation point; chunk bytes are immutable once committed

--- a/docs/design/2026_06_23_proposed_scaling_roadmap.md
+++ b/docs/design/2026_06_23_proposed_scaling_roadmap.md
@@ -377,17 +377,17 @@ reverse). (M3) auto-merge in the M3 detector (cold-route hysteresis).
 **Depends-on:** M2 migration plane for cross-group merge; the Composed-1 guard
 for cutover coherence.
 
-### Gap 6 — Connection / transport scaling (streaming transport revival)
-**Problem.** Raft inter-node messages use unary gRPC per message
-(`docs/design/2026_04_18_proposed_raft_grpc_streaming_transport.md` §1): each
-send pays a full RTT, capping per-peer throughput at ~RTT⁻¹ regardless of
-bandwidth. This bites exactly when multi-node multi-group (Gap 1) puts real
-inter-node Raft traffic on the wire. **Rough milestones:** revive the existing
-streaming-transport proposal (client-streaming `SendStream` per peer, biased
-heartbeat select, backward-compat fallback). The blob-fetch RPC in the S3
-offload doc (§3.6) already wants to reuse the same chunked-streaming
-abstraction, so landing both behind one transport layer is the leverage.
-**Depends-on:** nothing hard; value scales with Gap 1.
+### Gap 6 — Connection / transport scaling (streaming transport soak)
+**Problem.** Raft inter-node messages previously used unary gRPC per message
+(`docs/design/2026_04_18_implemented_raft_grpc_streaming_transport.md` §1),
+which paid a full RTT per send. The implemented `SendStream` transport removes
+that bottleneck, but multi-node multi-group (Gap 1) still needs transport soak
+coverage under real cross-node traffic. **Rough milestones:** (M1) run transport
+soak with multi-node multi-group traffic. (M2) decide whether the optional
+biased-select multiplexing worker from the implemented transport doc is needed.
+The blob-fetch RPC in the S3 offload doc (§3.6) can reuse the same
+chunked-streaming abstraction. **Depends-on:** Gap 1 for realistic traffic;
+value scales with Gap 1.
 
 ### Gap 7 — Auto group lifecycle (longest-term)
 **Problem.** Groups are static (`--raftGroups`). Elastic scale-out (add node →

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -32,7 +32,7 @@ YYYY_MM_DD_<status>_<name>.md
 
 ```text
 2026_04_20_implemented_lease_read.md
-2026_04_18_proposed_raft_grpc_streaming_transport.md
+2026_04_18_implemented_raft_grpc_streaming_transport.md
 2026_02_18_partial_hotspot_shard_split.md
 2026_04_24_proposed_sqs_compatible_adapter.md
 ```

--- a/internal/raftengine/etcd/grpc_transport.go
+++ b/internal/raftengine/etcd/grpc_transport.go
@@ -15,6 +15,8 @@ import (
 	raftpb "go.etcd.io/raft/v3/raftpb"
 	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const defaultSnapshotChunkSize = 16 << 20
@@ -41,6 +43,12 @@ var grpcNewClient = grpc.NewClient
 
 type MessageHandler func(context.Context, raftpb.Message) error
 
+type peerStream struct {
+	mu     sync.Mutex
+	stream pb.EtcdRaft_SendStreamClient
+	cancel context.CancelFunc
+}
+
 type GRPCTransport struct {
 	pb.UnimplementedEtcdRaftServer
 
@@ -48,6 +56,9 @@ type GRPCTransport struct {
 	peers             map[uint64]Peer
 	clients           map[string]pb.EtcdRaftClient
 	conns             map[string]*grpc.ClientConn
+	streams           map[string]*peerStream
+	streamSupported   map[string]bool
+	streamUnsupported map[string]bool
 	handler           MessageHandler
 	snapshotChunkSize int
 	spoolDir          string
@@ -86,6 +97,9 @@ func NewGRPCTransport(peers []Peer) *GRPCTransport {
 		peers:             peerMap,
 		clients:           make(map[string]pb.EtcdRaftClient),
 		conns:             make(map[string]*grpc.ClientConn),
+		streams:           make(map[string]*peerStream),
+		streamSupported:   make(map[string]bool),
+		streamUnsupported: make(map[string]bool),
 		snapshotChunkSize: defaultSnapshotChunkSize,
 		bridgeSem:         make(chan struct{}, defaultBridgeMaterializeLimit),
 	}
@@ -201,6 +215,10 @@ func (t *GRPCTransport) Close() error {
 	defer t.mu.Unlock()
 
 	var err error
+	for addr, stream := range t.streams {
+		delete(t.streams, addr)
+		stream.cancel()
+	}
 	for addr, conn := range t.conns {
 		delete(t.conns, addr)
 		delete(t.clients, addr)
@@ -213,6 +231,9 @@ func (t *GRPCTransport) closePeerConnLocked(address string) {
 	if address == "" {
 		return
 	}
+	t.closePeerStreamLocked(address)
+	delete(t.streamSupported, address)
+	delete(t.streamUnsupported, address)
 	conn, ok := t.conns[address]
 	if !ok {
 		delete(t.clients, address)
@@ -223,6 +244,28 @@ func (t *GRPCTransport) closePeerConnLocked(address string) {
 	if err := conn.Close(); err != nil {
 		slog.Warn("failed to close etcd raft peer connection", "address", address, "error", err)
 	}
+}
+
+func (t *GRPCTransport) closePeerStream(address string, expected *peerStream) {
+	if address == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	stream, ok := t.streams[address]
+	if !ok || (expected != nil && stream != expected) {
+		return
+	}
+	t.closePeerStreamLocked(address)
+}
+
+func (t *GRPCTransport) closePeerStreamLocked(address string) {
+	stream, ok := t.streams[address]
+	if !ok {
+		return
+	}
+	delete(t.streams, address)
+	stream.cancel()
 }
 
 func (t *GRPCTransport) Dispatch(ctx context.Context, msg raftpb.Message) error {
@@ -376,12 +419,130 @@ func (t *GRPCTransport) dispatchRegular(ctx context.Context, msg raftpb.Message)
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	client, err := t.clientFor(msg.To)
+	peer, err := t.peerFor(msg.To)
 	if err != nil {
 		return err
 	}
-	_, err = client.Send(ctx, &pb.EtcdRaftMessage{Message: raw})
+	client, err := t.clientForPeer(peer)
+	if err != nil {
+		return err
+	}
+	req := &pb.EtcdRaftMessage{Message: raw}
+	if t.peerStreamUnsupported(peer.Address) {
+		return t.dispatchRegularUnary(ctx, client, req)
+	}
+	err = t.dispatchRegularStream(ctx, peer.Address, client, req)
+	if err == nil {
+		return nil
+	}
+	if grpcStatusCode(err) == codes.Unimplemented {
+		t.markPeerStreamUnsupported(peer.Address)
+		return t.dispatchRegularUnary(ctx, client, req)
+	}
 	return errors.WithStack(err)
+}
+
+func (t *GRPCTransport) dispatchRegularUnary(ctx context.Context, client pb.EtcdRaftClient, req *pb.EtcdRaftMessage) error {
+	_, err := client.Send(ctx, req)
+	return errors.WithStack(err)
+}
+
+func (t *GRPCTransport) dispatchRegularStream(ctx context.Context, address string, client pb.EtcdRaftClient, req *pb.EtcdRaftMessage) error {
+	stream, err := t.streamFor(ctx, address, client)
+	if err != nil {
+		return err
+	}
+	stream.mu.Lock()
+	err = stream.stream.Send(req)
+	stream.mu.Unlock()
+	if err != nil {
+		t.closePeerStream(address, stream)
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func (t *GRPCTransport) streamFor(ctx context.Context, address string, client pb.EtcdRaftClient) (*peerStream, error) {
+	t.mu.RLock()
+	stream, ok := t.streams[address]
+	unsupported := t.streamUnsupported[address]
+	t.mu.RUnlock()
+	if ok {
+		return stream, nil
+	}
+	if unsupported {
+		return nil, errors.WithStack(status.Error(codes.Unimplemented, "etcd raft SendStream is not supported by peer"))
+	}
+	if err := t.probeSendStream(ctx, address, client); err != nil {
+		return nil, err
+	}
+
+	streamCtx, cancel := context.WithCancel(context.Background())
+	sendStream, err := client.SendStream(streamCtx)
+	if err != nil {
+		cancel()
+		return nil, errors.WithStack(err)
+	}
+	opened := &peerStream{stream: sendStream, cancel: cancel}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if existing, ok := t.streams[address]; ok {
+		cancel()
+		return existing, nil
+	}
+	t.streams[address] = opened
+	return opened, nil
+}
+
+func (t *GRPCTransport) probeSendStream(ctx context.Context, address string, client pb.EtcdRaftClient) error {
+	t.mu.RLock()
+	supported := t.streamSupported[address]
+	unsupported := t.streamUnsupported[address]
+	t.mu.RUnlock()
+	switch {
+	case supported:
+		return nil
+	case unsupported:
+		return errors.WithStack(status.Error(codes.Unimplemented, "etcd raft SendStream is not supported by peer"))
+	}
+
+	stream, err := client.SendStream(ctx)
+	if err != nil {
+		if grpcStatusCode(err) == codes.Unimplemented {
+			t.markPeerStreamUnsupported(address)
+		}
+		return errors.WithStack(err)
+	}
+	if _, err := stream.CloseAndRecv(); err != nil {
+		if grpcStatusCode(err) == codes.Unimplemented {
+			t.markPeerStreamUnsupported(address)
+		}
+		return errors.WithStack(err)
+	}
+	t.markPeerStreamSupported(address)
+	return nil
+}
+
+func (t *GRPCTransport) peerStreamUnsupported(address string) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.streamUnsupported[address]
+}
+
+func (t *GRPCTransport) markPeerStreamSupported(address string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.streamSupported[address] = true
+	delete(t.streamUnsupported, address)
+}
+
+func (t *GRPCTransport) markPeerStreamUnsupported(address string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.streamUnsupported[address] = true
+	delete(t.streamSupported, address)
+	t.closePeerStreamLocked(address)
 }
 
 func (t *GRPCTransport) DispatchSnapshotSpool(ctx context.Context, msg raftpb.Message, spool *snapshotSpool) error {
@@ -413,6 +574,23 @@ func (t *GRPCTransport) SendSnapshot(stream pb.EtcdRaft_SendSnapshotServer) erro
 		return err
 	}
 	return errors.WithStack(stream.SendAndClose(&pb.EtcdRaftAck{}))
+}
+
+func (t *GRPCTransport) SendStream(stream pb.EtcdRaft_SendStreamServer) error {
+	for {
+		req, err := stream.Recv()
+		switch {
+		case errors.Is(err, io.EOF):
+			return errors.WithStack(stream.SendAndClose(&pb.EtcdRaftAck{}))
+		case err != nil:
+			return errors.WithStack(err)
+		case req == nil:
+			continue
+		}
+		if err := t.handleRaftRequest(stream.Context(), req); err != nil {
+			return err
+		}
+	}
 }
 
 // removeOrphanedFSMSnapshot deletes the .fsm file that
@@ -457,14 +635,21 @@ func (t *GRPCTransport) Send(ctx context.Context, req *pb.EtcdRaftMessage) (*pb.
 	if req == nil {
 		return &pb.EtcdRaftAck{}, nil
 	}
-	var msg raftpb.Message
-	if err := msg.Unmarshal(req.Message); err != nil {
-		return nil, errors.WithStack(err)
-	}
-	if err := t.handle(ctx, msg); err != nil {
+	if err := t.handleRaftRequest(ctx, req); err != nil {
 		return nil, err
 	}
 	return &pb.EtcdRaftAck{}, nil
+}
+
+func (t *GRPCTransport) handleRaftRequest(ctx context.Context, req *pb.EtcdRaftMessage) error {
+	var msg raftpb.Message
+	if err := msg.Unmarshal(req.Message); err != nil {
+		return errors.WithStack(err)
+	}
+	if err := t.handle(ctx, msg); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (t *GRPCTransport) sendSnapshot(ctx context.Context, msg raftpb.Message) error {
@@ -520,7 +705,10 @@ func (t *GRPCTransport) clientFor(to uint64) (pb.EtcdRaftClient, error) {
 	if err != nil {
 		return nil, err
 	}
+	return t.clientForPeer(peer)
+}
 
+func (t *GRPCTransport) clientForPeer(peer Peer) (pb.EtcdRaftClient, error) {
 	t.mu.RLock()
 	client, ok := t.clients[peer.Address]
 	t.mu.RUnlock()
@@ -560,6 +748,13 @@ func (t *GRPCTransport) clientFor(to uint64) (pb.EtcdRaftClient, error) {
 		return nil, errors.New("etcd raft transport dial returned unexpected client type")
 	}
 	return client, nil
+}
+
+func grpcStatusCode(err error) codes.Code {
+	if err == nil {
+		return codes.OK
+	}
+	return status.Code(err)
 }
 
 func (t *GRPCTransport) chunkSize() int {

--- a/internal/raftengine/etcd/grpc_transport.go
+++ b/internal/raftengine/etcd/grpc_transport.go
@@ -23,6 +23,7 @@ const defaultSnapshotChunkSize = 16 << 20
 
 const defaultDispatchTimeout = 5 * time.Second
 const defaultSnapshotDispatchTimeout = 30 * time.Minute
+const defaultSendStreamReprobeInterval = 30 * time.Second
 
 // defaultBridgeMaterializeLimit caps the number of bridge-mode snapshot
 // materializations that may hold memory concurrently. Each call allocates up
@@ -37,6 +38,7 @@ var (
 	errSnapshotMessageNil        = errors.New("etcd raft snapshot message is required")
 	errSnapshotStreamShort       = errors.New("etcd raft snapshot stream closed before final chunk")
 	errReceivedFSMSnapshotStale  = errors.New("etcd raft received fsm snapshot is stale")
+	errPeerStreamClosed          = errors.New("etcd raft SendStream closed")
 )
 
 var grpcNewClient = grpc.NewClient
@@ -47,25 +49,62 @@ type peerStream struct {
 	mu     sync.Mutex
 	stream pb.EtcdRaft_SendStreamClient
 	cancel context.CancelFunc
+	done   chan struct{}
+	errMu  sync.Mutex
+	err    error
+}
+
+func newPeerStream(stream pb.EtcdRaft_SendStreamClient, cancel context.CancelFunc) *peerStream {
+	peer := &peerStream{
+		stream: stream,
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+	go peer.watchTerminal()
+	return peer
+}
+
+func (s *peerStream) watchTerminal() {
+	var ack pb.EtcdRaftAck
+	err := s.stream.RecvMsg(&ack)
+	if err == nil {
+		err = errPeerStreamClosed
+	}
+	s.errMu.Lock()
+	s.err = err
+	s.errMu.Unlock()
+	close(s.done)
+}
+
+func (s *peerStream) terminalErr() error {
+	select {
+	case <-s.done:
+	default:
+		return nil
+	}
+	s.errMu.Lock()
+	defer s.errMu.Unlock()
+	return s.err
 }
 
 type GRPCTransport struct {
 	pb.UnimplementedEtcdRaftServer
 
-	mu                sync.RWMutex
-	peers             map[uint64]Peer
-	clients           map[string]pb.EtcdRaftClient
-	conns             map[string]*grpc.ClientConn
-	streams           map[string]*peerStream
-	streamSupported   map[string]bool
-	streamUnsupported map[string]bool
-	handler           MessageHandler
-	snapshotChunkSize int
-	spoolDir          string
-	fsmSnapDir        string
-	prepareFSMWrite   func(index uint64) error
-	protectFSMWrite   func(index uint64) bool
-	unprotectFSMWrite func(index uint64)
+	mu                  sync.RWMutex
+	peers               map[uint64]Peer
+	clients             map[string]pb.EtcdRaftClient
+	conns               map[string]*grpc.ClientConn
+	streams             map[string]*peerStream
+	streamSupported     map[string]bool
+	streamUnsupported   map[string]bool
+	streamUnsupportedAt map[string]time.Time
+	handler             MessageHandler
+	snapshotChunkSize   int
+	spoolDir            string
+	fsmSnapDir          string
+	prepareFSMWrite     func(index uint64) error
+	protectFSMWrite     func(index uint64) bool
+	unprotectFSMWrite   func(index uint64)
 	// readFSMPayload is the fallback bridge callback that materialises the full
 	// FSM payload into memory. Used only when openFSMPayload is not set.
 	readFSMPayload func(index uint64) ([]byte, error)
@@ -94,14 +133,15 @@ func NewGRPCTransport(peers []Peer) *GRPCTransport {
 		peerMap[peer.NodeID] = peer
 	}
 	return &GRPCTransport{
-		peers:             peerMap,
-		clients:           make(map[string]pb.EtcdRaftClient),
-		conns:             make(map[string]*grpc.ClientConn),
-		streams:           make(map[string]*peerStream),
-		streamSupported:   make(map[string]bool),
-		streamUnsupported: make(map[string]bool),
-		snapshotChunkSize: defaultSnapshotChunkSize,
-		bridgeSem:         make(chan struct{}, defaultBridgeMaterializeLimit),
+		peers:               peerMap,
+		clients:             make(map[string]pb.EtcdRaftClient),
+		conns:               make(map[string]*grpc.ClientConn),
+		streams:             make(map[string]*peerStream),
+		streamSupported:     make(map[string]bool),
+		streamUnsupported:   make(map[string]bool),
+		streamUnsupportedAt: make(map[string]time.Time),
+		snapshotChunkSize:   defaultSnapshotChunkSize,
+		bridgeSem:           make(chan struct{}, defaultBridgeMaterializeLimit),
 	}
 }
 
@@ -234,6 +274,7 @@ func (t *GRPCTransport) closePeerConnLocked(address string) {
 	t.closePeerStreamLocked(address)
 	delete(t.streamSupported, address)
 	delete(t.streamUnsupported, address)
+	delete(t.streamUnsupportedAt, address)
 	conn, ok := t.conns[address]
 	if !ok {
 		delete(t.clients, address)
@@ -428,7 +469,7 @@ func (t *GRPCTransport) dispatchRegular(ctx context.Context, msg raftpb.Message)
 		return err
 	}
 	req := &pb.EtcdRaftMessage{Message: raw}
-	if t.peerStreamUnsupported(peer.Address) {
+	if isPriorityMsg(msg.Type) || !t.allowPeerStreamProbe(peer.Address, time.Now()) {
 		return t.dispatchRegularUnary(ctx, client, req)
 	}
 	err = t.dispatchRegularStream(ctx, peer.Address, client, req)
@@ -452,9 +493,25 @@ func (t *GRPCTransport) dispatchRegularStream(ctx context.Context, address strin
 	if err != nil {
 		return err
 	}
+	stopCancel := context.AfterFunc(ctx, func() {
+		t.closePeerStream(address, stream)
+	})
+	defer stopCancel()
+
 	stream.mu.Lock()
+	if err := stream.terminalErr(); err != nil {
+		stream.mu.Unlock()
+		t.closePeerStream(address, stream)
+		return errors.WithStack(err)
+	}
 	err = stream.stream.Send(req)
+	if err == nil {
+		err = stream.terminalErr()
+	}
 	stream.mu.Unlock()
+	if err == nil && ctx.Err() != nil {
+		err = ctx.Err()
+	}
 	if err != nil {
 		t.closePeerStream(address, stream)
 		return errors.WithStack(err)
@@ -465,45 +522,67 @@ func (t *GRPCTransport) dispatchRegularStream(ctx context.Context, address strin
 func (t *GRPCTransport) streamFor(ctx context.Context, address string, client pb.EtcdRaftClient) (*peerStream, error) {
 	t.mu.RLock()
 	stream, ok := t.streams[address]
-	unsupported := t.streamUnsupported[address]
 	t.mu.RUnlock()
 	if ok {
 		return stream, nil
 	}
-	if unsupported {
+	if !t.allowPeerStreamProbe(address, time.Now()) {
 		return nil, errors.WithStack(status.Error(codes.Unimplemented, "etcd raft SendStream is not supported by peer"))
 	}
-	if err := t.probeSendStream(ctx, address, client); err != nil {
-		return nil, err
-	}
 
-	streamCtx, cancel := context.WithCancel(context.Background())
-	sendStream, err := client.SendStream(streamCtx)
+	value, err, _ := t.dialGroup.Do("stream:"+address, func() (any, error) {
+		t.mu.RLock()
+		stream, ok := t.streams[address]
+		t.mu.RUnlock()
+		if ok {
+			return stream, nil
+		}
+		if !t.allowPeerStreamProbe(address, time.Now()) {
+			return nil, errors.WithStack(status.Error(codes.Unimplemented, "etcd raft SendStream is not supported by peer"))
+		}
+		if err := t.probeSendStream(ctx, address, client); err != nil {
+			return nil, err
+		}
+
+		streamCtx, cancel := context.WithCancel(context.Background())
+		sendStream, err := client.SendStream(streamCtx)
+		if err != nil {
+			cancel()
+			return nil, errors.WithStack(err)
+		}
+		opened := newPeerStream(sendStream, cancel)
+
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		if existing, ok := t.streams[address]; ok {
+			cancel()
+			return existing, nil
+		}
+		t.streams[address] = opened
+		go func() {
+			<-opened.done
+			t.closePeerStream(address, opened)
+		}()
+		return opened, nil
+	})
 	if err != nil {
-		cancel()
 		return nil, errors.WithStack(err)
 	}
-	opened := &peerStream{stream: sendStream, cancel: cancel}
-
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if existing, ok := t.streams[address]; ok {
-		cancel()
-		return existing, nil
+	stream, ok = value.(*peerStream)
+	if !ok {
+		return nil, errors.New("etcd raft transport stream group returned unexpected stream type")
 	}
-	t.streams[address] = opened
-	return opened, nil
+	return stream, nil
 }
 
 func (t *GRPCTransport) probeSendStream(ctx context.Context, address string, client pb.EtcdRaftClient) error {
 	t.mu.RLock()
 	supported := t.streamSupported[address]
-	unsupported := t.streamUnsupported[address]
 	t.mu.RUnlock()
-	switch {
-	case supported:
+	if supported {
 		return nil
-	case unsupported:
+	}
+	if !t.allowPeerStreamProbe(address, time.Now()) {
 		return errors.WithStack(status.Error(codes.Unimplemented, "etcd raft SendStream is not supported by peer"))
 	}
 
@@ -530,17 +609,45 @@ func (t *GRPCTransport) peerStreamUnsupported(address string) bool {
 	return t.streamUnsupported[address]
 }
 
+func (t *GRPCTransport) allowPeerStreamProbe(address string, now time.Time) bool {
+	t.mu.RLock()
+	unsupported := t.streamUnsupported[address]
+	markedAt := t.streamUnsupportedAt[address]
+	t.mu.RUnlock()
+	if !unsupported {
+		return true
+	}
+	if markedAt.IsZero() || now.Before(markedAt.Add(defaultSendStreamReprobeInterval)) {
+		return false
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	currentMarkedAt := t.streamUnsupportedAt[address]
+	if !t.streamUnsupported[address] {
+		return true
+	}
+	if currentMarkedAt.IsZero() || now.Before(currentMarkedAt.Add(defaultSendStreamReprobeInterval)) {
+		return false
+	}
+	delete(t.streamUnsupported, address)
+	delete(t.streamUnsupportedAt, address)
+	return true
+}
+
 func (t *GRPCTransport) markPeerStreamSupported(address string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.streamSupported[address] = true
 	delete(t.streamUnsupported, address)
+	delete(t.streamUnsupportedAt, address)
 }
 
 func (t *GRPCTransport) markPeerStreamUnsupported(address string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.streamUnsupported[address] = true
+	t.streamUnsupportedAt[address] = time.Now()
 	delete(t.streamSupported, address)
 	t.closePeerStreamLocked(address)
 }

--- a/internal/raftengine/etcd/grpc_transport_test.go
+++ b/internal/raftengine/etcd/grpc_transport_test.go
@@ -776,6 +776,115 @@ func TestNewGRPCTransportDerivesPeerNodeIDs(t *testing.T) {
 	require.Equal(t, "127.0.0.1:65530", peer.Address)
 }
 
+func TestSendStreamReceivesRegularMessages(t *testing.T) {
+	reqs := []*pb.EtcdRaftMessage{
+		mustEtcdRaftMessage(t, raftpb.Message{Type: raftpb.MsgApp, From: 1, To: 2, Term: 3, Index: 10}),
+		mustEtcdRaftMessage(t, raftpb.Message{Type: raftpb.MsgHeartbeat, From: 1, To: 2, Term: 3, Commit: 9}),
+	}
+	transport := NewGRPCTransport(nil)
+	var got []raftpb.Message
+	transport.SetHandler(func(_ context.Context, msg raftpb.Message) error {
+		got = append(got, msg)
+		return nil
+	})
+	stream := &testSendStreamServer{messages: reqs}
+
+	require.NoError(t, transport.SendStream(stream))
+	require.True(t, stream.closed)
+	require.Len(t, got, 2)
+	require.Equal(t, raftpb.MsgApp, got[0].Type)
+	require.Equal(t, uint64(10), got[0].Index)
+	require.Equal(t, raftpb.MsgHeartbeat, got[1].Type)
+	require.Equal(t, uint64(9), got[1].Commit)
+}
+
+func TestDispatchRegularUsesSendStream(t *testing.T) {
+	lis, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lis.Close() })
+
+	recvTransport := NewGRPCTransport(nil)
+	gotCh := make(chan raftpb.Message, 2)
+	recvTransport.SetHandler(func(_ context.Context, msg raftpb.Message) error {
+		gotCh <- msg
+		return nil
+	})
+
+	server := grpc.NewServer()
+	recvTransport.Register(server)
+	t.Cleanup(server.Stop)
+	go func() { _ = server.Serve(lis) }()
+
+	sendTransport := NewGRPCTransport([]Peer{{NodeID: 2, Address: lis.Addr().String()}})
+	t.Cleanup(func() { require.NoError(t, sendTransport.Close()) })
+
+	require.NoError(t, sendTransport.dispatchRegular(context.Background(), raftpb.Message{
+		Type:  raftpb.MsgApp,
+		From:  1,
+		To:    2,
+		Term:  4,
+		Index: 22,
+	}))
+	require.NoError(t, sendTransport.dispatchRegular(context.Background(), raftpb.Message{
+		Type:   raftpb.MsgHeartbeat,
+		From:   1,
+		To:     2,
+		Term:   4,
+		Commit: 22,
+	}))
+
+	got := collectRaftMessages(t, gotCh, 2)
+	require.Equal(t, raftpb.MsgApp, got[0].Type)
+	require.Equal(t, uint64(22), got[0].Index)
+	require.Equal(t, raftpb.MsgHeartbeat, got[1].Type)
+	require.Equal(t, uint64(22), got[1].Commit)
+
+	sendTransport.mu.RLock()
+	_, streamCached := sendTransport.streams[lis.Addr().String()]
+	streamSupported := sendTransport.streamSupported[lis.Addr().String()]
+	sendTransport.mu.RUnlock()
+	require.True(t, streamCached)
+	require.True(t, streamSupported)
+}
+
+func TestDispatchRegularFallsBackToUnaryWhenSendStreamUnimplemented(t *testing.T) {
+	lis, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lis.Close() })
+
+	legacy := &legacyEtcdRaftServer{got: make(chan raftpb.Message, 2)}
+	server := grpc.NewServer()
+	pb.RegisterEtcdRaftServer(server, legacy)
+	t.Cleanup(server.Stop)
+	go func() { _ = server.Serve(lis) }()
+
+	sendTransport := NewGRPCTransport([]Peer{{NodeID: 2, Address: lis.Addr().String()}})
+	t.Cleanup(func() { require.NoError(t, sendTransport.Close()) })
+
+	require.NoError(t, sendTransport.dispatchRegular(context.Background(), raftpb.Message{
+		Type:  raftpb.MsgApp,
+		From:  1,
+		To:    2,
+		Term:  5,
+		Index: 30,
+	}))
+	require.True(t, sendTransport.peerStreamUnsupported(lis.Addr().String()))
+
+	require.NoError(t, sendTransport.dispatchRegular(context.Background(), raftpb.Message{
+		Type:  raftpb.MsgAppResp,
+		From:  1,
+		To:    2,
+		Term:  5,
+		Index: 31,
+	}))
+
+	got := collectRaftMessages(t, legacy.got, 2)
+	require.Equal(t, raftpb.MsgApp, got[0].Type)
+	require.Equal(t, uint64(30), got[0].Index)
+	require.Equal(t, raftpb.MsgAppResp, got[1].Type)
+	require.Equal(t, uint64(31), got[1].Index)
+}
+
 type testSendSnapshotServer struct {
 	chunks []*pb.EtcdRaftSnapshotChunk
 	index  int
@@ -814,6 +923,83 @@ func (*testSendSnapshotServer) SendMsg(any) error {
 
 func (*testSendSnapshotServer) RecvMsg(any) error {
 	return nil
+}
+
+type testSendStreamServer struct {
+	messages []*pb.EtcdRaftMessage
+	index    int
+	closed   bool
+}
+
+func (s *testSendStreamServer) Recv() (*pb.EtcdRaftMessage, error) {
+	if s.index >= len(s.messages) {
+		return nil, io.EOF
+	}
+	msg := s.messages[s.index]
+	s.index++
+	return msg, nil
+}
+
+func (s *testSendStreamServer) SendAndClose(*pb.EtcdRaftAck) error {
+	s.closed = true
+	return nil
+}
+
+func (*testSendStreamServer) SetHeader(metadata.MD) error {
+	return nil
+}
+
+func (*testSendStreamServer) SendHeader(metadata.MD) error {
+	return nil
+}
+
+func (*testSendStreamServer) SetTrailer(metadata.MD) {}
+
+func (*testSendStreamServer) Context() context.Context {
+	return context.Background()
+}
+
+func (*testSendStreamServer) SendMsg(any) error {
+	return nil
+}
+
+func (*testSendStreamServer) RecvMsg(any) error {
+	return nil
+}
+
+type legacyEtcdRaftServer struct {
+	pb.UnimplementedEtcdRaftServer
+	got chan raftpb.Message
+}
+
+func (s *legacyEtcdRaftServer) Send(_ context.Context, req *pb.EtcdRaftMessage) (*pb.EtcdRaftAck, error) {
+	var msg raftpb.Message
+	if err := msg.Unmarshal(req.GetMessage()); err != nil {
+		return nil, err
+	}
+	s.got <- msg
+	return &pb.EtcdRaftAck{}, nil
+}
+
+func mustEtcdRaftMessage(t *testing.T, msg raftpb.Message) *pb.EtcdRaftMessage {
+	t.Helper()
+	raw, err := msg.Marshal()
+	require.NoError(t, err)
+	return &pb.EtcdRaftMessage{Message: raw}
+}
+
+func collectRaftMessages(t *testing.T, ch <-chan raftpb.Message, count int) []raftpb.Message {
+	t.Helper()
+	got := make([]raftpb.Message, 0, count)
+	for len(got) < count {
+		select {
+		case msg := <-ch:
+			got = append(got, msg)
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for raft message %d/%d", len(got)+1, count)
+		}
+	}
+	return got
 }
 
 // --- applyBridgeMode tests ---
@@ -936,16 +1122,46 @@ func (*testSnapshotSendClient) RecvMsg(any) error            { return nil }
 // testEtcdRaftClient is a minimal mock of pb.EtcdRaftClient that routes
 // SendSnapshot calls to a pre-wired testSnapshotSendClient.
 type testEtcdRaftClient struct {
-	stream *testSnapshotSendClient
+	stream     *testSnapshotSendClient
+	raftStream *testRaftSendStreamClient
 }
 
 func (c *testEtcdRaftClient) Send(_ context.Context, _ *pb.EtcdRaftMessage, _ ...grpc.CallOption) (*pb.EtcdRaftAck, error) {
 	return &pb.EtcdRaftAck{}, nil
 }
 
+func (c *testEtcdRaftClient) SendStream(_ context.Context, _ ...grpc.CallOption) (pb.EtcdRaft_SendStreamClient, error) {
+	if c.raftStream != nil {
+		return c.raftStream, nil
+	}
+	return &testRaftSendStreamClient{}, nil
+}
+
 func (c *testEtcdRaftClient) SendSnapshot(_ context.Context, _ ...grpc.CallOption) (pb.EtcdRaft_SendSnapshotClient, error) {
 	return c.stream, nil
 }
+
+type testRaftSendStreamClient struct {
+	messages []*pb.EtcdRaftMessage
+	closed   bool
+}
+
+func (c *testRaftSendStreamClient) Send(msg *pb.EtcdRaftMessage) error {
+	c.messages = append(c.messages, msg)
+	return nil
+}
+
+func (c *testRaftSendStreamClient) CloseAndRecv() (*pb.EtcdRaftAck, error) {
+	c.closed = true
+	return &pb.EtcdRaftAck{}, nil
+}
+
+func (*testRaftSendStreamClient) Header() (metadata.MD, error) { return nil, nil }
+func (*testRaftSendStreamClient) Trailer() metadata.MD         { return nil }
+func (*testRaftSendStreamClient) CloseSend() error             { return nil }
+func (*testRaftSendStreamClient) Context() context.Context     { return context.Background() }
+func (*testRaftSendStreamClient) SendMsg(any) error            { return nil }
+func (*testRaftSendStreamClient) RecvMsg(any) error            { return nil }
 
 // injectClient pre-populates the transport's client cache for the given peer
 // address so calls to clientFor return the mock without dialling.

--- a/internal/raftengine/etcd/grpc_transport_test.go
+++ b/internal/raftengine/etcd/grpc_transport_test.go
@@ -834,10 +834,21 @@ func TestDispatchRegularUsesSendStream(t *testing.T) {
 	}))
 
 	got := collectRaftMessages(t, gotCh, 2)
-	require.Equal(t, raftpb.MsgApp, got[0].Type)
-	require.Equal(t, uint64(22), got[0].Index)
-	require.Equal(t, raftpb.MsgHeartbeat, got[1].Type)
-	require.Equal(t, uint64(22), got[1].Commit)
+	var gotApp, gotHeartbeat bool
+	for _, msg := range got {
+		switch msg.Type { //nolint:exhaustive // this test expects only the two messages dispatched above.
+		case raftpb.MsgApp:
+			gotApp = true
+			require.Equal(t, uint64(22), msg.Index)
+		case raftpb.MsgHeartbeat:
+			gotHeartbeat = true
+			require.Equal(t, uint64(22), msg.Commit)
+		default:
+			t.Fatalf("unexpected raft message type %s", msg.Type)
+		}
+	}
+	require.True(t, gotApp)
+	require.True(t, gotHeartbeat)
 
 	sendTransport.mu.RLock()
 	_, streamCached := sendTransport.streams[lis.Addr().String()]
@@ -883,6 +894,146 @@ func TestDispatchRegularFallsBackToUnaryWhenSendStreamUnimplemented(t *testing.T
 	require.Equal(t, uint64(30), got[0].Index)
 	require.Equal(t, raftpb.MsgAppResp, got[1].Type)
 	require.Equal(t, uint64(31), got[1].Index)
+}
+
+func TestDispatchRegularUsesUnaryForPriorityMessages(t *testing.T) {
+	const addr = "host:2"
+	transport := NewGRPCTransport([]Peer{{NodeID: 2, Address: addr}})
+	t.Cleanup(func() { require.NoError(t, transport.Close()) })
+	client := &testEtcdRaftClient{}
+	injectClient(t, transport, addr, client)
+
+	require.NoError(t, transport.dispatchRegular(context.Background(), raftpb.Message{
+		Type:   raftpb.MsgHeartbeat,
+		From:   1,
+		To:     2,
+		Term:   4,
+		Commit: 22,
+	}))
+
+	require.Equal(t, int32(1), client.sendCalls.Load())
+	require.Zero(t, client.sendStreamCalls.Load())
+}
+
+func TestDispatchRegularReprobesStreamAfterUnsupportedCacheExpires(t *testing.T) {
+	const addr = "host:2"
+	transport := NewGRPCTransport([]Peer{{NodeID: 2, Address: addr}})
+	t.Cleanup(func() { require.NoError(t, transport.Close()) })
+	client := &testEtcdRaftClient{
+		raftStreams: []*testRaftSendStreamClient{{}, {}},
+	}
+	injectClient(t, transport, addr, client)
+
+	transport.markPeerStreamUnsupported(addr)
+	require.NoError(t, transport.dispatchRegular(context.Background(), raftpb.Message{
+		Type:  raftpb.MsgApp,
+		From:  1,
+		To:    2,
+		Term:  5,
+		Index: 40,
+	}))
+	require.Equal(t, int32(1), client.sendCalls.Load())
+	require.Zero(t, client.sendStreamCalls.Load())
+
+	transport.mu.Lock()
+	transport.streamUnsupportedAt[addr] = time.Now().Add(-defaultSendStreamReprobeInterval - time.Second)
+	transport.mu.Unlock()
+
+	require.NoError(t, transport.dispatchRegular(context.Background(), raftpb.Message{
+		Type:  raftpb.MsgApp,
+		From:  1,
+		To:    2,
+		Term:  5,
+		Index: 41,
+	}))
+	require.Equal(t, int32(1), client.sendCalls.Load())
+	require.Equal(t, int32(2), client.sendStreamCalls.Load())
+	require.False(t, transport.peerStreamUnsupported(addr))
+
+	transport.mu.RLock()
+	streamSupported := transport.streamSupported[addr]
+	_, streamCached := transport.streams[addr]
+	transport.mu.RUnlock()
+	require.True(t, streamSupported)
+	require.True(t, streamCached)
+}
+
+func TestStreamForDeduplicatesConcurrentOpen(t *testing.T) {
+	const addr = "host:2"
+	transport := NewGRPCTransport([]Peer{{NodeID: 2, Address: addr}})
+	t.Cleanup(func() { require.NoError(t, transport.Close()) })
+	client := &testEtcdRaftClient{}
+
+	const callers = 8
+	var wg sync.WaitGroup
+	wg.Add(callers)
+	streams := make([]*peerStream, callers)
+	errCh := make(chan error, callers)
+	for i := 0; i < callers; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			stream, err := transport.streamFor(context.Background(), addr, client)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			streams[idx] = stream
+		}(i)
+	}
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+	require.Equal(t, int32(2), client.sendStreamCalls.Load(), "one probe stream plus one cached send stream")
+	for i := 1; i < callers; i++ {
+		require.Equal(t, streams[0], streams[i])
+	}
+}
+
+func TestDispatchRegularStreamCancelsCachedStreamWhenContextDone(t *testing.T) {
+	const addr = "host:2"
+	transport := NewGRPCTransport([]Peer{{NodeID: 2, Address: addr}})
+	t.Cleanup(func() { require.NoError(t, transport.Close()) })
+	sendStarted := make(chan struct{})
+	client := &testEtcdRaftClient{
+		raftStreams: []*testRaftSendStreamClient{
+			{},
+			{blockSend: true, sendStarted: sendStarted},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- transport.dispatchRegularStream(ctx, addr, client, mustEtcdRaftMessage(t, raftpb.Message{
+			Type:  raftpb.MsgApp,
+			From:  1,
+			To:    2,
+			Term:  5,
+			Index: 42,
+		}))
+	}()
+
+	select {
+	case <-sendStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for stream Send to start")
+	}
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("dispatchRegularStream did not return after context cancellation")
+	}
+
+	transport.mu.RLock()
+	_, streamCached := transport.streams[addr]
+	transport.mu.RUnlock()
+	require.False(t, streamCached)
 }
 
 type testSendSnapshotServer struct {
@@ -1122,19 +1273,31 @@ func (*testSnapshotSendClient) RecvMsg(any) error            { return nil }
 // testEtcdRaftClient is a minimal mock of pb.EtcdRaftClient that routes
 // SendSnapshot calls to a pre-wired testSnapshotSendClient.
 type testEtcdRaftClient struct {
-	stream     *testSnapshotSendClient
-	raftStream *testRaftSendStreamClient
+	stream          *testSnapshotSendClient
+	raftStream      *testRaftSendStreamClient
+	raftStreams     []*testRaftSendStreamClient
+	sendCalls       atomic.Int32
+	sendStreamCalls atomic.Int32
 }
 
 func (c *testEtcdRaftClient) Send(_ context.Context, _ *pb.EtcdRaftMessage, _ ...grpc.CallOption) (*pb.EtcdRaftAck, error) {
+	c.sendCalls.Add(1)
 	return &pb.EtcdRaftAck{}, nil
 }
 
-func (c *testEtcdRaftClient) SendStream(_ context.Context, _ ...grpc.CallOption) (pb.EtcdRaft_SendStreamClient, error) {
+func (c *testEtcdRaftClient) SendStream(ctx context.Context, _ ...grpc.CallOption) (pb.EtcdRaft_SendStreamClient, error) {
+	c.sendStreamCalls.Add(1)
+	if len(c.raftStreams) > 0 {
+		stream := c.raftStreams[0]
+		c.raftStreams = c.raftStreams[1:]
+		stream.ctx = ctx
+		return stream, nil
+	}
 	if c.raftStream != nil {
+		c.raftStream.ctx = ctx
 		return c.raftStream, nil
 	}
-	return &testRaftSendStreamClient{}, nil
+	return &testRaftSendStreamClient{ctx: ctx}, nil
 }
 
 func (c *testEtcdRaftClient) SendSnapshot(_ context.Context, _ ...grpc.CallOption) (pb.EtcdRaft_SendSnapshotClient, error) {
@@ -1142,12 +1305,24 @@ func (c *testEtcdRaftClient) SendSnapshot(_ context.Context, _ ...grpc.CallOptio
 }
 
 type testRaftSendStreamClient struct {
-	messages []*pb.EtcdRaftMessage
-	closed   bool
+	messages    []*pb.EtcdRaftMessage
+	closed      bool
+	ctx         context.Context
+	recvErr     chan error
+	blockSend   bool
+	sendStarted chan struct{}
+	sendOnce    sync.Once
 }
 
 func (c *testRaftSendStreamClient) Send(msg *pb.EtcdRaftMessage) error {
 	c.messages = append(c.messages, msg)
+	if c.sendStarted != nil {
+		c.sendOnce.Do(func() { close(c.sendStarted) })
+	}
+	if c.blockSend {
+		<-c.Context().Done()
+		return c.Context().Err()
+	}
 	return nil
 }
 
@@ -1159,9 +1334,25 @@ func (c *testRaftSendStreamClient) CloseAndRecv() (*pb.EtcdRaftAck, error) {
 func (*testRaftSendStreamClient) Header() (metadata.MD, error) { return nil, nil }
 func (*testRaftSendStreamClient) Trailer() metadata.MD         { return nil }
 func (*testRaftSendStreamClient) CloseSend() error             { return nil }
-func (*testRaftSendStreamClient) Context() context.Context     { return context.Background() }
-func (*testRaftSendStreamClient) SendMsg(any) error            { return nil }
-func (*testRaftSendStreamClient) RecvMsg(any) error            { return nil }
+func (c *testRaftSendStreamClient) Context() context.Context {
+	if c.ctx != nil {
+		return c.ctx
+	}
+	return context.Background()
+}
+func (*testRaftSendStreamClient) SendMsg(any) error { return nil }
+func (c *testRaftSendStreamClient) RecvMsg(any) error {
+	if c.recvErr != nil {
+		select {
+		case err := <-c.recvErr:
+			return err
+		case <-c.Context().Done():
+			return c.Context().Err()
+		}
+	}
+	<-c.Context().Done()
+	return c.Context().Err()
+}
 
 // injectClient pre-populates the transport's client cache for the given peer
 // address so calls to clientFor return the mock without dialling.

--- a/proto/etcd_raft.pb.go
+++ b/proto/etcd_raft.pb.go
@@ -172,9 +172,11 @@ const file_etcd_raft_proto_rawDesc = "" +
 	"\bmetadata\x18\x01 \x01(\fR\bmetadata\x12\x14\n" +
 	"\x05chunk\x18\x02 \x01(\fR\x05chunk\x12\x14\n" +
 	"\x05final\x18\x03 \x01(\bR\x05final\"\r\n" +
-	"\vEtcdRaftAck2n\n" +
+	"\vEtcdRaftAck2\xa0\x01\n" +
 	"\bEtcdRaft\x12(\n" +
-	"\x04Send\x12\x10.EtcdRaftMessage\x1a\f.EtcdRaftAck\"\x00\x128\n" +
+	"\x04Send\x12\x10.EtcdRaftMessage\x1a\f.EtcdRaftAck\"\x00\x120\n" +
+	"\n" +
+	"SendStream\x12\x10.EtcdRaftMessage\x1a\f.EtcdRaftAck\"\x00(\x01\x128\n" +
 	"\fSendSnapshot\x12\x16.EtcdRaftSnapshotChunk\x1a\f.EtcdRaftAck\"\x00(\x01B#Z!github.com/bootjp/elastickv/protob\x06proto3"
 
 var (
@@ -197,11 +199,13 @@ var file_etcd_raft_proto_goTypes = []any{
 }
 var file_etcd_raft_proto_depIdxs = []int32{
 	0, // 0: EtcdRaft.Send:input_type -> EtcdRaftMessage
-	1, // 1: EtcdRaft.SendSnapshot:input_type -> EtcdRaftSnapshotChunk
-	2, // 2: EtcdRaft.Send:output_type -> EtcdRaftAck
-	2, // 3: EtcdRaft.SendSnapshot:output_type -> EtcdRaftAck
-	2, // [2:4] is the sub-list for method output_type
-	0, // [0:2] is the sub-list for method input_type
+	0, // 1: EtcdRaft.SendStream:input_type -> EtcdRaftMessage
+	1, // 2: EtcdRaft.SendSnapshot:input_type -> EtcdRaftSnapshotChunk
+	2, // 3: EtcdRaft.Send:output_type -> EtcdRaftAck
+	2, // 4: EtcdRaft.SendStream:output_type -> EtcdRaftAck
+	2, // 5: EtcdRaft.SendSnapshot:output_type -> EtcdRaftAck
+	3, // [3:6] is the sub-list for method output_type
+	0, // [0:3] is the sub-list for method input_type
 	0, // [0:0] is the sub-list for extension type_name
 	0, // [0:0] is the sub-list for extension extendee
 	0, // [0:0] is the sub-list for field type_name

--- a/proto/etcd_raft.proto
+++ b/proto/etcd_raft.proto
@@ -4,6 +4,7 @@ option go_package = "github.com/bootjp/elastickv/proto";
 
 service EtcdRaft {
   rpc Send(EtcdRaftMessage) returns (EtcdRaftAck) {}
+  rpc SendStream(stream EtcdRaftMessage) returns (EtcdRaftAck) {}
   rpc SendSnapshot(stream EtcdRaftSnapshotChunk) returns (EtcdRaftAck) {}
 }
 

--- a/proto/etcd_raft_grpc.pb.go
+++ b/proto/etcd_raft_grpc.pb.go
@@ -20,6 +20,7 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	EtcdRaft_Send_FullMethodName         = "/EtcdRaft/Send"
+	EtcdRaft_SendStream_FullMethodName   = "/EtcdRaft/SendStream"
 	EtcdRaft_SendSnapshot_FullMethodName = "/EtcdRaft/SendSnapshot"
 )
 
@@ -28,6 +29,7 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type EtcdRaftClient interface {
 	Send(ctx context.Context, in *EtcdRaftMessage, opts ...grpc.CallOption) (*EtcdRaftAck, error)
+	SendStream(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[EtcdRaftMessage, EtcdRaftAck], error)
 	SendSnapshot(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[EtcdRaftSnapshotChunk, EtcdRaftAck], error)
 }
 
@@ -49,9 +51,22 @@ func (c *etcdRaftClient) Send(ctx context.Context, in *EtcdRaftMessage, opts ...
 	return out, nil
 }
 
+func (c *etcdRaftClient) SendStream(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[EtcdRaftMessage, EtcdRaftAck], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &EtcdRaft_ServiceDesc.Streams[0], EtcdRaft_SendStream_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[EtcdRaftMessage, EtcdRaftAck]{ClientStream: stream}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type EtcdRaft_SendStreamClient = grpc.ClientStreamingClient[EtcdRaftMessage, EtcdRaftAck]
+
 func (c *etcdRaftClient) SendSnapshot(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[EtcdRaftSnapshotChunk, EtcdRaftAck], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &EtcdRaft_ServiceDesc.Streams[0], EtcdRaft_SendSnapshot_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &EtcdRaft_ServiceDesc.Streams[1], EtcdRaft_SendSnapshot_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -67,6 +82,7 @@ type EtcdRaft_SendSnapshotClient = grpc.ClientStreamingClient[EtcdRaftSnapshotCh
 // for forward compatibility.
 type EtcdRaftServer interface {
 	Send(context.Context, *EtcdRaftMessage) (*EtcdRaftAck, error)
+	SendStream(grpc.ClientStreamingServer[EtcdRaftMessage, EtcdRaftAck]) error
 	SendSnapshot(grpc.ClientStreamingServer[EtcdRaftSnapshotChunk, EtcdRaftAck]) error
 	mustEmbedUnimplementedEtcdRaftServer()
 }
@@ -80,6 +96,9 @@ type UnimplementedEtcdRaftServer struct{}
 
 func (UnimplementedEtcdRaftServer) Send(context.Context, *EtcdRaftMessage) (*EtcdRaftAck, error) {
 	return nil, status.Error(codes.Unimplemented, "method Send not implemented")
+}
+func (UnimplementedEtcdRaftServer) SendStream(grpc.ClientStreamingServer[EtcdRaftMessage, EtcdRaftAck]) error {
+	return status.Error(codes.Unimplemented, "method SendStream not implemented")
 }
 func (UnimplementedEtcdRaftServer) SendSnapshot(grpc.ClientStreamingServer[EtcdRaftSnapshotChunk, EtcdRaftAck]) error {
 	return status.Error(codes.Unimplemented, "method SendSnapshot not implemented")
@@ -123,6 +142,13 @@ func _EtcdRaft_Send_Handler(srv interface{}, ctx context.Context, dec func(inter
 	return interceptor(ctx, in, info, handler)
 }
 
+func _EtcdRaft_SendStream_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(EtcdRaftServer).SendStream(&grpc.GenericServerStream[EtcdRaftMessage, EtcdRaftAck]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type EtcdRaft_SendStreamServer = grpc.ClientStreamingServer[EtcdRaftMessage, EtcdRaftAck]
+
 func _EtcdRaft_SendSnapshot_Handler(srv interface{}, stream grpc.ServerStream) error {
 	return srv.(EtcdRaftServer).SendSnapshot(&grpc.GenericServerStream[EtcdRaftSnapshotChunk, EtcdRaftAck]{ServerStream: stream})
 }
@@ -143,6 +169,11 @@ var EtcdRaft_ServiceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "SendStream",
+			Handler:       _EtcdRaft_SendStream_Handler,
+			ClientStreams: true,
+		},
 		{
 			StreamName:    "SendSnapshot",
 			Handler:       _EtcdRaft_SendSnapshot_Handler,


### PR DESCRIPTION
## Summary
- add streaming gRPC send path for raft transport
- update transport docs and related design references
- mark the raft gRPC streaming transport design implemented

## Design doc
- docs/design/2026_04_18_implemented_raft_grpc_streaming_transport.md

## Validation
- go test ./internal/raftengine/etcd -run 'Test.*GRPC|Test.*Transport|Test.*Stream|Test.*Dispatch' -count=1
- golangci-lint --config=.golangci.yaml run ./internal/raftengine/etcd --timeout=5m
- git verify-commit HEAD

Author: bootjp