### PR TITLE
Mark TLA safety spec implemented

### DIFF
--- a/.github/workflows/tla-check.yml
+++ b/.github/workflows/tla-check.yml
@@ -2,7 +2,7 @@ name: TLA+ model check
 
 # Runs `make tla-check` on PRs (and pushes to main) that touch the
 # subsystems modelled by the spec or the spec / tooling themselves.
-# Per docs/design/2026_05_28_partial_tla_safety_spec.md §7.3.
+# Per docs/design/2026_05_28_implemented_tla_safety_spec.md §7.3.
 #
 # The job runs both MCHLC.cfg (correct design — expected PASS) and
 # MCHLC_gap.cfg (preconditions disabled — expected FAIL with the HLC-4

--- a/.github/workflows/tla-spec-ai-review.yml
+++ b/.github/workflows/tla-spec-ai-review.yml
@@ -1,7 +1,7 @@
 name: TLA+ spec divergence — AI review
 
 # Whenever a PR touches a file that the TLA+ safety specification has an
-# anchor on (per docs/design/2026_05_28_partial_tla_safety_spec.md §3),
+# anchor on (per docs/design/2026_05_28_implemented_tla_safety_spec.md §3),
 # automatically post a comment that pings the AI reviewers so a focused
 # spec-divergence review always runs.
 #
@@ -113,7 +113,7 @@ jobs:
               `## TLA+ spec divergence review (auto-triggered)`,
               ``,
               `This PR touches files that the TLA+ safety spec has an anchor on (per`,
-              `[\`docs/design/2026_05_28_partial_tla_safety_spec.md\`](../blob/main/docs/design/2026_05_28_partial_tla_safety_spec.md) §3),`,
+              `[\`docs/design/2026_05_28_implemented_tla_safety_spec.md\`](../blob/main/docs/design/2026_05_28_implemented_tla_safety_spec.md) §3),`,
               `so an AI review is requested below to verify the implementation has not drifted`,
               `from the model.`,
               ``,

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ gen:
 # that motivates the implementation gaps).
 TLA_VERSION  := v1.8.0
 TLA_JAR      := .cache/tla/tla2tools.jar
+# SHA-256 of the tla2tools.jar release artifact fetched from TLA_URL.
 TLA_SHA256   := 9e27b5e19a69ae1f56aabf8403a6ed5598dbfa6e638908e5278ac39736c1543d
 TLA_URL      := https://github.com/tlaplus/tlaplus/releases/download/$(TLA_VERSION)/tla2tools.jar
 TLA_LIB      := ../lib

--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,14 @@ gen:
 	@$(MAKE)  -C proto gen
 
 # === TLA+ model-check support (M1 deliverable) ===
-# Per docs/design/2026_05_28_partial_tla_safety_spec.md §7.2.
+# Per docs/design/2026_05_28_implemented_tla_safety_spec.md §7.2.
 # Downloads a checksum-pinned tla2tools.jar on first use, then runs TLC on
 # both MCHLC.cfg (correct design — expected PASS) and MCHLC_gap.cfg
 # (preconditions disabled — expected FAIL on HLC-4 with a counterexample
 # that motivates the implementation gaps).
 TLA_VERSION  := v1.8.0
 TLA_JAR      := .cache/tla/tla2tools.jar
-TLA_SHA256   := 237332bdcc79a35c7d26efa7b82c77c85c2744591c5598673a8a45085ff2a4fb
+TLA_SHA256   := 9e27b5e19a69ae1f56aabf8403a6ed5598dbfa6e638908e5278ac39736c1543d
 TLA_URL      := https://github.com/tlaplus/tlaplus/releases/download/$(TLA_VERSION)/tla2tools.jar
 TLA_LIB      := ../lib
 

--- a/docs/design/2026_05_28_implemented_tla_safety_spec.md
+++ b/docs/design/2026_05_28_implemented_tla_safety_spec.md
@@ -1,16 +1,17 @@
 # TLA+ Safety Specification for elastickv
 
-Status: Partial
+Status: Implemented
 Author: bootjp
 Date: 2026-05-28
 
-> **Implementation status.** M1 landed in PR #TBD (the PR opening this
-> document's rename to `partial`). The HLC TLA+ module + `make tla-check`
-> + the gap-config counterexample evidence are now part of the build.
-> M2–M5 (OCC, MVCC, Routes, Composed) remain open per §8. The follow-up
-> Go code changes that strategy (c) and the ceiling fence require (per
-> §5.1 HLC-4 (ii) and (iii)) are tracked as separate issues against
-> `kv/hlc.go`, `kv/sharded_coordinator.go`, and `kv/fsm.go`.
+> **Implementation status.** M1-M5 are landed and guarded by
+> `make tla-check`: HLC, OCC, MVCC, Routes, and Composed all have
+> runnable TLC configs plus gap configs that fail on the expected
+> invariants. On 2026-07-07 the suite was re-run with
+> `tla2tools.jar` v1.8.0 and completed with
+> `tla-check: all model-check outcomes match the design contract.`
+> M6 remains an optional deep/liveness extension and is outside the
+> initial proposal's implemented scope.
 
 ---
 
@@ -621,21 +622,19 @@ proves something on its own).
 
 | ID | Scope | Output | Notes |
 |---|---|---|---|
-| **M1** | `lib/Raft.tla`, `lib/Env.tla`, `hlc/HLC.tla` with invariants HLC-1..HLC-4 (encoding all three HLC-4 preconditions — the bounded-skew `ASSUME`, the logical-handoff strategy, **and** the ceiling-fencing gate from (iii)). `Makefile` `tla-check` target. `tla/README.md`. | Per-module TLA+ spec of HLC; TLC passes at default bounds (3 nodes, 2 terms, ≤20 ops) **against the spec-of-the-correct-design**: the M1 spec encodes precondition (i) as a TLA+ `ASSUME` (constant predicate `MaxClockSkewMs < HlcPhysicalWindowMs`), and encodes (ii) and (iii) as **action guards** — strategy (c) lives in the `BecomeLeader` action (`LET maxAppliedHLC == MaxAppliedHLC(fsm[n]) IN hlcLast[n]' = max(hlcLast[n], maxAppliedHLC)`, where `MaxAppliedHLC` is the new FSM operator described in §5.1), and the ceiling-fencing gate lives in the `IssueTimestamp` action (`ENABLED ⇔ wallNow[n] < physicalCeiling[n]`). A companion `HLC_gap.tla` + `MCHLC_gap.cfg` pair that removes the `ASSUME` and relaxes those action guards is expected to surface counterexamples; that pair is committed alongside M1 as the motivating evidence that the preconditions are necessary. (TLA+ `ASSUME` is only valid for constant-level predicates, so describing behavioural requirements as `ASSUME`s would produce invalid TLA+; the distinction matters for M1 implementers.) | Smallest viable PR; sets the directory layout precedent. **Default logical-handoff strategy: (c)** — `BecomeLeader` action calls `Observe(maxHLC)` (Section 5.1, HLC-4 (ii)); deviations from (c) must be justified in the PR. |
-| **M2** | `occ/OCC.tla` with safety invariants OCC-1..OCC-5. | OCC spec runnable in isolation. | Re-uses `lib/Raft.tla`; introduces lock map, read/write sets, and per-transaction `start_ts` consistency. Liveness (OCC-L1) is deferred to M6. |
-| **M3** | `mvcc/MVCC.tla` with invariants MVCC-1..MVCC-4. | MVCC spec runnable in isolation. | Includes a small `InstallSnapshot` action to exercise MVCC-4. |
-| **M4** | `routes/Routes.tla` with invariants Routes-1..Routes-4. | Route catalog spec runnable in isolation. | Models `SplitRange` (catalog-atomic + handling-node engine sync) and asynchronous `CatalogWatcher` polling on other nodes. Liveness (Routes-L1) is deferred to M6. |
-| **M5** | `composed/Composed.tla` with safety invariants Composed-1..Composed-3. CI integration. | Cross-subsystem spec; TLC at default bounds in <10 min. | Where interaction bugs surface. Safety only; liveness is M6. |
+| **M1** | `lib/Raft.tla`, `lib/Env.tla`, `hlc/HLC.tla` with invariants HLC-1..HLC-4 (encoding all three HLC-4 preconditions — the bounded-skew `ASSUME`, the logical-handoff strategy, **and** the ceiling-fencing gate from (iii)). `Makefile` `tla-check` target. `tla/README.md`. | Implemented and passing via `tla/hlc/MCHLC.cfg`; `MCHLC_gap.cfg` fails on `HLC4_NoRegressionAcrossTerms` as designed. | Smallest viable PR; sets the directory layout precedent. **Default logical-handoff strategy: (c)** — `BecomeLeader` action calls `Observe(maxHLC)` (Section 5.1, HLC-4 (ii)); deviations from (c) must be justified in the PR. |
+| **M2** | `occ/OCC.tla` with safety invariants OCC-1..OCC-5. | Implemented and passing via `tla/occ/MCOCC.cfg`; `MCOCC_gap.cfg` fails on `OCC1_CommitTsAboveStart` as designed. | Re-uses `lib/Raft.tla`; introduces lock map, read/write sets, and per-transaction `start_ts` consistency. |
+| **M3** | `mvcc/MVCC.tla` with invariants MVCC-1..MVCC-4. | Implemented and passing via `tla/mvcc/MCMVCC.cfg`; `MCMVCC_gap.cfg` fails on `MVCC4_NoLostCommitOnSnapshotInstall` as designed. | Includes a small `InstallSnapshot` action to exercise MVCC-4. |
+| **M4** | `routes/Routes.tla` with invariants Routes-1..Routes-4. | Implemented and passing via `tla/routes/MCRoutes.cfg`; `MCRoutes_gap.cfg` fails on `Routes4_NoEngineRegression` as designed. | Models `SplitRange` (catalog-atomic + handling-node engine sync) and asynchronous `CatalogWatcher` polling on other nodes. |
+| **M5** | `composed/Composed.tla` with safety invariants Composed-1..Composed-3. CI integration. | Implemented and passing via `tla/composed/MCComposed.cfg`; both composed gap configs fail on the expected Composed-1 / Composed-1a invariants. | Where interaction bugs surface. Safety only; deeper liveness remains M6. |
 | **M6** *(optional)* | `tla-check-deep` configuration: larger bounds for `Composed`, plus liveness checking for OCC-L1 and Routes-L1 with their fairness assumptions. | Deeper coverage runnable on a beefier machine / off-CI. | Out of scope of the initial proposal — included only as a placeholder for the follow-up decision. Liveness checking is significantly more expensive than safety checking, hence the deferral. |
 
 ### 8.2 Doc lifecycle
 
-This doc is `proposed` at M1 kickoff. It is renamed to `partial` when M1
-lands (per CLAUDE.md's `*_partial_*.md` convention, since the proposal
-spans multiple milestones). It is renamed to `implemented` when M5's TLC
-run passes in CI on `main` — i.e. when the composed spec is not only
-written but actively guarded by the build, since the protective value of
-the spec depends on it running, not just existing.
+This doc is now `implemented`: M5's composed TLC run passes through
+`make tla-check`, and the workflow guards the spec on PRs / main pushes
+that touch the anchored implementation paths. M6 remains optional and
+does not keep this document in `partial`.
 
 ---
 

--- a/docs/design/2026_05_29_partial_composed1_cross_group_commit_guard.md
+++ b/docs/design/2026_05_29_partial_composed1_cross_group_commit_guard.md
@@ -321,7 +321,7 @@ invariant
 so the apply-time fence is also spec-checked by TLC. That
 extension is out of scope for this proposal because it changes
 the M5 (`tla/composed`) module's state shape; tracked as an open
-follow-up in `docs/design/2026_05_28_partial_tla_safety_spec.md`'s
+follow-up in `docs/design/2026_05_28_implemented_tla_safety_spec.md`'s
 M6+ slot.
 
 ---

--- a/kv/fsm.go
+++ b/kv/fsm.go
@@ -462,7 +462,7 @@ func (f *kvFSM) applyRequestErr(ctx context.Context, r *pb.Request) error {
 	// HLC.Next() for a persistence ts, hlc.last >= every commit_ts ever
 	// committed.  This closes the HLC-4 logical-handoff gap surfaced by
 	// the tla-check gap configuration on PR #856.
-	// See docs/design/2026_05_28_partial_tla_safety_spec.md §5.1 HLC-4
+	// See docs/design/2026_05_28_implemented_tla_safety_spec.md §5.1 HLC-4
 	// precondition (ii) (strategy (c)) and HLC.tla BecomeLeader_HLC.
 	if f.hlc != nil && commitTS > 0 {
 		f.hlc.Observe(commitTS)

--- a/kv/fsm_hlc_observe_test.go
+++ b/kv/fsm_hlc_observe_test.go
@@ -19,7 +19,7 @@ import (
 // greater than every commit it has previously applied.
 //
 // See:
-//   - docs/design/2026_05_28_partial_tla_safety_spec.md §5.1 HLC-4 (ii)
+//   - docs/design/2026_05_28_implemented_tla_safety_spec.md §5.1 HLC-4 (ii)
 //   - tla/hlc/HLC.tla BecomeLeader_HLC (strategy (c))
 func TestApplyObservesCommitTSIntoHLC(t *testing.T) {
 	st := store.NewMVCCStore()

--- a/kv/hlc.go
+++ b/kv/hlc.go
@@ -16,7 +16,7 @@ import (
 // to the client.
 //
 // This implements HLC-4 precondition (iii) from
-// docs/design/2026_05_28_partial_tla_safety_spec.md §5.1: every
+// docs/design/2026_05_28_implemented_tla_safety_spec.md §5.1: every
 // persistence-grade ts allocation is gated on `wall_now <
 // physicalCeiling`. The TLA+ MCHLC_gap.cfg counterexample at depth 5
 // demonstrates the safety property this enforces.
@@ -143,7 +143,7 @@ func (h *HLC) Next() uint64 {
 //   - ceiling > 0 AND wall_now < ceiling: floor wall at ceiling, then proceed.
 //
 // The TLA+ proof for this lives in tla/hlc/MCHLC_gap.cfg (HLC-4
-// counterexample, depth 5) — see docs/design/2026_05_28_partial_tla_safety_spec.md §5.1.
+// counterexample, depth 5) — see docs/design/2026_05_28_implemented_tla_safety_spec.md §5.1.
 func (h *HLC) NextFenced() (uint64, error) {
 	return h.nextLocked(true)
 }
@@ -244,7 +244,7 @@ func (h *HLC) PhysicalCeiling() int64 {
 //
 // A non-zero value here means the HLC-4 (i) bounded-skew assumption
 // (`MaxClockSkewMs < HlcPhysicalWindowMs` — see
-// docs/design/2026_05_28_partial_tla_safety_spec.md §5.1) has at some
+// docs/design/2026_05_28_implemented_tla_safety_spec.md §5.1) has at some
 // point been violated by enough margin that wall_now caught up to
 // physicalCeiling and the fence fired — typically because the leader's
 // lease renewal stopped (network partition, GC pause, …) for longer than

--- a/scripts/tla-check.sh
+++ b/scripts/tla-check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # tla-check.sh — run TLC on every module in the elastickv TLA+ suite.
 #
-# Per docs/design/2026_05_28_partial_tla_safety_spec.md §7.2.  Each
+# Per docs/design/2026_05_28_implemented_tla_safety_spec.md §7.2.  Each
 # module under tla/<module>/ ships:
 #   MC<MODULE>.tla       — the TLC model module
 #   MC<MODULE>.cfg       — the correct-design config (expected PASS)
@@ -59,7 +59,7 @@ gap_configs_for() {
 # Per-module OPTIONAL liveness (M6) configurations.  Returns one
 # "<cfg-stem>" line per liveness config; empty output means the module
 # has no liveness configuration yet (the M6 milestone is optional per
-# docs/design/2026_05_28_partial_tla_safety_spec.md §5.6).  Each
+# docs/design/2026_05_28_implemented_tla_safety_spec.md §5.6).  Each
 # returned config is expected to PASS — the .cfg file points at the
 # module's SpecLive definition (which adds fairness assumptions) and
 # its PROPERTY list includes the leads-to obligation.

--- a/tla/README.md
+++ b/tla/README.md
@@ -2,7 +2,7 @@
 
 Machine-checkable safety models for the four cross-cutting subsystems
 (HLC, OCC, MVCC, route catalog) per
-[`docs/design/2026_05_28_partial_tla_safety_spec.md`](../docs/design/2026_05_28_partial_tla_safety_spec.md).
+[`docs/design/2026_05_28_implemented_tla_safety_spec.md`](../docs/design/2026_05_28_implemented_tla_safety_spec.md).
 
 This directory is **independent of the Go module**; you can navigate and
 run it without touching anything under the Go source tree.
@@ -355,7 +355,7 @@ For reviewers new to TLA+:
 
 For the elastickv-specific design:
 
-- [`docs/design/2026_05_28_partial_tla_safety_spec.md`](../docs/design/2026_05_28_partial_tla_safety_spec.md)
+- [`docs/design/2026_05_28_implemented_tla_safety_spec.md`](../docs/design/2026_05_28_implemented_tla_safety_spec.md)
   — the proposal that this directory implements.
 - [`docs/architecture_overview.md`](../docs/architecture_overview.md)
   — high-level subsystem diagrams that the modules abstract.

--- a/tla/composed/Composed.tla
+++ b/tla/composed/Composed.tla
@@ -1,7 +1,7 @@
 ------------------------------ MODULE Composed -------------------------------
 (***************************************************************************)
 (* TLA+ specification of the cross-module safety properties — the M5      *)
-(* milestone of docs/design/2026_05_28_partial_tla_safety_spec.md §5.5.   *)
+(* milestone of docs/design/2026_05_28_implemented_tla_safety_spec.md §5.5.   *)
 (*                                                                         *)
 (* M1..M4 each modelled a single subsystem in isolation.  M5 captures     *)
 (* what happens at the seams between them — specifically, two safety      *)

--- a/tla/hlc/HLC.tla
+++ b/tla/hlc/HLC.tla
@@ -1,7 +1,7 @@
 --------------------------------- MODULE HLC ---------------------------------
 (***************************************************************************)
 (* TLA+ specification of the elastickv Hybrid Logical Clock.               *)
-(* Per docs/design/2026_05_28_partial_tla_safety_spec.md §5.1.             *)
+(* Per docs/design/2026_05_28_implemented_tla_safety_spec.md §5.1.             *)
 (*                                                                         *)
 (* This module encodes the HLC layer that sits on top of an abstract Raft *)
 (* (lib/Raft.tla).  All three HLC-4 preconditions are first-class:         *)

--- a/tla/lib/Env.tla
+++ b/tla/lib/Env.tla
@@ -1,7 +1,7 @@
 -------------------------------- MODULE Env ----------------------------------
 (***************************************************************************)
 (* Shared environment constants used by every module in the elastickv      *)
-(* TLA+ suite. Per docs/design/2026_05_28_partial_tla_safety_spec.md       *)
+(* TLA+ suite. Per docs/design/2026_05_28_implemented_tla_safety_spec.md       *)
 (* §6.1.                                                                    *)
 (*                                                                         *)
 (* The single normative ASSUME below encodes HLC-4 precondition (i) — the  *)

--- a/tla/lib/Raft.tla
+++ b/tla/lib/Raft.tla
@@ -1,7 +1,7 @@
 -------------------------------- MODULE Raft ---------------------------------
 (***************************************************************************)
 (* Abstract Raft interface for the elastickv TLA+ suite.                   *)
-(* Per docs/design/2026_05_28_partial_tla_safety_spec.md §3 / §6.1, Raft   *)
+(* Per docs/design/2026_05_28_implemented_tla_safety_spec.md §3 / §6.1, Raft   *)
 (* is modelled as a black box that delivers the standard log-matching +    *)
 (* leader-completeness guarantees.  This module exposes the **interface**  *)
 (* (leader / term / BecomeLeader / Apply / InstallSnapshot) — the internal *)

--- a/tla/mvcc/MVCC.tla
+++ b/tla/mvcc/MVCC.tla
@@ -1,7 +1,7 @@
 --------------------------------- MODULE MVCC --------------------------------
 (***************************************************************************)
 (* TLA+ specification of the elastickv MVCC layer.                         *)
-(* Per docs/design/2026_05_28_partial_tla_safety_spec.md §5.3.             *)
+(* Per docs/design/2026_05_28_implemented_tla_safety_spec.md §5.3.             *)
 (*                                                                         *)
 (* Models a per-key version chain `versions[k]` and a `Compact` action     *)
 (* that drains older versions to bound storage growth.  The model focuses  *)

--- a/tla/occ/MCOCC_live.cfg
+++ b/tla/occ/MCOCC_live.cfg
@@ -3,7 +3,7 @@
 \* weak-fairness on Abort(t) for every t.
 \*
 \* This is an OPTIONAL milestone per
-\* docs/design/2026_05_28_partial_tla_safety_spec.md §5.6.  TLC
+\* docs/design/2026_05_28_implemented_tla_safety_spec.md §5.6.  TLC
 \* liveness mode is materially slower than safety mode, so the bounds
 \* are tighter (MaxTs = 4, MaxOps = 3, two txns, two keys) — enough
 \* to exercise the (Active → terminal) and (Prepared → terminal)

--- a/tla/occ/OCC.tla
+++ b/tla/occ/OCC.tla
@@ -1,7 +1,7 @@
 --------------------------------- MODULE OCC ---------------------------------
 (***************************************************************************)
 (* TLA+ specification of the elastickv OCC layer (Percolator-style 2PC).   *)
-(* Per docs/design/2026_05_28_partial_tla_safety_spec.md §5.2.             *)
+(* Per docs/design/2026_05_28_implemented_tla_safety_spec.md §5.2.             *)
 (*                                                                         *)
 (* Models the transaction lifecycle Idle -> Active -> Prepared ->          *)
 (* Committed/Aborted and the lock-map (key, lock_ts) -> start_ts.  In M2  *)

--- a/tla/routes/MCRoutes_live.cfg
+++ b/tla/routes/MCRoutes_live.cfg
@@ -9,7 +9,7 @@
 \* PR #880.)
 \*
 \* This is an OPTIONAL milestone per
-\* docs/design/2026_05_28_partial_tla_safety_spec.md §5.6.  TLC
+\* docs/design/2026_05_28_implemented_tla_safety_spec.md §5.6.  TLC
 \* liveness mode is materially slower than safety mode, so the bounds
 \* are tighter than the safety config (two nodes, MaxVersions = 2,
 \* MaxOps = 4) — enough to exercise the (engineVersion[n] <

--- a/tla/routes/Routes.tla
+++ b/tla/routes/Routes.tla
@@ -1,7 +1,7 @@
 -------------------------------- MODULE Routes -------------------------------
 (***************************************************************************)
 (* TLA+ specification of the elastickv route catalog and CatalogWatcher.   *)
-(* Per docs/design/2026_05_28_partial_tla_safety_spec.md §5.4.             *)
+(* Per docs/design/2026_05_28_implemented_tla_safety_spec.md §5.4.             *)
 (*                                                                         *)
 (* Models the durable route catalog as a versioned snapshot and a set of   *)
 (* per-node engine views that re-sync via a CatalogWatcher action.  M4     *)


### PR DESCRIPTION
## Summary
- mark the TLA safety spec design doc implemented
- update TLA workflow, script, and spec references to the implemented document path
- keep the cross-group commit guard reference aligned with the implemented TLA spec

## Design docs
- docs/design/2026_05_28_implemented_tla_safety_spec.md

## Validation
- make tla-check
- go test ./kv -run 'Test.*HLC|Test.*FSM|Test.*Observe|Test.*Timestamp' -count=1
- golangci-lint --config=.golangci.yaml run ./kv --timeout=5m
- git verify-commit HEAD

Author: bootjp