### PR TITLE
Complete Redis standalone transaction dedup

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -201,7 +201,7 @@ type RedisServer struct {
 	// retryable write error, list-push retries reuse the failed attempt's
 	// write set and carry prev_commit_ts so the FSM can dedup a commit that
 	// landed under leadership churn (see
-	// docs/design/2026_05_21_proposed_txn_secondary_idempotency.md). The
+	// docs/design/2026_05_21_implemented_txn_secondary_idempotency.md). The
 	// FSM probe ships on every node in production, satisfying R5 (FSM
 	// determinism across a rolling upgrade), so the gate now defaults on
 	// per docs/design/2026_06_10_proposed_redis_onephase_dedup_default_on.md.
@@ -209,18 +209,11 @@ type RedisServer struct {
 	// to opt out — kept as a one-env-var operator rollback.
 	onePhaseTxnDedup bool
 
-	// standaloneSetDedup gates whether the *standalone* SET command (not SET
-	// inside MULTI/EXEC) routes through runTransactionWithDedup. Default off
-	// because the dedup path's applySet does not match the legacy
-	// executeSet/replaceWithStringTxn semantics for SET-over-collection: a
-	// `SET k v` after `RPUSH k x` returns WRONGTYPE on the dedup path but
-	// overwrites correctly on the legacy path (PR #943 round-1 codex P1).
-	// Bringing applySet to parity (collection-deletion + string write inside
-	// the dedup txn) is tracked as a follow-up; until that lands, the
-	// standalone SET path stays on the legacy default-on-flip code path
-	// regardless of onePhaseTxnDedup's value. Enable explicitly via
-	// WithStandaloneSetDedup(true) or ELASTICKV_REDIS_ONEPHASE_DEDUP_SET=1
-	// only when applySet's parity is verified for the workload at hand.
+	// standaloneSetDedup is kept for compatibility with older tests and
+	// deployments that toggled the former standalone SET sub-gate. SET now
+	// has the same collection-overwrite semantics on the dedup path as the
+	// legacy path, so onePhaseTxnDedup alone controls standalone SET/INCR/HSET
+	// routing.
 	standaloneSetDedup bool
 
 	route map[string]func(conn redcon.Conn, cmd redcon.Command)
@@ -234,20 +227,15 @@ type RedisServerOption func(*RedisServer)
 // recorded in docs/design/2026_06_10_proposed_redis_onephase_dedup_default_on.md;
 // pass false to opt out from code, or set ELASTICKV_REDIS_ONEPHASE_DEDUP=0
 // to opt out from the environment. The constructor option trumps the env var.
-// Standalone SET requires the separate WithStandaloneSetDedup gate; see
-// RedisServer.standaloneSetDedup.
 func WithOnePhaseTxnDedup(enabled bool) RedisServerOption {
 	return func(r *RedisServer) {
 		r.onePhaseTxnDedup = enabled
 	}
 }
 
-// WithStandaloneSetDedup enables the option-2 dedup path on the *standalone*
-// SET command (not SET inside MULTI/EXEC). Off by default because the dedup
-// path's applySet does not yet match the legacy executeSet semantics for
-// SET-over-collection — see RedisServer.standaloneSetDedup. Enable only
-// after verifying applySet parity for the workload (no SET-over-list /
-// SET-over-hash / SET-over-set / SET-over-zset / SET-over-stream issued).
+// WithStandaloneSetDedup is a compatibility no-op. Standalone SET follows
+// onePhaseTxnDedup now that SET-over-collection parity is implemented in
+// txnContext.applySet.
 func WithStandaloneSetDedup(enabled bool) RedisServerOption {
 	return func(r *RedisServer) {
 		r.standaloneSetDedup = enabled
@@ -497,8 +485,7 @@ func NewRedisServer(listen net.Listener, redisAddr string, store store.MVCCStore
 		// ELASTICKV_REDIS_ONEPHASE_DEDUP=0 opts out; the WithOnePhaseTxnDedup
 		// constructor option still trumps the env var.
 		onePhaseTxnDedup: os.Getenv("ELASTICKV_REDIS_ONEPHASE_DEDUP") != "0",
-		// standaloneSetDedup defaults off; see field comment for the
-		// applySet-vs-executeSet parity gap that gates this separately.
+		// Compatibility field for the removed standalone SET sub-gate.
 		standaloneSetDedup: os.Getenv("ELASTICKV_REDIS_ONEPHASE_DEDUP_SET") == "1",
 		baseCtx:            baseCtx,
 		baseCancel:         baseCancel,

--- a/adapter/redis_bzpopmin_wake_test.go
+++ b/adapter/redis_bzpopmin_wake_test.go
@@ -220,7 +220,10 @@ func TestRedis_BZPopMinDetectsMidBlockWrongType(t *testing.T) {
 // has elapsed since the last full check, restoring the #666 ceiling.
 func TestRedis_BZPopMinDetectsWrongTypeUnderSignalLoad(t *testing.T) {
 	t.Parallel()
-	nodes, _, _ := createNode(t, 3)
+	// This test drives the in-process waiter registry directly, so a
+	// single-node cluster keeps the synthetic Signal calls on the same
+	// RedisServer that owns the blocking wait loop.
+	nodes, _, _ := createNode(t, 1)
 	defer shutdown(nodes)
 
 	rdbReader := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -325,14 +325,19 @@ func (r *RedisServer) keyTypeAt(ctx context.Context, key []byte, readTS uint64) 
 // the HLC-4 (iii) ceiling fence added a NextFenced error branch
 // (PR #867 Phase 2b).
 func (r *RedisServer) requireKeyTypeOrEmpty(ctx context.Context, key []byte, readTS uint64, expected redisValueType) error {
+	_, err := r.keyTypeOrEmptyAt(ctx, key, readTS, expected)
+	return err
+}
+
+func (r *RedisServer) keyTypeOrEmptyAt(ctx context.Context, key []byte, readTS uint64, expected redisValueType) (redisValueType, error) {
 	typ, err := r.keyTypeAtExpect(ctx, key, readTS, expected)
 	if err != nil {
-		return err
+		return redisTypeNone, err
 	}
 	if typ != redisTypeNone && typ != expected {
-		return wrongTypeError()
+		return typ, wrongTypeError()
 	}
-	return nil
+	return typ, nil
 }
 
 // keyTypeAtExpect is a fast-path replacement for keyTypeAt callers that

--- a/adapter/redis_hash_cmds.go
+++ b/adapter/redis_hash_cmds.go
@@ -18,6 +18,9 @@ func (r *RedisServer) hset(conn redcon.Conn, cmd redcon.Command) {
 	if r.proxyToLeader(conn, cmd, cmd.Args[1]) {
 		return
 	}
+	if r.runStandaloneDedup(conn, cmd) {
+		return
+	}
 	added, err := r.applyHashFieldPairs(cmd.Args[1], cmd.Args[2:])
 	if err != nil {
 		writeRedisError(conn, err)
@@ -28,6 +31,9 @@ func (r *RedisServer) hset(conn redcon.Conn, cmd redcon.Command) {
 
 func (r *RedisServer) hmset(conn redcon.Conn, cmd redcon.Command) {
 	if r.proxyToLeader(conn, cmd, cmd.Args[1]) {
+		return
+	}
+	if r.runStandaloneDedup(conn, cmd) {
 		return
 	}
 	if _, err := r.applyHashFieldPairs(cmd.Args[1], cmd.Args[2:]); err != nil {
@@ -747,6 +753,13 @@ func (r *RedisServer) incr(conn redcon.Conn, cmd redcon.Command) {
 	if r.proxyToLeader(conn, cmd, cmd.Args[1]) {
 		return
 	}
+	if r.runStandaloneDedup(conn, cmd) {
+		return
+	}
+	r.incrLegacy(conn, cmd)
+}
+
+func (r *RedisServer) incrLegacy(conn redcon.Conn, cmd redcon.Command) {
 	ctx, cancel := context.WithTimeout(context.Background(), redisDispatchTimeout)
 	defer cancel()
 	var current int64

--- a/adapter/redis_hash_cmds.go
+++ b/adapter/redis_hash_cmds.go
@@ -714,7 +714,8 @@ func (r *RedisServer) hincrbyWithMigration(ctx context.Context, key, fieldKey []
 
 func (r *RedisServer) hincrbyTxn(ctx context.Context, key, field []byte, increment int64) (int64, error) {
 	readTS := r.readTS()
-	if err := r.requireKeyTypeOrEmpty(ctx, key, readTS, redisTypeHash); err != nil {
+	typ, err := r.keyTypeOrEmptyAt(ctx, key, readTS, redisTypeHash)
+	if err != nil {
 		return 0, err
 	}
 
@@ -753,6 +754,7 @@ func (r *RedisServer) hincrbyTxn(ctx context.Context, key, field []byte, increme
 		IsTxn:    true,
 		StartTS:  normalizeStartTS(readTS),
 		CommitTS: commitTS,
+		ReadKeys: redisTxnWideCreateReadKeys(key, typ, redisTxnWideHashFenceKey),
 		Elems:    elems,
 	})
 	return current, cockerrors.WithStack(dispatchErr)

--- a/adapter/redis_hash_cmds.go
+++ b/adapter/redis_hash_cmds.go
@@ -162,11 +162,14 @@ func (r *RedisServer) applyHashFieldPairs(key []byte, args [][]byte) (int, error
 		// Emit a single delta key for all newly-added fields.
 		if newFields != 0 {
 			deltaVal := store.MarshalHashMetaDelta(store.HashMetaDelta{LenDelta: int64(newFields)})
-			elems = append(elems, &kv.Elem[kv.OP]{
-				Op:    kv.Put,
-				Key:   store.HashMetaDeltaKey(key, commitTS, 0),
-				Value: deltaVal,
-			})
+			elems = append(elems,
+				redisTxnWideHashFenceElem(key),
+				&kv.Elem[kv.OP]{
+					Op:    kv.Put,
+					Key:   store.HashMetaDeltaKey(key, commitTS, 0),
+					Value: deltaVal,
+				},
+			)
 		}
 
 		if len(elems) == 0 {
@@ -691,11 +694,14 @@ func (r *RedisServer) hincrbyWithMigration(ctx context.Context, key, fieldKey []
 	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: fieldKey, Value: []byte(newVal)})
 	if isNewField {
 		deltaVal := store.MarshalHashMetaDelta(store.HashMetaDelta{LenDelta: 1})
-		elems = append(elems, &kv.Elem[kv.OP]{
-			Op:    kv.Put,
-			Key:   store.HashMetaDeltaKey(key, commitTS, 0),
-			Value: deltaVal,
-		})
+		elems = append(elems,
+			redisTxnWideHashFenceElem(key),
+			&kv.Elem[kv.OP]{
+				Op:    kv.Put,
+				Key:   store.HashMetaDeltaKey(key, commitTS, 0),
+				Value: deltaVal,
+			},
+		)
 	}
 	_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 		IsTxn:    true,
@@ -734,11 +740,14 @@ func (r *RedisServer) hincrbyTxn(ctx context.Context, key, field []byte, increme
 	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: fieldKey, Value: []byte(newVal)})
 	if isNewField {
 		deltaVal := store.MarshalHashMetaDelta(store.HashMetaDelta{LenDelta: 1})
-		elems = append(elems, &kv.Elem[kv.OP]{
-			Op:    kv.Put,
-			Key:   store.HashMetaDeltaKey(key, commitTS, 0),
-			Value: deltaVal,
-		})
+		elems = append(elems,
+			redisTxnWideHashFenceElem(key),
+			&kv.Elem[kv.OP]{
+				Op:    kv.Put,
+				Key:   store.HashMetaDeltaKey(key, commitTS, 0),
+				Value: deltaVal,
+			},
+		)
 	}
 	_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 		IsTxn:    true,

--- a/adapter/redis_hash_cmds.go
+++ b/adapter/redis_hash_cmds.go
@@ -682,7 +682,7 @@ func (r *RedisServer) readHashFieldInt(ctx context.Context, key, field []byte, r
 
 // hincrbyWithMigration handles the HINCRBY case where a legacy JSON blob must be migrated
 // atomically with the increment operation.
-func (r *RedisServer) hincrbyWithMigration(ctx context.Context, key, fieldKey []byte, readTS, commitTS uint64, current int64, isNewField bool, increment int64) (int64, error) {
+func (r *RedisServer) hincrbyWithMigration(ctx context.Context, key, fieldKey []byte, readTS, commitTS uint64, current int64, isNewField bool, typ redisValueType, increment int64) (int64, error) {
 	migrationElems, migErr := r.buildHashLegacyMigrationElems(ctx, key, readTS)
 	if migErr != nil {
 		return 0, migErr
@@ -707,6 +707,7 @@ func (r *RedisServer) hincrbyWithMigration(ctx context.Context, key, fieldKey []
 		IsTxn:    true,
 		StartTS:  normalizeStartTS(readTS),
 		CommitTS: commitTS,
+		ReadKeys: redisTxnWideCreateReadKeys(key, typ, redisTxnWideHashFenceKey),
 		Elems:    elems,
 	})
 	return current, cockerrors.WithStack(dispatchErr)
@@ -732,7 +733,7 @@ func (r *RedisServer) hincrbyTxn(ctx context.Context, key, field []byte, increme
 
 	// If a legacy blob exists, migrate it atomically with the increment.
 	if len(legacyValue) > 0 {
-		return r.hincrbyWithMigration(ctx, key, fieldKey, readTS, commitTS, current, isNewField, increment)
+		return r.hincrbyWithMigration(ctx, key, fieldKey, readTS, commitTS, current, isNewField, typ, increment)
 	}
 
 	current += increment

--- a/adapter/redis_keys.go
+++ b/adapter/redis_keys.go
@@ -309,6 +309,9 @@ func redisVisibleUserKey(key []byte) []byte {
 	if bytes.HasPrefix(key, redisTxnKeyPrefix) || isRedisTTLKey(key) {
 		return nil
 	}
+	if redisTxnWideFenceUserKey(key) != nil {
+		return nil
+	}
 	// List item keys are visible; meta, delta, and claim keys are internal-only.
 	if store.IsListItemKey(key) {
 		return store.ExtractListUserKey(key)

--- a/adapter/redis_keys_pattern_test.go
+++ b/adapter/redis_keys_pattern_test.go
@@ -160,6 +160,7 @@ func TestCollectUserKeys_FiltersByPattern(t *testing.T) {
 		{Key: redisTxnWideHashFenceKey([]byte("test:hash")), Value: []byte("1")},
 		{Key: redisTxnWideSetFenceKey([]byte("test:set")), Value: []byte("1")},
 		{Key: redisTxnWideListFenceKey([]byte("test:list")), Value: []byte("1")},
+		{Key: redisTxnWideZSetFenceKey([]byte("test:zset")), Value: []byte("1")},
 	}
 
 	keys := r.collectUserKeys(kvs, []byte("test*"))
@@ -168,6 +169,7 @@ func TestCollectUserKeys_FiltersByPattern(t *testing.T) {
 	require.Contains(t, keys, "test:list")
 	require.NotContains(t, keys, "test:hash")
 	require.NotContains(t, keys, "test:set")
+	require.NotContains(t, keys, "test:zset")
 }
 
 func TestLocalKeysPattern_FindsListKeysForUserPrefix(t *testing.T) {

--- a/adapter/redis_keys_pattern_test.go
+++ b/adapter/redis_keys_pattern_test.go
@@ -157,12 +157,17 @@ func TestCollectUserKeys_FiltersByPattern(t *testing.T) {
 		{Key: []byte("toast:key"), Value: []byte("v")},
 		{Key: store.ListMetaKey([]byte("test:list")), Value: []byte("m")},
 		{Key: store.ListItemKey([]byte("test:list"), 1), Value: []byte("i")},
+		{Key: redisTxnWideHashFenceKey([]byte("test:hash")), Value: []byte("1")},
+		{Key: redisTxnWideSetFenceKey([]byte("test:set")), Value: []byte("1")},
+		{Key: redisTxnWideListFenceKey([]byte("test:list")), Value: []byte("1")},
 	}
 
 	keys := r.collectUserKeys(kvs, []byte("test*"))
 	require.Len(t, keys, 2)
 	require.Contains(t, keys, "test:key")
 	require.Contains(t, keys, "test:list")
+	require.NotContains(t, keys, "test:hash")
+	require.NotContains(t, keys, "test:set")
 }
 
 func TestLocalKeysPattern_FindsListKeysForUserPrefix(t *testing.T) {

--- a/adapter/redis_list_dedup_test.go
+++ b/adapter/redis_list_dedup_test.go
@@ -124,6 +124,18 @@ func minElemKey(elems []*kv.Elem[kv.OP]) []byte {
 	return primary
 }
 
+func TestListPushBoundaryReadKeysIncludeWideFence(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("list:fence")
+	require.Equal(t,
+		[][]byte{redisTxnWideListFenceKey(key)},
+		listPushBoundaryReadKeys(key, store.ListMeta{}))
+	require.Equal(t,
+		[][]byte{redisTxnWideListFenceKey(key), listItemKey(key, 7)},
+		listPushBoundaryReadKeys(key, store.ListMeta{Head: 7, Len: 1, Tail: 8}))
+}
+
 // TestListPushDedup_LandedPriorAttempt_NoDuplicate is the option-2 headline:
 // attempt 1 commits the RPUSH but returns an ambiguous error; the retry
 // reuses the same write set with prev_commit_ts, the probe finds the landed

--- a/adapter/redis_lists.go
+++ b/adapter/redis_lists.go
@@ -53,11 +53,6 @@ func (r *RedisServer) loadListMetaAt(ctx context.Context, key []byte, readTS uin
 	return meta, true, nil
 }
 
-func (r *RedisServer) isListKeyAt(ctx context.Context, key []byte, readTS uint64) (bool, error) {
-	_, exists, err := r.loadListMetaAt(ctx, key, readTS)
-	return exists, err
-}
-
 // buildRPushOps creates operations to append values to the tail of a list using
 // the Delta pattern. Instead of writing to the base metadata key (causing OCC
 // conflicts), it emits a single ListMetaDelta key with LenDelta = len(values).

--- a/adapter/redis_lists.go
+++ b/adapter/redis_lists.go
@@ -124,6 +124,7 @@ func (r *RedisServer) listPushCore(ctx context.Context, key []byte, values [][]b
 			IsTxn:    true,
 			StartTS:  normalizeStartTS(readTS),
 			CommitTS: commitTS,
+			ReadKeys: listPushBoundaryReadKeys(key, meta),
 			Elems:    ops,
 		})
 		if dispErr != nil {
@@ -309,21 +310,25 @@ func firstWriteKey(ops []*kv.Elem[kv.OP]) []byte {
 	return nil
 }
 
-// listPushBoundaryReadKeys returns the boundary positions of the list as
-// read keys for OCC. Including these in the dispatched OperationGroup makes
+// listPushBoundaryReadKeys returns the collection fence plus the boundary
+// positions of the list as read keys for OCC. Including these in the
+// dispatched OperationGroup makes
 // FSM apply atomically reject the retry when any pop/trim has touched the
 // boundary between attempts (codex P1 fix: prevents a reused seq from
-// landing past a shrunk Tail). The keys are deduped: a single-element list
-// has Head == Tail-1, so we emit it once.
+// landing past a shrunk Tail). The wide fence also catches SET/DEL
+// replacements that commit before this append. The keys are deduped: a
+// single-element list has Head == Tail-1, so we emit it once.
 func listPushBoundaryReadKeys(key []byte, meta store.ListMeta) [][]byte {
+	fence := redisTxnWideListFenceKey(key)
 	if meta.Len <= 0 {
-		return nil
+		return [][]byte{fence}
 	}
 	tailIdx := meta.Tail - 1
 	if tailIdx == meta.Head {
-		return [][]byte{listItemKey(key, meta.Head)}
+		return [][]byte{fence, listItemKey(key, meta.Head)}
 	}
 	return [][]byte{
+		fence,
 		listItemKey(key, meta.Head),
 		listItemKey(key, tailIdx),
 	}

--- a/adapter/redis_lists.go
+++ b/adapter/redis_lists.go
@@ -100,7 +100,7 @@ func (r *RedisServer) listPushCore(ctx context.Context, key []byte, values [][]b
 	var newLen int64
 	err := r.retryRedisWrite(ctx, func() error {
 		readTS := r.readTS()
-		meta, _, err := r.resolveListMeta(ctx, key, readTS)
+		meta, metaExists, err := r.resolveListMeta(ctx, key, readTS)
 		if err != nil {
 			return err
 		}
@@ -124,7 +124,7 @@ func (r *RedisServer) listPushCore(ctx context.Context, key []byte, values [][]b
 			IsTxn:    true,
 			StartTS:  normalizeStartTS(readTS),
 			CommitTS: commitTS,
-			ReadKeys: listPushBoundaryReadKeys(key, meta),
+			ReadKeys: listPushReadKeys(key, meta, metaExists),
 			Elems:    ops,
 		})
 		if dispErr != nil {
@@ -334,6 +334,13 @@ func listPushBoundaryReadKeys(key []byte, meta store.ListMeta) [][]byte {
 	}
 }
 
+func listPushReadKeys(key []byte, meta store.ListMeta, metaExists bool) [][]byte {
+	if !metaExists {
+		return redisTxnWideCollectionFenceKeys(key)
+	}
+	return listPushBoundaryReadKeys(key, meta)
+}
+
 // listPushCoreWithDedup is the option-2 retry loop. The first attempt computes
 // the write set from the current meta; any retryable failure makes the next
 // iteration REUSE that write set under a fresh commit_ts with prev_commit_ts
@@ -357,7 +364,7 @@ func (r *RedisServer) listPushCoreWithDedup(ctx context.Context, key []byte, val
 		}
 
 		readTS := r.readTS()
-		meta, _, err := r.resolveListMeta(ctx, key, readTS)
+		meta, metaExists, err := r.resolveListMeta(ctx, key, readTS)
 		if err != nil {
 			return err
 		}
@@ -378,7 +385,7 @@ func (r *RedisServer) listPushCoreWithDedup(ctx context.Context, key []byte, val
 		}
 
 		startTS := normalizeStartTS(readTS)
-		boundaryReads := listPushBoundaryReadKeys(key, meta)
+		boundaryReads := listPushReadKeys(key, meta, metaExists)
 		_, dispErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 			IsTxn:    true,
 			StartTS:  startTS,

--- a/adapter/redis_lists.go
+++ b/adapter/redis_lists.go
@@ -100,7 +100,7 @@ func (r *RedisServer) listPushCore(ctx context.Context, key []byte, values [][]b
 	var newLen int64
 	err := r.retryRedisWrite(ctx, func() error {
 		readTS := r.readTS()
-		meta, metaExists, err := r.resolveListMeta(ctx, key, readTS)
+		meta, metaExists, typ, err := r.listPushSnapshot(ctx, key, readTS)
 		if err != nil {
 			return err
 		}
@@ -124,7 +124,7 @@ func (r *RedisServer) listPushCore(ctx context.Context, key []byte, values [][]b
 			IsTxn:    true,
 			StartTS:  normalizeStartTS(readTS),
 			CommitTS: commitTS,
-			ReadKeys: listPushReadKeys(key, meta, metaExists),
+			ReadKeys: listPushReadKeys(key, meta, typ, metaExists),
 			Elems:    ops,
 		})
 		if dispErr != nil {
@@ -134,6 +134,18 @@ func (r *RedisServer) listPushCore(ctx context.Context, key []byte, values [][]b
 		return nil
 	})
 	return newLen, err
+}
+
+func (r *RedisServer) listPushSnapshot(ctx context.Context, key []byte, readTS uint64) (store.ListMeta, bool, redisValueType, error) {
+	typ, err := r.keyTypeOrEmptyAt(ctx, key, readTS, redisTypeList)
+	if err != nil {
+		return store.ListMeta{}, false, redisTypeNone, err
+	}
+	meta, exists, err := r.resolveListMeta(ctx, key, readTS)
+	if err != nil {
+		return store.ListMeta{}, false, redisTypeNone, err
+	}
+	return meta, exists, typ, nil
 }
 
 // reusableListPush captures a dispatched list-push attempt so a subsequent
@@ -334,8 +346,8 @@ func listPushBoundaryReadKeys(key []byte, meta store.ListMeta) [][]byte {
 	}
 }
 
-func listPushReadKeys(key []byte, meta store.ListMeta, metaExists bool) [][]byte {
-	if !metaExists {
+func listPushReadKeys(key []byte, meta store.ListMeta, typ redisValueType, metaExists bool) [][]byte {
+	if typ == redisTypeNone || !metaExists {
 		return redisTxnWideCollectionFenceKeys(key)
 	}
 	return listPushBoundaryReadKeys(key, meta)
@@ -364,7 +376,7 @@ func (r *RedisServer) listPushCoreWithDedup(ctx context.Context, key []byte, val
 		}
 
 		readTS := r.readTS()
-		meta, metaExists, err := r.resolveListMeta(ctx, key, readTS)
+		meta, metaExists, typ, err := r.listPushSnapshot(ctx, key, readTS)
 		if err != nil {
 			return err
 		}
@@ -385,7 +397,7 @@ func (r *RedisServer) listPushCoreWithDedup(ctx context.Context, key []byte, val
 		}
 
 		startTS := normalizeStartTS(readTS)
-		boundaryReads := listPushReadKeys(key, meta, metaExists)
+		boundaryReads := listPushReadKeys(key, meta, typ, metaExists)
 		_, dispErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 			IsTxn:    true,
 			StartTS:  startTS,

--- a/adapter/redis_lists.go
+++ b/adapter/redis_lists.go
@@ -19,6 +19,8 @@ func listItemKey(userKey []byte, seq int64) []byte {
 	return store.ListItemKey(userKey, seq)
 }
 
+const listPushFenceAndDeltaElems = 2
+
 func clampRange(start, end, length int) (int, int) {
 	if start < 0 {
 		start = length + start
@@ -63,7 +65,7 @@ func (r *RedisServer) buildRPushOps(meta store.ListMeta, key []byte, values [][]
 		return nil, meta, nil
 	}
 
-	elems := make([]*kv.Elem[kv.OP], 0, len(values)+1)
+	elems := make([]*kv.Elem[kv.OP], 0, len(values)+listPushFenceAndDeltaElems)
 	seq := meta.Head + meta.Len
 	for _, v := range values {
 		vCopy := bytes.Clone(v)
@@ -73,7 +75,10 @@ func (r *RedisServer) buildRPushOps(meta store.ListMeta, key []byte, values [][]
 
 	// Emit a Delta key instead of writing the base meta key.
 	delta := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: 0, LenDelta: int64(len(values))})
-	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: store.ListMetaDeltaKey(key, commitTS, seqInTxn), Value: delta})
+	elems = append(elems,
+		redisTxnWideListFenceElem(key),
+		&kv.Elem[kv.OP]{Op: kv.Put, Key: store.ListMetaDeltaKey(key, commitTS, seqInTxn), Value: delta},
+	)
 
 	meta.Len += int64(len(values))
 	meta.Tail = meta.Head + meta.Len
@@ -419,7 +424,7 @@ func (r *RedisServer) buildLPushOps(meta store.ListMeta, key []byte, values [][]
 	if meta.Head < math.MinInt64+n {
 		return nil, meta, errors.WithStack(errors.New("LPUSH would underflow list Head sequence number"))
 	}
-	elems := make([]*kv.Elem[kv.OP], 0, len(values)+1)
+	elems := make([]*kv.Elem[kv.OP], 0, len(values)+listPushFenceAndDeltaElems)
 	// LPUSH reverses args, so last arg gets the lowest sequence number.
 	newHead := meta.Head - n
 	for i, v := range values {
@@ -431,7 +436,10 @@ func (r *RedisServer) buildLPushOps(meta store.ListMeta, key []byte, values [][]
 
 	// Emit a Delta key instead of writing the base meta key.
 	delta := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: -n, LenDelta: n})
-	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: store.ListMetaDeltaKey(key, commitTS, seqInTxn), Value: delta})
+	elems = append(elems,
+		redisTxnWideListFenceElem(key),
+		&kv.Elem[kv.OP]{Op: kv.Put, Key: store.ListMetaDeltaKey(key, commitTS, seqInTxn), Value: delta},
+	)
 
 	meta.Head = newHead
 	meta.Len += n
@@ -587,11 +595,14 @@ func (r *RedisServer) commitListPop(ctx context.Context, key []byte, elems []*kv
 		headDelta = n // head advances by n positions for LPOP
 	}
 	delta := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: headDelta, LenDelta: -n})
-	elems = append(elems, &kv.Elem[kv.OP]{
-		Op:    kv.Put,
-		Key:   store.ListMetaDeltaKey(key, commitTS, 0),
-		Value: delta,
-	})
+	elems = append(elems,
+		redisTxnWideListFenceElem(key),
+		&kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.ListMetaDeltaKey(key, commitTS, 0),
+			Value: delta,
+		},
+	)
 
 	if _, dispErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 		IsTxn:    true,

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -3423,7 +3423,7 @@ func (c *luaScriptContext) hashCommitElems(key string) ([]*kv.Elem[kv.OP], error
 	}
 	// Wide-column: write per-field keys and a base meta key with the final count.
 	// deleteLogicalKeyElems (called by the Lua commit flow) clears any old keys.
-	elems := make([]*kv.Elem[kv.OP], 0, len(st.value)+1)
+	elems := make([]*kv.Elem[kv.OP], 0, len(st.value)+setWideColOverhead)
 	for field, val := range st.value {
 		elems = append(elems, &kv.Elem[kv.OP]{
 			Op:    kv.Put,
@@ -3431,6 +3431,7 @@ func (c *luaScriptContext) hashCommitElems(key string) ([]*kv.Elem[kv.OP], error
 			Value: []byte(val),
 		})
 	}
+	elems = append(elems, redisTxnWideHashFenceElem([]byte(key)))
 	elems = append(elems, &kv.Elem[kv.OP]{
 		Op:    kv.Put,
 		Key:   store.HashMetaKey([]byte(key)),
@@ -3449,7 +3450,7 @@ func (c *luaScriptContext) setCommitElems(key string) ([]*kv.Elem[kv.OP], error)
 		return nil, nil
 	}
 	// Wide-column: write per-member keys and a base meta key with the final count.
-	elems := make([]*kv.Elem[kv.OP], 0, len(st.members)+1)
+	elems := make([]*kv.Elem[kv.OP], 0, len(st.members)+setWideColOverhead)
 	for member := range st.members {
 		elems = append(elems, &kv.Elem[kv.OP]{
 			Op:    kv.Put,
@@ -3457,6 +3458,7 @@ func (c *luaScriptContext) setCommitElems(key string) ([]*kv.Elem[kv.OP], error)
 			Value: []byte{},
 		})
 	}
+	elems = append(elems, redisTxnWideSetFenceElem([]byte(key)))
 	elems = append(elems, &kv.Elem[kv.OP]{
 		Op:    kv.Put,
 		Key:   store.SetMetaKey([]byte(key)),

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -3233,8 +3233,12 @@ func (c *luaScriptContext) commitPlanForKey(ctx context.Context, key string, com
 		return luaKeyPlan{}, err
 	}
 
+	startType, err := c.server.keyTypeAt(context.Background(), []byte(key), c.startTS)
+	if err != nil {
+		return luaKeyPlan{}, err
+	}
 	var deleteElems []*kv.Elem[kv.OP]
-	readKeys := luaWideFenceReadKeysForPlan([]byte(key), finalType, valuePlan.preserveExisting)
+	readKeys := luaWideFenceReadKeysForPlan([]byte(key), finalType, startType, valuePlan.preserveExisting)
 	if !valuePlan.preserveExisting {
 		deleteElems, _, err = c.server.deleteLogicalKeyElems(ctx, []byte(key), c.startTS)
 		if err != nil {
@@ -3254,8 +3258,8 @@ func (c *luaScriptContext) commitPlanForKey(ctx context.Context, key string, com
 	}, nil
 }
 
-func luaWideFenceReadKeysForPlan(key []byte, finalType redisValueType, preserveExisting bool) [][]byte {
-	if !preserveExisting {
+func luaWideFenceReadKeysForPlan(key []byte, finalType, startType redisValueType, preserveExisting bool) [][]byte {
+	if !preserveExisting || startType == redisTypeNone {
 		return redisTxnWideCollectionFenceKeys(key)
 	}
 	switch finalType {

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -3143,6 +3143,7 @@ type luaCommitPlan struct {
 // luaKeyPlan carries the data elements and TTL metadata for a single key commit.
 type luaKeyPlan struct {
 	elems            []*kv.Elem[kv.OP]
+	readKeys         [][]byte
 	finalType        redisValueType
 	preserveExisting bool
 }
@@ -3161,6 +3162,7 @@ func (c *luaScriptContext) commit() error {
 	}
 
 	elems := make([]*kv.Elem[kv.OP], 0, len(keys)*redisPairWidth)
+	readKeys := make([][]byte, 0, len(keys))
 	ctx := context.Background()
 	for _, key := range keys {
 		plan, err := c.commitPlanForKey(ctx, key, commitTS)
@@ -3168,6 +3170,7 @@ func (c *luaScriptContext) commit() error {
 			return err
 		}
 		elems = append(elems, plan.elems...)
+		readKeys = append(readKeys, plan.readKeys...)
 		// For non-string keys with dirty TTL: include !redis|ttl| in the same txn.
 		// String keys already have TTL embedded in the value via stringCommitElems.
 		if isNonStringCollectionType(plan.finalType) {
@@ -3193,6 +3196,7 @@ func (c *luaScriptContext) commit() error {
 		IsTxn:    true,
 		StartTS:  startTS,
 		CommitTS: commitTS,
+		ReadKeys: readKeys,
 		Elems:    elems,
 	}); err != nil {
 		return errors.WithStack(err)
@@ -3230,11 +3234,13 @@ func (c *luaScriptContext) commitPlanForKey(ctx context.Context, key string, com
 	}
 
 	var deleteElems []*kv.Elem[kv.OP]
+	readKeys := luaWideFenceReadKeysForPlan([]byte(key), finalType, valuePlan.preserveExisting)
 	if !valuePlan.preserveExisting {
 		deleteElems, _, err = c.server.deleteLogicalKeyElems(ctx, []byte(key), c.startTS)
 		if err != nil {
 			return luaKeyPlan{}, err
 		}
+		deleteElems = append(deleteElems, redisTxnWideCollectionFenceElems([]byte(key))...)
 	}
 
 	dataElems := make([]*kv.Elem[kv.OP], 0, len(deleteElems)+len(valuePlan.elems))
@@ -3242,9 +3248,29 @@ func (c *luaScriptContext) commitPlanForKey(ctx context.Context, key string, com
 	dataElems = append(dataElems, valuePlan.elems...)
 	return luaKeyPlan{
 		elems:            dataElems,
+		readKeys:         readKeys,
 		finalType:        finalType,
 		preserveExisting: valuePlan.preserveExisting,
 	}, nil
+}
+
+func luaWideFenceReadKeysForPlan(key []byte, finalType redisValueType, preserveExisting bool) [][]byte {
+	if !preserveExisting {
+		return redisTxnWideCollectionFenceKeys(key)
+	}
+	switch finalType {
+	case redisTypeHash:
+		return [][]byte{redisTxnWideHashFenceKey(key)}
+	case redisTypeSet:
+		return [][]byte{redisTxnWideSetFenceKey(key)}
+	case redisTypeList:
+		return [][]byte{redisTxnWideListFenceKey(key)}
+	case redisTypeZSet:
+		return [][]byte{redisTxnWideZSetFenceKey(key)}
+	case redisTypeNone, redisTypeString, redisTypeStream:
+		return nil
+	}
+	return nil
 }
 
 func (c *luaScriptContext) valueCommitPlan(key string, finalType redisValueType, commitTS uint64) (luaCommitPlan, error) {
@@ -3374,6 +3400,9 @@ func (c *luaScriptContext) listDeltaCommitElems(key string, st *luaListState, co
 			Key:   store.ListMetaDeltaKey([]byte(key), commitTS, seqInTxn),
 			Value: leftDelta,
 		})
+	}
+	if len(elems) != 0 {
+		elems = append(elems, redisTxnWideListFenceElem([]byte(key)))
 	}
 	return elems, nil
 }
@@ -3540,6 +3569,7 @@ func (c *luaScriptContext) zsetFullCommitElems(key string) []*kv.Elem[kv.OP] {
 		Key:   store.ZSetMetaKey([]byte(key)),
 		Value: store.MarshalZSetMeta(store.ZSetMeta{Len: int64(len(st.members))}),
 	})
+	elems = append(elems, redisTxnWideZSetFenceElem([]byte(key)))
 	return elems
 }
 
@@ -3586,6 +3616,9 @@ func (c *luaScriptContext) zsetDeltaCommitElems(key string, st *luaZSetState, co
 		)
 	}
 	elems = append(elems, c.zsetDeltaMetaElems([]byte(key), st, commitTS)...)
+	if len(elems) != 0 {
+		elems = append(elems, redisTxnWideZSetFenceElem([]byte(key)))
+	}
 	return elems
 }
 

--- a/adapter/redis_multi_test.go
+++ b/adapter/redis_multi_test.go
@@ -286,6 +286,53 @@ func TestRedis_MultiExec_ListOpsRejectStagedHashAndString(t *testing.T) {
 	require.Equal(t, "1", rdb.Get(ctx, "txn:string-before-list").Val())
 }
 
+func TestRedis_MultiExec_StagedTypeAfterDeleteWinsOverDeletionOnlyState(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+	ctx := context.Background()
+
+	require.Equal(t, "OK", rdb.Do(ctx, "MULTI").Val())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "HSET", "txn:hash-del-list-hash", "f", "v").Val())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "DEL", "txn:hash-del-list-hash").Val())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "RPUSH", "txn:hash-del-list-hash", "x").Val())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "HSET", "txn:hash-del-list-hash", "g", "w").Val())
+	execRes, err := rdb.Do(ctx, "EXEC").Result()
+	require.NoError(t, err)
+	vals, ok := execRes.([]any)
+	require.True(t, ok)
+	require.Len(t, vals, 4)
+	require.Equal(t, int64(1), vals[0])
+	require.Equal(t, int64(1), vals[1])
+	require.Equal(t, int64(1), vals[2])
+	hashErr, ok := vals[3].(error)
+	require.True(t, ok, "HSET after recreated list should be an EXEC item error, got %T", vals[3])
+	require.Contains(t, hashErr.Error(), "WRONGTYPE")
+	rangeRes, err := rdb.Do(ctx, "LRANGE", "txn:hash-del-list-hash", 0, -1).Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{"x"}, rangeRes)
+
+	require.NoError(t, rdb.Set(ctx, "txn:str-del-incr-rpush", "old", 0).Err())
+	require.Equal(t, "OK", rdb.Do(ctx, "MULTI").Val())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "DEL", "txn:str-del-incr-rpush").Val())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "INCR", "txn:str-del-incr-rpush").Val())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "RPUSH", "txn:str-del-incr-rpush", "x").Val())
+	execRes, err = rdb.Do(ctx, "EXEC").Result()
+	require.NoError(t, err)
+	vals, ok = execRes.([]any)
+	require.True(t, ok)
+	require.Len(t, vals, 3)
+	require.Equal(t, int64(1), vals[0])
+	require.Equal(t, int64(1), vals[1])
+	listErr, ok := vals[2].(error)
+	require.True(t, ok, "RPUSH after recreated string should be an EXEC item error, got %T", vals[2])
+	require.Contains(t, listErr.Error(), "WRONGTYPE")
+	require.Equal(t, "1", rdb.Get(ctx, "txn:str-del-incr-rpush").Val())
+}
+
 func TestRedis_RPushLRange(t *testing.T) {
 	t.Parallel()
 	nodes, _, _ := createNode(t, 3)

--- a/adapter/redis_multi_test.go
+++ b/adapter/redis_multi_test.go
@@ -229,6 +229,63 @@ func TestRedis_MultiExec_IncrDoesNotOverwriteHLL(t *testing.T) {
 	require.Equal(t, "ok", rdb.Get(ctx, "txn:hll-neighbor").Val())
 }
 
+func TestRedis_MultiExec_IncrCreatedStringCanBeIncrementedAgain(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+	ctx := context.Background()
+
+	require.Equal(t, "OK", rdb.Do(ctx, "MULTI").Val())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "INCR", "txn:double-incr").Val())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "INCR", "txn:double-incr").Val())
+
+	execRes, err := rdb.Do(ctx, "EXEC").Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{int64(1), int64(2)}, execRes)
+	require.Equal(t, "2", rdb.Get(ctx, "txn:double-incr").Val())
+}
+
+func TestRedis_MultiExec_ListOpsRejectStagedHashAndString(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+	ctx := context.Background()
+
+	require.Equal(t, "OK", rdb.Do(ctx, "MULTI").Val())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "HSET", "txn:hash-before-list", "f", "v").Val())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "RPUSH", "txn:hash-before-list", "x").Val())
+	execRes, err := rdb.Do(ctx, "EXEC").Result()
+	require.NoError(t, err)
+	vals, ok := execRes.([]any)
+	require.True(t, ok)
+	require.Len(t, vals, 2)
+	require.Equal(t, int64(1), vals[0])
+	hashErr, ok := vals[1].(error)
+	require.True(t, ok, "RPUSH after HSET should be an EXEC item error, got %T", vals[1])
+	require.Contains(t, hashErr.Error(), "WRONGTYPE")
+	require.Equal(t, map[string]string{"f": "v"}, rdb.HGetAll(ctx, "txn:hash-before-list").Val())
+
+	require.Equal(t, "OK", rdb.Do(ctx, "MULTI").Val())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "INCR", "txn:string-before-list").Val())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "RPUSH", "txn:string-before-list", "x").Val())
+	execRes, err = rdb.Do(ctx, "EXEC").Result()
+	require.NoError(t, err)
+	vals, ok = execRes.([]any)
+	require.True(t, ok)
+	require.Len(t, vals, 2)
+	require.Equal(t, int64(1), vals[0])
+	stringErr, ok := vals[1].(error)
+	require.True(t, ok, "RPUSH after INCR should be an EXEC item error, got %T", vals[1])
+	require.Contains(t, stringErr.Error(), "WRONGTYPE")
+	require.Equal(t, "1", rdb.Get(ctx, "txn:string-before-list").Val())
+}
+
 func TestRedis_RPushLRange(t *testing.T) {
 	t.Parallel()
 	nodes, _, _ := createNode(t, 3)

--- a/adapter/redis_multi_test.go
+++ b/adapter/redis_multi_test.go
@@ -248,6 +248,34 @@ func TestRedis_MultiExec_IncrCreatedStringCanBeIncrementedAgain(t *testing.T) {
 	require.Equal(t, "2", rdb.Get(ctx, "txn:double-incr").Val())
 }
 
+func TestRedis_MultiExec_HSetArityErrorDoesNotAbortExec(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+	ctx := context.Background()
+
+	require.Equal(t, "OK", rdb.Do(ctx, "MULTI").Val())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "SET", "txn:hset-arity-a", "1").Val())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "HSET", "txn:hset-arity-h", "f", "v", "dangling").Val())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "SET", "txn:hset-arity-b", "2").Val())
+	execRes, err := rdb.Do(ctx, "EXEC").Result()
+	require.NoError(t, err)
+	vals, ok := execRes.([]any)
+	require.True(t, ok)
+	require.Len(t, vals, 3)
+	require.Equal(t, "OK", vals[0])
+	arityErr, ok := vals[1].(error)
+	require.True(t, ok, "HSET odd field/value count should be an EXEC item error, got %T", vals[1])
+	require.Contains(t, arityErr.Error(), "wrong number of arguments")
+	require.Equal(t, "OK", vals[2])
+	require.Equal(t, "1", rdb.Get(ctx, "txn:hset-arity-a").Val())
+	require.Equal(t, "2", rdb.Get(ctx, "txn:hset-arity-b").Val())
+	require.Equal(t, int64(0), rdb.Exists(ctx, "txn:hset-arity-h").Val())
+}
+
 func TestRedis_MultiExec_ListOpsRejectStagedHashAndString(t *testing.T) {
 	t.Parallel()
 	nodes, _, _ := createNode(t, 3)

--- a/adapter/redis_retry.go
+++ b/adapter/redis_retry.go
@@ -175,6 +175,9 @@ func normalizeRetryableRedisTxnKey(key []byte) []byte {
 	if userKey := kv.ExtractTxnUserKey(key); userKey != nil {
 		key = userKey
 	}
+	if userKey := redisTxnWideFenceUserKey(key); userKey != nil {
+		return userKey
+	}
 	if store.IsListMetaKey(key) || store.IsListItemKey(key) {
 		return store.ExtractListUserKey(key)
 	}

--- a/adapter/redis_retry_test.go
+++ b/adapter/redis_retry_test.go
@@ -321,6 +321,18 @@ func TestNormalizeRetryableRedisTxnErrTxnTTLKey(t *testing.T) {
 	require.NotContains(t, normalized.Error(), redisTTLPrefix)
 }
 
+func TestNormalizeRetryableRedisTxnErrWideFenceKey(t *testing.T) {
+	t.Parallel()
+
+	err := store.NewWriteConflictError(redisTxnWideHashFenceKey([]byte("retry:hash")))
+
+	normalized := normalizeRetryableRedisTxnErr(err)
+
+	require.ErrorIs(t, normalized, store.ErrWriteConflict)
+	require.ErrorContains(t, normalized, "key: retry:hash")
+	require.NotContains(t, normalized.Error(), string(redisTxnWideFencePrefix))
+}
+
 func TestNormalizeRetryableRedisTxnErrPreservesTxnLockedDetail(t *testing.T) {
 	t.Parallel()
 

--- a/adapter/redis_retry_test.go
+++ b/adapter/redis_retry_test.go
@@ -330,7 +330,8 @@ func TestNormalizeRetryableRedisTxnErrWideFenceKey(t *testing.T) {
 
 	require.ErrorIs(t, normalized, store.ErrWriteConflict)
 	require.ErrorContains(t, normalized, "key: retry:hash")
-	require.NotContains(t, normalized.Error(), string(redisTxnWideFencePrefix))
+	require.NotContains(t, normalized.Error(), string(redisTxnWideHashFencePrefix))
+	require.NotContains(t, normalized.Error(), "!redis|")
 }
 
 func TestNormalizeRetryableRedisTxnErrPreservesTxnLockedDetail(t *testing.T) {

--- a/adapter/redis_set_cmds.go
+++ b/adapter/redis_set_cmds.go
@@ -265,6 +265,9 @@ func (r *RedisServer) mutateExactSetWide(conn redcon.Conn, ctx context.Context, 
 		if err != nil {
 			return err
 		}
+		if err := r.rejectHLLPayloadForSetCreate(key, readTS, typ); err != nil {
+			return err
+		}
 
 		commitTS, err := r.coordinator.Clock().NextFenced()
 		if err != nil {
@@ -312,6 +315,20 @@ func (r *RedisServer) mutateExactSetWide(conn redcon.Conn, ctx context.Context, 
 		return
 	}
 	conn.WriteInt(changed)
+}
+
+func (r *RedisServer) rejectHLLPayloadForSetCreate(key []byte, readTS uint64, typ redisValueType) error {
+	if typ != redisTypeNone {
+		return nil
+	}
+	hllExists, err := r.hllExistsAt(key, readTS)
+	if err != nil {
+		return err
+	}
+	if hllExists {
+		return wrongTypeError()
+	}
+	return nil
 }
 
 func appendSetDeltaElems(elems []*kv.Elem[kv.OP], key []byte, lenDelta int64, commitTS uint64) []*kv.Elem[kv.OP] {

--- a/adapter/redis_set_cmds.go
+++ b/adapter/redis_set_cmds.go
@@ -82,6 +82,7 @@ func (r *RedisServer) buildSetLegacyMigrationElems(ctx context.Context, key []by
 		Key:   store.SetMetaKey(key),
 		Value: store.MarshalSetMeta(store.SetMeta{Len: int64(len(value.Members))}),
 	})
+	elems = append(elems, redisTxnWideSetFenceElem(key))
 	return elems, nil
 }
 

--- a/adapter/redis_set_cmds.go
+++ b/adapter/redis_set_cmds.go
@@ -261,7 +261,8 @@ func (r *RedisServer) mutateExactSetWide(conn redcon.Conn, ctx context.Context, 
 	var changed int
 	if err := r.retryRedisWrite(ctx, func() error {
 		readTS := r.readTS()
-		if err := r.validateExactSetKind(setKind, key, readTS); err != nil {
+		typ, err := r.keyTypeOrEmptyAt(ctx, key, readTS, redisTypeSet)
+		if err != nil {
 			return err
 		}
 
@@ -302,7 +303,7 @@ func (r *RedisServer) mutateExactSetWide(conn redcon.Conn, ctx context.Context, 
 			IsTxn:    true,
 			StartTS:  normalizeStartTS(readTS),
 			CommitTS: commitTS,
-			ReadKeys: [][]byte{redisTxnWideSetFenceKey(key)},
+			ReadKeys: redisTxnWideCreateReadKeys(key, typ, redisTxnWideSetFenceKey),
 			Elems:    elems,
 		})
 		return cockerrors.WithStack(dispatchErr)

--- a/adapter/redis_set_cmds.go
+++ b/adapter/redis_set_cmds.go
@@ -301,6 +301,7 @@ func (r *RedisServer) mutateExactSetWide(conn redcon.Conn, ctx context.Context, 
 			IsTxn:    true,
 			StartTS:  normalizeStartTS(readTS),
 			CommitTS: commitTS,
+			ReadKeys: [][]byte{redisTxnWideSetFenceKey(key)},
 			Elems:    elems,
 		})
 		return cockerrors.WithStack(dispatchErr)
@@ -315,9 +316,7 @@ func appendSetDeltaElems(elems []*kv.Elem[kv.OP], key []byte, lenDelta int64, co
 	if lenDelta == 0 {
 		return elems
 	}
-	if lenDelta > 0 {
-		elems = append(elems, redisTxnWideSetFenceElem(key))
-	}
+	elems = append(elems, redisTxnWideSetFenceElem(key))
 	deltaVal := store.MarshalSetMetaDelta(store.SetMetaDelta{LenDelta: lenDelta})
 	return append(elems, &kv.Elem[kv.OP]{
 		Op:    kv.Put,

--- a/adapter/redis_set_cmds.go
+++ b/adapter/redis_set_cmds.go
@@ -291,14 +291,7 @@ func (r *RedisServer) mutateExactSetWide(conn redcon.Conn, ctx context.Context, 
 			return nil
 		}
 
-		if lenDelta != 0 {
-			deltaVal := store.MarshalSetMetaDelta(store.SetMetaDelta{LenDelta: lenDelta})
-			elems = append(elems, &kv.Elem[kv.OP]{
-				Op:    kv.Put,
-				Key:   store.SetMetaDeltaKey(key, commitTS, 0),
-				Value: deltaVal,
-			})
-		}
+		elems = appendSetDeltaElems(elems, key, lenDelta, commitTS)
 
 		if len(elems) == 0 {
 			return nil
@@ -316,6 +309,21 @@ func (r *RedisServer) mutateExactSetWide(conn redcon.Conn, ctx context.Context, 
 		return
 	}
 	conn.WriteInt(changed)
+}
+
+func appendSetDeltaElems(elems []*kv.Elem[kv.OP], key []byte, lenDelta int64, commitTS uint64) []*kv.Elem[kv.OP] {
+	if lenDelta == 0 {
+		return elems
+	}
+	if lenDelta > 0 {
+		elems = append(elems, redisTxnWideSetFenceElem(key))
+	}
+	deltaVal := store.MarshalSetMetaDelta(store.SetMetaDelta{LenDelta: lenDelta})
+	return append(elems, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   store.SetMetaDeltaKey(key, commitTS, 0),
+		Value: deltaVal,
+	})
 }
 
 // scanSetMemberExistsMap does a paginated prefix scan of all member keys for

--- a/adapter/redis_set_dedup_test.go
+++ b/adapter/redis_set_dedup_test.go
@@ -21,19 +21,13 @@ import (
 //
 // Pins that the gate-on path uses the same dedup machinery as MULTI/EXEC.
 // Without this routing, a standalone SET under leadership churn would not
-// benefit from option-2 dedup (the design's "still open" item before this
-// PR).
+// benefit from option-2 dedup.
 func TestStandaloneSetDedup_LandedPriorAttempt_ReturnsOK(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	st := store.NewMVCCStore()
 	coord := newDedupTestCoordinator(st, 1, true) // attempt 1 lands then errors
-	// Both gates: onePhaseTxnDedup is the umbrella; standaloneSetDedup is
-	// the per-path sub-gate that opts the *standalone* SET branch into
-	// the dedup routing. The sub-gate defaults off (PR #943 round-1 codex
-	// P1 — applySet diverges from executeSet on SET-over-collection).
-	// Tests that pin the dedup-on routing must explicitly enable both.
-	srv := &RedisServer{store: st, coordinator: coord, scriptCache: map[string]string{}, onePhaseTxnDedup: true, standaloneSetDedup: true}
+	srv := &RedisServer{store: st, coordinator: coord, scriptCache: map[string]string{}, onePhaseTxnDedup: true}
 
 	conn := &recordingConn{}
 	cmd := redcon.Command{Args: [][]byte{[]byte(cmdSet), []byte("k"), []byte("v1")}}
@@ -66,12 +60,7 @@ func TestStandaloneSetDedup_NXMissReturnsNil(t *testing.T) {
 	require.NoError(t, st.PutAt(ctx, redisStrKey([]byte("k")), encodeRedisStr([]byte("seed"), nil), 5, 0))
 
 	coord := newDedupTestCoordinator(st, 1, true) // attempt 1 lands then errors
-	// Both gates: onePhaseTxnDedup is the umbrella; standaloneSetDedup is
-	// the per-path sub-gate that opts the *standalone* SET branch into
-	// the dedup routing. The sub-gate defaults off (PR #943 round-1 codex
-	// P1 — applySet diverges from executeSet on SET-over-collection).
-	// Tests that pin the dedup-on routing must explicitly enable both.
-	srv := &RedisServer{store: st, coordinator: coord, scriptCache: map[string]string{}, onePhaseTxnDedup: true, standaloneSetDedup: true}
+	srv := &RedisServer{store: st, coordinator: coord, scriptCache: map[string]string{}, onePhaseTxnDedup: true}
 
 	conn := &recordingConn{}
 	// SET k v1 NX -- attempt 1 records resultNil because NX miss.
@@ -109,12 +98,7 @@ func TestStandaloneSetDedup_GETOptionReturnsOldBulk(t *testing.T) {
 	require.NoError(t, st.PutAt(ctx, redisStrKey([]byte("k")), encodeRedisStr([]byte("prior"), nil), 5, 0))
 
 	coord := newDedupTestCoordinator(st, 1, true) // attempt 1 lands then errors
-	// Both gates: onePhaseTxnDedup is the umbrella; standaloneSetDedup is
-	// the per-path sub-gate that opts the *standalone* SET branch into
-	// the dedup routing. The sub-gate defaults off (PR #943 round-1 codex
-	// P1 — applySet diverges from executeSet on SET-over-collection).
-	// Tests that pin the dedup-on routing must explicitly enable both.
-	srv := &RedisServer{store: st, coordinator: coord, scriptCache: map[string]string{}, onePhaseTxnDedup: true, standaloneSetDedup: true}
+	srv := &RedisServer{store: st, coordinator: coord, scriptCache: map[string]string{}, onePhaseTxnDedup: true}
 
 	conn := &recordingConn{}
 	// SET k v1 GET -- attempt 1 records resultBulk("prior").
@@ -132,6 +116,94 @@ func TestStandaloneSetDedup_GETOptionReturnsOldBulk(t *testing.T) {
 	val, _, err := decodeRedisStr(rawVal)
 	require.NoError(t, err)
 	require.Equal(t, []byte("v1"), val, "SET GET still applies the new value; dedup just preserves the GET result")
+}
+
+// TestStandaloneSetDedup_OverwritesWideHash verifies that the default-on
+// standalone SET dedup path keeps Redis overwrite semantics: a SET without
+// GET replaces a collection value with a string and tombstones the old
+// wide-column hash rows.
+func TestStandaloneSetDedup_OverwritesWideHash(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	key := []byte("k")
+	require.NoError(t, st.PutAt(ctx, store.HashFieldKey(key, []byte("f")), []byte("old"), 5, 0))
+	require.NoError(t, st.PutAt(ctx, store.HashMetaKey(key), store.MarshalHashMeta(store.HashMeta{Len: 1}), 5, 0))
+
+	coord := newDedupTestCoordinator(st, 1, true)
+	srv := &RedisServer{store: st, coordinator: coord, scriptCache: map[string]string{}, onePhaseTxnDedup: true}
+
+	conn := &recordingConn{}
+	cmd := redcon.Command{Args: [][]byte{[]byte(cmdSet), key, []byte("v1")}}
+	srv.set(conn, cmd)
+
+	require.Equal(t, "OK", string(conn.bulk))
+	require.Empty(t, conn.err)
+	require.Equal(t, 2, coord.dispatches)
+	require.Equal(t, 1, coord.probeNoOps)
+
+	readTS := snapshotTS(coord.Clock(), st)
+	rawVal, err := st.GetAt(ctx, redisStrKey(key), readTS)
+	require.NoError(t, err)
+	val, _, err := decodeRedisStr(rawVal)
+	require.NoError(t, err)
+	require.Equal(t, []byte("v1"), val)
+	_, err = st.GetAt(ctx, store.HashFieldKey(key, []byte("f")), readTS)
+	require.ErrorIs(t, err, store.ErrKeyNotFound)
+}
+
+func TestStandaloneIncrDedup_LandedPriorAttemptReturnsCachedValue(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	key := []byte("counter")
+	require.NoError(t, st.PutAt(ctx, redisStrKey(key), encodeRedisStr([]byte("1"), nil), 5, 0))
+
+	coord := newDedupTestCoordinator(st, 1, true)
+	srv := &RedisServer{store: st, coordinator: coord, scriptCache: map[string]string{}, onePhaseTxnDedup: true}
+
+	conn := &recordingConn{}
+	cmd := redcon.Command{Args: [][]byte{[]byte(cmdIncr), key}}
+	srv.incr(conn, cmd)
+
+	require.Empty(t, conn.err)
+	require.Equal(t, int64(2), conn.int)
+	require.Equal(t, 2, coord.dispatches)
+	require.Equal(t, 1, coord.probeNoOps)
+
+	rawVal, err := st.GetAt(ctx, redisStrKey(key), snapshotTS(coord.Clock(), st))
+	require.NoError(t, err)
+	val, _, err := decodeRedisStr(rawVal)
+	require.NoError(t, err)
+	require.Equal(t, []byte("2"), val)
+}
+
+func TestStandaloneHSetDedup_LandedPriorAttemptReturnsCachedAdded(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	key := []byte("hash")
+
+	coord := newDedupTestCoordinator(st, 1, true)
+	srv := &RedisServer{store: st, coordinator: coord, scriptCache: map[string]string{}, onePhaseTxnDedup: true}
+
+	conn := &recordingConn{}
+	cmd := redcon.Command{Args: [][]byte{[]byte(cmdHSet), key, []byte("f"), []byte("v")}}
+	srv.hset(conn, cmd)
+
+	require.Empty(t, conn.err)
+	require.Equal(t, int64(1), conn.int)
+	require.Equal(t, 2, coord.dispatches)
+	require.Equal(t, 1, coord.probeNoOps)
+
+	readTS := snapshotTS(coord.Clock(), st)
+	raw, err := st.GetAt(ctx, store.HashFieldKey(key, []byte("f")), readTS)
+	require.NoError(t, err)
+	require.Equal(t, []byte("v"), raw)
+	count, exists, err := srv.resolveHashMeta(ctx, key, readTS)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Equal(t, int64(1), count)
 }
 
 // TestStandaloneSetDedup_DisabledKeepsLegacyPath verifies the gate is honored

--- a/adapter/redis_set_overwrite_default_test.go
+++ b/adapter/redis_set_overwrite_default_test.go
@@ -8,24 +8,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestRedis_SET_OverwritesList_UnderDefaultGate locks in the legacy
-// SET-over-collection overwrite semantics under the new default-on dedup
-// gate landed in PR #943. The dedup path's applySet returns WRONGTYPE on
-// a SET that hits a key already holding a list/hash/set/zset/stream,
-// while the legacy setLegacy / executeSet / replaceWithStringTxn path
-// deletes the collection's logical elements and writes the string.
-// Codex flagged this as a P1 regression on PR #943 round-1: flipping
-// onePhaseTxnDedup default-on without a separate gate on the standalone
-// SET path would have changed normal Redis overwrite behaviour. The fix
-// is the standaloneSetDedup sub-gate, which defaults off — so
-// `SET k v` after `RPUSH k x` must still return OK and let the next
-// GET observe the string value, not WRONGTYPE.
+// TestRedis_SET_OverwritesList_UnderDefaultGate locks in Redis
+// SET-over-collection overwrite semantics under the default-on dedup gate.
+// `SET k v` after `RPUSH k x` must return OK and let the next GET observe
+// the string value, not WRONGTYPE.
 //
 // This is a regression test (CLAUDE.md self-review §5 + the
 // "when code review surfaces a defect, first add a failing test"
-// convention). If a future change re-enables standaloneSetDedup as
-// default-on without bringing applySet to parity with executeSet, this
-// test must fail.
+// convention). If a future change regresses applySet parity with executeSet,
+// this test must fail.
 func TestRedis_SET_OverwritesList_UnderDefaultGate(t *testing.T) {
 	t.Parallel()
 	nodes, _, _ := createNode(t, 3)
@@ -41,9 +32,7 @@ func TestRedis_SET_OverwritesList_UnderDefaultGate(t *testing.T) {
 
 	// Real Redis behaviour: SET unconditionally replaces the value,
 	// dropping the previous type. The legacy path implements this; the
-	// dedup path returns WRONGTYPE. With the default config
-	// (onePhaseTxnDedup on, standaloneSetDedup off) we must take the
-	// legacy path and observe OK + string value.
+	// default-on dedup path must preserve the legacy OK + string value shape.
 	res, err := rdb.Do(ctx, "SET", "setover:list", "replaced").Result()
 	require.NoError(t, err, "SET must overwrite an existing list under default config")
 	require.Equal(t, "OK", res)

--- a/adapter/redis_strings.go
+++ b/adapter/redis_strings.go
@@ -212,42 +212,23 @@ func (r *RedisServer) set(conn redcon.Conn, cmd redcon.Command) {
 	if r.proxyToLeader(conn, cmd, cmd.Args[1]) {
 		return
 	}
-	// Option-2 dedup for standalone SET: route through runTransactionWithDedup
-	// as a single-mop EXEC body when the gate is on. SET inside MULTI/EXEC
-	// already has full dedup coverage via applySet (§M3 in the design doc),
-	// so we just reuse that machinery instead of building a per-handler
-	// reusableSetTxn + dispatchSetReuse shape. The fast-path optimization is
-	// intentionally bypassed under the gate — dedup is opt-in, and a
-	// non-dedup'd fast path under a dedup-on cluster would split the
-	// idempotency contract.
-	//
-	// Result translation: runTransactionWithDedup returns []redisResult; for
-	// SET there is exactly one element with the same redisResult shape as
-	// the standalone reply (resultString OK / resultNil for NX/XX miss /
-	// resultBulk for GET).
-	// Both gates must be on to route standalone SET through the dedup path.
-	// onePhaseTxnDedup covers the MULTI/EXEC and list-push retries that the
-	// parent design's M4 validated; standaloneSetDedup is a separate sub-gate
-	// (default off) because applySet diverges from executeSet on SET-over-
-	// collection — flipping onePhaseTxnDedup default-on without this guard
-	// would change normal Redis overwrite behaviour (PR #943 round-1 codex P1).
-	if r.onePhaseTxnDedup && r.standaloneSetDedup {
-		// Call runTransactionWithDedup directly instead of going through
-		// runTransaction. runTransaction re-checks the same
-		// r.onePhaseTxnDedup gate and routes here anyway; the indirection
-		// would make the call chain misleading ("dispatches via
-		// runTransactionWithDedup" being true only by indirection).
-		// Direct call makes the intent explicit and removes the double
-		// gate check.
-		results, err := r.runTransactionWithDedup([]redcon.Command{cmd})
-		if err != nil {
-			writeRedisError(conn, err)
-			return
-		}
-		writeRedisStandaloneResult(conn, results)
+	if r.runStandaloneDedup(conn, cmd) {
 		return
 	}
 	r.setLegacy(conn, cmd)
+}
+
+func (r *RedisServer) runStandaloneDedup(conn redcon.Conn, cmd redcon.Command) bool {
+	if !r.onePhaseTxnDedup {
+		return false
+	}
+	results, err := r.runTransactionWithDedup([]redcon.Command{cmd})
+	if err != nil {
+		writeRedisError(conn, err)
+		return true
+	}
+	writeRedisStandaloneResult(conn, results)
+	return true
 }
 
 // setLegacy is the pre-dedup standalone SET path. Extracted from set() so

--- a/adapter/redis_ttl_compat_test.go
+++ b/adapter/redis_ttl_compat_test.go
@@ -293,6 +293,29 @@ func TestRedis_MultiExec_HSetRecreatesExpiredListAsHash(t *testing.T) {
 	require.ErrorContains(t, rdb.LRange(ctx, "multi:expired-list-hset", 0, -1).Err(), "WRONGTYPE")
 }
 
+func TestRedis_SAddRejectsExpiredHLLPayload(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.Do(ctx, "PFADD", "set:expired-hll", "a").Err())
+	require.NoError(t, rdb.PExpire(ctx, "set:expired-hll", time.Millisecond).Err())
+	require.Eventually(t, func() bool {
+		exists, err := rdb.Exists(ctx, "set:expired-hll").Result()
+		return err == nil && exists == 0
+	}, time.Second, 10*time.Millisecond)
+
+	err := rdb.SAdd(ctx, "set:expired-hll", "member").Err()
+	require.ErrorContains(t, err, "WRONGTYPE")
+	count, err := rdb.Do(ctx, "PFCOUNT", "set:expired-hll").Int64()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+}
+
 func TestRedis_MultiExec_IncrRecreatesExpiredStringWithoutTTLIndex(t *testing.T) {
 	t.Parallel()
 	nodes, _, _ := createNode(t, 3)

--- a/adapter/redis_ttl_compat_test.go
+++ b/adapter/redis_ttl_compat_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bootjp/elastickv/store"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/require"
 )
@@ -199,6 +200,40 @@ func TestRedis_MultiExec_SetThenExpireStoresReplacementTTL(t *testing.T) {
 	require.LessOrEqual(t, ttl, 30*time.Second)
 }
 
+func TestRedis_MultiExec_ExpireNXUsesStagedSetTTL(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.Do(ctx, "SET", "multi:nx-keeps-setex", "old", "EX", "100").Err())
+	require.NoError(t, rdb.Do(ctx, "MULTI").Err())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "SET", "multi:nx-keeps-setex", "new", "EX", "10").Val())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "EXPIRE", "multi:nx-keeps-setex", "20", "NX").Val())
+	execRes, err := rdb.Do(ctx, "EXEC").Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{"OK", int64(0)}, execRes)
+	ttl, err := rdb.TTL(ctx, "multi:nx-keeps-setex").Result()
+	require.NoError(t, err)
+	require.Greater(t, ttl, time.Duration(0))
+	require.LessOrEqual(t, ttl, 10*time.Second)
+
+	require.NoError(t, rdb.Do(ctx, "SET", "multi:nx-after-persistent-set", "old", "EX", "100").Err())
+	require.NoError(t, rdb.Do(ctx, "MULTI").Err())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "SET", "multi:nx-after-persistent-set", "new").Val())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "EXPIRE", "multi:nx-after-persistent-set", "20", "NX").Val())
+	execRes, err = rdb.Do(ctx, "EXEC").Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{"OK", int64(1)}, execRes)
+	ttl, err = rdb.TTL(ctx, "multi:nx-after-persistent-set").Result()
+	require.NoError(t, err)
+	require.Greater(t, ttl, time.Duration(0))
+	require.LessOrEqual(t, ttl, 20*time.Second)
+}
+
 func TestRedis_MultiExec_HSetRecreatesExpiredHash(t *testing.T) {
 	t.Parallel()
 	nodes, _, _ := createNode(t, 3)
@@ -228,6 +263,66 @@ func TestRedis_MultiExec_HSetRecreatesExpiredHash(t *testing.T) {
 	ttl, err := rdb.TTL(ctx, "multi:expired-hash").Result()
 	require.NoError(t, err)
 	require.Equal(t, time.Duration(-1), ttl)
+}
+
+func TestRedis_MultiExec_HSetRecreatesExpiredListAsHash(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.RPush(ctx, "multi:expired-list-hset", "stale").Err())
+	require.NoError(t, rdb.PExpire(ctx, "multi:expired-list-hset", time.Millisecond).Err())
+	require.Eventually(t, func() bool {
+		exists, err := rdb.Exists(ctx, "multi:expired-list-hset").Result()
+		return err == nil && exists == 0
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, rdb.Do(ctx, "MULTI").Err())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "HSET", "multi:expired-list-hset", "fresh", "new").Val())
+	execRes, err := rdb.Do(ctx, "EXEC").Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{int64(1)}, execRes)
+
+	got, err := rdb.HGetAll(ctx, "multi:expired-list-hset").Result()
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"fresh": "new"}, got)
+	require.ErrorContains(t, rdb.LRange(ctx, "multi:expired-list-hset", 0, -1).Err(), "WRONGTYPE")
+}
+
+func TestRedis_MultiExec_IncrRecreatesExpiredStringWithoutTTLIndex(t *testing.T) {
+	t.Parallel()
+	nodes, _, _ := createNode(t, 3)
+	defer shutdown(nodes)
+
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{Addr: nodes[0].redisAddress})
+	defer func() { _ = rdb.Close() }()
+
+	require.NoError(t, rdb.Do(ctx, "SET", "multi:expired-incr", "0", "PX", "1").Err())
+	require.Eventually(t, func() bool {
+		exists, err := rdb.Exists(ctx, "multi:expired-incr").Result()
+		return err == nil && exists == 0
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, rdb.Do(ctx, "MULTI").Err())
+	require.Equal(t, "QUEUED", rdb.Do(ctx, "INCR", "multi:expired-incr").Val())
+	execRes, err := rdb.Do(ctx, "EXEC").Result()
+	require.NoError(t, err)
+	require.Equal(t, []any{int64(1)}, execRes)
+	require.Equal(t, "1", rdb.Get(ctx, "multi:expired-incr").Val())
+
+	ttl, err := rdb.TTL(ctx, "multi:expired-incr").Result()
+	require.NoError(t, err)
+	require.Equal(t, time.Duration(-1), ttl)
+	require.Eventually(t, func() bool {
+		readTS := nodes[0].redisServer.readTS()
+		_, err := nodes[0].redisServer.store.GetAt(ctx, redisTTLKey([]byte("multi:expired-incr")), readTS)
+		return errors.Is(err, store.ErrKeyNotFound)
+	}, time.Second, 10*time.Millisecond)
 }
 
 // ────────────────────────────────────────────────────────────────

--- a/adapter/redis_txn.go
+++ b/adapter/redis_txn.go
@@ -106,17 +106,18 @@ type txnContext struct {
 	// inside the EXEC such as load() → readValueAt() respect the
 	// caller's deadline rather than falling back to handlerContext +
 	// the verifyLeaderEngineCtx safety net.
-	ctx         context.Context //nolint:containedctx // EXEC is a long-lived value type that wraps a single client command, ctx must travel with it.
-	working     map[string]*txnValue
-	replacers   map[string]*stringReplacement
-	listStates  map[string]*listTxnState
-	hashStates  map[string]*hashTxnState
-	zsetStates  map[string]*zsetTxnState
-	ttlStates   map[string]*ttlTxnState
-	readKeys    map[string][]byte
-	deletedKeys map[string]struct{}
-	hashDeletes map[string][]byte
-	setDeletes  map[string][]byte
+	ctx            context.Context //nolint:containedctx // EXEC is a long-lived value type that wraps a single client command, ctx must travel with it.
+	working        map[string]*txnValue
+	replacers      map[string]*stringReplacement
+	listStates     map[string]*listTxnState
+	hashStates     map[string]*hashTxnState
+	zsetStates     map[string]*zsetTxnState
+	ttlStates      map[string]*ttlTxnState
+	readKeys       map[string][]byte
+	deletedKeys    map[string]struct{}
+	logicalDeletes map[string][]byte
+	hashDeletes    map[string][]byte
+	setDeletes     map[string][]byte
 	// streamDeletions tracks user keys whose stream wide-column layout must
 	// be tombstoned on commit: the !stream|meta|<key> record plus every
 	// !stream|entry|<key><ID> row. stageKeyDeletion seeds this (MULTI/EXEC
@@ -340,19 +341,10 @@ func (t *txnContext) storeEmptyHashState(key string) *hashTxnState {
 }
 
 func (t *txnContext) loadExpiredHashAsEmpty(key []byte, keyString string) (*hashTxnState, error) {
-	ttlSt, err := t.loadTTLState(key)
-	if err != nil {
+	expired, err := t.stageExpiredKeyCleanupForRecreate(key)
+	if err != nil || !expired {
 		return nil, err
 	}
-	if ttlSt.value == nil || ttlSt.value.After(time.Now()) {
-		return nil, nil
-	}
-	ttlSt.value = nil
-	ttlSt.dirty = true
-	if t.hashDeletes == nil {
-		t.hashDeletes = map[string][]byte{}
-	}
-	t.hashDeletes[keyString] = bytes.Clone(key)
 	return t.storeEmptyHashState(keyString), nil
 }
 
@@ -659,6 +651,23 @@ func (t *txnContext) stageStringValue(key, value []byte, ttl *time.Time) error {
 	return nil
 }
 
+func (t *txnContext) stageExpiredKeyCleanupForRecreate(key []byte) (bool, error) {
+	ttlSt, err := t.loadTTLState(key)
+	if err != nil {
+		return false, err
+	}
+	if ttlSt.value == nil || hasActiveTTL(ttlSt.value, time.Now()) {
+		return false, nil
+	}
+	ttlSt.value = nil
+	ttlSt.dirty = true
+	if t.logicalDeletes == nil {
+		t.logicalDeletes = map[string][]byte{}
+	}
+	t.logicalDeletes[string(key)] = bytes.Clone(key)
+	return true, nil
+}
+
 func (t *txnContext) applyIncr(cmd redcon.Command) (redisResult, error) {
 	typ, err := t.stagedKeyType(cmd.Args[1])
 	if err != nil {
@@ -676,6 +685,11 @@ func (t *txnContext) applyIncr(cmd redcon.Command) (redisResult, error) {
 		return incrOverflowResult(), nil
 	}
 	current++
+	if typ == redisTypeNone {
+		if _, err := t.stageExpiredKeyCleanupForRecreate(cmd.Args[1]); err != nil {
+			return redisResult{}, err
+		}
+	}
 	if err := t.stageStringValue(cmd.Args[1], []byte(strconv.FormatInt(current, 10)), ttl); err != nil {
 		return redisResult{}, err
 	}
@@ -704,7 +718,7 @@ func (t *txnContext) incrBaseValue(key []byte, typ redisValueType) (int64, *time
 }
 
 func (t *txnContext) rejectNonPlainIncrString(key []byte) (redisResult, bool, error) {
-	if t.hasReplacement(key) {
+	if t.hasReplacement(key) || t.hasDirtyStagedString(key) {
 		return redisResult{}, false, nil
 	}
 	plain, err := t.server.isPlainRedisString(t.ctxOrBackground(), key, t.startTS)
@@ -715,6 +729,11 @@ func (t *txnContext) rejectNonPlainIncrString(key []byte) (redisResult, bool, er
 		return redisResult{}, false, nil
 	}
 	return integerValueErrorResult(), true, nil
+}
+
+func (t *txnContext) hasDirtyStagedString(key []byte) bool {
+	tv, ok := t.working[string(redisStrKey(key))]
+	return ok && tv.dirty && !tv.deleted && tv.raw != nil
 }
 
 func parseRedisIncrValue(raw []byte) (int64, bool) {
@@ -814,6 +833,9 @@ func (t *txnContext) applyExists(cmd redcon.Command) (redisResult, error) {
 }
 
 func (t *txnContext) applyRPush(cmd redcon.Command) (redisResult, error) {
+	if res, handled, err := t.prepareListWrite(cmd.Args[1]); err != nil || handled {
+		return res, err
+	}
 	st, err := t.loadListState(cmd.Args[1])
 	if err != nil {
 		return redisResult{}, err
@@ -837,7 +859,38 @@ func (t *txnContext) applyRPush(cmd redcon.Command) (redisResult, error) {
 	return redisResult{typ: resultInt, integer: t.listLength(st)}, nil
 }
 
+func (t *txnContext) prepareListWrite(key []byte) (redisResult, bool, error) {
+	typ, err := t.stagedKeyType(key)
+	if err != nil {
+		return redisResult{}, false, err
+	}
+	if typ != redisTypeNone && typ != redisTypeList {
+		return redisResult{typ: resultError, err: wrongTypeError()}, true, nil
+	}
+	if typ != redisTypeNone {
+		return redisResult{}, false, nil
+	}
+	expired, err := t.stageExpiredKeyCleanupForRecreate(key)
+	if err != nil {
+		return redisResult{}, false, err
+	}
+	if expired {
+		t.listStates[string(key)] = &listTxnState{appends: [][]byte{}}
+	}
+	return redisResult{}, false, nil
+}
+
 func (t *txnContext) applyLRange(cmd redcon.Command) (redisResult, error) {
+	typ, err := t.stagedKeyType(cmd.Args[1])
+	if err != nil {
+		return redisResult{}, err
+	}
+	if typ == redisTypeNone {
+		return redisResult{typ: resultArray, arr: []string{}}, nil
+	}
+	if typ != redisTypeList {
+		return redisResult{typ: resultError, err: wrongTypeError()}, nil
+	}
 	st, err := t.loadListState(cmd.Args[1])
 	if err != nil {
 		return redisResult{}, err
@@ -904,7 +957,7 @@ func (t *txnContext) applyExpire(cmd redcon.Command, unit time.Duration) (redisR
 	if err != nil {
 		return redisResult{}, err
 	}
-	if nxOnly && hasActiveTTL(state.value, time.Now()) {
+	if nxOnly && hasActiveTTL(t.effectiveTTLForExpire(cmd.Args[1], state), time.Now()) {
 		return redisResult{typ: resultInt, integer: 0}, nil
 	}
 
@@ -912,6 +965,23 @@ func (t *txnContext) applyExpire(cmd redcon.Command, unit time.Duration) (redisR
 		return t.stageKeyDeletion(cmd.Args[1])
 	}
 	return t.applyPositiveExpire(cmd.Args[1], ttl, unit, typ, state)
+}
+
+func (t *txnContext) effectiveTTLForExpire(key []byte, state *ttlTxnState) *time.Time {
+	if repl, ok := t.replacers[string(key)]; ok {
+		return cloneTimePtr(repl.ttl)
+	}
+	tv, ok := t.working[string(redisStrKey(key))]
+	if ok && !tv.deleted && tv.raw != nil {
+		if state != nil && state.dirty {
+			return cloneTimePtr(state.value)
+		}
+		return cloneTimePtr(tv.ttl)
+	}
+	if state == nil {
+		return nil
+	}
+	return cloneTimePtr(state.value)
 }
 
 func (t *txnContext) applyPositiveExpire(key []byte, ttl int64, unit time.Duration, typ redisValueType, state *ttlTxnState) (redisResult, error) {
@@ -1166,6 +1236,11 @@ func (t *txnContext) prepareDispatch() (preparedTxnDispatch, error) {
 		cancel()
 		return preparedTxnDispatch{cancel: func() {}}, err
 	}
+	logicalDeleteElems, err := t.buildLogicalDeletionElems(ctx)
+	if err != nil {
+		cancel()
+		return preparedTxnDispatch{cancel: func() {}}, err
+	}
 	hashDeleteElems, err := t.buildHashDeletionElems(ctx)
 	if err != nil {
 		cancel()
@@ -1176,8 +1251,9 @@ func (t *txnContext) prepareDispatch() (preparedTxnDispatch, error) {
 		cancel()
 		return preparedTxnDispatch{cancel: func() {}}, err
 	}
-	elems := make([]*kv.Elem[kv.OP], 0, len(replacementElems)+len(hashDeleteElems)+len(setDeleteElems))
+	elems := make([]*kv.Elem[kv.OP], 0, len(replacementElems)+len(logicalDeleteElems)+len(hashDeleteElems)+len(setDeleteElems))
 	elems = append(elems, replacementElems...)
+	elems = append(elems, logicalDeleteElems...)
 	elems = append(elems, hashDeleteElems...)
 	elems = append(elems, setDeleteElems...)
 	elems = append(elems, t.buildKeyElems()...)
@@ -1295,6 +1371,30 @@ func (t *txnContext) buildReplacementElems(ctx context.Context) ([]*kv.Elem[kv.O
 			continue
 		}
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: redisTTLKey(repl.key), Value: encodeRedisTTL(*repl.ttl)})
+	}
+	return elems, nil
+}
+
+func (t *txnContext) buildLogicalDeletionElems(ctx context.Context) ([]*kv.Elem[kv.OP], error) {
+	if len(t.logicalDeletes) == 0 {
+		return nil, nil
+	}
+	keys := make([]string, 0, len(t.logicalDeletes))
+	for k := range t.logicalDeletes {
+		if _, ok := t.replacers[k]; ok {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var elems []*kv.Elem[kv.OP]
+	for _, k := range keys {
+		next, _, err := t.server.deleteLogicalKeyElems(ctx, t.logicalDeletes[k], t.startTS)
+		if err != nil {
+			return nil, err
+		}
+		elems = append(elems, next...)
 	}
 	return elems, nil
 }
@@ -1739,6 +1839,7 @@ func (r *RedisServer) runTransaction(queue []redcon.Command) ([]redisResult, err
 			ttlStates:       map[string]*ttlTxnState{},
 			readKeys:        map[string][]byte{},
 			deletedKeys:     map[string]struct{}{},
+			logicalDeletes:  map[string][]byte{},
 			hashDeletes:     map[string][]byte{},
 			setDeletes:      map[string][]byte{},
 			streamDeletions: map[string][]byte{},
@@ -1945,6 +2046,7 @@ func (r *RedisServer) firstExecAttempt(dispatchCtx context.Context, queue []redc
 		ttlStates:       map[string]*ttlTxnState{},
 		readKeys:        map[string][]byte{},
 		deletedKeys:     map[string]struct{}{},
+		logicalDeletes:  map[string][]byte{},
 		hashDeletes:     map[string][]byte{},
 		setDeletes:      map[string][]byte{},
 		streamDeletions: map[string][]byte{},

--- a/adapter/redis_txn.go
+++ b/adapter/redis_txn.go
@@ -1551,6 +1551,7 @@ func (t *txnContext) buildWideDeletionElems(
 			return nil, err
 		}
 		elems = append(elems, next...)
+		elems = append(elems, redisTxnWideFenceElem(fenceKey(key)))
 	}
 	return elems, nil
 }
@@ -1671,6 +1672,7 @@ func appendListDeletionElems(elems []*kv.Elem[kv.OP], userKey []byte, st *listTx
 	for _, dk := range st.existingDeltas {
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: dk})
 	}
+	elems = append(elems, redisTxnWideListFenceElem(userKey))
 	return elems
 }
 
@@ -1852,7 +1854,7 @@ const hashLegacyRewriteOverhead = 2
 
 func buildHashLegacyRewriteElems(key []byte, fields map[string][]byte) []*kv.Elem[kv.OP] {
 	fieldNames := sortedHashFieldNames(fields)
-	elems := make([]*kv.Elem[kv.OP], 0, len(fieldNames)+hashLegacyRewriteOverhead)
+	elems := make([]*kv.Elem[kv.OP], 0, len(fieldNames)+hashLegacyRewriteOverhead+1)
 	for _, field := range fieldNames {
 		elems = append(elems, &kv.Elem[kv.OP]{
 			Op:    kv.Put,
@@ -1867,6 +1869,7 @@ func buildHashLegacyRewriteElems(key []byte, fields map[string][]byte) []*kv.Ele
 			Key:   store.HashMetaKey(key),
 			Value: store.MarshalHashMeta(store.HashMeta{Len: int64(len(fieldNames))}),
 		},
+		redisTxnWideHashFenceElem(key),
 	)
 	return elems
 }

--- a/adapter/redis_txn.go
+++ b/adapter/redis_txn.go
@@ -245,6 +245,13 @@ func redisTxnWideCollectionFenceElems(userKey []byte) []*kv.Elem[kv.OP] {
 	return elems
 }
 
+func redisTxnWideCreateReadKeys(userKey []byte, typ redisValueType, fenceKey func([]byte) []byte) [][]byte {
+	if typ == redisTypeNone {
+		return redisTxnWideCollectionFenceKeys(userKey)
+	}
+	return [][]byte{fenceKey(userKey)}
+}
+
 func redisTxnWideFenceElem(key []byte) *kv.Elem[kv.OP] {
 	return &kv.Elem[kv.OP]{Op: kv.Put, Key: key, Value: []byte{}}
 }

--- a/adapter/redis_txn.go
+++ b/adapter/redis_txn.go
@@ -396,7 +396,9 @@ func (t *txnContext) loadHashStateForFields(key []byte, fields [][]byte) (*hashT
 		t.hashStates = map[string]*hashTxnState{}
 	}
 	if st, ok := t.hashStates[k]; ok {
-		st = reviveDeletedHashState(st)
+		if st.deleted {
+			return reviveDeletedHashState(st), nil
+		}
 		return st, t.loadHashFieldsIntoState(key, fields, st)
 	}
 	if _, deleted := t.deletedKeys[k]; deleted {

--- a/adapter/redis_txn.go
+++ b/adapter/redis_txn.go
@@ -1922,6 +1922,9 @@ func (t *txnContext) buildTTLElems() []*kv.Elem[kv.OP] {
 			continue
 		}
 		if _, ok := t.replacers[k]; ok {
+			// A staged string replacement owns both the inline TTL and the
+			// scan-index TTL. applyPositiveExpire updates the replacement TTL
+			// directly so EXPIRE after SET is emitted by buildReplacementElems.
 			continue
 		}
 		// String keys encode TTL inside the value in buildKeyElems; skip them here.

--- a/adapter/redis_txn.go
+++ b/adapter/redis_txn.go
@@ -925,7 +925,7 @@ func incrOverflowResult() redisResult {
 
 func (t *txnContext) applyHSet(cmd redcon.Command) (redisResult, error) {
 	if len(cmd.Args[2:]) == 0 || len(cmd.Args[2:])%redisPairWidth != 0 {
-		return redisResult{}, errors.New("ERR wrong number of arguments for hash command")
+		return redisResult{typ: resultError, err: errors.New("ERR wrong number of arguments for hash command")}, nil
 	}
 	typ, err := t.stagedKeyType(cmd.Args[1])
 	if err != nil {
@@ -1276,6 +1276,7 @@ func (t *txnContext) stageCollectionStateDeletion(key []byte) error {
 		return err
 	}
 	zs.members = map[string]float64{}
+	zs.origMembers = map[string]float64{}
 	zs.exists = false
 	zs.dirty = true
 	return nil

--- a/adapter/redis_txn.go
+++ b/adapter/redis_txn.go
@@ -1070,6 +1070,7 @@ func (t *txnContext) applyLRange(cmd redcon.Command) (redisResult, error) {
 		return redisResult{}, err
 	}
 	if typ == redisTypeNone {
+		t.trackReadKey(redisTxnWideListFenceKey(cmd.Args[1]))
 		return redisResult{typ: resultArray, arr: []string{}}, nil
 	}
 	if typ != redisTypeList {

--- a/adapter/redis_txn.go
+++ b/adapter/redis_txn.go
@@ -16,6 +16,7 @@ import (
 )
 
 var redisTxnKeyPrefix = []byte("!txn|")
+var redisTxnWideFencePrefix = []byte("!txn|redis-wide|")
 
 type txnCommandHandler func(*txnContext, redcon.Command) (redisResult, error)
 
@@ -168,6 +169,46 @@ func stageListDelete(st *listTxnState) {
 	}
 	st.deleted = true
 	st.appends = nil
+}
+
+func redisTxnWideHashFenceKey(userKey []byte) []byte {
+	return redisTxnWideFenceKey([]byte("hash|"), userKey)
+}
+
+func redisTxnWideSetFenceKey(userKey []byte) []byte {
+	return redisTxnWideFenceKey([]byte("set|"), userKey)
+}
+
+func redisTxnWideFenceUserKey(key []byte) []byte {
+	for _, prefix := range [][]byte{
+		redisTxnWideFenceKey([]byte("hash|"), nil),
+		redisTxnWideFenceKey([]byte("set|"), nil),
+	} {
+		if bytes.HasPrefix(key, prefix) {
+			return key[len(prefix):]
+		}
+	}
+	return nil
+}
+
+func redisTxnWideFenceKey(kind, userKey []byte) []byte {
+	buf := make([]byte, 0, len(redisTxnWideFencePrefix)+len(kind)+len(userKey))
+	buf = append(buf, redisTxnWideFencePrefix...)
+	buf = append(buf, kind...)
+	buf = append(buf, userKey...)
+	return buf
+}
+
+func redisTxnWideHashFenceElem(userKey []byte) *kv.Elem[kv.OP] {
+	return redisTxnWideFenceElem(redisTxnWideHashFenceKey(userKey))
+}
+
+func redisTxnWideSetFenceElem(userKey []byte) *kv.Elem[kv.OP] {
+	return redisTxnWideFenceElem(redisTxnWideSetFenceKey(userKey))
+}
+
+func redisTxnWideFenceElem(key []byte) *kv.Elem[kv.OP] {
+	return &kv.Elem[kv.OP]{Op: kv.Put, Key: key, Value: []byte{}}
 }
 
 func (t *txnContext) trackReadKey(key []byte) {
@@ -452,73 +493,83 @@ func (t *txnContext) stagedKeyType(key []byte) (redisValueType, error) {
 	if _, ok := t.replacers[k]; ok {
 		return redisTypeString, nil
 	}
-	if typ, ok := t.stagedHashType(k); ok {
+	if typ, ok := t.stagedPositiveKeyType(k); ok {
 		return typ, nil
 	}
-	if typ, ok := t.stagedZSetType(k); ok {
-		return typ, nil
-	}
-	if typ, ok := t.stagedListType(k); ok {
-		return typ, nil
-	}
-	if typ, ok := t.stagedStringType(k); ok {
-		return typ, nil
-	}
-	if _, ok := t.deletedKeys[k]; ok {
+	if t.hasStagedTypeDeletion(k) {
 		return redisTypeNone, nil
 	}
 	t.trackTypeReadKeys(key)
 	return t.server.keyTypeAt(t.ctxOrBackground(), key, t.startTS)
 }
 
-func (t *txnContext) stagedHashType(key string) (redisValueType, bool) {
-	st, ok := t.hashStates[key]
-	if !ok {
-		return redisTypeNone, false
+func (t *txnContext) stagedPositiveKeyType(key string) (redisValueType, bool) {
+	if t.hasPositiveHashState(key) {
+		return redisTypeHash, true
 	}
-	if st.deleted {
-		return redisTypeNone, true
+	if t.hasPositiveZSetState(key) {
+		return redisTypeZSet, true
 	}
-	if len(st.fields) == 0 {
-		return redisTypeNone, true
-	}
-	return redisTypeHash, true
-}
-
-func (t *txnContext) stagedZSetType(key string) (redisValueType, bool) {
-	st, ok := t.zsetStates[key]
-	if !ok || (!st.dirty && !st.exists) {
-		return redisTypeNone, false
-	}
-	if len(st.members) == 0 {
-		return redisTypeNone, true
-	}
-	return redisTypeZSet, true
-}
-
-func (t *txnContext) stagedListType(key string) (redisValueType, bool) {
-	st, ok := t.listStates[key]
-	if !ok {
-		return redisTypeNone, false
-	}
-	if st.deleted {
-		return redisTypeNone, true
-	}
-	if st.metaExists || len(st.appends) > 0 {
+	if t.hasPositiveListState(key) {
 		return redisTypeList, true
+	}
+	if t.hasPositiveStringState(key) {
+		return redisTypeString, true
 	}
 	return redisTypeNone, false
 }
 
-func (t *txnContext) stagedStringType(key string) (redisValueType, bool) {
+func (t *txnContext) hasStagedTypeDeletion(key string) bool {
+	return t.hasDeletedHashState(key) ||
+		t.hasDeletedZSetState(key) ||
+		t.hasDeletedListState(key) ||
+		t.hasDeletedStringState(key) ||
+		t.isLogicallyDeleted(key)
+}
+
+func (t *txnContext) hasPositiveHashState(key string) bool {
+	st, ok := t.hashStates[key]
+	return ok && !st.deleted && len(st.fields) > 0
+}
+
+func (t *txnContext) hasPositiveZSetState(key string) bool {
+	st, ok := t.zsetStates[key]
+	return ok && len(st.members) > 0
+}
+
+func (t *txnContext) hasPositiveListState(key string) bool {
+	st, ok := t.listStates[key]
+	return ok && !st.deleted && (st.metaExists || len(st.appends) > 0)
+}
+
+func (t *txnContext) hasPositiveStringState(key string) bool {
 	tv, ok := t.working[string(redisStrKey([]byte(key)))]
-	if !ok {
-		return redisTypeNone, false
-	}
-	if tv.deleted || tv.raw == nil {
-		return redisTypeNone, true
-	}
-	return redisTypeString, true
+	return ok && !tv.deleted && tv.raw != nil
+}
+
+func (t *txnContext) hasDeletedHashState(key string) bool {
+	st, ok := t.hashStates[key]
+	return ok && (st.deleted || len(st.fields) == 0)
+}
+
+func (t *txnContext) hasDeletedZSetState(key string) bool {
+	st, ok := t.zsetStates[key]
+	return ok && (st.dirty || st.exists) && len(st.members) == 0
+}
+
+func (t *txnContext) hasDeletedListState(key string) bool {
+	st, ok := t.listStates[key]
+	return ok && st.deleted
+}
+
+func (t *txnContext) hasDeletedStringState(key string) bool {
+	tv, ok := t.working[string(redisStrKey([]byte(key)))]
+	return ok && (tv.deleted || tv.raw == nil)
+}
+
+func (t *txnContext) isLogicallyDeleted(key string) bool {
+	_, ok := t.deletedKeys[key]
+	return ok
 }
 
 func (t *txnContext) apply(cmd redcon.Command) (redisResult, error) {
@@ -1047,6 +1098,8 @@ func (t *txnContext) markLogicalDeletion(key []byte, k string) {
 	}
 	t.hashDeletes[k] = bytes.Clone(key)
 	t.setDeletes[k] = bytes.Clone(key)
+	t.trackReadKey(redisTxnWideHashFenceKey(key))
+	t.trackReadKey(redisTxnWideSetFenceKey(key))
 	if st, ok := t.hashStates[k]; ok {
 		st.deleted = true
 		st.dirty = false
@@ -1401,12 +1454,12 @@ func (t *txnContext) buildLogicalDeletionElems(ctx context.Context) ([]*kv.Elem[
 
 func (t *txnContext) buildHashDeletionElems(ctx context.Context) ([]*kv.Elem[kv.OP], error) {
 	return t.buildWideDeletionElems(ctx, t.hashDeletes,
-		store.HashFieldScanPrefix, store.HashMetaKey, store.HashMetaDeltaScanPrefix)
+		store.HashFieldScanPrefix, store.HashMetaKey, store.HashMetaDeltaScanPrefix, redisTxnWideHashFenceKey)
 }
 
 func (t *txnContext) buildSetDeletionElems(ctx context.Context) ([]*kv.Elem[kv.OP], error) {
 	return t.buildWideDeletionElems(ctx, t.setDeletes,
-		store.SetMemberScanPrefix, store.SetMetaKey, store.SetMetaDeltaScanPrefix)
+		store.SetMemberScanPrefix, store.SetMetaKey, store.SetMetaDeltaScanPrefix, redisTxnWideSetFenceKey)
 }
 
 func (t *txnContext) buildWideDeletionElems(
@@ -1415,6 +1468,7 @@ func (t *txnContext) buildWideDeletionElems(
 	fieldPrefix func([]byte) []byte,
 	metaKey func([]byte) []byte,
 	deltaPrefix func([]byte) []byte,
+	fenceKey func([]byte) []byte,
 ) ([]*kv.Elem[kv.OP], error) {
 	if len(deletes) == 0 {
 		return nil, nil
@@ -1431,6 +1485,7 @@ func (t *txnContext) buildWideDeletionElems(
 	var elems []*kv.Elem[kv.OP]
 	for _, k := range keys {
 		key := deletes[k]
+		t.trackReadKey(fenceKey(key))
 		next, err := t.server.deleteWideColumnElems(ctx, t.startTS,
 			fieldPrefix(key), metaKey(key), deltaPrefix(key))
 		if err != nil {
@@ -1718,11 +1773,14 @@ func appendHashChangedFieldElems(elems []*kv.Elem[kv.OP], key []byte, st *hashTx
 
 func appendHashDeltaElem(elems []*kv.Elem[kv.OP], key []byte, newFields int64, commitTS uint64, seqInTxn uint32) []*kv.Elem[kv.OP] {
 	deltaVal := store.MarshalHashMetaDelta(store.HashMetaDelta{LenDelta: newFields})
-	return append(elems, &kv.Elem[kv.OP]{
-		Op:    kv.Put,
-		Key:   store.HashMetaDeltaKey(key, commitTS, seqInTxn),
-		Value: deltaVal,
-	})
+	return append(elems,
+		redisTxnWideHashFenceElem(key),
+		&kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.HashMetaDeltaKey(key, commitTS, seqInTxn),
+			Value: deltaVal,
+		},
+	)
 }
 
 const hashLegacyRewriteOverhead = 2

--- a/adapter/redis_txn.go
+++ b/adapter/redis_txn.go
@@ -142,11 +142,12 @@ type listTxnState struct {
 }
 
 type hashTxnState struct {
-	fields     map[string][]byte
-	origFields map[string][]byte
-	legacy     bool
-	deleted    bool
-	dirty      bool
+	fields      map[string][]byte
+	origFields  map[string][]byte
+	dirtyFields map[string]struct{}
+	legacy      bool
+	deleted     bool
+	dirty       bool
 }
 
 type zsetTxnState struct {
@@ -389,13 +390,14 @@ func (t *txnContext) loadListState(key []byte) (*listTxnState, error) {
 	return st, nil
 }
 
-func (t *txnContext) loadHashState(key []byte) (*hashTxnState, error) {
+func (t *txnContext) loadHashStateForFields(key []byte, fields [][]byte) (*hashTxnState, error) {
 	k := string(key)
 	if t.hashStates == nil {
 		t.hashStates = map[string]*hashTxnState{}
 	}
 	if st, ok := t.hashStates[k]; ok {
-		return reviveDeletedHashState(st), nil
+		st = reviveDeletedHashState(st)
+		return st, t.loadHashFieldsIntoState(key, fields, st)
 	}
 	if _, deleted := t.deletedKeys[k]; deleted {
 		return t.storeEmptyHashState(k), nil
@@ -403,13 +405,17 @@ func (t *txnContext) loadHashState(key []byte) (*hashTxnState, error) {
 	if st, err := t.loadExpiredHashAsEmpty(key, k); err != nil || st != nil {
 		return st, err
 	}
-	return t.loadExistingHashState(key, k)
+	if len(fields) == 0 {
+		return t.loadExistingHashState(key, k)
+	}
+	return t.loadExistingHashFieldState(key, k, fields)
 }
 
 func reviveDeletedHashState(st *hashTxnState) *hashTxnState {
 	if st.deleted {
 		st.fields = map[string][]byte{}
 		st.origFields = map[string][]byte{}
+		st.dirtyFields = map[string]struct{}{}
 		st.legacy = false
 		st.deleted = false
 		st.dirty = true
@@ -419,9 +425,10 @@ func reviveDeletedHashState(st *hashTxnState) *hashTxnState {
 
 func (t *txnContext) storeEmptyHashState(key string) *hashTxnState {
 	st := &hashTxnState{
-		fields:     map[string][]byte{},
-		origFields: map[string][]byte{},
-		dirty:      true,
+		fields:      map[string][]byte{},
+		origFields:  map[string][]byte{},
+		dirtyFields: map[string]struct{}{},
+		dirty:       true,
 	}
 	t.hashStates[key] = st
 	return st
@@ -454,12 +461,67 @@ func (t *txnContext) loadExistingHashState(key []byte, keyString string) (*hashT
 		return nil, errors.WithStack(err)
 	}
 	st := &hashTxnState{
-		fields:     fields,
-		origFields: origFields,
-		legacy:     legacy,
+		fields:      fields,
+		origFields:  origFields,
+		dirtyFields: map[string]struct{}{},
+		legacy:      legacy,
 	}
 	t.hashStates[keyString] = st
 	return st, nil
+}
+
+func (t *txnContext) loadExistingHashFieldState(key []byte, keyString string, fields [][]byte) (*hashTxnState, error) {
+	ctx := t.ctxOrBackground()
+	t.trackReadKey(redisTxnWideHashFenceKey(key))
+	wide, err := t.server.prefixExistsAt(ctx, store.HashFieldScanPrefix(key), t.startTS)
+	if err != nil {
+		return nil, err
+	}
+	if !wide {
+		legacy, err := t.server.store.ExistsAt(ctx, redisHashKey(key), t.startTS)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		if legacy {
+			return t.loadExistingHashState(key, keyString)
+		}
+	}
+	st := &hashTxnState{
+		fields:      map[string][]byte{},
+		origFields:  map[string][]byte{},
+		dirtyFields: map[string]struct{}{},
+	}
+	t.hashStates[keyString] = st
+	if err := t.loadHashFieldsIntoState(key, fields, st); err != nil {
+		return nil, err
+	}
+	return st, nil
+}
+
+func (t *txnContext) loadHashFieldsIntoState(key []byte, fields [][]byte, st *hashTxnState) error {
+	if st.legacy {
+		return nil
+	}
+	ctx := t.ctxOrBackground()
+	for _, field := range fields {
+		fieldName := string(field)
+		if _, loaded := st.origFields[fieldName]; loaded {
+			continue
+		}
+		if _, staged := st.fields[fieldName]; staged {
+			continue
+		}
+		raw, err := t.server.store.GetAt(ctx, store.HashFieldKey(key, field), t.startTS)
+		if err != nil {
+			if errors.Is(err, store.ErrKeyNotFound) {
+				continue
+			}
+			return errors.WithStack(err)
+		}
+		st.fields[fieldName] = bytes.Clone(raw)
+		st.origFields[fieldName] = bytes.Clone(raw)
+	}
+	return nil
 }
 
 func (t *txnContext) listLength(st *listTxnState) int64 {
@@ -868,7 +930,8 @@ func (t *txnContext) applyHSet(cmd redcon.Command) (redisResult, error) {
 		return redisResult{typ: resultError, err: wrongTypeError()}, nil
 	}
 	t.trackMissingKeyCreatorFenceReads(cmd.Args[1], typ)
-	st, err := t.loadHashState(cmd.Args[1])
+	fields := hashCommandFields(cmd.Args[2:])
+	st, err := t.loadHashStateForFields(cmd.Args[1], fields)
 	if err != nil {
 		return redisResult{}, err
 	}
@@ -879,6 +942,7 @@ func (t *txnContext) applyHSet(cmd redcon.Command) (redisResult, error) {
 			added++
 		}
 		st.fields[field] = bytes.Clone(cmd.Args[i+1])
+		st.dirtyFields[field] = struct{}{}
 	}
 	st.deleted = false
 	st.dirty = true
@@ -887,6 +951,14 @@ func (t *txnContext) applyHSet(cmd redcon.Command) (redisResult, error) {
 		return redisResult{typ: resultString, str: "OK"}, nil
 	}
 	return redisResult{typ: resultInt, integer: added}, nil
+}
+
+func hashCommandFields(args [][]byte) [][]byte {
+	fields := make([][]byte, 0, len(args)/redisPairWidth)
+	for i := 0; i < len(args); i += redisPairWidth {
+		fields = append(fields, args[i])
+	}
+	return fields
 }
 
 func (t *txnContext) applyDel(cmd redcon.Command) (redisResult, error) {
@@ -1827,12 +1899,9 @@ func (t *txnContext) appendHashStateElems(elems []*kv.Elem[kv.OP], key []byte, s
 
 func appendHashChangedFieldElems(elems []*kv.Elem[kv.OP], key []byte, st *hashTxnState) ([]*kv.Elem[kv.OP], int64) {
 	var newFields int64
-	for _, field := range sortedHashFieldNames(st.fields) {
+	for _, field := range sortedHashDirtyFieldNames(st.dirtyFields) {
 		value := st.fields[field]
-		old, existed := st.origFields[field]
-		if existed && bytes.Equal(old, value) {
-			continue
-		}
+		_, existed := st.origFields[field]
 		if !existed {
 			newFields++
 		}
@@ -1882,6 +1951,15 @@ func buildHashLegacyRewriteElems(key []byte, fields map[string][]byte) []*kv.Ele
 }
 
 func sortedHashFieldNames(fields map[string][]byte) []string {
+	names := make([]string, 0, len(fields))
+	for field := range fields {
+		names = append(names, field)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func sortedHashDirtyFieldNames(fields map[string]struct{}) []string {
 	names := make([]string, 0, len(fields))
 	for field := range fields {
 		names = append(names, field)

--- a/adapter/redis_txn.go
+++ b/adapter/redis_txn.go
@@ -16,7 +16,9 @@ import (
 )
 
 var redisTxnKeyPrefix = []byte("!txn|")
-var redisTxnWideFencePrefix = []byte("!txn|redis-wide|")
+var redisTxnWideHashFencePrefix = []byte("!redis|txn-wide-hash|")
+var redisTxnWideSetFencePrefix = []byte("!redis|txn-wide-set|")
+var redisTxnWideListFencePrefix = []byte("!redis|txn-wide-list|")
 
 type txnCommandHandler func(*txnContext, redcon.Command) (redisResult, error)
 
@@ -172,17 +174,22 @@ func stageListDelete(st *listTxnState) {
 }
 
 func redisTxnWideHashFenceKey(userKey []byte) []byte {
-	return redisTxnWideFenceKey([]byte("hash|"), userKey)
+	return redisTxnWideFenceKey(redisTxnWideHashFencePrefix, userKey)
 }
 
 func redisTxnWideSetFenceKey(userKey []byte) []byte {
-	return redisTxnWideFenceKey([]byte("set|"), userKey)
+	return redisTxnWideFenceKey(redisTxnWideSetFencePrefix, userKey)
+}
+
+func redisTxnWideListFenceKey(userKey []byte) []byte {
+	return redisTxnWideFenceKey(redisTxnWideListFencePrefix, userKey)
 }
 
 func redisTxnWideFenceUserKey(key []byte) []byte {
 	for _, prefix := range [][]byte{
-		redisTxnWideFenceKey([]byte("hash|"), nil),
-		redisTxnWideFenceKey([]byte("set|"), nil),
+		redisTxnWideHashFencePrefix,
+		redisTxnWideSetFencePrefix,
+		redisTxnWideListFencePrefix,
 	} {
 		if bytes.HasPrefix(key, prefix) {
 			return key[len(prefix):]
@@ -191,10 +198,9 @@ func redisTxnWideFenceUserKey(key []byte) []byte {
 	return nil
 }
 
-func redisTxnWideFenceKey(kind, userKey []byte) []byte {
-	buf := make([]byte, 0, len(redisTxnWideFencePrefix)+len(kind)+len(userKey))
-	buf = append(buf, redisTxnWideFencePrefix...)
-	buf = append(buf, kind...)
+func redisTxnWideFenceKey(prefix, userKey []byte) []byte {
+	buf := make([]byte, 0, len(prefix)+len(userKey))
+	buf = append(buf, prefix...)
 	buf = append(buf, userKey...)
 	return buf
 }
@@ -205,6 +211,10 @@ func redisTxnWideHashFenceElem(userKey []byte) *kv.Elem[kv.OP] {
 
 func redisTxnWideSetFenceElem(userKey []byte) *kv.Elem[kv.OP] {
 	return redisTxnWideFenceElem(redisTxnWideSetFenceKey(userKey))
+}
+
+func redisTxnWideListFenceElem(userKey []byte) *kv.Elem[kv.OP] {
+	return redisTxnWideFenceElem(redisTxnWideListFenceKey(userKey))
 }
 
 func redisTxnWideFenceElem(key []byte) *kv.Elem[kv.OP] {
@@ -716,6 +726,7 @@ func (t *txnContext) stageExpiredKeyCleanupForRecreate(key []byte) (bool, error)
 		t.logicalDeletes = map[string][]byte{}
 	}
 	t.logicalDeletes[string(key)] = bytes.Clone(key)
+	t.trackWideCollectionFenceReads(key)
 	return true, nil
 }
 
@@ -1098,12 +1109,17 @@ func (t *txnContext) markLogicalDeletion(key []byte, k string) {
 	}
 	t.hashDeletes[k] = bytes.Clone(key)
 	t.setDeletes[k] = bytes.Clone(key)
-	t.trackReadKey(redisTxnWideHashFenceKey(key))
-	t.trackReadKey(redisTxnWideSetFenceKey(key))
+	t.trackWideCollectionFenceReads(key)
 	if st, ok := t.hashStates[k]; ok {
 		st.deleted = true
 		st.dirty = false
 	}
+}
+
+func (t *txnContext) trackWideCollectionFenceReads(key []byte) {
+	t.trackReadKey(redisTxnWideHashFenceKey(key))
+	t.trackReadKey(redisTxnWideSetFenceKey(key))
+	t.trackReadKey(redisTxnWideListFenceKey(key))
 }
 
 func (t *txnContext) stageCollectionStateDeletion(key []byte) error {
@@ -1409,6 +1425,7 @@ func (t *txnContext) buildReplacementElems(ctx context.Context) ([]*kv.Elem[kv.O
 	var elems []*kv.Elem[kv.OP]
 	for _, k := range keys {
 		repl := t.replacers[k]
+		t.trackWideCollectionFenceReads(repl.key)
 		deleteElems, _, err := t.server.deleteLogicalKeyElems(ctx, repl.key, t.startTS)
 		if err != nil {
 			return nil, err
@@ -1629,11 +1646,14 @@ func appendListAppendElems(elems []*kv.Elem[kv.OP], userKey []byte, st *listTxnS
 
 func appendListDeltaElem(elems []*kv.Elem[kv.OP], userKey []byte, st *listTxnState, commitTS uint64, seqInTxn uint32) []*kv.Elem[kv.OP] {
 	deltaVal := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: 0, LenDelta: int64(len(st.appends))})
-	return append(elems, &kv.Elem[kv.OP]{
-		Op:    kv.Put,
-		Key:   store.ListMetaDeltaKey(userKey, commitTS, seqInTxn),
-		Value: deltaVal,
-	})
+	return append(elems,
+		redisTxnWideListFenceElem(userKey),
+		&kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.ListMetaDeltaKey(userKey, commitTS, seqInTxn),
+			Value: deltaVal,
+		},
+	)
 }
 
 func (t *txnContext) buildZSetElems(commitTS uint64) ([]*kv.Elem[kv.OP], error) {

--- a/adapter/redis_txn.go
+++ b/adapter/redis_txn.go
@@ -24,6 +24,9 @@ var txnApplyHandlers = map[string]txnCommandHandler{
 	cmdDel:     (*txnContext).applyDel,
 	cmdGet:     (*txnContext).applyGet,
 	cmdExists:  (*txnContext).applyExists,
+	cmdIncr:    (*txnContext).applyIncr,
+	cmdHSet:    (*txnContext).applyHSet,
+	cmdHMSet:   (*txnContext).applyHSet,
 	cmdRPush:   (*txnContext).applyRPush,
 	cmdLRange:  (*txnContext).applyLRange,
 	cmdZIncrBy: (*txnContext).applyZIncrBy,
@@ -90,6 +93,12 @@ type txnValue struct {
 	loaded  bool
 }
 
+type stringReplacement struct {
+	key   []byte
+	value []byte
+	ttl   *time.Time
+}
+
 type txnContext struct {
 	server *RedisServer
 	// ctx is the per-EXEC dispatch context (redisDispatchTimeout-bounded
@@ -97,12 +106,17 @@ type txnContext struct {
 	// inside the EXEC such as load() → readValueAt() respect the
 	// caller's deadline rather than falling back to handlerContext +
 	// the verifyLeaderEngineCtx safety net.
-	ctx        context.Context //nolint:containedctx // EXEC is a long-lived value type that wraps a single client command, ctx must travel with it.
-	working    map[string]*txnValue
-	listStates map[string]*listTxnState
-	zsetStates map[string]*zsetTxnState
-	ttlStates  map[string]*ttlTxnState
-	readKeys   map[string][]byte
+	ctx         context.Context //nolint:containedctx // EXEC is a long-lived value type that wraps a single client command, ctx must travel with it.
+	working     map[string]*txnValue
+	replacers   map[string]*stringReplacement
+	listStates  map[string]*listTxnState
+	hashStates  map[string]*hashTxnState
+	zsetStates  map[string]*zsetTxnState
+	ttlStates   map[string]*ttlTxnState
+	readKeys    map[string][]byte
+	deletedKeys map[string]struct{}
+	hashDeletes map[string][]byte
+	setDeletes  map[string][]byte
 	// streamDeletions tracks user keys whose stream wide-column layout must
 	// be tombstoned on commit: the !stream|meta|<key> record plus every
 	// !stream|entry|<key><ID> row. stageKeyDeletion seeds this (MULTI/EXEC
@@ -120,6 +134,14 @@ type listTxnState struct {
 	purge          bool
 	purgeMeta      store.ListMeta
 	existingDeltas [][]byte // delta key bytes present at load time; deleted on purge/delete
+}
+
+type hashTxnState struct {
+	fields     map[string][]byte
+	origFields map[string][]byte
+	legacy     bool
+	deleted    bool
+	dirty      bool
 }
 
 type zsetTxnState struct {
@@ -279,6 +301,56 @@ func (t *txnContext) loadListState(key []byte) (*listTxnState, error) {
 	return st, nil
 }
 
+func (t *txnContext) loadHashState(key []byte) (*hashTxnState, error) {
+	k := string(key)
+	if t.hashStates == nil {
+		t.hashStates = map[string]*hashTxnState{}
+	}
+	if st, ok := t.hashStates[k]; ok {
+		if st.deleted {
+			st.fields = map[string][]byte{}
+			st.origFields = map[string][]byte{}
+			st.legacy = false
+			st.deleted = false
+			st.dirty = true
+		}
+		return st, nil
+	}
+	if _, deleted := t.deletedKeys[k]; deleted {
+		st := &hashTxnState{
+			fields:     map[string][]byte{},
+			origFields: map[string][]byte{},
+			dirty:      true,
+		}
+		t.hashStates[k] = st
+		return st, nil
+	}
+
+	ctx := t.ctxOrBackground()
+	value, err := t.server.loadHashAt(ctx, key, t.startTS)
+	if err != nil {
+		return nil, err
+	}
+	fields := make(map[string][]byte, len(value))
+	origFields := make(map[string][]byte, len(value))
+	for field, value := range value {
+		raw := []byte(value)
+		fields[field] = bytes.Clone(raw)
+		origFields[field] = bytes.Clone(raw)
+	}
+	legacy, err := t.server.store.ExistsAt(ctx, redisHashKey(key), t.startTS)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	st := &hashTxnState{
+		fields:     fields,
+		origFields: origFields,
+		legacy:     legacy,
+	}
+	t.hashStates[k] = st
+	return st, nil
+}
+
 func (t *txnContext) listLength(st *listTxnState) int64 {
 	return st.meta.Len + int64(len(st.appends))
 }
@@ -354,6 +426,12 @@ func (t *txnContext) loadTTLState(key []byte) (*ttlTxnState, error) {
 
 func (t *txnContext) stagedKeyType(key []byte) (redisValueType, error) {
 	k := string(key)
+	if _, ok := t.replacers[k]; ok {
+		return redisTypeString, nil
+	}
+	if typ, ok := t.stagedHashType(k); ok {
+		return typ, nil
+	}
 	if typ, ok := t.stagedZSetType(k); ok {
 		return typ, nil
 	}
@@ -363,8 +441,25 @@ func (t *txnContext) stagedKeyType(key []byte) (redisValueType, error) {
 	if typ, ok := t.stagedStringType(k); ok {
 		return typ, nil
 	}
+	if _, ok := t.deletedKeys[k]; ok {
+		return redisTypeNone, nil
+	}
 	t.trackTypeReadKeys(key)
 	return t.server.keyTypeAt(t.ctxOrBackground(), key, t.startTS)
+}
+
+func (t *txnContext) stagedHashType(key string) (redisValueType, bool) {
+	st, ok := t.hashStates[key]
+	if !ok {
+		return redisTypeNone, false
+	}
+	if st.deleted {
+		return redisTypeNone, true
+	}
+	if len(st.fields) == 0 {
+		return redisTypeNone, true
+	}
+	return redisTypeHash, true
 }
 
 func (t *txnContext) stagedZSetType(key string) (redisValueType, bool) {
@@ -420,77 +515,44 @@ func (t *txnContext) applyExpireMilliseconds(cmd redcon.Command) (redisResult, e
 }
 
 func (t *txnContext) applySet(cmd redcon.Command) (redisResult, error) {
-	if isList, err := t.server.isListKeyAt(t.ctxOrBackground(), cmd.Args[1], t.startTS); err != nil {
-		return redisResult{}, err
-	} else if isList {
-		return redisResult{typ: resultError, err: errors.New("WRONGTYPE Operation against a key holding the wrong kind of value")}, nil
-	}
-
 	opts, err := parseRedisSetOptions(cmd.Args[3:], time.Now())
+	if err != nil {
+		return redisResult{}, err
+	}
+	typ, err := t.stagedKeyType(cmd.Args[1])
 	if err != nil {
 		return redisResult{}, err
 	}
 
 	// NX/XX: skip the write if the key-existence condition is not met.
-	blocked, res, err := t.applySetCondition(cmd.Args[1], opts)
+	exists := typ != redisTypeNone
+	if !opts.allows(exists) {
+		return redisResult{typ: resultNil}, nil
+	}
+	if opts.returnOld && exists && typ != redisTypeString {
+		return redisResult{typ: resultError, err: wrongTypeError()}, nil
+	}
+
+	oldValue, err := t.oldStringValueForSet(cmd.Args[1], opts.returnOld, typ)
 	if err != nil {
 		return redisResult{}, err
 	}
-	if blocked {
-		return res, nil
-	}
-
-	tv, err := t.load(cmd.Args[1])
-	if err != nil {
-		return redisResult{}, err
-	}
-
-	var oldValue []byte
-	if opts.returnOld && !tv.deleted {
-		oldValue = tv.raw
-	}
-
-	tv.raw = cmd.Args[2]
-	tv.deleted = false
-	tv.dirty = true
-
-	// Always update TTL state: EX/PX sets a new expiry; a plain SET clears it
-	// (opts.ttl == nil → nil stored → PERSIST semantics, matching Redis behaviour).
-	if err := t.applySetTTL(cmd.Args[1], opts.ttl); err != nil {
-		return redisResult{}, err
-	}
-
+	t.stageStringReplacement(cmd.Args[1], cmd.Args[2], opts.ttl)
 	return applySetResult(opts, oldValue), nil
 }
 
-// applySetCondition checks NX/XX conditions.  Returns (blocked, result, err).
-// blocked=true means the condition prevented the write; callers should return result.
-// Returns (false, _, nil) immediately when no condition is set.
-func (t *txnContext) applySetCondition(key []byte, opts redisSetOptions) (bool, redisResult, error) {
-	if !opts.existsCond && !opts.missingCond {
-		return false, redisResult{}, nil
+func (t *txnContext) oldStringValueForSet(key []byte, returnOld bool, typ redisValueType) ([]byte, error) {
+	if !returnOld || typ != redisTypeString {
+		return nil, nil
 	}
-	typ, err := t.stagedKeyType(key)
+	raw, _, ok, err := t.currentStringValue(key)
 	if err != nil {
-		return false, redisResult{}, err
+		return nil, err
 	}
-	exists := typ != redisTypeNone
-	if (opts.missingCond && exists) || (opts.existsCond && !exists) {
-		return true, redisResult{typ: resultNil}, nil
+	if !ok {
+		return nil, nil
 	}
-	return false, redisResult{}, nil
-}
-
-// applySetTTL stores the expiry in ttlStates so flushTTLToBuffer sends it to
-// the TTLBuffer after a successful commit.
-func (t *txnContext) applySetTTL(key []byte, expireAt *time.Time) error {
-	ttlSt, err := t.loadTTLState(key)
-	if err != nil {
-		return err
-	}
-	ttlSt.value = expireAt
-	ttlSt.dirty = true
-	return nil
+	return raw, nil
 }
 
 // applySetResult returns the appropriate redisResult for a completed SET.
@@ -502,6 +564,122 @@ func applySetResult(opts redisSetOptions, oldValue []byte) redisResult {
 		return redisResult{typ: resultNil}
 	}
 	return redisResult{typ: resultBulk, bulk: oldValue}
+}
+
+func cloneTimePtr(in *time.Time) *time.Time {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}
+
+func (t *txnContext) stageStringReplacement(key, value []byte, ttl *time.Time) {
+	if t.replacers == nil {
+		t.replacers = map[string]*stringReplacement{}
+	}
+	k := string(key)
+	t.replacers[k] = &stringReplacement{
+		key:   bytes.Clone(key),
+		value: bytes.Clone(value),
+		ttl:   cloneTimePtr(ttl),
+	}
+	delete(t.deletedKeys, k)
+}
+
+func (t *txnContext) currentStringValue(key []byte) ([]byte, *time.Time, bool, error) {
+	if repl, ok := t.replacers[string(key)]; ok {
+		return bytes.Clone(repl.value), cloneTimePtr(repl.ttl), true, nil
+	}
+	tv, err := t.load(key)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if tv.deleted || tv.raw == nil {
+		return nil, nil, false, nil
+	}
+	return bytes.Clone(tv.raw), cloneTimePtr(tv.ttl), true, nil
+}
+
+func (t *txnContext) stageStringValue(key, value []byte, ttl *time.Time) error {
+	if repl, ok := t.replacers[string(key)]; ok {
+		repl.value = bytes.Clone(value)
+		repl.ttl = cloneTimePtr(ttl)
+		return nil
+	}
+	tv, err := t.load(key)
+	if err != nil {
+		return err
+	}
+	tv.raw = bytes.Clone(value)
+	tv.ttl = cloneTimePtr(ttl)
+	tv.deleted = false
+	tv.dirty = true
+	delete(t.deletedKeys, string(key))
+	return nil
+}
+
+func (t *txnContext) applyIncr(cmd redcon.Command) (redisResult, error) {
+	typ, err := t.stagedKeyType(cmd.Args[1])
+	if err != nil {
+		return redisResult{}, err
+	}
+	if typ != redisTypeNone && typ != redisTypeString {
+		return redisResult{typ: resultError, err: wrongTypeError()}, nil
+	}
+
+	var current int64
+	var ttl *time.Time
+	if typ == redisTypeString {
+		raw, existingTTL, ok, err := t.currentStringValue(cmd.Args[1])
+		if err != nil {
+			return redisResult{}, err
+		}
+		ttl = existingTTL
+		if ok {
+			current, err = strconv.ParseInt(string(raw), 10, 64)
+			if err != nil {
+				return redisResult{}, errors.New("ERR value is not an integer or out of range")
+			}
+		}
+	}
+	current++
+	if err := t.stageStringValue(cmd.Args[1], []byte(strconv.FormatInt(current, 10)), ttl); err != nil {
+		return redisResult{}, err
+	}
+	return redisResult{typ: resultInt, integer: current}, nil
+}
+
+func (t *txnContext) applyHSet(cmd redcon.Command) (redisResult, error) {
+	if len(cmd.Args[2:]) == 0 || len(cmd.Args[2:])%redisPairWidth != 0 {
+		return redisResult{}, errors.New("ERR wrong number of arguments for hash command")
+	}
+	typ, err := t.stagedKeyType(cmd.Args[1])
+	if err != nil {
+		return redisResult{}, err
+	}
+	if typ != redisTypeNone && typ != redisTypeHash {
+		return redisResult{typ: resultError, err: wrongTypeError()}, nil
+	}
+	st, err := t.loadHashState(cmd.Args[1])
+	if err != nil {
+		return redisResult{}, err
+	}
+	added := int64(0)
+	for i := 2; i < len(cmd.Args); i += redisPairWidth {
+		field := string(cmd.Args[i])
+		if _, exists := st.fields[field]; !exists {
+			added++
+		}
+		st.fields[field] = bytes.Clone(cmd.Args[i+1])
+	}
+	st.deleted = false
+	st.dirty = true
+	delete(t.deletedKeys, string(cmd.Args[1]))
+	if strings.EqualFold(string(cmd.Args[0]), cmdHMSet) {
+		return redisResult{typ: resultString, str: "OK"}, nil
+	}
+	return redisResult{typ: resultInt, integer: added}, nil
 }
 
 func (t *txnContext) applyDel(cmd redcon.Command) (redisResult, error) {
@@ -689,23 +867,57 @@ func (t *txnContext) markStringDirty(key []byte) (redisResult, error) {
 }
 
 func (t *txnContext) stageKeyDeletion(key []byte) (redisResult, error) {
+	k := string(key)
+	t.markLogicalDeletion(key, k)
+	if err := t.stageCollectionStateDeletion(key); err != nil {
+		return redisResult{}, err
+	}
+	if err := t.stageLegacyInternalDeletion(key); err != nil {
+		return redisResult{}, err
+	}
+	t.stageStreamWideDeletion(key, k)
+	t.stageBareStringDeletion(key, k)
+	return redisResult{typ: resultInt, integer: 1}, nil
+}
+
+func (t *txnContext) markLogicalDeletion(key []byte, k string) {
+	if t.deletedKeys == nil {
+		t.deletedKeys = map[string]struct{}{}
+	}
+	t.deletedKeys[k] = struct{}{}
+	delete(t.replacers, k)
+	if t.hashDeletes == nil {
+		t.hashDeletes = map[string][]byte{}
+	}
+	if t.setDeletes == nil {
+		t.setDeletes = map[string][]byte{}
+	}
+	t.hashDeletes[k] = bytes.Clone(key)
+	t.setDeletes[k] = bytes.Clone(key)
+	if st, ok := t.hashStates[k]; ok {
+		st.deleted = true
+		st.dirty = false
+	}
+}
+
+func (t *txnContext) stageCollectionStateDeletion(key []byte) error {
 	// Mark the list for deletion.
 	st, err := t.loadListState(key)
 	if err != nil {
-		return redisResult{}, err
+		return err
 	}
 	stageListDelete(st)
 	// Mark the string/main value for deletion.
 	tv, err := t.load(key)
 	if err != nil {
-		return redisResult{}, err
+		return err
 	}
 	tv.deleted = true
 	tv.dirty = true
 	// Mark TTL for deletion.
 	ttlState, err := t.loadTTLState(key)
 	if err != nil {
-		return redisResult{}, err
+		return err
 	}
 	ttlState.value = nil
 	ttlState.dirty = true
@@ -713,11 +925,15 @@ func (t *txnContext) stageKeyDeletion(key []byte) (redisResult, error) {
 	// writes (e.g. ZINCRBY) in the same transaction can safely insert.
 	zs, err := t.loadZSetState(key)
 	if err != nil {
-		return redisResult{}, err
+		return err
 	}
 	zs.members = map[string]float64{}
 	zs.exists = false
 	zs.dirty = true
+	return nil
+}
+
+func (t *txnContext) stageLegacyInternalDeletion(key []byte) error {
 	// Mark hash, set, stream (legacy blob), and HLL internal keys for deletion.
 	for _, internalKey := range [][]byte{
 		redisHashKey(key),
@@ -727,11 +943,15 @@ func (t *txnContext) stageKeyDeletion(key []byte) (redisResult, error) {
 	} {
 		iv, err := t.load(internalKey)
 		if err != nil {
-			return redisResult{}, err
+			return err
 		}
 		iv.deleted = true
 		iv.dirty = true
 	}
+	return nil
+}
+
+func (t *txnContext) stageStreamWideDeletion(key []byte, k string) {
 	// Stage the wide-column stream cleanup: the !stream|meta| record and
 	// every !stream|entry| row must also be tombstoned when the user deletes
 	// a migrated stream via MULTI/EXEC DEL or EXPIRE 0. Without this step
@@ -743,19 +963,20 @@ func (t *txnContext) stageKeyDeletion(key []byte) (redisResult, error) {
 	if t.streamDeletions == nil {
 		t.streamDeletions = map[string][]byte{}
 	}
-	t.streamDeletions[string(key)] = bytes.Clone(key)
+	t.streamDeletions[k] = bytes.Clone(key)
 	t.trackReadKey(store.StreamMetaKey(key))
+}
+
+func (t *txnContext) stageBareStringDeletion(key []byte, k string) {
 	// Mark legacy bare string key for deletion. We bypass load() here
 	// because load() auto-prefixes bare keys to !redis|str|.
 	// Track the bare key in the read set for conflict detection.
 	t.trackReadKey(key)
-	bareK := string(key)
-	if _, ok := t.working[bareK]; !ok {
-		t.working[bareK] = &txnValue{}
+	if _, ok := t.working[k]; !ok {
+		t.working[k] = &txnValue{}
 	}
-	t.working[bareK].deleted = true
-	t.working[bareK].dirty = true
-	return redisResult{typ: resultInt, integer: 1}, nil
+	t.working[k].deleted = true
+	t.working[k].dirty = true
 }
 
 func parseRangeBounds(startRaw, endRaw []byte, total int) (int, int, error) {
@@ -835,23 +1056,12 @@ type preparedTxnDispatch struct {
 // a prepared value with empty `elems` and a no-op cancel — callers can
 // check len(prepared.elems)==0 and skip the dispatch.
 func (t *txnContext) prepareDispatch() (preparedTxnDispatch, error) {
-	elems := t.buildKeyElems()
-
 	// Pre-allocate commitTS so Delta keys can embed it in their bytes before
 	// the coordinator assigns it during Dispatch.
 	commitTS, err := t.server.coordinator.Clock().NextFenced()
 	if err != nil {
 		return preparedTxnDispatch{cancel: func() {}}, errors.Wrap(err, "redis txn commit: allocate commitTS")
 	}
-	listElems := t.buildListElems(commitTS)
-	zsetElems, err := t.buildZSetElems(commitTS)
-	if err != nil {
-		return preparedTxnDispatch{cancel: func() {}}, err
-	}
-	// TTL elements: string keys have TTL embedded in value (buildKeyElems handles that),
-	// non-string keys get a !redis|ttl| element written in the same transaction.
-	ttlElems := t.buildTTLElems()
-
 	// Derive a single redisDispatchTimeout-bounded context covering both
 	// the stream-deletion scans (paginated ScanAt/ExistsAt over
 	// StreamEntryScanPrefix) and the final Dispatch. The parent is the
@@ -868,6 +1078,37 @@ func (t *txnContext) prepareDispatch() (preparedTxnDispatch, error) {
 	}
 	ctx, cancel := context.WithTimeout(parentCtx, redisDispatchTimeout)
 
+	replacementElems, err := t.buildReplacementElems(ctx)
+	if err != nil {
+		cancel()
+		return preparedTxnDispatch{cancel: func() {}}, err
+	}
+	hashDeleteElems, err := t.buildHashDeletionElems(ctx)
+	if err != nil {
+		cancel()
+		return preparedTxnDispatch{cancel: func() {}}, err
+	}
+	setDeleteElems, err := t.buildSetDeletionElems(ctx)
+	if err != nil {
+		cancel()
+		return preparedTxnDispatch{cancel: func() {}}, err
+	}
+	elems := make([]*kv.Elem[kv.OP], 0, len(replacementElems)+len(hashDeleteElems)+len(setDeleteElems))
+	elems = append(elems, replacementElems...)
+	elems = append(elems, hashDeleteElems...)
+	elems = append(elems, setDeleteElems...)
+	elems = append(elems, t.buildKeyElems()...)
+	listElems := t.buildListElems(commitTS)
+	zsetElems, err := t.buildZSetElems(commitTS)
+	if err != nil {
+		cancel()
+		return preparedTxnDispatch{cancel: func() {}}, err
+	}
+	hashElems := t.buildHashElems(commitTS)
+	// TTL elements: string keys have TTL embedded in value (buildKeyElems handles that),
+	// non-string keys get a !redis|ttl| element written in the same transaction.
+	ttlElems := t.buildTTLElems()
+
 	streamElems, err := t.buildStreamDeletionElems(ctx)
 	if err != nil {
 		cancel()
@@ -876,6 +1117,7 @@ func (t *txnContext) prepareDispatch() (preparedTxnDispatch, error) {
 
 	elems = append(elems, listElems...)
 	elems = append(elems, zsetElems...)
+	elems = append(elems, hashElems...)
 	elems = append(elems, ttlElems...)
 	elems = append(elems, streamElems...)
 
@@ -937,6 +1179,85 @@ func (t *txnContext) stringValueAndTTLElem(userKey []byte, tv *txnValue) ([]byte
 	return value, nil
 }
 
+func (t *txnContext) hasReplacement(key []byte) bool {
+	_, ok := t.replacers[string(key)]
+	return ok
+}
+
+func (t *txnContext) buildReplacementElems(ctx context.Context) ([]*kv.Elem[kv.OP], error) {
+	if len(t.replacers) == 0 {
+		return nil, nil
+	}
+	keys := make([]string, 0, len(t.replacers))
+	for k := range t.replacers {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var elems []*kv.Elem[kv.OP]
+	for _, k := range keys {
+		repl := t.replacers[k]
+		deleteElems, _, err := t.server.deleteLogicalKeyElems(ctx, repl.key, t.startTS)
+		if err != nil {
+			return nil, err
+		}
+		elems = append(elems, deleteElems...)
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   redisStrKey(repl.key),
+			Value: encodeRedisStr(repl.value, repl.ttl),
+		})
+		if repl.ttl == nil {
+			elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisTTLKey(repl.key)})
+			continue
+		}
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: redisTTLKey(repl.key), Value: encodeRedisTTL(*repl.ttl)})
+	}
+	return elems, nil
+}
+
+func (t *txnContext) buildHashDeletionElems(ctx context.Context) ([]*kv.Elem[kv.OP], error) {
+	return t.buildWideDeletionElems(ctx, t.hashDeletes,
+		store.HashFieldScanPrefix, store.HashMetaKey, store.HashMetaDeltaScanPrefix)
+}
+
+func (t *txnContext) buildSetDeletionElems(ctx context.Context) ([]*kv.Elem[kv.OP], error) {
+	return t.buildWideDeletionElems(ctx, t.setDeletes,
+		store.SetMemberScanPrefix, store.SetMetaKey, store.SetMetaDeltaScanPrefix)
+}
+
+func (t *txnContext) buildWideDeletionElems(
+	ctx context.Context,
+	deletes map[string][]byte,
+	fieldPrefix func([]byte) []byte,
+	metaKey func([]byte) []byte,
+	deltaPrefix func([]byte) []byte,
+) ([]*kv.Elem[kv.OP], error) {
+	if len(deletes) == 0 {
+		return nil, nil
+	}
+	keys := make([]string, 0, len(deletes))
+	for k := range deletes {
+		if t.hasReplacement([]byte(k)) {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var elems []*kv.Elem[kv.OP]
+	for _, k := range keys {
+		key := deletes[k]
+		next, err := t.server.deleteWideColumnElems(ctx, t.startTS,
+			fieldPrefix(key), metaKey(key), deltaPrefix(key))
+		if err != nil {
+			return nil, err
+		}
+		elems = append(elems, next...)
+	}
+	return elems, nil
+}
+
 func (t *txnContext) buildKeyElems() []*kv.Elem[kv.OP] {
 	keys := make([]string, 0, len(t.working))
 	for k := range t.working {
@@ -951,29 +1272,44 @@ func (t *txnContext) buildKeyElems() []*kv.Elem[kv.OP] {
 			continue
 		}
 		storageKey := []byte(k)
-		if tv.deleted {
-			elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: storageKey})
-			// Deleting a string anchor must also drop any stale !redis|ttl|
-			// scan-index entry; buildTTLElems skips strings because it assumes
-			// the inline-TTL path owns them.
-			if bytes.HasPrefix(storageKey, []byte(redisStrPrefix)) {
-				userKey := storageKey[len(redisStrPrefix):]
-				elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisTTLKey(userKey)})
-			}
+		if t.skipWorkingKeyForReplacement(storageKey) {
 			continue
 		}
-		value := tv.raw
-		if bytes.HasPrefix(storageKey, []byte(redisStrPrefix)) {
-			userKey := storageKey[len(redisStrPrefix):]
-			var extra *kv.Elem[kv.OP]
-			value, extra = t.stringValueAndTTLElem(userKey, tv)
-			if extra != nil {
-				elems = append(elems, extra)
-			}
-		}
-		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: storageKey, Value: value})
+		elems = t.appendWorkingKeyElems(elems, storageKey, tv)
 	}
 	return elems
+}
+
+func (t *txnContext) skipWorkingKeyForReplacement(storageKey []byte) bool {
+	if bytes.HasPrefix(storageKey, []byte(redisStrPrefix)) {
+		userKey := storageKey[len(redisStrPrefix):]
+		return t.hasReplacement(userKey)
+	}
+	return t.hasReplacement(storageKey)
+}
+
+func (t *txnContext) appendWorkingKeyElems(elems []*kv.Elem[kv.OP], storageKey []byte, tv *txnValue) []*kv.Elem[kv.OP] {
+	if tv.deleted {
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: storageKey})
+		// Deleting a string anchor must also drop any stale !redis|ttl|
+		// scan-index entry; buildTTLElems skips strings because it assumes
+		// the inline-TTL path owns them.
+		if bytes.HasPrefix(storageKey, []byte(redisStrPrefix)) {
+			userKey := storageKey[len(redisStrPrefix):]
+			elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: redisTTLKey(userKey)})
+		}
+		return elems
+	}
+	value := tv.raw
+	if bytes.HasPrefix(storageKey, []byte(redisStrPrefix)) {
+		userKey := storageKey[len(redisStrPrefix):]
+		var extra *kv.Elem[kv.OP]
+		value, extra = t.stringValueAndTTLElem(userKey, tv)
+		if extra != nil {
+			elems = append(elems, extra)
+		}
+	}
+	return append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: storageKey, Value: value})
 }
 
 func listDeleteMeta(st *listTxnState) (store.ListMeta, bool) {
@@ -1004,51 +1340,62 @@ func (t *txnContext) buildListElems(commitTS uint64) []*kv.Elem[kv.OP] {
 	var elems []*kv.Elem[kv.OP]
 	var seqInTxn uint32
 	for _, k := range listKeys {
-		st := t.listStates[k]
-		userKey := []byte(k)
-
-		if st.deleted {
-			if meta, ok := listDeleteMeta(st); ok {
-				elems = appendListDeleteOps(elems, userKey, meta)
-			}
-			// Delete existing delta keys so they don't survive the logical delete.
-			for _, dk := range st.existingDeltas {
-				elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: dk})
-			}
-			continue
+		var emitted bool
+		elems, emitted = t.appendListStateElems(elems, []byte(k), t.listStates[k], commitTS, seqInTxn)
+		if emitted {
+			seqInTxn++
 		}
-		if len(st.appends) == 0 {
-			continue
-		}
-		if st.purge {
-			elems = appendListDeleteOps(elems, userKey, st.purgeMeta)
-			// Delete existing delta keys so they don't accumulate after DEL+RPUSH.
-			for _, dk := range st.existingDeltas {
-				elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: dk})
-			}
-		}
-
-		startSeq := st.meta.Head + st.meta.Len
-		for i, v := range st.appends {
-			elems = append(elems, &kv.Elem[kv.OP]{
-				Op:    kv.Put,
-				Key:   listItemKey(userKey, startSeq+int64(i)),
-				Value: v,
-			})
-		}
-
-		// Emit a Delta key instead of updating the base metadata key.
-		// Each list key in this transaction gets a unique seqInTxn.
-		n := int64(len(st.appends))
-		deltaVal := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: 0, LenDelta: n})
-		elems = append(elems, &kv.Elem[kv.OP]{
-			Op:    kv.Put,
-			Key:   store.ListMetaDeltaKey(userKey, commitTS, seqInTxn),
-			Value: deltaVal,
-		})
-		seqInTxn++
 	}
 	return elems
+}
+
+func (t *txnContext) appendListStateElems(elems []*kv.Elem[kv.OP], userKey []byte, st *listTxnState, commitTS uint64, seqInTxn uint32) ([]*kv.Elem[kv.OP], bool) {
+	if t.hasReplacement(userKey) {
+		return elems, false
+	}
+	if st.deleted {
+		return appendListDeletionElems(elems, userKey, st), false
+	}
+	if len(st.appends) == 0 {
+		return elems, false
+	}
+	if st.purge {
+		elems = appendListDeletionElems(elems, userKey, st)
+	}
+	elems = appendListAppendElems(elems, userKey, st)
+	return appendListDeltaElem(elems, userKey, st, commitTS, seqInTxn), true
+}
+
+func appendListDeletionElems(elems []*kv.Elem[kv.OP], userKey []byte, st *listTxnState) []*kv.Elem[kv.OP] {
+	if meta, ok := listDeleteMeta(st); ok {
+		elems = appendListDeleteOps(elems, userKey, meta)
+	}
+	// Delete existing delta keys so they do not survive logical delete/purge.
+	for _, dk := range st.existingDeltas {
+		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: dk})
+	}
+	return elems
+}
+
+func appendListAppendElems(elems []*kv.Elem[kv.OP], userKey []byte, st *listTxnState) []*kv.Elem[kv.OP] {
+	startSeq := st.meta.Head + st.meta.Len
+	for i, v := range st.appends {
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   listItemKey(userKey, startSeq+int64(i)),
+			Value: v,
+		})
+	}
+	return elems
+}
+
+func appendListDeltaElem(elems []*kv.Elem[kv.OP], userKey []byte, st *listTxnState, commitTS uint64, seqInTxn uint32) []*kv.Elem[kv.OP] {
+	deltaVal := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: 0, LenDelta: int64(len(st.appends))})
+	return append(elems, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   store.ListMetaDeltaKey(userKey, commitTS, seqInTxn),
+		Value: deltaVal,
+	})
 }
 
 func (t *txnContext) buildZSetElems(commitTS uint64) ([]*kv.Elem[kv.OP], error) {
@@ -1062,6 +1409,9 @@ func (t *txnContext) buildZSetElems(commitTS uint64) ([]*kv.Elem[kv.OP], error) 
 	seqInTxn := uint32(0)
 	for _, k := range keys {
 		st := t.zsetStates[k]
+		if t.hasReplacement([]byte(k)) {
+			continue
+		}
 		if !st.dirty {
 			continue
 		}
@@ -1130,6 +1480,100 @@ func buildZSetWideElems(key []byte, st *zsetTxnState) ([]*kv.Elem[kv.OP], int64)
 	return elems, lenDelta
 }
 
+func (t *txnContext) buildHashElems(commitTS uint64) []*kv.Elem[kv.OP] {
+	keys := make([]string, 0, len(t.hashStates))
+	for k := range t.hashStates {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var elems []*kv.Elem[kv.OP]
+	var seqInTxn uint32
+	for _, k := range keys {
+		var emitted bool
+		elems, emitted = t.appendHashStateElems(elems, []byte(k), t.hashStates[k], commitTS, seqInTxn)
+		if emitted {
+			seqInTxn++
+		}
+	}
+	return elems
+}
+
+func (t *txnContext) appendHashStateElems(elems []*kv.Elem[kv.OP], key []byte, st *hashTxnState, commitTS uint64, seqInTxn uint32) ([]*kv.Elem[kv.OP], bool) {
+	if !st.dirty || st.deleted || t.hasReplacement(key) {
+		return elems, false
+	}
+	if st.legacy {
+		return append(elems, buildHashLegacyRewriteElems(key, st.fields)...), false
+	}
+	next, newFields := appendHashChangedFieldElems(elems, key, st)
+	if newFields == 0 {
+		return next, false
+	}
+	return appendHashDeltaElem(next, key, newFields, commitTS, seqInTxn), true
+}
+
+func appendHashChangedFieldElems(elems []*kv.Elem[kv.OP], key []byte, st *hashTxnState) ([]*kv.Elem[kv.OP], int64) {
+	var newFields int64
+	for _, field := range sortedHashFieldNames(st.fields) {
+		value := st.fields[field]
+		old, existed := st.origFields[field]
+		if existed && bytes.Equal(old, value) {
+			continue
+		}
+		if !existed {
+			newFields++
+		}
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.HashFieldKey(key, []byte(field)),
+			Value: bytes.Clone(value),
+		})
+	}
+	return elems, newFields
+}
+
+func appendHashDeltaElem(elems []*kv.Elem[kv.OP], key []byte, newFields int64, commitTS uint64, seqInTxn uint32) []*kv.Elem[kv.OP] {
+	deltaVal := store.MarshalHashMetaDelta(store.HashMetaDelta{LenDelta: newFields})
+	return append(elems, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   store.HashMetaDeltaKey(key, commitTS, seqInTxn),
+		Value: deltaVal,
+	})
+}
+
+const hashLegacyRewriteOverhead = 2
+
+func buildHashLegacyRewriteElems(key []byte, fields map[string][]byte) []*kv.Elem[kv.OP] {
+	fieldNames := sortedHashFieldNames(fields)
+	elems := make([]*kv.Elem[kv.OP], 0, len(fieldNames)+hashLegacyRewriteOverhead)
+	for _, field := range fieldNames {
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.HashFieldKey(key, []byte(field)),
+			Value: bytes.Clone(fields[field]),
+		})
+	}
+	elems = append(elems,
+		&kv.Elem[kv.OP]{Op: kv.Del, Key: redisHashKey(key)},
+		&kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.HashMetaKey(key),
+			Value: store.MarshalHashMeta(store.HashMeta{Len: int64(len(fieldNames))}),
+		},
+	)
+	return elems
+}
+
+func sortedHashFieldNames(fields map[string][]byte) []string {
+	names := make([]string, 0, len(fields))
+	for field := range fields {
+		names = append(names, field)
+	}
+	sort.Strings(names)
+	return names
+}
+
 // buildStreamDeletionElems expands every user key queued in streamDeletions
 // into the Del operations that actually tombstone a migrated stream:
 // !stream|meta|<key> and every !stream|entry|<key><ID> row. Called from
@@ -1171,6 +1615,9 @@ func (t *txnContext) buildTTLElems() []*kv.Elem[kv.OP] {
 		if !st.dirty {
 			continue
 		}
+		if t.hasReplacement([]byte(k)) {
+			continue
+		}
 		// String keys encode TTL inside the value in buildKeyElems; skip them here.
 		if _, isString := t.working[string(redisStrKey([]byte(k)))]; isString {
 			continue
@@ -1202,10 +1649,15 @@ func (r *RedisServer) runTransaction(queue []redcon.Command) ([]redisResult, err
 			server:          r,
 			ctx:             dispatchCtx,
 			working:         map[string]*txnValue{},
+			replacers:       map[string]*stringReplacement{},
 			listStates:      map[string]*listTxnState{},
+			hashStates:      map[string]*hashTxnState{},
 			zsetStates:      map[string]*zsetTxnState{},
 			ttlStates:       map[string]*ttlTxnState{},
 			readKeys:        map[string][]byte{},
+			deletedKeys:     map[string]struct{}{},
+			hashDeletes:     map[string][]byte{},
+			setDeletes:      map[string][]byte{},
 			streamDeletions: map[string][]byte{},
 			startTS:         startTS,
 		}
@@ -1403,10 +1855,15 @@ func (r *RedisServer) firstExecAttempt(dispatchCtx context.Context, queue []redc
 		server:          r,
 		ctx:             dispatchCtx,
 		working:         map[string]*txnValue{},
+		replacers:       map[string]*stringReplacement{},
 		listStates:      map[string]*listTxnState{},
+		hashStates:      map[string]*hashTxnState{},
 		zsetStates:      map[string]*zsetTxnState{},
 		ttlStates:       map[string]*ttlTxnState{},
 		readKeys:        map[string][]byte{},
+		deletedKeys:     map[string]struct{}{},
+		hashDeletes:     map[string][]byte{},
+		setDeletes:      map[string][]byte{},
 		streamDeletions: map[string][]byte{},
 		startTS:         startTS,
 	}

--- a/adapter/redis_txn.go
+++ b/adapter/redis_txn.go
@@ -761,6 +761,12 @@ func (t *txnContext) stageExpiredKeyCleanupForRecreate(key []byte) (bool, error)
 	return true, nil
 }
 
+func (t *txnContext) trackMissingKeyCreatorFenceReads(key []byte, typ redisValueType) {
+	if typ == redisTypeNone {
+		t.trackWideCollectionFenceReads(key)
+	}
+}
+
 func (t *txnContext) applyIncr(cmd redcon.Command) (redisResult, error) {
 	typ, err := t.stagedKeyType(cmd.Args[1])
 	if err != nil {
@@ -769,6 +775,7 @@ func (t *txnContext) applyIncr(cmd redcon.Command) (redisResult, error) {
 	if typ != redisTypeNone && typ != redisTypeString {
 		return redisResult{typ: resultError, err: wrongTypeError()}, nil
 	}
+	t.trackMissingKeyCreatorFenceReads(cmd.Args[1], typ)
 
 	current, ttl, res, handled, err := t.incrBaseValue(cmd.Args[1], typ)
 	if err != nil || handled {
@@ -853,6 +860,7 @@ func (t *txnContext) applyHSet(cmd redcon.Command) (redisResult, error) {
 	if typ != redisTypeNone && typ != redisTypeHash {
 		return redisResult{typ: resultError, err: wrongTypeError()}, nil
 	}
+	t.trackMissingKeyCreatorFenceReads(cmd.Args[1], typ)
 	st, err := t.loadHashState(cmd.Args[1])
 	if err != nil {
 		return redisResult{}, err
@@ -963,6 +971,7 @@ func (t *txnContext) prepareListWrite(key []byte) (redisResult, bool, error) {
 	if typ != redisTypeNone {
 		return redisResult{}, false, nil
 	}
+	t.trackMissingKeyCreatorFenceReads(key, typ)
 	expired, err := t.stageExpiredKeyCleanupForRecreate(key)
 	if err != nil {
 		return redisResult{}, false, err

--- a/adapter/redis_txn.go
+++ b/adapter/redis_txn.go
@@ -333,9 +333,9 @@ func (t *txnContext) loadHashState(key []byte) (*hashTxnState, error) {
 	}
 	fields := make(map[string][]byte, len(value))
 	origFields := make(map[string][]byte, len(value))
-	for field, value := range value {
-		raw := []byte(value)
-		fields[field] = bytes.Clone(raw)
+	for field, val := range value {
+		raw := []byte(val)
+		fields[field] = raw
 		origFields[field] = bytes.Clone(raw)
 	}
 	legacy, err := t.server.store.ExistsAt(ctx, redisHashKey(key), t.startTS)
@@ -709,14 +709,14 @@ func (t *txnContext) applyGet(cmd redcon.Command) (redisResult, error) {
 		return redisResult{typ: resultError, err: wrongTypeError()}, nil
 	}
 
-	tv, err := t.load(cmd.Args[1])
+	raw, _, ok, err := t.currentStringValue(cmd.Args[1])
 	if err != nil {
 		return redisResult{}, err
 	}
-	if tv.deleted || tv.raw == nil {
+	if !ok {
 		return redisResult{typ: resultNil}, nil
 	}
-	return redisResult{typ: resultBulk, bulk: tv.raw}, nil
+	return redisResult{typ: resultBulk, bulk: raw}, nil
 }
 
 func (t *txnContext) applyExists(cmd redcon.Command) (redisResult, error) {
@@ -1238,7 +1238,7 @@ func (t *txnContext) buildWideDeletionElems(
 	}
 	keys := make([]string, 0, len(deletes))
 	for k := range deletes {
-		if t.hasReplacement([]byte(k)) {
+		if _, ok := t.replacers[k]; ok {
 			continue
 		}
 		keys = append(keys, k)
@@ -1409,7 +1409,7 @@ func (t *txnContext) buildZSetElems(commitTS uint64) ([]*kv.Elem[kv.OP], error) 
 	seqInTxn := uint32(0)
 	for _, k := range keys {
 		st := t.zsetStates[k]
-		if t.hasReplacement([]byte(k)) {
+		if _, ok := t.replacers[k]; ok {
 			continue
 		}
 		if !st.dirty {
@@ -1615,7 +1615,7 @@ func (t *txnContext) buildTTLElems() []*kv.Elem[kv.OP] {
 		if !st.dirty {
 			continue
 		}
-		if t.hasReplacement([]byte(k)) {
+		if _, ok := t.replacers[k]; ok {
 			continue
 		}
 		// String keys encode TTL inside the value in buildKeyElems; skip them here.

--- a/adapter/redis_txn.go
+++ b/adapter/redis_txn.go
@@ -19,6 +19,7 @@ var redisTxnKeyPrefix = []byte("!txn|")
 var redisTxnWideHashFencePrefix = []byte("!redis|txn-wide-hash|")
 var redisTxnWideSetFencePrefix = []byte("!redis|txn-wide-set|")
 var redisTxnWideListFencePrefix = []byte("!redis|txn-wide-list|")
+var redisTxnWideZSetFencePrefix = []byte("!redis|txn-wide-zset|")
 
 type txnCommandHandler func(*txnContext, redcon.Command) (redisResult, error)
 
@@ -185,11 +186,16 @@ func redisTxnWideListFenceKey(userKey []byte) []byte {
 	return redisTxnWideFenceKey(redisTxnWideListFencePrefix, userKey)
 }
 
+func redisTxnWideZSetFenceKey(userKey []byte) []byte {
+	return redisTxnWideFenceKey(redisTxnWideZSetFencePrefix, userKey)
+}
+
 func redisTxnWideFenceUserKey(key []byte) []byte {
 	for _, prefix := range [][]byte{
 		redisTxnWideHashFencePrefix,
 		redisTxnWideSetFencePrefix,
 		redisTxnWideListFencePrefix,
+		redisTxnWideZSetFencePrefix,
 	} {
 		if bytes.HasPrefix(key, prefix) {
 			return key[len(prefix):]
@@ -215,6 +221,28 @@ func redisTxnWideSetFenceElem(userKey []byte) *kv.Elem[kv.OP] {
 
 func redisTxnWideListFenceElem(userKey []byte) *kv.Elem[kv.OP] {
 	return redisTxnWideFenceElem(redisTxnWideListFenceKey(userKey))
+}
+
+func redisTxnWideZSetFenceElem(userKey []byte) *kv.Elem[kv.OP] {
+	return redisTxnWideFenceElem(redisTxnWideZSetFenceKey(userKey))
+}
+
+func redisTxnWideCollectionFenceKeys(userKey []byte) [][]byte {
+	return [][]byte{
+		redisTxnWideHashFenceKey(userKey),
+		redisTxnWideSetFenceKey(userKey),
+		redisTxnWideListFenceKey(userKey),
+		redisTxnWideZSetFenceKey(userKey),
+	}
+}
+
+func redisTxnWideCollectionFenceElems(userKey []byte) []*kv.Elem[kv.OP] {
+	keys := redisTxnWideCollectionFenceKeys(userKey)
+	elems := make([]*kv.Elem[kv.OP], 0, len(keys))
+	for _, key := range keys {
+		elems = append(elems, redisTxnWideFenceElem(key))
+	}
+	return elems
 }
 
 func redisTxnWideFenceElem(key []byte) *kv.Elem[kv.OP] {
@@ -303,6 +331,7 @@ func (t *txnContext) loadListState(key []byte) (*listTxnState, error) {
 	if st, ok := t.listStates[k]; ok {
 		return st, nil
 	}
+	t.trackReadKey(redisTxnWideListFenceKey(key))
 	ctx := t.ctxOrBackground()
 	meta, exists, err := t.server.resolveListMeta(ctx, key, t.startTS)
 	if err != nil {
@@ -401,6 +430,7 @@ func (t *txnContext) loadExpiredHashAsEmpty(key []byte, keyString string) (*hash
 
 func (t *txnContext) loadExistingHashState(key []byte, keyString string) (*hashTxnState, error) {
 	ctx := t.ctxOrBackground()
+	t.trackReadKey(redisTxnWideHashFenceKey(key))
 	value, err := t.server.loadHashAt(ctx, key, t.startTS)
 	if err != nil {
 		return nil, err
@@ -434,6 +464,7 @@ func (t *txnContext) loadZSetState(key []byte) (*zsetTxnState, error) {
 	if st, ok := t.zsetStates[k]; ok {
 		return st, nil
 	}
+	t.trackReadKey(redisTxnWideZSetFenceKey(key))
 	t.trackReadKey(redisZSetKey(key))
 	// Check TTL: treat expired keys as non-existent.
 	ttlSt, err := t.loadTTLState(key)
@@ -1117,9 +1148,9 @@ func (t *txnContext) markLogicalDeletion(key []byte, k string) {
 }
 
 func (t *txnContext) trackWideCollectionFenceReads(key []byte) {
-	t.trackReadKey(redisTxnWideHashFenceKey(key))
-	t.trackReadKey(redisTxnWideSetFenceKey(key))
-	t.trackReadKey(redisTxnWideListFenceKey(key))
+	for _, fenceKey := range redisTxnWideCollectionFenceKeys(key) {
+		t.trackReadKey(fenceKey)
+	}
 }
 
 func (t *txnContext) stageCollectionStateDeletion(key []byte) error {
@@ -1431,6 +1462,7 @@ func (t *txnContext) buildReplacementElems(ctx context.Context) ([]*kv.Elem[kv.O
 			return nil, err
 		}
 		elems = append(elems, deleteElems...)
+		elems = append(elems, redisTxnWideCollectionFenceElems(repl.key)...)
 		elems = append(elems, &kv.Elem[kv.OP]{
 			Op:    kv.Put,
 			Key:   redisStrKey(repl.key),
@@ -1465,6 +1497,7 @@ func (t *txnContext) buildLogicalDeletionElems(ctx context.Context) ([]*kv.Elem[
 			return nil, err
 		}
 		elems = append(elems, next...)
+		elems = append(elems, redisTxnWideCollectionFenceElems(t.logicalDeletes[k])...)
 	}
 	return elems, nil
 }
@@ -1734,6 +1767,9 @@ func buildZSetWideElems(key []byte, st *zsetTxnState) ([]*kv.Elem[kv.OP], int64)
 		if !wasOrig {
 			lenDelta++
 		}
+	}
+	if len(elems) != 0 {
+		elems = append(elems, redisTxnWideZSetFenceElem(key))
 	}
 	return elems, lenDelta
 }

--- a/adapter/redis_txn.go
+++ b/adapter/redis_txn.go
@@ -854,12 +854,15 @@ func (t *txnContext) applyIncr(cmd redcon.Command) (redisResult, error) {
 		return incrOverflowResult(), nil
 	}
 	current++
+	next := []byte(strconv.FormatInt(current, 10))
 	if typ == redisTypeNone {
 		if _, err := t.stageExpiredKeyCleanupForRecreate(cmd.Args[1]); err != nil {
 			return redisResult{}, err
 		}
+		t.stageStringReplacement(cmd.Args[1], next, ttl)
+		return redisResult{typ: resultInt, integer: current}, nil
 	}
-	if err := t.stageStringValue(cmd.Args[1], []byte(strconv.FormatInt(current, 10)), ttl); err != nil {
+	if err := t.stageStringValue(cmd.Args[1], next, ttl); err != nil {
 		return redisResult{}, err
 	}
 	return redisResult{typ: resultInt, integer: current}, nil
@@ -1101,6 +1104,7 @@ func (t *txnContext) applyZIncrBy(cmd redcon.Command) (redisResult, error) {
 	if typ != redisTypeNone && typ != redisTypeZSet {
 		return redisResult{typ: resultError, err: wrongTypeError()}, nil
 	}
+	t.trackMissingKeyCreatorFenceReads(cmd.Args[1], typ)
 
 	inc, err := strconv.ParseFloat(string(cmd.Args[2]), 64)
 	if err != nil {
@@ -1820,7 +1824,10 @@ func (t *txnContext) buildZSetElems(commitTS uint64) ([]*kv.Elem[kv.OP], error) 
 		if err != nil {
 			return nil, err
 		}
-		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: redisZSetKey(key), Value: payload})
+		elems = append(elems,
+			&kv.Elem[kv.OP]{Op: kv.Put, Key: redisZSetKey(key), Value: payload},
+			redisTxnWideZSetFenceElem(key),
+		)
 	}
 	return elems, nil
 }

--- a/adapter/redis_txn_test.go
+++ b/adapter/redis_txn_test.go
@@ -360,6 +360,15 @@ func TestRedisTxnMissingKeyCreatorsReadAllWideFences(t *testing.T) {
 				require.Equal(t, int64(1), res.integer)
 			},
 		},
+		{
+			name: "zincrby",
+			apply: func(t *testing.T, txn *txnContext, key []byte) {
+				t.Helper()
+				res, err := txn.applyZIncrBy(redcon.Command{Args: [][]byte{[]byte(cmdZIncrBy), key, []byte("1"), []byte("member")}})
+				require.NoError(t, err)
+				require.Equal(t, resultBulk, res.typ)
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -498,15 +507,56 @@ func TestRedisTxnBuildZSetWideElemsWritesFence(t *testing.T) {
 		"wide zset writers must update the replacement/delete fence")
 }
 
+func TestRedisTxnBuildZSetLegacyElemsWritesFence(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("zset:legacy-fence")
+	txn := &txnContext{
+		zsetStates: map[string]*zsetTxnState{
+			string(key): {
+				members: map[string]float64{"member": 1},
+				dirty:   true,
+			},
+		},
+		replacers: map[string]*stringReplacement{},
+	}
+
+	elems, err := txn.buildZSetElems(20)
+	require.NoError(t, err)
+	require.True(t, elemKeysContain(elems, redisTxnWideZSetFenceKey(key)),
+		"legacy zset writers must update the replacement/delete fence")
+}
+
+func TestRedisTxnMissingIncrWritesWideFences(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	server, _ := newRedisStorageMigrationTestServer(t)
+	txn := newRedisTxnTestContext(server)
+	key := []byte("missing-incr:fence")
+
+	res, err := txn.applyIncr(redcon.Command{Args: [][]byte{[]byte(cmdIncr), key}})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), res.integer)
+
+	elems, err := txn.buildReplacementElems(ctx)
+	require.NoError(t, err)
+	for _, fenceKey := range redisTxnWideCollectionFenceKeys(key) {
+		require.True(t, elemKeysContain(elems, fenceKey))
+	}
+}
+
 func TestLuaWideFenceReadKeysForPlan(t *testing.T) {
 	t.Parallel()
 
 	key := []byte("lua:fence")
 	require.Equal(t, redisTxnWideCollectionFenceKeys(key),
-		luaWideFenceReadKeysForPlan(key, redisTypeString, false))
+		luaWideFenceReadKeysForPlan(key, redisTypeString, redisTypeNone, false))
+	require.Equal(t, redisTxnWideCollectionFenceKeys(key),
+		luaWideFenceReadKeysForPlan(key, redisTypeList, redisTypeNone, true))
 	require.Equal(t, [][]byte{redisTxnWideZSetFenceKey(key)},
-		luaWideFenceReadKeysForPlan(key, redisTypeZSet, true))
-	require.Nil(t, luaWideFenceReadKeysForPlan(key, redisTypeString, true))
+		luaWideFenceReadKeysForPlan(key, redisTypeZSet, redisTypeZSet, true))
+	require.Nil(t, luaWideFenceReadKeysForPlan(key, redisTypeString, redisTypeString, true))
 }
 
 func TestRedisTxnSetReplacementConflictsWithConcurrentWideHashWrite(t *testing.T) {
@@ -626,6 +676,23 @@ func TestRedisStandaloneMissingCreatorsReadAllWideFences(t *testing.T) {
 		require.Equal(t, int64(1), n)
 		requireReadKeysMatch(t, coord.lastReadKeys, redisTxnWideCollectionFenceKeys(key))
 	})
+}
+
+func TestRedisListPushRechecksTypeAtDispatchSnapshot(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	coord := newLocalAdapterCoordinator(st)
+	server := NewRedisServer(nil, "", st, coord, nil, nil)
+	key := []byte("list-push:type-recheck")
+	raw, err := marshalHashValue(redisHashValue{"field": "value"})
+	require.NoError(t, err)
+	require.NoError(t, st.PutAt(ctx, redisHashKey(key), raw, redisTxnTestStartTS, 0))
+	coord.Clock().Observe(redisTxnTestStartTS)
+
+	_, err = server.listRPush(ctx, key, [][]byte{[]byte("value")})
+	require.ErrorContains(t, err, wrongTypeMessage)
 }
 
 func TestRedisTxnSetThenExpireUpdatesReplacementTTL(t *testing.T) {

--- a/adapter/redis_txn_test.go
+++ b/adapter/redis_txn_test.go
@@ -1,6 +1,7 @@
 package adapter
 
 import (
+	"bytes"
 	"context"
 	"testing"
 	"time"
@@ -68,6 +69,41 @@ func requireTTLNear(t *testing.T, raw []byte, want time.Time) {
 	got, err := decodeRedisTTL(raw)
 	require.NoError(t, err)
 	require.WithinDuration(t, want, got, 3*time.Second)
+}
+
+type readKeyRecordingCoordinator struct {
+	*localAdapterCoordinator
+	lastReadKeys [][]byte
+}
+
+func newReadKeyRecordingCoordinator(st store.MVCCStore) *readKeyRecordingCoordinator {
+	return &readKeyRecordingCoordinator{localAdapterCoordinator: newLocalAdapterCoordinator(st)}
+}
+
+func (c *readKeyRecordingCoordinator) Dispatch(ctx context.Context, req *kv.OperationGroup[kv.OP]) (*kv.CoordinateResponse, error) {
+	c.lastReadKeys = cloneReadKeys(req.ReadKeys)
+	return c.localAdapterCoordinator.Dispatch(ctx, req)
+}
+
+func cloneReadKeys(in [][]byte) [][]byte {
+	out := make([][]byte, 0, len(in))
+	for _, key := range in {
+		out = append(out, bytes.Clone(key))
+	}
+	return out
+}
+
+func requireReadKeysMatch(t *testing.T, got [][]byte, want [][]byte) {
+	t.Helper()
+	gotSet := make(map[string]struct{}, len(got))
+	for _, key := range got {
+		gotSet[string(key)] = struct{}{}
+	}
+	wantSet := make(map[string]struct{}, len(want))
+	for _, key := range want {
+		wantSet[string(key)] = struct{}{}
+	}
+	require.Equal(t, wantSet, gotSet)
 }
 
 // TestRedisTxnValidateReadSet_ConcurrentRPushTriggersConflict verifies that a
@@ -499,6 +535,65 @@ func TestRedisTxnSetReplacementConflictsWithConcurrentListPush(t *testing.T) {
 	err = txn.validateReadSet(ctx)
 	require.ErrorIs(t, err, store.ErrWriteConflict,
 		"SET replacement in MULTI must conflict with concurrent RPUSH on the same key")
+}
+
+func TestRedisStandaloneMissingCreatorsReadAllWideFences(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("sadd", func(t *testing.T) {
+		t.Parallel()
+		st := store.NewMVCCStore()
+		coord := newReadKeyRecordingCoordinator(st)
+		server := NewRedisServer(nil, "", st, coord, nil, nil)
+		key := []byte("missing-create:sadd")
+
+		conn := &recordingConn{}
+		server.mutateExactSetWide(conn, ctx, key, [][]byte{[]byte("member")}, true)
+		require.Empty(t, conn.err)
+		require.Equal(t, int64(1), conn.int)
+		requireReadKeysMatch(t, coord.lastReadKeys, redisTxnWideCollectionFenceKeys(key))
+	})
+
+	t.Run("rpush", func(t *testing.T) {
+		t.Parallel()
+		st := store.NewMVCCStore()
+		coord := newReadKeyRecordingCoordinator(st)
+		server := NewRedisServer(nil, "", st, coord, nil, nil)
+		key := []byte("missing-create:rpush")
+
+		n, err := server.listRPush(ctx, key, [][]byte{[]byte("value")})
+		require.NoError(t, err)
+		require.Equal(t, int64(1), n)
+		requireReadKeysMatch(t, coord.lastReadKeys, redisTxnWideCollectionFenceKeys(key))
+	})
+
+	t.Run("zadd", func(t *testing.T) {
+		t.Parallel()
+		st := store.NewMVCCStore()
+		coord := newReadKeyRecordingCoordinator(st)
+		server := NewRedisServer(nil, "", st, coord, nil, nil)
+		key := []byte("missing-create:zadd")
+
+		n, err := server.zaddTxn(ctx, key, zaddFlags{}, []zaddPair{{score: 1, member: "member"}})
+		require.NoError(t, err)
+		require.Equal(t, 1, n)
+		requireReadKeysMatch(t, coord.lastReadKeys, redisTxnWideCollectionFenceKeys(key))
+	})
+
+	t.Run("hincrby", func(t *testing.T) {
+		t.Parallel()
+		st := store.NewMVCCStore()
+		coord := newReadKeyRecordingCoordinator(st)
+		server := NewRedisServer(nil, "", st, coord, nil, nil)
+		key := []byte("missing-create:hincrby")
+
+		n, err := server.hincrbyTxn(ctx, key, []byte("field"), 1)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), n)
+		requireReadKeysMatch(t, coord.lastReadKeys, redisTxnWideCollectionFenceKeys(key))
+	})
 }
 
 func TestRedisTxnSetThenExpireUpdatesReplacementTTL(t *testing.T) {

--- a/adapter/redis_txn_test.go
+++ b/adapter/redis_txn_test.go
@@ -448,6 +448,40 @@ func TestRedisTxnHSetAfterDelDoesNotReloadDeletedHash(t *testing.T) {
 	require.Equal(t, int64(1), delta.LenDelta)
 }
 
+func TestRedisTxnZIncrByAfterDelDoesNotDiffAgainstDeletedZSet(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	server, st := newRedisStorageMigrationTestServer(t)
+	key := []byte("txn:zset-del-recreate")
+	member := []byte("member")
+	require.NoError(t, st.PutAt(ctx, store.ZSetMemberKey(key, member), store.MarshalZSetScore(10), redisTxnTestStartTS, 0))
+	require.NoError(t, st.PutAt(ctx, store.ZSetScoreKey(key, 10, member), []byte{}, redisTxnTestStartTS, 0))
+	require.NoError(t, st.PutAt(ctx, store.ZSetMetaKey(key), store.MarshalZSetMeta(store.ZSetMeta{Len: 1}), redisTxnTestStartTS, 0))
+
+	txn := newRedisTxnTestContext(server)
+	delRes, err := txn.applyDel(redcon.Command{Args: [][]byte{[]byte(cmdDel), key}})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), delRes.integer)
+
+	recreated, err := txn.applyZIncrBy(redcon.Command{Args: [][]byte{[]byte(cmdZIncrBy), key, []byte("1"), member}})
+	require.NoError(t, err)
+	require.Equal(t, resultBulk, recreated.typ)
+	require.Equal(t, []byte("1"), recreated.bulk)
+
+	zsetState := txn.zsetStates[string(key)]
+	require.NotNil(t, zsetState)
+	require.True(t, zsetState.isWide)
+	require.Empty(t, zsetState.origMembers)
+
+	elems, err := txn.buildZSetElems(20)
+	require.NoError(t, err)
+	deltaElem := requireElemByKey(t, elems, store.ZSetMetaDeltaKey(key, 20, 0))
+	delta, err := store.UnmarshalZSetMetaDelta(deltaElem.Value)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), delta.LenDelta)
+}
+
 func requireTxnReadKeysContainWideFences(t *testing.T, txn *txnContext, key []byte) {
 	t.Helper()
 	for _, fenceKey := range redisTxnWideCollectionFenceKeys(key) {

--- a/adapter/redis_txn_test.go
+++ b/adapter/redis_txn_test.go
@@ -266,6 +266,131 @@ func TestRedisTxnWideFenceKeysUseRedisRoutePrefix(t *testing.T) {
 	require.Len(t, redisTxnWideCollectionFenceKeys(key), 4)
 }
 
+func TestRedisTxnMissingKeyCreatorsReadAllWideFences(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newRedisStorageMigrationTestServer(t)
+	cases := []struct {
+		name  string
+		apply func(*testing.T, *txnContext, []byte)
+	}{
+		{
+			name: "incr",
+			apply: func(t *testing.T, txn *txnContext, key []byte) {
+				t.Helper()
+				res, err := txn.applyIncr(redcon.Command{Args: [][]byte{[]byte(cmdIncr), key}})
+				require.NoError(t, err)
+				require.Equal(t, int64(1), res.integer)
+			},
+		},
+		{
+			name: "hset",
+			apply: func(t *testing.T, txn *txnContext, key []byte) {
+				t.Helper()
+				res, err := txn.applyHSet(redcon.Command{Args: [][]byte{[]byte(cmdHSet), key, []byte("field"), []byte("value")}})
+				require.NoError(t, err)
+				require.Equal(t, int64(1), res.integer)
+			},
+		},
+		{
+			name: "rpush",
+			apply: func(t *testing.T, txn *txnContext, key []byte) {
+				t.Helper()
+				res, err := txn.applyRPush(redcon.Command{Args: [][]byte{[]byte(cmdRPush), key, []byte("value")}})
+				require.NoError(t, err)
+				require.Equal(t, int64(1), res.integer)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			txn := newRedisTxnTestContext(server)
+			key := []byte("missing:" + tc.name)
+			tc.apply(t, txn, key)
+			requireTxnReadKeysContainWideFences(t, txn, key)
+		})
+	}
+}
+
+func requireTxnReadKeysContainWideFences(t *testing.T, txn *txnContext, key []byte) {
+	t.Helper()
+	for _, fenceKey := range redisTxnWideCollectionFenceKeys(key) {
+		require.Contains(t, txn.readKeys, string(fenceKey))
+	}
+}
+
+func TestRedisTxnMissingKeyCreatorsConflictWithConcurrentWideCreator(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		apply      func(*testing.T, *txnContext, []byte)
+		concurrent func(*testing.T, context.Context, *RedisServer, []byte)
+	}{
+		{
+			name: "incr_vs_hash",
+			apply: func(t *testing.T, txn *txnContext, key []byte) {
+				t.Helper()
+				_, err := txn.applyIncr(redcon.Command{Args: [][]byte{[]byte(cmdIncr), key}})
+				require.NoError(t, err)
+			},
+			concurrent: func(t *testing.T, _ context.Context, server *RedisServer, key []byte) {
+				t.Helper()
+				added, err := server.applyHashFieldPairs(key, [][]byte{[]byte("field"), []byte("value")})
+				require.NoError(t, err)
+				require.Equal(t, 1, added)
+			},
+		},
+		{
+			name: "hset_vs_list",
+			apply: func(t *testing.T, txn *txnContext, key []byte) {
+				t.Helper()
+				_, err := txn.applyHSet(redcon.Command{Args: [][]byte{[]byte(cmdHSet), key, []byte("field"), []byte("value")}})
+				require.NoError(t, err)
+			},
+			concurrent: func(t *testing.T, ctx context.Context, server *RedisServer, key []byte) {
+				t.Helper()
+				length, err := server.listRPush(ctx, key, [][]byte{[]byte("value")})
+				require.NoError(t, err)
+				require.Equal(t, int64(1), length)
+			},
+		},
+		{
+			name: "rpush_vs_zset",
+			apply: func(t *testing.T, txn *txnContext, key []byte) {
+				t.Helper()
+				_, err := txn.applyRPush(redcon.Command{Args: [][]byte{[]byte(cmdRPush), key, []byte("value")}})
+				require.NoError(t, err)
+			},
+			concurrent: func(t *testing.T, ctx context.Context, server *RedisServer, key []byte) {
+				t.Helper()
+				score, err := server.zincrbyTxn(ctx, key, "member", 1)
+				require.NoError(t, err)
+				require.Equal(t, float64(1), score)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			st := store.NewMVCCStore()
+			coord := newOCCAdapterCoordinator(st)
+			server := NewRedisServer(nil, "", st, coord, nil, nil)
+			coord.Clock().Observe(redisTxnTestStartTS)
+			key := []byte("missing-conflict:" + tc.name)
+
+			txn := newRedisTxnTestContext(server)
+			tc.apply(t, txn, key)
+			tc.concurrent(t, ctx, server, key)
+
+			err := txn.validateReadSet(ctx)
+			require.ErrorIs(t, err, store.ErrWriteConflict)
+		})
+	}
+}
+
 func TestRedisTxnBuildZSetWideElemsWritesFence(t *testing.T) {
 	t.Parallel()
 

--- a/adapter/redis_txn_test.go
+++ b/adapter/redis_txn_test.go
@@ -17,6 +17,25 @@ func newRedisStorageMigrationTestServer(t *testing.T) (*RedisServer, store.MVCCS
 	return server, st
 }
 
+func newRedisTxnTestContext(server *RedisServer, startTS uint64) *txnContext {
+	return &txnContext{
+		server:          server,
+		working:         map[string]*txnValue{},
+		replacers:       map[string]*stringReplacement{},
+		listStates:      map[string]*listTxnState{},
+		hashStates:      map[string]*hashTxnState{},
+		zsetStates:      map[string]*zsetTxnState{},
+		ttlStates:       map[string]*ttlTxnState{},
+		readKeys:        map[string][]byte{},
+		deletedKeys:     map[string]struct{}{},
+		logicalDeletes:  map[string][]byte{},
+		hashDeletes:     map[string][]byte{},
+		setDeletes:      map[string][]byte{},
+		streamDeletions: map[string][]byte{},
+		startTS:         startTS,
+	}
+}
+
 // TestRedisTxnValidateReadSet_ConcurrentRPushTriggersConflict verifies that a
 // concurrent RPUSH to a list triggers an OCC read-write conflict for a MULTI
 // transaction that read the list via LRANGE.  Without the boundary key tracking
@@ -163,6 +182,61 @@ func TestRedisTxnValidateReadSet_TTLUpdateNoConflict(t *testing.T) {
 
 	err = txn.validateReadSet(context.Background())
 	require.NoError(t, err)
+}
+
+func TestRedisTxnWideHashDeleteConflictsWithConcurrentNewField(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	coord := newOCCAdapterCoordinator(st)
+	server := NewRedisServer(nil, "", st, coord, nil, nil)
+	key := []byte("hash:wide-delete-conflict")
+
+	require.NoError(t, st.PutAt(ctx, store.HashFieldKey(key, []byte("old")), []byte("v"), 10, 0))
+	require.NoError(t, st.PutAt(ctx, store.HashMetaKey(key), store.MarshalHashMeta(store.HashMeta{Len: 1}), 10, 0))
+	coord.Clock().Observe(10)
+
+	txn := newRedisTxnTestContext(server, 10)
+	res, err := txn.stageKeyDeletion(key)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), res.integer)
+
+	added, err := server.applyHashFieldPairs(key, [][]byte{[]byte("new"), []byte("v")})
+	require.NoError(t, err)
+	require.Equal(t, 1, added)
+
+	err = txn.validateReadSet(ctx)
+	require.ErrorIs(t, err, store.ErrWriteConflict,
+		"wide hash DEL in MULTI must conflict with concurrent HSET of a new field")
+}
+
+func TestRedisTxnWideSetDeleteConflictsWithConcurrentNewMember(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	coord := newOCCAdapterCoordinator(st)
+	server := NewRedisServer(nil, "", st, coord, nil, nil)
+	key := []byte("set:wide-delete-conflict")
+
+	require.NoError(t, st.PutAt(ctx, store.SetMemberKey(key, []byte("old")), []byte{}, 10, 0))
+	require.NoError(t, st.PutAt(ctx, store.SetMetaKey(key), store.MarshalSetMeta(store.SetMeta{Len: 1}), 10, 0))
+	coord.Clock().Observe(10)
+
+	txn := newRedisTxnTestContext(server, 10)
+	res, err := txn.stageKeyDeletion(key)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), res.integer)
+
+	conn := &recordingConn{}
+	server.mutateExactSetWide(conn, ctx, key, [][]byte{[]byte("new")}, true)
+	require.Empty(t, conn.err)
+	require.Equal(t, int64(1), conn.int)
+
+	err = txn.validateReadSet(ctx)
+	require.ErrorIs(t, err, store.ErrWriteConflict,
+		"wide set DEL in MULTI must conflict with concurrent SADD of a new member")
 }
 
 // TestRedisTxnMULTIEXECRetriesOnCoordinatorConflict verifies that runTransaction

--- a/adapter/redis_txn_test.go
+++ b/adapter/redis_txn_test.go
@@ -660,6 +660,68 @@ func TestRedisTxnExistingWideWritersReadReplacementFences(t *testing.T) {
 	}
 }
 
+func TestRedisTxnWideDeletionElemsWriteFences(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	server := NewRedisServer(nil, "", st, newLocalAdapterCoordinator(st), nil, nil)
+	hashKey := []byte("delete-fence:hash")
+	setKey := []byte("delete-fence:set")
+	require.NoError(t, st.PutAt(ctx, store.HashFieldKey(hashKey, []byte("old")), []byte("v"), 10, 0))
+	require.NoError(t, st.PutAt(ctx, store.HashMetaKey(hashKey), store.MarshalHashMeta(store.HashMeta{Len: 1}), 10, 0))
+	require.NoError(t, st.PutAt(ctx, store.SetMemberKey(setKey, []byte("old")), []byte{}, 10, 0))
+	require.NoError(t, st.PutAt(ctx, store.SetMetaKey(setKey), store.MarshalSetMeta(store.SetMeta{Len: 1}), 10, 0))
+
+	txn := newRedisTxnTestContext(server)
+	txn.hashDeletes[string(hashKey)] = hashKey
+	txn.setDeletes[string(setKey)] = setKey
+
+	hashElems, err := txn.buildHashDeletionElems(ctx)
+	require.NoError(t, err)
+	require.True(t, elemKeysContain(hashElems, redisTxnWideHashFenceKey(hashKey)))
+
+	setElems, err := txn.buildSetDeletionElems(ctx)
+	require.NoError(t, err)
+	require.True(t, elemKeysContain(setElems, redisTxnWideSetFenceKey(setKey)))
+}
+
+func TestRedisTxnListDeletionElemsWriteFence(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("delete-fence:list")
+	elems := appendListDeletionElems(nil, key, &listTxnState{
+		meta:       store.ListMeta{Len: 1, Tail: 1},
+		metaExists: true,
+		deleted:    true,
+	})
+	require.True(t, elemKeysContain(elems, redisTxnWideListFenceKey(key)))
+}
+
+func TestRedisTxnHashLegacyRewriteWritesFence(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("legacy-rewrite:hash")
+	elems := buildHashLegacyRewriteElems(key, map[string][]byte{"field": []byte("value")})
+	require.True(t, elemKeysContain(elems, redisTxnWideHashFenceKey(key)))
+}
+
+func TestRedisSetLegacyMigrationWritesFenceWithoutLenDelta(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	server := NewRedisServer(nil, "", st, newLocalAdapterCoordinator(st), nil, nil)
+	key := []byte("legacy-migration:set")
+	raw, err := marshalSetValue(redisSetValue{Members: []string{"member"}})
+	require.NoError(t, err)
+	require.NoError(t, st.PutAt(ctx, redisSetKey(key), raw, 10, 0))
+
+	elems, err := server.buildSetLegacyMigrationElems(ctx, key, 10)
+	require.NoError(t, err)
+	require.True(t, elemKeysContain(elems, redisTxnWideSetFenceKey(key)))
+}
+
 func TestRedisTxnExpiredRecreateConflictsWithConcurrentCollectionWrite(t *testing.T) {
 	t.Parallel()
 

--- a/adapter/redis_txn_test.go
+++ b/adapter/redis_txn_test.go
@@ -412,6 +412,42 @@ func TestRedisStandaloneHSetDedupAvoidsWideHashMaterializationLimit(t *testing.T
 	require.Equal(t, []byte("new-value"), raw)
 }
 
+func TestRedisTxnHSetAfterDelDoesNotReloadDeletedHash(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	server := NewRedisServer(nil, "", st, newLocalAdapterCoordinator(st), nil, nil)
+	key := []byte("txn:hash-del-recreate")
+	field := []byte("field")
+	require.NoError(t, st.PutAt(ctx, store.HashFieldKey(key, field), []byte("old"), redisTxnTestStartTS, 0))
+	require.NoError(t, st.PutAt(ctx, store.HashMetaKey(key), store.MarshalHashMeta(store.HashMeta{Len: 1}), redisTxnTestStartTS, 0))
+
+	txn := newRedisTxnTestContext(server)
+	first, err := txn.applyHSet(redcon.Command{Args: [][]byte{[]byte(cmdHSet), key, field, []byte("updated")}})
+	require.NoError(t, err)
+	require.Equal(t, int64(0), first.integer)
+
+	delRes, err := txn.applyDel(redcon.Command{Args: [][]byte{[]byte(cmdDel), key}})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), delRes.integer)
+
+	recreated, err := txn.applyHSet(redcon.Command{Args: [][]byte{[]byte(cmdHSet), key, field, []byte("recreated")}})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), recreated.integer)
+
+	hashState := txn.hashStates[string(key)]
+	require.NotNil(t, hashState)
+	require.False(t, hashState.deleted)
+	require.Empty(t, hashState.origFields)
+
+	elems := txn.buildHashElems(20)
+	deltaElem := requireElemByKey(t, elems, store.HashMetaDeltaKey(key, 20, 0))
+	delta, err := store.UnmarshalHashMetaDelta(deltaElem.Value)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), delta.LenDelta)
+}
+
 func requireTxnReadKeysContainWideFences(t *testing.T, txn *txnContext, key []byte) {
 	t.Helper()
 	for _, fenceKey := range redisTxnWideCollectionFenceKeys(key) {

--- a/adapter/redis_txn_test.go
+++ b/adapter/redis_txn_test.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/bootjp/elastickv/kv"
 	"github.com/bootjp/elastickv/store"
@@ -17,7 +18,9 @@ func newRedisStorageMigrationTestServer(t *testing.T) (*RedisServer, store.MVCCS
 	return server, st
 }
 
-func newRedisTxnTestContext(server *RedisServer, startTS uint64) *txnContext {
+const redisTxnTestStartTS = 10
+
+func newRedisTxnTestContext(server *RedisServer) *txnContext {
 	return &txnContext{
 		server:          server,
 		working:         map[string]*txnValue{},
@@ -32,7 +35,7 @@ func newRedisTxnTestContext(server *RedisServer, startTS uint64) *txnContext {
 		hashDeletes:     map[string][]byte{},
 		setDeletes:      map[string][]byte{},
 		streamDeletions: map[string][]byte{},
-		startTS:         startTS,
+		startTS:         redisTxnTestStartTS,
 	}
 }
 
@@ -197,7 +200,7 @@ func TestRedisTxnWideHashDeleteConflictsWithConcurrentNewField(t *testing.T) {
 	require.NoError(t, st.PutAt(ctx, store.HashMetaKey(key), store.MarshalHashMeta(store.HashMeta{Len: 1}), 10, 0))
 	coord.Clock().Observe(10)
 
-	txn := newRedisTxnTestContext(server, 10)
+	txn := newRedisTxnTestContext(server)
 	res, err := txn.stageKeyDeletion(key)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), res.integer)
@@ -224,7 +227,7 @@ func TestRedisTxnWideSetDeleteConflictsWithConcurrentNewMember(t *testing.T) {
 	require.NoError(t, st.PutAt(ctx, store.SetMetaKey(key), store.MarshalSetMeta(store.SetMeta{Len: 1}), 10, 0))
 	coord.Clock().Observe(10)
 
-	txn := newRedisTxnTestContext(server, 10)
+	txn := newRedisTxnTestContext(server)
 	res, err := txn.stageKeyDeletion(key)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), res.integer)
@@ -237,6 +240,104 @@ func TestRedisTxnWideSetDeleteConflictsWithConcurrentNewMember(t *testing.T) {
 	err = txn.validateReadSet(ctx)
 	require.ErrorIs(t, err, store.ErrWriteConflict,
 		"wide set DEL in MULTI must conflict with concurrent SADD of a new member")
+}
+
+func TestRedisTxnWideFenceKeysUseRedisRoutePrefix(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("user:key")
+	require.Equal(t, []byte("!redis|txn-wide-hash|user:key"), redisTxnWideHashFenceKey(key))
+	require.Equal(t, key, redisTxnWideFenceUserKey(redisTxnWideHashFenceKey(key)))
+	require.Equal(t, []byte("!redis|txn-wide-set|user:key"), redisTxnWideSetFenceKey(key))
+	require.Equal(t, key, redisTxnWideFenceUserKey(redisTxnWideSetFenceKey(key)))
+	require.Equal(t, []byte("!redis|txn-wide-list|user:key"), redisTxnWideListFenceKey(key))
+	require.Equal(t, key, redisTxnWideFenceUserKey(redisTxnWideListFenceKey(key)))
+}
+
+func TestRedisTxnSetReplacementConflictsWithConcurrentWideHashWrite(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	coord := newOCCAdapterCoordinator(st)
+	server := NewRedisServer(nil, "", st, coord, nil, nil)
+	key := []byte("hash:set-replace-conflict")
+
+	require.NoError(t, st.PutAt(ctx, store.HashFieldKey(key, []byte("old")), []byte("v"), 10, 0))
+	require.NoError(t, st.PutAt(ctx, store.HashMetaKey(key), store.MarshalHashMeta(store.HashMeta{Len: 1}), 10, 0))
+	coord.Clock().Observe(10)
+
+	txn := newRedisTxnTestContext(server)
+	res, err := txn.applySet(redcon.Command{Args: [][]byte{[]byte(cmdSet), key, []byte("string")}})
+	require.NoError(t, err)
+	require.Equal(t, "OK", res.str)
+	_, err = txn.buildReplacementElems(ctx)
+	require.NoError(t, err)
+
+	added, err := server.applyHashFieldPairs(key, [][]byte{[]byte("new"), []byte("v")})
+	require.NoError(t, err)
+	require.Equal(t, 1, added)
+
+	err = txn.validateReadSet(ctx)
+	require.ErrorIs(t, err, store.ErrWriteConflict,
+		"SET replacement in MULTI must conflict with concurrent HSET of a new field")
+}
+
+func TestRedisTxnSetReplacementConflictsWithConcurrentListPush(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	coord := newOCCAdapterCoordinator(st)
+	server := NewRedisServer(nil, "", st, coord, nil, nil)
+	key := []byte("list:set-replace-conflict")
+
+	metaBytes, err := store.MarshalListMeta(store.ListMeta{Len: 1})
+	require.NoError(t, err)
+	require.NoError(t, st.PutAt(ctx, store.ListMetaKey(key), metaBytes, 10, 0))
+	require.NoError(t, st.PutAt(ctx, store.ListItemKey(key, 0), []byte("old"), 10, 0))
+	coord.Clock().Observe(10)
+
+	txn := newRedisTxnTestContext(server)
+	res, err := txn.applySet(redcon.Command{Args: [][]byte{[]byte(cmdSet), key, []byte("string")}})
+	require.NoError(t, err)
+	require.Equal(t, "OK", res.str)
+	_, err = txn.buildReplacementElems(ctx)
+	require.NoError(t, err)
+
+	newLen, err := server.listRPush(ctx, key, [][]byte{[]byte("new")})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), newLen)
+
+	err = txn.validateReadSet(ctx)
+	require.ErrorIs(t, err, store.ErrWriteConflict,
+		"SET replacement in MULTI must conflict with concurrent RPUSH on the same key")
+}
+
+func TestRedisTxnExpiredRecreateConflictsWithConcurrentCollectionWrite(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	coord := newOCCAdapterCoordinator(st)
+	server := NewRedisServer(nil, "", st, coord, nil, nil)
+	key := []byte("expired:recreate-conflict")
+
+	require.NoError(t, st.PutAt(ctx, redisTTLKey(key), encodeRedisTTL(time.Now().Add(-time.Hour)), 10, 0))
+	coord.Clock().Observe(10)
+
+	txn := newRedisTxnTestContext(server)
+	res, err := txn.applyRPush(redcon.Command{Args: [][]byte{[]byte(cmdRPush), key, []byte("list-value")}})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), res.integer)
+
+	added, err := server.applyHashFieldPairs(key, [][]byte{[]byte("field"), []byte("hash-value")})
+	require.NoError(t, err)
+	require.Equal(t, 1, added)
+
+	err = txn.validateReadSet(ctx)
+	require.ErrorIs(t, err, store.ErrWriteConflict,
+		"expired-key recreate in MULTI must conflict with a concurrent collection recreate")
 }
 
 // TestRedisTxnMULTIEXECRetriesOnCoordinatorConflict verifies that runTransaction

--- a/adapter/redis_txn_test.go
+++ b/adapter/redis_txn_test.go
@@ -676,6 +676,48 @@ func TestRedisStandaloneMissingCreatorsReadAllWideFences(t *testing.T) {
 		require.Equal(t, int64(1), n)
 		requireReadKeysMatch(t, coord.lastReadKeys, redisTxnWideCollectionFenceKeys(key))
 	})
+
+	t.Run("hincrby-legacy-migration-expired", func(t *testing.T) {
+		t.Parallel()
+		st := store.NewMVCCStore()
+		coord := newReadKeyRecordingCoordinator(st)
+		server := NewRedisServer(nil, "", st, coord, nil, nil)
+		key := []byte("missing-create:hincrby-legacy")
+
+		raw, err := marshalHashValue(redisHashValue{"field": "1"})
+		require.NoError(t, err)
+		require.NoError(t, st.PutAt(ctx, redisHashKey(key), raw, redisTxnTestStartTS, 0))
+		require.NoError(t, st.PutAt(ctx, redisTTLKey(key), encodeRedisTTL(time.Now().Add(-time.Hour)), redisTxnTestStartTS, 0))
+		coord.Clock().Observe(redisTxnTestStartTS)
+
+		n, err := server.hincrbyTxn(ctx, key, []byte("field"), 2)
+		require.NoError(t, err)
+		require.NotZero(t, n)
+		requireReadKeysMatch(t, coord.lastReadKeys, redisTxnWideCollectionFenceKeys(key))
+	})
+}
+
+func TestRedisTxnMissingLRangeConflictsWithConcurrentRPush(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	server, _ := newRedisStorageMigrationTestServer(t)
+	key := []byte("missing-lrange:concurrent-rpush")
+
+	txn := newRedisTxnTestContext(server)
+	res, err := txn.applyLRange(redcon.Command{Args: [][]byte{[]byte(cmdLRange), key, []byte("0"), []byte("-1")}})
+	require.NoError(t, err)
+	require.Equal(t, resultArray, res.typ)
+	require.Empty(t, res.arr)
+	require.Contains(t, txn.readKeys, string(redisTxnWideListFenceKey(key)))
+
+	newLen, err := server.listRPush(ctx, key, [][]byte{[]byte("value")})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), newLen)
+
+	err = txn.validateReadSet(ctx)
+	require.ErrorIs(t, err, store.ErrWriteConflict,
+		"missing-key LRANGE in MULTI must conflict with a concurrent RPUSH on the same key")
 }
 
 func TestRedisListPushRechecksTypeAtDispatchSnapshot(t *testing.T) {

--- a/adapter/redis_txn_test.go
+++ b/adapter/redis_txn_test.go
@@ -48,6 +48,28 @@ func elemKeysContain(elems []*kv.Elem[kv.OP], want []byte) bool {
 	return false
 }
 
+func requireElemByKey(t *testing.T, elems []*kv.Elem[kv.OP], want []byte) *kv.Elem[kv.OP] {
+	t.Helper()
+	var found *kv.Elem[kv.OP]
+	for _, elem := range elems {
+		if elem != nil && string(elem.Key) == string(want) {
+			found = elem
+		}
+	}
+	if found != nil {
+		return found
+	}
+	t.Fatalf("missing elem key %q", string(want))
+	return nil
+}
+
+func requireTTLNear(t *testing.T, raw []byte, want time.Time) {
+	t.Helper()
+	got, err := decodeRedisTTL(raw)
+	require.NoError(t, err)
+	require.WithinDuration(t, want, got, 3*time.Second)
+}
+
 // TestRedisTxnValidateReadSet_ConcurrentRPushTriggersConflict verifies that a
 // concurrent RPUSH to a list triggers an OCC read-write conflict for a MULTI
 // transaction that read the list via LRANGE.  Without the boundary key tracking
@@ -477,6 +499,165 @@ func TestRedisTxnSetReplacementConflictsWithConcurrentListPush(t *testing.T) {
 	err = txn.validateReadSet(ctx)
 	require.ErrorIs(t, err, store.ErrWriteConflict,
 		"SET replacement in MULTI must conflict with concurrent RPUSH on the same key")
+}
+
+func TestRedisTxnSetThenExpireUpdatesReplacementTTL(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newRedisStorageMigrationTestServer(t)
+	txn := newRedisTxnTestContext(server)
+	key := []byte("set:then-expire")
+
+	setRes, err := txn.applySet(redcon.Command{Args: [][]byte{[]byte(cmdSet), key, []byte("v")}})
+	require.NoError(t, err)
+	require.Equal(t, "OK", setRes.str)
+
+	wantExpire := time.Now().Add(20 * time.Second)
+	expireRes, err := txn.applyExpire(redcon.Command{Args: [][]byte{[]byte(cmdExpire), key, []byte("20")}}, time.Second)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), expireRes.integer)
+
+	elems, err := txn.buildReplacementElems(context.Background())
+	require.NoError(t, err)
+	strElem := requireElemByKey(t, elems, redisStrKey(key))
+	value, inlineTTL, err := decodeRedisStr(strElem.Value)
+	require.NoError(t, err)
+	require.Equal(t, []byte("v"), value)
+	require.NotNil(t, inlineTTL)
+	require.WithinDuration(t, wantExpire, *inlineTTL, 3*time.Second)
+	requireTTLNear(t, requireElemByKey(t, elems, redisTTLKey(key)).Value, wantExpire)
+}
+
+func TestRedisTxnExpireNXUsesStagedReplacementTTL(t *testing.T) {
+	t.Parallel()
+
+	server, _ := newRedisStorageMigrationTestServer(t)
+	txn := newRedisTxnTestContext(server)
+	key := []byte("set:expire-nx")
+
+	setRes, err := txn.applySet(redcon.Command{Args: [][]byte{[]byte(cmdSet), key, []byte("v"), []byte("EX"), []byte("10")}})
+	require.NoError(t, err)
+	require.Equal(t, "OK", setRes.str)
+	initialTTL := cloneTimePtr(txn.replacers[string(key)].ttl)
+	require.NotNil(t, initialTTL)
+
+	expireRes, err := txn.applyExpire(redcon.Command{Args: [][]byte{[]byte(cmdExpire), key, []byte("20"), []byte("NX")}}, time.Second)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), expireRes.integer)
+	require.Equal(t, initialTTL, txn.replacers[string(key)].ttl)
+}
+
+func TestRedisTxnSetClearsOldTTLBeforeExpireNX(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	server, st := newRedisStorageMigrationTestServer(t)
+	key := []byte("set:clear-old-ttl")
+	oldExpire := time.Now().Add(time.Hour)
+	require.NoError(t, st.PutAt(ctx, redisStrKey(key), encodeRedisStr([]byte("old"), &oldExpire), 10, 0))
+	require.NoError(t, st.PutAt(ctx, redisTTLKey(key), encodeRedisTTL(oldExpire), 10, 0))
+
+	txn := newRedisTxnTestContext(server)
+	setRes, err := txn.applySet(redcon.Command{Args: [][]byte{[]byte(cmdSet), key, []byte("v")}})
+	require.NoError(t, err)
+	require.Equal(t, "OK", setRes.str)
+	require.Nil(t, txn.replacers[string(key)].ttl)
+
+	wantExpire := time.Now().Add(20 * time.Second)
+	expireRes, err := txn.applyExpire(redcon.Command{Args: [][]byte{[]byte(cmdExpire), key, []byte("20"), []byte("NX")}}, time.Second)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), expireRes.integer)
+
+	elems, err := txn.buildReplacementElems(ctx)
+	require.NoError(t, err)
+	requireTTLNear(t, requireElemByKey(t, elems, redisTTLKey(key)).Value, wantExpire)
+}
+
+func TestRedisTxnStagedStringWinsOverDeletionOnlyCollectionStates(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	server, st := newRedisStorageMigrationTestServer(t)
+	key := []byte("del-incr-rpush")
+	require.NoError(t, st.PutAt(ctx, redisStrKey(key), encodeRedisStr([]byte("0"), nil), 10, 0))
+
+	txn := newRedisTxnTestContext(server)
+	delRes, err := txn.applyDel(redcon.Command{Args: [][]byte{[]byte(cmdDel), key}})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), delRes.integer)
+
+	incrRes, err := txn.applyIncr(redcon.Command{Args: [][]byte{[]byte(cmdIncr), key}})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), incrRes.integer)
+
+	typ, err := txn.stagedKeyType(key)
+	require.NoError(t, err)
+	require.Equal(t, redisTypeString, typ)
+
+	pushRes, err := txn.applyRPush(redcon.Command{Args: [][]byte{[]byte(cmdRPush), key, []byte("x")}})
+	require.NoError(t, err)
+	require.Equal(t, resultError, pushRes.typ)
+	require.Error(t, pushRes.err)
+}
+
+func TestRedisTxnExistingWideWritersReadReplacementFences(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cases := []struct {
+		name  string
+		seed  func(store.MVCCStore, []byte)
+		apply func(*testing.T, *txnContext, []byte)
+		fence func([]byte) []byte
+	}{
+		{
+			name: "hash",
+			seed: func(st store.MVCCStore, key []byte) {
+				require.NoError(t, st.PutAt(ctx, store.HashFieldKey(key, []byte("old")), []byte("v"), 10, 0))
+				require.NoError(t, st.PutAt(ctx, store.HashMetaKey(key), store.MarshalHashMeta(store.HashMeta{Len: 1}), 10, 0))
+			},
+			apply: func(t *testing.T, txn *txnContext, key []byte) {
+				t.Helper()
+				res, err := txn.applyHSet(redcon.Command{Args: [][]byte{[]byte(cmdHSet), key, []byte("new"), []byte("v")}})
+				require.NoError(t, err)
+				require.Equal(t, int64(1), res.integer)
+			},
+			fence: redisTxnWideHashFenceKey,
+		},
+		{
+			name: "list",
+			seed: func(st store.MVCCStore, key []byte) {
+				meta, err := store.MarshalListMeta(store.ListMeta{Len: 1, Tail: 1})
+				require.NoError(t, err)
+				require.NoError(t, st.PutAt(ctx, store.ListMetaKey(key), meta, 10, 0))
+				require.NoError(t, st.PutAt(ctx, store.ListItemKey(key, 0), []byte("old"), 10, 0))
+			},
+			apply: func(t *testing.T, txn *txnContext, key []byte) {
+				t.Helper()
+				res, err := txn.applyRPush(redcon.Command{Args: [][]byte{[]byte(cmdRPush), key, []byte("new")}})
+				require.NoError(t, err)
+				require.Equal(t, int64(2), res.integer)
+			},
+			fence: redisTxnWideListFenceKey,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			st := store.NewMVCCStore()
+			server := NewRedisServer(nil, "", st, newLocalAdapterCoordinator(st), nil, nil)
+			key := []byte("existing-wide-fence:" + tc.name)
+			tc.seed(st, key)
+
+			txn := newRedisTxnTestContext(server)
+			tc.apply(t, txn, key)
+			fenceKey := tc.fence(key)
+			require.Contains(t, txn.readKeys, string(fenceKey))
+
+			require.NoError(t, st.PutAt(ctx, fenceKey, []byte{}, 11, 0))
+			require.ErrorIs(t, txn.validateReadSet(ctx), store.ErrWriteConflict)
+		})
+	}
 }
 
 func TestRedisTxnExpiredRecreateConflictsWithConcurrentCollectionWrite(t *testing.T) {

--- a/adapter/redis_txn_test.go
+++ b/adapter/redis_txn_test.go
@@ -39,6 +39,15 @@ func newRedisTxnTestContext(server *RedisServer) *txnContext {
 	}
 }
 
+func elemKeysContain(elems []*kv.Elem[kv.OP], want []byte) bool {
+	for _, elem := range elems {
+		if elem != nil && string(elem.Key) == string(want) {
+			return true
+		}
+	}
+	return false
+}
+
 // TestRedisTxnValidateReadSet_ConcurrentRPushTriggersConflict verifies that a
 // concurrent RPUSH to a list triggers an OCC read-write conflict for a MULTI
 // transaction that read the list via LRANGE.  Without the boundary key tracking
@@ -252,6 +261,37 @@ func TestRedisTxnWideFenceKeysUseRedisRoutePrefix(t *testing.T) {
 	require.Equal(t, key, redisTxnWideFenceUserKey(redisTxnWideSetFenceKey(key)))
 	require.Equal(t, []byte("!redis|txn-wide-list|user:key"), redisTxnWideListFenceKey(key))
 	require.Equal(t, key, redisTxnWideFenceUserKey(redisTxnWideListFenceKey(key)))
+	require.Equal(t, []byte("!redis|txn-wide-zset|user:key"), redisTxnWideZSetFenceKey(key))
+	require.Equal(t, key, redisTxnWideFenceUserKey(redisTxnWideZSetFenceKey(key)))
+	require.Len(t, redisTxnWideCollectionFenceKeys(key), 4)
+}
+
+func TestRedisTxnBuildZSetWideElemsWritesFence(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("zset:wide-fence")
+	elems, lenDelta := buildZSetWideElems(key, &zsetTxnState{
+		members:     map[string]float64{"new": 1},
+		origMembers: map[string]float64{},
+		isWide:      true,
+		exists:      true,
+		dirty:       true,
+	})
+
+	require.Equal(t, int64(1), lenDelta)
+	require.True(t, elemKeysContain(elems, redisTxnWideZSetFenceKey(key)),
+		"wide zset writers must update the replacement/delete fence")
+}
+
+func TestLuaWideFenceReadKeysForPlan(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("lua:fence")
+	require.Equal(t, redisTxnWideCollectionFenceKeys(key),
+		luaWideFenceReadKeysForPlan(key, redisTypeString, false))
+	require.Equal(t, [][]byte{redisTxnWideZSetFenceKey(key)},
+		luaWideFenceReadKeysForPlan(key, redisTypeZSet, true))
+	require.Nil(t, luaWideFenceReadKeysForPlan(key, redisTypeString, true))
 }
 
 func TestRedisTxnSetReplacementConflictsWithConcurrentWideHashWrite(t *testing.T) {

--- a/adapter/redis_txn_test.go
+++ b/adapter/redis_txn_test.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -369,6 +370,37 @@ func TestRedisTxnMissingKeyCreatorsReadAllWideFences(t *testing.T) {
 			requireTxnReadKeysContainWideFences(t, txn, key)
 		})
 	}
+}
+
+func TestRedisStandaloneHSetDedupAvoidsWideHashMaterializationLimit(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	coord := newLocalAdapterCoordinator(st)
+	server := NewRedisServer(nil, "", st, coord, nil, nil)
+	key := []byte("hash:oversized-wide")
+
+	for i := 0; i <= maxWideColumnItems; i++ {
+		field := []byte(fmt.Sprintf("field:%06d", i))
+		require.NoError(t, st.PutAt(ctx, store.HashFieldKey(key, field), []byte("v"), redisTxnTestStartTS, 0))
+	}
+	coord.Clock().Observe(redisTxnTestStartTS)
+
+	_, err := server.loadHashAt(ctx, key, redisTxnTestStartTS)
+	require.ErrorIs(t, err, ErrCollectionTooLarge)
+
+	results, err := server.runTransactionWithDedup([]redcon.Command{{
+		Args: [][]byte{[]byte(cmdHSet), key, []byte("new-field"), []byte("new-value")},
+	}})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, resultInt, results[0].typ)
+	require.Equal(t, int64(1), results[0].integer)
+
+	raw, err := st.GetAt(ctx, store.HashFieldKey(key, []byte("new-field")), server.readTS())
+	require.NoError(t, err)
+	require.Equal(t, []byte("new-value"), raw)
 }
 
 func requireTxnReadKeysContainWideFences(t *testing.T, txn *txnContext, key []byte) {

--- a/adapter/redis_zset_cmds.go
+++ b/adapter/redis_zset_cmds.go
@@ -638,6 +638,7 @@ func (r *RedisServer) zaddTxn(ctx context.Context, key []byte, flags zaddFlags, 
 		return 0, nil
 	}
 
+	elems = append(elems, redisTxnWideZSetFenceElem(key))
 	if lenDelta != 0 {
 		deltaVal := store.MarshalZSetMetaDelta(store.ZSetMetaDelta{LenDelta: lenDelta})
 		elems = append(elems, &kv.Elem[kv.OP]{
@@ -668,6 +669,7 @@ func (r *RedisServer) dispatchAndSignalZSet(
 		IsTxn:    true,
 		StartTS:  normalizeStartTS(readTS),
 		CommitTS: commitTS,
+		ReadKeys: [][]byte{redisTxnWideZSetFenceKey(zsetKey)},
 		Elems:    elems,
 	})
 	if err != nil {
@@ -716,6 +718,7 @@ func (r *RedisServer) zincrbyTxn(ctx context.Context, key []byte, member string,
 	elems = append(elems,
 		&kv.Elem[kv.OP]{Op: kv.Put, Key: memberKey, Value: store.MarshalZSetScore(newScore)},
 		&kv.Elem[kv.OP]{Op: kv.Put, Key: store.ZSetScoreKey(key, newScore, []byte(member)), Value: []byte{}},
+		redisTxnWideZSetFenceElem(key),
 	)
 	if !memberExists {
 		deltaVal := store.MarshalZSetMetaDelta(store.ZSetMetaDelta{LenDelta: 1})
@@ -847,6 +850,7 @@ func (r *RedisServer) persistZSetEntriesTxn(ctx context.Context, key []byte, rea
 				IsTxn:    true,
 				StartTS:  normalizeStartTS(readTS),
 				CommitTS: commitTS,
+				ReadKeys: [][]byte{redisTxnWideZSetFenceKey(key)},
 				Elems:    elems,
 			})
 			return cockerrors.WithStack(dispatchErr)
@@ -898,10 +902,12 @@ func (r *RedisServer) persistZSetRemovalsTxn(ctx context.Context, key []byte, re
 		Key:   store.ZSetMetaDeltaKey(key, commitTS, 0),
 		Value: deltaVal,
 	})
+	elems = append(elems, redisTxnWideZSetFenceElem(key))
 	_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 		IsTxn:    true,
 		StartTS:  normalizeStartTS(readTS),
 		CommitTS: commitTS,
+		ReadKeys: [][]byte{redisTxnWideZSetFenceKey(key)},
 		Elems:    elems,
 	})
 	return cockerrors.WithStack(dispatchErr)
@@ -1132,11 +1138,13 @@ func (r *RedisServer) persistBZPopMinResult(ctx context.Context, key []byte, rea
 			{Op: kv.Del, Key: store.ZSetMemberKey(key, []byte(popped.Member))},
 			{Op: kv.Del, Key: store.ZSetScoreKey(key, popped.Score, []byte(popped.Member))},
 			{Op: kv.Put, Key: store.ZSetMetaDeltaKey(key, commitTS, 0), Value: deltaVal},
+			redisTxnWideZSetFenceElem(key),
 		}
 		_, dispatchErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 			IsTxn:    true,
 			StartTS:  normalizeStartTS(readTS),
 			CommitTS: commitTS,
+			ReadKeys: [][]byte{redisTxnWideZSetFenceKey(key)},
 			Elems:    elems,
 		})
 		return cockerrors.WithStack(dispatchErr)

--- a/adapter/redis_zset_cmds.go
+++ b/adapter/redis_zset_cmds.go
@@ -591,7 +591,8 @@ func (r *RedisServer) applyZAddPair(ctx context.Context, key []byte, p zaddPair,
 
 func (r *RedisServer) zaddTxn(ctx context.Context, key []byte, flags zaddFlags, pairs []zaddPair) (int, error) {
 	readTS := r.readTS()
-	if err := r.requireKeyTypeOrEmpty(ctx, key, readTS, redisTypeZSet); err != nil {
+	typ, err := r.keyTypeOrEmptyAt(ctx, key, readTS, redisTypeZSet)
+	if err != nil {
 		return 0, err
 	}
 
@@ -648,7 +649,8 @@ func (r *RedisServer) zaddTxn(ctx context.Context, key []byte, flags zaddFlags, 
 		})
 	}
 
-	return added, r.dispatchAndSignalZSet(ctx, readTS, commitTS, elems, key)
+	return added, r.dispatchAndSignalZSet(ctx, readTS, commitTS, elems, key,
+		redisTxnWideCreateReadKeys(key, typ, redisTxnWideZSetFenceKey))
 }
 
 // dispatchAndSignalZSet dispatches the elems through the coordinator
@@ -664,12 +666,13 @@ func (r *RedisServer) dispatchAndSignalZSet(
 	readTS, commitTS uint64,
 	elems []*kv.Elem[kv.OP],
 	zsetKey []byte,
+	readKeys [][]byte,
 ) error {
 	_, err := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
 		IsTxn:    true,
 		StartTS:  normalizeStartTS(readTS),
 		CommitTS: commitTS,
-		ReadKeys: [][]byte{redisTxnWideZSetFenceKey(zsetKey)},
+		ReadKeys: readKeys,
 		Elems:    elems,
 	})
 	if err != nil {
@@ -683,7 +686,8 @@ func (r *RedisServer) dispatchAndSignalZSet(
 // Returns the new score after applying increment.
 func (r *RedisServer) zincrbyTxn(ctx context.Context, key []byte, member string, increment float64) (float64, error) {
 	readTS := r.readTS()
-	if err := r.requireKeyTypeOrEmpty(ctx, key, readTS, redisTypeZSet); err != nil {
+	typ, err := r.keyTypeOrEmptyAt(ctx, key, readTS, redisTypeZSet)
+	if err != nil {
 		return 0, err
 	}
 
@@ -728,7 +732,8 @@ func (r *RedisServer) zincrbyTxn(ctx context.Context, key []byte, member string,
 			Value: deltaVal,
 		})
 	}
-	if err := r.dispatchAndSignalZSet(ctx, readTS, commitTS, elems, key); err != nil {
+	if err := r.dispatchAndSignalZSet(ctx, readTS, commitTS, elems, key,
+		redisTxnWideCreateReadKeys(key, typ, redisTxnWideZSetFenceKey)); err != nil {
 		return 0, err
 	}
 	return newScore, nil

--- a/docs/design/2026_05_21_implemented_txn_secondary_idempotency.md
+++ b/docs/design/2026_05_21_implemented_txn_secondary_idempotency.md
@@ -1,14 +1,13 @@
 # Transactional secondary-commit idempotency
 
-> **Status: partial — option 2 reader landed everywhere; writer (emission)
-> gated off by default pending cluster-wide rollout.** M2a (store exact-ts
-> probe), M2b (`prev_commit_ts` in `TxnMeta` V2 + one-phase FSM probe), and
-> M1+M3 for the list-push family (write-set reuse + `OperationGroup.PrevCommitTS`
-> threading through both `ShardedCoordinator` and the legacy `Coordinate`
-> redirect path) have shipped on this branch and are tested. Emission stays
-> off by default (`RedisServer.onePhaseTxnDedup`), so the FSM is byte-identical
-> to today until operators enable it after a full probe-aware rollout — see
-> R5. Remaining: `runTransaction` EXEC-body reuse and M4 (Jepsen).
+> **Status: implemented.** Option 2 is shipped end-to-end: the store exact-ts
+> probe, `prev_commit_ts` in `TxnMeta` V2, one-phase FSM no-op on an exact hit,
+> `OperationGroup.PrevCommitTS` threading, list-push reuse, MULTI/EXEC reuse,
+> and standalone SET/INCR/HSET single-command routing all use the same
+> reusable write-set contract. The rollout gate is now default-on through
+> `RedisServer.onePhaseTxnDedup` with `ELASTICKV_REDIS_ONEPHASE_DEDUP=0` kept
+> as the operator rollback switch; scheduled Redis Jepsen covers the default
+> path.
 >
 > Triggered by the 2026-05-21 Jepsen scheduled run
 > [26198185540](https://github.com/bootjp/elastickv/actions/runs/26198185540)
@@ -463,10 +462,10 @@ preserves availability and adds correctness.
 
 - **Emission gating (R5) — LANDED.** `prev_commit_ts` is emitted only when
   `RedisServer.onePhaseTxnDedup` is on (`WithOnePhaseTxnDedup` /
-  `ELASTICKV_REDIS_ONEPHASE_DEDUP`), **default off** until the whole cluster
-  runs a probe-aware binary. While off, `listPushCore` keeps the legacy
-  recompute-on-retry loop, no V2 meta is produced, the probe never fires, and
-  the FSM is byte-identical to today — no mixed-version divergence window.
+  `ELASTICKV_REDIS_ONEPHASE_DEDUP`). It shipped default-off for the
+  reader-before-writer rollout, then flipped default-on after the probe-aware
+  binary was deployed everywhere. `ELASTICKV_REDIS_ONEPHASE_DEDUP=0` remains
+  the single rollback switch.
 - **`listPushCore` (RPUSH/LPUSH) — LANDED.** When the gate is on, the retry
   loop tracks a `reusableListPush` (the prior attempt's `ops`, `startTS`,
   `commitTS`, and computed `length`). On a retryable error it REUSES that
@@ -514,24 +513,23 @@ preserves availability and adds correctness.
        what changes is that an expired outer ctx is now respected
        promptly instead of being ignored until the fresh budget
        elapses.
-- **Standalone SET — LANDED.** The standalone `r.set` handler now routes
-  through `runTransactionWithDedup` as a single-mop EXEC body when the gate
-  is on (the dedup machinery's "free" extension to any command whose
-  `applyXxx` already exists on `txnContext`). The fast-path optimization
-  (`trySetFastPath`) is intentionally bypassed under the gate — dedup is
-  opt-in, and a non-dedup'd fast path under a dedup-on cluster would split
-  the idempotency contract. Tested by `TestStandaloneSetDedup_*` in
-  `adapter/redis_set_dedup_test.go`.
-- **Standalone INCR / HSET — still open.** Both lack a `txnContext.applyXxx`
-  implementation, so the "route through single-mop EXEC" pattern that
-  worked for SET cannot apply as-is. Bringing them into the dedup'd path
-  requires implementing `applyIncr` / `applyHSet` first (each ~30–50 LOC
-  for the txn-state-aware read-compute-write shape), then the standalone
-  handler routing is a one-liner via `runTransactionWithDedup`. Tracked
-  as separate follow-up PRs; until then, INCR and HSET keep today's
-  buggy-under-churn behaviour, which is the design doc's stated default
-  ("everything else keeps today's behaviour until its hook is added" —
-  Open questions).
+- **Standalone SET — LANDED.** The standalone `r.set` handler routes through
+  `runTransactionWithDedup` as a single-mop EXEC body when
+  `onePhaseTxnDedup` is on. `txnContext.applySet` now stages a final string
+  replacement and uses the same logical-key cleanup as `executeSet`, so
+  SET-over-list/hash/set/zset/stream preserves Redis overwrite semantics on
+  the dedup path. The fast-path optimization (`trySetFastPath`) is
+  intentionally bypassed under the gate so the standalone path does not split
+  the idempotency contract. Tested by `TestStandaloneSetDedup_*` and
+  `TestRedis_SET_OverwritesList_UnderDefaultGate`.
+- **Standalone INCR / HSET — LANDED.** `txnContext.applyIncr` preserves the
+  existing string TTL while staging the post-increment value, and
+  `txnContext.applyHSet` stages wide-column hash field updates plus the
+  corresponding hash meta delta or legacy-blob migration. The standalone
+  `INCR`, `HSET`, and `HMSET` handlers now route through the single-command
+  dedup helper when `onePhaseTxnDedup` is on; the legacy handlers remain as
+  the opt-out path. Tests pin ambiguous landed attempts returning cached
+  `INCR` / `HSET` results without reapplying.
 
 ### M4 — Validation
 
@@ -550,7 +548,7 @@ preserves availability and adds correctness.
   the Redis workload. The dedup feature ships behind the Redis
   adapter's `onePhaseTxnDedup` flag (RPUSH/LPUSH via
   `listPushCoreWithDedup`, MULTI/EXEC via `runTransactionWithDedup`,
-  standalone SET via single-mop EXEC routing); DynamoDB / S3 / SQS do
+  standalone SET/INCR/HSET via single-mop EXEC routing); DynamoDB / S3 / SQS do
   not route through the dedup loop, so re-running them under the gate
   would add hours of CI for zero signal on the new code path.
 - **Demo cluster gate confirmation.** The launch step asserts
@@ -586,12 +584,13 @@ fresh meta anyway, so the length is naturally correct.
 
 This invariance is specific to commands whose retry reuses a fixed write set.
 A MULTI/EXEC body with read-dependent results (e.g. an `INCR` whose return is
-the post-increment value) needs the same treatment — remember the
+the post-increment value) uses the same treatment: remember the
 client-visible result computed on the first attempt and return it on a dedup
-no-op — which is tractable but per-command. Mitigation unchanged: scope the
-first PR to RPUSH/LPUSH (the commands the Jepsen workload exercises); commands
-without a reuse path keep today's (buggy-under-churn, gate-off-by-default)
-recompute, so the change is strictly an improvement, never a regression.
+no-op. That contract now covers RPUSH/LPUSH, MULTI/EXEC, standalone SET,
+standalone INCR, standalone HSET, and standalone HMSET. Future write commands
+that join `txnApplyHandlers` must follow the same "stage once, cache result,
+reuse write-set" shape before their standalone handlers route through the
+dedup helper.
 
 ### R2 — Probe read cost on the retry path
 
@@ -732,20 +731,18 @@ flakiness, tracked separately from the correctness fix.
 
 ## Open questions
 
-- **Result reconstruction coverage.** The dedup no-op must reconstruct each
-  command's client-visible result at `prev_commit_ts`. RPUSH/LPUSH (length)
-  and single-mop EXEC are in scope for the first PR; multi-mop EXEC and
-  other write commands (SET/INCR/HSET/…) need per-command reconstruction
-  hooks. Which commands beyond RPUSH/LPUSH must land in the first PR vs.
-  follow-ups? (Default: only the list-append family the Jepsen workload
-  exercises; everything else keeps today's behaviour until its hook is
-  added.)
+- **Result reconstruction coverage — CLOSED 2026-07-07.** The dedup no-op
+  returns the result captured while staging the first attempt. The coverage
+  now includes RPUSH/LPUSH, multi-mop MULTI/EXEC, and standalone
+  SET/INCR/HSET/HMSET. Commands not implemented in `txnApplyHandlers` remain
+  unsupported inside this retry contract and must add staging + cached-result
+  tests before standalone routing.
 - **Race-freedom linchpin — RE-VERIFIED (2026-05-30).** The race-freedom
   argument needs **E1 applies before E2, or never** — never the other way
   round. An earlier verification (2026-05-26) appealed to `applyRequests`
   using `context.Background()` so that `Engine.Propose` could not abandon on
-  a caller timeout. That argument was based on a stale read; codex correctly
-  pointed out (PR #796 review) that the current single-shard txn path
+  a caller timeout. That argument was based on a stale read; review correctly
+  pointed out that the current single-shard txn path
   threads the caller ctx through (`dispatchSingleShardTxn` →
   `TransactionManager.Commit(ctx, …)` → `applyRequests(ctx, …)` →
   `Engine.Propose(ctx, …)`), and `Engine.Propose` has a live `ctx.Done()`
@@ -790,7 +787,7 @@ flakiness, tracked separately from the correctness fix.
 - **FSM probe determinism — retention guard reverted (2026-05-30, round-11).**
   Round-10 surfaced `ErrReadTSCompacted` from `CommittedVersionAt` when
   the probed `commit_ts` fell below `minRetainedTS`, mirroring
-  `GetAt`/`ExistsAt` semantics (codex P2 round-10). Codex P1 round-11
+  `GetAt`/`ExistsAt` semantics. Round-11
   correctly flagged that branching the FSM dedup decision on this signal
   is non-deterministic across raft replicas: FSM compaction advances
   `minRetainedTS` from local wall clock and per-replica scheduler
@@ -872,3 +869,10 @@ flakiness, tracked separately from the correctness fix.
   duplicate; not-landed→apply; genuine cross-txn conflict→recompute) against
   real OCC + the real probe, plus the gate-off legacy path. Remaining:
   `runTransaction` EXEC-body reuse (per-command result memo) and M4 (Jepsen).
+- (2026-07-07) **Standalone writer coverage completed.** `txnContext.applySet`
+  now stages final string replacement with full logical-key cleanup, removing
+  the old SET-over-collection parity gap. `txnContext.applyIncr` and
+  `txnContext.applyHSet` landed, and standalone SET/INCR/HSET/HMSET route
+  through `runTransactionWithDedup` when `onePhaseTxnDedup` is on. Tests cover
+  landed-then-error retries returning cached SET/INCR/HSET results and SET
+  replacing a wide-column hash without leaving field rows behind.

--- a/docs/design/2026_06_03_partial_dynamodb_onephase_dedup.md
+++ b/docs/design/2026_06_03_partial_dynamodb_onephase_dedup.md
@@ -14,7 +14,7 @@ Date: 2026-06-03
 > (`OperationGroup.PrevCommitTS` → `onePhaseTxnRequestWithPrevCommit`) already
 > exist and are shared across adapters; only the DynamoDB adapter retry loop
 > and a default-off gate are new. Follows the parent design
-> [`2026_05_21_proposed_txn_secondary_idempotency.md`](2026_05_21_proposed_txn_secondary_idempotency.md);
+> [`2026_05_21_implemented_txn_secondary_idempotency.md`](2026_05_21_implemented_txn_secondary_idempotency.md);
 > read that first — this doc reuses its correctness argument verbatim and only
 > develops the DynamoDB-specific differences.
 >
@@ -484,7 +484,7 @@ change (the probe already exists), no proto change, no new store primitive.
 - (2026-06-03) Initial proposal, triggered by Jepsen run 26856696842
   (`:duplicate-elements` on the DynamoDB list-append workload). Open for
   review. Diagnosis confirmed: same anomaly class as the parent design
-  (`2026_05_21_proposed_txn_secondary_idempotency.md`); the DynamoDB
+  (`2026_05_21_implemented_txn_secondary_idempotency.md`); the DynamoDB
   single-item write recomputes its write set on a self-inflicted
   `WriteConflict` under leadership churn and double-applies. Fix: extend
   option-2 reuse-dedup to `retryItemWriteWithGeneration`.

--- a/docs/design/2026_06_10_implemented_redis_onephase_dedup_default_on.md
+++ b/docs/design/2026_06_10_implemented_redis_onephase_dedup_default_on.md
@@ -1,13 +1,12 @@
 # Redis one-phase txn dedup — flip default to on
 
-Status: Proposed
+Status: Implemented
 Author: bootjp
 Date: 2026-06-10
 
-> **Status: proposed.** Flip
-> `adapter.RedisServer.onePhaseTxnDedup` from default-off to default-on,
-> closing the rollout of the option-2 idempotency design landed by
-> [`2026_05_21_proposed_txn_secondary_idempotency.md`][parent]. No new
+> **Status: implemented.** `adapter.RedisServer.onePhaseTxnDedup` is
+> default-on, closing the rollout of the option-2 idempotency design landed by
+> [`2026_05_21_implemented_txn_secondary_idempotency.md`][parent]. No new
 > mechanism — the FSM probe (`dedupProbeOnePhase` in `kv/fsm.go`), the
 > wire change (`TxnMeta.PrevCommitTS`, V2-only when non-zero), and every
 > adapter-side reuse path (RPUSH/LPUSH, MULTI/EXEC, standalone SET, etc.)
@@ -27,7 +26,7 @@ Date: 2026-06-10
 > [#937](https://github.com/bootjp/elastickv/issues/937) tracks that
 > failure; this proposal closes it by retiring the unprotected default.
 
-[parent]: 2026_05_21_proposed_txn_secondary_idempotency.md
+[parent]: 2026_05_21_implemented_txn_secondary_idempotency.md
 
 ## Background
 
@@ -111,36 +110,22 @@ Comment and `WithOnePhaseTxnDedup`'s godoc are updated to describe the
 new default; the in-file pointer to R5 stays (now reframed as "the
 ordering constraint that authorized this default flip").
 
-### M1a — Carve out standalone `SET` behind a separate sub-gate
+### M1a — Standalone `SET` parity
 
-PR #943 round-1 codex P1 flagged that `txnContext.applySet`
-(`adapter/redis.go:2356-2360`) returns `WRONGTYPE` when the existing
-key is a list/hash/set/zset/stream, while the legacy `setLegacy` →
-`executeSet` → `replaceWithStringTxn` path correctly deletes the
-collection's logical elements and writes the string. Real Redis lets
-`SET k v` overwrite any existing type unconditionally; flipping
-`onePhaseTxnDedup` default-on therefore would have silently changed
-normal Redis overwrite behaviour for every standalone-`SET`-against-
-collection configuration.
+The first default-on rollout kept standalone `SET` behind a compatibility
+sub-gate because `txnContext.applySet` did not yet match legacy
+`executeSet` semantics for SET-over-collection. That parity gap is now
+closed in the parent design: `applySet` stages a final string replacement
+and uses logical-key cleanup before writing the new string, so standalone
+SET follows `onePhaseTxnDedup` directly. `RedisServer.standaloneSetDedup`,
+`WithStandaloneSetDedup`, and `ELASTICKV_REDIS_ONEPHASE_DEDUP_SET` remain
+as compatibility no-ops for older deployments and tests that still set them.
 
-This proposal does not bring `applySet` to parity (collection-deletion
-inside the dedup txn is a larger surgery, tracked as a separate
-follow-up). Instead it introduces a dedicated sub-gate
-`RedisServer.standaloneSetDedup` (default off, opt-in via
-`WithStandaloneSetDedup(true)` or
-`ELASTICKV_REDIS_ONEPHASE_DEDUP_SET=1`). The standalone-`SET` branch
-in `set()` now requires **both** `onePhaseTxnDedup` **and**
-`standaloneSetDedup` to be true before routing through
-`runTransactionWithDedup`; the previous behaviour is preserved as the
-default. MULTI/EXEC and list-push paths (the parent design's actual
-M4-validated workloads) are unaffected.
-
-The new field, option, env var, and the regression test
-`TestRedis_SET_OverwritesList_UnderDefaultGate`
-(`adapter/redis_set_overwrite_default_test.go`) all land in this PR.
-The test seeds `RPUSH k x`, calls `SET k v`, asserts `OK` + a
-subsequent `GET` returns `v` — it fails on the pre-fix build
-(WRONGTYPE) and passes on the fixed build.
+Regression coverage:
+`TestRedis_SET_OverwritesList_UnderDefaultGate` verifies `RPUSH k x` followed
+by `SET k v` returns `OK` and makes `GET k` return `v`;
+`TestStandaloneSetDedup_OverwritesWideHash` verifies the dedup path also
+tombstones wide-column hash rows before writing the replacement string.
 
 ### M2 — Control workflow disposition
 

--- a/kv/shard_key_test.go
+++ b/kv/shard_key_test.go
@@ -29,6 +29,19 @@ func TestRouteKey_NormalizesTxnWrappedS3Key(t *testing.T) {
 	require.Equal(t, s3keys.RouteKey("bucket-a", 7, "path/to/object"), routeKey(txnLockKey(embedded)))
 }
 
+func TestRouteKey_NormalizesRedisTxnWideFenceKeys(t *testing.T) {
+	t.Parallel()
+
+	userKey := []byte("user:key")
+	for _, raw := range [][]byte{
+		[]byte("!redis|txn-wide-hash|user:key"),
+		[]byte("!redis|txn-wide-set|user:key"),
+		[]byte("!redis|txn-wide-list|user:key"),
+	} {
+		require.Equal(t, userKey, routeKey(raw))
+	}
+}
+
 func TestRouteKey_NormalizesDynamoKeysToTable(t *testing.T) {
 	t.Parallel()
 

--- a/kv/shard_key_test.go
+++ b/kv/shard_key_test.go
@@ -37,6 +37,7 @@ func TestRouteKey_NormalizesRedisTxnWideFenceKeys(t *testing.T) {
 		[]byte("!redis|txn-wide-hash|user:key"),
 		[]byte("!redis|txn-wide-set|user:key"),
 		[]byte("!redis|txn-wide-list|user:key"),
+		[]byte("!redis|txn-wide-zset|user:key"),
 	} {
 		require.Equal(t, userKey, routeKey(raw))
 	}


### PR DESCRIPTION
## Summary
- complete Redis standalone transaction dedup reuse paths
- mark the transaction secondary idempotency and Redis one-phase dedup default-on docs implemented
- update the DynamoDB dedup doc reference to the implemented Redis baseline

## Design docs
- docs/design/2026_05_21_implemented_txn_secondary_idempotency.md
- docs/design/2026_06_10_implemented_redis_onephase_dedup_default_on.md
- docs/design/2026_06_03_partial_dynamodb_onephase_dedup.md

## Validation
- go test ./adapter -run 'TestRedis.*Dedup|TestRedis.*OnePhase|TestRedis.*Txn|TestRedis.*Set|TestRedis.*Hash|TestRedis.*List|TestOnePhase|TestStandalone' -count=1
- golangci-lint --config=.golangci.yaml run ./adapter --timeout=5m
- git verify-commit HEAD

Author: bootjp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Redis の one-phase 冪等（dedup）をデフォルトで有効化し、単体更新・トランザクション・TTL で一貫した挙動に対応しました。
  * ワイドフェンスを用いた読み取り整合性強化により、リスト/ハッシュ/セット/ソート済みセットの更新競合に対する再試行が安定しました。
* **バグ修正**
  * `SET`/`INCR`/`HSET` などで型不正や競合時の結果が適切に返るよう改善しました。
  * `MULTI/EXEC` の TTL 互換（置換TTL含む）や期限切れキーの再作成挙動を修正しました。
* **ドキュメント**
  * 実装状況と仕様範囲を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->