### PR TITLE
Add encryption rotate on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ gen:
 # that motivates the implementation gaps).
 TLA_VERSION  := v1.8.0
 TLA_JAR      := .cache/tla/tla2tools.jar
-TLA_SHA256   := 237332bdcc79a35c7d26efa7b82c77c85c2744591c5598673a8a45085ff2a4fb
+TLA_SHA256   := 9e27b5e19a69ae1f56aabf8403a6ed5598dbfa6e638908e5278ac39736c1543d
 TLA_URL      := https://github.com/tlaplus/tlaplus/releases/download/$(TLA_VERSION)/tla2tools.jar
 TLA_LIB      := ../lib
 

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -288,6 +288,12 @@ func NewDynamoDBServer(listen net.Listener, st store.MVCCStore, coordinate kv.Co
 	return d
 }
 
+// SetListener installs the listener Run serves from. Startup wiring uses this
+// to build admin-forward sources before binding the public socket.
+func (d *DynamoDBServer) SetListener(listen net.Listener) {
+	d.listen = listen
+}
+
 func (d *DynamoDBServer) Run() error {
 	if err := d.httpServer.Serve(d.listen); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return errors.WithStack(err)

--- a/adapter/dynamodb.go
+++ b/adapter/dynamodb.go
@@ -97,6 +97,7 @@ var dynamoOperationTargets = map[string]string{
 const (
 	dynamoErrValidation          = "ValidationException"
 	dynamoErrInternal            = "InternalServerError"
+	dynamoErrServiceUnavailable  = "ServiceUnavailable"
 	dynamoErrConditionalFailed   = "ConditionalCheckFailedException"
 	dynamoErrTransactionCanceled = "TransactionCanceledException"
 	dynamoErrResourceNotFound    = "ResourceNotFoundException"

--- a/adapter/dynamodb_errors.go
+++ b/adapter/dynamodb_errors.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/cockroachdb/errors"
 	json "github.com/goccy/go-json"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type dynamoAPIError struct {
@@ -35,6 +37,10 @@ func writeDynamoErrorFromErr(w http.ResponseWriter, err error) {
 	var apiErr *dynamoAPIError
 	if errors.As(err, &apiErr) {
 		writeDynamoError(w, apiErr.status, apiErr.errorType, apiErr.message)
+		return
+	}
+	if status.Code(errors.Cause(err)) == codes.Unavailable {
+		writeDynamoError(w, http.StatusServiceUnavailable, dynamoErrServiceUnavailable, "service unavailable")
 		return
 	}
 	writeDynamoError(w, http.StatusInternalServerError, dynamoErrInternal, err.Error())

--- a/adapter/s3.go
+++ b/adapter/s3.go
@@ -28,6 +28,8 @@ import (
 	"github.com/bootjp/elastickv/store"
 	"github.com/cockroachdb/errors"
 	json "github.com/goccy/go-json"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -2969,6 +2971,10 @@ func writeS3MutationError(w http.ResponseWriter, err error, bucket string, key s
 	}
 	if isRetryableS3MutationErr(err) {
 		writeS3Error(w, http.StatusConflict, "OperationAborted", "conflicting conditional operation in progress", bucket, key)
+		return
+	}
+	if status.Code(errors.Cause(err)) == codes.Unavailable {
+		writeS3Error(w, http.StatusServiceUnavailable, "ServiceUnavailable", "service unavailable", bucket, key)
 		return
 	}
 	writeS3InternalError(w, err)

--- a/adapter/s3.go
+++ b/adapter/s3.go
@@ -343,6 +343,12 @@ func NewS3Server(listen net.Listener, s3Addr string, st store.MVCCStore, coordin
 	return s
 }
 
+// SetListener installs the listener Run serves from. Startup wiring uses this
+// to build admin-forward sources before binding the public socket.
+func (s *S3Server) SetListener(listen net.Listener) {
+	s.listen = listen
+}
+
 func (s *S3Server) Run() error {
 	if s.httpServer == nil {
 		return errors.New("s3 server httpServer is nil")

--- a/adapter/sqs_catalog.go
+++ b/adapter/sqs_catalog.go
@@ -18,6 +18,8 @@ import (
 	"github.com/bootjp/elastickv/store"
 	"github.com/cockroachdb/errors"
 	json "github.com/goccy/go-json"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // AWS SQS defaults, reproduced from the public API reference so clients that
@@ -241,6 +243,10 @@ func writeSQSErrorFromErr(w http.ResponseWriter, err error) {
 	var rateLimit *purgeRateLimitedError
 	if errors.As(err, &rateLimit) {
 		writeSQSError(w, http.StatusBadRequest, sqsErrPurgeInProgress, rateLimit.Error())
+		return
+	}
+	if status.Code(errors.Cause(err)) == codes.Unavailable {
+		writeSQSError(w, http.StatusServiceUnavailable, sqsErrServiceUnavailable, "service unavailable")
 		return
 	}
 	// Internal errors can wrap Pebble file names, Raft peer ids, stack

--- a/adapter/startup_gate_error_test.go
+++ b/adapter/startup_gate_error_test.go
@@ -1,0 +1,56 @@
+package adapter
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	crdberrors "github.com/cockroachdb/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestHTTPAdaptersMapStartupGateUnavailableTo503(t *testing.T) {
+	t.Parallel()
+	err := crdberrors.Wrap(status.Error(codes.Unavailable, "startup rotation has not completed"), "dispatch")
+
+	t.Run("dynamodb", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		writeDynamoErrorFromErr(rec, err)
+
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status=%d, want 503", rec.Code)
+		}
+		if body := rec.Body.String(); !strings.Contains(body, dynamoErrServiceUnavailable) {
+			t.Fatalf("body %q does not contain %q", body, dynamoErrServiceUnavailable)
+		}
+	})
+
+	t.Run("sqs", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		writeSQSErrorFromErr(rec, err)
+
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status=%d, want 503", rec.Code)
+		}
+		if body := rec.Body.String(); !strings.Contains(body, sqsErrServiceUnavailable) {
+			t.Fatalf("body %q does not contain %q", body, sqsErrServiceUnavailable)
+		}
+	})
+
+	t.Run("s3", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		writeS3MutationError(rec, err, "bucket-a", "key-a")
+
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status=%d, want 503", rec.Code)
+		}
+		if body := rec.Body.String(); !strings.Contains(body, "<Code>ServiceUnavailable</Code>") {
+			t.Fatalf("body %q does not contain ServiceUnavailable", body)
+		}
+	})
+}

--- a/docs/design/2026_04_29_partial_data_at_rest_encryption.md
+++ b/docs/design/2026_04_29_partial_data_at_rest_encryption.md
@@ -29,7 +29,7 @@ Date: 2026-04-29
 | 6C-4 | Phase-2-specific §9.1 guards: `ErrEnvelopeCutoverDivergence` (sidecar `raft_envelope_cutover_index` disagrees with snapshot header), `ErrEncryptionNotBootstrapped` (`enable-raft-envelope` before bootstrap), `ErrLocalEpochOutOfRange` on wire-side `local_epoch` decode boundaries. Bundles with Stage 6E (`enable-raft-envelope` admin RPC + Phase-2 cutover). | shipped | this PR |
 | 6D | §6.6 `enable-storage-envelope` admin RPC + §7.1 Phase-1 storage cutover (§6.2 toggle ON) + Voters ∪ Learners capability gate (depends on 6B for mutator wiring AND 6C-1+6C-2 for §9.1 startup-refusal guards; bundles 6C-3 for the membership-view-dependent collision check — see rationale) | open | — |
 | 6E | §6.6 `enable-raft-envelope` admin RPC + §7.1 Phase-2 raft cutover + `raft_envelope_cutover_index` sidecar record + `internal/raftengine/etcd/engine.go` `applyNormalEntry` unwrap hook activation + `ErrRaftUnwrapFailed` HaltApply path + `kv/coordinator.go` / `kv/sharded_coordinator.go` wrap-on-propose switch (Phase-2 leader-side §6.3 proposal-payload wrap) + §7.1 steps 1–6 proposal quiescence barrier (block new user proposal intake, drain in-flight queue, source-tag exemption for the cutover entry itself) + production runtime wiring for startup/apply-time wrap install and post-cutover admin proposals + 6C-4 fail-closed guards. | shipped | 2026_05_31_implemented_6e_enable_raft_envelope.md |
-| 6F | §6.5 `--encryption-rotate-on-startup` request flag + leader-elected rotation proposal | open | — |
+| 6F | §6.5 `--encryption-rotate-on-startup` request flag + leader-elected rotation proposal on the default encryption Raft group. The leader rotates every active DEK purpose once before listeners open; followers keep an in-memory pending request and fire only if they acquire leadership in the same process uptime. | shipped | this PR |
 | 7 | Writer registry + deterministic nonce (§4.1) | open | — |
 | 8 | Snapshot header v2 + WAL coverage (§4.4, §4.5) | open | — |
 | 9 | KMS-backed wrappers, compression, rotation/retire/rewrite, Jepsen (§5.2, §5.4, §6.4, §8) | open | — |
@@ -299,8 +299,8 @@ production-safe state, and unblocks the next one.
 - **6F is optional ergonomics.** `--encryption-rotate-on-startup`
   is documented in §6.5 as a request, not a guarantee, and the
   operator can always run `elastickv-admin encryption rotate-dek`
-  out-of-band. 6F lands the convenience flag after the five
-  load-bearing PRs (6A–6E) are in.
+  out-of-band. 6F ships the convenience flag after the five
+  load-bearing stages (6A–6E) are in.
 
 ---
 

--- a/internal/encryption/applier.go
+++ b/internal/encryption/applier.go
@@ -123,7 +123,8 @@ type Applier struct {
 	raftLocalEpoch uint16
 	// raftCutoverWrapInstaller is the Stage 6E-2e-1 hook that
 	// applyEnableRaftEnvelope invokes on every replica's local FSM
-	// apply of the cutover marker. Production wiring (6E-2e-3:
+	// apply of the cutover marker, and applyRotateDEK invokes after
+	// post-cutover raft DEK rotations. Production wiring (6E-2e-3:
 	// main.go) supplies a closure that publishes the wrap closure to
 	// every participating kv.ShardGroup via SetRaftPayloadWrap, so a
 	// follower that becomes leader post-cutover already has wrap
@@ -153,8 +154,9 @@ type Applier struct {
 
 // RaftCutoverWrapInstaller is the Stage 6E-2e-1 callback the Applier
 // invokes on every replica's local FSM apply of the
-// EnableRaftEnvelope cutover marker to publish the §4.2 raft envelope
-// wrap closure on this node.
+// EnableRaftEnvelope cutover marker, and after post-cutover raft
+// RotateDEK applies, to publish the §4.2 raft envelope wrap closure
+// on this node.
 //
 // Contract:
 //   - cutoverIdx is the Raft index recorded in the sidecar
@@ -419,10 +421,11 @@ func WithRaftLocalEpoch(epoch uint16) ApplierOption {
 }
 
 // WithRaftCutoverWrapInstaller installs the Stage 6E-2e-1 hook the
-// Applier invokes from applyEnableRaftEnvelope to publish the wrap
-// closure on this node. nil is a no-op (the option is omitted on the
-// test surface and on the pre-6E-2e-1 production posture); a
-// non-nil installer is invoked on both fresh-success and
+// Applier invokes from applyEnableRaftEnvelope and post-cutover raft
+// RotateDEK applies to publish the wrap closure on this node. nil is
+// a no-op (the option is omitted on the test surface and on the
+// pre-6E-2e-1 production posture); a non-nil installer is invoked on
+// both fresh-success and
 // already-active apply paths but NOT on the stale-DEK no-op branch.
 //
 // See the RaftCutoverWrapInstaller type comment for the contract;
@@ -968,11 +971,15 @@ func (a *Applier) applyRotateDEK(raftIdx uint64, p fsmwire.RotationPayload) erro
 	if err := a.keystore.Set(p.DEKID, dek); err != nil {
 		return errors.Wrap(err, "applier: keystore set rotation DEK")
 	}
-	if err := a.writeRotationSidecar(raftIdx, p); err != nil {
+	sc, err := a.writeRotationSidecar(raftIdx, p)
+	if err != nil {
 		return err
 	}
 	if err := a.ApplyRegistration(p.ProposerRegistration); err != nil {
 		return errors.Wrap(err, "applier: rotation proposer-registration insert")
+	}
+	if p.Purpose == fsmwire.PurposeRaft && sc.RaftEnvelopeCutoverIndex != 0 {
+		return a.invokeRaftCutoverWrapInstaller(sc.RaftEnvelopeCutoverIndex, sc.Active.Raft, "rotate-dek apply")
 	}
 	return nil
 }
@@ -1325,12 +1332,11 @@ func (a *Applier) applyEnableRaftEnvelope(raftIdx uint64, p fsmwire.RotationPayl
 	return a.invokeRaftCutoverWrapInstaller(raftIdx, sc.Active.Raft, "fresh-success apply")
 }
 
-// invokeRaftCutoverWrapInstaller is the Stage 6E-2e-1 dispatch
-// shared between fresh-success and already-active branches of
-// applyEnableRaftEnvelope. nil installer is a no-op (preserves the
-// pre-6E-2e-1 test surface); a non-nil installer's error is wrapped
-// with the branch tag so operator logs distinguish a failure on
-// fresh apply from one on FSM replay.
+// invokeRaftCutoverWrapInstaller is the Stage 6E-2e-1 dispatch shared
+// by raft cutover applies and post-cutover raft DEK rotations. nil
+// installer is a no-op (preserves the pre-6E-2e-1 test surface); a
+// non-nil installer's error is wrapped with the branch tag so operator
+// logs distinguish the failing apply path.
 func (a *Applier) invokeRaftCutoverWrapInstaller(cutoverIdx uint64, activeRaftDEKID uint32, branchTag string) error {
 	if a.raftCutoverWrapInstaller == nil {
 		return nil
@@ -1346,17 +1352,17 @@ func (a *Applier) invokeRaftCutoverWrapInstaller(cutoverIdx uint64, activeRaftDE
 // p.DEKID, then crash-durably writes. Existing keys[] entries are
 // preserved (rotation does not retire old DEKs — that is a
 // separate sub-tag in Stage 6E).
-func (a *Applier) writeRotationSidecar(raftIdx uint64, p fsmwire.RotationPayload) error {
+func (a *Applier) writeRotationSidecar(raftIdx uint64, p fsmwire.RotationPayload) (*Sidecar, error) {
 	sc, err := ReadSidecar(a.sidecarPath)
 	if err != nil {
-		return errors.Wrap(err, "applier: read sidecar for rotation")
+		return nil, errors.Wrap(err, "applier: read sidecar for rotation")
 	}
 	if sc.Keys == nil {
 		sc.Keys = map[string]SidecarKey{}
 	}
 	purpose, err := sidecarPurposeFor(p.Purpose)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	// Stage 7b' §3.1 and Stage 6E: write THIS node's pinned
 	// per-purpose local_epoch into Keys[newDEK].LocalEpoch so the
@@ -1381,10 +1387,10 @@ func (a *Applier) writeRotationSidecar(raftIdx uint64, p fsmwire.RotationPayload
 		LocalEpoch: keyLocalEpoch,
 	}
 	if err := WriteSidecar(a.sidecarPath, sc); err != nil {
-		return errors.Wrap(err, "applier: write sidecar for rotation")
+		return nil, errors.Wrap(err, "applier: write sidecar for rotation")
 	}
 	a.stateCache.RefreshFromSidecar(sc)
-	return nil
+	return sc, nil
 }
 
 // sidecarPurposeFor maps the fsmwire.Purpose enum to the

--- a/internal/encryption/applier_test.go
+++ b/internal/encryption/applier_test.go
@@ -2638,6 +2638,44 @@ func TestApplyRotation_EnableRaftEnvelope_FreshSuccess_InvokesInstaller(t *testi
 	}
 }
 
+func TestApplyRotation_RaftRotateDEK_CutoverActiveRepublishesInstaller(t *testing.T) {
+	t.Parallel()
+	_, sidecarPath := bootstrappedDir(t)
+	app, rec := newCutoverApplierWithInstaller(t, sidecarPath)
+	const raftCutoverIdx uint64 = 600
+	if err := app.ApplyRotation(raftCutoverIdx, fsmwire.RotationPayload{
+		SubTag:  fsmwire.RotateSubEnableRaftEnvelope,
+		DEKID:   cutoverBootstrapRaftDEKID,
+		Purpose: fsmwire.PurposeRaft,
+		Wrapped: []byte{},
+		ProposerRegistration: fsmwire.RegistrationPayload{
+			DEKID: cutoverBootstrapRaftDEKID, FullNodeID: 0xBBBB, LocalEpoch: 1,
+		},
+	}); err != nil {
+		t.Fatalf("ApplyRotation raft-cutover: %v", err)
+	}
+	const newRaftDEKID uint32 = 99
+	if err := app.ApplyRotation(raftCutoverIdx+1, fsmwire.RotationPayload{
+		SubTag:               fsmwire.RotateSubRotateDEK,
+		DEKID:                newRaftDEKID,
+		Purpose:              fsmwire.PurposeRaft,
+		Wrapped:              []byte("new-raft-dek"),
+		ProposerRegistration: fsmwire.RegistrationPayload{DEKID: newRaftDEKID, FullNodeID: 0xBBBB, LocalEpoch: 2},
+	}); err != nil {
+		t.Fatalf("ApplyRotation raft RotateDEK: %v", err)
+	}
+	if got, want := len(rec.calls), 2; got != want {
+		t.Fatalf("installer called %d times, want %d (cutover + raft RotateDEK republish)", got, want)
+	}
+	last := rec.calls[len(rec.calls)-1]
+	if last.cutoverIdx != raftCutoverIdx {
+		t.Errorf("installer cutoverIdx after RotateDEK = %d, want %d", last.cutoverIdx, raftCutoverIdx)
+	}
+	if last.activeRaftDEKID != newRaftDEKID {
+		t.Errorf("installer activeRaftDEKID after RotateDEK = %d, want %d", last.activeRaftDEKID, newRaftDEKID)
+	}
+}
+
 // TestApplyRotation_EnableRaftEnvelope_AlreadyActive_InvokesInstaller
 // pins the FSM-replay safety contract: a duplicate cutover apply
 // (sidecar.RaftEnvelopeCutoverIndex already non-zero) MUST still

--- a/kv/coordinator.go
+++ b/kv/coordinator.go
@@ -93,6 +93,15 @@ func WithLeaseReadObserver(observer LeaseReadObserver) CoordinatorOption {
 	}
 }
 
+// SetHLCLeaseRenewalBlocker installs a predicate that suppresses background
+// HLC lease-renewal proposals while it returns true.
+func (c *Coordinate) SetHLCLeaseRenewalBlocker(blocked func() bool) {
+	if c == nil {
+		return
+	}
+	c.hlcRenewalBlocked = blocked
+}
+
 // normalizeLeaseObserver flattens a typed-nil LeaseReadObserver to an
 // untyped nil interface so downstream `observer != nil` checks behave
 // as expected.
@@ -187,6 +196,9 @@ type Coordinate struct {
 	connCache GRPCConnCache
 	log       *slog.Logger
 	lease     leaseState
+	// hlcRenewalBlocked lets startup code temporarily suppress background HLC
+	// lease proposals while another startup-only Raft mutation must run first.
+	hlcRenewalBlocked func() bool
 	// deregisterLeaseCb removes the leader-loss callback registered
 	// against engine at construction. Long-lived Coordinates don't
 	// need to call it (the engine will be closed after them), but
@@ -790,6 +802,10 @@ func (c *Coordinate) RunHLCLeaseRenewal(ctx context.Context) {
 	for {
 		select {
 		case <-timer.C:
+			if c.hlcRenewalBlocked != nil && c.hlcRenewalBlocked() {
+				timer.Reset(hlcRenewalInterval)
+				continue
+			}
 			if c.IsLeaderAcceptingWrites() {
 				ceilingMs := time.Now().UnixMilli() + hlcPhysicalWindowMs
 				if err := c.ProposeHLCLease(ctx, ceilingMs); err != nil {

--- a/kv/lease_warmup_test.go
+++ b/kv/lease_warmup_test.go
@@ -3,6 +3,7 @@ package kv
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -136,6 +137,35 @@ func TestCoordinate_ProposeHLCLease_NoLeaseProviderNoPanic(t *testing.T) {
 
 	require.NoError(t, c.ProposeHLCLease(context.Background(), time.Now().UnixMilli()+hlcPhysicalWindowMs))
 	require.False(t, c.lease.valid(monoclock.Now()))
+}
+
+func TestCoordinate_RunHLCLeaseRenewal_BlockerSuppressesProposals(t *testing.T) {
+	eng := &fakeLeaseEngine{applied: 11, leaseDur: time.Hour}
+	c := NewCoordinatorWithEngine(nil, eng)
+	var blocked atomic.Bool
+	blocked.Store(true)
+	c.SetHLCLeaseRenewalBlocker(blocked.Load)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		c.RunHLCLeaseRenewal(ctx)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+
+	time.Sleep(hlcRenewalInterval + 100*time.Millisecond)
+	require.Equal(t, int32(0), eng.proposeCalls.Load(),
+		"blocked HLC renewal must not propose while startup rotation is active")
+
+	blocked.Store(false)
+	require.Eventually(t, func() bool {
+		return eng.proposeCalls.Load() > 0
+	}, 2*time.Second, 10*time.Millisecond,
+		"HLC renewal should resume after startup rotation blocker clears")
 }
 
 // TestShardedCoordinator_RenewHLCLease_WarmsDefaultGroupLease proves the

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -354,6 +354,9 @@ type ShardedCoordinator struct {
 	// disabled keyviz wires through to a no-op without branching on
 	// the hot path.
 	sampler keyviz.Sampler
+	// hlcRenewalBlocked lets startup code temporarily suppress background HLC
+	// lease proposals while another startup-only Raft mutation must run first.
+	hlcRenewalBlocked func() bool
 	// registrationGate is the Stage 7a §4.1 first-write barrier: when
 	// set, self-originated mutating writes that would land as §4.1
 	// storage envelopes block until this node's writer registration
@@ -516,6 +519,15 @@ func hasMutatingElems(reqs *OperationGroup[OP]) bool {
 func (c *ShardedCoordinator) WithLeaseReadObserver(observer LeaseReadObserver) *ShardedCoordinator {
 	c.leaseObserver = normalizeLeaseObserver(observer)
 	return c
+}
+
+// SetHLCLeaseRenewalBlocker installs a predicate that suppresses background
+// HLC lease-renewal proposals while it returns true.
+func (c *ShardedCoordinator) SetHLCLeaseRenewalBlocker(blocked func() bool) {
+	if c == nil {
+		return
+	}
+	c.hlcRenewalBlocked = blocked
 }
 
 // WithSampler wires a keyviz.Sampler onto a ShardedCoordinator. The
@@ -1974,6 +1986,10 @@ func (c *ShardedCoordinator) RunHLCLeaseRenewal(ctx context.Context) {
 	for {
 		select {
 		case <-timer.C:
+			if c.hlcRenewalBlocked != nil && c.hlcRenewalBlocked() {
+				timer.Reset(hlcRenewalInterval)
+				continue
+			}
 			if group.Engine.State() == raftengine.StateLeader {
 				c.renewHLCLease(ctx, group)
 			}

--- a/main.go
+++ b/main.go
@@ -1223,20 +1223,10 @@ type serversInput struct {
 	encryptionConfChangeInterceptor internalraftadmin.MembershipChangeInterceptor
 }
 
-// startServers wires up the AdminServer, builds the runtime runner, and
-// kicks off both the per-group raft listeners and the admin HTTP listener.
-// Extracted from run() to keep cyclomatic complexity within budget.
+// startServersAfterStartupRotation wires up the AdminServer, starts the
+// per-group Raft listeners needed for quorum traffic, waits for any requested
+// startup rotation, then opens the public service listeners.
 func startServersAfterStartupRotation(waitRotateOnStartup func(context.Context) error, in serversInput) error {
-	if waitRotateOnStartup != nil {
-		if err := waitRotateOnStartup(in.ctx); err != nil {
-			in.cancel()
-			return errors.Wrap(err, "encryption rotate-on-startup: wait before serving")
-		}
-	}
-	return startServers(in)
-}
-
-func startServers(in serversInput) error {
 	adminServer, adminGRPCOpts, err := setupAdminService(*raftId, *myAddr, in.runtimes, in.bootstrapServers, in.keyvizSampler)
 	if err != nil {
 		return err
@@ -1324,10 +1314,20 @@ func startServers(in serversInput) error {
 		roleStore:                       roleStore,
 		encryptionConfChangeInterceptor: in.encryptionConfChangeInterceptor,
 	}
-	if err := runner.start(); err != nil {
+	if err := runner.startRaftTransport(); err != nil {
 		return err
 	}
-	// runner.start() populates runner.dynamoServer for the admin
+	if waitRotateOnStartup != nil {
+		if err := waitRotateOnStartup(in.ctx); err != nil {
+			runner.closePreparedExternalListeners()
+			in.cancel()
+			return errors.Wrap(err, "encryption rotate-on-startup: wait before serving")
+		}
+	}
+	if err := runner.startPublicServices(); err != nil {
+		return err
+	}
+	// runner.startPublicServices() populates runner.dynamoServer for the admin
 	// listener's SigV4-bypass entrypoints (see adapter/dynamodb_admin.go).
 	// Passing nil here would leave the admin dashboard with no
 	// access to table metadata; the admin handler answers
@@ -1344,7 +1344,7 @@ func startServers(in serversInput) error {
 		Timeout: *keyvizFanoutTimeout,
 	}
 	if err := startAdminFromFlags(in.ctx, in.lc, in.eg, in.runtimes, runner.dynamoServer, runner.s3Server, runner.sqsServer, in.coordinate, connCache, in.keyvizSampler, fanoutCfg); err != nil {
-		return waitErrgroupAfterStartupFailure(in.cancel, in.eg, err)
+		return runner.startupFailure(err)
 	}
 	return nil
 }
@@ -1809,10 +1809,10 @@ func startRedisServer(ctx context.Context, lc *net.ListenConfig, eg *errgroup.Gr
 	return nil
 }
 
-func startDynamoDBServer(ctx context.Context, lc *net.ListenConfig, eg *errgroup.Group, dynamoAddr string, shardStore *kv.ShardStore, coordinate kv.Coordinator, leaderDynamo map[string]string, metricsRegistry *monitoring.Registry, readTracker *kv.ActiveTimestampTracker) (*adapter.DynamoDBServer, error) {
+func prepareDynamoDBServer(ctx context.Context, lc *net.ListenConfig, dynamoAddr string, shardStore *kv.ShardStore, coordinate kv.Coordinator, leaderDynamo map[string]string, metricsRegistry *monitoring.Registry, readTracker *kv.ActiveTimestampTracker) (*adapter.DynamoDBServer, net.Listener, error) {
 	dynamoL, err := lc.Listen(ctx, "tcp", dynamoAddr)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to listen on %s", dynamoAddr)
+		return nil, nil, errors.Wrapf(err, "failed to listen on %s", dynamoAddr)
 	}
 	dynamoServer := adapter.NewDynamoDBServer(
 		dynamoL,
@@ -1822,6 +1822,10 @@ func startDynamoDBServer(ctx context.Context, lc *net.ListenConfig, eg *errgroup
 		adapter.WithDynamoDBRequestObserver(metricsRegistry.DynamoDBObserver()),
 		adapter.WithDynamoDBLeaderMap(leaderDynamo),
 	)
+	return dynamoServer, dynamoL, nil
+}
+
+func runDynamoDBServer(ctx context.Context, eg *errgroup.Group, dynamoServer *adapter.DynamoDBServer) {
 	eg.Go(func() error {
 		defer dynamoServer.Stop()
 		stop := make(chan struct{})
@@ -1839,7 +1843,6 @@ func startDynamoDBServer(ctx context.Context, lc *net.ListenConfig, eg *errgroup
 		}
 		return errors.WithStack(err)
 	})
-	return dynamoServer, nil
 }
 
 func startPprofServer(ctx context.Context, lc *net.ListenConfig, eg *errgroup.Group, pprofAddr string, pprofToken string) error {
@@ -2006,13 +2009,15 @@ type runtimeServerRunner struct {
 	// adapter/dynamodb_admin.go) without going through HTTP. The
 	// field is unexported on purpose — it is package-private state,
 	// not a public API. Nil until start() reaches the dynamo step.
-	dynamoServer *adapter.DynamoDBServer
+	dynamoServer   *adapter.DynamoDBServer
+	dynamoListener net.Listener
 
 	// s3Server is the parallel field for the S3 admin endpoints
 	// (read-only in this slice). Nil when --s3Address is empty,
 	// in which case the admin handler answers /s3/buckets* with
 	// 404, mirroring the dynamoServer == nil contract.
-	s3Server *adapter.S3Server
+	s3Server   *adapter.S3Server
+	s3Listener net.Listener
 
 	// sqsServer plays the same role for the SQS admin entrypoints
 	// (adapter/sqs_admin.go). Always non-nil after startup —
@@ -2049,28 +2054,10 @@ type runtimeServerRunner struct {
 	roleStore admin.RoleStore
 }
 
-func (r *runtimeServerRunner) start() error {
-	if err := startRedisServer(r.ctx, r.lc, r.eg, r.redisAddress, r.shardStore, r.coordinate, r.leaderRedis, r.pubsubRelay, r.metricsRegistry, r.readTracker); err != nil {
-		return waitErrgroupAfterStartupFailure(r.cancel, r.eg, err)
+func (r *runtimeServerRunner) startRaftTransport() error {
+	if err := r.prepareAdminForwardServers(); err != nil {
+		return r.startupFailure(err)
 	}
-	// startDynamoDBServer + startS3Server must run BEFORE
-	// startRaftServers so the resulting *DynamoDBServer / *S3Server
-	// are available to the leader-side gRPC AdminForward registration
-	// in startRaftServers (design 3.3, P2 slice 2b). Each server
-	// listens on its own address; them accepting traffic before the
-	// raft TCP listeners are up is no different from the existing
-	// startup-race semantics — a hit in that window already returned
-	// 503 before this reorder.
-	dynamoServer, err := startDynamoDBServer(r.ctx, r.lc, r.eg, r.dynamoAddress, r.shardStore, r.coordinate, r.leaderDynamo, r.metricsRegistry, r.readTracker)
-	if err != nil {
-		return waitErrgroupAfterStartupFailure(r.cancel, r.eg, err)
-	}
-	r.dynamoServer = dynamoServer
-	s3Server, err := startS3Server(r.ctx, r.lc, r.eg, r.s3Address, r.shardStore, r.coordinate, r.leaderS3, r.s3Region, r.s3CredsFile, r.s3PathStyleOnly, r.readTracker)
-	if err != nil {
-		return waitErrgroupAfterStartupFailure(r.cancel, r.eg, err)
-	}
-	r.s3Server = s3Server
 	forwardDeps := adminForwardServerDeps{
 		tables:  newDynamoTablesSource(r.dynamoServer),
 		buckets: newBucketsSource(r.s3Server),
@@ -2095,11 +2082,54 @@ func (r *runtimeServerRunner) start() error {
 		r.encryptionConfChangeInterceptor,
 		r.encWiring,
 	); err != nil {
-		return waitErrgroupAfterStartupFailure(r.cancel, r.eg, err)
+		return r.startupFailure(err)
 	}
+	return nil
+}
+
+func (r *runtimeServerRunner) prepareAdminForwardServers() error {
+	dynamoServer, dynamoListener, err := prepareDynamoDBServer(r.ctx, r.lc, r.dynamoAddress, r.shardStore, r.coordinate, r.leaderDynamo, r.metricsRegistry, r.readTracker)
+	if err != nil {
+		return err
+	}
+	r.dynamoServer = dynamoServer
+	r.dynamoListener = dynamoListener
+	s3Server, s3Listener, err := prepareS3Server(r.ctx, r.lc, r.s3Address, r.shardStore, r.coordinate, r.leaderS3, r.s3Region, r.s3CredsFile, r.s3PathStyleOnly, r.readTracker)
+	if err != nil {
+		return err
+	}
+	r.s3Server = s3Server
+	r.s3Listener = s3Listener
+	return nil
+}
+
+func (r *runtimeServerRunner) closePreparedExternalListeners() {
+	if r.dynamoListener != nil {
+		_ = r.dynamoListener.Close()
+		r.dynamoListener = nil
+	}
+	if r.s3Listener != nil {
+		_ = r.s3Listener.Close()
+		r.s3Listener = nil
+	}
+}
+
+func (r *runtimeServerRunner) startupFailure(err error) error {
+	r.closePreparedExternalListeners()
+	return waitErrgroupAfterStartupFailure(r.cancel, r.eg, err)
+}
+
+func (r *runtimeServerRunner) startPublicServices() error {
+	if err := startRedisServer(r.ctx, r.lc, r.eg, r.redisAddress, r.shardStore, r.coordinate, r.leaderRedis, r.pubsubRelay, r.metricsRegistry, r.readTracker); err != nil {
+		return r.startupFailure(err)
+	}
+	runDynamoDBServer(r.ctx, r.eg, r.dynamoServer)
+	r.dynamoListener = nil
+	runS3Server(r.ctx, r.eg, r.s3Server)
+	r.s3Listener = nil
 	sqsServer, err := startSQSServer(r.ctx, r.lc, r.eg, r.sqsAddress, r.shardStore, r.coordinate, r.leaderSQS, r.sqsRegion, r.sqsCredsFile, r.sqsPartitionResolver, r.sqsPartitionObserver)
 	if err != nil {
-		return waitErrgroupAfterStartupFailure(r.cancel, r.eg, err)
+		return r.startupFailure(err)
 	}
 	r.sqsServer = sqsServer
 	// Plug the SQS adapter into the monitoring registry's depth
@@ -2110,10 +2140,10 @@ func (r *runtimeServerRunner) start() error {
 		startSQSDepthObserver(r.ctx, r.metricsRegistry, r.sqsServer)
 	}
 	if err := startMetricsServer(r.ctx, r.lc, r.eg, r.metricsAddress, r.metricsToken, r.metricsRegistry.Handler()); err != nil {
-		return waitErrgroupAfterStartupFailure(r.cancel, r.eg, err)
+		return r.startupFailure(err)
 	}
 	if err := startPprofServer(r.ctx, r.lc, r.eg, r.pprofAddress, r.pprofToken); err != nil {
-		return waitErrgroupAfterStartupFailure(r.cancel, r.eg, err)
+		return r.startupFailure(err)
 	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -175,6 +175,13 @@ var (
 	// not yet committed to encryption are unaffected.
 	encryptionEnabled = flag.Bool("encryption-enabled", false, "§6.5 opt-in to encryption-mutating EncryptionAdmin RPCs. Requires --kekFile to be set; without that, mutators still refuse with FailedPrecondition. Default off.")
 
+	// Stage 6F: operator-requested DEK rotation at boot. The flag is
+	// intentionally a request, not a guarantee: only the leader of the
+	// default encryption Raft group proposes the rotation; followers
+	// keep the request in memory and fire it only if they acquire
+	// leadership during this process uptime.
+	encryptionRotateOnStartup = flag.Bool("encryption-rotate-on-startup", false, "§6.5 request a one-shot DEK rotation after this node becomes leader of the default Raft group. Safe for rolling restarts: followers keep the request in memory and only fire if they acquire leadership during this process uptime.")
+
 	// Stage 6B-2: KEK source. The KEK never appears in elastickv's
 	// data dir; it is held externally and exercised only at process
 	// boot and at DEK bootstrap/rotation per §5.1. Stage 6B-2 ships
@@ -440,6 +447,19 @@ func run() error {
 		ctx, runtimes, cfg.sqsFifoPartitionMap,
 		sqsAdvertisesHTFIFO(), slog.Default())
 	cleanup.Add(leadershipRefusalDeregister)
+	defaultRuntime := findDefaultGroupRuntime(runtimes, cfg.defaultGroup)
+	cleanup.Add(installEncryptionRotateOnStartup(
+		ctx,
+		*encryptionRotateOnStartup,
+		defaultRuntime,
+		postCutoverProposerForRuntime(defaultRuntime, shardGroups),
+		*encryptionSidecarPath,
+		kekWrapper,
+		etcdraftengine.DeriveNodeID(*raftId),
+		encWiring.epoch,
+		encWiring.raftEpoch,
+		slog.Default(),
+	))
 	eg, runCtx := errgroup.WithContext(ctx)
 	startRaftEngineLifecycleWatchers(runCtx, eg, runtimes)
 	// setupDistributionCatalog + the Stage 7a process-start registration
@@ -947,6 +967,13 @@ func proposerForGroup(rt *raftGroupRuntime, shardGroups map[uint64]*kv.ShardGrou
 		return sg.Proposer()
 	}
 	return rt.engine
+}
+
+func postCutoverProposerForRuntime(rt *raftGroupRuntime, shardGroups map[uint64]*kv.ShardGroup) raftengine.Proposer {
+	if rt == nil {
+		return nil
+	}
+	return proposerForGroup(rt, shardGroups)
 }
 
 // loadKEKAndRunStartupGuards loads the file-backed KEK wrapper and

--- a/main.go
+++ b/main.go
@@ -1228,7 +1228,7 @@ type serversInput struct {
 // startServersAfterStartupRotation wires up the AdminServer, starts the
 // per-group Raft listeners needed for quorum traffic, waits for any requested
 // startup rotation, then opens the public service listeners.
-func startServersAfterStartupRotation(waitRotateOnStartup func(context.Context) error, in serversInput) error {
+func startServersAfterStartupRotation(waitRotateOnStartup startupRotationWaiter, in serversInput) error {
 	adminServer, adminGRPCOpts, err := setupAdminService(*raftId, *myAddr, in.runtimes, in.bootstrapServers, in.keyvizSampler)
 	if err != nil {
 		return err
@@ -1321,12 +1321,9 @@ func startServersAfterStartupRotation(waitRotateOnStartup func(context.Context) 
 	if err := runner.startRaftTransport(); err != nil {
 		return err
 	}
-	if waitRotateOnStartup != nil {
-		if err := waitRotateOnStartup(in.ctx); err != nil {
-			runner.closePreparedExternalListeners()
-			in.cancel()
-			return errors.Wrap(err, "encryption rotate-on-startup: wait before serving")
-		}
+	publicKVGate.blockMutator = waitRotateOnStartup.BlockMutators
+	if err := waitRotateOnStartup.Wait(in.ctx); err != nil {
+		return runner.startupFailure(errors.Wrap(err, "encryption rotate-on-startup: wait before serving"))
 	}
 	publicKVGate.markReady()
 	if err := runner.startPublicServices(); err != nil {
@@ -1458,7 +1455,8 @@ func (a adminGRPCInterceptors) empty() bool {
 }
 
 type startupPublicKVGate struct {
-	ready atomic.Bool
+	ready        atomic.Bool
+	blockMutator func() bool
 }
 
 func (g *startupPublicKVGate) markReady() {
@@ -1473,7 +1471,7 @@ func (g *startupPublicKVGate) unaryInterceptor(
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
 ) (interface{}, error) {
-	if g != nil && info != nil && !g.ready.Load() && startupRotationGatedMethod(info.FullMethod) {
+	if g != nil && info != nil && startupRotationGatedMethod(info.FullMethod) && g.blocked() {
 		// Return a raw gRPC status so clients and retry policy see Unavailable.
 		//nolint:wrapcheck
 		return nil, status.Error(codes.Unavailable, "startup rotation has not completed")
@@ -1481,11 +1479,26 @@ func (g *startupPublicKVGate) unaryInterceptor(
 	return handler(ctx, req)
 }
 
+func (g *startupPublicKVGate) blocked() bool {
+	if g == nil {
+		return false
+	}
+	if !g.ready.Load() {
+		return true
+	}
+	return g.blockMutator != nil && g.blockMutator()
+}
+
 func startupRotationGatedMethod(fullMethod string) bool {
 	switch fullMethod {
 	case pb.Internal_Forward_FullMethodName,
 		pb.AdminForward_Forward_FullMethodName,
 		pb.Distribution_SplitRange_FullMethodName,
+		pb.RaftAdmin_AddVoter_FullMethodName,
+		pb.RaftAdmin_AddLearner_FullMethodName,
+		pb.RaftAdmin_PromoteLearner_FullMethodName,
+		pb.RaftAdmin_RemoveServer_FullMethodName,
+		pb.RaftAdmin_TransferLeadership_FullMethodName,
 		pb.EncryptionAdmin_BootstrapEncryption_FullMethodName,
 		pb.EncryptionAdmin_RotateDEK_FullMethodName,
 		pb.EncryptionAdmin_RegisterEncryptionWriter_FullMethodName,

--- a/main.go
+++ b/main.go
@@ -455,6 +455,7 @@ func run() error {
 		postCutoverProposerForRuntime(defaultRuntime, shardGroups),
 		*encryptionSidecarPath,
 		kekWrapper,
+		encWiring.raftEnvelope,
 		etcdraftengine.DeriveNodeID(*raftId),
 		encWiring.epoch,
 		encWiring.raftEpoch,

--- a/main.go
+++ b/main.go
@@ -491,10 +491,6 @@ func run() error {
 	eg.Go(func() error {
 		return compactor.Run(runCtx)
 	})
-	eg.Go(func() error {
-		coordinate.RunHLCLeaseRenewal(runCtx)
-		return nil
-	})
 
 	// Stage 7c §3.1: build the encryption-aware
 	// MembershipChangeInterceptor here where the concrete
@@ -1239,9 +1235,9 @@ func startServersAfterStartupRotation(waitRotateOnStartup startupRotationWaiter,
 	// otherwise still flip forwardDeps.readyForRegistration() to
 	// true, registering the leader-side gRPC AdminForward service
 	// and re-exposing the table-write surface a follower-direct
-	// admin call could reach (Codex P1, CodeRabbit Major on #648).
+	// admin call could reach (P1/Major review on #648).
 	// The HTTP admin listener already short-circuits in
-	// startAdminFromFlags when *adminEnabled is false; the gRPC path
+	// prepareAdminFromFlags when *adminEnabled is false; the gRPC path
 	// must do the same.
 	var (
 		roleStore admin.RoleStore
@@ -1250,7 +1246,7 @@ func startServersAfterStartupRotation(waitRotateOnStartup startupRotationWaiter,
 	if *adminEnabled {
 		roleStore = roleStoreFromFlags(parseCSV(*adminFullAccessKeys), parseCSV(*adminReadOnlyAccessKeys))
 		// connCache is shared between the follower-side LeaderForwarder
-		// (built inside startAdminFromFlags) and any future bridge that
+		// (built inside prepareAdminFromFlags) and any future bridge that
 		// dials the leader's gRPC ports. Keeping a single instance per
 		// process means the two paths re-use TLS / HTTP/2 connections
 		// rather than each maintaining a parallel pool. The shutdown
@@ -1268,6 +1264,11 @@ func startServersAfterStartupRotation(waitRotateOnStartup startupRotationWaiter,
 		})
 	}
 	publicKVGate := &startupPublicKVGate{}
+	installHLCLeaseRenewalBlocker(in.coordinate, waitRotateOnStartup.BlockMutators)
+	adapterCoordinate := startupGatedCoordinator{
+		inner: in.coordinate,
+		gate:  publicKVGate,
+	}
 	runner := runtimeServerRunner{
 		ctx:             in.ctx,
 		lc:              in.lc,
@@ -1276,7 +1277,7 @@ func startServersAfterStartupRotation(waitRotateOnStartup startupRotationWaiter,
 		runtimes:        in.runtimes,
 		shardGroups:     in.shardGroups,
 		shardStore:      in.shardStore,
-		coordinate:      in.coordinate,
+		coordinate:      adapterCoordinate,
 		distServer:      in.distServer,
 		adminServer:     adminServer,
 		adminGRPCOpts:   adminGRPCOpts,
@@ -1321,21 +1322,16 @@ func startServersAfterStartupRotation(waitRotateOnStartup startupRotationWaiter,
 	if err := runner.startRaftTransport(); err != nil {
 		return err
 	}
-	publicKVGate.blockMutator = waitRotateOnStartup.BlockMutators
-	if err := waitRotateOnStartup.Wait(in.ctx); err != nil {
-		return runner.startupFailure(errors.Wrap(err, "encryption rotate-on-startup: wait before serving"))
+	if err := runner.preparePublicServices(); err != nil {
+		return runner.startupFailure(err)
 	}
-	publicKVGate.markReady()
-	if err := runner.startPublicServices(); err != nil {
-		return err
-	}
-	// runner.startPublicServices() populates runner.dynamoServer for the admin
-	// listener's SigV4-bypass entrypoints (see adapter/dynamodb_admin.go).
+	// runner.startRaftTransport() has populated runner.dynamoServer for the
+	// admin listener's SigV4-bypass entrypoints (see adapter/dynamodb_admin.go).
 	// Passing nil here would leave the admin dashboard with no
 	// access to table metadata; the admin handler answers
 	// /admin/api/v1/dynamo/* with 404 in that case.
 	//
-	// in.coordinate + connCache are forwarded so the admin HTTP
+	// runner.coordinate + connCache are forwarded so the admin HTTP
 	// dynamo handler can construct its production LeaderForwarder
 	// (Phase 3 of design 3.3): when the local node is a follower,
 	// the handler hands ErrTablesNotLeader writes to the forwarder
@@ -1345,10 +1341,53 @@ func startServersAfterStartupRotation(waitRotateOnStartup startupRotationWaiter,
 		Nodes:   parseCSV(*keyvizFanoutNodes),
 		Timeout: *keyvizFanoutTimeout,
 	}
-	if err := startAdminFromFlags(in.ctx, in.lc, in.eg, in.runtimes, runner.dynamoServer, runner.s3Server, runner.sqsServer, in.coordinate, connCache, in.keyvizSampler, fanoutCfg); err != nil {
+	adminHTTP, err := prepareAdminFromFlags(in.ctx, in.lc, in.runtimes, runner.dynamoServer, runner.s3Server, runner.sqsServer, runner.coordinate, connCache, in.keyvizSampler, fanoutCfg)
+	if err != nil {
 		return runner.startupFailure(err)
 	}
+	runner.adminHTTP = adminHTTP
+	publicKVGate.blockMutator = waitRotateOnStartup.BlockMutators
+	if err := waitRotateOnStartup.Wait(in.ctx); err != nil {
+		return runner.startupFailure(errors.Wrap(err, "encryption rotate-on-startup: wait before serving"))
+	}
+	startHLCLeaseRenewal(in.ctx, in.eg, in.coordinate)
+	publicKVGate.markReady()
+	if err := runner.startPublicServices(); err != nil {
+		return err
+	}
+	runner.startAdminHTTP()
 	return nil
+}
+
+type hlcLeaseRenewalBlocker interface {
+	SetHLCLeaseRenewalBlocker(func() bool)
+}
+
+type hlcLeaseRenewalRunner interface {
+	RunHLCLeaseRenewal(context.Context)
+}
+
+func installHLCLeaseRenewalBlocker(coordinate kv.Coordinator, blocked func() bool) {
+	if coordinate == nil || blocked == nil {
+		return
+	}
+	if installer, ok := coordinate.(hlcLeaseRenewalBlocker); ok {
+		installer.SetHLCLeaseRenewalBlocker(blocked)
+	}
+}
+
+func startHLCLeaseRenewal(ctx context.Context, eg *errgroup.Group, coordinate kv.Coordinator) {
+	if eg == nil || coordinate == nil {
+		return
+	}
+	runner, ok := coordinate.(hlcLeaseRenewalRunner)
+	if !ok {
+		return
+	}
+	eg.Go(func() error {
+		runner.RunHLCLeaseRenewal(ctx)
+		return nil
+	})
 }
 
 func setupAdminService(
@@ -1452,6 +1491,74 @@ type adminGRPCInterceptors struct {
 
 func (a adminGRPCInterceptors) empty() bool {
 	return len(a.unary) == 0 && len(a.stream) == 0
+}
+
+type startupGatedCoordinator struct {
+	inner kv.Coordinator
+	gate  *startupPublicKVGate
+}
+
+var _ kv.Coordinator = (*startupGatedCoordinator)(nil)
+var _ kv.LeaseReadableCoordinator = (*startupGatedCoordinator)(nil)
+var _ kv.AllGroupsLeaseReadableCoordinator = (*startupGatedCoordinator)(nil)
+var _ kv.GroupRoutableCoordinator = (*startupGatedCoordinator)(nil)
+
+func (c startupGatedCoordinator) Dispatch(ctx context.Context, reqs *kv.OperationGroup[kv.OP]) (*kv.CoordinateResponse, error) {
+	if c.gate != nil && c.gate.blocked() {
+		return nil, status.Error(codes.Unavailable, "startup rotation has not completed") //nolint:wrapcheck // Preserve the gRPC status for adapters.
+	}
+	return c.inner.Dispatch(ctx, reqs) //nolint:wrapcheck // Pass through coordinator errors unchanged.
+}
+
+func (c startupGatedCoordinator) IsLeader() bool {
+	return c.inner.IsLeader()
+}
+
+func (c startupGatedCoordinator) VerifyLeader(ctx context.Context) error {
+	return c.inner.VerifyLeader(ctx) //nolint:wrapcheck // Pass through coordinator errors unchanged.
+}
+
+func (c startupGatedCoordinator) LinearizableRead(ctx context.Context) (uint64, error) {
+	return c.inner.LinearizableRead(ctx) //nolint:wrapcheck // Pass through coordinator errors unchanged.
+}
+
+func (c startupGatedCoordinator) RaftLeader() string {
+	return c.inner.RaftLeader()
+}
+
+func (c startupGatedCoordinator) IsLeaderForKey(key []byte) bool {
+	return c.inner.IsLeaderForKey(key)
+}
+
+func (c startupGatedCoordinator) VerifyLeaderForKey(ctx context.Context, key []byte) error {
+	return c.inner.VerifyLeaderForKey(ctx, key) //nolint:wrapcheck // Pass through coordinator errors unchanged.
+}
+
+func (c startupGatedCoordinator) RaftLeaderForKey(key []byte) string {
+	return c.inner.RaftLeaderForKey(key)
+}
+
+func (c startupGatedCoordinator) Clock() *kv.HLC {
+	return c.inner.Clock()
+}
+
+func (c startupGatedCoordinator) LeaseRead(ctx context.Context) (uint64, error) {
+	return kv.LeaseReadThrough(c.inner, ctx) //nolint:wrapcheck // Pass through coordinator errors unchanged.
+}
+
+func (c startupGatedCoordinator) LeaseReadForKey(ctx context.Context, key []byte) (uint64, error) {
+	return kv.LeaseReadForKeyThrough(c.inner, ctx, key) //nolint:wrapcheck // Pass through coordinator errors unchanged.
+}
+
+func (c startupGatedCoordinator) LeaseReadAllGroups(ctx context.Context) error {
+	return kv.LeaseReadAllGroupsThrough(c.inner, ctx) //nolint:wrapcheck // Pass through coordinator errors unchanged.
+}
+
+func (c startupGatedCoordinator) EngineGroupIDForKey(key []byte) uint64 {
+	if router, ok := c.inner.(kv.GroupRoutableCoordinator); ok {
+		return router.EngineGroupIDForKey(key)
+	}
+	return 0
 }
 
 type startupPublicKVGate struct {
@@ -1824,13 +1931,12 @@ func startRaftServers(
 	return nil
 }
 
-func startRedisServer(ctx context.Context, lc *net.ListenConfig, eg *errgroup.Group, redisAddr string, shardStore *kv.ShardStore, coordinate kv.Coordinator, leaderRedis map[string]string, relay *adapter.RedisPubSubRelay, metricsRegistry *monitoring.Registry, readTracker *kv.ActiveTimestampTracker) error {
+func prepareRedisServer(ctx context.Context, lc *net.ListenConfig, redisAddr string, shardStore *kv.ShardStore, coordinate kv.Coordinator, leaderRedis map[string]string, relay *adapter.RedisPubSubRelay, metricsRegistry *monitoring.Registry, readTracker *kv.ActiveTimestampTracker) (*adapter.RedisServer, *adapter.DeltaCompactor, net.Listener, error) {
 	redisL, err := lc.Listen(ctx, "tcp", redisAddr)
 	if err != nil {
-		return errors.Wrapf(err, "failed to listen on %s", redisAddr)
+		return nil, nil, nil, errors.Wrapf(err, "failed to listen on %s", redisAddr)
 	}
 	deltaCompactor := adapter.NewDeltaCompactor(shardStore, coordinate)
-	eg.Go(func() error { return deltaCompactor.Run(ctx) })
 	redisServer := adapter.NewRedisServer(redisL, redisAddr, shardStore, coordinate, leaderRedis, relay,
 		adapter.WithRedisActiveTimestampTracker(readTracker),
 		adapter.WithRedisRequestObserver(metricsRegistry.RedisObserver()),
@@ -1849,6 +1955,16 @@ func startRedisServer(ctx context.Context, lc *net.ListenConfig, eg *errgroup.Gr
 	if err := redisServer.RegisterLuaPoolMetrics(metricsRegistry.Registerer()); err != nil {
 		slog.Warn("failed to register lua pool metrics; pool counters will be invisible in Prometheus", "err", err)
 	}
+	return redisServer, deltaCompactor, redisL, nil
+}
+
+func runRedisServer(ctx context.Context, eg *errgroup.Group, redisServer *adapter.RedisServer, deltaCompactor *adapter.DeltaCompactor) {
+	if redisServer == nil {
+		return
+	}
+	if deltaCompactor != nil {
+		eg.Go(func() error { return deltaCompactor.Run(ctx) })
+	}
 	eg.Go(func() error {
 		defer redisServer.Stop()
 		stop := make(chan struct{})
@@ -1866,7 +1982,6 @@ func startRedisServer(ctx context.Context, lc *net.ListenConfig, eg *errgroup.Gr
 		}
 		return errors.WithStack(err)
 	})
-	return nil
 }
 
 func newDynamoDBServer(shardStore *kv.ShardStore, coordinate kv.Coordinator, leaderDynamo map[string]string, metricsRegistry *monitoring.Registry, readTracker *kv.ActiveTimestampTracker) *adapter.DynamoDBServer {
@@ -1913,45 +2028,75 @@ func runDynamoDBServer(ctx context.Context, eg *errgroup.Group, dynamoServer *ad
 }
 
 func startPprofServer(ctx context.Context, lc *net.ListenConfig, eg *errgroup.Group, pprofAddr string, pprofToken string) error {
-	pprofAddr = strings.TrimSpace(pprofAddr)
-	if pprofAddr == "" {
-		return nil
-	}
-	if _, _, err := net.SplitHostPort(pprofAddr); err != nil {
-		return errors.Wrapf(err, "invalid pprofAddress %q; expected host:port", pprofAddr)
-	}
-	if monitoring.AddressRequiresToken(pprofAddr) && strings.TrimSpace(pprofToken) == "" {
-		return errors.New("pprofToken is required when pprofAddress is not loopback")
-	}
-	pprofL, err := lc.Listen(ctx, "tcp", pprofAddr)
+	pprofServer, pprofL, bindAddr, err := preparePprofServer(ctx, lc, pprofAddr, pprofToken)
 	if err != nil {
-		return errors.Wrapf(err, "failed to listen on %s", pprofAddr)
+		return err
 	}
-	pprofServer := monitoring.NewPprofServer(pprofToken)
-	eg.Go(monitoring.PprofShutdownTask(ctx, pprofServer, pprofAddr))
-	eg.Go(monitoring.PprofServeTask(pprofServer, pprofL, pprofAddr))
+	runPreparedPprofServer(ctx, eg, pprofServer, pprofL, bindAddr)
 	return nil
 }
 
+func preparePprofServer(ctx context.Context, lc *net.ListenConfig, pprofAddr string, pprofToken string) (*http.Server, net.Listener, string, error) {
+	pprofAddr = strings.TrimSpace(pprofAddr)
+	if pprofAddr == "" {
+		return nil, nil, "", nil
+	}
+	if _, _, err := net.SplitHostPort(pprofAddr); err != nil {
+		return nil, nil, "", errors.Wrapf(err, "invalid pprofAddress %q; expected host:port", pprofAddr)
+	}
+	if monitoring.AddressRequiresToken(pprofAddr) && strings.TrimSpace(pprofToken) == "" {
+		return nil, nil, "", errors.New("pprofToken is required when pprofAddress is not loopback")
+	}
+	pprofL, err := lc.Listen(ctx, "tcp", pprofAddr)
+	if err != nil {
+		return nil, nil, "", errors.Wrapf(err, "failed to listen on %s", pprofAddr)
+	}
+	pprofServer := monitoring.NewPprofServer(pprofToken)
+	return pprofServer, pprofL, pprofAddr, nil
+}
+
+func runPreparedPprofServer(ctx context.Context, eg *errgroup.Group, pprofServer *http.Server, pprofL net.Listener, pprofAddr string) {
+	if pprofServer == nil || pprofL == nil {
+		return
+	}
+	eg.Go(monitoring.PprofShutdownTask(ctx, pprofServer, pprofAddr))
+	eg.Go(monitoring.PprofServeTask(pprofServer, pprofL, pprofAddr))
+}
+
 func startMetricsServer(ctx context.Context, lc *net.ListenConfig, eg *errgroup.Group, metricsAddr string, metricsToken string, handler http.Handler) error {
+	metricsServer, metricsL, bindAddr, err := prepareMetricsServer(ctx, lc, metricsAddr, metricsToken, handler)
+	if err != nil {
+		return err
+	}
+	runPreparedMetricsServer(ctx, eg, metricsServer, metricsL, bindAddr)
+	return nil
+}
+
+func prepareMetricsServer(ctx context.Context, lc *net.ListenConfig, metricsAddr string, metricsToken string, handler http.Handler) (*http.Server, net.Listener, string, error) {
 	metricsAddr = strings.TrimSpace(metricsAddr)
 	if metricsAddr == "" || handler == nil {
-		return nil
+		return nil, nil, "", nil
 	}
 	if _, _, err := net.SplitHostPort(metricsAddr); err != nil {
-		return errors.Wrapf(err, "invalid metricsAddress %q; expected host:port", metricsAddr)
+		return nil, nil, "", errors.Wrapf(err, "invalid metricsAddress %q; expected host:port", metricsAddr)
 	}
 	if monitoring.AddressRequiresToken(metricsAddr) && strings.TrimSpace(metricsToken) == "" {
-		return errors.New("metricsToken is required when metricsAddress is not loopback")
+		return nil, nil, "", errors.New("metricsToken is required when metricsAddress is not loopback")
 	}
 	metricsL, err := lc.Listen(ctx, "tcp", metricsAddr)
 	if err != nil {
-		return errors.Wrapf(err, "failed to listen on %s", metricsAddr)
+		return nil, nil, "", errors.Wrapf(err, "failed to listen on %s", metricsAddr)
 	}
 	metricsServer := monitoring.NewMetricsServer(handler, metricsToken)
+	return metricsServer, metricsL, metricsAddr, nil
+}
+
+func runPreparedMetricsServer(ctx context.Context, eg *errgroup.Group, metricsServer *http.Server, metricsL net.Listener, metricsAddr string) {
+	if metricsServer == nil || metricsL == nil {
+		return
+	}
 	eg.Go(monitoring.MetricsShutdownTask(ctx, metricsServer, metricsAddr))
 	eg.Go(monitoring.MetricsServeTask(metricsServer, metricsL, metricsAddr))
-	return nil
 }
 
 func distributionCatalogStoreForGroup(runtimes []*raftGroupRuntime, groupID uint64) *distribution.CatalogStore {
@@ -2071,13 +2216,16 @@ type runtimeServerRunner struct {
 	encryptionConfChangeInterceptor internalraftadmin.MembershipChangeInterceptor
 
 	// dynamoServer is populated by start() and made available to
-	// startAdminFromFlags in this package so the admin listener can
+	// prepareAdminFromFlags in this package so the admin listener can
 	// call SigV4-bypass admin entrypoints (see
 	// adapter/dynamodb_admin.go) without going through HTTP. The
 	// field is unexported on purpose — it is package-private state,
 	// not a public API. Nil until start() reaches the dynamo step.
 	dynamoServer   *adapter.DynamoDBServer
 	dynamoListener net.Listener
+	redisServer    *adapter.RedisServer
+	redisCompactor *adapter.DeltaCompactor
+	redisListener  net.Listener
 
 	// s3Server is the parallel field for the S3 admin endpoints
 	// (read-only in this slice). Nil when --s3Address is empty,
@@ -2088,18 +2236,27 @@ type runtimeServerRunner struct {
 
 	// sqsServer plays the same role for the SQS admin entrypoints
 	// (adapter/sqs_admin.go). Always non-nil after startup —
-	// startSQSServer constructs a listenless SQSServer when
+	// prepareSQSServer constructs a listenless SQSServer when
 	// --sqsAddress is empty (the public SigV4 listener is
 	// suppressed but the admin bridge stays wired since the admin
 	// handlers only need the coordinator/store, not the listener).
-	sqsServer *adapter.SQSServer
+	sqsServer   *adapter.SQSServer
+	sqsListener net.Listener
+
+	metricsServer   *http.Server
+	metricsListener net.Listener
+	metricsBindAddr string
+	pprofServer     *http.Server
+	pprofListener   net.Listener
+	pprofBindAddr   string
+	adminHTTP       *preparedAdminServer
 
 	// sqsPartitionResolver is the concrete pointer to the same
-	// resolver installed on the coordinator (line ~322). startSQSServer
+	// resolver installed on the coordinator (line ~322). prepareSQSServer
 	// hands this through WithSQSPartitionResolver so the CreateQueue
 	// capability gate can verify routing coverage on partitioned
-	// creates without re-parsing --sqsFifoPartitionMap (Codex P1
-	// review on PR #734, round 2). Nil on single-shard / no-flag
+	// creates without re-parsing --sqsFifoPartitionMap (P1 review on
+	// PR #734, round 2). Nil on single-shard / no-flag
 	// deployments — the gate's resolver==nil branch then skips
 	// the coverage check.
 	sqsPartitionResolver *adapter.SQSPartitionResolver
@@ -2114,7 +2271,7 @@ type runtimeServerRunner struct {
 	// roleStore is the access-key → role index the leader-side
 	// gRPC AdminForward service uses to re-validate the principal
 	// on every forwarded write. Mirrors what admin.Config.RoleIndex
-	// produces inside startAdminFromFlags; built up-front in
+	// produces inside prepareAdminFromFlags; built up-front in
 	// startServers so registerAdminForwardServer in startRaftServers
 	// does not need to wait for the (later) admin-config parse.
 	// Nil when no admin access keys are configured.
@@ -2170,7 +2327,66 @@ func (r *runtimeServerRunner) prepareAdminForwardServers() error {
 	return nil
 }
 
+func (r *runtimeServerRunner) preparePublicServices() error {
+	redisServer, redisCompactor, redisListener, err := prepareRedisServer(
+		r.ctx, r.lc, r.redisAddress, r.shardStore, r.coordinate,
+		r.leaderRedis, r.pubsubRelay, r.metricsRegistry, r.readTracker,
+	)
+	if err != nil {
+		return err
+	}
+	r.redisServer = redisServer
+	r.redisCompactor = redisCompactor
+	r.redisListener = redisListener
+
+	dynamoListener, err := bindDynamoDBServer(r.ctx, r.lc, r.dynamoAddress, r.dynamoServer)
+	if err != nil {
+		return err
+	}
+	r.dynamoListener = dynamoListener
+
+	s3Listener, err := bindS3Server(r.ctx, r.lc, r.s3Address, r.s3Server)
+	if err != nil {
+		return err
+	}
+	r.s3Listener = s3Listener
+
+	sqsServer, sqsListener, err := prepareSQSServer(
+		r.ctx, r.lc, r.sqsAddress, r.shardStore, r.coordinate,
+		r.leaderSQS, r.sqsRegion, r.sqsCredsFile,
+		r.sqsPartitionResolver, r.sqsPartitionObserver,
+	)
+	if err != nil {
+		return err
+	}
+	r.sqsServer = sqsServer
+	r.sqsListener = sqsListener
+
+	metricsServer, metricsListener, metricsAddr, err := prepareMetricsServer(
+		r.ctx, r.lc, r.metricsAddress, r.metricsToken, r.metricsRegistry.Handler(),
+	)
+	if err != nil {
+		return err
+	}
+	r.metricsServer = metricsServer
+	r.metricsListener = metricsListener
+	r.metricsBindAddr = metricsAddr
+
+	pprofServer, pprofListener, pprofAddr, err := preparePprofServer(r.ctx, r.lc, r.pprofAddress, r.pprofToken)
+	if err != nil {
+		return err
+	}
+	r.pprofServer = pprofServer
+	r.pprofListener = pprofListener
+	r.pprofBindAddr = pprofAddr
+	return nil
+}
+
 func (r *runtimeServerRunner) closePreparedExternalListeners() {
+	if r.redisListener != nil {
+		_ = r.redisListener.Close()
+		r.redisListener = nil
+	}
 	if r.dynamoListener != nil {
 		_ = r.dynamoListener.Close()
 		r.dynamoListener = nil
@@ -2178,6 +2394,21 @@ func (r *runtimeServerRunner) closePreparedExternalListeners() {
 	if r.s3Listener != nil {
 		_ = r.s3Listener.Close()
 		r.s3Listener = nil
+	}
+	if r.sqsListener != nil {
+		_ = r.sqsListener.Close()
+		r.sqsListener = nil
+	}
+	if r.metricsListener != nil {
+		_ = r.metricsListener.Close()
+		r.metricsListener = nil
+	}
+	if r.pprofListener != nil {
+		_ = r.pprofListener.Close()
+		r.pprofListener = nil
+	}
+	if r.adminHTTP != nil {
+		r.adminHTTP.close()
 	}
 }
 
@@ -2187,28 +2418,23 @@ func (r *runtimeServerRunner) startupFailure(err error) error {
 }
 
 func (r *runtimeServerRunner) startPublicServices() error {
-	if err := startRedisServer(r.ctx, r.lc, r.eg, r.redisAddress, r.shardStore, r.coordinate, r.leaderRedis, r.pubsubRelay, r.metricsRegistry, r.readTracker); err != nil {
-		return r.startupFailure(err)
+	if r.redisServer == nil || r.redisListener == nil {
+		return r.startupFailure(errors.New("redis server is not prepared"))
 	}
-	dynamoListener, err := bindDynamoDBServer(r.ctx, r.lc, r.dynamoAddress, r.dynamoServer)
-	if err != nil {
-		return r.startupFailure(err)
+	if r.dynamoServer == nil || r.dynamoListener == nil {
+		return r.startupFailure(errors.New("dynamodb server is not prepared"))
 	}
-	r.dynamoListener = dynamoListener
+	if r.sqsServer == nil {
+		return r.startupFailure(errors.New("sqs server is not prepared"))
+	}
+	runRedisServer(r.ctx, r.eg, r.redisServer, r.redisCompactor)
+	r.redisListener = nil
 	runDynamoDBServer(r.ctx, r.eg, r.dynamoServer)
 	r.dynamoListener = nil
-	s3Listener, err := bindS3Server(r.ctx, r.lc, r.s3Address, r.s3Server)
-	if err != nil {
-		return r.startupFailure(err)
-	}
-	r.s3Listener = s3Listener
 	runS3Server(r.ctx, r.eg, r.s3Server)
 	r.s3Listener = nil
-	sqsServer, err := startSQSServer(r.ctx, r.lc, r.eg, r.sqsAddress, r.shardStore, r.coordinate, r.leaderSQS, r.sqsRegion, r.sqsCredsFile, r.sqsPartitionResolver, r.sqsPartitionObserver)
-	if err != nil {
-		return r.startupFailure(err)
-	}
-	r.sqsServer = sqsServer
+	runSQSServer(r.ctx, r.eg, r.sqsServer)
+	r.sqsListener = nil
 	// Plug the SQS adapter into the monitoring registry's depth
 	// observer (see startSQSDepthObserver). nil sqsServer (e.g.
 	// --sqsAddress empty on this node) is a no-op so single-binary
@@ -2216,13 +2442,18 @@ func (r *runtimeServerRunner) startPublicServices() error {
 	if r.sqsServer != nil {
 		startSQSDepthObserver(r.ctx, r.metricsRegistry, r.sqsServer)
 	}
-	if err := startMetricsServer(r.ctx, r.lc, r.eg, r.metricsAddress, r.metricsToken, r.metricsRegistry.Handler()); err != nil {
-		return r.startupFailure(err)
-	}
-	if err := startPprofServer(r.ctx, r.lc, r.eg, r.pprofAddress, r.pprofToken); err != nil {
-		return r.startupFailure(err)
-	}
+	runPreparedMetricsServer(r.ctx, r.eg, r.metricsServer, r.metricsListener, r.metricsBindAddr)
+	r.metricsListener = nil
+	runPreparedPprofServer(r.ctx, r.eg, r.pprofServer, r.pprofListener, r.pprofBindAddr)
+	r.pprofListener = nil
 	return nil
+}
+
+func (r *runtimeServerRunner) startAdminHTTP() {
+	if r.adminHTTP == nil {
+		return
+	}
+	r.adminHTTP.start(r.ctx, r.eg)
 }
 
 // buildKeyVizSampler constructs the in-memory keyviz sampler from

--- a/main.go
+++ b/main.go
@@ -1473,7 +1473,7 @@ func (g *startupPublicKVGate) unaryInterceptor(
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
 ) (interface{}, error) {
-	if g != nil && info != nil && !g.ready.Load() && startupPublicKVMethod(info.FullMethod) {
+	if g != nil && info != nil && !g.ready.Load() && startupRotationGatedMethod(info.FullMethod) {
 		// Return a raw gRPC status so clients and retry policy see Unavailable.
 		//nolint:wrapcheck
 		return nil, status.Error(codes.Unavailable, "startup rotation has not completed")
@@ -1481,9 +1481,22 @@ func (g *startupPublicKVGate) unaryInterceptor(
 	return handler(ctx, req)
 }
 
-func startupPublicKVMethod(fullMethod string) bool {
-	return strings.HasPrefix(fullMethod, "/RawKV/") ||
-		strings.HasPrefix(fullMethod, "/TransactionalKV/")
+func startupRotationGatedMethod(fullMethod string) bool {
+	switch fullMethod {
+	case pb.Internal_Forward_FullMethodName,
+		pb.AdminForward_Forward_FullMethodName,
+		pb.Distribution_SplitRange_FullMethodName,
+		pb.EncryptionAdmin_BootstrapEncryption_FullMethodName,
+		pb.EncryptionAdmin_RotateDEK_FullMethodName,
+		pb.EncryptionAdmin_RegisterEncryptionWriter_FullMethodName,
+		pb.EncryptionAdmin_ResyncSidecar_FullMethodName,
+		pb.EncryptionAdmin_EnableStorageEnvelope_FullMethodName,
+		pb.EncryptionAdmin_EnableRaftEnvelope_FullMethodName:
+		return true
+	default:
+		return strings.HasPrefix(fullMethod, "/RawKV/") ||
+			strings.HasPrefix(fullMethod, "/TransactionalKV/")
+	}
 }
 
 // configureAdminService builds the node-side AdminServer plus the interceptor

--- a/main.go
+++ b/main.go
@@ -34,7 +34,9 @@ import (
 	"github.com/cockroachdb/errors"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/reflection"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -1265,6 +1267,7 @@ func startServersAfterStartupRotation(waitRotateOnStartup func(context.Context) 
 			return nil
 		})
 	}
+	publicKVGate := &startupPublicKVGate{}
 	runner := runtimeServerRunner{
 		ctx:             in.ctx,
 		lc:              in.lc,
@@ -1313,6 +1316,7 @@ func startServersAfterStartupRotation(waitRotateOnStartup func(context.Context) 
 		metricsRegistry:                 in.metricsRegistry,
 		roleStore:                       roleStore,
 		encryptionConfChangeInterceptor: in.encryptionConfChangeInterceptor,
+		publicKVGate:                    publicKVGate,
 	}
 	if err := runner.startRaftTransport(); err != nil {
 		return err
@@ -1324,6 +1328,7 @@ func startServersAfterStartupRotation(waitRotateOnStartup func(context.Context) 
 			return errors.Wrap(err, "encryption rotate-on-startup: wait before serving")
 		}
 	}
+	publicKVGate.markReady()
 	if err := runner.startPublicServices(); err != nil {
 		return err
 	}
@@ -1450,6 +1455,35 @@ type adminGRPCInterceptors struct {
 
 func (a adminGRPCInterceptors) empty() bool {
 	return len(a.unary) == 0 && len(a.stream) == 0
+}
+
+type startupPublicKVGate struct {
+	ready atomic.Bool
+}
+
+func (g *startupPublicKVGate) markReady() {
+	if g != nil {
+		g.ready.Store(true)
+	}
+}
+
+func (g *startupPublicKVGate) unaryInterceptor(
+	ctx context.Context,
+	req interface{},
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
+) (interface{}, error) {
+	if g != nil && info != nil && !g.ready.Load() && startupPublicKVMethod(info.FullMethod) {
+		// Return a raw gRPC status so clients and retry policy see Unavailable.
+		//nolint:wrapcheck
+		return nil, status.Error(codes.Unavailable, "startup rotation has not completed")
+	}
+	return handler(ctx, req)
+}
+
+func startupPublicKVMethod(fullMethod string) bool {
+	return strings.HasPrefix(fullMethod, "/RawKV/") ||
+		strings.HasPrefix(fullMethod, "/TransactionalKV/")
 }
 
 // configureAdminService builds the node-side AdminServer plus the interceptor
@@ -1809,20 +1843,27 @@ func startRedisServer(ctx context.Context, lc *net.ListenConfig, eg *errgroup.Gr
 	return nil
 }
 
-func prepareDynamoDBServer(ctx context.Context, lc *net.ListenConfig, dynamoAddr string, shardStore *kv.ShardStore, coordinate kv.Coordinator, leaderDynamo map[string]string, metricsRegistry *monitoring.Registry, readTracker *kv.ActiveTimestampTracker) (*adapter.DynamoDBServer, net.Listener, error) {
-	dynamoL, err := lc.Listen(ctx, "tcp", dynamoAddr)
-	if err != nil {
-		return nil, nil, errors.Wrapf(err, "failed to listen on %s", dynamoAddr)
-	}
-	dynamoServer := adapter.NewDynamoDBServer(
-		dynamoL,
+func newDynamoDBServer(shardStore *kv.ShardStore, coordinate kv.Coordinator, leaderDynamo map[string]string, metricsRegistry *monitoring.Registry, readTracker *kv.ActiveTimestampTracker) *adapter.DynamoDBServer {
+	return adapter.NewDynamoDBServer(
+		nil,
 		shardStore,
 		coordinate,
 		adapter.WithDynamoDBActiveTimestampTracker(readTracker),
 		adapter.WithDynamoDBRequestObserver(metricsRegistry.DynamoDBObserver()),
 		adapter.WithDynamoDBLeaderMap(leaderDynamo),
 	)
-	return dynamoServer, dynamoL, nil
+}
+
+func bindDynamoDBServer(ctx context.Context, lc *net.ListenConfig, dynamoAddr string, dynamoServer *adapter.DynamoDBServer) (net.Listener, error) {
+	if dynamoServer == nil {
+		return nil, errors.New("dynamodb server is not prepared")
+	}
+	dynamoL, err := lc.Listen(ctx, "tcp", dynamoAddr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to listen on %s", dynamoAddr)
+	}
+	dynamoServer.SetListener(dynamoL)
+	return dynamoL, nil
 }
 
 func runDynamoDBServer(ctx context.Context, eg *errgroup.Group, dynamoServer *adapter.DynamoDBServer) {
@@ -2052,11 +2093,17 @@ type runtimeServerRunner struct {
 	// does not need to wait for the (later) admin-config parse.
 	// Nil when no admin access keys are configured.
 	roleStore admin.RoleStore
+
+	publicKVGate *startupPublicKVGate
 }
 
 func (r *runtimeServerRunner) startRaftTransport() error {
 	if err := r.prepareAdminForwardServers(); err != nil {
 		return r.startupFailure(err)
+	}
+	adminGRPCOpts := r.adminGRPCOpts
+	if r.publicKVGate != nil {
+		adminGRPCOpts.unary = append(adminGRPCOpts.unary, r.publicKVGate.unaryInterceptor)
 	}
 	forwardDeps := adminForwardServerDeps{
 		tables:  newDynamoTablesSource(r.dynamoServer),
@@ -2077,7 +2124,7 @@ func (r *runtimeServerRunner) startRaftTransport() error {
 			return r.metricsRegistry.RaftProposalObserver(groupID)
 		},
 		r.adminServer,
-		r.adminGRPCOpts,
+		adminGRPCOpts,
 		forwardDeps,
 		r.encryptionConfChangeInterceptor,
 		r.encWiring,
@@ -2088,18 +2135,12 @@ func (r *runtimeServerRunner) startRaftTransport() error {
 }
 
 func (r *runtimeServerRunner) prepareAdminForwardServers() error {
-	dynamoServer, dynamoListener, err := prepareDynamoDBServer(r.ctx, r.lc, r.dynamoAddress, r.shardStore, r.coordinate, r.leaderDynamo, r.metricsRegistry, r.readTracker)
-	if err != nil {
-		return err
-	}
-	r.dynamoServer = dynamoServer
-	r.dynamoListener = dynamoListener
-	s3Server, s3Listener, err := prepareS3Server(r.ctx, r.lc, r.s3Address, r.shardStore, r.coordinate, r.leaderS3, r.s3Region, r.s3CredsFile, r.s3PathStyleOnly, r.readTracker)
+	r.dynamoServer = newDynamoDBServer(r.shardStore, r.coordinate, r.leaderDynamo, r.metricsRegistry, r.readTracker)
+	s3Server, err := newS3Server(r.s3Address, r.shardStore, r.coordinate, r.leaderS3, r.s3Region, r.s3CredsFile, r.s3PathStyleOnly, r.readTracker)
 	if err != nil {
 		return err
 	}
 	r.s3Server = s3Server
-	r.s3Listener = s3Listener
 	return nil
 }
 
@@ -2123,8 +2164,18 @@ func (r *runtimeServerRunner) startPublicServices() error {
 	if err := startRedisServer(r.ctx, r.lc, r.eg, r.redisAddress, r.shardStore, r.coordinate, r.leaderRedis, r.pubsubRelay, r.metricsRegistry, r.readTracker); err != nil {
 		return r.startupFailure(err)
 	}
+	dynamoListener, err := bindDynamoDBServer(r.ctx, r.lc, r.dynamoAddress, r.dynamoServer)
+	if err != nil {
+		return r.startupFailure(err)
+	}
+	r.dynamoListener = dynamoListener
 	runDynamoDBServer(r.ctx, r.eg, r.dynamoServer)
 	r.dynamoListener = nil
+	s3Listener, err := bindS3Server(r.ctx, r.lc, r.s3Address, r.s3Server)
+	if err != nil {
+		return r.startupFailure(err)
+	}
+	r.s3Listener = s3Listener
 	runS3Server(r.ctx, r.eg, r.s3Server)
 	r.s3Listener = nil
 	sqsServer, err := startSQSServer(r.ctx, r.lc, r.eg, r.sqsAddress, r.shardStore, r.coordinate, r.leaderSQS, r.sqsRegion, r.sqsCredsFile, r.sqsPartitionResolver, r.sqsPartitionObserver)

--- a/main_admin.go
+++ b/main_admin.go
@@ -62,10 +62,6 @@ type adminListenerConfig struct {
 	fullAccessKeys     []string
 }
 
-// startAdminFromFlags is the single entrypoint main.run() uses to stand
-// up the admin listener. It owns the flag → config translation and the
-// credentials loading so run() does not inherit that complexity.
-//
 // keyVizFanoutConfig bundles the operator-supplied fan-out flags.
 // Empty Nodes leaves the keyviz handler in single-node mode.
 type keyVizFanoutConfig struct {
@@ -73,14 +69,16 @@ type keyVizFanoutConfig struct {
 	Timeout time.Duration
 }
 
+// prepareAdminFromFlags owns the flag → config translation and credentials
+// loading so run() does not inherit that complexity.
+//
 // When admin is disabled (the default) the function returns immediately
 // without touching --s3CredentialsFile: pulling the admin feature into
 // a hard dependency on that file would break deployments that never
 // intended to use it.
-func startAdminFromFlags(
+func prepareAdminFromFlags(
 	ctx context.Context,
 	lc *net.ListenConfig,
-	eg *errgroup.Group,
 	runtimes []*raftGroupRuntime,
 	dynamoServer *adapter.DynamoDBServer,
 	s3Server *adapter.S3Server,
@@ -89,13 +87,13 @@ func startAdminFromFlags(
 	connCache *kv.GRPCConnCache,
 	keyvizSampler *keyviz.MemSampler,
 	keyvizFanoutCfg keyVizFanoutConfig,
-) error {
+) (*preparedAdminServer, error) {
 	if !*adminEnabled {
-		return nil
+		return nil, nil
 	}
 	staticCreds, err := loadS3StaticCredentials(*s3CredsFile)
 	if err != nil {
-		return errors.Wrapf(err, "load static credentials for admin listener")
+		return nil, errors.Wrapf(err, "load static credentials for admin listener")
 	}
 	// An admin listener with zero credentials would accept logins
 	// only to reject every one of them with invalid_credentials, so a
@@ -105,16 +103,16 @@ func startAdminFromFlags(
 	// untyped `== nil` check cannot detect a nil-map-valued interface
 	// on its own).
 	if len(staticCreds) == 0 {
-		return errors.New("admin listener is enabled but no static credentials are configured; " +
+		return nil, errors.New("admin listener is enabled but no static credentials are configured; " +
 			"set -s3CredentialsFile to a file with at least one entry")
 	}
 	primaryKey, err := resolveSigningKey(*adminSessionSigningKey, *adminSessionSigningKeyFile, envAdminSessionSigningKey)
 	if err != nil {
-		return errors.Wrap(err, "resolve -adminSessionSigningKey")
+		return nil, errors.Wrap(err, "resolve -adminSessionSigningKey")
 	}
 	previousKey, err := resolveSigningKey(*adminSessionSigningKeyPrevious, *adminSessionSigningKeyPreviousFile, envAdminSessionSigningKeyPrevious)
 	if err != nil {
-		return errors.Wrap(err, "resolve -adminSessionSigningKeyPrevious")
+		return nil, errors.Wrap(err, "resolve -adminSessionSigningKeyPrevious")
 	}
 	cfg := adminListenerConfig{
 		enabled:                   *adminEnabled,
@@ -134,11 +132,10 @@ func startAdminFromFlags(
 	queuesSrc := newSqsQueuesSource(sqsServer)
 	forwarder, err := buildAdminLeaderForwarder(coordinate, connCache, *raftId)
 	if err != nil {
-		return errors.Wrap(err, "build admin leader forwarder")
+		return nil, errors.Wrap(err, "build admin leader forwarder")
 	}
 	leaderProbe := newAdminLeaderProbe(coordinate)
-	_, err = startAdminServer(ctx, lc, eg, cfg, staticCreds, clusterSrc, tablesSrc, bucketsSrc, queuesSrc, forwarder, leaderProbe, keyvizSampler, keyvizFanoutCfg, buildVersion())
-	return err
+	return prepareAdminServer(ctx, lc, cfg, staticCreds, clusterSrc, tablesSrc, bucketsSrc, queuesSrc, forwarder, leaderProbe, keyvizSampler, keyvizFanoutCfg, buildVersion())
 }
 
 // newAdminLeaderProbe builds the LeaderProbe consumed by
@@ -1019,21 +1016,17 @@ func buildAdminConfig(in adminListenerConfig) admin.Config {
 	}
 }
 
-// startAdminServer validates the admin configuration, constructs the admin
-// server, and attaches its lifecycle to eg. It is a no-op when the admin
-// listener is disabled. Errors at this point are hard startup failures:
-// the design doc mandates ハードエラーで起動失敗 for every invalid
-// configuration, and we honour that uniformly.
-//
-// The returned address is the actual host:port the listener bound to; it
-// differs from adminCfg.Listen only when the caller passed a port of 0,
-// but tests rely on this to avoid the bind-close-rebind race that a
-// pre-allocated free-port helper would otherwise introduce. When admin
-// is disabled the returned address is empty.
-func startAdminServer(
+type preparedAdminServer struct {
+	httpSrv    *http.Server
+	listener   net.Listener
+	cfg        admin.Config
+	tlsEnabled bool
+	version    string
+}
+
+func prepareAdminServer(
 	ctx context.Context,
 	lc *net.ListenConfig,
-	eg *errgroup.Group,
 	cfg adminListenerConfig,
 	creds map[string]string,
 	cluster admin.ClusterInfoSource,
@@ -1045,20 +1038,20 @@ func startAdminServer(
 	keyvizSampler *keyviz.MemSampler,
 	keyvizFanoutCfg keyVizFanoutConfig,
 	version string,
-) (string, error) {
+) (*preparedAdminServer, error) {
 	adminCfg := buildAdminConfig(cfg)
 	enabled, err := checkAdminConfig(&adminCfg, cluster)
 	if err != nil || !enabled {
-		return "", err
+		return nil, err
 	}
 	server, err := buildAdminHTTPServer(&adminCfg, creds, cluster, tables, buckets, queues, forwarder, leaderProbe, keyvizSampler, keyvizFanoutCfg)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	httpSrv := newAdminHTTPServer(server)
 	listener, err := lc.Listen(ctx, "tcp", adminCfg.Listen)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to listen on admin address %s", adminCfg.Listen)
+		return nil, errors.Wrapf(err, "failed to listen on admin address %s", adminCfg.Listen)
 	}
 	tlsEnabled := strings.TrimSpace(adminCfg.TLSCertFile) != "" && strings.TrimSpace(adminCfg.TLSKeyFile) != ""
 	if tlsEnabled {
@@ -1069,8 +1062,31 @@ func startAdminServer(
 	// task so the shutdown banner matches startup.
 	boundCfg := adminCfg
 	boundCfg.Listen = actualAddr
-	registerAdminLifecycle(ctx, eg, httpSrv, listener, &boundCfg, tlsEnabled, version)
-	return actualAddr, nil
+	return &preparedAdminServer{
+		httpSrv:    httpSrv,
+		listener:   listener,
+		cfg:        boundCfg,
+		tlsEnabled: tlsEnabled,
+		version:    version,
+	}, nil
+}
+
+func (p *preparedAdminServer) start(ctx context.Context, eg *errgroup.Group) {
+	if p == nil || p.httpSrv == nil || p.listener == nil {
+		return
+	}
+	registerAdminLifecycle(ctx, eg, p.httpSrv, p.listener, &p.cfg, p.tlsEnabled, p.version)
+	p.listener = nil
+}
+
+func (p *preparedAdminServer) close() {
+	if p == nil {
+		return
+	}
+	if p.listener != nil {
+		_ = p.listener.Close()
+		p.listener = nil
+	}
 }
 
 // checkAdminConfig validates adminCfg; returns (enabled=false, nil) when

--- a/main_admin_forward.go
+++ b/main_admin_forward.go
@@ -106,7 +106,7 @@ func registerAdminForwardServer(gs *grpc.Server, deps adminForwardServerDeps, lo
 // roleStoreFromFlags builds the same access-key → role map that
 // admin.Config.RoleIndex produces, but from the raw flag strings so
 // the gRPC ForwardServer registration in startRaftServers does not
-// need to wait for startAdminFromFlags to parse the admin config.
+// need to wait for prepareAdminFromFlags to parse the admin config.
 // Returns nil when no keys are configured at all — that shape is the
 // "admin auth disabled" signal adminForwardServerDeps consumes to
 // skip registration.
@@ -120,7 +120,7 @@ func roleStoreFromFlags(fullKeys, readOnlyKeys []string) admin.RoleStore {
 	}
 	for _, k := range readOnlyKeys {
 		// Overlap with FullAccessKeys is rejected at admin.Config.Validate
-		// time during startAdminFromFlags. We can't replicate that here
+		// time during prepareAdminFromFlags. We can't replicate that here
 		// without parsing the full config, so the ReadOnlyAccessKeys loop
 		// runs second to mirror RoleIndex's "last-write-wins-but-only-for-
 		// non-overlapping-keys" semantics — overlap is a startup error

--- a/main_admin_test.go
+++ b/main_admin_test.go
@@ -196,50 +196,43 @@ func TestParseCSV(t *testing.T) {
 }
 
 func TestStartAdminServer_DisabledNoOp(t *testing.T) {
-	eg, ctx := errgroup.WithContext(context.Background())
-	defer func() { _ = eg.Wait() }()
 	var lc net.ListenConfig
-	_, err := startAdminServer(ctx, &lc, eg, adminListenerConfig{enabled: false}, nil, nil, nil, nil, nil, nil, nil, nil, keyVizFanoutConfig{}, "")
+	prepared, err := prepareAdminServer(context.Background(), &lc, adminListenerConfig{enabled: false}, nil, nil, nil, nil, nil, nil, nil, nil, keyVizFanoutConfig{}, "")
 	require.NoError(t, err)
+	require.Nil(t, prepared)
 }
 
 func TestStartAdminServer_InvalidConfigRejected(t *testing.T) {
-	eg, ctx := errgroup.WithContext(context.Background())
-	defer func() { _ = eg.Wait() }()
 	var lc net.ListenConfig
 	cfg := adminListenerConfig{
 		enabled: true,
 		listen:  "127.0.0.1:0",
 		// missing signing key
 	}
-	_, err := startAdminServer(ctx, &lc, eg, cfg, map[string]string{}, nil, nil, nil, nil, nil, nil, nil, keyVizFanoutConfig{}, "")
+	_, err := prepareAdminServer(context.Background(), &lc, cfg, map[string]string{}, nil, nil, nil, nil, nil, nil, nil, keyVizFanoutConfig{}, "")
 	require.Error(t, err)
 }
 
 func TestStartAdminServer_NonLoopbackWithoutTLSRejected(t *testing.T) {
-	eg, ctx := errgroup.WithContext(context.Background())
-	defer func() { _ = eg.Wait() }()
 	var lc net.ListenConfig
 	cfg := adminListenerConfig{
 		enabled:           true,
 		listen:            "0.0.0.0:0",
 		sessionSigningKey: freshKey(),
 	}
-	_, err := startAdminServer(ctx, &lc, eg, cfg, map[string]string{}, nil, nil, nil, nil, nil, nil, nil, keyVizFanoutConfig{}, "")
+	_, err := prepareAdminServer(context.Background(), &lc, cfg, map[string]string{}, nil, nil, nil, nil, nil, nil, nil, keyVizFanoutConfig{}, "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "TLS")
 }
 
 func TestStartAdminServer_RejectsMissingClusterSource(t *testing.T) {
-	eg, ctx := errgroup.WithContext(context.Background())
-	defer func() { _ = eg.Wait() }()
 	var lc net.ListenConfig
 	cfg := adminListenerConfig{
 		enabled:           true,
 		listen:            "127.0.0.1:0",
 		sessionSigningKey: freshKey(),
 	}
-	_, err := startAdminServer(ctx, &lc, eg, cfg, map[string]string{}, nil, nil, nil, nil, nil, nil, nil, keyVizFanoutConfig{}, "")
+	_, err := prepareAdminServer(context.Background(), &lc, cfg, map[string]string{}, nil, nil, nil, nil, nil, nil, nil, keyVizFanoutConfig{}, "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cluster info source")
 }
@@ -262,8 +255,11 @@ func TestStartAdminServer_ServesHealthz(t *testing.T) {
 	cluster := admin.ClusterInfoFunc(func(_ context.Context) (admin.ClusterInfo, error) {
 		return admin.ClusterInfo{NodeID: "n1", Version: "test"}, nil
 	})
-	addr, err := startAdminServer(eCtx, &lc, eg, cfg, map[string]string{}, cluster, nil, nil, nil, nil, nil, nil, keyVizFanoutConfig{}, "test")
+	prepared, err := prepareAdminServer(eCtx, &lc, cfg, map[string]string{}, cluster, nil, nil, nil, nil, nil, nil, keyVizFanoutConfig{}, "test")
 	require.NoError(t, err)
+	require.NotNil(t, prepared)
+	addr := prepared.cfg.Listen
+	prepared.start(eCtx, eg)
 
 	// Poll /admin/healthz until success or the test deadline.
 	client := &http.Client{Timeout: 2 * time.Second}
@@ -305,8 +301,11 @@ func TestStartAdminServer_ServesTLS(t *testing.T) {
 	cluster := admin.ClusterInfoFunc(func(_ context.Context) (admin.ClusterInfo, error) {
 		return admin.ClusterInfo{NodeID: "n-tls", Version: "test"}, nil
 	})
-	addr, err := startAdminServer(eCtx, &lc, eg, cfg, map[string]string{}, cluster, nil, nil, nil, nil, nil, nil, keyVizFanoutConfig{}, "test")
+	prepared, err := prepareAdminServer(eCtx, &lc, cfg, map[string]string{}, cluster, nil, nil, nil, nil, nil, nil, keyVizFanoutConfig{}, "test")
 	require.NoError(t, err)
+	require.NotNil(t, prepared)
+	addr := prepared.cfg.Listen
+	prepared.start(eCtx, eg)
 
 	transport := &http.Transport{TLSClientConfig: &tls.Config{
 		InsecureSkipVerify: true, //nolint:gosec // self-signed certificate in test; server identity is not what we assert here.

--- a/main_encryption_rotate_on_startup.go
+++ b/main_encryption_rotate_on_startup.go
@@ -1,0 +1,326 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"log/slog"
+	"math"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	"github.com/bootjp/elastickv/adapter"
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/bootjp/elastickv/internal/encryption/kek"
+	"github.com/bootjp/elastickv/internal/raftengine"
+	pb "github.com/bootjp/elastickv/proto"
+	"github.com/cockroachdb/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type encryptionRotateOnStartupController interface {
+	raftengine.LeaderView
+	RegisterLeaderAcquiredCallback(fn func()) (deregister func())
+}
+
+type encryptionRotateOnStartupRunner interface {
+	Run(context.Context) error
+	Done() bool
+}
+
+type encryptionRotateOnStartupTask struct {
+	server       *adapter.EncryptionAdminServer
+	sidecarPath  string
+	kekWrapper   kek.Wrapper
+	fullNodeID   uint64
+	storageEpoch uint16
+	raftEpoch    uint16
+
+	mu          sync.Mutex
+	nextReady   bool
+	nextKeyID   uint32
+	storageDone bool
+	raftDone    bool
+}
+
+func installEncryptionRotateOnStartup(
+	ctx context.Context,
+	requested bool,
+	rt *raftGroupRuntime,
+	postCutoverProposer raftengine.Proposer,
+	sidecarPath string,
+	kekWrapper kek.Wrapper,
+	fullNodeID uint64,
+	storageEpoch uint16,
+	raftEpoch uint16,
+	logger *slog.Logger,
+) func() {
+	if !requested {
+		return func() {}
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if rt == nil || rt.engine == nil {
+		logger.Warn("encryption rotate-on-startup skipped: default raft group is not available")
+		return func() {}
+	}
+	controller, ok := rt.engine.(encryptionRotateOnStartupController)
+	if !ok {
+		logger.Warn("encryption rotate-on-startup skipped: engine does not implement leader-acquired observer")
+		return func() {}
+	}
+	if sidecarPath == "" || kekWrapper == nil {
+		logger.Warn("encryption rotate-on-startup skipped: encryption sidecar or KEK is not configured")
+		return func() {}
+	}
+	server := adapter.NewEncryptionAdminServer(
+		adapter.WithEncryptionAdminSidecarPath(sidecarPath),
+		adapter.WithEncryptionAdminFullNodeID(fullNodeID),
+		adapter.WithEncryptionAdminProposer(rt.engine),
+		adapter.WithEncryptionAdminLeaderView(rt.engine),
+		adapter.WithEncryptionAdminPostCutoverProposer(postCutoverProposer),
+	)
+	if err := server.Validate(); err != nil {
+		logger.Warn("encryption rotate-on-startup skipped: admin server wiring invalid", "err", err)
+		return func() {}
+	}
+	task := &encryptionRotateOnStartupTask{
+		server:       server,
+		sidecarPath:  sidecarPath,
+		kekWrapper:   kekWrapper,
+		fullNodeID:   fullNodeID,
+		storageEpoch: storageEpoch,
+		raftEpoch:    raftEpoch,
+	}
+	return installEncryptionRotateOnStartupRequest(ctx, controller, task, logger)
+}
+
+func installEncryptionRotateOnStartupRequest(
+	ctx context.Context,
+	controller encryptionRotateOnStartupController,
+	task encryptionRotateOnStartupRunner,
+	logger *slog.Logger,
+) func() {
+	if controller == nil || task == nil {
+		return func() {}
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	var inFlight atomic.Bool
+	fire := func(block bool) {
+		fireEncryptionRotateOnStartup(ctx, controller, task, logger, &inFlight, block)
+	}
+	wasLeaderBefore := controller.State() == raftengine.StateLeader
+	if wasLeaderBefore {
+		fire(true)
+	}
+	deregister := controller.RegisterLeaderAcquiredCallback(func() {
+		fire(false)
+	})
+	if !wasLeaderBefore && controller.State() == raftengine.StateLeader {
+		fire(false)
+	}
+	return deregister
+}
+
+func fireEncryptionRotateOnStartup(
+	ctx context.Context,
+	controller encryptionRotateOnStartupController,
+	task encryptionRotateOnStartupRunner,
+	logger *slog.Logger,
+	inFlight *atomic.Bool,
+	block bool,
+) {
+	if task.Done() || controller.State() != raftengine.StateLeader {
+		return
+	}
+	run := func() {
+		if !inFlight.CompareAndSwap(false, true) {
+			return
+		}
+		defer inFlight.Store(false)
+		if task.Done() || controller.State() != raftengine.StateLeader {
+			return
+		}
+		if err := task.Run(ctx); err != nil {
+			logEncryptionRotateOnStartupError(logger, err)
+		}
+	}
+	if block {
+		run()
+		return
+	}
+	go run()
+}
+
+func logEncryptionRotateOnStartupError(logger *slog.Logger, err error) {
+	if retryableEncryptionRotateOnStartupError(err) {
+		logger.Warn("encryption rotate-on-startup deferred after transient error", "err", err)
+		return
+	}
+	logger.Warn("encryption rotate-on-startup gave up after permanent error", "err", err)
+}
+
+func (t *encryptionRotateOnStartupTask) Done() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.storageDone && t.raftDone
+}
+
+func (t *encryptionRotateOnStartupTask) Run(ctx context.Context) error {
+	sc, err := encryption.ReadSidecar(t.sidecarPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) || encryption.IsNotExist(err) {
+			t.markAllDone()
+			return nil
+		}
+		return errors.Wrap(err, "encryption rotate-on-startup: read sidecar")
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if err := t.prepareNextKeyIDLocked(sc); err != nil {
+		t.storageDone = true
+		t.raftDone = true
+		return err
+	}
+	if err := t.rotatePurposeIfActiveLocked(
+		ctx, &t.storageDone, sc.Active.Storage,
+		pb.RotateDEKRequest_PURPOSE_STORAGE, t.storageEpoch,
+	); err != nil {
+		return err
+	}
+	if err := t.rotatePurposeIfActiveLocked(
+		ctx, &t.raftDone, sc.Active.Raft,
+		pb.RotateDEKRequest_PURPOSE_RAFT, t.raftEpoch,
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *encryptionRotateOnStartupTask) markAllDone() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.storageDone = true
+	t.raftDone = true
+}
+
+func (t *encryptionRotateOnStartupTask) prepareNextKeyIDLocked(sc *encryption.Sidecar) error {
+	if t.nextReady {
+		return nil
+	}
+	next, err := nextEncryptionRotateOnStartupKeyID(sc)
+	if err != nil {
+		return err
+	}
+	t.nextKeyID = next
+	t.nextReady = true
+	return nil
+}
+
+func (t *encryptionRotateOnStartupTask) rotatePurposeIfActiveLocked(
+	ctx context.Context,
+	done *bool,
+	activeID uint32,
+	purpose pb.RotateDEKRequest_Purpose,
+	localEpoch uint16,
+) error {
+	if activeID == encryption.ReservedKeyID {
+		*done = true
+		return nil
+	}
+	if *done {
+		return nil
+	}
+	if err := t.rotateLocked(ctx, purpose, localEpoch); err != nil {
+		return err
+	}
+	*done = true
+	return nil
+}
+
+func (t *encryptionRotateOnStartupTask) rotateLocked(ctx context.Context, purpose pb.RotateDEKRequest_Purpose, localEpoch uint16) error {
+	if t.nextKeyID == encryption.ReservedKeyID {
+		return errors.New("encryption rotate-on-startup: key_id space exhausted")
+	}
+	keyID := t.nextKeyID
+	wrapped, err := wrapFreshStartupDEK(t.kekWrapper)
+	if err != nil {
+		return err
+	}
+	_, err = t.server.RotateDEK(ctx, &pb.RotateDEKRequest{
+		Purpose:            purpose,
+		NewDekId:           keyID,
+		WrappedNewDek:      wrapped,
+		ProposerNodeId:     t.fullNodeID,
+		ProposerLocalEpoch: uint32(localEpoch),
+	})
+	if err != nil {
+		return errors.Wrap(err, "encryption rotate-on-startup: RotateDEK")
+	}
+	if keyID == math.MaxUint32 {
+		t.nextKeyID = encryption.ReservedKeyID
+	} else {
+		t.nextKeyID = keyID + 1
+	}
+	return nil
+}
+
+func nextEncryptionRotateOnStartupKeyID(sc *encryption.Sidecar) (uint32, error) {
+	var maxID uint32
+	for raw := range sc.Keys {
+		id64, err := strconv.ParseUint(raw, 10, 32)
+		if err != nil {
+			return 0, errors.Wrapf(err, "encryption rotate-on-startup: parse sidecar key_id %q", raw)
+		}
+		if uint32(id64) > maxID {
+			maxID = uint32(id64)
+		}
+	}
+	if maxID == math.MaxUint32 {
+		return 0, errors.New("encryption rotate-on-startup: key_id space exhausted")
+	}
+	return maxID + 1, nil
+}
+
+func wrapFreshStartupDEK(wrapper kek.Wrapper) ([]byte, error) {
+	if wrapper == nil {
+		return nil, errors.New("encryption rotate-on-startup: KEK wrapper is nil")
+	}
+	dek := make([]byte, encryption.KeySize)
+	if _, err := rand.Read(dek); err != nil {
+		return nil, errors.Wrap(err, "encryption rotate-on-startup: generate DEK")
+	}
+	defer zeroBytes(dek)
+	wrapped, err := wrapper.Wrap(dek)
+	if err != nil {
+		return nil, errors.Wrap(err, "encryption rotate-on-startup: wrap DEK")
+	}
+	return wrapped, nil
+}
+
+func zeroBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+func retryableEncryptionRotateOnStartupError(err error) bool {
+	switch {
+	case errors.Is(err, raftengine.ErrNotLeader),
+		errors.Is(err, raftengine.ErrLeadershipLost),
+		errors.Is(err, raftengine.ErrLeadershipTransferInProgress):
+		return true
+	case errors.Is(err, context.Canceled):
+		return false
+	}
+	code := status.Code(err)
+	return code == codes.FailedPrecondition ||
+		code == codes.Unavailable ||
+		code == codes.DeadlineExceeded
+}

--- a/main_encryption_rotate_on_startup.go
+++ b/main_encryption_rotate_on_startup.go
@@ -70,25 +70,25 @@ func installEncryptionRotateOnStartup(
 	storageEpoch uint16,
 	raftEpoch uint16,
 	logger *slog.Logger,
-) (func(), func(context.Context) error) {
+) (func(), startupRotationWaiter) {
 	if !requested {
-		return func() {}, encryptionRotateOnStartupNoopWait
+		return func() {}, startupRotationWaiter{}
 	}
 	if logger == nil {
 		logger = slog.Default()
 	}
 	if rt == nil || rt.engine == nil {
 		logger.Warn("encryption rotate-on-startup skipped: default raft group is not available")
-		return func() {}, encryptionRotateOnStartupNoopWait
+		return func() {}, startupRotationWaiter{}
 	}
 	controller, ok := rt.engine.(encryptionRotateOnStartupController)
 	if !ok {
 		logger.Warn("encryption rotate-on-startup skipped: engine does not implement leader-acquired observer")
-		return func() {}, encryptionRotateOnStartupNoopWait
+		return func() {}, startupRotationWaiter{}
 	}
 	if sidecarPath == "" || kekWrapper == nil {
 		logger.Warn("encryption rotate-on-startup skipped: encryption sidecar or KEK is not configured")
-		return func() {}, encryptionRotateOnStartupNoopWait
+		return func() {}, startupRotationWaiter{}
 	}
 	server := adapter.NewEncryptionAdminServer(
 		adapter.WithEncryptionAdminSidecarPath(sidecarPath),
@@ -99,7 +99,7 @@ func installEncryptionRotateOnStartup(
 	)
 	if err := server.Validate(); err != nil {
 		logger.Warn("encryption rotate-on-startup skipped: admin server wiring invalid", "err", err)
-		return func() {}, encryptionRotateOnStartupNoopWait
+		return func() {}, startupRotationWaiter{}
 	}
 	task := &encryptionRotateOnStartupTask{
 		server:       server,
@@ -114,14 +114,30 @@ func installEncryptionRotateOnStartup(
 	return installEncryptionRotateOnStartupRequestWithWait(ctx, controller, task, logger)
 }
 
+type startupRotationWaiter struct {
+	wait         func(context.Context) error
+	blockMutator func() bool
+}
+
+func (w startupRotationWaiter) Wait(ctx context.Context) error {
+	if w.wait == nil {
+		return nil
+	}
+	return w.wait(ctx)
+}
+
+func (w startupRotationWaiter) BlockMutators() bool {
+	return w.blockMutator != nil && w.blockMutator()
+}
+
 func installEncryptionRotateOnStartupRequestWithWait(
 	ctx context.Context,
 	controller encryptionRotateOnStartupController,
 	task encryptionRotateOnStartupRunner,
 	logger *slog.Logger,
-) (func(), func(context.Context) error) {
+) (func(), startupRotationWaiter) {
 	if controller == nil || task == nil {
-		return func() {}, encryptionRotateOnStartupNoopWait
+		return func() {}, startupRotationWaiter{}
 	}
 	if logger == nil {
 		logger = slog.Default()
@@ -141,7 +157,13 @@ func installEncryptionRotateOnStartupRequestWithWait(
 		callbacksEnabled.Store(true)
 		return waitEncryptionRotateOnStartupIdle(waitCtx, controller, task, logger, &flight)
 	}
-	return deregister, waitStartup
+	blockMutators := func() bool {
+		if flight.terminalError() != nil {
+			return true
+		}
+		return controller.State() == raftengine.StateLeader && !task.Done()
+	}
+	return deregister, startupRotationWaiter{wait: waitStartup, blockMutator: blockMutators}
 }
 
 func (s *encryptionRotateOnStartupFlightState) publishDone(done <-chan struct{}) {
@@ -300,8 +322,6 @@ func waitEncryptionRotateOnStartupFlightPublish(ctx context.Context) error {
 		return nil
 	}
 }
-
-func encryptionRotateOnStartupNoopWait(context.Context) error { return nil }
 
 func logEncryptionRotateOnStartupError(logger *slog.Logger, err error) {
 	if retryableEncryptionRotateOnStartupError(err) {

--- a/main_encryption_rotate_on_startup.go
+++ b/main_encryption_rotate_on_startup.go
@@ -22,6 +22,7 @@ import (
 )
 
 var encryptionRotateOnStartupRetryDelay = 200 * time.Millisecond
+var encryptionRotateOnStartupFlightPublishPoll = 10 * time.Millisecond
 
 type encryptionRotateOnStartupController interface {
 	raftengine.LeaderView
@@ -31,6 +32,14 @@ type encryptionRotateOnStartupController interface {
 type encryptionRotateOnStartupRunner interface {
 	Run(context.Context) error
 	Done() bool
+}
+
+type encryptionRotateOnStartupFlightState struct {
+	inFlight atomic.Bool
+
+	mu          sync.Mutex
+	done        <-chan struct{}
+	terminalErr error
 }
 
 type encryptionRotateOnStartupTask struct {
@@ -127,17 +136,9 @@ func installEncryptionRotateOnStartupRequestWithWait(
 	if logger == nil {
 		logger = slog.Default()
 	}
-	var inFlight atomic.Bool
-	var flightMu sync.Mutex
-	var flightDone <-chan struct{}
+	var flight encryptionRotateOnStartupFlightState
 	fire := func(block bool) {
-		done := fireEncryptionRotateOnStartup(ctx, controller, task, logger, &inFlight, block)
-		if done == nil {
-			return
-		}
-		flightMu.Lock()
-		flightDone = done
-		flightMu.Unlock()
+		_ = fireEncryptionRotateOnStartup(ctx, controller, task, logger, &flight, block)
 	}
 	wasLeaderBefore := controller.State() == raftengine.StateLeader
 	if wasLeaderBefore {
@@ -150,9 +151,46 @@ func installEncryptionRotateOnStartupRequestWithWait(
 		fire(false)
 	}
 	waitStartup := func(waitCtx context.Context) error {
-		return waitEncryptionRotateOnStartupIdle(waitCtx, controller, task, logger, &inFlight, &flightMu, &flightDone)
+		return waitEncryptionRotateOnStartupIdle(waitCtx, controller, task, logger, &flight)
 	}
 	return deregister, waitStartup
+}
+
+func (s *encryptionRotateOnStartupFlightState) publishDone(done <-chan struct{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.done = done
+}
+
+func (s *encryptionRotateOnStartupFlightState) currentDone() <-chan struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.done
+}
+
+func (s *encryptionRotateOnStartupFlightState) clearDone(done <-chan struct{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.done == done {
+		s.done = nil
+	}
+}
+
+func (s *encryptionRotateOnStartupFlightState) setTerminalError(err error) {
+	if err == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.terminalErr == nil {
+		s.terminalErr = err
+	}
+}
+
+func (s *encryptionRotateOnStartupFlightState) terminalError() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.terminalErr
 }
 
 func fireEncryptionRotateOnStartup(
@@ -160,19 +198,23 @@ func fireEncryptionRotateOnStartup(
 	controller encryptionRotateOnStartupController,
 	task encryptionRotateOnStartupRunner,
 	logger *slog.Logger,
-	inFlight *atomic.Bool,
+	flight *encryptionRotateOnStartupFlightState,
 	block bool,
 ) <-chan struct{} {
+	if flight.terminalError() != nil {
+		return nil
+	}
 	if controller.State() != raftengine.StateLeader {
 		return nil
 	}
-	if !inFlight.CompareAndSwap(false, true) {
+	if !flight.inFlight.CompareAndSwap(false, true) {
 		return nil
 	}
 	done := make(chan struct{})
+	flight.publishDone(done)
 	run := func() {
 		defer close(done)
-		runEncryptionRotateOnStartup(ctx, controller, task, logger, inFlight)
+		flight.setTerminalError(runEncryptionRotateOnStartup(ctx, controller, task, logger, &flight.inFlight))
 	}
 	if block {
 		run()
@@ -188,25 +230,25 @@ func runEncryptionRotateOnStartup(
 	task encryptionRotateOnStartupRunner,
 	logger *slog.Logger,
 	inFlight *atomic.Bool,
-) {
+) error {
 	defer inFlight.Store(false)
 	for {
 		if task.Done() || controller.State() != raftengine.StateLeader {
-			return
+			return nil
 		}
 		err := task.Run(ctx)
 		if err == nil || task.Done() || controller.State() != raftengine.StateLeader {
-			return
+			return nil
 		}
 		logEncryptionRotateOnStartupError(logger, err)
 		if !retryableEncryptionRotateOnStartupError(err) {
-			return
+			return errors.Wrap(err, "encryption rotate-on-startup: permanent failure")
 		}
 		timer := time.NewTimer(encryptionRotateOnStartupRetryDelay)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return
+			return errors.Wrap(ctx.Err(), "encryption rotate-on-startup: retry wait")
 		case <-timer.C:
 		}
 	}
@@ -217,34 +259,57 @@ func waitEncryptionRotateOnStartupIdle(
 	controller encryptionRotateOnStartupController,
 	task encryptionRotateOnStartupRunner,
 	logger *slog.Logger,
-	inFlight *atomic.Bool,
-	flightMu *sync.Mutex,
-	flightDone *<-chan struct{},
+	flight *encryptionRotateOnStartupFlightState,
 ) error {
 	for {
-		flightMu.Lock()
-		done := *flightDone
-		flightMu.Unlock()
-		if done != nil {
-			select {
-			case <-ctx.Done():
-				return errors.Wrap(ctx.Err(), "encryption rotate-on-startup: wait for in-flight attempt")
-			case <-done:
-			}
-			flightMu.Lock()
-			if *flightDone == done {
-				*flightDone = nil
-			}
-			flightMu.Unlock()
+		if err := flight.terminalError(); err != nil {
+			return err
+		}
+		waited, err := waitCurrentEncryptionRotateOnStartupFlight(ctx, flight)
+		if err != nil {
+			return err
+		}
+		if waited {
 			continue
 		}
 		if task.Done() || controller.State() != raftengine.StateLeader {
 			return nil
 		}
-		done = fireEncryptionRotateOnStartup(ctx, controller, task, logger, inFlight, true)
+		if flight.inFlight.Load() {
+			if err := waitEncryptionRotateOnStartupFlightPublish(ctx); err != nil {
+				return err
+			}
+			continue
+		}
+		done := fireEncryptionRotateOnStartup(ctx, controller, task, logger, flight, true)
 		if done == nil {
 			return nil
 		}
+	}
+}
+
+func waitCurrentEncryptionRotateOnStartupFlight(ctx context.Context, flight *encryptionRotateOnStartupFlightState) (bool, error) {
+	done := flight.currentDone()
+	if done == nil {
+		return false, nil
+	}
+	select {
+	case <-ctx.Done():
+		return true, errors.Wrap(ctx.Err(), "encryption rotate-on-startup: wait for in-flight attempt")
+	case <-done:
+	}
+	flight.clearDone(done)
+	return true, nil
+}
+
+func waitEncryptionRotateOnStartupFlightPublish(ctx context.Context) error {
+	timer := time.NewTimer(encryptionRotateOnStartupFlightPublishPoll)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return errors.Wrap(ctx.Err(), "encryption rotate-on-startup: wait for in-flight publication")
+	case <-timer.C:
+		return nil
 	}
 }
 
@@ -280,8 +345,6 @@ func (t *encryptionRotateOnStartupTask) Run(ctx context.Context) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if err := t.prepareNextKeyIDLocked(sc); err != nil {
-		t.storageDone = true
-		t.raftDone = true
 		return err
 	}
 	if err := t.rotatePurposeIfActiveLocked(

--- a/main_encryption_rotate_on_startup.go
+++ b/main_encryption_rotate_on_startup.go
@@ -34,6 +34,7 @@ type encryptionRotateOnStartupTask struct {
 	server       *adapter.EncryptionAdminServer
 	sidecarPath  string
 	kekWrapper   kek.Wrapper
+	raftEnvelope *raftEnvelopeRuntime
 	fullNodeID   uint64
 	storageEpoch uint16
 	raftEpoch    uint16
@@ -52,6 +53,7 @@ func installEncryptionRotateOnStartup(
 	postCutoverProposer raftengine.Proposer,
 	sidecarPath string,
 	kekWrapper kek.Wrapper,
+	raftEnvelope *raftEnvelopeRuntime,
 	fullNodeID uint64,
 	storageEpoch uint16,
 	raftEpoch uint16,
@@ -91,6 +93,7 @@ func installEncryptionRotateOnStartup(
 		server:       server,
 		sidecarPath:  sidecarPath,
 		kekWrapper:   kekWrapper,
+		raftEnvelope: raftEnvelope,
 		fullNodeID:   fullNodeID,
 		storageEpoch: storageEpoch,
 		raftEpoch:    raftEpoch,
@@ -121,7 +124,7 @@ func installEncryptionRotateOnStartupRequest(
 	deregister := controller.RegisterLeaderAcquiredCallback(func() {
 		fire(false)
 	})
-	if !wasLeaderBefore && controller.State() == raftengine.StateLeader {
+	if controller.State() == raftengine.StateLeader && !task.Done() {
 		fire(false)
 	}
 	return deregister
@@ -261,14 +264,26 @@ func (t *encryptionRotateOnStartupTask) rotateLocked(ctx context.Context, purpos
 		ProposerLocalEpoch: uint32(localEpoch),
 	})
 	if err != nil {
+		if retryableEncryptionRotateOnStartupError(err) {
+			t.advanceNextKeyIDLocked(keyID)
+		}
 		return errors.Wrap(err, "encryption rotate-on-startup: RotateDEK")
 	}
+	t.advanceNextKeyIDLocked(keyID)
+	if purpose == pb.RotateDEKRequest_PURPOSE_RAFT && t.raftEnvelope != nil {
+		if err := t.raftEnvelope.installRotatedRaftDEK(keyID); err != nil {
+			return errors.Wrap(err, "encryption rotate-on-startup: install rotated raft envelope wrapper")
+		}
+	}
+	return nil
+}
+
+func (t *encryptionRotateOnStartupTask) advanceNextKeyIDLocked(keyID uint32) {
 	if keyID == math.MaxUint32 {
 		t.nextKeyID = encryption.ReservedKeyID
 	} else {
 		t.nextKeyID = keyID + 1
 	}
-	return nil
 }
 
 func nextEncryptionRotateOnStartupKeyID(sc *encryption.Sidecar) (uint32, error) {
@@ -319,7 +334,7 @@ func retryableEncryptionRotateOnStartupError(err error) bool {
 	case errors.Is(err, context.Canceled):
 		return false
 	}
-	code := status.Code(err)
+	code := status.Code(errors.Cause(err))
 	return code == codes.FailedPrecondition ||
 		code == codes.Unavailable ||
 		code == codes.DeadlineExceeded

--- a/main_encryption_rotate_on_startup.go
+++ b/main_encryption_rotate_on_startup.go
@@ -35,12 +35,12 @@ type encryptionRotateOnStartupTask struct {
 	sidecarPath  string
 	kekWrapper   kek.Wrapper
 	raftEnvelope *raftEnvelopeRuntime
+	readFence    func(context.Context) (uint64, error)
 	fullNodeID   uint64
 	storageEpoch uint16
 	raftEpoch    uint16
 
 	mu          sync.Mutex
-	nextReady   bool
 	nextKeyID   uint32
 	storageDone bool
 	raftDone    bool
@@ -94,6 +94,7 @@ func installEncryptionRotateOnStartup(
 		sidecarPath:  sidecarPath,
 		kekWrapper:   kekWrapper,
 		raftEnvelope: raftEnvelope,
+		readFence:    controller.LinearizableRead,
 		fullNodeID:   fullNodeID,
 		storageEpoch: storageEpoch,
 		raftEpoch:    raftEpoch,
@@ -175,6 +176,9 @@ func (t *encryptionRotateOnStartupTask) Done() bool {
 }
 
 func (t *encryptionRotateOnStartupTask) Run(ctx context.Context) error {
+	if err := t.fenceSidecarRead(ctx); err != nil {
+		return err
+	}
 	sc, err := encryption.ReadSidecar(t.sidecarPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) || encryption.IsNotExist(err) {
@@ -206,6 +210,16 @@ func (t *encryptionRotateOnStartupTask) Run(ctx context.Context) error {
 	return nil
 }
 
+func (t *encryptionRotateOnStartupTask) fenceSidecarRead(ctx context.Context) error {
+	if t.readFence == nil {
+		return nil
+	}
+	if _, err := t.readFence(ctx); err != nil {
+		return errors.Wrap(err, "encryption rotate-on-startup: sidecar read fence")
+	}
+	return nil
+}
+
 func (t *encryptionRotateOnStartupTask) markAllDone() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -214,15 +228,11 @@ func (t *encryptionRotateOnStartupTask) markAllDone() {
 }
 
 func (t *encryptionRotateOnStartupTask) prepareNextKeyIDLocked(sc *encryption.Sidecar) error {
-	if t.nextReady {
-		return nil
-	}
 	next, err := nextEncryptionRotateOnStartupKeyID(sc)
 	if err != nil {
 		return err
 	}
 	t.nextKeyID = next
-	t.nextReady = true
 	return nil
 }
 
@@ -264,9 +274,6 @@ func (t *encryptionRotateOnStartupTask) rotateLocked(ctx context.Context, purpos
 		ProposerLocalEpoch: uint32(localEpoch),
 	})
 	if err != nil {
-		if retryableEncryptionRotateOnStartupError(err) {
-			t.advanceNextKeyIDLocked(keyID)
-		}
 		return errors.Wrap(err, "encryption rotate-on-startup: RotateDEK")
 	}
 	t.advanceNextKeyIDLocked(keyID)

--- a/main_encryption_rotate_on_startup.go
+++ b/main_encryption_rotate_on_startup.go
@@ -293,7 +293,7 @@ func waitEncryptionRotateOnStartupIdle(
 		}
 		done := fireEncryptionRotateOnStartup(ctx, controller, task, logger, flight, true)
 		if done == nil {
-			return nil
+			continue
 		}
 	}
 }
@@ -396,8 +396,24 @@ func (t *encryptionRotateOnStartupTask) prepareNextKeyIDLocked(sc *encryption.Si
 	if err != nil {
 		return err
 	}
+	pending := t.pendingRotatePurposeCountLocked(sc)
+	remaining := uint64(math.MaxUint32) - uint64(next) + 1
+	if pending > remaining {
+		return errors.New("encryption rotate-on-startup: key_id space exhausted")
+	}
 	t.nextKeyID = next
 	return nil
+}
+
+func (t *encryptionRotateOnStartupTask) pendingRotatePurposeCountLocked(sc *encryption.Sidecar) uint64 {
+	var pending uint64
+	if sc.Active.Storage != encryption.ReservedKeyID && !t.storageDone {
+		pending++
+	}
+	if sc.Active.Raft != encryption.ReservedKeyID && !t.raftDone {
+		pending++
+	}
+	return pending
 }
 
 func (t *encryptionRotateOnStartupTask) rotatePurposeIfActive(

--- a/main_encryption_rotate_on_startup.go
+++ b/main_encryption_rotate_on_startup.go
@@ -350,19 +350,17 @@ func (t *encryptionRotateOnStartupTask) Run(ctx context.Context) error {
 		return errors.Wrap(err, "encryption rotate-on-startup: read sidecar")
 	}
 
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if err := t.prepareNextKeyIDLocked(sc); err != nil {
+	if err := t.prepareNextKeyID(sc); err != nil {
 		return err
 	}
-	if err := t.rotatePurposeIfActiveLocked(
-		ctx, &t.storageDone, sc.Active.Storage,
+	if err := t.rotatePurposeIfActive(
+		ctx, sc.Active.Storage,
 		pb.RotateDEKRequest_PURPOSE_STORAGE, t.storageEpoch,
 	); err != nil {
 		return err
 	}
-	if err := t.rotatePurposeIfActiveLocked(
-		ctx, &t.raftDone, sc.Active.Raft,
+	if err := t.rotatePurposeIfActive(
+		ctx, sc.Active.Raft,
 		pb.RotateDEKRequest_PURPOSE_RAFT, t.raftEpoch,
 	); err != nil {
 		return err
@@ -387,6 +385,12 @@ func (t *encryptionRotateOnStartupTask) markAllDone() {
 	t.raftDone = true
 }
 
+func (t *encryptionRotateOnStartupTask) prepareNextKeyID(sc *encryption.Sidecar) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.prepareNextKeyIDLocked(sc)
+}
+
 func (t *encryptionRotateOnStartupTask) prepareNextKeyIDLocked(sc *encryption.Sidecar) error {
 	next, err := nextEncryptionRotateOnStartupKeyID(sc)
 	if err != nil {
@@ -396,32 +400,76 @@ func (t *encryptionRotateOnStartupTask) prepareNextKeyIDLocked(sc *encryption.Si
 	return nil
 }
 
-func (t *encryptionRotateOnStartupTask) rotatePurposeIfActiveLocked(
+func (t *encryptionRotateOnStartupTask) rotatePurposeIfActive(
 	ctx context.Context,
-	done *bool,
 	activeID uint32,
 	purpose pb.RotateDEKRequest_Purpose,
 	localEpoch uint16,
 ) error {
-	if activeID == encryption.ReservedKeyID {
-		*done = true
-		return nil
-	}
-	if *done {
-		return nil
-	}
-	if err := t.rotateLocked(ctx, purpose, localEpoch); err != nil {
+	keyID, rotate, err := t.reserveRotateKey(activeID, purpose)
+	if err != nil || !rotate {
 		return err
 	}
-	*done = true
+	if err := t.rotateWithKeyID(ctx, purpose, localEpoch, keyID); err != nil {
+		return err
+	}
+	t.mu.Lock()
+	t.advanceNextKeyIDLocked(keyID)
+	t.mu.Unlock()
+	if purpose == pb.RotateDEKRequest_PURPOSE_RAFT && t.raftEnvelope != nil {
+		if err := t.raftEnvelope.installRotatedRaftDEK(keyID); err != nil {
+			return errors.Wrap(err, "encryption rotate-on-startup: install rotated raft envelope wrapper")
+		}
+	}
+	t.markPurposeDone(purpose)
 	return nil
 }
 
-func (t *encryptionRotateOnStartupTask) rotateLocked(ctx context.Context, purpose pb.RotateDEKRequest_Purpose, localEpoch uint16) error {
+func (t *encryptionRotateOnStartupTask) reserveRotateKey(
+	activeID uint32,
+	purpose pb.RotateDEKRequest_Purpose,
+) (uint32, bool, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	done := t.purposeDoneLocked(purpose)
+	if activeID == encryption.ReservedKeyID {
+		t.markPurposeDoneLocked(purpose)
+		return 0, false, nil
+	}
+	if done {
+		return 0, false, nil
+	}
 	if t.nextKeyID == encryption.ReservedKeyID {
+		return 0, false, errors.New("encryption rotate-on-startup: key_id space exhausted")
+	}
+	return t.nextKeyID, true, nil
+}
+
+func (t *encryptionRotateOnStartupTask) purposeDoneLocked(purpose pb.RotateDEKRequest_Purpose) bool {
+	if purpose == pb.RotateDEKRequest_PURPOSE_RAFT {
+		return t.raftDone
+	}
+	return t.storageDone
+}
+
+func (t *encryptionRotateOnStartupTask) markPurposeDone(purpose pb.RotateDEKRequest_Purpose) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.markPurposeDoneLocked(purpose)
+}
+
+func (t *encryptionRotateOnStartupTask) markPurposeDoneLocked(purpose pb.RotateDEKRequest_Purpose) {
+	if purpose == pb.RotateDEKRequest_PURPOSE_RAFT {
+		t.raftDone = true
+		return
+	}
+	t.storageDone = true
+}
+
+func (t *encryptionRotateOnStartupTask) rotateWithKeyID(ctx context.Context, purpose pb.RotateDEKRequest_Purpose, localEpoch uint16, keyID uint32) error {
+	if keyID == encryption.ReservedKeyID {
 		return errors.New("encryption rotate-on-startup: key_id space exhausted")
 	}
-	keyID := t.nextKeyID
 	wrapped, err := wrapFreshStartupDEK(t.kekWrapper)
 	if err != nil {
 		return err
@@ -435,12 +483,6 @@ func (t *encryptionRotateOnStartupTask) rotateLocked(ctx context.Context, purpos
 	})
 	if err != nil {
 		return errors.Wrap(err, "encryption rotate-on-startup: RotateDEK")
-	}
-	t.advanceNextKeyIDLocked(keyID)
-	if purpose == pb.RotateDEKRequest_PURPOSE_RAFT && t.raftEnvelope != nil {
-		if err := t.raftEnvelope.installRotatedRaftDEK(keyID); err != nil {
-			return errors.Wrap(err, "encryption rotate-on-startup: install rotated raft envelope wrapper")
-		}
 	}
 	return nil
 }

--- a/main_encryption_rotate_on_startup.go
+++ b/main_encryption_rotate_on_startup.go
@@ -114,16 +114,6 @@ func installEncryptionRotateOnStartup(
 	return installEncryptionRotateOnStartupRequestWithWait(ctx, controller, task, logger)
 }
 
-func installEncryptionRotateOnStartupRequest(
-	ctx context.Context,
-	controller encryptionRotateOnStartupController,
-	task encryptionRotateOnStartupRunner,
-	logger *slog.Logger,
-) func() {
-	deregister, _ := installEncryptionRotateOnStartupRequestWithWait(ctx, controller, task, logger)
-	return deregister
-}
-
 func installEncryptionRotateOnStartupRequestWithWait(
 	ctx context.Context,
 	controller encryptionRotateOnStartupController,
@@ -137,20 +127,18 @@ func installEncryptionRotateOnStartupRequestWithWait(
 		logger = slog.Default()
 	}
 	var flight encryptionRotateOnStartupFlightState
+	var callbacksEnabled atomic.Bool
 	fire := func(block bool) {
 		_ = fireEncryptionRotateOnStartup(ctx, controller, task, logger, &flight, block)
 	}
-	wasLeaderBefore := controller.State() == raftengine.StateLeader
-	if wasLeaderBefore {
-		fire(true)
-	}
 	deregister := controller.RegisterLeaderAcquiredCallback(func() {
+		if !callbacksEnabled.Load() {
+			return
+		}
 		fire(false)
 	})
-	if controller.State() == raftengine.StateLeader {
-		fire(false)
-	}
 	waitStartup := func(waitCtx context.Context) error {
+		callbacksEnabled.Store(true)
 		return waitEncryptionRotateOnStartupIdle(waitCtx, controller, task, logger, &flight)
 	}
 	return deregister, waitStartup
@@ -233,11 +221,11 @@ func runEncryptionRotateOnStartup(
 ) error {
 	defer inFlight.Store(false)
 	for {
-		if task.Done() || controller.State() != raftengine.StateLeader {
+		if controller.State() != raftengine.StateLeader || task.Done() {
 			return nil
 		}
 		err := task.Run(ctx)
-		if err == nil || task.Done() || controller.State() != raftengine.StateLeader {
+		if err == nil || controller.State() != raftengine.StateLeader || task.Done() {
 			return nil
 		}
 		logEncryptionRotateOnStartupError(logger, err)
@@ -272,7 +260,7 @@ func waitEncryptionRotateOnStartupIdle(
 		if waited {
 			continue
 		}
-		if task.Done() || controller.State() != raftengine.StateLeader {
+		if controller.State() != raftengine.StateLeader || task.Done() {
 			return nil
 		}
 		if flight.inFlight.Load() {

--- a/main_encryption_rotate_on_startup_test.go
+++ b/main_encryption_rotate_on_startup_test.go
@@ -133,6 +133,33 @@ func (b *blockingRunRotateStartupRunner) Run(context.Context) error {
 
 func (b *blockingRunRotateStartupRunner) Done() bool { return b.done.Load() }
 
+type raceFireRotateStartupController struct {
+	fakeRotateStartupController
+	stateCalls atomic.Int32
+	runner     *blockingRunRotateStartupRunner
+}
+
+func (r *raceFireRotateStartupController) State() raftengine.State {
+	r.mu.Lock()
+	state := r.state
+	callbacks := append([]func(){}, r.callbacks...)
+	r.mu.Unlock()
+	if r.stateCalls.Add(1) == 2 {
+		go func() {
+			for _, cb := range callbacks {
+				if cb != nil {
+					cb()
+				}
+			}
+		}()
+		select {
+		case <-r.runner.started:
+		case <-time.After(2 * time.Second):
+		}
+	}
+	return state
+}
+
 type stubStartupCoordinator struct {
 	dispatches atomic.Int32
 	clock      *kv.HLC
@@ -293,6 +320,44 @@ func TestInstallEncryptionRotateOnStartupRequest_WaitTracksAsyncFlight(t *testin
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("startup wait did not finish after rotation completed")
+	}
+}
+
+func TestInstallEncryptionRotateOnStartupRequest_WaitContinuesAfterConcurrentFire(t *testing.T) {
+	runner := &blockingRunRotateStartupRunner{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	controller := &raceFireRotateStartupController{
+		fakeRotateStartupController: fakeRotateStartupController{state: raftengine.StateLeader},
+		runner:                      runner,
+	}
+	deregister, waitStartup := installEncryptionRotateOnStartupRequestWithWait(context.Background(), controller, runner, nil)
+	defer deregister()
+
+	waitDone := make(chan error, 1)
+	go func() {
+		waitDone <- waitStartup.Wait(context.Background())
+	}()
+	select {
+	case <-runner.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("concurrent startup rotation did not start")
+	}
+	select {
+	case err := <-waitDone:
+		t.Fatalf("startup wait returned before concurrent rotation finished: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(runner.release)
+	select {
+	case err := <-waitDone:
+		if err != nil {
+			t.Fatalf("startup wait returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("startup wait did not finish after concurrent rotation completed")
 	}
 }
 
@@ -834,6 +899,41 @@ func TestEncryptionRotateOnStartupTask_KeyIDExhaustionDoesNotMarkDone(t *testing
 	}
 	if task.Done() {
 		t.Fatal("key-id exhaustion must not mark rotation done")
+	}
+}
+
+func TestEncryptionRotateOnStartupTask_PreflightsKeyIDCapacity(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	sidecarPath := filepath.Join(dir, encryption.SidecarFilename)
+	sc := &encryption.Sidecar{
+		Version:          encryption.SidecarVersion,
+		RaftAppliedIndex: 1,
+		Active:           encryption.ActiveKeys{Storage: 7, Raft: 8},
+		Keys: map[string]encryption.SidecarKey{
+			"7":          {Purpose: encryption.SidecarPurposeStorage, Wrapped: []byte("storage")},
+			"8":          {Purpose: encryption.SidecarPurposeRaft, Wrapped: []byte("raft")},
+			"4294967294": {Purpose: encryption.SidecarPurposeStorage, Wrapped: []byte("near-max")},
+		},
+	}
+	if err := encryption.WriteSidecar(sidecarPath, sc); err != nil {
+		t.Fatalf("WriteSidecar: %v", err)
+	}
+	rec := &recordingRotateProposer{}
+	task := &encryptionRotateOnStartupTask{
+		server:      adapterServerForRotateStartup(t, sidecarPath, rec),
+		sidecarPath: sidecarPath,
+		kekWrapper:  fakeStartupKEK{},
+		fullNodeID:  0xCAFE,
+	}
+	if err := task.Run(context.Background()); err == nil {
+		t.Fatal("Run returned nil, want preflight key-id exhaustion error")
+	}
+	if len(rec.proposals) != 0 {
+		t.Fatalf("proposals=%d, want 0 before capacity preflight passes", len(rec.proposals))
+	}
+	if task.Done() {
+		t.Fatal("key-id preflight exhaustion must not mark rotation done")
 	}
 }
 

--- a/main_encryption_rotate_on_startup_test.go
+++ b/main_encryption_rotate_on_startup_test.go
@@ -1,0 +1,261 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bootjp/elastickv/adapter"
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
+	"github.com/bootjp/elastickv/internal/raftengine"
+	pb "github.com/bootjp/elastickv/proto"
+)
+
+type fakeRotateStartupController struct {
+	mu        sync.Mutex
+	state     raftengine.State
+	callbacks []func()
+}
+
+func (f *fakeRotateStartupController) State() raftengine.State {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.state
+}
+
+func (f *fakeRotateStartupController) Leader() raftengine.LeaderInfo { return raftengine.LeaderInfo{} }
+func (f *fakeRotateStartupController) VerifyLeader(context.Context) error {
+	return nil
+}
+func (f *fakeRotateStartupController) LinearizableRead(context.Context) (uint64, error) {
+	return 0, nil
+}
+
+func (f *fakeRotateStartupController) RegisterLeaderAcquiredCallback(fn func()) func() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.callbacks = append(f.callbacks, fn)
+	idx := len(f.callbacks) - 1
+	return func() {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		if idx >= 0 && idx < len(f.callbacks) {
+			f.callbacks[idx] = nil
+		}
+	}
+}
+
+func (f *fakeRotateStartupController) becomeLeader() {
+	f.mu.Lock()
+	f.state = raftengine.StateLeader
+	callbacks := append([]func(){}, f.callbacks...)
+	f.mu.Unlock()
+	for _, cb := range callbacks {
+		if cb != nil {
+			cb()
+		}
+	}
+}
+
+type fakeRotateStartupRunner struct {
+	runs atomic.Int32
+	done atomic.Bool
+	err  error
+}
+
+func (f *fakeRotateStartupRunner) Run(context.Context) error {
+	f.runs.Add(1)
+	if f.err == nil {
+		f.done.Store(true)
+	}
+	return f.err
+}
+
+func (f *fakeRotateStartupRunner) Done() bool { return f.done.Load() }
+
+func TestInstallEncryptionRotateOnStartupRequest_ImmediateLeaderBlocks(t *testing.T) {
+	t.Parallel()
+	controller := &fakeRotateStartupController{state: raftengine.StateLeader}
+	runner := &fakeRotateStartupRunner{}
+	deregister := installEncryptionRotateOnStartupRequest(context.Background(), controller, runner, nil)
+	defer deregister()
+	if got := runner.runs.Load(); got != 1 {
+		t.Fatalf("immediate leader must run rotation synchronously before returning; runs=%d", got)
+	}
+}
+
+func TestInstallEncryptionRotateOnStartupRequest_FollowerFiresOnLeadership(t *testing.T) {
+	t.Parallel()
+	controller := &fakeRotateStartupController{state: raftengine.StateFollower}
+	runner := &fakeRotateStartupRunner{}
+	deregister := installEncryptionRotateOnStartupRequest(context.Background(), controller, runner, nil)
+	defer deregister()
+	if got := runner.runs.Load(); got != 0 {
+		t.Fatalf("follower install must not run immediately; runs=%d", got)
+	}
+	controller.becomeLeader()
+	deadline := time.Now().Add(2 * time.Second)
+	for runner.runs.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := runner.runs.Load(); got != 1 {
+		t.Fatalf("leader-acquired callback must run rotation once; runs=%d", got)
+	}
+}
+
+type fakeStartupKEK struct{}
+
+func (fakeStartupKEK) Wrap(dek []byte) ([]byte, error) {
+	if len(dek) != encryption.KeySize {
+		return nil, errors.New("bad dek length")
+	}
+	out := make([]byte, 1, 1+len(dek))
+	out[0] = 0xAA
+	out = append(out, dek...)
+	return out, nil
+}
+func (fakeStartupKEK) Unwrap(wrapped []byte) ([]byte, error) { return wrapped, nil }
+func (fakeStartupKEK) Name() string                          { return "fake" }
+
+type recordingRotateProposer struct {
+	proposals [][]byte
+	err       error
+}
+
+func (r *recordingRotateProposer) Propose(context.Context, []byte) (*raftengine.ProposalResult, error) {
+	return nil, errors.New("unexpected Propose")
+}
+
+func (r *recordingRotateProposer) ProposeAdmin(_ context.Context, data []byte) (*raftengine.ProposalResult, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	cp := append([]byte(nil), data...)
+	r.proposals = append(r.proposals, cp)
+	return &raftengine.ProposalResult{CommitIndex: uint64(len(r.proposals))}, nil
+}
+
+type rotateStartupLeader struct {
+	*recordingRotateProposer
+}
+
+func (rotateStartupLeader) State() raftengine.State            { return raftengine.StateLeader }
+func (rotateStartupLeader) Leader() raftengine.LeaderInfo      { return raftengine.LeaderInfo{} }
+func (rotateStartupLeader) VerifyLeader(context.Context) error { return nil }
+func (rotateStartupLeader) LinearizableRead(context.Context) (uint64, error) {
+	return 0, nil
+}
+
+func TestEncryptionRotateOnStartupTask_RunRotatesStorageAndRaft(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	sidecarPath := filepath.Join(dir, encryption.SidecarFilename)
+	sc := &encryption.Sidecar{
+		Version:          encryption.SidecarVersion,
+		RaftAppliedIndex: 1,
+		Active:           encryption.ActiveKeys{Storage: 7, Raft: 8},
+		Keys: map[string]encryption.SidecarKey{
+			"7": {Purpose: encryption.SidecarPurposeStorage, Wrapped: []byte("storage"), Created: "2026-07-07T00:00:00Z", LocalEpoch: 2},
+			"8": {Purpose: encryption.SidecarPurposeRaft, Wrapped: []byte("raft"), Created: "2026-07-07T00:00:00Z", LocalEpoch: 3},
+		},
+	}
+	if err := encryption.WriteSidecar(sidecarPath, sc); err != nil {
+		t.Fatalf("WriteSidecar: %v", err)
+	}
+	rec := &recordingRotateProposer{}
+	server := adapterServerForRotateStartup(t, sidecarPath, rec)
+	task := &encryptionRotateOnStartupTask{
+		server:       server,
+		sidecarPath:  sidecarPath,
+		kekWrapper:   fakeStartupKEK{},
+		fullNodeID:   0xCAFE,
+		storageEpoch: 11,
+		raftEpoch:    12,
+	}
+	if err := task.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !task.Done() {
+		t.Fatal("task must be done after both active purposes rotate")
+	}
+	if got := len(rec.proposals); got != 2 {
+		t.Fatalf("proposals=%d, want 2", got)
+	}
+	assertRotateProposal(t, rec.proposals[0], pb.RotateDEKRequest_PURPOSE_STORAGE, 9, 11)
+	assertRotateProposal(t, rec.proposals[1], pb.RotateDEKRequest_PURPOSE_RAFT, 10, 12)
+}
+
+func adapterServerForRotateStartup(t *testing.T, sidecarPath string, rec *recordingRotateProposer) *adapter.EncryptionAdminServer {
+	t.Helper()
+	leader := rotateStartupLeader{recordingRotateProposer: rec}
+	server := adapter.NewEncryptionAdminServer(
+		adapter.WithEncryptionAdminSidecarPath(sidecarPath),
+		adapter.WithEncryptionAdminFullNodeID(0xCAFE),
+		adapter.WithEncryptionAdminProposer(leader),
+		adapter.WithEncryptionAdminLeaderView(leader),
+	)
+	if err := server.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	return server
+}
+
+func assertRotateProposal(t *testing.T, raw []byte, purpose pb.RotateDEKRequest_Purpose, wantDEKID uint32, wantEpoch uint16) {
+	t.Helper()
+	if len(raw) == 0 {
+		t.Fatal("empty proposal")
+	}
+	if raw[0] != fsmwire.OpRotation {
+		t.Fatalf("proposal tag=%#v, want OpRotation", raw)
+	}
+	got, err := fsmwire.DecodeRotation(raw[1:])
+	if err != nil {
+		t.Fatalf("DecodeRotation: %v", err)
+	}
+	wantPurpose := rotateStartupWirePurpose(purpose)
+	if got.SubTag != fsmwire.RotateSubRotateDEK || got.Purpose != wantPurpose || got.DEKID != wantDEKID {
+		t.Fatalf("rotation payload=%+v, want subtag rotate purpose=%v dek=%d", got, wantPurpose, wantDEKID)
+	}
+	if got.ProposerRegistration.FullNodeID != 0xCAFE ||
+		got.ProposerRegistration.DEKID != wantDEKID ||
+		got.ProposerRegistration.LocalEpoch != wantEpoch {
+		t.Fatalf("registration=%+v, want node=0xCAFE dek=%d epoch=%d",
+			got.ProposerRegistration, wantDEKID, wantEpoch)
+	}
+	assertRotateWrappedDEK(t, got.Wrapped)
+}
+
+func rotateStartupWirePurpose(purpose pb.RotateDEKRequest_Purpose) fsmwire.Purpose {
+	if purpose == pb.RotateDEKRequest_PURPOSE_RAFT {
+		return fsmwire.PurposeRaft
+	}
+	return fsmwire.PurposeStorage
+}
+
+func assertRotateWrappedDEK(t *testing.T, wrapped []byte) {
+	t.Helper()
+	if len(wrapped) != 1+encryption.KeySize {
+		t.Fatalf("wrapped len=%d, want %d", len(wrapped), 1+encryption.KeySize)
+	}
+	if wrapped[0] != 0xAA {
+		t.Fatalf("wrapped len/prefix=(%d,%#x), want (%d,0xAA)",
+			len(wrapped), wrapped[0], 1+encryption.KeySize)
+	}
+}
+
+func TestNextEncryptionRotateOnStartupKeyID_Exhausted(t *testing.T) {
+	t.Parallel()
+	_, err := nextEncryptionRotateOnStartupKeyID(&encryption.Sidecar{
+		Keys: map[string]encryption.SidecarKey{
+			"4294967295": {Purpose: encryption.SidecarPurposeStorage},
+		},
+	})
+	if err == nil {
+		t.Fatal("max key id must refuse rotation")
+	}
+}

--- a/main_encryption_rotate_on_startup_test.go
+++ b/main_encryption_rotate_on_startup_test.go
@@ -281,45 +281,88 @@ func TestInstallEncryptionRotateOnStartupRequest_WaitReturnsPermanentError(t *te
 	}
 }
 
-func TestStartupPublicKVGate_BlocksOnlyPublicKVUntilReady(t *testing.T) {
+func TestStartupPublicKVGate_BlocksMutatorsUntilReady(t *testing.T) {
 	t.Parallel()
 	gate := &startupPublicKVGate{}
-	handlerCalled := false
-	handler := func(context.Context, interface{}) (interface{}, error) {
-		handlerCalled = true
-		return "ok", nil
+
+	blockedMethods := []string{
+		pb.RawKV_RawGet_FullMethodName,
+		pb.TransactionalKV_Get_FullMethodName,
+		pb.Internal_Forward_FullMethodName,
+		pb.AdminForward_Forward_FullMethodName,
+		pb.Distribution_SplitRange_FullMethodName,
+		pb.EncryptionAdmin_BootstrapEncryption_FullMethodName,
+		pb.EncryptionAdmin_RotateDEK_FullMethodName,
+		pb.EncryptionAdmin_RegisterEncryptionWriter_FullMethodName,
+		pb.EncryptionAdmin_ResyncSidecar_FullMethodName,
+		pb.EncryptionAdmin_EnableStorageEnvelope_FullMethodName,
+		pb.EncryptionAdmin_EnableRaftEnvelope_FullMethodName,
 	}
-	if _, err := gate.unaryInterceptor(
-		context.Background(), nil,
-		&grpc.UnaryServerInfo{FullMethod: pb.RawKV_RawGet_FullMethodName},
-		handler,
-	); status.Code(err) != codes.Unavailable {
-		t.Fatalf("RawKV before ready err=%v, want Unavailable", err)
+
+	for _, method := range blockedMethods {
+		t.Run("blocked/"+method, func(t *testing.T) {
+			handlerCalled := false
+			handler := func(context.Context, interface{}) (interface{}, error) {
+				handlerCalled = true
+				return "ok", nil
+			}
+			if _, err := gate.unaryInterceptor(
+				context.Background(), nil,
+				&grpc.UnaryServerInfo{FullMethod: method},
+				handler,
+			); status.Code(err) != codes.Unavailable {
+				t.Fatalf("%s before ready err=%v, want Unavailable", method, err)
+			}
+			if handlerCalled {
+				t.Fatalf("%s handler ran before startup gate opened", method)
+			}
+		})
 	}
-	if handlerCalled {
-		t.Fatal("RawKV handler ran before startup gate opened")
+
+	allowedMethods := []string{
+		pb.Internal_RelayPublish_FullMethodName,
+		pb.EncryptionAdmin_GetCapability_FullMethodName,
+		pb.EncryptionAdmin_GetSidecarState_FullMethodName,
 	}
-	if _, err := gate.unaryInterceptor(
-		context.Background(), nil,
-		&grpc.UnaryServerInfo{FullMethod: "/Internal/GetTimestamp"},
-		handler,
-	); err != nil {
-		t.Fatalf("internal method before ready must pass: %v", err)
+	for _, method := range allowedMethods {
+		t.Run("allowed/"+method, func(t *testing.T) {
+			handlerCalled := false
+			handler := func(context.Context, interface{}) (interface{}, error) {
+				handlerCalled = true
+				return "ok", nil
+			}
+			if _, err := gate.unaryInterceptor(
+				context.Background(), nil,
+				&grpc.UnaryServerInfo{FullMethod: method},
+				handler,
+			); err != nil {
+				t.Fatalf("%s before ready must pass: %v", method, err)
+			}
+			if !handlerCalled {
+				t.Fatalf("%s handler did not run", method)
+			}
+		})
 	}
-	if !handlerCalled {
-		t.Fatal("internal handler did not run")
-	}
+
 	gate.markReady()
-	handlerCalled = false
-	if _, err := gate.unaryInterceptor(
-		context.Background(), nil,
-		&grpc.UnaryServerInfo{FullMethod: pb.TransactionalKV_Get_FullMethodName},
-		handler,
-	); err != nil {
-		t.Fatalf("TransactionalKV after ready err=%v", err)
-	}
-	if !handlerCalled {
-		t.Fatal("TransactionalKV handler did not run after gate opened")
+	for _, method := range blockedMethods {
+		t.Run("ready/"+method, func(t *testing.T) {
+			handlerCalled := false
+			handler := func(context.Context, interface{}) (interface{}, error) {
+				handlerCalled = true
+				return "ok", nil
+			}
+			if _, err := gate.unaryInterceptor(
+				context.Background(), nil,
+				&grpc.UnaryServerInfo{FullMethod: method},
+				handler,
+			); err != nil {
+				t.Fatalf("%s after ready err=%v", method, err)
+			}
+			if !handlerCalled {
+				t.Fatalf("%s handler did not run after startup gate opened", method)
+			}
+		})
 	}
 }
 

--- a/main_encryption_rotate_on_startup_test.go
+++ b/main_encryption_rotate_on_startup_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -15,8 +16,10 @@ import (
 	"github.com/bootjp/elastickv/internal/encryption"
 	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
 	"github.com/bootjp/elastickv/internal/raftengine"
+	"github.com/bootjp/elastickv/monitoring"
 	pb "github.com/bootjp/elastickv/proto"
 	crdberrors "github.com/cockroachdb/errors"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -129,33 +132,42 @@ func (b *blockingRunRotateStartupRunner) Run(context.Context) error {
 
 func (b *blockingRunRotateStartupRunner) Done() bool { return b.done.Load() }
 
-func TestInstallEncryptionRotateOnStartupRequest_ImmediateLeaderBlocks(t *testing.T) {
+func TestInstallEncryptionRotateOnStartupRequest_ImmediateLeaderWaitRuns(t *testing.T) {
 	t.Parallel()
 	controller := &fakeRotateStartupController{state: raftengine.StateLeader}
 	runner := &fakeRotateStartupRunner{}
-	deregister := installEncryptionRotateOnStartupRequest(context.Background(), controller, runner, slog.Default())
+	deregister, waitStartup := installEncryptionRotateOnStartupRequestWithWait(context.Background(), controller, runner, slog.Default())
 	defer deregister()
+	if got := runner.runs.Load(); got != 0 {
+		t.Fatalf("install must defer immediate-leader rotation until startup wait; runs=%d", got)
+	}
+	if err := waitStartup(context.Background()); err != nil {
+		t.Fatalf("waitStartup: %v", err)
+	}
 	if got := runner.runs.Load(); got != 1 {
-		t.Fatalf("immediate leader must run rotation synchronously before returning; runs=%d", got)
+		t.Fatalf("startup wait must run immediate-leader rotation once; runs=%d", got)
 	}
 }
 
-func TestInstallEncryptionRotateOnStartupRequest_FollowerFiresOnLeadership(t *testing.T) {
+func TestInstallEncryptionRotateOnStartupRequest_FollowerDefersUntilStartupWait(t *testing.T) {
 	t.Parallel()
 	controller := &fakeRotateStartupController{state: raftengine.StateFollower}
 	runner := &fakeRotateStartupRunner{}
-	deregister := installEncryptionRotateOnStartupRequest(context.Background(), controller, runner, nil)
+	deregister, waitStartup := installEncryptionRotateOnStartupRequestWithWait(context.Background(), controller, runner, nil)
 	defer deregister()
 	if got := runner.runs.Load(); got != 0 {
 		t.Fatalf("follower install must not run immediately; runs=%d", got)
 	}
 	controller.becomeLeader()
-	deadline := time.Now().Add(2 * time.Second)
-	for runner.runs.Load() == 0 && time.Now().Before(deadline) {
-		time.Sleep(5 * time.Millisecond)
+	time.Sleep(25 * time.Millisecond)
+	if got := runner.runs.Load(); got != 0 {
+		t.Fatalf("leader callback before startup wait must not run rotation; runs=%d", got)
+	}
+	if err := waitStartup(context.Background()); err != nil {
+		t.Fatalf("waitStartup: %v", err)
 	}
 	if got := runner.runs.Load(); got != 1 {
-		t.Fatalf("leader-acquired callback must run rotation once; runs=%d", got)
+		t.Fatalf("startup wait must run deferred leader rotation once; runs=%d", got)
 	}
 }
 
@@ -166,10 +178,16 @@ func TestInstallEncryptionRotateOnStartupRequest_RetriesTransientWhileLeader(t *
 
 	controller := &fakeRotateStartupController{state: raftengine.StateLeader}
 	runner := &retryOnceRotateStartupRunner{err: status.Error(codes.Unavailable, "try again")}
-	deregister := installEncryptionRotateOnStartupRequest(context.Background(), controller, runner, nil)
+	deregister, waitStartup := installEncryptionRotateOnStartupRequestWithWait(context.Background(), controller, runner, nil)
 	defer deregister()
+	if got := runner.runs.Load(); got != 0 {
+		t.Fatalf("install must defer immediate-leader retry loop until startup wait; runs=%d", got)
+	}
+	if err := waitStartup(context.Background()); err != nil {
+		t.Fatalf("waitStartup: %v", err)
+	}
 	if got := runner.runs.Load(); got != 2 {
-		t.Fatalf("transient startup rotation must retry before returning; runs=%d", got)
+		t.Fatalf("transient startup rotation must retry before startup wait returns; runs=%d", got)
 	}
 }
 
@@ -179,9 +197,15 @@ func TestInstallEncryptionRotateOnStartupRequest_CallbackDoesNotBlockOnDone(t *t
 		doneEntered: make(chan struct{}),
 		releaseDone: make(chan struct{}),
 	}
-	deregister := installEncryptionRotateOnStartupRequest(context.Background(), controller, runner, nil)
+	deregister, waitStartup := installEncryptionRotateOnStartupRequestWithWait(context.Background(), controller, runner, nil)
 	defer deregister()
 	defer close(runner.releaseDone)
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := waitStartup(waitCtx); err != nil {
+		t.Fatalf("startup wait while follower: %v", err)
+	}
 
 	returned := make(chan struct{})
 	go func() {
@@ -209,6 +233,9 @@ func TestInstallEncryptionRotateOnStartupRequest_WaitTracksAsyncFlight(t *testin
 	deregister, waitStartup := installEncryptionRotateOnStartupRequestWithWait(context.Background(), controller, runner, nil)
 	defer deregister()
 
+	if err := waitStartup(context.Background()); err != nil {
+		t.Fatalf("initial follower wait: %v", err)
+	}
 	controller.becomeLeader()
 	select {
 	case <-runner.started:
@@ -251,6 +278,85 @@ func TestInstallEncryptionRotateOnStartupRequest_WaitReturnsPermanentError(t *te
 	}
 	if got := runner.runs.Load(); got != 1 {
 		t.Fatalf("permanent error must not be retried; runs=%d", got)
+	}
+}
+
+func TestStartupPublicKVGate_BlocksOnlyPublicKVUntilReady(t *testing.T) {
+	t.Parallel()
+	gate := &startupPublicKVGate{}
+	handlerCalled := false
+	handler := func(context.Context, interface{}) (interface{}, error) {
+		handlerCalled = true
+		return "ok", nil
+	}
+	if _, err := gate.unaryInterceptor(
+		context.Background(), nil,
+		&grpc.UnaryServerInfo{FullMethod: pb.RawKV_RawGet_FullMethodName},
+		handler,
+	); status.Code(err) != codes.Unavailable {
+		t.Fatalf("RawKV before ready err=%v, want Unavailable", err)
+	}
+	if handlerCalled {
+		t.Fatal("RawKV handler ran before startup gate opened")
+	}
+	if _, err := gate.unaryInterceptor(
+		context.Background(), nil,
+		&grpc.UnaryServerInfo{FullMethod: "/Internal/GetTimestamp"},
+		handler,
+	); err != nil {
+		t.Fatalf("internal method before ready must pass: %v", err)
+	}
+	if !handlerCalled {
+		t.Fatal("internal handler did not run")
+	}
+	gate.markReady()
+	handlerCalled = false
+	if _, err := gate.unaryInterceptor(
+		context.Background(), nil,
+		&grpc.UnaryServerInfo{FullMethod: pb.TransactionalKV_Get_FullMethodName},
+		handler,
+	); err != nil {
+		t.Fatalf("TransactionalKV after ready err=%v", err)
+	}
+	if !handlerCalled {
+		t.Fatal("TransactionalKV handler did not run after gate opened")
+	}
+}
+
+func TestRuntimeServerRunner_PrepareAdminForwardServersDoesNotBindPublicListeners(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	lc := &net.ListenConfig{}
+	heldDynamo, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen held dynamo: %v", err)
+	}
+	defer heldDynamo.Close()
+	heldS3, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen held s3: %v", err)
+	}
+	defer heldS3.Close()
+
+	runner := runtimeServerRunner{
+		ctx:             ctx,
+		lc:              lc,
+		dynamoAddress:   heldDynamo.Addr().String(),
+		s3Address:       heldS3.Addr().String(),
+		s3PathStyleOnly: true,
+		metricsRegistry: monitoring.NewRegistry("test-node", "127.0.0.1:0"),
+	}
+	if err := runner.prepareAdminForwardServers(); err != nil {
+		t.Fatalf("prepareAdminForwardServers: %v", err)
+	}
+	if runner.dynamoServer == nil {
+		t.Fatal("dynamo admin-forward server was not prepared")
+	}
+	if runner.s3Server == nil {
+		t.Fatal("s3 admin-forward server was not prepared")
+	}
+	if runner.dynamoListener != nil || runner.s3Listener != nil {
+		t.Fatalf("prepareAdminForwardServers bound listeners: dynamo=%v s3=%v", runner.dynamoListener, runner.s3Listener)
 	}
 }
 

--- a/main_encryption_rotate_on_startup_test.go
+++ b/main_encryption_rotate_on_startup_test.go
@@ -141,7 +141,7 @@ func TestInstallEncryptionRotateOnStartupRequest_ImmediateLeaderWaitRuns(t *test
 	if got := runner.runs.Load(); got != 0 {
 		t.Fatalf("install must defer immediate-leader rotation until startup wait; runs=%d", got)
 	}
-	if err := waitStartup(context.Background()); err != nil {
+	if err := waitStartup.Wait(context.Background()); err != nil {
 		t.Fatalf("waitStartup: %v", err)
 	}
 	if got := runner.runs.Load(); got != 1 {
@@ -163,7 +163,7 @@ func TestInstallEncryptionRotateOnStartupRequest_FollowerDefersUntilStartupWait(
 	if got := runner.runs.Load(); got != 0 {
 		t.Fatalf("leader callback before startup wait must not run rotation; runs=%d", got)
 	}
-	if err := waitStartup(context.Background()); err != nil {
+	if err := waitStartup.Wait(context.Background()); err != nil {
 		t.Fatalf("waitStartup: %v", err)
 	}
 	if got := runner.runs.Load(); got != 1 {
@@ -183,7 +183,7 @@ func TestInstallEncryptionRotateOnStartupRequest_RetriesTransientWhileLeader(t *
 	if got := runner.runs.Load(); got != 0 {
 		t.Fatalf("install must defer immediate-leader retry loop until startup wait; runs=%d", got)
 	}
-	if err := waitStartup(context.Background()); err != nil {
+	if err := waitStartup.Wait(context.Background()); err != nil {
 		t.Fatalf("waitStartup: %v", err)
 	}
 	if got := runner.runs.Load(); got != 2 {
@@ -203,7 +203,7 @@ func TestInstallEncryptionRotateOnStartupRequest_CallbackDoesNotBlockOnDone(t *t
 
 	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := waitStartup(waitCtx); err != nil {
+	if err := waitStartup.Wait(waitCtx); err != nil {
 		t.Fatalf("startup wait while follower: %v", err)
 	}
 
@@ -233,7 +233,7 @@ func TestInstallEncryptionRotateOnStartupRequest_WaitTracksAsyncFlight(t *testin
 	deregister, waitStartup := installEncryptionRotateOnStartupRequestWithWait(context.Background(), controller, runner, nil)
 	defer deregister()
 
-	if err := waitStartup(context.Background()); err != nil {
+	if err := waitStartup.Wait(context.Background()); err != nil {
 		t.Fatalf("initial follower wait: %v", err)
 	}
 	controller.becomeLeader()
@@ -245,7 +245,7 @@ func TestInstallEncryptionRotateOnStartupRequest_WaitTracksAsyncFlight(t *testin
 
 	waitDone := make(chan error, 1)
 	go func() {
-		waitDone <- waitStartup(context.Background())
+		waitDone <- waitStartup.Wait(context.Background())
 	}()
 	select {
 	case err := <-waitDone:
@@ -264,6 +264,39 @@ func TestInstallEncryptionRotateOnStartupRequest_WaitTracksAsyncFlight(t *testin
 	}
 }
 
+func TestInstallEncryptionRotateOnStartupRequest_BlocksMutatorsDuringAsyncStartupFlight(t *testing.T) {
+	controller := &fakeRotateStartupController{state: raftengine.StateFollower}
+	runner := &blockingRunRotateStartupRunner{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	deregister, waitStartup := installEncryptionRotateOnStartupRequestWithWait(context.Background(), controller, runner, nil)
+	defer deregister()
+
+	if err := waitStartup.Wait(context.Background()); err != nil {
+		t.Fatalf("initial follower wait: %v", err)
+	}
+	controller.becomeLeader()
+	select {
+	case <-runner.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("async startup rotation did not start")
+	}
+	if !waitStartup.BlockMutators() {
+		t.Fatal("startup mutator gate must remain closed while async rotation is in flight")
+	}
+
+	close(runner.release)
+	deadline := time.After(2 * time.Second)
+	for waitStartup.BlockMutators() {
+		select {
+		case <-deadline:
+			t.Fatal("startup mutator gate did not open after async rotation finished")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
 func TestInstallEncryptionRotateOnStartupRequest_WaitReturnsPermanentError(t *testing.T) {
 	t.Parallel()
 	controller := &fakeRotateStartupController{state: raftengine.StateLeader}
@@ -272,7 +305,7 @@ func TestInstallEncryptionRotateOnStartupRequest_WaitReturnsPermanentError(t *te
 
 	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	err := waitStartup(waitCtx)
+	err := waitStartup.Wait(waitCtx)
 	if err == nil || !strings.Contains(err.Error(), "bad sidecar") {
 		t.Fatalf("startup wait err=%v, want bad sidecar", err)
 	}
@@ -291,6 +324,11 @@ func TestStartupPublicKVGate_BlocksMutatorsUntilReady(t *testing.T) {
 		pb.Internal_Forward_FullMethodName,
 		pb.AdminForward_Forward_FullMethodName,
 		pb.Distribution_SplitRange_FullMethodName,
+		pb.RaftAdmin_AddVoter_FullMethodName,
+		pb.RaftAdmin_AddLearner_FullMethodName,
+		pb.RaftAdmin_PromoteLearner_FullMethodName,
+		pb.RaftAdmin_RemoveServer_FullMethodName,
+		pb.RaftAdmin_TransferLeadership_FullMethodName,
 		pb.EncryptionAdmin_BootstrapEncryption_FullMethodName,
 		pb.EncryptionAdmin_RotateDEK_FullMethodName,
 		pb.EncryptionAdmin_RegisterEncryptionWriter_FullMethodName,
@@ -321,6 +359,8 @@ func TestStartupPublicKVGate_BlocksMutatorsUntilReady(t *testing.T) {
 
 	allowedMethods := []string{
 		pb.Internal_RelayPublish_FullMethodName,
+		pb.RaftAdmin_Status_FullMethodName,
+		pb.RaftAdmin_Configuration_FullMethodName,
 		pb.EncryptionAdmin_GetCapability_FullMethodName,
 		pb.EncryptionAdmin_GetSidecarState_FullMethodName,
 	}
@@ -363,6 +403,41 @@ func TestStartupPublicKVGate_BlocksMutatorsUntilReady(t *testing.T) {
 				t.Fatalf("%s handler did not run after startup gate opened", method)
 			}
 		})
+	}
+}
+
+func TestStartupPublicKVGate_BlocksAfterReadyWhenStartupRotationPending(t *testing.T) {
+	t.Parallel()
+	blocked := true
+	gate := &startupPublicKVGate{blockMutator: func() bool { return blocked }}
+	gate.markReady()
+
+	handlerCalled := false
+	handler := func(context.Context, interface{}) (interface{}, error) {
+		handlerCalled = true
+		return "ok", nil
+	}
+	if _, err := gate.unaryInterceptor(
+		context.Background(), nil,
+		&grpc.UnaryServerInfo{FullMethod: pb.RaftAdmin_AddVoter_FullMethodName},
+		handler,
+	); status.Code(err) != codes.Unavailable {
+		t.Fatalf("ready gate with pending startup rotation err=%v, want Unavailable", err)
+	}
+	if handlerCalled {
+		t.Fatal("gated handler ran while startup rotation blocker was active")
+	}
+
+	blocked = false
+	if _, err := gate.unaryInterceptor(
+		context.Background(), nil,
+		&grpc.UnaryServerInfo{FullMethod: pb.RaftAdmin_AddVoter_FullMethodName},
+		handler,
+	); err != nil {
+		t.Fatalf("gate after blocker cleared: %v", err)
+	}
+	if !handlerCalled {
+		t.Fatal("gated handler did not run after blocker cleared")
 	}
 }
 

--- a/main_encryption_rotate_on_startup_test.go
+++ b/main_encryption_rotate_on_startup_test.go
@@ -14,6 +14,9 @@ import (
 	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
 	"github.com/bootjp/elastickv/internal/raftengine"
 	pb "github.com/bootjp/elastickv/proto"
+	crdberrors "github.com/cockroachdb/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type fakeRotateStartupController struct {
@@ -108,6 +111,21 @@ func TestInstallEncryptionRotateOnStartupRequest_FollowerFiresOnLeadership(t *te
 	}
 }
 
+func TestInstallEncryptionRotateOnStartupRequest_RechecksLeaderAfterRegister(t *testing.T) {
+	t.Parallel()
+	controller := &fakeRotateStartupController{state: raftengine.StateLeader}
+	runner := &fakeRotateStartupRunner{err: raftengine.ErrLeadershipLost}
+	deregister := installEncryptionRotateOnStartupRequest(context.Background(), controller, runner, nil)
+	defer deregister()
+	deadline := time.Now().Add(2 * time.Second)
+	for runner.runs.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := runner.runs.Load(); got < 2 {
+		t.Fatalf("leader recheck after callback registration did not retry pending rotation; runs=%d", got)
+	}
+}
+
 type fakeStartupKEK struct{}
 
 func (fakeStartupKEK) Wrap(dek []byte) ([]byte, error) {
@@ -188,6 +206,52 @@ func TestEncryptionRotateOnStartupTask_RunRotatesStorageAndRaft(t *testing.T) {
 	}
 	assertRotateProposal(t, rec.proposals[0], pb.RotateDEKRequest_PURPOSE_STORAGE, 9, 11)
 	assertRotateProposal(t, rec.proposals[1], pb.RotateDEKRequest_PURPOSE_RAFT, 10, 12)
+}
+
+func TestEncryptionRotateOnStartupTask_RetryableRotateErrorSkipsUncertainKeyID(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	sidecarPath := filepath.Join(dir, encryption.SidecarFilename)
+	sc := &encryption.Sidecar{
+		Version:          encryption.SidecarVersion,
+		RaftAppliedIndex: 1,
+		Active:           encryption.ActiveKeys{Storage: 7},
+		Keys: map[string]encryption.SidecarKey{
+			"7": {Purpose: encryption.SidecarPurposeStorage, Wrapped: []byte("storage"), Created: "2026-07-07T00:00:00Z"},
+		},
+	}
+	if err := encryption.WriteSidecar(sidecarPath, sc); err != nil {
+		t.Fatalf("WriteSidecar: %v", err)
+	}
+	rec := &recordingRotateProposer{err: status.Error(codes.Unavailable, "commit result uncertain")}
+	task := &encryptionRotateOnStartupTask{
+		server:      adapterServerForRotateStartup(t, sidecarPath, rec),
+		sidecarPath: sidecarPath,
+		kekWrapper:  fakeStartupKEK{},
+		fullNodeID:  0xCAFE,
+	}
+	if err := task.Run(context.Background()); err == nil {
+		t.Fatal("Run returned nil, want retryable rotate error")
+	}
+	if got := task.nextKeyID; got != 9 {
+		t.Fatalf("nextKeyID=%d, want 9 after treating key 8 as uncertain/committed", got)
+	}
+	rec.err = nil
+	if err := task.Run(context.Background()); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if got := len(rec.proposals); got != 1 {
+		t.Fatalf("successful proposals=%d, want 1", got)
+	}
+	assertRotateProposal(t, rec.proposals[0], pb.RotateDEKRequest_PURPOSE_STORAGE, 9, 0)
+}
+
+func TestRetryableEncryptionRotateOnStartupError_UnwrapsStatus(t *testing.T) {
+	t.Parallel()
+	err := crdberrors.Wrap(status.Error(codes.Unavailable, "try later"), "wrapped")
+	if !retryableEncryptionRotateOnStartupError(err) {
+		t.Fatal("wrapped Unavailable status must be retryable")
+	}
 }
 
 func adapterServerForRotateStartup(t *testing.T, sidecarPath string, rec *recordingRotateProposer) *adapter.EncryptionAdminServer {

--- a/main_encryption_rotate_on_startup_test.go
+++ b/main_encryption_rotate_on_startup_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bootjp/elastickv/internal/encryption"
 	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
 	"github.com/bootjp/elastickv/internal/raftengine"
+	"github.com/bootjp/elastickv/kv"
 	"github.com/bootjp/elastickv/monitoring"
 	pb "github.com/bootjp/elastickv/proto"
 	crdberrors "github.com/cockroachdb/errors"
@@ -131,6 +132,37 @@ func (b *blockingRunRotateStartupRunner) Run(context.Context) error {
 }
 
 func (b *blockingRunRotateStartupRunner) Done() bool { return b.done.Load() }
+
+type stubStartupCoordinator struct {
+	dispatches atomic.Int32
+	clock      *kv.HLC
+}
+
+func (s *stubStartupCoordinator) Dispatch(context.Context, *kv.OperationGroup[kv.OP]) (*kv.CoordinateResponse, error) {
+	s.dispatches.Add(1)
+	return &kv.CoordinateResponse{}, nil
+}
+
+func (s *stubStartupCoordinator) IsLeader() bool { return true }
+
+func (s *stubStartupCoordinator) VerifyLeader(context.Context) error { return nil }
+
+func (s *stubStartupCoordinator) LinearizableRead(context.Context) (uint64, error) { return 1, nil }
+
+func (s *stubStartupCoordinator) RaftLeader() string { return "n1" }
+
+func (s *stubStartupCoordinator) IsLeaderForKey([]byte) bool { return true }
+
+func (s *stubStartupCoordinator) VerifyLeaderForKey(context.Context, []byte) error { return nil }
+
+func (s *stubStartupCoordinator) RaftLeaderForKey([]byte) string { return "n1" }
+
+func (s *stubStartupCoordinator) Clock() *kv.HLC {
+	if s.clock == nil {
+		s.clock = kv.NewHLC()
+	}
+	return s.clock
+}
 
 func TestInstallEncryptionRotateOnStartupRequest_ImmediateLeaderWaitRuns(t *testing.T) {
 	t.Parallel()
@@ -441,6 +473,33 @@ func TestStartupPublicKVGate_BlocksAfterReadyWhenStartupRotationPending(t *testi
 	}
 }
 
+func TestStartupGatedCoordinator_BlocksAdapterDispatchDuringAsyncRotation(t *testing.T) {
+	t.Parallel()
+	inner := &stubStartupCoordinator{clock: kv.NewHLC()}
+	blocked := true
+	gate := &startupPublicKVGate{blockMutator: func() bool { return blocked }}
+	gate.markReady()
+	coord := startupGatedCoordinator{inner: inner, gate: gate}
+
+	if _, err := coord.Dispatch(context.Background(), nil); status.Code(err) != codes.Unavailable {
+		t.Fatalf("blocked Dispatch err=%v, want Unavailable", err)
+	}
+	if got := inner.dispatches.Load(); got != 0 {
+		t.Fatalf("inner Dispatch calls while blocked=%d, want 0", got)
+	}
+	if _, err := coord.LinearizableRead(context.Background()); err != nil {
+		t.Fatalf("LinearizableRead should pass through while Dispatch is blocked: %v", err)
+	}
+
+	blocked = false
+	if _, err := coord.Dispatch(context.Background(), nil); err != nil {
+		t.Fatalf("Dispatch after blocker cleared: %v", err)
+	}
+	if got := inner.dispatches.Load(); got != 1 {
+		t.Fatalf("inner Dispatch calls after unblock=%d, want 1", got)
+	}
+}
+
 func TestRuntimeServerRunner_PrepareAdminForwardServersDoesNotBindPublicListeners(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -478,6 +537,38 @@ func TestRuntimeServerRunner_PrepareAdminForwardServersDoesNotBindPublicListener
 	}
 }
 
+func TestRuntimeServerRunner_PreparePublicServicesBindsBeforeRotation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	lc := &net.ListenConfig{}
+	heldDynamo, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen held dynamo: %v", err)
+	}
+	defer heldDynamo.Close()
+
+	runner := runtimeServerRunner{
+		ctx:             ctx,
+		lc:              lc,
+		redisAddress:    "127.0.0.1:0",
+		dynamoAddress:   heldDynamo.Addr().String(),
+		s3PathStyleOnly: true,
+		metricsAddress:  "",
+		pprofAddress:    "",
+		pubsubRelay:     adapter.NewRedisPubSubRelay(),
+		metricsRegistry: monitoring.NewRegistry("test-node", "127.0.0.1:0"),
+		coordinate:      &stubStartupCoordinator{clock: kv.NewHLC()},
+	}
+	if err := runner.prepareAdminForwardServers(); err != nil {
+		t.Fatalf("prepareAdminForwardServers: %v", err)
+	}
+	err = runner.preparePublicServices()
+	if err == nil || !strings.Contains(err.Error(), "failed to listen") {
+		t.Fatalf("preparePublicServices err=%v, want occupied listener error before rotation", err)
+	}
+	runner.closePreparedExternalListeners()
+}
+
 type fakeStartupKEK struct{}
 
 func (fakeStartupKEK) Wrap(dek []byte) ([]byte, error) {
@@ -510,8 +601,24 @@ func (r *recordingRotateProposer) ProposeAdmin(_ context.Context, data []byte) (
 	return &raftengine.ProposalResult{CommitIndex: uint64(len(r.proposals))}, nil
 }
 
+type blockingRotateProposer struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingRotateProposer) Propose(context.Context, []byte) (*raftengine.ProposalResult, error) {
+	return nil, errors.New("unexpected Propose")
+}
+
+func (b *blockingRotateProposer) ProposeAdmin(context.Context, []byte) (*raftengine.ProposalResult, error) {
+	b.once.Do(func() { close(b.started) })
+	<-b.release
+	return &raftengine.ProposalResult{CommitIndex: 1}, nil
+}
+
 type rotateStartupLeader struct {
-	*recordingRotateProposer
+	raftengine.Proposer
 }
 
 func (rotateStartupLeader) State() raftengine.State            { return raftengine.StateLeader }
@@ -558,6 +665,63 @@ func TestEncryptionRotateOnStartupTask_RunRotatesStorageAndRaft(t *testing.T) {
 	}
 	assertRotateProposal(t, rec.proposals[0], pb.RotateDEKRequest_PURPOSE_STORAGE, 9, 11)
 	assertRotateProposal(t, rec.proposals[1], pb.RotateDEKRequest_PURPOSE_RAFT, 10, 12)
+}
+
+func TestEncryptionRotateOnStartupTask_DoneDoesNotWaitForRotateDEK(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	sidecarPath := filepath.Join(dir, encryption.SidecarFilename)
+	sc := &encryption.Sidecar{
+		Version:          encryption.SidecarVersion,
+		RaftAppliedIndex: 1,
+		Active:           encryption.ActiveKeys{Storage: 7},
+		Keys: map[string]encryption.SidecarKey{
+			"7": {Purpose: encryption.SidecarPurposeStorage, Wrapped: []byte("storage"), Created: "2026-07-07T00:00:00Z"},
+		},
+	}
+	if err := encryption.WriteSidecar(sidecarPath, sc); err != nil {
+		t.Fatalf("WriteSidecar: %v", err)
+	}
+	blocking := &blockingRotateProposer{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	task := &encryptionRotateOnStartupTask{
+		server:      adapterServerForRotateStartupProposer(t, sidecarPath, blocking),
+		sidecarPath: sidecarPath,
+		kekWrapper:  fakeStartupKEK{},
+		fullNodeID:  0xCAFE,
+	}
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- task.Run(context.Background())
+	}()
+	select {
+	case <-blocking.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RotateDEK proposal did not start")
+	}
+
+	doneReturned := make(chan bool, 1)
+	go func() { doneReturned <- task.Done() }()
+	select {
+	case got := <-doneReturned:
+		if got {
+			t.Fatal("task must not be done while RotateDEK is still in flight")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Done blocked behind in-flight RotateDEK")
+	}
+
+	close(blocking.release)
+	select {
+	case err := <-runDone:
+		if err != nil {
+			t.Fatalf("Run after release: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not finish after RotateDEK release")
+	}
 }
 
 func TestEncryptionRotateOnStartupTask_RunFencesBeforeSidecarRead(t *testing.T) {
@@ -683,7 +847,12 @@ func TestRetryableEncryptionRotateOnStartupError_UnwrapsStatus(t *testing.T) {
 
 func adapterServerForRotateStartup(t *testing.T, sidecarPath string, rec *recordingRotateProposer) *adapter.EncryptionAdminServer {
 	t.Helper()
-	leader := rotateStartupLeader{recordingRotateProposer: rec}
+	return adapterServerForRotateStartupProposer(t, sidecarPath, rec)
+}
+
+func adapterServerForRotateStartupProposer(t *testing.T, sidecarPath string, proposer raftengine.Proposer) *adapter.EncryptionAdminServer {
+	t.Helper()
+	leader := rotateStartupLeader{Proposer: proposer}
 	server := adapter.NewEncryptionAdminServer(
 		adapter.WithEncryptionAdminSidecarPath(sidecarPath),
 		adapter.WithEncryptionAdminFullNodeID(0xCAFE),

--- a/main_encryption_rotate_on_startup_test.go
+++ b/main_encryption_rotate_on_startup_test.go
@@ -208,7 +208,46 @@ func TestEncryptionRotateOnStartupTask_RunRotatesStorageAndRaft(t *testing.T) {
 	assertRotateProposal(t, rec.proposals[1], pb.RotateDEKRequest_PURPOSE_RAFT, 10, 12)
 }
 
-func TestEncryptionRotateOnStartupTask_RetryableRotateErrorSkipsUncertainKeyID(t *testing.T) {
+func TestEncryptionRotateOnStartupTask_RunFencesBeforeSidecarRead(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	sidecarPath := filepath.Join(dir, encryption.SidecarFilename)
+	sc := &encryption.Sidecar{
+		Version:          encryption.SidecarVersion,
+		RaftAppliedIndex: 10,
+		Active:           encryption.ActiveKeys{Storage: 7},
+		Keys: map[string]encryption.SidecarKey{
+			"7": {Purpose: encryption.SidecarPurposeStorage, Wrapped: []byte("storage"), Created: "2026-07-07T00:00:00Z"},
+		},
+	}
+	rec := &recordingRotateProposer{}
+	var fenced atomic.Bool
+	task := &encryptionRotateOnStartupTask{
+		server:      adapterServerForRotateStartup(t, sidecarPath, rec),
+		sidecarPath: sidecarPath,
+		kekWrapper:  fakeStartupKEK{},
+		fullNodeID:  0xCAFE,
+		readFence: func(context.Context) (uint64, error) {
+			fenced.Store(true)
+			if err := encryption.WriteSidecar(sidecarPath, sc); err != nil {
+				return 0, err
+			}
+			return sc.RaftAppliedIndex, nil
+		},
+	}
+	if err := task.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !fenced.Load() {
+		t.Fatal("read fence was not called")
+	}
+	if got := len(rec.proposals); got != 1 {
+		t.Fatalf("proposals=%d, want 1 after fenced sidecar read", got)
+	}
+	assertRotateProposal(t, rec.proposals[0], pb.RotateDEKRequest_PURPOSE_STORAGE, 8, 0)
+}
+
+func TestEncryptionRotateOnStartupTask_RetryRereadsSidecarKeyID(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	sidecarPath := filepath.Join(dir, encryption.SidecarFilename)
@@ -233,8 +272,14 @@ func TestEncryptionRotateOnStartupTask_RetryableRotateErrorSkipsUncertainKeyID(t
 	if err := task.Run(context.Background()); err == nil {
 		t.Fatal("Run returned nil, want retryable rotate error")
 	}
-	if got := task.nextKeyID; got != 9 {
-		t.Fatalf("nextKeyID=%d, want 9 after treating key 8 as uncertain/committed", got)
+	sc.Active.Storage = 8
+	sc.Keys["8"] = encryption.SidecarKey{
+		Purpose: encryption.SidecarPurposeStorage,
+		Wrapped: []byte("storage-v2"),
+		Created: "2026-07-07T00:00:01Z",
+	}
+	if err := encryption.WriteSidecar(sidecarPath, sc); err != nil {
+		t.Fatalf("WriteSidecar retry fixture: %v", err)
 	}
 	rec.err = nil
 	if err := task.Run(context.Background()); err != nil {

--- a/main_encryption_rotate_on_startup_test.go
+++ b/main_encryption_rotate_on_startup_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -112,6 +113,22 @@ func (b *blockingDoneRotateStartupRunner) Done() bool {
 	return false
 }
 
+type blockingRunRotateStartupRunner struct {
+	started chan struct{}
+	release chan struct{}
+	done    atomic.Bool
+	once    sync.Once
+}
+
+func (b *blockingRunRotateStartupRunner) Run(context.Context) error {
+	b.once.Do(func() { close(b.started) })
+	<-b.release
+	b.done.Store(true)
+	return nil
+}
+
+func (b *blockingRunRotateStartupRunner) Done() bool { return b.done.Load() }
+
 func TestInstallEncryptionRotateOnStartupRequest_ImmediateLeaderBlocks(t *testing.T) {
 	t.Parallel()
 	controller := &fakeRotateStartupController{state: raftengine.StateLeader}
@@ -180,6 +197,60 @@ func TestInstallEncryptionRotateOnStartupRequest_CallbackDoesNotBlockOnDone(t *t
 	case <-runner.doneEntered:
 	case <-time.After(2 * time.Second):
 		t.Fatal("async rotation did not reach Done")
+	}
+}
+
+func TestInstallEncryptionRotateOnStartupRequest_WaitTracksAsyncFlight(t *testing.T) {
+	controller := &fakeRotateStartupController{state: raftengine.StateFollower}
+	runner := &blockingRunRotateStartupRunner{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	deregister, waitStartup := installEncryptionRotateOnStartupRequestWithWait(context.Background(), controller, runner, nil)
+	defer deregister()
+
+	controller.becomeLeader()
+	select {
+	case <-runner.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("async rotation did not start")
+	}
+
+	waitDone := make(chan error, 1)
+	go func() {
+		waitDone <- waitStartup(context.Background())
+	}()
+	select {
+	case err := <-waitDone:
+		t.Fatalf("startup wait returned before async rotation finished: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(runner.release)
+	select {
+	case err := <-waitDone:
+		if err != nil {
+			t.Fatalf("startup wait returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("startup wait did not finish after rotation completed")
+	}
+}
+
+func TestInstallEncryptionRotateOnStartupRequest_WaitReturnsPermanentError(t *testing.T) {
+	t.Parallel()
+	controller := &fakeRotateStartupController{state: raftengine.StateLeader}
+	runner := &fakeRotateStartupRunner{err: errors.New("bad sidecar")}
+	_, waitStartup := installEncryptionRotateOnStartupRequestWithWait(context.Background(), controller, runner, nil)
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	err := waitStartup(waitCtx)
+	if err == nil || !strings.Contains(err.Error(), "bad sidecar") {
+		t.Fatalf("startup wait err=%v, want bad sidecar", err)
+	}
+	if got := runner.runs.Load(); got != 1 {
+		t.Fatalf("permanent error must not be retried; runs=%d", got)
 	}
 }
 
@@ -346,6 +417,36 @@ func TestEncryptionRotateOnStartupTask_RetryRereadsSidecarKeyID(t *testing.T) {
 		t.Fatalf("successful proposals=%d, want 1", got)
 	}
 	assertRotateProposal(t, rec.proposals[0], pb.RotateDEKRequest_PURPOSE_STORAGE, 9, 0)
+}
+
+func TestEncryptionRotateOnStartupTask_KeyIDExhaustionDoesNotMarkDone(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	sidecarPath := filepath.Join(dir, encryption.SidecarFilename)
+	sc := &encryption.Sidecar{
+		Version:          encryption.SidecarVersion,
+		RaftAppliedIndex: 1,
+		Active:           encryption.ActiveKeys{Storage: 7},
+		Keys: map[string]encryption.SidecarKey{
+			"7":          {Purpose: encryption.SidecarPurposeStorage, Wrapped: []byte("storage")},
+			"4294967295": {Purpose: encryption.SidecarPurposeRaft, Wrapped: []byte("raft")},
+		},
+	}
+	if err := encryption.WriteSidecar(sidecarPath, sc); err != nil {
+		t.Fatalf("WriteSidecar: %v", err)
+	}
+	task := &encryptionRotateOnStartupTask{
+		server:      adapterServerForRotateStartup(t, sidecarPath, &recordingRotateProposer{}),
+		sidecarPath: sidecarPath,
+		kekWrapper:  fakeStartupKEK{},
+		fullNodeID:  0xCAFE,
+	}
+	if err := task.Run(context.Background()); err == nil {
+		t.Fatal("Run returned nil, want key-id exhaustion error")
+	}
+	if task.Done() {
+		t.Fatal("key-id exhaustion must not mark rotation done")
+	}
 }
 
 func TestRetryableEncryptionRotateOnStartupError_UnwrapsStatus(t *testing.T) {

--- a/main_raft_envelope_wiring.go
+++ b/main_raft_envelope_wiring.go
@@ -98,6 +98,32 @@ func (r *raftEnvelopeRuntime) installFromApply(cutoverIdx uint64, activeRaftDEKI
 	return nil
 }
 
+func (r *raftEnvelopeRuntime) installRotatedRaftDEK(activeRaftDEKID uint32) error {
+	if r == nil {
+		return nil
+	}
+	if r.cutoverIndex == nil {
+		return errors.New("raft envelope runtime: nil cutover cell")
+	}
+	if r.cutoverIndex.Load() == 0 {
+		return nil
+	}
+	if activeRaftDEKID == 0 {
+		return errors.New("raft envelope runtime: active raft DEK must be non-zero")
+	}
+	wrap, err := r.wrapFor(activeRaftDEKID)
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	r.activeWrap = wrap
+	for _, g := range r.groups {
+		g.SetRaftPayloadWrap(wrap)
+	}
+	r.mu.Unlock()
+	return nil
+}
+
 func (r *raftEnvelopeRuntime) reinstallActiveWrap() {
 	if r == nil {
 		return

--- a/main_raft_envelope_wiring_test.go
+++ b/main_raft_envelope_wiring_test.go
@@ -94,3 +94,47 @@ func TestRaftEnvelopeRuntime_InstallFromApplyPublishesWrap(t *testing.T) {
 		t.Fatal("installFromApply did not publish wrap to attached group")
 	}
 }
+
+func TestRaftEnvelopeRuntime_InstallRotatedRaftDEKRepublishesWrap(t *testing.T) {
+	t.Parallel()
+	const (
+		oldKeyID uint32 = 4
+		newKeyID uint32 = 9
+	)
+	ks := encryption.NewKeystore()
+	for _, keyID := range []uint32{oldKeyID, newKeyID} {
+		key := bytes.Repeat([]byte{byte(keyID)}, encryption.KeySize)
+		if err := ks.Set(keyID, key); err != nil {
+			t.Fatalf("keystore Set(%d): %v", keyID, err)
+		}
+	}
+	cipher, err := encryption.NewCipher(ks)
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	var cutover atomic.Uint64
+	runtime, err := newRaftEnvelopeRuntime(cipher, encryption.NewDeterministicNonceFactory(0xCAFE, 7), 1234, oldKeyID, &cutover)
+	if err != nil {
+		t.Fatalf("newRaftEnvelopeRuntime: %v", err)
+	}
+	sg := &kv.ShardGroup{}
+	runtime.attachGroup(7, sg)
+	if err := runtime.installRotatedRaftDEK(newKeyID); err != nil {
+		t.Fatalf("installRotatedRaftDEK: %v", err)
+	}
+	wrap := sg.RaftPayloadWrap()
+	if wrap == nil {
+		t.Fatal("installRotatedRaftDEK did not publish wrap to attached group")
+	}
+	wrapped, err := wrap([]byte("raft payload"))
+	if err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+	env, err := encryption.DecodeEnvelope(wrapped)
+	if err != nil {
+		t.Fatalf("DecodeEnvelope: %v", err)
+	}
+	if env.KeyID != newKeyID {
+		t.Fatalf("wrapped key_id=%d, want rotated key_id=%d", env.KeyID, newKeyID)
+	}
+}

--- a/main_s3.go
+++ b/main_s3.go
@@ -33,25 +33,45 @@ func startS3Server(
 	pathStyleOnly bool,
 	readTracker *kv.ActiveTimestampTracker,
 ) (*adapter.S3Server, error) {
+	s3Server, _, err := prepareS3Server(ctx, lc, s3Addr, shardStore, coordinate, leaderS3, region, credentialsFile, pathStyleOnly, readTracker)
+	if err != nil {
+		return nil, err
+	}
+	runS3Server(ctx, eg, s3Server)
+	return s3Server, nil
+}
+
+func prepareS3Server(
+	ctx context.Context,
+	lc *net.ListenConfig,
+	s3Addr string,
+	shardStore *kv.ShardStore,
+	coordinate kv.Coordinator,
+	leaderS3 map[string]string,
+	region string,
+	credentialsFile string,
+	pathStyleOnly bool,
+	readTracker *kv.ActiveTimestampTracker,
+) (*adapter.S3Server, net.Listener, error) {
 	s3Addr = strings.TrimSpace(s3Addr)
 	if s3Addr == "" {
 		// (nil, nil) is the explicit "S3 disabled" signal — the empty
 		// flag value is a valid configuration, not an error. The
 		// nilnil linter is not enabled in .golangci.yaml so no
 		// suppression directive is needed.
-		return nil, nil
+		return nil, nil, nil
 	}
 	if !pathStyleOnly {
-		return nil, errors.New("virtual-hosted style S3 requests are not implemented")
+		return nil, nil, errors.New("virtual-hosted style S3 requests are not implemented")
 	}
 	s3L, err := lc.Listen(ctx, "tcp", s3Addr)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to listen on %s", s3Addr)
+		return nil, nil, errors.Wrapf(err, "failed to listen on %s", s3Addr)
 	}
 	staticCreds, err := loadS3StaticCredentials(credentialsFile)
 	if err != nil {
 		_ = s3L.Close()
-		return nil, err
+		return nil, nil, err
 	}
 	s3Server := adapter.NewS3Server(
 		s3L,
@@ -63,6 +83,13 @@ func startS3Server(
 		adapter.WithS3StaticCredentials(staticCreds),
 		adapter.WithS3ActiveTimestampTracker(readTracker),
 	)
+	return s3Server, s3L, nil
+}
+
+func runS3Server(ctx context.Context, eg *errgroup.Group, s3Server *adapter.S3Server) {
+	if s3Server == nil {
+		return
+	}
 	runDoneCtx, runDoneCancel := context.WithCancel(context.Background())
 	eg.Go(func() error {
 		select {
@@ -80,7 +107,6 @@ func startS3Server(
 		}
 		return errors.WithStack(err)
 	})
-	return s3Server, nil
 }
 
 func loadS3StaticCredentials(path string) (map[string]string, error) {

--- a/main_s3.go
+++ b/main_s3.go
@@ -53,28 +53,44 @@ func prepareS3Server(
 	pathStyleOnly bool,
 	readTracker *kv.ActiveTimestampTracker,
 ) (*adapter.S3Server, net.Listener, error) {
+	s3Server, err := newS3Server(s3Addr, shardStore, coordinate, leaderS3, region, credentialsFile, pathStyleOnly, readTracker)
+	if err != nil {
+		return nil, nil, err
+	}
+	s3L, err := bindS3Server(ctx, lc, s3Addr, s3Server)
+	if err != nil {
+		return nil, nil, err
+	}
+	return s3Server, s3L, nil
+}
+
+func newS3Server(
+	s3Addr string,
+	shardStore *kv.ShardStore,
+	coordinate kv.Coordinator,
+	leaderS3 map[string]string,
+	region string,
+	credentialsFile string,
+	pathStyleOnly bool,
+	readTracker *kv.ActiveTimestampTracker,
+) (*adapter.S3Server, error) {
 	s3Addr = strings.TrimSpace(s3Addr)
 	if s3Addr == "" {
 		// (nil, nil) is the explicit "S3 disabled" signal — the empty
 		// flag value is a valid configuration, not an error. The
 		// nilnil linter is not enabled in .golangci.yaml so no
 		// suppression directive is needed.
-		return nil, nil, nil
+		return nil, nil
 	}
 	if !pathStyleOnly {
-		return nil, nil, errors.New("virtual-hosted style S3 requests are not implemented")
-	}
-	s3L, err := lc.Listen(ctx, "tcp", s3Addr)
-	if err != nil {
-		return nil, nil, errors.Wrapf(err, "failed to listen on %s", s3Addr)
+		return nil, errors.New("virtual-hosted style S3 requests are not implemented")
 	}
 	staticCreds, err := loadS3StaticCredentials(credentialsFile)
 	if err != nil {
-		_ = s3L.Close()
-		return nil, nil, err
+		return nil, err
 	}
 	s3Server := adapter.NewS3Server(
-		s3L,
+		nil,
 		s3Addr,
 		shardStore,
 		coordinate,
@@ -83,7 +99,20 @@ func prepareS3Server(
 		adapter.WithS3StaticCredentials(staticCreds),
 		adapter.WithS3ActiveTimestampTracker(readTracker),
 	)
-	return s3Server, s3L, nil
+	return s3Server, nil
+}
+
+func bindS3Server(ctx context.Context, lc *net.ListenConfig, s3Addr string, s3Server *adapter.S3Server) (net.Listener, error) {
+	s3Addr = strings.TrimSpace(s3Addr)
+	if s3Server == nil || s3Addr == "" {
+		return nil, nil
+	}
+	s3L, err := lc.Listen(ctx, "tcp", s3Addr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to listen on %s", s3Addr)
+	}
+	s3Server.SetListener(s3L)
+	return s3L, nil
 }
 
 func runS3Server(ctx context.Context, eg *errgroup.Group, s3Server *adapter.S3Server) {

--- a/main_sqs.go
+++ b/main_sqs.go
@@ -12,21 +12,14 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// startSQSServer constructs the SQS adapter and returns the running
-// *adapter.SQSServer. The admin listener calls SigV4-bypass admin
-// entrypoints against this server (see adapter/sqs_admin.go); those
-// admin methods only need the coordinator/store, NOT the public SQS
-// HTTP listener. So when sqsAddr is empty the function still
-// constructs the server (with a nil net.Listener) — Run() then skips
-// httpServer.Serve while the reaper and throttle-sweep goroutines
-// still run, keeping retention math behind the admin counters
-// correct. The admin bridge in main_admin.go therefore wires
-// /admin/api/v1/sqs/* on the wire even on builds that disabled the
-// public SigV4 endpoint.
-func startSQSServer(
+// prepareSQSServer constructs the SQS adapter. The admin listener calls
+// SigV4-bypass admin entrypoints against this server (see adapter/sqs_admin.go);
+// those admin methods only need the coordinator/store, NOT the public SQS HTTP
+// listener. So when sqsAddr is empty the function still constructs the server
+// with a nil net.Listener.
+func prepareSQSServer(
 	ctx context.Context,
 	lc *net.ListenConfig,
-	eg *errgroup.Group,
 	sqsAddr string,
 	shardStore *kv.ShardStore,
 	coordinate kv.Coordinator,
@@ -35,16 +28,16 @@ func startSQSServer(
 	credentialsFile string,
 	partitionResolver *adapter.SQSPartitionResolver,
 	partitionObserver adapter.SQSPartitionObserver,
-) (*adapter.SQSServer, error) {
+) (*adapter.SQSServer, net.Listener, error) {
 	sqsAddr = strings.TrimSpace(sqsAddr)
 	sqsL, err := openSQSListener(ctx, lc, sqsAddr)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	staticCreds, err := loadSQSStaticCredentials(credentialsFile, sqsAddr)
 	if err != nil {
 		closeSQSListenerOnError(sqsL, sqsAddr)
-		return nil, err
+		return nil, nil, err
 	}
 	sqsServer := adapter.NewSQSServer(
 		sqsL,
@@ -56,6 +49,13 @@ func startSQSServer(
 		adapter.WithSQSPartitionResolver(partitionResolver),
 		adapter.WithSQSPartitionObserver(partitionObserver),
 	)
+	return sqsServer, sqsL, nil
+}
+
+func runSQSServer(ctx context.Context, eg *errgroup.Group, sqsServer *adapter.SQSServer) {
+	if sqsServer == nil {
+		return
+	}
 	// Two-goroutine shutdown pattern mirrors startS3Server: one goroutine waits
 	// on either ctx.Done() or Run completion to call Stop, the other runs the
 	// server and cancels the waiter once it has returned.
@@ -76,12 +76,11 @@ func startSQSServer(
 		}
 		return errors.WithStack(err)
 	})
-	return sqsServer, nil
 }
 
 // openSQSListener returns the bound listener for sqsAddr, or
 // (nil, nil) when sqsAddr is empty (listenless / admin-only mode).
-// Pulled out of startSQSServer so the constructor stays under the
+// Pulled out of prepareSQSServer so the constructor stays under the
 // cyclop budget; the listenless branch is otherwise the same one
 // the function-level docstring describes.
 func openSQSListener(ctx context.Context, lc *net.ListenConfig, sqsAddr string) (net.Listener, error) {


### PR DESCRIPTION
## Summary
- add --encryption-rotate-on-startup request handling for the default encryption Raft group
- run leader-only startup rotation for active storage and raft DEKs before listeners open, with follower retry on leadership acquisition
- update the data-at-rest encryption milestone table for Stage 6F

## Design docs
- docs/design/2026_04_29_partial_data_at_rest_encryption.md

## Stack
- base branch: design/encryption-raft-envelope-cutover

## Validation
- git verify-commit HEAD
- go test . ./internal/encryption -run 'Test.*Rotate|Test.*Startup|Test.*Encryption|Test.*Leader|Test.*DEK' -count=1
- golangci-lint --config=.golangci.yaml run . ./internal/encryption --timeout=5m

Author: bootjp