### PR TITLE
Mark admin delete safety net implemented

### DIFF
--- a/adapter/s3_admin.go
+++ b/adapter/s3_admin.go
@@ -379,7 +379,7 @@ func (s *S3Server) AdminPutBucketAcl(ctx context.Context, principal AdminPrincip
 //	         orphans left by any PutObject that committed
 //	         chunks/manifest between the empty-probe and the
 //	         Phase-1 commit. See design doc
-//	         2026_04_28_proposed_admin_delete_bucket_safety_net.md
+//	         2026_04_28_implemented_admin_delete_bucket_safety_net.md
 //	         §6.2 for the original single-OperationGroup design
 //	         and the dispatch-shape rejection that forced the
 //	         two-phase split.

--- a/adapter/s3_admin_test.go
+++ b/adapter/s3_admin_test.go
@@ -348,8 +348,8 @@ func TestS3Server_AdminListBuckets_PaginatesPastSinglePage(t *testing.T) {
 
 // TestS3Server_AdminDeleteBucket_SweepsOrphansAcrossAllPerBucketPrefixes
 // is the regression test for the AdminDeleteBucket TOCTOU race
-// (design doc 2026_04_28_proposed_admin_delete_bucket_safety_net.md;
-// coderabbitai 🔴/🟠 on PR #669). The race lands when a concurrent
+// (design doc 2026_04_28_implemented_admin_delete_bucket_safety_net.md;
+// high-severity review finding on PR #669). The race lands when a concurrent
 // PutObject inserts data between AdminDeleteBucket's empty-probe
 // scan (at readTS) and its commit (at a later commitTS). Without
 // the DEL_PREFIX safety net, the BucketMetaKey delete commits but

--- a/docs/admin_deployment.md
+++ b/docs/admin_deployment.md
@@ -331,7 +331,7 @@ is tombstoned at the same `commitTS` rather than left as an
 unreachable orphan. The behaviour is intentional — the
 alternative was orphan objects that no API can enumerate or
 remove. See
-[`docs/design/2026_04_28_proposed_admin_delete_bucket_safety_net.md`](design/2026_04_28_proposed_admin_delete_bucket_safety_net.md)
+[`docs/design/2026_04_28_implemented_admin_delete_bucket_safety_net.md`](design/2026_04_28_implemented_admin_delete_bucket_safety_net.md)
 for the full race analysis.
 
 Operationally:

--- a/docs/design/2026_04_24_implemented_admin_dashboard.md
+++ b/docs/design/2026_04_24_implemented_admin_dashboard.md
@@ -14,7 +14,7 @@
 | **P3** — React SPA + embed | ✅ shipped | #649, #650 |
 | **P4** — TLS, read-only role, CSRF, `docs/admin.md`, deployment runbook + `scripts/rolling-update.sh` admin support | ✅ shipped | TLS / role / CSRF live in P1; operator doc + runbook + script wiring in #674 / #669 / #678 |
 
-The AdminDeleteBucket TOCTOU is fully resolved: see [`2026_04_28_proposed_admin_delete_bucket_safety_net.md`](2026_04_28_proposed_admin_delete_bucket_safety_net.md) for the safety-net design and [`docs/admin_deployment.md`](../admin_deployment.md) §4.6 for the operator-side contract (a `PutObject` 200-OK landing during the race window can be swept by the concurrent admin delete; pause writes before delete to retain in-flight writes).
+The AdminDeleteBucket TOCTOU is fully resolved: see [`2026_04_28_implemented_admin_delete_bucket_safety_net.md`](2026_04_28_implemented_admin_delete_bucket_safety_net.md) for the safety-net design and [`docs/admin_deployment.md`](../admin_deployment.md) §4.6 for the operator-side contract (a `PutObject` 200-OK landing during the race window can be swept by the concurrent admin delete; pause writes before delete to retain in-flight writes).
 
 ### Out-of-scope follow-ups
 

--- a/docs/design/2026_04_28_implemented_admin_delete_bucket_safety_net.md
+++ b/docs/design/2026_04_28_implemented_admin_delete_bucket_safety_net.md
@@ -1,6 +1,6 @@
 # AdminDeleteBucket Orphan-Object Safety Net
 
-**Status:** Proposed
+**Status:** Implemented
 **Author:** bootjp
 **Date:** 2026-04-28
 
@@ -10,7 +10,7 @@
 TOCTOU race resolved by this design and recorded in the
 implementation-status block of
 [`docs/design/2026_04_24_implemented_admin_dashboard.md`](2026_04_24_implemented_admin_dashboard.md).
-coderabbitai 🔴/🟠 flagged it during PR #669 review.
+A high-severity review finding flagged it during PR #669 review.
 
 The current shape:
 
@@ -174,7 +174,7 @@ The original revision of this design proposed a **single
 OperationGroup** carrying both the `Del BucketMetaKey` and the
 six `DelPrefix` ops, relying on the FSM to apply them all at one
 commitTS. That shape is rejected by the production coordinator
-(Codex P1 on PR #695):
+(P1 review finding on PR #695):
 
 - `kv/sharded_coordinator.go:dispatchDelPrefixBroadcast` rejects
   any `OperationGroup` containing `DelPrefix` when `IsTxn` is
@@ -238,7 +238,7 @@ well-defined audit trail in slog.
 mirrors the production rejection rules in `localAdapterCoordinator.
 validateDispatchShape`. Without that, the original single-group
 shape passed local tests while production rejected every bucket
-delete with `ErrInvalidRequest` — exactly the gap Codex P1 caught.
+delete with `ErrInvalidRequest` — exactly the gap the P1 review finding caught.
 
 ### 6.3 Apply-time cost
 

--- a/internal/s3keys/keys.go
+++ b/internal/s3keys/keys.go
@@ -197,7 +197,7 @@ func ObjectManifestPrefixForBucket(bucket string, generation uint64) []byte {
 // BlobPrefixForBucket / GCUploadPrefixForBucket / RoutePrefixForBucket
 // each isolate to a single bucket+generation tuple. Used by
 // AdminDeleteBucket's DEL_PREFIX safety net (design doc
-// 2026_04_28_proposed_admin_delete_bucket_safety_net.md): the bucket-
+// 2026_04_28_implemented_admin_delete_bucket_safety_net.md): the bucket-
 // must-be-empty empty-probe is racy against concurrent PutObject, so
 // the delete commit also DEL_PREFIXes every per-bucket key family to
 // sweep anything that snuck in during the readTS → commitTS window.

--- a/internal/s3keys/keys_test.go
+++ b/internal/s3keys/keys_test.go
@@ -278,7 +278,7 @@ func TestBlobPrefixForUpload_IsPrefixOfBlobKeys(t *testing.T) {
 // TestPerBucketPrefixes_IsolateByBucketAndGeneration covers the
 // new *PrefixForBucket helpers used by AdminDeleteBucket's
 // DEL_PREFIX safety net (design doc
-// 2026_04_28_proposed_admin_delete_bucket_safety_net.md). For each
+// 2026_04_28_implemented_admin_delete_bucket_safety_net.md). For each
 // of the six per-bucket key families, the test pins three
 // invariants:
 //


### PR DESCRIPTION
## Summary
- promote the AdminDeleteBucket safety-net design doc to implemented
- refresh source and operator-doc references to the implemented design filename
- keep the implementation note aligned with the shipped two-phase delete safety net

## Design docs
- docs/design/2026_04_28_implemented_admin_delete_bucket_safety_net.md

## Validation
- git diff --check origin/main..HEAD
- rg -n "2026_04_28_proposed_admin_delete_bucket_safety_net" . (no matches)
- git verify-commit HEAD

Author: bootjp