### PR TITLE
Mark KeyViz adapter labels implemented

### DIFF
--- a/docs/design/2026_04_28_implemented_keyviz_adapter_labels.md
+++ b/docs/design/2026_04_28_implemented_keyviz_adapter_labels.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: implemented
 phase: 2-C+
 parent_design: docs/admin_ui_key_visualizer_design.md
 author: bootjp
@@ -579,7 +579,7 @@ from PR #694: Claude bot critical, Gemini high.)
 The fan-out aggregator's per-cell merge key gains the label:
 
 - Phase 2-C (current): `(bucketID, raftGroupID, leaderTerm,
-  windowStart)` per design `2026_04_27_proposed_keyviz_cluster_fanout.md`
+  windowStart)` per design `2026_04_27_implemented_keyviz_cluster_fanout.md`
   §4.
 - With labels: same tuple — but `bucketID` itself now carries the
   label via the §5 composite (`route:1:dynamo`). The merge key


### PR DESCRIPTION
Author: bootjp

## Summary
- mark the KeyViz adapter-label design as implemented
- update its cluster fan-out design reference

## Dependency
- Depends on #1025 for the cluster fan-out implemented design filename.

## Verification
- git diff --check
- commit signature verified with git verify-commit HEAD