### PR TITLE
Mark Redis one-phase dedup default implemented

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -204,7 +204,7 @@ type RedisServer struct {
 	// docs/design/2026_05_21_proposed_txn_secondary_idempotency.md). The
 	// FSM probe ships on every node in production, satisfying R5 (FSM
 	// determinism across a rolling upgrade), so the gate now defaults on
-	// per docs/design/2026_06_10_proposed_redis_onephase_dedup_default_on.md.
+	// per docs/design/2026_06_10_implemented_redis_onephase_dedup_default_on.md.
 	// Set ELASTICKV_REDIS_ONEPHASE_DEDUP=0 (or WithOnePhaseTxnDedup(false))
 	// to opt out — kept as a one-env-var operator rollback.
 	onePhaseTxnDedup bool
@@ -231,7 +231,7 @@ type RedisServerOption func(*RedisServer)
 // WithOnePhaseTxnDedup enables (or disables) the option-2 one-phase
 // idempotency dedup on list-push and MULTI/EXEC retries
 // (see RedisServer.onePhaseTxnDedup). On by default since the rollout
-// recorded in docs/design/2026_06_10_proposed_redis_onephase_dedup_default_on.md;
+// recorded in docs/design/2026_06_10_implemented_redis_onephase_dedup_default_on.md;
 // pass false to opt out from code, or set ELASTICKV_REDIS_ONEPHASE_DEDUP=0
 // to opt out from the environment. The constructor option trumps the env var.
 // Standalone SET requires the separate WithStandaloneSetDedup gate; see
@@ -493,7 +493,7 @@ func NewRedisServer(listen net.Listener, redisAddr string, store store.MVCCStore
 		// onePhaseTxnDedup defaults on — the parent design's R5 rolling-upgrade
 		// constraint is discharged (FSM probe shipped on every node months ago,
 		// 12 consecutive green dedup-mode Jepsen runs 2026-05-31 → 2026-06-10).
-		// See docs/design/2026_06_10_proposed_redis_onephase_dedup_default_on.md.
+		// See docs/design/2026_06_10_implemented_redis_onephase_dedup_default_on.md.
 		// ELASTICKV_REDIS_ONEPHASE_DEDUP=0 opts out; the WithOnePhaseTxnDedup
 		// constructor option still trumps the env var.
 		onePhaseTxnDedup: os.Getenv("ELASTICKV_REDIS_ONEPHASE_DEDUP") != "0",

--- a/docs/design/2026_06_10_implemented_redis_onephase_dedup_default_on.md
+++ b/docs/design/2026_06_10_implemented_redis_onephase_dedup_default_on.md
@@ -1,12 +1,11 @@
 # Redis one-phase txn dedup — flip default to on
 
-Status: Proposed
+Status: Implemented
 Author: bootjp
 Date: 2026-06-10
 
-> **Status: proposed.** Flip
-> `adapter.RedisServer.onePhaseTxnDedup` from default-off to default-on,
-> closing the rollout of the option-2 idempotency design landed by
+> **Status: implemented.** `adapter.RedisServer.onePhaseTxnDedup` is
+> default-on, closing the rollout of the option-2 idempotency design landed by
 > [`2026_05_21_proposed_txn_secondary_idempotency.md`][parent]. No new
 > mechanism — the FSM probe (`dedupProbeOnePhase` in `kv/fsm.go`), the
 > wire change (`TxnMeta.PrevCommitTS`, V2-only when non-zero), and every


### PR DESCRIPTION
Author: bootjp

## Summary
- mark the Redis one-phase dedup default-on design as implemented
- update adapter comments to the implemented design filename

## Verification
- git diff --check
- commit signature verified with git verify-commit HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Redis の one-phase transaction dedup に関する設計ドキュメントを更新し、ステータスを「Proposed」から「Implemented」に変更しました。
  * 関連する説明も最新の実装完了状態に合わせて整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->