### PR TITLE
Mark snapshot logical decoder implemented

### DIFF
--- a/docs/design/2026_04_29_implemented_snapshot_logical_decoder.md
+++ b/docs/design/2026_04_29_implemented_snapshot_logical_decoder.md
@@ -1,10 +1,10 @@
 # Snapshot ↔ Logical-Format Decoder (Phase 0)
 
-Status: Partial
+Status: Implemented
 Author: bootjp
 Date: 2026-04-29
 
-> **Lifecycle (2026-05-25):** Phase 0a (decoder) has fully shipped —
+> **Lifecycle (2026-07-07):** Phase 0a (decoder) has fully shipped —
 > `internal/backup/` + `cmd/elastickv-snapshot-decode` (PRs #790,
 > #791, #792, #806, #810). Phase 0b (encoder) has shipped and is
 > specified in detail in

--- a/docs/design/2026_05_25_implemented_snapshot_logical_encoder.md
+++ b/docs/design/2026_05_25_implemented_snapshot_logical_encoder.md
@@ -6,7 +6,7 @@ Date: 2026-05-25
 
 ## Background
 
-Phase 0a (`2026_04_29_partial_snapshot_logical_decoder.md`,
+Phase 0a (`2026_04_29_implemented_snapshot_logical_decoder.md`,
 milestones all merged: PRs #790, #791, #792, #806, #810) shipped the
 **decoder**: an offline tool that reads a native Pebble `.fsm`
 snapshot and writes a vendor-independent, per-adapter directory tree
@@ -459,9 +459,9 @@ P2:
 
 ## References
 
-- `2026_04_29_partial_snapshot_logical_decoder.md` — Phase 0 format
-  owner; Phase 0a (decoder) shipped. Promoted to `partial` on landing
-  this doc.
+- `2026_04_29_implemented_snapshot_logical_decoder.md` — Phase 0 format
+  owner; Phase 0a (decoder), Phase 0b (encoder), and Phase 0c
+  operator integration are shipped.
 - `2026_04_29_proposed_logical_backup.md` — Phase 1 (live PIT
   extraction); produces the same directory format this encoder reads.
 - `2026_04_14_implemented_etcd_snapshot_disk_offload.md` — the `.fsm`


### PR DESCRIPTION
Author: bootjp

## Summary
- mark the snapshot logical decoder design as implemented now that Phase 0a, Phase 0b, and Phase 0c are shipped
- update the encoder design references to the implemented decoder design filename

## Validation
- git diff --check HEAD~1..HEAD
- git verify-commit HEAD
- searched for stale 2026_04_29_partial_snapshot_logical_decoder references in the touched docs
