### PR TITLE
Mark idempotent snapshot restore implemented

### DIFF
--- a/docs/design/2026_06_02_implemented_idempotent_snapshot_restore.md
+++ b/docs/design/2026_06_02_implemented_idempotent_snapshot_restore.md
@@ -1,9 +1,24 @@
 # Idempotent FSM Snapshot Restore on Cold Start
 
-**Status**: Proposal (Round 7 — split CRC seam + force pebble.Sync on checkpoint)
+**Status**: Implemented (B2/B3 shipped; B4 health-timeout tightening remains an operational follow-up)
 **Date**: 2026-06-02 (round 1), 2026-06-03 (rounds 2 / 3 / 4 / 5 / 6 / 7)
 **Author**: bootjp
-**Related**: PR #909 (`HEALTH_TIMEOUT_SECONDS` 60s → 300s)
+**Related**: PR #909 (`HEALTH_TIMEOUT_SECONDS` 60s -> 300s), PR #915 (B2), PR #934 (B3)
+
+## Implementation Record
+
+The cold-start snapshot-restore skip path is implemented on `main`.
+
+- PR #915 shipped the durable `metaAppliedIndex` plumbing through raft
+  data applies, DEL_PREFIX applies, and both snapshot-persist sites.
+- PR #934 shipped the `restoreSnapshotState` skip gate, CRC-verified
+  header preservation, cold-start metrics, and duplicate replay
+  handling.
+
+B4, lowering the rolling-update health timeout again after production
+skip-rate observation, is intentionally left as an operational tuning
+follow-up. The design's central subsystem is the B2/B3 restore-skip
+mechanism.
 
 ## Problem
 

--- a/internal/raftengine/cold_start.go
+++ b/internal/raftengine/cold_start.go
@@ -8,7 +8,7 @@ package raftengine
 // behaviour for tests and callers that do not wire monitoring).
 //
 // Three outcomes match the design's strictly-additive policy
-// (docs/design/2026_06_02_idempotent_snapshot_restore.md §9):
+// (docs/design/2026_06_02_implemented_idempotent_snapshot_restore.md §9):
 //
 //   - RestoreSkipped: the gate fired. `gap = haveAppliedIndex -
 //     snapshot.Metadata.Index` (how far ahead the live store was).

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -191,7 +191,7 @@ type OpenConfig struct {
 	// ColdStartObserver receives the cold-start snapshot-restore
 	// skip-gate lifecycle events (skipped / executed / fallback).
 	// nil disables metrics; the skip itself still runs. See
-	// docs/design/2026_06_02_idempotent_snapshot_restore.md §9 and
+	// docs/design/2026_06_02_implemented_idempotent_snapshot_restore.md §9 and
 	// internal/raftengine/cold_start.go for the contract.
 	ColdStartObserver raftengine.ColdStartObserver
 }
@@ -2202,7 +2202,7 @@ func (e *Engine) applyReadySnapshotLocked(snapshot raftpb.Snapshot) error {
 		// store (engine.persistLocalSnapshotPayload), but the receiving
 		// node's restored store inherits the pre-bump value embedded in
 		// the snapshot artifact. Design Non-Goals §
-		// docs/design/2026_06_02_idempotent_snapshot_restore.md:71-74
+		// docs/design/2026_06_02_implemented_idempotent_snapshot_restore.md:71-74
 		// scopes this out of Branch 2; see PR #915 round-4/5 codex P2 on
 		// engine.go:4077 for the rationale.
 		if err := openAndRestoreFSMSnapshot(e.fsm, fsmSnapPath(e.fsmSnapDir, tok.Index), tok.CRC32C); err != nil {

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -2202,7 +2202,7 @@ func (e *Engine) applyReadySnapshotLocked(snapshot raftpb.Snapshot) error {
 		// store (engine.persistLocalSnapshotPayload), but the receiving
 		// node's restored store inherits the pre-bump value embedded in
 		// the snapshot artifact. Design Non-Goals §
-		// docs/design/2026_06_02_implemented_idempotent_snapshot_restore.md:71-74
+		// docs/design/2026_06_02_implemented_idempotent_snapshot_restore.md#non-goals
 		// scopes this out of Branch 2; see PR #915 round-4/5 codex P2 on
 		// engine.go:4077 for the rationale.
 		if err := openAndRestoreFSMSnapshot(e.fsm, fsmSnapPath(e.fsmSnapDir, tok.Index), tok.CRC32C); err != nil {

--- a/internal/raftengine/statemachine.go
+++ b/internal/raftengine/statemachine.go
@@ -49,7 +49,7 @@ type ApplyIndexAware interface {
 
 // AppliedIndexReader is an OPTIONAL extension that lets the engine
 // query the FSM's durable applied-index for the cold-start skip gate.
-// See docs/design/2026_06_02_idempotent_snapshot_restore.md §3.
+// See docs/design/2026_06_02_implemented_idempotent_snapshot_restore.md §3.
 //
 // The returned value MUST be the largest Raft entry index whose Apply
 // produced a durable mutation on the FSM's primary store (i.e. the
@@ -70,7 +70,7 @@ type AppliedIndexReader interface {
 
 // AppliedIndexWriter is an OPTIONAL extension that lets the engine
 // pin the FSM's durable applied-index to a known value at snapshot
-// persist time. See docs/design/2026_06_02_idempotent_snapshot_restore.md
+// persist time. See docs/design/2026_06_02_implemented_idempotent_snapshot_restore.md
 // §6 "HLC lease entries — checkpoint at snapshot persist".
 //
 // The engine calls SetDurableAppliedIndex(snap.Metadata.Index)
@@ -95,7 +95,7 @@ type AppliedIndexWriter interface {
 // cold-start skip gate preserve the header state (HLC ceiling,
 // Stage 8a cutover) the FSM's Restore would normally apply, without
 // running the (multi-GiB) body restore. See
-// docs/design/2026_06_02_idempotent_snapshot_restore.md §5.
+// docs/design/2026_06_02_implemented_idempotent_snapshot_restore.md §5.
 //
 // The interface is two-phase by design:
 //

--- a/kv/fsm.go
+++ b/kv/fsm.go
@@ -148,7 +148,7 @@ func (f *kvFSM) SetApplyIndex(idx uint64) {
 // (0, false, nil) propagates the strictly-additive fallback when
 // the store does not expose the seam — the future skip gate treats
 // "missing" as "fall back to full restore." See
-// docs/design/2026_06_02_idempotent_snapshot_restore.md §3 / §4.
+// docs/design/2026_06_02_implemented_idempotent_snapshot_restore.md §3 / §4.
 func (f *kvFSM) LastAppliedIndex() (uint64, bool, error) {
 	r, ok := f.store.(raftengine.AppliedIndexReader)
 	if !ok {

--- a/monitoring/cold_start.go
+++ b/monitoring/cold_start.go
@@ -10,7 +10,7 @@ import "github.com/prometheus/client_golang/prometheus"
 // soak threshold (design target: ≥ 90% in steady state) or when
 // fallback_reason rises unexpectedly.
 //
-// See docs/design/2026_06_02_idempotent_snapshot_restore.md §9.
+// See docs/design/2026_06_02_implemented_idempotent_snapshot_restore.md §9.
 type ColdStartMetrics struct {
 	// restoreTotal is the per-outcome counter for the three skip-
 	// gate outcomes. Labels:

--- a/scripts/rolling-update.sh
+++ b/scripts/rolling-update.sh
@@ -238,10 +238,10 @@ SQS_FIFO_PARTITION_MAP="${SQS_FIFO_PARTITION_MAP:-}"
 # fails fast on genuine crash-loop bugs (which never finish (1) or (2)).
 # Operators with smaller FSMs can shrink HEALTH_TIMEOUT_SECONDS via env.
 # Root-cause fix (skip restoreSnapshotState when the on-disk FSM is
-# already at >= snapshot.Metadata.Index): see PR #910 and
-# docs/design/2026_06_02_idempotent_snapshot_restore.md. Once that
-# lands and steady-state skip rates are observed in production, this
-# default can be tightened back down.
+# already at >= snapshot.Metadata.Index) shipped in PR #915 / #934;
+# see docs/design/2026_06_02_implemented_idempotent_snapshot_restore.md.
+# Once steady-state skip rates are observed in production, this default
+# can be tightened back down.
 HEALTH_TIMEOUT_SECONDS="${HEALTH_TIMEOUT_SECONDS:-300}"
 LEADERSHIP_TRANSFER_TIMEOUT_SECONDS="${LEADERSHIP_TRANSFER_TIMEOUT_SECONDS:-30}"
 # Maximum leader-commit-to-candidate-last-log lag tolerated for a targeted

--- a/store/lsm_store.go
+++ b/store/lsm_store.go
@@ -46,7 +46,7 @@ const (
 	// applyMutationsRaftAt / deletePrefixAtRaftAt) and pinned to
 	// snap.Metadata.Index by SetDurableAppliedIndex at every snapshot
 	// persist site. See
-	// docs/design/2026_06_02_idempotent_snapshot_restore.md §3.
+	// docs/design/2026_06_02_implemented_idempotent_snapshot_restore.md §3.
 	metaAppliedIndex = "_meta_applied_index"
 	spoolBufSize     = 32 * 1024 // buffer size for streaming I/O during restore
 
@@ -578,7 +578,7 @@ func (s *pebbleStore) saveLastCommitTS(ts uint64) error {
 // fsm.db that has not yet bumped through a raft-Apply, or a freshly
 // restored store. Callers MUST treat this as "missing" and fall back
 // to the full restore path; see
-// docs/design/2026_06_02_idempotent_snapshot_restore.md §4 fallback
+// docs/design/2026_06_02_implemented_idempotent_snapshot_restore.md §4 fallback
 // policy. Any other error propagates.
 //
 // dbMu.RLock matches the rest of the read path


### PR DESCRIPTION
Author: bootjp

## Summary
- rename the idempotent snapshot restore design doc to implemented
- record the shipped B2/B3 implementation PRs for durable applied-index plumbing and the cold-start skip gate
- update in-code doc references and the rolling-update health-timeout note to the implemented document path

## Validation
- git diff --check
- bash -n scripts/rolling-update.sh
- go test ./internal/raftengine/etcd ./store ./kv -run 'AppliedIndex|SkipGate|ColdStart|SnapshotHeader|RestoreSnapshot|SetDurableAppliedIndex|LastAppliedIndex' -count=1 -timeout=240s
