### PR TITLE
Increase Raft inbound queue capacity

### DIFF
--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -56,6 +56,9 @@ const (
 	// memory remains much lower than that worst-case bound.
 	defaultMaxInflightMsg = 1024
 	defaultMaxSizePerMsg  = 1 << 20
+	// minInboundQueueCapacity keeps very small test/operator inflight limits
+	// from shrinking the shared inbound queue enough to drop heartbeats.
+	minInboundQueueCapacity = 128
 	// defaultHeartbeatBufPerPeer is the capacity of the priority dispatch channel.
 	// It carries low-frequency control traffic: heartbeats, votes, read-index,
 	// leader-transfer, and their corresponding response messages
@@ -246,7 +249,7 @@ type OpenConfig struct {
 	// per peer before waiting for an acknowledgement (Raft-level flow control).
 	// It also sets the per-peer dispatch channel capacity, so total buffered
 	// memory is bounded by O(numPeers * MaxInflightMsg * avgMsgSize).
-	// Default: 256. Increase for deeper pipelining on high-bandwidth links;
+	// Default: 1024. Increase for deeper pipelining on high-bandwidth links;
 	// lower in memory-constrained clusters.
 	MaxInflightMsg int
 	// RaftCipher carries the AES-GCM Cipher used by the §4.2 raft
@@ -607,6 +610,7 @@ func Open(ctx context.Context, cfg OpenConfig) (*Engine, error) {
 	if prepared.cfg.Transport != nil {
 		dispatchCtx, dispatchCancel = context.WithCancel(context.Background())
 	}
+	inboundQueueCap := inboundQueueCapacity(len(prepared.peers), prepared.cfg.MaxInflightMsg)
 	opened := false
 	defer func() {
 		if opened || dispatchCancel == nil {
@@ -635,8 +639,8 @@ func Open(ctx context.Context, cfg OpenConfig) (*Engine, error) {
 		proposeCh:        make(chan proposalRequest),
 		readCh:           make(chan readRequest),
 		adminCh:          make(chan adminRequest),
-		stepCh:           make(chan raftpb.Message, defaultMaxInflightMsg),
-		dispatchReportCh: make(chan dispatchReport, defaultMaxInflightMsg),
+		stepCh:           make(chan raftpb.Message, inboundQueueCap),
+		dispatchReportCh: make(chan dispatchReport, inboundQueueCap),
 		closeCh:          make(chan struct{}),
 		doneCh:           make(chan struct{}),
 		startedCh:        make(chan struct{}),
@@ -3983,6 +3987,22 @@ func normalizeLimitConfig(cfg OpenConfig) OpenConfig {
 		cfg.MaxSizePerMsg = defaultMaxSizePerMsg
 	}
 	return cfg
+}
+
+func inboundQueueCapacity(peerCount, maxInflight int) int {
+	if maxInflight <= 0 {
+		maxInflight = defaultMaxInflightMsg
+	}
+	if peerCount < 1 {
+		peerCount = 1
+	}
+
+	scaled := defaultMaxInflightMsg
+	if maxInflight <= defaultMaxInflightMsg && peerCount <= defaultMaxInflightMsg/maxInflight {
+		scaled = peerCount * maxInflight
+	}
+	capacity := max(maxInflight, scaled)
+	return max(minInboundQueueCapacity, capacity)
 }
 
 func validateConfig(cfg OpenConfig) error {

--- a/internal/raftengine/etcd/engine_test.go
+++ b/internal/raftengine/etcd/engine_test.go
@@ -245,6 +245,68 @@ func TestProposeAdmin_EquivalentToProposeToday(t *testing.T) {
 // the failure mode this guard exists to produce.
 var _ raftengine.Proposer = (*Engine)(nil)
 
+func TestInboundQueueCapacityScalesSmallInflight(t *testing.T) {
+	tests := []struct {
+		name        string
+		peerCount   int
+		maxInflight int
+		want        int
+	}{
+		{
+			name:        "single peer small inflight uses floor",
+			peerCount:   1,
+			maxInflight: 17,
+			want:        minInboundQueueCapacity,
+		},
+		{
+			name:        "multi peer default is memory bounded",
+			peerCount:   5,
+			maxInflight: 256,
+			want:        defaultMaxInflightMsg,
+		},
+		{
+			name:        "production inflight stays at default cap",
+			peerCount:   5,
+			maxInflight: defaultMaxInflightMsg,
+			want:        defaultMaxInflightMsg,
+		},
+		{
+			name:        "explicit large inflight is preserved",
+			peerCount:   5,
+			maxInflight: 2048,
+			want:        2048,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, inboundQueueCapacity(tc.peerCount, tc.maxInflight))
+		})
+	}
+}
+
+func TestOpenConfigMaxInflightSizesInboundQueues(t *testing.T) {
+	fsm := &testStateMachine{}
+	const maxInflight = 17
+
+	engine, err := Open(context.Background(), OpenConfig{
+		NodeID:         1,
+		LocalID:        "n1",
+		LocalAddress:   "127.0.0.1:7011",
+		DataDir:        t.TempDir(),
+		Bootstrap:      true,
+		StateMachine:   fsm,
+		MaxInflightMsg: maxInflight,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, engine.Close())
+	})
+
+	require.Equal(t, minInboundQueueCapacity, cap(engine.stepCh))
+	require.Equal(t, minInboundQueueCapacity, cap(engine.dispatchReportCh))
+}
+
 func TestOpenSingleNodeProposeAndReadIndex(t *testing.T) {
 	fsm := &testStateMachine{}
 	engine, err := Open(context.Background(), OpenConfig{

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ const (
 	etcdHeartbeatMinTicks = 1
 	etcdElectionMinTicks  = 2
 	etcdMaxSizePerMsg     = 1 << 20
-	etcdMaxInflightMsg    = 256
+	etcdMaxInflightMsg    = 1024
 	defaultTSOBatchSize   = 256
 )
 


### PR DESCRIPTION
## Summary
- size the etcd raft inbound step and dispatch report queues from MaxInflightMsg
- raise the server production MaxInflightMsg setting to 1024
- add coverage that OpenConfig.MaxInflightMsg controls the inbound queue capacities

## Investigation
- current 5-node rollout showed leader n4 at 192.168.0.213 and SQS leader health returning 200 only on that node
- leader logs showed MsgHeartbeat to n3 failing with `etcd raft inbound step queue is full` around 09:04, 09:19, and 09:35 UTC
- follower logs showed repeated pre-vote windows while term 1831 stayed stable, matching heartbeat admission failures rather than SQS leader-health routing

## Tests
- go test ./internal/raftengine/etcd
- go test .
- go test ./internal/raftengine/... ./kv

## Notes
- go test ./adapter was interrupted after 207s while still running; no completed adapter failure was observed before the interrupt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - Raft エンジンのメッセージ処理容量を拡大し、高負荷時により多くの処理を受け付けられるようになりました。
  - 設定した inflight メッセージ上限が処理キューの容量に正しく反映されるようになり、構成に応じた安定した処理が可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->