### PR TITLE
Reduce Raft leader churn under maintenance load

### DIFF
--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -59,6 +59,16 @@ const (
 	// minInboundQueueCapacity keeps very small test/operator inflight limits
 	// from shrinking the shared inbound queue enough to drop heartbeats.
 	minInboundQueueCapacity = 128
+	// priorityStepQueueCapacity is the inbound control-plane queue size.
+	// Heartbeats, votes, read-index responses, and timeout-now messages are
+	// tiny but time-sensitive; keeping them off the bulk stepCh prevents a
+	// MsgApp burst from forcing followers into avoidable elections.
+	priorityStepQueueCapacity = 1024
+	// priorityStepBurstLimit bounds consecutive non-blocking priority drains
+	// so a sustained control-message stream cannot starve Tick, proposals, or
+	// admin work. The next event goes through the blocking select, where Tick
+	// competes fairly with priority and bulk steps.
+	priorityStepBurstLimit = 64
 	// defaultHeartbeatBufPerPeer is the capacity of the priority dispatch channel.
 	// It carries low-frequency control traffic: heartbeats, votes, read-index,
 	// leader-transfer, and their corresponding response messages
@@ -309,13 +319,15 @@ type Engine struct {
 
 	nextRequestID atomic.Uint64
 
-	proposeCh        chan proposalRequest
-	readCh           chan readRequest
-	adminCh          chan adminRequest
-	stepCh           chan raftpb.Message
-	dispatchReportCh chan dispatchReport
-	peerDispatchers  map[uint64]*peerQueues
-	perPeerQueueSize int
+	proposeCh         chan proposalRequest
+	readCh            chan readRequest
+	adminCh           chan adminRequest
+	stepCh            chan raftpb.Message
+	priorityStepCh    chan raftpb.Message
+	priorityStepBurst int
+	dispatchReportCh  chan dispatchReport
+	peerDispatchers   map[uint64]*peerQueues
+	perPeerQueueSize  int
 	// dispatcherLanesEnabled toggles the 4-lane dispatcher layout. Captured
 	// once at Open from ELASTICKV_RAFT_DISPATCHER_LANES so the run-time code
 	// path is branch-free per message and does not need to re-read env vars.
@@ -406,7 +418,7 @@ type Engine struct {
 	dispatchErrorByCode   map[string]uint64
 	// stepQueueFullCount tracks the number of inbound raft messages
 	// (from remote peers and local handlers) that were dropped because
-	// stepCh was full. Surfaced to Prometheus as
+	// the selected inbound step queue was full. Surfaced to Prometheus as
 	// elastickv_raft_step_queue_full_total so operators can correlate
 	// seek-storm goroutine spikes with raft backpressure.
 	stepQueueFullCount atomic.Uint64
@@ -640,6 +652,7 @@ func Open(ctx context.Context, cfg OpenConfig) (*Engine, error) {
 		readCh:           make(chan readRequest),
 		adminCh:          make(chan adminRequest),
 		stepCh:           make(chan raftpb.Message, inboundQueueCap),
+		priorityStepCh:   make(chan raftpb.Message, priorityStepQueueCapacity),
 		dispatchReportCh: make(chan dispatchReport, inboundQueueCap),
 		closeCh:          make(chan struct{}),
 		doneCh:           make(chan struct{}),
@@ -1179,10 +1192,11 @@ func (e *Engine) recordDispatchErrorCode(code string) uint64 {
 }
 
 // StepQueueFullCount returns the total number of inbound raft messages
-// that could not be enqueued into stepCh because the channel was at
-// capacity. This is the "etcd raft inbound step queue is full" signal
-// from the task description: a spike indicates the local raft loop
-// is starved, usually by something blocking the apply path such as
+// that could not be enqueued into the selected inbound step queue
+// because the channel was at capacity. This is the "etcd raft inbound
+// step queue is full" signal from the task description: a spike
+// indicates the local raft loop is starved, usually by something
+// blocking the apply path such as
 // the pre-#560 rawKeyTypeAt seek storm.
 func (e *Engine) StepQueueFullCount() uint64 {
 	if e == nil {
@@ -1712,6 +1726,27 @@ func (e *Engine) startup() error {
 }
 
 func (e *Engine) handleEvent(tick <-chan time.Time) (bool, error) {
+	if e.isClosing() {
+		return false, nil
+	}
+
+	if e.tryHandlePriorityStep() {
+		return true, nil
+	}
+
+	return e.handleBlockingEvent(tick)
+}
+
+func (e *Engine) isClosing() bool {
+	select {
+	case <-e.closeCh:
+		return true
+	default:
+		return false
+	}
+}
+
+func (e *Engine) handleBlockingEvent(tick <-chan time.Time) (bool, error) {
 	select {
 	case <-e.closeCh:
 		return false, nil
@@ -1723,16 +1758,47 @@ func (e *Engine) handleEvent(tick <-chan time.Time) (bool, error) {
 		e.handleRead(req)
 	case req := <-e.adminCh:
 		e.handleAdmin(req)
+	case msg := <-e.priorityStepCh:
+		e.handleStep(msg)
 	case msg := <-e.stepCh:
 		e.handleStep(msg)
 	case report := <-e.dispatchReportCh:
 		e.handleDispatchReport(report)
 	case result := <-e.snapshotResCh:
-		if err := e.handleSnapshotResult(result); err != nil {
-			return false, err
-		}
+		return e.handleSnapshotResultEvent(result)
 	}
 	return true, nil
+}
+
+func (e *Engine) handleSnapshotResultEvent(result snapshotResult) (bool, error) {
+	if err := e.handleSnapshotResult(result); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (e *Engine) tryHandlePriorityStep() bool {
+	if e.priorityStepBurst >= priorityStepBurstLimit {
+		e.priorityStepBurst = 0
+		return false
+	}
+	msg, ok := e.tryReceivePriorityStep()
+	if !ok {
+		e.priorityStepBurst = 0
+		return false
+	}
+	e.priorityStepBurst++
+	e.handleStep(msg)
+	return true
+}
+
+func (e *Engine) tryReceivePriorityStep() (raftpb.Message, bool) {
+	select {
+	case msg := <-e.priorityStepCh:
+		return msg, true
+	default:
+		return raftpb.Message{}, false
+	}
 }
 
 // dispatchReport is posted by the dispatch workers when a transport send
@@ -4139,12 +4205,17 @@ func maxAppliedIndex(snapshot raftpb.Snapshot) uint64 {
 }
 
 func (e *Engine) enqueueStep(ctx context.Context, msg raftpb.Message) error {
+	ch := e.stepCh
+	if isPriorityMsg(msg.GetType()) && e.priorityStepCh != nil {
+		ch = e.priorityStepCh
+	}
+
 	select {
 	case <-ctx.Done():
 		return errors.WithStack(ctx.Err())
 	case <-e.doneCh:
 		return e.currentErrorOrClosed()
-	case e.stepCh <- msg:
+	case ch <- msg:
 		return nil
 	default:
 		e.stepQueueFullCount.Add(1)

--- a/internal/raftengine/etcd/engine_test.go
+++ b/internal/raftengine/etcd/engine_test.go
@@ -589,6 +589,71 @@ func TestEnqueueStepReturnsQueueFull(t *testing.T) {
 	require.Equal(t, uint64(2), engine.StepQueueFullCount())
 }
 
+func TestEnqueueStepPriorityBypassesFullBulkQueue(t *testing.T) {
+	engine := &Engine{
+		doneCh:         make(chan struct{}),
+		stepCh:         make(chan raftpb.Message, 1),
+		priorityStepCh: make(chan raftpb.Message, 1),
+	}
+	engine.stepCh <- raftpb.Message{Type: messageTypePtr(raftpb.MsgApp)}
+
+	err := engine.enqueueStep(context.Background(), raftpb.Message{Type: messageTypePtr(raftpb.MsgHeartbeat)})
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), engine.StepQueueFullCount())
+
+	select {
+	case msg := <-engine.priorityStepCh:
+		require.Equal(t, raftpb.MsgHeartbeat, msg.GetType())
+	default:
+		t.Fatal("priority heartbeat was not enqueued")
+	}
+
+	err = engine.enqueueStep(context.Background(), raftpb.Message{Type: messageTypePtr(raftpb.MsgApp)})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, errStepQueueFull))
+	require.Equal(t, uint64(1), engine.StepQueueFullCount())
+}
+
+func TestHandleEventDrainsPriorityStepBeforeBulkStep(t *testing.T) {
+	engine := &Engine{
+		closeCh:          make(chan struct{}),
+		proposeCh:        make(chan proposalRequest),
+		readCh:           make(chan readRequest),
+		adminCh:          make(chan adminRequest),
+		stepCh:           make(chan raftpb.Message, 1),
+		priorityStepCh:   make(chan raftpb.Message, 1),
+		dispatchReportCh: make(chan dispatchReport),
+		snapshotResCh:    make(chan snapshotResult),
+	}
+	engine.stepCh <- raftpb.Message{Type: messageTypePtr(raftpb.MsgApp)}
+	engine.priorityStepCh <- raftpb.Message{Type: messageTypePtr(raftpb.MsgHeartbeat)}
+
+	handled, err := engine.handleEvent(make(chan time.Time))
+	require.NoError(t, err)
+	require.True(t, handled)
+
+	require.Empty(t, engine.priorityStepCh)
+	require.Len(t, engine.stepCh, 1)
+	msg := <-engine.stepCh
+	require.Equal(t, raftpb.MsgApp, msg.GetType())
+}
+
+func TestTryHandlePriorityStepYieldsAfterBurstLimit(t *testing.T) {
+	engine := &Engine{
+		priorityStepCh:    make(chan raftpb.Message, 1),
+		priorityStepBurst: priorityStepBurstLimit,
+	}
+	engine.priorityStepCh <- raftpb.Message{Type: messageTypePtr(raftpb.MsgHeartbeat)}
+
+	require.False(t, engine.tryHandlePriorityStep())
+	require.Zero(t, engine.priorityStepBurst)
+	require.Len(t, engine.priorityStepCh, 1)
+
+	require.True(t, engine.tryHandlePriorityStep())
+	require.Equal(t, 1, engine.priorityStepBurst)
+	require.Empty(t, engine.priorityStepCh)
+}
+
 func TestHandleStepIgnoresPeerNotFoundResponses(t *testing.T) {
 	engine := &Engine{
 		rawNode: mustRawNode(t, etcdraft.NewMemoryStorage(), 1),

--- a/kv/compactor.go
+++ b/kv/compactor.go
@@ -14,6 +14,7 @@ const (
 	defaultFSMCompactorInterval        = 5 * time.Minute
 	defaultFSMCompactorRetentionWindow = 30 * time.Minute
 	defaultFSMCompactorTimeout         = 5 * time.Second
+	defaultFSMCompactorLeaderTimeout   = 500 * time.Millisecond
 )
 
 type RaftStatusProvider interface {
@@ -34,6 +35,7 @@ type FSMCompactor struct {
 	interval        time.Duration
 	retentionWindow time.Duration
 	timeout         time.Duration
+	leaderTimeout   time.Duration
 	logger          *slog.Logger
 }
 
@@ -67,6 +69,14 @@ func WithFSMCompactorTimeout(timeout time.Duration) FSMCompactorOption {
 	}
 }
 
+func WithFSMCompactorLeaderTimeout(timeout time.Duration) FSMCompactorOption {
+	return func(c *FSMCompactor) {
+		if timeout > 0 {
+			c.leaderTimeout = timeout
+		}
+	}
+}
+
 func WithFSMCompactorLogger(logger *slog.Logger) FSMCompactorOption {
 	return func(c *FSMCompactor) {
 		if logger != nil {
@@ -81,6 +91,7 @@ func NewFSMCompactor(runtimes []FSMCompactRuntime, opts ...FSMCompactorOption) *
 		interval:        defaultFSMCompactorInterval,
 		retentionWindow: defaultFSMCompactorRetentionWindow,
 		timeout:         defaultFSMCompactorTimeout,
+		leaderTimeout:   defaultFSMCompactorLeaderTimeout,
 		logger:          slog.Default(),
 	}
 	for _, opt := range opts {
@@ -166,7 +177,7 @@ func (c *FSMCompactor) compactRuntime(ctx context.Context, runtime FSMCompactRun
 		return nil
 	}
 
-	compactCtx, cancel := c.compactContext(ctx)
+	compactCtx, cancel := c.compactContext(ctx, status)
 	defer cancel()
 
 	if err := runtime.Store.Compact(compactCtx, safeMinTS); err != nil {
@@ -197,15 +208,22 @@ func (c *FSMCompactor) targetMinTS(lastCommitTS, minRetainedTS uint64, now time.
 	return safeMinTS, true
 }
 
-func (c *FSMCompactor) compactContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	if c.timeout <= 0 {
+func (c *FSMCompactor) compactContext(ctx context.Context, status raftengine.Status) (context.Context, context.CancelFunc) {
+	timeout := c.timeout
+	if status.State == raftengine.StateLeader && c.leaderTimeout > 0 && (timeout <= 0 || c.leaderTimeout < timeout) {
+		timeout = c.leaderTimeout
+	}
+	if timeout <= 0 {
 		return ctx, func() {}
 	}
-	return context.WithTimeout(ctx, c.timeout)
+	return context.WithTimeout(ctx, timeout)
 }
 
 func shouldSkipFSMCompaction(status raftengine.Status) bool {
 	if status.State == raftengine.StateCandidate {
+		return true
+	}
+	if status.LeadTransferee != 0 || status.PendingConfChange {
 		return true
 	}
 	if status.FSMPending > 0 {

--- a/kv/compactor_test.go
+++ b/kv/compactor_test.go
@@ -19,6 +19,37 @@ func (f fakeRaftStatus) Status() raftengine.Status {
 	return f.status
 }
 
+type deadlineCapturingStore struct {
+	store.MVCCStore
+	store.RetentionController
+
+	lastCommitTS  uint64
+	minRetainedTS uint64
+	compactCalled bool
+	compactMinTS  uint64
+	hasDeadline   bool
+	deadline      time.Time
+}
+
+func (s *deadlineCapturingStore) LastCommitTS() uint64 {
+	return s.lastCommitTS
+}
+
+func (s *deadlineCapturingStore) MinRetainedTS() uint64 {
+	return s.minRetainedTS
+}
+
+func (s *deadlineCapturingStore) SetMinRetainedTS(ts uint64) {
+	s.minRetainedTS = ts
+}
+
+func (s *deadlineCapturingStore) Compact(ctx context.Context, minTS uint64) error {
+	s.compactCalled = true
+	s.compactMinTS = minTS
+	s.deadline, s.hasDeadline = ctx.Deadline()
+	return nil
+}
+
 func TestFSMCompactorCompactsEligibleRuntime(t *testing.T) {
 	st := store.NewMVCCStore()
 	ctx := context.Background()
@@ -111,6 +142,38 @@ func TestFSMCompactorSkipsLaggingRuntime(t *testing.T) {
 	val, err := st.GetAt(ctx, []byte("k"), 10)
 	require.NoError(t, err)
 	require.Equal(t, []byte("v10"), val)
+}
+
+func TestFSMCompactorCompactsLeaderRuntimeWithShortTimeout(t *testing.T) {
+	const leaderTimeout = 20 * time.Millisecond
+	st := &deadlineCapturingStore{lastCommitTS: 20}
+	ctx := context.Background()
+
+	compactor := NewFSMCompactor(
+		[]FSMCompactRuntime{{
+			GroupID: 1,
+			StatusReader: fakeRaftStatus{status: raftengine.Status{
+				State:        raftengine.StateLeader,
+				FSMPending:   0,
+				AppliedIndex: 10,
+				CommitIndex:  10,
+			}},
+			Store: st,
+		}},
+		WithFSMCompactorInterval(time.Hour),
+		WithFSMCompactorRetentionWindow(time.Millisecond),
+		WithFSMCompactorTimeout(time.Hour),
+		WithFSMCompactorLeaderTimeout(leaderTimeout),
+	)
+
+	start := time.Now()
+	require.NoError(t, compactor.SyncOnce(ctx))
+
+	require.True(t, st.compactCalled)
+	require.Equal(t, uint64(20), st.compactMinTS)
+	require.True(t, st.hasDeadline)
+	require.LessOrEqual(t, st.deadline.Sub(start), leaderTimeout+50*time.Millisecond)
+	require.Greater(t, st.deadline.Sub(start), time.Duration(0))
 }
 
 func TestFSMCompactorCompactsEligiblePebbleRuntime(t *testing.T) {

--- a/monitoring/grafana/dashboards/elastickv-redis-summary.json
+++ b/monitoring/grafana/dashboards/elastickv-redis-summary.json
@@ -1683,7 +1683,7 @@
           ],
           "title": "Raft Queue Saturation (stepCh full / outbound drops / errors)",
           "type": "timeseries",
-          "description": "Counter rates from the etcd raft engine. stepCh-full means inbound messages from remote peers were dropped because the local raft loop was too slow to consume them (the 'etcd raft inbound step queue is full' log line). dispatch-dropped means outbound messages were discarded before transport because the per-peer channel was full. dispatch-errors means transport delivery failed. The pre-#560 seek storm caused all three to spike together; watch for them to fall after the rollout and stay flat."
+          "description": "Counter rates from the etcd raft engine. step-queue-full means inbound messages from remote peers were dropped because the local raft loop was too slow to consume the selected step queue (the 'etcd raft inbound step queue is full' log line). dispatch-dropped means outbound messages were discarded before transport because the per-peer channel was full. dispatch-errors means transport delivery failed. The pre-#560 seek storm caused all three to spike together; watch for them to fall after the rollout and stay flat."
         },
         {
           "datasource": "$datasource",

--- a/monitoring/hotpath.go
+++ b/monitoring/hotpath.go
@@ -98,7 +98,7 @@ func newHotPathMetrics(registerer prometheus.Registerer) *HotPathMetrics {
 		stepQueueFullTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "elastickv_raft_step_queue_full_total",
-				Help: "Inbound raft messages that could not be enqueued because stepCh was full; indicates the raft loop is starved (classic pre-#560 seek-storm symptom).",
+				Help: "Inbound raft messages that could not be enqueued because the selected step queue was full; indicates the raft loop is starved (classic pre-#560 seek-storm symptom).",
 			},
 			[]string{"group"},
 		),

--- a/monitoring/hotpath_test.go
+++ b/monitoring/hotpath_test.go
@@ -147,7 +147,7 @@ elastickv_raft_dispatch_dropped_total{group="1",node_address="10.0.0.1:50051",no
 # HELP elastickv_raft_dispatch_errors_total Outbound raft dispatches that reached the transport but failed. Mirrors etcd raft Engine.dispatchErrorCount.
 # TYPE elastickv_raft_dispatch_errors_total counter
 elastickv_raft_dispatch_errors_total{group="1",node_address="10.0.0.1:50051",node_id="n1"} 2
-# HELP elastickv_raft_step_queue_full_total Inbound raft messages that could not be enqueued because stepCh was full; indicates the raft loop is starved (classic pre-#560 seek-storm symptom).
+# HELP elastickv_raft_step_queue_full_total Inbound raft messages that could not be enqueued because the selected step queue was full; indicates the raft loop is starved (classic pre-#560 seek-storm symptom).
 # TYPE elastickv_raft_step_queue_full_total counter
 elastickv_raft_step_queue_full_total{group="1",node_address="10.0.0.1:50051",node_id="n1"} 1
 `),


### PR DESCRIPTION
## Summary
- Add a dedicated inbound priority step queue for Raft control messages.
- Drain priority steps before bulk MsgApp traffic with a burst cap so heartbeat/vote/read-index messages are not rejected while Tick still gets scheduled.
- Skip FSM compaction while a node is the Raft leader so local maintenance scans do not stall leader heartbeats and HLC lease renewal.
- Update hot-path metric wording for the selected inbound step queue.

## Tests
- go test ./internal/raftengine/etcd ./kv ./monitoring
- go test ./internal/raftengine/... ./store
- golangci-lint --config=.golangci.yaml run --fix ./kv ./internal/raftengine/etcd ./monitoring

Author: bootjp