### PR TITLE
Bound FSM compaction under Raft membership

### DIFF
--- a/kv/compactor.go
+++ b/kv/compactor.go
@@ -15,6 +15,7 @@ const (
 	defaultFSMCompactorRetentionWindow = 30 * time.Minute
 	defaultFSMCompactorTimeout         = 5 * time.Second
 	defaultFSMCompactorLeaderTimeout   = 500 * time.Millisecond
+	defaultFSMCompactorRaftTimeout     = 500 * time.Millisecond
 )
 
 type RaftStatusProvider interface {
@@ -36,6 +37,7 @@ type FSMCompactor struct {
 	retentionWindow time.Duration
 	timeout         time.Duration
 	leaderTimeout   time.Duration
+	raftTimeout     time.Duration
 	logger          *slog.Logger
 }
 
@@ -77,6 +79,14 @@ func WithFSMCompactorLeaderTimeout(timeout time.Duration) FSMCompactorOption {
 	}
 }
 
+func WithFSMCompactorRaftTimeout(timeout time.Duration) FSMCompactorOption {
+	return func(c *FSMCompactor) {
+		if timeout > 0 {
+			c.raftTimeout = timeout
+		}
+	}
+}
+
 func WithFSMCompactorLogger(logger *slog.Logger) FSMCompactorOption {
 	return func(c *FSMCompactor) {
 		if logger != nil {
@@ -92,6 +102,7 @@ func NewFSMCompactor(runtimes []FSMCompactRuntime, opts ...FSMCompactorOption) *
 		retentionWindow: defaultFSMCompactorRetentionWindow,
 		timeout:         defaultFSMCompactorTimeout,
 		leaderTimeout:   defaultFSMCompactorLeaderTimeout,
+		raftTimeout:     defaultFSMCompactorRaftTimeout,
 		logger:          slog.Default(),
 	}
 	for _, opt := range opts {
@@ -210,6 +221,9 @@ func (c *FSMCompactor) targetMinTS(lastCommitTS, minRetainedTS uint64, now time.
 
 func (c *FSMCompactor) compactContext(ctx context.Context, status raftengine.Status) (context.Context, context.CancelFunc) {
 	timeout := c.timeout
+	if status.NumPeers > 0 && c.raftTimeout > 0 && (timeout <= 0 || c.raftTimeout < timeout) {
+		timeout = c.raftTimeout
+	}
 	if status.State == raftengine.StateLeader && c.leaderTimeout > 0 && (timeout <= 0 || c.leaderTimeout < timeout) {
 		timeout = c.leaderTimeout
 	}

--- a/kv/compactor.go
+++ b/kv/compactor.go
@@ -15,7 +15,6 @@ const (
 	defaultFSMCompactorRetentionWindow = 30 * time.Minute
 	defaultFSMCompactorTimeout         = 5 * time.Second
 	defaultFSMCompactorLeaderTimeout   = 500 * time.Millisecond
-	defaultFSMCompactorRaftTimeout     = 500 * time.Millisecond
 )
 
 type RaftStatusProvider interface {
@@ -37,7 +36,6 @@ type FSMCompactor struct {
 	retentionWindow time.Duration
 	timeout         time.Duration
 	leaderTimeout   time.Duration
-	raftTimeout     time.Duration
 	logger          *slog.Logger
 }
 
@@ -79,14 +77,6 @@ func WithFSMCompactorLeaderTimeout(timeout time.Duration) FSMCompactorOption {
 	}
 }
 
-func WithFSMCompactorRaftTimeout(timeout time.Duration) FSMCompactorOption {
-	return func(c *FSMCompactor) {
-		if timeout > 0 {
-			c.raftTimeout = timeout
-		}
-	}
-}
-
 func WithFSMCompactorLogger(logger *slog.Logger) FSMCompactorOption {
 	return func(c *FSMCompactor) {
 		if logger != nil {
@@ -102,7 +92,6 @@ func NewFSMCompactor(runtimes []FSMCompactRuntime, opts ...FSMCompactorOption) *
 		retentionWindow: defaultFSMCompactorRetentionWindow,
 		timeout:         defaultFSMCompactorTimeout,
 		leaderTimeout:   defaultFSMCompactorLeaderTimeout,
-		raftTimeout:     defaultFSMCompactorRaftTimeout,
 		logger:          slog.Default(),
 	}
 	for _, opt := range opts {
@@ -221,9 +210,6 @@ func (c *FSMCompactor) targetMinTS(lastCommitTS, minRetainedTS uint64, now time.
 
 func (c *FSMCompactor) compactContext(ctx context.Context, status raftengine.Status) (context.Context, context.CancelFunc) {
 	timeout := c.timeout
-	if status.NumPeers > 0 && c.raftTimeout > 0 && (timeout <= 0 || c.raftTimeout < timeout) {
-		timeout = c.raftTimeout
-	}
 	if status.State == raftengine.StateLeader && c.leaderTimeout > 0 && (timeout <= 0 || c.leaderTimeout < timeout) {
 		timeout = c.leaderTimeout
 	}

--- a/kv/compactor.go
+++ b/kv/compactor.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bootjp/elastickv/internal/raftengine"
 	"github.com/bootjp/elastickv/store"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/v2"
 )
 
 const (
@@ -15,6 +16,8 @@ const (
 	defaultFSMCompactorRetentionWindow = 30 * time.Minute
 	defaultFSMCompactorTimeout         = 5 * time.Second
 	defaultFSMCompactorLeaderTimeout   = 500 * time.Millisecond
+	defaultFSMCompactorMaxL0Files      = 256
+	defaultFSMCompactorMaxLSMDebtBytes = 512 << 20
 )
 
 type RaftStatusProvider interface {
@@ -36,7 +39,13 @@ type FSMCompactor struct {
 	retentionWindow time.Duration
 	timeout         time.Duration
 	leaderTimeout   time.Duration
+	maxL0Files      int64
+	maxLSMDebtBytes uint64
 	logger          *slog.Logger
+}
+
+type pebbleMetricsSource interface {
+	Metrics() *pebble.Metrics
 }
 
 func WithFSMCompactorActiveTimestampTracker(tracker *ActiveTimestampTracker) FSMCompactorOption {
@@ -77,6 +86,17 @@ func WithFSMCompactorLeaderTimeout(timeout time.Duration) FSMCompactorOption {
 	}
 }
 
+func WithFSMCompactorLSMBackpressureLimits(maxL0Files int64, maxDebtBytes uint64) FSMCompactorOption {
+	return func(c *FSMCompactor) {
+		if maxL0Files > 0 {
+			c.maxL0Files = maxL0Files
+		}
+		if maxDebtBytes > 0 {
+			c.maxLSMDebtBytes = maxDebtBytes
+		}
+	}
+}
+
 func WithFSMCompactorLogger(logger *slog.Logger) FSMCompactorOption {
 	return func(c *FSMCompactor) {
 		if logger != nil {
@@ -92,6 +112,8 @@ func NewFSMCompactor(runtimes []FSMCompactRuntime, opts ...FSMCompactorOption) *
 		retentionWindow: defaultFSMCompactorRetentionWindow,
 		timeout:         defaultFSMCompactorTimeout,
 		leaderTimeout:   defaultFSMCompactorLeaderTimeout,
+		maxL0Files:      defaultFSMCompactorMaxL0Files,
+		maxLSMDebtBytes: defaultFSMCompactorMaxLSMDebtBytes,
 		logger:          slog.Default(),
 	}
 	for _, opt := range opts {
@@ -170,6 +192,14 @@ func (c *FSMCompactor) compactRuntime(ctx context.Context, runtime FSMCompactRun
 	if shouldSkipFSMCompaction(status) {
 		return nil
 	}
+	if overloaded, snap := c.lsmBackpressure(runtime.Store); overloaded {
+		c.logger.WarnContext(ctx, "skipping fsm compaction under pebble backpressure",
+			"group_id", runtime.GroupID,
+			"l0_files", snap.Levels[0].TablesCount,
+			"compaction_debt_bytes", snap.Compact.EstimatedDebt,
+		)
+		return nil
+	}
 
 	lastCommitTS := runtime.Store.LastCommitTS()
 	safeMinTS, ok := c.targetMinTS(lastCommitTS, retention.MinRetainedTS(), time.Now())
@@ -217,6 +247,24 @@ func (c *FSMCompactor) compactContext(ctx context.Context, status raftengine.Sta
 		return ctx, func() {}
 	}
 	return context.WithTimeout(ctx, timeout)
+}
+
+func (c *FSMCompactor) lsmBackpressure(st store.MVCCStore) (bool, *pebble.Metrics) {
+	source, ok := st.(pebbleMetricsSource)
+	if !ok {
+		return false, nil
+	}
+	snap := source.Metrics()
+	if snap == nil {
+		return false, nil
+	}
+	if c.maxL0Files > 0 && snap.Levels[0].TablesCount >= c.maxL0Files {
+		return true, snap
+	}
+	if c.maxLSMDebtBytes > 0 && snap.Compact.EstimatedDebt >= c.maxLSMDebtBytes {
+		return true, snap
+	}
+	return false, snap
 }
 
 func shouldSkipFSMCompaction(status raftengine.Status) bool {

--- a/kv/compactor_test.go
+++ b/kv/compactor_test.go
@@ -50,6 +50,12 @@ func (s *deadlineCapturingStore) Compact(ctx context.Context, minTS uint64) erro
 	return nil
 }
 
+func requireDeadlineWithin(t *testing.T, deadline time.Time, start time.Time, timeout time.Duration) {
+	t.Helper()
+	require.False(t, deadline.Before(start))
+	require.LessOrEqual(t, deadline.Sub(start), timeout+50*time.Millisecond)
+}
+
 func TestFSMCompactorCompactsEligibleRuntime(t *testing.T) {
 	st := store.NewMVCCStore()
 	ctx := context.Background()
@@ -144,10 +150,11 @@ func TestFSMCompactorSkipsLaggingRuntime(t *testing.T) {
 	require.Equal(t, []byte("v10"), val)
 }
 
-func TestFSMCompactorCompactsLeaderRuntimeWithShortTimeout(t *testing.T) {
-	const leaderTimeout = 20 * time.Millisecond
+func TestFSMCompactorCompactsMultiPeerLeaderRuntimeWithShortTimeout(t *testing.T) {
 	st := &deadlineCapturingStore{lastCommitTS: 20}
 	ctx := context.Background()
+	leaderTimeout := 20 * time.Millisecond
+	start := time.Now()
 
 	compactor := NewFSMCompactor(
 		[]FSMCompactRuntime{{
@@ -157,6 +164,7 @@ func TestFSMCompactorCompactsLeaderRuntimeWithShortTimeout(t *testing.T) {
 				FSMPending:   0,
 				AppliedIndex: 10,
 				CommitIndex:  10,
+				NumPeers:     1,
 			}},
 			Store: st,
 		}},
@@ -166,14 +174,73 @@ func TestFSMCompactorCompactsLeaderRuntimeWithShortTimeout(t *testing.T) {
 		WithFSMCompactorLeaderTimeout(leaderTimeout),
 	)
 
-	start := time.Now()
 	require.NoError(t, compactor.SyncOnce(ctx))
 
 	require.True(t, st.compactCalled)
-	require.Equal(t, uint64(20), st.compactMinTS)
 	require.True(t, st.hasDeadline)
-	require.LessOrEqual(t, st.deadline.Sub(start), leaderTimeout+50*time.Millisecond)
-	require.Greater(t, st.deadline.Sub(start), time.Duration(0))
+	requireDeadlineWithin(t, st.deadline, start, leaderTimeout)
+}
+
+func TestFSMCompactorCompactsMultiPeerFollowerRuntimeWithShortTimeout(t *testing.T) {
+	st := &deadlineCapturingStore{lastCommitTS: 20}
+	ctx := context.Background()
+	raftTimeout := 20 * time.Millisecond
+	start := time.Now()
+
+	compactor := NewFSMCompactor(
+		[]FSMCompactRuntime{{
+			GroupID: 1,
+			StatusReader: fakeRaftStatus{status: raftengine.Status{
+				State:        raftengine.StateFollower,
+				FSMPending:   0,
+				AppliedIndex: 10,
+				CommitIndex:  10,
+				NumPeers:     1,
+			}},
+			Store: st,
+		}},
+		WithFSMCompactorInterval(time.Hour),
+		WithFSMCompactorRetentionWindow(time.Millisecond),
+		WithFSMCompactorTimeout(time.Hour),
+		WithFSMCompactorRaftTimeout(raftTimeout),
+	)
+
+	require.NoError(t, compactor.SyncOnce(ctx))
+
+	require.True(t, st.compactCalled)
+	require.True(t, st.hasDeadline)
+	requireDeadlineWithin(t, st.deadline, start, raftTimeout)
+}
+
+func TestFSMCompactorCompactsSingleNodeLeaderRuntimeWithShortTimeout(t *testing.T) {
+	st := &deadlineCapturingStore{lastCommitTS: 20}
+	ctx := context.Background()
+	leaderTimeout := 20 * time.Millisecond
+	start := time.Now()
+
+	compactor := NewFSMCompactor(
+		[]FSMCompactRuntime{{
+			GroupID: 1,
+			StatusReader: fakeRaftStatus{status: raftengine.Status{
+				State:        raftengine.StateLeader,
+				FSMPending:   0,
+				AppliedIndex: 10,
+				CommitIndex:  10,
+				NumPeers:     0,
+			}},
+			Store: st,
+		}},
+		WithFSMCompactorInterval(time.Hour),
+		WithFSMCompactorRetentionWindow(time.Millisecond),
+		WithFSMCompactorTimeout(time.Hour),
+		WithFSMCompactorLeaderTimeout(leaderTimeout),
+	)
+
+	require.NoError(t, compactor.SyncOnce(ctx))
+
+	require.True(t, st.compactCalled)
+	require.True(t, st.hasDeadline)
+	requireDeadlineWithin(t, st.deadline, start, leaderTimeout)
 }
 
 func TestFSMCompactorCompactsEligiblePebbleRuntime(t *testing.T) {

--- a/kv/compactor_test.go
+++ b/kv/compactor_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bootjp/elastickv/internal/raftengine"
 	"github.com/bootjp/elastickv/store"
+	"github.com/cockroachdb/pebble/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,6 +49,15 @@ func (s *deadlineCapturingStore) Compact(ctx context.Context, minTS uint64) erro
 	s.compactMinTS = minTS
 	s.deadline, s.hasDeadline = ctx.Deadline()
 	return nil
+}
+
+type metricsCapturingStore struct {
+	deadlineCapturingStore
+	metrics *pebble.Metrics
+}
+
+func (s *metricsCapturingStore) Metrics() *pebble.Metrics {
+	return s.metrics
 }
 
 func requireDeadlineWithin(t *testing.T, deadline time.Time, start time.Time, timeout time.Duration) {
@@ -210,6 +220,36 @@ func TestFSMCompactorCompactsMultiPeerFollowerRuntimeWithConfiguredTimeout(t *te
 	require.True(t, st.hasDeadline)
 	requireDeadlineWithin(t, st.deadline, start, configuredTimeout)
 	require.Greater(t, st.deadline.Sub(start), defaultFSMCompactorLeaderTimeout)
+}
+
+func TestFSMCompactorSkipsPebbleRuntimeUnderLSMBackpressure(t *testing.T) {
+	metrics := &pebble.Metrics{}
+	metrics.Levels[0].TablesCount = defaultFSMCompactorMaxL0Files
+	st := &metricsCapturingStore{
+		deadlineCapturingStore: deadlineCapturingStore{lastCommitTS: 20},
+		metrics:                metrics,
+	}
+	ctx := context.Background()
+
+	compactor := NewFSMCompactor(
+		[]FSMCompactRuntime{{
+			GroupID: 1,
+			StatusReader: fakeRaftStatus{status: raftengine.Status{
+				State:        raftengine.StateFollower,
+				FSMPending:   0,
+				AppliedIndex: 10,
+				CommitIndex:  10,
+				NumPeers:     1,
+			}},
+			Store: st,
+		}},
+		WithFSMCompactorInterval(time.Hour),
+		WithFSMCompactorRetentionWindow(time.Millisecond),
+		WithFSMCompactorTimeout(time.Second),
+	)
+
+	require.NoError(t, compactor.SyncOnce(ctx))
+	require.False(t, st.compactCalled)
 }
 
 func TestFSMCompactorCompactsSingleNodeLeaderRuntimeWithShortTimeout(t *testing.T) {

--- a/kv/compactor_test.go
+++ b/kv/compactor_test.go
@@ -181,10 +181,10 @@ func TestFSMCompactorCompactsMultiPeerLeaderRuntimeWithShortTimeout(t *testing.T
 	requireDeadlineWithin(t, st.deadline, start, leaderTimeout)
 }
 
-func TestFSMCompactorCompactsMultiPeerFollowerRuntimeWithShortTimeout(t *testing.T) {
+func TestFSMCompactorCompactsMultiPeerFollowerRuntimeWithConfiguredTimeout(t *testing.T) {
 	st := &deadlineCapturingStore{lastCommitTS: 20}
 	ctx := context.Background()
-	raftTimeout := 20 * time.Millisecond
+	configuredTimeout := 2 * time.Second
 	start := time.Now()
 
 	compactor := NewFSMCompactor(
@@ -201,15 +201,15 @@ func TestFSMCompactorCompactsMultiPeerFollowerRuntimeWithShortTimeout(t *testing
 		}},
 		WithFSMCompactorInterval(time.Hour),
 		WithFSMCompactorRetentionWindow(time.Millisecond),
-		WithFSMCompactorTimeout(time.Hour),
-		WithFSMCompactorRaftTimeout(raftTimeout),
+		WithFSMCompactorTimeout(configuredTimeout),
 	)
 
 	require.NoError(t, compactor.SyncOnce(ctx))
 
 	require.True(t, st.compactCalled)
 	require.True(t, st.hasDeadline)
-	requireDeadlineWithin(t, st.deadline, start, raftTimeout)
+	requireDeadlineWithin(t, st.deadline, start, configuredTimeout)
+	require.Greater(t, st.deadline.Sub(start), defaultFSMCompactorLeaderTimeout)
 }
 
 func TestFSMCompactorCompactsSingleNodeLeaderRuntimeWithShortTimeout(t *testing.T) {

--- a/kv/lease_warmup_test.go
+++ b/kv/lease_warmup_test.go
@@ -3,6 +3,7 @@ package kv
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -315,8 +316,9 @@ func TestShardedCoordinator_RenewHLCLeases_SlowGroupDoesNotBlockPeers(t *testing
 	eng2 := newShardedLeaseEngine(200)
 	entered := make(chan struct{})
 	release := make(chan struct{})
+	var enteredOnce sync.Once
 	eng1.proposeHook = func() {
-		close(entered)
+		enteredOnce.Do(func() { close(entered) })
 		<-release
 	}
 	coord := mustShardedLeaseCoord(t, eng1, eng2)
@@ -329,6 +331,42 @@ func TestShardedCoordinator_RenewHLCLeases_SlowGroupDoesNotBlockPeers(t *testing
 		"a slow led group must not delay renewal for another led group")
 	close(release)
 	requireRenewalDone(t, done)
+}
+
+func TestShardedCoordinator_RenewHLCLeases_SkipsInFlightGroup(t *testing.T) {
+	eng1 := newShardedLeaseEngine(100)
+	eng2 := newShardedLeaseEngine(200)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var enteredOnce sync.Once
+	eng1.proposeHook = func() {
+		enteredOnce.Do(func() { close(entered) })
+		<-release
+	}
+	coord := mustShardedLeaseCoord(t, eng1, eng2)
+
+	first := coord.renewHLCLeases(context.Background())
+	<-entered
+	require.Eventually(t, func() bool {
+		return coord.groups[2].lease.valid(monoclock.Now())
+	}, time.Second, 10*time.Millisecond,
+		"precondition: the first round must finish for the non-blocked group")
+
+	second := coord.renewHLCLeases(context.Background())
+	requireRenewalDone(t, second)
+
+	require.Equal(t, int32(1), eng1.proposeCalls.Load(),
+		"an in-flight group must not receive a second concurrent renewal proposal")
+	require.Equal(t, int32(2), eng2.proposeCalls.Load(),
+		"other led groups must still renew while one group is in flight")
+
+	close(release)
+	requireRenewalDone(t, first)
+
+	third := coord.renewHLCLeases(context.Background())
+	requireRenewalDone(t, third)
+	require.Equal(t, int32(2), eng1.proposeCalls.Load(),
+		"the group must be eligible for renewal after the in-flight proposal finishes")
 }
 
 func requireRenewalDone(t *testing.T, done <-chan struct{}) {

--- a/kv/lease_warmup_test.go
+++ b/kv/lease_warmup_test.go
@@ -348,9 +348,9 @@ func TestShardedCoordinator_RenewHLCLeases_SkipsInFlightGroup(t *testing.T) {
 	first := coord.renewHLCLeases(context.Background())
 	<-entered
 	require.Eventually(t, func() bool {
-		return coord.groups[2].lease.valid(monoclock.Now())
+		return eng2.proposeCalls.Load() == 1 && !hlcRenewalInFlight(coord, 2)
 	}, time.Second, 10*time.Millisecond,
-		"precondition: the first round must finish for the non-blocked group")
+		"precondition: the first round must fully finish for the non-blocked group")
 
 	second := coord.renewHLCLeases(context.Background())
 	requireRenewalDone(t, second)
@@ -367,6 +367,13 @@ func TestShardedCoordinator_RenewHLCLeases_SkipsInFlightGroup(t *testing.T) {
 	requireRenewalDone(t, third)
 	require.Equal(t, int32(2), eng1.proposeCalls.Load(),
 		"the group must be eligible for renewal after the in-flight proposal finishes")
+}
+
+func hlcRenewalInFlight(coord *ShardedCoordinator, gid uint64) bool {
+	coord.hlcRenewalMu.Lock()
+	defer coord.hlcRenewalMu.Unlock()
+	_, ok := coord.hlcRenewalInFlight[gid]
+	return ok
 }
 
 func requireRenewalDone(t *testing.T, done <-chan struct{}) {

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -396,6 +396,10 @@ type ShardedCoordinator struct {
 	// hlcRenewalBlocked lets startup code temporarily suppress background HLC
 	// lease proposals while another startup-only Raft mutation must run first.
 	hlcRenewalBlocked func() bool
+	// hlcRenewalInFlight prevents a slow or quorum-stalled group from stacking
+	// another background HLC lease proposal for the same group on the next tick.
+	hlcRenewalMu       sync.Mutex
+	hlcRenewalInFlight map[uint64]struct{}
 	// registrationGate is the Stage 7a §4.1 first-write barrier: when
 	// set, self-originated mutating writes that would land as §4.1
 	// storage envelopes block until this node's writer registration
@@ -2158,9 +2162,13 @@ func (c *ShardedCoordinator) renewHLCLeases(ctx context.Context) <-chan struct{}
 		if group.Engine.State() != raftengine.StateLeader {
 			continue
 		}
+		if !c.startHLCLeaseRenewal(gid) {
+			continue
+		}
 		wg.Add(1)
 		go func(gid uint64, group *ShardGroup) {
 			defer wg.Done()
+			defer c.finishHLCLeaseRenewal(gid)
 			pctx, cancel := context.WithTimeout(ctx, hlcRenewalInterval)
 			defer cancel()
 			c.renewHLCLease(pctx, gid, group)
@@ -2171,6 +2179,25 @@ func (c *ShardedCoordinator) renewHLCLeases(ctx context.Context) <-chan struct{}
 		close(done)
 	}()
 	return done
+}
+
+func (c *ShardedCoordinator) startHLCLeaseRenewal(gid uint64) bool {
+	c.hlcRenewalMu.Lock()
+	defer c.hlcRenewalMu.Unlock()
+	if c.hlcRenewalInFlight == nil {
+		c.hlcRenewalInFlight = make(map[uint64]struct{})
+	}
+	if _, ok := c.hlcRenewalInFlight[gid]; ok {
+		return false
+	}
+	c.hlcRenewalInFlight[gid] = struct{}{}
+	return true
+}
+
+func (c *ShardedCoordinator) finishHLCLeaseRenewal(gid uint64) {
+	c.hlcRenewalMu.Lock()
+	defer c.hlcRenewalMu.Unlock()
+	delete(c.hlcRenewalInFlight, gid)
 }
 
 // renewHLCLease proposes a fresh physical ceiling on one shard

--- a/store/lsm_store.go
+++ b/store/lsm_store.go
@@ -1854,6 +1854,22 @@ func (s *pebbleStore) runCompactionGC(ctx context.Context, minTS uint64) (pebble
 	return stats, nil
 }
 
+func (s *pebbleStore) runCompactionPhase(ctx context.Context, targetMinTS uint64, resumingPending bool) (pebbleCompactionStats, error) {
+	retainPending := resumingPending
+	stats, err := s.runCompactionGC(ctx, targetMinTS)
+	retainPending = retainPending || stats.committedDeletes
+	if err != nil {
+		s.cleanupPendingCompaction(&retainPending)
+		return stats, err
+	}
+
+	if err := s.commitCompactionMinRetainedTS(targetMinTS); err != nil {
+		s.cleanupPendingCompaction(&retainPending)
+		return stats, err
+	}
+	return stats, nil
+}
+
 func (s *pebbleStore) Compact(ctx context.Context, minTS uint64) error {
 	ctx = ensureContext(ctx)
 
@@ -1873,48 +1889,43 @@ func (s *pebbleStore) Compact(ctx context.Context, minTS uint64) error {
 	s.dbMu.RLock()
 	defer s.dbMu.RUnlock()
 
-	pending, committed := s.compactionWatermarks()
-	resumingPending := pending > committed
-	targetMinTS := minTS
-	if resumingPending {
-		// A pending watermark means an earlier compaction may have already
-		// committed delete batches. Keep reads fail-closed, but do not finalize
-		// the watermark until an idempotent GC pass reaches EOF.
-		targetMinTS = pending
-	} else if minTS <= committed {
-		return nil
-	}
+	for {
+		pending, committed := s.compactionWatermarks()
+		resumingPending := pending > committed
+		targetMinTS := minTS
+		if resumingPending {
+			// A pending watermark means an earlier compaction may have already
+			// committed delete batches. Keep reads fail-closed, but do not finalize
+			// the watermark until an idempotent GC pass reaches EOF.
+			targetMinTS = pending
+		} else if minTS <= committed {
+			return nil
+		}
 
-	if !resumingPending {
-		shouldRun, err := s.beginCompaction(targetMinTS)
+		if !resumingPending {
+			shouldRun, err := s.beginCompaction(targetMinTS)
+			if err != nil {
+				return err
+			}
+			if !shouldRun {
+				return nil
+			}
+		}
+
+		stats, err := s.runCompactionPhase(ctx, targetMinTS, resumingPending)
 		if err != nil {
 			return err
 		}
-		if !shouldRun {
+
+		s.log.InfoContext(ctx, "compact",
+			slog.Uint64("min_ts", targetMinTS),
+			slog.Int("updated_keys", stats.updatedKeys),
+			slog.Int("deleted_versions", stats.deletedVersions),
+		)
+		if targetMinTS >= minTS {
 			return nil
 		}
 	}
-
-	retainPending := resumingPending
-	defer s.cleanupPendingCompaction(&retainPending)
-
-	stats, err := s.runCompactionGC(ctx, targetMinTS)
-	retainPending = retainPending || stats.committedDeletes
-	if err != nil {
-		return err
-	}
-
-	if err := s.commitCompactionMinRetainedTS(targetMinTS); err != nil {
-		return err
-	}
-	retainPending = false
-
-	s.log.InfoContext(ctx, "compact",
-		slog.Uint64("min_ts", targetMinTS),
-		slog.Int("updated_keys", stats.updatedKeys),
-		slog.Int("deleted_versions", stats.deletedVersions),
-	)
-	return nil
 }
 
 func (s *pebbleStore) Snapshot() (Snapshot, error) {

--- a/store/lsm_store.go
+++ b/store/lsm_store.go
@@ -1707,8 +1707,8 @@ func (s *pebbleStore) beginCompaction(minTS uint64) (bool, error) {
 	return true, nil
 }
 
-func (s *pebbleStore) cleanupPendingCompaction(committedDeletes *bool) {
-	if committedDeletes != nil && *committedDeletes {
+func (s *pebbleStore) cleanupPendingCompaction(retainPending *bool) {
+	if retainPending != nil && *retainPending {
 		return
 	}
 
@@ -1723,6 +1723,12 @@ func (s *pebbleStore) commitCompactionMinRetainedTS(minTS uint64) error {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 	return s.commitMinRetainedTSLocked(minTS, pebble.Sync)
+}
+
+func (s *pebbleStore) compactionWatermarks() (pending, committed uint64) {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	return s.pendingMinRetainedTS, s.minRetainedTS
 }
 
 func shouldDeleteCompactionVersion(rawKey []byte, minTS uint64, currentUserKey *[]byte, keptVisibleAtMinTS *bool, changedCurrentKey *bool) bool {
@@ -1867,44 +1873,44 @@ func (s *pebbleStore) Compact(ctx context.Context, minTS uint64) error {
 	s.dbMu.RLock()
 	defer s.dbMu.RUnlock()
 
-	if minTS <= s.effectiveMinRetainedTS() {
-		// Fast path: the requested watermark is already covered. However, a
-		// pending watermark may have survived a previous crash (GC ran and
-		// deleted versions but minRetainedTS was never committed). Finalize it
-		// now so reads < pending are unblocked and the pending key is not leaked.
-		s.mtx.RLock()
-		pending, committed := s.pendingMinRetainedTS, s.minRetainedTS
-		s.mtx.RUnlock()
-		if pending <= committed {
-			return nil
-		}
-		return s.commitCompactionMinRetainedTS(pending)
-	}
-
-	shouldRun, err := s.beginCompaction(minTS)
-	if err != nil {
-		return err
-	}
-	if !shouldRun {
+	pending, committed := s.compactionWatermarks()
+	resumingPending := pending > committed
+	targetMinTS := minTS
+	if resumingPending {
+		// A pending watermark means an earlier compaction may have already
+		// committed delete batches. Keep reads fail-closed, but do not finalize
+		// the watermark until an idempotent GC pass reaches EOF.
+		targetMinTS = pending
+	} else if minTS <= committed {
 		return nil
 	}
 
-	committedDeletes := false
-	defer s.cleanupPendingCompaction(&committedDeletes)
+	if !resumingPending {
+		shouldRun, err := s.beginCompaction(targetMinTS)
+		if err != nil {
+			return err
+		}
+		if !shouldRun {
+			return nil
+		}
+	}
 
-	stats, err := s.runCompactionGC(ctx, minTS)
-	committedDeletes = stats.committedDeletes
+	retainPending := resumingPending
+	defer s.cleanupPendingCompaction(&retainPending)
+
+	stats, err := s.runCompactionGC(ctx, targetMinTS)
+	retainPending = retainPending || stats.committedDeletes
 	if err != nil {
 		return err
 	}
 
-	if err := s.commitCompactionMinRetainedTS(minTS); err != nil {
+	if err := s.commitCompactionMinRetainedTS(targetMinTS); err != nil {
 		return err
 	}
-	committedDeletes = false
+	retainPending = false
 
 	s.log.InfoContext(ctx, "compact",
-		slog.Uint64("min_ts", minTS),
+		slog.Uint64("min_ts", targetMinTS),
 		slog.Int("updated_keys", stats.updatedKeys),
 		slog.Int("deleted_versions", stats.deletedVersions),
 	)

--- a/store/lsm_store.go
+++ b/store/lsm_store.go
@@ -29,18 +29,20 @@ const (
 	//   bit 0      tombstone
 	//   bits 1-2   encryption_state (0b00 cleartext, 0b01 encrypted, 0b10/0b11 reserved)
 	//   bits 3-7   reserved (must be zero)
-	encStateMask             byte = 0b0000_0110
-	encStateShift                 = 1
-	tombstoneMask            byte = 0b0000_0001
-	encStateCleartext        byte = 0b00
-	encStateEncrypted        byte = 0b01
-	encStateReservedMask     byte = 0b1111_1000 // bits 3-7 must stay zero
-	snapshotBatchCountLimit       = 1000
-	snapshotBatchByteLimit        = 8 << 20 // 8 MiB; balances restore write amplification vs peak memory usage
-	dirPerms                      = 0755
-	metaLastCommitTS              = "_meta_last_commit_ts"
-	metaMinRetainedTS             = "_meta_min_retained_ts"
-	metaPendingMinRetainedTS      = "_meta_pending_min_retained_ts"
+	encStateMask                    byte = 0b0000_0110
+	encStateShift                        = 1
+	tombstoneMask                   byte = 0b0000_0001
+	encStateCleartext               byte = 0b00
+	encStateEncrypted               byte = 0b01
+	encStateReservedMask            byte = 0b1111_1000 // bits 3-7 must stay zero
+	snapshotBatchCountLimit              = 1000
+	snapshotBatchByteLimit               = 8 << 20 // 8 MiB; balances restore write amplification vs peak memory usage
+	compactionDeleteBatchCountLimit      = 128
+	compactionDeleteBatchByteLimit       = 1 << 20
+	dirPerms                             = 0755
+	metaLastCommitTS                     = "_meta_last_commit_ts"
+	metaMinRetainedTS                    = "_meta_min_retained_ts"
+	metaPendingMinRetainedTS             = "_meta_pending_min_retained_ts"
 	// metaAppliedIndex is the durable raft-applied index meta key.
 	// Bundled atomically with each raft-Apply pebble.Batch (see
 	// applyMutationsRaftAt / deletePrefixAtRaftAt) and pinned to
@@ -1791,7 +1793,7 @@ func (s *pebbleStore) scanCompactionDeletes(ctx context.Context, minTS uint64, i
 		if err := addCompactionDelete(*batch, rawKey, stats, &changedCurrentKey); err != nil {
 			return err
 		}
-		if snapshotBatchShouldFlush(*batch) {
+		if compactionDeleteBatchShouldFlush(*batch) {
 			if err := s.flushCompactionBatch(batch, stats, pebble.NoSync); err != nil {
 				return err
 			}
@@ -1838,10 +1840,10 @@ func (s *pebbleStore) runCompactionGC(ctx context.Context, minTS uint64) (pebble
 
 	stats := pebbleCompactionStats{}
 	if err := s.scanCompactionDeletes(ctx, minTS, iter, &batch, &stats); err != nil {
-		return pebbleCompactionStats{}, errors.WithStack(err)
+		return stats, errors.WithStack(err)
 	}
 	if err := commitCompactionDeletes(&batch, &stats); err != nil {
-		return pebbleCompactionStats{}, err
+		return stats, err
 	}
 	return stats, nil
 }
@@ -1891,10 +1893,10 @@ func (s *pebbleStore) Compact(ctx context.Context, minTS uint64) error {
 	defer s.cleanupPendingCompaction(&committedDeletes)
 
 	stats, err := s.runCompactionGC(ctx, minTS)
+	committedDeletes = stats.committedDeletes
 	if err != nil {
 		return err
 	}
-	committedDeletes = stats.committedDeletes
 
 	if err := s.commitCompactionMinRetainedTS(minTS); err != nil {
 		return err
@@ -1977,6 +1979,10 @@ func restoreFieldLenInt(raw uint64, field string, maxSize int) (int, error) {
 
 func snapshotBatchShouldFlush(batch *pebble.Batch) bool {
 	return batch.Count() >= snapshotBatchCountLimit || batch.Len() >= snapshotBatchByteLimit
+}
+
+func compactionDeleteBatchShouldFlush(batch *pebble.Batch) bool {
+	return batch.Count() >= compactionDeleteBatchCountLimit || batch.Len() >= compactionDeleteBatchByteLimit
 }
 
 func commitSnapshotBatch(batch *pebble.Batch, opts *pebble.WriteOptions) error {

--- a/store/lsm_store_test.go
+++ b/store/lsm_store_test.go
@@ -389,6 +389,7 @@ func TestPebbleStore_CompactCanceledAfterDeleteFlushKeepsPendingMinRetainedTS(t 
 	for ts := uint64(1); ts <= compactionDeleteBatchCountLimit*2+1; ts++ {
 		require.NoError(t, st.PutAt(ctx, key, value, ts, 0))
 	}
+	require.Equal(t, compactionDeleteBatchCountLimit*2+1, countPebbleVersions(t, st))
 
 	cancelAfterFirstDeleteFlush := &cancelAfterErrCallsContext{
 		Context:        ctx,
@@ -396,6 +397,7 @@ func TestPebbleStore_CompactCanceledAfterDeleteFlushKeepsPendingMinRetainedTS(t 
 	}
 	require.ErrorIs(t, st.Compact(cancelAfterFirstDeleteFlush, compactionDeleteBatchCountLimit*3), context.Canceled)
 	require.Equal(t, uint64(0), requirePebbleRetentionController(t, st).MinRetainedTS())
+	require.Equal(t, compactionDeleteBatchCountLimit+1, countPebbleVersions(t, st))
 
 	_, err = st.GetAt(ctx, key, compactionDeleteBatchCountLimit+50)
 	require.ErrorIs(t, err, ErrReadTSCompacted)
@@ -412,6 +414,7 @@ func TestPebbleStore_CompactCanceledAfterDeleteFlushKeepsPendingMinRetainedTS(t 
 
 	require.NoError(t, reopened.Compact(ctx, compactionDeleteBatchCountLimit*3))
 	require.Equal(t, uint64(compactionDeleteBatchCountLimit*3), requirePebbleRetentionController(t, reopened).MinRetainedTS())
+	require.Equal(t, 1, countPebbleVersions(t, reopened))
 }
 
 func TestPebbleStore_CompactWaitsForMaintenanceLock(t *testing.T) {

--- a/store/lsm_store_test.go
+++ b/store/lsm_store_test.go
@@ -417,6 +417,54 @@ func TestPebbleStore_CompactCanceledAfterDeleteFlushKeepsPendingMinRetainedTS(t 
 	require.Equal(t, 1, countPebbleVersions(t, reopened))
 }
 
+func TestPebbleStore_CompactResumedPendingAdvancesToRequestedMinTS(t *testing.T) {
+	dir, err := os.MkdirTemp("", "pebble-compact-resume-higher-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	ctx := context.Background()
+
+	st, err := NewPebbleStore(dir)
+	require.NoError(t, err)
+
+	key := []byte{0x01}
+	value := []byte("value")
+	pendingMinTS := uint64(compactionDeleteBatchCountLimit * 2)
+	requestedMinTS := uint64(compactionDeleteBatchCountLimit * 3)
+	for ts := uint64(1); ts <= pendingMinTS+1; ts++ {
+		require.NoError(t, st.PutAt(ctx, key, value, ts, 0))
+	}
+
+	cancelAfterFirstDeleteFlush := &cancelAfterErrCallsContext{
+		Context:        ctx,
+		maxNilErrCalls: compactionDeleteBatchCountLimit + 10,
+	}
+	require.ErrorIs(t, st.Compact(cancelAfterFirstDeleteFlush, pendingMinTS), context.Canceled)
+	require.Equal(t, uint64(0), requirePebbleRetentionController(t, st).MinRetainedTS())
+	for ts := pendingMinTS + 2; ts <= requestedMinTS+10; ts++ {
+		require.NoError(t, st.PutAt(ctx, key, value, ts, 0))
+	}
+
+	require.NoError(t, st.Close())
+
+	reopened, err := NewPebbleStore(dir)
+	require.NoError(t, err)
+	defer reopened.Close()
+
+	_, err = reopened.GetAt(ctx, key, pendingMinTS-1)
+	require.ErrorIs(t, err, ErrReadTSCompacted)
+
+	require.NoError(t, reopened.Compact(ctx, requestedMinTS))
+	require.Equal(t, requestedMinTS, requirePebbleRetentionController(t, reopened).MinRetainedTS())
+
+	_, err = reopened.GetAt(ctx, key, requestedMinTS-1)
+	require.ErrorIs(t, err, ErrReadTSCompacted)
+
+	val, err := reopened.GetAt(ctx, key, requestedMinTS+1)
+	require.NoError(t, err)
+	require.Equal(t, value, val)
+}
+
 func TestPebbleStore_CompactWaitsForMaintenanceLock(t *testing.T) {
 	dir, err := os.MkdirTemp("", "pebble-compact-lock-*")
 	require.NoError(t, err)

--- a/store/lsm_store_test.go
+++ b/store/lsm_store_test.go
@@ -57,6 +57,23 @@ func requireChannelBlocked[T any](t *testing.T, ch <-chan T, started <-chan stru
 	}
 }
 
+type cancelAfterErrCallsContext struct {
+	context.Context
+	maxNilErrCalls int
+	errCalls       int
+}
+
+func (c *cancelAfterErrCallsContext) Err() error {
+	if err := c.Context.Err(); err != nil {
+		return err
+	}
+	c.errCalls++
+	if c.errCalls > c.maxNilErrCalls {
+		return context.Canceled
+	}
+	return nil
+}
+
 func TestPebbleStore_Basic(t *testing.T) {
 	dir, err := os.MkdirTemp("", "pebble-test")
 	require.NoError(t, err)
@@ -355,6 +372,46 @@ func TestPebbleStore_CompactCanceledDoesNotAdvanceMinRetainedTS(t *testing.T) {
 	val, err = reopened.GetAt(ctx, key, 15)
 	require.NoError(t, err)
 	require.Equal(t, []byte("v10"), val)
+}
+
+func TestPebbleStore_CompactCanceledAfterDeleteFlushKeepsPendingMinRetainedTS(t *testing.T) {
+	dir, err := os.MkdirTemp("", "pebble-compact-partial-cancel-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	ctx := context.Background()
+
+	st, err := NewPebbleStore(dir)
+	require.NoError(t, err)
+
+	key := []byte{0x01}
+	value := []byte("value")
+	for ts := uint64(1); ts <= compactionDeleteBatchCountLimit*2+1; ts++ {
+		require.NoError(t, st.PutAt(ctx, key, value, ts, 0))
+	}
+
+	cancelAfterFirstDeleteFlush := &cancelAfterErrCallsContext{
+		Context:        ctx,
+		maxNilErrCalls: compactionDeleteBatchCountLimit + 1,
+	}
+	require.ErrorIs(t, st.Compact(cancelAfterFirstDeleteFlush, compactionDeleteBatchCountLimit*3), context.Canceled)
+	require.Equal(t, uint64(0), requirePebbleRetentionController(t, st).MinRetainedTS())
+
+	_, err = st.GetAt(ctx, key, compactionDeleteBatchCountLimit+50)
+	require.ErrorIs(t, err, ErrReadTSCompacted)
+
+	require.NoError(t, st.Close())
+
+	reopened, err := NewPebbleStore(dir)
+	require.NoError(t, err)
+	defer reopened.Close()
+
+	require.Equal(t, uint64(0), requirePebbleRetentionController(t, reopened).MinRetainedTS())
+	_, err = reopened.GetAt(ctx, key, compactionDeleteBatchCountLimit+50)
+	require.ErrorIs(t, err, ErrReadTSCompacted)
+
+	require.NoError(t, reopened.Compact(ctx, compactionDeleteBatchCountLimit*3))
+	require.Equal(t, uint64(compactionDeleteBatchCountLimit*3), requirePebbleRetentionController(t, reopened).MinRetainedTS())
 }
 
 func TestPebbleStore_CompactWaitsForMaintenanceLock(t *testing.T) {


### PR DESCRIPTION
## Summary
- Keep FSM compaction enabled on leaders, but bound leader compaction with the short leader timeout.
- Preserve pending min-retained timestamps when Pebble compaction is canceled after partial delete flushes, and resume safely before committing the watermark.
- Continue to the caller-requested min-retained timestamp after finalizing an older pending compaction watermark.
- Avoid the short leader timeout on multi-peer followers, while skipping FSM compaction when Pebble L0/compaction-debt backpressure is high.
- Prevent sharded HLC lease renewal storms by allowing only one in-flight renewal per group, and stabilize the renewal test precondition on in-flight completion.

## Live check
- Checked 192.168.0.210-214 via `deploy.env`; SQS leader health is leader-only as expected.
- Observed leader churn around terms 1852-1855 and HLC lease renewal proposal timeouts before the fix.
- Observed 192.168.0.213 lagging with `etcd raft inbound step queue is full`, L0 files around 499, and compaction debt around 1.4GB; the LSM backpressure gate avoids adding FSM compaction load while Pebble is already behind.

## Verification
- `go test ./kv -run 'TestFSMCompactor(CompactsMultiPeerFollowerRuntimeWithConfiguredTimeout|SkipsPebbleRuntimeUnderLSMBackpressure|CompactsMultiPeerLeaderRuntimeWithShortTimeout|CompactsSingleNodeLeaderRuntimeWithShortTimeout|CompactsEligiblePebbleRuntime)' -count=1`
- `go test ./kv -run 'TestShardedCoordinator_RenewHLCLeases_(SkipsInFlightGroup|SlowGroupDoesNotBlockPeers|ProposesToEveryLedGroup|SkipsNonLeaders)' -count=1`
- `go test ./kv -count=1`
- `go test ./store -count=1`
- `go test ./internal/raftengine/etcd ./adapter -run 'TestFSMCompactor|TestDeltaCompactor|TestServeSQSHealth|TestServeSQSLeader|TestSQS.*Health|TestBuildSQSPartitionResolver|TestRedis.*Compactor' -count=1`
- `GOCACHE=$(pwd)/.cache/go GOLANGCI_LINT_CACHE=$(pwd)/.golangci-cache golangci-lint --config=.golangci.yaml run ./kv --timeout=5m`
- `git diff --check`

Author: bootjp
