### PR TITLE
Add Raft SendStream kill switch

### DIFF
--- a/docs/design/2026_04_18_implemented_raft_grpc_streaming_transport.md
+++ b/docs/design/2026_04_18_implemented_raft_grpc_streaming_transport.md
@@ -231,8 +231,9 @@ during the reconnect window, matching the previous drop semantics.
 | 2. Receiver handler | `GRPCTransport.SendStream` | Implemented |
 | 3. Stream open/close/reconnect | `streamFor`, `peerStream` lifecycle, peer removal cleanup | Implemented |
 | 4. Sender: swap unary → stream in `dispatchRegular` | Streaming default with unary fallback | Implemented |
-| 5. Backward-compat fallback | Empty-stream probe plus `codes.Unimplemented` cache | Implemented |
-| 6. Tests | Server handler, streaming dispatch, legacy-peer fallback | Implemented |
+| 5. Operational kill switch | `ELASTICKV_RAFT_SEND_STREAM=false` forces unary `Send` without unregistering `SendStream` | Implemented |
+| 6. Backward-compat fallback | Empty-stream probe plus `codes.Unimplemented` cache | Implemented |
+| 7. Tests | Server handler, streaming dispatch, legacy-peer fallback, kill switch | Implemented |
 
 ---
 
@@ -245,6 +246,7 @@ Because `SendStream` is additive, the rollout is zero-downtime by design:
 | **Deploy new server binary** | All nodes register both `Send` (unary) and `SendStream`. Existing peers that have not yet upgraded continue to use `Send` — no behaviour change. |
 | **Gradual upgrade** | As each peer is upgraded, the sender's empty-stream probe detects `SendStream` availability and opens a stream. Unary `Send` remains the fallback for un-upgraded peers. |
 | **Full cutover** | Once all peers run the new binary, every peer-to-peer path uses streaming. The unary `Send` handler is kept indefinitely for backward compatibility. |
+| **Emergency rollback** | Set `ELASTICKV_RAFT_SEND_STREAM=false` on every node and restart. The node still serves `SendStream` for upgraded peers, but its own outbound regular Raft messages use unary `Send`. |
 
 No dual-write or blue/green deployment is required: the `codes.Unimplemented` probe
 (§3.5) makes the switch per-peer and per-connection atomically.

--- a/internal/raftengine/etcd/grpc_transport.go
+++ b/internal/raftengine/etcd/grpc_transport.go
@@ -516,6 +516,9 @@ func (t *GRPCTransport) dispatchRegular(ctx context.Context, msg raftpb.Message)
 		t.markPeerStreamUnsupported(peer.Address)
 		return t.dispatchRegularUnary(ctx, client, req)
 	}
+	if !t.sendStreamEnabledNow() {
+		return t.dispatchRegularUnary(ctx, client, req)
+	}
 	return errors.WithStack(err)
 }
 
@@ -556,59 +559,76 @@ func (t *GRPCTransport) dispatchRegularStream(ctx context.Context, address strin
 }
 
 func (t *GRPCTransport) streamFor(ctx context.Context, address string, client pb.EtcdRaftClient) (*peerStream, error) {
-	t.mu.RLock()
-	stream, ok := t.streams[address]
-	t.mu.RUnlock()
-	if ok {
-		return stream, nil
+	stream, err := t.cachedStream(address)
+	if err != nil || stream != nil {
+		return stream, err
 	}
 	if !t.allowPeerStreamProbe(address, time.Now()) {
 		return nil, errors.WithStack(status.Error(codes.Unimplemented, "etcd raft SendStream is not supported by peer"))
 	}
 
 	value, err, _ := t.dialGroup.Do("stream:"+address, func() (any, error) {
-		t.mu.RLock()
-		stream, ok := t.streams[address]
-		t.mu.RUnlock()
-		if ok {
-			return stream, nil
-		}
-		if !t.allowPeerStreamProbe(address, time.Now()) {
-			return nil, errors.WithStack(status.Error(codes.Unimplemented, "etcd raft SendStream is not supported by peer"))
-		}
-		if err := t.probeSendStream(ctx, address, client); err != nil {
-			return nil, err
-		}
-
-		streamCtx, cancel := context.WithCancel(context.Background())
-		sendStream, err := client.SendStream(streamCtx)
-		if err != nil {
-			cancel()
-			return nil, errors.WithStack(err)
-		}
-		opened := newPeerStream(sendStream, cancel)
-
-		t.mu.Lock()
-		defer t.mu.Unlock()
-		if existing, ok := t.streams[address]; ok {
-			cancel()
-			return existing, nil
-		}
-		t.streams[address] = opened
-		go func() {
-			<-opened.done
-			t.closePeerStream(address, opened)
-		}()
-		return opened, nil
+		return t.openPeerStream(ctx, address, client)
 	})
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	stream, ok = value.(*peerStream)
+	stream, ok := value.(*peerStream)
 	if !ok {
 		return nil, errors.New("etcd raft transport stream group returned unexpected stream type")
 	}
 	return stream, nil
+}
+
+func (t *GRPCTransport) cachedStream(address string) (*peerStream, error) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if t.sendStreamDisabled {
+		return nil, errors.WithStack(status.Error(codes.Unavailable, "etcd raft SendStream is disabled"))
+	}
+	stream, ok := t.streams[address]
+	if ok {
+		return stream, nil
+	}
+	return nil, nil
+}
+
+func (t *GRPCTransport) openPeerStream(ctx context.Context, address string, client pb.EtcdRaftClient) (*peerStream, error) {
+	stream, err := t.cachedStream(address)
+	if err != nil || stream != nil {
+		return stream, err
+	}
+	if !t.allowPeerStreamProbe(address, time.Now()) {
+		return nil, errors.WithStack(status.Error(codes.Unimplemented, "etcd raft SendStream is not supported by peer"))
+	}
+	if err := t.probeSendStream(ctx, address, client); err != nil {
+		return nil, err
+	}
+
+	streamCtx, cancel := context.WithCancel(context.Background())
+	sendStream, err := client.SendStream(streamCtx)
+	if err != nil {
+		cancel()
+		return nil, errors.WithStack(err)
+	}
+	opened := newPeerStream(sendStream, cancel)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.sendStreamDisabled {
+		cancel()
+		return nil, errors.WithStack(status.Error(codes.Unavailable, "etcd raft SendStream is disabled"))
+	}
+	if existing, ok := t.streams[address]; ok {
+		cancel()
+		return existing, nil
+	}
+	t.streams[address] = opened
+	go func() {
+		<-opened.done
+		t.closePeerStream(address, opened)
+	}()
+	return opened, nil
 }
 
 func (t *GRPCTransport) probeSendStream(ctx context.Context, address string, client pb.EtcdRaftClient) error {

--- a/internal/raftengine/etcd/grpc_transport.go
+++ b/internal/raftengine/etcd/grpc_transport.go
@@ -43,6 +43,7 @@ var (
 	errSnapshotStreamShort       = errors.New("etcd raft snapshot stream closed before final chunk")
 	errReceivedFSMSnapshotStale  = errors.New("etcd raft received fsm snapshot is stale")
 	errPeerStreamClosed          = errors.New("etcd raft SendStream closed")
+	errSendStreamDisabled        = errors.New("etcd raft SendStream is disabled")
 )
 
 var grpcNewClient = grpc.NewClient
@@ -53,15 +54,17 @@ type peerStream struct {
 	mu     sync.Mutex
 	stream pb.EtcdRaft_SendStreamClient
 	cancel context.CancelFunc
+	gate   context.Context
 	done   chan struct{}
 	errMu  sync.Mutex
 	err    error
 }
 
-func newPeerStream(stream pb.EtcdRaft_SendStreamClient, cancel context.CancelFunc) *peerStream {
+func newPeerStream(stream pb.EtcdRaft_SendStreamClient, cancel context.CancelFunc, gate context.Context) *peerStream {
 	peer := &peerStream{
 		stream: stream,
 		cancel: cancel,
+		gate:   gate,
 		done:   make(chan struct{}),
 	}
 	go peer.watchTerminal()
@@ -91,6 +94,13 @@ func (s *peerStream) terminalErr() error {
 	return s.err
 }
 
+func (s *peerStream) disabledErr() error {
+	if s != nil && s.gate != nil && s.gate.Err() != nil {
+		return errors.WithStack(sendStreamDisabledError())
+	}
+	return nil
+}
+
 type GRPCTransport struct {
 	pb.UnimplementedEtcdRaftServer
 
@@ -103,6 +113,8 @@ type GRPCTransport struct {
 	streamUnsupported   map[string]bool
 	streamUnsupportedAt map[string]time.Time
 	sendStreamDisabled  bool
+	sendStreamCtx       context.Context
+	sendStreamCancel    context.CancelFunc
 	handler             MessageHandler
 	snapshotChunkSize   int
 	spoolDir            string
@@ -137,6 +149,11 @@ func NewGRPCTransport(peers []Peer) *GRPCTransport {
 		}
 		peerMap[peer.NodeID] = peer
 	}
+	sendStreamCtx, sendStreamCancel := context.WithCancel(context.Background())
+	sendStreamDisabled := !sendStreamEnabledFromEnv()
+	if sendStreamDisabled {
+		sendStreamCancel()
+	}
 	return &GRPCTransport{
 		peers:               peerMap,
 		clients:             make(map[string]pb.EtcdRaftClient),
@@ -145,7 +162,9 @@ func NewGRPCTransport(peers []Peer) *GRPCTransport {
 		streamSupported:     make(map[string]bool),
 		streamUnsupported:   make(map[string]bool),
 		streamUnsupportedAt: make(map[string]time.Time),
-		sendStreamDisabled:  !sendStreamEnabledFromEnv(),
+		sendStreamDisabled:  sendStreamDisabled,
+		sendStreamCtx:       sendStreamCtx,
+		sendStreamCancel:    sendStreamCancel,
 		snapshotChunkSize:   defaultSnapshotChunkSize,
 		bridgeSem:           make(chan struct{}, defaultBridgeMaterializeLimit),
 	}
@@ -246,10 +265,18 @@ func (t *GRPCTransport) SetSendStreamEnabled(enabled bool) {
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.sendStreamDisabled = !enabled
 	if enabled {
+		if !t.sendStreamDisabled {
+			return
+		}
+		t.sendStreamCtx, t.sendStreamCancel = context.WithCancel(context.Background())
+		t.sendStreamDisabled = false
 		return
 	}
+	if !t.sendStreamDisabled && t.sendStreamCancel != nil {
+		t.sendStreamCancel()
+	}
+	t.sendStreamDisabled = true
 	for address := range t.streams {
 		t.closePeerStreamLocked(address)
 	}
@@ -516,7 +543,7 @@ func (t *GRPCTransport) dispatchRegular(ctx context.Context, msg raftpb.Message)
 		t.markPeerStreamUnsupported(peer.Address)
 		return t.dispatchRegularUnary(ctx, client, req)
 	}
-	if !t.sendStreamEnabledNow() {
+	if isSendStreamDisabled(err) {
 		return t.dispatchRegularUnary(ctx, client, req)
 	}
 	return errors.WithStack(err)
@@ -541,6 +568,9 @@ func (t *GRPCTransport) dispatchRegularStream(ctx context.Context, address strin
 	if err := stream.terminalErr(); err != nil {
 		stream.mu.Unlock()
 		t.closePeerStream(address, stream)
+		if disabledErr := stream.disabledErr(); disabledErr != nil {
+			return disabledErr
+		}
 		return errors.WithStack(err)
 	}
 	err = stream.stream.Send(req)
@@ -553,6 +583,9 @@ func (t *GRPCTransport) dispatchRegularStream(ctx context.Context, address strin
 	}
 	if err != nil {
 		t.closePeerStream(address, stream)
+		if disabledErr := stream.disabledErr(); disabledErr != nil {
+			return disabledErr
+		}
 		return errors.WithStack(err)
 	}
 	return nil
@@ -584,7 +617,7 @@ func (t *GRPCTransport) cachedStream(address string) (*peerStream, error) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	if t.sendStreamDisabled {
-		return nil, errors.WithStack(status.Error(codes.Unavailable, "etcd raft SendStream is disabled"))
+		return nil, errors.WithStack(sendStreamDisabledError())
 	}
 	stream, ok := t.streams[address]
 	if ok {
@@ -605,19 +638,22 @@ func (t *GRPCTransport) openPeerStream(ctx context.Context, address string, clie
 		return nil, err
 	}
 
-	streamCtx, cancel := context.WithCancel(context.Background())
+	streamCtx, cancel, gateCtx, err := t.sendStreamContext(context.Background())
+	if err != nil {
+		return nil, err
+	}
 	sendStream, err := client.SendStream(streamCtx)
 	if err != nil {
 		cancel()
-		return nil, errors.WithStack(err)
+		return nil, wrapSendStreamContextErr(err, gateCtx)
 	}
-	opened := newPeerStream(sendStream, cancel)
+	opened := newPeerStream(sendStream, cancel, gateCtx)
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.sendStreamDisabled {
 		cancel()
-		return nil, errors.WithStack(status.Error(codes.Unavailable, "etcd raft SendStream is disabled"))
+		return nil, errors.WithStack(sendStreamDisabledError())
 	}
 	if existing, ok := t.streams[address]; ok {
 		cancel()
@@ -632,9 +668,11 @@ func (t *GRPCTransport) openPeerStream(ctx context.Context, address string, clie
 }
 
 func (t *GRPCTransport) probeSendStream(ctx context.Context, address string, client pb.EtcdRaftClient) error {
-	if !t.sendStreamEnabledNow() {
-		return errors.WithStack(status.Error(codes.Unavailable, "etcd raft SendStream is disabled"))
+	probeCtx, cancel, gateCtx, err := t.sendStreamContext(ctx)
+	if err != nil {
+		return err
 	}
+	defer cancel()
 	t.mu.RLock()
 	supported := t.streamSupported[address]
 	t.mu.RUnlock()
@@ -645,18 +683,18 @@ func (t *GRPCTransport) probeSendStream(ctx context.Context, address string, cli
 		return errors.WithStack(status.Error(codes.Unimplemented, "etcd raft SendStream is not supported by peer"))
 	}
 
-	stream, err := client.SendStream(ctx)
+	stream, err := client.SendStream(probeCtx)
 	if err != nil {
 		if grpcStatusCode(err) == codes.Unimplemented {
 			t.markPeerStreamUnsupported(address)
 		}
-		return errors.WithStack(err)
+		return wrapSendStreamContextErr(err, gateCtx)
 	}
 	if _, err := stream.CloseAndRecv(); err != nil {
 		if grpcStatusCode(err) == codes.Unimplemented {
 			t.markPeerStreamUnsupported(address)
 		}
-		return errors.WithStack(err)
+		return wrapSendStreamContextErr(err, gateCtx)
 	}
 	t.markPeerStreamSupported(address)
 	return nil
@@ -672,6 +710,47 @@ func (t *GRPCTransport) sendStreamEnabledNow() bool {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return !t.sendStreamDisabled
+}
+
+func (t *GRPCTransport) sendStreamContext(parent context.Context) (context.Context, context.CancelFunc, context.Context, error) {
+	t.mu.RLock()
+	if t.sendStreamDisabled {
+		t.mu.RUnlock()
+		return nil, nil, nil, errors.WithStack(sendStreamDisabledError())
+	}
+	gateCtx := t.sendStreamCtx
+	t.mu.RUnlock()
+	if gateCtx == nil {
+		gateCtx = context.Background()
+	}
+
+	ctx, cancel := context.WithCancel(gateCtx)
+	if parent == nil {
+		return ctx, cancel, gateCtx, nil
+	}
+	stopParentCancel := context.AfterFunc(parent, cancel)
+	return ctx, func() {
+		stopParentCancel()
+		cancel()
+	}, gateCtx, nil
+}
+
+func wrapSendStreamContextErr(err error, gateCtx context.Context) error {
+	if err == nil {
+		return nil
+	}
+	if gateCtx != nil && gateCtx.Err() != nil {
+		return errors.WithStack(sendStreamDisabledError())
+	}
+	return errors.WithStack(err)
+}
+
+func sendStreamDisabledError() error {
+	return errors.WithStack(errors.Mark(status.Error(codes.Unavailable, errSendStreamDisabled.Error()), errSendStreamDisabled))
+}
+
+func isSendStreamDisabled(err error) bool {
+	return errors.Is(err, errSendStreamDisabled)
 }
 
 func (t *GRPCTransport) allowPeerStreamProbe(address string, now time.Time) bool {

--- a/internal/raftengine/etcd/grpc_transport.go
+++ b/internal/raftengine/etcd/grpc_transport.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -25,6 +27,7 @@ const defaultSnapshotChunkSize = 16 << 20
 const defaultDispatchTimeout = 5 * time.Second
 const defaultSnapshotDispatchTimeout = 30 * time.Minute
 const defaultSendStreamReprobeInterval = 30 * time.Second
+const sendStreamEnabledEnvVar = "ELASTICKV_RAFT_SEND_STREAM"
 
 // defaultBridgeMaterializeLimit caps the number of bridge-mode snapshot
 // materializations that may hold memory concurrently. Each call allocates up
@@ -99,6 +102,7 @@ type GRPCTransport struct {
 	streamSupported     map[string]bool
 	streamUnsupported   map[string]bool
 	streamUnsupportedAt map[string]time.Time
+	sendStreamDisabled  bool
 	handler             MessageHandler
 	snapshotChunkSize   int
 	spoolDir            string
@@ -141,9 +145,23 @@ func NewGRPCTransport(peers []Peer) *GRPCTransport {
 		streamSupported:     make(map[string]bool),
 		streamUnsupported:   make(map[string]bool),
 		streamUnsupportedAt: make(map[string]time.Time),
+		sendStreamDisabled:  !sendStreamEnabledFromEnv(),
 		snapshotChunkSize:   defaultSnapshotChunkSize,
 		bridgeSem:           make(chan struct{}, defaultBridgeMaterializeLimit),
 	}
+}
+
+func sendStreamEnabledFromEnv() bool {
+	raw := strings.TrimSpace(os.Getenv(sendStreamEnabledEnvVar))
+	if raw == "" {
+		return true
+	}
+	enabled, err := strconv.ParseBool(raw)
+	if err != nil {
+		slog.Warn("invalid ELASTICKV_RAFT_SEND_STREAM; using default", "value", raw, "default", true)
+		return true
+	}
+	return enabled
 }
 
 func (t *GRPCTransport) Register(server grpc.ServiceRegistrar) {
@@ -218,6 +236,23 @@ func (t *GRPCTransport) SetFSMPayloadOpener(fn func(index uint64) (io.ReadCloser
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.openFSMPayload = fn
+}
+
+// SetSendStreamEnabled toggles outbound regular Raft message streaming.
+// Disabling it closes cached streams so later dispatches use unary Send.
+func (t *GRPCTransport) SetSendStreamEnabled(enabled bool) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.sendStreamDisabled = !enabled
+	if enabled {
+		return
+	}
+	for address := range t.streams {
+		t.closePeerStreamLocked(address)
+	}
 }
 
 func (t *GRPCTransport) UpsertPeer(peer Peer) {
@@ -470,7 +505,7 @@ func (t *GRPCTransport) dispatchRegular(ctx context.Context, msg raftpb.Message)
 		return err
 	}
 	req := &pb.EtcdRaftMessage{Message: raw}
-	if isPriorityMsg(msg.GetType()) || !t.allowPeerStreamProbe(peer.Address, time.Now()) {
+	if isPriorityMsg(msg.GetType()) || !t.sendStreamEnabledNow() || !t.allowPeerStreamProbe(peer.Address, time.Now()) {
 		return t.dispatchRegularUnary(ctx, client, req)
 	}
 	err = t.dispatchRegularStream(ctx, peer.Address, client, req)
@@ -577,6 +612,9 @@ func (t *GRPCTransport) streamFor(ctx context.Context, address string, client pb
 }
 
 func (t *GRPCTransport) probeSendStream(ctx context.Context, address string, client pb.EtcdRaftClient) error {
+	if !t.sendStreamEnabledNow() {
+		return errors.WithStack(status.Error(codes.Unavailable, "etcd raft SendStream is disabled"))
+	}
 	t.mu.RLock()
 	supported := t.streamSupported[address]
 	t.mu.RUnlock()
@@ -608,6 +646,12 @@ func (t *GRPCTransport) peerStreamUnsupported(address string) bool {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return t.streamUnsupported[address]
+}
+
+func (t *GRPCTransport) sendStreamEnabledNow() bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return !t.sendStreamDisabled
 }
 
 func (t *GRPCTransport) allowPeerStreamProbe(address string, now time.Time) bool {

--- a/internal/raftengine/etcd/grpc_transport_test.go
+++ b/internal/raftengine/etcd/grpc_transport_test.go
@@ -964,14 +964,12 @@ func TestStreamForAbortsCachingWhenSendStreamDisabledDuringOpen(t *testing.T) {
 	transport := NewGRPCTransport([]Peer{{NodeID: 2, Address: addr}})
 	t.Cleanup(func() { require.NoError(t, transport.Close()) })
 
-	secondStream := &testRaftSendStreamClient{}
 	openStarted := make(chan struct{})
-	releaseOpen := make(chan struct{})
 	client := &testEtcdRaftClient{
-		raftStreams:         []*testRaftSendStreamClient{{}, secondStream},
-		blockSendStreamCall: 2,
-		sendStreamStarted:   openStarted,
-		releaseSendStream:   releaseOpen,
+		raftStreams:                 []*testRaftSendStreamClient{{}},
+		blockSendStreamCall:         2,
+		blockSendStreamUntilContext: true,
+		sendStreamStarted:           openStarted,
 	}
 
 	errCh := make(chan error, 1)
@@ -986,12 +984,12 @@ func TestStreamForAbortsCachingWhenSendStreamDisabledDuringOpen(t *testing.T) {
 		t.Fatal("timed out waiting for SendStream open")
 	}
 	transport.SetSendStreamEnabled(false)
-	close(releaseOpen)
 
 	select {
 	case err := <-errCh:
 		require.Error(t, err)
 		require.Equal(t, codes.Unavailable, grpcStatusCode(err))
+		require.True(t, isSendStreamDisabled(err))
 	case <-time.After(5 * time.Second):
 		t.Fatal("streamFor did not return after SendStream was disabled")
 	}
@@ -1000,12 +998,6 @@ func TestStreamForAbortsCachingWhenSendStreamDisabledDuringOpen(t *testing.T) {
 	_, streamCached := transport.streams[addr]
 	transport.mu.RUnlock()
 	require.False(t, streamCached)
-
-	select {
-	case <-secondStream.Context().Done():
-	case <-time.After(5 * time.Second):
-		t.Fatal("opened stream context was not cancelled")
-	}
 }
 
 func TestDispatchRegularFallsBackToUnaryWhenSendStreamDisabledDuringSend(t *testing.T) {
@@ -1051,6 +1043,118 @@ func TestDispatchRegularFallsBackToUnaryWhenSendStreamDisabledDuringSend(t *test
 	_, streamCached := transport.streams[addr]
 	transport.mu.RUnlock()
 	require.False(t, streamCached)
+}
+
+func TestDispatchRegularFallsBackToUnaryWhenSendStreamDisabledDuringProbe(t *testing.T) {
+	const addr = "host:2"
+	transport := NewGRPCTransport([]Peer{{NodeID: 2, Address: addr}})
+	t.Cleanup(func() { require.NoError(t, transport.Close()) })
+	probeStarted := make(chan struct{})
+	client := &testEtcdRaftClient{
+		blockSendStreamCall:         1,
+		blockSendStreamUntilContext: true,
+		sendStreamStarted:           probeStarted,
+	}
+	injectClient(t, transport, addr, client)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- transport.dispatchRegular(context.Background(), raftpb.Message{
+			Type:  messageTypePtr(raftpb.MsgApp),
+			From:  uint64Ptr(1),
+			To:    uint64Ptr(2),
+			Term:  uint64Ptr(5),
+			Index: uint64Ptr(51),
+		})
+	}()
+
+	select {
+	case <-probeStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for SendStream probe")
+	}
+	transport.SetSendStreamEnabled(false)
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("dispatchRegular did not fall back after SendStream probe was disabled")
+	}
+
+	require.Equal(t, int32(1), client.sendCalls.Load())
+	require.Equal(t, int32(1), client.sendStreamCalls.Load())
+}
+
+func TestDispatchRegularFallsBackToUnaryWhenSendStreamDisabledDuringOpen(t *testing.T) {
+	const addr = "host:2"
+	transport := NewGRPCTransport([]Peer{{NodeID: 2, Address: addr}})
+	t.Cleanup(func() { require.NoError(t, transport.Close()) })
+	openStarted := make(chan struct{})
+	client := &testEtcdRaftClient{
+		raftStreams:                 []*testRaftSendStreamClient{{}},
+		blockSendStreamCall:         2,
+		blockSendStreamUntilContext: true,
+		sendStreamStarted:           openStarted,
+	}
+	injectClient(t, transport, addr, client)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- transport.dispatchRegular(context.Background(), raftpb.Message{
+			Type:  messageTypePtr(raftpb.MsgApp),
+			From:  uint64Ptr(1),
+			To:    uint64Ptr(2),
+			Term:  uint64Ptr(5),
+			Index: uint64Ptr(52),
+		})
+	}()
+
+	select {
+	case <-openStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for SendStream open")
+	}
+	transport.SetSendStreamEnabled(false)
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("dispatchRegular did not fall back after SendStream open was disabled")
+	}
+
+	require.Equal(t, int32(1), client.sendCalls.Load())
+	require.Equal(t, int32(2), client.sendStreamCalls.Load())
+	transport.mu.RLock()
+	_, streamCached := transport.streams[addr]
+	transport.mu.RUnlock()
+	require.False(t, streamCached)
+}
+
+func TestDispatchRegularFallsBackToUnaryForSendStreamDisabledErrorAfterReenable(t *testing.T) {
+	const addr = "host:2"
+	transport := NewGRPCTransport([]Peer{{NodeID: 2, Address: addr}})
+	t.Cleanup(func() { require.NoError(t, transport.Close()) })
+	client := &testEtcdRaftClient{
+		raftStreams: []*testRaftSendStreamClient{
+			{},
+			{sendErr: sendStreamDisabledError()},
+		},
+	}
+	injectClient(t, transport, addr, client)
+
+	require.NoError(t, transport.dispatchRegular(context.Background(), raftpb.Message{
+		Type:  messageTypePtr(raftpb.MsgApp),
+		From:  uint64Ptr(1),
+		To:    uint64Ptr(2),
+		Term:  uint64Ptr(5),
+		Index: uint64Ptr(53),
+	}))
+
+	require.True(t, transport.sendStreamEnabledNow())
+	require.Equal(t, int32(1), client.sendCalls.Load())
+	require.Equal(t, int32(2), client.sendStreamCalls.Load())
 }
 
 func TestDispatchRegularReprobesStreamAfterUnsupportedCacheExpires(t *testing.T) {
@@ -1411,14 +1515,15 @@ func (*testSnapshotSendClient) RecvMsg(any) error            { return nil }
 // testEtcdRaftClient is a minimal mock of pb.EtcdRaftClient that routes
 // SendSnapshot calls to a pre-wired testSnapshotSendClient.
 type testEtcdRaftClient struct {
-	stream              *testSnapshotSendClient
-	raftStream          *testRaftSendStreamClient
-	raftStreams         []*testRaftSendStreamClient
-	blockSendStreamCall int32
-	sendStreamStarted   chan struct{}
-	releaseSendStream   chan struct{}
-	sendCalls           atomic.Int32
-	sendStreamCalls     atomic.Int32
+	stream                      *testSnapshotSendClient
+	raftStream                  *testRaftSendStreamClient
+	raftStreams                 []*testRaftSendStreamClient
+	blockSendStreamCall         int32
+	blockSendStreamUntilContext bool
+	sendStreamStarted           chan struct{}
+	releaseSendStream           chan struct{}
+	sendCalls                   atomic.Int32
+	sendStreamCalls             atomic.Int32
 }
 
 func (c *testEtcdRaftClient) Send(_ context.Context, _ *pb.EtcdRaftMessage, _ ...grpc.CallOption) (*pb.EtcdRaftAck, error) {
@@ -1431,6 +1536,10 @@ func (c *testEtcdRaftClient) SendStream(ctx context.Context, _ ...grpc.CallOptio
 	if c.blockSendStreamCall != 0 && call == c.blockSendStreamCall {
 		if c.sendStreamStarted != nil {
 			close(c.sendStreamStarted)
+		}
+		if c.blockSendStreamUntilContext {
+			<-ctx.Done()
+			return nil, ctx.Err()
 		}
 		if c.releaseSendStream != nil {
 			<-c.releaseSendStream
@@ -1458,6 +1567,7 @@ type testRaftSendStreamClient struct {
 	closed      bool
 	ctx         context.Context
 	recvErr     chan error
+	sendErr     error
 	blockSend   bool
 	sendStarted chan struct{}
 	sendOnce    sync.Once
@@ -1471,6 +1581,9 @@ func (c *testRaftSendStreamClient) Send(msg *pb.EtcdRaftMessage) error {
 	if c.blockSend {
 		<-c.Context().Done()
 		return c.Context().Err()
+	}
+	if c.sendErr != nil {
+		return c.sendErr
 	}
 	return nil
 }

--- a/internal/raftengine/etcd/grpc_transport_test.go
+++ b/internal/raftengine/etcd/grpc_transport_test.go
@@ -907,6 +907,57 @@ func TestDispatchRegularUsesUnaryForPriorityMessages(t *testing.T) {
 	require.Zero(t, client.sendStreamCalls.Load())
 }
 
+func TestDispatchRegularUsesUnaryWhenSendStreamDisabled(t *testing.T) {
+	t.Setenv(sendStreamEnabledEnvVar, "false")
+	const addr = "host:2"
+	transport := NewGRPCTransport([]Peer{{NodeID: 2, Address: addr}})
+	t.Cleanup(func() { require.NoError(t, transport.Close()) })
+	client := &testEtcdRaftClient{}
+	injectClient(t, transport, addr, client)
+
+	require.NoError(t, transport.dispatchRegular(context.Background(), raftpb.Message{
+		Type:  messageTypePtr(raftpb.MsgApp),
+		From:  uint64Ptr(1),
+		To:    uint64Ptr(2),
+		Term:  uint64Ptr(4),
+		Index: uint64Ptr(22),
+	}))
+
+	require.Equal(t, int32(1), client.sendCalls.Load())
+	require.Zero(t, client.sendStreamCalls.Load())
+	transport.mu.RLock()
+	_, streamCached := transport.streams[addr]
+	transport.mu.RUnlock()
+	require.False(t, streamCached)
+}
+
+func TestSetSendStreamEnabledClosesCachedStreams(t *testing.T) {
+	const addr = "host:2"
+	transport := NewGRPCTransport([]Peer{{NodeID: 2, Address: addr}})
+	t.Cleanup(func() { require.NoError(t, transport.Close()) })
+	client := &testEtcdRaftClient{}
+	injectClient(t, transport, addr, client)
+
+	require.NoError(t, transport.dispatchRegular(context.Background(), raftpb.Message{
+		Type:  messageTypePtr(raftpb.MsgApp),
+		From:  uint64Ptr(1),
+		To:    uint64Ptr(2),
+		Term:  uint64Ptr(4),
+		Index: uint64Ptr(22),
+	}))
+	transport.mu.RLock()
+	_, streamCached := transport.streams[addr]
+	transport.mu.RUnlock()
+	require.True(t, streamCached)
+
+	transport.SetSendStreamEnabled(false)
+
+	transport.mu.RLock()
+	_, streamCached = transport.streams[addr]
+	transport.mu.RUnlock()
+	require.False(t, streamCached)
+}
+
 func TestDispatchRegularReprobesStreamAfterUnsupportedCacheExpires(t *testing.T) {
 	const addr = "host:2"
 	transport := NewGRPCTransport([]Peer{{NodeID: 2, Address: addr}})

--- a/internal/raftengine/etcd/grpc_transport_test.go
+++ b/internal/raftengine/etcd/grpc_transport_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	raftpb "go.etcd.io/raft/v3/raftpb"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 )
@@ -958,6 +959,100 @@ func TestSetSendStreamEnabledClosesCachedStreams(t *testing.T) {
 	require.False(t, streamCached)
 }
 
+func TestStreamForAbortsCachingWhenSendStreamDisabledDuringOpen(t *testing.T) {
+	const addr = "host:2"
+	transport := NewGRPCTransport([]Peer{{NodeID: 2, Address: addr}})
+	t.Cleanup(func() { require.NoError(t, transport.Close()) })
+
+	secondStream := &testRaftSendStreamClient{}
+	openStarted := make(chan struct{})
+	releaseOpen := make(chan struct{})
+	client := &testEtcdRaftClient{
+		raftStreams:         []*testRaftSendStreamClient{{}, secondStream},
+		blockSendStreamCall: 2,
+		sendStreamStarted:   openStarted,
+		releaseSendStream:   releaseOpen,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := transport.streamFor(context.Background(), addr, client)
+		errCh <- err
+	}()
+
+	select {
+	case <-openStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for SendStream open")
+	}
+	transport.SetSendStreamEnabled(false)
+	close(releaseOpen)
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		require.Equal(t, codes.Unavailable, grpcStatusCode(err))
+	case <-time.After(5 * time.Second):
+		t.Fatal("streamFor did not return after SendStream was disabled")
+	}
+
+	transport.mu.RLock()
+	_, streamCached := transport.streams[addr]
+	transport.mu.RUnlock()
+	require.False(t, streamCached)
+
+	select {
+	case <-secondStream.Context().Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("opened stream context was not cancelled")
+	}
+}
+
+func TestDispatchRegularFallsBackToUnaryWhenSendStreamDisabledDuringSend(t *testing.T) {
+	const addr = "host:2"
+	transport := NewGRPCTransport([]Peer{{NodeID: 2, Address: addr}})
+	t.Cleanup(func() { require.NoError(t, transport.Close()) })
+	sendStarted := make(chan struct{})
+	client := &testEtcdRaftClient{
+		raftStreams: []*testRaftSendStreamClient{
+			{},
+			{blockSend: true, sendStarted: sendStarted},
+		},
+	}
+	injectClient(t, transport, addr, client)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- transport.dispatchRegular(context.Background(), raftpb.Message{
+			Type:  messageTypePtr(raftpb.MsgApp),
+			From:  uint64Ptr(1),
+			To:    uint64Ptr(2),
+			Term:  uint64Ptr(5),
+			Index: uint64Ptr(50),
+		})
+	}()
+
+	select {
+	case <-sendStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for stream Send to start")
+	}
+	transport.SetSendStreamEnabled(false)
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("dispatchRegular did not fall back after SendStream was disabled")
+	}
+
+	require.Equal(t, int32(1), client.sendCalls.Load())
+	transport.mu.RLock()
+	_, streamCached := transport.streams[addr]
+	transport.mu.RUnlock()
+	require.False(t, streamCached)
+}
+
 func TestDispatchRegularReprobesStreamAfterUnsupportedCacheExpires(t *testing.T) {
 	const addr = "host:2"
 	transport := NewGRPCTransport([]Peer{{NodeID: 2, Address: addr}})
@@ -1316,11 +1411,14 @@ func (*testSnapshotSendClient) RecvMsg(any) error            { return nil }
 // testEtcdRaftClient is a minimal mock of pb.EtcdRaftClient that routes
 // SendSnapshot calls to a pre-wired testSnapshotSendClient.
 type testEtcdRaftClient struct {
-	stream          *testSnapshotSendClient
-	raftStream      *testRaftSendStreamClient
-	raftStreams     []*testRaftSendStreamClient
-	sendCalls       atomic.Int32
-	sendStreamCalls atomic.Int32
+	stream              *testSnapshotSendClient
+	raftStream          *testRaftSendStreamClient
+	raftStreams         []*testRaftSendStreamClient
+	blockSendStreamCall int32
+	sendStreamStarted   chan struct{}
+	releaseSendStream   chan struct{}
+	sendCalls           atomic.Int32
+	sendStreamCalls     atomic.Int32
 }
 
 func (c *testEtcdRaftClient) Send(_ context.Context, _ *pb.EtcdRaftMessage, _ ...grpc.CallOption) (*pb.EtcdRaftAck, error) {
@@ -1329,7 +1427,15 @@ func (c *testEtcdRaftClient) Send(_ context.Context, _ *pb.EtcdRaftMessage, _ ..
 }
 
 func (c *testEtcdRaftClient) SendStream(ctx context.Context, _ ...grpc.CallOption) (pb.EtcdRaft_SendStreamClient, error) {
-	c.sendStreamCalls.Add(1)
+	call := c.sendStreamCalls.Add(1)
+	if c.blockSendStreamCall != 0 && call == c.blockSendStreamCall {
+		if c.sendStreamStarted != nil {
+			close(c.sendStreamStarted)
+		}
+		if c.releaseSendStream != nil {
+			<-c.releaseSendStream
+		}
+	}
 	if len(c.raftStreams) > 0 {
 		stream := c.raftStreams[0]
 		c.raftStreams = c.raftStreams[1:]


### PR DESCRIPTION
## Summary
- add ELASTICKV_RAFT_SEND_STREAM=false to force outbound regular Raft messages back to unary Send
- keep SendStream registered for wire compatibility and close cached streams when disabled at runtime
- document the rollback flag in the implemented streaming transport design

## Verification
- go test ./internal/raftengine/etcd -run 'TestDispatchRegularUsesSendStream|TestDispatchRegularUsesUnaryForPriorityMessages|TestDispatchRegularUsesUnaryWhenSendStreamDisabled|TestSetSendStreamEnabledClosesCachedStreams|TestDispatchRegularFallsBackToUnaryWhenSendStreamUnimplemented' -count=1\n- go test ./internal/raftengine/etcd -count=1 -timeout=240s\n- go test ./internal/raftengine/... -count=1 -timeout=300s\n- golangci-lint run ./internal/raftengine/etcd --timeout=5m\n\nAuthor: bootjp