### PR TITLE
raft: add send stream kill switch

### DIFF
--- a/internal/raftengine/etcd/grpc_transport.go
+++ b/internal/raftengine/etcd/grpc_transport.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -25,6 +26,7 @@ const defaultSnapshotChunkSize = 16 << 20
 const defaultDispatchTimeout = 5 * time.Second
 const defaultSnapshotDispatchTimeout = 30 * time.Minute
 const defaultSendStreamReprobeInterval = 30 * time.Second
+const sendStreamEnvVar = "ELASTICKV_RAFT_SEND_STREAM"
 
 // defaultBridgeMaterializeLimit caps the number of bridge-mode snapshot
 // materializations that may hold memory concurrently. Each call allocates up
@@ -111,8 +113,9 @@ type GRPCTransport struct {
 	readFSMPayload func(index uint64) ([]byte, error)
 	// openFSMPayload is the preferred bridge callback that opens the .fsm file
 	// for streaming without allocating a large buffer.
-	openFSMPayload func(index uint64) (io.ReadCloser, error)
-	dialGroup      singleflight.Group
+	openFSMPayload    func(index uint64) (io.ReadCloser, error)
+	sendStreamEnabled bool
+	dialGroup         singleflight.Group
 	// bridgeSem limits concurrent bridge-mode snapshot materializations so
 	// that aggregate in-memory allocation stays bounded even when multiple
 	// dispatch workers run simultaneously.
@@ -142,7 +145,24 @@ func NewGRPCTransport(peers []Peer) *GRPCTransport {
 		streamUnsupported:   make(map[string]bool),
 		streamUnsupportedAt: make(map[string]time.Time),
 		snapshotChunkSize:   defaultSnapshotChunkSize,
+		sendStreamEnabled:   sendStreamEnabledFromEnv(),
 		bridgeSem:           make(chan struct{}, defaultBridgeMaterializeLimit),
+	}
+}
+
+func sendStreamEnabledFromEnv() bool {
+	v := strings.TrimSpace(os.Getenv(sendStreamEnvVar))
+	switch strings.ToLower(v) {
+	case "", "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		slog.Warn("invalid raft send stream flag; defaulting to enabled",
+			"env", sendStreamEnvVar,
+			"value", v,
+		)
+		return true
 	}
 }
 
@@ -470,7 +490,7 @@ func (t *GRPCTransport) dispatchRegular(ctx context.Context, msg raftpb.Message)
 		return err
 	}
 	req := &pb.EtcdRaftMessage{Message: raw}
-	if isPriorityMsg(msg.GetType()) || !t.allowPeerStreamProbe(peer.Address, time.Now()) {
+	if isPriorityMsg(msg.GetType()) || !t.sendStreamAllowed(peer.Address, time.Now()) {
 		return t.dispatchRegularUnary(ctx, client, req)
 	}
 	err = t.dispatchRegularStream(ctx, peer.Address, client, req)
@@ -527,7 +547,7 @@ func (t *GRPCTransport) streamFor(ctx context.Context, address string, client pb
 	if ok {
 		return stream, nil
 	}
-	if !t.allowPeerStreamProbe(address, time.Now()) {
+	if !t.sendStreamAllowed(address, time.Now()) {
 		return nil, errors.WithStack(status.Error(codes.Unimplemented, "etcd raft SendStream is not supported by peer"))
 	}
 
@@ -538,7 +558,7 @@ func (t *GRPCTransport) streamFor(ctx context.Context, address string, client pb
 		if ok {
 			return stream, nil
 		}
-		if !t.allowPeerStreamProbe(address, time.Now()) {
+		if !t.sendStreamAllowed(address, time.Now()) {
 			return nil, errors.WithStack(status.Error(codes.Unimplemented, "etcd raft SendStream is not supported by peer"))
 		}
 		if err := t.probeSendStream(ctx, address, client); err != nil {
@@ -583,7 +603,7 @@ func (t *GRPCTransport) probeSendStream(ctx context.Context, address string, cli
 	if supported {
 		return nil
 	}
-	if !t.allowPeerStreamProbe(address, time.Now()) {
+	if !t.sendStreamAllowed(address, time.Now()) {
 		return errors.WithStack(status.Error(codes.Unimplemented, "etcd raft SendStream is not supported by peer"))
 	}
 
@@ -608,6 +628,13 @@ func (t *GRPCTransport) peerStreamUnsupported(address string) bool {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return t.streamUnsupported[address]
+}
+
+func (t *GRPCTransport) sendStreamAllowed(address string, now time.Time) bool {
+	if !t.sendStreamEnabled {
+		return false
+	}
+	return t.allowPeerStreamProbe(address, now)
 }
 
 func (t *GRPCTransport) allowPeerStreamProbe(address string, now time.Time) bool {

--- a/internal/raftengine/etcd/grpc_transport_test.go
+++ b/internal/raftengine/etcd/grpc_transport_test.go
@@ -907,6 +907,60 @@ func TestDispatchRegularUsesUnaryForPriorityMessages(t *testing.T) {
 	require.Zero(t, client.sendStreamCalls.Load())
 }
 
+func TestDispatchRegularUsesUnaryWhenSendStreamDisabled(t *testing.T) {
+	t.Setenv(sendStreamEnvVar, "false")
+
+	const addr = "host:2"
+	transport := NewGRPCTransport([]Peer{{NodeID: 2, Address: addr}})
+	t.Cleanup(func() { require.NoError(t, transport.Close()) })
+	client := &testEtcdRaftClient{}
+	injectClient(t, transport, addr, client)
+
+	require.NoError(t, transport.dispatchRegular(context.Background(), raftpb.Message{
+		Type:  messageTypePtr(raftpb.MsgApp),
+		From:  uint64Ptr(1),
+		To:    uint64Ptr(2),
+		Term:  uint64Ptr(5),
+		Index: uint64Ptr(40),
+	}))
+
+	require.Equal(t, int32(1), client.sendCalls.Load())
+	require.Zero(t, client.sendStreamCalls.Load())
+
+	transport.mu.RLock()
+	_, streamCached := transport.streams[addr]
+	streamSupported := transport.streamSupported[addr]
+	transport.mu.RUnlock()
+	require.False(t, streamCached)
+	require.False(t, streamSupported)
+}
+
+func TestSendStreamEnabledFromEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{name: "unset", want: true},
+		{name: "true", env: "true", want: true},
+		{name: "one", env: "1", want: true},
+		{name: "false", env: "false", want: false},
+		{name: "zero", env: "0", want: false},
+		{name: "invalid", env: "maybe", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "unset" {
+				t.Setenv(sendStreamEnvVar, "")
+			} else {
+				t.Setenv(sendStreamEnvVar, tt.env)
+			}
+			require.Equal(t, tt.want, sendStreamEnabledFromEnv())
+		})
+	}
+}
+
 func TestDispatchRegularReprobesStreamAfterUnsupportedCacheExpires(t *testing.T) {
 	const addr = "host:2"
 	transport := NewGRPCTransport([]Peer{{NodeID: 2, Address: addr}})


### PR DESCRIPTION
## Summary
- Wire ELASTICKV_RAFT_SEND_STREAM so false routes regular Raft messages over unary Send
- Keep priority traffic and snapshot streaming behavior unchanged
- Add env parsing and dispatch coverage

## Testing
- go test ./internal/raftengine/etcd -run 'Test(DispatchRegularUsesSendStream|DispatchRegularFallsBackToUnaryWhenSendStreamUnimplemented|DispatchRegularUsesUnaryForPriorityMessages|DispatchRegularUsesUnaryWhenSendStreamDisabled|SendStreamEnabledFromEnv|DispatchRegularReprobesStreamAfterUnsupportedCacheExpires|StreamForDeduplicatesConcurrentOpen|DispatchRegularStreamCancelsCachedStreamWhenContextDone)' -count=1\n- go test ./internal/raftengine/etcd -run '^$' -count=1\n- go test ./... -run '^$' -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 環境変数により、Raft 通信の gRPC ストリーミング送信を有効・無効に切り替えられるようになりました。
  * ストリーミング送信を無効にした場合は、通常のユニキャスト送信が使用されます。

* **バグ修正**
  * ストリーミング送信を無効にした設定で、不要なプローブやストリーム利用が発生しないよう改善しました。

* **テスト**
  * 環境変数の各設定値と、ストリーミング無効時の送信動作を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->