### PR TITLE
Refactor S3 write paths

### DIFF
--- a/adapter/s3.go
+++ b/adapter/s3.go
@@ -3,9 +3,7 @@ package adapter
 import (
 	"bytes"
 	"context"
-	"crypto/md5" //nolint:gosec // S3 ETag compatibility requires MD5.
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
@@ -169,6 +167,25 @@ func (e *s3ResponseError) Error() string {
 		return ""
 	}
 	return e.Message
+}
+
+func newS3ResponseError(statusCode int, code, message, bucket, objectKey string) error {
+	return &s3ResponseError{
+		Status:  statusCode,
+		Code:    code,
+		Message: message,
+		Bucket:  bucket,
+		Key:     objectKey,
+	}
+}
+
+func writeS3ResponseOrInternalError(w http.ResponseWriter, err error) {
+	var responseErr *s3ResponseError
+	if errors.As(err, &responseErr) {
+		writeS3Error(w, responseErr.Status, responseErr.Code, responseErr.Message, responseErr.Bucket, responseErr.Key)
+		return
+	}
+	writeS3InternalError(w, err)
 }
 
 type s3ErrorResponse struct {
@@ -843,44 +860,15 @@ func (s *S3Server) putBucketAcl(w http.ResponseWriter, r *http.Request, bucket s
 	w.WriteHeader(http.StatusOK)
 }
 
-//nolint:cyclop,gocognit,gocyclo,nestif // The S3 PUT flow is intentionally linear and maps directly to protocol steps.
 func (s *S3Server) putObject(w http.ResponseWriter, r *http.Request, bucket string, objectKey string) {
-	readTS := s.readTS()
-	startTS, err := s.txnStartTS(r.Context(), readTS)
+	state, err := s.prepareS3PutObject(r.Context(), r, bucket, objectKey)
 	if err != nil {
-		writeS3InternalError(w, err)
+		writeS3ResponseOrInternalError(w, err)
 		return
 	}
-	readPin := s.pinReadTS(readTS)
-	defer readPin.Release()
+	defer state.readPin.Release()
 
-	meta, exists, err := s.loadBucketMetaAt(r.Context(), bucket, readTS)
-	if err != nil {
-		writeS3InternalError(w, err)
-		return
-	}
-	if !exists || meta == nil {
-		writeS3Error(w, http.StatusNotFound, "NoSuchBucket", "bucket not found", bucket, objectKey)
-		return
-	}
-
-	headKey := s3keys.ObjectManifestKey(bucket, meta.Generation, objectKey)
-	previous, _, err := s.loadObjectManifestAt(r.Context(), headKey, readTS)
-	if err != nil {
-		writeS3InternalError(w, err)
-		return
-	}
-	if err := validateS3PutPreconditions(r, previous); err != nil {
-		writeS3Error(w, http.StatusPreconditionFailed, "PreconditionFailed", err.Error(), bucket, objectKey)
-		return
-	}
-
-	uploadID := newS3UploadID(s.clock())
-	hasher := md5.New() //nolint:gosec // S3 ETag compatibility requires MD5.
-	sha256Hasher := sha256.New()
 	expectedPayloadSHA := normalizeS3PayloadHash(r.Header.Get("X-Amz-Content-Sha256"))
-	validatePayloadSHA := expectedPayloadSHA != "" && !isS3PayloadMarker(expectedPayloadSHA)
-	admissionProtocol := s3PutAdmissionProtocolForPayload(expectedPayloadSHA)
 	streamBody, bodyErr := prepareStreamingPutBody(w, r, s3MaxObjectSizeBytes, expectedPayloadSHA, "object exceeds maximum allowed size")
 	if bodyErr != nil {
 		writeS3Error(w, bodyErr.Status, bodyErr.Code, bodyErr.Message, bucket, objectKey)
@@ -889,192 +877,25 @@ func (s *S3Server) putObject(w http.ResponseWriter, r *http.Request, bucket stri
 	if !s.admitS3PutRequest(w, r, bucket, objectKey, s3MaxObjectSizeBytes, "object exceeds maximum allowed size") {
 		return
 	}
-	part := s3ObjectPart{PartNo: 1}
-	sizeBytes := int64(0)
-	chunkNo := uint64(0)
-	buf := make([]byte, s3ChunkSize)
-	pendingBatch := make([]*kv.Elem[kv.OP], 0, s3ChunkBatchOps)
-	pendingChunkSizes := make([]uint64, 0, s3ChunkBatchOps)
-	pendingAdmission := make([]func(), 0, s3ChunkBatchOps)
-	releasePendingAdmission := func() {
-		for _, release := range pendingAdmission {
-			release()
-		}
-		pendingAdmission = pendingAdmission[:0]
-	}
-	defer releasePendingAdmission()
-	nextReadBuffer := func() ([]byte, bool) {
-		return nextS3PutReadBuffer(buf, admissionProtocol, r.ContentLength, sizeBytes)
-	}
-	uploadedManifest := func() *s3ObjectManifest {
-		if len(part.ChunkSizes) == 0 {
-			return &s3ObjectManifest{UploadID: uploadID}
-		}
-		clonedPart := part
-		clonedPart.ChunkSizes = append([]uint64(nil), part.ChunkSizes...)
-		clonedPart.ChunkCount = uint64(len(clonedPart.ChunkSizes))
-		return &s3ObjectManifest{
-			UploadID: uploadID,
-			Parts:    []s3ObjectPart{clonedPart},
-		}
-	}
-	flushBatch := func() error {
-		if len(pendingBatch) == 0 {
-			return nil
-		}
-		_, err := s.coordinator.Dispatch(r.Context(), &kv.OperationGroup[kv.OP]{Elems: pendingBatch})
-		releasePendingAdmission()
-		if err != nil {
-			return errors.WithStack(err)
-		}
-		part.ChunkSizes = append(part.ChunkSizes, pendingChunkSizes...)
-		part.ChunkCount = uint64(len(part.ChunkSizes))
-		pendingBatch = pendingBatch[:0]
-		pendingChunkSizes = pendingChunkSizes[:0]
-		return nil
-	}
-	for {
-		if s.shouldFlushS3PutBatchBeforeRead(admissionProtocol, len(pendingAdmission)) {
-			if err := flushBatch(); err != nil {
-				s.cleanupManifestBlobs(r.Context(), bucket, meta.Generation, objectKey, uploadedManifest())
-				writeS3InternalError(w, err)
-				return
-			}
-		}
-		readBuf, finalRead := nextReadBuffer()
-		if len(readBuf) == 0 {
-			break
-		}
-		releaseAdmission, admissionErr := s.acquireS3PutAdmissionForRead(r.Context(), len(readBuf), admissionProtocol, streamBody, sizeBytes)
-		if admissionErr != nil {
-			s.cleanupManifestBlobs(r.Context(), bucket, meta.Generation, objectKey, uploadedManifest())
-			writeS3AdmissionError(w, bucket, objectKey, s.s3PutAdmissionRetryAfter())
-			return
-		}
-		allowFinalPartial := s3PutReadAllowsFinalPartial(admissionProtocol, r.ContentLength)
-		n, readErr := readS3PutChunk(r.Body, readBuf, allowFinalPartial, finalRead)
-		if readErr != nil && !errors.Is(readErr, io.EOF) {
-			releaseAdmission()
-			s.cleanupManifestBlobs(r.Context(), bucket, meta.Generation, objectKey, uploadedManifest())
-			if be, ok := classifyS3BodyReadErr(readErr, "object exceeds maximum allowed size"); ok {
-				writeS3Error(w, be.Status, be.Code, be.Message, bucket, objectKey)
-				return
-			}
-			writeS3InternalError(w, readErr)
-			return
-		}
-		if n > 0 {
-			pendingAdmission = append(pendingAdmission, releaseAdmission)
-			chunk := append([]byte(nil), readBuf[:n]...)
-			if _, err := hasher.Write(chunk); err != nil {
-				writeS3InternalError(w, err)
-				return
-			}
-			if validatePayloadSHA {
-				if _, err := sha256Hasher.Write(chunk); err != nil {
-					writeS3InternalError(w, err)
-					return
-				}
-			}
-			streamBody.writeDecoded(chunk)
-			chunkKey := s3keys.BlobKey(bucket, meta.Generation, objectKey, uploadID, part.PartNo, chunkNo)
-			pendingBatch = append(pendingBatch, &kv.Elem[kv.OP]{Op: kv.Put, Key: chunkKey, Value: chunk})
-			chunkSize, err := uint64FromInt(n)
-			if err != nil {
-				s.cleanupManifestBlobs(r.Context(), bucket, meta.Generation, objectKey, uploadedManifest())
-				writeS3InternalError(w, err)
-				return
-			}
-			pendingChunkSizes = append(pendingChunkSizes, chunkSize)
-			if len(pendingBatch) >= s3ChunkBatchOps {
-				if err := flushBatch(); err != nil {
-					s.cleanupManifestBlobs(r.Context(), bucket, meta.Generation, objectKey, uploadedManifest())
-					writeS3InternalError(w, err)
-					return
-				}
-			}
-			sizeBytes += int64(n)
-			chunkNo++
-		} else {
-			releaseAdmission()
-		}
-		if errors.Is(readErr, io.EOF) {
-			break
-		}
-	}
-	if err := flushBatch(); err != nil {
-		s.cleanupManifestBlobs(r.Context(), bucket, meta.Generation, objectKey, uploadedManifest())
-		writeS3InternalError(w, err)
+	upload, uploadBodyErr, uploadErr := s.uploadS3ObjectData(
+		r.Context(), r, streamBody, state, bucket, objectKey, expectedPayloadSHA,
+	)
+	if uploadErr != nil || uploadBodyErr != nil {
+		s.cleanupS3PutObjectChunks(r.Context(), state, upload, bucket, objectKey)
+		s.writeS3ChunkUploadError(w, uploadBodyErr, uploadErr, bucket, objectKey)
 		return
 	}
-	if validatePayloadSHA {
-		actualPayloadSHA := hex.EncodeToString(sha256Hasher.Sum(nil))
-		if !strings.EqualFold(actualPayloadSHA, expectedPayloadSHA) {
-			s.cleanupManifestBlobs(r.Context(), bucket, meta.Generation, objectKey, uploadedManifest())
-			writeS3Error(w, http.StatusBadRequest, "XAmzContentSHA256Mismatch", "payload SHA256 does not match x-amz-content-sha256", bucket, objectKey)
-			return
-		}
-	}
-	if err := streamBody.verifyTrailer(); err != nil {
-		s.cleanupManifestBlobs(r.Context(), bucket, meta.Generation, objectKey, uploadedManifest())
-		writeS3Error(w, http.StatusBadRequest, "BadDigest", err.Error(), bucket, objectKey)
+	mutationAttempted, err := s.commitS3PutObject(r.Context(), r, state, upload, bucket)
+	if err != nil {
+		s.cleanupS3PutObjectChunks(r.Context(), state, upload, bucket, objectKey)
+		writeS3PutObjectCommitError(w, err, mutationAttempted, bucket, objectKey)
 		return
 	}
 
-	etag := hex.EncodeToString(hasher.Sum(nil))
-	part.ETag = etag
-	part.SizeBytes = sizeBytes
-	part.ChunkCount = uint64(len(part.ChunkSizes))
-	commitTS, err := s.nextTxnCommitTS(r.Context(), startTS)
-	if err != nil {
-		s.cleanupManifestBlobs(r.Context(), bucket, meta.Generation, objectKey, uploadedManifest())
-		writeS3InternalError(w, err)
-		return
+	if state.previous != nil {
+		s.cleanupManifestBlobsAsync(bucket, state.meta.Generation, objectKey, state.previous)
 	}
-	manifest := &s3ObjectManifest{
-		UploadID:           uploadID,
-		ETag:               etag,
-		SizeBytes:          sizeBytes,
-		LastModifiedHLC:    commitTS,
-		ContentType:        headerOrDefault(r.Header.Get("Content-Type"), "application/octet-stream"),
-		ContentEncoding:    cleanStoredContentEncoding(r.Header.Get("Content-Encoding")),
-		CacheControl:       r.Header.Get("Cache-Control"),
-		ContentDisposition: r.Header.Get("Content-Disposition"),
-		UserMetadata:       collectS3UserMetadata(r.Header),
-	}
-	if sizeBytes > 0 {
-		manifest.Parts = []s3ObjectPart{part}
-	}
-	body, err := encodeS3ObjectManifest(manifest)
-	if err != nil {
-		s.cleanupManifestBlobs(r.Context(), bucket, meta.Generation, objectKey, uploadedManifest())
-		writeS3InternalError(w, err)
-		return
-	}
-	bucketFence, err := encodeS3BucketMeta(meta)
-	if err != nil {
-		s.cleanupManifestBlobs(r.Context(), bucket, meta.Generation, objectKey, uploadedManifest())
-		writeS3InternalError(w, err)
-		return
-	}
-	if _, err := s.coordinator.Dispatch(r.Context(), &kv.OperationGroup[kv.OP]{
-		IsTxn:    true,
-		StartTS:  startTS,
-		CommitTS: commitTS,
-		Elems: []*kv.Elem[kv.OP]{
-			{Op: kv.Put, Key: s3keys.BucketMetaKey(bucket), Value: bucketFence},
-			{Op: kv.Put, Key: headKey, Value: body},
-		},
-	}); err != nil {
-		s.cleanupManifestBlobs(r.Context(), bucket, meta.Generation, objectKey, uploadedManifest())
-		writeS3MutationError(w, err, bucket, objectKey)
-		return
-	}
-
-	if previous != nil {
-		s.cleanupManifestBlobsAsync(bucket, meta.Generation, objectKey, previous)
-	}
-	w.Header().Set("ETag", quoteS3ETag(etag))
+	w.Header().Set("ETag", quoteS3ETag(upload.ETag))
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -1389,43 +1210,17 @@ func (s *S3Server) createMultipartUpload(w http.ResponseWriter, r *http.Request,
 	})
 }
 
-//nolint:cyclop,gocognit,gocyclo // Upload part is intentionally linear and maps directly to protocol steps.
-func (s *S3Server) uploadPart(w http.ResponseWriter, r *http.Request, bucket string, objectKey string, uploadID string, partNumberStr string) {
-	partNumber, err := strconv.Atoi(partNumberStr)
-	if err != nil || partNumber < s3MinPartNumber || partNumber > s3MaxPartNumber {
-		writeS3Error(w, http.StatusBadRequest, "InvalidArgument", "part number must be between 1 and 10000", bucket, objectKey)
-		return
-	}
-	partNo := uint64(partNumber)
-
-	readTS := s.readTS()
-	readPin := s.pinReadTS(readTS)
-	defer readPin.Release()
-
-	meta, exists, err := s.loadBucketMetaAt(r.Context(), bucket, readTS)
+func (s *S3Server) uploadPart(w http.ResponseWriter, r *http.Request, bucket string, objectKey string, uploadID string, partNumberRaw string) {
+	state, err := s.prepareS3UploadPart(r.Context(), bucket, objectKey, uploadID, partNumberRaw)
 	if err != nil {
-		writeS3InternalError(w, err)
+		writeS3ResponseOrInternalError(w, err)
 		return
 	}
-	if !exists || meta == nil {
-		writeS3Error(w, http.StatusNotFound, "NoSuchBucket", "bucket not found", bucket, objectKey)
-		return
-	}
+	defer state.readPin.Release()
 
-	// Verify upload exists.
-	uploadMetaKey := s3keys.UploadMetaKey(bucket, meta.Generation, objectKey, uploadID)
-	if _, err := s.store.GetAt(r.Context(), uploadMetaKey, readTS); err != nil {
-		if errors.Is(err, store.ErrKeyNotFound) {
-			writeS3Error(w, http.StatusNotFound, "NoSuchUpload", "upload not found", bucket, objectKey)
-			return
-		}
-		writeS3InternalError(w, err)
-		return
-	}
-
-	partPayloadSHA := normalizeS3PayloadHash(r.Header.Get("X-Amz-Content-Sha256"))
-	admissionProtocol := s3PutAdmissionProtocolForPayload(partPayloadSHA)
-	partStreamBody, bodyErr := prepareStreamingPutBody(w, r, s3MaxPartSizeBytes, partPayloadSHA, "part exceeds maximum allowed size")
+	payloadSHA := normalizeS3PayloadHash(r.Header.Get("X-Amz-Content-Sha256"))
+	admissionProtocol := s3PutAdmissionProtocolForPayload(payloadSHA)
+	streamBody, bodyErr := prepareStreamingPutBody(w, r, s3MaxPartSizeBytes, payloadSHA, "part exceeds maximum allowed size")
 	if bodyErr != nil {
 		writeS3Error(w, bodyErr.Status, bodyErr.Code, bodyErr.Message, bucket, objectKey)
 		return
@@ -1433,426 +1228,50 @@ func (s *S3Server) uploadPart(w http.ResponseWriter, r *http.Request, bucket str
 	if !s.admitS3PutRequest(w, r, bucket, objectKey, s3MaxPartSizeBytes, "part exceeds maximum allowed size") {
 		return
 	}
-
-	// Pre-allocate the part's commit timestamp before writing any blob chunks so
-	// that the same version identifier is used for every chunk in this attempt.
-	// Embedding partCommitTS as PartVersion in the blob keys isolates each
-	// UploadPart attempt in its own key space: a concurrent or retried request
-	// for the same partNo receives a different timestamp and therefore writes to
-	// different keys, leaving the chunk data referenced by an in-progress
-	// CompleteMultipartUpload untouched.
-	partReadTS := s.readTS()
-	partStartTS, err := s.txnStartTS(r.Context(), partReadTS)
-	if err != nil {
-		writeS3InternalError(w, err)
-		return
-	}
-	partCommitTS, err := s.nextTxnCommitTS(r.Context(), partStartTS)
-	if err != nil {
-		writeS3InternalError(w, err)
+	upload, previous, uploadBodyErr, uploadErr := s.storeS3UploadPart(
+		r.Context(), r, streamBody, state, bucket, objectKey, uploadID, admissionProtocol,
+	)
+	if uploadErr != nil || uploadBodyErr != nil {
+		s.writeS3ChunkUploadError(w, uploadBodyErr, uploadErr, bucket, objectKey)
 		return
 	}
 
-	hasher := md5.New() //nolint:gosec // S3 ETag compatibility requires MD5.
-	sizeBytes := int64(0)
-	chunkNo := uint64(0)
-	buf := make([]byte, s3ChunkSize)
-	pendingBatch := make([]*kv.Elem[kv.OP], 0, s3ChunkBatchOps)
-	chunkSizes := make([]uint64, 0, s3ChunkBatchOps)
-	pendingAdmission := make([]func(), 0, s3ChunkBatchOps)
-	releasePendingAdmission := func() {
-		for _, release := range pendingAdmission {
-			release()
-		}
-		pendingAdmission = pendingAdmission[:0]
+	if previous != nil {
+		s.cleanupPartBlobsAsync(
+			bucket, state.meta.Generation, objectKey, uploadID,
+			previous.PartNo, previous.ChunkCount, previous.PartVersion,
+		)
 	}
-	defer releasePendingAdmission()
-	nextReadBuffer := func() ([]byte, bool) {
-		return nextS3PutReadBuffer(buf, admissionProtocol, r.ContentLength, sizeBytes)
-	}
-	partCommitted := false
-	defer func() {
-		if !partCommitted && chunkNo > 0 {
-			s.cleanupPartBlobsAsync(bucket, meta.Generation, objectKey, uploadID, partNo, chunkNo, partCommitTS)
-		}
-	}()
-
-	flushBatch := func() error {
-		if len(pendingBatch) == 0 {
-			return nil
-		}
-		_, err := s.coordinator.Dispatch(r.Context(), &kv.OperationGroup[kv.OP]{Elems: pendingBatch})
-		releasePendingAdmission()
-		if err != nil {
-			return errors.WithStack(err)
-		}
-		pendingBatch = pendingBatch[:0]
-		return nil
-	}
-
-	for {
-		if s.shouldFlushS3PutBatchBeforeRead(admissionProtocol, len(pendingAdmission)) {
-			if err := flushBatch(); err != nil {
-				writeS3InternalError(w, err)
-				return
-			}
-		}
-		readBuf, finalRead := nextReadBuffer()
-		if len(readBuf) == 0 {
-			break
-		}
-		releaseAdmission, admissionErr := s.acquireS3PutAdmissionForRead(r.Context(), len(readBuf), admissionProtocol, partStreamBody, sizeBytes)
-		if admissionErr != nil {
-			writeS3AdmissionError(w, bucket, objectKey, s.s3PutAdmissionRetryAfter())
-			return
-		}
-		allowFinalPartial := s3PutReadAllowsFinalPartial(admissionProtocol, r.ContentLength)
-		n, readErr := readS3PutChunk(r.Body, readBuf, allowFinalPartial, finalRead)
-		if readErr != nil && !errors.Is(readErr, io.EOF) {
-			releaseAdmission()
-			if be, ok := classifyS3BodyReadErr(readErr, "part exceeds maximum allowed size"); ok {
-				writeS3Error(w, be.Status, be.Code, be.Message, bucket, objectKey)
-				return
-			}
-			writeS3InternalError(w, readErr)
-			return
-		}
-		if n == 0 {
-			releaseAdmission()
-			if errors.Is(readErr, io.EOF) {
-				break
-			}
-			continue
-		}
-		pendingAdmission = append(pendingAdmission, releaseAdmission)
-		chunk := append([]byte(nil), readBuf[:n]...)
-		if _, err := hasher.Write(chunk); err != nil {
-			writeS3InternalError(w, err)
-			return
-		}
-		partStreamBody.writeDecoded(chunk)
-		chunkKey := s3keys.VersionedBlobKey(bucket, meta.Generation, objectKey, uploadID, partNo, chunkNo, partCommitTS)
-		pendingBatch = append(pendingBatch, &kv.Elem[kv.OP]{Op: kv.Put, Key: chunkKey, Value: chunk})
-		cs, err := uint64FromInt(n)
-		if err != nil {
-			writeS3InternalError(w, err)
-			return
-		}
-		chunkSizes = append(chunkSizes, cs)
-		if len(pendingBatch) >= s3ChunkBatchOps {
-			if err := flushBatch(); err != nil {
-				writeS3InternalError(w, err)
-				return
-			}
-		}
-		sizeBytes += int64(n)
-		chunkNo++
-		if errors.Is(readErr, io.EOF) {
-			break
-		}
-	}
-	if err := flushBatch(); err != nil {
-		writeS3InternalError(w, err)
-		return
-	}
-	if err := partStreamBody.verifyTrailer(); err != nil {
-		writeS3Error(w, http.StatusBadRequest, "BadDigest", err.Error(), bucket, objectKey)
-		return
-	}
-
-	etag := hex.EncodeToString(hasher.Sum(nil))
-	partDesc := &s3PartDescriptor{
-		PartNo:      partNo,
-		ETag:        etag,
-		SizeBytes:   sizeBytes,
-		ChunkCount:  chunkNo,
-		ChunkSizes:  chunkSizes,
-		PartVersion: partCommitTS,
-	}
-	descBody, err := json.Marshal(partDesc)
-	if err != nil {
-		writeS3InternalError(w, err)
-		return
-	}
-	partKey := s3keys.UploadPartKey(bucket, meta.Generation, objectKey, uploadID, partNo)
-
-	// Load previous part descriptor (if any) so we can clean up its blobs after overwrite.
-	var prevDesc *s3PartDescriptor
-	if prevRaw, err := s.store.GetAt(r.Context(), partKey, readTS); err == nil {
-		var pd s3PartDescriptor
-		if json.Unmarshal(prevRaw, &pd) == nil {
-			prevDesc = &pd
-		}
-	}
-
-	// Re-verify upload still exists at a fresh snapshot before committing.
-	// This narrows the race window with concurrent Abort/Complete.
-	freshTS := s.readTS()
-	if _, err := s.store.GetAt(r.Context(), uploadMetaKey, freshTS); err != nil {
-		if errors.Is(err, store.ErrKeyNotFound) {
-			writeS3Error(w, http.StatusNotFound, "NoSuchUpload", "upload not found", bucket, objectKey)
-			return
-		}
-		writeS3InternalError(w, err)
-		return
-	}
-
-	if _, err := s.coordinator.Dispatch(r.Context(), &kv.OperationGroup[kv.OP]{
-		IsTxn:    true,
-		StartTS:  partStartTS,
-		CommitTS: partCommitTS,
-		Elems: []*kv.Elem[kv.OP]{
-			{Op: kv.Put, Key: partKey, Value: descBody},
-		},
-	}); err != nil {
-		writeS3InternalError(w, err)
-		return
-	}
-	partCommitted = true
-
-	// Clean up blobs from the previous version of this part (if overwritten).
-	if prevDesc != nil {
-		s.cleanupPartBlobsAsync(bucket, meta.Generation, objectKey, uploadID, prevDesc.PartNo, prevDesc.ChunkCount, prevDesc.PartVersion)
-	}
-
-	w.Header().Set("ETag", quoteS3ETag(etag))
+	w.Header().Set("ETag", quoteS3ETag(upload.ETag))
 	w.WriteHeader(http.StatusOK)
 }
 
-//nolint:cyclop,gocognit,gocyclo // CompleteMultipartUpload validates parts, computes composite ETag, and commits atomically.
 func (s *S3Server) completeMultipartUpload(w http.ResponseWriter, r *http.Request, bucket string, objectKey string, uploadID string) {
-	bodyBytes, err := io.ReadAll(io.LimitReader(r.Body, s3ChunkSize))
+	request, err := parseS3MultipartCompletion(r.Body, bucket, objectKey)
 	if err != nil {
-		writeS3InternalError(w, err)
+		writeS3ResponseOrInternalError(w, err)
 		return
 	}
-	var completionReq s3CompleteMultipartUploadRequest
-	if err := xml.Unmarshal(bodyBytes, &completionReq); err != nil {
-		writeS3Error(w, http.StatusBadRequest, "MalformedXML", "request body is not valid XML", bucket, objectKey)
-		return
-	}
-	if len(completionReq.Parts) == 0 {
-		writeS3Error(w, http.StatusBadRequest, "InvalidArgument", "at least one part is required", bucket, objectKey)
-		return
-	}
-	if len(completionReq.Parts) > s3MaxPartsPerUpload {
-		writeS3Error(w, http.StatusBadRequest, "InvalidArgument",
-			fmt.Sprintf("too many parts in CompleteMultipartUpload request (maximum %d)", s3MaxPartsPerUpload), bucket, objectKey)
-		return
-	}
-
-	// Parts must be in ascending order, within allowed part number range.
-	for i, part := range completionReq.Parts {
-		if part.PartNumber < s3MinPartNumber || part.PartNumber > s3MaxPartNumber {
-			writeS3Error(w, http.StatusBadRequest, "InvalidArgument", "part number out of allowed range", bucket, objectKey)
-			return
-		}
-		if i > 0 && part.PartNumber <= completionReq.Parts[i-1].PartNumber {
-			writeS3Error(w, http.StatusBadRequest, "InvalidPartOrder", "parts must be in ascending order", bucket, objectKey)
-			return
-		}
-	}
-
-	// Phase 1: Read and validate parts (outside retry — idempotent, avoids O(parts) re-reads).
-	readTS := s.readTS()
-	readPin := s.pinReadTS(readTS)
-
-	meta, exists, err := s.loadBucketMetaAt(r.Context(), bucket, readTS)
+	completion, err := s.loadS3MultipartCompletion(r.Context(), bucket, objectKey, uploadID, request)
 	if err != nil {
-		readPin.Release()
-		writeS3InternalError(w, err)
+		writeS3ResponseOrInternalError(w, err)
 		return
 	}
-	if !exists || meta == nil {
-		readPin.Release()
-		writeS3Error(w, http.StatusNotFound, "NoSuchBucket", "bucket not found", bucket, objectKey)
-		return
-	}
-	generation := meta.Generation
-
-	uploadMetaKey := s3keys.UploadMetaKey(bucket, meta.Generation, objectKey, uploadID)
-	uploadMetaRaw, err := s.store.GetAt(r.Context(), uploadMetaKey, readTS)
-	if err != nil {
-		readPin.Release()
-		if errors.Is(err, store.ErrKeyNotFound) {
-			writeS3Error(w, http.StatusNotFound, "NoSuchUpload", "upload not found", bucket, objectKey)
-			return
-		}
-		writeS3InternalError(w, err)
-		return
-	}
-	var uploadMeta s3UploadMeta
-	if err := json.Unmarshal(uploadMetaRaw, &uploadMeta); err != nil {
-		readPin.Release()
-		writeS3InternalError(w, err)
-		return
-	}
-
-	manifestParts := make([]s3ObjectPart, 0, len(completionReq.Parts))
-	md5Concat := md5.New() //nolint:gosec // S3 composite ETag requires MD5.
-	totalSize := int64(0)
-
-	for i, reqPart := range completionReq.Parts {
-		partKey := s3keys.UploadPartKey(bucket, meta.Generation, objectKey, uploadID, uint64(reqPart.PartNumber)) //nolint:gosec // G115: PartNumber validated in [1,10000].
-		raw, err := s.store.GetAt(r.Context(), partKey, readTS)
-		if err != nil {
-			readPin.Release()
-			if errors.Is(err, store.ErrKeyNotFound) {
-				writeS3Error(w, http.StatusBadRequest, "InvalidPart", fmt.Sprintf("part %d not found", reqPart.PartNumber), bucket, objectKey)
-				return
-			}
-			writeS3InternalError(w, err)
-			return
-		}
-		var desc s3PartDescriptor
-		if err := json.Unmarshal(raw, &desc); err != nil {
-			readPin.Release()
-			writeS3InternalError(w, err)
-			return
-		}
-		reqETag := strings.Trim(reqPart.ETag, `"`)
-		if reqETag != desc.ETag {
-			readPin.Release()
-			writeS3Error(w, http.StatusBadRequest, "InvalidPart",
-				fmt.Sprintf("part %d ETag mismatch: got %q, want %q", reqPart.PartNumber, reqETag, desc.ETag), bucket, objectKey)
-			return
-		}
-		if i < len(completionReq.Parts)-1 && desc.SizeBytes < int64(s3MinPartSize) {
-			readPin.Release()
-			writeS3Error(w, http.StatusBadRequest, "EntityTooSmall",
-				fmt.Sprintf("part %d is too small (%d bytes)", reqPart.PartNumber, desc.SizeBytes), bucket, objectKey)
-			return
-		}
-
-		partMD5, err := hex.DecodeString(desc.ETag)
-		if err != nil {
-			readPin.Release()
-			writeS3InternalError(w, err)
-			return
-		}
-		if _, err := md5Concat.Write(partMD5); err != nil {
-			readPin.Release()
-			writeS3InternalError(w, err)
-			return
-		}
-
-		manifestParts = append(manifestParts, s3ObjectPart(desc))
-		totalSize += desc.SizeBytes
-	}
-	readPin.Release()
-
-	compositeETag := hex.EncodeToString(md5Concat.Sum(nil)) + fmt.Sprintf("-%d", len(completionReq.Parts))
-
-	// Phase 2: Commit (inside retry — only fencing + manifest write).
-	var previous *s3ObjectManifest
-
-	err = s.retryS3Mutation(r.Context(), func() error {
-		retryReadTS := s.readTS()
-		startTS, err := s.txnStartTS(r.Context(), retryReadTS)
-		if err != nil {
-			return errors.Wrap(err, "s3: allocate startTS for completeMultipartUpload retry")
-		}
-		retryPin := s.pinReadTS(retryReadTS)
-		defer retryPin.Release()
-
-		// Re-verify bucket generation hasn't changed (fence against delete+recreate).
-		retryMeta, retryExists, err := s.loadBucketMetaAt(r.Context(), bucket, retryReadTS)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-		if !retryExists || retryMeta == nil {
-			return &s3ResponseError{
-				Status:  http.StatusNotFound,
-				Code:    "NoSuchBucket",
-				Message: "bucket not found",
-				Bucket:  bucket,
-				Key:     objectKey,
-			}
-		}
-		if retryMeta.Generation != generation {
-			return &s3ResponseError{
-				Status:  http.StatusNotFound,
-				Code:    "NoSuchUpload",
-				Message: "upload not found (bucket was recreated)",
-				Bucket:  bucket,
-				Key:     objectKey,
-			}
-		}
-
-		// Re-verify upload still exists (fence against concurrent Abort).
-		if _, err := s.store.GetAt(r.Context(), uploadMetaKey, retryReadTS); err != nil {
-			if errors.Is(err, store.ErrKeyNotFound) {
-				return &s3ResponseError{
-					Status:  http.StatusNotFound,
-					Code:    "NoSuchUpload",
-					Message: "upload not found",
-					Bucket:  bucket,
-					Key:     objectKey,
-				}
-			}
-			return errors.WithStack(err)
-		}
-
-		commitTS, err := s.nextTxnCommitTS(r.Context(), startTS)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-
-		headKey := s3keys.ObjectManifestKey(bucket, retryMeta.Generation, objectKey)
-		previous, _, err = s.loadObjectManifestAt(r.Context(), headKey, retryReadTS)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-
-		manifest := &s3ObjectManifest{
-			UploadID:        uploadID,
-			ETag:            compositeETag,
-			SizeBytes:       totalSize,
-			LastModifiedHLC: commitTS,
-			ContentType:     uploadMeta.ContentType,
-			UserMetadata:    uploadMeta.Metadata,
-			Parts:           manifestParts,
-		}
-		manifestBody, err := encodeS3ObjectManifest(manifest)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-
-		bucketFence, err := encodeS3BucketMeta(retryMeta)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-
-		// Atomically: fence bucket (conflict with DELETE bucket), write manifest,
-		// delete UploadMeta + GCUpload (fence against Abort).
-		_, err = s.coordinator.Dispatch(r.Context(), &kv.OperationGroup[kv.OP]{
-			IsTxn:    true,
-			StartTS:  startTS,
-			CommitTS: commitTS,
-			Elems: []*kv.Elem[kv.OP]{
-				{Op: kv.Put, Key: s3keys.BucketMetaKey(bucket), Value: bucketFence},
-				{Op: kv.Put, Key: headKey, Value: manifestBody},
-				{Op: kv.Del, Key: uploadMetaKey},
-				{Op: kv.Del, Key: s3keys.GCUploadKey(bucket, meta.Generation, objectKey, uploadID)},
-			},
-		})
-		return errors.WithStack(err)
-	})
+	previous, err := s.commitS3MultipartCompletion(r.Context(), completion)
 	if err != nil {
 		writeS3MutationError(w, err, bucket, objectKey)
 		return
 	}
 
 	if previous != nil {
-		s.cleanupManifestBlobsAsync(bucket, generation, objectKey, previous)
+		s.cleanupManifestBlobsAsync(bucket, completion.generation, objectKey, previous)
 	}
-	s.cleanupUploadPartsAsync(bucket, generation, objectKey, uploadID)
-
+	s.cleanupUploadPartsAsync(bucket, completion.generation, objectKey, uploadID)
 	writeS3XML(w, http.StatusOK, s3CompleteMultipartUploadResult{
 		XMLNS:  s3XMLNamespace,
 		Bucket: bucket,
 		Key:    objectKey,
-		ETag:   quoteS3ETag(compositeETag),
+		ETag:   quoteS3ETag(completion.compositeETag),
 	})
 }
 

--- a/adapter/s3_chunk_upload.go
+++ b/adapter/s3_chunk_upload.go
@@ -1,0 +1,211 @@
+package adapter
+
+import (
+	"context"
+	"crypto/md5" //nolint:gosec // S3 ETag compatibility requires MD5.
+	"crypto/sha256"
+	"encoding/hex"
+	"hash"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/bootjp/elastickv/kv"
+	"github.com/cockroachdb/errors"
+)
+
+type s3ChunkUploadConfig struct {
+	request            *http.Request
+	streamBody         *s3StreamingBody
+	admissionProtocol  string
+	tooLargeMessage    string
+	expectedPayloadSHA string
+	chunkKey           func(chunkNo uint64) []byte
+}
+
+type s3ChunkUploadResult struct {
+	ETag            string
+	SizeBytes       int64
+	ChunkSizes      []uint64
+	PersistedChunks int
+	ChunkCount      uint64
+}
+
+type s3ChunkUploader struct {
+	server            *S3Server
+	ctx               context.Context
+	cfg               s3ChunkUploadConfig
+	result            s3ChunkUploadResult
+	etagHasher        hash.Hash
+	payloadHasher     hash.Hash
+	buf               []byte
+	pendingBatch      []*kv.Elem[kv.OP]
+	pendingChunkSizes []uint64
+	pendingAdmission  []func()
+}
+
+// uploadS3Chunks owns the shared streaming data path for PutObject and
+// UploadPart. It reads and hashes the request body, holds admission capacity
+// until each batch is dispatched, and verifies payload and trailer checksums.
+// The caller remains responsible for protocol setup, metadata transactions,
+// and cleanup of any chunks reported in the result.
+func (s *S3Server) uploadS3Chunks(ctx context.Context, cfg s3ChunkUploadConfig) (s3ChunkUploadResult, *s3PutBodyError, error) {
+	if cfg.request == nil || cfg.request.Body == nil || cfg.chunkKey == nil {
+		return s3ChunkUploadResult{}, nil, errors.New("s3: invalid chunk upload configuration")
+	}
+	uploader := &s3ChunkUploader{
+		server:            s,
+		ctx:               ctx,
+		cfg:               cfg,
+		etagHasher:        md5.New(), //nolint:gosec // S3 ETag compatibility requires MD5.
+		buf:               make([]byte, s3ChunkSize),
+		pendingBatch:      make([]*kv.Elem[kv.OP], 0, s3ChunkBatchOps),
+		pendingChunkSizes: make([]uint64, 0, s3ChunkBatchOps),
+		pendingAdmission:  make([]func(), 0, s3ChunkBatchOps),
+	}
+	if cfg.expectedPayloadSHA != "" {
+		uploader.payloadHasher = sha256.New()
+	}
+	return uploader.run()
+}
+
+func (u *s3ChunkUploader) run() (s3ChunkUploadResult, *s3PutBodyError, error) {
+	defer u.releasePendingAdmission()
+	for {
+		done, bodyErr, err := u.uploadNextChunk()
+		if err != nil || bodyErr != nil {
+			return u.result, bodyErr, err
+		}
+		if done {
+			break
+		}
+	}
+	if err := u.flushBatch(); err != nil {
+		return u.result, nil, err
+	}
+	if bodyErr := u.verifyChecksums(); bodyErr != nil {
+		return u.result, bodyErr, nil
+	}
+	u.result.ETag = hex.EncodeToString(u.etagHasher.Sum(nil))
+	return u.result, nil, nil
+}
+
+func (u *s3ChunkUploader) uploadNextChunk() (bool, *s3PutBodyError, error) {
+	if err := u.flushBeforeRead(); err != nil {
+		return false, nil, err
+	}
+	request := u.cfg.request
+	readBuf, finalRead := nextS3PutReadBuffer(u.buf, u.cfg.admissionProtocol, request.ContentLength, u.result.SizeBytes)
+	if len(readBuf) == 0 {
+		return true, nil, nil
+	}
+	release, err := u.server.acquireS3PutAdmissionForRead(u.ctx, len(readBuf), u.cfg.admissionProtocol, u.cfg.streamBody, u.result.SizeBytes)
+	if err != nil {
+		return false, nil, errors.WithStack(err)
+	}
+	allowFinalPartial := s3PutReadAllowsFinalPartial(u.cfg.admissionProtocol, request.ContentLength)
+	n, readErr := readS3PutChunk(request.Body, readBuf, allowFinalPartial, finalRead)
+	if readErr != nil && !errors.Is(readErr, io.EOF) {
+		release()
+		return u.classifyReadError(readErr)
+	}
+	if n == 0 {
+		release()
+		return errors.Is(readErr, io.EOF), nil, nil
+	}
+	if err := u.appendChunk(readBuf[:n], release); err != nil {
+		return false, nil, err
+	}
+	if err := u.flushFullBatch(); err != nil {
+		return false, nil, err
+	}
+	return errors.Is(readErr, io.EOF), nil, nil
+}
+
+func (u *s3ChunkUploader) flushBeforeRead() error {
+	if !u.server.shouldFlushS3PutBatchBeforeRead(u.cfg.admissionProtocol, len(u.pendingAdmission)) {
+		return nil
+	}
+	return u.flushBatch()
+}
+
+func (u *s3ChunkUploader) flushFullBatch() error {
+	if len(u.pendingBatch) < s3ChunkBatchOps {
+		return nil
+	}
+	return u.flushBatch()
+}
+
+func (u *s3ChunkUploader) classifyReadError(err error) (bool, *s3PutBodyError, error) {
+	if bodyErr, ok := classifyS3BodyReadErr(err, u.cfg.tooLargeMessage); ok {
+		return false, bodyErr, nil
+	}
+	return false, nil, errors.WithStack(err)
+}
+
+func (u *s3ChunkUploader) appendChunk(data []byte, release func()) error {
+	u.pendingAdmission = append(u.pendingAdmission, release)
+	chunk := append([]byte(nil), data...)
+	if _, err := u.etagHasher.Write(chunk); err != nil {
+		return errors.WithStack(err)
+	}
+	if u.payloadHasher != nil {
+		if _, err := u.payloadHasher.Write(chunk); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+	u.cfg.streamBody.writeDecoded(chunk)
+	u.pendingBatch = append(u.pendingBatch, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   u.cfg.chunkKey(u.result.ChunkCount),
+		Value: chunk,
+	})
+	chunkSize, err := uint64FromInt(len(data))
+	if err != nil {
+		return err
+	}
+	u.result.ChunkSizes = append(u.result.ChunkSizes, chunkSize)
+	u.pendingChunkSizes = append(u.pendingChunkSizes, chunkSize)
+	u.result.SizeBytes += int64(len(data))
+	u.result.ChunkCount++
+	return nil
+}
+
+func (u *s3ChunkUploader) flushBatch() error {
+	if len(u.pendingBatch) == 0 {
+		return nil
+	}
+	_, err := u.server.coordinator.Dispatch(u.ctx, &kv.OperationGroup[kv.OP]{Elems: u.pendingBatch})
+	u.releasePendingAdmission()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	u.result.PersistedChunks += len(u.pendingChunkSizes)
+	u.pendingBatch = u.pendingBatch[:0]
+	u.pendingChunkSizes = u.pendingChunkSizes[:0]
+	return nil
+}
+
+func (u *s3ChunkUploader) releasePendingAdmission() {
+	for _, release := range u.pendingAdmission {
+		release()
+	}
+	u.pendingAdmission = u.pendingAdmission[:0]
+}
+
+func (u *s3ChunkUploader) verifyChecksums() *s3PutBodyError {
+	if u.payloadHasher != nil {
+		actualPayloadSHA := hex.EncodeToString(u.payloadHasher.Sum(nil))
+		if !strings.EqualFold(actualPayloadSHA, u.cfg.expectedPayloadSHA) {
+			return &s3PutBodyError{
+				Status:  http.StatusBadRequest,
+				Code:    "XAmzContentSHA256Mismatch",
+				Message: "payload SHA256 does not match x-amz-content-sha256",
+			}
+		}
+	}
+	if err := u.cfg.streamBody.verifyTrailer(); err != nil {
+		return &s3PutBodyError{Status: http.StatusBadRequest, Code: "BadDigest", Message: err.Error()}
+	}
+	return nil
+}

--- a/adapter/s3_chunk_upload.go
+++ b/adapter/s3_chunk_upload.go
@@ -50,9 +50,6 @@ type s3ChunkUploader struct {
 // The caller remains responsible for protocol setup, metadata transactions,
 // and cleanup of any chunks reported in the result.
 func (s *S3Server) uploadS3Chunks(ctx context.Context, cfg s3ChunkUploadConfig) (s3ChunkUploadResult, *s3PutBodyError, error) {
-	if cfg.request == nil || cfg.request.Body == nil || cfg.chunkKey == nil {
-		return s3ChunkUploadResult{}, nil, errors.New("s3: invalid chunk upload configuration")
-	}
 	uploader := &s3ChunkUploader{
 		server:            s,
 		ctx:               ctx,
@@ -160,10 +157,7 @@ func (u *s3ChunkUploader) appendChunk(data []byte, release func()) error {
 		Key:   u.cfg.chunkKey(u.result.ChunkCount),
 		Value: chunk,
 	})
-	chunkSize, err := uint64FromInt(len(data))
-	if err != nil {
-		return err
-	}
+	chunkSize := uint64(len(data))
 	u.result.ChunkSizes = append(u.result.ChunkSizes, chunkSize)
 	u.pendingChunkSizes = append(u.pendingChunkSizes, chunkSize)
 	u.result.SizeBytes += int64(len(data))

--- a/adapter/s3_multipart_complete.go
+++ b/adapter/s3_multipart_complete.go
@@ -1,0 +1,241 @@
+package adapter
+
+import (
+	"context"
+	"crypto/md5" //nolint:gosec // S3 composite ETag compatibility requires MD5.
+	"encoding/hex"
+	"encoding/xml"
+	"fmt"
+	"hash"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/bootjp/elastickv/internal/s3keys"
+	"github.com/bootjp/elastickv/kv"
+	"github.com/bootjp/elastickv/store"
+	"github.com/cockroachdb/errors"
+	json "github.com/goccy/go-json"
+)
+
+type s3MultipartCompletion struct {
+	bucket        string
+	objectKey     string
+	uploadID      string
+	generation    uint64
+	uploadMetaKey []byte
+	uploadMeta    s3UploadMeta
+	manifestParts []s3ObjectPart
+	totalSize     int64
+	compositeETag string
+}
+
+func parseS3MultipartCompletion(body io.Reader, bucket, objectKey string) (s3CompleteMultipartUploadRequest, error) {
+	var request s3CompleteMultipartUploadRequest
+	bodyBytes, err := io.ReadAll(io.LimitReader(body, s3ChunkSize))
+	if err != nil {
+		return request, errors.WithStack(err)
+	}
+	if err := xml.Unmarshal(bodyBytes, &request); err != nil {
+		return request, newS3ResponseError(http.StatusBadRequest, "MalformedXML", "request body is not valid XML", bucket, objectKey)
+	}
+	if err := validateS3MultipartCompletionParts(request.Parts, bucket, objectKey); err != nil {
+		return request, err
+	}
+	return request, nil
+}
+
+func validateS3MultipartCompletionParts(parts []s3CompleteMultipartUploadPart, bucket, objectKey string) error {
+	if len(parts) == 0 {
+		return newS3ResponseError(http.StatusBadRequest, "InvalidArgument", "at least one part is required", bucket, objectKey)
+	}
+	if len(parts) > s3MaxPartsPerUpload {
+		message := fmt.Sprintf("too many parts in CompleteMultipartUpload request (maximum %d)", s3MaxPartsPerUpload)
+		return newS3ResponseError(http.StatusBadRequest, "InvalidArgument", message, bucket, objectKey)
+	}
+	for i, part := range parts {
+		if part.PartNumber < s3MinPartNumber || part.PartNumber > s3MaxPartNumber {
+			return newS3ResponseError(http.StatusBadRequest, "InvalidArgument", "part number out of allowed range", bucket, objectKey)
+		}
+		if i > 0 && part.PartNumber <= parts[i-1].PartNumber {
+			return newS3ResponseError(http.StatusBadRequest, "InvalidPartOrder", "parts must be in ascending order", bucket, objectKey)
+		}
+	}
+	return nil
+}
+
+func (s *S3Server) loadS3MultipartCompletion(ctx context.Context, bucket, objectKey, uploadID string, request s3CompleteMultipartUploadRequest) (s3MultipartCompletion, error) {
+	completion := s3MultipartCompletion{bucket: bucket, objectKey: objectKey, uploadID: uploadID}
+	readTS := s.readTS()
+	readPin := s.pinReadTS(readTS)
+	defer readPin.Release()
+
+	meta, exists, err := s.loadBucketMetaAt(ctx, bucket, readTS)
+	if err != nil {
+		return completion, errors.WithStack(err)
+	}
+	if !exists || meta == nil {
+		return completion, newS3ResponseError(http.StatusNotFound, "NoSuchBucket", "bucket not found", bucket, objectKey)
+	}
+	completion.generation = meta.Generation
+	completion.uploadMetaKey = s3keys.UploadMetaKey(bucket, meta.Generation, objectKey, uploadID)
+	if err := s.loadS3MultipartUploadMeta(ctx, readTS, &completion); err != nil {
+		return completion, err
+	}
+	if err := s.loadS3MultipartParts(ctx, readTS, request.Parts, &completion); err != nil {
+		return completion, err
+	}
+	return completion, nil
+}
+
+func (s *S3Server) loadS3MultipartUploadMeta(ctx context.Context, readTS uint64, completion *s3MultipartCompletion) error {
+	raw, err := s.store.GetAt(ctx, completion.uploadMetaKey, readTS)
+	if err != nil {
+		if errors.Is(err, store.ErrKeyNotFound) {
+			return newS3ResponseError(http.StatusNotFound, "NoSuchUpload", "upload not found", completion.bucket, completion.objectKey)
+		}
+		return errors.WithStack(err)
+	}
+	return errors.WithStack(json.Unmarshal(raw, &completion.uploadMeta))
+}
+
+func (s *S3Server) loadS3MultipartParts(ctx context.Context, readTS uint64, requested []s3CompleteMultipartUploadPart, completion *s3MultipartCompletion) error {
+	completion.manifestParts = make([]s3ObjectPart, 0, len(requested))
+	md5Concat := md5.New() //nolint:gosec // S3 composite ETag compatibility requires MD5.
+	for i, requestedPart := range requested {
+		part, partMD5, err := s.loadS3MultipartPart(ctx, readTS, requestedPart, i == len(requested)-1, completion)
+		if err != nil {
+			return err
+		}
+		if _, err := md5Concat.Write(partMD5); err != nil {
+			return errors.WithStack(err)
+		}
+		completion.manifestParts = append(completion.manifestParts, part)
+		completion.totalSize += part.SizeBytes
+	}
+	completion.compositeETag = multipartCompositeETag(md5Concat, len(requested))
+	return nil
+}
+
+func (s *S3Server) loadS3MultipartPart(ctx context.Context, readTS uint64, requested s3CompleteMultipartUploadPart, last bool, completion *s3MultipartCompletion) (s3ObjectPart, []byte, error) {
+	partNo, err := uint64FromInt(requested.PartNumber)
+	if err != nil {
+		return s3ObjectPart{}, nil, errors.WithStack(err)
+	}
+	partKey := s3keys.UploadPartKey(completion.bucket, completion.generation, completion.objectKey, completion.uploadID, partNo)
+	raw, err := s.store.GetAt(ctx, partKey, readTS)
+	if err != nil {
+		if errors.Is(err, store.ErrKeyNotFound) {
+			message := fmt.Sprintf("part %d not found", requested.PartNumber)
+			return s3ObjectPart{}, nil, newS3ResponseError(http.StatusBadRequest, "InvalidPart", message, completion.bucket, completion.objectKey)
+		}
+		return s3ObjectPart{}, nil, errors.WithStack(err)
+	}
+	var descriptor s3PartDescriptor
+	if err := json.Unmarshal(raw, &descriptor); err != nil {
+		return s3ObjectPart{}, nil, errors.WithStack(err)
+	}
+	requestedETag := strings.Trim(requested.ETag, `"`)
+	if requestedETag != descriptor.ETag {
+		message := fmt.Sprintf("part %d ETag mismatch: got %q, want %q", requested.PartNumber, requestedETag, descriptor.ETag)
+		return s3ObjectPart{}, nil, newS3ResponseError(http.StatusBadRequest, "InvalidPart", message, completion.bucket, completion.objectKey)
+	}
+	if !last && descriptor.SizeBytes < int64(s3MinPartSize) {
+		message := fmt.Sprintf("part %d is too small (%d bytes)", requested.PartNumber, descriptor.SizeBytes)
+		return s3ObjectPart{}, nil, newS3ResponseError(http.StatusBadRequest, "EntityTooSmall", message, completion.bucket, completion.objectKey)
+	}
+	partMD5, err := hex.DecodeString(descriptor.ETag)
+	if err != nil {
+		return s3ObjectPart{}, nil, errors.WithStack(err)
+	}
+	return s3ObjectPart(descriptor), partMD5, nil
+}
+
+func multipartCompositeETag(md5Concat hash.Hash, partCount int) string {
+	return hex.EncodeToString(md5Concat.Sum(nil)) + fmt.Sprintf("-%d", partCount)
+}
+
+func (s *S3Server) commitS3MultipartCompletion(ctx context.Context, completion s3MultipartCompletion) (*s3ObjectManifest, error) {
+	var previous *s3ObjectManifest
+	err := s.retryS3Mutation(ctx, func() error {
+		var err error
+		previous, err = s.commitS3MultipartCompletionAttempt(ctx, completion)
+		return err
+	})
+	return previous, err
+}
+
+func (s *S3Server) commitS3MultipartCompletionAttempt(ctx context.Context, completion s3MultipartCompletion) (*s3ObjectManifest, error) {
+	readTS := s.readTS()
+	startTS, err := s.txnStartTS(ctx, readTS)
+	if err != nil {
+		return nil, errors.Wrap(err, "s3: allocate startTS for completeMultipartUpload retry")
+	}
+	readPin := s.pinReadTS(readTS)
+	defer readPin.Release()
+
+	meta, err := s.validateS3MultipartCommitFences(ctx, readTS, completion)
+	if err != nil {
+		return nil, err
+	}
+	commitTS, err := s.nextTxnCommitTS(ctx, startTS)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	headKey := s3keys.ObjectManifestKey(completion.bucket, meta.Generation, completion.objectKey)
+	previous, _, err := s.loadObjectManifestAt(ctx, headKey, readTS)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	manifestBody, err := encodeS3ObjectManifest(&s3ObjectManifest{
+		UploadID:        completion.uploadID,
+		ETag:            completion.compositeETag,
+		SizeBytes:       completion.totalSize,
+		LastModifiedHLC: commitTS,
+		ContentType:     completion.uploadMeta.ContentType,
+		UserMetadata:    completion.uploadMeta.Metadata,
+		Parts:           completion.manifestParts,
+	})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	bucketFence, err := encodeS3BucketMeta(meta)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	_, err = s.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+		IsTxn:    true,
+		StartTS:  startTS,
+		CommitTS: commitTS,
+		Elems: []*kv.Elem[kv.OP]{
+			{Op: kv.Put, Key: s3keys.BucketMetaKey(completion.bucket), Value: bucketFence},
+			{Op: kv.Put, Key: headKey, Value: manifestBody},
+			{Op: kv.Del, Key: completion.uploadMetaKey},
+			{Op: kv.Del, Key: s3keys.GCUploadKey(completion.bucket, completion.generation, completion.objectKey, completion.uploadID)},
+		},
+	})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return previous, nil
+}
+
+func (s *S3Server) validateS3MultipartCommitFences(ctx context.Context, readTS uint64, completion s3MultipartCompletion) (*s3BucketMeta, error) {
+	meta, exists, err := s.loadBucketMetaAt(ctx, completion.bucket, readTS)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if !exists || meta == nil {
+		return nil, newS3ResponseError(http.StatusNotFound, "NoSuchBucket", "bucket not found", completion.bucket, completion.objectKey)
+	}
+	if meta.Generation != completion.generation {
+		return nil, newS3ResponseError(http.StatusNotFound, "NoSuchUpload", "upload not found (bucket was recreated)", completion.bucket, completion.objectKey)
+	}
+	if _, err := s.store.GetAt(ctx, completion.uploadMetaKey, readTS); err != nil {
+		if errors.Is(err, store.ErrKeyNotFound) {
+			return nil, newS3ResponseError(http.StatusNotFound, "NoSuchUpload", "upload not found", completion.bucket, completion.objectKey)
+		}
+		return nil, errors.WithStack(err)
+	}
+	return meta, nil
+}

--- a/adapter/s3_multipart_complete.go
+++ b/adapter/s3_multipart_complete.go
@@ -118,10 +118,7 @@ func (s *S3Server) loadS3MultipartParts(ctx context.Context, readTS uint64, requ
 }
 
 func (s *S3Server) loadS3MultipartPart(ctx context.Context, readTS uint64, requested s3CompleteMultipartUploadPart, last bool, completion *s3MultipartCompletion) (s3ObjectPart, []byte, error) {
-	partNo, err := uint64FromInt(requested.PartNumber)
-	if err != nil {
-		return s3ObjectPart{}, nil, errors.WithStack(err)
-	}
+	partNo := uint64(requested.PartNumber) //nolint:gosec // validated by validateS3MultipartCompletionParts before loading parts.
 	partKey := s3keys.UploadPartKey(completion.bucket, completion.generation, completion.objectKey, completion.uploadID, partNo)
 	raw, err := s.store.GetAt(ctx, partKey, readTS)
 	if err != nil {

--- a/adapter/s3_put_object.go
+++ b/adapter/s3_put_object.go
@@ -1,0 +1,142 @@
+package adapter
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/bootjp/elastickv/internal/s3keys"
+	"github.com/bootjp/elastickv/kv"
+	"github.com/cockroachdb/errors"
+)
+
+type s3PutObjectState struct {
+	startTS  uint64
+	meta     *s3BucketMeta
+	headKey  []byte
+	previous *s3ObjectManifest
+	uploadID string
+	readPin  *kv.ActiveTimestampToken
+}
+
+func (s *S3Server) prepareS3PutObject(ctx context.Context, request *http.Request, bucket, objectKey string) (*s3PutObjectState, error) {
+	readTS := s.readTS()
+	startTS, err := s.txnStartTS(ctx, readTS)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	state := &s3PutObjectState{startTS: startTS, readPin: s.pinReadTS(readTS)}
+	prepared := false
+	defer func() {
+		if !prepared {
+			state.readPin.Release()
+		}
+	}()
+
+	meta, exists, err := s.loadBucketMetaAt(ctx, bucket, readTS)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if !exists || meta == nil {
+		return nil, newS3ResponseError(http.StatusNotFound, "NoSuchBucket", "bucket not found", bucket, objectKey)
+	}
+	state.meta = meta
+	state.headKey = s3keys.ObjectManifestKey(bucket, meta.Generation, objectKey)
+	state.previous, _, err = s.loadObjectManifestAt(ctx, state.headKey, readTS)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if err := validateS3PutPreconditions(request, state.previous); err != nil {
+		return nil, newS3ResponseError(http.StatusPreconditionFailed, "PreconditionFailed", err.Error(), bucket, objectKey)
+	}
+	state.uploadID = newS3UploadID(s.clock())
+	prepared = true
+	return state, nil
+}
+
+func (s *S3Server) uploadS3ObjectData(ctx context.Context, request *http.Request, streamBody *s3StreamingBody, state *s3PutObjectState, bucket, objectKey, expectedPayloadSHA string) (s3ChunkUploadResult, *s3PutBodyError, error) {
+	payloadChecksum := expectedPayloadSHA
+	if isS3PayloadMarker(payloadChecksum) {
+		payloadChecksum = ""
+	}
+	return s.uploadS3Chunks(ctx, s3ChunkUploadConfig{
+		request:            request,
+		streamBody:         streamBody,
+		admissionProtocol:  s3PutAdmissionProtocolForPayload(expectedPayloadSHA),
+		tooLargeMessage:    "object exceeds maximum allowed size",
+		expectedPayloadSHA: payloadChecksum,
+		chunkKey: func(chunkNo uint64) []byte {
+			return s3keys.BlobKey(bucket, state.meta.Generation, objectKey, state.uploadID, 1, chunkNo)
+		},
+	})
+}
+
+func (s *S3Server) cleanupS3PutObjectChunks(ctx context.Context, state *s3PutObjectState, upload s3ChunkUploadResult, bucket, objectKey string) {
+	part := s3ObjectPart{PartNo: 1, ChunkSizes: upload.ChunkSizes[:upload.PersistedChunks]}
+	manifest := &s3ObjectManifest{UploadID: state.uploadID}
+	if len(part.ChunkSizes) > 0 {
+		manifest.Parts = []s3ObjectPart{part}
+	}
+	s.cleanupManifestBlobs(ctx, bucket, state.meta.Generation, objectKey, manifest)
+}
+
+func (s *S3Server) commitS3PutObject(ctx context.Context, request *http.Request, state *s3PutObjectState, upload s3ChunkUploadResult, bucket string) (bool, error) {
+	commitTS, err := s.nextTxnCommitTS(ctx, state.startTS)
+	if err != nil {
+		return false, errors.WithStack(err)
+	}
+	manifest := &s3ObjectManifest{
+		UploadID:           state.uploadID,
+		ETag:               upload.ETag,
+		SizeBytes:          upload.SizeBytes,
+		LastModifiedHLC:    commitTS,
+		ContentType:        headerOrDefault(request.Header.Get("Content-Type"), "application/octet-stream"),
+		ContentEncoding:    cleanStoredContentEncoding(request.Header.Get("Content-Encoding")),
+		CacheControl:       request.Header.Get("Cache-Control"),
+		ContentDisposition: request.Header.Get("Content-Disposition"),
+		UserMetadata:       collectS3UserMetadata(request.Header),
+	}
+	if upload.SizeBytes > 0 {
+		manifest.Parts = []s3ObjectPart{{
+			PartNo: 1, ETag: upload.ETag, SizeBytes: upload.SizeBytes,
+			ChunkCount: upload.ChunkCount, ChunkSizes: upload.ChunkSizes,
+		}}
+	}
+	body, err := encodeS3ObjectManifest(manifest)
+	if err != nil {
+		return false, errors.WithStack(err)
+	}
+	bucketFence, err := encodeS3BucketMeta(state.meta)
+	if err != nil {
+		return false, errors.WithStack(err)
+	}
+	_, err = s.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+		IsTxn:    true,
+		StartTS:  state.startTS,
+		CommitTS: commitTS,
+		Elems: []*kv.Elem[kv.OP]{
+			{Op: kv.Put, Key: s3keys.BucketMetaKey(bucket), Value: bucketFence},
+			{Op: kv.Put, Key: state.headKey, Value: body},
+		},
+	})
+	return true, errors.WithStack(err)
+}
+
+func writeS3PutObjectCommitError(w http.ResponseWriter, err error, mutationAttempted bool, bucket, objectKey string) {
+	if mutationAttempted {
+		writeS3MutationError(w, err, bucket, objectKey)
+		return
+	}
+	writeS3InternalError(w, err)
+}
+
+func (s *S3Server) writeS3ChunkUploadError(w http.ResponseWriter, bodyErr *s3PutBodyError, err error, bucket, objectKey string) {
+	if bodyErr != nil {
+		writeS3Error(w, bodyErr.Status, bodyErr.Code, bodyErr.Message, bucket, objectKey)
+		return
+	}
+	if errors.Is(err, errS3PutAdmissionExhausted) {
+		writeS3AdmissionError(w, bucket, objectKey, s.s3PutAdmissionRetryAfter())
+		return
+	}
+	writeS3ResponseOrInternalError(w, err)
+}

--- a/adapter/s3_upload_part.go
+++ b/adapter/s3_upload_part.go
@@ -58,8 +58,7 @@ func parseS3UploadPartNumber(raw, bucket, objectKey string) (uint64, error) {
 	if err != nil || partNumber < s3MinPartNumber || partNumber > s3MaxPartNumber {
 		return 0, newS3ResponseError(http.StatusBadRequest, "InvalidArgument", "part number must be between 1 and 10000", bucket, objectKey)
 	}
-	partNo, err := uint64FromInt(partNumber)
-	return partNo, errors.WithStack(err)
+	return uint64(partNumber), nil
 }
 
 func (s *S3Server) storeS3UploadPart(ctx context.Context, request *http.Request, streamBody *s3StreamingBody, state *s3UploadPartState, bucket, objectKey, uploadID, admissionProtocol string) (s3ChunkUploadResult, *s3PartDescriptor, *s3PutBodyError, error) {

--- a/adapter/s3_upload_part.go
+++ b/adapter/s3_upload_part.go
@@ -1,0 +1,153 @@
+package adapter
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	"github.com/bootjp/elastickv/internal/s3keys"
+	"github.com/bootjp/elastickv/kv"
+	"github.com/bootjp/elastickv/store"
+	"github.com/cockroachdb/errors"
+	json "github.com/goccy/go-json"
+)
+
+type s3UploadPartState struct {
+	partNo        uint64
+	readTS        uint64
+	meta          *s3BucketMeta
+	uploadMetaKey []byte
+	readPin       *kv.ActiveTimestampToken
+}
+
+func (s *S3Server) prepareS3UploadPart(ctx context.Context, bucket, objectKey, uploadID, partNumberRaw string) (*s3UploadPartState, error) {
+	partNo, err := parseS3UploadPartNumber(partNumberRaw, bucket, objectKey)
+	if err != nil {
+		return nil, err
+	}
+	state := &s3UploadPartState{partNo: partNo, readTS: s.readTS()}
+	state.readPin = s.pinReadTS(state.readTS)
+	prepared := false
+	defer func() {
+		if !prepared {
+			state.readPin.Release()
+		}
+	}()
+
+	meta, exists, err := s.loadBucketMetaAt(ctx, bucket, state.readTS)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if !exists || meta == nil {
+		return nil, newS3ResponseError(http.StatusNotFound, "NoSuchBucket", "bucket not found", bucket, objectKey)
+	}
+	state.meta = meta
+	state.uploadMetaKey = s3keys.UploadMetaKey(bucket, meta.Generation, objectKey, uploadID)
+	if _, err := s.store.GetAt(ctx, state.uploadMetaKey, state.readTS); err != nil {
+		if errors.Is(err, store.ErrKeyNotFound) {
+			return nil, newS3ResponseError(http.StatusNotFound, "NoSuchUpload", "upload not found", bucket, objectKey)
+		}
+		return nil, errors.WithStack(err)
+	}
+	prepared = true
+	return state, nil
+}
+
+func parseS3UploadPartNumber(raw, bucket, objectKey string) (uint64, error) {
+	partNumber, err := strconv.Atoi(raw)
+	if err != nil || partNumber < s3MinPartNumber || partNumber > s3MaxPartNumber {
+		return 0, newS3ResponseError(http.StatusBadRequest, "InvalidArgument", "part number must be between 1 and 10000", bucket, objectKey)
+	}
+	partNo, err := uint64FromInt(partNumber)
+	return partNo, errors.WithStack(err)
+}
+
+func (s *S3Server) storeS3UploadPart(ctx context.Context, request *http.Request, streamBody *s3StreamingBody, state *s3UploadPartState, bucket, objectKey, uploadID, admissionProtocol string) (s3ChunkUploadResult, *s3PartDescriptor, *s3PutBodyError, error) {
+	startTS, commitTS, err := s.allocateS3UploadPartVersion(ctx)
+	if err != nil {
+		return s3ChunkUploadResult{}, nil, nil, err
+	}
+	upload, bodyErr, err := s.uploadS3Chunks(ctx, s3ChunkUploadConfig{
+		request:           request,
+		streamBody:        streamBody,
+		admissionProtocol: admissionProtocol,
+		tooLargeMessage:   "part exceeds maximum allowed size",
+		chunkKey: func(chunkNo uint64) []byte {
+			return s3keys.VersionedBlobKey(bucket, state.meta.Generation, objectKey, uploadID, state.partNo, chunkNo, commitTS)
+		},
+	})
+	committed := false
+	defer func() {
+		if !committed && upload.ChunkCount > 0 {
+			s.cleanupPartBlobsAsync(bucket, state.meta.Generation, objectKey, uploadID, state.partNo, upload.ChunkCount, commitTS)
+		}
+	}()
+	if err != nil || bodyErr != nil {
+		return upload, nil, bodyErr, err
+	}
+	previous, err := s.commitS3UploadPart(ctx, state, upload, bucket, objectKey, uploadID, startTS, commitTS)
+	if err != nil {
+		return upload, nil, nil, err
+	}
+	committed = true
+	return upload, previous, nil, nil
+}
+
+func (s *S3Server) allocateS3UploadPartVersion(ctx context.Context) (uint64, uint64, error) {
+	readTS := s.readTS()
+	startTS, err := s.txnStartTS(ctx, readTS)
+	if err != nil {
+		return 0, 0, errors.WithStack(err)
+	}
+	commitTS, err := s.nextTxnCommitTS(ctx, startTS)
+	if err != nil {
+		return 0, 0, errors.WithStack(err)
+	}
+	return startTS, commitTS, nil
+}
+
+func (s *S3Server) commitS3UploadPart(ctx context.Context, state *s3UploadPartState, upload s3ChunkUploadResult, bucket, objectKey, uploadID string, startTS, commitTS uint64) (*s3PartDescriptor, error) {
+	descriptor := &s3PartDescriptor{
+		PartNo: state.partNo, ETag: upload.ETag, SizeBytes: upload.SizeBytes,
+		ChunkCount: upload.ChunkCount, ChunkSizes: upload.ChunkSizes, PartVersion: commitTS,
+	}
+	body, err := json.Marshal(descriptor)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	partKey := s3keys.UploadPartKey(bucket, state.meta.Generation, objectKey, uploadID, state.partNo)
+	previous := s.loadPreviousS3PartDescriptor(ctx, partKey, state.readTS)
+	if err := s.verifyS3UploadStillExists(ctx, state.uploadMetaKey, bucket, objectKey); err != nil {
+		return nil, err
+	}
+	_, err = s.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+		IsTxn: true, StartTS: startTS, CommitTS: commitTS,
+		Elems: []*kv.Elem[kv.OP]{{Op: kv.Put, Key: partKey, Value: body}},
+	})
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return previous, nil
+}
+
+func (s *S3Server) loadPreviousS3PartDescriptor(ctx context.Context, partKey []byte, readTS uint64) *s3PartDescriptor {
+	raw, err := s.store.GetAt(ctx, partKey, readTS)
+	if err != nil {
+		return nil
+	}
+	var descriptor s3PartDescriptor
+	if json.Unmarshal(raw, &descriptor) != nil {
+		return nil
+	}
+	return &descriptor
+}
+
+func (s *S3Server) verifyS3UploadStillExists(ctx context.Context, uploadMetaKey []byte, bucket, objectKey string) error {
+	if _, err := s.store.GetAt(ctx, uploadMetaKey, s.readTS()); err != nil {
+		if errors.Is(err, store.ErrKeyNotFound) {
+			return newS3ResponseError(http.StatusNotFound, "NoSuchUpload", "upload not found", bucket, objectKey)
+		}
+		return errors.WithStack(err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- extract the shared S3 chunk upload pipeline used by PutObject and UploadPart
- split PutObject and UploadPart preparation, persistence, cleanup, and response handling into focused helpers
- split CompleteMultipartUpload into request validation, part loading, fence validation, and atomic commit phases
- remove complexity suppressions from the refactored write handlers

## Impact

This is a behavior-preserving refactor. S3 request validation, admission control, chunk batching, checksum and trailer verification, generation fencing, upload fencing, and orphan cleanup remain in place while the HTTP handlers become small orchestration functions.

## Risk

The main risk is changing error or cleanup ordering in the S3 write path. The extracted pipeline retains admission releases at batch dispatch boundaries, tracks only persisted chunks for PutObject cleanup, keeps per-attempt part versions for UploadPart, and preserves bucket generation and upload existence fences for multipart completion.

## Validation

- `go test ./adapter -run '^Test(S3|ReadS3|PrepareStreaming|AWSChunked|IsS3)' -count=1 -timeout=5m`
- `go test ./... -run '^$' -count=1 -timeout=5m`
- `golangci-lint run ./... --timeout=5m --allow-parallel-runners`
- `git diff --check origin/main...HEAD`

## Review passes

- Data loss: no issues found; atomic manifest commits and persisted-chunk cleanup boundaries are preserved.
- Concurrency and distributed failures: no issues found; read timestamp pins and generation/upload fences remain active.
- Performance: no issues found; chunk buffer size, batch size, and admission-release timing are unchanged.
- Error handling: no issues found; protocol, admission, internal, and mutation errors retain their response paths.
- API compatibility: no issues found; S3 statuses, ETags, payload checksums, and multipart validation are covered by the existing regression suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * S3互換のPUTおよびマルチパートアップロード処理を改善しました。
  * 大容量データをチャンク単位で効率的に処理し、アップロードの安定性を向上しました。
  * ETag、チェックサム、トレーラー検証の精度を高めました。
  * マルチパート完了時のパーツ順序、サイズ、ETag検証を強化しました。

* **バグ修正**
  * 不正なリクエストや存在しないバケット・アップロードに対して、より適切なS3形式のエラーを返すよう改善しました。
  * 失敗したアップロードデータの後処理を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->