### PR TITLE
kv: yield lock resolver under raft pressure

### DIFF
--- a/kv/lock_resolver.go
+++ b/kv/lock_resolver.go
@@ -202,9 +202,6 @@ func (lr *LockResolver) resolveScannedLock(ctx context.Context, gid uint64, g *S
 	if !txnLockExpired(lock) {
 		return lockResolveSkippedActive, nil
 	}
-	if !lr.primaryGroupReadyForBackgroundResolve(lock.PrimaryKey) {
-		return lockResolveIgnored, nil
-	}
 
 	opCtx, cancel := context.WithTimeout(ctx, lockResolverOperationBudget)
 	defer cancel()
@@ -237,7 +234,7 @@ func (lr *LockResolver) groupReadyForBackgroundResolve(ctx context.Context, gid 
 	return ready
 }
 
-func (lr *LockResolver) primaryGroupReadyForBackgroundResolve(primaryKey []byte) bool {
+func (lr *LockResolver) primaryGroupReadyForBackgroundAbort(primaryKey []byte) bool {
 	pg, ok := lr.store.groupForKey(primaryKey)
 	return ok && lockResolverGroupCanResolve(pg)
 }
@@ -298,7 +295,7 @@ func lockResolverBudgetExhausted(err error, workCtx, parentCtx context.Context) 
 }
 
 func (lr *LockResolver) resolveExpiredLock(ctx context.Context, g *ShardGroup, userKey []byte, lock txnLock) error {
-	status, commitTS, err := lr.store.primaryTxnStatus(ctx, lock.PrimaryKey, lock.StartTS)
+	status, commitTS, err := lr.backgroundPrimaryTxnStatus(ctx, lock)
 	if err != nil {
 		return err
 	}
@@ -313,12 +310,33 @@ func (lr *LockResolver) resolveExpiredLock(ctx context.Context, g *ShardGroup, u
 		}
 		return applyTxnResolution(ctx, g, pb.Phase_ABORT, lock.StartTS, abortTS, lock.PrimaryKey, [][]byte{userKey})
 	case txnStatusPending:
-		// Lock is expired but primary is still pending — the primary's
-		// tryAbortExpiredPrimary inside primaryTxnStatus should have
-		// attempted to abort it. If it couldn't (e.g., primary shard
-		// unreachable), we skip and retry next cycle.
+		// Lock is expired but primary is still pending. The background path
+		// skips abort when the primary shard is not locally ready, so retry
+		// cleanup on a later cycle.
 		return nil
 	default:
 		return errors.Wrapf(ErrTxnInvalidMeta, "unknown txn status for key %s", string(userKey))
 	}
+}
+
+func (lr *LockResolver) backgroundPrimaryTxnStatus(ctx context.Context, lock txnLock) (txnStatus, uint64, error) {
+	status, commitTS, done, err := lr.store.primaryTxnRecordedStatus(ctx, lock.PrimaryKey, lock.StartTS)
+	if err != nil || done {
+		return status, commitTS, err
+	}
+
+	primaryLock, locked, err := lr.store.primaryTxnLock(ctx, lock.PrimaryKey, lock.StartTS)
+	if err != nil {
+		return txnStatusPending, 0, err
+	}
+	if !locked {
+		return txnStatusRolledBack, 0, nil
+	}
+	if !txnLockExpired(primaryLock) {
+		return txnStatusPending, 0, nil
+	}
+	if !lr.primaryGroupReadyForBackgroundAbort(lock.PrimaryKey) {
+		return txnStatusPending, 0, nil
+	}
+	return lr.store.expiredPrimaryTxnStatus(ctx, lock.PrimaryKey, lock.StartTS)
 }

--- a/kv/lock_resolver.go
+++ b/kv/lock_resolver.go
@@ -81,23 +81,22 @@ func (lr *LockResolver) run(ctx context.Context) {
 }
 
 func (lr *LockResolver) resolveAllGroups(ctx context.Context) {
+	passCtx, cancel := context.WithTimeout(ctx, lockResolverCycleBudget)
+	defer cancel()
+
 	for gid, g := range lr.groups {
 		if ctx.Err() != nil {
 			return
 		}
-		if !lr.groupReadyForBackgroundResolve(ctx, gid, g) {
-			continue
+		if passCtx.Err() != nil {
+			lr.logLockResolverYield(gid, passCtx.Err())
+			return
 		}
-		groupCtx, cancel := context.WithTimeout(ctx, lockResolverCycleBudget)
-		err := lr.resolveGroupLocks(groupCtx, gid, g)
-		cancel()
+		err := lr.resolveGroupLocks(passCtx, gid, g)
 		if err != nil {
-			if errors.Is(err, errLockResolverBudgetExhausted) || lockResolverBudgetExhausted(err, groupCtx, ctx) {
-				lr.log.Warn("lock resolver: yielding after resolver budget",
-					slog.Uint64("gid", gid),
-					slog.Any("err", err),
-				)
-				continue
+			if errors.Is(err, errLockResolverBudgetExhausted) || lockResolverBudgetExhausted(err, passCtx, ctx) {
+				lr.logLockResolverYield(gid, err)
+				return
 			}
 			lr.log.Warn("lock resolver: group scan failed",
 				slog.Uint64("gid", gid),
@@ -108,7 +107,7 @@ func (lr *LockResolver) resolveAllGroups(ctx context.Context) {
 }
 
 func (lr *LockResolver) resolveGroupLocks(ctx context.Context, gid uint64, g *ShardGroup) error {
-	if !lockResolverGroupCanResolve(g) {
+	if !lr.groupReadyForBackgroundResolve(ctx, gid, g) {
 		return nil
 	}
 
@@ -149,14 +148,19 @@ func (lr *LockResolver) resolveGroupLocks(ctx context.Context, gid uint64, g *Sh
 }
 
 func lockResolverGroupCanResolve(g *ShardGroup) bool {
+	ready, _, _ := lockResolverGroupResolveState(g)
+	return ready
+}
+
+func lockResolverGroupResolveState(g *ShardGroup) (ready bool, overloaded bool, snap *pebble.Metrics) {
 	if g == nil || g.Store == nil {
-		return false
+		return false, false, nil
 	}
 	if !lockResolverRaftReady(engineForGroup(g)) {
-		return false
+		return false, false, nil
 	}
-	overloaded, _ := lockResolverLSMBackpressured(g.Store)
-	return !overloaded
+	overloaded, snap = lockResolverLSMBackpressured(g.Store)
+	return !overloaded, overloaded, snap
 }
 
 func lockResolveOutcomeCounts(outcome lockResolveOutcome) (resolved int, skippedActive int) {
@@ -198,10 +202,13 @@ func (lr *LockResolver) resolveScannedLock(ctx context.Context, gid uint64, g *S
 	if !txnLockExpired(lock) {
 		return lockResolveSkippedActive, nil
 	}
+	if !lr.primaryGroupReadyForBackgroundResolve(lock.PrimaryKey) {
+		return lockResolveIgnored, nil
+	}
 
 	opCtx, cancel := context.WithTimeout(ctx, lockResolverOperationBudget)
+	defer cancel()
 	err = lr.resolveExpiredLock(opCtx, g, userKey, lock)
-	cancel()
 	if err == nil {
 		return lockResolveResolved, nil
 	}
@@ -219,21 +226,27 @@ func (lr *LockResolver) resolveScannedLock(ctx context.Context, gid uint64, g *S
 }
 
 func (lr *LockResolver) groupReadyForBackgroundResolve(ctx context.Context, gid uint64, g *ShardGroup) bool {
-	if g == nil || g.Store == nil {
-		return false
-	}
-	if !lockResolverRaftReady(engineForGroup(g)) {
-		return false
-	}
-	if overloaded, snap := lockResolverLSMBackpressured(g.Store); overloaded {
+	ready, overloaded, snap := lockResolverGroupResolveState(g)
+	if overloaded {
 		lr.log.WarnContext(ctx, "lock resolver: skipping under pebble backpressure",
-			"group_id", gid,
-			"l0_files", snap.Levels[0].TablesCount,
-			"compaction_debt_bytes", snap.Compact.EstimatedDebt,
+			slog.Uint64("gid", gid),
+			slog.Any("l0_files", snap.Levels[0].TablesCount),
+			slog.Any("compaction_debt_bytes", snap.Compact.EstimatedDebt),
 		)
-		return false
 	}
-	return true
+	return ready
+}
+
+func (lr *LockResolver) primaryGroupReadyForBackgroundResolve(primaryKey []byte) bool {
+	pg, ok := lr.store.groupForKey(primaryKey)
+	return ok && lockResolverGroupCanResolve(pg)
+}
+
+func (lr *LockResolver) logLockResolverYield(gid uint64, err error) {
+	lr.log.Warn("lock resolver: yielding after resolver budget",
+		slog.Uint64("gid", gid),
+		slog.Any("err", err),
+	)
 }
 
 func lockResolverRaftReady(engine interface {

--- a/kv/lock_resolver.go
+++ b/kv/lock_resolver.go
@@ -6,8 +6,11 @@ import (
 	"math"
 	"time"
 
+	"github.com/bootjp/elastickv/internal/raftengine"
 	pb "github.com/bootjp/elastickv/proto"
+	"github.com/bootjp/elastickv/store"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/v2"
 )
 
 const (
@@ -15,7 +18,17 @@ const (
 	lockResolverInterval = 10 * time.Second
 	// lockResolverBatchSize limits the number of locks scanned per group per cycle.
 	lockResolverBatchSize = 100
+	// lockResolverCycleBudget caps best-effort cleanup work so it cannot occupy
+	// the Raft leader long enough to starve HLC lease renewal.
+	lockResolverCycleBudget = 500 * time.Millisecond
+	// lockResolverOperationBudget bounds a single background resolution attempt.
+	// Foreground read/write paths still use their own caller deadlines.
+	lockResolverOperationBudget = 250 * time.Millisecond
+	lockResolverMaxL0Files      = defaultFSMCompactorMaxL0Files
+	lockResolverMaxLSMDebtBytes = defaultFSMCompactorMaxLSMDebtBytes
 )
+
+var errLockResolverBudgetExhausted = errors.New("lock resolver budget exhausted")
 
 // LockResolver periodically scans for expired transaction locks and resolves
 // them. This handles the case where secondary commit fails and leaves orphaned
@@ -72,12 +85,20 @@ func (lr *LockResolver) resolveAllGroups(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
-		// Only resolve on the leader and skip during leadership transfer to
-		// avoid a flood of dropped proposals.
-		if !isLeaderAcceptingWrites(engineForGroup(g)) {
+		if !lr.groupReadyForBackgroundResolve(ctx, gid, g) {
 			continue
 		}
-		if err := lr.resolveGroupLocks(ctx, gid, g); err != nil {
+		groupCtx, cancel := context.WithTimeout(ctx, lockResolverCycleBudget)
+		err := lr.resolveGroupLocks(groupCtx, gid, g)
+		cancel()
+		if err != nil {
+			if errors.Is(err, errLockResolverBudgetExhausted) || lockResolverBudgetExhausted(err, groupCtx, ctx) {
+				lr.log.Warn("lock resolver: yielding after resolver budget",
+					slog.Uint64("gid", gid),
+					slog.Any("err", err),
+				)
+				continue
+			}
 			lr.log.Warn("lock resolver: group scan failed",
 				slog.Uint64("gid", gid),
 				slog.Any("err", err),
@@ -87,7 +108,7 @@ func (lr *LockResolver) resolveAllGroups(ctx context.Context) {
 }
 
 func (lr *LockResolver) resolveGroupLocks(ctx context.Context, gid uint64, g *ShardGroup) error {
-	if g.Store == nil {
+	if !lockResolverGroupCanResolve(g) {
 		return nil
 	}
 
@@ -105,36 +126,16 @@ func (lr *LockResolver) resolveGroupLocks(ctx context.Context, gid uint64, g *Sh
 		if ctx.Err() != nil {
 			return errors.WithStack(ctx.Err())
 		}
-		userKey, ok := txnUserKeyFromLockKey(kvp.Key)
-		if !ok {
-			continue
+		if !lockResolverRaftReady(engineForGroup(g)) {
+			return nil
 		}
-
-		lock, err := decodeTxnLock(kvp.Value)
+		outcome, err := lr.resolveScannedLock(ctx, gid, g, kvp)
 		if err != nil {
-			lr.log.Warn("lock resolver: decode lock failed",
-				slog.String("key", string(userKey)),
-				slog.Any("err", err),
-			)
-			continue
+			return err
 		}
-
-		// Only resolve expired locks — active transaction locks are not touched.
-		if !txnLockExpired(lock) {
-			skipped++
-			continue
-		}
-
-		if err := lr.resolveExpiredLock(ctx, g, userKey, lock); err != nil {
-			lr.log.Warn("lock resolver: resolve failed",
-				slog.Uint64("gid", gid),
-				slog.String("key", string(userKey)),
-				slog.Uint64("start_ts", lock.StartTS),
-				slog.Any("err", err),
-			)
-			continue
-		}
-		resolved++
+		resolvedDelta, skippedDelta := lockResolveOutcomeCounts(outcome)
+		resolved += resolvedDelta
+		skipped += skippedDelta
 	}
 
 	if resolved > 0 {
@@ -145,6 +146,142 @@ func (lr *LockResolver) resolveGroupLocks(ctx context.Context, gid uint64, g *Sh
 		)
 	}
 	return nil
+}
+
+func lockResolverGroupCanResolve(g *ShardGroup) bool {
+	if g == nil || g.Store == nil {
+		return false
+	}
+	if !lockResolverRaftReady(engineForGroup(g)) {
+		return false
+	}
+	overloaded, _ := lockResolverLSMBackpressured(g.Store)
+	return !overloaded
+}
+
+func lockResolveOutcomeCounts(outcome lockResolveOutcome) (resolved int, skippedActive int) {
+	switch outcome {
+	case lockResolveResolved:
+		return 1, 0
+	case lockResolveSkippedActive:
+		return 0, 1
+	case lockResolveIgnored:
+		return 0, 0
+	}
+	return 0, 0
+}
+
+type lockResolveOutcome int
+
+const (
+	lockResolveIgnored lockResolveOutcome = iota
+	lockResolveSkippedActive
+	lockResolveResolved
+)
+
+func (lr *LockResolver) resolveScannedLock(ctx context.Context, gid uint64, g *ShardGroup, kvp *store.KVPair) (lockResolveOutcome, error) {
+	userKey, ok := txnUserKeyFromLockKey(kvp.Key)
+	if !ok {
+		return lockResolveIgnored, nil
+	}
+
+	lock, err := decodeTxnLock(kvp.Value)
+	if err != nil {
+		lr.log.Warn("lock resolver: decode lock failed",
+			slog.String("key", string(userKey)),
+			slog.Any("err", err),
+		)
+		return lockResolveIgnored, nil
+	}
+
+	// Only resolve expired locks; active transaction locks are not touched.
+	if !txnLockExpired(lock) {
+		return lockResolveSkippedActive, nil
+	}
+
+	opCtx, cancel := context.WithTimeout(ctx, lockResolverOperationBudget)
+	err = lr.resolveExpiredLock(opCtx, g, userKey, lock)
+	cancel()
+	if err == nil {
+		return lockResolveResolved, nil
+	}
+	if lockResolverBudgetExhausted(err, opCtx, ctx) {
+		marked := errors.Mark(err, errLockResolverBudgetExhausted)
+		return lockResolveIgnored, errors.Wrap(marked, "lock resolver budget exhausted")
+	}
+	lr.log.Warn("lock resolver: resolve failed",
+		slog.Uint64("gid", gid),
+		slog.String("key", string(userKey)),
+		slog.Uint64("start_ts", lock.StartTS),
+		slog.Any("err", err),
+	)
+	return lockResolveIgnored, nil
+}
+
+func (lr *LockResolver) groupReadyForBackgroundResolve(ctx context.Context, gid uint64, g *ShardGroup) bool {
+	if g == nil || g.Store == nil {
+		return false
+	}
+	if !lockResolverRaftReady(engineForGroup(g)) {
+		return false
+	}
+	if overloaded, snap := lockResolverLSMBackpressured(g.Store); overloaded {
+		lr.log.WarnContext(ctx, "lock resolver: skipping under pebble backpressure",
+			"group_id", gid,
+			"l0_files", snap.Levels[0].TablesCount,
+			"compaction_debt_bytes", snap.Compact.EstimatedDebt,
+		)
+		return false
+	}
+	return true
+}
+
+func lockResolverRaftReady(engine interface {
+	raftengine.LeaderView
+	raftengine.StatusReader
+}) bool {
+	if !isLeaderEngine(engine) {
+		return false
+	}
+	status := engine.Status()
+	if status.State != raftengine.StateLeader {
+		return false
+	}
+	if status.LeadTransferee != 0 || status.PendingConfChange {
+		return false
+	}
+	if status.FSMPending > 0 {
+		return false
+	}
+	return status.AppliedIndex >= status.CommitIndex
+}
+
+func lockResolverLSMBackpressured(st store.MVCCStore) (bool, *pebble.Metrics) {
+	source, ok := st.(pebbleMetricsSource)
+	if !ok {
+		return false, nil
+	}
+	snap := source.Metrics()
+	if snap == nil {
+		return false, nil
+	}
+	if lockResolverMaxL0Files > 0 && snap.Levels[0].TablesCount >= lockResolverMaxL0Files {
+		return true, snap
+	}
+	if lockResolverMaxLSMDebtBytes > 0 && snap.Compact.EstimatedDebt >= lockResolverMaxLSMDebtBytes {
+		return true, snap
+	}
+	return false, snap
+}
+
+func lockResolverBudgetExhausted(err error, workCtx, parentCtx context.Context) bool {
+	if err == nil || workCtx == nil {
+		return false
+	}
+	if parentCtx != nil && parentCtx.Err() != nil {
+		return false
+	}
+	return workCtx.Err() != nil && errors.Is(err, workCtx.Err())
 }
 
 func (lr *LockResolver) resolveExpiredLock(ctx context.Context, g *ShardGroup, userKey []byte, lock txnLock) error {

--- a/kv/lock_resolver_test.go
+++ b/kv/lock_resolver_test.go
@@ -107,6 +107,34 @@ func TestLockResolver_ResolvesExpiredCommittedLock(t *testing.T) {
 	require.Equal(t, "v2", string(v))
 }
 
+func TestLockResolver_ResolvesCommittedLockWhenPrimaryGroupBackpressured(t *testing.T) {
+	t.Parallel()
+
+	lr, ss, groups, cleanup := setupLockResolverEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	startTS := uint64(10)
+	commitTS := uint64(20)
+	primaryKey := []byte("b")   // group 1
+	secondaryKey := []byte("n") // group 2
+
+	prepareLock(t, groups[1], startTS, primaryKey, primaryKey, []byte("v1"), 0)
+	prepareLock(t, groups[2], startTS, secondaryKey, primaryKey, []byte("v2"), 0)
+	commitPrimary(t, groups[1], startTS, commitTS, primaryKey)
+
+	metrics := &pebble.Metrics{}
+	metrics.Levels[0].TablesCount = lockResolverMaxL0Files
+	groups[1].Store = &lockResolverBackpressureStore{MVCCStore: groups[1].Store, metrics: metrics}
+
+	err := lr.resolveGroupLocks(ctx, 2, groups[2])
+	require.NoError(t, err)
+
+	v, err := ss.GetAt(ctx, secondaryKey, commitTS)
+	require.NoError(t, err)
+	require.Equal(t, "v2", string(v))
+}
+
 func TestLockResolver_ResolvesExpiredCommittedPrimaryLock(t *testing.T) {
 	t.Parallel()
 
@@ -178,7 +206,7 @@ func TestLockResolver_ResolvesExpiredRolledBackLock(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestLockResolver_SkipsWhenPrimaryGroupBackpressured(t *testing.T) {
+func TestLockResolver_SkipsPendingPrimaryAbortWhenPrimaryGroupBackpressured(t *testing.T) {
 	t.Parallel()
 
 	lr, _, groups, cleanup := setupLockResolverEnv(t)

--- a/kv/lock_resolver_test.go
+++ b/kv/lock_resolver_test.go
@@ -6,8 +6,10 @@ import (
 	"time"
 
 	"github.com/bootjp/elastickv/distribution"
+	"github.com/bootjp/elastickv/internal/raftengine"
 	pb "github.com/bootjp/elastickv/proto"
 	"github.com/bootjp/elastickv/store"
+	"github.com/cockroachdb/pebble/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -258,4 +260,122 @@ func TestLockResolver_CloseStopsBackground(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("LockResolver.Close() did not return within 5s")
 	}
+}
+
+func TestLockResolverRaftReadyRequiresSettledLeader(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		engine any
+		want   bool
+	}{
+		{name: "nil engine", engine: nil},
+		{
+			name: "follower",
+			engine: lockResolverStatusEngine{
+				state:  raftengine.StateFollower,
+				status: raftengine.Status{State: raftengine.StateFollower, CommitIndex: 10, AppliedIndex: 10},
+			},
+		},
+		{
+			name: "state/status mismatch fails closed",
+			engine: lockResolverStatusEngine{
+				state:  raftengine.StateLeader,
+				status: raftengine.Status{State: raftengine.StateFollower, CommitIndex: 10, AppliedIndex: 10},
+			},
+		},
+		{
+			name: "leader transfer in progress",
+			engine: lockResolverStatusEngine{
+				state:  raftengine.StateLeader,
+				status: raftengine.Status{State: raftengine.StateLeader, CommitIndex: 10, AppliedIndex: 10, LeadTransferee: 2},
+			},
+		},
+		{
+			name: "pending conf change",
+			engine: lockResolverStatusEngine{
+				state:  raftengine.StateLeader,
+				status: raftengine.Status{State: raftengine.StateLeader, CommitIndex: 10, AppliedIndex: 10, PendingConfChange: true},
+			},
+		},
+		{
+			name: "fsm backlog",
+			engine: lockResolverStatusEngine{
+				state:  raftengine.StateLeader,
+				status: raftengine.Status{State: raftengine.StateLeader, CommitIndex: 10, AppliedIndex: 10, FSMPending: 1},
+			},
+		},
+		{
+			name: "applied lag",
+			engine: lockResolverStatusEngine{
+				state:  raftengine.StateLeader,
+				status: raftengine.Status{State: raftengine.StateLeader, CommitIndex: 10, AppliedIndex: 9},
+			},
+		},
+		{
+			name: "settled leader",
+			engine: lockResolverStatusEngine{
+				state:  raftengine.StateLeader,
+				status: raftengine.Status{State: raftengine.StateLeader, CommitIndex: 10, AppliedIndex: 10},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			engine, _ := tc.engine.(interface {
+				raftengine.LeaderView
+				raftengine.StatusReader
+			})
+			require.Equal(t, tc.want, lockResolverRaftReady(engine))
+		})
+	}
+}
+
+func TestLockResolverLSMBackpressured(t *testing.T) {
+	t.Parallel()
+
+	base := store.NewMVCCStore()
+
+	noPressure := &lockResolverBackpressureStore{MVCCStore: base, metrics: &pebble.Metrics{}}
+	overloaded, _ := lockResolverLSMBackpressured(noPressure)
+	require.False(t, overloaded)
+
+	l0Pressure := &lockResolverBackpressureStore{MVCCStore: base, metrics: &pebble.Metrics{}}
+	l0Pressure.metrics.Levels[0].TablesCount = lockResolverMaxL0Files
+	overloaded, _ = lockResolverLSMBackpressured(l0Pressure)
+	require.True(t, overloaded)
+
+	debtPressure := &lockResolverBackpressureStore{MVCCStore: base, metrics: &pebble.Metrics{}}
+	debtPressure.metrics.Compact.EstimatedDebt = lockResolverMaxLSMDebtBytes
+	overloaded, _ = lockResolverLSMBackpressured(debtPressure)
+	require.True(t, overloaded)
+}
+
+type lockResolverStatusEngine struct {
+	state  raftengine.State
+	status raftengine.Status
+}
+
+func (e lockResolverStatusEngine) State() raftengine.State { return e.state }
+
+func (e lockResolverStatusEngine) Leader() raftengine.LeaderInfo { return e.status.Leader }
+
+func (e lockResolverStatusEngine) VerifyLeader(context.Context) error { return nil }
+
+func (e lockResolverStatusEngine) LinearizableRead(context.Context) (uint64, error) {
+	return e.status.AppliedIndex, nil
+}
+
+func (e lockResolverStatusEngine) Status() raftengine.Status { return e.status }
+
+type lockResolverBackpressureStore struct {
+	store.MVCCStore
+	metrics *pebble.Metrics
+}
+
+func (s *lockResolverBackpressureStore) Metrics() *pebble.Metrics {
+	return s.metrics
 }

--- a/kv/lock_resolver_test.go
+++ b/kv/lock_resolver_test.go
@@ -178,6 +178,31 @@ func TestLockResolver_ResolvesExpiredRolledBackLock(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestLockResolver_SkipsWhenPrimaryGroupBackpressured(t *testing.T) {
+	t.Parallel()
+
+	lr, _, groups, cleanup := setupLockResolverEnv(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	startTS := uint64(25)
+	primaryKey := []byte("b")   // group 1
+	secondaryKey := []byte("n") // group 2
+
+	prepareLock(t, groups[1], startTS, primaryKey, primaryKey, []byte("v1"), 0)
+	prepareLock(t, groups[2], startTS, secondaryKey, primaryKey, []byte("v2"), 0)
+
+	metrics := &pebble.Metrics{}
+	metrics.Levels[0].TablesCount = lockResolverMaxL0Files
+	groups[1].Store = &lockResolverBackpressureStore{MVCCStore: groups[1].Store, metrics: metrics}
+
+	err := lr.resolveGroupLocks(ctx, 2, groups[2])
+	require.NoError(t, err)
+
+	_, err = groups[2].Store.GetAt(ctx, txnLockKey(secondaryKey), ^uint64(0))
+	require.NoError(t, err)
+}
+
 func TestLockResolver_SkipsNonExpiredLocks(t *testing.T) {
 	t.Parallel()
 
@@ -338,20 +363,37 @@ func TestLockResolverLSMBackpressured(t *testing.T) {
 	t.Parallel()
 
 	base := store.NewMVCCStore()
+	tests := []struct {
+		name  string
+		setup func(*pebble.Metrics)
+		want  bool
+	}{
+		{name: "no pressure", setup: func(*pebble.Metrics) {}, want: false},
+		{
+			name: "l0 files at threshold",
+			setup: func(m *pebble.Metrics) {
+				m.Levels[0].TablesCount = lockResolverMaxL0Files
+			},
+			want: true,
+		},
+		{
+			name: "compaction debt at threshold",
+			setup: func(m *pebble.Metrics) {
+				m.Compact.EstimatedDebt = lockResolverMaxLSMDebtBytes
+			},
+			want: true,
+		},
+	}
 
-	noPressure := &lockResolverBackpressureStore{MVCCStore: base, metrics: &pebble.Metrics{}}
-	overloaded, _ := lockResolverLSMBackpressured(noPressure)
-	require.False(t, overloaded)
-
-	l0Pressure := &lockResolverBackpressureStore{MVCCStore: base, metrics: &pebble.Metrics{}}
-	l0Pressure.metrics.Levels[0].TablesCount = lockResolverMaxL0Files
-	overloaded, _ = lockResolverLSMBackpressured(l0Pressure)
-	require.True(t, overloaded)
-
-	debtPressure := &lockResolverBackpressureStore{MVCCStore: base, metrics: &pebble.Metrics{}}
-	debtPressure.metrics.Compact.EstimatedDebt = lockResolverMaxLSMDebtBytes
-	overloaded, _ = lockResolverLSMBackpressured(debtPressure)
-	require.True(t, overloaded)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			metrics := &pebble.Metrics{}
+			tc.setup(metrics)
+			st := &lockResolverBackpressureStore{MVCCStore: base, metrics: metrics}
+			overloaded, _ := lockResolverLSMBackpressured(st)
+			require.Equal(t, tc.want, overloaded)
+		})
+	}
 }
 
 type lockResolverStatusEngine struct {

--- a/store/lsm_store.go
+++ b/store/lsm_store.go
@@ -1029,6 +1029,30 @@ func nextScannableUserKey(iter *pebble.Iterator) ([]byte, uint64, bool) {
 	return nil, 0, false
 }
 
+func nextScannableUserKeyContext(ctx context.Context, iter *pebble.Iterator) ([]byte, uint64, bool, error) {
+	for iter.Valid() {
+		if err := ctx.Err(); err != nil {
+			return nil, 0, false, errors.WithStack(err)
+		}
+		rawKey := iter.Key()
+		if isPebbleMetaKey(rawKey) {
+			if !iter.Next() {
+				return nil, 0, false, nil
+			}
+			continue
+		}
+		userKey, version := decodeKey(rawKey)
+		if userKey == nil {
+			if !iter.Next() {
+				return nil, 0, false, nil
+			}
+			continue
+		}
+		return userKey, version, true, nil
+	}
+	return nil, 0, false, nil
+}
+
 func prevScannableUserKey(iter *pebble.Iterator) ([]byte, bool) {
 	for iter.Valid() {
 		rawKey := iter.Key()
@@ -1050,11 +1074,14 @@ func prevScannableUserKey(iter *pebble.Iterator) ([]byte, bool) {
 	return nil, false
 }
 
-func (s *pebbleStore) collectScanResults(iter *pebble.Iterator, start, end []byte, limit int, ts uint64) ([]*KVPair, error) {
+func (s *pebbleStore) collectScanResults(ctx context.Context, iter *pebble.Iterator, start, end []byte, limit int, ts uint64) ([]*KVPair, error) {
 	result := make([]*KVPair, 0, boundedScanResultCapacity(limit))
 
 	for iter.SeekGE(encodeKey(start, math.MaxUint64)); iter.Valid() && len(result) < limit; {
-		userKey, version, ok := nextScannableUserKey(iter)
+		userKey, version, ok, err := nextScannableUserKeyContext(ctx, iter)
+		if err != nil {
+			return nil, err
+		}
 		if !ok {
 			break
 		}
@@ -1087,11 +1114,17 @@ func (s *pebbleStore) ScanAt(ctx context.Context, start []byte, end []byte, limi
 	if limit <= 0 {
 		return []*KVPair{}, nil
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, errors.WithStack(err)
+	}
 
 	// Acquire dbMu.RLock before reading effectiveMinRetainedTS (which takes
 	// mtx.RLock) to preserve the global lock ordering: dbMu before mtx.
 	s.dbMu.RLock()
 	defer s.dbMu.RUnlock()
+	if err := ctx.Err(); err != nil {
+		return nil, errors.WithStack(err)
+	}
 
 	if readTSCompacted(ts, s.effectiveMinRetainedTS()) {
 		return nil, ErrReadTSCompacted
@@ -1105,7 +1138,7 @@ func (s *pebbleStore) ScanAt(ctx context.Context, start []byte, end []byte, limi
 	}
 	defer iter.Close()
 
-	return s.collectScanResults(iter, start, end, limit, ts)
+	return s.collectScanResults(ctx, iter, start, end, limit, ts)
 }
 
 func (s *pebbleStore) collectReverseScanResults(

--- a/store/mvcc_store.go
+++ b/store/mvcc_store.go
@@ -305,9 +305,12 @@ func computeScanCapHint(treeSize, limit int) int {
 	return capHint
 }
 
-func (s *mvccStore) collectScanResults(it *treemap.Iterator, end []byte, limit, capHint int, ts uint64) []*KVPair {
+func (s *mvccStore) collectScanResults(ctx context.Context, it *treemap.Iterator, end []byte, limit, capHint int, ts uint64) ([]*KVPair, error) {
 	result := make([]*KVPair, 0, capHint)
 	for ok := true; ok && len(result) < limit; ok = it.Next() {
+		if err := ctx.Err(); err != nil {
+			return nil, errors.WithStack(err)
+		}
 		k, keyOK := it.Key().([]byte)
 		if !keyOK {
 			continue
@@ -325,12 +328,18 @@ func (s *mvccStore) collectScanResults(it *treemap.Iterator, end []byte, limit, 
 			Value: bytes.Clone(val),
 		})
 	}
-	return result
+	return result, nil
 }
 
-func (s *mvccStore) ScanAt(_ context.Context, start []byte, end []byte, limit int, ts uint64) ([]*KVPair, error) {
+func (s *mvccStore) ScanAt(ctx context.Context, start []byte, end []byte, limit int, ts uint64) ([]*KVPair, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, errors.WithStack(err)
+	}
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
+	if err := ctx.Err(); err != nil {
+		return nil, errors.WithStack(err)
+	}
 	if readTSCompacted(ts, s.minRetainedTS) {
 		return nil, ErrReadTSCompacted
 	}
@@ -344,7 +353,7 @@ func (s *mvccStore) ScanAt(_ context.Context, start []byte, end []byte, limit in
 	if !seekForwardIteratorStart(s.tree, &it, start) {
 		return make([]*KVPair, 0, capHint), nil
 	}
-	return s.collectScanResults(&it, end, limit, capHint, ts), nil
+	return s.collectScanResults(ctx, &it, end, limit, capHint, ts)
 }
 
 // seekForwardIteratorStart positions the iterator at the first key >= start.

--- a/store/scan_bounds_test.go
+++ b/store/scan_bounds_test.go
@@ -57,6 +57,15 @@ func TestMVCCStore_ScanAt_NilEnd(t *testing.T) {
 	require.Len(t, kvs, 2)
 }
 
+func TestMVCCStore_ScanAtContextCanceled(t *testing.T) {
+	st := NewMVCCStore()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := st.ScanAt(ctx, []byte("a"), nil, 10, 10)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 // TestPebbleStore_ScanAt_ExclusiveEndBound verifies [start, end) for pebble.
 func TestPebbleStore_ScanAt_ExclusiveEndBound(t *testing.T) {
 	dir, err := os.MkdirTemp("", "pebble-scan-bound-*")
@@ -100,4 +109,20 @@ func TestPebbleStore_ScanAt_EndEqualsLastKey(t *testing.T) {
 	require.Len(t, kvs, 2)
 	assert.Equal(t, []byte("x"), kvs[0].Key)
 	assert.Equal(t, []byte("y"), kvs[1].Key)
+}
+
+func TestPebbleStore_ScanAtContextCanceled(t *testing.T) {
+	dir, err := os.MkdirTemp("", "pebble-scan-canceled-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	s, err := NewPebbleStore(dir)
+	require.NoError(t, err)
+	defer s.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = s.ScanAt(ctx, []byte("a"), nil, 10, 10)
+	require.ErrorIs(t, err, context.Canceled)
 }


### PR DESCRIPTION
## Summary
- gate background lock resolution on settled Raft leader state and Pebble backpressure
- add short per-cycle and per-lock budgets so orphan cleanup cannot starve HLC lease renewal
- keep foreground lock resolution semantics unchanged

## Root cause
Production logs on 192.168.0.210-214 showed repeated leader churn while Pebble was under compaction debt and the background lock resolver was resolving expired locks in 100-item cycles. Each resolution can perform primary transaction status reads and Raft-backed resolution writes, which added leader-side work during backpressure and coincided with HLC lease renewal deadline failures. Disabling Raft SendStream was already deployed, so the remaining churn path was the best-effort resolver running during Raft/Pebble pressure.

## Validation
- go test ./kv -run 'TestLockResolver|Test(Coordinate|ShardedCoordinator|Lease)' -count=1 -timeout=120s\n- go test ./... -run '^$' -count=1 -timeout=240s\n- golangci-lint run ./kv --timeout=5m\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ロック解決処理を段階的に実行し、処理時間や操作数の上限を考慮して安定性を向上しました。
  * Raft の準備状態やストレージ負荷を確認し、必要に応じて処理を一時停止して他の処理への影響を抑制します。
  * 一時的な予算超過やスキャン失敗が発生しても、処理全体を停止せず継続できるようになりました。

* **テスト**
  * Raft のリーダー状態やストレージ負荷の判定に関するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->