### PR TITLE
Remove dead code and simplify adapter tests

### DIFF
--- a/adapter/dynamodb_schema.go
+++ b/adapter/dynamodb_schema.go
@@ -73,39 +73,6 @@ type dynamoGlobalSecondaryIndex struct {
 	Projection dynamoGSIProjection `json:"projection"`
 }
 
-func (g *dynamoGlobalSecondaryIndex) UnmarshalJSON(b []byte) error {
-	type rawGSI struct {
-		KeySchema  *dynamoKeySchema     `json:"key_schema"`
-		Projection *dynamoGSIProjection `json:"projection"`
-		HashKey    string               `json:"hash_key"`
-		RangeKey   string               `json:"range_key"`
-	}
-
-	var raw rawGSI
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return errors.WithStack(err)
-	}
-
-	if raw.KeySchema != nil {
-		g.KeySchema = *raw.KeySchema
-	} else {
-		g.KeySchema = dynamoKeySchema{
-			HashKey:  raw.HashKey,
-			RangeKey: raw.RangeKey,
-		}
-	}
-
-	if raw.Projection != nil && strings.TrimSpace(raw.Projection.ProjectionType) != "" {
-		g.Projection = *raw.Projection
-	} else {
-		// Older schema snapshots stored only the key schema. Those GSIs behaved
-		// like ALL projections, so preserve that behavior when normalizing.
-		g.Projection = dynamoGSIProjection{ProjectionType: "ALL"}
-	}
-
-	return nil
-}
-
 type dynamoTableSchema struct {
 	TableName               string                                `json:"table_name"`
 	AttributeDefinitions    map[string]string                     `json:"attribute_definitions,omitempty"`

--- a/adapter/dynamodb_test.go
+++ b/adapter/dynamodb_test.go
@@ -187,31 +187,35 @@ func TestDynamoDB_DeleteItem_Condition(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestDynamoDB_DeleteItem_RequestBodyTooLarge(t *testing.T) {
+func TestDynamoDB_RequestBodyTooLarge(t *testing.T) {
 	t.Parallel()
 	nodes, _, _ := createNode(t, 1)
 	defer shutdown(nodes)
 
-	reqBody := strings.Repeat("a", dynamoMaxRequestBodyBytes+1)
-	req, err := http.NewRequestWithContext(
-		context.Background(),
-		http.MethodPost,
-		"http://"+nodes[0].dynamoAddress+"/",
-		strings.NewReader(reqBody),
-	)
-	require.NoError(t, err)
-	req.Header.Set("X-Amz-Target", deleteItemTarget)
-	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
+	for _, target := range []string{deleteItemTarget, putItemTarget} {
+		t.Run(target, func(t *testing.T) {
+			reqBody := strings.Repeat("a", dynamoMaxRequestBodyBytes+1)
+			req, err := http.NewRequestWithContext(
+				context.Background(),
+				http.MethodPost,
+				"http://"+nodes[0].dynamoAddress+"/",
+				strings.NewReader(reqBody),
+			)
+			require.NoError(t, err)
+			req.Header.Set("X-Amz-Target", target)
+			req.Header.Set("Content-Type", "application/x-amz-json-1.0")
 
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
 
-	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.Contains(t, string(body), dynamoErrValidation)
-	require.Contains(t, string(body), "too large")
+			require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			require.Contains(t, string(body), dynamoErrValidation)
+			require.Contains(t, string(body), "too large")
+		})
+	}
 }
 
 func TestDynamoDB_Healthz(t *testing.T) {
@@ -282,33 +286,6 @@ func TestDynamoDB_LeaderHealthz(t *testing.T) {
 			require.Equal(t, tc.body, string(body))
 		})
 	}
-}
-
-func TestDynamoDB_PutItem_RequestBodyTooLarge(t *testing.T) {
-	t.Parallel()
-	nodes, _, _ := createNode(t, 1)
-	defer shutdown(nodes)
-
-	reqBody := strings.Repeat("a", dynamoMaxRequestBodyBytes+1)
-	req, err := http.NewRequestWithContext(
-		context.Background(),
-		http.MethodPost,
-		"http://"+nodes[0].dynamoAddress+"/",
-		strings.NewReader(reqBody),
-	)
-	require.NoError(t, err)
-	req.Header.Set("X-Amz-Target", putItemTarget)
-	req.Header.Set("Content-Type", "application/x-amz-json-1.0")
-
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
-	body, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.Contains(t, string(body), dynamoErrValidation)
-	require.Contains(t, string(body), "too large")
 }
 
 func TestDynamoDB_TransactWriteItems(t *testing.T) {

--- a/adapter/encryption_admin.go
+++ b/adapter/encryption_admin.go
@@ -29,7 +29,6 @@ import (
 // leader-gated through requireLeader / VerifyLeader.
 type EncryptionAdminServer struct {
 	sidecarPath        string
-	keystore           *encryption.Keystore
 	fullNodeID         uint64
 	buildSHA           string
 	latestAppliedIndex func() uint64
@@ -169,18 +168,6 @@ type EncryptionAdminServerOption func(*EncryptionAdminServer)
 func WithEncryptionAdminSidecarPath(path string) EncryptionAdminServerOption {
 	return func(s *EncryptionAdminServer) {
 		s.sidecarPath = path
-	}
-}
-
-// WithEncryptionAdminKeystore lets the server consult the in-memory
-// keystore for the §5.5 fallback paths. Stage 5 PR-A / PR-B do not
-// require it because ReadSidecar covers every field the read-only
-// RPCs need and RotateDEK relies on FSM-side validation rather
-// than a pre-check. Stage 7 (writer registry) will use it for the
-// in-memory counter fast-path.
-func WithEncryptionAdminKeystore(k *encryption.Keystore) EncryptionAdminServerOption {
-	return func(s *EncryptionAdminServer) {
-		s.keystore = k
 	}
 }
 

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -222,13 +222,6 @@ type RedisServer struct {
 	// to opt out — kept as a one-env-var operator rollback.
 	onePhaseTxnDedup bool
 
-	// standaloneSetDedup is kept for compatibility with older tests and
-	// deployments that toggled the former standalone SET sub-gate. SET now
-	// has the same collection-overwrite semantics on the dedup path as the
-	// legacy path, so onePhaseTxnDedup alone controls standalone SET/INCR/HSET
-	// routing.
-	standaloneSetDedup bool
-
 	route map[string]func(conn redcon.Conn, cmd redcon.Command)
 }
 
@@ -243,15 +236,6 @@ type RedisServerOption func(*RedisServer)
 func WithOnePhaseTxnDedup(enabled bool) RedisServerOption {
 	return func(r *RedisServer) {
 		r.onePhaseTxnDedup = enabled
-	}
-}
-
-// WithStandaloneSetDedup is a compatibility no-op. Standalone SET follows
-// onePhaseTxnDedup now that SET-over-collection parity is implemented in
-// txnContext.applySet.
-func WithStandaloneSetDedup(enabled bool) RedisServerOption {
-	return func(r *RedisServer) {
-		r.standaloneSetDedup = enabled
 	}
 }
 
@@ -522,12 +506,10 @@ func NewRedisServer(listen net.Listener, redisAddr string, store store.MVCCStore
 		// ELASTICKV_REDIS_ONEPHASE_DEDUP=0 opts out; the WithOnePhaseTxnDedup
 		// constructor option still trumps the env var.
 		onePhaseTxnDedup: os.Getenv("ELASTICKV_REDIS_ONEPHASE_DEDUP") != "0",
-		// Compatibility field for the removed standalone SET sub-gate.
-		standaloneSetDedup: os.Getenv("ELASTICKV_REDIS_ONEPHASE_DEDUP_SET") == "1",
-		baseCtx:            baseCtx,
-		baseCancel:         baseCancel,
-		streamWaiters:      newKeyWaiterRegistry(),
-		zsetWaiters:        newKeyWaiterRegistry(),
+		baseCtx:          baseCtx,
+		baseCancel:       baseCancel,
+		streamWaiters:    newKeyWaiterRegistry(),
+		zsetWaiters:      newKeyWaiterRegistry(),
 	}
 	r.relay.Bind(r.publishLocal)
 

--- a/adapter/s3.go
+++ b/adapter/s3.go
@@ -2424,15 +2424,20 @@ func (s *S3Server) maybeProxyToLeader(w http.ResponseWriter, r *http.Request) bo
 		return true
 	}
 	target := &url.URL{Scheme: "http", Host: targetHost}
-	originalHost := r.Host
-	proxy := httputil.NewSingleHostReverseProxy(target)
-	origDirector := proxy.Director
-	proxy.Director = func(req *http.Request) {
-		origDirector(req)
-		req.Host = originalHost
-	}
-	proxy.ErrorHandler = func(rw http.ResponseWriter, _ *http.Request, err error) {
-		writeS3InternalError(rw, err)
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(req *httputil.ProxyRequest) {
+			req.SetURL(target)
+			// SigV4 includes Host in the canonical request, so the leader must see
+			// the same Host value that the client signed for the follower endpoint.
+			req.Out.Host = req.In.Host
+			// Rewrite strips forwarding headers before this callback. Rebuild them
+			// explicitly to preserve the legacy Director behavior.
+			req.Out.Header["X-Forwarded-For"] = req.In.Header["X-Forwarded-For"]
+			req.SetXForwarded()
+		},
+		ErrorHandler: func(rw http.ResponseWriter, _ *http.Request, err error) {
+			writeS3InternalError(rw, err)
+		},
 	}
 	proxy.ServeHTTP(w, r)
 	return true

--- a/adapter/s3.go
+++ b/adapter/s3.go
@@ -2427,6 +2427,9 @@ func (s *S3Server) maybeProxyToLeader(w http.ResponseWriter, r *http.Request) bo
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(req *httputil.ProxyRequest) {
 			req.SetURL(target)
+			// ReverseProxy removes unparsable query parameters before Rewrite.
+			// Preserve the exact client query because SigV4 signs the raw value.
+			req.Out.URL.RawQuery = req.In.URL.RawQuery
 			// SigV4 includes Host in the canonical request, so the leader must see
 			// the same Host value that the client signed for the follower endpoint.
 			req.Out.Host = req.In.Host

--- a/adapter/s3_test.go
+++ b/adapter/s3_test.go
@@ -121,14 +121,20 @@ func TestS3Server_ProxiesFollowerRequests(t *testing.T) {
 	})
 
 	rec := httptest.NewRecorder()
-	req := newS3TestRequest(http.MethodGet, "/?uploadId=abc%2F123", nil)
+	const rawQuery = "uploadId=abc%2F123&response-content-disposition=attachment;filename=x"
+	req := newS3TestRequest(http.MethodGet, "/?"+rawQuery, nil)
 	req.Host = "signed-s3.example.test"
 	server.handle(rec, req)
 
-	got := <-proxied
+	var got proxiedRequest
+	select {
+	case got = <-proxied:
+	case <-time.After(5 * time.Second):
+		t.Fatal("request was not proxied to the leader")
+	}
 	require.Equal(t, "signed-s3.example.test", got.host)
 	require.Equal(t, "/", got.path)
-	require.Equal(t, "uploadId=abc%2F123", got.rawQuery)
+	require.Equal(t, rawQuery, got.rawQuery)
 	require.Equal(t, "signed-s3.example.test", got.forwardedHost)
 	require.Equal(t, "http", got.forwardedProto)
 	require.Equal(t, http.StatusOK, rec.Code)

--- a/adapter/s3_test.go
+++ b/adapter/s3_test.go
@@ -95,9 +95,22 @@ func TestS3Server_BucketAndObjectLifecycle(t *testing.T) {
 func TestS3Server_ProxiesFollowerRequests(t *testing.T) {
 	t.Parallel()
 
-	var proxied bool
+	type proxiedRequest struct {
+		host           string
+		path           string
+		rawQuery       string
+		forwardedHost  string
+		forwardedProto string
+	}
+	proxied := make(chan proxiedRequest, 1)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		proxied = true
+		proxied <- proxiedRequest{
+			host:           r.Host,
+			path:           r.URL.Path,
+			rawQuery:       r.URL.RawQuery,
+			forwardedHost:  r.Header.Get("X-Forwarded-Host"),
+			forwardedProto: r.Header.Get("X-Forwarded-Proto"),
+		}
 		_, _ = io.WriteString(w, "proxied")
 	}))
 	defer upstream.Close()
@@ -108,10 +121,16 @@ func TestS3Server_ProxiesFollowerRequests(t *testing.T) {
 	})
 
 	rec := httptest.NewRecorder()
-	req := newS3TestRequest(http.MethodGet, "/", nil)
+	req := newS3TestRequest(http.MethodGet, "/?uploadId=abc%2F123", nil)
+	req.Host = "signed-s3.example.test"
 	server.handle(rec, req)
 
-	require.True(t, proxied)
+	got := <-proxied
+	require.Equal(t, "signed-s3.example.test", got.host)
+	require.Equal(t, "/", got.path)
+	require.Equal(t, "uploadId=abc%2F123", got.rawQuery)
+	require.Equal(t, "signed-s3.example.test", got.forwardedHost)
+	require.Equal(t, "http", got.forwardedProto)
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, "proxied", rec.Body.String())
 }

--- a/docs/design/2026_06_10_implemented_redis_onephase_dedup_default_on.md
+++ b/docs/design/2026_06_10_implemented_redis_onephase_dedup_default_on.md
@@ -117,9 +117,9 @@ sub-gate because `txnContext.applySet` did not yet match legacy
 `executeSet` semantics for SET-over-collection. That parity gap is now
 closed in the parent design: `applySet` stages a final string replacement
 and uses logical-key cleanup before writing the new string, so standalone
-SET follows `onePhaseTxnDedup` directly. `RedisServer.standaloneSetDedup`,
-`WithStandaloneSetDedup`, and `ELASTICKV_REDIS_ONEPHASE_DEDUP_SET` remain
-as compatibility no-ops for older deployments and tests that still set them.
+SET follows `onePhaseTxnDedup` directly. The former standalone SET sub-gate
+and its `ELASTICKV_REDIS_ONEPHASE_DEDUP_SET` compatibility no-op were removed
+after the rollout because they no longer affected routing.
 
 Regression coverage:
 `TestRedis_SET_OverwritesList_UnderDefaultGate` verifies `RPUSH k x` followed

--- a/internal/test_helper.go
+++ b/internal/test_helper.go
@@ -1,8 +1,0 @@
-package internal
-
-import "github.com/cockroachdb/errors"
-
-func WithStacks[T any](t T, err error) (T, error) {
-	//nolint:wrapcheck
-	return t, errors.WithStackDepth(err, 1)
-}

--- a/store/stream_helpers.go
+++ b/store/stream_helpers.go
@@ -101,15 +101,6 @@ func EncodeStreamID(ms, seq uint64) []byte {
 	return buf[:]
 }
 
-// DecodeStreamID parses a 16-byte big-endian ms||seq tuple. Returns false if
-// the slice length is wrong.
-func DecodeStreamID(b []byte) (ms, seq uint64, ok bool) {
-	if len(b) != StreamIDBytes {
-		return 0, 0, false
-	}
-	return binary.BigEndian.Uint64(b[0:8]), binary.BigEndian.Uint64(b[8:16]), true
-}
-
 // StreamEntryKey builds the per-entry key for a stream.
 func StreamEntryKey(userKey []byte, ms, seq uint64) []byte {
 	buf := make([]byte, 0, len(StreamEntryPrefix)+wideColKeyLenSize+len(userKey)+StreamIDBytes)
@@ -120,16 +111,6 @@ func StreamEntryKey(userKey []byte, ms, seq uint64) []byte {
 	buf = append(buf, userKey...)
 	buf = append(buf, EncodeStreamID(ms, seq)...)
 	return buf
-}
-
-// ExtractStreamEntryID extracts (ms, seq) from a stream entry key. Returns
-// false if the key is not a valid entry key for the given userKey.
-func ExtractStreamEntryID(entryKey, userKey []byte) (ms, seq uint64, ok bool) {
-	prefix := StreamEntryScanPrefix(userKey)
-	if !bytes.HasPrefix(entryKey, prefix) {
-		return 0, 0, false
-	}
-	return DecodeStreamID(entryKey[len(prefix):])
 }
 
 // IsStreamMetaKey reports whether the key is a stream metadata key.


### PR DESCRIPTION
## Summary

- remove unreachable DynamoDB legacy JSON decoding, unused encryption/stream helpers, and the obsolete Redis standalone SET dedup no-op
- consolidate duplicate DynamoDB request-size tests into table-driven coverage
- replace the deprecated S3 reverse-proxy Director hook with Rewrite while preserving the signed Host, path, query, and forwarding headers
- update the Redis rollout design note to match the removed compatibility switch

## Impact and risk

The removed symbols had no reachable callers in the complete program, including tests, on both macOS and Linux analysis. Active configuration options remain unchanged. The S3 proxy refactor preserves SigV4-sensitive request fields and adds explicit regression coverage.

## Validation

- `golangci-lint run ./... --timeout=5m`
- `staticcheck ./...`
- dead-code analysis with tests on macOS and linux/amd64
- `go test -race ./adapter -run ^TestS3Server_ProxiesFollowerRequests$ -count=1`
- `go test ./adapter -run ^(TestS3Server_ProxiesFollowerRequests|TestDynamoDB_RequestBodyTooLarge)$ -count=1`
- all packages except the known long-running full adapter suite: `go list ./... | rg -v ^github.com/bootjp/elastickv/adapter$ | xargs go test -count=1`

The full `go test ./... -count=1` run reached the adapter suite but was stopped after it made no progress for approximately four minutes; the targeted adapter tests above passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - S3のリーダー転送時に、ホスト名・パス・クエリ・転送ヘッダーが正しく引き継がれるよう改善しました。
  - プロキシ転送エラー時のエラーレスポンスを統一しました。
  - RedisのスタンドアロンSETが、トランザクション重複排除設定に従う動作へ整理されました。

- **ドキュメント**
  - Redisのデフォルト動作と互換設定の扱いを更新しました。

- **テスト**
  - 大きすぎるリクエストボディの検証を統合し、S3転送情報の確認範囲を拡張しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->