### PR TITLE
kv: refine pebble backpressure guard

### DIFF
--- a/kv/compactor.go
+++ b/kv/compactor.go
@@ -17,6 +17,7 @@ const (
 	defaultFSMCompactorTimeout         = 5 * time.Second
 	defaultFSMCompactorLeaderTimeout   = 500 * time.Millisecond
 	defaultFSMCompactorMaxL0Files      = 256
+	defaultFSMCompactorMaxL0Sublevels  = 20
 	defaultFSMCompactorMaxLSMDebtBytes = 512 << 20
 )
 
@@ -40,6 +41,7 @@ type FSMCompactor struct {
 	timeout         time.Duration
 	leaderTimeout   time.Duration
 	maxL0Files      int64
+	maxL0Sublevels  int32
 	maxLSMDebtBytes uint64
 	logger          *slog.Logger
 }
@@ -97,6 +99,14 @@ func WithFSMCompactorLSMBackpressureLimits(maxL0Files int64, maxDebtBytes uint64
 	}
 }
 
+func WithFSMCompactorLSMBackpressureSublevelLimit(maxL0Sublevels int32) FSMCompactorOption {
+	return func(c *FSMCompactor) {
+		if maxL0Sublevels > 0 {
+			c.maxL0Sublevels = maxL0Sublevels
+		}
+	}
+}
+
 func WithFSMCompactorLogger(logger *slog.Logger) FSMCompactorOption {
 	return func(c *FSMCompactor) {
 		if logger != nil {
@@ -113,6 +123,7 @@ func NewFSMCompactor(runtimes []FSMCompactRuntime, opts ...FSMCompactorOption) *
 		timeout:         defaultFSMCompactorTimeout,
 		leaderTimeout:   defaultFSMCompactorLeaderTimeout,
 		maxL0Files:      defaultFSMCompactorMaxL0Files,
+		maxL0Sublevels:  defaultFSMCompactorMaxL0Sublevels,
 		maxLSMDebtBytes: defaultFSMCompactorMaxLSMDebtBytes,
 		logger:          slog.Default(),
 	}
@@ -196,7 +207,10 @@ func (c *FSMCompactor) compactRuntime(ctx context.Context, runtime FSMCompactRun
 		c.logger.WarnContext(ctx, "skipping fsm compaction under pebble backpressure",
 			"group_id", runtime.GroupID,
 			"l0_files", snap.Levels[0].TablesCount,
+			"l0_sublevels", snap.Levels[0].Sublevels,
 			"compaction_debt_bytes", snap.Compact.EstimatedDebt,
+			"compactions_in_progress", snap.Compact.NumInProgress,
+			"compaction_in_progress_bytes", snap.Compact.InProgressBytes,
 		)
 		return nil
 	}
@@ -258,13 +272,11 @@ func (c *FSMCompactor) lsmBackpressure(st store.MVCCStore) (bool, *pebble.Metric
 	if snap == nil {
 		return false, nil
 	}
-	if c.maxL0Files > 0 && snap.Levels[0].TablesCount >= c.maxL0Files {
-		return true, snap
-	}
-	if c.maxLSMDebtBytes > 0 && snap.Compact.EstimatedDebt >= c.maxLSMDebtBytes {
-		return true, snap
-	}
-	return false, snap
+	return lsmWriteBackpressured(snap, lsmBackpressureLimits{
+		maxL0Files:      c.maxL0Files,
+		maxL0Sublevels:  c.maxL0Sublevels,
+		maxLSMDebtBytes: c.maxLSMDebtBytes,
+	}), snap
 }
 
 func shouldSkipFSMCompaction(status raftengine.Status) bool {

--- a/kv/compactor.go
+++ b/kv/compactor.go
@@ -17,7 +17,7 @@ const (
 	defaultFSMCompactorTimeout         = 5 * time.Second
 	defaultFSMCompactorLeaderTimeout   = 500 * time.Millisecond
 	defaultFSMCompactorMaxL0Files      = 256
-	defaultFSMCompactorMaxL0Sublevels  = 20
+	defaultFSMCompactorMaxL0Sublevels  = 12
 	defaultFSMCompactorMaxLSMDebtBytes = 512 << 20
 )
 

--- a/kv/compactor_test.go
+++ b/kv/compactor_test.go
@@ -224,7 +224,7 @@ func TestFSMCompactorCompactsMultiPeerFollowerRuntimeWithConfiguredTimeout(t *te
 
 func TestFSMCompactorSkipsPebbleRuntimeUnderLSMBackpressure(t *testing.T) {
 	metrics := &pebble.Metrics{}
-	metrics.Levels[0].TablesCount = defaultFSMCompactorMaxL0Files
+	metrics.Levels[0].Sublevels = defaultFSMCompactorMaxL0Sublevels
 	st := &metricsCapturingStore{
 		deadlineCapturingStore: deadlineCapturingStore{lastCommitTS: 20},
 		metrics:                metrics,
@@ -250,6 +250,38 @@ func TestFSMCompactorSkipsPebbleRuntimeUnderLSMBackpressure(t *testing.T) {
 
 	require.NoError(t, compactor.SyncOnce(ctx))
 	require.False(t, st.compactCalled)
+}
+
+func TestFSMCompactorAllowsStableWideL0(t *testing.T) {
+	metrics := &pebble.Metrics{}
+	metrics.Levels[0].Sublevels = 1
+	metrics.Levels[0].TablesCount = defaultFSMCompactorMaxL0Files * 2
+	metrics.Compact.EstimatedDebt = defaultFSMCompactorMaxLSMDebtBytes * 2
+	st := &metricsCapturingStore{
+		deadlineCapturingStore: deadlineCapturingStore{lastCommitTS: 20},
+		metrics:                metrics,
+	}
+	ctx := context.Background()
+
+	compactor := NewFSMCompactor(
+		[]FSMCompactRuntime{{
+			GroupID: 1,
+			StatusReader: fakeRaftStatus{status: raftengine.Status{
+				State:        raftengine.StateFollower,
+				FSMPending:   0,
+				AppliedIndex: 10,
+				CommitIndex:  10,
+				NumPeers:     1,
+			}},
+			Store: st,
+		}},
+		WithFSMCompactorInterval(time.Hour),
+		WithFSMCompactorRetentionWindow(time.Millisecond),
+		WithFSMCompactorTimeout(time.Second),
+	)
+
+	require.NoError(t, compactor.SyncOnce(ctx))
+	require.True(t, st.compactCalled)
 }
 
 func TestFSMCompactorCompactsSingleNodeLeaderRuntimeWithShortTimeout(t *testing.T) {

--- a/kv/compactor_test.go
+++ b/kv/compactor_test.go
@@ -252,6 +252,12 @@ func TestFSMCompactorSkipsPebbleRuntimeUnderLSMBackpressure(t *testing.T) {
 	require.False(t, st.compactCalled)
 }
 
+func TestFSMCompactorDefaultL0SublevelLimitMatchesPebbleStopWrites(t *testing.T) {
+	var opts pebble.Options
+	opts.EnsureDefaults()
+	require.Equal(t, defaultFSMCompactorMaxL0Sublevels, opts.L0StopWritesThreshold)
+}
+
 func TestFSMCompactorAllowsStableWideL0(t *testing.T) {
 	metrics := &pebble.Metrics{}
 	metrics.Levels[0].Sublevels = 1

--- a/kv/lock_resolver.go
+++ b/kv/lock_resolver.go
@@ -25,6 +25,7 @@ const (
 	// Foreground read/write paths still use their own caller deadlines.
 	lockResolverOperationBudget = 250 * time.Millisecond
 	lockResolverMaxL0Files      = defaultFSMCompactorMaxL0Files
+	lockResolverMaxL0Sublevels  = defaultFSMCompactorMaxL0Sublevels
 	lockResolverMaxLSMDebtBytes = defaultFSMCompactorMaxLSMDebtBytes
 )
 
@@ -228,7 +229,10 @@ func (lr *LockResolver) groupReadyForBackgroundResolve(ctx context.Context, gid 
 		lr.log.WarnContext(ctx, "lock resolver: skipping under pebble backpressure",
 			slog.Uint64("gid", gid),
 			slog.Any("l0_files", snap.Levels[0].TablesCount),
+			slog.Any("l0_sublevels", snap.Levels[0].Sublevels),
 			slog.Any("compaction_debt_bytes", snap.Compact.EstimatedDebt),
+			slog.Any("compactions_in_progress", snap.Compact.NumInProgress),
+			slog.Any("compaction_in_progress_bytes", snap.Compact.InProgressBytes),
 		)
 	}
 	return ready
@@ -275,13 +279,11 @@ func lockResolverLSMBackpressured(st store.MVCCStore) (bool, *pebble.Metrics) {
 	if snap == nil {
 		return false, nil
 	}
-	if lockResolverMaxL0Files > 0 && snap.Levels[0].TablesCount >= lockResolverMaxL0Files {
-		return true, snap
-	}
-	if lockResolverMaxLSMDebtBytes > 0 && snap.Compact.EstimatedDebt >= lockResolverMaxLSMDebtBytes {
-		return true, snap
-	}
-	return false, snap
+	return lsmWriteBackpressured(snap, lsmBackpressureLimits{
+		maxL0Files:      lockResolverMaxL0Files,
+		maxL0Sublevels:  lockResolverMaxL0Sublevels,
+		maxLSMDebtBytes: lockResolverMaxLSMDebtBytes,
+	}), snap
 }
 
 func lockResolverBudgetExhausted(err error, workCtx, parentCtx context.Context) bool {

--- a/kv/lock_resolver_test.go
+++ b/kv/lock_resolver_test.go
@@ -124,7 +124,7 @@ func TestLockResolver_ResolvesCommittedLockWhenPrimaryGroupBackpressured(t *test
 	commitPrimary(t, groups[1], startTS, commitTS, primaryKey)
 
 	metrics := &pebble.Metrics{}
-	metrics.Levels[0].TablesCount = lockResolverMaxL0Files
+	metrics.Levels[0].Sublevels = lockResolverMaxL0Sublevels
 	groups[1].Store = &lockResolverBackpressureStore{MVCCStore: groups[1].Store, metrics: metrics}
 
 	err := lr.resolveGroupLocks(ctx, 2, groups[2])
@@ -221,7 +221,7 @@ func TestLockResolver_SkipsPendingPrimaryAbortWhenPrimaryGroupBackpressured(t *t
 	prepareLock(t, groups[2], startTS, secondaryKey, primaryKey, []byte("v2"), 0)
 
 	metrics := &pebble.Metrics{}
-	metrics.Levels[0].TablesCount = lockResolverMaxL0Files
+	metrics.Levels[0].Sublevels = lockResolverMaxL0Sublevels
 	groups[1].Store = &lockResolverBackpressureStore{MVCCStore: groups[1].Store, metrics: metrics}
 
 	err := lr.resolveGroupLocks(ctx, 2, groups[2])
@@ -398,16 +398,41 @@ func TestLockResolverLSMBackpressured(t *testing.T) {
 	}{
 		{name: "no pressure", setup: func(*pebble.Metrics) {}, want: false},
 		{
-			name: "l0 files at threshold",
+			name: "stable wide l0 and debt without active compaction",
 			setup: func(m *pebble.Metrics) {
-				m.Levels[0].TablesCount = lockResolverMaxL0Files
+				m.Levels[0].Sublevels = 1
+				m.Levels[0].TablesCount = lockResolverMaxL0Files * 2
+				m.Compact.EstimatedDebt = lockResolverMaxLSMDebtBytes * 2
+			},
+			want: false,
+		},
+		{
+			name: "l0 sublevels at threshold",
+			setup: func(m *pebble.Metrics) {
+				m.Levels[0].Sublevels = lockResolverMaxL0Sublevels
 			},
 			want: true,
 		},
 		{
-			name: "compaction debt at threshold",
+			name: "l0 files at threshold with active compaction",
+			setup: func(m *pebble.Metrics) {
+				m.Levels[0].TablesCount = lockResolverMaxL0Files
+				m.Compact.NumInProgress = 1
+			},
+			want: true,
+		},
+		{
+			name: "compaction debt at threshold without active compaction",
 			setup: func(m *pebble.Metrics) {
 				m.Compact.EstimatedDebt = lockResolverMaxLSMDebtBytes
+			},
+			want: false,
+		},
+		{
+			name: "compaction debt at threshold with active compaction",
+			setup: func(m *pebble.Metrics) {
+				m.Compact.EstimatedDebt = lockResolverMaxLSMDebtBytes
+				m.Compact.NumInProgress = 1
 			},
 			want: true,
 		},

--- a/kv/lsm_backpressure.go
+++ b/kv/lsm_backpressure.go
@@ -1,0 +1,32 @@
+package kv
+
+import "github.com/cockroachdb/pebble/v2"
+
+type lsmBackpressureLimits struct {
+	maxL0Files      int64
+	maxL0Sublevels  int32
+	maxLSMDebtBytes uint64
+}
+
+func lsmWriteBackpressured(snap *pebble.Metrics, limits lsmBackpressureLimits) bool {
+	if snap == nil {
+		return false
+	}
+	if limits.maxL0Sublevels > 0 && snap.Levels[0].Sublevels >= limits.maxL0Sublevels {
+		return true
+	}
+	if !pebbleCompactionActive(snap) {
+		return false
+	}
+	if limits.maxL0Files > 0 && snap.Levels[0].TablesCount >= limits.maxL0Files {
+		return true
+	}
+	if limits.maxLSMDebtBytes > 0 && snap.Compact.EstimatedDebt >= limits.maxLSMDebtBytes {
+		return true
+	}
+	return false
+}
+
+func pebbleCompactionActive(snap *pebble.Metrics) bool {
+	return snap.Compact.NumInProgress > 0 || snap.Compact.InProgressBytes > 0
+}


### PR DESCRIPTION
## Summary
- Refine the Pebble backpressure guard shared by the FSM compactor and lock resolver.
- Allow stable wide-L0 shapes, such as many L0 files and existing compaction debt with `L0 sublevels=1` and no active compactions, so maintenance does not skip forever.
- Keep yielding on high L0 sublevels and on high L0 file/debt pressure while Pebble compactions are active.
- Add the relevant Pebble pressure fields to skip logs.

## Tests
- `GOCACHE=$(pwd)/.cache GOTMPDIR=$(pwd)/.cache/tmp go test ./kv`
- `GOCACHE=$(pwd)/.cache GOTMPDIR=$(pwd)/.cache/tmp go test ./store ./internal/raftengine/...`
- `GOCACHE=$(pwd)/.cache GOTMPDIR=$(pwd)/.cache/tmp go test ./adapter -timeout=20m`
- `GOCACHE=$(pwd)/.cache GOTMPDIR=$(pwd)/.cache/tmp go test ./...` fails because `adapter` exceeds the default 10m package timeout; `./adapter` passes with `-timeout=20m`.
