### PR TITLE
Throttle background maintenance under pressure

### DIFF
--- a/kv/compactor.go
+++ b/kv/compactor.go
@@ -3,6 +3,7 @@ package kv
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/bootjp/elastickv/internal/raftengine"
@@ -16,6 +17,7 @@ const (
 	defaultFSMCompactorRetentionWindow = 30 * time.Minute
 	defaultFSMCompactorTimeout         = 5 * time.Second
 	defaultFSMCompactorLeaderTimeout   = 500 * time.Millisecond
+	defaultFSMCompactorTimeoutBackoff  = 30 * time.Minute
 	defaultFSMCompactorMaxL0Files      = 256
 	defaultFSMCompactorMaxL0Sublevels  = 12
 	defaultFSMCompactorMaxLSMDebtBytes = 512 << 20
@@ -40,10 +42,13 @@ type FSMCompactor struct {
 	retentionWindow time.Duration
 	timeout         time.Duration
 	leaderTimeout   time.Duration
+	timeoutBackoff  time.Duration
 	maxL0Files      int64
 	maxL0Sublevels  int32
 	maxLSMDebtBytes uint64
 	logger          *slog.Logger
+	mu              sync.Mutex
+	backoffUntil    map[uint64]time.Time
 }
 
 type pebbleMetricsSource interface {
@@ -88,6 +93,14 @@ func WithFSMCompactorLeaderTimeout(timeout time.Duration) FSMCompactorOption {
 	}
 }
 
+func WithFSMCompactorTimeoutBackoff(backoff time.Duration) FSMCompactorOption {
+	return func(c *FSMCompactor) {
+		if backoff >= 0 {
+			c.timeoutBackoff = backoff
+		}
+	}
+}
+
 func WithFSMCompactorLSMBackpressureLimits(maxL0Files int64, maxDebtBytes uint64) FSMCompactorOption {
 	return func(c *FSMCompactor) {
 		if maxL0Files > 0 {
@@ -122,10 +135,12 @@ func NewFSMCompactor(runtimes []FSMCompactRuntime, opts ...FSMCompactorOption) *
 		retentionWindow: defaultFSMCompactorRetentionWindow,
 		timeout:         defaultFSMCompactorTimeout,
 		leaderTimeout:   defaultFSMCompactorLeaderTimeout,
+		timeoutBackoff:  defaultFSMCompactorTimeoutBackoff,
 		maxL0Files:      defaultFSMCompactorMaxL0Files,
 		maxL0Sublevels:  defaultFSMCompactorMaxL0Sublevels,
 		maxLSMDebtBytes: defaultFSMCompactorMaxLSMDebtBytes,
 		logger:          slog.Default(),
+		backoffUntil:    make(map[uint64]time.Time),
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -203,6 +218,10 @@ func (c *FSMCompactor) compactRuntime(ctx context.Context, runtime FSMCompactRun
 	if shouldSkipFSMCompaction(status) {
 		return nil
 	}
+	now := time.Now()
+	if c.compactionBackoffActive(runtime.GroupID, now) {
+		return nil
+	}
 	if overloaded, snap := c.lsmBackpressure(runtime.Store); overloaded {
 		c.logger.WarnContext(ctx, "skipping fsm compaction under pebble backpressure",
 			"group_id", runtime.GroupID,
@@ -216,7 +235,7 @@ func (c *FSMCompactor) compactRuntime(ctx context.Context, runtime FSMCompactRun
 	}
 
 	lastCommitTS := runtime.Store.LastCommitTS()
-	safeMinTS, ok := c.targetMinTS(lastCommitTS, retention.MinRetainedTS(), time.Now())
+	safeMinTS, ok := c.targetMinTS(lastCommitTS, retention.MinRetainedTS(), now)
 	if !ok {
 		return nil
 	}
@@ -225,6 +244,9 @@ func (c *FSMCompactor) compactRuntime(ctx context.Context, runtime FSMCompactRun
 	defer cancel()
 
 	if err := runtime.Store.Compact(compactCtx, safeMinTS); err != nil {
+		if fsmCompactionBudgetExhausted(err, compactCtx, ctx) {
+			c.backoffCompaction(runtime.GroupID, c.timeoutBackoff)
+		}
 		return errors.Wrapf(err, "compact group %d", runtime.GroupID)
 	}
 	c.logger.InfoContext(compactCtx, "fsm compacted",
@@ -280,9 +302,6 @@ func (c *FSMCompactor) lsmBackpressure(st store.MVCCStore) (bool, *pebble.Metric
 }
 
 func shouldSkipFSMCompaction(status raftengine.Status) bool {
-	if status.State == raftengine.StateLeader && status.NumPeers > 0 {
-		return true
-	}
 	if status.State == raftengine.StateCandidate {
 		return true
 	}
@@ -293,6 +312,47 @@ func shouldSkipFSMCompaction(status raftengine.Status) bool {
 		return true
 	}
 	return status.AppliedIndex < status.CommitIndex
+}
+
+func (c *FSMCompactor) compactionBackoffActive(groupID uint64, now time.Time) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	until, ok := c.backoffUntil[groupID]
+	if !ok {
+		return false
+	}
+	if now.Before(until) {
+		return true
+	}
+	delete(c.backoffUntil, groupID)
+	return false
+}
+
+func (c *FSMCompactor) backoffCompaction(groupID uint64, d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ensureStateLocked()
+	c.backoffUntil[groupID] = time.Now().Add(d)
+}
+
+func (c *FSMCompactor) ensureStateLocked() {
+	if c.backoffUntil == nil {
+		c.backoffUntil = make(map[uint64]time.Time)
+	}
+}
+
+func fsmCompactionBudgetExhausted(err error, workCtx, parentCtx context.Context) bool {
+	if err == nil || workCtx == nil {
+		return false
+	}
+	if parentCtx != nil && parentCtx.Err() != nil {
+		return false
+	}
+	return workCtx.Err() != nil
 }
 
 func (c *FSMCompactor) safeMinTS(now time.Time) uint64 {

--- a/kv/compactor.go
+++ b/kv/compactor.go
@@ -17,6 +17,7 @@ const (
 	defaultFSMCompactorRetentionWindow = 30 * time.Minute
 	defaultFSMCompactorTimeout         = 5 * time.Second
 	defaultFSMCompactorLeaderTimeout   = 500 * time.Millisecond
+	defaultFSMCompactorLeaderCooldown  = 30 * time.Minute
 	defaultFSMCompactorTimeoutBackoff  = 30 * time.Minute
 	defaultFSMCompactorMaxL0Files      = 256
 	defaultFSMCompactorMaxL0Sublevels  = 12
@@ -42,6 +43,7 @@ type FSMCompactor struct {
 	retentionWindow time.Duration
 	timeout         time.Duration
 	leaderTimeout   time.Duration
+	leaderCooldown  time.Duration
 	timeoutBackoff  time.Duration
 	maxL0Files      int64
 	maxL0Sublevels  int32
@@ -49,6 +51,7 @@ type FSMCompactor struct {
 	logger          *slog.Logger
 	mu              sync.Mutex
 	backoffUntil    map[uint64]time.Time
+	leaderUntil     map[uint64]time.Time
 }
 
 type pebbleMetricsSource interface {
@@ -89,6 +92,14 @@ func WithFSMCompactorLeaderTimeout(timeout time.Duration) FSMCompactorOption {
 	return func(c *FSMCompactor) {
 		if timeout > 0 {
 			c.leaderTimeout = timeout
+		}
+	}
+}
+
+func WithFSMCompactorLeaderCooldown(cooldown time.Duration) FSMCompactorOption {
+	return func(c *FSMCompactor) {
+		if cooldown >= 0 {
+			c.leaderCooldown = cooldown
 		}
 	}
 }
@@ -135,12 +146,14 @@ func NewFSMCompactor(runtimes []FSMCompactRuntime, opts ...FSMCompactorOption) *
 		retentionWindow: defaultFSMCompactorRetentionWindow,
 		timeout:         defaultFSMCompactorTimeout,
 		leaderTimeout:   defaultFSMCompactorLeaderTimeout,
+		leaderCooldown:  defaultFSMCompactorLeaderCooldown,
 		timeoutBackoff:  defaultFSMCompactorTimeoutBackoff,
 		maxL0Files:      defaultFSMCompactorMaxL0Files,
 		maxL0Sublevels:  defaultFSMCompactorMaxL0Sublevels,
 		maxLSMDebtBytes: defaultFSMCompactorMaxLSMDebtBytes,
 		logger:          slog.Default(),
 		backoffUntil:    make(map[uint64]time.Time),
+		leaderUntil:     make(map[uint64]time.Time),
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -206,31 +219,13 @@ func (c *FSMCompactor) validate() error {
 }
 
 func (c *FSMCompactor) compactRuntime(ctx context.Context, runtime FSMCompactRuntime) error {
-	if runtime.StatusReader == nil || runtime.Store == nil {
-		return nil
-	}
-	retention, ok := runtime.Store.(store.RetentionController)
+	retention, status, ok := c.compactionRuntimeReady(runtime)
 	if !ok {
 		return nil
 	}
-
-	status := runtime.StatusReader.Status()
-	if shouldSkipFSMCompaction(status) {
-		return nil
-	}
 	now := time.Now()
-	if c.compactionBackoffActive(runtime.GroupID, now) {
-		return nil
-	}
-	if overloaded, snap := c.lsmBackpressure(runtime.Store); overloaded {
-		c.logger.WarnContext(ctx, "skipping fsm compaction under pebble backpressure",
-			"group_id", runtime.GroupID,
-			"l0_files", snap.Levels[0].TablesCount,
-			"l0_sublevels", snap.Levels[0].Sublevels,
-			"compaction_debt_bytes", snap.Compact.EstimatedDebt,
-			"compactions_in_progress", snap.Compact.NumInProgress,
-			"compaction_in_progress_bytes", snap.Compact.InProgressBytes,
-		)
+	replicatedLeader := isReplicatedLeader(status)
+	if c.shouldDeferRuntimeCompaction(ctx, runtime, status, now) {
 		return nil
 	}
 
@@ -244,10 +239,11 @@ func (c *FSMCompactor) compactRuntime(ctx context.Context, runtime FSMCompactRun
 	defer cancel()
 
 	if err := runtime.Store.Compact(compactCtx, safeMinTS); err != nil {
-		if fsmCompactionBudgetExhausted(err, compactCtx, ctx) {
-			c.backoffCompaction(runtime.GroupID, c.timeoutBackoff)
-		}
+		c.handleCompactError(ctx, runtime.GroupID, status, compactCtx, err)
 		return errors.Wrapf(err, "compact group %d", runtime.GroupID)
+	}
+	if replicatedLeader {
+		c.cooldownLeaderCompaction(runtime.GroupID, c.leaderCooldown)
 	}
 	c.logger.InfoContext(compactCtx, "fsm compacted",
 		"group_id", runtime.GroupID,
@@ -255,6 +251,78 @@ func (c *FSMCompactor) compactRuntime(ctx context.Context, runtime FSMCompactRun
 		"last_commit_ts", lastCommitTS,
 	)
 	return nil
+}
+
+func (c *FSMCompactor) compactionRuntimeReady(runtime FSMCompactRuntime) (store.RetentionController, raftengine.Status, bool) {
+	if runtime.StatusReader == nil || runtime.Store == nil {
+		return nil, raftengine.Status{}, false
+	}
+	retention, ok := runtime.Store.(store.RetentionController)
+	if !ok {
+		return nil, raftengine.Status{}, false
+	}
+	status := runtime.StatusReader.Status()
+	if shouldSkipFSMCompaction(status) {
+		return nil, raftengine.Status{}, false
+	}
+	return retention, status, true
+}
+
+func (c *FSMCompactor) shouldDeferRuntimeCompaction(ctx context.Context, runtime FSMCompactRuntime, status raftengine.Status, now time.Time) bool {
+	if c.skipCompactionBackoff(ctx, runtime.GroupID, now) {
+		return true
+	}
+	if isReplicatedLeader(status) && !c.replicatedLeaderCompactionDue(ctx, runtime.GroupID, now) {
+		return true
+	}
+	overloaded, snap := c.lsmBackpressure(runtime.Store)
+	if !overloaded {
+		return false
+	}
+	c.logger.WarnContext(ctx, "skipping fsm compaction under pebble backpressure",
+		"group_id", runtime.GroupID,
+		"l0_files", snap.Levels[0].TablesCount,
+		"l0_sublevels", snap.Levels[0].Sublevels,
+		"compaction_debt_bytes", snap.Compact.EstimatedDebt,
+		"compactions_in_progress", snap.Compact.NumInProgress,
+		"compaction_in_progress_bytes", snap.Compact.InProgressBytes,
+	)
+	return true
+}
+
+func (c *FSMCompactor) skipCompactionBackoff(ctx context.Context, groupID uint64, now time.Time) bool {
+	if !c.compactionBackoffActive(groupID, now) {
+		return false
+	}
+	c.logger.DebugContext(ctx, "skipping fsm compaction during timeout backoff",
+		"group_id", groupID,
+	)
+	return true
+}
+
+func (c *FSMCompactor) replicatedLeaderCompactionDue(ctx context.Context, groupID uint64, now time.Time) bool {
+	due, until := c.leaderCompactionDue(groupID, now)
+	if due {
+		return true
+	}
+	c.logger.DebugContext(ctx, "skipping fsm compaction on replicated leader cooldown",
+		"group_id", groupID,
+		"leader_cooldown_until", until,
+		"leader_cooldown", c.leaderCooldown,
+	)
+	return false
+}
+
+func (c *FSMCompactor) handleCompactError(ctx context.Context, groupID uint64, status raftengine.Status, compactCtx context.Context, err error) {
+	if !fsmCompactionBudgetExhausted(err, compactCtx, ctx) {
+		return
+	}
+	c.backoffCompaction(groupID, c.timeoutBackoff)
+	c.logger.WarnContext(ctx, "backing off fsm compaction after timeout",
+		"group_id", groupID,
+		"backoff", c.timeoutBackoff,
+		"leader", status.State == raftengine.StateLeader,
+	)
 }
 
 func (c *FSMCompactor) targetMinTS(lastCommitTS, minRetainedTS uint64, now time.Time) (uint64, bool) {
@@ -314,6 +382,10 @@ func shouldSkipFSMCompaction(status raftengine.Status) bool {
 	return status.AppliedIndex < status.CommitIndex
 }
 
+func isReplicatedLeader(status raftengine.Status) bool {
+	return status.State == raftengine.StateLeader && status.NumPeers > 0
+}
+
 func (c *FSMCompactor) compactionBackoffActive(groupID uint64, now time.Time) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -339,9 +411,43 @@ func (c *FSMCompactor) backoffCompaction(groupID uint64, d time.Duration) {
 	c.backoffUntil[groupID] = time.Now().Add(d)
 }
 
+func (c *FSMCompactor) leaderCompactionDue(groupID uint64, now time.Time) (bool, time.Time) {
+	if c.leaderCooldown <= 0 {
+		return true, time.Time{}
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ensureStateLocked()
+
+	until, ok := c.leaderUntil[groupID]
+	if !ok {
+		until = now.Add(c.leaderCooldown)
+		c.leaderUntil[groupID] = until
+		return false, until
+	}
+	if now.Before(until) {
+		return false, until
+	}
+	delete(c.leaderUntil, groupID)
+	return true, time.Time{}
+}
+
+func (c *FSMCompactor) cooldownLeaderCompaction(groupID uint64, d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ensureStateLocked()
+	c.leaderUntil[groupID] = time.Now().Add(d)
+}
+
 func (c *FSMCompactor) ensureStateLocked() {
 	if c.backoffUntil == nil {
 		c.backoffUntil = make(map[uint64]time.Time)
+	}
+	if c.leaderUntil == nil {
+		c.leaderUntil = make(map[uint64]time.Time)
 	}
 }
 

--- a/kv/compactor.go
+++ b/kv/compactor.go
@@ -280,6 +280,9 @@ func (c *FSMCompactor) lsmBackpressure(st store.MVCCStore) (bool, *pebble.Metric
 }
 
 func shouldSkipFSMCompaction(status raftengine.Status) bool {
+	if status.State == raftengine.StateLeader && status.NumPeers > 0 {
+		return true
+	}
 	if status.State == raftengine.StateCandidate {
 		return true
 	}

--- a/kv/compactor_test.go
+++ b/kv/compactor_test.go
@@ -174,11 +174,35 @@ func TestFSMCompactorSkipsLaggingRuntime(t *testing.T) {
 	require.Equal(t, []byte("v10"), val)
 }
 
-func TestFSMCompactorCompactsMultiPeerLeaderRuntimeWithShortTimeout(t *testing.T) {
+func TestFSMCompactorSkipsMultiPeerLeaderRuntimeDuringCooldown(t *testing.T) {
+	st := &deadlineCapturingStore{lastCommitTS: 20}
+	ctx := context.Background()
+
+	compactor := NewFSMCompactor(
+		[]FSMCompactRuntime{{
+			GroupID: 1,
+			StatusReader: fakeRaftStatus{status: raftengine.Status{
+				State:        raftengine.StateLeader,
+				FSMPending:   0,
+				AppliedIndex: 10,
+				CommitIndex:  10,
+				NumPeers:     1,
+			}},
+			Store: st,
+		}},
+		WithFSMCompactorInterval(time.Hour),
+		WithFSMCompactorRetentionWindow(time.Millisecond),
+	)
+
+	require.NoError(t, compactor.SyncOnce(ctx))
+	require.False(t, st.compactCalled)
+}
+
+func TestFSMCompactorCompactsMultiPeerLeaderRuntimeAfterCooldown(t *testing.T) {
 	st := &deadlineCapturingStore{lastCommitTS: 20}
 	ctx := context.Background()
 	leaderTimeout := 20 * time.Millisecond
-	start := time.Now()
+	leaderCooldown := 5 * time.Millisecond
 
 	compactor := NewFSMCompactor(
 		[]FSMCompactRuntime{{
@@ -196,8 +220,14 @@ func TestFSMCompactorCompactsMultiPeerLeaderRuntimeWithShortTimeout(t *testing.T
 		WithFSMCompactorRetentionWindow(time.Millisecond),
 		WithFSMCompactorTimeout(time.Hour),
 		WithFSMCompactorLeaderTimeout(leaderTimeout),
+		WithFSMCompactorLeaderCooldown(leaderCooldown),
 	)
 
+	require.NoError(t, compactor.SyncOnce(ctx))
+	require.False(t, st.compactCalled)
+
+	time.Sleep(leaderCooldown + 5*time.Millisecond)
+	start := time.Now()
 	require.NoError(t, compactor.SyncOnce(ctx))
 
 	require.True(t, st.compactCalled)
@@ -358,6 +388,7 @@ func TestFSMCompactorBacksOffLeaderRuntimeAfterTimeout(t *testing.T) {
 		WithFSMCompactorRetentionWindow(time.Millisecond),
 		WithFSMCompactorTimeout(time.Hour),
 		WithFSMCompactorLeaderTimeout(leaderTimeout),
+		WithFSMCompactorLeaderCooldown(0),
 		WithFSMCompactorTimeoutBackoff(time.Hour),
 	)
 
@@ -367,6 +398,45 @@ func TestFSMCompactorBacksOffLeaderRuntimeAfterTimeout(t *testing.T) {
 
 	require.NoError(t, compactor.SyncOnce(ctx))
 	require.Equal(t, 1, st.calls)
+}
+
+func TestFSMCompactorResumesLeaderRuntimeAfterTimeoutBackoffExpires(t *testing.T) {
+	st := &timeoutCompactionStore{
+		deadlineCapturingStore: deadlineCapturingStore{lastCommitTS: 20},
+	}
+	ctx := context.Background()
+	leaderTimeout := 5 * time.Millisecond
+	timeoutBackoff := 10 * time.Millisecond
+
+	compactor := NewFSMCompactor(
+		[]FSMCompactRuntime{{
+			GroupID: 1,
+			StatusReader: fakeRaftStatus{status: raftengine.Status{
+				State:        raftengine.StateLeader,
+				FSMPending:   0,
+				AppliedIndex: 10,
+				CommitIndex:  10,
+				NumPeers:     1,
+			}},
+			Store: st,
+		}},
+		WithFSMCompactorInterval(time.Hour),
+		WithFSMCompactorRetentionWindow(time.Millisecond),
+		WithFSMCompactorTimeout(time.Hour),
+		WithFSMCompactorLeaderTimeout(leaderTimeout),
+		WithFSMCompactorLeaderCooldown(0),
+		WithFSMCompactorTimeoutBackoff(timeoutBackoff),
+	)
+
+	require.Error(t, compactor.SyncOnce(ctx))
+	require.Equal(t, 1, st.calls)
+
+	require.NoError(t, compactor.SyncOnce(ctx))
+	require.Equal(t, 1, st.calls)
+
+	time.Sleep(timeoutBackoff + 5*time.Millisecond)
+	require.Error(t, compactor.SyncOnce(ctx))
+	require.Equal(t, 2, st.calls)
 }
 
 func TestFSMCompactorCompactsEligiblePebbleRuntime(t *testing.T) {

--- a/kv/compactor_test.go
+++ b/kv/compactor_test.go
@@ -160,11 +160,9 @@ func TestFSMCompactorSkipsLaggingRuntime(t *testing.T) {
 	require.Equal(t, []byte("v10"), val)
 }
 
-func TestFSMCompactorCompactsMultiPeerLeaderRuntimeWithShortTimeout(t *testing.T) {
+func TestFSMCompactorSkipsMultiPeerLeaderRuntime(t *testing.T) {
 	st := &deadlineCapturingStore{lastCommitTS: 20}
 	ctx := context.Background()
-	leaderTimeout := 20 * time.Millisecond
-	start := time.Now()
 
 	compactor := NewFSMCompactor(
 		[]FSMCompactRuntime{{
@@ -180,15 +178,10 @@ func TestFSMCompactorCompactsMultiPeerLeaderRuntimeWithShortTimeout(t *testing.T
 		}},
 		WithFSMCompactorInterval(time.Hour),
 		WithFSMCompactorRetentionWindow(time.Millisecond),
-		WithFSMCompactorTimeout(time.Hour),
-		WithFSMCompactorLeaderTimeout(leaderTimeout),
 	)
 
 	require.NoError(t, compactor.SyncOnce(ctx))
-
-	require.True(t, st.compactCalled)
-	require.True(t, st.hasDeadline)
-	requireDeadlineWithin(t, st.deadline, start, leaderTimeout)
+	require.False(t, st.compactCalled)
 }
 
 func TestFSMCompactorCompactsMultiPeerFollowerRuntimeWithConfiguredTimeout(t *testing.T) {

--- a/kv/compactor_test.go
+++ b/kv/compactor_test.go
@@ -60,6 +60,20 @@ func (s *metricsCapturingStore) Metrics() *pebble.Metrics {
 	return s.metrics
 }
 
+type timeoutCompactionStore struct {
+	deadlineCapturingStore
+	calls int
+}
+
+func (s *timeoutCompactionStore) Compact(ctx context.Context, minTS uint64) error {
+	s.calls++
+	s.compactCalled = true
+	s.compactMinTS = minTS
+	s.deadline, s.hasDeadline = ctx.Deadline()
+	<-ctx.Done()
+	return ctx.Err()
+}
+
 func requireDeadlineWithin(t *testing.T, deadline time.Time, start time.Time, timeout time.Duration) {
 	t.Helper()
 	require.False(t, deadline.Before(start))
@@ -160,9 +174,11 @@ func TestFSMCompactorSkipsLaggingRuntime(t *testing.T) {
 	require.Equal(t, []byte("v10"), val)
 }
 
-func TestFSMCompactorSkipsMultiPeerLeaderRuntime(t *testing.T) {
+func TestFSMCompactorCompactsMultiPeerLeaderRuntimeWithShortTimeout(t *testing.T) {
 	st := &deadlineCapturingStore{lastCommitTS: 20}
 	ctx := context.Background()
+	leaderTimeout := 20 * time.Millisecond
+	start := time.Now()
 
 	compactor := NewFSMCompactor(
 		[]FSMCompactRuntime{{
@@ -178,10 +194,15 @@ func TestFSMCompactorSkipsMultiPeerLeaderRuntime(t *testing.T) {
 		}},
 		WithFSMCompactorInterval(time.Hour),
 		WithFSMCompactorRetentionWindow(time.Millisecond),
+		WithFSMCompactorTimeout(time.Hour),
+		WithFSMCompactorLeaderTimeout(leaderTimeout),
 	)
 
 	require.NoError(t, compactor.SyncOnce(ctx))
-	require.False(t, st.compactCalled)
+
+	require.True(t, st.compactCalled)
+	require.True(t, st.hasDeadline)
+	requireDeadlineWithin(t, st.deadline, start, leaderTimeout)
 }
 
 func TestFSMCompactorCompactsMultiPeerFollowerRuntimeWithConfiguredTimeout(t *testing.T) {
@@ -312,6 +333,40 @@ func TestFSMCompactorCompactsSingleNodeLeaderRuntimeWithShortTimeout(t *testing.
 	require.True(t, st.compactCalled)
 	require.True(t, st.hasDeadline)
 	requireDeadlineWithin(t, st.deadline, start, leaderTimeout)
+}
+
+func TestFSMCompactorBacksOffLeaderRuntimeAfterTimeout(t *testing.T) {
+	st := &timeoutCompactionStore{
+		deadlineCapturingStore: deadlineCapturingStore{lastCommitTS: 20},
+	}
+	ctx := context.Background()
+	leaderTimeout := 5 * time.Millisecond
+
+	compactor := NewFSMCompactor(
+		[]FSMCompactRuntime{{
+			GroupID: 1,
+			StatusReader: fakeRaftStatus{status: raftengine.Status{
+				State:        raftengine.StateLeader,
+				FSMPending:   0,
+				AppliedIndex: 10,
+				CommitIndex:  10,
+				NumPeers:     1,
+			}},
+			Store: st,
+		}},
+		WithFSMCompactorInterval(time.Hour),
+		WithFSMCompactorRetentionWindow(time.Millisecond),
+		WithFSMCompactorTimeout(time.Hour),
+		WithFSMCompactorLeaderTimeout(leaderTimeout),
+		WithFSMCompactorTimeoutBackoff(time.Hour),
+	)
+
+	require.Error(t, compactor.SyncOnce(ctx))
+	require.True(t, st.hasDeadline)
+	require.Equal(t, 1, st.calls)
+
+	require.NoError(t, compactor.SyncOnce(ctx))
+	require.Equal(t, 1, st.calls)
 }
 
 func TestFSMCompactorCompactsEligiblePebbleRuntime(t *testing.T) {

--- a/kv/lock_resolver.go
+++ b/kv/lock_resolver.go
@@ -1,9 +1,11 @@
 package kv
 
 import (
+	"bytes"
 	"context"
 	"log/slog"
 	"math"
+	"sync"
 	"time"
 
 	"github.com/bootjp/elastickv/internal/raftengine"
@@ -24,6 +26,9 @@ const (
 	// lockResolverOperationBudget bounds a single background resolution attempt.
 	// Foreground read/write paths still use their own caller deadlines.
 	lockResolverOperationBudget = 250 * time.Millisecond
+	// lockResolverBudgetBackoff keeps best-effort cleanup from immediately
+	// hammering the same saturated Raft/LSM path after a budget timeout.
+	lockResolverBudgetBackoff   = time.Minute
 	lockResolverMaxL0Files      = defaultFSMCompactorMaxL0Files
 	lockResolverMaxL0Sublevels  = defaultFSMCompactorMaxL0Sublevels
 	lockResolverMaxLSMDebtBytes = defaultFSMCompactorMaxLSMDebtBytes
@@ -35,11 +40,14 @@ var errLockResolverBudgetExhausted = errors.New("lock resolver budget exhausted"
 // them. This handles the case where secondary commit fails and leaves orphaned
 // locks that no read path would discover (e.g., cold keys).
 type LockResolver struct {
-	store  *ShardStore
-	groups map[uint64]*ShardGroup
-	log    *slog.Logger
-	cancel context.CancelFunc
-	done   chan struct{}
+	store             *ShardStore
+	groups            map[uint64]*ShardGroup
+	log               *slog.Logger
+	mu                sync.Mutex
+	nextLockScanStart map[uint64][]byte
+	resolveBackoff    map[uint64]time.Time
+	cancel            context.CancelFunc
+	done              chan struct{}
 }
 
 // NewLockResolver creates and starts a background lock resolver.
@@ -49,11 +57,13 @@ func NewLockResolver(ss *ShardStore, groups map[uint64]*ShardGroup, log *slog.Lo
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	lr := &LockResolver{
-		store:  ss,
-		groups: groups,
-		log:    log,
-		cancel: cancel,
-		done:   make(chan struct{}),
+		store:             ss,
+		groups:            groups,
+		log:               log,
+		nextLockScanStart: make(map[uint64][]byte),
+		resolveBackoff:    make(map[uint64]time.Time),
+		cancel:            cancel,
+		done:              make(chan struct{}),
 	}
 	go lr.run(ctx)
 	return lr
@@ -89,6 +99,9 @@ func (lr *LockResolver) resolveAllGroups(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
+		if lr.resolveBackoffActive(gid, time.Now()) {
+			continue
+		}
 		if passCtx.Err() != nil {
 			lr.logLockResolverYield(gid, passCtx.Err())
 			return
@@ -96,6 +109,7 @@ func (lr *LockResolver) resolveAllGroups(ctx context.Context) {
 		err := lr.resolveGroupLocks(passCtx, gid, g)
 		if err != nil {
 			if errors.Is(err, errLockResolverBudgetExhausted) || lockResolverBudgetExhausted(err, passCtx, ctx) {
+				lr.backoffGroupResolve(gid, lockResolverBudgetBackoff)
 				lr.logLockResolverYield(gid, err)
 				return
 			}
@@ -113,12 +127,17 @@ func (lr *LockResolver) resolveGroupLocks(ctx context.Context, gid uint64, g *Sh
 	}
 
 	// Scan lock key range: [!txn|lock| ... prefixEnd(!txn|lock|))
-	lockStart := txnLockKey(nil)
-	lockEnd := prefixScanEnd(lockStart)
+	lockRangeStart := txnLockKey(nil)
+	lockEnd := prefixScanEnd(lockRangeStart)
+	lockStart := lr.lockScanStart(gid, lockRangeStart, lockEnd)
 
 	lockKVs, err := g.Store.ScanAt(ctx, lockStart, lockEnd, lockResolverBatchSize, math.MaxUint64)
 	if err != nil {
 		return errors.WithStack(err)
+	}
+	if len(lockKVs) == 0 {
+		lr.resetLockScanStart(gid)
+		return nil
 	}
 
 	var resolved, skipped int
@@ -126,6 +145,7 @@ func (lr *LockResolver) resolveGroupLocks(ctx context.Context, gid uint64, g *Sh
 		if ctx.Err() != nil {
 			return errors.WithStack(ctx.Err())
 		}
+		lr.advanceLockScanStart(gid, kvp.Key, lockEnd)
 		if !lockResolverRaftReady(engineForGroup(g)) {
 			return nil
 		}
@@ -136,6 +156,9 @@ func (lr *LockResolver) resolveGroupLocks(ctx context.Context, gid uint64, g *Sh
 		resolvedDelta, skippedDelta := lockResolveOutcomeCounts(outcome)
 		resolved += resolvedDelta
 		skipped += skippedDelta
+	}
+	if len(lockKVs) < lockResolverBatchSize {
+		lr.resetLockScanStart(gid)
 	}
 
 	if resolved > 0 {
@@ -246,8 +269,84 @@ func (lr *LockResolver) primaryGroupReadyForBackgroundAbort(primaryKey []byte) b
 func (lr *LockResolver) logLockResolverYield(gid uint64, err error) {
 	lr.log.Warn("lock resolver: yielding after resolver budget",
 		slog.Uint64("gid", gid),
+		slog.Duration("backoff", lockResolverBudgetBackoff),
 		slog.Any("err", err),
 	)
+}
+
+func (lr *LockResolver) lockScanStart(gid uint64, lockRangeStart, lockRangeEnd []byte) []byte {
+	lr.mu.Lock()
+	defer lr.mu.Unlock()
+
+	start := lr.nextLockScanStart[gid]
+	if len(start) == 0 || !lockScanStartInRange(start, lockRangeStart, lockRangeEnd) {
+		return append([]byte(nil), lockRangeStart...)
+	}
+	return append([]byte(nil), start...)
+}
+
+func (lr *LockResolver) advanceLockScanStart(gid uint64, key, lockRangeEnd []byte) {
+	next := lockResolverNextScanStartAfter(key, lockRangeEnd)
+	lr.mu.Lock()
+	defer lr.mu.Unlock()
+	lr.ensureStateLocked()
+	if len(next) == 0 {
+		delete(lr.nextLockScanStart, gid)
+		return
+	}
+	lr.nextLockScanStart[gid] = next
+}
+
+func (lr *LockResolver) resetLockScanStart(gid uint64) {
+	lr.mu.Lock()
+	defer lr.mu.Unlock()
+	delete(lr.nextLockScanStart, gid)
+}
+
+func (lr *LockResolver) resolveBackoffActive(gid uint64, now time.Time) bool {
+	lr.mu.Lock()
+	defer lr.mu.Unlock()
+
+	until, ok := lr.resolveBackoff[gid]
+	if !ok {
+		return false
+	}
+	if now.Before(until) {
+		return true
+	}
+	delete(lr.resolveBackoff, gid)
+	return false
+}
+
+func (lr *LockResolver) backoffGroupResolve(gid uint64, d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	lr.mu.Lock()
+	defer lr.mu.Unlock()
+	lr.ensureStateLocked()
+	lr.resolveBackoff[gid] = time.Now().Add(d)
+}
+
+func (lr *LockResolver) ensureStateLocked() {
+	if lr.nextLockScanStart == nil {
+		lr.nextLockScanStart = make(map[uint64][]byte)
+	}
+	if lr.resolveBackoff == nil {
+		lr.resolveBackoff = make(map[uint64]time.Time)
+	}
+}
+
+func lockScanStartInRange(start, lockRangeStart, lockRangeEnd []byte) bool {
+	return bytes.Compare(start, lockRangeStart) >= 0 && (len(lockRangeEnd) == 0 || bytes.Compare(start, lockRangeEnd) < 0)
+}
+
+func lockResolverNextScanStartAfter(key, lockRangeEnd []byte) []byte {
+	next := append(append([]byte(nil), key...), 0)
+	if len(lockRangeEnd) > 0 && bytes.Compare(next, lockRangeEnd) >= 0 {
+		return nil
+	}
+	return next
 }
 
 func lockResolverRaftReady(engine interface {
@@ -293,7 +392,7 @@ func lockResolverBudgetExhausted(err error, workCtx, parentCtx context.Context) 
 	if parentCtx != nil && parentCtx.Err() != nil {
 		return false
 	}
-	return workCtx.Err() != nil && errors.Is(err, workCtx.Err())
+	return workCtx.Err() != nil
 }
 
 func (lr *LockResolver) resolveExpiredLock(ctx context.Context, g *ShardGroup, userKey []byte, lock txnLock) error {

--- a/kv/lock_resolver.go
+++ b/kv/lock_resolver.go
@@ -145,7 +145,6 @@ func (lr *LockResolver) resolveGroupLocks(ctx context.Context, gid uint64, g *Sh
 		if ctx.Err() != nil {
 			return errors.WithStack(ctx.Err())
 		}
-		lr.advanceLockScanStart(gid, kvp.Key, lockEnd)
 		if !lockResolverRaftReady(engineForGroup(g)) {
 			return nil
 		}
@@ -153,6 +152,7 @@ func (lr *LockResolver) resolveGroupLocks(ctx context.Context, gid uint64, g *Sh
 		if err != nil {
 			return err
 		}
+		lr.advanceLockScanStart(gid, kvp.Key, lockEnd)
 		resolvedDelta, skippedDelta := lockResolveOutcomeCounts(outcome)
 		resolved += resolvedDelta
 		skipped += skippedDelta

--- a/kv/lock_resolver_test.go
+++ b/kv/lock_resolver_test.go
@@ -45,6 +45,13 @@ func setupLockResolverEnv(t *testing.T) (*LockResolver, *ShardStore, map[uint64]
 	}
 }
 
+func requireLockResolverGroupReady(t *testing.T, g *ShardGroup) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return lockResolverGroupCanResolve(g)
+	}, time.Second, 10*time.Millisecond)
+}
+
 // prepareLock writes a PREPARE request (which creates a lock) for a key.
 func prepareLock(t *testing.T, g *ShardGroup, startTS uint64, key, primaryKey, value []byte, lockTTLms uint64) {
 	t.Helper()
@@ -100,6 +107,7 @@ func TestLockResolver_ResolvesExpiredCommittedLock(t *testing.T) {
 	commitPrimary(t, groups[1], startTS, commitTS, primaryKey)
 
 	// Run the resolver on the secondary shard — it should resolve the lock.
+	requireLockResolverGroupReady(t, groups[2])
 	err := lr.resolveGroupLocks(ctx, 2, groups[2])
 	require.NoError(t, err)
 
@@ -129,6 +137,7 @@ func TestLockResolver_ResolvesCommittedLockWhenPrimaryGroupBackpressured(t *test
 	metrics.Levels[0].Sublevels = lockResolverMaxL0Sublevels
 	groups[1].Store = &lockResolverBackpressureStore{MVCCStore: groups[1].Store, metrics: metrics}
 
+	requireLockResolverGroupReady(t, groups[2])
 	err := lr.resolveGroupLocks(ctx, 2, groups[2])
 	require.NoError(t, err)
 
@@ -161,6 +170,7 @@ func TestLockResolver_ResolvesExpiredCommittedPrimaryLock(t *testing.T) {
 	})
 	require.NoError(t, groups[1].Store.PutAt(ctx, txnLockKey(primaryKey), staleLock, commitTS, 0))
 
+	requireLockResolverGroupReady(t, groups[1])
 	err := lr.resolveGroupLocks(ctx, 1, groups[1])
 	require.NoError(t, err)
 
@@ -200,6 +210,7 @@ func TestLockResolver_ResolvesExpiredRolledBackLock(t *testing.T) {
 	require.NoError(t, err)
 
 	// Resolve expired locks on the secondary shard.
+	requireLockResolverGroupReady(t, groups[2])
 	err = lr.resolveGroupLocks(ctx, 2, groups[2])
 	require.NoError(t, err)
 
@@ -226,6 +237,7 @@ func TestLockResolver_SkipsPendingPrimaryAbortWhenPrimaryGroupBackpressured(t *t
 	metrics.Levels[0].Sublevels = lockResolverMaxL0Sublevels
 	groups[1].Store = &lockResolverBackpressureStore{MVCCStore: groups[1].Store, metrics: metrics}
 
+	requireLockResolverGroupReady(t, groups[2])
 	err := lr.resolveGroupLocks(ctx, 2, groups[2])
 	require.NoError(t, err)
 
@@ -247,6 +259,7 @@ func TestLockResolver_SkipsNonExpiredLocks(t *testing.T) {
 	prepareLock(t, groups[1], startTS, key, key, []byte("v1"), 60_000)
 
 	// Run the resolver — it should not touch this lock.
+	requireLockResolverGroupReady(t, groups[1])
 	err := lr.resolveGroupLocks(ctx, 1, groups[1])
 	require.NoError(t, err)
 

--- a/kv/lock_resolver_test.go
+++ b/kv/lock_resolver_test.go
@@ -1,7 +1,9 @@
 package kv
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -447,6 +449,52 @@ func TestLockResolverLSMBackpressured(t *testing.T) {
 			require.Equal(t, tc.want, overloaded)
 		})
 	}
+}
+
+func TestLockResolverScanCursorAdvancesAfterKey(t *testing.T) {
+	t.Parallel()
+
+	lockEnd := prefixScanEnd(txnLockKey(nil))
+	key := txnLockKey([]byte("queue:0"))
+
+	next := lockResolverNextScanStartAfter(key, lockEnd)
+	require.NotEmpty(t, next)
+	require.Greater(t, bytes.Compare(next, key), 0)
+	require.Less(t, bytes.Compare(next, lockEnd), 0)
+	require.Equal(t, append(append([]byte(nil), key...), 0), next)
+}
+
+func TestLockResolverScanCursorWrapsAtRangeEnd(t *testing.T) {
+	t.Parallel()
+
+	lockEnd := prefixScanEnd(txnLockKey(nil))
+	require.Empty(t, lockResolverNextScanStartAfter([]byte{0xff}, lockEnd))
+	require.Empty(t, lockResolverNextScanStartAfter(lockEnd, lockEnd))
+}
+
+func TestLockResolverBackoffActiveExpires(t *testing.T) {
+	t.Parallel()
+
+	lr := &LockResolver{resolveBackoff: make(map[uint64]time.Time)}
+	lr.resolveBackoff[1] = time.Now().Add(time.Second)
+
+	require.True(t, lr.resolveBackoffActive(1, time.Now()))
+	require.False(t, lr.resolveBackoffActive(1, time.Now().Add(2*time.Second)))
+	require.Empty(t, lr.resolveBackoff)
+}
+
+func TestLockResolverBudgetExhaustedUsesWorkContext(t *testing.T) {
+	t.Parallel()
+
+	workCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.True(t, lockResolverBudgetExhausted(errors.New("grpc deadline"), workCtx, context.Background()))
+
+	parentCtx, cancelParent := context.WithCancel(context.Background())
+	cancelParent()
+	require.False(t, lockResolverBudgetExhausted(errors.New("grpc deadline"), workCtx, parentCtx))
+	require.False(t, lockResolverBudgetExhausted(errors.New("grpc deadline"), context.Background(), context.Background()))
 }
 
 type lockResolverStatusEngine struct {


### PR DESCRIPTION
## Summary
- skip FSM compaction on multi-peer Raft leaders so best-effort MVCC GC does not contend with leader lease/propose work
- add a per-group lock resolver scan cursor and budget backoff after timeout
- treat work-context deadline expiry as resolver budget exhaustion even when the returned error is a gRPC DeadlineExceeded

## Risk
- expired orphan lock cleanup may be delayed after timeout, but foreground paths still resolve locks they encounter
- FSM compaction still runs on followers and single-node leaders; multi-peer leaders avoid best-effort compaction to preserve availability

## Tests
- GOCACHE=$(pwd)/.cache GOTMPDIR=$(pwd)/.cache/tmp go test ./kv -run 'Test(FSMCompactor|LockResolver)'\n- GOCACHE=$(pwd)/.cache GOTMPDIR=$(pwd)/.cache/tmp go test ./adapter -run 'TestDeltaCompactor' -count=1 -timeout=2m\n- GOCACHE=$(pwd)/.cache GOTMPDIR=$(pwd)/.cache/tmp go test ./... (fails: existing TestRedis_StreamXReadLatencyIsConstant timeout; reproduced on clean origin/main with the same command subset)\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * ロック解決のスキャン位置をグループごとに保持し、処理量超過時はグループ単位でバックオフして安定性と効率を向上しました。
  * リーダータイムアウト後のFSMコンパクションを抑制するバックオフ挙動を追加し、リトライの増加を抑えました。
* **テスト**
  * ロック解決のスキャン再開・折り返し・バックオフ期限切れの検証を追加しました。
  * リーダータイムアウト後にコンパクションが抑制されることを検証するテストを更新・追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->