### PR TITLE
Limit Redis proxy ElasticKV pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ docker run --rm \
   -listen :6479 \
   -primary redis.internal:6379 \
   -secondary elastickv.internal:6380 \
+  -elastickv-pool-size 4 \
   -mode dual-write
 ```
 

--- a/cmd/redis-proxy/main.go
+++ b/cmd/redis-proxy/main.go
@@ -33,6 +33,8 @@ func main() {
 func run() error {
 	cfg := proxy.DefaultConfig()
 	var modeStr string
+	primaryPoolSize := proxy.DefaultBackendOptions().PoolSize
+	elasticKVPoolSize := proxy.DefaultElasticKVBackendOptions().PoolSize
 
 	flag.StringVar(&cfg.ListenAddr, "listen", cfg.ListenAddr, "Proxy listen address")
 	flag.StringVar(&cfg.PrimaryAddr, "primary", cfg.PrimaryAddr, "Primary (Redis) address")
@@ -41,6 +43,8 @@ func run() error {
 	flag.StringVar(&cfg.SecondaryAddr, "secondary", cfg.SecondaryAddr, "Secondary (ElasticKV) address. Comma-separated list of seeds is supported; the proxy discovers the current Raft leader via INFO replication.")
 	flag.IntVar(&cfg.SecondaryDB, "secondary-db", cfg.SecondaryDB, "Secondary Redis DB number")
 	flag.StringVar(&cfg.SecondaryPassword, "secondary-password", cfg.SecondaryPassword, "Secondary Redis password")
+	flag.IntVar(&primaryPoolSize, "primary-pool-size", primaryPoolSize, "Primary Redis backend connection pool size")
+	flag.IntVar(&elasticKVPoolSize, "elastickv-pool-size", elasticKVPoolSize, "ElasticKV backend connection pool size")
 	flag.StringVar(&modeStr, "mode", "dual-write", "Proxy mode: redis-only, dual-write, dual-write-shadow, elastickv-primary, elastickv-only")
 	flag.DurationVar(&cfg.SecondaryTimeout, "secondary-timeout", cfg.SecondaryTimeout, "Secondary write timeout")
 	flag.DurationVar(&cfg.ShadowTimeout, "shadow-timeout", cfg.ShadowTimeout, "Shadow read timeout")
@@ -50,9 +54,9 @@ func run() error {
 	flag.StringVar(&cfg.MetricsAddr, "metrics", cfg.MetricsAddr, "Prometheus metrics address")
 	flag.Parse()
 
-	mode, ok := proxy.ParseProxyMode(modeStr)
-	if !ok {
-		return fmt.Errorf("unknown mode: %s", modeStr)
+	mode, err := parseRuntimeOptions(modeStr, primaryPoolSize, elasticKVPoolSize)
+	if err != nil {
+		return err
 	}
 	cfg.Mode = mode
 
@@ -70,9 +74,11 @@ func run() error {
 	primaryOpts := proxy.DefaultBackendOptions()
 	primaryOpts.DB = cfg.PrimaryDB
 	primaryOpts.Password = cfg.PrimaryPassword
-	secondaryOpts := proxy.DefaultBackendOptions()
+	primaryOpts.PoolSize = primaryPoolSize
+	secondaryOpts := proxy.DefaultElasticKVBackendOptions()
 	secondaryOpts.DB = cfg.SecondaryDB
 	secondaryOpts.Password = cfg.SecondaryPassword
+	secondaryOpts.PoolSize = elasticKVPoolSize
 
 	secondarySeeds := parseAddrList(cfg.SecondaryAddr)
 	if len(secondarySeeds) == 0 {
@@ -129,6 +135,20 @@ func run() error {
 		return fmt.Errorf("proxy server: %w", err)
 	}
 	return nil
+}
+
+func parseRuntimeOptions(modeStr string, primaryPoolSize, elasticKVPoolSize int) (proxy.ProxyMode, error) {
+	mode, ok := proxy.ParseProxyMode(modeStr)
+	if !ok {
+		return 0, fmt.Errorf("unknown mode: %s", modeStr)
+	}
+	if primaryPoolSize <= 0 {
+		return 0, fmt.Errorf("primary-pool-size must be positive: %d", primaryPoolSize)
+	}
+	if elasticKVPoolSize <= 0 {
+		return 0, fmt.Errorf("elastickv-pool-size must be positive: %d", elasticKVPoolSize)
+	}
+	return mode, nil
 }
 
 func parseAddrList(raw string) []string {

--- a/deploy/redis-proxy/docker-compose.ha.yml
+++ b/deploy/redis-proxy/docker-compose.ha.yml
@@ -26,6 +26,7 @@ services:
       - -listen=:6379
       - -primary=${REDIS_PROXY_PRIMARY:-redis:6379}
       - -secondary=${REDIS_PROXY_SECONDARY:-elastickv:6380}
+      - -elastickv-pool-size=${REDIS_PROXY_ELASTICKV_POOL_SIZE:-4}
       - -mode=${REDIS_PROXY_MODE:-dual-write-shadow}
       - -metrics=:9191
     networks:
@@ -45,6 +46,7 @@ services:
       - -listen=:6379
       - -primary=${REDIS_PROXY_PRIMARY:-redis:6379}
       - -secondary=${REDIS_PROXY_SECONDARY:-elastickv:6380}
+      - -elastickv-pool-size=${REDIS_PROXY_ELASTICKV_POOL_SIZE:-4}
       - -mode=${REDIS_PROXY_MODE:-dual-write-shadow}
       - -metrics=:9191
     networks:

--- a/docs/redis-proxy-deployment.md
+++ b/docs/redis-proxy-deployment.md
@@ -34,6 +34,8 @@ go build -o redis-proxy ./cmd/redis-proxy/
 | `-secondary` | `localhost:6380` | Secondary (ElasticKV) address |
 | `-secondary-db` | `0` | Secondary Redis DB number |
 | `-secondary-password` | (empty) | Secondary Redis password |
+| `-primary-pool-size` | `128` | Primary Redis backend connection pool size |
+| `-elastickv-pool-size` | `4` | ElasticKV backend connection pool size |
 | `-mode` | `dual-write` | Proxy mode (see below) |
 | `-secondary-timeout` | `5s` | Secondary write timeout |
 | `-shadow-timeout` | `3s` | Shadow read timeout |
@@ -88,6 +90,7 @@ docker run --rm \
   -primary redis.internal:6379 \
   -primary-password "${REDIS_PASSWORD}" \
   -secondary elastickv.internal:6380 \
+  -elastickv-pool-size 4 \
   -mode dual-write-shadow \
   -secondary-timeout 5s \
   -shadow-timeout 3s \
@@ -109,6 +112,7 @@ services:
       - -listen=:6479
       - -primary=redis:6379
       - -secondary=elastickv:6380
+      - -elastickv-pool-size=4
       - -mode=dual-write-shadow
       - -metrics=:9191
     depends_on:
@@ -201,6 +205,7 @@ Override backend wiring via env vars before `docker compose up`:
 ```bash
 REDIS_PROXY_PRIMARY=redis.prod.internal:6379 \
 REDIS_PROXY_SECONDARY=elastickv-1.prod.internal:6380,elastickv-2.prod.internal:6380,elastickv-3.prod.internal:6380 \
+REDIS_PROXY_ELASTICKV_POOL_SIZE=4 \
 REDIS_PROXY_MODE=dual-write-shadow \
   docker compose -f docker-compose.ha.yml up -d
 ```

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -10,12 +10,13 @@ import (
 )
 
 const (
-	defaultPoolSize     = 128
-	defaultDialTimeout  = 5 * time.Second
-	defaultReadTimeout  = 3 * time.Second
-	defaultWriteTimeout = 3 * time.Second
-	blockingReadGrace   = 10 * time.Second
-	respProtocolV2      = 2
+	defaultPoolSize          = 128
+	defaultElasticKVPoolSize = 4
+	defaultDialTimeout       = 5 * time.Second
+	defaultReadTimeout       = 3 * time.Second
+	defaultWriteTimeout      = 3 * time.Second
+	blockingReadGrace        = 10 * time.Second
+	respProtocolV2           = 2
 )
 
 // Backend abstracts a Redis-protocol endpoint (real Redis or ElasticKV).
@@ -48,6 +49,16 @@ func DefaultBackendOptions() BackendOptions {
 		ReadTimeout:  defaultReadTimeout,
 		WriteTimeout: defaultWriteTimeout,
 	}
+}
+
+// DefaultElasticKVBackendOptions returns defaults for proxy backends that
+// connect to ElasticKV's Redis adapter. ElasticKV limits concurrent Redis
+// connections per peer by default, so keep the pool below that cap unless the
+// operator also raises ELASTICKV_REDIS_PER_PEER_CONNECTIONS on the cluster.
+func DefaultElasticKVBackendOptions() BackendOptions {
+	opts := DefaultBackendOptions()
+	opts.PoolSize = defaultElasticKVPoolSize
+	return opts
 }
 
 // PubSubBackend is an optional interface for backends that support

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -813,6 +813,14 @@ func TestDefaultBackendOptions(t *testing.T) {
 	assert.Equal(t, 5*time.Second, opts.DialTimeout)
 }
 
+func TestDefaultElasticKVBackendOptions(t *testing.T) {
+	opts := DefaultElasticKVBackendOptions()
+	assert.Equal(t, 4, opts.PoolSize)
+	assert.Equal(t, 5*time.Second, opts.DialTimeout)
+	assert.Equal(t, 3*time.Second, opts.ReadTimeout)
+	assert.Equal(t, 3*time.Second, opts.WriteTimeout)
+}
+
 func TestNewRedisBackend_UsesRESP2(t *testing.T) {
 	backend := NewRedisBackend("127.0.0.1:6379", "test")
 	t.Cleanup(func() {


### PR DESCRIPTION
## Summary
- lower the default ElasticKV backend pool for redis-proxy to 4 connections
- add `-elastickv-pool-size` so operators can tune the pool with the cluster per-peer limit
- document the new option in deployment examples and HA compose

## Root cause
The redis-proxy ElasticKV backend used the generic go-redis pool default of 128 connections, while ElasticKV Redis adapter defaults to 8 concurrent connections per peer. Under dual-write load from a single proxy host, new connections from that host exceeded the adapter cap and surfaced as EOF / connection reset / broken pipe errors during secondary writes and leader probes.

## Validation
- `GOCACHE=$(pwd)/.cache GOTMPDIR=$(pwd)/.cache/tmp go test ./cmd/redis-proxy ./proxy`
- pre-fix runtime check on 192.168.0.64 showed recent proxy reset spam and `INFO replication` returning `ERR max connections per client exceeded` from 192.168.0.210


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * プライマリおよび ElasticKV バックエンドの接続プールサイズを設定できるようになりました。
  * 不正なプールサイズや未知の実行モードを検出し、エラーを表示します。
  * HA 構成で ElasticKV 接続プールサイズを環境変数から変更できるようになりました。

* **ドキュメント**
  * Docker、Docker Compose、HA 構成の設定例に新しいオプションを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->