### PR TITLE
Limit Redis proxy secondary concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ docker run --rm \
   -primary redis.internal:6379 \
   -secondary elastickv.internal:6380 \
   -elastickv-pool-size 4 \
+  -secondary-write-concurrency 2 \
+  -secondary-script-concurrency 1 \
   -mode dual-write
 ```
 

--- a/cmd/redis-proxy/main.go
+++ b/cmd/redis-proxy/main.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	sentryFlushTimeout     = 2 * time.Second
-	metricsShutdownTimeout = 5 * time.Second
+	sentryFlushTimeout          = 2 * time.Second
+	metricsShutdownTimeout      = 5 * time.Second
+	secondaryConcurrencyDivisor = 2
 )
 
 func main() {
@@ -35,6 +36,8 @@ func run() error {
 	var modeStr string
 	primaryPoolSize := proxy.DefaultBackendOptions().PoolSize
 	elasticKVPoolSize := proxy.DefaultElasticKVBackendOptions().PoolSize
+	secondaryWriteConcurrency := 0
+	secondaryScriptConcurrency := 0
 
 	flag.StringVar(&cfg.ListenAddr, "listen", cfg.ListenAddr, "Proxy listen address")
 	flag.StringVar(&cfg.PrimaryAddr, "primary", cfg.PrimaryAddr, "Primary (Redis) address")
@@ -45,6 +48,8 @@ func run() error {
 	flag.StringVar(&cfg.SecondaryPassword, "secondary-password", cfg.SecondaryPassword, "Secondary Redis password")
 	flag.IntVar(&primaryPoolSize, "primary-pool-size", primaryPoolSize, "Primary Redis backend connection pool size")
 	flag.IntVar(&elasticKVPoolSize, "elastickv-pool-size", elasticKVPoolSize, "ElasticKV backend connection pool size")
+	flag.IntVar(&secondaryWriteConcurrency, "secondary-write-concurrency", secondaryWriteConcurrency, "Maximum concurrent asynchronous secondary writes (0 = half of secondary backend pool size)")
+	flag.IntVar(&secondaryScriptConcurrency, "secondary-script-concurrency", secondaryScriptConcurrency, "Maximum concurrent asynchronous secondary Lua-script writes (0 = half of secondary write concurrency)")
 	flag.StringVar(&modeStr, "mode", "dual-write", "Proxy mode: redis-only, dual-write, dual-write-shadow, elastickv-primary, elastickv-only")
 	flag.DurationVar(&cfg.SecondaryTimeout, "secondary-timeout", cfg.SecondaryTimeout, "Secondary write timeout")
 	flag.DurationVar(&cfg.ShadowTimeout, "shadow-timeout", cfg.ShadowTimeout, "Shadow read timeout")
@@ -54,11 +59,18 @@ func run() error {
 	flag.StringVar(&cfg.MetricsAddr, "metrics", cfg.MetricsAddr, "Prometheus metrics address")
 	flag.Parse()
 
-	mode, err := parseRuntimeOptions(modeStr, primaryPoolSize, elasticKVPoolSize)
+	mode, err := parseRuntimeOptions(modeStr, primaryPoolSize, elasticKVPoolSize, secondaryWriteConcurrency, secondaryScriptConcurrency)
 	if err != nil {
 		return err
 	}
 	cfg.Mode = mode
+	cfg.SecondaryWriteConcurrency, cfg.SecondaryScriptConcurrency = deriveSecondaryConcurrency(
+		mode,
+		primaryPoolSize,
+		elasticKVPoolSize,
+		secondaryWriteConcurrency,
+		secondaryScriptConcurrency,
+	)
 
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
@@ -137,7 +149,7 @@ func run() error {
 	return nil
 }
 
-func parseRuntimeOptions(modeStr string, primaryPoolSize, elasticKVPoolSize int) (proxy.ProxyMode, error) {
+func parseRuntimeOptions(modeStr string, primaryPoolSize, elasticKVPoolSize, secondaryWriteConcurrency, secondaryScriptConcurrency int) (proxy.ProxyMode, error) {
 	mode, ok := proxy.ParseProxyMode(modeStr)
 	if !ok {
 		return 0, fmt.Errorf("unknown mode: %s", modeStr)
@@ -148,7 +160,45 @@ func parseRuntimeOptions(modeStr string, primaryPoolSize, elasticKVPoolSize int)
 	if elasticKVPoolSize <= 0 {
 		return 0, fmt.Errorf("elastickv-pool-size must be positive: %d", elasticKVPoolSize)
 	}
+	if secondaryWriteConcurrency < 0 {
+		return 0, fmt.Errorf("secondary-write-concurrency must be non-negative: %d", secondaryWriteConcurrency)
+	}
+	if secondaryScriptConcurrency < 0 {
+		return 0, fmt.Errorf("secondary-script-concurrency must be non-negative: %d", secondaryScriptConcurrency)
+	}
 	return mode, nil
+}
+
+func deriveSecondaryConcurrency(mode proxy.ProxyMode, primaryPoolSize, elasticKVPoolSize, writeConcurrency, scriptConcurrency int) (int, int) {
+	if writeConcurrency == 0 {
+		writeConcurrency = defaultSecondaryWriteConcurrency(secondaryBackendPoolSize(mode, primaryPoolSize, elasticKVPoolSize))
+	}
+	if scriptConcurrency == 0 {
+		scriptConcurrency = defaultSecondaryScriptConcurrency(writeConcurrency)
+	}
+	return writeConcurrency, scriptConcurrency
+}
+
+func secondaryBackendPoolSize(mode proxy.ProxyMode, primaryPoolSize, elasticKVPoolSize int) int {
+	if mode == proxy.ModeElasticKVPrimary {
+		return primaryPoolSize
+	}
+	return elasticKVPoolSize
+}
+
+func defaultSecondaryWriteConcurrency(poolSize int) int {
+	return atLeastOne(poolSize / secondaryConcurrencyDivisor)
+}
+
+func defaultSecondaryScriptConcurrency(writeConcurrency int) int {
+	return atLeastOne(writeConcurrency / secondaryConcurrencyDivisor)
+}
+
+func atLeastOne(n int) int {
+	if n < 1 {
+		return 1
+	}
+	return n
 }
 
 func parseAddrList(raw string) []string {

--- a/cmd/redis-proxy/main_test.go
+++ b/cmd/redis-proxy/main_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/bootjp/elastickv/proxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRuntimeOptionsRejectsNegativeSecondaryConcurrency(t *testing.T) {
+	_, err := parseRuntimeOptions("dual-write", 128, 4, -1, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secondary-write-concurrency")
+
+	_, err = parseRuntimeOptions("dual-write", 128, 4, 0, -1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secondary-script-concurrency")
+}
+
+func TestDeriveSecondaryConcurrency(t *testing.T) {
+	tests := []struct {
+		name                  string
+		mode                  proxy.ProxyMode
+		primaryPoolSize       int
+		elasticKVPoolSize     int
+		writeConcurrency      int
+		scriptConcurrency     int
+		wantWriteConcurrency  int
+		wantScriptConcurrency int
+	}{
+		{
+			name:                  "dual write derives from ElasticKV pool",
+			mode:                  proxy.ModeDualWrite,
+			primaryPoolSize:       128,
+			elasticKVPoolSize:     4,
+			wantWriteConcurrency:  2,
+			wantScriptConcurrency: 1,
+		},
+		{
+			name:                  "shadow mode derives from ElasticKV pool",
+			mode:                  proxy.ModeDualWriteShadow,
+			primaryPoolSize:       128,
+			elasticKVPoolSize:     8,
+			wantWriteConcurrency:  4,
+			wantScriptConcurrency: 2,
+		},
+		{
+			name:                  "ElasticKV primary derives from Redis secondary pool",
+			mode:                  proxy.ModeElasticKVPrimary,
+			primaryPoolSize:       128,
+			elasticKVPoolSize:     4,
+			wantWriteConcurrency:  64,
+			wantScriptConcurrency: 32,
+		},
+		{
+			name:                  "explicit write keeps derived script",
+			mode:                  proxy.ModeDualWrite,
+			primaryPoolSize:       128,
+			elasticKVPoolSize:     4,
+			writeConcurrency:      5,
+			wantWriteConcurrency:  5,
+			wantScriptConcurrency: 2,
+		},
+		{
+			name:                  "explicit values win",
+			mode:                  proxy.ModeDualWrite,
+			primaryPoolSize:       128,
+			elasticKVPoolSize:     4,
+			writeConcurrency:      5,
+			scriptConcurrency:     3,
+			wantWriteConcurrency:  5,
+			wantScriptConcurrency: 3,
+		},
+		{
+			name:                  "small pool stays usable",
+			mode:                  proxy.ModeDualWrite,
+			primaryPoolSize:       128,
+			elasticKVPoolSize:     1,
+			wantWriteConcurrency:  1,
+			wantScriptConcurrency: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writeConcurrency, scriptConcurrency := deriveSecondaryConcurrency(
+				tt.mode,
+				tt.primaryPoolSize,
+				tt.elasticKVPoolSize,
+				tt.writeConcurrency,
+				tt.scriptConcurrency,
+			)
+			assert.Equal(t, tt.wantWriteConcurrency, writeConcurrency)
+			assert.Equal(t, tt.wantScriptConcurrency, scriptConcurrency)
+		})
+	}
+}

--- a/docs/redis-proxy-deployment.md
+++ b/docs/redis-proxy-deployment.md
@@ -36,6 +36,8 @@ go build -o redis-proxy ./cmd/redis-proxy/
 | `-secondary-password` | (empty) | Secondary Redis password |
 | `-primary-pool-size` | `128` | Primary Redis backend connection pool size |
 | `-elastickv-pool-size` | `4` | ElasticKV backend connection pool size |
+| `-secondary-write-concurrency` | `0` | Maximum concurrent asynchronous secondary writes. `0` derives half of the secondary backend pool size, minimum `1` |
+| `-secondary-script-concurrency` | `0` | Maximum concurrent asynchronous secondary Lua-script writes. `0` derives half of `-secondary-write-concurrency`, minimum `1` |
 | `-mode` | `dual-write` | Proxy mode (see below) |
 | `-secondary-timeout` | `5s` | Secondary write timeout |
 | `-shadow-timeout` | `3s` | Shadow read timeout |
@@ -91,6 +93,8 @@ docker run --rm \
   -primary-password "${REDIS_PASSWORD}" \
   -secondary elastickv.internal:6380 \
   -elastickv-pool-size 4 \
+  -secondary-write-concurrency 2 \
+  -secondary-script-concurrency 1 \
   -mode dual-write-shadow \
   -secondary-timeout 5s \
   -shadow-timeout 3s \
@@ -113,6 +117,8 @@ services:
       - -primary=redis:6379
       - -secondary=elastickv:6380
       - -elastickv-pool-size=4
+      - -secondary-write-concurrency=2
+      - -secondary-script-concurrency=1
       - -mode=dual-write-shadow
       - -metrics=:9191
     depends_on:

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -51,21 +51,27 @@ func (m ProxyMode) String() string {
 
 // ProxyConfig holds all configuration for the dual-write proxy.
 type ProxyConfig struct {
-	ListenAddr          string
-	PrimaryAddr         string
-	PrimaryDB           int
-	PrimaryPassword     string
-	SecondaryAddr       string
-	SecondaryDB         int
-	SecondaryPassword   string
-	Mode                ProxyMode
-	SecondaryTimeout    time.Duration
-	ShadowTimeout       time.Duration
-	SentryDSN           string
-	SentryEnv           string
-	SentrySampleRate    float64
-	MetricsAddr         string
-	PubSubCompareWindow time.Duration
+	ListenAddr        string
+	PrimaryAddr       string
+	PrimaryDB         int
+	PrimaryPassword   string
+	SecondaryAddr     string
+	SecondaryDB       int
+	SecondaryPassword string
+	Mode              ProxyMode
+	SecondaryTimeout  time.Duration
+	// SecondaryWriteConcurrency limits concurrent asynchronous secondary writes.
+	// Zero keeps the package default.
+	SecondaryWriteConcurrency int
+	// SecondaryScriptConcurrency limits concurrent asynchronous secondary Lua
+	// script writes. Zero keeps the package default.
+	SecondaryScriptConcurrency int
+	ShadowTimeout              time.Duration
+	SentryDSN                  string
+	SentryEnv                  string
+	SentrySampleRate           float64
+	MetricsAddr                string
+	PubSubCompareWindow        time.Duration
 }
 
 // DefaultConfig returns a ProxyConfig with sensible defaults.

--- a/proxy/dualwrite.go
+++ b/proxy/dualwrite.go
@@ -94,9 +94,9 @@ func NewDualWriter(primary, secondary Backend, cfg ProxyConfig, metrics *ProxyMe
 		metrics:   metrics,
 		sentry:    sentryReporter,
 		logger:    logger,
-		writeSem:  make(chan struct{}, maxWriteGoroutines),
+		writeSem:  make(chan struct{}, secondaryWriteConcurrency(cfg)),
 		shadowSem: make(chan struct{}, maxShadowGoroutines),
-		scriptSem: make(chan struct{}, maxScriptWriteGoroutines),
+		scriptSem: make(chan struct{}, secondaryScriptConcurrency(cfg)),
 		scripts:   make(map[string]string),
 	}
 
@@ -109,6 +109,21 @@ func NewDualWriter(primary, secondary Backend, cfg ProxyConfig, metrics *ProxyMe
 	}
 
 	return d
+}
+
+func secondaryWriteConcurrency(cfg ProxyConfig) int {
+	return configuredConcurrencyOrDefault(cfg.SecondaryWriteConcurrency, maxWriteGoroutines)
+}
+
+func secondaryScriptConcurrency(cfg ProxyConfig) int {
+	return configuredConcurrencyOrDefault(cfg.SecondaryScriptConcurrency, maxScriptWriteGoroutines)
+}
+
+func configuredConcurrencyOrDefault(configured, fallback int) int {
+	if configured > 0 {
+		return configured
+	}
+	return fallback
 }
 
 // Close waits for all in-flight async goroutines to finish.

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -347,6 +347,40 @@ func TestHasSecondaryWrite(t *testing.T) {
 	}
 }
 
+func TestNewDualWriter_UsesConfiguredSecondaryConcurrency(t *testing.T) {
+	metrics := newTestMetrics()
+	d := NewDualWriter(
+		newMockBackend("primary"),
+		newMockBackend("secondary"),
+		ProxyConfig{
+			Mode:                       ModeDualWrite,
+			SecondaryWriteConcurrency:  2,
+			SecondaryScriptConcurrency: 1,
+		},
+		metrics,
+		newTestSentry(),
+		testLogger,
+	)
+
+	assert.Equal(t, 2, cap(d.writeSem))
+	assert.Equal(t, 1, cap(d.scriptSem))
+}
+
+func TestNewDualWriter_DefaultSecondaryConcurrency(t *testing.T) {
+	metrics := newTestMetrics()
+	d := NewDualWriter(
+		newMockBackend("primary"),
+		newMockBackend("secondary"),
+		ProxyConfig{Mode: ModeDualWrite},
+		metrics,
+		newTestSentry(),
+		testLogger,
+	)
+
+	assert.Equal(t, maxWriteGoroutines, cap(d.writeSem))
+	assert.Equal(t, maxScriptWriteGoroutines, cap(d.scriptSem))
+}
+
 func TestDualWriter_Write_PrimarySuccess(t *testing.T) {
 	primary := newMockBackend("primary")
 	primary.doFunc = makeCmd("OK", nil)


### PR DESCRIPTION
## Summary
- derive redis-proxy secondary write concurrency from the secondary backend pool by default
- add separate secondary Lua script concurrency control
- document the operational defaults for dual-write deployments

## Validation
- GOCACHE=$(pwd)/.cache GOTMPDIR=$(pwd)/.cache/tmp go test ./cmd/redis-proxy ./proxy
- GOCACHE=$(pwd)/.cache GOLANGCI_LINT_CACHE=$(pwd)/.golangci-cache golangci-lint run ./cmd/redis-proxy ./proxy --timeout=5m
- go test ./... was started but interrupted after 246s while adapter integration tests were still running

Author: bootjp