### PR TITLE
Rate limit Redis proxy async drop logs

### DIFF
--- a/proxy/dualwrite.go
+++ b/proxy/dualwrite.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -47,6 +48,10 @@ const (
 	// compactedRetryJitterDivisor bounds the jitter to backoff/divisor so
 	// jitter stays small relative to the base delay.
 	compactedRetryJitterDivisor = 2
+
+	// asyncDropLogInterval keeps the secondary-drop warning useful without
+	// emitting one log line per dropped fire-and-forget write under load.
+	asyncDropLogInterval = 5 * time.Second
 )
 
 // readTSCompactedMarker is the substring produced by
@@ -83,6 +88,12 @@ type DualWriter struct {
 	scripts  map[string]string
 	// scriptOrder tracks insertion order for FIFO eviction of the bounded script cache.
 	scriptOrder []string
+	asyncDropMu sync.Mutex
+	// nextAsyncDropLog and suppressedAsyncDrops are accessed on the hot drop
+	// path, so use atomics for the fast path and keep the mutex for the rare
+	// logging path.
+	nextAsyncDropLog     int64
+	suppressedAsyncDrops int64
 }
 
 // NewDualWriter creates a DualWriter with the given backends.
@@ -450,8 +461,36 @@ func (d *DualWriter) goAsyncWithSem(sem chan struct{}, fn func()) {
 	default:
 		d.mu.Unlock()
 		d.metrics.AsyncDrops.Inc()
-		d.logger.Warn("async goroutine limit reached, dropping secondary operation")
+		d.logAsyncDrop()
 	}
+}
+
+func (d *DualWriter) logAsyncDrop() {
+	nowNano := time.Now().UnixNano()
+
+	nextLog := atomic.LoadInt64(&d.nextAsyncDropLog)
+	if nextLog != 0 && nowNano < nextLog {
+		atomic.AddInt64(&d.suppressedAsyncDrops, 1)
+		return
+	}
+
+	d.asyncDropMu.Lock()
+	defer d.asyncDropMu.Unlock()
+
+	nowNano = time.Now().UnixNano()
+	nextLog = atomic.LoadInt64(&d.nextAsyncDropLog)
+	if nextLog != 0 && nowNano < nextLog {
+		atomic.AddInt64(&d.suppressedAsyncDrops, 1)
+		return
+	}
+	suppressed := atomic.SwapInt64(&d.suppressedAsyncDrops, 0)
+	atomic.StoreInt64(&d.nextAsyncDropLog, time.Now().Add(asyncDropLogInterval).UnixNano())
+
+	if suppressed > 0 {
+		d.logger.Warn("async goroutine limit reached, dropping secondary operation", "suppressed", suppressed)
+		return
+	}
+	d.logger.Warn("async goroutine limit reached, dropping secondary operation")
 }
 
 func (d *DualWriter) hasSecondaryWrite() bool {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1,11 +1,13 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -657,6 +659,33 @@ func TestDualWriter_GoAsync_Bounded(t *testing.T) {
 
 	close(blocker) // unblock all
 	d.Close()      // wait for all goroutines to finish
+}
+
+func TestDualWriter_GoAsync_DropLogsAreRateLimited(t *testing.T) {
+	primary := newMockBackend("primary")
+	primary.doFunc = makeCmd("OK", nil)
+	secondary := newMockBackend("secondary")
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	metrics := newTestMetrics()
+	cfg := ProxyConfig{Mode: ModeDualWrite, SecondaryWriteConcurrency: 1, SecondaryTimeout: 10 * time.Second}
+	d := NewDualWriter(primary, secondary, cfg, metrics, newTestSentry(), logger)
+
+	blocker := make(chan struct{})
+	d.goAsync(func() {
+		<-blocker
+	})
+
+	for range 3 {
+		d.goAsync(func() { t.Error("should not run") })
+	}
+
+	assert.InDelta(t, 3, testutil.ToFloat64(metrics.AsyncDrops), 0.001)
+	assert.Equal(t, 1, strings.Count(logs.String(), "async goroutine limit reached"))
+
+	close(blocker)
+	d.Close()
 }
 
 func TestDualWriter_Script_DropsWhenScriptSemFull(t *testing.T) {


### PR DESCRIPTION
## Summary
- rate limit redis-proxy async secondary drop warnings
- keep proxy_async_drops_total incrementing for every dropped operation
- add coverage that repeated drops emit one warning within the interval

## Validation
- GOCACHE=$(pwd)/.cache GOTMPDIR=$(pwd)/.cache/tmp go test ./proxy
- GOCACHE=$(pwd)/.cache GOLANGCI_LINT_CACHE=$(pwd)/.golangci-cache golangci-lint run ./proxy --timeout=5m

Author: bootjp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 非同期処理の上限到達時に発生する警告ログをレート制限し、過剰なログ出力を抑制。
  * 抑制された発生回数をまとめて通知し、状況を把握しやすく改善。

* **テスト**
  * 非同期処理のドロップ回数とログ出力頻度が適切に制御されることを確認するテストを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->