### PR TITLE
Reduce background maintenance pressure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ gen:
 # that motivates the implementation gaps).
 TLA_VERSION  := v1.8.0
 TLA_JAR      := .cache/tla/tla2tools.jar
-TLA_SHA256   := 9e27b5e19a69ae1f56aabf8403a6ed5598dbfa6e638908e5278ac39736c1543d
+TLA_SHA256   := 33de7da9ce1b7fffb9d1c184021178dbb051747be48504e65c584c423721a32e
 TLA_URL      := https://github.com/tlaplus/tlaplus/releases/download/$(TLA_VERSION)/tla2tools.jar
 TLA_LIB      := ../lib
 

--- a/adapter/redis_delta_compactor.go
+++ b/adapter/redis_delta_compactor.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	defaultDeltaCompactorMaxDeltaCount = 64
-	defaultDeltaCompactorScanInterval  = 30 * time.Second
-	defaultDeltaCompactorTimeout       = 5 * time.Second
+	defaultDeltaCompactorMaxDeltaCount  = 64
+	defaultDeltaCompactorScanInterval   = 30 * time.Second
+	defaultDeltaCompactorTimeout        = 5 * time.Second
+	defaultDeltaCompactorTimeoutBackoff = time.Minute
 
 	// deltaCompactorTickScanLimit is the maximum number of delta keys scanned
 	// per collection type per compaction tick. It bounds per-tick I/O while
@@ -45,12 +46,13 @@ type urgentCompactionRequest struct {
 // tick silently. Compaction is performed as an OCC transaction so concurrent
 // writers never conflict with the compactor.
 type DeltaCompactor struct {
-	st       store.MVCCStore
-	coord    kv.Coordinator
-	logger   *slog.Logger
-	maxCount int
-	interval time.Duration
-	timeout  time.Duration
+	st             store.MVCCStore
+	coord          kv.Coordinator
+	logger         *slog.Logger
+	maxCount       int
+	interval       time.Duration
+	timeout        time.Duration
+	timeoutBackoff time.Duration
 	// cursors tracks the exclusive lower bound for the next scan of each
 	// collection type (keyed by collectionDeltaHandler.typeName). This allows
 	// each tick to resume where the previous one stopped, ensuring that keys
@@ -67,6 +69,9 @@ type DeltaCompactor struct {
 	// loop drains this channel between regular ticks so hot keys are unblocked
 	// quickly without waiting for the next scheduled pass.
 	urgentCh chan urgentCompactionRequest
+
+	stateMu      sync.Mutex
+	backoffUntil time.Time
 }
 
 // DeltaCompactorOption configures a DeltaCompactor.
@@ -101,6 +106,16 @@ func WithDeltaCompactorTimeout(d time.Duration) DeltaCompactorOption {
 	}
 }
 
+// WithDeltaCompactorTimeoutBackoff sets how long background passes are skipped
+// after a tick exhausts its timeout. Default: 1m.
+func WithDeltaCompactorTimeoutBackoff(d time.Duration) DeltaCompactorOption {
+	return func(c *DeltaCompactor) {
+		if d >= 0 {
+			c.timeoutBackoff = d
+		}
+	}
+}
+
 // WithDeltaCompactorLogger sets the logger.
 func WithDeltaCompactorLogger(l *slog.Logger) DeltaCompactorOption {
 	return func(c *DeltaCompactor) {
@@ -113,14 +128,15 @@ func WithDeltaCompactorLogger(l *slog.Logger) DeltaCompactorOption {
 // NewDeltaCompactor creates a DeltaCompactor that operates on st using coord.
 func NewDeltaCompactor(st store.MVCCStore, coord kv.Coordinator, opts ...DeltaCompactorOption) *DeltaCompactor {
 	c := &DeltaCompactor{
-		st:       st,
-		coord:    kv.WithKeyVizLabel(coord, keyviz.LabelRedis),
-		logger:   slog.Default(),
-		maxCount: defaultDeltaCompactorMaxDeltaCount,
-		interval: defaultDeltaCompactorScanInterval,
-		timeout:  defaultDeltaCompactorTimeout,
-		cursors:  make(map[string][]byte),
-		urgentCh: make(chan urgentCompactionRequest, urgentCompactionChanSize),
+		st:             st,
+		coord:          kv.WithKeyVizLabel(coord, keyviz.LabelRedis),
+		logger:         slog.Default(),
+		maxCount:       defaultDeltaCompactorMaxDeltaCount,
+		interval:       defaultDeltaCompactorScanInterval,
+		timeout:        defaultDeltaCompactorTimeout,
+		timeoutBackoff: defaultDeltaCompactorTimeoutBackoff,
+		cursors:        make(map[string][]byte),
+		urgentCh:       make(chan urgentCompactionRequest, urgentCompactionChanSize),
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -266,11 +282,19 @@ func (c *DeltaCompactor) compactUrgentKeyBatch(ctx context.Context, req urgentCo
 // which uses IsLeaderForKey for per-key routing. buildBatchElems adds an
 // additional per-key IsLeaderForKey filter so a default-group leader never
 // dispatches mutations for shards it does not own.
-// Each collection-type handler runs in its own goroutine so that a slow
-// handler (e.g. one with many list deltas) does not delay Hash/Set/ZSet
-// compaction. All goroutines share the same per-tick timeout context.
+// Collection-type handlers run sequentially under one per-tick timeout. A
+// production leader can otherwise receive four full-prefix scans at the same
+// time; under Redis migration load that can starve Raft heartbeats and cause
+// callers to see connection resets. Urgent single-key compaction remains
+// independent, so a hot key that has exceeded MaxDeltaScanLimit can still be
+// repaired promptly between regular ticks.
 func (c *DeltaCompactor) SyncOnce(ctx context.Context) error {
 	if c.coord == nil || !c.coord.IsLeader() {
+		return nil
+	}
+	if c.backgroundBackoffActive(time.Now()) {
+		c.logger.DebugContext(ctx, "delta compactor: skipping pass during timeout backoff",
+			"backoff_until", c.currentBackoffUntil())
 		return nil
 	}
 	readTS := snapshotTS(c.coord.Clock(), c.st)
@@ -278,32 +302,74 @@ func (c *DeltaCompactor) SyncOnce(ctx context.Context) error {
 	defer cancel()
 
 	handlers := c.allHandlers()
-	errs := make([]error, len(handlers))
-	var wg sync.WaitGroup
-	for i, h := range handlers {
-		wg.Add(1)
-		go func(idx int, handler collectionDeltaHandler) {
-			defer wg.Done()
-			defer func() {
-				if rec := recover(); rec != nil {
-					c.logger.Error("DeltaCompactor: panic in handler",
-						slog.String("type", handler.typeName),
-						slog.Any("panic", rec))
-					errs[idx] = errors.Errorf("panic in %s compactor: %v", handler.typeName, rec)
-				}
-			}()
-			errs[idx] = c.compactHandler(tickCtx, handler, readTS)
-		}(i, h)
-	}
-	wg.Wait()
-
 	var combined error
-	for _, err := range errs {
+	for _, h := range handlers {
+		if tickCtx.Err() != nil {
+			combined = errors.CombineErrors(combined, tickCtx.Err())
+			break
+		}
+		err := c.compactHandlerSafely(tickCtx, h, readTS)
 		if err != nil && !errors.Is(err, context.Canceled) {
 			combined = errors.CombineErrors(combined, err)
 		}
 	}
+	if deltaCompactorBudgetExhausted(combined, tickCtx, ctx) {
+		c.backoffBackgroundCompaction(c.timeoutBackoff)
+		c.logger.WarnContext(ctx, "delta compactor: backing off after timeout",
+			"backoff", c.timeoutBackoff,
+			"error", combined)
+	}
 	return errors.WithStack(combined)
+}
+
+func (c *DeltaCompactor) compactHandlerSafely(ctx context.Context, h collectionDeltaHandler, readTS uint64) (err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			c.logger.Error("DeltaCompactor: panic in handler",
+				slog.String("type", h.typeName),
+				slog.Any("panic", rec))
+			err = errors.Errorf("panic in %s compactor: %v", h.typeName, rec)
+		}
+	}()
+	return c.compactHandler(ctx, h, readTS)
+}
+
+func (c *DeltaCompactor) backgroundBackoffActive(now time.Time) bool {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	if c.backoffUntil.IsZero() {
+		return false
+	}
+	if now.Before(c.backoffUntil) {
+		return true
+	}
+	c.backoffUntil = time.Time{}
+	return false
+}
+
+func (c *DeltaCompactor) currentBackoffUntil() time.Time {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	return c.backoffUntil
+}
+
+func (c *DeltaCompactor) backoffBackgroundCompaction(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	c.backoffUntil = time.Now().Add(d)
+}
+
+func deltaCompactorBudgetExhausted(err error, workCtx, parentCtx context.Context) bool {
+	if err == nil || workCtx == nil {
+		return false
+	}
+	if parentCtx != nil && parentCtx.Err() != nil {
+		return false
+	}
+	return workCtx.Err() != nil
 }
 
 // collectionDeltaHandler holds the type-specific functions for one collection type.

--- a/adapter/redis_delta_compactor.go
+++ b/adapter/redis_delta_compactor.go
@@ -292,9 +292,9 @@ func (c *DeltaCompactor) SyncOnce(ctx context.Context) error {
 	if c.coord == nil || !c.coord.IsLeader() {
 		return nil
 	}
-	if c.backgroundBackoffActive(time.Now()) {
+	if active, until := c.backgroundBackoffActive(time.Now()); active {
 		c.logger.DebugContext(ctx, "delta compactor: skipping pass during timeout backoff",
-			"backoff_until", c.currentBackoffUntil())
+			"backoff_until", until)
 		return nil
 	}
 	readTS := snapshotTS(c.coord.Clock(), c.st)
@@ -334,23 +334,17 @@ func (c *DeltaCompactor) compactHandlerSafely(ctx context.Context, h collectionD
 	return c.compactHandler(ctx, h, readTS)
 }
 
-func (c *DeltaCompactor) backgroundBackoffActive(now time.Time) bool {
+func (c *DeltaCompactor) backgroundBackoffActive(now time.Time) (bool, time.Time) {
 	c.stateMu.Lock()
 	defer c.stateMu.Unlock()
 	if c.backoffUntil.IsZero() {
-		return false
+		return false, time.Time{}
 	}
 	if now.Before(c.backoffUntil) {
-		return true
+		return true, c.backoffUntil
 	}
 	c.backoffUntil = time.Time{}
-	return false
-}
-
-func (c *DeltaCompactor) currentBackoffUntil() time.Time {
-	c.stateMu.Lock()
-	defer c.stateMu.Unlock()
-	return c.backoffUntil
+	return false, time.Time{}
 }
 
 func (c *DeltaCompactor) backoffBackgroundCompaction(d time.Duration) {

--- a/adapter/redis_delta_compactor.go
+++ b/adapter/redis_delta_compactor.go
@@ -70,8 +70,9 @@ type DeltaCompactor struct {
 	// quickly without waiting for the next scheduled pass.
 	urgentCh chan urgentCompactionRequest
 
-	stateMu      sync.Mutex
-	backoffUntil time.Time
+	stateMu       sync.Mutex
+	backoffUntil  time.Time
+	handlerCursor int
 }
 
 // DeltaCompactorOption configures a DeltaCompactor.
@@ -303,12 +304,16 @@ func (c *DeltaCompactor) SyncOnce(ctx context.Context) error {
 
 	handlers := c.allHandlers()
 	var combined error
-	for _, h := range handlers {
+	start := c.backgroundHandlerStart(len(handlers))
+	for offset := range handlers {
 		if tickCtx.Err() != nil {
 			combined = errors.CombineErrors(combined, tickCtx.Err())
 			break
 		}
+		idx := (start + offset) % len(handlers)
+		h := handlers[idx]
 		err := c.compactHandlerSafely(tickCtx, h, readTS)
+		c.advanceBackgroundHandlerCursor(idx, len(handlers))
 		if err != nil && !errors.Is(err, context.Canceled) {
 			combined = errors.CombineErrors(combined, err)
 		}
@@ -320,6 +325,27 @@ func (c *DeltaCompactor) SyncOnce(ctx context.Context) error {
 			"error", combined)
 	}
 	return errors.WithStack(combined)
+}
+
+func (c *DeltaCompactor) backgroundHandlerStart(total int) int {
+	if total <= 0 {
+		return 0
+	}
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	if c.handlerCursor < 0 || c.handlerCursor >= total {
+		c.handlerCursor = 0
+	}
+	return c.handlerCursor
+}
+
+func (c *DeltaCompactor) advanceBackgroundHandlerCursor(current, total int) {
+	if total <= 0 {
+		return
+	}
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	c.handlerCursor = (current + 1) % total
 }
 
 func (c *DeltaCompactor) compactHandlerSafely(ctx context.Context, h collectionDeltaHandler, readTS uint64) (err error) {

--- a/adapter/redis_delta_compactor_test.go
+++ b/adapter/redis_delta_compactor_test.go
@@ -21,6 +21,17 @@ func newDeltaCompactorTestFixture(t *testing.T) (store.MVCCStore, *DeltaCompacto
 	return st, c
 }
 
+type timeoutScanStore struct {
+	store.MVCCStore
+	scans int
+}
+
+func (s *timeoutScanStore) ScanAt(ctx context.Context, start []byte, end []byte, limit int, ts uint64) ([]*store.KVPair, error) {
+	s.scans++
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
 type recordingCompactorCoordinator struct {
 	stubAdapterCoordinator
 	labels []keyviz.Label
@@ -40,6 +51,27 @@ func TestDeltaCompactorStampsRedisKeyVizLabel(t *testing.T) {
 	_, err := c.coord.Dispatch(context.Background(), &kv.OperationGroup[kv.OP]{})
 	require.NoError(t, err)
 	require.Equal(t, []keyviz.Label{keyviz.LabelRedis}, rec.labels)
+}
+
+func TestDeltaCompactor_BackoffAfterTimeout(t *testing.T) {
+	t.Parallel()
+
+	base := store.NewMVCCStore()
+	st := &timeoutScanStore{MVCCStore: base}
+	coord := newLocalAdapterCoordinator(st)
+	c := NewDeltaCompactor(
+		st,
+		coord,
+		WithDeltaCompactorTimeout(time.Millisecond),
+		WithDeltaCompactorTimeoutBackoff(time.Hour),
+	)
+
+	err := c.SyncOnce(context.Background())
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Equal(t, 1, st.scans, "timeout pass should run one scan before yielding")
+
+	require.NoError(t, c.SyncOnce(context.Background()))
+	require.Equal(t, 1, st.scans, "backoff pass should not scan again")
 }
 
 func TestDeltaCompactor_ListDeltaFoldedIntoBaseMeta(t *testing.T) {

--- a/adapter/redis_delta_compactor_test.go
+++ b/adapter/redis_delta_compactor_test.go
@@ -1,6 +1,7 @@
 package adapter
 
 import (
+	"bytes"
 	"context"
 	"testing"
 	"time"
@@ -23,11 +24,13 @@ func newDeltaCompactorTestFixture(t *testing.T) (store.MVCCStore, *DeltaCompacto
 
 type timeoutScanStore struct {
 	store.MVCCStore
-	scans int
+	scans  int
+	starts [][]byte
 }
 
 func (s *timeoutScanStore) ScanAt(ctx context.Context, start []byte, end []byte, limit int, ts uint64) ([]*store.KVPair, error) {
 	s.scans++
+	s.starts = append(s.starts, bytes.Clone(start))
 	<-ctx.Done()
 	return nil, ctx.Err()
 }
@@ -72,6 +75,35 @@ func TestDeltaCompactor_BackoffAfterTimeout(t *testing.T) {
 
 	require.NoError(t, c.SyncOnce(context.Background()))
 	require.Equal(t, 1, st.scans, "backoff pass should not scan again")
+}
+
+func TestDeltaCompactor_RotatesHandlerAfterTimeout(t *testing.T) {
+	t.Parallel()
+
+	base := store.NewMVCCStore()
+	st := &timeoutScanStore{MVCCStore: base}
+	coord := newLocalAdapterCoordinator(st)
+	c := NewDeltaCompactor(
+		st,
+		coord,
+		WithDeltaCompactorTimeout(10*time.Millisecond),
+		WithDeltaCompactorTimeoutBackoff(0),
+	)
+
+	wantPrefixes := []string{
+		store.ListMetaDeltaPrefix,
+		store.HashMetaDeltaPrefix,
+		store.SetMetaDeltaPrefix,
+		store.ZSetMetaDeltaPrefix,
+		store.ListMetaDeltaPrefix,
+	}
+	for _, prefix := range wantPrefixes {
+		err := c.SyncOnce(context.Background())
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Len(t, st.starts, st.scans)
+		require.True(t, bytes.HasPrefix(st.starts[len(st.starts)-1], []byte(prefix)),
+			"scan should start with %q after timeout rotation; got %q", prefix, st.starts[len(st.starts)-1])
+	}
 }
 
 func TestDeltaCompactor_ListDeltaFoldedIntoBaseMeta(t *testing.T) {

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -2002,19 +2002,48 @@ func (c *luaScriptContext) popList(key string, left bool) (luaReply, error) {
 	}
 	var value string
 	if st.materialized {
-		if left {
-			value = st.values[0]
-			st.values = st.values[1:]
-		} else {
-			value = st.values[len(st.values)-1]
-			st.values = st.values[:len(st.values)-1]
-		}
+		value = popMaterializedListValue(st, left)
 	} else {
-		value, err = c.popLazyListValue([]byte(key), st, left)
+		var ok bool
+		value, ok, err = c.popLazyListValue([]byte(key), st, left)
 		if err != nil {
 			return luaReply{}, err
 		}
+		if !ok {
+			c.markListEmptyAfterLazyPop(key, st)
+			return luaNilReply(), nil
+		}
 	}
+	return c.finishPoppedListValue(key, st, value), nil
+}
+
+func popMaterializedListValue(st *luaListState, left bool) string {
+	if left {
+		value := st.values[0]
+		st.values = st.values[1:]
+		return value
+	}
+	value := st.values[len(st.values)-1]
+	st.values = st.values[:len(st.values)-1]
+	return value
+}
+
+func (c *luaScriptContext) markListEmptyAfterLazyPop(key string, st *luaListState) {
+	st.dirty = true
+	st.exists = false
+	st.materialized = false
+	st.meta = store.ListMeta{}
+	st.leftTrim = 0
+	st.rightTrim = 0
+	st.leftValues = nil
+	st.rightValues = nil
+	st.values = nil
+	c.deleted[key] = true
+	c.clearTTL([]byte(key))
+	c.markTouched([]byte(key))
+}
+
+func (c *luaScriptContext) finishPoppedListValue(key string, st *luaListState, value string) luaReply {
 	st.dirty = true
 	if st.currentLen() == 0 {
 		st.exists = false
@@ -2029,61 +2058,71 @@ func (c *luaScriptContext) popList(key string, left bool) (luaReply, error) {
 		c.clearTTL([]byte(key))
 	}
 	c.markTouched([]byte(key))
-	return luaStringReply(value), nil
+	return luaStringReply(value)
 }
 
-func (c *luaScriptContext) popLazyListValue(key []byte, st *luaListState, left bool) (string, error) {
+func (c *luaScriptContext) popLazyListValue(key []byte, st *luaListState, left bool) (string, bool, error) {
 	if left {
 		return c.popLazyListLeft(key, st)
 	}
 	return c.popLazyListRight(key, st)
 }
 
-func (c *luaScriptContext) popLazyListLeft(key []byte, st *luaListState) (string, error) {
-	if len(st.leftValues) > 0 {
-		value := st.leftValues[0]
-		st.leftValues = st.leftValues[1:]
-		return value, nil
-	}
-	if remaining := st.remainingOriginalLen(); remaining > 0 {
-		values, err := c.server.fetchListRange(context.Background(), key, st.meta, st.leftTrim, st.leftTrim, c.startTS)
-		if err != nil {
-			return "", err
+func (c *luaScriptContext) popLazyListLeft(key []byte, st *luaListState) (string, bool, error) {
+	for {
+		if len(st.leftValues) > 0 {
+			value := st.leftValues[0]
+			st.leftValues = st.leftValues[1:]
+			return value, true, nil
 		}
-		if len(values) == 0 {
-			return "", errors.WithStack(store.ErrKeyNotFound)
+		if remaining := st.remainingOriginalLen(); remaining > 0 {
+			values, err := c.server.fetchListRange(context.Background(), key, st.meta, st.leftTrim, st.leftTrim, c.startTS)
+			if err != nil {
+				return "", false, err
+			}
+			st.leftTrim++
+			if len(values) == 0 {
+				continue
+			}
+			return values[0], true, nil
 		}
-		st.leftTrim++
-		return values[0], nil
+		if len(st.rightValues) == 0 {
+			return "", false, nil
+		}
+		value := st.rightValues[0]
+		st.rightValues = st.rightValues[1:]
+		return value, true, nil
 	}
-	value := st.rightValues[0]
-	st.rightValues = st.rightValues[1:]
-	return value, nil
 }
 
-func (c *luaScriptContext) popLazyListRight(key []byte, st *luaListState) (string, error) {
-	if len(st.rightValues) > 0 {
-		last := len(st.rightValues) - 1
-		value := st.rightValues[last]
-		st.rightValues = st.rightValues[:last]
-		return value, nil
-	}
-	if remaining := st.remainingOriginalLen(); remaining > 0 {
-		index := st.meta.Len - st.rightTrim - 1
-		values, err := c.server.fetchListRange(context.Background(), key, st.meta, index, index, c.startTS)
-		if err != nil {
-			return "", err
+func (c *luaScriptContext) popLazyListRight(key []byte, st *luaListState) (string, bool, error) {
+	for {
+		if len(st.rightValues) > 0 {
+			last := len(st.rightValues) - 1
+			value := st.rightValues[last]
+			st.rightValues = st.rightValues[:last]
+			return value, true, nil
 		}
-		if len(values) == 0 {
-			return "", errors.WithStack(store.ErrKeyNotFound)
+		if remaining := st.remainingOriginalLen(); remaining > 0 {
+			index := st.meta.Len - st.rightTrim - 1
+			values, err := c.server.fetchListRange(context.Background(), key, st.meta, index, index, c.startTS)
+			if err != nil {
+				return "", false, err
+			}
+			st.rightTrim++
+			if len(values) == 0 {
+				continue
+			}
+			return values[0], true, nil
 		}
-		st.rightTrim++
-		return values[0], nil
+		if len(st.leftValues) == 0 {
+			return "", false, nil
+		}
+		last := len(st.leftValues) - 1
+		value := st.leftValues[last]
+		st.leftValues = st.leftValues[:last]
+		return value, true, nil
 	}
-	last := len(st.leftValues) - 1
-	value := st.leftValues[last]
-	st.leftValues = st.leftValues[:last]
-	return value, nil
 }
 
 func (c *luaScriptContext) cmdRPopLPush(args []string) (luaReply, error) {

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -2177,15 +2177,12 @@ func (c *luaScriptContext) scanListItemWindow(key []byte, meta store.ListMeta, s
 		kvs []*store.KVPair
 		err error
 	)
-	scanLimit := endIdx - startIdx + 1
-	if scanLimit > int64(luaSparseListPopScanLimit) {
-		scanLimit = int64(luaSparseListPopScanLimit)
-	}
+	scanLimit := luaSparseListPopScanLimit
 
 	if left {
-		kvs, err = c.server.store.ScanAt(c.ctx, startKey, endKey, int(scanLimit), c.startTS)
+		kvs, err = c.server.store.ScanAt(c.ctx, startKey, endKey, scanLimit, c.startTS)
 	} else {
-		kvs, err = c.server.store.ReverseScanAt(c.ctx, startKey, endKey, int(scanLimit), c.startTS)
+		kvs, err = c.server.store.ReverseScanAt(c.ctx, startKey, endKey, scanLimit, c.startTS)
 	}
 	if err != nil {
 		return luaLazyListBoundaryItem{}, false, errors.WithStack(err)
@@ -2200,7 +2197,7 @@ func (c *luaScriptContext) scanListItemWindow(key []byte, meta store.ListMeta, s
 			index: seq - meta.Head,
 		}, true, nil
 	}
-	if len(kvs) >= int(scanLimit) {
+	if len(kvs) >= scanLimit {
 		return luaLazyListBoundaryItem{}, false, errors.Wrapf(ErrCollectionTooLarge,
 			"list %q sparse pop scanned %d non-matching item rows", string(key), scanLimit)
 	}

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -2177,10 +2177,15 @@ func (c *luaScriptContext) scanListItemWindow(key []byte, meta store.ListMeta, s
 		kvs []*store.KVPair
 		err error
 	)
+	scanLimit := endIdx - startIdx + 1
+	if scanLimit > int64(luaSparseListPopScanLimit) {
+		scanLimit = int64(luaSparseListPopScanLimit)
+	}
+
 	if left {
-		kvs, err = c.server.store.ScanAt(c.ctx, startKey, endKey, 1, c.startTS)
+		kvs, err = c.server.store.ScanAt(c.ctx, startKey, endKey, int(scanLimit), c.startTS)
 	} else {
-		kvs, err = c.server.store.ReverseScanAt(c.ctx, startKey, endKey, 1, c.startTS)
+		kvs, err = c.server.store.ReverseScanAt(c.ctx, startKey, endKey, int(scanLimit), c.startTS)
 	}
 	if err != nil {
 		return luaLazyListBoundaryItem{}, false, errors.WithStack(err)
@@ -2194,6 +2199,10 @@ func (c *luaScriptContext) scanListItemWindow(key []byte, meta store.ListMeta, s
 			value: string(kvp.Value),
 			index: seq - meta.Head,
 		}, true, nil
+	}
+	if len(kvs) >= int(scanLimit) {
+		return luaLazyListBoundaryItem{}, false, errors.Wrapf(ErrCollectionTooLarge,
+			"list %q sparse pop scanned %d non-matching item rows", string(key), scanLimit)
 	}
 	return luaLazyListBoundaryItem{}, false, nil
 }
@@ -3497,7 +3506,7 @@ func (c *luaScriptContext) listDeltaCommitElems(key string, st *luaListState, co
 	// Emit Delta keys for any appended values and trims instead of writing base meta.
 	// Trims are counted separately as negative deltas.
 	var seqInTxn uint32
-	if len(st.rightValues) > 0 {
+	if len(st.rightValues) > 0 || st.rightTrim > 0 {
 		rightDelta := store.MarshalListMetaDelta(store.ListMetaDelta{
 			HeadDelta: 0,
 			LenDelta:  int64(len(st.rightValues)) - st.rightTrim,

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -172,6 +172,8 @@ const (
 	zsetMetaBaseElems   = 1 // PUT or DEL ZSetMetaKey
 	zsetElemsPerAdded   = 3 // optional DEL stale score key + PUT member key + PUT score key
 	zsetElemsPerRemoved = 2 // DEL member key + DEL score key
+
+	luaSparseListPopScanLimit = store.MaxDeltaScanLimit
 )
 
 type luaCommandHandler func(*luaScriptContext, []string) (luaReply, error)
@@ -1881,6 +1883,7 @@ func (c *luaScriptContext) cmdLRem(args []string) (luaReply, error) {
 	if len(values) == 0 {
 		st.exists = false
 		c.deleted[args[0]] = true
+		c.everDeleted[args[0]] = true
 		c.clearTTL([]byte(args[0]))
 	}
 	c.markTouched([]byte(args[0]))
@@ -1972,6 +1975,7 @@ func (c *luaScriptContext) cmdLTrim(args []string) (luaReply, error) {
 		st.dirty = true
 		c.clearTTL([]byte(args[0]))
 		c.deleted[args[0]] = true
+		c.everDeleted[args[0]] = true
 		c.markTouched([]byte(args[0]))
 		return luaStatusReply("OK"), nil
 	}
@@ -2039,6 +2043,7 @@ func (c *luaScriptContext) markListEmptyAfterLazyPop(key string, st *luaListStat
 	st.rightValues = nil
 	st.values = nil
 	c.deleted[key] = true
+	c.everDeleted[key] = true
 	c.clearTTL([]byte(key))
 	c.markTouched([]byte(key))
 }
@@ -2055,6 +2060,7 @@ func (c *luaScriptContext) finishPoppedListValue(key string, st *luaListState, v
 		st.rightValues = nil
 		st.values = nil
 		c.deleted[key] = true
+		c.everDeleted[key] = true
 		c.clearTTL([]byte(key))
 	}
 	c.markTouched([]byte(key))
@@ -2076,15 +2082,16 @@ func (c *luaScriptContext) popLazyListLeft(key []byte, st *luaListState) (string
 			return value, true, nil
 		}
 		if remaining := st.remainingOriginalLen(); remaining > 0 {
-			values, err := c.server.fetchListRange(context.Background(), key, st.meta, st.leftTrim, st.leftTrim, c.startTS)
+			item, ok, err := c.scanLazyListBoundaryItem(key, st, true)
 			if err != nil {
 				return "", false, err
 			}
-			st.leftTrim++
-			if len(values) == 0 {
+			if !ok {
+				st.leftTrim += remaining
 				continue
 			}
-			return values[0], true, nil
+			st.leftTrim = item.index + 1
+			return item.value, true, nil
 		}
 		if len(st.rightValues) == 0 {
 			return "", false, nil
@@ -2104,16 +2111,16 @@ func (c *luaScriptContext) popLazyListRight(key []byte, st *luaListState) (strin
 			return value, true, nil
 		}
 		if remaining := st.remainingOriginalLen(); remaining > 0 {
-			index := st.meta.Len - st.rightTrim - 1
-			values, err := c.server.fetchListRange(context.Background(), key, st.meta, index, index, c.startTS)
+			item, ok, err := c.scanLazyListBoundaryItem(key, st, false)
 			if err != nil {
 				return "", false, err
 			}
-			st.rightTrim++
-			if len(values) == 0 {
+			if !ok {
+				st.rightTrim += remaining
 				continue
 			}
-			return values[0], true, nil
+			st.rightTrim = st.meta.Len - item.index
+			return item.value, true, nil
 		}
 		if len(st.leftValues) == 0 {
 			return "", false, nil
@@ -2123,6 +2130,72 @@ func (c *luaScriptContext) popLazyListRight(key []byte, st *luaListState) (strin
 		st.leftValues = st.leftValues[:last]
 		return value, true, nil
 	}
+}
+
+type luaLazyListBoundaryItem struct {
+	value string
+	index int64
+}
+
+func (c *luaScriptContext) scanLazyListBoundaryItem(key []byte, st *luaListState, left bool) (luaLazyListBoundaryItem, bool, error) {
+	remaining := st.remainingOriginalLen()
+	if remaining <= 0 {
+		return luaLazyListBoundaryItem{}, false, nil
+	}
+
+	startIdx := st.leftTrim
+	endIdx := st.meta.Len - st.rightTrim - 1
+	scanLen := remaining
+	if scanLen > int64(luaSparseListPopScanLimit) {
+		scanLen = int64(luaSparseListPopScanLimit)
+		if left {
+			endIdx = startIdx + scanLen - 1
+		} else {
+			startIdx = endIdx - scanLen + 1
+		}
+	}
+
+	item, ok, err := c.scanListItemWindow(key, st.meta, startIdx, endIdx, left)
+	if err != nil || ok {
+		return item, ok, err
+	}
+	if remaining > int64(luaSparseListPopScanLimit) {
+		return luaLazyListBoundaryItem{}, false, errors.Wrapf(ErrCollectionTooLarge,
+			"list %q sparse pop skipped more than %d missing items", string(key), luaSparseListPopScanLimit)
+	}
+	return luaLazyListBoundaryItem{}, false, nil
+}
+
+func (c *luaScriptContext) scanListItemWindow(key []byte, meta store.ListMeta, startIdx, endIdx int64, left bool) (luaLazyListBoundaryItem, bool, error) {
+	if endIdx < startIdx {
+		return luaLazyListBoundaryItem{}, false, nil
+	}
+	startKey := listItemKey(key, meta.Head+startIdx)
+	endKey := listItemKey(key, meta.Head+endIdx+1)
+
+	var (
+		kvs []*store.KVPair
+		err error
+	)
+	if left {
+		kvs, err = c.server.store.ScanAt(c.ctx, startKey, endKey, 1, c.startTS)
+	} else {
+		kvs, err = c.server.store.ReverseScanAt(c.ctx, startKey, endKey, 1, c.startTS)
+	}
+	if err != nil {
+		return luaLazyListBoundaryItem{}, false, errors.WithStack(err)
+	}
+	for _, kvp := range kvs {
+		seq, ok := store.ExtractListItemSeq(kvp.Key, key)
+		if !ok {
+			continue
+		}
+		return luaLazyListBoundaryItem{
+			value: string(kvp.Value),
+			index: seq - meta.Head,
+		}, true, nil
+	}
+	return luaLazyListBoundaryItem{}, false, nil
 }
 
 func (c *luaScriptContext) cmdRPopLPush(args []string) (luaReply, error) {

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -1882,8 +1882,7 @@ func (c *luaScriptContext) cmdLRem(args []string) (luaReply, error) {
 	st.dirty = true
 	if len(values) == 0 {
 		st.exists = false
-		c.deleted[args[0]] = true
-		c.everDeleted[args[0]] = true
+		c.markListDeleted(args[0])
 		c.clearTTL([]byte(args[0]))
 	}
 	c.markTouched([]byte(args[0]))
@@ -1974,8 +1973,7 @@ func (c *luaScriptContext) cmdLTrim(args []string) (luaReply, error) {
 		st.exists = false
 		st.dirty = true
 		c.clearTTL([]byte(args[0]))
-		c.deleted[args[0]] = true
-		c.everDeleted[args[0]] = true
+		c.markListDeleted(args[0])
 		c.markTouched([]byte(args[0]))
 		return luaStatusReply("OK"), nil
 	}
@@ -2042,8 +2040,7 @@ func (c *luaScriptContext) markListEmptyAfterLazyPop(key string, st *luaListStat
 	st.leftValues = nil
 	st.rightValues = nil
 	st.values = nil
-	c.deleted[key] = true
-	c.everDeleted[key] = true
+	c.markListDeleted(key)
 	c.clearTTL([]byte(key))
 	c.markTouched([]byte(key))
 }
@@ -2059,12 +2056,15 @@ func (c *luaScriptContext) finishPoppedListValue(key string, st *luaListState, v
 		st.leftValues = nil
 		st.rightValues = nil
 		st.values = nil
-		c.deleted[key] = true
-		c.everDeleted[key] = true
+		c.markListDeleted(key)
 		c.clearTTL([]byte(key))
 	}
 	c.markTouched([]byte(key))
 	return luaStringReply(value)
+}
+
+func (c *luaScriptContext) markListDeleted(key string) {
+	c.everDeleted[key], c.deleted[key] = true, true
 }
 
 func (c *luaScriptContext) popLazyListValue(key []byte, st *luaListState, left bool) (string, bool, error) {

--- a/adapter/redis_lua_list_holes_test.go
+++ b/adapter/redis_lua_list_holes_test.go
@@ -1,0 +1,73 @@
+package adapter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bootjp/elastickv/store"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedisLua_RPopLPushMissingTailItemReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := newListPopTestServer(t)
+	src := []byte("bull:test:wait")
+	dst := []byte("bull:test:active")
+	seedListMeta(t, r, src, store.ListMeta{Head: 0, Len: 1, Tail: 1}, 1)
+
+	scriptCtx, err := newLuaScriptContext(ctx, r)
+	require.NoError(t, err)
+	defer scriptCtx.Close()
+
+	reply, err := scriptCtx.cmdRPopLPush([]string{string(src), string(dst)})
+	require.NoError(t, err)
+	require.Equal(t, luaReplyNil, reply.kind)
+	require.NoError(t, scriptCtx.commit())
+
+	readTS := r.readTS()
+	typ, err := r.keyTypeAt(ctx, src, readTS)
+	require.NoError(t, err)
+	require.Equal(t, redisTypeNone, typ)
+	dstValues, err := r.listValuesAt(ctx, dst, readTS)
+	require.NoError(t, err)
+	require.Empty(t, dstValues)
+}
+
+func TestRedisLua_RPopLPushSkipsTailHole(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := newListPopTestServer(t)
+	src := []byte("bull:test:wait:hole")
+	dst := []byte("bull:test:active:hole")
+	seedListMeta(t, r, src, store.ListMeta{Head: 0, Len: 2, Tail: 2}, 1)
+	require.NoError(t, r.store.PutAt(ctx, listItemKey(src, 0), []byte("job-1"), 2, 0))
+
+	scriptCtx, err := newLuaScriptContext(ctx, r)
+	require.NoError(t, err)
+	defer scriptCtx.Close()
+
+	reply, err := scriptCtx.cmdRPopLPush([]string{string(src), string(dst)})
+	require.NoError(t, err)
+	require.Equal(t, luaReplyString, reply.kind)
+	require.Equal(t, "job-1", reply.text)
+	require.NoError(t, scriptCtx.commit())
+
+	readTS := r.readTS()
+	srcValues, err := r.listValuesAt(ctx, src, readTS)
+	require.NoError(t, err)
+	require.Empty(t, srcValues)
+	dstValues, err := r.listValuesAt(ctx, dst, readTS)
+	require.NoError(t, err)
+	require.Equal(t, []string{"job-1"}, dstValues)
+}
+
+func seedListMeta(t *testing.T, r *RedisServer, key []byte, meta store.ListMeta, commitTS uint64) {
+	t.Helper()
+
+	raw, err := store.MarshalListMeta(meta)
+	require.NoError(t, err)
+	require.NoError(t, r.store.PutAt(context.Background(), store.ListMetaKey(key), raw, commitTS, 0))
+}

--- a/adapter/redis_lua_list_holes_test.go
+++ b/adapter/redis_lua_list_holes_test.go
@@ -15,7 +15,7 @@ func TestRedisLua_RPopLPushMissingTailItemReturnsNil(t *testing.T) {
 	r := newListPopTestServer(t)
 	src := []byte("bull:test:wait")
 	dst := []byte("bull:test:active")
-	seedListMeta(t, r, src, store.ListMeta{Head: 0, Len: 1, Tail: 1}, 1)
+	seedListMeta(t, r, src, store.ListMeta{Head: 0, Len: 1, Tail: 1})
 
 	scriptCtx, err := newLuaScriptContext(ctx, r)
 	require.NoError(t, err)
@@ -42,7 +42,7 @@ func TestRedisLua_RPopLPushSkipsTailHole(t *testing.T) {
 	r := newListPopTestServer(t)
 	src := []byte("bull:test:wait:hole")
 	dst := []byte("bull:test:active:hole")
-	seedListMeta(t, r, src, store.ListMeta{Head: 0, Len: 2, Tail: 2}, 1)
+	seedListMeta(t, r, src, store.ListMeta{Head: 0, Len: 2, Tail: 2})
 	require.NoError(t, r.store.PutAt(ctx, listItemKey(src, 0), []byte("job-1"), 2, 0))
 
 	scriptCtx, err := newLuaScriptContext(ctx, r)
@@ -64,10 +64,62 @@ func TestRedisLua_RPopLPushSkipsTailHole(t *testing.T) {
 	require.Equal(t, []string{"job-1"}, dstValues)
 }
 
-func seedListMeta(t *testing.T, r *RedisServer, key []byte, meta store.ListMeta, commitTS uint64) {
+func TestRedisLua_RPopLPushMissingTailThenRecreateRewritesMeta(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := newListPopTestServer(t)
+	src := []byte("bull:test:wait:recreate")
+	dst := []byte("bull:test:active:recreate")
+	seedListMeta(t, r, src, store.ListMeta{Head: 0, Len: 1, Tail: 1})
+
+	scriptCtx, err := newLuaScriptContext(ctx, r)
+	require.NoError(t, err)
+	defer scriptCtx.Close()
+
+	reply, err := scriptCtx.cmdRPopLPush([]string{string(src), string(dst)})
+	require.NoError(t, err)
+	require.Equal(t, luaReplyNil, reply.kind)
+
+	llen, err := scriptCtx.cmdRPush([]string{string(src), "job-new"})
+	require.NoError(t, err)
+	require.Equal(t, luaReplyInt, llen.kind)
+	require.Equal(t, int64(1), llen.integer)
+	require.NoError(t, scriptCtx.commit())
+
+	readTS := r.readTS()
+	meta, exists, err := r.resolveListMeta(ctx, src, readTS)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Equal(t, int64(1), meta.Len)
+	srcValues, err := r.listValuesAt(ctx, src, readTS)
+	require.NoError(t, err)
+	require.Equal(t, []string{"job-new"}, srcValues)
+}
+
+func TestRedisLua_RPopLPushBoundsSparseTailHoleScan(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := newListPopTestServer(t)
+	src := []byte("bull:test:wait:long-hole")
+	dst := []byte("bull:test:active:long-hole")
+	largeLen := int64(luaSparseListPopScanLimit) + 2
+	seedListMeta(t, r, src, store.ListMeta{Head: 0, Len: largeLen, Tail: largeLen})
+	require.NoError(t, r.store.PutAt(ctx, listItemKey(src, 0), []byte("job-1"), 2, 0))
+
+	scriptCtx, err := newLuaScriptContext(ctx, r)
+	require.NoError(t, err)
+	defer scriptCtx.Close()
+
+	_, err = scriptCtx.cmdRPopLPush([]string{string(src), string(dst)})
+	require.ErrorIs(t, err, ErrCollectionTooLarge)
+}
+
+func seedListMeta(t *testing.T, r *RedisServer, key []byte, meta store.ListMeta) {
 	t.Helper()
 
 	raw, err := store.MarshalListMeta(meta)
 	require.NoError(t, err)
-	require.NoError(t, r.store.PutAt(context.Background(), store.ListMetaKey(key), raw, commitTS, 0))
+	require.NoError(t, r.store.PutAt(context.Background(), store.ListMetaKey(key), raw, 1, 0))
 }

--- a/adapter/redis_lua_list_holes_test.go
+++ b/adapter/redis_lua_list_holes_test.go
@@ -64,6 +64,65 @@ func TestRedisLua_RPopLPushSkipsTailHole(t *testing.T) {
 	require.Equal(t, []string{"job-1"}, dstValues)
 }
 
+func TestRedisLua_RPopLPushSparseTailEmitsRightTrimDelta(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := newListPopTestServer(t)
+	src := []byte("bull:test:wait:tail-trim")
+	dst := []byte("bull:test:active:tail-trim")
+	seedListMeta(t, r, src, store.ListMeta{Head: 0, Len: 3, Tail: 3})
+	require.NoError(t, r.store.PutAt(ctx, listItemKey(src, 0), []byte("job-1"), 2, 0))
+	require.NoError(t, r.store.PutAt(ctx, listItemKey(src, 1), []byte("job-2"), 2, 0))
+
+	scriptCtx, err := newLuaScriptContext(ctx, r)
+	require.NoError(t, err)
+	defer scriptCtx.Close()
+
+	reply, err := scriptCtx.cmdRPopLPush([]string{string(src), string(dst)})
+	require.NoError(t, err)
+	require.Equal(t, luaReplyString, reply.kind)
+	require.Equal(t, "job-2", reply.text)
+	require.NoError(t, scriptCtx.commit())
+
+	readTS := r.readTS()
+	meta, exists, err := r.resolveListMeta(ctx, src, readTS)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Equal(t, int64(1), meta.Len)
+	srcValues, err := r.listValuesAt(ctx, src, readTS)
+	require.NoError(t, err)
+	require.Equal(t, []string{"job-1"}, srcValues)
+	dstValues, err := r.listValuesAt(ctx, dst, readTS)
+	require.NoError(t, err)
+	require.Equal(t, []string{"job-2"}, dstValues)
+}
+
+func TestRedisLua_RPopLPushSkipsPrefixCollisionItem(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := newListPopTestServer(t)
+	src := []byte("bull:test:wait:prefix")
+	dst := []byte("bull:test:active:prefix")
+	seedListMeta(t, r, src, store.ListMeta{Head: 0, Len: 2, Tail: 2})
+	require.NoError(t, r.store.PutAt(ctx, listItemKey(src, 0), []byte("job-1"), 2, 0))
+	collider := append([]byte{}, src...)
+	collider = append(collider, listItemKey(src, 1)[len(store.ListItemPrefix)+len(src):]...)
+	collider = append(collider, 'x')
+	require.NoError(t, r.store.PutAt(ctx, listItemKey(collider, 0), []byte("other-list-job"), 2, 0))
+
+	scriptCtx, err := newLuaScriptContext(ctx, r)
+	require.NoError(t, err)
+	defer scriptCtx.Close()
+
+	reply, err := scriptCtx.cmdRPopLPush([]string{string(src), string(dst)})
+	require.NoError(t, err)
+	require.Equal(t, luaReplyString, reply.kind)
+	require.Equal(t, "job-1", reply.text)
+	require.NoError(t, scriptCtx.commit())
+}
+
 func TestRedisLua_RPopLPushMissingTailThenRecreateRewritesMeta(t *testing.T) {
 	t.Parallel()
 

--- a/adapter/redis_lua_list_holes_test.go
+++ b/adapter/redis_lua_list_holes_test.go
@@ -105,10 +105,10 @@ func TestRedisLua_RPopLPushSkipsPrefixCollisionItem(t *testing.T) {
 	r := newListPopTestServer(t)
 	src := []byte("bull:test:wait:prefix")
 	dst := []byte("bull:test:active:prefix")
-	seedListMeta(t, r, src, store.ListMeta{Head: 0, Len: 2, Tail: 2})
+	seedListMeta(t, r, src, store.ListMeta{Head: 0, Len: 1, Tail: 1})
 	require.NoError(t, r.store.PutAt(ctx, listItemKey(src, 0), []byte("job-1"), 2, 0))
 	collider := append([]byte{}, src...)
-	collider = append(collider, listItemKey(src, 1)[len(store.ListItemPrefix)+len(src):]...)
+	collider = append(collider, listItemKey(src, 0)[len(store.ListItemPrefix)+len(src):]...)
 	collider = append(collider, 'x')
 	require.NoError(t, r.store.PutAt(ctx, listItemKey(collider, 0), []byte("other-list-job"), 2, 0))
 

--- a/kv/lock_resolver.go
+++ b/kv/lock_resolver.go
@@ -392,7 +392,10 @@ func lockResolverBudgetExhausted(err error, workCtx, parentCtx context.Context) 
 	if parentCtx != nil && parentCtx.Err() != nil {
 		return false
 	}
-	return workCtx.Err() != nil
+	if workCtx.Err() != nil {
+		return true
+	}
+	return errors.Is(err, context.DeadlineExceeded)
 }
 
 func (lr *LockResolver) resolveExpiredLock(ctx context.Context, g *ShardGroup, userKey []byte, lock txnLock) error {

--- a/kv/lock_resolver_test.go
+++ b/kv/lock_resolver_test.go
@@ -508,6 +508,9 @@ func TestLockResolverBudgetExhaustedUsesWorkContext(t *testing.T) {
 	cancelParent()
 	require.False(t, lockResolverBudgetExhausted(errors.New("grpc deadline"), workCtx, parentCtx))
 	require.False(t, lockResolverBudgetExhausted(errors.New("grpc deadline"), context.Background(), context.Background()))
+
+	require.True(t, lockResolverBudgetExhausted(context.DeadlineExceeded, context.Background(), context.Background()))
+	require.False(t, lockResolverBudgetExhausted(context.DeadlineExceeded, context.Background(), parentCtx))
 }
 
 type lockResolverStatusEngine struct {


### PR DESCRIPTION
## Summary
- Run Redis delta compactor background handlers sequentially under one shared tick budget instead of launching four full-prefix scans concurrently.
- Back off regular background delta compaction after a tick exhausts its timeout, then resume from the next collection type so list-heavy passes cannot starve hash/set/zset maintenance.
- Treat lock resolver background deadline errors as budget exhaustion so cleanup yields and backs off instead of repeatedly hammering a saturated leader.
- Keep urgent single-key delta compaction active so over-limit hot keys can still be repaired between regular ticks.
- Make Lua list pops tolerate sparse/missing boundary item rows so BullMQ `RPOPLPUSH` scripts return Redis-compatible nil/next-item behavior instead of surfacing `<string>:215: not found`.
- Bound Lua sparse-list hole scanning and force full rewrite after in-script list deletion/recreation so stale metadata cannot be preserved.
- Refresh the checked TLA tools checksum to match the pinned upstream v1.8.0 jar.

## Root cause
During the Redis migration workload, the background delta compactor could start list/hash/set/zset full-prefix scans concurrently on every leader tick. On a saturated leader this created maintenance backpressure, contributed to missed Raft progress, and showed up at the proxy as resets and broken pipes.

The first mitigation made handlers sequential under one budget, but fixed ordering meant a repeatedly timing-out list pass could always consume the next post-backoff tick before hash/set/zset ran. This update stores a background handler cursor and advances it after every attempted handler, so timeout recovery continues with the next collection type.

After the initial deploy reduced leader churn, the remaining high-volume proxy warning was BullMQ `moveToActive` hitting Lua `RPOPLPUSH`. The lazy Lua list-pop path returned `ErrKeyNotFound` when list metadata pointed at a boundary item row that was already absent; Redis-compatible behavior is to skip logically absent boundary rows and return nil if the logical list is exhausted. The sparse path is now bounded and marks in-script list deletions as requiring a full rewrite if the key is recreated.

## Validation
- `GOCACHE=$(pwd)/.cache GOTMPDIR=$(pwd)/.cache/tmp go test ./adapter -run 'TestDeltaCompactor|TestRedisLua_RPopLPush|TestRedis_LuaRPopLPush|TestListPop' -count=1`
- `GOCACHE=$(pwd)/.cache GOTMPDIR=$(pwd)/.cache/tmp go test ./kv -run 'TestLockResolverBudgetExhaustedUsesWorkContext|TestLockResolver' -count=1`
- caller audit for Lua pop error-path change: only Lua `LPOP`/`RPOP`/`RPOPLPUSH` route through `popLazyListValue`; non-Lua Redis pop commands use separate list-pop code
- `make tla-tools`
- `make tla-check`
- `git diff --check`
- commit hook: `golangci-lint --config=.golangci.yaml run --fix` reported `0 issues`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 背景コンパクションを時間予算内で順次実行し、タイムアウト後は一定期間自動的に再試行を抑制します。
  - タイムアウト時も処理対象を順番に切り替え、継続的な進行を可能にしました。
  - リスト操作で欠損要素や疎なデータを正しく処理し、不要な変更を防止します。
  - スキャン上限を超えた場合は適切なエラーを返します。
  - ロック解決のタイムアウト判定を改善しました。

- **テスト**
  - コンパクションのバックオフ、処理順序、リストの欠損要素に関する検証を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->