### PR TITLE
Handle large sparse Lua list pops

### DIFF
--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -2145,23 +2145,10 @@ func (c *luaScriptContext) scanLazyListBoundaryItem(key []byte, st *luaListState
 
 	startIdx := st.leftTrim
 	endIdx := st.meta.Len - st.rightTrim - 1
-	scanLen := remaining
-	if scanLen > int64(luaSparseListPopScanLimit) {
-		scanLen = int64(luaSparseListPopScanLimit)
-		if left {
-			endIdx = startIdx + scanLen - 1
-		} else {
-			startIdx = endIdx - scanLen + 1
-		}
-	}
 
 	item, ok, err := c.scanListItemWindow(key, st.meta, startIdx, endIdx, left)
 	if err != nil || ok {
 		return item, ok, err
-	}
-	if remaining > int64(luaSparseListPopScanLimit) {
-		return luaLazyListBoundaryItem{}, false, errors.Wrapf(ErrCollectionTooLarge,
-			"list %q sparse pop skipped more than %d missing items", string(key), luaSparseListPopScanLimit)
 	}
 	return luaLazyListBoundaryItem{}, false, nil
 }

--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -79,6 +79,7 @@ type luaListState struct {
 	meta         store.ListMeta
 	leftTrim     int64
 	rightTrim    int64
+	trimDeletes  []int64
 	leftValues   []string
 	rightValues  []string
 	values       []string
@@ -175,6 +176,11 @@ const (
 
 	luaSparseListPopScanLimit = store.MaxDeltaScanLimit
 )
+
+type luaPhysicalLimitedScanStore interface {
+	ScanAtPhysicalLimit(ctx context.Context, start []byte, end []byte, visibleLimit, physicalLimit int, ts uint64) ([]*store.KVPair, bool, error)
+	ReverseScanAtPhysicalLimit(ctx context.Context, start []byte, end []byte, visibleLimit, physicalLimit int, ts uint64) ([]*store.KVPair, bool, error)
+}
 
 type luaCommandHandler func(*luaScriptContext, []string) (luaReply, error)
 type luaRenameHandler func(*luaScriptContext, []byte, []byte) error
@@ -356,6 +362,7 @@ func (c *luaScriptContext) deleteLogical(key []byte) {
 		st.meta = store.ListMeta{}
 		st.leftTrim = 0
 		st.rightTrim = 0
+		st.trimDeletes = nil
 		st.leftValues = nil
 		st.rightValues = nil
 		st.values = nil
@@ -610,6 +617,7 @@ func (c *luaScriptContext) materializeList(key []byte, st *luaListState) error {
 	st.materialized = true
 	st.leftTrim = 0
 	st.rightTrim = 0
+	st.trimDeletes = nil
 	st.leftValues = nil
 	st.rightValues = nil
 	st.values = values
@@ -990,6 +998,7 @@ func (c *luaScriptContext) markListValue(key []byte, values []string) error {
 	st.meta = store.ListMeta{}
 	st.leftTrim = 0
 	st.rightTrim = 0
+	st.trimDeletes = nil
 	st.leftValues = nil
 	st.rightValues = nil
 	st.values = append([]string(nil), values...)
@@ -1761,6 +1770,7 @@ func (c *luaScriptContext) pushList(args []string, left bool) (luaReply, error) 
 		st.meta = store.ListMeta{}
 		st.leftTrim = 0
 		st.rightTrim = 0
+		st.trimDeletes = nil
 		st.leftValues = nil
 		st.rightValues = nil
 		st.values = nil
@@ -2037,6 +2047,7 @@ func (c *luaScriptContext) markListEmptyAfterLazyPop(key string, st *luaListStat
 	st.meta = store.ListMeta{}
 	st.leftTrim = 0
 	st.rightTrim = 0
+	st.trimDeletes = nil
 	st.leftValues = nil
 	st.rightValues = nil
 	st.values = nil
@@ -2053,6 +2064,7 @@ func (c *luaScriptContext) finishPoppedListValue(key string, st *luaListState, v
 		st.meta = store.ListMeta{}
 		st.leftTrim = 0
 		st.rightTrim = 0
+		st.trimDeletes = nil
 		st.leftValues = nil
 		st.rightValues = nil
 		st.values = nil
@@ -2091,6 +2103,7 @@ func (c *luaScriptContext) popLazyListLeft(key []byte, st *luaListState) (string
 				continue
 			}
 			st.leftTrim = item.index + 1
+			st.trimDeletes = append(st.trimDeletes, st.meta.Head+item.index)
 			return item.value, true, nil
 		}
 		if len(st.rightValues) == 0 {
@@ -2120,6 +2133,7 @@ func (c *luaScriptContext) popLazyListRight(key []byte, st *luaListState) (strin
 				continue
 			}
 			st.rightTrim = st.meta.Len - item.index
+			st.trimDeletes = append(st.trimDeletes, st.meta.Head+item.index)
 			return item.value, true, nil
 		}
 		if len(st.leftValues) == 0 {
@@ -2161,15 +2175,16 @@ func (c *luaScriptContext) scanListItemWindow(key []byte, meta store.ListMeta, s
 	endKey := listItemKey(key, meta.Head+endIdx+1)
 
 	var (
-		kvs []*store.KVPair
-		err error
+		kvs                  []*store.KVPair
+		physicalLimitReached bool
+		err                  error
 	)
 	scanLimit := luaSparseListPopScanLimit
 
 	if left {
-		kvs, err = c.server.store.ScanAt(c.ctx, startKey, endKey, scanLimit, c.startTS)
+		kvs, physicalLimitReached, err = c.scanAtPhysicalLimit(startKey, endKey, scanLimit)
 	} else {
-		kvs, err = c.server.store.ReverseScanAt(c.ctx, startKey, endKey, scanLimit, c.startTS)
+		kvs, physicalLimitReached, err = c.reverseScanAtPhysicalLimit(startKey, endKey, scanLimit)
 	}
 	if err != nil {
 		return luaLazyListBoundaryItem{}, false, errors.WithStack(err)
@@ -2184,11 +2199,33 @@ func (c *luaScriptContext) scanListItemWindow(key []byte, meta store.ListMeta, s
 			index: seq - meta.Head,
 		}, true, nil
 	}
+	if physicalLimitReached {
+		return luaLazyListBoundaryItem{}, false, errors.Wrapf(ErrCollectionTooLarge,
+			"list %q sparse pop scanned %d physical item rows", string(key), scanLimit)
+	}
 	if len(kvs) >= scanLimit {
 		return luaLazyListBoundaryItem{}, false, errors.Wrapf(ErrCollectionTooLarge,
 			"list %q sparse pop scanned %d non-matching item rows", string(key), scanLimit)
 	}
 	return luaLazyListBoundaryItem{}, false, nil
+}
+
+func (c *luaScriptContext) scanAtPhysicalLimit(startKey, endKey []byte, scanLimit int) ([]*store.KVPair, bool, error) {
+	if scanner, ok := c.server.store.(luaPhysicalLimitedScanStore); ok {
+		kvs, limitReached, err := scanner.ScanAtPhysicalLimit(c.ctx, startKey, endKey, scanLimit, scanLimit, c.startTS)
+		return kvs, limitReached, errors.WithStack(err)
+	}
+	kvs, err := c.server.store.ScanAt(c.ctx, startKey, endKey, scanLimit, c.startTS)
+	return kvs, false, errors.WithStack(err)
+}
+
+func (c *luaScriptContext) reverseScanAtPhysicalLimit(startKey, endKey []byte, scanLimit int) ([]*store.KVPair, bool, error) {
+	if scanner, ok := c.server.store.(luaPhysicalLimitedScanStore); ok {
+		kvs, limitReached, err := scanner.ReverseScanAtPhysicalLimit(c.ctx, startKey, endKey, scanLimit, scanLimit, c.startTS)
+		return kvs, limitReached, errors.WithStack(err)
+	}
+	kvs, err := c.server.store.ReverseScanAt(c.ctx, startKey, endKey, scanLimit, c.startTS)
+	return kvs, false, errors.WithStack(err)
 }
 
 func (c *luaScriptContext) cmdRPopLPush(args []string) (luaReply, error) {
@@ -3482,7 +3519,7 @@ func (c *luaScriptContext) listDeltaCommitElems(key string, st *luaListState, co
 		return nil, err
 	}
 
-	elems := make([]*kv.Elem[kv.OP], 0, int(st.leftTrim+st.rightTrim)+len(st.leftValues)+len(st.rightValues)+setWideColOverhead)
+	elems := make([]*kv.Elem[kv.OP], 0, len(st.trimDeletes)+len(st.leftValues)+len(st.rightValues)+setWideColOverhead)
 	elems = appendListTrimDeletes(elems, []byte(key), st)
 	elems = appendListPuts(elems, []byte(key), st.leftValues, newHead)
 	elems = appendListPuts(elems, []byte(key), st.rightValues, rightStart)
@@ -3533,10 +3570,7 @@ func validateListDeltaRanges(st *luaListState) (int64, int64, error) {
 }
 
 func appendListTrimDeletes(elems []*kv.Elem[kv.OP], key []byte, st *luaListState) []*kv.Elem[kv.OP] {
-	for seq := st.meta.Head; seq < st.meta.Head+st.leftTrim; seq++ {
-		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: listItemKey(key, seq)})
-	}
-	for seq := st.meta.Tail - st.rightTrim; seq < st.meta.Tail; seq++ {
+	for _, seq := range st.trimDeletes {
 		elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: listItemKey(key, seq)})
 	}
 	return elems

--- a/adapter/redis_lua_list_holes_test.go
+++ b/adapter/redis_lua_list_holes_test.go
@@ -186,6 +186,60 @@ func TestRedisLua_RPopLPushScansPastLargeTailHole(t *testing.T) {
 	require.Equal(t, []string{"job-1"}, dstValues)
 }
 
+func TestRedisLua_RPopLPushKeepsRemainingSparseHeadItem(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := newListPopTestServer(t)
+	src := []byte("bull:test:wait:remaining-head")
+	dst := []byte("bull:test:active:remaining-head")
+	largeLen := int64(luaSparseListPopScanLimit) + 2
+	seedListMeta(t, r, src, store.ListMeta{Head: 0, Len: largeLen, Tail: largeLen})
+	require.NoError(t, r.store.PutAt(ctx, listItemKey(src, 0), []byte("job-1"), 2, 0))
+	require.NoError(t, r.store.PutAt(ctx, listItemKey(src, 1), []byte("job-2"), 3, 0))
+
+	scriptCtx, err := newLuaScriptContext(ctx, r)
+	require.NoError(t, err)
+	defer scriptCtx.Close()
+
+	reply, err := scriptCtx.cmdRPopLPush([]string{string(src), string(dst)})
+	require.NoError(t, err)
+	require.Equal(t, luaReplyString, reply.kind)
+	require.Equal(t, "job-2", reply.text)
+	require.NoError(t, scriptCtx.commit())
+
+	readTS := r.readTS()
+	srcValues, err := r.listValuesAt(ctx, src, readTS)
+	require.NoError(t, err)
+	require.Equal(t, []string{"job-1"}, srcValues)
+	dstValues, err := r.listValuesAt(ctx, dst, readTS)
+	require.NoError(t, err)
+	require.Equal(t, []string{"job-2"}, dstValues)
+}
+
+func TestRedisLua_RPopLPushFailsOnTooManyPhysicalTailTombstones(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := newListPopTestServer(t)
+	src := []byte("bull:test:wait:tombstone-tail")
+	dst := []byte("bull:test:active:tombstone-tail")
+	largeLen := int64(luaSparseListPopScanLimit) + 2
+	seedListMeta(t, r, src, store.ListMeta{Head: 0, Len: largeLen, Tail: largeLen})
+	commitTS := uint64(3)
+	for seq := int64(1); seq <= int64(luaSparseListPopScanLimit)+1; seq++ {
+		require.NoError(t, r.store.DeleteAt(ctx, listItemKey(src, seq), commitTS))
+		commitTS++
+	}
+
+	scriptCtx, err := newLuaScriptContext(ctx, r)
+	require.NoError(t, err)
+	defer scriptCtx.Close()
+
+	_, err = scriptCtx.cmdRPopLPush([]string{string(src), string(dst)})
+	require.ErrorIs(t, err, ErrCollectionTooLarge)
+}
+
 func TestRedisLua_RPopLPushDeletesLargeSparseListWithoutItems(t *testing.T) {
 	t.Parallel()
 

--- a/adapter/redis_lua_list_holes_test.go
+++ b/adapter/redis_lua_list_holes_test.go
@@ -156,7 +156,7 @@ func TestRedisLua_RPopLPushMissingTailThenRecreateRewritesMeta(t *testing.T) {
 	require.Equal(t, []string{"job-new"}, srcValues)
 }
 
-func TestRedisLua_RPopLPushBoundsSparseTailHoleScan(t *testing.T) {
+func TestRedisLua_RPopLPushScansPastLargeTailHole(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -171,8 +171,47 @@ func TestRedisLua_RPopLPushBoundsSparseTailHoleScan(t *testing.T) {
 	require.NoError(t, err)
 	defer scriptCtx.Close()
 
-	_, err = scriptCtx.cmdRPopLPush([]string{string(src), string(dst)})
-	require.ErrorIs(t, err, ErrCollectionTooLarge)
+	reply, err := scriptCtx.cmdRPopLPush([]string{string(src), string(dst)})
+	require.NoError(t, err)
+	require.Equal(t, luaReplyString, reply.kind)
+	require.Equal(t, "job-1", reply.text)
+	require.NoError(t, scriptCtx.commit())
+
+	readTS := r.readTS()
+	typ, err := r.keyTypeAt(ctx, src, readTS)
+	require.NoError(t, err)
+	require.Equal(t, redisTypeNone, typ)
+	dstValues, err := r.listValuesAt(ctx, dst, readTS)
+	require.NoError(t, err)
+	require.Equal(t, []string{"job-1"}, dstValues)
+}
+
+func TestRedisLua_RPopLPushDeletesLargeSparseListWithoutItems(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r := newListPopTestServer(t)
+	src := []byte("bull:test:wait:large-empty")
+	dst := []byte("bull:test:active:large-empty")
+	largeLen := int64(luaSparseListPopScanLimit) + 2
+	seedListMeta(t, r, src, store.ListMeta{Head: 0, Len: largeLen, Tail: largeLen})
+
+	scriptCtx, err := newLuaScriptContext(ctx, r)
+	require.NoError(t, err)
+	defer scriptCtx.Close()
+
+	reply, err := scriptCtx.cmdRPopLPush([]string{string(src), string(dst)})
+	require.NoError(t, err)
+	require.Equal(t, luaReplyNil, reply.kind)
+	require.NoError(t, scriptCtx.commit())
+
+	readTS := r.readTS()
+	typ, err := r.keyTypeAt(ctx, src, readTS)
+	require.NoError(t, err)
+	require.Equal(t, redisTypeNone, typ)
+	dstValues, err := r.listValuesAt(ctx, dst, readTS)
+	require.NoError(t, err)
+	require.Empty(t, dstValues)
 }
 
 func seedListMeta(t *testing.T, r *RedisServer, key []byte, meta store.ListMeta) {

--- a/kv/leader_routed_store.go
+++ b/kv/leader_routed_store.go
@@ -303,8 +303,9 @@ func (s *LeaderRoutedStore) scanAtPhysicalLimit(ctx context.Context, start []byt
 		kvs, err := s.local.ReverseScanAt(ctx, start, end, visibleLimit, max(ts, fenceTS))
 		return kvs, false, errors.WithStack(err)
 	}
-	kvs, err := s.proxyRawScanAt(ctx, start, end, visibleLimit, ts, reverse)
-	return kvs, false, errors.WithStack(err)
+	// RawScanAt cannot enforce physicalLimit, so report truncation and let
+	// callers fail closed instead of proxying an unbounded physical scan.
+	return nil, true, nil
 }
 
 func (s *LeaderRoutedStore) PutAt(ctx context.Context, key []byte, value []byte, commitTS uint64, expireAt uint64) error {

--- a/kv/leader_routed_store.go
+++ b/kv/leader_routed_store.go
@@ -260,6 +260,10 @@ func (s *LeaderRoutedStore) ScanAt(ctx context.Context, start []byte, end []byte
 	return s.proxyRawScanAt(ctx, start, end, limit, ts, false)
 }
 
+func (s *LeaderRoutedStore) ScanAtPhysicalLimit(ctx context.Context, start []byte, end []byte, visibleLimit, physicalLimit int, ts uint64) ([]*store.KVPair, bool, error) {
+	return s.scanAtPhysicalLimit(ctx, start, end, visibleLimit, physicalLimit, ts, false)
+}
+
 func (s *LeaderRoutedStore) ReverseScanAt(ctx context.Context, start []byte, end []byte, limit int, ts uint64) ([]*store.KVPair, error) {
 	if s == nil || s.local == nil {
 		return []*store.KVPair{}, nil
@@ -273,6 +277,34 @@ func (s *LeaderRoutedStore) ReverseScanAt(ctx context.Context, start []byte, end
 		return kvs, errors.WithStack(err)
 	}
 	return s.proxyRawScanAt(ctx, start, end, limit, ts, true)
+}
+
+func (s *LeaderRoutedStore) ReverseScanAtPhysicalLimit(ctx context.Context, start []byte, end []byte, visibleLimit, physicalLimit int, ts uint64) ([]*store.KVPair, bool, error) {
+	return s.scanAtPhysicalLimit(ctx, start, end, visibleLimit, physicalLimit, ts, true)
+}
+
+func (s *LeaderRoutedStore) scanAtPhysicalLimit(ctx context.Context, start []byte, end []byte, visibleLimit, physicalLimit int, ts uint64, reverse bool) ([]*store.KVPair, bool, error) {
+	if s == nil || s.local == nil {
+		return []*store.KVPair{}, false, nil
+	}
+	if visibleLimit <= 0 || physicalLimit <= 0 {
+		return []*store.KVPair{}, false, nil
+	}
+	ok, fenceTS := s.leaderFenceTS(ctx, start)
+	if ok {
+		scanner, hasPhysicalLimit := s.local.(physicalLimitedStore)
+		if hasPhysicalLimit {
+			return scanPhysicalLimitLocal(ctx, scanner, start, end, visibleLimit, physicalLimit, max(ts, fenceTS), reverse)
+		}
+		if !reverse {
+			kvs, err := s.local.ScanAt(ctx, start, end, visibleLimit, max(ts, fenceTS))
+			return kvs, false, errors.WithStack(err)
+		}
+		kvs, err := s.local.ReverseScanAt(ctx, start, end, visibleLimit, max(ts, fenceTS))
+		return kvs, false, errors.WithStack(err)
+	}
+	kvs, err := s.proxyRawScanAt(ctx, start, end, visibleLimit, ts, reverse)
+	return kvs, false, errors.WithStack(err)
 }
 
 func (s *LeaderRoutedStore) PutAt(ctx context.Context, key []byte, value []byte, commitTS uint64, expireAt uint64) error {

--- a/kv/shard_store.go
+++ b/kv/shard_store.go
@@ -446,11 +446,9 @@ func (s *ShardStore) scanRouteAtDirectionPhysicalLimit(
 		return s.scanRouteAtLeaderPhysicalLimit(ctx, g, start, end, visibleLimit, physicalLimit, ts, reverse)
 	}
 
-	kvs, err := s.proxyRawScanAt(ctx, g, start, end, visibleLimit, ts, reverse, 0)
-	if err != nil {
-		return nil, false, err
-	}
-	return filterTxnInternalKVs(kvs), false, nil
+	// RawScanAt cannot enforce physicalLimit, so report truncation and let
+	// callers fail closed instead of proxying an unbounded physical scan.
+	return nil, true, nil
 }
 
 func scanLocalPhysicalLimit(

--- a/kv/shard_store.go
+++ b/kv/shard_store.go
@@ -204,6 +204,18 @@ func (s *ShardStore) ScanAt(ctx context.Context, start []byte, end []byte, limit
 	return out, nil
 }
 
+func (s *ShardStore) ScanAtPhysicalLimit(ctx context.Context, start []byte, end []byte, visibleLimit, physicalLimit int, ts uint64) ([]*store.KVPair, bool, error) {
+	if visibleLimit <= 0 || physicalLimit <= 0 {
+		return []*store.KVPair{}, false, nil
+	}
+	routes, clampToRoutes := s.routesForScan(start, end)
+	if len(routes) != 1 || clampToRoutes {
+		kvs, err := s.ScanAt(ctx, start, end, visibleLimit, ts)
+		return kvs, false, err
+	}
+	return s.scanRouteAtDirectionPhysicalLimit(ctx, routes[0], start, end, visibleLimit, physicalLimit, ts, false)
+}
+
 // ScanGroupAt scans a range on the explicitly selected Raft group.
 // It is for keyspaces whose owner is resolved outside the byte-range
 // engine (for example SQS HT-FIFO's (queue, partition) resolver).
@@ -230,6 +242,18 @@ func (s *ShardStore) ReverseScanAt(ctx context.Context, start []byte, end []byte
 		out = out[:limit]
 	}
 	return out, nil
+}
+
+func (s *ShardStore) ReverseScanAtPhysicalLimit(ctx context.Context, start []byte, end []byte, visibleLimit, physicalLimit int, ts uint64) ([]*store.KVPair, bool, error) {
+	if visibleLimit <= 0 || physicalLimit <= 0 {
+		return []*store.KVPair{}, false, nil
+	}
+	routes, clampToRoutes := s.routesForScan(start, end)
+	if len(routes) != 1 || clampToRoutes {
+		kvs, err := s.ReverseScanAt(ctx, start, end, visibleLimit, ts)
+		return kvs, false, err
+	}
+	return s.scanRouteAtDirectionPhysicalLimit(ctx, routes[0], start, end, visibleLimit, physicalLimit, ts, true)
 }
 
 func (s *ShardStore) routesForScan(start []byte, end []byte) ([]distribution.Route, bool) {
@@ -390,6 +414,85 @@ func (s *ShardStore) scanRouteAtDirection(
 	return filterTxnInternalKVs(kvs), nil
 }
 
+type physicalLimitedStore interface {
+	ScanAtPhysicalLimit(ctx context.Context, start []byte, end []byte, visibleLimit, physicalLimit int, ts uint64) ([]*store.KVPair, bool, error)
+	ReverseScanAtPhysicalLimit(ctx context.Context, start []byte, end []byte, visibleLimit, physicalLimit int, ts uint64) ([]*store.KVPair, bool, error)
+}
+
+func (s *ShardStore) scanRouteAtDirectionPhysicalLimit(
+	ctx context.Context,
+	route distribution.Route,
+	start []byte,
+	end []byte,
+	visibleLimit int,
+	physicalLimit int,
+	ts uint64,
+	reverse bool,
+) ([]*store.KVPair, bool, error) {
+	g, ok := s.groupForID(route.GroupID)
+	if !ok || g == nil || g.Store == nil {
+		return nil, false, nil
+	}
+
+	if engineForGroup(g) == nil {
+		kvs, limitReached, err := scanLocalPhysicalLimit(ctx, g.Store, start, end, visibleLimit, physicalLimit, ts, reverse)
+		if err != nil {
+			return nil, limitReached, errors.WithStack(err)
+		}
+		return filterTxnInternalKVs(kvs), limitReached, nil
+	}
+
+	if isLinearizableRaftLeader(ctx, engineForGroup(g)) {
+		return s.scanRouteAtLeaderPhysicalLimit(ctx, g, start, end, visibleLimit, physicalLimit, ts, reverse)
+	}
+
+	kvs, err := s.proxyRawScanAt(ctx, g, start, end, visibleLimit, ts, reverse, 0)
+	if err != nil {
+		return nil, false, err
+	}
+	return filterTxnInternalKVs(kvs), false, nil
+}
+
+func scanLocalPhysicalLimit(
+	ctx context.Context,
+	st store.MVCCStore,
+	start []byte,
+	end []byte,
+	visibleLimit int,
+	physicalLimit int,
+	ts uint64,
+	reverse bool,
+) ([]*store.KVPair, bool, error) {
+	scanner, ok := st.(physicalLimitedStore)
+	if !ok {
+		if reverse {
+			kvs, err := st.ReverseScanAt(ctx, start, end, visibleLimit, ts)
+			return kvs, false, errors.WithStack(err)
+		}
+		kvs, err := st.ScanAt(ctx, start, end, visibleLimit, ts)
+		return kvs, false, errors.WithStack(err)
+	}
+	return scanPhysicalLimitLocal(ctx, scanner, start, end, visibleLimit, physicalLimit, ts, reverse)
+}
+
+func scanPhysicalLimitLocal(
+	ctx context.Context,
+	scanner physicalLimitedStore,
+	start []byte,
+	end []byte,
+	visibleLimit int,
+	physicalLimit int,
+	ts uint64,
+	reverse bool,
+) ([]*store.KVPair, bool, error) {
+	if reverse {
+		kvs, limitReached, err := scanner.ReverseScanAtPhysicalLimit(ctx, start, end, visibleLimit, physicalLimit, ts)
+		return kvs, limitReached, errors.WithStack(err)
+	}
+	kvs, limitReached, err := scanner.ScanAtPhysicalLimit(ctx, start, end, visibleLimit, physicalLimit, ts)
+	return kvs, limitReached, errors.WithStack(err)
+}
+
 func (s *ShardStore) scanRouteLocal(
 	ctx context.Context,
 	g *ShardGroup,
@@ -405,6 +508,29 @@ func (s *ShardStore) scanRouteLocal(
 	}
 	kvs, err := g.Store.ScanAt(ctx, start, end, limit, ts)
 	return kvs, errors.WithStack(err)
+}
+
+func (s *ShardStore) scanRouteAtLeaderPhysicalLimit(
+	ctx context.Context,
+	g *ShardGroup,
+	start []byte,
+	end []byte,
+	visibleLimit int,
+	physicalLimit int,
+	ts uint64,
+	reverse bool,
+) ([]*store.KVPair, bool, error) {
+	kvs, limitReached, err := scanLocalPhysicalLimit(ctx, g.Store, start, end, visibleLimit, physicalLimit, ts, reverse)
+	if err != nil {
+		return nil, limitReached, errors.WithStack(err)
+	}
+	lockStart, lockEnd := scanLockBoundsForKVs(kvs, start, end, visibleLimit)
+	lockKVs, err := scanTxnLockRangeAt(ctx, g, lockStart, lockEnd, ts, visibleLimit)
+	if err != nil {
+		return nil, limitReached, err
+	}
+	resolved, err := s.resolveScanLocks(ctx, g, kvs, lockKVs, ts)
+	return resolved, limitReached, err
 }
 
 func (s *ShardStore) scanRouteAtLeader(

--- a/store/lsm_store.go
+++ b/store/lsm_store.go
@@ -1075,39 +1075,55 @@ func prevScannableUserKey(iter *pebble.Iterator) ([]byte, bool) {
 }
 
 func (s *pebbleStore) collectScanResults(ctx context.Context, iter *pebble.Iterator, start, end []byte, limit int, ts uint64) ([]*KVPair, error) {
+	result, _, err := s.collectScanResultsWithPhysicalLimit(ctx, iter, start, end, limit, 0, ts)
+	return result, err
+}
+
+func (s *pebbleStore) collectScanResultsWithPhysicalLimit(ctx context.Context, iter *pebble.Iterator, start, end []byte, limit, physicalLimit int, ts uint64) ([]*KVPair, bool, error) {
 	result := make([]*KVPair, 0, boundedScanResultCapacity(limit))
+	visited := 0
 
 	for iter.SeekGE(encodeKey(start, math.MaxUint64)); iter.Valid() && len(result) < limit; {
 		userKey, version, ok, err := nextScannableUserKeyContext(ctx, iter)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
-		if !ok {
+		if forwardScanDone(userKey, end, ok) {
 			break
 		}
-
-		if pastScanEnd(userKey, end) {
-			break
+		if physicalLimit > 0 && visited >= physicalLimit {
+			return result, true, nil
 		}
+		visited++
 
-		if !s.seekToVisibleVersion(iter, userKey, version, ts) {
-			continue
-		}
-
-		kv, err := s.processFoundValue(iter, userKey, ts)
+		kv, advance, err := s.collectForwardScanKV(iter, userKey, version, ts)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		if kv != nil {
 			result = append(result, kv)
 		}
-
-		if !s.skipToNextUserKey(iter, userKey) {
+		if !advance {
 			break
 		}
 	}
 
-	return result, nil
+	return result, false, nil
+}
+
+func forwardScanDone(userKey, end []byte, ok bool) bool {
+	return !ok || pastScanEnd(userKey, end)
+}
+
+func (s *pebbleStore) collectForwardScanKV(iter *pebble.Iterator, userKey []byte, version uint64, ts uint64) (*KVPair, bool, error) {
+	if !s.seekToVisibleVersion(iter, userKey, version, ts) {
+		return nil, true, nil
+	}
+	kv, err := s.processFoundValue(iter, userKey, ts)
+	if err != nil {
+		return nil, false, err
+	}
+	return kv, s.skipToNextUserKey(iter, userKey), nil
 }
 
 func (s *pebbleStore) ScanAt(ctx context.Context, start []byte, end []byte, limit int, ts uint64) ([]*KVPair, error) {
@@ -1141,6 +1157,34 @@ func (s *pebbleStore) ScanAt(ctx context.Context, start []byte, end []byte, limi
 	return s.collectScanResults(ctx, iter, start, end, limit, ts)
 }
 
+func (s *pebbleStore) ScanAtPhysicalLimit(ctx context.Context, start []byte, end []byte, visibleLimit, physicalLimit int, ts uint64) ([]*KVPair, bool, error) {
+	if visibleLimit <= 0 || physicalLimit <= 0 {
+		return []*KVPair{}, false, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, false, errors.WithStack(err)
+	}
+
+	s.dbMu.RLock()
+	defer s.dbMu.RUnlock()
+	if err := ctx.Err(); err != nil {
+		return nil, false, errors.WithStack(err)
+	}
+	if readTSCompacted(ts, s.effectiveMinRetainedTS()) {
+		return nil, false, ErrReadTSCompacted
+	}
+
+	iter, err := s.db.NewIter(&pebble.IterOptions{
+		LowerBound: encodeKey(start, math.MaxUint64),
+	})
+	if err != nil {
+		return nil, false, errors.WithStack(err)
+	}
+	defer iter.Close()
+
+	return s.collectScanResultsWithPhysicalLimit(ctx, iter, start, end, visibleLimit, physicalLimit, ts)
+}
+
 func (s *pebbleStore) collectReverseScanResults(
 	iter *pebble.Iterator,
 	start []byte,
@@ -1148,24 +1192,41 @@ func (s *pebbleStore) collectReverseScanResults(
 	limit int,
 	ts uint64,
 ) ([]*KVPair, error) {
+	result, _, err := s.collectReverseScanResultsWithPhysicalLimit(iter, start, end, limit, 0, ts)
+	return result, err
+}
+
+func (s *pebbleStore) collectReverseScanResultsWithPhysicalLimit(
+	iter *pebble.Iterator,
+	start []byte,
+	end []byte,
+	limit int,
+	physicalLimit int,
+	ts uint64,
+) ([]*KVPair, bool, error) {
 	result := make([]*KVPair, 0, boundedScanResultCapacity(limit))
 
 	valid := seekReverseScanStart(iter, end)
+	visited := 0
 	for valid && len(result) < limit {
+		if physicalLimit > 0 && visited >= physicalLimit {
+			return result, true, nil
+		}
 		kv, nextValid, done, err := s.nextReverseScanKV(iter, start, ts)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		valid = nextValid
 		if done {
 			break
 		}
+		visited++
 		if kv != nil {
 			result = append(result, kv)
 		}
 	}
 
-	return result, nil
+	return result, false, nil
 }
 
 func seekReverseScanStart(iter *pebble.Iterator, end []byte) bool {
@@ -1230,6 +1291,38 @@ func (s *pebbleStore) ReverseScanAt(ctx context.Context, start []byte, end []byt
 	defer iter.Close()
 
 	return s.collectReverseScanResults(iter, start, end, limit, ts)
+}
+
+func (s *pebbleStore) ReverseScanAtPhysicalLimit(ctx context.Context, start []byte, end []byte, visibleLimit, physicalLimit int, ts uint64) ([]*KVPair, bool, error) {
+	if visibleLimit <= 0 || physicalLimit <= 0 {
+		return []*KVPair{}, false, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, false, errors.WithStack(err)
+	}
+
+	s.dbMu.RLock()
+	defer s.dbMu.RUnlock()
+	if err := ctx.Err(); err != nil {
+		return nil, false, errors.WithStack(err)
+	}
+	if readTSCompacted(ts, s.effectiveMinRetainedTS()) {
+		return nil, false, ErrReadTSCompacted
+	}
+
+	opts := &pebble.IterOptions{
+		LowerBound: encodeKey(start, math.MaxUint64),
+	}
+	if end != nil {
+		opts.UpperBound = encodeKey(end, math.MaxUint64)
+	}
+	iter, err := s.db.NewIter(opts)
+	if err != nil {
+		return nil, false, errors.WithStack(err)
+	}
+	defer iter.Close()
+
+	return s.collectReverseScanResultsWithPhysicalLimit(iter, start, end, visibleLimit, physicalLimit, ts)
 }
 
 func (s *pebbleStore) PutAt(ctx context.Context, key []byte, value []byte, commitTS uint64, expireAt uint64) error {

--- a/store/mvcc_store.go
+++ b/store/mvcc_store.go
@@ -306,10 +306,16 @@ func computeScanCapHint(treeSize, limit int) int {
 }
 
 func (s *mvccStore) collectScanResults(ctx context.Context, it *treemap.Iterator, end []byte, limit, capHint int, ts uint64) ([]*KVPair, error) {
+	result, _, err := collectScanResultsWithPhysicalLimit(ctx, it, end, limit, 0, capHint, ts)
+	return result, err
+}
+
+func collectScanResultsWithPhysicalLimit(ctx context.Context, it *treemap.Iterator, end []byte, limit, physicalLimit, capHint int, ts uint64) ([]*KVPair, bool, error) {
 	result := make([]*KVPair, 0, capHint)
+	visited := 0
 	for ok := true; ok && len(result) < limit; ok = it.Next() {
 		if err := ctx.Err(); err != nil {
-			return nil, errors.WithStack(err)
+			return nil, false, errors.WithStack(err)
 		}
 		k, keyOK := it.Key().([]byte)
 		if !keyOK {
@@ -318,6 +324,10 @@ func (s *mvccStore) collectScanResults(ctx context.Context, it *treemap.Iterator
 		if end != nil && bytes.Compare(k, end) >= 0 {
 			break
 		}
+		if physicalLimit > 0 && visited >= physicalLimit {
+			return result, true, nil
+		}
+		visited++
 		versions, _ := it.Value().([]VersionedValue)
 		val, visible := visibleValue(versions, ts)
 		if !visible {
@@ -328,7 +338,7 @@ func (s *mvccStore) collectScanResults(ctx context.Context, it *treemap.Iterator
 			Value: bytes.Clone(val),
 		})
 	}
-	return result, nil
+	return result, false, nil
 }
 
 func (s *mvccStore) ScanAt(ctx context.Context, start []byte, end []byte, limit int, ts uint64) ([]*KVPair, error) {
@@ -354,6 +364,30 @@ func (s *mvccStore) ScanAt(ctx context.Context, start []byte, end []byte, limit 
 		return make([]*KVPair, 0, capHint), nil
 	}
 	return s.collectScanResults(ctx, &it, end, limit, capHint, ts)
+}
+
+func (s *mvccStore) ScanAtPhysicalLimit(ctx context.Context, start []byte, end []byte, visibleLimit, physicalLimit int, ts uint64) ([]*KVPair, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, errors.WithStack(err)
+	}
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	if err := ctx.Err(); err != nil {
+		return nil, false, errors.WithStack(err)
+	}
+	if readTSCompacted(ts, s.minRetainedTS) {
+		return nil, false, ErrReadTSCompacted
+	}
+	if visibleLimit <= 0 || physicalLimit <= 0 {
+		return []*KVPair{}, false, nil
+	}
+
+	capHint := computeScanCapHint(s.tree.Size(), visibleLimit)
+	it := s.tree.Iterator()
+	if !seekForwardIteratorStart(s.tree, &it, start) {
+		return make([]*KVPair, 0, capHint), false, nil
+	}
+	return collectScanResultsWithPhysicalLimit(ctx, &it, end, visibleLimit, physicalLimit, capHint, ts)
 }
 
 // seekForwardIteratorStart positions the iterator at the first key >= start.
@@ -406,6 +440,38 @@ func (s *mvccStore) ReverseScanAt(_ context.Context, start []byte, end []byte, l
 	return result, nil
 }
 
+func (s *mvccStore) ReverseScanAtPhysicalLimit(ctx context.Context, start []byte, end []byte, visibleLimit, physicalLimit int, ts uint64) ([]*KVPair, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, errors.WithStack(err)
+	}
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+	if err := ctx.Err(); err != nil {
+		return nil, false, errors.WithStack(err)
+	}
+	if readTSCompacted(ts, s.minRetainedTS) {
+		return nil, false, ErrReadTSCompacted
+	}
+	if visibleLimit <= 0 || physicalLimit <= 0 {
+		return []*KVPair{}, false, nil
+	}
+
+	capHint := boundedScanResultCapacity(visibleLimit)
+	if size := s.tree.Size(); size < capHint {
+		capHint = size
+	}
+	if capHint < 0 {
+		capHint = 0
+	}
+	result := make([]*KVPair, 0, capHint)
+	it := s.tree.Iterator()
+	if !seekReverseIteratorStart(s.tree, &it, end) {
+		return result, false, nil
+	}
+	limitReached, err := collectReverseVisibleKVsWithPhysicalLimit(ctx, &it, start, visibleLimit, physicalLimit, ts, &result)
+	return result, limitReached, err
+}
+
 func seekReverseIteratorStart(tree *treemap.Map, it *treemap.Iterator, end []byte) bool {
 	if end == nil {
 		return it.Last()
@@ -438,16 +504,37 @@ func collectReverseVisibleKVs(
 	ts uint64,
 	result *[]*KVPair,
 ) {
+	_, _ = collectReverseVisibleKVsWithPhysicalLimit(context.Background(), it, start, limit, 0, ts, result)
+}
+
+func collectReverseVisibleKVsWithPhysicalLimit(
+	ctx context.Context,
+	it *treemap.Iterator,
+	start []byte,
+	limit int,
+	physicalLimit int,
+	ts uint64,
+	result *[]*KVPair,
+) (bool, error) {
+	visited := 0
 	for ok := true; ok && len(*result) < limit; ok = it.Prev() {
+		if err := ctx.Err(); err != nil {
+			return false, errors.WithStack(err)
+		}
 		k, keyOK := it.Key().([]byte)
 		if !keyOK {
 			continue
 		}
 		if start != nil && bytes.Compare(k, start) < 0 {
-			return
+			return false, nil
 		}
+		if physicalLimit > 0 && visited >= physicalLimit {
+			return true, nil
+		}
+		visited++
 		appendVisibleReverseKV(it, k, ts, result)
 	}
+	return false, nil
 }
 
 func appendVisibleReverseKV(it *treemap.Iterator, key []byte, ts uint64, result *[]*KVPair) {


### PR DESCRIPTION
## Summary
- scan sparse Lua list pops across the full boundary key range while keeping the physical row scan bounded
- treat large sparse lists with no item rows as empty instead of returning collection-too-large to BullMQ
- add regression coverage for large tail holes and fully sparse lists

## Validation
- `GOCACHE=$(pwd)/.cache GOTMPDIR=$(pwd)/.cache/tmp go test ./adapter -run 'TestRedisLua_RPopLPush|TestRedis_LuaRPopLPush|TestListPop' -count=1`\n- `GOCACHE=$(pwd)/.cache GOTMPDIR=$(pwd)/.cache/tmp go test ./adapter -run 'TestDeltaCompactor|TestRedisLua_RPopLPush|TestRedis_LuaRPopLPush|TestListPop' -count=1`\n- `git diff --check`\n- commit hook: `golangci-lint --config=.golangci.yaml run --fix`\n\nAuthor: bootjp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * リスト操作で、空き領域や削除済み項目が多い場合も、必要なデータを正確に走査・削除できるようになりました。
  * 前後方向の検索で、表示対象数とは別に物理的な走査上限を設定できるようになりました。
  * 物理的な走査上限に達した場合、状況に応じて適切なエラーを返すようになりました。

* **不具合修正**
  * 大きな空き領域を含むリストの移動・削除処理で、残存データや空リストが正しく処理されない問題を修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->