### PR TITLE
distribution: add split job catalog helpers

### DIFF
--- a/distribution/split_job_catalog.go
+++ b/distribution/split_job_catalog.go
@@ -372,8 +372,8 @@ func (s *CatalogStore) ListSplitJobsAt(ctx context.Context, ts uint64) ([]SplitJ
 	return out, nil
 }
 
-// SaveSplitJob upserts a live split job and advances next_job_id when needed.
-func (s *CatalogStore) SaveSplitJob(ctx context.Context, job SplitJob) error {
+// CreateSplitJob creates a live split job and advances next_job_id when needed.
+func (s *CatalogStore) CreateSplitJob(ctx context.Context, job SplitJob) error {
 	if err := ensureCatalogStore(s); err != nil {
 		return err
 	}
@@ -382,28 +382,76 @@ func (s *CatalogStore) SaveSplitJob(ctx context.Context, job SplitJob) error {
 	if err != nil {
 		return err
 	}
-	mutations, readTS, err := s.buildSplitJobPutMutations(ctx, CatalogSplitJobKey(job.JobID), encoded, job.JobID)
+	readTS := s.store.LastCommitTS()
+	if err := s.expectNoSplitJobAt(ctx, job.JobID, readTS); err != nil {
+		return err
+	}
+	mutations, err := s.buildSplitJobPutMutations(ctx, readTS, CatalogSplitJobKey(job.JobID), encoded, job.JobID)
 	if err != nil {
 		return err
 	}
-	return s.applySplitJobMutations(ctx, readTS, mutations)
+	return s.applySplitJobMutations(ctx, readTS, [][]byte{CatalogSplitJobKey(job.JobID)}, mutations)
+}
+
+// SaveSplitJob updates a live split job if it still matches expected.
+func (s *CatalogStore) SaveSplitJob(ctx context.Context, expected SplitJob, job SplitJob) error {
+	if err := ensureCatalogStore(s); err != nil {
+		return err
+	}
+	if expected.JobID != job.JobID {
+		return errors.WithStack(ErrCatalogSplitJobKeyIDMismatch)
+	}
+	ctx = contextOrBackground(ctx)
+	expectedRaw, err := EncodeSplitJob(expected)
+	if err != nil {
+		return err
+	}
+	encoded, err := EncodeSplitJob(job)
+	if err != nil {
+		return err
+	}
+	readTS := s.store.LastCommitTS()
+	if err := s.expectLiveSplitJobAt(ctx, job.JobID, expectedRaw, readTS); err != nil {
+		return err
+	}
+	if _, found, err := s.historySplitJobAt(ctx, job.JobID, readTS); err != nil {
+		return err
+	} else if found {
+		return errors.WithStack(ErrCatalogSplitJobConflict)
+	}
+	mutations, err := s.buildSplitJobPutMutations(ctx, readTS, CatalogSplitJobKey(job.JobID), encoded, job.JobID)
+	if err != nil {
+		return err
+	}
+	return s.applySplitJobMutations(ctx, readTS, [][]byte{CatalogSplitJobKey(job.JobID)}, mutations)
 }
 
 // MoveSplitJobToHistory moves a terminal split job from live state to history.
-func (s *CatalogStore) MoveSplitJobToHistory(ctx context.Context, job SplitJob) error {
+func (s *CatalogStore) MoveSplitJobToHistory(ctx context.Context, expected SplitJob, job SplitJob) error {
 	if err := ensureCatalogStore(s); err != nil {
 		return err
 	}
-	if !job.Phase.terminal() || job.TerminalAtMs <= 0 {
-		return errors.WithStack(ErrCatalogSplitJobTerminalRequired)
+	if err := validateSplitJobHistoryMove(expected, job); err != nil {
+		return err
 	}
 	ctx = contextOrBackground(ctx)
+	expectedRaw, err := EncodeSplitJob(expected)
+	if err != nil {
+		return err
+	}
 	encoded, err := EncodeSplitJob(job)
 	if err != nil {
 		return err
 	}
+	readTS := s.store.LastCommitTS()
+	if applied, err := s.splitJobHistoryMoveApplied(ctx, job.JobID, readTS); err != nil || applied {
+		return err
+	}
+	if err := s.expectLiveSplitJobAt(ctx, job.JobID, expectedRaw, readTS); err != nil {
+		return err
+	}
 	historyKey := CatalogSplitJobHistoryKey(job.TerminalAtMs, job.JobID)
-	mutations, readTS, err := s.buildSplitJobPutMutations(ctx, historyKey, encoded, job.JobID)
+	mutations, err := s.buildSplitJobPutMutations(ctx, readTS, historyKey, encoded, job.JobID)
 	if err != nil {
 		return err
 	}
@@ -411,7 +459,31 @@ func (s *CatalogStore) MoveSplitJobToHistory(ctx context.Context, job SplitJob) 
 		Op:  store.OpTypeDelete,
 		Key: CatalogSplitJobKey(job.JobID),
 	})
-	return s.applySplitJobMutations(ctx, readTS, mutations)
+	return s.applySplitJobMutations(ctx, readTS, [][]byte{CatalogSplitJobKey(job.JobID)}, mutations)
+}
+
+func validateSplitJobHistoryMove(expected SplitJob, job SplitJob) error {
+	if expected.JobID != job.JobID {
+		return errors.WithStack(ErrCatalogSplitJobKeyIDMismatch)
+	}
+	if !job.Phase.terminal() || job.TerminalAtMs <= 0 {
+		return errors.WithStack(ErrCatalogSplitJobTerminalRequired)
+	}
+	return nil
+}
+
+func (s *CatalogStore) splitJobHistoryMoveApplied(ctx context.Context, jobID uint64, ts uint64) (bool, error) {
+	if _, found, err := s.historySplitJobAt(ctx, jobID, ts); err != nil {
+		return false, err
+	} else if !found {
+		return false, nil
+	}
+	if _, liveFound, err := s.liveSplitJobAt(ctx, jobID, ts); err != nil {
+		return false, err
+	} else if liveFound {
+		return false, errors.WithStack(ErrCatalogSplitJobConflict)
+	}
+	return true, nil
 }
 
 // DeleteSplitJob deletes a live split job.
@@ -424,7 +496,7 @@ func (s *CatalogStore) DeleteSplitJob(ctx context.Context, jobID uint64) error {
 	}
 	ctx = contextOrBackground(ctx)
 	readTS := s.store.LastCommitTS()
-	return s.applySplitJobMutations(ctx, readTS, []*store.KVPairMutation{{
+	return s.applySplitJobMutations(ctx, readTS, [][]byte{CatalogSplitJobKey(jobID)}, []*store.KVPairMutation{{
 		Op:  store.OpTypeDelete,
 		Key: CatalogSplitJobKey(jobID),
 	}})
@@ -622,18 +694,41 @@ func (s *CatalogStore) scanCatalogEntriesAt(ctx context.Context, prefix []byte, 
 	return out, nil
 }
 
-func (s *CatalogStore) buildSplitJobPutMutations(ctx context.Context, key []byte, encoded []byte, jobID uint64) ([]*store.KVPairMutation, uint64, error) {
-	if jobID == math.MaxUint64 {
-		return nil, 0, errors.WithStack(ErrCatalogSplitJobIDOverflow)
+func (s *CatalogStore) expectNoSplitJobAt(ctx context.Context, jobID uint64, ts uint64) error {
+	if _, found, err := s.liveSplitJobAt(ctx, jobID, ts); err != nil {
+		return err
+	} else if found {
+		return errors.WithStack(ErrCatalogSplitJobConflict)
 	}
-	readTS := s.store.LastCommitTS()
-	nextJobID, err := s.nextSplitJobIDAt(ctx, readTS)
+	if _, found, err := s.historySplitJobAt(ctx, jobID, ts); err != nil {
+		return err
+	} else if found {
+		return errors.WithStack(ErrCatalogSplitJobConflict)
+	}
+	return nil
+}
+
+func (s *CatalogStore) expectLiveSplitJobAt(ctx context.Context, jobID uint64, expectedRaw []byte, ts uint64) error {
+	raw, err := s.store.GetAt(ctx, CatalogSplitJobKey(jobID), ts)
 	if err != nil {
-		return nil, 0, err
+		if errors.Is(err, store.ErrKeyNotFound) {
+			return errors.WithStack(ErrCatalogSplitJobConflict)
+		}
+		return errors.WithStack(err)
 	}
-	floor := jobID + 1
-	if nextJobID < floor {
-		nextJobID = floor
+	if !bytes.Equal(raw, expectedRaw) {
+		return errors.WithStack(ErrCatalogSplitJobConflict)
+	}
+	return nil
+}
+
+func (s *CatalogStore) buildSplitJobPutMutations(ctx context.Context, readTS uint64, key []byte, encoded []byte, jobID uint64) ([]*store.KVPairMutation, error) {
+	if jobID == math.MaxUint64 {
+		return nil, errors.WithStack(ErrCatalogSplitJobIDOverflow)
+	}
+	nextJobID, err := s.splitJobNextIDFloorAt(ctx, readTS, jobID)
+	if err != nil {
+		return nil, err
 	}
 
 	mutations := []*store.KVPairMutation{{
@@ -648,10 +743,33 @@ func (s *CatalogStore) buildSplitJobPutMutations(ctx context.Context, key []byte
 			Value: EncodeCatalogNextSplitJobID(nextJobID),
 		})
 	}
-	return mutations, readTS, nil
+	return mutations, nil
 }
 
-func (s *CatalogStore) applySplitJobMutations(ctx context.Context, readTS uint64, mutations []*store.KVPairMutation) error {
+func (s *CatalogStore) splitJobNextIDFloorAt(ctx context.Context, ts uint64, jobID uint64) (uint64, error) {
+	nextJobID, err := s.nextSplitJobIDAt(ctx, ts)
+	if err != nil {
+		return 0, err
+	}
+	jobs, err := s.ListSplitJobsAt(ctx, ts)
+	if err != nil {
+		return 0, err
+	}
+	floor, err := NextSplitJobIDFloor(jobs)
+	if err != nil {
+		return 0, err
+	}
+	if nextJobID < floor {
+		nextJobID = floor
+	}
+	floor = jobID + 1
+	if nextJobID < floor {
+		nextJobID = floor
+	}
+	return nextJobID, nil
+}
+
+func (s *CatalogStore) applySplitJobMutations(ctx context.Context, readTS uint64, readKeys [][]byte, mutations []*store.KVPairMutation) error {
 	minCommitTS := readTS + 1
 	if minCommitTS == 0 {
 		return errors.WithStack(ErrCatalogVersionOverflow)
@@ -660,7 +778,7 @@ func (s *CatalogStore) applySplitJobMutations(ctx context.Context, readTS uint64
 	if err != nil {
 		return err
 	}
-	if err := s.store.ApplyMutations(ctx, mutations, nil, readTS, commitTS); err != nil {
+	if err := s.store.ApplyMutations(ctx, mutations, readKeys, readTS, commitTS); err != nil {
 		if errors.Is(err, store.ErrWriteConflict) {
 			return errors.WithStack(ErrCatalogSplitJobConflict)
 		}

--- a/distribution/split_job_catalog.go
+++ b/distribution/split_job_catalog.go
@@ -206,7 +206,7 @@ func CatalogSplitJobHistoryKey(terminalAtMs int64, jobID uint64) []byte {
 		terminalAtMs = 0
 	}
 	off := len(catalogSplitJobHistoryPrefix)
-	putCatalogInt64BE(key[off:], terminalAtMs)
+	binary.BigEndian.PutUint64(key[off:], uint64(terminalAtMs)) //nolint:gosec // terminalAtMs is clamped non-negative above.
 	binary.BigEndian.PutUint64(key[off+catalogUint64Bytes:], jobID)
 	return key
 }
@@ -487,14 +487,6 @@ func validateSplitJobBracketProgress(progress []SplitJobBracketProgress) error {
 		}
 	}
 	return nil
-}
-
-func putCatalogInt64BE(dst []byte, v int64) {
-	var buf bytes.Buffer
-	if err := binary.Write(&buf, binary.BigEndian, v); err != nil {
-		panic(err)
-	}
-	copy(dst, buf.Bytes())
 }
 
 func (s *CatalogStore) nextSplitJobIDAt(ctx context.Context, ts uint64) (uint64, error) {

--- a/distribution/split_job_catalog.go
+++ b/distribution/split_job_catalog.go
@@ -1,0 +1,939 @@
+package distribution
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"math"
+	"sort"
+
+	pb "github.com/bootjp/elastickv/proto"
+	"github.com/bootjp/elastickv/store"
+	"github.com/cockroachdb/errors"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+const (
+	catalogNextSplitJobIDKey     = catalogMetaPrefix + "next_job_id"
+	catalogSplitJobPrefix        = "!dist|job|"
+	catalogSplitJobHistoryPrefix = "!dist|jobhist|"
+
+	catalogJobCodecVersion byte = 1
+)
+
+var (
+	ErrCatalogSplitJobIDRequired          = errors.New("catalog split job id is required")
+	ErrCatalogSplitJobSourceRouteRequired = errors.New("catalog split job source route id is required")
+	ErrCatalogSplitJobTargetGroupRequired = errors.New("catalog split job target group id is required")
+	ErrCatalogInvalidSplitJobRecord       = errors.New("catalog split job record is invalid")
+	ErrCatalogInvalidSplitJobPhase        = errors.New("catalog split job phase is invalid")
+	ErrCatalogInvalidSplitJobBarrierState = errors.New("catalog split job barrier state is invalid")
+	ErrCatalogInvalidSplitJobExportPhase  = errors.New("catalog split job export phase is invalid")
+	ErrCatalogInvalidSplitJobKey          = errors.New("catalog split job key is invalid")
+	ErrCatalogInvalidNextSplitJobID       = errors.New("catalog next split job id record is invalid")
+	ErrCatalogSplitJobIDOverflow          = errors.New("catalog split job id overflow")
+	ErrCatalogSplitJobKeyIDMismatch       = errors.New("catalog split job key and record job id mismatch")
+	ErrCatalogSplitJobConflict            = errors.New("catalog split job conflict")
+	ErrCatalogSplitJobTerminalRequired    = errors.New("catalog split job terminal state is required")
+)
+
+// SplitJobPhase is the durable phase of a split migration job.
+type SplitJobPhase byte
+
+const (
+	SplitJobPhaseNone SplitJobPhase = iota
+	SplitJobPhasePlanned
+	SplitJobPhaseBackfill
+	SplitJobPhaseFence
+	SplitJobPhaseDeltaCopy
+	SplitJobPhaseCutover
+	SplitJobPhaseCleanup
+	SplitJobPhaseDone
+	SplitJobPhaseFailed
+	SplitJobPhaseAbandoning
+	SplitJobPhaseAbandoned
+)
+
+func (p SplitJobPhase) valid() bool {
+	switch p {
+	case SplitJobPhaseNone,
+		SplitJobPhasePlanned,
+		SplitJobPhaseBackfill,
+		SplitJobPhaseFence,
+		SplitJobPhaseDeltaCopy,
+		SplitJobPhaseCutover,
+		SplitJobPhaseCleanup,
+		SplitJobPhaseDone,
+		SplitJobPhaseFailed,
+		SplitJobPhaseAbandoning,
+		SplitJobPhaseAbandoned:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p SplitJobPhase) terminal() bool {
+	return p == SplitJobPhaseDone || p == SplitJobPhaseAbandoned
+}
+
+// SplitJobBarrierState is a restart witness for per-voter barrier progress.
+type SplitJobBarrierState byte
+
+const (
+	SplitJobBarrierNone SplitJobBarrierState = iota
+	SplitJobBarrierArming
+	SplitJobBarrierArmed
+	SplitJobBarrierClearing
+)
+
+func (s SplitJobBarrierState) valid() bool {
+	switch s {
+	case SplitJobBarrierNone,
+		SplitJobBarrierArming,
+		SplitJobBarrierArmed,
+		SplitJobBarrierClearing:
+		return true
+	default:
+		return false
+	}
+}
+
+// SplitJobExportPhase records which export window a bracket is scanning.
+type SplitJobExportPhase byte
+
+const (
+	SplitJobExportPhaseNone SplitJobExportPhase = iota
+	SplitJobExportPhaseBackfill
+	SplitJobExportPhaseDeltaCopy
+)
+
+func (p SplitJobExportPhase) valid() bool {
+	switch p {
+	case SplitJobExportPhaseNone,
+		SplitJobExportPhaseBackfill,
+		SplitJobExportPhaseDeltaCopy:
+		return true
+	default:
+		return false
+	}
+}
+
+// SplitJobBracketProgress is per-family export-bracket resume state.
+type SplitJobBracketProgress struct {
+	BracketID         uint64
+	Family            uint32
+	ExportPhase       SplitJobExportPhase
+	Cursor            []byte
+	Done              bool
+	ScannedBytes      uint64
+	AcceptedRows      uint64
+	LastAckedBatchSeq uint64
+}
+
+// SplitJob is the durable default-group state for a range split migration.
+type SplitJob struct {
+	JobID                            uint64
+	SourceRouteID                    uint64
+	SplitKey                         []byte
+	TargetGroupID                    uint64
+	Phase                            SplitJobPhase
+	RetryPhase                       SplitJobPhase
+	AbandonFromPhase                 SplitJobPhase
+	SnapshotTS                       uint64
+	SnapshotMinAdmittedTS            uint64
+	WriteTrackerArmed                bool
+	DeltaFloor                       uint64
+	PostFenceDrainCompleted          bool
+	FenceTS                          uint64
+	CutoverVersion                   uint64
+	CutoverReadFenceState            SplitJobBarrierState
+	TargetStagedReadinessState       SplitJobBarrierState
+	SourceCutoverReadFenceAckCursor  []byte
+	TargetStagedReadinessAckCursor   []byte
+	Cursor                           []byte
+	MaxImportedTS                    uint64
+	TargetPromotionDone              bool
+	PromotionCompletedTS             uint64
+	FenceCatalogVersion              uint64
+	FenceAckCursor                   []byte
+	SourceCutoverAckCursor           []byte
+	SourceReadDrainCursor            []byte
+	TargetClearedDescriptorAckCursor []byte
+	BracketProgress                  []SplitJobBracketProgress
+	SourceRetentionPinTS             uint64
+	LastError                        string
+	StartedAtMs                      int64
+	UpdatedAtMs                      int64
+	TerminalAtMs                     int64
+}
+
+// CatalogNextSplitJobIDKey returns the reserved key used for split-job ID allocation.
+func CatalogNextSplitJobIDKey() []byte {
+	return []byte(catalogNextSplitJobIDKey)
+}
+
+// CatalogSplitJobKey returns the reserved live-job key for a split job.
+func CatalogSplitJobKey(jobID uint64) []byte {
+	key := make([]byte, len(catalogSplitJobPrefix)+catalogUint64Bytes)
+	copy(key, []byte(catalogSplitJobPrefix))
+	binary.BigEndian.PutUint64(key[len(catalogSplitJobPrefix):], jobID)
+	return key
+}
+
+// IsCatalogSplitJobKey reports whether key belongs to the live split-job namespace.
+func IsCatalogSplitJobKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(catalogSplitJobPrefix))
+}
+
+// CatalogSplitJobIDFromKey parses the job ID from a live split-job key.
+func CatalogSplitJobIDFromKey(key []byte) (uint64, bool) {
+	if !IsCatalogSplitJobKey(key) {
+		return 0, false
+	}
+	suffix := key[len(catalogSplitJobPrefix):]
+	if len(suffix) != catalogUint64Bytes {
+		return 0, false
+	}
+	return binary.BigEndian.Uint64(suffix), true
+}
+
+// CatalogSplitJobHistoryKey returns the reserved history key for a terminal split job.
+func CatalogSplitJobHistoryKey(terminalAtMs int64, jobID uint64) []byte {
+	key := make([]byte, len(catalogSplitJobHistoryPrefix)+catalogUint64Bytes+catalogUint64Bytes)
+	copy(key, []byte(catalogSplitJobHistoryPrefix))
+	if terminalAtMs < 0 {
+		terminalAtMs = 0
+	}
+	off := len(catalogSplitJobHistoryPrefix)
+	putCatalogInt64BE(key[off:], terminalAtMs)
+	binary.BigEndian.PutUint64(key[off+catalogUint64Bytes:], jobID)
+	return key
+}
+
+// IsCatalogSplitJobHistoryKey reports whether key belongs to the split-job history namespace.
+func IsCatalogSplitJobHistoryKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(catalogSplitJobHistoryPrefix))
+}
+
+// CatalogSplitJobHistoryKeyParts parses terminal time and job ID from a history key.
+func CatalogSplitJobHistoryKeyParts(key []byte) (int64, uint64, bool) {
+	if !IsCatalogSplitJobHistoryKey(key) {
+		return 0, 0, false
+	}
+	suffix := key[len(catalogSplitJobHistoryPrefix):]
+	if len(suffix) != 2*catalogUint64Bytes {
+		return 0, 0, false
+	}
+	terminalAtRaw := binary.BigEndian.Uint64(suffix[:catalogUint64Bytes])
+	if terminalAtRaw > uint64(math.MaxInt64) {
+		return 0, 0, false
+	}
+	terminalAtMs := int64(terminalAtRaw)
+	jobID := binary.BigEndian.Uint64(suffix[catalogUint64Bytes:])
+	return terminalAtMs, jobID, true
+}
+
+// EncodeCatalogNextSplitJobID serializes a next split-job ID record.
+func EncodeCatalogNextSplitJobID(nextJobID uint64) []byte {
+	return EncodeCatalogVersion(nextJobID)
+}
+
+// DecodeCatalogNextSplitJobID deserializes a next split-job ID record.
+func DecodeCatalogNextSplitJobID(raw []byte) (uint64, error) {
+	nextJobID, err := DecodeCatalogVersion(raw)
+	if err != nil {
+		return 0, errors.Wrapf(ErrCatalogInvalidNextSplitJobID, "decode next split job id: %v", err)
+	}
+	if nextJobID == 0 {
+		return 0, errors.WithStack(ErrCatalogInvalidNextSplitJobID)
+	}
+	return nextJobID, nil
+}
+
+// EncodeSplitJob serializes a SplitJob record as version byte + protobuf body.
+func EncodeSplitJob(job SplitJob) ([]byte, error) {
+	if err := validateSplitJob(job); err != nil {
+		return nil, err
+	}
+	body, err := gproto.MarshalOptions{Deterministic: true}.Marshal(splitJobToProto(job))
+	if err != nil {
+		return nil, errors.Wrapf(ErrCatalogInvalidSplitJobRecord, "marshal split job: %v", err)
+	}
+	out := make([]byte, 1+len(body))
+	out[0] = catalogJobCodecVersion
+	copy(out[1:], body)
+	return out, nil
+}
+
+// DecodeSplitJob deserializes a SplitJob record.
+func DecodeSplitJob(raw []byte) (SplitJob, error) {
+	if len(raw) < 1 {
+		return SplitJob{}, errors.WithStack(ErrCatalogInvalidSplitJobRecord)
+	}
+	if raw[0] != catalogJobCodecVersion {
+		return SplitJob{}, errors.Wrapf(ErrCatalogInvalidSplitJobRecord, "unsupported version %d", raw[0])
+	}
+	var msg pb.SplitJob
+	if err := gproto.Unmarshal(raw[1:], &msg); err != nil {
+		return SplitJob{}, errors.Wrapf(ErrCatalogInvalidSplitJobRecord, "unmarshal split job: %v", err)
+	}
+	job, err := splitJobFromProto(&msg)
+	if err != nil {
+		return SplitJob{}, err
+	}
+	if err := validateSplitJob(job); err != nil {
+		return SplitJob{}, err
+	}
+	return job, nil
+}
+
+// NextSplitJobID reads the next split-job ID counter from catalog metadata.
+func (s *CatalogStore) NextSplitJobID(ctx context.Context) (uint64, error) {
+	if err := ensureCatalogStore(s); err != nil {
+		return 0, err
+	}
+	ctx = contextOrBackground(ctx)
+	return s.NextSplitJobIDAt(ctx, s.store.LastCommitTS())
+}
+
+// NextSplitJobIDAt reads the next split-job ID counter at a given snapshot timestamp.
+func (s *CatalogStore) NextSplitJobIDAt(ctx context.Context, ts uint64) (uint64, error) {
+	if err := ensureCatalogStore(s); err != nil {
+		return 0, err
+	}
+	ctx = contextOrBackground(ctx)
+	nextJobID, err := s.nextSplitJobIDAt(ctx, ts)
+	if err != nil {
+		return 0, err
+	}
+	if nextJobID != 0 {
+		return nextJobID, nil
+	}
+	jobs, err := s.ListSplitJobsAt(ctx, ts)
+	if err != nil {
+		return 0, err
+	}
+	return NextSplitJobIDFloor(jobs)
+}
+
+// SplitJob reads a live or history split job by ID at the latest timestamp.
+func (s *CatalogStore) SplitJob(ctx context.Context, jobID uint64) (SplitJob, bool, error) {
+	if err := ensureCatalogStore(s); err != nil {
+		return SplitJob{}, false, err
+	}
+	ctx = contextOrBackground(ctx)
+	return s.SplitJobAt(ctx, jobID, s.store.LastCommitTS())
+}
+
+// SplitJobAt reads a live or history split job by ID at a snapshot timestamp.
+func (s *CatalogStore) SplitJobAt(ctx context.Context, jobID uint64, ts uint64) (SplitJob, bool, error) {
+	if err := ensureCatalogStore(s); err != nil {
+		return SplitJob{}, false, err
+	}
+	if jobID == 0 {
+		return SplitJob{}, false, errors.WithStack(ErrCatalogSplitJobIDRequired)
+	}
+	ctx = contextOrBackground(ctx)
+	job, found, err := s.liveSplitJobAt(ctx, jobID, ts)
+	if err != nil || found {
+		return job, found, err
+	}
+	return s.historySplitJobAt(ctx, jobID, ts)
+}
+
+// ListSplitJobs returns live and history split jobs at the latest timestamp.
+func (s *CatalogStore) ListSplitJobs(ctx context.Context) ([]SplitJob, error) {
+	if err := ensureCatalogStore(s); err != nil {
+		return nil, err
+	}
+	ctx = contextOrBackground(ctx)
+	return s.ListSplitJobsAt(ctx, s.store.LastCommitTS())
+}
+
+// ListSplitJobsAt returns live and history split jobs at a snapshot timestamp.
+func (s *CatalogStore) ListSplitJobsAt(ctx context.Context, ts uint64) ([]SplitJob, error) {
+	if err := ensureCatalogStore(s); err != nil {
+		return nil, err
+	}
+	ctx = contextOrBackground(ctx)
+	liveJobs, err := s.liveSplitJobsAt(ctx, ts)
+	if err != nil {
+		return nil, err
+	}
+	historyJobs, err := s.historySplitJobsAt(ctx, ts)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]SplitJob, 0, len(liveJobs)+len(historyJobs))
+	out = append(out, liveJobs...)
+	out = append(out, historyJobs...)
+	sortSplitJobs(out)
+	return out, nil
+}
+
+// SaveSplitJob upserts a live split job and advances next_job_id when needed.
+func (s *CatalogStore) SaveSplitJob(ctx context.Context, job SplitJob) error {
+	if err := ensureCatalogStore(s); err != nil {
+		return err
+	}
+	ctx = contextOrBackground(ctx)
+	encoded, err := EncodeSplitJob(job)
+	if err != nil {
+		return err
+	}
+	mutations, readTS, err := s.buildSplitJobPutMutations(ctx, CatalogSplitJobKey(job.JobID), encoded, job.JobID)
+	if err != nil {
+		return err
+	}
+	return s.applySplitJobMutations(ctx, readTS, mutations)
+}
+
+// MoveSplitJobToHistory moves a terminal split job from live state to history.
+func (s *CatalogStore) MoveSplitJobToHistory(ctx context.Context, job SplitJob) error {
+	if err := ensureCatalogStore(s); err != nil {
+		return err
+	}
+	if !job.Phase.terminal() || job.TerminalAtMs <= 0 {
+		return errors.WithStack(ErrCatalogSplitJobTerminalRequired)
+	}
+	ctx = contextOrBackground(ctx)
+	encoded, err := EncodeSplitJob(job)
+	if err != nil {
+		return err
+	}
+	historyKey := CatalogSplitJobHistoryKey(job.TerminalAtMs, job.JobID)
+	mutations, readTS, err := s.buildSplitJobPutMutations(ctx, historyKey, encoded, job.JobID)
+	if err != nil {
+		return err
+	}
+	mutations = append(mutations, &store.KVPairMutation{
+		Op:  store.OpTypeDelete,
+		Key: CatalogSplitJobKey(job.JobID),
+	})
+	return s.applySplitJobMutations(ctx, readTS, mutations)
+}
+
+// DeleteSplitJob deletes a live split job.
+func (s *CatalogStore) DeleteSplitJob(ctx context.Context, jobID uint64) error {
+	if err := ensureCatalogStore(s); err != nil {
+		return err
+	}
+	if jobID == 0 {
+		return errors.WithStack(ErrCatalogSplitJobIDRequired)
+	}
+	ctx = contextOrBackground(ctx)
+	readTS := s.store.LastCommitTS()
+	return s.applySplitJobMutations(ctx, readTS, []*store.KVPairMutation{{
+		Op:  store.OpTypeDelete,
+		Key: CatalogSplitJobKey(jobID),
+	}})
+}
+
+// NextSplitJobIDFloor returns the minimum valid next split-job ID for jobs.
+func NextSplitJobIDFloor(jobs []SplitJob) (uint64, error) {
+	maxJobID := uint64(0)
+	for _, job := range jobs {
+		if job.JobID > maxJobID {
+			maxJobID = job.JobID
+		}
+	}
+	if maxJobID == math.MaxUint64 {
+		return 0, errors.WithStack(ErrCatalogSplitJobIDOverflow)
+	}
+	return maxJobID + 1, nil
+}
+
+func validateSplitJob(job SplitJob) error {
+	if job.JobID == 0 {
+		return errors.WithStack(ErrCatalogSplitJobIDRequired)
+	}
+	if job.SourceRouteID == 0 {
+		return errors.WithStack(ErrCatalogSplitJobSourceRouteRequired)
+	}
+	if job.TargetGroupID == 0 {
+		return errors.WithStack(ErrCatalogSplitJobTargetGroupRequired)
+	}
+	if err := validateSplitJobPhases(job); err != nil {
+		return err
+	}
+	if err := validateSplitJobBarriers(job); err != nil {
+		return err
+	}
+	return validateSplitJobBracketProgress(job.BracketProgress)
+}
+
+func validateSplitJobPhases(job SplitJob) error {
+	if job.Phase == SplitJobPhaseNone || !job.Phase.valid() {
+		return errors.WithStack(ErrCatalogInvalidSplitJobPhase)
+	}
+	if !job.RetryPhase.valid() || !job.AbandonFromPhase.valid() {
+		return errors.WithStack(ErrCatalogInvalidSplitJobPhase)
+	}
+	return nil
+}
+
+func validateSplitJobBarriers(job SplitJob) error {
+	if !job.CutoverReadFenceState.valid() || !job.TargetStagedReadinessState.valid() {
+		return errors.WithStack(ErrCatalogInvalidSplitJobBarrierState)
+	}
+	return nil
+}
+
+func validateSplitJobBracketProgress(progress []SplitJobBracketProgress) error {
+	for _, p := range progress {
+		if !p.ExportPhase.valid() {
+			return errors.WithStack(ErrCatalogInvalidSplitJobExportPhase)
+		}
+	}
+	return nil
+}
+
+func putCatalogInt64BE(dst []byte, v int64) {
+	var buf bytes.Buffer
+	if err := binary.Write(&buf, binary.BigEndian, v); err != nil {
+		panic(err)
+	}
+	copy(dst, buf.Bytes())
+}
+
+func (s *CatalogStore) nextSplitJobIDAt(ctx context.Context, ts uint64) (uint64, error) {
+	raw, err := s.store.GetAt(ctx, CatalogNextSplitJobIDKey(), ts)
+	if err != nil {
+		if errors.Is(err, store.ErrKeyNotFound) {
+			return 0, nil
+		}
+		return 0, errors.WithStack(err)
+	}
+	nextJobID, err := DecodeCatalogNextSplitJobID(raw)
+	if err != nil {
+		return 0, err
+	}
+	return nextJobID, nil
+}
+
+func (s *CatalogStore) liveSplitJobAt(ctx context.Context, jobID uint64, ts uint64) (SplitJob, bool, error) {
+	raw, err := s.store.GetAt(ctx, CatalogSplitJobKey(jobID), ts)
+	if err != nil {
+		if errors.Is(err, store.ErrKeyNotFound) {
+			return SplitJob{}, false, nil
+		}
+		return SplitJob{}, false, errors.WithStack(err)
+	}
+	job, err := DecodeSplitJob(raw)
+	if err != nil {
+		return SplitJob{}, false, err
+	}
+	if job.JobID != jobID {
+		return SplitJob{}, false, errors.WithStack(ErrCatalogSplitJobKeyIDMismatch)
+	}
+	return job, true, nil
+}
+
+func (s *CatalogStore) historySplitJobAt(ctx context.Context, jobID uint64, ts uint64) (SplitJob, bool, error) {
+	jobs, err := s.historySplitJobsAt(ctx, ts)
+	if err != nil {
+		return SplitJob{}, false, err
+	}
+	for _, job := range jobs {
+		if job.JobID == jobID {
+			return job, true, nil
+		}
+	}
+	return SplitJob{}, false, nil
+}
+
+func (s *CatalogStore) liveSplitJobsAt(ctx context.Context, ts uint64) ([]SplitJob, error) {
+	entries, err := s.scanCatalogEntriesAt(ctx, []byte(catalogSplitJobPrefix), ts)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]SplitJob, 0, len(entries))
+	seen := make(map[uint64]struct{}, len(entries))
+	for _, kvp := range entries {
+		jobID, ok := CatalogSplitJobIDFromKey(kvp.Key)
+		if !ok {
+			return nil, errors.WithStack(ErrCatalogInvalidSplitJobKey)
+		}
+		job, err := DecodeSplitJob(kvp.Value)
+		if err != nil {
+			return nil, err
+		}
+		if job.JobID != jobID {
+			return nil, errors.WithStack(ErrCatalogSplitJobKeyIDMismatch)
+		}
+		if _, exists := seen[job.JobID]; exists {
+			return nil, errors.WithStack(ErrCatalogSplitJobKeyIDMismatch)
+		}
+		seen[job.JobID] = struct{}{}
+		out = append(out, job)
+	}
+	sortSplitJobs(out)
+	return out, nil
+}
+
+func (s *CatalogStore) historySplitJobsAt(ctx context.Context, ts uint64) ([]SplitJob, error) {
+	entries, err := s.scanCatalogEntriesAt(ctx, []byte(catalogSplitJobHistoryPrefix), ts)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]SplitJob, 0, len(entries))
+	for _, kvp := range entries {
+		terminalAtMs, jobID, ok := CatalogSplitJobHistoryKeyParts(kvp.Key)
+		if !ok {
+			return nil, errors.WithStack(ErrCatalogInvalidSplitJobKey)
+		}
+		job, err := DecodeSplitJob(kvp.Value)
+		if err != nil {
+			return nil, err
+		}
+		if job.JobID != jobID || job.TerminalAtMs != terminalAtMs {
+			return nil, errors.WithStack(ErrCatalogSplitJobKeyIDMismatch)
+		}
+		out = append(out, job)
+	}
+	sortSplitJobs(out)
+	return out, nil
+}
+
+func (s *CatalogStore) scanCatalogEntriesAt(ctx context.Context, prefix []byte, ts uint64) ([]*store.KVPair, error) {
+	upper := prefixScanEnd(prefix)
+	cursor := CloneBytes(prefix)
+	out := make([]*store.KVPair, 0)
+
+	for {
+		page, err := s.store.ScanAt(ctx, cursor, upper, catalogScanPageSize, ts)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		if len(page) == 0 {
+			break
+		}
+
+		var (
+			lastKey []byte
+			done    bool
+		)
+		out, lastKey, done = appendRoutePage(out, page, prefix)
+		if done {
+			return out, nil
+		}
+		if lastKey == nil || len(page) < catalogScanPageSize {
+			break
+		}
+		nextCursor, inRange := nextCursorWithinUpper(lastKey, upper)
+		if !inRange {
+			break
+		}
+		cursor = nextCursor
+	}
+	return out, nil
+}
+
+func (s *CatalogStore) buildSplitJobPutMutations(ctx context.Context, key []byte, encoded []byte, jobID uint64) ([]*store.KVPairMutation, uint64, error) {
+	if jobID == math.MaxUint64 {
+		return nil, 0, errors.WithStack(ErrCatalogSplitJobIDOverflow)
+	}
+	readTS := s.store.LastCommitTS()
+	nextJobID, err := s.nextSplitJobIDAt(ctx, readTS)
+	if err != nil {
+		return nil, 0, err
+	}
+	floor := jobID + 1
+	if nextJobID < floor {
+		nextJobID = floor
+	}
+
+	mutations := []*store.KVPairMutation{{
+		Op:    store.OpTypePut,
+		Key:   CloneBytes(key),
+		Value: CloneBytes(encoded),
+	}}
+	if nextJobID != 0 {
+		mutations = append(mutations, &store.KVPairMutation{
+			Op:    store.OpTypePut,
+			Key:   CatalogNextSplitJobIDKey(),
+			Value: EncodeCatalogNextSplitJobID(nextJobID),
+		})
+	}
+	return mutations, readTS, nil
+}
+
+func (s *CatalogStore) applySplitJobMutations(ctx context.Context, readTS uint64, mutations []*store.KVPairMutation) error {
+	minCommitTS := readTS + 1
+	if minCommitTS == 0 {
+		return errors.WithStack(ErrCatalogVersionOverflow)
+	}
+	commitTS, err := s.commitTSForApply(minCommitTS)
+	if err != nil {
+		return err
+	}
+	if err := s.store.ApplyMutations(ctx, mutations, nil, readTS, commitTS); err != nil {
+		if errors.Is(err, store.ErrWriteConflict) {
+			return errors.WithStack(ErrCatalogSplitJobConflict)
+		}
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func sortSplitJobs(jobs []SplitJob) {
+	sort.Slice(jobs, func(i, j int) bool {
+		return splitJobLess(jobs[i], jobs[j])
+	})
+}
+
+func splitJobLess(left, right SplitJob) bool {
+	leftTerminal := left.TerminalAtMs > 0
+	rightTerminal := right.TerminalAtMs > 0
+	if leftTerminal != rightTerminal {
+		return !leftTerminal
+	}
+	if left.TerminalAtMs != right.TerminalAtMs {
+		return left.TerminalAtMs < right.TerminalAtMs
+	}
+	return left.JobID < right.JobID
+}
+
+func CloneSplitJob(job SplitJob) SplitJob {
+	return SplitJob{
+		JobID:                            job.JobID,
+		SourceRouteID:                    job.SourceRouteID,
+		SplitKey:                         CloneBytes(job.SplitKey),
+		TargetGroupID:                    job.TargetGroupID,
+		Phase:                            job.Phase,
+		RetryPhase:                       job.RetryPhase,
+		AbandonFromPhase:                 job.AbandonFromPhase,
+		SnapshotTS:                       job.SnapshotTS,
+		SnapshotMinAdmittedTS:            job.SnapshotMinAdmittedTS,
+		WriteTrackerArmed:                job.WriteTrackerArmed,
+		DeltaFloor:                       job.DeltaFloor,
+		PostFenceDrainCompleted:          job.PostFenceDrainCompleted,
+		FenceTS:                          job.FenceTS,
+		CutoverVersion:                   job.CutoverVersion,
+		CutoverReadFenceState:            job.CutoverReadFenceState,
+		TargetStagedReadinessState:       job.TargetStagedReadinessState,
+		SourceCutoverReadFenceAckCursor:  CloneBytes(job.SourceCutoverReadFenceAckCursor),
+		TargetStagedReadinessAckCursor:   CloneBytes(job.TargetStagedReadinessAckCursor),
+		Cursor:                           CloneBytes(job.Cursor),
+		MaxImportedTS:                    job.MaxImportedTS,
+		TargetPromotionDone:              job.TargetPromotionDone,
+		PromotionCompletedTS:             job.PromotionCompletedTS,
+		FenceCatalogVersion:              job.FenceCatalogVersion,
+		FenceAckCursor:                   CloneBytes(job.FenceAckCursor),
+		SourceCutoverAckCursor:           CloneBytes(job.SourceCutoverAckCursor),
+		SourceReadDrainCursor:            CloneBytes(job.SourceReadDrainCursor),
+		TargetClearedDescriptorAckCursor: CloneBytes(job.TargetClearedDescriptorAckCursor),
+		BracketProgress:                  cloneSplitJobBracketProgress(job.BracketProgress),
+		SourceRetentionPinTS:             job.SourceRetentionPinTS,
+		LastError:                        job.LastError,
+		StartedAtMs:                      job.StartedAtMs,
+		UpdatedAtMs:                      job.UpdatedAtMs,
+		TerminalAtMs:                     job.TerminalAtMs,
+	}
+}
+
+func splitJobToProto(job SplitJob) *pb.SplitJob {
+	job = CloneSplitJob(job)
+	return &pb.SplitJob{
+		JobId:                            job.JobID,
+		SourceRouteId:                    job.SourceRouteID,
+		SplitKey:                         job.SplitKey,
+		TargetGroupId:                    job.TargetGroupID,
+		Phase:                            pb.SplitJobPhase(job.Phase),
+		RetryPhase:                       pb.SplitJobPhase(job.RetryPhase),
+		AbandonFromPhase:                 pb.SplitJobPhase(job.AbandonFromPhase),
+		SnapshotTs:                       job.SnapshotTS,
+		SnapshotMinAdmittedTs:            job.SnapshotMinAdmittedTS,
+		WriteTrackerArmed:                job.WriteTrackerArmed,
+		DeltaFloor:                       job.DeltaFloor,
+		PostFenceDrainCompleted:          job.PostFenceDrainCompleted,
+		FenceTs:                          job.FenceTS,
+		CutoverVersion:                   job.CutoverVersion,
+		CutoverReadFenceState:            pb.SplitJobBarrierState(job.CutoverReadFenceState),
+		TargetStagedReadinessState:       pb.SplitJobBarrierState(job.TargetStagedReadinessState),
+		SourceCutoverReadFenceAckCursor:  job.SourceCutoverReadFenceAckCursor,
+		TargetStagedReadinessAckCursor:   job.TargetStagedReadinessAckCursor,
+		Cursor:                           job.Cursor,
+		MaxImportedTs:                    job.MaxImportedTS,
+		TargetPromotionDone:              job.TargetPromotionDone,
+		PromotionCompletedTs:             job.PromotionCompletedTS,
+		FenceCatalogVersion:              job.FenceCatalogVersion,
+		FenceAckCursor:                   job.FenceAckCursor,
+		SourceCutoverAckCursor:           job.SourceCutoverAckCursor,
+		SourceReadDrainCursor:            job.SourceReadDrainCursor,
+		TargetClearedDescriptorAckCursor: job.TargetClearedDescriptorAckCursor,
+		BracketProgress:                  splitJobBracketProgressToProto(job.BracketProgress),
+		SourceRetentionPinTs:             job.SourceRetentionPinTS,
+		LastError:                        job.LastError,
+		StartedAtMs:                      job.StartedAtMs,
+		UpdatedAtMs:                      job.UpdatedAtMs,
+		TerminalAtMs:                     job.TerminalAtMs,
+	}
+}
+
+func splitJobFromProto(msg *pb.SplitJob) (SplitJob, error) {
+	if msg == nil {
+		return SplitJob{}, nil
+	}
+	phase, err := splitJobPhaseFromProto(msg.GetPhase())
+	if err != nil {
+		return SplitJob{}, err
+	}
+	retryPhase, err := splitJobPhaseFromProto(msg.GetRetryPhase())
+	if err != nil {
+		return SplitJob{}, err
+	}
+	abandonFromPhase, err := splitJobPhaseFromProto(msg.GetAbandonFromPhase())
+	if err != nil {
+		return SplitJob{}, err
+	}
+	cutoverReadFenceState, err := splitJobBarrierStateFromProto(msg.GetCutoverReadFenceState())
+	if err != nil {
+		return SplitJob{}, err
+	}
+	targetStagedReadinessState, err := splitJobBarrierStateFromProto(msg.GetTargetStagedReadinessState())
+	if err != nil {
+		return SplitJob{}, err
+	}
+	bracketProgress, err := splitJobBracketProgressFromProto(msg.GetBracketProgress())
+	if err != nil {
+		return SplitJob{}, err
+	}
+	return SplitJob{
+		JobID:                            msg.GetJobId(),
+		SourceRouteID:                    msg.GetSourceRouteId(),
+		SplitKey:                         CloneBytes(msg.GetSplitKey()),
+		TargetGroupID:                    msg.GetTargetGroupId(),
+		Phase:                            phase,
+		RetryPhase:                       retryPhase,
+		AbandonFromPhase:                 abandonFromPhase,
+		SnapshotTS:                       msg.GetSnapshotTs(),
+		SnapshotMinAdmittedTS:            msg.GetSnapshotMinAdmittedTs(),
+		WriteTrackerArmed:                msg.GetWriteTrackerArmed(),
+		DeltaFloor:                       msg.GetDeltaFloor(),
+		PostFenceDrainCompleted:          msg.GetPostFenceDrainCompleted(),
+		FenceTS:                          msg.GetFenceTs(),
+		CutoverVersion:                   msg.GetCutoverVersion(),
+		CutoverReadFenceState:            cutoverReadFenceState,
+		TargetStagedReadinessState:       targetStagedReadinessState,
+		SourceCutoverReadFenceAckCursor:  CloneBytes(msg.GetSourceCutoverReadFenceAckCursor()),
+		TargetStagedReadinessAckCursor:   CloneBytes(msg.GetTargetStagedReadinessAckCursor()),
+		Cursor:                           CloneBytes(msg.GetCursor()),
+		MaxImportedTS:                    msg.GetMaxImportedTs(),
+		TargetPromotionDone:              msg.GetTargetPromotionDone(),
+		PromotionCompletedTS:             msg.GetPromotionCompletedTs(),
+		FenceCatalogVersion:              msg.GetFenceCatalogVersion(),
+		FenceAckCursor:                   CloneBytes(msg.GetFenceAckCursor()),
+		SourceCutoverAckCursor:           CloneBytes(msg.GetSourceCutoverAckCursor()),
+		SourceReadDrainCursor:            CloneBytes(msg.GetSourceReadDrainCursor()),
+		TargetClearedDescriptorAckCursor: CloneBytes(msg.GetTargetClearedDescriptorAckCursor()),
+		BracketProgress:                  bracketProgress,
+		SourceRetentionPinTS:             msg.GetSourceRetentionPinTs(),
+		LastError:                        msg.GetLastError(),
+		StartedAtMs:                      msg.GetStartedAtMs(),
+		UpdatedAtMs:                      msg.GetUpdatedAtMs(),
+		TerminalAtMs:                     msg.GetTerminalAtMs(),
+	}, nil
+}
+
+func splitJobBracketProgressToProto(progress []SplitJobBracketProgress) []*pb.SplitJobBracketProgress {
+	if len(progress) == 0 {
+		return nil
+	}
+	out := make([]*pb.SplitJobBracketProgress, 0, len(progress))
+	for _, p := range progress {
+		out = append(out, &pb.SplitJobBracketProgress{
+			BracketId:         p.BracketID,
+			Family:            p.Family,
+			ExportPhase:       pb.SplitJobExportPhase(p.ExportPhase),
+			Cursor:            CloneBytes(p.Cursor),
+			Done:              p.Done,
+			ScannedBytes:      p.ScannedBytes,
+			AcceptedRows:      p.AcceptedRows,
+			LastAckedBatchSeq: p.LastAckedBatchSeq,
+		})
+	}
+	return out
+}
+
+func splitJobBracketProgressFromProto(progress []*pb.SplitJobBracketProgress) ([]SplitJobBracketProgress, error) {
+	if len(progress) == 0 {
+		return nil, nil
+	}
+	out := make([]SplitJobBracketProgress, 0, len(progress))
+	for _, p := range progress {
+		if p == nil {
+			continue
+		}
+		exportPhase, err := splitJobExportPhaseFromProto(p.GetExportPhase())
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, SplitJobBracketProgress{
+			BracketID:         p.GetBracketId(),
+			Family:            p.GetFamily(),
+			ExportPhase:       exportPhase,
+			Cursor:            CloneBytes(p.GetCursor()),
+			Done:              p.GetDone(),
+			ScannedBytes:      p.GetScannedBytes(),
+			AcceptedRows:      p.GetAcceptedRows(),
+			LastAckedBatchSeq: p.GetLastAckedBatchSeq(),
+		})
+	}
+	return out, nil
+}
+
+func splitJobPhaseFromProto(p pb.SplitJobPhase) (SplitJobPhase, error) {
+	switch p {
+	case pb.SplitJobPhase_SPLIT_JOB_PHASE_NONE,
+		pb.SplitJobPhase_SPLIT_JOB_PHASE_PLANNED,
+		pb.SplitJobPhase_SPLIT_JOB_PHASE_BACKFILL,
+		pb.SplitJobPhase_SPLIT_JOB_PHASE_FENCE,
+		pb.SplitJobPhase_SPLIT_JOB_PHASE_DELTA_COPY,
+		pb.SplitJobPhase_SPLIT_JOB_PHASE_CUTOVER,
+		pb.SplitJobPhase_SPLIT_JOB_PHASE_CLEANUP,
+		pb.SplitJobPhase_SPLIT_JOB_PHASE_DONE,
+		pb.SplitJobPhase_SPLIT_JOB_PHASE_FAILED,
+		pb.SplitJobPhase_SPLIT_JOB_PHASE_ABANDONING,
+		pb.SplitJobPhase_SPLIT_JOB_PHASE_ABANDONED:
+		return SplitJobPhase(p), nil
+	default:
+		return 0, errors.WithStack(ErrCatalogInvalidSplitJobPhase)
+	}
+}
+
+func splitJobBarrierStateFromProto(s pb.SplitJobBarrierState) (SplitJobBarrierState, error) {
+	switch s {
+	case pb.SplitJobBarrierState_SPLIT_JOB_BARRIER_STATE_NONE,
+		pb.SplitJobBarrierState_SPLIT_JOB_BARRIER_STATE_ARMING,
+		pb.SplitJobBarrierState_SPLIT_JOB_BARRIER_STATE_ARMED,
+		pb.SplitJobBarrierState_SPLIT_JOB_BARRIER_STATE_CLEARING:
+		return SplitJobBarrierState(s), nil
+	default:
+		return 0, errors.WithStack(ErrCatalogInvalidSplitJobBarrierState)
+	}
+}
+
+func splitJobExportPhaseFromProto(p pb.SplitJobExportPhase) (SplitJobExportPhase, error) {
+	switch p {
+	case pb.SplitJobExportPhase_SPLIT_JOB_EXPORT_PHASE_NONE,
+		pb.SplitJobExportPhase_SPLIT_JOB_EXPORT_PHASE_BACKFILL,
+		pb.SplitJobExportPhase_SPLIT_JOB_EXPORT_PHASE_DELTA_COPY:
+		return SplitJobExportPhase(p), nil
+	default:
+		return 0, errors.WithStack(ErrCatalogInvalidSplitJobExportPhase)
+	}
+}
+
+func cloneSplitJobBracketProgress(progress []SplitJobBracketProgress) []SplitJobBracketProgress {
+	if len(progress) == 0 {
+		return nil
+	}
+	out := make([]SplitJobBracketProgress, len(progress))
+	for i := range progress {
+		out[i] = progress[i]
+		out[i].Cursor = CloneBytes(progress[i].Cursor)
+	}
+	return out
+}

--- a/distribution/split_job_catalog.go
+++ b/distribution/split_job_catalog.go
@@ -545,7 +545,64 @@ func validateSplitJobPhases(job SplitJob) error {
 	if !job.RetryPhase.valid() || !job.AbandonFromPhase.valid() {
 		return errors.WithStack(ErrCatalogInvalidSplitJobPhase)
 	}
+	if !job.retryPhaseValidForPhase() || !job.abandonFromPhaseValidForPhase() {
+		return errors.WithStack(ErrCatalogInvalidSplitJobPhase)
+	}
 	return nil
+}
+
+func (job SplitJob) retryPhaseValidForPhase() bool {
+	if job.Phase == SplitJobPhaseFailed {
+		return job.RetryPhase.retryable()
+	}
+	return job.RetryPhase == SplitJobPhaseNone
+}
+
+func (job SplitJob) abandonFromPhaseValidForPhase() bool {
+	if job.Phase == SplitJobPhaseAbandoning {
+		return job.AbandonFromPhase.abandonable()
+	}
+	return job.AbandonFromPhase == SplitJobPhaseNone
+}
+
+func (p SplitJobPhase) retryable() bool {
+	switch p {
+	case SplitJobPhaseBackfill,
+		SplitJobPhaseFence,
+		SplitJobPhaseDeltaCopy,
+		SplitJobPhaseCutover,
+		SplitJobPhaseCleanup:
+		return true
+	case SplitJobPhaseNone,
+		SplitJobPhasePlanned,
+		SplitJobPhaseDone,
+		SplitJobPhaseFailed,
+		SplitJobPhaseAbandoning,
+		SplitJobPhaseAbandoned:
+		return false
+	default:
+		return false
+	}
+}
+
+func (p SplitJobPhase) abandonable() bool {
+	switch p {
+	case SplitJobPhaseBackfill,
+		SplitJobPhaseFence,
+		SplitJobPhaseDeltaCopy:
+		return true
+	case SplitJobPhaseNone,
+		SplitJobPhasePlanned,
+		SplitJobPhaseCutover,
+		SplitJobPhaseCleanup,
+		SplitJobPhaseDone,
+		SplitJobPhaseFailed,
+		SplitJobPhaseAbandoning,
+		SplitJobPhaseAbandoned:
+		return false
+	default:
+		return false
+	}
 }
 
 func validateSplitJobBarriers(job SplitJob) error {
@@ -556,10 +613,15 @@ func validateSplitJobBarriers(job SplitJob) error {
 }
 
 func validateSplitJobBracketProgress(progress []SplitJobBracketProgress) error {
+	seen := make(map[uint64]struct{}, len(progress))
 	for _, p := range progress {
 		if !p.ExportPhase.valid() {
 			return errors.WithStack(ErrCatalogInvalidSplitJobExportPhase)
 		}
+		if _, ok := seen[p.BracketID]; ok {
+			return errors.WithStack(ErrCatalogInvalidSplitJobRecord)
+		}
+		seen[p.BracketID] = struct{}{}
 	}
 	return nil
 }
@@ -729,7 +791,7 @@ func (s *CatalogStore) buildSplitJobPutMutations(ctx context.Context, readTS uin
 	if jobID == math.MaxUint64 {
 		return nil, errors.WithStack(ErrCatalogSplitJobIDOverflow)
 	}
-	nextJobID, err := s.splitJobNextIDFloorAt(ctx, readTS, jobID)
+	nextJobID, err := s.splitJobNextIDAdvanceAt(ctx, readTS, jobID)
 	if err != nil {
 		return nil, err
 	}
@@ -749,7 +811,7 @@ func (s *CatalogStore) buildSplitJobPutMutations(ctx context.Context, readTS uin
 	return mutations, nil
 }
 
-func (s *CatalogStore) splitJobNextIDFloorAt(ctx context.Context, ts uint64, jobID uint64) (uint64, error) {
+func (s *CatalogStore) splitJobNextIDAdvanceAt(ctx context.Context, ts uint64, jobID uint64) (uint64, error) {
 	nextJobID, err := s.nextSplitJobIDAt(ctx, ts)
 	if err != nil {
 		return 0, err
@@ -762,14 +824,13 @@ func (s *CatalogStore) splitJobNextIDFloorAt(ctx context.Context, ts uint64, job
 	if err != nil {
 		return 0, err
 	}
-	if nextJobID < floor {
-		nextJobID = floor
+	if jobID+1 > floor {
+		floor = jobID + 1
 	}
-	floor = jobID + 1
-	if nextJobID < floor {
-		nextJobID = floor
+	if nextJobID == 0 || nextJobID < floor {
+		return floor, nil
 	}
-	return nextJobID, nil
+	return 0, nil
 }
 
 func (s *CatalogStore) applySplitJobMutations(ctx context.Context, readTS uint64, readKeys [][]byte, mutations []*store.KVPairMutation) error {

--- a/distribution/split_job_catalog.go
+++ b/distribution/split_job_catalog.go
@@ -260,7 +260,10 @@ func EncodeSplitJob(job SplitJob) ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrapf(ErrCatalogInvalidSplitJobRecord, "marshal split job: %v", err)
 	}
-	out := make([]byte, 1+len(body))
+	if len(body) > math.MaxInt-1 {
+		return nil, errors.Wrap(ErrCatalogInvalidSplitJobRecord, "encoded split job exceeds maximum slice length")
+	}
+	out := make([]byte, len(body)+1)
 	out[0] = catalogJobCodecVersion
 	copy(out[1:], body)
 	return out, nil

--- a/distribution/split_job_catalog_test.go
+++ b/distribution/split_job_catalog_test.go
@@ -1,0 +1,355 @@
+package distribution
+
+import (
+	"context"
+	"math"
+	"reflect"
+	"testing"
+
+	pb "github.com/bootjp/elastickv/proto"
+	"github.com/bootjp/elastickv/store"
+	"github.com/cockroachdb/errors"
+	gproto "google.golang.org/protobuf/proto"
+)
+
+func TestCatalogNextSplitJobIDCodecRoundTrip(t *testing.T) {
+	raw := EncodeCatalogNextSplitJobID(42)
+	got, err := DecodeCatalogNextSplitJobID(raw)
+	if err != nil {
+		t.Fatalf("decode next split job id: %v", err)
+	}
+	if got != 42 {
+		t.Fatalf("expected 42, got %d", got)
+	}
+}
+
+func TestCatalogNextSplitJobIDCodecRejectsInvalidPayload(t *testing.T) {
+	if _, err := DecodeCatalogNextSplitJobID(nil); !errors.Is(err, ErrCatalogInvalidNextSplitJobID) {
+		t.Fatalf("expected ErrCatalogInvalidNextSplitJobID, got %v", err)
+	}
+	if _, err := DecodeCatalogNextSplitJobID(EncodeCatalogVersion(0)); !errors.Is(err, ErrCatalogInvalidNextSplitJobID) {
+		t.Fatalf("expected ErrCatalogInvalidNextSplitJobID, got %v", err)
+	}
+}
+
+func TestCatalogSplitJobKeyHelpers(t *testing.T) {
+	key := CatalogSplitJobKey(11)
+	if !IsCatalogSplitJobKey(key) {
+		t.Fatal("expected split job key prefix match")
+	}
+	id, ok := CatalogSplitJobIDFromKey(key)
+	if !ok {
+		t.Fatal("expected split job id parse to succeed")
+	}
+	if id != 11 {
+		t.Fatalf("expected split job id 11, got %d", id)
+	}
+	if _, ok := CatalogSplitJobIDFromKey([]byte("not-a-job-key")); ok {
+		t.Fatal("expected parse failure for non-job key")
+	}
+	if _, ok := CatalogSplitJobIDFromKey([]byte(catalogSplitJobPrefix + "short")); ok {
+		t.Fatal("expected parse failure for short job key")
+	}
+}
+
+func TestCatalogSplitJobHistoryKeyHelpers(t *testing.T) {
+	key := CatalogSplitJobHistoryKey(12345, 99)
+	if !IsCatalogSplitJobHistoryKey(key) {
+		t.Fatal("expected split job history key prefix match")
+	}
+	terminalAtMs, jobID, ok := CatalogSplitJobHistoryKeyParts(key)
+	if !ok {
+		t.Fatal("expected split job history key parse to succeed")
+	}
+	if terminalAtMs != 12345 || jobID != 99 {
+		t.Fatalf("expected terminal/job (12345,99), got (%d,%d)", terminalAtMs, jobID)
+	}
+	if _, _, ok := CatalogSplitJobHistoryKeyParts([]byte("not-a-history-key")); ok {
+		t.Fatal("expected parse failure for non-history key")
+	}
+}
+
+func TestSplitJobCodecRoundTrip(t *testing.T) {
+	want := sampleSplitJob(7)
+	raw, err := EncodeSplitJob(want)
+	if err != nil {
+		t.Fatalf("encode split job: %v", err)
+	}
+	got, err := DecodeSplitJob(raw)
+	if err != nil {
+		t.Fatalf("decode split job: %v", err)
+	}
+	assertSplitJobEqual(t, want, got)
+}
+
+func TestSplitJobCodecRejectsInvalidVersion(t *testing.T) {
+	job := sampleSplitJob(1)
+	raw, err := EncodeSplitJob(job)
+	if err != nil {
+		t.Fatalf("encode split job: %v", err)
+	}
+	raw[0] = catalogJobCodecVersion + 1
+	if _, err := DecodeSplitJob(raw); !errors.Is(err, ErrCatalogInvalidSplitJobRecord) {
+		t.Fatalf("expected ErrCatalogInvalidSplitJobRecord, got %v", err)
+	}
+}
+
+func TestSplitJobCodecRejectsInvalidPhase(t *testing.T) {
+	job := sampleSplitJob(1)
+	job.Phase = SplitJobPhaseNone
+	if _, err := EncodeSplitJob(job); !errors.Is(err, ErrCatalogInvalidSplitJobPhase) {
+		t.Fatalf("expected ErrCatalogInvalidSplitJobPhase, got %v", err)
+	}
+}
+
+func TestSplitJobCodecRejectsUnknownProtoEnumValues(t *testing.T) {
+	body, err := gproto.MarshalOptions{Deterministic: true}.Marshal(&pb.SplitJob{
+		JobId:         1,
+		SourceRouteId: 2,
+		TargetGroupId: 3,
+		Phase:         pb.SplitJobPhase(300),
+	})
+	if err != nil {
+		t.Fatalf("marshal invalid split job proto: %v", err)
+	}
+	raw := append([]byte{catalogJobCodecVersion}, body...)
+	if _, err := DecodeSplitJob(raw); !errors.Is(err, ErrCatalogInvalidSplitJobPhase) {
+		t.Fatalf("expected ErrCatalogInvalidSplitJobPhase, got %v", err)
+	}
+
+	body, err = gproto.MarshalOptions{Deterministic: true}.Marshal(&pb.SplitJob{
+		JobId:                 1,
+		SourceRouteId:         2,
+		TargetGroupId:         3,
+		Phase:                 pb.SplitJobPhase_SPLIT_JOB_PHASE_PLANNED,
+		CutoverReadFenceState: pb.SplitJobBarrierState(300),
+		BracketProgress:       []*pb.SplitJobBracketProgress{{ExportPhase: pb.SplitJobExportPhase_SPLIT_JOB_EXPORT_PHASE_BACKFILL}},
+	})
+	if err != nil {
+		t.Fatalf("marshal invalid barrier proto: %v", err)
+	}
+	raw = append([]byte{catalogJobCodecVersion}, body...)
+	if _, err := DecodeSplitJob(raw); !errors.Is(err, ErrCatalogInvalidSplitJobBarrierState) {
+		t.Fatalf("expected ErrCatalogInvalidSplitJobBarrierState, got %v", err)
+	}
+
+	body, err = gproto.MarshalOptions{Deterministic: true}.Marshal(&pb.SplitJob{
+		JobId:         1,
+		SourceRouteId: 2,
+		TargetGroupId: 3,
+		Phase:         pb.SplitJobPhase_SPLIT_JOB_PHASE_PLANNED,
+		BracketProgress: []*pb.SplitJobBracketProgress{{
+			ExportPhase: pb.SplitJobExportPhase(300),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal invalid export phase proto: %v", err)
+	}
+	raw = append([]byte{catalogJobCodecVersion}, body...)
+	if _, err := DecodeSplitJob(raw); !errors.Is(err, ErrCatalogInvalidSplitJobExportPhase) {
+		t.Fatalf("expected ErrCatalogInvalidSplitJobExportPhase, got %v", err)
+	}
+}
+
+func TestCatalogStoreNextSplitJobID_DefaultsToOne(t *testing.T) {
+	cs := NewCatalogStore(store.NewMVCCStore())
+	next, err := cs.NextSplitJobID(context.Background())
+	if err != nil {
+		t.Fatalf("next split job id: %v", err)
+	}
+	if next != 1 {
+		t.Fatalf("expected next split job id 1, got %d", next)
+	}
+}
+
+func TestCatalogStoreSaveAndLoadSplitJob(t *testing.T) {
+	cs := NewCatalogStore(store.NewMVCCStore())
+	ctx := context.Background()
+	job := sampleSplitJob(7)
+
+	if err := cs.SaveSplitJob(ctx, job); err != nil {
+		t.Fatalf("save split job: %v", err)
+	}
+	got, found, err := cs.SplitJob(ctx, job.JobID)
+	if err != nil {
+		t.Fatalf("load split job: %v", err)
+	}
+	if !found {
+		t.Fatal("expected split job to be found")
+	}
+	assertSplitJobEqual(t, job, got)
+
+	next, err := cs.NextSplitJobID(ctx)
+	if err != nil {
+		t.Fatalf("next split job id: %v", err)
+	}
+	if next != 8 {
+		t.Fatalf("expected next split job id 8, got %d", next)
+	}
+}
+
+func TestCatalogStoreListSplitJobsIncludesLiveAndHistory(t *testing.T) {
+	cs := NewCatalogStore(store.NewMVCCStore())
+	ctx := context.Background()
+	live := sampleSplitJob(2)
+	history := sampleSplitJob(1)
+	history.Phase = SplitJobPhaseDone
+	history.TerminalAtMs = 1000
+
+	if err := cs.SaveSplitJob(ctx, live); err != nil {
+		t.Fatalf("save live split job: %v", err)
+	}
+	if err := cs.SaveSplitJob(ctx, history); err != nil {
+		t.Fatalf("save terminal split job: %v", err)
+	}
+	if err := cs.MoveSplitJobToHistory(ctx, history); err != nil {
+		t.Fatalf("move split job to history: %v", err)
+	}
+
+	jobs, err := cs.ListSplitJobs(ctx)
+	if err != nil {
+		t.Fatalf("list split jobs: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("expected 2 jobs, got %d", len(jobs))
+	}
+	assertSplitJobEqual(t, live, jobs[0])
+	assertSplitJobEqual(t, history, jobs[1])
+
+	got, found, err := cs.SplitJob(ctx, history.JobID)
+	if err != nil {
+		t.Fatalf("load history split job: %v", err)
+	}
+	if !found {
+		t.Fatal("expected history split job to be found by id")
+	}
+	assertSplitJobEqual(t, history, got)
+}
+
+func TestCatalogStoreMoveSplitJobToHistoryRejectsNonTerminal(t *testing.T) {
+	cs := NewCatalogStore(store.NewMVCCStore())
+	if err := cs.MoveSplitJobToHistory(context.Background(), sampleSplitJob(1)); !errors.Is(err, ErrCatalogSplitJobTerminalRequired) {
+		t.Fatalf("expected ErrCatalogSplitJobTerminalRequired, got %v", err)
+	}
+}
+
+func TestCatalogStoreDeleteSplitJob(t *testing.T) {
+	cs := NewCatalogStore(store.NewMVCCStore())
+	ctx := context.Background()
+	job := sampleSplitJob(3)
+	if err := cs.SaveSplitJob(ctx, job); err != nil {
+		t.Fatalf("save split job: %v", err)
+	}
+	if err := cs.DeleteSplitJob(ctx, job.JobID); err != nil {
+		t.Fatalf("delete split job: %v", err)
+	}
+	if _, found, err := cs.SplitJob(ctx, job.JobID); err != nil {
+		t.Fatalf("load deleted split job: %v", err)
+	} else if found {
+		t.Fatal("expected deleted split job to be absent")
+	}
+	next, err := cs.NextSplitJobID(ctx)
+	if err != nil {
+		t.Fatalf("next split job id: %v", err)
+	}
+	if next != 4 {
+		t.Fatalf("expected next split job id to remain 4, got %d", next)
+	}
+}
+
+func TestCatalogStoreNextSplitJobIDAt_FallsBackWhenMetaMissing(t *testing.T) {
+	st := store.NewMVCCStore()
+	cs := NewCatalogStore(st)
+	ctx := context.Background()
+
+	live := sampleSplitJob(10)
+	liveRaw, err := EncodeSplitJob(live)
+	if err != nil {
+		t.Fatalf("encode live split job: %v", err)
+	}
+	history := sampleSplitJob(20)
+	history.Phase = SplitJobPhaseAbandoned
+	history.TerminalAtMs = 5000
+	historyRaw, err := EncodeSplitJob(history)
+	if err != nil {
+		t.Fatalf("encode history split job: %v", err)
+	}
+
+	const ts = uint64(7)
+	if err := st.PutAt(ctx, CatalogSplitJobKey(live.JobID), liveRaw, ts, 0); err != nil {
+		t.Fatalf("put live split job: %v", err)
+	}
+	if err := st.PutAt(ctx, CatalogSplitJobHistoryKey(history.TerminalAtMs, history.JobID), historyRaw, ts, 0); err != nil {
+		t.Fatalf("put history split job: %v", err)
+	}
+
+	nextAt, err := cs.NextSplitJobIDAt(ctx, ts)
+	if err != nil {
+		t.Fatalf("next split job id at ts: %v", err)
+	}
+	if nextAt != 21 {
+		t.Fatalf("expected next split job id 21, got %d", nextAt)
+	}
+}
+
+func TestNextSplitJobIDFloorRejectsOverflow(t *testing.T) {
+	_, err := NextSplitJobIDFloor([]SplitJob{{JobID: math.MaxUint64}})
+	if !errors.Is(err, ErrCatalogSplitJobIDOverflow) {
+		t.Fatalf("expected ErrCatalogSplitJobIDOverflow, got %v", err)
+	}
+}
+
+func sampleSplitJob(jobID uint64) SplitJob {
+	return SplitJob{
+		JobID:                            jobID,
+		SourceRouteID:                    11,
+		SplitKey:                         []byte("split-key"),
+		TargetGroupID:                    22,
+		Phase:                            SplitJobPhaseDeltaCopy,
+		RetryPhase:                       SplitJobPhaseBackfill,
+		AbandonFromPhase:                 SplitJobPhaseFence,
+		SnapshotTS:                       101,
+		SnapshotMinAdmittedTS:            102,
+		WriteTrackerArmed:                true,
+		DeltaFloor:                       103,
+		PostFenceDrainCompleted:          true,
+		FenceTS:                          104,
+		CutoverVersion:                   105,
+		CutoverReadFenceState:            SplitJobBarrierArmed,
+		TargetStagedReadinessState:       SplitJobBarrierArming,
+		SourceCutoverReadFenceAckCursor:  []byte("source-read-fence"),
+		TargetStagedReadinessAckCursor:   []byte("target-ready"),
+		Cursor:                           []byte("cursor"),
+		MaxImportedTS:                    106,
+		TargetPromotionDone:              true,
+		PromotionCompletedTS:             107,
+		FenceCatalogVersion:              108,
+		FenceAckCursor:                   []byte("fence-ack"),
+		SourceCutoverAckCursor:           []byte("source-cutover"),
+		SourceReadDrainCursor:            []byte("source-drain"),
+		TargetClearedDescriptorAckCursor: []byte("target-clear"),
+		BracketProgress: []SplitJobBracketProgress{
+			{
+				BracketID:         31,
+				Family:            2,
+				ExportPhase:       SplitJobExportPhaseDeltaCopy,
+				Cursor:            []byte("bracket-cursor"),
+				Done:              true,
+				ScannedBytes:      4096,
+				AcceptedRows:      128,
+				LastAckedBatchSeq: 9,
+			},
+		},
+		SourceRetentionPinTS: 109,
+		LastError:            "last error",
+		StartedAtMs:          10000,
+		UpdatedAtMs:          20000,
+	}
+}
+
+func assertSplitJobEqual(t *testing.T, want, got SplitJob) {
+	t.Helper()
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("split job mismatch:\nwant=%+v\ngot=%+v", want, got)
+	}
+}

--- a/distribution/split_job_catalog_test.go
+++ b/distribution/split_job_catalog_test.go
@@ -102,6 +102,102 @@ func TestSplitJobCodecRejectsInvalidPhase(t *testing.T) {
 	}
 }
 
+func TestSplitJobCodecValidatesRestartPhases(t *testing.T) {
+	for _, phase := range []SplitJobPhase{
+		SplitJobPhaseBackfill,
+		SplitJobPhaseFence,
+		SplitJobPhaseDeltaCopy,
+		SplitJobPhaseCutover,
+		SplitJobPhaseCleanup,
+	} {
+		job := sampleSplitJob(uint64(phase) + 10)
+		job.Phase = SplitJobPhaseFailed
+		job.RetryPhase = phase
+		if _, err := EncodeSplitJob(job); err != nil {
+			t.Fatalf("expected failed job with retry phase %v to encode: %v", phase, err)
+		}
+	}
+
+	for _, phase := range []SplitJobPhase{
+		SplitJobPhaseBackfill,
+		SplitJobPhaseFence,
+		SplitJobPhaseDeltaCopy,
+	} {
+		job := sampleSplitJob(uint64(phase) + 20)
+		job.Phase = SplitJobPhaseAbandoning
+		job.AbandonFromPhase = phase
+		if _, err := EncodeSplitJob(job); err != nil {
+			t.Fatalf("expected abandoning job from phase %v to encode: %v", phase, err)
+		}
+	}
+}
+
+func TestSplitJobCodecRejectsInvalidRestartPhases(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		phase            SplitJobPhase
+		retryPhase       SplitJobPhase
+		abandonFromPhase SplitJobPhase
+	}{
+		{
+			name:       "retry phase outside failed",
+			phase:      SplitJobPhaseDeltaCopy,
+			retryPhase: SplitJobPhaseBackfill,
+		},
+		{
+			name:       "failed without retry phase",
+			phase:      SplitJobPhaseFailed,
+			retryPhase: SplitJobPhaseNone,
+		},
+		{
+			name:       "failed retry to planned",
+			phase:      SplitJobPhaseFailed,
+			retryPhase: SplitJobPhasePlanned,
+		},
+		{
+			name:       "failed retry to terminal",
+			phase:      SplitJobPhaseFailed,
+			retryPhase: SplitJobPhaseDone,
+		},
+		{
+			name:             "abandon phase outside abandoning",
+			phase:            SplitJobPhaseDeltaCopy,
+			abandonFromPhase: SplitJobPhaseFence,
+		},
+		{
+			name:             "abandoning without source phase",
+			phase:            SplitJobPhaseAbandoning,
+			abandonFromPhase: SplitJobPhaseNone,
+		},
+		{
+			name:             "abandoning from cutover",
+			phase:            SplitJobPhaseAbandoning,
+			abandonFromPhase: SplitJobPhaseCutover,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			job := sampleSplitJob(2)
+			job.Phase = tc.phase
+			job.RetryPhase = tc.retryPhase
+			job.AbandonFromPhase = tc.abandonFromPhase
+			if _, err := EncodeSplitJob(job); !errors.Is(err, ErrCatalogInvalidSplitJobPhase) {
+				t.Fatalf("expected ErrCatalogInvalidSplitJobPhase, got %v", err)
+			}
+		})
+	}
+}
+
+func TestSplitJobCodecRejectsDuplicateBracketIDs(t *testing.T) {
+	job := sampleSplitJob(1)
+	dupe := job.BracketProgress[0]
+	dupe.Family++
+	dupe.Cursor = []byte("other-cursor")
+	job.BracketProgress = append(job.BracketProgress, dupe)
+	if _, err := EncodeSplitJob(job); !errors.Is(err, ErrCatalogInvalidSplitJobRecord) {
+		t.Fatalf("expected ErrCatalogInvalidSplitJobRecord, got %v", err)
+	}
+}
+
 func TestSplitJobCodecRejectsUnknownProtoEnumValues(t *testing.T) {
 	body, err := gproto.MarshalOptions{Deterministic: true}.Marshal(&pb.SplitJob{
 		JobId:         1,
@@ -412,6 +508,36 @@ func TestCatalogStoreSaveSeedsNextSplitJobIDFromExistingJobsWhenMetaMissing(t *t
 	}
 }
 
+func TestCatalogStoreBuildSplitJobPutMutationsSkipsCurrentNextSplitJobID(t *testing.T) {
+	st := store.NewMVCCStore()
+	cs := NewCatalogStore(st)
+	ctx := context.Background()
+
+	for _, jobID := range []uint64{1, 2} {
+		if err := cs.CreateSplitJob(ctx, sampleSplitJob(jobID)); err != nil {
+			t.Fatalf("create split job %d: %v", jobID, err)
+		}
+	}
+	updated := sampleSplitJob(1)
+	updated.Phase = SplitJobPhaseBackfill
+	updated.UpdatedAtMs++
+	raw, err := EncodeSplitJob(updated)
+	if err != nil {
+		t.Fatalf("encode updated split job: %v", err)
+	}
+
+	mutations, err := cs.buildSplitJobPutMutations(ctx, st.LastCommitTS(), CatalogSplitJobKey(updated.JobID), raw, updated.JobID)
+	if err != nil {
+		t.Fatalf("build split job mutations: %v", err)
+	}
+	if len(mutations) != 1 {
+		t.Fatalf("expected only job mutation, got %d", len(mutations))
+	}
+	if string(mutations[0].Key) != string(CatalogSplitJobKey(updated.JobID)) {
+		t.Fatalf("expected job mutation, got key %q", mutations[0].Key)
+	}
+}
+
 func TestCatalogStoreNextSplitJobIDAt_FallsBackWhenMetaMissing(t *testing.T) {
 	st := store.NewMVCCStore()
 	cs := NewCatalogStore(st)
@@ -461,8 +587,8 @@ func sampleSplitJob(jobID uint64) SplitJob {
 		SplitKey:                         []byte("split-key"),
 		TargetGroupID:                    22,
 		Phase:                            SplitJobPhaseDeltaCopy,
-		RetryPhase:                       SplitJobPhaseBackfill,
-		AbandonFromPhase:                 SplitJobPhaseFence,
+		RetryPhase:                       SplitJobPhaseNone,
+		AbandonFromPhase:                 SplitJobPhaseNone,
 		SnapshotTS:                       101,
 		SnapshotMinAdmittedTS:            102,
 		WriteTrackerArmed:                true,

--- a/distribution/split_job_catalog_test.go
+++ b/distribution/split_job_catalog_test.go
@@ -167,8 +167,8 @@ func TestCatalogStoreSaveAndLoadSplitJob(t *testing.T) {
 	ctx := context.Background()
 	job := sampleSplitJob(7)
 
-	if err := cs.SaveSplitJob(ctx, job); err != nil {
-		t.Fatalf("save split job: %v", err)
+	if err := cs.CreateSplitJob(ctx, job); err != nil {
+		t.Fatalf("create split job: %v", err)
 	}
 	got, found, err := cs.SplitJob(ctx, job.JobID)
 	if err != nil {
@@ -188,6 +188,60 @@ func TestCatalogStoreSaveAndLoadSplitJob(t *testing.T) {
 	}
 }
 
+func TestCatalogStoreCreateSplitJobRejectsExistingJob(t *testing.T) {
+	cs := NewCatalogStore(store.NewMVCCStore())
+	ctx := context.Background()
+	job := sampleSplitJob(7)
+
+	if err := cs.CreateSplitJob(ctx, job); err != nil {
+		t.Fatalf("create split job: %v", err)
+	}
+	if err := cs.CreateSplitJob(ctx, job); !errors.Is(err, ErrCatalogSplitJobConflict) {
+		t.Fatalf("expected ErrCatalogSplitJobConflict, got %v", err)
+	}
+}
+
+func TestCatalogStoreSaveSplitJobRejectsStaleExpectedJob(t *testing.T) {
+	cs := NewCatalogStore(store.NewMVCCStore())
+	ctx := context.Background()
+	job := sampleSplitJob(8)
+
+	if err := cs.CreateSplitJob(ctx, job); err != nil {
+		t.Fatalf("create split job: %v", err)
+	}
+	expected, found, err := cs.SplitJob(ctx, job.JobID)
+	if err != nil {
+		t.Fatalf("load split job: %v", err)
+	}
+	if !found {
+		t.Fatal("expected split job to be found")
+	}
+
+	advanced := expected
+	advanced.Phase = SplitJobPhaseCutover
+	advanced.Cursor = []byte("advanced")
+	advanced.UpdatedAtMs++
+	if err := cs.SaveSplitJob(ctx, expected, advanced); err != nil {
+		t.Fatalf("save advanced split job: %v", err)
+	}
+
+	stale := expected
+	stale.Phase = SplitJobPhaseBackfill
+	stale.Cursor = []byte("stale")
+	stale.UpdatedAtMs++
+	if err := cs.SaveSplitJob(ctx, expected, stale); !errors.Is(err, ErrCatalogSplitJobConflict) {
+		t.Fatalf("expected ErrCatalogSplitJobConflict, got %v", err)
+	}
+	got, found, err := cs.SplitJob(ctx, job.JobID)
+	if err != nil {
+		t.Fatalf("reload split job: %v", err)
+	}
+	if !found {
+		t.Fatal("expected split job to remain found")
+	}
+	assertSplitJobEqual(t, advanced, got)
+}
+
 func TestCatalogStoreListSplitJobsIncludesLiveAndHistory(t *testing.T) {
 	cs := NewCatalogStore(store.NewMVCCStore())
 	ctx := context.Background()
@@ -196,13 +250,13 @@ func TestCatalogStoreListSplitJobsIncludesLiveAndHistory(t *testing.T) {
 	history.Phase = SplitJobPhaseDone
 	history.TerminalAtMs = 1000
 
-	if err := cs.SaveSplitJob(ctx, live); err != nil {
-		t.Fatalf("save live split job: %v", err)
+	if err := cs.CreateSplitJob(ctx, live); err != nil {
+		t.Fatalf("create live split job: %v", err)
 	}
-	if err := cs.SaveSplitJob(ctx, history); err != nil {
-		t.Fatalf("save terminal split job: %v", err)
+	if err := cs.CreateSplitJob(ctx, history); err != nil {
+		t.Fatalf("create terminal split job: %v", err)
 	}
-	if err := cs.MoveSplitJobToHistory(ctx, history); err != nil {
+	if err := cs.MoveSplitJobToHistory(ctx, history, history); err != nil {
 		t.Fatalf("move split job to history: %v", err)
 	}
 
@@ -226,9 +280,74 @@ func TestCatalogStoreListSplitJobsIncludesLiveAndHistory(t *testing.T) {
 	assertSplitJobEqual(t, history, got)
 }
 
+func TestCatalogStoreMoveSplitJobToHistoryIsIdempotentByJobID(t *testing.T) {
+	cs := NewCatalogStore(store.NewMVCCStore())
+	ctx := context.Background()
+	job := sampleSplitJob(12)
+
+	if err := cs.CreateSplitJob(ctx, job); err != nil {
+		t.Fatalf("create split job: %v", err)
+	}
+	terminal := job
+	terminal.Phase = SplitJobPhaseDone
+	terminal.TerminalAtMs = 1000
+	if err := cs.MoveSplitJobToHistory(ctx, job, terminal); err != nil {
+		t.Fatalf("move split job to history: %v", err)
+	}
+
+	retryTerminal := terminal
+	retryTerminal.TerminalAtMs = 2000
+	retryTerminal.LastError = "rebuilt terminal record"
+	if err := cs.MoveSplitJobToHistory(ctx, job, retryTerminal); err != nil {
+		t.Fatalf("retry move split job to history: %v", err)
+	}
+
+	jobs, err := cs.ListSplitJobs(ctx)
+	if err != nil {
+		t.Fatalf("list split jobs: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("expected one history job, got %d", len(jobs))
+	}
+	assertSplitJobEqual(t, terminal, jobs[0])
+}
+
+func TestCatalogStoreMoveSplitJobToHistoryRejectsStaleExpectedJob(t *testing.T) {
+	cs := NewCatalogStore(store.NewMVCCStore())
+	ctx := context.Background()
+	job := sampleSplitJob(13)
+
+	if err := cs.CreateSplitJob(ctx, job); err != nil {
+		t.Fatalf("create split job: %v", err)
+	}
+	advanced := job
+	advanced.Phase = SplitJobPhaseFence
+	advanced.Cursor = []byte("advanced")
+	advanced.UpdatedAtMs++
+	if err := cs.SaveSplitJob(ctx, job, advanced); err != nil {
+		t.Fatalf("save advanced split job: %v", err)
+	}
+
+	terminal := job
+	terminal.Phase = SplitJobPhaseDone
+	terminal.TerminalAtMs = 1000
+	if err := cs.MoveSplitJobToHistory(ctx, job, terminal); !errors.Is(err, ErrCatalogSplitJobConflict) {
+		t.Fatalf("expected ErrCatalogSplitJobConflict, got %v", err)
+	}
+	got, found, err := cs.SplitJob(ctx, job.JobID)
+	if err != nil {
+		t.Fatalf("reload split job: %v", err)
+	}
+	if !found {
+		t.Fatal("expected split job to remain live")
+	}
+	assertSplitJobEqual(t, advanced, got)
+}
+
 func TestCatalogStoreMoveSplitJobToHistoryRejectsNonTerminal(t *testing.T) {
 	cs := NewCatalogStore(store.NewMVCCStore())
-	if err := cs.MoveSplitJobToHistory(context.Background(), sampleSplitJob(1)); !errors.Is(err, ErrCatalogSplitJobTerminalRequired) {
+	job := sampleSplitJob(1)
+	if err := cs.MoveSplitJobToHistory(context.Background(), job, job); !errors.Is(err, ErrCatalogSplitJobTerminalRequired) {
 		t.Fatalf("expected ErrCatalogSplitJobTerminalRequired, got %v", err)
 	}
 }
@@ -237,8 +356,8 @@ func TestCatalogStoreDeleteSplitJob(t *testing.T) {
 	cs := NewCatalogStore(store.NewMVCCStore())
 	ctx := context.Background()
 	job := sampleSplitJob(3)
-	if err := cs.SaveSplitJob(ctx, job); err != nil {
-		t.Fatalf("save split job: %v", err)
+	if err := cs.CreateSplitJob(ctx, job); err != nil {
+		t.Fatalf("create split job: %v", err)
 	}
 	if err := cs.DeleteSplitJob(ctx, job.JobID); err != nil {
 		t.Fatalf("delete split job: %v", err)
@@ -254,6 +373,42 @@ func TestCatalogStoreDeleteSplitJob(t *testing.T) {
 	}
 	if next != 4 {
 		t.Fatalf("expected next split job id to remain 4, got %d", next)
+	}
+}
+
+func TestCatalogStoreSaveSeedsNextSplitJobIDFromExistingJobsWhenMetaMissing(t *testing.T) {
+	st := store.NewMVCCStore()
+	cs := NewCatalogStore(st)
+	ctx := context.Background()
+
+	live := sampleSplitJob(50)
+	liveRaw, err := EncodeSplitJob(live)
+	if err != nil {
+		t.Fatalf("encode live split job: %v", err)
+	}
+	history := sampleSplitJob(80)
+	history.Phase = SplitJobPhaseAbandoned
+	history.TerminalAtMs = 5000
+	historyRaw, err := EncodeSplitJob(history)
+	if err != nil {
+		t.Fatalf("encode history split job: %v", err)
+	}
+	if err := st.PutAt(ctx, CatalogSplitJobKey(live.JobID), liveRaw, 7, 0); err != nil {
+		t.Fatalf("put live split job: %v", err)
+	}
+	if err := st.PutAt(ctx, CatalogSplitJobHistoryKey(history.TerminalAtMs, history.JobID), historyRaw, 8, 0); err != nil {
+		t.Fatalf("put history split job: %v", err)
+	}
+
+	if err := cs.CreateSplitJob(ctx, sampleSplitJob(10)); err != nil {
+		t.Fatalf("create split job: %v", err)
+	}
+	next, err := cs.NextSplitJobID(ctx)
+	if err != nil {
+		t.Fatalf("next split job id: %v", err)
+	}
+	if next != 81 {
+		t.Fatalf("expected next split job id 81, got %d", next)
 	}
 }
 

--- a/proto/distribution.pb.go
+++ b/proto/distribution.pb.go
@@ -76,6 +76,180 @@ func (RouteState) EnumDescriptor() ([]byte, []int) {
 	return file_distribution_proto_rawDescGZIP(), []int{0}
 }
 
+type SplitJobPhase int32
+
+const (
+	SplitJobPhase_SPLIT_JOB_PHASE_NONE       SplitJobPhase = 0
+	SplitJobPhase_SPLIT_JOB_PHASE_PLANNED    SplitJobPhase = 1
+	SplitJobPhase_SPLIT_JOB_PHASE_BACKFILL   SplitJobPhase = 2
+	SplitJobPhase_SPLIT_JOB_PHASE_FENCE      SplitJobPhase = 3
+	SplitJobPhase_SPLIT_JOB_PHASE_DELTA_COPY SplitJobPhase = 4
+	SplitJobPhase_SPLIT_JOB_PHASE_CUTOVER    SplitJobPhase = 5
+	SplitJobPhase_SPLIT_JOB_PHASE_CLEANUP    SplitJobPhase = 6
+	SplitJobPhase_SPLIT_JOB_PHASE_DONE       SplitJobPhase = 7
+	SplitJobPhase_SPLIT_JOB_PHASE_FAILED     SplitJobPhase = 8
+	SplitJobPhase_SPLIT_JOB_PHASE_ABANDONING SplitJobPhase = 9
+	SplitJobPhase_SPLIT_JOB_PHASE_ABANDONED  SplitJobPhase = 10
+)
+
+// Enum value maps for SplitJobPhase.
+var (
+	SplitJobPhase_name = map[int32]string{
+		0:  "SPLIT_JOB_PHASE_NONE",
+		1:  "SPLIT_JOB_PHASE_PLANNED",
+		2:  "SPLIT_JOB_PHASE_BACKFILL",
+		3:  "SPLIT_JOB_PHASE_FENCE",
+		4:  "SPLIT_JOB_PHASE_DELTA_COPY",
+		5:  "SPLIT_JOB_PHASE_CUTOVER",
+		6:  "SPLIT_JOB_PHASE_CLEANUP",
+		7:  "SPLIT_JOB_PHASE_DONE",
+		8:  "SPLIT_JOB_PHASE_FAILED",
+		9:  "SPLIT_JOB_PHASE_ABANDONING",
+		10: "SPLIT_JOB_PHASE_ABANDONED",
+	}
+	SplitJobPhase_value = map[string]int32{
+		"SPLIT_JOB_PHASE_NONE":       0,
+		"SPLIT_JOB_PHASE_PLANNED":    1,
+		"SPLIT_JOB_PHASE_BACKFILL":   2,
+		"SPLIT_JOB_PHASE_FENCE":      3,
+		"SPLIT_JOB_PHASE_DELTA_COPY": 4,
+		"SPLIT_JOB_PHASE_CUTOVER":    5,
+		"SPLIT_JOB_PHASE_CLEANUP":    6,
+		"SPLIT_JOB_PHASE_DONE":       7,
+		"SPLIT_JOB_PHASE_FAILED":     8,
+		"SPLIT_JOB_PHASE_ABANDONING": 9,
+		"SPLIT_JOB_PHASE_ABANDONED":  10,
+	}
+)
+
+func (x SplitJobPhase) Enum() *SplitJobPhase {
+	p := new(SplitJobPhase)
+	*p = x
+	return p
+}
+
+func (x SplitJobPhase) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SplitJobPhase) Descriptor() protoreflect.EnumDescriptor {
+	return file_distribution_proto_enumTypes[1].Descriptor()
+}
+
+func (SplitJobPhase) Type() protoreflect.EnumType {
+	return &file_distribution_proto_enumTypes[1]
+}
+
+func (x SplitJobPhase) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SplitJobPhase.Descriptor instead.
+func (SplitJobPhase) EnumDescriptor() ([]byte, []int) {
+	return file_distribution_proto_rawDescGZIP(), []int{1}
+}
+
+type SplitJobBarrierState int32
+
+const (
+	SplitJobBarrierState_SPLIT_JOB_BARRIER_STATE_NONE     SplitJobBarrierState = 0
+	SplitJobBarrierState_SPLIT_JOB_BARRIER_STATE_ARMING   SplitJobBarrierState = 1
+	SplitJobBarrierState_SPLIT_JOB_BARRIER_STATE_ARMED    SplitJobBarrierState = 2
+	SplitJobBarrierState_SPLIT_JOB_BARRIER_STATE_CLEARING SplitJobBarrierState = 3
+)
+
+// Enum value maps for SplitJobBarrierState.
+var (
+	SplitJobBarrierState_name = map[int32]string{
+		0: "SPLIT_JOB_BARRIER_STATE_NONE",
+		1: "SPLIT_JOB_BARRIER_STATE_ARMING",
+		2: "SPLIT_JOB_BARRIER_STATE_ARMED",
+		3: "SPLIT_JOB_BARRIER_STATE_CLEARING",
+	}
+	SplitJobBarrierState_value = map[string]int32{
+		"SPLIT_JOB_BARRIER_STATE_NONE":     0,
+		"SPLIT_JOB_BARRIER_STATE_ARMING":   1,
+		"SPLIT_JOB_BARRIER_STATE_ARMED":    2,
+		"SPLIT_JOB_BARRIER_STATE_CLEARING": 3,
+	}
+)
+
+func (x SplitJobBarrierState) Enum() *SplitJobBarrierState {
+	p := new(SplitJobBarrierState)
+	*p = x
+	return p
+}
+
+func (x SplitJobBarrierState) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SplitJobBarrierState) Descriptor() protoreflect.EnumDescriptor {
+	return file_distribution_proto_enumTypes[2].Descriptor()
+}
+
+func (SplitJobBarrierState) Type() protoreflect.EnumType {
+	return &file_distribution_proto_enumTypes[2]
+}
+
+func (x SplitJobBarrierState) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SplitJobBarrierState.Descriptor instead.
+func (SplitJobBarrierState) EnumDescriptor() ([]byte, []int) {
+	return file_distribution_proto_rawDescGZIP(), []int{2}
+}
+
+type SplitJobExportPhase int32
+
+const (
+	SplitJobExportPhase_SPLIT_JOB_EXPORT_PHASE_NONE       SplitJobExportPhase = 0
+	SplitJobExportPhase_SPLIT_JOB_EXPORT_PHASE_BACKFILL   SplitJobExportPhase = 1
+	SplitJobExportPhase_SPLIT_JOB_EXPORT_PHASE_DELTA_COPY SplitJobExportPhase = 2
+)
+
+// Enum value maps for SplitJobExportPhase.
+var (
+	SplitJobExportPhase_name = map[int32]string{
+		0: "SPLIT_JOB_EXPORT_PHASE_NONE",
+		1: "SPLIT_JOB_EXPORT_PHASE_BACKFILL",
+		2: "SPLIT_JOB_EXPORT_PHASE_DELTA_COPY",
+	}
+	SplitJobExportPhase_value = map[string]int32{
+		"SPLIT_JOB_EXPORT_PHASE_NONE":       0,
+		"SPLIT_JOB_EXPORT_PHASE_BACKFILL":   1,
+		"SPLIT_JOB_EXPORT_PHASE_DELTA_COPY": 2,
+	}
+)
+
+func (x SplitJobExportPhase) Enum() *SplitJobExportPhase {
+	p := new(SplitJobExportPhase)
+	*p = x
+	return p
+}
+
+func (x SplitJobExportPhase) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SplitJobExportPhase) Descriptor() protoreflect.EnumDescriptor {
+	return file_distribution_proto_enumTypes[3].Descriptor()
+}
+
+func (SplitJobExportPhase) Type() protoreflect.EnumType {
+	return &file_distribution_proto_enumTypes[3]
+}
+
+func (x SplitJobExportPhase) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SplitJobExportPhase.Descriptor instead.
+func (SplitJobExportPhase) EnumDescriptor() ([]byte, []int) {
+	return file_distribution_proto_rawDescGZIP(), []int{3}
+}
+
 type GetRouteRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Key           []byte                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
@@ -346,6 +520,406 @@ func (x *RouteDescriptor) GetParentRouteId() uint64 {
 	return 0
 }
 
+type SplitJobBracketProgress struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	BracketId         uint64                 `protobuf:"varint,1,opt,name=bracket_id,json=bracketId,proto3" json:"bracket_id,omitempty"`
+	Family            uint32                 `protobuf:"varint,2,opt,name=family,proto3" json:"family,omitempty"`
+	ExportPhase       SplitJobExportPhase    `protobuf:"varint,3,opt,name=export_phase,json=exportPhase,proto3,enum=SplitJobExportPhase" json:"export_phase,omitempty"`
+	Cursor            []byte                 `protobuf:"bytes,4,opt,name=cursor,proto3" json:"cursor,omitempty"`
+	Done              bool                   `protobuf:"varint,5,opt,name=done,proto3" json:"done,omitempty"`
+	ScannedBytes      uint64                 `protobuf:"varint,6,opt,name=scanned_bytes,json=scannedBytes,proto3" json:"scanned_bytes,omitempty"`
+	AcceptedRows      uint64                 `protobuf:"varint,7,opt,name=accepted_rows,json=acceptedRows,proto3" json:"accepted_rows,omitempty"`
+	LastAckedBatchSeq uint64                 `protobuf:"varint,8,opt,name=last_acked_batch_seq,json=lastAckedBatchSeq,proto3" json:"last_acked_batch_seq,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *SplitJobBracketProgress) Reset() {
+	*x = SplitJobBracketProgress{}
+	mi := &file_distribution_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SplitJobBracketProgress) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SplitJobBracketProgress) ProtoMessage() {}
+
+func (x *SplitJobBracketProgress) ProtoReflect() protoreflect.Message {
+	mi := &file_distribution_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SplitJobBracketProgress.ProtoReflect.Descriptor instead.
+func (*SplitJobBracketProgress) Descriptor() ([]byte, []int) {
+	return file_distribution_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *SplitJobBracketProgress) GetBracketId() uint64 {
+	if x != nil {
+		return x.BracketId
+	}
+	return 0
+}
+
+func (x *SplitJobBracketProgress) GetFamily() uint32 {
+	if x != nil {
+		return x.Family
+	}
+	return 0
+}
+
+func (x *SplitJobBracketProgress) GetExportPhase() SplitJobExportPhase {
+	if x != nil {
+		return x.ExportPhase
+	}
+	return SplitJobExportPhase_SPLIT_JOB_EXPORT_PHASE_NONE
+}
+
+func (x *SplitJobBracketProgress) GetCursor() []byte {
+	if x != nil {
+		return x.Cursor
+	}
+	return nil
+}
+
+func (x *SplitJobBracketProgress) GetDone() bool {
+	if x != nil {
+		return x.Done
+	}
+	return false
+}
+
+func (x *SplitJobBracketProgress) GetScannedBytes() uint64 {
+	if x != nil {
+		return x.ScannedBytes
+	}
+	return 0
+}
+
+func (x *SplitJobBracketProgress) GetAcceptedRows() uint64 {
+	if x != nil {
+		return x.AcceptedRows
+	}
+	return 0
+}
+
+func (x *SplitJobBracketProgress) GetLastAckedBatchSeq() uint64 {
+	if x != nil {
+		return x.LastAckedBatchSeq
+	}
+	return 0
+}
+
+type SplitJob struct {
+	state                            protoimpl.MessageState     `protogen:"open.v1"`
+	JobId                            uint64                     `protobuf:"varint,1,opt,name=job_id,json=jobId,proto3" json:"job_id,omitempty"`
+	SourceRouteId                    uint64                     `protobuf:"varint,2,opt,name=source_route_id,json=sourceRouteId,proto3" json:"source_route_id,omitempty"`
+	SplitKey                         []byte                     `protobuf:"bytes,3,opt,name=split_key,json=splitKey,proto3" json:"split_key,omitempty"`
+	TargetGroupId                    uint64                     `protobuf:"varint,4,opt,name=target_group_id,json=targetGroupId,proto3" json:"target_group_id,omitempty"`
+	Phase                            SplitJobPhase              `protobuf:"varint,5,opt,name=phase,proto3,enum=SplitJobPhase" json:"phase,omitempty"`
+	RetryPhase                       SplitJobPhase              `protobuf:"varint,6,opt,name=retry_phase,json=retryPhase,proto3,enum=SplitJobPhase" json:"retry_phase,omitempty"`
+	AbandonFromPhase                 SplitJobPhase              `protobuf:"varint,7,opt,name=abandon_from_phase,json=abandonFromPhase,proto3,enum=SplitJobPhase" json:"abandon_from_phase,omitempty"`
+	SnapshotTs                       uint64                     `protobuf:"varint,8,opt,name=snapshot_ts,json=snapshotTs,proto3" json:"snapshot_ts,omitempty"`
+	SnapshotMinAdmittedTs            uint64                     `protobuf:"varint,9,opt,name=snapshot_min_admitted_ts,json=snapshotMinAdmittedTs,proto3" json:"snapshot_min_admitted_ts,omitempty"`
+	WriteTrackerArmed                bool                       `protobuf:"varint,10,opt,name=write_tracker_armed,json=writeTrackerArmed,proto3" json:"write_tracker_armed,omitempty"`
+	DeltaFloor                       uint64                     `protobuf:"varint,11,opt,name=delta_floor,json=deltaFloor,proto3" json:"delta_floor,omitempty"`
+	PostFenceDrainCompleted          bool                       `protobuf:"varint,12,opt,name=post_fence_drain_completed,json=postFenceDrainCompleted,proto3" json:"post_fence_drain_completed,omitempty"`
+	FenceTs                          uint64                     `protobuf:"varint,13,opt,name=fence_ts,json=fenceTs,proto3" json:"fence_ts,omitempty"`
+	CutoverVersion                   uint64                     `protobuf:"varint,14,opt,name=cutover_version,json=cutoverVersion,proto3" json:"cutover_version,omitempty"`
+	CutoverReadFenceState            SplitJobBarrierState       `protobuf:"varint,15,opt,name=cutover_read_fence_state,json=cutoverReadFenceState,proto3,enum=SplitJobBarrierState" json:"cutover_read_fence_state,omitempty"`
+	TargetStagedReadinessState       SplitJobBarrierState       `protobuf:"varint,16,opt,name=target_staged_readiness_state,json=targetStagedReadinessState,proto3,enum=SplitJobBarrierState" json:"target_staged_readiness_state,omitempty"`
+	SourceCutoverReadFenceAckCursor  []byte                     `protobuf:"bytes,17,opt,name=source_cutover_read_fence_ack_cursor,json=sourceCutoverReadFenceAckCursor,proto3" json:"source_cutover_read_fence_ack_cursor,omitempty"`
+	TargetStagedReadinessAckCursor   []byte                     `protobuf:"bytes,18,opt,name=target_staged_readiness_ack_cursor,json=targetStagedReadinessAckCursor,proto3" json:"target_staged_readiness_ack_cursor,omitempty"`
+	Cursor                           []byte                     `protobuf:"bytes,19,opt,name=cursor,proto3" json:"cursor,omitempty"`
+	MaxImportedTs                    uint64                     `protobuf:"varint,20,opt,name=max_imported_ts,json=maxImportedTs,proto3" json:"max_imported_ts,omitempty"`
+	TargetPromotionDone              bool                       `protobuf:"varint,21,opt,name=target_promotion_done,json=targetPromotionDone,proto3" json:"target_promotion_done,omitempty"`
+	PromotionCompletedTs             uint64                     `protobuf:"varint,22,opt,name=promotion_completed_ts,json=promotionCompletedTs,proto3" json:"promotion_completed_ts,omitempty"`
+	FenceCatalogVersion              uint64                     `protobuf:"varint,23,opt,name=fence_catalog_version,json=fenceCatalogVersion,proto3" json:"fence_catalog_version,omitempty"`
+	FenceAckCursor                   []byte                     `protobuf:"bytes,24,opt,name=fence_ack_cursor,json=fenceAckCursor,proto3" json:"fence_ack_cursor,omitempty"`
+	SourceCutoverAckCursor           []byte                     `protobuf:"bytes,25,opt,name=source_cutover_ack_cursor,json=sourceCutoverAckCursor,proto3" json:"source_cutover_ack_cursor,omitempty"`
+	SourceReadDrainCursor            []byte                     `protobuf:"bytes,26,opt,name=source_read_drain_cursor,json=sourceReadDrainCursor,proto3" json:"source_read_drain_cursor,omitempty"`
+	TargetClearedDescriptorAckCursor []byte                     `protobuf:"bytes,27,opt,name=target_cleared_descriptor_ack_cursor,json=targetClearedDescriptorAckCursor,proto3" json:"target_cleared_descriptor_ack_cursor,omitempty"`
+	BracketProgress                  []*SplitJobBracketProgress `protobuf:"bytes,28,rep,name=bracket_progress,json=bracketProgress,proto3" json:"bracket_progress,omitempty"`
+	SourceRetentionPinTs             uint64                     `protobuf:"varint,29,opt,name=source_retention_pin_ts,json=sourceRetentionPinTs,proto3" json:"source_retention_pin_ts,omitempty"`
+	LastError                        string                     `protobuf:"bytes,30,opt,name=last_error,json=lastError,proto3" json:"last_error,omitempty"`
+	StartedAtMs                      int64                      `protobuf:"varint,31,opt,name=started_at_ms,json=startedAtMs,proto3" json:"started_at_ms,omitempty"`
+	UpdatedAtMs                      int64                      `protobuf:"varint,32,opt,name=updated_at_ms,json=updatedAtMs,proto3" json:"updated_at_ms,omitempty"`
+	TerminalAtMs                     int64                      `protobuf:"varint,33,opt,name=terminal_at_ms,json=terminalAtMs,proto3" json:"terminal_at_ms,omitempty"`
+	unknownFields                    protoimpl.UnknownFields
+	sizeCache                        protoimpl.SizeCache
+}
+
+func (x *SplitJob) Reset() {
+	*x = SplitJob{}
+	mi := &file_distribution_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SplitJob) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SplitJob) ProtoMessage() {}
+
+func (x *SplitJob) ProtoReflect() protoreflect.Message {
+	mi := &file_distribution_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SplitJob.ProtoReflect.Descriptor instead.
+func (*SplitJob) Descriptor() ([]byte, []int) {
+	return file_distribution_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *SplitJob) GetJobId() uint64 {
+	if x != nil {
+		return x.JobId
+	}
+	return 0
+}
+
+func (x *SplitJob) GetSourceRouteId() uint64 {
+	if x != nil {
+		return x.SourceRouteId
+	}
+	return 0
+}
+
+func (x *SplitJob) GetSplitKey() []byte {
+	if x != nil {
+		return x.SplitKey
+	}
+	return nil
+}
+
+func (x *SplitJob) GetTargetGroupId() uint64 {
+	if x != nil {
+		return x.TargetGroupId
+	}
+	return 0
+}
+
+func (x *SplitJob) GetPhase() SplitJobPhase {
+	if x != nil {
+		return x.Phase
+	}
+	return SplitJobPhase_SPLIT_JOB_PHASE_NONE
+}
+
+func (x *SplitJob) GetRetryPhase() SplitJobPhase {
+	if x != nil {
+		return x.RetryPhase
+	}
+	return SplitJobPhase_SPLIT_JOB_PHASE_NONE
+}
+
+func (x *SplitJob) GetAbandonFromPhase() SplitJobPhase {
+	if x != nil {
+		return x.AbandonFromPhase
+	}
+	return SplitJobPhase_SPLIT_JOB_PHASE_NONE
+}
+
+func (x *SplitJob) GetSnapshotTs() uint64 {
+	if x != nil {
+		return x.SnapshotTs
+	}
+	return 0
+}
+
+func (x *SplitJob) GetSnapshotMinAdmittedTs() uint64 {
+	if x != nil {
+		return x.SnapshotMinAdmittedTs
+	}
+	return 0
+}
+
+func (x *SplitJob) GetWriteTrackerArmed() bool {
+	if x != nil {
+		return x.WriteTrackerArmed
+	}
+	return false
+}
+
+func (x *SplitJob) GetDeltaFloor() uint64 {
+	if x != nil {
+		return x.DeltaFloor
+	}
+	return 0
+}
+
+func (x *SplitJob) GetPostFenceDrainCompleted() bool {
+	if x != nil {
+		return x.PostFenceDrainCompleted
+	}
+	return false
+}
+
+func (x *SplitJob) GetFenceTs() uint64 {
+	if x != nil {
+		return x.FenceTs
+	}
+	return 0
+}
+
+func (x *SplitJob) GetCutoverVersion() uint64 {
+	if x != nil {
+		return x.CutoverVersion
+	}
+	return 0
+}
+
+func (x *SplitJob) GetCutoverReadFenceState() SplitJobBarrierState {
+	if x != nil {
+		return x.CutoverReadFenceState
+	}
+	return SplitJobBarrierState_SPLIT_JOB_BARRIER_STATE_NONE
+}
+
+func (x *SplitJob) GetTargetStagedReadinessState() SplitJobBarrierState {
+	if x != nil {
+		return x.TargetStagedReadinessState
+	}
+	return SplitJobBarrierState_SPLIT_JOB_BARRIER_STATE_NONE
+}
+
+func (x *SplitJob) GetSourceCutoverReadFenceAckCursor() []byte {
+	if x != nil {
+		return x.SourceCutoverReadFenceAckCursor
+	}
+	return nil
+}
+
+func (x *SplitJob) GetTargetStagedReadinessAckCursor() []byte {
+	if x != nil {
+		return x.TargetStagedReadinessAckCursor
+	}
+	return nil
+}
+
+func (x *SplitJob) GetCursor() []byte {
+	if x != nil {
+		return x.Cursor
+	}
+	return nil
+}
+
+func (x *SplitJob) GetMaxImportedTs() uint64 {
+	if x != nil {
+		return x.MaxImportedTs
+	}
+	return 0
+}
+
+func (x *SplitJob) GetTargetPromotionDone() bool {
+	if x != nil {
+		return x.TargetPromotionDone
+	}
+	return false
+}
+
+func (x *SplitJob) GetPromotionCompletedTs() uint64 {
+	if x != nil {
+		return x.PromotionCompletedTs
+	}
+	return 0
+}
+
+func (x *SplitJob) GetFenceCatalogVersion() uint64 {
+	if x != nil {
+		return x.FenceCatalogVersion
+	}
+	return 0
+}
+
+func (x *SplitJob) GetFenceAckCursor() []byte {
+	if x != nil {
+		return x.FenceAckCursor
+	}
+	return nil
+}
+
+func (x *SplitJob) GetSourceCutoverAckCursor() []byte {
+	if x != nil {
+		return x.SourceCutoverAckCursor
+	}
+	return nil
+}
+
+func (x *SplitJob) GetSourceReadDrainCursor() []byte {
+	if x != nil {
+		return x.SourceReadDrainCursor
+	}
+	return nil
+}
+
+func (x *SplitJob) GetTargetClearedDescriptorAckCursor() []byte {
+	if x != nil {
+		return x.TargetClearedDescriptorAckCursor
+	}
+	return nil
+}
+
+func (x *SplitJob) GetBracketProgress() []*SplitJobBracketProgress {
+	if x != nil {
+		return x.BracketProgress
+	}
+	return nil
+}
+
+func (x *SplitJob) GetSourceRetentionPinTs() uint64 {
+	if x != nil {
+		return x.SourceRetentionPinTs
+	}
+	return 0
+}
+
+func (x *SplitJob) GetLastError() string {
+	if x != nil {
+		return x.LastError
+	}
+	return ""
+}
+
+func (x *SplitJob) GetStartedAtMs() int64 {
+	if x != nil {
+		return x.StartedAtMs
+	}
+	return 0
+}
+
+func (x *SplitJob) GetUpdatedAtMs() int64 {
+	if x != nil {
+		return x.UpdatedAtMs
+	}
+	return 0
+}
+
+func (x *SplitJob) GetTerminalAtMs() int64 {
+	if x != nil {
+		return x.TerminalAtMs
+	}
+	return 0
+}
+
 type ListRoutesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -354,7 +928,7 @@ type ListRoutesRequest struct {
 
 func (x *ListRoutesRequest) Reset() {
 	*x = ListRoutesRequest{}
-	mi := &file_distribution_proto_msgTypes[5]
+	mi := &file_distribution_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -366,7 +940,7 @@ func (x *ListRoutesRequest) String() string {
 func (*ListRoutesRequest) ProtoMessage() {}
 
 func (x *ListRoutesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_distribution_proto_msgTypes[5]
+	mi := &file_distribution_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -379,7 +953,7 @@ func (x *ListRoutesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoutesRequest.ProtoReflect.Descriptor instead.
 func (*ListRoutesRequest) Descriptor() ([]byte, []int) {
-	return file_distribution_proto_rawDescGZIP(), []int{5}
+	return file_distribution_proto_rawDescGZIP(), []int{7}
 }
 
 type ListRoutesResponse struct {
@@ -392,7 +966,7 @@ type ListRoutesResponse struct {
 
 func (x *ListRoutesResponse) Reset() {
 	*x = ListRoutesResponse{}
-	mi := &file_distribution_proto_msgTypes[6]
+	mi := &file_distribution_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -404,7 +978,7 @@ func (x *ListRoutesResponse) String() string {
 func (*ListRoutesResponse) ProtoMessage() {}
 
 func (x *ListRoutesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_distribution_proto_msgTypes[6]
+	mi := &file_distribution_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -417,7 +991,7 @@ func (x *ListRoutesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRoutesResponse.ProtoReflect.Descriptor instead.
 func (*ListRoutesResponse) Descriptor() ([]byte, []int) {
-	return file_distribution_proto_rawDescGZIP(), []int{6}
+	return file_distribution_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ListRoutesResponse) GetCatalogVersion() uint64 {
@@ -445,7 +1019,7 @@ type SplitRangeRequest struct {
 
 func (x *SplitRangeRequest) Reset() {
 	*x = SplitRangeRequest{}
-	mi := &file_distribution_proto_msgTypes[7]
+	mi := &file_distribution_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -457,7 +1031,7 @@ func (x *SplitRangeRequest) String() string {
 func (*SplitRangeRequest) ProtoMessage() {}
 
 func (x *SplitRangeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_distribution_proto_msgTypes[7]
+	mi := &file_distribution_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -470,7 +1044,7 @@ func (x *SplitRangeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SplitRangeRequest.ProtoReflect.Descriptor instead.
 func (*SplitRangeRequest) Descriptor() ([]byte, []int) {
-	return file_distribution_proto_rawDescGZIP(), []int{7}
+	return file_distribution_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *SplitRangeRequest) GetExpectedCatalogVersion() uint64 {
@@ -505,7 +1079,7 @@ type SplitRangeResponse struct {
 
 func (x *SplitRangeResponse) Reset() {
 	*x = SplitRangeResponse{}
-	mi := &file_distribution_proto_msgTypes[8]
+	mi := &file_distribution_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -517,7 +1091,7 @@ func (x *SplitRangeResponse) String() string {
 func (*SplitRangeResponse) ProtoMessage() {}
 
 func (x *SplitRangeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_distribution_proto_msgTypes[8]
+	mi := &file_distribution_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -530,7 +1104,7 @@ func (x *SplitRangeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SplitRangeResponse.ProtoReflect.Descriptor instead.
 func (*SplitRangeResponse) Descriptor() ([]byte, []int) {
-	return file_distribution_proto_rawDescGZIP(), []int{8}
+	return file_distribution_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *SplitRangeResponse) GetCatalogVersion() uint64 {
@@ -574,7 +1148,56 @@ const file_distribution_proto_rawDesc = "" +
 	"\x03end\x18\x03 \x01(\fR\x03end\x12\"\n" +
 	"\rraft_group_id\x18\x04 \x01(\x04R\vraftGroupId\x12!\n" +
 	"\x05state\x18\x05 \x01(\x0e2\v.RouteStateR\x05state\x12&\n" +
-	"\x0fparent_route_id\x18\x06 \x01(\x04R\rparentRouteId\"\x13\n" +
+	"\x0fparent_route_id\x18\x06 \x01(\x04R\rparentRouteId\"\xb0\x02\n" +
+	"\x17SplitJobBracketProgress\x12\x1d\n" +
+	"\n" +
+	"bracket_id\x18\x01 \x01(\x04R\tbracketId\x12\x16\n" +
+	"\x06family\x18\x02 \x01(\rR\x06family\x127\n" +
+	"\fexport_phase\x18\x03 \x01(\x0e2\x14.SplitJobExportPhaseR\vexportPhase\x12\x16\n" +
+	"\x06cursor\x18\x04 \x01(\fR\x06cursor\x12\x12\n" +
+	"\x04done\x18\x05 \x01(\bR\x04done\x12#\n" +
+	"\rscanned_bytes\x18\x06 \x01(\x04R\fscannedBytes\x12#\n" +
+	"\raccepted_rows\x18\a \x01(\x04R\facceptedRows\x12/\n" +
+	"\x14last_acked_batch_seq\x18\b \x01(\x04R\x11lastAckedBatchSeq\"\xe9\f\n" +
+	"\bSplitJob\x12\x15\n" +
+	"\x06job_id\x18\x01 \x01(\x04R\x05jobId\x12&\n" +
+	"\x0fsource_route_id\x18\x02 \x01(\x04R\rsourceRouteId\x12\x1b\n" +
+	"\tsplit_key\x18\x03 \x01(\fR\bsplitKey\x12&\n" +
+	"\x0ftarget_group_id\x18\x04 \x01(\x04R\rtargetGroupId\x12$\n" +
+	"\x05phase\x18\x05 \x01(\x0e2\x0e.SplitJobPhaseR\x05phase\x12/\n" +
+	"\vretry_phase\x18\x06 \x01(\x0e2\x0e.SplitJobPhaseR\n" +
+	"retryPhase\x12<\n" +
+	"\x12abandon_from_phase\x18\a \x01(\x0e2\x0e.SplitJobPhaseR\x10abandonFromPhase\x12\x1f\n" +
+	"\vsnapshot_ts\x18\b \x01(\x04R\n" +
+	"snapshotTs\x127\n" +
+	"\x18snapshot_min_admitted_ts\x18\t \x01(\x04R\x15snapshotMinAdmittedTs\x12.\n" +
+	"\x13write_tracker_armed\x18\n" +
+	" \x01(\bR\x11writeTrackerArmed\x12\x1f\n" +
+	"\vdelta_floor\x18\v \x01(\x04R\n" +
+	"deltaFloor\x12;\n" +
+	"\x1apost_fence_drain_completed\x18\f \x01(\bR\x17postFenceDrainCompleted\x12\x19\n" +
+	"\bfence_ts\x18\r \x01(\x04R\afenceTs\x12'\n" +
+	"\x0fcutover_version\x18\x0e \x01(\x04R\x0ecutoverVersion\x12N\n" +
+	"\x18cutover_read_fence_state\x18\x0f \x01(\x0e2\x15.SplitJobBarrierStateR\x15cutoverReadFenceState\x12X\n" +
+	"\x1dtarget_staged_readiness_state\x18\x10 \x01(\x0e2\x15.SplitJobBarrierStateR\x1atargetStagedReadinessState\x12M\n" +
+	"$source_cutover_read_fence_ack_cursor\x18\x11 \x01(\fR\x1fsourceCutoverReadFenceAckCursor\x12J\n" +
+	"\"target_staged_readiness_ack_cursor\x18\x12 \x01(\fR\x1etargetStagedReadinessAckCursor\x12\x16\n" +
+	"\x06cursor\x18\x13 \x01(\fR\x06cursor\x12&\n" +
+	"\x0fmax_imported_ts\x18\x14 \x01(\x04R\rmaxImportedTs\x122\n" +
+	"\x15target_promotion_done\x18\x15 \x01(\bR\x13targetPromotionDone\x124\n" +
+	"\x16promotion_completed_ts\x18\x16 \x01(\x04R\x14promotionCompletedTs\x122\n" +
+	"\x15fence_catalog_version\x18\x17 \x01(\x04R\x13fenceCatalogVersion\x12(\n" +
+	"\x10fence_ack_cursor\x18\x18 \x01(\fR\x0efenceAckCursor\x129\n" +
+	"\x19source_cutover_ack_cursor\x18\x19 \x01(\fR\x16sourceCutoverAckCursor\x127\n" +
+	"\x18source_read_drain_cursor\x18\x1a \x01(\fR\x15sourceReadDrainCursor\x12N\n" +
+	"$target_cleared_descriptor_ack_cursor\x18\x1b \x01(\fR targetClearedDescriptorAckCursor\x12C\n" +
+	"\x10bracket_progress\x18\x1c \x03(\v2\x18.SplitJobBracketProgressR\x0fbracketProgress\x125\n" +
+	"\x17source_retention_pin_ts\x18\x1d \x01(\x04R\x14sourceRetentionPinTs\x12\x1d\n" +
+	"\n" +
+	"last_error\x18\x1e \x01(\tR\tlastError\x12\"\n" +
+	"\rstarted_at_ms\x18\x1f \x01(\x03R\vstartedAtMs\x12\"\n" +
+	"\rupdated_at_ms\x18  \x01(\x03R\vupdatedAtMs\x12$\n" +
+	"\x0eterminal_at_ms\x18! \x01(\x03R\fterminalAtMs\"\x13\n" +
 	"\x11ListRoutesRequest\"g\n" +
 	"\x12ListRoutesResponse\x12'\n" +
 	"\x0fcatalog_version\x18\x01 \x01(\x04R\x0ecatalogVersion\x12(\n" +
@@ -593,7 +1216,29 @@ const file_distribution_proto_rawDesc = "" +
 	"\x12ROUTE_STATE_ACTIVE\x10\x01\x12\x1c\n" +
 	"\x18ROUTE_STATE_WRITE_FENCED\x10\x02\x12 \n" +
 	"\x1cROUTE_STATE_MIGRATING_SOURCE\x10\x03\x12 \n" +
-	"\x1cROUTE_STATE_MIGRATING_TARGET\x10\x042\xf2\x01\n" +
+	"\x1cROUTE_STATE_MIGRATING_TARGET\x10\x04*\xce\x02\n" +
+	"\rSplitJobPhase\x12\x18\n" +
+	"\x14SPLIT_JOB_PHASE_NONE\x10\x00\x12\x1b\n" +
+	"\x17SPLIT_JOB_PHASE_PLANNED\x10\x01\x12\x1c\n" +
+	"\x18SPLIT_JOB_PHASE_BACKFILL\x10\x02\x12\x19\n" +
+	"\x15SPLIT_JOB_PHASE_FENCE\x10\x03\x12\x1e\n" +
+	"\x1aSPLIT_JOB_PHASE_DELTA_COPY\x10\x04\x12\x1b\n" +
+	"\x17SPLIT_JOB_PHASE_CUTOVER\x10\x05\x12\x1b\n" +
+	"\x17SPLIT_JOB_PHASE_CLEANUP\x10\x06\x12\x18\n" +
+	"\x14SPLIT_JOB_PHASE_DONE\x10\a\x12\x1a\n" +
+	"\x16SPLIT_JOB_PHASE_FAILED\x10\b\x12\x1e\n" +
+	"\x1aSPLIT_JOB_PHASE_ABANDONING\x10\t\x12\x1d\n" +
+	"\x19SPLIT_JOB_PHASE_ABANDONED\x10\n" +
+	"*\xa5\x01\n" +
+	"\x14SplitJobBarrierState\x12 \n" +
+	"\x1cSPLIT_JOB_BARRIER_STATE_NONE\x10\x00\x12\"\n" +
+	"\x1eSPLIT_JOB_BARRIER_STATE_ARMING\x10\x01\x12!\n" +
+	"\x1dSPLIT_JOB_BARRIER_STATE_ARMED\x10\x02\x12$\n" +
+	" SPLIT_JOB_BARRIER_STATE_CLEARING\x10\x03*\x82\x01\n" +
+	"\x13SplitJobExportPhase\x12\x1f\n" +
+	"\x1bSPLIT_JOB_EXPORT_PHASE_NONE\x10\x00\x12#\n" +
+	"\x1fSPLIT_JOB_EXPORT_PHASE_BACKFILL\x10\x01\x12%\n" +
+	"!SPLIT_JOB_EXPORT_PHASE_DELTA_COPY\x10\x022\xf2\x01\n" +
 	"\fDistribution\x121\n" +
 	"\bGetRoute\x12\x10.GetRouteRequest\x1a\x11.GetRouteResponse\"\x00\x12=\n" +
 	"\fGetTimestamp\x12\x14.GetTimestampRequest\x1a\x15.GetTimestampResponse\"\x00\x127\n" +
@@ -614,38 +1259,50 @@ func file_distribution_proto_rawDescGZIP() []byte {
 	return file_distribution_proto_rawDescData
 }
 
-var file_distribution_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_distribution_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_distribution_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_distribution_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_distribution_proto_goTypes = []any{
-	(RouteState)(0),              // 0: RouteState
-	(*GetRouteRequest)(nil),      // 1: GetRouteRequest
-	(*GetRouteResponse)(nil),     // 2: GetRouteResponse
-	(*GetTimestampRequest)(nil),  // 3: GetTimestampRequest
-	(*GetTimestampResponse)(nil), // 4: GetTimestampResponse
-	(*RouteDescriptor)(nil),      // 5: RouteDescriptor
-	(*ListRoutesRequest)(nil),    // 6: ListRoutesRequest
-	(*ListRoutesResponse)(nil),   // 7: ListRoutesResponse
-	(*SplitRangeRequest)(nil),    // 8: SplitRangeRequest
-	(*SplitRangeResponse)(nil),   // 9: SplitRangeResponse
+	(RouteState)(0),                 // 0: RouteState
+	(SplitJobPhase)(0),              // 1: SplitJobPhase
+	(SplitJobBarrierState)(0),       // 2: SplitJobBarrierState
+	(SplitJobExportPhase)(0),        // 3: SplitJobExportPhase
+	(*GetRouteRequest)(nil),         // 4: GetRouteRequest
+	(*GetRouteResponse)(nil),        // 5: GetRouteResponse
+	(*GetTimestampRequest)(nil),     // 6: GetTimestampRequest
+	(*GetTimestampResponse)(nil),    // 7: GetTimestampResponse
+	(*RouteDescriptor)(nil),         // 8: RouteDescriptor
+	(*SplitJobBracketProgress)(nil), // 9: SplitJobBracketProgress
+	(*SplitJob)(nil),                // 10: SplitJob
+	(*ListRoutesRequest)(nil),       // 11: ListRoutesRequest
+	(*ListRoutesResponse)(nil),      // 12: ListRoutesResponse
+	(*SplitRangeRequest)(nil),       // 13: SplitRangeRequest
+	(*SplitRangeResponse)(nil),      // 14: SplitRangeResponse
 }
 var file_distribution_proto_depIdxs = []int32{
-	0, // 0: RouteDescriptor.state:type_name -> RouteState
-	5, // 1: ListRoutesResponse.routes:type_name -> RouteDescriptor
-	5, // 2: SplitRangeResponse.left:type_name -> RouteDescriptor
-	5, // 3: SplitRangeResponse.right:type_name -> RouteDescriptor
-	1, // 4: Distribution.GetRoute:input_type -> GetRouteRequest
-	3, // 5: Distribution.GetTimestamp:input_type -> GetTimestampRequest
-	6, // 6: Distribution.ListRoutes:input_type -> ListRoutesRequest
-	8, // 7: Distribution.SplitRange:input_type -> SplitRangeRequest
-	2, // 8: Distribution.GetRoute:output_type -> GetRouteResponse
-	4, // 9: Distribution.GetTimestamp:output_type -> GetTimestampResponse
-	7, // 10: Distribution.ListRoutes:output_type -> ListRoutesResponse
-	9, // 11: Distribution.SplitRange:output_type -> SplitRangeResponse
-	8, // [8:12] is the sub-list for method output_type
-	4, // [4:8] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	0,  // 0: RouteDescriptor.state:type_name -> RouteState
+	3,  // 1: SplitJobBracketProgress.export_phase:type_name -> SplitJobExportPhase
+	1,  // 2: SplitJob.phase:type_name -> SplitJobPhase
+	1,  // 3: SplitJob.retry_phase:type_name -> SplitJobPhase
+	1,  // 4: SplitJob.abandon_from_phase:type_name -> SplitJobPhase
+	2,  // 5: SplitJob.cutover_read_fence_state:type_name -> SplitJobBarrierState
+	2,  // 6: SplitJob.target_staged_readiness_state:type_name -> SplitJobBarrierState
+	9,  // 7: SplitJob.bracket_progress:type_name -> SplitJobBracketProgress
+	8,  // 8: ListRoutesResponse.routes:type_name -> RouteDescriptor
+	8,  // 9: SplitRangeResponse.left:type_name -> RouteDescriptor
+	8,  // 10: SplitRangeResponse.right:type_name -> RouteDescriptor
+	4,  // 11: Distribution.GetRoute:input_type -> GetRouteRequest
+	6,  // 12: Distribution.GetTimestamp:input_type -> GetTimestampRequest
+	11, // 13: Distribution.ListRoutes:input_type -> ListRoutesRequest
+	13, // 14: Distribution.SplitRange:input_type -> SplitRangeRequest
+	5,  // 15: Distribution.GetRoute:output_type -> GetRouteResponse
+	7,  // 16: Distribution.GetTimestamp:output_type -> GetTimestampResponse
+	12, // 17: Distribution.ListRoutes:output_type -> ListRoutesResponse
+	14, // 18: Distribution.SplitRange:output_type -> SplitRangeResponse
+	15, // [15:19] is the sub-list for method output_type
+	11, // [11:15] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_distribution_proto_init() }
@@ -658,8 +1315,8 @@ func file_distribution_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_distribution_proto_rawDesc), len(file_distribution_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   9,
+			NumEnums:      4,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/distribution.proto
+++ b/proto/distribution.proto
@@ -44,6 +44,80 @@ message RouteDescriptor {
   uint64 parent_route_id = 6;
 }
 
+enum SplitJobPhase {
+  SPLIT_JOB_PHASE_NONE = 0;
+  SPLIT_JOB_PHASE_PLANNED = 1;
+  SPLIT_JOB_PHASE_BACKFILL = 2;
+  SPLIT_JOB_PHASE_FENCE = 3;
+  SPLIT_JOB_PHASE_DELTA_COPY = 4;
+  SPLIT_JOB_PHASE_CUTOVER = 5;
+  SPLIT_JOB_PHASE_CLEANUP = 6;
+  SPLIT_JOB_PHASE_DONE = 7;
+  SPLIT_JOB_PHASE_FAILED = 8;
+  SPLIT_JOB_PHASE_ABANDONING = 9;
+  SPLIT_JOB_PHASE_ABANDONED = 10;
+}
+
+enum SplitJobBarrierState {
+  SPLIT_JOB_BARRIER_STATE_NONE = 0;
+  SPLIT_JOB_BARRIER_STATE_ARMING = 1;
+  SPLIT_JOB_BARRIER_STATE_ARMED = 2;
+  SPLIT_JOB_BARRIER_STATE_CLEARING = 3;
+}
+
+enum SplitJobExportPhase {
+  SPLIT_JOB_EXPORT_PHASE_NONE = 0;
+  SPLIT_JOB_EXPORT_PHASE_BACKFILL = 1;
+  SPLIT_JOB_EXPORT_PHASE_DELTA_COPY = 2;
+}
+
+message SplitJobBracketProgress {
+  uint64 bracket_id = 1;
+  uint32 family = 2;
+  SplitJobExportPhase export_phase = 3;
+  bytes cursor = 4;
+  bool done = 5;
+  uint64 scanned_bytes = 6;
+  uint64 accepted_rows = 7;
+  uint64 last_acked_batch_seq = 8;
+}
+
+message SplitJob {
+  uint64 job_id = 1;
+  uint64 source_route_id = 2;
+  bytes split_key = 3;
+  uint64 target_group_id = 4;
+  SplitJobPhase phase = 5;
+  SplitJobPhase retry_phase = 6;
+  SplitJobPhase abandon_from_phase = 7;
+  uint64 snapshot_ts = 8;
+  uint64 snapshot_min_admitted_ts = 9;
+  bool write_tracker_armed = 10;
+  uint64 delta_floor = 11;
+  bool post_fence_drain_completed = 12;
+  uint64 fence_ts = 13;
+  uint64 cutover_version = 14;
+  SplitJobBarrierState cutover_read_fence_state = 15;
+  SplitJobBarrierState target_staged_readiness_state = 16;
+  bytes source_cutover_read_fence_ack_cursor = 17;
+  bytes target_staged_readiness_ack_cursor = 18;
+  bytes cursor = 19;
+  uint64 max_imported_ts = 20;
+  bool target_promotion_done = 21;
+  uint64 promotion_completed_ts = 22;
+  uint64 fence_catalog_version = 23;
+  bytes fence_ack_cursor = 24;
+  bytes source_cutover_ack_cursor = 25;
+  bytes source_read_drain_cursor = 26;
+  bytes target_cleared_descriptor_ack_cursor = 27;
+  repeated SplitJobBracketProgress bracket_progress = 28;
+  uint64 source_retention_pin_ts = 29;
+  string last_error = 30;
+  int64 started_at_ms = 31;
+  int64 updated_at_ms = 32;
+  int64 terminal_at_ms = 33;
+}
+
 message ListRoutesRequest {}
 
 message ListRoutesResponse {


### PR DESCRIPTION
Author: bootjp

## Summary
- Add SplitJob durable proto messages and catalog codec for hotspot split M2.
- Add reserved key helpers for next_job_id, live jobs, and history jobs.
- Add CatalogStore helpers for live/history read, list, save, delete, and history moves.

## Tests
- make -C proto gen
- go test ./distribution ./proto -count=1 -timeout=120s
- golangci-lint run ./distribution ./proto --timeout=5m
- go test ./adapter -run 'TestDistributionServer|TestMilestone1SplitRange' -count=1 -timeout=180s
- go test ./kv ./store ./internal/... ./cmd/... -count=1 -timeout=180s
- go test . -count=1 -timeout=180s

## Note
- go test ./... was attempted, but the full adapter package run timed out; focused adapter distribution tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 分割ジョブの状態、進行状況、エクスポート段階を新たに管理できるようになりました。
  * 分割ジョブの保存、取得、一覧表示、履歴への移行、削除に対応しました。
  * ジョブIDの自動採番と、過去時点の参照に対応しました（メタ欠損時のフォールバック含む）。

* **テスト**
  * 保存・取得・一覧・履歴移行・削除、ID採番の境界条件や競合、無効データ拒否を網羅するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->