### PR TITLE
Add migration bracket planner

### DIFF
--- a/adapter/redis_compat_commands_stream_test.go
+++ b/adapter/redis_compat_commands_stream_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -286,13 +287,7 @@ func TestRedis_StreamXReadLatencyIsConstant(t *testing.T) {
 	)
 	lastID := ""
 	for i := range total {
-		id, err := rdb.XAdd(ctx, &redis.XAddArgs{
-			Stream: "stream-lat",
-			ID:     "*",
-			Values: []string{"i", fmt.Sprint(i)},
-		}).Result()
-		require.NoError(t, err)
-		lastID = id
+		lastID = xaddStreamLatencySeed(t, ctx, rdb, fmt.Sprint(i))
 	}
 
 	measure := func() time.Duration {
@@ -346,6 +341,34 @@ func TestRedis_StreamXReadLatencyIsConstant(t *testing.T) {
 	require.LessOrEqualf(t, p95, p95Ceiling,
 		"XREAD p95 latency should not grow with stream size: baseline=%s median=%s p95=%s",
 		baseline, median, p95)
+}
+
+func xaddStreamLatencySeed(t *testing.T, ctx context.Context, rdb *redis.Client, value string) string {
+	t.Helper()
+
+	const maxAttempts = 10
+	for attempt := range maxAttempts {
+		id, err := rdb.XAdd(ctx, &redis.XAddArgs{
+			Stream: "stream-lat",
+			ID:     "*",
+			Values: []string{"i", value},
+		}).Result()
+		if err == nil {
+			return id
+		}
+		if attempt == maxAttempts-1 || !isRetryableStreamLatencySeedErr(err) {
+			require.NoError(t, err)
+		}
+		time.Sleep(time.Duration(attempt+1) * leaderChurnRetryInterval)
+	}
+	return ""
+}
+
+func isRetryableStreamLatencySeedErr(err error) bool {
+	if err == nil || isTransientNotLeaderErr(err) {
+		return err != nil
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "write conflict")
 }
 
 func TestRedis_StreamXTrimMaxLen(t *testing.T) {

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -267,16 +267,33 @@ func (r *RedisServer) probeListType(ctx context.Context, key []byte, readTS uint
 	if metaExists {
 		return redisTypeList, true, nil
 	}
-	deltaPrefix := store.ListMetaDeltaScanPrefix(key)
-	deltaEnd := store.PrefixScanEnd(deltaPrefix)
-	deltaKVs, err := r.store.ScanAt(ctx, deltaPrefix, deltaEnd, 1, readTS)
-	if err != nil {
-		return redisTypeNone, false, errors.WithStack(err)
-	}
-	if len(deltaKVs) > 0 {
-		return redisTypeList, true, nil
+	for _, deltaPrefix := range store.ListMetaDeltaScanPrefixes(key) {
+		found, err := r.listMetaDeltaExistsAt(ctx, key, deltaPrefix, readTS)
+		if err != nil {
+			return redisTypeNone, false, err
+		}
+		if found {
+			return redisTypeList, true, nil
+		}
 	}
 	return redisTypeNone, false, nil
+}
+
+func (r *RedisServer) listMetaDeltaExistsAt(ctx context.Context, key []byte, deltaPrefix []byte, readTS uint64) (bool, error) {
+	deltaEnd := store.PrefixScanEnd(deltaPrefix)
+	deltaKVs, err := r.store.ScanAt(ctx, deltaPrefix, deltaEnd, store.MaxDeltaScanLimit, readTS)
+	if err != nil {
+		return false, errors.WithStack(err)
+	}
+	if !isLegacyListMetaDeltaPrefix(deltaPrefix) {
+		return len(deltaKVs) > 0, nil
+	}
+	for _, pair := range deltaKVs {
+		if legacyListDeltaPairForUserKey(pair, key) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // probeLegacyCollectionTypes checks for single-blob hash/set/zset/stream
@@ -927,7 +944,7 @@ func (r *RedisServer) deleteListElems(ctx context.Context, key []byte, readTS ui
 	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: listMetaKey(key)})
 	// Delete all delta keys (paginated), including the pre-upgrade prefix.
 	for _, deltaPrefix := range store.ListMetaDeltaScanPrefixes(key) {
-		deltaElems, err := r.scanAllDeltaElems(ctx, deltaPrefix, readTS)
+		deltaElems, err := r.scanListDeltaDelElems(ctx, key, deltaPrefix, readTS)
 		if err != nil {
 			return nil, err
 		}
@@ -979,6 +996,24 @@ func (r *RedisServer) scanListItemDelElems(ctx context.Context, key []byte, read
 // MaxDeltaScanLimit entries. Total results are capped at maxWideColumnItems
 // to prevent unbounded memory growth if the compactor falls behind.
 func (r *RedisServer) scanAllDeltaElems(ctx context.Context, deltaPrefix []byte, readTS uint64) ([]*kv.Elem[kv.OP], error) {
+	return r.scanAllDeltaElemsFiltered(ctx, deltaPrefix, readTS, nil)
+}
+
+func (r *RedisServer) scanListDeltaDelElems(ctx context.Context, key []byte, deltaPrefix []byte, readTS uint64) ([]*kv.Elem[kv.OP], error) {
+	if !isLegacyListMetaDeltaPrefix(deltaPrefix) {
+		return r.scanAllDeltaElems(ctx, deltaPrefix, readTS)
+	}
+	return r.scanAllDeltaElemsFiltered(ctx, deltaPrefix, readTS, func(pair *store.KVPair) bool {
+		return legacyListDeltaPairForUserKey(pair, key)
+	})
+}
+
+func (r *RedisServer) scanAllDeltaElemsFiltered(
+	ctx context.Context,
+	deltaPrefix []byte,
+	readTS uint64,
+	include func(*store.KVPair) bool,
+) ([]*kv.Elem[kv.OP], error) {
 	const cursorAdv = byte(0x00) // appended to advance past the last scanned key
 	var elems []*kv.Elem[kv.OP]
 	deltaEnd := store.PrefixScanEnd(deltaPrefix)
@@ -988,12 +1023,14 @@ func (r *RedisServer) scanAllDeltaElems(ctx context.Context, deltaPrefix []byte,
 		if scanErr != nil {
 			return nil, errors.WithStack(scanErr)
 		}
-		// Check before appending so len(elems) never exceeds maxWideColumnItems
-		// by more than one scan page.
-		if len(elems)+len(deltaKVs) > maxWideColumnItems {
-			return nil, errors.Wrapf(ErrCollectionTooLarge, "delta key count exceeds %d", maxWideColumnItems)
-		}
 		for _, pair := range deltaKVs {
+			if include != nil && !include(pair) {
+				continue
+			}
+			// Check before appending so len(elems) never exceeds maxWideColumnItems.
+			if len(elems)+1 > maxWideColumnItems {
+				return nil, errors.Wrapf(ErrCollectionTooLarge, "delta key count exceeds %d", maxWideColumnItems)
+			}
 			elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: pair.Key})
 		}
 		if len(deltaKVs) < store.MaxDeltaScanLimit {
@@ -1002,6 +1039,17 @@ func (r *RedisServer) scanAllDeltaElems(ctx context.Context, deltaPrefix []byte,
 		deltaCursor = append(bytes.Clone(deltaKVs[len(deltaKVs)-1].Key), cursorAdv)
 	}
 	return elems, nil
+}
+
+func isLegacyListMetaDeltaPrefix(prefix []byte) bool {
+	return bytes.HasPrefix(prefix, []byte(store.LegacyListMetaDeltaPrefix))
+}
+
+func legacyListDeltaPairForUserKey(pair *store.KVPair, userKey []byte) bool {
+	if pair == nil || !store.IsListMetaDeltaValue(pair.Value) {
+		return false
+	}
+	return bytes.Equal(store.ExtractLegacyListUserKeyFromDelta(pair.Key), userKey)
 }
 
 // deleteWideColumnElems returns delete operations for all wide-column field/member keys,
@@ -1262,7 +1310,12 @@ func minRedisInt(a, b int) int {
 // aggregateLenDeltas scans delta keys under prefix and sums the LenDelta values
 // via unmarshalDelta. Returns (sum, hasDeltas, error).
 // ErrDeltaScanTruncated is returned when the scan hits MaxDeltaScanLimit.
-func (r *RedisServer) aggregateLenDeltas(ctx context.Context, prefix []byte, readTS uint64, unmarshalDelta func([]byte) (int64, error)) (int64, bool, error) {
+func (r *RedisServer) aggregateLenDeltas(
+	ctx context.Context,
+	prefix []byte,
+	readTS uint64,
+	unmarshalDelta func(key []byte, value []byte) (int64, bool, error),
+) (int64, bool, error) {
 	end := store.PrefixScanEnd(prefix)
 	// Scan one extra key beyond the limit so we can distinguish "exactly
 	// MaxDeltaScanLimit results" (no truncation) from "more than MaxDeltaScanLimit
@@ -1276,30 +1329,36 @@ func (r *RedisServer) aggregateLenDeltas(ctx context.Context, prefix []byte, rea
 		return 0, false, ErrDeltaScanTruncated
 	}
 	var sum int64
+	var any bool
 	for _, d := range deltas {
-		delta, err := unmarshalDelta(d.Value)
+		delta, include, err := unmarshalDelta(d.Key, d.Value)
 		if err != nil {
 			return 0, false, errors.WithStack(err)
 		}
+		if !include {
+			continue
+		}
+		any = true
 		sum += delta
 	}
-	return sum, len(deltas) > 0, nil
+	return sum, any, nil
 }
 
 func (r *RedisServer) aggregateListMetaDeltas(ctx context.Context, key []byte, readTS uint64, applyDelta func(store.ListMetaDelta)) (int64, bool, error) {
 	var total int64
 	var any bool
 	for _, prefix := range store.ListMetaDeltaScanPrefixes(key) {
-		lenSum, hasDeltas, err := r.aggregateLenDeltas(ctx, prefix, readTS, func(b []byte) (int64, error) {
-			if !store.IsListMetaDeltaValue(b) {
-				return 0, nil
+		legacy := isLegacyListMetaDeltaPrefix(prefix)
+		lenSum, hasDeltas, err := r.aggregateLenDeltas(ctx, prefix, readTS, func(deltaKey []byte, b []byte) (int64, bool, error) {
+			if legacy && (!store.IsListMetaDeltaValue(b) || !bytes.Equal(store.ExtractLegacyListUserKeyFromDelta(deltaKey), key)) {
+				return 0, false, nil
 			}
 			d, unmarshalErr := store.UnmarshalListMetaDelta(b)
 			if unmarshalErr != nil {
-				return 0, errors.WithStack(unmarshalErr)
+				return 0, false, errors.WithStack(unmarshalErr)
 			}
 			applyDelta(d)
-			return d.LenDelta, nil
+			return d.LenDelta, true, nil
 		})
 		if err != nil {
 			return 0, false, err
@@ -1369,7 +1428,10 @@ func (r *RedisServer) resolveCollectionLen(
 		}
 	}
 
-	deltaSum, hasDeltas, err := r.aggregateLenDeltas(ctx, deltaPrefix, readTS, unmarshalDelta)
+	deltaSum, hasDeltas, err := r.aggregateLenDeltas(ctx, deltaPrefix, readTS, func(_ []byte, value []byte) (int64, bool, error) {
+		delta, err := unmarshalDelta(value)
+		return delta, true, err
+	})
 	if err != nil {
 		return 0, false, err
 	}

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -925,12 +925,14 @@ func (r *RedisServer) deleteListElems(ctx context.Context, key []byte, readTS ui
 	}
 	// Always delete the base meta key (no-op tombstone if it doesn't exist).
 	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Del, Key: listMetaKey(key)})
-	// Delete all delta keys (paginated).
-	deltaElems, err := r.scanAllDeltaElems(ctx, store.ListMetaDeltaScanPrefix(key), readTS)
-	if err != nil {
-		return nil, err
+	// Delete all delta keys (paginated), including the pre-upgrade prefix.
+	for _, deltaPrefix := range store.ListMetaDeltaScanPrefixes(key) {
+		deltaElems, err := r.scanAllDeltaElems(ctx, deltaPrefix, readTS)
+		if err != nil {
+			return nil, err
+		}
+		elems = append(elems, deltaElems...)
 	}
-	elems = append(elems, deltaElems...)
 	// Delete all claim keys (paginated).
 	claimElems, err := r.scanAllDeltaElems(ctx, store.ListClaimScanPrefix(key), readTS)
 	if err != nil {
@@ -1284,6 +1286,30 @@ func (r *RedisServer) aggregateLenDeltas(ctx context.Context, prefix []byte, rea
 	return sum, len(deltas) > 0, nil
 }
 
+func (r *RedisServer) aggregateListMetaDeltas(ctx context.Context, key []byte, readTS uint64, applyDelta func(store.ListMetaDelta)) (int64, bool, error) {
+	var total int64
+	var any bool
+	for _, prefix := range store.ListMetaDeltaScanPrefixes(key) {
+		lenSum, hasDeltas, err := r.aggregateLenDeltas(ctx, prefix, readTS, func(b []byte) (int64, error) {
+			if !store.IsListMetaDeltaValue(b) {
+				return 0, nil
+			}
+			d, unmarshalErr := store.UnmarshalListMetaDelta(b)
+			if unmarshalErr != nil {
+				return 0, errors.WithStack(unmarshalErr)
+			}
+			applyDelta(d)
+			return d.LenDelta, nil
+		})
+		if err != nil {
+			return 0, false, err
+		}
+		total += lenSum
+		any = any || hasDeltas
+	}
+	return total, any, nil
+}
+
 // resolveListMeta aggregates the base list metadata with all uncompacted Delta keys
 // visible at readTS. Returns ErrDeltaScanTruncated if > MaxDeltaScanLimit deltas exist.
 func (r *RedisServer) resolveListMeta(ctx context.Context, key []byte, readTS uint64) (store.ListMeta, bool, error) {
@@ -1295,15 +1321,13 @@ func (r *RedisServer) resolveListMeta(ctx context.Context, key []byte, readTS ui
 
 	// 2. Scan and aggregate delta keys.
 	// The closure also captures baseMeta to accumulate the list-specific HeadDelta.
-	prefix := store.ListMetaDeltaScanPrefix(key)
-	lenSum, hasDeltas, err := r.aggregateLenDeltas(ctx, prefix, readTS, func(b []byte) (int64, error) {
-		d, unmarshalErr := store.UnmarshalListMetaDelta(b)
+	lenSum, hasDeltas, err := r.aggregateListMetaDeltas(ctx, key, readTS, func(d store.ListMetaDelta) {
 		baseMeta.Head += d.HeadDelta
-		return d.LenDelta, errors.WithStack(unmarshalErr)
 	})
 	if err != nil {
 		if errors.Is(err, ErrDeltaScanTruncated) {
 			r.triggerUrgentCompaction("list", key)
+			r.triggerUrgentCompaction("list-legacy", key)
 		}
 		return store.ListMeta{}, false, err
 	}

--- a/adapter/redis_delta_compactor.go
+++ b/adapter/redis_delta_compactor.go
@@ -259,6 +259,10 @@ func (c *DeltaCompactor) compactUrgentKeyBatch(ctx context.Context, req urgentCo
 	if len(kvs) == 0 {
 		return 0, true
 	}
+	kvs = filterDeltaKVs(kvs, h.acceptDeltaKV)
+	if len(kvs) == 0 {
+		return 0, true
+	}
 
 	elems, err := h.buildElems(ctx, req.userKey, kvs, readTS)
 	if err != nil {
@@ -397,6 +401,7 @@ type collectionDeltaHandler struct {
 	typeName       string
 	prefix         []byte
 	extractUserKey func(key []byte) []byte
+	acceptDeltaKV  func(*store.KVPair) bool
 	// deltaKeyPrefixFn returns the prefix that covers all delta keys for a single
 	// user key. Used by compactUrgentKey to perform a targeted single-key scan.
 	deltaKeyPrefixFn func(userKey []byte) []byte
@@ -407,6 +412,7 @@ type collectionDeltaHandler struct {
 func (c *DeltaCompactor) allHandlers() []collectionDeltaHandler {
 	return []collectionDeltaHandler{
 		c.listHandler(),
+		c.legacyListHandler(),
 		c.hashHandler(),
 		c.setHandler(),
 		c.zsetHandler(),
@@ -466,6 +472,7 @@ func (c *DeltaCompactor) compactHandler(ctx context.Context, h collectionDeltaHa
 		return err
 	}
 
+	kvs = filterDeltaKVs(kvs, h.acceptDeltaKV)
 	byKey, ukOrder := c.groupByUserKey(kvs, h.extractUserKey)
 	lastScannedKey := c.splitGuardCursor(byKey, ukOrder, kvs, truncated)
 
@@ -483,6 +490,19 @@ func (c *DeltaCompactor) compactHandler(ctx context.Context, h collectionDeltaHa
 
 // groupByUserKey groups KVPairs by their user key, returning both the map and
 // the unique user keys in lexicographic (scan) order.
+func filterDeltaKVs(kvs []*store.KVPair, accept func(*store.KVPair) bool) []*store.KVPair {
+	if accept == nil || len(kvs) == 0 {
+		return kvs
+	}
+	out := kvs[:0]
+	for _, pair := range kvs {
+		if accept(pair) {
+			out = append(out, pair)
+		}
+	}
+	return out
+}
+
 func (c *DeltaCompactor) groupByUserKey(kvs []*store.KVPair, extractUserKey func([]byte) []byte) (map[string][]*store.KVPair, []string) {
 	byKey := make(map[string][]*store.KVPair)
 	var ukOrder []string
@@ -628,9 +648,25 @@ func (c *DeltaCompactor) listHandler() collectionDeltaHandler {
 		typeName:         "list",
 		prefix:           []byte(store.ListMetaDeltaPrefix),
 		extractUserKey:   store.ExtractListUserKeyFromDelta,
+		acceptDeltaKV:    isListMetaDeltaKV,
 		deltaKeyPrefixFn: store.ListMetaDeltaScanPrefix,
 		buildElems:       c.buildListCompactElems,
 	}
+}
+
+func (c *DeltaCompactor) legacyListHandler() collectionDeltaHandler {
+	return collectionDeltaHandler{
+		typeName:         "list-legacy",
+		prefix:           []byte(store.LegacyListMetaDeltaPrefix),
+		extractUserKey:   store.ExtractLegacyListUserKeyFromDelta,
+		acceptDeltaKV:    isListMetaDeltaKV,
+		deltaKeyPrefixFn: store.LegacyListMetaDeltaScanPrefix,
+		buildElems:       c.buildListCompactElems,
+	}
+}
+
+func isListMetaDeltaKV(pair *store.KVPair) bool {
+	return pair != nil && store.IsListMetaDeltaValue(pair.Value)
 }
 
 func (c *DeltaCompactor) buildListCompactElems(ctx context.Context, userKey []byte, deltaKVs []*store.KVPair, readTS uint64) ([]*kv.Elem[kv.OP], error) {

--- a/adapter/redis_delta_compactor_test.go
+++ b/adapter/redis_delta_compactor_test.go
@@ -162,8 +162,8 @@ func TestDeltaCompactor_LegacyListDeltaFoldedIntoBaseMeta(t *testing.T) {
 	require.NoError(t, st.PutAt(ctx, store.ListMetaKey(userKey), metaBytes, 1, 0))
 
 	delta := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: -1, LenDelta: 2})
-	d1Key := legacyListMetaDeltaKey(userKey, 10, 0)
-	d2Key := legacyListMetaDeltaKey(userKey, 11, 0)
+	d1Key := legacyListMetaDeltaKey(userKey, 10)
+	d2Key := legacyListMetaDeltaKey(userKey, 11)
 	require.NoError(t, st.PutAt(ctx, d1Key, delta, 10, 0))
 	require.NoError(t, st.PutAt(ctx, d2Key, delta, 11, 0))
 

--- a/adapter/redis_delta_compactor_test.go
+++ b/adapter/redis_delta_compactor_test.go
@@ -92,6 +92,7 @@ func TestDeltaCompactor_RotatesHandlerAfterTimeout(t *testing.T) {
 
 	wantPrefixes := []string{
 		store.ListMetaDeltaPrefix,
+		store.LegacyListMetaDeltaPrefix,
 		store.HashMetaDeltaPrefix,
 		store.SetMetaDeltaPrefix,
 		store.ZSetMetaDeltaPrefix,
@@ -144,6 +145,42 @@ func TestDeltaCompactor_ListDeltaFoldedIntoBaseMeta(t *testing.T) {
 	for _, dk := range [][]byte{d1Key, d2Key, d3Key} {
 		_, getErr := st.GetAt(ctx, dk, readTS)
 		require.ErrorIs(t, getErr, store.ErrKeyNotFound, "delta key should be deleted after compaction: %s", dk)
+	}
+}
+
+func TestDeltaCompactor_LegacyListDeltaFoldedIntoBaseMeta(t *testing.T) {
+	t.Parallel()
+
+	st, c := newDeltaCompactorTestFixture(t)
+	ctx := context.Background()
+	userKey := []byte("legacy-list")
+
+	baseMeta := store.ListMeta{Head: 5, Len: 2}
+	baseMeta.Tail = baseMeta.Head + baseMeta.Len
+	metaBytes, err := store.MarshalListMeta(baseMeta)
+	require.NoError(t, err)
+	require.NoError(t, st.PutAt(ctx, store.ListMetaKey(userKey), metaBytes, 1, 0))
+
+	delta := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: -1, LenDelta: 2})
+	d1Key := legacyListMetaDeltaKey(userKey, 10, 0)
+	d2Key := legacyListMetaDeltaKey(userKey, 11, 0)
+	require.NoError(t, st.PutAt(ctx, d1Key, delta, 10, 0))
+	require.NoError(t, st.PutAt(ctx, d2Key, delta, 11, 0))
+
+	require.NoError(t, c.SyncOnce(ctx))
+
+	readTS := st.LastCommitTS()
+	raw, err := st.GetAt(ctx, store.ListMetaKey(userKey), readTS)
+	require.NoError(t, err)
+	got, err := store.UnmarshalListMeta(raw)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), got.Head)
+	require.Equal(t, int64(6), got.Len)
+	require.Equal(t, int64(9), got.Tail)
+
+	for _, dk := range [][]byte{d1Key, d2Key} {
+		_, getErr := st.GetAt(ctx, dk, readTS)
+		require.ErrorIs(t, getErr, store.ErrKeyNotFound, "legacy delta key should be deleted after compaction: %s", dk)
 	}
 }
 

--- a/adapter/redis_list_dedup_test.go
+++ b/adapter/redis_list_dedup_test.go
@@ -66,7 +66,7 @@ func TestResolveListMetaReadsLegacyDeltaPrefix(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, st.PutAt(ctx, store.ListMetaKey(key), base, 1, 0))
 	delta := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: -1, LenDelta: 3})
-	require.NoError(t, st.PutAt(ctx, legacyListMetaDeltaKey(key, 2, 0), delta, 2, 0))
+	require.NoError(t, st.PutAt(ctx, legacyListMetaDeltaKey(key, 2), delta, 2, 0))
 
 	meta, exists, err := srv.resolveListMeta(ctx, key, 3)
 	require.NoError(t, err)
@@ -82,7 +82,7 @@ func TestResolveListMetaDoesNotTreatDeltaLookingMetaValueAsLegacyDelta(t *testin
 	ctx := context.Background()
 	st := store.NewMVCCStore()
 	srv := &RedisServer{store: st}
-	key := deltaLookingListMetaUserKey([]byte("embedded"), 7, 1)
+	key := deltaLookingListMetaUserKey([]byte("embedded"))
 	base, err := store.MarshalListMeta(store.ListMeta{Head: 4, Tail: 6, Len: 2})
 	require.NoError(t, err)
 	require.NoError(t, st.PutAt(ctx, store.ListMetaKey(key), base, 1, 0))
@@ -95,17 +95,95 @@ func TestResolveListMetaDoesNotTreatDeltaLookingMetaValueAsLegacyDelta(t *testin
 	require.Equal(t, int64(6), meta.Tail)
 }
 
-func legacyListMetaDeltaKey(userKey []byte, commitTS uint64, seqInTxn uint32) []byte {
+func TestResolveListMetaIgnoresLegacyDeltaPrefixCollisionForMissingKey(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	srv := &RedisServer{store: st}
+	key := []byte("legacy-collision")
+	collidingUserKey := deltaLookingListMetaUserKey(key)
+	base, err := store.MarshalListMeta(store.ListMeta{Head: 4, Tail: 6, Len: 2})
+	require.NoError(t, err)
+	require.NoError(t, st.PutAt(ctx, store.ListMetaKey(collidingUserKey), base, 1, 0))
+
+	_, exists, err := srv.resolveListMeta(ctx, key, 2)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+func TestProbeListTypeReadsLegacyDeltaPrefix(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	srv := &RedisServer{store: st}
+	key := []byte("legacy-list-type")
+	delta := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: 0, LenDelta: 1})
+	require.NoError(t, st.PutAt(ctx, legacyListMetaDeltaKey(key, 2), delta, 2, 0))
+
+	typ, found, err := srv.probeListType(ctx, key, 3)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, redisTypeList, typ)
+}
+
+func TestProbeListTypeIgnoresLegacyDeltaPrefixCollision(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	srv := &RedisServer{store: st}
+	key := []byte("legacy-list-type-collision")
+	collidingUserKey := deltaLookingListMetaUserKey(key)
+	base, err := store.MarshalListMeta(store.ListMeta{Head: 4, Tail: 6, Len: 2})
+	require.NoError(t, err)
+	require.NoError(t, st.PutAt(ctx, store.ListMetaKey(collidingUserKey), base, 1, 0))
+
+	_, found, err := srv.probeListType(ctx, key, 2)
+	require.NoError(t, err)
+	require.False(t, found)
+}
+
+func TestDeleteListElemsFiltersLegacyDeltaPrefixCollisions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	srv := &RedisServer{store: st}
+	key := []byte("legacy-list-delete")
+	collidingUserKey := deltaLookingListMetaUserKey(key)
+	base, err := store.MarshalListMeta(store.ListMeta{Head: 4, Tail: 6, Len: 2})
+	require.NoError(t, err)
+	collidingMetaKey := store.ListMetaKey(collidingUserKey)
+	require.NoError(t, st.PutAt(ctx, collidingMetaKey, base, 1, 0))
+	deltaKey := legacyListMetaDeltaKey(key, 2)
+	delta := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: 0, LenDelta: 1})
+	require.NoError(t, st.PutAt(ctx, deltaKey, delta, 2, 0))
+
+	elems, err := srv.deleteListElems(ctx, key, 3)
+	require.NoError(t, err)
+	deleted := make(map[string]struct{}, len(elems))
+	for _, elem := range elems {
+		if elem.Op == kv.Del {
+			deleted[string(elem.Key)] = struct{}{}
+		}
+	}
+	require.Contains(t, deleted, string(deltaKey))
+	require.NotContains(t, deleted, string(collidingMetaKey))
+}
+
+func legacyListMetaDeltaKey(userKey []byte, commitTS uint64) []byte {
 	key := store.LegacyListMetaDeltaScanPrefix(userKey)
 	var ts [8]byte
 	binary.BigEndian.PutUint64(ts[:], commitTS)
 	key = append(key, ts[:]...)
 	var seq [4]byte
-	binary.BigEndian.PutUint32(seq[:], seqInTxn)
+	binary.BigEndian.PutUint32(seq[:], 0)
 	return append(key, seq[:]...)
 }
 
-func deltaLookingListMetaUserKey(fakeUserKey []byte, commitTS uint64, seqInTxn uint32) []byte {
+func deltaLookingListMetaUserKey(fakeUserKey []byte) []byte {
 	key := make([]byte, 0, len("d|")+4+len(fakeUserKey)+8+4)
 	key = append(key, "d|"...)
 	var lenPrefix [4]byte
@@ -113,10 +191,10 @@ func deltaLookingListMetaUserKey(fakeUserKey []byte, commitTS uint64, seqInTxn u
 	key = append(key, lenPrefix[:]...)
 	key = append(key, fakeUserKey...)
 	var ts [8]byte
-	binary.BigEndian.PutUint64(ts[:], commitTS)
+	binary.BigEndian.PutUint64(ts[:], 7)
 	key = append(key, ts[:]...)
 	var seq [4]byte
-	binary.BigEndian.PutUint32(seq[:], seqInTxn)
+	binary.BigEndian.PutUint32(seq[:], 1)
 	return append(key, seq[:]...)
 }
 

--- a/adapter/redis_list_dedup_test.go
+++ b/adapter/redis_list_dedup_test.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"testing"
 
 	"github.com/bootjp/elastickv/kv"
@@ -52,6 +53,71 @@ func newDedupTestCoordinator(st store.MVCCStore, ambiguousDispatch int, lands bo
 		ambiguousDispatch:     ambiguousDispatch,
 		ambiguousLands:        lands,
 	}
+}
+
+func TestResolveListMetaReadsLegacyDeltaPrefix(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	srv := &RedisServer{store: st}
+	key := []byte("legacy-list")
+	base, err := store.MarshalListMeta(store.ListMeta{Head: 10, Tail: 12, Len: 2})
+	require.NoError(t, err)
+	require.NoError(t, st.PutAt(ctx, store.ListMetaKey(key), base, 1, 0))
+	delta := store.MarshalListMetaDelta(store.ListMetaDelta{HeadDelta: -1, LenDelta: 3})
+	require.NoError(t, st.PutAt(ctx, legacyListMetaDeltaKey(key, 2, 0), delta, 2, 0))
+
+	meta, exists, err := srv.resolveListMeta(ctx, key, 3)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Equal(t, int64(9), meta.Head)
+	require.Equal(t, int64(5), meta.Len)
+	require.Equal(t, int64(14), meta.Tail)
+}
+
+func TestResolveListMetaDoesNotTreatDeltaLookingMetaValueAsLegacyDelta(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := store.NewMVCCStore()
+	srv := &RedisServer{store: st}
+	key := deltaLookingListMetaUserKey([]byte("embedded"), 7, 1)
+	base, err := store.MarshalListMeta(store.ListMeta{Head: 4, Tail: 6, Len: 2})
+	require.NoError(t, err)
+	require.NoError(t, st.PutAt(ctx, store.ListMetaKey(key), base, 1, 0))
+
+	meta, exists, err := srv.resolveListMeta(ctx, key, 2)
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Equal(t, int64(4), meta.Head)
+	require.Equal(t, int64(2), meta.Len)
+	require.Equal(t, int64(6), meta.Tail)
+}
+
+func legacyListMetaDeltaKey(userKey []byte, commitTS uint64, seqInTxn uint32) []byte {
+	key := store.LegacyListMetaDeltaScanPrefix(userKey)
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], commitTS)
+	key = append(key, ts[:]...)
+	var seq [4]byte
+	binary.BigEndian.PutUint32(seq[:], seqInTxn)
+	return append(key, seq[:]...)
+}
+
+func deltaLookingListMetaUserKey(fakeUserKey []byte, commitTS uint64, seqInTxn uint32) []byte {
+	key := make([]byte, 0, len("d|")+4+len(fakeUserKey)+8+4)
+	key = append(key, "d|"...)
+	var lenPrefix [4]byte
+	binary.BigEndian.PutUint32(lenPrefix[:], uint32(len(fakeUserKey))) //nolint:gosec // test data is small.
+	key = append(key, lenPrefix[:]...)
+	key = append(key, fakeUserKey...)
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], commitTS)
+	key = append(key, ts[:]...)
+	var seq [4]byte
+	binary.BigEndian.PutUint32(seq[:], seqInTxn)
+	return append(key, seq[:]...)
 }
 
 func (c *dedupTestCoordinator) Dispatch(ctx context.Context, req *kv.OperationGroup[kv.OP]) (*kv.CoordinateResponse, error) {

--- a/adapter/redis_txn.go
+++ b/adapter/redis_txn.go
@@ -351,18 +351,19 @@ func (t *txnContext) loadListState(key []byte) (*listTxnState, error) {
 	// truncation: if >MaxDeltaScanLimit deltas exist the transaction cannot
 	// safely enumerate all of them for deletion, so we return ErrDeltaScanTruncated
 	// and let the caller retry after the background compactor has caught up.
-	deltaPrefix := store.ListMetaDeltaScanPrefix(key)
-	deltaEnd := store.PrefixScanEnd(deltaPrefix)
-	deltaKVs, err := t.server.store.ScanAt(ctx, deltaPrefix, deltaEnd, store.MaxDeltaScanLimit+1, t.startTS)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	if len(deltaKVs) > store.MaxDeltaScanLimit {
-		return nil, ErrDeltaScanTruncated
-	}
-	existingDeltas := make([][]byte, 0, len(deltaKVs))
-	for _, kv := range deltaKVs {
-		existingDeltas = append(existingDeltas, kv.Key)
+	var existingDeltas [][]byte
+	for _, deltaPrefix := range store.ListMetaDeltaScanPrefixes(key) {
+		deltaEnd := store.PrefixScanEnd(deltaPrefix)
+		deltaKVs, err := t.server.store.ScanAt(ctx, deltaPrefix, deltaEnd, store.MaxDeltaScanLimit+1, t.startTS)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		if len(deltaKVs) > store.MaxDeltaScanLimit {
+			return nil, ErrDeltaScanTruncated
+		}
+		for _, kv := range deltaKVs {
+			existingDeltas = append(existingDeltas, kv.Key)
+		}
 	}
 
 	st := &listTxnState{

--- a/distribution/migrator.go
+++ b/distribution/migrator.go
@@ -278,7 +278,7 @@ func (b MigrationBracket) decodedS3Bucket(rawKey []byte) (string, bool) {
 }
 
 func routeKeyInRange(routeKey, routeStart, routeEnd []byte) bool {
-	if len(routeKey) == 0 {
+	if routeKey == nil {
 		return false
 	}
 	if bytes.Compare(routeKey, routeStart) < 0 {

--- a/distribution/migrator.go
+++ b/distribution/migrator.go
@@ -146,12 +146,14 @@ type MigrationBracket struct {
 	ExcludeKnownInternal  bool
 	DrainOnly             bool
 	RequiresRouteKeyCheck bool
+	RequiresDecodedS3     bool
 }
 
 // PlanMigrationBrackets returns the full M2 migration plan, including the
 // drain-only transaction lock bracket. Data export callers should use
 // PlanExportBrackets, which omits drain-only control state.
 func PlanMigrationBrackets(routeStart, routeEnd []byte) ([]MigrationBracket, error) {
+	routeEnd = normalizeMigrationRouteEnd(routeEnd)
 	if err := ValidateMigrationRouteRange(routeStart, routeEnd); err != nil {
 		return nil, err
 	}
@@ -215,10 +217,24 @@ func (b MigrationBracket) ContainsRawKey(rawKey []byte) bool {
 	if len(b.End) > 0 && bytes.Compare(rawKey, b.End) >= 0 {
 		return false
 	}
+	if !b.containsFamilyShape(rawKey) {
+		return false
+	}
 	if b.ExcludeKnownInternal && IsMigrationKnownInternalKey(rawKey) {
 		return false
 	}
 	return !hasAnyPrefix(rawKey, b.ExcludePrefixes)
+}
+
+func (b MigrationBracket) containsFamilyShape(rawKey []byte) bool {
+	switch b.Family {
+	case MigrationFamilyListMetaDelta:
+		return store.ExtractListUserKeyFromDelta(rawKey) != nil
+	case MigrationFamilyListMeta:
+		return store.ExtractListUserKeyFromDelta(rawKey) == nil
+	default:
+		return true
+	}
 }
 
 // InitializeSplitJobPlan validates the source route and seeds the job's
@@ -312,7 +328,7 @@ func migrationFamilyBrackets() []MigrationBracket {
 		{family: MigrationFamilyTxnMeta, prefix: migrationTxnMetaPrefix},
 		{family: MigrationFamilyListMetaDelta, prefix: store.ListMetaDeltaPrefix},
 		{family: MigrationFamilyListClaim, prefix: store.ListClaimPrefix},
-		{family: MigrationFamilyListMeta, prefix: store.ListMetaPrefix, excludePrefixes: []string{store.ListMetaDeltaPrefix}},
+		{family: MigrationFamilyListMeta, prefix: store.ListMetaPrefix},
 		{family: MigrationFamilyListItem, prefix: store.ListItemPrefix},
 		{family: MigrationFamilyRedisLegacy, prefix: migrationRedisPrefix},
 		{family: MigrationFamilyHash, prefix: migrationHashPrefix},
@@ -350,6 +366,7 @@ func migrationFamilyBrackets() []MigrationBracket {
 	out := make([]MigrationBracket, 0, len(defs))
 	for _, def := range defs {
 		start := []byte(def.prefix)
+		requiresRouteKeyCheck, requiresDecodedS3 := migrationBracketRouteCheck(def.family)
 		out = append(out, MigrationBracket{
 			BracketID:             uint64(def.family),
 			Family:                def.family,
@@ -357,10 +374,27 @@ func migrationFamilyBrackets() []MigrationBracket {
 			End:                   prefixScanEnd(start),
 			ExcludePrefixes:       stringsToByteSlices(def.excludePrefixes),
 			DrainOnly:             def.drainOnly,
-			RequiresRouteKeyCheck: true,
+			RequiresRouteKeyCheck: requiresRouteKeyCheck,
+			RequiresDecodedS3:     requiresDecodedS3,
 		})
 	}
 	return out
+}
+
+func migrationBracketRouteCheck(family uint32) (requiresRouteKeyCheck bool, requiresDecodedS3 bool) {
+	switch family {
+	case MigrationFamilyS3BucketMeta, MigrationFamilyS3BucketGeneration:
+		return false, true
+	default:
+		return true, false
+	}
+}
+
+func normalizeMigrationRouteEnd(routeEnd []byte) []byte {
+	if len(routeEnd) == 0 {
+		return nil
+	}
+	return routeEnd
 }
 
 func stringsToByteSlices(in []string) [][]byte {

--- a/distribution/migrator.go
+++ b/distribution/migrator.go
@@ -1,0 +1,425 @@
+package distribution
+
+import (
+	"bytes"
+
+	"github.com/bootjp/elastickv/internal/s3keys"
+	"github.com/bootjp/elastickv/store"
+	"github.com/cockroachdb/errors"
+)
+
+const (
+	MigrationFamilyUser uint32 = iota + 1
+	MigrationFamilyTxnIntent
+	MigrationFamilyTxnCommit
+	MigrationFamilyTxnRollback
+	MigrationFamilyTxnSuccess
+	MigrationFamilyTxnMeta
+	MigrationFamilyTxnLock
+	MigrationFamilyListMeta
+	MigrationFamilyListItem
+	MigrationFamilyListMetaDelta
+	MigrationFamilyListClaim
+	MigrationFamilyRedisLegacy
+	MigrationFamilyHash
+	MigrationFamilySet
+	MigrationFamilyZSet
+	MigrationFamilyStreamMeta
+	MigrationFamilyStreamEntry
+	MigrationFamilyDynamoTableMeta
+	MigrationFamilyDynamoTableGeneration
+	MigrationFamilyDynamoItem
+	MigrationFamilyDynamoGSI
+	MigrationFamilySQSQueueMeta
+	MigrationFamilySQSQueueGeneration
+	MigrationFamilySQSQueueSequence
+	MigrationFamilySQSQueueTombstone
+	MigrationFamilySQSMessageData
+	MigrationFamilySQSMessageVisibility
+	MigrationFamilySQSMessageDedup
+	MigrationFamilySQSMessageGroup
+	MigrationFamilySQSMessageByAge
+	MigrationFamilySQSPartitionedMessageData
+	MigrationFamilySQSPartitionedMessageVisibility
+	MigrationFamilySQSPartitionedMessageDedup
+	MigrationFamilySQSPartitionedMessageGroup
+	MigrationFamilySQSPartitionedMessageByAge
+	MigrationFamilyS3BucketMeta
+	MigrationFamilyS3BucketGeneration
+	MigrationFamilyS3ObjectManifest
+	MigrationFamilyS3UploadMeta
+	MigrationFamilyS3UploadPart
+	MigrationFamilyS3Blob
+	MigrationFamilyS3GCUpload
+)
+
+const (
+	migrationTxnIntentPrefix   = "!txn|int|"
+	migrationTxnCommitPrefix   = "!txn|cmt|"
+	migrationTxnRollbackPrefix = "!txn|rb|"
+	migrationTxnSuccessPrefix  = "!txn|ok|"
+	migrationTxnMetaPrefix     = "!txn|meta|"
+	migrationTxnLockPrefix     = "!txn|lock|"
+	migrationRedisPrefix       = "!redis|"
+	migrationHashPrefix        = "!hs|"
+	migrationSetPrefix         = "!st|"
+	migrationZSetPrefix        = "!zs|"
+	migrationDynamoMetaPrefix  = "!ddb|meta|table|"
+	migrationDynamoGenPrefix   = "!ddb|meta|gen|"
+	migrationDynamoItemPrefix  = "!ddb|item|"
+	migrationDynamoGSIPrefix   = "!ddb|gsi|"
+)
+
+const (
+	migrationSQSQueueMetaPrefix      = "!sqs|queue|meta|"
+	migrationSQSQueueGenPrefix       = "!sqs|queue|gen|"
+	migrationSQSQueueSeqPrefix       = "!sqs|queue|seq|"
+	migrationSQSQueueTombstonePrefix = "!sqs|queue|tombstone|"
+	migrationSQSMsgDataPrefix        = "!sqs|msg|data|"
+	migrationSQSMsgVisPrefix         = "!sqs|msg|vis|"
+	migrationSQSMsgDedupPrefix       = "!sqs|msg|dedup|"
+	migrationSQSMsgGroupPrefix       = "!sqs|msg|group|"
+	migrationSQSMsgByAgePrefix       = "!sqs|msg|byage|"
+	migrationSQSPartitionedSuffix    = "p|"
+)
+
+var (
+	ErrMigrationReservedRange      = errors.New("migration range intersects reserved control prefix")
+	ErrMigrationInvalidRoute       = errors.New("migration route is invalid")
+	ErrMigrationDataMoveRequired   = errors.New("migration data move is not implemented")
+	ErrMigrationSourceRouteChanged = errors.New("migration source route does not match split job")
+)
+
+var migrationReservedControlPrefixes = [][]byte{
+	[]byte("!dist|"),
+	[]byte("!migstage|"),
+	[]byte("!migwrite|"),
+	[]byte("!migfence|"),
+}
+
+var migrationInternalFamilyPrefixes = [][]byte{
+	[]byte(migrationTxnLockPrefix),
+	[]byte(migrationTxnIntentPrefix),
+	[]byte(migrationTxnCommitPrefix),
+	[]byte(migrationTxnRollbackPrefix),
+	[]byte(migrationTxnSuccessPrefix),
+	[]byte(migrationTxnMetaPrefix),
+	[]byte(store.ListMetaDeltaPrefix),
+	[]byte(store.ListClaimPrefix),
+	[]byte(store.ListMetaPrefix),
+	[]byte(store.ListItemPrefix),
+	[]byte(migrationRedisPrefix),
+	[]byte(migrationHashPrefix),
+	[]byte(migrationSetPrefix),
+	[]byte(migrationZSetPrefix),
+	[]byte(store.StreamMetaPrefix),
+	[]byte(store.StreamEntryPrefix),
+	[]byte(migrationDynamoMetaPrefix),
+	[]byte(migrationDynamoGenPrefix),
+	[]byte(migrationDynamoItemPrefix),
+	[]byte(migrationDynamoGSIPrefix),
+	[]byte(migrationSQSQueueMetaPrefix),
+	[]byte(migrationSQSQueueGenPrefix),
+	[]byte(migrationSQSQueueSeqPrefix),
+	[]byte(migrationSQSQueueTombstonePrefix),
+	[]byte(migrationSQSMsgDataPrefix),
+	[]byte(migrationSQSMsgVisPrefix),
+	[]byte(migrationSQSMsgDedupPrefix),
+	[]byte(migrationSQSMsgGroupPrefix),
+	[]byte(migrationSQSMsgByAgePrefix),
+	[]byte(s3keys.BucketMetaPrefix),
+	[]byte(s3keys.BucketGenerationPrefix),
+	[]byte(s3keys.ObjectManifestPrefix),
+	[]byte(s3keys.UploadMetaPrefix),
+	[]byte(s3keys.UploadPartPrefix),
+	[]byte(s3keys.BlobPrefix),
+	[]byte(s3keys.GCUploadPrefix),
+}
+
+// MigrationBracket is a raw MVCC export or drain slice used by the migrator.
+type MigrationBracket struct {
+	BracketID             uint64
+	Family                uint32
+	Start                 []byte
+	End                   []byte
+	ExcludePrefixes       [][]byte
+	ExcludeKnownInternal  bool
+	DrainOnly             bool
+	RequiresRouteKeyCheck bool
+}
+
+// PlanMigrationBrackets returns the full M2 migration plan, including the
+// drain-only transaction lock bracket. Data export callers should use
+// PlanExportBrackets, which omits drain-only control state.
+func PlanMigrationBrackets(routeStart, routeEnd []byte) ([]MigrationBracket, error) {
+	if err := ValidateMigrationRouteRange(routeStart, routeEnd); err != nil {
+		return nil, err
+	}
+
+	brackets := []MigrationBracket{
+		{
+			BracketID:             uint64(MigrationFamilyUser),
+			Family:                MigrationFamilyUser,
+			Start:                 CloneBytes(routeStart),
+			End:                   CloneBytes(routeEnd),
+			ExcludeKnownInternal:  true,
+			RequiresRouteKeyCheck: true,
+		},
+	}
+	brackets = append(brackets, migrationFamilyBrackets()...)
+	return brackets, nil
+}
+
+// PlanExportBrackets returns the data-copy bracket plan. Intent locks are
+// deliberately absent because the source drains them route-faithfully before
+// cutover and the target must not materialize in-flight intents as data.
+func PlanExportBrackets(routeStart, routeEnd []byte) ([]MigrationBracket, error) {
+	brackets, err := PlanMigrationBrackets(routeStart, routeEnd)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]MigrationBracket, 0, len(brackets))
+	for _, bracket := range brackets {
+		if bracket.DrainOnly {
+			continue
+		}
+		out = append(out, bracket)
+	}
+	return out, nil
+}
+
+// SplitJobBracketProgressForPlan creates durable per-bracket resume state for
+// a SplitJob phase.
+func SplitJobBracketProgressForPlan(brackets []MigrationBracket, phase SplitJobExportPhase) []SplitJobBracketProgress {
+	out := make([]SplitJobBracketProgress, 0, len(brackets))
+	for _, bracket := range brackets {
+		if bracket.DrainOnly {
+			continue
+		}
+		out = append(out, SplitJobBracketProgress{
+			BracketID:   bracket.BracketID,
+			Family:      bracket.Family,
+			ExportPhase: phase,
+		})
+	}
+	return out
+}
+
+// ContainsRawKey reports whether rawKey is inside the bracket's raw scan
+// interval after applying bracket-local exclusions. Route ownership still
+// requires the caller's RouteKeyFilter for every bracket.
+func (b MigrationBracket) ContainsRawKey(rawKey []byte) bool {
+	if bytes.Compare(rawKey, b.Start) < 0 {
+		return false
+	}
+	if len(b.End) > 0 && bytes.Compare(rawKey, b.End) >= 0 {
+		return false
+	}
+	if b.ExcludeKnownInternal && IsMigrationKnownInternalKey(rawKey) {
+		return false
+	}
+	return !hasAnyPrefix(rawKey, b.ExcludePrefixes)
+}
+
+// InitializeSplitJobPlan validates the source route and seeds the job's
+// bracket progress for the moving right child [SplitKey, source.End).
+func InitializeSplitJobPlan(job SplitJob, source RouteDescriptor, nowMs int64) (SplitJob, error) {
+	if err := validateSplitJobSource(job, source); err != nil {
+		return SplitJob{}, err
+	}
+	routeStart := CloneBytes(job.SplitKey)
+	routeEnd := CloneBytes(source.End)
+	brackets, err := PlanExportBrackets(routeStart, routeEnd)
+	if err != nil {
+		return SplitJob{}, err
+	}
+
+	out := CloneSplitJob(job)
+	if out.Phase == SplitJobPhaseNone {
+		out.Phase = SplitJobPhasePlanned
+	}
+	if len(out.BracketProgress) == 0 {
+		out.BracketProgress = SplitJobBracketProgressForPlan(brackets, SplitJobExportPhaseBackfill)
+	}
+	if out.StartedAtMs == 0 {
+		out.StartedAtMs = nowMs
+	}
+	out.UpdatedAtMs = nowMs
+	return out, nil
+}
+
+// AdvanceSameGroupNoop completes the PR4 same-group path without attempting
+// data movement. Cross-group data copy is added by later M2 PRs.
+func AdvanceSameGroupNoop(job SplitJob, source RouteDescriptor, nowMs int64) (SplitJob, error) {
+	planned, err := InitializeSplitJobPlan(job, source, nowMs)
+	if err != nil {
+		return SplitJob{}, err
+	}
+	if planned.TargetGroupID != source.GroupID {
+		return SplitJob{}, errors.WithStack(ErrMigrationDataMoveRequired)
+	}
+
+	planned.Phase = SplitJobPhaseDone
+	planned.TargetPromotionDone = true
+	planned.PromotionCompletedTS = migrationWallMillisToUint64(nowMs)
+	planned.UpdatedAtMs = nowMs
+	planned.TerminalAtMs = nowMs
+	for i := range planned.BracketProgress {
+		planned.BracketProgress[i].Done = true
+	}
+	return planned, nil
+}
+
+// MigrationKnownInternalPrefixes returns the concrete internal data/control
+// prefixes that the user bracket must exclude. It intentionally does not
+// include broad umbrellas such as !txn|, !ddb|, !sqs|, !s3|, or !stream|.
+func MigrationKnownInternalPrefixes() [][]byte {
+	return cloneByteSlices(migrationInternalFamilyPrefixes)
+}
+
+// IsMigrationKnownInternalKey reports whether a raw key belongs to a concrete
+// internal family owned by an explicit export bracket or by the txn-lock drain.
+func IsMigrationKnownInternalKey(key []byte) bool {
+	return hasAnyPrefix(key, migrationInternalFamilyPrefixes)
+}
+
+// ValidateMigrationRouteRange rejects route intervals that intersect reserved
+// distribution/migration control namespaces.
+func ValidateMigrationRouteRange(routeStart, routeEnd []byte) error {
+	if len(routeEnd) > 0 && bytes.Compare(routeStart, routeEnd) >= 0 {
+		return errors.WithStack(ErrMigrationInvalidRoute)
+	}
+	for _, prefix := range migrationReservedControlPrefixes {
+		if rangesIntersect(routeStart, routeEnd, prefix, prefixScanEnd(prefix)) {
+			return errors.WithStack(ErrMigrationReservedRange)
+		}
+	}
+	return nil
+}
+
+func migrationFamilyBrackets() []MigrationBracket {
+	defs := []struct {
+		family          uint32
+		prefix          string
+		drainOnly       bool
+		excludePrefixes []string
+	}{
+		{family: MigrationFamilyTxnLock, prefix: migrationTxnLockPrefix, drainOnly: true},
+		{family: MigrationFamilyTxnIntent, prefix: migrationTxnIntentPrefix},
+		{family: MigrationFamilyTxnCommit, prefix: migrationTxnCommitPrefix},
+		{family: MigrationFamilyTxnRollback, prefix: migrationTxnRollbackPrefix},
+		{family: MigrationFamilyTxnSuccess, prefix: migrationTxnSuccessPrefix},
+		{family: MigrationFamilyTxnMeta, prefix: migrationTxnMetaPrefix},
+		{family: MigrationFamilyListMetaDelta, prefix: store.ListMetaDeltaPrefix},
+		{family: MigrationFamilyListClaim, prefix: store.ListClaimPrefix},
+		{family: MigrationFamilyListMeta, prefix: store.ListMetaPrefix, excludePrefixes: []string{store.ListMetaDeltaPrefix}},
+		{family: MigrationFamilyListItem, prefix: store.ListItemPrefix},
+		{family: MigrationFamilyRedisLegacy, prefix: migrationRedisPrefix},
+		{family: MigrationFamilyHash, prefix: migrationHashPrefix},
+		{family: MigrationFamilySet, prefix: migrationSetPrefix},
+		{family: MigrationFamilyZSet, prefix: migrationZSetPrefix},
+		{family: MigrationFamilyStreamMeta, prefix: store.StreamMetaPrefix},
+		{family: MigrationFamilyStreamEntry, prefix: store.StreamEntryPrefix},
+		{family: MigrationFamilyDynamoTableMeta, prefix: migrationDynamoMetaPrefix},
+		{family: MigrationFamilyDynamoTableGeneration, prefix: migrationDynamoGenPrefix},
+		{family: MigrationFamilyDynamoItem, prefix: migrationDynamoItemPrefix},
+		{family: MigrationFamilyDynamoGSI, prefix: migrationDynamoGSIPrefix},
+		{family: MigrationFamilySQSQueueMeta, prefix: migrationSQSQueueMetaPrefix},
+		{family: MigrationFamilySQSQueueGeneration, prefix: migrationSQSQueueGenPrefix},
+		{family: MigrationFamilySQSQueueSequence, prefix: migrationSQSQueueSeqPrefix},
+		{family: MigrationFamilySQSQueueTombstone, prefix: migrationSQSQueueTombstonePrefix},
+		{family: MigrationFamilySQSMessageData, prefix: migrationSQSMsgDataPrefix, excludePrefixes: []string{migrationSQSMsgDataPrefix + migrationSQSPartitionedSuffix}},
+		{family: MigrationFamilySQSMessageVisibility, prefix: migrationSQSMsgVisPrefix, excludePrefixes: []string{migrationSQSMsgVisPrefix + migrationSQSPartitionedSuffix}},
+		{family: MigrationFamilySQSMessageDedup, prefix: migrationSQSMsgDedupPrefix, excludePrefixes: []string{migrationSQSMsgDedupPrefix + migrationSQSPartitionedSuffix}},
+		{family: MigrationFamilySQSMessageGroup, prefix: migrationSQSMsgGroupPrefix, excludePrefixes: []string{migrationSQSMsgGroupPrefix + migrationSQSPartitionedSuffix}},
+		{family: MigrationFamilySQSMessageByAge, prefix: migrationSQSMsgByAgePrefix, excludePrefixes: []string{migrationSQSMsgByAgePrefix + migrationSQSPartitionedSuffix}},
+		{family: MigrationFamilySQSPartitionedMessageData, prefix: migrationSQSMsgDataPrefix + migrationSQSPartitionedSuffix},
+		{family: MigrationFamilySQSPartitionedMessageVisibility, prefix: migrationSQSMsgVisPrefix + migrationSQSPartitionedSuffix},
+		{family: MigrationFamilySQSPartitionedMessageDedup, prefix: migrationSQSMsgDedupPrefix + migrationSQSPartitionedSuffix},
+		{family: MigrationFamilySQSPartitionedMessageGroup, prefix: migrationSQSMsgGroupPrefix + migrationSQSPartitionedSuffix},
+		{family: MigrationFamilySQSPartitionedMessageByAge, prefix: migrationSQSMsgByAgePrefix + migrationSQSPartitionedSuffix},
+		{family: MigrationFamilyS3BucketMeta, prefix: s3keys.BucketMetaPrefix},
+		{family: MigrationFamilyS3BucketGeneration, prefix: s3keys.BucketGenerationPrefix},
+		{family: MigrationFamilyS3ObjectManifest, prefix: s3keys.ObjectManifestPrefix},
+		{family: MigrationFamilyS3UploadMeta, prefix: s3keys.UploadMetaPrefix},
+		{family: MigrationFamilyS3UploadPart, prefix: s3keys.UploadPartPrefix},
+		{family: MigrationFamilyS3Blob, prefix: s3keys.BlobPrefix},
+		{family: MigrationFamilyS3GCUpload, prefix: s3keys.GCUploadPrefix},
+	}
+
+	out := make([]MigrationBracket, 0, len(defs))
+	for _, def := range defs {
+		start := []byte(def.prefix)
+		out = append(out, MigrationBracket{
+			BracketID:             uint64(def.family),
+			Family:                def.family,
+			Start:                 CloneBytes(start),
+			End:                   prefixScanEnd(start),
+			ExcludePrefixes:       stringsToByteSlices(def.excludePrefixes),
+			DrainOnly:             def.drainOnly,
+			RequiresRouteKeyCheck: true,
+		})
+	}
+	return out
+}
+
+func stringsToByteSlices(in []string) [][]byte {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([][]byte, len(in))
+	for i := range in {
+		out[i] = []byte(in[i])
+	}
+	return out
+}
+
+func migrationWallMillisToUint64(ms int64) uint64 {
+	if ms <= 0 {
+		return 0
+	}
+	return uint64(ms)
+}
+
+func validateSplitJobSource(job SplitJob, source RouteDescriptor) error {
+	if job.SourceRouteID != source.RouteID {
+		return errors.WithStack(ErrMigrationSourceRouteChanged)
+	}
+	if len(job.SplitKey) == 0 {
+		return errors.WithStack(ErrMigrationInvalidRoute)
+	}
+	if bytes.Compare(job.SplitKey, source.Start) <= 0 {
+		return errors.WithStack(ErrMigrationInvalidRoute)
+	}
+	if len(source.End) > 0 && bytes.Compare(job.SplitKey, source.End) >= 0 {
+		return errors.WithStack(ErrMigrationInvalidRoute)
+	}
+	return nil
+}
+
+func rangesIntersect(aStart, aEnd, bStart, bEnd []byte) bool {
+	if len(aEnd) > 0 && bytes.Compare(aEnd, bStart) <= 0 {
+		return false
+	}
+	if len(bEnd) > 0 && bytes.Compare(bEnd, aStart) <= 0 {
+		return false
+	}
+	return true
+}
+
+func hasAnyPrefix(key []byte, prefixes [][]byte) bool {
+	for _, prefix := range prefixes {
+		if bytes.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func cloneByteSlices(in [][]byte) [][]byte {
+	out := make([][]byte, len(in))
+	for i := range in {
+		out[i] = CloneBytes(in[i])
+	}
+	return out
+}

--- a/distribution/migrator.go
+++ b/distribution/migrator.go
@@ -226,6 +226,26 @@ func (b MigrationBracket) ContainsRawKey(rawKey []byte) bool {
 	return !hasAnyPrefix(rawKey, b.ExcludePrefixes)
 }
 
+// ContainsRoutedKey applies both the bracket's raw family interval and its
+// route ownership predicate. S3 bucket-level auxiliary rows do not encode an
+// object route key, so they are matched by bucket route-prefix intersection.
+func (b MigrationBracket) ContainsRoutedKey(rawKey, routeStart, routeEnd []byte, routeKey func([]byte) []byte) bool {
+	if !b.ContainsRawKey(rawKey) {
+		return false
+	}
+	routeEnd = normalizeMigrationRouteEnd(routeEnd)
+	if b.RequiresDecodedS3 {
+		return b.containsDecodedS3Route(rawKey, routeStart, routeEnd)
+	}
+	if !b.RequiresRouteKeyCheck {
+		return true
+	}
+	if routeKey == nil {
+		return false
+	}
+	return routeKeyInRange(routeKey(rawKey), routeStart, routeEnd)
+}
+
 func (b MigrationBracket) containsFamilyShape(rawKey []byte) bool {
 	switch b.Family {
 	case MigrationFamilyListMetaDelta:
@@ -237,6 +257,36 @@ func (b MigrationBracket) containsFamilyShape(rawKey []byte) bool {
 	}
 }
 
+func (b MigrationBracket) containsDecodedS3Route(rawKey, routeStart, routeEnd []byte) bool {
+	bucket, ok := b.decodedS3Bucket(rawKey)
+	if !ok {
+		return false
+	}
+	bucketRouteStart := s3keys.RoutePrefixForBucketAnyGeneration(bucket)
+	return rangesIntersect(routeStart, routeEnd, bucketRouteStart, prefixScanEnd(bucketRouteStart))
+}
+
+func (b MigrationBracket) decodedS3Bucket(rawKey []byte) (string, bool) {
+	switch b.Family {
+	case MigrationFamilyS3BucketMeta:
+		return s3keys.ParseBucketMetaKey(rawKey)
+	case MigrationFamilyS3BucketGeneration:
+		return s3keys.ParseBucketGenerationKey(rawKey)
+	default:
+		return "", false
+	}
+}
+
+func routeKeyInRange(routeKey, routeStart, routeEnd []byte) bool {
+	if len(routeKey) == 0 {
+		return false
+	}
+	if bytes.Compare(routeKey, routeStart) < 0 {
+		return false
+	}
+	return len(routeEnd) == 0 || bytes.Compare(routeKey, routeEnd) < 0
+}
+
 // InitializeSplitJobPlan validates the source route and seeds the job's
 // bracket progress for the moving right child [SplitKey, source.End).
 func InitializeSplitJobPlan(job SplitJob, source RouteDescriptor, nowMs int64) (SplitJob, error) {
@@ -244,7 +294,7 @@ func InitializeSplitJobPlan(job SplitJob, source RouteDescriptor, nowMs int64) (
 		return SplitJob{}, err
 	}
 	routeStart := CloneBytes(job.SplitKey)
-	routeEnd := CloneBytes(source.End)
+	routeEnd := CloneBytes(normalizeMigrationRouteEnd(source.End))
 	brackets, err := PlanExportBrackets(routeStart, routeEnd)
 	if err != nil {
 		return SplitJob{}, err

--- a/distribution/migrator.go
+++ b/distribution/migrator.go
@@ -262,6 +262,9 @@ func (b MigrationBracket) containsDecodedS3Route(rawKey, routeStart, routeEnd []
 	if !ok {
 		return false
 	}
+	if routeKeyInRange(rawKey, routeStart, routeEnd) {
+		return true
+	}
 	bucketRouteStart := s3keys.RoutePrefixForBucketAnyGeneration(bucket)
 	return rangesIntersect(routeStart, routeEnd, bucketRouteStart, prefixScanEnd(bucketRouteStart))
 }

--- a/distribution/migrator_export_plan_test.go
+++ b/distribution/migrator_export_plan_test.go
@@ -145,6 +145,86 @@ func TestPlanMigrationBracketsNormalizesEmptyRouteEnd(t *testing.T) {
 	require.True(t, user.ContainsRawKey([]byte("z")))
 }
 
+func TestSplitJobPlanNormalizesEmptySourceRouteEnd(t *testing.T) {
+	t.Parallel()
+
+	source := RouteDescriptor{
+		RouteID: 9,
+		Start:   []byte("a"),
+		End:     []byte{},
+		GroupID: 3,
+		State:   RouteStateActive,
+	}
+	job := SplitJob{
+		JobID:         1,
+		SourceRouteID: source.RouteID,
+		SplitKey:      []byte("m"),
+		TargetGroupID: source.GroupID,
+		Phase:         SplitJobPhasePlanned,
+	}
+
+	planned, err := InitializeSplitJobPlan(job, source, 1000)
+	require.NoError(t, err)
+	for _, progress := range planned.BracketProgress {
+		if progress.Family != MigrationFamilyUser {
+			continue
+		}
+		require.False(t, progress.Done)
+		return
+	}
+	require.Fail(t, "missing user bracket progress")
+}
+
+func TestMigrationBracketContainsRoutedKeyForS3BucketAuxiliaryState(t *testing.T) {
+	t.Parallel()
+
+	brackets, err := PlanMigrationBrackets([]byte("m"), []byte("z"))
+	require.NoError(t, err)
+	byFamily := bracketsByFamily(brackets)
+
+	routeStart := s3keys.RouteKey("bucket-b", 7, "a")
+	routeEnd := s3keys.RouteKey("bucket-b", 7, "z")
+	for _, tc := range []struct {
+		name   string
+		family uint32
+		key    []byte
+		want   bool
+	}{
+		{name: "meta same bucket", family: MigrationFamilyS3BucketMeta, key: s3keys.BucketMetaKey("bucket-b"), want: true},
+		{name: "generation same bucket", family: MigrationFamilyS3BucketGeneration, key: s3keys.BucketGenerationKey("bucket-b"), want: true},
+		{name: "meta different bucket", family: MigrationFamilyS3BucketMeta, key: s3keys.BucketMetaKey("bucket-c"), want: false},
+		{name: "generation different bucket", family: MigrationFamilyS3BucketGeneration, key: s3keys.BucketGenerationKey("bucket-c"), want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := byFamily[tc.family].ContainsRoutedKey(tc.key, routeStart, routeEnd, s3keys.ExtractRouteKey)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestMigrationBracketContainsRoutedKeyUsesObjectRoutes(t *testing.T) {
+	t.Parallel()
+
+	brackets, err := PlanMigrationBrackets([]byte("m"), []byte("z"))
+	require.NoError(t, err)
+	manifest := bracketsByFamily(brackets)[MigrationFamilyS3ObjectManifest]
+
+	key := s3keys.ObjectManifestKey("bucket-b", 7, "m")
+	require.True(t, manifest.ContainsRoutedKey(
+		key,
+		s3keys.RouteKey("bucket-b", 7, "a"),
+		s3keys.RouteKey("bucket-b", 7, "z"),
+		s3keys.ExtractRouteKey,
+	))
+	require.False(t, manifest.ContainsRoutedKey(
+		key,
+		s3keys.RouteKey("bucket-c", 1, "a"),
+		nil,
+		s3keys.ExtractRouteKey,
+	))
+}
+
 func TestMigrationKnownInternalPrefixesAreConcreteOnly(t *testing.T) {
 	t.Parallel()
 

--- a/distribution/migrator_export_plan_test.go
+++ b/distribution/migrator_export_plan_test.go
@@ -204,6 +204,22 @@ func TestMigrationBracketContainsRoutedKeyForS3BucketAuxiliaryState(t *testing.T
 	}
 }
 
+func TestMigrationBracketContainsRoutedKeyForS3BucketRawRoute(t *testing.T) {
+	t.Parallel()
+
+	brackets, err := PlanMigrationBrackets([]byte("m"), []byte("z"))
+	require.NoError(t, err)
+	byFamily := bracketsByFamily(brackets)
+	routeStart := []byte("!s3|")
+
+	require.True(t, byFamily[MigrationFamilyS3BucketMeta].ContainsRoutedKey(
+		s3keys.BucketMetaKey("bucket-b"), routeStart, nil, s3keys.ExtractRouteKey,
+	))
+	require.True(t, byFamily[MigrationFamilyS3BucketGeneration].ContainsRoutedKey(
+		s3keys.BucketGenerationKey("bucket-b"), routeStart, nil, s3keys.ExtractRouteKey,
+	))
+}
+
 func TestMigrationBracketContainsRoutedKeyUsesObjectRoutes(t *testing.T) {
 	t.Parallel()
 

--- a/distribution/migrator_export_plan_test.go
+++ b/distribution/migrator_export_plan_test.go
@@ -225,6 +225,29 @@ func TestMigrationBracketContainsRoutedKeyUsesObjectRoutes(t *testing.T) {
 	))
 }
 
+func TestMigrationBracketContainsRoutedKeyAcceptsEmptyLogicalRouteKey(t *testing.T) {
+	t.Parallel()
+
+	routeEnd := []byte{0x01}
+	brackets, err := PlanMigrationBrackets(nil, routeEnd)
+	require.NoError(t, err)
+	hash := bracketsByFamily(brackets)[MigrationFamilyHash]
+	rawKey := store.HashMetaKey(nil)
+
+	require.True(t, hash.ContainsRoutedKey(
+		rawKey,
+		nil,
+		routeEnd,
+		store.ExtractHashUserKeyFromMeta,
+	))
+	require.False(t, hash.ContainsRoutedKey(
+		rawKey,
+		nil,
+		routeEnd,
+		func([]byte) []byte { return nil },
+	))
+}
+
 func TestMigrationKnownInternalPrefixesAreConcreteOnly(t *testing.T) {
 	t.Parallel()
 

--- a/distribution/migrator_export_plan_test.go
+++ b/distribution/migrator_export_plan_test.go
@@ -1,0 +1,235 @@
+package distribution
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/s3keys"
+	"github.com/bootjp/elastickv/store"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlanMigrationBracketsIncludesRequiredFamilies(t *testing.T) {
+	t.Parallel()
+
+	brackets, err := PlanMigrationBrackets([]byte("m"), []byte("z"))
+	require.NoError(t, err)
+
+	byFamily := bracketsByFamily(brackets)
+	required := map[uint32]string{
+		MigrationFamilyUser:                            "user",
+		MigrationFamilyTxnIntent:                       migrationTxnIntentPrefix,
+		MigrationFamilyTxnCommit:                       migrationTxnCommitPrefix,
+		MigrationFamilyTxnRollback:                     migrationTxnRollbackPrefix,
+		MigrationFamilyTxnSuccess:                      migrationTxnSuccessPrefix,
+		MigrationFamilyTxnMeta:                         migrationTxnMetaPrefix,
+		MigrationFamilyTxnLock:                         migrationTxnLockPrefix,
+		MigrationFamilyListMeta:                        store.ListMetaPrefix,
+		MigrationFamilyListItem:                        store.ListItemPrefix,
+		MigrationFamilyListMetaDelta:                   store.ListMetaDeltaPrefix,
+		MigrationFamilyListClaim:                       store.ListClaimPrefix,
+		MigrationFamilyRedisLegacy:                     migrationRedisPrefix,
+		MigrationFamilyHash:                            migrationHashPrefix,
+		MigrationFamilySet:                             migrationSetPrefix,
+		MigrationFamilyZSet:                            migrationZSetPrefix,
+		MigrationFamilyStreamMeta:                      store.StreamMetaPrefix,
+		MigrationFamilyStreamEntry:                     store.StreamEntryPrefix,
+		MigrationFamilyDynamoTableMeta:                 migrationDynamoMetaPrefix,
+		MigrationFamilyDynamoTableGeneration:           migrationDynamoGenPrefix,
+		MigrationFamilyDynamoItem:                      migrationDynamoItemPrefix,
+		MigrationFamilyDynamoGSI:                       migrationDynamoGSIPrefix,
+		MigrationFamilySQSQueueMeta:                    migrationSQSQueueMetaPrefix,
+		MigrationFamilySQSQueueGeneration:              migrationSQSQueueGenPrefix,
+		MigrationFamilySQSQueueSequence:                migrationSQSQueueSeqPrefix,
+		MigrationFamilySQSQueueTombstone:               migrationSQSQueueTombstonePrefix,
+		MigrationFamilySQSMessageData:                  migrationSQSMsgDataPrefix,
+		MigrationFamilySQSMessageVisibility:            migrationSQSMsgVisPrefix,
+		MigrationFamilySQSMessageDedup:                 migrationSQSMsgDedupPrefix,
+		MigrationFamilySQSMessageGroup:                 migrationSQSMsgGroupPrefix,
+		MigrationFamilySQSMessageByAge:                 migrationSQSMsgByAgePrefix,
+		MigrationFamilySQSPartitionedMessageData:       migrationSQSMsgDataPrefix + migrationSQSPartitionedSuffix,
+		MigrationFamilySQSPartitionedMessageVisibility: migrationSQSMsgVisPrefix + migrationSQSPartitionedSuffix,
+		MigrationFamilySQSPartitionedMessageDedup:      migrationSQSMsgDedupPrefix + migrationSQSPartitionedSuffix,
+		MigrationFamilySQSPartitionedMessageGroup:      migrationSQSMsgGroupPrefix + migrationSQSPartitionedSuffix,
+		MigrationFamilySQSPartitionedMessageByAge:      migrationSQSMsgByAgePrefix + migrationSQSPartitionedSuffix,
+		MigrationFamilyS3BucketMeta:                    s3keys.BucketMetaPrefix,
+		MigrationFamilyS3BucketGeneration:              s3keys.BucketGenerationPrefix,
+		MigrationFamilyS3ObjectManifest:                s3keys.ObjectManifestPrefix,
+		MigrationFamilyS3UploadMeta:                    s3keys.UploadMetaPrefix,
+		MigrationFamilyS3UploadPart:                    s3keys.UploadPartPrefix,
+		MigrationFamilyS3Blob:                          s3keys.BlobPrefix,
+		MigrationFamilyS3GCUpload:                      s3keys.GCUploadPrefix,
+	}
+
+	for family, prefix := range required {
+		bracket, ok := byFamily[family]
+		require.True(t, ok, "missing family %d", family)
+		require.Equal(t, uint64(family), bracket.BracketID)
+		require.True(t, bracket.RequiresRouteKeyCheck)
+		if family == MigrationFamilyUser {
+			require.Equal(t, []byte("m"), bracket.Start)
+			require.Equal(t, []byte("z"), bracket.End)
+			require.True(t, bracket.ExcludeKnownInternal)
+			continue
+		}
+		require.Equal(t, []byte(prefix), bracket.Start, "family %d start", family)
+		require.Equal(t, prefixScanEnd([]byte(prefix)), bracket.End, "family %d end", family)
+	}
+
+	require.True(t, byFamily[MigrationFamilyTxnLock].DrainOnly)
+	export, err := PlanExportBrackets([]byte("m"), []byte("z"))
+	require.NoError(t, err)
+	_, exportedLock := bracketsByFamily(export)[MigrationFamilyTxnLock]
+	require.False(t, exportedLock, "txn locks are drain-only and must not be exported as data")
+}
+
+func TestPlanMigrationBracketsDisjointPrefixContainment(t *testing.T) {
+	t.Parallel()
+
+	brackets, err := PlanMigrationBrackets([]byte("m"), []byte("z"))
+	require.NoError(t, err)
+	byFamily := bracketsByFamily(brackets)
+
+	listDelta := store.ListMetaDeltaKey([]byte("list"), 1, 0)
+	require.True(t, byFamily[MigrationFamilyListMetaDelta].ContainsRawKey(listDelta))
+	require.False(t, byFamily[MigrationFamilyListMeta].ContainsRawKey(listDelta))
+
+	partitionedSQS := []byte(migrationSQSMsgDataPrefix + migrationSQSPartitionedSuffix + "queue|0|1|msg")
+	require.True(t, byFamily[MigrationFamilySQSPartitionedMessageData].ContainsRawKey(partitionedSQS))
+	require.False(t, byFamily[MigrationFamilySQSMessageData].ContainsRawKey(partitionedSQS))
+
+	user := byFamily[MigrationFamilyUser]
+	user.Start = nil
+	user.End = nil
+	for _, raw := range [][]byte{
+		[]byte("!txn|foo"),
+		[]byte("!stream|foo"),
+		[]byte("!ddb|foo"),
+		[]byte("!sqs|foo"),
+		[]byte("!s3|foo"),
+		[]byte("ordinary-user-key"),
+	} {
+		require.True(t, user.ContainsRawKey(raw), "raw user key %q must stay in familyUser", raw)
+	}
+	for _, raw := range [][]byte{
+		[]byte(migrationTxnSuccessPrefix + "x"),
+		[]byte(store.StreamMetaPrefix + "x"),
+		[]byte(migrationDynamoItemPrefix + "x"),
+		[]byte(migrationSQSMsgVisPrefix + "x"),
+		[]byte(s3keys.ObjectManifestPrefix + "x"),
+		[]byte(migrationRedisPrefix + "string|k"),
+		[]byte(migrationHashPrefix + "meta|x"),
+	} {
+		require.False(t, user.ContainsRawKey(raw), "concrete internal key %q must be excluded from familyUser", raw)
+	}
+}
+
+func TestMigrationKnownInternalPrefixesAreConcreteOnly(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range [][]byte{
+		[]byte(migrationTxnIntentPrefix + "k"),
+		[]byte(migrationTxnSuccessPrefix + "k"),
+		[]byte(store.ListClaimPrefix + "k"),
+		[]byte(store.HashFieldPrefix + "k"),
+		[]byte(store.StreamEntryPrefix + "k"),
+		[]byte(migrationDynamoMetaPrefix + "t"),
+		[]byte(migrationSQSQueueMetaPrefix + "q"),
+		[]byte(s3keys.BlobPrefix + "b"),
+	} {
+		require.True(t, IsMigrationKnownInternalKey(raw), "concrete internal key %q", raw)
+	}
+
+	for _, raw := range [][]byte{
+		[]byte("!txn|foo"),
+		[]byte("!stream|foo"),
+		[]byte("!ddb|foo"),
+		[]byte("!sqs|foo"),
+		[]byte("!s3|foo"),
+	} {
+		require.False(t, IsMigrationKnownInternalKey(raw), "umbrella-looking user key %q", raw)
+	}
+
+	prefixes := MigrationKnownInternalPrefixes()
+	require.NotEmpty(t, prefixes)
+	prefixes[0][0] ^= 0xff
+	require.False(t, bytes.Equal(prefixes[0], MigrationKnownInternalPrefixes()[0]), "prefix list must be cloned")
+}
+
+func TestValidateMigrationRouteRangeRejectsReservedControlPrefixes(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		start []byte
+		end   []byte
+	}{
+		{name: "exact dist", start: []byte("!dist|"), end: prefixScanEnd([]byte("!dist|"))},
+		{name: "migstage", start: []byte("!migstage|"), end: prefixScanEnd([]byte("!migstage|"))},
+		{name: "broad intersection", start: []byte("!"), end: []byte("~")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateMigrationRouteRange(tc.start, tc.end)
+			require.True(t, errors.Is(err, ErrMigrationReservedRange), "got %v", err)
+		})
+	}
+
+	require.NoError(t, ValidateMigrationRouteRange([]byte("m"), []byte("z")))
+	err := ValidateMigrationRouteRange([]byte("z"), []byte("m"))
+	require.True(t, errors.Is(err, ErrMigrationInvalidRoute), "got %v", err)
+}
+
+func TestSplitJobPlannerAndSameGroupNoop(t *testing.T) {
+	t.Parallel()
+
+	source := RouteDescriptor{
+		RouteID: 9,
+		Start:   []byte("a"),
+		End:     []byte("z"),
+		GroupID: 3,
+		State:   RouteStateActive,
+	}
+	job := SplitJob{
+		JobID:         1,
+		SourceRouteID: source.RouteID,
+		SplitKey:      []byte("m"),
+		TargetGroupID: source.GroupID,
+		Phase:         SplitJobPhasePlanned,
+	}
+
+	planned, err := InitializeSplitJobPlan(job, source, 1000)
+	require.NoError(t, err)
+	require.Equal(t, SplitJobPhasePlanned, planned.Phase)
+	require.NotEmpty(t, planned.BracketProgress)
+	require.Equal(t, int64(1000), planned.StartedAtMs)
+	require.Equal(t, int64(1000), planned.UpdatedAtMs)
+	for _, progress := range planned.BracketProgress {
+		require.Equal(t, SplitJobExportPhaseBackfill, progress.ExportPhase)
+		require.NotEqual(t, MigrationFamilyTxnLock, progress.Family)
+	}
+
+	done, err := AdvanceSameGroupNoop(job, source, 2000)
+	require.NoError(t, err)
+	require.Equal(t, SplitJobPhaseDone, done.Phase)
+	require.True(t, done.TargetPromotionDone)
+	require.Equal(t, uint64(2000), done.PromotionCompletedTS)
+	require.Equal(t, int64(2000), done.TerminalAtMs)
+	for _, progress := range done.BracketProgress {
+		require.True(t, progress.Done)
+	}
+
+	crossGroup := job
+	crossGroup.TargetGroupID = source.GroupID + 1
+	_, err = AdvanceSameGroupNoop(crossGroup, source, 3000)
+	require.True(t, errors.Is(err, ErrMigrationDataMoveRequired), "got %v", err)
+}
+
+func bracketsByFamily(brackets []MigrationBracket) map[uint32]MigrationBracket {
+	out := make(map[uint32]MigrationBracket, len(brackets))
+	for _, bracket := range brackets {
+		out[bracket.Family] = bracket
+	}
+	return out
+}

--- a/distribution/migrator_export_plan_test.go
+++ b/distribution/migrator_export_plan_test.go
@@ -2,6 +2,7 @@ package distribution
 
 import (
 	"bytes"
+	"encoding/binary"
 	"testing"
 
 	"github.com/bootjp/elastickv/internal/s3keys"
@@ -101,7 +102,7 @@ func TestPlanMigrationBracketsDisjointPrefixContainment(t *testing.T) {
 	require.True(t, byFamily[MigrationFamilyListMetaDelta].ContainsRawKey(listDelta))
 	require.False(t, byFamily[MigrationFamilyListMeta].ContainsRawKey(listDelta))
 
-	listMetaWithDeltaLookingUserKey := store.ListMetaKey([]byte("d|list"))
+	listMetaWithDeltaLookingUserKey := store.ListMetaKey(deltaLookingListMetaUserKey([]byte("list"), 2, 0))
 	require.True(t, byFamily[MigrationFamilyListMeta].ContainsRawKey(listMetaWithDeltaLookingUserKey))
 	require.False(t, byFamily[MigrationFamilyListMetaDelta].ContainsRawKey(listMetaWithDeltaLookingUserKey))
 
@@ -355,4 +356,19 @@ func bracketsByFamily(brackets []MigrationBracket) map[uint32]MigrationBracket {
 		out[bracket.Family] = bracket
 	}
 	return out
+}
+
+func deltaLookingListMetaUserKey(fakeUserKey []byte, commitTS uint64, seqInTxn uint32) []byte {
+	key := make([]byte, 0, len("d|")+4+len(fakeUserKey)+8+4)
+	key = append(key, "d|"...)
+	var lenPrefix [4]byte
+	binary.BigEndian.PutUint32(lenPrefix[:], uint32(len(fakeUserKey))) //nolint:gosec // test data is small.
+	key = append(key, lenPrefix[:]...)
+	key = append(key, fakeUserKey...)
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], commitTS)
+	key = append(key, ts[:]...)
+	var seq [4]byte
+	binary.BigEndian.PutUint32(seq[:], seqInTxn)
+	return append(key, seq[:]...)
 }

--- a/distribution/migrator_export_plan_test.go
+++ b/distribution/migrator_export_plan_test.go
@@ -66,7 +66,13 @@ func TestPlanMigrationBracketsIncludesRequiredFamilies(t *testing.T) {
 		bracket, ok := byFamily[family]
 		require.True(t, ok, "missing family %d", family)
 		require.Equal(t, uint64(family), bracket.BracketID)
-		require.True(t, bracket.RequiresRouteKeyCheck)
+		if family == MigrationFamilyS3BucketMeta || family == MigrationFamilyS3BucketGeneration {
+			require.False(t, bracket.RequiresRouteKeyCheck)
+			require.True(t, bracket.RequiresDecodedS3)
+		} else {
+			require.True(t, bracket.RequiresRouteKeyCheck)
+			require.False(t, bracket.RequiresDecodedS3)
+		}
 		if family == MigrationFamilyUser {
 			require.Equal(t, []byte("m"), bracket.Start)
 			require.Equal(t, []byte("z"), bracket.End)
@@ -94,6 +100,10 @@ func TestPlanMigrationBracketsDisjointPrefixContainment(t *testing.T) {
 	listDelta := store.ListMetaDeltaKey([]byte("list"), 1, 0)
 	require.True(t, byFamily[MigrationFamilyListMetaDelta].ContainsRawKey(listDelta))
 	require.False(t, byFamily[MigrationFamilyListMeta].ContainsRawKey(listDelta))
+
+	listMetaWithDeltaLookingUserKey := store.ListMetaKey([]byte("d|list"))
+	require.True(t, byFamily[MigrationFamilyListMeta].ContainsRawKey(listMetaWithDeltaLookingUserKey))
+	require.False(t, byFamily[MigrationFamilyListMetaDelta].ContainsRawKey(listMetaWithDeltaLookingUserKey))
 
 	partitionedSQS := []byte(migrationSQSMsgDataPrefix + migrationSQSPartitionedSuffix + "queue|0|1|msg")
 	require.True(t, byFamily[MigrationFamilySQSPartitionedMessageData].ContainsRawKey(partitionedSQS))
@@ -123,6 +133,16 @@ func TestPlanMigrationBracketsDisjointPrefixContainment(t *testing.T) {
 	} {
 		require.False(t, user.ContainsRawKey(raw), "concrete internal key %q must be excluded from familyUser", raw)
 	}
+}
+
+func TestPlanMigrationBracketsNormalizesEmptyRouteEnd(t *testing.T) {
+	t.Parallel()
+
+	brackets, err := PlanMigrationBrackets([]byte("m"), []byte{})
+	require.NoError(t, err)
+	user := bracketsByFamily(brackets)[MigrationFamilyUser]
+	require.Nil(t, user.End)
+	require.True(t, user.ContainsRawKey([]byte("z")))
 }
 
 func TestMigrationKnownInternalPrefixesAreConcreteOnly(t *testing.T) {

--- a/internal/backup/redis_list.go
+++ b/internal/backup/redis_list.go
@@ -42,11 +42,16 @@ import (
 //     source of truth and the
 //     delta arithmetic is not
 //     replayed at backup time.
+//   - !lst|meta|d|...                 -> legacy meta delta. This overlaps
+//     with base !lst|meta| keys whose user key begins with d|, so routing
+//     checks both the key prefix and the 16-byte delta value shape before
+//     dropping it as a delta.
 const (
-	ListMetaPrefix      = "!lst|meta|"
-	ListItemPrefix      = "!lst|itm|"
-	ListMetaDeltaPrefix = "!lst|delta|"
-	ListClaimPrefix     = "!lst|claim|"
+	ListMetaPrefix            = "!lst|meta|"
+	ListItemPrefix            = "!lst|itm|"
+	ListMetaDeltaPrefix       = "!lst|delta|"
+	LegacyListMetaDeltaPrefix = "!lst|meta|d|"
+	ListClaimPrefix           = "!lst|claim|"
 
 	// listMetaBinarySize mirrors store/list_helpers.go (24 bytes:
 	// Head(8) + Tail(8) + Len(8)). Re-declared here rather than
@@ -57,6 +62,8 @@ const (
 	// listSeqBytes is the fixed width of the trailing sortable-int64
 	// sequence number in an !lst|itm| key.
 	listSeqBytes = 8
+
+	listMetaDeltaBinarySize = 16
 )
 
 // ErrRedisInvalidListMeta is returned when an !lst|meta| value is not
@@ -90,7 +97,7 @@ type redisListState struct {
 // records are the source of truth for the restored list contents and
 // the delta arithmetic does not need to be replayed at backup time.
 func (r *RedisDB) HandleListMeta(key, value []byte) error {
-	if bytes.HasPrefix(key, []byte(ListMetaDeltaPrefix)) {
+	if isListMetaDeltaRecord(key, value) {
 		return nil
 	}
 	userKey, ok := parseListMetaKey(key)
@@ -171,6 +178,14 @@ func parseListMetaKey(key []byte) ([]byte, bool) {
 		return nil, false
 	}
 	return rest, true
+}
+
+func isListMetaDeltaRecord(key, value []byte) bool {
+	if bytes.HasPrefix(key, []byte(ListMetaDeltaPrefix)) {
+		return true
+	}
+	return bytes.HasPrefix(key, []byte(LegacyListMetaDeltaPrefix)) &&
+		len(value) == listMetaDeltaBinarySize
 }
 
 // parseListItemKey strips !lst|itm| and extracts (userKey, seq). The

--- a/internal/backup/redis_list.go
+++ b/internal/backup/redis_list.go
@@ -33,7 +33,7 @@ import (
 //     item record for the popped
 //     seq. The encoder therefore
 //     skips claim keys entirely.
-//   - !lst|meta|d|...                 -> meta delta. The hash encoder
+//   - !lst|delta|...                  -> meta delta. The hash encoder
 //     skips its analogous deltas
 //     and treats !hs|fld| as the
 //     source of truth; the list
@@ -45,7 +45,7 @@ import (
 const (
 	ListMetaPrefix      = "!lst|meta|"
 	ListItemPrefix      = "!lst|itm|"
-	ListMetaDeltaPrefix = "!lst|meta|d|"
+	ListMetaDeltaPrefix = "!lst|delta|"
 	ListClaimPrefix     = "!lst|claim|"
 
 	// listMetaBinarySize mirrors store/list_helpers.go (24 bytes:
@@ -85,11 +85,8 @@ type redisListState struct {
 // register the user key so a later !redis|ttl|<userKey> record routes
 // back to this list state.
 //
-// !lst|meta|d|<userKey>... delta keys share the !lst|meta| string
-// prefix, so a snapshot dispatcher that routes by "starts with
-// ListMetaPrefix" lands delta records here too. The hash encoder
-// solved the analogous problem (Codex P1 round 14 PR #725) by silently
-// skipping the delta family; we mirror that policy because !lst|itm|
+// List deltas normally dispatch through HandleListMetaDelta, but keep
+// the guard here so direct callers also skip the delta family. !lst|itm|
 // records are the source of truth for the restored list contents and
 // the delta arithmetic does not need to be replayed at backup time.
 func (r *RedisDB) HandleListMeta(key, value []byte) error {
@@ -140,7 +137,7 @@ func (r *RedisDB) HandleListItem(key, value []byte) error {
 // therefore reflect the post-POP state without any claim replay.
 func (r *RedisDB) HandleListClaim(_, _ []byte) error { return nil }
 
-// HandleListMetaDelta accepts and discards one !lst|meta|d|... record.
+// HandleListMetaDelta accepts and discards one !lst|delta|... record.
 // See HandleListMeta's docstring for the rationale; !lst|itm| is the
 // source of truth at backup time.
 func (r *RedisDB) HandleListMetaDelta(_, _ []byte) error { return nil }
@@ -162,10 +159,9 @@ func (r *RedisDB) listState(userKey []byte) *redisListState {
 // parseListMetaKey strips !lst|meta| from a meta key and returns
 // (userKey, true). The list meta key shape is `prefix + userKey` with
 // no length prefix (mirror of store.ListMetaKey), so the trimmed
-// remainder is the userKey verbatim. Delta keys (!lst|meta|d|...)
-// share the meta string prefix and must be rejected here so a
-// misrouted delta surfaces a parse failure rather than silent state
-// corruption — analogous to parseHashMetaKey's delta guard.
+// remainder is the userKey verbatim. Delta keys are rejected here so
+// a misrouted delta surfaces a parse failure rather than silent state
+// corruption.
 func parseListMetaKey(key []byte) ([]byte, bool) {
 	if bytes.HasPrefix(key, []byte(ListMetaDeltaPrefix)) {
 		return nil, false

--- a/internal/backup/redis_list_test.go
+++ b/internal/backup/redis_list_test.go
@@ -40,7 +40,7 @@ func listItemKey(userKey string, seq int64) []byte {
 }
 
 // listMetaDeltaKey mirrors store.ListMetaDeltaKey:
-// !lst|meta|d|<userKeyLen(4)><userKey><commitTS(8)><seqInTxn(4)>.
+// !lst|delta|<userKeyLen(4)><userKey><commitTS(8)><seqInTxn(4)>.
 // The shape is irrelevant to the encoder (it skips deltas), but we
 // build a well-formed key here so the dispatcher integration test
 // would exercise the same byte sequence the live store emits.
@@ -275,10 +275,9 @@ func TestRedisDB_ListBinaryItemUsesBase64Envelope(t *testing.T) {
 }
 
 // TestRedisDB_ListHandleListMetaSkipsDeltaKey pins that the
-// !lst|meta|d|... family is silently skipped by HandleListMeta. Without
+// !lst|delta|... family is silently skipped by HandleListMeta. Without
 // this, parsing the delta's userKeyLen prefix as the start of a
-// userKey would corrupt the lists map. Mirrors the hash delta-key
-// guard (Codex P1 round 14 PR #725).
+// userKey would corrupt the lists map. Mirrors the hash delta-key guard.
 func TestRedisDB_ListHandleListMetaSkipsDeltaKey(t *testing.T) {
 	t.Parallel()
 	db, _ := newRedisDB(t)
@@ -353,7 +352,7 @@ func TestRedisDB_ListRejectsMalformedMetaValueLength(t *testing.T) {
 // firing the declared-vs-observed length mismatch warning (because
 // metaSeen=false means we have no "declared" baseline to compare
 // against). Mirrors the items-as-source-of-truth contract that
-// makes the !lst|meta|d| delta family safe to skip.
+// makes the !lst|delta| delta family safe to skip.
 func TestRedisDB_ListItemsWithoutMetaStillEmitsFile(t *testing.T) {
 	t.Parallel()
 	db, root := newRedisDB(t)

--- a/internal/backup/redis_list_test.go
+++ b/internal/backup/redis_list_test.go
@@ -58,6 +58,20 @@ func listMetaDeltaKey(userKey string, commitTS uint64, seqInTxn uint32) []byte {
 	return append(out, seq[:]...)
 }
 
+func legacyListMetaDeltaKey(userKey string, commitTS uint64, seqInTxn uint32) []byte {
+	out := []byte(LegacyListMetaDeltaPrefix)
+	var l [4]byte
+	binary.BigEndian.PutUint32(l[:], uint32(len(userKey))) //nolint:gosec
+	out = append(out, l[:]...)
+	out = append(out, userKey...)
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], commitTS)
+	out = append(out, ts[:]...)
+	var seq [4]byte
+	binary.BigEndian.PutUint32(seq[:], seqInTxn)
+	return append(out, seq[:]...)
+}
+
 // listClaimKey mirrors store.ListClaimKey:
 // !lst|claim|<userKeyLen(4)><userKey><sortable_seq(8)>.
 func listClaimKey(userKey string, seq int64) []byte {
@@ -185,6 +199,45 @@ func TestRedisDB_ListEmptyListStillEmitsFile(t *testing.T) {
 	if items := listItemsArray(t, got); len(items) != 0 {
 		t.Fatalf("empty list should emit empty items array, got %v", items)
 	}
+}
+
+func TestRedisDB_ListLegacyDeltaIsSkippedButDeltaLookingMetaIsPreserved(t *testing.T) {
+	t.Parallel()
+	db, root := newRedisDB(t)
+	if err := db.HandleListMeta(legacyListMetaDeltaKey("q", 10, 0), make([]byte, listMetaDeltaBinarySize)); err != nil {
+		t.Fatal(err)
+	}
+	userKey := string(deltaLookingListMetaUserKeyForBackup([]byte("real"), 11, 1))
+	if err := db.HandleListMeta(listMetaKey(userKey), listMetaValue(0, 1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.HandleListItem(listItemKey(userKey, 0), []byte("v")); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Finalize(); err != nil {
+		t.Fatal(err)
+	}
+
+	got := readListJSON(t, filepath.Join(root, "redis", "db_0", "lists", EncodeSegment([]byte(userKey))+".json"))
+	assertListItems(t, got, []any{"v"})
+	if _, err := os.Stat(filepath.Join(root, "redis", "db_0", "lists", "q.json")); !os.IsNotExist(err) {
+		t.Fatalf("legacy delta must not emit q.json: stat err=%v", err)
+	}
+}
+
+func deltaLookingListMetaUserKeyForBackup(fakeUserKey []byte, commitTS uint64, seqInTxn uint32) []byte {
+	key := make([]byte, 0, len("d|")+4+len(fakeUserKey)+8+4)
+	key = append(key, "d|"...)
+	var lenPrefix [4]byte
+	binary.BigEndian.PutUint32(lenPrefix[:], uint32(len(fakeUserKey))) //nolint:gosec // test data is small.
+	key = append(key, lenPrefix[:]...)
+	key = append(key, fakeUserKey...)
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], commitTS)
+	key = append(key, ts[:]...)
+	var seq [4]byte
+	binary.BigEndian.PutUint32(seq[:], seqInTxn)
+	return append(key, seq[:]...)
 }
 
 // TestRedisDB_ListTTLInlinedFromScanIndex pins that !redis|ttl| records

--- a/internal/s3keys/keys.go
+++ b/internal/s3keys/keys.go
@@ -80,6 +80,17 @@ func ParseBucketMetaKey(key []byte) (string, bool) {
 	return string(segment), true
 }
 
+func ParseBucketGenerationKey(key []byte) (string, bool) {
+	if !bytes.HasPrefix(key, bucketGenerationPrefixBytes) {
+		return "", false
+	}
+	segment, next, ok := decodeSegment(key, len(bucketGenerationPrefixBytes))
+	if !ok || next != len(key) {
+		return "", false
+	}
+	return string(segment), true
+}
+
 func ObjectManifestKey(bucket string, generation uint64, object string) []byte {
 	return buildObjectKey(objectManifestPrefixBytes, bucket, generation, object, "", 0, 0)
 }
@@ -225,6 +236,13 @@ func GCUploadPrefixForBucket(bucket string, generation uint64) []byte {
 
 func RoutePrefixForBucket(bucket string, generation uint64) []byte {
 	return bucketScopedPrefix(routePrefixBytes, bucket, generation)
+}
+
+func RoutePrefixForBucketAnyGeneration(bucket string) []byte {
+	out := make([]byte, 0, len(RoutePrefix)+len(bucket)+segmentEscapeOverhead)
+	out = append(out, routePrefixBytes...)
+	out = append(out, EncodeSegment([]byte(bucket))...)
+	return out
 }
 
 func bucketScopedPrefix(prefix []byte, bucket string, generation uint64) []byte {

--- a/internal/s3keys/keys_test.go
+++ b/internal/s3keys/keys_test.go
@@ -18,6 +18,17 @@ func TestBucketMetaKey_RoundTripsZeroByteSegments(t *testing.T) {
 	require.Equal(t, bucket, parsed)
 }
 
+func TestBucketGenerationKey_RoundTripsZeroByteSegments(t *testing.T) {
+	t.Parallel()
+
+	bucket := string([]byte{'b', 'u', 0x00, 'c', 'k', 'e', 't'})
+	key := BucketGenerationKey(bucket)
+
+	parsed, ok := ParseBucketGenerationKey(key)
+	require.True(t, ok)
+	require.Equal(t, bucket, parsed)
+}
+
 func TestObjectManifestKey_RoundTripsZeroByteSegments(t *testing.T) {
 	t.Parallel()
 
@@ -50,6 +61,17 @@ func TestExtractRouteKey_ObjectScopedKeys(t *testing.T) {
 	for _, key := range keys {
 		require.Equal(t, want, ExtractRouteKey(key))
 	}
+}
+
+func TestRoutePrefixForBucketAnyGeneration(t *testing.T) {
+	t.Parallel()
+
+	bucket := string([]byte{'b', 0x00, 'k'})
+	prefix := RoutePrefixForBucketAnyGeneration(bucket)
+
+	require.True(t, bytes.HasPrefix(RouteKey(bucket, 1, "a"), prefix))
+	require.True(t, bytes.HasPrefix(RouteKey(bucket, 2, "b"), prefix))
+	require.False(t, bytes.HasPrefix(RouteKey("other", 1, "a"), prefix))
 }
 
 func TestManifestScanRouteBounds(t *testing.T) {

--- a/kv/migrator_filter.go
+++ b/kv/migrator_filter.go
@@ -10,20 +10,29 @@ import (
 // rangeEnd nil or empty means +infinity, matching the route descriptor wire
 // convention.
 func RouteKeyFilter(rangeStart, rangeEnd []byte) func([]byte) bool {
+	return RouteKeyFilterForGroup(rangeStart, rangeEnd, 0, nil)
+}
+
+// RouteKeyFilterForGroup returns the migration export predicate for a source
+// route and group. Partition-resolved keyspaces such as HT-FIFO SQS are matched
+// by resolver group instead of the byte-range route key.
+func RouteKeyFilterForGroup(rangeStart, rangeEnd []byte, sourceGroupID uint64, resolver PartitionResolver) func([]byte) bool {
 	start := bytes.Clone(rangeStart)
 	end := bytes.Clone(rangeEnd)
 	return func(rawKey []byte) bool {
+		if resolver != nil {
+			if gid, ok := resolver.ResolveGroup(rawKey); ok {
+				return gid == sourceGroupID
+			}
+			if resolver.RecognisesPartitionedKey(rawKey) {
+				return false
+			}
+		}
 		if s3BucketAuxiliaryRouteInRange(rawKey, start, end) {
 			return true
 		}
 		rkey := routeKey(rawKey)
-		if bytes.Compare(rkey, start) < 0 {
-			return false
-		}
-		if len(end) > 0 && bytes.Compare(rkey, end) >= 0 {
-			return false
-		}
-		return true
+		return keyInMigrationRouteRange(rkey, start, end)
 	}
 }
 
@@ -35,8 +44,21 @@ func s3BucketAuxiliaryRouteInRange(rawKey, routeStart, routeEnd []byte) bool {
 	if !ok {
 		return false
 	}
+	if keyInMigrationRouteRange(rawKey, routeStart, routeEnd) {
+		return true
+	}
 	bucketRouteStart := s3keys.RoutePrefixForBucketAnyGeneration(bucket)
 	return migrationRouteRangesIntersect(routeStart, routeEnd, bucketRouteStart, prefixScanEnd(bucketRouteStart))
+}
+
+func keyInMigrationRouteRange(key, routeStart, routeEnd []byte) bool {
+	if key == nil {
+		return false
+	}
+	if bytes.Compare(key, routeStart) < 0 {
+		return false
+	}
+	return len(routeEnd) == 0 || bytes.Compare(key, routeEnd) < 0
 }
 
 func migrationRouteRangesIntersect(aStart, aEnd, bStart, bEnd []byte) bool {

--- a/kv/migrator_filter.go
+++ b/kv/migrator_filter.go
@@ -1,0 +1,21 @@
+package kv
+
+import "bytes"
+
+// RouteKeyFilter returns the migration export predicate for raw MVCC keys.
+// rangeEnd nil or empty means +infinity, matching the route descriptor wire
+// convention.
+func RouteKeyFilter(rangeStart, rangeEnd []byte) func([]byte) bool {
+	start := bytes.Clone(rangeStart)
+	end := bytes.Clone(rangeEnd)
+	return func(rawKey []byte) bool {
+		rkey := routeKey(rawKey)
+		if bytes.Compare(rkey, start) < 0 {
+			return false
+		}
+		if len(end) > 0 && bytes.Compare(rkey, end) >= 0 {
+			return false
+		}
+		return true
+	}
+}

--- a/kv/migrator_filter.go
+++ b/kv/migrator_filter.go
@@ -1,6 +1,10 @@
 package kv
 
-import "bytes"
+import (
+	"bytes"
+
+	"github.com/bootjp/elastickv/internal/s3keys"
+)
 
 // RouteKeyFilter returns the migration export predicate for raw MVCC keys.
 // rangeEnd nil or empty means +infinity, matching the route descriptor wire
@@ -9,6 +13,9 @@ func RouteKeyFilter(rangeStart, rangeEnd []byte) func([]byte) bool {
 	start := bytes.Clone(rangeStart)
 	end := bytes.Clone(rangeEnd)
 	return func(rawKey []byte) bool {
+		if s3BucketAuxiliaryRouteInRange(rawKey, start, end) {
+			return true
+		}
 		rkey := routeKey(rawKey)
 		if bytes.Compare(rkey, start) < 0 {
 			return false
@@ -18,4 +25,26 @@ func RouteKeyFilter(rangeStart, rangeEnd []byte) func([]byte) bool {
 		}
 		return true
 	}
+}
+
+func s3BucketAuxiliaryRouteInRange(rawKey, routeStart, routeEnd []byte) bool {
+	bucket, ok := s3keys.ParseBucketMetaKey(rawKey)
+	if !ok {
+		bucket, ok = s3keys.ParseBucketGenerationKey(rawKey)
+	}
+	if !ok {
+		return false
+	}
+	bucketRouteStart := s3keys.RoutePrefixForBucketAnyGeneration(bucket)
+	return migrationRouteRangesIntersect(routeStart, routeEnd, bucketRouteStart, prefixScanEnd(bucketRouteStart))
+}
+
+func migrationRouteRangesIntersect(aStart, aEnd, bStart, bEnd []byte) bool {
+	if len(aEnd) > 0 && bytes.Compare(aEnd, bStart) <= 0 {
+		return false
+	}
+	if len(bEnd) > 0 && bytes.Compare(bEnd, aStart) <= 0 {
+		return false
+	}
+	return true
 }

--- a/kv/shard_key.go
+++ b/kv/shard_key.go
@@ -149,14 +149,16 @@ func dynamoRouteTableKey(tableSegment []byte) []byte {
 }
 
 func listRouteKey(key []byte) []byte {
-	switch {
-	case store.IsListMetaDeltaKey(key):
-		return store.ExtractListUserKeyFromDelta(key)
-	case store.IsListClaimKey(key):
-		return store.ExtractListUserKeyFromClaim(key)
-	default:
-		return nil
+	if userKey := store.ExtractListUserKeyFromDelta(key); userKey != nil {
+		return userKey
 	}
+	if userKey := store.ExtractLegacyListUserKeyFromDelta(key); userKey != nil {
+		return userKey
+	}
+	if userKey := store.ExtractListUserKeyFromClaim(key); userKey != nil {
+		return userKey
+	}
+	return nil
 }
 
 func hashRouteKey(key []byte) []byte {

--- a/kv/shard_key.go
+++ b/kv/shard_key.go
@@ -36,6 +36,17 @@ const (
 	// family (!sqs|queue|meta|, !sqs|msg|vis|, etc.). Used by
 	// sqsRouteKey to dispatch the routing decision.
 	sqsInternalPrefix = "!sqs|"
+
+	sqsQueueMetaPrefix      = "!sqs|queue|meta|"
+	sqsQueueGenPrefix       = "!sqs|queue|gen|"
+	sqsQueueSeqPrefix       = "!sqs|queue|seq|"
+	sqsQueueTombstonePrefix = "!sqs|queue|tombstone|"
+	sqsMsgDataPrefix        = "!sqs|msg|data|"
+	sqsMsgVisPrefix         = "!sqs|msg|vis|"
+	sqsMsgDedupPrefix       = "!sqs|msg|dedup|"
+	sqsMsgGroupPrefix       = "!sqs|msg|group|"
+	sqsMsgByAgePrefix       = "!sqs|msg|byage|"
+	sqsPartitionMarker      = "p|"
 )
 
 var (
@@ -44,8 +55,31 @@ var (
 	dynamoTableGenerationPrefixBytes = []byte(DynamoTableGenerationPrefix)
 	dynamoItemPrefixBytes            = []byte(DynamoItemPrefix)
 	dynamoGSIPrefixBytes             = []byte(DynamoGSIPrefix)
-	sqsRoutePrefixBytes              = []byte(sqsRoutePrefix)
 	sqsInternalPrefixBytes           = []byte(sqsInternalPrefix)
+	sqsGlobalRouteKey                = []byte(sqsRoutePrefix + "global")
+	sqsConcreteInternalPrefixBytes   = [][]byte{
+		[]byte(sqsQueueMetaPrefix),
+		[]byte(sqsQueueGenPrefix),
+		[]byte(sqsQueueSeqPrefix),
+		[]byte(sqsQueueTombstonePrefix),
+		[]byte(sqsMsgDataPrefix),
+		[]byte(sqsMsgVisPrefix),
+		[]byte(sqsMsgDedupPrefix),
+		[]byte(sqsMsgGroupPrefix),
+		[]byte(sqsMsgByAgePrefix),
+	}
+	routeKeyExtractors = []func([]byte) []byte{
+		redisRouteKey,
+		dynamoRouteKey,
+		sqsRouteKey,
+		s3keys.ExtractRouteKey,
+		listRouteKey,
+		hashRouteKey,
+		setRouteKey,
+		zsetRouteKey,
+		streamRouteKey,
+		store.ExtractListUserKey,
+	}
 )
 
 // routeKey normalizes internal keys (e.g., list metadata/items) to the logical
@@ -61,20 +95,10 @@ func routeKey(key []byte) []byte {
 }
 
 func normalizeRouteKey(key []byte) []byte {
-	if user := redisRouteKey(key); user != nil {
-		return user
-	}
-	if table := dynamoRouteKey(key); table != nil {
-		return table
-	}
-	if route := sqsRouteKey(key); route != nil {
-		return route
-	}
-	if user := s3keys.ExtractRouteKey(key); user != nil {
-		return user
-	}
-	if user := store.ExtractListUserKey(key); user != nil {
-		return user
+	for _, extract := range routeKeyExtractors {
+		if user := extract(key); user != nil {
+			return user
+		}
 	}
 	return key
 }
@@ -124,19 +148,87 @@ func dynamoRouteTableKey(tableSegment []byte) []byte {
 	return out
 }
 
-// sqsRouteKey maps any !sqs|... internal key to a stable route key so
-// multi-shard deployments that partition by user-key range still land
-// every SQS mutation on a configured group. Milestone 1 collapses all
-// SQS keys to a single !sqs|route|global route — this keeps the
-// catalog and every queue's message keyspace on the same group, which
-// is the minimum needed for FIFO group-lock semantics (landing later)
-// to work. When per-queue sharding is implemented it will live here.
+func listRouteKey(key []byte) []byte {
+	switch {
+	case store.IsListMetaDeltaKey(key):
+		return store.ExtractListUserKeyFromDelta(key)
+	case store.IsListClaimKey(key):
+		return store.ExtractListUserKeyFromClaim(key)
+	default:
+		return nil
+	}
+}
+
+func hashRouteKey(key []byte) []byte {
+	switch {
+	case store.IsHashMetaDeltaKey(key):
+		return store.ExtractHashUserKeyFromDelta(key)
+	case store.IsHashMetaKey(key):
+		return store.ExtractHashUserKeyFromMeta(key)
+	case store.IsHashFieldKey(key):
+		return store.ExtractHashUserKeyFromField(key)
+	default:
+		return nil
+	}
+}
+
+func setRouteKey(key []byte) []byte {
+	switch {
+	case store.IsSetMetaDeltaKey(key):
+		return store.ExtractSetUserKeyFromDelta(key)
+	case store.IsSetMetaKey(key):
+		return store.ExtractSetUserKeyFromMeta(key)
+	case store.IsSetMemberKey(key):
+		return store.ExtractSetUserKeyFromMember(key)
+	default:
+		return nil
+	}
+}
+
+func zsetRouteKey(key []byte) []byte {
+	switch {
+	case store.IsZSetMetaDeltaKey(key):
+		return store.ExtractZSetUserKeyFromDelta(key)
+	case store.IsZSetMetaKey(key):
+		return store.ExtractZSetUserKeyFromMeta(key)
+	case store.IsZSetMemberKey(key):
+		return store.ExtractZSetUserKeyFromMember(key)
+	case store.IsZSetScoreKey(key):
+		return store.ExtractZSetUserKeyFromScore(key)
+	default:
+		return nil
+	}
+}
+
+func streamRouteKey(key []byte) []byte {
+	switch {
+	case store.IsStreamMetaKey(key):
+		return store.ExtractStreamUserKeyFromMeta(key)
+	case store.IsStreamEntryKey(key):
+		return store.ExtractStreamUserKeyFromEntry(key)
+	default:
+		return nil
+	}
+}
+
+// sqsRouteKey maps concrete persisted !sqs|... storage prefixes to a stable
+// route key. Adapter-looking raw user keys such as !sqs|foo intentionally stay
+// on their raw route and migrate through the user-key bracket.
 func sqsRouteKey(key []byte) []byte {
 	if !bytes.HasPrefix(key, sqsInternalPrefixBytes) {
 		return nil
 	}
-	out := make([]byte, 0, len(sqsRoutePrefixBytes)+len("global"))
-	out = append(out, sqsRoutePrefixBytes...)
-	out = append(out, []byte("global")...)
-	return out
+	if !hasSQSConcreteInternalPrefix(key) {
+		return nil
+	}
+	return sqsGlobalRouteKey
+}
+
+func hasSQSConcreteInternalPrefix(key []byte) bool {
+	for _, prefix := range sqsConcreteInternalPrefixBytes {
+		if bytes.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/kv/shard_key_test.go
+++ b/kv/shard_key_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/bootjp/elastickv/internal/s3keys"
+	"github.com/bootjp/elastickv/store"
 	"github.com/stretchr/testify/require"
 )
 
@@ -94,4 +95,102 @@ func TestRouteKey_CollapsesDynamoGenerationsToSameTableRoute(t *testing.T) {
 	require.Equal(t, want, routeKey(currentGSIKey))
 	require.Equal(t, want, routeKey(sourceGSIKey),
 		"migration source generation GSI key must route to the same table group as the current generation")
+}
+
+func TestRouteKey_NormalizesCollectionMigrationFamilies(t *testing.T) {
+	t.Parallel()
+
+	userKey := []byte("redis:user|with|separators")
+	cases := [][]byte{
+		store.ListMetaDeltaKey(userKey, 10, 1),
+		store.ListClaimKey(userKey, -2),
+		store.HashMetaKey(userKey),
+		store.HashFieldKey(userKey, []byte("field")),
+		store.HashMetaDeltaKey(userKey, 11, 2),
+		store.SetMetaKey(userKey),
+		store.SetMemberKey(userKey, []byte("member")),
+		store.SetMetaDeltaKey(userKey, 12, 3),
+		store.ZSetMetaKey(userKey),
+		store.ZSetMemberKey(userKey, []byte("member")),
+		store.ZSetScoreKey(userKey, 1.25, []byte("member")),
+		store.ZSetMetaDeltaKey(userKey, 13, 4),
+		store.StreamMetaKey(userKey),
+		store.StreamEntryKey(userKey, 14, 5),
+	}
+
+	for _, raw := range cases {
+		require.Equal(t, userKey, routeKey(raw), "raw key %q must route by its logical user key", raw)
+	}
+}
+
+func TestRouteKey_NormalizesTxnSuccessMarkerByLockedKey(t *testing.T) {
+	t.Parallel()
+
+	lockedKey := []byte("secondary|key\x00with|separators")
+	primaryKey := []byte("primary|key\x00with|separators")
+	marker := TxnSuccessMarkerKey(lockedKey, 100, 200, primaryKey)
+
+	require.Equal(t, lockedKey, routeKey(marker))
+
+	malformed := append([]byte(nil), marker...)
+	malformed[len(txnSuccessPrefixBytes)] = 2
+	require.Equal(t, malformed, routeKey(malformed), "malformed success markers must fall back to their raw key")
+}
+
+func TestRouteKey_SQSDecoderIsConcreteOnly(t *testing.T) {
+	t.Parallel()
+
+	want := []byte(sqsRoutePrefix + "global")
+	for _, raw := range [][]byte{
+		[]byte(sqsQueueMetaPrefix + "queue"),
+		[]byte(sqsQueueGenPrefix + "queue"),
+		[]byte(sqsQueueSeqPrefix + "queue"),
+		[]byte(sqsQueueTombstonePrefix + "queue"),
+		[]byte(sqsMsgDataPrefix + "queue|1|msg"),
+		[]byte(sqsMsgVisPrefix + "queue|1|msg"),
+		[]byte(sqsMsgDedupPrefix + "queue|1|dedup"),
+		[]byte(sqsMsgGroupPrefix + "queue|1|group"),
+		[]byte(sqsMsgByAgePrefix + "queue|1|ts"),
+		[]byte(sqsMsgDataPrefix + sqsPartitionMarker + "queue|0|1|msg"),
+		[]byte(sqsMsgVisPrefix + sqsPartitionMarker + "queue|0|1|msg"),
+		[]byte(sqsMsgDedupPrefix + sqsPartitionMarker + "queue|0|1|dedup"),
+		[]byte(sqsMsgGroupPrefix + sqsPartitionMarker + "queue|0|1|group"),
+		[]byte(sqsMsgByAgePrefix + sqsPartitionMarker + "queue|0|1|ts"),
+	} {
+		require.Equal(t, want, routeKey(raw), "concrete SQS key %q must use the SQS route", raw)
+	}
+
+	rawUser := []byte("!sqs|foo")
+	require.Equal(t, rawUser, routeKey(rawUser), "adapter-looking raw user key must stay on its raw route")
+}
+
+func TestRouteKey_S3DecoderIsConcreteOnly(t *testing.T) {
+	t.Parallel()
+
+	manifest := s3keys.ObjectManifestKey("bucket", 2, "obj")
+	require.Equal(t, s3keys.RouteKey("bucket", 2, "obj"), routeKey(manifest))
+
+	rawUser := []byte("!s3|foo")
+	require.Equal(t, rawUser, routeKey(rawUser), "adapter-looking raw user key must stay on its raw route")
+}
+
+func TestRouteKeyFilterTreatsNilAndEmptyEndAsInfinity(t *testing.T) {
+	t.Parallel()
+
+	start := []byte("m")
+	for _, tc := range []struct {
+		name string
+		end  []byte
+	}{
+		{name: "nil"},
+		{name: "empty", end: []byte{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			filter := RouteKeyFilter(start, tc.end)
+			require.False(t, filter([]byte("a")))
+			require.True(t, filter([]byte("m")))
+			require.True(t, filter([]byte("z")))
+		})
+	}
 }

--- a/kv/shard_key_test.go
+++ b/kv/shard_key_test.go
@@ -125,16 +125,22 @@ func TestRouteKey_NormalizesCollectionMigrationFamilies(t *testing.T) {
 	}
 }
 
-func TestRouteKey_ListMetaKeyThatLooksLikeDeltaRoutesByRealListKey(t *testing.T) {
+func TestRouteKey_ListMetaKeyThatLooksLikeNewDeltaRoutesByRealListKey(t *testing.T) {
 	t.Parallel()
 
-	fakeUserKey := []byte("fake:user")
-	userKey := deltaLookingListMetaUserKey(fakeUserKey, 42, 7)
+	userKey := []byte(store.ListMetaDeltaPrefix + "fake:user")
 	baseMeta := store.ListMetaKey(userKey)
 	deltaKey := store.ListMetaDeltaKey(userKey, 10, 1)
 
-	require.Equal(t, userKey, routeKey(baseMeta), "base list metadata must not decode as a delta for %q", fakeUserKey)
+	require.Equal(t, userKey, routeKey(baseMeta), "base list metadata must not decode as a new delta")
 	require.Equal(t, userKey, routeKey(deltaKey), "real list deltas must still route by the logical list key")
+}
+
+func TestRouteKey_LegacyListDeltaRoutesByDecodedUserKey(t *testing.T) {
+	t.Parallel()
+
+	userKey := []byte("legacy:list")
+	require.Equal(t, userKey, routeKey(legacyListMetaDeltaKey(userKey, 42, 7)))
 }
 
 func TestRouteKey_MalformedWideColumnKeysFallBackToRaw(t *testing.T) {
@@ -169,13 +175,8 @@ func malformedWideColumnKey(prefix string, suffixLen int) []byte {
 	return key
 }
 
-func deltaLookingListMetaUserKey(fakeUserKey []byte, commitTS uint64, seqInTxn uint32) []byte {
-	key := make([]byte, 0, len("d|")+4+len(fakeUserKey)+8+4)
-	key = append(key, "d|"...)
-	var lenPrefix [4]byte
-	binary.BigEndian.PutUint32(lenPrefix[:], uint32(len(fakeUserKey))) //nolint:gosec // test data is small.
-	key = append(key, lenPrefix[:]...)
-	key = append(key, fakeUserKey...)
+func legacyListMetaDeltaKey(userKey []byte, commitTS uint64, seqInTxn uint32) []byte {
+	key := store.LegacyListMetaDeltaScanPrefix(userKey)
 	var ts [8]byte
 	binary.BigEndian.PutUint64(ts[:], commitTS)
 	key = append(key, ts[:]...)

--- a/kv/shard_key_test.go
+++ b/kv/shard_key_test.go
@@ -124,6 +124,18 @@ func TestRouteKey_NormalizesCollectionMigrationFamilies(t *testing.T) {
 	}
 }
 
+func TestRouteKey_ListMetaKeyThatLooksLikeDeltaRoutesByRealListKey(t *testing.T) {
+	t.Parallel()
+
+	fakeUserKey := []byte("fake:user")
+	userKey := deltaLookingListMetaUserKey(fakeUserKey, 42, 7)
+	baseMeta := store.ListMetaKey(userKey)
+	deltaKey := store.ListMetaDeltaKey(userKey, 10, 1)
+
+	require.Equal(t, userKey, routeKey(baseMeta), "base list metadata must not decode as a delta for %q", fakeUserKey)
+	require.Equal(t, userKey, routeKey(deltaKey), "real list deltas must still route by the logical list key")
+}
+
 func TestRouteKey_MalformedWideColumnKeysFallBackToRaw(t *testing.T) {
 	t.Parallel()
 
@@ -154,6 +166,21 @@ func malformedWideColumnKey(prefix string, suffixLen int) []byte {
 	key = append(key, lenPrefix[:]...)
 	key = append(key, make([]byte, suffixLen)...)
 	return key
+}
+
+func deltaLookingListMetaUserKey(fakeUserKey []byte, commitTS uint64, seqInTxn uint32) []byte {
+	key := make([]byte, 0, len("d|")+4+len(fakeUserKey)+8+4)
+	key = append(key, "d|"...)
+	var lenPrefix [4]byte
+	binary.BigEndian.PutUint32(lenPrefix[:], uint32(len(fakeUserKey))) //nolint:gosec // test data is small.
+	key = append(key, lenPrefix[:]...)
+	key = append(key, fakeUserKey...)
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], commitTS)
+	key = append(key, ts[:]...)
+	var seq [4]byte
+	binary.BigEndian.PutUint32(seq[:], seqInTxn)
+	return append(key, seq[:]...)
 }
 
 func TestRouteKey_NormalizesTxnSuccessMarkerByLockedKey(t *testing.T) {

--- a/kv/shard_key_test.go
+++ b/kv/shard_key_test.go
@@ -1,6 +1,7 @@
 package kv
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/binary"
 	"testing"
@@ -268,4 +269,41 @@ func TestRouteKeyFilterIncludesS3BucketAuxiliaryKeys(t *testing.T) {
 	require.True(t, filter(s3keys.ObjectManifestKey("bucket-b", 7, "m")))
 	require.False(t, filter(s3keys.BucketMetaKey("bucket-c")))
 	require.False(t, filter(s3keys.BucketGenerationKey("bucket-c")))
+}
+
+func TestRouteKeyFilterIncludesS3BucketAuxiliaryRawRoute(t *testing.T) {
+	t.Parallel()
+
+	filter := RouteKeyFilter([]byte("!s3|"), nil)
+
+	require.True(t, filter(s3keys.BucketMetaKey("bucket-b")))
+	require.True(t, filter(s3keys.BucketGenerationKey("bucket-b")))
+}
+
+func TestRouteKeyFilterForGroupUsesPartitionResolver(t *testing.T) {
+	t.Parallel()
+
+	partitionedKey := []byte(sqsMsgDataPrefix + sqsPartitionMarker + "orders|partition-0|message")
+	resolver := &migrationFilterPartitionResolver{
+		groups: map[string]uint64{string(partitionedKey): 42},
+	}
+
+	require.True(t, RouteKeyFilterForGroup(nil, nil, 42, resolver)(partitionedKey))
+	require.False(t, RouteKeyFilterForGroup(nil, nil, 7, resolver)(partitionedKey))
+	require.False(t, RouteKeyFilterForGroup(nil, nil, 42, resolver)(
+		[]byte(sqsMsgDataPrefix+sqsPartitionMarker+"orders|unknown-partition"),
+	))
+}
+
+type migrationFilterPartitionResolver struct {
+	groups map[string]uint64
+}
+
+func (r *migrationFilterPartitionResolver) ResolveGroup(key []byte) (uint64, bool) {
+	gid, ok := r.groups[string(key)]
+	return gid, ok
+}
+
+func (r *migrationFilterPartitionResolver) RecognisesPartitionedKey(key []byte) bool {
+	return bytes.HasPrefix(key, []byte(sqsMsgDataPrefix+sqsPartitionMarker))
 }

--- a/kv/shard_key_test.go
+++ b/kv/shard_key_test.go
@@ -2,6 +2,7 @@ package kv
 
 import (
 	"encoding/base64"
+	"encoding/binary"
 	"testing"
 
 	"github.com/bootjp/elastickv/internal/s3keys"
@@ -123,6 +124,38 @@ func TestRouteKey_NormalizesCollectionMigrationFamilies(t *testing.T) {
 	}
 }
 
+func TestRouteKey_MalformedWideColumnKeysFallBackToRaw(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range [][]byte{
+		malformedWideColumnKey(store.ListClaimPrefix, 8),
+		malformedWideColumnKey(store.HashMetaPrefix, 0),
+		malformedWideColumnKey(store.HashFieldPrefix, 0),
+		malformedWideColumnKey(store.HashMetaDeltaPrefix, 12),
+		malformedWideColumnKey(store.SetMetaPrefix, 0),
+		malformedWideColumnKey(store.SetMemberPrefix, 0),
+		malformedWideColumnKey(store.SetMetaDeltaPrefix, 12),
+		malformedWideColumnKey(store.ZSetMetaPrefix, 0),
+		malformedWideColumnKey(store.ZSetMemberPrefix, 0),
+		malformedWideColumnKey(store.ZSetScorePrefix, 8),
+		malformedWideColumnKey(store.ZSetMetaDeltaPrefix, 12),
+	} {
+		require.NotPanics(t, func() {
+			require.Equal(t, raw, routeKey(raw), "malformed key %q must not decode to a logical route", raw)
+		})
+	}
+}
+
+func malformedWideColumnKey(prefix string, suffixLen int) []byte {
+	key := make([]byte, 0, len(prefix)+4+suffixLen)
+	key = append(key, prefix...)
+	var lenPrefix [4]byte
+	binary.BigEndian.PutUint32(lenPrefix[:], ^uint32(0))
+	key = append(key, lenPrefix[:]...)
+	key = append(key, make([]byte, suffixLen)...)
+	return key
+}
+
 func TestRouteKey_NormalizesTxnSuccessMarkerByLockedKey(t *testing.T) {
 	t.Parallel()
 
@@ -193,4 +226,19 @@ func TestRouteKeyFilterTreatsNilAndEmptyEndAsInfinity(t *testing.T) {
 			require.True(t, filter([]byte("z")))
 		})
 	}
+}
+
+func TestRouteKeyFilterIncludesS3BucketAuxiliaryKeys(t *testing.T) {
+	t.Parallel()
+
+	filter := RouteKeyFilter(
+		s3keys.RouteKey("bucket-b", 7, "a"),
+		s3keys.RouteKey("bucket-b", 7, "z"),
+	)
+
+	require.True(t, filter(s3keys.BucketMetaKey("bucket-b")))
+	require.True(t, filter(s3keys.BucketGenerationKey("bucket-b")))
+	require.True(t, filter(s3keys.ObjectManifestKey("bucket-b", 7, "m")))
+	require.False(t, filter(s3keys.BucketMetaKey("bucket-c")))
+	require.False(t, filter(s3keys.BucketGenerationKey("bucket-c")))
 }

--- a/kv/shard_store.go
+++ b/kv/shard_store.go
@@ -291,9 +291,9 @@ func scanRouteUserKey(start []byte) []byte {
 }
 
 var scanRouteUserKeyExtractors = []func([]byte) []byte{
-	store.ExtractListUserKey,
 	store.ExtractListUserKeyFromDeltaScanPrefix,
 	store.ExtractLegacyListUserKeyFromDeltaScanPrefix,
+	store.ExtractListUserKey,
 	store.ExtractListUserKeyFromClaimScanPrefix,
 	store.ExtractHashUserKeyFromField,
 	store.ExtractHashUserKeyFromDeltaScanPrefix,
@@ -303,6 +303,8 @@ var scanRouteUserKeyExtractors = []func([]byte) []byte{
 	store.ExtractZSetUserKeyFromScore,
 	store.ExtractZSetUserKeyFromScoreScanPrefix,
 	store.ExtractZSetUserKeyFromDeltaScanPrefix,
+	store.ExtractStreamUserKeyFromMeta,
+	store.ExtractStreamUserKeyFromEntryScanPrefix,
 }
 
 func (s *ShardStore) scanRoutesAt(ctx context.Context, routes []distribution.Route, start []byte, end []byte, limit int, ts uint64, clampToRoutes bool) ([]*store.KVPair, error) {

--- a/kv/shard_store.go
+++ b/kv/shard_store.go
@@ -260,9 +260,9 @@ func (s *ShardStore) routesForScan(start []byte, end []byte) ([]distribution.Rou
 	if routeStart, routeEnd, ok := s3keys.ManifestScanRouteBounds(start, end); ok {
 		return s.engine.GetIntersectingRoutes(routeStart, routeEnd), false
 	}
-	// For internal list keys, shard routing is based on the logical user key
-	// rather than the raw key prefix.
-	if userKey := store.ExtractListUserKey(start); userKey != nil {
+	// For internal wide-column keys, shard routing is based on the logical
+	// user key rather than the raw key prefix.
+	if userKey := scanRouteUserKey(start); userKey != nil {
 		route, ok := s.engine.GetRoute(userKey)
 		if !ok {
 			return []distribution.Route{}, false
@@ -279,6 +279,30 @@ func (s *ShardStore) routesForScan(start []byte, end []byte) ([]distribution.Rou
 	}
 
 	return routes, true
+}
+
+func scanRouteUserKey(start []byte) []byte {
+	for _, extract := range scanRouteUserKeyExtractors {
+		if userKey := extract(start); userKey != nil {
+			return userKey
+		}
+	}
+	return nil
+}
+
+var scanRouteUserKeyExtractors = []func([]byte) []byte{
+	store.ExtractListUserKey,
+	store.ExtractListUserKeyFromDeltaScanPrefix,
+	store.ExtractLegacyListUserKeyFromDeltaScanPrefix,
+	store.ExtractListUserKeyFromClaimScanPrefix,
+	store.ExtractHashUserKeyFromField,
+	store.ExtractHashUserKeyFromDeltaScanPrefix,
+	store.ExtractSetUserKeyFromMember,
+	store.ExtractSetUserKeyFromDeltaScanPrefix,
+	store.ExtractZSetUserKeyFromMember,
+	store.ExtractZSetUserKeyFromScore,
+	store.ExtractZSetUserKeyFromScoreScanPrefix,
+	store.ExtractZSetUserKeyFromDeltaScanPrefix,
 }
 
 func (s *ShardStore) scanRoutesAt(ctx context.Context, routes []distribution.Route, start []byte, end []byte, limit int, ts uint64, clampToRoutes bool) ([]*store.KVPair, error) {

--- a/kv/shard_store_test.go
+++ b/kv/shard_store_test.go
@@ -75,17 +75,27 @@ func TestShardStoreScanAt_RoutesListDeltaScansByUserKey(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	st := newTwoRouteShardStoreForScanTest()
-	userKey := []byte("x") // routes to group 2; raw !lst|delta| prefix would route to group 1.
-	deltaKey := store.ListMetaDeltaKey(userKey, 10, 1)
-	deltaValue := store.MarshalListMetaDelta(store.ListMetaDelta{LenDelta: 1})
-	require.NoError(t, st.PutAt(ctx, deltaKey, deltaValue, 1, 0))
+	userKey := []byte("x") // routes to group 2; raw !lst|* prefixes route to group 1.
+	for _, tc := range []struct {
+		name      string
+		key       []byte
+		scanStart []byte
+	}{
+		{name: "current", key: store.ListMetaDeltaKey(userKey, 10, 1), scanStart: store.ListMetaDeltaScanPrefix(userKey)},
+		{name: "legacy", key: legacyListMetaDeltaKey(userKey, 10, 1), scanStart: store.LegacyListMetaDeltaScanPrefix(userKey)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			st := newTwoRouteShardStoreForScanTest()
+			deltaValue := store.MarshalListMetaDelta(store.ListMetaDelta{LenDelta: 1})
+			require.NoError(t, st.PutAt(ctx, tc.key, deltaValue, 1, 0))
 
-	start := store.ListMetaDeltaScanPrefix(userKey)
-	kvs, err := st.ScanAt(ctx, start, store.PrefixScanEnd(start), 10, ^uint64(0))
-	require.NoError(t, err)
-	require.Len(t, kvs, 1)
-	require.Equal(t, deltaKey, kvs[0].Key)
+			kvs, err := st.ScanAt(ctx, tc.scanStart, store.PrefixScanEnd(tc.scanStart), 10, ^uint64(0))
+			require.NoError(t, err)
+			require.Len(t, kvs, 1)
+			require.Equal(t, tc.key, kvs[0].Key)
+		})
+	}
 }
 
 func TestShardStoreScanAt_RoutesWideColumnScansByUserKey(t *testing.T) {
@@ -104,6 +114,8 @@ func TestShardStoreScanAt_RoutesWideColumnScansByUserKey(t *testing.T) {
 		{name: "zset member", key: store.ZSetMemberKey([]byte("x"), []byte("m")), scanStart: store.ZSetMemberScanPrefix([]byte("x"))},
 		{name: "zset score", key: store.ZSetScoreKey([]byte("x"), 1.5, []byte("m")), scanStart: store.ZSetScoreScanPrefix([]byte("x"))},
 		{name: "zset delta", key: store.ZSetMetaDeltaKey([]byte("x"), 10, 0), scanStart: store.ZSetMetaDeltaScanPrefix([]byte("x"))},
+		{name: "stream meta", key: store.StreamMetaKey([]byte("x")), scanStart: store.StreamMetaKey([]byte("x"))},
+		{name: "stream entry", key: store.StreamEntryKey([]byte("x"), 10, 0), scanStart: store.StreamEntryScanPrefix([]byte("x"))},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/kv/shard_store_test.go
+++ b/kv/shard_store_test.go
@@ -71,6 +71,65 @@ func TestShardStoreScanAt_RoutesListItemScansByUserKey(t *testing.T) {
 	require.Equal(t, k2, kvs[2].Key)
 }
 
+func TestShardStoreScanAt_RoutesListDeltaScansByUserKey(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	st := newTwoRouteShardStoreForScanTest()
+	userKey := []byte("x") // routes to group 2; raw !lst|delta| prefix would route to group 1.
+	deltaKey := store.ListMetaDeltaKey(userKey, 10, 1)
+	deltaValue := store.MarshalListMetaDelta(store.ListMetaDelta{LenDelta: 1})
+	require.NoError(t, st.PutAt(ctx, deltaKey, deltaValue, 1, 0))
+
+	start := store.ListMetaDeltaScanPrefix(userKey)
+	kvs, err := st.ScanAt(ctx, start, store.PrefixScanEnd(start), 10, ^uint64(0))
+	require.NoError(t, err)
+	require.Len(t, kvs, 1)
+	require.Equal(t, deltaKey, kvs[0].Key)
+}
+
+func TestShardStoreScanAt_RoutesWideColumnScansByUserKey(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	for _, tc := range []struct {
+		name      string
+		key       []byte
+		scanStart []byte
+	}{
+		{name: "hash field", key: store.HashFieldKey([]byte("x"), []byte("f")), scanStart: store.HashFieldScanPrefix([]byte("x"))},
+		{name: "hash delta", key: store.HashMetaDeltaKey([]byte("x"), 10, 0), scanStart: store.HashMetaDeltaScanPrefix([]byte("x"))},
+		{name: "set member", key: store.SetMemberKey([]byte("x"), []byte("m")), scanStart: store.SetMemberScanPrefix([]byte("x"))},
+		{name: "set delta", key: store.SetMetaDeltaKey([]byte("x"), 10, 0), scanStart: store.SetMetaDeltaScanPrefix([]byte("x"))},
+		{name: "zset member", key: store.ZSetMemberKey([]byte("x"), []byte("m")), scanStart: store.ZSetMemberScanPrefix([]byte("x"))},
+		{name: "zset score", key: store.ZSetScoreKey([]byte("x"), 1.5, []byte("m")), scanStart: store.ZSetScoreScanPrefix([]byte("x"))},
+		{name: "zset delta", key: store.ZSetMetaDeltaKey([]byte("x"), 10, 0), scanStart: store.ZSetMetaDeltaScanPrefix([]byte("x"))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			st := newTwoRouteShardStoreForScanTest()
+			require.NoError(t, st.PutAt(ctx, tc.key, []byte("v"), 1, 0))
+
+			kvs, err := st.ScanAt(ctx, tc.scanStart, store.PrefixScanEnd(tc.scanStart), 10, ^uint64(0))
+			require.NoError(t, err)
+			require.Len(t, kvs, 1)
+			require.Equal(t, tc.key, kvs[0].Key)
+		})
+	}
+}
+
+func newTwoRouteShardStoreForScanTest() *ShardStore {
+	engine := distribution.NewEngine()
+	engine.UpdateRoute([]byte(""), []byte("m"), 1)
+	engine.UpdateRoute([]byte("m"), nil, 2)
+
+	groups := map[uint64]*ShardGroup{
+		1: {Store: store.NewMVCCStore()},
+		2: {Store: store.NewMVCCStore()},
+	}
+	return NewShardStore(engine, groups)
+}
+
 func TestShardStoreScanGroupAt_UsesExplicitGroup(t *testing.T) {
 	t.Parallel()
 

--- a/kv/txn_keys.go
+++ b/kv/txn_keys.go
@@ -16,6 +16,7 @@ const (
 	txnIntentPrefix   = TxnKeyPrefix + "int|"
 	txnCommitPrefix   = TxnKeyPrefix + "cmt|"
 	txnRollbackPrefix = TxnKeyPrefix + "rb|"
+	txnSuccessPrefix  = TxnKeyPrefix + "ok|"
 	txnMetaPrefix     = TxnKeyPrefix + "meta|"
 )
 
@@ -27,11 +28,14 @@ var (
 	txnIntentPrefixBytes   = []byte(txnIntentPrefix)
 	txnCommitPrefixBytes   = []byte(txnCommitPrefix)
 	txnRollbackPrefixBytes = []byte(txnRollbackPrefix)
+	txnSuccessPrefixBytes  = []byte(txnSuccessPrefix)
 	txnMetaPrefixBytes     = []byte(txnMetaPrefix)
 	txnCommonPrefix        = []byte(TxnKeyPrefix)
 )
 
 const txnStartTSSuffixLen = 8
+const txnSuccessMarkerVersion = byte(1)
+const maxIntValue = int(^uint(0) >> 1)
 
 func txnLockKey(userKey []byte) []byte {
 	k := make([]byte, 0, len(txnLockPrefixBytes)+len(userKey))
@@ -75,6 +79,7 @@ func isTxnInternalKey(key []byte) bool {
 		bytes.HasPrefix(key, txnIntentPrefixBytes) ||
 		bytes.HasPrefix(key, txnCommitPrefixBytes) ||
 		bytes.HasPrefix(key, txnRollbackPrefixBytes) ||
+		bytes.HasPrefix(key, txnSuccessPrefixBytes) ||
 		bytes.HasPrefix(key, txnMetaPrefixBytes)
 }
 
@@ -104,6 +109,8 @@ func txnRouteKey(key []byte) ([]byte, bool) {
 			return nil, false
 		}
 		return rest[:len(rest)-txnStartTSSuffixLen], true
+	case bytes.HasPrefix(key, txnSuccessPrefixBytes):
+		return txnSuccessLockedKey(key)
 	default:
 		return nil, false
 	}
@@ -118,4 +125,56 @@ func ExtractTxnUserKey(key []byte) []byte {
 		return nil
 	}
 	return userKey
+}
+
+// TxnSuccessMarkerKey builds the route-local transaction-success marker key
+// used by the migration planner. Normal transaction traffic only writes this
+// after the migration capability gate opens in a later PR.
+func TxnSuccessMarkerKey(lockedKey []byte, startTS, commitTS uint64, primaryKey []byte) []byte {
+	out := make([]byte, 0, len(txnSuccessPrefixBytes)+1+binary.MaxVarintLen64+len(lockedKey)+2*txnStartTSSuffixLen+binary.MaxVarintLen64+len(primaryKey))
+	out = append(out, txnSuccessPrefixBytes...)
+	out = append(out, txnSuccessMarkerVersion)
+	out = binary.AppendUvarint(out, uint64(len(lockedKey)))
+	out = append(out, lockedKey...)
+	var raw [txnStartTSSuffixLen]byte
+	binary.BigEndian.PutUint64(raw[:], startTS)
+	out = append(out, raw[:]...)
+	binary.BigEndian.PutUint64(raw[:], commitTS)
+	out = append(out, raw[:]...)
+	out = binary.AppendUvarint(out, uint64(len(primaryKey)))
+	out = append(out, primaryKey...)
+	return out
+}
+
+func txnSuccessLockedKey(key []byte) ([]byte, bool) {
+	rest := key[len(txnSuccessPrefixBytes):]
+	if len(rest) == 0 || rest[0] != txnSuccessMarkerVersion {
+		return nil, false
+	}
+	rest = rest[1:]
+	lockedLenRaw, n := binary.Uvarint(rest)
+	lockedLen, ok := uvarintToInt(lockedLenRaw)
+	if n <= 0 || !ok || lockedLen > len(rest)-n {
+		return nil, false
+	}
+	lockedStart := n
+	lockedEnd := lockedStart + lockedLen
+	rest = rest[lockedEnd:]
+	if len(rest) < 2*txnStartTSSuffixLen {
+		return nil, false
+	}
+	rest = rest[2*txnStartTSSuffixLen:]
+	primaryLenRaw, n := binary.Uvarint(rest)
+	primaryLen, ok := uvarintToInt(primaryLenRaw)
+	if n <= 0 || !ok || primaryLen != len(rest)-n {
+		return nil, false
+	}
+	return key[len(txnSuccessPrefixBytes)+1+lockedStart : len(txnSuccessPrefixBytes)+1+lockedEnd], true
+}
+
+func uvarintToInt(v uint64) (int, bool) {
+	if v > uint64(maxIntValue) {
+		return 0, false
+	}
+	return int(v), true
 }

--- a/store/hash_helpers.go
+++ b/store/hash_helpers.go
@@ -150,40 +150,15 @@ func IsHashMetaDeltaKey(key []byte) bool {
 
 // ExtractHashUserKeyFromMeta extracts the logical user key from a hash meta key.
 func ExtractHashUserKeyFromMeta(key []byte) []byte {
-	trimmed := bytes.TrimPrefix(key, []byte(HashMetaPrefix))
-	if len(trimmed) < wideColKeyLenSize {
-		return nil
-	}
-	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
-		return nil
-	}
-	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+	return extractWideColumnUserKey(key, []byte(HashMetaPrefix), 0, true)
 }
 
 // ExtractHashUserKeyFromField extracts the logical user key from a hash field key.
 func ExtractHashUserKeyFromField(key []byte) []byte {
-	trimmed := bytes.TrimPrefix(key, []byte(HashFieldPrefix))
-	if len(trimmed) < wideColKeyLenSize {
-		return nil
-	}
-	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
-		return nil
-	}
-	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+	return extractWideColumnUserKey(key, []byte(HashFieldPrefix), 0, false)
 }
 
 // ExtractHashUserKeyFromDelta extracts the logical user key from a hash delta key.
 func ExtractHashUserKeyFromDelta(key []byte) []byte {
-	trimmed := bytes.TrimPrefix(key, []byte(HashMetaDeltaPrefix))
-	minLen := wideColKeyLenSize + deltaKeyTSSize + deltaKeySeqSize
-	if len(trimmed) < minLen {
-		return nil
-	}
-	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen+uint32(deltaKeyTSSize+deltaKeySeqSize) { //nolint:gosec // constants fit in uint32
-		return nil
-	}
-	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+	return extractWideColumnUserKey(key, []byte(HashMetaDeltaPrefix), deltaKeyTSSize+deltaKeySeqSize, true)
 }

--- a/store/hash_helpers.go
+++ b/store/hash_helpers.go
@@ -162,3 +162,9 @@ func ExtractHashUserKeyFromField(key []byte) []byte {
 func ExtractHashUserKeyFromDelta(key []byte) []byte {
 	return extractWideColumnUserKey(key, []byte(HashMetaDeltaPrefix), deltaKeyTSSize+deltaKeySeqSize, true)
 }
+
+// ExtractHashUserKeyFromDeltaScanPrefix extracts the user key from a hash
+// metadata delta scan start/prefix.
+func ExtractHashUserKeyFromDeltaScanPrefix(key []byte) []byte {
+	return extractWideColumnUserKey(key, []byte(HashMetaDeltaPrefix), 0, false)
+}

--- a/store/list_helpers.go
+++ b/store/list_helpers.go
@@ -131,33 +131,32 @@ func IsListClaimKey(key []byte) bool {
 
 // ExtractListUserKeyFromDelta extracts the logical user key from a list delta key.
 func ExtractListUserKeyFromDelta(key []byte) []byte {
-	if !bytes.HasPrefix(key, []byte(ListMetaDeltaPrefix)) {
-		return nil
-	}
-	trimmed := key[len(ListMetaDeltaPrefix):]
-	if len(trimmed) < wideColKeyLenSize+deltaKeyTSSize+deltaKeySeqSize {
-		return nil
-	}
-	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	wantLen := uint64(wideColKeyLenSize) + uint64(ukLen) + uint64(deltaKeyTSSize+deltaKeySeqSize)
-	if uint64(len(trimmed)) != wantLen {
-		return nil
-	}
-	userEnd := wideColKeyLenSize + int(ukLen) //nolint:gosec // exact length check above bounds ukLen to len(trimmed)
-	return trimmed[wideColKeyLenSize:userEnd]
+	return extractWideColumnUserKey(key, []byte(ListMetaDeltaPrefix), deltaKeyTSSize+deltaKeySeqSize, true)
 }
 
 // ExtractListUserKeyFromClaim extracts the logical user key from a list claim key.
 func ExtractListUserKeyFromClaim(key []byte) []byte {
-	trimmed := bytes.TrimPrefix(key, []byte(ListClaimPrefix))
-	if len(trimmed) < wideColKeyLenSize+sortableInt64Bytes {
+	return extractWideColumnUserKey(key, []byte(ListClaimPrefix), sortableInt64Bytes, true)
+}
+
+func extractWideColumnUserKey(key, prefix []byte, suffixLen uint64, exactLen bool) []byte {
+	if !bytes.HasPrefix(key, prefix) {
+		return nil
+	}
+	trimmed := key[len(prefix):]
+	if uint64(len(trimmed)) < uint64(wideColKeyLenSize)+suffixLen {
 		return nil
 	}
 	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen+uint32(sortableInt64Bytes) { //nolint:gosec // constants fit in uint32
+	userEnd := uint64(wideColKeyLenSize) + uint64(ukLen)
+	minLen := userEnd + suffixLen
+	if minLen > uint64(len(trimmed)) {
 		return nil
 	}
-	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+	if exactLen && minLen != uint64(len(trimmed)) {
+		return nil
+	}
+	return trimmed[wideColKeyLenSize:int(userEnd)] //nolint:gosec // userEnd is bounded by len(trimmed) above.
 }
 
 // PrefixScanEnd returns the exclusive end key for a prefix scan.

--- a/store/list_helpers.go
+++ b/store/list_helpers.go
@@ -14,6 +14,11 @@ const (
 	// Layout: !lst|delta|<userKeyLen(4)><userKey><commitTS(8)><seqInTxn(4)>
 	ListMetaDeltaPrefix = "!lst|delta|"
 
+	// LegacyListMetaDeltaPrefix is the pre-upgrade list metadata delta prefix.
+	// Writers use ListMetaDeltaPrefix, but readers and compactors keep scanning
+	// this prefix until old uncompacted deltas have been drained.
+	LegacyListMetaDeltaPrefix = "!lst|meta|d|"
+
 	// ListClaimPrefix is the prefix for list claim keys used by POP operations.
 	// Layout: !lst|claim|<userKeyLen(4)><userKey><seq(8-byte sortable)>
 	ListClaimPrefix = "!lst|claim|"
@@ -85,8 +90,27 @@ func ListMetaDeltaKey(userKey []byte, commitTS uint64, seqInTxn uint32) []byte {
 
 // ListMetaDeltaScanPrefix returns the prefix used to scan all delta keys for a userKey.
 func ListMetaDeltaScanPrefix(userKey []byte) []byte {
-	buf := make([]byte, 0, len(ListMetaDeltaPrefix)+wideColKeyLenSize+len(userKey))
-	buf = append(buf, ListMetaDeltaPrefix...)
+	return listMetaDeltaScanPrefixFor(ListMetaDeltaPrefix, userKey)
+}
+
+// LegacyListMetaDeltaScanPrefix returns the pre-upgrade delta scan prefix for a userKey.
+func LegacyListMetaDeltaScanPrefix(userKey []byte) []byte {
+	return listMetaDeltaScanPrefixFor(LegacyListMetaDeltaPrefix, userKey)
+}
+
+// ListMetaDeltaScanPrefixes returns all prefixes that may contain visible list
+// metadata deltas for userKey. New writers emit only ListMetaDeltaPrefix, but
+// upgrade reads must include LegacyListMetaDeltaPrefix until compaction drains it.
+func ListMetaDeltaScanPrefixes(userKey []byte) [][]byte {
+	return [][]byte{
+		ListMetaDeltaScanPrefix(userKey),
+		LegacyListMetaDeltaScanPrefix(userKey),
+	}
+}
+
+func listMetaDeltaScanPrefixFor(prefix string, userKey []byte) []byte {
+	buf := make([]byte, 0, len(prefix)+wideColKeyLenSize+len(userKey))
+	buf = append(buf, prefix...)
 	var kl [4]byte
 	binary.BigEndian.PutUint32(kl[:], uint32(len(userKey))) //nolint:gosec // len is bounded by max slice size
 	buf = append(buf, kl[:]...)
@@ -134,9 +158,40 @@ func ExtractListUserKeyFromDelta(key []byte) []byte {
 	return extractWideColumnUserKey(key, []byte(ListMetaDeltaPrefix), deltaKeyTSSize+deltaKeySeqSize, true)
 }
 
+// ExtractLegacyListUserKeyFromDelta extracts the user key from an old
+// !lst|meta|d| delta key. Callers that only have a key must be careful: this
+// legacy layout overlaps with base !lst|meta| keys whose user key begins with
+// d|. Prefer using it when the associated value is known to be a delta value.
+func ExtractLegacyListUserKeyFromDelta(key []byte) []byte {
+	return extractWideColumnUserKey(key, []byte(LegacyListMetaDeltaPrefix), deltaKeyTSSize+deltaKeySeqSize, true)
+}
+
+// ExtractListUserKeyFromDeltaScanPrefix extracts the user key from a new-list
+// delta scan start/prefix.
+func ExtractListUserKeyFromDeltaScanPrefix(key []byte) []byte {
+	return extractWideColumnUserKey(key, []byte(ListMetaDeltaPrefix), 0, false)
+}
+
+// ExtractLegacyListUserKeyFromDeltaScanPrefix extracts the user key from a
+// legacy-list delta scan start/prefix.
+func ExtractLegacyListUserKeyFromDeltaScanPrefix(key []byte) []byte {
+	return extractWideColumnUserKey(key, []byte(LegacyListMetaDeltaPrefix), 0, false)
+}
+
 // ExtractListUserKeyFromClaim extracts the logical user key from a list claim key.
 func ExtractListUserKeyFromClaim(key []byte) []byte {
 	return extractWideColumnUserKey(key, []byte(ListClaimPrefix), sortableInt64Bytes, true)
+}
+
+// ExtractListUserKeyFromClaimScanPrefix extracts the user key from a list claim
+// scan start/prefix.
+func ExtractListUserKeyFromClaimScanPrefix(key []byte) []byte {
+	return extractWideColumnUserKey(key, []byte(ListClaimPrefix), 0, false)
+}
+
+// IsListMetaDeltaValue reports whether value has the fixed delta encoding.
+func IsListMetaDeltaValue(value []byte) bool {
+	return len(value) == listDeltaSizeBytes
 }
 
 func extractWideColumnUserKey(key, prefix []byte, suffixLen uint64, exactLen bool) []byte {

--- a/store/list_helpers.go
+++ b/store/list_helpers.go
@@ -11,8 +11,8 @@ import (
 // Delta/Claim key constants.
 const (
 	// ListMetaDeltaPrefix is the prefix for all list metadata delta keys.
-	// Layout: !lst|meta|d|<userKeyLen(4)><userKey><commitTS(8)><seqInTxn(4)>
-	ListMetaDeltaPrefix = "!lst|meta|d|"
+	// Layout: !lst|delta|<userKeyLen(4)><userKey><commitTS(8)><seqInTxn(4)>
+	ListMetaDeltaPrefix = "!lst|delta|"
 
 	// ListClaimPrefix is the prefix for list claim keys used by POP operations.
 	// Layout: !lst|claim|<userKeyLen(4)><userKey><seq(8-byte sortable)>

--- a/store/list_helpers.go
+++ b/store/list_helpers.go
@@ -121,7 +121,7 @@ func ListClaimScanPrefix(userKey []byte) []byte {
 
 // IsListMetaDeltaKey reports whether the key is a list metadata delta key.
 func IsListMetaDeltaKey(key []byte) bool {
-	return bytes.HasPrefix(key, []byte(ListMetaDeltaPrefix))
+	return ExtractListUserKeyFromDelta(key) != nil
 }
 
 // IsListClaimKey reports whether the key is a list claim key.
@@ -131,15 +131,20 @@ func IsListClaimKey(key []byte) bool {
 
 // ExtractListUserKeyFromDelta extracts the logical user key from a list delta key.
 func ExtractListUserKeyFromDelta(key []byte) []byte {
-	trimmed := bytes.TrimPrefix(key, []byte(ListMetaDeltaPrefix))
+	if !bytes.HasPrefix(key, []byte(ListMetaDeltaPrefix)) {
+		return nil
+	}
+	trimmed := key[len(ListMetaDeltaPrefix):]
 	if len(trimmed) < wideColKeyLenSize+deltaKeyTSSize+deltaKeySeqSize {
 		return nil
 	}
 	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen+uint32(deltaKeyTSSize+deltaKeySeqSize) { //nolint:gosec // constants fit in uint32
+	wantLen := uint64(wideColKeyLenSize) + uint64(ukLen) + uint64(deltaKeyTSSize+deltaKeySeqSize)
+	if uint64(len(trimmed)) != wantLen {
 		return nil
 	}
-	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+	userEnd := wideColKeyLenSize + int(ukLen) //nolint:gosec // exact length check above bounds ukLen to len(trimmed)
+	return trimmed[wideColKeyLenSize:userEnd]
 }
 
 // ExtractListUserKeyFromClaim extracts the logical user key from a list claim key.

--- a/store/list_helpers_test.go
+++ b/store/list_helpers_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -25,4 +26,37 @@ func TestExtractListUserKeyFromDeltaRequiresExactDeltaShape(t *testing.T) {
 
 	require.False(t, IsListMetaDeltaKey([]byte("not-a-delta-key")))
 	require.Nil(t, ExtractListUserKeyFromDelta([]byte("not-a-delta-key")))
+}
+
+func TestListMetaDeltaPrefixDoesNotOverlapBaseMetaKeys(t *testing.T) {
+	t.Parallel()
+
+	fakeUserKey := []byte("fake-user")
+	userKey := deltaLookingListMetaUserKey(fakeUserKey, 42, 7)
+	baseMeta := ListMetaKey(userKey)
+	deltaKey := ListMetaDeltaKey(userKey, 42, 7)
+
+	require.True(t, IsListMetaKey(baseMeta))
+	require.False(t, IsListMetaDeltaKey(baseMeta))
+	require.Equal(t, userKey, ExtractListUserKey(baseMeta))
+	require.Nil(t, ExtractListUserKeyFromDelta(baseMeta))
+
+	require.False(t, IsListMetaKey(deltaKey))
+	require.True(t, IsListMetaDeltaKey(deltaKey))
+	require.Equal(t, userKey, ExtractListUserKeyFromDelta(deltaKey))
+}
+
+func deltaLookingListMetaUserKey(fakeUserKey []byte, commitTS uint64, seqInTxn uint32) []byte {
+	buf := make([]byte, 0, len("d|")+4+len(fakeUserKey)+8+4)
+	buf = append(buf, "d|"...)
+	var keyLen [4]byte
+	binary.BigEndian.PutUint32(keyLen[:], uint32(len(fakeUserKey))) //nolint:gosec // test data is small.
+	buf = append(buf, keyLen[:]...)
+	buf = append(buf, fakeUserKey...)
+	var ts [8]byte
+	binary.BigEndian.PutUint64(ts[:], commitTS)
+	buf = append(buf, ts[:]...)
+	var seq [4]byte
+	binary.BigEndian.PutUint32(seq[:], seqInTxn)
+	return append(buf, seq[:]...)
 }

--- a/store/list_helpers_test.go
+++ b/store/list_helpers_test.go
@@ -46,6 +46,23 @@ func TestListMetaDeltaPrefixDoesNotOverlapBaseMetaKeys(t *testing.T) {
 	require.Equal(t, userKey, ExtractListUserKeyFromDelta(deltaKey))
 }
 
+func TestLegacyListMetaDeltaHelpersScanOldPrefixWithoutReclassifyingNewDelta(t *testing.T) {
+	t.Parallel()
+
+	userKey := []byte("list")
+	legacyPrefix := LegacyListMetaDeltaScanPrefix(userKey)
+	legacyKey := append(append([]byte(nil), legacyPrefix...), make([]byte, deltaKeyTSSize+deltaKeySeqSize)...)
+
+	require.Equal(t, userKey, ExtractLegacyListUserKeyFromDeltaScanPrefix(legacyPrefix))
+	require.Equal(t, userKey, ExtractLegacyListUserKeyFromDelta(legacyKey))
+	require.False(t, IsListMetaDeltaKey(legacyKey), "legacy prefix is ambiguous with base !lst|meta| keys")
+	require.True(t, IsListMetaDeltaValue(MarshalListMetaDelta(ListMetaDelta{HeadDelta: 1, LenDelta: 2})))
+
+	metaValue, err := MarshalListMeta(ListMeta{Head: 1, Tail: 2, Len: 1})
+	require.NoError(t, err)
+	require.False(t, IsListMetaDeltaValue(metaValue))
+}
+
 func deltaLookingListMetaUserKey(fakeUserKey []byte, commitTS uint64, seqInTxn uint32) []byte {
 	buf := make([]byte, 0, len("d|")+4+len(fakeUserKey)+8+4)
 	buf = append(buf, "d|"...)

--- a/store/list_helpers_test.go
+++ b/store/list_helpers_test.go
@@ -1,0 +1,28 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractListUserKeyFromDeltaRequiresExactDeltaShape(t *testing.T) {
+	t.Parallel()
+
+	userKey := []byte("d|list")
+	deltaKey := ListMetaDeltaKey(userKey, 42, 7)
+	require.True(t, IsListMetaDeltaKey(deltaKey))
+	require.Equal(t, userKey, ExtractListUserKeyFromDelta(deltaKey))
+
+	baseMetaWithDeltaLookingUserKey := ListMetaKey(userKey)
+	require.False(t, IsListMetaDeltaKey(baseMetaWithDeltaLookingUserKey))
+	require.Nil(t, ExtractListUserKeyFromDelta(baseMetaWithDeltaLookingUserKey))
+
+	trailingGarbage := append([]byte{}, deltaKey...)
+	trailingGarbage = append(trailingGarbage, 0)
+	require.False(t, IsListMetaDeltaKey(trailingGarbage))
+	require.Nil(t, ExtractListUserKeyFromDelta(trailingGarbage))
+
+	require.False(t, IsListMetaDeltaKey([]byte("not-a-delta-key")))
+	require.Nil(t, ExtractListUserKeyFromDelta([]byte("not-a-delta-key")))
+}

--- a/store/set_helpers.go
+++ b/store/set_helpers.go
@@ -162,3 +162,9 @@ func ExtractSetUserKeyFromMember(key []byte) []byte {
 func ExtractSetUserKeyFromDelta(key []byte) []byte {
 	return extractWideColumnUserKey(key, []byte(SetMetaDeltaPrefix), deltaKeyTSSize+deltaKeySeqSize, true)
 }
+
+// ExtractSetUserKeyFromDeltaScanPrefix extracts the user key from a set
+// metadata delta scan start/prefix.
+func ExtractSetUserKeyFromDeltaScanPrefix(key []byte) []byte {
+	return extractWideColumnUserKey(key, []byte(SetMetaDeltaPrefix), 0, false)
+}

--- a/store/set_helpers.go
+++ b/store/set_helpers.go
@@ -150,40 +150,15 @@ func IsSetMetaDeltaKey(key []byte) bool {
 
 // ExtractSetUserKeyFromMeta extracts the logical user key from a set meta key.
 func ExtractSetUserKeyFromMeta(key []byte) []byte {
-	trimmed := bytes.TrimPrefix(key, []byte(SetMetaPrefix))
-	if len(trimmed) < wideColKeyLenSize {
-		return nil
-	}
-	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
-		return nil
-	}
-	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+	return extractWideColumnUserKey(key, []byte(SetMetaPrefix), 0, true)
 }
 
 // ExtractSetUserKeyFromMember extracts the logical user key from a set member key.
 func ExtractSetUserKeyFromMember(key []byte) []byte {
-	trimmed := bytes.TrimPrefix(key, []byte(SetMemberPrefix))
-	if len(trimmed) < wideColKeyLenSize {
-		return nil
-	}
-	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
-		return nil
-	}
-	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+	return extractWideColumnUserKey(key, []byte(SetMemberPrefix), 0, false)
 }
 
 // ExtractSetUserKeyFromDelta extracts the logical user key from a set delta key.
 func ExtractSetUserKeyFromDelta(key []byte) []byte {
-	trimmed := bytes.TrimPrefix(key, []byte(SetMetaDeltaPrefix))
-	minLen := wideColKeyLenSize + deltaKeyTSSize + deltaKeySeqSize
-	if len(trimmed) < minLen {
-		return nil
-	}
-	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen+uint32(deltaKeyTSSize+deltaKeySeqSize) { //nolint:gosec // constants fit in uint32
-		return nil
-	}
-	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+	return extractWideColumnUserKey(key, []byte(SetMetaDeltaPrefix), deltaKeyTSSize+deltaKeySeqSize, true)
 }

--- a/store/stream_helpers.go
+++ b/store/stream_helpers.go
@@ -129,6 +129,9 @@ func IsStreamEntryKey(key []byte) bool {
 // math.MaxUint32 cannot wrap (uint32(wideColKeyLenSize)+ukLen) and pass a
 // false negative, which would then panic on the trimmed[lo:hi] slice below.
 func ExtractStreamUserKeyFromMeta(key []byte) []byte {
+	if !bytes.HasPrefix(key, streamMetaPrefixBytes) {
+		return nil
+	}
 	trimmed := bytes.TrimPrefix(key, streamMetaPrefixBytes)
 	if len(trimmed) < wideColKeyLenSize {
 		return nil
@@ -140,12 +143,21 @@ func ExtractStreamUserKeyFromMeta(key []byte) []byte {
 	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
 }
 
+// ExtractStreamUserKeyFromEntryScanPrefix extracts the logical user key from
+// the prefix used to scan all entries for a stream.
+func ExtractStreamUserKeyFromEntryScanPrefix(key []byte) []byte {
+	return extractWideColumnUserKey(key, streamEntryPrefixBytes, 0, false)
+}
+
 // ExtractStreamUserKeyFromEntry extracts the logical user key from a stream entry key.
 //
 // See ExtractStreamUserKeyFromMeta for the rationale of the uint64 bounds
 // check; the entry variant additionally has to account for the trailing
 // StreamIDBytes (16 bytes) suffix.
 func ExtractStreamUserKeyFromEntry(key []byte) []byte {
+	if !bytes.HasPrefix(key, streamEntryPrefixBytes) {
+		return nil
+	}
 	trimmed := bytes.TrimPrefix(key, streamEntryPrefixBytes)
 	if len(trimmed) < wideColKeyLenSize+StreamIDBytes {
 		return nil

--- a/store/stream_helpers_test.go
+++ b/store/stream_helpers_test.go
@@ -75,3 +75,26 @@ func TestExtractStreamUserKeyFromEntry_RoundTrip(t *testing.T) {
 		t.Fatalf("round trip: want %q, got %q", want, got)
 	}
 }
+
+func TestExtractStreamUserKeyFromEntryScanPrefix_RoundTrip(t *testing.T) {
+	t.Parallel()
+	want := []byte("entry-scan-user-key")
+	if got := ExtractStreamUserKeyFromEntryScanPrefix(StreamEntryScanPrefix(want)); !bytes.Equal(got, want) {
+		t.Fatalf("scan prefix round trip: want %q, got %q", want, got)
+	}
+}
+
+func TestExtractStreamUserKeyRejectsForeignPrefixes(t *testing.T) {
+	t.Parallel()
+
+	key := append([]byte{0, 0, 0, 1}, 'x')
+	if got := ExtractStreamUserKeyFromMeta(key); got != nil {
+		t.Fatalf("meta extractor accepted non-stream key: %q", got)
+	}
+	if got := ExtractStreamUserKeyFromEntry(key); got != nil {
+		t.Fatalf("entry extractor accepted non-stream key: %q", got)
+	}
+	if got := ExtractStreamUserKeyFromEntryScanPrefix(key); got != nil {
+		t.Fatalf("entry scan extractor accepted non-stream key: %q", got)
+	}
+}

--- a/store/wide_column_helpers_test.go
+++ b/store/wide_column_helpers_test.go
@@ -1,0 +1,79 @@
+package store
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestWideColumnExtractorsRejectOverflowingUserKeyLength(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		prefix    string
+		suffixLen int
+		extract   func([]byte) []byte
+	}{
+		{name: "list claim", prefix: ListClaimPrefix, suffixLen: sortableInt64Bytes, extract: ExtractListUserKeyFromClaim},
+		{name: "hash meta", prefix: HashMetaPrefix, extract: ExtractHashUserKeyFromMeta},
+		{name: "hash field", prefix: HashFieldPrefix, extract: ExtractHashUserKeyFromField},
+		{name: "hash delta", prefix: HashMetaDeltaPrefix, suffixLen: deltaKeyTSSize + deltaKeySeqSize, extract: ExtractHashUserKeyFromDelta},
+		{name: "set meta", prefix: SetMetaPrefix, extract: ExtractSetUserKeyFromMeta},
+		{name: "set member", prefix: SetMemberPrefix, extract: ExtractSetUserKeyFromMember},
+		{name: "set delta", prefix: SetMetaDeltaPrefix, suffixLen: deltaKeyTSSize + deltaKeySeqSize, extract: ExtractSetUserKeyFromDelta},
+		{name: "zset meta", prefix: ZSetMetaPrefix, extract: ExtractZSetUserKeyFromMeta},
+		{name: "zset member", prefix: ZSetMemberPrefix, extract: ExtractZSetUserKeyFromMember},
+		{name: "zset score", prefix: ZSetScorePrefix, suffixLen: zsetMetaSizeBytes, extract: ExtractZSetUserKeyFromScore},
+		{name: "zset delta", prefix: ZSetMetaDeltaPrefix, suffixLen: deltaKeyTSSize + deltaKeySeqSize, extract: ExtractZSetUserKeyFromDelta},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.extract(malformedWideColumnStorageKey(tc.prefix, tc.suffixLen)); got != nil {
+				t.Fatalf("overflowing user-key length: want nil, got %q", got)
+			}
+		})
+	}
+}
+
+func TestWideColumnExtractorsRoundTripEmptyUserKey(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		key     []byte
+		extract func([]byte) []byte
+	}{
+		{name: "list claim", key: ListClaimKey(nil, 1), extract: ExtractListUserKeyFromClaim},
+		{name: "hash meta", key: HashMetaKey(nil), extract: ExtractHashUserKeyFromMeta},
+		{name: "hash field", key: HashFieldKey(nil, []byte("field")), extract: ExtractHashUserKeyFromField},
+		{name: "hash delta", key: HashMetaDeltaKey(nil, 2, 3), extract: ExtractHashUserKeyFromDelta},
+		{name: "set meta", key: SetMetaKey(nil), extract: ExtractSetUserKeyFromMeta},
+		{name: "set member", key: SetMemberKey(nil, []byte("member")), extract: ExtractSetUserKeyFromMember},
+		{name: "set delta", key: SetMetaDeltaKey(nil, 2, 3), extract: ExtractSetUserKeyFromDelta},
+		{name: "zset meta", key: ZSetMetaKey(nil), extract: ExtractZSetUserKeyFromMeta},
+		{name: "zset member", key: ZSetMemberKey(nil, []byte("member")), extract: ExtractZSetUserKeyFromMember},
+		{name: "zset score", key: ZSetScoreKey(nil, 1.5, []byte("member")), extract: ExtractZSetUserKeyFromScore},
+		{name: "zset delta", key: ZSetMetaDeltaKey(nil, 2, 3), extract: ExtractZSetUserKeyFromDelta},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.extract(tc.key)
+			if got == nil {
+				t.Fatal("empty user-key extraction returned nil")
+			}
+			if len(got) != 0 {
+				t.Fatalf("empty user-key extraction: want empty, got %q", got)
+			}
+		})
+	}
+}
+
+func malformedWideColumnStorageKey(prefix string, suffixLen int) []byte {
+	key := make([]byte, 0, len(prefix)+wideColKeyLenSize+suffixLen)
+	key = append(key, prefix...)
+	var lenPrefix [wideColKeyLenSize]byte
+	binary.BigEndian.PutUint32(lenPrefix[:], ^uint32(0))
+	key = append(key, lenPrefix[:]...)
+	key = append(key, make([]byte, suffixLen)...)
+	return key
+}

--- a/store/zset_helpers.go
+++ b/store/zset_helpers.go
@@ -264,53 +264,20 @@ func IsZSetMetaDeltaKey(key []byte) bool {
 
 // ExtractZSetUserKeyFromDelta extracts the logical user key from a zset delta key.
 func ExtractZSetUserKeyFromDelta(key []byte) []byte {
-	trimmed := bytes.TrimPrefix(key, []byte(ZSetMetaDeltaPrefix))
-	minLen := wideColKeyLenSize + deltaKeyTSSize + deltaKeySeqSize
-	if len(trimmed) < minLen {
-		return nil
-	}
-	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen+uint32(deltaKeyTSSize+deltaKeySeqSize) { //nolint:gosec // constants fit in uint32
-		return nil
-	}
-	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+	return extractWideColumnUserKey(key, []byte(ZSetMetaDeltaPrefix), deltaKeyTSSize+deltaKeySeqSize, true)
 }
 
 // ExtractZSetUserKeyFromMeta extracts the logical user key from a zset meta key.
 func ExtractZSetUserKeyFromMeta(key []byte) []byte {
-	trimmed := bytes.TrimPrefix(key, []byte(ZSetMetaPrefix))
-	if len(trimmed) < wideColKeyLenSize {
-		return nil
-	}
-	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
-		return nil
-	}
-	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+	return extractWideColumnUserKey(key, []byte(ZSetMetaPrefix), 0, true)
 }
 
 // ExtractZSetUserKeyFromMember extracts the logical user key from a zset member key.
 func ExtractZSetUserKeyFromMember(key []byte) []byte {
-	trimmed := bytes.TrimPrefix(key, []byte(ZSetMemberPrefix))
-	if len(trimmed) < wideColKeyLenSize {
-		return nil
-	}
-	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
-		return nil
-	}
-	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+	return extractWideColumnUserKey(key, []byte(ZSetMemberPrefix), 0, false)
 }
 
 // ExtractZSetUserKeyFromScore extracts the logical user key from a zset score index key.
 func ExtractZSetUserKeyFromScore(key []byte) []byte {
-	trimmed := bytes.TrimPrefix(key, []byte(ZSetScorePrefix))
-	if len(trimmed) < wideColKeyLenSize {
-		return nil
-	}
-	ukLen := binary.BigEndian.Uint32(trimmed[:wideColKeyLenSize])
-	if uint32(len(trimmed)) < uint32(wideColKeyLenSize)+ukLen { //nolint:gosec // wideColKeyLenSize fits in uint32
-		return nil
-	}
-	return trimmed[wideColKeyLenSize : wideColKeyLenSize+ukLen]
+	return extractWideColumnUserKey(key, []byte(ZSetScorePrefix), zsetMetaSizeBytes, false)
 }

--- a/store/zset_helpers.go
+++ b/store/zset_helpers.go
@@ -281,3 +281,15 @@ func ExtractZSetUserKeyFromMember(key []byte) []byte {
 func ExtractZSetUserKeyFromScore(key []byte) []byte {
 	return extractWideColumnUserKey(key, []byte(ZSetScorePrefix), zsetMetaSizeBytes, false)
 }
+
+// ExtractZSetUserKeyFromScoreScanPrefix extracts the user key from a zset
+// score-index scan start/prefix that does not yet include the sortable score.
+func ExtractZSetUserKeyFromScoreScanPrefix(key []byte) []byte {
+	return extractWideColumnUserKey(key, []byte(ZSetScorePrefix), 0, false)
+}
+
+// ExtractZSetUserKeyFromDeltaScanPrefix extracts the user key from a zset
+// metadata delta scan start/prefix.
+func ExtractZSetUserKeyFromDeltaScanPrefix(key []byte) []byte {
+	return extractWideColumnUserKey(key, []byte(ZSetMetaDeltaPrefix), 0, false)
+}


### PR DESCRIPTION
Author: bootjp

## Summary
- Add the M2 migration bracket planner and same-group no-op state transition helpers.
- Add route-key filtering and decoder coverage for txn success markers, list delta/claim rows, Redis wide-column families, streams, and concrete SQS/S3 prefixes.
- Add export-plan and route-key tests covering disjoint internal brackets, drain-only txn locks, reserved control ranges, concrete-only SQS/S3 decoding, and rightmost route filters.

## Validation
- `go test ./kv ./distribution -count=1 -timeout=240s`
- `GOCACHE=$(pwd)/.cache GOLANGCI_LINT_CACHE=$(pwd)/.golangci-cache golangci-lint run ./kv ./distribution --timeout=5m`
- `go test ./adapter -run 'TestIsKnownInternalKey_StreamPrefixNarrowed|TestRedisStandaloneMissingCreatorsReadAllWideFences|TestSqsPartitionedMsgKeys_DistinctFromLegacy|TestSQSPartitionResolver_' -count=1 -timeout=120s`
- `go test ./adapter -run '^TestSQS|^TestSqs|SQS|Sqs' -count=1 -timeout=90s -json`

## Note
- `go test ./... -count=1 -timeout=300s` reached the adapter package timeout; SQS/route-key-related adapter subsets passed, and all other packages reported pass before the timeout.