### PR TITLE
tso: wire dedicated group state machine

### DIFF
--- a/docs/design/2026_04_16_partial_centralized_tso.md
+++ b/docs/design/2026_04_16_partial_centralized_tso.md
@@ -55,7 +55,12 @@ Implemented:
     for Raft-envelope cutovers, while route validation keeps all user data out
     of the control group. Restore accepts snapshots written by the earlier
     compatibility `kvFSM`, imports their HLC ceiling, derives a safe allocation
-    floor, and drains the legacy MVCC payload for full CRC verification.
+    floor, and drains the legacy MVCC payload for full CRC verification. The
+    group-0 `EncryptionAdmin` surface is capability-only: mutators are left
+    unwired and return `FailedPrecondition`. During upgrade replay, valid
+    encryption control entries committed by the earlier compatibility FSM are
+    decoded and deterministically rejected without halting the TSO apply loop;
+    malformed control entries still halt fail-closed.
 
 Remaining:
 
@@ -715,4 +720,7 @@ least as large as the maximum shard ceiling.
    logs already carry compatible HLC lease entries. `TSOStateMachine.Restore`
    recognizes legacy `kvFSM` snapshot headers, imports the ceiling, derives the
    allocation floor, and drains the old store payload before Raft resumes log
-   replay, so runtime wiring does not require deleting group-0 state.
+   replay. Valid historical encryption control entries are decoded and rejected
+   as obsolete ordinary apply responses, so replay advances without mutating
+   TSO state; new group-0 encryption mutators are disabled at the RPC boundary.
+   Runtime wiring therefore does not require deleting group-0 state.

--- a/docs/design/2026_04_16_partial_centralized_tso.md
+++ b/docs/design/2026_04_16_partial_centralized_tso.md
@@ -2,11 +2,11 @@
 
 - Status: Partial — M1 all-led-group HLC renewal, the M2 reserved-group
   bootstrap bridge, and the M3-M5 TSO allocator/batch cutover are implemented;
-  the minimal TSO-only FSM is implemented, while runtime wiring and follower
-  redirect/admin exposure remain open
+  the minimal TSO-only FSM and runtime group-0 wiring are implemented, while
+  follower redirect/admin exposure and shadow validation remain open
 - Author: bootjp
 - Date: 2026-04-16
-- Updated: 2026-07-17
+- Updated: 2026-07-18
 
 ---
 
@@ -50,14 +50,17 @@ Implemented:
    entries, snapshots/restores TSO-owned ceiling/floor state, and classifies
    full ceiling/floor mirror entries as volatile-only so post-snapshot HLC
    mirror raises are not lost on duplicate replay skip paths.
+10. Runtime bootstrap instantiates `TSOStateMachine` for `groupID = 0` without
+    opening an MVCC store. Group 0 retains the normal wrap-aware proposer path
+    for Raft-envelope cutovers, while route validation keeps all user data out
+    of the control group. Restore accepts snapshots written by the earlier
+    compatibility `kvFSM`, imports their HLC ceiling, derives a safe allocation
+    floor, and drains the legacy MVCC payload for full CRC verification.
 
 Remaining:
 
-1. Wire runtime bootstrap for `groupID = 0` to instantiate `TSOStateMachine`
-   instead of the compatibility key-value FSM once the redirect path can route
-   timestamp requests to that group.
-2. Add follower redirect/admin exposure for the dedicated TSO leader.
-3. Add Phase B shadow-read validation before making dedicated TSO the only
+1. Add follower redirect/admin exposure for the dedicated TSO leader.
+2. Add Phase B shadow-read validation before making dedicated TSO the only
    production timestamp path.
 
 ### 1.1 Original Limitation
@@ -687,7 +690,7 @@ least as large as the maximum shard ceiling.
 | M3 — shipped | Define `TSOAllocator` interface; implement backed by `defaultGroup` | Medium |
 | M4 — shipped | `BatchAllocator` with atomic counter for low-latency timestamp serving | Medium |
 | M5 — shipped for default-group bridge | Coordinator feature-flag cutover via `--tsoEnabled`; shadow validation against a dedicated group remains deferred to M6 | Medium |
-| M6 — partial | Dedicated TSO Raft group (`groupID = 0`) is reserved/bootstrap-capable and warmed by the HLC renewal bridge; the minimal `TSOStateMachine` persists TSO-owned ceiling/floor state, while runtime group-0 wiring and TSO-leader-only timestamp issuance remain open | Low |
+| M6 — partial | Dedicated TSO Raft group (`groupID = 0`) is reserved/bootstrap-capable, warmed by the HLC renewal bridge, and runs the minimal `TSOStateMachine` without an MVCC store; TSO-leader redirect/admin exposure and TSO-leader-only timestamp issuance remain open | Low |
 | M7 | Phase D legacy cleanup + cross-shard SSI read-timestamp validation via TSO | Low |
 
 ---
@@ -708,6 +711,8 @@ least as large as the maximum shard ceiling.
    leader via gRPC, or support follower reads with a known-safe timestamp
    bound?
 
-5. **Backward compatibility:** Existing snapshots and Raft logs store ceiling
-   values inline in shard FSMs. Migration to a dedicated TSO FSM requires a
-   coordinated snapshot + compaction pass.
+5. **Backward compatibility (resolved for group 0):** Existing group-0 Raft
+   logs already carry compatible HLC lease entries. `TSOStateMachine.Restore`
+   recognizes legacy `kvFSM` snapshot headers, imports the ceiling, derives the
+   allocation floor, and drains the old store payload before Raft resumes log
+   replay, so runtime wiring does not require deleting group-0 state.

--- a/kv/tso_fsm.go
+++ b/kv/tso_fsm.go
@@ -1,6 +1,7 @@
 package kv
 
 import (
+	"bufio"
 	"encoding/binary"
 	"io"
 	"sync/atomic"
@@ -94,9 +95,31 @@ func (f *TSOStateMachine) Restore(r io.Reader) error {
 	if r == nil {
 		return errors.New("tso fsm snapshot: reader is nil")
 	}
-	payload, err := io.ReadAll(io.LimitReader(r, tsoSnapshotV2Len+1))
+	br := tsoSnapshotReader(r)
+	if legacy, err := restoreLegacyKVFSMSnapshot(f, br); legacy || err != nil {
+		return err
+	}
+	ceilingMs, allocationFloor, err := readTSOSnapshotState(br)
 	if err != nil {
-		return errors.Wrap(err, "restore tso fsm snapshot")
+		return err
+	}
+	if f != nil {
+		f.restoreSnapshotState(ceilingMs, allocationFloor)
+	}
+	return nil
+}
+
+func tsoSnapshotReader(r io.Reader) *bufio.Reader {
+	if br, ok := r.(*bufio.Reader); ok {
+		return br
+	}
+	return bufio.NewReader(r)
+}
+
+func readTSOSnapshotState(br *bufio.Reader) (int64, uint64, error) {
+	payload, err := io.ReadAll(io.LimitReader(br, tsoSnapshotV2Len+1))
+	if err != nil {
+		return 0, 0, errors.Wrap(err, "restore tso fsm snapshot")
 	}
 	var ceilingMs int64
 	var allocationFloor uint64
@@ -109,18 +132,59 @@ func (f *TSOStateMachine) Restore(r io.Reader) error {
 		ceilingMs = int64(binary.BigEndian.Uint64(payload[:hlcLeasePayloadLen])) //nolint:gosec // snapshot value.
 		allocationFloor = binary.BigEndian.Uint64(payload[hlcLeasePayloadLen:])
 	default:
-		return errors.Wrapf(ErrTSOStateMachineInvalidEntry, "tso fsm snapshot: expected %d or %d bytes, got %d", tsoSnapshotV1Len, tsoSnapshotV2Len, len(payload))
+		return 0, 0, errors.Wrapf(ErrTSOStateMachineInvalidEntry, "tso fsm snapshot: expected %d or %d bytes, got %d", tsoSnapshotV1Len, tsoSnapshotV2Len, len(payload))
 	}
 	if ceilingMs < 0 {
-		return errors.Wrapf(ErrTSOStateMachineInvalidEntry, "tso fsm snapshot: negative ceiling %d", ceilingMs)
+		return 0, 0, errors.Wrapf(ErrTSOStateMachineInvalidEntry, "tso fsm snapshot: negative ceiling %d", ceilingMs)
 	}
 	if legacySnapshot && ceilingMs > 0 {
 		allocationFloor = tsoLeaseAllocationFloor(ceilingMs)
 	}
-	if f != nil {
-		f.restoreSnapshotState(ceilingMs, allocationFloor)
+	return ceilingMs, allocationFloor, nil
+}
+
+// restoreLegacyKVFSMSnapshot migrates snapshots produced while reserved group
+// 0 still used kvFSM as a compatibility bridge. Only the HLC header is TSO
+// state; the empty MVCC payload is drained so the raft engine can verify the
+// complete snapshot CRC. Non-kvFSM snapshots are left untouched in br.
+func restoreLegacyKVFSMSnapshot(f *TSOStateMachine, br *bufio.Reader) (bool, error) {
+	legacy, err := hasLegacyKVFSMSnapshotHeader(br)
+	if err != nil || !legacy {
+		return legacy, err
 	}
-	return nil
+	ceiling, _, err := ReadSnapshotHeader(br)
+	if err != nil {
+		return true, errors.Wrap(err, "tso fsm snapshot: read legacy kv fsm header")
+	}
+	if _, err := io.Copy(io.Discard, br); err != nil {
+		return true, errors.Wrap(err, "tso fsm snapshot: drain legacy kv fsm payload")
+	}
+	ceilingMs := int64(ceiling) //nolint:gosec // validated below before use.
+	if ceilingMs < 0 {
+		return true, errors.Wrapf(ErrTSOStateMachineInvalidEntry, "tso fsm snapshot: negative legacy ceiling %d", ceilingMs)
+	}
+	if f == nil || ceilingMs == 0 {
+		return true, nil
+	}
+	f.restoreSnapshotState(ceilingMs, tsoLeaseAllocationFloor(ceilingMs))
+	return true, nil
+}
+
+func hasLegacyKVFSMSnapshotHeader(br *bufio.Reader) (bool, error) {
+	peeked, err := br.Peek(len(hlcSnapshotMagic))
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return false, errors.Wrap(err, "tso fsm snapshot: peek legacy header")
+	}
+	switch {
+	case isV1Magic(peeked):
+		return true, nil
+	case isV2Magic(peeked):
+		return true, nil
+	case isUnknownEKVTHLC(peeked):
+		return true, nil
+	default:
+		return false, nil
+	}
 }
 
 func (f *TSOStateMachine) IsVolatileOnlyPayload(payload []byte) bool {

--- a/kv/tso_fsm.go
+++ b/kv/tso_fsm.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"sync/atomic"
 
+	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
 	"github.com/bootjp/elastickv/internal/raftengine"
 	"github.com/cockroachdb/errors"
 )
@@ -13,7 +14,10 @@ import (
 var _ raftengine.StateMachine = (*TSOStateMachine)(nil)
 var _ raftengine.VolatileEntryClassifier = (*TSOStateMachine)(nil)
 
-var ErrTSOStateMachineInvalidEntry = errors.New("tso fsm: invalid entry")
+var (
+	ErrTSOStateMachineInvalidEntry      = errors.New("tso fsm: invalid entry")
+	ErrTSOLegacyEncryptionEntryRejected = errors.New("tso fsm: legacy encryption entry rejected")
+)
 
 const (
 	// raftEncodeTSOAllocationFloor is TSO-FSM-local. It intentionally uses a
@@ -48,9 +52,35 @@ func (f *TSOStateMachine) Apply(data []byte) any {
 		return f.applyLeaseEntry(data)
 	case raftEncodeTSOAllocationFloor:
 		return f.applyAllocationFloorEntry(data)
+	case fsmwire.OpRegistration, fsmwire.OpBootstrap, fsmwire.OpRotation:
+		return rejectLegacyTSOEncryptionEntry(data)
 	default:
 		return haltErr(errors.Wrapf(ErrTSOStateMachineInvalidEntry, "unexpected tag 0x%02x", data[0]))
 	}
+}
+
+// rejectLegacyTSOEncryptionEntry lets an upgraded group 0 advance past a
+// control entry committed while it still ran kvFSM. New group-0 listeners do
+// not expose encryption mutators, so these entries can only be historical.
+// Validate the old wire shape before returning an ordinary apply response:
+// malformed control bytes still halt, while a valid obsolete entry is
+// deterministically rejected without mutating TSO state or halting replay.
+func rejectLegacyTSOEncryptionEntry(data []byte) any {
+	var err error
+	switch data[0] {
+	case fsmwire.OpRegistration:
+		_, err = fsmwire.DecodeRegistration(data[1:])
+	case fsmwire.OpBootstrap:
+		_, err = fsmwire.DecodeBootstrap(data[1:])
+	case fsmwire.OpRotation:
+		_, err = fsmwire.DecodeRotation(data[1:])
+	}
+	if err != nil {
+		return haltErr(errors.Wrapf(ErrTSOStateMachineInvalidEntry,
+			"malformed legacy encryption entry tag 0x%02x: %v", data[0], err))
+	}
+	return errors.Wrapf(ErrTSOLegacyEncryptionEntryRejected,
+		"tag 0x%02x is not part of dedicated TSO state", data[0])
 }
 
 func (f *TSOStateMachine) applyLeaseEntry(data []byte) any {
@@ -172,7 +202,10 @@ func restoreLegacyKVFSMSnapshot(f *TSOStateMachine, br *bufio.Reader) (bool, err
 
 func hasLegacyKVFSMSnapshotHeader(br *bufio.Reader) (bool, error) {
 	peeked, err := br.Peek(len(hlcSnapshotMagic))
-	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+	if err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			return false, nil
+		}
 		return false, errors.Wrap(err, "tso fsm snapshot: peek legacy header")
 	}
 	switch {

--- a/kv/tso_fsm_test.go
+++ b/kv/tso_fsm_test.go
@@ -1,11 +1,13 @@
 package kv
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/binary"
 	"testing"
 	"time"
 
+	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
 	"github.com/bootjp/elastickv/store"
 	"github.com/stretchr/testify/require"
 )
@@ -49,6 +51,64 @@ func TestTSOStateMachineRejectsNonLeaseEntry(t *testing.T) {
 	payload[0] = raftEncodeSingle
 
 	err := requireTSOHaltError(t, NewTSOStateMachine(NewHLC()).Apply(payload))
+	require.ErrorIs(t, err, ErrTSOStateMachineInvalidEntry)
+}
+
+func TestTSOStateMachineRejectsLegacyEncryptionEntriesWithoutHalting(t *testing.T) {
+	t.Parallel()
+
+	registration := fsmwire.RegistrationPayload{DEKID: 1, FullNodeID: 2, LocalEpoch: 3}
+	tests := []struct {
+		name    string
+		opcode  byte
+		payload []byte
+	}{
+		{
+			name:    "registration",
+			opcode:  fsmwire.OpRegistration,
+			payload: fsmwire.EncodeRegistration(registration),
+		},
+		{
+			name:   "bootstrap",
+			opcode: fsmwire.OpBootstrap,
+			payload: fsmwire.EncodeBootstrap(fsmwire.BootstrapPayload{
+				StorageDEKID:   1,
+				WrappedStorage: []byte("storage"),
+				RaftDEKID:      2,
+				WrappedRaft:    []byte("raft"),
+				BatchRegistry:  []fsmwire.RegistrationPayload{registration},
+			}),
+		},
+		{
+			name:   "rotation",
+			opcode: fsmwire.OpRotation,
+			payload: fsmwire.EncodeRotation(fsmwire.RotationPayload{
+				SubTag:               fsmwire.RotateSubRotateDEK,
+				DEKID:                4,
+				Purpose:              fsmwire.PurposeStorage,
+				Wrapped:              []byte("rotated"),
+				ProposerRegistration: registration,
+			}),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := append([]byte{tc.opcode}, tc.payload...)
+			result := NewTSOStateMachine(NewHLC()).Apply(entry)
+			err, ok := result.(error)
+			require.Truef(t, ok, "legacy control response type = %T, want ordinary error", result)
+			require.ErrorIs(t, err, ErrTSOLegacyEncryptionEntryRejected)
+			_, halts := result.(interface{ HaltApply() error })
+			require.False(t, halts, "valid legacy control entry must not halt replay")
+		})
+	}
+}
+
+func TestTSOStateMachineHaltsMalformedLegacyEncryptionEntry(t *testing.T) {
+	t.Parallel()
+
+	err := requireTSOHaltError(t, NewTSOStateMachine(NewHLC()).Apply([]byte{fsmwire.OpRegistration}))
 	require.ErrorIs(t, err, ErrTSOStateMachineInvalidEntry)
 }
 
@@ -152,6 +212,17 @@ func TestTSOStateMachineRestoreRejectsTruncatedSnapshot(t *testing.T) {
 
 	err := NewTSOStateMachine(NewHLC()).Restore(bytes.NewReader([]byte{0x01, 0x02}))
 	require.Error(t, err)
+}
+
+func TestTSOStateMachineLegacySnapshotProbeRejectsEveryShortMagicPrefix(t *testing.T) {
+	t.Parallel()
+
+	for size := range len(hlcSnapshotMagic) {
+		payload := append([]byte(nil), hlcSnapshotMagic[:size]...)
+		legacy, err := hasLegacyKVFSMSnapshotHeader(bufio.NewReader(bytes.NewReader(payload)))
+		require.NoError(t, err)
+		require.False(t, legacy)
+	}
 }
 
 func TestTSOStateMachineRestoreLegacySnapshotDerivesAllocationFloor(t *testing.T) {

--- a/kv/tso_fsm_test.go
+++ b/kv/tso_fsm_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bootjp/elastickv/store"
 	"github.com/stretchr/testify/require"
 )
 
@@ -195,6 +196,47 @@ func TestTSOStateMachineRestoreKeepsMonotonicCeiling(t *testing.T) {
 	require.EqualValues(t, tsoSnapshotV2Len, n)
 	require.Equal(t, uint64(higherCeiling), binary.BigEndian.Uint64(snapBuf.Bytes()[:hlcLeasePayloadLen]))
 	require.Equal(t, tsoLeaseAllocationFloor(higherCeiling), binary.BigEndian.Uint64(snapBuf.Bytes()[hlcLeasePayloadLen:]))
+}
+
+func TestTSOStateMachineRestoresLegacyKVFSMSnapshot(t *testing.T) {
+	const ceilingMs = int64(1_700_000_123_456)
+	tests := []struct {
+		name string
+		opts []FSMOption
+	}{
+		{name: "v1"},
+		{name: "v2", opts: []FSMOption{WithCutoverSource(&staticCutoverSource{v: 42})}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			legacyClock := NewHLC()
+			legacyClock.SetPhysicalCeiling(ceilingMs)
+			legacyFSM := NewKvFSMWithHLC(store.NewMVCCStore(), legacyClock, tc.opts...)
+			legacySnapshot, err := legacyFSM.Snapshot()
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, legacySnapshot.Close()) })
+
+			var legacy bytes.Buffer
+			_, err = legacySnapshot.WriteTo(&legacy)
+			require.NoError(t, err)
+
+			targetClock := NewHLC()
+			target := NewTSOStateMachine(targetClock)
+			require.NoError(t, target.Restore(bytes.NewReader(legacy.Bytes())))
+			require.Equal(t, ceilingMs, targetClock.PhysicalCeiling())
+			require.Equal(t, tsoLeaseAllocationFloor(ceilingMs), targetClock.Current())
+
+			got, err := target.Snapshot()
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, got.Close()) })
+			var payload bytes.Buffer
+			_, err = got.WriteTo(&payload)
+			require.NoError(t, err)
+			require.Len(t, payload.Bytes(), tsoSnapshotV2Len)
+			require.Equal(t, uint64(ceilingMs), binary.BigEndian.Uint64(payload.Bytes()[:hlcLeasePayloadLen]))
+			require.Equal(t, tsoLeaseAllocationFloor(ceilingMs), binary.BigEndian.Uint64(payload.Bytes()[hlcLeasePayloadLen:]))
+		})
+	}
 }
 
 func TestTSOStateMachineClassifiesOnlyFullLeaseEntriesAsVolatile(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -1054,104 +1054,147 @@ func buildShardGroups(
 	// breaking the shared-cache invariant 6D-6c-1 relies on.
 	encWiring = encWiring.withDefaultedCache()
 	multi = effectiveMultiDataDirs(groups, multi)
+	builder := shardGroupBuilder{
+		raftID:                   raftID,
+		raftDir:                  raftDir,
+		multi:                    multi,
+		bootstrap:                bootstrap,
+		bootstrapCfg:             bootstrapCfg,
+		factory:                  factory,
+		proposalObserverForGroup: proposalObserverForGroup,
+		clock:                    clock,
+		kekWrapper:               kekWrapper,
+		keystore:                 keystore,
+		sidecarPath:              sidecarPath,
+		encWiring:                encWiring,
+		routeEngine:              routeEngine,
+		applyObservers:           applyObservers,
+	}
 	runtimes := make([]*raftGroupRuntime, 0, len(groups))
 	shardGroups := make(map[uint64]*kv.ShardGroup, len(groups))
 	for _, g := range groups {
-		dir := groupDataDir(raftDir, raftID, g.id, multi)
-		if err := os.MkdirAll(dir, dirPerm); err != nil {
-			return nil, nil, errors.Wrapf(err, "failed to create fsm store dir for group %d", g.id)
-		}
-		st, err := store.NewPebbleStore(filepath.Join(dir, "fsm.db"), encWiring.pebbleOptions()...)
+		runtime, sg, err := builder.build(g)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "failed to open pebble fsm store for group %d", g.id)
-		}
-		// Each shard FSM shares the same HLC so any shard's lease renewal advances
-		// the global physicalCeiling. The logical counter remains in-memory only.
-		//
-		// §6.3 EncryptionApplier wiring (Stage 6A). Constructs an
-		// Applier backed by the FSM's Pebble store and threads it
-		// into the FSM dispatch via kv.WithEncryption. The applier's
-		// ApplyBootstrap / ApplyRotation paths return ErrKEKNotConfigured
-		// until Stage 6B threads in the KEK plumbing; only
-		// ApplyRegistration is fully functional in 6A, but the gRPC
-		// mutator gate (registerEncryptionAdminServer, Stage 5D
-		// posture) keeps the operator surface inert until 6B re-enables
-		// it gated on (--encryption-enabled AND KEKConfigured()).
-		reg, err := store.WriterRegistryFor(st)
-		if err != nil {
-			for _, rt := range runtimes {
-				rt.Close()
-			}
-			_ = st.Close()
-			return nil, nil, errors.Wrapf(err, "failed to construct writer registry for group %d", g.id)
-		}
-		// Stage 6B-2: thread WithKEK + WithKeystore + WithSidecarPath
-		// into the Applier when all three are supplied. Without
-		// any of them the applier stays in the Stage 6A posture
-		// (ApplyBootstrap / ApplyRotation return ErrKEKNotConfigured)
-		// which is exactly the desired apply-time fail-closed
-		// behaviour when an operator has not opted in to encryption.
-		//
-		// Stage 6D-6c-1: WithStateCache threads the process-shared
-		// StateCache so an encryption apply landing on this shard's
-		// FSM updates the atomics every shard's storage layer reads.
-		// Stage 7b' §3.1: WithLocalEpoch threads this process load's
-		// pinned storage write-path w.epoch into the Applier so
-		// applyRotateDEK (PurposeStorage) can write each node's own
-		// highest-emitted local_epoch into Keys[newDEK].LocalEpoch
-		// rather than the proposer's 0. Stage 6E does the same for
-		// raft rotations through WithRaftLocalEpoch using the raft
-		// DEK's separate per-process epoch.
-		applierOpts := encryptionApplierOptionsFor(kekWrapper, keystore, sidecarPath, encWiring)
-		applier, err := encryption.NewApplier(reg, applierOpts...)
-		if err != nil {
-			for _, rt := range runtimes {
-				rt.Close()
-			}
-			_ = st.Close()
-			return nil, nil, errors.Wrapf(err, "failed to construct encryption applier for group %d", g.id)
-		}
-		// Composed-1 M2 plumbing: wire the shared route catalog
-		// engine and this shard's owning group ID so M3's
-		// verifyComposed1 apply-time gate can resolve the
-		// observed-version owner-of-key without further plumbing
-		// work. At M2 the FSM stores both but does not consult them;
-		// see docs/design/2026_05_29_implemented_composed1_cross_group_commit_guard.md
-		// §M2.
-		sm := kv.NewKvFSMWithHLC(st, clock, fsmOptionsForGroup(applier, routeEngine, g.id, encWiring, applyObservers...)...)
-		groupBootstrap, groupBootstrapServers, groupBootstrapSeed := bootstrapSettingsForGroup(bootstrapCfg, g.id, bootstrap)
-		runtime, err := buildRuntimeForGroup(
-			raftID, g, raftDir, multi, groupBootstrap,
-			groupBootstrapServers, groupBootstrapSeed,
-			st, sm, factory, *raftJoinAsLearner)
-		if err != nil {
-			for _, rt := range runtimes {
-				rt.Close()
-			}
-			_ = st.Close()
-			return nil, nil, errors.Wrapf(err, "failed to start raft group %d", g.id)
+			closeRaftGroupRuntimes(runtimes)
+			return nil, nil, err
 		}
 		runtimes = append(runtimes, runtime)
-		// Stage 6E-2c: route every shard group's TransactionManager
-		// through NewLeaderProxyForShardGroup so the proposer chain
-		// consults sg.raftPayloadWrap on every Propose / ProposeAdmin.
-		// The cell is nil at startup (the Stage 3 default — payloads
-		// pass through cleartext); Stage 6E-2d's EnableRaftEnvelope
-		// handler will publish the active wrap closure the instant
-		// the cutover entry commits. Going through this constructor
-		// for every group avoids a future "I forgot to wire wrap on
-		// this code path" regression — if a new shard group bypasses
-		// this helper, the wrap install would silently no-op on
-		// proposals for that group.
-		sg := &kv.ShardGroup{
-			Engine: runtime.engine,
-			Store:  st,
-		}
-		sg.Txn = kv.NewLeaderProxyForShardGroup(sg, kv.WithProposalObserver(observerForGroup(proposalObserverForGroup, g.id)))
 		shardGroups[g.id] = sg
 		encWiring.attachRaftEnvelopeGroup(g.id, sg)
 	}
 	return runtimes, shardGroups, nil
+}
+
+type shardGroupBuilder struct {
+	raftID                   string
+	raftDir                  string
+	multi                    bool
+	bootstrap                bool
+	bootstrapCfg             raftBootstrapConfig
+	factory                  raftengine.Factory
+	proposalObserverForGroup func(uint64) kv.ProposalObserver
+	clock                    *kv.HLC
+	kekWrapper               kek.Wrapper
+	keystore                 *encryption.Keystore
+	sidecarPath              string
+	encWiring                encryptionWriteWiring
+	routeEngine              *distribution.Engine
+	applyObservers           []kv.ApplyObserver
+}
+
+func (b shardGroupBuilder) build(group groupSpec) (*raftGroupRuntime, *kv.ShardGroup, error) {
+	groupBootstrap, groupBootstrapServers, groupBootstrapSeed := bootstrapSettingsForGroup(b.bootstrapCfg, group.id, b.bootstrap)
+	observer := observerForGroup(b.proposalObserverForGroup, group.id)
+	if group.id == dedicatedTSORaftGroupID {
+		runtime, sg, err := buildDedicatedTSOGroup(
+			b.raftID, group, b.raftDir, b.multi, groupBootstrap,
+			groupBootstrapServers, groupBootstrapSeed,
+			b.factory, b.clock, observer,
+		)
+		return runtime, sg, errors.Wrap(err, "failed to start dedicated TSO group")
+	}
+	return b.buildDataGroup(group, groupBootstrap, groupBootstrapServers, groupBootstrapSeed, observer)
+}
+
+func (b shardGroupBuilder) buildDataGroup(
+	group groupSpec,
+	bootstrap bool,
+	bootstrapServers []raftengine.Server,
+	bootstrapSeed []raftengine.Server,
+	proposalObserver kv.ProposalObserver,
+) (*raftGroupRuntime, *kv.ShardGroup, error) {
+	dir := groupDataDir(b.raftDir, b.raftID, group.id, b.multi)
+	if err := os.MkdirAll(dir, dirPerm); err != nil {
+		return nil, nil, errors.Wrapf(err, "failed to create fsm store dir for group %d", group.id)
+	}
+	st, err := store.NewPebbleStore(filepath.Join(dir, "fsm.db"), b.encWiring.pebbleOptions()...)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "failed to open pebble fsm store for group %d", group.id)
+	}
+	reg, err := store.WriterRegistryFor(st)
+	if err != nil {
+		_ = st.Close()
+		return nil, nil, errors.Wrapf(err, "failed to construct writer registry for group %d", group.id)
+	}
+	applierOpts := encryptionApplierOptionsFor(b.kekWrapper, b.keystore, b.sidecarPath, b.encWiring)
+	applier, err := encryption.NewApplier(reg, applierOpts...)
+	if err != nil {
+		_ = st.Close()
+		return nil, nil, errors.Wrapf(err, "failed to construct encryption applier for group %d", group.id)
+	}
+	sm := kv.NewKvFSMWithHLC(st, b.clock, fsmOptionsForGroup(applier, b.routeEngine, group.id, b.encWiring, b.applyObservers...)...)
+	runtime, err := buildRuntimeForGroup(
+		b.raftID, group, b.raftDir, b.multi, bootstrap,
+		bootstrapServers, bootstrapSeed,
+		st, sm, b.factory, *raftJoinAsLearner,
+	)
+	if err != nil {
+		_ = st.Close()
+		return nil, nil, errors.Wrapf(err, "failed to start raft group %d", group.id)
+	}
+	// Every group goes through the wrap-aware proposer so HLC renewals and
+	// transactional proposals observe raft-envelope cutovers uniformly.
+	sg := &kv.ShardGroup{Engine: runtime.engine, Store: st}
+	sg.Txn = kv.NewLeaderProxyForShardGroup(sg, kv.WithProposalObserver(proposalObserver))
+	return runtime, sg, nil
+}
+
+func closeRaftGroupRuntimes(runtimes []*raftGroupRuntime) {
+	for _, runtime := range runtimes {
+		runtime.Close()
+	}
+}
+
+// buildDedicatedTSOGroup constructs group 0 with the minimal TSO state machine.
+// It intentionally does not open an MVCC store: shard routing validation keeps
+// user data out of group 0, while the state machine persists only its ceiling
+// and allocation floor in Raft snapshots. The ShardGroup still receives the
+// normal proposer wrapper so lease renewals participate in raft-envelope
+// cutovers exactly like data-group proposals.
+func buildDedicatedTSOGroup(
+	raftID string,
+	group groupSpec,
+	baseDir string,
+	multi bool,
+	bootstrap bool,
+	bootstrapServers []raftengine.Server,
+	bootstrapSeed []raftengine.Server,
+	factory raftengine.Factory,
+	clock *kv.HLC,
+	proposalObserver kv.ProposalObserver,
+) (*raftGroupRuntime, *kv.ShardGroup, error) {
+	sm := kv.NewTSOStateMachine(clock)
+	runtime, err := buildRuntimeForGroup(
+		raftID, group, baseDir, multi, bootstrap,
+		bootstrapServers, bootstrapSeed,
+		nil, sm, factory, *raftJoinAsLearner,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	sg := &kv.ShardGroup{Engine: runtime.engine}
+	sg.Txn = kv.NewLeaderProxyForShardGroup(sg, kv.WithProposalObserver(proposalObserver))
+	return runtime, sg, nil
 }
 
 func bootstrapSettingsForGroup(

--- a/main.go
+++ b/main.go
@@ -2179,12 +2179,17 @@ func startRaftServers(
 		// Proposer + LeaderView for the cutover marker, while
 		// ShardGroup.Proposer() supplies the wrap-aware post-cutover
 		// path for normal admin entries.
+		runtimeMutators, runtimeEncryptionEngine := encryptionAdminWiringForGroup(
+			rt.spec.id,
+			enableMutators,
+			rt.engine,
+		)
 		registerEncryptionAdminServer(
 			gs,
 			etcdraftengine.DeriveNodeID(*raftId),
 			*encryptionSidecarPath,
-			enableMutators,
-			rt.engine,
+			runtimeMutators,
+			runtimeEncryptionEngine,
 			encryptionCapabilityFanout,
 			adapter.WithEncryptionAdminLatestAppliedIndex(appliedIndexForEngine(rt.engine)),
 			adapter.WithEncryptionAdminPostCutoverProposer(proposerForGroup(rt, shardGroups)),

--- a/main_encryption_admin.go
+++ b/main_encryption_admin.go
@@ -76,6 +76,18 @@ type encryptionAdminEngine interface {
 	raftengine.LeaderView
 }
 
+// encryptionAdminWiringForGroup keeps the read-only capability service on the
+// dedicated TSO listener while withholding every mutating proposal path. The
+// TSO FSM has no encryption applier or writer registry, so allowing a mutator
+// to propose there would commit an entry that cannot update dedicated TSO
+// state. Data groups retain the normal flag-driven mutator wiring.
+func encryptionAdminWiringForGroup(groupID uint64, enableMutators bool, engine encryptionAdminEngine) (bool, encryptionAdminEngine) {
+	if groupID == dedicatedTSORaftGroupID {
+		return false, nil
+	}
+	return enableMutators, engine
+}
+
 // registerEncryptionAdminServer constructs and registers an
 // EncryptionAdminServer on the supplied gRPC server. The function
 // is intentionally per-shard: the §7.1 Phase-0 GetCapability

--- a/main_encryption_admin_test.go
+++ b/main_encryption_admin_test.go
@@ -134,6 +134,29 @@ func TestEncryptionAdmin_MutatingRPCEnabledWhenGateOn(t *testing.T) {
 	}
 }
 
+func TestEncryptionAdmin_DedicatedTSOGroupAlwaysRefusesMutators(t *testing.T) {
+	enabled, engine := encryptionAdminWiringForGroup(
+		dedicatedTSORaftGroupID,
+		true,
+		stubEncryptionAdminEngine{},
+	)
+	if enabled || engine != nil {
+		t.Fatalf("dedicated TSO mutator wiring = (%v, %T), want (false, nil)", enabled, engine)
+	}
+	err := callBootstrapAgainstNewServer(t, enabled, engine)
+	if got := status.Code(err); got != codes.FailedPrecondition {
+		t.Fatalf("BootstrapEncryption status=%v, want FailedPrecondition; err=%v", got, err)
+	}
+}
+
+func TestEncryptionAdmin_DataGroupPreservesMutatorGate(t *testing.T) {
+	want := stubEncryptionAdminEngine{}
+	enabled, engine := encryptionAdminWiringForGroup(1, true, want)
+	if !enabled || engine == nil {
+		t.Fatalf("data-group mutator wiring = (%v, %T), want (true, non-nil)", enabled, engine)
+	}
+}
+
 func callBootstrapAgainstNewServer(t *testing.T, enableMutators bool, engine encryptionAdminEngine) error {
 	t.Helper()
 	listener := bufconn.Listen(1024 * 1024)

--- a/multiraft_runtime_test.go
+++ b/multiraft_runtime_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/bootjp/elastickv/distribution"
+	"github.com/bootjp/elastickv/internal/encryption/fsmwire"
 	"github.com/bootjp/elastickv/kv"
 	"github.com/bootjp/elastickv/store"
 	"github.com/stretchr/testify/require"
@@ -118,6 +119,91 @@ func TestBuildShardGroupsWithDedicatedTSOPreservesLegacyGroupZeroStore(t *testin
 	got, err := os.ReadFile(legacyMarker)
 	require.NoError(t, err)
 	require.Equal(t, []byte("preserve"), got)
+}
+
+func TestBuildShardGroupsClosesEarlierStoresWhenLaterGroupFails(t *testing.T) {
+	baseDir := t.TempDir()
+	badGroupDir := groupDataDir(baseDir, "n1", 2, true)
+	require.NoError(t, os.MkdirAll(badGroupDir, raftDirPerm))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(badGroupDir, raftEngineMarkerFile),
+		[]byte("unsupported\n"),
+		raftEngineMarkerPerm,
+	))
+
+	factory, err := newRaftFactory(raftEngineEtcd, nil)
+	require.NoError(t, err)
+	runtimes, shardGroups, err := buildShardGroups(
+		"n1",
+		baseDir,
+		[]groupSpec{
+			{id: 1, address: "127.0.0.1:17011"},
+			{id: 2, address: "127.0.0.1:17012"},
+		},
+		true,
+		true,
+		raftBootstrapConfig{},
+		factory,
+		nil,
+		kv.NewHLC(),
+		nil,
+		nil,
+		"",
+		encryptionWriteWiring{},
+		nil,
+	)
+	require.ErrorIs(t, err, ErrUnsupportedRaftEngine)
+	require.Nil(t, runtimes)
+	require.Nil(t, shardGroups)
+
+	// Reopening the first group's Pebble directory proves the error path ran
+	// raftGroupRuntime.Close, which owns both engine and store cleanup.
+	reopened, err := store.NewPebbleStore(filepath.Join(
+		groupDataDir(baseDir, "n1", 1, true),
+		"fsm.db",
+	))
+	require.NoError(t, err)
+	require.NoError(t, reopened.Close())
+}
+
+func TestDedicatedTSOGroupContinuesAfterLegacyEncryptionEntry(t *testing.T) {
+	baseDir := t.TempDir()
+	factory, err := newRaftFactory(raftEngineEtcd, nil)
+	require.NoError(t, err)
+	clock := kv.NewHLC()
+	runtimes, _, err := buildShardGroups(
+		"n1",
+		baseDir,
+		[]groupSpec{{id: dedicatedTSORaftGroupID, address: "127.0.0.1:17020"}},
+		true,
+		true,
+		raftBootstrapConfig{},
+		factory,
+		nil,
+		clock,
+		nil,
+		nil,
+		"",
+		encryptionWriteWiring{},
+		nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { closeRaftGroupRuntimes(runtimes) })
+
+	legacyEntry := append([]byte{fsmwire.OpRegistration}, fsmwire.EncodeRegistration(
+		fsmwire.RegistrationPayload{DEKID: 1, FullNodeID: 2, LocalEpoch: 3},
+	)...)
+	result, err := runtimes[0].engine.ProposeAdmin(context.Background(), legacyEntry)
+	require.NoError(t, err)
+	legacyErr, ok := result.Response.(error)
+	require.Truef(t, ok, "legacy response type = %T, want error", result.Response)
+	require.ErrorIs(t, legacyErr, kv.ErrTSOLegacyEncryptionEntryRejected)
+
+	const ceilingMs = int64(1_700_000_123_456)
+	coordinator := kv.NewCoordinatorWithEngine(nil, runtimes[0].engine)
+	t.Cleanup(func() { require.NoError(t, coordinator.Close()) })
+	require.NoError(t, coordinator.ProposeHLCLease(context.Background(), ceilingMs))
+	require.Equal(t, ceilingMs, clock.PhysicalCeiling())
 }
 
 func TestParseRaftEngineType(t *testing.T) {

--- a/multiraft_runtime_test.go
+++ b/multiraft_runtime_test.go
@@ -70,8 +70,12 @@ func TestBuildShardGroupsWithDedicatedTSOPreservesSingleDataGroupDir(t *testing.
 	})
 	require.Contains(t, shardGroups, uint64(dedicatedTSORaftGroupID))
 	require.Contains(t, shardGroups, uint64(1))
+	require.Nil(t, shardGroups[dedicatedTSORaftGroupID].Store)
+	require.IsType(t, &kv.TSOStateMachine{}, runtimes[0].stateMachine)
+	require.Nil(t, runtimes[0].store)
 	require.DirExists(t, filepath.Join(legacyDir, "fsm.db"))
-	require.DirExists(t, filepath.Join(legacyDir, "group-0", "fsm.db"))
+	require.DirExists(t, filepath.Join(legacyDir, "group-0"))
+	require.NoDirExists(t, filepath.Join(legacyDir, "group-0", "fsm.db"))
 	if _, err := os.Stat(filepath.Join(legacyDir, "group-1")); !os.IsNotExist(err) {
 		require.NoError(t, err)
 		t.Fatalf("group 1 should stay in legacy dir, but group-1 dir exists")
@@ -79,6 +83,41 @@ func TestBuildShardGroupsWithDedicatedTSOPreservesSingleDataGroupDir(t *testing.
 	got, err := os.ReadFile(legacyMarker)
 	require.NoError(t, err)
 	require.Equal(t, []byte("keep"), got)
+}
+
+func TestBuildShardGroupsWithDedicatedTSOPreservesLegacyGroupZeroStore(t *testing.T) {
+	baseDir := t.TempDir()
+	legacyStoreDir := filepath.Join(baseDir, "n1", "group-0", "fsm.db")
+	require.NoError(t, os.MkdirAll(legacyStoreDir, raftDirPerm))
+	legacyMarker := filepath.Join(legacyStoreDir, "legacy.marker")
+	require.NoError(t, os.WriteFile(legacyMarker, []byte("preserve"), 0o600))
+
+	factory, err := newRaftFactory(raftEngineEtcd, nil)
+	require.NoError(t, err)
+	runtimes, shardGroups, err := buildShardGroups(
+		"n1",
+		baseDir,
+		[]groupSpec{{id: dedicatedTSORaftGroupID, address: "127.0.0.1:17002"}},
+		true,
+		true,
+		raftBootstrapConfig{},
+		factory,
+		nil,
+		kv.NewHLC(),
+		nil,
+		nil,
+		"",
+		encryptionWriteWiring{},
+		nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { closeRaftGroupRuntimes(runtimes) })
+	require.Nil(t, shardGroups[dedicatedTSORaftGroupID].Store)
+	require.Nil(t, runtimes[0].store)
+
+	got, err := os.ReadFile(legacyMarker)
+	require.NoError(t, err)
+	require.Equal(t, []byte("preserve"), got)
 }
 
 func TestParseRaftEngineType(t *testing.T) {


### PR DESCRIPTION
Author: bootjp

## Summary
- run reserved Raft group 0 with the minimal TSO state machine and no MVCC store
- retain the wrap-aware proposer path for control-group lease renewals
- migrate legacy group-0 KV FSM snapshots by importing the HLC header while preserving old store files

## Risk
- the change is limited to reserved group 0; data groups retain the existing KV FSM and storage wiring
- `--tsoEnabled` keeps its current default-group allocation bridge until the leader-redirect follow-up
- preexisting group-0 `fsm.db` files are retained but no longer opened

## Testing
- `go test ./kv -run 'TestTSOStateMachine|TestLocalTSOAllocator|TestBatchAllocator|TestShardedCoordinator.*Timestamp' -count=1 -timeout=180s`
- `go test . -run 'TestBuildShardGroupsWithDedicatedTSO|TestGroupDataDir|TestConfigureCoordinatorTSO' -count=1 -timeout=180s`
- `golangci-lint --config=.golangci.yaml run ./kv . --timeout=5m`
- `git diff --check`
