### PR TITLE
Add encryption compress-then-encrypt path

### DIFF
--- a/docs/design/2026_04_29_partial_data_at_rest_encryption.md
+++ b/docs/design/2026_04_29_partial_data_at_rest_encryption.md
@@ -1,6 +1,6 @@
 # Data-at-rest encryption for elastickv
 
-Status: Partial — Stages 0–8 shipped (5E deferred); Stage 9 open
+Status: Partial — Stages 0–8 and 9A shipped (5E deferred); remaining Stage 9 work open
 Author: bootjp
 Date: 2026-04-29
 
@@ -32,7 +32,8 @@ Date: 2026-04-29
 | 6F | §6.5 `--encryption-rotate-on-startup` request flag + leader-elected rotation proposal on the default encryption Raft group. The leader rotates every active DEK purpose once before listeners open; followers keep an in-memory pending request and fire only if they acquire leadership in the same process uptime. | shipped | this PR |
 | 7 | Writer registry + deterministic nonce (§4.1). Covers process-start registration, storage-layer registration gate, runtime re-registration for cutover and rotation, conf-change-time pre-registration, and §5.5 registry projection in `GetSidecarState` / `ResyncSidecar` (`WriterRegistryForCaller`). | shipped | `2026_05_26_implemented_7a_process_start_registration.md` + `2026_05_26_implemented_7a2_storage_layer_registration_enforcement.md` + `2026_05_28_implemented_7b_runtime_reregistration.md` + `2026_05_28_implemented_7b_prime_runtime_reregistration_rotation.md` + `2026_05_29_implemented_7c_confchange_time_registration.md` + `2026_07_11_implemented_7d_sidecar_registry_projection.md` |
 | 8 | Snapshot header v2 (§4.4); WAL coverage closure (§4.3 / §4.6) | shipped | [`2026_05_29_implemented_8a_snapshot_header_v2.md`](2026_05_29_implemented_8a_snapshot_header_v2.md) + [`2026_06_01_implemented_8b_wal_coverage_closure.md`](2026_06_01_implemented_8b_wal_coverage_closure.md) |
-| 9 | KMS-backed wrappers, compression, rotation/retire/rewrite, Jepsen (§5.2, §5.4, §6.4, §8) | open | — |
+| 9A | Compress-then-encrypt, authenticated compression flag, encrypted-store Pebble compression policy, storage benchmark (§6.4, §8.3) | shipped | `2026_07_18_implemented_9a_encryption_compression.md` |
+| 9B+ | KMS-backed wrappers, rotation/retire/rewrite, remaining benchmarks and encrypted Jepsen (§5.2, §5.4, §6.5, §8) | open | — |
 
 Stages 0–4 ship the entire byte-tag pipeline (storage envelope, raft
 envelope, FSM dispatch, halt-on-error) but leave it **production

--- a/docs/design/2026_07_18_implemented_9a_encryption_compression.md
+++ b/docs/design/2026_07_18_implemented_9a_encryption_compression.md
@@ -1,0 +1,39 @@
+# Stage 9A data-at-rest compression
+
+Status: Implemented
+Author: bootjp
+Date: 2026-07-18
+
+## Scope
+
+This milestone implements the compress-then-encrypt storage path from
+`2026_04_29_partial_data_at_rest_encryption.md` §6.4.
+
+- Snappy runs on plaintext before AES-256-GCM.
+- The compressed representation is selected only when it is strictly smaller.
+- `FlagCompressed` is authenticated as part of the envelope AAD.
+- Reads decompress only after GCM authentication succeeds.
+- Unknown v1 flag bits fail closed.
+- The cleartext-rebadge guard verifies both valid compression-flag variants.
+- Pebble block compression is disabled for encryption-wired stores, including
+  database reopen and snapshot-restore temporary databases.
+
+Raft proposal envelopes remain uncompressed. Their apply path is latency
+sensitive and the storage layer already performs the only value-compression
+pass after proposal decryption.
+
+## Compatibility
+
+Existing v1 envelopes have `flag=0` and remain readable. New readers accept
+both `flag=0` and `FlagCompressed`; legacy cleartext operation and stores with
+no encryption wiring retain Pebble's default block-compression policy.
+
+## Verification
+
+- Storage round trips for compressed, uncompressed, empty, and already
+  compressed values.
+- Authenticated compression-flag tamper rejection.
+- Fail-closed handling for an authenticated malformed Snappy payload.
+- Property testing over arbitrary byte slices for compression framing.
+- Pebble compression-policy tests for encrypted and legacy stores.
+- Paired cleartext/encrypted 1 KiB storage benchmark for `benchstat` review.

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/emirpasic/gods v1.18.1
 	github.com/getsentry/sentry-go v0.47.0
 	github.com/goccy/go-json v0.10.6
+	github.com/golang/snappy v0.0.5-0.20231225225746-43d5d4cd4e0e
 	github.com/klauspost/compress v1.18.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
@@ -68,7 +69,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/golang/snappy v0.0.5-0.20231225225746-43d5d4cd4e0e // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect

--- a/internal/encryption/envelope.go
+++ b/internal/encryption/envelope.go
@@ -90,6 +90,10 @@ func (e *Envelope) Encode() ([]byte, error) {
 		return nil, errors.Wrapf(ErrEnvelopeVersion,
 			"encode: got 0x%02x, want 0x%02x", e.Version, EnvelopeVersionV1)
 	}
+	if e.Flag&^FlagCompressed != 0 {
+		return nil, errors.Wrapf(ErrEnvelopeFlag,
+			"encode: got 0x%02x, allowed mask 0x%02x", e.Flag, FlagCompressed)
+	}
 	if len(e.Body) < TagSize {
 		return nil, errors.Wrapf(ErrEnvelopeShort,
 			"encode: body %d bytes, want >= %d", len(e.Body), TagSize)
@@ -115,6 +119,10 @@ func DecodeEnvelope(src []byte) (*Envelope, error) {
 	if src[versionOffset] != EnvelopeVersionV1 {
 		return nil, errors.Wrapf(ErrEnvelopeVersion,
 			"got 0x%02x, want 0x%02x", src[versionOffset], EnvelopeVersionV1)
+	}
+	if src[flagOffset]&^FlagCompressed != 0 {
+		return nil, errors.Wrapf(ErrEnvelopeFlag,
+			"got 0x%02x, allowed mask 0x%02x", src[flagOffset], FlagCompressed)
 	}
 	e := &Envelope{
 		Version: src[versionOffset],

--- a/internal/encryption/envelope_test.go
+++ b/internal/encryption/envelope_test.go
@@ -2,6 +2,7 @@ package encryption_test
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/bootjp/elastickv/internal/encryption"
@@ -35,7 +36,7 @@ func TestEnvelope_RoundTrip(t *testing.T) {
 			name: "max key_id",
 			env: encryption.Envelope{
 				Version: encryption.EnvelopeVersionV1,
-				Flag:    0xff,
+				Flag:    encryption.FlagCompressed,
 				KeyID:   0xFFFF_FFFF,
 				Body:    bytes.Repeat([]byte{0x77}, 1024+encryption.TagSize),
 			},
@@ -126,6 +127,30 @@ func TestEnvelope_Decode_RejectsUnknownVersion(t *testing.T) {
 		if !errors.Is(err, encryption.ErrEnvelopeVersion) {
 			t.Fatalf("version=0x%02x: expected ErrEnvelopeVersion, got %v", version, err)
 		}
+	}
+}
+
+func TestEnvelope_RejectsUnknownFlagBits(t *testing.T) {
+	t.Parallel()
+	for _, flag := range []byte{0x02, 0x80, 0xff} {
+		t.Run(fmt.Sprintf("flag_%02x", flag), func(t *testing.T) {
+			env := encryption.Envelope{
+				Version: encryption.EnvelopeVersionV1,
+				Flag:    flag,
+				KeyID:   1,
+				Body:    bytes.Repeat([]byte{0x55}, encryption.TagSize),
+			}
+			if _, err := env.Encode(); !errors.Is(err, encryption.ErrEnvelopeFlag) {
+				t.Fatalf("Encode flag=%#x: expected ErrEnvelopeFlag, got %v", flag, err)
+			}
+
+			buf := make([]byte, encryption.HeaderSize+encryption.TagSize)
+			buf[0] = encryption.EnvelopeVersionV1
+			buf[1] = flag
+			if _, err := encryption.DecodeEnvelope(buf); !errors.Is(err, encryption.ErrEnvelopeFlag) {
+				t.Fatalf("DecodeEnvelope flag=%#x: expected ErrEnvelopeFlag, got %v", flag, err)
+			}
+		})
 	}
 }
 

--- a/internal/encryption/errors.go
+++ b/internal/encryption/errors.go
@@ -35,6 +35,12 @@ var (
 	// current build does not know how to parse. Reserved values per §11.3.
 	ErrEnvelopeVersion = errors.New("encryption: unknown envelope version")
 
+	// ErrEnvelopeFlag indicates an envelope set a flag bit that the current
+	// format does not define. V1 only permits FlagCompressed; accepting other
+	// bits would make future format extensions ambiguous and could route
+	// authenticated plaintext through the wrong post-decrypt transform.
+	ErrEnvelopeFlag = errors.New("encryption: unknown envelope flag bits")
+
 	// ErrNilKeystore indicates NewCipher was called with a nil Keystore.
 	// Surfaced at construction time so a wiring mistake is caught
 	// before the first Encrypt/Decrypt would otherwise nil-deref panic.

--- a/internal/encryption/raft_envelope.go
+++ b/internal/encryption/raft_envelope.go
@@ -88,6 +88,7 @@ func WrapRaftPayload(c *Cipher, keyID uint32, nonce, payload []byte) ([]byte, er
 //
 //   - ErrEnvelopeShort: encoded shorter than HeaderSize+TagSize
 //   - ErrEnvelopeVersion: unknown version byte
+//   - ErrEnvelopeFlag: a storage-only or unknown flag bit is present
 //   - ErrUnknownKeyID: DEK is not loaded (retired or sidecar missing)
 //   - ErrIntegrity: GCM tag mismatch (tampered envelope, wrong DEK,
 //     or layer confusion with a storage envelope)
@@ -103,6 +104,10 @@ func UnwrapRaftPayload(c *Cipher, encoded []byte) ([]byte, error) {
 	env, err := DecodeEnvelope(encoded)
 	if err != nil {
 		return nil, errors.Wrap(err, "encryption: raft envelope decode")
+	}
+	if env.Flag != 0 {
+		return nil, errors.Wrapf(ErrEnvelopeFlag,
+			"encryption: raft envelope flag must be 0x00, got 0x%02x", env.Flag)
 	}
 	aad := BuildRaftAAD(env.Version, env.KeyID)
 	plain, err := c.Decrypt(env.Body, aad, env.KeyID, env.Nonce[:])

--- a/internal/encryption/raft_envelope_test.go
+++ b/internal/encryption/raft_envelope_test.go
@@ -172,6 +172,33 @@ func TestRaftEnvelope_RejectsRetiredKey(t *testing.T) {
 	}
 }
 
+func TestRaftEnvelope_RejectsStorageCompressionFlag(t *testing.T) {
+	t.Parallel()
+	c, keyID := raftFixture(t)
+	nonce := newRandomNonce(t)
+	payload := []byte("raft payload")
+	aad := encryption.BuildRaftAAD(encryption.EnvelopeVersionV1, keyID)
+	body, err := c.Encrypt(payload, aad, keyID, nonce)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	var nonceArray [encryption.NonceSize]byte
+	copy(nonceArray[:], nonce)
+	encoded, err := (&encryption.Envelope{
+		Version: encryption.EnvelopeVersionV1,
+		Flag:    encryption.FlagCompressed,
+		KeyID:   keyID,
+		Nonce:   nonceArray,
+		Body:    body,
+	}).Encode()
+	if err != nil {
+		t.Fatalf("Envelope.Encode: %v", err)
+	}
+	if _, err := encryption.UnwrapRaftPayload(c, encoded); !errors.Is(err, encryption.ErrEnvelopeFlag) {
+		t.Fatalf("expected ErrEnvelopeFlag, got %v", err)
+	}
+}
+
 // TestRaftEnvelope_ShortInputRejected covers DecodeEnvelope's
 // length precondition (HeaderSize + TagSize = 34 bytes minimum).
 func TestRaftEnvelope_ShortInputRejected(t *testing.T) {

--- a/store/encryption_compression_test.go
+++ b/store/encryption_compression_test.go
@@ -26,6 +26,8 @@ func TestEncryption_CompressesOnlyWhenSmaller(t *testing.T) {
 		compressed bool
 	}{
 		{name: "compressible", value: bytes.Repeat([]byte("json-field:"), 512), compressed: true},
+		{name: "below threshold", value: bytes.Repeat([]byte("a"), minEncryptionCompressionSize-1), compressed: false},
+		{name: "at threshold", value: bytes.Repeat([]byte("a"), minEncryptionCompressionSize), compressed: true},
 		{name: "empty", value: []byte{}, compressed: false},
 		{name: "small", value: []byte("value"), compressed: false},
 		{name: "high entropy", value: incompressible, compressed: false},
@@ -139,6 +141,57 @@ func TestEncryption_RejectsAuthenticatedMalformedSnappy(t *testing.T) {
 
 	if _, err := f.mvcc.GetAt(context.Background(), key, commitTS); !errors.Is(err, ErrEncryptedReadCompression) {
 		t.Fatalf("malformed authenticated Snappy: expected ErrEncryptedReadCompression, got %v", err)
+	}
+}
+
+func TestEncryption_RejectsAuthenticatedOversizedSnappyBeforeDecode(t *testing.T) {
+	previousMax := maxSnapshotValueSize
+	maxSnapshotValueSize = 64
+	t.Cleanup(func() { maxSnapshotValueSize = previousMax })
+
+	f := newEncryptedStoreFixture(t, 106)
+	key := []byte("oversized-snappy")
+	const commitTS uint64 = 100
+	pebbleKey := encodeKey(key, commitTS)
+	var header [valueHeaderSize]byte
+	writeValueHeaderBytes(header[:], false, 0, encStateEncrypted)
+	aad := buildStorageAAD(encryption.EnvelopeVersionV1, encryption.FlagCompressed, f.keyID, header[:], pebbleKey)
+	compressed := snappy.Encode(nil, bytes.Repeat([]byte("a"), maxSnapshotValueSize+1))
+	var nonce [encryption.NonceSize]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		t.Fatalf("rand.Read nonce: %v", err)
+	}
+	body, err := f.cipher.Encrypt(compressed, aad, f.keyID, nonce[:])
+	if err != nil {
+		t.Fatalf("Encrypt oversized payload: %v", err)
+	}
+	envelopeBytes, err := (&encryption.Envelope{
+		Version: encryption.EnvelopeVersionV1,
+		Flag:    encryption.FlagCompressed,
+		KeyID:   f.keyID,
+		Nonce:   nonce,
+		Body:    body,
+	}).Encode()
+	if err != nil {
+		t.Fatalf("Envelope.Encode: %v", err)
+	}
+
+	f.closeIfOpen(t)
+	pdb, err := pebble.Open(f.dir, &pebble.Options{})
+	if err != nil {
+		t.Fatalf("pebble.Open: %v", err)
+	}
+	if err := pdb.Set(pebbleKey, encodeValue(envelopeBytes, false, 0, encStateEncrypted), pebble.Sync); err != nil {
+		_ = pdb.Close()
+		t.Fatalf("pdb.Set: %v", err)
+	}
+	if err := pdb.Close(); err != nil {
+		t.Fatalf("pdb.Close: %v", err)
+	}
+	f.reopen(t)
+
+	if _, err := f.mvcc.GetAt(context.Background(), key, commitTS); !errors.Is(err, ErrEncryptedReadCompression) {
+		t.Fatalf("oversized authenticated Snappy: expected ErrEncryptedReadCompression, got %v", err)
 	}
 }
 

--- a/store/encryption_compression_test.go
+++ b/store/encryption_compression_test.go
@@ -1,0 +1,240 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/encryption"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/golang/snappy"
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+func TestEncryption_CompressesOnlyWhenSmaller(t *testing.T) {
+	t.Parallel()
+	incompressible := make([]byte, 4096)
+	if _, err := rand.Read(incompressible); err != nil {
+		t.Fatalf("rand.Read incompressible value: %v", err)
+	}
+	cases := []struct {
+		name       string
+		value      []byte
+		compressed bool
+	}{
+		{name: "compressible", value: bytes.Repeat([]byte("json-field:"), 512), compressed: true},
+		{name: "empty", value: []byte{}, compressed: false},
+		{name: "small", value: []byte("value"), compressed: false},
+		{name: "high entropy", value: incompressible, compressed: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newEncryptedStoreFixture(t, 101)
+			key := []byte("compression/" + tc.name)
+			if err := f.mvcc.PutAt(context.Background(), key, tc.value, 100, 0); err != nil {
+				t.Fatalf("PutAt: %v", err)
+			}
+
+			var flag byte
+			f.tamperPebbleValue(t, key, 100, func(raw []byte) []byte {
+				sv, err := decodeValue(raw)
+				if err != nil {
+					t.Fatalf("decodeValue: %v", err)
+				}
+				env, err := encryption.DecodeEnvelope(sv.Value)
+				if err != nil {
+					t.Fatalf("DecodeEnvelope: %v", err)
+				}
+				flag = env.Flag
+				return raw
+			})
+			require.Equal(t, tc.compressed, flag&encryption.FlagCompressed != 0)
+
+			got, err := f.mvcc.GetAt(context.Background(), key, 100)
+			require.NoError(t, err)
+			require.Equal(t, tc.value, got)
+		})
+	}
+}
+
+func TestEncryption_CompressionFlagTamperRejected(t *testing.T) {
+	t.Parallel()
+	f := newEncryptedStoreFixture(t, 102)
+	key := []byte("compressed-tamper")
+	value := bytes.Repeat([]byte("compress-me"), 512)
+	if err := f.mvcc.PutAt(context.Background(), key, value, 100, 0); err != nil {
+		t.Fatalf("PutAt: %v", err)
+	}
+	f.tamperPebbleValue(t, key, 100, func(raw []byte) []byte {
+		// value header (9) + envelope version (1) precede the flag.
+		raw[valueHeaderSize+1] &^= encryption.FlagCompressed
+		return raw
+	})
+	if _, err := f.mvcc.GetAt(context.Background(), key, 100); !errors.Is(err, ErrEncryptedReadIntegrity) {
+		t.Fatalf("compression flag tamper: expected ErrEncryptedReadIntegrity, got %v", err)
+	}
+}
+
+func TestEncryption_CompressedEnvelopeRebadgeRejected(t *testing.T) {
+	t.Parallel()
+	f := newEncryptedStoreFixture(t, 104)
+	key := []byte("compressed-rebadge")
+	value := bytes.Repeat([]byte("sensitive-json-field"), 512)
+	if err := f.mvcc.PutAt(context.Background(), key, value, 100, 0); err != nil {
+		t.Fatalf("PutAt: %v", err)
+	}
+	f.tamperPebbleValue(t, key, 100, func(raw []byte) []byte {
+		raw[0] &^= encStateMask
+		return raw
+	})
+	if _, err := f.mvcc.GetAt(context.Background(), key, 100); !errors.Is(err, ErrEncryptedReadIntegrity) {
+		t.Fatalf("compressed rebadge: expected ErrEncryptedReadIntegrity, got %v", err)
+	}
+}
+
+func TestEncryption_RejectsAuthenticatedMalformedSnappy(t *testing.T) {
+	t.Parallel()
+	f := newEncryptedStoreFixture(t, 103)
+	key := []byte("malformed-snappy")
+	const commitTS uint64 = 100
+	pebbleKey := encodeKey(key, commitTS)
+	var header [valueHeaderSize]byte
+	writeValueHeaderBytes(header[:], false, 0, encStateEncrypted)
+	aad := buildStorageAAD(encryption.EnvelopeVersionV1, encryption.FlagCompressed, f.keyID, header[:], pebbleKey)
+	var nonce [encryption.NonceSize]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		t.Fatalf("rand.Read nonce: %v", err)
+	}
+	body, err := f.cipher.Encrypt([]byte{0xff}, aad, f.keyID, nonce[:])
+	if err != nil {
+		t.Fatalf("Encrypt malformed payload: %v", err)
+	}
+	envelopeBytes, err := (&encryption.Envelope{
+		Version: encryption.EnvelopeVersionV1,
+		Flag:    encryption.FlagCompressed,
+		KeyID:   f.keyID,
+		Nonce:   nonce,
+		Body:    body,
+	}).Encode()
+	if err != nil {
+		t.Fatalf("Envelope.Encode: %v", err)
+	}
+
+	f.closeIfOpen(t)
+	pdb, err := pebble.Open(f.dir, &pebble.Options{})
+	if err != nil {
+		t.Fatalf("pebble.Open: %v", err)
+	}
+	if err := pdb.Set(pebbleKey, encodeValue(envelopeBytes, false, 0, encStateEncrypted), pebble.Sync); err != nil {
+		_ = pdb.Close()
+		t.Fatalf("pdb.Set: %v", err)
+	}
+	if err := pdb.Close(); err != nil {
+		t.Fatalf("pdb.Close: %v", err)
+	}
+	f.reopen(t)
+
+	if _, err := f.mvcc.GetAt(context.Background(), key, commitTS); !errors.Is(err, ErrEncryptedReadCompression) {
+		t.Fatalf("malformed authenticated Snappy: expected ErrEncryptedReadCompression, got %v", err)
+	}
+}
+
+func TestCompressionRoundTripProperty(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		plaintext := rapid.SliceOfN(rapid.Byte(), 0, 16<<10).Draw(t, "plaintext")
+		payload, flag := compressForEncryption(plaintext)
+		if flag == 0 {
+			if !bytes.Equal(payload, plaintext) {
+				t.Fatalf("uncompressed payload mismatch")
+			}
+			return
+		}
+		if flag != encryption.FlagCompressed {
+			t.Fatalf("unexpected compression flag %#x", flag)
+		}
+		if len(payload) >= len(plaintext) {
+			t.Fatalf("compressed payload grew: got=%d original=%d", len(payload), len(plaintext))
+		}
+		got, err := snappy.Decode(nil, payload)
+		if err != nil {
+			t.Fatalf("snappy.Decode: %v", err)
+		}
+		if !bytes.Equal(got, plaintext) {
+			t.Fatalf("round-trip mismatch")
+		}
+	})
+}
+
+func TestEncryptedStoreCompressionRoundTripProperty(t *testing.T) {
+	t.Parallel()
+	ks := encryption.NewKeystore()
+	dek := make([]byte, encryption.KeySize)
+	if _, err := rand.Read(dek); err != nil {
+		t.Fatalf("rand.Read DEK: %v", err)
+	}
+	const keyID uint32 = 105
+	if err := ks.Set(keyID, dek); err != nil {
+		t.Fatalf("Keystore.Set: %v", err)
+	}
+	cipher, err := encryption.NewCipher(ks)
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	s := &pebbleStore{
+		cipher:             cipher,
+		nonceFactory:       NewCounterNonceFactory(0x0102, 0x0304),
+		activeStorageKeyID: func() (uint32, bool) { return keyID, true },
+	}
+	rapid.Check(t, func(t *rapid.T) {
+		key := rapid.SliceOfN(rapid.Byte(), 0, 256).Draw(t, "key")
+		plaintext := rapid.SliceOfN(rapid.Byte(), 0, 16<<10).Draw(t, "plaintext")
+		expireAt := rapid.Uint64().Draw(t, "expireAt")
+		pebbleKey := encodeKey(key, 100)
+		body, encState, err := s.encryptForKey(pebbleKey, plaintext, expireAt, false)
+		if err != nil {
+			t.Fatalf("encryptForKey: %v", err)
+		}
+		if encState != encStateEncrypted {
+			t.Fatalf("encryption state=%#x, want encrypted", encState)
+		}
+		got, err := s.decryptForKey(pebbleKey, storedValue{
+			Value:    body,
+			EncState: encState,
+			ExpireAt: expireAt,
+		}, body)
+		if err != nil {
+			t.Fatalf("decryptForKey: %v", err)
+		}
+		if !bytes.Equal(got, plaintext) {
+			t.Fatalf("round-trip mismatch")
+		}
+	})
+}
+
+func TestPebbleCompressionPolicy(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		disable  bool
+		wantName string
+	}{
+		{name: "legacy defaults", disable: false, wantName: "Snappy"},
+		{name: "encrypted store", disable: true, wantName: "NoCompression"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, cache := defaultPebbleOptionsWithCache(tc.disable)
+			t.Cleanup(cache.Unref)
+			for level, levelOpts := range opts.Levels {
+				profile := levelOpts.Compression()
+				if tc.disable {
+					require.Equalf(t, tc.wantName, profile.Name, "level %d", level)
+					continue
+				}
+				require.NotEqualf(t, "NoCompression", profile.Name, "level %d", level)
+			}
+		})
+	}
+}

--- a/store/encryption_glue.go
+++ b/store/encryption_glue.go
@@ -4,6 +4,7 @@ import (
 	"github.com/bootjp/elastickv/internal/encryption"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/v2"
+	"github.com/golang/snappy"
 )
 
 // ErrUnsupportedStoreForWriterRegistry is returned by
@@ -102,6 +103,13 @@ func WriterRegistryFor(s MVCCStore) (encryption.WriterRegistryStore, error) {
 //
 // Callers can disambiguate it from any other read error with errors.Is.
 var ErrEncryptedReadIntegrity = errors.New("store: encrypted value failed integrity check (GCM tag mismatch); refusing to surface plaintext")
+
+// ErrEncryptedReadCompression is returned when an authenticated envelope is
+// marked as Snappy-compressed but its decrypted body is not a valid Snappy
+// stream. Disk corruption normally fails GCM first; reaching this sentinel
+// means a writer produced a malformed authenticated payload, so reads fail
+// closed instead of surfacing the compressed bytes as user data.
+var ErrEncryptedReadCompression = errors.New("store: authenticated encrypted value contains an invalid Snappy payload")
 
 // NonceFactory produces unique 12-byte AES-GCM nonces for the storage
 // envelope (§4.1). The factory is responsible for the cluster-wide
@@ -345,12 +353,11 @@ func (s *pebbleStore) encryptForKey(pebbleKey, plaintext []byte, expireAt uint64
 		return nil, 0, errors.Wrap(err, "store: nonce factory")
 	}
 	nonce := nonceArr[:]
-	// flag = 0: Snappy compression deferred to Stage 9 per design §4.1.
-	const envelopeFlag byte = 0
+	payload, envelopeFlag := compressForEncryption(plaintext)
 	var hdr [valueHeaderSize]byte
 	writeValueHeaderBytes(hdr[:], false /*tombstone*/, expireAt, encStateEncrypted)
 	aad := buildStorageAAD(encryption.EnvelopeVersionV1, envelopeFlag, keyID, hdr[:], pebbleKey)
-	ciphertextAndTag, err := s.cipher.Encrypt(plaintext, aad, keyID, nonce)
+	ciphertextAndTag, err := s.cipher.Encrypt(payload, aad, keyID, nonce)
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "store: encrypt value")
 	}
@@ -413,6 +420,14 @@ func (s *pebbleStore) decryptForKey(pebbleKey []byte, sv storedValue, body []byt
 		}
 		return nil, errors.Wrap(err, "store: decrypt value")
 	}
+	if env.Flag&encryption.FlagCompressed != 0 {
+		plain, err = snappy.Decode(nil, plain)
+		if err != nil {
+			return nil, errors.Wrap(
+				errors.WithSecondaryError(ErrEncryptedReadCompression, err),
+				"store: decompress encrypted value")
+		}
+	}
 	// AES-GCM Open returns a nil dst slice for an empty plaintext;
 	// upstream callers (notably ExistsAt) distinguish "key absent"
 	// from "key present with empty value" via val != nil. Normalize
@@ -422,6 +437,18 @@ func (s *pebbleStore) decryptForKey(pebbleKey []byte, sv storedValue, body []byt
 		plain = []byte{}
 	}
 	return plain, nil
+}
+
+// compressForEncryption applies §6.4's compress-then-encrypt policy. Snappy
+// output is used only when it is strictly smaller than the original bytes;
+// already-compressed and small payloads stay uncompressed so encryption never
+// increases CPU and storage cost for a larger intermediate representation.
+func compressForEncryption(plaintext []byte) ([]byte, byte) {
+	compressed := snappy.Encode(nil, plaintext)
+	if len(compressed) >= len(plaintext) {
+		return plaintext, 0
+	}
+	return compressed, encryption.FlagCompressed
 }
 
 // rejectRebadgedEnvelope is the cleartext-branch guard for the §4.1
@@ -447,8 +474,8 @@ func (s *pebbleStore) decryptForKey(pebbleKey []byte, sv storedValue, body []byt
 //   - envelope_version = EnvelopeVersionV1 (the encrypt path's
 //     fixed value; trusting on-disk would let a corrupted version
 //     byte force the body through DecodeEnvelope's error path)
-//   - flag             = 0 (Snappy compression is deferred; the
-//     encrypt path's fixed value)
+//   - flag: both supported values (uncompressed and Snappy-compressed),
+//     because the attacker can rewrite the on-disk flag byte
 //   - tombstone        = false (the encrypt path never wraps
 //     tombstones, so any on-disk tombstone bit on an encrypted
 //     entry is necessarily attacker-supplied)
@@ -496,12 +523,14 @@ func (s *pebbleStore) rejectRebadgedEnvelope(pebbleKey []byte, sv storedValue, b
 	}
 	for _, kid := range s.cipher.LoadedKeyIDs() {
 		for _, candidateExpire := range candidateExpireAts {
-			var hdr [valueHeaderSize]byte
-			writeValueHeaderBytes(hdr[:], false /*canonical*/, candidateExpire, encStateEncrypted)
-			aad := buildStorageAAD(encryption.EnvelopeVersionV1, 0 /*flag canonical*/, kid, hdr[:], pebbleKey)
-			if _, err := s.cipher.Decrypt(ct, aad, kid, nonce); err == nil {
-				return errors.Wrap(ErrEncryptedReadIntegrity,
-					"store: cleartext-labelled value verifies as a relabeled envelope under a loaded DEK")
+			for _, candidateFlag := range []byte{0, encryption.FlagCompressed} {
+				var hdr [valueHeaderSize]byte
+				writeValueHeaderBytes(hdr[:], false /*canonical*/, candidateExpire, encStateEncrypted)
+				aad := buildStorageAAD(encryption.EnvelopeVersionV1, candidateFlag, kid, hdr[:], pebbleKey)
+				if _, err := s.cipher.Decrypt(ct, aad, kid, nonce); err == nil {
+					return errors.Wrap(ErrEncryptedReadIntegrity,
+						"store: cleartext-labelled value verifies as a relabeled envelope under a loaded DEK")
+				}
 			}
 		}
 	}

--- a/store/encryption_glue.go
+++ b/store/encryption_glue.go
@@ -111,6 +111,8 @@ var ErrEncryptedReadIntegrity = errors.New("store: encrypted value failed integr
 // closed instead of surfacing the compressed bytes as user data.
 var ErrEncryptedReadCompression = errors.New("store: authenticated encrypted value contains an invalid Snappy payload")
 
+const minEncryptionCompressionSize = 32
+
 // NonceFactory produces unique 12-byte AES-GCM nonces for the storage
 // envelope (§4.1). The factory is responsible for the cluster-wide
 // uniqueness invariant across `(node_id, local_epoch, write_count)` —
@@ -420,13 +422,9 @@ func (s *pebbleStore) decryptForKey(pebbleKey []byte, sv storedValue, body []byt
 		}
 		return nil, errors.Wrap(err, "store: decrypt value")
 	}
-	if env.Flag&encryption.FlagCompressed != 0 {
-		plain, err = snappy.Decode(nil, plain)
-		if err != nil {
-			return nil, errors.Wrap(
-				errors.WithSecondaryError(ErrEncryptedReadCompression, err),
-				"store: decompress encrypted value")
-		}
+	plain, err = decompressAuthenticatedValue(plain, env.Flag)
+	if err != nil {
+		return nil, err
 	}
 	// AES-GCM Open returns a nil dst slice for an empty plaintext;
 	// upstream callers (notably ExistsAt) distinguish "key absent"
@@ -439,11 +437,43 @@ func (s *pebbleStore) decryptForKey(pebbleKey []byte, sv storedValue, body []byt
 	return plain, nil
 }
 
+// decompressAuthenticatedValue inspects the Snappy length prefix before any
+// output allocation. Callers must authenticate the envelope before reaching
+// this helper; the compressed bytes are otherwise attacker-controlled.
+func decompressAuthenticatedValue(plain []byte, flag byte) ([]byte, error) {
+	if flag&encryption.FlagCompressed == 0 {
+		return plain, nil
+	}
+	decodedLen, err := snappy.DecodedLen(plain)
+	if err != nil {
+		return nil, errors.Wrap(
+			errors.WithSecondaryError(ErrEncryptedReadCompression, err),
+			"store: inspect compressed encrypted value")
+	}
+	if decodedLen > maxSnapshotValueSize {
+		return nil, errors.Wrapf(
+			ErrEncryptedReadCompression,
+			"store: compressed encrypted value expands to %d bytes, maximum is %d",
+			decodedLen,
+			maxSnapshotValueSize)
+	}
+	decoded, err := snappy.Decode(nil, plain)
+	if err != nil {
+		return nil, errors.Wrap(
+			errors.WithSecondaryError(ErrEncryptedReadCompression, err),
+			"store: decompress encrypted value")
+	}
+	return decoded, nil
+}
+
 // compressForEncryption applies §6.4's compress-then-encrypt policy. Snappy
 // output is used only when it is strictly smaller than the original bytes;
 // already-compressed and small payloads stay uncompressed so encryption never
 // increases CPU and storage cost for a larger intermediate representation.
 func compressForEncryption(plaintext []byte) ([]byte, byte) {
+	if len(plaintext) < minEncryptionCompressionSize {
+		return plaintext, 0
+	}
 	compressed := snappy.Encode(nil, plaintext)
 	if len(compressed) >= len(plaintext) {
 		return plaintext, 0

--- a/store/lsm_store.go
+++ b/store/lsm_store.go
@@ -272,7 +272,7 @@ func WithPebbleLogger(l *slog.Logger) PebbleStoreOption {
 // fully release the memory. Callers that only need *pebble.Options should
 // still take the cache handle and defer its Unref to avoid leaking a
 // 256 MiB (default) allocation per call.
-func defaultPebbleOptionsWithCache() (*pebble.Options, *pebble.Cache) {
+func defaultPebbleOptionsWithCache(disableCompression bool) (*pebble.Options, *pebble.Cache) {
 	cache := pebble.NewCache(pebbleCacheBytes)
 	opts := &pebble.Options{
 		FS:                 vfs.Default,
@@ -282,6 +282,14 @@ func defaultPebbleOptionsWithCache() (*pebble.Options, *pebble.Cache) {
 	// Enable automatic compactions and apply all other Pebble defaults.
 	// EnsureDefaults leaves Cache alone because we already set it.
 	opts.EnsureDefaults()
+	if disableCompression {
+		// Storage-envelope payloads are compressed before encryption. The
+		// resulting ciphertext is high entropy, so Pebble block compression
+		// only burns CPU and cannot recover additional space.
+		opts.ApplyCompressionSettings(func() pebble.DBCompressionSettings {
+			return pebble.DBCompressionNone
+		})
+	}
 	return opts, cache
 }
 
@@ -301,7 +309,7 @@ func NewPebbleStore(dir string, opts ...PebbleStoreOption) (MVCCStore, error) {
 		opt(s)
 	}
 
-	pebbleOpts, cache := defaultPebbleOptionsWithCache()
+	pebbleOpts, cache := defaultPebbleOptionsWithCache(s.cipher != nil)
 	db, err := pebble.Open(dir, pebbleOpts)
 	if err != nil {
 		cache.Unref()
@@ -2164,7 +2172,7 @@ func (s *pebbleStore) reopenFreshDB() error {
 	if err := os.MkdirAll(s.dir, dirPerms); err != nil {
 		return errors.WithStack(err)
 	}
-	opts, cache := defaultPebbleOptionsWithCache()
+	opts, cache := defaultPebbleOptionsWithCache(s.cipher != nil)
 	db, err := pebble.Open(s.dir, opts)
 	if err != nil {
 		cache.Unref()
@@ -2235,7 +2243,7 @@ func (s *pebbleStore) restorePebbleNativeAtomic(r io.Reader) error {
 		return err
 	}
 
-	if err := writeNativeSnapshotToTempDir(r, tmpDir, ts); err != nil {
+	if err := writeNativeSnapshotToTempDir(r, tmpDir, ts, s.cipher != nil); err != nil {
 		_ = os.RemoveAll(tmpDir)
 		return err
 	}
@@ -2277,8 +2285,8 @@ func makeSiblingTempDir(dir, tag string) (string, error) {
 // writeNativeSnapshotToTempDir writes batch-loop entries from r into a fresh
 // Pebble database at tmpDir, persists ts as the lastCommitTS meta-key, then
 // closes the database.
-func writeNativeSnapshotToTempDir(r io.Reader, tmpDir string, ts uint64) error {
-	opts, cache := defaultPebbleOptionsWithCache()
+func writeNativeSnapshotToTempDir(r io.Reader, tmpDir string, ts uint64, disableCompression bool) error {
+	opts, cache := defaultPebbleOptionsWithCache(disableCompression)
 	tmpDB, err := pebble.Open(tmpDir, opts)
 	if err != nil {
 		cache.Unref()
@@ -2324,12 +2332,12 @@ func readStreamingMVCCRestoreHeader(r io.Reader) (io.Reader, hash.Hash32, uint32
 	return body, hash, expectedChecksum, lastCommitTS, minRetainedTS, nil
 }
 
-func writeStreamingMVCCRestoreTempDB(dir string, body io.Reader, hash hash.Hash32, expectedChecksum uint32, lastCommitTS uint64, minRetainedTS uint64) (string, error) {
+func writeStreamingMVCCRestoreTempDB(dir string, body io.Reader, hash hash.Hash32, expectedChecksum uint32, lastCommitTS uint64, minRetainedTS uint64, disableCompression bool) (string, error) {
 	tmpDir := filepath.Clean(dir) + ".restore-tmp"
 	if err := os.RemoveAll(tmpDir); err != nil {
 		return "", errors.WithStack(err)
 	}
-	opts, cache := defaultPebbleOptionsWithCache()
+	opts, cache := defaultPebbleOptionsWithCache(disableCompression)
 	tmpDB, err := pebble.Open(tmpDir, opts)
 	if err != nil {
 		cache.Unref()
@@ -2369,7 +2377,7 @@ func (s *pebbleStore) restoreFromStreamingMVCC(r io.Reader) error {
 		return err
 	}
 
-	tmpDir, err := writeStreamingMVCCRestoreTempDB(s.dir, body, hash, expectedChecksum, lastCommitTS, minRetainedTS)
+	tmpDir, err := writeStreamingMVCCRestoreTempDB(s.dir, body, hash, expectedChecksum, lastCommitTS, minRetainedTS, s.cipher != nil)
 	if err != nil {
 		return err
 	}
@@ -2424,7 +2432,7 @@ func (s *pebbleStore) swapInTempDB(tmpDir string) error {
 		_ = os.RemoveAll(tmpDir)
 		return errors.WithStack(err)
 	}
-	opts, cache := defaultPebbleOptionsWithCache()
+	opts, cache := defaultPebbleOptionsWithCache(s.cipher != nil)
 	newDB, err := pebble.Open(s.dir, opts)
 	if err != nil {
 		cache.Unref()

--- a/store/lsm_store_env_test.go
+++ b/store/lsm_store_env_test.go
@@ -83,7 +83,7 @@ func TestSetPebbleCacheBytesForTestRestores(t *testing.T) {
 // is safe to call after closing the DB (the primary lifecycle path).
 func TestDefaultPebbleOptionsCarriesCache(t *testing.T) {
 	setPebbleCacheBytesForTest(t, 16<<20)
-	opts, cache := defaultPebbleOptionsWithCache()
+	opts, cache := defaultPebbleOptionsWithCache(false)
 	require.NotNil(t, cache)
 	require.Same(t, cache, opts.Cache)
 	require.Equal(t, int64(16)<<20, cache.MaxSize())

--- a/store/lsm_store_sync_mode_benchmark_test.go
+++ b/store/lsm_store_sync_mode_benchmark_test.go
@@ -2,9 +2,11 @@ package store
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	"testing"
 
+	"github.com/bootjp/elastickv/internal/encryption"
 	"github.com/cockroachdb/pebble/v2"
 )
 
@@ -73,4 +75,72 @@ func BenchmarkApplyMutationsRaft_SyncMode(b *testing.B) {
 			}
 		})
 	}
+}
+
+// BenchmarkApplyMutationsRaft_Encryption compares the Stage 9
+// compress-then-encrypt path against the legacy cleartext path with 1 KiB
+// values. NoSync isolates encryption/compression CPU from fsync latency; the
+// merge gate is evaluated with benchstat on the paired results.
+func BenchmarkApplyMutationsRaft_Encryption(b *testing.B) {
+	value := make([]byte, 1024)
+	if _, err := rand.Read(value); err != nil {
+		b.Fatalf("rand.Read value: %v", err)
+	}
+	for _, tc := range []struct {
+		name      string
+		encrypted bool
+	}{
+		{name: "cleartext", encrypted: false},
+		{name: "encrypted", encrypted: true},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			s, err := NewPebbleStore(b.TempDir(), benchmarkEncryptionOptions(b, tc.encrypted)...)
+			if err != nil {
+				b.Fatalf("NewPebbleStore: %v", err)
+			}
+			defer s.Close()
+			ps, ok := s.(*pebbleStore)
+			if !ok {
+				b.Fatalf("NewPebbleStore returned non-*pebbleStore type: %T", s)
+			}
+			ps.fsmApplyWriteOpts = pebble.NoSync
+			ps.fsmApplySyncModeLabel = fsmSyncModeNoSync
+			b.SetBytes(int64(len(value)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				key := []byte(fmt.Sprintf("enc-bench-%010d", i))
+				startTS := uint64(i) * 2 //nolint:gosec // benchmark loop index is non-negative.
+				muts := []*KVPairMutation{{Op: OpTypePut, Key: key, Value: value}}
+				if err := s.ApplyMutationsRaft(context.Background(), muts, nil, startTS, startTS+1); err != nil {
+					b.Fatalf("ApplyMutationsRaft: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func benchmarkEncryptionOptions(b *testing.B, enabled bool) []PebbleStoreOption {
+	b.Helper()
+	if !enabled {
+		return nil
+	}
+	ks := encryption.NewKeystore()
+	dek := make([]byte, encryption.KeySize)
+	if _, err := rand.Read(dek); err != nil {
+		b.Fatalf("rand.Read DEK: %v", err)
+	}
+	const keyID uint32 = 1
+	if err := ks.Set(keyID, dek); err != nil {
+		b.Fatalf("Keystore.Set: %v", err)
+	}
+	cipher, err := encryption.NewCipher(ks)
+	if err != nil {
+		b.Fatalf("NewCipher: %v", err)
+	}
+	return []PebbleStoreOption{WithEncryption(
+		cipher,
+		NewCounterNonceFactory(1, 1),
+		func() (uint32, bool) { return keyID, true },
+	)}
 }

--- a/store/lsm_store_sync_mode_benchmark_test.go
+++ b/store/lsm_store_sync_mode_benchmark_test.go
@@ -110,7 +110,10 @@ func BenchmarkApplyMutationsRaft_Encryption(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				key := []byte(fmt.Sprintf("enc-bench-%010d", i))
-				startTS := uint64(i) * 2 //nolint:gosec // benchmark loop index is non-negative.
+				if i < 0 {
+					b.Fatalf("unexpected negative iteration counter: %d", i)
+				}
+				startTS := uint64(i) * 2
 				muts := []*KVPairMutation{{Op: OpTypePut, Key: key, Value: value}}
 				if err := s.ApplyMutationsRaft(context.Background(), muts, nil, startTS, startTS+1); err != nil {
 					b.Fatalf("ApplyMutationsRaft: %v", err)

--- a/store/lsm_store_test.go
+++ b/store/lsm_store_test.go
@@ -617,7 +617,7 @@ func TestSnapshotBatchShouldFlushOnByteLimit(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	opts, cache := defaultPebbleOptionsWithCache()
+	opts, cache := defaultPebbleOptionsWithCache(false)
 	db, err := pebble.Open(dir, opts)
 	require.NoError(t, err)
 	defer func() {


### PR DESCRIPTION
## Summary

- compress storage plaintext with Snappy before AES-GCM when the result is smaller
- authenticate and validate the compression flag, including fail-closed Raft flag handling
- disable Pebble block compression for encryption-wired open and restore paths
- add property, tamper, restore-policy, race, and paired performance coverage

## Risk

The storage envelope gains a second valid flag value. Existing flag-zero envelopes remain readable. Unknown flag bits and nonzero Raft flags fail closed. Compression runs only after the storage-envelope cutover gate selects encrypted writes.

## Caller audit

- `encryptForKey`: all callers (`PutAt`, `ExpireAt`, direct and Raft `ApplyMutations`) propagate errors and share the same compression policy.
- `decryptForKey`: `GetAt`, forward/reverse scans, `ExistsAt`, and delete-prefix visibility checks propagate integrity/decompression errors.
- `DecodeEnvelope`: storage propagates decode errors; Raft now additionally rejects every nonzero flag.
- Pebble open helpers: initial open, fresh reopen, native restore temp DB, streaming restore temp DB, and post-swap reopen all preserve the encrypted-store compression policy.

## Verification

- `go test ./... -count=1 -timeout=20m`
- `go test -race ./store -run 'TestEncryption_|TestCompressionRoundTripProperty|TestPebbleCompressionPolicy' -count=1 -timeout=15m`\n- `go test . -run 'Test.*Encryption|Test.*Sidecar|Test.*Snapshot' -count=1 -timeout=10m`\n- `go test ./adapter -run TestEncryptionAdmin -count=1 -timeout=10m`\n- `golangci-lint --allow-parallel-runners --config=.golangci.yaml run ./internal/encryption ./store --timeout=5m`\n- paired 1 KiB benchmark, fixed 1000 iterations x 10: cleartext median ~119.7 us/op; encrypted median ~113.9 us/op\n- `git diff --check`\n- signed commit verified for `bootjp <contact@bootjp.me>`\n\n## Author\n\nbootjp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 暗号化データをSnappyで圧縮し、圧縮効果がある場合のみ保存するようになりました。
  * 圧縮状態を含むデータの整合性検証を強化しました。

* **バグ修正**
  * 未対応の暗号化フラグや改ざんされた圧縮データを安全に拒否するようになりました。
  * 暗号化ストアでは重複したストレージ圧縮を無効化し、保存効率を改善しました。

* **ドキュメント**
  * Stage 9Aの実装完了範囲と、今後の対応項目を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->