### PR TITLE
docs: mark June 12 scaling roadmap superseded

### DIFF
--- a/docs/design/2026_06_12_proposed_scaling_roadmap.md
+++ b/docs/design/2026_06_12_proposed_scaling_roadmap.md
@@ -1,8 +1,14 @@
 # Scaling roadmap — multi-region, route scale-out, storage tier, coordinator
 
-**Status:** Proposed (no implementation yet).
+**Status:** Proposed. Superseded by `2026_06_23_proposed_scaling_roadmap.md`.
 **Author:** bootjp
 **Date:** 2026-06-12
+
+> This document is retained as the original sequencing and SLO record. It is
+> not an implementation specification and must not be used as the scope for a
+> combined implementation PR. The 2026-06-23 roadmap audits the current
+> implementation, closes completed prerequisites, and tracks the remaining
+> work as separate design documents and milestone PRs.
 
 > This roadmap captures the scaling work elastickv needs across four
 > subsystems that today have known ceilings and have not yet been

--- a/docs/design/2026_06_12_proposed_scaling_roadmap.md
+++ b/docs/design/2026_06_12_proposed_scaling_roadmap.md
@@ -1,12 +1,13 @@
 # Scaling roadmap — multi-region, route scale-out, storage tier, coordinator
 
-**Status:** Proposed. Superseded by `2026_06_23_proposed_scaling_roadmap.md`.
+**Status:** Proposed. Superseded by [2026_06_23_proposed_scaling_roadmap.md](2026_06_23_proposed_scaling_roadmap.md).
 **Author:** bootjp
 **Date:** 2026-06-12
 
 > This document is retained as the original sequencing and SLO record. It is
 > not an implementation specification and must not be used as the scope for a
-> combined implementation PR. The 2026-06-23 roadmap audits the current
+> combined implementation PR. The
+> [2026-06-23 roadmap](2026_06_23_proposed_scaling_roadmap.md) audits the current
 > implementation, closes completed prerequisites, and tracks the remaining
 > work as separate design documents and milestone PRs.
 


### PR DESCRIPTION
## Summary

- Mark the June 12 scaling roadmap as superseded by the June 23 roadmap.
- Preserve the original document as the historical sequencing and SLO record.
- Clarify that the roadmap is not the scope for one combined implementation PR.

## Requirement audit

### Completed or present on main
- Multi-node multi-group bootstrap and leader balancing.
- Raft gRPC streaming transport.
- Cross-shard transaction coordination.
- Per-led-group HLC renewal and the default-group TSO allocator bridge.

### In progress in dedicated PR stacks
- Shared Pebble cache.
- Hotspot split migration and automation.
- Dedicated TSO routing.
- S3 blob offload and live-backup foundations.

### Still requiring separate design and implementation work
- Catalog deltas, indexed route storage, and batched splits.
- WAN and region-aware placement, region-local HLC and catalog mirrors, and regional failover.
- SST-ingest snapshot transfer and adaptive per-shard MVCC retention.
- Follower reads, partitioned lock resolution, and bounded leader-proxy redirects.

> **Note:** These items remain separate milestones because this document explicitly requires a sibling design and PR for each milestone. Combining them here would bypass the dependency and review boundaries defined by the roadmap.

## Verification

- **Commit hook:** full `golangci-lint`, 0 issues.
- `git diff --check`
- Documentation-only change.