### PR TITLE
jepsen: preserve uncertain ZSet dependencies

### DIFF
--- a/jepsen/src/elastickv/redis_zset_safety_workload.clj
+++ b/jepsen/src/elastickv/redis_zset_safety_workload.clj
@@ -581,25 +581,36 @@
   (and (some? (:complete-idx earlier))
        (> (:invoke-idx later) (:complete-idx earlier))))
 
-(defn- superseded-by-preceding-state-change?
-  "True iff a committed mutation before the read strictly follows m and
-  changes this member's state. Such a later committed write/remove
-  determines the read's base state and makes m's pre-read uncertainty
-  irrelevant for this read.
-
-  Relative increments are not absolute overwrites. Earlier uncertainty
-  may still be required to make a later :ok ZINCRBY reply consistent, so
-  later ZINCRBYs do not supersede pre-read :info operations."
-  [preceding m]
-  (some #(and (or (= :zadd (:f %))
-                  (effective-zrem? %))
-              (strictly-follows? % m))
-        preceding))
-
 (defn- real-time-before?
   [a b]
   (and (some? (:complete-idx a))
        (< (:complete-idx a) (:invoke-idx b))))
+
+(defn- could-linearize-between?
+  "True when candidate can be ordered after earlier and before later without
+  violating either operation's real-time window."
+  [candidate earlier later]
+  (and (not (real-time-before? candidate earlier))
+       (not (real-time-before? later candidate))))
+
+(defn- superseded-by-preceding-state-change?
+  "True iff an unconditional committed ZADD before the read makes m's
+  pre-read uncertainty irrelevant.
+
+  ZINCRBY and ZREM are state-dependent: their replies can require m to have
+  taken effect. When either could linearize between m and a later ZADD, keep
+  m so the checker can validate that dependent reply before the ZADD resets
+  the member state. A successful ZREM is also state-dependent (it can return
+  true only for a present member), so it cannot supersede uncertainty by
+  itself."
+  [preceding m]
+  (some (fn [reset]
+          (and (= :zadd (:f reset))
+               (strictly-follows? reset m)
+               (not-any? #(and (#{:zincrby :zrem} (:f %))
+                                (could-linearize-between? % m reset))
+                         preceding)))
+        preceding))
 
 (defn- unique-mutations
   [muts]

--- a/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
+++ b/jepsen/test/elastickv/redis_zset_safety_workload_test.clj
@@ -252,6 +252,25 @@
         (str "expected earlier :info increment to remain admissible, got: "
              result))))
 
+(deftest pre-read-info-zadd-can-feed-zincrby-before-later-zadd
+  ;; The final ZADD resets the score observed by the read, but it must not
+  ;; discard an earlier :info ZADD that is needed to explain an intervening
+  ;; committed ZINCRBY reply. This ordering appeared in the scheduled Jepsen
+  ;; history: info ZADD 29, ZINCRBY +9 -> 38, then ZADD 35.
+  (let [history [{:type :invoke :process 0 :f :zadd :value ["m1" 29] :index 0}
+                 {:type :info   :process 0 :f :zadd :value ["m1" 29] :index 1}
+                 {:type :invoke :process 1 :f :zincrby :value ["m1" 9] :index 2}
+                 {:type :ok     :process 1 :f :zincrby :value ["m1" 38.0] :index 3}
+                 {:type :invoke :process 2 :f :zadd :value ["m1" 35] :index 4}
+                 {:type :ok     :process 2 :f :zadd :value ["m1" 35] :index 5}
+                 {:type :invoke :process 3 :f :zrange-all :index 6}
+                 {:type :ok     :process 3 :f :zrange-all
+                  :value [["m1" 35.0]] :index 7}]
+        result (run-checker history)]
+    (is (:valid? result)
+        (str "expected dependent :info ZADD to remain admissible, got: "
+             result))))
+
 (deftest pre-read-info-zincrby-superseded-by-later-zadd
   ;; A pre-read :info ZINCRBY is uncertainty only until a later committed
   ;; state-changing op strictly follows it before the read. The later ZADD


### PR DESCRIPTION
## Summary
- Preserve pre-read `:info` mutations when an intervening ZINCRBY or ZREM may depend on them.
- Treat only an unconditional committed ZADD as a superseding reset when no state-dependent mutation can linearize in between.
- Add a regression test for an uncertain ZADD feeding a committed ZINCRBY before a later ZADD.

## Root cause
The ZSet safety checker discarded an uncertain mutation whenever a later committed state change existed. In the failing scheduled history, an uncertain ZADD was required to explain an intervening successful ZINCRBY reply. Removing it made the mutation chain impossible and caused 157 false `unexpected-presence` errors.

## Impact
Valid ZSet histories containing response-loss uncertainty are no longer rejected, while later ZADDs still supersede uncertainty when no state-dependent operation can rely on it.

## Tests
- `cd jepsen && lein test` (143 tests, 335 assertions)
- Replayed the failing run artifact (493 reads, 971 mutations, 0 errors, `valid? true`)
- Commit hook `golangci-lint --config=.golangci.yaml run --fix` (0 issues)
- `git diff --check`