### PR TITLE
Support fresh Raft learner replacement

### DIFF
--- a/docs/design/2026_04_26_implemented_raft_learner.md
+++ b/docs/design/2026_04_26_implemented_raft_learner.md
@@ -521,6 +521,15 @@ Cold bootstrap (`--raftBootstrap` plus optionally `--raftBootstrapMembers`):
 Joining an existing cluster as a learner:
 
 - New CLI flag (per group): `--raftJoinAsLearner` (default `false`).
+- `--raftJoinMembers id=addr,...` supplies the full single-group peer address
+  inventory used by a fresh joiner's transport. It is deliberately separate
+  from `--raftBootstrapMembers`: join members leave `Bootstrap=false` and the
+  initial `ConfState` empty. The flag requires `--raftJoinAsLearner`, includes
+  the local ID/address plus at least one existing remote member, and is mutually
+  exclusive with every bootstrap flag. This closes the post-design startup gap
+  where the self-bootstrap guard correctly rejected an empty fresh data dir but
+  the only peer-list flag incorrectly implied new-cluster bootstrap. See
+  `2026_07_18_implemented_raft_fresh_learner_join.md`.
 - **Enforcement is local and post-apply, not pre-propose.** The flag
   does *not* attempt to block the leader from issuing a
   `ConfChangeAddNode` for this node. Doing so would either require a
@@ -544,9 +553,9 @@ Joining an existing cluster as a learner:
   3. The flag is therefore primarily an **operator alarm**, not a
      consensus-level enforcement. The runbook makes this explicit.
 - Operationally:
-  1. Operator brings up the joiner with `--raftJoinAsLearner` and the
-     peer list it knows about (existing voters; the joiner's own
-     `--raftId` is the local node).
+  1. Operator brings up the joiner with `--raftJoinAsLearner` and
+     `--raftJoinMembers` containing the current voters plus the joiner's own
+     `--raftId` and address.
   2. The joiner starts but stays in follower-no-config until the leader
      fans out the new `ConfState` via `MsgApp` / `MsgSnap`.
   3. Operator calls `raftadmin <leader> add_learner <id> <address>`.
@@ -555,9 +564,10 @@ Joining an existing cluster as a learner:
      `promote_learner` with `min_applied_index` set to a recent leader
      commit index. The engine re-verifies against
      `Progress[nodeID].Match` before proposing.
-- This flow does **not** require a new `--raftBootstrapMembers` syntax.
-  The joiner does not appear in any cold-bootstrap member list; it only
-  enters the cluster's `ConfState` via the explicit `add_learner` RPC.
+- This flow does **not** overload `--raftBootstrapMembers`. The joiner only
+  enters the cluster's `ConfState` via the explicit `add_learner` RPC;
+  `--raftJoinMembers` is transport discovery and durable address inventory,
+  not a cold-bootstrap member list.
 
 ### 4.6 Quorum, lease reads, and the ack tracker
 

--- a/docs/design/2026_07_18_implemented_raft_fresh_learner_join.md
+++ b/docs/design/2026_07_18_implemented_raft_fresh_learner_join.md
@@ -338,6 +338,13 @@ transport discovery without creating an initial voter `ConfState`, and that the
 post-promotion membership survives a full-cluster restart rather than depending
 on one still-running member's in-memory view.
 
+`TestFreshLearnerJoinReusesRemovedVoterID` exercises the production replacement
+shape with three voters: it stops and removes one voter while the remaining two
+retain quorum, wipes only that node, rejoins the same ID as a learner, promotes
+it, restarts all three voters without join settings, and commits another write.
+The three-voter fixture is required because removing a stopped member from a
+two-voter cluster cannot commit after the remaining voter loses quorum.
+
 ### 11.3 Operational validation
 
 The rolling-update script is syntax-checked and dry-run with `RAFT_JOIN_NODE` to

--- a/docs/design/2026_07_18_implemented_raft_fresh_learner_join.md
+++ b/docs/design/2026_07_18_implemented_raft_fresh_learner_join.md
@@ -102,7 +102,9 @@ existing leader commits `AddLearner`.
 9. **Discovery does not become durable membership.** Snapshot and ConfChange
    persistence filter the address cache to IDs present in `ConfState`; stale
    discovery-only peers cannot cause the next restart to fail membership
-   validation.
+   validation. Every authoritative member must also have a non-empty address in
+   the cache; snapshot or ConfChange apply fails before publishing unusable peer
+   metadata when the join inventory omitted a member.
 10. **Public protocols wait for membership readiness.** Raft transport and
     RaftAdmin start first, but user-facing listeners remain closed until the
     local ID is a learner or voter, a leader is known, no ConfChange is pending,
@@ -248,10 +250,11 @@ Durability then follows the existing configuration-change path:
 
 Both ConfChange and received-snapshot paths derive the persisted peer list by
 iterating the authoritative voters and learners in `ConfState`. Addresses are
-reused from the discovery cache when present; an ID missing from the cache gets
-a non-dialable placeholder rather than being omitted. Discovery-only IDs not in
-`ConfState` are dropped. This keeps peer metadata and snapshot membership
-cardinality aligned on the next open.
+reused from the discovery cache. An ID missing from the cache, or one with an
+empty address, aborts the apply path before FSM snapshot restore or peer
+metadata publication. Discovery-only IDs not in `ConfState` are dropped. This
+keeps peer metadata and snapshot membership cardinality aligned on the next
+open without allowing a node to restart with a quorum member it cannot dial.
 
 Peer metadata may be published just before the matching local Raft snapshot;
 restart recovery tolerates this ordering and replays the committed conf change
@@ -269,6 +272,7 @@ discovery.
 | Promotion is rejected as not caught up | Wait for leader-side progress to reach the chosen bound and retry. Do not bypass the check in normal production recovery. |
 | Joiner was added as a voter | Treat the role alarm as a failed procedure. Preserve quorum, then remove the node and repeat the learner workflow after the removal commits. |
 | Joiner crashes after `AddLearner` or promotion | Restart first from its existing data dir. Once membership has persisted, do not wipe it merely to repeat the join command. |
+| Snapshot or ConfChange reports `etcd raft peer address is required` | The join inventory omitted an authoritative voter or learner. Stop the joiner, supply the complete current membership plus the local joiner, and restart from the same data dir unless the membership operation itself must first be rolled back. |
 | Remaining cluster loses quorum | Stop replacement work. `--raftJoinMembers` cannot recover quorum or create a replacement cluster. Use a separately reviewed quorum-recovery procedure. |
 | Deployment must roll back to an older binary | Remove the learner before downgrade if it has not been promoted. If it is already a voter, first verify that the target version can read the current WAL, snapshot, and peers metadata; do not erase durable state as a rollback mechanism. |
 
@@ -317,6 +321,10 @@ existing cluster.
 catch-up, pending ConfChange rejection, and configuration-read errors for the
 public-service gate.
 
+`TestPreparePublicServicesAfterRaftJoinReadyDoesNotBindWhileJoinIsUnready`
+locks down startup ordering: join readiness is checked before any public
+listener preparation callback can bind a socket.
+
 ### 11.2 Engine end-to-end test
 
 `TestFreshLearnerJoinPromotesAndRestartsFromPersistedMembership` exercises the
@@ -332,6 +340,10 @@ engine lifecycle with real transports:
 8. stop both voters; and
 9. reopen both without join peers or learner intent, elect a leader from the
    recovered two-member configuration, and commit another application write.
+
+`TestApplyReadySnapshotRejectsMissingPeerAddressBeforeRestore` verifies that a
+snapshot containing an authoritative member absent from discovery fails before
+restoring FSM state or advancing the local Raft snapshot.
 
 This test protects the central invariant that an explicit peer list can support
 transport discovery without creating an initial voter `ConfState`, and that the

--- a/docs/design/2026_07_18_implemented_raft_fresh_learner_join.md
+++ b/docs/design/2026_07_18_implemented_raft_fresh_learner_join.md
@@ -1,0 +1,361 @@
+# Fresh Raft learner join for wiped and replacement nodes
+
+Status: Implemented
+Author: bootjp
+Date: 2026-07-18
+
+## 1. Incident and root cause
+
+During recovery of the production Raft cluster, nodes `n2` and `n4` were
+started with fresh, wiped data directories. Those nodes no longer had any of
+the durable local state that identifies an existing Raft member:
+
+- the Raft WAL and snapshots, including the committed `ConfState`;
+- `etcd-raft-peers.bin`, which supplies the transport peer inventory on
+  restart; and
+- the local applied/configuration indexes used by cold-start recovery.
+
+This is intentionally different from a normal restart. A normal restart can
+recover membership from disk and must ignore stale bootstrap intent after the
+first committed membership change. A wiped node has no authoritative local
+membership and cannot infer whether it is a voter, learner, removed member, or
+founder of a new cluster.
+
+The existing startup flags did not represent the required state:
+
+1. `--raftJoinAsLearner` expressed operator intent and enabled role-mismatch
+   alarms, but supplied no transport peers. With an empty peer list and no
+   persisted peers, `normalizePeers` correctly hit the self-bootstrap guard and
+   returned `errNoPeersConfigured`. Relaxing that guard would reintroduce the
+   split-brain failure where a wiped node silently starts a one-node cluster.
+2. `--raftBootstrapMembers` supplied peer addresses, but its presence implies
+   bootstrap. Passing it to a replacement creates an initial voter
+   configuration instead of joining the surviving cluster. It is therefore not
+   a discovery flag and must not be reused for replacement.
+3. Copying `etcd-raft-peers.bin` or another node's data directory would confuse
+   transport discovery with committed membership and could copy identity or
+   state that does not belong to the replacement.
+
+The missing state was a third startup mode: a fresh node needs addresses for
+Raft transport, while its initial local `ConfState` must remain empty until the
+existing leader commits `AddLearner`.
+
+## 2. Goals
+
+1. Start one wiped or new node against a live single-group cluster without
+   self-bootstrapping it.
+2. Keep transport discovery separate from both bootstrap membership and
+   durable Raft membership.
+3. Attach the node as a learner, catch it up, promote it, and then restart it
+   using only membership persisted by Raft.
+4. Provide a safe same-ID replacement procedure that never runs the old and
+   replacement instances concurrently.
+5. Make the production rolling-update path express the temporary join mode for
+   exactly one node through `RAFT_JOIN_NODE`.
+6. Preserve the self-bootstrap guard for every startup that does not explicitly
+   request bootstrap or supply join discovery peers.
+7. Keep Redis, DynamoDB, S3, and SQS listeners closed until the joiner has
+   committed membership, knows a leader, and applied through its observed
+   commit index.
+8. Persist only peers present in the authoritative `ConfState`, even when the
+   join discovery inventory contains a stale extra address.
+
+## 3. Non-goals
+
+1. Recovering a cluster that has lost voter quorum. A join requires a live
+   leader that can commit configuration changes.
+2. Automatically deciding which member to remove, attaching a learner, or
+   promoting it. Membership changes remain explicit Raft admin operations.
+3. Recovering or automatically fencing a stale removed node. Durable removal
+   tombstones and an authoritative rejoin protocol remain follow-up work.
+4. Joining more than one Raft group in one process. The implemented flag is
+   single-group only; a future design needs a per-group join inventory.
+5. Changing learner read behavior, voter quorum calculation, snapshot format,
+   or the existing bootstrap protocols.
+
+## 4. Invariants
+
+1. **Join discovery never bootstraps.** `--raftJoinMembers` may initialize a
+   transport peer map, but it must produce `Bootstrap=false`, an empty
+   `BootstrapSeed`, and an initially empty `ConfState` on a fresh data dir.
+2. **Bootstrap discovery and join discovery are disjoint.** A process cannot
+   combine `--raftJoinMembers` with `--raftBootstrap`,
+   `--raftBootstrapMembers`, or `--raftGroupPeers`.
+3. **The local node is addressable but not yet a member.** The join list must
+   contain the local `--raftId` at the local group's listener address. Presence
+   in the transport map does not grant voter or learner suffrage.
+4. **Only consensus assigns suffrage.** The node becomes a learner only after a
+   committed `ConfChangeAddLearnerNode`; it becomes a voter only after a
+   committed promotion. `--raftJoinAsLearner` remains an operator alarm, not a
+   local consensus veto.
+5. **A replacement ID has one live owner.** The old process or VM is fenced
+   before its ID is removed and remains fenced while the fresh instance joins.
+6. **Wiping is target-local and sequential.** Operators wipe only the selected
+   replacement node after removal has committed. No second node is wiped while
+   the replacement is incomplete.
+7. **Join flags are temporary.** Once the learner membership and promotion are
+   durable, the node is redeployed without `--raftJoinMembers` and
+   `--raftJoinAsLearner`.
+8. **Normal restart remains disk-authoritative.** WAL, snapshot, and persisted
+   peer metadata take precedence after the first successful join; bootstrap or
+   join input is not a substitute for committed state.
+9. **Discovery does not become durable membership.** Snapshot and ConfChange
+   persistence filter the address cache to IDs present in `ConfState`; stale
+   discovery-only peers cannot cause the next restart to fail membership
+   validation.
+10. **Public protocols wait for membership readiness.** Raft transport and
+    RaftAdmin start first, but user-facing listeners remain closed until the
+    local ID is a learner or voter, a leader is known, no ConfChange is pending,
+    and `AppliedIndex >= CommitIndex`.
+
+## 5. CLI and configuration validation
+
+The server adds:
+
+```text
+--raftJoinMembers "n1=192.168.0.210:50051,n2=192.168.0.211:50051,n3=192.168.0.212:50051"
+--raftJoinAsLearner
+```
+
+`resolveRuntimeInputs` delegates all peer-mode selection to
+`resolveRaftPeerConfig`. When `--raftJoinMembers` is empty, startup follows the
+existing `resolveBootstrapConfig` path unchanged. When it is non-empty, startup
+fails before opening an engine unless all of these conditions hold:
+
+- `--raftJoinAsLearner` is set;
+- exactly one Raft group is configured;
+- no explicit or member-list bootstrap flag is set;
+- the list parses with the existing `raftID=host:port` member grammar;
+- the list contains at least the local node and one remote member;
+- the local `--raftId` appears exactly once; and
+- its address matches the local Raft group address.
+
+The resolved `raftBootstrapConfig` stores these peers in `joinServers`, not in
+`legacyServers` or `groupServers`. Consequently:
+
+- `serversForGroup` and `adminSeed` expose the join peers for transport and
+  discovery;
+- `anyBootstrapServers` remains false;
+- `bootstrapsGroup` remains false; and
+- `bootstrapSeedForGroup` returns nil.
+
+This separation prevents the previous `len(servers) > 0` shortcut from turning
+join discovery into bootstrap intent.
+
+## 6. Runtime flow
+
+### 6.1 Fresh process startup
+
+For a fresh data directory, the factory receives all join peers in `Peers`, no
+bootstrap seed, and `Bootstrap=false`.
+
+1. `Factory.Create` creates a `GRPCTransport` because the join list contains
+   more than one peer.
+2. `normalizePeers` validates and normalizes the local identity against that
+   list. The self-bootstrap guard is satisfied by explicit discovery peers; it
+   is not disabled globally.
+3. `openDiskState` finds no WAL or legacy state and calls
+   `bootstrapNewCluster`.
+4. Because there are multiple peers and `Bootstrap=false`,
+   `bootstrapNewCluster` selects `joinWalState`, not `bootstrapWalState`.
+5. `joinWalState` creates an empty WAL state. The local snapshot has no voters
+   or learners, so the initial `ConfState` is empty and the node cannot campaign
+   or count toward quorum.
+6. The gRPC Raft listener is available, and the peer map can route traffic to
+   and from the existing members. The node waits for the live leader to commit
+   its membership change.
+
+Only the Raft transport/RaftAdmin listener is available at this stage. Public
+protocol listeners are held behind `waitForRaftJoinReady`, so clients cannot
+send Redis/SQS/etc. work to an empty-ConfState process and receive a storm of
+leader-not-found failures.
+
+Transport peers are an address cache only. They are deliberately a superset of
+the empty initial `ConfState`; `validateOpenPeers` permits that state while the
+snapshot index or voter set is empty.
+
+### 6.2 Attach, catch up, and promote
+
+The operator sends `add_learner <id> <address>` to the current leader. The
+leader commits `ConfChangeAddLearnerNode`, existing members add the peer to
+their transport maps, and the joiner observes itself in
+`ConfState.Learners`. The learner does not change the voter quorum denominator.
+
+The leader then replicates log entries or a snapshot. Before promotion, the
+operator compares leader progress with a chosen non-zero minimum applied index.
+`PromoteLearner` rejects a target that is not currently a learner or has not
+caught up to that bound. After the promotion conf change commits, the node is
+listed in `ConfState.Voters` and participates in quorum.
+
+If a node started with `--raftJoinAsLearner` is instead added directly as a
+voter, the post-apply role check emits the existing ERROR-level alarm and
+increments `JoinRoleViolationCount`. The process keeps running because stopping
+an already committed voter would reduce availability; remediation is an
+explicit remove and correct learner rejoin.
+
+## 7. Safe replacement sequence
+
+For replacement of an unhealthy voter while reusing its Raft ID:
+
+1. Verify the surviving cluster has a leader and enough healthy voters to
+   commit a membership change.
+2. Fence the old instance at the process, VM, and network level. Confirm its
+   Raft listener cannot return before proceeding.
+3. Run `remove_server <id>` against the leader and wait until
+   `configuration` no longer contains the ID.
+4. Stop the target container and wipe or archive only the target's Raft data
+   directory. Do not wipe another member.
+5. Start only the target in join mode. With the rolling-update script:
+
+   ```sh
+   ROLLING_ORDER=n2 RAFT_JOIN_NODE=n2 ./scripts/rolling-update.sh
+   ```
+
+   The script derives `RAFT_JOIN_MEMBERS` from `NODES`, injects
+   `--raftJoinAsLearner --raftJoinMembers ...` only into the selected node, and
+   includes the mode in the deployment configuration fingerprint.
+6. Run `add_learner`, wait for the configuration to show learner suffrage, and
+   wait until replication catches up.
+7. Run `promote_learner` with a non-zero catch-up bound and verify the ID is a
+   voter.
+8. Clear `RAFT_JOIN_NODE` and redeploy that same node once more. This removes
+   the temporary join flags and exercises a normal restart from durable
+   membership.
+9. Verify a stable leader, full expected voter configuration, advancing applied
+   indexes, and a committed application write before replacing another node.
+
+`scripts/rolling-update.sh` rejects `RAFT_JOIN_NODE` when it names an unknown
+ID, when `ROLLING_ORDER` contains any other node, or when
+`RAFT_BOOTSTRAP_MEMBERS` is also set. These checks make the one-target nature of
+the recovery explicit.
+
+## 8. Persistence and restart
+
+The temporary join list is sufficient only until consensus state arrives.
+Durability then follows the existing configuration-change path:
+
+1. Applying `AddLearner` updates the peer address cache and derives suffrage
+   from the post-change `ConfState`.
+2. `persistConfigState` writes the current peer inventory to
+   `etcd-raft-peers.bin` at the committed configuration index and persists a
+   Raft snapshot carrying the same `ConfState`.
+3. Catch-up entries and snapshots persist the replicated log/FSM state.
+4. Promotion repeats the configuration persistence with the node in
+   `ConfState.Voters`.
+5. On restart, `Factory.Create` loads persisted peers before constructing the
+   transport, while `openDiskState` loads the WAL/snapshot. The recovered
+   `ConfState`, not the old join list, determines voter and learner roles.
+
+Both ConfChange and received-snapshot paths derive the persisted peer list by
+iterating the authoritative voters and learners in `ConfState`. Addresses are
+reused from the discovery cache when present; an ID missing from the cache gets
+a non-dialable placeholder rather than being omitted. Discovery-only IDs not in
+`ConfState` are dropped. This keeps peer metadata and snapshot membership
+cardinality aligned on the next open.
+
+Peer metadata may be published just before the matching local Raft snapshot;
+restart recovery tolerates this ordering and replays the committed conf change
+from WAL when needed. The final redeploy without join flags is therefore an
+acceptance criterion: it proves that peer inventory, suffrage, and replicated
+state are durable and that the node no longer depends on operator-supplied join
+discovery.
+
+## 9. Failure handling and rollback
+
+| Failure | Required action |
+|---|---|
+| Joiner fails before `AddLearner` commits | Stop it, keep the old instance fenced, wipe only the incomplete joiner's target data dir if necessary, and retry join mode. Existing quorum is unchanged. |
+| `AddLearner` committed but catch-up stalls | Keep the node a learner while diagnosing transport, disk, and snapshot transfer. Retry without promotion, or commit `remove_server` and restart the join sequence. |
+| Promotion is rejected as not caught up | Wait for leader-side progress to reach the chosen bound and retry. Do not bypass the check in normal production recovery. |
+| Joiner was added as a voter | Treat the role alarm as a failed procedure. Preserve quorum, then remove the node and repeat the learner workflow after the removal commits. |
+| Joiner crashes after `AddLearner` or promotion | Restart first from its existing data dir. Once membership has persisted, do not wipe it merely to repeat the join command. |
+| Remaining cluster loses quorum | Stop replacement work. `--raftJoinMembers` cannot recover quorum or create a replacement cluster. Use a separately reviewed quorum-recovery procedure. |
+| Deployment must roll back to an older binary | Remove the learner before downgrade if it has not been promoted. If it is already a voter, first verify that the target version can read the current WAL, snapshot, and peers metadata; do not erase durable state as a rollback mechanism. |
+
+At every failure point, the safe rollback is a committed membership operation
+against the surviving leader. Bootstrap flags are never a rollback path for an
+existing cluster.
+
+## 10. Security and operations
+
+- `--raftJoinMembers` contains cluster topology. Protect deployment
+  configuration and logs accordingly; do not accept untrusted values that can
+  redirect Raft traffic.
+- Raft transport must remain on the trusted cluster network with the same
+  firewall and authentication controls as normal replication. Join mode does
+  not add an authorization bypass to `AddLearner` or `PromoteLearner`.
+- Fencing is mandatory when reusing a Raft ID. The implementation cannot prove
+  that a removed VM will never reboot with stale data.
+- Confirm host identity and target data path before wiping. The script does not
+  authorize multi-node destructive cleanup.
+- Monitor `configuration`, leader stability, commit/applied indexes, snapshot
+  transfer, transport errors, and `JoinRoleViolationCount` throughout the
+  operation.
+- Keep bootstrap variables unset during replacement. In particular,
+  `RAFT_BOOTSTRAP_MEMBERS` describes a new cluster and is rejected with
+  `RAFT_JOIN_NODE`.
+- Remove join mode after promotion. Leaving it configured causes misleading
+  intent alarms and obscures whether normal disk recovery works.
+
+## 11. Tests and acceptance evidence
+
+### 11.1 Configuration tests
+
+`TestResolveRaftPeerConfigJoinMembers` covers the server-level contract:
+
+- join peers are available to engine/admin discovery without enabling
+  bootstrap;
+- bootstrap seed remains nil;
+- learner intent is required;
+- explicit bootstrap, legacy bootstrap members, and group bootstrap peers are
+  rejected;
+- multi-group join is rejected;
+- missing local ID and local-address mismatch are rejected; and
+- a local-only list is rejected.
+
+`TestRaftJoinRuntimesReady` covers membership presence, known leader, apply
+catch-up, pending ConfChange rejection, and configuration-read errors for the
+public-service gate.
+
+### 11.2 Engine end-to-end test
+
+`TestFreshLearnerJoinPromotesAndRestartsFromPersistedMembership` exercises the
+engine lifecycle with real transports:
+
+1. bootstrap one existing voter;
+2. prove the second node has no copied peer metadata;
+3. open the fresh node with all transport peers and `Bootstrap=false`;
+4. assert its configuration is initially empty;
+5. add it as learner and replicate an application proposal;
+6. promote only after the leader reports sufficient progress;
+7. verify a stale discovery-only peer is absent from persisted metadata;
+8. stop both voters; and
+9. reopen both without join peers or learner intent, elect a leader from the
+   recovered two-member configuration, and commit another application write.
+
+This test protects the central invariant that an explicit peer list can support
+transport discovery without creating an initial voter `ConfState`, and that the
+post-promotion membership survives a full-cluster restart rather than depending
+on one still-running member's in-memory view.
+
+### 11.3 Operational validation
+
+The rolling-update script is syntax-checked and dry-run with `RAFT_JOIN_NODE` to
+confirm the selected-node-only plan and derived join list. Production
+acceptance additionally requires the post-promotion normal redeploy, stable
+leadership, expected voter count, advancing indexes, and a successful write.
+
+## 12. Follow-ups
+
+1. Add durable removed-node tombstones or an authoritative cluster-side rejoin
+   handshake so a stale removed node can fail closed even if an operator starts
+   its old data directory.
+2. Design a per-group equivalent of `--raftJoinMembers` for multi-group
+   processes, including independent catch-up and promotion state per group.
+3. Add a Jepsen replacement workload covering remove, wipe, learner catch-up,
+   promotion, restart, and network partitions.
+4. Add scripted status gates around catch-up and post-promotion stability so the
+   rolling update cannot advance based only on the process port becoming ready.
+
+Stale removed-node recovery and multi-group join are deliberately not claimed
+by this implementation.

--- a/docs/raft_learner_operations.md
+++ b/docs/raft_learner_operations.md
@@ -40,12 +40,27 @@ go run . \
   --address         127.0.0.1:50054 \
   --redisAddress    127.0.0.1:63794 \
   --raftDataDir     /var/lib/elastickv/n4 \
-  --raftJoinAsLearner
+  --raftJoinAsLearner \
+  --raftJoinMembers "n1=127.0.0.1:50051,n2=127.0.0.1:50052,n3=127.0.0.1:50053,n4=127.0.0.1:50054"
 ```
+
+`--raftJoinMembers` is transport discovery only. Unlike
+`--raftBootstrapMembers`, it does not create an initial `ConfState` and does
+not make the node campaign. The list must describe the current single-group
+membership plus the local joiner, include at least one existing remote member,
+and match the joiner's `--raftId` and `--address`. It is rejected unless
+`--raftJoinAsLearner` is set, and it cannot be combined with any bootstrap
+flag.
 
 The joiner will start, register with the gRPC transport, and wait for
 the leader to fan out the cluster's `ConfState` — it has no
 peer membership of its own yet.
+
+While it waits, the Raft/RaftAdmin port is available so the operator can run
+`add_learner` and inspect status. Redis, DynamoDB, S3, and SQS listeners remain
+closed until the local ID appears in committed membership, a leader is known,
+the local apply index has caught up to its observed commit index, and no
+configuration change is pending.
 
 `--raftJoinAsLearner` does *not* prevent the leader from issuing an
 `AddVoter` for this node. If that happens (operator typo, runaway
@@ -173,6 +188,11 @@ After a successful promote, `raftadmin configuration` shows the peer
 with `suffrage: "voter"` and the cluster's voter count has grown by
 one.
 
+Restart the promoted node without `--raftJoinAsLearner` and
+`--raftJoinMembers`. Its committed `ConfState` and peer inventory are now
+durable in the Raft snapshot/WAL and `etcd-raft-peers.bin`; normal restart must
+use that state rather than the temporary join intent.
+
 ### 6. Sanity checks after promotion
 
 - `raftadmin configuration` lists the new voter.
@@ -180,6 +200,38 @@ one.
   `LEADER` if it later wins an election).
 - A `Propose` against the leader still commits — write traffic is
   uninterrupted by the membership change.
+
+## Replacing a voter with a fresh data dir
+
+Do not erase a voter and run a normal deploy. A wiped node no longer has the
+Raft WAL, snapshot, or `etcd-raft-peers.bin` that identify the committed
+cluster. The normal startup guard intentionally refuses to self-bootstrap in
+that state.
+
+Use this order for a replacement that keeps the same Raft ID:
+
+1. Fence the old process or VM so the old and replacement instances cannot run
+   concurrently with the same Raft ID.
+2. Verify the remaining voters have a leader and can commit a configuration
+   change. Run `remove_server <id>` against that leader and wait until the ID
+   disappears from `configuration`.
+3. Stop the target container and erase or archive only that node's Raft data
+   directory. Never wipe more than one replacement target at a time.
+4. Start the target with `--raftJoinAsLearner` and `--raftJoinMembers`, then
+   follow the add, catch-up, and promote steps above.
+5. Restart the promoted node without the two join flags and verify a write can
+   commit.
+
+For `scripts/rolling-update.sh`, step 4 can be expressed without copying peer
+metadata by selecting exactly one rollout node:
+
+```sh
+ROLLING_ORDER=n4 RAFT_JOIN_NODE=n4 ./scripts/rolling-update.sh
+```
+
+The script derives `--raftJoinMembers` from `NODES` and rejects a join rollout
+that contains another node. After promotion, clear `RAFT_JOIN_NODE` and run the
+same single-node rollout once more to remove the temporary join flags.
 
 ## Removing a learner
 
@@ -205,6 +257,8 @@ voter.
 | `promote learner: rpc error: ... target has not caught up to min_applied_index` | Learner is still replicating. | Wait and retry; lower `min_applied_index` only if you understand the safety implication. |
 | `promote learner: rpc error: ... target has no leader-side progress entry` | The learner is not in the leader's `Progress` map (e.g., raft has not yet processed the AddLearner). | Confirm the prior `add_learner` was committed via `configuration` before issuing `promote_learner`. |
 | `add learner: rpc error: ... has too many pending config changes` | A previous conf change is still in flight. | Wait for it to commit; retry. |
+| `flag --raftJoinMembers requires --raftJoinAsLearner` | Join discovery was configured without learner intent. | Pass both flags for a fresh join, or neither for a normal restart. |
+| `flag --raftJoinMembers cannot be combined with raft bootstrap flags` | Join and new-cluster creation were requested together. | Remove every bootstrap flag; a replacement joins the surviving cluster. |
 
 ## Observability
 
@@ -228,3 +282,8 @@ voter.
   caller must forward to the leader. Follower-served reads are an
   explicit non-goal of this milestone and will be addressed in a
   separate proposal.
+- **Recover a cluster that has lost quorum.** Join members are only transport
+  discovery for attaching to a live leader; they are not a force-new-cluster
+  or quorum-recovery mechanism.
+- **Join multiple Raft groups.** The first implementation is single-group. A
+  future per-group join inventory must preserve the same bootstrap separation.

--- a/docs/raft_learner_operations.md
+++ b/docs/raft_learner_operations.md
@@ -259,7 +259,7 @@ voter.
 | `add learner: rpc error: ... has too many pending config changes` | A previous conf change is still in flight. | Wait for it to commit; retry. |
 | `flag --raftJoinMembers requires --raftJoinAsLearner` | Join discovery was configured without learner intent. | Pass both flags for a fresh join, or neither for a normal restart. |
 | `flag --raftJoinMembers cannot be combined with raft bootstrap flags` | Join and new-cluster creation were requested together. | Remove every bootstrap flag; a replacement joins the surviving cluster. |
-| `etcd raft peer address is required: conf state node id=...` | The join list omitted a voter or learner present in the authoritative `ConfState`. | Stop the joiner and restart it with the complete current member inventory plus its own ID/address. Do not insert an empty or guessed address. |
+| `conf state node id=...: etcd raft peer address is required` | The join list omitted a voter or learner present in the authoritative `ConfState`. | Stop the joiner and restart it with the complete current member inventory plus its own ID/address. Do not insert an empty or guessed address. |
 
 ## Observability
 

--- a/docs/raft_learner_operations.md
+++ b/docs/raft_learner_operations.md
@@ -259,6 +259,7 @@ voter.
 | `add learner: rpc error: ... has too many pending config changes` | A previous conf change is still in flight. | Wait for it to commit; retry. |
 | `flag --raftJoinMembers requires --raftJoinAsLearner` | Join discovery was configured without learner intent. | Pass both flags for a fresh join, or neither for a normal restart. |
 | `flag --raftJoinMembers cannot be combined with raft bootstrap flags` | Join and new-cluster creation were requested together. | Remove every bootstrap flag; a replacement joins the surviving cluster. |
+| `etcd raft peer address is required: conf state node id=...` | The join list omitted a voter or learner present in the authoritative `ConfState`. | Stop the joiner and restart it with the complete current member inventory plus its own ID/address. Do not insert an empty or guessed address. |
 
 ## Observability
 

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -2472,6 +2472,13 @@ func (e *Engine) applyReadySnapshotLocked(snapshot *raftpb.Snapshot) error {
 	if len(snapshot.GetData()) == 0 {
 		return errors.WithStack(errSnapshotRequired)
 	}
+	confState := confStateValue(snapshot.GetMetadata().GetConfState())
+	e.mu.RLock()
+	peers, err := peerListForConfState(e.peers, confState)
+	e.mu.RUnlock()
+	if err != nil {
+		return errors.Wrapf(err, "validate snapshot peers index=%d", snapshot.GetMetadata().GetIndex())
+	}
 	// Snapshot application is intentionally synchronous with the raft loop: the
 	// local FSM must reflect the incoming raft snapshot before Ready can advance
 	// and later committed entries can be applied safely.
@@ -2512,8 +2519,8 @@ func (e *Engine) applyReadySnapshotLocked(snapshot *raftpb.Snapshot) error {
 	// further conf-change entries arrive. Mirrors the apply-loop
 	// sequence in applyConfigChange. The order matches §4.6:
 	// voterCache first, then config.Servers.
-	e.refreshVoterCache(confStateValue(snapshot.GetMetadata().GetConfState()))
-	e.setConfigurationFromConfState(confStateValue(snapshot.GetMetadata().GetConfState()), snapshot.GetMetadata().GetIndex())
+	e.refreshVoterCache(confState)
+	e.setConfigurationFromConfState(confState, snapshot.GetMetadata().GetIndex())
 	// Persist the post-snapshot peers file with suffrage drawn from
 	// the snapshot's ConfState so a learner that received catch-up
 	// state via snapshot (the common case for fresh joiners) writes
@@ -2521,21 +2528,17 @@ func (e *Engine) applyReadySnapshotLocked(snapshot *raftpb.Snapshot) error {
 	// snapshot path bypasses the apply-loop's nextPeersAfterConfigChange
 	// hook, so without this the joiner's peers file would carry the
 	// pre-AddLearner suffrage forever. See learner design doc §4.3.
-	if err := e.savePeersFileForSnapshot(snapshot); err != nil {
+	if err := e.savePeersFileForSnapshot(snapshot, peers); err != nil {
 		return err
 	}
-	e.alarmIfJoinedAsVoter(confStateValue(snapshot.GetMetadata().GetConfState()))
+	e.alarmIfJoinedAsVoter(confState)
 	return nil
 }
 
 // savePeersFileForSnapshot writes the v2 peers file with suffrage
 // drawn from the snapshot's ConfState. Idempotent: savePersistedPeers
 // short-circuits when the on-disk index already covers `index`.
-func (e *Engine) savePeersFileForSnapshot(snapshot *raftpb.Snapshot) error {
-	confState := confStateValue(snapshot.GetMetadata().GetConfState())
-	e.mu.RLock()
-	peers := peerListForConfState(e.peers, confState)
-	e.mu.RUnlock()
+func (e *Engine) savePeersFileForSnapshot(snapshot *raftpb.Snapshot, peers []Peer) error {
 	if len(peers) == 0 {
 		return nil
 	}
@@ -2782,7 +2785,10 @@ func (e *Engine) applyConfChangeCommitted(entry raftpb.Entry) error {
 		return errors.WithStack(err)
 	}
 	confState := e.rawNode.ApplyConfChange(&cc)
-	nextPeers := e.nextPeersAfterConfigChange(cc.GetType(), cc.GetNodeId(), cc.GetContext(), confStateValue(confState))
+	nextPeers, err := e.nextPeersAfterConfigChange(cc.GetType(), cc.GetNodeId(), cc.GetContext(), confStateValue(confState))
+	if err != nil {
+		return errors.Wrapf(err, "build peer inventory for config change index=%d", entry.GetIndex())
+	}
 	if err := e.persistConfigState(entry.GetIndex(), confStateValue(confState), nextPeers); err != nil {
 		return err
 	}
@@ -2800,7 +2806,10 @@ func (e *Engine) applyConfChangeV2Committed(entry raftpb.Entry) error {
 		return errors.WithStack(err)
 	}
 	confState := e.rawNode.ApplyConfChange(&cc)
-	nextPeers := e.nextPeersAfterConfigChangeV2(cc, confStateValue(confState))
+	nextPeers, err := e.nextPeersAfterConfigChangeV2(cc, confStateValue(confState))
+	if err != nil {
+		return errors.Wrapf(err, "build peer inventory for config change v2 index=%d", entry.GetIndex())
+	}
 	if err := e.persistConfigState(entry.GetIndex(), confStateValue(confState), nextPeers); err != nil {
 		return err
 	}
@@ -4710,7 +4719,7 @@ func (e *Engine) upsertPeer(peer Peer) {
 	}
 }
 
-func (e *Engine) nextPeersAfterConfigChange(changeType raftpb.ConfChangeType, nodeID uint64, context []byte, confState raftpb.ConfState) []Peer {
+func (e *Engine) nextPeersAfterConfigChange(changeType raftpb.ConfChangeType, nodeID uint64, context []byte, confState raftpb.ConfState) ([]Peer, error) {
 	e.mu.RLock()
 	next := clonePeerMap(e.peers)
 	e.mu.RUnlock()
@@ -4718,7 +4727,7 @@ func (e *Engine) nextPeersAfterConfigChange(changeType raftpb.ConfChangeType, no
 	return peerListForConfState(next, confState)
 }
 
-func (e *Engine) nextPeersAfterConfigChangeV2(cc raftpb.ConfChangeV2, confState raftpb.ConfState) []Peer {
+func (e *Engine) nextPeersAfterConfigChangeV2(cc raftpb.ConfChangeV2, confState raftpb.ConfState) ([]Peer, error) {
 	e.mu.RLock()
 	next := clonePeerMap(e.peers)
 	e.mu.RUnlock()

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -2532,13 +2532,13 @@ func (e *Engine) applyReadySnapshotLocked(snapshot *raftpb.Snapshot) error {
 // drawn from the snapshot's ConfState. Idempotent: savePersistedPeers
 // short-circuits when the on-disk index already covers `index`.
 func (e *Engine) savePeersFileForSnapshot(snapshot *raftpb.Snapshot) error {
+	confState := confStateValue(snapshot.GetMetadata().GetConfState())
 	e.mu.RLock()
-	peers := sortedPeerList(e.peers)
+	peers := peerListForConfState(e.peers, confState)
 	e.mu.RUnlock()
 	if len(peers) == 0 {
 		return nil
 	}
-	annotatePeerSuffrageInSlice(peers, confStateValue(snapshot.GetMetadata().GetConfState()))
 	if err := savePersistedPeers(e.dataDir, snapshot.GetMetadata().GetIndex(), peers); err != nil {
 		return errors.Wrapf(err, "save peers file from snapshot index=%d", snapshot.GetMetadata().GetIndex())
 	}
@@ -4715,8 +4715,7 @@ func (e *Engine) nextPeersAfterConfigChange(changeType raftpb.ConfChangeType, no
 	next := clonePeerMap(e.peers)
 	e.mu.RUnlock()
 	applyConfigPeerChangeToMap(next, changeType, nodeID, context)
-	annotatePeerSuffrageFromConfState(next, confState)
-	return sortedPeerList(next)
+	return peerListForConfState(next, confState)
 }
 
 func (e *Engine) nextPeersAfterConfigChangeV2(cc raftpb.ConfChangeV2, confState raftpb.ConfState) []Peer {
@@ -4726,14 +4725,11 @@ func (e *Engine) nextPeersAfterConfigChangeV2(cc raftpb.ConfChangeV2, confState 
 	for _, change := range cc.GetChanges() {
 		applyConfigPeerChangeToMap(next, change.GetType(), change.GetNodeId(), cc.GetContext())
 	}
-	annotatePeerSuffrageFromConfState(next, confState)
-	return sortedPeerList(next)
+	return peerListForConfState(next, confState)
 }
 
-// annotatePeerSuffrageInSlice is the slice form of
-// annotatePeerSuffrageFromConfState used at bootstrap-time, where
-// `peers` is a sorted operator-provided slice rather than the apply
-// loop's clone of e.peers.
+// annotatePeerSuffrageInSlice stamps a bootstrap/restart peer slice from the
+// authoritative ConfState loaded from disk.
 func annotatePeerSuffrageInSlice(peers []Peer, conf raftpb.ConfState) {
 	if len(peers) == 0 {
 		return
@@ -4753,46 +4749,6 @@ func annotatePeerSuffrageInSlice(peers []Peer, conf raftpb.ConfState) {
 		case voters[peers[i].NodeID]:
 			peers[i].Suffrage = SuffrageVoter
 		}
-	}
-}
-
-// annotatePeerSuffrageFromConfState stamps each peer's Suffrage from
-// the post-change ConfState so the v2 peers file written by
-// persistConfigState round-trips suffrage across restarts. Without
-// this, every Peer in the persist path carries Suffrage="" (the
-// ConfChange context bytes do not encode suffrage; e.peers
-// deliberately stores only nodeID/ID/address), and
-// persistedSuffrageByte("") writes voter — which on restart causes
-// validateConfState to see a learner-as-voter peer list and reject
-// startup with errClusterMismatch. See learner design doc §4.3
-// "Authoritative source of suffrage during recovery".
-//
-// The map is mutated in place. Peers not present in either
-// confState.Voters or confState.Learners (transient state during a
-// removal) keep whatever Suffrage they had — they will fall out of
-// the persisted peers list on the next conf change anyway.
-func annotatePeerSuffrageFromConfState(peers map[uint64]Peer, conf raftpb.ConfState) {
-	if len(peers) == 0 {
-		return
-	}
-	learners := make(map[uint64]bool, len(conf.Learners))
-	for _, id := range conf.Learners {
-		learners[id] = true
-	}
-	voters := make(map[uint64]bool, len(conf.Voters))
-	for _, id := range conf.Voters {
-		voters[id] = true
-	}
-	for id, peer := range peers {
-		switch {
-		case learners[id]:
-			peer.Suffrage = SuffrageLearner
-		case voters[id]:
-			peer.Suffrage = SuffrageVoter
-		default:
-			continue
-		}
-		peers[id] = peer
 	}
 }
 

--- a/internal/raftengine/etcd/engine_applied_index_test.go
+++ b/internal/raftengine/etcd/engine_applied_index_test.go
@@ -113,6 +113,9 @@ func TestPersistReadyWithSnapshotHoldsSnapshotMuThroughSaveSnap(t *testing.T) {
 		persist:    &recordingPersistStorage{saveStarted: saveStarted, saveRelease: releaseSave},
 		dataDir:    t.TempDir(),
 		fsmSnapDir: t.TempDir(),
+		peers: map[uint64]Peer{
+			1: {NodeID: 1, ID: "n1", Address: "127.0.0.1:7001"},
+		},
 	}
 	e.protectReceivedFSMSnapshot(7)
 	readySnapshot := appliedIndexTestSnapshot(7, []byte("payload"))

--- a/internal/raftengine/etcd/engine_test.go
+++ b/internal/raftengine/etcd/engine_test.go
@@ -726,6 +726,7 @@ func TestApplyReadySnapshotAdvancesAppliedIndex(t *testing.T) {
 	engine := &Engine{
 		storage: etcdraft.NewMemoryStorage(),
 		fsm:     &testStateMachine{},
+		dataDir: t.TempDir(),
 	}
 
 	payload := mustEncodeSnapshotData(t, [][]byte{[]byte("snap")})

--- a/internal/raftengine/etcd/engine_test.go
+++ b/internal/raftengine/etcd/engine_test.go
@@ -727,6 +727,9 @@ func TestApplyReadySnapshotAdvancesAppliedIndex(t *testing.T) {
 		storage: etcdraft.NewMemoryStorage(),
 		fsm:     &testStateMachine{},
 		dataDir: t.TempDir(),
+		peers: map[uint64]Peer{
+			1: {NodeID: 1, ID: "n1", Address: "127.0.0.1:7001"},
+		},
 	}
 
 	payload := mustEncodeSnapshotData(t, [][]byte{[]byte("snap")})
@@ -740,6 +743,30 @@ func TestApplyReadySnapshotAdvancesAppliedIndex(t *testing.T) {
 	snapshot, err := engine.storage.Snapshot()
 	require.NoError(t, err)
 	require.Equal(t, payload, snapshot.Data)
+}
+
+func TestApplyReadySnapshotRejectsMissingPeerAddressBeforeRestore(t *testing.T) {
+	storage := etcdraft.NewMemoryStorage()
+	fsm := &testStateMachine{}
+	engine := &Engine{
+		storage: storage,
+		fsm:     fsm,
+		dataDir: t.TempDir(),
+		peers: map[uint64]Peer{
+			1: {NodeID: 1, ID: "n1", Address: "127.0.0.1:7001"},
+		},
+	}
+
+	payload := mustEncodeSnapshotData(t, [][]byte{[]byte("snap")})
+	snap := raftTestSnapshot(7, 2, []uint64{1, 2}, payload)
+	err := engine.applyReadySnapshot(&snap)
+	require.ErrorIs(t, err, errPeerAddressRequired)
+	require.Contains(t, err.Error(), "node id=2")
+	require.Zero(t, engine.applied)
+	require.Empty(t, fsm.Applied())
+	stored, snapshotErr := storage.Snapshot()
+	require.NoError(t, snapshotErr)
+	require.Zero(t, stored.GetMetadata().GetIndex())
 }
 
 func TestSendMessagesDoesNotBlockWhenDispatchQueueIsFull(t *testing.T) {
@@ -1170,6 +1197,10 @@ func TestPersistConfigStateBlocksConcurrentRestore(t *testing.T) {
 		persist: mockstorage.NewStorageRecorder(""),
 		fsm:     fsm,
 		dataDir: t.TempDir(),
+		peers: map[uint64]Peer{
+			1: {NodeID: 1, ID: "n1", Address: "127.0.0.1:7001"},
+			2: {NodeID: 2, ID: "n2", Address: "127.0.0.1:7002"},
+		},
 	}
 	t.Cleanup(release)
 
@@ -1227,7 +1258,7 @@ func TestNextPeersAfterConfigChangeKeepsLearnerMetadata(t *testing.T) {
 	learner := Peer{NodeID: 2, ID: "n2", Address: "127.0.0.1:7002"}
 	context, err := encodeConfChangeContext(17, learner)
 	require.NoError(t, err)
-	next := engine.nextPeersAfterConfigChange(
+	next, err := engine.nextPeersAfterConfigChange(
 		raftpb.ConfChangeAddLearnerNode,
 		learner.NodeID,
 		context,
@@ -1236,6 +1267,7 @@ func TestNextPeersAfterConfigChangeKeepsLearnerMetadata(t *testing.T) {
 			Learners: []uint64{2},
 		},
 	)
+	require.NoError(t, err)
 
 	// nextPeersAfterConfigChange now annotates Suffrage from the
 	// post-change ConfState so persistConfigState can write a v2
@@ -1247,7 +1279,7 @@ func TestNextPeersAfterConfigChangeKeepsLearnerMetadata(t *testing.T) {
 	}, next)
 }
 
-func TestNextPeersAfterConfigChangeV2IgnoresMismatchedPeerContext(t *testing.T) {
+func TestNextPeersAfterConfigChangeV2RejectsMismatchedPeerContext(t *testing.T) {
 	engine := &Engine{
 		peers: map[uint64]Peer{
 			1: {NodeID: 1, ID: "n1", Address: "127.0.0.1:7001"},
@@ -1257,19 +1289,16 @@ func TestNextPeersAfterConfigChangeV2IgnoresMismatchedPeerContext(t *testing.T) 
 	context, err := encodeConfChangeContext(17, Peer{NodeID: 2, ID: "n2", Address: "127.0.0.1:7002"})
 	require.NoError(t, err)
 
-	next := engine.nextPeersAfterConfigChangeV2(raftpb.ConfChangeV2{
+	next, err := engine.nextPeersAfterConfigChangeV2(raftpb.ConfChangeV2{
 		Context: context,
 		Changes: []*raftpb.ConfChangeSingle{
 			{Type: confChangeTypePtr(raftpb.ConfChangeAddNode), NodeId: uint64Ptr(2)},
 			{Type: confChangeTypePtr(raftpb.ConfChangeAddNode), NodeId: uint64Ptr(3)},
 		},
 	}, raftpb.ConfState{Voters: []uint64{1, 2, 3}})
-
-	require.Equal(t, []Peer{
-		{NodeID: 1, ID: "n1", Address: "127.0.0.1:7001", Suffrage: SuffrageVoter},
-		{NodeID: 2, ID: "n2", Address: "127.0.0.1:7002", Suffrage: SuffrageVoter},
-		{NodeID: 3, ID: "3", Address: "", Suffrage: SuffrageVoter},
-	}, next)
+	require.ErrorIs(t, err, errPeerAddressRequired)
+	require.Contains(t, err.Error(), "node id=3")
+	require.Nil(t, next)
 }
 
 func TestNextPeersAfterConfigChangeV2PreservesExistingPeerWithoutContext(t *testing.T) {
@@ -1280,11 +1309,12 @@ func TestNextPeersAfterConfigChangeV2PreservesExistingPeerWithoutContext(t *test
 		},
 	}
 
-	next := engine.nextPeersAfterConfigChangeV2(raftpb.ConfChangeV2{
+	next, err := engine.nextPeersAfterConfigChangeV2(raftpb.ConfChangeV2{
 		Changes: []*raftpb.ConfChangeSingle{
 			{Type: confChangeTypePtr(raftpb.ConfChangeAddNode), NodeId: uint64Ptr(2)},
 		},
 	}, raftpb.ConfState{Voters: []uint64{1, 2}})
+	require.NoError(t, err)
 
 	require.Equal(t, []Peer{
 		{NodeID: 1, ID: "n1", Address: "127.0.0.1:7001", Suffrage: SuffrageVoter},

--- a/internal/raftengine/etcd/learner_test.go
+++ b/internal/raftengine/etcd/learner_test.go
@@ -181,7 +181,11 @@ func TestFreshLearnerJoinPromotesAndRestartsFromPersistedMembership(t *testing.T
 }
 
 func TestFreshLearnerJoinReusesRemovedVoterID(t *testing.T) {
-	nodes, peers := newTransportTestNodes(t, 2)
+	nodes, peers := newTransportTestNodes(t, 3)
+	for i := range nodes {
+		peers[i].NodeID = DeriveNodeID(peers[i].ID)
+		nodes[i].peer.NodeID = peers[i].NodeID
+	}
 	startTransportTestServers(nodes, peers)
 	t.Cleanup(func() { cleanupTransportTestNodes(t, nodes) })
 
@@ -196,12 +200,21 @@ func TestFreshLearnerJoinReusesRemovedVoterID(t *testing.T) {
 	require.NoError(t, err)
 	waitForConfigSize(t, leader.engine, 2)
 	waitForConfigSize(t, nodes[1].engine, 2)
+	require.NoError(t, openTransportTestNode(ctx, nodes[2], peers, false))
+	_, err = leader.engine.AddVoter(ctx, nodes[2].peer.ID, nodes[2].peer.Address, 0)
+	require.NoError(t, err)
+	waitForConfigSize(t, leader.engine, 3)
+	waitForConfigSize(t, nodes[1].engine, 3)
+	waitForConfigSize(t, nodes[2].engine, 3)
 
 	require.NoError(t, nodes[1].engine.Close())
 	nodes[1].engine = nil
+	leader = waitForLeaderNode(t, []*transportTestNode{nodes[0], nodes[2]})
 	_, err = leader.engine.RemoveServer(ctx, nodes[1].peer.ID, 0)
 	require.NoError(t, err)
-	waitForConfigSize(t, leader.engine, 1)
+	waitForConfigSize(t, leader.engine, 2)
+	waitForConfigSize(t, nodes[0].engine, 2)
+	waitForConfigSize(t, nodes[2].engine, 2)
 
 	require.NoError(t, os.RemoveAll(nodes[1].dir))
 	require.NoError(t, os.MkdirAll(nodes[1].dir, 0o750))
@@ -215,18 +228,19 @@ func TestFreshLearnerJoinReusesRemovedVoterID(t *testing.T) {
 
 	addIndex, err := leader.engine.AddLearner(ctx, nodes[1].peer.ID, nodes[1].peer.Address, 0)
 	require.NoError(t, err)
-	waitForConfigSize(t, leader.engine, 2)
-	waitForConfigSize(t, nodes[1].engine, 2)
+	waitForConfigSize(t, leader.engine, 3)
+	waitForConfigSize(t, nodes[1].engine, 3)
+	waitForConfigSize(t, nodes[2].engine, 3)
 
 	warm, err := leader.engine.Propose(ctx, []byte("same-id-replacement"))
 	require.NoError(t, err)
 	requireTransportNodeAppliedValue(t, nodes[1], "same-id-replacement")
 	requireLearnerPromoted(t, ctx, leader.engine, nodes[1].peer.ID, addIndex, warm.CommitIndex)
-	requireTransportNodeSuffrage(t, ctx, nodes[1], SuffrageVoter, 2)
+	requireTransportNodeSuffrage(t, ctx, nodes[1], SuffrageVoter, 3)
 
 	restartTransportTestNodesWithoutJoin(t, ctx, nodes)
 	restartedLeader := waitForLeaderNode(t, nodes)
-	requireTransportNodesConfigSize(t, ctx, nodes, 2)
+	requireTransportNodesConfigSize(t, ctx, nodes, 3)
 	result, err := restartedLeader.engine.Propose(ctx, []byte("after-same-id-restart"))
 	require.NoError(t, err)
 	require.NotZero(t, result.CommitIndex)

--- a/internal/raftengine/etcd/learner_test.go
+++ b/internal/raftengine/etcd/learner_test.go
@@ -2,6 +2,7 @@ package etcd
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -134,6 +135,193 @@ func TestPromoteLearnerSwapsRoleToVoter(t *testing.T) {
 			}
 		}
 		return voters == 2
+	}, 5*time.Second, 20*time.Millisecond)
+}
+
+func TestFreshLearnerJoinPromotesAndRestartsFromPersistedMembership(t *testing.T) {
+	nodes, peers := newTransportTestNodes(t, 3)
+	activeNodes := nodes[:2]
+	startTransportTestServers(nodes, peers)
+	t.Cleanup(func() { cleanupTransportTestNodes(t, nodes) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	require.NoError(t, openTransportTestNode(ctx, nodes[0], peers[:1], true))
+	leader := waitForLeaderNode(t, activeNodes[:1])
+
+	_, ok, err := LoadPersistedPeers(nodes[1].dir)
+	require.NoError(t, err)
+	require.False(t, ok, "fresh joiner must start without copied peer metadata")
+
+	nodes[1].joinAsLearner = true
+	require.NoError(t, openTransportTestNode(ctx, nodes[1], peers, false))
+	joinerConfig, err := nodes[1].engine.Configuration(ctx)
+	require.NoError(t, err)
+	require.Empty(t, joinerConfig.Servers, "join transport peers must not bootstrap ConfState")
+
+	addIndex, err := leader.engine.AddLearner(ctx, nodes[1].peer.ID, nodes[1].peer.Address, 0)
+	require.NoError(t, err)
+	waitForConfigSize(t, leader.engine, 2)
+	waitForConfigSize(t, nodes[1].engine, 2)
+
+	warm, err := leader.engine.Propose(ctx, []byte("fresh-join"))
+	require.NoError(t, err)
+	requireTransportNodeAppliedValue(t, nodes[1], "fresh-join")
+	requireLearnerPromoted(t, ctx, leader.engine, nodes[1].peer.ID, addIndex, warm.CommitIndex)
+	requireTransportNodeSuffrage(t, ctx, nodes[1], SuffrageVoter, 2)
+	requirePersistedPeersExcludeNode(t, nodes[1].dir, nodes[2].peer.NodeID, 2)
+	restartTransportTestNodesWithoutJoin(t, ctx, activeNodes)
+
+	restartedLeader := waitForLeaderNode(t, activeNodes)
+	requireTransportNodesConfigSize(t, ctx, activeNodes, 2)
+	result, err := restartedLeader.engine.Propose(ctx, []byte("after-full-restart"))
+	require.NoError(t, err)
+	require.NotZero(t, result.CommitIndex)
+}
+
+func TestFreshLearnerJoinReusesRemovedVoterID(t *testing.T) {
+	nodes, peers := newTransportTestNodes(t, 2)
+	startTransportTestServers(nodes, peers)
+	t.Cleanup(func() { cleanupTransportTestNodes(t, nodes) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	require.NoError(t, openTransportTestNode(ctx, nodes[0], peers[:1], true))
+	leader := waitForLeaderNode(t, nodes[:1])
+	require.NoError(t, openTransportTestNode(ctx, nodes[1], peers, false))
+
+	_, err := leader.engine.AddVoter(ctx, nodes[1].peer.ID, nodes[1].peer.Address, 0)
+	require.NoError(t, err)
+	waitForConfigSize(t, leader.engine, 2)
+	waitForConfigSize(t, nodes[1].engine, 2)
+
+	require.NoError(t, nodes[1].engine.Close())
+	nodes[1].engine = nil
+	_, err = leader.engine.RemoveServer(ctx, nodes[1].peer.ID, 0)
+	require.NoError(t, err)
+	waitForConfigSize(t, leader.engine, 1)
+
+	require.NoError(t, os.RemoveAll(nodes[1].dir))
+	require.NoError(t, os.MkdirAll(nodes[1].dir, 0o750))
+	nodes[1].fsm = &testStateMachine{}
+	nodes[1].joinAsLearner = true
+	require.NoError(t, openTransportTestNode(ctx, nodes[1], peers, false))
+
+	joinerConfig, err := nodes[1].engine.Configuration(ctx)
+	require.NoError(t, err)
+	require.Empty(t, joinerConfig.Servers, "wiped replacement must not recover its removed voter role")
+
+	addIndex, err := leader.engine.AddLearner(ctx, nodes[1].peer.ID, nodes[1].peer.Address, 0)
+	require.NoError(t, err)
+	waitForConfigSize(t, leader.engine, 2)
+	waitForConfigSize(t, nodes[1].engine, 2)
+
+	warm, err := leader.engine.Propose(ctx, []byte("same-id-replacement"))
+	require.NoError(t, err)
+	requireTransportNodeAppliedValue(t, nodes[1], "same-id-replacement")
+	requireLearnerPromoted(t, ctx, leader.engine, nodes[1].peer.ID, addIndex, warm.CommitIndex)
+	requireTransportNodeSuffrage(t, ctx, nodes[1], SuffrageVoter, 2)
+
+	restartTransportTestNodesWithoutJoin(t, ctx, nodes)
+	restartedLeader := waitForLeaderNode(t, nodes)
+	requireTransportNodesConfigSize(t, ctx, nodes, 2)
+	result, err := restartedLeader.engine.Propose(ctx, []byte("after-same-id-restart"))
+	require.NoError(t, err)
+	require.NotZero(t, result.CommitIndex)
+}
+
+func requireTransportNodeAppliedValue(t *testing.T, node *transportTestNode, value string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		applied := node.fsm.Applied()
+		return len(applied) == 1 && string(applied[0]) == value
+	}, 5*time.Second, 20*time.Millisecond)
+}
+
+func requireLearnerPromoted(
+	t *testing.T,
+	ctx context.Context,
+	engine *Engine,
+	learnerID string,
+	addIndex uint64,
+	minAppliedIndex uint64,
+) {
+	t.Helper()
+	var promoteErr error
+	require.Eventually(t, func() bool {
+		_, promoteErr = engine.PromoteLearner(ctx, learnerID, addIndex, minAppliedIndex, false)
+		return promoteErr == nil || !errors.Is(promoteErr, errPromoteLearnerNotCaughtUp)
+	}, 5*time.Second, 20*time.Millisecond)
+	require.NoError(t, promoteErr)
+}
+
+func requireTransportNodeSuffrage(
+	t *testing.T,
+	ctx context.Context,
+	node *transportTestNode,
+	suffrage string,
+	configSize int,
+) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		cfg, err := node.engine.Configuration(ctx)
+		if err != nil || len(cfg.Servers) != configSize {
+			return false
+		}
+		for _, server := range cfg.Servers {
+			if server.ID == node.peer.ID {
+				return server.Suffrage == suffrage
+			}
+		}
+		return false
+	}, 5*time.Second, 20*time.Millisecond)
+}
+
+func requirePersistedPeersExcludeNode(t *testing.T, dataDir string, excludedNodeID uint64, expectedSize int) {
+	t.Helper()
+	persisted, ok, err := LoadPersistedPeers(dataDir)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, persisted, expectedSize, "authoritative ConfState must prune stale discovery peers")
+	for _, peer := range persisted {
+		require.NotEqual(t, excludedNodeID, peer.NodeID)
+	}
+}
+
+func restartTransportTestNodesWithoutJoin(t *testing.T, ctx context.Context, nodes []*transportTestNode) {
+	t.Helper()
+	for _, node := range nodes {
+		require.NoError(t, node.engine.Close())
+		node.engine = nil
+		node.joinAsLearner = false
+	}
+
+	for _, node := range nodes {
+		reopened, err := Open(ctx, OpenConfig{
+			NodeID:       node.peer.NodeID,
+			LocalID:      node.peer.ID,
+			LocalAddress: node.peer.Address,
+			DataDir:      node.dir,
+			Transport:    node.transport,
+			StateMachine: node.fsm,
+		})
+		require.NoError(t, err, "%s must restart from durable membership without join peers", node.peer.ID)
+		node.engine = reopened
+	}
+}
+
+func requireTransportNodesConfigSize(t *testing.T, ctx context.Context, nodes []*transportTestNode, expected int) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		for _, node := range nodes {
+			cfg, err := node.engine.Configuration(ctx)
+			if err != nil || len(cfg.Servers) != expected {
+				return false
+			}
+		}
+		return true
 	}, 5*time.Second, 20*time.Millisecond)
 }
 

--- a/internal/raftengine/etcd/peers.go
+++ b/internal/raftengine/etcd/peers.go
@@ -274,18 +274,24 @@ func removePeerFromMap(peers map[uint64]Peer, nodeID uint64) {
 	delete(peers, nodeID)
 }
 
-func sortedPeerList(peers map[uint64]Peer) []Peer {
-	if len(peers) == 0 {
+func peerListForConfState(peers map[uint64]Peer, conf raftpb.ConfState) []Peer {
+	if len(conf.Voters) == 0 && len(conf.Learners) == 0 {
 		return nil
 	}
-	out := make([]Peer, 0, len(peers))
-	for _, peer := range peers {
-		normalizedPeer, err := normalizePersistedPeer(peer)
-		if err != nil {
-			continue
+	out := make([]Peer, 0, len(conf.Voters)+len(conf.Learners))
+	appendPeer := func(nodeID uint64, suffrage string) {
+		peer, ok := peers[nodeID]
+		if !ok {
+			peer = Peer{NodeID: nodeID, ID: strconv.FormatUint(nodeID, 10)}
 		}
-		out = append(out, normalizedPeer)
+		peer.Suffrage = suffrage
+		out = append(out, peer)
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].NodeID < out[j].NodeID })
+	for _, nodeID := range conf.Voters {
+		appendPeer(nodeID, SuffrageVoter)
+	}
+	for _, nodeID := range conf.Learners {
+		appendPeer(nodeID, SuffrageLearner)
+	}
 	return out
 }

--- a/internal/raftengine/etcd/peers.go
+++ b/internal/raftengine/etcd/peers.go
@@ -274,24 +274,29 @@ func removePeerFromMap(peers map[uint64]Peer, nodeID uint64) {
 	delete(peers, nodeID)
 }
 
-func peerListForConfState(peers map[uint64]Peer, conf raftpb.ConfState) []Peer {
+func peerListForConfState(peers map[uint64]Peer, conf raftpb.ConfState) ([]Peer, error) {
 	if len(conf.Voters) == 0 && len(conf.Learners) == 0 {
-		return nil
+		return nil, nil
 	}
 	out := make([]Peer, 0, len(conf.Voters)+len(conf.Learners))
-	appendPeer := func(nodeID uint64, suffrage string) {
+	appendPeer := func(nodeID uint64, suffrage string) error {
 		peer, ok := peers[nodeID]
-		if !ok {
-			peer = Peer{NodeID: nodeID, ID: strconv.FormatUint(nodeID, 10)}
+		if !ok || strings.TrimSpace(peer.Address) == "" {
+			return errors.Wrapf(errPeerAddressRequired, "conf state node id=%d", nodeID)
 		}
 		peer.Suffrage = suffrage
 		out = append(out, peer)
+		return nil
 	}
 	for _, nodeID := range conf.Voters {
-		appendPeer(nodeID, SuffrageVoter)
+		if err := appendPeer(nodeID, SuffrageVoter); err != nil {
+			return nil, err
+		}
 	}
 	for _, nodeID := range conf.Learners {
-		appendPeer(nodeID, SuffrageLearner)
+		if err := appendPeer(nodeID, SuffrageLearner); err != nil {
+			return nil, err
+		}
 	}
-	return out
+	return out, nil
 }

--- a/main.go
+++ b/main.go
@@ -107,6 +107,7 @@ var (
 	raftBootstrap                   = flag.Bool("raftBootstrap", false, "Whether to bootstrap the Raft cluster")
 	raftBootstrapMembers            = flag.String("raftBootstrapMembers", "", "Comma-separated bootstrap raft members (raftID=host:port,...)")
 	raftGroupPeers                  = flag.String("raftGroupPeers", "", "Semicolon-separated per-group bootstrap members (groupID=raftID@host:port,...)")
+	raftJoinMembers                 = flag.String("raftJoinMembers", "", "Comma-separated raft members used only for transport discovery while this fresh node joins an existing single-group cluster (raftID=host:port,...); requires --raftJoinAsLearner")
 	raftJoinAsLearner               = flag.Bool("raftJoinAsLearner", false, "Local node expects to join an existing cluster as a learner; if a post-apply ConfState lists this node as a voter instead, an ERROR-level alarm fires (the node keeps running -- the flag is an operator alarm, not a consensus veto). See docs/design/2026_04_26_implemented_raft_learner.md §4.5.")
 	tsoEnabled                      = flag.Bool("tsoEnabled", false, "Issue coordinator-owned persistence timestamps through the local TSO batch allocator instead of direct HLC calls")
 	tsoBatchSize                    = flag.Int("tsoBatchSize", defaultTSOBatchSize, "Timestamp batch size used when --tsoEnabled is true")
@@ -647,7 +648,15 @@ func resolveRuntimeInputs() (runtimeConfig, raftEngineType, raftBootstrapConfig,
 		return runtimeConfig{}, "", raftBootstrapConfig{}, false, err
 	}
 
-	bootstrapCfg, err := resolveBootstrapConfig(*raftId, cfg.groups, *raftBootstrapMembers, *raftGroupPeers)
+	bootstrapCfg, err := resolveRaftPeerConfig(
+		*raftId,
+		cfg.groups,
+		*raftBootstrapMembers,
+		*raftGroupPeers,
+		*raftJoinMembers,
+		*raftJoinAsLearner,
+		*raftBootstrap,
+	)
 	if err != nil {
 		return runtimeConfig{}, "", raftBootstrapConfig{}, false, err
 	}
@@ -658,6 +667,7 @@ func resolveRuntimeInputs() (runtimeConfig, raftEngineType, raftBootstrapConfig,
 type raftBootstrapConfig struct {
 	legacyServers []raftengine.Server
 	groupServers  map[uint64][]raftengine.Server
+	joinServers   []raftengine.Server
 }
 
 func (c raftBootstrapConfig) anyBootstrapServers() bool {
@@ -665,10 +675,20 @@ func (c raftBootstrapConfig) anyBootstrapServers() bool {
 }
 
 func (c raftBootstrapConfig) serversForGroup(groupID uint64) []raftengine.Server {
+	if len(c.joinServers) != 0 {
+		return cloneRaftServers(c.joinServers)
+	}
 	if len(c.groupServers) != 0 {
 		return cloneRaftServers(c.groupServers[groupID])
 	}
 	return cloneRaftServers(c.legacyServers)
+}
+
+func (c raftBootstrapConfig) bootstrapsGroup(groupID uint64) bool {
+	if len(c.groupServers) != 0 {
+		return len(c.groupServers[groupID]) > 0
+	}
+	return len(c.legacyServers) > 0
 }
 
 func (c raftBootstrapConfig) bootstrapSeedForGroup(groupID uint64) []raftengine.Server {
@@ -679,6 +699,9 @@ func (c raftBootstrapConfig) bootstrapSeedForGroup(groupID uint64) []raftengine.
 }
 
 func (c raftBootstrapConfig) adminSeed(defaultGroup uint64) []raftengine.Server {
+	if len(c.joinServers) != 0 {
+		return cloneRaftServers(c.joinServers)
+	}
 	if len(c.groupServers) != 0 {
 		return cloneRaftServers(c.groupServers[defaultGroup])
 	}
@@ -903,9 +926,19 @@ var (
 	ErrRaftGroupPeersTooFewVoters         = errors.New("flag --raftGroupPeers group must contain at least two voters")
 	ErrRaftGroupPeersHeterogeneous        = errors.New("flag --raftGroupPeers requires identical raft IDs across groups")
 	ErrNoRaftGroupPeersConfigured         = errors.New("no raft group peers configured")
+	ErrJoinMembersRequireSingleGroup      = errors.New("flag --raftJoinMembers requires exactly one raft group")
+	ErrJoinMembersRequireLearner          = errors.New("flag --raftJoinMembers requires --raftJoinAsLearner")
+	ErrJoinMembersConflictBootstrap       = errors.New("flag --raftJoinMembers cannot be combined with raft bootstrap flags")
+	ErrJoinMembersMissingLocalNode        = errors.New("flag --raftJoinMembers must include local --raftId")
+	ErrJoinMembersLocalAddrMismatch       = errors.New("flag --raftJoinMembers local address must match local raft group address")
+	ErrJoinMembersTooFewMembers           = errors.New("flag --raftJoinMembers must include the local node and at least one existing member")
+	ErrNoJoinMembersConfigured            = errors.New("no raft join members configured")
 )
 
-const minRaftGroupPeerVoters = 2
+const (
+	minRaftGroupPeerVoters = 2
+	minRaftJoinMembers     = 2
+)
 
 func resolveBootstrapConfig(
 	raftID string,
@@ -928,6 +961,59 @@ func resolveBootstrapConfig(
 		return raftBootstrapConfig{}, err
 	}
 	return raftBootstrapConfig{groupServers: groupServers}, nil
+}
+
+func resolveRaftPeerConfig(
+	raftID string,
+	groups []groupSpec,
+	bootstrapMembers string,
+	groupPeersRaw string,
+	joinMembers string,
+	joinAsLearner bool,
+	explicitBootstrap bool,
+) (raftBootstrapConfig, error) {
+	if strings.TrimSpace(joinMembers) == "" {
+		return resolveBootstrapConfig(raftID, groups, bootstrapMembers, groupPeersRaw)
+	}
+	if !joinAsLearner {
+		return raftBootstrapConfig{}, errors.WithStack(ErrJoinMembersRequireLearner)
+	}
+	if explicitBootstrap || strings.TrimSpace(bootstrapMembers) != "" || strings.TrimSpace(groupPeersRaw) != "" {
+		return raftBootstrapConfig{}, errors.WithStack(ErrJoinMembersConflictBootstrap)
+	}
+	servers, err := resolveJoinServers(raftID, groups, joinMembers)
+	if err != nil {
+		return raftBootstrapConfig{}, err
+	}
+	return raftBootstrapConfig{joinServers: servers}, nil
+}
+
+func resolveJoinServers(raftID string, groups []groupSpec, joinMembers string) ([]raftengine.Server, error) {
+	if len(groups) != 1 {
+		return nil, errors.WithStack(ErrJoinMembersRequireSingleGroup)
+	}
+	servers, err := parseRaftBootstrapMembers(joinMembers)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse raft join members")
+	}
+	if len(servers) == 0 {
+		return nil, errors.WithStack(ErrNoJoinMembersConfigured)
+	}
+	if len(servers) < minRaftJoinMembers {
+		return nil, errors.WithStack(ErrJoinMembersTooFewMembers)
+	}
+
+	localAddr := groups[0].address
+	for _, server := range servers {
+		if server.ID != raftID {
+			continue
+		}
+		if server.Address != localAddr {
+			return nil, errors.Wrapf(ErrJoinMembersLocalAddrMismatch, "expected %q got %q", localAddr, server.Address)
+		}
+		return servers, nil
+	}
+	return nil, errors.Wrapf(ErrJoinMembersMissingLocalNode, "raftId=%q", raftID)
 }
 
 func resolveBootstrapServers(raftID string, groups []groupSpec, bootstrapMembers string) ([]raftengine.Server, error) {
@@ -1178,7 +1264,7 @@ func bootstrapSettingsForGroup(
 	explicitBootstrap bool,
 ) (bool, []raftengine.Server, []raftengine.Server) {
 	servers := cfg.serversForGroup(groupID)
-	return explicitBootstrap || len(servers) > 0, servers, cfg.bootstrapSeedForGroup(groupID)
+	return explicitBootstrap || cfg.bootstrapsGroup(groupID), servers, cfg.bootstrapSeedForGroup(groupID)
 }
 
 func fsmOptionsForGroup(applier *encryption.Applier, routeEngine *distribution.Engine, groupID uint64, encWiring encryptionWriteWiring, applyObservers ...kv.ApplyObserver) []kv.FSMOption {
@@ -1600,6 +1686,9 @@ func startServersAfterStartupRotation(waitRotateOnStartup startupRotationWaiter,
 	if err := waitRotateOnStartup.Wait(in.ctx); err != nil {
 		return runner.startupFailure(errors.Wrap(err, "encryption rotate-on-startup: wait before serving"))
 	}
+	if err := waitForRaftJoinReady(in.ctx, in.runtimes, *raftId, strings.TrimSpace(*raftJoinMembers) != ""); err != nil {
+		return runner.startupFailure(errors.Wrap(err, "wait for fresh raft join before serving"))
+	}
 	startHLCLeaseRenewal(in.ctx, in.eg, in.coordinate)
 	publicKVGate.markReady()
 	if err := runner.startPublicServices(); err != nil {
@@ -1607,6 +1696,62 @@ func startServersAfterStartupRotation(waitRotateOnStartup startupRotationWaiter,
 	}
 	runner.startAdminHTTP()
 	return nil
+}
+
+const raftJoinReadyPollInterval = 100 * time.Millisecond
+
+func waitForRaftJoinReady(ctx context.Context, runtimes []*raftGroupRuntime, localID string, enabled bool) error {
+	if !enabled {
+		return nil
+	}
+	ticker := time.NewTicker(raftJoinReadyPollInterval)
+	defer ticker.Stop()
+	for {
+		ready, err := raftJoinRuntimesReady(ctx, runtimes, localID)
+		if err != nil {
+			return err
+		}
+		if ready {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return errors.WithStack(ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func raftJoinRuntimesReady(ctx context.Context, runtimes []*raftGroupRuntime, localID string) (bool, error) {
+	if len(runtimes) == 0 {
+		return false, nil
+	}
+	for _, runtime := range runtimes {
+		if runtime == nil || runtime.engine == nil {
+			return false, nil
+		}
+		configuration, err := runtime.engine.Configuration(ctx)
+		if err != nil {
+			return false, errors.Wrapf(err, "read raft group %d join configuration", runtime.spec.id)
+		}
+		if !configurationContainsMember(configuration, localID) {
+			return false, nil
+		}
+		status := runtime.engine.Status()
+		if status.Leader.ID == "" || status.PendingConfChange || status.AppliedIndex < status.CommitIndex {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func configurationContainsMember(configuration raftengine.Configuration, localID string) bool {
+	for _, server := range configuration.Servers {
+		if server.ID == localID && (server.Suffrage == "learner" || server.Suffrage == "voter") {
+			return true
+		}
+	}
+	return false
 }
 
 func configureCoordinatorTSO(coordinate *kv.ShardedCoordinator) error {

--- a/main.go
+++ b/main.go
@@ -1557,8 +1557,9 @@ type serversInput struct {
 }
 
 // startServersAfterStartupRotation wires up the AdminServer, starts the
-// per-group Raft listeners needed for quorum traffic, waits for any requested
-// startup rotation, then opens the public service listeners.
+// per-group Raft listeners needed for quorum traffic, waits for a fresh join
+// to catch up, prepares the public listeners, waits for any requested startup
+// rotation, then starts serving public traffic.
 func startServersAfterStartupRotation(waitRotateOnStartup startupRotationWaiter, in serversInput) error {
 	adminServer, adminGRPCOpts, err := setupAdminService(*raftId, *myAddr, in.runtimes, in.bootstrapServers, in.keyvizSampler)
 	if err != nil {
@@ -1658,7 +1659,13 @@ func startServersAfterStartupRotation(waitRotateOnStartup startupRotationWaiter,
 	if err := runner.startRaftTransport(); err != nil {
 		return err
 	}
-	if err := runner.preparePublicServices(); err != nil {
+	if err := preparePublicServicesAfterRaftJoinReady(
+		in.ctx,
+		in.runtimes,
+		*raftId,
+		strings.TrimSpace(*raftJoinMembers) != "",
+		runner.preparePublicServices,
+	); err != nil {
 		return runner.startupFailure(err)
 	}
 	// runner.startRaftTransport() has populated runner.dynamoServer for the
@@ -1686,9 +1693,6 @@ func startServersAfterStartupRotation(waitRotateOnStartup startupRotationWaiter,
 	if err := waitRotateOnStartup.Wait(in.ctx); err != nil {
 		return runner.startupFailure(errors.Wrap(err, "encryption rotate-on-startup: wait before serving"))
 	}
-	if err := waitForRaftJoinReady(in.ctx, in.runtimes, *raftId, strings.TrimSpace(*raftJoinMembers) != ""); err != nil {
-		return runner.startupFailure(errors.Wrap(err, "wait for fresh raft join before serving"))
-	}
 	startHLCLeaseRenewal(in.ctx, in.eg, in.coordinate)
 	publicKVGate.markReady()
 	if err := runner.startPublicServices(); err != nil {
@@ -1699,6 +1703,19 @@ func startServersAfterStartupRotation(waitRotateOnStartup startupRotationWaiter,
 }
 
 const raftJoinReadyPollInterval = 100 * time.Millisecond
+
+func preparePublicServicesAfterRaftJoinReady(
+	ctx context.Context,
+	runtimes []*raftGroupRuntime,
+	localID string,
+	enabled bool,
+	prepare func() error,
+) error {
+	if err := waitForRaftJoinReady(ctx, runtimes, localID, enabled); err != nil {
+		return errors.Wrap(err, "wait for fresh raft join before binding public services")
+	}
+	return prepare()
+}
 
 func waitForRaftJoinReady(ctx context.Context, runtimes []*raftGroupRuntime, localID string, enabled bool) error {
 	if !enabled {

--- a/main_bootstrap_test.go
+++ b/main_bootstrap_test.go
@@ -115,6 +115,83 @@ func TestResolveBootstrapConfigGroupPeers(t *testing.T) {
 	})
 }
 
+func TestResolveRaftPeerConfigJoinMembers(t *testing.T) {
+	groups := []groupSpec{{id: 1, address: "10.0.0.12:50051"}}
+	joinMembers := "n1=10.0.0.11:50051,n2=10.0.0.12:50051,n3=10.0.0.13:50051"
+
+	t.Run("join members provide peers without enabling bootstrap", func(t *testing.T) {
+		cfg, err := resolveRaftPeerConfig("n2", groups, "", "", joinMembers, true, false)
+		require.NoError(t, err)
+		require.False(t, cfg.anyBootstrapServers())
+		require.Equal(t, []raftengine.Server{
+			{Suffrage: "voter", ID: "n1", Address: "10.0.0.11:50051"},
+			{Suffrage: "voter", ID: "n2", Address: "10.0.0.12:50051"},
+			{Suffrage: "voter", ID: "n3", Address: "10.0.0.13:50051"},
+		}, cfg.serversForGroup(1))
+		require.Equal(t, cfg.serversForGroup(1), cfg.adminSeed(1))
+		require.Nil(t, cfg.bootstrapSeedForGroup(1))
+
+		bootstrap, peers, seed := bootstrapSettingsForGroup(cfg, 1, false)
+		require.False(t, bootstrap)
+		require.Equal(t, cfg.serversForGroup(1), peers)
+		require.Nil(t, seed)
+	})
+
+	t.Run("requires learner mode", func(t *testing.T) {
+		_, err := resolveRaftPeerConfig("n2", groups, "", "", joinMembers, false, false)
+		require.ErrorIs(t, err, ErrJoinMembersRequireLearner)
+	})
+
+	for _, tc := range []struct {
+		name             string
+		bootstrapMembers string
+		groupPeers       string
+		explicit         bool
+	}{
+		{name: "explicit bootstrap", explicit: true},
+		{name: "bootstrap members", bootstrapMembers: joinMembers},
+		{name: "group peers", groupPeers: "1=n1@10.0.0.11:50051,n2@10.0.0.12:50051"},
+	} {
+		t.Run("rejects "+tc.name, func(t *testing.T) {
+			_, err := resolveRaftPeerConfig(
+				"n2", groups, tc.bootstrapMembers, tc.groupPeers, joinMembers, true, tc.explicit,
+			)
+			require.ErrorIs(t, err, ErrJoinMembersConflictBootstrap)
+		})
+	}
+
+	t.Run("requires a single group", func(t *testing.T) {
+		_, err := resolveRaftPeerConfig("n2", []groupSpec{
+			{id: 1, address: "10.0.0.12:50051"},
+			{id: 2, address: "10.0.0.12:50052"},
+		}, "", "", joinMembers, true, false)
+		require.ErrorIs(t, err, ErrJoinMembersRequireSingleGroup)
+	})
+
+	t.Run("requires local member", func(t *testing.T) {
+		_, err := resolveRaftPeerConfig(
+			"n2", groups, "", "",
+			"n1=10.0.0.11:50051,n3=10.0.0.13:50051", true, false,
+		)
+		require.ErrorIs(t, err, ErrJoinMembersMissingLocalNode)
+	})
+
+	t.Run("requires matching local address", func(t *testing.T) {
+		_, err := resolveRaftPeerConfig(
+			"n2", groups, "", "",
+			"n1=10.0.0.11:50051,n2=10.0.0.99:50051", true, false,
+		)
+		require.ErrorIs(t, err, ErrJoinMembersLocalAddrMismatch)
+	})
+
+	t.Run("requires a remote member", func(t *testing.T) {
+		_, err := resolveRaftPeerConfig(
+			"n2", groups, "", "", "n2=10.0.0.12:50051", true, false,
+		)
+		require.ErrorIs(t, err, ErrJoinMembersTooFewMembers)
+	})
+}
+
 func TestDurationToTicks(t *testing.T) {
 	t.Parallel()
 

--- a/main_raft_join_test.go
+++ b/main_raft_join_test.go
@@ -87,3 +87,44 @@ func TestRaftJoinRuntimesReadyReturnsConfigurationError(t *testing.T) {
 func TestWaitForRaftJoinReadyDisabled(t *testing.T) {
 	require.NoError(t, waitForRaftJoinReady(context.Background(), nil, "n2", false))
 }
+
+func TestPreparePublicServicesAfterRaftJoinReadyDoesNotBindWhileJoinIsUnready(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	prepared := false
+
+	err := preparePublicServicesAfterRaftJoinReady(
+		ctx,
+		[]*raftGroupRuntime{{
+			spec: groupSpec{id: 1},
+			engine: &raftJoinReadyEngineStub{
+				status: raftengine.Status{Leader: raftengine.LeaderInfo{ID: "n1"}},
+			},
+		}},
+		"n2",
+		true,
+		func() error {
+			prepared = true
+			return nil
+		},
+	)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, prepared)
+}
+
+func TestPreparePublicServicesAfterRaftJoinReadyBindsWhenJoinIsDisabled(t *testing.T) {
+	prepared := false
+	err := preparePublicServicesAfterRaftJoinReady(
+		context.Background(),
+		nil,
+		"n2",
+		false,
+		func() error {
+			prepared = true
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.True(t, prepared)
+}

--- a/main_raft_join_test.go
+++ b/main_raft_join_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/bootjp/elastickv/internal/raftengine"
+	"github.com/stretchr/testify/require"
+)
+
+type raftJoinReadyEngineStub struct {
+	raftengine.Engine
+	configuration raftengine.Configuration
+	status        raftengine.Status
+	err           error
+}
+
+func (e *raftJoinReadyEngineStub) Configuration(context.Context) (raftengine.Configuration, error) {
+	return e.configuration, e.err
+}
+
+func (e *raftJoinReadyEngineStub) Status() raftengine.Status {
+	return e.status
+}
+
+func TestRaftJoinRuntimesReady(t *testing.T) {
+	readyStatus := raftengine.Status{
+		Leader:       raftengine.LeaderInfo{ID: "n1"},
+		CommitIndex:  42,
+		AppliedIndex: 42,
+	}
+	readyConfig := raftengine.Configuration{Servers: []raftengine.Server{
+		{ID: "n1", Suffrage: "voter"},
+		{ID: "n2", Suffrage: "learner"},
+	}}
+
+	tests := []struct {
+		name   string
+		engine *raftJoinReadyEngineStub
+		ready  bool
+	}{
+		{name: "member caught up", engine: &raftJoinReadyEngineStub{configuration: readyConfig, status: readyStatus}, ready: true},
+		{name: "membership missing", engine: &raftJoinReadyEngineStub{status: readyStatus}},
+		{name: "leader unknown", engine: &raftJoinReadyEngineStub{configuration: readyConfig}},
+		{name: "apply lag", engine: &raftJoinReadyEngineStub{
+			configuration: readyConfig,
+			status: raftengine.Status{
+				Leader:       raftengine.LeaderInfo{ID: "n1"},
+				CommitIndex:  42,
+				AppliedIndex: 41,
+			},
+		}},
+		{name: "conf change pending", engine: &raftJoinReadyEngineStub{
+			configuration: readyConfig,
+			status: func() raftengine.Status {
+				status := readyStatus
+				status.PendingConfChange = true
+				return status
+			}(),
+		}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ready, err := raftJoinRuntimesReady(context.Background(), []*raftGroupRuntime{{
+				spec:   groupSpec{id: 1},
+				engine: tc.engine,
+			}}, "n2")
+			require.NoError(t, err)
+			require.Equal(t, tc.ready, ready)
+		})
+	}
+}
+
+func TestRaftJoinRuntimesReadyReturnsConfigurationError(t *testing.T) {
+	readErr := errors.New("configuration unavailable")
+	ready, err := raftJoinRuntimesReady(context.Background(), []*raftGroupRuntime{{
+		spec:   groupSpec{id: 7},
+		engine: &raftJoinReadyEngineStub{err: readErr},
+	}}, "n2")
+	require.False(t, ready)
+	require.ErrorIs(t, err, readErr)
+	require.Contains(t, err.Error(), "raft group 7")
+}
+
+func TestWaitForRaftJoinReadyDisabled(t *testing.T) {
+	require.NoError(t, waitForRaftJoinReady(context.Background(), nil, "n2", false))
+}

--- a/scripts/rolling-update.env.example
+++ b/scripts/rolling-update.env.example
@@ -20,6 +20,13 @@ SERVER_ENTRYPOINT="/app"
 # hashicorp and etcd is intentionally rejected.
 RAFT_ENGINE="etcd"
 
+# Fresh learner replacement only. Fence and remove the old voter first, set
+# ROLLING_ORDER to this one ID, then set RAFT_JOIN_NODE to the same ID. The
+# script derives --raftJoinMembers from NODES. Clear RAFT_JOIN_NODE and
+# redeploy this node after promotion so it returns to normal restart mode.
+# ROLLING_ORDER="n2"
+# RAFT_JOIN_NODE="n2"
+
 RAFT_PORT="50051"
 REDIS_PORT="6379"
 DYNAMO_PORT="8000"

--- a/scripts/rolling-update.sh
+++ b/scripts/rolling-update.sh
@@ -37,6 +37,11 @@ Optional environment:
   RAFT_ENGINE
   RAFT_PORT
   RAFT_BOOTSTRAP_MEMBERS
+  RAFT_JOIN_NODE
+    Raft ID of one fresh node that is being attached as a learner. Requires
+    ROLLING_ORDER to contain only that node. The script derives
+    --raftJoinMembers from NODES and passes --raftJoinAsLearner only to this
+    node. Remove RAFT_JOIN_NODE and redeploy the node after promotion.
   REDIS_PORT
   DYNAMO_PORT
   RAFT_TO_REDIS_MAP
@@ -147,6 +152,7 @@ Optional environment:
 
 Notes:
   - RAFT_BOOTSTRAP_MEMBERS is only forwarded when explicitly set.
+  - RAFT_JOIN_NODE and RAFT_BOOTSTRAP_MEMBERS are mutually exclusive.
   - If RAFT_TO_REDIS_MAP is unset, it is derived automatically from NODES,
     RAFT_PORT, and REDIS_PORT.
   - If RAFT_TO_S3_MAP is unset, it is derived automatically from NODES,
@@ -275,6 +281,7 @@ NODES="${NODES:-}"
 SSH_TARGETS="${SSH_TARGETS:-}"
 ROLLING_ORDER="${ROLLING_ORDER:-}"
 RAFT_BOOTSTRAP_MEMBERS="${RAFT_BOOTSTRAP_MEMBERS:-}"
+RAFT_JOIN_NODE="${RAFT_JOIN_NODE:-}"
 RAFT_TO_REDIS_MAP="${RAFT_TO_REDIS_MAP:-}"
 RAFT_TO_S3_MAP="${RAFT_TO_S3_MAP:-}"
 RAFT_TO_SQS_MAP="${RAFT_TO_SQS_MAP:-}"
@@ -531,6 +538,20 @@ derive_raft_to_redis_map() {
   )
 }
 
+derive_raft_join_members() {
+  local parts=()
+  local i
+
+  for i in "${!NODE_IDS[@]}"; do
+    parts+=("${NODE_IDS[$i]}=${NODE_HOSTS[$i]}:${RAFT_PORT}")
+  done
+
+  (
+    IFS=,
+    printf '%s\n' "${parts[*]}"
+  )
+}
+
 derive_raft_to_s3_map() {
   local parts=()
   local i
@@ -566,6 +587,10 @@ print_dry_run_plan() {
   echo "[rolling-update] target image: $IMAGE"
   echo "[rolling-update] container: $CONTAINER_NAME"
   echo "[rolling-update] raft engine: $RAFT_ENGINE"
+  if [[ -n "$RAFT_JOIN_NODE" ]]; then
+    echo "[rolling-update] learner join node: $RAFT_JOIN_NODE"
+    echo "[rolling-update] RAFT_JOIN_MEMBERS=$RAFT_JOIN_MEMBERS"
+  fi
   echo "[rolling-update] rolling order:"
   for node_id in "${ROLLING_NODE_IDS[@]}"; do
     node_host="$(node_host_by_id "$node_id")"
@@ -696,6 +721,11 @@ update_one_node() {
   local node_host="$2"
   local ssh_target="$3"
   local all_node_ids_csv all_node_hosts_csv
+  local raft_join_as_learner=false
+
+  if [[ -n "$RAFT_JOIN_NODE" && "$node_id" == "$RAFT_JOIN_NODE" ]]; then
+    raft_join_as_learner=true
+  fi
 
   all_node_ids_csv="$(IFS=,; echo "${NODE_IDS[*]}")"
   all_node_hosts_csv="$(IFS=,; echo "${NODE_HOSTS[*]}")"
@@ -738,6 +768,8 @@ update_one_node() {
       ALL_NODE_IDS_CSV="$all_node_ids_csv" \
       ALL_NODE_HOSTS_CSV="$all_node_hosts_csv" \
       RAFT_BOOTSTRAP_MEMBERS="$RAFT_BOOTSTRAP_MEMBERS_Q" \
+      RAFT_JOIN_AS_LEARNER="$raft_join_as_learner" \
+      RAFT_JOIN_MEMBERS="$RAFT_JOIN_MEMBERS_Q" \
       RAFT_TO_REDIS_MAP="$RAFT_TO_REDIS_MAP_Q" \
       RAFT_TO_S3_MAP="$RAFT_TO_S3_MAP_Q" \
       RAFT_TO_SQS_MAP="$RAFT_TO_SQS_MAP_Q" \
@@ -1200,6 +1232,11 @@ run_container() {
     raft_bootstrap_flags=(--raftBootstrapMembers "$RAFT_BOOTSTRAP_MEMBERS")
   fi
 
+  local raft_join_flags=()
+  if [[ "${RAFT_JOIN_AS_LEARNER:-false}" == "true" ]]; then
+    raft_join_flags=(--raftJoinAsLearner --raftJoinMembers "$RAFT_JOIN_MEMBERS")
+  fi
+
   # config-fingerprint label drives the skip check on the next deploy
   # (see DEPLOY_CONFIG_FP_LABEL block above). Empty value here means
   # the deploy script was run on an old layout that didn't compute one
@@ -1228,6 +1265,7 @@ run_container() {
     --raftId "$NODE_ID" \
     --raftEngine "$RAFT_ENGINE" \
     "${raft_bootstrap_flags[@]}" \
+    "${raft_join_flags[@]}" \
     --raftDataDir "$DATA_DIR" \
     --raftRedisMap "$RAFT_TO_REDIS_MAP" \
     "${s3_flags[@]}" \
@@ -1505,6 +1543,7 @@ config_fp() {
     "$NODE_HOST" "$NODE_ID" \
     "$RAFT_ENGINE" \
     "$RAFT_BOOTSTRAP_MEMBERS" \
+    "$RAFT_JOIN_AS_LEARNER" "$RAFT_JOIN_MEMBERS" \
     "$RAFT_PORT" "$REDIS_PORT" "$DYNAMO_PORT" \
     "$RAFT_TO_REDIS_MAP" \
     "$ENABLE_S3" "$S3_PORT" "$S3_REGION" "$S3_PATH_STYLE_ONLY" \
@@ -1580,6 +1619,26 @@ REMOTE
 
 parse_nodes
 prepare_rolling_order
+
+if [[ -n "$RAFT_JOIN_NODE" ]]; then
+  if [[ -n "$RAFT_BOOTSTRAP_MEMBERS" ]]; then
+    echo "rolling-update: RAFT_JOIN_NODE and RAFT_BOOTSTRAP_MEMBERS are mutually exclusive" >&2
+    exit 1
+  fi
+  if ! contains_value "$RAFT_JOIN_NODE" "${NODE_IDS[@]}"; then
+    echo "rolling-update: RAFT_JOIN_NODE references unknown raft ID: $RAFT_JOIN_NODE" >&2
+    exit 1
+  fi
+  if [[ "${#ROLLING_NODE_IDS[@]}" -ne 1 || "${ROLLING_NODE_IDS[0]}" != "$RAFT_JOIN_NODE" ]]; then
+    echo "rolling-update: RAFT_JOIN_NODE requires ROLLING_ORDER to contain only $RAFT_JOIN_NODE" >&2
+    exit 1
+  fi
+fi
+
+RAFT_JOIN_MEMBERS=""
+if [[ -n "$RAFT_JOIN_NODE" ]]; then
+  RAFT_JOIN_MEMBERS="$(derive_raft_join_members)"
+fi
 
 if [[ -z "$RAFT_TO_REDIS_MAP" ]]; then
   RAFT_TO_REDIS_MAP="$(derive_raft_to_redis_map)"
@@ -1755,6 +1814,7 @@ SERVER_ENTRYPOINT_Q="$(printf '%q' "$SERVER_ENTRYPOINT")"
 RAFTADMIN_REMOTE_BIN_Q="$(printf '%q' "$RAFTADMIN_REMOTE_BIN")"
 CONTAINER_NAME_Q="$(printf '%q' "$CONTAINER_NAME")"
 RAFT_BOOTSTRAP_MEMBERS_Q="$(printf '%q' "$RAFT_BOOTSTRAP_MEMBERS")"
+RAFT_JOIN_MEMBERS_Q="$(printf '%q' "$RAFT_JOIN_MEMBERS")"
 RAFT_TO_REDIS_MAP_Q="$(printf '%q' "$RAFT_TO_REDIS_MAP")"
 RAFT_TO_S3_MAP_Q="$(printf '%q' "$RAFT_TO_S3_MAP")"
 RAFT_TO_SQS_MAP_Q="$(printf '%q' "$RAFT_TO_SQS_MAP")"


### PR DESCRIPTION
## Summary

- add `--raftJoinMembers` as transport-only discovery for a fresh single-group learner without enabling bootstrap
- keep public Redis, DynamoDB, S3, and SQS listeners closed until membership and apply catch-up are ready
- persist only peers in authoritative `ConfState`, including after received snapshots
- add a one-node `RAFT_JOIN_NODE` rolling replacement mode, design document, runbook, and restart coverage

## Safety

Existing bootstrap and normal restart paths are unchanged when `--raftJoinMembers` is unset. Join mode rejects bootstrap flags, multi-group use, a missing or mismatched local member, and a local-only peer list. Same-ID replacement still requires fencing and an explicit remove, add-learner, catch-up, and promote sequence.

## Tests

- `go test . ./internal/raftengine/etcd -count=1`
- `go test . ./internal/raftengine/etcd -count=1 -run "TestResolveRaftPeerConfigJoinMembers|TestRaftJoin|TestFreshLearnerJoinPromotesAndRestartsFromPersistedMembership"`
- `golangci-lint run ./... --timeout=5m` with isolated caches: 0 issues
- `bash -n scripts/rolling-update.sh`
- `shellcheck scripts/rolling-update.sh`
- valid and invalid `RAFT_JOIN_NODE` dry runs

`go test ./... -p 1 -count=1 -timeout=20m` was also attempted, but the local host temporary volume returned `no space left on device`; the affected main-package tests pass in the package-level run above.