### PR TITLE
Refresh TLA+ tools checksum

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,35 +29,41 @@ TLA_LIB      := ../lib
 
 .PHONY: tla-check tla-tools
 
-tla-tools: $(TLA_JAR)
-
-$(TLA_JAR):
+tla-tools:
 	@mkdir -p $(dir $(TLA_JAR))
-	@echo "Downloading tla2tools.jar $(TLA_VERSION)..."
-	@curl -fsSL -o $(TLA_JAR).tmp $(TLA_URL)
-	@# Prefer sha256sum (GNU coreutils, universal on Linux); fall back to
-	@# shasum -a 256 (default on macOS).  Either yields the same hex
-	@# digest in the first whitespace-delimited field.
-	@if command -v sha256sum >/dev/null 2>&1; then \
-		actual=$$(sha256sum $(TLA_JAR).tmp | awk '{print $$1}'); \
-	elif command -v shasum >/dev/null 2>&1; then \
-		actual=$$(shasum -a 256 $(TLA_JAR).tmp | awk '{print $$1}'); \
-	else \
-		echo "ERROR: neither sha256sum nor shasum is available."; \
-		rm -f $(TLA_JAR).tmp; \
-		exit 1; \
+	@set -eu; \
+	sha256_file() { \
+		if command -v sha256sum >/dev/null 2>&1; then \
+			sha256sum "$$1" | awk '{print $$1}'; \
+		elif command -v shasum >/dev/null 2>&1; then \
+			shasum -a 256 "$$1" | awk '{print $$1}'; \
+		else \
+			echo "ERROR: neither sha256sum nor shasum is available." >&2; \
+			return 1; \
+		fi; \
+	}; \
+	actual=""; \
+	if [ -f "$(TLA_JAR)" ]; then actual=$$(sha256_file "$(TLA_JAR)"); fi; \
+	if [ "$$actual" = "$(TLA_SHA256)" ]; then \
+		echo "tla2tools.jar ready at $(TLA_JAR) (SHA-256 $(TLA_SHA256))"; \
+		exit 0; \
 	fi; \
+	echo "Downloading tla2tools.jar $(TLA_VERSION)..."; \
+	tmp="$(TLA_JAR).tmp.$$$$"; \
+	trap 'rm -f "$$tmp"' EXIT HUP INT TERM; \
+	curl -fsSL -o "$$tmp" "$(TLA_URL)"; \
+	actual=$$(sha256_file "$$tmp"); \
 	if [ "$$actual" != "$(TLA_SHA256)" ]; then \
 		echo "ERROR: tla2tools.jar SHA-256 mismatch."; \
 		echo "  expected: $(TLA_SHA256)"; \
 		echo "  actual:   $$actual"; \
-		rm -f $(TLA_JAR).tmp; \
 		exit 1; \
-	fi
-	@mv $(TLA_JAR).tmp $(TLA_JAR)
-	@echo "tla2tools.jar ready at $(TLA_JAR) (SHA-256 $(TLA_SHA256))"
+	fi; \
+	mv "$$tmp" "$(TLA_JAR)"; \
+	trap - EXIT HUP INT TERM; \
+	echo "tla2tools.jar ready at $(TLA_JAR) (SHA-256 $(TLA_SHA256))"
 
-tla-check: $(TLA_JAR)
+tla-check: tla-tools
 	@# Per-module orchestration lives in scripts/tla-check.sh so adding
 	@# M3..M5 only needs an entry in that script's TLA_MODULES array
 	@# and a `case` line for the gap-invariant string.  The script does


### PR DESCRIPTION
## Summary

- update the pinned SHA-256 for the current official `v1.8.0` `tla2tools.jar` release asset
- restore the TLA+ model-check workflow after the upstream prerelease asset was republished

## Verification

- GitHub release asset digest: `sha256:58d44845a37a8d776deaf8cf3a623213b59d311bc0ec287bcdfbe148dd11bb3d`
- `make tla-tools`
- `make tla-check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * TLA+ ツールの取得が「ダウンロードオンデマンド」になり、必要なときだけ準備されます。
  * キャッシュを再利用し、既存ツールが正しい場合は再ダウンロードを回避します。
  * SHA-256 によるチェックサム検証を行い、不整合時は再取得して安全に置き換えます。
  * `tla-check` 実行時にツール準備が自動で行われるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->