### PR TITLE
adapter: Retry forwarded transaction conflicts

### DIFF
--- a/adapter/redis_exec_dedup_test.go
+++ b/adapter/redis_exec_dedup_test.go
@@ -93,6 +93,7 @@ func TestExecDedup_GenuineConflictRebuildsAndApplies(t *testing.T) {
 	ctx := context.Background()
 	st := store.NewMVCCStore()
 	coord := newDedupTestCoordinator(st, 1, false) // attempt 1 errors without landing
+	coord.wireWriteConflicts = true                // forwarded conflict loses its typed chain
 	key := []byte("k")
 
 	// Before dispatch 2 (the reuse), inject a concurrent SET so the reuse

--- a/adapter/redis_list_dedup_test.go
+++ b/adapter/redis_list_dedup_test.go
@@ -3,11 +3,14 @@ package adapter
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/bootjp/elastickv/kv"
 	"github.com/bootjp/elastickv/store"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // dedupTestCoordinator drives the option-2 one-phase idempotency path
@@ -38,8 +41,13 @@ type dedupTestCoordinator struct {
 	// WITHOUT applying — an ambiguous retryable error distinct from
 	// WriteConflict, exercising the "advance pending.commitTS and retry" branch.
 	txnLockedAtDispatch int
-	dispatches          int
-	probeNoOps          int
+	// wireWriteConflicts converts every typed write conflict this test
+	// coordinator returns into the keyed gRPC status produced by leader
+	// forwarding. It exercises adapter-side type restoration without changing
+	// the underlying landed-vs-not-landed scenario.
+	wireWriteConflicts bool
+	dispatches         int
+	probeNoOps         int
 	// beforeDispatch, if set, runs at the start of each Dispatch with the
 	// 1-based dispatch number — lets a test inject a concurrent commit
 	// between the adapter's attempts.
@@ -65,7 +73,7 @@ func (c *dedupTestCoordinator) Dispatch(ctx context.Context, req *kv.OperationGr
 	}
 	if n == c.ambiguousDispatch && !c.ambiguousLands {
 		// OCC-style pre-reject: nothing is written, definitely did not land.
-		return nil, store.ErrWriteConflict
+		return nil, c.maybeWireWriteConflict(req, store.ErrWriteConflict)
 	}
 	if n == c.txnLockedAtDispatch {
 		// Ambiguous lock error, nothing written: definitely did not land.
@@ -73,20 +81,31 @@ func (c *dedupTestCoordinator) Dispatch(ctx context.Context, req *kv.OperationGr
 	}
 	resp, err := c.occAdapterCoordinator.Dispatch(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, c.maybeWireWriteConflict(req, err)
 	}
 	if n == c.ambiguousDispatch && c.ambiguousLands {
 		// The apply LANDED, but the adapter sees an ambiguous retryable error.
-		return nil, store.ErrWriteConflict
+		return nil, c.maybeWireWriteConflict(req, store.ErrWriteConflict)
 	}
 	if n == c.landThenWriteConflictAtDispatch {
 		// The apply LANDED, but leadership churn surfaces the commit as
 		// store.ErrWriteConflict — the original bug class. The adapter's
 		// self-inflicted-conflict guard must probe our just-committed
 		// commit_ts before treating this as a third-party conflict.
-		return nil, store.ErrWriteConflict
+		return nil, c.maybeWireWriteConflict(req, store.ErrWriteConflict)
 	}
 	return resp, nil
+}
+
+func (c *dedupTestCoordinator) maybeWireWriteConflict(req *kv.OperationGroup[kv.OP], err error) error {
+	if !c.wireWriteConflicts || !errors.Is(err, store.ErrWriteConflict) {
+		return err
+	}
+	key, ok := store.WriteConflictKey(err)
+	if !ok || len(key) == 0 {
+		key = minElemKey(req.Elems)
+	}
+	return status.Error(codes.Unknown, store.NewWriteConflictError(key).Error())
 }
 
 // maybeProbe mimics handleOnePhaseTxnRequest's exact-ts dedup check. It
@@ -206,6 +225,7 @@ func TestListPushDedup_GenuineConflictRecomputes(t *testing.T) {
 	ctx := context.Background()
 	st := store.NewMVCCStore()
 	coord := newDedupTestCoordinator(st, 1, false) // attempt 1 errors without landing
+	coord.wireWriteConflicts = true                // forwarded conflict loses its typed chain
 	key := []byte("mylist")
 	// Before the reuse (dispatch 2), simulate another client's RPUSH landing
 	// at seq 0 so the reuse conflicts and must recompute.

--- a/adapter/redis_lists.go
+++ b/adapter/redis_lists.go
@@ -223,6 +223,11 @@ func (r *RedisServer) dispatchListPushReuse(ctx context.Context, key []byte, pen
 	if dispErr == nil {
 		return r.resolveReuseLength(ctx, key, pending), false, nil
 	}
+	// This path owns an exact reusable write set plus PrevCommitTS, so it can
+	// safely opt in to retrying an otherwise-ambiguous forwarded conflict.
+	// Normalize before the typed conflict branch; generic Redis writes keep
+	// raw wire write conflicts fail-closed.
+	dispErr = normalizeRetryableRedisTxnErr(dispErr)
 	if errors.Is(dispErr, store.ErrWriteConflict) {
 		// Self-inflicted-conflict guard (codex P1): the apply might have
 		// landed at this fresh commitTS but bubbled up as WriteConflict due
@@ -422,6 +427,10 @@ func (r *RedisServer) listPushCoreWithDedup(ctx context.Context, key []byte, val
 			newLen = updatedMeta.Len
 			return nil
 		}
+		// Preserve the exact attempt for a forwarded conflict only after
+		// restoring its typed form. The next iteration can then reuse these
+		// operations instead of recomputing a second list append.
+		dispErr = normalizeRetryableRedisTxnErr(dispErr)
 		// Only remember the attempt for reuse if retryRedisWrite will actually
 		// loop — i.e. the error is one of WriteConflict / TxnLocked. For
 		// errors that escape the loop (transient-leader, context deadline,

--- a/adapter/redis_retry.go
+++ b/adapter/redis_retry.go
@@ -5,11 +5,14 @@ import (
 	"context"
 	"log/slog"
 	"math/rand/v2"
+	"strings"
 	"time"
 
 	"github.com/bootjp/elastickv/kv"
 	"github.com/bootjp/elastickv/store"
 	"github.com/cockroachdb/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -41,14 +44,55 @@ var (
 )
 
 func isRetryableRedisTxnErr(err error) bool {
-	return errors.Is(err, store.ErrWriteConflict) || errors.Is(err, kv.ErrTxnLocked)
+	return errors.Is(err, store.ErrWriteConflict) ||
+		errors.Is(err, kv.ErrTxnLocked) ||
+		wireRedisTxnErrKind(err) != redisTxnWireErrNone
 }
 
 func retryPolicyForRedisTxnErr(err error) redisTxnRetryPolicy {
-	if errors.Is(err, kv.ErrTxnLocked) {
+	if errors.Is(err, kv.ErrTxnLocked) || wireRedisTxnErrKind(err) == redisTxnWireErrLocked {
 		return redisTxnLockedRetryPolicy
 	}
 	return redisWriteConflictRetryPolicy
+}
+
+type redisTxnWireErrKind uint8
+
+const (
+	redisTxnWireErrNone redisTxnWireErrKind = iota
+	redisTxnWireErrWriteConflict
+	redisTxnWireErrLocked
+)
+
+// wireRedisTxnErrKind restores retry classification after an internal leader
+// redirect crosses gRPC. Forward currently returns transaction failures as a
+// codes.Unknown status, which strips the typed ErrWriteConflict / ErrTxnLocked
+// chain. Match only the exact server-generated key error envelope so unrelated
+// Unknown statuses that happen to mention a conflict remain terminal.
+func wireRedisTxnErrKind(err error) redisTxnWireErrKind {
+	type grpcStatusCarrier interface {
+		GRPCStatus() *status.Status
+	}
+	var carrier grpcStatusCarrier
+	if !errors.As(err, &carrier) {
+		return redisTxnWireErrNone
+	}
+	st := carrier.GRPCStatus()
+	if st == nil || (st.Code() != codes.Unknown && st.Code() != codes.Aborted) {
+		return redisTxnWireErrNone
+	}
+	msg := st.Message()
+	if !strings.HasPrefix(msg, "key: ") {
+		return redisTxnWireErrNone
+	}
+	switch {
+	case strings.HasSuffix(msg, ": "+store.ErrWriteConflict.Error()):
+		return redisTxnWireErrWriteConflict
+	case strings.HasSuffix(msg, ": "+kv.ErrTxnLocked.Error()):
+		return redisTxnWireErrLocked
+	default:
+		return redisTxnWireErrNone
+	}
 }
 
 func waitRedisRetryBackoff(ctx context.Context, delay time.Duration) bool {

--- a/adapter/redis_retry.go
+++ b/adapter/redis_retry.go
@@ -64,31 +64,67 @@ const (
 	redisTxnWireErrLocked
 )
 
-// wireRedisTxnErrKind restores retry classification after an internal leader
-// redirect crosses gRPC. Forward currently returns transaction failures as a
-// codes.Unknown status, which strips the typed ErrWriteConflict / ErrTxnLocked
-// chain. Match only the exact server-generated key error envelope so unrelated
-// Unknown statuses that happen to mention a conflict remain terminal.
-func wireRedisTxnErrKind(err error) redisTxnWireErrKind {
+// parseWireRedisTxnErr restores transaction error typing after an internal
+// leader redirect crosses gRPC. Forward currently returns transaction failures
+// as a status, which strips the typed ErrWriteConflict / ErrTxnLocked chain.
+// Match only the exact server-generated key error envelope and normalize the
+// storage key before rebuilding the typed error so terminal retry paths cannot
+// expose the internal key layout to Redis clients.
+func wireRedisTxnStatus(err error) (*status.Status, bool) {
 	type grpcStatusCarrier interface {
 		GRPCStatus() *status.Status
 	}
 	var carrier grpcStatusCarrier
 	if !errors.As(err, &carrier) {
-		return redisTxnWireErrNone
+		return nil, false
 	}
 	st := carrier.GRPCStatus()
 	if st == nil || (st.Code() != codes.Unknown && st.Code() != codes.Aborted) {
-		return redisTxnWireErrNone
+		return nil, false
+	}
+	return st, true
+}
+
+func parseWireRedisTxnErr(err error) error {
+	st, ok := wireRedisTxnStatus(err)
+	if !ok {
+		return nil
 	}
 	msg := st.Message()
 	if !strings.HasPrefix(msg, "key: ") {
-		return redisTxnWireErrNone
+		return nil
 	}
+
+	if content, ok := strings.CutSuffix(strings.TrimPrefix(msg, "key: "), ": "+store.ErrWriteConflict.Error()); ok {
+		logicalKey := normalizeRetryableRedisTxnKey([]byte(content))
+		return errors.WithStack(store.NewWriteConflictError(logicalKey))
+	}
+
+	content, ok := strings.CutSuffix(strings.TrimPrefix(msg, "key: "), ": "+kv.ErrTxnLocked.Error())
+	if !ok {
+		return nil
+	}
+	keyText := content
+	detail := ""
+	if strings.HasSuffix(content, ")") {
+		if detailStart := strings.LastIndex(content, " ("); detailStart >= 0 {
+			keyText = content[:detailStart]
+			detail = content[detailStart+2 : len(content)-1]
+		}
+	}
+	logicalKey := normalizeRetryableRedisTxnKey([]byte(keyText))
+	if detail != "" {
+		return errors.WithStack(kv.NewTxnLockedErrorWithDetail(logicalKey, detail))
+	}
+	return errors.WithStack(kv.NewTxnLockedError(logicalKey))
+}
+
+func wireRedisTxnErrKind(err error) redisTxnWireErrKind {
+	parsed := parseWireRedisTxnErr(err)
 	switch {
-	case strings.HasSuffix(msg, ": "+store.ErrWriteConflict.Error()):
+	case errors.Is(parsed, store.ErrWriteConflict):
 		return redisTxnWireErrWriteConflict
-	case strings.HasSuffix(msg, ": "+kv.ErrTxnLocked.Error()):
+	case errors.Is(parsed, kv.ErrTxnLocked):
 		return redisTxnWireErrLocked
 	default:
 		return redisTxnWireErrNone
@@ -151,6 +187,9 @@ func (r *RedisServer) retryRedisWrite(ctx context.Context, fn func() error) erro
 }
 
 func normalizeRetryableRedisTxnErr(err error) error {
+	if parsed := parseWireRedisTxnErr(err); parsed != nil {
+		return parsed
+	}
 	if key, detail, ok := kv.TxnLockedDetails(err); ok {
 		logicalKey := normalizeRetryableRedisTxnKey(key)
 		if len(logicalKey) == 0 || bytes.Equal(logicalKey, key) {

--- a/adapter/redis_retry.go
+++ b/adapter/redis_retry.go
@@ -46,7 +46,7 @@ var (
 func isRetryableRedisTxnErr(err error) bool {
 	return errors.Is(err, store.ErrWriteConflict) ||
 		errors.Is(err, kv.ErrTxnLocked) ||
-		wireRedisTxnErrKind(err) != redisTxnWireErrNone
+		wireRedisTxnErrKind(err) == redisTxnWireErrLocked
 }
 
 func retryPolicyForRedisTxnErr(err error) redisTxnRetryPolicy {
@@ -68,8 +68,11 @@ const (
 // leader redirect crosses gRPC. Forward currently returns transaction failures
 // as a status, which strips the typed ErrWriteConflict / ErrTxnLocked chain.
 // Match only the exact server-generated key error envelope and normalize the
-// storage key before rebuilding the typed error so terminal retry paths cannot
-// expose the internal key layout to Redis clients.
+// storage key before rebuilding the typed error. Wire write conflicts are not
+// generally retryable: a lost forwarding response can turn an already-applied
+// write into a later self-conflict. Reuse-aware callers explicitly normalize
+// them before retrying; all other callers return the normalized error without
+// replaying the operation or exposing the internal key layout.
 func wireRedisTxnStatus(err error) (*status.Status, bool) {
 	type grpcStatusCarrier interface {
 		GRPCStatus() *status.Status
@@ -168,11 +171,17 @@ func (r *RedisServer) retryRedisWrite(ctx context.Context, fn func() error) erro
 		if err == nil {
 			return nil
 		}
-		if !isRetryableRedisTxnErr(err) {
+		// Classify the original transport shape before normalization. A wire
+		// write conflict is ambiguous — the forwarded apply may already have
+		// landed — so the generic loop must return it without replaying. Wire
+		// TxnLocked remains retryable because the lock rejection did not apply
+		// the transaction. Reuse-aware callers convert wire conflicts to typed
+		// errors before returning them here.
+		retryable := isRetryableRedisTxnErr(err)
+		err = normalizeRetryableRedisTxnErr(err)
+		if !retryable {
 			return err
 		}
-
-		err = normalizeRetryableRedisTxnErr(err)
 		nextPolicy := retryPolicyForRedisTxnErr(err)
 		if attempt == 0 || nextPolicy != policy {
 			backoff = nextPolicy.initialBackoff

--- a/adapter/redis_retry.go
+++ b/adapter/redis_retry.go
@@ -106,6 +106,10 @@ func parseWireRedisTxnErr(err error) error {
 	}
 	keyText := content
 	detail := ""
+	// TxnLockedError's wire format does not escape the key/detail boundary.
+	// A foreign key containing " (" and ending in ")" is therefore ambiguous;
+	// splitting at the last delimiter preserves the server format, and any
+	// ambiguity affects only the reconstructed display fields, not retry typing.
 	if strings.HasSuffix(content, ")") {
 		if detailStart := strings.LastIndex(content, " ("); detailStart >= 0 {
 			keyText = content[:detailStart]

--- a/adapter/redis_retry_test.go
+++ b/adapter/redis_retry_test.go
@@ -388,6 +388,71 @@ func TestRetryRedisWriteDoesNotRetryUnclassifiedWireErrors(t *testing.T) {
 	}
 }
 
+func TestRetryRedisWriteDoesNotLeakWireInternalKeyAtRetryLimit(t *testing.T) {
+	internalKey := store.StreamEntryKey([]byte("retry:stream"), 1, 2)
+	wireErr := errors.WithStack(status.Error(codes.Unknown,
+		store.NewWriteConflictError(internalKey).Error()))
+	attempts := 0
+	srv := &RedisServer{}
+
+	err := srv.retryRedisWrite(context.Background(), func() error {
+		attempts++
+		return wireErr
+	})
+
+	require.ErrorIs(t, err, store.ErrWriteConflict)
+	require.ErrorContains(t, err, "redis txn retry limit exceeded")
+	require.ErrorContains(t, err, "key: retry:stream")
+	require.NotContains(t, err.Error(), store.StreamEntryPrefix)
+	require.Equal(t, redisTxnRetryMaxAttempts+1, attempts)
+}
+
+func TestNormalizeRetryableRedisTxnErrWireErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		wireErr          error
+		wantSentinel     error
+		wantKey          string
+		wantDetail       string
+		internalKeyToken string
+	}{
+		{
+			name: "write conflict",
+			wireErr: errors.WithStack(status.Error(codes.Unknown,
+				store.NewWriteConflictError(store.StreamEntryKey([]byte("retry:stream"), 1, 2)).Error())),
+			wantSentinel:     store.ErrWriteConflict,
+			wantKey:          "retry:stream",
+			internalKeyToken: store.StreamEntryPrefix,
+		},
+		{
+			name: "transaction locked with detail",
+			wireErr: errors.WithStack(status.Error(codes.Aborted,
+				kv.NewTxnLockedErrorWithDetail(store.ListItemKey([]byte("retry:list"), 2), "timestamp overflow").Error())),
+			wantSentinel:     kv.ErrTxnLocked,
+			wantKey:          "retry:list",
+			wantDetail:       "timestamp overflow",
+			internalKeyToken: store.ListItemPrefix,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			normalized := normalizeRetryableRedisTxnErr(tt.wireErr)
+
+			require.ErrorIs(t, normalized, tt.wantSentinel)
+			require.ErrorContains(t, normalized, "key: "+tt.wantKey)
+			if tt.wantDetail != "" {
+				require.ErrorContains(t, normalized, tt.wantDetail)
+			}
+			require.NotContains(t, normalized.Error(), tt.internalKeyToken)
+		})
+	}
+}
+
 func TestNormalizeRetryableRedisTxnErrListKey(t *testing.T) {
 	t.Parallel()
 

--- a/adapter/redis_retry_test.go
+++ b/adapter/redis_retry_test.go
@@ -301,13 +301,13 @@ func TestRedisXAddRetriesWireWriteConflict(t *testing.T) {
 	t.Parallel()
 
 	st := store.NewMVCCStore()
-	coord := newRetryOnceCoordinator(st)
-	coord.firstErr = errors.WithStack(status.Error(codes.Unknown,
-		store.NewWriteConflictError(store.StreamEntryKey([]byte("retry:stream"), 1, 2)).Error()))
+	coord := newDedupTestCoordinator(st, 1, false)
+	coord.wireWriteConflicts = true
 	srv := &RedisServer{
-		store:       st,
-		coordinator: coord,
-		scriptCache: map[string]string{},
+		store:            st,
+		coordinator:      coord,
+		scriptCache:      map[string]string{},
+		onePhaseTxnDedup: true,
 	}
 	conn := &recordingConn{}
 
@@ -324,47 +324,79 @@ func TestRedisXAddRetriesWireWriteConflict(t *testing.T) {
 	require.Equal(t, int64(1), meta.Length)
 }
 
-func TestRetryRedisWriteRetriesWireTransactionErrors(t *testing.T) {
+func TestRedisXAddDedupsLandedWireWriteConflict(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name       string
-		wireErr    error
-		wantPolicy redisTxnRetryPolicy
-	}{
-		{
-			name: "write conflict",
-			wireErr: errors.WithStack(status.Error(codes.Unknown,
-				store.NewWriteConflictError(store.StreamEntryKey([]byte("stream-lat"), 1, 2)).Error())),
-			wantPolicy: redisWriteConflictRetryPolicy,
-		},
-		{
-			name: "transaction locked",
-			wireErr: errors.WithStack(status.Error(codes.Aborted,
-				kv.NewTxnLockedError(store.ListItemKey([]byte("list"), 1)).Error())),
-			wantPolicy: redisTxnLockedRetryPolicy,
-		},
+	st := store.NewMVCCStore()
+	coord := newDedupTestCoordinator(st, 1, true)
+	coord.wireWriteConflicts = true
+	srv := &RedisServer{
+		store:            st,
+		coordinator:      coord,
+		scriptCache:      map[string]string{},
+		onePhaseTxnDedup: true,
 	}
+	conn := &recordingConn{}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+	srv.xadd(conn, redcon.Command{Args: [][]byte{
+		[]byte(cmdXAdd), []byte("retry:stream"), []byte("*"), []byte("field"), []byte("value"),
+	}})
 
-			attempts := 0
-			srv := &RedisServer{}
-			err := srv.retryRedisWrite(context.Background(), func() error {
-				attempts++
-				if attempts == 1 {
-					return tt.wireErr
-				}
-				return nil
-			})
+	require.Empty(t, conn.err)
+	require.NotEmpty(t, conn.bulk)
+	require.Equal(t, 2, coord.dispatches, "ambiguous apply plus exact-ts reuse probe")
+	require.Equal(t, 1, coord.probeNoOps, "reuse must observe the landed first attempt")
+	meta, found, err := srv.loadStreamMetaAt(context.Background(), []byte("retry:stream"), snapshotTS(coord.Clock(), st))
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, int64(1), meta.Length, "the generated XADD entry must not be appended twice")
+}
 
-			require.NoError(t, err)
-			require.Equal(t, 2, attempts)
-			require.Equal(t, tt.wantPolicy, retryPolicyForRedisTxnErr(tt.wireErr))
-		})
+func TestRedisXAddDedupDisabledDoesNotReplayLandedWireConflict(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	coord := newDedupTestCoordinator(st, 1, true)
+	coord.wireWriteConflicts = true
+	srv := &RedisServer{
+		store:       st,
+		coordinator: coord,
+		scriptCache: map[string]string{},
 	}
+	conn := &recordingConn{}
+
+	srv.xadd(conn, redcon.Command{Args: [][]byte{
+		[]byte(cmdXAdd), []byte("retry:stream"), []byte("*"), []byte("field"), []byte("value"),
+	}})
+
+	require.NotEmpty(t, conn.err)
+	require.Contains(t, conn.err, "key: retry:stream")
+	require.NotContains(t, conn.err, store.StreamEntryPrefix)
+	require.Equal(t, 1, coord.dispatches, "unsafe legacy path must fail closed instead of replaying XADD")
+	meta, found, err := srv.loadStreamMetaAt(context.Background(), []byte("retry:stream"), snapshotTS(coord.Clock(), st))
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, int64(1), meta.Length)
+}
+
+func TestRetryRedisWriteRetriesWireTxnLocked(t *testing.T) {
+	t.Parallel()
+
+	wireErr := errors.WithStack(status.Error(codes.Aborted,
+		kv.NewTxnLockedError(store.ListItemKey([]byte("list"), 1)).Error()))
+	attempts := 0
+	srv := &RedisServer{}
+	err := srv.retryRedisWrite(context.Background(), func() error {
+		attempts++
+		if attempts == 1 {
+			return wireErr
+		}
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 2, attempts)
+	require.Equal(t, redisTxnLockedRetryPolicy, retryPolicyForRedisTxnErr(wireErr))
 }
 
 func TestRetryRedisWriteDoesNotRetryUnclassifiedWireErrors(t *testing.T) {
@@ -393,7 +425,7 @@ func TestRetryRedisWriteDoesNotRetryUnclassifiedWireErrors(t *testing.T) {
 	}
 }
 
-func TestRetryRedisWriteDoesNotLeakWireInternalKeyAtRetryLimit(t *testing.T) {
+func TestRetryRedisWriteDoesNotReplayOrLeakWireWriteConflict(t *testing.T) {
 	internalKey := store.StreamEntryKey([]byte("retry:stream"), 1, 2)
 	wireErr := errors.WithStack(status.Error(codes.Unknown,
 		store.NewWriteConflictError(internalKey).Error()))
@@ -406,10 +438,10 @@ func TestRetryRedisWriteDoesNotLeakWireInternalKeyAtRetryLimit(t *testing.T) {
 	})
 
 	require.ErrorIs(t, err, store.ErrWriteConflict)
-	require.ErrorContains(t, err, "redis txn retry limit exceeded")
 	require.ErrorContains(t, err, "key: retry:stream")
+	require.NotContains(t, err.Error(), "redis txn retry limit exceeded")
 	require.NotContains(t, err.Error(), store.StreamEntryPrefix)
-	require.Equal(t, redisTxnRetryMaxAttempts+1, attempts)
+	require.Equal(t, 1, attempts)
 }
 
 func TestNormalizeRetryableRedisTxnErrWireErrors(t *testing.T) {

--- a/adapter/redis_retry_test.go
+++ b/adapter/redis_retry_test.go
@@ -370,21 +370,26 @@ func TestRetryRedisWriteRetriesWireTransactionErrors(t *testing.T) {
 func TestRetryRedisWriteDoesNotRetryUnclassifiedWireErrors(t *testing.T) {
 	t.Parallel()
 
-	tests := []error{
-		status.Error(codes.Unknown, "write conflict"),
-		status.Error(codes.Unknown, "key: user-visible failure"),
-		status.Error(codes.Internal, "key: k: write conflict"),
+	tests := []struct {
+		name    string
+		wireErr error
+	}{
+		{name: "plain unknown", wireErr: status.Error(codes.Unknown, "write conflict")},
+		{name: "unknown non-matching envelope", wireErr: status.Error(codes.Unknown, "key: user-visible failure")},
+		{name: "internal code with matching message", wireErr: status.Error(codes.Internal, "key: k: write conflict")},
 	}
-	for _, wireErr := range tests {
-		attempts := 0
-		srv := &RedisServer{}
-		err := srv.retryRedisWrite(context.Background(), func() error {
-			attempts++
-			return wireErr
-		})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attempts := 0
+			srv := &RedisServer{}
+			err := srv.retryRedisWrite(context.Background(), func() error {
+				attempts++
+				return tt.wireErr
+			})
 
-		require.ErrorIs(t, err, wireErr)
-		require.Equal(t, 1, attempts)
+			require.ErrorIs(t, err, tt.wireErr)
+			require.Equal(t, 1, attempts)
+		})
 	}
 }
 

--- a/adapter/redis_retry_test.go
+++ b/adapter/redis_retry_test.go
@@ -12,25 +12,29 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/redcon"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type retryOnceCoordinator struct {
 	store      store.MVCCStore
 	clock      *kv.HLC
 	dispatches int
+	firstErr   error
 }
 
 func newRetryOnceCoordinator(st store.MVCCStore) *retryOnceCoordinator {
 	return &retryOnceCoordinator{
-		store: st,
-		clock: kv.NewHLC(),
+		store:    st,
+		clock:    kv.NewHLC(),
+		firstErr: store.ErrWriteConflict,
 	}
 }
 
 func (c *retryOnceCoordinator) Dispatch(ctx context.Context, reqs *kv.OperationGroup[kv.OP]) (*kv.CoordinateResponse, error) {
 	c.dispatches++
 	if c.dispatches == 1 {
-		return nil, store.ErrWriteConflict
+		return nil, c.firstErr
 	}
 
 	ts := c.clock.Next()
@@ -291,6 +295,97 @@ func TestRedisEvalRetriesWriteConflict(t *testing.T) {
 	value, _, err := decodeRedisStr(rawValue)
 	require.NoError(t, err)
 	require.Equal(t, []byte("v1"), value)
+}
+
+func TestRedisXAddRetriesWireWriteConflict(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	coord := newRetryOnceCoordinator(st)
+	coord.firstErr = errors.WithStack(status.Error(codes.Unknown,
+		store.NewWriteConflictError(store.StreamEntryKey([]byte("retry:stream"), 1, 2)).Error()))
+	srv := &RedisServer{
+		store:       st,
+		coordinator: coord,
+		scriptCache: map[string]string{},
+	}
+	conn := &recordingConn{}
+
+	srv.xadd(conn, redcon.Command{Args: [][]byte{
+		[]byte(cmdXAdd), []byte("retry:stream"), []byte("*"), []byte("field"), []byte("value"),
+	}})
+
+	require.Empty(t, conn.err)
+	require.NotEmpty(t, conn.bulk)
+	require.Equal(t, 2, coord.dispatches)
+	meta, found, err := srv.loadStreamMetaAt(context.Background(), []byte("retry:stream"), snapshotTS(coord.clock, st))
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, int64(1), meta.Length)
+}
+
+func TestRetryRedisWriteRetriesWireTransactionErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		wireErr    error
+		wantPolicy redisTxnRetryPolicy
+	}{
+		{
+			name: "write conflict",
+			wireErr: errors.WithStack(status.Error(codes.Unknown,
+				store.NewWriteConflictError(store.StreamEntryKey([]byte("stream-lat"), 1, 2)).Error())),
+			wantPolicy: redisWriteConflictRetryPolicy,
+		},
+		{
+			name: "transaction locked",
+			wireErr: errors.WithStack(status.Error(codes.Aborted,
+				kv.NewTxnLockedError(store.ListItemKey([]byte("list"), 1)).Error())),
+			wantPolicy: redisTxnLockedRetryPolicy,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			attempts := 0
+			srv := &RedisServer{}
+			err := srv.retryRedisWrite(context.Background(), func() error {
+				attempts++
+				if attempts == 1 {
+					return tt.wireErr
+				}
+				return nil
+			})
+
+			require.NoError(t, err)
+			require.Equal(t, 2, attempts)
+			require.Equal(t, tt.wantPolicy, retryPolicyForRedisTxnErr(tt.wireErr))
+		})
+	}
+}
+
+func TestRetryRedisWriteDoesNotRetryUnclassifiedWireErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []error{
+		status.Error(codes.Unknown, "write conflict"),
+		status.Error(codes.Unknown, "key: user-visible failure"),
+		status.Error(codes.Internal, "key: k: write conflict"),
+	}
+	for _, wireErr := range tests {
+		attempts := 0
+		srv := &RedisServer{}
+		err := srv.retryRedisWrite(context.Background(), func() error {
+			attempts++
+			return wireErr
+		})
+
+		require.ErrorIs(t, err, wireErr)
+		require.Equal(t, 1, attempts)
+	}
 }
 
 func TestNormalizeRetryableRedisTxnErrListKey(t *testing.T) {

--- a/adapter/redis_stream_cmds.go
+++ b/adapter/redis_stream_cmds.go
@@ -215,10 +215,15 @@ func (r *RedisServer) xadd(conn redcon.Conn, cmd redcon.Command) {
 	ctx, cancel := context.WithTimeout(r.handlerContext(), redisDispatchTimeout)
 	defer cancel()
 	var id string
-	if err := r.retryRedisWrite(ctx, func() error {
-		id, err = r.xaddTxn(ctx, cmd.Args[1], req)
-		return err
-	}); err != nil {
+	if r.onePhaseTxnDedup {
+		id, err = r.xaddTxnWithDedup(ctx, cmd.Args[1], req)
+	} else {
+		err = r.retryRedisWrite(ctx, func() error {
+			id, err = r.xaddTxn(ctx, cmd.Args[1], req)
+			return err
+		})
+	}
+	if err != nil {
 		writeRedisError(conn, err)
 		return
 	}
@@ -226,34 +231,50 @@ func (r *RedisServer) xadd(conn redcon.Conn, cmd redcon.Command) {
 }
 
 func (r *RedisServer) xaddTxn(ctx context.Context, key []byte, req xaddRequest) (string, error) {
+	id, readTS, elems, err := r.prepareXAdd(ctx, key, req)
+	if err != nil {
+		return "", err
+	}
+	return id, r.dispatchAndSignalStream(ctx, true, readTS, elems, key)
+}
+
+// prepareXAdd fixes one XADD attempt's stream ID and exact write set at a
+// single read snapshot. The dedup path retains this result across retries so a
+// forwarded ambiguous conflict cannot resolve "*" again and append a second
+// entry after the first attempt already landed.
+func (r *RedisServer) prepareXAdd(
+	ctx context.Context,
+	key []byte,
+	req xaddRequest,
+) (string, uint64, []*kv.Elem[kv.OP], error) {
 	readTS := r.readTS()
 	typ, err := r.streamTypeForXAdd(ctx, key, readTS)
 	if err != nil {
-		return "", err
+		return "", 0, nil, err
 	}
 
 	legacyCleanup, meta, metaFound, err := r.streamWriteBase(ctx, key, readTS)
 	if err != nil {
-		return "", err
+		return "", 0, nil, err
 	}
 	legacyCleanup, meta, metaFound, err = r.streamCleanupForExpiredRecreate(
 		ctx, key, readTS, typ, legacyCleanup, meta, metaFound)
 	if err != nil {
-		return "", err
+		return "", 0, nil, err
 	}
 
 	id, parsedID, err := resolveXAddID(meta, metaFound, req.id)
 	if err != nil {
-		return "", err
+		return "", 0, nil, err
 	}
 
 	if err := xaddEnforceMaxWideColumn(key, meta.Length, req.maxLen); err != nil {
-		return "", err
+		return "", 0, nil, err
 	}
 
 	entryValue, err := marshalStreamEntry(newRedisStreamEntry(id, req.fields))
 	if err != nil {
-		return "", err
+		return "", 0, nil, err
 	}
 
 	// Capacity hint covers: stream cleanup Dels + one entry Put + one meta
@@ -272,7 +293,7 @@ func (r *RedisServer) xaddTxn(ctx context.Context, key []byte, req xaddRequest) 
 
 	nextLen, trim, err := r.xaddTrimIfNeeded(ctx, key, readTS, req.maxLen, meta.Length+1)
 	if err != nil {
-		return "", err
+		return "", 0, nil, err
 	}
 	elems = append(elems, trim...)
 	elems = appendMaxLenZeroSelfDel(elems, req.maxLen, key, parsedID)
@@ -284,11 +305,147 @@ func (r *RedisServer) xaddTxn(ctx context.Context, key []byte, req xaddRequest) 
 		ExpireAt: meta.ExpireAt,
 	})
 	if err != nil {
-		return "", cockerrors.WithStack(err)
+		return "", 0, nil, cockerrors.WithStack(err)
 	}
 	elems = append(elems, &kv.Elem[kv.OP]{Op: kv.Put, Key: store.StreamMetaKey(key), Value: metaBytes})
 
-	return id, r.dispatchAndSignalStream(ctx, true, readTS, elems, key)
+	return id, readTS, elems, nil
+}
+
+// reusableXAdd captures the exact ID and write set from an XADD attempt. A
+// retry carries commitTS as PrevCommitTS so the FSM can no-op when that attempt
+// already landed instead of resolving "*" against newer stream metadata and
+// appending a duplicate entry.
+type reusableXAdd struct {
+	elems    []*kv.Elem[kv.OP]
+	startTS  uint64
+	commitTS uint64
+	probeKey []byte
+	id       string
+}
+
+// xaddTxnWithDedup retries XADD only through exact write-set reuse. This is the
+// opt-in counterpart to retryRedisWrite's fail-closed treatment of raw wire
+// write conflicts: the retained write set and PrevCommitTS make a retry safe
+// even when the forwarded response was lost after the leader applied it.
+func (r *RedisServer) xaddTxnWithDedup(ctx context.Context, key []byte, req xaddRequest) (string, error) {
+	var id string
+	var pending *reusableXAdd
+	err := r.retryRedisWrite(ctx, func() error {
+		if pending != nil {
+			nextID, drop, reuseErr := r.dispatchXAddReuse(ctx, key, pending)
+			if drop {
+				pending = nil
+			}
+			if reuseErr != nil {
+				return reuseErr
+			}
+			id = nextID
+			return nil
+		}
+
+		nextID, next, firstErr := r.firstXAddAttempt(ctx, key, req)
+		if next != nil {
+			pending = next
+		}
+		if firstErr != nil {
+			return firstErr
+		}
+		id = nextID
+		return nil
+	})
+	return id, err
+}
+
+func (r *RedisServer) firstXAddAttempt(
+	ctx context.Context,
+	key []byte,
+	req xaddRequest,
+) (string, *reusableXAdd, error) {
+	id, readTS, elems, err := r.prepareXAdd(ctx, key, req)
+	if err != nil {
+		return "", nil, err
+	}
+	startTS := normalizeStartTS(readTS)
+	commitTS, err := r.nextCommitTSAfter(ctx, startTS, "redis xadd first-attempt: allocate commitTS")
+	if err != nil {
+		return "", nil, cockerrors.WithStack(err)
+	}
+	_, dispErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+		IsTxn:    true,
+		StartTS:  startTS,
+		CommitTS: commitTS,
+		Elems:    elems,
+	})
+	if dispErr == nil {
+		r.streamWaiters.Signal(key)
+		return id, nil, nil
+	}
+
+	// This path owns the exact ID and write set, so it can safely restore a
+	// forwarded conflict to its typed form before entering retryRedisWrite.
+	dispErr = normalizeRetryableRedisTxnErr(dispErr)
+	if !isRetryableRedisTxnErr(dispErr) {
+		return "", nil, cockerrors.WithStack(dispErr)
+	}
+	return "", &reusableXAdd{
+		elems:    elems,
+		startTS:  startTS,
+		commitTS: commitTS,
+		probeKey: kv.PrimaryKeyForElems(elems),
+		id:       id,
+	}, cockerrors.WithStack(dispErr)
+}
+
+// dispatchXAddReuse re-dispatches one captured XADD write set. A conflict on
+// the fresh commitTS is probed before pending is dropped: if the apply landed,
+// returning success is the only outcome that avoids appending the same logical
+// request again; if it did not land, a fresh snapshot may safely recompute.
+func (r *RedisServer) dispatchXAddReuse(
+	ctx context.Context,
+	key []byte,
+	pending *reusableXAdd,
+) (id string, drop bool, err error) {
+	commitTS, allocErr := r.nextCommitTSAfter(ctx, pending.startTS, "redis xadd reuse: allocate commitTS")
+	if allocErr != nil {
+		return "", false, cockerrors.WithStack(allocErr)
+	}
+	_, dispErr := r.coordinator.Dispatch(ctx, &kv.OperationGroup[kv.OP]{
+		IsTxn:        true,
+		StartTS:      pending.startTS,
+		CommitTS:     commitTS,
+		PrevCommitTS: pending.commitTS,
+		Elems:        pending.elems,
+	})
+	if dispErr == nil {
+		r.streamWaiters.Signal(key)
+		return pending.id, false, nil
+	}
+
+	dispErr = normalizeRetryableRedisTxnErr(dispErr)
+	if errors.Is(dispErr, store.ErrWriteConflict) {
+		if len(pending.probeKey) == 0 {
+			return "", false, cockerrors.Wrap(dispErr, "redis xadd reuse: missing dedup probe key")
+		}
+		landed, probeErr := r.store.CommittedVersionAt(ctx, pending.probeKey, commitTS)
+		if probeErr != nil {
+			// Whether this reuse applied is unknowable. Fail closed rather than
+			// recompute and risk a duplicate append.
+			return "", false, cockerrors.Wrap(probeErr, "redis xadd reuse: self-conflict probe")
+		}
+		if landed {
+			pending.commitTS = commitTS
+			r.streamWaiters.Signal(key)
+			return pending.id, false, nil
+		}
+		return "", true, cockerrors.WithStack(dispErr)
+	}
+	if isRetryableRedisTxnErr(dispErr) {
+		// A lock response did not apply, but carrying the fresh commitTS keeps
+		// the retry correct if a future retryable transport shape is added.
+		pending.commitTS = commitTS
+	}
+	return "", false, cockerrors.WithStack(dispErr)
 }
 
 func redisTTLMillisExpired(ttlMs uint64) bool {

--- a/adapter/redis_txn.go
+++ b/adapter/redis_txn.go
@@ -2489,6 +2489,11 @@ func (r *RedisServer) dispatchExecReuse(ctx context.Context, pending *reusableEx
 	if dispErr == nil {
 		return pending.results, false, nil
 	}
+	// This path owns an exact reusable write set plus PrevCommitTS, so it can
+	// safely opt in to retrying an otherwise-ambiguous forwarded conflict.
+	// Normalize before the typed conflict branch; the generic retry loop keeps
+	// raw wire write conflicts fail-closed for callers without this protection.
+	dispErr = normalizeRetryableRedisTxnErr(dispErr)
 	if errors.Is(dispErr, store.ErrWriteConflict) {
 		// Self-inflicted-conflict guard (mirrors dispatchListPushReuse):
 		// the apply might have landed at this fresh commitTS but bubbled
@@ -2643,6 +2648,10 @@ func (r *RedisServer) firstExecAttempt(dispatchCtx context.Context, queue []redc
 		ReadKeys: prepared.readKeys,
 	}
 	if _, dispErr := r.coordinator.Dispatch(prepared.ctx, group); dispErr != nil {
+		// Preserve the exact attempt for a forwarded conflict only after
+		// restoring its typed form. runTransactionWithDedup can then reuse this
+		// write set instead of replaying the EXEC body from a new snapshot.
+		dispErr = normalizeRetryableRedisTxnErr(dispErr)
 		// Only remember the attempt for reuse if retryRedisWrite will
 		// actually loop. Mirrors listPushCoreWithDedup's gating
 		// rationale — errors that escape the loop (transient-leader,


### PR DESCRIPTION
## Summary

- restore transaction-error typing after internal gRPC leader forwarding
- normalize internal storage keys before returning Redis errors
- retry forwarded write conflicts only through exact write-set reuse for XADD, MULTI/EXEC, and list push
- keep raw forwarded write conflicts fail-closed for callers without dedup state
- add regression coverage for landed, non-landed, and genuine-conflict retry outcomes

## Root cause

Internal leader forwarding converts typed transaction errors into gRPC statuses. The Redis retry layer originally recognized only the typed error chain, so a forwarded conflict could escape instead of being handled.

Blindly making every forwarded write conflict retryable is unsafe: if the leader applied an operation but its response was lost, a later forwarded self-conflict is ambiguous. Recomputing XADD with `*` can then append a second entry, while EXEC and list-push reuse paths can retain stale pending state unless the wire error is normalized before their typed conflict handling.

## Behavior

- Wire `TxnLocked` errors remain retryable because the lock rejection did not apply the transaction.
- Generic wire `WriteConflict` errors are normalized and returned without replay.
- Dedup-enabled XADD captures the generated ID and exact write set, then retries with `PrevCommitTS`.
- EXEC and list-push normalize wire conflicts before reuse conflict probing and stale-state invalidation.
- The dedup-disabled rollback path fails closed after one ambiguous wire conflict.

## Risk

Wire parsing remains restricted to `Unknown` or `Aborted` statuses with the exact server-generated keyed envelope. Retry promotion is limited to operations that retain an exact write set and use the one-phase exact-timestamp probe.

## Validation

- `go test -race ./adapter -run '^(TestRedisXAddRetriesWireWriteConflict|TestRedisXAddDedupsLandedWireWriteConflict|TestRedisXAddDedupDisabledDoesNotReplayLandedWireConflict|TestRetryRedisWriteRetriesWireTxnLocked|TestRetryRedisWriteDoesNotRetryUnclassifiedWireErrors|TestRetryRedisWriteDoesNotReplayOrLeakWireWriteConflict|TestNormalizeRetryableRedisTxnErrWireErrors|TestListPushDedup_GenuineConflictRecomputes|TestExecDedup_GenuineConflictRebuildsAndApplies)$' -count=10`
- `go test ./adapter`
- `go test ./...`
- `golangci-lint run ./... --timeout=5m`
