### PR TITLE
raft: add streaming multi-group soak evidence

### DIFF
--- a/cmd/elastickv-raft-stream-soak/main.go
+++ b/cmd/elastickv-raft-stream-soak/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/bootjp/elastickv/internal/raftengine/etcd/transportsoak"
+	"github.com/cockroachdb/errors"
+)
+
+const defaultSoakTimeout = 2 * time.Minute
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	defaults := transportsoak.DefaultConfig()
+	groups := flag.Int("groups", defaults.Groups, "number of concurrent transport groups")
+	nodes := flag.Int("nodes", defaults.NodesPerGroup, "number of TCP endpoints per group")
+	messages := flag.Int("messages-per-link", defaults.MessagesPerLink, "steady messages per directed peer link")
+	regularBytes := flag.Int("regular-payload-bytes", defaults.RegularPayloadBytes, "steady MsgApp payload bytes")
+	backpressureBytes := flag.Int("backpressure-payload-bytes", defaults.BackpressurePayloadBytes, "MsgApp payload bytes used while receiver is blocked")
+	snapshotBytes := flag.Int("snapshot-payload-bytes", defaults.SnapshotPayloadBytes, "snapshot payload bytes per node")
+	timeout := flag.Duration("timeout", defaultSoakTimeout, "overall soak deadline")
+	output := flag.String("output", "", "write generated JSON evidence to this path")
+	verify := flag.String("verify", "", "verify an existing JSON evidence file instead of running")
+	flag.Parse()
+
+	if *verify != "" {
+		evidence, err := transportsoak.ReadEvidence(*verify)
+		if err != nil {
+			return errors.Wrap(err, "read streaming transport evidence")
+		}
+		if err := transportsoak.Verify(evidence); err != nil {
+			return errors.Wrap(err, "verify streaming transport evidence")
+		}
+		fmt.Printf("verified streaming transport soak evidence: groups=%d nodes_per_group=%d result=%s\n", evidence.Config.Groups, evidence.Config.NodesPerGroup, evidence.Result)
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+	evidence, err := transportsoak.Run(ctx, transportsoak.Config{
+		Groups:                   *groups,
+		NodesPerGroup:            *nodes,
+		MessagesPerLink:          *messages,
+		RegularPayloadBytes:      *regularBytes,
+		BackpressurePayloadBytes: *backpressureBytes,
+		SnapshotPayloadBytes:     *snapshotBytes,
+	})
+	if err != nil {
+		return errors.Wrap(err, "run streaming transport soak")
+	}
+	if *output != "" {
+		if err := transportsoak.WriteEvidence(*output, evidence); err != nil {
+			return errors.Wrap(err, "write streaming transport evidence")
+		}
+	}
+	fmt.Printf("streaming transport soak passed: groups=%d nodes_per_group=%d evidence=%s\n", evidence.Config.Groups, evidence.Config.NodesPerGroup, *output)
+	return nil
+}

--- a/docs/design/2026_04_18_implemented_raft_grpc_streaming_transport.md
+++ b/docs/design/2026_04_18_implemented_raft_grpc_streaming_transport.md
@@ -1,10 +1,13 @@
 # Design: gRPC Streaming Transport for Raft Messages
 
-> **Status: implemented.**
-> The per-peer dispatch channel foundation from PR #522 remains in place.
-> Regular Raft messages now use a long-lived client-streaming gRPC connection
-> per peer when the remote node supports `SendStream`, with unary `Send`
-> retained as the mixed-version fallback.
+Status: Implemented
+Author: bootjp
+Date: 2026-04-18
+
+The per-peer dispatch channel foundation from PR #522 remains in place.
+Regular Raft messages now use a long-lived client-streaming gRPC connection
+per peer when the remote node supports `SendStream`, with unary `Send`
+retained as the mixed-version fallback.
 
 ## 1. Background and motivation
 
@@ -234,6 +237,7 @@ during the reconnect window, matching the previous drop semantics.
 | 5. Operational kill switch | `ELASTICKV_RAFT_SEND_STREAM=false` forces unary `Send` without unregistering `SendStream` | Implemented |
 | 6. Backward-compat fallback | Empty-stream probe plus `codes.Unimplemented` cache | Implemented |
 | 7. Tests | Server handler, streaming dispatch, legacy-peer fallback, kill switch | Implemented |
+| 8. Multi-group soak evidence | Concurrent TCP groups, disconnect/reconnect, flow-control timeout, recovery, snapshot traffic, and a fail-closed verifier | Implemented |
 
 ---
 
@@ -257,4 +261,112 @@ No dual-write or blue/green deployment is required: the `codes.Unimplemented` pr
 
 - Batch encoding (multiple `EtcdRaftMessage` payloads in one proto message) — independent optimisation.
 - Replacing the current per-lane workers with one biased-select multiplexing worker — an optional scheduler optimization on top of this transport protocol.
-- Snapshot streaming changes — already implemented.
+- Snapshot protocol changes — already implemented. The soak below exercises the existing snapshot stream without changing its wire format.
+
+---
+
+## 8. Multi-node, multi-group soak evidence
+
+### 8.1 Deterministic transport soak
+
+`cmd/elastickv-raft-stream-soak` starts real loopback TCP gRPC servers rather
+than an in-memory mock. Each configured Raft group has its own three-node
+transport mesh. All groups run concurrently through these phases:
+
+1. every directed peer link sends regular `MsgApp` traffic through `SendStream`;
+2. one receiver per group is stopped, the sender observes the broken stream,
+   the receiver restarts on the same address, and a recovery sentinel arrives;
+3. another receiver stops consuming a 1 MiB stream payload until gRPC flow
+   control blocks the sender and its dispatch context expires, then a second
+   recovery sentinel arrives;
+4. every node sends one existing-format `MsgSnap` to its next peer.
+
+The schema-v2 verifier fails unless every group has at least three nodes, every
+directed sender-to-receiver link delivered its configured steady message count,
+a stream reopened, both fault classes were observed, both uniquely indexed
+recovery sentinels reached the receiver handler, and per-node snapshot
+send/receive counts and bytes agree with the configured minimum. Re-run the
+checked-in evidence exactly with:
+
+```bash
+mkdir -p .cache/go .cache/tmp docs/evidence
+GOCACHE="$(pwd)/.cache/go" GOTMPDIR="$(pwd)/.cache/tmp" \
+  go run ./cmd/elastickv-raft-stream-soak \
+    --groups 3 \
+    --nodes 3 \
+    --messages-per-link 8 \
+    --regular-payload-bytes 1024 \
+    --backpressure-payload-bytes 1048576 \
+    --snapshot-payload-bytes 65536 \
+    --timeout 90s \
+    --output docs/evidence/raft_streaming_multigroup_soak.json
+
+GOCACHE="$(pwd)/.cache/go" GOTMPDIR="$(pwd)/.cache/tmp" \
+  go run ./cmd/elastickv-raft-stream-soak \
+    --verify docs/evidence/raft_streaming_multigroup_soak.json
+```
+
+The committed evidence records a passing `3 groups x 3 nodes` run. Each group
+opened all six directed peer streams, recorded at least one successful reopen,
+observed both disconnect and backpressure failures, delivered two recovery
+sentinels, and acknowledged three 64 KiB snapshot streams. Per-sender receive
+counts, TCP ports, and ordered UTC timestamps are retained in the JSON so the
+artifact describes and verifies the actual run.
+
+Focused regression tests:
+
+```bash
+GOCACHE="$(pwd)/.cache/go" GOTMPDIR="$(pwd)/.cache/tmp" \
+  go test ./internal/raftengine/etcd/transportsoak \
+          ./internal/raftengine/etcd \
+          ./monitoring \
+          ./cmd/elastickv-raft-stream-soak -count=1
+```
+
+### 8.2 Full Raft/Jepsen soak
+
+The deterministic command isolates transport lifecycle behavior. The existing
+DynamoDB multi-table Jepsen workload remains the full Raft correctness gate.
+On a standard Jepsen control host with `n1` through `n5` reachable over SSH,
+run:
+
+```bash
+TIME_LIMIT=600 RATE=50 CONCURRENCY=30 FAULT_INTERVAL=15 SNAPSHOT_COUNT=64 \
+  ./scripts/run-jepsen-raft-streaming-multigroup-soak.sh
+```
+
+The script deploys five processes, each hosting groups `1`, `2`, and `3`, and
+routes the four workload tables across all three groups. It enables streaming
+and dispatcher lanes, lowers the snapshot threshold, and applies partition,
+kill, and pause faults. The combined nemesis final generator heals outstanding
+faults before teardown. Jepsen's `LogFiles` collection preserves each server
+log and `elastickv-transport-metrics.prom`. The metrics file appends one final
+counter snapshot for each process lifetime before a kill, plus the final
+process snapshot collected by Jepsen. This preserves evidence when counters
+reset after a kill/restart cycle instead of overwriting the previous lifetime.
+
+The script then runs
+`scripts/verify-raft-streaming-multigroup-metrics.sh` over the newly collected
+node snapshots. It rejects malformed values, missing identity labels, duplicate
+node IDs or addresses, and groups without stream activity from at least three
+distinct nodes. For every expected group it also requires non-zero stream opens,
+successful reconnects, streamed messages, snapshot sends and bytes, and at
+least one backpressure signal (`DeadlineExceeded`, `ResourceExhausted`, a
+dispatcher drop, or a full inbound step queue). The Jepsen history must also be
+valid; the workload process exits non-zero before metrics verification when
+Elle reports an anomaly.
+
+The following Prometheus counters make the evidence independent of log wording:
+
+| Metric | Meaning |
+|---|---|
+| `elastickv_raft_send_stream_opens_total` | Successful outbound stream opens, including reopens |
+| `elastickv_raft_send_stream_reconnects_total` | Successful opens for an address that previously had a stream |
+| `elastickv_raft_send_stream_messages_total` | Regular Raft messages accepted by the stream send path |
+| `elastickv_raft_snapshot_stream_sends_total` | Snapshot streams acknowledged by the peer |
+| `elastickv_raft_snapshot_stream_payload_bytes_total` | Payload bytes in acknowledged snapshot streams |
+
+These counters are observational. They are updated only after successful
+transport operations and are never read by dispatch, fallback, retry, or Raft
+state-machine decisions, so this evidence work does not alter protocol
+semantics.

--- a/docs/evidence/raft_streaming_multigroup_soak.json
+++ b/docs/evidence/raft_streaming_multigroup_soak.json
@@ -1,0 +1,175 @@
+{
+  "schema_version": 2,
+  "started_at": "2026-07-19T09:42:00.117212Z",
+  "finished_at": "2026-07-19T09:42:01.44008Z",
+  "config": {
+    "groups": 3,
+    "nodes_per_group": 3,
+    "messages_per_link": 8,
+    "regular_payload_bytes": 1024,
+    "backpressure_payload_bytes": 1048576,
+    "snapshot_payload_bytes": 65536
+  },
+  "groups": [
+    {
+      "group_id": 1,
+      "nodes": [
+        {
+          "node": 1,
+          "address": "127.0.0.1:63452",
+          "regular_received": 16,
+          "regular_received_by_sender": {
+            "2": 8,
+            "3": 8
+          },
+          "snapshots_received": 1,
+          "send_stream_opens": 4,
+          "send_stream_reconnects": 2,
+          "send_stream_messages": 21,
+          "snapshot_stream_sends": 1,
+          "snapshot_payload_bytes": 65536
+        },
+        {
+          "node": 2,
+          "address": "127.0.0.1:63453",
+          "regular_received": 17,
+          "regular_received_by_sender": {
+            "1": 9,
+            "3": 8
+          },
+          "snapshots_received": 1,
+          "send_stream_opens": 2,
+          "send_stream_reconnects": 0,
+          "send_stream_messages": 16,
+          "snapshot_stream_sends": 1,
+          "snapshot_payload_bytes": 65536
+        },
+        {
+          "node": 3,
+          "address": "127.0.0.1:63454",
+          "regular_received": 18,
+          "regular_received_by_sender": {
+            "1": 10,
+            "2": 8
+          },
+          "snapshots_received": 1,
+          "send_stream_opens": 2,
+          "send_stream_reconnects": 0,
+          "send_stream_messages": 16,
+          "snapshot_stream_sends": 1,
+          "snapshot_payload_bytes": 65536
+        }
+      ],
+      "disconnect_errors": 1,
+      "backpressure_errors": 1,
+      "recovery_messages": 2
+    },
+    {
+      "group_id": 2,
+      "nodes": [
+        {
+          "node": 1,
+          "address": "127.0.0.1:63455",
+          "regular_received": 16,
+          "regular_received_by_sender": {
+            "2": 8,
+            "3": 8
+          },
+          "snapshots_received": 1,
+          "send_stream_opens": 4,
+          "send_stream_reconnects": 2,
+          "send_stream_messages": 21,
+          "snapshot_stream_sends": 1,
+          "snapshot_payload_bytes": 65536
+        },
+        {
+          "node": 2,
+          "address": "127.0.0.1:63456",
+          "regular_received": 17,
+          "regular_received_by_sender": {
+            "1": 9,
+            "3": 8
+          },
+          "snapshots_received": 1,
+          "send_stream_opens": 2,
+          "send_stream_reconnects": 0,
+          "send_stream_messages": 16,
+          "snapshot_stream_sends": 1,
+          "snapshot_payload_bytes": 65536
+        },
+        {
+          "node": 3,
+          "address": "127.0.0.1:63457",
+          "regular_received": 18,
+          "regular_received_by_sender": {
+            "1": 10,
+            "2": 8
+          },
+          "snapshots_received": 1,
+          "send_stream_opens": 2,
+          "send_stream_reconnects": 0,
+          "send_stream_messages": 16,
+          "snapshot_stream_sends": 1,
+          "snapshot_payload_bytes": 65536
+        }
+      ],
+      "disconnect_errors": 1,
+      "backpressure_errors": 1,
+      "recovery_messages": 2
+    },
+    {
+      "group_id": 3,
+      "nodes": [
+        {
+          "node": 1,
+          "address": "127.0.0.1:63458",
+          "regular_received": 16,
+          "regular_received_by_sender": {
+            "2": 8,
+            "3": 8
+          },
+          "snapshots_received": 1,
+          "send_stream_opens": 4,
+          "send_stream_reconnects": 2,
+          "send_stream_messages": 21,
+          "snapshot_stream_sends": 1,
+          "snapshot_payload_bytes": 65536
+        },
+        {
+          "node": 2,
+          "address": "127.0.0.1:63459",
+          "regular_received": 17,
+          "regular_received_by_sender": {
+            "1": 9,
+            "3": 8
+          },
+          "snapshots_received": 1,
+          "send_stream_opens": 2,
+          "send_stream_reconnects": 0,
+          "send_stream_messages": 16,
+          "snapshot_stream_sends": 1,
+          "snapshot_payload_bytes": 65536
+        },
+        {
+          "node": 3,
+          "address": "127.0.0.1:63460",
+          "regular_received": 18,
+          "regular_received_by_sender": {
+            "1": 10,
+            "2": 8
+          },
+          "snapshots_received": 1,
+          "send_stream_opens": 2,
+          "send_stream_reconnects": 0,
+          "send_stream_messages": 16,
+          "snapshot_stream_sends": 1,
+          "snapshot_payload_bytes": 65536
+        }
+      ],
+      "disconnect_errors": 1,
+      "backpressure_errors": 1,
+      "recovery_messages": 2
+    }
+  ],
+  "result": "pass"
+}

--- a/internal/raftengine/etcd/engine.go
+++ b/internal/raftengine/etcd/engine.go
@@ -1196,6 +1196,50 @@ func (e *Engine) DispatchErrorCount() uint64 {
 	return e.dispatchErrorCount.Load()
 }
 
+// SendStreamOpenCount returns successful outbound SendStream opens, including
+// reconnects. The transport counters are monotonic for the engine lifetime.
+func (e *Engine) SendStreamOpenCount() uint64 {
+	if e == nil || e.transport == nil {
+		return 0
+	}
+	return e.transport.Stats().SendStreamOpens
+}
+
+// SendStreamReconnectCount returns successful SendStream opens for peer
+// addresses that had previously held a stream.
+func (e *Engine) SendStreamReconnectCount() uint64 {
+	if e == nil || e.transport == nil {
+		return 0
+	}
+	return e.transport.Stats().SendStreamReconnects
+}
+
+// SendStreamMessageCount returns regular Raft messages accepted by gRPC's
+// SendStream send path.
+func (e *Engine) SendStreamMessageCount() uint64 {
+	if e == nil || e.transport == nil {
+		return 0
+	}
+	return e.transport.Stats().SendStreamMessages
+}
+
+// SnapshotStreamSendCount returns snapshot streams acknowledged by peers.
+func (e *Engine) SnapshotStreamSendCount() uint64 {
+	if e == nil || e.transport == nil {
+		return 0
+	}
+	return e.transport.Stats().SnapshotStreamSends
+}
+
+// SnapshotPayloadByteCount returns payload bytes in acknowledged snapshot
+// streams.
+func (e *Engine) SnapshotPayloadByteCount() uint64 {
+	if e == nil || e.transport == nil {
+		return 0
+	}
+	return e.transport.Stats().SnapshotPayloadBytes
+}
+
 // DispatchErrorCountsByCode returns a snapshot of dispatch-error
 // counts keyed by grpc status code ("Unavailable",
 // "DeadlineExceeded", "ResourceExhausted", ...). Sum of values

--- a/internal/raftengine/etcd/grpc_transport.go
+++ b/internal/raftengine/etcd/grpc_transport.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	internalutil "github.com/bootjp/elastickv/internal"
@@ -49,6 +50,17 @@ var (
 var grpcNewClient = grpc.NewClient
 
 type MessageHandler func(context.Context, raftpb.Message) error
+
+// TransportStats is a monotonic snapshot of successful streaming transport
+// activity. The counters are observational only: no dispatch or retry decision
+// depends on them.
+type TransportStats struct {
+	SendStreamOpens      uint64
+	SendStreamReconnects uint64
+	SendStreamMessages   uint64
+	SnapshotStreamSends  uint64
+	SnapshotPayloadBytes uint64
+}
 
 type peerStream struct {
 	mu     sync.Mutex
@@ -112,6 +124,7 @@ type GRPCTransport struct {
 	streamSupported     map[string]bool
 	streamUnsupported   map[string]bool
 	streamUnsupportedAt map[string]time.Time
+	streamOpenedBefore  map[string]struct{}
 	sendStreamDisabled  bool
 	sendStreamCtx       context.Context
 	sendStreamCancel    context.CancelFunc
@@ -133,6 +146,12 @@ type GRPCTransport struct {
 	// that aggregate in-memory allocation stays bounded even when multiple
 	// dispatch workers run simultaneously.
 	bridgeSem chan struct{}
+
+	sendStreamOpenCount      atomic.Uint64
+	sendStreamReconnectCount atomic.Uint64
+	sendStreamMessageCount   atomic.Uint64
+	snapshotStreamSendCount  atomic.Uint64
+	snapshotPayloadByteCount atomic.Uint64
 }
 
 func NewGRPCTransport(peers []Peer) *GRPCTransport {
@@ -162,12 +181,40 @@ func NewGRPCTransport(peers []Peer) *GRPCTransport {
 		streamSupported:     make(map[string]bool),
 		streamUnsupported:   make(map[string]bool),
 		streamUnsupportedAt: make(map[string]time.Time),
+		streamOpenedBefore:  make(map[string]struct{}),
 		sendStreamDisabled:  sendStreamDisabled,
 		sendStreamCtx:       sendStreamCtx,
 		sendStreamCancel:    sendStreamCancel,
 		snapshotChunkSize:   defaultSnapshotChunkSize,
 		bridgeSem:           make(chan struct{}, defaultBridgeMaterializeLimit),
 	}
+}
+
+// Stats returns a point-in-time copy of the transport's monotonic streaming
+// counters. It is safe to call concurrently with dispatch.
+func (t *GRPCTransport) Stats() TransportStats {
+	if t == nil {
+		return TransportStats{}
+	}
+	return TransportStats{
+		SendStreamOpens:      t.sendStreamOpenCount.Load(),
+		SendStreamReconnects: t.sendStreamReconnectCount.Load(),
+		SendStreamMessages:   t.sendStreamMessageCount.Load(),
+		SnapshotStreamSends:  t.snapshotStreamSendCount.Load(),
+		SnapshotPayloadBytes: t.snapshotPayloadByteCount.Load(),
+	}
+}
+
+func (t *GRPCTransport) recordSnapshotStreamSend(payloadBytes uint64) {
+	t.snapshotStreamSendCount.Add(1)
+	t.snapshotPayloadByteCount.Add(payloadBytes)
+}
+
+func snapshotPayloadByteCount(size int64) uint64 {
+	if size <= 0 {
+		return 0
+	}
+	return uint64(size) //nolint:gosec // size is explicitly checked non-negative above.
 }
 
 func sendStreamEnabledFromEnv() bool {
@@ -448,6 +495,7 @@ func (t *GRPCTransport) streamFSMSnapshot(ctx context.Context, msg raftpb.Messag
 	if _, err := stream.CloseAndRecv(); err != nil {
 		return errors.WithStack(err)
 	}
+	t.recordSnapshotStreamSend(snapshotPayloadByteCount(counter.n))
 	slog.Info("etcd raft snapshot stream sent",
 		"index", index,
 		"to", msg.GetTo(),
@@ -575,6 +623,7 @@ func (t *GRPCTransport) dispatchRegularStream(ctx context.Context, address strin
 	}
 	err = stream.stream.Send(req)
 	if err == nil {
+		t.sendStreamMessageCount.Add(1)
 		err = stream.terminalErr()
 	}
 	stream.mu.Unlock()
@@ -660,6 +709,12 @@ func (t *GRPCTransport) openPeerStream(ctx context.Context, address string, clie
 		return existing, nil
 	}
 	t.streams[address] = opened
+	if _, reopened := t.streamOpenedBefore[address]; reopened {
+		t.sendStreamReconnectCount.Add(1)
+	} else {
+		t.streamOpenedBefore[address] = struct{}{}
+	}
+	t.sendStreamOpenCount.Add(1)
 	go func() {
 		<-opened.done
 		t.closePeerStream(address, opened)
@@ -922,8 +977,11 @@ func (t *GRPCTransport) sendSnapshot(ctx context.Context, msg raftpb.Message) er
 	if err := sendSnapshotChunks(stream, header, payload, t.chunkSize()); err != nil {
 		return err
 	}
-	_, err = stream.CloseAndRecv()
-	return errors.WithStack(err)
+	if _, err := stream.CloseAndRecv(); err != nil {
+		return errors.WithStack(err)
+	}
+	t.recordSnapshotStreamSend(uint64(len(payload)))
+	return nil
 }
 
 func (t *GRPCTransport) sendSnapshotSpool(ctx context.Context, msg raftpb.Message, spool *snapshotSpool) error {
@@ -947,8 +1005,11 @@ func (t *GRPCTransport) sendSnapshotSpool(ctx context.Context, msg raftpb.Messag
 	if err := sendSnapshotReaderChunks(stream, header, reader, t.chunkSize()); err != nil {
 		return err
 	}
-	_, err = stream.CloseAndRecv()
-	return errors.WithStack(err)
+	if _, err := stream.CloseAndRecv(); err != nil {
+		return errors.WithStack(err)
+	}
+	t.recordSnapshotStreamSend(snapshotPayloadByteCount(spool.size))
+	return nil
 }
 
 func (t *GRPCTransport) clientFor(to uint64) (pb.EtcdRaftClient, error) {

--- a/internal/raftengine/etcd/transportsoak/soak.go
+++ b/internal/raftengine/etcd/transportsoak/soak.go
@@ -1,0 +1,849 @@
+package transportsoak
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	etcdtransport "github.com/bootjp/elastickv/internal/raftengine/etcd"
+	"github.com/cockroachdb/errors"
+	raftpb "go.etcd.io/raft/v3/raftpb"
+	"google.golang.org/grpc"
+)
+
+const EvidenceSchemaVersion = 2
+
+const (
+	evidenceFileMode               = os.FileMode(0o600)
+	minimumGroups                  = 2
+	minimumNodesPerGroup           = 3
+	defaultGroups                  = 3
+	defaultNodesPerGroup           = 3
+	defaultMessagesPerLink         = 16
+	defaultRegularPayloadBytes     = 1024
+	defaultBackpressurePayloadSize = 1 << 20
+	defaultSnapshotPayloadBytes    = 256 << 10
+	minimumBackpressurePayloadSize = 64 << 10
+	rebindAttempts                 = 50
+	backpressureAttempts           = 8
+	minimumRecoveryMessages        = 2
+	rebindRetryDelay               = 20 * time.Millisecond
+	steadyDispatchTimeout          = 3 * time.Second
+	disconnectObservationTimeout   = 2 * time.Second
+	disconnectAttemptTimeout       = 200 * time.Millisecond
+	backpressureAttemptTimeout     = 150 * time.Millisecond
+	recoveryDispatchTimeout        = 5 * time.Second
+	deliveryPollInterval           = 10 * time.Millisecond
+	dispatchAttemptTimeout         = 500 * time.Millisecond
+	dispatchRetryDelay             = 25 * time.Millisecond
+	disconnectRecoverySequence     = ^uint64(0) - 1
+	backpressureRecoverySequence   = ^uint64(0) - 2
+)
+
+type regularMessageKey struct {
+	sender   uint64
+	sequence uint64
+}
+
+type Config struct {
+	Groups                   int `json:"groups"`
+	NodesPerGroup            int `json:"nodes_per_group"`
+	MessagesPerLink          int `json:"messages_per_link"`
+	RegularPayloadBytes      int `json:"regular_payload_bytes"`
+	BackpressurePayloadBytes int `json:"backpressure_payload_bytes"`
+	SnapshotPayloadBytes     int `json:"snapshot_payload_bytes"`
+}
+
+func DefaultConfig() Config {
+	return Config{
+		Groups:                   defaultGroups,
+		NodesPerGroup:            defaultNodesPerGroup,
+		MessagesPerLink:          defaultMessagesPerLink,
+		RegularPayloadBytes:      defaultRegularPayloadBytes,
+		BackpressurePayloadBytes: defaultBackpressurePayloadSize,
+		SnapshotPayloadBytes:     defaultSnapshotPayloadBytes,
+	}
+}
+
+type NodeEvidence struct {
+	Node                    uint64            `json:"node"`
+	Address                 string            `json:"address"`
+	RegularReceived         uint64            `json:"regular_received"`
+	RegularReceivedBySender map[uint64]uint64 `json:"regular_received_by_sender"`
+	SnapshotsReceived       uint64            `json:"snapshots_received"`
+	SendStreamOpens         uint64            `json:"send_stream_opens"`
+	SendStreamReconnects    uint64            `json:"send_stream_reconnects"`
+	SendStreamMessages      uint64            `json:"send_stream_messages"`
+	SnapshotStreamSends     uint64            `json:"snapshot_stream_sends"`
+	SnapshotPayloadBytes    uint64            `json:"snapshot_payload_bytes"`
+}
+
+type GroupEvidence struct {
+	GroupID            int            `json:"group_id"`
+	Nodes              []NodeEvidence `json:"nodes"`
+	DisconnectErrors   uint64         `json:"disconnect_errors"`
+	BackpressureErrors uint64         `json:"backpressure_errors"`
+	RecoveryMessages   uint64         `json:"recovery_messages"`
+}
+
+type Evidence struct {
+	SchemaVersion int             `json:"schema_version"`
+	StartedAt     time.Time       `json:"started_at"`
+	FinishedAt    time.Time       `json:"finished_at"`
+	Config        Config          `json:"config"`
+	Groups        []GroupEvidence `json:"groups"`
+	Result        string          `json:"result"`
+}
+
+type soakNode struct {
+	id        uint64
+	address   string
+	transport *etcdtransport.GRPCTransport
+
+	serverMu sync.Mutex
+	server   *grpc.Server
+	listener net.Listener
+
+	gateMu sync.RWMutex
+	gate   chan struct{}
+
+	receivedMu              sync.Mutex
+	regularReceivedBySender map[uint64]uint64
+	regularReceivedByKey    map[regularMessageKey]uint64
+	snapshotsReceived       atomic.Uint64
+}
+
+type soakGroup struct {
+	id                 int
+	nodes              []*soakNode
+	disconnectErrors   atomic.Uint64
+	backpressureErrors atomic.Uint64
+	recoveryMessages   atomic.Uint64
+}
+
+func Run(ctx context.Context, cfg Config) (Evidence, error) {
+	if err := validateConfig(cfg); err != nil {
+		return Evidence{}, err
+	}
+	evidence := Evidence{SchemaVersion: EvidenceSchemaVersion, StartedAt: time.Now().UTC(), Config: cfg}
+
+	groups, err := startGroups(ctx, cfg)
+	if err != nil {
+		return Evidence{}, err
+	}
+	defer closeGroups(groups)
+
+	if err := runSteadyTraffic(ctx, groups, cfg); err != nil {
+		return Evidence{}, errors.Wrap(err, "steady concurrent traffic")
+	}
+	if err := runDisconnectTraffic(ctx, groups); err != nil {
+		return Evidence{}, errors.Wrap(err, "disconnect/reconnect traffic")
+	}
+	if err := runBackpressureTraffic(ctx, groups, cfg); err != nil {
+		return Evidence{}, errors.Wrap(err, "backpressure traffic")
+	}
+	if err := runSnapshotTraffic(ctx, groups, cfg); err != nil {
+		return Evidence{}, errors.Wrap(err, "snapshot traffic")
+	}
+
+	evidence.FinishedAt = time.Now().UTC()
+	evidence.Groups = collectEvidence(groups)
+	evidence.Result = "pass"
+	if err := Verify(evidence); err != nil {
+		return Evidence{}, errors.Wrap(err, "verify generated evidence")
+	}
+	return evidence, nil
+}
+
+func validateConfig(cfg Config) error {
+	switch {
+	case cfg.Groups < minimumGroups:
+		return errors.New("streaming soak requires at least two groups")
+	case cfg.NodesPerGroup < minimumNodesPerGroup:
+		return errors.New("streaming soak requires at least three nodes per group")
+	case cfg.MessagesPerLink < 1:
+		return errors.New("messages per link must be positive")
+	case cfg.RegularPayloadBytes < 1:
+		return errors.New("regular payload bytes must be positive")
+	case cfg.BackpressurePayloadBytes < minimumBackpressurePayloadSize:
+		return errors.New("backpressure payload must be at least 64 KiB")
+	case cfg.SnapshotPayloadBytes < 1:
+		return errors.New("snapshot payload bytes must be positive")
+	default:
+		return nil
+	}
+}
+
+func positiveIntToUint64(value int) uint64 {
+	if value <= 0 {
+		return 0
+	}
+	return uint64(value) //nolint:gosec // callers validate or construct a strictly positive int.
+}
+
+func startGroups(ctx context.Context, cfg Config) ([]*soakGroup, error) {
+	groups := make([]*soakGroup, 0, cfg.Groups)
+	for groupID := 1; groupID <= cfg.Groups; groupID++ {
+		group, err := startGroup(ctx, groupID, cfg.NodesPerGroup)
+		if err != nil {
+			closeGroups(groups)
+			return nil, errors.Wrapf(err, "start group %d", groupID)
+		}
+		groups = append(groups, group)
+	}
+	return groups, nil
+}
+
+func startGroup(ctx context.Context, groupID int, nodeCount int) (*soakGroup, error) {
+	group := &soakGroup{id: groupID, nodes: make([]*soakNode, nodeCount)}
+	for i := range nodeCount {
+		listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+		if err != nil {
+			closeGroup(group)
+			return nil, errors.WithStack(err)
+		}
+		group.nodes[i] = &soakNode{
+			id:                      positiveIntToUint64(i + 1),
+			address:                 listener.Addr().String(),
+			listener:                listener,
+			regularReceivedBySender: make(map[uint64]uint64, nodeCount-1),
+			regularReceivedByKey:    make(map[regularMessageKey]uint64),
+		}
+	}
+	for i, node := range group.nodes {
+		peers := make([]etcdtransport.Peer, 0, nodeCount-1)
+		for j, peer := range group.nodes {
+			if i == j {
+				continue
+			}
+			peers = append(peers, etcdtransport.Peer{NodeID: peer.id, ID: fmt.Sprintf("g%d-n%d", groupID, j+1), Address: peer.address})
+		}
+		node.transport = etcdtransport.NewGRPCTransport(peers)
+		node.transport.SetSendStreamEnabled(true)
+		node.transport.SetHandler(node.handle)
+		node.startServerWithListener(node.listener)
+	}
+	return group, nil
+}
+
+func (n *soakNode) handle(ctx context.Context, msg raftpb.Message) error {
+	n.gateMu.RLock()
+	gate := n.gate
+	n.gateMu.RUnlock()
+	if gate != nil {
+		select {
+		case <-gate:
+		case <-ctx.Done():
+			return errors.WithStack(ctx.Err())
+		}
+	}
+	if msg.GetType() == raftpb.MsgSnap {
+		n.snapshotsReceived.Add(1)
+	} else {
+		n.receivedMu.Lock()
+		n.regularReceivedBySender[msg.GetFrom()]++
+		n.regularReceivedByKey[regularMessageKey{sender: msg.GetFrom(), sequence: msg.GetIndex()}]++
+		n.receivedMu.Unlock()
+	}
+	return nil
+}
+
+func (n *soakNode) regularReceivedFrom(sender uint64) uint64 {
+	n.receivedMu.Lock()
+	defer n.receivedMu.Unlock()
+	return n.regularReceivedBySender[sender]
+}
+
+func (n *soakNode) regularReceivedAt(sender, sequence uint64) uint64 {
+	n.receivedMu.Lock()
+	defer n.receivedMu.Unlock()
+	return n.regularReceivedByKey[regularMessageKey{sender: sender, sequence: sequence}]
+}
+
+func (n *soakNode) regularReceivedSnapshot() (uint64, map[uint64]uint64) {
+	n.receivedMu.Lock()
+	defer n.receivedMu.Unlock()
+	out := make(map[uint64]uint64, len(n.regularReceivedBySender))
+	var total uint64
+	for sender, count := range n.regularReceivedBySender {
+		out[sender] = count
+		total += count
+	}
+	return total, out
+}
+
+func (n *soakNode) startServerWithListener(listener net.Listener) {
+	n.serverMu.Lock()
+	defer n.serverMu.Unlock()
+	server := grpc.NewServer()
+	n.transport.Register(server)
+	n.server = server
+	n.listener = listener
+	go func() { _ = server.Serve(listener) }()
+}
+
+func (n *soakNode) stopServer() {
+	n.serverMu.Lock()
+	defer n.serverMu.Unlock()
+	if n.server != nil {
+		n.server.Stop()
+		n.server = nil
+		n.listener = nil
+	}
+}
+
+func (n *soakNode) restartServer(ctx context.Context) error {
+	var lastErr error
+	for range rebindAttempts {
+		listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", n.address)
+		if err == nil {
+			n.startServerWithListener(listener)
+			return nil
+		}
+		lastErr = err
+		select {
+		case <-ctx.Done():
+			return errors.WithStack(ctx.Err())
+		case <-time.After(rebindRetryDelay):
+		}
+	}
+	return errors.Wrap(lastErr, "rebind receiver address")
+}
+
+func (n *soakNode) block() {
+	n.gateMu.Lock()
+	defer n.gateMu.Unlock()
+	if n.gate == nil {
+		n.gate = make(chan struct{})
+	}
+}
+
+func (n *soakNode) unblock() {
+	n.gateMu.Lock()
+	defer n.gateMu.Unlock()
+	if n.gate != nil {
+		close(n.gate)
+		n.gate = nil
+	}
+}
+
+func closeGroups(groups []*soakGroup) {
+	for _, group := range groups {
+		closeGroup(group)
+	}
+}
+
+func closeGroup(group *soakGroup) {
+	if group == nil {
+		return
+	}
+	for _, node := range group.nodes {
+		if node == nil {
+			continue
+		}
+		node.unblock()
+		node.stopServer()
+		if node.listener != nil {
+			_ = node.listener.Close()
+		}
+		if node.transport != nil {
+			_ = node.transport.Close()
+		}
+	}
+}
+
+func runSteadyTraffic(ctx context.Context, groups []*soakGroup, cfg Config) error {
+	payload := make([]byte, cfg.RegularPayloadBytes)
+	var wg sync.WaitGroup
+	errCh := make(chan error, cfg.Groups*cfg.NodesPerGroup*cfg.NodesPerGroup)
+	for _, group := range groups {
+		for _, from := range group.nodes {
+			for _, to := range group.nodes {
+				if from == to {
+					continue
+				}
+				wg.Add(1)
+				go func(groupID int, from, to *soakNode) {
+					defer wg.Done()
+					for sequence := 1; sequence <= cfg.MessagesPerLink; sequence++ {
+						msg := regularMessage(from.id, to.id, positiveIntToUint64(sequence), payload)
+						if err := dispatchWithRetry(ctx, from.transport, msg, steadyDispatchTimeout); err != nil {
+							errCh <- errors.Wrapf(err, "group %d node %d -> %d sequence %d", groupID, from.id, to.id, sequence)
+							return
+						}
+					}
+				}(group.id, from, to)
+			}
+		}
+	}
+	wg.Wait()
+	close(errCh)
+	if err := combineErrors(errCh); err != nil {
+		return err
+	}
+	return waitForSteadyDeliveries(ctx, groups, cfg)
+}
+
+func waitForSteadyDeliveries(ctx context.Context, groups []*soakGroup, cfg Config) error {
+	for _, group := range groups {
+		for _, receiver := range group.nodes {
+			for _, sender := range group.nodes {
+				if sender == receiver {
+					continue
+				}
+				if err := waitForRegularDelivery(ctx, receiver, sender.id, positiveIntToUint64(cfg.MessagesPerLink)); err != nil {
+					return errors.Wrapf(err, "group %d steady delivery node %d -> %d", group.id, sender.id, receiver.id)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func runDisconnectTraffic(ctx context.Context, groups []*soakGroup) error {
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(groups))
+	for _, group := range groups {
+		wg.Add(1)
+		go func(group *soakGroup) {
+			defer wg.Done()
+			sender, receiver := group.nodes[0], group.nodes[1]
+			receiver.stopServer()
+			failureCtx, failureCancel := context.WithTimeout(ctx, disconnectObservationTimeout)
+			for sequence := uint64(1); ; sequence++ {
+				attemptCtx, attemptCancel := context.WithTimeout(failureCtx, disconnectAttemptTimeout)
+				err := sender.transport.Dispatch(attemptCtx, regularMessage(sender.id, receiver.id, sequence, []byte("disconnect")))
+				attemptCancel()
+				if err != nil {
+					break
+				}
+				select {
+				case <-failureCtx.Done():
+					failureCancel()
+					errCh <- errors.Errorf("group %d did not observe receiver disconnect", group.id)
+					return
+				case <-time.After(deliveryPollInterval):
+				}
+			}
+			failureCancel()
+			group.disconnectErrors.Add(1)
+			if err := receiver.restartServer(ctx); err != nil {
+				errCh <- errors.Wrapf(err, "group %d restart receiver", group.id)
+				return
+			}
+			if err := dispatchWithRetry(ctx, sender.transport, regularMessage(sender.id, receiver.id, disconnectRecoverySequence, []byte("recovered")), recoveryDispatchTimeout); err != nil {
+				errCh <- errors.Wrapf(err, "group %d post-restart sentinel", group.id)
+				return
+			}
+			if err := waitForRegularMessage(ctx, receiver, sender.id, disconnectRecoverySequence); err != nil {
+				errCh <- errors.Wrapf(err, "group %d post-restart sentinel delivery", group.id)
+				return
+			}
+			group.recoveryMessages.Add(1)
+		}(group)
+	}
+	wg.Wait()
+	close(errCh)
+	return combineErrors(errCh)
+}
+
+func runBackpressureTraffic(ctx context.Context, groups []*soakGroup, cfg Config) error {
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(groups))
+	payload := make([]byte, cfg.BackpressurePayloadBytes)
+	for _, group := range groups {
+		wg.Add(1)
+		go func(group *soakGroup) {
+			defer wg.Done()
+			sender, receiver := group.nodes[0], group.nodes[2]
+			receiver.block()
+			defer receiver.unblock()
+			observed := false
+			for sequence := 1; sequence <= backpressureAttempts; sequence++ {
+				sendCtx, cancel := context.WithTimeout(ctx, backpressureAttemptTimeout)
+				err := sender.transport.Dispatch(sendCtx, regularMessage(sender.id, receiver.id, positiveIntToUint64(sequence), payload))
+				cancel()
+				if err != nil {
+					observed = true
+					group.backpressureErrors.Add(1)
+					break
+				}
+			}
+			if !observed {
+				errCh <- errors.Errorf("group %d did not observe flow-control timeout", group.id)
+				return
+			}
+			receiver.unblock()
+			if err := dispatchWithRetry(ctx, sender.transport, regularMessage(sender.id, receiver.id, backpressureRecoverySequence, []byte("backpressure-recovered")), recoveryDispatchTimeout); err != nil {
+				errCh <- errors.Wrapf(err, "group %d post-backpressure sentinel", group.id)
+				return
+			}
+			if err := waitForRegularMessage(ctx, receiver, sender.id, backpressureRecoverySequence); err != nil {
+				errCh <- errors.Wrapf(err, "group %d post-backpressure sentinel delivery", group.id)
+				return
+			}
+			group.recoveryMessages.Add(1)
+		}(group)
+	}
+	wg.Wait()
+	close(errCh)
+	return combineErrors(errCh)
+}
+
+func waitForRegularDelivery(ctx context.Context, receiver *soakNode, sender, minimum uint64) error {
+	ticker := time.NewTicker(deliveryPollInterval)
+	defer ticker.Stop()
+	for {
+		if receiver.regularReceivedFrom(sender) >= minimum {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return errors.WithStack(ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func waitForRegularMessage(ctx context.Context, receiver *soakNode, sender, sequence uint64) error {
+	ticker := time.NewTicker(deliveryPollInterval)
+	defer ticker.Stop()
+	for {
+		if receiver.regularReceivedAt(sender, sequence) > 0 {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return errors.WithStack(ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func runSnapshotTraffic(ctx context.Context, groups []*soakGroup, cfg Config) error {
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(groups)*cfg.NodesPerGroup)
+	payload := make([]byte, cfg.SnapshotPayloadBytes)
+	for _, group := range groups {
+		for i, sender := range group.nodes {
+			receiver := group.nodes[(i+1)%len(group.nodes)]
+			wg.Add(1)
+			go func(groupID int, sender, receiver *soakNode) {
+				defer wg.Done()
+				if err := dispatchWithRetry(ctx, sender.transport, snapshotMessage(sender.id, receiver.id, payload), recoveryDispatchTimeout); err != nil {
+					errCh <- errors.Wrapf(err, "group %d snapshot node %d -> %d", groupID, sender.id, receiver.id)
+				}
+			}(group.id, sender, receiver)
+		}
+	}
+	wg.Wait()
+	close(errCh)
+	return combineErrors(errCh)
+}
+
+func dispatchWithRetry(parent context.Context, transport *etcdtransport.GRPCTransport, msg raftpb.Message, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+	var lastErr error
+	for {
+		attemptCtx, attemptCancel := context.WithTimeout(ctx, dispatchAttemptTimeout)
+		err := transport.Dispatch(attemptCtx, msg)
+		attemptCancel()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		select {
+		case <-ctx.Done():
+			return errors.Wrap(lastErr, "dispatch retry deadline")
+		case <-time.After(dispatchRetryDelay):
+		}
+	}
+}
+
+func regularMessage(from, to, sequence uint64, payload []byte) raftpb.Message {
+	messageType := raftpb.MsgApp
+	term := uint64(1)
+	entryType := raftpb.EntryNormal
+	return raftpb.Message{
+		Type:  &messageType,
+		From:  &from,
+		To:    &to,
+		Term:  &term,
+		Index: &sequence,
+		Entries: []*raftpb.Entry{{
+			Type:  &entryType,
+			Term:  &term,
+			Index: &sequence,
+			Data:  payload,
+		}},
+	}
+}
+
+func snapshotMessage(from, to uint64, payload []byte) raftpb.Message {
+	messageType := raftpb.MsgSnap
+	index, term := uint64(1), uint64(1)
+	return raftpb.Message{
+		Type: &messageType,
+		From: &from,
+		To:   &to,
+		Snapshot: &raftpb.Snapshot{
+			Data: payload,
+			Metadata: &raftpb.SnapshotMetadata{
+				Index: &index,
+				Term:  &term,
+			},
+		},
+	}
+}
+
+func combineErrors(errCh <-chan error) error {
+	var combined error
+	for err := range errCh {
+		combined = errors.CombineErrors(combined, err)
+	}
+	if combined != nil {
+		return errors.WithStack(combined)
+	}
+	return nil
+}
+
+func collectEvidence(groups []*soakGroup) []GroupEvidence {
+	out := make([]GroupEvidence, 0, len(groups))
+	for _, group := range groups {
+		groupEvidence := GroupEvidence{
+			GroupID:            group.id,
+			DisconnectErrors:   group.disconnectErrors.Load(),
+			BackpressureErrors: group.backpressureErrors.Load(),
+			RecoveryMessages:   group.recoveryMessages.Load(),
+			Nodes:              make([]NodeEvidence, 0, len(group.nodes)),
+		}
+		for _, node := range group.nodes {
+			stats := node.transport.Stats()
+			regularReceived, regularReceivedBySender := node.regularReceivedSnapshot()
+			groupEvidence.Nodes = append(groupEvidence.Nodes, NodeEvidence{
+				Node:                    node.id,
+				Address:                 node.address,
+				RegularReceived:         regularReceived,
+				RegularReceivedBySender: regularReceivedBySender,
+				SnapshotsReceived:       node.snapshotsReceived.Load(),
+				SendStreamOpens:         stats.SendStreamOpens,
+				SendStreamReconnects:    stats.SendStreamReconnects,
+				SendStreamMessages:      stats.SendStreamMessages,
+				SnapshotStreamSends:     stats.SnapshotStreamSends,
+				SnapshotPayloadBytes:    stats.SnapshotPayloadBytes,
+			})
+		}
+		out = append(out, groupEvidence)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].GroupID < out[j].GroupID })
+	return out
+}
+
+func Verify(evidence Evidence) error {
+	if err := verifyEvidenceHeader(evidence); err != nil {
+		return err
+	}
+	seenGroups := make(map[int]struct{}, len(evidence.Groups))
+	seenAddresses := make(map[string]struct{}, evidence.Config.Groups*evidence.Config.NodesPerGroup)
+	for _, group := range evidence.Groups {
+		if err := verifyGroupEvidence(evidence.Config, group, seenGroups, seenAddresses); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func verifyEvidenceHeader(evidence Evidence) error {
+	if evidence.SchemaVersion != EvidenceSchemaVersion {
+		return errors.Errorf("unsupported evidence schema %d", evidence.SchemaVersion)
+	}
+	if err := validateConfig(evidence.Config); err != nil {
+		return err
+	}
+	if evidence.Result != "pass" {
+		return errors.Errorf("evidence result is %q", evidence.Result)
+	}
+	if evidence.StartedAt.IsZero() || evidence.FinishedAt.IsZero() || evidence.FinishedAt.Before(evidence.StartedAt) {
+		return errors.New("evidence timestamps are missing or out of order")
+	}
+	if len(evidence.Groups) != evidence.Config.Groups {
+		return errors.Errorf("evidence has %d groups, want %d", len(evidence.Groups), evidence.Config.Groups)
+	}
+	return nil
+}
+
+type groupTotals struct {
+	received          uint64
+	opens             uint64
+	reconnects        uint64
+	streamed          uint64
+	snapshotSends     uint64
+	snapshotBytes     uint64
+	snapshotsReceived uint64
+}
+
+func verifyGroupEvidence(cfg Config, group GroupEvidence, seenGroups map[int]struct{}, seenAddresses map[string]struct{}) error {
+	if group.GroupID < 1 || group.GroupID > cfg.Groups {
+		return errors.Errorf("group id %d is outside expected range 1..%d", group.GroupID, cfg.Groups)
+	}
+	if _, duplicate := seenGroups[group.GroupID]; duplicate {
+		return errors.Errorf("duplicate group %d", group.GroupID)
+	}
+	seenGroups[group.GroupID] = struct{}{}
+	if len(group.Nodes) != cfg.NodesPerGroup {
+		return errors.Errorf("group %d has %d nodes, want %d", group.GroupID, len(group.Nodes), cfg.NodesPerGroup)
+	}
+	if group.DisconnectErrors == 0 {
+		return errors.Errorf("group %d has no disconnect error evidence", group.GroupID)
+	}
+	if group.BackpressureErrors == 0 {
+		return errors.Errorf("group %d has no backpressure error evidence", group.GroupID)
+	}
+	if group.RecoveryMessages < minimumRecoveryMessages {
+		return errors.Errorf("group %d has only %d recovery messages", group.GroupID, group.RecoveryMessages)
+	}
+
+	seenNodes := make(map[uint64]struct{}, len(group.Nodes))
+	var totals groupTotals
+	for _, node := range group.Nodes {
+		if err := verifyNodeEvidence(cfg, group.GroupID, node, seenNodes, seenAddresses); err != nil {
+			return err
+		}
+		totals.add(node)
+	}
+	return verifyGroupTotals(cfg, group.GroupID, totals)
+}
+
+func verifyNodeEvidence(cfg Config, groupID int, node NodeEvidence, seenNodes map[uint64]struct{}, seenAddresses map[string]struct{}) error {
+	if err := verifyNodeIdentity(cfg, groupID, node, seenNodes, seenAddresses); err != nil {
+		return err
+	}
+	return verifyNodeTransport(cfg, groupID, node)
+}
+
+func verifyNodeIdentity(cfg Config, groupID int, node NodeEvidence, seenNodes map[uint64]struct{}, seenAddresses map[string]struct{}) error {
+	nodeCount := positiveIntToUint64(cfg.NodesPerGroup)
+	if node.Node < 1 || node.Node > nodeCount {
+		return errors.Errorf("group %d node id %d is outside expected range 1..%d", groupID, node.Node, cfg.NodesPerGroup)
+	}
+	if _, duplicate := seenNodes[node.Node]; duplicate {
+		return errors.Errorf("group %d has duplicate node %d", groupID, node.Node)
+	}
+	seenNodes[node.Node] = struct{}{}
+	if node.Address == "" {
+		return errors.Errorf("group %d node %d has an empty address", groupID, node.Node)
+	}
+	if _, duplicate := seenAddresses[node.Address]; duplicate {
+		return errors.Errorf("duplicate transport address %q", node.Address)
+	}
+	seenAddresses[node.Address] = struct{}{}
+	return nil
+}
+
+func verifyNodeTransport(cfg Config, groupID int, node NodeEvidence) error {
+	nodeCount := positiveIntToUint64(cfg.NodesPerGroup)
+	messagesPerLink := positiveIntToUint64(cfg.MessagesPerLink)
+	if err := verifyDirectedDeliveries(groupID, node, nodeCount, messagesPerLink); err != nil {
+		return err
+	}
+	minimumPerNode := (nodeCount - 1) * messagesPerLink
+	if node.SendStreamOpens < nodeCount-1 {
+		return errors.Errorf("group %d node %d opened only %d peer streams", groupID, node.Node, node.SendStreamOpens)
+	}
+	if node.SendStreamMessages < minimumPerNode {
+		return errors.Errorf("group %d node %d streamed %d regular messages, want at least %d", groupID, node.Node, node.SendStreamMessages, minimumPerNode)
+	}
+	if node.SnapshotStreamSends < 1 || node.SnapshotsReceived < 1 || node.SnapshotPayloadBytes < positiveIntToUint64(cfg.SnapshotPayloadBytes) {
+		return errors.Errorf("group %d node %d snapshot evidence incomplete: sends=%d received=%d bytes=%d", groupID, node.Node, node.SnapshotStreamSends, node.SnapshotsReceived, node.SnapshotPayloadBytes)
+	}
+	return nil
+}
+
+func verifyDirectedDeliveries(groupID int, node NodeEvidence, nodeCount, messagesPerLink uint64) error {
+	var bySenderTotal uint64
+	for sender, count := range node.RegularReceivedBySender {
+		if sender < 1 || sender > nodeCount || sender == node.Node {
+			return errors.Errorf("group %d node %d has unexpected sender %d", groupID, node.Node, sender)
+		}
+		bySenderTotal += count
+	}
+	for sender := uint64(1); sender <= nodeCount; sender++ {
+		if sender == node.Node {
+			continue
+		}
+		count := node.RegularReceivedBySender[sender]
+		if count < messagesPerLink {
+			return errors.Errorf("group %d link %d -> %d delivered %d regular messages, want at least %d", groupID, sender, node.Node, count, messagesPerLink)
+		}
+	}
+	if node.RegularReceived != bySenderTotal {
+		return errors.Errorf("group %d node %d regular_received=%d differs from sender total %d", groupID, node.Node, node.RegularReceived, bySenderTotal)
+	}
+	return nil
+}
+
+func (totals *groupTotals) add(node NodeEvidence) {
+	totals.received += node.RegularReceived
+	totals.opens += node.SendStreamOpens
+	totals.reconnects += node.SendStreamReconnects
+	totals.streamed += node.SendStreamMessages
+	totals.snapshotSends += node.SnapshotStreamSends
+	totals.snapshotBytes += node.SnapshotPayloadBytes
+	totals.snapshotsReceived += node.SnapshotsReceived
+}
+
+func verifyGroupTotals(cfg Config, groupID int, totals groupTotals) error {
+	nodeCount := positiveIntToUint64(cfg.NodesPerGroup)
+	minimumSteady := nodeCount * (nodeCount - 1) * positiveIntToUint64(cfg.MessagesPerLink)
+	if totals.received < minimumSteady {
+		return errors.Errorf("group %d received %d regular messages, want at least %d", groupID, totals.received, minimumSteady)
+	}
+	if totals.opens < nodeCount*(nodeCount-1) {
+		return errors.Errorf("group %d opened only %d peer streams", groupID, totals.opens)
+	}
+	if totals.reconnects == 0 {
+		return errors.Errorf("group %d has no successful stream reconnect", groupID)
+	}
+	if totals.streamed < minimumSteady {
+		return errors.Errorf("group %d streamed %d regular messages, want at least %d", groupID, totals.streamed, minimumSteady)
+	}
+	if totals.snapshotSends < nodeCount || totals.snapshotsReceived < nodeCount {
+		return errors.Errorf("group %d snapshot evidence incomplete: sends=%d received=%d", groupID, totals.snapshotSends, totals.snapshotsReceived)
+	}
+	minimumSnapshotBytes := nodeCount * positiveIntToUint64(cfg.SnapshotPayloadBytes)
+	if totals.snapshotBytes < minimumSnapshotBytes {
+		return errors.Errorf("group %d snapshot bytes=%d, want at least %d", groupID, totals.snapshotBytes, minimumSnapshotBytes)
+	}
+	return nil
+}
+
+func WriteEvidence(path string, evidence Evidence) error {
+	data, err := json.MarshalIndent(evidence, "", "  ")
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, evidenceFileMode); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+
+func ReadEvidence(path string) (Evidence, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Evidence{}, errors.WithStack(err)
+	}
+	var evidence Evidence
+	if err := json.Unmarshal(data, &evidence); err != nil {
+		return Evidence{}, errors.WithStack(err)
+	}
+	return evidence, nil
+}

--- a/internal/raftengine/etcd/transportsoak/soak_test.go
+++ b/internal/raftengine/etcd/transportsoak/soak_test.go
@@ -1,0 +1,219 @@
+package transportsoak
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunProducesVerifiableMultiGroupEvidence(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	evidence, err := Run(ctx, Config{
+		Groups:                   2,
+		NodesPerGroup:            3,
+		MessagesPerLink:          2,
+		RegularPayloadBytes:      128,
+		BackpressurePayloadBytes: 1 << 20,
+		SnapshotPayloadBytes:     4096,
+	})
+	require.NoError(t, err)
+	require.NoError(t, Verify(evidence))
+	require.Len(t, evidence.Groups, 2)
+}
+
+func TestVerifyRejectsMissingFaultEvidence(t *testing.T) {
+	t.Parallel()
+	evidence := validEvidence()
+	evidence.Groups[0].DisconnectErrors = 0
+
+	err := Verify(evidence)
+	require.ErrorContains(t, err, "no disconnect error evidence")
+}
+
+func TestVerifyRejectsIncompleteOrInconsistentEvidence(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		mutate func(*Evidence)
+		want   string
+	}{
+		{name: "schema", mutate: func(e *Evidence) { e.SchemaVersion++ }, want: "unsupported evidence schema"},
+		{name: "timestamps", mutate: func(e *Evidence) { e.FinishedAt = e.StartedAt.Add(-time.Second) }, want: "timestamps are missing or out of order"},
+		{name: "result", mutate: func(e *Evidence) { e.Result = "unknown" }, want: `evidence result is "unknown"`},
+		{name: "group count", mutate: func(e *Evidence) { e.Groups = e.Groups[:1] }, want: "evidence has 1 groups"},
+		{name: "group range", mutate: func(e *Evidence) { e.Groups[0].GroupID = 3 }, want: "outside expected range"},
+		{name: "duplicate group", mutate: func(e *Evidence) { e.Groups[1].GroupID = 1 }, want: "duplicate group 1"},
+		{name: "duplicate node", mutate: func(e *Evidence) { e.Groups[0].Nodes[1].Node = 1 }, want: "duplicate node 1"},
+		{name: "empty address", mutate: func(e *Evidence) { e.Groups[0].Nodes[0].Address = "" }, want: "empty address"},
+		{name: "duplicate address", mutate: func(e *Evidence) { e.Groups[1].Nodes[0].Address = e.Groups[0].Nodes[0].Address }, want: "duplicate transport address"},
+		{name: "missing directed link", mutate: func(e *Evidence) { e.Groups[0].Nodes[0].RegularReceivedBySender[2] = 1 }, want: "link 2 -> 1 delivered 1"},
+		{name: "unexpected sender", mutate: func(e *Evidence) { e.Groups[0].Nodes[0].RegularReceivedBySender[99] = 1 }, want: "unexpected sender 99"},
+		{name: "total mismatch", mutate: func(e *Evidence) { e.Groups[0].Nodes[0].RegularReceived++ }, want: "differs from sender total"},
+		{name: "stream opens", mutate: func(e *Evidence) { e.Groups[0].Nodes[0].SendStreamOpens = 1 }, want: "opened only 1 peer streams"},
+		{name: "stream messages", mutate: func(e *Evidence) { e.Groups[0].Nodes[0].SendStreamMessages = 3 }, want: "streamed 3 regular messages"},
+		{name: "snapshot", mutate: func(e *Evidence) { e.Groups[0].Nodes[0].SnapshotPayloadBytes = 0 }, want: "snapshot evidence incomplete"},
+		{name: "backpressure", mutate: func(e *Evidence) { e.Groups[0].BackpressureErrors = 0 }, want: "no backpressure error evidence"},
+		{name: "recovery", mutate: func(e *Evidence) { e.Groups[0].RecoveryMessages = 1 }, want: "only 1 recovery messages"},
+		{name: "reconnect", mutate: func(e *Evidence) { e.Groups[0].Nodes[0].SendStreamReconnects = 0 }, want: "no successful stream reconnect"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evidence := validEvidence()
+			tt.mutate(&evidence)
+			require.ErrorContains(t, Verify(evidence), tt.want)
+		})
+	}
+}
+
+func TestEvidenceRoundTrip(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "evidence.json")
+	want := validEvidence()
+	require.NoError(t, WriteEvidence(path, want))
+	got, err := ReadEvidence(path)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestMetricsVerifierRequiresDistinctActiveNodes(t *testing.T) {
+	t.Parallel()
+	repoRoot := repositoryRoot(t)
+	script := filepath.Join(repoRoot, "scripts", "verify-raft-streaming-multigroup-metrics.sh")
+	dir := t.TempDir()
+	files := make([]string, 3)
+	for i := range files {
+		files[i] = filepath.Join(dir, fmt.Sprintf("n%d.prom", i+1))
+		require.NoError(t, os.WriteFile(files[i], []byte(metricsFixture(fmt.Sprintf("n%d", i+1), i == 0, i == 0, true)), 0o600))
+	}
+
+	out, err := runMetricsVerifier(t, script, files)
+	require.NoError(t, err, string(out))
+	require.Contains(t, string(out), "group=3 activity_nodes=3")
+	require.Contains(t, string(out), "result=pass")
+
+	require.NoError(t, os.WriteFile(files[2], []byte(metricsFixture("n2", false, false, true)), 0o600))
+	out, err = runMetricsVerifier(t, script, files)
+	require.Error(t, err)
+	require.Contains(t, string(out), "duplicate node_id n2")
+
+	require.NoError(t, os.WriteFile(files[2], []byte(metricsFixture("n3", false, false, false)), 0o600))
+	out, err = runMetricsVerifier(t, script, files)
+	require.Error(t, err)
+	require.Contains(t, string(out), "group 1 has stream activity on only 2 nodes")
+
+	require.NoError(t, os.WriteFile(files[0], []byte(metricsFixture("n1", true, false, true)), 0o600))
+	require.NoError(t, os.WriteFile(files[2], []byte(metricsFixture("n3", false, false, true)), 0o600))
+	out, err = runMetricsVerifier(t, script, files)
+	require.Error(t, err)
+	require.Contains(t, string(out), "group 1 missing backpressure evidence")
+
+	require.NoError(t, os.WriteFile(files[0], []byte(metricsFixture("n1", true, true, true)+"elastickv_raft_send_stream_messages_total{group=\"1\",node_address=\"n1:50051\",node_id=\"n1\"} NaN\n"), 0o600))
+	out, err = runMetricsVerifier(t, script, files)
+	require.Error(t, err)
+	require.Contains(t, string(out), "invalid metric value")
+}
+
+func validEvidence() Evidence {
+	started := time.Unix(1_700_000_000, 0).UTC()
+	evidence := Evidence{
+		SchemaVersion: EvidenceSchemaVersion,
+		StartedAt:     started,
+		FinishedAt:    started.Add(time.Second),
+		Config: Config{
+			Groups:                   2,
+			NodesPerGroup:            3,
+			MessagesPerLink:          2,
+			RegularPayloadBytes:      128,
+			BackpressurePayloadBytes: 1 << 20,
+			SnapshotPayloadBytes:     4096,
+		},
+		Result: "pass",
+	}
+	for groupID := 1; groupID <= evidence.Config.Groups; groupID++ {
+		group := GroupEvidence{
+			GroupID:            groupID,
+			DisconnectErrors:   1,
+			BackpressureErrors: 1,
+			RecoveryMessages:   2,
+		}
+		for nodeID := 1; nodeID <= evidence.Config.NodesPerGroup; nodeID++ {
+			bySender := make(map[uint64]uint64, evidence.Config.NodesPerGroup-1)
+			for sender := 1; sender <= evidence.Config.NodesPerGroup; sender++ {
+				if sender != nodeID {
+					bySender[positiveIntToUint64(sender)] = positiveIntToUint64(evidence.Config.MessagesPerLink)
+				}
+			}
+			reconnects := uint64(0)
+			if nodeID == 1 {
+				reconnects = 1
+			}
+			group.Nodes = append(group.Nodes, NodeEvidence{
+				Node:                    positiveIntToUint64(nodeID),
+				Address:                 fmt.Sprintf("127.0.0.1:%d", 50000+groupID*10+nodeID),
+				RegularReceived:         positiveIntToUint64((evidence.Config.NodesPerGroup - 1) * evidence.Config.MessagesPerLink),
+				RegularReceivedBySender: bySender,
+				SnapshotsReceived:       1,
+				SendStreamOpens:         positiveIntToUint64(evidence.Config.NodesPerGroup - 1),
+				SendStreamReconnects:    reconnects,
+				SendStreamMessages:      positiveIntToUint64((evidence.Config.NodesPerGroup - 1) * evidence.Config.MessagesPerLink),
+				SnapshotStreamSends:     1,
+				SnapshotPayloadBytes:    positiveIntToUint64(evidence.Config.SnapshotPayloadBytes),
+			})
+		}
+		evidence.Groups = append(evidence.Groups, group)
+	}
+	return evidence
+}
+
+func repositoryRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", "..", ".."))
+}
+
+func runMetricsVerifier(t *testing.T, script string, files []string) ([]byte, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	args := append([]string{script}, files...)
+	cmd := exec.CommandContext(ctx, "bash", args...) //nolint:gosec // script and files are repository/test-controlled paths.
+	cmd.Env = append(os.Environ(), "EXPECTED_GROUPS=1,2,3", "MIN_NODES=3")
+	return cmd.CombinedOutput()
+}
+
+func metricsFixture(nodeID string, reconnect, backpressure, active bool) string {
+	var out strings.Builder
+	messages := 0
+	if active {
+		messages = 10
+	}
+	for groupID := 1; groupID <= 3; groupID++ {
+		labels := fmt.Sprintf(`group="%d",node_address="%s:50051",node_id="%s"`, groupID, nodeID, nodeID)
+		fmt.Fprintf(&out, "elastickv_raft_send_stream_opens_total{%s} 2\n", labels)
+		fmt.Fprintf(&out, "elastickv_raft_send_stream_reconnects_total{%s} %d\n", labels, boolCount(reconnect))
+		fmt.Fprintf(&out, "elastickv_raft_send_stream_messages_total{%s} %d\n", labels, messages)
+		fmt.Fprintf(&out, "elastickv_raft_snapshot_stream_sends_total{%s} 1\n", labels)
+		fmt.Fprintf(&out, "elastickv_raft_snapshot_stream_payload_bytes_total{%s} 4096\n", labels)
+		fmt.Fprintf(&out, "elastickv_raft_dispatch_errors_by_code_total{code=\"DeadlineExceeded\",%s} %d\n", labels, boolCount(backpressure))
+	}
+	return out.String()
+}
+
+func boolCount(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}

--- a/jepsen/src/elastickv/cli.clj
+++ b/jepsen/src/elastickv/cli.clj
@@ -34,8 +34,11 @@
                      (into {})))]
    [nil "--shard-ranges RANGES" "Shard ranges (start:end=groupID,...)"
     :default nil]
-   [nil "--faults LIST" "Comma separated faults (partition,kill,clock)."
+   [nil "--faults LIST" "Comma separated faults (partition,kill,pause,clock)."
     :default "partition,kill,clock"]
+   [nil "--fault-interval SECONDS" "Seconds between nemesis operations."
+    :default 40
+    :parse-fn #(Double/parseDouble %)]
    [nil "--ssh-key PATH" "SSH private key path."
     :default "/home/vagrant/.ssh/id_rsa"]
    [nil "--ssh-user USER" "SSH username."

--- a/jepsen/src/elastickv/db.clj
+++ b/jepsen/src/elastickv/db.clj
@@ -12,6 +12,7 @@
 (def ^:private bin-dir "/opt/elastickv/bin")
 (def ^:private data-dir "/var/lib/elastickv")
 (def ^:private log-file "/var/log/elastickv.log")
+(def ^:private transport-metrics-file "/var/log/elastickv-transport-metrics.prom")
 (def ^:private pid-file "/var/run/elastickv.pid")
 (def ^:private server-bin (str bin-dir "/elastickv"))
 (def ^:private raftadmin-bin (str bin-dir "/raftadmin"))
@@ -97,7 +98,7 @@
          (clojure.string/join ","))))
 
 (defn- start-node!
-  [test node {:keys [bootstrap-node grpc-port redis-port dynamo-port s3-port sqs-port sqs-region data-dir raft-groups shard-ranges raft-engine]}]
+  [test node {:keys [bootstrap-node grpc-port redis-port dynamo-port s3-port sqs-port sqs-region data-dir raft-groups shard-ranges raft-engine server-env]}]
   (when (and (seq raft-groups)
              (> (count raft-groups) 1)
              (nil? shard-ranges))
@@ -114,8 +115,7 @@
               (node-addr node (port-for sqs-port node)))
         raft-redis-map (build-raft-redis-map (:nodes test) grpc-port redis-port raft-groups)
         bootstrap? (= node bootstrap-node)
-        args (cond-> [server-bin
-                      "--address" grpc
+        args (cond-> ["--address" grpc
                       "--redisAddress" redis
                       "--raftId" (name node)
                       "--raftDataDir" data-dir
@@ -127,15 +127,16 @@
                (and sqs sqs-region) (conj "--sqsRegion" sqs-region)
                (seq raft-groups) (conj "--raftGroups" (build-raft-groups-arg node raft-groups))
                (seq shard-ranges) (conj "--shardRanges" shard-ranges)
-               bootstrap? (conj "--raftBootstrap"))]
+               bootstrap? (conj "--raftBootstrap"))
+        daemon-opts (cond-> {:chdir bin-dir
+                             :logfile log-file
+                             :pidfile pid-file
+                             :background? true}
+                      (seq server-env) (assoc :env server-env))]
     (c/on node
       (c/su
         (c/exec :mkdir :-p data-dir)
-        (apply cu/start-daemon! {:chdir bin-dir
-                                 :logfile log-file
-                                 :pidfile pid-file
-                                 :background? true}
-               args)))))
+        (apply cu/start-daemon! daemon-opts server-bin args)))))
 
 (defn- stop-node!
   [node]
@@ -143,6 +144,18 @@
     (c/su
       (cu/stop-daemon! pid-file)
       (c/exec :rm :-f pid-file))))
+
+(defn- snapshot-transport-metrics!
+  [node]
+  (c/on node
+    (c/su
+      (c/exec :bash "-c"
+              (str "tmp=$(mktemp /var/log/elastickv-transport-metrics.XXXXXX); "
+                   "if curl -fsS http://127.0.0.1:9090/metrics "
+                   "| grep -E '^elastickv_raft_(send_stream|snapshot_stream|dispatch_errors|dispatch_dropped|step_queue_full)' > \"$tmp\"; "
+                   "then { printf '# transport metrics snapshot node=" (name node) " captured_at=%s\\n' \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"; cat \"$tmp\"; } >> " transport-metrics-file "; "
+                   "else printf '# metrics unavailable node=" (name node) " captured_at=%s\\n' \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" >> " transport-metrics-file "; fi; "
+                   "rm -f \"$tmp\"")))))
 
 (defn- wait-for-grpc!
   "Wait until the given node listens on grpc port."
@@ -170,7 +183,8 @@
     (upload-binaries! test node)
     (c/on node
       (c/su
-        (c/exec :mkdir :-p data-dir)))
+        (c/exec :mkdir :-p data-dir)
+        (c/exec :rm :-f log-file transport-metrics-file)))
     (start-node! test node (merge {:data-dir data-dir
                                    :grpc-port (or (:grpc-port opts) 50051)
                                    :redis-port (or (:redis-port opts) 6379)
@@ -207,13 +221,21 @@
 
   (teardown! [_ _test node]
     (try
+      (snapshot-transport-metrics! node)
+      (catch Throwable t
+        (warn t "transport metrics snapshot failed")))
+    (try
       (stop-node! node)
       (catch Throwable t
         (warn t "teardown stop failed")))
     (c/on node
       (c/su
-        (c/exec :rm :-rf data-dir)
-        (c/exec :rm :-f log-file))))
+        (c/exec :rm :-rf data-dir))))
+
+  db/LogFiles
+  (log-files [_ _test _node]
+    {log-file "elastickv.log"
+     transport-metrics-file "elastickv-transport-metrics.prom"})
 
   db/Kill
   (start! [this test node]
@@ -229,6 +251,10 @@
     (info "node started" node)
     this)
   (kill! [this _test node]
+    (try
+      (snapshot-transport-metrics! node)
+      (catch Throwable t
+        (warn t "transport metrics snapshot before kill failed")))
     (stop-node! node)
     this)
 
@@ -250,6 +276,7 @@
   "Constructs an ElastickvDB with optional opts.
    opts: {:grpc-port 50051 :redis-port 6379
           :raft-groups {1 50051 2 50052}
-          :shard-ranges \":m=1,m:=2\"}"
+          :shard-ranges \":m=1,m:=2\"
+          :server-env {\"ELASTICKV_RAFT_SEND_STREAM\" \"true\"}}"
   ([] (->ElastickvDB {}))
   ([opts] (->ElastickvDB opts)))

--- a/jepsen/src/elastickv/db.clj
+++ b/jepsen/src/elastickv/db.clj
@@ -85,17 +85,23 @@
               (str gid "=" (group-addr node raft-groups gid))))
        (clojure.string/join ",")))
 
-(defn- build-raft-redis-map [nodes grpc-port redis-port raft-groups]
+(defn- build-raft-service-map [nodes grpc-port service-port raft-groups]
   (let [groups (when (seq raft-groups) (group-ids raft-groups))]
     (->> nodes
          (mapcat (fn [n]
-                   (let [redis (node-addr n (port-for redis-port n))]
+                   (let [service-addr (node-addr n (port-for service-port n))]
                      (if (seq groups)
                        (map (fn [gid]
-                              (str (group-addr n raft-groups gid) "=" redis))
+                              (str (group-addr n raft-groups gid) "=" service-addr))
                             groups)
-                       [(str (node-addr n (port-for grpc-port n)) "=" redis)]))))
+                       [(str (node-addr n (port-for grpc-port n)) "=" service-addr)]))))
          (clojure.string/join ","))))
+
+(defn- build-raft-redis-map [nodes grpc-port redis-port raft-groups]
+  (build-raft-service-map nodes grpc-port redis-port raft-groups))
+
+(defn- build-raft-dynamo-map [nodes grpc-port dynamo-port raft-groups]
+  (build-raft-service-map nodes grpc-port dynamo-port raft-groups))
 
 (defn- start-node!
   [test node {:keys [bootstrap-node grpc-port redis-port dynamo-port s3-port sqs-port sqs-region data-dir raft-groups shard-ranges raft-engine server-env]}]
@@ -114,6 +120,8 @@
         sqs (when sqs-port
               (node-addr node (port-for sqs-port node)))
         raft-redis-map (build-raft-redis-map (:nodes test) grpc-port redis-port raft-groups)
+        raft-dynamo-map (when dynamo
+                          (build-raft-dynamo-map (:nodes test) grpc-port dynamo-port raft-groups))
         bootstrap? (= node bootstrap-node)
         args (cond-> ["--address" grpc
                       "--redisAddress" redis
@@ -121,7 +129,8 @@
                       "--raftDataDir" data-dir
                       "--raftEngine" (or raft-engine "etcd")
                       "--raftRedisMap" raft-redis-map]
-               dynamo (conj "--dynamoAddress" dynamo)
+               dynamo (conj "--dynamoAddress" dynamo
+                            "--raftDynamoMap" raft-dynamo-map)
                s3 (conj "--s3Address" s3)
                sqs (conj "--sqsAddress" sqs)
                (and sqs sqs-region) (conj "--sqsRegion" sqs-region)
@@ -151,7 +160,7 @@
     (c/su
       (c/exec :bash "-c"
               (str "tmp=$(mktemp /var/log/elastickv-transport-metrics.XXXXXX); "
-                   "if curl -fsS http://127.0.0.1:9090/metrics "
+                   "if curl --connect-timeout 2 --max-time 5 -fsS http://127.0.0.1:9090/metrics "
                    "| grep -E '^elastickv_raft_(send_stream|snapshot_stream|dispatch_errors|dispatch_dropped|step_queue_full)' > \"$tmp\"; "
                    "then { printf '# transport metrics snapshot node=" (name node) " captured_at=%s\\n' \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"; cat \"$tmp\"; } >> " transport-metrics-file "; "
                    "else printf '# metrics unavailable node=" (name node) " captured_at=%s\\n' \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" >> " transport-metrics-file "; fi; "

--- a/jepsen/src/elastickv/dynamodb_multi_table_workload.clj
+++ b/jepsen/src/elastickv/dynamodb_multi_table_workload.clj
@@ -520,7 +520,8 @@
                                   :redis-port   (or (:redis-port opts) 6379)
                                   :dynamo-port  node->port
                                   :raft-groups  (:raft-groups opts)
-                                  :shard-ranges (:shard-ranges opts)}))
+                                  :shard-ranges (:shard-ranges opts)
+                                  :server-env   (:server-env opts)}))
          rate         (double (or (:rate opts) 5))
          time-limit   (or (:time-limit opts) 30)
          faults       (if local?
@@ -564,7 +565,7 @@
                                      (:ssh opts))
              :remote          control/ssh
              :nemesis         (or (:nemesis nemesis-p) nemesis/noop)
-             :final-generator nil
+             :final-generator (when nemesis-p (:final-generator nemesis-p))
              :concurrency     (or (:concurrency opts) 5)
              :generator       (->> (:generator workload)
                                    (gen/nemesis nemesis-gen)
@@ -604,7 +605,12 @@
     :default false]
    [nil "--route-shuffle-interval SECONDS" "Seconds between route-shuffle nemesis operations."
     :default 30
-    :parse-fn #(Double/parseDouble %)]])
+    :parse-fn #(Double/parseDouble %)]
+   [nil "--raft-snapshot-count N" "FSM snapshot threshold for transport soak runs."
+    :default nil
+    :parse-fn #(Long/parseLong %)]
+   [nil "--raft-dispatcher-lanes" "Enable the four-lane Raft dispatcher during the soak."
+    :default false]])
 
 (defn- prepare-dynamo-opts
   "Transform parsed CLI options into the map expected by
@@ -619,7 +625,12 @@
       :dynamo-host (:host options)
       :node->port  node->port
       :dynamo-port (:dynamo-port options)
-      :redis-port  (:redis-port options))))
+      :redis-port  (:redis-port options)
+      :server-env  (cond-> {"ELASTICKV_RAFT_SEND_STREAM" "true"}
+                     (:raft-snapshot-count options)
+                     (assoc "ELASTICKV_RAFT_SNAPSHOT_COUNT" (str (:raft-snapshot-count options)))
+                     (:raft-dispatcher-lanes options)
+                     (assoc "ELASTICKV_RAFT_DISPATCHER_LANES" "true")))))
 
 (defn -main
   [& args]

--- a/jepsen/test/elastickv/dynamodb_multi_table_workload_test.clj
+++ b/jepsen/test/elastickv/dynamodb_multi_table_workload_test.clj
@@ -1,6 +1,9 @@
 (ns elastickv.dynamodb-multi-table-workload-test
   (:require [clojure.test :refer :all]
+            [elastickv.cli :as cli]
+            [elastickv.db :as ekdb]
             [jepsen.client :as client]
+            [jepsen.db :as jdb]
             [elastickv.dynamodb-multi-table-workload :as workload]))
 
 (deftest builds-test-spec
@@ -21,6 +24,32 @@
                    {:local true
                     :nodes ["n1"]})]
     (is (some? (:nemesis test-map)))))
+
+(deftest distributed-test-retains-nemesis-healing-generator
+  (let [test-map (workload/elastickv-dynamodb-multi-table-test
+                   {:faults [:partition :kill :pause]})]
+    (is (some? (:final-generator test-map))
+        "partition, kill, and pause faults must be healed before evidence collection")))
+
+(deftest transport-soak-options-enable-server-environment
+  (let [prepare (var-get #'workload/prepare-dynamo-opts)
+        opts    (prepare {:nodes cli/default-nodes-str
+                          :faults "partition,kill,pause"
+                          :ssh-user "vagrant"
+                          :ssh-key "/home/vagrant/.ssh/id_rsa"
+                          :dynamo-port 8000
+                          :redis-port 6379
+                          :raft-snapshot-count 64
+                          :raft-dispatcher-lanes true})]
+    (is (= {"ELASTICKV_RAFT_SEND_STREAM" "true"
+            "ELASTICKV_RAFT_SNAPSHOT_COUNT" "64"
+            "ELASTICKV_RAFT_DISPATCHER_LANES" "true"}
+           (:server-env opts)))))
+
+(deftest db-collects-log-and-cumulative-transport-evidence
+  (is (= {"/var/log/elastickv.log" "elastickv.log"
+          "/var/log/elastickv-transport-metrics.prom" "elastickv-transport-metrics.prom"}
+         (jdb/log-files (ekdb/db) {} "n1"))))
 
 (deftest host-override-creates-client
   (let [test-map (workload/elastickv-dynamodb-multi-table-test

--- a/jepsen/test/elastickv/dynamodb_multi_table_workload_test.clj
+++ b/jepsen/test/elastickv/dynamodb_multi_table_workload_test.clj
@@ -51,6 +51,14 @@
           "/var/log/elastickv-transport-metrics.prom" "elastickv-transport-metrics.prom"}
          (jdb/log-files (ekdb/db) {} "n1"))))
 
+(deftest raft-dynamo-map-covers-every-node-and-group
+  (let [build-map (var-get #'ekdb/build-raft-dynamo-map)]
+    (is (= "n1:50051=n1:8001,n1:50052=n1:8001,n2:50051=n2:8002,n2:50052=n2:8002"
+           (build-map ["n1" "n2"]
+                      50051
+                      {"n1" 8001 "n2" 8002}
+                      {1 50051 2 50052})))))
+
 (deftest host-override-creates-client
   (let [test-map (workload/elastickv-dynamodb-multi-table-test
                    {:dynamo-host "127.0.0.1"

--- a/monitoring/hotpath.go
+++ b/monitoring/hotpath.go
@@ -36,6 +36,11 @@ type HotPathMetrics struct {
 	dispatchErrorsTotal       *prometheus.CounterVec
 	dispatchErrorsByCodeTotal *prometheus.CounterVec
 	stepQueueFullTotal        *prometheus.CounterVec
+	sendStreamOpensTotal      *prometheus.CounterVec
+	sendStreamReconnectsTotal *prometheus.CounterVec
+	sendStreamMessagesTotal   *prometheus.CounterVec
+	snapshotStreamSendsTotal  *prometheus.CounterVec
+	snapshotPayloadBytesTotal *prometheus.CounterVec
 	luaFastPathTotal          *prometheus.CounterVec
 }
 
@@ -102,6 +107,41 @@ func newHotPathMetrics(registerer prometheus.Registerer) *HotPathMetrics {
 			},
 			[]string{"group"},
 		),
+		sendStreamOpensTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "elastickv_raft_send_stream_opens_total",
+				Help: "Successful outbound Raft SendStream opens, including reconnects.",
+			},
+			[]string{"group"},
+		),
+		sendStreamReconnectsTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "elastickv_raft_send_stream_reconnects_total",
+				Help: "Successful outbound Raft SendStream reopens for peer addresses previously streamed to.",
+			},
+			[]string{"group"},
+		),
+		sendStreamMessagesTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "elastickv_raft_send_stream_messages_total",
+				Help: "Regular Raft messages accepted by the outbound SendStream path.",
+			},
+			[]string{"group"},
+		),
+		snapshotStreamSendsTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "elastickv_raft_snapshot_stream_sends_total",
+				Help: "Outbound Raft snapshot streams acknowledged by peers.",
+			},
+			[]string{"group"},
+		),
+		snapshotPayloadBytesTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "elastickv_raft_snapshot_stream_payload_bytes_total",
+				Help: "Payload bytes in outbound Raft snapshot streams acknowledged by peers.",
+			},
+			[]string{"group"},
+		),
 		dispatchErrorsByCodeTotal: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "elastickv_raft_dispatch_errors_by_code_total",
@@ -124,6 +164,11 @@ func newHotPathMetrics(registerer prometheus.Registerer) *HotPathMetrics {
 		m.dispatchErrorsTotal,
 		m.dispatchErrorsByCodeTotal,
 		m.stepQueueFullTotal,
+		m.sendStreamOpensTotal,
+		m.sendStreamReconnectsTotal,
+		m.sendStreamMessagesTotal,
+		m.snapshotStreamSendsTotal,
+		m.snapshotPayloadBytesTotal,
 		m.luaFastPathTotal,
 	)
 	return m
@@ -257,6 +302,11 @@ type DispatchCounterSource interface {
 	DispatchDropCount() uint64
 	DispatchErrorCount() uint64
 	StepQueueFullCount() uint64
+	SendStreamOpenCount() uint64
+	SendStreamReconnectCount() uint64
+	SendStreamMessageCount() uint64
+	SnapshotStreamSendCount() uint64
+	SnapshotPayloadByteCount() uint64
 	// DispatchErrorCountsByCode returns a snapshot of dispatch error
 	// counts keyed by grpc status code ("Unavailable",
 	// "DeadlineExceeded", ...). Sum of values equals
@@ -286,9 +336,14 @@ type DispatchCollector struct {
 }
 
 type dispatchSnapshot struct {
-	drops     uint64
-	errors    uint64
-	stepFulls uint64
+	drops                uint64
+	errors               uint64
+	stepFulls            uint64
+	streamOpens          uint64
+	streamReconnects     uint64
+	streamMessages       uint64
+	snapshotStreamSends  uint64
+	snapshotPayloadBytes uint64
 	// byCode keeps the last-seen per-grpc-code error totals so the
 	// collector can emit monotonic deltas per code on each poll. nil
 	// until the first observation.
@@ -340,37 +395,46 @@ func (c *DispatchCollector) observeOnce(sources []DispatchSource) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for _, src := range sources {
-		if src.Source == nil {
-			continue
-		}
-		curr := dispatchSnapshot{
-			drops:     src.Source.DispatchDropCount(),
-			errors:    src.Source.DispatchErrorCount(),
-			stepFulls: src.Source.StepQueueFullCount(),
-			byCode:    src.Source.DispatchErrorCountsByCode(),
-		}
-		prev := c.previous[src.GroupID]
-		group := strconv.FormatUint(src.GroupID, 10)
-		// The engine's counters are monotonic; still, guard against
-		// wraparound / replacement of the underlying engine (e.g. a
-		// test reopens it) by only advancing the Prometheus counter
-		// when the current value is strictly greater than the last
-		// snapshot. A smaller value means the source was reset and
-		// we restart the delta baseline without emitting negative.
-		if curr.drops > prev.drops {
-			c.metrics.dispatchDroppedTotal.WithLabelValues(group).Add(float64(curr.drops - prev.drops))
-		}
-		if curr.errors > prev.errors {
-			c.metrics.dispatchErrorsTotal.WithLabelValues(group).Add(float64(curr.errors - prev.errors))
-		}
-		if curr.stepFulls > prev.stepFulls {
-			c.metrics.stepQueueFullTotal.WithLabelValues(group).Add(float64(curr.stepFulls - prev.stepFulls))
-		}
-		for code, count := range curr.byCode {
-			if prevCount := prev.byCode[code]; count > prevCount {
-				c.metrics.dispatchErrorsByCodeTotal.WithLabelValues(group, code).Add(float64(count - prevCount))
-			}
-		}
-		c.previous[src.GroupID] = curr
+		c.observeSource(src)
+	}
+}
+
+func (c *DispatchCollector) observeSource(src DispatchSource) {
+	if src.Source == nil {
+		return
+	}
+	curr := dispatchSnapshot{
+		drops:                src.Source.DispatchDropCount(),
+		errors:               src.Source.DispatchErrorCount(),
+		stepFulls:            src.Source.StepQueueFullCount(),
+		streamOpens:          src.Source.SendStreamOpenCount(),
+		streamReconnects:     src.Source.SendStreamReconnectCount(),
+		streamMessages:       src.Source.SendStreamMessageCount(),
+		snapshotStreamSends:  src.Source.SnapshotStreamSendCount(),
+		snapshotPayloadBytes: src.Source.SnapshotPayloadByteCount(),
+		byCode:               src.Source.DispatchErrorCountsByCode(),
+	}
+	prev := c.previous[src.GroupID]
+	group := strconv.FormatUint(src.GroupID, 10)
+
+	addCounterDelta(c.metrics.dispatchDroppedTotal.WithLabelValues(group), curr.drops, prev.drops)
+	addCounterDelta(c.metrics.dispatchErrorsTotal.WithLabelValues(group), curr.errors, prev.errors)
+	addCounterDelta(c.metrics.stepQueueFullTotal.WithLabelValues(group), curr.stepFulls, prev.stepFulls)
+	addCounterDelta(c.metrics.sendStreamOpensTotal.WithLabelValues(group), curr.streamOpens, prev.streamOpens)
+	addCounterDelta(c.metrics.sendStreamReconnectsTotal.WithLabelValues(group), curr.streamReconnects, prev.streamReconnects)
+	addCounterDelta(c.metrics.sendStreamMessagesTotal.WithLabelValues(group), curr.streamMessages, prev.streamMessages)
+	addCounterDelta(c.metrics.snapshotStreamSendsTotal.WithLabelValues(group), curr.snapshotStreamSends, prev.snapshotStreamSends)
+	addCounterDelta(c.metrics.snapshotPayloadBytesTotal.WithLabelValues(group), curr.snapshotPayloadBytes, prev.snapshotPayloadBytes)
+	for code, count := range curr.byCode {
+		addCounterDelta(c.metrics.dispatchErrorsByCodeTotal.WithLabelValues(group, code), count, prev.byCode[code])
+	}
+	c.previous[src.GroupID] = curr
+}
+
+// addCounterDelta also handles a source reset: a value below the previous
+// sample becomes the new baseline and emits no negative Prometheus delta.
+func addCounterDelta(counter prometheus.Counter, current, previous uint64) {
+	if current > previous {
+		counter.Add(float64(current - previous))
 	}
 }

--- a/monitoring/hotpath_test.go
+++ b/monitoring/hotpath_test.go
@@ -89,16 +89,32 @@ func TestLeaseReadObserverZeroValueIsNoop(t *testing.T) {
 // uint64s so tests can advance counters without touching the etcd
 // engine directly.
 type fakeDispatchSource struct {
-	drops      atomic.Uint64
-	errors     atomic.Uint64
-	stepFulls  atomic.Uint64
-	byCodeMu   sync.Mutex
-	byCodeVals map[string]uint64
+	drops                atomic.Uint64
+	errors               atomic.Uint64
+	stepFulls            atomic.Uint64
+	streamOpens          atomic.Uint64
+	streamReconnects     atomic.Uint64
+	streamMessages       atomic.Uint64
+	snapshotStreamSends  atomic.Uint64
+	snapshotPayloadBytes atomic.Uint64
+	byCodeMu             sync.Mutex
+	byCodeVals           map[string]uint64
 }
 
-func (f *fakeDispatchSource) DispatchDropCount() uint64  { return f.drops.Load() }
-func (f *fakeDispatchSource) DispatchErrorCount() uint64 { return f.errors.Load() }
-func (f *fakeDispatchSource) StepQueueFullCount() uint64 { return f.stepFulls.Load() }
+func (f *fakeDispatchSource) DispatchDropCount() uint64   { return f.drops.Load() }
+func (f *fakeDispatchSource) DispatchErrorCount() uint64  { return f.errors.Load() }
+func (f *fakeDispatchSource) StepQueueFullCount() uint64  { return f.stepFulls.Load() }
+func (f *fakeDispatchSource) SendStreamOpenCount() uint64 { return f.streamOpens.Load() }
+func (f *fakeDispatchSource) SendStreamReconnectCount() uint64 {
+	return f.streamReconnects.Load()
+}
+func (f *fakeDispatchSource) SendStreamMessageCount() uint64 { return f.streamMessages.Load() }
+func (f *fakeDispatchSource) SnapshotStreamSendCount() uint64 {
+	return f.snapshotStreamSends.Load()
+}
+func (f *fakeDispatchSource) SnapshotPayloadByteCount() uint64 {
+	return f.snapshotPayloadBytes.Load()
+}
 
 func (f *fakeDispatchSource) DispatchErrorCountsByCode() map[string]uint64 {
 	f.byCodeMu.Lock()
@@ -133,6 +149,11 @@ func TestDispatchCollectorMirrorsDeltas(t *testing.T) {
 	src.drops.Store(3)
 	src.errors.Store(2)
 	src.stepFulls.Store(1)
+	src.streamOpens.Store(4)
+	src.streamReconnects.Store(2)
+	src.streamMessages.Store(30)
+	src.snapshotStreamSends.Store(3)
+	src.snapshotPayloadBytes.Store(4096)
 	collector.ObserveOnce(sources)
 
 	// A second pass with no change must NOT double-count.
@@ -150,10 +171,30 @@ elastickv_raft_dispatch_errors_total{group="1",node_address="10.0.0.1:50051",nod
 # HELP elastickv_raft_step_queue_full_total Inbound raft messages that could not be enqueued because the selected step queue was full; indicates the raft loop is starved (classic pre-#560 seek-storm symptom).
 # TYPE elastickv_raft_step_queue_full_total counter
 elastickv_raft_step_queue_full_total{group="1",node_address="10.0.0.1:50051",node_id="n1"} 1
+# HELP elastickv_raft_send_stream_opens_total Successful outbound Raft SendStream opens, including reconnects.
+# TYPE elastickv_raft_send_stream_opens_total counter
+elastickv_raft_send_stream_opens_total{group="1",node_address="10.0.0.1:50051",node_id="n1"} 4
+# HELP elastickv_raft_send_stream_reconnects_total Successful outbound Raft SendStream reopens for peer addresses previously streamed to.
+# TYPE elastickv_raft_send_stream_reconnects_total counter
+elastickv_raft_send_stream_reconnects_total{group="1",node_address="10.0.0.1:50051",node_id="n1"} 2
+# HELP elastickv_raft_send_stream_messages_total Regular Raft messages accepted by the outbound SendStream path.
+# TYPE elastickv_raft_send_stream_messages_total counter
+elastickv_raft_send_stream_messages_total{group="1",node_address="10.0.0.1:50051",node_id="n1"} 30
+# HELP elastickv_raft_snapshot_stream_sends_total Outbound Raft snapshot streams acknowledged by peers.
+# TYPE elastickv_raft_snapshot_stream_sends_total counter
+elastickv_raft_snapshot_stream_sends_total{group="1",node_address="10.0.0.1:50051",node_id="n1"} 3
+# HELP elastickv_raft_snapshot_stream_payload_bytes_total Payload bytes in outbound Raft snapshot streams acknowledged by peers.
+# TYPE elastickv_raft_snapshot_stream_payload_bytes_total counter
+elastickv_raft_snapshot_stream_payload_bytes_total{group="1",node_address="10.0.0.1:50051",node_id="n1"} 4096
 `),
 		"elastickv_raft_dispatch_dropped_total",
 		"elastickv_raft_dispatch_errors_total",
 		"elastickv_raft_step_queue_full_total",
+		"elastickv_raft_send_stream_opens_total",
+		"elastickv_raft_send_stream_reconnects_total",
+		"elastickv_raft_send_stream_messages_total",
+		"elastickv_raft_snapshot_stream_sends_total",
+		"elastickv_raft_snapshot_stream_payload_bytes_total",
 	)
 	require.NoError(t, err)
 }

--- a/scripts/run-jepsen-raft-streaming-multigroup-soak.sh
+++ b/scripts/run-jepsen-raft-streaming-multigroup-soak.sh
@@ -9,9 +9,11 @@ CONCURRENCY="${CONCURRENCY:-30}"
 FAULT_INTERVAL="${FAULT_INTERVAL:-15}"
 SNAPSHOT_COUNT="${SNAPSHOT_COUNT:-64}"
 STORE_ROOT="${STORE_ROOT:-$REPO_ROOT/jepsen/store}"
+GRPC_HOST_PORT="${GRPC_HOST_PORT:-n1:50051}"
 MARKER="$(mktemp "${TMPDIR:-/tmp}/elastickv-streaming-soak.XXXXXX")"
 ROUTE_KEY_BIN="$(mktemp "${TMPDIR:-/tmp}/elastickv-route-key.XXXXXX")"
-trap 'rm -f "$MARKER" "$ROUTE_KEY_BIN"' EXIT
+LIST_ROUTES_BIN="$(mktemp "${TMPDIR:-/tmp}/elastickv-list-routes.XXXXXX")"
+trap 'rm -f "$MARKER" "$ROUTE_KEY_BIN" "$LIST_ROUTES_BIN"' EXIT
 
 if [ -z "$LEIN_BIN" ] || [ ! -x "$LEIN_BIN" ]; then
   echo "lein not found; set LEIN to an executable" >&2
@@ -20,6 +22,7 @@ fi
 
 cd "$REPO_ROOT"
 go build -o "$ROUTE_KEY_BIN" ./cmd/elastickv-route-key
+go build -o "$LIST_ROUTES_BIN" ./cmd/elastickv-list-routes
 T2_KEY="$("$ROUTE_KEY_BIN" jepsen_append_t2)"
 T3_KEY="$("$ROUTE_KEY_BIN" jepsen_append_t3)"
 SHARD_RANGES=":${T2_KEY}=1,${T2_KEY}:${T3_KEY}=2,${T3_KEY}:=3"
@@ -32,6 +35,8 @@ HOME="$(pwd)/tmp-home" LEIN_HOME="$(pwd)/.lein" \
     --nodes n1,n2,n3,n4,n5 \
     --raft-groups 1=50051,2=50052,3=50053 \
     --shard-ranges "$SHARD_RANGES" \
+    --list-routes-bin "$LIST_ROUTES_BIN" \
+    --grpc-host-port "$GRPC_HOST_PORT" \
     --faults partition,kill,pause \
     --fault-interval "$FAULT_INTERVAL" \
     --time-limit "$TIME_LIMIT" \

--- a/scripts/run-jepsen-raft-streaming-multigroup-soak.sh
+++ b/scripts/run-jepsen-raft-streaming-multigroup-soak.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LEIN_BIN="${LEIN:-$(command -v lein || true)}"
+TIME_LIMIT="${TIME_LIMIT:-600}"
+RATE="${RATE:-50}"
+CONCURRENCY="${CONCURRENCY:-30}"
+FAULT_INTERVAL="${FAULT_INTERVAL:-15}"
+SNAPSHOT_COUNT="${SNAPSHOT_COUNT:-64}"
+STORE_ROOT="${STORE_ROOT:-$REPO_ROOT/jepsen/store}"
+MARKER="$(mktemp "${TMPDIR:-/tmp}/elastickv-streaming-soak.XXXXXX")"
+ROUTE_KEY_BIN="$(mktemp "${TMPDIR:-/tmp}/elastickv-route-key.XXXXXX")"
+trap 'rm -f "$MARKER" "$ROUTE_KEY_BIN"' EXIT
+
+if [ -z "$LEIN_BIN" ] || [ ! -x "$LEIN_BIN" ]; then
+  echo "lein not found; set LEIN to an executable" >&2
+  exit 127
+fi
+
+cd "$REPO_ROOT"
+go build -o "$ROUTE_KEY_BIN" ./cmd/elastickv-route-key
+T2_KEY="$("$ROUTE_KEY_BIN" jepsen_append_t2)"
+T3_KEY="$("$ROUTE_KEY_BIN" jepsen_append_t3)"
+SHARD_RANGES=":${T2_KEY}=1,${T2_KEY}:${T3_KEY}=2,${T3_KEY}:=3"
+
+cd "$REPO_ROOT/jepsen"
+mkdir -p tmp-home .lein
+HOME="$(pwd)/tmp-home" LEIN_HOME="$(pwd)/.lein" \
+  LEIN_JVM_OPTS="-Duser.home=$(pwd)/tmp-home" \
+  "$LEIN_BIN" run -m elastickv.dynamodb-multi-table-workload \
+    --nodes n1,n2,n3,n4,n5 \
+    --raft-groups 1=50051,2=50052,3=50053 \
+    --shard-ranges "$SHARD_RANGES" \
+    --faults partition,kill,pause \
+    --fault-interval "$FAULT_INTERVAL" \
+    --time-limit "$TIME_LIMIT" \
+    --rate "$RATE" \
+    --concurrency "$CONCURRENCY" \
+    --raft-snapshot-count "$SNAPSHOT_COUNT" \
+    --raft-dispatcher-lanes
+
+metrics_files=()
+while IFS= read -r -d '' file; do
+  metrics_files+=("$file")
+done < <(find "$STORE_ROOT" -type f -name elastickv-transport-metrics.prom -newer "$MARKER" -print0)
+if [ "${#metrics_files[@]}" -lt 3 ]; then
+  echo "Jepsen completed but fewer than three metrics evidence files were collected under $STORE_ROOT" >&2
+  exit 1
+fi
+
+verification="$STORE_ROOT/raft-streaming-multigroup-verification.txt"
+EXPECTED_GROUPS=1,2,3 MIN_NODES=3 \
+  "$REPO_ROOT/scripts/verify-raft-streaming-multigroup-metrics.sh" "${metrics_files[@]}" \
+  | tee "$verification"
+echo "verification evidence: $verification"

--- a/scripts/verify-raft-streaming-multigroup-metrics.sh
+++ b/scripts/verify-raft-streaming-multigroup-metrics.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: $0 METRICS_FILE [METRICS_FILE ...]" >&2
+  exit 2
+fi
+
+EXPECTED_GROUPS="${EXPECTED_GROUPS:-1,2,3}"
+MIN_NODES="${MIN_NODES:-3}"
+
+case "$MIN_NODES" in
+  ''|*[!0-9]*)
+    echo "MIN_NODES must be a positive integer" >&2
+    exit 2
+    ;;
+esac
+if [ "$MIN_NODES" -lt 1 ]; then
+  echo "MIN_NODES must be a positive integer" >&2
+  exit 2
+fi
+
+if [ "$#" -lt "$MIN_NODES" ]; then
+  echo "expected metrics from at least $MIN_NODES nodes, got $#" >&2
+  exit 1
+fi
+
+for file in "$@"; do
+  if [ ! -s "$file" ]; then
+    echo "missing or empty metrics evidence: $file" >&2
+    exit 1
+  fi
+  if ! awk '
+    /^elastickv_raft_/ {
+      if ($NF !~ /^([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+)?$/) {
+        print "invalid metric value in " FILENAME ": " $0 > "/dev/stderr"
+        bad = 1
+      }
+      if (index($0, "group=\"") == 0 || index($0, "node_id=\"") == 0 || index($0, "node_address=\"") == 0) {
+        print "missing required metric labels in " FILENAME ": " $0 > "/dev/stderr"
+        bad = 1
+      }
+    }
+    END { exit bad }
+  ' "$file"; then
+    exit 1
+  fi
+done
+
+seen_node_ids=","
+seen_node_addresses=","
+for file in "$@"; do
+  node_ids="$(sed -n 's/.*node_id="\([^"]*\)".*/\1/p' "$file" | sort -u)"
+  node_id_count="$(printf '%s\n' "$node_ids" | awk 'NF { count++ } END { print count + 0 }')"
+  if [ "$node_id_count" -ne 1 ]; then
+    echo "expected exactly one node_id in $file, got $node_id_count" >&2
+    exit 1
+  fi
+  node_id="$(printf '%s\n' "$node_ids" | awk 'NF { print; exit }')"
+  case "$node_id" in
+    *[!A-Za-z0-9._-]*|'')
+      echo "invalid node_id $node_id in $file" >&2
+      exit 1
+      ;;
+  esac
+  case "$seen_node_ids" in
+    *,"$node_id",*)
+      echo "duplicate node_id $node_id across metrics files" >&2
+      exit 1
+      ;;
+  esac
+  seen_node_ids="${seen_node_ids}${node_id},"
+
+  node_addresses="$(sed -n 's/.*node_address="\([^"]*\)".*/\1/p' "$file" | sort -u)"
+  node_address_count="$(printf '%s\n' "$node_addresses" | awk 'NF { count++ } END { print count + 0 }')"
+  if [ "$node_address_count" -ne 1 ]; then
+    echo "expected exactly one node_address in $file, got $node_address_count" >&2
+    exit 1
+  fi
+  node_address="$(printf '%s\n' "$node_addresses" | awk 'NF { print; exit }')"
+  case "$node_address" in
+    *[!A-Za-z0-9._:\[\]-]*|'')
+      echo "invalid node_address $node_address in $file" >&2
+      exit 1
+      ;;
+  esac
+  case "$seen_node_addresses" in
+    *,"$node_address",*)
+      echo "duplicate node_address $node_address across metrics files" >&2
+      exit 1
+      ;;
+  esac
+  seen_node_addresses="${seen_node_addresses}${node_address},"
+done
+
+metric_total() {
+  local metric="$1"
+  local group="$2"
+  shift 2
+  awk -v metric="$metric" -v group="$group" '
+    index($0, metric "{") == 1 && index($0, "group=\"" group "\"") > 0 { total += $NF }
+    END { printf "%.0f", total + 0 }
+  ' "$@"
+}
+
+metric_code_total() {
+  local group="$1"
+  local code="$2"
+  shift 2
+  awk -v group="$group" -v code="$code" '
+    index($0, "elastickv_raft_dispatch_errors_by_code_total{") == 1 &&
+      index($0, "group=\"" group "\"") > 0 &&
+      index($0, "code=\"" code "\"") > 0 { total += $NF }
+    END { printf "%.0f", total + 0 }
+  ' "$@"
+}
+
+group_activity_file_count() {
+  local group="$1"
+  shift
+  local count=0
+  local file
+  for file in "$@"; do
+    if awk -v group="$group" '
+      index($0, "elastickv_raft_send_stream_messages_total{") == 1 &&
+        index($0, "group=\"" group "\"") > 0 && $NF > 0 { found = 1 }
+      END { exit !found }
+    ' "$file"; then
+      count=$((count + 1))
+    fi
+  done
+  printf '%d' "$count"
+}
+
+IFS=',' read -r -a groups <<< "$EXPECTED_GROUPS"
+printf 'streaming_multigroup_soak_metrics_v1\n'
+for group in "${groups[@]}"; do
+  case "$group" in
+    ''|*[!0-9]*|0)
+      echo "EXPECTED_GROUPS must contain positive numeric group IDs" >&2
+      exit 2
+      ;;
+  esac
+  opens="$(metric_total elastickv_raft_send_stream_opens_total "$group" "$@")"
+  reconnects="$(metric_total elastickv_raft_send_stream_reconnects_total "$group" "$@")"
+  messages="$(metric_total elastickv_raft_send_stream_messages_total "$group" "$@")"
+  snapshots="$(metric_total elastickv_raft_snapshot_stream_sends_total "$group" "$@")"
+  snapshot_bytes="$(metric_total elastickv_raft_snapshot_stream_payload_bytes_total "$group" "$@")"
+  deadlines="$(metric_code_total "$group" DeadlineExceeded "$@")"
+  exhausted="$(metric_code_total "$group" ResourceExhausted "$@")"
+  drops="$(metric_total elastickv_raft_dispatch_dropped_total "$group" "$@")"
+  step_full="$(metric_total elastickv_raft_step_queue_full_total "$group" "$@")"
+  activity_nodes="$(group_activity_file_count "$group" "$@")"
+
+  if [ "$activity_nodes" -lt "$MIN_NODES" ]; then
+    echo "group $group has stream activity on only $activity_nodes nodes, want at least $MIN_NODES" >&2
+    exit 1
+  fi
+  if [ "$opens" -eq 0 ] || [ "$reconnects" -eq 0 ] || [ "$messages" -eq 0 ]; then
+    echo "group $group missing stream activity: opens=$opens reconnects=$reconnects messages=$messages" >&2
+    exit 1
+  fi
+  if [ "$snapshots" -eq 0 ] || [ "$snapshot_bytes" -eq 0 ]; then
+    echo "group $group missing snapshot activity: sends=$snapshots bytes=$snapshot_bytes" >&2
+    exit 1
+  fi
+  if [ "$deadlines" -eq 0 ] && [ "$exhausted" -eq 0 ] && [ "$drops" -eq 0 ] && [ "$step_full" -eq 0 ]; then
+    echo "group $group missing backpressure evidence" >&2
+    exit 1
+  fi
+  printf 'group=%s activity_nodes=%s opens=%s reconnects=%s messages=%s snapshots=%s snapshot_bytes=%s deadline_errors=%s resource_exhausted=%s drops=%s step_full=%s\n' \
+    "$group" "$activity_nodes" "$opens" "$reconnects" "$messages" "$snapshots" "$snapshot_bytes" "$deadlines" "$exhausted" "$drops" "$step_full"
+done
+printf 'result=pass\n'


### PR DESCRIPTION
## Summary

- add an executable three-group, three-node-per-group gRPC transport soak with reconnect, flow-control backpressure, snapshot, and recovery sentinels
- integrate a five-node, three-group DynamoDB Jepsen run and fail-closed cumulative transport-metrics verification
- expose observational transport counters and record schema-v2 evidence
- mark the streaming transport design as implemented with its acceptance evidence and operational instructions

## Risk

The runtime change is limited to observational transport counters. Raft message routing, acknowledgements, quorum decisions, and fallback behavior are unchanged. The soak and verifier fail closed when required topology, delivery, reconnect, snapshot, or backpressure evidence is missing.

## Test evidence

- `make lint`
- `go test -race ./internal/raftengine/etcd/transportsoak ./internal/raftengine/etcd ./monitoring ./cmd/elastickv-raft-stream-soak`
- `go run ./cmd/elastickv-raft-stream-soak -output docs/evidence/raft_streaming_multigroup_soak.json`
- `go run ./cmd/elastickv-raft-stream-soak -verify docs/evidence/raft_streaming_multigroup_soak.json`
- `bash -n scripts/run-jepsen-raft-streaming-multigroup-soak.sh scripts/verify-raft-streaming-multigroup-metrics.sh`
- `shellcheck scripts/run-jepsen-raft-streaming-multigroup-soak.sh scripts/verify-raft-streaming-multigroup-metrics.sh`
- `cd jepsen && lein test elastickv.cli-test elastickv.dynamodb-multi-table-workload-test` (23 tests, 42 assertions)