### PR TITLE
Add Pebble SST ingest snapshot transfer

### DIFF
--- a/docs/design/2026_06_12_proposed_scaling_roadmap.md
+++ b/docs/design/2026_06_12_proposed_scaling_roadmap.md
@@ -364,7 +364,8 @@ control-plane (`*_proposed_*` doc TBD).**
 
 ### 5.2 Design — milestones
 
-**M1 — SST ingest snapshot transfer (`*_proposed_*` doc TBD).**
+**M1 — SST ingest snapshot transfer
+([focused design](2026_07_19_proposed_pebble_sst_ingest_snapshot_transfer.md)).**
 - Replace `pebbleSnapshot.WriteTo`'s full-iter stream with
   **Pebble SST-level snapshot transfer**: leader takes a
   Pebble snapshot, copies the live SSTs (+ memtable flush) as

--- a/docs/design/2026_06_12_proposed_scaling_roadmap.md
+++ b/docs/design/2026_06_12_proposed_scaling_roadmap.md
@@ -365,7 +365,7 @@ control-plane (`*_proposed_*` doc TBD).**
 ### 5.2 Design — milestones
 
 **M1 — SST ingest snapshot transfer
-([focused design](2026_07_19_proposed_pebble_sst_ingest_snapshot_transfer.md)).**
+([focused design](2026_07_19_implemented_pebble_sst_ingest_snapshot_transfer.md)).**
 - Replace `pebbleSnapshot.WriteTo`'s full-iter stream with
   **Pebble SST-level snapshot transfer**: leader takes a
   Pebble snapshot, copies the live SSTs (+ memtable flush) as

--- a/docs/design/2026_07_19_implemented_pebble_sst_ingest_snapshot_transfer.md
+++ b/docs/design/2026_07_19_implemented_pebble_sst_ingest_snapshot_transfer.md
@@ -1,6 +1,6 @@
 # Pebble SST Ingest Snapshot Transfer
 
-Status: Proposed
+Status: Implemented
 Author: bootjp
 Date: 2026-07-19
 

--- a/docs/design/2026_07_19_proposed_pebble_sst_ingest_snapshot_transfer.md
+++ b/docs/design/2026_07_19_proposed_pebble_sst_ingest_snapshot_transfer.md
@@ -1,0 +1,215 @@
+# Pebble SST Ingest Snapshot Transfer
+
+Status: Proposed
+Author: bootjp
+Date: 2026-07-19
+
+## 1. Scope
+
+This design implements storage-tier milestone M1 from the scaling roadmap. A
+Pebble-backed Raft state machine may emit a checkpoint-derived set of external
+SST files. The existing Raft snapshot transport carries those files in a
+self-describing stream, and the receiver verifies and ingests them into an
+empty temporary Pebble database before replacing the live database.
+
+The central scope is:
+
+- capture a point-in-time checkpoint that matches the Raft snapshot request;
+- export non-overlapping, ingestible SST files;
+- carry an integrity-protected manifest and file bodies through the existing
+  disk-spooled gRPC snapshot transport;
+- restore by `pebble.DB.Ingest`, not by per-entry Pebble batches;
+- leave the current database untouched on parse, checksum, ingest, metadata,
+  rename, or reopen failure;
+- clean temporary checkpoint, export, receive, ingest, and rollback paths;
+- preserve the legacy `EKVPBBL1` stream as the default and as a sender-side
+  fallback.
+
+This change is independent of physical object offload. It does not reference
+S3, remote Pebble objects, shared storage locators, or the backup subsystem.
+
+## 2. Pebble constraint
+
+Pebble's local ingest API accepts external SSTs whose internal sequence number
+is zero, then assigns the ingest sequence number atomically. SST files already
+owned by a live Pebble database contain non-zero sequence numbers and therefore
+cannot be copied directly into `DB.Ingest`.
+
+The sender consequently performs one merge iteration over a stable checkpoint
+and writes equivalent external SSTs with `sstable.Writer`. MVCC versions remain
+distinct because elastickv's physical Pebble user key already includes the
+inverted commit timestamp. Values, including storage-encryption envelopes, are
+copied byte-for-byte. This removes the receiver's per-key batch rewrite and
+write amplification while respecting Pebble's ingest contract.
+
+## 3. Consistency boundary
+
+`pebbleStore.Snapshot` is called synchronously from the Raft run loop before
+the next committed entry is applied. When SST snapshots are enabled it acquires
+locks in the existing order:
+
+1. `maintenanceMu`;
+2. `dbMu.Lock`;
+3. `applyMu`.
+
+While those locks are held, the store flushes the memtable and calls
+`DB.Checkpoint(..., pebble.WithFlushedWAL())`. The exclusive database lock is
+required because direct `PutAt`, `DeleteAt`, and `ExpireAt` writes do not use
+`applyMu`. Compaction, restore, close, direct writes, Raft apply batches,
+applied-index checkpoints, and prefix-delete batches cannot cross this
+boundary. The checkpoint is therefore the same logical store image captured
+by the fallback `pebble.Snapshot` handle.
+
+Checkpoint construction stays in `Snapshot`; expensive SST export remains in
+`Snapshot.WriteTo`. This is necessary because deferring `DB.Checkpoint` to the
+background writer would allow later Raft applies into an older snapshot index.
+
+## 4. Stream format
+
+The store payload uses the following format. The existing KV FSM header and
+the Raft engine's `.fsm` CRC32C footer remain outside it and are unchanged.
+
+```text
+magic                 8 bytes  "EKVSSTI1"
+manifest_length       8 bytes  signed big-endian, 1..64 MiB
+manifest_sha256      32 bytes
+manifest JSON         manifest_length bytes
+file[0] bytes         manifest.files[0].size bytes
+...
+file[n] bytes         manifest.files[n].size bytes
+EOF                   required; trailing bytes are rejected
+```
+
+The manifest records:
+
+- format version;
+- `last_commit_ts`, committed and pending retention watermarks;
+- optional durable Raft applied index;
+- entry count and uncompressed byte count;
+- total SST bytes;
+- ordered file name, size, SHA-256, smallest key, and largest key.
+
+File names are canonical (`000000.sst`, `000001.sst`, ...), so a manifest
+cannot escape the receive directory. Key bounds must be strictly
+non-overlapping. The manifest SHA-256 is checked before any file is created;
+each file SHA-256 and exact byte count are checked before ingest. The outer
+Raft CRC32C remains a transport and disk corruption check, while the inner
+hashes prevent the store from swapping state before the outer restore pass
+finishes computing its footer checksum.
+
+The stream remains compatible with arbitrary gRPC chunk boundaries. No file is
+materialized in memory; the sender copies files to the existing `.fsm` spool
+and the receiver copies each bounded body directly to a staging file.
+
+## 5. Export and transport
+
+The checkpoint is opened read-only. A sorted iterator writes approximately
+64 MiB external SST files using the checkpoint's table format and Pebble's
+default comparer. The boundary is approximate because an individual entry is
+never split. The exporter computes the physical maximum MVCC commit timestamp
+while iterating and raises the manifest watermark if an older metadata key is
+stale.
+
+All files are completed and hashed before the first new-format byte is written.
+If checkpoint creation, checkpoint open, iteration, SST close, manifest encode,
+or pre-stream preparation fails, `WriteTo` emits the legacy `EKVPBBL1` stream
+from the point-in-time fallback snapshot. Once streaming begins, an I/O error
+fails the snapshot write; it never appends a second format to a partial stream.
+
+The existing `SendSnapshot` gRPC RPC remains the authoritative Raft transport.
+It already provides disk spooling, bounded chunks, flow control, CRC32C, retry,
+and orphan cleanup. Parallel multi-RPC transfer of files is a future extension:
+it needs a resumable transfer ID and random-access receiver assembly to retain
+the current one-token/one-snapshot publication rule. It is not required for
+the safe ingest format and does not couple this work to remote object storage.
+
+## 6. Restore and rollback
+
+The receiver accepts `EKVSSTI1` regardless of whether local emission is
+enabled. It performs these steps while `Restore` holds the existing exclusive
+maintenance, DB, and metadata locks:
+
+1. parse and validate the manifest;
+2. receive each file into a sibling staging directory and verify SHA-256;
+3. reject truncation and trailing bytes;
+4. open a fresh sibling Pebble database;
+5. ingest all files in one `DB.Ingest` call;
+6. synchronously write and verify snapshot metadata;
+7. close the temporary database;
+8. rename the current database to a same-filesystem rollback directory;
+9. rename and reopen the replacement;
+10. verify metadata again, then delete the rollback directory.
+
+If rename, reopen, or metadata verification fails after step 8, the replacement
+is closed and removed, the old directory is renamed back, and the old database
+is reopened. The same rollback helper also strengthens the existing native and
+streaming-MVCC restore callers.
+
+At startup, a missing live directory and exactly one rollback directory means
+the process stopped between the two renames, so the rollback directory is
+restored before Pebble is opened. Multiple rollback directories are ambiguous
+and fail closed without deleting any candidate. A rollback directory beside a
+live database is removed only after the live database opens and its metadata
+scans succeed. Startup also removes stale directories matching only the
+store-specific checkpoint, receive, and ingest prefixes. Normal
+`Snapshot.Close` removes its checkpoint, and every export/restore error path
+removes its temporary files.
+
+### 6.1 Caller audit
+
+The return and success semantics of `swapInTempDB` are unchanged, but its
+failure semantics now restore the previous database. Its three production
+callers were audited: native Pebble restore, streaming-MVCC restore, and the new
+SST-ingest restore. Each creates a closed temporary database in a sibling
+directory and invokes the swap while `Restore` holds `maintenanceMu`, the
+exclusive `dbMu`, and `mtx`.
+
+Snapshot callers were also audited. The Raft FSM and leader-routed wrapper keep
+the `Snapshot`/`WriteTo`/`Close` contract, while the etcd migration helper still
+accepts either payload because it restores through the same receiver-capable
+binary. With emission disabled, all callers continue to receive `EKVPBBL1`.
+
+## 7. Rollout and fallback
+
+Emission is disabled by default. Operators first deploy a receiver-capable
+binary to every member, then set:
+
+```text
+ELASTICKV_PEBBLE_SST_INGEST_SNAPSHOT=true
+```
+
+on all members in a rolling restart. This cluster-wide gate is required because
+an older receiver does not recognize `EKVSSTI1`. Setting the variable to an
+invalid value is fail-safe and leaves legacy emission enabled. Disabling it and
+restarting restores legacy emission without changing persisted data.
+
+New receivers continue to restore `EKVPBBL1` and streaming MVCC snapshots. A
+new sender also falls back to `EKVPBBL1` before output if SST preparation fails.
+
+## 8. Acceptance evidence
+
+| Requirement | Test or code evidence |
+|---|---|
+| Checkpoint excludes later writes | `TestPebbleStoreSSTIngestSnapshotRoundTrip` |
+| Multiple sorted SST files ingest correctly | `TestPebbleStoreSSTIngestSnapshotRoundTrip` |
+| Arbitrary transport chunk boundaries | one-byte reader in `TestPebbleStoreSSTIngestSnapshotRoundTrip` |
+| gRPC spool, CRC/token, and fresh-FSM restore | `TestGRPCSnapshotTransportRoundTripsSSTIngestPayload` |
+| Manifest, file, truncation/trailing integrity | `TestPebbleStoreSSTIngestSnapshotCorruptionPreservesDestination` |
+| Invalid signed manifest length is rejected | `TestSSTIngestManifestRejectsNegativeLength` |
+| Corruption leaves destination unchanged | `TestPebbleStoreSSTIngestSnapshotCorruptionPreservesDestination` |
+| Preparation failure uses legacy stream | `TestPebbleStoreSSTIngestSnapshotFallsBackBeforeStreaming` |
+| Rename/open verification rollback | `TestSwapInTempDBRollsBackOnMetadataFailure` |
+| Interrupted rename recovers old DB; ambiguous backups fail closed | `TestPebbleStoreCleansStaleSSTSnapshotArtifacts` |
+| Env is opt-in and invalid values fail closed | `TestSSTIngestSnapshotConfigurationAndManifestValidation` |
+| KV FSM header preserves the store payload | `TestKVFSMSnapshotRoundTripsSSTIngestPayload` |
+| Existing native/MVCC restore behavior | full `go test ./store` suite |
+
+## 9. Intentional non-goals
+
+- physical S3/object offload and shared Pebble object references;
+- resumable or parallel multi-RPC snapshot files;
+- changing the Raft snapshot token, membership protocol, or snapshot cadence;
+- eliminating sender-side iteration, which Pebble's zero-sequence ingest
+  contract prevents for live database SSTs;
+- proving the roadmap's 5 TiB/one-hour production SLO in unit tests. That
+  requires deployment-scale evidence after this safe transport format lands.

--- a/internal/raftengine/etcd/grpc_transport_sst_snapshot_test.go
+++ b/internal/raftengine/etcd/grpc_transport_sst_snapshot_test.go
@@ -1,0 +1,77 @@
+package etcd
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/bootjp/elastickv/kv"
+	pb "github.com/bootjp/elastickv/proto"
+	"github.com/bootjp/elastickv/store"
+	"github.com/stretchr/testify/require"
+	raftpb "go.etcd.io/raft/v3/raftpb"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestGRPCSnapshotTransportRoundTripsSSTIngestPayload(t *testing.T) {
+	const (
+		index     = uint64(321)
+		term      = uint64(7)
+		chunkSize = 17
+	)
+
+	srcStore, err := store.NewPebbleStore(
+		filepath.Join(t.TempDir(), "src"),
+		store.WithSSTIngestSnapshots(true),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, srcStore.Close()) })
+	require.NoError(t, srcStore.PutAt(context.Background(), []byte("key"), []byte("value"), 41, 0))
+
+	senderFSM := kv.NewKvFSMWithHLC(srcStore, kv.NewHLC())
+	snapshot, err := senderFSM.Snapshot()
+	require.NoError(t, err)
+	var payload bytes.Buffer
+	_, err = snapshot.WriteTo(&payload)
+	require.NoError(t, err)
+	require.NoError(t, snapshot.Close())
+
+	metadata := raftpb.Message{
+		Type: messageTypePtr(raftpb.MsgSnap),
+		From: uint64Ptr(1),
+		To:   uint64Ptr(2),
+		Snapshot: &raftpb.Snapshot{
+			Metadata: testSnapshotMetadata(index, term, nil),
+		},
+	}
+	encodedMetadata, err := proto.Marshal(&metadata)
+	require.NoError(t, err)
+
+	chunks := []*pb.EtcdRaftSnapshotChunk{{Metadata: encodedMetadata}}
+	for remaining := payload.Bytes(); len(remaining) > 0; {
+		n := min(chunkSize, len(remaining))
+		chunks = append(chunks, &pb.EtcdRaftSnapshotChunk{Chunk: bytes.Clone(remaining[:n])})
+		remaining = remaining[n:]
+	}
+	chunks[len(chunks)-1].Final = true
+
+	fsmSnapDir := t.TempDir()
+	transport := NewGRPCTransport(nil)
+	transport.SetSpoolDir(t.TempDir())
+	transport.SetFSMSnapDir(fsmSnapDir)
+	received, err := transport.receiveSnapshotStream(&testSendSnapshotServer{chunks: chunks})
+	require.NoError(t, err)
+	require.True(t, isSnapshotToken(received.Snapshot.Data))
+
+	dstStore, err := store.NewPebbleStore(filepath.Join(t.TempDir(), "dst"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, dstStore.Close()) })
+	receiverFSM := kv.NewKvFSMWithHLC(dstStore, kv.NewHLC())
+	_, err = restoreSnapshotState(receiverFSM, *received.Snapshot, index, fsmSnapDir, nil, nil)
+	require.NoError(t, err)
+
+	value, err := dstStore.GetAt(context.Background(), []byte("key"), 41)
+	require.NoError(t, err)
+	require.Equal(t, []byte("value"), value)
+}

--- a/kv/snapshot_sst_ingest_test.go
+++ b/kv/snapshot_sst_ingest_test.go
@@ -1,0 +1,40 @@
+package kv
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"path/filepath"
+	"testing"
+
+	store3 "github.com/bootjp/elastickv/store"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKVFSMSnapshotRoundTripsSSTIngestPayload(t *testing.T) {
+	srcStore, err := store3.NewPebbleStore(
+		filepath.Join(t.TempDir(), "src"),
+		store3.WithSSTIngestSnapshots(true),
+	)
+	require.NoError(t, err)
+	defer srcStore.Close()
+	require.NoError(t, srcStore.PutAt(context.Background(), []byte("key"), []byte("value"), 41, 0))
+
+	srcFSM := NewKvFSMWithHLC(srcStore, NewHLC())
+	snapshot, err := srcFSM.Snapshot()
+	require.NoError(t, err)
+	var payload bytes.Buffer
+	_, err = snapshot.WriteTo(&payload)
+	require.NoError(t, err)
+	require.NoError(t, snapshot.Close())
+
+	dstStore, err := store3.NewPebbleStore(filepath.Join(t.TempDir(), "dst"))
+	require.NoError(t, err)
+	defer dstStore.Close()
+	dstFSM := NewKvFSMWithHLC(dstStore, NewHLC())
+	require.NoError(t, dstFSM.Restore(io.NopCloser(bytes.NewReader(payload.Bytes()))))
+
+	value, err := dstStore.GetAt(context.Background(), []byte("key"), 41)
+	require.NoError(t, err)
+	require.Equal(t, []byte("value"), value)
+}

--- a/store/lsm_store.go
+++ b/store/lsm_store.go
@@ -212,7 +212,8 @@ type pebbleStore struct {
 	// implemented in snapshot_pebble_sst.go. Receivers always understand the
 	// format; senders keep the legacy stream by default for rolling-upgrade
 	// compatibility with older binaries.
-	sstIngestSnapshots bool
+	sstIngestSnapshots       bool
+	sstIngestTargetFileBytes uint64
 	// writeConflicts tracks per-(kind, key_prefix) OCC conflict counts
 	// detected inside ApplyMutations. Polled by the monitoring
 	// WriteConflictCollector; not part of the authoritative OCC path.
@@ -320,10 +321,11 @@ func NewPebbleStore(dir string, opts ...PebbleStoreOption) (MVCCStore, error) {
 		log: slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 			Level: slog.LevelWarn,
 		})),
-		writeConflicts:        newWriteConflictCounter(),
-		fsmApplyWriteOpts:     fsmOpts,
-		fsmApplySyncModeLabel: fsmLabel,
-		sstIngestSnapshots:    resolveSSTIngestSnapshots(os.Getenv(sstIngestSnapshotEnv)),
+		writeConflicts:           newWriteConflictCounter(),
+		fsmApplyWriteOpts:        fsmOpts,
+		fsmApplySyncModeLabel:    fsmLabel,
+		sstIngestSnapshots:       resolveSSTIngestSnapshots(os.Getenv(sstIngestSnapshotEnv)),
+		sstIngestTargetFileBytes: defaultSSTIngestTargetFileSize,
 	}
 	for _, opt := range opts {
 		opt(s)

--- a/store/lsm_store.go
+++ b/store/lsm_store.go
@@ -208,6 +208,11 @@ type pebbleStore struct {
 	applyMu              sync.Mutex // serializes ApplyMutations: conflict check → commit
 	maintenanceMu        sync.Mutex
 	dir                  string
+	// sstIngestSnapshots enables the cluster-wide opt-in snapshot format
+	// implemented in snapshot_pebble_sst.go. Receivers always understand the
+	// format; senders keep the legacy stream by default for rolling-upgrade
+	// compatibility with older binaries.
+	sstIngestSnapshots bool
 	// writeConflicts tracks per-(kind, key_prefix) OCC conflict counts
 	// detected inside ApplyMutations. Polled by the monitoring
 	// WriteConflictCollector; not part of the authoritative OCC path.
@@ -270,6 +275,15 @@ func WithPebbleLogger(l *slog.Logger) PebbleStoreOption {
 	}
 }
 
+// WithSSTIngestSnapshots controls whether Snapshot emits the SST-ingest
+// format. It is primarily useful for tests and embedded callers; production
+// resolves ELASTICKV_PEBBLE_SST_INGEST_SNAPSHOT at store construction time.
+func WithSSTIngestSnapshots(enabled bool) PebbleStoreOption {
+	return func(s *pebbleStore) {
+		s.sstIngestSnapshots = enabled
+	}
+}
+
 // defaultPebbleOptionsWithCache returns the standard Pebble options used
 // throughout the store (including restores) to ensure consistent behaviour
 // between a freshly opened and a restored/swapped-in database, along with
@@ -309,9 +323,13 @@ func NewPebbleStore(dir string, opts ...PebbleStoreOption) (MVCCStore, error) {
 		writeConflicts:        newWriteConflictCounter(),
 		fsmApplyWriteOpts:     fsmOpts,
 		fsmApplySyncModeLabel: fsmLabel,
+		sstIngestSnapshots:    resolveSSTIngestSnapshots(os.Getenv(sstIngestSnapshotEnv)),
 	}
 	for _, opt := range opts {
 		opt(s)
+	}
+	if err := cleanupPebbleSnapshotArtifacts(dir); err != nil {
+		return nil, err
 	}
 
 	pebbleOpts, cache := defaultPebbleOptionsWithCache()
@@ -357,6 +375,13 @@ func NewPebbleStore(dir string, opts ...PebbleStoreOption) (MVCCStore, error) {
 	s.lastCommitTS = maxTS
 	s.minRetainedTS = minRetainedTS
 	s.pendingMinRetainedTS = pendingMinRetainedTS
+	// A backup is only stale after the live directory has opened and its
+	// metadata has been read successfully. Before this point it is the recovery
+	// source for a process crash between the two restore renames.
+	if err := cleanupPebbleRestoreBackups(dir); err != nil {
+		cleanupOnInitFail()
+		return nil, err
+	}
 
 	return s, nil
 }
@@ -2761,6 +2786,9 @@ func (s *pebbleStore) Compact(ctx context.Context, minTS uint64) error {
 }
 
 func (s *pebbleStore) Snapshot() (Snapshot, error) {
+	if s.sstIngestSnapshots {
+		return s.newSSTIngestSnapshot()
+	}
 	s.dbMu.RLock()
 	defer s.dbMu.RUnlock()
 	snap := s.db.NewSnapshot()
@@ -2944,6 +2972,8 @@ func (s *pebbleStore) Restore(r io.Reader) error {
 		// Native Pebble format: restorePebbleNativeAtomic performs a temp-dir
 		// swap so the existing DB is preserved if the restore fails midway.
 		return s.restorePebbleNativeAtomic(br)
+	case bytes.Equal(header, pebbleSSTIngestSnapshotMagic[:]):
+		return s.restorePebbleSSTIngestAtomic(br)
 	case bytes.Equal(header, mvccSnapshotMagic[:]):
 		// Streaming MVCC format: restoreFromStreamingMVCC performs an atomic
 		// temp-dir swap, so the existing DB is preserved until checksum
@@ -3236,62 +3266,101 @@ func writeMVCCEntriesToDB(body io.Reader, db *pebble.DB) error {
 	return commitSnapshotBatch(batch, pebble.Sync)
 }
 
-// swapInTempDB closes the current DB, removes its directory, and renames tmpDir
-// to s.dir, then reopens the DB. The caller is responsible for closing tmpDB
-// before calling this.
+// swapInTempDB closes the current DB and atomically exchanges its directory
+// with tmpDir. The old directory remains as a same-filesystem rollback point
+// until the replacement has opened and its metadata has been verified.
 func (s *pebbleStore) swapInTempDB(tmpDir string) error {
+	return s.swapInTempDBWithMetadata(tmpDir, nil)
+}
+
+func (s *pebbleStore) swapInTempDBWithMetadata(tmpDir string, expected *pebbleSnapshotMetadata) error {
+	backupDir, err := makeSiblingTempDir(s.dir, "restore-backup")
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return err
+	}
 	if err := s.db.Close(); err != nil {
 		_ = os.RemoveAll(tmpDir)
+		_ = os.RemoveAll(backupDir)
 		return errors.WithStack(err)
 	}
 	if s.cache != nil {
 		s.cache.Unref()
 		s.cache = nil
 	}
-	if err := os.RemoveAll(s.dir); err != nil {
+	s.db = nil
+	if err := os.Rename(s.dir, backupDir); err != nil {
 		_ = os.RemoveAll(tmpDir)
-		return errors.WithStack(err)
+		_ = os.RemoveAll(backupDir)
+		return errors.Join(errors.WithStack(err), s.reopenStoreDB(s.dir))
 	}
 	if err := os.Rename(tmpDir, s.dir); err != nil {
 		_ = os.RemoveAll(tmpDir)
-		return errors.WithStack(err)
+		return errors.Join(errors.WithStack(err), s.restoreSwapBackup(backupDir))
 	}
-	opts, cache := defaultPebbleOptionsWithCache()
-	newDB, err := pebble.Open(s.dir, opts)
+	if err := s.reopenStoreDB(s.dir); err != nil {
+		return errors.Join(err, s.restoreSwapBackup(backupDir))
+	}
+	lastCommitTS, minRetainedTS, pendingMinRetainedTS, err := s.metadataAfterSwap(expected)
 	if err != nil {
-		cache.Unref()
-		return errors.WithStack(err)
-	}
-	s.db = newDB
-	s.cache = cache
-	// cleanupOnSwapFail mirrors the cleanup in NewPebbleStore: release the
-	// creator ref on the freshly-opened cache so a failed metadata read
-	// does not pin a ~256 MiB cache on the store across restore retries.
-	cleanupOnSwapFail := func() {
-		_ = newDB.Close()
-		cache.Unref()
-		s.db = nil
-		s.cache = nil
-	}
-	lastCommitTS, err := s.findMaxCommitTS()
-	if err != nil {
-		cleanupOnSwapFail()
-		return err
-	}
-	minRetainedTS, err := s.findMinRetainedTS()
-	if err != nil {
-		cleanupOnSwapFail()
-		return err
-	}
-	pendingMinRetainedTS, err := s.findPendingMinRetainedTS()
-	if err != nil {
-		cleanupOnSwapFail()
-		return err
+		return errors.Join(err, s.restoreSwapBackup(backupDir))
 	}
 	s.lastCommitTS = lastCommitTS
 	s.minRetainedTS = minRetainedTS
 	s.pendingMinRetainedTS = pendingMinRetainedTS
+	if err := os.RemoveAll(backupDir); err != nil {
+		s.log.Warn("failed to remove restore backup", "path", backupDir, "error", err)
+	}
 	return nil
+}
+
+func (s *pebbleStore) reopenStoreDB(dir string) error {
+	opts, cache := defaultPebbleOptionsWithCache()
+	db, err := pebble.Open(dir, opts)
+	if err != nil {
+		cache.Unref()
+		return errors.WithStack(err)
+	}
+	s.db = db
+	s.cache = cache
+	return nil
+}
+
+func (s *pebbleStore) restoreSwapBackup(backupDir string) error {
+	var cleanupErr error
+	if s.db != nil {
+		cleanupErr = s.db.Close()
+		s.db = nil
+	}
+	if s.cache != nil {
+		s.cache.Unref()
+		s.cache = nil
+	}
+	removeErr := os.RemoveAll(s.dir)
+	renameErr := os.Rename(backupDir, s.dir)
+	if renameErr != nil {
+		return errors.Join(errors.WithStack(cleanupErr), errors.WithStack(removeErr), errors.WithStack(renameErr))
+	}
+	return errors.Join(errors.WithStack(cleanupErr), errors.WithStack(removeErr), s.reopenStoreDB(s.dir))
+}
+
+func (s *pebbleStore) metadataAfterSwap(expected *pebbleSnapshotMetadata) (uint64, uint64, uint64, error) {
+	if expected == nil {
+		lastCommitTS, err := s.findMaxCommitTS()
+		if err != nil {
+			return 0, 0, 0, err
+		}
+		minRetainedTS, err := s.findMinRetainedTS()
+		if err != nil {
+			return 0, 0, 0, err
+		}
+		pendingMinRetainedTS, err := s.findPendingMinRetainedTS()
+		return lastCommitTS, minRetainedTS, pendingMinRetainedTS, err
+	}
+	if err := verifyPebbleSnapshotMetadata(s.db, *expected); err != nil {
+		return 0, 0, 0, err
+	}
+	return expected.LastCommitTS, expected.MinRetainedTS, expected.PendingMinRetainedTS, nil
 }
 
 func (s *pebbleStore) Close() error {

--- a/store/snapshot_pebble.go
+++ b/store/snapshot_pebble.go
@@ -112,5 +112,8 @@ type countingWriter struct {
 func (w *countingWriter) Write(p []byte) (int, error) {
 	n, err := w.w.Write(p)
 	w.n += int64(n)
+	if err == nil && n != len(p) {
+		err = io.ErrShortWrite
+	}
 	return n, errors.WithStack(err)
 }

--- a/store/snapshot_pebble_sst.go
+++ b/store/snapshot_pebble_sst.go
@@ -35,10 +35,7 @@ const (
 	sstIngestFilePerm              = 0600
 )
 
-var (
-	pebbleSSTIngestSnapshotMagic = [8]byte{'E', 'K', 'V', 'S', 'S', 'T', 'I', '1'}
-	sstIngestTargetFileBytes     = uint64(defaultSSTIngestTargetFileSize)
-)
+var pebbleSSTIngestSnapshotMagic = [8]byte{'E', 'K', 'V', 'S', 'S', 'T', 'I', '1'}
 
 type pebbleSnapshotMetadata struct {
 	LastCommitTS         uint64
@@ -69,12 +66,13 @@ type pebbleSSTIngestFileMeta struct {
 }
 
 type pebbleSSTIngestSnapshot struct {
-	checkpointDir string
-	fallback      *pebbleSnapshot
-	metadata      pebbleSnapshotMetadata
-	log           *slog.Logger
-	once          sync.Once
-	err           error
+	checkpointDir   string
+	fallback        *pebbleSnapshot
+	metadata        pebbleSnapshotMetadata
+	targetFileBytes uint64
+	log             *slog.Logger
+	once            sync.Once
+	err             error
 }
 
 type pebbleSSTIngestBundle struct {
@@ -84,16 +82,17 @@ type pebbleSSTIngestBundle struct {
 }
 
 type pebbleSSTExporter struct {
-	db           *pebble.DB
-	dir          string
-	manifest     pebbleSSTIngestManifest
-	writer       *sstable.Writer
-	currentPath  string
-	currentName  string
-	currentBytes uint64
-	smallest     []byte
-	largest      []byte
-	fileIndex    int
+	db              *pebble.DB
+	dir             string
+	manifest        pebbleSSTIngestManifest
+	writer          *sstable.Writer
+	currentPath     string
+	currentName     string
+	currentBytes    uint64
+	smallest        []byte
+	largest         []byte
+	fileIndex       int
+	targetFileBytes uint64
 }
 
 func resolveSSTIngestSnapshots(raw string) bool {
@@ -105,16 +104,16 @@ func cleanupPebbleSnapshotArtifacts(dir string) error {
 	clean := filepath.Clean(dir)
 	parent := filepath.Dir(clean)
 	base := filepath.Base(clean)
-	if err := recoverPebbleRestoreBackup(clean, filepath.Join(parent, base+"-restore-backup-*")); err != nil {
+	if err := recoverPebbleRestoreBackup(clean); err != nil {
 		return err
 	}
-	patterns := []string{
-		base + "-sst-checkpoint-*",
-		base + "-sst-ingest-*",
-		base + "-sst-receive-*",
+	prefixes := []string{
+		base + "-sst-checkpoint-",
+		base + "-sst-ingest-",
+		base + "-sst-receive-",
 	}
-	for _, pattern := range patterns {
-		matches, err := filepath.Glob(filepath.Join(parent, pattern))
+	for _, prefix := range prefixes {
+		matches, err := siblingPathsWithPrefix(parent, prefix)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -127,13 +126,31 @@ func cleanupPebbleSnapshotArtifacts(dir string) error {
 	return nil
 }
 
-func recoverPebbleRestoreBackup(dir, pattern string) error {
+func siblingPathsWithPrefix(parent, prefix string) ([]string, error) {
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, errors.WithStack(err)
+	}
+	paths := make([]string, 0)
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), prefix) {
+			paths = append(paths, filepath.Join(parent, entry.Name()))
+		}
+	}
+	return paths, nil
+}
+
+func recoverPebbleRestoreBackup(dir string) error {
 	if _, err := os.Stat(dir); err == nil {
 		return nil
 	} else if !os.IsNotExist(err) {
 		return errors.WithStack(err)
 	}
-	backups, err := filepath.Glob(pattern)
+	clean := filepath.Clean(dir)
+	backups, err := siblingPathsWithPrefix(filepath.Dir(clean), filepath.Base(clean)+"-restore-backup-")
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -151,8 +168,7 @@ func recoverPebbleRestoreBackup(dir, pattern string) error {
 
 func cleanupPebbleRestoreBackups(dir string) error {
 	clean := filepath.Clean(dir)
-	pattern := filepath.Join(filepath.Dir(clean), filepath.Base(clean)+"-restore-backup-*")
-	backups, err := filepath.Glob(pattern)
+	backups, err := siblingPathsWithPrefix(filepath.Dir(clean), filepath.Base(clean)+"-restore-backup-")
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -205,14 +221,19 @@ func (s *pebbleStore) newSSTIngestSnapshot() (Snapshot, error) {
 		_ = os.RemoveAll(checkpointDir)
 		return nil, err
 	}
+	targetFileBytes := s.sstIngestTargetFileBytes
+	if targetFileBytes == 0 {
+		targetFileBytes = defaultSSTIngestTargetFileSize
+	}
 	return &pebbleSSTIngestSnapshot{
 		checkpointDir: checkpointDir,
 		fallback: &pebbleSnapshot{
 			snapshot:     pebbleSnap,
 			lastCommitTS: metadata.LastCommitTS,
 		},
-		metadata: metadata,
-		log:      s.log,
+		metadata:        metadata,
+		targetFileBytes: targetFileBytes,
+		log:             s.log,
 	}, nil
 }
 
@@ -275,7 +296,7 @@ func (s *pebbleSSTIngestSnapshot) WriteTo(w io.Writer) (int64, error) {
 	if s == nil || s.fallback == nil {
 		return 0, errors.New("snapshot is not available")
 	}
-	bundle, err := buildPebbleSSTIngestBundle(s.checkpointDir, s.metadata)
+	bundle, err := buildPebbleSSTIngestBundle(s.checkpointDir, s.metadata, s.targetFileBytes)
 	if err != nil {
 		if s.log != nil {
 			s.log.Warn("failed to build SST ingest snapshot; using legacy stream", "error", err)
@@ -305,7 +326,7 @@ func (s *pebbleSSTIngestSnapshot) Close() error {
 	return errors.WithStack(s.err)
 }
 
-func buildPebbleSSTIngestBundle(checkpointDir string, metadata pebbleSnapshotMetadata) (*pebbleSSTIngestBundle, error) {
+func buildPebbleSSTIngestBundle(checkpointDir string, metadata pebbleSnapshotMetadata, targetFileBytes uint64) (*pebbleSSTIngestBundle, error) {
 	opts, cache := defaultPebbleOptionsWithCache()
 	opts.ReadOnly = true
 	db, err := pebble.Open(checkpointDir, opts)
@@ -328,7 +349,7 @@ func buildPebbleSSTIngestBundle(checkpointDir string, metadata pebbleSnapshotMet
 		return nil, err
 	}
 
-	manifest, err := exportPebbleSnapshotSSTs(db, exportDir, metadata)
+	manifest, err := exportPebbleSnapshotSSTs(db, exportDir, metadata, targetFileBytes)
 	if err != nil {
 		return cleanup(err)
 	}
@@ -353,10 +374,14 @@ func buildPebbleSSTIngestBundle(checkpointDir string, metadata pebbleSnapshotMet
 	return bundle, nil
 }
 
-func exportPebbleSnapshotSSTs(db *pebble.DB, exportDir string, metadata pebbleSnapshotMetadata) (pebbleSSTIngestManifest, error) {
+func exportPebbleSnapshotSSTs(db *pebble.DB, exportDir string, metadata pebbleSnapshotMetadata, targetFileBytes uint64) (pebbleSSTIngestManifest, error) {
+	if targetFileBytes == 0 {
+		targetFileBytes = defaultSSTIngestTargetFileSize
+	}
 	exporter := pebbleSSTExporter{
-		db:  db,
-		dir: exportDir,
+		db:              db,
+		dir:             exportDir,
+		targetFileBytes: targetFileBytes,
 		manifest: pebbleSSTIngestManifest{
 			Version:              sstIngestSnapshotVersion,
 			LastCommitTS:         metadata.LastCommitTS,
@@ -415,7 +440,7 @@ func (e *pebbleSSTExporter) Add(key, value []byte) error {
 			e.manifest.LastCommitTS = commitTS
 		}
 	}
-	if e.currentBytes >= sstIngestTargetFileBytes {
+	if e.currentBytes >= e.targetFileBytes {
 		return e.finishFile()
 	}
 	return nil
@@ -472,19 +497,20 @@ func (e *pebbleSSTExporter) Abort() {
 	}
 }
 
-func inspectSSTIngestFile(path, name string, smallest, largest []byte) (pebbleSSTIngestFileMeta, error) {
+func inspectSSTIngestFile(path, name string, smallest, largest []byte) (_ pebbleSSTIngestFileMeta, retErr error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return pebbleSSTIngestFileMeta{}, errors.WithStack(err)
 	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			retErr = errors.Join(retErr, errors.WithStack(err))
+		}
+	}()
 	h := sha256.New()
-	size, copyErr := io.Copy(h, f)
-	closeErr := f.Close()
-	if copyErr != nil {
-		return pebbleSSTIngestFileMeta{}, errors.WithStack(copyErr)
-	}
-	if closeErr != nil {
-		return pebbleSSTIngestFileMeta{}, errors.WithStack(closeErr)
+	size, err := io.Copy(h, f)
+	if err != nil {
+		return pebbleSSTIngestFileMeta{}, errors.WithStack(err)
 	}
 	return pebbleSSTIngestFileMeta{
 		Name:     name,
@@ -511,24 +537,31 @@ func (b *pebbleSSTIngestBundle) WriteTo(w io.Writer) (int64, error) {
 		return cw.n, err
 	}
 	for _, file := range b.manifest.Files {
-		path := filepath.Join(b.dir, file.Name)
-		f, err := os.Open(path)
-		if err != nil {
-			return cw.n, errors.WithStack(err)
-		}
-		written, copyErr := io.Copy(cw, f)
-		closeErr := f.Close()
-		if copyErr != nil {
-			return cw.n, errors.WithStack(copyErr)
-		}
-		if closeErr != nil {
-			return cw.n, errors.WithStack(closeErr)
-		}
-		if written != file.Size {
-			return cw.n, errors.WithStack(errors.Newf("SST ingest file %s changed while streaming", file.Name))
+		if err := b.writeFileTo(cw, file); err != nil {
+			return cw.n, err
 		}
 	}
 	return cw.n, nil
+}
+
+func (b *pebbleSSTIngestBundle) writeFileTo(w io.Writer, fileMeta pebbleSSTIngestFileMeta) (retErr error) {
+	f, err := os.Open(filepath.Join(b.dir, fileMeta.Name))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			retErr = errors.Join(retErr, errors.WithStack(err))
+		}
+	}()
+	written, err := io.Copy(w, f)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if written != fileMeta.Size {
+		return errors.WithStack(errors.Newf("SST ingest file %s changed while streaming", fileMeta.Name))
+	}
+	return nil
 }
 
 func (b *pebbleSSTIngestBundle) Close() error {
@@ -674,26 +707,9 @@ func validateSSTIngestFileMeta(file pebbleSSTIngestFileMeta, index int, previous
 func receiveSSTIngestFiles(r io.Reader, stageDir string, manifest pebbleSSTIngestManifest) ([]string, error) {
 	paths := make([]string, 0, len(manifest.Files))
 	for _, fileMeta := range manifest.Files {
-		path := filepath.Join(stageDir, fileMeta.Name)
-		file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, sstIngestFilePerm)
+		path, err := receiveSSTIngestFile(r, stageDir, fileMeta)
 		if err != nil {
-			return nil, errors.WithStack(err)
-		}
-		h := sha256.New()
-		written, copyErr := io.CopyN(io.MultiWriter(file, h), r, fileMeta.Size)
-		syncErr := file.Sync()
-		closeErr := file.Close()
-		if copyErr != nil {
-			return nil, errors.Wrapf(copyErr, "receive SST ingest file %s", fileMeta.Name)
-		}
-		if syncErr != nil {
-			return nil, errors.WithStack(syncErr)
-		}
-		if closeErr != nil {
-			return nil, errors.WithStack(closeErr)
-		}
-		if written != fileMeta.Size || hex.EncodeToString(h.Sum(nil)) != fileMeta.SHA256 {
-			return nil, errors.WithStack(errors.Newf("SST ingest file integrity mismatch: %s", fileMeta.Name))
+			return nil, err
 		}
 		paths = append(paths, path)
 	}
@@ -704,6 +720,31 @@ func receiveSSTIngestFiles(r io.Reader, stageDir string, manifest pebbleSSTInges
 		return nil, errors.WithStack(err)
 	}
 	return paths, nil
+}
+
+func receiveSSTIngestFile(r io.Reader, stageDir string, fileMeta pebbleSSTIngestFileMeta) (_ string, retErr error) {
+	path := filepath.Join(stageDir, fileMeta.Name)
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, sstIngestFilePerm)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			retErr = errors.Join(retErr, errors.WithStack(err))
+		}
+	}()
+	h := sha256.New()
+	written, err := io.CopyN(io.MultiWriter(file, h), r, fileMeta.Size)
+	if err != nil {
+		return "", errors.Wrapf(err, "receive SST ingest file %s", fileMeta.Name)
+	}
+	if err := file.Sync(); err != nil {
+		return "", errors.WithStack(err)
+	}
+	if written != fileMeta.Size || hex.EncodeToString(h.Sum(nil)) != fileMeta.SHA256 {
+		return "", errors.WithStack(errors.Newf("SST ingest file integrity mismatch: %s", fileMeta.Name))
+	}
+	return path, nil
 }
 
 func metadataFromSSTIngestManifest(manifest pebbleSSTIngestManifest) pebbleSnapshotMetadata {

--- a/store/snapshot_pebble_sst.go
+++ b/store/snapshot_pebble_sst.go
@@ -1,0 +1,777 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/cockroachdb/pebble/v2/objstorage/objstorageprovider"
+	"github.com/cockroachdb/pebble/v2/sstable"
+	"github.com/cockroachdb/pebble/v2/vfs"
+)
+
+const (
+	sstIngestSnapshotEnv           = "ELASTICKV_PEBBLE_SST_INGEST_SNAPSHOT"
+	sstIngestSnapshotVersion       = 1
+	sstIngestManifestMaxBytes      = 64 << 20
+	sstIngestSnapshotDigestBytes   = sha256.Size
+	sstIngestSnapshotFileNameWidth = 6
+	sstIngestSnapshotMaxFiles      = 1 << 20
+	defaultSSTIngestTargetFileSize = 64 << 20
+	sstIngestFilePerm              = 0600
+)
+
+var (
+	pebbleSSTIngestSnapshotMagic = [8]byte{'E', 'K', 'V', 'S', 'S', 'T', 'I', '1'}
+	sstIngestTargetFileBytes     = uint64(defaultSSTIngestTargetFileSize)
+)
+
+type pebbleSnapshotMetadata struct {
+	LastCommitTS         uint64
+	MinRetainedTS        uint64
+	PendingMinRetainedTS uint64
+	AppliedIndex         uint64
+	AppliedIndexPresent  bool
+}
+
+type pebbleSSTIngestManifest struct {
+	Version              int                       `json:"version"`
+	LastCommitTS         uint64                    `json:"last_commit_ts"`
+	MinRetainedTS        uint64                    `json:"min_retained_ts"`
+	PendingMinRetainedTS uint64                    `json:"pending_min_retained_ts"`
+	AppliedIndex         *uint64                   `json:"applied_index,omitempty"`
+	EntryCount           uint64                    `json:"entry_count"`
+	UncompressedBytes    uint64                    `json:"uncompressed_bytes"`
+	TotalFileBytes       int64                     `json:"total_file_bytes"`
+	Files                []pebbleSSTIngestFileMeta `json:"files"`
+}
+
+type pebbleSSTIngestFileMeta struct {
+	Name     string `json:"name"`
+	Size     int64  `json:"size"`
+	SHA256   string `json:"sha256"`
+	Smallest []byte `json:"smallest"`
+	Largest  []byte `json:"largest"`
+}
+
+type pebbleSSTIngestSnapshot struct {
+	checkpointDir string
+	fallback      *pebbleSnapshot
+	metadata      pebbleSnapshotMetadata
+	log           *slog.Logger
+	once          sync.Once
+	err           error
+}
+
+type pebbleSSTIngestBundle struct {
+	dir          string
+	manifest     pebbleSSTIngestManifest
+	manifestJSON []byte
+}
+
+type pebbleSSTExporter struct {
+	db           *pebble.DB
+	dir          string
+	manifest     pebbleSSTIngestManifest
+	writer       *sstable.Writer
+	currentPath  string
+	currentName  string
+	currentBytes uint64
+	smallest     []byte
+	largest      []byte
+	fileIndex    int
+}
+
+func resolveSSTIngestSnapshots(raw string) bool {
+	enabled, err := strconv.ParseBool(strings.TrimSpace(raw))
+	return err == nil && enabled
+}
+
+func cleanupPebbleSnapshotArtifacts(dir string) error {
+	clean := filepath.Clean(dir)
+	parent := filepath.Dir(clean)
+	base := filepath.Base(clean)
+	if err := recoverPebbleRestoreBackup(clean, filepath.Join(parent, base+"-restore-backup-*")); err != nil {
+		return err
+	}
+	patterns := []string{
+		base + "-sst-checkpoint-*",
+		base + "-sst-ingest-*",
+		base + "-sst-receive-*",
+	}
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(filepath.Join(parent, pattern))
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		for _, match := range matches {
+			if err := os.RemoveAll(match); err != nil {
+				return errors.Wrapf(err, "remove stale snapshot artifact %s", match)
+			}
+		}
+	}
+	return nil
+}
+
+func recoverPebbleRestoreBackup(dir, pattern string) error {
+	if _, err := os.Stat(dir); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return errors.WithStack(err)
+	}
+	backups, err := filepath.Glob(pattern)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if len(backups) == 0 {
+		return nil
+	}
+	if len(backups) != 1 {
+		return errors.WithStack(errors.Newf("cannot recover Pebble store with %d restore backups", len(backups)))
+	}
+	if err := os.Rename(backups[0], dir); err != nil {
+		return errors.Wrapf(err, "recover Pebble restore backup %s", backups[0])
+	}
+	return nil
+}
+
+func cleanupPebbleRestoreBackups(dir string) error {
+	clean := filepath.Clean(dir)
+	pattern := filepath.Join(filepath.Dir(clean), filepath.Base(clean)+"-restore-backup-*")
+	backups, err := filepath.Glob(pattern)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	for _, backup := range backups {
+		if err := os.RemoveAll(backup); err != nil {
+			return errors.Wrapf(err, "remove stale Pebble restore backup %s", backup)
+		}
+	}
+	return nil
+}
+
+func (s *pebbleStore) newSSTIngestSnapshot() (Snapshot, error) {
+	// Checkpoint must represent the exact state visible when the Raft run loop
+	// calls Snapshot. Block compaction/restore and all commit paths while the
+	// memtable is flushed and Pebble hard-links the stable checkpoint files.
+	s.maintenanceMu.Lock()
+	defer s.maintenanceMu.Unlock()
+	s.dbMu.Lock()
+	defer s.dbMu.Unlock()
+	s.applyMu.Lock()
+	defer s.applyMu.Unlock()
+
+	fallback := func(reason error) (Snapshot, error) {
+		snap, err := s.newLegacyPebbleSnapshotLocked()
+		if err != nil {
+			return nil, err
+		}
+		if s.log != nil {
+			s.log.Warn("falling back to legacy pebble snapshot stream", "error", reason)
+		}
+		return snap, nil
+	}
+
+	if err := s.db.Flush(); err != nil {
+		return fallback(errors.Wrap(err, "flush pebble before SST checkpoint"))
+	}
+	checkpointDir, err := makeSiblingTempDir(s.dir, "sst-checkpoint")
+	if err != nil {
+		return fallback(err)
+	}
+	if err := s.db.Checkpoint(checkpointDir, pebble.WithFlushedWAL()); err != nil {
+		_ = os.RemoveAll(checkpointDir)
+		return fallback(errors.Wrap(err, "create pebble SST checkpoint"))
+	}
+
+	pebbleSnap := s.db.NewSnapshot()
+	metadata, err := readPebbleSnapshotMetadata(pebbleSnap)
+	if err != nil {
+		_ = pebbleSnap.Close()
+		_ = os.RemoveAll(checkpointDir)
+		return nil, err
+	}
+	return &pebbleSSTIngestSnapshot{
+		checkpointDir: checkpointDir,
+		fallback: &pebbleSnapshot{
+			snapshot:     pebbleSnap,
+			lastCommitTS: metadata.LastCommitTS,
+		},
+		metadata: metadata,
+		log:      s.log,
+	}, nil
+}
+
+func (s *pebbleStore) newLegacyPebbleSnapshotLocked() (*pebbleSnapshot, error) {
+	snap := s.db.NewSnapshot()
+	lastCommitTS, err := readPebbleSnapshotLastCommitTS(snap)
+	if err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+	return &pebbleSnapshot{snapshot: snap, lastCommitTS: lastCommitTS}, nil
+}
+
+func readPebbleSnapshotMetadata(snapshot *pebble.Snapshot) (pebbleSnapshotMetadata, error) {
+	return readPebbleMetadata(snapshot)
+}
+
+func readPebbleMetadata(src pebbleUint64Getter) (pebbleSnapshotMetadata, error) {
+	lastCommitTS, err := readPebbleUint64(src, metaLastCommitTSBytes)
+	if err != nil {
+		return pebbleSnapshotMetadata{}, err
+	}
+	minRetainedTS, err := readPebbleUint64(src, metaMinRetainedTSBytes)
+	if err != nil {
+		return pebbleSnapshotMetadata{}, err
+	}
+	pendingMinRetainedTS, err := readPebbleUint64(src, metaPendingMinRetainedTSBytes)
+	if err != nil {
+		return pebbleSnapshotMetadata{}, err
+	}
+	appliedIndex, present, err := readPebbleUint64Present(src, metaAppliedIndexBytes)
+	if err != nil {
+		return pebbleSnapshotMetadata{}, err
+	}
+	return pebbleSnapshotMetadata{
+		LastCommitTS:         lastCommitTS,
+		MinRetainedTS:        minRetainedTS,
+		PendingMinRetainedTS: pendingMinRetainedTS,
+		AppliedIndex:         appliedIndex,
+		AppliedIndexPresent:  present,
+	}, nil
+}
+
+func readPebbleUint64Present(src pebbleUint64Getter, key []byte) (uint64, bool, error) {
+	val, closer, err := src.Get(key)
+	if err != nil {
+		if errors.Is(err, pebble.ErrNotFound) {
+			return 0, false, nil
+		}
+		return 0, false, errors.WithStack(err)
+	}
+	defer func() { _ = closer.Close() }()
+	if len(val) < timestampSize {
+		return 0, false, nil
+	}
+	return binary.LittleEndian.Uint64(val), true, nil
+}
+
+func (s *pebbleSSTIngestSnapshot) WriteTo(w io.Writer) (int64, error) {
+	if s == nil || s.fallback == nil {
+		return 0, errors.New("snapshot is not available")
+	}
+	bundle, err := buildPebbleSSTIngestBundle(s.checkpointDir, s.metadata)
+	if err != nil {
+		if s.log != nil {
+			s.log.Warn("failed to build SST ingest snapshot; using legacy stream", "error", err)
+		}
+		return s.fallback.WriteTo(w)
+	}
+	defer bundle.Close()
+	return bundle.WriteTo(w)
+}
+
+func (s *pebbleSSTIngestSnapshot) Close() error {
+	if s == nil {
+		return nil
+	}
+	s.once.Do(func() {
+		var errs []error
+		if s.fallback != nil {
+			errs = append(errs, s.fallback.Close())
+			s.fallback = nil
+		}
+		if s.checkpointDir != "" {
+			errs = append(errs, os.RemoveAll(s.checkpointDir))
+			s.checkpointDir = ""
+		}
+		s.err = errors.Join(errs...)
+	})
+	return errors.WithStack(s.err)
+}
+
+func buildPebbleSSTIngestBundle(checkpointDir string, metadata pebbleSnapshotMetadata) (*pebbleSSTIngestBundle, error) {
+	opts, cache := defaultPebbleOptionsWithCache()
+	opts.ReadOnly = true
+	db, err := pebble.Open(checkpointDir, opts)
+	if err != nil {
+		cache.Unref()
+		return nil, errors.WithStack(err)
+	}
+
+	exportDir, err := os.MkdirTemp(checkpointDir, "sst-export-")
+	if err != nil {
+		_ = db.Close()
+		cache.Unref()
+		return nil, errors.WithStack(err)
+	}
+	bundle := &pebbleSSTIngestBundle{dir: exportDir}
+	cleanup := func(err error) (*pebbleSSTIngestBundle, error) {
+		_ = db.Close()
+		cache.Unref()
+		_ = bundle.Close()
+		return nil, err
+	}
+
+	manifest, err := exportPebbleSnapshotSSTs(db, exportDir, metadata)
+	if err != nil {
+		return cleanup(err)
+	}
+	if err := db.Close(); err != nil {
+		cache.Unref()
+		_ = bundle.Close()
+		return nil, errors.WithStack(err)
+	}
+	cache.Unref()
+
+	manifestJSON, err := json.Marshal(manifest)
+	if err != nil {
+		_ = bundle.Close()
+		return nil, errors.WithStack(err)
+	}
+	if len(manifestJSON) > sstIngestManifestMaxBytes {
+		_ = bundle.Close()
+		return nil, errors.WithStack(errors.Newf("SST ingest manifest is too large: %d bytes", len(manifestJSON)))
+	}
+	bundle.manifest = manifest
+	bundle.manifestJSON = manifestJSON
+	return bundle, nil
+}
+
+func exportPebbleSnapshotSSTs(db *pebble.DB, exportDir string, metadata pebbleSnapshotMetadata) (pebbleSSTIngestManifest, error) {
+	exporter := pebbleSSTExporter{
+		db:  db,
+		dir: exportDir,
+		manifest: pebbleSSTIngestManifest{
+			Version:              sstIngestSnapshotVersion,
+			LastCommitTS:         metadata.LastCommitTS,
+			MinRetainedTS:        metadata.MinRetainedTS,
+			PendingMinRetainedTS: metadata.PendingMinRetainedTS,
+		},
+	}
+	if metadata.AppliedIndexPresent {
+		applied := metadata.AppliedIndex
+		exporter.manifest.AppliedIndex = &applied
+	}
+
+	iter, err := db.NewIter(nil)
+	if err != nil {
+		return exporter.manifest, errors.WithStack(err)
+	}
+	defer iter.Close()
+
+	for iter.First(); iter.Valid(); iter.Next() {
+		if err := exporter.Add(iter.Key(), iter.Value()); err != nil {
+			exporter.Abort()
+			return exporter.manifest, err
+		}
+	}
+	if err := iter.Error(); err != nil {
+		exporter.Abort()
+		return exporter.manifest, errors.WithStack(err)
+	}
+	if err := exporter.Finish(); err != nil {
+		exporter.Abort()
+		return exporter.manifest, err
+	}
+	return exporter.manifest, nil
+}
+
+func (e *pebbleSSTExporter) Add(key, value []byte) error {
+	if e.writer == nil {
+		if err := e.startFile(key); err != nil {
+			return err
+		}
+	}
+	if err := e.writer.Set(key, value); err != nil {
+		return errors.WithStack(err)
+	}
+	e.largest = bytes.Clone(key)
+	entryBytes := uint64(len(key)) + uint64(len(value))
+	if e.manifest.EntryCount == math.MaxUint64 || math.MaxUint64-e.manifest.UncompressedBytes < entryBytes {
+		return errors.New("SST ingest entry counters overflow uint64")
+	}
+	e.manifest.EntryCount++
+	e.manifest.UncompressedBytes += entryBytes
+	e.currentBytes += entryBytes
+	if !isPebbleOperationalKey(key) {
+		_, commitTS := decodeKeyView(key)
+		if commitTS > e.manifest.LastCommitTS {
+			e.manifest.LastCommitTS = commitTS
+		}
+	}
+	if e.currentBytes >= sstIngestTargetFileBytes {
+		return e.finishFile()
+	}
+	return nil
+}
+
+func (e *pebbleSSTExporter) startFile(firstKey []byte) error {
+	if e.fileIndex >= sstIngestSnapshotMaxFiles {
+		return errors.New("SST ingest snapshot exceeds file-count limit")
+	}
+	e.currentName = fmt.Sprintf("%0*d.sst", sstIngestSnapshotFileNameWidth, e.fileIndex)
+	e.currentPath = filepath.Join(e.dir, e.currentName)
+	file, err := vfs.Default.Create(e.currentPath, vfs.WriteCategoryUnspecified)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	e.writer = sstable.NewWriter(objstorageprovider.NewFileWritable(file), sstable.WriterOptions{
+		Comparer:    pebble.DefaultComparer,
+		TableFormat: e.db.TableFormat(),
+	})
+	e.currentBytes = 0
+	e.smallest = bytes.Clone(firstKey)
+	e.fileIndex++
+	return nil
+}
+
+func (e *pebbleSSTExporter) finishFile() error {
+	if e.writer == nil {
+		return nil
+	}
+	if err := e.writer.Close(); err != nil {
+		return errors.WithStack(err)
+	}
+	e.writer = nil
+	fileMeta, err := inspectSSTIngestFile(e.currentPath, e.currentName, e.smallest, e.largest)
+	if err != nil {
+		return err
+	}
+	if math.MaxInt64-e.manifest.TotalFileBytes < fileMeta.Size {
+		return errors.New("SST ingest total file size overflows int64")
+	}
+	e.manifest.Files = append(e.manifest.Files, fileMeta)
+	e.manifest.TotalFileBytes += fileMeta.Size
+	return nil
+}
+
+func (e *pebbleSSTExporter) Finish() error {
+	return e.finishFile()
+}
+
+func (e *pebbleSSTExporter) Abort() {
+	if e.writer != nil {
+		_ = e.writer.Close()
+		e.writer = nil
+	}
+}
+
+func inspectSSTIngestFile(path, name string, smallest, largest []byte) (pebbleSSTIngestFileMeta, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return pebbleSSTIngestFileMeta{}, errors.WithStack(err)
+	}
+	h := sha256.New()
+	size, copyErr := io.Copy(h, f)
+	closeErr := f.Close()
+	if copyErr != nil {
+		return pebbleSSTIngestFileMeta{}, errors.WithStack(copyErr)
+	}
+	if closeErr != nil {
+		return pebbleSSTIngestFileMeta{}, errors.WithStack(closeErr)
+	}
+	return pebbleSSTIngestFileMeta{
+		Name:     name,
+		Size:     size,
+		SHA256:   hex.EncodeToString(h.Sum(nil)),
+		Smallest: bytes.Clone(smallest),
+		Largest:  bytes.Clone(largest),
+	}, nil
+}
+
+func (b *pebbleSSTIngestBundle) WriteTo(w io.Writer) (int64, error) {
+	cw := &countingWriter{w: w}
+	if _, err := cw.Write(pebbleSSTIngestSnapshotMagic[:]); err != nil {
+		return cw.n, err
+	}
+	if err := binary.Write(cw, binary.BigEndian, int64(len(b.manifestJSON))); err != nil {
+		return cw.n, errors.WithStack(err)
+	}
+	digest := sha256.Sum256(b.manifestJSON)
+	if _, err := cw.Write(digest[:]); err != nil {
+		return cw.n, err
+	}
+	if _, err := cw.Write(b.manifestJSON); err != nil {
+		return cw.n, err
+	}
+	for _, file := range b.manifest.Files {
+		path := filepath.Join(b.dir, file.Name)
+		f, err := os.Open(path)
+		if err != nil {
+			return cw.n, errors.WithStack(err)
+		}
+		written, copyErr := io.Copy(cw, f)
+		closeErr := f.Close()
+		if copyErr != nil {
+			return cw.n, errors.WithStack(copyErr)
+		}
+		if closeErr != nil {
+			return cw.n, errors.WithStack(closeErr)
+		}
+		if written != file.Size {
+			return cw.n, errors.WithStack(errors.Newf("SST ingest file %s changed while streaming", file.Name))
+		}
+	}
+	return cw.n, nil
+}
+
+func (b *pebbleSSTIngestBundle) Close() error {
+	if b == nil || b.dir == "" {
+		return nil
+	}
+	err := os.RemoveAll(b.dir)
+	b.dir = ""
+	return errors.WithStack(err)
+}
+
+func (s *pebbleStore) restorePebbleSSTIngestAtomic(r io.Reader) error {
+	manifest, err := readPebbleSSTIngestManifest(r)
+	if err != nil {
+		return err
+	}
+	stageDir, err := os.MkdirTemp(filepath.Dir(filepath.Clean(s.dir)), filepath.Base(s.dir)+"-sst-receive-*")
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer os.RemoveAll(stageDir)
+
+	paths, err := receiveSSTIngestFiles(r, stageDir, manifest)
+	if err != nil {
+		return err
+	}
+	tmpDir, err := makeSiblingTempDir(s.dir, "sst-ingest")
+	if err != nil {
+		return err
+	}
+	metadata := metadataFromSSTIngestManifest(manifest)
+	if err := ingestSSTSnapshotIntoTempDB(tmpDir, paths, metadata); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return err
+	}
+	return s.swapInTempDBWithMetadata(tmpDir, &metadata)
+}
+
+func readPebbleSSTIngestManifest(r io.Reader) (pebbleSSTIngestManifest, error) {
+	manifestJSON, err := readPebbleSSTIngestManifestBytes(r)
+	if err != nil {
+		return pebbleSSTIngestManifest{}, err
+	}
+	manifest, err := decodePebbleSSTIngestManifest(manifestJSON)
+	if err != nil {
+		return pebbleSSTIngestManifest{}, err
+	}
+	if err := validateSSTIngestManifest(manifest); err != nil {
+		return pebbleSSTIngestManifest{}, err
+	}
+	return manifest, nil
+}
+
+func readPebbleSSTIngestManifestBytes(r io.Reader) ([]byte, error) {
+	var magic [8]byte
+	if _, err := io.ReadFull(r, magic[:]); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if !bytes.Equal(magic[:], pebbleSSTIngestSnapshotMagic[:]) {
+		return nil, errors.New("invalid SST ingest snapshot magic header")
+	}
+	var manifestLen int64
+	if err := binary.Read(r, binary.BigEndian, &manifestLen); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	if manifestLen <= 0 || manifestLen > sstIngestManifestMaxBytes {
+		return nil, errors.WithStack(errors.Newf("invalid SST ingest manifest length: %d", manifestLen))
+	}
+	var expectedDigest [sstIngestSnapshotDigestBytes]byte
+	if _, err := io.ReadFull(r, expectedDigest[:]); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	manifestJSON := make([]byte, manifestLen)
+	if _, err := io.ReadFull(r, manifestJSON); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	actualDigest := sha256.Sum256(manifestJSON)
+	if actualDigest != expectedDigest {
+		return nil, errors.New("SST ingest manifest SHA-256 mismatch")
+	}
+	return manifestJSON, nil
+}
+
+func decodePebbleSSTIngestManifest(manifestJSON []byte) (pebbleSSTIngestManifest, error) {
+	var manifest pebbleSSTIngestManifest
+	decoder := json.NewDecoder(bytes.NewReader(manifestJSON))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&manifest); err != nil {
+		return pebbleSSTIngestManifest{}, errors.WithStack(err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return pebbleSSTIngestManifest{}, errors.New("SST ingest manifest contains trailing JSON")
+	}
+	return manifest, nil
+}
+
+func validateSSTIngestManifest(manifest pebbleSSTIngestManifest) error {
+	if manifest.Version != sstIngestSnapshotVersion {
+		return errors.WithStack(errors.Newf("unsupported SST ingest snapshot version: %d", manifest.Version))
+	}
+	if len(manifest.Files) > sstIngestSnapshotMaxFiles {
+		return errors.WithStack(errors.Newf("SST ingest snapshot has too many files: %d", len(manifest.Files)))
+	}
+	var total int64
+	var previousLargest []byte
+	for i, file := range manifest.Files {
+		if err := validateSSTIngestFileMeta(file, i, previousLargest); err != nil {
+			return err
+		}
+		if math.MaxInt64-total < file.Size {
+			return errors.New("SST ingest total size overflows int64")
+		}
+		total += file.Size
+		previousLargest = file.Largest
+	}
+	if total != manifest.TotalFileBytes {
+		return errors.WithStack(errors.Newf("SST ingest total size mismatch: manifest=%d files=%d", manifest.TotalFileBytes, total))
+	}
+	return nil
+}
+
+func validateSSTIngestFileMeta(file pebbleSSTIngestFileMeta, index int, previousLargest []byte) error {
+	expectedName := fmt.Sprintf("%0*d.sst", sstIngestSnapshotFileNameWidth, index)
+	if file.Name != expectedName {
+		return errors.WithStack(errors.Newf("invalid SST ingest file name %q", file.Name))
+	}
+	if file.Size <= 0 {
+		return errors.WithStack(errors.Newf("invalid SST ingest file size for %s: %d", file.Name, file.Size))
+	}
+	if len(file.Smallest) == 0 || len(file.Largest) == 0 || bytes.Compare(file.Smallest, file.Largest) > 0 {
+		return errors.WithStack(errors.Newf("invalid SST ingest key bounds for %s", file.Name))
+	}
+	if index > 0 && bytes.Compare(previousLargest, file.Smallest) >= 0 {
+		return errors.WithStack(errors.Newf("overlapping SST ingest key bounds at %s", file.Name))
+	}
+	digest, err := hex.DecodeString(file.SHA256)
+	if err != nil || len(digest) != sha256.Size {
+		return errors.WithStack(errors.Newf("invalid SST ingest SHA-256 for %s", file.Name))
+	}
+	return nil
+}
+
+func receiveSSTIngestFiles(r io.Reader, stageDir string, manifest pebbleSSTIngestManifest) ([]string, error) {
+	paths := make([]string, 0, len(manifest.Files))
+	for _, fileMeta := range manifest.Files {
+		path := filepath.Join(stageDir, fileMeta.Name)
+		file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, sstIngestFilePerm)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+		h := sha256.New()
+		written, copyErr := io.CopyN(io.MultiWriter(file, h), r, fileMeta.Size)
+		syncErr := file.Sync()
+		closeErr := file.Close()
+		if copyErr != nil {
+			return nil, errors.Wrapf(copyErr, "receive SST ingest file %s", fileMeta.Name)
+		}
+		if syncErr != nil {
+			return nil, errors.WithStack(syncErr)
+		}
+		if closeErr != nil {
+			return nil, errors.WithStack(closeErr)
+		}
+		if written != fileMeta.Size || hex.EncodeToString(h.Sum(nil)) != fileMeta.SHA256 {
+			return nil, errors.WithStack(errors.Newf("SST ingest file integrity mismatch: %s", fileMeta.Name))
+		}
+		paths = append(paths, path)
+	}
+	var trailing [1]byte
+	if _, err := io.ReadFull(r, trailing[:]); err == nil {
+		return nil, errors.New("SST ingest snapshot contains trailing bytes")
+	} else if !errors.Is(err, io.EOF) {
+		return nil, errors.WithStack(err)
+	}
+	return paths, nil
+}
+
+func metadataFromSSTIngestManifest(manifest pebbleSSTIngestManifest) pebbleSnapshotMetadata {
+	metadata := pebbleSnapshotMetadata{
+		LastCommitTS:         manifest.LastCommitTS,
+		MinRetainedTS:        manifest.MinRetainedTS,
+		PendingMinRetainedTS: manifest.PendingMinRetainedTS,
+	}
+	if manifest.AppliedIndex != nil {
+		metadata.AppliedIndex = *manifest.AppliedIndex
+		metadata.AppliedIndexPresent = true
+	}
+	return metadata
+}
+
+func ingestSSTSnapshotIntoTempDB(tmpDir string, paths []string, metadata pebbleSnapshotMetadata) error {
+	opts, cache := defaultPebbleOptionsWithCache()
+	db, err := pebble.Open(tmpDir, opts)
+	if err != nil {
+		cache.Unref()
+		return errors.WithStack(err)
+	}
+	defer cache.Unref()
+	cleanup := func(err error) error {
+		_ = db.Close()
+		return err
+	}
+	if len(paths) > 0 {
+		if err := db.Ingest(context.Background(), paths); err != nil {
+			return cleanup(errors.Wrap(err, "ingest snapshot SST files"))
+		}
+	}
+	if err := writePebbleSnapshotMetadata(db, metadata); err != nil {
+		return cleanup(err)
+	}
+	if err := verifyPebbleSnapshotMetadata(db, metadata); err != nil {
+		return cleanup(err)
+	}
+	return errors.WithStack(db.Close())
+}
+
+func writePebbleSnapshotMetadata(db *pebble.DB, metadata pebbleSnapshotMetadata) error {
+	batch := db.NewBatch()
+	defer batch.Close()
+	if err := setPebbleUint64InBatch(batch, metaLastCommitTSBytes, metadata.LastCommitTS); err != nil {
+		return err
+	}
+	if err := setPebbleUint64InBatch(batch, metaMinRetainedTSBytes, metadata.MinRetainedTS); err != nil {
+		return err
+	}
+	if err := setPebbleUint64InBatch(batch, metaPendingMinRetainedTSBytes, metadata.PendingMinRetainedTS); err != nil {
+		return err
+	}
+	if metadata.AppliedIndexPresent {
+		if err := setPebbleUint64InBatch(batch, metaAppliedIndexBytes, metadata.AppliedIndex); err != nil {
+			return err
+		}
+	}
+	return errors.WithStack(batch.Commit(pebble.Sync))
+}
+
+func verifyPebbleSnapshotMetadata(db *pebble.DB, expected pebbleSnapshotMetadata) error {
+	actual, err := readPebbleMetadata(db)
+	if err != nil {
+		return err
+	}
+	if actual != expected {
+		return errors.New("SST ingest snapshot metadata verification failed")
+	}
+	return nil
+}

--- a/store/snapshot_pebble_sst_test.go
+++ b/store/snapshot_pebble_sst_test.go
@@ -1,0 +1,322 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/iotest"
+
+	internalutil "github.com/bootjp/elastickv/internal"
+	"github.com/stretchr/testify/require"
+)
+
+type shortWriteBuffer struct {
+	bytes.Buffer
+}
+
+func (w *shortWriteBuffer) Write(p []byte) (int, error) {
+	if len(p) > 1 {
+		p = p[:1]
+	}
+	return w.Buffer.Write(p)
+}
+
+func openSSTSnapshotTestStore(t *testing.T, dir string, opts ...PebbleStoreOption) *pebbleStore {
+	t.Helper()
+	mvcc, err := NewPebbleStore(dir, opts...)
+	require.NoError(t, err)
+	store, ok := mvcc.(*pebbleStore)
+	require.True(t, ok)
+	t.Cleanup(func() {
+		if store.db != nil {
+			require.NoError(t, store.Close())
+		}
+	})
+	return store
+}
+
+func writeSSTSnapshotTestData(t *testing.T, store *pebbleStore) {
+	t.Helper()
+	ctx := context.Background()
+	timestamps := []uint64{10, 11, 12, 13}
+	for i, key := range []string{"alpha", "bravo", "charlie", "delta"} {
+		value := strings.Repeat(key, 32)
+		require.NoError(t, store.PutAt(ctx, []byte(key), []byte(value), timestamps[i], 0))
+	}
+	require.NoError(t, store.SetDurableAppliedIndex(77))
+}
+
+func snapshotBytesForTest(t *testing.T, store *pebbleStore) ([]byte, Snapshot) {
+	t.Helper()
+	snapshot, err := store.Snapshot()
+	require.NoError(t, err)
+	var raw bytes.Buffer
+	_, err = snapshot.WriteTo(&raw)
+	require.NoError(t, err)
+	return raw.Bytes(), snapshot
+}
+
+func TestPebbleStoreSSTIngestSnapshotRoundTrip(t *testing.T) {
+	setPebbleCacheBytesForTest(t, 8<<20)
+	oldTarget := sstIngestTargetFileBytes
+	sstIngestTargetFileBytes = 128
+	t.Cleanup(func() { sstIngestTargetFileBytes = oldTarget })
+
+	src := openSSTSnapshotTestStore(t, filepath.Join(t.TempDir(), "src"), WithSSTIngestSnapshots(true))
+	writeSSTSnapshotTestData(t, src)
+
+	snapshot, err := src.Snapshot()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, snapshot.Close()) })
+	sstSnapshot, ok := snapshot.(*pebbleSSTIngestSnapshot)
+	require.True(t, ok)
+	checkpointDir := sstSnapshot.checkpointDir
+	require.DirExists(t, checkpointDir)
+
+	// This write happens after the checkpoint and must not leak into the image.
+	require.NoError(t, src.PutAt(context.Background(), []byte("late"), []byte("not-in-snapshot"), 99, 0))
+	var raw bytes.Buffer
+	_, err = snapshot.WriteTo(&raw)
+	require.NoError(t, err)
+	require.Equal(t, pebbleSSTIngestSnapshotMagic[:], raw.Bytes()[:len(pebbleSSTIngestSnapshotMagic)])
+
+	reader := bytes.NewReader(raw.Bytes())
+	manifest, err := readPebbleSSTIngestManifest(reader)
+	require.NoError(t, err)
+	require.Greater(t, len(manifest.Files), 1)
+	require.GreaterOrEqual(t, manifest.EntryCount, uint64(4))
+	require.NotNil(t, manifest.AppliedIndex)
+	require.Equal(t, uint64(77), *manifest.AppliedIndex)
+
+	dst := openSSTSnapshotTestStore(t, filepath.Join(t.TempDir(), "dst"))
+	require.NoError(t, dst.PutAt(context.Background(), []byte("old"), []byte("remove-me"), 1, 0))
+	require.NoError(t, dst.Restore(iotest.OneByteReader(bytes.NewReader(raw.Bytes()))))
+
+	for _, key := range []string{"alpha", "bravo", "charlie", "delta"} {
+		value, getErr := dst.GetAt(context.Background(), []byte(key), 100)
+		require.NoError(t, getErr)
+		require.Equal(t, strings.Repeat(key, 32), string(value))
+	}
+	_, err = dst.GetAt(context.Background(), []byte("late"), 100)
+	require.ErrorIs(t, err, ErrKeyNotFound)
+	_, err = dst.GetAt(context.Background(), []byte("old"), 100)
+	require.ErrorIs(t, err, ErrKeyNotFound)
+	applied, present, err := dst.LastAppliedIndex()
+	require.NoError(t, err)
+	require.True(t, present)
+	require.Equal(t, uint64(77), applied)
+
+	require.NoError(t, snapshot.Close())
+	require.NoDirExists(t, checkpointDir)
+}
+
+func TestPebbleStoreSSTIngestSnapshotCorruptionPreservesDestination(t *testing.T) {
+	setPebbleCacheBytesForTest(t, 8<<20)
+	src := openSSTSnapshotTestStore(t, filepath.Join(t.TempDir(), "src"), WithSSTIngestSnapshots(true))
+	writeSSTSnapshotTestData(t, src)
+	raw, snapshot := snapshotBytesForTest(t, src)
+	require.NoError(t, snapshot.Close())
+
+	manifestLen, err := internalutil.Uint64ToInt(binary.BigEndian.Uint64(raw[len(pebbleSSTIngestSnapshotMagic):]))
+	require.NoError(t, err)
+	dataOffset := len(pebbleSSTIngestSnapshotMagic) + 8 + sstIngestSnapshotDigestBytes + manifestLen
+	require.Less(t, dataOffset, len(raw))
+
+	tests := []struct {
+		name    string
+		corrupt func([]byte) []byte
+	}{
+		{"manifest digest", func(corrupt []byte) []byte {
+			manifestOffset := len(pebbleSSTIngestSnapshotMagic) + 8 + sstIngestSnapshotDigestBytes
+			corrupt[manifestOffset] ^= 0x01
+			return corrupt
+		}},
+		{"file digest", func(corrupt []byte) []byte {
+			corrupt[dataOffset] ^= 0x01
+			return corrupt
+		}},
+		{"truncated file", func(corrupt []byte) []byte {
+			return corrupt[:len(corrupt)-1]
+		}},
+		{"trailing bytes", func(corrupt []byte) []byte {
+			return append(corrupt, 0x01)
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			corrupt := append([]byte(nil), raw...)
+			corrupt = test.corrupt(corrupt)
+			dstDir := filepath.Join(t.TempDir(), "dst")
+			dst := openSSTSnapshotTestStore(t, dstDir)
+			require.NoError(t, dst.PutAt(context.Background(), []byte("sentinel"), []byte("keep"), 5, 0))
+			require.Error(t, dst.Restore(bytes.NewReader(corrupt)))
+			value, err := dst.GetAt(context.Background(), []byte("sentinel"), 10)
+			require.NoError(t, err)
+			require.Equal(t, []byte("keep"), value)
+			matches, err := filepath.Glob(dstDir + "-sst-*")
+			require.NoError(t, err)
+			require.Empty(t, matches)
+		})
+	}
+}
+
+func TestPebbleStoreSSTIngestSnapshotFallsBackBeforeStreaming(t *testing.T) {
+	setPebbleCacheBytesForTest(t, 8<<20)
+	src := openSSTSnapshotTestStore(t, filepath.Join(t.TempDir(), "src"), WithSSTIngestSnapshots(true))
+	writeSSTSnapshotTestData(t, src)
+	snapshot, err := src.Snapshot()
+	require.NoError(t, err)
+	sstSnapshot, ok := snapshot.(*pebbleSSTIngestSnapshot)
+	require.True(t, ok)
+	require.NoError(t, os.RemoveAll(sstSnapshot.checkpointDir))
+
+	var raw bytes.Buffer
+	_, err = snapshot.WriteTo(&raw)
+	require.NoError(t, err)
+	require.Equal(t, pebbleSnapshotMagic[:], raw.Bytes()[:len(pebbleSnapshotMagic)])
+
+	dst := openSSTSnapshotTestStore(t, filepath.Join(t.TempDir(), "dst"))
+	require.NoError(t, dst.Restore(bytes.NewReader(raw.Bytes())))
+	value, err := dst.GetAt(context.Background(), []byte("alpha"), 100)
+	require.NoError(t, err)
+	require.Equal(t, strings.Repeat("alpha", 32), string(value))
+	require.NoError(t, snapshot.Close())
+}
+
+func TestPebbleStoreCleansStaleSSTSnapshotArtifacts(t *testing.T) {
+	setPebbleCacheBytesForTest(t, 8<<20)
+	t.Run("recovers interrupted swap", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "fsm.db")
+		original := openSSTSnapshotTestStore(t, dir)
+		require.NoError(t, original.PutAt(context.Background(), []byte("sentinel"), []byte("keep"), 5, 0))
+		require.NoError(t, original.Close())
+		original.db = nil
+
+		backup := dir + "-restore-backup-interrupted"
+		require.NoError(t, os.Rename(dir, backup))
+		restored := openSSTSnapshotTestStore(t, dir)
+		value, err := restored.GetAt(context.Background(), []byte("sentinel"), 10)
+		require.NoError(t, err)
+		require.Equal(t, []byte("keep"), value)
+		require.NoDirExists(t, backup)
+	})
+
+	t.Run("removes stale artifacts around live store", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "fsm.db")
+		original := openSSTSnapshotTestStore(t, dir)
+		require.NoError(t, original.PutAt(context.Background(), []byte("sentinel"), []byte("keep"), 5, 0))
+		require.NoError(t, original.Close())
+		original.db = nil
+
+		stale := []string{
+			dir + "-sst-checkpoint-stale",
+			dir + "-sst-ingest-stale",
+			dir + "-sst-receive-stale",
+			dir + "-restore-backup-stale",
+		}
+		for _, path := range stale {
+			require.NoError(t, os.MkdirAll(path, 0755))
+		}
+		restored := openSSTSnapshotTestStore(t, dir)
+		value, err := restored.GetAt(context.Background(), []byte("sentinel"), 10)
+		require.NoError(t, err)
+		require.Equal(t, []byte("keep"), value)
+		for _, path := range stale {
+			require.NoDirExists(t, path)
+		}
+	})
+
+	t.Run("preserves ambiguous restore backups", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "fsm.db")
+		backups := []string{
+			dir + "-restore-backup-first",
+			dir + "-restore-backup-second",
+		}
+		for _, backup := range backups {
+			require.NoError(t, os.MkdirAll(backup, 0755))
+		}
+		require.Error(t, cleanupPebbleSnapshotArtifacts(dir))
+		for _, backup := range backups {
+			require.DirExists(t, backup)
+		}
+		require.NoDirExists(t, dir)
+	})
+}
+
+func TestSwapInTempDBRollsBackOnMetadataFailure(t *testing.T) {
+	setPebbleCacheBytesForTest(t, 8<<20)
+	parent := t.TempDir()
+	dstDir := filepath.Join(parent, "dst")
+	dst := openSSTSnapshotTestStore(t, dstDir)
+	require.NoError(t, dst.PutAt(context.Background(), []byte("sentinel"), []byte("keep"), 5, 0))
+
+	tmpDir, err := makeSiblingTempDir(dstDir, "test-replacement")
+	require.NoError(t, err)
+	replacement, err := NewPebbleStore(tmpDir)
+	require.NoError(t, err)
+	require.NoError(t, replacement.PutAt(context.Background(), []byte("replacement"), []byte("discard"), 9, 0))
+	require.NoError(t, replacement.Close())
+
+	dst.maintenanceMu.Lock()
+	dst.dbMu.Lock()
+	dst.mtx.Lock()
+	err = dst.swapInTempDBWithMetadata(tmpDir, &pebbleSnapshotMetadata{LastCommitTS: 999})
+	dst.mtx.Unlock()
+	dst.dbMu.Unlock()
+	dst.maintenanceMu.Unlock()
+	require.Error(t, err)
+
+	value, err := dst.GetAt(context.Background(), []byte("sentinel"), 10)
+	require.NoError(t, err)
+	require.Equal(t, []byte("keep"), value)
+	_, err = dst.GetAt(context.Background(), []byte("replacement"), 10)
+	require.ErrorIs(t, err, ErrKeyNotFound)
+	matches, err := filepath.Glob(dstDir + "-restore-backup-*")
+	require.NoError(t, err)
+	require.Empty(t, matches)
+}
+
+func TestSSTIngestSnapshotConfigurationAndManifestValidation(t *testing.T) {
+	require.False(t, resolveSSTIngestSnapshots(""))
+	require.False(t, resolveSSTIngestSnapshots("invalid"))
+	require.True(t, resolveSSTIngestSnapshots(" true "))
+	require.True(t, resolveSSTIngestSnapshots("1"))
+
+	manifest := pebbleSSTIngestManifest{
+		Version:        sstIngestSnapshotVersion,
+		TotalFileBytes: 1,
+		Files: []pebbleSSTIngestFileMeta{{
+			Name:     "../escape.sst",
+			Size:     1,
+			SHA256:   strings.Repeat("0", 64),
+			Smallest: []byte("a"),
+			Largest:  []byte("b"),
+		}},
+	}
+	require.Error(t, validateSSTIngestManifest(manifest))
+}
+
+func TestSSTIngestManifestRejectsNegativeLength(t *testing.T) {
+	t.Parallel()
+
+	var stream bytes.Buffer
+	stream.Write(pebbleSSTIngestSnapshotMagic[:])
+	require.NoError(t, binary.Write(&stream, binary.BigEndian, int64(-1)))
+
+	_, err := readPebbleSSTIngestManifest(&stream)
+	require.ErrorContains(t, err, "invalid SST ingest manifest length")
+}
+
+func TestCountingWriterRejectsShortWrites(t *testing.T) {
+	var dst shortWriteBuffer
+	writer := &countingWriter{w: &dst}
+	n, err := writer.Write([]byte("transport"))
+	require.Equal(t, 1, n)
+	require.ErrorIs(t, err, io.ErrShortWrite)
+}

--- a/store/snapshot_pebble_sst_test.go
+++ b/store/snapshot_pebble_sst_test.go
@@ -40,6 +40,12 @@ func openSSTSnapshotTestStore(t *testing.T, dir string, opts ...PebbleStoreOptio
 	return store
 }
 
+func withSSTIngestTargetFileBytesForTest(target uint64) PebbleStoreOption {
+	return func(store *pebbleStore) {
+		store.sstIngestTargetFileBytes = target
+	}
+}
+
 func writeSSTSnapshotTestData(t *testing.T, store *pebbleStore) {
 	t.Helper()
 	ctx := context.Background()
@@ -63,11 +69,12 @@ func snapshotBytesForTest(t *testing.T, store *pebbleStore) ([]byte, Snapshot) {
 
 func TestPebbleStoreSSTIngestSnapshotRoundTrip(t *testing.T) {
 	setPebbleCacheBytesForTest(t, 8<<20)
-	oldTarget := sstIngestTargetFileBytes
-	sstIngestTargetFileBytes = 128
-	t.Cleanup(func() { sstIngestTargetFileBytes = oldTarget })
-
-	src := openSSTSnapshotTestStore(t, filepath.Join(t.TempDir(), "src"), WithSSTIngestSnapshots(true))
+	src := openSSTSnapshotTestStore(
+		t,
+		filepath.Join(t.TempDir(), "src"),
+		WithSSTIngestSnapshots(true),
+		withSSTIngestTargetFileBytesForTest(128),
+	)
 	writeSSTSnapshotTestData(t, src)
 
 	snapshot, err := src.Snapshot()
@@ -208,7 +215,7 @@ func TestPebbleStoreCleansStaleSSTSnapshotArtifacts(t *testing.T) {
 	})
 
 	t.Run("removes stale artifacts around live store", func(t *testing.T) {
-		dir := filepath.Join(t.TempDir(), "fsm.db")
+		dir := filepath.Join(t.TempDir(), "fsm[1].db")
 		original := openSSTSnapshotTestStore(t, dir)
 		require.NoError(t, original.PutAt(context.Background(), []byte("sentinel"), []byte("keep"), 5, 0))
 		require.NoError(t, original.Close())


### PR DESCRIPTION
## Summary

- add an opt-in checkpoint-derived Pebble SST snapshot stream with a versioned integrity manifest
- restore verified SST files through `DB.Ingest` into a temporary database with atomic swap, rollback, and crash recovery
- retain legacy snapshot emission by default and fall back before streaming when SST preparation fails
- cover KV FSM and disk-spooled gRPC snapshot transport integration
- mark the focused design implemented and keep physical object offload out of scope

## Safety and rollout

Set `ELASTICKV_PEBBLE_SST_INGEST_SNAPSHOT=true` only after every member runs a receiver-capable binary. Receivers always accept the new format. Invalid or unset values preserve legacy emission. Manifest, file bounds, exact lengths, SHA-256 digests, and EOF are verified before the live database is replaced.

The shared restore swap now retains the old database until the replacement opens and metadata verifies. Startup recovers a single interrupted rollback directory and preserves ambiguous backups instead of deleting them.

## Tests

- `go test ./store ./kv ./internal/raftengine/etcd -count=1 -timeout=20m`
- `go test -race ./store ./kv ./internal/raftengine/etcd -run 'TestPebbleStoreSST|TestSSTIngest|TestCountingWriter|TestSwapInTempDB|TestKVFSMSnapshotRoundTripsSSTIngestPayload|TestGRPCSnapshotTransportRoundTripsSSTIngestPayload|TestPebbleStore_SnapshotRestore|TestPebbleStore_Restore' -count=1 -timeout=15m`\n- `go test ./adapter -count=1 -timeout=20m`\n- `golangci-lint --config=.golangci.yaml run --fix`