### PR TITLE
Add leader proxy circuit breaker

### DIFF
--- a/adapter/dynamodb_errors.go
+++ b/adapter/dynamodb_errors.go
@@ -3,6 +3,7 @@ package adapter
 import (
 	"net/http"
 
+	"github.com/bootjp/elastickv/kv"
 	"github.com/cockroachdb/errors"
 	json "github.com/goccy/go-json"
 	"google.golang.org/grpc/codes"
@@ -39,7 +40,7 @@ func writeDynamoErrorFromErr(w http.ResponseWriter, err error) {
 		writeDynamoError(w, apiErr.status, apiErr.errorType, apiErr.message)
 		return
 	}
-	if status.Code(errors.Cause(err)) == codes.Unavailable {
+	if errors.Is(err, kv.ErrLeaderProxyCircuitOpen) || status.Code(errors.Cause(err)) == codes.Unavailable {
 		writeDynamoError(w, http.StatusServiceUnavailable, dynamoErrServiceUnavailable, "service unavailable")
 		return
 	}

--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -391,6 +391,7 @@ func isTransientLeaderRedisError(err error) bool {
 	if errors.Is(err, ErrLeaderNotFound) ||
 		errors.Is(err, ErrNotLeader) ||
 		errors.Is(err, kv.ErrLeaderNotFound) ||
+		errors.Is(err, kv.ErrLeaderProxyCircuitOpen) ||
 		errors.Is(err, raftengine.ErrNotLeader) ||
 		errors.Is(err, raftengine.ErrLeadershipLost) ||
 		errors.Is(err, raftengine.ErrLeadershipTransferInProgress) {
@@ -412,15 +413,16 @@ func isTransientLeaderRedisError(err error) bool {
 }
 
 // redisLeaderErrorPhrases mirrors kv.leaderErrorPhrases (the kv
-// package keeps it unexported). Any new transient-leader phrase the
-// kv layer treats as retryable should also flip a NOTLEADER prefix
-// on the Redis wire so Carmine's with-exceptions catches it; keep
-// in lockstep.
+// package keeps it unexported) and adds adapter-visible availability
+// sentinels such as the leader-proxy circuit. The circuit is deliberately
+// not coordinator-retryable, but Redis clients still need NOTLEADER so they
+// can retry without treating it as a command failure.
 var redisLeaderErrorPhrases = []string{
 	"not leader",
 	"leader not found",
 	"leadership lost",
 	"leadership transfer in progress",
+	"leader proxy circuit open",
 }
 
 // hasTransientLeaderSuffix is the suffix-match fallback for

--- a/adapter/redis_error_prefix_test.go
+++ b/adapter/redis_error_prefix_test.go
@@ -37,6 +37,7 @@ func TestIsTransientLeaderRedisError(t *testing.T) {
 		{"adapter.ErrLeaderNotFound", ErrLeaderNotFound, true},
 		{"adapter.ErrNotLeader", ErrNotLeader, true},
 		{"kv.ErrLeaderNotFound", kv.ErrLeaderNotFound, true},
+		{"kv.ErrLeaderProxyCircuitOpen", kv.ErrLeaderProxyCircuitOpen, true},
 		{"raftengine.ErrNotLeader", raftengine.ErrNotLeader, true},
 		{"raftengine.ErrLeadershipLost", raftengine.ErrLeadershipLost, true},
 		{"raftengine.ErrLeadershipTransferInProgress",
@@ -67,6 +68,8 @@ func TestIsTransientLeaderRedisError(t *testing.T) {
 			errors.New("rpc error: code = Aborted desc = raft engine: leadership lost"), true},
 		{"grpc-wrapped leadership transfer",
 			errors.New("rpc error: code = Aborted desc = raft engine: leadership transfer in progress"), true},
+		{"grpc-wrapped leader proxy circuit open",
+			errors.New("rpc error: code = Unavailable desc = leader proxy circuit open"), true},
 		// Suffix discipline: a user-controlled key in the middle
 		// of the message must NOT trigger a false positive. The kv
 		// suffix matcher pins this exact scenario; mirror it here.

--- a/adapter/s3.go
+++ b/adapter/s3.go
@@ -2520,7 +2520,7 @@ func writeS3MutationError(w http.ResponseWriter, err error, bucket string, key s
 		writeS3Error(w, http.StatusConflict, "OperationAborted", "conflicting conditional operation in progress", bucket, key)
 		return
 	}
-	if status.Code(errors.Cause(err)) == codes.Unavailable {
+	if errors.Is(err, kv.ErrLeaderProxyCircuitOpen) || status.Code(errors.Cause(err)) == codes.Unavailable {
 		writeS3Error(w, http.StatusServiceUnavailable, "ServiceUnavailable", "service unavailable", bucket, key)
 		return
 	}

--- a/adapter/s3.go
+++ b/adapter/s3.go
@@ -188,6 +188,10 @@ func writeS3ResponseOrInternalError(w http.ResponseWriter, err error) {
 		writeS3Error(w, responseErr.Status, responseErr.Code, responseErr.Message, responseErr.Bucket, responseErr.Key)
 		return
 	}
+	if isS3ServiceUnavailable(err) {
+		writeS3Error(w, http.StatusServiceUnavailable, "ServiceUnavailable", "service unavailable", "", "")
+		return
+	}
 	writeS3InternalError(w, err)
 }
 
@@ -2520,11 +2524,15 @@ func writeS3MutationError(w http.ResponseWriter, err error, bucket string, key s
 		writeS3Error(w, http.StatusConflict, "OperationAborted", "conflicting conditional operation in progress", bucket, key)
 		return
 	}
-	if errors.Is(err, kv.ErrLeaderProxyCircuitOpen) || status.Code(errors.Cause(err)) == codes.Unavailable {
+	if isS3ServiceUnavailable(err) {
 		writeS3Error(w, http.StatusServiceUnavailable, "ServiceUnavailable", "service unavailable", bucket, key)
 		return
 	}
 	writeS3InternalError(w, err)
+}
+
+func isS3ServiceUnavailable(err error) bool {
+	return errors.Is(err, kv.ErrLeaderProxyCircuitOpen) || status.Code(errors.Cause(err)) == codes.Unavailable
 }
 
 var errUnsupportedCannedAcl = errors.New("unsupported canned ACL")

--- a/adapter/s3.go
+++ b/adapter/s3.go
@@ -1208,7 +1208,7 @@ func (s *S3Server) createMultipartUpload(w http.ResponseWriter, r *http.Request,
 			{Op: kv.Put, Key: s3keys.GCUploadKey(bucket, meta.Generation, objectKey, uploadID), Value: body},
 		},
 	}); err != nil {
-		writeS3InternalError(w, err)
+		writeS3MutationError(w, err, bucket, objectKey)
 		return
 	}
 	writeS3XML(w, http.StatusOK, s3InitiateMultipartUploadResult{

--- a/adapter/sqs_catalog.go
+++ b/adapter/sqs_catalog.go
@@ -250,7 +250,7 @@ func writeSQSErrorFromErr(w http.ResponseWriter, err error) {
 		writeSQSError(w, http.StatusBadRequest, sqsErrPurgeInProgress, rateLimit.Error())
 		return
 	}
-	if errors.Is(err, kv.ErrLeaderProxyCircuitOpen) || status.Code(errors.Cause(err)) == codes.Unavailable {
+	if isSQSServiceUnavailable(err) {
 		writeSQSError(w, http.StatusServiceUnavailable, sqsErrServiceUnavailable, "service unavailable")
 		return
 	}
@@ -262,6 +262,10 @@ func writeSQSErrorFromErr(w http.ResponseWriter, err error) {
 	// chain) and return a generic 500 body.
 	slog.Error("sqs adapter internal error", "err", err)
 	writeSQSError(w, http.StatusInternalServerError, sqsErrInternalFailure, "internal error")
+}
+
+func isSQSServiceUnavailable(err error) bool {
+	return errors.Is(err, kv.ErrLeaderProxyCircuitOpen) || status.Code(errors.Cause(err)) == codes.Unavailable
 }
 
 func writeSQSJSON(w http.ResponseWriter, payload any) {

--- a/adapter/sqs_catalog.go
+++ b/adapter/sqs_catalog.go
@@ -250,7 +250,7 @@ func writeSQSErrorFromErr(w http.ResponseWriter, err error) {
 		writeSQSError(w, http.StatusBadRequest, sqsErrPurgeInProgress, rateLimit.Error())
 		return
 	}
-	if status.Code(errors.Cause(err)) == codes.Unavailable {
+	if errors.Is(err, kv.ErrLeaderProxyCircuitOpen) || status.Code(errors.Cause(err)) == codes.Unavailable {
 		writeSQSError(w, http.StatusServiceUnavailable, sqsErrServiceUnavailable, "service unavailable")
 		return
 	}
@@ -940,7 +940,7 @@ func (s *SQSServer) createQueueCore(ctx context.Context, in *sqsCreateQueueInput
 	// here. Idempotent CreateQueue retries on an already-existing
 	// partitioned queue must NOT pay the network poll cost or risk a
 	// transient peer-poll failure flipping a 200-OK retry into a 400
-	// (Codex P1 review on PR #734).
+	// (P1 review on PR #734).
 	if len(in.Tags) > sqsMaxTagsPerQueue {
 		// AWS caps tags per queue at 50. CreateQueue must reject
 		// over-cap tag bundles up front; a silent slice-and-store
@@ -1001,7 +1001,7 @@ func (s *SQSServer) tryCreateQueueOnce(ctx context.Context, requested *sqsQueueM
 	// Runs AFTER the existence check (so idempotent CreateQueue
 	// retries on an already-existing partitioned queue do not pay
 	// the network poll cost or risk a transient peer-poll failure
-	// flipping a 200-OK retry into a 400 — Codex P1 review on PR
+	// flipping a 200-OK retry into a 400 — P1 review on PR
 	// #734) and BEFORE the dispatch (so a rejected create does not
 	// burn an OCC commit).
 	if err := s.validateHTFIFOCapability(ctx, requested); err != nil {

--- a/adapter/sqs_query_protocol.go
+++ b/adapter/sqs_query_protocol.go
@@ -1322,6 +1322,11 @@ func sqsQueryErrorDetails(err error) (int, string, string, int) {
 	code := sqsErrInternalFailure
 	message := "internal error"
 	retryAfter := 0
+	if isSQSServiceUnavailable(err) {
+		status = http.StatusServiceUnavailable
+		code = sqsErrServiceUnavailable
+		message = "service unavailable"
+	}
 	var throttled *sqsThrottlingError
 	if errors.As(err, &throttled) {
 		status = http.StatusBadRequest

--- a/adapter/startup_gate_error_test.go
+++ b/adapter/startup_gate_error_test.go
@@ -1,12 +1,14 @@
 package adapter
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/bootjp/elastickv/kv"
+	"github.com/bootjp/elastickv/store"
 	crdberrors "github.com/cockroachdb/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -26,6 +28,19 @@ func TestHTTPAdaptersMapStartupGateUnavailableTo503(t *testing.T) {
 		}
 		if body := rec.Body.String(); !strings.Contains(body, dynamoErrServiceUnavailable) {
 			t.Fatalf("body %q does not contain %q", body, dynamoErrServiceUnavailable)
+		}
+	})
+
+	t.Run("sqs query", func(t *testing.T) {
+		t.Parallel()
+		rec := httptest.NewRecorder()
+		writeSQSQueryError(rec, err)
+
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status=%d, want 503", rec.Code)
+		}
+		if body := rec.Body.String(); !strings.Contains(body, "<Code>"+sqsErrServiceUnavailable+"</Code>") {
+			t.Fatalf("body %q does not contain %q", body, sqsErrServiceUnavailable)
 		}
 	})
 
@@ -75,6 +90,11 @@ func TestHTTPAdaptersMapLeaderProxyCircuitOpenTo503(t *testing.T) {
 			body: sqsErrServiceUnavailable,
 		},
 		{
+			name: "sqs query",
+			call: func(w http.ResponseWriter) { writeSQSQueryError(w, kv.ErrLeaderProxyCircuitOpen) },
+			body: "<Code>" + sqsErrServiceUnavailable + "</Code>",
+		},
+		{
 			name: "s3",
 			call: func(w http.ResponseWriter) {
 				writeS3MutationError(w, kv.ErrLeaderProxyCircuitOpen, "bucket-a", "key-a")
@@ -99,6 +119,58 @@ func TestHTTPAdaptersMapLeaderProxyCircuitOpenTo503(t *testing.T) {
 			}
 			if body := rec.Body.String(); !strings.Contains(body, tt.body) {
 				t.Fatalf("body %q does not contain %q", body, tt.body)
+			}
+		})
+	}
+}
+
+type availabilityErrorCoordinator struct {
+	stubAdapterCoordinator
+	err error
+}
+
+func (c *availabilityErrorCoordinator) Dispatch(context.Context, *kv.OperationGroup[kv.OP]) (*kv.CoordinateResponse, error) {
+	return nil, c.err
+}
+
+func TestS3CreateMultipartUploadMapsAvailabilityErrorsTo503(t *testing.T) {
+	t.Parallel()
+
+	st := store.NewMVCCStore()
+	local := newLocalAdapterCoordinator(st)
+	server := NewS3Server(nil, "", st, local, nil)
+
+	rec := httptest.NewRecorder()
+	server.handle(rec, newS3TestRequest(http.MethodPut, "/bucket-a", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("create bucket status=%d, want 200: %s", rec.Code, rec.Body.String())
+	}
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "circuit open", err: kv.ErrLeaderProxyCircuitOpen},
+		{name: "grpc unavailable", err: crdberrors.Wrap(status.Error(codes.Unavailable, "startup gate closed"), "dispatch")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server.coordinator = &availabilityErrorCoordinator{
+				stubAdapterCoordinator: stubAdapterCoordinator{clock: local.Clock()},
+				err:                    tt.err,
+			}
+			rec := httptest.NewRecorder()
+			server.createMultipartUpload(
+				rec,
+				newS3TestRequest(http.MethodPost, "/bucket-a/key?uploads=", nil),
+				"bucket-a",
+				"key",
+			)
+			if rec.Code != http.StatusServiceUnavailable {
+				t.Fatalf("status=%d, want 503: %s", rec.Code, rec.Body.String())
+			}
+			if body := rec.Body.String(); !strings.Contains(body, "<Code>ServiceUnavailable</Code>") {
+				t.Fatalf("body %q does not contain ServiceUnavailable", body)
 			}
 		})
 	}

--- a/adapter/startup_gate_error_test.go
+++ b/adapter/startup_gate_error_test.go
@@ -81,6 +81,13 @@ func TestHTTPAdaptersMapLeaderProxyCircuitOpenTo503(t *testing.T) {
 			},
 			body: "<Code>ServiceUnavailable</Code>",
 		},
+		{
+			name: "s3 chunk upload",
+			call: func(w http.ResponseWriter) {
+				(&S3Server{}).writeS3ChunkUploadError(w, nil, kv.ErrLeaderProxyCircuitOpen, "bucket-a", "key-a")
+			},
+			body: "<Code>ServiceUnavailable</Code>",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/adapter/startup_gate_error_test.go
+++ b/adapter/startup_gate_error_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bootjp/elastickv/kv"
 	crdberrors "github.com/cockroachdb/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -53,4 +54,45 @@ func TestHTTPAdaptersMapStartupGateUnavailableTo503(t *testing.T) {
 			t.Fatalf("body %q does not contain ServiceUnavailable", body)
 		}
 	})
+}
+
+func TestHTTPAdaptersMapLeaderProxyCircuitOpenTo503(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		call func(http.ResponseWriter)
+		body string
+	}{
+		{
+			name: "dynamodb",
+			call: func(w http.ResponseWriter) { writeDynamoErrorFromErr(w, kv.ErrLeaderProxyCircuitOpen) },
+			body: dynamoErrServiceUnavailable,
+		},
+		{
+			name: "sqs",
+			call: func(w http.ResponseWriter) { writeSQSErrorFromErr(w, kv.ErrLeaderProxyCircuitOpen) },
+			body: sqsErrServiceUnavailable,
+		},
+		{
+			name: "s3",
+			call: func(w http.ResponseWriter) {
+				writeS3MutationError(w, kv.ErrLeaderProxyCircuitOpen, "bucket-a", "key-a")
+			},
+			body: "<Code>ServiceUnavailable</Code>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			rec := httptest.NewRecorder()
+			tt.call(rec)
+			if rec.Code != http.StatusServiceUnavailable {
+				t.Fatalf("status=%d, want 503", rec.Code)
+			}
+			if body := rec.Body.String(); !strings.Contains(body, tt.body) {
+				t.Fatalf("body %q does not contain %q", body, tt.body)
+			}
+		})
+	}
 }

--- a/docs/design/2026_07_19_implemented_leader_proxy_circuit_breaker.md
+++ b/docs/design/2026_07_19_implemented_leader_proxy_circuit_breaker.md
@@ -103,6 +103,10 @@ Unit coverage pins:
 - late in-flight failure handling;
 - exponential backoff cap;
 - transport and business-error classification; and
+- proxy-budget deadline accounting against a blackholed endpoint;
+- caller cancellation releasing a blackholed half-open probe;
+- recovery-owner half-open success after transport `Unavailable` failures;
+- S3 chunk-upload circuit-open mapping; and
 - the existing short-election and full-budget integration cases.
 
 The race suite covers concurrent breaker access and half-open probe admission.

--- a/docs/design/2026_07_19_implemented_leader_proxy_circuit_breaker.md
+++ b/docs/design/2026_07_19_implemented_leader_proxy_circuit_breaker.md
@@ -68,7 +68,9 @@ identity are ignored after a newer identity has been observed.
 
 Caller cancellation and caller-deadline expiry are not leader health signals.
 They release an acquired half-open probe without incrementing or clearing the
-failure count, so another live request can probe the same identity.
+failure count. A recovery owner that exits during backoff also releases its
+reservation, so another live request can probe the same identity without
+allowing a later request to steal an active owner's probe.
 
 Any change in leader ID, address, or term resets the breaker immediately. A
 verified local-leader commit also resets it.
@@ -106,7 +108,9 @@ Unit coverage pins:
 - proxy-budget deadline accounting against a blackholed endpoint;
 - caller cancellation releasing a blackholed half-open probe;
 - recovery-owner half-open success after transport `Unavailable` failures;
-- S3 chunk-upload circuit-open mapping; and
+- recovery-owner reservation under concurrent half-open admission;
+- S3 chunk-upload and create-multipart circuit-open mapping;
+- SQS JSON and Query protocol service-unavailable mapping; and
 - the existing short-election and full-budget integration cases.
 
 The race suite covers concurrent breaker access and half-open probe admission.

--- a/docs/design/2026_07_19_implemented_leader_proxy_circuit_breaker.md
+++ b/docs/design/2026_07_19_implemented_leader_proxy_circuit_breaker.md
@@ -1,0 +1,122 @@
+# Leader proxy circuit breaker
+
+Status: Implemented
+
+Document type: Focused design and implementation record
+
+Author: bootjp
+
+Date: 2026-07-19
+
+## 1. Problem
+
+`LeaderProxy` already bounds one forwarding request with a five-second retry
+budget. That bound does not coordinate concurrent requests. During an election
+or an unreachable-leader interval, every request can independently retry the
+same endpoint, repeatedly ask the shared gRPC connection to reconnect, and
+amplify an availability incident into connection and scheduler pressure.
+
+The proxy needs cross-request memory. It must suppress repeated work against a
+leader identity that has just failed while preserving the existing behavior
+that lets one request wait through a short election.
+
+## 2. Scope
+
+This change owns the data-plane `kv.LeaderProxy` forwarding breaker:
+
+1. failure accounting across requests;
+2. leader-change reset using leader ID, address, and Raft term;
+3. bounded exponential backoff and one half-open probe;
+4. adapter-visible transient error classification; and
+5. interaction with the shared gRPC connection cache.
+
+HTTP leader proxying is separate. Raft election policy, transport health, and
+application-level retry/idempotency remain unchanged.
+
+## 3. State machine
+
+Each `LeaderProxy` owns one breaker because each instance fronts one Raft
+group. The breaker key is `(leader_id, leader_address, term)`.
+
+### 3.1 Closed
+
+Requests use the existing per-request retry loop. Typed leadership errors,
+wire-level leadership errors, and gRPC `Unavailable` or `DeadlineExceeded`
+responses count as breaker failures. Business errors do not.
+
+Three consecutive failures open the breaker. A successful RPC, including a
+terminal application response from a reachable leader, clears the failure
+count.
+
+### 3.2 Open
+
+The first request that reaches the threshold remains the owner of recovery. It
+continues to honor the existing five-second request budget, but it does not send
+RPCs while the breaker backoff is active. Other requests fail immediately with
+`ErrLeaderProxyCircuitOpen` instead of starting their own retry loops.
+
+Backoff begins at 100 ms, doubles after each failed half-open probe, and is
+capped at two seconds.
+
+### 3.3 Half-open
+
+After backoff, exactly one request may probe the current identity. Success
+closes the breaker. A transient failure reopens it with the next backoff. Late
+failures from requests that were already in flight when the breaker opened do
+not steal probe ownership or extend the outage. Results from an older leader
+identity are ignored after a newer identity has been observed.
+
+Caller cancellation and caller-deadline expiry are not leader health signals.
+They release an acquired half-open probe without incrementing or clearing the
+failure count, so another live request can probe the same identity.
+
+Any change in leader ID, address, or term resets the breaker immediately. A
+verified local-leader commit also resets it.
+
+## 4. Error contract
+
+`ErrLeaderProxyCircuitOpen` is a transient availability error. Redis maps it to
+`NOTLEADER`; DynamoDB, SQS, S3, and Admin map it to their existing 503
+surfaces, including the exact suffix used after a gRPC boundary. It is
+deliberately excluded from the coordinator's transaction retry predicate: the
+breaker has already made the retry decision, and an outer retry could reissue a
+transaction with new timestamps or mutation contents.
+
+The breaker does not change ambiguous-write semantics. A request that may have
+reached a leader still returns through the same adapter-specific idempotency and
+error handling paths as before.
+
+## 5. gRPC connection behavior
+
+`GRPCConnCache` continues to reuse one connection per address and replaces only
+connections in `Shutdown`. It no longer calls `ResetConnectBackoff` whenever a
+caller observes `TransientFailure`; doing so on every request defeats gRPC's
+own reconnect backoff and recreates the retry storm below the breaker.
+
+## 6. Verification
+
+Unit coverage pins:
+
+- threshold/open behavior;
+- one half-open probe;
+- leader/term reset;
+- late in-flight failure handling;
+- exponential backoff cap;
+- transport and business-error classification; and
+- the existing short-election and full-budget integration cases.
+
+The race suite covers concurrent breaker access and half-open probe admission.
+
+## 7. Rollout and rollback
+
+The change is local and carries no Raft, protobuf, or persisted-data format.
+Mixed-version nodes are safe. Rollback restores independent per-request retry
+loops and connection-backoff resets; it does not require data repair.
+
+## 8. Non-goals
+
+- changing Raft election timeout or leader selection;
+- sharing breaker state across Raft groups;
+- replacing adapter-level idempotency;
+- changing HTTP reverse-proxy retries; or
+- hiding persistent unavailability beyond the existing request deadline.

--- a/kv/coordinator_retry_test.go
+++ b/kv/coordinator_retry_test.go
@@ -97,7 +97,8 @@ func TestIsTransientLeaderError_Classification(t *testing.T) {
 			fmt.Errorf("rpc error: code = Unknown desc = raft engine: leadership lost"), true},
 		{"unrelated error", errors.New("write conflict"), false},
 		{"validation error", errors.New("invalid request"), false},
-		// Codex P2 regression: before the HasSuffix switch this was
+		{"leader proxy circuit open", cerrors.WithStack(ErrLeaderProxyCircuitOpen), false},
+		// P2 regression: before the HasSuffix switch this was
 		// misclassified as transient because the substring matcher
 		// saw "not leader" in the middle. store.WriteConflictError
 		// literally formats as "key: <user-key>: write conflict",
@@ -115,6 +116,12 @@ func TestIsTransientLeaderError_Classification(t *testing.T) {
 			require.Equal(t, tc.want, isTransientLeaderError(tc.err))
 		})
 	}
+}
+
+func TestShouldRetryDispatchDoesNotRetryLeaderProxyCircuitOpen(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, shouldRetryDispatch(cerrors.WithStack(ErrLeaderProxyCircuitOpen)))
 }
 
 // newRetryCoordinate wires a Coordinate against stubLeaderEngine and the
@@ -303,7 +310,7 @@ func TestIsTransientLeaderError_PinsRealSentinels(t *testing.T) {
 }
 
 // TestFinalDispatchErr_PrefersTransientOnBudgetExpiry pins the
-// Codex-P2 fix: when Dispatch's bounded retry budget fires
+// P2 fix: when Dispatch's bounded retry budget fires
 // mid-attempt, dispatchOnce returns a context.DeadlineExceeded
 // propagated from boundedCtx rather than a genuine failure. The
 // gRPC caller should see the last transient leader error collected

--- a/kv/grpc_conn_cache.go
+++ b/kv/grpc_conn_cache.go
@@ -35,9 +35,6 @@ func (c *GRPCConnCache) cachedConn(addr string) *grpc.ClientConn {
 		delete(c.conns, addr)
 		return nil
 	}
-	if st == connectivity.TransientFailure {
-		conn.ResetConnectBackoff()
-	}
 	return conn
 }
 
@@ -53,9 +50,6 @@ func (c *GRPCConnCache) storeConn(addr string, conn *grpc.ClientConn) *grpc.Clie
 	if ok && existing != nil {
 		st := existing.GetState()
 		if st != connectivity.Shutdown {
-			if st == connectivity.TransientFailure {
-				existing.ResetConnectBackoff()
-			}
 			return existing
 		}
 		delete(c.conns, addr)

--- a/kv/leader_proxy.go
+++ b/kv/leader_proxy.go
@@ -110,6 +110,7 @@ func (p *LeaderProxy) forwardWithRetry(callerCtx context.Context, reqs []*pb.Req
 	parentCtx, cancelParent := context.WithDeadline(callerCtx, deadline)
 	defer cancelParent()
 	requestID := p.forwardSeq.Add(1)
+	defer p.forwardBreaker.releaseRequest(requestID)
 
 	var lastErr error
 	for {

--- a/kv/leader_proxy.go
+++ b/kv/leader_proxy.go
@@ -3,6 +3,7 @@ package kv
 import (
 	"context"
 	"io"
+	"sync/atomic"
 	"time"
 
 	"github.com/bootjp/elastickv/internal/raftengine"
@@ -29,7 +30,9 @@ type LeaderProxy struct {
 	engine raftengine.Engine
 	tm     *TransactionManager
 
-	connCache GRPCConnCache
+	connCache      GRPCConnCache
+	forwardBreaker leaderProxyCircuitBreaker
+	forwardSeq     atomic.Uint64
 }
 
 func NewLeaderProxyWithEngine(engine raftengine.Engine, opts ...TransactionOption) *LeaderProxy {
@@ -51,6 +54,7 @@ func (p *LeaderProxy) Commit(ctx context.Context, reqs []*pb.Request) (*Transact
 	if err := verifyLeaderEngineCtx(ctx, p.engine); err != nil {
 		return p.forwardWithRetry(ctx, reqs)
 	}
+	p.forwardBreaker.reset(leaderProxyIdentityFromEngine(p.engine))
 	return p.tm.Commit(ctx, reqs)
 }
 
@@ -62,6 +66,7 @@ func (p *LeaderProxy) Abort(ctx context.Context, reqs []*pb.Request) (*Transacti
 	if err := verifyLeaderEngineCtx(ctx, p.engine); err != nil {
 		return p.forwardWithRetry(ctx, reqs)
 	}
+	p.forwardBreaker.reset(leaderProxyIdentityFromEngine(p.engine))
 	return p.tm.Abort(ctx, reqs)
 }
 
@@ -104,6 +109,7 @@ func (p *LeaderProxy) forwardWithRetry(callerCtx context.Context, reqs []*pb.Req
 	// retry budget exits early without waiting out the full 5 s.
 	parentCtx, cancelParent := context.WithDeadline(callerCtx, deadline)
 	defer cancelParent()
+	requestID := p.forwardSeq.Add(1)
 
 	var lastErr error
 	for {
@@ -111,11 +117,13 @@ func (p *LeaderProxy) forwardWithRetry(callerCtx context.Context, reqs []*pb.Req
 		// whatever leader is currently visible and returns either a
 		// committed response, a terminal error, or the last transient
 		// leader error for the outer loop to re-poll on.
-		resp, err, done := p.runForwardCycle(parentCtx, reqs, deadline)
+		resp, err, done := p.runForwardCycle(parentCtx, reqs, deadline, requestID)
 		if done {
 			return resp, err
 		}
-		lastErr = err
+		if !errors.Is(err, ErrLeaderProxyCircuitOpen) {
+			lastErr = err
+		}
 		// Defensive: if runForwardCycle exited on the deadline guard
 		// before ever calling forward() (e.g. a future refactor
 		// shortens the budget, or the clock jumps forward between the
@@ -170,18 +178,22 @@ func waitLeaderProxyBackoff(parentCtx context.Context, interval time.Duration, d
 //   - (nil, nil, false) when the inner loop exited on the deadline
 //     guard before calling forward() at all; caller surfaces
 //     ErrLeaderNotFound for that defensive path.
-func (p *LeaderProxy) runForwardCycle(parentCtx context.Context, reqs []*pb.Request, deadline time.Time) (*TransactionResponse, error, bool) {
+func (p *LeaderProxy) runForwardCycle(parentCtx context.Context, reqs []*pb.Request, deadline time.Time, requestID uint64) (*TransactionResponse, error, bool) {
 	var lastErr error
 	for attempt := 0; attempt < maxForwardRetries; attempt++ {
 		if !time.Now().Before(deadline) {
 			// Budget expired mid-cycle; do not start another RPC.
 			break
 		}
-		resp, err := p.forward(parentCtx, reqs)
+		resp, err := p.forward(parentCtx, reqs, requestID)
 		if err == nil {
 			return resp, nil, true
 		}
 		lastErr = err
+		if errors.Is(err, ErrLeaderProxyCircuitOpen) {
+			identity := leaderProxyIdentityFromEngine(p.engine)
+			return nil, err, !p.forwardBreaker.mayRetryAfterOpen(identity, requestID)
+		}
 		if isTransientLeaderError(err) {
 			break
 		}
@@ -192,14 +204,21 @@ func (p *LeaderProxy) runForwardCycle(parentCtx context.Context, reqs []*pb.Requ
 	return nil, lastErr, false
 }
 
-func (p *LeaderProxy) forward(parentCtx context.Context, reqs []*pb.Request) (*TransactionResponse, error) {
-	addr := leaderAddrFromEngine(p.engine)
+func (p *LeaderProxy) forward(parentCtx context.Context, reqs []*pb.Request, requestID uint64) (*TransactionResponse, error) {
+	identity := leaderProxyIdentityFromEngine(p.engine)
+	if err := p.forwardBreaker.allow(identity, requestID, time.Now()); err != nil {
+		return nil, err
+	}
+	addr := identity.address
 	if addr == "" {
-		return nil, errors.WithStack(ErrLeaderNotFound)
+		err := errors.WithStack(ErrLeaderNotFound)
+		p.forwardBreaker.record(identity, requestID, err, time.Now())
+		return nil, err
 	}
 
 	conn, err := p.connCache.ConnFor(addr)
 	if err != nil {
+		p.forwardBreaker.record(identity, requestID, err, time.Now())
 		return nil, err
 	}
 
@@ -215,8 +234,15 @@ func (p *LeaderProxy) forward(parentCtx context.Context, reqs []*pb.Request) (*T
 		Requests: reqs,
 	})
 	if err != nil {
-		return nil, errors.WithStack(err)
+		wrapped := errors.WithStack(err)
+		if parentCtx.Err() != nil {
+			p.forwardBreaker.release(identity, requestID)
+			return nil, wrapped
+		}
+		p.forwardBreaker.record(identity, requestID, wrapped, time.Now())
+		return nil, wrapped
 	}
+	p.forwardBreaker.record(identity, requestID, nil, time.Now())
 	if !resp.Success {
 		return nil, ErrInvalidRequest
 	}

--- a/kv/leader_proxy.go
+++ b/kv/leader_proxy.go
@@ -117,7 +117,7 @@ func (p *LeaderProxy) forwardWithRetry(callerCtx context.Context, reqs []*pb.Req
 		// whatever leader is currently visible and returns either a
 		// committed response, a terminal error, or the last transient
 		// leader error for the outer loop to re-poll on.
-		resp, err, done := p.runForwardCycle(parentCtx, reqs, deadline, requestID)
+		resp, err, done := p.runForwardCycle(callerCtx, parentCtx, reqs, deadline, requestID)
 		if done {
 			return resp, err
 		}
@@ -138,6 +138,9 @@ func (p *LeaderProxy) forwardWithRetry(callerCtx context.Context, reqs []*pb.Req
 			return nil, lastErr
 		}
 		waitLeaderProxyBackoff(parentCtx, leaderProxyRetryInterval, deadline)
+		if err := callerCtx.Err(); err != nil {
+			return nil, errors.WithStack(err)
+		}
 		// Re-check the deadline AFTER the back-off: if the budget is
 		// exhausted, do not enter another maxForwardRetries cycle
 		// (which could issue up to three more RPCs, each bounded by
@@ -178,24 +181,26 @@ func waitLeaderProxyBackoff(parentCtx context.Context, interval time.Duration, d
 //   - (nil, nil, false) when the inner loop exited on the deadline
 //     guard before calling forward() at all; caller surfaces
 //     ErrLeaderNotFound for that defensive path.
-func (p *LeaderProxy) runForwardCycle(parentCtx context.Context, reqs []*pb.Request, deadline time.Time, requestID uint64) (*TransactionResponse, error, bool) {
+func (p *LeaderProxy) runForwardCycle(callerCtx context.Context, parentCtx context.Context, reqs []*pb.Request, deadline time.Time, requestID uint64) (*TransactionResponse, error, bool) {
 	var lastErr error
 	for attempt := 0; attempt < maxForwardRetries; attempt++ {
+		if err := callerCtx.Err(); err != nil {
+			return nil, errors.WithStack(err), true
+		}
 		if !time.Now().Before(deadline) {
 			// Budget expired mid-cycle; do not start another RPC.
 			break
 		}
-		resp, err := p.forward(parentCtx, reqs, requestID)
+		resp, err := p.forward(callerCtx, parentCtx, reqs, requestID)
 		if err == nil {
 			return resp, nil, true
 		}
 		lastErr = err
-		if errors.Is(err, ErrLeaderProxyCircuitOpen) {
-			identity := leaderProxyIdentityFromEngine(p.engine)
-			return nil, err, !p.forwardBreaker.mayRetryAfterOpen(identity, requestID)
+		if callerErr := callerCtx.Err(); callerErr != nil {
+			return nil, errors.WithStack(callerErr), true
 		}
-		if isTransientLeaderError(err) {
-			break
+		if leaveCycle, done := p.forwardFailureDecision(err, requestID); leaveCycle {
+			return nil, err, done
 		}
 	}
 	if lastErr != nil && !isTransientLeaderError(lastErr) {
@@ -204,22 +209,40 @@ func (p *LeaderProxy) runForwardCycle(parentCtx context.Context, reqs []*pb.Requ
 	return nil, lastErr, false
 }
 
-func (p *LeaderProxy) forward(parentCtx context.Context, reqs []*pb.Request, requestID uint64) (*TransactionResponse, error) {
+func (p *LeaderProxy) forwardFailureDecision(err error, requestID uint64) (leaveCycle bool, done bool) {
+	if errors.Is(err, ErrLeaderProxyCircuitOpen) {
+		identity := leaderProxyIdentityFromEngine(p.engine)
+		return true, !p.forwardBreaker.mayRetryAfterOpen(identity, requestID)
+	}
+	if isTransientLeaderError(err) {
+		return true, false
+	}
+	if !isLeaderProxyBreakerFailure(err) {
+		return false, false
+	}
+	identity := leaderProxyIdentityFromEngine(p.engine)
+	if p.forwardBreaker.mayRetryAfterOpen(identity, requestID) {
+		return true, false
+	}
+	return false, false
+}
+
+func (p *LeaderProxy) forward(callerCtx context.Context, parentCtx context.Context, reqs []*pb.Request, requestID uint64) (*TransactionResponse, error) {
+	if err := callerCtx.Err(); err != nil {
+		return nil, errors.WithStack(err)
+	}
 	identity := leaderProxyIdentityFromEngine(p.engine)
 	if err := p.forwardBreaker.allow(identity, requestID, time.Now()); err != nil {
 		return nil, err
 	}
 	addr := identity.address
 	if addr == "" {
-		err := errors.WithStack(ErrLeaderNotFound)
-		p.forwardBreaker.record(identity, requestID, err, time.Now())
-		return nil, err
+		return nil, p.recordForwardFailure(callerCtx, identity, requestID, ErrLeaderNotFound)
 	}
 
 	conn, err := p.connCache.ConnFor(addr)
 	if err != nil {
-		p.forwardBreaker.record(identity, requestID, err, time.Now())
-		return nil, err
+		return nil, p.recordForwardFailure(callerCtx, identity, requestID, err)
 	}
 
 	cli := pb.NewInternalClient(conn)
@@ -234,19 +257,23 @@ func (p *LeaderProxy) forward(parentCtx context.Context, reqs []*pb.Request, req
 		Requests: reqs,
 	})
 	if err != nil {
-		wrapped := errors.WithStack(err)
-		if parentCtx.Err() != nil {
-			p.forwardBreaker.release(identity, requestID)
-			return nil, wrapped
-		}
-		p.forwardBreaker.record(identity, requestID, wrapped, time.Now())
-		return nil, wrapped
+		return nil, p.recordForwardFailure(callerCtx, identity, requestID, err)
 	}
 	p.forwardBreaker.record(identity, requestID, nil, time.Now())
 	if !resp.Success {
 		return nil, ErrInvalidRequest
 	}
 	return &TransactionResponse{CommitIndex: resp.CommitIndex}, nil
+}
+
+func (p *LeaderProxy) recordForwardFailure(callerCtx context.Context, identity leaderProxyIdentity, requestID uint64, err error) error {
+	if callerErr := callerCtx.Err(); callerErr != nil {
+		p.forwardBreaker.release(identity, requestID)
+		return errors.WithStack(callerErr)
+	}
+	wrapped := errors.WithStack(err)
+	p.forwardBreaker.record(identity, requestID, wrapped, time.Now())
+	return wrapped
 }
 
 var _ Transactional = (*LeaderProxy)(nil)

--- a/kv/leader_proxy_breaker.go
+++ b/kv/leader_proxy_breaker.go
@@ -63,11 +63,16 @@ func (b *leaderProxyCircuitBreaker) allow(identity leaderProxyIdentity, requestI
 	if b.openUntil.IsZero() {
 		return nil
 	}
+	if b.owner != 0 && b.owner != requestID {
+		return leaderProxyCircuitOpenError(identity, b.openUntilText)
+	}
 	if b.probeInFlight {
 		return leaderProxyCircuitOpenError(identity, b.openUntilText)
 	}
 	b.probeInFlight = true
-	b.owner = requestID
+	if b.owner == 0 {
+		b.owner = requestID
+	}
 	return nil
 }
 
@@ -102,13 +107,24 @@ func (b *leaderProxyCircuitBreaker) record(identity leaderProxyIdentity, request
 	b.owner = requestID
 }
 
-// release abandons a half-open probe without treating caller cancellation as
+// release abandons recovery ownership without treating caller cancellation as
 // evidence that the leader is unhealthy. The next request may take the probe.
 func (b *leaderProxyCircuitBreaker) release(identity leaderProxyIdentity, requestID uint64) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if !b.initialized || b.identity != identity || b.owner != requestID || !b.probeInFlight {
+	if !b.initialized || b.identity != identity || b.owner != requestID {
+		return
+	}
+	b.probeInFlight = false
+	b.owner = 0
+}
+
+func (b *leaderProxyCircuitBreaker) releaseRequest(requestID uint64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.owner != requestID {
 		return
 	}
 	b.probeInFlight = false

--- a/kv/leader_proxy_breaker.go
+++ b/kv/leader_proxy_breaker.go
@@ -1,0 +1,177 @@
+package kv
+
+import (
+	"sync"
+	"time"
+
+	"github.com/bootjp/elastickv/internal/raftengine"
+	"github.com/cockroachdb/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	leaderProxyBreakerFailureThreshold = 3
+	leaderProxyBreakerBaseBackoff      = 100 * time.Millisecond
+	leaderProxyBreakerMaxBackoff       = 2 * time.Second
+)
+
+// ErrLeaderProxyCircuitOpen indicates that recent attempts against the same
+// leader identity failed and the shared forwarding breaker is suppressing a
+// retry storm. It is transient: callers may retry after leader publication or
+// the breaker backoff, but a single request must not busy-loop on it.
+var ErrLeaderProxyCircuitOpen = errors.New("leader proxy circuit open")
+
+type leaderProxyIdentity struct {
+	id      string
+	address string
+	term    uint64
+}
+
+func leaderProxyIdentityFromEngine(engine raftengine.Engine) leaderProxyIdentity {
+	if engine == nil {
+		return leaderProxyIdentity{}
+	}
+	status := engine.Status()
+	leader := status.Leader
+	if leader.ID == "" && leader.Address == "" {
+		leader = engine.Leader()
+	}
+	return leaderProxyIdentity{id: leader.ID, address: leader.Address, term: status.Term}
+}
+
+type leaderProxyCircuitBreaker struct {
+	mu sync.Mutex
+
+	identity      leaderProxyIdentity
+	initialized   bool
+	failures      int
+	openUntil     time.Time
+	probeInFlight bool
+	owner         uint64
+}
+
+func (b *leaderProxyCircuitBreaker) allow(identity leaderProxyIdentity, requestID uint64, now time.Time) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.resetForIdentityLocked(identity)
+	if now.Before(b.openUntil) {
+		return leaderProxyCircuitOpenError(identity, b.openUntil)
+	}
+	if b.openUntil.IsZero() {
+		return nil
+	}
+	if b.probeInFlight {
+		return leaderProxyCircuitOpenError(identity, b.openUntil)
+	}
+	b.probeInFlight = true
+	b.owner = requestID
+	return nil
+}
+
+func (b *leaderProxyCircuitBreaker) record(identity leaderProxyIdentity, requestID uint64, err error, now time.Time) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// Every record follows a successful allow. If the identity has changed in
+	// the meantime, this is a late result from the old leader and must not
+	// resurrect stale breaker state.
+	if !b.initialized || b.identity != identity {
+		return
+	}
+	if !isLeaderProxyBreakerFailure(err) {
+		b.failures = 0
+		b.openUntil = time.Time{}
+		b.probeInFlight = false
+		b.owner = 0
+		return
+	}
+	if !b.openUntil.IsZero() && b.owner != requestID {
+		return
+	}
+	b.probeInFlight = false
+	b.failures++
+	if b.failures < leaderProxyBreakerFailureThreshold {
+		return
+	}
+	b.openUntil = now.Add(leaderProxyBreakerBackoff(b.failures))
+	b.owner = requestID
+}
+
+// release abandons a half-open probe without treating caller cancellation as
+// evidence that the leader is unhealthy. The next request may take the probe.
+func (b *leaderProxyCircuitBreaker) release(identity leaderProxyIdentity, requestID uint64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if !b.initialized || b.identity != identity || b.owner != requestID || !b.probeInFlight {
+		return
+	}
+	b.probeInFlight = false
+	b.owner = 0
+}
+
+func (b *leaderProxyCircuitBreaker) owns(identity leaderProxyIdentity, requestID uint64) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.initialized && b.identity == identity && b.owner == requestID
+}
+
+func (b *leaderProxyCircuitBreaker) mayRetryAfterOpen(current leaderProxyIdentity, requestID uint64) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.initialized && (b.identity != current || b.owner == requestID)
+}
+
+func (b *leaderProxyCircuitBreaker) reset(identity leaderProxyIdentity) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.identity = identity
+	b.initialized = true
+	b.failures = 0
+	b.openUntil = time.Time{}
+	b.probeInFlight = false
+	b.owner = 0
+}
+
+func (b *leaderProxyCircuitBreaker) resetForIdentityLocked(identity leaderProxyIdentity) {
+	if b.initialized && b.identity == identity {
+		return
+	}
+	b.identity = identity
+	b.initialized = true
+	b.failures = 0
+	b.openUntil = time.Time{}
+	b.probeInFlight = false
+	b.owner = 0
+}
+
+func leaderProxyCircuitOpenError(identity leaderProxyIdentity, until time.Time) error {
+	return errors.Wrapf(ErrLeaderProxyCircuitOpen,
+		"leader id=%q address=%q term=%d unavailable until %s",
+		identity.id, identity.address, identity.term, until.UTC().Format(time.RFC3339Nano))
+}
+
+func leaderProxyBreakerBackoff(failures int) time.Duration {
+	exponent := failures - leaderProxyBreakerFailureThreshold
+	backoff := leaderProxyBreakerBaseBackoff
+	for range exponent {
+		if backoff >= leaderProxyBreakerMaxBackoff/2 {
+			return leaderProxyBreakerMaxBackoff
+		}
+		backoff *= 2
+	}
+	return min(backoff, leaderProxyBreakerMaxBackoff)
+}
+
+func isLeaderProxyBreakerFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	if isTransientLeaderError(err) {
+		return true
+	}
+	code := status.Code(err)
+	return code == codes.Unavailable || code == codes.DeadlineExceeded
+}

--- a/kv/leader_proxy_breaker.go
+++ b/kv/leader_proxy_breaker.go
@@ -47,6 +47,7 @@ type leaderProxyCircuitBreaker struct {
 	initialized   bool
 	failures      int
 	openUntil     time.Time
+	openUntilText string
 	probeInFlight bool
 	owner         uint64
 }
@@ -57,13 +58,13 @@ func (b *leaderProxyCircuitBreaker) allow(identity leaderProxyIdentity, requestI
 
 	b.resetForIdentityLocked(identity)
 	if now.Before(b.openUntil) {
-		return leaderProxyCircuitOpenError(identity, b.openUntil)
+		return leaderProxyCircuitOpenError(identity, b.openUntilText)
 	}
 	if b.openUntil.IsZero() {
 		return nil
 	}
 	if b.probeInFlight {
-		return leaderProxyCircuitOpenError(identity, b.openUntil)
+		return leaderProxyCircuitOpenError(identity, b.openUntilText)
 	}
 	b.probeInFlight = true
 	b.owner = requestID
@@ -83,6 +84,7 @@ func (b *leaderProxyCircuitBreaker) record(identity leaderProxyIdentity, request
 	if !isLeaderProxyBreakerFailure(err) {
 		b.failures = 0
 		b.openUntil = time.Time{}
+		b.openUntilText = ""
 		b.probeInFlight = false
 		b.owner = 0
 		return
@@ -96,6 +98,7 @@ func (b *leaderProxyCircuitBreaker) record(identity leaderProxyIdentity, request
 		return
 	}
 	b.openUntil = now.Add(leaderProxyBreakerBackoff(b.failures))
+	b.openUntilText = b.openUntil.UTC().Format(time.RFC3339Nano)
 	b.owner = requestID
 }
 
@@ -131,6 +134,7 @@ func (b *leaderProxyCircuitBreaker) reset(identity leaderProxyIdentity) {
 	b.initialized = true
 	b.failures = 0
 	b.openUntil = time.Time{}
+	b.openUntilText = ""
 	b.probeInFlight = false
 	b.owner = 0
 }
@@ -143,14 +147,15 @@ func (b *leaderProxyCircuitBreaker) resetForIdentityLocked(identity leaderProxyI
 	b.initialized = true
 	b.failures = 0
 	b.openUntil = time.Time{}
+	b.openUntilText = ""
 	b.probeInFlight = false
 	b.owner = 0
 }
 
-func leaderProxyCircuitOpenError(identity leaderProxyIdentity, until time.Time) error {
+func leaderProxyCircuitOpenError(identity leaderProxyIdentity, untilText string) error {
 	return errors.Wrapf(ErrLeaderProxyCircuitOpen,
 		"leader id=%q address=%q term=%d unavailable until %s",
-		identity.id, identity.address, identity.term, until.UTC().Format(time.RFC3339Nano))
+		identity.id, identity.address, identity.term, untilText)
 }
 
 func leaderProxyBreakerBackoff(failures int) time.Duration {

--- a/kv/leader_proxy_breaker_test.go
+++ b/kv/leader_proxy_breaker_test.go
@@ -1,0 +1,178 @@
+package kv
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestLeaderProxyCircuitBreakerOpensAndLimitsHalfOpenProbe(t *testing.T) {
+	t.Parallel()
+
+	var breaker leaderProxyCircuitBreaker
+	identity := leaderProxyIdentity{id: "n1", address: "127.0.0.1:50051", term: 7}
+	now := time.Unix(100, 0)
+
+	for attempt := 1; attempt <= leaderProxyBreakerFailureThreshold; attempt++ {
+		require.NoError(t, breaker.allow(identity, 1, now))
+		breaker.record(identity, 1, ErrLeaderNotFound, now)
+	}
+
+	err := breaker.allow(identity, 1, now.Add(time.Millisecond))
+	require.ErrorIs(t, err, ErrLeaderProxyCircuitOpen)
+	require.True(t, breaker.owns(identity, 1))
+
+	err = breaker.allow(identity, 2, now.Add(time.Millisecond))
+	require.ErrorIs(t, err, ErrLeaderProxyCircuitOpen)
+	require.False(t, breaker.owns(identity, 2))
+
+	probeAt := now.Add(leaderProxyBreakerBaseBackoff)
+	require.NoError(t, breaker.allow(identity, 2, probeAt))
+	require.True(t, breaker.owns(identity, 2))
+	require.ErrorIs(t, breaker.allow(identity, 3, probeAt), ErrLeaderProxyCircuitOpen)
+
+	breaker.record(identity, 2, nil, probeAt)
+	require.NoError(t, breaker.allow(identity, 3, probeAt))
+}
+
+func TestLeaderProxyCircuitBreakerResetsOnLeaderIdentityChange(t *testing.T) {
+	t.Parallel()
+
+	var breaker leaderProxyCircuitBreaker
+	oldLeader := leaderProxyIdentity{id: "n1", address: "127.0.0.1:50051", term: 7}
+	newLeader := leaderProxyIdentity{id: "n2", address: "127.0.0.1:50052", term: 8}
+	now := time.Unix(100, 0)
+
+	for range leaderProxyBreakerFailureThreshold {
+		require.NoError(t, breaker.allow(oldLeader, 1, now))
+		breaker.record(oldLeader, 1, ErrLeaderNotFound, now)
+	}
+	require.ErrorIs(t, breaker.allow(oldLeader, 2, now), ErrLeaderProxyCircuitOpen)
+	require.True(t, breaker.mayRetryAfterOpen(newLeader, 2))
+	require.NoError(t, breaker.allow(newLeader, 2, now))
+	require.False(t, breaker.owns(oldLeader, 1))
+}
+
+func TestLeaderProxyCircuitBreakerIgnoresLateResultFromOldIdentity(t *testing.T) {
+	t.Parallel()
+
+	var breaker leaderProxyCircuitBreaker
+	oldLeader := leaderProxyIdentity{id: "n1", address: "127.0.0.1:50051", term: 7}
+	newLeader := leaderProxyIdentity{id: "n2", address: "127.0.0.1:50052", term: 8}
+	now := time.Unix(100, 0)
+
+	for range leaderProxyBreakerFailureThreshold - 1 {
+		require.NoError(t, breaker.allow(newLeader, 2, now))
+		breaker.record(newLeader, 2, ErrLeaderNotFound, now)
+	}
+	breaker.record(oldLeader, 1, nil, now)
+	require.NoError(t, breaker.allow(newLeader, 2, now))
+	breaker.record(newLeader, 2, ErrLeaderNotFound, now)
+
+	require.ErrorIs(t, breaker.allow(newLeader, 3, now), ErrLeaderProxyCircuitOpen)
+}
+
+func TestLeaderProxyCircuitBreakerIgnoresLateFailureFromSuppressedRequest(t *testing.T) {
+	t.Parallel()
+
+	var breaker leaderProxyCircuitBreaker
+	identity := leaderProxyIdentity{id: "n1", address: "127.0.0.1:50051", term: 7}
+	now := time.Unix(100, 0)
+
+	for range leaderProxyBreakerFailureThreshold {
+		require.NoError(t, breaker.allow(identity, 1, now))
+		breaker.record(identity, 1, ErrLeaderNotFound, now)
+	}
+	breaker.record(identity, 2, ErrLeaderNotFound, now.Add(time.Millisecond))
+	breaker.record(identity, 2, ErrLeaderNotFound, now.Add(leaderProxyBreakerBaseBackoff))
+
+	require.True(t, breaker.owns(identity, 1))
+	require.NoError(t, breaker.allow(identity, 2, now.Add(leaderProxyBreakerBaseBackoff)))
+	require.True(t, breaker.owns(identity, 2))
+}
+
+func TestLeaderProxyCircuitBreakerReleasesCanceledHalfOpenProbe(t *testing.T) {
+	t.Parallel()
+
+	var breaker leaderProxyCircuitBreaker
+	identity := leaderProxyIdentity{id: "n1", address: "127.0.0.1:50051", term: 7}
+	now := time.Unix(100, 0)
+
+	for range leaderProxyBreakerFailureThreshold {
+		require.NoError(t, breaker.allow(identity, 1, now))
+		breaker.record(identity, 1, ErrLeaderNotFound, now)
+	}
+	probeAt := now.Add(leaderProxyBreakerBaseBackoff)
+	require.NoError(t, breaker.allow(identity, 2, probeAt))
+
+	breaker.release(identity, 2)
+
+	require.False(t, breaker.owns(identity, 2))
+	require.NoError(t, breaker.allow(identity, 3, probeAt))
+	require.True(t, breaker.owns(identity, 3))
+}
+
+func TestLeaderProxyCircuitBreakerAllowsOneConcurrentHalfOpenProbe(t *testing.T) {
+	t.Parallel()
+
+	var breaker leaderProxyCircuitBreaker
+	identity := leaderProxyIdentity{id: "n1", address: "127.0.0.1:50051", term: 7}
+	now := time.Unix(100, 0)
+	for range leaderProxyBreakerFailureThreshold {
+		require.NoError(t, breaker.allow(identity, 1, now))
+		breaker.record(identity, 1, ErrLeaderNotFound, now)
+	}
+
+	const requests = 32
+	start := make(chan struct{})
+	var allowed atomic.Int32
+	var wg sync.WaitGroup
+	for requestID := uint64(2); requestID < requests+2; requestID++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if breaker.allow(identity, requestID, now.Add(leaderProxyBreakerBaseBackoff)) == nil {
+				allowed.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	require.Equal(t, int32(1), allowed.Load())
+}
+
+func TestLeaderProxyBreakerBackoffIsBounded(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		failures int
+		want     time.Duration
+	}{
+		{leaderProxyBreakerFailureThreshold, 100 * time.Millisecond},
+		{leaderProxyBreakerFailureThreshold + 1, 200 * time.Millisecond},
+		{leaderProxyBreakerFailureThreshold + 4, 1600 * time.Millisecond},
+		{leaderProxyBreakerFailureThreshold + 5, leaderProxyBreakerMaxBackoff},
+		{leaderProxyBreakerFailureThreshold + 20, leaderProxyBreakerMaxBackoff},
+	}
+	for _, tt := range tests {
+		require.Equal(t, tt.want, leaderProxyBreakerBackoff(tt.failures))
+	}
+}
+
+func TestLeaderProxyBreakerFailureClassification(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isLeaderProxyBreakerFailure(ErrLeaderNotFound))
+	require.True(t, isLeaderProxyBreakerFailure(status.Error(codes.Unavailable, "connection reset")))
+	require.True(t, isLeaderProxyBreakerFailure(status.Error(codes.DeadlineExceeded, "forward timeout")))
+	require.False(t, isLeaderProxyBreakerFailure(errors.New("write conflict")))
+	require.False(t, isLeaderProxyBreakerFailure(nil))
+}

--- a/kv/leader_proxy_breaker_test.go
+++ b/kv/leader_proxy_breaker_test.go
@@ -35,11 +35,12 @@ func TestLeaderProxyCircuitBreakerOpensAndLimitsHalfOpenProbe(t *testing.T) {
 	require.False(t, breaker.owns(identity, 2))
 
 	probeAt := now.Add(leaderProxyBreakerBaseBackoff)
-	require.NoError(t, breaker.allow(identity, 2, probeAt))
-	require.True(t, breaker.owns(identity, 2))
+	require.ErrorIs(t, breaker.allow(identity, 2, probeAt), ErrLeaderProxyCircuitOpen)
+	require.True(t, breaker.owns(identity, 1))
+	require.NoError(t, breaker.allow(identity, 1, probeAt))
 	require.ErrorIs(t, breaker.allow(identity, 3, probeAt), ErrLeaderProxyCircuitOpen)
 
-	breaker.record(identity, 2, nil, probeAt)
+	breaker.record(identity, 1, nil, probeAt)
 	require.Empty(t, breaker.openUntilText)
 	require.NoError(t, breaker.allow(identity, 3, probeAt))
 }
@@ -97,8 +98,9 @@ func TestLeaderProxyCircuitBreakerIgnoresLateFailureFromSuppressedRequest(t *tes
 	breaker.record(identity, 2, ErrLeaderNotFound, now.Add(leaderProxyBreakerBaseBackoff))
 
 	require.True(t, breaker.owns(identity, 1))
-	require.NoError(t, breaker.allow(identity, 2, now.Add(leaderProxyBreakerBaseBackoff)))
-	require.True(t, breaker.owns(identity, 2))
+	require.ErrorIs(t, breaker.allow(identity, 2, now.Add(leaderProxyBreakerBaseBackoff)), ErrLeaderProxyCircuitOpen)
+	require.True(t, breaker.owns(identity, 1))
+	require.NoError(t, breaker.allow(identity, 1, now.Add(leaderProxyBreakerBaseBackoff)))
 }
 
 func TestLeaderProxyCircuitBreakerReleasesCanceledHalfOpenProbe(t *testing.T) {
@@ -113,11 +115,11 @@ func TestLeaderProxyCircuitBreakerReleasesCanceledHalfOpenProbe(t *testing.T) {
 		breaker.record(identity, 1, ErrLeaderNotFound, now)
 	}
 	probeAt := now.Add(leaderProxyBreakerBaseBackoff)
-	require.NoError(t, breaker.allow(identity, 2, probeAt))
+	require.NoError(t, breaker.allow(identity, 1, probeAt))
 
-	breaker.release(identity, 2)
+	breaker.release(identity, 1)
 
-	require.False(t, breaker.owns(identity, 2))
+	require.False(t, breaker.owns(identity, 1))
 	require.NoError(t, breaker.allow(identity, 3, probeAt))
 	require.True(t, breaker.owns(identity, 3))
 }
@@ -136,21 +138,24 @@ func TestLeaderProxyCircuitBreakerAllowsOneConcurrentHalfOpenProbe(t *testing.T)
 	const requests = 32
 	start := make(chan struct{})
 	var allowed atomic.Int32
+	var allowedOwner atomic.Uint64
 	var wg sync.WaitGroup
-	for requestID := uint64(2); requestID < requests+2; requestID++ {
+	for requestID := uint64(1); requestID <= requests; requestID++ {
 		wg.Add(1)
-		go func() {
+		go func(requestID uint64) {
 			defer wg.Done()
 			<-start
 			if breaker.allow(identity, requestID, now.Add(leaderProxyBreakerBaseBackoff)) == nil {
 				allowed.Add(1)
+				allowedOwner.Store(requestID)
 			}
-		}()
+		}(requestID)
 	}
 	close(start)
 	wg.Wait()
 
 	require.Equal(t, int32(1), allowed.Load())
+	require.Equal(t, uint64(1), allowedOwner.Load())
 }
 
 func TestLeaderProxyBreakerBackoffIsBounded(t *testing.T) {

--- a/kv/leader_proxy_breaker_test.go
+++ b/kv/leader_proxy_breaker_test.go
@@ -23,9 +23,11 @@ func TestLeaderProxyCircuitBreakerOpensAndLimitsHalfOpenProbe(t *testing.T) {
 		require.NoError(t, breaker.allow(identity, 1, now))
 		breaker.record(identity, 1, ErrLeaderNotFound, now)
 	}
+	require.Equal(t, now.Add(leaderProxyBreakerBaseBackoff).UTC().Format(time.RFC3339Nano), breaker.openUntilText)
 
 	err := breaker.allow(identity, 1, now.Add(time.Millisecond))
 	require.ErrorIs(t, err, ErrLeaderProxyCircuitOpen)
+	require.ErrorContains(t, err, breaker.openUntilText)
 	require.True(t, breaker.owns(identity, 1))
 
 	err = breaker.allow(identity, 2, now.Add(time.Millisecond))
@@ -38,6 +40,7 @@ func TestLeaderProxyCircuitBreakerOpensAndLimitsHalfOpenProbe(t *testing.T) {
 	require.ErrorIs(t, breaker.allow(identity, 3, probeAt), ErrLeaderProxyCircuitOpen)
 
 	breaker.record(identity, 2, nil, probeAt)
+	require.Empty(t, breaker.openUntilText)
 	require.NoError(t, breaker.allow(identity, 3, probeAt))
 }
 
@@ -56,6 +59,7 @@ func TestLeaderProxyCircuitBreakerResetsOnLeaderIdentityChange(t *testing.T) {
 	require.ErrorIs(t, breaker.allow(oldLeader, 2, now), ErrLeaderProxyCircuitOpen)
 	require.True(t, breaker.mayRetryAfterOpen(newLeader, 2))
 	require.NoError(t, breaker.allow(newLeader, 2, now))
+	require.Empty(t, breaker.openUntilText)
 	require.False(t, breaker.owns(oldLeader, 1))
 }
 

--- a/kv/leader_proxy_test.go
+++ b/kv/leader_proxy_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/bootjp/elastickv/store"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type fakeInternal struct {
@@ -22,6 +24,8 @@ type fakeInternal struct {
 	calls   int
 	lastReq *pb.ForwardRequest
 	resp    *pb.ForwardResponse
+	err     error
+	failFor int
 }
 
 func (f *fakeInternal) Forward(_ context.Context, req *pb.ForwardRequest) (*pb.ForwardResponse, error) {
@@ -29,10 +33,44 @@ func (f *fakeInternal) Forward(_ context.Context, req *pb.ForwardRequest) (*pb.F
 	defer f.mu.Unlock()
 	f.calls++
 	f.lastReq = req
+	if f.err != nil && (f.failFor == 0 || f.calls <= f.failFor) {
+		return nil, f.err
+	}
 	if f.resp != nil {
 		return f.resp, nil
 	}
 	return &pb.ForwardResponse{Success: true, CommitIndex: 0}, nil
+}
+
+func (f *fakeInternal) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func startLeaderProxyBlackhole(t *testing.T) string {
+	t.Helper()
+	var lc net.ListenConfig
+	lis, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	stop := make(chan struct{})
+	go func() {
+		for {
+			conn, acceptErr := lis.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go func() {
+				<-stop
+				_ = conn.Close()
+			}()
+		}
+	}()
+	t.Cleanup(func() {
+		close(stop)
+		_ = lis.Close()
+	})
+	return lis.Addr().String()
 }
 
 // stubFollowerEngine is a minimal raftengine.Engine stub that reports the
@@ -305,7 +343,7 @@ func TestLeaderProxy_FailsAfterLeaderBudgetElapses(t *testing.T) {
 func TestLeaderProxy_CanceledForwardReleasesHalfOpenProbe(t *testing.T) {
 	t.Parallel()
 
-	eng := &stubFollowerEngine{leaderAddr: "127.0.0.1:1"}
+	eng := &stubFollowerEngine{leaderAddr: startLeaderProxyBlackhole(t)}
 	p := NewLeaderProxyWithEngine(eng)
 	t.Cleanup(func() { _ = p.connCache.Close() })
 
@@ -316,11 +354,83 @@ func TestLeaderProxy_CanceledForwardReleasesHalfOpenProbe(t *testing.T) {
 		p.forwardBreaker.record(identity, 1, ErrLeaderNotFound, openedAt)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	_, err := p.forward(ctx, []*pb.Request{{IsTxn: false}}, 2)
-	require.ErrorContains(t, err, context.Canceled.Error())
+	callerCtx, cancelCaller := context.WithCancel(context.Background())
+	proxyCtx, cancelProxy := context.WithTimeout(callerCtx, time.Second)
+	time.AfterFunc(50*time.Millisecond, cancelCaller)
+	_, err := p.forward(callerCtx, proxyCtx, []*pb.Request{{IsTxn: false}}, 2)
+	cancelProxy()
+	require.ErrorIs(t, err, context.Canceled)
 
 	require.NoError(t, p.forwardBreaker.allow(identity, 3, time.Now()))
 	require.True(t, p.forwardBreaker.owns(identity, 3))
+}
+
+func TestLeaderProxy_ProxyBudgetDeadlineCountsTowardBreaker(t *testing.T) {
+	t.Parallel()
+
+	eng := &stubFollowerEngine{leaderAddr: startLeaderProxyBlackhole(t)}
+	p := NewLeaderProxyWithEngine(eng)
+	t.Cleanup(func() { _ = p.connCache.Close() })
+	identity := leaderProxyIdentityFromEngine(eng)
+	reqs := []*pb.Request{{IsTxn: false}}
+
+	for range leaderProxyBreakerFailureThreshold {
+		proxyCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		_, forwardErr := p.forward(context.Background(), proxyCtx, reqs, 1)
+		cancel()
+		require.Equal(t, codes.DeadlineExceeded, status.Code(forwardErr))
+	}
+
+	require.ErrorIs(t, p.forwardBreaker.allow(identity, 2, time.Now()), ErrLeaderProxyCircuitOpen)
+}
+
+func TestLeaderProxy_CanceledRecoveryOwnerStopsRetrying(t *testing.T) {
+	t.Parallel()
+
+	eng := &stubFollowerEngine{leaderAddr: "127.0.0.1:1"}
+	p := NewLeaderProxyWithEngine(eng)
+	t.Cleanup(func() { _ = p.connCache.Close() })
+	identity := leaderProxyIdentityFromEngine(eng)
+	const requestID = uint64(7)
+	openedAt := time.Now()
+	for range leaderProxyBreakerFailureThreshold {
+		require.NoError(t, p.forwardBreaker.allow(identity, requestID, openedAt))
+		p.forwardBreaker.record(identity, requestID, ErrLeaderNotFound, openedAt)
+	}
+	p.forwardSeq.Store(requestID - 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := p.forwardWithRetry(ctx, []*pb.Request{{IsTxn: false}})
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestLeaderProxy_TransportFailureOwnerPerformsHalfOpenProbe(t *testing.T) {
+	t.Parallel()
+
+	var lc net.ListenConfig
+	lis, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	svc := &fakeInternal{
+		resp:    &pb.ForwardResponse{Success: true, CommitIndex: 77},
+		err:     status.Error(codes.Unavailable, "startup gate closed"),
+		failFor: leaderProxyBreakerFailureThreshold,
+	}
+	srv := grpc.NewServer()
+	pb.RegisterInternalServer(srv, svc)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(func() {
+		srv.Stop()
+		_ = lis.Close()
+	})
+
+	eng := &stubFollowerEngine{leaderAddr: lis.Addr().String()}
+	p := NewLeaderProxyWithEngine(eng)
+	t.Cleanup(func() { _ = p.connCache.Close() })
+
+	resp, err := p.Commit(context.Background(), []*pb.Request{{IsTxn: false}})
+	require.NoError(t, err)
+	require.Equal(t, uint64(77), resp.CommitIndex)
+	require.Equal(t, leaderProxyBreakerFailureThreshold+1, svc.callCount())
 }

--- a/kv/leader_proxy_test.go
+++ b/kv/leader_proxy_test.go
@@ -357,7 +357,7 @@ func TestLeaderProxy_CanceledForwardReleasesHalfOpenProbe(t *testing.T) {
 	callerCtx, cancelCaller := context.WithCancel(context.Background())
 	proxyCtx, cancelProxy := context.WithTimeout(callerCtx, time.Second)
 	time.AfterFunc(50*time.Millisecond, cancelCaller)
-	_, err := p.forward(callerCtx, proxyCtx, []*pb.Request{{IsTxn: false}}, 2)
+	_, err := p.forward(callerCtx, proxyCtx, []*pb.Request{{IsTxn: false}}, 1)
 	cancelProxy()
 	require.ErrorIs(t, err, context.Canceled)
 
@@ -404,6 +404,7 @@ func TestLeaderProxy_CanceledRecoveryOwnerStopsRetrying(t *testing.T) {
 	_, err := p.forwardWithRetry(ctx, []*pb.Request{{IsTxn: false}})
 
 	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, p.forwardBreaker.owns(identity, requestID))
 }
 
 func TestLeaderProxy_TransportFailureOwnerPerformsHalfOpenProbe(t *testing.T) {

--- a/kv/leader_proxy_test.go
+++ b/kv/leader_proxy_test.go
@@ -301,3 +301,26 @@ func TestLeaderProxy_FailsAfterLeaderBudgetElapses(t *testing.T) {
 	require.ErrorIs(t, err, ErrLeaderNotFound)
 	require.GreaterOrEqual(t, elapsed, leaderProxyRetryBudget)
 }
+
+func TestLeaderProxy_CanceledForwardReleasesHalfOpenProbe(t *testing.T) {
+	t.Parallel()
+
+	eng := &stubFollowerEngine{leaderAddr: "127.0.0.1:1"}
+	p := NewLeaderProxyWithEngine(eng)
+	t.Cleanup(func() { _ = p.connCache.Close() })
+
+	identity := leaderProxyIdentityFromEngine(eng)
+	openedAt := time.Now().Add(-2 * leaderProxyBreakerBaseBackoff)
+	for range leaderProxyBreakerFailureThreshold {
+		require.NoError(t, p.forwardBreaker.allow(identity, 1, openedAt))
+		p.forwardBreaker.record(identity, 1, ErrLeaderNotFound, openedAt)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := p.forward(ctx, []*pb.Request{{IsTxn: false}}, 2)
+	require.ErrorContains(t, err, context.Canceled.Error())
+
+	require.NoError(t, p.forwardBreaker.allow(identity, 3, time.Now()))
+	require.True(t, p.forwardBreaker.owns(identity, 3))
+}

--- a/main_admin.go
+++ b/main_admin.go
@@ -154,7 +154,7 @@ func prepareAdminFromFlags(
 // design returned true on any local-group leadership; in a multi-group
 // deployment that could surface 200 on a node leading only a non-
 // default group while admin writes there still 503'd or forwarded.
-// Codex P1 on PR #689 caught this; using the coordinator keeps the
+// P1 review on PR #689 caught this; using the coordinator keeps the
 // healthz contract aligned with the actual admin-write leader.
 //
 // Returns nil when no coordinator is wired so the router answers
@@ -849,7 +849,7 @@ func translateAdminItemsError(err error) error {
 		// adapter's isVerifiedDynamoLeader check and the actual
 		// Raft propose). Map to the Items not-leader sentinel so the
 		// handler returns 503 + Retry-After: 1 and the SPA's retry
-		// contract stays intact (Codex P2 on PR #813 — the table-side
+		// contract stays intact (P2 review on PR #813 — the table-side
 		// translator already does this; the item-side translator
 		// initially shipped without the parallel branch).
 		return admin.ErrItemsNotLeader
@@ -939,7 +939,7 @@ func translateAdminTablesError(err error) error {
 		// dispatch — the kv coordinator can drop leadership in
 		// that window and the resulting transient error should
 		// surface as 503 leader_unavailable + Retry-After: 1
-		// rather than a generic 500. Codex P2 on PR #634.
+		// rather than a generic 500. P2 review on PR #634.
 		return admin.ErrTablesNotLeader
 	default:
 		return err //nolint:wrapcheck // forwarded so the handler logs but does not surface it.
@@ -948,9 +948,10 @@ func translateAdminTablesError(err error) error {
 
 // isLeaderChurnError reports whether err looks like one of the
 // transient leader sentinels the kv coordinator and adapter
-// internals emit during a leadership change. The set mirrors the
-// closed list in kv.leaderErrorPhrases — keep them in sync if a
-// new sentinel is added on the kv side.
+// internals emit during a leadership change. The suffix set mirrors the
+// closed list in kv.leaderErrorPhrases and also includes availability
+// sentinels that intentionally bypass coordinator retry, such as the
+// leader-proxy circuit.
 //
 // Phrase matching uses HasSuffix (not Contains) on the standard
 // canonical strings because every kv-internal sentinel emits the
@@ -958,7 +959,7 @@ func translateAdminTablesError(err error) error {
 // "raft engine: not leader", "dispatch failed: leader not found").
 // A user-supplied string that happens to contain a leader phrase
 // in the MIDDLE of an unrelated error message therefore does not
-// false-positive — Codex P2 on PR #634 flagged the original
+// false-positive — P2 review on PR #634 flagged the original
 // strings.Contains form for misclassifying validation messages
 // like "conflicting attribute type for <user-name>" when the
 // name itself was "not leader".
@@ -967,6 +968,7 @@ func isLeaderChurnError(err error) bool {
 		return false
 	}
 	if errors.Is(err, kv.ErrLeaderNotFound) ||
+		errors.Is(err, kv.ErrLeaderProxyCircuitOpen) ||
 		errors.Is(err, adapter.ErrNotLeader) ||
 		errors.Is(err, adapter.ErrLeaderNotFound) {
 		return true
@@ -975,7 +977,8 @@ func isLeaderChurnError(err error) bool {
 	return strings.HasSuffix(msg, "not leader") ||
 		strings.HasSuffix(msg, "leader not found") ||
 		strings.HasSuffix(msg, "leadership lost") ||
-		strings.HasSuffix(msg, "leadership transfer in progress")
+		strings.HasSuffix(msg, "leadership transfer in progress") ||
+		strings.HasSuffix(msg, "leader proxy circuit open")
 }
 
 func convertAdminTableSummary(in *adapter.AdminTableSummary) *admin.DynamoTableSummary {
@@ -1212,7 +1215,7 @@ func newClusterInfoSource(nodeID, version string, runtimes []*raftGroupRuntime) 
 			// HTTP/gRPC handler running on its own goroutine
 			// cannot race rt.Close() clearing the field on
 			// shutdown. Same race class as the keyviz
-			// leader-term publisher (Codex P2 on PR #720).
+			// leader-term publisher (P2 review on PR #720).
 			engine := rt.snapshotEngine()
 			if engine == nil {
 				continue

--- a/main_admin_test.go
+++ b/main_admin_test.go
@@ -370,13 +370,14 @@ func writeSelfSignedCert(t *testing.T) (string, string) {
 // bridge maps transient leader-churn errors from the kv coordinator
 // (which AdminCreateTable/AdminDeleteTable can return after their
 // initial isVerifiedDynamoLeader check) to admin.ErrTablesNotLeader
-// rather than the generic 500 fallthrough. Codex P2 on PR #634.
+// rather than the generic 500 fallthrough. P2 review on PR #634.
 func TestTranslateAdminTablesError_LeaderChurn(t *testing.T) {
 	cases := []struct {
 		name string
 		in   error
 	}{
 		{"kv.ErrLeaderNotFound", kv.ErrLeaderNotFound},
+		{"kv.ErrLeaderProxyCircuitOpen", kv.ErrLeaderProxyCircuitOpen},
 		{"adapter.ErrNotLeader", adapter.ErrNotLeader},
 		{"adapter.ErrLeaderNotFound", adapter.ErrLeaderNotFound},
 		{"wrapped not leader", errors.New("dispatch failed: not leader")},
@@ -394,7 +395,7 @@ func TestTranslateAdminTablesError_LeaderChurn(t *testing.T) {
 }
 
 // TestTranslateAdminTablesError_LeaderPhraseInMiddleOfMessage covers
-// the false-positive class Codex P2 flagged: a message that
+// the false-positive class P2 review flagged: a message that
 // happens to contain a leader phrase NOT at the suffix must NOT
 // be classified as leader-churn. Switching from strings.Contains
 // to strings.HasSuffix is what makes this test pass.
@@ -428,8 +429,8 @@ func TestTranslateAdminTablesError_UnrelatedErrorPassesThrough(t *testing.T) {
 }
 
 // TestTranslateAdminItemsError_LeaderChurn is the items-tier
-// counterpart of TestTranslateAdminTablesError_LeaderChurn — Codex
-// P2 on PR #813 flagged that translateAdminItemsError did not
+// counterpart of TestTranslateAdminTablesError_LeaderChurn — P2
+// review on PR #813 flagged that translateAdminItemsError did not
 // classify transient leader-churn errors as 503/retryable, so an
 // election mid-AdminPutItem / AdminGetItem would 500 instead of
 // surfacing through the SPA's retry path.
@@ -439,6 +440,7 @@ func TestTranslateAdminItemsError_LeaderChurn(t *testing.T) {
 		in   error
 	}{
 		{"kv.ErrLeaderNotFound", kv.ErrLeaderNotFound},
+		{"kv.ErrLeaderProxyCircuitOpen", kv.ErrLeaderProxyCircuitOpen},
 		{"adapter.ErrNotLeader", adapter.ErrNotLeader},
 		{"adapter.ErrLeaderNotFound", adapter.ErrLeaderNotFound},
 		{"wrapped not leader", errors.New("dispatch failed: not leader")},
@@ -496,6 +498,7 @@ func TestTranslateAdminQueuesError_LeaderChurn(t *testing.T) {
 		in   error
 	}{
 		{"kv.ErrLeaderNotFound", kv.ErrLeaderNotFound},
+		{"kv.ErrLeaderProxyCircuitOpen", kv.ErrLeaderProxyCircuitOpen},
 		{"adapter.ErrNotLeader", adapter.ErrNotLeader},
 		{"adapter.ErrLeaderNotFound", adapter.ErrLeaderNotFound},
 		{"wrapped not leader", errors.New("dispatch failed: not leader")},


### PR DESCRIPTION
Author: bootjp

## Summary
- add a per-Raft-group circuit breaker keyed by leader ID, address, and term
- allow one half-open probe while concurrent requests fail fast through protocol-specific availability responses
- preserve transaction semantics by excluding circuit-open errors from coordinator redispatch
- stop resetting gRPC reconnect backoff on every transient failure

## Safety and risk
- no Raft, protobuf, or persisted-data format changes
- caller cancellation does not count as leader failure and releases half-open ownership
- late results from old leader identities cannot overwrite current breaker state
- Redis returns NOTLEADER; DynamoDB, SQS, S3, and Admin return their existing 503 surfaces

## Verification
- `go test ./... -timeout=20m`
- focused `go test -race` for leader proxy, connection cache, and retry classification
- `golangci-lint run ./... --timeout=10m`
- `git diff --check`