### PR TITLE
Avoid full scans for Lua stream appends

### DIFF
--- a/adapter/redis_lua_context.go
+++ b/adapter/redis_lua_context.go
@@ -34,6 +34,7 @@ type luaScriptContext struct {
 	redisCallCount    int
 
 	touched     map[string]struct{}
+	readKeys    map[string][]byte
 	deleted     map[string]bool
 	everDeleted map[string]bool
 	// negativeType caches keys for which server.keyTypeAt() has already
@@ -123,10 +124,16 @@ type luaZSetState struct {
 }
 
 type luaStreamState struct {
-	loaded bool
-	exists bool
-	dirty  bool
-	value  redisStreamValue
+	loaded              bool
+	exists              bool
+	dirty               bool
+	materialized        bool
+	requiresFullRewrite bool
+	baseMeta            store.StreamMeta
+	meta                store.StreamMeta
+	baseTrim            int64
+	appended            []redisStreamEntry
+	value               redisStreamValue
 }
 
 type luaTTLState struct {
@@ -166,7 +173,9 @@ const (
 
 	zsetWithScoresArgIndex = 3
 	xAddMinArgs            = 3
-	xTrimMinArgs           = 4
+	xTrimMinArgs           = 3
+	luaXRangeBaseArgs      = 3
+	luaXRangeCountArgs     = 5
 
 	// Element counts for ZSet commit slice pre-allocation.
 	zsetElemsPerMember  = 2 // PUT member key + PUT score index key
@@ -182,6 +191,8 @@ type luaPhysicalLimitedScanStore interface {
 	ScanAtPhysicalLimit(ctx context.Context, start []byte, end []byte, visibleLimit, physicalLimit int, ts uint64) ([]*store.KVPair, bool, error)
 	ReverseScanAtPhysicalLimit(ctx context.Context, start []byte, end []byte, visibleLimit, physicalLimit int, ts uint64) ([]*store.KVPair, bool, error)
 }
+
+var errLuaStreamDeltaNeedsFullRewrite = errors.New("lua stream delta requires full rewrite")
 
 type luaCommandHandler func(*luaScriptContext, []string) (luaReply, error)
 type luaRenameHandler func(*luaScriptContext, []byte, []byte) error
@@ -235,6 +246,9 @@ var luaCommandHandlers = map[string]luaCommandHandler{
 	cmdZRemRangeByRank:  (*luaScriptContext).cmdZRemRangeByRank,
 	cmdZRemRangeByScore: (*luaScriptContext).cmdZRemRangeByScore,
 	cmdXAdd:             (*luaScriptContext).cmdXAdd,
+	cmdXLen:             (*luaScriptContext).cmdXLen,
+	cmdXRange:           (*luaScriptContext).cmdXRange,
+	cmdXRevRange:        (*luaScriptContext).cmdXRevRange,
 	cmdXTrim:            (*luaScriptContext).cmdXTrim,
 	cmdSetEx:            (*luaScriptContext).cmdSetEx,
 	cmdGetDel:           (*luaScriptContext).cmdGetDel,
@@ -266,6 +280,7 @@ func newLuaScriptContext(ctx context.Context, server *RedisServer) (*luaScriptCo
 		readPin:      server.pinReadTS(startTS),
 		ctx:          ctx,
 		touched:      map[string]struct{}{},
+		readKeys:     map[string][]byte{},
 		deleted:      map[string]bool{},
 		everDeleted:  map[string]bool{},
 		negativeType: map[string]bool{},
@@ -302,6 +317,46 @@ func (c *luaScriptContext) exec(command string, args []string) (luaReply, error)
 
 func (c *luaScriptContext) markTouched(key []byte) {
 	c.touched[string(key)] = struct{}{}
+}
+
+func (c *luaScriptContext) trackReadKey(key []byte) {
+	if len(key) == 0 {
+		return
+	}
+	if c.readKeys == nil {
+		c.readKeys = map[string][]byte{}
+	}
+	k := string(key)
+	if _, ok := c.readKeys[k]; ok {
+		return
+	}
+	c.readKeys[k] = append([]byte(nil), key...)
+}
+
+func (c *luaScriptContext) trackStreamTypeReadKeys(key []byte, exists bool) {
+	// Every stream mutation rewrites StreamMetaKey, so that key alone fences
+	// an existing stream. For an absent key, fence every physical type anchor
+	// that does not itself participate in the stream write plus the wide-type
+	// creation fences, preventing concurrent cross-type creation.
+	c.trackReadKey(store.StreamMetaKey(key))
+	if exists {
+		return
+	}
+	for _, readKey := range redisTxnWideCollectionFenceKeys(key) {
+		c.trackReadKey(readKey)
+	}
+	for _, readKey := range [][]byte{
+		redisStrKey(key),
+		redisHLLKey(key),
+		key,
+		store.ListMetaKey(key),
+		redisHashKey(key),
+		redisSetKey(key),
+		redisZSetKey(key),
+		redisStreamKey(key),
+	} {
+		c.trackReadKey(readKey)
+	}
 }
 
 func (c *luaScriptContext) ttlState(key []byte) *luaTTLState {
@@ -395,6 +450,12 @@ func (c *luaScriptContext) deleteLogical(key []byte) {
 		st.loaded = true
 		st.exists = false
 		st.dirty = true
+		st.materialized = true
+		st.requiresFullRewrite = true
+		st.baseMeta = store.StreamMeta{}
+		st.meta = store.StreamMeta{}
+		st.baseTrim = 0
+		st.appended = nil
 		st.value = redisStreamValue{}
 	}
 }
@@ -937,6 +998,24 @@ func (c *luaScriptContext) zsetStateForRead(key []byte) (*luaZSetState, bool, er
 	return st, true, nil
 }
 
+func (c *luaScriptContext) streamType(key []byte) (redisValueType, error) {
+	if typ, ok := c.cachedType(key); ok {
+		if typ != redisTypeNone {
+			return typ, c.ensureKeyNotExpired(key)
+		}
+		return typ, nil
+	}
+	c.keyTypeProbeCount++
+	typ, err := c.server.keyTypeAtExpect(c.scriptCtx(), key, c.startTS, redisTypeStream)
+	if err != nil {
+		return redisTypeNone, err
+	}
+	if typ == redisTypeNone && len(c.negativeType) < maxNegativeTypeCacheEntries {
+		c.negativeType[string(key)] = true
+	}
+	return typ, nil
+}
+
 func (c *luaScriptContext) streamState(key []byte) (*luaStreamState, error) {
 	k := string(key)
 	if st, ok := c.streams[k]; ok {
@@ -945,9 +1024,10 @@ func (c *luaScriptContext) streamState(key []byte) (*luaStreamState, error) {
 	st := &luaStreamState{}
 	c.streams[k] = st
 
-	typ, err := c.keyType(key)
+	typ, err := c.streamType(key)
 	if errors.Is(err, store.ErrKeyNotFound) {
 		st.loaded = true
+		c.trackStreamTypeReadKeys(key, false)
 		return st, nil
 	}
 	if err != nil {
@@ -955,20 +1035,64 @@ func (c *luaScriptContext) streamState(key []byte) (*luaStreamState, error) {
 	}
 	if typ == redisTypeNone {
 		st.loaded = true
+		rawType, rawErr := c.server.rawKeyTypeAt(c.scriptCtx(), key, c.startTS)
+		if rawErr != nil {
+			return nil, rawErr
+		}
+		// A TTL-expired value is logically absent, but its physical rows must
+		// be removed before a stream is recreated. The full path performs that
+		// cleanup; a delta create is safe only for a physically absent key.
+		st.requiresFullRewrite = rawType != redisTypeNone
+		c.trackStreamTypeReadKeys(key, false)
 		return st, nil
 	}
 	if typ != redisTypeStream {
 		return nil, wrongTypeError()
 	}
 
-	value, err := c.server.loadStreamAt(context.Background(), key, c.startTS)
+	meta, found, err := c.server.loadStreamMetaAt(c.scriptCtx(), key, c.startTS)
 	if err != nil {
 		return nil, err
 	}
 	st.loaded = true
 	st.exists = true
-	st.value = cloneStreamValue(value)
+	c.trackStreamTypeReadKeys(key, true)
+	if !found {
+		// Legacy stream blobs are intentionally discarded by the current read
+		// contract. Rewriting this key must still delete the legacy blob, so it
+		// cannot use the preserve-existing delta path.
+		st.materialized = true
+		st.requiresFullRewrite = true
+		return st, nil
+	}
+	st.baseMeta = meta
+	st.meta = meta
 	return st, nil
+}
+
+// materializeStream reconstructs the script-visible stream only for commands
+// that require arbitrary entry access. XADD, XLEN, and head trims stay lazy.
+func (c *luaScriptContext) materializeStream(key []byte, st *luaStreamState) error {
+	if st.materialized {
+		return nil
+	}
+	entries := []redisStreamEntry{}
+	if st.exists && (st.baseMeta.Length > 0 || st.baseMeta.LastMs != 0 || st.baseMeta.LastSeq != 0) {
+		value, err := c.server.loadStreamAt(c.scriptCtx(), key, c.startTS)
+		if err != nil {
+			return err
+		}
+		entries = value.Entries
+	}
+	trim := min(st.baseTrim, int64(len(entries)))
+	entries = entries[trim:]
+	entries = append(entries, st.appended...)
+	st.value = cloneStreamValue(redisStreamValue{Entries: entries})
+	st.meta.Length = int64(len(entries))
+	st.materialized = true
+	st.baseTrim = 0
+	st.appended = nil
+	return nil
 }
 
 func (c *luaScriptContext) markStringValue(key []byte, value []byte) {
@@ -1055,7 +1179,7 @@ func (c *luaScriptContext) markZSetValue(key []byte, members map[string]float64)
 	return nil
 }
 
-func (c *luaScriptContext) markStreamValue(key []byte, value redisStreamValue) error {
+func (c *luaScriptContext) markStreamValue(key []byte, value redisStreamValue, meta store.StreamMeta) error {
 	st, err := c.streamState(key)
 	if err != nil {
 		return err
@@ -1063,6 +1187,13 @@ func (c *luaScriptContext) markStreamValue(key []byte, value redisStreamValue) e
 	st.loaded = true
 	st.exists = true
 	st.dirty = true
+	st.materialized = true
+	st.requiresFullRewrite = true
+	st.baseMeta = store.StreamMeta{}
+	st.meta = meta
+	st.meta.Length = int64(len(value.Entries))
+	st.baseTrim = 0
+	st.appended = nil
 	st.value = cloneStreamValue(value)
 	c.markTouched(key)
 	c.deleted[string(key)] = false
@@ -1434,8 +1565,11 @@ func (c *luaScriptContext) renameStreamValue(src, dst []byte) error {
 	if err != nil {
 		return err
 	}
+	if err := c.materializeStream(src, st); err != nil {
+		return err
+	}
 	c.deleteLogical(dst)
-	return c.markStreamValue(dst, st.value)
+	return c.markStreamValue(dst, st.value, st.meta)
 }
 
 func (c *luaScriptContext) cmdHGet(args []string) (luaReply, error) {
@@ -3155,21 +3289,32 @@ func (c *luaScriptContext) cmdXAdd(args []string) (luaReply, error) {
 	if err != nil {
 		return luaReply{}, err
 	}
-	if !st.exists {
-		st.exists = true
+	if err := xaddEnforceMaxWideColumn(parsed.key, st.meta.Length, parsed.maxLen); err != nil {
+		return luaReply{}, err
 	}
-
-	id := parsed.id
-	if id == "*" {
-		id = nextLuaStreamID(st.value)
-	} else if !isNextStreamID(st.value, id) {
-		return luaReply{}, errors.New("ERR The ID specified in XADD is equal or smaller than the target stream top item")
+	if st.meta.Length == math.MaxInt64 {
+		return luaReply{}, errors.Wrapf(ErrCollectionTooLarge,
+			"stream %q length cannot be incremented", parsed.key)
 	}
-	st.value.Entries = append(st.value.Entries, newRedisStreamEntry(id, append([]string(nil), parsed.fields...)))
+	hadStream := st.exists
+	id, parsedID, err := resolveXAddID(st.meta, hadStream, parsed.id)
+	if err != nil {
+		return luaReply{}, err
+	}
+	entry := newRedisStreamEntry(id, append([]string(nil), parsed.fields...))
+	st.exists = true
 	st.loaded = true
 	st.dirty = true
-	if parsed.maxLen >= 0 && len(st.value.Entries) > parsed.maxLen {
-		st.value.Entries = append([]redisStreamEntry(nil), st.value.Entries[len(st.value.Entries)-parsed.maxLen:]...)
+	st.meta.Length++
+	st.meta.LastMs = parsedID.ms
+	st.meta.LastSeq = parsedID.seq
+	if st.materialized {
+		st.value.Entries = append(st.value.Entries, entry)
+	} else {
+		st.appended = append(st.appended, entry)
+	}
+	if parsed.maxLen >= 0 && st.meta.Length > int64(parsed.maxLen) {
+		trimLuaStreamHead(st, st.meta.Length-int64(parsed.maxLen))
 	}
 	c.markTouched(parsed.key)
 	c.deleted[string(parsed.key)] = false
@@ -3193,7 +3338,7 @@ func parseLuaXAddArgs(args []string) (luaXAddArgs, error) {
 
 	parsed.id = args[argIndex]
 	argIndex++
-	if (len(args)-argIndex)%2 != 0 {
+	if argIndex >= len(args) || (len(args)-argIndex)%2 != 0 {
 		return luaXAddArgs{}, errors.New("ERR wrong number of arguments for 'XADD' command")
 	}
 	parsed.fields = append([]string(nil), args[argIndex:]...)
@@ -3216,17 +3361,111 @@ func parseLuaXAddMaxLen(args []string) (int, int, error) {
 	}
 
 	maxLen, err := strconv.Atoi(args[argIndex])
-	if err != nil {
-		return 0, 0, errors.WithStack(err)
+	if err != nil || maxLen < 0 {
+		return 0, 0, errors.New("ERR syntax error")
 	}
 	return argIndex + 1, maxLen, nil
 }
 
-func isNextStreamID(value redisStreamValue, id string) bool {
-	if len(value.Entries) == 0 {
-		return true
+func trimLuaStreamHead(st *luaStreamState, requested int64) int64 {
+	if requested <= 0 || st.meta.Length <= 0 {
+		return 0
 	}
-	return compareRedisStreamID(id, value.Entries[len(value.Entries)-1].ID) > 0
+	requested = min(requested, st.meta.Length)
+	if st.materialized {
+		actual := min(requested, int64(len(st.value.Entries)))
+		st.value.Entries = append([]redisStreamEntry(nil), st.value.Entries[actual:]...)
+		st.meta.Length = int64(len(st.value.Entries))
+		return actual
+	}
+
+	baseRemaining := max(st.baseMeta.Length-st.baseTrim, 0)
+	fromBase := min(requested, min(baseRemaining, int64(maxWideColumnItems)))
+	st.baseTrim += fromBase
+	fromPending := int64(0)
+	if fromBase == baseRemaining {
+		fromPending = min(requested-fromBase, int64(len(st.appended)))
+	}
+	st.appended = append([]redisStreamEntry(nil), st.appended[fromPending:]...)
+	actual := fromBase + fromPending
+	st.meta.Length -= actual
+	return actual
+}
+
+func (c *luaScriptContext) cmdXLen(args []string) (luaReply, error) {
+	if len(args) != 1 {
+		return luaReply{}, errors.New("ERR wrong number of arguments for 'XLEN' command")
+	}
+	st, err := c.streamState([]byte(args[0]))
+	if err != nil {
+		return luaReply{}, err
+	}
+	if !st.exists {
+		return luaIntReply(0), nil
+	}
+	return luaIntReply(st.meta.Length), nil
+}
+
+func (c *luaScriptContext) cmdXRange(args []string) (luaReply, error) {
+	return c.cmdXRangeDirection(args, false)
+}
+
+func (c *luaScriptContext) cmdXRevRange(args []string) (luaReply, error) {
+	return c.cmdXRangeDirection(args, true)
+}
+
+func (c *luaScriptContext) cmdXRangeDirection(args []string, reverse bool) (luaReply, error) {
+	count, err := parseLuaXRangeCount(args)
+	if err != nil {
+		return luaReply{}, err
+	}
+	if count == 0 {
+		return luaArrayReply(), nil
+	}
+
+	key := []byte(args[0])
+	st, err := c.streamState(key)
+	if err != nil {
+		return luaReply{}, err
+	}
+	if !st.exists {
+		return luaArrayReply(), nil
+	}
+	if err := c.materializeStream(key, st); err != nil {
+		return luaReply{}, err
+	}
+	selected := selectStreamRangeEntries(st.value.Entries, args[1], args[2], reverse, count)
+	return luaStreamEntriesReply(selected), nil
+}
+
+func parseLuaXRangeCount(args []string) (int, error) {
+	switch len(args) {
+	case luaXRangeBaseArgs:
+		return -1, nil
+	case luaXRangeCountArgs:
+		if !strings.EqualFold(args[3], redisKeywordCount) {
+			return 0, errors.New("ERR syntax error")
+		}
+		count, err := strconv.Atoi(args[4])
+		if err != nil || count < 0 {
+			return 0, errors.New("ERR syntax error")
+		}
+		return min(count, maxWideColumnItems), nil
+	default:
+		return 0, errors.New("ERR wrong number of arguments for stream range command")
+	}
+}
+
+func luaStreamEntriesReply(entries []redisStreamEntry) luaReply {
+	out := make([]luaReply, 0, len(entries))
+	for _, entry := range entries {
+		fields := make([]luaReply, 0, len(entry.Fields))
+		for _, field := range entry.Fields {
+			fields = append(fields, luaStringReply(field))
+		}
+		out = append(out, luaArrayReply(luaStringReply(entry.ID), luaArrayReply(fields...)))
+	}
+	return luaArrayReply(out...)
 }
 
 func (c *luaScriptContext) cmdXTrim(args []string) (luaReply, error) {
@@ -3247,33 +3486,42 @@ func (c *luaScriptContext) cmdXTrim(args []string) (luaReply, error) {
 	if !st.exists {
 		return luaIntReply(0), nil
 	}
-	if maxLen >= len(st.value.Entries) {
+	if int64(maxLen) >= st.meta.Length {
 		return luaIntReply(0), nil
 	}
-	removed := len(st.value.Entries) - maxLen
-	if maxLen <= 0 {
+	removed := st.meta.Length - int64(maxLen)
+	if maxLen == 0 {
 		st.value.Entries = nil
 		st.exists = false
 		c.deleted[string(key)] = true
+		c.everDeleted[string(key)] = true
 		c.clearTTL(key)
+		st.materialized = true
+		st.requiresFullRewrite = true
+		st.baseMeta = store.StreamMeta{}
+		st.meta = store.StreamMeta{}
+		st.baseTrim = 0
+		st.appended = nil
 	} else {
-		st.value.Entries = append([]redisStreamEntry(nil), st.value.Entries[removed:]...)
+		removed = trimLuaStreamHead(st, removed)
 	}
 	st.loaded = true
 	st.dirty = true
 	c.markTouched(key)
-	return luaIntReply(int64(removed)), nil
+	return luaIntReply(removed), nil
 }
 
 func parseLuaXTrimArgs(args []string) ([]byte, int, error) {
 	argIndex := 2
-	if args[argIndex] == "~" || args[argIndex] == "=" {
+	if argIndex < len(args) && (args[argIndex] == "~" || args[argIndex] == "=") {
 		argIndex++
 	}
-
+	if argIndex != len(args)-1 {
+		return nil, 0, errors.New("ERR syntax error")
+	}
 	maxLen, err := strconv.Atoi(args[argIndex])
-	if err != nil {
-		return nil, 0, errors.WithStack(err)
+	if err != nil || maxLen < 0 {
+		return nil, 0, errors.New("ERR syntax error")
 	}
 	return []byte(args[0]), maxLen, nil
 }
@@ -3310,14 +3558,14 @@ func (c *luaScriptContext) commit() error {
 	}
 
 	elems := make([]*kv.Elem[kv.OP], 0, len(keys)*redisPairWidth)
-	readKeys := make([][]byte, 0, len(keys))
+	readKeys, readKeySet := c.sortedTrackedReadKeys(len(keys))
 	for _, key := range keys {
 		plan, err := c.commitPlanForKey(ctx, key, commitTS)
 		if err != nil {
 			return err
 		}
 		elems = append(elems, plan.elems...)
-		readKeys = append(readKeys, plan.readKeys...)
+		readKeys = appendUniqueLuaReadKeys(readKeys, readKeySet, plan.readKeys...)
 		// For collection keys with dirty TTL: update the inline metadata
 		// anchor and keep !redis|ttl| as the secondary scan index.
 		if isNonStringCollectionType(plan.finalType) {
@@ -3344,6 +3592,35 @@ func (c *luaScriptContext) commit() error {
 		return errors.WithStack(err)
 	}
 	return nil
+}
+
+func (c *luaScriptContext) sortedTrackedReadKeys(extraCapacity int) ([][]byte, map[string]struct{}) {
+	readKeys := make([][]byte, 0, extraCapacity+len(c.readKeys))
+	readKeySet := make(map[string]struct{}, extraCapacity+len(c.readKeys))
+	tracked := make([]string, 0, len(c.readKeys))
+	for key := range c.readKeys {
+		tracked = append(tracked, key)
+	}
+	sort.Strings(tracked)
+	for _, key := range tracked {
+		readKeys = appendUniqueLuaReadKeys(readKeys, readKeySet, c.readKeys[key])
+	}
+	return readKeys, readKeySet
+}
+
+func appendUniqueLuaReadKeys(dst [][]byte, seen map[string]struct{}, keys ...[]byte) [][]byte {
+	for _, key := range keys {
+		if len(key) == 0 {
+			continue
+		}
+		k := string(key)
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+		dst = append(dst, append([]byte(nil), key...))
+	}
+	return dst
 }
 
 func luaCommitFloor(startTS uint64) uint64 {
@@ -3458,8 +3735,7 @@ func (c *luaScriptContext) valueCommitPlan(ctx context.Context, key string, fina
 	case redisTypeZSet:
 		return c.zsetCommitPlan(ctx, key, commitTS)
 	case redisTypeStream:
-		elems, err := c.streamCommitElems(ctx, key)
-		return luaCommitPlan{elems: elems}, err
+		return c.streamCommitPlan(ctx, key)
 	default:
 		return luaCommitPlan{}, errors.New("ERR unsupported final redis type")
 	}
@@ -3915,6 +4191,26 @@ func luaZSetMetaRewritten(elems []*kv.Elem[kv.OP], key []byte) bool {
 	return false
 }
 
+func (c *luaScriptContext) streamCommitPlan(ctx context.Context, key string) (luaCommitPlan, error) {
+	st := c.streams[key]
+	if st == nil || !st.dirty {
+		return luaCommitPlan{preserveExisting: true}, nil
+	}
+	if st.materialized || st.requiresFullRewrite || c.everDeleted[key] {
+		elems, err := c.streamCommitElems(ctx, key)
+		return luaCommitPlan{elems: elems, inlineMetaRewritten: true}, err
+	}
+	elems, err := c.streamDeltaCommitElems(ctx, key, st)
+	if errors.Is(err, errLuaStreamDeltaNeedsFullRewrite) {
+		if materializeErr := c.materializeStream([]byte(key), st); materializeErr != nil {
+			return luaCommitPlan{}, materializeErr
+		}
+		elems, err = c.streamCommitElems(ctx, key)
+		return luaCommitPlan{elems: elems, inlineMetaRewritten: true}, err
+	}
+	return luaCommitPlan{preserveExisting: true, inlineMetaRewritten: true, elems: elems}, err
+}
+
 // streamCommitElems writes the script's final stream state in the
 // wide-column layout — one StreamEntryKey Put per entry plus a StreamMetaKey
 // Put for the aggregate meta. The legacy single-blob path is no longer
@@ -3931,13 +4227,86 @@ func (c *luaScriptContext) streamCommitElems(ctx context.Context, key string) ([
 		return nil, err
 	}
 	keyBytes := []byte(key)
+	if err := c.materializeStream(keyBytes, st); err != nil {
+		return nil, err
+	}
 	ttl, err := c.finalTTL(ctx, keyBytes)
 	if err != nil {
 		return nil, err
 	}
-	elems := make([]*kv.Elem[kv.OP], 0, len(st.value.Entries)+1)
-	var meta store.StreamMeta
-	for _, entry := range st.value.Entries {
+	elems, meta, err := marshalLuaStreamEntries(keyBytes, st.value.Entries, st.meta)
+	if err != nil {
+		return nil, err
+	}
+	meta.ExpireAt = ttlMillis(ttl)
+	metaBytes, err := store.MarshalStreamMeta(meta)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	elems = append(elems, &kv.Elem[kv.OP]{
+		Op:    kv.Put,
+		Key:   store.StreamMetaKey(keyBytes),
+		Value: metaBytes,
+	})
+	return elems, nil
+}
+
+func marshalLuaStreamEntries(
+	key []byte,
+	entries []redisStreamEntry,
+	meta store.StreamMeta,
+) ([]*kv.Elem[kv.OP], store.StreamMeta, error) {
+	elems := make([]*kv.Elem[kv.OP], 0, len(entries)+1)
+	for _, entry := range entries {
+		parsed, err := parseRedisStreamID(entry.ID)
+		if err != nil {
+			return nil, store.StreamMeta{}, errors.WithStack(err)
+		}
+		entryValue, err := marshalStreamEntry(entry)
+		if err != nil {
+			return nil, store.StreamMeta{}, err
+		}
+		elems = append(elems, &kv.Elem[kv.OP]{
+			Op:    kv.Put,
+			Key:   store.StreamEntryKey(key, parsed.ms, parsed.seq),
+			Value: entryValue,
+		})
+		// Track the highest ID — entries may not be strictly sorted in the
+		// in-memory slice if a script writes IDs explicitly, so take the
+		// max rather than trusting the tail position.
+		if parsed.ms > meta.LastMs || (parsed.ms == meta.LastMs && parsed.seq > meta.LastSeq) {
+			meta.LastMs, meta.LastSeq = parsed.ms, parsed.seq
+		}
+	}
+	meta.Length = int64(len(entries))
+	return elems, meta, nil
+}
+
+// streamDeltaCommitElems emits only the newly appended entries, bounded head
+// tombstones, and the authoritative metadata record. Untouched entries remain
+// in place, avoiding the O(stream length) Lua XADD rewrite.
+func (c *luaScriptContext) streamDeltaCommitElems(
+	ctx context.Context,
+	key string,
+	st *luaStreamState,
+) ([]*kv.Elem[kv.OP], error) {
+	keyBytes := []byte(key)
+	ttl, err := c.finalTTL(ctx, keyBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	trimCount := int(st.baseTrim)
+	trimElems, err := c.server.buildXTrimHeadElems(ctx, keyBytes, c.startTS, trimCount)
+	if err != nil {
+		return nil, err
+	}
+	if len(trimElems) != trimCount {
+		return nil, errLuaStreamDeltaNeedsFullRewrite
+	}
+	elems := make([]*kv.Elem[kv.OP], 0, len(trimElems)+len(st.appended)+1)
+	elems = append(elems, trimElems...)
+	for _, entry := range st.appended {
 		parsed, err := parseRedisStreamID(entry.ID)
 		if err != nil {
 			return nil, errors.WithStack(err)
@@ -3951,14 +4320,8 @@ func (c *luaScriptContext) streamCommitElems(ctx context.Context, key string) ([
 			Key:   store.StreamEntryKey(keyBytes, parsed.ms, parsed.seq),
 			Value: entryValue,
 		})
-		// Track the highest ID — entries may not be strictly sorted in the
-		// in-memory slice if a script writes IDs explicitly, so take the
-		// max rather than trusting the tail position.
-		if parsed.ms > meta.LastMs || (parsed.ms == meta.LastMs && parsed.seq > meta.LastSeq) {
-			meta.LastMs, meta.LastSeq = parsed.ms, parsed.seq
-		}
 	}
-	meta.Length = int64(len(st.value.Entries))
+	meta := st.meta
 	meta.ExpireAt = ttlMillis(ttl)
 	metaBytes, err := store.MarshalStreamMeta(meta)
 	if err != nil {
@@ -4107,21 +4470,4 @@ func cloneStreamValue(in redisStreamValue) redisStreamValue {
 		})
 	}
 	return out
-}
-
-func nextLuaStreamID(stream redisStreamValue) string {
-	nowID := strconv.FormatInt(time.Now().UnixMilli(), 10) + "-0"
-	if len(stream.Entries) == 0 {
-		return nowID
-	}
-	lastEntry := stream.Entries[len(stream.Entries)-1]
-	lastID := lastEntry.ID
-	if compareRedisStreamID(nowID, lastID) > 0 {
-		return nowID
-	}
-	if !lastEntry.parsedIDValid {
-		return nowID
-	}
-	last := lastEntry.parsedID
-	return strconv.FormatUint(last.ms, 10) + "-" + strconv.FormatUint(last.seq+1, 10)
 }

--- a/adapter/redis_lua_stream_delta_test.go
+++ b/adapter/redis_lua_stream_delta_test.go
@@ -1,0 +1,463 @@
+package adapter
+
+import (
+	"bytes"
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/bootjp/elastickv/kv"
+	"github.com/bootjp/elastickv/store"
+	"github.com/stretchr/testify/require"
+)
+
+type luaStreamCountingStore struct {
+	store.MVCCStore
+	entryPrefix  []byte
+	entryScans   []int
+	entryPuts    int
+	entryDeletes int
+}
+
+type luaStreamFenceRaceCoordinator struct {
+	*occAdapterCoordinator
+	key      []byte
+	injected bool
+}
+
+func (c *luaStreamFenceRaceCoordinator) Dispatch(
+	ctx context.Context,
+	req *kv.OperationGroup[kv.OP],
+) (*kv.CoordinateResponse, error) {
+	if req != nil && req.IsTxn && !c.injected {
+		c.injected = true
+		if err := c.store.PutAt(ctx, redisStrKey(c.key), encodeRedisStr([]byte("racer"), nil), req.StartTS+1, 0); err != nil {
+			return nil, err
+		}
+	}
+	return c.occAdapterCoordinator.Dispatch(ctx, req)
+}
+
+func newLuaStreamCountingStore(inner store.MVCCStore, key []byte) *luaStreamCountingStore {
+	return &luaStreamCountingStore{
+		MVCCStore:   inner,
+		entryPrefix: store.StreamEntryScanPrefix(key),
+	}
+}
+
+func (s *luaStreamCountingStore) ScanAt(
+	ctx context.Context,
+	start []byte,
+	end []byte,
+	limit int,
+	ts uint64,
+) ([]*store.KVPair, error) {
+	if bytes.HasPrefix(start, s.entryPrefix) {
+		s.entryScans = append(s.entryScans, limit)
+	}
+	return s.MVCCStore.ScanAt(ctx, start, end, limit, ts)
+}
+
+func (s *luaStreamCountingStore) PutAt(ctx context.Context, key, value []byte, commitTS, expireAt uint64) error {
+	if bytes.HasPrefix(key, s.entryPrefix) {
+		s.entryPuts++
+	}
+	return s.MVCCStore.PutAt(ctx, key, value, commitTS, expireAt)
+}
+
+func (s *luaStreamCountingStore) DeleteAt(ctx context.Context, key []byte, commitTS uint64) error {
+	if bytes.HasPrefix(key, s.entryPrefix) {
+		s.entryDeletes++
+	}
+	return s.MVCCStore.DeleteAt(ctx, key, commitTS)
+}
+
+func (s *luaStreamCountingStore) reset() {
+	s.entryScans = nil
+	s.entryPuts = 0
+	s.entryDeletes = 0
+}
+
+func seedLuaWideStream(
+	t *testing.T,
+	st store.MVCCStore,
+	key []byte,
+	length int,
+	expireAt uint64,
+) {
+	t.Helper()
+	ctx := context.Background()
+	var lastMs uint64
+	for range length {
+		lastMs++
+		id := redisStreamID{ms: lastMs, seq: 0}
+		entry := newRedisStreamEntry(formatStreamID(id.ms, id.seq), []string{"field", "value"})
+		raw, err := marshalStreamEntry(entry)
+		require.NoError(t, err)
+		require.NoError(t, st.PutAt(ctx, store.StreamEntryKey(key, id.ms, id.seq), raw, 1, 0))
+	}
+	meta := store.StreamMeta{Length: int64(length), ExpireAt: expireAt}
+	if length > 0 {
+		meta.LastMs = lastMs
+	}
+	rawMeta, err := store.MarshalStreamMeta(meta)
+	require.NoError(t, err)
+	require.NoError(t, st.PutAt(ctx, store.StreamMetaKey(key), rawMeta, 1, 0))
+}
+
+func formatStreamID(ms, seq uint64) string {
+	return strconv.FormatUint(ms, 10) + "-" + strconv.FormatUint(seq, 10)
+}
+
+func newLuaStreamDeltaTestServer(
+	t *testing.T,
+	key []byte,
+) (*RedisServer, store.MVCCStore, *luaStreamCountingStore) {
+	t.Helper()
+	base := store.NewMVCCStore()
+	counting := newLuaStreamCountingStore(base, key)
+	server := NewRedisServer(nil, "", counting, newLocalAdapterCoordinator(counting), nil, nil)
+	return server, base, counting
+}
+
+func TestLuaStreamXAddDeltaCommitAvoidsFullScanAndRewrite(t *testing.T) {
+	key := []byte("lua:stream:delta")
+	server, base, counting := newLuaStreamDeltaTestServer(t, key)
+	seedLuaWideStream(t, base, key, 128, 0)
+	counting.reset()
+
+	conn := &recordingConn{}
+	server.runLuaScript(conn, `
+redis.call("XADD", KEYS[1], "129-0", "field", "a")
+redis.call("XADD", KEYS[1], "130-0", "field", "b")
+return redis.call("XLEN", KEYS[1])
+`, [][]byte{[]byte("1"), key})
+	require.Empty(t, conn.err)
+	require.Equal(t, int64(130), conn.int)
+	require.Empty(t, counting.entryScans, "XADD-only Lua must not scan existing stream entries")
+	require.Equal(t, 2, counting.entryPuts, "only the two appended rows should be written")
+	require.Zero(t, counting.entryDeletes)
+
+	meta, found, err := server.loadStreamMetaAt(context.Background(), key, server.readTS())
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, int64(130), meta.Length)
+	require.Equal(t, uint64(130), meta.LastMs)
+}
+
+func TestLuaStreamXAddMaxLenUsesBoundedDeltaTrim(t *testing.T) {
+	key := []byte("lua:stream:maxlen-delta")
+	server, base, counting := newLuaStreamDeltaTestServer(t, key)
+	seedLuaWideStream(t, base, key, 128, 0)
+	counting.reset()
+
+	conn := &recordingConn{}
+	server.runLuaScript(conn, `
+redis.call("XADD", KEYS[1], "MAXLEN", "~", 128, "129-0", "field", "a")
+return redis.call("XADD", KEYS[1], "MAXLEN", "~", 128, "130-0", "field", "b")
+`, [][]byte{[]byte("1"), key})
+	require.Empty(t, conn.err)
+	require.Equal(t, "130-0", string(conn.bulk))
+	require.Equal(t, []int{2}, counting.entryScans, "two head deletions should share one bounded scan")
+	require.Equal(t, 2, counting.entryPuts)
+	require.Equal(t, 2, counting.entryDeletes)
+
+	meta, found, err := server.loadStreamMetaAt(context.Background(), key, server.readTS())
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, int64(128), meta.Length)
+	require.Equal(t, uint64(130), meta.LastMs)
+}
+
+func TestLuaStreamXAddMaxLenZeroKeepsLastIDWithoutRows(t *testing.T) {
+	key := []byte("lua:stream:maxlen-zero")
+	server, base, counting := newLuaStreamDeltaTestServer(t, key)
+	seedLuaWideStream(t, base, key, 2, 0)
+	counting.reset()
+
+	conn := &recordingConn{}
+	server.runLuaScript(conn, `
+redis.call("XADD", KEYS[1], "MAXLEN", 0, "3-0", "field", "a")
+local next = redis.call("XADD", KEYS[1], "MAXLEN", 0, "*", "field", "b")
+return next
+`, [][]byte{[]byte("1"), key})
+	require.Empty(t, conn.err)
+	require.Greater(t, compareRedisStreamID(string(conn.bulk), "3-0"), 0)
+	require.Equal(t, []int{2}, counting.entryScans)
+	require.Zero(t, counting.entryPuts, "both script-local appends are trimmed before commit")
+	require.Equal(t, 2, counting.entryDeletes)
+
+	meta, found, err := server.loadStreamMetaAt(context.Background(), key, server.readTS())
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Zero(t, meta.Length)
+	require.Equal(t, string(conn.bulk), formatStreamID(meta.LastMs, meta.LastSeq))
+}
+
+func TestTrimLuaStreamHeadMaxLenZeroAtStorageCapRemovesPendingAppend(t *testing.T) {
+	st := &luaStreamState{
+		baseMeta: store.StreamMeta{Length: maxWideColumnItems},
+		meta:     store.StreamMeta{Length: maxWideColumnItems + 1},
+		appended: []redisStreamEntry{newRedisStreamEntry("100001-0", []string{"field", "value"})},
+	}
+
+	removed := trimLuaStreamHead(st, st.meta.Length)
+	require.Equal(t, int64(maxWideColumnItems+1), removed)
+	require.Equal(t, int64(maxWideColumnItems), st.baseTrim)
+	require.Empty(t, st.appended)
+	require.Zero(t, st.meta.Length)
+}
+
+func TestLuaStreamTTLAndExplicitIDDeltaSemantics(t *testing.T) {
+	key := []byte("lua:stream:ttl")
+	expireAt := time.Now().Add(time.Minute)
+	server, base, counting := newLuaStreamDeltaTestServer(t, key)
+	seedLuaWideStream(t, base, key, 2, redisExpireAtMillis(expireAt))
+	counting.reset()
+
+	updatedTTL := 45 * time.Second
+	conn := &recordingConn{}
+	server.runLuaScript(conn, `
+local id = redis.call("XADD", KEYS[1], "3-7", "field", "value")
+redis.call("PEXPIRE", KEYS[1], ARGV[1])
+return id
+`, [][]byte{
+		[]byte("1"), key, []byte(strconv.FormatInt(updatedTTL.Milliseconds(), 10)),
+	})
+	require.Empty(t, conn.err)
+	require.Equal(t, "3-7", string(conn.bulk))
+	require.Empty(t, counting.entryScans)
+
+	meta, found, err := server.loadStreamMetaAt(context.Background(), key, server.readTS())
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, int64(3), meta.Length)
+	require.Equal(t, uint64(3), meta.LastMs)
+	require.Equal(t, uint64(7), meta.LastSeq)
+	require.WithinDuration(t, time.Now().Add(updatedTTL), *redisTimeFromMillis(meta.ExpireAt), 3*time.Second)
+
+	rejected := &recordingConn{}
+	server.runLuaScript(rejected, `return redis.call("XADD", KEYS[1], "3-6", "field", "value")`, [][]byte{
+		[]byte("1"), key,
+	})
+	require.Contains(t, rejected.err, "equal or smaller")
+}
+
+func TestLuaStreamRangeForcesFullFallbackAndSeesScriptMutations(t *testing.T) {
+	key := []byte("lua:stream:range-fallback")
+	server, base, counting := newLuaStreamDeltaTestServer(t, key)
+	seedLuaWideStream(t, base, key, 3, 0)
+	counting.reset()
+
+	ctx, err := newLuaScriptContext(context.Background(), server)
+	require.NoError(t, err)
+	defer ctx.Close()
+
+	_, err = ctx.cmdXAdd([]string{string(key), "4-0", "field", "new"})
+	require.NoError(t, err)
+	length, err := ctx.cmdXLen([]string{string(key)})
+	require.NoError(t, err)
+	require.Equal(t, int64(4), length.integer)
+
+	ranged, err := ctx.cmdXRange([]string{string(key), "2-0", "+", "COUNT", "2"})
+	require.NoError(t, err)
+	require.Len(t, ranged.array, 2)
+	require.Equal(t, "2-0", ranged.array[0].array[0].text)
+	require.True(t, ctx.streams[string(key)].materialized)
+	reversed, err := ctx.cmdXRevRange([]string{string(key), "+", "-", "COUNT", "1"})
+	require.NoError(t, err)
+	require.Len(t, reversed.array, 1)
+	require.Equal(t, "4-0", reversed.array[0].array[0].text)
+
+	trimmed, err := ctx.cmdXTrim([]string{string(key), "MAXLEN", "2"})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), trimmed.integer)
+	length, err = ctx.cmdXLen([]string{string(key)})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), length.integer)
+
+	plan, err := ctx.streamCommitPlan(context.Background(), string(key))
+	require.NoError(t, err)
+	require.False(t, plan.preserveExisting, "range access must select the full fallback")
+	require.Len(t, plan.elems, 3, "two final entries plus metadata")
+	require.Equal(t, []int{scanStreamEntriesLimit(3)}, counting.entryScans)
+}
+
+func TestLuaStreamDeleteRecreateAndExpiredFallbackCleanOldRows(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      []byte
+		expireAt uint64
+		script   string
+		newID    redisStreamID
+		writeTTL bool
+	}{
+		{
+			name:   "delete then recreate",
+			key:    []byte("lua:stream:delete-recreate"),
+			script: `redis.call("DEL", KEYS[1]); return redis.call("XADD", KEYS[1], "1-1", "field", "new")`,
+			newID:  redisStreamID{ms: 1, seq: 1},
+		},
+		{
+			name:     "expired layout",
+			key:      []byte("lua:stream:expired-recreate"),
+			expireAt: redisExpireAtMillis(time.UnixMilli(1)),
+			script:   `return redis.call("XADD", KEYS[1], "1-1", "field", "new")`,
+			newID:    redisStreamID{ms: 1, seq: 1},
+			writeTTL: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server, base, _ := newLuaStreamDeltaTestServer(t, tc.key)
+			seedLuaWideStream(t, base, tc.key, 3, tc.expireAt)
+			if tc.writeTTL {
+				require.NoError(t, base.PutAt(context.Background(), redisTTLKey(tc.key), encodeRedisTTL(time.UnixMilli(1)), 2, 0))
+			}
+
+			conn := &recordingConn{}
+			server.runLuaScript(conn, tc.script, [][]byte{[]byte("1"), tc.key})
+			require.Empty(t, conn.err)
+
+			readTS := server.readTS()
+			meta, found, err := server.loadStreamMetaAt(context.Background(), tc.key, readTS)
+			require.NoError(t, err)
+			require.True(t, found)
+			require.Equal(t, int64(1), meta.Length)
+			require.Zero(t, meta.ExpireAt)
+			oldExists, err := base.ExistsAt(context.Background(), store.StreamEntryKey(tc.key, 2, 0), readTS)
+			require.NoError(t, err)
+			require.False(t, oldExists)
+			newExists, err := base.ExistsAt(context.Background(), store.StreamEntryKey(tc.key, tc.newID.ms, tc.newID.seq), readTS)
+			require.NoError(t, err)
+			require.True(t, newExists)
+			ttlExists, err := base.ExistsAt(context.Background(), redisTTLKey(tc.key), readTS)
+			require.NoError(t, err)
+			require.False(t, ttlExists)
+		})
+	}
+}
+
+func TestLuaStreamLegacyFallbackDiscardsBlobAndWritesDeltaLayout(t *testing.T) {
+	key := []byte("lua:stream:legacy")
+	server, base, _ := newLuaStreamDeltaTestServer(t, key)
+	legacyRaw, err := marshalStreamValue(redisStreamValue{Entries: []redisStreamEntry{
+		newRedisStreamEntry("9-0", []string{"field", "old"}),
+	}})
+	require.NoError(t, err)
+	require.NoError(t, base.PutAt(context.Background(), redisStreamKey(key), legacyRaw, 1, 0))
+
+	conn := &recordingConn{}
+	server.runLuaScript(conn, `return redis.call("XADD", KEYS[1], "1-1", "field", "new")`, [][]byte{
+		[]byte("1"), key,
+	})
+	require.Empty(t, conn.err)
+	readTS := server.readTS()
+	legacyExists, err := base.ExistsAt(context.Background(), redisStreamKey(key), readTS)
+	require.NoError(t, err)
+	require.False(t, legacyExists)
+	meta, found, err := server.loadStreamMetaAt(context.Background(), key, readTS)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, int64(1), meta.Length)
+}
+
+func TestLuaStreamDeltaCommitCarriesTypeAndMetaReadFences(t *testing.T) {
+	key := []byte("lua:stream:read-fences")
+	st := store.NewMVCCStore()
+	coord := newReadKeyRecordingCoordinator(st)
+	server := NewRedisServer(nil, "", st, coord, nil, nil)
+
+	conn := &recordingConn{}
+	server.runLuaScript(conn, `return redis.call("XADD", KEYS[1], "1-1", "field", "value")`, [][]byte{
+		[]byte("1"), key,
+	})
+	require.Empty(t, conn.err)
+	want := append([][]byte{}, redisTxnWideCollectionFenceKeys(key)...)
+	want = append(want,
+		store.StreamMetaKey(key),
+		redisStrKey(key),
+		redisHLLKey(key),
+		key,
+		store.ListMetaKey(key),
+		redisHashKey(key),
+		redisSetKey(key),
+		redisZSetKey(key),
+		redisStreamKey(key),
+	)
+	requireReadKeysMatch(t, coord.lastReadKeys, want)
+}
+
+func TestLuaStreamAbsentCreateReadFenceRejectsConcurrentString(t *testing.T) {
+	key := []byte("lua:stream:read-fence-race")
+	st := store.NewMVCCStore()
+	coord := &luaStreamFenceRaceCoordinator{
+		occAdapterCoordinator: newOCCAdapterCoordinator(st),
+		key:                   key,
+	}
+	server := NewRedisServer(nil, "", st, coord, nil, nil)
+
+	conn := &recordingConn{}
+	server.runLuaScript(conn, `return redis.call("XADD", KEYS[1], "1-1", "field", "value")`, [][]byte{
+		[]byte("1"), key,
+	})
+	require.True(t, coord.injected)
+	require.Contains(t, conn.err, wrongTypeMessage)
+	_, found, err := server.loadStreamMetaAt(context.Background(), key, server.readTS())
+	require.NoError(t, err)
+	require.False(t, found, "conflicting stream create must not leave a second logical type")
+	value, _, err := server.readRedisStringAtSnapshot(key, server.readTS())
+	require.NoError(t, err)
+	require.Equal(t, []byte("racer"), value)
+}
+
+func TestLuaStreamXAddRetryDoesNotDuplicateEntries(t *testing.T) {
+	key := []byte("lua:stream:retry")
+	st := store.NewMVCCStore()
+	seedLuaWideStream(t, st, key, 1, 0)
+	coord := newRetryOnceCoordinator(st)
+	coord.clock.Observe(1)
+	server := NewRedisServer(nil, "", st, coord, nil, nil)
+
+	conn := &recordingConn{}
+	server.runLuaScript(conn, `return redis.call("XADD", KEYS[1], "2-0", "field", "value")`, [][]byte{
+		[]byte("1"), key,
+	})
+	require.Empty(t, conn.err)
+	require.Equal(t, 2, coord.dispatches)
+	meta, found, err := server.loadStreamMetaAt(context.Background(), key, server.readTS())
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, int64(2), meta.Length)
+	entries, err := server.scanStreamEntriesAt(context.Background(), key, server.readTS(), meta.Length)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+}
+
+func TestLuaStreamXAddAmbiguousWireConflictFailsClosed(t *testing.T) {
+	key := []byte("lua:stream:wire-conflict")
+	st := store.NewMVCCStore()
+	seedLuaWideStream(t, st, key, 1, 0)
+	coord := newDedupTestCoordinator(st, 1, true)
+	coord.wireWriteConflicts = true
+	server := NewRedisServer(nil, "", st, coord, nil, nil)
+
+	conn := &recordingConn{}
+	server.runLuaScript(conn, `return redis.call("XADD", KEYS[1], "2-0", "field", "value")`, [][]byte{
+		[]byte("1"), key,
+	})
+	require.NotEmpty(t, conn.err)
+	require.Equal(t, 1, coord.dispatches, "generic Lua retry must not replay an ambiguous applied write")
+	meta, found, err := server.loadStreamMetaAt(context.Background(), key, server.readTS())
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, int64(2), meta.Length)
+	entries, err := server.scanStreamEntriesAt(context.Background(), key, server.readTS(), meta.Length)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+}
+
+var _ store.MVCCStore = (*luaStreamCountingStore)(nil)
+var _ kv.Coordinator = (*readKeyRecordingCoordinator)(nil)


### PR DESCRIPTION
## Summary
- Avoid full stream entry scans for Lua XADD and XLEN when the stream is already in the wide-column layout.
- Track stream metadata, appended entries, and bounded head trims inside the Lua script context, then commit only the delta where safe.
- Materialize the full stream only for Lua commands that need arbitrary entry access, such as XRANGE and XREVRANGE.
- Add OCC read fences so absent-stream creation still rejects concurrent cross-type creation.

## Root cause
The production CPU profile under Redis proxy traffic showed Lua EVAL/EVALSHA dominated by streamState -> loadStreamAt -> scanStreamEntriesAt. XADD in Lua was loading every existing stream entry before appending one row, which turned Redis proxy secondary replay into O(stream length) scans.

## Validation
- go test ./adapter -run TestLuaStream
- go test ./adapter -run 'TestRedisEval|TestRedisLua|TestRedisScript|TestRedisStream|TestRedisX'
- go test -race ./adapter -run 'TestLuaStream'
- go test ./... -run '^$'
- golangci-lint run ./adapter --timeout=5m
- go test ./adapter was attempted in the original worktree but stopped after 449s with no completion; targeted adapter coverage and full-package compile passed in this branch.
