### PR TITLE
Add Redis delta compactor toggle

### DIFF
--- a/main.go
+++ b/main.go
@@ -288,8 +288,9 @@ const memoryShutdownThresholdEnvVar = "ELASTICKV_MEMORY_SHUTDOWN_THRESHOLD_MB"
 const memoryShutdownPollIntervalEnvVar = "ELASTICKV_MEMORY_SHUTDOWN_POLL_INTERVAL"
 
 const (
-	lockResolverEnabledEnvVar = "ELASTICKV_LOCK_RESOLVER_ENABLED"
-	fsmCompactorEnabledEnvVar = "ELASTICKV_FSM_COMPACTOR_ENABLED"
+	lockResolverEnabledEnvVar        = "ELASTICKV_LOCK_RESOLVER_ENABLED"
+	fsmCompactorEnabledEnvVar        = "ELASTICKV_FSM_COMPACTOR_ENABLED"
+	redisDeltaCompactorEnabledEnvVar = "ELASTICKV_REDIS_DELTA_COMPACTOR_ENABLED"
 )
 
 const bytesPerMiB = 1024 * 1024
@@ -396,6 +397,14 @@ func startFSMCompactorIfEnabled(ctx context.Context, eg *errgroup.Group, runtime
 		return
 	}
 	slog.Info("fsm compactor disabled", "env", fsmCompactorEnabledEnvVar)
+}
+
+func newRedisDeltaCompactorIfEnabled(shardStore *kv.ShardStore, coordinate kv.Coordinator) *adapter.DeltaCompactor {
+	if enabledEnv(redisDeltaCompactorEnabledEnvVar) {
+		return adapter.NewDeltaCompactor(shardStore, coordinate)
+	}
+	slog.Info("redis delta compactor disabled", "env", redisDeltaCompactorEnabledEnvVar)
+	return nil
 }
 
 func run() error {
@@ -2758,16 +2767,19 @@ func prepareRedisServer(ctx context.Context, lc *net.ListenConfig, redisAddr str
 	if err != nil {
 		return nil, nil, nil, errors.Wrapf(err, "failed to listen on %s", redisAddr)
 	}
-	deltaCompactor := adapter.NewDeltaCompactor(shardStore, coordinate)
-	redisServer := adapter.NewRedisServer(redisL, redisAddr, shardStore, coordinate, leaderRedis, relay,
+	deltaCompactor := newRedisDeltaCompactorIfEnabled(shardStore, coordinate)
+	redisOpts := []adapter.RedisServerOption{
 		adapter.WithRedisActiveTimestampTracker(readTracker),
 		adapter.WithRedisRequestObserver(metricsRegistry.RedisObserver()),
 		adapter.WithLuaObserver(metricsRegistry.LuaObserver()),
 		adapter.WithLuaFastPathObserver(metricsRegistry.LuaFastPathObserver()),
-		adapter.WithRedisCompactor(deltaCompactor),
 		adapter.WithLuaPoolMaxIdle(*redisLuaMaxIdleStates),
 		adapter.WithRedisApplyObserver(redisApplyObserver),
-	)
+	}
+	if deltaCompactor != nil {
+		redisOpts = append(redisOpts, adapter.WithRedisCompactor(deltaCompactor))
+	}
+	redisServer := adapter.NewRedisServer(redisL, redisAddr, shardStore, coordinate, leaderRedis, relay, redisOpts...)
 	// Wire the bounded Lua VM pool into Prometheus. The metrics
 	// (hits/misses/drops/idle/max_idle) are read at scrape time via
 	// CounterFunc / GaugeFunc, so the EVAL hot path stays

--- a/main_background_env_test.go
+++ b/main_background_env_test.go
@@ -24,3 +24,19 @@ func TestEnabledEnv(t *testing.T) {
 		}
 	})
 }
+
+func TestRedisDeltaCompactorEnv(t *testing.T) {
+	t.Run("default enabled", func(t *testing.T) {
+		t.Setenv(redisDeltaCompactorEnabledEnvVar, "")
+		if newRedisDeltaCompactorIfEnabled(nil, nil) == nil {
+			t.Fatal("newRedisDeltaCompactorIfEnabled() = nil, want compactor")
+		}
+	})
+
+	t.Run("false disables", func(t *testing.T) {
+		t.Setenv(redisDeltaCompactorEnabledEnvVar, "false")
+		if newRedisDeltaCompactorIfEnabled(nil, nil) != nil {
+			t.Fatal("newRedisDeltaCompactorIfEnabled() returned compactor, want nil")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- add ELASTICKV_REDIS_DELTA_COMPACTOR_ENABLED to disable the Redis DeltaCompactor background loop
- skip RedisServer compactor wiring when the toggle is false so urgent compaction requests are ignored
- keep the default enabled to preserve existing behavior

## Risk
- disabling the compactor can let Redis collection delta keys accumulate, so it should be used as an operational relief switch while investigating scan load

## Validation
- go test .
- golangci-lint run . --timeout=5m

Author: bootjp