### PR TITLE
Avoid registry decode errors during scans

### DIFF
--- a/internal/encryption/registry.go
+++ b/internal/encryption/registry.go
@@ -97,8 +97,8 @@ func IsRegistryKey(key []byte) bool {
 
 // DecodeRegistryKey parses a registry-row key back into its
 // (dek_id, uint16 node_id) tuple. Returns ErrRegistryKeyMalformed
-// when the key does not start with WriterRegistryPrefix or has the
-// wrong length. The decoder does NOT range-check the parsed
+// when the key does not match the exact writer-registry key shape.
+// The decoder does NOT range-check the parsed
 // dek_id against ReservedKeyID — that is the caller's policy.
 func DecodeRegistryKey(key []byte) (dekID uint32, nodeID16 uint16, err error) {
 	if !IsRegistryKey(key) {

--- a/internal/encryption/registry.go
+++ b/internal/encryption/registry.go
@@ -78,24 +78,33 @@ func RegistryDEKPrefix(dekID uint32) []byte {
 	return out
 }
 
+// IsRegistryKey reports whether key has the exact writer-registry row shape.
+//
+// This is intentionally error-free: raw Pebble scans call it for every scanned
+// key to skip operational rows, so using DecodeRegistryKey there would allocate
+// stack-bearing errors for ordinary user keys.
+func IsRegistryKey(key []byte) bool {
+	if len(key) != len(WriterRegistryPrefix)+registryKeySuffixSize {
+		return false
+	}
+	for i, b := range WriterRegistryPrefix {
+		if key[i] != b {
+			return false
+		}
+	}
+	return key[len(WriterRegistryPrefix)+4] == registryKeySep
+}
+
 // DecodeRegistryKey parses a registry-row key back into its
 // (dek_id, uint16 node_id) tuple. Returns ErrRegistryKeyMalformed
 // when the key does not start with WriterRegistryPrefix or has the
 // wrong length. The decoder does NOT range-check the parsed
 // dek_id against ReservedKeyID — that is the caller's policy.
 func DecodeRegistryKey(key []byte) (dekID uint32, nodeID16 uint16, err error) {
-	if len(key) != len(WriterRegistryPrefix)+registryKeySuffixSize {
+	if !IsRegistryKey(key) {
 		return 0, 0, errors.Wrapf(ErrRegistryKeyMalformed, "got %d bytes", len(key))
 	}
-	for i, b := range WriterRegistryPrefix {
-		if key[i] != b {
-			return 0, 0, errors.WithStack(ErrRegistryKeyMalformed)
-		}
-	}
 	body := key[len(WriterRegistryPrefix):]
-	if body[4] != registryKeySep {
-		return 0, 0, errors.WithStack(ErrRegistryKeyMalformed)
-	}
 	dekID = binary.BigEndian.Uint32(body[0:4])
 	nodeID16 = binary.BigEndian.Uint16(body[5:7])
 	return dekID, nodeID16, nil

--- a/internal/encryption/registry_test.go
+++ b/internal/encryption/registry_test.go
@@ -75,6 +75,36 @@ func TestRegistryDEKPrefix(t *testing.T) {
 	}
 }
 
+func TestIsRegistryKey(t *testing.T) {
+	t.Parallel()
+	valid := encryption.RegistryKey(0xfeedbeef, 0xcafe)
+	wrongPrefix := append([]byte{}, valid...)
+	wrongPrefix[1] = 'x'
+	missingSep := append([]byte{}, valid...)
+	missingSep[len(encryption.WriterRegistryPrefix)+4] = 'X'
+	prefixUserKey := append([]byte{}, encryption.WriterRegistryPrefix...)
+	prefixUserKey = append(prefixUserKey, []byte("tenant-visible-key")...)
+	cases := []struct {
+		name string
+		key  []byte
+		want bool
+	}{
+		{"valid", valid, true},
+		{"empty", nil, false},
+		{"wrong length", append([]byte{}, valid[:len(valid)-1]...), false},
+		{"wrong prefix same length", wrongPrefix, false},
+		{"missing separator", missingSep, false},
+		{"user key with registry prefix remains data", prefixUserKey, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := encryption.IsRegistryKey(tc.key); got != tc.want {
+				t.Fatalf("IsRegistryKey() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestDecodeRegistryKey_RejectsMalformed(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/store/lsm_store.go
+++ b/store/lsm_store.go
@@ -699,8 +699,7 @@ func isPebbleOperationalKey(rawKey []byte) bool {
 }
 
 func isPebbleWriterRegistryKey(rawKey []byte) bool {
-	_, _, err := encryption.DecodeRegistryKey(rawKey)
-	return err == nil
+	return encryption.IsRegistryKey(rawKey)
 }
 
 func (s *pebbleStore) findMaxCommitTS() (uint64, error) {


### PR DESCRIPTION
## Summary
- add an allocation-free writer-registry key shape check
- use it on Pebble scan hot paths instead of decoding every non-registry key
- cover exact registry-row detection and prefix-like user keys

## Validation
- go test ./internal/encryption ./store -count=1
- golangci-lint run ./internal/encryption ./store --timeout=5m

## Runtime evidence
- n1 profile showed scan CPU dominated by stack-bearing registry decode errors during Redis proxy dual-write load


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - Pebble の writer registry キーをより正確に判定できるようになりました。
  - 不正なキー形式に対するエラー情報を整理し、キー長を含む明確なエラーを返すようになりました。
  - スキャンやコンパクション時に、対象外キーをより正しく識別できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->