### PR TITLE
Reduce Redis block wait scan pressure

### DIFF
--- a/adapter/redis.go
+++ b/adapter/redis.go
@@ -115,14 +115,21 @@ const (
 )
 
 const (
-	redisDispatchTimeout     = 10 * time.Second
-	redisFlushLegacyTimeout  = 10 * time.Minute
-	redisRelayPublishTimeout = 2 * time.Second
-	redisTraceArgLimit       = 6
-	redisTraceArgMaxLen      = 96
-	redisTraceArgEllipsis    = "..."
-	redisTraceArgTrimLen     = redisTraceArgMaxLen - len(redisTraceArgEllipsis)
-	redisTraceRedactAfter    = 1 // redact arguments after key (command name already stripped by caller)
+	redisDispatchTimeout = 10 * time.Second
+	// defaultRedisBlockWaitFallback is the safety-net poll interval for
+	// blocking-command wait loops when no in-process write signal arrives.
+	// Signals cover normal XADD / ZADD / ZINCRBY wakeups immediately; this
+	// interval only bounds missed-signal, wrong-type, and BLOCK-deadline checks.
+	// Keep it below common sub-second BLOCK budgets while reducing idle
+	// fallback scans versus the previous 100ms cadence.
+	defaultRedisBlockWaitFallback = 250 * time.Millisecond
+	redisFlushLegacyTimeout       = 10 * time.Minute
+	redisRelayPublishTimeout      = 2 * time.Second
+	redisTraceArgLimit            = 6
+	redisTraceArgMaxLen           = 96
+	redisTraceArgEllipsis         = "..."
+	redisTraceArgTrimLen          = redisTraceArgMaxLen - len(redisTraceArgEllipsis)
+	redisTraceRedactAfter         = 1 // redact arguments after key (command name already stripped by caller)
 
 	// listPopDeltaOverhead is the number of extra elements reserved in a list
 	// pop elem slice beyond the per-position claim keys and per-item del keys:
@@ -166,6 +173,9 @@ type RedisServer struct {
 	heavyCommandLimiter *redisHeavyCommandLimiter
 	// peerLimiter bounds concurrent Redis connections per remote peer IP.
 	peerLimiter *redisPeerLimiter
+	// blockWaitFallback is the safety-net polling interval used by blocking
+	// Redis commands when no waiter signal arrives.
+	blockWaitFallback time.Duration
 	// baseCtx is the parent context for per-request handlers.
 	// NewRedisServer creates a cancelable context here; Stop() cancels
 	// it so in-flight handlers abort promptly instead of running
@@ -327,6 +337,18 @@ func WithRedisHeavyCommandSlots(n int) RedisServerOption {
 func WithRedisPerPeerConnectionLimit(n int) RedisServerOption {
 	return func(r *RedisServer) {
 		r.peerLimiter = newRedisPeerLimiter(n)
+	}
+}
+
+// WithRedisBlockWaitFallback overrides the safety-net polling interval for
+// blocking Redis commands. Production should normally use the default and rely
+// on waiter signals for immediate wakeups; tests use a shorter interval to keep
+// package runtime bounded.
+func WithRedisBlockWaitFallback(d time.Duration) RedisServerOption {
+	return func(r *RedisServer) {
+		if d > 0 {
+			r.blockWaitFallback = d
+		}
 	}
 }
 
@@ -517,6 +539,7 @@ func NewRedisServer(listen net.Listener, redisAddr string, store store.MVCCStore
 		traceCommands:       os.Getenv("ELASTICKV_REDIS_TRACE") == "1",
 		heavyCommandLimiter: newDefaultRedisHeavyCommandLimiter(),
 		peerLimiter:         newDefaultRedisPeerLimiter(),
+		blockWaitFallback:   defaultRedisBlockWaitFallback,
 		// onePhaseTxnDedup defaults on — the parent design's R5 rolling-upgrade
 		// constraint is discharged (FSM probe shipped on every node months ago,
 		// 12 consecutive green dedup-mode Jepsen runs 2026-05-31 → 2026-06-10).

--- a/adapter/redis_bzpopmin_wake_test.go
+++ b/adapter/redis_bzpopmin_wake_test.go
@@ -146,7 +146,7 @@ func TestRedis_BZPopMinRejectsInitialWrongType(t *testing.T) {
 // non-existent key and a wrongType encoding (e.g. SET) is written
 // to that key during the BLOCK window, the next fallback-timer
 // wake must run the full check and surface WRONGTYPE within
-// ~redisBlockWaitFallback (100 ms). A pure signal-driven path
+// ~redisBlockWaitFallback. A pure signal-driven path
 // would miss this because SET / HSET / etc. do not fire
 // zsetWaiters.Signal.
 //
@@ -176,7 +176,7 @@ func TestRedis_BZPopMinDetectsMidBlockWrongType(t *testing.T) {
 
 	// Let the reader enter the wait loop and exhaust its first
 	// (full) iteration on a missing key. Then SET a string at the
-	// same key. The next fallback-timer wake (~100 ms after the
+	// same key. The next fallback-timer wake after the
 	// previous one) must run the full check and surface WRONGTYPE.
 	time.Sleep(50 * time.Millisecond)
 	require.NoError(t, rdbWriter.Set(ctx, "bzpop-mid-wrongtype", "I am a string", 0).Err())
@@ -197,7 +197,7 @@ func TestRedis_BZPopMinDetectsMidBlockWrongType(t *testing.T) {
 // The fast-path optimisation skips the wrongType slow probe on
 // signal-driven wakes. If `fast` is set directly from
 // waitForBlockedCommandUpdate's return value, sustained ZADD/ZINCRBY
-// signals can keep `fast=true` indefinitely — the 100 ms fallback
+// signals can keep `fast=true` indefinitely — the fallback
 // timer never fires because waiterC is constantly refilled. A
 // mid-block wrongType write on one of the registered keys then goes
 // undetected for the entire BLOCK window.
@@ -263,9 +263,8 @@ func TestRedis_BZPopMinDetectsWrongTypeUnderSignalLoad(t *testing.T) {
 	}()
 
 	// Let the reader complete several signal-driven wakes before we
-	// introduce the wrongType. 200 ms is well above the 100 ms
-	// fallback budget; with the fix in place a forced full check
-	// has run during this window.
+	// introduce the wrongType after the reader has settled into the
+	// signal-driven fast path.
 	time.Sleep(200 * time.Millisecond)
 
 	require.NoError(t, rdbWriter.Set(context.Background(), "bzpop-press-cold",
@@ -296,7 +295,7 @@ func TestRedis_BZPopMinTimesOutOnEmptyKey(t *testing.T) {
 	ctx := context.Background()
 
 	// 250 ms BLOCK on a key that never receives a write. The fallback
-	// timer (100 ms) fires twice, then the deadline branch writes
+	// timer is capped by the remaining BLOCK budget, then the deadline branch writes
 	// nil. Total budget: redisDispatchTimeout caps each iter; we
 	// expect ~250 ms total wall time and a redis.Nil reply.
 	zwk, err := rdb.BZPopMin(ctx, 250*time.Millisecond, "zset-empty").Result()

--- a/adapter/redis_bzpopmin_wake_test.go
+++ b/adapter/redis_bzpopmin_wake_test.go
@@ -177,7 +177,7 @@ func TestRedis_BZPopMinDetectsMidBlockWrongType(t *testing.T) {
 	// Let the reader enter the wait loop and exhaust its first
 	// (full) iteration on a missing key. Then SET a string at the
 	// same key. The next fallback-timer wake after the
-	// previous one) must run the full check and surface WRONGTYPE.
+	// previous one must run the full check and surface WRONGTYPE.
 	time.Sleep(50 * time.Millisecond)
 	require.NoError(t, rdbWriter.Set(ctx, "bzpop-mid-wrongtype", "I am a string", 0).Err())
 

--- a/adapter/redis_bzpopmin_wake_test.go
+++ b/adapter/redis_bzpopmin_wake_test.go
@@ -146,7 +146,7 @@ func TestRedis_BZPopMinRejectsInitialWrongType(t *testing.T) {
 // non-existent key and a wrongType encoding (e.g. SET) is written
 // to that key during the BLOCK window, the next fallback-timer
 // wake must run the full check and surface WRONGTYPE within
-// ~redisBlockWaitFallback. A pure signal-driven path
+// roughly one configured block fallback interval. A pure signal-driven path
 // would miss this because SET / HSET / etc. do not fire
 // zsetWaiters.Signal.
 //
@@ -216,8 +216,8 @@ func TestRedis_BZPopMinDetectsMidBlockWrongType(t *testing.T) {
 // instead of returning WRONGTYPE.
 //
 // The fix maintains a lastFullCheck wall time inside bzpopminWaitLoop
-// and demotes `fast` back to false when more than redisBlockWaitFallback
-// has elapsed since the last full check, restoring the #666 ceiling.
+// and demotes `fast` back to false when more than the configured fallback
+// interval has elapsed since the last full check, restoring the #666 ceiling.
 func TestRedis_BZPopMinDetectsWrongTypeUnderSignalLoad(t *testing.T) {
 	t.Parallel()
 	// This test drives the in-process waiter registry directly, so a

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -17,10 +17,11 @@ const (
 	// Signal (Lua flush, follower-applied entries — both addressed by
 	// the FSM ApplyObserver tracked in
 	// docs/design/2026_04_26_implemented_fsm_apply_observer.md).
-	// 100 ms keeps the fallback CPU at roughly 1/10th of the prior
-	// busy-poll, while bounding stale-poll latency to a value clients
-	// already tolerate from network round-trips.
-	redisBlockWaitFallback = 100 * time.Millisecond
+	// Most wakeups should come from the waiter signal path; the fallback is
+	// only a safety net for missed signals, wrong-type detection, and the
+	// BLOCK deadline. Keep it coarse enough that many idle blocking commands
+	// do not turn into a constant stream of full key-type scans.
+	redisBlockWaitFallback = time.Second
 	redisKeywordCount      = "COUNT"
 
 	// setWideColOverhead is the number of extra elements reserved in a set

--- a/adapter/redis_compat_commands.go
+++ b/adapter/redis_compat_commands.go
@@ -1,28 +1,11 @@
 package adapter
 
-import (
-	"time"
-)
-
 const (
 	redisPairWidth      = 2
 	redisTripletWidth   = 3
 	pubsubPatternArgMin = 3
 	pubsubFirstChannel  = 2
-	// redisBlockWaitFallback is the safety-net poll interval that fires
-	// in blocking-command wait loops (XREAD BLOCK, BZPOPMIN — and the
-	// future BLPOP / BRPOP / BLMOVE) when no in-process write signal
-	// arrives. The signal path covers all in-process XADD / ZADD /
-	// ZINCRBY on the same node; the fallback covers paths that bypass
-	// Signal (Lua flush, follower-applied entries — both addressed by
-	// the FSM ApplyObserver tracked in
-	// docs/design/2026_04_26_implemented_fsm_apply_observer.md).
-	// Most wakeups should come from the waiter signal path; the fallback is
-	// only a safety net for missed signals, wrong-type detection, and the
-	// BLOCK deadline. Keep it coarse enough that many idle blocking commands
-	// do not turn into a constant stream of full key-type scans.
-	redisBlockWaitFallback = time.Second
-	redisKeywordCount      = "COUNT"
+	redisKeywordCount   = "COUNT"
 
 	// setWideColOverhead is the number of extra elements reserved in a set
 	// wide-column mutation slice beyond the per-member elements: one for the

--- a/adapter/redis_compat_commands_stream_test.go
+++ b/adapter/redis_compat_commands_stream_test.go
@@ -975,7 +975,7 @@ func TestRedis_StreamXReadShutdownShortCircuits(t *testing.T) {
 	// pre-fix this would happily run for the full 5 s after Close()
 	// because iterCtx was rooted in context.Background(). Post-fix the
 	// handlerCtx.Err() guard at the top of each loop iteration kicks
-	// in within ~one redisBlockWaitFallback (100 ms) and we reply null.
+	// in promptly and we reply null.
 	_, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "stream-shutdown",
 		ID:     "1-0",

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -388,7 +388,7 @@ func (r *RedisServer) keyTypeAtExpect(ctx context.Context, key []byte, readTS ui
 // appeared between iterations is invisible to this fast path; the
 // blocking command's fallback-timer wake (which uses the slow
 // keyTypeAtExpect) is the safety net that detects it within
-// ~redisBlockWaitFallback.
+// roughly one configured block fallback interval.
 //
 // Compared to keyTypeAtExpect on the empty-key case
 // (probeExpectedType -> false -> rawKeyTypeAt slow path = ~19

--- a/adapter/redis_compat_helpers.go
+++ b/adapter/redis_compat_helpers.go
@@ -388,7 +388,7 @@ func (r *RedisServer) keyTypeAtExpect(ctx context.Context, key []byte, readTS ui
 // appeared between iterations is invisible to this fast path; the
 // blocking command's fallback-timer wake (which uses the slow
 // keyTypeAtExpect) is the safety net that detects it within
-// ~redisBlockWaitFallback (100ms).
+// ~redisBlockWaitFallback.
 //
 // Compared to keyTypeAtExpect on the empty-key case
 // (probeExpectedType -> false -> rawKeyTypeAt slow path = ~19

--- a/adapter/redis_key_waiters_test.go
+++ b/adapter/redis_key_waiters_test.go
@@ -110,7 +110,7 @@ func TestKeyWaiterRegistry_SignalFullDowngradesCoalescedFastSignal(t *testing.T)
 	reg.Signal([]byte("k"))
 	reg.SignalFull([]byte("k"))
 
-	fast := waitForBlockedCommandUpdate(context.Background(), w, time.Now().Add(time.Second))
+	fast := waitForBlockedCommandUpdate(context.Background(), w, time.Now().Add(time.Second), defaultRedisBlockWaitFallback)
 	if fast {
 		t.Fatal("SignalFull must force the next wake to use the full re-check")
 	}

--- a/adapter/redis_options_test.go
+++ b/adapter/redis_options_test.go
@@ -1,0 +1,50 @@
+package adapter
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWithRedisBlockWaitFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		opt  RedisServerOption
+		want time.Duration
+	}{
+		{
+			name: "default",
+			want: defaultRedisBlockWaitFallback,
+		},
+		{
+			name: "positive override",
+			opt:  WithRedisBlockWaitFallback(42 * time.Millisecond),
+			want: 42 * time.Millisecond,
+		},
+		{
+			name: "zero preserves default",
+			opt:  WithRedisBlockWaitFallback(0),
+			want: defaultRedisBlockWaitFallback,
+		},
+		{
+			name: "negative preserves default",
+			opt:  WithRedisBlockWaitFallback(-time.Millisecond),
+			want: defaultRedisBlockWaitFallback,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := NewRedisServer(nil, "", nil, nil, nil, nil)
+			if tc.opt != nil {
+				tc.opt(server)
+			}
+			if server.blockWaitFallback != tc.want {
+				t.Fatalf("blockWaitFallback = %v, want %v", server.blockWaitFallback, tc.want)
+			}
+		})
+	}
+}

--- a/adapter/redis_stream_cmds.go
+++ b/adapter/redis_stream_cmds.go
@@ -1337,7 +1337,7 @@ func (r *RedisServer) xreadBusyPoll(conn redcon.Conn, req xreadRequest, deadline
 		// in handlerCtx, so it would cancel-on-call too — but routing
 		// through isXReadIterCtxError silently translates that into an
 		// empty iteration and the loop would otherwise wait at
-		// redisBlockWaitFallback cadence until the deadline.
+		// the configured block fallback cadence until the deadline.
 		if handlerCtx.Err() != nil {
 			conn.WriteNull()
 			return
@@ -1397,7 +1397,7 @@ func (r *RedisServer) xreadBusyPoll(conn redcon.Conn, req xreadRequest, deadline
 			conn.WriteNull()
 			return
 		}
-		waitForBlockedCommandUpdate(handlerCtx, w, deadline)
+		waitForBlockedCommandUpdate(handlerCtx, w, deadline, r.blockWaitFallback)
 	}
 }
 

--- a/adapter/redis_zset_cmds.go
+++ b/adapter/redis_zset_cmds.go
@@ -1245,7 +1245,7 @@ func (r *RedisServer) bzpopminWaitLoop(conn redcon.Conn, keys [][]byte, deadline
 	// full, starving the fallback timer and letting a wrongType
 	// write on a co-registered key (multi-key BZPOPMIN) go
 	// undetected for the entire BLOCK window. Demoting `fast` back
-	// to false after redisBlockWaitFallback elapses since the last
+	// to false after the configured block fallback elapses since the last
 	// full check restores the #666 ceiling: WRONGTYPE on any
 	// registered key surfaces within ~one fallback interval
 	// regardless of signal rate. See
@@ -1275,8 +1275,8 @@ func (r *RedisServer) bzpopminWaitLoop(conn redcon.Conn, keys [][]byte, deadline
 			conn.WriteNull()
 			return
 		}
-		signaled := waitForBlockedCommandUpdate(handlerCtx, w, deadline)
-		fast = signaled && time.Since(lastFullCheck) < redisBlockWaitFallback
+		signaled := waitForBlockedCommandUpdate(handlerCtx, w, deadline, r.blockWaitFallback)
+		fast = signaled && time.Since(lastFullCheck) < r.blockWaitFallback
 	}
 }
 
@@ -1325,8 +1325,11 @@ func (r *RedisServer) bzpopminTryAllKeys(conn redcon.Conn, keys [][]byte, fast b
 // because writes that bypass fast-safe Signal (Lua flush, follower-applied
 // entries, wrongType-introducing commands) may be observable only through those
 // paths.
-func waitForBlockedCommandUpdate(handlerCtx context.Context, waiter *keyWaiter, deadline time.Time) bool {
-	fallback := redisBlockWaitFallback
+func waitForBlockedCommandUpdate(handlerCtx context.Context, waiter *keyWaiter, deadline time.Time, fallbackInterval time.Duration) bool {
+	fallback := fallbackInterval
+	if fallback <= 0 {
+		fallback = defaultRedisBlockWaitFallback
+	}
 	if remaining := time.Until(deadline); remaining < fallback {
 		fallback = remaining
 	}

--- a/adapter/redis_zset_cmds.go
+++ b/adapter/redis_zset_cmds.go
@@ -1247,7 +1247,7 @@ func (r *RedisServer) bzpopminWaitLoop(conn redcon.Conn, keys [][]byte, deadline
 	// undetected for the entire BLOCK window. Demoting `fast` back
 	// to false after redisBlockWaitFallback elapses since the last
 	// full check restores the #666 ceiling: WRONGTYPE on any
-	// registered key surfaces within ~one fallback interval (100 ms)
+	// registered key surfaces within ~one fallback interval
 	// regardless of signal rate. See
 	// TestRedis_BZPopMinDetectsWrongTypeUnderSignalLoad for the
 	// regression scenario.

--- a/adapter/test_util.go
+++ b/adapter/test_util.go
@@ -54,6 +54,10 @@ const (
 	leaderChurnRetryTimeout = 5 * time.Second
 	// leaderChurnRetryInterval is the poll interval between retries.
 	leaderChurnRetryInterval = 50 * time.Millisecond
+
+	// testRedisBlockWaitFallback preserves the short wait-loop fallback in
+	// integration tests while production defaults to a coarser interval.
+	testRedisBlockWaitFallback = 100 * time.Millisecond
 )
 
 func newTestFactory() raftengine.Factory {
@@ -654,6 +658,7 @@ func setupNodes(t *testing.T, ctx context.Context, n int, ports []portsAdress) (
 		go func() { _ = dc.Run(opsCtx) }()
 		rd := NewRedisServer(redisSock, port.redisAddress, routedStore, coordinator, leaderRedisMap, relay,
 			WithRedisCompactor(dc),
+			WithRedisBlockWaitFallback(testRedisBlockWaitFallback),
 		)
 		go func(server *RedisServer) {
 			assert.NoError(t, server.Run())


### PR DESCRIPTION
## Summary
- increase the Redis blocking-command fallback interval from 100ms to 250ms to reduce full key-type scan pressure from idle BZPOPMIN/XREAD wait loops
- keep the fallback below common sub-second BLOCK budgets, and keep signal-driven ZADD/XADD wakeups immediate
- make the fallback configurable so integration tests can retain a shorter cadence without forcing production to scan as often

## Runtime evidence
- Redis proxy pool pending stayed at 0 while async drops continued, so the remaining bottleneck was not connection checkout
- post-deploy CPU profile moved from registry decode error allocation to BZPOPMIN/XREAD key-type scans
- leader CPU dropped after the registry fast path, but proxy drops still increased with write queue depth around 1k+, requiring this follow-up

## Validation
- go test ./adapter -run 'TestRedis_BZPopMin|TestRedis_StreamXRead|TestKeyWaiterRegistry|TestCommandGetKeys_BZPOPMIN' -count=1
- golangci-lint run ./adapter --timeout=5m

Author: bootjp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Redisのブロッキングコマンドにおける待機フォールバック間隔を設定できるようになりました。
  - デフォルト値を維持しつつ、環境や用途に応じて待機間隔を調整できます。

- **改善**
  - ストリームやソート済みセットの待機処理が、設定された間隔とブロック残り時間に応じて動作するようになりました。
  - 接続終了時やデータ更新時の待機解除が、より適切なタイミングで行われます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->