### PR TITLE
Reduce Redis blocking replay pressure

### DIFF
--- a/proxy/blocking.go
+++ b/proxy/blocking.go
@@ -52,3 +52,7 @@ func parseBlockingMillisecondsArg(raw []byte) time.Duration {
 	}
 	return time.Duration(millis) * time.Millisecond
 }
+
+func shouldReplayBlockingToSecondary(cmd string) bool {
+	return !strings.EqualFold(cmd, "XREAD")
+}

--- a/proxy/dualwrite.go
+++ b/proxy/dualwrite.go
@@ -297,8 +297,9 @@ func (d *DualWriter) Read(ctx context.Context, cmd string, args [][]byte) (any, 
 	return resp, err //nolint:wrapcheck // redis.Nil must pass through unwrapped for callers to detect nil replies
 }
 
-// Blocking forwards a blocking command to the primary only.
-// Optionally sends a short-timeout version to secondary for warmup.
+// Blocking forwards a blocking command to the primary. Read-only blocking
+// commands are not replayed to the secondary; mutating blocking commands keep a
+// bounded secondary replay so the secondary observes the same consumption.
 // cmd must be the pre-uppercased command name.
 func (d *DualWriter) Blocking(ctx context.Context, cmd string, args [][]byte) (any, error) {
 	iArgs := bytesArgsToInterfaces(args)
@@ -320,8 +321,7 @@ func (d *DualWriter) Blocking(ctx context.Context, cmd string, args [][]byte) (a
 	}
 	d.metrics.CommandTotal.WithLabelValues(cmd, d.primary.Name(), "ok").Inc()
 
-	// Warmup: send to secondary with short timeout (fire-and-forget, bounded)
-	if d.hasSecondaryWrite() {
+	if d.hasSecondaryWrite() && shouldReplayBlockingToSecondary(cmd) {
 		d.goWrite(func(ctx context.Context) {
 			sCtx, cancel := context.WithTimeout(ctx, time.Second)
 			defer cancel()

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -636,6 +636,62 @@ func TestDualWriter_Blocking_UsesTimeoutAwareBackend(t *testing.T) {
 	assert.Equal(t, []any{[]byte("BZPOPMIN"), []byte("queue"), []byte("5")}, primary.args)
 }
 
+func TestDualWriter_Blocking_ReplaysMutatingBlockingCommand(t *testing.T) {
+	primary := &timeoutCapturingBackend{
+		name:        "primary",
+		returnValue: []any{"queue", "job-1", "12.5"},
+	}
+	secondary := newMockBackend("secondary")
+
+	metrics := newTestMetrics()
+	d := NewDualWriter(
+		primary,
+		secondary,
+		ProxyConfig{Mode: ModeDualWrite, SecondaryTimeout: time.Second},
+		metrics,
+		newTestSentry(),
+		testLogger,
+	)
+
+	resp, err := d.Blocking(context.Background(), "BZPOPMIN", [][]byte{[]byte("BZPOPMIN"), []byte("queue"), []byte("5")})
+	assert.NoError(t, err)
+	assert.Equal(t, []any{"queue", "job-1", "12.5"}, resp)
+	d.Close()
+
+	assert.Equal(t, 1, secondary.CallCount())
+	secondary.mu.Lock()
+	got := append([]any(nil), secondary.calls[0]...)
+	secondary.mu.Unlock()
+	assert.Equal(t, []any{[]byte("BZPOPMIN"), []byte("queue"), []byte("5")}, got)
+}
+
+func TestDualWriter_Blocking_DoesNotReplayXRead(t *testing.T) {
+	primary := &timeoutCapturingBackend{
+		name:        "primary",
+		returnValue: []any{"stream-result"},
+	}
+	secondary := newMockBackend("secondary")
+
+	metrics := newTestMetrics()
+	d := NewDualWriter(
+		primary,
+		secondary,
+		ProxyConfig{Mode: ModeDualWrite, SecondaryTimeout: time.Second},
+		metrics,
+		newTestSentry(),
+		testLogger,
+	)
+
+	resp, err := d.Blocking(context.Background(), "XREAD", [][]byte{
+		[]byte("XREAD"), []byte("BLOCK"), []byte("1000"), []byte("STREAMS"), []byte("jobs"), []byte("0"),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, []any{"stream-result"}, resp)
+	d.Close()
+
+	assert.Equal(t, 0, secondary.CallCount())
+}
+
 func TestDualWriter_GoAsync_QueuesBurstBeforeDropping(t *testing.T) {
 	primary := newMockBackend("primary")
 	primary.doFunc = makeCmd("OK", nil)


### PR DESCRIPTION
Author: bootjp

## Summary
- stop replaying read-only XREAD BLOCK calls to the secondary backend
- keep bounded replay for mutating blocking commands such as BZPOP/XREADGROUP
- add coverage for blocking replay behavior

## Risk
- changes secondary replay behavior for XREAD BLOCK only; mutating blocking commands continue to replay to preserve secondary consumption state

## Tests
- go test ./proxy -run 'TestDualWriter_Blocking|TestBlockingCommandTimeout|TestClassifyCommand' -count=1\n- go test ./proxy -count=1\n- go test ./cmd/redis-proxy -count=1\n- golangci-lint run ./proxy ./cmd/redis-proxy --timeout=5m