### PR TITLE
Retry Redis BZPOP secondary replay

### DIFF
--- a/proxy/blocking.go
+++ b/proxy/blocking.go
@@ -56,3 +56,24 @@ func parseBlockingMillisecondsArg(raw []byte) time.Duration {
 func shouldReplayBlockingToSecondary(cmd string) bool {
 	return !strings.EqualFold(cmd, "XREAD")
 }
+
+func secondaryBlockingReplay(cmd string, resp any) (string, []any, bool) {
+	switch strings.ToUpper(cmd) {
+	case "BZPOPMIN", "BZPOPMAX":
+		key, member, ok := zsetPopKeyMember(resp)
+		if !ok {
+			return "", nil, false
+		}
+		return "ZREM", []any{"ZREM", key, member}, true
+	default:
+		return "", nil, false
+	}
+}
+
+func zsetPopKeyMember(resp any) (any, any, bool) {
+	arr, ok := resp.([]any)
+	if !ok || len(arr) < 2 || arr[0] == nil || arr[1] == nil {
+		return nil, nil, false
+	}
+	return arr[0], arr[1], true
+}

--- a/proxy/dualwrite.go
+++ b/proxy/dualwrite.go
@@ -46,6 +46,11 @@ const (
 	// transient admission failures into backpressure without hiding a sustained
 	// overload.
 	maxServerOverloadedRetries = 8
+	// maxNoEffectReplayRetries bounds deterministic replay retries when the
+	// secondary has not observed the producer write yet. With the shared retry
+	// backoff capped at 100ms this covers normal queue reordering without
+	// allowing an unbounded worker leak if the producer write never lands.
+	maxNoEffectReplayRetries = 256
 	// compactedRetryInitialBackoff is the first delay before retrying a secondary
 	// command that failed with a compacted-read error.
 	compactedRetryInitialBackoff = 10 * time.Millisecond
@@ -73,6 +78,8 @@ const (
 // because both layers erase the typed error.
 const readTSCompactedMarker = "read timestamp has been compacted"
 const serverOverloadedMarker = "BUSY server overloaded"
+
+var errSecondaryReplayNoEffect = errors.New("secondary replay produced no effect")
 
 func isReadTSCompactedError(err error) bool {
 	if err == nil {
@@ -321,12 +328,16 @@ func (d *DualWriter) Blocking(ctx context.Context, cmd string, args [][]byte) (a
 	}
 	d.metrics.CommandTotal.WithLabelValues(cmd, d.primary.Name(), "ok").Inc()
 
-	if d.hasSecondaryWrite() && shouldReplayBlockingToSecondary(cmd) {
-		d.goWrite(func(ctx context.Context) {
-			sCtx, cancel := context.WithTimeout(ctx, time.Second)
-			defer cancel()
-			d.secondary.Do(sCtx, iArgs...)
-		})
+	if d.hasSecondaryWrite() {
+		if replayCmd, replayArgs, ok := secondaryBlockingReplay(cmd, resp); ok {
+			d.goWrite(func(ctx context.Context) { d.writeSecondaryPositiveInt(ctx, replayCmd, replayArgs) })
+		} else if shouldReplayBlockingToSecondary(cmd) {
+			d.goWrite(func(ctx context.Context) {
+				sCtx, cancel := context.WithTimeout(ctx, time.Second)
+				defer cancel()
+				d.secondary.Do(sCtx, iArgs...)
+			})
+		}
 	}
 
 	return resp, err //nolint:wrapcheck // redis.Nil must pass through unwrapped for callers to detect nil replies
@@ -430,6 +441,66 @@ func (d *DualWriter) writeSecondary(sCtx context.Context, cmd string, iArgs []an
 		return
 	}
 	d.metrics.CommandTotal.WithLabelValues(cmd, d.secondary.Name(), "ok").Inc()
+}
+
+func (d *DualWriter) writeSecondaryPositiveInt(sCtx context.Context, cmd string, iArgs []any) {
+	start := time.Now()
+
+	backoff := compactedRetryInitialBackoff
+	var sErr error
+	var attempt int
+	for ; ; attempt++ {
+		var resp any
+		result := d.secondary.Do(sCtx, iArgs...)
+		resp, sErr = result.Result()
+		if sErr == nil {
+			if n, ok := redisInteger(resp); ok && n > 0 {
+				elapsed := time.Since(start)
+				d.metrics.CommandDuration.WithLabelValues(cmd, d.secondary.Name()).Observe(elapsed.Seconds())
+				d.metrics.CommandTotal.WithLabelValues(cmd, d.secondary.Name(), "ok").Inc()
+				return
+			}
+			sErr = errSecondaryReplayNoEffect
+		}
+
+		retryReason, retryLimit := secondaryRetryReasonAndLimit(cmd, sErr)
+		if errors.Is(sErr, errSecondaryReplayNoEffect) {
+			retryReason = "no_effect"
+			retryLimit = maxNoEffectReplayRetries
+		}
+		if retryReason == "" {
+			break
+		}
+		if attempt >= retryLimit {
+			break
+		}
+		d.logger.Debug("retrying secondary write",
+			"cmd", cmd, "reason", retryReason, "attempt", attempt+1, "backoff", backoff, "err", sErr)
+		if !waitCompactedRetryBackoff(sCtx, backoff) {
+			break
+		}
+		backoff = nextCompactedRetryBackoff(backoff)
+	}
+
+	elapsed := time.Since(start)
+	d.metrics.CommandDuration.WithLabelValues(cmd, d.secondary.Name()).Observe(elapsed.Seconds())
+	d.recordSecondaryWriteFailure(cmd, iArgs, elapsed, attempt+1, false, sErr)
+}
+
+func redisInteger(resp any) (int64, bool) {
+	switch v := resp.(type) {
+	case int:
+		return int64(v), true
+	case int64:
+		return v, true
+	case uint64:
+		if v > uint64(1<<63-1) {
+			return 0, false
+		}
+		return int64(v), true
+	default:
+		return 0, false
+	}
 }
 
 func (d *DualWriter) writeSecondaryPipeline(sCtx context.Context, cmds [][]any) {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -636,10 +636,84 @@ func TestDualWriter_Blocking_UsesTimeoutAwareBackend(t *testing.T) {
 	assert.Equal(t, []any{[]byte("BZPOPMIN"), []byte("queue"), []byte("5")}, primary.args)
 }
 
-func TestDualWriter_Blocking_ReplaysMutatingBlockingCommand(t *testing.T) {
+func TestDualWriter_Blocking_ReplaysBZPopAsZRem(t *testing.T) {
+	for _, tc := range []struct {
+		cmd string
+	}{
+		{cmd: "BZPOPMIN"},
+		{cmd: "BZPOPMAX"},
+	} {
+		t.Run(tc.cmd, func(t *testing.T) {
+			primary := &timeoutCapturingBackend{
+				name:        "primary",
+				returnValue: []any{"queue", "job-1", "12.5"},
+			}
+			secondary := newMockBackend("secondary")
+			secondary.doFunc = makeCmd(int64(1), nil)
+
+			metrics := newTestMetrics()
+			d := NewDualWriter(
+				primary,
+				secondary,
+				ProxyConfig{Mode: ModeDualWrite, SecondaryTimeout: time.Second},
+				metrics,
+				newTestSentry(),
+				testLogger,
+			)
+
+			resp, err := d.Blocking(context.Background(), tc.cmd, [][]byte{[]byte(tc.cmd), []byte("queue"), []byte("5")})
+			assert.NoError(t, err)
+			assert.Equal(t, []any{"queue", "job-1", "12.5"}, resp)
+			d.Close()
+
+			assert.Equal(t, 1, secondary.CallCount())
+			secondary.mu.Lock()
+			got := append([]any(nil), secondary.calls[0]...)
+			secondary.mu.Unlock()
+			assert.Equal(t, []any{"ZREM", "queue", "job-1"}, got)
+		})
+	}
+}
+
+func TestDualWriter_Blocking_RetriesBZPopReplayUntilRemoved(t *testing.T) {
 	primary := &timeoutCapturingBackend{
 		name:        "primary",
 		returnValue: []any{"queue", "job-1", "12.5"},
+	}
+	secondary := newMockBackend("secondary")
+	var attempts atomic.Int32
+	secondary.doFunc = func(ctx context.Context, args ...any) *redis.Cmd {
+		cmd := redis.NewCmd(ctx, args...)
+		if attempts.Add(1) == 1 {
+			cmd.SetVal(int64(0))
+			return cmd
+		}
+		cmd.SetVal(int64(1))
+		return cmd
+	}
+
+	metrics := newTestMetrics()
+	d := NewDualWriter(
+		primary,
+		secondary,
+		ProxyConfig{Mode: ModeDualWrite, SecondaryTimeout: time.Second},
+		metrics,
+		newTestSentry(),
+		testLogger,
+	)
+
+	_, err := d.Blocking(context.Background(), "BZPOPMIN", [][]byte{[]byte("BZPOPMIN"), []byte("queue"), []byte("5")})
+	assert.NoError(t, err)
+	d.Close()
+
+	assert.Equal(t, int32(2), attempts.Load())
+	assert.Equal(t, 2, secondary.CallCount())
+}
+
+func TestDualWriter_Blocking_ReplaysXReadGroup(t *testing.T) {
+	primary := &timeoutCapturingBackend{
+		name:        "primary",
+		returnValue: []any{"stream-result"},
 	}
 	secondary := newMockBackend("secondary")
 
@@ -653,16 +727,20 @@ func TestDualWriter_Blocking_ReplaysMutatingBlockingCommand(t *testing.T) {
 		testLogger,
 	)
 
-	resp, err := d.Blocking(context.Background(), "BZPOPMIN", [][]byte{[]byte("BZPOPMIN"), []byte("queue"), []byte("5")})
+	args := [][]byte{
+		[]byte("XREADGROUP"), []byte("GROUP"), []byte("g"), []byte("c"),
+		[]byte("BLOCK"), []byte("1000"), []byte("STREAMS"), []byte("jobs"), []byte(">"),
+	}
+	resp, err := d.Blocking(context.Background(), "XREADGROUP", args)
 	assert.NoError(t, err)
-	assert.Equal(t, []any{"queue", "job-1", "12.5"}, resp)
+	assert.Equal(t, []any{"stream-result"}, resp)
 	d.Close()
 
 	assert.Equal(t, 1, secondary.CallCount())
 	secondary.mu.Lock()
 	got := append([]any(nil), secondary.calls[0]...)
 	secondary.mu.Unlock()
-	assert.Equal(t, []any{[]byte("BZPOPMIN"), []byte("queue"), []byte("5")}, got)
+	assert.Equal(t, bytesArgsToInterfaces(args), got)
 }
 
 func TestDualWriter_Blocking_DoesNotReplayXRead(t *testing.T) {


### PR DESCRIPTION
Author: bootjp

## Summary
- replay BZPOPMIN/BZPOPMAX as ZREM instead of a blocking secondary pop
- retry the ZREM when it removes 0 rows so replay ordering can wait for preceding secondary writes
- keep XREAD skipped and keep other mutating blocking commands on bounded replay

## Risk
- changes BZPOP secondary replay from blocking pop to deterministic member removal with retry; failure is reported if the matching secondary member never appears

## Tests
- go test ./proxy -run 'TestDualWriter_Blocking|TestBlockingCommandTimeout|TestClassifyCommand' -count=1\n- go test ./proxy -count=1\n- go test ./cmd/redis-proxy -count=1\n- golangci-lint run ./proxy ./cmd/redis-proxy --timeout=5m