### PR TITLE
Isolate Redis blocking replay workers

### DIFF
--- a/cmd/redis-proxy/main.go
+++ b/cmd/redis-proxy/main.go
@@ -291,7 +291,11 @@ func defaultSecondaryScriptConcurrency(writeConcurrency int) int {
 }
 
 func defaultSecondaryBlockingReplayConcurrency(poolSize, writeConcurrency int) int {
-	return atLeastOne(poolSize - writeConcurrency)
+	remaining := poolSize - writeConcurrency
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
 }
 
 func atLeastOne(n int) int {

--- a/cmd/redis-proxy/main.go
+++ b/cmd/redis-proxy/main.go
@@ -38,8 +38,10 @@ func run() error {
 	elasticKVPoolSize := proxy.DefaultElasticKVBackendOptions().PoolSize
 	secondaryWriteConcurrency := 0
 	secondaryScriptConcurrency := 0
+	secondaryBlockingReplayConcurrency := 0
 	secondaryWriteQueueSize := 0
 	secondaryScriptQueueSize := 0
+	secondaryBlockingReplayQueueSize := 0
 
 	flag.StringVar(&cfg.ListenAddr, "listen", cfg.ListenAddr, "Proxy listen address")
 	flag.StringVar(&cfg.PrimaryAddr, "primary", cfg.PrimaryAddr, "Primary (Redis) address")
@@ -52,8 +54,10 @@ func run() error {
 	flag.IntVar(&elasticKVPoolSize, "elastickv-pool-size", elasticKVPoolSize, "ElasticKV backend connection pool size")
 	flag.IntVar(&secondaryWriteConcurrency, "secondary-write-concurrency", secondaryWriteConcurrency, "Maximum concurrent asynchronous secondary writes including scripts (0 = half of secondary backend pool size)")
 	flag.IntVar(&secondaryScriptConcurrency, "secondary-script-concurrency", secondaryScriptConcurrency, "Maximum concurrent asynchronous secondary Lua-script writes within the write limit (0 = half of secondary write concurrency)")
+	flag.IntVar(&secondaryBlockingReplayConcurrency, "secondary-blocking-replay-concurrency", secondaryBlockingReplayConcurrency, "Maximum concurrent asynchronous secondary mutating blocking-command replays (0 = remaining secondary backend pool capacity after writes)")
 	flag.IntVar(&secondaryWriteQueueSize, "secondary-write-queue-size", secondaryWriteQueueSize, "Maximum queued asynchronous secondary writes (0 = derived from write concurrency)")
 	flag.IntVar(&secondaryScriptQueueSize, "secondary-script-queue-size", secondaryScriptQueueSize, "Maximum queued asynchronous secondary Lua-script writes (0 = derived from script concurrency)")
+	flag.IntVar(&secondaryBlockingReplayQueueSize, "secondary-blocking-replay-queue-size", secondaryBlockingReplayQueueSize, "Maximum queued asynchronous secondary mutating blocking-command replays (0 = derived from blocking replay concurrency)")
 	flag.StringVar(&modeStr, "mode", "dual-write", "Proxy mode: redis-only, dual-write, dual-write-shadow, elastickv-primary, elastickv-only")
 	flag.DurationVar(&cfg.SecondaryTimeout, "secondary-timeout", cfg.SecondaryTimeout, "Secondary write timeout")
 	flag.DurationVar(&cfg.ShadowTimeout, "shadow-timeout", cfg.ShadowTimeout, "Shadow read timeout")
@@ -63,14 +67,16 @@ func run() error {
 	flag.StringVar(&cfg.MetricsAddr, "metrics", cfg.MetricsAddr, "Prometheus metrics address")
 	flag.Parse()
 
-	mode, resolvedWriteConcurrency, resolvedScriptConcurrency, err := resolveRuntimeOptions(
+	mode, resolvedWriteConcurrency, resolvedScriptConcurrency, resolvedBlockingReplayConcurrency, err := resolveRuntimeOptions(
 		modeStr,
 		primaryPoolSize,
 		elasticKVPoolSize,
 		secondaryWriteConcurrency,
 		secondaryScriptConcurrency,
+		secondaryBlockingReplayConcurrency,
 		secondaryWriteQueueSize,
 		secondaryScriptQueueSize,
+		secondaryBlockingReplayQueueSize,
 	)
 	if err != nil {
 		return err
@@ -78,8 +84,10 @@ func run() error {
 	cfg.Mode = mode
 	cfg.SecondaryWriteConcurrency = resolvedWriteConcurrency
 	cfg.SecondaryScriptConcurrency = resolvedScriptConcurrency
+	cfg.SecondaryBlockingReplayConcurrency = resolvedBlockingReplayConcurrency
 	cfg.SecondaryWriteQueueCapacity = secondaryWriteQueueSize
 	cfg.SecondaryScriptQueueCapacity = secondaryScriptQueueSize
+	cfg.SecondaryBlockingReplayQueueCapacity = secondaryBlockingReplayQueueSize
 
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
@@ -161,27 +169,30 @@ func run() error {
 func resolveRuntimeOptions(
 	modeStr string,
 	primaryPoolSize, elasticKVPoolSize int,
-	secondaryWriteConcurrency, secondaryScriptConcurrency int,
-	secondaryWriteQueueSize, secondaryScriptQueueSize int,
-) (proxy.ProxyMode, int, int, error) {
+	secondaryWriteConcurrency, secondaryScriptConcurrency, secondaryBlockingReplayConcurrency int,
+	secondaryWriteQueueSize, secondaryScriptQueueSize, secondaryBlockingReplayQueueSize int,
+) (proxy.ProxyMode, int, int, int, error) {
 	mode, err := parseRuntimeOptions(
 		modeStr,
 		primaryPoolSize,
 		elasticKVPoolSize,
 		secondaryWriteConcurrency,
 		secondaryScriptConcurrency,
+		secondaryBlockingReplayConcurrency,
 		secondaryWriteQueueSize,
 		secondaryScriptQueueSize,
+		secondaryBlockingReplayQueueSize,
 	)
 	if err != nil {
-		return 0, 0, 0, err
+		return 0, 0, 0, 0, err
 	}
-	writeConcurrency, scriptConcurrency := deriveSecondaryConcurrency(
+	writeConcurrency, scriptConcurrency, blockingReplayConcurrency := deriveSecondaryConcurrency(
 		mode,
 		primaryPoolSize,
 		elasticKVPoolSize,
 		secondaryWriteConcurrency,
 		secondaryScriptConcurrency,
+		secondaryBlockingReplayConcurrency,
 	)
 	if err := validateSecondaryConcurrency(
 		mode,
@@ -189,17 +200,18 @@ func resolveRuntimeOptions(
 		elasticKVPoolSize,
 		writeConcurrency,
 		scriptConcurrency,
+		blockingReplayConcurrency,
 	); err != nil {
-		return 0, 0, 0, err
+		return 0, 0, 0, 0, err
 	}
-	return mode, writeConcurrency, scriptConcurrency, nil
+	return mode, writeConcurrency, scriptConcurrency, blockingReplayConcurrency, nil
 }
 
 func parseRuntimeOptions(
 	modeStr string,
 	primaryPoolSize, elasticKVPoolSize int,
-	secondaryWriteConcurrency, secondaryScriptConcurrency int,
-	secondaryWriteQueueSize, secondaryScriptQueueSize int,
+	secondaryWriteConcurrency, secondaryScriptConcurrency, secondaryBlockingReplayConcurrency int,
+	secondaryWriteQueueSize, secondaryScriptQueueSize, secondaryBlockingReplayQueueSize int,
 ) (proxy.ProxyMode, error) {
 	mode, ok := proxy.ParseProxyMode(modeStr)
 	if !ok {
@@ -217,16 +229,22 @@ func parseRuntimeOptions(
 	if secondaryScriptConcurrency < 0 {
 		return 0, fmt.Errorf("secondary-script-concurrency must be non-negative: %d", secondaryScriptConcurrency)
 	}
+	if secondaryBlockingReplayConcurrency < 0 {
+		return 0, fmt.Errorf("secondary-blocking-replay-concurrency must be non-negative: %d", secondaryBlockingReplayConcurrency)
+	}
 	if secondaryWriteQueueSize < 0 {
 		return 0, fmt.Errorf("secondary-write-queue-size must be non-negative: %d", secondaryWriteQueueSize)
 	}
 	if secondaryScriptQueueSize < 0 {
 		return 0, fmt.Errorf("secondary-script-queue-size must be non-negative: %d", secondaryScriptQueueSize)
 	}
+	if secondaryBlockingReplayQueueSize < 0 {
+		return 0, fmt.Errorf("secondary-blocking-replay-queue-size must be non-negative: %d", secondaryBlockingReplayQueueSize)
+	}
 	return mode, nil
 }
 
-func validateSecondaryConcurrency(mode proxy.ProxyMode, primaryPoolSize, elasticKVPoolSize, writeConcurrency, scriptConcurrency int) error {
+func validateSecondaryConcurrency(mode proxy.ProxyMode, primaryPoolSize, elasticKVPoolSize, writeConcurrency, scriptConcurrency, blockingReplayConcurrency int) error {
 	if mode == proxy.ModeRedisOnly || mode == proxy.ModeElasticKVOnly {
 		return nil
 	}
@@ -237,17 +255,24 @@ func validateSecondaryConcurrency(mode proxy.ProxyMode, primaryPoolSize, elastic
 	if scriptConcurrency > writeConcurrency {
 		return fmt.Errorf("secondary-script-concurrency %d exceeds secondary-write-concurrency %d", scriptConcurrency, writeConcurrency)
 	}
+	if writeConcurrency+blockingReplayConcurrency > poolSize {
+		return fmt.Errorf("secondary-write-concurrency %d plus secondary-blocking-replay-concurrency %d exceeds secondary backend pool size %d", writeConcurrency, blockingReplayConcurrency, poolSize)
+	}
 	return nil
 }
 
-func deriveSecondaryConcurrency(mode proxy.ProxyMode, primaryPoolSize, elasticKVPoolSize, writeConcurrency, scriptConcurrency int) (int, int) {
+func deriveSecondaryConcurrency(mode proxy.ProxyMode, primaryPoolSize, elasticKVPoolSize, writeConcurrency, scriptConcurrency, blockingReplayConcurrency int) (int, int, int) {
+	poolSize := secondaryBackendPoolSize(mode, primaryPoolSize, elasticKVPoolSize)
 	if writeConcurrency == 0 {
-		writeConcurrency = defaultSecondaryWriteConcurrency(secondaryBackendPoolSize(mode, primaryPoolSize, elasticKVPoolSize))
+		writeConcurrency = defaultSecondaryWriteConcurrency(poolSize)
 	}
 	if scriptConcurrency == 0 {
 		scriptConcurrency = defaultSecondaryScriptConcurrency(writeConcurrency)
 	}
-	return writeConcurrency, scriptConcurrency
+	if blockingReplayConcurrency == 0 {
+		blockingReplayConcurrency = defaultSecondaryBlockingReplayConcurrency(poolSize, writeConcurrency)
+	}
+	return writeConcurrency, scriptConcurrency, blockingReplayConcurrency
 }
 
 func secondaryBackendPoolSize(mode proxy.ProxyMode, primaryPoolSize, elasticKVPoolSize int) int {
@@ -263,6 +288,10 @@ func defaultSecondaryWriteConcurrency(poolSize int) int {
 
 func defaultSecondaryScriptConcurrency(writeConcurrency int) int {
 	return atLeastOne(writeConcurrency / secondaryConcurrencyDivisor)
+}
+
+func defaultSecondaryBlockingReplayConcurrency(poolSize, writeConcurrency int) int {
+	return atLeastOne(poolSize - writeConcurrency)
 }
 
 func atLeastOne(n int) int {

--- a/cmd/redis-proxy/main_test.go
+++ b/cmd/redis-proxy/main_test.go
@@ -38,6 +38,7 @@ func TestParseRuntimeOptionsRejectsNegativeSecondaryQueueSize(t *testing.T) {
 
 func TestValidateSecondaryConcurrency(t *testing.T) {
 	require.NoError(t, validateSecondaryConcurrency(proxy.ModeDualWrite, 128, 8, 4, 2, 4))
+	require.NoError(t, validateSecondaryConcurrency(proxy.ModeDualWrite, 128, 1, 1, 1, 0))
 	require.NoError(t, validateSecondaryConcurrency(proxy.ModeRedisOnly, 1, 1, 100, 100, 100))
 	require.NoError(t, validateSecondaryConcurrency(proxy.ModeElasticKVOnly, 1, 1, 100, 100, 100))
 
@@ -117,13 +118,13 @@ func TestDeriveSecondaryConcurrency(t *testing.T) {
 			wantBlockingConcurrency: 6,
 		},
 		{
-			name:                    "small pool stays usable",
+			name:                    "small pool disables blocking replay",
 			mode:                    proxy.ModeDualWrite,
 			primaryPoolSize:         128,
 			elasticKVPoolSize:       1,
 			wantWriteConcurrency:    1,
 			wantScriptConcurrency:   1,
-			wantBlockingConcurrency: 1,
+			wantBlockingConcurrency: 0,
 		},
 	}
 

--- a/cmd/redis-proxy/main_test.go
+++ b/cmd/redis-proxy/main_test.go
@@ -9,114 +9,137 @@ import (
 )
 
 func TestParseRuntimeOptionsRejectsNegativeSecondaryConcurrency(t *testing.T) {
-	_, err := parseRuntimeOptions("dual-write", 128, 4, -1, 0, 0, 0)
+	_, err := parseRuntimeOptions("dual-write", 128, 4, -1, 0, 0, 0, 0, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "secondary-write-concurrency")
 
-	_, err = parseRuntimeOptions("dual-write", 128, 4, 0, -1, 0, 0)
+	_, err = parseRuntimeOptions("dual-write", 128, 4, 0, -1, 0, 0, 0, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "secondary-script-concurrency")
+
+	_, err = parseRuntimeOptions("dual-write", 128, 4, 0, 0, -1, 0, 0, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secondary-blocking-replay-concurrency")
 }
 
 func TestParseRuntimeOptionsRejectsNegativeSecondaryQueueSize(t *testing.T) {
-	_, err := parseRuntimeOptions("dual-write", 128, 4, 0, 0, -1, 0)
+	_, err := parseRuntimeOptions("dual-write", 128, 4, 0, 0, 0, -1, 0, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "secondary-write-queue-size")
 
-	_, err = parseRuntimeOptions("dual-write", 128, 4, 0, 0, 0, -1)
+	_, err = parseRuntimeOptions("dual-write", 128, 4, 0, 0, 0, 0, -1, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "secondary-script-queue-size")
+
+	_, err = parseRuntimeOptions("dual-write", 128, 4, 0, 0, 0, 0, 0, -1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secondary-blocking-replay-queue-size")
 }
 
 func TestValidateSecondaryConcurrency(t *testing.T) {
-	require.NoError(t, validateSecondaryConcurrency(proxy.ModeDualWrite, 128, 8, 4, 2))
-	require.NoError(t, validateSecondaryConcurrency(proxy.ModeRedisOnly, 1, 1, 100, 100))
-	require.NoError(t, validateSecondaryConcurrency(proxy.ModeElasticKVOnly, 1, 1, 100, 100))
+	require.NoError(t, validateSecondaryConcurrency(proxy.ModeDualWrite, 128, 8, 4, 2, 4))
+	require.NoError(t, validateSecondaryConcurrency(proxy.ModeRedisOnly, 1, 1, 100, 100, 100))
+	require.NoError(t, validateSecondaryConcurrency(proxy.ModeElasticKVOnly, 1, 1, 100, 100, 100))
 
-	err := validateSecondaryConcurrency(proxy.ModeDualWrite, 128, 4, 5, 1)
+	err := validateSecondaryConcurrency(proxy.ModeDualWrite, 128, 4, 5, 1, 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "pool size")
 
-	err = validateSecondaryConcurrency(proxy.ModeDualWrite, 128, 8, 4, 5)
+	err = validateSecondaryConcurrency(proxy.ModeDualWrite, 128, 8, 4, 5, 4)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "secondary-write-concurrency")
+
+	err = validateSecondaryConcurrency(proxy.ModeDualWrite, 128, 8, 5, 2, 4)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secondary-blocking-replay-concurrency")
 }
 
 func TestDeriveSecondaryConcurrency(t *testing.T) {
 	tests := []struct {
-		name                  string
-		mode                  proxy.ProxyMode
-		primaryPoolSize       int
-		elasticKVPoolSize     int
-		writeConcurrency      int
-		scriptConcurrency     int
-		wantWriteConcurrency  int
-		wantScriptConcurrency int
+		name                    string
+		mode                    proxy.ProxyMode
+		primaryPoolSize         int
+		elasticKVPoolSize       int
+		writeConcurrency        int
+		scriptConcurrency       int
+		blockingConcurrency     int
+		wantWriteConcurrency    int
+		wantScriptConcurrency   int
+		wantBlockingConcurrency int
 	}{
 		{
-			name:                  "dual write derives from ElasticKV pool",
-			mode:                  proxy.ModeDualWrite,
-			primaryPoolSize:       128,
-			elasticKVPoolSize:     4,
-			wantWriteConcurrency:  2,
-			wantScriptConcurrency: 1,
+			name:                    "dual write derives from ElasticKV pool",
+			mode:                    proxy.ModeDualWrite,
+			primaryPoolSize:         128,
+			elasticKVPoolSize:       4,
+			wantWriteConcurrency:    2,
+			wantScriptConcurrency:   1,
+			wantBlockingConcurrency: 2,
 		},
 		{
-			name:                  "shadow mode derives from ElasticKV pool",
-			mode:                  proxy.ModeDualWriteShadow,
-			primaryPoolSize:       128,
-			elasticKVPoolSize:     8,
-			wantWriteConcurrency:  4,
-			wantScriptConcurrency: 2,
+			name:                    "shadow mode derives from ElasticKV pool",
+			mode:                    proxy.ModeDualWriteShadow,
+			primaryPoolSize:         128,
+			elasticKVPoolSize:       8,
+			wantWriteConcurrency:    4,
+			wantScriptConcurrency:   2,
+			wantBlockingConcurrency: 4,
 		},
 		{
-			name:                  "ElasticKV primary derives from Redis secondary pool",
-			mode:                  proxy.ModeElasticKVPrimary,
-			primaryPoolSize:       128,
-			elasticKVPoolSize:     4,
-			wantWriteConcurrency:  64,
-			wantScriptConcurrency: 32,
+			name:                    "ElasticKV primary derives from Redis secondary pool",
+			mode:                    proxy.ModeElasticKVPrimary,
+			primaryPoolSize:         128,
+			elasticKVPoolSize:       4,
+			wantWriteConcurrency:    64,
+			wantScriptConcurrency:   32,
+			wantBlockingConcurrency: 64,
 		},
 		{
-			name:                  "explicit write keeps derived script",
-			mode:                  proxy.ModeDualWrite,
-			primaryPoolSize:       128,
-			elasticKVPoolSize:     4,
-			writeConcurrency:      5,
-			wantWriteConcurrency:  5,
-			wantScriptConcurrency: 2,
+			name:                    "explicit write keeps derived script",
+			mode:                    proxy.ModeDualWrite,
+			primaryPoolSize:         128,
+			elasticKVPoolSize:       8,
+			writeConcurrency:        5,
+			wantWriteConcurrency:    5,
+			wantScriptConcurrency:   2,
+			wantBlockingConcurrency: 3,
 		},
 		{
-			name:                  "explicit values win",
-			mode:                  proxy.ModeDualWrite,
-			primaryPoolSize:       128,
-			elasticKVPoolSize:     4,
-			writeConcurrency:      5,
-			scriptConcurrency:     3,
-			wantWriteConcurrency:  5,
-			wantScriptConcurrency: 3,
+			name:                    "explicit values win",
+			mode:                    proxy.ModeDualWrite,
+			primaryPoolSize:         128,
+			elasticKVPoolSize:       16,
+			writeConcurrency:        5,
+			scriptConcurrency:       3,
+			blockingConcurrency:     6,
+			wantWriteConcurrency:    5,
+			wantScriptConcurrency:   3,
+			wantBlockingConcurrency: 6,
 		},
 		{
-			name:                  "small pool stays usable",
-			mode:                  proxy.ModeDualWrite,
-			primaryPoolSize:       128,
-			elasticKVPoolSize:     1,
-			wantWriteConcurrency:  1,
-			wantScriptConcurrency: 1,
+			name:                    "small pool stays usable",
+			mode:                    proxy.ModeDualWrite,
+			primaryPoolSize:         128,
+			elasticKVPoolSize:       1,
+			wantWriteConcurrency:    1,
+			wantScriptConcurrency:   1,
+			wantBlockingConcurrency: 1,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			writeConcurrency, scriptConcurrency := deriveSecondaryConcurrency(
+			writeConcurrency, scriptConcurrency, blockingConcurrency := deriveSecondaryConcurrency(
 				tt.mode,
 				tt.primaryPoolSize,
 				tt.elasticKVPoolSize,
 				tt.writeConcurrency,
 				tt.scriptConcurrency,
+				tt.blockingConcurrency,
 			)
 			assert.Equal(t, tt.wantWriteConcurrency, writeConcurrency)
 			assert.Equal(t, tt.wantScriptConcurrency, scriptConcurrency)
+			assert.Equal(t, tt.wantBlockingConcurrency, blockingConcurrency)
 		})
 	}
 }

--- a/proxy/async_queue.go
+++ b/proxy/async_queue.go
@@ -6,8 +6,6 @@ import (
 )
 
 const (
-	asyncDispatcherCount = 3
-
 	asyncQueueWrite    = "write"
 	asyncQueueScript   = "script"
 	asyncQueueBlocking = "blocking"
@@ -24,10 +22,14 @@ type asyncTask struct {
 }
 
 func (d *DualWriter) startAsyncDispatchers() {
-	d.dispatchWG.Add(asyncDispatcherCount)
+	d.dispatchWG.Add(1)
 	go d.dispatchAsyncQueue(d.writeQueue, d.writeQueueSlots, asyncQueueWrite, d.writeSem)
+	d.dispatchWG.Add(1)
 	go d.dispatchAsyncQueue(d.scriptQueue, d.scriptQueueSlots, asyncQueueScript, d.scriptSem, d.writeSem)
-	go d.dispatchAsyncQueue(d.blockingReplayQueue, d.blockingReplayQueueSlots, asyncQueueBlocking, d.blockingReplaySem)
+	if cap(d.blockingReplaySem) > 0 {
+		d.dispatchWG.Add(1)
+		go d.dispatchAsyncQueue(d.blockingReplayQueue, d.blockingReplayQueueSlots, asyncQueueBlocking, d.blockingReplaySem)
+	}
 }
 
 func (d *DualWriter) enqueueAsync(queue chan asyncTask, slots chan struct{}, queueName string, fn func(context.Context)) {

--- a/proxy/async_queue.go
+++ b/proxy/async_queue.go
@@ -6,11 +6,12 @@ import (
 )
 
 const (
-	asyncDispatcherCount = 2
+	asyncDispatcherCount = 3
 
-	asyncQueueWrite  = "write"
-	asyncQueueScript = "script"
-	asyncQueueShadow = "shadow"
+	asyncQueueWrite    = "write"
+	asyncQueueScript   = "script"
+	asyncQueueBlocking = "blocking"
+	asyncQueueShadow   = "shadow"
 
 	asyncDropQueueFull = "queue_full"
 	asyncDropExpired   = "expired"
@@ -26,6 +27,7 @@ func (d *DualWriter) startAsyncDispatchers() {
 	d.dispatchWG.Add(asyncDispatcherCount)
 	go d.dispatchAsyncQueue(d.writeQueue, d.writeQueueSlots, asyncQueueWrite, d.writeSem)
 	go d.dispatchAsyncQueue(d.scriptQueue, d.scriptQueueSlots, asyncQueueScript, d.scriptSem, d.writeSem)
+	go d.dispatchAsyncQueue(d.blockingReplayQueue, d.blockingReplayQueueSlots, asyncQueueBlocking, d.blockingReplaySem)
 }
 
 func (d *DualWriter) enqueueAsync(queue chan asyncTask, slots chan struct{}, queueName string, fn func(context.Context)) {

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -67,7 +67,7 @@ type ProxyConfig struct {
 	// script writes within SecondaryWriteConcurrency. Zero keeps the package default.
 	SecondaryScriptConcurrency int
 	// SecondaryBlockingReplayConcurrency limits concurrent secondary replays for
-	// mutating blocking commands such as BZPOP. Zero keeps the package default.
+	// mutating blocking commands such as BZPOP. Zero disables blocking replays.
 	SecondaryBlockingReplayConcurrency int
 	// SecondaryWriteQueueCapacity bounds queued non-script secondary writes.
 	// Zero derives a capacity from SecondaryWriteConcurrency.
@@ -89,14 +89,15 @@ type ProxyConfig struct {
 // DefaultConfig returns a ProxyConfig with sensible defaults.
 func DefaultConfig() ProxyConfig {
 	return ProxyConfig{
-		ListenAddr:          ":6479",
-		PrimaryAddr:         "localhost:6379",
-		SecondaryAddr:       "localhost:6380",
-		Mode:                ModeDualWrite,
-		SecondaryTimeout:    defaultSecondaryTimeout,
-		ShadowTimeout:       defaultShadowTimeout,
-		SentrySampleRate:    1.0,
-		MetricsAddr:         ":9191",
-		PubSubCompareWindow: defaultPubSubCompareWindow,
+		ListenAddr:                         ":6479",
+		PrimaryAddr:                        "localhost:6379",
+		SecondaryAddr:                      "localhost:6380",
+		Mode:                               ModeDualWrite,
+		SecondaryTimeout:                   defaultSecondaryTimeout,
+		SecondaryBlockingReplayConcurrency: maxBlockingReplayGoroutines,
+		ShadowTimeout:                      defaultShadowTimeout,
+		SentrySampleRate:                   1.0,
+		MetricsAddr:                        ":9191",
+		PubSubCompareWindow:                defaultPubSubCompareWindow,
 	}
 }

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -66,18 +66,24 @@ type ProxyConfig struct {
 	// SecondaryScriptConcurrency limits concurrent asynchronous secondary Lua
 	// script writes within SecondaryWriteConcurrency. Zero keeps the package default.
 	SecondaryScriptConcurrency int
+	// SecondaryBlockingReplayConcurrency limits concurrent secondary replays for
+	// mutating blocking commands such as BZPOP. Zero keeps the package default.
+	SecondaryBlockingReplayConcurrency int
 	// SecondaryWriteQueueCapacity bounds queued non-script secondary writes.
 	// Zero derives a capacity from SecondaryWriteConcurrency.
 	SecondaryWriteQueueCapacity int
 	// SecondaryScriptQueueCapacity bounds queued secondary Lua script writes.
 	// Zero derives a capacity from SecondaryScriptConcurrency.
 	SecondaryScriptQueueCapacity int
-	ShadowTimeout                time.Duration
-	SentryDSN                    string
-	SentryEnv                    string
-	SentrySampleRate             float64
-	MetricsAddr                  string
-	PubSubCompareWindow          time.Duration
+	// SecondaryBlockingReplayQueueCapacity bounds queued secondary blocking
+	// replay work. Zero derives a capacity from SecondaryBlockingReplayConcurrency.
+	SecondaryBlockingReplayQueueCapacity int
+	ShadowTimeout                        time.Duration
+	SentryDSN                            string
+	SentryEnv                            string
+	SentrySampleRate                     float64
+	MetricsAddr                          string
+	PubSubCompareWindow                  time.Duration
 }
 
 // DefaultConfig returns a ProxyConfig with sensible defaults.

--- a/proxy/dualwrite.go
+++ b/proxy/dualwrite.go
@@ -203,7 +203,7 @@ func secondaryScriptConcurrency(cfg ProxyConfig) int {
 }
 
 func secondaryBlockingReplayConcurrency(cfg ProxyConfig) int {
-	return configuredConcurrencyOrDefault(cfg.SecondaryBlockingReplayConcurrency, maxBlockingReplayGoroutines)
+	return cfg.SecondaryBlockingReplayConcurrency
 }
 
 func secondaryWriteQueueCapacity(cfg ProxyConfig) int {
@@ -215,9 +215,13 @@ func secondaryScriptQueueCapacity(cfg ProxyConfig) int {
 }
 
 func secondaryBlockingReplayQueueCapacity(cfg ProxyConfig) int {
+	concurrency := secondaryBlockingReplayConcurrency(cfg)
+	if concurrency <= 0 {
+		return 0
+	}
 	return configuredQueueCapacityOrDefault(
 		cfg.SecondaryBlockingReplayQueueCapacity,
-		secondaryBlockingReplayConcurrency(cfg),
+		concurrency,
 	)
 }
 
@@ -717,6 +721,9 @@ func (d *DualWriter) goScript(fn func(context.Context)) {
 // goBlockingReplay queues fn for bounded secondary replay of mutating blocking
 // commands without consuming the normal secondary write workers.
 func (d *DualWriter) goBlockingReplay(fn func(context.Context)) {
+	if cap(d.blockingReplaySem) == 0 {
+		return
+	}
 	d.enqueueAsync(d.blockingReplayQueue, d.blockingReplayQueueSlots, asyncQueueBlocking, fn)
 }
 

--- a/proxy/dualwrite.go
+++ b/proxy/dualwrite.go
@@ -29,6 +29,10 @@ const (
 	// contention bounded; this is only tolerable in modes where the script write
 	// is targeting the non-authoritative backend.
 	maxScriptWriteGoroutines = 64
+	// maxBlockingReplayGoroutines isolates mutating blocking command replays
+	// from normal secondary writes. Blocking replays may wait for the secondary
+	// to observe a producer write and must not occupy producer write workers.
+	maxBlockingReplayGoroutines = 64
 	// Async queues absorb short bursts without allowing an unavailable or slow
 	// secondary to build an unbounded replay backlog.
 	minAsyncQueueCapacity       = 64
@@ -105,13 +109,16 @@ type DualWriter struct {
 	sentry    *SentryReporter
 	logger    *slog.Logger
 
-	writeSem         chan struct{} // bounds concurrent secondary write goroutines
-	shadowSem        chan struct{} // bounds concurrent shadow read goroutines
-	scriptSem        chan struct{} // bounds concurrent secondary Lua-script write goroutines
-	writeQueue       chan asyncTask
-	scriptQueue      chan asyncTask
-	writeQueueSlots  chan struct{}
-	scriptQueueSlots chan struct{}
+	writeSem                 chan struct{} // bounds concurrent secondary write goroutines
+	shadowSem                chan struct{} // bounds concurrent shadow read goroutines
+	scriptSem                chan struct{} // bounds concurrent secondary Lua-script write goroutines
+	blockingReplaySem        chan struct{} // bounds secondary mutating blocking replays
+	writeQueue               chan asyncTask
+	scriptQueue              chan asyncTask
+	blockingReplayQueue      chan asyncTask
+	writeQueueSlots          chan struct{}
+	scriptQueueSlots         chan struct{}
+	blockingReplayQueueSlots chan struct{}
 
 	dispatchWG    sync.WaitGroup
 	workerWG      sync.WaitGroup
@@ -136,22 +143,25 @@ type DualWriter struct {
 // NewDualWriter creates a DualWriter with the given backends.
 func NewDualWriter(primary, secondary Backend, cfg ProxyConfig, metrics *ProxyMetrics, sentryReporter *SentryReporter, logger *slog.Logger) *DualWriter {
 	d := &DualWriter{
-		primary:          primary,
-		secondary:        secondary,
-		cfg:              cfg,
-		metrics:          metrics,
-		sentry:           sentryReporter,
-		logger:           logger,
-		writeSem:         make(chan struct{}, secondaryWriteConcurrency(cfg)),
-		shadowSem:        make(chan struct{}, maxShadowGoroutines),
-		scriptSem:        make(chan struct{}, secondaryScriptConcurrency(cfg)),
-		writeQueue:       make(chan asyncTask, secondaryWriteQueueCapacity(cfg)),
-		scriptQueue:      make(chan asyncTask, secondaryScriptQueueCapacity(cfg)),
-		writeQueueSlots:  make(chan struct{}, secondaryWriteQueueCapacity(cfg)),
-		scriptQueueSlots: make(chan struct{}, secondaryScriptQueueCapacity(cfg)),
-		closeDone:        make(chan struct{}),
-		poolStatsStop:    make(chan struct{}),
-		scripts:          make(map[string]string),
+		primary:                  primary,
+		secondary:                secondary,
+		cfg:                      cfg,
+		metrics:                  metrics,
+		sentry:                   sentryReporter,
+		logger:                   logger,
+		writeSem:                 make(chan struct{}, secondaryWriteConcurrency(cfg)),
+		shadowSem:                make(chan struct{}, maxShadowGoroutines),
+		scriptSem:                make(chan struct{}, secondaryScriptConcurrency(cfg)),
+		blockingReplaySem:        make(chan struct{}, secondaryBlockingReplayConcurrency(cfg)),
+		writeQueue:               make(chan asyncTask, secondaryWriteQueueCapacity(cfg)),
+		scriptQueue:              make(chan asyncTask, secondaryScriptQueueCapacity(cfg)),
+		blockingReplayQueue:      make(chan asyncTask, secondaryBlockingReplayQueueCapacity(cfg)),
+		writeQueueSlots:          make(chan struct{}, secondaryWriteQueueCapacity(cfg)),
+		scriptQueueSlots:         make(chan struct{}, secondaryScriptQueueCapacity(cfg)),
+		blockingReplayQueueSlots: make(chan struct{}, secondaryBlockingReplayQueueCapacity(cfg)),
+		closeDone:                make(chan struct{}),
+		poolStatsStop:            make(chan struct{}),
+		scripts:                  make(map[string]string),
 	}
 
 	if cfg.Mode == ModeDualWriteShadow || cfg.Mode == ModeElasticKVPrimary {
@@ -167,11 +177,14 @@ func NewDualWriter(primary, secondary Backend, cfg ProxyConfig, metrics *ProxyMe
 	d.startBackendPoolSampler()
 	d.metrics.AsyncQueueCapacity.WithLabelValues(asyncQueueWrite).Set(float64(cap(d.writeQueueSlots)))
 	d.metrics.AsyncQueueCapacity.WithLabelValues(asyncQueueScript).Set(float64(cap(d.scriptQueueSlots)))
+	d.metrics.AsyncQueueCapacity.WithLabelValues(asyncQueueBlocking).Set(float64(cap(d.blockingReplayQueueSlots)))
 	d.logger.Info("secondary async scheduler configured",
 		"write_concurrency", cap(d.writeSem),
 		"script_concurrency", cap(d.scriptSem),
+		"blocking_replay_concurrency", cap(d.blockingReplaySem),
 		"write_queue_capacity", cap(d.writeQueueSlots),
 		"script_queue_capacity", cap(d.scriptQueueSlots),
+		"blocking_replay_queue_capacity", cap(d.blockingReplayQueueSlots),
 		"timeout", cfg.SecondaryTimeout)
 
 	return d
@@ -189,12 +202,23 @@ func secondaryScriptConcurrency(cfg ProxyConfig) int {
 	return concurrency
 }
 
+func secondaryBlockingReplayConcurrency(cfg ProxyConfig) int {
+	return configuredConcurrencyOrDefault(cfg.SecondaryBlockingReplayConcurrency, maxBlockingReplayGoroutines)
+}
+
 func secondaryWriteQueueCapacity(cfg ProxyConfig) int {
 	return configuredQueueCapacityOrDefault(cfg.SecondaryWriteQueueCapacity, secondaryWriteConcurrency(cfg))
 }
 
 func secondaryScriptQueueCapacity(cfg ProxyConfig) int {
 	return configuredQueueCapacityOrDefault(cfg.SecondaryScriptQueueCapacity, secondaryScriptConcurrency(cfg))
+}
+
+func secondaryBlockingReplayQueueCapacity(cfg ProxyConfig) int {
+	return configuredQueueCapacityOrDefault(
+		cfg.SecondaryBlockingReplayQueueCapacity,
+		secondaryBlockingReplayConcurrency(cfg),
+	)
 }
 
 func configuredQueueCapacityOrDefault(configured, concurrency int) int {
@@ -234,6 +258,7 @@ func (d *DualWriter) Close() {
 	if d.hasSecondaryWrite() {
 		close(d.writeQueue)
 		close(d.scriptQueue)
+		close(d.blockingReplayQueue)
 	}
 	close(d.poolStatsStop)
 	d.mu.Unlock()
@@ -330,9 +355,9 @@ func (d *DualWriter) Blocking(ctx context.Context, cmd string, args [][]byte) (a
 
 	if d.hasSecondaryWrite() {
 		if replayCmd, replayArgs, ok := secondaryBlockingReplay(cmd, resp); ok {
-			d.goWrite(func(ctx context.Context) { d.writeSecondaryPositiveInt(ctx, replayCmd, replayArgs) })
+			d.goBlockingReplay(func(ctx context.Context) { d.writeSecondaryPositiveInt(ctx, replayCmd, replayArgs) })
 		} else if shouldReplayBlockingToSecondary(cmd) {
-			d.goWrite(func(ctx context.Context) {
+			d.goBlockingReplay(func(ctx context.Context) {
 				sCtx, cancel := context.WithTimeout(ctx, time.Second)
 				defer cancel()
 				d.secondary.Do(sCtx, iArgs...)
@@ -425,8 +450,10 @@ func (d *DualWriter) writeSecondary(sCtx context.Context, cmd string, iArgs []an
 		if attempt >= retryLimit {
 			break
 		}
-		d.logger.Debug("retrying secondary write",
-			"cmd", cmd, "reason", retryReason, "attempt", attempt+1, "backoff", backoff, "err", sErr)
+		if shouldLogSecondaryRetry(sErr) {
+			d.logger.Debug("retrying secondary write",
+				"cmd", cmd, "reason", retryReason, "attempt", attempt+1, "backoff", backoff, "err", sErr)
+		}
 		if !waitCompactedRetryBackoff(sCtx, backoff) {
 			break
 		}
@@ -453,29 +480,26 @@ func (d *DualWriter) writeSecondaryPositiveInt(sCtx context.Context, cmd string,
 		var resp any
 		result := d.secondary.Do(sCtx, iArgs...)
 		resp, sErr = result.Result()
-		if sErr == nil {
-			if n, ok := redisInteger(resp); ok && n > 0 {
-				elapsed := time.Since(start)
-				d.metrics.CommandDuration.WithLabelValues(cmd, d.secondary.Name()).Observe(elapsed.Seconds())
-				d.metrics.CommandTotal.WithLabelValues(cmd, d.secondary.Name(), "ok").Inc()
-				return
-			}
-			sErr = errSecondaryReplayNoEffect
+		if ok, err := positiveIntReplayResult(resp, sErr); ok {
+			elapsed := time.Since(start)
+			d.metrics.CommandDuration.WithLabelValues(cmd, d.secondary.Name()).Observe(elapsed.Seconds())
+			d.metrics.CommandTotal.WithLabelValues(cmd, d.secondary.Name(), "ok").Inc()
+			return
+		} else {
+			sErr = err
 		}
 
-		retryReason, retryLimit := secondaryRetryReasonAndLimit(cmd, sErr)
-		if errors.Is(sErr, errSecondaryReplayNoEffect) {
-			retryReason = "no_effect"
-			retryLimit = maxNoEffectReplayRetries
-		}
+		retryReason, retryLimit := secondaryPositiveIntRetryReasonAndLimit(cmd, sErr)
 		if retryReason == "" {
 			break
 		}
 		if attempt >= retryLimit {
 			break
 		}
-		d.logger.Debug("retrying secondary write",
-			"cmd", cmd, "reason", retryReason, "attempt", attempt+1, "backoff", backoff, "err", sErr)
+		if shouldLogSecondaryRetry(sErr) {
+			d.logger.Debug("retrying secondary write",
+				"cmd", cmd, "reason", retryReason, "attempt", attempt+1, "backoff", backoff, "err", sErr)
+		}
 		if !waitCompactedRetryBackoff(sCtx, backoff) {
 			break
 		}
@@ -484,7 +508,32 @@ func (d *DualWriter) writeSecondaryPositiveInt(sCtx context.Context, cmd string,
 
 	elapsed := time.Since(start)
 	d.metrics.CommandDuration.WithLabelValues(cmd, d.secondary.Name()).Observe(elapsed.Seconds())
+	if errors.Is(sErr, errSecondaryReplayNoEffect) {
+		d.metrics.CommandTotal.WithLabelValues(cmd, d.secondary.Name(), "miss").Inc()
+		return
+	}
 	d.recordSecondaryWriteFailure(cmd, iArgs, elapsed, attempt+1, false, sErr)
+}
+
+func positiveIntReplayResult(resp any, err error) (bool, error) {
+	if err != nil {
+		return false, err
+	}
+	if n, ok := redisInteger(resp); ok && n > 0 {
+		return true, nil
+	}
+	return false, errSecondaryReplayNoEffect
+}
+
+func secondaryPositiveIntRetryReasonAndLimit(cmd string, err error) (string, int) {
+	if errors.Is(err, errSecondaryReplayNoEffect) {
+		return "no_effect", maxNoEffectReplayRetries
+	}
+	return secondaryRetryReasonAndLimit(cmd, err)
+}
+
+func shouldLogSecondaryRetry(err error) bool {
+	return !errors.Is(err, errSecondaryReplayNoEffect)
 }
 
 func redisInteger(resp any) (int64, bool) {
@@ -663,6 +712,12 @@ func (d *DualWriter) goWrite(fn func(context.Context)) {
 // It uses a smaller class limit while also consuming the shared write limit.
 func (d *DualWriter) goScript(fn func(context.Context)) {
 	d.enqueueAsync(d.scriptQueue, d.scriptQueueSlots, asyncQueueScript, fn)
+}
+
+// goBlockingReplay queues fn for bounded secondary replay of mutating blocking
+// commands without consuming the normal secondary write workers.
+func (d *DualWriter) goBlockingReplay(fn func(context.Context)) {
+	d.enqueueAsync(d.blockingReplayQueue, d.blockingReplayQueueSlots, asyncQueueBlocking, fn)
 }
 
 // goShadow launches fn in a bounded shadow-read goroutine.

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -655,7 +655,11 @@ func TestDualWriter_Blocking_ReplaysBZPopAsZRem(t *testing.T) {
 			d := NewDualWriter(
 				primary,
 				secondary,
-				ProxyConfig{Mode: ModeDualWrite, SecondaryTimeout: time.Second},
+				ProxyConfig{
+					Mode:                               ModeDualWrite,
+					SecondaryTimeout:                   time.Second,
+					SecondaryBlockingReplayConcurrency: 1,
+				},
 				metrics,
 				newTestSentry(),
 				testLogger,
@@ -696,7 +700,11 @@ func TestDualWriter_Blocking_RetriesBZPopReplayUntilRemoved(t *testing.T) {
 	d := NewDualWriter(
 		primary,
 		secondary,
-		ProxyConfig{Mode: ModeDualWrite, SecondaryTimeout: time.Second},
+		ProxyConfig{
+			Mode:                               ModeDualWrite,
+			SecondaryTimeout:                   time.Second,
+			SecondaryBlockingReplayConcurrency: 1,
+		},
 		metrics,
 		newTestSentry(),
 		testLogger,
@@ -722,7 +730,11 @@ func TestDualWriter_Blocking_BZPopReplayMissIsNotSecondaryWriteError(t *testing.
 	d := NewDualWriter(
 		primary,
 		secondary,
-		ProxyConfig{Mode: ModeDualWrite, SecondaryTimeout: 30 * time.Millisecond},
+		ProxyConfig{
+			Mode:                               ModeDualWrite,
+			SecondaryTimeout:                   30 * time.Millisecond,
+			SecondaryBlockingReplayConcurrency: 1,
+		},
 		metrics,
 		newTestSentry(),
 		testLogger,
@@ -792,7 +804,11 @@ func TestDualWriter_Blocking_ReplaysXReadGroup(t *testing.T) {
 	d := NewDualWriter(
 		primary,
 		secondary,
-		ProxyConfig{Mode: ModeDualWrite, SecondaryTimeout: time.Second},
+		ProxyConfig{
+			Mode:                               ModeDualWrite,
+			SecondaryTimeout:                   time.Second,
+			SecondaryBlockingReplayConcurrency: 1,
+		},
 		metrics,
 		newTestSentry(),
 		testLogger,
@@ -839,6 +855,32 @@ func TestDualWriter_Blocking_DoesNotReplayXRead(t *testing.T) {
 	d.Close()
 
 	assert.Equal(t, 0, secondary.CallCount())
+}
+
+func TestDualWriter_Blocking_DoesNotReplayWhenBlockingReplayDisabled(t *testing.T) {
+	primary := &timeoutCapturingBackend{
+		name:        "primary",
+		returnValue: []any{"queue", "job-1", "12.5"},
+	}
+	secondary := newMockBackend("secondary")
+
+	metrics := newTestMetrics()
+	d := NewDualWriter(
+		primary,
+		secondary,
+		ProxyConfig{Mode: ModeDualWrite, SecondaryTimeout: time.Second},
+		metrics,
+		newTestSentry(),
+		testLogger,
+	)
+
+	resp, err := d.Blocking(context.Background(), "BZPOPMIN", [][]byte{[]byte("BZPOPMIN"), []byte("queue"), []byte("5")})
+	assert.NoError(t, err)
+	assert.Equal(t, []any{"queue", "job-1", "12.5"}, resp)
+	d.Close()
+
+	assert.Equal(t, 0, secondary.CallCount())
+	assert.InDelta(t, 0, testutil.ToFloat64(metrics.AsyncDrops), 0.001)
 }
 
 func TestDualWriter_GoAsync_QueuesBurstBeforeDropping(t *testing.T) {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -710,6 +710,77 @@ func TestDualWriter_Blocking_RetriesBZPopReplayUntilRemoved(t *testing.T) {
 	assert.Equal(t, 2, secondary.CallCount())
 }
 
+func TestDualWriter_Blocking_BZPopReplayMissIsNotSecondaryWriteError(t *testing.T) {
+	primary := &timeoutCapturingBackend{
+		name:        "primary",
+		returnValue: []any{"queue", "job-1", "12.5"},
+	}
+	secondary := newMockBackend("secondary")
+	secondary.doFunc = makeCmd(int64(0), nil)
+
+	metrics := newTestMetrics()
+	d := NewDualWriter(
+		primary,
+		secondary,
+		ProxyConfig{Mode: ModeDualWrite, SecondaryTimeout: 30 * time.Millisecond},
+		metrics,
+		newTestSentry(),
+		testLogger,
+	)
+
+	_, err := d.Blocking(context.Background(), "BZPOPMIN", [][]byte{[]byte("BZPOPMIN"), []byte("queue"), []byte("5")})
+	assert.NoError(t, err)
+	d.Close()
+
+	assert.Greater(t, secondary.CallCount(), 1)
+	assert.InDelta(t, 0, testutil.ToFloat64(metrics.SecondaryWriteErrors), 0.001)
+	assert.InDelta(t, 1, testutil.ToFloat64(
+		metrics.CommandTotal.WithLabelValues("ZREM", "secondary", "miss")), 0.001)
+}
+
+func TestDualWriter_BlockingReplayDoesNotConsumeWriteWorkers(t *testing.T) {
+	primary := &timeoutCapturingBackend{
+		name:        "primary",
+		returnValue: []any{"queue", "job-1", "12.5"},
+	}
+	secondary := newMockBackend("secondary")
+	secondary.doFunc = makeCmd(int64(1), nil)
+
+	metrics := newTestMetrics()
+	d := NewDualWriter(
+		primary,
+		secondary,
+		ProxyConfig{
+			Mode:                                 ModeDualWrite,
+			SecondaryTimeout:                     time.Second,
+			SecondaryWriteConcurrency:            1,
+			SecondaryBlockingReplayConcurrency:   1,
+			SecondaryWriteQueueCapacity:          1,
+			SecondaryBlockingReplayQueueCapacity: 1,
+		},
+		metrics,
+		newTestSentry(),
+		testLogger,
+	)
+
+	blocker := make(chan struct{})
+	started := make(chan struct{})
+	d.goWrite(func(context.Context) {
+		close(started)
+		<-blocker
+	})
+	<-started
+
+	_, err := d.Blocking(context.Background(), "BZPOPMIN", [][]byte{[]byte("BZPOPMIN"), []byte("queue"), []byte("5")})
+	assert.NoError(t, err)
+	assert.Eventually(t, func() bool { return secondary.CallCount() == 1 },
+		time.Second, 10*time.Millisecond)
+	assert.InDelta(t, 1, testutil.ToFloat64(metrics.AsyncWorkersActive.WithLabelValues(asyncQueueWrite)), 0.001)
+
+	close(blocker)
+	d.Close()
+}
+
 func TestDualWriter_Blocking_ReplaysXReadGroup(t *testing.T) {
 	primary := &timeoutCapturingBackend{
 		name:        "primary",


### PR DESCRIPTION
Author: bootjp

## Summary
- add a dedicated async queue and worker limit for mutating blocking-command secondary replays
- derive blocking replay concurrency from unused secondary backend pool capacity
- keep BZPOP replay misses visible as command miss metrics without counting them as secondary write failures

## Verification
- go test ./proxy -count=1
- go test ./cmd/redis-proxy -count=1
- golangci-lint run ./proxy ./cmd/redis-proxy --timeout=5m

## Risk
- limits normal secondary writes plus blocking replay workers to the secondary backend pool so long blocking replays do not starve producer writes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - セカンダリへのブロッキングコマンド再生に、同時実行数とキュー容量の設定を追加しました。
  - ブロッキング再生を通常の書き込み処理から分離し、通常処理のワーカーを圧迫しないよう改善しました。
  - 再生を無効化した場合は、セカンダリへの送信を停止できます。

- **改善**
  - 設定値の妥当性検証を強化し、実行プール容量を超える設定を防止します。
  - 再生結果や再試行、ミスのメトリクスとエラー記録を整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->