### PR TITLE
Cap Redis blocking replay pressure

### DIFF
--- a/cmd/redis-proxy/main.go
+++ b/cmd/redis-proxy/main.go
@@ -54,7 +54,7 @@ func run() error {
 	flag.IntVar(&elasticKVPoolSize, "elastickv-pool-size", elasticKVPoolSize, "ElasticKV backend connection pool size")
 	flag.IntVar(&secondaryWriteConcurrency, "secondary-write-concurrency", secondaryWriteConcurrency, "Maximum concurrent asynchronous secondary writes including scripts (0 = half of secondary backend pool size)")
 	flag.IntVar(&secondaryScriptConcurrency, "secondary-script-concurrency", secondaryScriptConcurrency, "Maximum concurrent asynchronous secondary Lua-script writes within the write limit (0 = half of secondary write concurrency)")
-	flag.IntVar(&secondaryBlockingReplayConcurrency, "secondary-blocking-replay-concurrency", secondaryBlockingReplayConcurrency, "Maximum concurrent asynchronous secondary mutating blocking-command replays (0 = remaining secondary backend pool capacity after writes)")
+	flag.IntVar(&secondaryBlockingReplayConcurrency, "secondary-blocking-replay-concurrency", secondaryBlockingReplayConcurrency, "Maximum concurrent asynchronous secondary mutating blocking-command replays (0 = capped remaining secondary backend pool capacity after writes)")
 	flag.IntVar(&secondaryWriteQueueSize, "secondary-write-queue-size", secondaryWriteQueueSize, "Maximum queued asynchronous secondary writes (0 = derived from write concurrency)")
 	flag.IntVar(&secondaryScriptQueueSize, "secondary-script-queue-size", secondaryScriptQueueSize, "Maximum queued asynchronous secondary Lua-script writes (0 = derived from script concurrency)")
 	flag.IntVar(&secondaryBlockingReplayQueueSize, "secondary-blocking-replay-queue-size", secondaryBlockingReplayQueueSize, "Maximum queued asynchronous secondary mutating blocking-command replays (0 = derived from blocking replay concurrency)")
@@ -292,8 +292,11 @@ func defaultSecondaryScriptConcurrency(writeConcurrency int) int {
 
 func defaultSecondaryBlockingReplayConcurrency(poolSize, writeConcurrency int) int {
 	remaining := poolSize - writeConcurrency
-	if remaining < 0 {
+	if remaining <= 0 {
 		return 0
+	}
+	if remaining > proxy.DefaultConfig().SecondaryBlockingReplayConcurrency {
+		return proxy.DefaultConfig().SecondaryBlockingReplayConcurrency
 	}
 	return remaining
 }

--- a/cmd/redis-proxy/main_test.go
+++ b/cmd/redis-proxy/main_test.go
@@ -93,7 +93,17 @@ func TestDeriveSecondaryConcurrency(t *testing.T) {
 			elasticKVPoolSize:       4,
 			wantWriteConcurrency:    64,
 			wantScriptConcurrency:   32,
-			wantBlockingConcurrency: 64,
+			wantBlockingConcurrency: 8,
+		},
+		{
+			name:                    "large remaining pool caps blocking replay",
+			mode:                    proxy.ModeDualWrite,
+			primaryPoolSize:         128,
+			elasticKVPoolSize:       144,
+			writeConcurrency:        80,
+			wantWriteConcurrency:    80,
+			wantScriptConcurrency:   40,
+			wantBlockingConcurrency: 8,
 		},
 		{
 			name:                    "explicit write keeps derived script",

--- a/proxy/dualwrite.go
+++ b/proxy/dualwrite.go
@@ -54,10 +54,10 @@ const (
 	// Blocking ZPOP replays trail the producer write path and must not occupy
 	// their dedicated workers for the full secondary timeout when the producer
 	// write is delayed or dropped. A short initial delay lets the common
-	// producer-before-consumer ordering settle; a small no-effect cap keeps
+	// producer-before-consumer ordering settle; a bounded no-effect window keeps
 	// BZPOP load from turning into a long retry backlog.
-	blockingReplayInitialDelay       = 250 * time.Millisecond
-	maxBlockingReplayNoEffectRetries = 8
+	blockingReplayInitialDelay        = 250 * time.Millisecond
+	blockingReplayNoEffectRetryWindow = 2 * time.Second
 	// compactedRetryInitialBackoff is the first delay before retrying a secondary
 	// command that failed with a compacted-read error.
 	compactedRetryInitialBackoff = 10 * time.Millisecond
@@ -364,9 +364,9 @@ func (d *DualWriter) Blocking(ctx context.Context, cmd string, args [][]byte) (a
 		if replayCmd, replayArgs, ok := secondaryBlockingReplay(cmd, resp); ok {
 			d.goBlockingReplay(func(ctx context.Context) {
 				d.writeSecondaryPositiveIntWithOptions(ctx, replayCmd, replayArgs, positiveIntReplayOptions{
-					initialDelay:       blockingReplayInitialDelay,
-					noEffectRetryLimit: maxBlockingReplayNoEffectRetries,
-					deadlineAsMiss:     true,
+					initialDelay:        blockingReplayInitialDelay,
+					noEffectRetryWindow: blockingReplayNoEffectRetryWindow,
+					deadlineAsMiss:      true,
 				})
 			})
 		} else if shouldReplayBlockingToSecondary(cmd) {
@@ -484,9 +484,9 @@ func (d *DualWriter) writeSecondary(sCtx context.Context, cmd string, iArgs []an
 }
 
 type positiveIntReplayOptions struct {
-	initialDelay       time.Duration
-	noEffectRetryLimit int
-	deadlineAsMiss     bool
+	initialDelay        time.Duration
+	noEffectRetryWindow time.Duration
+	deadlineAsMiss      bool
 }
 
 func (d *DualWriter) writeSecondaryPositiveIntWithOptions(sCtx context.Context, cmd string, iArgs []any, opts positiveIntReplayOptions) {
@@ -494,6 +494,7 @@ func (d *DualWriter) writeSecondaryPositiveIntWithOptions(sCtx context.Context, 
 	if !d.waitPositiveIntReplayInitialDelay(sCtx, cmd, start, opts.initialDelay) {
 		return
 	}
+	noEffectRetryLimit := noEffectReplayRetryLimit(sCtx, opts.noEffectRetryWindow)
 
 	backoff := compactedRetryInitialBackoff
 	var sErr error
@@ -511,7 +512,7 @@ func (d *DualWriter) writeSecondaryPositiveIntWithOptions(sCtx context.Context, 
 			sErr = err
 		}
 
-		retryReason, retryLimit := secondaryPositiveIntRetryReasonAndLimit(cmd, sErr, opts.noEffectRetryLimit)
+		retryReason, retryLimit := secondaryPositiveIntRetryReasonAndLimit(cmd, sErr, noEffectRetryLimit)
 		if retryReason == "" {
 			break
 		}
@@ -538,6 +539,7 @@ func (d *DualWriter) writeSecondaryPositiveIntWithOptions(sCtx context.Context, 
 }
 
 func (d *DualWriter) waitPositiveIntReplayInitialDelay(ctx context.Context, cmd string, start time.Time, delay time.Duration) bool {
+	delay = positiveIntReplayInitialDelay(ctx, delay)
 	if delay <= 0 {
 		return true
 	}
@@ -548,6 +550,21 @@ func (d *DualWriter) waitPositiveIntReplayInitialDelay(ctx context.Context, cmd 
 	d.metrics.CommandDuration.WithLabelValues(cmd, d.secondary.Name()).Observe(elapsed.Seconds())
 	d.metrics.CommandTotal.WithLabelValues(cmd, d.secondary.Name(), "miss").Inc()
 	return false
+}
+
+func positiveIntReplayInitialDelay(ctx context.Context, requested time.Duration) time.Duration {
+	if requested <= 0 {
+		return 0
+	}
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return requested
+	}
+	remaining := time.Until(deadline)
+	if remaining <= requested+compactedRetryInitialBackoff {
+		return 0
+	}
+	return requested
 }
 
 func positiveIntReplayResult(resp any, err error) (bool, error) {
@@ -568,6 +585,38 @@ func secondaryPositiveIntRetryReasonAndLimit(cmd string, err error, noEffectRetr
 		return "no_effect", noEffectRetryLimit
 	}
 	return secondaryRetryReasonAndLimit(cmd, err)
+}
+
+func noEffectReplayRetryLimit(ctx context.Context, maxWindow time.Duration) int {
+	window := positiveIntReplayRetryWindow(ctx, maxWindow)
+	if window <= 0 {
+		return 0
+	}
+	limit := 0
+	for spent, backoff := time.Duration(0), compactedRetryInitialBackoff; spent+backoff <= window; {
+		limit++
+		spent += backoff
+		backoff = nextCompactedRetryBackoff(backoff)
+	}
+	return limit
+}
+
+func positiveIntReplayRetryWindow(ctx context.Context, maxWindow time.Duration) time.Duration {
+	if maxWindow <= 0 {
+		return 0
+	}
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return maxWindow
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return 0
+	}
+	if remaining < maxWindow {
+		return remaining
+	}
+	return maxWindow
 }
 
 func positiveIntReplayMiss(ctx context.Context, opts positiveIntReplayOptions, err error) bool {

--- a/proxy/dualwrite.go
+++ b/proxy/dualwrite.go
@@ -31,8 +31,9 @@ const (
 	maxScriptWriteGoroutines = 64
 	// maxBlockingReplayGoroutines isolates mutating blocking command replays
 	// from normal secondary writes. Blocking replays may wait for the secondary
-	// to observe a producer write and must not occupy producer write workers.
-	maxBlockingReplayGoroutines = 64
+	// to observe a producer write, and they hit the secondary's heavy-command
+	// limiter, so keep the default well below the normal write limit.
+	maxBlockingReplayGoroutines = 8
 	// Async queues absorb short bursts without allowing an unavailable or slow
 	// secondary to build an unbounded replay backlog.
 	minAsyncQueueCapacity       = 64
@@ -50,11 +51,13 @@ const (
 	// transient admission failures into backpressure without hiding a sustained
 	// overload.
 	maxServerOverloadedRetries = 8
-	// maxNoEffectReplayRetries bounds deterministic replay retries when the
-	// secondary has not observed the producer write yet. With the shared retry
-	// backoff capped at 100ms this covers normal queue reordering without
-	// allowing an unbounded worker leak if the producer write never lands.
-	maxNoEffectReplayRetries = 256
+	// Blocking ZPOP replays trail the producer write path and must not occupy
+	// their dedicated workers for the full secondary timeout when the producer
+	// write is delayed or dropped. A short initial delay lets the common
+	// producer-before-consumer ordering settle; a small no-effect cap keeps
+	// BZPOP load from turning into a long retry backlog.
+	blockingReplayInitialDelay       = 250 * time.Millisecond
+	maxBlockingReplayNoEffectRetries = 8
 	// compactedRetryInitialBackoff is the first delay before retrying a secondary
 	// command that failed with a compacted-read error.
 	compactedRetryInitialBackoff = 10 * time.Millisecond
@@ -359,7 +362,13 @@ func (d *DualWriter) Blocking(ctx context.Context, cmd string, args [][]byte) (a
 
 	if d.hasSecondaryWrite() {
 		if replayCmd, replayArgs, ok := secondaryBlockingReplay(cmd, resp); ok {
-			d.goBlockingReplay(func(ctx context.Context) { d.writeSecondaryPositiveInt(ctx, replayCmd, replayArgs) })
+			d.goBlockingReplay(func(ctx context.Context) {
+				d.writeSecondaryPositiveIntWithOptions(ctx, replayCmd, replayArgs, positiveIntReplayOptions{
+					initialDelay:       blockingReplayInitialDelay,
+					noEffectRetryLimit: maxBlockingReplayNoEffectRetries,
+					deadlineAsMiss:     true,
+				})
+			})
 		} else if shouldReplayBlockingToSecondary(cmd) {
 			d.goBlockingReplay(func(ctx context.Context) {
 				sCtx, cancel := context.WithTimeout(ctx, time.Second)
@@ -474,8 +483,17 @@ func (d *DualWriter) writeSecondary(sCtx context.Context, cmd string, iArgs []an
 	d.metrics.CommandTotal.WithLabelValues(cmd, d.secondary.Name(), "ok").Inc()
 }
 
-func (d *DualWriter) writeSecondaryPositiveInt(sCtx context.Context, cmd string, iArgs []any) {
+type positiveIntReplayOptions struct {
+	initialDelay       time.Duration
+	noEffectRetryLimit int
+	deadlineAsMiss     bool
+}
+
+func (d *DualWriter) writeSecondaryPositiveIntWithOptions(sCtx context.Context, cmd string, iArgs []any, opts positiveIntReplayOptions) {
 	start := time.Now()
+	if !d.waitPositiveIntReplayInitialDelay(sCtx, cmd, start, opts.initialDelay) {
+		return
+	}
 
 	backoff := compactedRetryInitialBackoff
 	var sErr error
@@ -493,7 +511,7 @@ func (d *DualWriter) writeSecondaryPositiveInt(sCtx context.Context, cmd string,
 			sErr = err
 		}
 
-		retryReason, retryLimit := secondaryPositiveIntRetryReasonAndLimit(cmd, sErr)
+		retryReason, retryLimit := secondaryPositiveIntRetryReasonAndLimit(cmd, sErr, opts.noEffectRetryLimit)
 		if retryReason == "" {
 			break
 		}
@@ -512,11 +530,24 @@ func (d *DualWriter) writeSecondaryPositiveInt(sCtx context.Context, cmd string,
 
 	elapsed := time.Since(start)
 	d.metrics.CommandDuration.WithLabelValues(cmd, d.secondary.Name()).Observe(elapsed.Seconds())
-	if errors.Is(sErr, errSecondaryReplayNoEffect) {
+	if positiveIntReplayMiss(sCtx, opts, sErr) {
 		d.metrics.CommandTotal.WithLabelValues(cmd, d.secondary.Name(), "miss").Inc()
 		return
 	}
 	d.recordSecondaryWriteFailure(cmd, iArgs, elapsed, attempt+1, false, sErr)
+}
+
+func (d *DualWriter) waitPositiveIntReplayInitialDelay(ctx context.Context, cmd string, start time.Time, delay time.Duration) bool {
+	if delay <= 0 {
+		return true
+	}
+	if waitSecondaryReplayDelay(ctx, delay) {
+		return true
+	}
+	elapsed := time.Since(start)
+	d.metrics.CommandDuration.WithLabelValues(cmd, d.secondary.Name()).Observe(elapsed.Seconds())
+	d.metrics.CommandTotal.WithLabelValues(cmd, d.secondary.Name(), "miss").Inc()
+	return false
 }
 
 func positiveIntReplayResult(resp any, err error) (bool, error) {
@@ -529,11 +560,30 @@ func positiveIntReplayResult(resp any, err error) (bool, error) {
 	return false, errSecondaryReplayNoEffect
 }
 
-func secondaryPositiveIntRetryReasonAndLimit(cmd string, err error) (string, int) {
+func secondaryPositiveIntRetryReasonAndLimit(cmd string, err error, noEffectRetryLimit int) (string, int) {
 	if errors.Is(err, errSecondaryReplayNoEffect) {
-		return "no_effect", maxNoEffectReplayRetries
+		if noEffectRetryLimit <= 0 {
+			return "", 0
+		}
+		return "no_effect", noEffectRetryLimit
 	}
 	return secondaryRetryReasonAndLimit(cmd, err)
+}
+
+func positiveIntReplayMiss(ctx context.Context, opts positiveIntReplayOptions, err error) bool {
+	return errors.Is(err, errSecondaryReplayNoEffect) || opts.deadlineAsMiss && ctx.Err() != nil
+}
+
+func waitSecondaryReplayDelay(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
 }
 
 func shouldLogSecondaryRetry(err error) bool {

--- a/proxy/dualwrite.go
+++ b/proxy/dualwrite.go
@@ -594,11 +594,19 @@ func noEffectReplayRetryLimit(ctx context.Context, maxWindow time.Duration) int 
 	}
 	limit := 0
 	for spent, backoff := time.Duration(0), compactedRetryInitialBackoff; spent+backoff <= window; {
+		sleepBudget := retryBackoffWithMaxJitter(backoff)
+		if spent+sleepBudget > window {
+			break
+		}
 		limit++
-		spent += backoff
+		spent += sleepBudget
 		backoff = nextCompactedRetryBackoff(backoff)
 	}
 	return limit
+}
+
+func retryBackoffWithMaxJitter(backoff time.Duration) time.Duration {
+	return backoff + backoff/compactedRetryJitterDivisor
 }
 
 func positiveIntReplayRetryWindow(ctx context.Context, maxWindow time.Duration) time.Duration {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -732,7 +732,7 @@ func TestDualWriter_Blocking_BZPopReplayMissIsNotSecondaryWriteError(t *testing.
 		secondary,
 		ProxyConfig{
 			Mode:                               ModeDualWrite,
-			SecondaryTimeout:                   30 * time.Millisecond,
+			SecondaryTimeout:                   2 * time.Second,
 			SecondaryBlockingReplayConcurrency: 1,
 		},
 		metrics,
@@ -744,7 +744,7 @@ func TestDualWriter_Blocking_BZPopReplayMissIsNotSecondaryWriteError(t *testing.
 	assert.NoError(t, err)
 	d.Close()
 
-	assert.Greater(t, secondary.CallCount(), 1)
+	assert.Equal(t, maxBlockingReplayNoEffectRetries+1, secondary.CallCount())
 	assert.InDelta(t, 0, testutil.ToFloat64(metrics.SecondaryWriteErrors), 0.001)
 	assert.InDelta(t, 1, testutil.ToFloat64(
 		metrics.CommandTotal.WithLabelValues("ZREM", "secondary", "miss")), 0.001)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -744,7 +744,39 @@ func TestDualWriter_Blocking_BZPopReplayMissIsNotSecondaryWriteError(t *testing.
 	assert.NoError(t, err)
 	d.Close()
 
-	assert.Equal(t, maxBlockingReplayNoEffectRetries+1, secondary.CallCount())
+	assert.Greater(t, secondary.CallCount(), 9)
+	assert.InDelta(t, 0, testutil.ToFloat64(metrics.SecondaryWriteErrors), 0.001)
+	assert.InDelta(t, 1, testutil.ToFloat64(
+		metrics.CommandTotal.WithLabelValues("ZREM", "secondary", "miss")), 0.001)
+}
+
+func TestDualWriter_Blocking_BZPopReplayShortTimeoutStillAttemptsZRem(t *testing.T) {
+	primary := &timeoutCapturingBackend{
+		name:        "primary",
+		returnValue: []any{"queue", "job-1", "12.5"},
+	}
+	secondary := newMockBackend("secondary")
+	secondary.doFunc = makeCmd(int64(0), nil)
+
+	metrics := newTestMetrics()
+	d := NewDualWriter(
+		primary,
+		secondary,
+		ProxyConfig{
+			Mode:                               ModeDualWrite,
+			SecondaryTimeout:                   30 * time.Millisecond,
+			SecondaryBlockingReplayConcurrency: 1,
+		},
+		metrics,
+		newTestSentry(),
+		testLogger,
+	)
+
+	_, err := d.Blocking(context.Background(), "BZPOPMIN", [][]byte{[]byte("BZPOPMIN"), []byte("queue"), []byte("5")})
+	assert.NoError(t, err)
+	d.Close()
+
+	assert.GreaterOrEqual(t, secondary.CallCount(), 1)
 	assert.InDelta(t, 0, testutil.ToFloat64(metrics.SecondaryWriteErrors), 0.001)
 	assert.InDelta(t, 1, testutil.ToFloat64(
 		metrics.CommandTotal.WithLabelValues("ZREM", "secondary", "miss")), 0.001)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -782,6 +782,21 @@ func TestDualWriter_Blocking_BZPopReplayShortTimeoutStillAttemptsZRem(t *testing
 		metrics.CommandTotal.WithLabelValues("ZREM", "secondary", "miss")), 0.001)
 }
 
+func TestNoEffectReplayRetryLimitIncludesJitterBudget(t *testing.T) {
+	limit := noEffectReplayRetryLimit(context.Background(), blockingReplayNoEffectRetryWindow)
+	assert.Positive(t, limit)
+
+	var spent time.Duration
+	backoff := compactedRetryInitialBackoff
+	for range limit {
+		spent += retryBackoffWithMaxJitter(backoff)
+		backoff = nextCompactedRetryBackoff(backoff)
+	}
+
+	assert.LessOrEqual(t, spent, blockingReplayNoEffectRetryWindow)
+	assert.Greater(t, spent+retryBackoffWithMaxJitter(backoff), blockingReplayNoEffectRetryWindow)
+}
+
 func TestDualWriter_BlockingReplayDoesNotConsumeWriteWorkers(t *testing.T) {
 	primary := &timeoutCapturingBackend{
 		name:        "primary",


### PR DESCRIPTION
## Summary
- Cap derived secondary blocking replay concurrency instead of using all remaining backend connections
- Add a short delay before BZPOP ZREM replay and bound no-effect retries
- Count blocking replay deadline expiry as a replay miss instead of a secondary write failure

## Tests
- go test ./cmd/redis-proxy -count=1
- go test ./proxy -count=1
- golangci-lint run ./proxy ./cmd/redis-proxy --timeout=5m