### PR TITLE
kv: parallelize HLC lease recovery

### DIFF
--- a/kv/lease_read_test.go
+++ b/kv/lease_read_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"math"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -194,8 +195,12 @@ func applyHLCLeaseEntryToClock(t testing.TB, clock *HLC) func([]byte) {
 		if len(data) != hlcLeaseEntryLen || data[0] != raftEncodeHLCLease {
 			return
 		}
-		ceilingMs := int64(binary.BigEndian.Uint64(data[1:])) //nolint:gosec // encoded from a positive Unix ms timestamp.
-		clock.SetPhysicalCeiling(ceilingMs)
+		rawCeilingMs := binary.BigEndian.Uint64(data[1:])
+		if rawCeilingMs > uint64(math.MaxInt64) {
+			t.Error("invalid HLC lease ceiling")
+			return
+		}
+		clock.SetPhysicalCeiling(int64(rawCeilingMs))
 	}
 }
 

--- a/kv/lease_warmup_test.go
+++ b/kv/lease_warmup_test.go
@@ -315,6 +315,57 @@ func TestShardedCoordinator_RecoverHLCLease_ProposesToEveryLedGroup(t *testing.T
 	require.NotZero(t, got)
 }
 
+func TestShardedCoordinator_RecoverHLCLease_SlowTargetDoesNotBlockSuccessfulPeer(t *testing.T) {
+	t.Parallel()
+	clock := NewHLC()
+	clock.SetPhysicalCeiling(time.Now().Add(-time.Millisecond).UnixMilli())
+	eng1 := newShardedLeaseEngine(100)
+	eng2 := newShardedLeaseEngine(200)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var enteredOnce sync.Once
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(release) })
+	eng1.proposeHook = func() {
+		enteredOnce.Do(func() { close(entered) })
+		<-release
+	}
+	eng1.proposeApply = applyHLCLeaseEntryToClock(t, clock)
+	eng2.proposeApply = applyHLCLeaseEntryToClock(t, clock)
+	coord := mustShardedLeaseCoord(t, eng1, eng2)
+	coord.clock = clock
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- coord.RecoverHLCLease(context.Background())
+	}()
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-entered:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		return eng2.proposeCalls.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		_, err := clock.NextFenced()
+		return err == nil
+	}, time.Second, 10*time.Millisecond,
+		"a delayed first target must not stop another target from advancing the recovery ceiling")
+
+	select {
+	case err := <-errCh:
+		require.Failf(t, "RecoverHLCLease returned before all attempts finished", "err=%v", err)
+	default:
+	}
+	releaseOnce.Do(func() { close(release) })
+	require.NoError(t, <-errCh)
+}
+
 func TestShardedCoordinator_RecoverHLCLease_SucceedsWhenAnyTargetAdvancesCeiling(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {

--- a/kv/sharded_coordinator.go
+++ b/kv/sharded_coordinator.go
@@ -18,6 +18,7 @@ import (
 	pb "github.com/bootjp/elastickv/proto"
 	"github.com/bootjp/elastickv/store"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/errors/secondary"
 )
 
 type ShardGroup struct {
@@ -2469,11 +2470,22 @@ func (c *ShardedCoordinator) RecoverHLCLease(ctx context.Context) error {
 }
 
 func (c *ShardedCoordinator) recoverHLCLeaseTargets(ctx context.Context, targets []hlcLeaseRecoveryTarget, ceilingMs int64) error {
+	errCh := make(chan error, len(targets))
+	var wg sync.WaitGroup
 	var recoveryErr error
 	for _, target := range targets {
-		if err := c.proposeHLCLeaseForGroup(ctx, target.group, ceilingMs); err != nil {
-			recoveryErr = combineHLCRecoveryErrors(recoveryErr, errors.Wrapf(err, "recover hlc lease group %d", target.gid))
-		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := c.proposeHLCLeaseForGroup(ctx, target.group, ceilingMs); err != nil {
+				errCh <- errors.Wrapf(err, "recover hlc lease group %d", target.gid)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		recoveryErr = combineHLCRecoveryErrors(recoveryErr, err)
 	}
 	if !hlcCeilingExpired(c.clock) {
 		return nil
@@ -2485,13 +2497,13 @@ func combineHLCRecoveryErrors(first error, next error) error {
 	if first == nil {
 		return next
 	}
-	return errors.Wrap(errors.CombineErrors(first, next), "combine hlc recovery errors")
+	return errors.Wrap(secondary.CombineErrors(first, next), "combine hlc recovery errors")
 }
 
 func hlcRecoveryFailedError(recoveryErr error) error {
 	expiredErr := errors.Wrap(ErrCeilingExpired, "recover hlc lease did not advance ceiling")
 	if recoveryErr != nil {
-		return errors.Wrap(errors.CombineErrors(expiredErr, recoveryErr), "recover hlc lease failed")
+		return errors.Wrap(secondary.CombineErrors(expiredErr, recoveryErr), "recover hlc lease failed")
 	}
 	return expiredErr
 }


### PR DESCRIPTION
Author: bootjp

## Summary
- run HLC lease recovery proposals for all target groups concurrently
- use cockroachdb secondary error aggregation instead of an unsupported top-level CombineErrors call
- add regression coverage for a delayed recovery target alongside an immediately successful target
- replace the HLC lease test conversion nolint with an explicit range check

## Tests
- go test ./kv -run 'TestShardedCoordinator_(RecoverHLCLease|RenewHLCLease|RenewHLCLeases)|TestCoordinate_ProposeHLCLease|TestCoordinate_LeaseRead' -count=1 -timeout=300s\n- go test ./kv -count=1 -timeout=300s\n- golangci-lint run ./kv --timeout=5m

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - HLCリースの復旧処理を並列化し、一部の対象で処理が遅延しても、他の対象の復旧が不必要に待たされないよう改善しました。
  - 複数対象で発生した復旧エラーを適切に集約し、処理結果をより正確に報告できるようにしました。
  - 異常に大きな時刻情報によるオーバーフローを防止しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->